### PR TITLE
GS/HW: Adjust Barnyard fix for Jurassic Park and Nicktoons Unite

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -5308,7 +5308,7 @@ SCKA-20096:
     halfPixelOffset: 2 # Fix text and post blur.
     mipmap: 2 # Base mip level isn't always used.
     autoFlush: 1 # Needed for recursive mipmap rendering.
-    getSkipCount: "GSC_Barnyard" # Render mipmaps on the CPU.
+    getSkipCount: "GSC_BlueTongueGames" # Render mipmaps on the CPU.
 SCKA-20098:
   name: "Nickelodeon SpongeBob SquarePants - Creature from the Krusty Krab"
   region: "NTSC-K"
@@ -12484,9 +12484,11 @@ SLES-51354:
   region: "PAL-M5"
   compat: 5
   gsHWFixes:
-    autoFlush: 1 # Fixes glows.
-    mipmap: 1 # Better characters and environment but has a texture cache issue that makes it worse.
+    autoFlush: 1 # Fixes glows. Also needed for recursive mipmap rendering.
+    mipmap: 2 # Better characters and environment but has a texture cache issue that makes it worse.
+    trilinearFiltering: 1 # Using mipmaps, so may as well.
     textureInsideRT: 1 # Fixes rainbow lighting for some areas.
+    getSkipCount: "GSC_BlueTongueGames" # Mipmap rendering on CPU.
 SLES-51355:
   name: "Big Mutha Truckers"
   region: "PAL-M5"
@@ -17729,9 +17731,11 @@ SLES-53634:
   name: "Nicktoons Unite!"
   region: "PAL-A"
   gsHWFixes:
-    autoFlush: 1 # Fixes glows.
-    mipmap: 1 # Better characters and environment but has a texture cache issue that makes it worse.
-    textureInsideRT: 1 # Fixes rainbow lighting for lamps, computer and other areas.
+    autoFlush: 1 # Fixes glows. Also needed for recursive mipmap rendering.
+    mipmap: 2 # Better characters and environment but has a texture cache issue that makes it worse.
+    trilinearFiltering: 1 # Using mipmaps, so may as well.
+    textureInsideRT: 1 # Fixes rainbow lighting for some areas.
+    getSkipCount: "GSC_BlueTongueGames" # Mipmap rendering on CPU.
 SLES-53635:
   name: "NASCAR '06 - Total Team Control"
   region: "PAL-E"
@@ -19600,7 +19604,7 @@ SLES-54376:
     halfPixelOffset: 2 # Fix text and post blur.
     mipmap: 2 # Base mip level isn't always used.
     autoFlush: 1 # Needed for recursive mipmap rendering.
-    getSkipCount: "GSC_Barnyard" # Render mipmaps on the CPU.
+    getSkipCount: "GSC_BlueTongueGames" # Render mipmaps on the CPU.
 SLES-54377:
   name: "Barnyard"
   region: "PAL-G"
@@ -19608,7 +19612,7 @@ SLES-54377:
     halfPixelOffset: 2 # Fix text and post blur.
     mipmap: 2 # Base mip level isn't always used.
     autoFlush: 1 # Needed for recursive mipmap rendering.
-    getSkipCount: "GSC_Barnyard" # Render mipmaps on the CPU.
+    getSkipCount: "GSC_BlueTongueGames" # Render mipmaps on the CPU.
 SLES-54378:
   name: "Barnyard"
   region: "PAL-M4"
@@ -19616,7 +19620,7 @@ SLES-54378:
     halfPixelOffset: 2 # Fix text and post blur.
     mipmap: 2 # Base mip level isn't always used.
     autoFlush: 1 # Needed for recursive mipmap rendering.
-    getSkipCount: "GSC_Barnyard" # Render mipmaps on the CPU.
+    getSkipCount: "GSC_BlueTongueGames" # Render mipmaps on the CPU.
 SLES-54379:
   name: "NFL Street 3"
   region: "PAL-E"
@@ -25963,6 +25967,12 @@ SLPM-62345:
 SLPM-62346:
   name: "Keiei Simulation - Jurassic Park [Konami the Best]"
   region: "NTSC-J"
