### PR TITLE
GameDB: Correct Colin McRae Rally 3 sun rendering

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -11913,6 +11913,8 @@ SLES-51117:
   region: "PAL-M5"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
+    autoFlush: 1 # Fixes the sun flare.
+    halfPixelOffset: 2 # Fixes the sun flare.
 SLES-51118:
   name: "Wizardry - Tales of the Forsaken Land"
   region: "PAL-E"
@@ -42618,6 +42620,8 @@ SLUS-20502:
   compat: 5
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
+    autoFlush: 1 # Fixes the sun flare.
+    halfPixelOffset: 2 # Fixes the sun flare.
 SLUS-20504:
   name: "Tony Hawk's Pro Skater 4"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
Corrects sun rendering in CMR3 in Hardware mode and with upscaling, presumably by allowing the sun's occlusion query to work correctly.

SW:
![image](https://user-images.githubusercontent.com/7947461/213870798-634c8a63-735c-42e1-b171-849ea08dab6d.png)

HW, Vulkan, 4x upscaling, current master:
![image](https://user-images.githubusercontent.com/7947461/213870893-90eb8d5e-4b6a-4372-baa6-1488cbd8bef5.png)

HW, Vulkan, 4x upscaling, with this PR:
![image](https://user-images.githubusercontent.com/7947461/213870909-3357165b-f843-42cc-adba-7c800f084ebd.png)

### Rationale behind Changes
Hax is fix.

### Suggested Testing Steps
Check Colin McRae Rally 3.
