### PR TITLE
GameDB: Fix incorrect name of SLPM-65140

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -27230,7 +27230,7 @@ SLPM-65139:
   region: "NTSC-J"
   compat: 5
 SLPM-65140:
-  name: "Jojo's Bizarre Adventure 5"
+  name: "Jojo no Kimyou na Bouken - Ougon no Kaze"
   region: "NTSC-J"
 SLPM-65141:
   name: "Tsuzuse Gareijiri"


### PR DESCRIPTION
### Description of Changes
Fixes an incorrect game name.

### Rationale behind Changes
Having the wrong name is gross.

### Suggested Testing Steps
Make sure CI is happy.
