### PR TITLE
Qt: Remove hardware download mode from global settings

### DIFF
--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -336,12 +336,13 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsDialog* dialog, QWidget* 
 	updateRendererDependentOptions();
 
 #ifndef PCSX2_DEVBUILD
-	// only allow disabling readbacks for per-game settings, it's too dangerous
-	m_ui.gsDownloadMode->setEnabled(m_dialog->isPerGameSettings());
-
-	// Remove texture offset and skipdraw range for global settings.
 	if (!m_dialog->isPerGameSettings())
 	{
+		// Only allow disabling readbacks for per-game settings, it's too dangerous.
+		m_ui.advancedDebugFormLayout->removeRow(2);
+		m_ui.gsDownloadMode = nullptr;
+
+		// Remove texture offset and skipdraw range for global settings.
 		m_ui.upscalingFixesLayout->removeRow(2);
 		m_ui.hardwareFixesLayout->removeRow(2);
 		m_ui.hardwareFixesLayout->removeRow(1);

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
@@ -1596,7 +1596,7 @@
          <property name="title">
           <string>Debug Options</string>
          </property>
-         <layout class="QFormLayout" name="formLayout_6">
+         <layout class="QFormLayout" name="advancedDebugFormLayout">
           <item row="0" column="0">
            <widget class="QLabel" name="label_19">
             <property name="text">


### PR DESCRIPTION
### Description of Changes

Previously it would be disabled, leading to user confusion.

### Rationale behind Changes

See above.

### Suggested Testing Steps

Make sure it compiles.
