### PR TITLE
Common: Fix slow emulator startup on M1

### DIFF
--- a/common/AlignedMalloc.cpp
+++ b/common/AlignedMalloc.cpp
@@ -28,6 +28,11 @@ void* _aligned_malloc(size_t size, size_t align)
 #if defined(__USE_ISOC11) && !defined(ASAN_WORKAROUND) // not supported yet on gcc 4.9
 	return aligned_alloc(align, size);
 #else
+#ifdef __APPLE__
+	// MacOS has a bug where posix_memalign is ridiculously slow on unaligned sizes
+	// This especially bad on M1s for some reason
+	size = (size + align - 1) & ~(align - 1);
+#endif
 	void* result = 0;
 	posix_memalign(&result, align, size);
 	return result;

--- a/pcsx2/x86/newVif_HashBucket.h
+++ b/pcsx2/x86/newVif_HashBucket.h
@@ -137,7 +137,7 @@ public:
 		// Allocate an empty cell for all buckets
 		for (auto& bucket : m_bucket)
 		{
-			if ((bucket = (nVifBlock*)_aligned_malloc(sizeof(nVifBlock), 64)) == nullptr)
+			if ((bucket = (nVifBlock*)_aligned_malloc(sizeof(nVifBlock), 16)) == nullptr)
 			{
 				pxFailRel("Failed to allocate HashBucket Chain on reset");
 			}


### PR DESCRIPTION
### Description of Changes
Fixes an issue where starting games, and loading save states, and turning MTVU on and off were incredibly slow on M1

On M1...
Time to memalign then free 65536 16-byte aligned 64-byte blocks 100 times: 200ms
Time to memalign then free 65536 16-byte aligned 24-byte blocks 100 times: 180ms
Time to memalign then free 65536 64-byte aligned 64-byte blocks 100 times: 700ms
Time to memalign then free 65536 64-byte aligned 24-byte blocks 100 times: 80s

Further testing indicates that a single run of 65536 allocations varies wildly in speed on M1, ranging anywhere from 7ms to 7s. [Test program](https://github.com/PCSX2/pcsx2/files/10088643/memaligntest.cpp.zip), [Log of the speeds of 100 consecutive runs](https://github.com/PCSX2/pcsx2/files/10088503/results.txt)

On a horribly slow atom computer running Linux:
Time to memalign then free 65536 16-byte aligned 64-byte blocks 100 times: 1.1s
Time to memalign then free 65536 16-byte aligned 24-byte blocks 100 times: 800ms
Time to memalign then free 65536 64-byte aligned 64-byte blocks 100 times: 3.8s
Time to memalign then free 65536 64-byte aligned 24-byte blocks 100 times: 5.7s

### Rationale behind Changes
Not being incredibly slow is nice

### Suggested Testing Steps
Try starting games, loading save states, and turning MTVU on and off on M1
