### PR TITLE
GS/HW: Break slightly less when booting Mercenaries at high upscaling

### DIFF
--- a/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
@@ -318,8 +318,8 @@ GSTexture* GSDevice12::CreateSurface(GSTexture::Type type, int width, int height
 {
 	pxAssert(type != GSTexture::Type::Offscreen);
 
-	const u32 clamped_width = static_cast<u32>(std::clamp<int>(1, width, D3D12_REQ_TEXTURE2D_U_OR_V_DIMENSION));
-	const u32 clamped_height = static_cast<u32>(std::clamp<int>(1, height, D3D12_REQ_TEXTURE2D_U_OR_V_DIMENSION));
+	const u32 clamped_width = static_cast<u32>(std::clamp<int>(width, 1, D3D12_REQ_TEXTURE2D_U_OR_V_DIMENSION));
+	const u32 clamped_height = static_cast<u32>(std::clamp<int>(height, 1, D3D12_REQ_TEXTURE2D_U_OR_V_DIMENSION));
 
 	DXGI_FORMAT d3d_format, srv_format, rtv_format, dsv_format;
 	LookupNativeFormat(format, &d3d_format, &srv_format, &rtv_format, &dsv_format);

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -774,7 +774,7 @@ void GSTextureCache::ExpandTarget(const GIFRegBITBLTBUF& BITBLTBUF, const GSVect
 	{
 		Target* t = *i;
 
-		if (TEX0.TBP0 == t->m_TEX0.TBP0 && t->Overlaps(TEX0.TBP0, TEX0.TBW, TEX0.PSM, r))
+		if (TEX0.TBP0 == t->m_TEX0.TBP0 && TEX0.PSM == t->m_TEX0.PSM && t->Overlaps(TEX0.TBP0, TEX0.TBW, TEX0.PSM, r))
 		{
 			list.MoveFront(i.Index());
 

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -785,15 +785,19 @@ void GSTextureCache::ExpandTarget(const GIFRegBITBLTBUF& BITBLTBUF, const GSVect
 	
 	if (dst)
 	{
-		const GSVector2i rect_scaled = GSVector2i(r.z * g_gs_renderer->GetUpscaleMultiplier(), r.w * g_gs_renderer->GetUpscaleMultiplier());
+		// Round up to the nearest even height, like the draw target allocator.
+		const s32 aligned_height = Common::AlignUpPow2(r.w, 2);
+		const GSVector2i rect_scaled = GSVector2i(r.z * g_gs_renderer->GetUpscaleMultiplier(), aligned_height * g_gs_renderer->GetUpscaleMultiplier());
 		const int upsc_width = std::max(rect_scaled.x, dst->m_texture->GetWidth());
 		const int upsc_height = std::max(rect_scaled.y, dst->m_texture->GetHeight());
 		if (dst->m_texture->GetWidth() < upsc_width || dst->m_texture->GetHeight() < upsc_height)
 		{
-			if (dst->ResizeTexture(upsc_width, upsc_height))
+			// We don't recycle here, because most of the time when this happens it's strange-sized textures
+			// which are being expanded one-line-at-a-time.
+			if (dst->ResizeTexture(upsc_width, upsc_height, false))
 			{
 				AddDirtyRectTarget(dst, r, TEX0.PSM, TEX0.TBW);
-				GetTargetHeight(TEX0.TBP0, TEX0.TBW, TEX0.PSM, r.w);
+				GetTargetHeight(TEX0.TBP0, TEX0.TBW, TEX0.PSM, aligned_height);
 				dst->UpdateValidity(r);
 			}
 		}

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
@@ -404,8 +404,8 @@ GSTexture* GSDeviceVK::CreateSurface(GSTexture::Type type, int width, int height
 {
 	pxAssert(type != GSTexture::Type::Offscreen);
 
-	const u32 clamped_width = static_cast<u32>(std::clamp<int>(1, width, g_vulkan_context->GetMaxImageDimension2D()));
-	const u32 clamped_height = static_cast<u32>(std::clamp<int>(1, height, g_vulkan_context->GetMaxImageDimension2D()));
+	const u32 clamped_width = static_cast<u32>(std::clamp<int>(width, 1, g_vulkan_context->GetMaxImageDimension2D()));
+	const u32 clamped_height = static_cast<u32>(std::clamp<int>(height, 1, g_vulkan_context->GetMaxImageDimension2D()));
 
 	std::unique_ptr<GSTexture> tex(GSTextureVK::Create(type, clamped_width, clamped_height, levels, format, LookupNativeFormat(format)));
 	if (!tex)
@@ -1803,7 +1803,7 @@ bool GSDeviceVK::CompileCASPipelines()
 	dslb.AddBinding(1, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 1, VK_SHADER_STAGE_COMPUTE_BIT);
 	if ((m_cas_ds_layout = dslb.Create(dev)) == VK_NULL_HANDLE)
 		return false;
-	Vulkan::Util::SetObjectName(dev, m_cas_pipeline_layout, "CAS descriptor layout");
+	Vulkan::Util::SetObjectName(dev, m_cas_ds_layout, "CAS descriptor layout");
 
 	plb.AddPushConstants(VK_SHADER_STAGE_COMPUTE_BIT, 0, NUM_CAS_CONSTANTS * sizeof(u32));
 	plb.AddDescriptorSet(m_cas_ds_layout);


### PR DESCRIPTION
### Description of Changes

Detail in commits.

### Rationale behind Changes

Allocating a 32k texture is silly.

### Suggested Testing Steps

Jordan knows what to do.

