### PR TITLE
VU: Correct XGKick timing when using XGKickSync

### DIFF
--- a/pcsx2/VUops.cpp
+++ b/pcsx2/VUops.cpp
@@ -2721,7 +2721,9 @@ static __ri void _vuXGKICK(VURegs* VU)
 	VU->xgkicksizeremaining = 0;
 	VU->xgkickendpacket = false;
 	VU->xgkicklastcycle = VU->cycle;
-	VU->xgkickcyclecount = 0;
+	// XGKick command counts as one cycle for the transfer.
+	// Can be tested with Resident Evil: Outbreak, Kingdom Hearts, CART Fury.
+	VU->xgkickcyclecount = 1;
 	VU0.VI[REG_VPU_STAT].UL |= (1 << 12);
 	VUM_LOG("XGKICK addr %x", addr);
 }

--- a/pcsx2/x86/microVU_Compile.inl
+++ b/pcsx2/x86/microVU_Compile.inl
@@ -681,7 +681,9 @@ void* mVUcompile(microVU& mVU, u32 startPC, uptr pState)
 		}
 		else
 		{
-			mVUregs.xgkickcycles = 0;
+			// XGKick command counts as one cycle for the transfer.
+			// Can be tested with Resident Evil: Outbreak, Kingdom Hearts, CART Fury.
+			mVUregs.xgkickcycles = 1;
 			mVUlow.kickcycles = 0;
 		}
 


### PR DESCRIPTION
### Description of Changes
Fixes the timing when using XGKick Sync

### Rationale behind Changes
Some games are very sensitive to the timing at the beginning of an XGKick, particularly Resident Evil: Outbreak, CART Fury: Championship Racing and Kingdom Hearts, as the XGKick instruction itself counts for at least one cycle (each XG packet takes 2 cycles to transfer), this being out caused a lot of SPS problems.

### Suggested Testing Steps
Test games which use XGKick in the gamedb, make sure they're fine (Did test WRC PAL briefly and was fine)

Fixes #5328 CART Fury
Fixes #5107 Resident Evil Outbreak
