### PR TITLE
Qt: Fix graphics settings opening to replacement tab

### DIFF
--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
@@ -58,7 +58,7 @@
    <item>
     <widget class="QTabWidget" name="tabs">
      <property name="currentIndex">
-      <number>3</number>
+      <number>0</number>
      </property>
      <property name="documentMode">
       <bool>true</bool>


### PR DESCRIPTION
### Description of Changes

See title.

### Rationale behind Changes

Not opening to the first tab is wrong.

### Suggested Testing Steps

Trivial one-line change, so make sure build succeeds.
