### PR TITLE
FullscreenUI: Don't clear state when switching renderers

### DIFF
--- a/pcsx2-gsrunner/Main.cpp
+++ b/pcsx2-gsrunner/Main.cpp
@@ -255,7 +255,7 @@ void Host::OnInputDeviceDisconnected(const std::string_view& identifier)
 {
 }
 
-bool Host::AcquireHostDisplay(RenderAPI api)
+bool Host::AcquireHostDisplay(RenderAPI api, bool clear_state_on_fail)
 {
 	const std::optional<WindowInfo> wi(GSRunner::GetPlatformWindowInfo());
 	if (!wi.has_value())
@@ -267,7 +267,7 @@ bool Host::AcquireHostDisplay(RenderAPI api)
 
 	if (!g_host_display->CreateDevice(wi.value()) || !g_host_display->MakeCurrent() || !g_host_display->SetupDevice() || !ImGuiManager::Initialize())
 	{
-		ReleaseHostDisplay();
+		ReleaseHostDisplay(clear_state_on_fail);
 		return false;
 	}
 
@@ -277,12 +277,9 @@ bool Host::AcquireHostDisplay(RenderAPI api)
 	return g_host_display.get();
 }
 
-void Host::ReleaseHostDisplay()
+void Host::ReleaseHostDisplay(bool clear_state)
 {
-	if (!g_host_display)
-		return;
-
-	ImGuiManager::Shutdown();
+	ImGuiManager::Shutdown(clear_state);
 	g_host_display.reset();
 }
 

--- a/pcsx2-qt/QtHost.h
+++ b/pcsx2-qt/QtHost.h
@@ -70,9 +70,9 @@ public:
 	bool shouldRenderToMain() const;
 
 	/// Called back from the GS thread when the display state changes (e.g. fullscreen, render to main).
-	bool acquireHostDisplay(RenderAPI api);
+	bool acquireHostDisplay(RenderAPI api, bool clear_state_on_fail);
 	void connectDisplaySignals(DisplayWidget* widget);
-	void releaseHostDisplay();
+	void releaseHostDisplay(bool clear_state);
 	void updateDisplay();
 
 	void startBackgroundControllerPollTimer();

--- a/pcsx2/Frontend/Achievements.cpp
+++ b/pcsx2/Frontend/Achievements.cpp
@@ -19,6 +19,7 @@
 #include "Frontend/CommonHost.h"
 #include "Frontend/FullscreenUI.h"
 #include "Frontend/ImGuiFullscreen.h"
+#include "Frontend/ImGuiManager.h"
 
 #include "common/Assertions.h"
 #include "common/FileSystem.h"
@@ -427,7 +428,7 @@ std::string Achievements::GetUserAgent()
 
 void Achievements::BeginLoadingScreen(const char* text, bool* was_running_idle)
 {
-	GetMTGS().RunOnGSThread(&FullscreenUI::Initialize);
+	GetMTGS().RunOnGSThread(&ImGuiManager::InitializeFullscreenUI);
 	ImGuiFullscreen::OpenBackgroundProgressDialog("achievements_loading", text, 0, 0, 0);
 }
 
@@ -1131,7 +1132,7 @@ void Achievements::GetPatchesCallback(s32 status_code, const std::string& conten
 		return;
 
 	// ensure fullscreen UI is ready
-	GetMTGS().RunOnGSThread([]() { FullscreenUI::Initialize(); });
+	GetMTGS().RunOnGSThread(&ImGuiManager::InitializeFullscreenUI);
 
 	s_game_id = response.id;
 	s_game_title = response.title;

--- a/pcsx2/Frontend/FullscreenUI.cpp
+++ b/pcsx2/Frontend/FullscreenUI.cpp
@@ -553,17 +553,12 @@ bool FullscreenUI::Initialize()
 	if (!ImGuiManager::AddFullscreenFontsIfMissing() || !ImGuiFullscreen::Initialize("fullscreenui/placeholder.png") || !LoadResources())
 	{
 		DestroyResources();
-		ImGuiFullscreen::Shutdown();
+		ImGuiFullscreen::Shutdown(true);
 		s_tried_to_initialize = true;
 		return false;
 	}
 
 	s_initialized = true;
-	s_current_main_window = MainWindowType::None;
-	s_current_pause_submenu = PauseSubMenu::None;
-	s_pause_menu_was_open = false;
-	s_was_paused_on_quick_menu_open = false;
-	s_about_window_open = false;
 	s_hotkey_list_cache = InputManager::GetHotkeyList();
 	GetMTGS().SetRunIdle(true);
 
@@ -573,7 +568,9 @@ bool FullscreenUI::Initialize()
 	}
 	else
 	{
-		SwitchToLanding();
+		// only switch to landing if we weren't e.g. in settings
+		if (s_current_main_window == MainWindowType::None)
+			SwitchToLanding();
 	}
 
 	return true;
