### PR TITLE
GS: Manually throttle fullscreen UI rendering

### DIFF
--- a/common/Darwin/DarwinThreads.cpp
+++ b/common/Darwin/DarwinThreads.cpp
@@ -30,11 +30,6 @@
 // the LOCK prefix.  The prefix works on single core CPUs fine (but is slow), but not
 // having the LOCK prefix is very bad indeed.
 
-__forceinline void Threading::Sleep(int ms)
-{
-	usleep(1000 * ms);
-}
-
 __forceinline void Threading::Timeslice()
 {
 	sched_yield();

--- a/common/Linux/LnxMisc.cpp
+++ b/common/Linux/LnxMisc.cpp
@@ -28,6 +28,7 @@
 #include "common/Pcsx2Types.h"
 #include "common/General.h"
 #include "common/StringUtil.h"
+#include "common/Threading.h"
 #include "common/WindowInfo.h"
 
 // Returns 0 on failure (not supported by the operating system).
@@ -147,6 +148,19 @@ bool Common::PlaySoundAsync(const char* path)
 #else
 	return false;
 #endif
+}
+
+void Threading::Sleep(int ms)
+{
+	usleep(1000 * ms);
+}
+
+void Threading::SleepUntil(u64 ticks)
+{
+	struct timespec ts;
+	ts.tv_sec = static_cast<time_t>(ticks / 1000000000ULL);
+	ts.tv_nsec = static_cast<long>(ticks % 1000000000ULL);
+	clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, &ts, nullptr);
 }
 
 #endif

--- a/common/Linux/LnxThreads.cpp
+++ b/common/Linux/LnxThreads.cpp
@@ -54,11 +54,6 @@
 // the LOCK prefix.  The prefix works on single core CPUs fine (but is slow), but not
 // having the LOCK prefix is very bad indeed.
 
