### PR TITLE
Qt: Fix Host::GetTopLevelWindowInfo() in nogui mode

### DIFF
--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -1295,7 +1295,12 @@ void MainWindow::checkForSettingChanges()
 
 std::optional<WindowInfo> MainWindow::getWindowInfo()
 {
-	return QtUtils::GetWindowInfoForWidget(this);
+	if (isRenderingToMain())
+		return QtUtils::GetWindowInfoForWidget(this);
+	else if (QWidget* widget = getDisplayContainer())
+		return QtUtils::GetWindowInfoForWidget(widget);
+	else
+		return std::nullopt;
 }
 
 void Host::InvalidateSaveStateCache()

--- a/pcsx2-qt/QtUtils.cpp
+++ b/pcsx2-qt/QtUtils.cpp
@@ -40,6 +40,8 @@
 #include <array>
 #include <map>
 
+#include "common/Console.h"
+
 #if defined(_WIN32)
 #include "common/RedtapeWindows.h"
 #elif !defined(APPLE)
@@ -222,6 +224,12 @@ namespace QtUtils
 
 	std::optional<WindowInfo> GetWindowInfoForWidget(QWidget* widget)
 	{
+		if (!widget->isVisible())
+		{
+			Console.WriteLn("Returning null window info for widget because it is not visible.");
+			return std::nullopt;
+		}
+
 		WindowInfo wi;
 
 		// Windows and Apple are easy here since there's no display connection.
@@ -248,7 +256,7 @@ namespace QtUtils
 		}
 		else
 		{
-			qCritical() << "Unknown PNI platform " << platform_name;
+			Console.WriteLn("Unknown PNI platform '%s'.", platform_name.toUtf8().constData());
 			return std::nullopt;
 		}
 #endif


### PR DESCRIPTION
### Description of Changes

It tried to return the main window's handle for screensaver inhibit, which isn't visible/mapped in nogui mode.

### Rationale behind Changes

Fixes #7721.

### Suggested Testing Steps

Test nogui parameter (preferably on linux).
