### PR TITLE
SaveState: Bump version

### DIFF
--- a/pcsx2/SaveState.h
+++ b/pcsx2/SaveState.h
@@ -36,7 +36,7 @@ enum class FreezeAction
 // [SAVEVERSION+]
 // This informs the auto updater that the users savestates will be invalidated.
 
-static const u32 g_SaveVersion = (0x9A33 << 16) | 0x0000;
+static const u32 g_SaveVersion = (0x9A34 << 16) | 0x0000;
 
 
 // the freezing data between submodules and core


### PR DESCRIPTION
### Description of Changes

[SAVEVERSION+] 44e69a9 changed the size of the microVU state struct, which is saved (to resume incomplete micros), without bumping the version.

### Rationale behind Changes

Loading old save states and crashing is bad.

### Suggested Testing Steps

Make sure build succeeds (no reason why it wouldn't).
