### PR TITLE
Qt: Resizes + better tooltips + Savestate warning

### DIFF
--- a/pcsx2-qt/MainWindow.ui
+++ b/pcsx2-qt/MainWindow.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>950</width>
-    <height>640</height>
+    <width>1050</width>
+    <height>666</height>
    </rect>
   </property>
   <property name="acceptDrops">
@@ -22,7 +22,7 @@
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>950</width>
+     <width>1050</width>
      <height>22</height>
     </rect>
    </property>

--- a/pcsx2-qt/Settings/ControllerBindingWidget.ui
+++ b/pcsx2-qt/Settings/ControllerBindingWidget.ui
@@ -29,7 +29,7 @@
    <item>
     <widget class="QGroupBox" name="groupBox">
      <property name="title">
-      <string>Controller Type</string>
+      <string>Virtual Controller Type</string>
      </property>
      <layout class="QHBoxLayout" name="horizontalLayout_3">
       <item>
@@ -42,12 +42,12 @@
           <property name="text">
            <string>Bindings</string>
           </property>
-          <property name="checkable">
-           <bool>true</bool>
-          </property>
           <property name="icon">
            <iconset theme="gamepad-line">
             <normaloff>.</normaloff>.</iconset>
+          </property>
+          <property name="checkable">
+           <bool>true</bool>
           </property>
           <property name="toolButtonStyle">
            <enum>Qt::ToolButtonTextBesideIcon</enum>
@@ -148,7 +148,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QStackedWidget" name="stackedWidget" />
+    <widget class="QStackedWidget" name="stackedWidget"/>
    </item>
   </layout>
  </widget>

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -397,7 +397,10 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsDialog* dialog, QWidget* 
 			tr("Reduces texture aliasing at extreme viewing angles."));
 
 		dialog->registerWidgetHelp(m_ui.dithering, tr("Dithering"), tr("Unscaled (Default)"),
-			tr("Reduces banding between colors and improves the perceived color depth."));
+			tr("Reduces banding between colors and improves the perceived color depth.<br> "
+			   "Off: Disables any dithering.<br> "
+			   "Unscaled: Native Dithering / Lowest dithering effect does not increase size of squares when upscaling.<br> "
+			   "Scaled: Upscaling-aware / Highest dithering effect."));
 
 		dialog->registerWidgetHelp(m_ui.crcFixLevel, tr("CRC Fix Level"), tr("Automatic (Default)"),
 			tr("Control the number of Auto-CRC fixes and hacks applied to games."));

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>658</width>
-    <height>476</height>
+    <width>850</width>
+    <height>500</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -89,12 +89,12 @@
         <widget class="QComboBox" name="aspectRatio">
          <item>
           <property name="text">
-           <string>Fit to Window/Screen</string>
+           <string>Fit to Window / Fullscreen</string>
           </property>
          </item>
          <item>
           <property name="text">
-           <string>Auto Standard (4:3/3:2 Progressive)</string>
+           <string>Auto Standard (4:3 Interlaced / 3:2 Progressive)</string>
           </property>
          </item>
          <item>
@@ -125,7 +125,7 @@
          </item>
          <item>
           <property name="text">
-           <string>Auto Standard (4:3/3:2 Progressive)</string>
+           <string>Auto Standard (4:3 Interlaced / 3:2 Progressive)</string>
           </property>
          </item>
          <item>
@@ -143,7 +143,7 @@
        <item row="3" column="0">
         <widget class="QLabel" name="label_23">
          <property name="text">
-          <string>Deinterlacing:</string>
+          <string>De-interlacing:</string>
          </property>
         </widget>
        </item>
@@ -156,7 +156,7 @@
          </item>
          <item>
           <property name="text">
-           <string>None</string>
+           <string>None (Interlaced, also used by Progressive)</string>
           </property>
          </item>
          <item>
@@ -171,32 +171,32 @@
          </item>
          <item>
           <property name="text">
-           <string>Bob (Top Field First)</string>
+           <string>Bob (Top Field First, Full Frames)</string>
           </property>
          </item>
          <item>
           <property name="text">
