### PR TITLE
AppImage: Don't change current working directory

### DIFF
--- a/.github/workflows/scripts/linux/AppRun-qt
+++ b/.github/workflows/scripts/linux/AppRun-qt
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-cd "$(dirname "$0")"
-exec ./usr/bin/pcsx2-qt "$@"
+APPDIR=$(dirname "$0")
+exec "$APPDIR/usr/bin/pcsx2-qt" "$@"


### PR DESCRIPTION
### Description of Changes

Prevents relative paths from working.

### Rationale behind Changes

Should make relative paths work.

### Suggested Testing Steps

Test AppImage + CLI.
