### PR TITLE
Config: Add separate VU0/VU1 round/clamp mode options

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -1847,6 +1847,8 @@ SCED-50750:
 SCED-50781:
   name: "Destruction Derby Arenas [Beta]"
   region: "PAL-M5"
+  roundModes:
+    vu1RoundMode: 0 # Fixes tyre textures.
   gsHWFixes:
     halfPixelOffset: 2 # Corrects shadow position.
 SCED-50825:
@@ -3026,6 +3028,8 @@ SCES-50781:
   name: "Destruction Derby Arenas [Beta, Promo, & Full Retail]"
   region: "PAL-M6"
   compat: 5
+  roundModes:
+    vu1RoundMode: 0 # Fixes tyre textures.
   gsHWFixes:
     halfPixelOffset: 2 # Corrects shadow position.
 SCES-50791:
@@ -3425,6 +3429,8 @@ SCES-51977:
 SCES-51979:
   name: "Destruction Derby Arenas"
   region: "PAL-M6"
+  roundModes:
+    vu1RoundMode: 0 # Fixes tyre textures.
   gsHWFixes:
     halfPixelOffset: 2 # Corrects shadow position.
 SCES-52004:
@@ -43556,6 +43562,8 @@ SLUS-20855:
   name: "Destruction Derby Arenas"
   region: "NTSC-U"
   compat: 5
+  roundModes:
+    vu1RoundMode: 0 # Fixes tyre textures.
   gsHWFixes:
     halfPixelOffset: 2 # Corrects shadow position.
 SLUS-20856:

--- a/pcsx2-qt/Settings/AdvancedSettingsWidget.h
+++ b/pcsx2-qt/Settings/AdvancedSettingsWidget.h
@@ -30,9 +30,9 @@ public:
 	~AdvancedSettingsWidget();
 
 private:
-	int getGlobalClampingModeIndex(bool vu) const;
-	int getClampingModeIndex(bool vu) const;
-	void setClampingMode(bool vu, int index);
+	int getGlobalClampingModeIndex(int vunum) const;
+	int getClampingModeIndex(int vunum) const;
+	void setClampingMode(int vunum, int index);
 
 	SettingsDialog* m_dialog;
 

--- a/pcsx2-qt/Settings/AdvancedSettingsWidget.ui
+++ b/pcsx2-qt/Settings/AdvancedSettingsWidget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>628</width>
-    <height>375</height>
+    <width>809</width>
+    <height>647</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -36,8 +36,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>609</width>
-        <height>569</height>
+        <width>807</width>
+        <height>645</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout">
@@ -176,47 +176,15 @@
           <string>Vector Units (VU)</string>
          </property>
          <layout class="QGridLayout" name="gridLayout_3">
-          <item row="2" column="0" colspan="2">
-           <layout class="QGridLayout" name="gridLayout_6">
-            <item row="0" column="0">
-             <widget class="QCheckBox" name="vu0Recompiler">
-              <property name="text">
-               <string>Enable VU0 Recompiler (Micro Mode)</string>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="1">
-             <widget class="QCheckBox" name="vu1Recompiler">
-              <property name="text">
-               <string>Enable VU1 Recompiler</string>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="0">
-             <widget class="QCheckBox" name="vuFlagHack">
-              <property name="text">
-               <string>mVU Flag Hack</string>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="label_5">
+          <item row="2" column="0">
+           <widget class="QLabel" name="label_3">
             <property name="text">
-             <string>Clamping Mode:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="0">
-           <widget class="QLabel" name="label_6">
-            <property name="text">
-             <string>Rounding Mode:</string>
+             <string>VU1 Rounding Mode:</string>
             </property>
            </widget>
           </item>
           <item row="0" column="1">
-           <widget class="QComboBox" name="vuRoundingMode">
+           <widget class="QComboBox" name="vu0RoundingMode">
             <item>
              <property name="text">
               <string>Nearest</string>
@@ -239,8 +207,102 @@
             </item>
            </widget>
           </item>
+          <item row="4" column="0" colspan="2">
+           <layout class="QGridLayout" name="gridLayout_6">
+            <item row="1" column="0">
+             <widget class="QCheckBox" name="vuFlagHack">
+              <property name="text">
+               <string>mVU Flag Hack</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="QCheckBox" name="vu1Recompiler">
+              <property name="text">
+               <string>Enable VU1 Recompiler</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="0">
+             <widget class="QCheckBox" name="vu0Recompiler">
+              <property name="text">
+               <string>Enable VU0 Recompiler (Micro Mode)</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
           <item row="1" column="1">
-           <widget class="QComboBox" name="vuClampMode">
+           <widget class="QComboBox" name="vu0ClampMode">
+            <item>
+             <property name="text">
+              <string>None</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Normal (Default)</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Extra</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Extra + Preserve Sign</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_5">
+            <property name="text">
+             <string>VU0 Clamping Mode:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_6">
+            <property name="text">
+             <string>VU0 Rounding Mode:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="label_4">
+            <property name="text">
+             <string>VU1 Clamping Mode:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QComboBox" name="vu1RoundingMode">
+            <item>
+             <property name="text">
+              <string>Nearest</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Negative</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Positive</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Chop / Zero (Default)</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QComboBox" name="vu1ClampMode">
             <item>
              <property name="text">
               <string>None</string>

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -510,10 +510,16 @@ struct Pcsx2Config
 			EnableVU1 : 1;
 
 		bool
