### PR TITLE
GS: Expand "progressive" analogue games to full height, in case they lie

### DIFF
--- a/pcsx2/Counters.cpp
+++ b/pcsx2/Counters.cpp
@@ -301,7 +301,7 @@ const char* ReportVideoMode()
 const char* ReportInterlaceMode()
 {
 	const u64& smode2 = *(u64*)PS2GS_BASE(GS_SMODE2);
-	return (smode2 & 1) ? ((smode2 & 2) ? "Interlaced (Frame)" : "Interlaced (Field)") : "Progressive";
+	return !IsProgressiveVideoMode() ? ((smode2 & 2) ? "Interlaced (Frame)" : "Interlaced (Field)") : "Progressive";
 }
 
 double GetVerticalFrequency()

--- a/pcsx2/GS/Renderers/Common/GSRenderer.cpp
+++ b/pcsx2/GS/Renderers/Common/GSRenderer.cpp
@@ -368,10 +368,12 @@ bool GSRenderer::Merge(int field)
 	ds = fs;
 
 	// When interlace(FRAME) mode, the rect is half height, so it needs to be stretched.
-	if (m_regs->SMODE2.INT && m_regs->SMODE2.FFMD)
+	const bool is_interlaced_resolution = m_regs->SMODE2.INT || (isReallyInterlaced() && IsAnalogue() && GSConfig.InterlaceMode != GSInterlaceMode::Off);
+
+	if (is_interlaced_resolution && m_regs->SMODE2.FFMD)
 		ds.y *= 2;
 
-	m_real_size = ds;
+	m_real_size = GSVector2i(fs.x, is_interlaced_resolution ? ds.y : fs.y);
 
 	if (tex[0] || tex[1])
 	{


### PR DESCRIPTION
### Description of Changes
Expands "progressive" analogue games to the full 448/512 height, so if they aren't really progressive, they still get interlaced properly.

### Rationale behind Changes
Q-Ball Billiards Masters unsets the interlaced flag, but continues to interlace the signal, but due to some previous changes, we did rightly try to interlace it, it made it half resolution, but didn't expand the size so it interlaced properly, this fixes that.

### Suggested Testing Steps
Test "progressive" games (maybe no-interlace patches too), make sure nothing explodes.

Before:
![image](https://user-images.githubusercontent.com/6278726/201499749-883ae1c4-0abd-412c-924f-142d972ac76e.png)

After:
![image](https://user-images.githubusercontent.com/6278726/201499735-98b15095-31c5-4eb3-aa13-c9e0c36a0432.png)

