### PR TITLE
GS/Vulkan: Potential improvements to frame timing

### DIFF
--- a/common/Vulkan/Context.h
+++ b/common/Vulkan/Context.h
@@ -193,9 +193,7 @@ namespace Vulkan
 		// queued and executed. Do not wait for this fence before the buffer is executed.
 		u64 GetCurrentFenceCounter() const { return m_frame_resources[m_current_frame].fence_counter; }
 
-		void SubmitCommandBuffer(VkSemaphore wait_semaphore = VK_NULL_HANDLE,
-			VkSemaphore signal_semaphore = VK_NULL_HANDLE, VkSwapchainKHR present_swap_chain = VK_NULL_HANDLE,
-			uint32_t present_image_index = 0xFFFFFFFF, bool submit_on_thread = false);
+		void SubmitCommandBuffer(SwapChain* present_swap_chain = nullptr, bool submit_on_thread = false);
 		void MoveToNextCommandBuffer();
 
 		enum class WaitType
@@ -283,8 +281,8 @@ namespace Vulkan
 		void ScanForCommandBufferCompletion();
 		void WaitForCommandBufferCompletion(u32 index);
 
-		void DoSubmitCommandBuffer(u32 index, VkSemaphore wait_semaphore, VkSemaphore signal_semaphore, u32 spin_cycles);
-		void DoPresent(VkSemaphore wait_semaphore, VkSwapchainKHR present_swap_chain, uint32_t present_image_index);
+		void DoSubmitCommandBuffer(u32 index, SwapChain* present_swap_chain, u32 spin_cycles);
+		void DoPresent(SwapChain* present_swap_chain);
 		void WaitForPresentComplete(std::unique_lock<std::mutex>& lock);
 		void PresentThread();
 		void StartPresentThread();
@@ -384,11 +382,8 @@ namespace Vulkan
 
 		struct QueuedPresent
 		{
-			VkSemaphore wait_semaphore;
-			VkSemaphore signal_semaphore;
-			VkSwapchainKHR present_swap_chain;
+			SwapChain* swap_chain;
 			u32 command_buffer_index;
-			u32 present_image_index;
 			u32 spin_cycles;
 		};
 

--- a/common/Vulkan/SwapChain.cpp
+++ b/common/Vulkan/SwapChain.cpp
@@ -690,6 +690,7 @@ namespace Vulkan
 			vkDestroyFramebuffer(g_vulkan_context->GetDevice(), it.framebuffer, nullptr);
 		}
 		m_images.clear();
+		m_image_acquire_result.reset();
 	}
 
 	void SwapChain::DestroySwapChain()
@@ -705,6 +706,9 @@ namespace Vulkan
 
 	VkResult SwapChain::AcquireNextImage()
 	{
+		if (m_image_acquire_result.has_value())
+			return m_image_acquire_result.value();
+
 		if (!m_swap_chain)
 			return VK_ERROR_SURFACE_LOST_KHR;
 
@@ -723,7 +727,13 @@ namespace Vulkan
 			}
 		}
 
+		m_image_acquire_result = res;
 		return res;
+	}
+
+	void SwapChain::ReleaseCurrentImage()
+	{
+		m_image_acquire_result.reset();
 	}
 
 	bool SwapChain::ResizeSwapChain(u32 new_width, u32 new_height, float new_scale)

--- a/common/Vulkan/SwapChain.h
+++ b/common/Vulkan/SwapChain.h
@@ -20,6 +20,7 @@
 #include "common/Vulkan/Texture.h"
 #include "common/Vulkan/Loader.h"
 #include <memory>
+#include <optional>
 #include <vector>
 
 namespace Vulkan
@@ -74,6 +75,7 @@ namespace Vulkan
 		__fi VkSemaphore GetRenderingFinishedSemaphore() const { return m_images[m_current_image].rendering_finished_semaphore; }
 		__fi const VkSemaphore* GetRenderingFinishedSemaphorePtr() const { return &m_images[m_current_image].rendering_finished_semaphore; }
 		VkResult AcquireNextImage();
+		void ReleaseCurrentImage();
 
 		bool RecreateSurface(const WindowInfo& new_wi);
 		bool ResizeSwapChain(u32 new_width = 0, u32 new_height = 0, float new_scale = 1.0f);
