### PR TITLE
GIF: Fix reset functionality to properly abort the current packet

### DIFF
--- a/pcsx2/Gif_Unit.h
+++ b/pcsx2/Gif_Unit.h
@@ -239,7 +239,10 @@ struct Gif_Path
 			if (!isMTVU()) // MTVU Freaks out if you try to reset it, so let's just let it transfer
 			{
 				GUNIT_WARN("Gif Path %d - Soft Reset", idx + 1);
+				gifTag.Reset();
+				gsPack.Reset();
 				curSize = curOffset;
+				gsPack.offset = curOffset;
 			}
 			return;
 		}


### PR DESCRIPTION
### Description of Changes
Fixes the GIF unit reset behaviour to abort the currently in-process packet.

### Rationale behind Changes
It didn't abort properly before, causing misalignment of packets and resulting in either errors or crashes.

### Suggested Testing Steps
Test games and swapping games, make sure nothing crashes.

Fixes the boot issue with Monster Jam - Maximum Destruction