### PR TITLE
gui-wx: Add FidelityFX CAS support to wxwidgets gui.

### DIFF
--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -1446,7 +1446,7 @@ void GSApp::Init()
 	m_default_configuration["DumpPaletteTextures"]                        = "1";
 	m_default_configuration["extrathreads"]                               = "2";
 	m_default_configuration["extrathreads_height"]                        = "4";
-	m_default_configuration["filter"]                                     = std::to_string(static_cast<s8>(BiFiltering::PS2));
+	m_default_configuration["filter"]                                     = std::to_string(static_cast<u8>(BiFiltering::PS2));
 	m_default_configuration["FullscreenMode"]                             = "";
 	m_default_configuration["fxaa"]                                       = "0";
 	m_default_configuration["HWDownloadMode"]                             = std::to_string(static_cast<u8>(GSHardwareDownloadMode::Enabled));

--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -1403,6 +1403,10 @@ void GSApp::Init()
 	m_gs_tv_shaders.push_back(GSSetting(4, "Wave filter", ""));
 	m_gs_tv_shaders.push_back(GSSetting(5, "Lottes CRT filter", ""));
 
+	m_gs_casmode.push_back(GSSetting(static_cast<u32>(GSCASMode::Disabled), "Disabled", ""));
+	m_gs_casmode.push_back(GSSetting(static_cast<u32>(GSCASMode::SharpenOnly), "Sharpen Only", "Internal Resolution"));
+	m_gs_casmode.push_back(GSSetting(static_cast<u32>(GSCASMode::SharpenAndResize), "Sharpen And Resize", "Display Resolution"));
+
 	m_gs_hw_download_mode.push_back(GSSetting(static_cast<u32>(GSHardwareDownloadMode::Enabled), "Accurate", "Recommended"));
 	m_gs_hw_download_mode.push_back(GSSetting(static_cast<u32>(GSHardwareDownloadMode::NoReadbacks), "Disable Readbacks", "Synchronize GS Thread"));
 	m_gs_hw_download_mode.push_back(GSSetting(static_cast<u32>(GSHardwareDownloadMode::Unsynchronized), "Unsynchronized", "Non-Deterministic"));
@@ -1508,6 +1512,8 @@ void GSApp::Init()
 	m_default_configuration["ThreadedPresentation"]                       = "0";
 	m_default_configuration["TriFilter"]                                  = std::to_string(static_cast<s8>(TriFiltering::Automatic));
 	m_default_configuration["TVShader"]                                   = "0";
+	m_default_configuration["CASMode"]                                    = std::to_string(static_cast<u8>(GSCASMode::Disabled));
+	m_default_configuration["CASSharpness"]                               = "50";
 	m_default_configuration["upscale_multiplier"]                         = "1";
 	m_default_configuration["UseBlitSwapChain"]                           = "0";
 	m_default_configuration["UseDebugDevice"]                             = "0";

--- a/pcsx2/GS/GS.h
+++ b/pcsx2/GS/GS.h
@@ -143,6 +143,7 @@ public:
 	std::vector<GSSetting> m_gs_crc_level;
 	std::vector<GSSetting> m_gs_acc_blend_level;
 	std::vector<GSSetting> m_gs_tv_shaders;
+	std::vector<GSSetting> m_gs_casmode;
 	std::vector<GSSetting> m_gs_hw_download_mode;
 	std::vector<GSSetting> m_gs_dump_compression;
 };

