### PR TITLE
Qt: Lower audio ms + Tooltip (affinity+Cycle skip)

### DIFF
--- a/pcsx2-qt/Settings/AudioSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/AudioSettingsWidget.cpp
@@ -1,5 +1,5 @@
 /*  PCSX2 - PS2 Emulator for PCs
- *  Copyright (C) 2002-2022  PCSX2 Dev Team
+ *  Copyright (C) 2002-2023  PCSX2 Dev Team
  *
  *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU Lesser General Public License as published by the Free Software Found-
@@ -33,7 +33,7 @@ static constexpr s32 DEFAULT_SYNCHRONIZATION_MODE = 0;
 static constexpr s32 DEFAULT_EXPANSION_MODE = 0;
 static constexpr s32 DEFAULT_DPL_DECODING_LEVEL = 0;
 static const char* DEFAULT_OUTPUT_MODULE = "cubeb";
-static constexpr s32 DEFAULT_TARGET_LATENCY = 100;
+static constexpr s32 DEFAULT_TARGET_LATENCY = 60;
 static constexpr s32 DEFAULT_OUTPUT_LATENCY = 20;
 static constexpr s32 DEFAULT_VOLUME = 100;
 static constexpr s32 DEFAULT_SOUNDTOUCH_SEQUENCE_LENGTH = 30;
@@ -117,7 +117,7 @@ AudioSettingsWidget::AudioSettingsWidget(SettingsDialog* dialog, QWidget* parent
 
 	dialog->registerWidgetHelp(m_ui.backend, tr("Output Backend"), tr("Default"), tr(""));
 
-	dialog->registerWidgetHelp(m_ui.targetLatency, tr("Target Latency"), tr("100 ms"),
+	dialog->registerWidgetHelp(m_ui.targetLatency, tr("Target Latency"), tr("60 ms"),
 		tr("Determines the buffer size which the time stretcher will try to keep filled. It effectively selects the average latency, as "
 		   "audio will be stretched/shrunk to keep the buffer size within check."));
 	dialog->registerWidgetHelp(m_ui.outputLatency, tr("Output Latency"), tr("20 ms"),

--- a/pcsx2-qt/Settings/AudioSettingsWidget.ui
+++ b/pcsx2-qt/Settings/AudioSettingsWidget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>754</width>
-    <height>464</height>
+    <height>485</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -49,6 +49,9 @@
           <property name="maximum">
            <number>100</number>
           </property>
+          <property name="value">
+           <number>30</number>
+          </property>
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
           </property>
@@ -63,7 +66,7 @@
         <item>
          <widget class="QLabel" name="sequenceLengthLabel">
           <property name="text">
-           <string>100</string>
+           <string>30</string>
           </property>
          </widget>
         </item>
@@ -86,6 +89,9 @@
           <property name="maximum">
            <number>30</number>
           </property>
+          <property name="value">
+           <number>20</number>
+          </property>
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
           </property>
@@ -100,7 +106,7 @@
         <item>
          <widget class="QLabel" name="seekWindowSizeLabel">
           <property name="text">
-           <string>100</string>
+           <string>20</string>
           </property>
          </widget>
         </item>
@@ -123,6 +129,9 @@
           <property name="maximum">
            <number>15</number>
           </property>
+          <property name="value">
+           <number>10</number>
+          </property>
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
           </property>
@@ -137,7 +146,7 @@
         <item>
          <widget class="QLabel" name="overlapLabel">
           <property name="text">
-           <string>100</string>
+           <string>10</string>
           </property>
          </widget>
         </item>
@@ -200,6 +209,9 @@
           </property>
           <property name="maximum">
            <number>200</number>
+          </property>
+          <property name="value">
+           <number>100</number>
           </property>
           <property name="orientation">
            <enum>Qt::Vertical</enum>
@@ -366,7 +378,7 @@
            <number>200</number>
           </property>
           <property name="value">
-           <number>100</number>
+           <number>60</number>
           </property>
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
@@ -382,7 +394,7 @@
         <item>
          <widget class="QLabel" name="targetLatencyLabel">
           <property name="text">
-           <string>100 ms</string>
+           <string>60 ms</string>
           </property>
          </widget>
         </item>
@@ -425,7 +437,7 @@
            <number>200</number>
           </property>
           <property name="value">
-           <number>100</number>
+           <number>20</number>
           </property>
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
@@ -441,7 +453,7 @@
         <item>
          <widget class="QLabel" name="outputLatencyLabel">
           <property name="text">
-           <string>100 ms</string>
+           <string>20 ms</string>
           </property>
          </widget>
         </item>

--- a/pcsx2-qt/Settings/EmulationSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/EmulationSettingsWidget.cpp
@@ -1,5 +1,5 @@
 /*  PCSX2 - PS2 Emulator for PCs
- *  Copyright (C) 2002-2022  PCSX2 Dev Team
+ *  Copyright (C) 2002-2023  PCSX2 Dev Team
  *
  *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU Lesser General Public License as published by the Free Software Found-
@@ -100,9 +100,12 @@ EmulationSettingsWidget::EmulationSettingsWidget(SettingsDialog* dialog, QWidget
 	dialog->registerWidgetHelp(m_ui.eeCycleRate, tr("Cycle Rate"), tr("100% (Normal Speed)"),
 		tr("Higher values may increase internal framerate in games, but will increase CPU requirements substantially. "
 		   "Lower values will reduce the CPU load allowing lightweight games to run full speed on weaker CPUs."));
-	dialog->registerWidgetHelp(m_ui.eeCycleSkipping, tr("Cycle Skip"), tr("None"),
+	dialog->registerWidgetHelp(m_ui.eeCycleSkipping, tr("Cycle Skip"), tr("Disabled"),
 		tr("Makes the emulated Emotion Engine skip cycles. "
 		   "Helps a small subset of games like SOTC. Most of the time it's harmful to performance."));
+	dialog->registerWidgetHelp(m_ui.affinityControl, tr("Affinity Control"), tr("Disabled"),
+		tr("Sets the priority for specific threads in a specific order ignoring the system scheduler. "
+		   "May help CPUs with big (P) and little (E) cores (e.g. Intel 12th or newer generation CPUs from Intel or other vendors such as AMD)"));
 	dialog->registerWidgetHelp(m_ui.MTVU, tr("MTVU (Multi-threaded VU1)"), tr("Checked"),
 		tr("Generally a speedup on CPUs with 3 or more threads. "
 		   "Safe for most games, but a few are incompatible and may hang."));

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -821,7 +821,7 @@ struct Pcsx2Config
 		SynchronizationMode SynchMode = SynchronizationMode::TimeStretch;
 
 		s32 FinalVolume = 100;
-		s32 Latency = 100;
+		s32 Latency = 60;
 		s32 OutputLatency = 20;
 		s32 SpeakerConfiguration = 0;
 		s32 DplDecodingLevel = 0;


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Lowering 100 ms audio latency to 60 ms.
Makes 100 mixing latency with 20 output latency (120) into a new total default of 80 ms which is 50% lower but still is enough headroom as 40 ms even for less capable machines is too high. Unless you have a real potato which it will still skip at 200+ but at that time you will have changed to async mode to make it more bearable, switched games or other settings.

Lowering the mixing latency even more would be detrimental.

Adding tooltip for Affinity Control
Changing tooltip for Cycle Skip from None to Disabled as that is a valid option.
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
1.6 already had problems at 100 ms and 1.7 nightly/dev builds can handle much lower values without skipping.
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test games, preferable heavier games perhaps with weaker computers/laptops as well.