### PR TITLE
GS: More Metal fixes

### DIFF
--- a/pcsx2/Frontend/MetalHostDisplay.h
+++ b/pcsx2/Frontend/MetalHostDisplay.h
@@ -31,6 +31,12 @@
 
 class MetalHostDisplay final : public HostDisplay
 {
+	enum class UsePresentDrawable : u8
+	{
+		Never = 0,
+		Always = 1,
+		IfVsync = 2,
+	};
 	MRCOwned<NSView*> m_view;
 	MRCOwned<CAMetalLayer*> m_layer;
 	GSMTLDevice m_dev;
@@ -39,6 +45,7 @@ class MetalHostDisplay final : public HostDisplay
 	MRCOwned<id<CAMetalDrawable>> m_current_drawable;
 	MRCOwned<MTLRenderPassDescriptor*> m_pass_desc;
 	u32 m_capture_start_frame;
+	UsePresentDrawable m_use_present_drawable;
 	bool m_gpu_timing_enabled = false;
 	double m_accumulated_gpu_time = 0;
 	double m_last_gpu_time_end = 0;

--- a/pcsx2/GS/Renderers/Metal/GSDeviceMTL.h
+++ b/pcsx2/GS/Renderers/Metal/GSDeviceMTL.h
@@ -231,7 +231,7 @@ public:
 	// Spinning
 	ReadbackSpinManager m_spin_manager;
 	u32 m_encoders_in_current_cmdbuf;
-	u32 m_spin_timer;
+	u32 m_spin_timer = 0;
 	MRCOwned<id<MTLComputePipelineState>> m_spin_pipeline;
 	MRCOwned<id<MTLBuffer>> m_spin_buffer;
 	MRCOwned<id<MTLFence>> m_spin_fence;

--- a/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
+++ b/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
@@ -305,7 +305,7 @@ void GSDeviceMTL::FlushEncoders()
 			if (GSDeviceMTL* dev = backref->second)
 			{
 				dev->DrawCommandBufferFinished(draw, buf);
-				dev->m_spin_manager.DrawCompleted(spin_id, begin, end);
+				dev->m_spin_manager.DrawCompleted(spin_id, static_cast<u32>(begin), static_cast<u32>(end));
 			}
 		}];
 	}
@@ -342,7 +342,7 @@ void GSDeviceMTL::FlushEncoders()
 #pragma clang diagnostic pop
 			std::lock_guard<std::mutex> guard(backref->first);
 			if (GSDeviceMTL* dev = backref->second)
-				dev->m_spin_manager.SpinCompleted(spin_cycles, begin, end);
+				dev->m_spin_manager.SpinCompleted(spin_cycles, static_cast<u32>(begin), static_cast<u32>(end));
 		}];
 		[spinCmdBuf commit];
 	}


### PR DESCRIPTION
### Description of Changes
- Fixes an issue where gpu spinning would randomly be enabled when it wasn't requested or needed (oops)
- Uses `[MTLCommandBuffer presentDrawable:]` instead of `[MTLDrawable present]` when vsync'd or on Ventura
  - Previous use was to work around a bug where `presentDrawable:` acted like vsync was on no matter what.  On the other hand, `present` acted like vsync was off no matter what.  This has been fixed in Ventura, and `presentDrawable:` plays nicer with Xcode GPU traces

### Suggested Testing Steps
Test Metal Renderer
