### PR TITLE
Patches: Add extended PS2rd support; used by OPL

### DIFF
--- a/pcsx2/Patch_Memory.cpp
+++ b/pcsx2/Patch_Memory.cpp
@@ -266,8 +266,8 @@ void handle_extended_t(IniPatch *p)
 				data = data | ((u32)p->data & 0xF0000000) >> 8;
 			}
 
-			u8 type = (data & 0x000F0000) >> 16;
-			u8 cond = (data & 0x00F00000) >> 20;
+			const u8 type = (data & 0x000F0000) >> 16;
+			const u8 cond = (data & 0x00F00000) >> 20;
 
 			if (cond == 0)										// Daaaaaaa yy0zvvvv
 			{

--- a/pcsx2/Patch_Memory.cpp
+++ b/pcsx2/Patch_Memory.cpp
@@ -249,41 +249,253 @@ void handle_extended_t(IniPatch *p)
 		}
 		else if (p->addr < 0xE0000000)
 		{
-			if (((u32)p->data & 0xFFFF0000) == 0x00000000)		// Daaaaaaa 0000dddd
+			if (((u32)p->data & 0x00F00000) == 0x00000000)		// Daaaaaaa yy0zdddd
 			{
-				u16 mem = memRead16((u32)p->addr & 0x0FFFFFFF);
-				if (mem != (0x0000FFFF & (u32)p->data))
+				u8 z = ((u32)p->data & 0x000F0000) / 0x10000;
+
+				if (z == 0)											// Daaaaaaa yy00dddd
 				{
-					SkipCount = 1;
+					u16 mem = memRead16((u32)p->addr & 0x0FFFFFFF);
+					if (mem != (0x0000FFFF & (u32)p->data))
+					{
+						SkipCount = ((u32)p->addr & 0xFF000000) / 0x1000000;
+						if (!SkipCount)
+						{
+							SkipCount = 1;
+						}
+					}
+					PrevCheatType = 0;
 				}
-				PrevCheatType = 0;
+				else if (z == 1)									// Daaaaaaa yy01dddd
+				{
+					u8 mem = memRead8((u32)p->addr & 0x0FFFFFFF);
+					if (mem != (0x000000FF & (u32)p->data))
+					{
+						SkipCount = ((u32)p->addr & 0xFF000000) / 0x1000000;
+						if (!SkipCount)
+						{
+							SkipCount = 1;
+						}
+					}
+					PrevCheatType = 0;
+				}
 			}
-			else if (((u32)p->data & 0xFFFF0000) == 0x00100000)	// Daaaaaaa 0010dddd
+			else if (((u32)p->data & 0x00F00000) == 0x00100000)	// Daaaaaaa yy1zdddd
 			{
-				u16 mem = memRead16((u32)p->addr & 0x0FFFFFFF);
-				if (mem == (0x0000FFFF & (u32)p->data))
+				u8 z = ((u32)p->data & 0x000F0000) / 0x10000;
+
+				if (z == 0)											// Daaaaaaa yy10dddd
 				{
-					SkipCount = 1;
+					u16 mem = memRead16((u32)p->addr & 0x0FFFFFFF);
+					if (mem == (0x0000FFFF & (u32)p->data))
+					{
+						SkipCount = ((u32)p->addr & 0xFF000000) / 0x1000000;
+						if (!SkipCount)
+						{
+							SkipCount = 1;
+						}
+					}
+					PrevCheatType = 0;
 				}
-				PrevCheatType = 0;
+				else if (z == 1)									// Daaaaaaa yy11dddd
+				{
+					u8 mem = memRead8((u32)p->addr & 0x0FFFFFFF);
+					if (mem == (0x000000FF & (u32)p->data))
+					{
+						SkipCount = ((u32)p->addr & 0xFF000000) / 0x1000000;
+						if (!SkipCount)
+						{
+							SkipCount = 1;
+						}
+					}
+					PrevCheatType = 0;
+				}
 			}
-			else if (((u32)p->data & 0xFFFF0000) == 0x00200000)	// Daaaaaaa 0020dddd
+			else if (((u32)p->data & 0x00F00000) == 0x00200000)	// Daaaaaaa yy2zdddd
 			{
-				u16 mem = memRead16((u32)p->addr & 0x0FFFFFFF);
-				if (mem >= (0x0000FFFF & (u32)p->data))
+				u8 z = ((u32)p->data & 0x000F0000) / 0x10000;
+
+				if (z == 0)											// Daaaaaaa yy20dddd
 				{
-					SkipCount = 1;
+					u16 mem = memRead16((u32)p->addr & 0x0FFFFFFF);
+					if (mem >= (0x0000FFFF & (u32)p->data))
+					{
+						SkipCount = ((u32)p->addr & 0xFF000000) / 0x1000000;
+						if (!SkipCount)
+						{
+							SkipCount = 1;
+						}
+					}
+					PrevCheatType = 0;
 				}
-				PrevCheatType = 0;
+				else if (z == 1)									// Daaaaaaa yy21dddd
+				{
+					u8 mem = memRead8((u32)p->addr & 0x0FFFFFFF);
+					if (mem >= (0x000000FF & (u32)p->data))
+					{
+						SkipCount = ((u32)p->addr & 0xFF000000) / 0x1000000;
+						if (!SkipCount)
+						{
+							SkipCount = 1;
+						}
+					}
+					PrevCheatType = 0;
+				}
 			}
-			else if (((u32)p->data & 0xFFFF0000) == 0x00300000)	// Daaaaaaa 0030dddd
+			else if (((u32)p->data & 0x00F00000) == 0x00300000)	// Daaaaaaa yy3zdddd
 			{
-				u16 mem = memRead16((u32)p->addr & 0x0FFFFFFF);
-				if (mem <= (0x0000FFFF & (u32)p->data))
+				u8 z = ((u32)p->data & 0x000F0000) / 0x10000;
+
+				if (z == 0)											// Daaaaaaa yy30dddd
 				{
-					SkipCount = 1;
+					u16 mem = memRead16((u32)p->addr & 0x0FFFFFFF);
+					if (mem <= (0x0000FFFF & (u32)p->data))
+					{
+						SkipCount = ((u32)p->addr & 0xFF000000) / 0x1000000;
+						if (!SkipCount)
+						{
+							SkipCount = 1;
+						}
+					}
+					PrevCheatType = 0;
 				}
-				PrevCheatType = 0;
+				else if (z == 1)									// Daaaaaaa yy31dddd
+				{
+					u8 mem = memRead8((u32)p->addr & 0x0FFFFFFF);
+					if (mem <= (0x000000FF & (u32)p->data))
+					{
+						SkipCount = ((u32)p->addr & 0xFF000000) / 0x1000000;
+						if (!SkipCount)
+						{
+							SkipCount = 1;
+						}
+					}
+					PrevCheatType = 0;
+				}
+			}
+			else if (((u32)p->data & 0x00F00000) == 0x00400000)	// Daaaaaaa yy4zdddd
+			{
+				u8 z = ((u32)p->data & 0x000F0000) / 0x10000;
+
+				if (z == 0)											// Daaaaaaa yy40dddd
+				{
+					u16 mem = memRead16((u32)p->addr & 0x0FFFFFFF);
+					if (mem & (0x0000FFFF & (u32)p->data))
+					{
+						SkipCount = ((u32)p->addr & 0xFF000000) / 0x1000000;
+						if (!SkipCount)
+						{
+							SkipCount = 1;
+						}
+					}
+					PrevCheatType = 0;
+				}
+				else if (z == 1)									// Daaaaaaa yy41dddd
+				{
+					u8 mem = memRead8((u32)p->addr & 0x0FFFFFFF);
+					if (mem & (0x000000FF & (u32)p->data))
+					{
+						SkipCount = ((u32)p->addr & 0xFF000000) / 0x1000000;
+						if (!SkipCount)
+						{
+							SkipCount = 1;
+						}
+					}
+					PrevCheatType = 0;
+				}
+			}
+			else if (((u32)p->data & 0x00F00000) == 0x00500000)	// Daaaaaaa yy5zdddd
+			{
+				u8 z = ((u32)p->data & 0x000F0000) / 0x10000;
+
+				if (z == 0)											// Daaaaaaa yy50dddd
+				{
+					u16 mem = memRead16((u32)p->addr & 0x0FFFFFFF);
+					if (!(mem & (0x0000FFFF & (u32)p->data)))
+					{
+						SkipCount = ((u32)p->addr & 0xFF000000) / 0x1000000;
+						if (!SkipCount)
+						{
+							SkipCount = 1;
+						}
+					}
+					PrevCheatType = 0;
+				}
+				else if (z == 1)									// Daaaaaaa yy51dddd
+				{
+					u8 mem = memRead8((u32)p->addr & 0x0FFFFFFF);
+					if (!(mem & (0x000000FF & (u32)p->data)))
+					{
+						SkipCount = ((u32)p->addr & 0xFF000000) / 0x1000000;
+						if (!SkipCount)
+						{
+							SkipCount = 1;
+						}
+					}
+					PrevCheatType = 0;
+				}
+			}
+			else if (((u32)p->data & 0x00F00000) == 0x00600000)	// Daaaaaaa yy6zdddd
+			{
+				u8 z = ((u32)p->data & 0x000F0000) / 0x10000;
+
+				if (z == 0)											// Daaaaaaa yy60dddd
+				{
+					u16 mem = memRead16((u32)p->addr & 0x0FFFFFFF);
+					if (mem | (0x0000FFFF & (u32)p->data))
+					{
+						SkipCount = ((u32)p->addr & 0xFF000000) / 0x1000000;
+						if (!SkipCount)
+						{
+							SkipCount = 1;
+						}
+					}
+					PrevCheatType = 0;
+				}
+				else if (z == 1)									// Daaaaaaa yy61dddd
+				{
+					u8 mem = memRead8((u32)p->addr & 0x0FFFFFFF);
+					if (mem | (0x000000FF & (u32)p->data))
+					{
+						SkipCount = ((u32)p->addr & 0xFF000000) / 0x1000000;
+						if (!SkipCount)
+						{
+							SkipCount = 1;
+						}
+					}
+					PrevCheatType = 0;
+				}
+			}
+			else if (((u32)p->data & 0x00F00000) == 0x00700000)	// Daaaaaaa yy7zdddd
+			{
+				u8 z = ((u32)p->data & 0x000F0000) / 0x10000;
+
+				if (z == 0)											// Daaaaaaa yy70dddd
+				{
+					u16 mem = memRead16((u32)p->addr & 0x0FFFFFFF);
+					if (!(mem | (0x0000FFFF & (u32)p->data)))
+					{
+						SkipCount = ((u32)p->addr & 0xFF000000) / 0x1000000;
+						if (!SkipCount)
+						{
+							SkipCount = 1;
+						}
+					}
+					PrevCheatType = 0;
+				}
+				else if (z == 1)									// Daaaaaaa yy71dddd
+				{
+					u8 mem = memRead8((u32)p->addr & 0x0FFFFFFF);
+					if (!(mem | (0x000000FF & (u32)p->data)))
+					{
+						SkipCount = ((u32)p->addr & 0xFF000000) / 0x1000000;
+						if (!SkipCount)
+						{
+							SkipCount = 1;
+						}
+					}
+					PrevCheatType = 0;
+				}
 			}
 		}
 		else if (p->addr < 0xF0000000)
