### PR TITLE
USB: Only update when devices plugged

### DIFF
--- a/pcsx2/USB/USB.cpp
+++ b/pcsx2/USB/USB.cpp
@@ -509,6 +509,9 @@ s32 USBfreeze(FreezeAction mode, freezeData* data)
 
 void USBasync(u32 cycles)
 {
+	if (!s_usb_device[0] && !s_usb_device[1])
+		return;
+
 	s_usb_remaining += cycles;
 	s_usb_clocks += s_usb_remaining;
 	if (s_qemu_ohci->eof_timer > 0)


### PR DESCRIPTION
### Description of Changes

Although I made `USBasync()` a decent bit faster in the USB refactor, it's still not free, and wastes CPU time when there's no USB devices connected. So, in theory, we should be able to skip it entirely in such a case.

But I'm not 100% sure yet. From some quick testing, things seem to work fine if you hotplug, but if the game was talking to the USB controller prior to the device being connected, it might get confused.

So, testers, see if you find any games where hotplugging USB devices breaks with this PR.

### Rationale behind Changes

Saving some valuable EE thread CPU time.

### Suggested Testing Steps

See above.
