### PR TITLE
GS: Misc changes

### DIFF
--- a/common/GL/Program.cpp
+++ b/common/GL/Program.cpp
@@ -60,7 +60,10 @@ namespace GL
 		GLint info_log_length = 0;
 		glGetShaderiv(id, GL_INFO_LOG_LENGTH, &info_log_length);
 
-		if (status == GL_FALSE || info_log_length > 0)
+		// Log will create a new line when there are no warnings so let's set a minimum log length of 1.
+		constexpr int info_log_min_length = 1;
+
+		if (status == GL_FALSE || info_log_length > info_log_min_length)
 		{
 			std::string info_log;
 			info_log.resize(info_log_length + 1);

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -1554,7 +1554,7 @@ void GSRendererHW::Draw()
 		}
 
 		// Texture shuffle is not yet supported with strange clamp mode
-		ASSERT(!m_texture_shuffle || (context->stack.CLAMP.WMS < 3 && context->stack.WMT < 3));
+		ASSERT(!m_texture_shuffle || (context->CLAMP.WMS < 3 && context->CLAMP.WMT < 3));
 
 		if (m_src->m_target && m_context->TEX0.PSM == PSM_PSMT8 && single_page && draw_sprite_tex)
 		{

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -141,7 +141,7 @@ bool GSDeviceOGL::Create()
 		m_features.line_expand = false;
 	}
 
-	Console.WriteLn("Using %s for point expansion and %s for line expansion.",
+	DevCon.WriteLn("Using %s for point expansion and %s for line expansion.",
 		m_features.point_expand ? "hardware" : "geometry shaders", m_features.line_expand ? "hardware" : "geometry shaders");
 
 	{
@@ -994,9 +994,7 @@ std::string GSDeviceOGL::GenGlslHeader(const std::string_view& entry, GLenum typ
 
 std::string GSDeviceOGL::GetVSSource(VSSelector sel)
 {
-#ifdef PCSX2_DEVBUILD
-	Console.WriteLn("Compiling new vertex shader with selector 0x%" PRIX64, sel.key);
-#endif
+	DevCon.WriteLn("Compiling new vertex shader with selector 0x%" PRIX64, sel.key);
 
 	std::string macro = fmt::format("#define VS_INT_FST {}\n", static_cast<u32>(sel.int_fst))
 		+ fmt::format("#define VS_IIP {}\n", static_cast<u32>(sel.iip))
@@ -1012,9 +1010,7 @@ std::string GSDeviceOGL::GetVSSource(VSSelector sel)
 
 std::string GSDeviceOGL::GetGSSource(GSSelector sel)
 {
-#ifdef PCSX2_DEVBUILD
-	Console.WriteLn("Compiling new geometry shader with selector 0x%" PRIX64, sel.key);
-#endif
+	DevCon.WriteLn("Compiling new geometry shader with selector 0x%" PRIX64, sel.key);
 
 	std::string macro = fmt::format("#define GS_POINT {}\n", static_cast<u32>(sel.point))
 		+ fmt::format("#define GS_LINE {}\n", static_cast<u32>(sel.line))
@@ -1028,9 +1024,7 @@ std::string GSDeviceOGL::GetGSSource(GSSelector sel)
 
 std::string GSDeviceOGL::GetPSSource(const PSSelector& sel)
 {
-#ifdef PCSX2_DEVBUILD
-	Console.WriteLn("Compiling new pixel shader with selector 0x%" PRIX64 "%08X", sel.key_hi, sel.key_lo);
-#endif
+	DevCon.WriteLn("Compiling new pixel shader with selector 0x%" PRIX64 "%08X", sel.key_hi, sel.key_lo);
 
 	std::string macro = fmt::format("#define PS_FST {}\n", sel.fst)
 		+ fmt::format("#define PS_WMS {}\n", sel.wms)

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
@@ -270,7 +270,7 @@ bool GSDeviceVK::CheckFeatures()
 		(features.largePoints && limits.pointSizeRange[0] <= f_upscale && limits.pointSizeRange[1] >= f_upscale);
 	m_features.line_expand =
 		(features.wideLines && limits.lineWidthRange[0] <= f_upscale && limits.lineWidthRange[1] >= f_upscale);
-	Console.WriteLn("Using %s for point expansion and %s for line expansion.",
+	DevCon.WriteLn("Using %s for point expansion and %s for line expansion.",
 		m_features.point_expand ? "hardware" : "geometry shaders",
 		m_features.line_expand ? "hardware" : "geometry shaders");
 


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS-gl/vk: Cleanup some logs.
Instead of ifdefing the longs use Devcon, does the same thing. Hide point expansion logs behind dev/debug build.
common-ogl: Fix Shader compiled with warnings log spam on gl.
Observed on intel igpu.
GS-hw: Fix texture shuffle assert which broke debug builds.
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Log fixes and cleanup, debug build fix.
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Logs work as intended, debug build compiles.