### PR TITLE
USB: Support stereo input for Singstar Mic

### DIFF
--- a/pcsx2/USB/usb-mic/audiodev-cubeb.cpp
+++ b/pcsx2/USB/usb-mic/audiodev-cubeb.cpp
@@ -249,17 +249,6 @@ namespace usb_mic
 			ResetBuffers();
 		}
 
-		bool CubebAudioDevice::Compare(AudioDevice* compare) const
-		{
-			if (compare)
-			{
-				CubebAudioDevice* src = static_cast<CubebAudioDevice*>(compare);
-				if (src && mDeviceName == src->mDeviceName)
-					return true;
-			}
-			return false;
-		}
-
 		void CubebAudioDevice::ResetBuffers()
 		{
 			// TODO: Do we want to make the buffer size adjustable? Currently 100ms max.

--- a/pcsx2/USB/usb-mic/audiodev-cubeb.h
+++ b/pcsx2/USB/usb-mic/audiodev-cubeb.h
@@ -42,7 +42,6 @@ namespace usb_mic
 			void SetResampling(int samplerate) override;
 			bool Start() override;
 			void Stop() override;
-			bool Compare(AudioDevice* compare) const override;
 
 		protected:
 			void ResetBuffers();

--- a/pcsx2/USB/usb-mic/audiodev-noop.h
+++ b/pcsx2/USB/usb-mic/audiodev-noop.h
@@ -43,8 +43,6 @@ namespace usb_mic
 			}
 			uint32_t SetBuffer(int16_t* inBuf, uint32_t inFrames) override { return inFrames; }
 			void SetResampling(int samplerate) override {}
-
-			bool Compare(AudioDevice* compare) const override { return false; }
 		};
 	} // namespace audiodev_noop
 } // namespace usb_mic

--- a/pcsx2/USB/usb-mic/audiodev.h
+++ b/pcsx2/USB/usb-mic/audiodev.h
@@ -76,9 +76,6 @@ public:
 	virtual bool Start() = 0;
 	virtual void Stop() = 0;
 
-	// Compare if another instance is using the same device
-	virtual bool Compare(AudioDevice* compare) const = 0;
-
 	static std::unique_ptr<AudioDevice> CreateDevice(u32 port, AudioDir dir, u32 channels, std::string devname, s32 latency);
 	static std::unique_ptr<AudioDevice> CreateNoopDevice(u32 port, AudioDir dir, u32 channels);
 	static std::vector<std::pair<std::string, std::string>> GetInputDeviceList();


### PR DESCRIPTION
### Description of Changes

Turns out I broke this with the Qt refactor.

Probably a bit difficult to test if you don't have a stereo mic, but I've double checked the logic and it seems sound (hah).

### Rationale behind Changes

Using the real singstar mic currently doesn't support two players.

### Suggested Testing Steps

Test singstar games with usb mic.
