### PR TITLE
GS/DX12: Fix incorrect sampler being used in utility draws

### DIFF
--- a/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
@@ -2019,7 +2019,7 @@ void GSDevice12::SetUtilityTexture(GSTexture* dtex, const D3D12::DescriptorHandl
 		}
 	}
 
-	if (m_utility_sampler_gpu != sampler)
+	if (m_utility_sampler_cpu != sampler)
 	{
 		m_utility_sampler_cpu = sampler;
 		m_dirty_flags |= DIRTY_FLAG_SAMPLERS_DESCRIPTOR_TABLE;


### PR DESCRIPTION
### Description of Changes

What the title says.

### Rationale behind Changes

Unnecessary descriptor table updates and/or the wrong sampler being used is never good.

### Suggested Testing Steps

Probably wasn't _super_ common, but one way to reproduce it is to boot Time Crisis 2 in DX12, the image should no longer bob up and down.