### PR TITLE
VIF: use outer cast in VU cycle checks

### DIFF
--- a/pcsx2/Vif0_Dma.cpp
+++ b/pcsx2/Vif0_Dma.cpp
@@ -137,7 +137,7 @@ __fi void vif0SetupTransfer()
 __fi void vif0VUFinish()
 {
 	// Sync up VU0 so we don't errantly wait.
-	while ((static_cast<int>(cpuRegs.cycle) - static_cast<int>(VU0.cycle)) > 0 && (VU0.VI[REG_VPU_STAT].UL & 0x1))
+	while (static_cast<int>(cpuRegs.cycle - VU0.cycle) > 0 && (VU0.VI[REG_VPU_STAT].UL & 0x1))
 		CpuVU0->ExecuteBlock();
 
 	if (VU0.VI[REG_VPU_STAT].UL & 0x5)

--- a/pcsx2/Vif1_Dma.cpp
+++ b/pcsx2/Vif1_Dma.cpp
@@ -230,7 +230,7 @@ __fi void vif1SetupTransfer()
 __fi void vif1VUFinish()
 {
 	// Sync up VU1 so we don't errantly wait.
-	while (!THREAD_VU1 && (static_cast<int>(cpuRegs.cycle) - static_cast<int>(VU1.cycle)) > 0 && (VU0.VI[REG_VPU_STAT].UL & 0x100))
+	while (!THREAD_VU1 && static_cast<int>(cpuRegs.cycle - VU1.cycle) > 0 && (VU0.VI[REG_VPU_STAT].UL & 0x100))
 		CpuVU1->ExecuteBlock();
 
 	if (VU0.VI[REG_VPU_STAT].UL & 0x500)


### PR DESCRIPTION
### Description of Changes
do casting outside of calculation

### Rationale behind Changes
For some reason it wasn't working on linux, so just doing it like everywhere else.

### Suggested Testing Steps
Test Parappa the Rapper 2 on linux.

Fixes #7723 