### PR TITLE
MTGS: Make PresentCurrentFrame() callable from CPU thread

### DIFF
--- a/pcsx2-qt/QtHost.cpp
+++ b/pcsx2-qt/QtHost.cpp
@@ -826,7 +826,7 @@ void EmuThread::redrawDisplayWindow()
 	if (!VMManager::HasValidVM() || VMManager::GetState() == VMState::Running)
 		return;
 
-	GetMTGS().RunOnGSThread([]() { GetMTGS().PresentCurrentFrame(); });
+	GetMTGS().PresentCurrentFrame();
 }
 
 void EmuThread::runOnCPUThread(const std::function<void()>& func)
@@ -979,10 +979,6 @@ void Host::ResizeHostDisplay(u32 new_window_width, u32 new_window_height, float 
 {
 	g_host_display->ResizeWindow(new_window_width, new_window_height, new_window_scale);
 	ImGuiManager::WindowResized();
-
-	// if we're paused, re-present the current frame at the new window size.
-	if (VMManager::GetState() == VMState::Paused)
-		GetMTGS().PresentCurrentFrame();
 }
 
 void Host::RequestResizeHostDisplay(s32 width, s32 height)
@@ -994,10 +990,6 @@ void Host::UpdateHostDisplay()
 {
 	g_emu_thread->updateDisplay();
 	ImGuiManager::WindowResized();
-
-	// if we're paused, re-present the current frame at the new window size.
-	if (VMManager::GetState() == VMState::Paused)
-		GetMTGS().PresentCurrentFrame();
 }
 
 void Host::OnVMStarting()

--- a/pcsx2/GS.h
+++ b/pcsx2/GS.h
@@ -385,7 +385,7 @@ public:
 	void ShutdownThread();
 
 	/// Re-presents the current frame. Call when things like window resizes happen to re-display
-	/// the current frame with the correct proportions. Should only be called on the GS thread.
+	/// the current frame with the correct proportions. Should only be called from the CPU thread.
 	void PresentCurrentFrame();
 
 	// Waits for the GS to empty out the entire ring buffer contents.


### PR DESCRIPTION
### Description of Changes

Makes it so you can call `GetMTGS().PresentCurrentFrame()` from anywhere in the CPU thread.

### Rationale behind Changes

Consistency with the other functions in MTGS.

### Suggested Testing Steps

Test window resizing and fullscreening in Qt.
