### PR TITLE
GS: Add GPU Target CLUT

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -8991,7 +8991,7 @@ SLAJ-25053:
     preloadFrameData: 1 # Makes sun appear.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
-    cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
+    gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
 SLAJ-25055:
@@ -9029,7 +9029,7 @@ SLAJ-25066:
     preloadFrameData: 1 # Makes sun appear.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
-    cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
+    gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
   memcardFilters:
@@ -9061,7 +9061,8 @@ SLAJ-25075:
   region: "NTSC-Unk"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
-    cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
+    cpuCLUTRender: 1 # Final colour adjustment LUT.
+    gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
   memcardFilters:
     - "SLAJ-25075"
     - "SLPM-66232"
@@ -9151,7 +9152,7 @@ SLAJ-25094:
     preloadFrameData: 1 # Makes sun appear.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
-    cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
+    gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
 SLAJ-25095:
@@ -9315,7 +9316,7 @@ SLED-52597:
     preloadFrameData: 1 # Makes sun appear.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
-    cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
+    gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
 SLED-52852:
@@ -9381,7 +9382,7 @@ SLED-53512:
     preloadFrameData: 1 # Makes sun appear.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
-    cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
+    gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
 SLED-53537:
@@ -15071,7 +15072,7 @@ SLES-52584:
     preloadFrameData: 1 # Makes sun appear.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
-    cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
+    gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
 SLES-52585:
@@ -15085,7 +15086,7 @@ SLES-52585:
     preloadFrameData: 1 # Makes sun appear.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
-    cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
+    gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
 SLES-52587:
@@ -17267,7 +17268,7 @@ SLES-53506:
     preloadFrameData: 1 # Makes sun appear.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
-    cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
+    gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
   memcardFilters:
@@ -17288,7 +17289,7 @@ SLES-53507:
     preloadFrameData: 1 # Makes sun appear.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
-    cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
+    gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
   memcardFilters:
@@ -17519,7 +17520,8 @@ SLES-53557:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
-    cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
+    cpuCLUTRender: 1 # Final colour adjustment LUT.
+    gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
   memcardFilters: # Reads Underground 2 save for extra money.
     - "SLES-53557"
     - "SLES-53558"
@@ -17531,7 +17533,8 @@ SLES-53558:
   region: "PAL-M8"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
-    cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
+    cpuCLUTRender: 1 # Final colour adjustment LUT.
+    gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
   memcardFilters:
     - "SLES-53557"
     - "SLES-53558"
@@ -17543,7 +17546,8 @@ SLES-53559:
   region: "PAL-M3"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
-    cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
+    cpuCLUTRender: 1 # Final colour adjustment LUT.
+    gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
   memcardFilters:
     - "SLES-53557"
     - "SLES-53558"
@@ -18339,7 +18343,8 @@ SLES-53857:
   region: "PAL-M3"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
-    cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
+    cpuCLUTRender: 1 # Final colour adjustment LUT.
+    gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
   memcardFilters:
     - "SLES-53557"
     - "SLES-53558"
@@ -20223,7 +20228,7 @@ SLES-54627:
     preloadFrameData: 1 # Makes sun appear.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
-    cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
+    gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
 SLES-54628:
@@ -20397,7 +20402,7 @@ SLES-54681:
     preloadFrameData: 1 # Makes sun appear.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
-    cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
+    gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
 SLES-54683:
@@ -23641,7 +23646,7 @@ SLKA-25206:
     preloadFrameData: 1 # Makes sun appear.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
-    cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
+    gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
 SLKA-25207:
@@ -23934,7 +23939,7 @@ SLKA-25304:
     preloadFrameData: 1 # Makes sun appear.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
-    cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
+    gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
 SLKA-25307:
@@ -24029,7 +24034,8 @@ SLKA-25334:
   region: "NTSC-K"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
-    cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
+    cpuCLUTRender: 1 # Final colour adjustment LUT.
+    gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
 SLKA-25335:
   name: "Shadow the Hedgehog"
   region: "NTSC-K"
@@ -24248,7 +24254,7 @@ SLPM-55004:
     preloadFrameData: 1 # Makes sun appear.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
-    cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
+    gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
 SLPM-55005:
@@ -24289,7 +24295,7 @@ SLPM-55036:
     preloadFrameData: 1 # Makes sun appear.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
-    cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
+    gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
 SLPM-55039:
@@ -24867,7 +24873,7 @@ SLPM-60246:
     preloadFrameData: 1 # Makes sun appear.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
-    cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
+    gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
 SLPM-60251:
@@ -29717,7 +29723,7 @@ SLPM-65719:
     preloadFrameData: 1 # Makes sun appear.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
-    cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
+    gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
 SLPM-65720:
@@ -30547,7 +30553,7 @@ SLPM-65958:
     preloadFrameData: 1 # Makes sun appear.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
-    cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
+    gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
 SLPM-65959:
@@ -31100,7 +31106,7 @@ SLPM-66108:
     preloadFrameData: 1 # Makes sun appear.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
-    cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
+    gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
   memcardFilters:
@@ -31589,7 +31595,8 @@ SLPM-66232:
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
-    cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
+    cpuCLUTRender: 1 # Final colour adjustment LUT.
+    gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
   memcardFilters:
     - "SLAJ-25075"
     - "SLPM-66232"
@@ -32820,7 +32827,8 @@ SLPM-66562:
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
-    cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
+    cpuCLUTRender: 1 # Final colour adjustment LUT.
+    gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
   memcardFilters:
     - "SLAJ-25075"
     - "SLPM-66232"
@@ -33173,7 +33181,7 @@ SLPM-66652:
     preloadFrameData: 1 # Makes sun appear.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
-    cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
+    gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
   memcardFilters:
@@ -33557,7 +33565,7 @@ SLPM-66739:
     preloadFrameData: 1 # Makes sun appear.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
-    cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
+    gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
 SLPM-66740:
@@ -34293,7 +34301,7 @@ SLPM-66962:
     preloadFrameData: 1 # Makes sun appear.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
-    cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
+    gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
 SLPM-66963:
@@ -45259,7 +45267,7 @@ SLUS-21050:
     preloadFrameData: 1 # Makes sun appear.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
-    cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
+    gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
 SLUS-21051:
@@ -46233,7 +46241,7 @@ SLUS-21242:
     preloadFrameData: 1 # Makes sun appear.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
-    cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
+    gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
   memcardFilters: # Reads Burnout 3 and NFL 06 saves for unlockables.
@@ -46386,7 +46394,8 @@ SLUS-21267:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
-    cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
+    cpuCLUTRender: 1 # Final colour adjustment LUT.
+    gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
   memcardFilters:
     - "SLUS-21267"
     - "SLUS-21351"
@@ -46878,7 +46887,8 @@ SLUS-21351:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
-    cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
+    cpuCLUTRender: 1 # Final colour adjustment LUT.
+    gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
   memcardFilters:
     - "SLUS-21267"
     - "SLUS-21351"
@@ -48029,7 +48039,7 @@ SLUS-21596:
     preloadFrameData: 1 # Makes sun appear.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
-    cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
+    gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
 SLUS-21597:
@@ -50198,7 +50208,7 @@ SLUS-29113:
     preloadFrameData: 1 # Makes sun appear.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
-    cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
+    gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
 SLUS-29116:
@@ -50325,7 +50335,7 @@ SLUS-29153:
     preloadFrameData: 1 # Makes sun appear.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
-    cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
+    gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
 SLUS-29154:
@@ -50336,7 +50346,8 @@ SLUS-29155:
   region: "NTSC-U"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
-    cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
+    cpuCLUTRender: 1 # Final colour adjustment LUT.
+    gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
 SLUS-29156:
   name: "Marvel Nemesis - Rise of the Imperfects [Demo]"
   region: "NTSC-U"

--- a/bin/resources/shaders/dx11/convert.fx
+++ b/bin/resources/shaders/dx11/convert.fx
@@ -23,7 +23,8 @@ cbuffer cb0 : register(b0)
 	float4 BGColor;
 	int EMODA;
 	int EMODC;
-	int cb0_pad[2];
+	int DOFFSET;
+	int cb0_pad;
 };
 
 static const float3x3 rgb2yuv =
@@ -288,6 +289,41 @@ PS_OUTPUT ps_convert_rgba_8i(PS_INPUT input)
 	float2 sel0 = (pos.y & 2u) == 0u ? pixel.rb : pixel.ga;
 	float  sel1 = (pos.x & 8u) == 0u ? sel0.x : sel0.y;
 	output.c = (float4)(sel1); // Divide by something here?
