### PR TITLE
SPU2: Allow loop rewrite of LOOPSTART if block header already passed

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -19801,6 +19801,8 @@ SLES-54549:
 SLES-54550:
   name: "White Van Racer"
   region: "PAL-E"
+  gameFixes:
+    - InstantDMAHack # Fixes DMA timeout errors.
 SLES-54551:
   name: "Premier Manager 2006-2007"
   region: "PAL-G"

--- a/pcsx2/SPU2/spu2sys.cpp
+++ b/pcsx2/SPU2/spu2sys.cpp
@@ -1208,7 +1208,7 @@ static void RegWrite_VoiceAddr(u16 value)
 		case 2:
 			{
 				u32* LoopReg;
-				if ((Cycles - thisvoice.PlayCycle) < 4)
+				if ((Cycles - thisvoice.PlayCycle) < 4 && (int)(thisvoice.LoopCycle - thisvoice.PlayCycle) < 0)
 				{
 					LoopReg = &thisvoice.PendingLoopStartA;
 					thisvoice.PendingLoopStart = true;
@@ -1226,7 +1226,7 @@ static void RegWrite_VoiceAddr(u16 value)
 		case 3:
 			{
 				u32* LoopReg;
-				if ((Cycles - thisvoice.PlayCycle) < 4)
+				if ((Cycles - thisvoice.PlayCycle) < 4 && (int)(thisvoice.LoopCycle - thisvoice.PlayCycle) < 0)
 				{
 					LoopReg = &thisvoice.PendingLoopStartA;
 					thisvoice.PendingLoopStart = true;


### PR DESCRIPTION
### Description of Changes
Allows writing of loops start if voice processing has already written it.

### Rationale behind Changes
Games do sucky things they shouldn't, waveform writing in the first 4T's has priority over register writes, but if this has already passed then the register write can take effect. Regression from #4186 

### Suggested Testing Steps
Retest stuff on #2371 (already tested Mafia, Megaman X7, Unreal Tournament) and White Van Racer if you're insane enough to own that game.

Fixes White Van Racer
Fixes #5991 (Pro Biker 2)
