### PR TITLE
FullscreenUI: Add USB to controller settings

### DIFF
--- a/pcsx2-qt/Settings/ControllerBindingWidgets.cpp
+++ b/pcsx2-qt/Settings/ControllerBindingWidgets.cpp
@@ -875,7 +875,6 @@ QIcon USBDeviceWidget::getIcon() const
 
 void USBDeviceWidget::populateDeviceTypes()
 {
-	m_ui.deviceType->addItem(qApp->translate("USB", USB::GetDeviceName("None")), QStringLiteral("None"));
 	for (const auto& [name, display_name] : USB::GetDeviceTypes())
 		m_ui.deviceType->addItem(QString::fromStdString(display_name), QString::fromStdString(name));
 }
@@ -888,8 +887,8 @@ void USBDeviceWidget::populatePages()
 	{
 		QSignalBlocker sb(m_ui.deviceSubtype);
 		m_ui.deviceSubtype->clear();
-		for (const std::string& subtype : USB::GetDeviceSubtypes(m_device_type))
-			m_ui.deviceSubtype->addItem(qApp->translate("USB", subtype.c_str()));
+		for (const char* subtype : USB::GetDeviceSubtypes(m_device_type))
+			m_ui.deviceSubtype->addItem(qApp->translate("USB", subtype));
 		m_ui.deviceSubtype->setCurrentIndex(m_device_subtype);
 		m_ui.deviceSubtype->setVisible(m_ui.deviceSubtype->count() > 0);
 	}
@@ -1085,7 +1084,7 @@ QIcon USBBindingWidget::getIcon() const
 
 std::string USBBindingWidget::getBindingKey(const char* binding_name) const
 {
-	return USB::GetConfigBindKey(getDeviceType(), binding_name);
+	return USB::GetConfigSubKey(getDeviceType(), binding_name);
 }
 
 void USBBindingWidget::createWidgets(gsl::span<const InputBindingInfo> bindings)

--- a/pcsx2/Frontend/InputManager.cpp
+++ b/pcsx2/Frontend/InputManager.cpp
@@ -701,11 +701,11 @@ void InputManager::AddUSBBindings(SettingsInterface& si, u32 port)
 	if (device.empty() || device == "None")
 		return;
 