+	return output;
+}
+
+PS_OUTPUT ps_convert_clut_4(PS_INPUT input)
+{
+	// Borrowing the YUV constant buffer.
+	float2 scale = BGColor.xy;
+	uint2 offset = uint2(uint(EMODA), uint(EMODC)) + uint(DOFFSET);
+
+	// CLUT4 is easy, just two rows of 8x8.
+	uint index = uint(input.p.x);
+	uint2 pos = uint2(index % 8u, index / 8u);
+
+	int2 final = int2(floor(float2(offset + pos) * scale));
+	PS_OUTPUT output;
+	output.c = Texture.Load(int3(final, 0), 0);
+	return output;
+}
+
+PS_OUTPUT ps_convert_clut_8(PS_INPUT input)
+{
+	float2 scale = BGColor.xy;
+	uint2 offset = uint2(uint(EMODA), uint(EMODC));
+	uint index = min(uint(input.p.x) + uint(DOFFSET), 240u);
+
+	// CLUT is arranged into 8 groups of 16x2, with the top-right and bottom-left quadrants swapped.
+	// This can probably be done better..
+	uint subgroup = (index / 8u) % 4u;
+	uint2 pos;
+	pos.x = (index % 8u) + ((subgroup >= 2u) ? 8u : 0u);
+	pos.y = ((index / 32u) * 2u) + (subgroup % 2u);
+
+	int2 final = int2(floor(float2(offset + pos) * scale));
+	PS_OUTPUT output;
+	output.c = Texture.Load(int3(final, 0), 0);
 	return output;
 }
 

--- a/bin/resources/shaders/dx11/convert.fx
+++ b/bin/resources/shaders/dx11/convert.fx
@@ -312,7 +312,7 @@ PS_OUTPUT ps_convert_clut_8(PS_INPUT input)
 {
 	float2 scale = BGColor.xy;
 	uint2 offset = uint2(uint(EMODA), uint(EMODC));
-	uint index = min(uint(input.p.x) + uint(DOFFSET), 240u);
+	uint index = min(uint(input.p.x) + uint(DOFFSET), 255u);
 
 	// CLUT is arranged into 8 groups of 16x2, with the top-right and bottom-left quadrants swapped.
 	// This can probably be done better..

--- a/bin/resources/shaders/opengl/convert.glsl
+++ b/bin/resources/shaders/opengl/convert.glsl
@@ -335,7 +335,7 @@ uniform vec2 scale;
 
 void ps_convert_clut_8()
 {
-	uint index = min(uint(gl_FragCoord.x) + offset.z, 240u);
+	uint index = min(uint(gl_FragCoord.x) + offset.z, 255u);
 
 	// CLUT is arranged into 8 groups of 16x2, with the top-right and bottom-left quadrants swapped.
 	// This can probably be done better..

--- a/bin/resources/shaders/opengl/convert.glsl
+++ b/bin/resources/shaders/opengl/convert.glsl
@@ -314,6 +314,41 @@ void ps_hdr_resolve()
 }
 #endif
 
+#ifdef ps_convert_clut_4
+uniform uvec3 offset;
+uniform vec2 scale;
+
+void ps_convert_clut_4()
+{
+	// CLUT4 is easy, just two rows of 8x8.
+	uint index = uint(gl_FragCoord.x) + offset.z;
+	uvec2 pos = uvec2(index % 8u, index / 8u);
+
+	ivec2 final = ivec2(floor(vec2(offset.xy + pos) * scale));
+	SV_Target0 = texelFetch(TextureSampler, final, 0);
+}
+#endif
+
+#ifdef ps_convert_clut_8
+uniform uvec3 offset;
+uniform vec2 scale;
+
+void ps_convert_clut_8()
+{
+	uint index = min(uint(gl_FragCoord.x) + offset.z, 240u);
+
+	// CLUT is arranged into 8 groups of 16x2, with the top-right and bottom-left quadrants swapped.
+	// This can probably be done better..
+	uint subgroup = (index / 8u) % 4u;
+	uvec2 pos;
+	pos.x = (index % 8u) + ((subgroup >= 2u) ? 8u : 0u);
+	pos.y = ((index / 32u) * 2u) + (subgroup % 2u);
+
+	ivec2 final = ivec2(floor(vec2(offset.xy + pos) * scale));
+	SV_Target0 = texelFetch(TextureSampler, final, 0);
+}
+#endif
+
 #ifdef ps_yuv
 uniform ivec2 EMOD;
 

--- a/bin/resources/shaders/vulkan/convert.glsl
+++ b/bin/resources/shaders/vulkan/convert.glsl
@@ -303,7 +303,7 @@ layout(push_constant) uniform cb10
 
 void ps_convert_clut_8()
 {
-	uint index = min(uint(gl_FragCoord.x) + doffset, 240u);
+	uint index = min(uint(gl_FragCoord.x) + doffset, 255u);
 
 	// CLUT is arranged into 8 groups of 16x2, with the top-right and bottom-left quadrants swapped.
 	// This can probably be done better..

--- a/bin/resources/shaders/vulkan/convert.glsl
+++ b/bin/resources/shaders/vulkan/convert.glsl
@@ -274,6 +274,49 @@ void ps_convert_rgba_8i()
 }
 #endif
 
+#ifdef ps_convert_clut_4
+layout(push_constant) uniform cb10
+{
+	vec2 scale;
+	uvec2 offset;
+	uint doffset;
+};
+
+void ps_convert_clut_4()
+{
+	// CLUT4 is easy, just two rows of 8x8.
+	uint index = uint(gl_FragCoord.x) + doffset;
+	uvec2 pos = uvec2(index % 8u, index / 8u);
+
+	ivec2 final = ivec2(floor(vec2(offset + pos) * scale));
+	o_col0 = texelFetch(samp0, final, 0);
+}
+#endif
+
+#ifdef ps_convert_clut_8
+layout(push_constant) uniform cb10
+{
+	vec2 scale;
+	uvec2 offset;
+	uint doffset;
+};
+
+void ps_convert_clut_8()
+{
+	uint index = min(uint(gl_FragCoord.x) + doffset, 240u);
+
+	// CLUT is arranged into 8 groups of 16x2, with the top-right and bottom-left quadrants swapped.
+	// This can probably be done better..
+	uint subgroup = (index / 8u) % 4u;
+	uvec2 pos;
+	pos.x = (index % 8u) + ((subgroup >= 2u) ? 8u : 0u);
+	pos.y = ((index / 32u) * 2u) + (subgroup % 2u);
+
+	ivec2 final = ivec2(floor(vec2(offset + pos) * scale));
+	o_col0 = texelFetch(samp0, final, 0);
+}
+#endif
+
 #ifdef ps_yuv
 layout(push_constant) uniform cb10
 {

--- a/bin/resources/shaders/vulkan/tfx.glsl
+++ b/bin/resources/shaders/vulkan/tfx.glsl
@@ -390,7 +390,7 @@ layout(location = 0) out vec4 o_col0;
 #endif
 
 layout(set = 1, binding = 0) uniform sampler2D Texture;
-layout(set = 1, binding = 1) uniform sampler2D Palette;
+layout(set = 1, binding = 1) uniform texture2D Palette;
 
 #if PS_FEEDBACK_LOOP_IS_NEEDED
 	#ifndef DISABLE_TEXTURE_BARRIER
@@ -443,9 +443,14 @@ vec4 sample_c(vec2 uv)
 #endif
 }
 
-vec4 sample_p(float u)
+vec4 sample_p(uint idx)
 {
-	return texture(Palette, vec2(u, 0.0f));
+	return texelFetch(Palette, ivec2(int(idx), 0), 0);
+}
+
+vec4 sample_p_norm(float u)
+{
+	return sample_p(uint(u * 255.5f));
 }
 
 vec4 clamp_wrap_uv(vec4 uv)
@@ -519,7 +524,7 @@ mat4 sample_4c(vec4 uv)
 	return c;
 }
 
-vec4 sample_4_index(vec4 uv)
+uvec4 sample_4_index(vec4 uv)
 {
 	vec4 c;
 
@@ -533,18 +538,17 @@ vec4 sample_4_index(vec4 uv)
 
 	#if PS_PAL_FMT == 1
 		// 4HL
-		c = vec4(i & 0xFu) / 255.0f;
+		c = i & 0xFu;
 	#elif PS_PAL_FMT == 2
 		// 4HH
-		c = vec4(i >> 4u) / 255.0f;
+		c = i >> 4u;
+	#else
+		// 8
+		return i;
 	#endif
-
-	// Most of texture will hit this code so keep normalized float value
-	// 8 bits
-	return c * 255./256 + 0.5/256;
 }
 
-mat4 sample_4p(vec4 u)
+mat4 sample_4p(uvec4 u)
 {
 	mat4 c;
 
@@ -709,7 +713,7 @@ vec4 fetch_red(ivec2 xy)
 		rt = fetch_raw_color(xy);
 	#endif
 
-	return sample_p(rt.r) * 255.0f;
+	return sample_p_norm(rt.r) * 255.0f;
 }
 
 vec4 fetch_green(ivec2 xy)
@@ -723,7 +727,7 @@ vec4 fetch_green(ivec2 xy)
 		rt = fetch_raw_color(xy);
 	#endif
 
-	return sample_p(rt.g) * 255.0f;
+	return sample_p_norm(rt.g) * 255.0f;
 }
 
 vec4 fetch_blue(ivec2 xy)
@@ -737,19 +741,19 @@ vec4 fetch_blue(ivec2 xy)
 		rt = fetch_raw_color(xy);
 	#endif
 
