### PR TITLE
Better SDL Hints

### DIFF
--- a/common/SettingsInterface.h
+++ b/common/SettingsInterface.h
@@ -47,6 +47,9 @@ public:
 	virtual bool RemoveFromStringList(const char* section, const char* key, const char* item) = 0;
 	virtual bool AddToStringList(const char* section, const char* key, const char* item) = 0;
 
+	virtual std::vector<std::pair<std::string, std::string>> GetKeyValueList(const char* section) const = 0;
+	virtual void SetKeyValueList(const char* section, const std::vector<std::pair<std::string, std::string>>& items) = 0;
+
 	virtual bool ContainsValue(const char* section, const char* key) const = 0;
 	virtual void DeleteValue(const char* section, const char* key) = 0;
 	virtual void ClearSection(const char* section) = 0;
@@ -216,5 +219,10 @@ public:
 			SetStringList(section, key, value);
 		else
 			DeleteValue(section, key);
+	}
+
+	__fi void CopyKeysAndValues(const SettingsInterface& si, const char* section)
+	{
+		SetKeyValueList(section, si.GetKeyValueList(section));
 	}
 };

--- a/pcsx2/Frontend/LayeredSettingsInterface.cpp
+++ b/pcsx2/Frontend/LayeredSettingsInterface.cpp
@@ -37,7 +37,7 @@ bool LayeredSettingsInterface::GetIntValue(const char* section, const char* key,
 {
 	for (u32 layer = FIRST_LAYER; layer <= LAST_LAYER; layer++)
 	{
-		if (SettingsInterface* sif = m_layers[layer]; sif != nullptr)
+		if (SettingsInterface* sif = m_layers[layer])
 		{
 			if (sif->GetIntValue(section, key, value))
 				return true;
@@ -51,7 +51,7 @@ bool LayeredSettingsInterface::GetUIntValue(const char* section, const char* key
 {
 	for (u32 layer = FIRST_LAYER; layer <= LAST_LAYER; layer++)
 	{
-		if (SettingsInterface* sif = m_layers[layer]; sif != nullptr)
+		if (SettingsInterface* sif = m_layers[layer])
 		{
 			if (sif->GetUIntValue(section, key, value))
 				return true;
@@ -65,7 +65,7 @@ bool LayeredSettingsInterface::GetFloatValue(const char* section, const char* ke
 {
 	for (u32 layer = FIRST_LAYER; layer <= LAST_LAYER; layer++)
 	{
-		if (SettingsInterface* sif = m_layers[layer]; sif != nullptr)
+		if (SettingsInterface* sif = m_layers[layer])
 		{
 			if (sif->GetFloatValue(section, key, value))
 				return true;
@@ -79,7 +79,7 @@ bool LayeredSettingsInterface::GetDoubleValue(const char* section, const char* k
 {
 	for (u32 layer = FIRST_LAYER; layer <= LAST_LAYER; layer++)
 	{
-		if (SettingsInterface* sif = m_layers[layer]; sif != nullptr)
+		if (SettingsInterface* sif = m_layers[layer])
 		{
 			if (sif->GetDoubleValue(section, key, value))
 				return true;
@@ -93,7 +93,7 @@ bool LayeredSettingsInterface::GetBoolValue(const char* section, const char* key
 {
 	for (u32 layer = FIRST_LAYER; layer <= LAST_LAYER; layer++)
 	{
-		if (SettingsInterface* sif = m_layers[layer]; sif != nullptr)
+		if (SettingsInterface* sif = m_layers[layer])
 		{
 			if (sif->GetBoolValue(section, key, value))
 				return true;
@@ -107,7 +107,7 @@ bool LayeredSettingsInterface::GetStringValue(const char* section, const char* k
 {
 	for (u32 layer = FIRST_LAYER; layer <= LAST_LAYER; layer++)
 	{
-		if (SettingsInterface* sif = m_layers[layer]; sif != nullptr)
+		if (SettingsInterface* sif = m_layers[layer])
 		{
 			if (sif->GetStringValue(section, key, value))
 				return true;
@@ -151,7 +151,7 @@ bool LayeredSettingsInterface::ContainsValue(const char* section, const char* ke
 {
 	for (u32 layer = FIRST_LAYER; layer <= LAST_LAYER; layer++)
 	{
-		if (SettingsInterface* sif = m_layers[layer]; sif != nullptr)
+		if (SettingsInterface* sif = m_layers[layer])
 		{
 			if (sif->ContainsValue(key, section))
 				return true;
@@ -176,7 +176,7 @@ std::vector<std::string> LayeredSettingsInterface::GetStringList(const char* sec
 
 	for (u32 layer = FIRST_LAYER; layer <= LAST_LAYER; layer++)
 	{
-		if (SettingsInterface* sif = m_layers[layer]; sif != nullptr)
+		if (SettingsInterface* sif = m_layers[layer])
 		{
 			ret = sif->GetStringList(section, key);
 			if (!ret.empty())

--- a/pcsx2/Frontend/LayeredSettingsInterface.h
+++ b/pcsx2/Frontend/LayeredSettingsInterface.h
@@ -61,6 +61,9 @@ public:
 	bool RemoveFromStringList(const char* section, const char* key, const char* item) override;
 	bool AddToStringList(const char* section, const char* key, const char* item) override;
 
+	std::vector<std::pair<std::string, std::string>> GetKeyValueList(const char* section) const override;
+	void SetKeyValueList(const char* section, const std::vector<std::pair<std::string, std::string>>& items) override;
+
 	// default parameter overloads
 	using SettingsInterface::GetBoolValue;
 	using SettingsInterface::GetDoubleValue;

--- a/pcsx2/Frontend/SDLInputSource.cpp
+++ b/pcsx2/Frontend/SDLInputSource.cpp
@@ -164,6 +164,15 @@ void SDLInputSource::SetHints()
 {
 	SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_PS4_RUMBLE, m_controller_enhanced_mode ? "1" : "0");
 	SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_PS5_RUMBLE, m_controller_enhanced_mode ? "1" : "0");
+	// Enable Wii U Pro Controller support
+	// New as of SDL 2.26, so use string
+	SDL_SetHint("SDL_JOYSTICK_HIDAPI_WII", "1");
+#ifndef _WIN32
+	// Gets us pressure sensitive button support on Linux
+	// Apparently doesn't work on Windows, so leave it off there
+	// New as of SDL 2.26, so use string
+	SDL_SetHint("SDL_JOYSTICK_HIDAPI_PS3", "1");
+#endif
 }
 
 bool SDLInputSource::InitializeSubsystem()

--- a/pcsx2/Frontend/SDLInputSource.cpp
+++ b/pcsx2/Frontend/SDLInputSource.cpp
@@ -158,6 +158,7 @@ void SDLInputSource::Shutdown()
 void SDLInputSource::LoadSettings(SettingsInterface& si)
 {
 	m_controller_enhanced_mode = si.GetBoolValue("InputSources", "SDLControllerEnhancedMode", false);
+	m_sdl_hints = si.GetKeyValueList("SDLHints");
 }
 
 void SDLInputSource::SetHints()
@@ -173,6 +174,9 @@ void SDLInputSource::SetHints()
 	// New as of SDL 2.26, so use string
 	SDL_SetHint("SDL_JOYSTICK_HIDAPI_PS3", "1");
 #endif
+
+	for (const std::pair<std::string, std::string>& hint : m_sdl_hints)
+		SDL_SetHint(hint.first.c_str(), hint.second.c_str());
 }
 
 bool SDLInputSource::InitializeSubsystem()

--- a/pcsx2/Frontend/SDLInputSource.h
+++ b/pcsx2/Frontend/SDLInputSource.h
@@ -92,4 +92,5 @@ private:
 
 	bool m_sdl_subsystem_initialized = false;
 	bool m_controller_enhanced_mode = false;
+	std::vector<std::pair<std::string, std::string>> m_sdl_hints;
 };

--- a/pcsx2/INISettingsInterface.h
+++ b/pcsx2/INISettingsInterface.h
@@ -58,6 +58,9 @@ public:
 	bool RemoveFromStringList(const char* section, const char* key, const char* item) override;
 	bool AddToStringList(const char* section, const char* key, const char* item) override;
 
+	std::vector<std::pair<std::string, std::string>> GetKeyValueList(const char* section) const override;
+	void SetKeyValueList(const char* section, const std::vector<std::pair<std::string, std::string>>& items) override;
+
 	// default parameter overloads
 	using SettingsInterface::GetBoolValue;
 	using SettingsInterface::GetDoubleValue;

--- a/pcsx2/PAD/Linux/SDL/joystick.cpp
+++ b/pcsx2/PAD/Linux/SDL/joystick.cpp
@@ -42,6 +42,9 @@ void JoystickInfo::EnumerateJoysticks(std::vector<std::unique_ptr<Device>>& vjoy
 		// Super annoying to have a bright blue LED shining in your face all the time
 		// New as of SDL 2.0.18, so use string
 		SDL_SetHint("SDL_JOYSTICK_HIDAPI_SWITCH_HOME_LED", "0");
+		// Enable Wii U Pro Controller support
+		// New as of SDL 2.26, so use string
+		SDL_SetHint("SDL_JOYSTICK_HIDAPI_WII", "1");
 
 		for (const auto& hint : g_conf.sdl2_hints)
 			SDL_SetHint(hint.first.c_str(), hint.second.c_str());

--- a/pcsx2/gui/AppInit.cpp
+++ b/pcsx2/gui/AppInit.cpp
@@ -480,6 +480,7 @@ bool Pcsx2App::OnInit()
 #ifdef SDL_BUILD
 	// MacOS Game Controller framework requires a few runs of the main event loop after interest in game controllers is first indicated to connect controllers
 	// Since OnePad doesn't currently handle connection/disconnection events and requires controllers to be connected on start, we need to initialize SDL before OnePad looks at the controller list
+	SDL_SetHint(SDL_HINT_NO_SIGNAL_HANDLERS, "1");
 	SDL_Init(SDL_INIT_GAMECONTROLLER);
 #endif
 	return true;

--- a/pcsx2/gui/wxSettingsInterface.cpp
+++ b/pcsx2/gui/wxSettingsInterface.cpp
@@ -163,6 +163,17 @@ bool wxSettingsInterface::AddToStringList(const char* section, const char* key, 
 	return false;
 }
 
+std::vector<std::pair<std::string, std::string>> wxSettingsInterface::GetKeyValueList(const char* section) const
+{
+	pxFailRel("Not implemented");
+	return {};
+}
+
+void wxSettingsInterface::SetKeyValueList(const char* section, const std::vector<std::pair<std::string, std::string>>& items)
+{
+	pxFailRel("Not implemented");
+}
+
 bool wxSettingsInterface::ContainsValue(const char* section, const char* key) const
 {
 	CheckPath(section);

--- a/pcsx2/gui/wxSettingsInterface.h
+++ b/pcsx2/gui/wxSettingsInterface.h
@@ -23,39 +23,39 @@
 class wxSettingsInterface : public SettingsInterface
 {
 public:
-  wxSettingsInterface(wxConfigBase* config);
-  ~wxSettingsInterface();
+	wxSettingsInterface(wxConfigBase* config);
+	~wxSettingsInterface();
 
-  bool Save() override;
-  void Clear() override;
+	bool Save() override;
+	void Clear() override;
 
-  bool GetIntValue(const char* section, const char* key, int* value) const override;
-  bool GetUIntValue(const char* section, const char* key, uint* value) const override;
-  bool GetFloatValue(const char* section, const char* key, float* value) const override;
-  bool GetDoubleValue(const char* section, const char* key, double* value) const override;
-  bool GetBoolValue(const char* section, const char* key, bool* value) const override;
-  bool GetStringValue(const char* section, const char* key, std::string* value) const override;
+	bool GetIntValue(const char* section, const char* key, int* value) const override;
+	bool GetUIntValue(const char* section, const char* key, uint* value) const override;
+	bool GetFloatValue(const char* section, const char* key, float* value) const override;
+	bool GetDoubleValue(const char* section, const char* key, double* value) const override;
+	bool GetBoolValue(const char* section, const char* key, bool* value) const override;
+	bool GetStringValue(const char* section, const char* key, std::string* value) const override;
 
-  void SetIntValue(const char* section, const char* key, int value) override;
-  void SetUIntValue(const char* section, const char* key, uint value) override;
-  void SetFloatValue(const char* section, const char* key, float value) override;
-  void SetDoubleValue(const char* section, const char* key, double value) override;
-  void SetBoolValue(const char* section, const char* key, bool value) override;
+	void SetIntValue(const char* section, const char* key, int value) override;
+	void SetUIntValue(const char* section, const char* key, uint value) override;
+	void SetFloatValue(const char* section, const char* key, float value) override;
+	void SetDoubleValue(const char* section, const char* key, double value) override;
+	void SetBoolValue(const char* section, const char* key, bool value) override;
 
-  void SetStringValue(const char* section, const char* key, const char* value) override;
+	void SetStringValue(const char* section, const char* key, const char* value) override;
 
-  std::vector<std::string> GetStringList(const char* section, const char* key) const override;
-  void SetStringList(const char* section, const char* key, const std::vector<std::string>& items) override;
-  bool RemoveFromStringList(const char* section, const char* key, const char* item) override;
-  bool AddToStringList(const char* section, const char* key, const char* item) override;
+	std::vector<std::string> GetStringList(const char* section, const char* key) const override;
+	void SetStringList(const char* section, const char* key, const std::vector<std::string>& items) override;
+	bool RemoveFromStringList(const char* section, const char* key, const char* item) override;
+	bool AddToStringList(const char* section, const char* key, const char* item) override;
 
-  bool ContainsValue(const char* section, const char* key) const override;
-  void DeleteValue(const char* section, const char* key) override;
-  void ClearSection(const char* section) override;
+	bool ContainsValue(const char* section, const char* key) const override;
+	void DeleteValue(const char* section, const char* key) override;
+	void ClearSection(const char* section) override;
 
 private:
-  void CheckPath(const char* section) const;
+	void CheckPath(const char* section) const;
 
-  wxConfigBase* m_config;
-  mutable wxString m_current_path;
+	wxConfigBase* m_config;
+	mutable wxString m_current_path;
 };

--- a/pcsx2/gui/wxSettingsInterface.h
+++ b/pcsx2/gui/wxSettingsInterface.h
@@ -49,6 +49,9 @@ public:
 	bool RemoveFromStringList(const char* section, const char* key, const char* item) override;
 	bool AddToStringList(const char* section, const char* key, const char* item) override;
 
+	std::vector<std::pair<std::string, std::string>> GetKeyValueList(const char* section) const override;
+	void SetKeyValueList(const char* section, const std::vector<std::pair<std::string, std::string>>& items) override;
+
 	bool ContainsValue(const char* section, const char* key) const override;
 	void DeleteValue(const char* section, const char* key) override;
 	void ClearSection(const char* section) override;


### PR DESCRIPTION
### Description of Changes
- Default-enabled a hints for HIDAPI PS3 controllers on Linux and Wii controllers everywhere
  - PS3 controllers for pressure sensitive button support
  - Wii controllers for the ability to use Wii U Pro controllers without a separate program
- Added support for loading custom hints from the INI on Qt builds
  - In case users want their Switch controller home buttons glowing or something idk
  - Put your hints under `[SDLHints]` in the INI, e.g. `SDL_JOYSTICK_HIDAPI_SWITCH_HOME_LED = 0.5` to make your switch controllers' home buttons glow at half brightness

### Suggested Testing Steps
- Test Wii U Pro controllers, classic controllers, or try to play a PS2 game with a wiimote
  - (macOS > 12.0 is known to not be able to pair wiimotes and wiimote-derived controllers, so it's expected to not work there)
- Test PS3 controller pressure sensitivity on Linux
- Make your home buttons glow
