### PR TITLE
Formatting: return editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,30 @@
+# EditorConfig: http://EditorConfig.org
+
+# Top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+
+# Tab indentation
+[*.{cpp,h,js,cmake,mm,inl,in}]
+indent_style = tab
+
+# 1 space
+[*.{ui}]
+indent_style = space
+indent_size = 1
+
+# 2 space
+[*.{js,xml,c,py,asm,cmd,nsi,nsh,tex}]
+indent_style = space
+indent_size = 2
+
+# 4 space
+[*.{sh,pl}]
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
reverts #3995

### Description of Changes
Provide `Editor-config` configuration.

### Rationale behind Changes
`Editorconfig` covers more than `clang-format` and is safer. Clang-format only supports C style files (like .c, .cpp, .h, .hpp), while Editorconfig supports any text file.
When using macros like
```
// clang-format off
...
// clang-format on
```
code between these 2 macroses will be completely unchecked, but editor-config still can make simple code cleaning.
Editor-config is safer and doesn't require checking if the code is still in good condition as it is less sophisticated.
All that it does:
- remove trailing tabs and spaces
- converts line endings into one format
- inserts a final newline
- remove non-utf-8 characters

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
