### PR TITLE
CDVD: Don't account for rotation if sectors are buffered

### DIFF
--- a/pcsx2/CDVD/CDVD.cpp
+++ b/pcsx2/CDVD/CDVD.cpp
@@ -1364,13 +1364,18 @@ static uint cdvdStartSeek(uint newsector, CDVD_MODE_TYPE mode)
 		}
 		else
 		{
-			psxRegs.interrupt &= ~(1 << IopEvt_CdvdSectorReady);
-			cdvd.nextSectorsBuffered = 0;
+			if (delta >= cdvd.nextSectorsBuffered)
+			{
+				psxRegs.interrupt &= ~(1 << IopEvt_CdvdSectorReady);
+				cdvd.nextSectorsBuffered = 0;
+			}
+			else
+				cdvd.nextSectorsBuffered -= delta;
 		}
 	}
 
 	// Only do this on reads, the seek kind of accounts for this and then it reads the sectors after
-	if ((delta || cdvd.Action == cdvdAction_Seek) && !isSeeking)
+	if ((delta || cdvd.Action == cdvdAction_Seek) && !isSeeking && !cdvd.nextSectorsBuffered)
 	{
 		const u32 rotationalLatency = cdvdRotationalLatency((CDVD_MODE_TYPE)cdvdIsDVD());
 		//DevCon.Warning("%s rotational latency at sector %d is %d cycles", (cdvd.SpindlCtrl & CDVD_SPINDLE_CAV) ? "CAV" : "CLV", cdvd.SeekToSector, rotationalLatency);


### PR DESCRIPTION
### Description of Changes
Skips calculating rotational latency if the requested sector is already buffered

### Rationale behind Changes
No need to wait for rotation when it's buffered the sectors already, will kind of happen in async. Was breaking videos in Godzilla - Save the Earth.

### Suggested Testing Steps
Test CDVD Timing sensitive games make sure nothing is worse, yadda yadda, remind me never to emulate a system with a CD/DVD drive again, thanks.

Fixes Godzilla - Save the Earth video skipping problems.