### PR TITLE
USB: Fix incorrect serialization of HIDKbdDevice.

### DIFF
--- a/pcsx2/USB/usb-hid/usb-hid.cpp
+++ b/pcsx2/USB/usb-hid/usb-hid.cpp
@@ -965,7 +965,7 @@ namespace usb_hid
 		sw.DoPODArray(s->hid.kbd.keycodes, std::size(s->hid.kbd.keycodes));
 		sw.Do(&s->hid.kbd.modifiers);
 		sw.Do(&s->hid.kbd.leds);
-		sw.DoPODArray(&s->hid.kbd.key, std::size(s->hid.kbd.key));
+		sw.DoPODArray(s->hid.kbd.key, std::size(s->hid.kbd.key));
 		sw.Do(&s->hid.kbd.keys);
 
 		sw.Do(&s->hid.head);


### PR DESCRIPTION
### Description of Changes

It was reading/writing past the end of the array, striding by `sizeof(u8) * 16` instead of `sizeof(u8)` (but still saving the same total number of bytes).

### Rationale behind Changes

Fixes crash when using save states with USB keyboard.

### Suggested Testing Steps

Already tested, issue is fairly clear.
