### PR TITLE
GameDB: Fixes for SpongeBob - The Movie

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -15856,20 +15856,20 @@ SLES-52895:
   region: "PAL-E"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 1 # Fixes bloom misalignment when upscaling
-    cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling
+    halfPixelOffset: 1 # Fixes bloom misalignment when upscaling.
+    cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling.
 SLES-52896:
   name: "Spongebob SquarePants - The Movie"
   region: "PAL-F-G"
   gsHWFixes:
-    halfPixelOffset: 1 # Fixes bloom misalignment when upscaling
-    cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling
+    halfPixelOffset: 1 # Fixes bloom misalignment when upscaling.
+    cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling.
 SLES-52897:
   name: "Spongebob SquarePants - The Movie"
   region: "PAL-I"
   gsHWFixes:
-    halfPixelOffset: 1 # Fixes bloom misalignment when upscaling
-    cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling
+    halfPixelOffset: 1 # Fixes bloom misalignment when upscaling.
+    cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling.
 SLES-52898:
   name: "King of Fighters - Maximum Impact"
   region: "PAL-E-JP"
@@ -16100,8 +16100,8 @@ SLES-52985:
   name: "Spongebob SquarePants - The Movie"
   region: "PAL-G"
   gsHWFixes:
-    halfPixelOffset: 1 # Fixes bloom misalignment
-    cpuCLUTRender: 1 # Fixes duplicated bloom
+    halfPixelOffset: 1 # Fixes bloom misalignment when upscaling.
+    cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling.
 SLES-52986:
   name: "Bob Esponja La Película"
   region: "PAL-S"
@@ -44549,8 +44549,8 @@ SLUS-20904:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 1 # Fixes bloom misalignment when upscaling
-    cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling
+    halfPixelOffset: 1 # Fixes bloom misalignment when upscaling.
+    cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling.
 SLUS-20905:
   name: "Incredibles, The"
   region: "NTSC-U"

--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -15855,12 +15855,21 @@ SLES-52895:
   name: "Spongebob SquarePants - The Movie"
   region: "PAL-E"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 1 # Fixes bloom misalignment when upscaling
+    cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling
 SLES-52896:
   name: "Spongebob SquarePants - The Movie"
   region: "PAL-F-G"
+  gsHWFixes:
+    halfPixelOffset: 1 # Fixes bloom misalignment when upscaling
+    cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling
 SLES-52897:
   name: "Spongebob SquarePants - The Movie"
   region: "PAL-I"
+  gsHWFixes:
+    halfPixelOffset: 1 # Fixes bloom misalignment when upscaling
+    cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling
 SLES-52898:
   name: "King of Fighters - Maximum Impact"
   region: "PAL-E-JP"
@@ -16090,6 +16099,9 @@ SLES-52984:
 SLES-52985:
   name: "Spongebob SquarePants - The Movie"
   region: "PAL-G"
+  gsHWFixes:
+    halfPixelOffset: 1 # Fixes bloom misalignment
+    cpuCLUTRender: 1 # Fixes duplicated bloom
 SLES-52986:
   name: "Bob Esponja La Película"
   region: "PAL-S"
@@ -44536,6 +44548,9 @@ SLUS-20904:
   name: "SpongeBob SquarePants - The Movie"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 1 # Fixes bloom misalignment when upscaling
+    cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling
 SLUS-20905:
   name: "Incredibles, The"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
This PR contains fixes for misaligned and incorrect bloom effects when upscaling is used for SpongeBob The Movie.

### Rationale behind Changes
When upscaling is used, the bloom looks misaligned and duplicated, it looks disorienting.

Screenshot on 4x Upscale:
![SpongeBob SquarePants - The Movie_SLUS-20904_20230122193653](https://user-images.githubusercontent.com/14798312/213918270-5bf090ed-ea93-4e38-97b0-0d5de0f0df4a.png)

In Native Res:
![SpongeBob SquarePants - The Movie_SLUS-20904_20230122202745](https://user-images.githubusercontent.com/14798312/213918334-3cc1e339-c047-41f7-ad73-699e9f0f0707.png)


### Suggested Testing Steps
Make sure the bloom in-game are pleasant to see!
and make sure CI Bois is happy ;)

I have also tested it myself:
![Screenshot_20230122_203034](https://user-images.githubusercontent.com/14798312/213918436-296e4d81-c02d-44fb-823f-fc01210240ed.png)

