### PR TITLE
GS: Move most CRC hacks to the game database

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -5302,7 +5302,10 @@ SCKA-20096:
   name: "Barnyard"
   region: "NTSC-K"
   gsHWFixes:
-    mipmap: 1 # Better characters and environment but has a texture cache issue that makes it worse.
+    halfPixelOffset: 2 # Fix text and post blur.
+    mipmap: 2 # Base mip level isn't always used.
+    autoFlush: 1 # Needed for recursive mipmap rendering.
+    getSkipCount: "GSC_Barnyard" # Render mipmaps on the CPU.
 SCKA-20098:
   name: "Nickelodeon SpongeBob SquarePants - Creature from the Krusty Krab"
   region: "NTSC-K"
@@ -19573,17 +19576,26 @@ SLES-54376:
   name: "Barnyard"
   region: "PAL-E"
   gsHWFixes:
-    mipmap: 1 # Better characters and environment but has a texture cache issue that makes it worse.
+    halfPixelOffset: 2 # Fix text and post blur.
+    mipmap: 2 # Base mip level isn't always used.
+    autoFlush: 1 # Needed for recursive mipmap rendering.
+    getSkipCount: "GSC_Barnyard" # Render mipmaps on the CPU.
 SLES-54377:
   name: "Barnyard"
   region: "PAL-G"
   gsHWFixes:
-    mipmap: 1 # Better characters and environment but has a texture cache issue that makes it worse.
+    halfPixelOffset: 2 # Fix text and post blur.
+    mipmap: 2 # Base mip level isn't always used.
+    autoFlush: 1 # Needed for recursive mipmap rendering.
+    getSkipCount: "GSC_Barnyard" # Render mipmaps on the CPU.
 SLES-54378:
   name: "Barnyard"
   region: "PAL-M4"
   gsHWFixes:
-    mipmap: 1 # Better characters and environment but has a texture cache issue that makes it worse.
+    halfPixelOffset: 2 # Fix text and post blur.
+    mipmap: 2 # Base mip level isn't always used.
+    autoFlush: 1 # Needed for recursive mipmap rendering.
+    getSkipCount: "GSC_Barnyard" # Render mipmaps on the CPU.
 SLES-54379:
   name: "NFL Street 3"
   region: "PAL-E"
@@ -46400,7 +46412,10 @@ SLUS-21277:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    mipmap: 1 # Better characters and environment but has a texture cache issue that makes it worse.
+    halfPixelOffset: 2 # Fix text and post blur.
+    mipmap: 2 # Base mip level isn't always used.
+    autoFlush: 1 # Needed for recursive mipmap rendering.
+    getSkipCount: "GSC_Barnyard" # Render mipmaps on the CPU.
 SLUS-21278:
   name: "SSX on Tour"
   region: "NTSC-U"

--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -167,6 +167,7 @@ PAPX-90516:
     mipmap: 1 # Fixes broken textures.
     textureInsideRT: 1 # Fixes broken character models.
     autoFlush: 1 # Fixes lighting.
+    beforeDraw: "OI_JakGames"
 PAPX-90517:
   name: "Prince of Persia - Jikan no Suna [Trial]"
   region: "NTSC-J"
@@ -517,6 +518,9 @@ SCAJ-20009:
 SCAJ-20010:
   name: "Bakusou Dekotora Densetsu - Otoko Hanamichi Yume Roman"
   region: "NTSC-Unk"
+  gsHWFixes:
+    getSkipCount: "GSC_BigMuthaTruckers"
+    beforeDraw: "OI_BigMuthaTruckers"
 SCAJ-20011:
   name: "Armored Core 3 - Silent Line"
   region: "NTSC-HK"
@@ -748,6 +752,7 @@ SCAJ-20068:
     - SoftwareRendererFMVHack # Fixes brightness and overlapping subtitles.
   gsHWFixes:
     roundSprite: 1 # Fixes font artifacts.
+    getSkipCount: "GSC_FFXGames"
 SCAJ-20069:
   name: "Gallop Racer - Lucky 7"
   region: "NTSC-Unk"
@@ -765,6 +770,7 @@ SCAJ-20072:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes texture and lighting misalignment.
     mergeSprite: 1 # Fixes most vertical lines and lighting misalignment.
+    getSkipCount: "GSC_GiTS"
 SCAJ-20073:
   name: "Jak and Daxter II"
   region: "NTSC-Unk"
@@ -773,6 +779,7 @@ SCAJ-20073:
     mipmap: 1 # Fixes broken textures.
     textureInsideRT: 1 # Fixes broken character models.
     autoFlush: 1 # Fixes lighting.
+    beforeDraw: "OI_JakGames"
 SCAJ-20074:
   name: "King of Fighters 2002, The"
   region: "NTSC-Unk"
@@ -924,6 +931,7 @@ SCAJ-20102:
   region: "NTSC-Unk"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
+    getSkipCount: "GSC_TalesofSymphonia"
 SCAJ-20104:
   name: "Ace Combat 5 - The Unsung War"
   region: "NTSC-Unk"
@@ -984,6 +992,7 @@ SCAJ-20116:
   region: "NTSC-Ch-J"
   gsHWFixes:
     alignSprite: 1 # Fixes FMV lines.
+    getSkipCount: "GSC_DeathByDegreesTekkenNinaWilliams"
 SCAJ-20117:
   name: "Fu-un Bakumatsu-den"
   region: "NTSC-Unk"
@@ -1049,6 +1058,7 @@ SCAJ-20125:
     eeClampMode: 2 # Fixes camera and stops constant coin noises on Pirates Cove.
   gsHWFixes:
     alignSprite: 1
+    getSkipCount: "GSC_Tekken5"
 SCAJ-20126:
   name: "Tekken 5"
   region: "NTSC-Unk"
@@ -1056,6 +1066,7 @@ SCAJ-20126:
     eeClampMode: 2 # Fixes camera and stops constant coin noises on Pirates Cove.
   gsHWFixes:
     alignSprite: 1
+    getSkipCount: "GSC_Tekken5"
 SCAJ-20127:
   name: "EyeToy - Play 2 [with Camera]"
   region: "NTSC-Unk"
@@ -1159,6 +1170,8 @@ SCAJ-20145:
   region: "NTSC-J"
   gameFixes:
     - SoftwareRendererFMVHack # Fixes garbage textures presumably from texture cache issue.
+  gsHWFixes:
+    getSkipCount: "GSC_TalesOfLegendia"
 SCAJ-20146:
   name: "Wang Da Yu Ju Xiang"
   region: "NTSC-Ch"
@@ -1198,6 +1211,7 @@ SCAJ-20152:
     alignSprite: 1 # Fixes vertical lines.
     textureInsideRT: 1 # Fixes corruption.
     texturePreloading: 1 # Performs much better with partial preload.
+    getSkipCount: "GSC_UrbanReign"
 SCAJ-20153:
   name: "Code Age Commanders"
   region: "NTSC-J"
@@ -1305,9 +1319,12 @@ SCAJ-20171:
   region: "NTSC-J"
   gsHWFixes:
     cpuCLUTRender: 1 # Fixes some shading/shadows.
+    getSkipCount: "GSC_ZettaiZetsumeiToshi2"
 SCAJ-20172:
   name: "Final Fantasy XII"
   region: "NTSC-Unk"
+  gsHWFixes:
+    getSkipCount: "GSC_FFXGames"
 SCAJ-20173:
   name: "Ace Combat Zero - The Belkan War"
   region: "NTSC-Unk"
@@ -1355,6 +1372,7 @@ SCAJ-20179:
     halfPixelOffset: 1 # Fixes lighting misalignment and reduces ground shadows (probably texture cache issue).
     roundSprite: 2 # Fixes font artifacts.
     texturePreloading: 0 # Performs much better with it off.
+    getSkipCount: "GSC_XenosagaE3"
 SCAJ-20180:
   name: "Xenosaga Episode III - Also Sprach Zarathustra [Disc 2 of 2]"
   region: "NTSC-Unk"
@@ -1363,6 +1381,7 @@ SCAJ-20180:
     halfPixelOffset: 1 # Fixes lighting misalignment and reduces ground shadows (probably texture cache issue).
     roundSprite: 2 # Fixes font artifacts.
     texturePreloading: 0 # Performs much better with it off.
+    getSkipCount: "GSC_XenosagaE3"
 SCAJ-20181:
   name: "Minna no Tennis"
   region: "NTSC-Unk"
@@ -1389,6 +1408,8 @@ SCAJ-20185:
 SCAJ-20188:
   name: "Final Fantasy XII - International - Zodiac Job System"
   region: "NTSC-Unk"
+  gsHWFixes:
+    getSkipCount: "GSC_FFXGames"
 SCAJ-20190:
   name: "God of War II"
   region: "NTSC-Unk"
@@ -1455,6 +1476,7 @@ SCAJ-20199:
     eeClampMode: 2 # Fixes camera and stops constant coin noises on Pirates Cove.
   gsHWFixes:
     alignSprite: 1
+    getSkipCount: "GSC_Tekken5"
 SCAJ-25002:
   name: "Shinobi"
   region: "NTSC-Unk"
@@ -1471,9 +1493,12 @@ SCAJ-25012:
     - SoftwareRendererFMVHack # Fixes brightness and overlapping subtitles.
   gsHWFixes:
     roundSprite: 1 # Fixes font artifacts.
+    getSkipCount: "GSC_FFXGames"
 SCAJ-25026:
   name: "Kunoichi Shinobi"
   region: "NTSC-Unk"
+  gsHWFixes:
+    getSkipCount: "GSC_Kunoichi"
 SCAJ-25034:
   name: "Sakura Taisen Monogatari"
   region: "NTSC-Unk"
@@ -1791,6 +1816,8 @@ SCED-50642:
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
     textureInsideRT: 1 # Fixes wrong visuals for the summon Anima and The (Triple) Magus Sisters.
+    getSkipCount: "GSC_FFXGames"
+    beforeDraw: "OI_FFX"
 SCED-50675:
   name: "Official PlayStation 2 Magazine Demo 16"
   region: "PAL-M5"
@@ -1863,6 +1890,8 @@ SCED-50907:
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
     textureInsideRT: 1 # Fixes wrong visuals for the summon Anima and The (Triple) Magus Sisters.
+    getSkipCount: "GSC_FFXGames"
+    beforeDraw: "OI_FFX"
 SCED-50945:
   name: "Official PlayStation 2 Magazine Demo 20"
   region: "PAL-M5"
@@ -2040,6 +2069,7 @@ SCED-51700:
     textureInsideRT: 1 # Fixes broken character models.
     autoFlush: 1 # Fixes lighting.
     preloadFrameData: 1 # Fixes Sony splash at boot.
+    beforeDraw: "OI_JakGames"
 SCED-51899:
   name: "PlayStation Experience [Demo]"
   region: "PAL-E"
@@ -2338,6 +2368,7 @@ SCED-52952:
     textureInsideRT: 1
     autoFlush: 1
     preloadFrameData: 1 # Fixes Sony splash at boot.
+    beforeDraw: "OI_JakGames"
 SCED-52970:
   name: "SCEE Hits Demo"
   region: "PAL-M5"
@@ -2906,6 +2937,8 @@ SCES-50490:
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
     textureInsideRT: 1 # Fixes wrong visuals for the summon Anima and The (Triple) Magus Sisters.
+    getSkipCount: "GSC_FFXGames"
+    beforeDraw: "OI_FFX"
 SCES-50491:
   name: "Final Fantasy X"
   region: "PAL-F"
@@ -2914,6 +2947,8 @@ SCES-50491:
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
     textureInsideRT: 1 # Fixes wrong visuals for the summon Anima and The (Triple) Magus Sisters.
+    getSkipCount: "GSC_FFXGames"
+    beforeDraw: "OI_FFX"
 SCES-50492:
   name: "Final Fantasy X"
   region: "PAL-G"
@@ -2923,6 +2958,8 @@ SCES-50492:
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
     textureInsideRT: 1 # Fixes wrong visuals for the summon Anima and The (Triple) Magus Sisters..
+    getSkipCount: "GSC_FFXGames"
+    beforeDraw: "OI_FFX"
 SCES-50493:
   name: "Final Fantasy X"
   region: "PAL-I"
@@ -2931,6 +2968,8 @@ SCES-50493:
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
     textureInsideRT: 1 # Fixes wrong visuals for the summon Anima and The (Triple) Magus Sisters.
+    getSkipCount: "GSC_FFXGames"
+    beforeDraw: "OI_FFX"
 SCES-50494:
   name: "Final Fantasy X"
   region: "PAL-S"
@@ -2939,6 +2978,8 @@ SCES-50494:
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
     textureInsideRT: 1 # Fixes wrong visuals for the summon Anima and The (Triple) Magus Sisters.
+    getSkipCount: "GSC_FFXGames"
+    beforeDraw: "OI_FFX"
 SCES-50499:
   name: "Ecco the Dolphin - Defender of the Future"
   region: "PAL-M5"
@@ -3212,6 +3253,7 @@ SCES-51159:
     textureInsideRT: 1
     texturePreloading: 1 # Performs much better with partial preload.
     halfPixelOffset: 2 # Fixes outlines around characters.
+    getSkipCount: "GSC_GetawayGames"
 SCES-51164:
   name: "Mark of Kri, The"
   region: "PAL-M5"
@@ -3262,6 +3304,7 @@ SCES-51426:
     textureInsideRT: 1
     texturePreloading: 1 # Performs much better with partial preload.
     halfPixelOffset: 2 # Fixes outlines around characters.
+    getSkipCount: "GSC_GetawayGames"
 SCES-51428:
   name: "Shinobi"
   region: "PAL-M5"
@@ -3335,6 +3378,7 @@ SCES-51608:
     textureInsideRT: 1 # Fixes broken character models.
     autoFlush: 1 # Fixes lighting.
     preloadFrameData: 1 # Fixes Sony splash at boot.
+    beforeDraw: "OI_JakGames"
 SCES-51610:
   name: "This is Football 2004 [Red Devils 2004]"
   region: "PAL-BE"
@@ -3641,6 +3685,7 @@ SCES-52460:
     textureInsideRT: 1
     autoFlush: 1
     preloadFrameData: 1 # Fixes Sony splash at boot.
+    beforeDraw: "OI_JakGames"
 SCES-52529:
   name: "Sly 2 - Band of Thieves"
   region: "PAL-M11"
@@ -3671,6 +3716,7 @@ SCES-52586:
   compat: 5
   gsHWFixes:
     alignSprite: 1 # Fixes FMV lines.
+    getSkipCount: "GSC_DeathByDegreesTekkenNinaWilliams"
 SCES-52596:
   name: "This is Football 2005"
   region: "PAL-Unk"
@@ -3693,6 +3739,7 @@ SCES-52758:
   gsHWFixes:
     textureInsideRT: 1
     halfPixelOffset: 2 # Fixes outlines on screen edges.
+    getSkipCount: "GSC_GetawayGames"
 SCES-52762:
   name: "DJ Decks & FX"
   region: "PAL-F"
@@ -3742,6 +3789,7 @@ SCES-52948:
   gsHWFixes:
     textureInsideRT: 1
     halfPixelOffset: 2 # Fixes outlines on screen edges.
+    getSkipCount: "GSC_GetawayGames"
 SCES-53033:
   name: "Formula One 2005"
   region: "PAL-M7"
@@ -3751,12 +3799,14 @@ SCES-53053:
   region: "PAL-F-I"
   gsHWFixes:
     alignSprite: 1 # Fixes FMV lines.
+    getSkipCount: "GSC_DeathByDegreesTekkenNinaWilliams"
 SCES-53054:
   name: "Death by Degrees"
   region: "PAL-E-G"
   compat: 5
   gsHWFixes:
     alignSprite: 1 # Fixes FMV lines.
+    getSkipCount: "GSC_DeathByDegreesTekkenNinaWilliams"
 SCES-53055:
   name: "Eyetoy - Antigrav"
   region: "PAL-M5"
@@ -3800,6 +3850,7 @@ SCES-53202:
     eeClampMode: 2 # Fixes camera and stops constant coin noises on Pirates Cove.
   gsHWFixes:
     alignSprite: 1
+    getSkipCount: "GSC_Tekken5"
 SCES-53247:
   name: "WRC Rally Evolved"
   region: "PAL-M8"
@@ -3836,6 +3887,7 @@ SCES-53286:
     textureInsideRT: 1 # Fixes broken character models.
     autoFlush: 1 # Fixes lighting.
     preloadFrameData: 1 # Fixes Sony splash at boot.
+    beforeDraw: "OI_JakGames"
   memcardFilters: # Reads Ratchet Gladiator data.
     - "SCES-53286"
     - "SCES-53285"
@@ -3999,6 +4051,7 @@ SCES-53688:
     alignSprite: 1 # Fixes vertical lines.
     textureInsideRT: 1 # Fixes corruption.
     texturePreloading: 1 # Performs much better with partial preload.
+    getSkipCount: "GSC_UrbanReign"
 SCES-53795:
   name: "SingStar '80s"
   region: "PAL-Unk"
@@ -4800,6 +4853,7 @@ SCKA-20010:
     textureInsideRT: 1 # Fixes broken character models.
     autoFlush: 1 # Fixes lighting.
     preloadFrameData: 1 # Fixes Sony splash at boot.
+    beforeDraw: "OI_JakGames"
 SCKA-20011:
   name: "Ratchet & Clank 2"
   region: "NTSC-K"
@@ -4842,6 +4896,7 @@ SCKA-20018:
     textureInsideRT: 1
     texturePreloading: 1 # Performs much better with partial preload.
     halfPixelOffset: 2 # Fixes outlines around characters.
+    getSkipCount: "GSC_GetawayGames"
 SCKA-20019:
   name: "Siren"
   region: "NTSC-K"
@@ -4888,6 +4943,7 @@ SCKA-20027:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes texture and lighting misalignment.
     mergeSprite: 1 # Fixes most vertical lines and lighting misalignment.
+    getSkipCount: "GSC_GiTS"
 SCKA-20028:
   name: "ICO [PlayStation2 Big Hit Series]"
   region: "NTSC-K"
@@ -4960,6 +5016,7 @@ SCKA-20039:
   region: "NTSC-K"
   gsHWFixes:
     alignSprite: 1
+    getSkipCount: "GSC_DeathByDegreesTekkenNinaWilliams"
 SCKA-20040:
   name: "Jak 3"
   region: "NTSC-K"
@@ -4969,6 +5026,7 @@ SCKA-20040:
     textureInsideRT: 1
     autoFlush: 1
     preloadFrameData: 1 # Fixes Sony splash at boot.
+    beforeDraw: "OI_JakGames"
 SCKA-20041:
   name: "EyeToy - Play 2"
   region: "NTSC-K"
@@ -5002,12 +5060,15 @@ SCKA-20049:
     eeClampMode: 2 # Fixes camera and stops constant coin noises on Pirates Cove.
   gsHWFixes:
     alignSprite: 1
+    getSkipCount: "GSC_Tekken5"
 SCKA-20050:
   name: "Tales of Legendia"
   region: "NTSC-K"
   compat: 5
   gameFixes:
     - SoftwareRendererFMVHack # Fixes garbage textures presumably from texture cache issue.
+  gsHWFixes:
+    getSkipCount: "GSC_TalesOfLegendia"
 SCKA-20051:
   name: "Minna Daisuki Katamari Damacy"
   region: "NTSC-K"
@@ -5114,6 +5175,7 @@ SCKA-20065:
     alignSprite: 1 # Fixes vertical lines.
     textureInsideRT: 1 # Fixes corruption.
     texturePreloading: 1 # Performs much better with partial preload.
+    getSkipCount: "GSC_UrbanReign"
 SCKA-20066:
   name: "EyeToy - Play 3"
   region: "NTSC-K"
@@ -5164,6 +5226,7 @@ SCKA-20078:
     vuClampMode: 0 # Resolves I Reg Clamping / performance impact and yellow graphics in certain areas.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
+    getSkipCount: "GSC_FFXGames"
 SCKA-20079:
   name: "Valkyrie Profile 2 - Silmeria"
   region: "NTSC-K"
@@ -5180,16 +5243,19 @@ SCKA-20081:
     eeClampMode: 2 # Fixes camera and stops constant coin noises on Pirates Cove.
   gsHWFixes:
     alignSprite: 1
+    getSkipCount: "GSC_Tekken5"
 SCKA-20086:
   name: "Shin Onimusha - Dawn of Dreams [Disc 1 of 2]"
   region: "NTSC-K"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misalignment and upscaling lines.
+    getSkipCount: "GSC_ShinOnimusha"
 SCKA-20087:
   name: "Shin Onimusha - Dawn of Dreams [Disc 2 of 2]"
   region: "NTSC-K"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misalignment and upscaling lines.
+    getSkipCount: "GSC_ShinOnimusha"
   memcardFilters:
     - "SCKA-20086"
 SCKA-20089:
@@ -5206,6 +5272,7 @@ SCKA-20090:
   gsHWFixes:
     mergeSprite: 1 # Reduces bloom but fixes blurriness around models + Recommended to use Shadeboost brightness 80.
     halfPixelOffset: 2 # Depth of field effect aligned properly if CRC hack is off + Shifts buildings correctly.
+    getSkipCount: "GSC_GodHand"
 SCKA-20092:
   name: "K-1 World Grand Prix 2006"
   region: "NTSC-K"
@@ -5230,6 +5297,7 @@ SCKA-20095:
   region: "NTSC-K"
   gsHWFixes:
     roundSprite: 2 # Reduces misalignment issues but the game is just bad for upscaling.
+    getSkipCount: "GSC_Okami"
 SCKA-20096:
   name: "Barnyard"
   region: "NTSC-K"
@@ -5730,6 +5798,7 @@ SCPS-15057:
     mipmap: 1
     textureInsideRT: 1
     autoFlush: 1
+    beforeDraw: "OI_JakGames"
 SCPS-15058:
   name: "Arc the Lad - Generation"
   region: "NTSC-J"
@@ -5790,6 +5859,8 @@ SCPS-15064:
         patch=0,EE,001BDA30,word,4A5DEF40
         patch=0,EE,001BDFE8,word,48588800
         patch=0,EE,001BDFF4,word,4A5DEF40
+  gsHWFixes:
+    getSkipCount: "GSC_GiTS"
 SCPS-15065:
   name: "SOCOM II - U.S. Navy SEALs"
   region: "NTSC-J"
@@ -7067,6 +7138,7 @@ SCUS-97133:
     textureInsideRT: 1
     texturePreloading: 1 # Performs much better with partial preload.
     halfPixelOffset: 2 # Fixes outlines around characters.
+    getSkipCount: "GSC_GetawayGames"
 SCUS-97134:
   name: "SOCOM - U.S. Navy SEALs"
   region: "NTSC-U"
@@ -7438,6 +7510,7 @@ SCUS-97232:
   gsHWFixes:
     textureInsideRT: 1
     halfPixelOffset: 2 # Fixes outlines around characters.
+    getSkipCount: "GSC_GetawayGames"
 SCUS-97233:
   name: "World Tour Soccer 2003"
   region: "NTSC-U"
@@ -7558,6 +7631,7 @@ SCUS-97265:
     textureInsideRT: 1 # Fixes broken character models.
     autoFlush: 1 # Fixes lighting.
     preloadFrameData: 1 # Fixes Sony splash at boot.
+    beforeDraw: "OI_JakGames"
 SCUS-97266:
   name: "Final Fantasy XI [Disc 1 of 2]"
   region: "NTSC-U"
@@ -7596,6 +7670,7 @@ SCUS-97273:
     textureInsideRT: 1 # Fixes broken character models.
     autoFlush: 1 # Fixes lighting.
     preloadFrameData: 1 # Fixes Sony splash at boot.
+    beforeDraw: "OI_JakGames"
 SCUS-97274:
   name: "Jak II [Video Demo]"
   region: "NTSC-U"
@@ -7725,6 +7800,7 @@ SCUS-97330:
     textureInsideRT: 1
     autoFlush: 1
     preloadFrameData: 1 # Fixes Sony splash at boot.
+    beforeDraw: "OI_JakGames"
 SCUS-97331:
   name: "Official U.S. PlayStation Magazine Demo Disc 078"
   region: "NTSC-U"
@@ -7848,6 +7924,7 @@ SCUS-97374:
     textureInsideRT: 1 # Fixes broken character models.
     autoFlush: 1 # Fixes lighting.
     preloadFrameData: 1 # Fixes Sony splash at boot.
+    beforeDraw: "OI_JakGames"
 SCUS-97377:
   name: "Syphon Filter - The Omega Strain [Regular Demo]"
   region: "NTSC-U"
