### PR TITLE
GS: Rework of PCRTC code

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -424,7 +424,6 @@ SCAJ-10008:
   name: "Taiko no Tatsujin - Atsumare! Matsuri da!! Yondaime"
   region: "NTSC-Unk"
   gsHWFixes:
-    deinterlace: 5 # Game requires bob bff de-interlacing when auto.
     alignSprite: 1 # Fixes vertical lines.
 SCAJ-10009:
   name: "Psikyo Shooting Collection Vol.1 - Strikers 1-2"
@@ -439,31 +438,26 @@ SCAJ-10011:
   name: "Taiko no Tatsujin - Go! Go! Godaime"
   region: "NTSC-Unk"
   gsHWFixes:
-    deinterlace: 5 # Game requires bob bff de-interlacing when auto.
     alignSprite: 1 # Fixes vertical lines.
 SCAJ-10012:
   name: "Taiko Drum Master"
   region: "NTSC-Unk"
   gsHWFixes:
-    deinterlace: 5 # Game requires bob bff de-interlacing when auto.
     alignSprite: 1 # Fixes vertical lines.
 SCAJ-10013:
   name: "Taiko no Tatsujin - Tobikkiri! Anime Special"
   region: "NTSC-Unk"
   gsHWFixes:
-    deinterlace: 5 # Game requires bob bff de-interlacing when auto.
     alignSprite: 1 # Fixes vertical lines.
 SCAJ-10014:
   name: "Taiko no Tatsujin - Wai Wai Happy! Rokudaime"
   region: "NTSC-Unk"
   gsHWFixes:
-    deinterlace: 5 # Game requires bob bff de-interlacing when auto.
     alignSprite: 1 # Fixes vertical lines.
 SCAJ-10015:
   name: "Taiko no Tatsujin - Doka! to Oomori Nanadaime"
   region: "NTSC-Unk"
   gsHWFixes:
-    deinterlace: 5 # Game requires bob bff de-interlacing when auto.
     alignSprite: 1 # Fixes vertical lines.
 SCAJ-20001:
   name: "Ratchet & Clank"
@@ -3246,8 +3240,6 @@ SCES-51159:
 SCES-51164:
   name: "Mark of Kri, The"
   region: "PAL-M5"
-  gsHWFixes:
-    deinterlace: 4 # Game requires bob de-interlacing when auto.
 SCES-51176:
   name: "Disney's Treasure Planet"
   region: "PAL-M4"
@@ -7159,8 +7151,6 @@ SCUS-97140:
   name: "Mark of Kri, The"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    deinterlace: 4 # Game requires bob de-interlacing when auto.
   patches:
     DBD09DD4:
       content: |-
@@ -7390,8 +7380,6 @@ SCUS-97200:
 SCUS-97201:
   name: "Mark of Kri, The"
   region: "NTSC-U"
-  gsHWFixes:
-    deinterlace: 4 # Game requires bob de-interlacing when auto.
 SCUS-97203:
   name: "Wild ARMs 3"
   region: "NTSC-U"
@@ -7473,8 +7461,6 @@ SCUS-97220:
 SCUS-97222:
   name: "Mark of Kri [Demo]"
   region: "NTSC-U"
-  gsHWFixes:
-    deinterlace: 4 # Game requires bob de-interlacing when auto.
 SCUS-97223:
   name: "NFL GameDay 2003 [Demo]"
   region: "NTSC-U"
@@ -16131,7 +16117,6 @@ SLES-52988:
   gsHWFixes:
     autoFlush: 1 # Fixes bloom.
     roundSprite: 1 # Fixes misaligned bloom.
-    deinterlace: 6 # Game requires blend tff de-interlacing when auto for 'fixing' subtitles flickering or half weaved.
   memcardFilters: # Reads Command Mission save for bonus boss.
     - "SLES-52988"
     - "SLES-52832"
@@ -17788,7 +17773,6 @@ SLES-53621:
   region: "PAL-M5"
   compat: 5
   gsHWFixes:
-    deinterlace: 4 # Game requires bob de-interlacing when auto.
     halfPixelOffset: 1 # Fixes misalignment/bloom when upscaling.
 SLES-53623:
   name: "SpongeBob SquarePants - Battle for Bikini Bottom"
@@ -19935,7 +19919,6 @@ SLES-54455:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned bloom effects.
     mergeSprite: 1 # Fixes blurriness but removes bloom + Recommended to use Shadeboost brightness 80.
-    deinterlace: 8 # Game requires adaptive (or blend) tff de-interlacing instead of auto for the whole game.
 SLES-54456:
   name: "Beverly Hills Cop"
   region: "PAL-M11"
@@ -20101,14 +20084,12 @@ SLES-54516:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned bloom effects.
     mergeSprite: 1 # Fixes blurriness but removes bloom + Recommended to use Shadeboost brightness 80.
-    deinterlace: 8 # Game requires adaptive (or blend) tff de-interlacing instead of auto for the whole game.
 SLES-54517:
   name: "Thrillville"
   region: "PAL-M3"
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned bloom effects.
     mergeSprite: 1 # Fixes blurriness but removes bloom + Recommended to use Shadeboost brightness 80.
-    deinterlace: 8 # Game requires adaptive (or blend) tff de-interlacing instead of auto for the whole game.
 SLES-54518:
   name: "Clumsy Shumsy"
   region: "PAL-E"
@@ -20859,13 +20840,11 @@ SLES-54806:
   region: "PAL-E"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misaligned bloom effects, 1 is technically more correct compared to software but looks worse.
-    deinterlace: 8 # Game requires adaptive (or blend) tff de-interlacing instead of auto for the whole game.
 SLES-54807:
   name: "Thrillville - Off the Rails"
   region: "PAL-F"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misaligned bloom effects, 1 is technically more correct compared to software but looks worse.
-    deinterlace: 8 # Game requires adaptive (or blend) tff de-interlacing instead of auto for the whole game.
 SLES-54809:
   name: "Charlotte's Web"
   region: "PAL-A"
@@ -20883,6 +20862,8 @@ SLES-54812:
 SLES-54813:
   name: "NASCAR 08"
   region: "PAL-A-E"
+  gsHWFixes:
+    deinterlace: 8 # Game requires AdaptiveTFF de-interlacing when auto.
 SLES-54814:
   name: "Dead Eye Jim"
   region: "PAL-E"
@@ -21099,7 +21080,6 @@ SLES-54887:
   region: "PAL-G"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misaligned bloom effects, 1 is technically more correct compared to software but looks worse.
-    deinterlace: 8 # Game requires adaptive (or blend) tff de-interlacing instead of auto for the whole game.
 SLES-54888:
   name: "Pro Biker 2"
   region: "PAL-E"
@@ -21461,13 +21441,11 @@ SLES-55010:
   region: "PAL-I"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misaligned bloom effects, 1 is technically more correct compared to software but looks worse.
-    deinterlace: 8 # Game requires adaptive (or blend) tff de-interlacing instead of auto for the whole game.
 SLES-55011:
   name: "Thrillville - Fuera de Control"
   region: "PAL-S"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misaligned bloom effects, 1 is technically more correct compared to software but looks worse.
-    deinterlace: 8 # Game requires adaptive (or blend) tff de-interlacing instead of auto for the whole game.
 SLES-55012:
   name: "Golden Compass, The"
   region: "PAL-M5"
@@ -21917,6 +21895,8 @@ SLES-55199:
   name: "NASCAR 09"
   region: "PAL-M5"
   compat: 5
+  gsHWFixes:
+    deinterlace: 8 # Game requires AdaptiveTFF de-interlacing when auto.
 SLES-55200:
   name: "Guitar Hero - Aerosmith"
   region: "PAL-M4"
@@ -22710,8 +22690,6 @@ SLES-55579:
     eeRoundMode: 1 # Fixes black textures in conjunction with VU0 clamping set to none.
   clampModes:
     vu0ClampMode: 0 # Fixes black textures and SPS.
-  gsHWFixes:
-    deinterlace: 8 # Game requires adaptive (or blend) tff de-interlacing instead of auto for the FMVs.
 SLES-55581:
   name: "FIFA 10"
   region: "PAL-M5"
@@ -28674,8 +28652,6 @@ SLPM-65309:
 SLPM-65310:
   name: "Mark of Kri, The"
   region: "NTSC-J"
-  gsHWFixes:
-    deinterlace: 4 # Game requires bob de-interlacing when auto.
 SLPM-65311:
   name: "Violet no Atelier - Gramnad no Renkinjutsushi"
   region: "NTSC-J"
@@ -32257,7 +32233,6 @@ SLPM-66327:
   name: "Wallace & Gromit - The Curse of the Were-Rabbit"
   region: "NTSC-J"
   gsHWFixes:
-    deinterlace: 4 # Game requires bob de-interlacing when auto.
     halfPixelOffset: 1 # Fixes misalignment/bloom when upscaling.
 SLPM-66328:
   name: "Call of Duty 2 - Big Red One"
@@ -36292,13 +36267,11 @@ SLPS-20382:
   name: "Taiko no Tatsujin - Atsumare! Matsuri da!! Yondaime [with Tatacon]"
   region: "NTSC-J"
   gsHWFixes:
-    deinterlace: 5 # Game requires bob bff de-interlacing when auto.
     alignSprite: 1 # Fixes vertical lines.
 SLPS-20383:
   name: "Taiko no Tatsujin - Atsumare! Matsuri da!! Yondaime"
   region: "NTSC-J"
   gsHWFixes:
-    deinterlace: 5 # Game requires bob bff de-interlacing when auto.
     alignSprite: 1 # Fixes vertical lines.
 SLPS-20384:
   name: "Hayarigami - Keishichou Kaii Jiken File"
