### PR TITLE
GameDB: Correct Blood Omen 2 name

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -11068,7 +11068,7 @@ SLES-50770:
   name: "Mad Maestro!"
   region: "PAL-M4"
 SLES-50771:
-  name: "Blood Omen 2 - Legend of Kain"
+  name: "Blood Omen 2 - The Legacy of Kain"
   region: "PAL-E"
   compat: 5
   roundModes:
@@ -11076,7 +11076,7 @@ SLES-50771:
   gsHWFixes:
     mipmap: 1 # Fixes glitching textures.
 SLES-50772:
-  name: "Blood Omen 2 - Legend of Kain"
+  name: "Blood Omen 2 - The Legacy of Kain"
   region: "PAL-M3"
   roundModes:
     eeRoundMode: 0 # Fixes pathing.
@@ -11216,7 +11216,7 @@ SLES-50814:
   region: "PAL-G"
   compat: 5
 SLES-50815:
-  name: "Blood Omen 2 - Legend of Kain"
+  name: "Blood Omen 2 - The Legacy of Kain"
   region: "PAL-G"
   roundModes:
     eeRoundMode: 0 # Fixes pathing.
@@ -40489,7 +40489,7 @@ SLUS-20021:
   region: "NTSC-U"
   compat: 5
 SLUS-20024:
-  name: "Legacy of Kain - Blood Omen 2"
+  name: "Blood Omen 2 - The Legacy of Kain"
   region: "NTSC-U"
   compat: 5
   roundModes:


### PR DESCRIPTION
### Description of Changes
Corrects Blood Omen 2s name to properly say "The Legacy of Kain".

### Rationale behind Changes
Name correct more gooder.

### Suggested Testing Steps
Make sure CI is happy.
