### PR TITLE
GameDB: Fixes multiple games for Xth time and more

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -558,7 +558,7 @@ SCAJ-20019:
   region: "NTSC-J"
 SCAJ-20020:
   name: "Drag-on Dragoon"
-  region: "NTSC-J"
+  region: "NTSC-Ch-J"
   clampModes:
     eeClampMode: 3 # Characters are visible in-game.
   gsHWFixes:
@@ -1362,6 +1362,8 @@ SCAJ-20182:
   region: "NTSC-Unk"
   gameFixes:
     - FpuMulHack
+  gsHWFixes:
+    texturePreloading: 1 # Performs much better with partial preload.
 SCAJ-20183:
   name: "Wild ARMs - The Vth Vanguard"
   region: "NTSC-J"
@@ -1393,9 +1395,11 @@ SCAJ-20192:
   region: "NTSC-Unk"
 SCAJ-20193:
   name: "Tales of Destiny [Director's Cut] [Premium Box]"
-  region: "NTSC-Unk"
+  region: "NTSC-Ch-J"
   gameFixes:
     - FpuMulHack
+  gsHWFixes:
+    texturePreloading: 1 # Performs much better with partial preload.
 SCAJ-20194:
   name: "Minna no Golf 4 [PlayStation 2 The Best]"
   region: "NTSC-Unk"
@@ -11184,6 +11188,7 @@ SLES-50876:
   gsHWFixes:
     autoFlush: 1
     halfPixelOffset: 2 # Fixes misaligned lighting.
+    cpuCLUTRender: 1 # Fixes janky coloured cars.
 SLES-50877:
   name: "TimeSplitters 2"
   region: "PAL-M5"
@@ -13829,6 +13834,7 @@ SLES-52153:
   gsHWFixes:
     autoFlush: 1
     halfPixelOffset: 2 # Fixes misaligned lighting.
+    cpuCLUTRender: 1 # Fixes janky coloured cars.
 SLES-52155:
   name: "EyeToy - L'Eredita"
   region: "PAL-I"
@@ -15741,6 +15747,7 @@ SLES-52988:
   gsHWFixes:
     autoFlush: 1 # Fixes bloom.
     roundSprite: 1 # Fixes misalliged bloom.
+    deinterlace: 6 # Game requires blend tff deinterlacing when auto for 'fixing' subtitles flickering or half weaved.
   memcardFilters: # Reads Command Mission save for bonus boss.
     - "SLES-52988"
     - "SLES-52832"
@@ -22003,6 +22010,8 @@ SLES-55579:
     eeRoundMode: 1
   clampModes:
     vuClampMode: 0
+  gsHWFixes:
+    deinterlace: 8 # Game requires adaptive (or blend) tff deinterlacing when auto for the FMVs.
 SLES-55581:
   name: "FIFA 10"
   region: "PAL-M5"
@@ -23031,6 +23040,7 @@ SLKA-25196:
   gsHWFixes:
     autoFlush: 1
     halfPixelOffset: 2 # Fixes misaligned lighting.
+    cpuCLUTRender: 1 # Fixes janky coloured cars.
 SLKA-25198:
   name: "Tenchu Kurenai"
   region: "NTSC-K"
@@ -29129,6 +29139,7 @@ SLPM-65741:
   gsHWFixes:
     autoFlush: 1
     halfPixelOffset: 2 # Fixes misaligned lighting.
+    cpuCLUTRender: 1 # Fixes janky coloured cars.
 SLPM-65742:
   name: "Cool Girl [Konami the Best]"
   region: "NTSC-J"
@@ -38157,6 +38168,8 @@ SLPS-25715:
   region: "NTSC-J"
   gameFixes:
     - FpuMulHack
+  gsHWFixes:
+    texturePreloading: 1 # Performs much better with partial preload.
 SLPS-25716:
   name: "Digimon Savers - Another Mission"
   region: "NTSC-J"
@@ -38578,6 +38591,8 @@ SLPS-25841:
   region: "NTSC-J"
   gameFixes:
     - FpuMulHack
+  gsHWFixes:
+    texturePreloading: 1 # Performs much better with partial preload.
   memcardFilters: # Allows import of non-DC Tales of Destiny data.
     - "SLPS-25841"
     - "SLPS-25842"
@@ -38588,6 +38603,8 @@ SLPS-25842:
   compat: 5
   gameFixes:
     - FpuMulHack
+  gsHWFixes:
+    texturePreloading: 1 # Performs much better with partial preload.
   memcardFilters:
     - "SLPS-25841"
     - "SLPS-25842"
@@ -42054,6 +42071,7 @@ SLUS-20587:
   gsHWFixes:
     autoFlush: 1
     halfPixelOffset: 2 # Fixes misaligned lighting.
+    cpuCLUTRender: 1 # Fixes janky coloured cars.
 SLUS-20588:
   name: "Activision Anthology"
   region: "NTSC-U"
@@ -43821,6 +43839,7 @@ SLUS-20960:
   gsHWFixes:
     autoFlush: 1 # Fixes bloom.
     roundSprite: 1 # Fixes misalliged bloom.
+    deinterlace: 6 # Game requires blend tff deinterlacing when auto for 'fixing' subtitles flickering or half weaved.
   memcardFilters:
     - "SLUS-20960"
     - "SLUS-20903"
@@ -48455,6 +48474,8 @@ SLUS-21902:
     eeRoundMode: 1
   clampModes:
     vuClampMode: 0
+  gsHWFixes:
+    deinterlace: 8 # Game requires adaptive (or blend) tff deinterlacing when auto for the FMVs.
 SLUS-21904:
   name: "Teenage Mutant Ninja Turtles - Smash-Up"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Bakugan: Deinterlace adaptive tff due to the game attempting to deinterlace FMVs but PCSX2 going nuts
Driv3r: Fixes janky coloured cars with cpuCLUT
Megaman X8: Deinterlace blending tff due to either looking like missing half the text or flicker as how the game handles empty and subtitles
Tales of Destiny 1: Texture preload partial for better performance in certain areas
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Less tinkering
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test relevant games