### PR TITLE
USB: Limit microphone lower latency to 1ms

### DIFF
--- a/pcsx2/USB/usb-mic/usb-headset.cpp
+++ b/pcsx2/USB/usb-mic/usb-headset.cpp
@@ -1000,9 +1000,9 @@ namespace usb_mic
 				nullptr, nullptr, nullptr, nullptr, &AudioDevice::GetInputDeviceList},
 			{SettingInfo::Type::StringList, "output_device_name", "Output Device", "Selects the device to output audio to.", "", nullptr,
 				nullptr, nullptr, nullptr, nullptr, &AudioDevice::GetOutputDeviceList},
-			{SettingInfo::Type::Integer, "input_latency", "Input Latency", "Specifies the latency to the host input device.", AudioDevice::DEFAULT_LATENCY_STR, "0",
+			{SettingInfo::Type::Integer, "input_latency", "Input Latency", "Specifies the latency to the host input device.", AudioDevice::DEFAULT_LATENCY_STR, "1",
 				"1000", "1", "%dms", nullptr, nullptr, 1.0f},
-			{SettingInfo::Type::Integer, "output_latency", "Output Latency", "Specifies the latency to the host output device.", AudioDevice::DEFAULT_LATENCY_STR, "0",
+			{SettingInfo::Type::Integer, "output_latency", "Output Latency", "Specifies the latency to the host output device.", AudioDevice::DEFAULT_LATENCY_STR, "1",
 				"1000", "1", "%dms", nullptr, nullptr, 1.0f},
 		};
 		return info;

--- a/pcsx2/USB/usb-mic/usb-mic-singstar.cpp
+++ b/pcsx2/USB/usb-mic/usb-mic-singstar.cpp
@@ -855,7 +855,7 @@ namespace usb_mic
 			{SettingInfo::Type::StringList, "player2_device_name", "Player 2 Device", "Selects the input for the second player.", "",
 				nullptr, nullptr, nullptr, nullptr, nullptr, &AudioDevice::GetInputDeviceList},
 			{SettingInfo::Type::Integer, "input_latency", "Input Latency", "Specifies the latency to the host input device.",
-				AudioDevice::DEFAULT_LATENCY_STR, "0", "1000", "1", "%dms", nullptr, nullptr, 1.0f},
+				AudioDevice::DEFAULT_LATENCY_STR, "1", "1000", "1", "%dms", nullptr, nullptr, 1.0f},
 		};
 		return info;
 	}
@@ -876,7 +876,7 @@ namespace usb_mic
 			{SettingInfo::Type::StringList, "input_device_name", "Input Device", "Selects the device to read audio from.", "", nullptr,
 				nullptr, nullptr, nullptr, nullptr, &AudioDevice::GetInputDeviceList},
 			{SettingInfo::Type::Integer, "input_latency", "Input Latency", "Specifies the latency to the host input device.",
-				AudioDevice::DEFAULT_LATENCY_STR, "0", "1000", "1", "%dms", nullptr, nullptr, 1.0f},
+				AudioDevice::DEFAULT_LATENCY_STR, "1", "1000", "1", "%dms", nullptr, nullptr, 1.0f},
 		};
 		return info;
 	}

--- a/pcsx2/USB/usb-pad/usb-seamic.cpp
+++ b/pcsx2/USB/usb-pad/usb-seamic.cpp
@@ -386,7 +386,7 @@ namespace usb_pad
 			{SettingInfo::Type::StringList, "input_device_name", "Input Device", "Selects the device to read audio from.", "", nullptr,
 				nullptr, nullptr, nullptr, nullptr, &AudioDevice::GetInputDeviceList},
 			{SettingInfo::Type::Integer, "input_latency", "Input Latency", "Specifies the latency to the host input device.",
-				AudioDevice::DEFAULT_LATENCY_STR, "0", "1000", "1", "%dms", nullptr, nullptr, 1.0f},
+				AudioDevice::DEFAULT_LATENCY_STR, "1", "1000", "1", "%dms", nullptr, nullptr, 1.0f},
 		};
 		return info;
 	}


### PR DESCRIPTION
### Description of Changes
Limits the lowest value you can set for input/output latency to 1ms

### Rationale behind Changes
0ms is impossible, but also causes cubeb to crash, so probably best we don't allow it.

### Suggested Testing Steps
try to set stupid tiny values in the usb settings for any of the headset/singstar/seamic adapters, also boot emu and make sure it works.
