### PR TITLE
Core: Sign extend the interpreter implementation of MFC0

### DIFF
--- a/pcsx2/COP0.cpp
+++ b/pcsx2/COP0.cpp
@@ -465,7 +465,7 @@ void MFC0()
 			[[fallthrough]];
 
 		default:
-			cpuRegs.GPR.r[_Rt_].UD[0] = (s64)cpuRegs.CP0.r[_Rd_];
+			cpuRegs.GPR.r[_Rt_].SD[0] = (s32)cpuRegs.CP0.r[_Rd_];
 	}
 }
 


### PR DESCRIPTION
What are the chances that I run into this bug :L

### Description of Changes
When reading the 32 bit COP0 registers into the 128 GPRs, it sign extends.

### Rationale behind Changes
It was wrong and made my homebrew not work properly on the interpreter.

### Suggested Testing Steps
:shrug: 