### PR TITLE
Sio: Only eject memory cards when loading state if changed

### DIFF
--- a/pcsx2/SaveState.h
+++ b/pcsx2/SaveState.h
@@ -33,7 +33,7 @@ enum class FreezeAction
 // [SAVEVERSION+]
 // This informs the auto updater that the users savestates will be invalidated.
 
-static const u32 g_SaveVersion = (0x9A31 << 16) | 0x0000;
+static const u32 g_SaveVersion = (0x9A32 << 16) | 0x0000;
 
 
 // the freezing data between submodules and core


### PR DESCRIPTION
### Description of Changes

[SAVEVERSION+] Regression from #6741.

### Rationale behind Changes

Replugging all the time in some games is really annoying. Also TAS.

### Suggested Testing Steps

Test saving/loading with and without card changes (e.g. changing to a different card).
