### PR TITLE
DInputSource: Fix crash and operation in nogui mode

### DIFF
--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -1364,7 +1364,7 @@ void MainWindow::checkForSettingChanges()
 
 std::optional<WindowInfo> MainWindow::getWindowInfo()
 {
-	if (isRenderingToMain())
+	if (!m_display_widget || isRenderingToMain())
 		return QtUtils::GetWindowInfoForWidget(this);
 	else if (QWidget* widget = getDisplayContainer())
 		return QtUtils::GetWindowInfoForWidget(widget);

--- a/pcsx2-qt/QtUtils.cpp
+++ b/pcsx2-qt/QtUtils.cpp
@@ -224,12 +224,6 @@ namespace QtUtils
 
 	std::optional<WindowInfo> GetWindowInfoForWidget(QWidget* widget)
 	{
-		if (!widget->isVisible())
-		{
-			Console.WriteLn("Returning null window info for widget because it is not visible.");
-			return std::nullopt;
-		}
-
 		WindowInfo wi;
 
 		// Windows and Apple are easy here since there's no display connection.
@@ -244,6 +238,13 @@ namespace QtUtils
 		const QString platform_name = QGuiApplication::platformName();
 		if (platform_name == QStringLiteral("xcb"))
 		{
+			// Can't get a handle for an unmapped window in X, it doesn't like it.
+			if (!widget->isVisible())
+			{
+				Console.WriteLn("Returning null window info for widget because it is not visible.");
+				return std::nullopt;
+			}
+
 			wi.type = WindowInfo::Type::X11;
 			wi.display_connection = pni->nativeResourceForWindow("display", widget->windowHandle());
 			wi.window_handle = reinterpret_cast<void*>(widget->winId());

--- a/pcsx2/Frontend/DInputSource.cpp
+++ b/pcsx2/Frontend/DInputSource.cpp
@@ -96,12 +96,13 @@ bool DInputSource::Initialize(SettingsInterface& si, std::unique_lock<std::mutex
 	// need to release the lock while we're enumerating, because we call winId().
 	settings_lock.unlock();
 	const std::optional<WindowInfo> toplevel_wi(Host::GetTopLevelWindowInfo());
+	settings_lock.lock();
+
 	if (!toplevel_wi.has_value() || toplevel_wi->type != WindowInfo::Type::Win32)
 	{
 		Console.Error("Missing top level window, cannot add DInput devices.");
 		return false;
 	}
-	settings_lock.lock();
 
 	m_toplevel_window = static_cast<HWND>(toplevel_wi->window_handle);
 	ReloadDevices();


### PR DESCRIPTION
### Description of Changes

Using dinput would cause PCSX2 to crash on startup. See individual commits for more explanation.

### Rationale behind Changes

Crashes are bad.

### Suggested Testing Steps

Test dinput.