@@ -36340,13 +36313,11 @@ SLPS-20399:
   name: "Taiko no Tatsujin - Go! Go! Godaime [with Tatacon]"
   region: "NTSC-J"
   gsHWFixes:
-    deinterlace: 5 # Game requires bob bff de-interlacing when auto.
     alignSprite: 1 # Fixes vertical lines.
 SLPS-20400:
   name: "Taiko no Tatsujin - Go! Go! Godaime"
   region: "NTSC-J"
   gsHWFixes:
-    deinterlace: 5 # Game requires bob bff de-interlacing when auto.
     alignSprite: 1 # Fixes vertical lines.
 SLPS-20401:
   name: "Tecmo Hit Parade"
@@ -36387,14 +36358,12 @@ SLPS-20413:
   name: "Taiko no Tatsujin - Taiko Drum Master [with Tatacon]"
   region: "NTSC-J"
   gsHWFixes:
-    deinterlace: 5 # Game requires bob bff de-interlacing when auto.
     alignSprite: 1 # Fixes vertical lines.
 SLPS-20414:
   name: "Taiko no Tatsujin - Taiko Drum Master"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
-    deinterlace: 5 # Game requires bob bff de-interlacing when auto.
     alignSprite: 1 # Fixes vertical lines.
 SLPS-20416:
   name: "Inyou Taisenki - Byakko Enbu [with EyeToy]"
@@ -36423,13 +36392,11 @@ SLPS-20424:
   name: "Taiko no Tatsujin - Tobikkiri! Anime Special [with Tatacon]"
   region: "NTSC-J"
   gsHWFixes:
-    deinterlace: 5 # Game requires bob bff de-interlacing when auto.
     alignSprite: 1 # Fixes vertical lines.
 SLPS-20425:
   name: "Taiko no Tatsujin - Tobikkiri! Anime Special"
   region: "NTSC-J"
   gsHWFixes:
-    deinterlace: 5 # Game requires bob bff de-interlacing when auto.
     alignSprite: 1 # Fixes vertical lines.
 SLPS-20426:
   name: "Dreamworks Madagascar"
@@ -36495,13 +36462,11 @@ SLPS-20450:
   name: "Taiko no Tatsujin - Wai Wai Happy! Rokudaime [with Tatacon]"
   region: "NTSC-J"
   gsHWFixes:
-    deinterlace: 5 # Game requires bob bff de-interlacing when auto.
     alignSprite: 1 # Fixes vertical lines.
 SLPS-20451:
   name: "Taiko no Tatsujin - Wai Wai Happy! Rokudaime"
   region: "NTSC-J"
   gsHWFixes:
-    deinterlace: 5 # Game requires bob bff de-interlacing when auto.
     alignSprite: 1 # Fixes vertical lines.
 SLPS-20452:
   name: "Simple 2000 Series Ultimate Vol. 30 - Kourin! Zokusha Goddo!"
@@ -36622,13 +36587,11 @@ SLPS-20485:
   name: "Taiko no Tatsujin - Doka! to Oomori Nanadaime [with Tatacon]"
   region: "NTSC-J"
   gsHWFixes:
-    deinterlace: 5 # Game requires bob bff de-interlacing when auto.
     alignSprite: 1 # Fixes vertical lines.
 SLPS-20486:
   name: "Taiko no Tatsujin - Doka! to Oomori Nanadaime"
   region: "NTSC-J"
   gsHWFixes:
-    deinterlace: 5 # Game requires bob bff de-interlacing when auto.
     alignSprite: 1 # Fixes vertical lines.
 SLPS-20487:
   name: "Pachi-Slot King! Kagaku Ninja-Tai Gatchaman"
@@ -40214,7 +40177,6 @@ SLPS-73107:
   name: "Taiko no Tatsujin - Go! Go! Godaime [PlayStation 2 The Best]"
   region: "NTSC-J"
   gsHWFixes:
-    deinterlace: 5 # Game requires bob bff de-interlacing when auto.
     alignSprite: 1 # Fixes vertical lines.
 SLPS-73108:
   name: "Phantom Brave [PlayStation 2 The Best]"
@@ -42769,8 +42731,10 @@ SLUS-20474:
 SLUS-20475:
   name: "Dual Hearts"
   region: "NTSC-U"
+  gameFixes:
+    - SoftwareRendererFMVHack # Fixes flashing FMV.
   gsHWFixes:
-    deinterlace: 6 # Game requires blend tff de-interlacing when auto.
+    deinterlace: 9 # Game looks better with Adaptive BFF.
   compat: 5
 SLUS-20476:
   name: "NBA 2K3 - Sega Sports"
@@ -44322,7 +44286,6 @@ SLUS-20800:
   name: "Taiko Drum Master"
   region: "NTSC-U"
   gsHWFixes:
-    deinterlace: 5 # Game requires bob bff de-interlacing when auto.
     alignSprite: 1 # Fixes vertical lines.
 SLUS-20801:
   name: "Midway Arcade Treasures"
@@ -45059,7 +45022,6 @@ SLUS-20948:
   gsHWFixes:
     wildArmsHack: 1 # Fixes blurriness.
     roundSprite: 2 # Reduces misalignment bloom effects.
-#    deinterlace: 6 # Game requires blend tff de-interlacing when auto for 'fixing' shimmer on character models and more flickering or half weaved, though the game suffers from the field order.
 SLUS-20949:
   name: "Street Fighter Anniversary Collection"
   region: "NTSC-U"
@@ -47037,7 +46999,6 @@ SLUS-21312:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    deinterlace: 4 # Game requires bob de-interlacing when auto.
     halfPixelOffset: 1 # Fixes misalignment/bloom when upscaling.
 SLUS-21313:
   name: "Friends - The One with all the Trivia"
@@ -47660,7 +47621,6 @@ SLUS-21413:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned bloom effects.
     mergeSprite: 1 # Fixes blurriness but removes bloom + Recommended to use Shadeboost brightness 80.
-    deinterlace: 8 # Game requires adaptive (or blend) tff de-interlacing instead of auto for the whole game.
 SLUS-21414:
   name: "Delta Force - Black Hawk Down - Team Sabre"
   region: "NTSC-U"
@@ -48545,7 +48505,6 @@ SLUS-21611:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misaligned bloom effects, 1 is technically more correct compared to software but looks worse.
-    deinterlace: 8 # Game requires adaptive (or blend) tff de-interlacing instead of auto for the whole game.
 SLUS-21612:
   name: "Legend of the Dragon"
   region: "NTSC-U"
@@ -48703,6 +48662,8 @@ SLUS-21639:
   name: "NASCAR '08"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    deinterlace: 8 # Game requires AdaptiveTFF de-interlacing when auto.
 SLUS-21640:
   name: "Rugby '08"
   region: "NTSC-U"
@@ -49192,6 +49153,8 @@ SLUS-21744:
   name: "NASCAR '09"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    deinterlace: 8 # Game requires AdaptiveTFF de-interlacing when auto.
   patches:
     1B6C22B9:
       content: |-
@@ -49892,8 +49855,6 @@ SLUS-21902:
     eeRoundMode: 1 # Fixes black textures in conjunction with VU0 clamping set to none.
   clampModes:
     vu0ClampMode: 0 # Fixes black textures and SPS.
-  gsHWFixes:
-    deinterlace: 8 # Game requires adaptive (or blend) tff de-interlacing instead of auto for the FMVs.
 SLUS-21904:
   name: "Teenage Mutant Ninja Turtles - Smash-Up"
   region: "NTSC-U"

--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -232,6 +232,7 @@ static bool DoGSOpen(GSRendererType renderer, u8* basemem)
 		}
 
 		g_gs_renderer->SetRegsMem(basemem);
