### PR TITLE
SPU2: Purge interpolation options

### DIFF
--- a/pcsx2-qt/Settings/AudioSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/AudioSettingsWidget.cpp
@@ -60,7 +60,6 @@ AudioSettingsWidget::AudioSettingsWidget(SettingsDialog* dialog, QWidget* parent
 
 	m_ui.setupUi(this);
 
-	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.interpolation, "SPU2/Mixing", "Interpolation", DEFAULT_INTERPOLATION_MODE);
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.syncMode, "SPU2/Output", "SynchMode", DEFAULT_SYNCHRONIZATION_MODE);
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.expansionMode, "SPU2/Output", "SpeakerConfiguration", DEFAULT_EXPANSION_MODE);
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.dplLevel, "SPU2/Output", "DplDecodingLevel", DEFAULT_DPL_DECODING_LEVEL);
@@ -109,8 +108,6 @@ AudioSettingsWidget::AudioSettingsWidget(SettingsDialog* dialog, QWidget* parent
 
 	onMinimalOutputLatencyStateChanged();
 	updateLatencyLabels();
-
-	dialog->registerWidgetHelp(m_ui.interpolation, tr("Interpolation"), tr("Gaussian (PS2-like / great sound)"), tr(""));
 
 	dialog->registerWidgetHelp(m_ui.syncMode, tr("Synchronization"), tr("TimeStretch (Recommended)"), tr(""));
 

--- a/pcsx2-qt/Settings/AudioSettingsWidget.ui
+++ b/pcsx2-qt/Settings/AudioSettingsWidget.ui
@@ -268,52 +268,11 @@
       <item row="0" column="0">
        <widget class="QLabel" name="label">
         <property name="text">
-         <string>Interpolation:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QComboBox" name="interpolation">
-        <item>
-         <property name="text">
-          <string>Nearest (Fastest / worst quality)</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Linear (Simple / okay sound)</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Cubic (Fake highs / okay sound)</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Hermite (Better highs / okay sound)</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Catmull-Rom (PS2-like / good sound)</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Gaussian (PS2-like / great sound)</string>
-         </property>
-        </item>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_2">
-        <property name="text">
          <string>Synchronization:</string>
         </property>
        </widget>
       </item>
-      <item row="1" column="1">
+      <item row="0" column="1">
        <widget class="QComboBox" name="syncMode">
         <item>
          <property name="text">
@@ -332,14 +291,14 @@
         </item>
        </widget>
       </item>
-      <item row="2" column="0">
+      <item row="1" column="0">
        <widget class="QLabel" name="label_3">
         <property name="text">
          <string>Expansion:</string>
         </property>
        </widget>
       </item>
-      <item row="2" column="1">
+      <item row="1" column="1">
        <widget class="QComboBox" name="expansionMode">
         <item>
          <property name="text">

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -778,16 +778,6 @@ struct Pcsx2Config
 
 	struct SPU2Options
 	{
-		enum class InterpolationMode
-		{
-			Nearest,
-			Linear,
-			Cubic,
-			Hermite,
-			CatmullRom,
-			Gaussian
-		};
-
 		enum class SynchronizationMode
 		{
 			TimeStretch,
@@ -828,7 +818,6 @@ struct Pcsx2Config
 			VisualDebugEnabled : 1;
 		BITFIELD_END
 
-		InterpolationMode Interpolation = InterpolationMode::Gaussian;
 		SynchronizationMode SynchMode = SynchronizationMode::TimeStretch;
 
 		s32 FinalVolume = 100;
@@ -853,7 +842,6 @@ struct Pcsx2Config
 		{
 			return OpEqu(bitset) &&
 
-				OpEqu(Interpolation) &&
 				OpEqu(SynchMode) &&
 
 				OpEqu(FinalVolume) &&

--- a/pcsx2/Frontend/FullscreenUI.cpp
+++ b/pcsx2/Frontend/FullscreenUI.cpp
@@ -3362,9 +3362,6 @@ void FullscreenUI::DrawAudioSettingsPage()
 		"SPU2/Mixing", "FinalVolume", 100, 0, 200, "%d%%");
 
 	MenuHeading("Mixing Settings");
-	DrawIntListSetting(bsi, ICON_FA_MUSIC " Interpolation Mode", "Determines how ADPCM samples are interpolated to the target pitch.",
-		"SPU2/Mixing", "Interpolation", static_cast<int>(Pcsx2Config::SPU2Options::InterpolationMode::Gaussian), interpolation_modes,
-		std::size(interpolation_modes));
 	DrawIntListSetting(bsi, ICON_FA_RULER " Synchronization Mode", "Changes when SPU samples are generated relative to system emulation.",
 		"SPU2/Output", "SynchMode", static_cast<int>(Pcsx2Config::SPU2Options::SynchronizationMode::TimeStretch), synchronization_modes,
 		std::size(synchronization_modes));

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -818,7 +818,6 @@ void Pcsx2Config::SPU2Options::LoadSave(SettingsWrapper& wrap)
 	{
 		SettingsWrapSection("SPU2/Mixing");
 
-		Interpolation = static_cast<InterpolationMode>(wrap.EntryBitfield(CURRENT_SETTINGS_SECTION, "Interpolation", static_cast<int>(Interpolation), static_cast<int>(Interpolation)));
 		SettingsWrapEntry(FinalVolume);
 	}
 

--- a/pcsx2/SPU2/Mixer.cpp
+++ b/pcsx2/SPU2/Mixer.cpp
@@ -337,7 +337,6 @@ static void __forceinline UpdatePitch(uint coreidx, uint voiceidx)
 	vc.SP += pitch;
 }
 
-
 static __forceinline void CalculateADSR(V_Core& thiscore, uint voiceidx)
 {
 	V_Voice& vc(thiscore.Voices[voiceidx]);
@@ -361,7 +360,6 @@ static __forceinline void CalculateADSR(V_Core& thiscore, uint voiceidx)
 	pxAssume(vc.ADSR.Value >= 0); // ADSR should never be negative...
 }
 
-
 __forceinline static s32 GaussianInterpolate(s32 pv4, s32 pv3, s32 pv2, s32 pv1, s32 i)
 {
 	s32 out = 0;
@@ -373,93 +371,14 @@ __forceinline static s32 GaussianInterpolate(s32 pv4, s32 pv3, s32 pv2, s32 pv1,
 	return out;
 }
 
-/*
-   Tension: 65535 is high, 32768 is normal, 0 is low
-*/
-
-template <s32 i_tension>
-__forceinline static s32 HermiteInterpolate(
-	s32 y0, // 16.0
-	s32 y1, // 16.0
-	s32 y2, // 16.0
-	s32 y3, // 16.0
-	s32 mu  //  0.12
-)
-{
-	s32 m00 = ((y1 - y0) * i_tension) >> 16; // 16.0
-	s32 m01 = ((y2 - y1) * i_tension) >> 16; // 16.0
-	s32 m0 = m00 + m01;
-
-	s32 m10 = ((y2 - y1) * i_tension) >> 16; // 16.0
-	s32 m11 = ((y3 - y2) * i_tension) >> 16; // 16.0
-	s32 m1 = m10 + m11;
-
-	s32 val = ((2 * y1 + m0 + m1 - 2 * y2) * mu) >> 12;       // 16.0
-	val = ((val - 3 * y1 - 2 * m0 - m1 + 3 * y2) * mu) >> 12; // 16.0
-	val = ((val + m0) * mu) >> 12;                            // 16.0
-
-	return (val + (y1));
-}
-
-__forceinline static s32 CatmullRomInterpolate(
-	s32 y0, // 16.0
-	s32 y1, // 16.0
-	s32 y2, // 16.0
-	s32 y3, // 16.0
-	s32 mu  //  0.12
-)
-{
-	//q(t) = 0.5 *(    	(2 * P1) +
-	//	(-P0 + P2) * t +
-	//	(2*P0 - 5*P1 + 4*P2 - P3) * t2 +
-	//	(-P0 + 3*P1- 3*P2 + P3) * t3)
-
-	s32 a3 = (-y0 + 3 * y1 - 3 * y2 + y3);
-	s32 a2 = (2 * y0 - 5 * y1 + 4 * y2 - y3);
-	s32 a1 = (-y0 + y2);
-	s32 a0 = (2 * y1);
-
-	s32 val = ((a3)*mu) >> 12;
-	val = ((a2 + val) * mu) >> 12;
-	val = ((a1 + val) * mu) >> 12;
-
-	return (a0 + val) >> 1;
-}
-
-__forceinline static s32 CubicInterpolate(
-	s32 y0, // 16.0
-	s32 y1, // 16.0
-	s32 y2, // 16.0
-	s32 y3, // 16.0
-	s32 mu  //  0.12
-)
-{
-	const s32 a0 = y3 - y2 - y0 + y1;
-	const s32 a1 = y0 - y1 - a0;
-	const s32 a2 = y2 - y0;
-
-	s32 val = ((a0)*mu) >> 12;
-	val = ((val + a1) * mu) >> 12;
-	val = ((val + a2) * mu) >> 12;
-
-	return (val + y1);
-}
-
-// Returns a 16 bit result in Value.
-// Uses standard template-style optimization techniques to statically generate five different
-// versions of this function (one for each type of interpolation).
-template <int InterpType>
 static __forceinline s32 GetVoiceValues(V_Core& thiscore, uint voiceidx)
 {
 	V_Voice& vc(thiscore.Voices[voiceidx]);
 
 	while (vc.SP >= 0)
 	{
-		if (InterpType >= 2)
-		{
-			vc.PV4 = vc.PV3;
-			vc.PV3 = vc.PV2;
-		}
+		vc.PV4 = vc.PV3;
+		vc.PV3 = vc.PV2;
 		vc.PV2 = vc.PV1;
 		vc.PV1 = GetNextDataBuffered(thiscore, voiceidx);
 		vc.SP -= 0x1000;
@@ -467,26 +386,7 @@ static __forceinline s32 GetVoiceValues(V_Core& thiscore, uint voiceidx)
 
 	const s32 mu = vc.SP + 0x1000;
 
-	switch (InterpType)
-	{
-		case 0:
-			return vc.PV1;
-		case 1:
-			return (vc.PV1) - (((vc.PV2 - vc.PV1) * mu) >> 12);
-
-		case 2:
-			return CubicInterpolate(vc.PV4, vc.PV3, vc.PV2, vc.PV1, mu);
-		case 3:
-			return HermiteInterpolate<16384>(vc.PV4, vc.PV3, vc.PV2, vc.PV1, mu);
-		case 4:
-			return CatmullRomInterpolate(vc.PV4, vc.PV3, vc.PV2, vc.PV1, mu);
-		case 5:
-			return GaussianInterpolate(vc.PV4, vc.PV3, vc.PV2, vc.PV1, (mu & 0x0ff0) >> 4);
-
-			jNO_DEFAULT;
-	}
-
-	return 0; // technically unreachable!
+	return GaussianInterpolate(vc.PV4, vc.PV3, vc.PV2, vc.PV1, (mu & 0x0ff0) >> 4);
 }
 
 // This is Dr. Hell's noise algorithm as implemented in pcsxr
@@ -588,34 +488,7 @@ static __forceinline StereoOut32 MixVoice(uint coreidx, uint voiceidx)
 		if (vc.Noise)
 			Value = GetNoiseValues(thiscore);
 		else
-		{
-			// Optimization : Forceinline'd Templated Dispatch Table.  Any halfwit compiler will
-			// turn this into a clever jump dispatch table (no call/rets, no compares, uber-efficient!)
-
-			switch (EmuConfig.SPU2.Interpolation)
-			{
-				case Pcsx2Config::SPU2Options::InterpolationMode::Nearest:
-					Value = GetVoiceValues<0>(thiscore, voiceidx);
-					break;
-				case Pcsx2Config::SPU2Options::InterpolationMode::Linear:
-					Value = GetVoiceValues<1>(thiscore, voiceidx);
-					break;
-				case Pcsx2Config::SPU2Options::InterpolationMode::Cubic:
-					Value = GetVoiceValues<2>(thiscore, voiceidx);
-					break;
-				case Pcsx2Config::SPU2Options::InterpolationMode::Hermite:
-					Value = GetVoiceValues<3>(thiscore, voiceidx);
-					break;
-				case Pcsx2Config::SPU2Options::InterpolationMode::CatmullRom:
-					Value = GetVoiceValues<4>(thiscore, voiceidx);
-					break;
-				case Pcsx2Config::SPU2Options::InterpolationMode::Gaussian:
-					Value = GetVoiceValues<5>(thiscore, voiceidx);
-					break;
-
-					jNO_DEFAULT;
-			}
-		}
+			Value = GetVoiceValues(thiscore, voiceidx);
 
 		// Update and Apply ADSR  (applies to normal and noise sources)
 		//


### PR DESCRIPTION
### Description of Changes
Removes the options menu for interpolation as all but gaussian will be removed.

### Rationale behind Changes
Having a selection box for just one option is a bit silly I'll see if I can remove the actual code for it later on in another PR as that part frightens me more than this.

### Suggested Testing Steps
Make sure the CI doesn't explode and that audio still works.
