### PR TITLE
OSD: Decrease delay for messages and toasts

### DIFF
--- a/pcsx2/Frontend/Achievements.cpp
+++ b/pcsx2/Frontend/Achievements.cpp
@@ -549,7 +549,7 @@ void Achievements::UpdateSettings(const Pcsx2Config::AchievementsOptions& old_co
 		else if (!s_challenge_mode && EmuConfig.Achievements.ChallengeMode)
 		{
 			if (HasActiveGame())
-				ImGuiFullscreen::ShowToast(std::string(), "Hardcore mode will be enabled on system reset.", 10.0f);
+				ImGuiFullscreen::ShowToast(std::string(), "Hardcore mode will be enabled on system reset.", 5.0f);
 		}
 	}
 
@@ -634,7 +634,7 @@ void Achievements::SetChallengeMode(bool enabled)
 	s_challenge_mode = enabled;
 
 	if (HasActiveGame())
-		ImGuiFullscreen::ShowToast(std::string(), enabled ? "Hardcore mode is now enabled." : "Hardcore mode is now disabled.", 10.0f);
+		ImGuiFullscreen::ShowToast(std::string(), enabled ? "Hardcore mode is now enabled." : "Hardcore mode is now disabled.", 5.0f);
 
 	if (HasActiveGame() && !IsTestModeActive())
 	{
@@ -1053,7 +1053,7 @@ void Achievements::DisplayAchievementSummary()
 			summary.append("Leaderboard submission is enabled.");
 	}
 
-	ImGuiFullscreen::AddNotification(10.0f, std::move(title), std::move(summary), s_game_icon);
+	ImGuiFullscreen::AddNotification(5.0f, std::move(title), std::move(summary), s_game_icon);
 
 	// Technically not going through the resource API, but since we're passing this to something else, we can't.
 	if (EmuConfig.Achievements.SoundEffects)
@@ -1069,7 +1069,7 @@ void Achievements::DisplayMasteredNotification()
 	std::string message(fmt::format(
 		"{} achievements, {} points{}", GetAchievementCount(), GetCurrentPointsForGame(), s_challenge_mode ? " (Hardcore Mode)" : ""));
 
-	ImGuiFullscreen::AddNotification(20.0f, std::move(title), std::move(message), s_game_icon);
+	ImGuiFullscreen::AddNotification(5.0f, std::move(title), std::move(message), s_game_icon);
 }
 
 void Achievements::GetUserUnlocksCallback(s32 status_code, const std::string& content_type, Common::HTTPDownloader::Request::Data data)

--- a/pcsx2/Frontend/ImGuiFullscreen.h
+++ b/pcsx2/Frontend/ImGuiFullscreen.h
@@ -258,6 +258,6 @@ namespace ImGuiFullscreen
 	void AddNotification(float duration, std::string title, std::string text, std::string image_path);
 	void ClearNotifications();
 
-	void ShowToast(std::string title, std::string message, float duration = 10.0f);
+	void ShowToast(std::string title, std::string message, float duration = 5.0f);
 	void ClearToast();
 } // namespace ImGuiFullscreen

--- a/pcsx2/Recording/Utilities/InputRecordingLogger.cpp
+++ b/pcsx2/Recording/Utilities/InputRecordingLogger.cpp
@@ -34,7 +34,7 @@ namespace inputRec
 		recordingConLog(fmt::format("[REC]: {}\n", log));
 
 		// NOTE - Color is not currently used for OSD logs
-		Host::AddOSDMessage(log, 15.0f);
+		Host::AddOSDMessage(log, 5.0f);
 	}
 
 	void consoleLog(const std::string& log)

--- a/pcsx2/SaveState.cpp
+++ b/pcsx2/SaveState.cpp
@@ -372,7 +372,7 @@ void memLoadingState::FreezeMem( void* data, int size )
 std::string Exception::SaveStateLoadError::FormatDiagnosticMessage() const
 {
 	std::string retval = "Savestate is corrupt or incomplete!\n";
-	Host::AddOSDMessage("Error: Savestate is corrupt or incomplete!", 15.0f);
+	Host::AddOSDMessage("Error: Savestate is corrupt or incomplete!", 5.0f);
 	_formatDiagMsg(retval);
 	return retval;
 }
@@ -380,7 +380,7 @@ std::string Exception::SaveStateLoadError::FormatDiagnosticMessage() const
 std::string Exception::SaveStateLoadError::FormatDisplayMessage() const
 {
 	std::string retval = "The savestate cannot be loaded, as it appears to be corrupt or incomplete.\n";
-	Host::AddOSDMessage("Error: The savestate cannot be loaded, as it appears to be corrupt or incomplete.", 15.0f);
+	Host::AddOSDMessage("Error: The savestate cannot be loaded, as it appears to be corrupt or incomplete.", 5.0f);
 	_formatUserMsg(retval);
 	return retval;
 }

--- a/pcsx2/gui/ConsoleLogger.cpp
+++ b/pcsx2/gui/ConsoleLogger.cpp
@@ -1274,7 +1274,7 @@ void Pcsx2App::DisableWindowLogging() const
 
 void OSDlog(ConsoleColors color, bool console, const std::string& str)
 {
-	Host::AddOSDMessage(str, 15.0f);
+	Host::AddOSDMessage(str, 5.0f);
 
 	if (console)
 		Console.WriteLn(color, str.c_str());


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Decreases delay to five seconds for all OSD messages and toasts.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
For me, from the side of a regular player, it is not particularly pleasant to see a very long message delay, so I decided to reduce it to five seconds. I do not know why such a long delay was needed at all, because I can read this message several times, especially when you try to screenshots some moment and when you load seivestate with the right moments, these messages continue to hang long and tediously, it's annoying. Five seconds should be enough in that case.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Save/loading savestates messages, changing slots, etc.

Also some article sources to get the idea why long-delay toasts are bad:
https://www.w3.org/TR/UNDERSTANDING-WCAG20/time-limits-pause.html
https://sheribyrnehaber.medium.com/designing-toast-messages-for-accessibility-fb610ac364be