-	const std::string section(USBGetConfigSection(port));
+	const std::string section(USB::GetConfigSection(port));
 	const u32 subtype = USB::GetConfigSubType(si, port, device);
 	for (const InputBindingInfo& bi : USB::GetDeviceBindings(device, subtype))
 	{
-		const std::string bind_name(USB::GetConfigBindKey(device, bi.name));
+		const std::string bind_name(USB::GetConfigSubKey(device, bi.name));
 
 		switch (bi.bind_type)
 		{

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -1095,7 +1095,7 @@ void Pcsx2Config::USBOptions::LoadSave(SettingsWrapper& wrap)
 {
 	for (u32 i = 0; i < static_cast<u32>(Ports.size()); i++)
 	{
-		const std::string section(USBGetConfigSection(i));
+		const std::string section(USB::GetConfigSection(i));
 
 		std::string device = USB::DeviceTypeIndexToName(Ports[i].DeviceType);
 		wrap.Entry(section.c_str(), "Type", device, device);
@@ -1103,8 +1103,11 @@ void Pcsx2Config::USBOptions::LoadSave(SettingsWrapper& wrap)
 		if (wrap.IsLoading())
 			Ports[i].DeviceType = USB::DeviceTypeNameToIndex(device);
 
-		const std::string subtype_key(fmt::format("{}_subtype", USB::DeviceTypeIndexToName(Ports[i].DeviceType)));
-		wrap.Entry(section.c_str(), subtype_key.c_str(), Ports[i].DeviceSubtype);
+		if (Ports[i].DeviceType >= 0)
+		{
+			const std::string subtype_key(fmt::format("{}_subtype", USB::DeviceTypeIndexToName(Ports[i].DeviceType)));
+			wrap.Entry(section.c_str(), subtype_key.c_str(), Ports[i].DeviceSubtype);
+		}
 	}
 }
 

--- a/pcsx2/USB/USB.h
+++ b/pcsx2/USB/USB.h
@@ -40,7 +40,8 @@ namespace USB
 
 	std::vector<std::pair<std::string, std::string>> GetDeviceTypes();
 	const char* GetDeviceName(const std::string_view& device);
-	std::vector<std::string> GetDeviceSubtypes(const std::string_view& device);
+	const char* GetDeviceSubtypeName(const std::string_view& device, u32 subtype);
+	gsl::span<const char*> GetDeviceSubtypes(const std::string_view& device);
 	gsl::span<const InputBindingInfo> GetDeviceBindings(const std::string_view& device, u32 subtype);
 	gsl::span<const SettingInfo> GetDeviceSettings(const std::string_view& device, u32 subtype);
 
@@ -54,11 +55,14 @@ namespace USB
 	/// Called when an input device is disconnected.
 	void InputDeviceDisconnected(const std::string_view& identifier);
 
+	std::string GetConfigSection(int port);
 	std::string GetConfigDevice(const SettingsInterface& si, u32 port);
+	void SetConfigDevice(SettingsInterface& si, u32 port, const char* devname);
 	u32 GetConfigSubType(const SettingsInterface& si, u32 port, const std::string_view& devname);
+	void SetConfigSubType(SettingsInterface& si, u32 port, const std::string_view& devname, u32 subtype);
 
 	/// Returns the configuration key for the specified bind and device type.
-	std::string GetConfigBindKey(const std::string_view& device, const std::string_view& bind_name);
+	std::string GetConfigSubKey(const std::string_view& device, const std::string_view& bind_name);
 
 	/// Performs automatic controller mapping with the provided list of generic mappings.
 	bool MapDevice(SettingsInterface& si, u32 port, const std::vector<std::pair<GenericInputBinding, std::string>>& mapping);
@@ -81,8 +85,6 @@ namespace USB
 	/// Reads a device-specific configuration string.
 	std::string GetConfigString(SettingsInterface& si, u32 port, const char* devname, const char* key, const char* default_value = "");
 } // namespace USB
-
-std::string USBGetConfigSection(int port);
 
 struct WindowInfo;
 

--- a/pcsx2/USB/deviceproxy.cpp
+++ b/pcsx2/USB/deviceproxy.cpp
@@ -28,7 +28,7 @@ RegisterDevice* RegisterDevice::registerDevice = nullptr;
 
 DeviceProxy::~DeviceProxy() = default;
 
-std::vector<std::string> DeviceProxy::SubTypes() const
+gsl::span<const char*> DeviceProxy::SubTypes() const
 {
 	return {};
 }

--- a/pcsx2/USB/deviceproxy.h
+++ b/pcsx2/USB/deviceproxy.h
@@ -60,7 +60,7 @@ public:
 
 	virtual const char* Name() const = 0;
 	virtual const char* TypeName() const = 0;
-	virtual std::vector<std::string> SubTypes() const;
+	virtual gsl::span<const char*> SubTypes() const;
 	virtual gsl::span<const InputBindingInfo> Bindings(u32 subtype) const;
 	virtual gsl::span<const SettingInfo> Settings(u32 subtype) const;
 

--- a/pcsx2/USB/usb-eyetoy/usb-eyetoy-webcam.cpp
+++ b/pcsx2/USB/usb-eyetoy/usb-eyetoy-webcam.cpp
@@ -513,9 +513,10 @@ namespace usb_eyetoy
 		// TODO: Update device name
 	}
 
-	std::vector<std::string> EyeToyWebCamDevice::SubTypes() const
+	gsl::span<const char*> EyeToyWebCamDevice::SubTypes() const
 	{
-		return {"Sony EyeToy", "Konami Capture Eye"};
+		static const char* subtypes[] = {"Sony EyeToy", "Konami Capture Eye"};
+		return subtypes;
 	}
 
 	gsl::span<const SettingInfo> EyeToyWebCamDevice::Settings(u32 subtype) const

