### PR TITLE
GS: Add missing initialization of m_skipped_duplicate_frames

### DIFF
--- a/pcsx2/GS/Renderers/Common/GSRenderer.h
+++ b/pcsx2/GS/Renderers/Common/GSRenderer.h
@@ -40,7 +40,7 @@ private:
 #endif
 	std::string m_snapshot;
 	u32 m_dump_frames = 0;
-	u32 m_skipped_duplicate_frames;
+	u32 m_skipped_duplicate_frames = 0;
 
 protected:
 	GSVector2i m_real_size{0, 0};


### PR DESCRIPTION
### Description of Changes

Self-explanatory.

### Rationale behind Changes

Relying on uninitialized data is bad.

### Suggested Testing Steps

Make sure compile succeeds.