-			vuOverflow : 1,
-			vuExtraOverflow : 1,
-			vuSignOverflow : 1,
-			vuUnderflow : 1;
+			vu0Overflow : 1,
+			vu0ExtraOverflow : 1,
+			vu0SignOverflow : 1,
+			vu0Underflow : 1;
+
+		bool
+			vu1Overflow : 1,
+			vu1ExtraOverflow : 1,
+			vu1SignOverflow : 1,
+			vu1Underflow : 1;
 
 		bool
 			fpuOverflow : 1,
@@ -555,14 +561,7 @@ struct Pcsx2Config
 
 		u32 GetVUClampMode() const
 		{
-			return vuSignOverflow ? 3 : (vuExtraOverflow ? 2 : (vuOverflow ? 1 : 0));
-		}
-
-		void SetVUClampMode(u32 value)
-		{
-			vuOverflow = (value >= 1);
-			vuExtraOverflow = (value >= 2);
-			vuSignOverflow = (value >= 3);
+			return vu0SignOverflow ? 3 : (vu0ExtraOverflow ? 2 : (vu0Overflow ? 1 : 0));
 		}
 	};
 
@@ -572,7 +571,8 @@ struct Pcsx2Config
 		RecompilerOptions Recompiler;
 
 		SSE_MXCSR sseMXCSR;
-		SSE_MXCSR sseVUMXCSR;
+		SSE_MXCSR sseVU0MXCSR;
+		SSE_MXCSR sseVU1MXCSR;
 
 		u32 AffinityControlMode;
 
@@ -584,7 +584,7 @@ struct Pcsx2Config
 
 		bool operator==(const CpuOptions& right) const
 		{
-			return OpEqu(sseMXCSR) && OpEqu(sseVUMXCSR) && OpEqu(AffinityControlMode) && OpEqu(Recompiler);
+			return OpEqu(sseMXCSR) && OpEqu(sseVU0MXCSR) && OpEqu(sseVU1MXCSR) && OpEqu(AffinityControlMode) && OpEqu(Recompiler);
 		}
 
 		bool operator!=(const CpuOptions& right) const
@@ -1327,10 +1327,10 @@ namespace EmuFolders
 #define CHECK_FULLVU0SYNCHACK (EmuConfig.Gamefixes.FullVU0SyncHack)
 
 //------------ Advanced Options!!! ---------------
-#define CHECK_VU_OVERFLOW (EmuConfig.Cpu.Recompiler.vuOverflow)
-#define CHECK_VU_EXTRA_OVERFLOW (EmuConfig.Cpu.Recompiler.vuExtraOverflow) // If enabled, Operands are clamped before being used in the VU recs
-#define CHECK_VU_SIGN_OVERFLOW (EmuConfig.Cpu.Recompiler.vuSignOverflow)
-#define CHECK_VU_UNDERFLOW (EmuConfig.Cpu.Recompiler.vuUnderflow)
+#define CHECK_VU_OVERFLOW(vunum) (((vunum) == 0) ? EmuConfig.Cpu.Recompiler.vu0Overflow : EmuConfig.Cpu.Recompiler.vu1Overflow)
+#define CHECK_VU_EXTRA_OVERFLOW(vunum) (((vunum) == 0) ? EmuConfig.Cpu.Recompiler.vu0ExtraOverflow : EmuConfig.Cpu.Recompiler.vu1ExtraOverflow) // If enabled, Operands are clamped before being used in the VU recs
+#define CHECK_VU_SIGN_OVERFLOW(vunum) (((vunum) == 0) ? EmuConfig.Cpu.Recompiler.vu0SignOverflow : EmuConfig.Cpu.Recompiler.vu1SignOverflow)
+#define CHECK_VU_UNDERFLOW(vunum) (((vunum) == 0) ? EmuConfig.Cpu.Recompiler.vu0Underflow : EmuConfig.Cpu.Recompiler.vu1Underflow)
 
 #define CHECK_FPU_OVERFLOW (EmuConfig.Cpu.Recompiler.fpuOverflow)
 #define CHECK_FPU_EXTRA_OVERFLOW (EmuConfig.Cpu.Recompiler.fpuExtraOverflow) // If enabled, Operands are checked for infinities before being used in the FPU recs

--- a/pcsx2/Docs/gamedb-schema.json
+++ b/pcsx2/Docs/gamedb-schema.json
@@ -36,6 +36,16 @@
               "type": "integer",
               "minimum": 0,
               "maximum": 3
+            },
+            "vu0RoundMode": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 3
+            },
+            "vu1RoundMode": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 3
             }
           },
           "additionalProperties": false
