### PR TITLE
GameDB: Add AutoFlush to Battle For Volcano Island

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -20045,6 +20045,7 @@ SLES-54521:
   gsHWFixes:
     mipmap: 2 # Better characters and environment.
     trilinearFiltering: 1 # Using mipmaps, so may as well.
+    autoFlush: 1 # Fixes texture corruptions.
     getSkipCount: "GSC_BlueTongueGames" # Mipmap rendering on CPU.
 SLES-54527:
   name: "Flushed Away"
@@ -47662,6 +47663,7 @@ SLUS-21469:
   gsHWFixes:
     mipmap: 2 # Better characters and environment.
     trilinearFiltering: 1 # Using mipmaps, so may as well.
+    autoFlush: 1 # Fixes texture corruptions.
     getSkipCount: "GSC_BlueTongueGames" # Render mipmaps on the CPU.
 SLUS-21470:
   name: "Bratz - Forever Diamondz"


### PR DESCRIPTION
### Description of Changes
Adds autoflush to fix texture corruptions.

### Rationale behind Changes
Textures doing the rainbow is bad.

### Suggested Testing Steps
Make sure CI is happy.
