### PR TITLE
GameDB: Remove disable Instant VU1 from SoTC

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -1163,8 +1163,6 @@ SCAJ-20146:
   name: "Wang Da Yu Ju Xiang"
   region: "NTSC-Ch"
   compat: 5
-  speedHacks:
-    InstantVU1SpeedHack: 0 # Alleviates excessive VU load.
   gsHWFixes:
     mipmap: 1
     halfPixelOffset: 1 # Fixes misalignments and borders on side.
@@ -1427,8 +1425,6 @@ SCAJ-20195:
 SCAJ-20196:
   name: "Wang Da Yu Ju Xiang [PlayStation 2 The Best]"
   region: "NTSC-Ch"
-  speedHacks:
-    InstantVU1SpeedHack: 0 # Alleviates excessive VU load.
   gsHWFixes:
     mipmap: 1
     halfPixelOffset: 1 # Fixes misalignments and borders on side.
@@ -2543,8 +2539,6 @@ SCED-53939:
 SCED-53962:
   name: "Shadow of the Colossus [Demo]"
   region: "PAL-M5"
-  speedHacks:
-    InstantVU1SpeedHack: 0 # Alleviates excessive VU load.
   gsHWFixes:
     mipmap: 2 # Fixes Water with Trilinear.
     trilinearFiltering: 1 # Fixes Water with Mipmap (Full).
@@ -3886,8 +3880,6 @@ SCES-53326:
   name: "Shadow of the Colossus"
   region: "PAL-E"
   compat: 5
-  speedHacks:
-    InstantVU1SpeedHack: 0 # Alleviates excessive VU load.
   gsHWFixes:
     mipmap: 2 # Fixes Water with Trilinear.
     trilinearFiltering: 1 # Fixes Water with Mipmap (Full).
@@ -5076,8 +5068,6 @@ SCKA-20061:
   name: "Wanda to Kyozou"
   region: "NTSC-K"
   compat: 5
-  speedHacks:
-    InstantVU1SpeedHack: 0 # Alleviates excessive VU load.
   gsHWFixes:
     mipmap: 1
     halfPixelOffset: 1 # Fixes misalignments and borders on side.
@@ -5962,8 +5952,6 @@ SCPS-15097:
   name: "Wanda to Kyozou"
   region: "NTSC-J"
   compat: 5
-  speedHacks:
-    InstantVU1SpeedHack: 0 # Alleviates excessive VU load.
   gsHWFixes:
     mipmap: 1
     halfPixelOffset: 1 # Fixes misalignments and borders on side.
@@ -6421,8 +6409,6 @@ SCPS-19319:
 SCPS-19320:
   name: "Wanda to Kyozou [PlayStation 2 The Best]"
   region: "NTSC-J"
-  speedHacks:
-    InstantVU1SpeedHack: 0 # Alleviates excessive VU load.
   gsHWFixes:
     mipmap: 1
     halfPixelOffset: 1 # Fixes misalignments and borders on side.
@@ -6437,8 +6423,6 @@ SCPS-19320:
 SCPS-19335:
   name: "Wanda to Kyozou [PlayStation 2 The Best Reprint]"
   region: "NTSC-J"
-  speedHacks:
-    InstantVU1SpeedHack: 0 # Alleviates excessive VU load.
   gsHWFixes:
     mipmap: 1
     halfPixelOffset: 1 # Fixes misalignments and borders on side.
@@ -8217,8 +8201,6 @@ SCUS-97472:
   name: "Shadow of the Colossus"
   region: "NTSC-U"
   compat: 5
-  speedHacks:
-    InstantVU1SpeedHack: 0 # Alleviates excessive VU load.
   gsHWFixes:
     mipmap: 2 # Fixes Water with Trilinear.
     trilinearFiltering: 1 # Fixes Water with Mipmap (Full).
@@ -8406,8 +8388,6 @@ SCUS-97504:
 SCUS-97505:
   name: "Shadow of the Colossus [Demo]"
   region: "NTSC-U"
-  speedHacks:
-    InstantVU1SpeedHack: 0 # Alleviates excessive VU load.
   gsHWFixes:
     mipmap: 2 # Fixes Water with Trilinear.
     trilinearFiltering: 1 # Fixes Water with Mipmap (Full).


### PR DESCRIPTION
### Description of Changes
Removes disable Instant VU1 from SoTC as it should be user choice to enable or disable it if needed.

### Rationale behind Changes
It was dumb to even add this and I will now remove it because it is dumb and shouldn't have been even added.

### Suggested Testing Steps
Make sure CI is happy.
