### PR TITLE
Build/Qt/GS: Unmute some warnings, & resolve Qt/misc warnings.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,10 @@
 # versions as well, avoiding setting policies.
 cmake_minimum_required(VERSION 3.12...3.24)
 
+#Enabling this cmake policy gets rid of warnings regarding LTO.
+cmake_policy(SET CMP0069 NEW)
+set(CMAKE_POLICY_DEFAULT_CMP0069 NEW)
+
 if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
 	message(FATAL_ERROR "PCSX2 does not support in-tree builds.  Please make a build directory that is not the PCSX2 source directory and generate your CMake project there using either `cmake -B build_directory` or by running cmake from the build directory.")
 endif()

--- a/cmake/BuildParameters.cmake
+++ b/cmake/BuildParameters.cmake
@@ -209,14 +209,14 @@ endif()
 if (MSVC)
 	set(DEFAULT_WARNINGS)
 else()
-	set(DEFAULT_WARNINGS -Wall -Wextra -Wno-maybe-uninitialized -Wno-attributes -Wno-unused-function -Wno-unused-parameter -Wno-missing-field-initializers -Wno-format -Wno-format-security)
+	set(DEFAULT_WARNINGS -Wall -Wextra -Wno-attributes -Wno-unused-function -Wno-unused-parameter -Wno-missing-field-initializers -Wno-format -Wno-format-security)
 	if (NOT USE_ICC)
 		list(APPEND DEFAULT_WARNINGS -Wno-unused-value)
 	endif()
 endif()
 
 if (USE_GCC)
-	list(APPEND DEFAULT_WARNINGS -Wno-stringop-truncation -Wno-stringop-overflow)
+	list(APPEND DEFAULT_WARNINGS -Wno-stringop-truncation -Wno-stringop-overflow -Wno-maybe-uninitialized )
 endif()
 
 

--- a/cmake/BuildParameters.cmake
+++ b/cmake/BuildParameters.cmake
@@ -201,23 +201,18 @@ endif()
 # Note: future GCC (aka GCC 5.1.1) has less false positive so warning could maybe put back
 # -Wno-unused-function: warn for function not used in release build
 # -Wno-unused-value: lots of warning for this kind of statements "0 && ...". There are used to disable some parts of code in release/dev build.
-# -Wno-overloaded-virtual: Gives a fair number of warnings under clang over in the wxwidget gui section of the code.
-# -Wno-deprecated-declarations: The USB plugins dialogs are written in straight gtk 2, which gives a million deprecated warnings. Suppress them until we can deal with them.
 # -Wno-format*: Yeah, these need to be taken care of, but...
 # -Wno-stringop-truncation: Who comes up with these compiler warnings, anyways?
 # -Wno-stringop-overflow: Probably the same people as this one...
+# -Wno-maybe-uninitialized: Lots of gcc warnings like "‘test.GSVector8i::<anonymous>.GSVector8i::<unnamed union>::m’ may be used uninitialized" if this is removed.
 
 if (MSVC)
 	set(DEFAULT_WARNINGS)
 else()
-	set(DEFAULT_WARNINGS -Wall -Wextra -Wno-attributes -Wno-unused-function -Wno-unused-parameter -Wno-missing-field-initializers -Wno-deprecated-declarations -Wno-format -Wno-format-security -Wno-overloaded-virtual)
+	set(DEFAULT_WARNINGS -Wall -Wextra -Wno-maybe-uninitialized -Wno-attributes -Wno-unused-function -Wno-unused-parameter -Wno-missing-field-initializers -Wno-format -Wno-format-security)
 	if (NOT USE_ICC)
 		list(APPEND DEFAULT_WARNINGS -Wno-unused-value)
 	endif()
-endif()
-
-if (USE_CLANG)
-	list(APPEND DEFAULT_WARNINGS -Wno-overloaded-virtual)
 endif()
 
 if (USE_GCC)

