### PR TITLE
Qt: Ensure game list refresh is cancelled before destroying

### DIFF
--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -123,6 +123,9 @@ MainWindow::MainWindow()
 
 MainWindow::~MainWindow()
 {
+	// make sure the game list isn't refreshing, because it's on a separate thread
+	cancelGameListRefresh();
+
 	// we compare here, since recreate destroys the window later
 	if (g_main_window == this)
 		g_main_window = nullptr;


### PR DESCRIPTION
### Description of Changes

A race could happen if the game list was being refreshed on close (e.g. window closed -> play time update -> refresh).

### Rationale behind Changes

Races aren't fun.

### Suggested Testing Steps

Close main window while a game is running, make sure no crashy.
