### PR TITLE
SPU2: Cleanup SndOut

### DIFF
--- a/pcsx2/SPU2/SndOut.cpp
+++ b/pcsx2/SPU2/SndOut.cpp
@@ -347,31 +347,30 @@ void SndBuffer::_WriteSamples(StereoOut32* bData, int nSamples)
 
 		s32 comp = 0;
 
-		if( SynchMode == 0 ) // TimeStrech on
+		if (EmuConfig.SPU2.SynchMode == Pcsx2Config::SPU2Options::SynchronizationMode::TimeStretch) // TimeStrech on
 		{
 			comp = timeStretchOverrun();
 		}
 		else
 		{
 			// Toss half the buffer plus whatever's being written anew:
-			comp = GetAlignedBufferSize( (m_size + nSamples ) / 16 );
-			if( comp > (m_size-SndOutPacketSize) ) comp = m_size-SndOutPacketSize;
+			comp = GetAlignedBufferSize((m_size + nSamples) / 16);
+			if (comp > (m_size - SndOutPacketSize))
+				comp = m_size - SndOutPacketSize;
 		}
 
 		_DropSamples_Internal(comp);
 
-		if( MsgOverruns() )
-			ConLog(" * SPU2 > Overrun Compensation (%d packets tossed)\n", comp / SndOutPacketSize );
-		lastPct = 0.0;		// normalize the timestretcher
+		if (SPU2::MsgOverruns())
+			SPU2::ConLog(" * SPU2 > Overrun Compensation (%d packets tossed)\n", comp / SndOutPacketSize);
+		lastPct = 0.0; // normalize the timestretcher
+		_WriteSamples_Safe(bData, nSamples);
 #else
 		if (SPU2::MsgOverruns())
 			SPU2::ConLog(" * SPU2 > Overrun! 1 packet tossed)\n");
 		lastPct = 0.0; // normalize the timestretcher
-		return;
 #endif
 	}
-
-	_WriteSamples_Safe(bData, nSamples);
 }
 
 bool SndBuffer::Init(const char* modname)


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
SPU2: Cleanup SndOut.cpp
const, casts, constexpr, initializations.
Remove dynamic tuning commented out code. No longer works as it relied on wx.
SPU2: Update WriteSamples function commented out code to work properly when enabled.
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Code cleanup.
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Compiles, spu2 works.