### PR TITLE
Qt: Fix light themes

### DIFF
--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -600,6 +600,7 @@ else if (theme == "darkfusion")
 		qApp->setStyle(QStyleFactory::create("Fusion"));
 
 		const QColor black(25, 25, 25);
+		const QColor darkteal(0, 77, 77);
 		const QColor teal(0, 128, 128);
 		const QColor tameTeal(160, 190, 185);
 		const QColor grayBlue(160, 180, 190);
@@ -612,16 +613,16 @@ else if (theme == "darkfusion")
 		standardPalette.setColor(QPalette::ToolTipBase, tameTeal);
 		standardPalette.setColor(QPalette::ToolTipText, grayBlue);
 		standardPalette.setColor(QPalette::Text, black);
-		standardPalette.setColor(QPalette::Button, tameTeal.darker());
-		standardPalette.setColor(QPalette::ButtonText, Qt::white);
-		standardPalette.setColor(QPalette::Link, black);
+		standardPalette.setColor(QPalette::Button, tameTeal);
+		standardPalette.setColor(QPalette::ButtonText, black);
+		standardPalette.setColor(QPalette::Link, black.lighter());
 		standardPalette.setColor(QPalette::Highlight, teal);
-		standardPalette.setColor(QPalette::HighlightedText, Qt::white);
+		standardPalette.setColor(QPalette::HighlightedText, grayBlue.lighter());
 
-		standardPalette.setColor(QPalette::Active, QPalette::Button, tameTeal.darker());
-		standardPalette.setColor(QPalette::Disabled, QPalette::ButtonText, Qt::white);
-		standardPalette.setColor(QPalette::Disabled, QPalette::WindowText, Qt::white);
-		standardPalette.setColor(QPalette::Disabled, QPalette::Text, Qt::white);
+		standardPalette.setColor(QPalette::Active, QPalette::Button, tameTeal);
+		standardPalette.setColor(QPalette::Disabled, QPalette::ButtonText, darkteal);
+		standardPalette.setColor(QPalette::Disabled, QPalette::WindowText, darkteal.lighter());
+		standardPalette.setColor(QPalette::Disabled, QPalette::Text, darkteal.lighter());
 		standardPalette.setColor(QPalette::Disabled, QPalette::Light, tameTeal);
 
 		qApp->setPalette(standardPalette);
@@ -636,6 +637,7 @@ else if (theme == "darkfusion")
 
 		const QColor gray(150, 150, 150);
 		const QColor black(25, 25, 25);
+		const QColor redpinkish(200, 75, 132);
 		const QColor pink(255, 174, 201);
 		const QColor brightPink(255, 230, 255);
 		const QColor congoPink(255, 127, 121);
@@ -656,9 +658,9 @@ else if (theme == "darkfusion")
 		standardPalette.setColor(QPalette::HighlightedText, black);
 
 		standardPalette.setColor(QPalette::Active, QPalette::Button, pink);
-		standardPalette.setColor(QPalette::Disabled, QPalette::ButtonText, gray);
-		standardPalette.setColor(QPalette::Disabled, QPalette::WindowText, congoPink);
-		standardPalette.setColor(QPalette::Disabled, QPalette::Text, blue);
+		standardPalette.setColor(QPalette::Disabled, QPalette::ButtonText, redpinkish);
+		standardPalette.setColor(QPalette::Disabled, QPalette::WindowText, redpinkish);
+		standardPalette.setColor(QPalette::Disabled, QPalette::Text, redpinkish);
 		standardPalette.setColor(QPalette::Disabled, QPalette::Light, gray);
 
 		qApp->setPalette(standardPalette);
@@ -671,29 +673,30 @@ else if (theme == "darkfusion")
 		// Alternative light theme.
 		qApp->setStyle(QStyleFactory::create("Fusion"));
 
-		const QColor black(25, 25, 25);
+		const QColor blackish(35, 35, 35);
 		const QColor darkBlue(73, 97, 177);
+		const QColor blue2(80, 120, 200);
 		const QColor blue(106, 156, 255);
 		const QColor lightBlue(130, 155, 241);
 
 		QPalette standardPalette;
-		standardPalette.setColor(QPalette::Window, lightBlue);
-		standardPalette.setColor(QPalette::WindowText, black);
-		standardPalette.setColor(QPalette::Base, darkBlue);
-		standardPalette.setColor(QPalette::AlternateBase, lightBlue);
-		standardPalette.setColor(QPalette::ToolTipBase, lightBlue);
+		standardPalette.setColor(QPalette::Window, blue2.lighter());
+		standardPalette.setColor(QPalette::WindowText, blackish);
+		standardPalette.setColor(QPalette::Base, lightBlue);
+		standardPalette.setColor(QPalette::AlternateBase, blue2.lighter());
+		standardPalette.setColor(QPalette::ToolTipBase, blue2);
 		standardPalette.setColor(QPalette::ToolTipText, Qt::white);
-		standardPalette.setColor(QPalette::Text, Qt::white);
-		standardPalette.setColor(QPalette::Button, blue.darker());
-		standardPalette.setColor(QPalette::ButtonText, Qt::white);
+		standardPalette.setColor(QPalette::Text, blackish);
+		standardPalette.setColor(QPalette::Button, blue);
+		standardPalette.setColor(QPalette::ButtonText, blackish);
 		standardPalette.setColor(QPalette::Link, darkBlue);
 		standardPalette.setColor(QPalette::Highlight, Qt::white);
-		standardPalette.setColor(QPalette::HighlightedText, black);
+		standardPalette.setColor(QPalette::HighlightedText, blackish);
 
-		standardPalette.setColor(QPalette::Active, QPalette::Button, blue.darker());
+		standardPalette.setColor(QPalette::Active, QPalette::Button, blue);
 		standardPalette.setColor(QPalette::Disabled, QPalette::ButtonText, darkBlue);
 		standardPalette.setColor(QPalette::Disabled, QPalette::WindowText, darkBlue);
-		standardPalette.setColor(QPalette::Disabled, QPalette::Text, black);
+		standardPalette.setColor(QPalette::Disabled, QPalette::Text, darkBlue);
 		standardPalette.setColor(QPalette::Disabled, QPalette::Light, darkBlue);
 
 		qApp->setPalette(standardPalette);


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
I've given some love to dark themes, but doesn't mean light themes doesn't deserve it either. Making it better in contrast to make it more legible along with making it a bit more appealing.

- PCSX2
- Before:
![PCSX2Old](https://user-images.githubusercontent.com/24227051/210820495-2d618ac4-fa78-4d97-8d33-1e8d222d864a.png)
- After:
![PCSX2New](https://user-images.githubusercontent.com/24227051/210820543-0de7b18f-8378-4d34-8fc0-9adee4afdca4.png)

- Untouched Lagoon
- Before:
![LagoonOld](https://user-images.githubusercontent.com/24227051/210820613-efefbbcb-3d5b-4d94-af51-7b4be8dd2c59.png)
- Aft
![LagoonNew](https://user-images.githubusercontent.com/24227051/210820621-50d32054-ba20-4920-a9e3-4a132460283f.png)
er:

- Baby Pastel
- Before:
![BabyPastelOld](https://user-images.githubusercontent.com/24227051/210820656-e541dfb2-2c5a-45b6-83c5-9c001175b4fe.png)
- After:
![BabyPastelNew](https://user-images.githubusercontent.com/24227051/210820670-1f4e7ebb-626d-4324-acd5-af71dca20dc4.png)

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Don't want bad/worse themes and not be used at all
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test PCSX2 (Blue), Baby Pastel (Pink) and Untouched Lagoon (Green)