@@ -7945,6 +8022,7 @@ SCUS-97408:
   gsHWFixes:
     textureInsideRT: 1
     halfPixelOffset: 2 # Fixes outlines on screen edges.
+    getSkipCount: "GSC_GetawayGames"
 SCUS-97409:
   name: "Gretzky NHL 2005"
   region: "NTSC-U"
@@ -7972,6 +8050,7 @@ SCUS-97412:
     textureInsideRT: 1
     autoFlush: 1
     preloadFrameData: 1 # Fixes Sony splash at boot.
+    beforeDraw: "OI_JakGames"
 SCUS-97413:
   name: "Ratchet & Clank - Up Your Arsenal [Public Beta v1.0]"
   region: "NTSC-U"
@@ -8040,6 +8119,7 @@ SCUS-97429:
     textureInsideRT: 1 # Fixes broken character models.
     autoFlush: 1 # Fixes lighting.
     preloadFrameData: 1 # Fixes Sony splash at boot.
+    beforeDraw: "OI_JakGames"
   memcardFilters:
     - "SCUS-97429"
     - "SCUS-97465"
@@ -8102,6 +8182,7 @@ SCUS-97441:
   gsHWFixes:
     textureInsideRT: 1
     halfPixelOffset: 2 # Fixes outlines on screen edges.
+    getSkipCount: "GSC_GetawayGames"
 SCUS-97442:
   name: "Official U.S. PlayStation Magazine Demo Disc 090"
   region: "NTSC-U"
@@ -8308,6 +8389,7 @@ SCUS-97486:
     textureInsideRT: 1 # Fixes broken character models.
     autoFlush: 1 # Fixes lighting.
     preloadFrameData: 1 # Fixes Sony splash at boot.
+    beforeDraw: "OI_JakGames"
 SCUS-97487:
   name: "Ratchet - Deadlocked [Public Beta v.1]"
   region: "NTSC-U"
@@ -8327,6 +8409,7 @@ SCUS-97488:
     textureInsideRT: 1 # Fixes broken character models.
     autoFlush: 1 # Fixes lighting.
     preloadFrameData: 1 # Fixes Sony splash at boot.
+    beforeDraw: "OI_JakGames"
 SCUS-97489:
   name: "SOCOM 3 - U.S. Navy SEALs [Public Beta v.1]"
   region: "NTSC-U"
@@ -8415,6 +8498,7 @@ SCUS-97509:
     textureInsideRT: 1 # Fixes broken character models.
     autoFlush: 1 # Fixes lighting.
     preloadFrameData: 1 # Fixes Sony splash at boot.
+    beforeDraw: "OI_JakGames"
 SCUS-97510:
   name: "ATV Offroad Fury 2 [Greatest Hits]"
   region: "NTSC-U"
@@ -8459,6 +8543,7 @@ SCUS-97516:
     textureInsideRT: 1
     autoFlush: 1
     preloadFrameData: 1 # Fixes Sony splash at boot.
+    beforeDraw: "OI_JakGames"
 SCUS-97517:
   name: "Killzone [Greatest Hits]"
   region: "NTSC-U"
@@ -8573,6 +8658,7 @@ SCUS-97555:
     roundSprite: 1 # Fix lines in the sky.
     mipmap: 1
     textureInsideRT: 1
+    beforeDraw: "OI_JakGames"
 SCUS-97556:
   name: "MLB '07 - The Show"
   region: "NTSC-U"
@@ -8807,6 +8893,7 @@ SLAJ-25012:
     - SoftwareRendererFMVHack # Fixes brightness and overlapping subtitles.
   gsHWFixes:
     roundSprite: 1 # Fixes font artifacts.
+    getSkipCount: "GSC_FFXGames"
 SLAJ-25014:
   name: "Cyber Troopers - Virtual-On Marz"
   region: "NTSC-Unk"
@@ -8827,12 +8914,16 @@ SLAJ-25023:
 SLAJ-25026:
   name: "Kunoichi Shinobi"
   region: "NTSC-Unk"
+  gsHWFixes:
+    getSkipCount: "GSC_Kunoichi"
 SLAJ-25027:
   name: "Sonic Heroes"
   region: "NTSC-Unk"
 SLAJ-25031:
   name: "Kunoichi - Shinobu"
   region: "NTSC-Ch-J"
+  gsHWFixes:
+    getSkipCount: "GSC_Kunoichi"
 SLAJ-25033:
   name: "Puyo Puyo Fever"
   region: "NTSC-Unk"
@@ -8891,6 +8982,9 @@ SLAJ-25053:
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
     cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
+    getSkipCount: "GSC_BurnoutGames"
+    beforeDraw: "OI_BurnoutGames"
+    afterDraw: "OO_BurnoutGames"
 SLAJ-25055:
   name: "Def Jam - Fight for N.Y."
   region: "NTSC-Unk"
@@ -8927,6 +9021,9 @@ SLAJ-25066:
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
     cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
+    getSkipCount: "GSC_BurnoutGames"
+    beforeDraw: "OI_BurnoutGames"
+    afterDraw: "OO_BurnoutGames"
   memcardFilters:
     - "SLAJ-25066"
     - "SLPM-66108"
@@ -8995,6 +9092,8 @@ SLAJ-25078:
     roundSprite: 1 # Fixes lighting misalignment such as the street poles and the sun.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
+    beforeDraw: "OI_BurnoutGames"
+    afterDraw: "OO_BurnoutGames"
 SLAJ-25079:
   name: "Shin Sangoku Musou 4 - Empires"
   region: "NTSC-Unk"
@@ -9045,6 +9144,9 @@ SLAJ-25094:
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
     cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
+    getSkipCount: "GSC_BurnoutGames"
+    beforeDraw: "OI_BurnoutGames"
+    afterDraw: "OO_BurnoutGames"
 SLAJ-25095:
   name: "Medal of Honor - Vanguard"
   region: "NTSC-Unk"
@@ -9066,6 +9168,8 @@ SLAJ-35001:
 SLAJ-35003:
   name: "Sakura Taisen - Atsuki Chishio Ni"
   region: "NTSC-CH"
+  gsHWFixes:
+    getSkipCount: "GSC_SakuraTaisen"
 SLED-50117:
   name: "Metal Gear Solid 2 - Sons of Liberty [Demo] [Zone of the Enders Bonus Disc]"
   region: "PAL-E"
@@ -9205,6 +9309,9 @@ SLED-52597:
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
     cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
+    getSkipCount: "GSC_BurnoutGames"
+    beforeDraw: "OI_BurnoutGames"
+    afterDraw: "OO_BurnoutGames"
 SLED-52852:
   name: "Forgotten Realms - Demon Stone [Demo]"
   region: "PAL-E"
@@ -9269,6 +9376,9 @@ SLED-53512:
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
     cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
+    getSkipCount: "GSC_BurnoutGames"
+    beforeDraw: "OI_BurnoutGames"
+    afterDraw: "OO_BurnoutGames"
 SLED-53537:
   name: "187 - Ride or Die [Demo]"
   region: "PAL-E"
@@ -9291,6 +9401,8 @@ SLED-53732:
   region: "PAL"
   gameFixes:
     - EETimingHack # Fixes garbage textures flashing on the character model.
+  gsHWFixes:
+    getSkipCount: "GSC_Spartan"
 SLED-53745:
   name: "Total Overdose [Demo]"
   region: "PAL-M5"
@@ -9314,6 +9426,8 @@ SLED-53937:
     roundSprite: 1 # Fixes lighting misalignment such as the street poles and the sun.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
+    beforeDraw: "OI_BurnoutGames"
+    afterDraw: "OO_BurnoutGames"
 SLED-53951:
   name: "Honda Demo [Demo]"
   region: "PAL-E"
@@ -9571,6 +9685,8 @@ SLES-50072:
   name: "Street Fighter EX3"
   region: "PAL-E"
   compat: 5
+  gsHWFixes:
+    getSkipCount: "GSC_SFEX3"
 SLES-50073:
   name: "Driving Emotion Type-S"
   region: "PAL-M5"
@@ -10261,6 +10377,7 @@ SLES-50386:
   gsHWFixes:
     preloadFrameData: 1 # Fixes random texture corruptions such as horizontal lines.
     cpuFramebufferConversion: 1 # Fixes fog wall.
+    getSkipCount: "GSC_CrashBandicootWoC"
 SLES-50390:
   name: "Driven"
   region: "PAL-M5"
@@ -12369,6 +12486,9 @@ SLES-51355:
   name: "Big Mutha Truckers"
   region: "PAL-M5"
   compat: 5
+  gsHWFixes:
+    getSkipCount: "GSC_BigMuthaTruckers"
+    beforeDraw: "OI_BigMuthaTruckers"
 SLES-51356:
   name: "Road Trip Adventure"
   region: "PAL-M3"
@@ -13190,6 +13310,7 @@ SLES-51815:
     - SoftwareRendererFMVHack # Fixes brightness and overlapping subtitles.
   gsHWFixes:
     roundSprite: 1 # Fixes font artifacts.
+    getSkipCount: "GSC_FFXGames"
 SLES-51816:
   name: "Final Fantasy X-2"
   region: "PAL-F"
@@ -13197,6 +13318,7 @@ SLES-51816:
     - SoftwareRendererFMVHack # Fixes brightness and overlapping subtitles.
   gsHWFixes:
     roundSprite: 1 # Fixes font artifacts.
+    getSkipCount: "GSC_FFXGames"
 SLES-51817:
   name: "Final Fantasy X-2"
   region: "PAL-G"
@@ -13205,6 +13327,7 @@ SLES-51817:
     - SoftwareRendererFMVHack # Fixes brightness and overlapping subtitles.
   gsHWFixes:
     roundSprite: 1 # Fixes font artifacts.
+    getSkipCount: "GSC_FFXGames"
 SLES-51818:
   name: "Final Fantasy X-2"
   region: "PAL-I"
@@ -13212,6 +13335,7 @@ SLES-51818:
     - SoftwareRendererFMVHack # Fixes brightness and overlapping subtitles.
   gsHWFixes:
     roundSprite: 1 # Fixes font artifacts.
+    getSkipCount: "GSC_FFXGames"
 SLES-51819:
   name: "Final Fantasy X-2"
   region: "PAL-S"
@@ -13220,6 +13344,7 @@ SLES-51819:
     - SoftwareRendererFMVHack # Fixes brightness and overlapping subtitles.
   gsHWFixes:
     roundSprite: 1 # Fixes font artifacts.
+    getSkipCount: "GSC_FFXGames"
 SLES-51820:
   name: "Sniper Elite"
   region: "PAL-M5"
@@ -14090,6 +14215,8 @@ SLES-52238:
   name: "Nightshade"
   region: "PAL-M5"
   compat: 5
+  gsHWFixes:
+    getSkipCount: "GSC_Kunoichi"
 SLES-52240:
   name: "International Pool Championship"
   region: "PAL-M5"
@@ -14629,6 +14756,8 @@ SLES-52478:
   name: "Red Dead Revolver"
   region: "PAL-M5"
   compat: 4
+  gsHWFixes:
+    getSkipCount: "GSC_RedDeadRevolver"
 SLES-52479:
   name: "Samurai Jack - The Shadow of Aku"
   region: "PAL-M5"
@@ -14936,6 +15065,9 @@ SLES-52584:
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
     cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
+    getSkipCount: "GSC_BurnoutGames"
+    beforeDraw: "OI_BurnoutGames"
+    afterDraw: "OO_BurnoutGames"
 SLES-52585:
   name: "Burnout 3 - Takedown"
   region: "PAL-F-G-I"
@@ -14948,6 +15080,9 @@ SLES-52585:
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
     cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
+    getSkipCount: "GSC_BurnoutGames"
+    beforeDraw: "OI_BurnoutGames"
+    afterDraw: "OO_BurnoutGames"
 SLES-52587:
   name: "Army Men - Sarge's War"
   region: "PAL-M5"
@@ -15800,6 +15935,7 @@ SLES-52942:
         patch=1,EE,20525A1C,extended,00000000
   gsHWFixes:
     texturePreloading: 1 # Improves performance and prevents it disabling itself regardless.
+    getSkipCount: "GSC_MidnightClub3"
 SLES-52943:
   name: "ESPN NFL 2K5"
   region: "PAL-E"
@@ -16012,6 +16148,7 @@ SLES-53020:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes texture and lighting misalignment.
     mergeSprite: 1 # Fixes most vertical lines and lighting misalignment.
+    getSkipCount: "GSC_GiTS"
   patches:
     BF6F101F:
       content: |-
@@ -16827,11 +16964,15 @@ SLES-53393:
   compat: 5
   gameFixes:
     - EETimingHack # Fixes garbage textures flashing on the character model.
+  gsHWFixes:
+    getSkipCount: "GSC_Spartan"
 SLES-53396:
   name: "Spartan - Total Warrior"
   region: "PAL-M3"
   gameFixes:
     - EETimingHack # Fixes garbage textures flashing on the character model.
+  gsHWFixes:
+    getSkipCount: "GSC_Spartan"
 SLES-53398:
   name: "Zombie Zone"
   region: "PAL-E"
@@ -17122,6 +17263,9 @@ SLES-53506:
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
     cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
+    getSkipCount: "GSC_BurnoutGames"
+    beforeDraw: "OI_BurnoutGames"
+    afterDraw: "OO_BurnoutGames"
   memcardFilters:
     - "SLES-53506"
     - "SLES-53507"
@@ -17141,6 +17285,9 @@ SLES-53507:
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
     cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
+    getSkipCount: "GSC_BurnoutGames"
+    beforeDraw: "OI_BurnoutGames"
+    afterDraw: "OO_BurnoutGames"
   memcardFilters:
     - "SLES-53506"
     - "SLES-53507"
@@ -17615,6 +17762,8 @@ SLES-53645:
   name: "Knights of the Temple II"
   region: "PAL-M5"
   compat: 5
+  gsHWFixes:
+    getSkipCount: "GSC_KnightsOfTheTemple2"
 SLES-53646:
   name: "World Racing 2"
   region: "PAL-M5"
@@ -17820,6 +17969,7 @@ SLES-53717:
         patch=1,EE,20529074,extended,00000000
   gsHWFixes:
     texturePreloading: 1 # Improves performance and prevents it disabling itself regardless.
+    getSkipCount: "GSC_MidnightClub3"
 SLES-53718:
   name: "Sims 2, The"
   region: "PAL-M10"
@@ -18244,6 +18394,8 @@ SLES-53886:
     roundSprite: 1 # Fixes lighting misalignment such as the street poles and the sun.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
+    beforeDraw: "OI_BurnoutGames"
+    afterDraw: "OO_BurnoutGames"
   patches:
     ADDFF505:
       content: |-
@@ -18295,6 +18447,7 @@ SLES-53908:
     - SoftwareRendererFMVHack # Fixes garbage pixels.
   gsHWFixes:
     mipmap: 1 # Fixes distant characters and models but there are still some flickering textures.
+    getSkipCount: "GSC_TombRaiderLegend"
 SLES-53909:
   name: "Full Spectrum Warrior - Ten Hammers"
   region: "PAL-G"
@@ -18579,6 +18732,8 @@ SLES-54030:
     roundSprite: 1 # Fixes lighting misalignment such as the street poles and the sun.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
+    beforeDraw: "OI_BurnoutGames"
+    afterDraw: "OO_BurnoutGames"
   patches:
     CAA04879:
       content: |-
@@ -18759,6 +18914,8 @@ SLES-54137:
 SLES-54138:
   name: "Steambot Chronicles"
   region: "PAL-E"
+  gsHWFixes:
+    getSkipCount: "GSC_SteambotChronicles"
 SLES-54139:
   name: "Earache - Extreme Metal Racing"
   region: "PAL-E"
@@ -18853,6 +19010,7 @@ SLES-54164:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 1 # Fixes extreme ghosting.
+    beforeDraw: "OI_DBZBTGames"
 SLES-54165:
   name: "One Piece - Grand Adventure"
   region: "PAL-E"
@@ -18894,6 +19052,8 @@ SLES-54171:
   compat: 5
   gameFixes:
     - EETimingHack # Fixes flickering.
+  gsHWFixes:
+    getSkipCount: "GSC_YakuzaGames"
 SLES-54172:
   name: "Garfield 2 - Tale of Two Kitties"
   region: "PAL-M11"
@@ -19272,6 +19432,8 @@ SLES-54333:
 SLES-54335:
   name: "Steambot Chronicles"
   region: "PAL-F"
+  gsHWFixes:
+    getSkipCount: "GSC_SteambotChronicles"
 SLES-54336:
   name: "Lumines Plus"
   region: "PAL-M5"
@@ -19337,19 +19499,34 @@ SLES-54354:
   name: "Final Fantasy XII"
   region: "PAL-E"
   compat: 5
+  gsHWFixes:
+    getSkipCount: "GSC_FFXGames"
+    beforeDraw: "OI_FFXII"
 SLES-54355:
   name: "Final Fantasy XII"
   region: "PAL-F"
+  gsHWFixes:
+    getSkipCount: "GSC_FFXGames"
+    beforeDraw: "OI_FFXII"
 SLES-54356:
   name: "Final Fantasy XII"
   region: "PAL-G"
+  gsHWFixes:
+    getSkipCount: "GSC_FFXGames"
+    beforeDraw: "OI_FFXII"
 SLES-54357:
   name: "Final Fantasy XII"
   region: "PAL-I"
+  gsHWFixes:
+    getSkipCount: "GSC_FFXGames"
+    beforeDraw: "OI_FFXII"
 SLES-54358:
   name: "Final Fantasy XII"
   region: "PAL-S"
   compat: 5
+  gsHWFixes:
+    getSkipCount: "GSC_FFXGames"
+    beforeDraw: "OI_FFXII"
 SLES-54359:
   name: "Legend of Spyro, The - A New Beginning"
   region: "PAL-M6"
@@ -19549,6 +19726,7 @@ SLES-54439:
   region: "PAL-M3"
   gsHWFixes:
     roundSprite: 2 # Reduces misalignment issues but the game is just bad for upscaling.
+    getSkipCount: "GSC_Okami"
 SLES-54440:
   name: "GT-R Touring"
   region: "PAL-E"
@@ -19725,6 +19903,7 @@ SLES-54490:
   gsHWFixes:
     mergeSprite: 1 # Reduces bloom but fixes blurriness around models + Recommended to use Shadeboost brightness 80.
     halfPixelOffset: 2 # Depth of field effect aligned properly if CRC hack is off + Shifts buildings correctly.
+    getSkipCount: "GSC_GodHand"
 SLES-54492:
   name: "Need for Speed - Carbon [Collector's Edition]"
   region: "PAL-E"
@@ -20021,6 +20200,9 @@ SLES-54627:
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
     cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
+    getSkipCount: "GSC_BurnoutGames"
+    beforeDraw: "OI_BurnoutGames"
+    afterDraw: "OO_BurnoutGames"
 SLES-54628:
   name: "Skate Attack [Promo]"
   region: "PAL-E"
@@ -20170,6 +20352,7 @@ SLES-54674:
     - SoftwareRendererFMVHack # Fixes garbage pixels.
   gsHWFixes:
     mipmap: 1
+    getSkipCount: "GSC_TombRaiderAnniversary"
 SLES-54675:
   name: "Street Warrior"
   region: "PAL-E"
@@ -20192,6 +20375,9 @@ SLES-54681:
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
     cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
+    getSkipCount: "GSC_BurnoutGames"
+    beforeDraw: "OI_BurnoutGames"
+    afterDraw: "OO_BurnoutGames"
 SLES-54683:
   name: "Medal of Honor - Vanguard"
   region: "PAL-M9"
@@ -20564,6 +20750,8 @@ SLES-54819:
   name: "Manhunt 2"
   region: "PAL-M5"
   compat: 5
+  gsHWFixes:
+    getSkipCount: "GSC_Manhunt2"
 SLES-54820:
   name: "Stuntman Ignition"
   region: "PAL-M5"
@@ -20886,6 +21074,7 @@ SLES-54945:
   compat: 5
   gsHWFixes:
     cpuCLUTRender: 1 # Reduces the bloomy blur of characters.
+    beforeDraw: "OI_DBZBTGames"
 SLES-54946:
   name: "Sega Superstars Tennis"
   region: "PAL-M5"
@@ -21637,6 +21826,8 @@ SLES-55242:
   memcardFilters: # Allows import of Yakuza 1 data.
     - "SLES-55242"
     - "SLES-54171"
+  gsHWFixes:
+    getSkipCount: "GSC_YakuzaGames"
 SLES-55243:
   name: "FIFA 09"
   region: "PAL-E"
@@ -21970,6 +22161,8 @@ SLES-55380:
   name: "Sonic Unleashed"
   region: "PAL-M5"
   compat: 5
+  gsHWFixes:
+    beforeDraw: "OI_SonicUnleashed"
 SLES-55382:
   name: "Warriors Orochi 2"
   region: "PAL-E"
@@ -22058,6 +22251,8 @@ SLES-55442:
   name: "Tomb Raider - Underworld"
   region: "PAL-M8"
   compat: 5
+  gsHWFixes:
+    getSkipCount: "GSC_TombRaiderUnderWorld"
 SLES-55443:
   name: "Mana Khemia - Alchemists of Al-Revis"
   region: "PAL-E"
@@ -22076,6 +22271,7 @@ SLES-55444:
     eeRoundMode: 0 # Fixes "Fall through floor" bug when approaching chests.
   gsHWFixes:
     roundSprite: 1 # Fixes textboxes and character portraits.
+    beforeDraw: "OI_ArTonelico2"
 SLES-55448:
   name: "Indiana Jones and the Staff of Kings"
   region: "PAL-M5"
@@ -22667,12 +22863,14 @@ SLES-82038:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misalignment and upscaling lines.
+    getSkipCount: "GSC_ShinOnimusha"
 SLES-82039:
   name: "Onimusha - Dawn of Dreams [Disc 2 of 2]"
   region: "PAL-M5"
   compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misalignment and upscaling lines.
+    getSkipCount: "GSC_ShinOnimusha"
   memcardFilters:
     - "SLES-82038"
 SLES-82042:
@@ -23226,6 +23424,8 @@ SLKA-25135:
   name: "Kunoichi"
   region: "NTSC-K"
   compat: 5
+  gsHWFixes:
+    getSkipCount: "GSC_Kunoichi"
 SLKA-25136:
   name: "Need for Speed - Underground"
   region: "NTSC-K"
@@ -23255,6 +23455,7 @@ SLKA-25144:
     - SoftwareRendererFMVHack # Fixes brightness and overlapping subtitles.
   gsHWFixes:
     roundSprite: 1 # Fixes font artifacts.
+    getSkipCount: "GSC_FFXGames"
 SLKA-25145:
   name: "dot hack  - Outbreak"
   region: "NTSC-K"
@@ -23417,6 +23618,9 @@ SLKA-25206:
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
     cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
+    getSkipCount: "GSC_BurnoutGames"
+    beforeDraw: "OI_BurnoutGames"
+    afterDraw: "OO_BurnoutGames"
 SLKA-25207:
   name: "Sakura Taisen V - Episode 0 - Samurai Girl of Wild"
   region: "NTSC-K"
@@ -23449,6 +23653,8 @@ SLKA-25214:
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
     textureInsideRT: 1 # Fixes wrong visuals for the summon Anima and The (Triple) Magus Sisters.
+    getSkipCount: "GSC_FFXGames"
+    beforeDraw: "OI_FFX"
 SLKA-25215:
   name: "Shining Wind"
   region: "NTSC-K"
@@ -23634,12 +23840,16 @@ SLKA-25280:
   memcardFilters:
     - "SLKA-25280"
     - "SLKA-25342"
+  gsHWFixes:
+    getSkipCount: "GSC_YakuzaGames"
 SLKA-25281:
   name: "Ryu ga Gotoku 2 [Disc 2 of 2]"
   region: "NTSC-K"
   memcardFilters:
     - "SLKA-25280"
     - "SLKA-25342"
+  gsHWFixes:
+    getSkipCount: "GSC_YakuzaGames"
 SLKA-25284:
   name: "Sakura Taisen 3"
   region: "NTSC-K"
@@ -23702,6 +23912,9 @@ SLKA-25304:
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
     cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
+    getSkipCount: "GSC_BurnoutGames"
+    beforeDraw: "OI_BurnoutGames"
+    afterDraw: "OO_BurnoutGames"
 SLKA-25307:
   name: "Dragon Ball Z Sparking"
   region: "NTSC-K"
