### PR TITLE
Implemented Motion Adaptive Deinterlacing and integrated changes with UI

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -425,7 +425,7 @@ SCAJ-10008:
   name: "Taiko no Tatsujin - Atsumare! Matsuri da!! Yondaime"
   region: "NTSC-Unk"
   gsHWFixes:
-    deinterlace: 4 # Game requires bob bff deinterlacing when auto.
+    deinterlace: 5 # Game requires bob bff deinterlacing when auto.
     alignSprite: 1 # Fixes vertical lines.
 SCAJ-10009:
   name: "Psikyo Shooting Collection Vol.1 - Strikers 1-2"
@@ -440,31 +440,31 @@ SCAJ-10011:
   name: "Taiko no Tatsujin - Go! Go! Godaime"
   region: "NTSC-Unk"
   gsHWFixes:
-    deinterlace: 4 # Game requires bob bff deinterlacing when auto.
+    deinterlace: 5 # Game requires bob bff deinterlacing when auto.
     alignSprite: 1 # Fixes vertical lines.
 SCAJ-10012:
   name: "Taiko Drum Master"
   region: "NTSC-Unk"
   gsHWFixes:
-    deinterlace: 4 # Game requires bob bff deinterlacing when auto.
+    deinterlace: 5 # Game requires bob bff deinterlacing when auto.
     alignSprite: 1 # Fixes vertical lines.
 SCAJ-10013:
   name: "Taiko no Tatsujin - Tobikkiri! Anime Special"
   region: "NTSC-Unk"
   gsHWFixes:
-    deinterlace: 4 # Game requires bob bff deinterlacing when auto.
+    deinterlace: 5 # Game requires bob bff deinterlacing when auto.
     alignSprite: 1 # Fixes vertical lines.
 SCAJ-10014:
   name: "Taiko no Tatsujin - Wai Wai Happy! Rokudaime"
   region: "NTSC-Unk"
   gsHWFixes:
-    deinterlace: 4 # Game requires bob bff deinterlacing when auto.
+    deinterlace: 5 # Game requires bob bff deinterlacing when auto.
     alignSprite: 1 # Fixes vertical lines.
 SCAJ-10015:
   name: "Taiko no Tatsujin - Doka! to Oomori Nanadaime"
   region: "NTSC-Unk"
   gsHWFixes:
-    deinterlace: 4 # Game requires bob bff deinterlacing when auto.
+    deinterlace: 5 # Game requires bob bff deinterlacing when auto.
     alignSprite: 1 # Fixes vertical lines.
 SCAJ-20001:
   name: "Ratchet & Clank"
@@ -3170,7 +3170,7 @@ SCES-51164:
   name: "Mark of Kri, The"
   region: "PAL-M5"
   gsHWFixes:
-    deinterlace: 3 # Game requires bob deinterlacing when auto.
+    deinterlace: 4 # Game requires bob deinterlacing when auto.
 SCES-51176:
   name: "Disney's Treasure Planet"
   region: "PAL-M4"
@@ -6471,7 +6471,7 @@ SCPS-51011:
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
-    deinterlace: 6 # Fixes blurriness.
+    deinterlace: 7 # Fixes blurriness.
 SCPS-51012:
   name: "Gigantic Drive"
   region: "NTSC-J"
@@ -6992,7 +6992,7 @@ SCUS-97140:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    deinterlace: 3 # Game requires bob deinterlacing when auto.
+    deinterlace: 4 # Game requires bob deinterlacing when auto.
   patches:
     DBD09DD4:
       content: |-
@@ -7218,7 +7218,7 @@ SCUS-97201:
   name: "Mark of Kri, The"
   region: "NTSC-U"
   gsHWFixes:
-    deinterlace: 3 # Game requires bob deinterlacing when auto.
+    deinterlace: 4 # Game requires bob deinterlacing when auto.
 SCUS-97203:
   name: "Wild ARMs 3"
   region: "NTSC-U"
@@ -7300,7 +7300,7 @@ SCUS-97222:
   name: "Mark of Kri [Demo]"
   region: "NTSC-U"
   gsHWFixes:
-    deinterlace: 3 # Game requires bob deinterlacing when auto.
+    deinterlace: 4 # Game requires bob deinterlacing when auto.
 SCUS-97223:
   name: "NFL GameDay 2003 [Demo]"
   region: "NTSC-U"
@@ -11965,7 +11965,7 @@ SLES-51235:
   region: "PAL-M5"
   compat: 5
   gsHWFixes:
-    deinterlace: 6 # Fixes blurriness.
+    deinterlace: 7 # Fixes blurriness.
 SLES-51236:
   name: "Gungrave"
   region: "PAL-M3"
@@ -17330,7 +17330,7 @@ SLES-53621:
   region: "PAL-M5"
   compat: 5
   gsHWFixes:
-    deinterlace: 3 # Game requires bob deinterlacing when auto.
+    deinterlace: 4 # Game requires bob deinterlacing when auto.
     halfPixelOffset: 1 # Fixes misalignment/bloom when upscaling.
 SLES-53623:
   name: "SpongeBob SquarePants - Battle for Bikini Bottom"
@@ -19569,7 +19569,7 @@ SLES-54548:
   name: "Cocoto Fishing Master"
   region: "PAL-M4"
   gsHWFixes:
-    deinterlace: 6 # Fixes blurriness.
+    deinterlace: 7 # Fixes blurriness.
     halfPixelOffset: 1 # Fixes blur.
 SLES-54549:
   name: "Crazy Frog Racer 2"
@@ -26604,7 +26604,7 @@ SLPM-64521:
   region: "NTSC-K"
   compat: 5
   gsHWFixes:
-    deinterlace: 6 # Fixes blurriness.
+    deinterlace: 7 # Fixes blurriness.
 SLPM-64522:
   name: "La Pucelle"
   region: "NTSC-K"
@@ -27733,7 +27733,7 @@ SLPM-65310:
   name: "Mark of Kri, The"
   region: "NTSC-J"
   gsHWFixes:
-    deinterlace: 3 # Game requires bob deinterlacing when auto.
+    deinterlace: 4 # Game requires bob deinterlacing when auto.
 SLPM-65311:
   name: "Violet no Atelier - Gramnad no Renkinjutsushi"
   region: "NTSC-J"
@@ -31207,7 +31207,7 @@ SLPM-66327:
   name: "Wallace & Gromit - The Curse of the Were-Rabbit"
   region: "NTSC-J"
   gsHWFixes:
-    deinterlace: 3 # Game requires bob deinterlacing when auto.
+    deinterlace: 4 # Game requires bob deinterlacing when auto.
     halfPixelOffset: 1 # Fixes misalignment/bloom when upscaling.
 SLPM-66328:
   name: "Call of Duty 2 - Big Red One"
@@ -34743,7 +34743,7 @@ SLPS-20198:
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
-    deinterlace: 6 # Fixes blurriness.
+    deinterlace: 7 # Fixes blurriness.
 SLPS-20199:
   name: "F1 2002"
   region: "NTSC-J"
@@ -35146,13 +35146,13 @@ SLPS-20382:
   name: "Taiko no Tatsujin - Atsumare! Matsuri da!! Yondaime [with Tatacon]"
   region: "NTSC-J"
   gsHWFixes:
-    deinterlace: 4 # Game requires bob bff deinterlacing when auto.
+    deinterlace: 5 # Game requires bob bff deinterlacing when auto.
     alignSprite: 1 # Fixes vertical lines.
 SLPS-20383:
   name: "Taiko no Tatsujin - Atsumare! Matsuri da!! Yondaime"
   region: "NTSC-J"
   gsHWFixes:
-    deinterlace: 4 # Game requires bob bff deinterlacing when auto.
+    deinterlace: 5 # Game requires bob bff deinterlacing when auto.
     alignSprite: 1 # Fixes vertical lines.
 SLPS-20384:
   name: "Hayarigami - Keishichou Kaii Jiken File"
@@ -35194,13 +35194,13 @@ SLPS-20399:
   name: "Taiko no Tatsujin - Go! Go! Godaime [with Tatacon]"
   region: "NTSC-J"
   gsHWFixes:
-    deinterlace: 4 # Game requires bob bff deinterlacing when auto.
+    deinterlace: 5 # Game requires bob bff deinterlacing when auto.
     alignSprite: 1 # Fixes vertical lines.
 SLPS-20400:
   name: "Taiko no Tatsujin - Go! Go! Godaime"
   region: "NTSC-J"
   gsHWFixes:
-    deinterlace: 4 # Game requires bob bff deinterlacing when auto.
+    deinterlace: 5 # Game requires bob bff deinterlacing when auto.
     alignSprite: 1 # Fixes vertical lines.
 SLPS-20401:
   name: "Tecmo Hit Parade"
@@ -35241,14 +35241,14 @@ SLPS-20413:
   name: "Taiko no Tatsujin - Taiko Drum Master [with Tatacon]"
   region: "NTSC-J"
   gsHWFixes:
-    deinterlace: 4 # Game requires bob bff deinterlacing when auto.
+    deinterlace: 5 # Game requires bob bff deinterlacing when auto.
     alignSprite: 1 # Fixes vertical lines.
 SLPS-20414:
   name: "Taiko no Tatsujin - Taiko Drum Master"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
-    deinterlace: 4 # Game requires bob bff deinterlacing when auto.
+    deinterlace: 5 # Game requires bob bff deinterlacing when auto.
     alignSprite: 1 # Fixes vertical lines.
 SLPS-20416:
   name: "Inyou Taisenki - Byakko Enbu [with EyeToy]"
@@ -35277,13 +35277,13 @@ SLPS-20424:
   name: "Taiko no Tatsujin - Tobikkiri! Anime Special [with Tatacon]"
   region: "NTSC-J"
   gsHWFixes:
-    deinterlace: 4 # Game requires bob bff deinterlacing when auto.
+    deinterlace: 5 # Game requires bob bff deinterlacing when auto.
     alignSprite: 1 # Fixes vertical lines.
 SLPS-20425:
   name: "Taiko no Tatsujin - Tobikkiri! Anime Special"
   region: "NTSC-J"
   gsHWFixes:
-    deinterlace: 4 # Game requires bob bff deinterlacing when auto.
+    deinterlace: 5 # Game requires bob bff deinterlacing when auto.
     alignSprite: 1 # Fixes vertical lines.
 SLPS-20426:
   name: "Dreamworks Madagascar"
@@ -35345,13 +35345,13 @@ SLPS-20450:
   name: "Taiko no Tatsujin - Wai Wai Happy! Rokudaime [with Tatacon]"
   region: "NTSC-J"
   gsHWFixes:
-    deinterlace: 4 # Game requires bob bff deinterlacing when auto.
+    deinterlace: 5 # Game requires bob bff deinterlacing when auto.
     alignSprite: 1 # Fixes vertical lines.
 SLPS-20451:
   name: "Taiko no Tatsujin - Wai Wai Happy! Rokudaime"
   region: "NTSC-J"
   gsHWFixes:
-    deinterlace: 4 # Game requires bob bff deinterlacing when auto.
+    deinterlace: 5 # Game requires bob bff deinterlacing when auto.
     alignSprite: 1 # Fixes vertical lines.
 SLPS-20452:
   name: "Simple 2000 Series Ultimate Vol. 30 - Kourin! Zokusha Goddo!"
@@ -35472,13 +35472,13 @@ SLPS-20485:
   name: "Taiko no Tatsujin - Doka! to Oomori Nanadaime [with Tatacon]"
   region: "NTSC-J"
   gsHWFixes:
-    deinterlace: 4 # Game requires bob bff deinterlacing when auto.
+    deinterlace: 5 # Game requires bob bff deinterlacing when auto.
     alignSprite: 1 # Fixes vertical lines.
 SLPS-20486:
   name: "Taiko no Tatsujin - Doka! to Oomori Nanadaime"
   region: "NTSC-J"
   gsHWFixes:
-    deinterlace: 4 # Game requires bob bff deinterlacing when auto.
+    deinterlace: 5 # Game requires bob bff deinterlacing when auto.
     alignSprite: 1 # Fixes vertical lines.
 SLPS-20487:
   name: "Pachi-Slot King! Kagaku Ninja-Tai Gatchaman"
@@ -38987,7 +38987,7 @@ SLPS-73107:
   name: "Taiko no Tatsujin - Go! Go! Godaime [PlayStation 2 The Best]"
   region: "NTSC-J"
   gsHWFixes:
-    deinterlace: 4 # Game requires bob bff deinterlacing when auto.
+    deinterlace: 5 # Game requires bob bff deinterlacing when auto.
     alignSprite: 1 # Fixes vertical lines.
 SLPS-73108:
   name: "Phantom Brave [PlayStation 2 The Best]"
@@ -41510,7 +41510,7 @@ SLUS-20475:
   name: "Dual Hearts"
   region: "NTSC-U"
   gsHWFixes:
-    deinterlace: 5 # Game requires blend tff deinterlacing when auto.
+    deinterlace: 6 # Game requires blend tff deinterlacing when auto.
   compat: 5
 SLUS-20476:
   name: "NBA 2K3 - Sega Sports"
@@ -43036,7 +43036,7 @@ SLUS-20800:
   name: "Taiko Drum Master"
   region: "NTSC-U"
   gsHWFixes:
-    deinterlace: 4 # Game requires bob bff deinterlacing when auto.
+    deinterlace: 5 # Game requires bob bff deinterlacing when auto.
     alignSprite: 1 # Fixes vertical lines.
 SLUS-20801:
   name: "Midway Arcade Treasures"
@@ -45678,7 +45678,7 @@ SLUS-21312:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    deinterlace: 3 # Game requires bob deinterlacing when auto.
+    deinterlace: 4 # Game requires bob deinterlacing when auto.
     halfPixelOffset: 1 # Fixes misalignment/bloom when upscaling.
 SLUS-21313:
   name: "Friends - The One with all the Trivia"
@@ -47380,7 +47380,7 @@ SLUS-21663:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    deinterlace: 6 # Fixes blurriness.
+    deinterlace: 7 # Fixes blurriness.
     halfPixelOffset: 1 # Fixes blur.
 SLUS-21664:
   name: "Sims 2, The - Castaway"

--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -3030,6 +3030,8 @@ SCES-50887:
   name: "Alpine Racer 3"
   region: "PAL-M5"
   compat: 5
+  gsHWFixes:
+    deinterlace: 9 # Game requires Adaptive BFF deinterlacing when auto.
 SCES-50888:
   name: "Pac-Man World 2"
   region: "PAL-M5"
@@ -6457,6 +6459,8 @@ SCPS-51005:
 SCPS-51006:
   name: "Alpine Racer 3"
   region: "NTSC-J"
+  gsHWFixes:
+    deinterlace: 9 # Game requires Adaptive BFF deinterlacing when auto.
 SCPS-51008:
   name: "Wave Rally"
   region: "NTSC-J"
