### PR TITLE
GS: Don't do fast clear if SCANMSK is enabled.

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -3118,8 +3118,6 @@ SCES-50887:
   name: "Alpine Racer 3"
   region: "PAL-M5"
   compat: 5
-  gsHWFixes:
-    deinterlace: 9 # Game requires Adaptive BFF de-interlacing when auto.
 SCES-50888:
   name: "Pac-Man World 2"
   region: "PAL-M5"
@@ -6632,8 +6630,6 @@ SCPS-51005:
 SCPS-51006:
   name: "Alpine Racer 3"
   region: "NTSC-J"
-  gsHWFixes:
-    deinterlace: 9 # Game requires Adaptive BFF de-interlacing when auto.
 SCPS-51008:
   name: "Wave Rally"
   region: "NTSC-J"
@@ -35567,8 +35563,6 @@ SLPS-20178:
 SLPS-20181:
   name: "Alpine Racer 3"
   region: "NTSC-J"
-  gsHWFixes:
-    deinterlace: 9 # Game requires Adaptive BFF de-interlacing when auto.
 SLPS-20183:
   name: "Motto Golful Golf"
   region: "NTSC-J"

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -4349,6 +4349,7 @@ bool GSRendererHW::IsConstantDirectWriteMemClear()
 	if ((m_vt.m_primclass == GS_SPRITE_CLASS) && !PRIM->TME // Direct write
 		&& (!PRIM->ABE || IsOpaque() || m_context->ALPHA.IsCdOutput()) // No transparency
 		&& (m_context->FRAME.FBMSK == 0) // no color mask
+		&& !(m_env.SCANMSK.MSK & 2)
 		&& !m_context->TEST.ATE // no alpha test
 		&& (!m_context->TEST.ZTE || m_context->TEST.ZTST == ZTST_ALWAYS) // no depth test
 		&& (m_vt.m_eq.rgba == 0xFFFF) // constant color write

--- a/pcsx2/pcsx2core.vcxproj.filters
+++ b/pcsx2/pcsx2core.vcxproj.filters
@@ -1235,7 +1235,6 @@
     <ClCompile Include="x86\iR5900Analysis.cpp">
       <Filter>System\Ps2\EmotionEngine\EE\Dynarec</Filter>
     </ClCompile>
-    <ClCompile Include="GSDumpReplayer.cpp" />
     <ClCompile Include="GS\Renderers\DX12\GSTexture12.cpp">
       <Filter>System\Ps2\GS\Renderers\Direct3D12</Filter>
     </ClCompile>
@@ -1388,6 +1387,9 @@
     </ClCompile>
     <ClCompile Include="SPU2\SndOut_XAudio2.cpp">
       <Filter>System\Ps2\SPU2</Filter>
+    </ClCompile>
+    <ClCompile Include="GSDumpReplayer.cpp">
+      <Filter>Tools</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -1967,9 +1969,6 @@
     <ClInclude Include="GS\Renderers\Common\GSFastList.h">
       <Filter>System\Ps2\GS</Filter>
     </ClInclude>
-    <ClInclude Include="GS.h">
-      <Filter>System\Ps2\GS\GIF</Filter>
-    </ClInclude>
     <ClInclude Include="GS\Renderers\DX11\GSDevice11.h">
       <Filter>System\Ps2\GS\Renderers\Direct3D11</Filter>
     </ClInclude>
@@ -2157,7 +2156,6 @@
     <ClInclude Include="x86\iR5900Analysis.h">
       <Filter>System\Ps2\EmotionEngine\EE\Dynarec</Filter>
     </ClInclude>
-    <ClInclude Include="GSDumpReplayer.h" />
     <ClInclude Include="GS\Renderers\DX12\GSTexture12.h">
       <Filter>System\Ps2\GS\Renderers\Direct3D12</Filter>
     </ClInclude>
@@ -2209,7 +2207,6 @@
     <ClInclude Include="Frontend\Achievements.h">
       <Filter>Host</Filter>
     </ClInclude>
-    <ClInclude Include="Achievements.h" />
     <ClInclude Include="ShaderCacheVersion.h">
       <Filter>System\Include</Filter>
     </ClInclude>
@@ -2323,6 +2320,15 @@
     </ClInclude>
     <ClInclude Include="IPU\mpeg2_vlc.h">
       <Filter>System\Ps2\IPU</Filter>
+    </ClInclude>
+    <ClInclude Include="Achievements.h">
+      <Filter>Tools</Filter>
+    </ClInclude>
+    <ClInclude Include="GSDumpReplayer.h">
+      <Filter>Tools</Filter>
+    </ClInclude>
+    <ClInclude Include="GS.h">
+      <Filter>System\Ps2\GS\GIF</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
### Description of Changes
Don't do the fast mem clear in hardware if scanmsk is enabled.
Also fixed up some VS filters for files not being in respective locations while I was there.

### Rationale behind Changes
It broke Rimoko Koron's Sony Entertainment screen, and it's also incorrect behaviour.
Seems to also fix the same bad behaviour in Alpine Racer 3.
Apparently fixes Ichigeki Sacchuu! Hoihoi-san also.

### Suggested Testing Steps
Test Rimoko Koron in hardware.

Fixes #7923