--- a/pcsx2/USB/usb-eyetoy/usb-eyetoy-webcam.h
+++ b/pcsx2/USB/usb-eyetoy/usb-eyetoy-webcam.h
@@ -475,7 +475,7 @@ namespace usb_eyetoy
 		const char* TypeName() const override;
 		bool Freeze(USBDevice* dev, StateWrapper& sw) const override;
 		void UpdateSettings(USBDevice* dev, SettingsInterface& si) const override;
-		std::vector<std::string> SubTypes() const override;
+		gsl::span<const char*> SubTypes() const override;
 		gsl::span<const SettingInfo> Settings(u32 subtype) const override;
 	};
 

--- a/pcsx2/USB/usb-mic/usb-mic-singstar.cpp
+++ b/pcsx2/USB/usb-mic/usb-mic-singstar.cpp
@@ -915,12 +915,12 @@ std::unique_ptr<AudioDevice> AudioDevice::CreateDevice(u32 port, AudioDir dir, u
 	return CreateNoopDevice(port, dir, channels);
 }
 
-std::vector<std::string> AudioDevice::GetInputDeviceList()
+std::vector<std::pair<std::string, std::string>> AudioDevice::GetInputDeviceList()
 {
 	return {};
 }
 
-std::vector<std::string> AudioDevice::GetOutputDeviceList()
+std::vector<std::pair<std::string, std::string>> AudioDevice::GetOutputDeviceList()
 {
 	return {};
 }

--- a/pcsx2/USB/usb-pad/usb-pad.cpp
+++ b/pcsx2/USB/usb-pad/usb-pad.cpp
@@ -838,9 +838,10 @@ namespace usb_pad
 		s->SetBindValue(bind_index, value);
 	}
 
-	std::vector<std::string> PadDevice::SubTypes() const
+	gsl::span<const char*> PadDevice::SubTypes() const
 	{
-		return {"Driving Force", "Driving Force Pro", "Driving Force Pro (rev11.02)", "GT Force"};
+		static const char* subtypes[] = {"Driving Force", "Driving Force Pro", "Driving Force Pro (rev11.02)", "GT Force"};
+		return subtypes;
 	}
 
 	gsl::span<const InputBindingInfo> PadDevice::Bindings(u32 subtype) const
@@ -900,7 +901,7 @@ namespace usb_pad
 		return nullptr;
 	}
 
-	std::vector<std::string> RBDrumKitDevice::SubTypes() const
+	gsl::span<const char*> RBDrumKitDevice::SubTypes() const
 	{
 		return {};
 	}
@@ -937,7 +938,7 @@ namespace usb_pad
 		return "BuzzDevice";
 	}
 
-	std::vector<std::string> BuzzDevice::SubTypes() const
+	gsl::span<const char*> BuzzDevice::SubTypes() const
 	{
 		return {};
 	}
@@ -1011,7 +1012,7 @@ namespace usb_pad
 		return "Keyboardmania";
 	}
 
-	std::vector<std::string> KeyboardmaniaDevice::SubTypes() const
+	gsl::span<const char*> KeyboardmaniaDevice::SubTypes() const
 	{
 		return {};
 	}

--- a/pcsx2/USB/usb-pad/usb-pad.h
+++ b/pcsx2/USB/usb-pad/usb-pad.h
@@ -84,7 +84,7 @@ namespace usb_pad
 		void SetBindingValue(USBDevice* dev, u32 bind_index, float value) const override;
 		void InputDeviceConnected(USBDevice* dev, const std::string_view& identifier) const override;
 		void InputDeviceDisconnected(USBDevice* dev, const std::string_view& identifier) const override;
-		std::vector<std::string> SubTypes() const override;
+		gsl::span<const char*> SubTypes() const override;
 		gsl::span<const InputBindingInfo> Bindings(u32 subtype) const override;
 		gsl::span<const SettingInfo> Settings(u32 subtype) const override;
 	};
@@ -94,7 +94,7 @@ namespace usb_pad
 	public:
 		const char* Name() const override;
 		const char* TypeName() const override;
