### PR TITLE
Cmake: Mute lto warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,9 @@
 # versions as well, avoiding setting policies.
 cmake_minimum_required(VERSION 3.12...3.24)
 
+cmake_policy(SET CMP0069 NEW)
+set(CMAKE_POLICY_DEFAULT_CMP0069 NEW)
+
 if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
 	message(FATAL_ERROR "PCSX2 does not support in-tree builds.  Please make a build directory that is not the PCSX2 source directory and generate your CMake project there using either `cmake -B build_directory` or by running cmake from the build directory.")
 endif()

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -29,16 +29,6 @@
             }
         },
         {
-            "name": "lto",
-            "displayName": "Default Profile using clang/ninja & lto.",
-            "description": "Release lto build using ninja & clang.",
-            "inherits": "clang-base",
-            "cacheVariables": {
-                "CMAKE_INTERPROCEDURAL_OPTIMIZATION": "ON",
-                "CMAKE_BUILD_TYPE": "Release"
-            }
-        },
-        {
             "name": "ninja-multi",
             "displayName": "Ninja Multi Config",
             "description": "Generate multiple ninja build files.",
@@ -126,9 +116,10 @@
         {
             "name": "clang-release",
             "displayName": "Clang Release",
-            "description": "Release build using ninja & clang.",
+            "description": "Release lto build using ninja & clang.",
             "inherits": "clang-base",
             "cacheVariables": {
+                "CMAKE_INTERPROCEDURAL_OPTIMIZATION": "ON",
                 "CMAKE_BUILD_TYPE": "Release"
             }
         }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -7,85 +7,99 @@
     },
     "configurePresets": [
         {
-            "name": "defaults",
-            "displayName": "Defaults",
-            "description": "Base preset. Only for inheriting from.",
+            "name": "gcc-base",
+            "displayName": "GCC Base",
+            "description": "Base preset for GCC. Only for inheriting from.",
             "hidden": true,
             "binaryDir": "${sourceDir}/build"
         },
         {
-            "name": "clang",
-            "displayName": "Clang",
-            "description": "Base clang preset. Only for inheriting from.",
+            "name": "clang-base",
+            "displayName": "Base",
+            "description": "Base preset for Clang. Only for inheriting from.",
             "hidden": true,
-            "inherits": "defaults",
+            "binaryDir": "${sourceDir}/build",
+            "generator": "Ninja",
             "cacheVariables": {
+                "CMAKE_EXE_LINKER_FLAGS_INIT": "-fuse-ld=lld",
+                "CMAKE_MODULE_LINKER_FLAGS_INIT": "-fuse-ld=lld",
+                "CMAKE_SHARED_LINKER_FLAGS_INIT": "-fuse-ld=lld",
                 "CMAKE_C_COMPILER": "clang",
                 "CMAKE_CXX_COMPILER": "clang++"
+            }
+        },
+        {
+            "name": "lto",
+            "displayName": "Default Profile using clang/ninja & lto.",
+            "description": "Release lto build using ninja & clang.",
+            "inherits": "clang-base",
+            "cacheVariables": {
+                "CMAKE_INTERPROCEDURAL_OPTIMIZATION": "ON",
+                "CMAKE_BUILD_TYPE": "Release"
             }
         },
         {
             "name": "ninja-multi",
             "displayName": "Ninja Multi Config",
             "description": "Generate multiple ninja build files.",
-            "inherits": "defaults",
+            "inherits": "gcc-base",
             "generator": "Ninja Multi-Config"
         },
         {
-            "name": "debug",
-            "displayName": "Debug",
-            "description": "Debug build with make.",
-            "inherits": "defaults",
+            "name": "gcc-debug",
+            "displayName": "GCC Debug",
+            "description": "GCC Debug build with make.",
+            "inherits": "gcc-base",
             "generator": "Unix Makefiles",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Debug"
             }
         },
         {
-            "name": "devel",
-            "displayName": "Devel",
-            "description": "Developer build using make.",
-            "inherits": "defaults",
+            "name": "gcc-devel",
+            "displayName": "GCC Devel",
+            "description": "GCC Developer build using make.",
+            "inherits": "gcc-base",
             "generator": "Unix Makefiles",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Devel"
             }
         },
         {
-            "name": "release",
-            "displayName": "Release",
-            "description": "Release build using make.",
-            "inherits": "defaults",
+            "name": "gcc-release",
+            "displayName": "GCC Release",
+            "description": "GCC Release build using make.",
+            "inherits": "gcc-base",
             "generator": "Unix Makefiles",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Release"
             }
         },
         {
-            "name": "debug-ninja",
-            "displayName": "Debug Ninja",
+            "name": "gcc-debug-ninja",
+            "displayName": "GCC Debug Ninja",
             "description": "Debug build using ninja.",
-            "inherits": "defaults",
+            "inherits": "gcc-base",
             "generator": "Ninja",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Debug"
             }
         },
         {
-            "name": "devel-ninja",
-            "displayName": "Devel Ninja",
-            "description": "Developer build using ninja.",
-            "inherits": "defaults",
+            "name": "gcc-devel-ninja",
+            "displayName": "GCC Devel Ninja",
+            "description": "GCC Developer build using ninja.",
+            "inherits": "gcc-base",
             "generator": "Ninja",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Devel"
             }
         },
         {
-            "name": "release-ninja",
-            "displayName": "Release Ninja",
-            "description": "Release build using ninja.",
-            "inherits": "defaults",
+            "name": "gcc-release-ninja",
+            "displayName": "GCC Release Ninja",
+            "description": "GCC Release build using ninja.",
+            "inherits": "gcc-base",
             "generator": "Ninja",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Release"
@@ -95,8 +109,7 @@
             "name": "clang-debug",
             "displayName": "Clang Debug",
             "description": "Debug build using ninja and clang.",
-            "generator": "Ninja",
-            "inherits": "clang",
+            "inherits": "clang-base",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Debug"
             }
