### PR TITLE
Pad: SDL: Assign button names starting with Button0 instead of Button21

### DIFF
--- a/pcsx2/Frontend/SDLInputSource.cpp
+++ b/pcsx2/Frontend/SDLInputSource.cpp
@@ -336,7 +336,7 @@ std::optional<InputBindingKey> SDLInputSource::ParseKeyString(const std::string_
 			if (auto value = StringUtil::FromChars<u32>(binding.substr(6)))
 			{
 				key.source_subtype = InputSubclass::ControllerButton;
-				key.data = *value;
+				key.data = *value + std::size(s_sdl_button_names);
 				return key;
 			}
 		}
@@ -374,7 +374,7 @@ std::string SDLInputSource::ConvertKeyToString(InputBindingKey key)
 			if (key.data < std::size(s_sdl_button_names))
 				ret = StringUtil::StdStringFromFormat("SDL-%u/%s", key.source_index, s_sdl_button_names[key.data]);
 			else
-				ret = StringUtil::StdStringFromFormat("SDL-%u/Button%u", key.source_index, key.data);
+				ret = StringUtil::StdStringFromFormat("SDL-%u/Button%u", key.source_index, key.data - std::size(s_sdl_button_names));
 		}
 		else if (key.source_subtype == InputSubclass::ControllerHat)
 		{


### PR DESCRIPTION
### Description of Changes
Assign button names starting with Button0 instead of Button21

### Rationale behind Changes
- Easier to track the assigned buttons
- Consistent with DInput

Before: 
![image](https://user-images.githubusercontent.com/2995486/209486553-7a501171-3b95-4877-9991-4aedd8b466d5.png)

After:
![image](https://user-images.githubusercontent.com/2995486/209486563-32434fd1-7df9-4a1c-b16d-6facb3ef68bb.png)

### Suggested Testing Steps
Will need to reassign the impacted buttons to work