### PR TITLE
USB: Buzz Button reorder

### DIFF
--- a/pcsx2/USB/usb-pad/usb-pad.cpp
+++ b/pcsx2/USB/usb-pad/usb-pad.cpp
@@ -933,27 +933,28 @@ namespace usb_pad
 	{
 		static constexpr const InputBindingInfo bindings[] = {
 			{"Red1", "Player 1 Red", InputBindingInfo::Type::Button, CID_BUTTON0, GenericInputBinding::Circle},
-			{"Blue1", "Player 1 Blue", InputBindingInfo::Type::Button, CID_BUTTON4, GenericInputBinding::R1},
-			{"Orange1", "Player 1 Orange", InputBindingInfo::Type::Button, CID_BUTTON3, GenericInputBinding::Cross},
-			{"Green1", "Player 1 Green", InputBindingInfo::Type::Button, CID_BUTTON2, GenericInputBinding::Triangle},
-			{"Yellow1", "Player 1 Yellow", InputBindingInfo::Type::Button, CID_BUTTON1, GenericInputBinding::Square},
-
 			{"Red2", "Player 2 Red", InputBindingInfo::Type::Button, CID_BUTTON5, GenericInputBinding::Unknown},
-			{"Blue2", "Player 2 Blue", InputBindingInfo::Type::Button, CID_BUTTON9, GenericInputBinding::Unknown},
-			{"Orange2", "Player 2 Orange", InputBindingInfo::Type::Button, CID_BUTTON8, GenericInputBinding::Unknown},
-			{"Green2", "Player 2 Green", InputBindingInfo::Type::Button, CID_BUTTON7, GenericInputBinding::Unknown},
-			{"Yellow2", "Player 2 Yellow", InputBindingInfo::Type::Button, CID_BUTTON6, GenericInputBinding::Unknown},
-
 			{"Red3", "Player 3 Red", InputBindingInfo::Type::Button, CID_BUTTON10, GenericInputBinding::Unknown},
-			{"Blue3", "Player 3 Blue", InputBindingInfo::Type::Button, CID_BUTTON14, GenericInputBinding::Unknown},
-			{"Orange3", "Player 3 Orange", InputBindingInfo::Type::Button, CID_BUTTON13, GenericInputBinding::Unknown},
-			{"Green3", "Player 3 Green", InputBindingInfo::Type::Button, CID_BUTTON12, GenericInputBinding::Unknown},
-			{"Yellow3", "Player 3 Yellow", InputBindingInfo::Type::Button, CID_BUTTON11, GenericInputBinding::Unknown},
-
 			{"Red4", "Player 4 Red", InputBindingInfo::Type::Button, CID_BUTTON15, GenericInputBinding::Unknown},
+			
+			{"Blue1", "Player 1 Blue", InputBindingInfo::Type::Button, CID_BUTTON4, GenericInputBinding::R1},
+			{"Blue2", "Player 2 Blue", InputBindingInfo::Type::Button, CID_BUTTON9, GenericInputBinding::Unknown},
+			{"Blue3", "Player 3 Blue", InputBindingInfo::Type::Button, CID_BUTTON14, GenericInputBinding::Unknown},
 			{"Blue4", "Player 4 Blue", InputBindingInfo::Type::Button, CID_BUTTON19, GenericInputBinding::Unknown},
+			
+			{"Orange1", "Player 1 Orange", InputBindingInfo::Type::Button, CID_BUTTON3, GenericInputBinding::Cross},
+			{"Orange2", "Player 2 Orange", InputBindingInfo::Type::Button, CID_BUTTON8, GenericInputBinding::Unknown},
+			{"Orange3", "Player 3 Orange", InputBindingInfo::Type::Button, CID_BUTTON13, GenericInputBinding::Unknown},
 			{"Orange4", "Player 4 Orange", InputBindingInfo::Type::Button, CID_BUTTON18, GenericInputBinding::Unknown},
+			
+			{"Green1", "Player 1 Green", InputBindingInfo::Type::Button, CID_BUTTON2, GenericInputBinding::Triangle},
+			{"Green2", "Player 2 Green", InputBindingInfo::Type::Button, CID_BUTTON7, GenericInputBinding::Unknown},
+			{"Green3", "Player 3 Green", InputBindingInfo::Type::Button, CID_BUTTON12, GenericInputBinding::Unknown},
 			{"Green4", "Player 4 Green", InputBindingInfo::Type::Button, CID_BUTTON17, GenericInputBinding::Unknown},
+			
+			{"Yellow1", "Player 1 Yellow", InputBindingInfo::Type::Button, CID_BUTTON1, GenericInputBinding::Square},
+			{"Yellow2", "Player 2 Yellow", InputBindingInfo::Type::Button, CID_BUTTON6, GenericInputBinding::Unknown},
+			{"Yellow3", "Player 3 Yellow", InputBindingInfo::Type::Button, CID_BUTTON11, GenericInputBinding::Unknown},
 			{"Yellow4", "Player 4 Yellow", InputBindingInfo::Type::Button, CID_BUTTON16, GenericInputBinding::Unknown},
 		};
 


### PR DESCRIPTION
I reordered the buttons in the UI to make the layout more intuitive. 

Rationale: The previous button mapping page hurt my brain

Suggested testing steps: See if this works... I didn't screw up, did I? (I'm quite new to this) 

Before:
![image](https://user-images.githubusercontent.com/24227051/208318454-1154406b-f9c2-44a0-8441-6f4fc696592d.png)
After:
![image](https://user-images.githubusercontent.com/24227051/208319533-2f3ccf5e-fe45-40bc-a68e-d95824d1b760.png)