### PR TITLE
DEV9: AdapterUtils use unique_ptr to manage lifetime of ifaddrs array + formatting

### DIFF
--- a/pcsx2/DEV9/AdapterUtils.cpp
+++ b/pcsx2/DEV9/AdapterUtils.cpp
@@ -45,7 +45,7 @@ using namespace PacketReader::IP;
 bool AdapterUtils::GetWin32Adapter(const std::string& name, PIP_ADAPTER_ADDRESSES adapter, std::unique_ptr<IP_ADAPTER_ADDRESSES[]>* buffer)
 {
 	int neededSize = 128;
-	std::unique_ptr<IP_ADAPTER_ADDRESSES[]> AdapterInfo = std::make_unique<IP_ADAPTER_ADDRESSES[]>(neededSize);
+	std::unique_ptr<IP_ADAPTER_ADDRESSES[]> adapterInfo = std::make_unique<IP_ADAPTER_ADDRESSES[]>(neededSize);
 	ULONG dwBufLen = sizeof(IP_ADAPTER_ADDRESSES) * neededSize;
 
 	PIP_ADAPTER_ADDRESSES pAdapterInfo;
@@ -54,14 +54,14 @@ bool AdapterUtils::GetWin32Adapter(const std::string& name, PIP_ADAPTER_ADDRESSE
 		AF_UNSPEC,
 		GAA_FLAG_INCLUDE_PREFIX | GAA_FLAG_INCLUDE_GATEWAYS,
 		NULL,
-		AdapterInfo.get(),
+		adapterInfo.get(),
 		&dwBufLen);
 
 	if (dwStatus == ERROR_BUFFER_OVERFLOW)
 	{
 		DevCon.WriteLn("DEV9: GetWin32Adapter() buffer too small, resizing");
 		neededSize = dwBufLen / sizeof(IP_ADAPTER_ADDRESSES) + 1;
-		AdapterInfo = std::make_unique<IP_ADAPTER_ADDRESSES[]>(neededSize);
+		adapterInfo = std::make_unique<IP_ADAPTER_ADDRESSES[]>(neededSize);
 		dwBufLen = sizeof(IP_ADAPTER_ADDRESSES) * neededSize;
 		DevCon.WriteLn("DEV9: New size %i", neededSize);
 
@@ -69,31 +69,32 @@ bool AdapterUtils::GetWin32Adapter(const std::string& name, PIP_ADAPTER_ADDRESSE
 			AF_UNSPEC,
 			GAA_FLAG_INCLUDE_PREFIX | GAA_FLAG_INCLUDE_GATEWAYS,
 			NULL,
-			AdapterInfo.get(),
+			adapterInfo.get(),
 			&dwBufLen);
 	}
 	if (dwStatus != ERROR_SUCCESS)
 		return false;
 
-	pAdapterInfo = AdapterInfo.get();
+	pAdapterInfo = adapterInfo.get();
 
 	do
 	{
 		if (strcmp(pAdapterInfo->AdapterName, name.c_str()) == 0)
 		{
 			*adapter = *pAdapterInfo;
-			buffer->swap(AdapterInfo);
+			buffer->swap(adapterInfo);
 			return true;
 		}
 
 		pAdapterInfo = pAdapterInfo->Next;
 	} while (pAdapterInfo);
+
 	return false;
 }
 bool AdapterUtils::GetWin32AdapterAuto(PIP_ADAPTER_ADDRESSES adapter, std::unique_ptr<IP_ADAPTER_ADDRESSES[]>* buffer)
 {
 	int neededSize = 128;
-	std::unique_ptr<IP_ADAPTER_ADDRESSES[]> AdapterInfo = std::make_unique<IP_ADAPTER_ADDRESSES[]>(neededSize);
+	std::unique_ptr<IP_ADAPTER_ADDRESSES[]> adapterInfo = std::make_unique<IP_ADAPTER_ADDRESSES[]>(neededSize);
 	ULONG dwBufLen = sizeof(IP_ADAPTER_ADDRESSES) * neededSize;
 
 	PIP_ADAPTER_ADDRESSES pAdapter;
@@ -102,7 +103,7 @@ bool AdapterUtils::GetWin32AdapterAuto(PIP_ADAPTER_ADDRESSES adapter, std::uniqu
 		AF_UNSPEC,
 		GAA_FLAG_INCLUDE_PREFIX | GAA_FLAG_INCLUDE_GATEWAYS,
 		NULL,
-		AdapterInfo.get(),
+		adapterInfo.get(),
 		&dwBufLen);
 
 	if (dwStatus == ERROR_BUFFER_OVERFLOW)
@@ -110,7 +111,7 @@ bool AdapterUtils::GetWin32AdapterAuto(PIP_ADAPTER_ADDRESSES adapter, std::uniqu
 		DevCon.WriteLn("DEV9: PCAPGetWin32Adapter() buffer too small, resizing");
 		//
 		neededSize = dwBufLen / sizeof(IP_ADAPTER_ADDRESSES) + 1;
-		AdapterInfo = std::make_unique<IP_ADAPTER_ADDRESSES[]>(neededSize);
+		adapterInfo = std::make_unique<IP_ADAPTER_ADDRESSES[]>(neededSize);
 		dwBufLen = sizeof(IP_ADAPTER_ADDRESSES) * neededSize;
 		DevCon.WriteLn("DEV9: New size %i", neededSize);
 
@@ -118,45 +119,45 @@ bool AdapterUtils::GetWin32AdapterAuto(PIP_ADAPTER_ADDRESSES adapter, std::uniqu
 			AF_UNSPEC,
 			GAA_FLAG_INCLUDE_PREFIX | GAA_FLAG_INCLUDE_GATEWAYS,
 			NULL,
-			AdapterInfo.get(),
+			adapterInfo.get(),
 			&dwBufLen);
 	}
 
 	if (dwStatus != ERROR_SUCCESS)
 		return 0;
 
-	pAdapter = AdapterInfo.get();
+	pAdapter = adapterInfo.get();
 
 	do
 	{
 		if (pAdapter->IfType != IF_TYPE_SOFTWARE_LOOPBACK &&
 			pAdapter->OperStatus == IfOperStatusUp)
 		{
-			//Search for an adapter with;
-			//IPv4 Address
-			//DNS
-			//Gateway
+			// Search for an adapter with;
+			// IPv4 Address,
+			// DNS,
+			// Gateway.
 
 			bool hasIPv4 = false;
 			bool hasDNS = false;
 			bool hasGateway = false;
 
-			//IPv4
+			// IPv4.
 			if (GetAdapterIP(pAdapter).has_value())
 				hasIPv4 = true;
 
-			//DNS
+			// DNS.
 			if (GetDNS(pAdapter).size() > 0)
 				hasDNS = true;
 
-			//Gateway
+			// Gateway.
 			if (GetGateways(pAdapter).size() > 0)
 				hasGateway = true;
 
 			if (hasIPv4 && hasDNS && hasGateway)
 			{
 				*adapter = *pAdapter;
-				buffer->swap(AdapterInfo);
+				buffer->swap(adapterInfo);
 				return true;
 			}
 		}
@@ -212,9 +213,9 @@ bool AdapterUtils::GetIfAdapterAuto(ifaddrs* adapter, ifaddrs** buffer)
 		if ((pAdapter->ifa_flags & IFF_LOOPBACK) == 0 &&
 			(pAdapter->ifa_flags & IFF_UP) != 0)
 		{
-			//Search for an adapter with;
-			//IPv4 Address
-			//Gateway
+			// Search for an adapter with;
+			// IPv4 Address,
+			// Gateway.
 
 			bool hasIPv4 = false;
 			bool hasGateway = false;
@@ -241,7 +242,7 @@ bool AdapterUtils::GetIfAdapterAuto(ifaddrs* adapter, ifaddrs** buffer)
 }
 #endif
 
-//AdapterIP
+// AdapterIP.
 #ifdef _WIN32
 std::optional<IP_Address> AdapterUtils::GetAdapterIP(PIP_ADAPTER_ADDRESSES adapter)
 {
@@ -279,7 +280,7 @@ std::optional<IP_Address> AdapterUtils::GetAdapterIP(ifaddrs* adapter)
 }
 #endif
 
-//Gateways
+// Gateways.
 #ifdef _WIN32
 std::vector<IP_Address> AdapterUtils::GetGateways(PIP_ADAPTER_ADDRESSES adapter)
 {
@@ -305,8 +306,8 @@ std::vector<IP_Address> AdapterUtils::GetGateways(PIP_ADAPTER_ADDRESSES adapter)
 #ifdef __linux__
 std::vector<IP_Address> AdapterUtils::GetGateways(ifaddrs* adapter)
 {
-	///proc/net/route contains some information about gateway addresses,
-	//and separates the information about by each interface.
+	// /proc/net/route contains some information about gateway addresses,
+	// and separates the information about by each interface.
 	if (adapter == nullptr)
 		return {};
 
@@ -325,8 +326,8 @@ std::vector<IP_Address> AdapterUtils::GetGateways(ifaddrs* adapter)
 		routeLines.push_back(line);
 	route.close();
 
-	//Columns are as follows (first-line header):
-	//Iface  Destination  Gateway  Flags  RefCnt  Use  Metric  Mask  MTU  Window  IRTT
+	// Columns are as follows (first-line header):
+	// Iface  Destination  Gateway  Flags  RefCnt  Use  Metric  Mask  MTU  Window  IRTT.
 	for (size_t i = 1; i < routeLines.size(); i++)
 	{
 		std::string line = routeLines[i];
@@ -356,7 +357,7 @@ std::vector<IP_Address> AdapterUtils::GetGateways(ifaddrs* adapter)
 
 	std::vector<IP_Address> collection;
 
-	//Get index for our adapter by matching the adapter name
+	// Get index for our adapter by matching the adapter name.
 	int ifIndex = -1;
 
 	struct if_nameindex* ifNI;
@@ -379,14 +380,14 @@ std::vector<IP_Address> AdapterUtils::GetGateways(ifaddrs* adapter)
 	}
 	if_freenameindex(ifNI);
 
-	//Check if we found the adapter
+	// Check if we found the adapter.
 	if (ifIndex == -1)
 	{
 		Console.Error("DEV9: Failed to get index for adapter");
 		return collection;
 	}
 
-	//Find the gateway by looking though the routing information
+	// Find the gateway by looking though the routing information.
 	int name[] = {CTL_NET, PF_ROUTE, 0, AF_INET, NET_RT_DUMP, 0};
 	size_t bufferLen = 0;
 
@@ -396,7 +397,7 @@ std::vector<IP_Address> AdapterUtils::GetGateways(ifaddrs* adapter)
 		return collection;
 	}
 
-	//len is an estimate, double it to be safe
+	// bufferLen is an estimate, double it to be safe.
 	bufferLen *= 2;
 	std::unique_ptr<u8[]> buffer = std::make_unique<u8[]>(bufferLen);
 
@@ -416,7 +417,7 @@ std::vector<IP_Address> AdapterUtils::GetGateways(ifaddrs* adapter)
 			sockaddr* sockaddrs = (sockaddr*)(hdr + 1);
 			pxAssert(sockaddrs[RTAX_DST].sa_family == AF_INET);
 
-			//Default gateway has no destination address
+			// Default gateway has no destination address.
 			sockaddr_in* sockaddr = (sockaddr_in*)&sockaddrs[RTAX_DST];
 			if (sockaddr->sin_addr.s_addr != 0)
 				continue;
@@ -437,7 +438,7 @@ std::vector<IP_Address> AdapterUtils::GetGateways(ifaddrs* adapter)
 #endif
 #endif
 
-//DNS
+// DNS.
 #ifdef _WIN32
 std::vector<IP_Address> AdapterUtils::GetDNS(PIP_ADAPTER_ADDRESSES adapter)
 {
@@ -462,7 +463,7 @@ std::vector<IP_Address> AdapterUtils::GetDNS(PIP_ADAPTER_ADDRESSES adapter)
 #elif defined(__POSIX__)
 std::vector<IP_Address> AdapterUtils::GetDNS(ifaddrs* adapter)
 {
-	//On Linux and OSX, DNS is system wide, not adapter specific, so we can ignore adapter
+	// On Linux and OSX, DNS is system wide, not adapter specific, so we can ignore the adapter parameter.
 
 	// Parse /etc/resolv.conf for all of the "nameserver" entries.
 	// These are the DNS servers the machine is configured to use.

--- a/pcsx2/DEV9/AdapterUtils.h
+++ b/pcsx2/DEV9/AdapterUtils.h
@@ -35,7 +35,7 @@ namespace AdapterUtils
 	bool GetWin32AdapterAuto(PIP_ADAPTER_ADDRESSES adapter, std::unique_ptr<IP_ADAPTER_ADDRESSES[]>* buffer);
 
 	std::optional<PacketReader::IP::IP_Address> GetAdapterIP(PIP_ADAPTER_ADDRESSES adapter);
-	//Mask
+	// Mask.
 	std::vector<PacketReader::IP::IP_Address> GetGateways(PIP_ADAPTER_ADDRESSES adapter);
 	std::vector<PacketReader::IP::IP_Address> GetDNS(PIP_ADAPTER_ADDRESSES adapter);
 #elif defined(__POSIX__)
@@ -43,7 +43,7 @@ namespace AdapterUtils
 	bool GetIfAdapterAuto(ifaddrs* adapter, ifaddrs** buffer);
 
 	std::optional<PacketReader::IP::IP_Address> GetAdapterIP(ifaddrs* adapter);
-	//Mask
+	// Mask.
 	std::vector<PacketReader::IP::IP_Address> GetGateways(ifaddrs* adapter);
 	std::vector<PacketReader::IP::IP_Address> GetDNS(ifaddrs* adapter);
 #endif

--- a/pcsx2/DEV9/AdapterUtils.h
+++ b/pcsx2/DEV9/AdapterUtils.h
@@ -31,7 +31,8 @@
 namespace AdapterUtils
 {
 #ifdef _WIN32
-	bool GetWin32Adapter(const std::string& name, PIP_ADAPTER_ADDRESSES adapter, std::unique_ptr<IP_ADAPTER_ADDRESSES[]>* buffer);
+	typedef std::unique_ptr<IP_ADAPTER_ADDRESSES[]> AdapterBuffer;
+	bool GetWin32Adapter(const std::string& name, PIP_ADAPTER_ADDRESSES adapter, AdapterBuffer* buffer);
 	bool GetWin32AdapterAuto(PIP_ADAPTER_ADDRESSES adapter, std::unique_ptr<IP_ADAPTER_ADDRESSES[]>* buffer);
 
 	std::optional<PacketReader::IP::IP_Address> GetAdapterIP(PIP_ADAPTER_ADDRESSES adapter);
@@ -39,8 +40,13 @@ namespace AdapterUtils
 	std::vector<PacketReader::IP::IP_Address> GetGateways(PIP_ADAPTER_ADDRESSES adapter);
 	std::vector<PacketReader::IP::IP_Address> GetDNS(PIP_ADAPTER_ADDRESSES adapter);
 #elif defined(__POSIX__)
-	bool GetIfAdapter(const std::string& name, ifaddrs* adapter, ifaddrs** buffer);
-	bool GetIfAdapterAuto(ifaddrs* adapter, ifaddrs** buffer);
+	struct IfAdaptersDeleter
+	{
+		void operator()(ifaddrs* buffer) const { freeifaddrs(buffer); }
+	};
+	typedef std::unique_ptr<ifaddrs, IfAdaptersDeleter> AdapterBuffer;
+	bool GetIfAdapter(const std::string& name, ifaddrs* adapter, AdapterBuffer* buffer);
+	bool GetIfAdapterAuto(ifaddrs* adapter, AdapterBuffer* buffer);
 
 	std::optional<PacketReader::IP::IP_Address> GetAdapterIP(ifaddrs* adapter);
 	// Mask.

--- a/pcsx2/DEV9/pcap_io.cpp
+++ b/pcsx2/DEV9/pcap_io.cpp
@@ -311,7 +311,7 @@ PCAPAdapter::PCAPAdapter()
 
 #ifdef _WIN32
 	IP_ADAPTER_ADDRESSES adapter;
-	std::unique_ptr<IP_ADAPTER_ADDRESSES[]> buffer;
+	AdapterUtils::AdapterBuffer buffer;
 	if (AdapterUtils::GetWin32Adapter(EmuConfig.DEV9.EthDevice, &adapter, &buffer))
 		InitInternalServer(&adapter);
 	else
@@ -319,14 +319,12 @@ PCAPAdapter::PCAPAdapter()
 		Console.Error("DEV9: Failed to get adapter information");
 		InitInternalServer(nullptr);
 	}
+
 #elif defined(__POSIX__)
 	ifaddrs adapter;
-	ifaddrs* buffer;
+	AdapterUtils::AdapterBuffer buffer;
 	if (AdapterUtils::GetIfAdapter(EmuConfig.DEV9.EthDevice, &adapter, &buffer))
-	{
 		InitInternalServer(&adapter);
-		freeifaddrs(buffer);
-	}
 	else
 	{
 		Console.Error("DEV9: Failed to get adapter information");
@@ -383,19 +381,16 @@ void PCAPAdapter::reloadSettings()
 {
 #ifdef _WIN32
 	IP_ADAPTER_ADDRESSES adapter;
-	std::unique_ptr<IP_ADAPTER_ADDRESSES[]> buffer;
+	AdapterUtils::AdapterBuffer buffer;
 	if (AdapterUtils::GetWin32Adapter(EmuConfig.DEV9.EthDevice, &adapter, &buffer))
 		ReloadInternalServer(&adapter);
 	else
 		ReloadInternalServer(nullptr);
 #elif defined(__POSIX__)
 	ifaddrs adapter;
-	ifaddrs* buffer;
+	AdapterUtils::AdapterBuffer buffer;
 	if (AdapterUtils::GetIfAdapter(EmuConfig.DEV9.EthDevice, &adapter, &buffer))
-	{
 		ReloadInternalServer(&adapter);
-		freeifaddrs(buffer);
-	}
 	else
 		ReloadInternalServer(nullptr);
 #endif

--- a/pcsx2/DEV9/sockets.cpp
+++ b/pcsx2/DEV9/sockets.cpp
@@ -162,7 +162,7 @@ SocketAdapter::SocketAdapter()
 
 #ifdef _WIN32
 	IP_ADAPTER_ADDRESSES adapter;
-	std::unique_ptr<IP_ADAPTER_ADDRESSES[]> buffer;
+	AdapterUtils::AdapterBuffer buffer;
 
 	if (strcmp(EmuConfig.DEV9.EthDevice.c_str(), "Auto") != 0)
 	{
@@ -196,7 +196,7 @@ SocketAdapter::SocketAdapter()
 	}
 #elif defined(__POSIX__)
 	ifaddrs adapter;
-	ifaddrs* buffer;
+	AdapterUtils::AdapterBuffer buffer;
 
 	if (strcmp(EmuConfig.DEV9.EthDevice.c_str(), "Auto") != 0)
 	{
@@ -214,7 +214,6 @@ SocketAdapter::SocketAdapter()
 		else
 		{
 			Console.Error("DEV9: Socket: Failed To Get Adapter IP");
-			freeifaddrs(buffer);
 			return;
 		}
 	}
@@ -239,9 +238,6 @@ SocketAdapter::SocketAdapter()
 	const IP_Address gateway = internalIP;
 
 	InitInternalServer(&adapter, true, ps2IP, subnet, gateway);
-#ifdef __POSIX__
-	freeifaddrs(buffer);
-#endif
 
 	u8 hostMAC[6];
 	u8 newMAC[6];
@@ -433,7 +429,7 @@ void SocketAdapter::reloadSettings()
 	bool foundAdapter = false;
 #ifdef _WIN32
 	IP_ADAPTER_ADDRESSES adapter;
-	std::unique_ptr<IP_ADAPTER_ADDRESSES[]> buffer;
+	AdapterUtils::AdapterBuffer buffer;
 
 	if (strcmp(EmuConfig.DEV9.EthDevice.c_str(), "Auto") != 0)
 		foundAdapter = AdapterUtils::GetWin32Adapter(EmuConfig.DEV9.EthDevice, &adapter, &buffer);
@@ -442,7 +438,7 @@ void SocketAdapter::reloadSettings()
 
 #elif defined(__POSIX__)
 	ifaddrs adapter;
-	ifaddrs* buffer;
+	AdapterUtils::AdapterBuffer buffer;
 
 	if (strcmp(EmuConfig.DEV9.EthDevice.c_str(), "Auto") != 0)
 		foundAdapter = AdapterUtils::GetIfAdapter(EmuConfig.DEV9.EthDevice, &adapter, &buffer);
@@ -455,12 +451,7 @@ void SocketAdapter::reloadSettings()
 	const IP_Address gateway = internalIP;
 
 	if (foundAdapter)
-	{
 		ReloadInternalServer(&adapter, true, ps2IP, subnet, gateway);
-#ifdef __POSIX__
-		freeifaddrs(buffer);
-#endif
-	}
 	else
 	{
 		pxAssert(false);


### PR DESCRIPTION
### Description of Changes
Adjust formatting of AdapterUtils.
Use unique_ptr to manage lifetime of ifaddrs array.
typedef the buffer unique_ptr to make it simpler to use.

### Rationale behind Changes
More consistent formatting.
Makes AdapterUtils a little simpler to use.

### Suggested Testing Steps
Test networking on Linux.
