### PR TITLE
GameDB: Syphon Filter: The Omega Strain Beta Speed Fix

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -50677,8 +50677,8 @@ TCES-52033:
       content: |-
         author=YukiXXL
         // Speed Correction (25 FPS)
-        patch=1,EE,00175848,extended,00000019
         patch=1,EE,00175a7c,extended,00000019
+        patch=1,EE,00175848,extended,00000019
 TCES-52042:
   name: "Formula One 04 Beta Trial Code"
   region: "PAL-E"

--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -2186,6 +2186,12 @@ SCED-52162:
 SCED-52163:
   name: "Official PlayStation 2 Magazine Demo 48"
   region: "PAL-M5"
+  patches:
+    E1D1987F:
+      content: |-
+        author=YukiXXL
+        // Speed Correction (25 FPS)
+        patch=1,EE,00173f60,extended,00000019
 SCED-52164:
   name: "Official PlayStation 2 Magazine Demo 49"
   region: "PAL-M5"
@@ -2269,6 +2275,12 @@ SCED-52578:
 SCED-52619:
   name: "Official PlayStation 2 Magazine Demo 48"
   region: "PAL-M5"
+  patches:
+    90C0E5F1:
+      content: |-
+        author=YukiXXL
+        // Speed Correction (25 FPS)
+        patch=1,EE,00173f60,extended,00000019
 SCED-52681:
   name: "Gran Turismo 4 BMW 1 Series Virtual Drive [Demo]"
   region: "PAL-M11"
@@ -2716,6 +2728,12 @@ SCED-54414:
 SCED-54415:
   name: "Official PlayStation 2 Magazine Demo 90"
   region: "PAL-M5"
+  patches:
+    EDCD7FA9:
+      content: |-
+        author=YukiXXL
+        // Speed Correction (25 FPS)
+        patch=1,EE,00173f60,extended,00000019
 SCED-54416:
   name: "Official PlayStation 2 Magazine Demo 91"
   region: "PAL-M5"
@@ -50672,6 +50690,13 @@ TCES-52033:
     halfPixelOffset: 2 # Corrects light position.
   gameFixes:
     - EETimingHack # Fixes random hangs.
+  patches:
+    0DDA2728:
+      content: |-
+        author=YukiXXL
+        // Speed Correction (25 FPS)
+        patch=1,EE,00175848,extended,00000019
+        patch=1,EE,00175a7c,extended,00000019
 TCES-52042:
   name: "Formula One 04 Beta Trial Code"
   region: "PAL-E"

--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -2186,12 +2186,6 @@ SCED-52162:
 SCED-52163:
   name: "Official PlayStation 2 Magazine Demo 48"
   region: "PAL-M5"
-  patches:
-    E1D1987F:
-      content: |-
-        author=YukiXXL
-        // Speed Correction (25 FPS)
-        patch=1,EE,00173f60,extended,00000019
 SCED-52164:
   name: "Official PlayStation 2 Magazine Demo 49"
   region: "PAL-M5"
@@ -2275,12 +2269,6 @@ SCED-52578:
 SCED-52619:
   name: "Official PlayStation 2 Magazine Demo 48"
   region: "PAL-M5"
-  patches:
-    90C0E5F1:
-      content: |-
-        author=YukiXXL
-        // Speed Correction (25 FPS)
-        patch=1,EE,00173f60,extended,00000019
 SCED-52681:
   name: "Gran Turismo 4 BMW 1 Series Virtual Drive [Demo]"
   region: "PAL-M11"
@@ -2728,12 +2716,6 @@ SCED-54414:
 SCED-54415:
   name: "Official PlayStation 2 Magazine Demo 90"
   region: "PAL-M5"
-  patches:
-    EDCD7FA9:
-      content: |-
-        author=YukiXXL
-        // Speed Correction (25 FPS)
-        patch=1,EE,00173f60,extended,00000019
 SCED-54416:
   name: "Official PlayStation 2 Magazine Demo 91"
   region: "PAL-M5"


### PR DESCRIPTION
### Description of Changes
This beta's region is PAL and it has the same abnormal speed issue as the PAL version of the final release of Syphon Filter: The Omega Strain, same issue was discussed here #7806  so this is a patch to fix it

### Rationale behind Changes
This Syphon Filter PAL Beta runs at an incorrect speed just like the final PAL version of the game

### Suggested Testing Steps
-Run game without patch, it runs on 50 FPS on most session, but sometimes when you reboot it runs at 25 FPS
-On PS2 it runs at 25 FPS
-The Final release version of this beta has the same issue
-The NTSC version on the game is 30 FPS so the PAL must be 25 FPS not 50 FPS
-Apply the patch and the game will run at 25 FPS (in-game only not the menus which is correct)