### PR TITLE
NTFS: Disable the NTFS checkbox on Linux, not Windows.

### DIFF
--- a/pcsx2-qt/Settings/CreateMemoryCardDialog.cpp
+++ b/pcsx2-qt/Settings/CreateMemoryCardDialog.cpp
@@ -49,7 +49,7 @@ CreateMemoryCardDialog::CreateMemoryCardDialog(QWidget* parent /* = nullptr */)
 	connect(m_ui.buttonBox->button(QDialogButtonBox::Cancel), &QPushButton::clicked, this, &CreateMemoryCardDialog::close);
 	connect(m_ui.buttonBox->button(QDialogButtonBox::RestoreDefaults), &QPushButton::clicked, this, &CreateMemoryCardDialog::restoreDefaults);
 
-#ifdef _WIN32
+#ifndef _WIN32
 	m_ui.ntfsCompression->setEnabled(false);
 #endif
 


### PR DESCRIPTION
### Description of Changes
Fixes an #ifdef that should have been an #ifndef.

### Rationale behind Changes
We shouldn't have an option enabled on platforms that it doesn't work on.

### Suggested Testing Steps
Open pcsx2, go to create a memory card, and look at the checkbox for NTFS.
