### PR TITLE
Qt: Fix per-game enable/OSD message timing/reset play time

### DIFF
--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -1294,6 +1294,9 @@ void MainWindow::onGameListEntryContextMenuRequested(const QPoint& point)
 		connect(menu.addAction(tr("Exclude From List")), &QAction::triggered,
 			[this, entry]() { getSettingsDialog()->getGameListSettingsWidget()->addExcludedPath(entry->path); });
 
+		connect(menu.addAction(tr("Reset Play Time")), &QAction::triggered,
+			[this, entry]() { clearGameListEntryPlayTime(entry); });
+
 		menu.addSeparator();
 
 		if (!s_vm_valid)
@@ -2372,6 +2375,19 @@ void MainWindow::setGameListEntryCoverImage(const GameList::Entry* entry)
 	}
 
 	m_game_list_widget->refreshGridCovers();
+}
+
+void MainWindow::clearGameListEntryPlayTime(const GameList::Entry* entry)
+{
+	if (QMessageBox::question(this, tr("Confirm Reset"),
+		tr("Are you sure you want to reset the play time for '%1'?\n\nThis action cannot be undone.")
+		.arg(QString::fromStdString(entry->title))) != QMessageBox::Yes)
+	{
+		return;
+	}
+
+	GameList::ClearPlayedTimeForSerial(entry->serial);
+	m_game_list_widget->refresh(false);
 }
 
 std::optional<bool> MainWindow::promptForResumeState(const QString& save_state_path)

--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -2225,11 +2225,11 @@ void MainWindow::setDisplayFullscreen(const std::string& fullscreen_mode)
 	{
 		if (g_host_display->SetFullscreen(true, width, height, refresh_rate))
 		{
-			Host::AddOSDMessage("Acquired exclusive fullscreen.", 10.0f);
+			Host::AddOSDMessage("Acquired exclusive fullscreen.", Host::OSD_INFO_DURATION);
 		}
 		else
 		{
-			Host::AddOSDMessage("Failed to acquire exclusive fullscreen.", 10.0f);
+			Host::AddOSDMessage("Failed to acquire exclusive fullscreen.", Host::OSD_WARNING_DURATION);
 		}
 	}
 }

--- a/pcsx2-qt/MainWindow.h
+++ b/pcsx2-qt/MainWindow.h
@@ -231,6 +231,7 @@ private:
 	void startGameListEntry(const GameList::Entry* entry, std::optional<s32> save_slot = std::nullopt,
 		std::optional<bool> fast_boot = std::nullopt);
 	void setGameListEntryCoverImage(const GameList::Entry* entry);
+	void clearGameListEntryPlayTime(const GameList::Entry* entry);
 
 	std::optional<bool> promptForResumeState(const QString& save_state_path);
 	void loadSaveStateSlot(s32 slot);