@@ -51,6 +61,18 @@
               "maximum": 3
             },
             "vuClampMode": {
+              "type": "integer",
+              "description": "0 (Disables), 1 (Normally), 2 (Extra), 3 (Extra+Preserve Sign)",
+              "minimum": 0,
+              "maximum": 3
+            },
+            "vu0ClampMode": {
+              "type": "integer",
+              "description": "0 (Disables), 1 (Normally), 2 (Extra), 3 (Extra+Preserve Sign)",
+              "minimum": 0,
+              "maximum": 3
+            },
+            "vu1ClampMode": {
               "type": "integer",
               "description": "0 (Disables), 1 (Normally), 2 (Extra), 3 (Extra+Preserve Sign)",
               "minimum": 0,

--- a/pcsx2/Frontend/ImGuiOverlays.cpp
+++ b/pcsx2/Frontend/ImGuiOverlays.cpp
@@ -345,7 +345,7 @@ void ImGuiManager::DrawSettingsOverlay()
 		APPEND("MTVU ");
 
 	APPEND("EER={} EEC={} VUR={} VUC={} VQS={} ", static_cast<unsigned>(EmuConfig.Cpu.sseMXCSR.GetRoundMode()),
-		EmuConfig.Cpu.Recompiler.GetEEClampMode(), static_cast<unsigned>(EmuConfig.Cpu.sseVUMXCSR.GetRoundMode()),
+		EmuConfig.Cpu.Recompiler.GetEEClampMode(), static_cast<unsigned>(EmuConfig.Cpu.sseVU0MXCSR.GetRoundMode()),
 		EmuConfig.Cpu.Recompiler.GetVUClampMode(), EmuConfig.GS.VsyncQueueSize);
 
 	if (EmuConfig.EnableCheats || EmuConfig.EnableWideScreenPatches || EmuConfig.EnableNoInterlacingPatches)

--- a/pcsx2/GameDatabase.cpp
+++ b/pcsx2/GameDatabase.cpp
@@ -127,7 +127,20 @@ void GameDatabase::parseAndInsert(const std::string_view& serial, const c4::yml:
 		{
 			int vuVal = -1;
 			node["roundModes"]["vuRoundMode"] >> vuVal;
-			gameEntry.vuRoundMode = static_cast<GameDatabaseSchema::RoundMode>(vuVal);
+			gameEntry.vu0RoundMode = static_cast<GameDatabaseSchema::RoundMode>(vuVal);
+			gameEntry.vu1RoundMode = static_cast<GameDatabaseSchema::RoundMode>(vuVal);
+		}
+		if (node["roundModes"].has_child("vu0RoundMode"))
+		{
+			int vuVal = -1;
+			node["roundModes"]["vu0RoundMode"] >> vuVal;
+			gameEntry.vu0RoundMode = static_cast<GameDatabaseSchema::RoundMode>(vuVal);
+		}
+		if (node["roundModes"].has_child("vu1RoundMode"))
+		{
+			int vuVal = -1;
+			node["roundModes"]["vu1RoundMode"] >> vuVal;
+			gameEntry.vu1RoundMode = static_cast<GameDatabaseSchema::RoundMode>(vuVal);
 		}
 	}
 	if (node.has_child("clampModes"))
@@ -142,7 +155,20 @@ void GameDatabase::parseAndInsert(const std::string_view& serial, const c4::yml:
 		{
 			int vuVal = -1;
 			node["clampModes"]["vuClampMode"] >> vuVal;
-			gameEntry.vuClampMode = static_cast<GameDatabaseSchema::ClampMode>(vuVal);
+			gameEntry.vu0ClampMode = static_cast<GameDatabaseSchema::ClampMode>(vuVal);
+			gameEntry.vu1ClampMode = static_cast<GameDatabaseSchema::ClampMode>(vuVal);
+		}
+		if (node["clampModes"].has_child("vu0ClampMode"))
+		{
+			int vuVal = -1;
+			node["clampModes"]["vu0ClampMode"] >> vuVal;
+			gameEntry.vu0ClampMode = static_cast<GameDatabaseSchema::ClampMode>(vuVal);
+		}
+		if (node["clampModes"].has_child("vu1ClampMode"))
+		{
+			int vuVal = -1;
+			node["clampModes"]["vu1ClampMode"] >> vuVal;
+			gameEntry.vu1ClampMode = static_cast<GameDatabaseSchema::ClampMode>(vuVal);
 		}
 	}
 
@@ -378,19 +404,35 @@ u32 GameDatabaseSchema::GameEntry::applyGameFixes(Pcsx2Config& config, bool appl
 		}
 	}
 
-	if (vuRoundMode != GameDatabaseSchema::RoundMode::Undefined)
+	if (vu0RoundMode != GameDatabaseSchema::RoundMode::Undefined)
 	{
-		const SSE_RoundMode vuRM = (SSE_RoundMode)enum_cast(vuRoundMode);
+		const SSE_RoundMode vuRM = (SSE_RoundMode)enum_cast(vu0RoundMode);
 		if (EnumIsValid(vuRM))
 		{
 			if (applyAuto)
 			{
-				PatchesCon->WriteLn("(GameDB) Changing VU0/VU1 roundmode to %d [%s]", vuRM, EnumToString(vuRM));
-				config.Cpu.sseVUMXCSR.SetRoundMode(vuRM);
+				PatchesCon->WriteLn("(GameDB) Changing VU0 roundmode to %d [%s]", vuRM, EnumToString(vuRM));
+				config.Cpu.sseVU0MXCSR.SetRoundMode(vuRM);
 				num_applied_fixes++;
 			}
 			else
-				PatchesCon->Warning("[GameDB] Skipping changing VU0/VU1 roundmode to %d [%s]", vuRM, EnumToString(vuRM));
+				PatchesCon->Warning("[GameDB] Skipping changing VU0 roundmode to %d [%s]", vuRM, EnumToString(vuRM));
+		}
+	}
+
+	if (vu1RoundMode != GameDatabaseSchema::RoundMode::Undefined)
+	{
+		const SSE_RoundMode vuRM = (SSE_RoundMode)enum_cast(vu1RoundMode);
+		if (EnumIsValid(vuRM))
+		{
+			if (applyAuto)
+			{
+				PatchesCon->WriteLn("(GameDB) Changing VU1 roundmode to %d [%s]", vuRM, EnumToString(vuRM));
+				config.Cpu.sseVU1MXCSR.SetRoundMode(vuRM);
+				num_applied_fixes++;
+			}
+			else
+				PatchesCon->Warning("[GameDB] Skipping changing VU1 roundmode to %d [%s]", vuRM, EnumToString(vuRM));
 		}
 	}
 
