### PR TITLE
CDVD: macOS physical disc support

### DIFF
--- a/pcsx2/CDVD/Darwin/DriveUtility.cpp
+++ b/pcsx2/CDVD/Darwin/DriveUtility.cpp
@@ -41,8 +41,7 @@ std::vector<std::string> GetDriveListFromClasses(CFMutableDictionaryRef classes)
 	result = IOServiceGetMatchingServices(kIOMasterPortDefault, classes, &iterator);
 	if (result != KERN_SUCCESS)
 		return drives;
-	io_object_t media = IOIteratorNext(iterator);
-	while (media)
+	while (io_object_t media = IOIteratorNext(iterator))
 	{
 		CFTypeRef path_cfstr = IORegistryEntryCreateCFProperty(media, CFSTR(kIOBSDNameKey), kCFAllocatorDefault, 0);
 		if (path_cfstr)
@@ -58,7 +57,6 @@ std::vector<std::string> GetDriveListFromClasses(CFMutableDictionaryRef classes)
 			CFRelease(path_cfstr);
 		}
 		IOObjectRelease(media);
-		media = IOIteratorNext(iterator);
 	}
 	IOObjectRelease(iterator);
 	return drives;
@@ -71,15 +69,13 @@ std::vector<std::string> GetOpticalDriveList()
 #ifdef __APPLE__
 	std::vector<std::string> drives;
 
-	CFMutableDictionaryRef cd_classes = IOServiceMatching(kIOCDMediaClass);
-	if (cd_classes)
+	if (CFMutableDictionaryRef cd_classes = IOServiceMatching(kIOCDMediaClass))
 	{
 		std::vector<std::string> cd = GetDriveListFromClasses(cd_classes);
 		drives.insert(drives.end(), cd.begin(), cd.end());
 	}
 