--- a/pcsx2-qt/Settings/EmulationSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/EmulationSettingsWidget.cpp
@@ -49,9 +49,16 @@ EmulationSettingsWidget::EmulationSettingsWidget(SettingsDialog* dialog, QWidget
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.cheats, "EmuCore", "EnableCheats", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.widescreenPatches, "EmuCore", "EnableWideScreenPatches", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.noInterlacingPatches, "EmuCore", "EnableNoInterlacingPatches", false);
-	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.perGameSettings, "EmuCore", "EnablePerGameSettings", true);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.hostFilesystem, "EmuCore", "HostFs", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.warnAboutUnsafeSettings, "EmuCore", "WarnAboutUnsafeSettings", true);
+
+	// Per-game settings is special, we don't want to bind it if we're editing per-game settings.
+	m_ui.perGameSettings->setEnabled(!dialog->isPerGameSettings());
+	if (!dialog->isPerGameSettings())
+	{
+		SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.perGameSettings, "EmuCore", "EnablePerGameSettings", true);
+		connect(m_ui.perGameSettings, &QCheckBox::stateChanged, g_emu_thread, &EmuThread::reloadGameSettings);
+	}
 
 	dialog->registerWidgetHelp(m_ui.normalSpeed, tr("Normal Speed"), "100%",
 		tr("Sets the target emulation speed. It is not guaranteed that this speed will be reached, "

--- a/pcsx2/CDVD/CDVDcommon.cpp
+++ b/pcsx2/CDVD/CDVDcommon.cpp
@@ -413,7 +413,7 @@ bool DoCDVDopen()
 	CDVD->getTD(0, &td);
 
 #ifdef PCSX2_CORE
-	Host::AddKeyedOSDMessage("BlockDumpCreate", fmt::format("Saving CDVD block dump to '{}'.", temp), 10.0f);
+	Host::AddKeyedOSDMessage("BlockDumpCreate", fmt::format("Saving CDVD block dump to '{}'.", temp), Host::OSD_INFO_DURATION);
 #endif
 
 	blockDumpFile.Create(std::move(temp), 2);

--- a/pcsx2/Frontend/Achievements.cpp
+++ b/pcsx2/Frontend/Achievements.cpp
@@ -1468,7 +1468,7 @@ void Achievements::GameChanged(u32 crc)
 		if (crc != 0)
 		{
 			Host::AddKeyedOSDMessage(
-				"retroachievements_disc_read_failed", "Failed to read executable from disc. Achievements disabled.", 10.0f);
+				"retroachievements_disc_read_failed", "Failed to read executable from disc. Achievements disabled.", Host::OSD_CRITICAL_ERROR_DURATION);
 		}
 
 		s_last_game_crc = 0;

--- a/pcsx2/Frontend/CommonHotkeys.cpp
+++ b/pcsx2/Frontend/CommonHotkeys.cpp
@@ -48,7 +48,7 @@ static void HotkeyAdjustTargetSpeed(double delta)
 	gsUpdateFrequency(EmuConfig);
 	GetMTGS().UpdateVSyncMode();
 	Host::AddIconOSDMessage("SpeedChanged", ICON_FA_CLOCK,
-		fmt::format("Target speed set to {:.0f}%.", std::round(EmuConfig.Framerate.NominalScalar * 100.0)), 5.0f);
+		fmt::format("Target speed set to {:.0f}%.", std::round(EmuConfig.Framerate.NominalScalar * 100.0)), Host::OSD_QUICK_DURATION);
 }
 
 static constexpr s32 CYCLE_SAVE_STATE_SLOTS = 10;
@@ -80,13 +80,13 @@ static void HotkeyCycleSaveSlot(s32 delta)
 		if (len > 0 && date_buf[len - 1] == '\n')
 			date_buf[len - 1] = 0;
 
-		Host::AddIconOSDMessage(
-			"CycleSaveSlot", ICON_FA_SEARCH, fmt::format("Save slot {} selected (last save: {}).", s_current_save_slot, date_buf), 5.0f);
+		Host::AddIconOSDMessage("CycleSaveSlot", ICON_FA_SEARCH,
+			fmt::format("Save slot {} selected (last save: {}).", s_current_save_slot, date_buf), Host::OSD_QUICK_DURATION);
 	}
 	else
 	{
-		Host::AddIconOSDMessage(
-			"CycleSaveSlot", ICON_FA_SEARCH, fmt::format("Save slot {} selected (no save yet).", s_current_save_slot), 5.0f);
+		Host::AddIconOSDMessage("CycleSaveSlot", ICON_FA_SEARCH, fmt::format("Save slot {} selected (no save yet).", s_current_save_slot),
+			Host::OSD_QUICK_DURATION);
 	}
 }
 
@@ -95,15 +95,16 @@ static void HotkeyLoadStateSlot(s32 slot)
 	const u32 crc = VMManager::GetGameCRC();
 	if (crc == 0)
 	{
-		Host::AddIconOSDMessage(
-			"LoadStateFromSlot", ICON_FA_EXCLAMATION_TRIANGLE, "Cannot load state from a slot without a game running.", 10.0f);
+		Host::AddIconOSDMessage("LoadStateFromSlot", ICON_FA_EXCLAMATION_TRIANGLE, "Cannot load state from a slot without a game running.",
+			Host::OSD_INFO_DURATION);
 		return;
 	}
 
 	const std::string serial(VMManager::GetGameSerial());
 	if (!VMManager::HasSaveStateInSlot(serial.c_str(), crc, slot))
 	{
-		Host::AddIconOSDMessage("LoadStateFromSlot", ICON_FA_EXCLAMATION_TRIANGLE, fmt::format("No save state found in slot {}.", slot));
+		Host::AddIconOSDMessage("LoadStateFromSlot", ICON_FA_EXCLAMATION_TRIANGLE, fmt::format("No save state found in slot {}.", slot),
+			Host::OSD_INFO_DURATION);
 		return;
 	}
 