@@ -23811,6 +24024,8 @@ SLKA-25341:
 SLKA-25342:
   name: "Ryu ga Gotoku"
   region: "NTSC-K"
+  gsHWFixes:
+    getSkipCount: "GSC_YakuzaGames"
 SLKA-25346:
   name: "Prince of Persia - The Two Thrones"
   region: "NTSC-K"
@@ -23914,6 +24129,7 @@ SLKA-25397:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 1 # Fixes extreme ghosting.
+    beforeDraw: "OI_DBZBTGames"
 SLKA-25401:
   name: "FlatOut 2"
   region: "NTSC-K"
@@ -23928,6 +24144,8 @@ SLKA-25407:
   name: "Dragon Ball Z - Sparkling! Meteor"
   region: "NTSC-K"
   compat: 5
+  gsHWFixes:
+    beforeDraw: "OI_DBZBTGames"
 SLKA-25410:
   name: "BioHazard 4"
   region: "NTSC-K"
@@ -23978,10 +24196,14 @@ SLKA-35003:
   name: "Sakura Taisen - Atsuki Chishioni"
   region: "NTSC-K"
   compat: 5
+  gsHWFixes:
+    getSkipCount: "GSC_SakuraTaisen"
 SLKA-35004:
   name: "Sakura Wars 5 So Long My Love"
   region: "NTSC-K"
   compat: 5
+  gsHWFixes:
+    getSkipCount: "GSC_SakuraWarsSoLongMyLove"
 SLKA-35005:
   name: "Shin Sangoku Musou 5 Special"
   region: "NTSC-K"
@@ -24005,6 +24227,9 @@ SLPM-55004:
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
     cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
+    getSkipCount: "GSC_BurnoutGames"
+    beforeDraw: "OI_BurnoutGames"
+    afterDraw: "OO_BurnoutGames"
 SLPM-55005:
   name: "Mana Khemia 2 - Ochita Gakuen to Renkinjutsushi Tachi"
   region: "NTSC-J"
@@ -24044,6 +24269,9 @@ SLPM-55036:
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
     cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
+    getSkipCount: "GSC_BurnoutGames"
+    beforeDraw: "OI_BurnoutGames"
+    afterDraw: "OO_BurnoutGames"
 SLPM-55039:
   name: "Soukoku no Kusabi - Hiiro no Kakera 3 [Limited Edition]"
   region: "NTSC-J"
@@ -24158,7 +24386,7 @@ SLPM-55102:
   name: "Pia Carrot e Youkoso!! G.P. Gakuen Princess"
   region: "NTSC-J"
   gsHWFixes:
-    pointListPalette: 1
+    beforeDraw: "OI_PointListPalette"
 SLPM-55104:
   name: "Real Rode"
   region: "NTSC-J"
@@ -24362,6 +24590,8 @@ SLPM-55209:
 SLPM-55210:
   name: "Final Fantasy XII International Zodiac Job System [Ultimate Hits]"
   region: "NTSC-J"
+  gsHWFixes:
+    getSkipCount: "GSC_FFXGames"
 SLPM-55211:
   name: "Pachislot Higurashi no Naku Koro ni Matsuri"
   region: "NTSC-J"
@@ -24519,6 +24749,8 @@ SLPM-60104:
 SLPM-60105:
   name: "Street Fighter EX3 [Taikeban]"
   region: "NTSC-J"
+  gsHWFixes:
+    getSkipCount: "GSC_SFEX3"
 SLPM-60106:
   name: "Koei PlayStation 2 Line-Up"
   region: "NTSC-J"
@@ -24616,6 +24848,9 @@ SLPM-60246:
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
     cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
+    getSkipCount: "GSC_BurnoutGames"
+    beforeDraw: "OI_BurnoutGames"
+    afterDraw: "OO_BurnoutGames"
 SLPM-60251:
   name: "Devil May Cry 3 [Trial Version]"
   region: "NTSC-J"
@@ -24629,6 +24864,7 @@ SLPM-60254:
   region: "NTSC-J"
   gsHWFixes:
     cpuCLUTRender: 1 # Fixes some shading/shadows.
+    getSkipCount: "GSC_ZettaiZetsumeiToshi2"
 SLPM-60256:
   name: "Dengeki D73 demo"
   region: "NTSC-J"
@@ -24637,6 +24873,7 @@ SLPM-60257:
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes FMV lines.
+    getSkipCount: "GSC_DeathByDegreesTekkenNinaWilliams"
 SLPM-60260:
   name: "D1 Professional Drift Grand Prix Series [Taikenban]"
   region: "NTSC-J"
@@ -24651,6 +24888,8 @@ SLPM-60265:
 SLPM-60266:
   name: "Ponkotsu Roman Daikatsugeki Bumpy Trot [Trial]"
   region: "NTSC-J"
+  gsHWFixes:
+    getSkipCount: "GSC_SteambotChronicles"
 SLPM-60267:
   name: "Garouden Breakblow [Taikenban]"
   region: "NTSC-J"
@@ -24673,11 +24912,13 @@ SLPM-60272:
     alignSprite: 1 # Fixes vertical lines.
     textureInsideRT: 1 # Fixes corruption.
     texturePreloading: 1 # Performs much better with partial preload.
+    getSkipCount: "GSC_UrbanReign"
 SLPM-60273:
   name: "Zettai Zetsumei Toshi 2 - Itetsuita Kioku-tachi [Trial B]"
   region: "NTSC-J"
   gsHWFixes:
     cpuCLUTRender: 1 # Fixes some shading/shadows.
+    getSkipCount: "GSC_ZettaiZetsumeiToshi2"
 SLPM-60274:
   name: "Full House Kiss 2 [Trial]"
   region: "NTSC-J"
@@ -24806,6 +25047,7 @@ SLPM-61147:
     halfPixelOffset: 1 # Fixes lighting misalignment and reduces ground shadows (probably texture cache issue).
     roundSprite: 2 # Fixes font artifacts.
     texturePreloading: 0 # Performs much better with it off.
+    getSkipCount: "GSC_XenosagaE3"
 SLPM-61157:
   name: "Naruto Shippuuden - Narutimate Accel [Trial]"
   region: "NTSC-J"
@@ -25083,6 +25325,7 @@ SLPM-62114:
   gsHWFixes:
     preloadFrameData: 1 # Fixes random texture corruptions such as horizontal lines.
     cpuFramebufferConversion: 1 # Fixes fog wall.
+    getSkipCount: "GSC_CrashBandicootWoC"
 SLPM-62115:
   name: "EX Jinsei Game [Doukonban]"
   region: "NTSC-J"
@@ -26990,12 +27233,14 @@ SLPM-64509:
   gsHWFixes:
     preloadFrameData: 1 # Fixes random texture corruptions such as horizontal lines.
     cpuFramebufferConversion: 1 # Fixes fog wall.
+    getSkipCount: "GSC_CrashBandicootWoC"
 SLPM-64513:
   name: "Crash Bandicoot - Mawangui Buwhal" # Wrath of Cortex
   region: "NTSC-K"
   gsHWFixes:
     preloadFrameData: 1 # Fixes random texture corruptions such as horizontal lines.
     cpuFramebufferConversion: 1 # Fixes fog wall.
+    getSkipCount: "GSC_CrashBandicootWoC"
 SLPM-64514:
   name: "Legends of Wrestling"
   region: "NTSC-K"
@@ -27467,6 +27712,8 @@ SLPM-65115:
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
     textureInsideRT: 1 # Fixes wrong visuals for the summon Anima and The (Triple) Magus Sisters.
+    getSkipCount: "GSC_FFXGames"
+    beforeDraw: "OI_FFX"
 SLPM-65116:
   name: "Lilie no Atelier Plus - Salburg no Renkinjutsushi 3"
   region: "NTSC-J"
@@ -27858,6 +28105,9 @@ SLPM-65233:
 SLPM-65234:
   name: "Bakusou Dekotora Densetsu - Otoko Hanamichi Yume Roman"
   region: "NTSC-J"
+  gsHWFixes:
+    getSkipCount: "GSC_BigMuthaTruckers"
+    beforeDraw: "OI_BigMuthaTruckers"
 SLPM-65235:
   name: "New Roommania - Porori Seishun"
   region: "NTSC-J"
@@ -28440,6 +28690,7 @@ SLPM-65410:
     textureInsideRT: 1
     texturePreloading: 1 # Performs much better with partial preload.
     halfPixelOffset: 2 # Fixes outlines around characters.
+    getSkipCount: "GSC_GetawayGames"
 SLPM-65411:
   name: "Onimusha Buraiden"
   region: "NTSC-J"
@@ -28581,6 +28832,8 @@ SLPM-65447:
   name: "Kunoichi"
   region: "NTSC-J"
   compat: 5
+  gsHWFixes:
+    getSkipCount: "GSC_Kunoichi"
 SLPM-65448:
   name: "Cambrian QTS - Kaseki ni Natte mo"
   region: "NTSC-J"
@@ -28675,6 +28928,7 @@ SLPM-65478:
     - SoftwareRendererFMVHack # Fixes brightness and overlapping subtitles.
   gsHWFixes:
     roundSprite: 1 # Fixes font artifacts.
+    getSkipCount: "GSC_FFXGames"
 SLPM-65479:
   name: "Sims, The - Bustin' Out"
   region: "NTSC-J"
@@ -29445,6 +29699,9 @@ SLPM-65719:
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
     cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
+    getSkipCount: "GSC_BurnoutGames"
+    beforeDraw: "OI_BurnoutGames"
+    afterDraw: "OO_BurnoutGames"
 SLPM-65720:
   name: "Shin Sangoku Musou 2 Mushoden [Koei the Best]"
   region: "NTSC-J"
@@ -29908,6 +30165,8 @@ SLPM-65853:
 SLPM-65854:
   name: "Red Dead Revolver"
   region: "NTSC-J"
+  gsHWFixes:
+    getSkipCount: "GSC_RedDeadRevolver"
 SLPM-65855:
   name: "Girls Bravo - Romance 15's [Deluxe Pack]"
   region: "NTSC-J"
@@ -30034,7 +30293,7 @@ SLPM-65889:
   name: "Kazoku Keikaku - Kokoro no Kizuna"
   region: "NTSC-J"
   gsHWFixes:
-    pointListPalette: 1
+    beforeDraw: "OI_PointListPalette"
 SLPM-65890:
   name: "Shin Sangoku Musou 4"
   region: "NTSC-J"
@@ -30271,6 +30530,9 @@ SLPM-65958:
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
     cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
+    getSkipCount: "GSC_BurnoutGames"
+    beforeDraw: "OI_BurnoutGames"
+    afterDraw: "OO_BurnoutGames"
 SLPM-65959:
   name: "Standard Daisenryaku - Ushinawareta Shouri"
   region: "NTSC-J"
@@ -30726,12 +30988,12 @@ SLPM-66083:
   name: "Ramune - Garasu-Bin ni Utsuru Umi [Limited Edition]"
   region: "NTSC-J"
   gsHWFixes:
-    pointListPalette: 1
+    beforeDraw: "OI_PointListPalette"
 SLPM-66084:
   name: "Ramune - Garasu-Bin ni Utsuru Umi"
   region: "NTSC-J"
   gsHWFixes:
-    pointListPalette: 1
+    beforeDraw: "OI_PointListPalette"
 SLPM-66085:
   name: "Rumble Roses [Konami The Best]"
   region: "NTSC-J"
@@ -30822,6 +31084,9 @@ SLPM-66108:
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
     cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
+    getSkipCount: "GSC_BurnoutGames"
+    beforeDraw: "OI_BurnoutGames"
+    afterDraw: "OO_BurnoutGames"
   memcardFilters:
     - "SLAJ-25066"
     - "SLPM-66108"
@@ -30876,6 +31141,8 @@ SLPM-66124:
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
     textureInsideRT: 1 # Fixes wrong visuals for the summon Anima and The (Triple) Magus Sisters.
+    getSkipCount: "GSC_FFXGames"
+    beforeDraw: "OI_FFX"
 SLPM-66125:
   name: "Final Fantasy X-2 [Ultimate Hits]"
   region: "NTSC-J"
@@ -30883,6 +31150,7 @@ SLPM-66125:
     - SoftwareRendererFMVHack # Fixes brightness and overlapping subtitles.
   gsHWFixes:
     roundSprite: 1 # Fixes font artifacts.
+    getSkipCount: "GSC_FFXGames"
 SLPM-66129:
   name: "Guilty Gear XX #Reload"
   region: "NTSC-J"
@@ -30924,7 +31192,7 @@ SLPM-66139:
   name: "Duel Savior Destiny"
   region: "NTSC-J"
   gsHWFixes:
-    pointListPalette: 1
+    beforeDraw: "OI_PointListPalette"
 SLPM-66140:
   name: "Atelier Marie + Elie - Salburg no Renkinjutsushi 1 & 2"
   region: "NTSC-J"
@@ -31040,6 +31308,8 @@ SLPM-66167:
 SLPM-66168:
   name: "Ryu Ga Gotoku"
   region: "NTSC-J"
+  gsHWFixes:
+    getSkipCount: "GSC_YakuzaGames"
 SLPM-66169:
   name: "J-League Winning Eleven 9 - Asia Championship"
   region: "NTSC-J"
@@ -31094,6 +31364,7 @@ SLPM-66183:
   gsHWFixes:
     textureInsideRT: 1
     halfPixelOffset: 2 # Fixes outlines on screen edges.
+    getSkipCount: "GSC_GetawayGames"
 SLPM-66184:
   name: "Ikusa Gami"
   region: "NTSC-J"
@@ -31447,12 +31718,14 @@ SLPM-66275:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misalignment and upscaling lines.
+    getSkipCount: "GSC_ShinOnimusha"
 SLPM-66276:
   name: "Shin Onimusha - Dawn of Dreams [Disc 2 of 2]"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misalignment and upscaling lines.
+    getSkipCount: "GSC_ShinOnimusha"
   memcardFilters:
     - "SLPM-66275"
 SLPM-66277:
@@ -31612,6 +31885,8 @@ SLPM-66320:
   name: "Final Fantasy XII"
   region: "NTSC-J"
   compat: 5
+  gsHWFixes:
+    getSkipCount: "GSC_FFXGames"
 SLPM-66321:
   name: "Kurogane no Houkou - Warship Gunner 2"
   region: "NTSC-J"
@@ -31753,6 +32028,8 @@ SLPM-66354:
     roundSprite: 1 # Fixes lighting misalignment such as the street poles and the sun.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
+    beforeDraw: "OI_BurnoutGames"
+    afterDraw: "OO_BurnoutGames"
   patches:
     B3A9F9ED:
       content: |-
@@ -31815,6 +32092,7 @@ SLPM-66375:
   compat: 5
   gsHWFixes:
     roundSprite: 2 # Reduces misalignment issues but the game is just bad for upscaling.
+    getSkipCount: "GSC_Okami"
 SLPM-66376:
   name: "KimiStar - Kimi to Study [BGM Collection Package]"
   region: "NTSC-J"
@@ -32061,6 +32339,8 @@ SLPM-66444:
   region: "NTSC-J"
   gameFixes:
     - EETimingHack # Fixes garbage textures flashing on the character model.
+  gsHWFixes:
+    getSkipCount: "GSC_Spartan"
 SLPM-66445:
   name: "Persona 3"
   region: "NTSC-J"
@@ -32472,6 +32752,7 @@ SLPM-66550:
   gsHWFixes:
     mergeSprite: 1 # Reduces bloom but fixes blurriness around models + Recommended to use Shadeboost brightness 80.
     halfPixelOffset: 2 # Depth of field effect aligned properly if CRC hack is off + Shifts buildings correctly.
+    getSkipCount: "GSC_GodHand"
 SLPM-66551:
   name: "Appleseed EX"
   region: "NTSC-J"
@@ -32502,6 +32783,7 @@ SLPM-66558:
     - SoftwareRendererFMVHack # Fixes garbage pixels.
   gsHWFixes:
     mipmap: 1 # Fixes distant characters and models but there are still some flickering textures.
+    getSkipCount: "GSC_TombRaiderLegend"
 SLPM-66559:
   name: "Winning Post 6 [KOEI Selection]"
   region: "NTSC-J"
@@ -32684,6 +32966,8 @@ SLPM-66602:
     - "SLPM-66168"
     - "SLPM-74234"
     - "SLPM-74253"
+  gsHWFixes:
+    getSkipCount: "GSC_YakuzaGames"
 SLPM-66603:
   name: "Ryu ga Gotoku 2 [Disc 2 of 2]"
   region: "NTSC-J"
@@ -32693,6 +32977,8 @@ SLPM-66603:
     - "SLPM-66168"
     - "SLPM-74234"
     - "SLPM-74253"
+  gsHWFixes:
+    getSkipCount: "GSC_YakuzaGames"
 SLPM-66604:
   name: "Galaxy Angel - Moonlit Lovers [Banpresido the Best]"
   region: "NTSC-J"
@@ -32860,6 +33146,9 @@ SLPM-66652:
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
     cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
+    getSkipCount: "GSC_BurnoutGames"
+    beforeDraw: "OI_BurnoutGames"
+    afterDraw: "OO_BurnoutGames"
   memcardFilters:
     - "SLAJ-25066"
     - "SLPM-66108"
@@ -32981,6 +33270,8 @@ SLPM-66677:
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
     textureInsideRT: 1 # Fixes wrong visuals for the summon Anima and The (Triple) Magus Sisters.
+    getSkipCount: "GSC_FFXGames"
+    beforeDraw: "OI_FFX"
 SLPM-66678:
   name: "Final Fantasy X-2 - International + Last Mission [Ultimate Hits]"
   region: "NTSC-J"
@@ -32988,6 +33279,7 @@ SLPM-66678:
     - SoftwareRendererFMVHack # Fixes brightness and overlapping subtitles.
   gsHWFixes:
     roundSprite: 1 # Fixes font artifacts.
+    getSkipCount: "GSC_FFXGames"
 SLPM-66679:
   name: "Devil Summoner - Kuzunoha Raidou tai Abaddon Ou [Plus]"
   region: "NTSC-J"
@@ -33117,6 +33409,8 @@ SLPM-66712:
   name: "Rozen Maiden - Geppetto Garden [Limited Edition]"
   region: "NTSC-J"
   compat: 5
+  gsHWFixes:
+    beforeDraw: "OI_RozenMaidenGebetGarden"
 SLPM-66713:
   name: "Taito Memories Vol.2 Gekan"
   region: "NTSC-J"
@@ -33188,6 +33482,8 @@ SLPM-66731:
     roundSprite: 1 # Fixes lighting misalignment such as the street poles and the sun.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
+    beforeDraw: "OI_BurnoutGames"
+    afterDraw: "OO_BurnoutGames"
 SLPM-66732:
   name: "Iinazuke [Limited Edition]"
   region: "NTSC-J"
@@ -33235,6 +33531,9 @@ SLPM-66739:
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
     cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
+    getSkipCount: "GSC_BurnoutGames"
+    beforeDraw: "OI_BurnoutGames"
+    afterDraw: "OO_BurnoutGames"
 SLPM-66740:
   name: "Sentou Kokka Kai - Legend [DX Pack]"
   region: "NTSC-J"
@@ -33280,6 +33579,8 @@ SLPM-66750:
   name: "Final Fantasy XII International - Zodiac Job System [with Bonus DVD]"
   region: "NTSC-J"
   compat: 5
+  gsHWFixes:
+    getSkipCount: "GSC_FFXGames"
 SLPM-66751:
   name: "Mahoroba Stories"
   region: "NTSC-J"
@@ -33826,7 +34127,7 @@ SLPM-66919:
   name: "Kyuuketsu Kitan Moonties"
   region: "NTSC-J"
   gsHWFixes:
-    pointListPalette: 1
+    beforeDraw: "OI_PointListPalette"
 SLPM-66920:
   name: "Hoshi Furu"
   region: "NTSC-J"
@@ -33953,6 +34254,8 @@ SLPM-66961:
     roundSprite: 1 # Fixes lighting misalignment such as the street poles and the sun.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
+    beforeDraw: "OI_BurnoutGames"
+    afterDraw: "OO_BurnoutGames"
 SLPM-66962:
   name: "Burnout 3 - Takedown [EA-SY! 1980]"
   region: "NTSC-J"
@@ -33965,6 +34268,9 @@ SLPM-66962:
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
     cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
+    getSkipCount: "GSC_BurnoutGames"
+    beforeDraw: "OI_BurnoutGames"
+    afterDraw: "OO_BurnoutGames"
 SLPM-66963:
   name: "Medal of Honor - Frontline [EA-SY! 1980]"
   region: "NTSC-J"
@@ -34027,7 +34333,7 @@ SLPM-66990:
   name: "Majo-musume A La Mode II [Best Version]"
   region: "NTSC-J"
   gsHWFixes:
-    pointListPalette: 1
+    beforeDraw: "OI_PointListPalette"
 SLPM-66991:
   name: "Fuuuraiki [Best Version]"
   region: "NTSC-J"
@@ -34181,6 +34487,8 @@ SLPM-67513:
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
     textureInsideRT: 1 # Fixes wrong visuals for the summon Anima and The (Triple) Magus Sisters.
+    getSkipCount: "GSC_FFXGames"
+    beforeDraw: "OI_FFX"
 SLPM-67514:
   name: "Kessen"
   region: "NTSC-K"
@@ -34341,6 +34649,7 @@ SLPM-74003:
   gsHWFixes:
     preloadFrameData: 1 # Fixes random texture corruptions such as horizontal lines.
     cpuFramebufferConversion: 1 # Fixes fog wall.
+    getSkipCount: "GSC_CrashBandicootWoC"
 SLPM-74004:
   name: "Maximo - Ghosts to Glory [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -34470,16 +34779,20 @@ SLPM-74232:
     - SoftwareRendererFMVHack # Wrong white textures in FMV.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misalignment and upscaling lines.
+    getSkipCount: "GSC_ShinOnimusha"
 SLPM-74233:
   name: "Shin Onimusha - Dawn of Dreams [PlayStation 2 The Best][Disc 2]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misalignment and upscaling lines.
+    getSkipCount: "GSC_ShinOnimusha"
   memcardFilters:
     - "SLPM-74232"
 SLPM-74234:
   name: "Ryu Ga Gotoku [PlayStation 2 The Best]"
   region: "NTSC-J"
+  gsHWFixes:
+    getSkipCount: "GSC_YakuzaGames"
 SLPM-74235:
   name: "Sengoku Musou [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -34497,6 +34810,7 @@ SLPM-74239:
   region: "NTSC-J"
   gsHWFixes:
     roundSprite: 2 # Reduces misalignment issues but the game is just bad for upscaling.
+    getSkipCount: "GSC_Okami"
 SLPM-74240:
   name: "Tengai Makyou III - Namida [Best Version]"
   region: "NTSC-J"
@@ -34506,6 +34820,7 @@ SLPM-74241:
   gsHWFixes:
     mergeSprite: 1 # Reduces bloom but fixes blurriness around models + Recommended to use Shadeboost brightness 80.
     halfPixelOffset: 2 # Depth of field effect aligned properly if CRC hack is off + Shifts buildings correctly.
+    getSkipCount: "GSC_GodHand"
 SLPM-74242:
   name: "Devil May Cry 3 [Special Edition] [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -34571,16 +34886,20 @@ SLPM-74251:
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misalignment and upscaling lines.
+    getSkipCount: "GSC_ShinOnimusha"
 SLPM-74252:
   name: "Shin Onimusha - Dawn of Dreams [PlayStation 2 the Best - Reprint Disc 2]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misalignment and upscaling lines.
+    getSkipCount: "GSC_ShinOnimusha"
   memcardFilters:
     - "SLPM-74251"
 SLPM-74253:
   name: "Ryu ga Gotoku [PlayStation 2 the Best - Reprint]"
   region: "NTSC-J"
+  gsHWFixes:
+    getSkipCount: "GSC_YakuzaGames"
 SLPM-74254:
   name: "EX Jinsei Game II [PlayStation 2 the Best - Reprint]"
   region: "NTSC-J"
@@ -34626,6 +34945,8 @@ SLPM-74301:
     - "SLPM-66168"
     - "SLPM-74234"
     - "SLPM-74253"
+  gsHWFixes:
+    getSkipCount: "GSC_YakuzaGames"
 SLPM-74402:
   name: "Capcom vs. SNK 2 [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -34700,6 +35021,8 @@ SLPS-20002:
 SLPS-20003:
   name: "Street Fighter EX3"
   region: "NTSC-J"
