### PR TITLE
build: Add cmake presets to pcsx2.

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -29,16 +29,6 @@
             }
         },
         {
-            "name": "lto",
-            "displayName": "Default Profile using clang/ninja & lto.",
-            "description": "Release lto build using ninja & clang.",
-            "inherits": "clang-base",
-            "cacheVariables": {
-                "CMAKE_INTERPROCEDURAL_OPTIMIZATION": "ON",
-                "CMAKE_BUILD_TYPE": "Release"
-            }
-        },
-        {
             "name": "ninja-multi",
             "displayName": "Ninja Multi Config",
             "description": "Generate multiple ninja build files.",
@@ -126,9 +116,10 @@
         {
             "name": "clang-release",
             "displayName": "Clang Release",
-            "description": "Release build using ninja & clang.",
+            "description": "Release lto build using ninja & clang.",
             "inherits": "clang-base",
             "cacheVariables": {
+                "CMAKE_INTERPROCEDURAL_OPTIMIZATION": "ON",
                 "CMAKE_BUILD_TYPE": "Release"
             }
         }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -7,85 +7,99 @@
     },
     "configurePresets": [
         {
-            "name": "defaults",
-            "displayName": "Defaults",
-            "description": "Base preset. Only for inheriting from.",
+            "name": "gcc-base",
+            "displayName": "GCC Base",
+            "description": "Base preset for GCC. Only for inheriting from.",
             "hidden": true,
             "binaryDir": "${sourceDir}/build"
         },
         {
-            "name": "clang",
-            "displayName": "Clang",
-            "description": "Base clang preset. Only for inheriting from.",
+            "name": "clang-base",
+            "displayName": "Base",
+            "description": "Base preset for Clang. Only for inheriting from.",
             "hidden": true,
-            "inherits": "defaults",
+            "binaryDir": "${sourceDir}/build",
+            "generator": "Ninja",
             "cacheVariables": {
+                "CMAKE_EXE_LINKER_FLAGS_INIT": "-fuse-ld=lld",
+                "CMAKE_MODULE_LINKER_FLAGS_INIT": "-fuse-ld=lld",
+                "CMAKE_SHARED_LINKER_FLAGS_INIT": "-fuse-ld=lld",
                 "CMAKE_C_COMPILER": "clang",
                 "CMAKE_CXX_COMPILER": "clang++"
+            }
+        },
+        {
+            "name": "lto",
+            "displayName": "Default Profile using clang/ninja & lto.",
+            "description": "Release lto build using ninja & clang.",
+            "inherits": "clang-base",
+            "cacheVariables": {
+                "CMAKE_INTERPROCEDURAL_OPTIMIZATION": "ON",
+                "CMAKE_BUILD_TYPE": "Release"
             }
         },
         {
             "name": "ninja-multi",
             "displayName": "Ninja Multi Config",
             "description": "Generate multiple ninja build files.",
-            "inherits": "defaults",
+            "inherits": "gcc-base",
             "generator": "Ninja Multi-Config"
         },
         {
-            "name": "debug",
-            "displayName": "Debug",
-            "description": "Debug build with make.",
-            "inherits": "defaults",
+            "name": "gcc-debug",
+            "displayName": "GCC Debug",
+            "description": "GCC Debug build with make.",
+            "inherits": "gcc-base",
             "generator": "Unix Makefiles",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Debug"
             }
         },
         {
-            "name": "devel",
-            "displayName": "Devel",
-            "description": "Developer build using make.",
-            "inherits": "defaults",
+            "name": "gcc-devel",
+            "displayName": "GCC Devel",
+            "description": "GCC Developer build using make.",
+            "inherits": "gcc-base",
             "generator": "Unix Makefiles",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Devel"
             }
         },
         {
-            "name": "release",
-            "displayName": "Release",
-            "description": "Release build using make.",
-            "inherits": "defaults",
+            "name": "gcc-release",
+            "displayName": "GCC Release",
+            "description": "GCC Release build using make.",
+            "inherits": "gcc-base",
             "generator": "Unix Makefiles",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Release"
             }
         },
         {
-            "name": "debug-ninja",
-            "displayName": "Debug Ninja",
+            "name": "gcc-debug-ninja",
+            "displayName": "GCC Debug Ninja",
             "description": "Debug build using ninja.",
-            "inherits": "defaults",
+            "inherits": "gcc-base",
             "generator": "Ninja",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Debug"
             }
         },
         {
-            "name": "devel-ninja",
-            "displayName": "Devel Ninja",
-            "description": "Developer build using ninja.",
-            "inherits": "defaults",
+            "name": "gcc-devel-ninja",
+            "displayName": "GCC Devel Ninja",
+            "description": "GCC Developer build using ninja.",
+            "inherits": "gcc-base",
             "generator": "Ninja",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Devel"
             }
         },
         {
-            "name": "release-ninja",
-            "displayName": "Release Ninja",
-            "description": "Release build using ninja.",
-            "inherits": "defaults",
+            "name": "gcc-release-ninja",
+            "displayName": "GCC Release Ninja",
+            "description": "GCC Release build using ninja.",
+            "inherits": "gcc-base",
             "generator": "Ninja",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Release"
@@ -95,8 +109,7 @@
             "name": "clang-debug",
             "displayName": "Clang Debug",
             "description": "Debug build using ninja and clang.",
-            "generator": "Ninja",
-            "inherits": "clang",
+            "inherits": "clang-base",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Debug"
             }
@@ -105,8 +118,7 @@
             "name": "clang-devel",
             "displayName": "Clang Devel",
             "description": "Developer build using ninja & clang.",
-            "generator": "Ninja",
-            "inherits": "clang",
+            "inherits": "clang-base",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Devel"
             }
