### PR TITLE
VMManager: Increase software thread count on multicore (4+) CPUs

### DIFF
--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -2120,14 +2120,18 @@ static void SetMTVUAndAffinityControlDefault(SettingsInterface& si)
 
 	if (big_cores >= 3)
 	{
-		Console.WriteLn("  So enabling MTVU.");
+		Console.WriteLn("  Enabling MTVU.");
 		si.SetBoolValue("EmuCore/Speedhacks", "vuThread", true);
 	}
 	else
 	{
-		Console.WriteLn("  So disabling MTVU.");
+		Console.WriteLn("  Disabling MTVU.");
 		si.SetBoolValue("EmuCore/Speedhacks", "vuThread", false);
 	}
+
+	const int extra_threads = (big_cores > 3) ? 3 : 2;
+	Console.WriteLn("  Setting Extra Software Rendering Threads to %d.", extra_threads);
+	si.SetIntValue("EmuCore/GS", "extrathreads", extra_threads);
 }
 
 #else


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
3 is a nice compromise if you have 4 core or more but for some games higher numbers like 8 or even higher would work, however for a lot of games it would perhaps even reduce the performance compared to 3 software rendering threads or in more likelihood have diminishing returns.
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
MTVU was already auto-detected to be enabled if you have 4+ cores (minus the automatic fixes for specific games that dislike MTVU) which makes it better for the user experience not giving a single care and having a better experience than even 1.6 where you needed to enable it by hand or by preset 3. Now this will go hand in hand with MTVU and not leave free performance on the table where possible. Keep in mind if you have 2/4 CPUs like 2 cores with multithreading this won't be activated but might or not help if you do it by hand (too many variables to enable for those type of users and could have a negative impact).
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Open up PCSX2 with this Pull Request, make sure you have no inis or old settings and check the Software Rendering Threads:

New Default (if enough cores):
![image](https://user-images.githubusercontent.com/24227051/211349275-f16a15e8-b08c-4037-a6ca-9b71c1f620a6.png)

Old default (or not enough real cores):
![image](https://user-images.githubusercontent.com/24227051/211349412-9909d2f7-2948-489b-bfd8-5114f208fbba.png)
