### PR TITLE
UI: Fix selected tab from hotkeys menu shortcut

### DIFF
--- a/pcsx2-qt/Settings/ControllerSettingsDialog.cpp
+++ b/pcsx2-qt/Settings/ControllerSettingsDialog.cpp
@@ -82,7 +82,7 @@ void ControllerSettingsDialog::setCategory(Category category)
 			break;
 
 		case Category::HotkeySettings:
-			m_ui.settingsCategory->setCurrentRow(3);
+			m_ui.settingsCategory->setCurrentRow(5);
 			break;
 
 		default:


### PR DESCRIPTION
### Description of Changes
Corrects the tab it goes to when selecting Settings->Hotkeys

### Rationale behind Changes
Before USB was added it was tab 3, but now it's tab 5, but this wasn't updated to point to it, so Settings->Hotkeys went to the USB settings.

### Suggested Testing Steps
Test using the Settings menu
