### PR TITLE
OSD: Fix invisible inputs

### DIFF
--- a/pcsx2/Frontend/ImGuiOverlays.cpp
+++ b/pcsx2/Frontend/ImGuiOverlays.cpp
@@ -517,8 +517,10 @@ void ImGuiManager::DrawInputsOverlay()
 				{
 					// buttons only shown when active
 					const float value = static_cast<float>(g_key_status.GetRawPressure(port, bind)) * (1.0f / 255.0f);
-					if (value >= 0.5f)
+					if (value == 1.0f)
 						fmt::format_to(std::back_inserter(text), " {}", bi.name);
+					else if (value > 0.0f)
+						fmt::format_to(std::back_inserter(text), " {}: {:.2f}", bi.name, value);
 				}
 				break;
 


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Resolves inputs not appearing on OSD by changing pressure threshold for buttons to >0.00 from >= 0.50

Allows pressure to be seen on buttons that have it

~~Changes default button deadzone to 0.25 from 0.00~~
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
May or may not resolve #7881, ~~the deadzone can always be configured if users are unhappy, but having no deadzone causes problems when an analog stick is mapped to a digital button.~~
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Map an analog stick to the dpad and see if the inputs and OSD match

Try using a pressure sensitive button and see if the inputs and OSD match