### PR TITLE
GameDB: Add Mipmapping to Eragon

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -18740,9 +18740,17 @@ SLES-54158:
 SLES-54159:
   name: "Eragon"
   region: "PAL-M5"
+  gsHWFixes:
+    mipmap: 2 # Cleans up texture detail.
+    trilinearFiltering: 1 # Smoothes out mipmapping.
+    halfPixelOffset: 2 # Fixes post processing misalignment.
 SLES-54160:
   name: "Eragon"
   region: "PAL-R"
+  gsHWFixes:
+    mipmap: 2 # Cleans up texture detail.
+    trilinearFiltering: 1 # Smoothes out mipmapping.
+    halfPixelOffset: 2 # Fixes post processing misalignment.
 SLES-54161:
   name: "Super Dragon Ball Z"
   region: "PAL-E"
@@ -46011,6 +46019,10 @@ SLUS-21322:
   compat: 5
   clampModes:
     vuClampMode: 3 # Fixes SPS and spawn issues.
+  gsHWFixes:
+    mipmap: 2 # Cleans up texture detail.
+    trilinearFiltering: 1 # Smoothes out mipmapping.
+    halfPixelOffset: 2 # Fixes post processing misalignment.
 SLUS-21323:
   name: "Rampage - Total Destruction"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
Adds mipmapping full trilinear PS2 and HPO Special to Eragon to fix up the rather terrible looking image quality.

### Rationale behind Changes
It looks awful and should be fixed by these changes.

### Suggested Testing Steps
Makes sure CI is happy.