### PR TITLE
GameDB: Add SoftwareRendererFMVHack to Onimusha: Warlords

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -10063,6 +10063,8 @@ SLES-50247:
   compat: 5
   gsHWFixes:
     texturePreloading: 1 # Performs much better with partial preload.
+  gameFixes:
+    - SoftwareRendererFMVHack # Fixes flickering fmvs.
 SLES-50248:
   name: "MDK 2 - Armageddon"
   region: "PAL-M5"
@@ -34540,6 +34542,8 @@ SLPM-67507:
   region: "NTSC-K"
   gsHWFixes:
     texturePreloading: 1 # Performs much better with partial preload.
+  gameFixes:
+    - SoftwareRendererFMVHack # Fixes flickering fmvs.
 SLPM-67508:
   name: "Gitaroo Man"
   region: "NTSC-K"
@@ -40546,6 +40550,8 @@ SLUS-20018:
   compat: 5
   gsHWFixes:
     texturePreloading: 1 # Performs much better with partial preload.
+  gameFixes:
+    - SoftwareRendererFMVHack # Fixes flickering fmvs.
 SLUS-20021:
   name: "Kengo - Master of Bushido"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
Added switch to software renderer on fmvs to 3 regions of Onimusha - warlords

### Rationale behind Changes
It can be extremely dangerous for people who suffer from epilepy, and this is only added temporarily until a better fix is made. it should close #7787 as not planned for now.

### Suggested Testing Steps
Make sure refraction is ok with it and that it builds correctly