-	return sample_p(rt.b) * 255.0f;
+	return sample_p_norm(rt.b) * 255.0f;
 }
 
 vec4 fetch_alpha(ivec2 xy)
 {
 	vec4 rt = fetch_raw_color(xy);
-	return sample_p(rt.a) * 255.0f;
+	return sample_p_norm(rt.a) * 255.0f;
 }
 
 vec4 fetch_rgb(ivec2 xy)
 {
 	vec4 rt = fetch_raw_color(xy);
-	vec4 c = vec4(sample_p(rt.r).r, sample_p(rt.g).g, sample_p(rt.b).b, 1.0);
+	vec4 c = vec4(sample_p_norm(rt.r).r, sample_p_norm(rt.g).g, sample_p_norm(rt.b).b, 1.0);
 	return c * 255.0f;
 }
 

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -205,6 +205,7 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsDialog* dialog, QWidget* 
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.halfScreenFix, "EmuCore/GS", "UserHacks_Half_Bottom_Override", -1, -1);
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.cpuSpriteRenderBW, "EmuCore/GS", "UserHacks_CPUSpriteRenderBW", 0);
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.cpuCLUTRender, "EmuCore/GS", "UserHacks_CPUCLUTRender", 0);
+	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.gpuTargetCLUTMode, "EmuCore/GS", "UserHacks_GPUTargetCLUTMode", 0);
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.skipDrawStart, "EmuCore/GS", "UserHacks_SkipDraw_Start", 0);
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.skipDrawEnd, "EmuCore/GS", "UserHacks_SkipDraw_End", 0);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.hwAutoFlush, "EmuCore/GS", "UserHacks_AutoFlush", false);

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
@@ -920,14 +920,14 @@
          </item>
         </widget>
        </item>
-       <item row="3" column="0">
+       <item row="4" column="0">
         <widget class="QLabel" name="label_12">
          <property name="text">
           <string>Skipdraw Range:</string>
          </property>
         </widget>
        </item>
-       <item row="3" column="1">
+       <item row="4" column="1">
         <layout class="QHBoxLayout" name="horizontalLayout">
          <item>
           <widget class="QSpinBox" name="skipDrawStart">
@@ -945,7 +945,7 @@
          </item>
         </layout>
        </item>
-       <item row="4" column="0" colspan="2">
+       <item row="5" column="0" colspan="2">
         <layout class="QGridLayout" name="gridLayout">
          <item row="0" column="0">
           <widget class="QCheckBox" name="hwAutoFlush">
@@ -1028,6 +1028,32 @@
          <property name="text">
           <string>Software CLUT Render:</string>
          </property>
+        </widget>
+       </item>
+       <item row="3" column="0">
+        <widget class="QLabel" name="label_47">
+         <property name="text">
+          <string>GPU Target CLUT:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="1">
+        <widget class="QComboBox" name="gpuTargetCLUTMode">
+         <item>
+          <property name="text">
+           <string>Disabled (Default)</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Enabled (Exact Match)</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Enabled (Check Inside Target)</string>
+          </property>
+         </item>
         </widget>
        </item>
       </layout>

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -350,6 +350,13 @@ enum class GSCASMode : u8
 	SharpenAndResize,
 };
 
+enum class GSGPUTargetCLUTMode : u8
+{
+	Disabled,
+	Enabled,
+	InsideTarget,
+};
+
 // Template function for casting enumerations to their underlying type
 template <typename Enumeration>
 typename std::underlying_type<Enumeration>::type enum_cast(Enumeration E)
@@ -727,6 +734,7 @@ struct Pcsx2Config
 		int UserHacks_TCOffsetY{0};
 		int UserHacks_CPUSpriteRenderBW{0};
 		int UserHacks_CPUCLUTRender{ 0 };
+		GSGPUTargetCLUTMode UserHacks_GPUTargetCLUTMode{GSGPUTargetCLUTMode::Disabled};
 		TriFiltering TriFilter{TriFiltering::Automatic};
 		int OverrideTextureBarriers{-1};
 		int OverrideGeometryShaders{-1};

--- a/pcsx2/Docs/gamedb-schema.json
+++ b/pcsx2/Docs/gamedb-schema.json
@@ -221,6 +221,11 @@
               "minimum": 1,
               "maximum": 2
             },
+            "gpuTargetCLUT": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 2
+            },
             "gpuPaletteConversion": {
               "type": "integer",
               "minimum": 0,

--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -728,7 +728,8 @@ void GSUpdateConfig(const Pcsx2Config::GSOptions& new_config)
 		GSConfig.UserHacks_DisablePartialInvalidation != old_config.UserHacks_DisablePartialInvalidation ||
 		GSConfig.UserHacks_TextureInsideRt != old_config.UserHacks_TextureInsideRt ||
 		GSConfig.UserHacks_CPUSpriteRenderBW != old_config.UserHacks_CPUSpriteRenderBW ||
-		GSConfig.UserHacks_CPUCLUTRender != old_config.UserHacks_CPUCLUTRender)
+		GSConfig.UserHacks_CPUCLUTRender != old_config.UserHacks_CPUCLUTRender ||
+		GSConfig.UserHacks_GPUTargetCLUTMode != old_config.UserHacks_GPUTargetCLUTMode)
 	{
 		g_gs_renderer->PurgeTextureCache();
 		g_gs_renderer->PurgePool();

--- a/pcsx2/GS/GSClut.h
+++ b/pcsx2/GS/GSClut.h
@@ -21,6 +21,7 @@
 #include "GSAlignedClass.h"
 
 class GSLocalMemory;
+class GSTexture;
 
 class alignas(32) GSClut final : public GSAlignedClass<32>
 {
@@ -54,6 +55,10 @@ class alignas(32) GSClut final : public GSAlignedClass<32>
 		bool IsDirty(const GIFRegTEX0& TEX0);
 		bool IsDirty(const GIFRegTEX0& TEX0, const GIFRegTEXA& TEXA);
 	} m_read;
+
+	GSTexture* m_gpu_clut4 = nullptr;
+	GSTexture* m_gpu_clut8 = nullptr;
+	GSTexture* m_current_gpu_clut = nullptr;
 
 	typedef void (GSClut::*writeCLUT)(const GIFRegTEX0& TEX0, const GIFRegTEXCLUT& TEXCLUT);
 
@@ -100,6 +105,8 @@ private:
 public:
 	GSClut(GSLocalMemory* mem);
 	~GSClut();
+
+	__fi GSTexture* GetGPUTexture() const { return m_current_gpu_clut; }
 
 	bool InvalidateRange(u32 start_block, u32 end_block, bool is_draw = false);
 	u8 IsInvalid();

--- a/pcsx2/GS/Renderers/Common/GSDevice.cpp
+++ b/pcsx2/GS/Renderers/Common/GSDevice.cpp
@@ -46,6 +46,8 @@ const char* shaderName(ShaderConvert value)
 		case ShaderConvert::RGB5A1_TO_FLOAT16_BILN: return "ps_convert_rgb5a1_float16_biln";
 		case ShaderConvert::DEPTH_COPY:             return "ps_depth_copy";
 		case ShaderConvert::RGBA_TO_8I:             return "ps_convert_rgba_8i";
+		case ShaderConvert::CLUT_4:                 return "ps_convert_clut_4";
+		case ShaderConvert::CLUT_8:                 return "ps_convert_clut_8";
 		case ShaderConvert::YUV:                    return "ps_yuv";
 			// clang-format on
 		default:

--- a/pcsx2/GS/Renderers/Common/GSDevice.h
+++ b/pcsx2/GS/Renderers/Common/GSDevice.h
@@ -49,6 +49,8 @@ enum class ShaderConvert
 	RGB5A1_TO_FLOAT16_BILN,
 	DEPTH_COPY,
 	RGBA_TO_8I,
+	CLUT_4,
+	CLUT_8,
 	YUV,
 	Count
 };
@@ -833,6 +835,9 @@ public:
 
 	/// Performs a screen blit for display. If dTex is null, it assumes you are writing to the system framebuffer/swap chain.
 	virtual void PresentRect(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect, PresentShader shader, float shaderTime, bool linear) {}
+
+	/// Updates a GPU CLUT texture from a source texture.
+	virtual void UpdateCLUTTexture(GSTexture* sTex, u32 offsetX, u32 offsetY, GSTexture* dTex, u32 dOffset, u32 dSize) {}
 
 	virtual void RenderHW(GSHWDrawConfig& config) {}
 

--- a/pcsx2/GS/Renderers/Common/GSDirtyRect.cpp
+++ b/pcsx2/GS/Renderers/Common/GSDirtyRect.cpp
@@ -30,7 +30,7 @@ GSDirtyRect::GSDirtyRect(GSVector4i& r, u32 psm, u32 bw) :
 {
 }
 