--- a/pcsx2-qt/Debugger/DisassemblyWidget.cpp
+++ b/pcsx2-qt/Debugger/DisassemblyWidget.cpp
@@ -487,7 +487,7 @@ void DisassemblyWidget::paintEvent(QPaintEvent* event)
 
 void DisassemblyWidget::mousePressEvent(QMouseEvent* event)
 {
-	const u32 selectedAddress = (event->y() / m_rowHeight * 4) + m_visibleStart;
+	const u32 selectedAddress = (event->position().y() / m_rowHeight * 4) + m_visibleStart;
 	if (event->buttons() & Qt::LeftButton)
 	{
 		if (event->modifiers() & Qt::ShiftModifier)
@@ -523,7 +523,7 @@ void DisassemblyWidget::mouseDoubleClickEvent(QMouseEvent* event)
 	if (!m_cpu->isAlive())
 		return;
 
-	const u32 selectedAddress = (event->y() / m_rowHeight * 4) + m_visibleStart;
+	const u32 selectedAddress = (event->position().y() / m_rowHeight * 4) + m_visibleStart;
 	if (CBreakPoints::IsAddressBreakPoint(m_cpu->getCpuType(), selectedAddress))
 	{
 		Host::RunOnCPUThread([&] { CBreakPoints::RemoveBreakPoint(m_cpu->getCpuType(), selectedAddress); });

--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -521,7 +521,7 @@ void MainWindow::setStyleFromSettings()
 		qApp->setStyleSheet(QString());
 		qApp->setStyle(QStyleFactory::create("Fusion"));
 	}
-else if (theme == "darkfusion")
+	else if (theme == "darkfusion")
 	{
 		// adapted from https://gist.github.com/QuantumCD/6245215
 		qApp->setStyle(QStyleFactory::create("Fusion"));
@@ -742,7 +742,7 @@ else if (theme == "darkfusion")
 		// Custom palette by RedDevilus, Blue as main color and Purple as complimentary.
 		// Alternative dark theme.
 		qApp->setStyle(QStyleFactory::create("Fusion"));
-		
+
 		const QColor blackishblue(50, 25, 70);
 		const QColor darkerPurple(90, 30, 105);
 		const QColor nauticalPurple(110, 30, 125);
@@ -1640,7 +1640,7 @@ void MainWindow::onViewGamePropertiesActionTriggered()
 		auto lock = GameList::GetLock();
 		const GameList::Entry* entry = m_current_elf_override.isEmpty() ?
 										   GameList::GetEntryForPath(m_current_disc_path.toUtf8().constData()) :
-                                           GameList::GetEntryForPath(m_current_elf_override.toUtf8().constData());
+										   GameList::GetEntryForPath(m_current_elf_override.toUtf8().constData());
 		if (entry)
 		{
 			SettingsDialog::openGamePropertiesDialog(
@@ -2869,11 +2869,17 @@ void MainWindow::doDiscChange(CDVD_SourceType source, const QString& path)
 	bool reset_system = false;
 	if (!m_was_disc_change_request)
 	{
-		const int choice = QMessageBox::question(this, tr("Confirm Disc Change"),
-			tr("Do you want to swap discs or boot the new image (via system reset)?"), tr("Swap Disc"), tr("Reset"), tr("Cancel"), 0, 2);
-		if (choice == 2)
+		QMessageBox message(QMessageBox::Question, tr("Confirm Disc Change"),
+			tr("Do you want to swap discs or boot the new image (via system reset)?"));
+		message.addButton(tr("Swap Disc"), QMessageBox::ActionRole);
+		QPushButton* reset_button = message.addButton(tr("Reset"), QMessageBox::ActionRole);
+		QPushButton* cancel_button = message.addButton(QMessageBox::Cancel);
+		message.setDefaultButton(cancel_button);
+		message.exec();
+
+		if (message.clickedButton() == cancel_button)
 			return;
-		reset_system = (choice != 0);
+		reset_system = (message.clickedButton() == reset_button);
 	}
 
 	switchToEmulationView();

--- a/pcsx2-qt/QtHost.cpp
+++ b/pcsx2-qt/QtHost.cpp
@@ -1812,8 +1812,6 @@ int main(int argc, char* argv[])
 {
 	CrashHandler::Install();
 
-	QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
-	QGuiApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
 	QGuiApplication::setHighDpiScaleFactorRoundingPolicy(Qt::HighDpiScaleFactorRoundingPolicy::PassThrough);
 	RegisterTypes();
 

--- a/pcsx2-qt/SettingWidgetBinder.h
+++ b/pcsx2-qt/SettingWidgetBinder.h
@@ -1093,7 +1093,7 @@ namespace SettingWidgetBinder
 				[sif, slider, label, label_suffix, orig_font = std::move(orig_font), section, key, default_value](const QPoint& pt) {
 					QMenu menu(slider);
 					slider->connect(menu.addAction(qApp->translate("SettingWidgetBinder", "Reset")), &QAction::triggered, slider,
-						[sif, slider, label, label_suffix, orig_font, section, key, default_value]() {
+						[sif, label, label_suffix, orig_font, section, key, default_value]() {
 							const s32 global_value = Host::GetBaseIntSettingValue(section.c_str(), key.c_str(), default_value);
 							label->setText(QStringLiteral("%1%2").arg(global_value).arg(label_suffix));
 							label->setFont(orig_font);
@@ -1109,7 +1109,7 @@ namespace SettingWidgetBinder
 				});
 
 			slider->connect(slider, &QSlider::valueChanged, slider,
-				[sif, label, label_suffix, section = std::move(section), key = std::move(key), default_value,
+				[sif, label, label_suffix, section = std::move(section), key = std::move(key),
 					orig_font = std::move(orig_font), bold_font = std::move(bold_font)](int value) {
 					label->setText(QStringLiteral("%1%2").arg(value).arg(label_suffix));
 
@@ -1126,7 +1126,7 @@ namespace SettingWidgetBinder
 			label->setText(QStringLiteral("%1%2").arg(global_value).arg(label_suffix));
 
 			slider->connect(slider, &QSlider::valueChanged, slider,
-				[sif, label, label_suffix, section = std::move(section), key = std::move(key), default_value](int value) {
+				[label, label_suffix, section = std::move(section), key = std::move(key)](int value) {
 					label->setText(QStringLiteral("%1%2").arg(value).arg(label_suffix));
 					Host::SetBaseIntSettingValue(section.c_str(), key.c_str(), value);
 					Host::CommitBaseSettingChanges();

--- a/pcsx2-qt/Settings/ControllerSettingsDialog.cpp
+++ b/pcsx2-qt/Settings/ControllerSettingsDialog.cpp
@@ -447,7 +447,7 @@ void ControllerSettingsDialog::updateListDescription(u32 global_slot, Controller
 	{
 		QListWidgetItem* item = m_ui.settingsCategory->item(i);
 		const QVariant data(item->data(Qt::UserRole));
-		if (data.type() == QVariant::UInt && data.toUInt() == global_slot)
+		if (data.metaType().id() == QMetaType::UInt && data.toUInt() == global_slot)
 		{
 			const auto [port, slot] = sioConvertPadToPortAndSlot(global_slot);
 			const bool mtap_enabled = getBoolValue("Pad", (port == 0) ? "MultitapPort1" : "MultitapPort2", false);
@@ -469,7 +469,7 @@ void ControllerSettingsDialog::updateListDescription(u32 port, USBDeviceWidget* 
 	{
 		QListWidgetItem* item = m_ui.settingsCategory->item(i);
 		const QVariant data(item->data(Qt::UserRole));
-		if (data.type() == QVariant::UInt && data.toUInt() == (MAX_PORTS + port))
+		if (data.metaType().id() == QMetaType::UInt && data.toUInt() == (MAX_PORTS + port))
 		{
 			const std::string dtype(getStringValue(fmt::format("USB{}", port + 1).c_str(), "Type", "None"));
 			const QString display_name(qApp->translate("USB", USB::GetDeviceName(dtype)));

--- a/pcsx2-qt/Settings/InputBindingDialog.cpp
+++ b/pcsx2-qt/Settings/InputBindingDialog.cpp
@@ -109,7 +109,7 @@ bool InputBindingDialog::eventFilter(QObject* watched, QEvent* event)
 		// if we've moved more than a decent distance from the center of the widget, bind it.
 		// this is so we don't accidentally bind to the mouse if you bump it while reaching for your pad.
 		static constexpr const s32 THRESHOLD = 50;
-		const QPoint diff(static_cast<QMouseEvent*>(event)->globalPos() - m_input_listen_start_position);
+		const QPoint diff(static_cast<QMouseEvent*>(event)->globalPosition().toPoint() - m_input_listen_start_position);
 		bool has_one = false;
 
 		if (std::abs(diff.x()) >= THRESHOLD)

--- a/pcsx2-qt/Settings/InputBindingWidget.cpp
+++ b/pcsx2-qt/Settings/InputBindingWidget.cpp
@@ -166,7 +166,7 @@ bool InputBindingWidget::eventFilter(QObject* watched, QEvent* event)
 		// if we've moved more than a decent distance from the center of the widget, bind it.
 		// this is so we don't accidentally bind to the mouse if you bump it while reaching for your pad.
 		static constexpr const s32 THRESHOLD = 50;
-		const QPoint diff(static_cast<QMouseEvent*>(event)->globalPos() - m_input_listen_start_position);
+		const QPoint diff(static_cast<QMouseEvent*>(event)->globalPosition().toPoint() - m_input_listen_start_position);
 		bool has_one = false;
 
 		if (std::abs(diff.x()) >= THRESHOLD)


### PR DESCRIPTION
### Description of Changes
-Wno-overloaded-virtual & -Wno-deprecated-declarations were there to mute out warnings coming from wx and gtk 2 code, so I removed them.
This lot to a bunch of deprecated Qt warnings that had been muted showing up. Resolved those warnings.
Added -Wno-maybe-uninitialized, as the GS vector code in gcc spams a bunch of warnings (about member m in GSVector8i, IIRC), and I wasn't sure how to resolve them otherwise.
Added cmake policy code for CMP0069 that stenzek suggested earlier.

(There are still some warnings, but a good deal less, and one already has another pr open.)

### Rationale behind Changes
It's generally better to fix warnings, when possible. Deprecated api calls will eventually be removed, so it's best to take care of them. (With wxwidgets, it was using ancient gtk code in the library itself, so there was no way to get rid of the warnings...)

### Suggested Testing Steps
Trigger the code I changed/rewrote, and see if any problems exist. There was a change disc dialog that really needs testing, mouse input in the controller dialog, and some list updating in the usb section of the settings.

I'm setting this to a draft until I'm sure there are no issues in those areas.