### PR TITLE
Debugger Expressions: Add 'target', 'load', and 'store' references

### DIFF
--- a/pcsx2-qt/Debugger/BreakpointDialog.cpp
+++ b/pcsx2-qt/Debugger/BreakpointDialog.cpp
@@ -112,11 +112,14 @@ void BreakpointDialog::accept()
 			return;
 		}
 
+		bp->addr = address;
+
 		bp->enabled = m_ui.chkEnable->isChecked();
 
 		if (!m_ui.txtCondition->text().isEmpty())
 		{
 			bp->hasCond = true;
+			bp->cond.debug = m_cpu;
 
 			if (!m_cpu->initExpression(m_ui.txtCondition->text().toLocal8Bit().constData(), expr))
 			{

--- a/pcsx2-qt/Debugger/DisassemblyWidget.cpp
+++ b/pcsx2-qt/Debugger/DisassemblyWidget.cpp
@@ -487,7 +487,7 @@ void DisassemblyWidget::paintEvent(QPaintEvent* event)
 
 void DisassemblyWidget::mousePressEvent(QMouseEvent* event)
 {
-	const u32 selectedAddress = (event->position().y() / m_rowHeight * 4) + m_visibleStart;
+	const u32 selectedAddress = (static_cast<int>(event->position().y()) / m_rowHeight * 4) + m_visibleStart;
 	if (event->buttons() & Qt::LeftButton)
 	{
 		if (event->modifiers() & Qt::ShiftModifier)
@@ -523,7 +523,7 @@ void DisassemblyWidget::mouseDoubleClickEvent(QMouseEvent* event)
 	if (!m_cpu->isAlive())
 		return;
 
-	const u32 selectedAddress = (event->position().y() / m_rowHeight * 4) + m_visibleStart;
+	const u32 selectedAddress = (static_cast<int>(event->position().y()) / m_rowHeight * 4) + m_visibleStart;
 	if (CBreakPoints::IsAddressBreakPoint(m_cpu->getCpuType(), selectedAddress))
 	{
 		Host::RunOnCPUThread([&] { CBreakPoints::RemoveBreakPoint(m_cpu->getCpuType(), selectedAddress); });


### PR DESCRIPTION
### Description of Changes
This PR adds three new references for the debugger condition expressions

`target` -> The evaluated target of the load or the store, 0 if the opcode is not a memory access
`load` -> The evaluated target of a load, is 0 if the opcode is not loading
`store` -> The evaluated target of a store, is 0 if the opcode is not storing

----

#### Here is an example

`v1 = 0x12000000`
<table>
<tr>
	<td>
			<b>Breakpoint Instruction:</b>
	<td>
			<b>ld v0,0x1000(v1)</b>
	<td>
			<b>sd v0,0x1000(v1)</b>
	<td>
			<b>nop</b>
<tr>
	<td>
			<code>target</code>
	<td>
			<code>0x12001000</code>
	<td>
			<code>0x12001000</code>
	<td>
			<code>0</code>
<tr>
	<td>
			<code>load</code>
	<td>
			<code>0x12001000</code>
	<td>
			<code>0</code>
	<td>
			<code>0</code>
<tr>
	<td>
			<code>store</code>
	<td>
			<code>0</code>
	<td>
			<code>0x12001000</code>
	<td>
			<code>0</code>
</table>

Some other stuff fixed here:

Fixes the disassembly widget mouse click handler
Fixes the breakpoint dialog not setting the breakpoint address (oops)
Fixes the breakpoint dialog not setting the condition CPU.

### Rationale behind Changes
My solution to #7800, if I understood it correctly.

### Suggested Testing Steps
I've tested it with `ld`, `sd`, `lq`. You can try other memory load / store opcodes.

----
Resolves #7800 