### PR TITLE
USB: Power curve option for wheel steering axis.

### DIFF
--- a/pcsx2/USB/usb-pad/usb-pad.h
+++ b/pcsx2/USB/usb-pad/usb-pad.h
@@ -327,7 +327,7 @@ namespace usb_pad
 		void OpenFFDevice();
 		void ParseFFData(const ff_data* ffdata, bool isDFP);
 
-		s16 ApplySteeringAxisDeadzone(float value);
+		s16 ApplySteeringAxisModifiers(float value);
 
 		USBDevice dev{};
 		USBDesc desc{};
@@ -339,6 +339,7 @@ namespace usb_pad
 		s16 steering_range = 0;
 		u16 steering_step = 0;
 		s32 steering_deadzone = 0;
+		s16 steering_curve_exponent = 0;
 
 		struct
 		{


### PR DESCRIPTION
### Description of Changes
Adds a power curve option to the steering axis.

### Rationale behind Changes
Fully linear steering inputs are quite harsh when mapped to pad sticks. This applies an input^n+1/range^n function to damp smaller inputs at the expense of compressing input at higher values. Not recommended for use with a real wheel but helps smooth input for pad users.

### Suggested Testing Steps
Turning your wheel or stick too much shouldn't blow up things.
