### PR TITLE
GS/HW: Don't consider custom textures in hash cache overflow

### DIFF
--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -700,7 +700,7 @@ void GSgetStats(std::string& info)
 		{
 			info = StringUtil::StdStringFromFormat("%s HW | HC: %d MB | %d P | %d D | %d DC | %d B | %d RB | %d TC | %d TU",
 				api_name,
-				(int)std::ceil(GSRendererHW::GetInstance()->GetTextureCache()->GetHashCacheMemoryUsage() / 1048576.0f),
+				(int)std::ceil(GSRendererHW::GetInstance()->GetTextureCache()->GetTotalHashCacheMemoryUsage() / 1048576.0f),
 				(int)pm.Get(GSPerfMon::Prim),
 				(int)pm.Get(GSPerfMon::Draw),
 				(int)std::ceil(pm.Get(GSPerfMon::DrawCalls)),

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.h
@@ -300,6 +300,7 @@ protected:
 	SourceMap m_src;
 	std::unordered_map<HashCacheKey, HashCacheEntry, HashCacheKeyHash> m_hash_cache;
 	u64 m_hash_cache_memory_usage = 0;
+	u64 m_hash_cache_replacement_memory_usage;
 	FastList<Target*> m_dst[2];
 	FastList<TargetHeightElem> m_target_heights;
 	static u8* m_temp;
@@ -327,6 +328,8 @@ public:
 	~GSTextureCache();
 
 	__fi u64 GetHashCacheMemoryUsage() const { return m_hash_cache_memory_usage; }
+	__fi u64 GetHashCacheReplacementMemoryUsage() const { return m_hash_cache_replacement_memory_usage; }
+	__fi u64 GetTotalHashCacheMemoryUsage() const { return (m_hash_cache_memory_usage + m_hash_cache_replacement_memory_usage); }
 
 	void Read(Target* t, const GSVector4i& r);
 	void Read(Source* t, const GSVector4i& r);


### PR DESCRIPTION
### Description of Changes

Prevents hash cache from being disabled due to a large number of custom textures. The VRAM usage from the custom textures will still be shown in the OSD.

### Rationale behind Changes

Apparently people have some *really* high resolution replacement textures...

### Suggested Testing Steps

Probably a bit difficult to check if you don't have some of these textures.. but you can still check the hash cache usage increases as before with replacements.