@@ -409,19 +451,34 @@ u32 GameDatabaseSchema::GameEntry::applyGameFixes(Pcsx2Config& config, bool appl
 			PatchesCon->Warning("[GameDB] Skipping changing EE/FPU clamp mode [mode=%d]", clampMode);
 	}
 
-	if (vuClampMode != GameDatabaseSchema::ClampMode::Undefined)
+	if (vu0ClampMode != GameDatabaseSchema::ClampMode::Undefined)
 	{
-		const int clampMode = enum_cast(vuClampMode);
+		const int clampMode = enum_cast(vu0ClampMode);
 		if (applyAuto)
 		{
-			PatchesCon->WriteLn("(GameDB) Changing VU0/VU1 clamp mode [mode=%d]", clampMode);
-			config.Cpu.Recompiler.vuOverflow = (clampMode >= 1);
-			config.Cpu.Recompiler.vuExtraOverflow = (clampMode >= 2);
-			config.Cpu.Recompiler.vuSignOverflow = (clampMode >= 3);
+			PatchesCon->WriteLn("(GameDB) Changing VU0 clamp mode [mode=%d]", clampMode);
+			config.Cpu.Recompiler.vu0Overflow = (clampMode >= 1);
+			config.Cpu.Recompiler.vu0ExtraOverflow = (clampMode >= 2);
+			config.Cpu.Recompiler.vu0SignOverflow = (clampMode >= 3);
 			num_applied_fixes++;
 		}
 		else
-			PatchesCon->Warning("[GameDB] Skipping changing VU0/VU1 clamp mode [mode=%d]", clampMode);
+			PatchesCon->Warning("[GameDB] Skipping changing VU0 clamp mode [mode=%d]", clampMode);
+	}
+
+	if (vu1ClampMode != GameDatabaseSchema::ClampMode::Undefined)
+	{
+		const int clampMode = enum_cast(vu1ClampMode);
+		if (applyAuto)
+		{
+			PatchesCon->WriteLn("(GameDB) Changing VU1 clamp mode [mode=%d]", clampMode);
+			config.Cpu.Recompiler.vu1Overflow = (clampMode >= 1);
+			config.Cpu.Recompiler.vu1ExtraOverflow = (clampMode >= 2);
+			config.Cpu.Recompiler.vu1SignOverflow = (clampMode >= 3);
+			num_applied_fixes++;
+		}
+		else
+			PatchesCon->Warning("[GameDB] Skipping changing VU1 clamp mode [mode=%d]", clampMode);
 	}
 
 	// TODO - config - this could be simplified with maps instead of bitfields and enums

--- a/pcsx2/GameDatabase.h
+++ b/pcsx2/GameDatabase.h
@@ -95,9 +95,11 @@ namespace GameDatabaseSchema
 		std::string region;
 		Compatibility compat = Compatibility::Unknown;
 		RoundMode eeRoundMode = RoundMode::Undefined;
-		RoundMode vuRoundMode = RoundMode::Undefined;
+		RoundMode vu0RoundMode = RoundMode::Undefined;
+		RoundMode vu1RoundMode = RoundMode::Undefined;
 		ClampMode eeClampMode = ClampMode::Undefined;
-		ClampMode vuClampMode = ClampMode::Undefined;
+		ClampMode vu0ClampMode = ClampMode::Undefined;
+		ClampMode vu1ClampMode = ClampMode::Undefined;
 		std::vector<GamefixId> gameFixes;
 		std::vector<std::pair<SpeedhackId, int>> speedHacks;
 		std::vector<std::pair<GSHWFixId, s32>> gsHWFixes;

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -210,10 +210,14 @@ Pcsx2Config::RecompilerOptions::RecompilerOptions()
 	EnableFastmem = true;
 
 	// vu and fpu clamping default to standard overflow.
-	vuOverflow = true;
-	//vuExtraOverflow = false;
-	//vuSignOverflow = false;
-	//vuUnderflow = false;
+	vu0Overflow = true;
+	//vu0ExtraOverflow = false;
+	//vu0SignOverflow = false;
+	//vu0Underflow = false;
+	vu1Overflow = true;
+	//vu1ExtraOverflow = false;
+	//vu1SignOverflow = false;
+	//vu1Underflow = false;
 
 	fpuOverflow = true;
 	//fpuExtraOverflow = false;
@@ -240,18 +244,34 @@ void Pcsx2Config::RecompilerOptions::ApplySanityCheck()
 
 	bool vuIsOk = true;
 
