### PR TITLE
GameDB: Syphon Filter: The Omega Strain PAL speed fix patch

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -3470,7 +3470,7 @@ SCES-52033:
         patch=0,EE,003953F8,word,48438000
         patch=0,EE,003735FC,word,4B06521B
         author=YukiXXL
-        //Speed Correction (25 FPS)
+        // Speed Correction (25 FPS)
         patch=1,EE,00175E1C,extended,24020019
 SCES-52042:
   name: "Formula One 2004"

--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -3471,7 +3471,7 @@ SCES-52033:
         patch=0,EE,003735FC,word,4B06521B
         author=YukiXXL
         // Speed Correction (25 FPS)
-        patch=1,EE,00175E1C,extended,24020019
+        patch=1,EE,00175E1C,extended,00000019
 SCES-52042:
   name: "Formula One 2004"
   region: "PAL-M6"

--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -3469,6 +3469,9 @@ SCES-52033:
         // Cop2 problems.
         patch=0,EE,003953F8,word,48438000
         patch=0,EE,003735FC,word,4B06521B
+        author=YukiXXL
+        //Speed Correction (25 FPS)
+        patch=1,EE,00175E1C,extended,24020019
 SCES-52042:
   name: "Formula One 2004"
   region: "PAL-M6"


### PR DESCRIPTION
### Description of Changes
Note: All the FPS that is gonna be mentioned below is meant to be the in-game/in-level FPS, not the menus nor the cutscenes,

The PAL version of Syphon Filter: The Omega Strain runs at 25 FPS on PS2, but on PCSX2 1.6, 1.7, ..etc (all versions) it runs mostly at 50 FPS and it's abnormally fast which is changing the whole game speed, and on PCSX2 you can reproduce the issue by rebooting the emulator, each time you reboot you might get the game at 25 FPS or at 50 FPS (game of luck) but mostly 50 and sometimes 25, also the NTSC-U and NTSC-K versions of the game run at 30 FPS so the PAL can't be this much faster so the correct speed by A) conclusion and B) testing on a real PS2 should be 25 FPS, this is a patch to fix the issue and make it run always at 25 FPS.

I posted a github issue about this going into more detail and i'll link it here #7496

### Rationale behind Changes
Fixes the game speed and makes it run just like it originally did on PS2.

### Suggested Testing Steps
To reproduce the problem and check the effectiveness of the patch:
-Boot the PAL version of Syphon Filter: The Omega Strain.
-Keep rebooting PCSX2 1.7 you'll notice sometimes the PAL version runs at 50 FPS (abnormal) and sometimes at 25 FPS (correct), but mostly it's 50 FPS so keep rebooting until you get 25 FPS without the patch.
-Compare the game speed on the 25 FPS session (without the patch) to the speed of the game when the submitted 25 FPS is applied, if they're similar then that means the patch is doing its job correctly and is not changing anything in the game incorrectly, all it's doing is restoring its correct speed.
-This is not like applying a 60 FPS patch, it's not an add-on it's a fix, the game inherently runs wrong on the emulator only (it runs correct on PS2) so this is a necessary fix.
