### PR TITLE
GS-HW: Increase channel shuffle sizes to resolution or higher.

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -880,7 +880,7 @@ void GSTextureCache::InvalidateVideoMem(const GSOffset& off, const GSVector4i& r
 		auto& list = m_dst[type];
 		for (auto i = list.begin(); i != list.end();)
 		{
-			auto j = i++;
+			auto j = i;
 			Target* t = *j;
 
 			// GH: (I think) this code is completely broken. Typical issue:
@@ -935,12 +935,14 @@ void GSTextureCache::InvalidateVideoMem(const GSOffset& off, const GSVector4i& r
 					}
 					if (!ComputeSurfaceOffset(off, r, t).is_valid)
 					{
-						list.erase(j);
+						i = list.erase(j);
 						GL_CACHE("TC: Remove Target(%s) %d (0x%x)", to_string(type),
 							t->m_texture ? t->m_texture->GetID() : 0,
 							t->m_TEX0.TBP0);
 						delete t;
 					}
+					else
+						i++;
 					continue;
 				}
 			}
@@ -952,6 +954,8 @@ void GSTextureCache::InvalidateVideoMem(const GSOffset& off, const GSVector4i& r
 				// Game: Conflict - Desert Storm (flickering)
 				t->m_dirty_alpha = false;
 			}
+
+			i++;
 
 			// GH: Try to detect texture write that will overlap with a target buffer
 			// TODO Use ComputeSurfaceOffset below.


### PR DESCRIPTION
### Description of Changes
Make sure the texture is at least the size of the resolution and is on a page boundary (as it works in pages).

### Rationale behind Changes
channel shuffles are sent 1 page at a time, but we HLE it and skip the rest of the draws, but the resize function was only checking the draw size, so we need to resize it to the full size of the shuffle.

### Suggested Testing Steps
Test games with channel shuffle problems, especially those in #1318

Fixes post processing on Prince of Persia Warrior Within

### Screenshots

Prince of Persia
Before:
![image](https://user-images.githubusercontent.com/6278726/201669137-05de9f14-d637-48f4-9598-10930d925f6e.png)

After:
![image](https://user-images.githubusercontent.com/6278726/201669199-8836805e-e4c4-423b-8a6e-c052e6f61310.png)