-	if (vuExtraOverflow)
-		vuIsOk = vuIsOk && vuOverflow;
-	if (vuSignOverflow)
-		vuIsOk = vuIsOk && vuExtraOverflow;
+	if (vu0ExtraOverflow)
+		vuIsOk = vuIsOk && vu0Overflow;
+	if (vu0SignOverflow)
+		vuIsOk = vuIsOk && vu0ExtraOverflow;
 
 	if (!vuIsOk)
 	{
 		// Values are wonky; assume the defaults.
-		vuOverflow = RecompilerOptions().vuOverflow;
-		vuExtraOverflow = RecompilerOptions().vuExtraOverflow;
-		vuSignOverflow = RecompilerOptions().vuSignOverflow;
-		vuUnderflow = RecompilerOptions().vuUnderflow;
+		vu0Overflow = RecompilerOptions().vu0Overflow;
+		vu0ExtraOverflow = RecompilerOptions().vu0ExtraOverflow;
+		vu0SignOverflow = RecompilerOptions().vu0SignOverflow;
+		vu0Underflow = RecompilerOptions().vu0Underflow;
+	}
+
+	vuIsOk = true;
+
+	if (vu1ExtraOverflow)
+		vuIsOk = vuIsOk && vu1Overflow;
+	if (vu1SignOverflow)
+		vuIsOk = vuIsOk && vu1ExtraOverflow;
+
+	if (!vuIsOk)
+	{
+		// Values are wonky; assume the defaults.
+		vu1Overflow = RecompilerOptions().vu1Overflow;
+		vu1ExtraOverflow = RecompilerOptions().vu1ExtraOverflow;
+		vu1SignOverflow = RecompilerOptions().vu1SignOverflow;
+		vu1Underflow = RecompilerOptions().vu1Underflow;
 	}
 }
 
@@ -266,10 +286,14 @@ void Pcsx2Config::RecompilerOptions::LoadSave(SettingsWrapper& wrap)
 	SettingsWrapBitBool(EnableVU1);
 	SettingsWrapBitBool(EnableFastmem);
 
-	SettingsWrapBitBool(vuOverflow);
-	SettingsWrapBitBool(vuExtraOverflow);
-	SettingsWrapBitBool(vuSignOverflow);
-	SettingsWrapBitBool(vuUnderflow);
+	SettingsWrapBitBool(vu0Overflow);
+	SettingsWrapBitBool(vu0ExtraOverflow);
+	SettingsWrapBitBool(vu0SignOverflow);
+	SettingsWrapBitBool(vu0Underflow);
+	SettingsWrapBitBool(vu1Overflow);
+	SettingsWrapBitBool(vu1ExtraOverflow);
+	SettingsWrapBitBool(vu1SignOverflow);
+	SettingsWrapBitBool(vu1Underflow);
 
 	SettingsWrapBitBool(fpuOverflow);
 	SettingsWrapBitBool(fpuExtraOverflow);
@@ -287,14 +311,16 @@ bool Pcsx2Config::CpuOptions::CpusChanged(const CpuOptions& right) const
 Pcsx2Config::CpuOptions::CpuOptions()
 {
 	sseMXCSR.bitmask = DEFAULT_sseMXCSR;
-	sseVUMXCSR.bitmask = DEFAULT_sseVUMXCSR;
+	sseVU0MXCSR.bitmask = DEFAULT_sseVUMXCSR;
+	sseVU1MXCSR.bitmask = DEFAULT_sseVUMXCSR;
 	AffinityControlMode = 0;
 }
 
 void Pcsx2Config::CpuOptions::ApplySanityCheck()
 {
 	sseMXCSR.ClearExceptionFlags().DisableExceptions();
-	sseVUMXCSR.ClearExceptionFlags().DisableExceptions();
+	sseVU0MXCSR.ClearExceptionFlags().DisableExceptions();
+	sseVU1MXCSR.ClearExceptionFlags().DisableExceptions();
 	AffinityControlMode = std::min<u32>(AffinityControlMode, 6);
 
 	Recompiler.ApplySanityCheck();
@@ -309,9 +335,12 @@ void Pcsx2Config::CpuOptions::LoadSave(SettingsWrapper& wrap)
 	SettingsWrapBitfieldEx(sseMXCSR.RoundingControl, "FPU.Roundmode");
 	SettingsWrapEntry(AffinityControlMode);
 
-	SettingsWrapBitBoolEx(sseVUMXCSR.DenormalsAreZero, "VU.DenormalsAreZero");
-	SettingsWrapBitBoolEx(sseVUMXCSR.FlushToZero, "VU.FlushToZero");
-	SettingsWrapBitfieldEx(sseVUMXCSR.RoundingControl, "VU.Roundmode");
+	SettingsWrapBitBoolEx(sseVU0MXCSR.DenormalsAreZero, "VU0.DenormalsAreZero");
+	SettingsWrapBitBoolEx(sseVU0MXCSR.FlushToZero, "VU0.FlushToZero");
+	SettingsWrapBitfieldEx(sseVU0MXCSR.RoundingControl, "VU0.Roundmode");
+	SettingsWrapBitBoolEx(sseVU1MXCSR.DenormalsAreZero, "VU1.DenormalsAreZero");
+	SettingsWrapBitBoolEx(sseVU1MXCSR.FlushToZero, "VU1.FlushToZero");
+	SettingsWrapBitfieldEx(sseVU1MXCSR.RoundingControl, "VU1.Roundmode");
 
 	Recompiler.LoadSave(wrap);
 }

