### PR TITLE
GameDB: PAL localized names fixes

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -4146,7 +4146,7 @@ SCES-54261:
   name: "Buzz! The Sports Quiz"
   region: "PAL-I"
 SCES-54262:
-  name: "Buzz! The Sports Quiz"
+  name: "Buzz! - El Gran Concurso de Deportes"
   region: "PAL-S"
 SCES-54263:
   name: "Buzz! The Sports Quiz"
@@ -4483,7 +4483,7 @@ SCES-55255:
   name: "SingStar Singalong with Disney"
   region: "PAL-E"
 SCES-55256:
-  name: "SingStar Canciones Disney"
+  name: "SingStar canciones Disney"
   region: "PAL-S"
 SCES-55257:
   name: "SingStar - Chansons Magiques de Disney"
@@ -4582,7 +4582,7 @@ SCES-55521:
   name: "SingStar SuomiPop"
   region: "PAL-FI"
 SCES-55527:
-  name: "SingStar 2009"
+  name: "SingStar Pop 2009"
   region: "PAL-S"
 SCES-55535:
   name: "Desi Adda - Games of India"
@@ -9823,17 +9823,17 @@ SLES-50225:
   name: "Escape from Monkey Island"
   region: "PAL-E"
 SLES-50226:
-  name: "Escape from Monkey Island 4"
+  name: "Escape from Monkey Island"
   region: "PAL-F"
 SLES-50227:
   name: "Flucht von Monkey Island"
   region: "PAL-G"
   compat: 5
 SLES-50228:
-  name: "Escape from Monkey Island 4"
+  name: "Fuga da Monkey Island"
   region: "PAL-I"
 SLES-50229:
-  name: "Monkey Island 4"
+  name: "Fuga de Monkey Island, La"
   region: "PAL-S"
 SLES-50230:
   name: "Lotus Challenge"
@@ -11106,14 +11106,14 @@ SLES-50836:
   gsHWFixes:
     textureInsideRT: 1
 SLES-50837:
-  name: "Indiana Jones and The Emperor's Tomb"
+  name: "Indiana Jones et le Tombeau de L'Empereur"
   region: "PAL-F"
   gameFixes:
     - EETimingHack # For texture flicker.
   gsHWFixes:
     textureInsideRT: 1
 SLES-50838:
-  name: "Indiana Jones and The Emperor's Tomb"
+  name: "Indiana Jones und die Legende der Kaisergruft"
   region: "PAL-G"
   compat: 5
   gameFixes:
@@ -11121,14 +11121,14 @@ SLES-50838:
   gsHWFixes:
     textureInsideRT: 1
 SLES-50839:
-  name: "Indiana Jones and The Emperor's Tomb"
+  name: "Indiana Jones e la Tomba dell'Imperatore"
   region: "PAL-I"
   gameFixes:
     - EETimingHack # For texture flicker.
   gsHWFixes:
     textureInsideRT: 1
 SLES-50840:
-  name: "Indiana Jones and The Emperor's Tomb"
+  name: "Indiana Jones y la Tumba del Emperador"
   region: "PAL-S"
   gameFixes:
     - EETimingHack # For texture flicker.
@@ -11484,7 +11484,7 @@ SLES-51026:
   name: "Football Manager Campionato 2003"
   region: "PAL-I"
 SLES-51027:
-  name: "Mánager de Liga 2003"
+  name: "Manager de Liga 2003"
   region: "PAL-S"
 SLES-51038:
   name: "MX Superfly featuring Ricky Carmichael"
@@ -11843,7 +11843,7 @@ SLES-51194:
     mipmap: 1
     cpuFramebufferConversion: 1 # Fixes right side of the screen from garbage textures.
 SLES-51195:
-  name: "Harry Potter y La Camara Secreta"
+  name: "Harry Potter y la Cámara Secreta"
   region: "PAL-S"
   gameFixes:
     - EETimingHack # Fixes flickering textures.
@@ -12051,17 +12051,17 @@ SLES-51253:
   clampModes:
     vuClampMode: 3 # Fix white shiny weapons.
 SLES-51254:
-  name: "Der Herr der Ringe - Die Zwei Tuerme"
+  name: "Herr der Ringe, Der - Die Zwei Türme"
   region: "PAL-G"
   clampModes:
     vuClampMode: 3 # Fix white shiny weapons.
 SLES-51255:
-  name: "Lord of the Rings, The - The Two Towers"
+  name: "Signore Degli Anelli, Il - Le Due Torri"
   region: "PAL-I"
   clampModes:
     vuClampMode: 3 # Fix white shiny weapons.
 SLES-51256:
-  name: "El Senor de Los Anillos - Las Dos Torres"
+  name: "Señor de Los Anillos, El - Las Dos Torres"
   region: "PAL-S"
   compat: 5
   clampModes:
