### PR TITLE
GS-HW: Adjust Yakuza CRC hack to remove weird shadow

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSHwHack.cpp
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.cpp
@@ -618,7 +618,9 @@ bool GSC_YakuzaGames(const GSFrameInfo& fi, int& skip) noexcept
 		{
 			// Don't enable hack on native res if crc is below aggressive.
 			// Upscaling issues, removes glow/blur effect which fixes ghosting.
-			skip = 3;
+			// Skip 3 removes most of the post effect which doesn't upscale well, but causes a depth effect to completely mess up.
+			// Skip 9 removes both the depth and blur effect, which seems to work okay.
+			skip = 9;
 		}
 	}
 


### PR DESCRIPTION
### Description of Changes
Adjust the skip amount to get rid of a weird shadow as a result of the existing CRC. 

### Rationale behind Changes
Unfortunately although the original effect works, it doesn't upscale at all, so it's better removed, and the original hack caused a strange shadow caused by some depth read but made worse by the original skipped draws.

### Suggested Testing Steps
Already had the testers check the Yakuza 1 & 2 games.
