### PR TITLE
GameDB: Fixes for Finding Nemo, Haven: Call of the King, Kinetica

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -7083,7 +7083,6 @@ SCUS-97160:
 SCUS-97161:
   name: "Kinetica [Demo]"
   region: "NTSC-U"
-  compat: 5
   gsHWFixes:
     roundSprite: 1 # Fixes vertical lines and minor ghosting.
 SCUS-97163:
@@ -9024,7 +9023,6 @@ SLED-51225:
 SLED-51281:
   name: "Haven - Call of the King [Demo]"
   region: "PAL-E"
-  compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
     alignSprite: 1 # Fixes vertical lines.
@@ -12942,7 +12940,6 @@ SLES-51754:
 SLES-51755:
   name: "Disney-Pixar's Finding Nemo"
   region: "PAL-E"
-  compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
     alignSprite: 1 # Fixes vertical lines.
@@ -13228,7 +13225,6 @@ SLES-51869:
 SLES-51870:
   name: "Disney-Pixar's Finding Nemo"
   region: "PAL-FI-S"
-  compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
     alignSprite: 1 # Fixes vertical lines.
@@ -13242,7 +13238,6 @@ SLES-51871:
 SLES-51872:
   name: "Disney-Pixar's Finding Nemo"
   region: "PAL-M3"
-  compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
     alignSprite: 1 # Fixes vertical lines.
@@ -13318,7 +13313,6 @@ SLES-51906:
 SLES-51907:
   name: "Disney-Pixar Alla Ricerca di Nemo"
   region: "PAL-I"
-  compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
     alignSprite: 1 # Fixes vertical lines.
@@ -13461,7 +13455,6 @@ SLES-51959:
 SLES-51960:
   name: "Disney-Pixar À Procura de Nemo"
   region: "PAL-P"
-  compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
     alignSprite: 1 # Fixes vertical lines.
@@ -22643,7 +22636,6 @@ SLKA-25055:
 SLKA-25056:
   name: "Finding Nemo"
   region: "NTSC-K"
-  compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
     alignSprite: 1 # Fixes vertical lines.
@@ -28749,7 +28741,6 @@ SLPM-65654:
 SLPM-65655:
   name: "Finding Nemo [Yuke's The Best]"
   region: "NTSC-J"
-  compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
     alignSprite: 1 # Fixes vertical lines.
@@ -36498,7 +36489,6 @@ SLPS-25309:
 SLPS-25310:
   name: "Disney-Pixar's Finding Nemo"
   region: "NTSC-J"
-  compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
     alignSprite: 1 # Fixes vertical lines.
@@ -42099,7 +42089,6 @@ SLUS-20627:
 SLUS-20628:
   name: "Disney's Finding Nemo"
   region: "NTSC-U"
-  compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
     alignSprite: 1 # Fixes vertical lines.
@@ -48570,7 +48559,6 @@ SLUS-28016:
 SLUS-28019:
   name: "Haven - Call of the King [Trade Demo]"
   region: "NTSC-U"
-  compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
     alignSprite: 1 # Fixes vertical lines.
@@ -48813,7 +48801,6 @@ SLUS-29037:
 SLUS-29038:
   name: "Haven - Call of the King [Regular Demo]"
   region: "NTSC-U"
-  compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
     alignSprite: 1 # Fixes vertical lines.

--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -6963,6 +6963,8 @@ SCUS-97132:
   name: "Kinetica"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    roundSprite: 1 # Fixes vertical lines and minor ghosting.
 SCUS-97133:
   name: "Getaway, The"
   region: "NTSC-U"
@@ -7081,6 +7083,9 @@ SCUS-97160:
 SCUS-97161:
   name: "Kinetica [Demo]"
   region: "NTSC-U"
+  compat: 5
+  gsHWFixes:
+    roundSprite: 1 # Fixes vertical lines and minor ghosting.
 SCUS-97163:
   name: "Jampack Demo Disc - Winter 2001"
   region: "NTSC-U"
@@ -9019,6 +9024,10 @@ SLED-51225:
 SLED-51281:
   name: "Haven - Call of the King [Demo]"
   region: "PAL-E"
+  compat: 5
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes ghosting.
+    alignSprite: 1 # Fixes vertical lines.
 SLED-51342:
   name: "FIFA Soccer 2003 [Demo]"
   region: "PAL-E"
@@ -11839,6 +11848,9 @@ SLES-51209:
   name: "Haven - Call of the King"
   region: "PAL-M5"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes ghosting.
+    alignSprite: 1 # Fixes vertical lines.
 SLES-51214:
   name: "Harry Potter og Hemmelighedernes Kammer"
   region: "PAL-D"
@@ -12930,7 +12942,9 @@ SLES-51754:
 SLES-51755:
   name: "Disney-Pixar's Finding Nemo"
   region: "PAL-E"
+  compat: 5
   gsHWFixes:
+    halfPixelOffset: 2 # Fixes ghosting.
     alignSprite: 1 # Fixes vertical lines.
 SLES-51756:
   name: "Batman - Rise of Sin Tzu"
