### PR TITLE
VU: Fix out of bounds check for Q clamp

### DIFF
--- a/pcsx2/x86/microVU_IR.h
+++ b/pcsx2/x86/microVU_IR.h
@@ -598,7 +598,7 @@ public:
 
 	bool checkVFClamp(int regId)
 	{
-		if ((xmmMap[regId].VFreg == 33 && !EmuConfig.Gamefixes.IbitHack) || xmmMap[regId].isZero)
+		if (regId != xmmPQ.Id && ((xmmMap[regId].VFreg == 33 && !EmuConfig.Gamefixes.IbitHack) || xmmMap[regId].isZero))
 			return false;
 		else
 			return true;


### PR DESCRIPTION
### Description of Changes
Fixes out of bounds check when clamping Q register on the VU's

### Rationale behind Changes
Out of bounds undefined behaviour is bad, mkay.

### Suggested Testing Steps
Watch CI
