### PR TITLE
Debugger: Cleanup and fixes

### DIFF
--- a/pcsx2-qt/Debugger/BreakpointDialog.cpp
+++ b/pcsx2-qt/Debugger/BreakpointDialog.cpp
@@ -197,8 +197,10 @@ void BreakpointDialog::accept()
 		}
 		else
 		{
-			Host::RunOnCPUThread([this, address] { CBreakPoints::ChangeBreakPointRemoveCond(m_cpu->getCpuType(), address); }, true);
+			Host::RunOnCPUThread([this, address] { CBreakPoints::ChangeBreakPointRemoveCond(m_cpu->getCpuType(), address); });
 		}
+
+		Host::RunOnCPUThread([this, address] { CBreakPoints::ChangeBreakPoint(m_cpu->getCpuType(), address, m_ui.chkEnable->isChecked()); });
 		m_bp->addr = address;
 	}
 

--- a/pcsx2-qt/Debugger/CpuWidget.cpp
+++ b/pcsx2-qt/Debugger/CpuWidget.cpp
@@ -234,6 +234,8 @@ void CpuWidget::onVMPaused()
 
 void CpuWidget::updateBreakpoints()
 {
+	m_ui.breakpointList->blockSignals(true);
+
 	m_ui.breakpointList->setRowCount(0);
 	m_bplistObjects.clear();
 
@@ -355,6 +357,8 @@ void CpuWidget::updateBreakpoints()
 
 		iter++;
 	}
+
+	m_ui.breakpointList->blockSignals(false);
 }
 
 void CpuWidget::fixBPListColumnSize()
@@ -467,6 +471,21 @@ void CpuWidget::onBPListItemChange(QTableWidgetItem* item)
 			});
 			updateBreakpoints();
 		}
+	}
+	else if (item->column() == 6)
+	{
+		auto bpmc = m_bplistObjects.at(item->row());
+
+		Host::RunOnCPUThread([this, bpmc, checked = item->checkState()] {
+			if (bpmc.bp)
+			{
+				CBreakPoints::ChangeBreakPoint(m_cpu.getCpuType(), bpmc.bp->addr, checked);
+			}
+			else
+			{
+				CBreakPoints::ChangeMemCheck(m_cpu.getCpuType(), bpmc.mc->start, bpmc.mc->end, bpmc.mc->cond, MemCheckResult(bpmc.mc->result ^ MEMCHECK_BREAK));
+			}
+		});
 	}
 }
 

--- a/pcsx2-qt/Debugger/CpuWidget.cpp
+++ b/pcsx2-qt/Debugger/CpuWidget.cpp
@@ -373,6 +373,9 @@ void CpuWidget::fixBPListColumnSize()
 
 void CpuWidget::onBPListContextMenu(QPoint pos)
 {
+	if (!m_cpu.isAlive())
+		return;
+
 	if (m_bplistContextMenu)
 		delete m_bplistContextMenu;
 
@@ -951,6 +954,9 @@ std::vector<u32> startWorker(DebugInterface* cpu, int type, u32 start, u32 end, 
 
 void CpuWidget::onSearchButtonClicked()
 {
+	if (!m_cpu.isAlive())
+		return;
+
 	const int searchType = m_ui.cmbSearchType->currentIndex();
 	const bool searchHex = m_ui.chkSearchHex->isChecked();
 

--- a/pcsx2-qt/Debugger/DisassemblyWidget.cpp
+++ b/pcsx2-qt/Debugger/DisassemblyWidget.cpp
@@ -60,6 +60,8 @@ void DisassemblyWidget::CreateCustomContextMenu()
 	m_contextMenu->addSeparator();
 	m_contextMenu->addAction(action = new QAction(tr("Assemble new Instruction(s)"), this));
 	connect(action, &QAction::triggered, this, &DisassemblyWidget::contextAssembleInstruction);
+	m_contextMenu->addAction(action = new QAction(tr("NOP Instruction(s)"), this));
+	connect(action, &QAction::triggered, this, &DisassemblyWidget::contextNoopInstruction);
 	m_contextMenu->addSeparator();
 	m_contextMenu->addAction(action = new QAction(tr("Run to Cursor"), this));
 	connect(action, &QAction::triggered, this, &DisassemblyWidget::contextRunToCursor);
@@ -134,6 +136,17 @@ void DisassemblyWidget::contextAssembleInstruction()
 			QtHost::RunOnUIThread([this] { VMUpdate(); });
 		});
 	}
+}
+
+void DisassemblyWidget::contextNoopInstruction()
+{
+	Host::RunOnCPUThread([this, start = m_selectedAddressStart, end = m_selectedAddressEnd, cpu = m_cpu] {
+		for (u32 i = start; i <= end; i += 4)
+		{
+			cpu->write32(i, 0x00);
+		}
+		QtHost::RunOnUIThread([this] { VMUpdate(); });
+	});
 }
 
 void DisassemblyWidget::contextRunToCursor()

--- a/pcsx2-qt/Debugger/DisassemblyWidget.cpp
+++ b/pcsx2-qt/Debugger/DisassemblyWidget.cpp
@@ -545,6 +545,13 @@ void DisassemblyWidget::keyPressEvent(QKeyEvent* event)
 				m_visibleStart -= 4;
 		}
 		break;
+		case Qt::Key_PageUp:
+		{
+			m_selectedAddressStart -= m_visibleRows * 4;
+			m_selectedAddressEnd = m_selectedAddressStart;
+			m_visibleStart -= m_visibleRows * 4;
+		}
+		break;
 		case Qt::Key_Down:
 		{
 			m_selectedAddressEnd += 4;
@@ -555,8 +562,16 @@ void DisassemblyWidget::keyPressEvent(QKeyEvent* event)
 			// size the window so part of a row is visible and we don't want to have half a row selected and cut off!
 			if (m_visibleStart + ((m_visibleRows - 1) * 4) < m_selectedAddressEnd)
 				m_visibleStart += 4;
+
+			break;
 		}
