### PR TITLE
GS-HW: Update validity when resizing a texture during the draw.

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -1763,11 +1763,13 @@ void GSRendererHW::Draw()
 		{
 			pxAssert(rt->m_texture->GetScale() == up_s);
 			rt->ResizeTexture(new_w, new_h, up_s);
+			rt->UpdateValidity(m_r);
 		}
 		if (ds)
 		{
 			pxAssert(ds->m_texture->GetScale() == up_s);
 			ds->ResizeTexture(new_w, new_h, up_s);
+			ds->UpdateValidity(m_r);
 		}
 	}
 


### PR DESCRIPTION
### Description of Changes
Corrects the end block and valid rect for textures in the hardware renderer when they are resized.

### Rationale behind Changes
Some games were missing render targets when displaying FMVs causing flashing. Robot Warlords was one such game. If we're going to increase how much memory a texture covers, the end block should reflect that.

### Suggested Testing Steps
Test games, make sure nothing flashes bad.

Fixes Midas FMV on Robot Warlords.