-__forceinline void Threading::Sleep(int ms)
-{
-	usleep(1000 * ms);
-}
-
 __forceinline void Threading::Timeslice()
 {
 	sched_yield();

--- a/common/Threading.h
+++ b/common/Threading.h
@@ -55,6 +55,9 @@ namespace Threading
 	// sleeps the current thread for the given number of milliseconds.
 	extern void Sleep(int ms);
 
+	// sleeps the current thread until the specified time point, or later.
+	extern void SleepUntil(u64 ticks);
+
 	// --------------------------------------------------------------------------------------
 	//  ThreadHandle
 	// --------------------------------------------------------------------------------------

--- a/common/Windows/WinMisc.cpp
+++ b/common/Windows/WinMisc.cpp
@@ -19,6 +19,7 @@
 #include "common/RedtapeWindows.h"
 #include "common/Exceptions.h"
 #include "common/StringUtil.h"
+#include "common/Threading.h"
 #include "common/General.h"
 #include "common/WindowInfo.h"
 
@@ -29,6 +30,23 @@
 #include <VersionHelpers.h>
 
 alignas(16) static LARGE_INTEGER lfreq;
+
+// This gets leaked... oh well.
+static thread_local HANDLE s_sleep_timer;
+static thread_local bool s_sleep_timer_created = false;
+
+static HANDLE GetSleepTimer()
+{
+	if (s_sleep_timer_created)
+		return s_sleep_timer;
+
+	s_sleep_timer_created = true;
+	s_sleep_timer = CreateWaitableTimerEx(nullptr, nullptr, CREATE_WAITABLE_TIMER_HIGH_RESOLUTION, TIMER_ALL_ACCESS);
+	if (!s_sleep_timer)
+		s_sleep_timer = CreateWaitableTimer(nullptr, TRUE, nullptr);
+
+	return s_sleep_timer;
+}
 
 void InitCPUTicks()
 {
@@ -89,6 +107,36 @@ bool Common::PlaySoundAsync(const char* path)
 {
 	const std::wstring wpath(StringUtil::UTF8StringToWideString(path));
 	return PlaySoundW(wpath.c_str(), NULL, SND_ASYNC | SND_NODEFAULT);
+}
+
+void Threading::Sleep(int ms)
+{
+	::Sleep(ms);
+}
+
+void Threading::SleepUntil(u64 ticks)
+{
+	// This is definitely sub-optimal, but there's no way to sleep until a QPC timestamp on Win32.
+	const s64 diff = static_cast<s64>(ticks - GetCPUTicks());
+	if (diff <= 0)
+		return;
+
+	const HANDLE hTimer = GetSleepTimer();
+	if (!hTimer)
+		return;
+
+	const u64 one_hundred_nanos_diff = (static_cast<u64>(diff) * 10000000ULL) / GetTickFrequency();
+	if (one_hundred_nanos_diff == 0)
+		return;
+
+	LARGE_INTEGER fti;
+	fti.QuadPart = -static_cast<s64>(one_hundred_nanos_diff);
+
+	if (SetWaitableTimer(hTimer, &fti, 0, nullptr, nullptr, FALSE))
+	{
+		WaitForSingleObject(hTimer, INFINITE);
+		return;
+	}
 }
 
 #endif

--- a/common/Windows/WinThreads.cpp
+++ b/common/Windows/WinThreads.cpp
@@ -23,11 +23,6 @@
 #include <process.h>
 #include <timeapi.h>
 
-__fi void Threading::Sleep(int ms)
-{
-	::Sleep(ms);
-}
-
 __fi void Threading::Timeslice()
 {
 	::Sleep(0);

--- a/pcsx2-gsrunner/Main.cpp
+++ b/pcsx2-gsrunner/Main.cpp
@@ -265,7 +265,8 @@ bool Host::AcquireHostDisplay(RenderAPI api, bool clear_state_on_fail)
 	if (!g_host_display)
 		return false;
 
-	if (!g_host_display->CreateDevice(wi.value()) || !g_host_display->MakeCurrent() || !g_host_display->SetupDevice() || !ImGuiManager::Initialize())
+	if (!g_host_display->CreateDevice(wi.value(), Host::GetEffectiveVSyncMode()) ||
+		!g_host_display->MakeCurrent() || !g_host_display->SetupDevice() || !ImGuiManager::Initialize())
 	{
 		ReleaseHostDisplay(clear_state_on_fail);
 		return false;
@@ -281,12 +282,6 @@ void Host::ReleaseHostDisplay(bool clear_state)
 {
 	ImGuiManager::Shutdown(clear_state);
 	g_host_display.reset();
-}
-
-VsyncMode Host::GetEffectiveVSyncMode()
-{
-	// Never vsync! We want to finish as quickly as possible.
-	return VsyncMode::Off;
 }
 
 bool Host::BeginPresentFrame(bool frame_skip)

--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -2012,7 +2012,7 @@ DisplayWidget* MainWindow::createDisplay(bool fullscreen, bool render_to_main)
 
 	g_emu_thread->connectDisplaySignals(m_display_widget);
 
-	if (!g_host_display->CreateDevice(wi.value()))
+	if (!g_host_display->CreateDevice(wi.value(), Host::GetEffectiveVSyncMode()))
 	{
 		QMessageBox::critical(this, tr("Error"), tr("Failed to create host display device context."));
 		destroyDisplayWidget(true);

--- a/pcsx2-qt/QtHost.cpp
+++ b/pcsx2-qt/QtHost.cpp
@@ -931,26 +931,6 @@ void Host::ReleaseHostDisplay(bool clear_state)
 	g_emu_thread->releaseHostDisplay(clear_state);
 }
 
-VsyncMode Host::GetEffectiveVSyncMode()
-{
-	// Force vsync on when running big picture UI, and paused or no VM.
-	// We check the "running FSUI" flag here, because that way we set the initial vsync
-	// state when initalizing to on, avoiding an unnecessary switch.
-	if (FullscreenUI::HasActiveWindow() || (!FullscreenUI::IsInitialized() && g_emu_thread->isRunningFullscreenUI()))
-	{
-		const VMState state = VMManager::GetState();
-		if (state == VMState::Shutdown || state == VMState::Paused)
-			return VsyncMode::On;
-	}
-
-	// Force vsync off when not running at 100% speed.
-	if (EmuConfig.GS.LimitScalar != 1.0f)
-		return VsyncMode::Off;
-
-	// Otherwise use the config setting.
-	return EmuConfig.GS.VsyncEnable;
-}
-
 bool Host::BeginPresentFrame(bool frame_skip)
 {
 	if (!g_host_display->BeginPresent(frame_skip))

--- a/pcsx2/Frontend/CommonHost.cpp
+++ b/pcsx2/Frontend/CommonHost.cpp
@@ -346,7 +346,6 @@ void CommonHost::OnVMDestroyed()
 void CommonHost::OnVMPaused()
 {
 	InputManager::PauseVibration();
-	FullscreenUI::OnVMPaused();
 
 #ifdef ENABLE_ACHIEVEMENTS
 	Achievements::OnPaused(true);
@@ -357,8 +356,6 @@ void CommonHost::OnVMPaused()
 
 void CommonHost::OnVMResumed()
 {
-	FullscreenUI::OnVMResumed();
-
 #ifdef ENABLE_ACHIEVEMENTS
 	Achievements::OnPaused(false);
 #endif

--- a/pcsx2/Frontend/CommonHotkeys.cpp
+++ b/pcsx2/Frontend/CommonHotkeys.cpp
@@ -46,7 +46,6 @@ static void HotkeyAdjustTargetSpeed(double delta)
 	EmuConfig.Framerate.NominalScalar = std::max(min_speed, EmuConfig.GS.LimitScalar + delta);
 	VMManager::SetLimiterMode(LimiterModeType::Nominal);
 	gsUpdateFrequency(EmuConfig);
-	GetMTGS().UpdateVSyncMode();
 	Host::AddIconOSDMessage("SpeedChanged", ICON_FA_CLOCK,
 		fmt::format("Target speed set to {:.0f}%.", std::round(EmuConfig.Framerate.NominalScalar * 100.0)), Host::OSD_QUICK_DURATION);
 }

--- a/pcsx2/Frontend/D3D11HostDisplay.cpp
+++ b/pcsx2/Frontend/D3D11HostDisplay.cpp
@@ -210,7 +210,7 @@ void D3D11HostDisplay::SetVSync(VsyncMode mode)
 	m_vsync_mode = mode;
 }
 
-bool D3D11HostDisplay::CreateDevice(const WindowInfo& wi)
+bool D3D11HostDisplay::CreateDevice(const WindowInfo& wi, VsyncMode vsync)
 {
 	UINT create_flags = 0;
 	if (EmuConfig.GS.UseDebugDevice)
@@ -314,7 +314,7 @@ bool D3D11HostDisplay::CreateDevice(const WindowInfo& wi)
 	}
 
 	m_window_info = wi;
-	m_vsync_mode = Host::GetEffectiveVSyncMode();
+	m_vsync_mode = vsync;
 
 	if (m_window_info.type != WindowInfo::Type::Surfaceless && !CreateSwapChain(nullptr))
 		return false;

--- a/pcsx2/Frontend/D3D11HostDisplay.h
+++ b/pcsx2/Frontend/D3D11HostDisplay.h
@@ -43,7 +43,7 @@ public:
 	bool HasDevice() const override;
 	bool HasSurface() const override;
 
-	bool CreateDevice(const WindowInfo& wi) override;
+	bool CreateDevice(const WindowInfo& wi, VsyncMode vsync) override;
 	bool SetupDevice() override;
 
 	bool MakeCurrent() override;

--- a/pcsx2/Frontend/D3D12HostDisplay.cpp
+++ b/pcsx2/Frontend/D3D12HostDisplay.cpp
@@ -136,7 +136,7 @@ void D3D12HostDisplay::SetVSync(VsyncMode mode)
 	m_vsync_mode = mode;
 }
 
-bool D3D12HostDisplay::CreateDevice(const WindowInfo& wi)
+bool D3D12HostDisplay::CreateDevice(const WindowInfo& wi, VsyncMode vsync)
 {
 	ComPtr<IDXGIFactory> temp_dxgi_factory;
 	HRESULT hr = CreateDXGIFactory(IID_PPV_ARGS(temp_dxgi_factory.put()));
@@ -190,7 +190,7 @@ bool D3D12HostDisplay::CreateDevice(const WindowInfo& wi)
 	}
 
 	m_window_info = wi;
-	m_vsync_mode = Host::GetEffectiveVSyncMode();
+	m_vsync_mode = vsync;
 
 	if (m_window_info.type != WindowInfo::Type::Surfaceless && !CreateSwapChain(nullptr))
 		return false;

--- a/pcsx2/Frontend/D3D12HostDisplay.h
+++ b/pcsx2/Frontend/D3D12HostDisplay.h
@@ -49,7 +49,7 @@ public:
 	bool HasDevice() const override;
 	bool HasSurface() const override;
 
-	bool CreateDevice(const WindowInfo& wi) override;
+	bool CreateDevice(const WindowInfo& wi, VsyncMode vsync) override;
 	bool SetupDevice() override;
 
 	bool MakeCurrent() override;

--- a/pcsx2/Frontend/FullscreenUI.cpp
+++ b/pcsx2/Frontend/FullscreenUI.cpp
@@ -623,24 +623,6 @@ void FullscreenUI::OnVMStarted()
 	});
 }
 
-void FullscreenUI::OnVMPaused()
-{
-	if (!IsInitialized())
-		return;
-
-	// Force vsync on.
-	GetMTGS().UpdateVSyncMode();
-}
-
-void FullscreenUI::OnVMResumed()
-{
-	if (!IsInitialized())
-		return;
-
-	// Restore game vsync.
-	GetMTGS().UpdateVSyncMode();
-}
-
 void FullscreenUI::OnVMDestroyed()
 {
 	if (!IsInitialized())
@@ -652,7 +634,6 @@ void FullscreenUI::OnVMDestroyed()
 
 		s_pause_menu_was_open = false;
 		SwitchToLanding();
-		GetMTGS().UpdateVSyncMode();
 	});
 }
 