@@ -34700,6 +34704,8 @@ SLPS-20178:
 SLPS-20181:
   name: "Alpine Racer 3"
   region: "NTSC-J"
+  gsHWFixes:
+    deinterlace: 9 # Game requires Adaptive BFF deinterlacing when auto.
 SLPS-20183:
   name: "Motto Golful Golf"
   region: "NTSC-J"

--- a/bin/resources/shaders/dx11/interlace.fx
+++ b/bin/resources/shaders/dx11/interlace.fx
@@ -48,124 +48,143 @@ float4 ps_main3(PS_INPUT input) : SV_Target0
 
 float4 ps_main4(PS_INPUT input) : SV_Target0
 {
-    const int    vres     = int(round(ZrH.z));
-	const int    idx      = int(round(ZrH.x));
-	const int    bank     = idx >> 1;
-	const int    field    = idx & 1;
-	const int    vpos     = int(input.p.y) + (((((vres + 1) >> 1) << 1) - vres) & bank);
-	const float2 bofs     = float2(0.0f, 0.5f * bank);
-	const float2 vscale   = float2(1.0f, 2.0f);
-	const float2 optr     = input.t - bofs;
-	const float2 iptr     = optr * vscale;
+	// We take half the lines from the current frame and stores them in the MAD frame buffer.
+	// the MAD frame buffer is split in 2 consecutive banks of 2 fields each, the fields in each bank
+	// are interleaved (top field at even lines and bottom field at odd lines). 
+	// When the source texture has an odd vres, the first line of bank 1 would be an odd index
+	// causing the wrong lines to be discarded, so a vertical offset (lofs) is added to the vertical
+	// position of the destination texture to force the proper field alignment
 
-    if ((optr.y >= 0.0f) && (optr.y < 0.5f) && ((vpos & 1) == field))
+	const int    idx    = int(ZrH.x);                                // buffer index passed from CPU
+	const int    bank   = idx >> 1;                                  // current bank
+	const int    field  = idx & 1;                                   // current field
+	const int    vres   = int(ZrH.z);                                // vertical resolution of source texture
+	const int    lofs   = ((((vres + 1) >> 1) << 1) - vres) & bank;  // line alignment offset for bank 1
+	const int    vpos   = int(input.p.y) + lofs;                     // vertical position of destination texture
+	const float2 bofs   = float2(0.0f, 0.5f * bank);                 // vertical offset of the current bank relative to source texture size
+	const float2 vscale = float2(1.0f, 2.0f);                        // scaling factor from source to destination texture
+	const float2 optr   = input.t - bofs;                            // used to check if the current destination line is within the current bank
+	const float2 iptr   = optr * vscale;                             // pointer to the current pixel in the source texture
+
+	// if the index of current destination line belongs to the current fiels we update it, otherwise
+	// we leave the old line in the destination buffer
+	if ((optr.y >= 0.0f) && (optr.y < 0.5f) && ((vpos & 1) == field))
 		return Texture.Sample(Sampler, iptr);
 	else
 		discard;
 
 	return float4(0.0f, 0.0f, 0.0f, 0.0f);
-	
 }
 
 
 float4 ps_main5(PS_INPUT input) : SV_Target0
 {
-	const float  sensitivity = ZrH.w;
-	const float3 motion_thr = float3(1.0, 1.0, 1.0) * sensitivity;
-	const float2 vofs = float2(0.0f, 0.5f);
-	const float2 vscale = float2(1.0f, 0.5f);
-	const int    idx = int(round(ZrH.x));
-	const int    bank = idx >> 1;
-	const int    field = idx & 1;
-	const float2 line_ofs = float2(0.0f, ZrH.y);
-	const float2 iptr = input.t * vscale;
+	// we use the contents of the MAD frame buffer to reconstruct the missing lines from the current
+	// field.
 
-	float2 p_new_cf;
-	float2 p_old_cf;
-	float2 p_new_af;
-	float2 p_old_af;
+	const int    idx         = int(round(ZrH.x));                   // buffer index passed from CPU
+	const int    bank        = idx >> 1;                            // current bank
+	const int    field       = idx & 1;                             // current field
+	const int    vpos        = int(input.p.y);                      // vertical position of destination texture
+	const float  sensitivity = ZrH.w;                               // passed from CPU, higher values mean more likely to use weave
+	const float3 motion_thr  = float3(1.0, 1.0, 1.0) * sensitivity; //
+	const float2 bofs        = float2(0.0f, 0.5f);                  // position of the bank 1 relative to source texture size
+	const float2 vscale      = float2(1.0f, 0.5f);                  // scaling factor from source to destination texture
+	const float2 lofs        = float2(0.0f, ZrH.y);                 // distance between two adjacent lines relative to source texture size
+	const float2 iptr        = input.t * vscale;                    // pointer to the current pixel in the source texture
+
+	float2 p_t0; // pointer to current pixel (missing or not) from most recent frame
+	float2 p_t1; // pointer to current pixel (missing or not) from one frame back
+	float2 p_t2; // pointer to current pixel (missing or not) from two frames back
+	float2 p_t3; // pointer to current pixel (missing or not) from three frames back
 
 	switch (idx)
 	{
 		case 0:
-			p_new_cf = iptr;
-			p_new_af = iptr + vofs;
-			p_old_cf = iptr + vofs;
-			p_old_af = iptr;
+			p_t0 = iptr;
+			p_t1 = iptr + bofs;
+			p_t2 = iptr + bofs;
+			p_t3 = iptr;
 			break;
 		case 1:
-			p_new_cf = iptr;
-			p_new_af = iptr;
-			p_old_cf = iptr + vofs;
-			p_old_af = iptr + vofs;
+			p_t0 = iptr;
+			p_t1 = iptr;
+			p_t2 = iptr + bofs;
+			p_t3 = iptr + bofs;
 			break;
 		case 2:
-			p_new_cf = iptr + vofs;
-			p_new_af = iptr;
-			p_old_cf = iptr;
-			p_old_af = iptr + vofs;
+			p_t0 = iptr + bofs;
+			p_t1 = iptr;
+			p_t2 = iptr;
+			p_t3 = iptr + bofs;
 			break;
 		case 3:
-			p_new_cf = iptr + vofs;
-			p_new_af = iptr + vofs;
-			p_old_cf = iptr;
-			p_old_af = iptr;
+			p_t0 = iptr + bofs;
+			p_t1 = iptr + bofs;
+			p_t2 = iptr;
+			p_t3 = iptr;
 			break;
 		default:
 			break;
 	}
 
-	// calculating motion
+	// calculating motion, only relevant for missing lines where the "center line" is pointed
+	// by p_t1
 
-	float4 hn = Texture.Sample(Sampler, p_new_cf - line_ofs); // high
-	float4 cn = Texture.Sample(Sampler, p_new_af); // center
-	float4 ln = Texture.Sample(Sampler, p_new_cf + line_ofs); // low
+	float4 hn = Texture.Sample(Sampler, p_t0 - lofs); // new high pixel
+	float4 cn = Texture.Sample(Sampler, p_t1);        // new center pixel
+	float4 ln = Texture.Sample(Sampler, p_t0 + lofs); // new low pixel
 
-	float4 ho = Texture.Sample(Sampler, p_old_cf - line_ofs); // high
-	float4 co = Texture.Sample(Sampler, p_old_af); // center
-	float4 lo = Texture.Sample(Sampler, p_old_cf + line_ofs); // low
+	float4 ho = Texture.Sample(Sampler, p_t2 - lofs); // old high pixel
+	float4 co = Texture.Sample(Sampler, p_t3);        // old center pixel
+	float4 lo = Texture.Sample(Sampler, p_t2 + lofs); // old low pixel
 
-	float3 mh = hn.rgb - ho.rgb;
-	float3 mc = cn.rgb - co.rgb;
-	float3 ml = ln.rgb - lo.rgb;
+	float3 mh = hn.rgb - ho.rgb; // high pixel motion
+	float3 mc = cn.rgb - co.rgb; // center pixel motion
+	float3 ml = ln.rgb - lo.rgb; // low pixel motion
 
 	mh = max(mh, -mh) - motion_thr;
 	mc = max(mc, -mc) - motion_thr;
 	ml = max(ml, -ml) - motion_thr;
 
-
-//    float mh_max = max(max(mh.x, mh.y), mh.z);
-//    float mc_max = max(max(mc.x, mc.y), mc.z);
-//    float ml_max = max(max(ml.x, ml.y), ml.z);
-
-	float mh_max = mh.x + mh.y + mh.z;
-	float mc_max = mc.x + mc.y + mc.z;
-	float ml_max = ml.x + ml.y + ml.z;
+	#if 1 // use this code to evaluate each color motion separately
+		float mh_max = max(max(mh.x, mh.y), mh.z);
+		float mc_max = max(max(mc.x, mc.y), mc.z);
+		float ml_max = max(max(ml.x, ml.y), ml.z);
+	#else // use this code to evaluate average color motion
+		float mh_max = mh.x + mh.y + mh.z;
+		float mc_max = mc.x + mc.y + mc.z;
+		float ml_max = ml.x + ml.y + ml.z;
+	#endif
 
 	// selecting deinterlacing output
 
-	if (((int(input.p.y) & 1) == field)) // output coordinate present on current field
+	if ((vpos & 1) == field)
 	{
-		return Texture.Sample(Sampler, p_new_cf);
+		// output coordinate present on current field
+		return Texture.Sample(Sampler, p_t0);
 	}
-	else if ((iptr.y > 0.5f - line_ofs.y) || (iptr.y < 0.0 + line_ofs.y))
+	else if ((iptr.y > 0.5f - lofs.y) || (iptr.y < 0.0 + lofs.y))
 	{
-		return Texture.Sample(Sampler, p_new_af);
+		// top and bottom lines are always weaved
+		return cn;
 	}
 	else
 	{
+		// missing line needs to be reconstructed
 		if (((mh_max > 0.0f) || (ml_max > 0.0f)) || (mc_max > 0.0f))
 		{
+			// high motion -> interpolate pixels above and below
 			return (hn + ln) / 2.0f;
 		}
 		else
 		{
-			return Texture.Sample(Sampler, p_new_af);
+			// low motion -> weave
+			return cn;
 		}
 	}
 
 	return float4(0.0f, 0.0f, 0.0f, 0.0f);
 }
-
 
 #endif

--- a/bin/resources/shaders/dx11/interlace.fx
+++ b/bin/resources/shaders/dx11/interlace.fx
@@ -58,7 +58,7 @@ float4 ps_main4(PS_INPUT input) : SV_Target0
 	const int    idx    = int(ZrH.x);                                // buffer index passed from CPU
 	const int    bank   = idx >> 1;                                  // current bank
 	const int    field  = idx & 1;                                   // current field
-	const int    vres   = int(ZrH.z);                                // vertical resolution of source texture
+	const int    vres   = int(ZrH.z) >> 1;                           // vertical resolution of source texture
 	const int    lofs   = ((((vres + 1) >> 1) << 1) - vres) & bank;  // line alignment offset for bank 1
 	const int    vpos   = int(input.p.y) + lofs;                     // vertical position of destination texture
 	const float2 bofs   = float2(0.0f, 0.5f * bank);                 // vertical offset of the current bank relative to source texture size
@@ -68,7 +68,7 @@ float4 ps_main4(PS_INPUT input) : SV_Target0
 
 	// if the index of current destination line belongs to the current fiels we update it, otherwise
 	// we leave the old line in the destination buffer
-	if ((optr.y >= 0.0f) && (optr.y < 0.5f) && ((vpos & 1) == field))
+	if ((optr.y >= 0.0f) && (optr.y < 0.5f) && ((vpos & 1) != field))
 		return Texture.Sample(Sampler, iptr);
 	else
 		discard;
@@ -82,7 +82,7 @@ float4 ps_main5(PS_INPUT input) : SV_Target0
 	// we use the contents of the MAD frame buffer to reconstruct the missing lines from the current
 	// field.
 
-	const int    idx         = int(round(ZrH.x));                   // buffer index passed from CPU
+	const int    idx         = int(ZrH.x);                          // buffer index passed from CPU
 	const int    bank        = idx >> 1;                            // current bank
 	const int    field       = idx & 1;                             // current field
 	const int    vpos        = int(input.p.y);                      // vertical position of destination texture
@@ -90,7 +90,7 @@ float4 ps_main5(PS_INPUT input) : SV_Target0
 	const float3 motion_thr  = float3(1.0, 1.0, 1.0) * sensitivity; //
 	const float2 bofs        = float2(0.0f, 0.5f);                  // position of the bank 1 relative to source texture size
 	const float2 vscale      = float2(1.0f, 0.5f);                  // scaling factor from source to destination texture
-	const float2 lofs        = float2(0.0f, ZrH.y);                 // distance between two adjacent lines relative to source texture size
+	const float2 lofs        = float2(0.0f, ZrH.y) * vscale;        // distance between two adjacent lines relative to source texture size
 	const float2 iptr        = input.t * vscale;                    // pointer to the current pixel in the source texture
 
 	float2 p_t0; // pointer to current pixel (missing or not) from most recent frame
@@ -159,7 +159,7 @@ float4 ps_main5(PS_INPUT input) : SV_Target0
 
 	// selecting deinterlacing output
 
