### PR TITLE
x86/iR5900: Fix incorrect blend in mfsa

### DIFF
--- a/pcsx2/x86/iR5900Misc.cpp
+++ b/pcsx2/x86/iR5900Misc.cpp
@@ -100,7 +100,7 @@ void recMFSA()
 		// have to zero out bits 63:32
 		const int temp = _allocTempXMMreg(XMMT_INT);
 		xMOVSSZX(xRegisterSSE(temp), ptr32[&cpuRegs.sa]);
-		xBLEND.PD(xRegisterSSE(temp), xRegisterSSE(temp), 1);
+		xBLEND.PD(xRegisterSSE(mmreg), xRegisterSSE(temp), 1);
 		_freeXMMreg(temp);
 	}
 	else if (const int gprreg = _allocIfUsedGPRtoX86(_Rd_, MODE_WRITE); gprreg >= 0)


### PR DESCRIPTION
### Description of Changes

Typo which caused incorrect sa to be saved in the kernel, which crashed UEFA Champions League 2006-2007 on starting a game.

### Rationale behind Changes

Closes #7729

### Suggested Testing Steps

Safe to yolo merge, issue is obvious. But I did check it no longer crashes.

