### PR TITLE
mVU: Align x86ptr based on AVX2 caps

### DIFF
--- a/pcsx2/PCSX2Base.h
+++ b/pcsx2/PCSX2Base.h
@@ -31,14 +31,6 @@
 	#error PCSX2 requires compiling for at least SSE 4.1
 #endif
 
-// Require 32 bit alignment for vectors for AVX2.
-#if _M_SSE >= 0x501
-	#define SSE_ALIGN_N 32
-#else
-	#define SSE_ALIGN_N 16
-#endif
-#define SSE_ALIGN alignas(SSE_ALIGN_N)
-
 // Starting with AVX, processors have fast unaligned loads
 // Reduce code duplication by not compiling multiple versions
 #if _M_SSE >= 0x500

--- a/pcsx2/x86/microVU_Compile.inl
+++ b/pcsx2/x86/microVU_Compile.inl
@@ -482,7 +482,10 @@ void mVUtestCycles(microVU& mVU, microFlagCycles& mFC)
 	mVUendProgram(mVU, &mFC, 0);
 
 	{
-		xAlignPtr(SSE_ALIGN_N);
+		if(x86caps.hasAVX2)
+			xAlignPtr(32);
+		else
+			xAlignPtr(16);
 
 		u8* curx86Ptr = x86Ptr;
 		x86SetPtr(writeback);


### PR DESCRIPTION
### Description of Changes
Aligns the VU JIT buffer to 32byte for AVX2 and 16byte for SSE4, regardless of which version of PCSX2 you use.

### Rationale behind Changes
When using an SSE4 build (which the MultiISA technically will be) it could have aligned to 16bytes (128bits) not 32bytes(256bits) which is required for AVX2, causing crashes when using VMOVAPS (aligned move) since AVX2 instructions can still be used if available.

### Suggested Testing Steps
Already tested, just need to wait for the CI
