### PR TITLE
GS: Separate Cd output from Cs blend cases

### DIFF
--- a/pcsx2/GS/GSRegs.h
+++ b/pcsx2/GS/GSRegs.h
@@ -537,9 +537,13 @@ REG64_(GIFReg, ALPHA)
 	u8 _PAD2[3];
 REG_END2
 	// opaque => output will be Cs/As/zero
-	__forceinline bool IsOpaque() const { return ((A == B || (C == 2 && FIX == 0)) && D == 0) || (A == 0 && B == D && C == 2 && FIX == 0x80) || (C == 2 && D != 1 && FIX == 0x00); }
-	__forceinline bool IsOpaque(int amin, int amax) const { return ((A == B || amax == 0) && D == 0) || (A == 0 && B == D && amin == 0x80 && amax == 0x80) || (C == 2 && D != 1 && FIX == 0x00); }
-	__forceinline bool IsCd() { return (A == B) && (D == 1); }
+	__forceinline bool IsOpaque() const { return ((A == B || (C == 2 && FIX == 0)) && D == 0) || (A == 0 && B == D && C == 2 && FIX == 0x80); }
+	__forceinline bool IsOpaque(int amin, int amax) const { return ((A == B || amax == 0) && D == 0) || (A == 0 && B == D && amin == 0x80 && amax == 0x80); }
+	__forceinline bool IsCd() const { return (A == B) && (D == 1); }
+
+	// output will be Cd, Cs is discarded
+	__forceinline bool IsCdOutput() const { return (C == 2 && D != 1 && FIX == 0x00); }
+
 	__forceinline bool IsBlack() const { return ((C == 2 && FIX == 0) || (A == 2 && A == B)) && D == 2; }
 REG_END2
 

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -1692,7 +1692,7 @@ void GSRendererHW::Draw()
 	{
 		// Constant Direct Write without texture/test/blending (aka a GS mem clear)
 		if ((m_vt.m_primclass == GS_SPRITE_CLASS) && !PRIM->TME // Direct write
-			&& (!PRIM->ABE || IsOpaque()) // No transparency
+			&& (!PRIM->ABE || IsOpaque() || m_context->ALPHA.IsCdOutput()) // No transparency
 			&& (m_context->FRAME.FBMSK == 0) // no color mask
 			&& !m_context->TEST.ATE // no alpha test
 			&& (!m_context->TEST.ZTE || m_context->TEST.ZTST == ZTST_ALWAYS) // no depth test
@@ -1844,7 +1844,7 @@ void GSRendererHW::Draw()
 	{
 		// Constant Direct Write without texture/test/blending (aka a GS mem clear)
 		if ((m_vt.m_primclass == GS_SPRITE_CLASS) && !PRIM->TME // Direct write
-				&& (!PRIM->ABE || IsOpaque()) // No transparency
+				&& (!PRIM->ABE || IsOpaque() || m_context->ALPHA.IsCdOutput()) // No transparency
 				&& (m_context->FRAME.FBMSK == 0) // no color mask
 				&& !m_context->TEST.ATE // no alpha test
 				&& (!m_context->TEST.ZTE || m_context->TEST.ZTST == ZTST_ALWAYS) // no depth test


### PR DESCRIPTION
### Description of Changes

Fixes white screen inbetween logos in FFX.

It uses the following blend:
```
ALPHA
    A:1
    B:2
    C:2
    D:2
    FIX:0
    => (Cd - 0) * Af + 0
```

Which was one of the cases we optimized in #7539 - iirc Burnout 3 used it. But it was confusing the software renderer (causing it to use a block fill instead of a proper render, which tosed out Cd), I should have noted the comment above IsOpaque() that says that only Cs/As/0 is used.

So, handle the Cd case separately, and only for hardware.

In theory we could replace it with an fbmsk, but that would assume that the RGB mask was all zeros to begin with, otherwise there _would_ be a side-effect.

### Rationale behind Changes

Fixing regressions.

### Suggested Testing Steps

Test booting FFX in software, make sure there's no white flicker between logos.