@@ -12298,13 +12298,13 @@ SLES-51358:
   region: "PAL-E"
   compat: 5
 SLES-51360:
-  name: "Simpsons Skateboarding"
+  name: "Simpsons Skateboarding, The"
   region: "PAL-I"
 SLES-51361:
-  name: "Simpsons Skateboarding"
+  name: "Simpsons Skateboarding, The"
   region: "PAL-S"
 SLES-51362:
-  name: "Simpsons Skateboarding"
+  name: "Simpsons Skateboarding, The"
   region: "PAL-G"
 SLES-51363:
   name: "Music 3000"
@@ -12502,7 +12502,7 @@ SLES-51460:
   name: "Football Manager 2004"
   region: "PAL-I"
 SLES-51461:
-  name: "Football Manager 2004"
+  name: "Manager de Liga 2004"
   region: "PAL-S"
 SLES-51462:
   name: "Shrek Super Party"
@@ -12810,7 +12810,7 @@ SLES-51665:
   name: "Dynasty Warriors 4"
   region: "PAL-S"
 SLES-51666:
-  name: "Piglet's Big Game"
+  name: "Piglet - El Gran Juego de Disney"
   region: "PAL-S"
 SLES-51667:
   name: "Piglet's Big Game"
@@ -13240,7 +13240,7 @@ SLES-51853:
   roundModes:
     vuRoundMode: 0 # Crashes without.
 SLES-51854:
-  name: "Tony Hawk Underground"
+  name: "Tony Hawk's Underground"
   region: "PAL-S"
   roundModes:
     vuRoundMode: 0 # Crashes without.
@@ -13645,16 +13645,16 @@ SLES-52017:
   region: "PAL-M5"
   compat: 5
 SLES-52018:
-  name: "Der Herr der Ringe, Die Rueckkehr des Koenigs"
+  name: "Herr der Ringe, Der - Die Rückkehr des Königs"
   region: "PAL-G"
 SLES-52019:
-  name: "Lord of the Rings, The - Return of the King"
+  name: "Seigneur des Anneaux, Le - Le Retour du roi"
   region: "PAL-F"
 SLES-52020:
-  name: "Lord of the Rings, The - The Return of the King"
+  name: "Señor de Los Anillos, El - El Retorno del Rey"
   region: "PAL-S"
 SLES-52021:
-  name: "Lord of the Rings, The - The Return of the King"
+  name: "Signore degli Anelli, Il - Il Ritorno del Re"
   region: "PAL-I"
 SLES-52022:
   name: "Total Club Manager 2004"
@@ -13686,11 +13686,11 @@ SLES-52036:
   region: "PAL-E"
   compat: 5
 SLES-52038:
-  name: "Terminator 3 - Rise of the Machines"
+  name: "Terminator 3 - Rebellion der Maschinen"
   region: "PAL-G"
 SLES-52039:
-  name: "Terminator 3 - La Rebelión de las Máquinas"
-  region: "PAL-S"
+  name: "Terminator 3 - Rise Of The Machines"
+  region: "PAL-IS"
 SLES-52041:
   name: "Detonator"
   region: "PAL-E"
@@ -14129,7 +14129,7 @@ SLES-52284:
   name: "Deadly Skies III"
   region: "PAL-M5"
 SLES-52286:
-  name: "Tak and The Power of JuJu"
+  name: "Tak y el Poder Juju"
   region: "PAL-S"
   compat: 5
 SLES-52287:
@@ -15112,7 +15112,7 @@ SLES-52696:
   name: "Football Manager Campionato 2005"
   region: "PAL-I"
 SLES-52697:
-  name: "Manager de la Liga 2005"
+  name: "Manager de Liga 2005"
   region: "PAL-S"
 SLES-52700:
   name: "Adventures of Jimmy Neutron, The - Boy Genius - Attack of the Twonkies"
@@ -15341,20 +15341,20 @@ SLES-52801:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes ghosting in cutscenes.
 SLES-52802:
-  name: "Lord of the Rings, The - The Third Age"
+  name: "Seigneur des anneaux, Le - Le Tiers Âge"
   region: "PAL-F"
   gsHWFixes:
     halfPixelOffset: 1 # Fixes ghosting in cutscenes.
 SLES-52803:
-  name: "Der Herr der Ringe - Das dritte Zeitalter"
+  name: "Herr der Ringe, Der - Das dritte Zeitalter"
   region: "PAL-G"
 SLES-52804:
-  name: "Lord of the Rings, The - The Third Age"
+  name: "Signore degli Anelli, Il - La Terza Era"
   region: "PAL-I"
   gsHWFixes:
     halfPixelOffset: 1 # Fixes ghosting in cutscenes.
 SLES-52805:
-  name: "Lord of the Rings, The - The Third Age"
+  name: "Señor de Los Anillos, El - La Tercera Edad"
   region: "PAL-S"
   gsHWFixes:
     halfPixelOffset: 1 # Fixes ghosting in cutscenes.
@@ -15366,7 +15366,7 @@ SLES-52807:
   gsHWFixes:
     halfPixelOffset: 1 # Reduces lighting misalignment but doesn't fully fix it.
 SLES-52808:
-  name: "Lemony Snicket's A Series of Unfortunate Events"
+  name: "Désastreuses Aventures des orphelins Baudelaire, Les"
   region: "PAL-F"
   clampModes:
     eeClampMode: 3 # Fixes the inability to collect items.
@@ -15380,7 +15380,7 @@ SLES-52809:
   gsHWFixes:
     halfPixelOffset: 1 # Reduces lighting misalignment but doesn't fully fix it.
 SLES-52810:
-  name: "Lemony Snicket's Una Serie Disfortunati Eventi"
+  name: "Lemony Snicket Una Serie Di Sfortunati Eventi"
   region: "PAL-I"
   clampModes:
     eeClampMode: 3 # Fixes the inability to collect items.
@@ -15404,7 +15404,7 @@ SLES-52815:
   name: "Disney-Pixar's The Incredibles"
   region: "PAL-G"
 SLES-52816:
-  name: "Incredibles, The"
+  name: "Increíbles, Los"
   region: "PAL-S"
 SLES-52820:
   name: "Incredibles, The"
@@ -15422,7 +15422,7 @@ SLES-52824:
   name: "Furry Tales"
   region: "PAL-E-F"
 SLES-52825:
-  name: "Lemony Snicket's A Series of Unfortunate Events"
+  name: "Serie de Catastróficas Desdichas de Lemony Snicket, Una"
   region: "PAL-S"
   clampModes:
     eeClampMode: 3 # Fixes the inability to collect items.
@@ -15792,7 +15792,7 @@ SLES-52985:
   name: "Spongebob SquarePants - The Movie"
   region: "PAL-G"
 SLES-52986:
-  name: "Spongebob SquarePants - The Movie"
+  name: "Bob Esponja La Película"
   region: "PAL-S"
 SLES-52988:
   name: "Mega Man X8"
@@ -16233,7 +16233,7 @@ SLES-53143:
   name: "Fantastic Four"
   region: "PAL-E"
 SLES-53144:
-  name: "Four Fantastiques, Les"
+  name: "4 Fantastiques, Les"
   region: "PAL-F"
 SLES-53145:
   name: "Fantastic Four"
@@ -16242,7 +16242,7 @@ SLES-53146:
   name: "I Fantastici Quattro"
   region: "PAL-I"
 SLES-53147:
-  name: "Four Fantasticos, Los"
+  name: "4 Fantásticos, Los"
   region: "PAL-S"
 SLES-53148:
   name: "Fruitfall"
@@ -16437,7 +16437,7 @@ SLES-53242:
     roundSprite: 2 # Improves bloom alignment and clarity.
     halfPixelOffset: 2 # Improves bloom alignment and clarity.
 SLES-53246:
-  name: "Dreamworks Madagascar"
+  name: "Madagascar"
   region: "PAL-S"
   gsHWFixes:
     roundSprite: 2 # Improves bloom alignment and clarity.
@@ -17317,7 +17317,7 @@ SLES-53580:
   name: "NBA Live '06"
   region: "PAL-F"
 SLES-53581:
-  name: "NBA Live '06"
+  name: "NBA Live 06"
   region: "PAL-S"
 SLES-53582:
   name: "Bratz - Rock Angelz"
@@ -17623,12 +17623,12 @@ SLES-53706:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes lighting misalignment.
 SLES-53707:
-  name: "Chronicles of Narnia, The - The Lion, The Witch and The Wardrobe"
+  name: "Chroniken von Narnia, Die - Der König von Narnia"
   region: "PAL-G"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes lighting misalignment.
 SLES-53708:
-  name: "Chronicles of Narnia, The - The Lion, The Witch and The Wardrobe"
+  name: "Cronache di Narnia, Le - Il Leone, La Strega e L'Armadio"
   region: "PAL-I"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes lighting misalignment.
@@ -17638,7 +17638,7 @@ SLES-53709:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes lighting misalignment.
 SLES-53710:
-  name: "Chronicles of Narnia, The - The Lion, The Witch and The Wardrobe"
+  name: "Crónicas de Narnia, Las - El León, La Bruja y El Armario"
   region: "PAL-S"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes lighting misalignment.