@@ -708,7 +705,7 @@ void FullscreenUI::OpenPauseMenu()
 		return;
 
 	GetMTGS().RunOnGSThread([]() {
-		if (!Initialize() || s_current_main_window != MainWindowType::None)
+		if (!ImGuiManager::InitializeFullscreenUI() || s_current_main_window != MainWindowType::None)
 			return;
 
 		PauseForMenuOpen();
@@ -739,23 +736,32 @@ void FullscreenUI::OpenPauseSubMenu(PauseSubMenu submenu)
 	QueueResetFocus();
 }
 
-void FullscreenUI::Shutdown()
+void FullscreenUI::Shutdown(bool clear_state)
 {
-	CancelAsyncOps();
-	CloseSaveStateSelector();
-	s_cover_image_map.clear();
-	s_game_list_sorted_entries = {};
-	s_game_list_directories_cache = {};
-	s_fullscreen_mode_list_cache = {};
-	s_graphics_adapter_list_cache = {};
+	if (clear_state)
+	{
+		CancelAsyncOps();
+		CloseSaveStateSelector();
+		s_cover_image_map.clear();
+		s_game_list_sorted_entries = {};
+		s_game_list_directories_cache = {};
+		s_fullscreen_mode_list_cache = {};
+		s_graphics_adapter_list_cache = {};
+		s_current_game_title = {};
+		s_current_game_subtitle = {};
+		s_current_game_serial = {};
+		s_current_game_path = {};
+		s_current_game_crc = 0;
+
+		s_current_main_window = MainWindowType::None;
+		s_current_pause_submenu = PauseSubMenu::None;
+		s_pause_menu_was_open = false;
+		s_was_paused_on_quick_menu_open = false;
+		s_about_window_open = false;
+	}
 	s_hotkey_list_cache = {};
-	s_current_game_title = {};
-	s_current_game_subtitle = {};
-	s_current_game_serial = {};
-	s_current_game_path = {};
-	s_current_game_crc = 0;
 	DestroyResources();
-	ImGuiFullscreen::Shutdown();
+	ImGuiFullscreen::Shutdown(clear_state);
 	s_initialized = false;
 	s_tried_to_initialize = false;
 }
@@ -5688,7 +5694,7 @@ void FullscreenUI::OpenAchievementsWindow()
 		return;
 
 	GetMTGS().RunOnGSThread([]() {
-		if (!Initialize())
+		if (!ImGuiManager::InitializeFullscreenUI())
 			return;
 
 		SwitchToAchievementsWindow();
@@ -6078,7 +6084,7 @@ void FullscreenUI::OpenLeaderboardsWindow()
 		return;
 
 	GetMTGS().RunOnGSThread([]() {
-		if (!Initialize())
+		if (!ImGuiManager::InitializeFullscreenUI())
 			return;
 
 		SwitchToLeaderboardsWindow();

--- a/pcsx2/Frontend/FullscreenUI.h
+++ b/pcsx2/Frontend/FullscreenUI.h
@@ -38,7 +38,7 @@ namespace FullscreenUI
 	void OpenAchievementsWindow();
 	void OpenLeaderboardsWindow();
 
-	void Shutdown();
+	void Shutdown(bool clear_state);
 	void Render();
 	void InvalidateCoverCache();
 

--- a/pcsx2/Frontend/ImGuiFullscreen.cpp
+++ b/pcsx2/Frontend/ImGuiFullscreen.cpp
@@ -203,7 +203,7 @@ bool ImGuiFullscreen::Initialize(const char* placeholder_image_path)
 	return true;
 }
 
-void ImGuiFullscreen::Shutdown()
+void ImGuiFullscreen::Shutdown(bool clear_state)
 {
 	if (s_texture_load_thread.Joinable())
 	{
@@ -223,25 +223,28 @@ void ImGuiFullscreen::Shutdown()
 
 	s_texture_cache.Clear();
 
-	s_notifications.clear();
-	s_background_progress_dialogs.clear();
-	CloseInputDialog();
-	CloseMessageDialog();
-	s_choice_dialog_open = false;
-	s_choice_dialog_checkable = false;
-	s_choice_dialog_title = {};
-	s_choice_dialog_options.clear();
-	s_choice_dialog_callback = {};
-	s_enum_choice_button_id = 0;
-	s_enum_choice_button_value = 0;
-	s_enum_choice_button_set = false;
-	s_file_selector_open = false;
-	s_file_selector_directory = false;
-	s_file_selector_title = {};
-	s_file_selector_callback = {};
-	s_file_selector_current_directory = {};
-	s_file_selector_filters.clear();
-	s_file_selector_items.clear();
+	if (clear_state)
+	{
+		s_notifications.clear();
+		s_background_progress_dialogs.clear();
+		CloseInputDialog();
+		CloseMessageDialog();
+		s_choice_dialog_open = false;
+		s_choice_dialog_checkable = false;
+		s_choice_dialog_title = {};
+		s_choice_dialog_options.clear();
+		s_choice_dialog_callback = {};
+		s_enum_choice_button_id = 0;
+		s_enum_choice_button_value = 0;
+		s_enum_choice_button_set = false;
+		s_file_selector_open = false;
+		s_file_selector_directory = false;
+		s_file_selector_title = {};
+		s_file_selector_callback = {};
+		s_file_selector_current_directory = {};
+		s_file_selector_filters.clear();
+		s_file_selector_items.clear();
+	}
 }
 
 const std::shared_ptr<HostDisplayTexture>& ImGuiFullscreen::GetPlaceholderTexture()

--- a/pcsx2/Frontend/ImGuiFullscreen.h
+++ b/pcsx2/Frontend/ImGuiFullscreen.h
@@ -112,8 +112,8 @@ namespace ImGuiFullscreen
 	void SetFonts(ImFont* standard_font, ImFont* medium_font, ImFont* large_font);
 	bool UpdateLayoutScale();
 
-	/// Shuts down, clearing all state.
-	void Shutdown();
+	/// Shuts down, optionally clearing all state (including notifications).
+	void Shutdown(bool clear_state);
 
 	/// Texture cache.
 	const std::shared_ptr<HostDisplayTexture>& GetPlaceholderTexture();

--- a/pcsx2/Frontend/ImGuiManager.h
+++ b/pcsx2/Frontend/ImGuiManager.h
@@ -25,8 +25,11 @@ namespace ImGuiManager
 	/// Initializes ImGui, creates fonts, etc.
 	bool Initialize();
 
+	/// Initializes fullscreen UI.
+	bool InitializeFullscreenUI();
+
 	/// Frees all ImGui resources.
-	void Shutdown();
+	void Shutdown(bool clear_state);
 
 	/// Updates internal state when the window is size.
 	void WindowResized();

--- a/pcsx2/Frontend/InputManager.h
+++ b/pcsx2/Frontend/InputManager.h
@@ -257,6 +257,9 @@ namespace InputManager
 	/// Retrieves bindings that match the generic bindings for the specified device.
 	GenericInputBindingMapping GetGenericBindingMapping(const std::string_view& device);
 
+	/// Returns whether a given input source is enabled.
+	bool IsInputSourceEnabled(SettingsInterface& si, InputSourceType type);
+
 	/// Re-parses the config and registers all hotkey and pad bindings.
 	void ReloadBindings(SettingsInterface& si, SettingsInterface& binding_si);
 

--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -132,7 +132,7 @@ void GSshutdown()
 		g_gs_device.reset();
 	}
 
-	Host::ReleaseHostDisplay();
+	Host::ReleaseHostDisplay(true);
 #endif
 
 #ifdef _WIN32
@@ -161,7 +161,7 @@ void GSclose()
 	if (g_host_display)
 		g_host_display->SetGPUTimingEnabled(false);
 
-	Host::ReleaseHostDisplay();
+	Host::ReleaseHostDisplay(true);
 }
 
 static RenderAPI GetAPIForRenderer(GSRendererType renderer)
@@ -324,13 +324,13 @@ bool GSreopen(bool recreate_display, const Pcsx2Config::GSOptions& old_config)
 
 	if (recreate_display)
 	{
-		Host::ReleaseHostDisplay();
-		if (!Host::AcquireHostDisplay(GetAPIForRenderer(GSConfig.Renderer)))
+		Host::ReleaseHostDisplay(false);
+		if (!Host::AcquireHostDisplay(GetAPIForRenderer(GSConfig.Renderer), false))
 		{
 			Console.Error("(GSreopen) Failed to reacquire host display");
 
 			// try to get the old one back
-			if (!Host::AcquireHostDisplay(GetAPIForRenderer(old_config.Renderer)))
+			if (!Host::AcquireHostDisplay(GetAPIForRenderer(old_config.Renderer), false))
 			{
 				pxFailRel("Failed to recreate old config host display");
 				return false;
@@ -350,8 +350,8 @@ bool GSreopen(bool recreate_display, const Pcsx2Config::GSOptions& old_config)
 		// try the old config
 		if (recreate_display && GSConfig.Renderer != old_config.Renderer)
 		{
-			Host::ReleaseHostDisplay();
-			if (!Host::AcquireHostDisplay(GetAPIForRenderer(old_config.Renderer)))
+			Host::ReleaseHostDisplay(false);
+			if (!Host::AcquireHostDisplay(GetAPIForRenderer(old_config.Renderer), false))
 			{
 				pxFailRel("Failed to recreate old config host display (part 2)");
 				return false;
@@ -385,7 +385,7 @@ bool GSopen(const Pcsx2Config::GSOptions& config, GSRendererType renderer, u8* b
 	GSConfig = config;
 	GSConfig.Renderer = renderer;
 
-	if (!Host::AcquireHostDisplay(GetAPIForRenderer(renderer)))
+	if (!Host::AcquireHostDisplay(GetAPIForRenderer(renderer), true))
 	{
 		Console.Error("Failed to acquire host display");
 		return false;
@@ -393,7 +393,7 @@ bool GSopen(const Pcsx2Config::GSOptions& config, GSRendererType renderer, u8* b
 
 	if (!DoGSOpen(renderer, basemem))
 	{
-		Host::ReleaseHostDisplay();
+		Host::ReleaseHostDisplay(true);
 		return false;
 	}
 

--- a/pcsx2/HostDisplay.h
+++ b/pcsx2/HostDisplay.h
@@ -173,10 +173,10 @@ extern std::unique_ptr<HostDisplay> g_host_display;
 namespace Host
 {
 	/// Creates the host display. This may create a new window. The API used depends on the current configuration.
-	bool AcquireHostDisplay(RenderAPI api);
+	bool AcquireHostDisplay(RenderAPI api, bool clear_state_on_fail);
 
 	/// Destroys the host display. This may close the display window.
-	void ReleaseHostDisplay();
+	void ReleaseHostDisplay(bool clear_state);
 
 	/// Returns the desired vsync mode, depending on the runtime environment.
 	VsyncMode GetEffectiveVSyncMode();

--- a/pcsx2/gui/AppHost.cpp
+++ b/pcsx2/gui/AppHost.cpp
@@ -117,7 +117,7 @@ bool Host::ConfirmMessage(const std::string_view& title, const std::string_view&
 	return true;
 }
 
-bool Host::AcquireHostDisplay(RenderAPI api)
+bool Host::AcquireHostDisplay(RenderAPI api, bool clear_state_on_fail)
 {
 	sApp.OpenGsPanel();
 
@@ -141,9 +141,9 @@ bool Host::AcquireHostDisplay(RenderAPI api)
 	return true;
 }
 
-void Host::ReleaseHostDisplay()
+void Host::ReleaseHostDisplay(bool clear_state_on_fail)
 {
-	ImGuiManager::Shutdown();
+	ImGuiManager::Shutdown(clear_state_on_fail);
 
 	if (g_host_display)
 		g_host_display.reset();


### PR DESCRIPTION
### Description of Changes

Slightly messy, but it's needed to solve two issues:
 - Switching renderers in the fullscreen UI will boot you back to the main landing page.
 - Changing renderers while achievements are active (either with game settings or manually) will prevent notifications from being shown until you open the pause menu.

### Rationale behind Changes

Fixing my design oversights.

### Suggested Testing Steps

Briefly test achievements after switching renderer, or change renderers in the fullscreen UI. It should stay in the settings menu.