### PR TITLE
GS: Ensure screenshots are saved before shutting down

### DIFF
--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -121,20 +121,7 @@ void GSinitConfig()
 
 void GSshutdown()
 {
-#ifndef PCSX2_CORE
-	if (g_gs_renderer)
-	{
-		g_gs_renderer->Destroy();
-		g_gs_renderer.reset();
-	}
-	if (g_gs_device)
-	{
-		g_gs_device->Destroy();
-		g_gs_device.reset();
-	}
-
-	Host::ReleaseHostDisplay(true);
-#endif
+	GSclose();
 
 #ifdef _WIN32
 	if (SUCCEEDED(s_hr))
@@ -163,6 +150,9 @@ void GSclose()
 		g_host_display->SetGPUTimingEnabled(false);
 
 	Host::ReleaseHostDisplay(true);
+
+	// ensure all screenshots have been saved
+	GSJoinSnapshotThreads();
 }
 
 static RenderAPI GetAPIForRenderer(GSRendererType renderer)

--- a/pcsx2/GS/GS.h
+++ b/pcsx2/GS/GS.h
@@ -93,6 +93,7 @@ void GSResetAPIState();
 void GSRestoreAPIState();
 bool GSSaveSnapshotToMemory(u32 window_width, u32 window_height, bool apply_aspect, bool crop_borders,
 	u32* width, u32* height, std::vector<u32>* pixels);
+void GSJoinSnapshotThreads();
 
 class GSApp
 {

--- a/pcsx2/GSDumpReplayer.cpp
+++ b/pcsx2/GSDumpReplayer.cpp
@@ -284,11 +284,11 @@ void GSDumpReplayerCpuStep()
 		case GSDumpTypes::GSType::VSync:
 		{
 			s_dump_frame_number++;
-			GSDumpReplayerCpuCheckExecutionState();
 			GSDumpReplayerUpdateFrameLimit();
 			GSDumpReplayerFrameLimit();
 			GetMTGS().PostVsyncStart(false);
 			VMManager::Internal::VSyncOnCPUThread();
+			GSDumpReplayerCpuCheckExecutionState();
 		}
 		break;
 


### PR DESCRIPTION
### Description of Changes

Was lazy and didn't join the threads before, which could lead to incomplete files.

Also fixes frame advance when playing back a GS dump, it would always advance two frames before.

### Rationale behind Changes

Fixing my silly mistakes.

### Suggested Testing Steps

Spam a bunch of large screenshots and shut down. PCSX2 should freeze until they're all written.
