### PR TITLE
GS: Correct the height on reversed local->local transfers

### DIFF
--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -2176,7 +2176,10 @@ void GSState::Move()
 			const int ypage = _sy & ~(page_height - 1);
 			// Copying from itself to itself (rotating textures) used in Gitaroo Man stage 8
 			// What probably happens is because the copy is buffered, the source stays just ahead of the destination.
-			if (sbp == dbp && (((_sy < _dy) && ((ypage + page_height) > _dy)) || ((sx < dx) && ((xpage + page_width) > dx))))
+			// No need to do all this if the copy source/destination don't intersect, however.
+			const bool intersect = !(GSVector4i(sx, sy, sx + w, sy + h).rintersect(GSVector4i(dx, dy, dx + w, dy + h)).rempty());
+
+			if (intersect && sbp == dbp && (((_sy < _dy) && ((ypage + page_height) > _dy)) || ((sx < dx) && ((xpage + page_width) > dx))))
 			{
 				int starty = (yinc > 0) ? 0 : h-1;
 				int endy = (yinc > 0) ? h : -1;
@@ -2184,8 +2187,8 @@ void GSState::Move()
 
 				if (((_sy < _dy) && ((ypage + page_height) > _dy)) && yinc > 0)
 				{
-					_sy += h;
-					_dy += h;
+					_sy += h-1;
+					_dy += h-1;
 					starty = h-1;
 					endy = -1;
 					y_inc = -y_inc;


### PR DESCRIPTION
### Description of Changes
Corrects the height that is read/written when local->local transfer directions are reversed. Also avoid messing around in reverse if there is no overlap.

### Rationale behind Changes
The code was adding on the height to start from the top, but it doesn't end *exactly* on y + height, it's height-1, but that got missed and caused corruption during the transfer, this resolves it.  However the game didn't even need to do this since it wasn't overlapping, so I added a check for an intersect on the coordinates to avoid it completely.

### Suggested Testing Steps
Try loading Armored Core 2 Nexus (you can't use a GS dump, this is done during a loading screen), make sure there's no missing line. 

Armored Core 2 Nexus (Look at the line in the HUD on the right)

Before:
![image](https://user-images.githubusercontent.com/6278726/201492957-03b24447-6d04-46e4-82fa-6f09fb141a1e.png)

After:
![image](https://user-images.githubusercontent.com/6278726/201492911-ec2d479a-e31c-4235-adc4-c9912779b1d5.png)