+  gsHWFixes:
+    getSkipCount: "GSC_SFEX3"
 SLPS-20005:
   name: "EX Billiards"
   region: "NTSC-J"
@@ -35769,6 +36092,8 @@ SLPS-20444:
   name: "Simple 2000 Series Vol. 90 - The OneeChanBara 2"
   region: "NTSC-J"
   compat: 5
+  gsHWFixes:
+    getSkipCount: "GSC_Oneechanbara2Special"
 SLPS-20445:
   name: "Simple 2000 Series Ultimate Vol. 28 - Tousou! Kenka Grand Prix - Drive to Survive"
   region: "NTSC-J"
@@ -35852,6 +36177,8 @@ SLPS-20465:
 SLPS-20466:
   name: "Simple 2000 Series Vol. 101 - The OneeChanpon - OneeChan 2 Special Edition"
   region: "NTSC-J"
+  gsHWFixes:
+    getSkipCount: "GSC_Oneechanbara2Special"
 SLPS-20467:
   name: "Simple 2000 Series Vol. 102 - The Hohei - Senjou no Inutachi"
   region: "NTSC-J"
@@ -35932,6 +36259,7 @@ SLPS-20489:
   region: "NTSC-J"
   gsHWFixes:
     preloadFrameData: 1 # Fixes black screen in-game.
+    getSkipCount: "GSC_Simple2000Vol114"
 SLPS-20490:
   name: "Pachi-Slot Club Collection - IM Juggler EX - Juggler Selection"
   region: "NTSC-J"
@@ -36214,6 +36542,8 @@ SLPS-25050:
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
     textureInsideRT: 1 # Fixes wrong visuals for the summon Anima and The (Triple) Magus Sisters.
+    getSkipCount: "GSC_FFXGames"
+    beforeDraw: "OI_FFX"
 SLPS-25051:
   name: "Missing Blue"
   region: "NTSC-J"
@@ -36226,6 +36556,7 @@ SLPS-25052:
     roundSprite: 2 # Fixes font and HUD artifacts.
     alignSprite: 1 # Fixes vertical lines.
     mergeSprite: 1 # Fixes vertical lines.
+    getSkipCount: "GSC_AceCombat4"
 SLPS-25053:
   name: "Eikan wa Kimi ni - Koushien no Hasha"
   region: "NTSC-J"
@@ -36341,6 +36672,8 @@ SLPS-25088:
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
     textureInsideRT: 1 # Fixes wrong visuals for the summon Anima and The (Triple) Magus Sisters.
+    getSkipCount: "GSC_FFXGames"
+    beforeDraw: "OI_FFX"
 SLPS-25094:
   name: "Reveal Fantasia"
   region: "NTSC-J"
@@ -36870,6 +37203,7 @@ SLPS-25250:
     - SoftwareRendererFMVHack # Fixes brightness and overlapping subtitles.
   gsHWFixes:
     roundSprite: 1 # Fixes font artifacts.
+    getSkipCount: "GSC_FFXGames"
 SLPS-25251:
   name: "MVP Baseball 2003"
   region: "NTSC-J"
@@ -37424,6 +37758,7 @@ SLPS-25400:
   compat: 5
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
+    getSkipCount: "GSC_TalesofSymphonia"
 SLPS-25401:
   name: "Magna Carta"
   region: "NTSC-J"
@@ -37525,6 +37860,7 @@ SLPS-25422:
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes FMV lines.
+    getSkipCount: "GSC_DeathByDegreesTekkenNinaWilliams"
 SLPS-25423:
   name: "Kaitou Apricot - Complete Edition [Limited Edition]"
   region: "NTSC-J"
@@ -37819,6 +38155,7 @@ SLPS-25510:
     eeClampMode: 2 # Fixes camera and stops constant coin noises on Pirates Cove.
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
+    getSkipCount: "GSC_Tekken5"
 SLPS-25511:
   name: "Rasetsu Alternative"
   region: "NTSC-J"
@@ -37872,6 +38209,8 @@ SLPS-25528:
 SLPS-25529:
   name: "Ultraman Fighting Evolution - Rebirth"
   region: "NTSC-J"
+  gsHWFixes:
+    getSkipCount: "GSC_UltramanFightingEvolution"
 SLPS-25530:
   name: "Garouden Break Blow"
   region: "NTSC-J"
@@ -37887,6 +38226,8 @@ SLPS-25533:
   compat: 5
   gameFixes:
     - SoftwareRendererFMVHack # Fixes garbage textures presumably from texture cache issue.
+  gsHWFixes:
+    getSkipCount: "GSC_TalesOfLegendia"
 SLPS-25534:
   name: "Twinkle Star Sprites - La Petite Princesse"
   region: "NTSC-J"
@@ -37973,6 +38314,7 @@ SLPS-25557:
     alignSprite: 1 # Fixes vertical lines.
     textureInsideRT: 1 # Fixes corruption.
     texturePreloading: 1 # Performs much better with partial preload.
+    getSkipCount: "GSC_UrbanReign"
 SLPS-25558:
   name: "NeoGeo Battle Coliseum"
   region: "NTSC-J"
@@ -38152,6 +38494,7 @@ SLPS-25606:
   compat: 5
   gsHWFixes:
     cpuCLUTRender: 1 # Fixes some shading/shadows.
+    getSkipCount: "GSC_ZettaiZetsumeiToshi2"
 SLPS-25607:
   name: "Makai Senki Disgaea 2 [Limited Edition]"
   region: "NTSC-J"
@@ -38283,6 +38626,7 @@ SLPS-25640:
     halfPixelOffset: 1 # Fixes lighting misalignment and reduces ground shadows (probably texture cache issue).
     roundSprite: 2 # Fixes font artifacts.
     texturePreloading: 0 # Performs much better with it off.
+    getSkipCount: "GSC_XenosagaE3"
   memcardFilters: # Allows import of Xenosaga II save data.
     - "SLPS-25640"
     - "SLPS-25368"
@@ -38295,6 +38639,7 @@ SLPS-25641:
     halfPixelOffset: 1 # Fixes lighting misalignment and reduces ground shadows (probably texture cache issue).
     roundSprite: 2 # Fixes font artifacts.
     texturePreloading: 0 # Performs much better with it off.
+    getSkipCount: "GSC_XenosagaE3"
   memcardFilters:
     - "SLPS-25640"
     - "SLPS-25368"
@@ -38406,6 +38751,8 @@ SLPS-25657:
   name: "Fighting Beauty Wulong"
   region: "NTSC-J"
   compat: 5
+  gsHWFixes:
+    getSkipCount: "GSC_FightingBeautyWulong"
 SLPS-25658:
   name: "Binchou-Tan - Shiwase Goyomi [Shokai Genteiban]"
   region: "NTSC-J"
@@ -38463,6 +38810,8 @@ SLPS-25674:
   name: "Metal Slug 6"
   region: "NTSC-J"
   compat: 5
+  gsHWFixes:
+    beforeDraw: "OI_MetalSlug6"
 SLPS-25675:
   name: "Battle Stadium D.O.N"
   region: "NTSC-J"
@@ -38516,6 +38865,7 @@ SLPS-25690:
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 1 # Fixes extreme ghosting.
+    beforeDraw: "OI_DBZBTGames"
 SLPS-25691:
   name: "Captain Tsubasa"
   region: "NTSC-J"
@@ -38891,6 +39241,8 @@ SLPS-25799:
 SLPS-25800:
   name: "Ultraman Fighting Evolution - Rebirth [Banpresto Best]"
   region: "NTSC-J"
+  gsHWFixes:
+    getSkipCount: "GSC_UltramanFightingEvolution"
 SLPS-25801:
   name: "Kyou Kara Maou! Shin Ma-Kuni no Kyuujitsu [Limited Edition]"
   region: "NTSC-J"
@@ -38934,6 +39286,8 @@ SLPS-25814:
 SLPS-25815:
   name: "Dragon Ball Z Sparking! Meteor"
   region: "NTSC-J"
+  gsHWFixes:
+    beforeDraw: "OI_DBZBTGames"
 SLPS-25816:
   name: "Yamasa Digi World - Collaboration SP Pachi-Slot Ridge Racer"
   region: "NTSC-J"
@@ -38951,6 +39305,7 @@ SLPS-25819:
     eeRoundMode: 0 # Fixes "Fall through floor" bug when approaching chests.
   gsHWFixes:
     roundSprite: 1 # Fixes textboxes and character portraits.
+    beforeDraw: "OI_ArTonelico2"
 SLPS-25820:
   name: "Kateikyoushi Hitman Reborn!! Let's Ansatsu! Nerawareta 10 Daime!"
   region: "NTSC-J"
@@ -39075,6 +39430,7 @@ SLPS-25851:
   region: "NTSC-J"
   gsHWFixes:
     cpuCLUTRender: 1 # Fixes some shading/shadows.
+    getSkipCount: "GSC_ZettaiZetsumeiToshi2"
 SLPS-25852:
   name: "Sanyo Pachinko Paradise 13 [Irem Collection]"
   region: "NTSC-J"
@@ -39098,6 +39454,7 @@ SLPS-25856:
     - SoftwareRendererFMVHack # Fixes garbage pixels.
   gsHWFixes:
     mipmap: 1
+    getSkipCount: "GSC_TombRaiderAnniversary"
 SLPS-25858:
   name: "Dengeki SP - Shakugan no Shana"
   region: "NTSC-J"
@@ -39259,6 +39616,8 @@ SLPS-25915:
 SLPS-25917:
   name: "Sacred Blaze"
   region: "NTSC-J"
+  gsHWFixes:
+    getSkipCount: "GSC_SacredBlaze"
 SLPS-25922:
   name: "Vitamin Z [Limited Edition]"
   region: "NTSC-J"
@@ -39276,6 +39635,8 @@ SLPS-25919:
 SLPS-25927:
   name: "Tomb Raider - Underworld"
   region: "NTSC-J"
+  gsHWFixes:
+    getSkipCount: "GSC_TombRaiderUnderWorld"
 SLPS-25930:
   name: "Major League Baseball 2K9"
   region: "NTSC-J"
@@ -39428,6 +39789,8 @@ SLPS-72501:
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
     textureInsideRT: 1 # Fixes wrong visuals for the summon Anima and The (Triple) Magus Sisters.
+    getSkipCount: "GSC_FFXGames"
+    beforeDraw: "OI_FFX"
 SLPS-72502:
   name: "Tales of Destiny 2 [Mega Hits]"
   region: "NTSC-J"
@@ -39516,6 +39879,7 @@ SLPS-73205:
     roundSprite: 2 # Fixes font and HUD artifacts.
     alignSprite: 1 # Fixes vertical lines.
     mergeSprite: 1 # Fixes vertical lines.
+    getSkipCount: "GSC_AceCombat4"
 SLPS-73206:
   name: "Super Robot Taisen Alpha 2nd [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -39574,6 +39938,7 @@ SLPS-73217:
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
+    getSkipCount: "GSC_TalesofSymphonia"
 SLPS-73218:
   name: "Ace Combat 5 - The Unsung War [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -39606,6 +39971,7 @@ SLPS-73223:
     eeClampMode: 2 # Fixes camera and stops constant coin noises on Pirates Cove.
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
+    getSkipCount: "GSC_Tekken5"
 SLPS-73224:
   name: "Xenosaga Episode II - Jenseits von Gut und Bose [PlayStation 2 The Best] [Disc 1 of 2]"
   region: "NTSC-J"
@@ -39761,6 +40127,8 @@ SLPS-73242:
   region: "NTSC-J"
   gameFixes:
     - SoftwareRendererFMVHack # Fixes garbage textures presumably from texture cache issue.
+  gsHWFixes:
+    getSkipCount: "GSC_TalesOfLegendia"
 SLPS-73243:
   name: "Namco X Capcom [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -39859,6 +40227,7 @@ SLPS-73263:
     eeRoundMode: 0 # Fixes "Fall through floor" bug when approaching chests.
   gsHWFixes:
     roundSprite: 1 # Fixes textboxes and character portraits.
+    beforeDraw: "OI_ArTonelico2"
 SLPS-73269:
   name: "Kidou Senshi Gundam SEED - Rengou vs. Z.A.F.T."
   region: "NTSC-K"
@@ -39915,6 +40284,7 @@ SLPS-73410:
     roundSprite: 2 # Fixes font and HUD artifacts.
     alignSprite: 1 # Fixes vertical lines.
     mergeSprite: 1 # Fixes vertical lines.
+    getSkipCount: "GSC_AceCombat4"
 SLPS-73411:
   name: "Armored Core 2 - Another Age [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -40442,6 +40812,8 @@ SLUS-20130:
   name: "Street Fighter EX3"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    getSkipCount: "GSC_SFEX3"
 SLUS-20131:
   name: "Dark Angel - Vampire Apocalypse"
   region: "NTSC-U"
@@ -40549,6 +40921,7 @@ SLUS-20152:
     roundSprite: 2 # Fixes font and HUD artifacts.
     alignSprite: 1 # Fixes vertical lines.
     mergeSprite: 1 # Fixes vertical lines.
+    getSkipCount: "GSC_AceCombat4"
   patches:
     A32F7CD0:
       content: |-
@@ -40924,6 +41297,7 @@ SLUS-20238:
   gsHWFixes:
     preloadFrameData: 1 # Fixes random texture corruptions such as horizontal lines.
     cpuFramebufferConversion: 1 # Fixes fog wall.
+    getSkipCount: "GSC_CrashBandicootWoC"
 SLUS-20239:
   name: "Driven"
   region: "NTSC-U"
@@ -41140,6 +41514,9 @@ SLUS-20291:
   name: "Big Mutha Truckers"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    getSkipCount: "GSC_BigMuthaTruckers"
+    beforeDraw: "OI_BigMuthaTruckers"
 SLUS-20292:
   name: "Tsugunai - Atonement"
   region: "NTSC-U"
@@ -41226,6 +41603,8 @@ SLUS-20312:
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
     textureInsideRT: 1 # Fixes wrong visuals for the summon Anima and The (Triple) Magus Sisters.
+    getSkipCount: "GSC_FFXGames"
+    beforeDraw: "OI_FFX"
 SLUS-20313:
   name: "Wave Rally"
   region: "NTSC-U"
@@ -42111,6 +42490,8 @@ SLUS-20500:
   name: "Red Dead Revolver"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    getSkipCount: "GSC_RedDeadRevolver"
 SLUS-20502:
   name: "Colin McRae Rally 3"
   region: "NTSC-U"
@@ -42613,6 +42994,9 @@ SLUS-20604:
 SLUS-20605:
   name: "Big Mutha Truckers"
   region: "NTSC-U"
+  gsHWFixes:
+    getSkipCount: "GSC_BigMuthaTruckers"
+    beforeDraw: "OI_BigMuthaTruckers"
 SLUS-20606:
   name: "Bounty Hunter - Seek & Destroy"
   region: "NTSC-U"
@@ -42919,6 +43303,7 @@ SLUS-20672:
     - SoftwareRendererFMVHack # Fixes brightness and overlapping subtitles.
   gsHWFixes:
     roundSprite: 1 # Fixes font artifacts.
+    getSkipCount: "GSC_FFXGames"
 SLUS-20673:
   name: "Alias"
   region: "NTSC-U"
@@ -43574,6 +43959,8 @@ SLUS-20810:
   name: "Nightshade"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    getSkipCount: "GSC_Kunoichi"
 SLUS-20811:
   name: "Need for Speed - Underground"
   region: "NTSC-U"
@@ -44195,6 +44582,7 @@ SLUS-20934:
   compat: 5
   gsHWFixes:
     alignSprite: 1 # Fixes FMV lines.
+    getSkipCount: "GSC_DeathByDegreesTekkenNinaWilliams"
 SLUS-20935:
   name: "IHRA Professional Drag Racing 2005"
   region: "NTSC-U"
@@ -44338,6 +44726,8 @@ SLUS-20963:
   name: "Final Fantasy XII"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    getSkipCount: "GSC_FFXGames"
 SLUS-20964:
   name: "Devil May Cry 3 - Dante's Awakening"
   region: "NTSC-U"
@@ -44551,6 +44941,7 @@ SLUS-21006:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes texture and lighting misalignment.
     mergeSprite: 1 # Fixes most vertical lines and lighting misalignment.
+    getSkipCount: "GSC_GiTS"
   patches:
     default:
       content: |-
@@ -44717,6 +45108,7 @@ SLUS-21029:
         patch=1,EE,205257FC,extended,00000000
   gsHWFixes:
     texturePreloading: 1 # Improves performance and prevents it disabling itself regardless.
+    getSkipCount: "GSC_MidnightClub3"
 SLUS-21030:
   name: "Outlaw Golf 2"
   region: "NTSC-U"
@@ -44835,6 +45227,9 @@ SLUS-21050:
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
     cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
+    getSkipCount: "GSC_BurnoutGames"
+    beforeDraw: "OI_BurnoutGames"
+    afterDraw: "OO_BurnoutGames"
 SLUS-21051:
   name: "FIFA 2005"
   region: "NTSC-U"
@@ -44877,6 +45272,7 @@ SLUS-21059:
     eeClampMode: 2 # Fixes camera and stops constant coin noises on Pirates Cove.
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
+    getSkipCount: "GSC_Tekken5"
 SLUS-21060:
   name: "WWE SmackDown! vs. RAW"
   region: "NTSC-U"
@@ -45137,6 +45533,7 @@ SLUS-21115:
   compat: 5
   gsHWFixes:
     roundSprite: 2 # Reduces misalignment issues but the game is just bad for upscaling.
+    getSkipCount: "GSC_Okami"
 SLUS-21116:
   name: "187 - Ride or Die"
   region: "NTSC-U"
@@ -45349,6 +45746,7 @@ SLUS-21160:
     eeClampMode: 2 # Fixes camera and stops constant coin noises on Pirates Cove.
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
+    getSkipCount: "GSC_Tekken5"
 SLUS-21161:
   name: "Fight Night - Round 2"
   region: "NTSC-U"
@@ -45444,6 +45842,7 @@ SLUS-21180:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misalignment and upscaling lines.
+    getSkipCount: "GSC_ShinOnimusha"
 SLUS-21181:
   name: "D.I.C.E. - DNA Integrated Cybernetic Enterprises"
   region: "NTSC-U"
@@ -45549,6 +45948,8 @@ SLUS-21201:
   compat: 5
   gameFixes:
     - SoftwareRendererFMVHack # Fixes garbage textures presumably from texture cache issue.
+  gsHWFixes:
+    getSkipCount: "GSC_TalesOfLegendia"
 SLUS-21202:
   name: "Romance of the Three Kingdoms X"
   region: "NTSC-U"
@@ -45561,6 +45962,7 @@ SLUS-21203:
     - SoftwareRendererFMVHack # Fixes garbage pixels.
   gsHWFixes:
     mipmap: 1 # Fixes distant characters and models but there are still some flickering textures.
+    getSkipCount: "GSC_TombRaiderLegend"
 SLUS-21204:
   name: "Victorious Boxers 2 - Fighting Spirit"
   region: "NTSC-U"
@@ -45598,12 +46000,15 @@ SLUS-21209:
     alignSprite: 1 # Fixes vertical lines.
     textureInsideRT: 1 # Fixes corruption.
     texturePreloading: 1 # Performs much better with partial preload.
+    getSkipCount: "GSC_UrbanReign"
 SLUS-21212:
   name: "Spartan - Total Warrior"
   region: "NTSC-U"
   compat: 5
   gameFixes:
     - EETimingHack # Fixes garbage textures flashing on the character model.
+  gsHWFixes:
+    getSkipCount: "GSC_Spartan"
 SLUS-21213:
   name: "Madden NFL '06"
   region: "NTSC-U"
@@ -45797,6 +46202,9 @@ SLUS-21242:
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
     cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
+    getSkipCount: "GSC_BurnoutGames"
+    beforeDraw: "OI_BurnoutGames"
+    afterDraw: "OO_BurnoutGames"
   memcardFilters: # Reads Burnout 3 and NFL 06 saves for unlockables.
     - "SLUS-21242"
     - "SLUS-21050"
@@ -46381,6 +46789,8 @@ SLUS-21344:
   name: "Steambot Chronicles"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    getSkipCount: "GSC_SteambotChronicles"
 SLUS-21345:
   name: "Grandia III [Disc 2 of 2]"
   region: "NTSC-U"
@@ -46419,6 +46829,8 @@ SLUS-21348:
   compat: 5
   gameFixes:
     - EETimingHack # Fixes flickering.
+  gsHWFixes:
+    getSkipCount: "GSC_YakuzaGames"
 SLUS-21349:
   name: "Taito Legends 2"
   region: "NTSC-U"
@@ -46464,6 +46876,7 @@ SLUS-21355:
         patch=1,EE,2052907C,extended,00000000
   gsHWFixes:
     texturePreloading: 1 # Improves performance and prevents it disabling itself regardless.
+    getSkipCount: "GSC_MidnightClub3"
 SLUS-21356:
   name: "Tom Clancy's Splinter Cell - Double Agent"
   region: "NTSC-U"
@@ -46508,6 +46921,7 @@ SLUS-21362:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misalignment and upscaling lines.
+    getSkipCount: "GSC_ShinOnimusha"
   memcardFilters:
     - "SLUS-21180"
 SLUS-21363:
@@ -46589,6 +47003,8 @@ SLUS-21376:
     roundSprite: 1 # Fixes lighting misalignment such as the street poles and the sun.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
+    beforeDraw: "OI_BurnoutGames"
+    afterDraw: "OO_BurnoutGames"
   patches:
     5C891FF1:
       content: |-
@@ -46676,6 +47092,7 @@ SLUS-21389:
     halfPixelOffset: 1 # Fixes lighting misalignment and reduces ground shadows.
     roundSprite: 2 # Fixes font artifacts.
     texturePreloading: 0 # Performs much better with it off.
+    getSkipCount: "GSC_XenosagaE3"
   memcardFilters: # Allows import of Xenosaga II save data.
     - "SLUS-21389"
     - "SLUS-20892"
@@ -46818,6 +47235,7 @@ SLUS-21417:
     halfPixelOffset: 1 # Fixes lighting misalignment and reduces ground shadows.
     roundSprite: 2 # Fixes font artifacts.
     texturePreloading: 0 # Performs much better with it off.
+    getSkipCount: "GSC_XenosagaE3"
   memcardFilters:
     - "SLUS-21389"
     - "SLUS-20892"
@@ -46965,6 +47383,7 @@ SLUS-21441:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 1 # Fixes extreme ghosting.
+    beforeDraw: "OI_DBZBTGames"
 SLUS-21442:
   name: "Super Dragon Ball Z"
   region: "NTSC-U"
@@ -47125,6 +47544,8 @@ SLUS-21475:
   name: "Final Fantasy XII [Collector's Edition]"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    getSkipCount: "GSC_FFXGames"
 SLUS-21476:
   name: "Madden NFL '07"
   region: "NTSC-U"
@@ -47295,6 +47716,7 @@ SLUS-21503:
   gsHWFixes:
     mergeSprite: 1 # Reduces bloom but fixes blurriness around models + Recommended to use Shadeboost brightness 80.
     halfPixelOffset: 2 # Depth of field effect aligned properly if CRC hack is off + Shifts buildings correctly.
+    getSkipCount: "GSC_GodHand"
 SLUS-21536:
   name: "Sims 2, The - Pets"
   region: "NTSC-U"
@@ -47390,6 +47812,7 @@ SLUS-21555:
     - SoftwareRendererFMVHack # Fixes garbage pixels.
   gsHWFixes:
     mipmap: 1
+    getSkipCount: "GSC_TombRaiderAnniversary"
 SLUS-21556:
   name: "Konami Kids Playground - Dinosaur Shapes & Colors"
   region: "NTSC-U"
@@ -47573,6 +47996,9 @@ SLUS-21596:
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
     cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
+    getSkipCount: "GSC_BurnoutGames"
+    beforeDraw: "OI_BurnoutGames"
+    afterDraw: "OO_BurnoutGames"
 SLUS-21597:
   name: "Medal of Honor - Vanguard"
   region: "NTSC-U"
@@ -47672,6 +48098,8 @@ SLUS-21613:
   name: "Manhunt 2"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    getSkipCount: "GSC_Manhunt2"
 SLUS-21614:
   name: "Star Wars - The Force Unleashed"
   region: "NTSC-U"
@@ -47983,6 +48411,7 @@ SLUS-21678:
   compat: 5
   gsHWFixes:
     cpuCLUTRender: 1 # Reduces the bloomy blur of characters.
+    beforeDraw: "OI_DBZBTGames"
 SLUS-21679:
   name: "Power Rangers - Super Legends"
   region: "NTSC-U"
