### PR TITLE
GameDB: Syphon Filter: The Omega Virus (NTSC-K) DNAS Fix

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -4981,6 +4981,10 @@ SCKA-20032:
         // Cop2 problems.
         patch=1,EE,00398898,word,48438000 //4b06521b
         patch=1,EE,0039889c,word,4b06521b //48438000
+        author=1UP
+        // DNAS Bypass
+        patch=1,EE,20384D30,word,03E00008
+        patch=1,EE,20384D34,word,00000000
 SCKA-20033:
   name: "Smash Court Professional Tournament 2 [Limited Edition]"
   region: "NTSC-K"


### PR DESCRIPTION
### Description of Changes
Most PS2 games have "Date captures" for their DNAS, but the Korean version of this game doesn't. so when people try to play the game online they can't pass DNAS, and the capture for it is lost forever, i know DNAS codes are not a normal thing to implement automatically in the database, but there will never be another solution in the future, and people can't play this game online without these codes

### Rationale behind Changes
DNAS captures were never made for this game and it's lost forever and the game doesn't got online without those patches

### Suggested Testing Steps
-Boot the game, play online
-The game can't authenticate DNAS
-Apply the patches
-Try again and now the game bypasses DNAS authentication