### PR TITLE
GameDB: A few game fixes and tweaks 

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -1198,7 +1198,6 @@ SCAJ-20154:
   region: "NTSC-Unk"
   gsHWFixes:
     autoFlush: 1 # Reduces post-processing misalignment.
-    roundSprite: 2 # Reduces post-processing misalignment.
 SCAJ-20155:
   name: "Yoshitsune Eiyuuden Syura"
   region: "NTSC-Unk"
@@ -1264,7 +1263,7 @@ SCAJ-20164:
   region: "NTSC-Unk"
   gsHWFixes:
     autoFlush: 1 # Fixes effects.
-    halfPixelOffset: 1 # Fixes upscaling artifacts.
+    roundSprite: 2 # Fixes upscaling artifacts.
 SCAJ-20165:
   name: "Bleach - Hanatareshi Yabou"
   region: "NTSC-Unk"
@@ -3763,6 +3762,8 @@ SCES-53247:
     - XGKickHack # Fixes SPS.
   clampModes:
     eeClampMode: 2 # Fixes rare bug causing player to respawn when starting the race or during certain car crashes.
+  gsHWFixes:
+    roundSprite: 1 # Fixes misaligned text.
   patches:
     CBBC2E7F:
       content: |-
@@ -3935,6 +3936,8 @@ SCES-53680:
   region: "PAL-M5"
   gameFixes:
     - XGKickHack # Fixes SPS.
+  gsHWFixes:
+    roundSprite: 1 # Fixes misaligned text.
   patches:
     79BAD675:
       content: |-
@@ -9158,7 +9161,6 @@ SLED-52929:
   region: "PAL-M5"
   gsHWFixes:
     autoFlush: 1 # Reduces post-processing misalignment.
-    roundSprite: 2 # Reduces post-processing misalignment.
 SLED-53083:
   name: "Monster Hunter [Demo]"
   region: "PAL-M5"
@@ -15418,7 +15420,6 @@ SLES-52822:
   compat: 5
   gsHWFixes:
     autoFlush: 1 # Reduces post-processing misalignment.
-    roundSprite: 2 # Reduces post-processing misalignment.
 SLES-52824:
   name: "Furry Tales"
   region: "PAL-E-F"
@@ -18543,7 +18544,7 @@ SLES-54114:
   region: "PAL-E"
   gsHWFixes:
     autoFlush: 1 # Fixes effects.
-    halfPixelOffset: 1 # Fixes upscaling artifacts.
+    roundSprite: 2 # Fixes upscaling artifacts.
   compat: 5
 SLES-54115:
   name: "Delta Force - Black Hawk Down - Team Sabre"
@@ -18904,25 +18905,25 @@ SLES-54232:
   region: "PAL-F"
   gsHWFixes:
     autoFlush: 1 # Fixes effects.
-    halfPixelOffset: 1 # Fixes upscaling artifacts.
+    roundSprite: 2 # Fixes upscaling artifacts.
 SLES-54233:
   name: "Kingdom Hearts II"
   region: "PAL-G"
   gsHWFixes:
     autoFlush: 1 # Fixes effects.
-    halfPixelOffset: 1 # Fixes upscaling artifacts.
+    roundSprite: 2 # Fixes upscaling artifacts.
 SLES-54234:
   name: "Kingdom Hearts II"
   region: "PAL-I"
   gsHWFixes:
     autoFlush: 1 # Fixes effects.
-    halfPixelOffset: 1 # Fixes upscaling artifacts.
+    roundSprite: 2 # Fixes upscaling artifacts.
 SLES-54235:
   name: "Kingdom Hearts II"
   region: "PAL-S"
   gsHWFixes:
     autoFlush: 1 # Fixes effects.
-    halfPixelOffset: 1 # Fixes upscaling artifacts.
+    roundSprite: 2 # Fixes upscaling artifacts.
 SLES-54237:
   name: "Pirates of the Caribbean - The Legend of Jack Sparrow"
   region: "PAL-M5"
@@ -30153,7 +30154,6 @@ SLPM-66002:
   region: "NTSC-J"
   gsHWFixes:
     autoFlush: 1 # Reduces post-processing misalignment.
-    roundSprite: 2 # Reduces post-processing misalignment.
 SLPM-66006:
   name: "Angelique Trois - Aizouhen [Koei Selection]"
   region: "NTSC-J"
@@ -31012,7 +31012,7 @@ SLPM-66233:
   region: "NTSC-J"
   gsHWFixes:
     autoFlush: 1 # Fixes effects.
-    halfPixelOffset: 1 # Fixes upscaling artifacts.
+    roundSprite: 2 # Fixes upscaling artifacts.
   compat: 5
 SLPM-66234:
   name: "Wizardry X - Zensen no Gakufu [Wonder Price]"
@@ -32648,7 +32648,6 @@ SLPM-66673:
   region: "NTSC-J"
   gsHWFixes:
     autoFlush: 1 # Reduces post-processing misalignment.
-    roundSprite: 2 # Reduces post-processing misalignment.
 SLPM-66674:
   name: "Tiger Woods PGA Tour 07"
   region: "NTSC-J"
@@ -44203,7 +44202,7 @@ SLUS-21005:
   region: "NTSC-U"
   gsHWFixes:
     autoFlush: 1 # Fixes effects.
-    halfPixelOffset: 1 # Fixes upscaling artifacts.
+    roundSprite: 2 # Fixes upscaling artifacts.
   compat: 5
 SLUS-21006:
   name: "Ghost in the Shell - Stand Alone Complex"
@@ -44332,7 +44331,6 @@ SLUS-21022:
   compat: 5
   gsHWFixes:
     autoFlush: 1 # Reduces post-processing misalignment.
-    roundSprite: 2 # Reduces post-processing misalignment.
 SLUS-21025:
   name: "Madden NFL 2005 [Special Collectors Edition]"
   region: "NTSC-U"
@@ -49695,6 +49693,8 @@ TCES-53247:
   region: "PAL-E"
   gameFixes:
     - XGKickHack # Fixes SPS.
+  gsHWFixes:
+    roundSprite: 1 # Fixes misaligned text.
 TCES-53286:
   name: "Jak X Beta Trial Code"
   region: "PAL-E"


### PR DESCRIPTION
### Description of Changes
HPO Normal causes really bad glitching on the floor in KH2 round sprite breaks light bloom in Price of Persia WW and WRC Rally Evolved needs round sprite half to fix misaligned text.

### Rationale behind Changes
This is bad it shouldn't be doing this:

![image](https://user-images.githubusercontent.com/80843560/205713535-65226eab-7101-4ac4-aadb-cc7d7423ba1c.png)

It should look like this with Round Sprite Full:

![image](https://user-images.githubusercontent.com/80843560/205801211-956afe07-2eb4-4edf-a7a6-7a111b4ce708.png)


### Suggested Testing Steps
Happy CI is good yes.
