### PR TITLE
GameDB: Set preloading to Partial for Tekken 4

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -3068,6 +3068,7 @@ SCES-50878:
   compat: 5
   gsHWFixes:
     alignSprite: 1
+    texturePreloading: 1 # Performs much better with partial preload.
 SCES-50885:
   name: "Ape Escape 2"
   region: "PAL-E"
@@ -6668,6 +6669,7 @@ SCPS-55017:
   compat: 3
   gsHWFixes:
     alignSprite: 1
+    texturePreloading: 1 # Performs much better with partial preload.
 SCPS-55018:
   name: "Kingdom of Scribbling"
   region: "NTSC-J"
@@ -6875,6 +6877,7 @@ SCPS-56006:
   compat: 5
   gsHWFixes:
     alignSprite: 1
+    texturePreloading: 1 # Performs much better with partial preload.
 SCPS-56008:
   name: "Fatal Frame"
   region: "NTSC-K"
@@ -36244,6 +36247,7 @@ SLPS-25100:
   compat: 5
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
+    texturePreloading: 1 # Performs much better with partial preload.
 SLPS-25102:
   name: "Project Arms"
   region: "NTSC-J"
@@ -39400,6 +39404,7 @@ SLPS-73209:
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
+    texturePreloading: 1 # Performs much better with partial preload.
 SLPS-73210:
   name: "Katamari Damacy [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -41173,6 +41178,7 @@ SLUS-20328:
   compat: 5
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
+    texturePreloading: 1 # Performs much better with partial preload.
 SLUS-20329:
   name: "Pro Race Driver"
   region: "NTSC-U"
@@ -49080,6 +49086,7 @@ SLUS-28012:
   region: "NTSC-U"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
+    texturePreloading: 1 # Performs much better with partial preload.
 SLUS-28013:
   name: "Dual Hearts [Trade Demo]"
   region: "NTSC-U"
@@ -49325,6 +49332,7 @@ SLUS-29034:
   region: "NTSC-U"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
+    texturePreloading: 1 # Performs much better with partial preload.
 SLUS-29035:
   name: "Eidos Demo Disc"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
Sets texture preloading to partial for Tekken 4 to prevent it from exploding most violently.

### Rationale behind Changes
Performance being bad is bad we should make it good.

### Suggested Testing Steps
Make sure CI is happy.
