### PR TITLE
EE: In Clamp=Full manually assemble PS -+FLT_MAX

### DIFF
--- a/pcsx2/x86/iFPUd.cpp
+++ b/pcsx2/x86/iFPUd.cpp
@@ -210,8 +210,12 @@ void ToPS2FPU_Full(int reg, bool flags, int absreg, bool acc, bool addsub)
 	u32* end2 = JMP32(0);
 
 	x86SetJ8(to_overflow);
-	xCVTSD2SS(xRegisterSSE(reg), xRegisterSSE(reg));
-	xOR.PS(xRegisterSSE(reg), ptr[&s_const.pos]); //clamp
+
+	// Move sign bit to bottom 32bit
+	xSHUF.PS(xRegisterSSE(reg), xRegisterSSE(reg), 0x55);
+	// Saturate value for PS FLT_MAX
+	xOR.PS(xRegisterSSE(reg), ptr[&s_const.pos]);
+
 	if (flags && FPU_FLAGS_OVERFLOW)
 		xOR(ptr32[&fpuRegs.fprc[31]], (FPUflagO | FPUflagSO));
 	if (flags && FPU_FLAGS_OVERFLOW && acc)


### PR DESCRIPTION
### Description of Changes
Modify the handling of overflowed values when EE clamp = full (aka double precision handling), manual assembly of overflow value instead of conversion.

### Rationale behind Changes
I believe the conversion was failing, causing bad clamped values (wrong sign).  This was causing Gran Turismo 4 and Tourist Trophy to crash when doing license tests (possibly GT 3 too).
### Suggested Testing Steps
test GT4 and other games with full clamping, make sure everything works as expected (or at least doesn't crash)
Check games listed in #2245

Might Fix #2316
