### PR TITLE
CMake: Lowercase Winmm for case-sensitive fs

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -177,7 +177,7 @@ endif()
 if(WIN32)
 	enable_language(ASM_MASM)
 	target_sources(common PRIVATE FastJmp.asm)
-	target_link_libraries(common PUBLIC WIL::WIL D3D12MemAlloc Winmm.lib)
+	target_link_libraries(common PUBLIC WIL::WIL D3D12MemAlloc winmm)
 	target_sources(common PRIVATE
 		CrashHandler.cpp
 		CrashHandler.h


### PR DESCRIPTION
Fix build on mingw from linux
