### PR TITLE
GameDB: Add Disable Instant VU to Batman - Rise of Sin Tzu

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -13211,6 +13211,8 @@ SLES-51755:
 SLES-51756:
   name: "Batman - Rise of Sin Tzu"
   region: "PAL-M5"
+  speedHacks:
+    InstantVU1SpeedHack: 0 # Fixes hang on final boss.
 SLES-51757:
   name: "Dancing Stage Fever"
   region: "PAL-M5"
@@ -43486,6 +43488,8 @@ SLUS-20709:
   name: "Batman - Rise of Sin-Tzu"
   region: "NTSC-U"
   compat: 5
+  speedHacks:
+    InstantVU1SpeedHack: 0 # Fixes hang on final boss.
 SLUS-20710:
   name: "Onimusha - Blade Warriors"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
Adds gamedb entry of InstantVU1 being disabled for above game.

### Rationale behind Changes
Last boss hangs going in to his elevator kind of thing without this due to a timing problem, this seems to correct/avoid it.

### Suggested Testing Steps
Watch the CI, change has already been tested