### PR TITLE
GameDB: Remove Preload Frame Data for AC Last Raven

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -1143,7 +1143,6 @@ SCAJ-20143:
   name: "Armored Core - Last Raven"
   region: "NTSC-Unk"
   gsHWFixes:
-    preloadFrameData: 1 # Fixes black screen while in a mech.
     roundSprite: 2 # Fixes HUD artifacts.
 SCAJ-20144:
   name: "Zhuo Hou La 3"
@@ -18096,7 +18095,6 @@ SLES-53820:
   name: "Armored Core - Last Raven"
   region: "PAL-E"
   gsHWFixes:
-    preloadFrameData: 1 # Fixes black screen while in a mech.
     roundSprite: 2 # Fixes HUD artifacts.
 SLES-53821:
   name: "Radio Helicopter II"
@@ -37649,7 +37647,6 @@ SLPS-25462:
   name: "Armored Core - Last Raven"
   region: "NTSC-J"
   gsHWFixes:
-    preloadFrameData: 1 # Fixes black screen while in a mech.
     roundSprite: 2 # Fixes HUD artifacts.
   memcardFilters:
     - SLPS-25338
@@ -39778,7 +39775,6 @@ SLPS-73247:
   name: "Armored Core - Last Raven [PlayStation 2 The Best]"
   region: "NTSC-J"
   gsHWFixes:
-    preloadFrameData: 1 # Fixes black screen while in a mech.
     roundSprite: 2 # Fixes HUD artifacts.
   memcardFilters:
     - SLPS-25338
@@ -46355,7 +46351,6 @@ SLUS-21338:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    preloadFrameData: 1 # Fixes black screen while in a mech.
     roundSprite: 2 # Fixes HUD artifacts.
 SLUS-21339:
   name: "Puzzle Collection - Crosswords & More!"


### PR DESCRIPTION
### Description of Changes
Removed an unnecessary HW fix for Armored Core Last Raven.

### Rationale behind Changes
It just prevents the warning OSD when Preload Frame Data is disabled.

### Suggested Testing Steps
1. Open "Game Property"
2. Enable "Manual Hardware Fixes"
3. Disable "Preload Frame Data"
4. Start a new game
5. Start the AC Test to see if the black screen appears

I only tested SLPS-25462 (NTSC-J), so it's needed to test following games as well:
- SLPS-25730 (NTSC-J)
- SLPS-73247 (NTSC-J)
- SLUS-21338 (NTSC-U)
- SLES-53820 (PAL-E)