-	if ((vpos & 1) == field)
+	if ((vpos & 1) != field)
 	{
 		// output coordinate present on current field
 		return Texture.Sample(Sampler, p_t0);

--- a/bin/resources/shaders/dx11/interlace.fx
+++ b/bin/resources/shaders/dx11/interlace.fx
@@ -5,7 +5,7 @@ SamplerState Sampler;
 
 cbuffer cb0
 {
-	float2 ZrH;
+	float4 ZrH;
 };
 
 struct PS_INPUT
@@ -32,9 +32,10 @@ float4 ps_main1(PS_INPUT input) : SV_Target0
 
 float4 ps_main2(PS_INPUT input) : SV_Target0
 {
-	float4 c0 = Texture.Sample(Sampler, input.t - ZrH);
+	float2 vstep = float2(0.0f, ZrH.y);
+	float4 c0 = Texture.Sample(Sampler, input.t - vstep);
 	float4 c1 = Texture.Sample(Sampler, input.t);
-	float4 c2 = Texture.Sample(Sampler, input.t + ZrH);
+	float4 c2 = Texture.Sample(Sampler, input.t + vstep);
 
 	return (c0 + c1 * 2 + c2) / 4;
 }
@@ -43,4 +44,128 @@ float4 ps_main3(PS_INPUT input) : SV_Target0
 {
 	return Texture.Sample(Sampler, input.t);
 }
+
+
+float4 ps_main4(PS_INPUT input) : SV_Target0
+{
+    const int    vres     = int(round(ZrH.z));
+	const int    idx      = int(round(ZrH.x));
+	const int    bank     = idx >> 1;
+	const int    field    = idx & 1;
+	const int    vpos     = int(input.p.y) + (((((vres + 1) >> 1) << 1) - vres) & bank);
+	const float2 bofs     = float2(0.0f, 0.5f * bank);
+	const float2 vscale   = float2(1.0f, 2.0f);
+	const float2 optr     = input.t - bofs;
+	const float2 iptr     = optr * vscale;
+
+    if ((optr.y >= 0.0f) && (optr.y < 0.5f) && ((vpos & 1) == field))
+		return Texture.Sample(Sampler, iptr);
+	else
+		discard;
+
+	return float4(0.0f, 0.0f, 0.0f, 0.0f);
+	
+}
+
+
+float4 ps_main5(PS_INPUT input) : SV_Target0
+{
+	const float  sensitivity = ZrH.w;
+	const float3 motion_thr = float3(1.0, 1.0, 1.0) * sensitivity;
+	const float2 vofs = float2(0.0f, 0.5f);
+	const float2 vscale = float2(1.0f, 0.5f);
+	const int    idx = int(round(ZrH.x));
+	const int    bank = idx >> 1;
+	const int    field = idx & 1;
+	const float2 line_ofs = float2(0.0f, ZrH.y);
+	const float2 iptr = input.t * vscale;
+
+	float2 p_new_cf;
+	float2 p_old_cf;
+	float2 p_new_af;
+	float2 p_old_af;
+
+	switch (idx)
+	{
+		case 0:
+			p_new_cf = iptr;
+			p_new_af = iptr + vofs;
+			p_old_cf = iptr + vofs;
+			p_old_af = iptr;
+			break;
+		case 1:
+			p_new_cf = iptr;
+			p_new_af = iptr;
+			p_old_cf = iptr + vofs;
+			p_old_af = iptr + vofs;
+			break;
+		case 2:
+			p_new_cf = iptr + vofs;
+			p_new_af = iptr;
+			p_old_cf = iptr;
+			p_old_af = iptr + vofs;
+			break;
+		case 3:
+			p_new_cf = iptr + vofs;
+			p_new_af = iptr + vofs;
+			p_old_cf = iptr;
+			p_old_af = iptr;
+			break;
+		default:
+			break;
+	}
+
+	// calculating motion
+
+	float4 hn = Texture.Sample(Sampler, p_new_cf - line_ofs); // high
+	float4 cn = Texture.Sample(Sampler, p_new_af); // center
+	float4 ln = Texture.Sample(Sampler, p_new_cf + line_ofs); // low
+
+	float4 ho = Texture.Sample(Sampler, p_old_cf - line_ofs); // high
+	float4 co = Texture.Sample(Sampler, p_old_af); // center
+	float4 lo = Texture.Sample(Sampler, p_old_cf + line_ofs); // low
+
+	float3 mh = hn.rgb - ho.rgb;
+	float3 mc = cn.rgb - co.rgb;
+	float3 ml = ln.rgb - lo.rgb;
+
+	mh = max(mh, -mh) - motion_thr;
+	mc = max(mc, -mc) - motion_thr;
+	ml = max(ml, -ml) - motion_thr;
+
+
+//    float mh_max = max(max(mh.x, mh.y), mh.z);
+//    float mc_max = max(max(mc.x, mc.y), mc.z);
+//    float ml_max = max(max(ml.x, ml.y), ml.z);
+
+	float mh_max = mh.x + mh.y + mh.z;
+	float mc_max = mc.x + mc.y + mc.z;
+	float ml_max = ml.x + ml.y + ml.z;
+
+	// selecting deinterlacing output
+
+	if (((int(input.p.y) & 1) == field)) // output coordinate present on current field
+	{
+		return Texture.Sample(Sampler, p_new_cf);
+	}
+	else if ((iptr.y > 0.5f - line_ofs.y) || (iptr.y < 0.0 + line_ofs.y))
+	{
+		return Texture.Sample(Sampler, p_new_af);
+	}
+	else
+	{
+		if (((mh_max > 0.0f) || (ml_max > 0.0f)) || (mc_max > 0.0f))
+		{
+			return (hn + ln) / 2.0f;
+		}
+		else
+		{
+			return Texture.Sample(Sampler, p_new_af);
+		}
+	}
+
+	return float4(0.0f, 0.0f, 0.0f, 0.0f);
+}
+
+
 #endif

--- a/bin/resources/shaders/opengl/interlace.glsl
+++ b/bin/resources/shaders/opengl/interlace.glsl
@@ -6,7 +6,7 @@ in vec4 PSin_p;
 in vec2 PSin_t;
 in vec4 PSin_c;
 
-uniform vec2 ZrH;
+uniform vec4 ZrH;
 
 layout(location = 0) out vec4 SV_Target0;
 
@@ -35,9 +35,10 @@ void ps_main1()
 
 void ps_main2()
 {
-    vec4 c0 = texture(TextureSampler, PSin_t - ZrH);
+    vec2 vstep = vec2(0.0f, ZrH.y);
+    vec4 c0 = texture(TextureSampler, PSin_t - vstep);
     vec4 c1 = texture(TextureSampler, PSin_t);
-    vec4 c2 = texture(TextureSampler, PSin_t + ZrH);
+    vec4 c2 = texture(TextureSampler, PSin_t + vstep);
 
     SV_Target0 = (c0 + c1 * 2.0f + c2) / 4.0f;
 }
@@ -45,6 +46,124 @@ void ps_main2()
 void ps_main3()
 {
     SV_Target0 = texture(TextureSampler, PSin_t);
+}
+
+
+void ps_main4()
+{
+    const int  vres   = int(round(ZrH.z));
+    const int  idx    = int(round(ZrH.x));
+    const int  bank   = idx >> 1;
+    const int  field  = idx & 1;
+    const int  vpos   = int(gl_FragCoord.y) + (((((vres + 1) >> 1) << 1) - vres) & bank);
+    const vec2 bofs   = vec2(0.0f, 0.5f * bank);
+    const vec2 vscale = vec2(1.0f, 2.0f); 
+    const vec2 optr   = PSin_t - bofs;
+    const vec2 iptr   = optr * vscale;
+
+    if ((optr.y >= 0.0f) && (optr.y < 0.5f) && ((vpos & 1) == field))
+    //if ((optr.y >= 0.0f) && (optr.y < 0.5f) && (int(iptr.y * vres) & 1) == field)
+        SV_Target0 = texture(TextureSampler, iptr);
+    else
+        discard;
+}
+
+
+void ps_main5()
+{
+    const float sensitivity  = ZrH.w;
+    const vec3  motion_thr   = vec3(1.0, 1.0, 1.0) * sensitivity;
+    const vec2  vofs         = vec2(0.0f, 0.5f);
+    const vec2  vscale       = vec2(1.0f, 0.5f);
+    const int   idx          = int(round(ZrH.x));
+    const int   bank         = idx >> 1;
+    const int   field        = idx & 1;
+    const vec2  line_ofs     = vec2(0.0f, ZrH.y);
+    const vec2  iptr         = PSin_t * vscale;
+
+    vec2 p_new_cf;
+    vec2 p_old_cf;
+    vec2 p_new_af;
+    vec2 p_old_af;
+
+    switch (idx)
+    {
+        case 0:
+            p_new_cf = iptr;
+            p_new_af = iptr + vofs;
+            p_old_cf = iptr + vofs;
+            p_old_af = iptr;
+            break;
+        case 1:
+            p_new_cf = iptr;
+            p_new_af = iptr;
+            p_old_cf = iptr + vofs;
+            p_old_af = iptr + vofs;
+            break;
+        case 2:
+            p_new_cf = iptr + vofs;
+            p_new_af = iptr;
+            p_old_cf = iptr;
+            p_old_af = iptr + vofs;
+            break;
+        case 3:
+            p_new_cf = iptr + vofs;
+            p_new_af = iptr + vofs;
+            p_old_cf = iptr;
+            p_old_af = iptr;
+            break;
+        default:
+            break;
+    }
+
+    // calculating motion
+
+    vec4 hn = texture(TextureSampler, p_new_cf - line_ofs); // high
+    vec4 cn = texture(TextureSampler, p_new_af);            // center
+    vec4 ln = texture(TextureSampler, p_new_cf + line_ofs); // low
+
+    vec4 ho = texture(TextureSampler, p_old_cf - line_ofs); // high
+    vec4 co = texture(TextureSampler, p_old_af);            // center
+    vec4 lo = texture(TextureSampler, p_old_cf + line_ofs); // low
+
+    vec3 mh = hn.rgb - ho.rgb;
+    vec3 mc = cn.rgb - co.rgb;
+    vec3 ml = ln.rgb - lo.rgb;
+
+    mh = max(mh, -mh) - motion_thr;
+    mc = max(mc, -mc) - motion_thr;
+    ml = max(ml, -ml) - motion_thr;
+
+//    float mh_max = max(max(mh.x, mh.y), mh.z);
+//    float mc_max = max(max(mc.x, mc.y), mc.z);
+//    float ml_max = max(max(ml.x, ml.y), ml.z);
+
+    float mh_max = mh.x + mh.y + mh.z;
+    float mc_max = mc.x + mc.y + mc.z;
+    float ml_max = ml.x + ml.y + ml.z;
+
+    // selecting deinterlacing output
+
+    if (((int(gl_FragCoord.y) & 1) == field)) // output coordinate present on current field
+    {
+        SV_Target0 = texture(TextureSampler, p_new_cf);
+        
+    }
+    else if ((iptr.y > 0.5f - line_ofs.y) || (iptr.y < 0.0 + line_ofs.y))
+    {
+        SV_Target0 = texture(TextureSampler, p_new_af);
+    }
+    else
+    {
+        if(((mh_max > 0.0f) || (ml_max > 0.0f)) || (mc_max > 0.0f))
+        {
+            SV_Target0 = (hn + ln) / 2.0f;
+        }
+        else
+        {
+            SV_Target0 = texture(TextureSampler, p_new_af);
+        }
+    }
 }
 
 #endif

--- a/bin/resources/shaders/opengl/interlace.glsl
+++ b/bin/resources/shaders/opengl/interlace.glsl
@@ -61,7 +61,7 @@ void ps_main4()
 	const int  idx    = int(ZrH.x);                                // buffer index passed from CPU
 	const int  bank   = idx >> 1;                                  // current bank
 	const int  field  = idx & 1;                                   // current field
-	const int  vres   = int(ZrH.z);                                // vertical resolution of source texture
+	const int  vres   = int(ZrH.z) >> 1;                           // vertical resolution of source texture
 	const int  lofs   = ((((vres + 1) >> 1) << 1) - vres) & bank;  // line alignment offset for bank 1
 	const int  vpos   = int(gl_FragCoord.y) + lofs;                // vertical position of destination texture
 	const vec2 bofs   = vec2(0.0f, 0.5f * bank);                   // vertical offset of the current bank relative to source texture size
@@ -71,7 +71,7 @@ void ps_main4()
 
 	// if the index of current destination line belongs to the current fiels we update it, otherwise
 	// we leave the old line in the destination buffer
-	if ((optr.y >= 0.0f) && (optr.y < 0.5f) && ((vpos & 1) == field))
+	if ((optr.y >= 0.0f) && (optr.y < 0.5f) && ((vpos & 1) != field))
 		SV_Target0 = texture(TextureSampler, iptr);
 	else
 		discard;
@@ -83,7 +83,7 @@ void ps_main5()
 	// we use the contents of the MAD frame buffer to reconstruct the missing lines from the current
 	// field.
 
-	const int   idx          = int(round(ZrH.x));                  // buffer index passed from CPU
+	const int   idx          = int(ZrH.x);                         // buffer index passed from CPU
 	const int   bank         = idx >> 1;                           // current bank
 	const int   field        = idx & 1;                            // current field
 	const int   vpos         = int(gl_FragCoord.y);                // vertical position of destination texture
@@ -91,7 +91,7 @@ void ps_main5()
 	const vec3  motion_thr   = vec3(1.0, 1.0, 1.0) * sensitivity;  //
 	const vec2  bofs         = vec2(0.0f, 0.5f);                   // position of the bank 1 relative to source texture size
 	const vec2  vscale       = vec2(1.0f, 0.5f);                   // scaling factor from source to destination texture
-	const vec2  lofs         = vec2(0.0f, ZrH.y);                  // distance between two adjacent lines relative to source texture size
+	const vec2  lofs         = vec2(0.0f, ZrH.y) * vscale;         // distance between two adjacent lines relative to source texture size
 	const vec2  iptr         = PSin_t * vscale;                    // pointer to the current pixel in the source texture
 
 	vec2 p_t0; // pointer to current pixel (missing or not) from most recent frame
@@ -162,7 +162,7 @@ void ps_main5()
 
 	// selecting deinterlacing output
 		
-	if ((vpos & 1) == field)
+	if ((vpos & 1) != field)
 	{
 		// output coordinate present on current field
 		SV_Target0 = texture(TextureSampler, p_t0);

--- a/bin/resources/shaders/vulkan/interlace.glsl
+++ b/bin/resources/shaders/vulkan/interlace.glsl
@@ -73,10 +73,10 @@ void ps_main4()
 	// causing the wrong lines to be discarded, so a vertical offset (lofs) is added to the vertical
 	// position of the destination texture to force the proper field alignment
 
-	const int  idx    = int(round(ZrH.x));                        // buffer index passed from CPU
+	const int  idx    = int(ZrH.x);                               // buffer index passed from CPU
 	const int  bank   = idx >> 1;                                 // current bank
 	const int  field  = idx & 1;                                  // current field
-	const int  vres   = int(round(ZrH.z));                        // vertical resolution of source texture
+	const int  vres   = int(ZrH.z) >> 1;                          // vertical resolution of source texture
 	const int  lofs   = ((((vres + 1) >> 1) << 1) - vres) & bank; // line alignment offset for bank 1
 	const int  vpos   = int(gl_FragCoord.y) + lofs;               // vertical position of destination texture
 	const vec2 bofs   = vec2(0.0f, 0.5f * bank);                  // vertical offset of the current bank relative to source texture size
@@ -86,7 +86,7 @@ void ps_main4()
 
 	// if the index of current destination line belongs to the current fiels we update it, otherwise
 	// we leave the old line in the destination buffer
-	if ((optr.y >= 0.0f) && (optr.y < 0.5f) && ((vpos & 1) == field))
+	if ((optr.y >= 0.0f) && (optr.y < 0.5f) && ((vpos & 1) != field))
 		o_col0 = texture(samp0, iptr);
 	else
 		discard;
@@ -100,7 +100,7 @@ void ps_main5()
 	// we use the contents of the MAD frame buffer to reconstruct the missing lines from the current
 	// field.
 
-	const int   idx          = int(round(ZrH.x));                  // buffer index passed from CPU
+	const int   idx          = int(ZrH.x);                         // buffer index passed from CPU
 	const int   bank         = idx >> 1;                           // current bank
 	const int   field        = idx & 1;                            // current field
 	const int   vpos         = int(gl_FragCoord.y);                // vertical position of destination texture
@@ -108,7 +108,7 @@ void ps_main5()
 	const vec3  motion_thr   = vec3(1.0, 1.0, 1.0) * sensitivity;  //
 	const vec2  bofs         = vec2(0.0f, 0.5f);                   // position of the bank 1 relative to source texture size
 	const vec2  vscale       = vec2(1.0f, 0.5f);                   // scaling factor from source to destination texture
-	const vec2  lofs         = vec2(0.0f, ZrH.y);                  // distance between two adjacent lines relative to source texture size
+	const vec2  lofs         = vec2(0.0f, ZrH.y) * vscale;         // distance between two adjacent lines relative to source texture size
 	const vec2  iptr         = v_tex * vscale;                     // pointer to the current pixel in the source texture
 
 	vec2 p_t0; // pointer to current pixel (missing or not) from most recent frame
@@ -177,7 +177,7 @@ void ps_main5()
 
 	// selecting deinterlacing output
 
-	if ((vpos & 1) == field) // output coordinate present on current field
+	if ((vpos & 1) != field) // output coordinate present on current field
 	{
 		// output coordinate present on current field
 		o_col0 = texture(samp0, p_t0);

--- a/bin/resources/shaders/vulkan/interlace.glsl
+++ b/bin/resources/shaders/vulkan/interlace.glsl
@@ -20,7 +20,7 @@ layout(location = 0) out vec4 o_col0;
 
 layout(push_constant) uniform cb0
 {
-	vec2 ZrH;
+	vec4 ZrH;
 };
 
 layout(set = 0, binding = 0) uniform sampler2D samp0;
@@ -46,9 +46,10 @@ void ps_main1()
 #ifdef ps_main2
 void ps_main2()
 {
-	vec4 c0 = texture(samp0, v_tex - ZrH);
+	vec2 vstep = vec2(0.0f, ZrH.y);
+	vec4 c0 = texture(samp0, v_tex - vstep);
 	vec4 c1 = texture(samp0, v_tex);
-	vec4 c2 = texture(samp0, v_tex + ZrH);
+	vec4 c2 = texture(samp0, v_tex + vstep);
 
 	o_col0 = (c0 + c1 * 2.0f + c2) / 4.0f;
 }
@@ -58,6 +59,129 @@ void ps_main2()
 void ps_main3()
 {
 	o_col0 = texture(samp0, v_tex);
+}
+#endif
+
+
+#ifdef ps_main4
+void ps_main4()
+{
+    const int  vres   = int(round(ZrH.z));
+    const int  idx    = int(round(ZrH.x));
+    const int  bank   = idx >> 1;
+    const int  field  = idx & 1;
+	const int  vpos   = int(gl_FragCoord.y) + (((((vres + 1) >> 1) << 1) - vres) & bank);
+    const vec2 bofs   = vec2(0.0f, 0.5f * bank);
+    const vec2 vscale = vec2(1.0f, 2.0f); 
+    const vec2 optr   = v_tex - bofs;
+    const vec2 iptr   = optr * vscale;
+
+    if ((optr.y >= 0.0f) && (optr.y < 0.5f) && ((vpos & 1) == field))
+        o_col0 = texture(samp0, iptr);
+    else
+        discard;
+}
+#endif
+
+
+#ifdef ps_main5
+void ps_main5()
+{
+    const float sensitivity  = ZrH.w;
+    const vec3  motion_thr   = vec3(1.0, 1.0, 1.0) * sensitivity;
+    const vec2  vofs         = vec2(0.0f, 0.5f);
+    const vec2  vscale       = vec2(1.0f, 0.5f);
+
+    int  idx      = int(round(ZrH.x));
+    int  bank     = idx >> 1;
+    int  field    = idx & 1;
+    vec2 line_ofs = vec2(0.0f, ZrH.y);
+
+    vec2 iptr = v_tex * vscale;
+    vec2 p_new_cf = vec2(0.0f, 0.0f);
+    vec2 p_old_cf = vec2(0.0f, 0.0f);
+    vec2 p_new_af = vec2(0.0f, 0.0f);
+    vec2 p_old_af = vec2(0.0f, 0.0f);
+
+    switch (idx)
+    {
+        case 0:
+            p_new_cf = iptr;
+            p_new_af = iptr + vofs;
+            p_old_cf = iptr + vofs;
+            p_old_af = iptr;
+            break;
+        case 1:
+            p_new_cf = iptr;
+            p_new_af = iptr;
+            p_old_cf = iptr + vofs;
+            p_old_af = iptr + vofs;
+            break;
+        case 2:
+            p_new_cf = iptr + vofs;
+            p_new_af = iptr;
+            p_old_cf = iptr;
+            p_old_af = iptr + vofs;
+            break;
+        case 3:
+            p_new_cf = iptr + vofs;
+            p_new_af = iptr + vofs;
+            p_old_cf = iptr;
+            p_old_af = iptr;
+            break;
+        default:
+            break;
+    }
+
+    // calculating motion
+
+    vec4 hn = texture(samp0, p_new_cf - line_ofs); // high
+    vec4 cn = texture(samp0, p_new_af);            // center
+    vec4 ln = texture(samp0, p_new_cf + line_ofs); // low
+
+    vec4 ho = texture(samp0, p_old_cf - line_ofs); // high
+    vec4 co = texture(samp0, p_old_af);            // center
+    vec4 lo = texture(samp0, p_old_cf + line_ofs); // low
+
+    vec3 mh = hn.rgb - ho.rgb;
+    vec3 mc = cn.rgb - co.rgb;
+    vec3 ml = ln.rgb - lo.rgb;
+
+    mh = max(mh, -mh) - motion_thr;
+    mc = max(mc, -mc) - motion_thr;
+    ml = max(ml, -ml) - motion_thr;
+
+
+//    float mh_max = max(max(mh.x, mh.y), mh.z);
+//    float mc_max = max(max(mc.x, mc.y), mc.z);
+//    float ml_max = max(max(ml.x, ml.y), ml.z);
+
+    float mh_max = mh.x + mh.y + mh.z;
+    float mc_max = mc.x + mc.y + mc.z;
+    float ml_max = ml.x + ml.y + ml.z;
+
+    // selecting deinterlacing output
+
+    if (((int(gl_FragCoord.y) & 1) == field)) // output coordinate present on current field
+    {
+        o_col0 = texture(samp0, p_new_cf);
+        
+    }
+    else if ((iptr.y > 0.5f - line_ofs.y) || (iptr.y < 0.0 + line_ofs.y))
+    {
+        o_col0 = texture(samp0, p_new_af);
+    }
+    else
+    {
+        if(((mh_max > 0.0f) || (ml_max > 0.0f)) || (mc_max > 0.0f))
+        {
+            o_col0 = (hn + ln) / 2.0f;
+        }
+        else
+        {
+            o_col0 = texture(samp0, p_new_af);
+        }
+    }
 }
 #endif
 

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -108,7 +108,7 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsDialog* dialog, QWidget* 
 		sif, m_ui.aspectRatio, "EmuCore/GS", "AspectRatio", Pcsx2Config::GSOptions::AspectRatioNames, AspectRatioType::RAuto4_3_3_2);
 	SettingWidgetBinder::BindWidgetToEnumSetting(sif, m_ui.fmvAspectRatio, "EmuCore/GS", "FMVAspectRatioSwitch",
 		Pcsx2Config::GSOptions::FMVAspectRatioSwitchNames, FMVAspectRatioSwitchType::Off);
-	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.interlacing, "EmuCore/GS", "deinterlace", DEFAULT_INTERLACE_MODE);
+	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.interlacing, "EmuCore/GS", "deinterlace_mode", DEFAULT_INTERLACE_MODE);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.bilinearFiltering, "EmuCore/GS", "linear_present", true);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.integerScaling, "EmuCore/GS", "IntegerScaling", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.PCRTCOffsets, "EmuCore/GS", "pcrtc_offsets", false);

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -75,7 +75,7 @@ static const char* s_anisotropic_filtering_entries[] = {QT_TRANSLATE_NOOP("Graph
 	QT_TRANSLATE_NOOP("GraphicsSettingsWidget", "8x"), QT_TRANSLATE_NOOP("GraphicsSettingsWidget", "16x"), nullptr};
 static const char* s_anisotropic_filtering_values[] = {"0", "2", "4", "8", "16", nullptr};
 
-static constexpr int DEFAULT_INTERLACE_MODE = 7;
+static constexpr int DEFAULT_INTERLACE_MODE = 0;
 static constexpr int DEFAULT_TV_SHADER_MODE = 0;
 
 GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsDialog* dialog, QWidget* parent)

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
@@ -58,7 +58,7 @@
    <item>
     <widget class="QTabWidget" name="hardwareRendererGroup">
      <property name="currentIndex">
