### PR TITLE
GS-hw: Cleanup GSRendererHW.

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.h
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.h
@@ -138,7 +138,6 @@ public:
 	void Lines2Sprites();
 	bool VerifyIndices();
 	template <GSHWDrawConfig::VSExpand Expand> void ExpandIndices();
-	void EmulateAtst(GSVector4& FogColor_AREF, u8& atst, const bool pass_2);
 	void ConvertSpriteTextureShuffle(bool& write_ba, bool& read_ba);
 	GSVector4 RealignTargetTextureCoordinate(const GSTextureCache::Source* tex);
 	GSVector4i ComputeBoundingBox(const GSVector2& rtscale, const GSVector2i& rtsize);


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS-hw: Cleanup GSRendererHW.
Constants, initializations, casts, broken commented out logs and more. Remove unused/duplicate function EmulateAtst.
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Code cleanup.
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Tested on several dumps, but test more just to make sure nothing is broken, hw renderers.