### PR TITLE
D3D12/Texture: Fix crash when upload buffer exhausts

### DIFF
--- a/common/D3D12/Texture.cpp
+++ b/common/D3D12/Texture.cpp
@@ -26,11 +26,6 @@
 
 using namespace D3D12;
 
-// Somehow NOMINMAX isn't getting set for CMake builds...
-#ifdef min
-#undef min
-#endif
-
 Texture::Texture() = default;
 
 Texture::Texture(ID3D12Resource* resource, D3D12_RESOURCE_STATES state)
@@ -349,7 +344,7 @@ ID3D12GraphicsCommandList* Texture::BeginStreamUpdate(ID3D12GraphicsCommandList*
 		}
 
 		// cmdlist change
-		return g_d3d12_context->GetInitCommandList();
+		cmdlist = g_d3d12_context->GetInitCommandList();
 	}
 
 	*out_data = g_d3d12_context->GetTextureStreamBuffer().GetCurrentHostPointer();


### PR DESCRIPTION
### Description of Changes

Return instead of changing the variable, meant the pitch wasn't initialized and it'd crash.

### Rationale behind Changes

Crashes are bad.

### Suggested Testing Steps

Easiest way to test is by spamming window resize in big picture mode, but unless your resolution is high, might not be able to trigger the crash.