-      <number>2</number>
+      <number>0</number>
      </property>
      <property name="documentMode">
       <bool>true</bool>
@@ -151,6 +151,11 @@
         <widget class="QComboBox" name="interlacing">
          <item>
           <property name="text">
+           <string>Automatic (Default)</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
            <string>None</string>
           </property>
          </item>
@@ -186,7 +191,12 @@
          </item>
          <item>
           <property name="text">
-           <string>Automatic (Default)</string>
+           <string>Adaptive (Top Field First)</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Adaptive (Bottom Field First)</string>
           </property>
          </item>
         </widget>

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -130,6 +130,7 @@ enum class GSRendererType : s8
 
 enum class GSInterlaceMode : u8
 {
+	Automatic,
 	Off,
 	WeaveTFF,
 	WeaveBFF,
@@ -137,7 +138,8 @@ enum class GSInterlaceMode : u8
 	BobBFF,
 	BlendTFF,
 	BlendBFF,
-	Automatic,
+	AdaptiveTFF,
+	AdaptiveBFF,
 	Count
 };
 

--- a/pcsx2/Docs/GameIndex.md
+++ b/pcsx2/Docs/GameIndex.md
@@ -140,9 +140,18 @@ The clamp modes are also numerically based.
 
 ### GS Hardware General Fixes
 
-*   conservativeFramebuffer   [`0` or `1`]                 {Off or On}                                                                 Default: On (`1`)
-*   texturePreloading         [`0` or `1` or `2`]          {None, Partial or Full Hash Cache}                                          Default: None (`0`)
-*   deinterlace               [Value between `0` to `7`]   {Off, WeaveTFF, WeaveBFF, BobTFF, BobBFF, BlendTFF, BlendBFF, Automatic}    Default: Automatic (No value, looks up GameDB)
+*   conservativeFramebuffer
+        [`0` or `1`] 
+        {Off or On}
+        Default: On (`1`)
+*   texturePreloading
+        [`0` or `1` or `2`]
+        {None, Partial or Full Hash Cache}
+        Default: None (`0`)
+*   deinterlace
+        [Value between `0` to `9`]
+        {Automatic Off, WeaveTFF, WeaveBFF, BobTFF, BobBFF, BlendTFF, BlendBFF, AdaptiveTFF, AdaptiveBFF}
+        Default: Automatic (No value, looks up GameDB)
 
 ### GS Hardware Renderer Fixes
 

--- a/pcsx2/Docs/GameIndex.md
+++ b/pcsx2/Docs/GameIndex.md
@@ -150,7 +150,7 @@ The clamp modes are also numerically based.
         Default: None (`0`)
 *   deinterlace
         [Value between `0` to `9`]
-        {Automatic Off, WeaveTFF, WeaveBFF, BobTFF, BobBFF, BlendTFF, BlendBFF, AdaptiveTFF, AdaptiveBFF}
+        {Automatic, Off, WeaveTFF, WeaveBFF, BobTFF, BobBFF, BlendTFF, BlendBFF, AdaptiveTFF, AdaptiveBFF}
         Default: Automatic (No value, looks up GameDB)
 
 ### GS Hardware Renderer Fixes

