### PR TITLE
CDVD: Escape descriptor read on iso read failure

### DIFF
--- a/pcsx2/CDVD/IsoFS/IsoFS.cpp
+++ b/pcsx2/CDVD/IsoFS/IsoFS.cpp
@@ -62,7 +62,10 @@ IsoDirectory::IsoDirectory(SectorSource& r)
 	while (!done)
 	{
 		u8 sector[2048];
-		internalReader.readSector(sector, i);
+		// If this fails, we're not reading an iso, or it's bad.
+		if (!internalReader.readSector(sector, i))
+			break;
+
 		if (memcmp(&sector[1], "CD001", 5) == 0)
 		{
 			switch (sector[0])


### PR DESCRIPTION
### Description of Changes
Changes the ISO reader to escape from checking the descriptor information if it fails to read the ISO.

### Rationale behind Changes
Before it continued to loop checking the descriptor so if there was any residue data from a previous read, it would keep that, since the actual sector read would escape, leaving the buffer as-is, but it would continue to process it.  This now escapes.

### Suggested Testing Steps
Try booting a game,  once booted choose shut down without saving, click "boot bios"
