### PR TITLE
wx: Fix console warnings for no longer used hotkeys.

### DIFF
--- a/bin/PCSX2_keys.ini.default
+++ b/bin/PCSX2_keys.ini.default
@@ -38,11 +38,6 @@ States_DefrostCurrentSlotBackup   = Shift-F3
 States_CycleSlotForward           = F2
 States_CycleSlotBackward          = Shift-F2
 
-Frameskip_Toggle                  = Shift-F4
-Framelimiter_TurboToggle          = TAB
-Framelimiter_SlomoToggle          = Shift-TAB
-Framelimiter_MasterToggle         = F4
-
 FullscreenToggle                  = Alt-ENTER
 
 # Note: toggles suspend, but can resume only if the GS window is not set to hide
@@ -61,22 +56,10 @@ Sys_RecordingToggle               = F12
 
 GSwindow_CycleAspectRatio         = F6
 
-# Whole picture zoom in/out
-GSwindow_ZoomIn                   = Ctrl-KP_ADD
-GSwindow_ZoomOut                  = Ctrl-KP_SUBTRACT
-GSwindow_ZoomToggle               = Ctrl-KP_MULTIPLY
-
 # Vertical stretch/squash
 GSwindow_ZoomInY                  = Alt-Ctrl-KP_ADD
 GSwindow_ZoomOutY                 = Alt-Ctrl-KP_SUBTRACT
 GSwindow_ZoomResetY               = Alt-Ctrl-KP_MULTIPLY
-
-# Move the whole image
-GSwindow_OffsetYminus             = Alt-Ctrl-UP
-GSwindow_OffsetYplus              = Alt-Ctrl-DOWN
-GSwindow_OffsetXminus             = Alt-Ctrl-LEFT
-GSwindow_OffsetXplus              = Alt-Ctrl-RIGHT
-GSwindow_OffsetReset              = Alt-Ctrl-KP_DIVIDE
 
 # Recording Bindings
 # Note - These are disabled if 'System > Enable Recording Tools' is disabled

--- a/pcsx2/gui/FrameForGS.cpp
+++ b/pcsx2/gui/FrameForGS.cpp
@@ -82,19 +82,9 @@ void GSPanel::InitDefaultAccelerators()
 
 	m_Accels->Map( AAC( WXK_F6 ),				"GSwindow_CycleAspectRatio" );
 
-	m_Accels->Map( AAC( WXK_NUMPAD_ADD ).Cmd(),			"GSwindow_ZoomIn" );	//CTRL on Windows/linux, CMD on OSX
-	m_Accels->Map( AAC( WXK_NUMPAD_SUBTRACT ).Cmd(),	"GSwindow_ZoomOut" );
-	m_Accels->Map( AAC( WXK_NUMPAD_MULTIPLY ).Cmd(),	"GSwindow_ZoomToggle" );
-
 	m_Accels->Map( AAC( WXK_NUMPAD_ADD ).Cmd().Alt(),			"GSwindow_ZoomInY" );	//CTRL on Windows/linux, CMD on OSX
 	m_Accels->Map( AAC( WXK_NUMPAD_SUBTRACT ).Cmd().Alt(),	"GSwindow_ZoomOutY" );
 	m_Accels->Map( AAC( WXK_NUMPAD_MULTIPLY ).Cmd().Alt(),	"GSwindow_ZoomResetY" );
-
-	m_Accels->Map( AAC( WXK_UP ).Cmd().Alt(),	"GSwindow_OffsetYminus" );
-	m_Accels->Map( AAC( WXK_DOWN ).Cmd().Alt(),	"GSwindow_OffsetYplus" );
-	m_Accels->Map( AAC( WXK_LEFT ).Cmd().Alt(),	"GSwindow_OffsetXminus" );
-	m_Accels->Map( AAC( WXK_RIGHT ).Cmd().Alt(),	"GSwindow_OffsetXplus" );
-	m_Accels->Map( AAC( WXK_NUMPAD_DIVIDE ).Cmd().Alt(),	"GSwindow_OffsetReset" );
 
 	m_Accels->Map( AAC( WXK_ESCAPE ),			"Sys_SuspendResume" );
 	m_Accels->Map( AAC( WXK_F8 ),				"Sys_TakeSnapshot" ); // also shift and ctrl-shift will be added automatically


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
wx: Fix console warnings for no longer used hotkeys.
Fixes Kbd Accelerator warnings on pcsx2 console.
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Console warnings.
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test pcsx2 on wx, run a dump or game and see if the warnings are gone in the console.