### PR TITLE
GS: Make VK threaded presentation the default

### DIFF
--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -244,7 +244,7 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsDialog* dialog, QWidget* 
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.useBlitSwapChain, "EmuCore/GS", "UseBlitSwapChain", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.useDebugDevice, "EmuCore/GS", "UseDebugDevice", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.skipPresentingDuplicateFrames, "EmuCore/GS", "SkipDuplicateFrames", false);
-	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.threadedPresentation, "EmuCore/GS", "ThreadedPresentation", false);
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.threadedPresentation, "EmuCore/GS", "DisableThreadedPresentation", false);
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.overrideTextureBarriers, "EmuCore/GS", "OverrideTextureBarriers", -1, -1);
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.overrideGeometryShader, "EmuCore/GS", "OverrideGeometryShaders", -1, -1);
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.gsDumpCompression, "EmuCore/GS", "GSDumpCompression", static_cast<int>(GSDumpCompressionMethod::Zstandard));
@@ -624,9 +624,10 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsDialog* dialog, QWidget* 
 			   "the GPU has more time to complete it (this is NOT frame skipping). Can smooth our frame time fluctuations when the CPU/GPU are near maximum "
 			   "utilization, but makes frame pacing more inconsistent and can increase input lag."));
 
-		dialog->registerWidgetHelp(m_ui.threadedPresentation, tr("Threaded Presentation"), tr("Unchecked"),
-			tr("Presents frames on a worker thread, instead of on the GS thread. Can improve frame times on some systems, at the cost of "
-			   "potentially worse frame pacing. Only applies to the Vulkan renderer."));
+		dialog->registerWidgetHelp(m_ui.threadedPresentation, tr("Disable Threaded Presentation"), tr("Unchecked"),
+			tr("Presents frames on the main GS thread instead of a worker thread. Used for debugging frametime issues. "
+			   "Could reduce chance of missing a frame or reduce tearing at the expense of more erratic frame times. "
+			   "Only applies to the Vulkan renderer."));
 
 		dialog->registerWidgetHelp(m_ui.gsDownloadMode, tr("GS Download Mode"), tr("Accurate"),
 			tr("Skips synchronizing with the GS thread and host GPU for GS downloads. "

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
@@ -58,7 +58,7 @@
    <item>
     <widget class="QTabWidget" name="tabs">
      <property name="currentIndex">
-      <number>0</number>
+      <number>8</number>
      </property>
      <property name="documentMode">
       <bool>true</bool>
@@ -1710,7 +1710,7 @@
             <item row="1" column="0">
              <widget class="QCheckBox" name="threadedPresentation">
               <property name="text">
-               <string>Threaded Presentation</string>
+               <string>Disable Threaded Presentation</string>
               </property>
              </widget>
             </item>

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -626,7 +626,7 @@ struct Pcsx2Config
 					DisableShaderCache : 1,
 					DisableDualSourceBlend : 1,
 					DisableFramebufferFetch : 1,
-					ThreadedPresentation : 1,
+					DisableThreadedPresentation : 1,
 					SkipDuplicateFrames : 1,
 					OsdShowMessages : 1,
 					OsdShowSpeed : 1,

--- a/pcsx2/Frontend/FullscreenUI.cpp
+++ b/pcsx2/Frontend/FullscreenUI.cpp
@@ -3291,7 +3291,7 @@ void FullscreenUI::DrawGraphicsSettingsPage()
 		"EmuCore/GS", "SkipDuplicateFrames", false);
 	DrawToggleSetting(bsi, "Threaded Presentation",
 		"Presents frames on a worker thread, instead of on the GS thread. Can improve frame times on some systems, at the cost of "
-		"potentially worse frame pacing.", "EmuCore/GS", "ThreadedPresentation", false);
+		"potentially worse frame pacing.", "EmuCore/GS", "DisableThreadedPresentation", false);
 	DrawIntListSetting(bsi, "Override Texture Barriers", "Forces texture barrier functionality to the specified value.", "EmuCore/GS",
 		"OverrideTextureBarriers", -1, s_generic_options, std::size(s_generic_options), -1);
 	DrawIntListSetting(bsi, "Override Geometry Shaders", "Forces geometry shader functionality to the specified value.", "EmuCore/GS",

--- a/pcsx2/Frontend/VulkanHostDisplay.cpp
+++ b/pcsx2/Frontend/VulkanHostDisplay.cpp
@@ -279,7 +279,7 @@ bool VulkanHostDisplay::CreateDevice(const WindowInfo& wi, VsyncMode vsync)
 	WindowInfo local_wi(wi);
 	const bool debug_device = EmuConfig.GS.UseDebugDevice;
 	if (!Vulkan::Context::Create(EmuConfig.GS.Adapter, &local_wi, &m_swap_chain, GetPreferredPresentModeForVsyncMode(vsync),
-			EmuConfig.GS.ThreadedPresentation, debug_device, debug_device))
+			!EmuConfig.GS.DisableThreadedPresentation, debug_device, debug_device))
 	{
 		Console.Error("Failed to create Vulkan context");
 		m_window_info = {};

--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -682,7 +682,7 @@ void GSUpdateConfig(const Pcsx2Config::GSOptions& new_config)
 			GSConfig.UseDebugDevice != old_config.UseDebugDevice ||
 			GSConfig.UseBlitSwapChain != old_config.UseBlitSwapChain ||
 			GSConfig.DisableShaderCache != old_config.DisableShaderCache ||
-			GSConfig.ThreadedPresentation != old_config.ThreadedPresentation
+			GSConfig.DisableThreadedPresentation != old_config.DisableThreadedPresentation
 		);
 		if (!GSreopen(do_full_restart, old_config))
 			pxFailRel("Failed to do full GS reopen");

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -397,7 +397,7 @@ Pcsx2Config::GSOptions::GSOptions()
 	UseBlitSwapChain = false;
 	DisableShaderCache = false;
 	DisableFramebufferFetch = false;
-	ThreadedPresentation = false;
+	DisableThreadedPresentation = false;
 	SkipDuplicateFrames = false;
 	OsdShowMessages = true;
 	OsdShowSpeed = false;
@@ -544,7 +544,7 @@ bool Pcsx2Config::GSOptions::RestartOptionsAreEqual(const GSOptions& right) cons
 		   OpEqu(DisableShaderCache) &&
 		   OpEqu(DisableDualSourceBlend) &&
 		   OpEqu(DisableFramebufferFetch) &&
-		   OpEqu(ThreadedPresentation) &&
+		   OpEqu(DisableThreadedPresentation) &&
 		   OpEqu(OverrideTextureBarriers) &&
 		   OpEqu(OverrideGeometryShaders);
 }
@@ -599,7 +599,7 @@ void Pcsx2Config::GSOptions::LoadSave(SettingsWrapper& wrap)
 	GSSettingBoolEx(DisableShaderCache, "disable_shader_cache");
 	GSSettingBool(DisableDualSourceBlend);
 	GSSettingBool(DisableFramebufferFetch);
-	GSSettingBool(ThreadedPresentation);
+	GSSettingBool(DisableThreadedPresentation);
 	GSSettingBool(SkipDuplicateFrames);
 	GSSettingBool(OsdShowMessages);
 	GSSettingBool(OsdShowSpeed);


### PR DESCRIPTION
### Description of Changes
Makes the threaded presentation option the default for Vulkan

### Rationale behind Changes
No real disadvantage to doing this, seems to universally help, and it reduces frametime variance. Users who it hinders (which will be very, very few), can disable it.

### Suggested Testing Steps
check it defaults to being pretty flat in vulkan.