-		std::vector<std::string> SubTypes() const override;
+		gsl::span<const char*> SubTypes() const override;
 		gsl::span<const InputBindingInfo> Bindings(u32 subtype) const override;
 		gsl::span<const SettingInfo> Settings(u32 subtype) const override;
 		USBDevice* CreateDevice(SettingsInterface& si, u32 port, u32 subtype) const override;
@@ -105,7 +105,7 @@ namespace usb_pad
 	public:
 		const char* Name() const;
 		const char* TypeName() const;
-		std::vector<std::string> SubTypes() const;
+		gsl::span<const char*> SubTypes() const;
 		gsl::span<const InputBindingInfo> Bindings(u32 subtype) const;
 		gsl::span<const SettingInfo> Settings(u32 subtype) const;
 		USBDevice* CreateDevice(SettingsInterface& si, u32 port, u32 subtype) const;
@@ -116,7 +116,7 @@ namespace usb_pad
 	public:
 		const char* Name() const;
 		const char* TypeName() const;
-		std::vector<std::string> SubTypes() const;
+		gsl::span<const char*> SubTypes() const;
 		gsl::span<const InputBindingInfo> Bindings(u32 subtype) const;
 		gsl::span<const SettingInfo> Settings(u32 subtype) const;
 		USBDevice* CreateDevice(SettingsInterface& si, u32 port, u32 subtype) const;
@@ -128,7 +128,7 @@ namespace usb_pad
 	public:
 		const char* Name() const;
 		const char* TypeName() const;
-		std::vector<std::string> SubTypes() const;
+		gsl::span<const char*> SubTypes() const;
 		gsl::span<const InputBindingInfo> Bindings(u32 subtype) const;
 		gsl::span<const SettingInfo> Settings(u32 subtype) const;
 		USBDevice* CreateDevice(SettingsInterface& si, u32 port, u32 subtype) const;

--- a/pcsx2/USB/usb-pad/usb-seamic.cpp
+++ b/pcsx2/USB/usb-pad/usb-seamic.cpp
@@ -352,7 +352,7 @@ namespace usb_pad
 		return "seamic";
 	}
 
-	std::vector<std::string> SeamicDevice::SubTypes() const
+	gsl::span<const char*> SeamicDevice::SubTypes() const
 	{
 		return {};
 	}

--- a/pcsx2/USB/usb-printer/usb-printer.cpp
+++ b/pcsx2/USB/usb-printer/usb-printer.cpp
@@ -361,14 +361,9 @@ namespace usb_printer
 		return true;
 	}
 
-	std::vector<std::string> PrinterDevice::SubTypes() const
+	gsl::span<const char*> PrinterDevice::SubTypes() const
 	{
-		std::vector<std::string> ret;
-		for (uint32_t i = 0; i < sizeof(sPrinters) / sizeof(sPrinters[0]); i++)
-		{
-			ret.push_back(sPrinters[i].commercial_name);
-		}
-		return ret;
+		return sPrinterNames;
 	}
 
 } // namespace usb_printer

--- a/pcsx2/USB/usb-printer/usb-printer.h
+++ b/pcsx2/USB/usb-printer/usb-printer.h
@@ -120,6 +120,10 @@ namespace usb_printer
 		},
 	};
 
+	static const char* sPrinterNames[] = {
+		"Sony DPP-MP1",
+	};
+
 	class PrinterDevice final : public DeviceProxy
 	{
 	public:
@@ -128,7 +132,7 @@ namespace usb_printer
 		const char* TypeName() const override;
 
 		bool Freeze(USBDevice* dev, StateWrapper& sw) const override;
-		std::vector<std::string> SubTypes() const override;
+		gsl::span<const char*> SubTypes() const override;
 	};
 
 #pragma pack(push, 1)


### PR DESCRIPTION
### Description of Changes

What the title says. Adds USB options to the controller settings page of the big picture UI, plus some other minor misc USB fixes.

### Rationale behind Changes

It was missing and I said I'd do it post-merge.

### Suggested Testing Steps

Test new big picture options.