@@ -48417,6 +48846,8 @@ SLUS-21769:
   memcardFilters: # Allows import of Yakuza 1 data.
     - "SLUS-21769"
     - "SLUS-21348"
+  gsHWFixes:
+    getSkipCount: "GSC_YakuzaGames"
 SLUS-21770:
   name: "Madden NFL '09"
   region: "NTSC-U"
@@ -48519,6 +48950,7 @@ SLUS-21788:
     eeRoundMode: 0 # Fixes "Fall through floor" bug when approaching chests.
   gsHWFixes:
     roundSprite: 1 # Fixes textboxes and character portraits.
+    beforeDraw: "OI_ArTonelico2"
 SLUS-21789:
   name: "Cabela's Legendary Adventures"
   region: "NTSC-U"
@@ -48744,6 +49176,8 @@ SLUS-21846:
   name: "Sonic Unleashed"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    beforeDraw: "OI_SonicUnleashed"
 SLUS-21847:
   name: "Guilty Gear XX - Accent Core Plus"
   region: "NTSC-U"
@@ -48788,6 +49222,8 @@ SLUS-21858:
   name: "Tomb Raider - Underworld"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    getSkipCount: "GSC_TombRaiderUnderWorld"
 SLUS-21860:
   name: "Bigs 2, The"
   region: "NTSC-U"
@@ -49082,6 +49518,8 @@ SLUS-21927:
   name: "Sakura Wars - So Long, My Love [English - Disc 1]"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    getSkipCount: "GSC_SakuraWarsSoLongMyLove"
 SLUS-21928:
   name: "Scooby-Doo! and the Spooky Swamp"
   region: "NTSC-U"
@@ -49098,6 +49536,8 @@ SLUS-21930:
   name: "Sakura Wars - So Long, My Love [Japanese - Disc 2]"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    getSkipCount: "GSC_SakuraWarsSoLongMyLove"
 SLUS-21931:
   name: "Toy Story 3"
   region: "NTSC-U"
@@ -49356,6 +49796,8 @@ SLUS-28059:
 SLUS-28061:
   name: "Steambot Chronicles [Trade Demo]"
   region: "NTSC-U"
+  gsHWFixes:
+    getSkipCount: "GSC_SteambotChronicles"
 SLUS-28062:
   name: "Dance Factory [Trade Demo]"
   region: "NTSC-U"
@@ -49418,6 +49860,7 @@ SLUS-29010:
   gsHWFixes:
     preloadFrameData: 1 # Fixes random texture corruptions such as horizontal lines.
     cpuFramebufferConversion: 1 # Fixes fog wall.
+    getSkipCount: "GSC_CrashBandicootWoC"
 SLUS-29011:
   name: "WWF SmackDown! - Just Bring It [Demo]"
   region: "NTSC-U"
@@ -49721,6 +50164,9 @@ SLUS-29113:
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
     cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
+    getSkipCount: "GSC_BurnoutGames"
+    beforeDraw: "OI_BurnoutGames"
+    afterDraw: "OO_BurnoutGames"
 SLUS-29116:
   name: "WWE SmackDown! vs. RAW [Public Beta Vol.1.0]"
   region: "NTSC-U"
@@ -49740,6 +50186,7 @@ SLUS-29123:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes texture and lighting misalignment.
     mergeSprite: 1 # Fixes most vertical lines and lighting misalignment.
+    getSkipCount: "GSC_GiTS"
 SLUS-29124:
   name: "Fight Club [Demo]"
   region: "NTSC-U"
@@ -49833,6 +50280,9 @@ SLUS-29153:
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
     cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
+    getSkipCount: "GSC_BurnoutGames"
+    beforeDraw: "OI_BurnoutGames"
+    afterDraw: "OO_BurnoutGames"
 SLUS-29154:
   name: "NHL '06 [Demo]"
   region: "NTSC-U"
@@ -49898,6 +50348,8 @@ SLUS-29170:
 SLUS-29171:
   name: "Final Fantasy XII [Demo]"
   region: "NTSC-U"
+  gsHWFixes:
+    getSkipCount: "GSC_FFXGames"
 SLUS-29172:
   name: "Battlefield 2 - Modern Combat [Demo]"
   region: "NTSC-U"
@@ -49932,6 +50384,8 @@ SLUS-29180:
     roundSprite: 1 # Fixes lighting misalignment such as the street poles and the sun.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
+    beforeDraw: "OI_BurnoutGames"
+    afterDraw: "OO_BurnoutGames"
 SLUS-29183:
   name: "Fight Night - Round 3 [Demo]"
   region: "NTSC-U"
@@ -49946,6 +50400,8 @@ SLUS-29185:
 SLUS-29188:
   name: "Steambot Chronicles [Regular Demo]"
   region: "NTSC-U"
+  gsHWFixes:
+    getSkipCount: "GSC_SteambotChronicles"
 SLUS-29189:
   name: "FIFA World Cup - Germany 2006 [Demo]"
   region: "NTSC-U"
@@ -49980,6 +50436,8 @@ SLUS-29194:
 SLUS-29195:
   name: "Yakuza [Demo]"
   region: "NTSC-U"
+  gsHWFixes:
+    getSkipCount: "GSC_YakuzaGames"
 SLUS-29196:
   name: "Destroy All Humans! 2 [Demo]"
   region: "NTSC-U"
@@ -50015,6 +50473,7 @@ SLUS-97133:
     textureInsideRT: 1
     texturePreloading: 1 # Performs much better with partial preload.
     halfPixelOffset: 2 # Fixes outlines around characters.
+    getSkipCount: "GSC_GetawayGames"
 SLUS-97405:
   name: "ATV Offroad Fury 3 [Greatest Hits]"
   region: "NTSC-U"
@@ -50094,6 +50553,7 @@ TCES-53286:
     textureInsideRT: 1 # Fixes broken character models.
     autoFlush: 1 # Fixes lighting.
     preloadFrameData: 1 # Fixes Sony splash at boot.
+    beforeDraw: "OI_JakGames"
 TCPS-10058:
   name: "Densha de Go! Shinkansen [with Controller]"
   region: "NTSC-J"
@@ -50201,6 +50661,8 @@ TCPS-10172:
 TCPS-10182:
   name: "Rozen Maiden - Gebetgarten [Limited Edition]"
   region: "NTSC-J"
+  gsHWFixes:
+    beforeDraw: "OI_RozenMaidenGebetGarden"
 TCPS-10183:
   name: "Taito Memories II - Gekan"
   region: "NTSC-J"
@@ -50241,9 +50703,11 @@ VW067-J1:
   gsHWFixes:
     preloadFrameData: 1 # Fixes random texture corruptions such as horizontal lines.
     cpuFramebufferConversion: 1 # Fixes fog wall.
+    getSkipCount: "GSC_CrashBandicootWoC"
 VW067-J2:
   name: "Crash Bandicoot 4 - Sakuretsu! Majin Power! [PlayStation 2 The Best]"
   region: "NTSC-J"
   gsHWFixes:
     preloadFrameData: 1 # Fixes random texture corruptions such as horizontal lines.
     cpuFramebufferConversion: 1 # Fixes fog wall.
+    getSkipCount: "GSC_CrashBandicootWoC"

--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -8984,7 +8984,6 @@ SLAJ-25053:
     cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
-    afterDraw: "OO_BurnoutGames"
 SLAJ-25055:
   name: "Def Jam - Fight for N.Y."
   region: "NTSC-Unk"
@@ -9023,7 +9022,6 @@ SLAJ-25066:
     cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
-    afterDraw: "OO_BurnoutGames"
   memcardFilters:
     - "SLAJ-25066"
     - "SLPM-66108"
@@ -9092,8 +9090,8 @@ SLAJ-25078:
     roundSprite: 1 # Fixes lighting misalignment such as the street poles and the sun.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
+    getSkipCount: "GSC_BlackAndBurnoutSky"
     beforeDraw: "OI_BurnoutGames"
-    afterDraw: "OO_BurnoutGames"
 SLAJ-25079:
   name: "Shin Sangoku Musou 4 - Empires"
   region: "NTSC-Unk"
@@ -9146,7 +9144,6 @@ SLAJ-25094:
     cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
-    afterDraw: "OO_BurnoutGames"
 SLAJ-25095:
   name: "Medal of Honor - Vanguard"
   region: "NTSC-Unk"
@@ -9311,7 +9308,6 @@ SLED-52597:
     cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
-    afterDraw: "OO_BurnoutGames"
 SLED-52852:
   name: "Forgotten Realms - Demon Stone [Demo]"
   region: "PAL-E"
@@ -9378,7 +9374,6 @@ SLED-53512:
     cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
-    afterDraw: "OO_BurnoutGames"
 SLED-53537:
   name: "187 - Ride or Die [Demo]"
   region: "PAL-E"
@@ -9426,8 +9421,8 @@ SLED-53937:
     roundSprite: 1 # Fixes lighting misalignment such as the street poles and the sun.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
+    getSkipCount: "GSC_BlackAndBurnoutSky"
     beforeDraw: "OI_BurnoutGames"
-    afterDraw: "OO_BurnoutGames"
 SLED-53951:
   name: "Honda Demo [Demo]"
   region: "PAL-E"
@@ -15067,7 +15062,6 @@ SLES-52584:
     cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
-    afterDraw: "OO_BurnoutGames"
 SLES-52585:
   name: "Burnout 3 - Takedown"
   region: "PAL-F-G-I"
@@ -15082,7 +15076,6 @@ SLES-52585:
     cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
-    afterDraw: "OO_BurnoutGames"
 SLES-52587:
   name: "Army Men - Sarge's War"
   region: "PAL-M5"
@@ -17265,7 +17258,6 @@ SLES-53506:
     cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
-    afterDraw: "OO_BurnoutGames"
   memcardFilters:
     - "SLES-53506"
     - "SLES-53507"
@@ -17287,7 +17279,6 @@ SLES-53507:
     cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
-    afterDraw: "OO_BurnoutGames"
   memcardFilters:
     - "SLES-53506"
     - "SLES-53507"
@@ -18394,8 +18385,8 @@ SLES-53886:
     roundSprite: 1 # Fixes lighting misalignment such as the street poles and the sun.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
+    getSkipCount: "GSC_BlackAndBurnoutSky"
     beforeDraw: "OI_BurnoutGames"
-    afterDraw: "OO_BurnoutGames"
   patches:
     ADDFF505:
       content: |-
@@ -18732,8 +18723,8 @@ SLES-54030:
     roundSprite: 1 # Fixes lighting misalignment such as the street poles and the sun.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
+    getSkipCount: "GSC_BlackAndBurnoutSky"
     beforeDraw: "OI_BurnoutGames"
-    afterDraw: "OO_BurnoutGames"
   patches:
     CAA04879:
       content: |-
@@ -20202,7 +20193,6 @@ SLES-54627:
     cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
-    afterDraw: "OO_BurnoutGames"
 SLES-54628:
   name: "Skate Attack [Promo]"
   region: "PAL-E"
@@ -20377,7 +20367,6 @@ SLES-54681:
     cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
-    afterDraw: "OO_BurnoutGames"
 SLES-54683:
   name: "Medal of Honor - Vanguard"
   region: "PAL-M9"
@@ -23620,7 +23609,6 @@ SLKA-25206:
     cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
-    afterDraw: "OO_BurnoutGames"
 SLKA-25207:
   name: "Sakura Taisen V - Episode 0 - Samurai Girl of Wild"
   region: "NTSC-K"
@@ -23914,7 +23902,6 @@ SLKA-25304:
     cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
-    afterDraw: "OO_BurnoutGames"
 SLKA-25307:
   name: "Dragon Ball Z Sparking"
   region: "NTSC-K"
@@ -24229,7 +24216,6 @@ SLPM-55004:
     cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
-    afterDraw: "OO_BurnoutGames"
 SLPM-55005:
   name: "Mana Khemia 2 - Ochita Gakuen to Renkinjutsushi Tachi"
   region: "NTSC-J"
@@ -24271,7 +24257,6 @@ SLPM-55036:
     cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
-    afterDraw: "OO_BurnoutGames"
 SLPM-55039:
   name: "Soukoku no Kusabi - Hiiro no Kakera 3 [Limited Edition]"
   region: "NTSC-J"
@@ -24850,7 +24835,6 @@ SLPM-60246:
     cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
-    afterDraw: "OO_BurnoutGames"
 SLPM-60251:
   name: "Devil May Cry 3 [Trial Version]"
   region: "NTSC-J"
@@ -29701,7 +29685,6 @@ SLPM-65719:
     cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
-    afterDraw: "OO_BurnoutGames"
 SLPM-65720:
   name: "Shin Sangoku Musou 2 Mushoden [Koei the Best]"
   region: "NTSC-J"
@@ -30532,7 +30515,6 @@ SLPM-65958:
     cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
-    afterDraw: "OO_BurnoutGames"
 SLPM-65959:
   name: "Standard Daisenryaku - Ushinawareta Shouri"
   region: "NTSC-J"
@@ -31086,7 +31068,6 @@ SLPM-66108:
     cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
-    afterDraw: "OO_BurnoutGames"
   memcardFilters:
     - "SLAJ-25066"
     - "SLPM-66108"
@@ -32028,8 +32009,8 @@ SLPM-66354:
     roundSprite: 1 # Fixes lighting misalignment such as the street poles and the sun.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
+    getSkipCount: "GSC_BlackAndBurnoutSky"
     beforeDraw: "OI_BurnoutGames"
-    afterDraw: "OO_BurnoutGames"
   patches:
     B3A9F9ED:
       content: |-
@@ -33148,7 +33129,6 @@ SLPM-66652:
     cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
-    afterDraw: "OO_BurnoutGames"
   memcardFilters:
     - "SLAJ-25066"
     - "SLPM-66108"
@@ -33482,8 +33462,8 @@ SLPM-66731:
     roundSprite: 1 # Fixes lighting misalignment such as the street poles and the sun.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
+    getSkipCount: "GSC_BlackAndBurnoutSky"
     beforeDraw: "OI_BurnoutGames"
-    afterDraw: "OO_BurnoutGames"
 SLPM-66732:
   name: "Iinazuke [Limited Edition]"
   region: "NTSC-J"
@@ -33533,7 +33513,6 @@ SLPM-66739:
     cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
-    afterDraw: "OO_BurnoutGames"
 SLPM-66740:
   name: "Sentou Kokka Kai - Legend [DX Pack]"
   region: "NTSC-J"
@@ -34254,8 +34233,8 @@ SLPM-66961:
     roundSprite: 1 # Fixes lighting misalignment such as the street poles and the sun.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
+    getSkipCount: "GSC_BlackAndBurnoutSky"
     beforeDraw: "OI_BurnoutGames"
-    afterDraw: "OO_BurnoutGames"
 SLPM-66962:
   name: "Burnout 3 - Takedown [EA-SY! 1980]"
   region: "NTSC-J"
@@ -34270,7 +34249,6 @@ SLPM-66962:
     cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
-    afterDraw: "OO_BurnoutGames"
 SLPM-66963:
   name: "Medal of Honor - Frontline [EA-SY! 1980]"
   region: "NTSC-J"
@@ -45229,7 +45207,6 @@ SLUS-21050:
     cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
-    afterDraw: "OO_BurnoutGames"
 SLUS-21051:
   name: "FIFA 2005"
   region: "NTSC-U"
@@ -46204,7 +46181,6 @@ SLUS-21242:
     cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
-    afterDraw: "OO_BurnoutGames"
   memcardFilters: # Reads Burnout 3 and NFL 06 saves for unlockables.
     - "SLUS-21242"
     - "SLUS-21050"
@@ -47003,8 +46979,8 @@ SLUS-21376:
     roundSprite: 1 # Fixes lighting misalignment such as the street poles and the sun.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
+    getSkipCount: "GSC_BlackAndBurnoutSky"
     beforeDraw: "OI_BurnoutGames"
-    afterDraw: "OO_BurnoutGames"
   patches:
     5C891FF1:
       content: |-
@@ -47998,7 +47974,6 @@ SLUS-21596:
     cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
-    afterDraw: "OO_BurnoutGames"
 SLUS-21597:
   name: "Medal of Honor - Vanguard"
   region: "NTSC-U"
@@ -50166,7 +50141,6 @@ SLUS-29113:
     cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
-    afterDraw: "OO_BurnoutGames"
 SLUS-29116:
   name: "WWE SmackDown! vs. RAW [Public Beta Vol.1.0]"
   region: "NTSC-U"
@@ -50282,7 +50256,6 @@ SLUS-29153:
     cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
-    afterDraw: "OO_BurnoutGames"
 SLUS-29154:
   name: "NHL '06 [Demo]"
   region: "NTSC-U"
@@ -50384,8 +50357,8 @@ SLUS-29180:
     roundSprite: 1 # Fixes lighting misalignment such as the street poles and the sun.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
+    getSkipCount: "GSC_BlackAndBurnoutSky"
     beforeDraw: "OI_BurnoutGames"
-    afterDraw: "OO_BurnoutGames"
 SLUS-29183:
   name: "Fight Night - Round 3 [Demo]"
   region: "NTSC-U"

--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -18004,12 +18004,20 @@ SLES-53729:
   name: "Battlefield 2 - Modern Combat"
   region: "PAL-M4"
   gsHWFixes:
-    autoFlush: 1
+    autoFlush: 1 # Post-processing.
+    halfPixelOffset: 2 # Offset post-processing.
+    texturePreloading: 1 # Spikes all over the place otherwise.
+    getSkipCount: "GSC_Battlefield2" # Depth clear.
+    beforeDraw: "OI_Battlefield2" # Framebuffer copy, fixes rendering for bottom part of screen.
 SLES-53730:
   name: "Battlefield 2 - Modern Combat"
   region: "PAL-M3"
   gsHWFixes:
-    autoFlush: 1
+    autoFlush: 1 # Post-processing.
+    halfPixelOffset: 2 # Offset post-processing.
+    texturePreloading: 1 # Spikes all over the place otherwise.
+    getSkipCount: "GSC_Battlefield2" # Depth clear.
+    beforeDraw: "OI_Battlefield2" # Framebuffer copy, fixes rendering for bottom part of screen.
 SLES-53734:
   name: "50 Cent - Bulletproof"
   region: "PAL-E"
@@ -31447,7 +31455,11 @@ SLPM-66206:
   name: "Battlefield 2 - Modern Combat"
   region: "NTSC-J"
   gsHWFixes:
-    autoFlush: 1
+    autoFlush: 1 # Post-processing.
+    halfPixelOffset: 2 # Offset post-processing.
+    texturePreloading: 1 # Spikes all over the place otherwise.
+    getSkipCount: "GSC_Battlefield2" # Depth clear.
+    beforeDraw: "OI_Battlefield2" # Framebuffer copy, fixes rendering for bottom part of screen.
 SLPM-66207:
   name: "Dororo [Sega the Best 2800]"
   region: "NTSC-J"
@@ -33126,7 +33138,11 @@ SLPM-66651:
   name: "Battlefield 2 - Modern Combat [EA Best Hits]"
   region: "NTSC-J"
   gsHWFixes:
-    autoFlush: 1
+    autoFlush: 1 # Post-processing.
+    halfPixelOffset: 2 # Offset post-processing.
+    texturePreloading: 1 # Spikes all over the place otherwise.
+    getSkipCount: "GSC_Battlefield2" # Depth clear.
+    beforeDraw: "OI_Battlefield2" # Framebuffer copy, fixes rendering for bottom part of screen.
 SLPM-66652:
   name: "Burnout Revenge [EA Best Hits]"
   region: "NTSC-J"
@@ -45062,7 +45078,11 @@ SLUS-21026:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    autoFlush: 1
+    autoFlush: 1 # Post-processing.
+    halfPixelOffset: 2 # Offset post-processing.
+    texturePreloading: 1 # Spikes all over the place otherwise.
+    getSkipCount: "GSC_Battlefield2" # Depth clear.
+    beforeDraw: "OI_Battlefield2" # Framebuffer copy, fixes rendering for bottom part of screen.
 SLUS-21027:
   name: "Lord of the Rings, The - The Third Age"
   region: "NTSC-U"
@@ -50163,7 +50183,11 @@ SLUS-29117:
   name: "Battlefield 2 - Modern Combat [Public Beta Vol.1.0]"
   region: "NTSC-U"
   gsHWFixes:
-    autoFlush: 1
+    autoFlush: 1 # Post-processing.
+    halfPixelOffset: 2 # Offset post-processing.
+    texturePreloading: 1 # Spikes all over the place otherwise.
+    getSkipCount: "GSC_Battlefield2" # Depth clear.
+    beforeDraw: "OI_Battlefield2" # Framebuffer copy, fixes rendering for bottom part of screen.
 SLUS-29118:
   name: "Need for Speed - Underground 2 [Demo]"
   region: "NTSC-U"
@@ -50256,7 +50280,11 @@ SLUS-29152:
   name: "Battlefield 2 - Modern Combat [Regular Demo]"
   region: "NTSC-U"
   gsHWFixes:
-    autoFlush: 1
+    autoFlush: 1 # Post-processing.
+    halfPixelOffset: 2 # Offset post-processing.
+    texturePreloading: 1 # Spikes all over the place otherwise.
+    getSkipCount: "GSC_Battlefield2" # Depth clear.
+    beforeDraw: "OI_Battlefield2" # Framebuffer copy, fixes rendering for bottom part of screen.
 SLUS-29153:
   name: "Burnout Revenge [Demo]"
   region: "NTSC-U"
@@ -50342,7 +50370,11 @@ SLUS-29172:
   name: "Battlefield 2 - Modern Combat [Demo]"
   region: "NTSC-U"
   gsHWFixes:
-    autoFlush: 1
+    autoFlush: 1 # Post-processing.
+    halfPixelOffset: 2 # Offset post-processing.
+    texturePreloading: 1 # Spikes all over the place otherwise.
+    getSkipCount: "GSC_Battlefield2" # Depth clear.
+    beforeDraw: "OI_Battlefield2" # Framebuffer copy, fixes rendering for bottom part of screen.
 SLUS-29173:
   name: "Sims 2, The [Demo]"
   region: "NTSC-U"

--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -575,6 +575,7 @@ set(pcsx2GSHeaders
 	GS/Renderers/Null/GSDeviceNull.h
 	GS/Renderers/Null/GSRendererNull.h
 	GS/Renderers/Null/GSTextureNull.h
+	GS/Renderers/HW/GSHwHack.h
 	GS/Renderers/HW/GSRendererHW.h
 	GS/Renderers/HW/GSTextureCache.h
 	GS/Renderers/HW/GSTextureReplacements.h

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -717,7 +717,6 @@ struct Pcsx2Config
 		int TVShader{0};
 		s16 GetSkipCountFunctionId{-1};
 		s16 BeforeDrawFunctionId{-1};
-		s16 AfterDrawFunctionId{-1};
 		int SkipDrawStart{0};
 		int SkipDrawEnd{0};
 

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -648,7 +648,6 @@ struct Pcsx2Config
 					PreloadFrameWithGSData : 1,
 					WrapGSMem : 1,
 					Mipmap : 1,
-					PointListPalette : 1,
 					ManualUserHacks : 1,
 					UserHacks_AlignSpriteX : 1,
 					UserHacks_AutoFlush : 1,
@@ -716,6 +715,9 @@ struct Pcsx2Config
 		int SWExtraThreads{2};
 		int SWExtraThreadsHeight{4};
 		int TVShader{0};
+		s16 GetSkipCountFunctionId{-1};
+		s16 BeforeDrawFunctionId{-1};
+		s16 AfterDrawFunctionId{-1};
 		int SkipDrawStart{0};
 		int SkipDrawEnd{0};
 

--- a/pcsx2/Docs/gamedb-schema.json
+++ b/pcsx2/Docs/gamedb-schema.json
@@ -231,9 +231,6 @@
             },
             "beforeDraw": {
               "type": "string"
-            },
-            "afterDraw": {
-              "type": "string"
             }
           },
           "additionalProperties": false

--- a/pcsx2/Docs/gamedb-schema.json
+++ b/pcsx2/Docs/gamedb-schema.json
@@ -166,11 +166,6 @@
               "minimum": 0,
               "maximum": 1
             },
-            "pointListPalette": {
-              "type": "integer",
-              "minimum": 0,
-              "maximum": 1
-            },
             "mipmap": {
               "type": "integer",
               "minimum": 0,
@@ -230,6 +225,15 @@
               "type": "integer",
               "minimum": 0,
               "maximum": 2
+            },
+            "getSkipCount": {
+              "type": "string"
+            },
+            "beforeDraw": {
+              "type": "string"
+            },
+            "afterDraw": {
+              "type": "string"
             }
           },
           "additionalProperties": false

