### PR TITLE
CMake: Search specifically for the ffmpeg components we need

### DIFF
--- a/cmake/BuildParameters.cmake
+++ b/cmake/BuildParameters.cmake
@@ -103,10 +103,6 @@ if(CMAKE_CONFIGURATION_TYPES)
 	list(INSERT CMAKE_CONFIGURATION_TYPES 0 Devel)
 endif()
 mark_as_advanced(CMAKE_C_FLAGS_DEVEL CMAKE_CXX_FLAGS_DEVEL CMAKE_LINKER_FLAGS_DEVEL CMAKE_SHARED_LINKER_FLAGS_DEVEL CMAKE_EXE_LINKER_FLAGS_DEVEL)
-# AVX2 doesn't play well with gdb
-if(CMAKE_BUILD_TYPE MATCHES "Debug")
-	SET(DISABLE_ADVANCE_SIMD ON)
-endif()
 
 # Initially strip was disabled on release build but it is not stackstrace friendly!
 # It only cost several MB so disbable it by default

--- a/cmake/SearchForStuff.cmake
+++ b/cmake/SearchForStuff.cmake
@@ -35,8 +35,8 @@ else()
 
 	# Use bundled ffmpeg v4.x.x headers if we can't locate it in the system.
 	# We'll try to load it dynamically at runtime.
-	find_package(FFMPEG)
-	if(NOT FFMPEG_VERSION)
+	find_package(FFMPEG COMPONENTS avcodec avformat avutil swresample swscale)
+	if(NOT FFMPEG_FOUND)
 		message(WARNING "FFmpeg not found, using bundled headers.")
 		set(FFMPEG_INCLUDE_DIRS "${CMAKE_SOURCE_DIR}/3rdparty/ffmpeg/include")
 	endif()


### PR DESCRIPTION
### Description of Changes

Fixes the build system potentially getting confused with a partial ffmpeg installation.

Also gets rid of the stupid debug logic from 2016 which didn't make sense even back then.

### Rationale behind Changes

Should fix #7765, but I'm not installing Fedora to find out.

### Suggested Testing Steps

Make sure CI passes.
