### PR TITLE
Qt: Add debug options panel

### DIFF
--- a/pcsx2-qt/CMakeLists.txt
+++ b/pcsx2-qt/CMakeLists.txt
@@ -68,6 +68,9 @@ target_sources(pcsx2-qt PRIVATE
 	Settings/CreateMemoryCardDialog.cpp
 	Settings/CreateMemoryCardDialog.h
 	Settings/CreateMemoryCardDialog.ui
+	Settings/DebugSettingsWidget.cpp
+	Settings/DebugSettingsWidget.h
+	Settings/DebugSettingsWidget.ui
 	Settings/EmulationSettingsWidget.cpp
 	Settings/EmulationSettingsWidget.h
 	Settings/EmulationSettingsWidget.ui

--- a/pcsx2-qt/Settings/DebugSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/DebugSettingsWidget.cpp
@@ -1,0 +1,62 @@
+/*  PCSX2 - PS2 Emulator for PCs
+ *  Copyright (C) 2002-2022  PCSX2 Dev Team
+ *
+ *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU Lesser General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  PCSX2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with PCSX2.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "PrecompiledHeader.h"
+
+#include "DebugSettingsWidget.h"
+#include "QtUtils.h"
+#include "SettingWidgetBinder.h"
+#include "SettingsDialog.h"
+#include <QtWidgets/QMessageBox>
+
+#include "pcsx2/HostSettings.h"
+
+DebugSettingsWidget::DebugSettingsWidget(SettingsDialog* dialog, QWidget* parent)
+	: QWidget(parent)
+	, m_dialog(dialog)
+{
+	SettingsInterface* sif = dialog->getSettingsInterface();
+
+	m_ui.setupUi(this);
+
+	//////////////////////////////////////////////////////////////////////////
+	// GS Settings
+	//////////////////////////////////////////////////////////////////////////
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.dumpGSDraws, "EmuCore/GS", "dump", false);
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.saveRT, "EmuCore/GS", "save", false);
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.saveFrame, "EmuCore/GS", "savef", false);
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.saveTexture, "EmuCore/GS", "savet", false);
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.saveDepth, "EmuCore/GS", "savez", false);
+	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.startDraw, "EmuCore/GS", "saven", 0);
+	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.dumpCount, "EmuCore/GS", "savel", 5000);
+	SettingWidgetBinder::BindWidgetToFolderSetting(
+		sif, m_ui.hwDumpDirectory, m_ui.hwDumpBrowse, m_ui.hwDumpOpen, nullptr, "EmuCore/GS", "HWDumpDirectory", std::string());
+	SettingWidgetBinder::BindWidgetToFolderSetting(
+		sif, m_ui.swDumpDirectory, m_ui.swDumpBrowse, m_ui.swDumpOpen, nullptr, "EmuCore/GS", "SWDumpDirectory", std::string());
+
+	connect(m_ui.dumpGSDraws, &QCheckBox::stateChanged, this, &DebugSettingsWidget::onDrawDumpingChanged);
+	onDrawDumpingChanged();
+}
+
+DebugSettingsWidget::~DebugSettingsWidget() = default;
+
+void DebugSettingsWidget::onDrawDumpingChanged()
+{
+	const bool enabled = m_dialog->getEffectiveBoolValue("EmuCore/GS", "dump", false);
+	m_ui.saveRT->setEnabled(enabled);
+	m_ui.saveFrame->setEnabled(enabled);
+	m_ui.saveTexture->setEnabled(enabled);
+	m_ui.saveDepth->setEnabled(enabled);
+}

--- a/pcsx2-qt/Settings/DebugSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/DebugSettingsWidget.cpp
@@ -42,9 +42,9 @@ DebugSettingsWidget::DebugSettingsWidget(SettingsDialog* dialog, QWidget* parent
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.startDraw, "EmuCore/GS", "saven", 0);
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.dumpCount, "EmuCore/GS", "savel", 5000);
 	SettingWidgetBinder::BindWidgetToFolderSetting(
-		sif, m_ui.hwDumpDirectory, m_ui.hwDumpBrowse, m_ui.hwDumpOpen, nullptr, "EmuCore/GS", "HWDumpDirectory", std::string());
+		sif, m_ui.hwDumpDirectory, m_ui.hwDumpBrowse, m_ui.hwDumpOpen, nullptr, "EmuCore/GS", "HWDumpDirectory", std::string(), false);
 	SettingWidgetBinder::BindWidgetToFolderSetting(
-		sif, m_ui.swDumpDirectory, m_ui.swDumpBrowse, m_ui.swDumpOpen, nullptr, "EmuCore/GS", "SWDumpDirectory", std::string());
+		sif, m_ui.swDumpDirectory, m_ui.swDumpBrowse, m_ui.swDumpOpen, nullptr, "EmuCore/GS", "SWDumpDirectory", std::string(), false);
 
 	connect(m_ui.dumpGSDraws, &QCheckBox::stateChanged, this, &DebugSettingsWidget::onDrawDumpingChanged);
 	onDrawDumpingChanged();

--- a/pcsx2-qt/Settings/DebugSettingsWidget.h
+++ b/pcsx2-qt/Settings/DebugSettingsWidget.h
@@ -1,0 +1,41 @@
+/*  PCSX2 - PS2 Emulator for PCs
+ *  Copyright (C) 2002-2022  PCSX2 Dev Team
+ *
+ *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU Lesser General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  PCSX2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with PCSX2.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <QtWidgets/QWidget>
+
+#include "ui_DebugSettingsWidget.h"
+
+enum class GSRendererType : s8;
+
+class SettingsDialog;
+
+class DebugSettingsWidget : public QWidget
+{
+	Q_OBJECT
+
+public:
+	DebugSettingsWidget(SettingsDialog* dialog, QWidget* parent);
+	~DebugSettingsWidget();
+
+private Q_SLOTS:
+	void onDrawDumpingChanged();
+
+private:
+	SettingsDialog* m_dialog;
+
+	Ui::DebugSettingsWidget m_ui;
+};

--- a/pcsx2-qt/Settings/DebugSettingsWidget.ui
+++ b/pcsx2-qt/Settings/DebugSettingsWidget.ui
@@ -1,0 +1,198 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>DebugSettingsWidget</class>
+ <widget class="QWidget" name="DebugSettingsWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>861</width>
+    <height>501</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item>
+    <widget class="QTabWidget" name="gsTab">
+     <property name="currentIndex">
+      <number>0</number>
+     </property>
+     <property name="documentMode">
+      <bool>true</bool>
+     </property>
+     <widget class="QWidget" name="gsTabWidget">
+      <attribute name="title">
+       <string>GS</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <item>
+        <widget class="QGroupBox" name="groupBox">
+         <property name="title">
+          <string>Draw Dumping</string>
+         </property>
+         <layout class="QFormLayout" name="formLayout">
+          <item row="0" column="0" colspan="2">
+           <layout class="QGridLayout" name="gridLayout">
+            <item row="0" column="0">
+             <widget class="QCheckBox" name="dumpGSDraws">
+              <property name="text">
+               <string>Dump GS Draws</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="QCheckBox" name="saveRT">
+              <property name="text">
+               <string>Save RT</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="0">
+             <widget class="QCheckBox" name="saveFrame">
+              <property name="text">
+               <string>Save Frame</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="1">
+             <widget class="QCheckBox" name="saveTexture">
+              <property name="text">
+               <string>Save Texture</string>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="0">
+             <widget class="QCheckBox" name="saveDepth">
+              <property name="text">
+               <string>Save Depth</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label">
+            <property name="text">
+             <string>Start Draw Number:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QSpinBox" name="startDraw">
+            <property name="maximum">
+             <number>99999</number>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="label_2">
+            <property name="text">
+             <string>Draw Dump Count:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QSpinBox" name="dumpCount">
+            <property name="minimum">
+             <number>1</number>
+            </property>
+            <property name="maximum">
+             <number>99999</number>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="label_3">
+            <property name="text">
+             <string>Hardware Dump Directory:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0">
+           <widget class="QLabel" name="label_4">
+            <property name="text">
+             <string>Software Dump Directory:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="1">
+           <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="1,0,0">
+            <item>
+             <widget class="QLineEdit" name="swDumpDirectory"/>
+            </item>
+            <item>
+             <widget class="QPushButton" name="swDumpBrowse">
+              <property name="text">
+               <string>Browse...</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="swDumpOpen">
+              <property name="text">
+               <string>Open...</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item row="3" column="1">
+           <layout class="QHBoxLayout" name="horizontalLayout" stretch="1,0,0">
+            <item>
+             <widget class="QLineEdit" name="hwDumpDirectory"/>
+            </item>
+            <item>
+             <widget class="QPushButton" name="hwDumpBrowse">
+              <property name="text">
+               <string>Browse...</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="hwDumpOpen">
+              <property name="text">
+               <string>Open...</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>60</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/pcsx2-qt/Settings/SettingsDialog.cpp
+++ b/pcsx2-qt/Settings/SettingsDialog.cpp
@@ -41,6 +41,7 @@
 #include "HotkeySettingsWidget.h"
 #include "InterfaceSettingsWidget.h"
 #include "MemoryCardSettingsWidget.h"
+#include "DebugSettingsWidget.h"
 
 #ifdef ENABLE_ACHIEVEMENTS
 #include "AchievementSettingsWidget.h"
@@ -89,72 +90,80 @@ void SettingsDialog::setupUi(const GameList::Entry* game)
 
 	addWidget(m_interface_settings = new InterfaceSettingsWidget(this, m_ui.settingsContainer), tr("Interface"),
 		QStringLiteral("settings-3-line"),
-		tr("<strong>Interface Settings</strong><hr>These options control how the software looks and behaves.<br><br>Mouse over an option for "
-		   "additional information."));
+		tr("<strong>Interface Settings</strong><hr>These options control how the software looks and behaves.<br><br>Mouse over an option "
+		   "for additional information."));
 
 	// We don't include game list/bios settings in per-game settings.
 	if (!isPerGameSettings())
 	{
 		addWidget(m_game_list_settings = new GameListSettingsWidget(this, m_ui.settingsContainer), tr("Game List"),
 			QStringLiteral("folder-settings-line"),
-			tr("<strong>Game List Settings</strong><hr>The list above shows the directories which will be searched by PCSX2 to populate the game "
-			   "list. Search directories can be added, removed, and switched to recursive/non-recursive."));
+			tr("<strong>Game List Settings</strong><hr>The list above shows the directories which will be searched by PCSX2 to populate "
+			   "the game list. Search directories can be added, removed, and switched to recursive/non-recursive."));
 		addWidget(m_bios_settings = new BIOSSettingsWidget(this, m_ui.settingsContainer), tr("BIOS"), QStringLiteral("hard-drive-2-line"),
 			tr("<strong>BIOS Settings</strong><hr>Configure your BIOS here.<br><br>Mouse over an option for additional information."));
 	}
 
 	// Common to both per-game and global settings.
-	addWidget(m_emulation_settings = new EmulationSettingsWidget(this, m_ui.settingsContainer), tr("Emulation"), QStringLiteral("dashboard-line"),
-		tr("<strong>Emulation Settings</strong><hr>These options determine the configuration of frame pacing and game settings.<br><br>Mouse over an option for additional information."));
+	addWidget(m_emulation_settings = new EmulationSettingsWidget(this, m_ui.settingsContainer), tr("Emulation"),
+		QStringLiteral("dashboard-line"),
+		tr("<strong>Emulation Settings</strong><hr>These options determine the configuration of frame pacing and game "
+		   "settings.<br><br>Mouse over an option for additional information."));
 
 	// Only show the game fixes for per-game settings, there's really no reason to be setting them globally.
 	if (show_advanced_settings && isPerGameSettings())
 	{
 		addWidget(m_game_fix_settings_widget = new GameFixSettingsWidget(this, m_ui.settingsContainer), tr("Game Fix"),
-			QStringLiteral("close-line"), tr("<strong>Game Fix Settings</strong><hr>Gamefixes can work around incorrect emulation in some titles<br>however they can also cause problems in games if used incorrectly.<br>It is best to leave them all disabled unless advised otherwise."));
+			QStringLiteral("close-line"),
+			tr("<strong>Game Fix Settings</strong><hr>Gamefixes can work around incorrect emulation in some titles<br>however they can "
+			   "also cause problems in games if used incorrectly.<br>It is best to leave them all disabled unless advised otherwise."));
 	}
 
 	addWidget(m_graphics_settings = new GraphicsSettingsWidget(this, m_ui.settingsContainer), tr("Graphics"), QStringLiteral("brush-line"),
-		tr("<strong>Graphics Settings</strong><hr>These options determine the configuration of the graphical output.<br><br>Mouse over an option for additional information."));
+		tr("<strong>Graphics Settings</strong><hr>These options determine the configuration of the graphical output.<br><br>Mouse over an "
+		   "option for additional information."));
 	addWidget(m_audio_settings = new AudioSettingsWidget(this, m_ui.settingsContainer), tr("Audio"), QStringLiteral("volume-up-line"),
-		tr("<strong>Audio Settings</strong><hr>These options control the audio output of the console.<br><br>Mouse over an option for additional information."));
+		tr("<strong>Audio Settings</strong><hr>These options control the audio output of the console.<br><br>Mouse over an option for "
+		   "additional information."));
 
 	// for now, memory cards aren't settable per-game
 	if (!isPerGameSettings())
 	{
 		addWidget(m_memory_card_settings = new MemoryCardSettingsWidget(this, m_ui.settingsContainer), tr("Memory Cards"),
-			QStringLiteral("sd-card-line"), tr("<strong>Memory Card Settings</strong><hr>Create and configure Memory Cards here.<br><br>Mouse over an option for additional information."));
+			QStringLiteral("sd-card-line"),
+			tr("<strong>Memory Card Settings</strong><hr>Create and configure Memory Cards here.<br><br>Mouse over an option for "
+			   "additional information."));
 	}
 
 	addWidget(m_dev9_settings = new DEV9SettingsWidget(this, m_ui.settingsContainer), tr("Network & HDD"), QStringLiteral("dashboard-line"),
-		tr("<strong>Network & HDD Settings</strong><hr>These options control the network connectivity and internal HDD storage of the console.<br><br>"
-		   "Mouse over an option for additional information."));
+		tr("<strong>Network & HDD Settings</strong><hr>These options control the network connectivity and internal HDD storage of the "
+		   "console.<br><br>Mouse over an option for additional information."));
 
 	if (!isPerGameSettings())
 	{
-		addWidget(m_folder_settings = new FolderSettingsWidget(this, m_ui.settingsContainer), tr("Folders"), QStringLiteral("folder-open-line"),
+		addWidget(m_folder_settings = new FolderSettingsWidget(this, m_ui.settingsContainer), tr("Folders"),
+			QStringLiteral("folder-open-line"),
 			tr("<strong>Folder Settings</strong><hr>These options control where PCSX2 will save runtime data files."));
 	}
 
 	{
 		QString title = tr("Achievements");
 		QString icon_text(QStringLiteral("trophy-line"));
-		QString help_text = tr(
-			"<strong>Achievements Settings</strong><hr>"
-			"These options control the RetroAchievements implementation in PCSX2, allowing you to earn achievements in your games.");
+		QString help_text =
+			tr("<strong>Achievements Settings</strong><hr>"
+			   "These options control the RetroAchievements implementation in PCSX2, allowing you to earn achievements in your games.");
 #ifdef ENABLE_ACHIEVEMENTS
 		if (Achievements::IsUsingRAIntegration())
 		{
 			QLabel* placeholder_label =
-				new QLabel(tr("RAIntegration is being used, built-in RetroAchievements support is disabled."),
-					m_ui.settingsContainer);
+				new QLabel(tr("RAIntegration is being used, built-in RetroAchievements support is disabled."), m_ui.settingsContainer);
 			placeholder_label->setAlignment(Qt::AlignLeft | Qt::AlignTop);
 			addWidget(placeholder_label, std::move(title), std::move(icon_text), std::move(help_text));
 		}
 		else
 		{
-			addWidget((m_achievement_settings = new AchievementSettingsWidget(this, m_ui.settingsContainer)),
-				std::move(title), std::move(icon_text), std::move(help_text));
+			addWidget((m_achievement_settings = new AchievementSettingsWidget(this, m_ui.settingsContainer)), std::move(title),
+				std::move(icon_text), std::move(help_text));
 		}
 #else
 		QLabel* placeholder_label =
@@ -167,7 +176,14 @@ void SettingsDialog::setupUi(const GameList::Entry* game)
 	if (show_advanced_settings)
 	{
 		addWidget(m_advanced_settings = new AdvancedSettingsWidget(this, m_ui.settingsContainer), tr("Advanced"),
-			QStringLiteral("artboard-2-line"), tr("<strong>Advanced Settings</strong><hr>These are advanced options to determine the configuration of the simulated console.<br><br>Mouse over an option for additional information."));
+			QStringLiteral("artboard-2-line"),
+			tr("<strong>Advanced Settings</strong><hr>These are advanced options to determine the configuration of the simulated "
+			   "console.<br><br>Mouse over an option for additional information."));
+		addWidget(m_debug_settings = new DebugSettingsWidget(this, m_ui.settingsContainer), tr("Debug"),
+			QStringLiteral("folder-download-line"),
+			tr("<strong>Debug Settings</strong><hr>These are options which can be used to log internal information about the application. "
+			   "<strong>Do not modify unless you know what you are doing</strong>, it will cause significant slowdown, and can waste large "
+			   "amounts of disk space."));
 	}
 
 	m_ui.settingsCategory->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Minimum);
@@ -386,7 +402,8 @@ std::optional<float> SettingsDialog::getFloatValue(const char* section, const ch
 	return value;
 }
 
-std::optional<std::string> SettingsDialog::getStringValue(const char* section, const char* key, std::optional<const char*> default_value) const
+std::optional<std::string> SettingsDialog::getStringValue(
+	const char* section, const char* key, std::optional<const char*> default_value) const
 {
 	std::optional<std::string> value;
 	if (m_sif)

--- a/pcsx2-qt/Settings/SettingsDialog.h
+++ b/pcsx2-qt/Settings/SettingsDialog.h
@@ -41,6 +41,7 @@ class FolderSettingsWidget;
 class DEV9SettingsWidget;
 class AchievementSettingsWidget;
 class AdvancedSettingsWidget;
+class DebugSettingsWidget;
 
 class SettingsDialog final : public QDialog
 {
@@ -128,6 +129,7 @@ private:
 	DEV9SettingsWidget* m_dev9_settings = nullptr;
 	AchievementSettingsWidget* m_achievement_settings = nullptr;
 	AdvancedSettingsWidget* m_advanced_settings = nullptr;
+	DebugSettingsWidget* m_debug_settings = nullptr;
 
 	std::array<QString, MAX_SETTINGS_WIDGETS> m_category_help_text;
 

--- a/pcsx2-qt/pcsx2-qt.vcxproj
+++ b/pcsx2-qt/pcsx2-qt.vcxproj
@@ -132,6 +132,7 @@
   <ItemGroup>
     <ClCompile Include="EarlyHardwareCheck.cpp" />
     <ClCompile Include="QtProgressCallback.cpp" />
+    <ClCompile Include="Settings\DebugSettingsWidget.cpp" />
     <ClCompile Include="Settings\FolderSettingsWidget.cpp" />
     <ClCompile Include="Settings\MemoryCardConvertWorker.cpp" />
     <ClCompile Include="Tools\InputRecording\InputRecordingViewer.cpp" />
@@ -198,6 +199,7 @@
     <QtMoc Include="QtProgressCallback.h" />
     <ClInclude Include="Settings\ControllerSettingWidgetBinder.h" />
     <QtMoc Include="Settings\FolderSettingsWidget.h" />
+    <QtMoc Include="Settings\DebugSettingsWidget.h" />
     <ClInclude Include="Settings\HddCreateQt.h" />
     <QtMoc Include="Settings\GameSummaryWidget.h" />
     <QtMoc Include="Settings\CreateMemoryCardDialog.h" />
@@ -252,6 +254,7 @@
     <ClCompile Include="$(IntDir)Settings\moc_GameSummaryWidget.cpp" />
     <ClCompile Include="$(IntDir)Settings\moc_AchievementLoginDialog.cpp" />
     <ClCompile Include="$(IntDir)Settings\moc_AchievementSettingsWidget.cpp" />
+    <ClCompile Include="$(IntDir)Settings\moc_DebugSettingsWidget.cpp" />
     <ClCompile Include="$(IntDir)GameList\moc_GameListModel.cpp" />
     <ClCompile Include="$(IntDir)GameList\moc_GameListRefreshThread.cpp" />
     <ClCompile Include="$(IntDir)GameList\moc_GameListWidget.cpp" />
@@ -358,6 +361,9 @@
     </QtUi>
   </ItemGroup>
   <ItemGroup>
+    <QtUi Include="Settings\DebugSettingsWidget.ui">
+      <FileType>Document</FileType>
+    </QtUi>
     <None Include="Settings\USBBindingWidget_DrivingForce.ui" />
     <None Include="Settings\USBBindingWidget_GTForce.ui" />
     <QtUi Include="Settings\USBDeviceWidget.ui">

--- a/pcsx2-qt/pcsx2-qt.vcxproj.filters
+++ b/pcsx2-qt/pcsx2-qt.vcxproj.filters
@@ -250,6 +250,12 @@
     <ClCompile Include="Tools\InputRecording\InputRecordingViewer.cpp">
       <Filter>Tools\Input Recording</Filter>
     </ClCompile>
+    <ClCompile Include="Settings\DebugSettingsWidget.cpp">
+      <Filter>Settings</Filter>
+    </ClCompile>
+    <ClCompile Include="$(IntDir)Settings\moc_DebugSettingsWidget.cpp">
+      <Filter>moc</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Manifest Include="..\pcsx2\windows\PCSX2.manifest">
@@ -366,6 +372,9 @@
       <Filter>Settings</Filter>
     </QtMoc>
     <QtMoc Include="Tools\InputRecording\InputRecordingViewer.h" />
+    <QtMoc Include="Settings\DebugSettingsWidget.h">
+      <Filter>Settings</Filter>
+    </QtMoc>
   </ItemGroup>
   <ItemGroup>
     <QtResource Include="resources\resources.qrc">
@@ -461,6 +470,9 @@
       <Filter>Tools\Input Recording</Filter>
     </QtUi>
     <QtUi Include="Settings\USBDeviceWidget.ui">
+      <Filter>Settings</Filter>
+    </QtUi>
+    <QtUi Include="Settings\DebugSettingsWidget.ui">
       <Filter>Settings</Filter>
     </QtUi>
   </ItemGroup>

--- a/pcsx2-qt/resources/icons/black/svg/folder-download-line.svg
+++ b/pcsx2-qt/resources/icons/black/svg/folder-download-line.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24"><path fill="none" d="M0 0h24v24H0z"/><path d="M12.414 5H21a1 1 0 0 1 1 1v14a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h7.414l2 2zM4 5v14h16V7h-8.414l-2-2H4zm9 8h3l-4 4-4-4h3V9h2v4z" fill="#000000"/></svg>

--- a/pcsx2-qt/resources/icons/white/svg/folder-download-line.svg
+++ b/pcsx2-qt/resources/icons/white/svg/folder-download-line.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24"><path fill="none" d="M0 0h24v24H0z"/><path d="M12.414 5H21a1 1 0 0 1 1 1v14a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h7.414l2 2zM4 5v14h16V7h-8.414l-2-2H4zm9 8h3l-4 4-4-4h3V9h2v4z" fill="#ffffff"/></svg>

--- a/pcsx2-qt/resources/resources.qrc
+++ b/pcsx2-qt/resources/resources.qrc
@@ -25,6 +25,7 @@
 		<file>icons/black/svg/flashlight-line.svg</file>
 		<file>icons/black/svg/flask-line.svg</file>
 		<file>icons/black/svg/folder-add-line.svg</file>
+		<file>icons/black/svg/folder-download-line.svg</file>
 		<file>icons/black/svg/folder-open-line.svg</file>
 		<file>icons/black/svg/folder-reduce-line.svg</file>
 		<file>icons/black/svg/folder-settings-line.svg</file>
@@ -83,6 +84,7 @@
 		<file>icons/white/svg/flashlight-line.svg</file>
 		<file>icons/white/svg/flask-line.svg</file>
 		<file>icons/white/svg/folder-add-line.svg</file>
+		<file>icons/white/svg/folder-download-line.svg</file>
 		<file>icons/white/svg/folder-open-line.svg</file>
 		<file>icons/white/svg/folder-reduce-line.svg</file>
 		<file>icons/white/svg/folder-settings-line.svg</file>
@@ -112,7 +114,7 @@
 		<file>icons/white/svg/volume-up-line.svg</file>
 		<file>icons/white/svg/window-2-line.svg</file>
 		<file>images/DrivingForce.png</file>
-		<file>images/GTForce.png</file>
 		<file>images/dualshock-2.png</file>
+		<file>images/GTForce.png</file>
 	</qresource>
 </RCC>

--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -692,7 +692,6 @@ set(pcsx2GSSources
 	GS/Renderers/SW/GSNewCodeGenerator.cpp
 	GS/Renderers/SW/GSTextureCacheSW.cpp
 	GS/Renderers/SW/GSTextureSW.cpp
-	GS/Window/GSSetting.cpp
 	)
 
 # GS headers
@@ -757,7 +756,6 @@ set(pcsx2GSHeaders
 	GS/Renderers/SW/GSTextureCacheSW.h
 	GS/Renderers/SW/GSTextureSW.h
 	GS/Renderers/SW/GSVertexSW.h
-	GS/Window/GSSetting.h
 	)
 
 if(USE_OPENGL)
@@ -815,9 +813,11 @@ if(PCSX2_CORE)
 	endif()
 else()
 	list(APPEND pcsx2GSSources
+		GS/Window/GSSetting.cpp
 		GS/Window/GSwxDialog.cpp
 	)
 	list(APPEND pcsx2GSHeaders
+		GS/Window/GSSetting.h
 		GS/Window/GSwxDialog.h
 	)
 	if(WIN32)

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -748,6 +748,8 @@ struct Pcsx2Config
 		int VideoCaptureBitrate{DEFAULT_VIDEO_CAPTURE_BITRATE};
 
 		std::string Adapter;
+		std::string HWDumpDirectory;
+		std::string SWDumpDirectory;
 
 		GSOptions();
 

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -734,6 +734,7 @@ struct Pcsx2Config
 		int ShadeBoost_Brightness{50};
 		int ShadeBoost_Contrast{50};
 		int ShadeBoost_Saturation{50};
+		int PNGCompressionLevel{1};
 
 		int SaveN{0};
 		int SaveL{5000};

--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -908,20 +908,6 @@ std::string format(const char* fmt, ...)
 	return {buffer.data()};
 }
 
-// Helper path to dump texture
-#ifdef _WIN32
-const std::string root_sw("c:\\temp1\\_");
-const std::string root_hw("c:\\temp2\\_");
-#else
-#ifdef _M_AMD64
-const std::string root_sw("/tmp/GS_SW_dump64/");
-const std::string root_hw("/tmp/GS_HW_dump64/");
-#else
-const std::string root_sw("/tmp/GS_SW_dump32/");
-const std::string root_hw("/tmp/GS_HW_dump32/");
-#endif
-#endif
-
 #ifdef _WIN32
 
 static HANDLE s_fh = NULL;

--- a/pcsx2/GS/GS.h
+++ b/pcsx2/GS/GS.h
@@ -16,13 +16,16 @@
 #pragma once
 
 #include "common/WindowInfo.h"
-#include "Window/GSSetting.h"
 #include "SaveState.h"
 #include "pcsx2/Config.h"
 #include "pcsx2/GS/config.h"
 #include "gsl/span"
 
 #include <map>
+
+#ifndef PCSX2_CORE
+#include "Window/GSSetting.h"
+#endif
 
 #ifdef None
 	// X11 seems to like to define this, not fun
@@ -101,6 +104,8 @@ bool GSSaveSnapshotToMemory(u32 window_width, u32 window_height, bool apply_aspe
 	u32* width, u32* height, std::vector<u32>* pixels);
 void GSJoinSnapshotThreads();
 
+#ifndef PCSX2_CORE
+
 class GSApp
 {
 	std::string m_section;
@@ -157,14 +162,13 @@ public:
 	std::vector<GSSetting> m_gs_dump_compression;
 };
 
+extern GSApp theApp;
+
+#endif
+
 struct GSError
 {
 };
 struct GSRecoverableError : GSError
 {
 };
-struct GSErrorGlVertexArrayTooSmall : GSError
-{
-};
-
-extern GSApp theApp;

--- a/pcsx2/GS/GSCrc.cpp
+++ b/pcsx2/GS/GSCrc.cpp
@@ -19,6 +19,10 @@
 #include "GS.h"
 #include "common/StringUtil.h"
 
+#ifdef PCSX2_CORE
+#include "HostSettings.h"
+#endif
+
 const CRC::Game CRC::m_games[] =
 {
 	// Note: IDs 0x7ACF7E03, 0x7D4EA48F, 0x37C53760 - shouldn't be added as it's from the multiloaders when packing games.
@@ -337,7 +341,11 @@ const CRC::Game& CRC::Lookup(u32 crc)
 	printf("GS Lookup CRC:%08X\n", crc);
 	if (m_map.empty())
 	{
+#ifndef PCSX2_CORE
 		std::string exclusions = theApp.GetConfigS("CrcHacksExclusions");
+#else
+		std::string exclusions = Host::GetStringSettingValue("EmuCore/GS", "CrcHacksExclusions");
+#endif
 		if (exclusions.length() != 0)
 			printf("GS: CrcHacksExclusions: %s\n", exclusions.c_str());
 		int crcDups = 0;

--- a/pcsx2/GS/GSExtra.h
+++ b/pcsx2/GS/GSExtra.h
@@ -114,10 +114,6 @@ static constexpr int MAXIMUM_TEXTURE_MIPMAP_LEVELS = 7;
 // The maximum number of duplicate frames we can skip presenting for.
 static constexpr u32 MAX_SKIPPED_DUPLICATE_FRAMES = 3;
 
-// Helper path to dump texture
-extern const std::string root_sw;
-extern const std::string root_hw;
-
 extern void* GSAllocateWrappedMemory(size_t size, size_t repeat);
 extern void GSFreeWrappedMemory(void* ptr, size_t size, size_t repeat);
 

--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -25,6 +25,7 @@
 #include <iomanip> // Dump Verticles
 
 int GSState::s_n = 0;
+std::string GSState::s_dump_root;
 
 static __fi bool IsAutoFlushEnabled()
 {
@@ -55,16 +56,9 @@ GSState::GSState()
 	m_mipmap = GSConfig.Mipmap;
 
 	s_n = 0;
-	s_dump = theApp.GetConfigB("dump");
-	s_save = theApp.GetConfigB("save");
-	s_savet = theApp.GetConfigB("savet");
-	s_savez = theApp.GetConfigB("savez");
-	s_savef = theApp.GetConfigB("savef");
-	s_saven = theApp.GetConfigI("saven");
-	s_savel = theApp.GetConfigI("savel");
-	m_dump_root = "";
+	s_dump_root = "";
 #if defined(__unix__)
-	if (s_dump)
+	if (GSConfig.DumpGSData)
 	{
 		GSmkdir(root_hw.c_str());
 		GSmkdir(root_sw.c_str());
@@ -2085,9 +2079,9 @@ void GSState::Read(u8* mem, int len)
 
 	m_mem.ReadImageX(m_tr.x, m_tr.y, mem, len, m_env.BITBLTBUF, m_env.TRXPOS, m_env.TRXREG);
 
-	if (s_dump && s_save && s_n >= s_saven)
+	if (GSConfig.DumpGSData && GSConfig.SaveRT && s_n >= GSConfig.SaveN)
 	{
-		std::string s = m_dump_root + StringUtil::StdStringFromFormat(
+		std::string s = s_dump_root + StringUtil::StdStringFromFormat(
 			"%05d_read_%05x_%d_%d_%d_%d_%d_%d.bmp",
 			s_n, (int)m_env.BITBLTBUF.SBP, (int)m_env.BITBLTBUF.SBW, (int)m_env.BITBLTBUF.SPSM,
 			r.left, r.top, r.right, r.bottom);

--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -241,7 +241,6 @@ public:
 	int m_backed_up_ctx;
 
 	static int s_n;
-	static std::string s_dump_root;
 
 	static constexpr u32 STATE_VERSION = 8;
 
@@ -334,6 +333,9 @@ public:
 public:
 	GSState();
 	virtual ~GSState();
+
+	/// Returns the appropriate directory for draw dumping.
+	static std::string GetDrawDumpPath(const char* format, ...);
 
 	void ResetHandlers();
 

--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -241,14 +241,7 @@ public:
 	int m_backed_up_ctx;
 
 	static int s_n;
-	bool s_dump;
-	bool s_save;
-	bool s_savet;
-	bool s_savez;
-	bool s_savef;
-	int s_saven;
-	int s_savel;
-	std::string m_dump_root;
+	static std::string s_dump_root;
 
 	static constexpr u32 STATE_VERSION = 8;
 

--- a/pcsx2/GS/GSUtil.cpp
+++ b/pcsx2/GS/GSUtil.cpp
@@ -205,37 +205,6 @@ GSRendererType GSUtil::GetPreferredRenderer()
 #endif
 }
 
-#ifdef _WIN32
-void GSmkdir(const wchar_t* dir)
-{
-	if (!CreateDirectory(dir, nullptr))
-	{
-		DWORD errorID = ::GetLastError();
-		if (errorID != ERROR_ALREADY_EXISTS)
-		{
-			fprintf(stderr, "Failed to create directory: %ls error %u\n", dir, errorID);
-		}
-	}
-#else
-void GSmkdir(const char* dir)
-{
-	int err = mkdir(dir, 0777);
-	if (!err && errno != EEXIST)
-		fprintf(stderr, "Failed to create directory: %s\n", dir);
-#endif
-}
-
-std::string GStempdir()
-{
-#ifdef _WIN32
-	wchar_t path[MAX_PATH + 1];
-	GetTempPath(MAX_PATH, path);
-	return StringUtil::WideStringToUTF8String(path);
-#else
-	return "/tmp";
-#endif
-}
-
 const char* psm_str(int psm)
 {
 	switch (psm)

--- a/pcsx2/GS/GSUtil.h
+++ b/pcsx2/GS/GSUtil.h
@@ -42,11 +42,4 @@ public:
 	static GSRendererType GetPreferredRenderer();
 };
 
-#ifdef _WIN32
-void GSmkdir(const wchar_t* dir);
-#else
-void GSmkdir(const char* dir);
-#endif
-std::string GStempdir();
-
 const char* psm_str(int psm);

--- a/pcsx2/GS/Renderers/Common/GSRenderer.cpp
+++ b/pcsx2/GS/Renderers/Common/GSRenderer.cpp
@@ -629,7 +629,7 @@ void GSRenderer::VSync(u32 field, bool registers_written)
 {
 	Flush(GSFlushReason::VSYNC);
 
-	if (s_dump && s_n >= s_saven)
+	if (GSConfig.DumpGSData && s_n >= GSConfig.SaveN)
 	{
 		m_regs->Dump(root_sw + StringUtil::StdStringFromFormat("%05d_f%lld_gs_reg.txt", s_n, g_perfmon.GetFrame()));
 	}

--- a/pcsx2/GS/Renderers/Common/GSRenderer.cpp
+++ b/pcsx2/GS/Renderers/Common/GSRenderer.cpp
@@ -631,7 +631,7 @@ void GSRenderer::VSync(u32 field, bool registers_written)
 
 	if (GSConfig.DumpGSData && s_n >= GSConfig.SaveN)
 	{
-		m_regs->Dump(root_sw + StringUtil::StdStringFromFormat("%05d_f%lld_gs_reg.txt", s_n, g_perfmon.GetFrame()));
+		m_regs->Dump(GetDrawDumpPath("vsync_%05d_f%lld_gs_reg.txt", s_n, g_perfmon.GetFrame()));
 	}
 
 	const int fb_sprite_blits = g_perfmon.GetDisplayFramebufferSpriteBlits();

--- a/pcsx2/GS/Renderers/Common/GSTexture.cpp
+++ b/pcsx2/GS/Renderers/Common/GSTexture.cpp
@@ -58,7 +58,7 @@ bool GSTexture::Save(const std::string& fn)
 		return false;
 	}
 
-	const int compression = theApp.GetConfigI("png_compression_level");
+	const int compression = GSConfig.PNGCompressionLevel;
 	bool success = GSPng::Save(format, fn, map.bits, m_size.x, m_size.y, map.pitch, compression);
 
 	g_gs_device->DownloadTextureComplete();

--- a/pcsx2/GS/Renderers/DX11/GSTexture11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSTexture11.cpp
@@ -179,8 +179,7 @@ bool GSTexture11::Save(const std::string& fn)
 		return false;
 	}
 
-	int compression = theApp.GetConfigI("png_compression_level");
-	bool success = GSPng::Save(format, fn, static_cast<u8*>(sm.pData), desc.Width, desc.Height, sm.RowPitch, compression);
+	bool success = GSPng::Save(format, fn, static_cast<u8*>(sm.pData), desc.Width, desc.Height, sm.RowPitch, GSConfig.PNGCompressionLevel);
 
 	GSDevice11::GetInstance()->GetD3DContext()->Unmap(res.get(), 0);
 

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -37,7 +37,6 @@ GSRendererHW::GSRendererHW()
 	m_mipmap = (GSConfig.HWMipmap >= HWMipmapLevel::Basic);
 	SetTCOffset();
 
-	s_dump_root = root_hw;
 	GSTextureReplacements::Initialize(m_tc);
 
 	// Hope nothing requires too many draw calls.
@@ -1283,14 +1282,14 @@ void GSRendererHW::Draw()
 		std::string s;
 
 		// Dump Register state
-		s = StringUtil::StdStringFromFormat("%05d_context.txt", s_n);
+		s = GetDrawDumpPath("%05d_context.txt", s_n);
 
-		m_env.Dump(s_dump_root + s);
-		m_context->Dump(s_dump_root + s);
+		m_env.Dump(s);
+		m_context->Dump(s);
 
 		// Dump vertices
-		s = StringUtil::StdStringFromFormat("%05d_vertex.txt", s_n);
-		DumpVertices(s_dump_root + s);
+		s = GetDrawDumpPath("%05d_vertex.txt", s_n);
+		DumpVertices(s);
 	}
 
 	if (IsBadFrame())
@@ -1786,36 +1785,36 @@ void GSRendererHW::Draw()
 
 		if (GSConfig.SaveTexture && s_n >= GSConfig.SaveN && m_src)
 		{
-			s = StringUtil::StdStringFromFormat("%05d_f%lld_itex_%05x_%s_%d%d_%02x_%02x_%02x_%02x.dds",
+			s = GetDrawDumpPath("%05d_f%lld_itex_%05x_%s_%d%d_%02x_%02x_%02x_%02x.dds",
 				s_n, frame, (int)context->TEX0.TBP0, psm_str(context->TEX0.PSM),
 				(int)context->CLAMP.WMS, (int)context->CLAMP.WMT,
 				(int)context->CLAMP.MINU, (int)context->CLAMP.MAXU,
 				(int)context->CLAMP.MINV, (int)context->CLAMP.MAXV);
 
-			m_src->m_texture->Save(s_dump_root + s);
+			m_src->m_texture->Save(s);
 
 			if (m_src->m_palette)
 			{
-				s = StringUtil::StdStringFromFormat("%05d_f%lld_itpx_%05x_%s.dds", s_n, frame, context->TEX0.CBP, psm_str(context->TEX0.CPSM));
+				s = GetDrawDumpPath("%05d_f%lld_itpx_%05x_%s.dds", s_n, frame, context->TEX0.CBP, psm_str(context->TEX0.CPSM));
 
-				m_src->m_palette->Save(s_dump_root + s);
+				m_src->m_palette->Save(s);
 			}
 		}
 
 		if (rt && GSConfig.SaveRT && s_n >= GSConfig.SaveN)
 		{
-			s = StringUtil::StdStringFromFormat("%05d_f%lld_rt0_%05x_%s.bmp", s_n, frame, context->FRAME.Block(), psm_str(context->FRAME.PSM));
+			s = GetDrawDumpPath("%05d_f%lld_rt0_%05x_%s.bmp", s_n, frame, context->FRAME.Block(), psm_str(context->FRAME.PSM));
 
 			if (rt->m_texture)
-				rt->m_texture->Save(s_dump_root + s);
+				rt->m_texture->Save(s);
 		}
 
 		if (ds && GSConfig.SaveDepth && s_n >= GSConfig.SaveN)
 		{
-			s = StringUtil::StdStringFromFormat("%05d_f%lld_rz0_%05x_%s.bmp", s_n, frame, context->ZBUF.Block(), psm_str(context->ZBUF.PSM));
+			s = GetDrawDumpPath("%05d_f%lld_rz0_%05x_%s.bmp", s_n, frame, context->ZBUF.Block(), psm_str(context->ZBUF.PSM));
 
 			if (ds->m_texture)
-				ds->m_texture->Save(s_dump_root + s);
+				ds->m_texture->Save(s);
 		}
 	}
 
@@ -1947,18 +1946,18 @@ void GSRendererHW::Draw()
 
 		if (GSConfig.SaveRT && s_n >= GSConfig.SaveN)
 		{
-			s = StringUtil::StdStringFromFormat("%05d_f%lld_rt1_%05x_%s.bmp", s_n, frame, context->FRAME.Block(), psm_str(context->FRAME.PSM));
+			s = GetDrawDumpPath("%05d_f%lld_rt1_%05x_%s.bmp", s_n, frame, context->FRAME.Block(), psm_str(context->FRAME.PSM));
 
 			if (rt)
-				rt->m_texture->Save(s_dump_root + s);
+				rt->m_texture->Save(s);
 		}
 
 		if (GSConfig.SaveDepth && s_n >= GSConfig.SaveN)
 		{
-			s = StringUtil::StdStringFromFormat("%05d_f%lld_rz1_%05x_%s.bmp", s_n, frame, context->ZBUF.Block(), psm_str(context->ZBUF.PSM));
+			s = GetDrawDumpPath("%05d_f%lld_rz1_%05x_%s.bmp", s_n, frame, context->ZBUF.Block(), psm_str(context->ZBUF.PSM));
 
 			if (ds)
-				rt->m_texture->Save(s_dump_root + s);
+				rt->m_texture->Save(s);
 		}
 
 		if (GSConfig.SaveL > 0 && (s_n - GSConfig.SaveN) > GSConfig.SaveL)

--- a/pcsx2/GS/Renderers/HW/GSTextureReplacementLoaders.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureReplacementLoaders.cpp
@@ -235,7 +235,7 @@ bool PNGLoader(const std::string& filename, GSTextureReplacements::ReplacementTe
 
 bool GSTextureReplacements::SavePNGImage(const std::string& filename, u32 width, u32 height, const u8* buffer, u32 pitch)
 {
-	const int compression = theApp.GetConfigI("png_compression_level");
+	const int compression = GSConfig.PNGCompressionLevel;
 
 	png_structp png_ptr = png_create_write_struct(PNG_LIBPNG_VER_STRING, nullptr, nullptr, nullptr);
 	if (!png_ptr)

--- a/pcsx2/GS/Renderers/Metal/GSDeviceMTL.h
+++ b/pcsx2/GS/Renderers/Metal/GSDeviceMTL.h
@@ -212,9 +212,6 @@ public:
 
 	using PSSelector = GSHWDrawConfig::PSSelector;
 
-	// MARK: Configuration
-	int m_mipmap;
-
 	// MARK: Permanent resources
 	std::shared_ptr<std::pair<std::mutex, GSDeviceMTL*>> m_backref;
 	GSMTLDevice m_dev;

--- a/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
+++ b/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
@@ -89,7 +89,6 @@ GSDeviceMTL::GSDeviceMTL()
 	, m_dev(nil)
 {
 	m_backref->second = this;
-	m_mipmap = theApp.GetConfigI("mipmap");
 }
 
 GSDeviceMTL::~GSDeviceMTL()
@@ -783,7 +782,6 @@ bool GSDeviceMTL::Create()
 
 		// Init samplers
 		MTLSamplerDescriptor* sdesc = [[MTLSamplerDescriptor new] autorelease];
-		const int anisotropy = theApp.GetConfigI("MaxAnisotropy");
 		for (size_t i = 0; i < std::size(m_sampler_hw); i++)
 		{
 			GSHWDrawConfig::SamplerSelector sel;
@@ -826,7 +824,7 @@ bool GSDeviceMTL::Create()
 			sdesc.tAddressMode = sel.tav ? MTLSamplerAddressModeRepeat : MTLSamplerAddressModeClampToEdge;
 			sdesc.rAddressMode = MTLSamplerAddressModeClampToEdge;
 
-			sdesc.maxAnisotropy = anisotropy && sel.aniso ? anisotropy : 1;
+			sdesc.maxAnisotropy = GSConfig.MaxAnisotropy && sel.aniso ? GSConfig.MaxAnisotropy : 1;
 			sdesc.lodMaxClamp = sel.lodclamp ? 0.25f : FLT_MAX;
 
 			[sdesc setLabel:[NSString stringWithFormat:@"%s%s %s%s", taudesc, tavdesc, magname, minname]];

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -97,7 +97,7 @@ bool GSDeviceOGL::Create()
 	if (!GLLoader::check_gl_requirements())
 		return false;
 
-	if (!theApp.GetConfigB("disable_shader_cache"))
+	if (!GSConfig.DisableShaderCache)
 	{
 		if (!m_shader_cache.Open(false, EmuFolders::Cache, SHADER_CACHE_VERSION))
 			Console.Warning("Shader cache failed to open.");

--- a/pcsx2/GS/Renderers/OpenGL/GSTextureOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSTextureOGL.cpp
@@ -410,8 +410,7 @@ bool GSTextureOGL::Save(const std::string& fn)
 		glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
 	}
 
-	int compression = theApp.GetConfigI("png_compression_level");
-	return GSPng::Save(fmt, fn, image.get(), m_size.x, m_size.y, pitch, compression);
+	return GSPng::Save(fmt, fn, image.get(), m_size.x, m_size.y, pitch, GSConfig.PNGCompressionLevel);
 }
 
 void GSTextureOGL::Swap(GSTexture* tex)

--- a/pcsx2/GS/Renderers/SW/GSRasterizer.cpp
+++ b/pcsx2/GS/Renderers/SW/GSRasterizer.cpp
@@ -38,7 +38,7 @@ static int compute_best_thread_height(int threads)
 	// - but not too small to keep the threading overhead low
 	// - ideal value between 3 and 5, or log2(64 / number of threads)
 
-	int th = theApp.GetConfigI("extrathreads_height");
+	int th = GSConfig.SWExtraThreadsHeight;
 
 	if (th > 0 && th < 9)
 		return th;

--- a/pcsx2/GS/Renderers/SW/GSRendererSW.cpp
+++ b/pcsx2/GS/Renderers/SW/GSRendererSW.cpp
@@ -43,8 +43,6 @@ GSRendererSW::GSRendererSW(int threads)
 
 	std::fill(std::begin(m_fzb_pages), std::end(m_fzb_pages), 0);
 	std::fill(std::begin(m_tex_pages), std::end(m_tex_pages), 0);
-
-	s_dump_root = root_sw;
 }
 
 GSRendererSW::~GSRendererSW()
@@ -205,7 +203,7 @@ GSTexture* GSRendererSW::GetOutput(int i, int& y_offset)
 		{
 			if (GSConfig.SaveFrame && s_n >= GSConfig.SaveN)
 			{
-				m_texture[i]->Save(s_dump_root + StringUtil::StdStringFromFormat("%05d_f%lld_fr%d_%05x_%s.bmp", s_n, g_perfmon.GetFrame(), i, (int)DISPFB.Block(), psm_str(DISPFB.PSM)));
+				m_texture[i]->Save(GetDrawDumpPath("%05d_f%lld_fr%d_%05x_%s.bmp", s_n, g_perfmon.GetFrame(), i, (int)DISPFB.Block(), psm_str(DISPFB.PSM)));
 			}
 		}
 	}
@@ -340,14 +338,14 @@ void GSRendererSW::Draw()
 		if (s_n >= GSConfig.SaveN)
 		{
 			// Dump Register state
-			s = StringUtil::StdStringFromFormat("%05d_context.txt", s_n);
+			s = GetDrawDumpPath("%05d_context.txt", s_n);
 
-			m_env.Dump(s_dump_root + s);
-			m_context->Dump(s_dump_root + s);
+			m_env.Dump(s);
+			m_context->Dump(s);
 
 			// Dump vertices
-			s = StringUtil::StdStringFromFormat("%05d_vertex.txt", s_n);
-			DumpVertices(s_dump_root + s);
+			s = GetDrawDumpPath("%05d_vertex.txt", s_n);
+			DumpVertices(s);
 		}
 	}
 
@@ -470,12 +468,12 @@ void GSRendererSW::Draw()
 			if (texture_shuffle)
 			{
 				// Dump the RT in 32 bits format. It helps to debug texture shuffle effect
-				s = StringUtil::StdStringFromFormat("%05d_f%lld_itexraw_%05x_32bits.bmp", s_n, frame, (int)m_context->TEX0.TBP0);
-				m_mem.SaveBMP(s_dump_root + s, m_context->TEX0.TBP0, m_context->TEX0.TBW, 0, 1 << m_context->TEX0.TW, 1 << m_context->TEX0.TH);
+				s = GetDrawDumpPath("%05d_f%lld_itexraw_%05x_32bits.bmp", s_n, frame, (int)m_context->TEX0.TBP0);
+				m_mem.SaveBMP(s, m_context->TEX0.TBP0, m_context->TEX0.TBW, 0, 1 << m_context->TEX0.TW, 1 << m_context->TEX0.TH);
 			}
 
-			s = StringUtil::StdStringFromFormat("%05d_f%lld_itexraw_%05x_%s.bmp", s_n, frame, (int)m_context->TEX0.TBP0, psm_str(m_context->TEX0.PSM));
-			m_mem.SaveBMP(s_dump_root + s, m_context->TEX0.TBP0, m_context->TEX0.TBW, m_context->TEX0.PSM, 1 << m_context->TEX0.TW, 1 << m_context->TEX0.TH);
+			s = GetDrawDumpPath("%05d_f%lld_itexraw_%05x_%s.bmp", s_n, frame, (int)m_context->TEX0.TBP0, psm_str(m_context->TEX0.PSM));
+			m_mem.SaveBMP(s, m_context->TEX0.TBP0, m_context->TEX0.TBW, m_context->TEX0.PSM, 1 << m_context->TEX0.TW, 1 << m_context->TEX0.TH);
 		}
 
 		if (GSConfig.SaveRT && s_n >= GSConfig.SaveN)
@@ -484,19 +482,19 @@ void GSRendererSW::Draw()
 			if (texture_shuffle)
 			{
 				// Dump the RT in 32 bits format. It helps to debug texture shuffle effect
-				s = StringUtil::StdStringFromFormat("%05d_f%lld_rt0_%05x_32bits.bmp", s_n, frame, m_context->FRAME.Block());
-				m_mem.SaveBMP(s_dump_root + s, m_context->FRAME.Block(), m_context->FRAME.FBW, 0, GetFrameRect().width(), 512);
+				s = GetDrawDumpPath("%05d_f%lld_rt0_%05x_32bits.bmp", s_n, frame, m_context->FRAME.Block());
+				m_mem.SaveBMP(s, m_context->FRAME.Block(), m_context->FRAME.FBW, 0, GetFrameRect().width(), 512);
 			}
 
-			s = StringUtil::StdStringFromFormat("%05d_f%lld_rt0_%05x_%s.bmp", s_n, frame, m_context->FRAME.Block(), psm_str(m_context->FRAME.PSM));
-			m_mem.SaveBMP(s_dump_root + s, m_context->FRAME.Block(), m_context->FRAME.FBW, m_context->FRAME.PSM, GetFrameRect().width(), 512);
+			s = GetDrawDumpPath("%05d_f%lld_rt0_%05x_%s.bmp", s_n, frame, m_context->FRAME.Block(), psm_str(m_context->FRAME.PSM));
+			m_mem.SaveBMP(s, m_context->FRAME.Block(), m_context->FRAME.FBW, m_context->FRAME.PSM, GetFrameRect().width(), 512);
 		}
 
 		if (GSConfig.SaveDepth && s_n >= GSConfig.SaveN)
 		{
-			s = StringUtil::StdStringFromFormat("%05d_f%lld_rz0_%05x_%s.bmp", s_n, frame, m_context->ZBUF.Block(), psm_str(m_context->ZBUF.PSM));
+			s = GetDrawDumpPath("%05d_f%lld_rz0_%05x_%s.bmp", s_n, frame, m_context->ZBUF.Block(), psm_str(m_context->ZBUF.PSM));
 
-			m_mem.SaveBMP(s_dump_root + s, m_context->ZBUF.Block(), m_context->FRAME.FBW, m_context->ZBUF.PSM, GetFrameRect().width(), 512);
+			m_mem.SaveBMP(s, m_context->ZBUF.Block(), m_context->FRAME.FBW, m_context->ZBUF.PSM, GetFrameRect().width(), 512);
 		}
 
 		Queue(data);
@@ -508,19 +506,19 @@ void GSRendererSW::Draw()
 			if (texture_shuffle)
 			{
 				// Dump the RT in 32 bits format. It helps to debug texture shuffle effect
-				s = StringUtil::StdStringFromFormat("%05d_f%lld_rt1_%05x_32bits.bmp", s_n, frame, m_context->FRAME.Block());
-				m_mem.SaveBMP(s_dump_root + s, m_context->FRAME.Block(), m_context->FRAME.FBW, 0, GetFrameRect().width(), 512);
+				s = GetDrawDumpPath("%05d_f%lld_rt1_%05x_32bits.bmp", s_n, frame, m_context->FRAME.Block());
+				m_mem.SaveBMP(s, m_context->FRAME.Block(), m_context->FRAME.FBW, 0, GetFrameRect().width(), 512);
 			}
 
-			s = StringUtil::StdStringFromFormat("%05d_f%lld_rt1_%05x_%s.bmp", s_n, frame, m_context->FRAME.Block(), psm_str(m_context->FRAME.PSM));
-			m_mem.SaveBMP(s_dump_root + s, m_context->FRAME.Block(), m_context->FRAME.FBW, m_context->FRAME.PSM, GetFrameRect().width(), 512);
+			s = GetDrawDumpPath("%05d_f%lld_rt1_%05x_%s.bmp", s_n, frame, m_context->FRAME.Block(), psm_str(m_context->FRAME.PSM));
+			m_mem.SaveBMP(s, m_context->FRAME.Block(), m_context->FRAME.FBW, m_context->FRAME.PSM, GetFrameRect().width(), 512);
 		}
 
 		if (GSConfig.SaveDepth && s_n >= GSConfig.SaveN)
 		{
-			s = StringUtil::StdStringFromFormat("%05d_f%lld_rz1_%05x_%s.bmp", s_n, frame, m_context->ZBUF.Block(), psm_str(m_context->ZBUF.PSM));
+			s = GetDrawDumpPath("%05d_f%lld_rz1_%05x_%s.bmp", s_n, frame, m_context->ZBUF.Block(), psm_str(m_context->ZBUF.PSM));
 
-			m_mem.SaveBMP(s_dump_root + s, m_context->ZBUF.Block(), m_context->FRAME.FBW, m_context->ZBUF.PSM, GetFrameRect().width(), 512);
+			m_mem.SaveBMP(s, m_context->ZBUF.Block(), m_context->FRAME.FBW, m_context->ZBUF.PSM, GetFrameRect().width(), 512);
 		}
 
 		if (GSConfig.SaveL > 0 && (s_n - GSConfig.SaveN) > GSConfig.SaveL)
@@ -606,16 +604,16 @@ void GSRendererSW::Sync(int reason)
 
 		if (GSConfig.SaveRT)
 		{
-			s = StringUtil::StdStringFromFormat("%05d_f%lld_rt1_%05x_%s.bmp", s_n, g_perfmon.GetFrame(), m_context->FRAME.Block(), psm_str(m_context->FRAME.PSM));
+			s = GetDrawDumpPath("%05d_f%lld_rt1_%05x_%s.bmp", s_n, g_perfmon.GetFrame(), m_context->FRAME.Block(), psm_str(m_context->FRAME.PSM));
 
-			m_mem.SaveBMP(s_dump_root + s, m_context->FRAME.Block(), m_context->FRAME.FBW, m_context->FRAME.PSM, GetFrameRect().width(), 512);
+			m_mem.SaveBMP(s, m_context->FRAME.Block(), m_context->FRAME.FBW, m_context->FRAME.PSM, GetFrameRect().width(), 512);
 		}
 
 		if (GSConfig.SaveDepth)
 		{
-			s = StringUtil::StdStringFromFormat("%05d_f%lld_zb1_%05x_%s.bmp", s_n, g_perfmon.GetFrame(), m_context->ZBUF.Block(), psm_str(m_context->ZBUF.PSM));
+			s = GetDrawDumpPath("%05d_f%lld_zb1_%05x_%s.bmp", s_n, g_perfmon.GetFrame(), m_context->ZBUF.Block(), psm_str(m_context->ZBUF.PSM));
 
-			m_mem.SaveBMP(s_dump_root + s, m_context->ZBUF.Block(), m_context->FRAME.FBW, m_context->ZBUF.PSM, GetFrameRect().width(), 512);
+			m_mem.SaveBMP(s, m_context->ZBUF.Block(), m_context->FRAME.FBW, m_context->ZBUF.PSM, GetFrameRect().width(), 512);
 		}
 	}
 
@@ -1583,9 +1581,9 @@ void GSRendererSW::SharedData::UpdateSource()
 			{
 				const GIFRegTEX0& TEX0 = g_gs_renderer->GetTex0Layer(i);
 
-				s = StringUtil::StdStringFromFormat("%05d_f%lld_itex%d_%05x_%s.bmp", g_gs_renderer->s_n, frame, i, TEX0.TBP0, psm_str(TEX0.PSM));
+				s = GetDrawDumpPath("%05d_f%lld_itex%d_%05x_%s.bmp", g_gs_renderer->s_n, frame, i, TEX0.TBP0, psm_str(TEX0.PSM));
 
-				m_tex[i].t->Save(root_sw + s);
+				m_tex[i].t->Save(s);
 			}
 
 			if (global.clut != NULL)
@@ -1594,9 +1592,9 @@ void GSRendererSW::SharedData::UpdateSource()
 
 				t->Update(GSVector4i(0, 0, 256, 1), global.clut, sizeof(u32) * 256);
 
-				s = StringUtil::StdStringFromFormat("%05d_f%lld_itexp_%05x_%s.bmp", g_gs_renderer->s_n, frame, (int)g_gs_renderer->m_context->TEX0.CBP, psm_str(g_gs_renderer->m_context->TEX0.CPSM));
+				s = GetDrawDumpPath("%05d_f%lld_itexp_%05x_%s.bmp", g_gs_renderer->s_n, frame, (int)g_gs_renderer->m_context->TEX0.CBP, psm_str(g_gs_renderer->m_context->TEX0.CPSM));
 
-				t->Save(root_sw + s);
+				t->Save(s);
 
 				delete t;
 			}

--- a/pcsx2/GS/Renderers/SW/GSTextureSW.cpp
+++ b/pcsx2/GS/Renderers/SW/GSTextureSW.cpp
@@ -91,7 +91,7 @@ bool GSTextureSW::Save(const std::string& fn)
 #else
 	GSPng::Format fmt = GSPng::RGB_PNG;
 #endif
-	int compression = theApp.GetConfigI("png_compression_level");
+	int compression = GSConfig.PNGCompressionLevel;
 	return GSPng::Save(fmt, fn, static_cast<u8*>(m_data), m_size.x, m_size.y, m_pitch, compression);
 }
 

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -489,6 +489,7 @@ bool Pcsx2Config::GSOptions::OptionsAreEqual(const GSOptions& right) const
 		OpEqu(ShadeBoost_Brightness) &&
 		OpEqu(ShadeBoost_Contrast) &&
 		OpEqu(ShadeBoost_Saturation) &&
+		OpEqu(PNGCompressionLevel) &&
 		OpEqu(SaveN) &&
 		OpEqu(SaveL) &&
 
@@ -693,6 +694,7 @@ void Pcsx2Config::GSOptions::ReloadIniSettings()
 	GSSettingInt(ShadeBoost_Brightness);
 	GSSettingInt(ShadeBoost_Contrast);
 	GSSettingInt(ShadeBoost_Saturation);
+	GSSettingIntEx(PNGCompressionLevel, "png_compression_level");
 	GSSettingIntEx(SaveN, "saven");
 	GSSettingIntEx(SaveL, "savel");
 

--- a/pcsx2/pcsx2core.vcxproj
+++ b/pcsx2/pcsx2core.vcxproj
@@ -310,7 +310,6 @@
     <ClCompile Include="GS\Renderers\HW\GSRendererHWMultiISA.cpp" />
     <ClCompile Include="GS\Renderers\Null\GSRendererNull.cpp" />
     <ClCompile Include="GS\Renderers\SW\GSRendererSW.cpp" />
-    <ClCompile Include="GS\Window\GSSetting.cpp" />
     <ClCompile Include="GS\Renderers\SW\GSSetupPrimCodeGenerator.cpp" />
     <ClCompile Include="GS\Renderers\SW\GSSetupPrimCodeGenerator.all.cpp" />
     <ClCompile Include="GS\GSState.cpp" />
@@ -653,7 +652,6 @@
     <ClInclude Include="GS\Renderers\Null\GSRendererNull.h" />
     <ClInclude Include="GS\Renderers\SW\GSRendererSW.h" />
     <ClInclude Include="GS\Renderers\SW\GSScanlineEnvironment.h" />
-    <ClInclude Include="GS\Window\GSSetting.h" />
     <ClInclude Include="GS\Renderers\SW\GSSetupPrimCodeGenerator.h" />
     <ClInclude Include="GS\Renderers\SW\GSSetupPrimCodeGenerator.all.h" />
     <ClInclude Include="GS\GSState.h" />

--- a/pcsx2/pcsx2core.vcxproj.filters
+++ b/pcsx2/pcsx2core.vcxproj.filters
@@ -1175,9 +1175,6 @@
     <ClCompile Include="GS\GSCapture.cpp">
       <Filter>System\Ps2\GS\Window</Filter>
     </ClCompile>
-    <ClCompile Include="GS\Window\GSSetting.cpp">
-      <Filter>System\Ps2\GS\Window</Filter>
-    </ClCompile>
     <ClCompile Include="GS\Renderers\DX11\D3D.cpp">
       <Filter>System\Ps2\GS\Renderers\Direct3D11</Filter>
     </ClCompile>
@@ -2121,9 +2118,6 @@
       <Filter>System\Ps2\GS\Renderers\Common</Filter>
     </ClInclude>
     <ClInclude Include="GS\GSCapture.h">
-      <Filter>System\Ps2\GS\Window</Filter>
-    </ClInclude>
-    <ClInclude Include="GS\Window\GSSetting.h">
       <Filter>System\Ps2\GS\Window</Filter>
     </ClInclude>
     <ClInclude Include="GS\resource.h">


### PR DESCRIPTION
### Description of Changes

Adds draw dumping options (nicer than wx).

Also fixes a bug where relative custom folder paths would show up as `C:\pcsx2\directory\..\..\..\foo\bar`, i.e. not canonicalized.

### Rationale behind Changes

Feature parity with wx.

### Suggested Testing Steps

Test GS draw dumping.