@@ -115,8 +127,7 @@
             "name": "clang-release",
             "displayName": "Clang Release",
             "description": "Release build using ninja & clang.",
-            "generator": "Ninja",
-            "inherits": "clang",
+            "inherits": "clang-base",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Release"
             }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -19,9 +19,9 @@
             "description": "Base clang preset. Only for inheriting from.",
             "hidden": true,
             "inherits": "defaults",
-            "environment": {
-                "CC": "clang",
-                "CXX": "clang++"
+            "cacheVariables": {
+                "CMAKE_C_COMPILER": "clang",
+                "CMAKE_CXX_COMPILER": "clang++"
             }
         },
         {
@@ -42,7 +42,7 @@
             }
         },
         {
-            "name": "dev",
+            "name": "devel",
             "displayName": "Devel",
             "description": "Developer build using make.",
             "inherits": "defaults",
@@ -72,7 +72,7 @@
             }
         },
         {
-            "name": "dev-ninja",
+            "name": "devel-ninja",
             "displayName": "Devel Ninja",
             "description": "Developer build using ninja.",
             "inherits": "defaults",

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,125 @@
+{
+    "version": 6,
+    "cmakeMinimumRequired": {
+        "major": 3,
+        "minor": 19,
+        "patch": 0
+    },
+    "configurePresets": [
+        {
+            "name": "defaults",
+            "displayName": "Defaults",
+            "description": "Base preset. Only for inheriting from.",
+            "hidden": true,
+            "binaryDir": "${sourceDir}/build"
+        },
+        {
+            "name": "clang",
+            "displayName": "Clang",
+            "description": "Base clang preset. Only for inheriting from.",
+            "hidden": true,
+            "inherits": "defaults",
+            "environment": {
+                "CC": "clang",
+                "CXX": "clang++"
+            }
+        },
+        {
+            "name": "ninja-multi",
+            "displayName": "Ninja Multi Config",
+            "description": "Generate multiple ninja build files.",
+            "inherits": "defaults",
+            "generator": "Ninja Multi-Config"
+        },
+        {
+            "name": "debug",
+            "displayName": "Debug",
+            "description": "Debug build with make.",
+            "inherits": "defaults",
+            "generator": "Unix Makefiles",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug"
+            }
+        },
+        {
+            "name": "dev",
+            "displayName": "Devel",
+            "description": "Developer build using make.",
+            "inherits": "defaults",
+            "generator": "Unix Makefiles",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Devel"
+            }
+        },
+        {
+            "name": "release",
+            "displayName": "Release",
+            "description": "Release build using make.",
+            "inherits": "defaults",
+            "generator": "Unix Makefiles",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release"
+            }
+        },
+        {
+            "name": "debug-ninja",
+            "displayName": "Debug Ninja",
+            "description": "Debug build using ninja.",
+            "inherits": "defaults",
+            "generator": "Ninja",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug"
+            }
+        },
+        {
+            "name": "dev-ninja",
+            "displayName": "Devel Ninja",
+            "description": "Developer build using ninja.",
+            "inherits": "defaults",
+            "generator": "Ninja",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Devel"
+            }
+        },
+        {
+            "name": "release-ninja",
+            "displayName": "Release Ninja",
+            "description": "Release build using ninja.",
+            "inherits": "defaults",
+            "generator": "Ninja",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release"
+            }
+        },
+        {
+            "name": "clang-debug",
+            "displayName": "Clang Debug",
+            "description": "Debug build using ninja and clang.",
+            "generator": "Ninja",
+            "inherits": "clang",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug"
+            }
+        },
+        {
+            "name": "clang-devel",
+            "displayName": "Clang Devel",
+            "description": "Developer build using ninja & clang.",
+            "generator": "Ninja",
+            "inherits": "clang",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Devel"
+            }
+        },
+        {
+            "name": "clang-release",
+            "displayName": "Clang Release",
+            "description": "Release build using ninja & clang.",
+            "generator": "Ninja",
+            "inherits": "clang",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
### Description of Changes
This adds a number of cmake presets to the project to make compiling easier. These can be used when compiling on the command line, and Visual Studio Code has built in support for them.

Just to note, the existing ways of building still work. This is just an alternative.

Compiling with the clang-devel preset, for example, would be a matter of typing:
```
mkdir build
cd build
cmake --preset clang-devel ..
make
```

Alternatively, if you don't like command lines:
In Visual Studio Code, open the pcsx2 folder. It'll automatically have you choose a preset, create the build folder for you, run the cmake command, and if you hit play at the bottom, it'll compile and open pcsx2.

You can also add your own presets beyond the ones I've added by adding a CMakeUserPresets.json file.

Presets I've added:
"ninja-multi" - Generate multiple ninja build files.

"gcc-debug" - Debug build using make and the default compiler.
"gcc-devel" - Devel build using make and the default compiler.
"gcc-release" - Release build using make and the default compiler.

"gcc-debug-ninja" - Debug build using ninja and the default compiler.
"gcc-devel-ninja" - Devel build using ninja and the default compiler.
"gcc-release-ninja" - Release build using ninja and the default compiler.

"clang-debug"  - Debug build using ninja and clang.
"clang-devel" - Devel build using ninja and clang.
"clang-release" - Clang LTO Release build using ninja. 

The main one that likely needs explanation is ninja-multi. If you use that build, it generates build-*.ninja files for all configurations. You can specify a build file with -f (for example: ninja -f build-Debug.ninja).

### Rationale behind Changes
It's less typing to use a preset, and the Visual Studio Code integration's fairly nice.

Later on, we could build on this. For example, we could move all the warning flags over to presets, and it *is* possible to have windows and mac presets as well. (In fact, I think Microsoft was behind adding this to cmake.)

### Suggested Testing Steps
Build pcsx2 using presets.