-		break;
+		case Qt::Key_PageDown:
+		{
+			m_selectedAddressStart += m_visibleRows * 4;
+			m_selectedAddressEnd = m_selectedAddressStart;
+			m_visibleStart += m_visibleRows * 4;
+			break;
+		}
 		case Qt::Key_G:
 			contextGoToAddress();
 			break;
@@ -582,8 +597,6 @@ void DisassemblyWidget::keyPressEvent(QKeyEvent* event)
 
 void DisassemblyWidget::customMenuRequested(QPoint pos)
 {
-	// m_selectedAddressStart will be properly set as the mouse click handler is called _before_ us
-	// yay :)
 	m_contextMenu->popup(this->mapToGlobal(pos));
 }
 
@@ -633,7 +646,7 @@ QColor DisassemblyWidget::GetAddressFunctionColor(u32 address)
 	std::array<QColor, 6> colors;
 	const QColor base = this->palette().alternateBase().color();
 
-	auto Y = (base.redF() * 0.33) + (0.5 * base.greenF()) + (0.16 * base.blueF());
+	const auto Y = (base.redF() * 0.33) + (0.5 * base.greenF()) + (0.16 * base.blueF());
 
 	if (Y > 0.5)
 	{
@@ -658,7 +671,7 @@ QColor DisassemblyWidget::GetAddressFunctionColor(u32 address)
 		};
 	}
 
-	auto funNum = m_cpu->GetSymbolMap().GetFunctionNum(address);
+	const auto funNum = m_cpu->GetSymbolMap().GetFunctionNum(address);
 	if (funNum == -1)
 		return this->palette().text().color();
 

--- a/pcsx2-qt/Debugger/DisassemblyWidget.cpp
+++ b/pcsx2-qt/Debugger/DisassemblyWidget.cpp
@@ -151,6 +151,9 @@ void DisassemblyWidget::contextJumpToCursor()
 
 void DisassemblyWidget::contextToggleBreakpoint()
 {
+	if (!m_cpu->isAlive())
+		return;
+
 	if (CBreakPoints::IsAddressBreakPoint(m_cpu->getCpuType(), m_selectedAddressStart))
 	{
 		Host::RunOnCPUThread([&] { CBreakPoints::RemoveBreakPoint(m_cpu->getCpuType(), m_selectedAddressStart); });
@@ -504,6 +507,9 @@ void DisassemblyWidget::mousePressEvent(QMouseEvent* event)
 
 void DisassemblyWidget::mouseDoubleClickEvent(QMouseEvent* event)
 {
+	if (!m_cpu->isAlive())
+		return;
+
 	const u32 selectedAddress = (event->y() / m_rowHeight * 4) + m_visibleStart;
 	if (CBreakPoints::IsAddressBreakPoint(m_cpu->getCpuType(), selectedAddress))
 	{
@@ -597,6 +603,9 @@ void DisassemblyWidget::keyPressEvent(QKeyEvent* event)
 
 void DisassemblyWidget::customMenuRequested(QPoint pos)
 {
+	if (!m_cpu->isAlive())
+		return;
+
 	m_contextMenu->popup(this->mapToGlobal(pos));
 }
 

--- a/pcsx2-qt/Debugger/DisassemblyWidget.h
+++ b/pcsx2-qt/Debugger/DisassemblyWidget.h
@@ -55,6 +55,7 @@ public slots:
 	void contextCopyInstructionHex();
 	void contextCopyInstructionText();
 	void contextAssembleInstruction();
+	void contextNoopInstruction();
 	void contextRunToCursor();
 	void contextJumpToCursor();
 	void contextToggleBreakpoint();

--- a/pcsx2-qt/Debugger/MemoryViewWidget.cpp
+++ b/pcsx2-qt/Debugger/MemoryViewWidget.cpp
@@ -344,12 +344,18 @@ void MemoryViewWidget::paintEvent(QPaintEvent* event)
 
 void MemoryViewWidget::mousePressEvent(QMouseEvent* event)
 {
+	if (!m_cpu->isAlive())
+		return;
+
 	m_table.SelectAt(event->pos());
 	repaint();
 }
 
 void MemoryViewWidget::customMenuRequested(QPoint pos)
 {
+	if (!m_cpu->isAlive())
+		return;
+
 	if (!m_contextMenu)
 	{
 		m_contextMenu = new QMenu(this);

--- a/pcsx2-qt/Debugger/RegisterWidget.cpp
+++ b/pcsx2-qt/Debugger/RegisterWidget.cpp
@@ -219,6 +219,9 @@ void RegisterWidget::wheelEvent(QWheelEvent* event)
 
 void RegisterWidget::customMenuRequested(QPoint pos)
 {
+	if (!m_cpu->isAlive())
+		return;
+
 	if (m_selectedRow > m_rowEnd) // Unsigned underflow; selectedRow will be > m_rowEnd (technically negative)
 		return;
 


### PR DESCRIPTION
### Description of Changes
- Page Up/Down hotkey for the disassembly view
- Stops certain actions from being performed if the VM is dead (fixes crashes)
- Add the missing functionality of toggling breakpoints on or off through the breakpoint dialog and list
- Add a 'NOP Instruction(s)' context menu action for the disassembly view

### Rationale behind Changes
Fixes / Features

### Suggested Testing Steps
Test the above.