### PR TITLE
x86/microVU: Don't assert clearing macro mode temps

### DIFF
--- a/pcsx2/x86/microVU_IR.h
+++ b/pcsx2/x86/microVU_IR.h
@@ -881,7 +881,7 @@ public:
 		{
 			if (x86regs[regId].inuse && x86regs[regId].type == X86TYPE_VIREG)
 			{
-				pxAssert(x86regs[regId].reg == static_cast<u8>(clear.VIreg));
+				pxAssert(x86regs[regId].reg == clear.VIreg);
 				_freeX86regWithoutWriteback(regId);
 			}
 		}


### PR DESCRIPTION
### Description of Changes

`x86regs[n].reg` is signed now.

### Rationale behind Changes

Regression from #7769.

### Suggested Testing Steps

Difficult to test since release builds don't have assertions, but FFX no longer trips the assert in a debug build.