+  gsHWFixes:
+    autoFlush: 1 # Fixes glows. Also needed for recursive mipmap rendering.
+    mipmap: 2 # Better characters and environment but has a texture cache issue that makes it worse.
+    trilinearFiltering: 1 # Using mipmaps, so may as well.
+    textureInsideRT: 1 # Fixes rainbow lighting for some areas.
+    getSkipCount: "GSC_BlueTongueGames" # Mipmap rendering on CPU.
 SLPM-62348:
   name: "Mechsmith, The - Rum"
   region: "NTSC-J"
@@ -26439,9 +26449,11 @@ SLPM-62512:
   name: "Keiei Simulation - Jurassic Park [Konami The Best]"
   region: "NTSC-J"
   gsHWFixes:
-    autoFlush: 1 # Fixes glows.
-    mipmap: 1 # Better characters and environment but has a texture cache issue that makes it worse.
+    autoFlush: 1 # Fixes glows. Also needed for recursive mipmap rendering.
+    mipmap: 2 # Better characters and environment but has a texture cache issue that makes it worse.
+    trilinearFiltering: 1 # Using mipmaps, so may as well.
     textureInsideRT: 1 # Fixes rainbow lighting for some areas.
+    getSkipCount: "GSC_BlueTongueGames" # Mipmap rendering on CPU.
 SLPM-62513:
   name: "Harry Potter and the Chamber of Secrets [EA Best Hits]"
   region: "NTSC-J"
@@ -41929,9 +41941,11 @@ SLUS-20380:
   name: "Jurassic Park - Operation Genesis"
   region: "NTSC-U"
   gsHWFixes:
-    autoFlush: 1 # Fixes glows.
-    mipmap: 1 # Better characters and environment but has a texture cache issue that makes it worse.
+    autoFlush: 1 # Fixes glows. Also needed for recursive mipmap rendering.
+    mipmap: 2 # Better characters and environment but has a texture cache issue that makes it worse.
+    trilinearFiltering: 1 # Using mipmaps, so may as well.
     textureInsideRT: 1 # Fixes rainbow lighting for some areas.
+    getSkipCount: "GSC_BlueTongueGames" # Mipmap rendering on CPU.
 SLUS-20381:
   name: "MX SuperFly"
   region: "NTSC-U"
@@ -46458,7 +46472,7 @@ SLUS-21277:
     halfPixelOffset: 2 # Fix text and post blur.
     mipmap: 2 # Base mip level isn't always used.
     autoFlush: 1 # Needed for recursive mipmap rendering.
-    getSkipCount: "GSC_Barnyard" # Render mipmaps on the CPU.
+    getSkipCount: "GSC_BlueTongueGames" # Render mipmaps on the CPU.
 SLUS-21278:
   name: "SSX on Tour"
   region: "NTSC-U"
@@ -46489,9 +46503,11 @@ SLUS-21284:
   name: "Nicktoons Unite!"
   region: "NTSC-U"
   gsHWFixes:
-    autoFlush: 1 # Fixes glows.
-    mipmap: 1 # Better characters and environment but has a texture cache issue that makes it worse.
-    textureInsideRT: 1 # Fixes rainbow lighting for lamps, computer and other areas.
+    autoFlush: 1 # Fixes glows. Also needed for recursive mipmap rendering.
+    mipmap: 2 # Better characters and environment but has a texture cache issue that makes it worse.
+    trilinearFiltering: 1 # Using mipmaps, so may as well.
+    textureInsideRT: 1 # Fixes rainbow lighting for some areas.
+    getSkipCount: "GSC_BlueTongueGames" # Mipmap rendering on CPU.
 SLUS-21285:
   name: "Ultimate Spider-Man [Limited Edition]"
   region: "NTSC-U"

--- a/pcsx2/GS/Renderers/HW/GSHwHack.cpp
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.cpp
@@ -802,23 +802,24 @@ bool GSHwHack::GSC_XenosagaE3(GSRendererHW& r, const GSFrameInfo& fi, int& skip)
 	return true;
 }
 
