### PR TITLE
GS: Allow negative offset on single display

### DIFF
--- a/pcsx2/GS/Renderers/Common/GSRenderer.cpp
+++ b/pcsx2/GS/Renderers/Common/GSRenderer.cpp
@@ -266,8 +266,8 @@ bool GSRenderer::Merge(int field)
 				if (display_diff.y >= 4 || !GSConfig.PCRTCAntiBlur)
 					off.y = display_diff.y;
 
-
-				if (samesrc)
+				// Need to check if only circuit 2 is enabled. Stuntman toggles circuit 1 on and off every other frame.
+				if (samesrc || m_regs->PMODE.EN == 2)
 				{
 					// Adjusting the screen offset when using a negative offset.
 					const int videomode = static_cast<int>(GetVideoMode()) - 1;


### PR DESCRIPTION
### Description of Changes
Allow the merge circuit to apply a negative offset when there's only one display.

### Rationale behind Changes
Stuntman in all its wisdom was applying a negative offset, but also toggling one of the circuits on and off every other frame, so it was shaking like a madman and looked ugly.

### Suggested Testing Steps
Test games with PCRTC offsets (with screen offsets/overscan turned off)

Before:
![image](https://user-images.githubusercontent.com/6278726/202887824-bd803aaa-9c1e-4728-90ae-7a5584756795.png)

After:
![image](https://user-images.githubusercontent.com/6278726/202887916-114493f2-8f86-4111-8c63-5970e3931992.png)

