### PR TITLE
microVU: Fix VU1->VU0 register access in MTVU mode

### DIFF
--- a/pcsx2/x86/microVU_Execute.inl
+++ b/pcsx2/x86/microVU_Execute.inl
@@ -135,8 +135,9 @@ void mvuGenerateWaitMTVU(mV)
 		if (!xRegister32::IsCallerSaved(i) || i == rsp.GetId())
 			continue;
 
-		// no need to save temps
-		if (i == gprT1.GetId() || i == gprT2.GetId())
+		// T1 often contains the address we're loading when waiting for VU1.
+		// T2 isn't used until afterwards, so don't bother saving it.
+		if (i == gprT2.GetId())
 			continue;
 
 		xPUSH(xRegister64(i));
@@ -187,7 +188,7 @@ void mvuGenerateWaitMTVU(mV)
 		if (!xRegister32::IsCallerSaved(i) || i == rsp.GetId())
 			continue;
 
-		if (i == gprT1.GetId() || i == gprT2.GetId())
+		if (i == gprT2.GetId())
 			continue;
 
 		xPOP(xRegister64(i));

--- a/pcsx2/x86/microVU_Misc.inl
+++ b/pcsx2/x86/microVU_Misc.inl
@@ -326,7 +326,9 @@ __fi void mVUaddrFix(mV, const xAddressReg& gprReg)
 					{
 						xMOV(gprT1, mVU.prog.cur->idx); // Note: Kernel does it via COP2 to initialize VU1!
 						xMOV(gprT2, xPC);               // So we don't spam console, we'll only check micro-mode...
+						mVUbackupRegs(mVU, true, false);
 						xFastCall((void*)mVUwarningRegAccess, arg1regd, arg2regd);
+						mVUrestoreRegs(mVU, true, false);
 					}
 #endif
 				xFastCall((void*)mVU.waitMTVU);


### PR DESCRIPTION
### Description of Changes

eax wasn't being backed up, and in most cases it contains the address we're loading from/storing to.

### Rationale behind Changes

Fixes #7740.

### Suggested Testing Steps

Test Arc the Lad.