@@ -114,8 +115,8 @@ static void HotkeySaveStateSlot(s32 slot)
 {
 	if (VMManager::GetGameCRC() == 0)
 	{
-		Host::AddIconOSDMessage(
-			"SaveStateToSlot", ICON_FA_EXCLAMATION_TRIANGLE, "Cannot save state to a slot without a game running.", 10.0f);
+		Host::AddIconOSDMessage("SaveStateToSlot", ICON_FA_EXCLAMATION_TRIANGLE, "Cannot save state to a slot without a game running.",
+			Host::OSD_INFO_DURATION);
 		return;
 	}
 

--- a/pcsx2/Frontend/FullscreenUI.cpp
+++ b/pcsx2/Frontend/FullscreenUI.cpp
@@ -2633,8 +2633,11 @@ void FullscreenUI::DrawEmulationSettingsPage()
 		"EnableWideScreenPatches", false);
 	DrawToggleSetting(bsi, "Enable No-Interlacing Patches", "Enables loading no-interlacing patches from pnach files.", "EmuCore",
 		"EnableNoInterlacingPatches", false);
-	DrawToggleSetting(bsi, "Enable Per-Game Settings", "Enables loading ini overlays from gamesettings, or custom settings per-game.",
-		"EmuCore", "EnablePerGameSettings", true);
+	if (DrawToggleSetting(bsi, "Enable Per-Game Settings", "Enables loading ini overlays from gamesettings, or custom settings per-game.",
+			"EmuCore", "EnablePerGameSettings", IsEditingGameSettings(bsi)))
+	{
+		Host::RunOnCPUThread(&VMManager::ReloadGameSettings);
+	}
 	DrawToggleSetting(bsi, "Enable Host Filesystem", "Enables access to files from the host: namespace in the virtual machine.", "EmuCore",
 		"HostFs", false);
 	DrawToggleSetting(bsi, "Warn About Unsafe Settings", "Displays warnings when settings are enabled which may break games.", "EmuCore",

--- a/pcsx2/Frontend/FullscreenUI.cpp
+++ b/pcsx2/Frontend/FullscreenUI.cpp
@@ -5142,12 +5142,13 @@ void FullscreenUI::HandleGameListOptions(const GameList::Entry* entry)
 		{ICON_FA_COMPACT_DISC " Default Boot", false},
 		{ICON_FA_LIGHTBULB " Fast Boot", false},
 		{ICON_FA_MAGIC " Slow Boot", false},
+		{ICON_FA_FOLDER_MINUS " Reset Play Time", false},
 		{ICON_FA_WINDOW_CLOSE " Close Menu", false},
 	};
 
 	const bool has_resume_state = VMManager::HasSaveStateInSlot(entry->serial.c_str(), entry->crc, -1);
 	OpenChoiceDialog(entry->title.c_str(), false, std::move(options),
-		[has_resume_state, entry_path = entry->path](s32 index, const std::string& title, bool checked) {
+		[has_resume_state, entry_path = entry->path, entry_serial = entry->serial](s32 index, const std::string& title, bool checked) {
 			switch (index)
 			{
 				case 0: // Open Game Properties
@@ -5167,6 +5168,9 @@ void FullscreenUI::HandleGameListOptions(const GameList::Entry* entry)
 					break;
 				case 5: // Slow Boot
 					DoStartPath(entry_path, std::nullopt, false);
+					break;
+				case 6: // Reset Play Time
+					GameList::ClearPlayedTimeForSerial(entry_serial);
 					break;
 				default:
 					break;

--- a/pcsx2/Frontend/GameList.h
+++ b/pcsx2/Frontend/GameList.h
@@ -124,6 +124,7 @@ namespace GameList
 
 	/// Add played time for the specified serial.
 	void AddPlayedTimeForSerial(const std::string& serial, std::time_t last_time, std::time_t add_time);
+	void ClearPlayedTimeForSerial(const std::string& serial);
 
 	/// Returns the total time played for a game. Requires the game to be scanned in the list.
 	std::time_t GetCachedPlayedTimeForSerial(const std::string& serial);

--- a/pcsx2/Frontend/ImGuiFullscreen.cpp
+++ b/pcsx2/Frontend/ImGuiFullscreen.cpp
@@ -1817,7 +1817,7 @@ void ImGuiFullscreen::DrawChoiceDialog()
 	const float width = LayoutScale(600.0f);
 	const float title_height = g_large_font->FontSize + ImGui::GetStyle().FramePadding.y * 2.0f + ImGui::GetStyle().WindowPadding.y * 2.0f;
 	const float height = std::min(
-		LayoutScale(400.0f), title_height + LayoutScale(LAYOUT_MENU_BUTTON_HEIGHT_NO_SUMMARY + (LAYOUT_MENU_BUTTON_Y_PADDING * 2.0f)) *
+		LayoutScale(450.0f), title_height + LayoutScale(LAYOUT_MENU_BUTTON_HEIGHT_NO_SUMMARY + (LAYOUT_MENU_BUTTON_Y_PADDING * 2.0f)) *
 												static_cast<float>(s_choice_dialog_options.size()));
 	ImGui::SetNextWindowSize(ImVec2(width, height));
 	ImGui::SetNextWindowPos(ImGui::GetIO().DisplaySize * 0.5f, ImGuiCond_Always, ImVec2(0.5f, 0.5f));

--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -338,7 +338,7 @@ bool GSreopen(bool recreate_display, const Pcsx2Config::GSOptions& old_config)
 
 			Host::AddKeyedOSDMessage("GSReopenFailed", fmt::format("Failed to open {} display, switching back to {}.",
 														   HostDisplay::RenderAPIToString(GetAPIForRenderer(GSConfig.Renderer)),
-														   HostDisplay::RenderAPIToString(GetAPIForRenderer(old_config.Renderer)), 10.0f));
+														   HostDisplay::RenderAPIToString(GetAPIForRenderer(old_config.Renderer)), Host::OSD_CRITICAL_ERROR_DURATION));
 			GSConfig = old_config;
 		}
 	}