@@ -122,5 +124,6 @@ namespace Vulkan
 		VkSwapchainKHR m_swap_chain = VK_NULL_HANDLE;
 		std::vector<SwapChainImage> m_images;
 		u32 m_current_image = 0;
+		std::optional<VkResult> m_image_acquire_result;
 	};
 } // namespace Vulkan

--- a/common/Vulkan/SwapChain.h
+++ b/common/Vulkan/SwapChain.h
@@ -67,8 +67,8 @@ namespace Vulkan
 		__fi VkFramebuffer GetCurrentFramebuffer() const { return m_images[m_current_image].framebuffer; }
 		__fi VkRenderPass GetLoadRenderPass() const { return m_load_render_pass; }
 		__fi VkRenderPass GetClearRenderPass() const { return m_clear_render_pass; }
-		__fi VkSemaphore GetImageAvailableSemaphore() const { return m_image_available_semaphore; }
-		__fi VkSemaphore GetRenderingFinishedSemaphore() const { return m_rendering_finished_semaphore; }
+		__fi VkSemaphore GetImageAvailableSemaphore() const { return m_images[m_current_image].available_semaphore; }
+		__fi VkSemaphore GetRenderingFinishedSemaphore() const { return m_images[m_current_image].rendering_finished_semaphore; }
 		VkResult AcquireNextImage();
 
 		bool RecreateSurface(const WindowInfo& new_wi);
@@ -96,14 +96,13 @@ namespace Vulkan
 
 		void DestroySurface();
 
-		bool CreateSemaphores();
-		void DestroySemaphores();
-
 		struct SwapChainImage
 		{
 			VkImage image;
 			Texture texture;
 			VkFramebuffer framebuffer;
+			VkSemaphore available_semaphore;
+			VkSemaphore rendering_finished_semaphore;
 		};
 
 		WindowInfo m_window_info;
@@ -115,9 +114,6 @@ namespace Vulkan
 
 		VkRenderPass m_load_render_pass = VK_NULL_HANDLE;
 		VkRenderPass m_clear_render_pass = VK_NULL_HANDLE;
-
-		VkSemaphore m_image_available_semaphore = VK_NULL_HANDLE;
-		VkSemaphore m_rendering_finished_semaphore = VK_NULL_HANDLE;
 
 		VkSwapchainKHR m_swap_chain = VK_NULL_HANDLE;
 		std::vector<SwapChainImage> m_images;

--- a/common/Vulkan/SwapChain.h
+++ b/common/Vulkan/SwapChain.h
@@ -55,11 +55,13 @@ namespace Vulkan
 		__fi VkFormat GetTextureFormat() const { return m_surface_format.format; }
 		__fi VkPresentModeKHR GetPreferredPresentMode() const { return m_preferred_present_mode; }
 		__fi VkSwapchainKHR GetSwapChain() const { return m_swap_chain; }
+		__fi const VkSwapchainKHR* GetSwapChainPtr() const { return &m_swap_chain; }
 		__fi const WindowInfo& GetWindowInfo() const { return m_window_info; }
 		__fi u32 GetWidth() const { return m_window_info.surface_width; }
 		__fi u32 GetHeight() const { return m_window_info.surface_height; }
 		__fi float GetScale() const { return m_window_info.surface_scale; }
 		__fi u32 GetCurrentImageIndex() const { return m_current_image; }
+		__fi const u32* GetCurrentImageIndexPtr() const { return &m_current_image; }
 		__fi u32 GetImageCount() const { return static_cast<u32>(m_images.size()); }
 		__fi VkImage GetCurrentImage() const { return m_images[m_current_image].image; }
 		__fi const Texture& GetCurrentTexture() const { return m_images[m_current_image].texture; }
@@ -68,7 +70,9 @@ namespace Vulkan
 		__fi VkRenderPass GetLoadRenderPass() const { return m_load_render_pass; }
 		__fi VkRenderPass GetClearRenderPass() const { return m_clear_render_pass; }
 		__fi VkSemaphore GetImageAvailableSemaphore() const { return m_images[m_current_image].available_semaphore; }
