### PR TITLE
x86/iR5900: Ignore double jr/jalr branches like others

### DIFF
--- a/pcsx2/x86/ix86-32/iR5900-32.cpp
+++ b/pcsx2/x86/ix86-32/iR5900-32.cpp
@@ -1835,6 +1835,16 @@ void recompileNextInstruction(bool delayslot, bool swapped_delay_slot)
 		bool check_branch_delay = false;
 		switch (_Opcode_)
 		{
+			case 0:
+				switch (_Funct_)
+				{
+					case 8: // jr
+					case 9: // jalr
+						check_branch_delay = true;
+						break;
+				}
+				break;
+
 			case 1:
 				switch (_Rt_)
 				{
@@ -1847,6 +1857,7 @@ void recompileNextInstruction(bool delayslot, bool swapped_delay_slot)
 					case 0x12:
 					case 0x13:
 						check_branch_delay = true;
+						break;
 				}
 				break;
 
@@ -1861,6 +1872,7 @@ void recompileNextInstruction(bool delayslot, bool swapped_delay_slot)
 			case 0x16:
 			case 0x17:
 				check_branch_delay = true;
+				break;
 		}
 		// Check for branch in delay slot, new code by FlatOut.
 		// Gregory tested this in 2017 using the ps2autotests suite and remarked "So far we return 1 (even with this PR), and the HW 2.


### PR DESCRIPTION
### Description of Changes

A user reported a crash in Ico on Discord, turns out it was going into a stack overflow because of recursively compiling `jr ra`.

Full code is:
```
Compiling 00160720 jr   ->ra
Compiling delay slot 00160724 jr        ->ra
Compiling 00192B10 jal  ->$0x001448D8
Compiling delay slot 00192B14 daddu     a0, s5, zero
```

So, a triple jump, yay. While it _could_ be a bad dump, we shouldn't be crashing on such a code sequence regardless.

My understanding is it would execute as `jr ra`, `jr ra`, `jal nnn`, `jal nnn`, `daddu` (basically, the second jr rewinds the pc again). So, in this case, ignoring the first delay slot would have the same observable effect on the guest state by the time that `0x001448D8` executed.

Edit: would the new ra change after the second jal? possibly.... but it doesn't seem to matter here?

So, skipping it like the other double branches seems to be okay here. But it still scares me a bit.

### Rationale behind Changes

Crashing on bad code isn't intended.

### Suggested Testing Steps

I've tested with the reporters' save state and it no longer crashes. Hopefully it won't cause issues later in the game.
