### PR TITLE
microVU: Fix mVUcustomSearch

### DIFF
--- a/pcsx2/x86/microVU_Misc.inl
+++ b/pcsx2/x86/microVU_Misc.inl
@@ -587,7 +587,7 @@ void mVUcustomSearch()
 		xVMOVUPS(ymm0, ptr[arg1reg]);
 		xVPCMP.EQD(ymm0, ymm0, ptr[arg2reg]);
 		xVPMOVMSKB(eax, ymm0);
-		xNOT(eax);
+		xXOR(eax, 0xffffffff);
 		xForwardJNZ8 exitPoint;
 
 		xVMOVUPS(ymm0, ptr[arg1reg + 0x20]);


### PR DESCRIPTION
### Description of Changes
Apparently NOT doesn't set flags

### Rationale behind Changes
Less broken

### Suggested Testing Steps
Test on GCC, which is apparently the one who happened to enter the function with the zero flag cleared