+		g_gs_renderer->ResetPCRTC();
 	}
 	else
 	{

--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -330,6 +330,7 @@ public:
 			int FBP;
 			int FBW;
 			int PSM;
+			GSRegDISPFB prevFramebufferReg;
 			GSVector2i prevDisplayOffset;
 			GSVector2i displayOffset;
 			GSVector4i displayRect;
@@ -534,7 +535,7 @@ public:
 			PCRTCDisplays[display].FBP = framebufferReg.FBP;
 			PCRTCDisplays[display].FBW = framebufferReg.FBW;
 			PCRTCDisplays[display].PSM = framebufferReg.PSM;
-
+			PCRTCDisplays[display].prevFramebufferReg = framebufferReg;
 			// Probably not really enabled but will cause a mess.
 			// Q-Ball Billiards enables both circuits but doesn't set one of them up.
 			if (PCRTCDisplays[display].FBW == 0 && displayReg.DW == 0 && displayReg.DH == 0 && displayReg.MAGH == 0)

--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -290,59 +290,507 @@ public:
 	PRIM_OVERLAP m_prim_overlap;
 	std::vector<size_t> m_drawlist;
 
-	// The horizontal offset values (under z) for PAL and NTSC have been tweaked
-	// they should be apparently 632 and 652 respectively, but that causes a thick black line on the left
-	// these values leave a small black line on the right in a bunch of games, but it's not so bad.
-	// The only conclusion I can come to is there is horizontal overscan expected so there would normally
-	// be black borders either side anyway, or both sides slightly covered.
-	const GSVector4i VideoModeOffsets[6] = {
-		GSVector4i(640, 224, 642, 25),
-		GSVector4i(640, 256, 676, 36),
-		GSVector4i(640, 480, 276, 34),
-		GSVector4i(720, 480, 232, 35),
-		GSVector4i(1280, 720, 302, 24),
-		GSVector4i(1920, 540, 238, 40)
-	};
+	struct GSPCRTCRegs
+	{
+		// The horizontal offset values (under z) for PAL and NTSC have been tweaked
+		// they should be apparently 632 and 652 respectively, but that causes a thick black line on the left
+		// these values leave a small black line on the right in a bunch of games, but it's not so bad.
+		// The only conclusion I can come to is there is horizontal overscan expected so there would normally
+		// be black borders either side anyway, or both sides slightly covered.
+		const GSVector4i VideoModeOffsets[6] = {
+			GSVector4i(640, 224, 642, 25),
+			GSVector4i(640, 256, 676, 36),
+			GSVector4i(640, 480, 276, 34),
+			GSVector4i(720, 480, 232, 35),
+			GSVector4i(1280, 720, 302, 24),
+			GSVector4i(1920, 540, 238, 40)
+		};
 
-	const GSVector4i VideoModeOffsetsOverscan[6] = {
-		GSVector4i(711, 243, 498, 12),
-		GSVector4i(702, 288, 532, 18),
-		GSVector4i(640, 480, 276, 34),
-		GSVector4i(720, 480, 232, 35),
-		GSVector4i(1280, 720, 302, 24),
-		GSVector4i(1920, 540, 238, 40)
-	};
+		const GSVector4i VideoModeOffsetsOverscan[6] = {
+			GSVector4i(711, 243, 498, 12),
+			GSVector4i(702, 288, 532, 18),
+			GSVector4i(640, 480, 276, 34),
+			GSVector4i(720, 480, 232, 35),
+			GSVector4i(1280, 720, 302, 24),
+			GSVector4i(1920, 540, 238, 40)
+		};
 
-	const GSVector4i VideoModeDividers[6] = {
-		GSVector4i(3, 0, 2559, 239),
-		GSVector4i(3, 0, 2559, 287),
-		GSVector4i(1, 0, 1279, 479),
-		GSVector4i(1, 0, 1439, 479),
-		GSVector4i(0, 0, 1279, 719),
-		GSVector4i(0, 0, 1919, 1079)
-	};
+		const GSVector4i VideoModeDividers[6] = {
+			GSVector4i(3, 0, 2559, 239),
+			GSVector4i(3, 0, 2559, 287),
+			GSVector4i(1, 0, 1279, 479),
+			GSVector4i(1, 0, 1439, 479),
+			GSVector4i(0, 0, 1279, 719),
+			GSVector4i(0, 0, 1919, 1079)
+		};
+
+		struct PCRTCDisplay
+		{
+			bool enabled;
+			int FBP;
+			int FBW;
+			int PSM;
+			GSVector2i prevDisplayOffset;
+			GSVector2i displayOffset;
+			GSVector4i displayRect;
+			GSVector2i magnification;
+			GSVector2i prevFramebufferOffsets;
+			GSVector2i framebufferOffsets;
+			GSVector4i framebufferRect;
+
+			int Block()
+			{
+				return FBP << 5;
+			}
+		};
+
+		int videomode;
+		int interlaced;
+		int FFMD;
+		bool PCRTCSameSrc;
+		bool toggling_field;
+		PCRTCDisplay PCRTCDisplays[2];
+
+		bool IsAnalogue()
+		{
+			GSVideoMode video = static_cast<GSVideoMode>(videomode + 1);
+			return video == GSVideoMode::NTSC || video == GSVideoMode::PAL || video == GSVideoMode::HDTV_1080I;
+		}
+
+		// Calculates which display is closest to matching zero offsets in either direction.
+		GSVector2i NearestToZeroOffset()
+		{
+			GSVector2i returnValue = { 1, 1 };
+
+			if (!PCRTCDisplays[0].enabled && !PCRTCDisplays[1].enabled)
+				return returnValue;
+
+			for (int i = 0; i < 2; i++)
+			{
+				if (!PCRTCDisplays[i].enabled)
+				{
+					returnValue.x = 1 - i;
+					returnValue.y = 1 - i;
+					return returnValue;
+				}
+			}
+
+			if (abs(PCRTCDisplays[0].displayOffset.x - VideoModeOffsets[videomode].z) <
+				abs(PCRTCDisplays[1].displayOffset.x - VideoModeOffsets[videomode].z))
+				returnValue.x = 0;
+
+			// When interlaced, the vertical base offset is doubled
+			int verticalOffset = VideoModeOffsets[videomode].w * (1 << interlaced);
+
+			if (abs(PCRTCDisplays[0].displayOffset.y - verticalOffset) <
+				abs(PCRTCDisplays[1].displayOffset.y - verticalOffset))
+				returnValue.y = 0;
+
+			return returnValue;
+		}
+
+		void SetVideoMode(GSVideoMode videoModeIn)
+		{
+			videomode = static_cast<int>(videoModeIn) - 1;
+		}
+
+		// Enable each of the displays.
+		void EnableDisplays(GSRegPMODE pmode, GSRegSMODE2 smode2, bool smodetoggle)
+		{
+			PCRTCDisplays[0].enabled = pmode.EN1;
+			PCRTCDisplays[1].enabled = pmode.EN2;
+
+			interlaced = smode2.INT && IsAnalogue();
+			FFMD = smode2.FFMD;
+			toggling_field = smodetoggle && IsAnalogue();
+		}
+
+		void CheckSameSource()
+		{
+			if (PCRTCDisplays[0].enabled != PCRTCDisplays[1].enabled || (PCRTCDisplays[0].enabled | PCRTCDisplays[1].enabled) == false)
+			{
+				PCRTCSameSrc = false;
+				return;
+			}
+
+			PCRTCSameSrc = PCRTCDisplays[0].FBP == PCRTCDisplays[1].FBP &&
+			PCRTCDisplays[0].FBW == PCRTCDisplays[1].FBW &&
+			GSUtil::HasCompatibleBits(PCRTCDisplays[0].PSM, PCRTCDisplays[1].PSM);
+		}
+		
+		bool FrameWrap()
+		{
+			GSVector4i combined_rect = GSVector4i(PCRTCDisplays[0].framebufferRect.runion(PCRTCDisplays[1].framebufferRect));
+			return combined_rect.w >= 2048 || combined_rect.z >= 2048;
+		}
+
+		// If the start point of both frames match, we can do a single read
+		bool FrameRectMatch()
+		{
+			return PCRTCSameSrc;
+		}
+
+		GSVector2i GetResolution()
+		{
+			GSVector2i resolution;
+
+			const GSVector4i offsets = !GSConfig.PCRTCOverscan ? VideoModeOffsets[videomode] : VideoModeOffsetsOverscan[videomode];
+			const bool is_full_height = interlaced || (toggling_field && GSConfig.InterlaceMode != GSInterlaceMode::Off) || GSConfig.InterlaceMode == GSInterlaceMode::Off;
+
+			if (!GSConfig.PCRTCOffsets)
+			{
+				if (PCRTCDisplays[0].enabled && PCRTCDisplays[1].enabled)
+				{
+					GSVector4i combined_size = PCRTCDisplays[0].displayRect.runion(PCRTCDisplays[1].displayRect);
+					resolution = { combined_size.width(), combined_size.height() };
+				}
+				else if (PCRTCDisplays[0].enabled)
+				{
+					resolution = { PCRTCDisplays[0].displayRect.width(), PCRTCDisplays[0].displayRect.height() };
+				}
+				else
+				{
+					resolution = { PCRTCDisplays[1].displayRect.width(), PCRTCDisplays[1].displayRect.height() };
+				}
+			}
+			else
+			{
+				const int shift = is_full_height ? 1 : 0;
+				resolution = { offsets.x, offsets.y << shift };
+			}
+
+			resolution.x = std::min(resolution.x, offsets.x);
+			resolution.y = std::min(resolution.y, is_full_height ? offsets.y << 1 : offsets.y);
+
+			return resolution;
+		}
+
+		GSVector4i GetFramebufferRect(int display)
+		{
+			if (display == -1)
+			{
+				return GSVector4i(PCRTCDisplays[0].framebufferRect.runion(PCRTCDisplays[1].framebufferRect));
+			}
+			else
+			{
+				return PCRTCDisplays[display].framebufferRect;
+			}
+		}
+
+		int GetFramebufferBitDepth()
+		{
+			if (PCRTCDisplays[0].enabled)
+				return GSLocalMemory::m_psm[PCRTCDisplays[0].PSM].bpp;
+			else if (PCRTCDisplays[1].enabled)
+				return GSLocalMemory::m_psm[PCRTCDisplays[1].PSM].bpp;
+
+			return 32;
+		}
+
+		GSVector2i GetFramebufferSize(int display)
+		{
+			if (display == -1)
+			{
+				GSVector4i combined_rect = PCRTCDisplays[0].framebufferRect.runion(PCRTCDisplays[1].framebufferRect);
+
+				if (combined_rect.z >= 2048)
+				{
+					int high_x = (PCRTCDisplays[0].framebufferRect.x > PCRTCDisplays[1].framebufferRect.x) ? PCRTCDisplays[0].framebufferRect.x : PCRTCDisplays[1].framebufferRect.x;
+					combined_rect.z -= GSConfig.UseHardwareRenderer() ? 2048 : high_x;
+					combined_rect.x = 0;
+				}
+
+				if (combined_rect.w >= 2048)
+				{
+					int high_y = (PCRTCDisplays[0].framebufferRect.y > PCRTCDisplays[1].framebufferRect.y) ? PCRTCDisplays[0].framebufferRect.y : PCRTCDisplays[1].framebufferRect.y;
+					combined_rect.w -= GSConfig.UseHardwareRenderer() ? 2048 : high_y;
+					combined_rect.y = 0;
+				}
+				return GSVector2i(combined_rect.z, combined_rect.w);
+			}
+			else
+			{
+				GSVector4i out_rect = PCRTCDisplays[display].framebufferRect;
+
+				if (out_rect.z >= 2048)
+				{
+					out_rect.z -= GSConfig.UseHardwareRenderer() ? 2048 : out_rect.x;
+					out_rect.x = 0;
+				}
+
+				if (out_rect.w >= 2048)
+				{
+					out_rect.w -= GSConfig.UseHardwareRenderer() ? 2048 : out_rect.y;
+					out_rect.y = 0;
+				}
+				return GSVector2i(out_rect.z, out_rect.w);
+			}
+		}
+
+		// Sets up the rectangles for both the framebuffer read and the displays for the merge circuit.
+		void SetRects(int display, GSRegDISPLAY displayReg, GSRegDISPFB framebufferReg)
+		{
+			// Save framebuffer information first, while we're here.
+			PCRTCDisplays[display].FBP = framebufferReg.FBP;
+			PCRTCDisplays[display].FBW = framebufferReg.FBW;
+			PCRTCDisplays[display].PSM = framebufferReg.PSM;
+
+			// Probably not really enabled but will cause a mess.
+			// Q-Ball Billiards enables both circuits but doesn't set one of them up.
+			if (PCRTCDisplays[display].FBW == 0 && displayReg.DW == 0 && displayReg.DH == 0 && displayReg.MAGH == 0)
+			{
+				PCRTCDisplays[display].enabled = false;
+				return;
+			}
+			PCRTCDisplays[display].magnification = GSVector2i(displayReg.MAGH + 1, displayReg.MAGV + 1);
+			const u32 DW = displayReg.DW + 1;
+			const u32 DH = displayReg.DH + 1;
+
+			const int renderWidth = DW / PCRTCDisplays[display].magnification.x;
+			const int renderHeight = DH / PCRTCDisplays[display].magnification.y;
+
+			u32 finalDisplayWidth = renderWidth;
+			u32 finalDisplayHeight = renderHeight;
+			// When using screen offsets the screen gets squashed/resized in to the actual screen size.
+			if (GSConfig.PCRTCOffsets)
+			{
+				finalDisplayWidth = DW / (VideoModeDividers[videomode].x + 1);
+				finalDisplayHeight = DH / (VideoModeDividers[videomode].y + 1);
+			}
+			else
+			{
+				finalDisplayWidth = std::min(finalDisplayWidth ,DW / (VideoModeDividers[videomode].x + 1));
+				finalDisplayHeight = std::min(finalDisplayHeight, DH / (VideoModeDividers[videomode].y + 1));
+			}
+
+			// Framebuffer size and offsets.
+			PCRTCDisplays[display].prevFramebufferOffsets = PCRTCDisplays[display].framebufferOffsets;
+			PCRTCDisplays[display].framebufferRect.x = 0;
+			PCRTCDisplays[display].framebufferRect.y = 0;
+			PCRTCDisplays[display].framebufferRect.z = renderWidth;
+
+			if(FFMD && interlaced) // Round up the height as if it's an odd value, this will cause havok with the merge circuit.
+				PCRTCDisplays[display].framebufferRect.w = (renderHeight + 1) >> (FFMD * interlaced); // Half height read if FFMD + INT enabled.
+			else
+				PCRTCDisplays[display].framebufferRect.w = renderHeight;
+			PCRTCDisplays[display].framebufferOffsets.x = framebufferReg.DBX;
+			PCRTCDisplays[display].framebufferOffsets.y = framebufferReg.DBY;
+
+			const bool is_interlaced_resolution = interlaced || (toggling_field && GSConfig.InterlaceMode != GSInterlaceMode::Off);
+
+			// If the interlace flag isn't set, but it's still interlacing, the height is likely reported wrong.
+			// Q-Ball Billiards.
+			if (is_interlaced_resolution && !interlaced)
+				finalDisplayHeight *= 2;
+
+			// Display size and offsets.
+			PCRTCDisplays[display].displayRect.x = 0;
+			PCRTCDisplays[display].displayRect.y = 0;
+			PCRTCDisplays[display].displayRect.z = finalDisplayWidth;
+			PCRTCDisplays[display].displayRect.w = finalDisplayHeight;
+			PCRTCDisplays[display].prevDisplayOffset = PCRTCDisplays[display].displayOffset;
+			PCRTCDisplays[display].displayOffset.x = displayReg.DX;
+			PCRTCDisplays[display].displayOffset.y = displayReg.DY;
+		}
+
+		// Calculate framebuffer read offsets, should be considered if only one circuit is enabled, or difference is more than 1 line.
+		// Only considered if "Anti-blur" is enabled.
+		void CalculateFramebufferOffset()
+		{
+			if (GSConfig.PCRTCAntiBlur && PCRTCDisplays[0].enabled && PCRTCSameSrc)
+			{
+				if (abs(PCRTCDisplays[1].framebufferOffsets.y - PCRTCDisplays[0].framebufferOffsets.y) == 1
+					&& PCRTCDisplays[0].displayOffset.y == PCRTCDisplays[1].displayOffset.y)
+				{
+					if (PCRTCDisplays[1].framebufferOffsets.y < PCRTCDisplays[0].framebufferOffsets.y)
+						PCRTCDisplays[0].framebufferOffsets.y = PCRTCDisplays[1].framebufferOffsets.y;
+					else
+						PCRTCDisplays[1].framebufferOffsets.y = PCRTCDisplays[0].framebufferOffsets.y;
+				}
+			}
+			PCRTCDisplays[0].framebufferRect.x += PCRTCDisplays[0].framebufferOffsets.x;
+			PCRTCDisplays[0].framebufferRect.z += PCRTCDisplays[0].framebufferOffsets.x;
+			PCRTCDisplays[0].framebufferRect.y += PCRTCDisplays[0].framebufferOffsets.y;
+			PCRTCDisplays[0].framebufferRect.w += PCRTCDisplays[0].framebufferOffsets.y;
+
+			PCRTCDisplays[1].framebufferRect.x += PCRTCDisplays[1].framebufferOffsets.x;
+			PCRTCDisplays[1].framebufferRect.z += PCRTCDisplays[1].framebufferOffsets.x;
+			PCRTCDisplays[1].framebufferRect.y += PCRTCDisplays[1].framebufferOffsets.y;
+			PCRTCDisplays[1].framebufferRect.w += PCRTCDisplays[1].framebufferOffsets.y;
+		}
+
+		// Used in software mode to align the buffer when reading. Offset is accounted for (block aligned) by GetOutput.
+		void RemoveFramebufferOffset(int display)
+		{
+			if (display >= 0)
+			{
+				// Hardware needs nothing but handling for wrapped framebuffers.
+				if (GSConfig.UseHardwareRenderer())
+				{
+					if (PCRTCDisplays[display].framebufferRect.z >= 2048)
+					{
+						PCRTCDisplays[display].framebufferRect.x = 0;
+						PCRTCDisplays[display].framebufferRect.z -= 2048;
+					}
+					if (PCRTCDisplays[display].framebufferRect.w >= 2048)
+					{
+						PCRTCDisplays[display].framebufferRect.y = 0;
+						PCRTCDisplays[display].framebufferRect.w -= 2048;
+					}
+				}
+				else
+				{
+					const GSLocalMemory::psm_t& psm = GSLocalMemory::m_psm[PCRTCDisplays[display].PSM];
+
+					GSVector4i r = PCRTCDisplays[display].framebufferRect;
+					r = r.ralign<Align_Outside>(psm.bs);
+
+					PCRTCDisplays[display].framebufferRect.z -= r.x;
+					PCRTCDisplays[display].framebufferRect.w -= r.y;
+					PCRTCDisplays[display].framebufferRect.x -= r.x;
+					PCRTCDisplays[display].framebufferRect.y -= r.y;
+				}
+			}
+			else
+			{
+				// This code is to read the framebuffer nicely block aligned in software, then leave the remaining offset in to the block.
+				// In hardware mode this doesn't happen, it reads the whole framebuffer, so we need to keep the offset.
+				if (!GSConfig.UseHardwareRenderer())
+				{
+					const GSLocalMemory::psm_t& psm = GSLocalMemory::m_psm[PCRTCDisplays[1].PSM];
+
+					GSVector4i r = PCRTCDisplays[0].framebufferRect.runion(PCRTCDisplays[1].framebufferRect);
+					r = r.ralign<Align_Outside>(psm.bs);
+
+					PCRTCDisplays[0].framebufferRect.x -= r.x;
+					PCRTCDisplays[0].framebufferRect.y -= r.y;
+					PCRTCDisplays[0].framebufferRect.z -= r.x;
+					PCRTCDisplays[0].framebufferRect.w -= r.y;
+					PCRTCDisplays[1].framebufferRect.x -= r.x;
+					PCRTCDisplays[1].framebufferRect.y -= r.y;
+					PCRTCDisplays[1].framebufferRect.z -= r.x;
+					PCRTCDisplays[1].framebufferRect.w -= r.y;
+				}
+			}
+		}
+
+		// If the two displays are offset from each other, move them to the correct offsets.
+		// If using screen offsets, calculate the positions here.
+		void CalculateDisplayOffset(bool scanmask)
+		{
+			// Offsets are generally ignored, the "hacky" way of doing the displays, but direct to framebuffers.
+			if (!GSConfig.PCRTCOffsets)
+			{
+				const GSVector4i offsets = !GSConfig.PCRTCOverscan ? VideoModeOffsets[videomode] : VideoModeOffsetsOverscan[videomode];
+				int int_off[2] = { 0, 0 };
+				GSVector2i zeroDisplay = NearestToZeroOffset();
+				GSVector2i baseOffset = PCRTCDisplays[zeroDisplay.y].displayOffset;
+
+				int blurOffset = abs(PCRTCDisplays[1].displayOffset.y - PCRTCDisplays[0].displayOffset.y);
+				if (GSConfig.PCRTCAntiBlur && !scanmask && blurOffset < 4)
+				{
+					if (PCRTCDisplays[1].displayOffset.y > PCRTCDisplays[0].displayOffset.y)
+						PCRTCDisplays[1].displayOffset.y -= blurOffset;
+					else
+						PCRTCDisplays[0].displayOffset.y -= blurOffset;
+				}
+
+				// If there's a single pixel offset, account for it else it can throw interlacing out.
+				for (int i = 0; i < 2; i++)
+				{
+					if (!PCRTCDisplays[i].enabled)
+						continue;
+
+					// Should this be MAGV/H in the DISPLAY register rather than the "default" magnification?
+					const int offset = (PCRTCDisplays[i].displayOffset.y - (offsets.w * (interlaced + 1))) / (VideoModeDividers[videomode].y + 1);
+
+					if (offset > 4)
+						continue;
+
+					int_off[i] = offset & 1;
+					if (offset < 0)
+						int_off[i] = -int_off[i];
+
+					PCRTCDisplays[i].displayRect.y += int_off[i];
+					PCRTCDisplays[i].displayRect.w += int_off[i];
+				}
+
+				// Handle difference in offset between the two displays, used in games like DmC and Time Crisis 2 (for split screen).
+				// Offset is not screen based, but relative to each other.
+				if (PCRTCDisplays[0].enabled && PCRTCDisplays[1].enabled)
+				{
+					GSVector2i offset;
+
+					offset.x = (PCRTCDisplays[1 - zeroDisplay.x].displayOffset.x - PCRTCDisplays[zeroDisplay.x].displayOffset.x) / (VideoModeDividers[videomode].x + 1);
+					offset.y = (PCRTCDisplays[1 - zeroDisplay.y].displayOffset.y - PCRTCDisplays[zeroDisplay.y].displayOffset.y) / (VideoModeDividers[videomode].y + 1);
+
+					if (offset.x >= 4 || !GSConfig.PCRTCAntiBlur)
+					{
+						PCRTCDisplays[1 - zeroDisplay.x].displayRect.x += offset.x;
+						PCRTCDisplays[1 - zeroDisplay.x].displayRect.z += offset.x;
+					}
+					if (offset.y >= 4 || !GSConfig.PCRTCAntiBlur)
+					{
+						PCRTCDisplays[1 - zeroDisplay.y].displayRect.y += offset.y - int_off[1 - zeroDisplay.y];
+						PCRTCDisplays[1 - zeroDisplay.y].displayRect.w += offset.y - int_off[1 - zeroDisplay.y];
+					}
+
+					baseOffset = PCRTCDisplays[zeroDisplay.y].displayOffset;
+				}
+
+				// Handle any large vertical offset from the zero position on the screen.
+				// Example: Hokuto no Ken, does a rougly -14 offset to bring the screen up.
+				// Ignore the lowest bit, we've already accounted for this
+				int vOffset = ((static_cast<int>(baseOffset.y) - (offsets.w * (interlaced + 1))) / (VideoModeDividers[videomode].y + 1));
+
+				if(vOffset <= 4 && vOffset != 0)
+				{
+					PCRTCDisplays[0].displayRect.y += vOffset - int_off[0];
+					PCRTCDisplays[0].displayRect.w += vOffset - int_off[0];
+					PCRTCDisplays[1].displayRect.y += vOffset - int_off[1];
+					PCRTCDisplays[1].displayRect.w += vOffset - int_off[1];
+				}
+			}
+			else // We're using screen offsets, so just calculate the entire offset.
+			{
+				const GSVector4i offsets = !GSConfig.PCRTCOverscan ? VideoModeOffsets[videomode] : VideoModeOffsetsOverscan[videomode];
+				GSVector2i offset = { 0, 0 };
+
+				int blurOffset = abs(PCRTCDisplays[1].displayOffset.y - PCRTCDisplays[0].displayOffset.y);
+				if (GSConfig.PCRTCAntiBlur && !scanmask && blurOffset < 4)
+				{
+					if (PCRTCDisplays[1].displayOffset.y > PCRTCDisplays[0].displayOffset.y)
+						PCRTCDisplays[1].displayOffset.y -= blurOffset;
+					else
+						PCRTCDisplays[0].displayOffset.y -= blurOffset;
+				}
+
+				for (int i = 0; i < 2; i++)
+				{
+					// Should this be MAGV/H in the DISPLAY register rather than the "default" magnification?
+					offset.x = (static_cast<int>(PCRTCDisplays[i].displayOffset.x) - offsets.z) / (VideoModeDividers[videomode].x + 1);
+					offset.y = (static_cast<int>(PCRTCDisplays[i].displayOffset.y) - (offsets.w * (interlaced + 1))) / (VideoModeDividers[videomode].y + 1);
+
+					PCRTCDisplays[i].displayRect.x += offset.x;
+					PCRTCDisplays[i].displayRect.z += offset.x;
+					PCRTCDisplays[i].displayRect.y += offset.y;
+					PCRTCDisplays[i].displayRect.w += offset.y;
+				}
+			}
+		}
+	} PCRTCDisplays;
 
 public:
 	/// Returns the appropriate directory for draw dumping.
 	static std::string GetDrawDumpPath(const char* format, ...);
 
 	void ResetHandlers();
+	void ResetPCRTC();
 
-	int GetFramebufferHeight();
-	int GetFramebufferWidth();
-	int GetFramebufferBitDepth();
-	int GetDisplayHMagnification();
-	GSVector4i GetDisplayRect(int i = -1);
-	GSVector4i GetFrameMagnifiedRect(int i = -1);
-	GSVector2i GetResolutionOffset(int i = -1);
-	GSVector2i GetResolution();
-	GSVector4i GetFrameRect(int i = -1, bool ignore_off = false);
 	GSVideoMode GetVideoMode();
 
-	bool IsEnabled(int i);
 	bool isinterlaced();
 	bool isReallyInterlaced();
-	bool IsAnalogue();
 
 	float GetTvRefreshRate();
 

--- a/pcsx2/GS/Renderers/Common/GSDevice.cpp
+++ b/pcsx2/GS/Renderers/Common/GSDevice.cpp
@@ -356,6 +356,7 @@ void GSDevice::Interlace(const GSVector2i& ds, int field, int mode, float yoffse
 			break;
 		default:
 			m_current = m_merge;
+			break;
 	}
 }
 

