### PR TITLE
CMake: Fix issues with linkers failing on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Setting it to a range tells it that it supports the features on the newer
 # versions as well, avoiding setting policies.
-cmake_minimum_required(VERSION 3.11...3.22)
+cmake_minimum_required(VERSION 3.12...3.24)
 
 if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
 	message(FATAL_ERROR "PCSX2 does not support in-tree builds.  Please make a build directory that is not the PCSX2 source directory and generate your CMake project there using either `cmake -B build_directory` or by running cmake from the build directory.")

--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -6,7 +6,12 @@ add_library(PCSX2_FLAGS INTERFACE)
 if (NOT PCSX2_CORE)
 	add_executable(PCSX2)
 else()
-	add_library(PCSX2)
+	if(DISABLE_ADVANCE_SIMD OR LTO_PCSX2_CORE)
+		# Fixes issues with some compiler + linker combinations
+		add_library(PCSX2 OBJECT)
+	else()
+		add_library(PCSX2)
+	endif()
 	target_compile_definitions(PCSX2_FLAGS INTERFACE
 		"PCSX2_CORE"
 	)


### PR DESCRIPTION
### Description of Changes
Fixes issues with `DISABLE_ADVANCE_SIMD=ON` builds failing to link on some compiler+linker combinations

Fixes #7543 

### Rationale behind Changes
Less broken builds

### Suggested Testing Steps
Try to build on Linux with all sorts of compilers and linkers