### PR TITLE
GameDB: Add Half-Pixel Offset for Sega Superstars Tennis

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -21123,6 +21123,8 @@ SLES-54946:
   region: "PAL-M5"
   gameFixes:
     - VUSyncHack # Fixes SPS.
+  gsHWFixes:
+    halfPixelOffset: 1 # Fixes post bloom alignment.
 SLES-54947:
   name: "Dogz"
   region: "PAL-M6"
@@ -48747,6 +48749,8 @@ SLUS-21733:
   region: "NTSC-U"
   gameFixes:
     - VUSyncHack # Fixes SPS.
+  gsHWFixes:
+    halfPixelOffset: 1 # Fixes post bloom alignment.
 SLUS-21734:
   name: "Falling Stars"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
Add HPO Normal to Sega Superstars Tennis

### Rationale behind Changes
Bloom was misaligned when upscaling

### Suggested Testing Steps
watch CI
