### PR TITLE
common: Remove pxUSE_SECURE_MALLOC.

### DIFF
--- a/common/AlignedMalloc.h
+++ b/common/AlignedMalloc.h
@@ -27,12 +27,6 @@
 #include <malloc.h>
 #endif
 
-// pxUSE_SECURE_MALLOC - enables bounds checking on scoped malloc allocations.
-
-#ifndef pxUSE_SECURE_MALLOC
-#define pxUSE_SECURE_MALLOC 0
-#endif
-
 // Implementation note: all known implementations of _aligned_free check the pointer for
 // NULL status (our implementation under GCC, and microsoft's under MSVC), so no need to
 // do it here.
@@ -148,25 +142,16 @@ public:
 
 	T* GetPtr(uint idx = 0) const
 	{
-#if pxUSE_SECURE_MALLOC
-		IndexBoundsAssumeDev("ScopedAlloc", idx, m_size);
-#endif
 		return &m_buffer[idx];
 	}
 
 	T& operator[](uint idx)
 	{
-#if pxUSE_SECURE_MALLOC
-		IndexBoundsAssumeDev("ScopedAlloc", idx, m_size);
-#endif
 		return m_buffer[idx];
 	}
 
 	const T& operator[](uint idx) const
 	{
-#if pxUSE_SECURE_MALLOC
-		IndexBoundsAssumeDev("ScopedAlloc", idx, m_size);
-#endif
 		return m_buffer[idx];
 	}
 };

--- a/common/SafeArray.h
+++ b/common/SafeArray.h
@@ -17,13 +17,6 @@
 
 #include "common/Pcsx2Defs.h"
 
-// pxUSE_SECURE_MALLOC - enables bounds checking on scoped malloc allocations.
-
-#ifndef pxUSE_SECURE_MALLOC
-#define pxUSE_SECURE_MALLOC 0
-#endif
-
-
 // Microsoft Windows only macro, useful for freeing out COM objects:
 #define safe_release(ptr) \
 	((void)((((ptr) != NULL) && ((ptr)->Release(), !!0)), (ptr) = NULL))


### PR DESCRIPTION
### Description of Changes
Removes the define pxUSE_SECURE_MALLOC, and any code that checks for it.

### Rationale behind Changes
If you try and enable that code, it doesn't compile, as the function being called doesn't exist. Less dead code is better.

### Suggested Testing Steps
Compile!
