### PR TITLE
GS-TC: Only reset age on new Tex in RT targets.

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -1021,7 +1021,10 @@ void GSTextureCache::InvalidateVideoMem(const GSOffset& off, const GSVector4i& r
 					const SurfaceOffset so = ComputeSurfaceOffset(off, r, t);
 					if (so.is_valid)
 					{
-						t->m_age = 0;
+						// Don't reset the age on old targets, possibly misdetection, it upsets Urban Reign.
+						if (t->m_age < 30)
+							t->m_age = 0;
+
 						t->m_dirty.push_back(GSDirtyRect(so.b2a_offset, psm, bw));
 					}
 				}


### PR DESCRIPTION
### Description of Changes
Only reset the age of new targets when captures in Tex in RT.

### Rationale behind Changes
Caused huge GS usage on Urban Reign due to old target.

### Suggested Testing Steps
Test Urban Reign, make sure the GS usage doesn't go through the roof.
