### PR TITLE
VSProps: Use MultiToolTask mode

### DIFF
--- a/common/vsprops/BaseProjectConfig.props
+++ b/common/vsprops/BaseProjectConfig.props
@@ -14,4 +14,10 @@
       <Platform>x64</Platform>
     </ProjectConfiguration>
   </ItemGroup>
+
+  <!-- This better belongs in BaseProperies.props, but it needs to be set before the default props file is imported. -->
+  <PropertyGroup>
+    <UseMultiToolTask>true</UseMultiToolTask>
+    <EnforceProcessCountAcrossBuilds>true</EnforceProcessCountAcrossBuilds>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
### Description of Changes

Much better parallelism, due to our source files being spread out across multiple folders.

### Rationale behind Changes

pcsx2core build time on a Ryzen 3900X with 12C/24T:

Before: Time Elapsed 00:01:03.21
After: Time Elapsed 00:00:26.74

### Suggested Testing Steps

Make sure build succeeds.

