### PR TITLE
x86/iR5900: Don't swap loadstore delay slots for BC0/BC2 conditions

### DIFF
--- a/pcsx2/R5900OpcodeTables.cpp
+++ b/pcsx2/R5900OpcodeTables.cpp
@@ -634,7 +634,7 @@ namespace R5900
 		const OPCODE& Class_MMI3(u32 op) { return tbl_MMI3[(op >> 6) & 0x1F]; }
 
 		const OPCODE& Class_COP0(u32 op) { return tbl_COP0[(op >> 21) & 0x1F]; }
-		const OPCODE& Class_COP0_BC0(u32 op) { return tbl_COP0_BC0[(cpuRegs.code >> 16) & 0x03]; }
+		const OPCODE& Class_COP0_BC0(u32 op) { return tbl_COP0_BC0[(op >> 16) & 0x03]; }
 		const OPCODE& Class_COP0_C0(u32 op) { return tbl_COP0_C0[op & 0x3F]; }
 
 		const OPCODE& Class_COP1(u32 op) { return tbl_COP1[(op >> 21) & 0x1F]; }

--- a/pcsx2/x86/iCOP0.cpp
+++ b/pcsx2/x86/iCOP0.cpp
@@ -65,7 +65,7 @@ static void _setupBranchTest()
 void recBC0F()
 {
 	const u32 branchTo = ((s32)_Imm_ * 4) + pc;
-	const bool swap = TrySwapDelaySlot(0, 0, 0);
+	const bool swap = TrySwapDelaySlot(0, 0, 0, false);
 	_setupBranchTest();
 	recDoBranchImm(branchTo, JE32(0), false, swap);
 }
@@ -73,7 +73,7 @@ void recBC0F()
 void recBC0T()
 {
 	const u32 branchTo = ((s32)_Imm_ * 4) + pc;
-	const bool swap = TrySwapDelaySlot(0, 0, 0);
+	const bool swap = TrySwapDelaySlot(0, 0, 0, false);
 	_setupBranchTest();
 	recDoBranchImm(branchTo, JNE32(0), false, swap);
 }

--- a/pcsx2/x86/iFPU.cpp
+++ b/pcsx2/x86/iFPU.cpp
@@ -704,7 +704,7 @@ void recBC1F()
 {
 	EE::Profiler.EmitOp(eeOpcode::BC1F);
 	const u32 branchTo = ((s32)_Imm_ * 4) + pc;
-	const bool swap = TrySwapDelaySlot(0, 0, 0);
+	const bool swap = TrySwapDelaySlot(0, 0, 0, true);
 	_setupBranchTest();
 	recDoBranchImm(branchTo, JNZ32(0), false, swap);
 }
@@ -713,7 +713,7 @@ void recBC1T()
 {
 	EE::Profiler.EmitOp(eeOpcode::BC1T);
 	const u32 branchTo = ((s32)_Imm_ * 4) + pc;
-	const bool swap = TrySwapDelaySlot(0, 0, 0);
+	const bool swap = TrySwapDelaySlot(0, 0, 0, true);
 	_setupBranchTest();
 	recDoBranchImm(branchTo, JZ32(0), false, swap);
 }

--- a/pcsx2/x86/iR5900.h
+++ b/pcsx2/x86/iR5900.h
@@ -69,7 +69,7 @@ u8* recBeginThunk();
 u8* recEndThunk();
 
 // used when processing branches
-bool TrySwapDelaySlot(u32 rs, u32 rt, u32 rd);
+bool TrySwapDelaySlot(u32 rs, u32 rt, u32 rd, bool allow_loadstore);
 void SaveBranchState();
 void LoadBranchState();
 

--- a/pcsx2/x86/ix86-32/iR5900Branch.cpp
+++ b/pcsx2/x86/ix86-32/iR5900Branch.cpp
@@ -155,7 +155,7 @@ static void recBEQ_process(int process)
 	}
 	else
 	{
-		const bool swap = TrySwapDelaySlot(_Rs_, _Rt_, 0);
+		const bool swap = TrySwapDelaySlot(_Rs_, _Rt_, 0, true);
 
 		recSetBranchEQ(0, process);
 
@@ -219,7 +219,7 @@ static void recBNE_process(int process)
 		return;
 	}
 
