### PR TITLE
USB: Add deadzone for USB wheel steering axis

### DIFF
--- a/pcsx2/USB/usb-pad/usb-pad.h
+++ b/pcsx2/USB/usb-pad/usb-pad.h
@@ -327,6 +327,8 @@ namespace usb_pad
 		void OpenFFDevice();
 		void ParseFFData(const ff_data* ffdata, bool isDFP);
 
+		s16 ApplySteeringAxisDeadzone(float value);
+
 		USBDevice dev{};
 		USBDesc desc{};
 		USBDescDevice desc_dev{};
@@ -336,6 +338,7 @@ namespace usb_pad
 
 		s16 steering_range = 0;
 		u16 steering_step = 0;
+		s32 steering_deadzone = 0;
 
 		struct
 		{


### PR DESCRIPTION
### Description of Changes
Adds a deadzone setting to usb wheel axis handling. Also adds a small bit of feedback to the axis values to ensure that full deflection is registered even at extreme deadzone settings.

### Rationale behind Changes
Pad mapping to a wheel axis can be extremely twitchy. This will make it more useable for pad users that wish to map wheel support to a modern xbox/ps4 style controller or for wheels with no self centering or force feedback.

### Suggested Testing Steps
Tested on GT3 and 4 with each compatible wheel profile. The 900degree wheels will always have too much range to cleanly map to pads but less precise models behave quite nicely and all profiles will register full deflection for all deadzone values. Should be tested against other games supporting wheels. Ensure that center drift is avoided, the game registers the first post input deflection from its internal zero and the game registers the max input at the full stick deflection.