### PR TITLE
CDVD: Warn the user when a selected game image is on a removable drive.

### DIFF
--- a/pcsx2/CDVD/CDVDcommon.cpp
+++ b/pcsx2/CDVD/CDVDcommon.cpp
@@ -37,6 +37,7 @@
 #include "DebugTools/SymbolMap.h"
 #include "Config.h"
 #include "Host.h"
+#include "IconsFontAwesome5.h"
 
 CDVD_API* CDVD = NULL;
 
@@ -303,6 +304,21 @@ static CDVD_SourceType m_CurrentSourceType = CDVD_SourceType::NoDisc;
 
 void CDVDsys_SetFile(CDVD_SourceType srctype, std::string newfile)
 {
+#ifdef WIN32
+	if (Path::IsAbsolute(newfile))
+	{
+		const auto splitPath = Path::SplitNativePath(newfile);
+		// GetDriveType() Requires trailing backslashes
+		const auto root = fmt::format("{}\\", splitPath.at(0));
+
+		const auto driveType = GetDriveType(StringUtil::UTF8StringToWideString(root).c_str());
+		if (driveType == DRIVE_REMOVABLE)
+		{
+			Host::AddIconOSDMessage("RemovableDriveWarning", ICON_FA_EXCLAMATION_TRIANGLE, "Game disc location is on a removable drive, performance issues such as jittering and freezing may occur.", Host::OSD_WARNING_DURATION);
+		}
+	}
+#endif
+
 	m_SourceFilename[enum_cast(srctype)] = std::move(newfile);
 
 	// look for symbol file


### PR DESCRIPTION
### Description of Changes
Adds a warning to `CDVDsys_SetFile` when windows reports the source drive to be removable.
[GetDriveTypeW](https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-getdrivetypew)

### Rationale behind Changes
People have been experiencing poor performance when running their games off of removable media such as portable hard drives and thumb drives.

### Suggested Testing Steps
Try running an image on a USB stick, or any other removable media, and see if you get the warning. Please test things such as big picture mode.
