### PR TITLE
GameDB: Iris 2 + Iris 3

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -19399,6 +19399,11 @@ SLES-54384:
 SLES-54385:
   name: "Atelier Iris 2 - The Azoth of Destiny"
   region: "PAL-E"
+  gameFixes:
+    - SoftwareRendererFMVHack # Flickering in FMV.
+  gsHWFixes:
+    roundSprite: 1 # Fixes font artifacts for health and other sprites.
+    texturePreloading: 0 # Improves performance and prevents it disabling itself regardless.
 SLES-54388:
   name: "Kim Possible - What's the Switch"
   region: "PAL-M3"
@@ -30257,6 +30262,11 @@ SLPM-65984:
 SLPM-65985:
   name: "Iris no Atelier - Eternal Mana 2"
   region: "NTSC-J"
+  gameFixes:
+    - SoftwareRendererFMVHack # Flickering in FMV.
+  gsHWFixes:
+    roundSprite: 1 # Fixes font artifacts for health and other sprites.
+    texturePreloading: 0 # Improves performance and prevents it disabling itself regardless.
 SLPM-65986:
   name: "Quartett! The Stage of Love [Limited Edition]"
   region: "NTSC-J"
@@ -31899,6 +31909,8 @@ SLPM-66436:
   name: "Iris no Atelier - Grand Fantasm"
   region: "NTSC-J"
   compat: 5
+  gsHWFixes:
+    roundSprite: 1 # Fixes vertical lines in FMVs, character portraits and other sprites.
 SLPM-66437:
   name: "Soul Link Extension"
   region: "NTSC-J"
@@ -32312,6 +32324,11 @@ SLPM-66536:
 SLPM-66537:
   name: "Iris no Atelier - Eternal Mana 2 [Gust Best Price]"
   region: "NTSC-J"
+  gameFixes:
+    - SoftwareRendererFMVHack # Flickering in FMV.
+  gsHWFixes:
+    roundSprite: 1 # Fixes font artifacts for health and other sprites.
+    texturePreloading: 0 # Improves performance and prevents it disabling itself regardless.
 SLPM-66538:
   name: "GI Jockey 4 2006"
   region: "NTSC-J"
@@ -33459,6 +33476,8 @@ SLPM-66848:
 SLPM-66849:
   name: "Iris no Atelier - Grand Fantasm [Gust Best Price]"
   region: "NTSC-J"
+  gsHWFixes:
+    roundSprite: 1 # Fixes vertical lines in FMVs, character portraits and other sprites.
 SLPM-66850:
   name: "Arcana Heart"
   region: "NTSC-J"
@@ -46155,6 +46174,11 @@ SLUS-21327:
   name: "Atelier Iris 2 - The Azoth of Destiny"
   region: "NTSC-U"
   compat: 5
+  gameFixes:
+    - SoftwareRendererFMVHack # Flickering in FMV.
+  gsHWFixes:
+    roundSprite: 1 # Fixes font artifacts for health and other sprites.
+    texturePreloading: 0 # Improves performance and prevents it disabling itself regardless.
 SLUS-21328:
   name: "Pac-Man World Rally"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Hashcache disabled + FMVsoftwaregamefix + Roundsprite for Iris 2 Roundsprite was forgotten to be added for the Japanese entries for iris 3 (eternal mana 2)

Kinda fixes https://github.com/PCSX2/pcsx2/issues/7746
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Less tinkering
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test iris 2 or iris 3 variants.