@@ -18108,9 +18108,6 @@ SLES-53886:
         patch=1,EE,0037EBD8,word,4af103bc
         patch=1,EE,0037EBF0,word,4a800460
         patch=1,EE,0037EBF4,word,4b7103bc
-SLES-53897:
-  name: "Dreamworks Vecinos Invasores"
-  region: "PAL-S"
 SLES-53899:
   name: "Pro Evolution Soccer Management"
   region: "PAL-M5"
@@ -18171,7 +18168,7 @@ SLES-53913:
   name: "Plan, The"
   region: "PAL-F-I"
 SLES-53914:
-  name: "Plan, The"
+  name: "Plan, Th3"
   region: "PAL-S"
 SLES-53915:
   name: "Space War Attack"
@@ -18314,12 +18311,12 @@ SLES-53984:
         patch=1,EE,002FF3F0,word,27BDFEE0
         patch=1,EE,002FF42C,word,27BD0120
 SLES-53986:
-  name: "Over the Hedge"
+  name: "gang del bosco, La"
   region: "PAL-I"
   speedHacks:
     MTVUSpeedHack: 0 # Fixes bad graphics due to bad T-Bit handling.
 SLES-53987:
-  name: "Over the Hedge"
+  name: "Vecinos Invasores"
   region: "PAL-S"
   speedHacks:
     MTVUSpeedHack: 0 # Fixes bad graphics due to bad T-Bit handling.
@@ -18964,7 +18961,7 @@ SLES-54250:
   name: "NBA Live '07"
   region: "PAL-F"
 SLES-54251:
-  name: "NBA Live '07"
+  name: "NBA Live 07"
   region: "PAL-S"
 SLES-54252:
   name: "NBA Live '07"
@@ -19398,7 +19395,7 @@ SLES-54451:
   name: "Himmel und Huhn - Ace in Action"
   region: "PAL-G"
 SLES-54452:
-  name: "Chicken Little - 'As' en Accion"
+  name: "Disney Chicken Little - As en Acción"
   region: "PAL-S"
 SLES-54453:
   name: "Chicken Little - Asso Spaziale!"
@@ -19767,7 +19764,7 @@ SLES-54596:
   name: "Heatseeker"
   region: "PAL-M3"
 SLES-54604:
-  name: "¡Qué Pasa Neng! El Videojuego"
+  name: "¡Qué pasa Neng! El videojuego"
   region: "PAL-S"
 SLES-54606:
   name: "Harley-Davidson - Race to the Rally"


### PR DESCRIPTION
### Description of Changes
What began as a proofread/revision of all PAL-S discs ended up touching a bit more than I thought, adding the proper names for also other French/Italian/German exclusive versions.

Summary of changes:
 - Verified EVERY PAL-S disc's name and uppercasing following whatever is written on the cover's side.
 - Added the proper translations for French/German/Italian versions of the discs I have changed in their Spanish equivalents. For these cases, I first took the name from Wikipedia and then verified it by searching good photos of the cover sides on eBay. I was able to double check the wordings and accents (I'm looking at you, German Wikipedia and the Lord of The Rings games...), but not the actual uppercasing for all of these versions, so some of those have the uppercasing from Wikipedia.
- When I checked Terminator 3 - Rise of the Machines's Spanish version, I found out that the disc seems to be Italian/Spanish, so I changed that accordingly. Reference: [EBAY](https://www.ebay.es/itm/192542047505?hash=item2cd4667d11:g:420AAOSwJX5f9EXg&amdata=enc%3AAQAHAAAA4EfM99%2Bn1tQrgxNjriGyyACKNUHzF1eA2G3W4Ig9NuggC280vKaD5O0lG8xWUDOAS6vaXepjpLFpv0REdj8r5lGdiIUs4OFD6s65%2FH0vSC%2Bb7X%2F%2BmsfEyUGhuvJEXEFQC96lDHkyyOqkQabmyM%2Bj881BRmGiUzDorYRZWnHhAOEDWSmErI8oyK%2F0U5eCOF3vPF8bDZaFO54eJ7VjO0UcDmniSvyWUq7lOIiFhEgFeGeZIKIW%2BLPcQMGGZ7oUT5AmNis2aluj2Wg6rOSAQaie1fe7zf6%2FkJ5Db%2BDrfB6vsp31%7Ctkp%3ABk9SR_bDyeOgYQ)
 - I've removed a mistype for Over the Hedge's Spanish version, as it was duped: I do not know what SLES-53897 contains, but the actual game seems to be SLES-53987.

### Rationale behind Changes
 - Adding the correct localized versions of the game's names whenever there was an exclusive Spanish version.
 - Removing a duplicated element.

### Suggested Testing Steps
Check that nothing breaks and that everything follows the GameIndex's guidelines.