+		__fi const VkSemaphore* GetImageAvailableSemaphorePtr() const { return &m_images[m_current_image].available_semaphore; }
 		__fi VkSemaphore GetRenderingFinishedSemaphore() const { return m_images[m_current_image].rendering_finished_semaphore; }
+		__fi const VkSemaphore* GetRenderingFinishedSemaphorePtr() const { return &m_images[m_current_image].rendering_finished_semaphore; }
 		VkResult AcquireNextImage();
 
 		bool RecreateSurface(const WindowInfo& new_wi);

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -244,6 +244,7 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsDialog* dialog, QWidget* 
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.useBlitSwapChain, "EmuCore/GS", "UseBlitSwapChain", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.useDebugDevice, "EmuCore/GS", "UseDebugDevice", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.skipPresentingDuplicateFrames, "EmuCore/GS", "SkipDuplicateFrames", false);
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.threadedPresentation, "EmuCore/GS", "ThreadedPresentation", false);
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.overrideTextureBarriers, "EmuCore/GS", "OverrideTextureBarriers", -1, -1);
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.overrideGeometryShader, "EmuCore/GS", "OverrideGeometryShaders", -1, -1);
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.gsDumpCompression, "EmuCore/GS", "GSDumpCompression", static_cast<int>(GSDumpCompressionMethod::Zstandard));
@@ -622,6 +623,10 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsDialog* dialog, QWidget* 
 			tr("Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means "
 			   "the GPU has more time to complete it (this is NOT frame skipping). Can smooth our frame time fluctuations when the CPU/GPU are near maximum "
 			   "utilization, but makes frame pacing more inconsistent and can increase input lag."));
