### PR TITLE
GameDB: Black line removal K-1 World Grand Prix

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -42642,6 +42642,8 @@ SLUS-20682:
   name: "K-1 World Grand Prix"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    alignSprite: 1 # Fixes black vertical lines.
 SLUS-20683:
   name: "Lupin the 3rd - Treasure of the Sorcerer King"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Align Sprite needed, surprised this one wasn't discovered before. This removes the black vertical lines in-game.
![K-1 World Grand Prix_SLUS-20682_20221216045521](https://user-images.githubusercontent.com/24227051/208018714-c4ad682a-cd4f-43cb-966d-a122b372fdc8.png)
![K-1 World Grand Prix_SLUS-20682_20221216045539](https://user-images.githubusercontent.com/24227051/208018729-71f15c0a-6a70-40dc-9c85-aca3114af6b0.png)


### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Less tinkering, hurray for automatic settings
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test K-1 World Grand Prix