### PR TITLE
FullscreenUI: Allow unbinding a hotkey/controller with Triangle

### DIFF
--- a/pcsx2/Frontend/FullscreenUI.cpp
+++ b/pcsx2/Frontend/FullscreenUI.cpp
@@ -1265,7 +1265,7 @@ void FullscreenUI::DrawInputBindingButton(SettingsInterface* bsi, PAD::Controlle
 	{
 		BeginInputBinding(bsi, type, section, name, display_name);
 	}
-	else if (ImGui::IsItemClicked(ImGuiMouseButton_Right))
+	else if (ImGui::IsItemClicked(ImGuiMouseButton_Right) || ImGui::IsNavInputTest(ImGuiNavInput_Input, ImGuiNavReadMode_Pressed))
 	{
 		bsi->DeleteValue(section, name);
 		SetSettingsChanged(bsi);


### PR DESCRIPTION
### Description of Changes

Previously this wasn't possible with a controller, only the mouse.

Follow the same convention as other UI options (alternate action = triangle/Y).

### Rationale behind Changes

See above.

### Suggested Testing Steps

Make sure it compiles.