### PR TITLE
GS: Fix dx11 bad shader/crashing on dx10 gpus.

### DIFF
--- a/pcsx2/GS/Renderers/Common/GSRenderer.cpp
+++ b/pcsx2/GS/Renderers/Common/GSRenderer.cpp
@@ -687,13 +687,23 @@ void GSRenderer::VSync(u32 field, bool registers_written)
 			src_rect, current->GetSize(), g_host_display->GetDisplayAlignment(), g_host_display->UsesLowerLeftOrigin(),
 			GetVideoMode() == GSVideoMode::SDTV_480P || (GSConfig.PCRTCOverscan && GSConfig.PCRTCOffsets));
 
-		if (GSConfig.CASMode != GSCASMode::Disabled && g_gs_device->Features().cas_sharpening)
+		if (GSConfig.CASMode != GSCASMode::Disabled)
 		{
-			// sharpen only if the IR is higher than the display resolution
-			const bool sharpen_only = (GSConfig.CASMode == GSCASMode::SharpenOnly ||
-									   (current->GetWidth() > g_host_display->GetWindowWidth() &&
-										   current->GetHeight() > g_host_display->GetWindowHeight()));
-			g_gs_device->CAS(current, src_rect, src_uv, draw_rect, sharpen_only);
+			static bool cas_log_once = false;
+			if (g_gs_device->Features().cas_sharpening)
+			{
+				// sharpen only if the IR is higher than the display resolution
+				const bool sharpen_only = (GSConfig.CASMode == GSCASMode::SharpenOnly ||
+										   (current->GetWidth() > g_host_display->GetWindowWidth() &&
+											   current->GetHeight() > g_host_display->GetWindowHeight()));
+				g_gs_device->CAS(current, src_rect, src_uv, draw_rect, sharpen_only);
+			}
+			else if (!cas_log_once)
+			{
+				Host::AddIconOSDMessage("CASUnsupported", ICON_FA_EXCLAMATION_TRIANGLE,
+					"CAS is not available, your graphics driver does not support the required functionality.", 10.0f);
+				cas_log_once = true;
+			}
 		}
 	}
 

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
@@ -91,6 +91,7 @@ bool GSDevice11::Create()
 	m_dev = static_cast<ID3D11Device*>(g_host_display->GetDevice());
 	m_ctx = static_cast<ID3D11DeviceContext*>(g_host_display->GetContext());
 	level = m_dev->GetFeatureLevel();
+	const bool support_feature_level_11_0 = (level >= D3D_FEATURE_LEVEL_11_0);
 
 	if (!GSConfig.DisableShaderCache)
 	{
@@ -106,7 +107,7 @@ bool GSDevice11::Create()
 	}
 
 	// Set maximum texture size limit based on supported feature level.
-	if (level >= D3D_FEATURE_LEVEL_11_0)
+	if (support_feature_level_11_0)
 		m_d3d_texsize = D3D11_REQ_TEXTURE2D_U_OR_V_DIMENSION;
 	else
 		m_d3d_texsize = D3D10_REQ_TEXTURE2D_U_OR_V_DIMENSION;
@@ -342,7 +343,8 @@ bool GSDevice11::Create()
 			return false;
 	}
 
-	CreateCASShaders();
+	m_features.cas_sharpening = support_feature_level_11_0 && CreateCASShaders();
+
 	return true;
 }
 

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -414,11 +414,8 @@ bool GSDeviceOGL::Create()
 		m_shadeboost.ps.SetName("Shadeboost pipe");
 	}
 
-	if (!CreateCASPrograms() && GSConfig.CASMode != GSCASMode::Disabled)
-	{
-		Host::AddIconOSDMessage("CASUnsupported", ICON_FA_EXCLAMATION_TRIANGLE,
-			"CAS is not available, your graphics driver does not supported the required functionality.", 10.0f);
-	}
+	// Image load store and GLSL 420pack is core in GL4.2, no need to check.
+	m_features.cas_sharpening = ((GLAD_GL_VERSION_4_2 && GLAD_GL_ARB_compute_shader) || GLAD_GL_ES_VERSION_3_2) && CreateCASPrograms();
 
 	// ****************************************************************
 	// rasterization configuration
@@ -1543,14 +1540,6 @@ void GSDeviceOGL::ClearSamplerCache()
 
 bool GSDeviceOGL::CreateCASPrograms()
 {
-	// Image load store and GLSL 420pack is core in GL4.2, no need to check.
-	m_features.cas_sharpening = (GLAD_GL_VERSION_4_2 && GLAD_GL_ARB_compute_shader) || GLAD_GL_ES_VERSION_3_2;
-	if (!m_features.cas_sharpening)
-	{
-		Console.Warning("Compute shaders not supported, CAS is unavailable.");
-		return false;
-	}
-
 	std::optional<std::string> cas_source(Host::ReadResourceFileToString("shaders/opengl/cas.glsl"));
 	if (!cas_source.has_value() || !GetCASShaderSource(&cas_source.value()))
 	{


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS-d3d11: Fix dx11 crashing on dx10 gpus.
CAS requires feature level 11.0.

GS: Move osd log for unsupported cas in Renderer code.
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Crashes are bad mkay.
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test dx10 gpus.