### PR TITLE
SaveState: Partial migration to StateWrapper for USB

### DIFF
--- a/pcsx2/StateWrapper.h
+++ b/pcsx2/StateWrapper.h
@@ -85,6 +85,8 @@ public:
 		VectorMemoryStream();
 		VectorMemoryStream(u32 reserve);
 
+		const std::vector<u8>& GetBuffer() const { return m_buf; }
+
 		u32 Read(void* buf, u32 count) override;
 		u32 Write(const void* buf, u32 count) override;
 		u32 GetPosition() override;

--- a/pcsx2/USB/USB.h
+++ b/pcsx2/USB/USB.h
@@ -24,9 +24,9 @@
 #include "gsl/span"
 
 #include "Config.h"
-#include "SaveState.h"
 
 class SettingsInterface;
+class StateWrapper;
 
 namespace USB
 {
@@ -84,6 +84,9 @@ namespace USB
 
 	/// Reads a device-specific configuration string.
 	std::string GetConfigString(SettingsInterface& si, u32 port, const char* devname, const char* key, const char* default_value = "");
+
+	/// Handles loading/saving save state.
+	bool DoState(StateWrapper& sw);
 } // namespace USB
 
 struct WindowInfo;
@@ -96,7 +99,6 @@ void USBshutdown();
 void USBclose();
 bool USBopen();
 void USBreset();
-s32 USBfreeze(FreezeAction mode, freezeData* data);
 
 u8 USBread8(u32 addr);
 u16 USBread16(u32 addr);


### PR DESCRIPTION
### Description of Changes

The current save state system is utterly rubbish and completely incapable of storing variable sized data.

I'd like to rip it all out eventually, but this is a stop-gap solution (with a double copy) for now, so that PCSX2 doesn't crash when saving eyetoy data, which was above the fixed 64K previously reserved for USB devices.

### Rationale behind Changes

Closes #7689.

### Suggested Testing Steps

Test saving/loading state with USB devices, particularly eyetoy.
