### PR TITLE
GS/TextureCache: Better handle batched tiny moves

### DIFF
--- a/pcsx2/GS/Renderers/DX12/GSDevice12.h
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.h
@@ -297,7 +297,7 @@ public:
 	/// Ends any render pass, executes the command buffer, and invalidates cached state.
 	void ExecuteCommandList(bool wait_for_completion);
 	void ExecuteCommandList(bool wait_for_completion, const char* reason, ...);
-	void ExecuteCommandListAndRestartRenderPass(const char* reason);
+	void ExecuteCommandListAndRestartRenderPass(bool wait_for_completion, const char* reason);
 
 	/// Set dirty flags on everything to force re-bind at next draw time.
 	void InvalidateCachedState();

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.h
@@ -93,8 +93,8 @@ public:
 		bool Inside(u32 bp, u32 bw, u32 psm, const GSVector4i& rect);
 		bool Overlaps(u32 bp, u32 bw, u32 psm, const GSVector4i& rect);
 
-		void ResizeTexture(int new_width, int new_height);
-		void ResizeTexture(int new_width, int new_height, GSVector2 new_scale);
+		bool ResizeTexture(int new_width, int new_height, bool recycle_old = true);
+		bool ResizeTexture(int new_width, int new_height, GSVector2 new_scale, bool recycle_old = true);
 	};
 
 	struct PaletteKey

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h
@@ -283,7 +283,7 @@ public:
 	/// Ends any render pass, executes the command buffer, and invalidates cached state.
 	void ExecuteCommandBuffer(bool wait_for_completion);
 	void ExecuteCommandBuffer(bool wait_for_completion, const char* reason, ...);
-	void ExecuteCommandBufferAndRestartRenderPass(const char* reason);
+	void ExecuteCommandBufferAndRestartRenderPass(bool wait_for_completion, const char* reason);
 
 	/// Set dirty flags on everything to force re-bind at next draw time.
 	void InvalidateCachedState();


### PR DESCRIPTION
### Description of Changes

e.g. Dark Cloud's menu.

Also prevents an out-of-VRAM situation from crashing.

Generally improves out-of-VRAM for DX12/Vulkan, instead of immediately failing the allocation, flush the texture pool,
and execute/wait for the command buffer. This will clear out any textures which have already been freed, and the storage can be reused for.

### Rationale behind Changes

VRAM spikes and crashes are bad.

### Suggested Testing Steps

Test Dark Cloud menu.
