### PR TITLE
Clean up issues related to removing wx.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,9 +56,3 @@ if(ACTUALLY_ENABLE_TESTS)
 	add_subdirectory(tests/ctest)
 endif()
 
-#-------------------------------------------------------------------------------
-
-if(NOT WIN32 AND NOT DISABLE_PCSX2_WRAPPER)
-	# special case to avoid having linux files in windows
-	INSTALL(FILES "${CMAKE_SOURCE_DIR}/linux_various/PCSX2-linux.sh"          DESTINATION "${CMAKE_SOURCE_DIR}/bin")
-endif()

--- a/build.sh
+++ b/build.sh
@@ -149,8 +149,6 @@ for ARG in "$@"; do
         --prof              ) flags="$flags -DCMAKE_BUILD_TYPE=RelWithDebInfo"; build="$root/build_prof";;
         --strip             ) flags="$flags -DCMAKE_BUILD_STRIP=TRUE" ;;
         --asan              ) flags="$flags -DUSE_ASAN=TRUE" ;;
-        --gtk2              ) flags="$flags -DGTK2_API=TRUE" ;;
-        --qt6               ) flags="$flags -DQT_BUILD=TRUE" ;;
         --use-system        ) flags="$flags -DUSE_SYSTEM_LIBS=ON" ;;
         --use-bundled       ) flags="$flags -DUSE_SYSTEM_LIBS=OFF" ;;
         --lto               ) flags="$flags -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=TRUE" ;;
@@ -174,8 +172,6 @@ for ARG in "$@"; do
             echo "--no-simd         : Only allow sse2."
             echo
             echo "** Expert Developer option **"
-            echo "--gtk2            : use GTK 2 instead of GTK 3."
-            echo "--qt6             : Experimental qt 6 ui."
             echo "--no-trans        : Don't regenerate mo files when building."
             echo "--strip           : Strip binaries to save a small amount of space."
             echo "--clang           : Build with Clang/llvm."

--- a/build.sh
+++ b/build.sh
@@ -18,12 +18,6 @@
 set -u
 
 # Function declarations
-find_freetype()
-{
-    if [ "$(uname -m)" = "x86_64" ] && [ -e "/usr/include/x86_64-linux-gnu/freetype2/ft2build.h" ]; then
-        export GTKMM_BASEPATH=/usr/include/x86_64-linux-gnu/freetype2
-    fi
-}
 
 set_make()
 {
@@ -155,7 +149,6 @@ for ARG in "$@"; do
         --pgo-optimize      ) flags="$flags -DUSE_PGO_OPTIMIZE=TRUE" ;;
         --pgo-generate      ) flags="$flags -DUSE_PGO_GENERATE=TRUE" ;;
         --no-simd           ) flags="$flags -DDISABLE_ADVANCE_SIMD=TRUE" ;;
-        --no-trans          ) flags="$flags -DNO_TRANSLATION=TRUE" ;;
         --vtune             ) flags="$flags -DUSE_VTUNE=TRUE" ;;
         -D*                 ) flags="$flags $ARG" ;;
 
@@ -172,7 +165,6 @@ for ARG in "$@"; do
             echo "--no-simd         : Only allow sse2."
             echo
             echo "** Expert Developer option **"
-            echo "--no-trans        : Don't regenerate mo files when building."
             echo "--strip           : Strip binaries to save a small amount of space."
             echo "--clang           : Build with Clang/llvm."
             echo "--use-system      : Only use system libs."
@@ -199,9 +191,6 @@ if [ "$cleanBuild" -eq 1 ]; then
     # allow to keep build as a symlink (for example to a ramdisk)
     rm -fr "$build"/*
 fi
-
-# Workaround for Debian. Cmake failed to find freetype include path
-find_freetype
 
 echo "Building pcsx2 with $flags" | tee "$log"
 

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -270,7 +270,7 @@ GSTexture* GSRendererHW::GetOutput(int i, int& y_offset)
 		{
 			if (GSConfig.SaveFrame && s_n >= GSConfig.SaveN)
 			{
-				t->Save(s_dump_root + StringUtil::StdStringFromFormat("%05d_f%lld_fr%d_%05x_%s.bmp", s_n, g_perfmon.GetFrame(), i, (int)TEX0.TBP0, psm_str(TEX0.PSM)));
+				t->Save(GetDrawDumpPath("%05d_f%lld_fr%d_%05x_%s.bmp", s_n, g_perfmon.GetFrame(), i, (int)TEX0.TBP0, psm_str(TEX0.PSM)));
 			}
 		}
 #endif
@@ -299,7 +299,7 @@ GSTexture* GSRendererHW::GetFeedbackOutput()
 
 #ifdef ENABLE_OGL_DEBUG
 	if (GSConfig.DumpGSData && GSConfig.SaveFrame && s_n >= GSConfig.SaveN)
-		t->Save(s_dump_root + StringUtil::StdStringFromFormat("%05d_f%lld_fr%d_%05x_%s.bmp", s_n, g_perfmon.GetFrame(), 3, (int)TEX0.TBP0, psm_str(TEX0.PSM)));
+		t->Save(GetDrawDumpPath("%05d_f%lld_fr%d_%05x_%s.bmp", s_n, g_perfmon.GetFrame(), 3, (int)TEX0.TBP0, psm_str(TEX0.PSM)));
 #endif
 
 	return t;


### PR DESCRIPTION
### Description of Changes
This gets rid of two now obsolete flags in build.sh.

Also, the variable s_dump_root was still being used in two places, causing compilation to fail if ENABLE_OGL_DEBUG was defined, and it was trying to install a now non-existant file at the end of building.

### Rationale behind Changes
Being able to compile pcsx2 is good, as is not having flags in build.sh that don't do anything.

### Suggested Testing Steps
Check to see if OGL debug actually saves to the right directory, as I just made the same changes that were in the rest of the commit that removed that variable.