@@ -374,6 +586,98 @@ void handle_extended_t(IniPatch *p)
 				{
 					u8 mem = memRead8((u32)p->data & 0x0FFFFFFF);
 					if (mem <= (0x000000FF & (u32)p->addr))
+					{
+						SkipCount = ((u32)p->addr & 0x00FF0000) / 0x10000;
+					}
+					PrevCheatType = 0;
+				}
+			}
+			else if (((u32)p->data & 0xF0000000) == 0x40000000)	// Ezyyvvvv 4aaaaaaa
+			{
+				u8 z = ((u32)p->addr & 0x0F000000) / 0x01000000;
+
+				if (z == 0)											// E0yyvvvv 4aaaaaaa
+				{
+					u16 mem = memRead16((u32)p->data & 0x0FFFFFFF);
+					if (mem & (0x0000FFFF & (u32)p->addr))
+					{
+						SkipCount = ((u32)p->addr & 0x00FF0000) / 0x10000;
+					}
+					PrevCheatType = 0;
+				}
+				else if (z == 1)									// E1yy00vv 4aaaaaaa
+				{
+					u8 mem = memRead8((u32)p->data & 0x0FFFFFFF);
+					if (mem & (0x000000FF & (u32)p->addr))
+					{
+						SkipCount = ((u32)p->addr & 0x00FF0000) / 0x10000;
+					}
+					PrevCheatType = 0;
+				}
+			}
+			else if (((u32)p->data & 0xF0000000) == 0x50000000)	// Ezyyvvvv 5aaaaaaa
+			{
+				u8 z = ((u32)p->addr & 0x0F000000) / 0x01000000;
+
+				if (z == 0)											// E0yyvvvv 5aaaaaaa
+				{
+					u16 mem = memRead16((u32)p->data & 0x0FFFFFFF);
+					if (!(mem & (0x0000FFFF & (u32)p->addr)))
+					{
+						SkipCount = ((u32)p->addr & 0x00FF0000) / 0x10000;
+					}
+					PrevCheatType = 0;
+				}
+				else if (z == 1)									// E1yy00vv 5aaaaaaa
+				{
+					u8 mem = memRead8((u32)p->data & 0x0FFFFFFF);
+					if (!(mem & (0x000000FF & (u32)p->addr)))
+					{
+						SkipCount = ((u32)p->addr & 0x00FF0000) / 0x10000;
+					}
+					PrevCheatType = 0;
+				}
+			}
+			else if (((u32)p->data & 0xF0000000) == 0x60000000)	// Ezyyvvvv 6aaaaaaa
+			{
+				u8 z = ((u32)p->addr & 0x0F000000) / 0x01000000;
+
+				if (z == 0)											// E0yyvvvv 6aaaaaaa
+				{
+					u16 mem = memRead16((u32)p->data & 0x0FFFFFFF);
+					if (mem | (0x0000FFFF & (u32)p->addr))
+					{
+						SkipCount = ((u32)p->addr & 0x00FF0000) / 0x10000;
+					}
+					PrevCheatType = 0;
+				}
+				else if (z == 1)									// E1yy00vv 6aaaaaaa
+				{
+					u8 mem = memRead8((u32)p->data & 0x0FFFFFFF);
+					if (mem | (0x000000FF & (u32)p->addr))
+					{
+						SkipCount = ((u32)p->addr & 0x00FF0000) / 0x10000;
+					}
+					PrevCheatType = 0;
+				}
+			}
+			else if (((u32)p->data & 0xF0000000) == 0x70000000)	// Ezyyvvvv 7aaaaaaa
+			{
+				u8 z = ((u32)p->addr & 0x0F000000) / 0x01000000;
+
+				if (z == 0)											// E0yyvvvv 7aaaaaaa
+				{
+					u16 mem = memRead16((u32)p->data & 0x0FFFFFFF);
+					if (!(mem | (0x0000FFFF & (u32)p->addr)))
+					{
+						SkipCount = ((u32)p->addr & 0x00FF0000) / 0x10000;
+					}
+					PrevCheatType = 0;
+				}
+				else if (z == 1)									// E1yy00vv 7aaaaaaa
+				{
+					u8 mem = memRead8((u32)p->data & 0x0FFFFFFF);
+					if (!(mem | (0x000000FF & (u32)p->addr)))
 					{
 						SkipCount = ((u32)p->addr & 0x00FF0000) / 0x10000;
 					}


### PR DESCRIPTION
### Description of Changes
Adds additional extended codetype functionality that exists in [PS2rd](https://github.com/mlafeldt/ps2rd/blob/master/Documentation/code_types.txt) and is used by Open PS2 Loader, namely:
* Making use of the otherwise unused last 4 digits of the D-codetype data value to also allow for 8-bit and 16-bit multi-line conditionals.
This won't break compatibility with existing D-codes, because PS2rd itself also checks if the lines to skip is 0, and sets it to 1.
* Adds more test conditions 4 - 7 used by PS2rd - NAND, AND, NOR, OR for both D-codetypes and E-codetypes.

PS2rd also has one more C-codetype which is a 32-bit conditional that will block *every* following cheat line if the condition is not met, but at a glance I couldn't see if the function had any way of tracking which line out of how many total it's currently on to know how large to set the SkipCount that would include all the other codes after it.  Not implemented for now.

### Rationale behind Changes
Solves issue #7222 and saves headaches caused by people ~~(me)~~ not being aware that these were only available in PS2rd/OPL, and wondering why cheats and codes I've written work just fine for me on a real PS2, but not for others on PCSX2.

The PS2rd codetypes have stood their ground since 2009, so I'd say it has merit to be supported by PCSX2.  Not to mention OPL uses this too, which is presumably how most people nowadays use these codes on a real PS2 if they don't have access to a cheat disc.

<!-- ### Suggested Testing Steps
If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
