### PR TITLE
GameDB: Set texture preloading to Partial for Espagaluda

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -36889,6 +36889,8 @@ SLPS-25352:
   name: "Espgaluda"
   region: "NTSC-J"
   compat: 5
+  gsHWFixes:
+    texturePreloading: 1 # Performs much better with partial preload.
 SLPS-25353:
   name: "Xenosaga Freaks"
   region: "NTSC-J"


### PR DESCRIPTION
### Description of Changes
Setts texture preloading to partial to almost double the speed of the game because it's stupid and seems to absolutely destroy the HC.

### Rationale behind Changes
Choo choo

### Suggested Testing Steps
Make sure CI is happy
