### PR TITLE
Misc: Latest round of warning cleanups

### DIFF
--- a/common/emitter/cpudetect.cpp
+++ b/common/emitter/cpudetect.cpp
@@ -170,12 +170,6 @@ void x86capabilities::CountCores()
 {
 	Identify();
 
-	s32 regs[4];
-	u32 cmds;
-
-	cpuid(regs, 0x80000000);
-	cmds = regs[0];
-
 	// This will assign values into LogicalCores and PhysicalCores
 	CountLogicalCores();
 }

--- a/pcsx2-qt/Debugger/BreakpointDialog.cpp
+++ b/pcsx2-qt/Debugger/BreakpointDialog.cpp
@@ -177,7 +177,7 @@ void BreakpointDialog::accept()
 		m_bpModel.removeRows(m_rowIndex, 1);
 	}
 
-	m_bpModel.insertRows(0, 1, {m_bp_mc});
+	m_bpModel.insertBreakpointRows(0, 1, {m_bp_mc});
 
 	QDialog::accept();
 }

--- a/pcsx2-qt/Debugger/Models/BreakpointModel.cpp
+++ b/pcsx2-qt/Debugger/Models/BreakpointModel.cpp
@@ -306,9 +306,9 @@ bool BreakpointModel::removeRows(int row, int count, const QModelIndex& index)
 	return true;
 }
 
-bool BreakpointModel::insertRows(int row, int count, std::vector<BreakpointMemcheck> breakpoints, const QModelIndex& index)
+bool BreakpointModel::insertBreakpointRows(int row, int count, std::vector<BreakpointMemcheck> breakpoints, const QModelIndex& index)
 {
-	if (breakpoints.size() != count)
+	if (breakpoints.size() != static_cast<size_t>(count))
 		return false;
 
 	beginInsertRows(index, row, row + count);

--- a/pcsx2-qt/Debugger/Models/BreakpointModel.h
+++ b/pcsx2-qt/Debugger/Models/BreakpointModel.h
@@ -47,7 +47,7 @@ public:
 	Qt::ItemFlags flags(const QModelIndex& index) const override;
 	bool setData(const QModelIndex& index, const QVariant& value, int role) override;
 	bool removeRows(int row, int count, const QModelIndex& index = QModelIndex()) override;
-	bool insertRows(int row, int count, std::vector<BreakpointMemcheck> breakpoints, const QModelIndex& index = QModelIndex());
+	bool insertBreakpointRows(int row, int count, std::vector<BreakpointMemcheck> breakpoints, const QModelIndex& index = QModelIndex());
 
 	BreakpointMemcheck at(int row) const { return m_breakpoints.at(row); };
 

--- a/pcsx2-qt/Debugger/Models/ThreadModel.cpp
+++ b/pcsx2-qt/Debugger/Models/ThreadModel.cpp
@@ -79,7 +79,7 @@ QVariant ThreadModel::data(const QModelIndex& index, int role) const
 	}
 	else if (role == Qt::UserRole)
 	{
-		const auto& thread = getEEThreads().at(index.row());
+		const auto thread = getEEThreads().at(index.row());
 
 		switch (index.column())
 		{

--- a/pcsx2-qt/Settings/AudioSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/AudioSettingsWidget.cpp
@@ -28,7 +28,6 @@
 #include "SettingWidgetBinder.h"
 #include "SettingsDialog.h"
 
-static constexpr s32 DEFAULT_INTERPOLATION_MODE = 5;
 static constexpr s32 DEFAULT_SYNCHRONIZATION_MODE = 0;
 static constexpr s32 DEFAULT_EXPANSION_MODE = 0;
 static constexpr s32 DEFAULT_DPL_DECODING_LEVEL = 0;


### PR DESCRIPTION
### Description of Changes

What the title says.

### Rationale behind Changes

Reducing warning spam. One of these is actually a legit error too (the EE threads one, the object it's referencing is destroyed at the end of the statement).

### Suggested Testing Steps

Make sure build passes.
