### PR TITLE
cmake: Turn back on some warnings that no longer need to be turned off.

### DIFF
--- a/cmake/BuildParameters.cmake
+++ b/cmake/BuildParameters.cmake
@@ -227,11 +227,6 @@ elseif(NOT MSVC)
 	set(AGGRESSIVE_WARNING -Wstrict-aliasing -Wstrict-overflow=1)
 endif()
 
-if (USE_CLANG)
-	# -Wno-deprecated-register: glib issue...
-	list(APPEND DEFAULT_WARNINGS -Wno-deprecated-register -Wno-c++14-extensions)
-endif()
-
 if (USE_PGO_GENERATE OR USE_PGO_OPTIMIZE)
 	add_compile_options("-fprofile-dir=${CMAKE_SOURCE_DIR}/profile")
 endif()


### PR DESCRIPTION
### Description of Changes
Removed some code turning on -Wno-deprecated-register -Wno-c++14-extensions for clang.

### Rationale behind Changes
Compiling without those flags in clang doesn't have any warnings, so the issues that they were turned off for are no longer there.

### Suggested Testing Steps
Compile with clang.