-GSVector4i GSDirtyRect::GetDirtyRect(GIFRegTEX0& TEX0)
+GSVector4i GSDirtyRect::GetDirtyRect(GIFRegTEX0& TEX0) const
 {
 	GSVector4i _r;
 
@@ -55,7 +55,7 @@ GSVector4i GSDirtyRect::GetDirtyRect(GIFRegTEX0& TEX0)
 
 //
 
-GSVector4i GSDirtyRectList::GetDirtyRect(GIFRegTEX0& TEX0, const GSVector2i& size)
+GSVector4i GSDirtyRectList::GetDirtyRect(GIFRegTEX0& TEX0, const GSVector2i& size) const
 {
 	if (!empty())
 	{

--- a/pcsx2/GS/Renderers/Common/GSDirtyRect.h
+++ b/pcsx2/GS/Renderers/Common/GSDirtyRect.h
@@ -26,13 +26,13 @@ public:
 
 	GSDirtyRect();
 	GSDirtyRect(GSVector4i& r, u32 psm, u32 bw);
-	GSVector4i GetDirtyRect(GIFRegTEX0& TEX0);
+	GSVector4i GetDirtyRect(GIFRegTEX0& TEX0) const;
 };
 
 class GSDirtyRectList : public std::vector<GSDirtyRect>
 {
 public:
 	GSDirtyRectList() {}
-	GSVector4i GetDirtyRect(GIFRegTEX0& TEX0, const GSVector2i& size);
+	GSVector4i GetDirtyRect(GIFRegTEX0& TEX0, const GSVector2i& size) const;
 	GSVector4i GetDirtyRectAndClear(GIFRegTEX0& TEX0, const GSVector2i& size);
 };

--- a/pcsx2/GS/Renderers/Common/GSRenderer.cpp
+++ b/pcsx2/GS/Renderers/Common/GSRenderer.cpp
@@ -954,6 +954,11 @@ void GSRenderer::PurgeTextureCache()
 {
 }
 
+GSTexture* GSRenderer::LookupPaletteSource(u32 CBP, u32 CPSM, u32 CBW, GSVector2i& offset, const GSVector2i& size)
+{
+	return nullptr;
+}
+
 bool GSRenderer::SaveSnapshotToMemory(u32 window_width, u32 window_height, bool apply_aspect, bool crop_borders,
 	u32* width, u32* height, std::vector<u32>* pixels)
 {

--- a/pcsx2/GS/Renderers/Common/GSRenderer.h
+++ b/pcsx2/GS/Renderers/Common/GSRenderer.h
@@ -54,6 +54,8 @@ public:
 	virtual void PurgePool() override;
 	virtual void PurgeTextureCache();
 
+	virtual GSTexture* LookupPaletteSource(u32 CBP, u32 CPSM, u32 CBW, GSVector2i& offset, const GSVector2i& size);
+
 	bool SaveSnapshotToMemory(u32 window_width, u32 window_height, bool apply_aspect, bool crop_borders,
 		u32* width, u32* height, std::vector<u32>* pixels);
 

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
@@ -682,7 +682,7 @@ void GSDevice11::StretchRect(GSTexture* sTex, const GSVector4& sRect, GSTexture*
 	// ps
 
 	PSSetShaderResources(sTex, nullptr);
-	PSSetSamplerState(linear ? m_convert.ln.get() : m_convert.pt.get(), nullptr);
+	PSSetSamplerState(linear ? m_convert.ln.get() : m_convert.pt.get());
 	PSSetShader(ps, ps_cb);
 
 	//
@@ -759,7 +759,7 @@ void GSDevice11::PresentRect(GSTexture* sTex, const GSVector4& sRect, GSTexture*
 	// ps
 
 	PSSetShaderResources(sTex, nullptr);
-	PSSetSamplerState(linear ? m_convert.ln.get() : m_convert.pt.get(), nullptr);
+	PSSetSamplerState(linear ? m_convert.ln.get() : m_convert.pt.get());
 	PSSetShader(m_present.ps[static_cast<u32>(shader)].get(), m_present.ps_cb.get());
 
 	//
@@ -958,7 +958,7 @@ void GSDevice11::SetupDATE(GSTexture* rt, GSTexture* ds, const GSVertexPT1* vert
 
 	// ps
 	PSSetShaderResources(rt, nullptr);
-	PSSetSamplerState(m_convert.pt.get(), nullptr);
+	PSSetSamplerState(m_convert.pt.get());
 	PSSetShader(m_convert.ps[static_cast<int>(datm ? ShaderConvert::DATM_1 : ShaderConvert::DATM_0)].get(), nullptr);
 
 	//
@@ -1184,10 +1184,9 @@ void GSDevice11::PSSetShaderResource(int i, GSTexture* sr)
 	m_state.ps_sr_views[i] = sr ? static_cast<ID3D11ShaderResourceView*>(*static_cast<GSTexture11*>(sr)) : nullptr;
 }
 
-void GSDevice11::PSSetSamplerState(ID3D11SamplerState* ss0, ID3D11SamplerState* ss1)
+void GSDevice11::PSSetSamplerState(ID3D11SamplerState* ss0)
 {
 	m_state.ps_ss[0] = ss0;
-	m_state.ps_ss[1] = ss1;
 }
 
 void GSDevice11::PSSetShader(ID3D11PixelShader* ps, ID3D11Buffer* ps_cb)

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.h
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.h
@@ -267,6 +267,7 @@ public:
 	void StretchRect(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect, bool red, bool green, bool blue, bool alpha) override;
 	void StretchRect(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect, ID3D11PixelShader* ps, ID3D11Buffer* ps_cb, ID3D11BlendState* bs, bool linear = true);
 	void PresentRect(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect, PresentShader shader, float shaderTime, bool linear) override;
+	void UpdateCLUTTexture(GSTexture* sTex, u32 offsetX, u32 offsetY, GSTexture* dTex, u32 dOffset, u32 dSize) override;
 
 	void SetupDATE(GSTexture* rt, GSTexture* ds, const GSVertexPT1* vertices, bool datm);
 

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.h
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.h
@@ -110,7 +110,7 @@ public:
 
 private:
 	static constexpr u32 MAX_TEXTURES = 4;
-	static constexpr u32 MAX_SAMPLERS = 2;
+	static constexpr u32 MAX_SAMPLERS = 1;
 
 	int m_d3d_texsize;
 
@@ -221,7 +221,6 @@ private:
 	std::unordered_map<PSSelector, wil::com_ptr_nothrow<ID3D11PixelShader>, GSHWDrawConfig::PSSelectorHash> m_ps;
 	wil::com_ptr_nothrow<ID3D11Buffer> m_ps_cb;
 	std::unordered_map<u32, wil::com_ptr_nothrow<ID3D11SamplerState>> m_ps_ss;
-	wil::com_ptr_nothrow<ID3D11SamplerState> m_palette_ss;
 	std::unordered_map<u32, wil::com_ptr_nothrow<ID3D11DepthStencilState>> m_om_dss;
 	std::unordered_map<u32, wil::com_ptr_nothrow<ID3D11BlendState>> m_om_bs;
 	wil::com_ptr_nothrow<ID3D11RasterizerState> m_rs;
@@ -287,7 +286,7 @@ public:
 	void PSSetShaderResource(int i, GSTexture* sr);
 	void PSSetShader(ID3D11PixelShader* ps, ID3D11Buffer* ps_cb);
 	void PSUpdateShaderState();
-	void PSSetSamplerState(ID3D11SamplerState* ss0, ID3D11SamplerState* ss1);
+	void PSSetSamplerState(ID3D11SamplerState* ss0);
 
 	void OMSetDepthStencilState(ID3D11DepthStencilState* dss, u8 sref);
 	void OMSetBlendState(ID3D11BlendState* bs, float bf);

--- a/pcsx2/GS/Renderers/DX11/GSTextureFX11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSTextureFX11.cpp
@@ -46,24 +46,6 @@ bool GSDevice11::CreateTextureFX()
 	if (FAILED(hr))
 		return false;
 
-	D3D11_SAMPLER_DESC sd;
-
-	memset(&sd, 0, sizeof(sd));
-
-	sd.Filter = D3D11_FILTER_MIN_MAG_MIP_POINT;
-	sd.AddressU = D3D11_TEXTURE_ADDRESS_CLAMP;
-	sd.AddressV = D3D11_TEXTURE_ADDRESS_CLAMP;
-	sd.AddressW = D3D11_TEXTURE_ADDRESS_CLAMP;
-	sd.MinLOD = -FLT_MAX;
-	sd.MaxLOD = FLT_MAX;
-	sd.MaxAnisotropy = 1;
-	sd.ComparisonFunc = D3D11_COMPARISON_NEVER;
-
-	hr = m_dev->CreateSamplerState(&sd, m_palette_ss.put());
-
-	if (FAILED(hr))
-		return false;
-
 	// create layout
 
 	VSSelector sel;
@@ -212,7 +194,7 @@ void GSDevice11::SetupPS(const PSSelector& sel, const GSHWDrawConfig::PSConstant
 		m_ctx->UpdateSubresource(m_ps_cb.get(), 0, NULL, cb, 0, 0);
 	}
 
-	wil::com_ptr_nothrow<ID3D11SamplerState> ss0, ss1;
+	wil::com_ptr_nothrow<ID3D11SamplerState> ss0;
 
 	if (sel.tfx != 4)
 	{
@@ -267,14 +249,9 @@ void GSDevice11::SetupPS(const PSSelector& sel, const GSHWDrawConfig::PSConstant
 
 			m_ps_ss[ssel.key] = ss0;
 		}
-
-		if (sel.pal_fmt)
-		{
-			ss1 = m_palette_ss;
-		}
 	}
 
-	PSSetSamplerState(ss0.get(), ss1.get());
+	PSSetSamplerState(ss0.get());
 
 	PSSetShader(i->second.get(), m_ps_cb.get());
 }

--- a/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
@@ -521,6 +521,24 @@ void GSDevice12::PresentRect(GSTexture* sTex, const GSVector4& sRect, GSTexture*
 		m_present[static_cast<int>(shader)].get(), linear);
 }
 
+void GSDevice12::UpdateCLUTTexture(GSTexture* sTex, u32 offsetX, u32 offsetY, GSTexture* dTex, u32 dOffset, u32 dSize)
+{
+	struct Uniforms
+	{
+		float scaleX, scaleY;
+		float pad1[2];
+		u32 offsetX, offsetY, dOffset;
+		u32 pad2;
+	};
+	const Uniforms cb = {sTex->GetScale().x, sTex->GetScale().y, 0.0f, 0.0f, offsetX, offsetY, dOffset};
+	SetUtilityPushConstants(&cb, sizeof(cb));
+
+	const GSVector4 dRect(0, 0, dSize, 1);
+	const ShaderConvert shader = (dSize == 16) ? ShaderConvert::CLUT_4 : ShaderConvert::CLUT_8;
+	DoStretchRect(static_cast<GSTexture12*>(sTex), GSVector4::zero(), static_cast<GSTexture12*>(dTex), dRect,
+		m_convert[static_cast<int>(shader)].get(), false);
+}
+
 void GSDevice12::BeginRenderPassForStretchRect(GSTexture12* dTex, const GSVector4i& dtex_rc, const GSVector4i& dst_rc)
 {
 	const bool is_whole_target = dst_rc.eq(dtex_rc);

--- a/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
@@ -1143,7 +1143,7 @@ bool GSDevice12::CreateRootSignatures()
 	rsb.AddCBVParameter(0, D3D12_SHADER_VISIBILITY_ALL);
 	rsb.AddCBVParameter(1, D3D12_SHADER_VISIBILITY_PIXEL);
 	rsb.AddDescriptorTable(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 0, 2, D3D12_SHADER_VISIBILITY_PIXEL);
-	rsb.AddDescriptorTable(D3D12_DESCRIPTOR_RANGE_TYPE_SAMPLER, 0, 2, D3D12_SHADER_VISIBILITY_PIXEL);
+	rsb.AddDescriptorTable(D3D12_DESCRIPTOR_RANGE_TYPE_SAMPLER, 0, NUM_TFX_SAMPLERS, D3D12_SHADER_VISIBILITY_PIXEL);
 	rsb.AddDescriptorTable(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 2, 2, D3D12_SHADER_VISIBILITY_PIXEL);
 	if (!(m_tfx_root_signature = rsb.Create()))
 		return false;
@@ -1806,8 +1806,7 @@ void GSDevice12::InitializeState()
 {
 	for (u32 i = 0; i < NUM_TOTAL_TFX_TEXTURES; i++)
 		m_tfx_textures[i] = m_null_texture.GetSRVDescriptor();
-	for (u32 i = 0; i < NUM_TFX_SAMPLERS; i++)
-		m_tfx_sampler_sel[i] = GSHWDrawConfig::SamplerSelector::Point().key;
+	m_tfx_sampler_sel = GSHWDrawConfig::SamplerSelector::Point().key;
 
 	InvalidateCachedState();
 }
@@ -1816,9 +1815,7 @@ void GSDevice12::InitializeSamplers()
 {
 	bool result = GetSampler(&m_point_sampler_cpu, GSHWDrawConfig::SamplerSelector::Point());
 	result = result && GetSampler(&m_linear_sampler_cpu, GSHWDrawConfig::SamplerSelector::Linear());
-
-	for (u32 i = 0; i < NUM_TFX_SAMPLERS; i++)
-		result = result && GetSampler(&m_tfx_samplers[i], m_tfx_sampler_sel[i]);
+	result = result && GetSampler(&m_tfx_sampler, m_tfx_sampler_sel);
 
 	if (!result)
 		pxFailRel("Failed to initialize samplers");
@@ -1970,13 +1967,13 @@ void GSDevice12::PSSetShaderResource(int i, GSTexture* sr, bool check_state)
 	m_dirty_flags |= (i < 2) ? DIRTY_FLAG_TFX_TEXTURES : DIRTY_FLAG_TFX_RT_TEXTURES;
 }
 
-void GSDevice12::PSSetSampler(u32 index, GSHWDrawConfig::SamplerSelector sel)
+void GSDevice12::PSSetSampler(GSHWDrawConfig::SamplerSelector sel)
 {
-	if (m_tfx_sampler_sel[index] == sel.key)
+	if (m_tfx_sampler_sel == sel.key)
 		return;
 
-	GetSampler(&m_tfx_samplers[index], sel);
-	m_tfx_sampler_sel[index] = sel.key;
+	GetSampler(&m_tfx_sampler, sel);
+	m_tfx_sampler_sel = sel.key;
 	m_dirty_flags |= DIRTY_FLAG_TFX_SAMPLERS;
 }
 
@@ -2330,7 +2327,7 @@ bool GSDevice12::ApplyTFXState(bool already_execed)
 
 	if (flags & DIRTY_FLAG_TFX_SAMPLERS)
 	{
-		if (!g_d3d12_context->GetSamplerAllocator().LookupGroup(&m_tfx_samplers_handle_gpu, m_tfx_samplers.data()))
+		if (!g_d3d12_context->GetSamplerAllocator().LookupSingle(&m_tfx_samplers_handle_gpu, m_tfx_sampler))
 		{
 			ExecuteCommandListAndRestartRenderPass(false, "Ran out of sampler groups");
 			return ApplyTFXState(true);
@@ -2555,7 +2552,7 @@ void GSDevice12::RenderHW(GSHWDrawConfig& config)
 	if (config.tex)
 	{
 		PSSetShaderResource(0, config.tex, config.tex != config.rt);
-		PSSetSampler(0, config.sampler);
+		PSSetSampler(config.sampler);
 	}
 	if (config.pal)
 		PSSetShaderResource(1, config.pal, true);

--- a/pcsx2/GS/Renderers/DX12/GSDevice12.h
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.h
@@ -264,6 +264,7 @@ public:
 		bool green, bool blue, bool alpha) override;
 	void PresentRect(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect,
 		PresentShader shader, float shaderTime, bool linear) override;
+	void UpdateCLUTTexture(GSTexture* sTex, u32 offsetX, u32 offsetY, GSTexture* dTex, u32 dOffset, u32 dSize) override;
 
 	void BeginRenderPassForStretchRect(GSTexture12* dTex, const GSVector4i& dtex_rc, const GSVector4i& dst_rc);
 	void DoStretchRect(GSTexture12* sTex, const GSVector4& sRect, GSTexture12* dTex, const GSVector4& dRect,

--- a/pcsx2/GS/Renderers/DX12/GSDevice12.h
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.h
@@ -112,7 +112,7 @@ public:
 		NUM_TFX_TEXTURES = 2,
 		NUM_TFX_RT_TEXTURES = 2,
 		NUM_TOTAL_TFX_TEXTURES = NUM_TFX_TEXTURES + NUM_TFX_RT_TEXTURES,
-		NUM_TFX_SAMPLERS = 2,
+		NUM_TFX_SAMPLERS = 1,
 		NUM_UTILITY_TEXTURES = 1,
 		NUM_UTILITY_SAMPLERS = 1,
 		CONVERT_PUSH_CONSTANTS_SIZE = 96,
@@ -279,7 +279,7 @@ public:
 	void IASetIndexBuffer(const void* index, size_t count);
 
 	void PSSetShaderResource(int i, GSTexture* sr, bool check_state);
-	void PSSetSampler(u32 index, GSHWDrawConfig::SamplerSelector sel);
+	void PSSetSampler(GSHWDrawConfig::SamplerSelector sel);
 
 	void OMSetRenderTargets(GSTexture* rt, GSTexture* ds, const GSVector4i& scissor);
 
@@ -404,8 +404,8 @@ private:
 
 	std::array<D3D12_GPU_VIRTUAL_ADDRESS, NUM_TFX_CONSTANT_BUFFERS> m_tfx_constant_buffers{};
 	std::array<D3D12::DescriptorHandle, NUM_TOTAL_TFX_TEXTURES> m_tfx_textures{};
-	std::array<D3D12::DescriptorHandle, NUM_TFX_SAMPLERS> m_tfx_samplers{};
-	std::array<u32, NUM_TFX_SAMPLERS> m_tfx_sampler_sel{};
+	D3D12::DescriptorHandle m_tfx_sampler;
+	u32 m_tfx_sampler_sel = 0;
 	D3D12::DescriptorHandle m_tfx_textures_handle_gpu;
 	D3D12::DescriptorHandle m_tfx_samplers_handle_gpu;
 	D3D12::DescriptorHandle m_tfx_rt_textures_handle_gpu;

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.h
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.h
@@ -66,8 +66,15 @@ private:
 	void SwSpriteRender();
 	bool CanUseSwSpriteRender();
 
-	bool PossibleCLUTDraw();
-	bool PossibleCLUTDrawAggressive();
+	enum class CLUTDrawTestResult
+	{
+		NotCLUTDraw,
+		CLUTDrawOnCPU,
+		CLUTDrawOnGPU,
+	};
+
+	CLUTDrawTestResult PossibleCLUTDraw();
+	CLUTDrawTestResult PossibleCLUTDrawAggressive();
 	bool CanUseSwPrimRender(bool no_rt, bool no_ds, bool draw_sprite_tex);
 	bool (*SwPrimRender)(GSRendererHW&, bool invalidate_tc);
 
@@ -153,6 +160,7 @@ public:
 	void Draw() override;
 
 	void PurgeTextureCache() override;
+	GSTexture* LookupPaletteSource(u32 CBP, u32 CPSM, u32 CBW, GSVector2i& offset, const GSVector2i& size) override;
 
 	// Called by the texture cache to know if current texture is useful
 	bool UpdateTexIsFB(GSTextureCache::Target* src, const GIFRegTEX0& TEX0);

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -3244,7 +3244,7 @@ void GSTextureCache::Palette::InitializeTexture()
 		// sampling such texture are always normalized by 255.
 		// This is because indexes are stored as normalized values of an RGBA texture (e.g. index 15 will be read as (15/255),
 		// and therefore will read texel 15/255 * texture size).
-		m_tex_palette = g_gs_device->CreateTexture(256, 1, 1, GSTexture::Format::Color);
+		m_tex_palette = g_gs_device->CreateTexture(m_pal, 1, 1, GSTexture::Format::Color);
 		m_tex_palette->Update(GSVector4i(0, 0, m_pal, 1), m_clut, m_pal * sizeof(m_clut[0]));
 	}
 }

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -2269,7 +2269,7 @@ GSTexture* GSTextureCache::LookupPaletteSource(u32 CBP, u32 CPSM, u32 CBW, GSVec
 			if (t->m_TEX0.PSM != CPSM || (CBW != 0 && t->m_TEX0.TBW != CBW))
 				continue;
 
-			GL_INS("Exact match on BP 0x%04x BW %u", t->m_TEX0.CBP, t->m_TEX0.TBW);
+			GL_INS("Exact match on BP 0x%04x BW %u", t->m_TEX0.TBP0, t->m_TEX0.TBW);
 			this_offset.x = 0;
 			this_offset.y = 0;
 		}

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -224,12 +224,13 @@ GSTextureCache::Source* GSTextureCache::LookupDepthSource(const GIFRegTEX0& TEX0
 
 GSTextureCache::Source* GSTextureCache::LookupSource(const GIFRegTEX0& TEX0, const GIFRegTEXA& TEXA, const GSVector4i& r, const GSVector2i* lod)
 {
-	GL_CACHE("TC: Lookup Source <%d,%d => %d,%d> (0x%x, %s, BW: %u)", r.x, r.y, r.z, r.w, TEX0.TBP0, psm_str(TEX0.PSM), TEX0.TBW);
+	GL_CACHE("TC: Lookup Source <%d,%d => %d,%d> (0x%x, %s, BW: %u, CBP: 0x%x)", r.x, r.y, r.z, r.w, TEX0.TBP0, psm_str(TEX0.PSM), TEX0.TBW, TEX0.CBP);
 
 	const GSLocalMemory::psm_t& psm_s = GSLocalMemory::m_psm[TEX0.PSM];
 	//const GSLocalMemory::psm_t& cpsm = psm.pal > 0 ? GSLocalMemory::m_psm[TEX0.CPSM] : psm;
 
-	const u32* clut = g_gs_renderer->m_mem.m_clut;
+	const u32* const clut = g_gs_renderer->m_mem.m_clut;
+	GSTexture* const gpu_clut = (psm_s.pal > 0) ? g_gs_renderer->m_mem.m_clut.GetGPUTexture() : nullptr;
 
 	Source* src = NULL;
 
@@ -246,16 +247,25 @@ GSTextureCache::Source* GSTextureCache::LookupSource(const GIFRegTEX0& TEX0, con
 		// Target are converted (AEM & palette) on the fly by the GPU. They don't need extra check
 		if (!s->m_target)
 		{
-			// We request a palette texture (psm_s.pal). If the texture was
-			// converted by the CPU (!s->m_palette), we need to ensure
-			// palette content is the same.
-			if (psm_s.pal > 0 && !s->m_palette && !s->ClutMatch({clut, psm_s.pal}))
-				continue;
+			if (psm_s.pal > 0)
+			{
+				// If we're doing GPU CLUT, we don't want to use the CPU-converted version.
+				if (gpu_clut && !s->m_palette)
+					continue;
 
-			// We request a 24/16 bit RGBA texture. Alpha expansion was done by
-			// the CPU.  We need to check that TEXA is identical
-			if (psm_s.pal == 0 && psm_s.fmt > 0 && s->m_TEXA.U64 != TEXA.U64)
-				continue;
+				// We request a palette texture (psm_s.pal). If the texture was
+				// converted by the CPU (!s->m_palette), we need to ensure
+				// palette content is the same.
+				if (!s->m_palette && !s->ClutMatch({ clut, psm_s.pal }))
+					continue;
+			}
+			else
+			{
+				// We request a 24/16 bit RGBA texture. Alpha expansion was done by
+				// the CPU.  We need to check that TEXA is identical
+				if (psm_s.fmt > 0 && s->m_TEXA.U64 != TEXA.U64)
+					continue;
+			}
 
 			// Same base mip texture, but we need to check that MXL was the same as well.
 			// When mipmapping is off, this will be 0,0 vs 0,0.
@@ -404,9 +414,7 @@ GSTextureCache::Source* GSTextureCache::LookupSource(const GIFRegTEX0& TEX0, con
 		}
 	}
 
-	bool new_source = false;
-
-	if (src == NULL)
+	if (!src)
 	{
 #ifdef ENABLE_OGL_DEBUG
 		if (dst)
@@ -425,8 +433,7 @@ GSTextureCache::Source* GSTextureCache::LookupSource(const GIFRegTEX0& TEX0, con
 			GL_CACHE("TC: src miss (0x%x, 0x%x, %s)", TEX0.TBP0, psm_s.pal > 0 ? TEX0.CBP : 0, psm_str(TEX0.PSM));
 		}
 #endif
-		src = CreateSource(TEX0, TEXA, dst, half_right, x_offset, y_offset, lod, &r);
-		new_source = true;
+		src = CreateSource(TEX0, TEXA, dst, half_right, x_offset, y_offset, lod, &r, gpu_clut);
 	}
 	else
 	{
@@ -434,11 +441,11 @@ GSTextureCache::Source* GSTextureCache::LookupSource(const GIFRegTEX0& TEX0, con
 			src->m_texture ? src->m_texture->GetID() : 0,
 			TEX0.TBP0, psm_s.pal > 0 ? TEX0.CBP : 0,
 			psm_str(TEX0.PSM));
-	}
 
-	if (src->m_palette && !new_source && !src->ClutMatch({clut, psm_s.pal}))
-	{
-		AttachPaletteToSource(src, psm_s.pal, true);
+		if (gpu_clut)
+			AttachPaletteToSource(src, gpu_clut);
+		else if (src->m_palette && (!src->m_palette_obj || !src->ClutMatch({clut, psm_s.pal})))
+			AttachPaletteToSource(src, psm_s.pal, true);
 	}
 
 	src->Update(r);
@@ -448,7 +455,7 @@ GSTextureCache::Source* GSTextureCache::LookupSource(const GIFRegTEX0& TEX0, con
 	return src;
 }
 
-GSTextureCache::Target* GSTextureCache::LookupTarget(const GIFRegTEX0& TEX0, const GSVector2i& size, int type, bool used, u32 fbmask, const bool is_frame, const int real_w, const int real_h)
+GSTextureCache::Target* GSTextureCache::LookupTarget(const GIFRegTEX0& TEX0, const GSVector2i& size, int type, bool used, u32 fbmask, const bool is_frame, const int real_w, const int real_h, bool preload)
 {
 	const GSLocalMemory::psm_t& psm_s = GSLocalMemory::m_psm[TEX0.PSM];
 	const GSVector2& new_s = static_cast<GSRendererHW*>(g_gs_renderer.get())->GetTextureScaleFactor();
@@ -656,7 +663,7 @@ GSTextureCache::Target* GSTextureCache::LookupTarget(const GIFRegTEX0& TEX0, con
 		// From a performance point of view, it might cost a little on big upscaling
 		// but normally few RT are miss so it must remain reasonable.
 		bool supported_fmt = !GSConfig.UserHacks_DisableDepthSupport || psm_s.depth == 0;
-		if (GSConfig.PreloadFrameWithGSData && TEX0.TBW > 0 && supported_fmt)
+		if (preload && TEX0.TBW > 0 && supported_fmt)
 		{
 			GL_INS("Preloading the RT DATA");
 			// RT doesn't have height but if we use a too big value, we will read outside of the GS memory.
@@ -1726,7 +1733,7 @@ void GSTextureCache::IncAge()
 }
 
 //Fixme: Several issues in here. Not handling depth stencil, pitch conversion doesnt work.
-GSTextureCache::Source* GSTextureCache::CreateSource(const GIFRegTEX0& TEX0, const GIFRegTEXA& TEXA, Target* dst, bool half_right, int x_offset, int y_offset, const GSVector2i* lod, const GSVector4i* src_range)
+GSTextureCache::Source* GSTextureCache::CreateSource(const GIFRegTEX0& TEX0, const GIFRegTEXA& TEXA, Target* dst, bool half_right, int x_offset, int y_offset, const GSVector2i* lod, const GSVector4i* src_range, GSTexture* gpu_clut)
 {
 	const GSLocalMemory::psm_t& psm = GSLocalMemory::m_psm[TEX0.PSM];
 	Source* src = new Source(TEX0, TEXA, false);
@@ -2042,28 +2049,33 @@ GSTextureCache::Source* GSTextureCache::CreateSource(const GIFRegTEX0& TEX0, con
 	else
 	{
 		// maintain the clut even when paltex is on for the dump/replacement texture lookup
-		bool paltex = (GSConfig.GPUPaletteConversion && psm.pal > 0);
+		bool paltex = (GSConfig.GPUPaletteConversion && psm.pal > 0) || gpu_clut;
 		const u32* clut = (psm.pal > 0) ? static_cast<const u32*>(g_gs_renderer->m_mem.m_clut) : nullptr;
 
 		// try the hash cache
 		if ((src->m_from_hash_cache = LookupHashCache(TEX0, TEXA, paltex, clut, lod)) != nullptr)
 		{
 			src->m_texture = src->m_from_hash_cache->texture;
-			if (psm.pal > 0)
+			if (gpu_clut)
+				AttachPaletteToSource(src, gpu_clut);
+			else if (psm.pal > 0)
 				AttachPaletteToSource(src, psm.pal, paltex);
 		}
 		else if (paltex)
 		{
 			src->m_texture = g_gs_device->CreateTexture(tw, th, tlevels, GSTexture::Format::UNorm8);
-			AttachPaletteToSource(src, psm.pal, true);
+			if (gpu_clut)
+				AttachPaletteToSource(src, gpu_clut);
+			else
+				AttachPaletteToSource(src, psm.pal, true);
 		}
 		else
 		{
 			src->m_texture = g_gs_device->CreateTexture(tw, th, tlevels, GSTexture::Format::Color);
-			if (psm.pal > 0)
-			{
+			if (gpu_clut)
+				AttachPaletteToSource(src, gpu_clut);
+			else if (psm.pal > 0)
 				AttachPaletteToSource(src, psm.pal, false);
-			}
 		}
 	}
 
@@ -2241,6 +2253,71 @@ GSTextureCache::Target* GSTextureCache::CreateTarget(const GIFRegTEX0& TEX0, int
 	m_dst[type].push_front(t);
 
 	return t;
+}
+
+GSTexture* GSTextureCache::LookupPaletteSource(u32 CBP, u32 CPSM, u32 CBW, GSVector2i& offset, const GSVector2i& size)
+{
+	for (auto t : m_dst[RenderTarget])
+	{
+		if (!t->m_used)
+			continue;
+
+		GSVector2i this_offset;
+		if (t->m_TEX0.TBP0 == CBP)
+		{
+			// Exact match, this one's likely fine, unless the format is different.
+			if (t->m_TEX0.PSM != CPSM || (CBW != 0 && t->m_TEX0.TBW != CBW))
+				continue;
+
+			GL_INS("Exact match on BP 0x%04x BW %u", t->m_TEX0.CBP, t->m_TEX0.TBW);
+			this_offset.x = 0;
+			this_offset.y = 0;
+		}
+		else if (GSConfig.UserHacks_GPUTargetCLUTMode == GSGPUTargetCLUTMode::InsideTarget &&
+				 t->m_TEX0.TBP0 < CBP && t->m_end_block >= CBP)
+		{
+			// Somewhere within this target, can we find it?
+			const GSVector4i rc(0, 0, size.x, size.y);
+			SurfaceOffset so = ComputeSurfaceOffset(CBP, std::max<u32>(CBW, 0), CPSM, rc, t);
+			if (!so.is_valid)
+				continue;
+
+			GL_INS("Match inside RT at BP 0x%04X-0x%04X BW %u", t->m_TEX0.TBP0, t->m_end_block, t->m_TEX0.TBW);
+			this_offset.x = so.b2a_offset.left;
+			this_offset.y = so.b2a_offset.top;
+		}
+		else
+		{
+			// Not inside this target, skip.
+			continue;
+		}
+
+		// Make sure the clut isn't in an area of the target where the EE has overwritten it.
+		// Otherwise, we'll be using stale data on the CPU.
+		if (!t->m_dirty.empty())
+		{
+			GL_INS("Candidate is dirty, checking");
+
+			const GSVector4i clut_rc(this_offset.x, this_offset.y, this_offset.x + size.x, this_offset.y + size.y);
+			bool is_dirty = false;
+			for (const GSDirtyRect& dirty : t->m_dirty)
+			{
+				if (!dirty.GetDirtyRect(t->m_TEX0).rintersect(clut_rc).rempty())
+				{
+					GL_INS("Dirty rectangle overlaps CLUT rectangle, skipping");
+					is_dirty = true;
+					break;
+				}
+			}
+			if (is_dirty)
+				continue;
+		}
+
+		offset = this_offset;
+		return t->m_texture;
+	}
+
+	return nullptr;
 }
 
 void GSTextureCache::Read(Target* t, const GSVector4i& r)
@@ -2978,6 +3055,12 @@ void GSTextureCache::AttachPaletteToSource(Source* s, u16 pal, bool need_gs_text
 {
 	s->m_palette_obj = m_palette_map.LookupPalette(pal, need_gs_texture);
 	s->m_palette = need_gs_texture ? s->m_palette_obj->GetPaletteGSTexture() : nullptr;
+}
+
+void GSTextureCache::AttachPaletteToSource(Source* s, GSTexture* gpu_clut)
+{
+	s->m_palette_obj = nullptr;
+	s->m_palette = gpu_clut;
 }
 
 GSTextureCache::SurfaceOffset GSTextureCache::ComputeSurfaceOffset(const GSOffset& off, const GSVector4i& r, const Target* t)

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.h
@@ -308,7 +308,7 @@ protected:
 	std::unordered_map<SurfaceOffsetKey, SurfaceOffset, SurfaceOffsetKeyHash, SurfaceOffsetKeyEqual> m_surface_offset_cache;
 	Source* m_temporary_source = nullptr; // invalidated after the draw
 
-	Source* CreateSource(const GIFRegTEX0& TEX0, const GIFRegTEXA& TEXA, Target* t = NULL, bool half_right = false, int x_offset = 0, int y_offset = 0, const GSVector2i* lod = nullptr, const GSVector4i* src_range = nullptr);
+	Source* CreateSource(const GIFRegTEX0& TEX0, const GIFRegTEXA& TEXA, Target* t, bool half_right, int x_offset, int y_offset, const GSVector2i* lod, const GSVector4i* src_range, GSTexture* gpu_clut);
 	Target* CreateTarget(const GIFRegTEX0& TEX0, int w, int h, int type, const bool clear);
 
 	/// Expands a target when the block pointer for a display framebuffer is within another target, but the read offset
@@ -337,10 +337,12 @@ public:
 	void RemovePartial();
 	void AddDirtyRectTarget(Target* target, GSVector4i rect, u32 psm, u32 bw);
 
+	GSTexture* LookupPaletteSource(u32 CBP, u32 CPSM, u32 CBW, GSVector2i& offset, const GSVector2i& size);
+
 	Source* LookupSource(const GIFRegTEX0& TEX0, const GIFRegTEXA& TEXA, const GSVector4i& r, const GSVector2i* lod);
 	Source* LookupDepthSource(const GIFRegTEX0& TEX0, const GIFRegTEXA& TEXA, const GSVector4i& r, bool palette = false);
 
-	Target* LookupTarget(const GIFRegTEX0& TEX0, const GSVector2i& size, int type, bool used, u32 fbmask = 0, const bool is_frame = false, const int real_w = 0, const int real_h = 0);
+	Target* LookupTarget(const GIFRegTEX0& TEX0, const GSVector2i& size, int type, bool used, u32 fbmask = 0, const bool is_frame = false, const int real_w = 0, const int real_h = 0, bool preload = GSConfig.PreloadFrameWithGSData);
 	Target* LookupDisplayTarget(const GIFRegTEX0& TEX0, const GSVector2i& size, const int real_w, const int real_h);
 
 	/// Looks up a target in the cache, and only returns it if the BP/BW/PSM match exactly.
@@ -367,6 +369,7 @@ public:
 	void PrintMemoryUsage();
 
 	void AttachPaletteToSource(Source* s, u16 pal, bool need_gs_texture);
+	void AttachPaletteToSource(Source* s, GSTexture* gpu_clut);
 	SurfaceOffset ComputeSurfaceOffset(const GSOffset& off, const GSVector4i& r, const Target* t);
 	SurfaceOffset ComputeSurfaceOffset(const uint32_t bp, const uint32_t bw, const uint32_t psm, const GSVector4i& r, const Target* t);
 	SurfaceOffset ComputeSurfaceOffset(const SurfaceOffsetKey& sok);

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.h
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.h
@@ -334,6 +334,7 @@ public:
 	void StretchRect(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect, bool red, bool green, bool blue, bool alpha) final;
 	void StretchRect(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect, const GL::Program& ps, bool alpha_blend, OMColorMaskSelector cms, bool linear = true);
 	void PresentRect(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect, PresentShader shader, float shaderTime, bool linear) final;
+	void UpdateCLUTTexture(GSTexture* sTex, u32 offsetX, u32 offsetY, GSTexture* dTex, u32 dOffset, u32 dSize) final;
 
 	void RenderHW(GSHWDrawConfig& config) final;
 	void SendHWDraw(const GSHWDrawConfig& config, bool needs_barrier);

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
@@ -763,6 +763,23 @@ void GSDeviceVK::BlitRect(GSTexture* sTex, const GSVector4i& sRect, u32 sLevel, 
 		&ib, linear ? VK_FILTER_LINEAR : VK_FILTER_NEAREST);
 }
 
+void GSDeviceVK::UpdateCLUTTexture(GSTexture* sTex, u32 offsetX, u32 offsetY, GSTexture* dTex, u32 dOffset, u32 dSize)
+{
+	struct Uniforms
+	{
+		float scaleX, scaleY;
+		u32 offsetX, offsetY, dOffset;
+	};
+
+	const Uniforms uniforms = {sTex->GetScale().x, sTex->GetScale().y, offsetX, offsetY, dOffset};
+	SetUtilityPushConstants(&uniforms, sizeof(uniforms));
+
+	const GSVector4 dRect(0, 0, dSize, 1);
+	const ShaderConvert shader = (dSize == 16) ? ShaderConvert::CLUT_4 : ShaderConvert::CLUT_8;
+	DoStretchRect(static_cast<GSTextureVK*>(sTex), GSVector4::zero(), static_cast<GSTextureVK*>(dTex), dRect,
+		m_convert[static_cast<int>(shader)], false);
+}
+
 void GSDeviceVK::DoMerge(GSTexture* sTex[3], GSVector4* sRect, GSTexture* dTex, GSVector4* dRect,
 	const GSRegPMODE& PMODE, const GSRegEXTBUF& EXTBUF, const GSVector4& c)
 {

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h
@@ -72,9 +72,9 @@ public:
 	{
 		NUM_TFX_DESCRIPTOR_SETS = 3,
 		NUM_TFX_DYNAMIC_OFFSETS = 2,
-		NUM_TFX_SAMPLERS = 2,
+		NUM_TFX_DRAW_TEXTURES = 2,
 		NUM_TFX_RT_TEXTURES = 2,
-		NUM_TFX_TEXTURES = NUM_TFX_SAMPLERS + NUM_TFX_RT_TEXTURES,
+		NUM_TFX_TEXTURES = NUM_TFX_DRAW_TEXTURES + NUM_TFX_RT_TEXTURES,
 		NUM_CONVERT_TEXTURES = 1,
 		NUM_CONVERT_SAMPLERS = 1,
 		CONVERT_PUSH_CONSTANTS_SIZE = 96,
@@ -260,7 +260,7 @@ public:
 	void IASetIndexBuffer(const void* index, size_t count);
 
 	void PSSetShaderResource(int i, GSTexture* sr, bool check_state);
-	void PSSetSampler(u32 index, GSHWDrawConfig::SamplerSelector sel);
+	void PSSetSampler(GSHWDrawConfig::SamplerSelector sel);
 
 	void OMSetRenderTargets(GSTexture* rt, GSTexture* ds, const GSVector4i& scissor, bool feedback_loop);
 
@@ -372,8 +372,8 @@ private:
 	u8 m_blend_constant_color = 0;
 
 	std::array<VkImageView, NUM_TFX_TEXTURES> m_tfx_textures{};
-	std::array<VkSampler, NUM_TFX_SAMPLERS> m_tfx_samplers{};
-	std::array<u32, NUM_TFX_SAMPLERS> m_tfx_sampler_sel{};
+	VkSampler m_tfx_sampler = VK_NULL_HANDLE;
+	u32 m_tfx_sampler_sel = 0;
 	std::array<VkDescriptorSet, NUM_TFX_DESCRIPTOR_SETS> m_tfx_descriptor_sets{};
 	std::array<u32, NUM_TFX_DYNAMIC_OFFSETS> m_tfx_dynamic_offsets{};
 

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h
@@ -251,6 +251,8 @@ public:
 	void BlitRect(GSTexture* sTex, const GSVector4i& sRect, u32 sLevel, GSTexture* dTex, const GSVector4i& dRect,
 		u32 dLevel, bool linear);
 
+	void UpdateCLUTTexture(GSTexture* sTex, u32 offsetX, u32 offsetY, GSTexture* dTex, u32 dOffset, u32 dSize) override;
+
 	void SetupDATE(GSTexture* rt, GSTexture* ds, bool datm, const GSVector4i& bbox);
 	GSTextureVK* SetupPrimitiveTrackingDATE(GSHWDrawConfig& config);
 

--- a/pcsx2/GameDatabase.cpp
+++ b/pcsx2/GameDatabase.cpp
@@ -361,6 +361,7 @@ static const char* s_gs_hw_fix_names[] = {
 	"deinterlace",
 	"cpuSpriteRenderBW",
 	"cpuCLUTRender",
+	"gpuTargetCLUT",
 	"gpuPaletteConversion",
 	"getSkipCount",
 	"beforeDraw",
@@ -604,6 +605,9 @@ bool GameDatabaseSchema::GameEntry::configMatchesHWFix(const Pcsx2Config::GSOpti
 		case GSHWFixId::CPUCLUTRender:
 			return (config.UserHacks_CPUCLUTRender == value);
 
+		case GSHWFixId::GPUTargetCLUT:
+			return (static_cast<int>(config.UserHacks_GPUTargetCLUTMode) == value);
+
 		case GSHWFixId::GPUPaletteConversion:
 			return (config.GPUPaletteConversion == ((value > 1) ? (config.TexturePreloading == TexturePreloadingLevel::Full) : (value != 0)));
 
@@ -752,6 +756,13 @@ u32 GameDatabaseSchema::GameEntry::applyGSHardwareFixes(Pcsx2Config::GSOptions& 
 			case GSHWFixId::CPUCLUTRender:
 				config.UserHacks_CPUCLUTRender = value;
 				break;
+
+			case GSHWFixId::GPUTargetCLUT:
+			{
+				if (value >= 0 && value <= static_cast<int>(GSGPUTargetCLUTMode::InsideTarget))
+					config.UserHacks_GPUTargetCLUTMode = static_cast<GSGPUTargetCLUTMode>(value);
+			}
+			break;
 
 			case GSHWFixId::GPUPaletteConversion:
 			{

--- a/pcsx2/GameDatabase.h
+++ b/pcsx2/GameDatabase.h
@@ -83,6 +83,7 @@ namespace GameDatabaseSchema
 		Deinterlace,
 		CPUSpriteRenderBW,
 		CPUCLUTRender,
+		GPUTargetCLUT,
 		GPUPaletteConversion,
 		GetSkipCount,
 		BeforeDraw,

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -505,6 +505,7 @@ bool Pcsx2Config::GSOptions::OptionsAreEqual(const GSOptions& right) const
 		OpEqu(UserHacks_TCOffsetY) &&
 		OpEqu(UserHacks_CPUSpriteRenderBW) &&
 		OpEqu(UserHacks_CPUCLUTRender) &&
+		OpEqu(UserHacks_GPUTargetCLUTMode) &&
 		OpEqu(OverrideTextureBarriers) &&
 		OpEqu(OverrideGeometryShaders) &&
 
@@ -681,6 +682,7 @@ void Pcsx2Config::GSOptions::LoadSave(SettingsWrapper& wrap)
 	GSSettingIntEx(UserHacks_TCOffsetY, "UserHacks_TCOffsetY");
 	GSSettingIntEx(UserHacks_CPUSpriteRenderBW, "UserHacks_CPUSpriteRenderBW");
 	GSSettingIntEx(UserHacks_CPUCLUTRender, "UserHacks_CPUCLUTRender");
+	GSSettingIntEnumEx(UserHacks_GPUTargetCLUTMode, "UserHacks_GPUTargetCLUTMode");
 	GSSettingIntEnumEx(TriFilter, "TriFilter");
 	GSSettingIntEx(OverrideTextureBarriers, "OverrideTextureBarriers");
 	GSSettingIntEx(OverrideGeometryShaders, "OverrideGeometryShaders");
@@ -746,6 +748,7 @@ void Pcsx2Config::GSOptions::MaskUserHacks()
 	UserHacks_TCOffsetY = 0;
 	UserHacks_CPUSpriteRenderBW = 0;
 	UserHacks_CPUCLUTRender = 0;
+	UserHacks_GPUTargetCLUTMode = GSGPUTargetCLUTMode::Disabled;
 	SkipDrawStart = 0;
 	SkipDrawEnd = 0;
 }


### PR DESCRIPTION
### Description of Changes

An extension to CPU CLUT render, except it's all done on the GPU. So no readbacks or slowdown.

Still has a few things to do:

- [x] Properly handle CSA.
- [x] Fix in OpenGL.
- [x] Test more cases.
- [x] Don't require CPU CLUT enabled for preload heuristics.

### Rationale behind Changes

Readbacks are slow, even without EE<->GS thread sync.

### Suggested Testing Steps

Test games which currently need CPU CLUT, see if any can be changed to GPU.
Test Burnout series and NFS Most Wanted, I switched them to GPU.