--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -331,7 +331,7 @@ bool GSreopen(bool recreate_display, const Pcsx2Config::GSOptions& old_config)
 		return false;
 	}
 
-	g_gs_renderer->SetGameCRC(gamecrc, GSUtil::GetEffectiveCRCHackLevel(GSConfig.Renderer, GSConfig.CRCHack));
+	g_gs_renderer->SetGameCRC(gamecrc);
 	return true;
 }
 
@@ -560,7 +560,7 @@ void GSThrottlePresentation()
 
 void GSsetGameCRC(u32 crc)
 {
-	g_gs_renderer->SetGameCRC(crc, GSUtil::GetEffectiveCRCHackLevel(GSConfig.Renderer, GSConfig.CRCHack));
+	g_gs_renderer->SetGameCRC(crc);
 }
 
 GSVideoMode GSgetDisplayMode()
@@ -692,7 +692,6 @@ void GSUpdateConfig(const Pcsx2Config::GSOptions& new_config)
 	// Options which aren't using the global struct yet, so we need to recreate all GS objects.
 	if (
 		GSConfig.UpscaleMultiplier != old_config.UpscaleMultiplier ||
-		GSConfig.CRCHack != old_config.CRCHack ||
 		GSConfig.SWExtraThreads != old_config.SWExtraThreads ||
 		GSConfig.SWExtraThreadsHeight != old_config.SWExtraThreadsHeight)
 	{
@@ -706,9 +705,12 @@ void GSUpdateConfig(const Pcsx2Config::GSOptions& new_config)
 	// For example, flushing the texture cache when mipmap settings change.
 
 	if (GSConfig.CRCHack != old_config.CRCHack ||
-		GSConfig.PointListPalette != old_config.PointListPalette)
+		GSConfig.UpscaleMultiplier != old_config.UpscaleMultiplier ||
+		GSConfig.GetSkipCountFunctionId != old_config.GetSkipCountFunctionId ||
+		GSConfig.BeforeDrawFunctionId != old_config.BeforeDrawFunctionId ||
+		GSConfig.AfterDrawFunctionId != old_config.BeforeDrawFunctionId)
 	{
-		g_gs_renderer->SetGameCRC(g_gs_renderer->GetGameCRC(), GSUtil::GetEffectiveCRCHackLevel(GSConfig.Renderer, GSConfig.CRCHack));
+		g_gs_renderer->UpdateCRCHacks();
 	}
 
 	// renderer-specific options (e.g. auto flush, TC offset)

--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -707,8 +707,7 @@ void GSUpdateConfig(const Pcsx2Config::GSOptions& new_config)
 	if (GSConfig.CRCHack != old_config.CRCHack ||
 		GSConfig.UpscaleMultiplier != old_config.UpscaleMultiplier ||
 		GSConfig.GetSkipCountFunctionId != old_config.GetSkipCountFunctionId ||
-		GSConfig.BeforeDrawFunctionId != old_config.BeforeDrawFunctionId ||
-		GSConfig.AfterDrawFunctionId != old_config.BeforeDrawFunctionId)
+		GSConfig.BeforeDrawFunctionId != old_config.BeforeDrawFunctionId)
 	{
 		g_gs_renderer->UpdateCRCHacks();
 	}

--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -275,7 +275,6 @@ bool GSreopen(bool recreate_display, const Pcsx2Config::GSOptions& old_config)
 
 	u8* basemem = g_gs_renderer->GetRegsMem();
 	const u32 gamecrc = g_gs_renderer->GetGameCRC();
-	const int gamecrc_options = g_gs_renderer->GetGameCRCOptions();
 	g_gs_renderer->Destroy();
 	g_gs_renderer.reset();
 	g_gs_device->Destroy();
@@ -332,7 +331,7 @@ bool GSreopen(bool recreate_display, const Pcsx2Config::GSOptions& old_config)
 		return false;
 	}
 
-	g_gs_renderer->SetGameCRC(gamecrc, gamecrc_options);
+	g_gs_renderer->SetGameCRC(gamecrc, GSUtil::GetEffectiveCRCHackLevel(GSConfig.Renderer, GSConfig.CRCHack));
 	return true;
 }
 
@@ -559,9 +558,9 @@ void GSThrottlePresentation()
 	Threading::SleepUntil(s_next_manual_present_time);
 }
 
-void GSsetGameCRC(u32 crc, int options)
+void GSsetGameCRC(u32 crc)
 {
-	g_gs_renderer->SetGameCRC(crc, options);
+	g_gs_renderer->SetGameCRC(crc, GSUtil::GetEffectiveCRCHackLevel(GSConfig.Renderer, GSConfig.CRCHack));
 }
 
 GSVideoMode GSgetDisplayMode()
@@ -709,8 +708,7 @@ void GSUpdateConfig(const Pcsx2Config::GSOptions& new_config)
 	if (GSConfig.CRCHack != old_config.CRCHack ||
 		GSConfig.PointListPalette != old_config.PointListPalette)
 	{
-		// for automatic mipmaps, we need to reload the crc
-		g_gs_renderer->SetGameCRC(g_gs_renderer->GetGameCRC(), g_gs_renderer->GetGameCRCOptions());
+		g_gs_renderer->SetGameCRC(g_gs_renderer->GetGameCRC(), GSUtil::GetEffectiveCRCHackLevel(GSConfig.Renderer, GSConfig.CRCHack));
 	}
 
 	// renderer-specific options (e.g. auto flush, TC offset)

--- a/pcsx2/GS/GS.h
+++ b/pcsx2/GS/GS.h
@@ -22,6 +22,8 @@
 #include "gsl/span"
 
 #include <map>
+#include <string>
+#include <string_view>
 
 // ST_WRITE is defined in libc, avoid this
 enum stateType
@@ -45,6 +47,11 @@ enum class GSVideoMode : u8
 extern Pcsx2Config::GSOptions GSConfig;
 
 class HostDisplay;
+
+// Returns the ID for the specified function, otherwise -1.
+s16 GSLookupGetSkipCountFunctionId(const std::string_view& name);
+s16 GSLookupBeforeDrawFunctionId(const std::string_view& name);
+s16 GSLookupAfterDrawFunctionId(const std::string_view& name);
 
 int GSinit();
 void GSshutdown();

--- a/pcsx2/GS/GS.h
+++ b/pcsx2/GS/GS.h
@@ -51,7 +51,6 @@ class HostDisplay;
 // Returns the ID for the specified function, otherwise -1.
 s16 GSLookupGetSkipCountFunctionId(const std::string_view& name);
 s16 GSLookupBeforeDrawFunctionId(const std::string_view& name);
-s16 GSLookupAfterDrawFunctionId(const std::string_view& name);
 
 int GSinit();
 void GSshutdown();

--- a/pcsx2/GS/GS.h
+++ b/pcsx2/GS/GS.h
@@ -69,7 +69,7 @@ bool GSBeginCapture(std::string filename);
 void GSEndCapture();
 void GSPresentCurrentFrame();
 void GSThrottlePresentation();
-void GSsetGameCRC(u32 crc, int options);
+void GSsetGameCRC(u32 crc);
 
 GSVideoMode GSgetDisplayMode();
 void GSgetInternalResolution(int* width, int* height);

--- a/pcsx2/GS/GSCrc.cpp
+++ b/pcsx2/GS/GSCrc.cpp
@@ -23,349 +23,100 @@
 const CRC::Game CRC::m_games[] =
 {
 	// Note: IDs 0x7ACF7E03, 0x7D4EA48F, 0x37C53760 - shouldn't be added as it's from the multiloaders when packing games.
-	{0x00000000, NoTitle, NoRegion, 0},
-	{0xF95F37EE, ArTonelico2, US, 0},
-	{0x68CE6801, ArTonelico2, JP, 0},
-	{0xCE2C1DBF, ArTonelico2, EU, 0},
-	{0x5C891FF1, Black, US, 0},
-	{0xCAA04879, Black, EU, 0},
-	{0xADDFF505, Black, EU, 0},
-	{0xB3A9F9ED, Black, JP, 0},
-	{0x2113EA2E, MetalSlug6, JP, 0},
-	{0xA6167B59, Lamune, JP, 0},
-	{0xA39517AB, FFX, EU, 0},
-	{0x78D83FD5, FFX, EU, 0}, // Demo
-	{0xA39517AE, FFX, FR, 0},
-	{0x941BB7D9, FFX, DE, 0},
-	{0xA39517A9, FFX, IT, 0},
-	{0x941BB7DE, FFX, ES, 0},
-	{0xA80F497C, FFX, ES, 0},
-	{0xB4414EA1, FFX, RU, 0},
-	{0xEE97DB5B, FFX, RU, 0},
-	{0xAEC495CC, FFX, RU, 0},
-	{0xBB3D833A, FFX, US, 0},
-	{0x6A4EFE60, FFX, JP, 0},
-	{0x3866CA7E, FFX, ASIA, 0}, // int.
-	{0x658597E2, FFX, JP, 0}, // int.
-	{0x9AAC5309, FFX2, EU, 0},
-	{0x9AAC530C, FFX2, FR, 0},
-	{0x9AAC530A, FFX2, ES, 0},
-	{0x9AAC530D, FFX2, DE, 0},
-	{0x9AAC530B, FFX2, IT, 0},
-	{0x48FE0C71, FFX2, US, 0},
-	{0x8A6D7F14, FFX2, JP, 0},
-	{0xE1FD9A2D, FFX2, JP, 0}, // int.
-	{0x11624CD6, FFX2, KO, 0},
-	{0x78DA0252, FFXII, EU, 0},
-	{0xC1274668, FFXII, EU, 0},
-	{0xDC2A467E, FFXII, EU, 0},
-	{0xCA284668, FFXII, EU, 0},
-	{0xC52B466E, FFXII, EU, 0}, // ES
-	{0xE5E71BF9, FFXII, FR, 0},
-	{0x0779FBDB, FFXII, US, 0},
-	{0x280AD120, FFXII, JP, 0},
-	{0x08C1ED4D, HauntingGround, EU, 0},
-	{0x2CD5794C, HauntingGround, EU, 0},
-	{0x867BB945, HauntingGround, JP, 0},
-	{0xE263BC4B, HauntingGround, JP, 0},
-	{0x901AAC09, HauntingGround, US, 0},
-	{0x21068223, Okami, US, 0},
-	{0x891F223F, Okami, EU, 0}, // PAL DE, ES & FR.
-	{0xC5DEFEA0, Okami, JP, 0},
-	{0xCCC8F3A4, Okami, KO, 0},
-	{0x278722BF, DBZBT2, EU, 0},
-	{0xFE961D28, DBZBT2, US, 0},
-	{0x0393B6BE, DBZBT2, EU, 0},
-	{0xE2F289ED, DBZBT2, JP, 0}, // Sparking Neo!
-	{0xE29C09A3, DBZBT2, KO, 0}, // DragonBall Z Sparking Neo
-	{0x0BAA4387, DBZBT2, JP, 0},
-	{0x35AA84D1, DBZBT2, NoRegion, 0},
-	{0xBE6A9CFB, DBZBT2, NoRegion, 0},
-	{0x428113C2, DBZBT3, US, 0},
-	{0xA422BB13, DBZBT3, EU, 0},
-	{0xCE93CB30, DBZBT3, JP, 0},
-	{0xF28D21F1, DBZBT3, JP, 0},
-	{0x983C53D2, DBZBT3, NoRegion, 0},
-	{0x983C53D3, DBZBT3, EU, 0},
-	{0x9B0E119F, DBZBT3, KO, 0}, // DragonBall Z Sparking Meteo
-	{0x5E13E6D6, SFEX3, EU, 0},
-	{0x72B3802A, SFEX3, US, 0},
-	{0x71521863, SFEX3, US, 0},
-	{0x63642E9F, SFEX3, JP, 0},
-	{0xCA1F6E53, SFEX3, JP, 0}, // Taikenban Disc (Demo/Trial)
-	{0x6F8545DB, ICO, US, 0},
-	{0x48CDF317, ICO, US, 0}, // Demo
-	{0xB01A4C95, ICO, JP, 0},
-	{0x2DF2C1EA, ICO, KO, 0},
-	{0x5C991F4E, ICO, EU, 0},
-	{0x788D8B4F, ICO, EU, 0},
-	{0x29C28734, ICO, CH, 0},
-	{0x60013EBD, PolyphonyDigitalGames, EU, 0}, // Gran Turismo Concept
-	{0x6810C3BC, PolyphonyDigitalGames, CH, 0}, // Gran Turismo Concept 2002 Tokyo-Geneva
-	{0x0EEF32A3, PolyphonyDigitalGames, KO, 0}, // Gran Turismo Concept 2002 Tokyo-Seoul
-	{0x3E9D448A, PolyphonyDigitalGames, CH, 0}, // GT3
-	{0xAD66643C, PolyphonyDigitalGames, CH, 0}, // GT3
-	{0x85AE91B3, PolyphonyDigitalGames, US, 0}, // GT3
-	{0x8AA991B0, PolyphonyDigitalGames, US, 0}, // GT3
-	{0xC220951A, PolyphonyDigitalGames, JP, 0}, // GT3
-	{0x9DE5CF65, PolyphonyDigitalGames, JP, 0}, // GT3
-	{0x706DFF80, PolyphonyDigitalGames, JP, 0}, // GT3 Store Disc Vol. 2
-	{0x55CE5111, PolyphonyDigitalGames, JP, 0}, // Gran Turismo 2000 Body Omen
-	{0xE9A7E08D, PolyphonyDigitalGames, JP, 0}, // Gran Turismo 2000 Body Omen
-	{0xB590CE04, PolyphonyDigitalGames, EU, 0}, // GT3
-	{0xC02C653E, PolyphonyDigitalGames, CH, 0}, // GT4
-	{0x7ABDBB5E, PolyphonyDigitalGames, CH, 0}, // GT4
-	{0xAEAD1CA3, PolyphonyDigitalGames, JP, 0}, // GT4
-	{0xA3AF15A0, PolyphonyDigitalGames, JP, 0}, // GT4 PS2 Racing Pack
-	{0xE906EA37, PolyphonyDigitalGames, JP, 0}, // GT4 First Preview
-	{0xCA6243B9, PolyphonyDigitalGames, JP, 0}, // GT4 Prologue
-	{0xDD764BBE, PolyphonyDigitalGames, JP, 0}, // GT4 Prologue
-	{0xE1258846, PolyphonyDigitalGames, JP, 0}, // GT4 Prologue
-	{0x27B8F05F, PolyphonyDigitalGames, JP, 0}, // GT4 Prius Trial Version
-	{0x30E41D93, PolyphonyDigitalGames, KO, 0}, // GT4
-	{0x715CF2EC, PolyphonyDigitalGames, EU, 0}, // GT4
-	{0x44A61C8F, PolyphonyDigitalGames, EU, 0}, // GT4
-	{0x0086E35B, PolyphonyDigitalGames, EU, 0}, // GT4
-	{0x3FB69323, PolyphonyDigitalGames, EU, 0}, // GT4 Prologue
-	{0x77E61C8A, PolyphonyDigitalGames, US, 0}, // GT4
-	{0x33C6E35E, PolyphonyDigitalGames, US, 0}, // GT4
-	{0x70538747, PolyphonyDigitalGames, US, 0}, // GT4 Toyota Prius Trial
-	{0x32A1C752, PolyphonyDigitalGames, US, 0}, // GT4 Online Beta
-	{0x2A84A1E2, PolyphonyDigitalGames, US, 0}, // GT4 Mazda MX-5 Edition
-	{0x0087EEC4, PolyphonyDigitalGames, NoRegion, 0}, // GT4 Online Beta, JP and US versions have the same CRC
-	{0x5AC7E79C, PolyphonyDigitalGames, CH, 0}, // TouristTrophy
-	{0xFF9C0E93, PolyphonyDigitalGames, US, 0}, // TouristTrophy
-	{0xCA9AA903, PolyphonyDigitalGames, EU, 0}, // TouristTrophy
-	{0x8B029334, Manhunt2, EU, 0},
-	{0x3B0ADBEF, Manhunt2, US, 0},
-	{0x09F49E37, CrashBandicootWoC, NoRegion, 0},
-	{0x103B5706, CrashBandicootWoC, US, 0}, // American Greatest Hits release
-	{0x75182BE5, CrashBandicootWoC, US, 0},
-	{0x5188ABCA, CrashBandicootWoC, US, 0},
-	{0xEB1EB7FE, CrashBandicootWoC, US, 0}, // Regular Demo
-	{0x34E2EEC7, CrashBandicootWoC, RU, 0},
-	{0x00A074A7, CrashBandicootWoC, KO, 0},
-	{0xF8643F9B, CrashBandicootWoC, JP, 0},
-	{0x3A03D62F, CrashBandicootWoC, EU, 0},
-	{0x35D70452, CrashBandicootWoC, EU, 0},
-	{0x1E935600, CrashBandicootWoC, EU, 0},
-	{0x72E1E60E, Spartan, EU, 0},
-	{0x26689C87, Spartan, JP, 0},
-	{0x08277A9E, Spartan, US, 0},
-	{0xAC3C1147, SVCChaos, EU, 0}, // SVC Chaos: SNK vs. Capcom
-	{0xB00FF2ED, SVCChaos, JP, 0},
-	{0x94834BD3, SVCChaos, JP, 0},
-	{0xCF1D71EE, KOF2002, EU, 0}, // The King of Fighters 2002
-	{0xABD16263, KOF2002, JP, 0},
-	{0x424A8601, KOF2002, JP, 0},
-	{0x7F74D8D0, KOF2002, US, 0},
-	{0xA32F7CD0, AceCombat4, US, 0}, // Also needed for automatic mipmapping
-	{0x5ED8FB53, AceCombat4, JP, 0},
-	{0x1B9B7563, AceCombat4, EU, 0},
-	{0xFC46EA61, Tekken5, JP, 0},
-	{0x1F88EE37, Tekken5, EU, 0},
-	{0x1F88BECD, Tekken5, EU, 0}, // language selector...
-	{0x652050D2, Tekken5, US, 0},
-	{0xEA64EF39, Tekken5, KO, 0},
-	{0x95CC86EF, GiTS, US, 0}, // same CRC also reported as EU
-	{0x2C5BF134, GiTS, US, 0}, // Demo
-	{0xA5768F53, GiTS, JP, 0},
-	{0xA3643EB1, GiTS, KO, 0},
-	{0x28557423, GiTS, RU, 0},
-	{0xBF6F101F, GiTS, EU, 0}, // same CRC as another US disc
-	{0xA616A6C2, TalesOfAbyss, US, 0},
-	{0x14FE77F7, TalesOfAbyss, US, 0},
-	{0xAA5EC3A3, TalesOfAbyss, JP, 0},
-	{0xFB236A46, SonicUnleashed, US, 0},
-	{0x8C913264, SonicUnleashed, EU, 0},
-	{0xE8FCF8EC, SMTNocturne, US, 0},
-	{0xF0A31EE3, SMTNocturne, EU, 0}, // SMTNocturne (Lucifers Call in EU)
-	{0xAE0DE7B7, SMTNocturne, EU, 0}, // SMTNocturne (Lucifers Call in EU)
-	{0xD60DA6D4, SMTNocturne, JP, 0}, // SMTNocturne
-	{0x0E762E8D, SMTNocturne, JP, 0}, // SMTNocturne Maniacs
-	{0x47BA9034, SMTNocturne, JP, 0}, // SMTNocturne Maniacs Chronicle
-	{0xD3FFC263, SMTNocturne, KO, 0},
-	{0x84D1A8DA, SMTNocturne, KO, 0},
-	{0x0B8AB37B, RozenMaidenGebetGarden, JP, 0},
-	{0x506644B3, BigMuthaTruckers, EU, 0},
-	{0x90F0D852, BigMuthaTruckers, US, 0},
-	{0x92624842, BigMuthaTruckers, US, 0},
-	{0xDD93DA88, BigMuthaTruckers, JP, 0}, // Bakusou Convoy Densetsu - Otoko Hanamichi America Roman
-	{0xE169BAF8, RedDeadRevolver, US, 0},
-	{0xE2E67E23, RedDeadRevolver, EU, 0},
-	{0xC5B75C7C, Oneechanbara2Special, JP, 0},
-	{0xC725CC6C, Oneechanbara2Special, JP, 0},
-	{0x07608CA2, Oneechanbara2Special, EU, 0}, // Zombie Hunters 2
-	{0xE0347841, XenosagaE3, JP, 0},
-	{0xA707236E, XenosagaE3, JP, 0}, // Demo
-	{0xA4E88698, XenosagaE3, CH, 0},
-	{0x2088950A, XenosagaE3, US, 0},
-	{0x694A998E, TombRaiderUnderworld, JP, 0},
-	{0x8E214549, TombRaiderUnderworld, EU, 0},
-	{0x618769D6, TombRaiderUnderworld, US, 0},
-	{0xB639EB17, TombRaiderAnniversary, US, 0}, // Also needed for automatic mipmapping
-	{0xB05805B6, TombRaiderAnniversary, JP, 0},
-	{0xA629A376, TombRaiderAnniversary, EU, 0},
-	{0xBC8B3F50, TombRaiderLegend, US, 0},
-	{0x365172A0, TombRaiderLegend, JP, 0},
-	{0x05177ECE, TombRaiderLegend, EU, 0},
-	{0xBEBF8793, BurnoutGames, US, 0}, // BurnoutTakedown
-	{0xBB2E845F, BurnoutGames, JP, 0}, // BurnoutTakedown
-	{0x5F060991, BurnoutGames, KO, 0}, // BurnoutTakedown
-	{0x75BECC18, BurnoutGames, EU, 0}, // BurnoutTakedown
-	{0xCE49B0DE, BurnoutGames, EU, 0}, // BurnoutTakedown
-	{0x381EE9EF, BurnoutGames, EU, 0}, // BurnoutTakedown E3 Demo
-	{0xD224D348, BurnoutGames, US, 0}, // BurnoutRevenge
-	{0x878E7A1D, BurnoutGames, JP, 0}, // BurnoutRevenge
-	{0xEEA60511, BurnoutGames, KO, 0}, // BurnoutRevenge
-	{0x7E83CC5B, BurnoutGames, EU, 0}, // BurnoutRevenge
-	{0x2CAC3DBC, BurnoutGames, EU, 0}, // BurnoutRevenge
-	{0x8C9576A1, BurnoutGames, US, 0}, // BurnoutDominator
-	{0xDDF76A98, BurnoutGames, JP, 0}, // BurnoutDominator
-	{0x8C9576B4, BurnoutGames, EU, 0}, // BurnoutDominator
-	{0x8C9C76B4, BurnoutGames, EU, 0}, // BurnoutDominator
-	{0x4A0E5B3A, MidnightClub3, US, 0}, // dub
-	{0xEBE1972D, MidnightClub3, EU, 0}, // dub
-	{0x60A42FF5, MidnightClub3, US, 0}, // remix
-	{0x43AB7214, TalesOfLegendia, US, 0},
-	{0x1F8640E0, TalesOfLegendia, JP, 0},
-	{0xE4F5DA2B, TalesOfLegendia, KO, 0},
-	{0x519E816B, Kunoichi, US, 0}, // Nightshade
-	{0x3FB419FD, Kunoichi, JP, 0},
-	{0x086D198E, Kunoichi, CH, 0},
-	{0x3B470BBD, Kunoichi, EU, 0},
-	{0x6BA65DD8, Kunoichi, KO, 0},
-	{0XD3F182A3, YakuzaGames, EU, 0}, // Yakuza
-	{0x6F9F99F8, YakuzaGames, EU, 0}, // Yakuza
-	{0x388F687B, YakuzaGames, US, 0}, // Yakuza
-	{0xC1B91FC5, YakuzaGames, US, 0}, // Yakuza Demo
-	{0xB7B3800A, YakuzaGames, JP, 0}, // Yakuza2
-	{0xA60C2E65, YakuzaGames, EU, 0}, // Yakuza2
-	{0x800E3E5A, YakuzaGames, EU, 0}, // Yakuza2
-	{0x97E9C87E, YakuzaGames, US, 0}, // Yakuza2
-	{0xB1EBD841, YakuzaGames, US, 0}, // Yakuza2
-	{0xC6B95C48, YakuzaGames, JP, 0}, // Yakuza2
-	{0x2905C5C6, ZettaiZetsumeiToshi2, US, 0}, // Raw Danger!
-	{0xC988ECBB, ZettaiZetsumeiToshi2, JP, 0},
-	{0x90F4B057, ZettaiZetsumeiToshi2, CH, 0},
-	{0xA98B5B22, ZettaiZetsumeiToshi2, EU, 0},
-	{0xBD17248E, ShinOnimusha, JP, 0},
-	{0xBE17248E, ShinOnimusha, JP, 0},
-	{0xB817248E, ShinOnimusha, JP, 0},
-	{0xC1C77637, ShinOnimusha, JP, 0}, // PlayStation 2 The Best, Disc 1
-	{0x5C1E5BEF, ShinOnimusha, JP, 0}, // PlayStation 2 The Best, Disc 2
-	{0x812C5A96, ShinOnimusha, EU, 0},
-	{0xFE44479E, ShinOnimusha, US, 0},
-	{0xFFDE85E9, ShinOnimusha, US, 0},
-	{0xE21404E2, GetawayGames, US, 0}, // Getaway
-	{0xE8249852, GetawayGames, JP, 0}, // Getaway
-	{0x458485EF, GetawayGames, EU, 0}, // Getaway
-	{0x5DFBE144, GetawayGames, EU, 0}, // Getaway
-	{0xE78971DF, GetawayGames, US, 0}, // GetawayBlackMonday
-	{0x342D97FA, GetawayGames, US, 0}, // GetawayBlackMonday Demo
-	{0xE8C0AD1A, GetawayGames, JP, 0}, // GetawayBlackMonday
-	{0x09C3DF79, GetawayGames, EU, 0}, // GetawayBlackMonday
-	{0x1130BF23, SakuraTaisen, CH, 0},
-	{0x4FAE8B83, SakuraTaisen, KO, 0},
-	{0xEF06DBD6, SakuraWarsSoLongMyLove, JP, 0},
-	{0xDD41054D, SakuraWarsSoLongMyLove, US, 0},
-	{0xC2E3A7A4, SakuraWarsSoLongMyLove, KO, 0},
-	{0x4A4B623A, FightingBeautyWulong, JP, 0},
-	{0xAEDAEE99, GodHand, JP, 0},
-	{0x6FB69282, GodHand, US, 0},
-	{0x924C4AA6, GodHand, KO, 0},
-	{0xDE9722A5, GodHand, EU, 0},
-	{0x9637D496, KnightsOfTheTemple2, NoRegion, 0}, // // EU and JP versions have the same CRC
-	{0x4E811100, UltramanFightingEvolution, JP, 0},
-	{0xF7F181C3, DeathByDegreesTekkenNinaWilliams, CH, 0},
-	{0xF088FA5B, DeathByDegreesTekkenNinaWilliams, KO, 0},
-	{0xE1D6F85E, DeathByDegreesTekkenNinaWilliams, US, 0},
-	{0x59683BB0, DeathByDegreesTekkenNinaWilliams, EU, 0},
-	{0x830B6FB1, TalesofSymphonia, JP, 0},
-	{0xFC0F8A5B, Simple2000Vol114, JP, 0},
-	{0xBDD9BAAD, UrbanReign, US, 0},
-	{0x0418486E, UrbanReign, RU, 0},
-	{0xAE4BEBD3, UrbanReign, EU, 0},
-	{0x48AC09BC, SteambotChronicles, EU, 0},
-	{0x9F391882, SteambotChronicles, US, 0},
-	{0xFEFCF9DE, SteambotChronicles, JP, 0}, // Ponkotsu Roman Daikatsugeki: Bumpy Trot
-	{0XE1BF5DCA, SuperManReturns, US, 0},
-	{0XE8F7BAB6, SuperManReturns, EU, 0},
-	{0x06A7506A, SacredBlaze, JP, 0},
-	{0x2479F4A9, Jak2, EU, 0},
-	{0xF41C1B29, Jak2, EU, 0}, // Demo
-	{0x9184AAF1, Jak2, US, 0},
-	{0xA2034C69, Jak2, US, 0}, // Demo
-	{0x25FE4D23, Jak2, KO, 0},
-	{0xB4976DAF, Jak2, JP, 0}, // Jak II: Jak x Daxter 2
-	{0x43D4FF3E, Jak2, JP, 0}, // Demo
-	{0x12804727, Jak3, EU, 0},
-	{0xE59E10BF, Jak3, EU, 0},
-	{0xCA68E4D5, Jak3, EU, 0}, // Demo
-	{0x644CFD03, Jak3, US, 0},
-	{0xD401BC20, Jak3, US, 0}, // Demo
-	{0xD1368EAE, Jak3, KO, 0},
-	{0xDF659E77, JakX, EU, 0}, // Jak X: Combat Racing
-	{0xC20596DB, JakX, EU, 0}, // Beta Trial Disc, v0.01
-	{0x3091E6FB, JakX, US, 0},
-	{0xC417D919, JakX, US, 0}, // Demo
-	{0xDA366A53, JakX, US, 0}, // Public Beta v.1
-	{0x7B564230, JakX, US, 0}, // Jak and Daxter Complete Trilogy Demo
-	{0xDBA28C59, JakX, US, 0}, // Greatest Hits
+	{0x00000000, NoTitle /* NoRegion */},
+	{0x9AAC5309, FFX2 /* EU */},
+	{0x9AAC530C, FFX2 /* FR */},
+	{0x9AAC530A, FFX2 /* ES */},
+	{0x9AAC530D, FFX2 /* DE */},
+	{0x9AAC530B, FFX2 /* IT */},
+	{0x48FE0C71, FFX2 /* US */},
+	{0x8A6D7F14, FFX2 /* JP */},
+	{0xE1FD9A2D, FFX2 /* JP */}, // int.
+	{0x11624CD6, FFX2 /* KO */},
+	{0x08C1ED4D, HauntingGround /* EU */},
+	{0x2CD5794C, HauntingGround /* EU */},
+	{0x867BB945, HauntingGround /* JP */},
+	{0xE263BC4B, HauntingGround /* JP */},
+	{0x901AAC09, HauntingGround /* US */},
+	{0x6F8545DB, ICO /* US */},
+	{0x48CDF317, ICO /* US */}, // Demo
+	{0xB01A4C95, ICO /* JP */},
+	{0x2DF2C1EA, ICO /* KO */},
+	{0x5C991F4E, ICO /* EU */},
+	{0x788D8B4F, ICO /* EU */},
+	{0x29C28734, ICO /* CH */},
+	{0x60013EBD, PolyphonyDigitalGames /* EU */}, // Gran Turismo Concept
+	{0x6810C3BC, PolyphonyDigitalGames /* CH */}, // Gran Turismo Concept 2002 Tokyo-Geneva
+	{0x0EEF32A3, PolyphonyDigitalGames /* KO */}, // Gran Turismo Concept 2002 Tokyo-Seoul
+	{0x3E9D448A, PolyphonyDigitalGames /* CH */}, // GT3
+	{0xAD66643C, PolyphonyDigitalGames /* CH */}, // GT3
+	{0x85AE91B3, PolyphonyDigitalGames /* US */}, // GT3
+	{0x8AA991B0, PolyphonyDigitalGames /* US */}, // GT3
+	{0xC220951A, PolyphonyDigitalGames /* JP */}, // GT3
+	{0x9DE5CF65, PolyphonyDigitalGames /* JP */}, // GT3
+	{0x706DFF80, PolyphonyDigitalGames /* JP */}, // GT3 Store Disc Vol. 2
+	{0x55CE5111, PolyphonyDigitalGames /* JP */}, // Gran Turismo 2000 Body Omen
+	{0xE9A7E08D, PolyphonyDigitalGames /* JP */}, // Gran Turismo 2000 Body Omen
+	{0xB590CE04, PolyphonyDigitalGames /* EU */}, // GT3
+	{0xC02C653E, PolyphonyDigitalGames /* CH */}, // GT4
+	{0x7ABDBB5E, PolyphonyDigitalGames /* CH */}, // GT4
+	{0xAEAD1CA3, PolyphonyDigitalGames /* JP */}, // GT4
+	{0xA3AF15A0, PolyphonyDigitalGames /* JP */}, // GT4 PS2 Racing Pack
+	{0xE906EA37, PolyphonyDigitalGames /* JP */}, // GT4 First Preview
+	{0xCA6243B9, PolyphonyDigitalGames /* JP */}, // GT4 Prologue
+	{0xDD764BBE, PolyphonyDigitalGames /* JP */}, // GT4 Prologue
+	{0xE1258846, PolyphonyDigitalGames /* JP */}, // GT4 Prologue
+	{0x27B8F05F, PolyphonyDigitalGames /* JP */}, // GT4 Prius Trial Version
+	{0x30E41D93, PolyphonyDigitalGames /* KO */}, // GT4
+	{0x715CF2EC, PolyphonyDigitalGames /* EU */}, // GT4
+	{0x44A61C8F, PolyphonyDigitalGames /* EU */}, // GT4
+	{0x0086E35B, PolyphonyDigitalGames /* EU */}, // GT4
+	{0x3FB69323, PolyphonyDigitalGames /* EU */}, // GT4 Prologue
+	{0x77E61C8A, PolyphonyDigitalGames /* US */}, // GT4
+	{0x33C6E35E, PolyphonyDigitalGames /* US */}, // GT4
+	{0x70538747, PolyphonyDigitalGames /* US */}, // GT4 Toyota Prius Trial
+	{0x32A1C752, PolyphonyDigitalGames /* US */}, // GT4 Online Beta
+	{0x2A84A1E2, PolyphonyDigitalGames /* US */}, // GT4 Mazda MX-5 Edition
+	{0x0087EEC4, PolyphonyDigitalGames /* NoRegion */}, // GT4 Online Beta, JP and US versions have the same CRC
+	{0x5AC7E79C, PolyphonyDigitalGames /* CH */}, // TouristTrophy
+	{0xFF9C0E93, PolyphonyDigitalGames /* US */}, // TouristTrophy
+	{0xCA9AA903, PolyphonyDigitalGames /* EU */}, // TouristTrophy
+	{0xAC3C1147, SVCChaos /* EU */}, // SVC Chaos: SNK vs. Capcom
+	{0xB00FF2ED, SVCChaos /* JP */},
+	{0x94834BD3, SVCChaos /* JP */},
+	{0xCF1D71EE, KOF2002 /* EU */}, // The King of Fighters 2002
+	{0xABD16263, KOF2002 /* JP */},
+	{0x424A8601, KOF2002 /* JP */},
+	{0x7F74D8D0, KOF2002 /* US */},
+	{0xFC46EA61, Tekken5 /* JP */},
+	{0x1F88EE37, Tekken5 /* EU */},
+	{0x1F88BECD, Tekken5 /* EU */}, // language selector...
+	{0x652050D2, Tekken5 /* US */},
+	{0xEA64EF39, Tekken5 /* KO */},
+	{0xE8FCF8EC, SMTNocturne /* US */},
+	{0xF0A31EE3, SMTNocturne /* EU */}, // SMTNocturne (Lucifers Call in EU)
+	{0xAE0DE7B7, SMTNocturne /* EU */}, // SMTNocturne (Lucifers Call in EU)
+	{0xD60DA6D4, SMTNocturne /* JP */}, // SMTNocturne
+	{0x0E762E8D, SMTNocturne /* JP */}, // SMTNocturne Maniacs
+	{0x47BA9034, SMTNocturne /* JP */}, // SMTNocturne Maniacs Chronicle
+	{0xD3FFC263, SMTNocturne /* KO */},
+	{0x84D1A8DA, SMTNocturne /* KO */},
+	{0xE21404E2, GetawayGames /* US */}, // Getaway
+	{0xE8249852, GetawayGames /* JP */}, // Getaway
+	{0x458485EF, GetawayGames /* EU */}, // Getaway
+	{0x5DFBE144, GetawayGames /* EU */}, // Getaway
+	{0xE78971DF, GetawayGames /* US */}, // GetawayBlackMonday
+	{0x342D97FA, GetawayGames /* US */}, // GetawayBlackMonday Demo
+	{0xE8C0AD1A, GetawayGames /* JP */}, // GetawayBlackMonday
+	{0x09C3DF79, GetawayGames /* EU */}, // GetawayBlackMonday
 };
