### PR TITLE
Qt: Add -testconfig option

### DIFF
--- a/pcsx2/MTVU.h
+++ b/pcsx2/MTVU.h
@@ -66,6 +66,7 @@ public:
 	~VU_Thread();
 
 	__fi const Threading::ThreadHandle& GetThreadHandle() const { return m_thread; }
+	__fi bool IsOpen() const { return m_thread.Joinable(); }
 
 	/// Ensures the VU thread is started.
 	void Open();

--- a/pcsx2/x86/microVU.cpp
+++ b/pcsx2/x86/microVU.cpp
@@ -381,7 +381,8 @@ void recMicroVU0::Shutdown()
 }
 void recMicroVU1::Shutdown()
 {
-	vu1Thread.WaitVU();
+	if (vu1Thread.IsOpen())
+		vu1Thread.WaitVU();
 	mVUclose(microVU1);
 }
 


### PR DESCRIPTION
### Description of Changes

Option will create configuration (if non-existent), and then immediately exit.

### Rationale behind Changes

Can be used to set up the default configuration and directory structure, without fully starting PCSX2.

### Suggested Testing Steps

Test CLI option (already done myself - but you can run it in a new extracted copy, it should create inis etc).