### PR TITLE
Pad: DInput: Fix incorrect Dpad labels

### DIFF
--- a/pcsx2/Frontend/DInputSource.cpp
+++ b/pcsx2/Frontend/DInputSource.cpp
@@ -65,7 +65,7 @@ std::string DInputSource::GetDeviceIdentifier(u32 index)
 	return fmt::format("DInput-{}", index);
 }
 
-static constexpr std::array<const char*, DInputSource::NUM_HAT_DIRECTIONS> s_hat_directions = {{"Up", "Right", "Down", "Left"}};
+static constexpr std::array<const char*, DInputSource::NUM_HAT_DIRECTIONS> s_hat_directions = {{"Up", "Down", "Left", "Right"}};
 
 bool DInputSource::Initialize(SettingsInterface& si, std::unique_lock<std::mutex>& settings_lock)
 {


### PR DESCRIPTION
### Description of Changes
DInput: Fix incorrect Dpad labels

### Rationale behind Changes
Down/Left and Right labels are rotated:
![image](https://user-images.githubusercontent.com/2995486/209486000-2d9e9f5b-1c50-43a7-ada2-6c75e43a8548.png)

### Suggested Testing Steps
Will need to reassign the impacted buttons to work