--- a/pcsx2/Frontend/FullscreenUI.h
+++ b/pcsx2/Frontend/FullscreenUI.h
@@ -30,8 +30,6 @@ namespace FullscreenUI
 	bool HasActiveWindow();
 	void CheckForConfigChanges(const Pcsx2Config& old_config);
 	void OnVMStarted();
-	void OnVMPaused();
-	void OnVMResumed();
 	void OnVMDestroyed();
 	void OnRunningGameChanged(std::string path, std::string serial, std::string title, u32 crc);
 	void OpenPauseMenu();

--- a/pcsx2/Frontend/MetalHostDisplay.h
+++ b/pcsx2/Frontend/MetalHostDisplay.h
@@ -64,7 +64,7 @@ public:
 
 	bool HasDevice() const override;
 	bool HasSurface() const override;
-	bool CreateDevice(const WindowInfo& wi) override;
+	bool CreateDevice(const WindowInfo& wi, VsyncMode vsync) override;
 	bool SetupDevice() override;
 	bool MakeCurrent() override;
 	bool DoneCurrent() override;

--- a/pcsx2/Frontend/MetalHostDisplay.mm
+++ b/pcsx2/Frontend/MetalHostDisplay.mm
@@ -103,7 +103,7 @@ void MetalHostDisplay::DetachSurfaceOnMainThread()
 	m_layer = nullptr;
 }
 