-bool GSHwHack::GSC_Barnyard(GSRendererHW& r, const GSFrameInfo& fi, int& skip)
+bool GSHwHack::GSC_BlueTongueGames(GSRendererHW& r, const GSFrameInfo& fi, int& skip)
 {
 	GSDrawingContext* context = r.m_context;
 
 	// Whoever wrote this was kinda nuts. They draw a stipple/dither pattern to a framebuffer, then reuse that as
 	// the depth buffer. Textures are then drawn repeatedly on top of one another, each with a slight offset.
 	// Depth testing is enabled, and that determines which pixels make it into the final texture. Kinda like an
-	// attempt at anti-aliasing or adding more detail to the textures?
+	// attempt at anti-aliasing or adding more detail to the textures? Or, a way to get more colours..
 
 	// The size of these textures varies quite a bit. 16-bit, 24-bit and 32-bit formats are all used.
 	// The ones we need to take care of here, are the textures which use mipmaps. Those get drawn recursively, mip
 	// levels are then drawn to the right of the base texture. And we can't handle that in the texture cache. So
-	// we'll limit to 16/32-bit, going up to 320 wide. Some font textures are 1024x1024, we don't really want to
-	// be rasterizing that on the CPU.
+	// we'll limit to 16/24/32-bit, going up to 320 wide. Some font textures are 1024x1024, we don't really want
+	// to be rasterizing that on the CPU.
 
-	// Catch the mipmap draws.
-	if ((context->FRAME.PSM == PSM_PSMCT16S || context->FRAME.PSM == PSM_PSMCT32) && context->FRAME.FBW <= 5)
+	// Catch the mipmap draws. Barnyard only uses 16/32-bit, Jurassic Park uses 24-bit.
+	// Also used for Nicktoons Unite, same engine it appears.
+	if ((context->FRAME.PSM == PSM_PSMCT16S || context->FRAME.PSM <= PSM_PSMCT24) && context->FRAME.FBW <= 5)
 	{
 		r.SwPrimRender(r, true);
 		skip = 1;
@@ -1276,7 +1277,7 @@ const GSHwHack::Entry<GSRendererHW::GSC_Ptr> GSHwHack::s_get_skip_count_function
 	CRC_F(GSC_UrbanReign, CRCHackLevel::Partial),
 	CRC_F(GSC_ZettaiZetsumeiToshi2, CRCHackLevel::Partial),
 	CRC_F(GSC_BlackAndBurnoutSky, CRCHackLevel::Partial),
-	CRC_F(GSC_Barnyard, CRCHackLevel::Partial),
+	CRC_F(GSC_BlueTongueGames, CRCHackLevel::Partial),
 	CRC_F(GSC_Battlefield2, CRCHackLevel::Partial),
 
 	// Channel Effect

--- a/pcsx2/GS/Renderers/HW/GSHwHack.h
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.h
@@ -55,7 +55,7 @@ public:
 	static bool GSC_RedDeadRevolver(GSRendererHW& r, const GSFrameInfo& fi, int& skip);
 	static bool GSC_ShinOnimusha(GSRendererHW& r, const GSFrameInfo& fi, int& skip);
 	static bool GSC_XenosagaE3(GSRendererHW& r, const GSFrameInfo& fi, int& skip);
-	static bool GSC_Barnyard(GSRendererHW& r, const GSFrameInfo& fi, int& skip);
+	static bool GSC_BlueTongueGames(GSRendererHW& r, const GSFrameInfo& fi, int& skip);
 	static bool GSC_Battlefield2(GSRendererHW& r, const GSFrameInfo& fi, int& skip);
 
 	static bool OI_PointListPalette(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);


### PR DESCRIPTION
### Description of Changes

Draws its mipmaps at runtime in a very similar way, except with 24-bit textures as well as 16/32-bit.

### Rationale behind Changes

Closes #6953.
Closes #5743.

### Suggested Testing Steps

Test Jurassic Park and Nicktoons. I don't have the games, only the GS dumps, so someone who owns them will have to check.