-	CFMutableDictionaryRef dvd_classes = IOServiceMatching(kIODVDMediaClass);
-	if (dvd_classes)
+	if (CFMutableDictionaryRef dvd_classes = IOServiceMatching(kIODVDMediaClass))
 	{
 		std::vector<std::string> dvd = GetDriveListFromClasses(dvd_classes);
 		drives.insert(drives.end(), dvd.begin(), dvd.end());

--- a/pcsx2/CDVD/Darwin/DriveUtility.cpp
+++ b/pcsx2/CDVD/Darwin/DriveUtility.cpp
@@ -1,0 +1,119 @@
+/*  PCSX2 - PS2 Emulator for PCs
+ *  Copyright (C) 2002-2022  PCSX2 Dev Team
+ *
+ *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU Lesser General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  PCSX2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with PCSX2.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "PrecompiledHeader.h"
+#include "CDVD/CDVDdiscReader.h"
+
+#ifdef __APPLE__
+#include <CoreFoundation/CoreFoundation.h>
+
+#include <IOKit/storage/IOMedia.h>
+#include <IOKit/storage/IOCDMedia.h>
+#include <IOKit/storage/IODVDMedia.h>
+#include <IOKit/IOBSD.h>
+#include <IOKit/IOKitLib.h>
+#endif
+
+#include <fcntl.h>
+#include <unistd.h>
+
+#ifdef __APPLE__
+
+std::vector<std::string> GetDriveListFromClasses(CFMutableDictionaryRef classes)
+{
+	io_iterator_t iterator = IO_OBJECT_NULL;
+	kern_return_t result;
+	std::vector<std::string> drives;
+
+	CFDictionarySetValue(classes, CFSTR(kIOMediaEjectableKey), kCFBooleanTrue);
+	result = IOServiceGetMatchingServices(kIOMasterPortDefault, classes, &iterator);
+	if (result != KERN_SUCCESS)
+		return drives;
+	io_object_t media = IOIteratorNext(iterator);
+	while (media)
+	{
+		CFTypeRef path_cfstr = IORegistryEntryCreateCFProperty(media, CFSTR(kIOBSDNameKey), kCFAllocatorDefault, 0);
+		if (path_cfstr)
+		{
+			char path[PATH_MAX] = {0};
+			strlcpy(path, "/dev/r", PATH_MAX);
+			size_t path_prefix_len = strnlen(path, PATH_MAX);
+			result = CFStringGetCString((CFStringRef)path_cfstr, path + path_prefix_len, PATH_MAX - path_prefix_len, kCFStringEncodingUTF8);
+			if (result)
+			{
+				drives.emplace_back(path);
+			}
+			CFRelease(path_cfstr);
+		}
+		IOObjectRelease(media);
+		media = IOIteratorNext(iterator);
+	}
+	IOObjectRelease(iterator);
+	return drives;
+}
+
+#endif
+
+std::vector<std::string> GetOpticalDriveList()
+{
+#ifdef __APPLE__
+	std::vector<std::string> drives;
+
+	CFMutableDictionaryRef cd_classes = IOServiceMatching(kIOCDMediaClass);
+	if (cd_classes)
+	{
+		std::vector<std::string> cd = GetDriveListFromClasses(cd_classes);
+		drives.insert(drives.end(), cd.begin(), cd.end());
+	}
+
+	CFMutableDictionaryRef dvd_classes = IOServiceMatching(kIODVDMediaClass);
+	if (dvd_classes)
+	{
+		std::vector<std::string> dvd = GetDriveListFromClasses(dvd_classes);
+		drives.insert(drives.end(), dvd.begin(), dvd.end());
+	}
+	return drives;
+#else
+	return {};
+#endif
+}
+
+void GetValidDrive(std::string& drive)
+{
+	if (!drive.empty())
+	{
+#ifdef __APPLE__
+		int fd = open(drive.c_str(), O_RDONLY | O_NONBLOCK);
+		if (fd != -1)
+		{
+			close(fd);
+		}
+		else
+		{
+			drive.clear();
+		}
+#else
+		drive.clear();
+#endif
+	}
+	if (drive.empty())
+	{
+		auto drives = GetOpticalDriveList();
+		if (!drives.empty())
+			drive = drives.front();
+	}
+	if (!drive.empty())
+		printf(" * CDVD: Opening drive '%s'...\n", drive.c_str());
+}

--- a/pcsx2/CDVD/Darwin/DriveUtility.cpp
+++ b/pcsx2/CDVD/Darwin/DriveUtility.cpp
@@ -115,5 +115,5 @@ void GetValidDrive(std::string& drive)
 			drive = drives.front();
 	}
 	if (!drive.empty())
-		printf(" * CDVD: Opening drive '%s'...\n", drive.c_str());
+		DevCon.WriteLn("CDVD: Opening drive '%s'...", drive.c_str());
 }

--- a/pcsx2/CDVD/Darwin/IOCtlSrc.cpp
+++ b/pcsx2/CDVD/Darwin/IOCtlSrc.cpp
@@ -66,8 +66,17 @@ bool IOCtlSrc::Reopen()
 
 void IOCtlSrc::SetSpindleSpeed(bool restore_defaults) const
 {
-	// TODO: Seems it's actually able to set it (DKIOCCDSETSPEED) but I don't have
-	// physical drives right now to test
+	u16 speed = restore_defaults ? 0xFFFF : m_media_type >= 0 ? 5540 :
+																3600;
+	int ioctl_code = m_media_type >= 0 ? DKIOCDVDSETSPEED : DKIOCCDSETSPEED;
+	if (ioctl(m_device, ioctl_code, &speed) == -1)
+	{
+		fprintf(stderr, " * CDVD: Failed to set spindle speed: %s\n", strerror(errno));
+	}
+	else if (!restore_defaults)
+	{
+		printf(" * CDVD: Spindle speed set to %d\n", speed);
+	}
 }
 
 u32 IOCtlSrc::GetSectorCount() const

--- a/pcsx2/CDVD/Darwin/IOCtlSrc.cpp
+++ b/pcsx2/CDVD/Darwin/IOCtlSrc.cpp
@@ -71,11 +71,11 @@ void IOCtlSrc::SetSpindleSpeed(bool restore_defaults) const
 	int ioctl_code = m_media_type >= 0 ? DKIOCDVDSETSPEED : DKIOCCDSETSPEED;
 	if (ioctl(m_device, ioctl_code, &speed) == -1)
 	{
-		fprintf(stderr, " * CDVD: Failed to set spindle speed: %s\n", strerror(errno));
+		DevCon.Warning("CDVD: Failed to set spindle speed: %s", strerror(errno));
 	}
 	else if (!restore_defaults)
 	{
-		printf(" * CDVD: Spindle speed set to %d\n", speed);
+		DevCon.WriteLn("CDVD: Spindle speed set to %d", speed);
 	}
 }
 
@@ -107,10 +107,10 @@ bool IOCtlSrc::ReadSectors2048(u32 sector, u32 count, u8* buffer) const
 		return true;
 
 	if (bytes_read == -1)
-		fprintf(stderr, " * CDVD read sectors %u-%u failed: %s\n",
+		DevCon.Warning("CDVD: read sectors %u-%u failed: %s",
 			sector, sector + count - 1, strerror(errno));
 	else
-		fprintf(stderr, " * CDVD read sectors %u-%u: %zd bytes read, %zd bytes expected\n",
+		DevCon.Warning("CDVD: read sectors %u-%u: %zd bytes read, %zd bytes expected",
 			sector, sector + count - 1, bytes_read, bytes_to_read);
 	return false;
 }
@@ -129,7 +129,7 @@ bool IOCtlSrc::ReadSectors2352(u32 sector, u32 count, u8* buffer) const
 		desc.bufferLength = 2352;
 		if (ioctl(m_device, DKIOCCDREAD, &desc) == -1)
 		{
-			fprintf(stderr, " * CDVD DKIOCCDREAD sector %u failed: %s\n",
+			DevCon.Warning("CDVD: DKIOCCDREAD sector %u failed: %s",
 				sector + i, strerror(errno));
 			return false;
 		}
@@ -214,7 +214,7 @@ bool IOCtlSrc::ReadCDInfo()
 
 	if (ioctl(m_device, DKIOCCDREADTOC, &cdrt) == -1)
 	{
-		fprintf(stderr, "%s\n", strerror(errno));
+		DevCon.Warning("CDVD: DKIOCCDREADTOC failed: %s\n", strerror(errno));
 		return false;
 	}
 

--- a/pcsx2/CDVD/Linux/DriveUtility.cpp
+++ b/pcsx2/CDVD/Linux/DriveUtility.cpp
@@ -16,18 +16,14 @@
 #include "PrecompiledHeader.h"
 #include "CDVD/CDVDdiscReader.h"
 
-#ifdef __linux__
 #include <libudev.h>
 #include <linux/cdrom.h>
-#endif
-
 #include <fcntl.h>
 #include <sys/ioctl.h>
 #include <unistd.h>
 
 std::vector<std::string> GetOpticalDriveList()
 {
-#ifdef __linux__
 	udev* udev_context = udev_new();
 	if (!udev_context)
 		return {};
@@ -56,16 +52,12 @@ std::vector<std::string> GetOpticalDriveList()
 	udev_unref(udev_context);
 
 	return drives;
-#else
-	return {};
-#endif
 }
 
 void GetValidDrive(std::string& drive)
 {
 	if (!drive.empty())
 	{
-#ifdef __linux__
 		int fd = open(drive.c_str(), O_RDONLY | O_NONBLOCK);
 		if (fd != -1)
 		{
@@ -77,9 +69,6 @@ void GetValidDrive(std::string& drive)
 		{
 			drive.clear();
 		}
-#else
-		drive.clear();
-#endif
 	}
 	if (drive.empty())
 	{

--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -942,14 +942,14 @@ set(pcsx2LinuxSources
 	)
 
 set(pcsx2OSXSources
-	CDVD/Linux/DriveUtility.cpp
-	CDVD/Linux/IOCtlSrc.cpp
+	CDVD/Darwin/DriveUtility.cpp
+	CDVD/Darwin/IOCtlSrc.cpp
 	Darwin/DarwinFlatFileReader.cpp
 	)
 
 set(pcsx2FreeBSDSources
-	CDVD/Linux/DriveUtility.cpp
-	CDVD/Linux/IOCtlSrc.cpp
+	CDVD/Darwin/DriveUtility.cpp
+	CDVD/Darwin/IOCtlSrc.cpp
 	Darwin/DarwinFlatFileReader.cpp
 	)
 


### PR DESCRIPTION
### Description of Changes
Add physical disc support for macOS, moved FreeBSD null code to macOS code and removed conditional compilation from Linux code.

### Rationale behind Changes
For macOS physical disc support.

### Suggested Testing Steps
Test if PCSX2 still builds on FreeBSD.
Test if CDVD module still works on FreeBSD.
Test if physical CDs and DVDs could be played on macOS.