@@ -358,7 +358,7 @@ bool GSreopen(bool recreate_display, const Pcsx2Config::GSOptions& old_config)
 			}
 		}
 
-		Host::AddKeyedOSDMessage("GSReopenFailed","Failed to reopen, restoring old configuration.", 10.0f);
+		Host::AddKeyedOSDMessage("GSReopenFailed","Failed to reopen, restoring old configuration.", Host::OSD_CRITICAL_ERROR_DURATION);
 		GSConfig = old_config;
 		if (!DoGSOpen(GSConfig.Renderer, basemem))
 		{
@@ -1680,7 +1680,7 @@ void GSApp::SetConfig(const char* entry, int value)
 static void HotkeyAdjustUpscaleMultiplier(s32 delta)
 {
 	const u32 new_multiplier = static_cast<u32>(std::clamp(static_cast<s32>(EmuConfig.GS.UpscaleMultiplier) + delta, 1, 8));
-	Host::AddKeyedFormattedOSDMessage("UpscaleMultiplierChanged", 10.0f, "Upscale multiplier set to %ux.", new_multiplier);
+	Host::AddKeyedFormattedOSDMessage("UpscaleMultiplierChanged", Host::OSD_QUICK_DURATION, "Upscale multiplier set to %ux.", new_multiplier);
 	EmuConfig.GS.UpscaleMultiplier = new_multiplier;
 
 	// this is pretty slow. we only really need to flush the TC and recompile shaders.
@@ -1691,7 +1691,7 @@ static void HotkeyAdjustUpscaleMultiplier(s32 delta)
 static void HotkeyAdjustZoom(double delta)
 {
 	const double new_zoom = std::clamp(EmuConfig.GS.Zoom + delta, 1.0, 200.0);
-	Host::AddKeyedFormattedOSDMessage("ZoomChanged", 10.0f, "Zoom set to %.1f%%.", new_zoom);
+	Host::AddKeyedFormattedOSDMessage("ZoomChanged", Host::OSD_QUICK_DURATION, "Zoom set to %.1f%%.", new_zoom);
 	EmuConfig.GS.Zoom = new_zoom;
 
 	// no need to go through the full settings update for this
@@ -1741,7 +1741,7 @@ BEGIN_HOTKEY_LIST(g_gs_hotkeys)
 
 		 // technically this races, but the worst that'll happen is one frame uses the old AR.
 		 EmuConfig.CurrentAspectRatio = static_cast<AspectRatioType>((static_cast<int>(EmuConfig.CurrentAspectRatio) + 1) % static_cast<int>(AspectRatioType::MaxCount));
-		 Host::AddKeyedFormattedOSDMessage("CycleAspectRatio", 10.0f, "Aspect ratio set to '%s'.", Pcsx2Config::GSOptions::AspectRatioNames[static_cast<int>(EmuConfig.CurrentAspectRatio)]);
+		 Host::AddKeyedFormattedOSDMessage("CycleAspectRatio", Host::OSD_QUICK_DURATION, "Aspect ratio set to '%s'.", Pcsx2Config::GSOptions::AspectRatioNames[static_cast<int>(EmuConfig.CurrentAspectRatio)]);
 	 }},
 	{"CycleMipmapMode", "Graphics", "Cycle Hardware Mipmapping", [](s32 pressed) {
 		 if (pressed)
@@ -1751,7 +1751,7 @@ BEGIN_HOTKEY_LIST(g_gs_hotkeys)
 		 static constexpr std::array<const char*, CYCLE_COUNT> option_names = {{"Automatic", "Off", "Basic (Generated)", "Full (PS2)"}};
 
 		 const HWMipmapLevel new_level = static_cast<HWMipmapLevel>(((static_cast<s32>(EmuConfig.GS.HWMipmap) + 2) % CYCLE_COUNT) - 1);
-		 Host::AddKeyedFormattedOSDMessage("CycleMipmapMode", 10.0f, "Hardware mipmapping set to '%s'.", option_names[static_cast<s32>(new_level) + 1]);
+		 Host::AddKeyedFormattedOSDMessage("CycleMipmapMode", Host::OSD_QUICK_DURATION, "Hardware mipmapping set to '%s'.", option_names[static_cast<s32>(new_level) + 1]);
 		 EmuConfig.GS.HWMipmap = new_level;
 
 		 GetMTGS().RunOnGSThread([new_level]() {
@@ -1778,7 +1778,7 @@ BEGIN_HOTKEY_LIST(g_gs_hotkeys)
 		 }};
 
 		 const GSInterlaceMode new_mode = static_cast<GSInterlaceMode>((static_cast<s32>(EmuConfig.GS.InterlaceMode) + 1) % static_cast<s32>(GSInterlaceMode::Count));
-		 Host::AddKeyedFormattedOSDMessage("CycleInterlaceMode", 10.0f, "Deinterlace mode set to '%s'.", option_names[static_cast<s32>(new_mode)]);
+		 Host::AddKeyedFormattedOSDMessage("CycleInterlaceMode", Host::OSD_QUICK_DURATION, "Deinterlace mode set to '%s'.", option_names[static_cast<s32>(new_mode)]);
 		 EmuConfig.GS.InterlaceMode = new_mode;
 
 		 GetMTGS().RunOnGSThread([new_mode]() { GSConfig.InterlaceMode = new_mode; });
@@ -1795,7 +1795,9 @@ BEGIN_HOTKEY_LIST(g_gs_hotkeys)
 		 if (!pressed)
 		 {
 			 EmuConfig.GS.DumpReplaceableTextures = !EmuConfig.GS.DumpReplaceableTextures;
-			 Host::AddKeyedOSDMessage("ToggleTextureReplacements", EmuConfig.GS.DumpReplaceableTextures ? "Texture dumping is now enabled." : "Texture dumping is now disabled.", 10.0f);
+			 Host::AddKeyedOSDMessage("ToggleTextureReplacements",
+				 EmuConfig.GS.DumpReplaceableTextures ? "Texture dumping is now enabled." : "Texture dumping is now disabled.",
+				 Host::OSD_INFO_DURATION);
 			 GetMTGS().ApplySettings();
 		 }
 	 }},
@@ -1803,7 +1805,9 @@ BEGIN_HOTKEY_LIST(g_gs_hotkeys)
 		 if (!pressed)
 		 {
 			 EmuConfig.GS.LoadTextureReplacements = !EmuConfig.GS.LoadTextureReplacements;
-			 Host::AddKeyedOSDMessage("ToggleTextureReplacements", EmuConfig.GS.LoadTextureReplacements ? "Texture replacements are now enabled." : "Texture replacements are now disabled.", 10.0f);
+			 Host::AddKeyedOSDMessage("ToggleTextureReplacements",
+				 EmuConfig.GS.LoadTextureReplacements ? "Texture replacements are now enabled." : "Texture replacements are now disabled.",
+				 Host::OSD_INFO_DURATION);
 			 GetMTGS().ApplySettings();
 		 }
 	 }},
