### PR TITLE
common-ogl: Fix Program linked with warnings log spam on gl.

### DIFF
--- a/common/GL/Program.cpp
+++ b/common/GL/Program.cpp
@@ -249,9 +249,13 @@ namespace GL
 		glGetProgramiv(m_program_id, GL_LINK_STATUS, &status);
 
 		GLint info_log_length = 0;
+
+		// Log will create a new line when there are no warnings so let's set a minimum log length of 1.
+		constexpr int info_log_min_length = 1;
+
 		glGetProgramiv(m_program_id, GL_INFO_LOG_LENGTH, &info_log_length);
 
-		if (status == GL_FALSE || info_log_length > 0)
+		if (status == GL_FALSE || info_log_length > info_log_min_length)
 		{
 			std::string info_log;
 			info_log.resize(info_log_length + 1);


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
common-ogl: Fix Program linked with warnings log spam on gl.
Mostly observed on amd driver.
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Log spamming when it shouldn't.
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Make sure the console error is gone on amd gpus on windows.