### PR TITLE
VIF: Make sure VU's are updated when waiting

### DIFF
--- a/pcsx2/Vif0_Dma.cpp
+++ b/pcsx2/Vif0_Dma.cpp
@@ -136,6 +136,10 @@ __fi void vif0SetupTransfer()
 
 __fi void vif0VUFinish()
 {
+	// Sync up VU0 so we don't errantly wait.
+	while ((static_cast<int>(cpuRegs.cycle) - static_cast<int>(VU0.cycle)) > 0 && (VU0.VI[REG_VPU_STAT].UL & 0x1))
+		CpuVU0->ExecuteBlock();
+
 	if (VU0.VI[REG_VPU_STAT].UL & 0x5)
 	{
 		CPU_INT(VIF_VU0_FINISH, 128);

--- a/pcsx2/Vif1_Dma.cpp
+++ b/pcsx2/Vif1_Dma.cpp
@@ -229,6 +229,10 @@ __fi void vif1SetupTransfer()
 
 __fi void vif1VUFinish()
 {
+	// Sync up VU1 so we don't errantly wait.
+	while (!THREAD_VU1 && (static_cast<int>(cpuRegs.cycle) - static_cast<int>(VU1.cycle)) > 0 && (VU0.VI[REG_VPU_STAT].UL & 0x100))
+		CpuVU1->ExecuteBlock();
+
 	if (VU0.VI[REG_VPU_STAT].UL & 0x500)
 	{
 		vu1Thread.Get_MTVUChanges();


### PR DESCRIPTION
### Description of Changes
Updates the VU's before waiting for them.

### Rationale behind Changes
Could cause unnecessary delays when Instant VU is off, since the DMA's run before the VU's do, and if the game is running tons of tiny VU programs which are only a few cycles long, we could be inadvertantly waiting too long and wasting cycles.

### Suggested Testing Steps
Test games such as Parappa the Rapper, and random stuff with MTVU disabled.

Fixes #7608