@@ -1812,11 +1816,11 @@ BEGIN_HOTKEY_LIST(g_gs_hotkeys)
 		 {
 			 if (!EmuConfig.GS.LoadTextureReplacements)
 			 {
-				 Host::AddKeyedOSDMessage("ReloadTextureReplacements", "Texture replacements are not enabled.", 10.0f);
+				 Host::AddKeyedOSDMessage("ReloadTextureReplacements", "Texture replacements are not enabled.", Host::OSD_INFO_DURATION);
 			 }
 			 else
 			 {
-				 Host::AddKeyedOSDMessage("ReloadTextureReplacements", "Reloading texture replacements...", 10.0f);
+				 Host::AddKeyedOSDMessage("ReloadTextureReplacements", "Reloading texture replacements...", Host::OSD_INFO_DURATION);
 				 GetMTGS().RunOnGSThread([]() {
 					 GSTextureReplacements::ReloadReplacementMap();
 				 });

--- a/pcsx2/GS/Renderers/Common/GSRenderer.cpp
+++ b/pcsx2/GS/Renderers/Common/GSRenderer.cpp
@@ -694,7 +694,7 @@ void GSRenderer::VSync(u32 field, bool registers_written)
 
 			Host::AddKeyedOSDMessage("GSDump", fmt::format("Saving {0} GS dump {1} to '{2}'",
 				(m_dump_frames == 1) ? "single frame" : "multi-frame", compression_str,
-				Path::GetFileName(m_dump->GetPath())), 10.0f);
+				Path::GetFileName(m_dump->GetPath())), Host::OSD_INFO_DURATION);
 		}
 
 		if (GSTexture* t = g_gs_device->GetCurrent())