+
+		dialog->registerWidgetHelp(m_ui.threadedPresentation, tr("Threaded Presentation"), tr("Unchecked"),
+			tr("Presents frames on a worker thread, instead of on the GS thread. Can improve frame times on some systems, at the cost of "
+			   "potentially worse frame pacing. Only applies to the Vulkan renderer."));
 
 		dialog->registerWidgetHelp(m_ui.gsDownloadMode, tr("GS Download Mode"), tr("Accurate"),
 			tr("Skips synchronizing with the GS thread and host GPU for GS downloads. "

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
@@ -1693,6 +1693,13 @@
           </item>
           <item row="3" column="0" colspan="2">
            <layout class="QGridLayout" name="gridLayout_9">
+            <item row="0" column="1">
+             <widget class="QCheckBox" name="skipPresentingDuplicateFrames">
+              <property name="text">
+               <string>Skip Presenting Duplicate Frames</string>
+              </property>
+             </widget>
+            </item>
             <item row="0" column="0">
              <widget class="QCheckBox" name="useBlitSwapChain">
               <property name="text">
@@ -1700,10 +1707,10 @@
               </property>
              </widget>
             </item>
-            <item row="0" column="1">
-             <widget class="QCheckBox" name="skipPresentingDuplicateFrames">
+            <item row="1" column="0">
+             <widget class="QCheckBox" name="threadedPresentation">
               <property name="text">
-               <string>Skip Presenting Duplicate Frames</string>
+               <string>Threaded Presentation</string>
               </property>
              </widget>
             </item>

--- a/pcsx2/Frontend/FullscreenUI.cpp
+++ b/pcsx2/Frontend/FullscreenUI.cpp
@@ -3289,6 +3289,9 @@ void FullscreenUI::DrawGraphicsSettingsPage()
 	DrawToggleSetting(bsi, "Skip Presenting Duplicate Frames",
 		"Skips displaying frames that don't change in 25/30fps games. Can improve speed but increase input lag/make frame pacing worse.",
 		"EmuCore/GS", "SkipDuplicateFrames", false);
+	DrawToggleSetting(bsi, "Threaded Presentation",
+		"Presents frames on a worker thread, instead of on the GS thread. Can improve frame times on some systems, at the cost of "
+		"potentially worse frame pacing.", "EmuCore/GS", "ThreadedPresentation", false);
 	DrawIntListSetting(bsi, "Override Texture Barriers", "Forces texture barrier functionality to the specified value.", "EmuCore/GS",
 		"OverrideTextureBarriers", -1, s_generic_options, std::size(s_generic_options), -1);
 	DrawIntListSetting(bsi, "Override Geometry Shaders", "Forces geometry shader functionality to the specified value.", "EmuCore/GS",

--- a/pcsx2/Frontend/ImGuiOverlays.cpp
+++ b/pcsx2/Frontend/ImGuiOverlays.cpp
@@ -197,8 +197,8 @@ void ImGuiManager::DrawPerformanceOverlay()
 		if (GSConfig.OsdShowCPU)
 		{
 			text.clear();
-			fmt::format_to(std::back_inserter(text), "{:.2f}ms ({:.2f}ms worst)", PerformanceMetrics::GetAverageFrameTime(),
-				PerformanceMetrics::GetWorstFrameTime());
+			fmt::format_to(std::back_inserter(text), "{:.2f}ms | {:.2f}ms | {:.2f}ms", PerformanceMetrics::GetMinimumFrameTime(),
+				PerformanceMetrics::GetAverageFrameTime(), PerformanceMetrics::GetMaximumFrameTime());
 			DRAW_LINE(fixed_font, text.c_str(), IM_COL32(255, 255, 255, 255));
 
 			text.clear();

--- a/pcsx2/Frontend/VulkanHostDisplay.cpp
+++ b/pcsx2/Frontend/VulkanHostDisplay.cpp
@@ -353,6 +353,8 @@ bool VulkanHostDisplay::BeginPresent(bool frame_skip)
 	VkResult res = m_swap_chain->AcquireNextImage();
 	if (res != VK_SUCCESS)
 	{
+		m_swap_chain->ReleaseCurrentImage();
+
 		if (res == VK_SUBOPTIMAL_KHR || res == VK_ERROR_OUT_OF_DATE_KHR)
 		{
 			ResizeWindow(0, 0, m_window_info.surface_scale);

--- a/pcsx2/Frontend/VulkanHostDisplay.cpp
+++ b/pcsx2/Frontend/VulkanHostDisplay.cpp
@@ -411,8 +411,7 @@ void VulkanHostDisplay::EndPresent()
 	vkCmdEndRenderPass(g_vulkan_context->GetCurrentCommandBuffer());
 	m_swap_chain->GetCurrentTexture().TransitionToLayout(cmdbuffer, VK_IMAGE_LAYOUT_PRESENT_SRC_KHR);
 
-	g_vulkan_context->SubmitCommandBuffer(m_swap_chain->GetImageAvailableSemaphore(), m_swap_chain->GetRenderingFinishedSemaphore(),
-		m_swap_chain->GetSwapChain(), m_swap_chain->GetCurrentImageIndex(), !m_swap_chain->IsPresentModeSynchronizing());
+	g_vulkan_context->SubmitCommandBuffer(m_swap_chain.get(), !m_swap_chain->IsPresentModeSynchronizing());
 	g_vulkan_context->MoveToNextCommandBuffer();
 }
 

--- a/pcsx2/PerformanceMetrics.cpp
+++ b/pcsx2/PerformanceMetrics.cpp
@@ -33,10 +33,12 @@ static const float UPDATE_INTERVAL = 0.5f;
 static float s_vertical_frequency = 0.0f;
 static float s_fps = 0.0f;
 static float s_internal_fps = 0.0f;
-static float s_worst_frame_time = 0.0f;
+static float s_minimum_frame_time = 0.0f;
+static float s_minimum_frame_time_accumulator = 0.0f;
 static float s_average_frame_time = 0.0f;
 static float s_average_frame_time_accumulator = 0.0f;
-static float s_worst_frame_time_accumulator = 0.0f;
+static float s_maximum_frame_time = 0.0f;
+static float s_maximum_frame_time_accumulator = 0.0f;
 static u32 s_frames_since_last_update = 0;
 static u32 s_unskipped_frames_since_last_update = 0;
 static Common::Timer s_last_update_time;
@@ -86,8 +88,9 @@ void PerformanceMetrics::Clear()
 
 	s_fps = 0.0f;
 	s_internal_fps = 0.0f;
-	s_worst_frame_time = 0.0f;
+	s_minimum_frame_time = 0.0f;
 	s_average_frame_time = 0.0f;
+	s_maximum_frame_time = 0.0f;
 	s_internal_fps_method = PerformanceMetrics::InternalFPSMethod::None;
 
 	s_cpu_thread_usage = 0.0f;
@@ -112,8 +115,9 @@ void PerformanceMetrics::Reset()
 	s_unskipped_frames_since_last_update = 0;
 	s_gs_framebuffer_blits_since_last_update = 0;
 	s_gs_privileged_register_writes_since_last_update = 0;
+	s_minimum_frame_time_accumulator = 0.0f;
 	s_average_frame_time_accumulator = 0.0f;
-	s_worst_frame_time_accumulator = 0.0f;
+	s_maximum_frame_time_accumulator = 0.0f;
 
 	s_accumulated_gpu_time = 0.0f;
 	s_presents_since_last_update = 0;
@@ -135,8 +139,9 @@ void PerformanceMetrics::Update(bool gs_register_write, bool fb_blit, bool is_sk
 	if (!is_skipping_present)
 	{
 		const float frame_time = s_last_frame_time.GetTimeMillisecondsAndReset();
+		s_minimum_frame_time_accumulator = (s_minimum_frame_time_accumulator == 0.0f) ? frame_time : std::min(s_minimum_frame_time_accumulator, frame_time);
 		s_average_frame_time_accumulator += frame_time;
-		s_worst_frame_time_accumulator = std::max(s_worst_frame_time_accumulator, frame_time);
+		s_maximum_frame_time_accumulator = std::max(s_maximum_frame_time_accumulator, frame_time);
 		s_frame_time_history[s_frame_time_history_pos] = frame_time;
 		s_frame_time_history_pos = (s_frame_time_history_pos + 1) % NUM_FRAME_TIME_SAMPLES;
 		s_unskipped_frames_since_last_update++;
@@ -154,10 +159,9 @@ void PerformanceMetrics::Update(bool gs_register_write, bool fb_blit, bool is_sk
 		return;
 
 	s_last_update_time.ResetTo(now_ticks);
-	s_worst_frame_time = s_worst_frame_time_accumulator;
-	s_worst_frame_time_accumulator = 0.0f;
-	s_average_frame_time = s_average_frame_time_accumulator / static_cast<float>(s_unskipped_frames_since_last_update);
-	s_average_frame_time_accumulator = 0.0f;
+	s_minimum_frame_time = std::exchange(s_minimum_frame_time_accumulator, 0.0f);
+	s_average_frame_time = std::exchange(s_average_frame_time_accumulator, 0.0f) / static_cast<float>(s_unskipped_frames_since_last_update);
+	s_maximum_frame_time = std::exchange(s_maximum_frame_time_accumulator, 0.0f);
 	s_fps = static_cast<float>(s_frames_since_last_update) / time;
 	s_average_gpu_time = s_accumulated_gpu_time / static_cast<float>(s_unskipped_frames_since_last_update);
 	s_gpu_usage = s_accumulated_gpu_time / (time * 10.0f);
@@ -291,9 +295,14 @@ float PerformanceMetrics::GetAverageFrameTime()
 	return s_average_frame_time;
 }
 
-float PerformanceMetrics::GetWorstFrameTime()
+float PerformanceMetrics::GetMinimumFrameTime()
 {
-	return s_worst_frame_time;
+	return s_minimum_frame_time;
+}
+
+float PerformanceMetrics::GetMaximumFrameTime()
+{
+	return s_maximum_frame_time;
 }
 
 double PerformanceMetrics::GetCPUThreadUsage()

--- a/pcsx2/PerformanceMetrics.h
+++ b/pcsx2/PerformanceMetrics.h
@@ -54,7 +54,8 @@ namespace PerformanceMetrics
 	float GetInternalFPS();
 	float GetSpeed();
 	float GetAverageFrameTime();
-	float GetWorstFrameTime();
+	float GetMinimumFrameTime();
+	float GetMaximumFrameTime();
 
 	double GetCPUThreadUsage();
 	double GetCPUThreadAverageTime();


### PR DESCRIPTION
### Description of Changes

Avoid using the same semaphore for multiple images.

Grab the next swap chain image immediately after presenting, before going to sleep. Should reduce the next frame's present time.

Expose threaded presentation in the UI, apparently on some systems it improves things?

### Rationale behind Changes

Making Vulkan frame times less erratic.

### Suggested Testing Steps

Test new options, make sure stuff like window resizes/fullscreen toggles still work.