--- a/pcsx2/GS/Renderers/Common/GSRenderer.cpp
+++ b/pcsx2/GS/Renderers/Common/GSRenderer.cpp
@@ -77,82 +77,37 @@ void GSRenderer::Destroy()
 
 bool GSRenderer::Merge(int field)
 {
-	bool en[2];
-
-	GSVector4i fr[2];
-	GSVector4i dr[2];
-	GSVector2i display_offsets[2];
-
-	GSVector2i display_baseline = {INT_MAX, INT_MAX};
-	GSVector2i frame_baseline = {INT_MAX, INT_MAX};
-	GSVector2i display_combined = {0, 0};
-	bool feedback_merge = m_regs->EXTWRITE.WRITE == 1;
-	bool display_offset = false;
-
-	for (int i = 0; i < 2; i++)
-	{
-		en[i] = IsEnabled(i) || (m_regs->EXTBUF.FBIN == i && feedback_merge);
-
-		if (en[i])
-		{
-			fr[i] = GetFrameRect(i);
-			dr[i] = GetDisplayRect(i);
-			display_offsets[i] = GetResolutionOffset(i);
-
-			display_combined.x = std::max(((dr[i].right) - dr[i].left) + display_offsets[i].x, display_combined.x);
-			display_combined.y = std::max((dr[i].bottom - dr[i].top) + display_offsets[i].y, display_combined.y);
-
-			display_baseline.x = std::min(display_offsets[i].x, display_baseline.x);
-			display_baseline.y = std::min(display_offsets[i].y, display_baseline.y);
-			frame_baseline.x = std::min(std::max(fr[i].left, 0), frame_baseline.x);
-			frame_baseline.y = std::min(std::max(fr[i].top, 0), frame_baseline.y);
-
-			display_offset |= std::abs(display_baseline.y - display_offsets[i].y) == 1;
-			/*DevCon.Warning("Read offset was X %d(left %d) Y %d(top %d)", display_baseline.x, dr[i].left, display_baseline.y, dr[i].top);
-			DevCon.Warning("[%d]: %d %d %d %d, %d %d %d %d\n", i, fr[i].x,fr[i].y,fr[i].z,fr[i].w , dr[i].x,dr[i].y,dr[i].z,dr[i].w);
-			DevCon.Warning("Offset X %d Offset Y %d", display_offsets[i].x, display_offsets[i].y);*/
-		}
-	}
-
-	if (!en[0] && !en[1])
-	{
-		return false;
-	}
-
-	GL_PUSH("Renderer Merge %d (0: enabled %d 0x%x, 1: enabled %d 0x%x)", s_n, en[0], m_regs->DISP[0].DISPFB.Block(), en[1], m_regs->DISP[1].DISPFB.Block());
-
-	// try to avoid fullscreen blur, could be nice on tv but on a monitor it's like double vision, hurts my eyes (persona 4, guitar hero)
-	//
-	// NOTE: probably the technique explained in graphtip.pdf (Antialiasing by Supersampling / 4. Reading Odd/Even Scan Lines Separately with the PCRTC then Blending)
-
-	const bool samesrc =
-		en[0] && en[1] &&
-		m_regs->DISP[0].DISPFB.FBP == m_regs->DISP[1].DISPFB.FBP &&
-		m_regs->DISP[0].DISPFB.FBW == m_regs->DISP[1].DISPFB.FBW &&
-		GSUtil::HasCompatibleBits(m_regs->DISP[0].DISPFB.PSM, m_regs->DISP[1].DISPFB.PSM);
-	bool single_fetch = false;
-
-	GSVector2i fs(0, 0);
-	GSVector2i ds(0, 0);
-
-	GSTexture* tex[3] = {NULL, NULL, NULL};
-	int y_offset[3] = {0, 0, 0};
-
 	s_n++;
 
+	GSVector2i fs(0, 0);
+	GSTexture* tex[3] = { NULL, NULL, NULL };
+	int y_offset[3] = { 0, 0, 0 };
+	bool feedback_merge = m_regs->EXTWRITE.WRITE == 1;
+
+	PCRTCDisplays.SetVideoMode(GetVideoMode());
+	PCRTCDisplays.EnableDisplays(m_regs->PMODE, m_regs->SMODE2, isReallyInterlaced());
+
+	if (!PCRTCDisplays.PCRTCDisplays[0].enabled && !PCRTCDisplays.PCRTCDisplays[1].enabled)
+		return false;
+
+	PCRTCDisplays.SetRects(0, m_regs->DISP[0].DISPLAY, m_regs->DISP[0].DISPFB);
+	PCRTCDisplays.SetRects(1, m_regs->DISP[1].DISPLAY, m_regs->DISP[1].DISPFB);
+	PCRTCDisplays.CalculateDisplayOffset(m_scanmask_used);
+	PCRTCDisplays.CalculateFramebufferOffset();
+	PCRTCDisplays.CheckSameSource();
+
 	// Only need to check the right/bottom on software renderer, hardware always gets the full texture then cuts a bit out later.
-	if (samesrc && !feedback_merge && (GSConfig.UseHardwareRenderer() || (fr[0].right == fr[1].right && fr[0].bottom == fr[1].bottom)))
+	if (PCRTCDisplays.FrameRectMatch() && !PCRTCDisplays.FrameWrap() && !feedback_merge)
 	{
-		tex[0] = GetOutput(0, y_offset[0]);
+		tex[0] = GetOutput(-1, y_offset[0]);
 		tex[1] = tex[0]; // saves one texture fetch
 		y_offset[1] = y_offset[0];
-		single_fetch = true;
 	}
 	else
 	{
-		if (en[0])
+		if (PCRTCDisplays.PCRTCDisplays[0].enabled)
 			tex[0] = GetOutput(0, y_offset[0]);
-		if (en[1])
+		if (PCRTCDisplays.PCRTCDisplays[1].enabled)
 			tex[1] = GetOutput(1, y_offset[1]);
 		if (feedback_merge)
 			tex[2] = GetFeedbackOutput();
@@ -162,11 +117,6 @@ bool GSRenderer::Merge(int field)
 	GSVector4 src_gs_read[2];
 	GSVector4 dst[3];
 
-	const bool slbg = m_regs->PMODE.SLBG;
-
-	GSVector2i resolution(GetResolution());
-	bool scanmask_frame = m_scanmask_used && !display_offset;
-	const bool ignore_offset = !GSConfig.PCRTCOffsets;
 	const bool is_bob = GSConfig.InterlaceMode == GSInterlaceMode::BobTFF || GSConfig.InterlaceMode == GSInterlaceMode::BobBFF;
 
 	// Use offset for bob deinterlacing always, extra offset added later for FFMD mode.
@@ -175,6 +125,7 @@ bool GSRenderer::Merge(int field)
 	int field2 = 0;
 	int mode = 3;
 
+	bool scanmask_frame = m_scanmask_used && abs(PCRTCDisplays.PCRTCDisplays[0].displayRect.y - PCRTCDisplays.PCRTCDisplays[1].displayRect.y) != 1;
 	// FFMD (half frames) requires blend deinterlacing, so automatically use that. Same when SCANMSK is used but not blended in the merge circuit (Alpine Racer 3)
 	if (GSConfig.InterlaceMode != GSInterlaceMode::Automatic || (!m_regs->SMODE2.FFMD && !scanmask_frame))
 	{
@@ -184,157 +135,38 @@ bool GSRenderer::Merge(int field)
 
 	for (int i = 0; i < 2; i++)
 	{
-		if (!en[i] || !tex[i])
+		GSPCRTCRegs::PCRTCDisplay& curCircuit = PCRTCDisplays.PCRTCDisplays[i];
+
+		if (!curCircuit.enabled || !tex[i])
 			continue;
 
-		GSVector4i r = GetFrameMagnifiedRect(i);
 		GSVector4 scale = GSVector4(tex[i]->GetScale()).xyxy();
 
-
-		GSVector2i off(ignore_offset ? 0 : display_offsets[i]);
-		GSVector2i display_diff(display_offsets[i].x - display_baseline.x, display_offsets[i].y - display_baseline.y);
-		GSVector2i frame_diff(fr[i].left - frame_baseline.x, fr[i].top - frame_baseline.y);
-
-		if (!GSConfig.UseHardwareRenderer())
-		{
-			// Clear any frame offsets, offset is already done in the software GetOutput.
-			fr[i].right -= fr[i].left;
-			fr[i].left = 0;
-			fr[i].bottom -= fr[i].top;
-			fr[i].top = 0;
-
-			// Put any frame offset difference back if we aren't anti-blurring on a single fetch (not offset).
-			if (!GSConfig.PCRTCAntiBlur && single_fetch)
-			{
-				fr[i].right += frame_diff.x;
-				fr[i].left += frame_diff.x;
-				fr[i].bottom += frame_diff.y;
-				fr[i].top += frame_diff.y;
-			}
-			
-		}
-
-		// If using scanmsk we have to keep the single line offset, regardless of upscale
-		// so we handle this separately after the rect calculations.
-		float interlace_offset = 0.0f;
-
-		if ((!GSConfig.PCRTCAntiBlur || m_scanmask_used) && display_offset)
-		{
-			interlace_offset = static_cast<float>(display_diff.y & 1);
-
-			// When the displays are offset by 1 we need to adjust for upscale to handle it (reduces bounce in MGS2 when upscaling)
-			interlace_offset += (tex[i]->GetScale().y - 1.0f)  / 2;
-
-			if (interlace_offset >= 1.0f)
-			{
-				if (!ignore_offset)
-					off.y -= 1;
-
-				display_diff.y -= 1;
-			}
-		}
-
-		// Start of Anti-Blur code.
-		if (!ignore_offset)
-		{
-			if (GSConfig.PCRTCAntiBlur)
-			{
-				if (samesrc)
-				{
-					// Offset by DISPLAY setting
-					if (display_diff.x < 4)
-						off.x -= display_diff.x;
-					if (display_diff.y < 4)
-						off.y -= display_diff.y;
-
-					// Only functional in HW mode, software clips/positions the framebuffer on read.
-					if (GSConfig.UseHardwareRenderer())
-					{
-						// Offset by DISPFB setting
-						if (abs(frame_diff.x) < 4)
-							off.x += frame_diff.x;
-						if (abs(frame_diff.y) < 4)
-							off.y += frame_diff.y;
-					}
-				}
-			}
-		}
-		else
-		{
-			if (!slbg || !feedback_merge)
-			{
-				// If the offsets between the two displays are quite large, it's probably intended for an effect.
-				if (display_diff.x >= 4 || !GSConfig.PCRTCAntiBlur)
-					off.x = display_diff.x;
-
-				if (display_diff.y >= 4 || !GSConfig.PCRTCAntiBlur)
-					off.y = display_diff.y;
-
-				// Need to check if only circuit 2 is enabled. Stuntman toggles circuit 1 on and off every other frame.
-				if (samesrc || m_regs->PMODE.EN == 2)
-				{
-					// Adjusting the screen offset when using a negative offset.
-					const int videomode = static_cast<int>(GetVideoMode()) - 1;
-					const GSVector4i offsets = !GSConfig.PCRTCOverscan ? VideoModeOffsets[videomode] : VideoModeOffsetsOverscan[videomode];
-					GSVector2i base_resolution(offsets.x, offsets.y);
-
-					if (isinterlaced() && !m_regs->SMODE2.FFMD)
-						base_resolution.y *= 2;
-
-					// Offset by DISPLAY setting
-					if (display_diff.x < 0)
-					{
-						off.x = 0;
-						if (base_resolution.x > resolution.x)
-							resolution.x -= display_diff.x;
-					}
-					if (display_diff.y < 0)
-					{
-						off.y = 0;
-						if (base_resolution.y > resolution.y)
-							resolution.y -= display_diff.y;
-					}
-
-					// Don't do X, we only care about height, this would need to be tailored for games using X (Black does -5).
-					// Mainly for Hokuto no Ken which does -14 Y offset.
-					if (display_baseline.y < -4)
-						off.y += display_baseline.y;
-
-					// Anti-Blur stuff
-					// Only functional in HW mode, software clips/positions the framebuffer on read.
-					if (GSConfig.PCRTCAntiBlur && GSConfig.UseHardwareRenderer())
-					{
-						// Offset by DISPFB setting
-						if (abs(frame_diff.x) < 4)
-							off.x += frame_diff.x;
-						if (abs(frame_diff.y) < 4)
-							off.y += frame_diff.y;
-					}
-				}
-			}
-		}
-		// End of Anti-Blur code.
-
-		if (isinterlaced() && m_regs->SMODE2.FFMD)
-			off.y >>= 1;
-
 		// dst is the final destination rect with offset on the screen.
-		dst[i] = scale * (GSVector4(off).xyxy() + GSVector4(r.rsize()));
+		dst[i] = scale * GSVector4(curCircuit.displayRect);
 
 		// src_gs_read is the size which we're really reading from GS memory.
-		src_gs_read[i] = ((GSVector4(fr[i]) + GSVector4(0, y_offset[i], 0, y_offset[i])) * scale) / GSVector4(tex[i]->GetSize()).xyxy();
-
-		// src_out_rect is the resized rect for output. (Not really used)
-		src_out_rect[i] = (GSVector4(r) * scale) / GSVector4(tex[i]->GetSize()).xyxy();
-
-		if (m_regs->SMODE2.FFMD && !is_bob && !GSConfig.DisableInterlaceOffset && GSConfig.InterlaceMode != GSInterlaceMode::Off)
+		src_gs_read[i] = ((GSVector4(curCircuit.framebufferRect) + GSVector4(0, y_offset[i], 0, y_offset[i])) * scale) / GSVector4(tex[i]->GetSize()).xyxy();
+		
+		float interlace_offset = 0.0f;
+		if (isReallyInterlaced() && m_regs->SMODE2.FFMD && !is_bob && !GSConfig.DisableInterlaceOffset && GSConfig.InterlaceMode != GSInterlaceMode::Off)
 		{
-			// We do half because FFMD is a half sized framebuffer, then we offset by 1 in the shader for the actual interlace
-			if(GetUpscaleMultiplier() > 1.0f)
-				interlace_offset += ((((tex[1] ? tex[1]->GetScale().y : tex[0]->GetScale().y) + 0.5f) * 0.5f) - 1.0f) * static_cast<float>(field ^ field2);
-			offset = 1.0f;
+			interlace_offset = (scale.y) * static_cast<float>(field ^ field2);
 		}
-		// Restore manually offset "interlace" lines
+		// Scanmask frame offsets. It's gross, I'm sorry but it sucks.
+		if (m_scanmask_used)
+		{
+			int displayIntOffset = PCRTCDisplays.PCRTCDisplays[i].displayRect.y - PCRTCDisplays.PCRTCDisplays[1 - i].displayRect.y;
+			
+			if (displayIntOffset > 0)
+			{
+				displayIntOffset &= 1;
+				dst[i].y -= displayIntOffset * scale.y;
+				dst[i].w -= displayIntOffset * scale.y;
+				interlace_offset += displayIntOffset;
+			}
+		}
+
 		dst[i] += GSVector4(0.0f, interlace_offset, 0.0f, interlace_offset);
 	}
 
@@ -351,41 +183,21 @@ bool GSRenderer::Merge(int field)
 		dst[2] = GSVector4(scale * GSVector4(feedback_rect.rsize()));
 	}
 
-	// Set the resolution to the height of the displays (kind of a saturate height)
-	if (ignore_offset && !feedback_merge)
-	{
-		GSVector2i max_resolution = GetResolution();
-		resolution.x = display_combined.x - display_baseline.x;
-		resolution.y = display_combined.y - display_baseline.y;
-
-		if (isinterlaced() && m_regs->SMODE2.FFMD)
-		{
-			resolution.y >>= 1;
-		}
-
-		resolution.x = std::min(max_resolution.x, resolution.x);
-		resolution.y = std::min(max_resolution.y, resolution.y);
-	}
-
+	GSVector2i resolution = PCRTCDisplays.GetResolution();
 	fs = GSVector2i(static_cast<int>(static_cast<float>(resolution.x) * GetUpscaleMultiplier()),
 		static_cast<int>(static_cast<float>(resolution.y) * GetUpscaleMultiplier()));
-	ds = fs;
 
-	// When interlace(FRAME) mode, the rect is half height, so it needs to be stretched.
-	const bool is_interlaced_resolution = m_regs->SMODE2.INT || (isReallyInterlaced() && IsAnalogue() && GSConfig.InterlaceMode != GSInterlaceMode::Off);
-
-	if (is_interlaced_resolution && m_regs->SMODE2.FFMD)
-		ds.y *= 2;
-
-	m_real_size = GSVector2i(fs.x, is_interlaced_resolution ? ds.y : fs.y);
+	m_real_size = GSVector2i(fs.x, fs.y);
 
 	if (!tex[0] && !tex[1])
 		return false;
 
-	if ((tex[0] == tex[1]) && (src_out_rect[0] == src_out_rect[1]).alltrue() && (dst[0] == dst[1]).alltrue() && !feedback_merge && !slbg)
+	if ((tex[0] == tex[1]) && (src_out_rect[0] == src_out_rect[1]).alltrue() && 
+		(PCRTCDisplays.PCRTCDisplays[0].displayRect == PCRTCDisplays.PCRTCDisplays[1].displayRect).alltrue() &&
+		(PCRTCDisplays.PCRTCDisplays[0].framebufferRect == PCRTCDisplays.PCRTCDisplays[1].framebufferRect).alltrue() &&
+		!feedback_merge && !m_regs->PMODE.SLBG)
 	{
 		// the two outputs are identical, skip drawing one of them (the one that is alpha blended)
-
 		tex[0] = NULL;
 	}
 
@@ -394,7 +206,7 @@ bool GSRenderer::Merge(int field)
 	g_gs_device->Merge(tex, src_gs_read, dst, fs, m_regs->PMODE, m_regs->EXTBUF, c);
 
 	if (isReallyInterlaced() && GSConfig.InterlaceMode != GSInterlaceMode::Off)
-		g_gs_device->Interlace(ds, field ^ field2, mode, offset);
+		g_gs_device->Interlace(fs, field ^ field2, mode, offset);
 
 	if (GSConfig.ShadeBoost)
 		g_gs_device->ShadeBoost();

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
@@ -821,14 +821,14 @@ void GSDevice11::DoMerge(GSTexture* sTex[3], GSVector4* sRect, GSTexture* dTex, 
 	{
 		// 2nd output is enabled and selected. Copy it to destination so we can blend it with 1st output
 		// Note: value outside of dRect must contains the background color (c)
-		StretchRect(sTex[1], sRect[1], dTex, PMODE.SLBG ? dRect[2] : dRect[1], ShaderConvert::COPY);
+		StretchRect(sTex[1], sRect[1], dTex, PMODE.SLBG ? dRect[2] : dRect[1], ShaderConvert::COPY, false);
 	}
 
 	// Save 2nd output
 	if (feedback_write_2)
 	{
 		StretchRect(dTex, full_r, sTex[2], dRect[2], m_convert.ps[static_cast<int>(ShaderConvert::YUV)].get(),
-			m_merge.cb.get(), nullptr, true);
+			m_merge.cb.get(), nullptr, false);
 	}
 
 	// Restore background color to process the normal merge
@@ -838,13 +838,13 @@ void GSDevice11::DoMerge(GSTexture* sTex[3], GSVector4* sRect, GSTexture* dTex, 
 	if (sTex[0])
 	{
 		// 1st output is enabled. It must be blended
-		StretchRect(sTex[0], sRect[0], dTex, dRect[0], m_merge.ps[PMODE.MMOD].get(), m_merge.cb.get(), m_merge.bs.get(), true);
+		StretchRect(sTex[0], sRect[0], dTex, dRect[0], m_merge.ps[PMODE.MMOD].get(), m_merge.cb.get(), m_merge.bs.get(), false);
 	}
 
 	if (feedback_write_1)
 	{
 		StretchRect(sTex[0], full_r, sTex[2], dRect[2], m_convert.ps[static_cast<int>(ShaderConvert::YUV)].get(),
-			m_merge.cb.get(), nullptr, true);
+			m_merge.cb.get(), nullptr, false);
 	}
 }
 

--- a/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
@@ -605,7 +605,7 @@ void GSDevice12::DoMerge(GSTexture* sTex[3], GSVector4* sRect, GSTexture* dTex, 
 		{
 			static_cast<GSTexture12*>(sTex[1])->TransitionToState(D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
 			OMSetRenderTargets(dTex, nullptr, darea);
-			SetUtilityTexture(sTex[1], m_linear_sampler_cpu);
+			SetUtilityTexture(sTex[1], m_point_sampler_cpu);
 			BeginRenderPass(D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_CLEAR, D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_PRESERVE,
 				D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_NO_ACCESS, D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_NO_ACCESS,
 				D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_NO_ACCESS, D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_NO_ACCESS, c);
@@ -625,7 +625,7 @@ void GSDevice12::DoMerge(GSTexture* sTex[3], GSVector4* sRect, GSTexture* dTex, 
 		EndRenderPass();
 		OMSetRenderTargets(sTex[2], nullptr, fbarea);
 		if (dcleared)
-			SetUtilityTexture(dTex, m_linear_sampler_cpu);
+			SetUtilityTexture(dTex, m_point_sampler_cpu);
 
 		// sTex[2] can be sTex[0], in which case it might be cleared (e.g. Xenosaga).
 		BeginRenderPassForStretchRect(static_cast<GSTexture12*>(sTex[2]), fbarea, GSVector4i(dRect[2]));
@@ -663,7 +663,7 @@ void GSDevice12::DoMerge(GSTexture* sTex[3], GSVector4* sRect, GSTexture* dTex, 
 	{
 		// 1st output is enabled. It must be blended
 		SetUtilityRootSignature();
-		SetUtilityTexture(sTex[0], m_linear_sampler_cpu);
+		SetUtilityTexture(sTex[0], m_point_sampler_cpu);
 		SetPipeline(m_merge[PMODE.MMOD].get());
 		DrawStretchRect(sRect[0], dRect[0], dTex->GetSize());
 	}
@@ -673,7 +673,7 @@ void GSDevice12::DoMerge(GSTexture* sTex[3], GSVector4* sRect, GSTexture* dTex, 
 		EndRenderPass();
 		SetUtilityRootSignature();
 		SetPipeline(m_convert[static_cast<int>(ShaderConvert::YUV)].get());
-		SetUtilityTexture(dTex, m_linear_sampler_cpu);
+		SetUtilityTexture(dTex, m_point_sampler_cpu);
 		OMSetRenderTargets(sTex[2], nullptr, fbarea);
 		BeginRenderPass(D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_PRESERVE, D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_PRESERVE);
 		DrawStretchRect(full_r, dRect[2], dsize);

--- a/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
+++ b/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
@@ -563,12 +563,12 @@ void GSDeviceMTL::DoMerge(GSTexture* sTex[3], GSVector4* sRect, GSTexture* dTex,
 	{
 		// 2nd output is enabled and selected. Copy it to destination so we can blend it with 1st output
 		// Note: value outside of dRect must contains the background color (c)
-		StretchRect(sTex[1], sRect[1], dTex, dRect[1], ShaderConvert::COPY);
+		StretchRect(sTex[1], sRect[1], dTex, dRect[1], ShaderConvert::COPY, false);
 	}
 
 	// Save 2nd output
 	if (feedback_write_2) // FIXME I'm not sure dRect[1] is always correct
-		DoStretchRect(dTex, full_r, sTex[2], dRect[1], m_convert_pipeline[static_cast<int>(ShaderConvert::YUV)], true, LoadAction::DontCareIfFull, &cb_yuv, sizeof(cb_yuv));
+		DoStretchRect(dTex, full_r, sTex[2], dRect[1], m_convert_pipeline[static_cast<int>(ShaderConvert::YUV)], false, LoadAction::DontCareIfFull, &cb_yuv, sizeof(cb_yuv));
 
 	if (feedback_write_2_but_blend_bg)
 		ClearRenderTarget(dTex, c);
@@ -582,17 +582,17 @@ void GSDeviceMTL::DoMerge(GSTexture* sTex[3], GSVector4* sRect, GSTexture* dTex,
 		if (PMODE.MMOD == 1)
 		{
 			// Blend with a constant alpha
-			DoStretchRect(sTex[0], sRect[0], dTex, dRect[0], pipeline, true, LoadAction::Load, &cb_c, sizeof(cb_c));
+			DoStretchRect(sTex[0], sRect[0], dTex, dRect[0], pipeline, false, LoadAction::Load, &cb_c, sizeof(cb_c));
 		}
 		else
 		{
 			// Blend with 2 * input alpha
-			DoStretchRect(sTex[0], sRect[0], dTex, dRect[0], pipeline, true, LoadAction::Load, nullptr, 0);
+			DoStretchRect(sTex[0], sRect[0], dTex, dRect[0], pipeline, false, LoadAction::Load, nullptr, 0);
 		}
 	}
 
 	if (feedback_write_1) // FIXME I'm not sure dRect[0] is always correct
-		StretchRect(dTex, full_r, sTex[2], dRect[0], ShaderConvert::YUV);
+		StretchRect(dTex, full_r, sTex[2], dRect[0], ShaderConvert::YUV, false);
 }}
 
 void GSDeviceMTL::DoInterlace(GSTexture* sTex, GSTexture* dTex, int shader, bool linear, float yoffset, int bufIdx)

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -1327,7 +1327,7 @@ void GSDeviceOGL::DoMerge(GSTexture* sTex[3], GSVector4* sRect, GSTexture* dTex,
 	{
 		// 2nd output is enabled and selected. Copy it to destination so we can blend it with 1st output
 		// Note: value outside of dRect must contains the background color (c)
-		StretchRect(sTex[1], sRect[1], dTex, PMODE.SLBG ? dRect[2] : dRect[1], ShaderConvert::COPY);
+		StretchRect(sTex[1], sRect[1], dTex, PMODE.SLBG ? dRect[2] : dRect[1], ShaderConvert::COPY, false);
 	}
 
 	// Upload constant to select YUV algo
@@ -1340,7 +1340,7 @@ void GSDeviceOGL::DoMerge(GSTexture* sTex[3], GSVector4* sRect, GSTexture* dTex,
 
 	// Save 2nd output
 	if (feedback_write_2)
-		StretchRect(dTex, full_r, sTex[2], dRect[2], ShaderConvert::YUV);
+		StretchRect(dTex, full_r, sTex[2], dRect[2], ShaderConvert::YUV, false);
 
 	// Restore background color to process the normal merge
 	if (feedback_write_2_but_blend_bg)
@@ -1357,17 +1357,17 @@ void GSDeviceOGL::DoMerge(GSTexture* sTex[3], GSVector4* sRect, GSTexture* dTex,
 			// Blend with a constant alpha
 			m_merge_obj.ps[1].Bind();
 			m_merge_obj.ps[1].Uniform4fv(0, c.v);
-			StretchRect(sTex[0], sRect[0], dTex, dRect[0], m_merge_obj.ps[1], true, OMColorMaskSelector());
+			StretchRect(sTex[0], sRect[0], dTex, dRect[0], m_merge_obj.ps[1], true, OMColorMaskSelector(), false);
 		}
 		else
 		{
 			// Blend with 2 * input alpha
-			StretchRect(sTex[0], sRect[0], dTex, dRect[0], m_merge_obj.ps[0], true, OMColorMaskSelector());
+			StretchRect(sTex[0], sRect[0], dTex, dRect[0], m_merge_obj.ps[0], true, OMColorMaskSelector(), false);
 		}
 	}
 
 	if (feedback_write_1)
-		StretchRect(dTex, full_r, sTex[2], dRect[2], ShaderConvert::YUV);
+		StretchRect(dTex, full_r, sTex[2], dRect[2], ShaderConvert::YUV, false);
 }
 
 void GSDeviceOGL::DoInterlace(GSTexture* sTex, GSTexture* dTex, int shader, bool linear, float yoffset, int bufIdx)

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
@@ -736,7 +736,7 @@ void GSDeviceVK::DoMerge(GSTexture* sTex[3], GSVector4* sRect, GSTexture* dTex, 
 		{
 			static_cast<GSTextureVK*>(sTex[1])->TransitionToLayout(VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
 			OMSetRenderTargets(dTex, nullptr, darea, false);
-			SetUtilityTexture(sTex[1], m_linear_sampler);
+			SetUtilityTexture(sTex[1], m_point_sampler);
 			BeginClearRenderPass(m_utility_color_render_pass_clear, darea, c);
 			SetPipeline(m_convert[static_cast<int>(ShaderConvert::COPY)]);
 			DrawStretchRect(sRect[1], PMODE.SLBG ? dRect[2] : dRect[1], dsize);
@@ -753,7 +753,7 @@ void GSDeviceVK::DoMerge(GSTexture* sTex[3], GSVector4* sRect, GSTexture* dTex, 
 		EndRenderPass();
 		OMSetRenderTargets(sTex[2], nullptr, fbarea, false);
 		if (dcleared)
-			SetUtilityTexture(dTex, m_linear_sampler);
+			SetUtilityTexture(dTex, m_point_sampler);
 		// sTex[2] can be sTex[0], in which case it might be cleared (e.g. Xenosaga).
 		BeginRenderPassForStretchRect(static_cast<GSTextureVK*>(sTex[2]), fbarea, GSVector4i(dRect[2]));
 		if (dcleared)
@@ -787,7 +787,7 @@ void GSDeviceVK::DoMerge(GSTexture* sTex[3], GSVector4* sRect, GSTexture* dTex, 
 	if (sTex[0] && sTex[0]->GetState() == GSTexture::State::Dirty)
 	{
 		// 1st output is enabled. It must be blended
-		SetUtilityTexture(sTex[0], m_linear_sampler);
+		SetUtilityTexture(sTex[0], m_point_sampler);
 		SetPipeline(m_merge[PMODE.MMOD]);
 		SetUtilityPushConstants(&c, sizeof(c));
 		DrawStretchRect(sRect[0], dRect[0], dTex->GetSize());
@@ -797,7 +797,7 @@ void GSDeviceVK::DoMerge(GSTexture* sTex[3], GSVector4* sRect, GSTexture* dTex, 
 	{
 		EndRenderPass();
 		SetPipeline(m_convert[static_cast<int>(ShaderConvert::YUV)]);
-		SetUtilityTexture(dTex, m_linear_sampler);
+		SetUtilityTexture(dTex, m_point_sampler);
 		SetUtilityPushConstants(yuv_constants, sizeof(yuv_constants));
 		OMSetRenderTargets(sTex[2], nullptr, fbarea, false);
 		BeginRenderPass(m_utility_color_render_pass_load, fbarea);


### PR DESCRIPTION
### Description of Changes
Rewrite the PCRTC code to make more sense and not look quite so gross.

### Rationale behind Changes
Was gross, had flaws, needed fixing.

### Suggested Testing Steps
I guess check offsets on the screen n stuff, and games which make use of the positioning such as DmC and WipEout Fusion.

- [x] Add changes to hardware renderer
- [x] Handle wrapping around 2048
- [x] Reset framebuffer offsets when reading from Software
- [x] Readd feedback circuit
- [x] Fix Anti-Blur when screen offsets is enabled
- [x] Make sure no-interlace patches work (ugh)
- [x] Tidy up code