@@ -703,11 +703,11 @@ void GSRenderer::VSync(u32 field, bool registers_written)
 			if (t->Save(path))
 			{
 				Host::AddKeyedOSDMessage("GSScreenshot",
-					fmt::format("Screenshot saved to '{}'.", Path::GetFileName(path)), 10.0f);
+					fmt::format("Screenshot saved to '{}'.", Path::GetFileName(path)), Host::OSD_INFO_DURATION);
 			}
 			else
 			{
-				Host::AddFormattedOSDMessage(10.0f, "Failed to save screenshot to '%s'.", path.c_str());
+				Host::AddFormattedOSDMessage(Host::OSD_ERROR_DURATION, "Failed to save screenshot to '%s'.", path.c_str());
 			}
 		}
 
@@ -718,7 +718,7 @@ void GSRenderer::VSync(u32 field, bool registers_written)
 		const bool last = (m_dump_frames == 0);
 		if (m_dump->VSync(field, last, m_regs))
 		{
-			Host::AddKeyedOSDMessage("GSDump", fmt::format("Saved GS dump to '{}'.", Path::GetFileName(m_dump->GetPath())), 10.0f);
+			Host::AddKeyedOSDMessage("GSDump", fmt::format("Saved GS dump to '{}'.", Path::GetFileName(m_dump->GetPath())), Host::OSD_INFO_DURATION);
 			m_dump.reset();
 		}
 		else if (!last)

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -214,7 +214,7 @@ void GSRendererHW::VSync(u32 field, bool registers_written)
 
 	if (m_tc->GetHashCacheMemoryUsage() > 1024 * 1024 * 1024)
 	{
-		Host::AddKeyedFormattedOSDMessage("HashCacheOverflow", 15.0f, "Hash cache has used %.2f MB of VRAM, disabling.",
+		Host::AddKeyedFormattedOSDMessage("HashCacheOverflow", Host::OSD_ERROR_DURATION, "Hash cache has used %.2f MB of VRAM, disabling.",
 			static_cast<float>(m_tc->GetHashCacheMemoryUsage()) / 1048576.0f);
 		m_tc->RemoveAll();
 		g_gs_device->PurgePool();

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
@@ -295,7 +295,8 @@ bool GSDeviceVK::CheckFeatures()
 	if (!m_features.texture_barrier && !m_features.stencil_buffer)
 	{
 		Host::AddKeyedOSDMessage("GSDeviceVK_NoTextureBarrierOrStencilBuffer",
-			"Stencil buffers and texture barriers are both unavailable, this will break some graphical effects.", 10.0f);
+			"Stencil buffers and texture barriers are both unavailable, this will break some graphical effects.",
+			Host::OSD_WARNING_DURATION);
 	}
 
 	return true;
@@ -469,7 +470,8 @@ bool GSDeviceVK::DownloadTexture(GSTexture* src, const GSVector4i& rect, GSTextu
 		{
 			m_warned_slow_spin = true;
 			Host::AddKeyedOSDMessage("GSDeviceVK_NoCalibratedTimestamps",
-				"Spin GPU During Readbacks is enabled, but calibrated timestamps are unavailable.  This might be really slow.", 10.0f);
+				"Spin GPU During Readbacks is enabled, but calibrated timestamps are unavailable.  This might be really slow.",
+				Host::OSD_WARNING_DURATION);
 		}
 	}
 

