### PR TITLE
USB: Don't crash and burn if there is no ini file for pcsx2.

### DIFF
--- a/pcsx2/USB/USB.cpp
+++ b/pcsx2/USB/USB.cpp
@@ -74,7 +74,7 @@ OHCIPort& USB::GetOHCIPort(u32 port)
 bool USB::CreateDevice(u32 port)
 {
 	const Pcsx2Config::USBOptions::Port& portcfg = EmuConfig.USB.Ports[port];
-	const DeviceProxy* proxy = RegisterDevice::instance().Device(portcfg.DeviceType);
+	const DeviceProxy* proxy = (portcfg.DeviceType != DEVTYPE_NONE) ? RegisterDevice::instance().Device(portcfg.DeviceType) : nullptr;
 	if (!proxy)
 		return true;
 
@@ -561,7 +561,7 @@ s32 USB::DeviceTypeNameToIndex(const std::string_view& device)
 const char* USB::DeviceTypeIndexToName(s32 device)
 {
 	RegisterDevice& rd = RegisterDevice::instance();
-	const DeviceProxy* proxy = rd.Device(device);
+	const DeviceProxy* proxy = (device != DEVTYPE_NONE) ? rd.Device(device) : nullptr;
 	return proxy ? proxy->TypeName() : "None";
 }
 

--- a/pcsx2/USB/deviceproxy.h
+++ b/pcsx2/USB/deviceproxy.h
@@ -115,6 +115,9 @@ public:
 
 	DeviceProxy* Device(int index)
 	{
+		if (index < 0)
+			return nullptr; // Don't try to go backwards at the beginning of an iterator and crash and burn when pcsx2 is run for the first time.
+
 		auto it = registerDeviceMap.begin();
 		std::advance(it, index);
 		if (it != registerDeviceMap.end())


### PR DESCRIPTION
### Description of Changes
Prevents DeviceProxy from going backwards from the beginning of an iterator.

### Rationale behind Changes
If there is no ini file, such as on first bootup, Ports[i].DeviceType is initialized to -1, which will cause the emulator to crash when it reaches this point.

### Suggested Testing Steps
Check to make sure this doesn't cause any issues with usb.
