### PR TITLE
x86/iR5900: Align LQC2/SQC2 to 16 bytes / Write VIs from CTC2 as 16 bits

### DIFF
--- a/pcsx2/x86/ix86-32/iR5900LoadStore.cpp
+++ b/pcsx2/x86/ix86-32/iR5900LoadStore.cpp
@@ -939,7 +939,7 @@ void recLQC2()
 
 	if (GPR_IS_CONST1(_Rs_))
 	{
-		int addr = g_cpuConstRegs[_Rs_].UL[0] + _Imm_;
+		const u32 addr = (g_cpuConstRegs[_Rs_].UL[0] + _Imm_) & ~0xFu;
 
 		gpr = vtlb_DynGenReadQuad_Const(128, addr, -1);
 	}
@@ -948,6 +948,7 @@ void recLQC2()
 		_eeMoveGPRtoR(arg1regd, _Rs_);
 		if (_Imm_ != 0)
 			xADD(arg1regd, _Imm_);
+		xAND(arg1regd, ~0xF);
 
 		iFlushCall(FLUSH_FULLVTLB);
 
@@ -991,7 +992,7 @@ void recSQC2()
 
 	if (GPR_IS_CONST1(_Rs_))
 	{
-		int addr = g_cpuConstRegs[_Rs_].UL[0] + _Imm_;
+		const u32 addr = (g_cpuConstRegs[_Rs_].UL[0] + _Imm_) & ~0xFu;
 		vtlb_DynGenWrite_Const(128, addr);
 	}
 	else
@@ -999,6 +1000,7 @@ void recSQC2()
 		_eeMoveGPRtoR(arg1regd, _Rs_);
 		if (_Imm_ != 0)
 			xADD(arg1regd, _Imm_);
+		xAND(arg1regd, ~0xF);
 
 		iFlushCall(FLUSH_FULLVTLB);
 

--- a/pcsx2/x86/microVU_Macro.inl
+++ b/pcsx2/x86/microVU_Macro.inl
@@ -513,11 +513,22 @@ static void recCTC2()
 			xAND(eax, 0x0C0C);
 			xMOV(ptr32[&vu0Regs.VI[REG_FBRST].UL], eax);
 			break;
+		case 0:
+			// Ignore writes to vi00.
+			break;
 		default:
 			// Executing vu0 block here fixes the intro of Ratchet and Clank
 			// sVU's COP2 has a comment that "Donald Duck" needs this too...
-			if (_Rd_)
+			if (_Rd_ < REG_STATUS_FLAG)
+			{
+				// Need to expand this out, because we want to write as 16 bits.
+				_eeMoveGPRtoR(eax, _Rt_);
+				xMOV(ptr16[&vu0Regs.VI[_Rd_].US[0]], ax);
+			}
+			else
+			{
 				_eeMoveGPRtoM((uptr)&vu0Regs.VI[_Rd_].UL, _Rt_);
+			}
 			break;
 	}
 }


### PR DESCRIPTION
### Description of Changes

LQ/SQ were already 16 byte aligned.

The micro recompilers only write as 16 bit, so in case the value in the register was greater than 0xFFFF, we don't want to store higher bits that get stuck.

### Rationale behind Changes

Consistency.

### Suggested Testing Steps

Test a few games, make sure nothing broke. These changes should be relatively safe I think, but I didn't want to change the behaviour in my EE rec PR.
