### PR TITLE
MemoryCardFolder: Add missing bounds check to Read()

### DIFF
--- a/pcsx2/MemoryCardFolder.cpp
+++ b/pcsx2/MemoryCardFolder.cpp
@@ -1008,7 +1008,9 @@ s32 FolderMemoryCard::Read(u8* dest, u32 adr, int size)
 			FolderMemoryCard::CalculateECC(ecc + (i * 3), &data[i * 0x80]);
 		}
 
-		memcpy(dest + eccOffset, ecc, eccLength);
+		pxAssert(size >= eccOffset);
+		const u32 copySize = std::min((u32)size - eccOffset, eccLength);
+		memcpy(dest + eccOffset, ecc, copySize);
 	}
 
 	SetTimeLastReadToNow();


### PR DESCRIPTION
### Description of Changes

Happens when using memory card folders and booting God of War. Game does a bunch of 128 byte reads followed by a 12 byte read, ecc gets computed, 16 bytes get copied and overflows.

### Rationale behind Changes

Heap corruption is bad.

### Suggested Testing Steps

Test GoW with folder memcards.
