### PR TITLE
GS-d3d12: Fix macro redefinition error in fxaa shader.

### DIFF
--- a/bin/resources/shaders/common/fxaa.fx
+++ b/bin/resources/shaders/common/fxaa.fx
@@ -68,10 +68,12 @@ static constexpr sampler MAIN_SAMPLER(coord::normalized, address::clamp_to_edge,
 // pass to compute the values, which would be slower than the extra shader loads.
 
 #if (SHADER_MODEL >= 0x500)
+#undef FXAA_HLSL_5
 #define FXAA_HLSL_5 1
 #define FXAA_GATHER4_ALPHA 0
 
 #elif (SHADER_MODEL >= 0x400)
+#undef FXAA_HLSL_4
 #define FXAA_HLSL_4 1
 #define FXAA_GATHER4_ALPHA 0
 


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS-d3d12: Fix macro redefinition error in fxaa shader.
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Shader log warning.
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Make sure the warning is gone.