### PR TITLE
Misc: Remove GS/config.h include from PCSX2Base.h

### DIFF
--- a/pcsx2/GS/Renderers/SW/GSDrawScanline.h
+++ b/pcsx2/GS/Renderers/SW/GSDrawScanline.h
@@ -16,10 +16,11 @@
 #pragma once
 
 #include "GS/GSState.h"
-#include "GSRasterizer.h"
-#include "GSScanlineEnvironment.h"
-#include "GSSetupPrimCodeGenerator.h"
-#include "GSDrawScanlineCodeGenerator.h"
+#include "GS/Renderers/SW/GSRasterizer.h"
+#include "GS/Renderers/SW/GSScanlineEnvironment.h"
+#include "GS/Renderers/SW/GSSetupPrimCodeGenerator.h"
+#include "GS/Renderers/SW/GSDrawScanlineCodeGenerator.h"
+#include "GS/config.h"
 
 MULTI_ISA_UNSHARED_START
 

--- a/pcsx2/GS/Renderers/SW/GSRasterizer.h
+++ b/pcsx2/GS/Renderers/SW/GSRasterizer.h
@@ -15,13 +15,14 @@
 
 #pragma once
 
-#include "GSVertexSW.h"
+#include "GS/Renderers/SW/GSVertexSW.h"
 #include "GS/Renderers/Common/GSFunctionMap.h"
 #include "GS/GSAlignedClass.h"
 #include "GS/GSPerfMon.h"
 #include "GS/GSThread_CXX11.h"
 #include "GS/GSRingHeap.h"
 #include "GS/MultiISA.h"
+#include "GS/config.h"
 
 MULTI_ISA_UNSHARED_START
 

--- a/pcsx2/GS/config.h
+++ b/pcsx2/GS/config.h
@@ -16,9 +16,7 @@
 #pragma once
 
 //#define ENABLE_VTUNE
-//#define ENABLE_ACCURATE_BUFFER_EMULATION
+
 #define ENABLE_JIT_RASTERIZER
 
 //#define DISABLE_HW_TEXTURE_CACHE // Slow but fixes a lot of bugs
-
-//#define DISABLE_PERF_MON // Burn cycle for nothing in release mode

--- a/pcsx2/PCSX2Base.h
+++ b/pcsx2/PCSX2Base.h
@@ -19,7 +19,6 @@
 #pragma once
 
 #include "common/Pcsx2Defs.h"
-#include "GS/config.h"
 
 #if defined(__AVX2__)
 	#define _M_SSE 0x501


### PR DESCRIPTION
### Description of Changes

Also remove unused options from config.h

### Rationale behind Changes

Unnecessary includes, recompiling unnecessary files when changing config

### Suggested Testing Steps

Make sure build passes.

