### PR TITLE
Qt: Fix global string list setting not showing in input profiles

### DIFF
--- a/pcsx2-qt/Settings/ControllerBindingWidgets.cpp
+++ b/pcsx2-qt/Settings/ControllerBindingWidgets.cpp
@@ -636,7 +636,7 @@ void ControllerCustomSettingsWidget::createSettingWidgets(const char* translatio
 				else if (si.options)
 				{
 					for (u32 i = 0; si.options[i] != nullptr; i++)
-						cb->addItem(qApp->translate(translation_ctx, si.options[i]));
+						cb->addItem(qApp->translate(translation_ctx, si.options[i]), QString::fromUtf8(si.options[i]));
 				}
 				SettingWidgetBinder::BindWidgetToStringSetting(sif, cb, m_config_section, std::move(key_name), si.StringDefaultValue());
 				layout->addWidget(new QLabel(qApp->translate(translation_ctx, si.display_name), widget_parent), current_row, 0);


### PR DESCRIPTION
### Description of Changes

What the title says.

### Rationale behind Changes

Needed for #7633.

### Suggested Testing Steps

Can't really test it because nothing's using it yet. But the issue is fairly obvious - the binder was looking for a data value, but none of the items had it set.