### PR TITLE
GameDB: Remove blit from PAL being dumb

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -17597,8 +17597,6 @@ SLES-53702:
   name: "Resident Evil 4"
   region: "PAL-M5"
   compat: 5
-  gameFixes:
-    - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
 SLES-53703:
@@ -17799,8 +17797,6 @@ SLES-53755:
 SLES-53756:
   name: "Resident Evil 4"
   region: "PAL-M5"
-  gameFixes:
-    - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
 SLES-53758:


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
The gamefix works well for NTSC, but I had added blit to every version of resident evil doing wrong fixes which were meant for Silent Hill 4 and forget this part where it only gives 10 FPS instead of more.

![image](https://user-images.githubusercontent.com/24227051/204071411-82b45b71-be41-4463-8e3c-fabbe6e2cf9d.png)

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Fix visual issue
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test Resident evil 4 PAL versions