-bool MetalHostDisplay::CreateDevice(const WindowInfo& wi)
+bool MetalHostDisplay::CreateDevice(const WindowInfo& wi, VsyncMode vsync)
 { @autoreleasepool {
 	m_window_info = wi;
 	pxAssertRel(!m_dev.dev, "Device already created!");
@@ -152,7 +152,7 @@ bool MetalHostDisplay::CreateDevice(const WindowInfo& wi)
 		{
 			AttachSurfaceOnMainThread();
 		});
-		SetVSync(Host::GetEffectiveVSyncMode());
+		SetVSync(vsync);
 		return true;
 	}
 	else

--- a/pcsx2/Frontend/OpenGLHostDisplay.cpp
+++ b/pcsx2/Frontend/OpenGLHostDisplay.cpp
@@ -143,7 +143,7 @@ void OpenGLHostDisplay::UpdateTexture(HostDisplayTexture* texture, u32 x, u32 y,
 
 void OpenGLHostDisplay::SetVSync(VsyncMode mode)
 {
-	if (m_gl_context->GetWindowInfo().type == WindowInfo::Type::Surfaceless)
+	if (m_vsync_mode == mode || m_gl_context->GetWindowInfo().type == WindowInfo::Type::Surfaceless)
 		return;
 
 	// Window framebuffer has to be bound to call SetSwapInterval.
@@ -155,6 +155,7 @@ void OpenGLHostDisplay::SetVSync(VsyncMode mode)
 		m_gl_context->SetSwapInterval(static_cast<s32>(mode != VsyncMode::Off));
 
 	glBindFramebuffer(GL_DRAW_FRAMEBUFFER, current_fbo);
+	m_vsync_mode = mode;
 }
 
 const char* OpenGLHostDisplay::GetGLSLVersionString() const
@@ -198,7 +199,7 @@ bool OpenGLHostDisplay::HasSurface() const
 	return m_window_info.type != WindowInfo::Type::Surfaceless;
 }
 