--- a/pcsx2/Docs/gamedb-schema.json
+++ b/pcsx2/Docs/gamedb-schema.json
@@ -192,7 +192,7 @@
             "deinterlace": {
               "type": "integer",
               "minimum": 0,
-              "maximum": 7
+              "maximum": 9
             },
             "cpuSpriteRenderBW": {
               "type": "integer",

--- a/pcsx2/Frontend/CommonHost.cpp
+++ b/pcsx2/Frontend/CommonHost.cpp
@@ -52,7 +52,7 @@
 #include <ShlObj.h>
 #endif
 
-static constexpr u32 SETTINGS_VERSION = 2;
+static constexpr u32 SETTINGS_VERSION = 1;
 
 namespace CommonHost
 {

--- a/pcsx2/Frontend/CommonHost.cpp
+++ b/pcsx2/Frontend/CommonHost.cpp
@@ -52,7 +52,7 @@
 #include <ShlObj.h>
 #endif
 
-static constexpr u32 SETTINGS_VERSION = 1;
+static constexpr u32 SETTINGS_VERSION = 2;
 
 namespace CommonHost
 {

--- a/pcsx2/Frontend/FullscreenUI.cpp
+++ b/pcsx2/Frontend/FullscreenUI.cpp
@@ -2790,9 +2790,9 @@ void FullscreenUI::DrawGraphicsSettingsPage()
 		"11", //GSRendererType::Null
 	};
 	static constexpr const char* s_vsync_values[] = {"Off", "On", "Adaptive"};
-	static constexpr const char* s_deinterlacing_options[] = {"None", "Weave (Top Field First, Sawtooth)",
+	static constexpr const char* s_deinterlacing_options[] = {"Automatic (Default)", "None", "Weave (Top Field First, Sawtooth)",
 		"Weave (Bottom Field First, Sawtooth)", "Bob (Top Field First)", "Bob (Bottom Field First)", "Blend (Top Field First, Half FPS)",
-		"Blend (Bottom Field First, Half FPS)", "Automatic (Default)"};
+		"Blend (Bottom Field First, Half FPS)", "Adaptive (Top Field First", "Adaptive (Bottom Field First)"};
 	static const char* s_resolution_options[] = {
 		"Native (PS2)",
 		"1.25x Native",

--- a/pcsx2/Frontend/FullscreenUI.cpp
+++ b/pcsx2/Frontend/FullscreenUI.cpp
@@ -2866,7 +2866,7 @@ void FullscreenUI::DrawGraphicsSettingsPage()
 		"FMVAspectRatioSwitch", "Auto 4:3/3:2", Pcsx2Config::GSOptions::FMVAspectRatioSwitchNames,
 		Pcsx2Config::GSOptions::FMVAspectRatioSwitchNames, 0);
 	DrawIntListSetting(bsi, "Deinterlacing",
-		"Selects the algorithm used to convert the PS2's interlaced output to progressive for display.", "EmuCore/GS", "deinterlace",
+		"Selects the algorithm used to convert the PS2's interlaced output to progressive for display.", "EmuCore/GS", "deinterlace_mode",
 		static_cast<int>(GSInterlaceMode::Automatic), s_deinterlacing_options, std::size(s_deinterlacing_options));
 	DrawIntRangeSetting(bsi, "Zoom", "Increases or decreases the virtual picture size both horizontally and vertically.", "EmuCore/GS",
 		"Zoom", 100, 10, 300, "%d%%");

--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -1310,14 +1310,16 @@ void GSApp::Init()
 	// The null renderer goes last, it has use for benchmarking purposes in a release build
 	m_gs_renderers.push_back(GSSetting(static_cast<u32>(GSRendererType::Null), "Null", ""));
 
-	m_gs_deinterlace.push_back(GSSetting(0, "None", ""));
-	m_gs_deinterlace.push_back(GSSetting(1, "Weave tff", "saw-tooth"));
-	m_gs_deinterlace.push_back(GSSetting(2, "Weave bff", "saw-tooth"));
-	m_gs_deinterlace.push_back(GSSetting(3, "Bob tff", "use blend if shaking"));
-	m_gs_deinterlace.push_back(GSSetting(4, "Bob bff", "use blend if shaking"));
-	m_gs_deinterlace.push_back(GSSetting(5, "Blend tff", "slight blur, 1/2 fps"));
-	m_gs_deinterlace.push_back(GSSetting(6, "Blend bff", "slight blur, 1/2 fps"));
-	m_gs_deinterlace.push_back(GSSetting(7, "Automatic", "Default"));
+	m_gs_deinterlace.push_back(GSSetting(0, "Automatic", "Default"));
+	m_gs_deinterlace.push_back(GSSetting(1, "None", ""));
+	m_gs_deinterlace.push_back(GSSetting(2, "Weave tff", "saw-tooth"));
+	m_gs_deinterlace.push_back(GSSetting(3, "Weave bff", "saw-tooth"));
+	m_gs_deinterlace.push_back(GSSetting(4, "Bob tff", "use adaptive or blend if shaking"));
+	m_gs_deinterlace.push_back(GSSetting(5, "Bob bff", "use adaptive or blend if shaking"));
+	m_gs_deinterlace.push_back(GSSetting(6, "Blend tff", "slight blur, 1/2 fps"));
+	m_gs_deinterlace.push_back(GSSetting(7, "Blend bff", "slight blur, 1/2 fps"));
+	m_gs_deinterlace.push_back(GSSetting(8, "Adaptive tff", "minor artifacts"));
+	m_gs_deinterlace.push_back(GSSetting(9, "Adaptive bff", "minor artifacts"));
 
 	m_gs_upscale_multiplier.push_back(GSSetting(1, "Native", "PS2"));
 	m_gs_upscale_multiplier.push_back(GSSetting(2, "2x Native", "~720p"));

--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -1455,7 +1455,7 @@ void GSApp::Init()
 	m_default_configuration["pcrtc_offsets"]                              = "0";
 	m_default_configuration["pcrtc_overscan"]                             = "0";
 	m_default_configuration["IntegerScaling"]                             = "0";
-	m_default_configuration["deinterlace"]                                = "7";
+	m_default_configuration["deinterlace_mode"]                           = "0";
 	m_default_configuration["linear_present"]                             = "1";
 	m_default_configuration["LoadTextureReplacements"]                    = "0";
 	m_default_configuration["LoadTextureReplacementsAsync"]               = "1";
@@ -1765,6 +1765,7 @@ BEGIN_HOTKEY_LIST(g_gs_hotkeys)
 			 return;
 
 		 static constexpr std::array<const char*, static_cast<int>(GSInterlaceMode::Count)> option_names = {{
+			 "Automatic",
 			 "Off",
 			 "Weave (Top Field First)",
 			 "Weave (Bottom Field First)",
@@ -1772,7 +1773,8 @@ BEGIN_HOTKEY_LIST(g_gs_hotkeys)
 			 "Bob (Bottom Field First)",
 			 "Blend (Top Field First)",
 			 "Blend (Bottom Field First)",
-			 "Automatic",
+			 "Adaptive (Top Field First)",
+			 "Adaptive (Bottom Field First)",
 		 }};
 
 		 const GSInterlaceMode new_mode = static_cast<GSInterlaceMode>((static_cast<s32>(EmuConfig.GS.InterlaceMode) + 1) % static_cast<s32>(GSInterlaceMode::Count));

--- a/pcsx2/GS/Renderers/Common/GSDevice.cpp
+++ b/pcsx2/GS/Renderers/Common/GSDevice.cpp
@@ -369,18 +369,18 @@ void GSDevice::Interlace(const GSVector2i& ds, int field, int mode, float yoffse
 
 	switch (mode)
 	{
-		case 0: // weave
+		case 0: // Weave
 			ResizeTarget(&m_weavebob, ds.x, ds.y);
 			DoInterlace(m_merge, m_weavebob, 0, false, offset, field);
 			m_current = m_weavebob;
 			break;
-		case 1: // bob
+		case 1: // Bob
 			// Field is reversed here as we are countering the bounce.
 			ResizeTarget(&m_weavebob, ds.x, ds.y);
 			DoInterlace(m_merge, m_weavebob, 1, true, yoffset * (1 - field), 0);
 			m_current = m_weavebob;
 			break;
-		case 2: //Blend
+		case 2: // Blend
 			ResizeTarget(&m_weavebob, ds.x, ds.y);
 			DoInterlace(m_merge, m_weavebob, 0, false, offset, field);
 			ResizeTarget(&m_blend, ds.x, ds.y);

--- a/pcsx2/GS/Renderers/Common/GSDevice.cpp
+++ b/pcsx2/GS/Renderers/Common/GSDevice.cpp
@@ -371,18 +371,18 @@ void GSDevice::Interlace(const GSVector2i& ds, int field, int mode, float yoffse
 	{
 		case 0: // weave
 			ResizeTarget(&m_weavebob, ds.x, ds.y);
-			DoInterlace(m_merge, m_weavebob, field, false, offset, 0);
+			DoInterlace(m_merge, m_weavebob, 0, false, offset, field);
 			m_current = m_weavebob;
 			break;
 		case 1: // bob
 			// Field is reversed here as we are countering the bounce.
 			ResizeTarget(&m_weavebob, ds.x, ds.y);
-			DoInterlace(m_merge, m_weavebob, 3, true, yoffset * (1 - field), 0);
+			DoInterlace(m_merge, m_weavebob, 1, true, yoffset * (1 - field), 0);
 			m_current = m_weavebob;
 			break;
 		case 2: //Blend
 			ResizeTarget(&m_weavebob, ds.x, ds.y);
-			DoInterlace(m_merge, m_weavebob, field, false, offset, 0);
+			DoInterlace(m_merge, m_weavebob, 0, false, offset, field);
 			ResizeTarget(&m_blend, ds.x, ds.y);
 			DoInterlace(m_weavebob, m_blend, 2, false, 0, 0);
 			m_current = m_blend;
@@ -393,9 +393,9 @@ void GSDevice::Interlace(const GSVector2i& ds, int field, int mode, float yoffse
 			bufIdx |= field;
 			bufIdx &= 3;
 			ResizeTarget(&m_mad, ds.x, ds.y * 2.0f);
-			DoInterlace(m_merge, m_mad, 4, false, offset, bufIdx);
+			DoInterlace(m_merge, m_mad, 3, false, offset, bufIdx);
 			ResizeTarget(&m_weavebob, ds.x, ds.y);
-			DoInterlace(m_mad, m_weavebob, 5, false, 0, bufIdx);
+			DoInterlace(m_mad, m_weavebob, 4, false, 0, bufIdx);
 			m_current = m_weavebob;
 			break;
 		default:

--- a/pcsx2/GS/Renderers/Common/GSDevice.cpp
+++ b/pcsx2/GS/Renderers/Common/GSDevice.cpp
@@ -86,6 +86,7 @@ GSDevice::~GSDevice()
 	delete m_merge;
 	delete m_weavebob;
 	delete m_blend;
+	delete m_mad;
 	delete m_target_tmp;
 }
 
@@ -101,11 +102,13 @@ void GSDevice::Destroy()
 	delete m_merge;
 	delete m_weavebob;
 	delete m_blend;
+	delete m_mad;
 	delete m_target_tmp;
 
 	m_merge = nullptr;
 	m_weavebob = nullptr;
 	m_blend = nullptr;
+	m_mad = nullptr;
 	m_target_tmp = nullptr;
 
 	m_current = nullptr; // current is special, points to other textures, no need to delete
@@ -312,11 +315,13 @@ void GSDevice::ClearCurrent()
 	delete m_merge;
 	delete m_weavebob;
 	delete m_blend;
+	delete m_mad;
 	delete m_target_tmp;
 
 	m_merge = nullptr;
 	m_weavebob = nullptr;
 	m_blend = nullptr;
+	m_mad = nullptr;
 	m_target_tmp = nullptr;
 }
 
@@ -358,36 +363,39 @@ void GSDevice::Merge(GSTexture* sTex[3], GSVector4* sRect, GSVector4* dRect, con
 
 void GSDevice::Interlace(const GSVector2i& ds, int field, int mode, float yoffset)
 {
-	ResizeTarget(&m_weavebob, ds.x, ds.y);
+	static int bufIdx = 0;
 
-	if (mode == 0 || mode == 2) // weave or blend
+	if (mode == 0) // weave
 	{
-		// weave first
 		const float offset = yoffset * static_cast<float>(field);
-
-		DoInterlace(m_merge, m_weavebob, field, false, GSConfig.DisableInterlaceOffset ? 0.0f : offset);
-
-		if (mode == 2)
-		{
-			// blend
-
-			ResizeTarget(&m_blend, ds.x, ds.y);
-
-			DoInterlace(m_weavebob, m_blend, 2, false, 0);
-
-			m_current = m_blend;
-		}
-		else
-		{
-			m_current = m_weavebob;
-		}
+		ResizeTarget(&m_weavebob, ds.x, ds.y);
+		DoInterlace(m_merge, m_weavebob, field, false, GSConfig.DisableInterlaceOffset ? 0.0f : offset, 0);
+		m_current = m_weavebob;
 	}
 	else if (mode == 1) // bob
 	{
 		// Field is reversed here as we are countering the bounce.
-		DoInterlace(m_merge, m_weavebob, 3, true, yoffset * (1-field));
-
+		ResizeTarget(&m_weavebob, ds.x, ds.y);
+		DoInterlace(m_merge, m_weavebob, 3, true, yoffset * (1-field), 0);
 		m_current = m_weavebob;
+	}
+	else if  (mode == 2) // FastMAD Motion Adaptive Deinterlacing
+	{
+		bufIdx++;
+		bufIdx &= ~(field ^ 1);
+		bufIdx |= (field);
+		bufIdx &= 3;
+
+		float offset = (yoffset * field);
+		offset = GSConfig.DisableInterlaceOffset ? 0.0f : offset;
+
+		ResizeTarget(&m_mad, ds.x, ds.y * 2.0f);
+		DoInterlace(m_merge, m_mad, 4, false, offset, bufIdx);
+		ResizeTarget(&m_blend, ds.x, ds.y);
+		DoInterlace(m_mad, m_blend, 5, false, 0, bufIdx);
+
+
+		m_current = m_blend;
 	}
 	else
 	{

--- a/pcsx2/GS/Renderers/Common/GSDevice.h
+++ b/pcsx2/GS/Renderers/Common/GSDevice.h
@@ -191,9 +191,7 @@ public:
 class InterlaceConstantBuffer
 {
 public:
-	GSVector2 ZrH;
-	float _pad[2];
-
+	GSVector4 ZrH; // data passed to the shader
 	InterlaceConstantBuffer() { memset(this, 0, sizeof(*this)); }
 };
 
@@ -739,11 +737,14 @@ private:
 	static const std::array<u8, 16> m_replaceDualSrcBlendMap;
 
 protected:
-	static constexpr u32 MAX_POOLED_TEXTURES = 300;
+	static constexpr int   NUM_INTERLACE_SHADERS = 6;
+	static constexpr float MAD_SENSITIVITY = 0.08f;
+	static constexpr u32   MAX_POOLED_TEXTURES = 300;
 
 	GSTexture* m_merge = nullptr;
 	GSTexture* m_weavebob = nullptr;
 	GSTexture* m_blend = nullptr;
+	GSTexture* m_mad = nullptr;
 	GSTexture* m_target_tmp = nullptr;
 	GSTexture* m_current = nullptr;
 	struct
@@ -762,7 +763,7 @@ protected:
 	GSTexture* FetchSurface(GSTexture::Type type, int width, int height, int levels, GSTexture::Format format, bool clear, bool prefer_reuse);
 
 	virtual void DoMerge(GSTexture* sTex[3], GSVector4* sRect, GSTexture* dTex, GSVector4* dRect, const GSRegPMODE& PMODE, const GSRegEXTBUF& EXTBUF, const GSVector4& c) = 0;
-	virtual void DoInterlace(GSTexture* sTex, GSTexture* dTex, int shader, bool linear, float yoffset) = 0;
+	virtual void DoInterlace(GSTexture* sTex, GSTexture* dTex, int shader, bool linear, float yoffset, int bufIdx) = 0;
 	virtual void DoFXAA(GSTexture* sTex, GSTexture* dTex) {}
 	virtual void DoShadeBoost(GSTexture* sTex, GSTexture* dTex, const float params[4]) {}
 	virtual void DoExternalFX(GSTexture* sTex, GSTexture* dTex) {}

--- a/pcsx2/GS/Renderers/Common/GSDevice.h
+++ b/pcsx2/GS/Renderers/Common/GSDevice.h
@@ -737,7 +737,7 @@ private:
 	static const std::array<u8, 16> m_replaceDualSrcBlendMap;
 
 protected:
-	static constexpr int   NUM_INTERLACE_SHADERS = 6;
+	static constexpr int   NUM_INTERLACE_SHADERS = 5;
 	static constexpr float MAD_SENSITIVITY = 0.08f;
 	static constexpr u32   MAX_POOLED_TEXTURES = 300;
 

--- a/pcsx2/GS/Renderers/Common/GSRenderer.cpp
+++ b/pcsx2/GS/Renderers/Common/GSRenderer.cpp
@@ -919,7 +919,7 @@ void GSRenderer::KeyEvent(const HostKeyEvent& e)
 		{
 			case VK_F5:
 				GSConfig.InterlaceMode = static_cast<GSInterlaceMode>((static_cast<int>(GSConfig.InterlaceMode) + static_cast<int>(GSInterlaceMode::Count) + step) % static_cast<int>(GSInterlaceMode::Count));
-				theApp.SetConfig("deinterlace", static_cast<int>(GSConfig.InterlaceMode));
+				theApp.SetConfig("deinterlace_mode", static_cast<int>(GSConfig.InterlaceMode));
 				printf("GS: Set deinterlace mode to %d (%s).\n", static_cast<int>(GSConfig.InterlaceMode), theApp.m_gs_deinterlace.at(static_cast<int>(GSConfig.InterlaceMode)).name.c_str());
 				return;
 			case VK_NEXT: // As requested by Prafull, to be removed later

--- a/pcsx2/GS/Renderers/Common/GSRenderer.cpp
+++ b/pcsx2/GS/Renderers/Common/GSRenderer.cpp
@@ -179,13 +179,13 @@ bool GSRenderer::Merge(int field)
 	float offset = is_bob ? (tex[1] ? tex[1]->GetScale().y : tex[0]->GetScale().y) : 0.0f;
 
 	int field2 = 0;
-	int mode = 2;
+	int mode = 3;
 
 	// FFMD (half frames) requires blend deinterlacing, so automatically use that. Same when SCANMSK is used but not blended in the merge circuit (Alpine Racer 3)
 	if (GSConfig.InterlaceMode != GSInterlaceMode::Automatic || (!m_regs->SMODE2.FFMD && !scanmask_frame))
 	{
-		field2 = ((static_cast<int>(GSConfig.InterlaceMode) - 1) & 1);
-		mode = ((static_cast<int>(GSConfig.InterlaceMode) - 1) >> 1);
+		field2 = ((static_cast<int>(GSConfig.InterlaceMode) - 2) & 1);
+		mode = ((static_cast<int>(GSConfig.InterlaceMode) - 2) >> 1);
 	}
 
 	for (int i = 0; i < 2; i++)

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
@@ -823,16 +823,17 @@ void GSDevice11::DoMerge(GSTexture* sTex[3], GSVector4* sRect, GSTexture* dTex, 
 	}
 }
 
-void GSDevice11::DoInterlace(GSTexture* sTex, GSTexture* dTex, int shader, bool linear, float yoffset)
+void GSDevice11::DoInterlace(GSTexture* sTex, GSTexture* dTex, int shader, bool linear, float yoffset, int bufIdx)
 {
-	const GSVector4 s = GSVector4(dTex->GetSize());
+	const GSVector4 ss = GSVector4(sTex->GetSize());
+	const GSVector4 ds = GSVector4(dTex->GetSize());
 
 	const GSVector4 sRect(0, 0, 1, 1);
-	const GSVector4 dRect(0.0f, yoffset, s.x, s.y + yoffset);
+	const GSVector4 dRect(0.0f, yoffset, ds.x, ds.y + yoffset);
 
 	InterlaceConstantBuffer cb;
 
-	cb.ZrH = GSVector2(0, 1.0f / s.y);
+	cb.ZrH = GSVector4(static_cast<float>(bufIdx), 1.0f / ss.y, ss.y, MAD_SENSITIVITY);
 
 	m_ctx->UpdateSubresource(m_interlace.cb.get(), 0, nullptr, &cb, 0, 0);
 

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
@@ -825,7 +825,6 @@ void GSDevice11::DoMerge(GSTexture* sTex[3], GSVector4* sRect, GSTexture* dTex, 
 
 void GSDevice11::DoInterlace(GSTexture* sTex, GSTexture* dTex, int shader, bool linear, float yoffset, int bufIdx)
 {
-	const GSVector4 ss = GSVector4(sTex->GetSize());
 	const GSVector4 ds = GSVector4(dTex->GetSize());
 
 	const GSVector4 sRect(0, 0, 1, 1);
@@ -833,7 +832,7 @@ void GSDevice11::DoInterlace(GSTexture* sTex, GSTexture* dTex, int shader, bool 
 
 	InterlaceConstantBuffer cb;
 
-	cb.ZrH = GSVector4(static_cast<float>(bufIdx), 1.0f / ss.y, ss.y, MAD_SENSITIVITY);
+	cb.ZrH = GSVector4(static_cast<float>(bufIdx), 1.0f / ds.y, ds.y, MAD_SENSITIVITY);
 
 	m_ctx->UpdateSubresource(m_interlace.cb.get(), 0, nullptr, &cb, 0, 0);
 

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.h
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.h
@@ -119,7 +119,7 @@ private:
 	GSTexture* CreateSurface(GSTexture::Type type, int width, int height, int levels, GSTexture::Format format) final;
 
 	void DoMerge(GSTexture* sTex[3], GSVector4* sRect, GSTexture* dTex, GSVector4* dRect, const GSRegPMODE& PMODE, const GSRegEXTBUF& EXTBUF, const GSVector4& c) final;
-	void DoInterlace(GSTexture* sTex, GSTexture* dTex, int shader, bool linear, float yoffset = 0) final;
+	void DoInterlace(GSTexture* sTex, GSTexture* dTex, int shader, bool linear, float yoffset = 0, int bufIdx = 0) final;
 	void DoFXAA(GSTexture* sTex, GSTexture* dTex) final;
 	void DoShadeBoost(GSTexture* sTex, GSTexture* dTex, const float params[4]) final;
 	void DoExternalFX(GSTexture* sTex, GSTexture* dTex) final;
@@ -185,7 +185,7 @@ private:
 
 	struct
 	{
-		wil::com_ptr_nothrow<ID3D11PixelShader> ps[4];
+		wil::com_ptr_nothrow<ID3D11PixelShader> ps[NUM_INTERLACE_SHADERS];
 		wil::com_ptr_nothrow<ID3D11Buffer> cb;
 	} m_interlace;
 

--- a/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
@@ -722,7 +722,6 @@ void GSDevice12::DoMerge(GSTexture* sTex[3], GSVector4* sRect, GSTexture* dTex, 
 
 void GSDevice12::DoInterlace(GSTexture* sTex, GSTexture* dTex, int shader, bool linear, float yoffset, int bufIdx)
 {
-	const GSVector4  ss   = GSVector4(sTex->GetSize());
 	const GSVector2i ds_i = dTex->GetSize();
 	const GSVector4  ds   = GSVector4(ds_i);
 	
@@ -732,7 +731,7 @@ void GSDevice12::DoInterlace(GSTexture* sTex, GSTexture* dTex, int shader, bool 
 
 	InterlaceConstantBuffer cb;
 
-	cb.ZrH = GSVector4(static_cast<float>(bufIdx), 1.0f / ss.y, ss.y, MAD_SENSITIVITY);
+	cb.ZrH = GSVector4(static_cast<float>(bufIdx), 1.0f / ds.y, ds.y, MAD_SENSITIVITY);
 
 	GL_PUSH("DoInterlace %dx%d Shader:%d Linear:%d", ds_i.x, ds_i.y, shader, linear);
 

--- a/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
@@ -722,9 +722,10 @@ void GSDevice12::DoMerge(GSTexture* sTex[3], GSVector4* sRect, GSTexture* dTex, 
 
 void GSDevice12::DoInterlace(GSTexture* sTex, GSTexture* dTex, int shader, bool linear, float yoffset, int bufIdx)
 {
-	const GSVector4 ss = GSVector4(sTex->GetSize());
-	const GSVector4 ds = GSVector4(dTex->GetSize());
-	const GSVector2i ds_i(dTex->GetSize());
+	const GSVector4  ss   = GSVector4(sTex->GetSize());
+	const GSVector2i ds_i = dTex->GetSize();
+	const GSVector4  ds   = GSVector4(ds_i);
+	
 
 	const GSVector4 sRect(0, 0, 1, 1);
 	const GSVector4 dRect(0.0f, yoffset, ds.x, ds.y + yoffset);
@@ -733,7 +734,7 @@ void GSDevice12::DoInterlace(GSTexture* sTex, GSTexture* dTex, int shader, bool 
 
 	cb.ZrH = GSVector4(static_cast<float>(bufIdx), 1.0f / ss.y, ss.y, MAD_SENSITIVITY);
 
-	GL_PUSH("DoInterlace %dx%d Shader:%d Linear:%d", size.x, size.y, shader, linear);
+	GL_PUSH("DoInterlace %dx%d Shader:%d Linear:%d", ds_i.x, ds_i.y, shader, linear);
 
 	static_cast<GSTexture12*>(dTex)->TransitionToState(D3D12_RESOURCE_STATE_RENDER_TARGET);
 

--- a/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
@@ -720,22 +720,24 @@ void GSDevice12::DoMerge(GSTexture* sTex[3], GSVector4* sRect, GSTexture* dTex, 
 	static_cast<GSTexture12*>(dTex)->TransitionToState(D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
 }
 
-void GSDevice12::DoInterlace(GSTexture* sTex, GSTexture* dTex, int shader, bool linear, float yoffset)
+void GSDevice12::DoInterlace(GSTexture* sTex, GSTexture* dTex, int shader, bool linear, float yoffset, int bufIdx)
 {
-	const GSVector2i size(dTex->GetSize());
-	const GSVector4 s = GSVector4(size);
+	const GSVector4 ss = GSVector4(sTex->GetSize());
+	const GSVector4 ds = GSVector4(dTex->GetSize());
+	const GSVector2i ds_i(dTex->GetSize());
 
 	const GSVector4 sRect(0, 0, 1, 1);
-	const GSVector4 dRect(0.0f, yoffset, s.x, s.y + yoffset);
+	const GSVector4 dRect(0.0f, yoffset, ds.x, ds.y + yoffset);
 
 	InterlaceConstantBuffer cb;
-	cb.ZrH = GSVector2(0, 1.0f / s.y);
+
+	cb.ZrH = GSVector4(static_cast<float>(bufIdx), 1.0f / ss.y, ss.y, MAD_SENSITIVITY);
 
 	GL_PUSH("DoInterlace %dx%d Shader:%d Linear:%d", size.x, size.y, shader, linear);
 
 	static_cast<GSTexture12*>(dTex)->TransitionToState(D3D12_RESOURCE_STATE_RENDER_TARGET);
 
-	const GSVector4i rc(0, 0, size.x, size.y);
+	const GSVector4i rc(0, 0, ds_i.x, ds_i.y);
 	EndRenderPass();
 	OMSetRenderTargets(dTex, nullptr, rc);
 	SetUtilityRootSignature();

--- a/pcsx2/GS/Renderers/DX12/GSDevice12.h
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.h
@@ -156,7 +156,7 @@ private:
 	std::array<ComPtr<ID3D12PipelineState>, static_cast<int>(PresentShader::Count)> m_present{};
 	std::array<ComPtr<ID3D12PipelineState>, 16> m_color_copy{};
 	std::array<ComPtr<ID3D12PipelineState>, 2> m_merge{};
-	std::array<ComPtr<ID3D12PipelineState>, 4> m_interlace{};
+	std::array<ComPtr<ID3D12PipelineState>, NUM_INTERLACE_SHADERS> m_interlace{};
 	std::array<ComPtr<ID3D12PipelineState>, 2> m_hdr_setup_pipelines{}; // [depth]
 	std::array<ComPtr<ID3D12PipelineState>, 2> m_hdr_finish_pipelines{}; // [depth]
 	std::array<std::array<ComPtr<ID3D12PipelineState>, 2>, 2> m_date_image_setup_pipelines{}; // [depth][datm]
@@ -181,7 +181,7 @@ private:
 
 	void DoMerge(GSTexture* sTex[3], GSVector4* sRect, GSTexture* dTex, GSVector4* dRect, const GSRegPMODE& PMODE,
 		const GSRegEXTBUF& EXTBUF, const GSVector4& c) final;
-	void DoInterlace(GSTexture* sTex, GSTexture* dTex, int shader, bool linear, float yoffset = 0) final;
+	void DoInterlace(GSTexture* sTex, GSTexture* dTex, int shader, bool linear, float yoffset = 0, int bufIdx = 0) final;
 	void DoShadeBoost(GSTexture* sTex, GSTexture* dTex, const float params[4]) final;
 	void DoFXAA(GSTexture* sTex, GSTexture* dTex) final;
 

--- a/pcsx2/GS/Renderers/Metal/GSDeviceMTL.h
+++ b/pcsx2/GS/Renderers/Metal/GSDeviceMTL.h
@@ -347,7 +347,7 @@ public:
 	GSTexture* CreateSurface(GSTexture::Type type, int width, int height, int levels, GSTexture::Format format) override;
 
 	void DoMerge(GSTexture* sTex[3], GSVector4* sRect, GSTexture* dTex, GSVector4* dRect, const GSRegPMODE& PMODE, const GSRegEXTBUF& EXTBUF, const GSVector4& c) override;
-	void DoInterlace(GSTexture* sTex, GSTexture* dTex, int shader, bool linear, float yoffset) override;
+	void DoInterlace(GSTexture* sTex, GSTexture* dTex, int shader, bool linear, float yoffset, int bufIdx) override;
 	void DoFXAA(GSTexture* sTex, GSTexture* dTex) override;
 	void DoShadeBoost(GSTexture* sTex, GSTexture* dTex, const float params[4]) override;
 	void DoExternalFX(GSTexture* sTex, GSTexture* dTex) override;

--- a/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
+++ b/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
@@ -588,14 +588,13 @@ void GSDeviceMTL::DoInterlace(GSTexture* sTex, GSTexture* dTex, int shader, bool
 	id<MTLCommandBuffer> cmdbuf = GetRenderCmdBuf();
 	GSScopedDebugGroupMTL dbg(cmdbuf, @"DoInterlace");
 
-	GSVector4 ss = GSVector4(sTex->GetSize());
 	GSVector4 ds = GSVector4(dTex->GetSize());
 
 	GSVector4 sRect(0, 0, 1, 1);
 	GSVector4 dRect(0.f, yoffset, ds.x, ds.y + yoffset);
 
 	GSMTLInterlacePSUniform cb = {};
-	cb.ZrH = {static_cast<float>(bufIdx), 1.0f / ss.y, ss.y, MAD_SENSITIVITY};
+	cb.ZrH = {static_cast<float>(bufIdx), 1.0f / ds.y, ds.y, MAD_SENSITIVITY};
 
 	DoStretchRect(sTex, sRect, dTex, dRect, m_interlace_pipeline[shader], linear, shader > 1 ? LoadAction::DontCareIfFull : LoadAction::Load, &cb, sizeof(cb));
 }}

--- a/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
+++ b/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
@@ -583,18 +583,19 @@ void GSDeviceMTL::DoMerge(GSTexture* sTex[3], GSVector4* sRect, GSTexture* dTex,
 		StretchRect(dTex, full_r, sTex[2], dRect[0], ShaderConvert::YUV);
 }}
 
-void GSDeviceMTL::DoInterlace(GSTexture* sTex, GSTexture* dTex, int shader, bool linear, float yoffset)
+void GSDeviceMTL::DoInterlace(GSTexture* sTex, GSTexture* dTex, int shader, bool linear, float yoffset, int bufIdx)
 { @autoreleasepool {
 	id<MTLCommandBuffer> cmdbuf = GetRenderCmdBuf();
 	GSScopedDebugGroupMTL dbg(cmdbuf, @"DoInterlace");
 
-	GSVector4 s = GSVector4(dTex->GetSize());
+	GSVector4 ss = GSVector4(sTex->GetSize());
+	GSVector4 ds = GSVector4(dTex->GetSize());
 
 	GSVector4 sRect(0, 0, 1, 1);
-	GSVector4 dRect(0.f, yoffset, s.x, s.y + yoffset);
+	GSVector4 dRect(0.f, yoffset, ds.x, ds.y + yoffset);
 
 	GSMTLInterlacePSUniform cb = {};
-	cb.ZrH = {0, 1.f / s.y};
+	cb.ZrH = {static_cast<float>(bufIdx), 1.0f / ss.y, ss.y, MAD_SENSITIVITY};
 
 	DoStretchRect(sTex, sRect, dTex, dRect, m_interlace_pipeline[shader], linear, shader > 1 ? LoadAction::DontCareIfFull : LoadAction::Load, &cb, sizeof(cb));
 }}

--- a/pcsx2/GS/Renderers/Metal/GSMTLSharedHeader.h
+++ b/pcsx2/GS/Renderers/Metal/GSMTLSharedHeader.h
@@ -54,7 +54,7 @@ struct GSMTLPresentPSUniform
 
 struct GSMTLInterlacePSUniform
 {
-	vector_float2 ZrH;
+	vector_float4 ZrH;
 };
 
 struct GSMTLMainVertex

--- a/pcsx2/GS/Renderers/Metal/interlace.metal
+++ b/pcsx2/GS/Renderers/Metal/interlace.metal
@@ -36,9 +36,10 @@ fragment float4 ps_interlace1(ConvertShaderData data [[stage_in]], ConvertPSRes 
 fragment float4 ps_interlace2(ConvertShaderData data [[stage_in]], ConvertPSRes res,
 	constant GSMTLInterlacePSUniform& uniform [[buffer(GSMTLBufferIndexUniforms)]])
 {
-	float4 c0 = res.sample(data.t - uniform.ZrH);
+	float2 vstep = float2(0.0f, uniform.ZrH.y);
+	float4 c0 = res.sample(data.t - vstep);
 	float4 c1 = res.sample(data.t);
-	float4 c2 = res.sample(data.t + uniform.ZrH);
+	float4 c2 = res.sample(data.t + vstep);
 	return (c0 + c1 * 2.f + c2) / 4.f;
 }
 
@@ -47,3 +48,124 @@ fragment float4 ps_interlace3(ConvertShaderData data [[stage_in]], ConvertPSRes 
 	return res.sample(data.t);
 }
 
+fragment float4 ps_interlace4(ConvertShaderData data [[stage_in]], ConvertPSRes res,
+	constant GSMTLInterlacePSUniform& uniform [[buffer(GSMTLBufferIndexUniforms)]])
+{
+    const int    vres     = int(round(uniform.ZrH.z));
+	const int    idx      = int(round(uniform.ZrH.x));
+	const int    bank     = idx >> 1;
+	const int    field    = idx & 1;
+	const int    vpos     = int(data.p.y) + (((((vres + 1) >> 1) << 1) - vres) & bank);
+	const float2 bofs     = float2(0.0f, 0.5f * bank);
+	const float2 vscale   = float2(1.0f, 2.0f);
+	const float2 optr     = data.t - bofs;
+	const float2 iptr     = optr * vscale;
+
+    if ((optr.y >= 0.0f) && (optr.y < 0.5f) && ((vpos & 1) == field))
+		return res.sample(iptr);
+	else
+		discard_fragment();
+
+	return float4(0.0f, 0.0f, 0.0f, 0.0f);
+	
+}
+
+fragment float4 ps_interlace5(ConvertShaderData data [[stage_in]], ConvertPSRes res,
+	constant GSMTLInterlacePSUniform& uniform [[buffer(GSMTLBufferIndexUniforms)]])
+{
+	const float  sensitivity = uniform.ZrH.w;
+	const float3 motion_thr  = float3(1.0, 1.0, 1.0) * sensitivity;
+	const float2 vofs        = float2(0.0f, 0.5f);
+	const float2 vscale      = float2(1.0f, 0.5f);
+	const int    idx         = int(round(uniform.ZrH.x));
+	const int    bank        = idx >> 1;
+	const int    field       = idx & 1;
+	const float2 line_ofs    = float2(0.0f, uniform.ZrH.y);
+	const float2 iptr        = data.t * vscale;
+
+	float2 p_new_cf;
+	float2 p_old_cf;
+	float2 p_new_af;
+	float2 p_old_af;
+
+	switch (idx)
+	{
+		case 0:
+			p_new_cf = iptr;
+			p_new_af = iptr + vofs;
+			p_old_cf = iptr + vofs;
+			p_old_af = iptr;
+			break;
+		case 1:
+			p_new_cf = iptr;
+			p_new_af = iptr;
+			p_old_cf = iptr + vofs;
+			p_old_af = iptr + vofs;
+			break;
+		case 2:
+			p_new_cf = iptr + vofs;
+			p_new_af = iptr;
+			p_old_cf = iptr;
+			p_old_af = iptr + vofs;
+			break;
+		case 3:
+			p_new_cf = iptr + vofs;
+			p_new_af = iptr + vofs;
+			p_old_cf = iptr;
+			p_old_af = iptr;
+			break;
+		default:
+			break;
+	}
+
+	// calculating motion
+
+	float4 hn = res.sample(p_new_cf - line_ofs); // high
+	float4 cn = res.sample(p_new_af);            // center
+	float4 ln = res.sample(p_new_cf + line_ofs); // low
+
+	float4 ho = res.sample(p_old_cf - line_ofs); // high
+	float4 co = res.sample(p_old_af);            // center
+	float4 lo = res.sample(p_old_cf + line_ofs); // low
+
+	float3 mh = hn.rgb - ho.rgb;
+	float3 mc = cn.rgb - co.rgb;
+	float3 ml = ln.rgb - lo.rgb;
+
+	mh = max(mh, -mh) - motion_thr;
+	mc = max(mc, -mc) - motion_thr;
+	ml = max(ml, -ml) - motion_thr;
+
+
+//    float mh_max = max(max(mh.x, mh.y), mh.z);
+//    float mc_max = max(max(mc.x, mc.y), mc.z);
+//    float ml_max = max(max(ml.x, ml.y), ml.z);
+
+	float mh_max = mh.x + mh.y + mh.z;
+	float mc_max = mc.x + mc.y + mc.z;
+	float ml_max = ml.x + ml.y + ml.z;
+
+	// selecting deinterlacing output
+
+	if (((int(data.p.y) & 1) == field)) // output coordinate present on current field
+	{
+		return res.sample(p_new_cf);
+	}
+	else if ((iptr.y > 0.5f - line_ofs.y) || (iptr.y < 0.0 + line_ofs.y))
+	{
+		return res.sample(p_new_af);
+	}
+	else
+	{
+		if (((mh_max > 0.0f) || (ml_max > 0.0f)) || (mc_max > 0.0f))
+		{
+			return (hn + ln) / 2.0f;
+		}
+		else
+		{
+			return res.sample(p_new_af);
+		}
+	}
+
+	return float4(0.0f, 0.0f, 0.0f, 0.0f);
+}

--- a/pcsx2/GS/Renderers/Metal/interlace.metal
+++ b/pcsx2/GS/Renderers/Metal/interlace.metal
@@ -51,82 +51,94 @@ fragment float4 ps_interlace3(ConvertShaderData data [[stage_in]], ConvertPSRes 
 fragment float4 ps_interlace4(ConvertShaderData data [[stage_in]], ConvertPSRes res,
 	constant GSMTLInterlacePSUniform& uniform [[buffer(GSMTLBufferIndexUniforms)]])
 {
-    const int    vres     = int(round(uniform.ZrH.z));
-	const int    idx      = int(round(uniform.ZrH.x));
-	const int    bank     = idx >> 1;
-	const int    field    = idx & 1;
-	const int    vpos     = int(data.p.y) + (((((vres + 1) >> 1) << 1) - vres) & bank);
-	const float2 bofs     = float2(0.0f, 0.5f * bank);
-	const float2 vscale   = float2(1.0f, 2.0f);
-	const float2 optr     = data.t - bofs;
-	const float2 iptr     = optr * vscale;
+	// We take half the lines from the current frame and stores them in the MAD frame buffer.
+	// the MAD frame buffer is split in 2 consecutive banks of 2 fields each, the fields in each bank
+	// are interleaved (top field at even lines and bottom field at odd lines). 
+	// When the source texture has an odd vres, the first line of bank 1 would be an odd index
+	// causing the wrong lines to be discarded, so a vertical offset (lofs) is added to the vertical
+	// position of the destination texture to force the proper field alignment
 
-    if ((optr.y >= 0.0f) && (optr.y < 0.5f) && ((vpos & 1) == field))
+	const int    idx      = int(round(uniform.ZrH.x));                // buffer index passed from CPU
+	const int    bank     = idx >> 1;                                 // current bank
+	const int    field    = idx & 1;                                  // current field
+	const int    vres     = int(round(uniform.ZrH.z));                // vertical resolution of source texture
+	const int    lofs     = ((((vres + 1) >> 1) << 1) - vres) & bank; // line alignment offset for bank 1
+	const int    vpos     = int(data.p.y) + lofs;                     // vertical position of destination texture
+	const float2 bofs     = float2(0.0f, 0.5f * bank);                // vertical offset of the current bank relative to source texture size
+	const float2 vscale   = float2(1.0f, 2.0f);                       // scaling factor from source to destination texture
+	const float2 optr     = data.t - bofs;                            // used to check if the current destination line is within the current bank
+	const float2 iptr     = optr * vscale;                            // pointer to the current pixel in the source texture
+
+	// if the index of current destination line belongs to the current fiels we update it, otherwise
+	// we leave the old line in the destination buffer
+	if ((optr.y >= 0.0f) && (optr.y < 0.5f) && ((vpos & 1) == field))
 		return res.sample(iptr);
 	else
 		discard_fragment();
 
 	return float4(0.0f, 0.0f, 0.0f, 0.0f);
-	
 }
 
 fragment float4 ps_interlace5(ConvertShaderData data [[stage_in]], ConvertPSRes res,
 	constant GSMTLInterlacePSUniform& uniform [[buffer(GSMTLBufferIndexUniforms)]])
 {
-	const float  sensitivity = uniform.ZrH.w;
-	const float3 motion_thr  = float3(1.0, 1.0, 1.0) * sensitivity;
-	const float2 vofs        = float2(0.0f, 0.5f);
-	const float2 vscale      = float2(1.0f, 0.5f);
-	const int    idx         = int(round(uniform.ZrH.x));
-	const int    bank        = idx >> 1;
-	const int    field       = idx & 1;
-	const float2 line_ofs    = float2(0.0f, uniform.ZrH.y);
-	const float2 iptr        = data.t * vscale;
+	const int    idx         = int(round(uniform.ZrH.x));           // buffer index passed from CPU
+	const int    bank        = idx >> 1;                            // current bank
+	const int    field       = idx & 1;                             // current field
+	const int    vpos        = int(data.p.y);                       // vertical position of destination texture
+	const float  sensitivity = uniform.ZrH.w;                       // passed from CPU, higher values mean more likely to use weave
+	const float3 motion_thr  = float3(1.0, 1.0, 1.0) * sensitivity; //
+	const float2 bofs        = float2(0.0f, 0.5f);                  // position of the bank 1 relative to source texture size
+	const float2 vscale      = float2(1.0f, 0.5f);                  // scaling factor from source to destination texture
+	const float2 lofs        = float2(0.0f, uniform.ZrH.y);         // distance between two adjacent lines relative to source texture size
+	const float2 iptr        = data.t * vscale;                     // pointer to the current pixel in the source texture
 
-	float2 p_new_cf;
-	float2 p_old_cf;
-	float2 p_new_af;
-	float2 p_old_af;
+
+	float2 p_t0; // pointer to current pixel (missing or not) from most recent frame
+	float2 p_t1; // pointer to current pixel (missing or not) from one frame back
+	float2 p_t2; // pointer to current pixel (missing or not) from two frames back
+	float2 p_t3; // pointer to current pixel (missing or not) from three frames back
 
 	switch (idx)
 	{
 		case 0:
-			p_new_cf = iptr;
-			p_new_af = iptr + vofs;
-			p_old_cf = iptr + vofs;
-			p_old_af = iptr;
+			p_t0 = iptr;
+			p_t1 = iptr + bofs;
+			p_t2 = iptr + bofs;
+			p_t3 = iptr;
 			break;
 		case 1:
-			p_new_cf = iptr;
-			p_new_af = iptr;
-			p_old_cf = iptr + vofs;
-			p_old_af = iptr + vofs;
+			p_t0 = iptr;
+			p_t1 = iptr;
+			p_t2 = iptr + bofs;
+			p_t3 = iptr + bofs;
 			break;
 		case 2:
-			p_new_cf = iptr + vofs;
-			p_new_af = iptr;
-			p_old_cf = iptr;
-			p_old_af = iptr + vofs;
+			p_t0 = iptr + bofs;
+			p_t1 = iptr;
+			p_t2 = iptr;
+			p_t3 = iptr + bofs;
 			break;
 		case 3:
-			p_new_cf = iptr + vofs;
-			p_new_af = iptr + vofs;
-			p_old_cf = iptr;
-			p_old_af = iptr;
+			p_t0 = iptr + bofs;
+			p_t1 = iptr + bofs;
+			p_t2 = iptr;
+			p_t3 = iptr;
 			break;
 		default:
 			break;
 	}
 
-	// calculating motion
+	// calculating motion, only relevant for missing lines where the "center line" is pointed
+	// by p_t1
 
-	float4 hn = res.sample(p_new_cf - line_ofs); // high
-	float4 cn = res.sample(p_new_af);            // center
-	float4 ln = res.sample(p_new_cf + line_ofs); // low
+	float4 hn = res.sample(p_t0 - lofs); // new high pixel
+	float4 cn = res.sample(p_t1);        // new center pixel
+	float4 ln = res.sample(p_t0 + lofs); // new low pixel
 
-	float4 ho = res.sample(p_old_cf - line_ofs); // high
-	float4 co = res.sample(p_old_af);            // center
-	float4 lo = res.sample(p_old_cf + line_ofs); // low
+	float4 ho = res.sample(p_t2 - lofs); // old high pixel
+	float4 co = res.sample(p_t3);        // old center pixel
+	float4 lo = res.sample(p_t2 + lofs); // old low pixel
 
 	float3 mh = hn.rgb - ho.rgb;
 	float3 mc = cn.rgb - co.rgb;
@@ -136,34 +148,40 @@ fragment float4 ps_interlace5(ConvertShaderData data [[stage_in]], ConvertPSRes 
 	mc = max(mc, -mc) - motion_thr;
 	ml = max(ml, -ml) - motion_thr;
 
-
-//    float mh_max = max(max(mh.x, mh.y), mh.z);
-//    float mc_max = max(max(mc.x, mc.y), mc.z);
-//    float ml_max = max(max(ml.x, ml.y), ml.z);
-
-	float mh_max = mh.x + mh.y + mh.z;
-	float mc_max = mc.x + mc.y + mc.z;
-	float ml_max = ml.x + ml.y + ml.z;
+	#if 1 // use this code to evaluate each color motion separately
+		float mh_max = max(max(mh.x, mh.y), mh.z);
+		float mc_max = max(max(mc.x, mc.y), mc.z);
+		float ml_max = max(max(ml.x, ml.y), ml.z);
+	#else // use this code to evaluate average color motion
+		float mh_max = mh.x + mh.y + mh.z;
+		float mc_max = mc.x + mc.y + mc.z;
+		float ml_max = ml.x + ml.y + ml.z;
+	#endif
 
 	// selecting deinterlacing output
 
-	if (((int(data.p.y) & 1) == field)) // output coordinate present on current field
+	if ((vpos & 1) == field)
 	{
-		return res.sample(p_new_cf);
+		// output coordinate present on current field
+		return res.sample(p_t0);
 	}
-	else if ((iptr.y > 0.5f - line_ofs.y) || (iptr.y < 0.0 + line_ofs.y))
+	else if ((iptr.y > 0.5f - lofs.y) || (iptr.y < 0.0 + lofs.y))
 	{
-		return res.sample(p_new_af);
+		// top and bottom lines are always weaved
+		return cn;
 	}
 	else
 	{
+		// missing line needs to be reconstructed
 		if (((mh_max > 0.0f) || (ml_max > 0.0f)) || (mc_max > 0.0f))
 		{
+			// high motion -> interpolate pixels above and below
 			return (hn + ln) / 2.0f;
 		}
 		else
 		{
-			return res.sample(p_new_af);
+			// low motion -> weave
+			return cn;
 		}
 	}
 

--- a/pcsx2/GS/Renderers/Null/GSDeviceNull.h
+++ b/pcsx2/GS/Renderers/Null/GSDeviceNull.h
@@ -24,7 +24,7 @@ private:
 	GSTexture* CreateSurface(GSTexture::Type type, int w, int h, GSTexture::Format format);
 
 	void DoMerge(GSTexture* sTex[3], GSVector4* sRect, GSTexture* dTex, GSVector4* dRect, const GSRegPMODE& PMODE, const GSRegEXTBUF& EXTBUF, const GSVector4& c) {}
-	void DoInterlace(GSTexture* sTex, GSTexture* dTex, int shader, bool linear, float yoffset = 0) {}
+	void DoInterlace(GSTexture* sTex, GSTexture* dTex, int shader, bool linear, float yoffset = 0, int bufIdx = 0) {}
 	u16 ConvertBlendEnum(u16 generic) { return 0xFFFF; }
 
 public:

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -1385,19 +1385,20 @@ void GSDeviceOGL::DoMerge(GSTexture* sTex[3], GSVector4* sRect, GSTexture* dTex,
 		StretchRect(dTex, full_r, sTex[2], dRect[2], ShaderConvert::YUV);
 }
 
-void GSDeviceOGL::DoInterlace(GSTexture* sTex, GSTexture* dTex, int shader, bool linear, float yoffset)
+void GSDeviceOGL::DoInterlace(GSTexture* sTex, GSTexture* dTex, int shader, bool linear, float yoffset, int bufIdx)
 {
 	GL_PUSH("DoInterlace");
 
 	OMSetColorMaskState();
 
-	const GSVector4 s = GSVector4(dTex->GetSize());
+	const GSVector4 ss = GSVector4(sTex->GetSize());
+	const GSVector4 ds = GSVector4(dTex->GetSize());
 
 	const GSVector4 sRect(0, 0, 1, 1);
-	const GSVector4 dRect(0.0f, yoffset, s.x, s.y + yoffset);
+	const GSVector4 dRect(0.0f, yoffset, ds.x, ds.y + yoffset);
 
 	m_interlace.ps[shader].Bind();
-	m_interlace.ps[shader].Uniform2f(0, 0, 1.0f / s.y);
+	m_interlace.ps[shader].Uniform4f(0, bufIdx, 1.0f / ss.y, ss.y, MAD_SENSITIVITY);
 
 	StretchRect(sTex, sRect, dTex, dRect, m_interlace.ps[shader], linear);
 }

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -1391,14 +1391,13 @@ void GSDeviceOGL::DoInterlace(GSTexture* sTex, GSTexture* dTex, int shader, bool
 
 	OMSetColorMaskState();
 
-	const GSVector4 ss = GSVector4(sTex->GetSize());
 	const GSVector4 ds = GSVector4(dTex->GetSize());
 
 	const GSVector4 sRect(0, 0, 1, 1);
 	const GSVector4 dRect(0.0f, yoffset, ds.x, ds.y + yoffset);
 
 	m_interlace.ps[shader].Bind();
-	m_interlace.ps[shader].Uniform4f(0, bufIdx, 1.0f / ss.y, ss.y, MAD_SENSITIVITY);
+	m_interlace.ps[shader].Uniform4f(0, bufIdx, 1.0f / ds.y, ds.y, MAD_SENSITIVITY);
 
 	StretchRect(sTex, sRect, dTex, dRect, m_interlace.ps[shader], linear);
 }

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.h
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.h
@@ -239,7 +239,7 @@ private:
 
 	struct
 	{
-		GL::Program ps[4]; // program object
+		GL::Program ps[NUM_INTERLACE_SHADERS]; // program object
 	} m_interlace;
 
 	struct
@@ -300,7 +300,7 @@ private:
 	GSTexture* CreateSurface(GSTexture::Type type, int width, int height, int levels, GSTexture::Format format) final;
 
 	void DoMerge(GSTexture* sTex[3], GSVector4* sRect, GSTexture* dTex, GSVector4* dRect, const GSRegPMODE& PMODE, const GSRegEXTBUF& EXTBUF, const GSVector4& c) final;
-	void DoInterlace(GSTexture* sTex, GSTexture* dTex, int shader, bool linear, float yoffset = 0) final;
+	void DoInterlace(GSTexture* sTex, GSTexture* dTex, int shader, bool linear, float yoffset = 0, int bufIdx = 0) final;
 	void DoFXAA(GSTexture* sTex, GSTexture* dTex) final;
 	void DoShadeBoost(GSTexture* sTex, GSTexture* dTex, const float params[4]) final;
 	void DoExternalFX(GSTexture* sTex, GSTexture* dTex) final;

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
@@ -857,7 +857,6 @@ void GSDeviceVK::DoMerge(GSTexture* sTex[3], GSVector4* sRect, GSTexture* dTex, 
 
 void GSDeviceVK::DoInterlace(GSTexture* sTex, GSTexture* dTex, int shader, bool linear, float yoffset, int bufIdx)
 {
-	const GSVector4  ss   = GSVector4(sTex->GetSize());
 	const GSVector2i ds_i = dTex->GetSize();
 	const GSVector4  ds   = GSVector4(ds_i);
 	
@@ -867,7 +866,7 @@ void GSDeviceVK::DoInterlace(GSTexture* sTex, GSTexture* dTex, int shader, bool 
 
 	InterlaceConstantBuffer cb;
 
-	cb.ZrH = GSVector4(static_cast<float>(bufIdx), 1.0f / ss.y, ss.y, MAD_SENSITIVITY);
+	cb.ZrH = GSVector4(static_cast<float>(bufIdx), 1.0f / ds.y, ds.y, MAD_SENSITIVITY);
 
 	GL_PUSH("DoInterlace %dx%d Shader:%d Linear:%d", ds_i.x, ds_i.y, shader, linear);
 

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
@@ -855,22 +855,24 @@ void GSDeviceVK::DoMerge(GSTexture* sTex[3], GSVector4* sRect, GSTexture* dTex, 
 	static_cast<GSTextureVK*>(dTex)->TransitionToLayout(VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
 }
 
-void GSDeviceVK::DoInterlace(GSTexture* sTex, GSTexture* dTex, int shader, bool linear, float yoffset)
+void GSDeviceVK::DoInterlace(GSTexture* sTex, GSTexture* dTex, int shader, bool linear, float yoffset, int bufIdx)
 {
-	const GSVector2i size(dTex->GetSize());
-	const GSVector4 s = GSVector4(size);
+	const GSVector4 ss = GSVector4(sTex->GetSize());
+	const GSVector4 ds = GSVector4(dTex->GetSize());
+	const GSVector2i ds_i(dTex->GetSize());
 
 	const GSVector4 sRect(0, 0, 1, 1);
-	const GSVector4 dRect(0.0f, yoffset, s.x, s.y + yoffset);
+	const GSVector4 dRect(0.0f, yoffset, ds.x, ds.y + yoffset);
 
 	InterlaceConstantBuffer cb;
-	cb.ZrH = GSVector2(0, 1.0f / s.y);
+
+	cb.ZrH = GSVector4(static_cast<float>(bufIdx), 1.0f / ss.y, ss.y, MAD_SENSITIVITY);
 
 	GL_PUSH("DoInterlace %dx%d Shader:%d Linear:%d", size.x, size.y, shader, linear);
 
 	static_cast<GSTextureVK*>(dTex)->TransitionToLayout(VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
 
-	const GSVector4i rc(0, 0, size.x, size.y);
+	const GSVector4i rc(0, 0, ds_i.x, ds_i.y);
 	EndRenderPass();
 	OMSetRenderTargets(dTex, nullptr, rc, false);
 	SetUtilityTexture(sTex, linear ? m_linear_sampler : m_point_sampler);

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
@@ -857,9 +857,10 @@ void GSDeviceVK::DoMerge(GSTexture* sTex[3], GSVector4* sRect, GSTexture* dTex, 
 
 void GSDeviceVK::DoInterlace(GSTexture* sTex, GSTexture* dTex, int shader, bool linear, float yoffset, int bufIdx)
 {
-	const GSVector4 ss = GSVector4(sTex->GetSize());
-	const GSVector4 ds = GSVector4(dTex->GetSize());
-	const GSVector2i ds_i(dTex->GetSize());
+	const GSVector4  ss   = GSVector4(sTex->GetSize());
+	const GSVector2i ds_i = dTex->GetSize();
+	const GSVector4  ds   = GSVector4(ds_i);
+	
 
 	const GSVector4 sRect(0, 0, 1, 1);
 	const GSVector4 dRect(0.0f, yoffset, ds.x, ds.y + yoffset);
@@ -868,7 +869,7 @@ void GSDeviceVK::DoInterlace(GSTexture* sTex, GSTexture* dTex, int shader, bool 
 
 	cb.ZrH = GSVector4(static_cast<float>(bufIdx), 1.0f / ss.y, ss.y, MAD_SENSITIVITY);
 
-	GL_PUSH("DoInterlace %dx%d Shader:%d Linear:%d", size.x, size.y, shader, linear);
+	GL_PUSH("DoInterlace %dx%d Shader:%d Linear:%d", ds_i.x, ds_i.y, shader, linear);
 
 	static_cast<GSTextureVK*>(dTex)->TransitionToLayout(VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
 

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h
@@ -120,7 +120,7 @@ private:
 	std::array<VkPipeline, static_cast<int>(PresentShader::Count)> m_present{};
 	std::array<VkPipeline, 16> m_color_copy{};
 	std::array<VkPipeline, 2> m_merge{};
-	std::array<VkPipeline, 4> m_interlace{};
+	std::array<VkPipeline, NUM_INTERLACE_SHADERS> m_interlace{};
 	VkPipeline m_hdr_setup_pipelines[2][2] = {}; // [depth][feedback_loop]
 	VkPipeline m_hdr_finish_pipelines[2][2] = {}; // [depth][feedback_loop]
 	VkRenderPass m_date_image_setup_render_passes[2][2] = {}; // [depth][clear]
@@ -155,7 +155,7 @@ private:
 
 	void DoMerge(GSTexture* sTex[3], GSVector4* sRect, GSTexture* dTex, GSVector4* dRect, const GSRegPMODE& PMODE,
 		const GSRegEXTBUF& EXTBUF, const GSVector4& c) final;
-	void DoInterlace(GSTexture* sTex, GSTexture* dTex, int shader, bool linear, float yoffset = 0) final;
+	void DoInterlace(GSTexture* sTex, GSTexture* dTex, int shader, bool linear, float yoffset = 0, int bufIdx = 0) final;
 	void DoShadeBoost(GSTexture* sTex, GSTexture* dTex, const float params[4]) final;
 	void DoFXAA(GSTexture* sTex, GSTexture* dTex) final;
 

--- a/pcsx2/GameDatabase.cpp
+++ b/pcsx2/GameDatabase.cpp
@@ -632,7 +632,7 @@ u32 GameDatabaseSchema::GameEntry::applyGSHardwareFixes(Pcsx2Config::GSOptions& 
 
 			case GSHWFixId::Deinterlace:
 			{
-				if (value >= 0 && value <= static_cast<int>(GSInterlaceMode::Automatic))
+				if (value >= static_cast<int>(GSInterlaceMode::Automatic) && value < static_cast<int>(GSInterlaceMode::Count))
 				{
 					if (config.InterlaceMode == GSInterlaceMode::Automatic)
 						config.InterlaceMode = static_cast<GSInterlaceMode>(value);

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -585,7 +585,7 @@ void Pcsx2Config::GSOptions::ReloadIniSettings()
 	GSSettingBool(LoadTextureReplacementsAsync);
 	GSSettingBool(PrecacheTextureReplacements);
 
-	GSSettingIntEnumEx(InterlaceMode, "deinterlace");
+	GSSettingIntEnumEx(InterlaceMode, "deinterlace_mode");
 
 	GSSettingFloat(OsdScale);
 


### PR DESCRIPTION
### Description of Changes
Adds Motion Adaptive Deinterlacing as an additional deinterlacing option (new default).

### Rationale behind Changes
Blend deinterlacing tends to blur objects in motion which isn't very desirable, this new method reduces visual artifacts in games that do not output progressive frames and attempts to provide clear and smooth motion, resulting in a superior experience.

### Suggested Testing Steps
Test games which are generally quite blurry, such as GT4, King's Field VI etc. Also check random games to make sure nothing is broken (confirm it's not broken with "none" deinterlacing before reporting)
