### PR TITLE
GS: Improve deinterlacing offsets when upscaling

### DIFF
--- a/pcsx2/GS/Renderers/Common/GSRenderer.h
+++ b/pcsx2/GS/Renderers/Common/GSRenderer.h
@@ -28,7 +28,7 @@ struct HostKeyEvent;
 class GSRenderer : public GSState
 {
 private:
-	bool Merge(int field);
+	bool Merge(int field, bool unique);
 
 	u64 m_shader_time_start = 0;
 


### PR DESCRIPTION
### Description of Changes
Improves the handling of half height framebuffers when upscaling.

### Rationale behind Changes
It was kind of magic numbers and didn't work very well still when upscaling, this improves it much more, by moving the offsets to the merge circuit.

### Suggested Testing Steps
Test interlaced games with upscaling, see if they look better/broken.

### Screenshots - All taken at x8 Upscale

Gran Turismo 4 FMV's

Before:
![image](https://user-images.githubusercontent.com/6278726/201514977-f4b3b5cb-8051-4d61-b746-0c26bfdbcfdd.png)

After:
![image](https://user-images.githubusercontent.com/6278726/201514979-46d89b56-67bd-4532-9c81-ffeefee314ed.png)

Baldurs Gate Dark Alliance 2

Before:
![image](https://user-images.githubusercontent.com/6278726/201514995-2ccfb3cf-6054-4c98-8d70-5f536a05d9d9.png)

After:
![image](https://user-images.githubusercontent.com/6278726/201514999-9cf3309d-d80a-4c7d-a49f-d147f661daab.png)

Raging Blades

Before:
![image](https://user-images.githubusercontent.com/6278726/201515007-8a5a8674-d1f1-4045-9ac7-10c6401827cb.png)

After:
![image](https://user-images.githubusercontent.com/6278726/201515013-9b290c28-be08-426b-b017-b1cf6e74bafe.png)