--- a/pcsx2/GS/Window/GSwxDialog.cpp
+++ b/pcsx2/GS/Window/GSwxDialog.cpp
@@ -462,19 +462,43 @@ PostTab::PostTab(wxWindow* parent)
 {
 	const int space = wxSizerFlags().Border().GetBorderInPixels();
 	PaddedBoxSizer<wxBoxSizer> tab_box(wxVERTICAL);
-	PaddedBoxSizer<wxStaticBoxSizer> shader_box(wxVERTICAL, this, "Custom Shader");
-
-	auto not_vk_prereq = [this] { return !m_is_vk_hw; };
+	PaddedBoxSizer<wxStaticBoxSizer> shader_box(wxVERTICAL, this, "Shader Options");
 	
-	PaddedBoxSizer<wxStaticBoxSizer> tex_filter_box(wxVERTICAL, this, "Debug");
-	auto* tex_filter_grid_box = new wxFlexGridSizer(2, space, space);
+	// Bilinear filtering
+	auto* bil_filter_grid_box = new wxFlexGridSizer(2, space, space);
+	bil_filter_grid_box->AddGrowableCol(1);
 
-	m_ui.addComboBoxAndLabel(tex_filter_grid_box, "Texture Filtering of Display:", "linear_present_mode", &theApp.m_gs_tex_display_list, IDC_LINEAR_PRESENT);
+	m_ui.addComboBoxAndLabel(bil_filter_grid_box, "Bilinear Filtering:", "linear_present_mode", &theApp.m_gs_tex_display_list, IDC_LINEAR_PRESENT);
 
-	m_ui.addCheckBox(shader_box.inner, "FXAA Shader (PgUp)",           "fxaa",           IDC_FXAA);
+	shader_box->Add(bil_filter_grid_box, wxSizerFlags().Expand());
 
+	// Sharpening, fxaa
+	PaddedBoxSizer<wxStaticBoxSizer> sharpening_box(wxVERTICAL, this, "Sharpening/Anti-aliasing");
+	auto* casmode_grid = new wxFlexGridSizer(2, space, space);
+	casmode_grid->AddGrowableCol(1);
+
+	m_ui.addComboBoxAndLabel(casmode_grid, "Contrast Adaptive Sharpening:", "CASMode", &theApp.m_gs_casmode);
+
+	sharpening_box->Add(casmode_grid, wxSizerFlags().Expand());
+
+	auto* sharpness_grid = new wxFlexGridSizer(2, space, space);
+	sharpness_grid->AddGrowableCol(1);
+
+	m_ui.addSliderAndLabel(sharpness_grid, "Sharpness:", "CASSharpness", 0, 100, 50, -1);
+
+	sharpening_box->Add(sharpness_grid, wxSizerFlags().Expand());
+
+	auto* fxaa_grid = new wxFlexGridSizer(2, space, space);
+	fxaa_grid->AddGrowableCol(1);
+
+	m_ui.addCheckBox(fxaa_grid, "FXAA (PgUp)", "fxaa", IDC_FXAA);
+
+	sharpening_box->Add(fxaa_grid, wxSizerFlags().Expand());
+
+	shader_box->Add(sharpening_box.outer, wxSizerFlags().Expand());
+
+	// Shade boost
 	CheckboxPrereq shade_boost_check(m_ui.addCheckBox(shader_box.inner, "Enable Shade Boost", "ShadeBoost", IDC_SHADEBOOST));
-
 	PaddedBoxSizer<wxStaticBoxSizer> shade_boost_box(wxVERTICAL, this, "Shade Boost");
 	auto* shader_boost_grid = new wxFlexGridSizer(2, space, space);
 	shader_boost_grid->AddGrowableCol(1);
@@ -484,16 +508,17 @@ PostTab::PostTab(wxWindow* parent)
 	m_ui.addSliderAndLabel(shader_boost_grid, "Saturation:", "ShadeBoost_Saturation", 0, 100, 50, -1, shade_boost_check);
 
 	shade_boost_box->Add(shader_boost_grid, wxSizerFlags().Expand());
-	shader_box->Add(tex_filter_grid_box, wxSizerFlags().Expand());
 	shader_box->Add(shade_boost_box.outer, wxSizerFlags().Expand());
 
+	// External shader
+	auto not_vk_prereq = [this] { return !m_is_vk_hw; };
 	CheckboxPrereq ext_shader_check(m_ui.addCheckBox(shader_box.inner, "Enable External Shader", "shaderfx", IDC_SHADER_FX, not_vk_prereq));
-
 	PaddedBoxSizer<wxStaticBoxSizer> ext_shader_box(wxVERTICAL, this, "External Shader (Home)");
+
 	auto* ext_shader_grid = new wxFlexGridSizer(2, space, space);
 	ext_shader_grid->AddGrowableCol(1);
-
 	auto shaderext_prereq = [ext_shader_check, this] { return !m_is_vk_hw && ext_shader_check.box->GetValue(); };
+
 	m_ui.addFilePickerAndLabel(ext_shader_grid, "GLSL fx File:", "shaderfx_glsl", -1, shaderext_prereq);
 	m_ui.addFilePickerAndLabel(ext_shader_grid, "Config File:",  "shaderfx_conf", -1, shaderext_prereq);
 
@@ -503,9 +528,12 @@ PostTab::PostTab(wxWindow* parent)
 	// TV Shader
 	auto* tv_box = new wxFlexGridSizer(2, space, space);
 	tv_box->AddGrowableCol(1);
+
 	m_ui.addComboBoxAndLabel(tv_box, "TV Shader:", "TVShader", &theApp.m_gs_tv_shaders);
+
 	shader_box->Add(tv_box, wxSizerFlags().Expand());
 	tab_box->Add(shader_box.outer, wxSizerFlags().Expand());
+
 	SetSizerAndFit(tab_box.outer);
 }
 


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
gui-wx: Add default configs for CAS filtering.

gui-wx: Add FidelityFX CAS support.
Add FidelityFX CAS support to wxwidgets.
Rename Texture Filtering of Display to Bilinear filtering.
Remove Debug box.
Misc cleanup.
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Parity with Qt.
Fixes #7451
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Check if CAS works on wx.