-
-std::map<u32, const CRC::Game*> CRC::m_map;
-
-std::string ToLower(std::string str)
-{
-	transform(str.begin(), str.end(), str.begin(), ::tolower);
-	return str;
-}
-
-// The exclusions list is a comma separated list of: the word "all" and/or CRCs in standard hex notation (0x and 8 digits with leading 0's if required).
-// The list is case insensitive and order insensitive.
-// E.g. Disable all CRC hacks:          CrcHacksExclusions=all
-// E.g. Disable hacks for these CRCs:   CrcHacksExclusions=0x0F0C4A9C, 0x0EE5646B, 0x7ACF7E03
-bool IsCrcExcluded(std::string exclusionList, u32 crc)
-{
-	std::string target = StringUtil::StdStringFromFormat("0x%08x", crc);
-	exclusionList = ToLower(exclusionList);
-	return exclusionList.find(target) != std::string::npos || exclusionList.find("all") != std::string::npos;
-}
 
 const CRC::Game& CRC::Lookup(u32 crc)
 {
-	printf("GS Lookup CRC:%08X\n", crc);
-	if (m_map.empty())
+	for (const Game& game : m_games)
 	{
-		std::string exclusions = Host::GetStringSettingValue("EmuCore/GS", "CrcHacksExclusions");
-		if (exclusions.length() != 0)
-			printf("GS: CrcHacksExclusions: %s\n", exclusions.c_str());
-		int crcDups = 0;
-		for (const Game& game : m_games)
-		{
-			if (!IsCrcExcluded(exclusions, game.crc))
-			{
-				if (m_map[game.crc])
-				{
-					printf("[FIXME] GS: Duplicate CRC: 0x%08X: (game-id/region-id) %d/%d overrides %d/%d\n", game.crc, game.title, game.region, m_map[game.crc]->title, m_map[game.crc]->region);
-					crcDups++;
-				}
-
-				m_map[game.crc] = &game;
-			}
-			//else
-			//	printf( "GS: excluding CRC hack for 0x%08x\n", game.crc );
-		}
-		if (crcDups)
-			printf("[FIXME] GS: Duplicate CRC: Overall: %d\n", crcDups);
-	}
-
-	auto i = m_map.find(crc);
-
-	if (i != m_map.end())
-	{
-		return *i->second;
+		if (game.crc == crc)
+			return game;
 	}
 
 	return m_games[0];

--- a/pcsx2/GS/GSCrc.h
+++ b/pcsx2/GS/GSCrc.h
@@ -20,97 +20,29 @@
 class CRC
 {
 public:
-	enum Title : u16
+	enum Title : u32
 	{
 		NoTitle,
-		AceCombat4,
-		ArTonelico2,
-		BigMuthaTruckers,
-		Black,
-		BurnoutGames,
-		CrashBandicootWoC,
-		DBZBT2,
-		DBZBT3,
-		DeathByDegreesTekkenNinaWilliams,
-		FFX,
 		FFX2,
-		FFXII,
-		FightingBeautyWulong,
 		GetawayGames,
-		GiTS,
-		GodHand,
 		HauntingGround,
 		ICO,
-		Jak2,
-		Jak3,
-		JakX,
-		KnightsOfTheTemple2,
 		KOF2002,
-		Kunoichi,
-		Lamune,
-		Manhunt2,
-		MetalSlug6,
-		MidnightClub3,
-		Okami,
-		Oneechanbara2Special,
 		PolyphonyDigitalGames,
-		RedDeadRevolver,
-		RozenMaidenGebetGarden,
-		SacredBlaze,
-		SakuraTaisen,
-		SakuraWarsSoLongMyLove,
-		SFEX3,
-		ShinOnimusha,
-		Simple2000Vol114,
 		SMTNocturne,
-		SonicUnleashed,
-		Spartan,
-		SteambotChronicles,
-		SuperManReturns,
 		SVCChaos,
-		TalesOfAbyss,
-		TalesOfLegendia,
-		TalesofSymphonia,
 		Tekken5,
-		TombRaiderAnniversary,
-		TombRaiderLegend,
-		TombRaiderUnderworld,
-		UltramanFightingEvolution,
-		UrbanReign,
-		XenosagaE3,
-		YakuzaGames,
-		ZettaiZetsumeiToshi2,
 		TitleCount,
-	};
-
-	enum Region : u8
-	{
-		NoRegion,
-		US,
-		EU,
-		JP,
-		RU,
-		FR,
-		DE,
-		IT,
-		ES,
-		CH,
-		ASIA,
-		KO,
-		RegionCount,
 	};
 
 	struct Game
 	{
 		u32 crc;
 		Title title;
-		Region region;
-		u32 flags;
 	};
 
 private:
 	static const Game m_games[];
-	static std::map<u32, const Game*> m_map;
 
 public:
 	static const Game& Lookup(u32 crc);

--- a/pcsx2/GS/GSCrc.h
+++ b/pcsx2/GS/GSCrc.h
@@ -20,7 +20,7 @@
 class CRC
 {
 public:
-	enum Title
+	enum Title : u16
 	{
 		NoTitle,
 		AceCombat4,
@@ -83,7 +83,7 @@ public:
 		TitleCount,
 	};
 
-	enum Region
+	enum Region : u8
 	{
 		NoRegion,
 		US,

--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -2751,10 +2751,15 @@ int GSState::Defrost(const freezeData* fd)
 	return 0;
 }
 
-void GSState::SetGameCRC(u32 crc, CRCHackLevel level)
+void GSState::SetGameCRC(u32 crc)
 {
 	m_crc = crc;
-	m_game = CRC::Lookup((level != CRCHackLevel::Off) ? crc : 0);
+	UpdateCRCHacks();
+}
+
+void GSState::UpdateCRCHacks()
+{
+	m_game = CRC::Lookup((GSConfig.CRCHack != CRCHackLevel::Off) ? m_crc : 0);
 }
 
 //

--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -39,16 +39,12 @@ static __fi bool IsFirstProvokingVertex()
 
 GSState::GSState()
 	: m_version(STATE_VERSION)
-	, m_gsc(NULL)
-	, m_skip(0)
-	, m_skip_offset(0)
 	, m_q(1.0f)
 	, m_scanmask_used(0)
 	, tex_flushed(true)
 	, m_vt(this, IsFirstProvokingVertex())
 	, m_regs(NULL)
 	, m_crc(0)
-	, m_options(0)
 {
 	// m_nativeres seems to be a hack. Unfortunately it impacts draw call number which make debug painful in the replayer.
 	// Let's keep it disabled to ease debug.
@@ -56,10 +52,6 @@ GSState::GSState()
 	m_mipmap = GSConfig.Mipmap;
 
 	s_n = 0;
-
-	m_crc_hack_level = GSConfig.CRCHack;
-	if (m_crc_hack_level == CRCHackLevel::Automatic)
-		m_crc_hack_level = GSUtil::GetRecommendedCRCHackLevel(GSConfig.Renderer);
 
 	memset(&m_v, 0, sizeof(m_v));
 	memset(&m_vertex, 0, sizeof(m_vertex));
@@ -2759,12 +2751,10 @@ int GSState::Defrost(const freezeData* fd)
 	return 0;
 }
 
-void GSState::SetGameCRC(u32 crc, int options)
+void GSState::SetGameCRC(u32 crc, CRCHackLevel level)
 {
 	m_crc = crc;
-	m_options = options;
-	m_game = CRC::Lookup(m_crc_hack_level != CRCHackLevel::Off ? crc : 0);
-	SetupCrcHack();
+	m_game = CRC::Lookup((level != CRCHackLevel::Off) ? crc : 0);
 }
 
 //

--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -29,19 +29,6 @@
 #include "GSAlignedClass.h"
 #include "GSDump.h"
 
-struct GSFrameInfo
-{
-	u32 FBP;
-	u32 FPSM;
-	u32 FBMSK;
-	u32 TBP0;
-	u32 TPSM;
-	u32 TZTST;
-	bool TME;
-};
-
-typedef bool (*GetSkipCount)(const GSFrameInfo& fi, int& skip);
-
 class GSState : public GSAlignedClass<32>
 {
 public:
@@ -152,15 +139,6 @@ private:
 	void CalcAlphaMinMax();
 
 protected:
-	bool IsBadFrame();
-	void SetupCrcHack() noexcept;
-
-	bool m_isPackedUV_HackFlag;
-	CRCHackLevel m_crc_hack_level;
-	GetSkipCount m_gsc;
-	int m_skip;
-	int m_skip_offset;
-
 	GSVertex m_v;
 	float m_q;
 	GSVector4i m_scissor;
@@ -168,6 +146,7 @@ protected:
 
 	u8 m_scanmask_used;
 	bool tex_flushed;
+	bool m_isPackedUV_HackFlag;
 
 	struct
 	{
@@ -239,7 +218,6 @@ public:
 	u32 m_crc;
 	CRC::Game m_game;
 	std::unique_ptr<GSDumpBase> m_dump;
-	int m_options;
 	bool m_nativeres;
 	bool m_mipmap;
 	u32 m_dirty_gs_regs;
@@ -387,8 +365,7 @@ public:
 	int Defrost(const freezeData* fd);
 
 	u32 GetGameCRC() const { return m_crc; }
-	int GetGameCRCOptions() const { return m_options; }
-	virtual void SetGameCRC(u32 crc, int options);
+	virtual void SetGameCRC(u32 crc, CRCHackLevel level);
 
 	u8* GetRegsMem() const { return reinterpret_cast<u8*>(m_regs); }
 	void SetRegsMem(u8* basemem) { m_regs = reinterpret_cast<GSPrivRegSet*>(basemem); }

--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -365,7 +365,8 @@ public:
 	int Defrost(const freezeData* fd);
 
 	u32 GetGameCRC() const { return m_crc; }
-	virtual void SetGameCRC(u32 crc, CRCHackLevel level);
+	virtual void SetGameCRC(u32 crc);
+	virtual void UpdateCRCHacks();
 
 	u8* GetRegsMem() const { return reinterpret_cast<u8*>(m_regs); }
 	void SetRegsMem(u8* basemem) { m_regs = reinterpret_cast<GSPrivRegSet*>(basemem); }

--- a/pcsx2/GS/GSUtil.cpp
+++ b/pcsx2/GS/GSUtil.cpp
@@ -145,11 +145,8 @@ bool GSUtil::HasCompatibleBits(u32 spsm, u32 dpsm)
 	return (s_maps.CompatibleBitsField[spsm][dpsm >> 5] & (1 << (dpsm & 0x1f))) != 0;
 }
 
-CRCHackLevel GSUtil::GetEffectiveCRCHackLevel(GSRendererType type, CRCHackLevel level)
+CRCHackLevel GSUtil::GetRecommendedCRCHackLevel(GSRendererType type)
 {
-	if (level != CRCHackLevel::Automatic)
-		return level;
-
 	return (type == GSRendererType::DX11 || type == GSRendererType::DX12) ? CRCHackLevel::Full : CRCHackLevel::Partial;
 }
 

--- a/pcsx2/GS/GSUtil.cpp
+++ b/pcsx2/GS/GSUtil.cpp
@@ -145,8 +145,11 @@ bool GSUtil::HasCompatibleBits(u32 spsm, u32 dpsm)
 	return (s_maps.CompatibleBitsField[spsm][dpsm >> 5] & (1 << (dpsm & 0x1f))) != 0;
 }
 
-CRCHackLevel GSUtil::GetRecommendedCRCHackLevel(GSRendererType type)
+CRCHackLevel GSUtil::GetEffectiveCRCHackLevel(GSRendererType type, CRCHackLevel level)
 {
+	if (level != CRCHackLevel::Automatic)
+		return level;
+
 	return (type == GSRendererType::DX11 || type == GSRendererType::DX12) ? CRCHackLevel::Full : CRCHackLevel::Partial;
 }
 

--- a/pcsx2/GS/GSUtil.h
+++ b/pcsx2/GS/GSUtil.h
@@ -33,7 +33,7 @@ public:
 	static bool HasSharedBits(u32 sbp, u32 spsm, u32 dbp, u32 dpsm);
 	static bool HasCompatibleBits(u32 spsm, u32 dpsm);
 
-	static CRCHackLevel GetRecommendedCRCHackLevel(GSRendererType type);
+	static CRCHackLevel GetEffectiveCRCHackLevel(GSRendererType type, CRCHackLevel level);
 	static GSRendererType GetPreferredRenderer();
 };
 

--- a/pcsx2/GS/GSUtil.h
+++ b/pcsx2/GS/GSUtil.h
@@ -33,7 +33,7 @@ public:
 	static bool HasSharedBits(u32 sbp, u32 spsm, u32 dbp, u32 dpsm);
 	static bool HasCompatibleBits(u32 spsm, u32 dpsm);
 
-	static CRCHackLevel GetEffectiveCRCHackLevel(GSRendererType type, CRCHackLevel level);
+	static CRCHackLevel GetRecommendedCRCHackLevel(GSRendererType type);
 	static GSRendererType GetPreferredRenderer();
 };
 

--- a/pcsx2/GS/Renderers/HW/GSHwHack.cpp
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.cpp
@@ -353,7 +353,7 @@ bool GSHwHack::GSC_BlackAndBurnoutSky(GSRendererHW& r, const GSFrameInfo& fi, in
 		// the clouds on top of the sky at each frame.
 		// Burnout 3 PAL 50Hz: 0x3ba0 => 0x1e80.
 		GL_INS("OO_BurnoutGames - Readback clouds renderered from TEX0.TBP0 = 0x%04x (TEX0.CBP = 0x%04x) to FBP = 0x%04x", TEX0.TBP0, TEX0.CBP, FRAME.Block());
-		r.SwPrimRender(r);
+		r.SwPrimRender(r, true);
 		skip = 1;
 	}
 

--- a/pcsx2/GS/Renderers/HW/GSHwHack.h
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.h
@@ -33,6 +33,7 @@ public:
 	static bool GSC_TombRaiderLegend(GSRendererHW& r, const GSFrameInfo& fi, int& skip);
 	static bool GSC_TombRaiderUnderWorld(GSRendererHW& r, const GSFrameInfo& fi, int& skip);
 	static bool GSC_BurnoutGames(GSRendererHW& r, const GSFrameInfo& fi, int& skip);
+	static bool GSC_BlackAndBurnoutSky(GSRendererHW& r, const GSFrameInfo& fi, int& skip);
 	static bool GSC_MidnightClub3(GSRendererHW& r, const GSFrameInfo& fi, int& skip);
 	static bool GSC_TalesOfLegendia(GSRendererHW& r, const GSFrameInfo& fi, int& skip);
 	static bool GSC_Kunoichi(GSRendererHW& r, const GSFrameInfo& fi, int& skip);
@@ -67,8 +68,6 @@ public:
 	static bool OI_JakGames(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
 	static bool OI_BurnoutGames(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
 
-	static void OO_BurnoutGames(GSRendererHW& r);
-
 	template <typename F>
 	struct Entry
 	{
@@ -79,5 +78,4 @@ public:
 
 	static const Entry<GSRendererHW::GSC_Ptr> s_get_skip_count_functions[];
 	static const Entry<GSRendererHW::OI_Ptr> s_before_draw_functions[];
-	static const Entry<GSRendererHW::OO_Ptr> s_after_draw_functions[];
 };

--- a/pcsx2/GS/Renderers/HW/GSHwHack.h
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.h
@@ -1,0 +1,88 @@
+/*  PCSX2 - PS2 Emulator for PCs
+ *  Copyright (C) 2002-2023 PCSX2 Dev Team
+ *
+ *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU Lesser General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  PCSX2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with PCSX2.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "GS/Renderers/HW/GSRendererHW.h"
+
+class GSHwHack
+{
+public:
+	static bool GSC_BigMuthaTruckers(GSRendererHW& r, const GSFrameInfo& fi, int& skip);
+	static bool GSC_DeathByDegreesTekkenNinaWilliams(GSRendererHW& r, const GSFrameInfo& fi, int& skip);
+	static bool GSC_GiTS(GSRendererHW& r, const GSFrameInfo& fi, int& skip);
+	static bool GSC_Manhunt2(GSRendererHW& r, const GSFrameInfo& fi, int& skip);
+	static bool GSC_CrashBandicootWoC(GSRendererHW& r, const GSFrameInfo& fi, int& skip);
+	static bool GSC_SacredBlaze(GSRendererHW& r, const GSFrameInfo& fi, int& skip);
+	static bool GSC_Spartan(GSRendererHW& r, const GSFrameInfo& fi, int& skip);
+	static bool GSC_Oneechanbara2Special(GSRendererHW& r, const GSFrameInfo& fi, int& skip);
+	static bool GSC_SakuraTaisen(GSRendererHW& r, const GSFrameInfo& fi, int& skip);
+	static bool GSC_SFEX3(GSRendererHW& r, const GSFrameInfo& fi, int& skip);
+	static bool GSC_Tekken5(GSRendererHW& r, const GSFrameInfo& fi, int& skip);
+	static bool GSC_TombRaiderAnniversary(GSRendererHW& r, const GSFrameInfo& fi, int& skip);
+	static bool GSC_TombRaiderLegend(GSRendererHW& r, const GSFrameInfo& fi, int& skip);
+	static bool GSC_TombRaiderUnderWorld(GSRendererHW& r, const GSFrameInfo& fi, int& skip);
+	static bool GSC_BurnoutGames(GSRendererHW& r, const GSFrameInfo& fi, int& skip);
+	static bool GSC_MidnightClub3(GSRendererHW& r, const GSFrameInfo& fi, int& skip);
+	static bool GSC_TalesOfLegendia(GSRendererHW& r, const GSFrameInfo& fi, int& skip);
+	static bool GSC_Kunoichi(GSRendererHW& r, const GSFrameInfo& fi, int& skip);
+	static bool GSC_ZettaiZetsumeiToshi2(GSRendererHW& r, const GSFrameInfo& fi, int& skip);
+	static bool GSC_SakuraWarsSoLongMyLove(GSRendererHW& r, const GSFrameInfo& fi, int& skip);
+	static bool GSC_FightingBeautyWulong(GSRendererHW& r, const GSFrameInfo& fi, int& skip);
+	static bool GSC_GodHand(GSRendererHW& r, const GSFrameInfo& fi, int& skip);
+	static bool GSC_KnightsOfTheTemple2(GSRendererHW& r, const GSFrameInfo& fi, int& skip);
+	static bool GSC_UltramanFightingEvolution(GSRendererHW& r, const GSFrameInfo& fi, int& skip);
+	static bool GSC_TalesofSymphonia(GSRendererHW& r, const GSFrameInfo& fi, int& skip);
+	static bool GSC_Simple2000Vol114(GSRendererHW& r, const GSFrameInfo& fi, int& skip);
+	static bool GSC_UrbanReign(GSRendererHW& r, const GSFrameInfo& fi, int& skip);
+	static bool GSC_SteambotChronicles(GSRendererHW& r, const GSFrameInfo& fi, int& skip);
+	static bool GSC_YakuzaGames(GSRendererHW& r, const GSFrameInfo& fi, int& skip);
+	static bool GSC_GetawayGames(GSRendererHW& r, const GSFrameInfo& fi, int& skip);
+	static bool GSC_AceCombat4(GSRendererHW& r, const GSFrameInfo& fi, int& skip);
+	static bool GSC_FFXGames(GSRendererHW& r, const GSFrameInfo& fi, int& skip);
+	static bool GSC_Okami(GSRendererHW& r, const GSFrameInfo& fi, int& skip);
+	static bool GSC_RedDeadRevolver(GSRendererHW& r, const GSFrameInfo& fi, int& skip);
+	static bool GSC_ShinOnimusha(GSRendererHW& r, const GSFrameInfo& fi, int& skip);
+	static bool GSC_XenosagaE3(GSRendererHW& r, const GSFrameInfo& fi, int& skip);
+
+	static bool OI_BigMuthaTruckers(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
+	static bool OI_DBZBTGames(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
+	static bool OI_FFXII(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
+	static bool OI_FFX(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
+	static bool OI_MetalSlug6(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
+	static bool OI_RozenMaidenGebetGarden(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
+	static bool OI_SonicUnleashed(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
+	static bool OI_ArTonelico2(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
+	static bool OI_JakGames(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
+	static bool OI_BurnoutGames(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
+
+	static void OO_BurnoutGames(GSRendererHW& r);
+
+	template <typename F>
+	struct Entry
+	{
+		CRC::Title game;
+		CRC::Region region;
+		CRCHackLevel level;
+		F ptr;
+
+		__fi bool Test(CRC::Title title_, CRC::Region region_, CRCHackLevel level_) const
+		{
+			return (game == title_ && (region == CRC::RegionCount || region == region_) && level_ >= level);
+		}
+	};
+
+	static const Entry<GSRendererHW::GSC_Ptr> s_gsc_functions[];
+	static const Entry<GSRendererHW::OI_Ptr> s_oi_functions[];
+	static const Entry<GSRendererHW::OO_Ptr> s_oo_functions[];
+};

--- a/pcsx2/GS/Renderers/HW/GSHwHack.h
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.h
@@ -55,6 +55,7 @@ public:
 	static bool GSC_ShinOnimusha(GSRendererHW& r, const GSFrameInfo& fi, int& skip);
 	static bool GSC_XenosagaE3(GSRendererHW& r, const GSFrameInfo& fi, int& skip);
 
+	static bool OI_PointListPalette(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
 	static bool OI_BigMuthaTruckers(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
 	static bool OI_DBZBTGames(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
 	static bool OI_FFXII(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
@@ -71,18 +72,12 @@ public:
 	template <typename F>
 	struct Entry
 	{
-		CRC::Title game;
-		CRC::Region region;
-		CRCHackLevel level;
+		const char* name;
 		F ptr;
-
-		__fi bool Test(CRC::Title title_, CRC::Region region_, CRCHackLevel level_) const
-		{
-			return (game == title_ && (region == CRC::RegionCount || region == region_) && level_ >= level);
-		}
+		CRCHackLevel level;
 	};
 
-	static const Entry<GSRendererHW::GSC_Ptr> s_gsc_functions[];
-	static const Entry<GSRendererHW::OI_Ptr> s_oi_functions[];
-	static const Entry<GSRendererHW::OO_Ptr> s_oo_functions[];
+	static const Entry<GSRendererHW::GSC_Ptr> s_get_skip_count_functions[];
+	static const Entry<GSRendererHW::OI_Ptr> s_before_draw_functions[];
+	static const Entry<GSRendererHW::OO_Ptr> s_after_draw_functions[];
 };

--- a/pcsx2/GS/Renderers/HW/GSHwHack.h
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.h
@@ -55,6 +55,7 @@ public:
 	static bool GSC_RedDeadRevolver(GSRendererHW& r, const GSFrameInfo& fi, int& skip);
 	static bool GSC_ShinOnimusha(GSRendererHW& r, const GSFrameInfo& fi, int& skip);
 	static bool GSC_XenosagaE3(GSRendererHW& r, const GSFrameInfo& fi, int& skip);
+	static bool GSC_Barnyard(GSRendererHW& r, const GSFrameInfo& fi, int& skip);
 
 	static bool OI_PointListPalette(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
 	static bool OI_BigMuthaTruckers(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);

--- a/pcsx2/GS/Renderers/HW/GSHwHack.h
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.h
@@ -56,6 +56,7 @@ public:
 	static bool GSC_ShinOnimusha(GSRendererHW& r, const GSFrameInfo& fi, int& skip);
 	static bool GSC_XenosagaE3(GSRendererHW& r, const GSFrameInfo& fi, int& skip);
 	static bool GSC_Barnyard(GSRendererHW& r, const GSFrameInfo& fi, int& skip);
+	static bool GSC_Battlefield2(GSRendererHW& r, const GSFrameInfo& fi, int& skip);
 
 	static bool OI_PointListPalette(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
 	static bool OI_BigMuthaTruckers(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
@@ -68,6 +69,8 @@ public:
 	static bool OI_ArTonelico2(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
 	static bool OI_JakGames(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
 	static bool OI_BurnoutGames(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
+
+	static bool OI_Battlefield2(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
 
 	template <typename F>
 	struct Entry

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -1943,9 +1943,6 @@ void GSRendererHW::Draw()
 
 	//
 
-	if (m_oo)
-		m_oo(*this);
-
 	if (GSConfig.DumpGSData)
 	{
 		const u64 frame = g_perfmon.GetFrame();

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -1399,7 +1399,7 @@ void GSRendererHW::Draw()
 	const bool single_page = (delta_p.x <= 64.0f) && (delta_p.y <= 64.0f);
 
 	// We trigger the sw prim render here super early, to avoid creating superfluous render targets.
-	if (CanUseSwPrimRender(no_rt, no_ds, draw_sprite_tex) && SwPrimRender(*this))
+	if (CanUseSwPrimRender(no_rt, no_ds, draw_sprite_tex) && SwPrimRender(*this, true))
 	{
 		GL_CACHE("Possible texture decompression, drawn with SwPrimRender()");
 		return;
@@ -1412,7 +1412,7 @@ void GSRendererHW::Draw()
 		m_mem.m_clut.ClearDrawInvalidity();
 		if (result)
 		{
-			if (SwPrimRender(*this))
+			if (SwPrimRender(*this, true))
 			{
 				GL_CACHE("Possible clut draw, drawn with SwPrimRender()");
 				return;

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.h
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.h
@@ -69,7 +69,7 @@ private:
 	bool PossibleCLUTDraw();
 	bool PossibleCLUTDrawAggressive();
 	bool CanUseSwPrimRender(bool no_rt, bool no_ds, bool draw_sprite_tex);
-	bool (*SwPrimRender)(GSRendererHW&);
+	bool (*SwPrimRender)(GSRendererHW&, bool invalidate_tc);
 
 	template <bool linear>
 	void RoundSpriteOffset();
@@ -111,7 +111,7 @@ private:
 
 	// software sprite renderer state
 	std::vector<GSVertexSW> m_sw_vertex_buffer;
-	std::unique_ptr<GSTextureCacheSW::Texture> m_sw_texture;
+	std::unique_ptr<GSTextureCacheSW::Texture> m_sw_texture[7 + 1];
 	std::unique_ptr<GSVirtualAlignedClass<32>> m_sw_rasterizer;
 
 public:

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.h
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.h
@@ -60,7 +60,6 @@ private:
 	bool OI_BlitFMV(GSTextureCache::Target* _rt, GSTextureCache::Source* t, const GSVector4i& r_draw);
 	bool OI_GsMemClear(); // always on
 	void OI_DoubleHalfClear(GSTextureCache::Target*& rt, GSTextureCache::Target*& ds); // always on
-	static bool OI_PointListPalette(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
 
 	u16 Interpolate_UV(float alpha, int t0, int t1);
 	float alpha0(int L, int X0, int X1);
@@ -95,8 +94,6 @@ private:
 
 	// CRC Hacks
 	bool IsBadFrame();
-	void SetupCrcHack(CRCHackLevel level);
-
 	GSC_Ptr m_gsc = nullptr;
 	OI_Ptr m_oi = nullptr;
 	OO_Ptr m_oo = nullptr;
@@ -128,7 +125,9 @@ public:
 
 	void Destroy() override;
 
-	void SetGameCRC(u32 crc, CRCHackLevel level) override;
+	void SetGameCRC(u32 crc) override;
+	void UpdateCRCHacks() override;
+
 	bool CanUpscale() override;
 	float GetUpscaleMultiplier() override;
 	void Lines2Sprites();

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.h
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.h
@@ -54,7 +54,6 @@ private:
 
 	using GSC_Ptr = bool(*)(GSRendererHW& r, const GSFrameInfo& fi, int& skip);	// GSC - Get Skip Count
 	using OI_Ptr = bool(*)(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t); // OI - Before draw
-	using OO_Ptr = void(*)(GSRendererHW& r); // OO - After draw
 
 	// Require special argument
 	bool OI_BlitFMV(GSTextureCache::Target* _rt, GSTextureCache::Source* t, const GSVector4i& r_draw);
@@ -96,7 +95,6 @@ private:
 	bool IsBadFrame();
 	GSC_Ptr m_gsc = nullptr;
 	OI_Ptr m_oi = nullptr;
-	OO_Ptr m_oo = nullptr;
 	int m_skip = 0;
 	int m_skip_offset = 0;
 

--- a/pcsx2/GameDatabase.cpp
+++ b/pcsx2/GameDatabase.cpp
@@ -242,15 +242,13 @@ void GameDatabase::parseAndInsert(const std::string_view& serial, const c4::yml:
 			const std::string_view id_name(n.key().data(), n.key().size());
 			std::optional<GameDatabaseSchema::GSHWFixId> id = GameDatabaseSchema::parseHWFixName(id_name);
 			std::optional<s32> value;
-			if (id.has_value() && (id.value() == GameDatabaseSchema::GSHWFixId::GetSkipCount || id.value() == GameDatabaseSchema::GSHWFixId::BeforeDraw || id.value() == GameDatabaseSchema::GSHWFixId::AfterDraw))
+			if (id.has_value() && (id.value() == GameDatabaseSchema::GSHWFixId::GetSkipCount || id.value() == GameDatabaseSchema::GSHWFixId::BeforeDraw))
 			{
 				const std::string_view str_value(n.has_val() ? std::string_view(n.val().data(), n.val().size()) : std::string_view());
 				if (id.value() == GameDatabaseSchema::GSHWFixId::GetSkipCount)
 					value = GSLookupGetSkipCountFunctionId(str_value);
 				else if (id.value() == GameDatabaseSchema::GSHWFixId::BeforeDraw)
 					value = GSLookupBeforeDrawFunctionId(str_value);
-				else if (id.value() == GameDatabaseSchema::GSHWFixId::AfterDraw)
-					value = GSLookupAfterDrawFunctionId(str_value);
 
 				if (value.value_or(-1) < 0)
 				{
@@ -366,7 +364,6 @@ static const char* s_gs_hw_fix_names[] = {
 	"gpuPaletteConversion",
 	"getSkipCount",
 	"beforeDraw",
-	"afterDraw"
 };
 static_assert(std::size(s_gs_hw_fix_names) == static_cast<u32>(GameDatabaseSchema::GSHWFixId::Count), "HW fix name lookup is correct size");
 
@@ -396,7 +393,6 @@ bool GameDatabaseSchema::isUserHackHWFix(GSHWFixId id)
 		case GSHWFixId::TrilinearFiltering:
 		case GSHWFixId::GetSkipCount:
 		case GSHWFixId::BeforeDraw:
-		case GSHWFixId::AfterDraw:
 			return false;
 		default:
 			return true;
@@ -617,9 +613,6 @@ bool GameDatabaseSchema::GameEntry::configMatchesHWFix(const Pcsx2Config::GSOpti
 		case GSHWFixId::BeforeDraw:
 			return (static_cast<int>(config.BeforeDrawFunctionId) == value);
 
-		case GSHWFixId::AfterDraw:
-			return (static_cast<int>(config.AfterDrawFunctionId) == value);
-
 		default:
 			return false;
 	}
@@ -776,10 +769,6 @@ u32 GameDatabaseSchema::GameEntry::applyGSHardwareFixes(Pcsx2Config::GSOptions& 
 
 			case GSHWFixId::BeforeDraw:
 				config.BeforeDrawFunctionId = static_cast<s16>(value);
-				break;
-
-			case GSHWFixId::AfterDraw:
-				config.AfterDrawFunctionId = static_cast<s16>(value);
 				break;
 
 			default:

--- a/pcsx2/GameDatabase.h
+++ b/pcsx2/GameDatabase.h
@@ -70,7 +70,6 @@ namespace GameDatabaseSchema
 		AlignSprite,
 		MergeSprite,
 		WildArmsHack,
-		PointListPalette,
 
 		// integer settings
 		Mipmap,
@@ -85,6 +84,9 @@ namespace GameDatabaseSchema
 		CPUSpriteRenderBW,
 		CPUCLUTRender,
 		GPUPaletteConversion,
+		GetSkipCount,
+		BeforeDraw,
+		AfterDraw,
 
 		Count
 	};

--- a/pcsx2/GameDatabase.h
+++ b/pcsx2/GameDatabase.h
@@ -86,7 +86,6 @@ namespace GameDatabaseSchema
 		GPUPaletteConversion,
 		GetSkipCount,
 		BeforeDraw,
-		AfterDraw,
 
 		Count
 	};

--- a/pcsx2/MTGS.cpp
+++ b/pcsx2/MTGS.cpp
@@ -276,7 +276,7 @@ bool SysMtgsThread::TryOpenGS()
 	if (!GSopen(EmuConfig.GS, EmuConfig.GS.Renderer, RingBuffer.Regs))
 		return false;
 
-	GSsetGameCRC(ElfCRC, 0);
+	GSsetGameCRC(ElfCRC);
 	return true;
 }
 
@@ -511,7 +511,7 @@ void SysMtgsThread::MainLoop()
 						break;
 
 						case GS_RINGTYPE_CRC:
-							GSsetGameCRC(tag.data[0], 0);
+							GSsetGameCRC(tag.data[0]);
 							break;
 
 						case GS_RINGTYPE_INIT_AND_READ_FIFO:

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -495,7 +495,6 @@ bool Pcsx2Config::GSOptions::OptionsAreEqual(const GSOptions& right) const
 		OpEqu(TVShader) &&
 		OpEqu(GetSkipCountFunctionId) &&
 		OpEqu(BeforeDrawFunctionId) &&
-		OpEqu(AfterDrawFunctionId) &&
 		OpEqu(SkipDrawEnd) &&
 		OpEqu(SkipDrawStart) &&
 

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -419,7 +419,6 @@ Pcsx2Config::GSOptions::GSOptions()
 	PreloadFrameWithGSData = false;
 	WrapGSMem = false;
 	Mipmap = true;
-	PointListPalette = false;
 
 	ManualUserHacks = false;
 	UserHacks_AlignSpriteX = false;
@@ -494,6 +493,9 @@ bool Pcsx2Config::GSOptions::OptionsAreEqual(const GSOptions& right) const
 		OpEqu(SWExtraThreadsHeight) &&
 		OpEqu(TriFilter) &&
 		OpEqu(TVShader) &&
+		OpEqu(GetSkipCountFunctionId) &&
+		OpEqu(BeforeDrawFunctionId) &&
+		OpEqu(AfterDrawFunctionId) &&
 		OpEqu(SkipDrawEnd) &&
 		OpEqu(SkipDrawStart) &&
 

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -736,6 +736,11 @@ void VMManager::UpdateRunningGame(bool resetting, bool game_starting)
 			AutoEject::ClearAll();
 	}
 
+	Console.WriteLn(Color_StrongGreen, "Game Changed:");
+	Console.WriteLn(Color_StrongGreen, fmt::format("  Name: {}", s_game_name));
+	Console.WriteLn(Color_StrongGreen, fmt::format("  Serial: {}", s_game_serial));
+	Console.WriteLn(Color_StrongGreen, fmt::format("  CRC: {:08X}", s_game_crc));
+
 	UpdateGameSettingsLayer();
 	ApplySettings();
 

--- a/pcsx2/pcsx2core.vcxproj
+++ b/pcsx2/pcsx2core.vcxproj
@@ -555,6 +555,7 @@
     <ClInclude Include="Frontend\imgui_impl_dx12.h" />
     <ClInclude Include="Frontend\imgui_impl_opengl3.h" />
     <ClInclude Include="Frontend\imgui_impl_vulkan.h" />
+    <ClInclude Include="GS\Renderers\HW\GSHwHack.h" />
     <ClInclude Include="INISettingsInterface.h" />
     <ClInclude Include="Frontend\InputManager.h" />
     <ClInclude Include="Frontend\InputSource.h" />

--- a/pcsx2/pcsx2core.vcxproj.filters
+++ b/pcsx2/pcsx2core.vcxproj.filters
@@ -2342,6 +2342,9 @@
     <ClInclude Include="SPU2\Dma.h">
       <Filter>System\Ps2\SPU2</Filter>
     </ClInclude>
+    <ClInclude Include="GS\Renderers\HW\GSHwHack.h">
+      <Filter>System\Ps2\GS\Renderers\Hardware</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <CustomBuildStep Include="rdebug\deci2.h">


### PR DESCRIPTION
### Description of Changes

The game database is a better place for them.

Also gets rid of CRC hacks from the base GSState class - the software renderer doesn't need to worry about them, let alone use them.

Also adds a CRC hack for Barnyard to fix the mipmap rendering by punting it to the CPU.

Also fixes the cut-off screen in Battlefield 2 - Modern Combat. But you need full blending for the terrain to render correctly, and draw calls go brr haha.

### Rationale behind Changes

Making CRC hacks apply to demos etc, easier maintenance in the future (we don't know all game CRCs).
Fixes mipyard (barnyard).
Fixes #1565.
Closes #5062.

### Suggested Testing Steps

Test games which use CRC hacks (e.g. burnout 3).
Test Barnyard.
Test Battlefield 2 Modern Combat.