### PR TITLE
GS-DX11: Fix D3D11_BOX parameters (missing "front")

### DIFF
--- a/pcsx2/GS/Renderers/DX11/GSTexture11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSTexture11.cpp
@@ -46,7 +46,8 @@ bool GSTexture11::Update(const GSVector4i& r, const void* data, int pitch, int l
 	g_perfmon.Put(GSPerfMon::TextureUploads, 1);
 
 	const u32 bs = GetCompressedBlockSize();
-	const D3D11_BOX box = {Common::AlignDownPow2((u32)r.left, bs), Common::AlignDownPow2((u32)r.top, bs),
+	
+	const D3D11_BOX box = {Common::AlignDownPow2((u32)r.left, bs), Common::AlignDownPow2((u32)r.top, bs), 0U,
 		Common::AlignUpPow2((u32)r.right, bs), Common::AlignUpPow2((u32)r.bottom, bs), 1U};
 	const UINT subresource = layer; // MipSlice + (ArraySlice * MipLevels).
 


### PR DESCRIPTION
### Description of Changes
Fixes D3D11 box parameters for textures.

### Rationale behind Changes
mistake from #7477 which apparently the compiler lets you get away with.

### Suggested Testing Steps
test games on DX11, noticed on burnout.