--- a/pcsx2/System.cpp
+++ b/pcsx2/System.cpp
@@ -37,16 +37,18 @@
 extern R5900cpu GSDumpReplayerCpu;
 
 SSE_MXCSR g_sseMXCSR   = {DEFAULT_sseMXCSR};
-SSE_MXCSR g_sseVUMXCSR = {DEFAULT_sseVUMXCSR};
+SSE_MXCSR g_sseVU0MXCSR = {DEFAULT_sseVUMXCSR};
+SSE_MXCSR g_sseVU1MXCSR = {DEFAULT_sseVUMXCSR};
 
 // SetCPUState -- for assignment of SSE roundmodes and clampmodes.
 //
-void SetCPUState(SSE_MXCSR sseMXCSR, SSE_MXCSR sseVUMXCSR)
+void SetCPUState(SSE_MXCSR sseMXCSR, SSE_MXCSR sseVU0MXCSR, SSE_MXCSR sseVU1MXCSR)
 {
 	//Msgbox::Alert("SetCPUState: Config.sseMXCSR = %x; Config.sseVUMXCSR = %x \n", Config.sseMXCSR, Config.sseVUMXCSR);
 
 	g_sseMXCSR   = sseMXCSR.ApplyReserveMask();
-	g_sseVUMXCSR = sseVUMXCSR.ApplyReserveMask();
+	g_sseVU0MXCSR = sseVU0MXCSR.ApplyReserveMask();
+	g_sseVU1MXCSR = sseVU1MXCSR.ApplyReserveMask();
 
 	_mm_setcsr(g_sseMXCSR.bitmask);
 }

--- a/pcsx2/System.h
+++ b/pcsx2/System.h
@@ -146,5 +146,5 @@ extern std::string SysGetDiscID();
 
 extern SysMainMemory& GetVmMemory();
 
-extern void SetCPUState(SSE_MXCSR sseMXCSR, SSE_MXCSR sseVUMXCSR);
-extern SSE_MXCSR g_sseVUMXCSR, g_sseMXCSR;
+extern void SetCPUState(SSE_MXCSR sseMXCSR, SSE_MXCSR sseVU0MXCSR, SSE_MXCSR sseVU1MXCSR);
+extern SSE_MXCSR g_sseVU0MXCSR, g_sseVU1MXCSR, g_sseMXCSR;

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -1036,7 +1036,7 @@ bool VMManager::Initialize(VMBootParameters boot_params)
 
 	s_cpu_implementation_changed = false;
 	s_cpu_provider_pack->ApplyConfig();
-	SetCPUState(EmuConfig.Cpu.sseMXCSR, EmuConfig.Cpu.sseVUMXCSR);
+	SetCPUState(EmuConfig.Cpu.sseMXCSR, EmuConfig.Cpu.sseVU0MXCSR, EmuConfig.Cpu.sseVU1MXCSR);
 	SysClearExecutionCache();
 	memBindConditionalHandlers();
 
@@ -1635,7 +1635,7 @@ void VMManager::CheckForCPUConfigChanges(const Pcsx2Config& old_config)
 	}
 
 	Console.WriteLn("Updating CPU configuration...");
-	SetCPUState(EmuConfig.Cpu.sseMXCSR, EmuConfig.Cpu.sseVUMXCSR);
+	SetCPUState(EmuConfig.Cpu.sseMXCSR, EmuConfig.Cpu.sseVU0MXCSR, EmuConfig.Cpu.sseVU1MXCSR);
 	SysClearExecutionCache();
 	memBindConditionalHandlers();
 
@@ -1950,14 +1950,17 @@ void VMManager::WarnAboutUnsafeSettings()
 		messages += ICON_FA_FIRST_AID " CRC Fix Level is not set to default, this may break effects in some games.\n";
 	if (EmuConfig.GS.HWDownloadMode != GSHardwareDownloadMode::Enabled)
 		messages += ICON_FA_DOWNLOAD " Hardware Download Mode is not set to Accurate, this may break rendering in some games.\n";
-	if (EmuConfig.Cpu.sseMXCSR.GetRoundMode() != SSEround_Chop || EmuConfig.Cpu.sseVUMXCSR.GetRoundMode() != SSEround_Chop)
+	if (EmuConfig.Cpu.sseMXCSR.GetRoundMode() != SSEround_Chop)
 		messages += ICON_FA_MICROCHIP " EE FPU Round Mode is not set to default, this may break some games.\n";
 	if (!EmuConfig.Cpu.Recompiler.fpuOverflow || EmuConfig.Cpu.Recompiler.fpuExtraOverflow || EmuConfig.Cpu.Recompiler.fpuFullMode)
 		messages += ICON_FA_MICROCHIP " EE FPU Clamp Mode is not set to default, this may break some games.\n";
-	if (EmuConfig.Cpu.sseVUMXCSR.GetRoundMode() != SSEround_Chop)
+	if (EmuConfig.Cpu.sseVU0MXCSR.GetRoundMode() != SSEround_Chop || EmuConfig.Cpu.sseVU1MXCSR.GetRoundMode() != SSEround_Chop)
 		messages += ICON_FA_MICROCHIP " VU Round Mode is not set to default, this may break some games.\n";