-bool OpenGLHostDisplay::CreateDevice(const WindowInfo& wi)
+bool OpenGLHostDisplay::CreateDevice(const WindowInfo& wi, VsyncMode vsync)
 {
 	m_gl_context = GL::Context::Create(wi);
 	if (!m_gl_context)
@@ -209,7 +210,7 @@ bool OpenGLHostDisplay::CreateDevice(const WindowInfo& wi)
 	}
 
 	m_window_info = m_gl_context->GetWindowInfo();
-	m_vsync_mode = Host::GetEffectiveVSyncMode();
+	m_vsync_mode = vsync;
 	return true;
 }
 

--- a/pcsx2/Frontend/OpenGLHostDisplay.h
+++ b/pcsx2/Frontend/OpenGLHostDisplay.h
@@ -38,7 +38,7 @@ public:
 	bool HasDevice() const override;
 	bool HasSurface() const override;
 
-	bool CreateDevice(const WindowInfo& wi) override;
+	bool CreateDevice(const WindowInfo& wi, VsyncMode vsync) override;
 	bool SetupDevice() override;
 
 	bool MakeCurrent() override;

--- a/pcsx2/Frontend/VulkanHostDisplay.cpp
+++ b/pcsx2/Frontend/VulkanHostDisplay.cpp
@@ -274,10 +274,9 @@ void VulkanHostDisplay::SetVSync(VsyncMode mode)
 	m_vsync_mode = mode;
 }
 
-bool VulkanHostDisplay::CreateDevice(const WindowInfo& wi)
+bool VulkanHostDisplay::CreateDevice(const WindowInfo& wi, VsyncMode vsync)
 {
 	WindowInfo local_wi(wi);
-	const VsyncMode vsync = Host::GetEffectiveVSyncMode();
 	const bool debug_device = EmuConfig.GS.UseDebugDevice;
 	if (!Vulkan::Context::Create(EmuConfig.GS.Adapter, &local_wi, &m_swap_chain, GetPreferredPresentModeForVsyncMode(vsync),
 			EmuConfig.GS.ThreadedPresentation, debug_device, debug_device))

--- a/pcsx2/Frontend/VulkanHostDisplay.h
+++ b/pcsx2/Frontend/VulkanHostDisplay.h
@@ -27,7 +27,7 @@ public:
 	bool HasDevice() const override;
 	bool HasSurface() const override;
 
-	bool CreateDevice(const WindowInfo& wi) override;
+	bool CreateDevice(const WindowInfo& wi, VsyncMode vsync) override;
 	bool SetupDevice() override;
 
 	bool MakeCurrent() override;

--- a/pcsx2/GS.cpp
+++ b/pcsx2/GS.cpp
@@ -74,6 +74,10 @@ void gsUpdateFrequency(Pcsx2Config& config)
 		config.GS.LimitScalar = 0.0f;
 	}
 
+#ifdef PCSX2_CORE
+	GetMTGS().UpdateVSyncMode();
+#endif
+
 	UpdateVSyncRate();
 }
 

--- a/pcsx2/GS/GS.h
+++ b/pcsx2/GS/GS.h
@@ -72,6 +72,7 @@ int GSfreeze(FreezeAction mode, freezeData* data);
 void GSQueueSnapshot(const std::string& path, u32 gsdump_frames = 0);
 void GSStopGSDump();
 void GSPresentCurrentFrame();
+void GSThrottlePresentation();
 #ifndef PCSX2_CORE
 void GSkeyEvent(const HostKeyEvent& e);
 void GSconfigure();

--- a/pcsx2/Host.h
+++ b/pcsx2/Host.h
@@ -24,6 +24,7 @@
 #include <optional>
 #include <vector>
 
+#ifndef PCSX2_CORE
 struct HostKeyEvent
 {
 	enum class Type
@@ -43,6 +44,7 @@ struct HostKeyEvent
 	Type type;
 	u32 key;
 };
