### PR TITLE
GameDB: Add CPU CLUT to Lego Batman The Videogame

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -21217,6 +21217,8 @@ SLES-55134:
 SLES-55135:
   name: "LEGO Batman - The VideoGame"
   region: "PAL-M6"
+  gsHWFixes:
+    cpuCLUTRender: 1 # Fixes ghosting on objects and people.
 SLES-55136:
   name: "Let's Ride! Silver Buckle Stables"
   region: "PAL-M4"
@@ -38995,6 +38997,11 @@ SLPS-25906:
   name: "ADK Tamashii"
   region: "NTSC-J"
   compat: 5
+SLPS-25908:
+  name: "LEGO Batman - The Videogame"
+  region: "NTSC-J"
+  gsHWFixes:
+    cpuCLUTRender: 1 # Fixes ghosting on objects and people.
 SLPS-25909:
   name: "Hisshou Pachinko Pachi-Slot Kouryaku Series Vol. 13 - Shin Seiki Evangelion - Yakusoku no Toki"
   region: "NTSC-J"
@@ -48220,6 +48227,8 @@ SLUS-21785:
   name: "LEGO Batman - The Videogame"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    cpuCLUTRender: 1 # Fixes ghosting on objects and people.
 SLUS-21786:
   name: "Summer Athletics - The Ultimate Challenge"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
Adds CPU CLUT to fix ghosting on basically everything.

### Rationale behind Changes
Ghosting is bad.

### Suggested Testing Steps
Make sure CI is happy.
