### PR TITLE
Mis: Flag Windows 8.1 as unsupported OS.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,8 @@ _Note: Recommended GPU is based on 3x Internal, ~1080p resolution requirements. 
 
 -   You need the [Visual C++ 2019 x64 Redistributables](https://support.microsoft.com/en-us/help/2977003/) to run PCSX2.
 -   Windows XP and Direct3D9 support was dropped after stable release 1.4.0.
--   Windows 7 and Windows 8.0 support was dropped after stable release 1.6.0.
+-   Windows 7, Windows 8.0, and Windows 8.1 support was dropped after stable release 1.6.0.
 -   32-bit support was dropped after stable release 1.6.0.
--   The Qt version is only supported on Windows 10 or newer, Ubuntu/Debian 20.04 or equivalent and newer.
 -   Make sure to update your operating system and drivers to ensure you have the best experience possible. Having a newer GPU is also recommended so you have the latest supported drivers.
 -   Because of copyright issues, and the complexity of trying to work around it, you need a BIOS dump extracted from a legitimately-owned PS2 console to use the emulator. For more information about the BIOS and how to get it from your console, visit [this page](pcsx2/Docs/PCSX2_FAQ.md#question-13-where-do-i-get-a-ps2-bios).
 -   PCSX2 uses two CPU cores for emulation by default. A third core can be used via the MTVU speed hack, which is compatible with most games. This can be a significant speedup on CPUs with 3+ cores, but it may be a slowdown on GS-limited games (or on CPUs with fewer than 2 cores). Software renderers will then additionally use however many rendering threads it is set to and will need higher core counts to run efficiently.

--- a/common/HTTPDownloaderWinHTTP.cpp
+++ b/common/HTTPDownloaderWinHTTP.cpp
@@ -52,9 +52,7 @@ std::unique_ptr<HTTPDownloader> HTTPDownloader::Create(const char* user_agent)
 
 bool HTTPDownloaderWinHttp::Initialize(const char* user_agent)
 {
-	// WINHTTP_ACCESS_TYPE_AUTOMATIC_PROXY is not supported before Win8.1.
-	const DWORD dwAccessType =
-		IsWindows8Point1OrGreater() ? WINHTTP_ACCESS_TYPE_AUTOMATIC_PROXY : WINHTTP_ACCESS_TYPE_DEFAULT_PROXY;
+	const DWORD dwAccessType = WINHTTP_ACCESS_TYPE_AUTOMATIC_PROXY;
 
 	m_hSession = WinHttpOpen(StringUtil::UTF8StringToWideString(user_agent).c_str(), dwAccessType, nullptr, nullptr,
 		WINHTTP_FLAG_ASYNC);

--- a/common/Windows/WinMisc.cpp
+++ b/common/Windows/WinMisc.cpp
@@ -64,19 +64,14 @@ std::string GetOSVersionString()
 	SYSTEM_INFO si;
 	GetNativeSystemInfo(&si);
 
-	if (!IsWindows8Point1OrGreater())
-	{
-		retval = "Unsupported Operating System!";
-	}
-	else
+	if (IsWindows10OrGreater())
 	{
 		retval = "Microsoft ";
-
-		if (IsWindows10OrGreater())
-			retval += IsWindowsServer() ? "Windows Server 2016" : "Windows 10";
-		else // IsWindows8Point1OrGreater()
-			retval += IsWindowsServer() ? "Windows Server 2012 R2" : "Windows 8.1";
+		retval += IsWindowsServer() ? "Windows Server 2016" : "Windows 10";
+		
 	}
+	else
+		retval = "Unsupported Operating System!";
 
 	return retval;
 }


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Mis: Flag Windows 8.1 as unsupported OS.
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
No longer supported.

Might be worth using the newest sdk(10.0.22000) so we can properly detect win 11.
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
