### PR TITLE
GS: Compute luminance in shader for FXAA

### DIFF
--- a/bin/resources/shaders/common/fxaa.fx
+++ b/bin/resources/shaders/common/fxaa.fx
@@ -55,19 +55,22 @@ static constexpr sampler MAIN_SAMPLER(coord::normalized, address::clamp_to_edge,
                              [FXAA CODE SECTION]
 ------------------------------------------------------------------------------*/
 
+// We don't use gather4 for alpha/luminance because it would require an additional
+// pass to compute the values, which would be slower than the extra shader loads.
+
 #if (SHADER_MODEL >= 0x500)
 #define FXAA_HLSL_5 1
-#define FXAA_GATHER4_ALPHA 1
+#define FXAA_GATHER4_ALPHA 0
 
 #elif (SHADER_MODEL >= 0x400)
 #define FXAA_HLSL_4 1
 #define FXAA_GATHER4_ALPHA 0
 
 #elif (FXAA_GLSL_130 == 1 || FXAA_GLSL_VK == 1)
-#define FXAA_GATHER4_ALPHA 1
+#define FXAA_GATHER4_ALPHA 0
 
 #elif defined(__METAL_VERSION__)
-#define FXAA_GATHER4_ALPHA 1
+#define FXAA_GATHER4_ALPHA 0
 #endif
 
 #if (FXAA_HLSL_5 == 1)
@@ -526,7 +529,7 @@ void main()
 	color      = PreGammaPass(color);
 	color      = FxaaPass(color, PSin_t);
 
-	SV_Target0 = color;
+	SV_Target0 = float4(color.rgb, 1.0);
 }
 
 #elif (SHADER_MODEL >= 0x400)
@@ -539,7 +542,7 @@ PS_OUTPUT ps_main(VS_OUTPUT input)
 	color = PreGammaPass(color);
 	color = FxaaPass(color, input.t);
 
-	output.c = color;
+	output.c = float4(color.rgb, 1.0);
 	
 	return output;
 }

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
@@ -871,7 +871,7 @@ void GSDevice11::DoShadeBoost(GSTexture* sTex, GSTexture* dTex, const float para
 
 	m_ctx->UpdateSubresource(m_shadeboost.cb.get(), 0, nullptr, params, 0, 0);
 
-	StretchRect(sTex, sRect, dTex, dRect, m_shadeboost.ps.get(), m_shadeboost.cb.get(), true);
+	StretchRect(sTex, sRect, dTex, dRect, m_shadeboost.ps.get(), m_shadeboost.cb.get(), false);
 }
 
 bool GSDevice11::CreateCASShaders()

--- a/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
@@ -770,6 +770,7 @@ void GSDevice12::DoShadeBoost(GSTexture* sTex, GSTexture* dTex, const float para
 	const GSVector4i dRect(0, 0, dTex->GetWidth(), dTex->GetHeight());
 	EndRenderPass();
 	OMSetRenderTargets(dTex, nullptr, dRect);
+	SetUtilityRootSignature();
 	SetUtilityTexture(sTex, m_point_sampler_cpu);
 	BeginRenderPass(D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_DISCARD, D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_PRESERVE,
 		D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_NO_ACCESS, D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_NO_ACCESS);
@@ -787,6 +788,7 @@ void GSDevice12::DoFXAA(GSTexture* sTex, GSTexture* dTex)
 	const GSVector4i dRect(0, 0, dTex->GetWidth(), dTex->GetHeight());
 	EndRenderPass();
 	OMSetRenderTargets(dTex, nullptr, dRect);
+	SetUtilityRootSignature();
 	SetUtilityTexture(sTex, m_linear_sampler_cpu);
 	BeginRenderPass(D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_DISCARD, D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_PRESERVE,
 		D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_NO_ACCESS, D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_NO_ACCESS);

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -1446,7 +1446,7 @@ void GSDeviceOGL::DoShadeBoost(GSTexture* sTex, GSTexture* dTex, const float par
 	const GSVector4 sRect(0, 0, 1, 1);
 	const GSVector4 dRect(0, 0, s.x, s.y);
 
-	StretchRect(sTex, sRect, dTex, dRect, m_shadeboost.ps, true);
+	StretchRect(sTex, sRect, dTex, dRect, m_shadeboost.ps, false);
 }
 
 void GSDeviceOGL::SetupDATE(GSTexture* rt, GSTexture* ds, const GSVertexPT1* vertices, bool datm)


### PR DESCRIPTION
### Description of Changes

Fixes FXAA being broken after https://github.com/PCSX2/pcsx2/commit/b706c25b68b25fe5e4cc84b5420f225f201ac739.

Will be slightly difference since this is using the BT.709 coefficients instead of CCIR 601 - but it matches the non-gather codepath now.

Also gets rid of an additional copy when FXAA/ShadeBoost is active.

### Rationale behind Changes

Regression fix, ever-so-slight VRAM bandwidth savings.

### Suggested Testing Steps

Test FXAA and also make sure I didn't regress #7565.
