### PR TITLE
Qt: Fix crash opening ELF game properties

### DIFF
--- a/pcsx2-qt/Settings/GameSummaryWidget.cpp
+++ b/pcsx2-qt/Settings/GameSummaryWidget.cpp
@@ -85,7 +85,7 @@ void GameSummaryWidget::populateDiscPath(const GameList::Entry* entry)
 	if (entry->type == GameList::EntryType::ELF)
 	{
 		std::optional<std::string> iso_path(m_dialog->getStringValue("EmuCore", "DiscPath", std::nullopt));
-		if (!iso_path->empty())
+		if (iso_path.has_value() && !iso_path->empty())
 			m_ui.discPath->setText(QString::fromStdString(iso_path.value()));
 
 		connect(m_ui.discPath, &QLineEdit::textChanged, this, &GameSummaryWidget::onDiscPathChanged);


### PR DESCRIPTION
### Description of Changes

Introduced in 9da8e9280f67e0a311b9a8f10d35acc9b0638b70

### Rationale behind Changes

Crash bad.

### Suggested Testing Steps

Make sure it builds (issue is obvious).