-           <string>Bob (Bottom Field First)</string>
+           <string>Bob (Bottom Field First, Full Frames)</string>
           </property>
          </item>
          <item>
           <property name="text">
-           <string>Blend (Top Field First, Half FPS)</string>
+           <string>Blend (Top Field First, Merge 2 Fields)</string>
           </property>
          </item>
          <item>
           <property name="text">
-           <string>Blend (Bottom Field First, Half FPS)</string>
+           <string>Blend (Bottom Field First, Merge 2 Fields)</string>
           </property>
          </item>
          <item>
           <property name="text">
-           <string>Adaptive (Top Field First)</string>
+           <string>Adaptive (Top Field First, Similar to Bob + Weave)</string>
           </property>
          </item>
          <item>
           <property name="text">
-           <string>Adaptive (Bottom Field First)</string>
+           <string>Adaptive (Bottom Field First, Similar to Bob + Weave)</string>
           </property>
          </item>
         </widget>
@@ -1772,8 +1772,8 @@
      </property>
      <property name="sizeHint" stdset="0">
       <size>
-       <width>20</width>
-       <height>40</height>
+       <width>40</width>
+       <height>60</height>
       </size>
      </property>
     </spacer>

--- a/pcsx2/CDVD/InputIsoFile.cpp
+++ b/pcsx2/CDVD/InputIsoFile.cpp
@@ -250,7 +250,7 @@ bool InputIsoFile::Open(std::string srcfile, bool testOnly)
 
 	if (!detected)
 		throw Exception::BadStream()
-			.SetUserMsg("Unrecognized ISO image file format")
+			.SetUserMsg("Unrecognized ISO image file format.")
 			.SetDiagMsg("ISO mounting failed: PCSX2 is unable to identify the ISO image type.");
 
 	if (!isBlockdump && !isCompressed)

--- a/pcsx2/SaveState.cpp
+++ b/pcsx2/SaveState.cpp
@@ -1048,15 +1048,13 @@ static void CheckVersion(const std::string& filename, zip_t* zf)
 	if (savever > g_SaveVersion)
 		throw Exception::SaveStateLoadError(filename)
 			.SetDiagMsg(fmt::format("Savestate uses an unsupported or unknown savestate version.\n(PCSX2 ver={:x}, state ver={:x})", g_SaveVersion, savever))
-			.SetUserMsg("Cannot load this savestate. The state is an unsupported version.");
-
+			.SetUserMsg("Cannot load this savestate. The state is an unsupported version.\nOption 1: Download an older PCSX2 version from pcsx2.net and make a memcard save like on the physical PS2.\nOption 2: Delete the savestates.");
 	// check for a "minor" version incompatibility; which happens if the savestate being loaded is a newer version
 	// than the emulator recognizes.  99% chance that trying to load it will just corrupt emulation or crash.
 	if ((savever >> 16) != (g_SaveVersion >> 16))
 		throw Exception::SaveStateLoadError(filename)
 			.SetDiagMsg(fmt::format("Savestate uses an unknown savestate version.\n(PCSX2 ver={:x}, state ver={:x})", g_SaveVersion, savever))
-			.SetUserMsg("Cannot load this savestate. The state is an unsupported version.");
-}
+			.SetUserMsg("Cannot load this savestate. The state is an unsupported version.\nOption 1: Download an older PCSX2 version from pcsx2.net and make a memcard save like on the physical PS2.\nOption 2: Delete the savestates.");}
 
 static zip_int64_t CheckFileExistsInState(zip_t* zf, const char* name, bool required)
 {


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Bigger tooltip window
Controllers button shows up correctly at different DPI percentages 
Rename some options.

![image](https://user-images.githubusercontent.com/24227051/206067931-426a6a3a-c26b-4a8e-8db1-0bc768db51e4.png)

![image](https://user-images.githubusercontent.com/24227051/206067988-4bfd48be-5052-47ac-b947-d77f7e510753.png)

![image](https://user-images.githubusercontent.com/24227051/206068042-e8095c54-2921-445e-9be4-09d0965f87dd.png)

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
More sense and more obvious settings or options.
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Check the GUI in Qt