### PR TITLE
Qt: enable editing cheats directory

### DIFF
--- a/pcsx2-qt/Settings/FolderSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/FolderSettingsWidget.cpp
@@ -30,6 +30,7 @@ FolderSettingsWidget::FolderSettingsWidget(SettingsDialog* dialog, QWidget* pare
 	m_ui.setupUi(this);
 
 	SettingWidgetBinder::BindWidgetToFolderSetting(sif, m_ui.cache, m_ui.cacheBrowse, m_ui.cacheOpen, m_ui.cacheReset, "Folders", "Cache", Path::Combine(EmuFolders::DataRoot, "cache"));
+	SettingWidgetBinder::BindWidgetToFolderSetting(sif, m_ui.cheats, m_ui.cheatsBrowse, m_ui.cheatsOpen, m_ui.cheatsReset, "Folders", "Cheats", Path::Combine(EmuFolders::DataRoot, "cheats"));
 	SettingWidgetBinder::BindWidgetToFolderSetting(sif, m_ui.covers, m_ui.coversBrowse, m_ui.coversOpen, m_ui.coversReset, "Folders", "Covers", Path::Combine(EmuFolders::DataRoot, "covers"));
 	SettingWidgetBinder::BindWidgetToFolderSetting(sif, m_ui.snapshots, m_ui.snapshotsBrowse, m_ui.snapshotsOpen, m_ui.snapshotsReset, "Folders", "Snapshots", Path::Combine(EmuFolders::DataRoot, "snaps"));
 	SettingWidgetBinder::BindWidgetToFolderSetting(sif, m_ui.saveStates, m_ui.saveStatesBrowse, m_ui.saveStatesOpen, m_ui.saveStatesReset, "Folders", "SaveStates", Path::Combine(EmuFolders::DataRoot, "sstates"));

--- a/pcsx2-qt/Settings/FolderSettingsWidget.ui
+++ b/pcsx2-qt/Settings/FolderSettingsWidget.ui
@@ -67,6 +67,46 @@
     </widget>
    </item>
    <item>
+    <widget class="QGroupBox" name="groupBox_5">
+     <property name="title">
+      <string>Cheats Directory</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_5">
+      <item row="1" column="0">
+       <widget class="QLineEdit" name="cheats"/>
+      </item>
+      <item row="1" column="1">
+       <widget class="QPushButton" name="cheatsBrowse">
+        <property name="text">
+         <string>Browse...</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="2">
+       <widget class="QPushButton" name="cheatsOpen">
+        <property name="text">
+         <string>Open...</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="3">
+       <widget class="QPushButton" name="cheatsReset">
+        <property name="text">
+         <string>Reset</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0" colspan="4">
+       <widget class="QLabel" name="label_5">
+        <property name="text">
+         <string>Used for storing .pnach files containing game cheats.</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <widget class="QGroupBox" name="groupBox_4">
      <property name="title">
       <string>Covers Directory</string>


### PR DESCRIPTION
### Description of Changes
Allow the cheats directory to be edited from the Qt GUI.

### Rationale behind Changes
Feature parity with the now-departed wx. Fixes issue #7436

### Suggested Testing Steps
Build, change the cheat folder, and ensure any cheats in that folder load.
