### PR TITLE
GS: Fix crash if FXAA/Shadeboost enabled with Bilinear Sharp

### DIFF
--- a/pcsx2/GS/Renderers/Common/GSDevice.cpp
+++ b/pcsx2/GS/Renderers/Common/GSDevice.cpp
@@ -422,6 +422,7 @@ void GSDevice::ShadeBoost()
 
 void GSDevice::Resize(int width, int height)
 {
+	GSTexture*& dTex = (m_current == m_target_tmp) ? m_merge : m_target_tmp;
 	GSVector2i s = m_current->GetSize();
 	int multiplier = 1;
 
@@ -430,12 +431,12 @@ void GSDevice::Resize(int width, int height)
 		s = m_current->GetSize() * GSVector2i(++multiplier);
 	}
 
-	if (ResizeTexture(&m_target_tmp, GSTexture::Type::RenderTarget, s.x, s.y, false))
+	if (ResizeTexture(&dTex, GSTexture::Type::RenderTarget, s.x, s.y, false))
 	{
 		const GSVector4 sRect(0, 0, 1, 1);
 		const GSVector4 dRect(0, 0, s.x, s.y);
-		StretchRect(m_current, sRect, m_target_tmp, dRect, ShaderConvert::COPY, false);
-		m_current = m_target_tmp;
+		StretchRect(m_current, sRect, dTex, dRect, ShaderConvert::COPY, false);
+		m_current = dTex;
 	}
 }
 


### PR DESCRIPTION
### Description of Changes
Fixes crash when Bilinear(Sharp) selected along with FXAA or Shadeboost

### Rationale behind Changes
Crashes are bad. Don't Stretchrect src->src.

### Suggested Testing Steps
Check it doesn't crash with FXAA and Bilinear Sharp
