### PR TITLE
GS: Combine dirty rects when having matching edges

### DIFF
--- a/pcsx2/GS/Renderers/Common/GSDirtyRect.cpp
+++ b/pcsx2/GS/Renderers/Common/GSDirtyRect.cpp
@@ -23,14 +23,14 @@ GSDirtyRect::GSDirtyRect() :
 {
 }
 
-GSDirtyRect::GSDirtyRect(const GSVector4i& r, const u32 psm, const u32 bw) :
+GSDirtyRect::GSDirtyRect(GSVector4i& r, u32 psm, u32 bw) :
 	r(r),
 	psm(psm),
 	bw(bw)
 {
 }
 
-const GSVector4i GSDirtyRect::GetDirtyRect(const GIFRegTEX0& TEX0) const
+GSVector4i GSDirtyRect::GetDirtyRect(GIFRegTEX0& TEX0)
 {
 	GSVector4i _r;
 
@@ -55,13 +55,13 @@ const GSVector4i GSDirtyRect::GetDirtyRect(const GIFRegTEX0& TEX0) const
 
 //
 
-const GSVector4i GSDirtyRectList::GetDirtyRect(const GIFRegTEX0& TEX0, const GSVector2i& size) const
+GSVector4i GSDirtyRectList::GetDirtyRect(GIFRegTEX0& TEX0, const GSVector2i& size)
 {
 	if (!empty())
 	{
 		GSVector4i r(INT_MAX, INT_MAX, 0, 0);
 
-		for (const auto& dirty_rect : *this)
+		for (auto& dirty_rect : *this)
 		{
 			r = r.runion(dirty_rect.GetDirtyRect(TEX0));
 		}
@@ -74,9 +74,9 @@ const GSVector4i GSDirtyRectList::GetDirtyRect(const GIFRegTEX0& TEX0, const GSV
 	return GSVector4i::zero();
 }
 
-const GSVector4i GSDirtyRectList::GetDirtyRectAndClear(const GIFRegTEX0& TEX0, const GSVector2i& size)
+GSVector4i GSDirtyRectList::GetDirtyRectAndClear(GIFRegTEX0& TEX0, const GSVector2i& size)
 {
-	const GSVector4i r = GetDirtyRect(TEX0, size);
+	GSVector4i r = GetDirtyRect(TEX0, size);
 	clear();
 	return r;
 }

--- a/pcsx2/GS/Renderers/Common/GSDirtyRect.h
+++ b/pcsx2/GS/Renderers/Common/GSDirtyRect.h
@@ -20,19 +20,19 @@
 class GSDirtyRect
 {
 public:
-	const GSVector4i r;
-	const u32 psm;
-	const u32 bw;
+	GSVector4i r;
+	u32 psm;
+	u32 bw;
 
 	GSDirtyRect();
-	GSDirtyRect(const GSVector4i& r, const u32 psm, const u32 bw);
-	const GSVector4i GetDirtyRect(const GIFRegTEX0& TEX0) const;
+	GSDirtyRect(GSVector4i& r, u32 psm, u32 bw);
+	GSVector4i GetDirtyRect(GIFRegTEX0& TEX0);
 };
 
 class GSDirtyRectList : public std::vector<GSDirtyRect>
 {
 public:
 	GSDirtyRectList() {}
-	const GSVector4i GetDirtyRect(const GIFRegTEX0& TEX0, const GSVector2i& size) const;
-	const GSVector4i GetDirtyRectAndClear(const GIFRegTEX0& TEX0, const GSVector2i& size);
+	GSVector4i GetDirtyRect(GIFRegTEX0& TEX0, const GSVector2i& size);
+	GSVector4i GetDirtyRectAndClear(GIFRegTEX0& TEX0, const GSVector2i& size);
 };

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.h
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.h
@@ -198,7 +198,7 @@ public:
 
 	GSTexture* GetOutput(int i, int& y_offset) override;
 	GSTexture* GetFeedbackOutput() override;
-	void ExpandTarget(const GIFRegBITBLTBUF& BITBLTBUF, const GSVector4i& r);
+	void ExpandTarget(const GIFRegBITBLTBUF& BITBLTBUF, const GSVector4i& r) override;
 	void InvalidateVideoMem(const GIFRegBITBLTBUF& BITBLTBUF, const GSVector4i& r, bool eewrite = false) override;
 	void InvalidateLocalMem(const GIFRegBITBLTBUF& BITBLTBUF, const GSVector4i& r, bool clut = false) override;
 	void Move() override;

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.h
@@ -332,6 +332,7 @@ public:
 	void Read(Source* t, const GSVector4i& r);
 	void RemoveAll();
 	void RemovePartial();
+	void AddDirtyRectTarget(Target* target, GSVector4i rect, u32 psm, u32 bw);
 
 	Source* LookupSource(const GIFRegTEX0& TEX0, const GIFRegTEXA& TEXA, const GSVector4i& r, const GSVector2i* lod);
 	Source* LookupDepthSource(const GIFRegTEX0& TEX0, const GIFRegTEXA& TEXA, const GSVector4i& r, bool palette = false);


### PR DESCRIPTION
### Description of Changes
Attempts to combine dirty rects and skip duplicates

### Rationale behind Changes
before it was YOLO adding dirty rects, so if a game did thousands of tiny draws before it became valid, any surface offset calculations were exceptionally slow due to thousands of dirty rects in the list, further to this, it was compounded by repeat writes to the same location.

### Suggested Testing Steps
test stuff, make sure nothing's bust.

Might slightly lower GS thread usage in some cases, might slightly increase it, nobody knows! spin the wheel of chance to find out!

This was the original problem with Urban Reign, but might have also affected Guitar Hero 3 and others.