### PR TITLE
Use semaphores with a userspace fast path

### DIFF
--- a/common/Darwin/DarwinSemaphore.cpp
+++ b/common/Darwin/DarwinSemaphore.cpp
@@ -42,16 +42,10 @@
 
 static void MACH_CHECK(kern_return_t mach_retval)
 {
-	switch (mach_retval)
+	if (mach_retval != KERN_SUCCESS)
 	{
-		case KERN_SUCCESS:
-			break;
-		case KERN_ABORTED: // Awoken due reason unrelated to semaphore (e.g. pthread_cancel)
-			pthread_testcancel(); // Unlike sem_wait, mach semaphore ops aren't cancellation points
-			// fallthrough
-		default:
-			fprintf(stderr, "mach error: %s", mach_error_string(mach_retval));
-			assert(mach_retval == KERN_SUCCESS);
+		fprintf(stderr, "mach error: %s", mach_error_string(mach_retval));
+		assert(mach_retval == KERN_SUCCESS);
 	}
 }
 

--- a/common/Threading.h
+++ b/common/Threading.h
@@ -235,7 +235,7 @@ namespace Threading
 	class UserspaceSemaphore
 	{
 		KernelSemaphore m_sema;
-		std::atomic<uint32_t> m_counter{0};
+		std::atomic<int32_t> m_counter{0};
 
 	public:
 		UserspaceSemaphore() = default;

--- a/pcsx2/GS.h
+++ b/pcsx2/GS.h
@@ -342,8 +342,8 @@ public:
 	std::mutex m_mtx_RingBufferBusy2; // Gets released on semaXGkick waiting...
 	std::mutex m_mtx_WaitGS;
 	Threading::WorkSema m_sem_event;
-	Threading::KernelSemaphore m_sem_OnRingReset;
-	Threading::KernelSemaphore m_sem_Vsync;
+	Threading::UserspaceSemaphore m_sem_OnRingReset;
+	Threading::UserspaceSemaphore m_sem_Vsync;
 
 	// used to keep multiple threads from sending packets to the ringbuffer concurrently.
 	// (currently not used or implemented -- is a planned feature for a future threaded VU1)
@@ -369,7 +369,7 @@ public:
 	std::atomic_bool m_open_flag{false};
 	std::atomic_bool m_shutdown_flag{false};
 	std::atomic_bool m_run_idle_flag{false};
-	Threading::KernelSemaphore m_open_or_close_done;
+	Threading::UserspaceSemaphore m_open_or_close_done;
 
 public:
 	SysMtgsThread();

--- a/pcsx2/GS.h
+++ b/pcsx2/GS.h
@@ -340,7 +340,6 @@ public:
 	std::atomic<bool> m_VsyncSignalListener;
 
 	std::mutex m_mtx_RingBufferBusy2; // Gets released on semaXGkick waiting...
-	std::mutex m_mtx_WaitGS;
 	Threading::WorkSema m_sem_event;
 	Threading::UserspaceSemaphore m_sem_OnRingReset;
 	Threading::UserspaceSemaphore m_sem_Vsync;

--- a/pcsx2/MTGS.cpp
+++ b/pcsx2/MTGS.cpp
@@ -617,7 +617,7 @@ void SysMtgsThread::WaitGS(bool syncRegs, bool weakWait, bool isMTVU)
 	// we don't want to access the content of the queue
 
 	SetEvent();
-	if (weakWait)
+	if (weakWait && isMTVU)
 	{
 		// On weakWait we will stop waiting on the MTGS thread if the
 		// MTGS thread has processed a vu1 xgkick packet, or is pending on
@@ -644,9 +644,10 @@ void SysMtgsThread::WaitGS(bool syncRegs, bool weakWait, bool isMTVU)
 			pxFailRel("MTGS Thread Died");
 	}
 
+	assert(!(weakWait && syncRegs) && "No synchronization for this!");
+
 	if (syncRegs)
 	{
-		std::unique_lock lock(m_mtx_WaitGS);
 		// Completely synchronize GS and MTGS register states.
 		memcpy(RingBuffer.Regs, PS2MEM_GS, sizeof(RingBuffer.Regs));
 	}

--- a/pcsx2/MTVU.h
+++ b/pcsx2/MTVU.h
@@ -45,7 +45,7 @@ class VU_Thread final {
 public:
 	alignas(16)  vifStruct        vif;
 	alignas(16)  VIFregisters     vifRegs;
-	Threading::KernelSemaphore semaXGkick;
+	Threading::UserspaceSemaphore semaXGkick;
 	std::atomic<unsigned int> vuCycles[4]; // Used for VU cycle stealing hack
 	u32 vuCycleIdx;  // Used for VU cycle stealing hack
 	u32 vuFBRST;


### PR DESCRIPTION
### Description of Changes
Adds a semaphore with a userspace fast path and uses it
Improves performance in GS thread limited applications, when MTVU is enabled.  Amount depends on operating system (how slow kernel semaphores were).
In Sly at 1x:
- macOS: +30%
- Windows: +20%
- Linux: +1%

Also fixes high EE thread usage during gsdump playback

### Rationale behind Changes
Faster yay

### Suggested Testing Steps
Test your GS thread limited games (I recommend sly)
