### PR TITLE
GameDB: Fix Terminator 3 Spain region, add Buzz Brain of Spain

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -4620,6 +4620,9 @@ SCES-55386:
 SCES-55387:
   name: "Buzz! Deutschlands Superquiz"
   region: "PAL-G"
+SCES-55388:
+  name: "Buzz! Brain of Spain-Portugal"
+  region: "PAL-M2"
 SCES-55401:
   name: "SingStar Zingt met Disney"
   region: "PAL-NL"
@@ -13910,7 +13913,7 @@ SLES-52038:
   region: "PAL-G"
 SLES-52039:
   name: "Terminator 3 - Rise Of The Machines"
-  region: "PAL-IS"
+  region: "PAL-S"
 SLES-52041:
   name: "Detonator"
   region: "PAL-E"


### PR DESCRIPTION
### Description of Changes
- So I have found an actual Spanish copy of Terminator 3 - Rise of the Machines. When I did my previous research, I mostly focused on information legally locatable on the Internet (mostly pictures taken by news websites and second hand markets such as eBay). Turns out the region labelling is wrong (it's a Spanish-only disc), but the name is still correct? (the cover/manual are for Spanish and Portugal, while the game does not have a Spanish/Portuguese selector and the main menu reads the localized "La rebelión de las máquinas" name). The Italian release has a separate disc elsewhere.
 - Adding Buzz!: ¿Qué sabes de tu país? (Buzz! Brain of... from Spain/Portugal).

### Rationale behind Changes
Polishing the GameDB to the nth degree.

### Suggested Testing Steps
Find those games and see that the names are now adequate.