-	if (!EmuConfig.Cpu.Recompiler.vuOverflow || EmuConfig.Cpu.Recompiler.vuExtraOverflow || EmuConfig.Cpu.Recompiler.vuSignOverflow)
+	if (!EmuConfig.Cpu.Recompiler.vu0Overflow || EmuConfig.Cpu.Recompiler.vu0ExtraOverflow || EmuConfig.Cpu.Recompiler.vu0SignOverflow ||
+		!EmuConfig.Cpu.Recompiler.vu1Overflow || EmuConfig.Cpu.Recompiler.vu1ExtraOverflow || EmuConfig.Cpu.Recompiler.vu1SignOverflow)
+	{
 		messages += ICON_FA_MICROCHIP " VU Clamp Mode is not set to default, this may break some games.\n";
+	}
 	if (!EmuConfig.EnableGameFixes)
 		messages += ICON_FA_GAMEPAD " Game Fixes are not enabled. Compatibility with some games may be affected.\n";
 	if (!EmuConfig.EnablePatches)

--- a/pcsx2/VU0microInterp.cpp
+++ b/pcsx2/VU0microInterp.cpp
@@ -268,7 +268,7 @@ void InterpVU0::Step()
 void InterpVU0::Execute(u32 cycles)
 {
 	const int originalRounding = fegetround();
-	fesetround(g_sseVUMXCSR.RoundingControl << 8);
+	fesetround(g_sseVU0MXCSR.RoundingControl << 8);
 
 	VU0.VI[REG_TPC].UL <<= 3;
 	VU0.flags &= ~VUFLAG_MFLAGSET;

--- a/pcsx2/VU1microInterp.cpp
+++ b/pcsx2/VU1microInterp.cpp
@@ -273,7 +273,7 @@ void InterpVU1::Step()
 void InterpVU1::Execute(u32 cycles)
 {
 	const int originalRounding = fegetround();
-	fesetround(g_sseVUMXCSR.RoundingControl << 8);
+	fesetround(g_sseVU1MXCSR.RoundingControl << 8);
 
 	VU1.VI[REG_TPC].UL <<= 3;
 	u32 startcycles = VU1.cycle;

--- a/pcsx2/VUflags.cpp
+++ b/pcsx2/VUflags.cpp
@@ -49,7 +49,7 @@ static __ri u32 VU_MAC_UPDATE( int shift, VURegs * VU, float f )
 			return s;
 		case 255:
 			VU->macflag = (VU->macflag&~(0x0101<<shift)) | (0x1000<<shift);
-			if (CHECK_VU_OVERFLOW)
+			if (CHECK_VU_OVERFLOW((VU == &VU1) ? 1 : 0))
 				return s | 0x7f7fffff; /* max allowed */
 			else
 				return v;

--- a/pcsx2/VUops.cpp
+++ b/pcsx2/VUops.cpp
@@ -459,7 +459,7 @@ static float vuDouble(u32 f)
 			return *(float*)&f;
 			break;
 		case 0x7f800000:
-			if (CHECK_VU_OVERFLOW)
+			if (CHECK_VU_OVERFLOW(0))
 			{
 				u32 d = (f & 0x80000000) | 0x7f7fffff;
 				return *(float*)&d;

--- a/pcsx2/x86/microVU_Clamp.inl
+++ b/pcsx2/x86/microVU_Clamp.inl
@@ -36,7 +36,7 @@ alignas(16) const u32 sse4_maxvals[2][4] = {
 // and its faster... so just always make NaNs into positive infinity.
 void mVUclamp1(microVU& mVU, const xmm& reg, const xmm& regT1, int xyzw, bool bClampE = 0)
 {
-	if (((!clampE && CHECK_VU_OVERFLOW) || (clampE && bClampE)) && mVU.regAlloc->checkVFClamp(reg.Id))
+	if (((!clampE && CHECK_VU_OVERFLOW(mVU.index)) || (clampE && bClampE)) && mVU.regAlloc->checkVFClamp(reg.Id))
 	{
 		switch (xyzw)
 		{
@@ -59,7 +59,7 @@ void mVUclamp1(microVU& mVU, const xmm& reg, const xmm& regT1, int xyzw, bool bC
 // so we just use a temporary mem location for our backup for now... (non-sse4 version only)
 void mVUclamp2(microVU& mVU, const xmm& reg, const xmm& regT1in, int xyzw, bool bClampE = 0)
 {
-	if (((!clampE && CHECK_VU_SIGN_OVERFLOW) || (clampE && bClampE && CHECK_VU_SIGN_OVERFLOW)) && mVU.regAlloc->checkVFClamp(reg.Id))
+	if (((!clampE && CHECK_VU_SIGN_OVERFLOW(mVU.index)) || (clampE && bClampE && CHECK_VU_SIGN_OVERFLOW(mVU.index))) && mVU.regAlloc->checkVFClamp(reg.Id))
 	{
 		int i = (xyzw == 1 || xyzw == 2 || xyzw == 4 || xyzw == 8) ? 0 : 1;
 		xPMIN.SD(reg, ptr128[&sse4_maxvals[i][0]]);
@@ -85,6 +85,6 @@ void mVUclamp3(microVU& mVU, const xmm& reg, const xmm& regT1, int xyzw)
 // but this clamp is just a precaution just-in-case.
 void mVUclamp4(microVU& mVU, const xmm& reg, const xmm& regT1, int xyzw)
 {
-	if (clampE && !CHECK_VU_SIGN_OVERFLOW && mVU.regAlloc->checkVFClamp(reg.Id))
+	if (clampE && !CHECK_VU_SIGN_OVERFLOW(mVU.index) && mVU.regAlloc->checkVFClamp(reg.Id))
 		mVUclamp1(mVU, reg, regT1, xyzw, 1);
 }

--- a/pcsx2/x86/microVU_Compile.inl
+++ b/pcsx2/x86/microVU_Compile.inl
@@ -156,7 +156,7 @@ void doIbit(mV)
 		else
 		{
 			u32 tempI;
-			if (CHECK_VU_OVERFLOW && ((curI & 0x7fffffff) >= 0x7f800000))
+			if (CHECK_VU_OVERFLOW(mVU.index) && ((curI & 0x7fffffff) >= 0x7f800000))
 			{
 				DevCon.WriteLn(Color_Green, "microVU%d: Clamping I Reg", mVU.index);
 				tempI = (0x80000000 & curI) | 0x7f7fffff; // Clamp I Reg

--- a/pcsx2/x86/microVU_Execute.inl
+++ b/pcsx2/x86/microVU_Execute.inl
@@ -32,7 +32,7 @@ void mVUdispatcherAB(mV)
 		else        xFastCall((void*)mVUexecuteVU1, arg1reg, arg2reg);
 
 		// Load VU's MXCSR state
-		xLDMXCSR(g_sseVUMXCSR);
+		xLDMXCSR(isVU0 ? g_sseVU0MXCSR : g_sseVU1MXCSR);
 
 		// Load Regs
 		xMOVAPS (xmmT1, ptr128[&mVU.regs().VI[REG_P].UL]);
@@ -94,7 +94,7 @@ void mVUdispatcherCD(mV)
 		xScopedStackFrame frame(false, true);
 
 		// Load VU's MXCSR state
-		xLDMXCSR(g_sseVUMXCSR);
+		xLDMXCSR(isVU0 ? g_sseVU0MXCSR : g_sseVU1MXCSR);
 
 		mVUrestoreRegs(mVU);
 		xMOV(gprF0, ptr32[&mVU.regs().micro_statusflags[0]]);

--- a/pcsx2/x86/microVU_Lower.inl
+++ b/pcsx2/x86/microVU_Lower.inl
@@ -101,7 +101,7 @@ mVUop(mVU_SQRT)
 		xMOV(ptr32[&mVU.divFlag], 0); // Clear I/D flags
 		testNeg(mVU, Ft, gprT1); // Check for negative sqrt
 
-		if (CHECK_VU_OVERFLOW) // Clamp infinities (only need to do positive clamp since xmmFt is positive)
+		if (CHECK_VU_OVERFLOW(mVU.index)) // Clamp infinities (only need to do positive clamp since xmmFt is positive)
 			xMIN.SS(Ft, ptr32[mVUglob.maxvals]);
 		xSQRT.SS(Ft, Ft);
 		writeQreg(Ft, mVUinfo.writeQ);

--- a/pcsx2/x86/microVU_Misc.h
+++ b/pcsx2/x86/microVU_Misc.h
@@ -239,7 +239,7 @@ typedef u32 (*mVUCall)(void*, void*);
 #define Rmem         &mVU.regs().VI[REG_R].UL
 #define aWrap(x, m)  ((x > m) ? 0 : x)
 #define shuffleSS(x) ((x == 1) ? (0x27) : ((x == 2) ? (0xc6) : ((x == 4) ? (0xe1) : (0xe4))))
-#define clampE       CHECK_VU_EXTRA_OVERFLOW
+#define clampE       CHECK_VU_EXTRA_OVERFLOW(mVU.index)
 #define varPrint(x)  DevCon.WriteLn(#x " = %d", (int)x)
 #define islowerOP    ((iPC & 1) == 0)
 

--- a/pcsx2/x86/microVU_Upper.inl
+++ b/pcsx2/x86/microVU_Upper.inl
@@ -205,7 +205,7 @@ static void setupFtReg(microVU& mVU, xmm& Ft, xmm& tempFt, int opCase, int clamp
 	opCase1
 	{
 		// Based on mVUclamp2 -> mVUclamp1 below.
-		const bool willClamp = (clampE || ((clampType & cFt) && !clampE && (CHECK_VU_OVERFLOW || CHECK_VU_SIGN_OVERFLOW)));
+		const bool willClamp = (clampE || ((clampType & cFt) && !clampE && (CHECK_VU_OVERFLOW(mVU.index) || CHECK_VU_SIGN_OVERFLOW(mVU.index))));
 
 		if (_XYZW_SS2)      { Ft = mVU.regAlloc->allocReg(_Ft_, 0, _X_Y_Z_W); tempFt = Ft; }
 		else if (willClamp) { Ft = mVU.regAlloc->allocReg(_Ft_, 0, 0xf);      tempFt = Ft; }


### PR DESCRIPTION
### Description of Changes

As discussed in #7241.

~Untested apart from checking the config loads as expected. Not complete, the big picture UI hasn't been updated, nor have the ints for clamping.~

~Also has no gamedb support yet.~

Note that when testing you'll probably want to disable game fixes (also in the advanced tab), to stop the existing gamedb overriding it (if any). Confirm in the console/log that the correct settings are being applied.

### Rationale behind Changes

#7241.

### Suggested Testing Steps

None at the moment.

Closes #5188