@@ -13214,18 +13228,23 @@ SLES-51869:
 SLES-51870:
   name: "Disney-Pixar's Finding Nemo"
   region: "PAL-FI-S"
+  compat: 5
   gsHWFixes:
+    halfPixelOffset: 2 # Fixes ghosting.
     alignSprite: 1 # Fixes vertical lines.
 SLES-51871:
   name: "Disney-Pixar's Finding Nemo"
   region: "PAL-F-G"
   compat: 5
   gsHWFixes:
+    halfPixelOffset: 2 # Fixes ghosting.
     alignSprite: 1 # Fixes vertical lines.
 SLES-51872:
   name: "Disney-Pixar's Finding Nemo"
   region: "PAL-M3"
+  compat: 5
   gsHWFixes:
+    halfPixelOffset: 2 # Fixes ghosting.
     alignSprite: 1 # Fixes vertical lines.
 SLES-51873:
   name: "Medal of Honor - Rising Sun"
@@ -13299,6 +13318,10 @@ SLES-51906:
 SLES-51907:
   name: "Disney-Pixar Alla Ricerca di Nemo"
   region: "PAL-I"
+  compat: 5
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes ghosting.
+    alignSprite: 1 # Fixes vertical lines.
 SLES-51908:
   name: "Van Helsing"
   region: "PAL-M5"
@@ -13438,6 +13461,10 @@ SLES-51959:
 SLES-51960:
   name: "Disney-Pixar À Procura de Nemo"
   region: "PAL-P"
+  compat: 5
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes ghosting.
+    alignSprite: 1 # Fixes vertical lines.
 SLES-51961:
   name: "Prince of Persia - The Sands of Time" # Pre-order Demo
   region: "PAL-E"
@@ -22616,7 +22643,9 @@ SLKA-25055:
 SLKA-25056:
   name: "Finding Nemo"
   region: "NTSC-K"
+  compat: 5
   gsHWFixes:
+    halfPixelOffset: 2 # Fixes ghosting.
     alignSprite: 1 # Fixes vertical lines.
 SLKA-25060:
   name: "I.Q. Remix+ - Intelligent Qube"
@@ -28720,7 +28749,9 @@ SLPM-65654:
 SLPM-65655:
   name: "Finding Nemo [Yuke's The Best]"
   region: "NTSC-J"
+  compat: 5
   gsHWFixes:
+    halfPixelOffset: 2 # Fixes ghosting.
     alignSprite: 1 # Fixes vertical lines.
 SLPM-65657:
   name: "World Soccer Winning Eleven 8"
@@ -36467,7 +36498,9 @@ SLPS-25309:
 SLPS-25310:
   name: "Disney-Pixar's Finding Nemo"
   region: "NTSC-J"
+  compat: 5
   gsHWFixes:
+    halfPixelOffset: 2 # Fixes ghosting.
     alignSprite: 1 # Fixes vertical lines.
 SLPS-25311:
   name: "Spy Fiction"
@@ -39938,9 +39971,6 @@ SLUS-20153:
 SLUS-20154:
   name: "NFL Quarterback Club 2002"
   region: "NTSC-U"
-SLUS-20157:
-  name: "Haven - Call of the King"
-  region: "NTSC-U"
 SLUS-20158:
   name: "Heroes of Might and Magic"
   region: "NTSC-U"
@@ -41552,6 +41582,9 @@ SLUS-20517:
   name: "Haven - Call of the King"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes ghosting.
+    alignSprite: 1 # Fixes vertical lines.
 SLUS-20519:
   name: "Tak and The Power of Juju"
   region: "NTSC-U"
@@ -42066,7 +42099,9 @@ SLUS-20627:
 SLUS-20628:
   name: "Disney's Finding Nemo"
   region: "NTSC-U"
+  compat: 5
   gsHWFixes:
+    halfPixelOffset: 2 # Fixes ghosting.
     alignSprite: 1 # Fixes vertical lines.
 SLUS-20630:
   name: "Grand Prix Challenge"
@@ -48535,6 +48570,10 @@ SLUS-28016:
 SLUS-28019:
   name: "Haven - Call of the King [Trade Demo]"
   region: "NTSC-U"
+  compat: 5
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes ghosting.
+    alignSprite: 1 # Fixes vertical lines.
 SLUS-28020:
   name: "Everquest Online Adventures [Beta Vol.1.0]"
   region: "NTSC-U"
@@ -48774,6 +48813,10 @@ SLUS-29037:
 SLUS-29038:
   name: "Haven - Call of the King [Regular Demo]"
   region: "NTSC-U"
+  compat: 5
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes ghosting.
+    alignSprite: 1 # Fixes vertical lines.
 SLUS-29040:
   name: "Dr. Muto [Demo]"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
Adds HalfPixelOffset and AlignSprite to Finding Nemo and Haven: Call of the King. Also removes a non-existent NTSC-U Haven serial number. Adds AlignSprite to Kinetica as well, uses God of War's engine.

### Rationale behind Changes
Less ghosting and vertical lines when upscaling, and less tinkering for users.

### Suggested Testing Steps
Test said games for ghosting or vertical lines.
