### PR TITLE
GS-HW: Handle clears with single page width better + use vert color

### DIFF
--- a/pcsx2/GS/GSRegs.h
+++ b/pcsx2/GS/GSRegs.h
@@ -540,7 +540,7 @@ REG_END2
 	__forceinline bool IsOpaque() const { return ((A == B || (C == 2 && FIX == 0)) && D == 0) || (A == 0 && B == D && C == 2 && FIX == 0x80) || (C == 2 && D != 1 && FIX == 0x00); }
 	__forceinline bool IsOpaque(int amin, int amax) const { return ((A == B || amax == 0) && D == 0) || (A == 0 && B == D && amin == 0x80 && amax == 0x80) || (C == 2 && D != 1 && FIX == 0x00); }
 	__forceinline bool IsCd() { return (A == B) && (D == 1); }
-	__forceinline bool IsBlack() { return ((C == 2 && FIX == 0) || (A == 2 && A == B)) && D == 2; }
+	__forceinline bool IsBlack() const { return ((C == 2 && FIX == 0) || (A == 2 && A == B)) && D == 2; }
 REG_END2
 
 REG64_(GIFReg, BITBLTBUF)

--- a/pcsx2/GS/GSRegs.h
+++ b/pcsx2/GS/GSRegs.h
@@ -536,9 +536,9 @@ REG64_(GIFReg, ALPHA)
 	u8 FIX;
 	u8 _PAD2[3];
 REG_END2
-	// opaque => output will be Cs/As
-	__forceinline bool IsOpaque() const { return ((A == B || (C == 2 && FIX == 0)) && D == 0) || (A == 0 && B == D && C == 2 && FIX == 0x80); }
-	__forceinline bool IsOpaque(int amin, int amax) const { return ((A == B || amax == 0) && D == 0) || (A == 0 && B == D && amin == 0x80 && amax == 0x80); }
+	// opaque => output will be Cs/As/zero
+	__forceinline bool IsOpaque() const { return ((A == B || (C == 2 && FIX == 0)) && D == 0) || (A == 0 && B == D && C == 2 && FIX == 0x80) || (C == 2 && D != 1 && FIX == 0x00); }
+	__forceinline bool IsOpaque(int amin, int amax) const { return ((A == B || amax == 0) && D == 0) || (A == 0 && B == D && amin == 0x80 && amax == 0x80) || (C == 2 && D != 1 && FIX == 0x00); }
 	__forceinline bool IsCd() { return (A == B) && (D == 1); }
 REG_END2
 

--- a/pcsx2/GS/GSRegs.h
+++ b/pcsx2/GS/GSRegs.h
@@ -540,6 +540,7 @@ REG_END2
 	__forceinline bool IsOpaque() const { return ((A == B || (C == 2 && FIX == 0)) && D == 0) || (A == 0 && B == D && C == 2 && FIX == 0x80) || (C == 2 && D != 1 && FIX == 0x00); }
 	__forceinline bool IsOpaque(int amin, int amax) const { return ((A == B || amax == 0) && D == 0) || (A == 0 && B == D && amin == 0x80 && amax == 0x80) || (C == 2 && D != 1 && FIX == 0x00); }
 	__forceinline bool IsCd() { return (A == B) && (D == 1); }
+	__forceinline bool IsBlack() { return ((C == 2 && FIX == 0) || (A == 2 && A == B)) && D == 2; }
 REG_END2
 
 REG64_(GIFReg, BITBLTBUF)

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -3627,7 +3627,7 @@ void GSRendererHW::DrawPrims(GSTexture* rt, GSTexture* ds, GSTextureCache::Sourc
 	// Blend
 
 	bool blending_alpha_pass = false;
-	if (!IsOpaque() && rt && m_conf.colormask.wrgba != 0)
+	if ((!IsOpaque() || (PRIM->ABE && m_context->ALPHA.IsBlack())) && rt && m_conf.colormask.wrgba != 0)
 	{
 		EmulateBlending(DATE_PRIMID, DATE_BARRIER, blending_alpha_pass);
 	}

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -1456,7 +1456,8 @@ void GSRendererHW::Draw()
 	m_texture_shuffle = false;
 	m_tex_is_fb = false;
 
-	if (PRIM->TME)
+	// Disable texture mapping if the blend is black and using alpha from vertex.
+	if (PRIM->TME && !(PRIM->ABE && m_context->ALPHA.IsBlack() && !m_context->TEX0.TCC))
 	{
 		GIFRegCLAMP MIP_CLAMP = context->CLAMP;
 		GSVector2i hash_lod_range(0, 0);
@@ -3627,7 +3628,7 @@ void GSRendererHW::DrawPrims(GSTexture* rt, GSTexture* ds, GSTextureCache::Sourc
 	// Blend
 
 	bool blending_alpha_pass = false;
-	if ((!IsOpaque() || (PRIM->ABE && m_context->ALPHA.IsBlack())) && rt && m_conf.colormask.wrgba != 0)
+	if ((!IsOpaque() || m_context->ALPHA.IsBlack()) && rt && (m_conf.colormask.wrgba & 0x7))
 	{
 		EmulateBlending(DATE_PRIMID, DATE_BARRIER, blending_alpha_pass);
 	}

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.h
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.h
@@ -54,7 +54,6 @@ private:
 	bool OI_RozenMaidenGebetGarden(GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
 	bool OI_SonicUnleashed(GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
 	bool OI_PointListPalette(GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
-	bool OI_SuperManReturns(GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
 	bool OI_ArTonelico2(GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
 	bool OI_JakGames(GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
 	bool OI_BurnoutGames(GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);


### PR DESCRIPTION
### Description of Changes
Handles single page width clears with a large height as a full buffer clear, since HW cannot handle it. Also uses the colour the game wishes to clear with instead of forcing zero.

### Rationale behind Changes
Superman Returns does single page width clears with a non-zero colour which causes massive textures consuming the entire GS memory to be created, causing bad frames to be selected at the present, resulting in flashing, since we're now more specific on which target we use now.

### Suggested Testing Steps
Test games, make sure nothing is broken, especially games which break if you disable safe features or know of ones which do "double half clear", etc.

Fixes screen flashing on Superman Returns: The Video Game.
