### PR TITLE
GameDB: Add Mipmapping and Trilinear to Parappa the Rapper 2

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -2907,7 +2907,7 @@ SCES-50408:
     MTVUSpeedHack: 0
   gsHWFixes:
     mipmap: 2 # Fixes missing floor texture.
-    trilinearFiltering: 1 #Fixes fog effect.
+    trilinearFiltering: 1 # Fixes fog effect.
 SCES-50409:
   name: "MotoGP 2"
   region: "PAL-M5"
@@ -5623,7 +5623,7 @@ SCPS-15017:
     MTVUSpeedHack: 0
   gsHWFixes:
     mipmap: 2 # Fixes missing floor texture.
-    trilinearFiltering: 1 #Fixes fog effect.
+    trilinearFiltering: 1 # Fixes fog effect.
 SCPS-15018:
   name: "Train Simulator Real, The - Yamanote Sen"
   region: "NTSC-J"
@@ -6282,7 +6282,7 @@ SCPS-19201:
     MTVUSpeedHack: 0
   gsHWFixes:
     mipmap: 2 # Fixes missing floor texture.
-    trilinearFiltering: 1 #Fixes fog effect.
+    trilinearFiltering: 1 # Fixes fog effect.
 SCPS-19202:
   name: "Extermination [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -7295,7 +7295,7 @@ SCUS-97167:
     MTVUSpeedHack: 0
   gsHWFixes:
     mipmap: 2 # Fixes missing floor texture.
-    trilinearFiltering: 1 #Fixes fog effect.
+    trilinearFiltering: 1 # Fixes fog effect.
 SCUS-97169:
   name: "Drakan - The Ancients' Gates [Demo]"
   region: "NTSC-U"

--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -2902,11 +2902,12 @@ SCES-50408:
   name: "PaRappa the Rapper 2"
   region: "PAL-M5"
   compat: 5
-  gsHWFixes:
-    mipmap: 1 # Fixes missing floor texture
   speedHacks:
     InstantVU1SpeedHack: 0 # Fixes noodles.
     MTVUSpeedHack: 0
+  gsHWFixes:
+    mipmap: 2 # Fixes missing floor texture
+    trilinearFiltering: 1
 SCES-50409:
   name: "MotoGP 2"
   region: "PAL-M5"
@@ -5617,11 +5618,12 @@ SCPS-15016:
 SCPS-15017:
   name: "PaRappa the Rapper 2"
   region: "NTSC-J"
-  gsHWFixes:
-    mipmap: 1 # Fixes missing floor texture
   speedHacks:
     InstantVU1SpeedHack: 0 # Fixes noodles.
     MTVUSpeedHack: 0
+  gsHWFixes:
+    mipmap: 2 # Fixes missing floor texture
+    trilinearFiltering: 1
 SCPS-15018:
   name: "Train Simulator Real, The - Yamanote Sen"
   region: "NTSC-J"
@@ -6275,11 +6277,12 @@ SCPS-19153:
 SCPS-19201:
   name: "PaRappa the Rapper 2 [PlayStation 2 The Best]"
   region: "NTSC-J"
-  gsHWFixes:
-    mipmap: 1 # Fixes missing floor texture
   speedHacks:
     InstantVU1SpeedHack: 0 # Fixes noodles.
     MTVUSpeedHack: 0
+  gsHWFixes:
+    mipmap: 2 # Fixes missing floor texture
+    trilinearFiltering: 1
 SCPS-19202:
   name: "Extermination [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -7287,11 +7290,12 @@ SCUS-97167:
   name: "PaRappa the Rapper 2"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    mipmap: 1 # Fixes missing floor texture
   speedHacks:
     InstantVU1SpeedHack: 0 # Fixes noodles.
     MTVUSpeedHack: 0
+  gsHWFixes:
+    mipmap: 2 # Fixes missing floor texture
+    trilinearFiltering: 1
 SCUS-97169:
   name: "Drakan - The Ancients' Gates [Demo]"
   region: "NTSC-U"

--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -2902,6 +2902,8 @@ SCES-50408:
   name: "PaRappa the Rapper 2"
   region: "PAL-M5"
   compat: 5
+  gsHWFixes:
+    mipmap: 1 # Fixes missing floor texture
   speedHacks:
     InstantVU1SpeedHack: 0 # Fixes noodles.
     MTVUSpeedHack: 0
@@ -5615,6 +5617,8 @@ SCPS-15016:
 SCPS-15017:
   name: "PaRappa the Rapper 2"
   region: "NTSC-J"
+  gsHWFixes:
+    mipmap: 1 # Fixes missing floor texture
   speedHacks:
     InstantVU1SpeedHack: 0 # Fixes noodles.
     MTVUSpeedHack: 0
@@ -6271,6 +6275,8 @@ SCPS-19153:
 SCPS-19201:
   name: "PaRappa the Rapper 2 [PlayStation 2 The Best]"
   region: "NTSC-J"
+  gsHWFixes:
+    mipmap: 1 # Fixes missing floor texture
   speedHacks:
     InstantVU1SpeedHack: 0 # Fixes noodles.
     MTVUSpeedHack: 0
@@ -7281,6 +7287,8 @@ SCUS-97167:
   name: "PaRappa the Rapper 2"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    mipmap: 1 # Fixes missing floor texture
   speedHacks:
     InstantVU1SpeedHack: 0 # Fixes noodles.
     MTVUSpeedHack: 0

--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -2906,8 +2906,8 @@ SCES-50408:
     InstantVU1SpeedHack: 0 # Fixes noodles.
     MTVUSpeedHack: 0
   gsHWFixes:
-    mipmap: 2 # Fixes missing floor texture
-    trilinearFiltering: 1
+    mipmap: 2 # Fixes missing floor texture.
+    trilinearFiltering: 1 #Fixes fog effect.
 SCES-50409:
   name: "MotoGP 2"
   region: "PAL-M5"
@@ -5622,8 +5622,8 @@ SCPS-15017:
     InstantVU1SpeedHack: 0 # Fixes noodles.
     MTVUSpeedHack: 0
   gsHWFixes:
-    mipmap: 2 # Fixes missing floor texture
-    trilinearFiltering: 1
+    mipmap: 2 # Fixes missing floor texture.
+    trilinearFiltering: 1 #Fixes fog effect.
 SCPS-15018:
   name: "Train Simulator Real, The - Yamanote Sen"
   region: "NTSC-J"
@@ -6281,8 +6281,8 @@ SCPS-19201:
     InstantVU1SpeedHack: 0 # Fixes noodles.
     MTVUSpeedHack: 0
   gsHWFixes:
-    mipmap: 2 # Fixes missing floor texture
-    trilinearFiltering: 1
+    mipmap: 2 # Fixes missing floor texture.
+    trilinearFiltering: 1 #Fixes fog effect.
 SCPS-19202:
   name: "Extermination [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -7294,8 +7294,8 @@ SCUS-97167:
     InstantVU1SpeedHack: 0 # Fixes noodles.
     MTVUSpeedHack: 0
   gsHWFixes:
-    mipmap: 2 # Fixes missing floor texture
-    trilinearFiltering: 1
+    mipmap: 2 # Fixes missing floor texture.
+    trilinearFiltering: 1 #Fixes fog effect.
 SCUS-97169:
   name: "Drakan - The Ancients' Gates [Demo]"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
Adds Full mipmapping to parappa the rapper 2 to fix missing floor textures,
and Trilinear filtering to fix fog in certain levels Closes #7922

### Rationale behind Changes
It's how the game should look like normally.

### Suggested Testing Steps
Make sure it builds correctly. and that nothing more needs to be added.
