### PR TITLE
CDVD: fix compilation if DISABLE_RECORDING is defined.

### DIFF
--- a/pcsx2/CDVD/CDVD.cpp
+++ b/pcsx2/CDVD/CDVD.cpp
@@ -870,6 +870,7 @@ void cdvdReset()
 	cdvd.Action = cdvdAction_None;
 	cdvd.ReadTime = cdvdBlockReadTime(MODE_DVDROM);
 
+#ifndef DISABLE_RECORDING
 	// If we are recording, always use the same RTC setting
 	// for games that use the RTC to seed their RNG -- this is very important to be the same everytime!
 	if (g_InputRecording.isActive())
@@ -886,6 +887,7 @@ void cdvdReset()
 	}
 	else
 	{
+#endif
 		// CDVD internally uses GMT+9.  If you think the time's wrong, you're wrong.
 		// Set up your time zone and winter/summer in the BIOS.  No PS2 BIOS I know of features automatic DST.
 		const std::time_t utc_time = std::time(nullptr);
@@ -902,7 +904,9 @@ void cdvdReset()
 		cdvd.RTC.day = (u8)curtime.tm_mday;
 		cdvd.RTC.month = (u8)curtime.tm_mon + 1; // WX returns Jan as "0"
 		cdvd.RTC.year = (u8)(curtime.tm_year - 100); // offset from 2000
+#ifndef DISABLE_RECORDING
 	}
+#endif
 
 	g_GameStarted = false;
 	g_GameLoading = false;


### PR DESCRIPTION
### Description of Changes
This makes it so that CDVD can compile if the `DISABLE_RECORDING` macro is defined.

### Rationale behind Changes
If `DISABLE_RECORDING` was defined, the header `"Recording/InputRecording.h"` would not be included, but the code still expected `g_InputRecording` to be defined.

### Suggested Testing Steps
None that I can think of.