### PR TITLE
3rdparty/zydis: Silence static define warning

### DIFF
--- a/3rdparty/zydis/dependencies/zycore/include/Zycore/Defines.h
+++ b/3rdparty/zydis/dependencies/zycore/include/Zycore/Defines.h
@@ -201,7 +201,8 @@
 // backward compatibility for users that don't use CMake and previously manually defined these, we
 // translate the old defines here and print a warning.
 #if defined(ZYCORE_STATIC_DEFINE)
-#   pragma message("ZYCORE_STATIC_DEFINE was renamed to ZYCORE_STATIC_BUILD.")
+// Warning disabled for PCSX2 since we define this on the command line.
+//#   pragma message("ZYCORE_STATIC_DEFINE was renamed to ZYCORE_STATIC_BUILD.")
 #   define ZYCORE_STATIC_BUILD
 #endif
 #if defined(Zycore_EXPORTS)

--- a/pcsx2/x86/ix86-32/iR5900-32.cpp
+++ b/pcsx2/x86/ix86-32/iR5900-32.cpp
@@ -199,9 +199,9 @@ static ZyanStatus ZydisFormatterPrintAddressAbsolute(const ZydisFormatter* forma
 	{
 		len = snprintf(buf, sizeof(buf), "cpuRegs.cycle");
 	}
-	else if (address == A(&g_nextEventCycle))
+	else if (address == A(&cpuRegs.nextEventCycle))
 	{
-		len = snprintf(buf, sizeof(buf), "g_nextEventCycle");
+		len = snprintf(buf, sizeof(buf), "cpuRegs.nextEventCycle");
 	}
 	else if (address >= A(fpuRegs.fpr) && address < A(fpuRegs.fprc))
 	{


### PR DESCRIPTION
### Description of Changes

Silences the zycore warning which gets spammed, and fixes compiling with DUMP_BLOCKS (disabled by default obviously).

### Rationale behind Changes

Stuff I should've had in the EE rec PR.

### Suggested Testing Steps

Make sure build completes, no functional changes.