@@ -105,8 +118,7 @@
             "name": "clang-devel",
             "displayName": "Clang Devel",
             "description": "Developer build using ninja & clang.",
-            "generator": "Ninja",
-            "inherits": "clang",
+            "inherits": "clang-base",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Devel"
             }
@@ -115,8 +127,7 @@
             "name": "clang-release",
             "displayName": "Clang Release",
             "description": "Release build using ninja & clang.",
-            "generator": "Ninja",
-            "inherits": "clang",
+            "inherits": "clang-base",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Release"
             }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -19,9 +19,9 @@
             "description": "Base clang preset. Only for inheriting from.",
             "hidden": true,
             "inherits": "defaults",
-            "environment": {
-                "CC": "clang",
-                "CXX": "clang++"
+            "cacheVariables": {
+                "CMAKE_C_COMPILER": "clang",
+                "CMAKE_CXX_COMPILER": "clang++"
             }
         },
         {
@@ -42,7 +42,7 @@
             }
         },
         {
-            "name": "dev",
+            "name": "devel",
             "displayName": "Devel",
             "description": "Developer build using make.",
             "inherits": "defaults",
@@ -72,7 +72,7 @@
             }
         },
         {
-            "name": "dev-ninja",
+            "name": "devel-ninja",
             "displayName": "Devel Ninja",
             "description": "Developer build using ninja.",
             "inherits": "defaults",

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,125 @@
+{
+    "version": 6,
+    "cmakeMinimumRequired": {
+        "major": 3,
+        "minor": 19,
+        "patch": 0
+    },
+    "configurePresets": [
+        {
+            "name": "defaults",
+            "displayName": "Defaults",
+            "description": "Base preset. Only for inheriting from.",
+            "hidden": true,
+            "binaryDir": "${sourceDir}/build"
+        },
+        {
+            "name": "clang",
+            "displayName": "Clang",
+            "description": "Base clang preset. Only for inheriting from.",
+            "hidden": true,
+            "inherits": "defaults",
+            "environment": {
+                "CC": "clang",
+                "CXX": "clang++"
+            }
+        },
+        {
+            "name": "ninja-multi",
+            "displayName": "Ninja Multi Config",
+            "description": "Generate multiple ninja build files.",
+            "inherits": "defaults",
+            "generator": "Ninja Multi-Config"
+        },
+        {
+            "name": "debug",
+            "displayName": "Debug",
+            "description": "Debug build with make.",
+            "inherits": "defaults",
+            "generator": "Unix Makefiles",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug"
+            }
+        },
+        {
+            "name": "dev",
+            "displayName": "Devel",
+            "description": "Developer build using make.",
+            "inherits": "defaults",
+            "generator": "Unix Makefiles",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Devel"
+            }
+        },
+        {
+            "name": "release",
+            "displayName": "Release",
+            "description": "Release build using make.",
+            "inherits": "defaults",
+            "generator": "Unix Makefiles",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release"
+            }
+        },
+        {
+            "name": "debug-ninja",
+            "displayName": "Debug Ninja",
+            "description": "Debug build using ninja.",
+            "inherits": "defaults",
+            "generator": "Ninja",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug"
+            }
+        },
+        {
+            "name": "dev-ninja",
+            "displayName": "Devel Ninja",
+            "description": "Developer build using ninja.",
+            "inherits": "defaults",
+            "generator": "Ninja",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Devel"
+            }
+        },
+        {
+            "name": "release-ninja",
+            "displayName": "Release Ninja",
+            "description": "Release build using ninja.",
+            "inherits": "defaults",
+            "generator": "Ninja",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release"
+            }
+        },
+        {
+            "name": "clang-debug",
+            "displayName": "Clang Debug",
+            "description": "Debug build using ninja and clang.",
+            "generator": "Ninja",
+            "inherits": "clang",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug"
+            }
+        },
+        {
+            "name": "clang-devel",
+            "displayName": "Clang Devel",
+            "description": "Developer build using ninja & clang.",
+            "generator": "Ninja",
+            "inherits": "clang",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Devel"
+            }
+        },
+        {
+            "name": "clang-release",
+            "displayName": "Clang Release",
+            "description": "Release build using ninja & clang.",
+            "generator": "Ninja",
+            "inherits": "clang",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
### Description of Changes
Set cmake policy CMP0069 to new. 

### Rationale behind Changes
As suggested by stenzek, prevents cmake from spamming a bunch of INTERPROCEDURAL_OPTIMIZATION property warnings when compiling with LTO.

### Suggested Testing Steps
Compile with lto.