-	const bool swap = TrySwapDelaySlot(_Rs_, _Rt_, 0);
+	const bool swap = TrySwapDelaySlot(_Rs_, _Rt_, 0, true);
 
 	recSetBranchEQ(1, process);
 
@@ -383,7 +383,7 @@ void recBLTZAL()
 		return;
 	}
 
-	const bool swap = TrySwapDelaySlot(_Rs_, 0, 0);
+	const bool swap = TrySwapDelaySlot(_Rs_, 0, 0, true);
 
 	recSetBranchL(1);
 
@@ -432,7 +432,7 @@ void recBGEZAL()
 		return;
 	}
 
-	const bool swap = TrySwapDelaySlot(_Rs_, 0, 0);
+	const bool swap = TrySwapDelaySlot(_Rs_, 0, 0, true);
 
 	recSetBranchL(0);
 
@@ -551,7 +551,7 @@ void recBLEZ()
 		return;
 	}
 
-	const bool swap = TrySwapDelaySlot(_Rs_, 0, 0);
+	const bool swap = TrySwapDelaySlot(_Rs_, 0, 0, true);
 	const int regs = _checkX86reg(X86TYPE_GPR, _Rs_, MODE_READ);
 	_eeFlushAllDirty();
 
@@ -600,7 +600,7 @@ void recBGTZ()
 		return;
 	}
 
-	const bool swap = TrySwapDelaySlot(_Rs_, 0, 0);
+	const bool swap = TrySwapDelaySlot(_Rs_, 0, 0, true);
 	const int regs = _checkX86reg(X86TYPE_GPR, _Rs_, MODE_READ);
 	_eeFlushAllDirty();
 
@@ -649,7 +649,7 @@ void recBLTZ()
 		return;
 	}
 
-	const bool swap = TrySwapDelaySlot(_Rs_, 0, 0);
+	const bool swap = TrySwapDelaySlot(_Rs_, 0, 0, true);
 	_eeFlushAllDirty();
 	recSetBranchL(1);
 
@@ -691,7 +691,7 @@ void recBGEZ()
 		return;
 	}
 
-	const bool swap = TrySwapDelaySlot(_Rs_, 0, 0);
+	const bool swap = TrySwapDelaySlot(_Rs_, 0, 0, true);
 	_eeFlushAllDirty();
 
 	recSetBranchL(0);

--- a/pcsx2/x86/ix86-32/iR5900Jump.cpp
+++ b/pcsx2/x86/ix86-32/iR5900Jump.cpp
@@ -99,7 +99,7 @@ void recJALR()
 	EE::Profiler.EmitOp(eeOpcode::JALR);
 
 	const u32 newpc = pc + 4;
-	const bool swap = (EmuConfig.Gamefixes.GoemonTlbHack || _Rd_ == _Rs_) ? false : TrySwapDelaySlot(_Rs_, 0, _Rd_);
+	const bool swap = (EmuConfig.Gamefixes.GoemonTlbHack || _Rd_ == _Rs_) ? false : TrySwapDelaySlot(_Rs_, 0, _Rd_, true);
 
 	// uncomment when there are NO instructions that need to call interpreter
 	//	int mmreg;

--- a/pcsx2/x86/microVU_Macro.inl
+++ b/pcsx2/x86/microVU_Macro.inl
@@ -311,7 +311,7 @@ static void _setupBranchTest(u32*(jmpType)(u32), bool isLikely)
 {
 	printCOP2("COP2 Branch");
 	const u32 branchTo = ((s32)_Imm_ * 4) + pc;
-	const bool swap = isLikely ? false : TrySwapDelaySlot(0, 0, 0);
+	const bool swap = isLikely ? false : TrySwapDelaySlot(0, 0, 0, false);
 	_eeFlushAllDirty();
 	//xTEST(ptr32[&vif1Regs.stat._u32], 0x4);
 	xTEST(ptr32[&VU0.VI[REG_VPU_STAT].UL], 0x100);


### PR DESCRIPTION
### Description of Changes

Swapping the loadstore could affect the condition of the instruction, leading to incorrect code execution.

Fixes lock up in Oni after intro FMVs. Also fixed the incorrect disassembly of those instructions while I was at it.

### Rationale behind Changes

Fixes #7417.

### Suggested Testing Steps

Test Oni (already done here).

