### PR TITLE
GS-SW: Revert software clamp changes from large TH/TW PR.

### DIFF
--- a/pcsx2/GS/Renderers/SW/GSRendererSW.cpp
+++ b/pcsx2/GS/Renderers/SW/GSRendererSW.cpp
@@ -1231,9 +1231,10 @@ bool GSRendererSW::GetScanlineGlobalData(SharedData* data)
 					gd.t.mask.U32[0] = 0;
 					break;
 				case CLAMP_REGION_CLAMP:
-					// REGION_CLAMP ignores the actual texture size
-					gd.t.min.U16[0] = gd.t.minmax.U16[0] = context->CLAMP.MINU;
-					gd.t.max.U16[0] = gd.t.minmax.U16[2] = context->CLAMP.MAXU;
+					// REGION_CLAMP ignores the actual texture size, but tw is already optimised in GetFixedTEX0Size.
+					// It's important we don't go off MAXU (if bigger) here as the sw renderer can attempt to draw pixels outside the triangle which can cause out of bounds issues.
+					gd.t.min.U16[0] = gd.t.minmax.U16[0] = std::min<u16>(context->CLAMP.MINU, tw - 1);
+					gd.t.max.U16[0] = gd.t.minmax.U16[2] = std::min<u16>(context->CLAMP.MAXU, tw - 1);
 					gd.t.mask.U32[0] = 0;
 					break;
 				case CLAMP_REGION_REPEAT:
@@ -1259,9 +1260,10 @@ bool GSRendererSW::GetScanlineGlobalData(SharedData* data)
 					gd.t.mask.U32[2] = 0;
 					break;
 				case CLAMP_REGION_CLAMP:
-					// REGION_CLAMP ignores the actual texture size
-					gd.t.min.U16[4] = gd.t.minmax.U16[1] = context->CLAMP.MINV;
-					gd.t.max.U16[4] = gd.t.minmax.U16[3] = context->CLAMP.MAXV; // ffx anima summon scene, when the anchor appears (th = 256, maxv > 256)
+					// REGION_CLAMP ignores the actual texture size, but th is already optimised in GetFixedTEX0Size
+					// It's important we don't go off MAXV (if bigger) here as the sw renderer can attempt to draw pixels outside the triangle which can cause out of bounds issues.
+					gd.t.min.U16[4] = gd.t.minmax.U16[1] = std::min<u16>(context->CLAMP.MINV, th - 1);
+					gd.t.max.U16[4] = gd.t.minmax.U16[3] = std::min<u16>(context->CLAMP.MAXV, th - 1); // ffx anima summon scene, when the anchor appears (th = 256, maxv > 256)
 					gd.t.mask.U32[2] = 0;
 					break;
 				case CLAMP_REGION_REPEAT:


### PR DESCRIPTION
### Description of Changes
Clamps the draw to the read size to make sure reads aren't done out of bounds of the available texture.

### Rationale behind Changes
This change didn't need to be done as the th and tw are sized based on the actual sizes anyway, if these are wrong, the software renderer can crash when trying to draw out of bounds, so this needs to stay as it is. Regression from #7104

### Suggested Testing Steps
Test MGS2 in the software renderer, make sure it doesn't explode (was tested using the intro)
