### PR TITLE
GameDB: Add fixes for Robin Hood 2 - The Siege

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -18630,6 +18630,9 @@ SLES-54120:
 SLES-54122:
   name: "Robin Hood 2 - The Siege"
   region: "PAL-E"
+  gameFixes:
+    - GIFFIFOHack # Partially fixes PATH3 Masking timing, not enough on its own.
+    - EETimingHack # Massages the timing slightly further to make it work okay.
 SLES-54123:
   name: "Marvel - Ultimate Alliance"
   region: "PAL-E-I"


### PR DESCRIPTION
### Description of Changes
Adds timing fixes for Robin Hood 2 - The Siege

### Rationale behind Changes
Game is broken, this combination of things seems to be enough to make it mostly work.

### Suggested Testing Steps
Watch CI

![image](https://user-images.githubusercontent.com/6278726/209785693-7570d356-4d71-42d6-bfe4-aeb5f73abe3a.png)

