### PR TITLE
GameDB: Fix empty could not find serial and searching for serial logs.

### DIFF
--- a/pcsx2/GameDatabase.cpp
+++ b/pcsx2/GameDatabase.cpp
@@ -753,6 +753,10 @@ const GameDatabaseSchema::GameEntry* GameDatabase::findGame(const std::string_vi
 	GameDatabase::ensureLoaded();
 
 	std::string serialLower = StringUtil::toLower(serial);
+
+	if (serialLower.empty())
+		return nullptr;
+
 	Console.WriteLn(fmt::format("[GameDB] Searching for '{}' in GameDB", serialLower));
 	const auto gameEntry = s_game_db.find(serialLower);
 	if (gameEntry != s_game_db.end())


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GameDB: Fix empty could not find serial and searching for serial logs.
Fixes the logs from pasting when the size of the serial is 0 which is invalid.
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Fixes the logs from pasting when they shouldn't.
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Make sure the logs only paste when they actually detect a missing serial in gamedb.