### PR TITLE
mVU: Clean up range function and improve merging. Slim down cmpProg.

### DIFF
--- a/pcsx2/x86/microVU_Misc.h
+++ b/pcsx2/x86/microVU_Misc.h
@@ -292,14 +292,14 @@ typedef u32 (*mVUCall)(void*, void*);
 //------------------------------------------------------------------
 
 // Reg Alloc
-static const bool doRegAlloc = true; // Set to false to flush every 32bit Instruction
+static constexpr bool doRegAlloc = true; // Set to false to flush every 32bit Instruction
 // This turns off reg alloc for the most part, but reg alloc will still
 // be done within instructions... Also on doSwapOp() regAlloc is needed between
 // Lower and Upper instructions, so in this case it flushes after the full
 // 64bit instruction (lower and upper)
 
 // No Flag Optimizations
-static const bool noFlagOpts = false; // Set to true to disable all flag setting optimizations
+static constexpr bool noFlagOpts = false; // Set to true to disable all flag setting optimizations
 // Note: The flag optimizations this disables should all be harmless, so
 // this option is mainly just for debugging... it effectively forces mVU
 // to always update Mac and Status Flags (both sticky and non-sticky) whenever
@@ -307,9 +307,9 @@ static const bool noFlagOpts = false; // Set to true to disable all flag setting
 // flag instances between blocks...
 
 // Multiple Flag Instances
-static const bool doSFlagInsts = true; // Set to true to enable multiple status flag instances
-static const bool doMFlagInsts = true; // Set to true to enable multiple mac    flag instances
-static const bool doCFlagInsts = true; // Set to true to enable multiple clip   flag instances
+static constexpr bool doSFlagInsts = true; // Set to true to enable multiple status flag instances
+static constexpr bool doMFlagInsts = true; // Set to true to enable multiple mac    flag instances
+static constexpr bool doCFlagInsts = true; // Set to true to enable multiple clip   flag instances
 // This is the correct behavior of the VU's. Due to the pipeline of the VU's
 // there can be up to 4 different instances of values to keep track of
 // for the 3 different types of flags: Status, Mac, Clip flags.
@@ -317,27 +317,27 @@ static const bool doCFlagInsts = true; // Set to true to enable multiple clip   
 // corresponding flag, which may be useful when debugging flag pipeline bugs.
 
 // Branch in Branch Delay Slots
-static const bool doBranchInDelaySlot = true; // Set to true to enable evil-branches
+static constexpr bool doBranchInDelaySlot = true; // Set to true to enable evil-branches
 // This attempts to emulate the correct behavior for branches in branch delay
 // slots. It is evil that games do this, and handling the different possible
 // cases is tricky and bug prone. If this option is disabled then the second
 // branch is treated as a NOP and effectively ignored.
 
 // Constant Propagation
-static const bool doConstProp = false; // Set to true to turn on vi15 const propagation
+static constexpr bool doConstProp = false; // Set to true to turn on vi15 const propagation
 // Enables Constant Propagation for Jumps based on vi15 'link-register'
 // allowing us to know many indirect jump target addresses.
 // Makes GoW a lot slower due to extra recompilation time and extra code-gen!
 
 // Indirect Jump Caching
-static const bool doJumpCaching = true; // Set to true to enable jump caching
+static constexpr bool doJumpCaching = true; // Set to true to enable jump caching
 // Indirect jumps (JR/JALR) will remember the entry points to their previously
 // jumped-to addresses. This allows us to skip the microBlockManager::search()
 // routine that is performed every indirect jump in order to find a block within a
 // program that matches the correct pipeline state.
 
 // Indirect Jumps are part of same cached microProgram
-static const bool doJumpAsSameProgram = false; // Set to true to treat jumps as same program
+static constexpr bool doJumpAsSameProgram = false; // Set to true to treat jumps as same program
 // Enabling this treats indirect jumps (JR/JALR) as part of the same microProgram
 // when determining the valid ranges for the microProgram cache. Disabling this
 // counts indirect jumps as separate cached microPrograms which generally leads
@@ -347,10 +347,16 @@ static const bool doJumpAsSameProgram = false; // Set to true to treat jumps as 
 // Note: You MUST disable doJumpCaching if you enable this option.
 
 // Handling of D-Bit in Micro Programs
-static const bool doDBitHandling = false;
+static constexpr bool doDBitHandling = false;
 // This flag shouldn't be enabled in released versions of games. Any games which
 // need this method of pausing the VU should be using the T-Bit instead, however
 // this could prove useful for VU debugging.
+
+// Whole program comparison on search
+static constexpr bool doWholeProgCompare = false;
+// This shouldn't be needed and could inflate program generation.
+// Compares the entire VU memory with the stored micro program's memory, regardless of if it's used.
+// Generally slower but may be useful for debugging.
 
 //------------------------------------------------------------------
 // Speed Hacks (can cause infinite loops, SPS, Black Screens, etc...)


### PR DESCRIPTION
### Description of Changes
Cleans up the micro program range merging functions and gets rid of some of the junk in the program comparison function. Also only copy parts of the program which are needed for the current microprogram during compilation, which should reduce compilation time slightly.

### Rationale behind Changes
Might be slightly faster in some cases? idk, but it's nicer.

### Suggested Testing Steps
Test games, make sure the VU's don't explode.
