### PR TITLE
PAD: increase number of macros per controller from 4 to 16

### DIFF
--- a/pcsx2/PAD/Host/PAD.h
+++ b/pcsx2/PAD/Host/PAD.h
@@ -125,7 +125,7 @@ namespace PAD
 	static constexpr u32 NUM_CONTROLLER_PORTS = 8;
 
 	/// Number of macro buttons per controller.
-	static constexpr u32 NUM_MACRO_BUTTONS_PER_CONTROLLER = 4;
+	static constexpr u32 NUM_MACRO_BUTTONS_PER_CONTROLLER = 16;
 
 	/// Default stick deadzone/sensitivity.
 	static constexpr float DEFAULT_STICK_DEADZONE = 0.0f;


### PR DESCRIPTION
### Description of Changes
Increases the limit of macros from 4 to 16 to fill the UI up.

### Rationale behind Changes
Not sure why it was limited to 4, I don't think there's a technical reason, and some users were after more than 4, so why not have a screen's worth? :)

### Suggested Testing Steps
Make a bunch of macros for your controller, try them out, see what happens.

Closes #7009