+#endif
 
 namespace Host
 {

--- a/pcsx2/HostDisplay.h
+++ b/pcsx2/HostDisplay.h
@@ -84,6 +84,7 @@ public:
 	__fi s32 GetWindowWidth() const { return static_cast<s32>(m_window_info.surface_width); }
 	__fi s32 GetWindowHeight() const { return static_cast<s32>(m_window_info.surface_height); }
 	__fi float GetWindowScale() const { return m_window_info.surface_scale; }
+	__fi VsyncMode GetVsyncMode() const { return m_vsync_mode; }
 
 	/// Changes the alignment for this display (screen positioning).
 	__fi Alignment GetDisplayAlignment() const { return m_display_alignment; }
@@ -98,7 +99,7 @@ public:
 	virtual bool HasSurface() const = 0;
 
 	/// Creates the rendering/GPU device. This should be called on the thread which owns the window.
-	virtual bool CreateDevice(const WindowInfo& wi) = 0;
+	virtual bool CreateDevice(const WindowInfo& wi, VsyncMode vsync) = 0;
 
 	/// Fully initializes the rendering device. This should be called on the GS thread.
 	virtual bool SetupDevice() = 0;

--- a/pcsx2/MTGS.cpp
+++ b/pcsx2/MTGS.cpp
@@ -298,16 +298,14 @@ void SysMtgsThread::MainLoop()
 
 	while (true)
 	{
-
-		// Performance note: Both of these perform cancellation tests, but pthread_testcancel
-		// is very optimized (only 1 instruction test in most cases), so no point in trying
-		// to avoid it.
-
 #ifdef PCSX2_CORE
 		if (m_run_idle_flag.load(std::memory_order_acquire) && VMManager::GetState() != VMState::Running)
 		{
 			if (!m_sem_event.CheckForWork())
+			{
 				GSPresentCurrentFrame();
+				GSThrottlePresentation();
+			}
 		}
 		else
 		{

--- a/pcsx2/PAD/Gamepad.h
+++ b/pcsx2/PAD/Gamepad.h
@@ -27,11 +27,16 @@ void PADclose();
 u8 PADstartPoll(int port, int slot);
 u8 PADpoll(u8 value);
 bool PADcomplete();
-HostKeyEvent* PADkeyEvent();
 void PADconfigure();
 s32 PADfreeze(FreezeAction mode, freezeData* data);
 s32 PADsetSlot(u8 port, u8 slot);
 
+#ifndef PCSX2_CORE
+
+HostKeyEvent* PADkeyEvent();
+
 #if defined(__unix__) || defined(__APPLE__)
 void PADWriteEvent(HostKeyEvent& evt);
+#endif
+
 #endif

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -1393,7 +1393,6 @@ void VMManager::SetLimiterMode(LimiterModeType type)
 
 	EmuConfig.LimiterMode = type;
 	gsUpdateFrequency(EmuConfig);
-	GetMTGS().UpdateVSyncMode();
 }
 
 void VMManager::FrameAdvance(u32 num_frames /*= 1*/)
@@ -1635,7 +1634,6 @@ void VMManager::CheckForFramerateConfigChanges(const Pcsx2Config& old_config)
 	gsUpdateFrequency(EmuConfig);
 	UpdateVSyncRate();
 	frameLimitReset();
-	GetMTGS().UpdateVSyncMode();
 }
 
 void VMManager::CheckForPatchConfigChanges(const Pcsx2Config& old_config)

--- a/pcsx2/gui/AppHost.cpp
+++ b/pcsx2/gui/AppHost.cpp
@@ -129,7 +129,8 @@ bool Host::AcquireHostDisplay(RenderAPI api, bool clear_state_on_fail)
 	if (!g_host_display)
 		return false;
 
-	if (!g_host_display->CreateDevice(g_gs_window_info) || !g_host_display->SetupDevice() || !ImGuiManager::Initialize())
+	if (!g_host_display->CreateDevice(g_gs_window_info, Host::GetEffectiveVSyncMode()) ||
+		!g_host_display->SetupDevice() || !ImGuiManager::Initialize())
 	{
 		g_host_display.reset();
 		return false;
@@ -149,16 +150,6 @@ void Host::ReleaseHostDisplay(bool clear_state_on_fail)
 		g_host_display.reset();
 
 	sApp.CloseGsPanel();
-}
-
-VsyncMode Host::GetEffectiveVSyncMode()
-{
-	// Force vsync off when not running at 100% speed.
-	if (EmuConfig.GS.LimitScalar != 1.0f)
-		return VsyncMode::Off;
-
-	// Otherwise use the config setting.
-	return EmuConfig.GS.VsyncEnable;
 }
 
 bool Host::BeginPresentFrame(bool frame_skip)


### PR DESCRIPTION
### Description of Changes

Fixes rendering at thousands of FPS when pausing if FSUI is active.

Avoids flickering when recreating swap chain in vulkan on menu open, because we're no longer doing it.

### Rationale behind Changes

Above reasons.

### Suggested Testing Steps

Test pausing with and without fullscreen UI with some external FPS monitoring tool, make sure the FPS doesn't exceed the screen refresh rate.
