### PR TITLE
GameDB: Add Mipmap Full + Trilinear for Shadow of the Colossus

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -2509,7 +2509,8 @@ SCED-53962:
   speedHacks:
     InstantVU1SpeedHack: 0 # Alleviates excessive VU load.
   gsHWFixes:
-    mipmap: 1
+    mipmap: 2 # Fixes Water with Trilinear.
+    trilinearFiltering: 1 # Fixes Water with Mipmap (Full).
     halfPixelOffset: 1 # Fixes misalignments and borders on side.
 SCED-53978:
   name: "Official PlayStation 2 Magazine Demo 69"
@@ -3828,7 +3829,8 @@ SCES-53326:
   speedHacks:
     InstantVU1SpeedHack: 0 # Alleviates excessive VU load.
   gsHWFixes:
-    mipmap: 1
+    mipmap: 2 # Fixes Water with Trilinear.
+    trilinearFiltering: 1 # Fixes Water with Mipmap (Full).
     halfPixelOffset: 1 # Fixes misalignments and borders on side.
   memcardFilters:
     - "SCES-53326"
@@ -8117,7 +8119,8 @@ SCUS-97472:
   speedHacks:
     InstantVU1SpeedHack: 0 # Alleviates excessive VU load.
   gsHWFixes:
-    mipmap: 1
+    mipmap: 2 # Fixes Water with Trilinear.
+    trilinearFiltering: 1 # Fixes Water with Mipmap (Full).
     halfPixelOffset: 1 # Fixes misalignments and borders on side.
   memcardFilters:
     - "SCUS-97472"
@@ -8305,7 +8308,8 @@ SCUS-97505:
   speedHacks:
     InstantVU1SpeedHack: 0 # Alleviates excessive VU load.
   gsHWFixes:
-    mipmap: 1
+    mipmap: 2 # Fixes Water with Trilinear.
+    trilinearFiltering: 1 # Fixes Water with Mipmap (Full).
     halfPixelOffset: 1 # Fixes misalignments and borders on side.
 SCUS-97506:
   name: "Gretzky NHL '06 [Demo]"


### PR DESCRIPTION
### Description of Changes
Adds mipmapping full and trilinear to Shadow of the Colossus as an automatic fix

### Rationale behind Changes
Fixes broken water in hardware mode.

### Suggested Testing Steps
check CI

Before:
![image](https://user-images.githubusercontent.com/6278726/202839126-e9ee0190-3269-4228-9b82-5f1444b2e43a.png)

After:
![image](https://user-images.githubusercontent.com/6278726/202839137-c2ca311e-f74b-42ed-9a06-a331bd0384f8.png)