--- a/pcsx2/GameDatabase.cpp
+++ b/pcsx2/GameDatabase.cpp
@@ -677,7 +677,7 @@ u32 GameDatabaseSchema::GameEntry::applyGSHardwareFixes(Pcsx2Config::GSOptions& 
 		Host::AddKeyedOSDMessage("HWFixesWarning",
 			fmt::format("Manual GS hardware renderer fixes are enabled, automatic fixes were not applied:\n{}",
 				disabled_fixes),
-			10.0f);
+			Host::OSD_ERROR_DURATION);
 	}
 	else
 	{

--- a/pcsx2/Host.h
+++ b/pcsx2/Host.h
@@ -46,6 +46,13 @@ struct HostKeyEvent
 
 namespace Host
 {
+	/// Typical durations for OSD messages.
+	static constexpr float OSD_CRITICAL_ERROR_DURATION = 20.0f;
+	static constexpr float OSD_ERROR_DURATION = 15.0f;
+	static constexpr float OSD_WARNING_DURATION = 10.0f;
+	static constexpr float OSD_INFO_DURATION = 5.0f;
+	static constexpr float OSD_QUICK_DURATION = 2.5f;
+
 	/// Reads a file from the resources directory of the application.
 	/// This may be outside of the "normal" filesystem on platforms such as Mac.
 	std::optional<std::vector<u8>> ReadResourceFile(const char* filename);

--- a/pcsx2/MTGS.cpp
+++ b/pcsx2/MTGS.cpp
@@ -28,6 +28,7 @@
 
 #include "Host.h"
 #include "HostDisplay.h"
+#include "IconsFontAwesome5.h"
 
 #ifndef PCSX2_CORE
 #include "gui/Dialogs/ModalPopups.h"
@@ -986,8 +987,8 @@ void SysMtgsThread::SwitchRenderer(GSRendererType renderer, bool display_message
 
 	if (display_message)
 	{
-		Host::AddKeyedFormattedOSDMessage("SwitchRenderer", 10.0f, "Switching to %s renderer...",
-			Pcsx2Config::GSOptions::GetRendererName(renderer));
+		Host::AddIconOSDMessage("SwitchRenderer", ICON_FA_MAGIC, fmt::format("Switching to {} renderer...",
+			Pcsx2Config::GSOptions::GetRendererName(renderer)), Host::OSD_INFO_DURATION);
 	}
 
 	RunOnGSThread([renderer]() {

--- a/pcsx2/MemoryCardFile.cpp
+++ b/pcsx2/MemoryCardFile.cpp
@@ -537,7 +537,8 @@ s32 FileMemoryCard::Save(uint slot, const u8* src, u32 adr, int size)
 		if (elapsed > std::chrono::seconds(5))
 		{
 			Host::AddIconOSDMessage(fmt::format("MemoryCardSave{}", slot), ICON_FA_SD_CARD,
-				fmt::format("Memory card '{}' was saved to storage.", Path::GetFileName(m_filenames[slot])), 10.0f);
+				fmt::format("Memory card '{}' was saved to storage.", Path::GetFileName(m_filenames[slot])),
+				Host::OSD_INFO_DURATION);
 			last = std::chrono::system_clock::now();
 		}
 		return 1;

--- a/pcsx2/MemoryCardFolder.cpp
+++ b/pcsx2/MemoryCardFolder.cpp
@@ -1728,7 +1728,7 @@ void FolderMemoryCard::SetTimeLastReadToNow()
 void FolderMemoryCard::SetTimeLastWrittenToNow()
 {
 	// CHANGE: this was local time milliseconds, which might be problematic...
-	m_timeLastWritten = std::time(nullptr);// wxGetLocalTimeMillis().GetValue();
+	m_timeLastWritten = std::time(nullptr); // wxGetLocalTimeMillis().GetValue();
 	m_framesUntilFlush = FramesAfterWriteUntilFlush;
 }
 
@@ -2080,7 +2080,7 @@ void FileAccessHelper::WriteIndex(const std::string& baseFolderName, MemoryCardF
 	}
 	else
 	{
-		Console.Warning(fmt::format("(FileAccesHelper::WriteIndex()) '{}' has null parent",Path::Combine(baseFolderName,(const char*)entry->entry.data.name)));
+		Console.Warning(fmt::format("(FileAccesHelper::WriteIndex()) '{}' has null parent", Path::Combine(baseFolderName, (const char*)entry->entry.data.name)));
 	}
 
 	char cleanName[sizeof(entry->entry.data.name)];
@@ -2352,7 +2352,7 @@ s32 FolderMemoryCardAggregator::Save(uint slot, const u8* src, u32 adr, int size
 	{
 		const std::string_view filename = Path::GetFileName(m_cards[slot].GetFolderName());
 		Host::AddIconOSDMessage(fmt::format("MemoryCardSave{}", slot), ICON_FA_SD_CARD,
-			fmt::format("Memory card '{}' was saved to storage.", filename), 10.0f);
+			fmt::format("Memory card '{}' was saved to storage.", filename), Host::OSD_INFO_DURATION);
 	}
 
 	return saveResult;

--- a/pcsx2/Sio.cpp
+++ b/pcsx2/Sio.cpp
@@ -27,6 +27,7 @@
 
 #include "common/Timer.h"
 #include "Recording/InputRecording.h"
+#include "IconsFontAwesome5.h"
 
 #define SIO0LOG_ENABLE 0
 #define SIO2LOG_ENABLE 0
@@ -954,7 +955,7 @@ void AutoEject::Clear(size_t port, size_t slot)
 
 void AutoEject::SetAll()
 {
-	Host::AddKeyedFormattedOSDMessage("AutoEjectAllSet", 10.0f, "Force ejecting all memory cards");
+	Host::AddIconOSDMessage("AutoEjectAllSet", ICON_FA_SD_CARD, "Force ejecting all memory cards.", Host::OSD_INFO_DURATION);
 
 	for (size_t port = 0; port < SIO::PORTS; port++)
 	{

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -421,7 +421,7 @@ void VMManager::RequestDisplaySize(float scale /*= 0.0f*/)
 bool VMManager::UpdateGameSettingsLayer()
 {
 	std::unique_ptr<INISettingsInterface> new_interface;
-	if (s_game_crc != 0)
+	if (s_game_crc != 0 && Host::GetBaseBoolSettingValue("EmuCore", "EnablePerGameSettings", true))
 	{
 		std::string filename(GetGameSettingsPath(s_game_serial.c_str(), s_game_crc));
 		if (!FileSystem::FileExists(filename.c_str()))


### PR DESCRIPTION
### Description of Changes

 - Fix Enable Per-Game Settings 
 - Make OSD message timing consistent for categories of messages
 - Add option to reset play time for games

### Rationale behind Changes

QOL/consistency improvements.

### Suggested Testing Steps

Test stuff mentioned in list above.
