### PR TITLE
VM: Queue shutdown message when called from inside emulation.

### DIFF
--- a/pcsx2-qt/QtHost.cpp
+++ b/pcsx2-qt/QtHost.cpp
@@ -1237,9 +1237,16 @@ void Host::RequestVMShutdown(bool allow_confirm, bool allow_save_state, bool def
 	if (!VMManager::HasValidVM())
 		return;
 
-	// Run it on the host thread, that way we get the confirm prompt (if enabled).
-	QMetaObject::invokeMethod(g_main_window, "requestShutdown", Qt::QueuedConnection, Q_ARG(bool, allow_confirm),
-		Q_ARG(bool, allow_save_state), Q_ARG(bool, default_save_state), Q_ARG(bool, false));
+	if (allow_confirm)
+	{
+		// Run it on the host thread, that way we get the confirm prompt (if enabled).
+		QMetaObject::invokeMethod(g_main_window, "requestShutdown", Qt::QueuedConnection, Q_ARG(bool, allow_confirm),
+			Q_ARG(bool, allow_save_state), Q_ARG(bool, default_save_state), Q_ARG(bool, false));
+	}
+	else
+	{
+		g_emu_thread->shutdownVM(allow_save_state && default_save_state);
+	}
 }
 
 bool Host::IsFullscreen()

--- a/pcsx2/CDVD/CDVD.cpp
+++ b/pcsx2/CDVD/CDVD.cpp
@@ -37,7 +37,7 @@
 #include "Elfheader.h"
 #include "ps2/BiosTools.h"
 #include "Recording/InputRecording.h"
-#include "VMManager.h"
+#include "Host.h"
 
 // This typically reflects the Sony-assigned serial code for the Disc, if one exists.
 //  (examples:  SLUS-2113, etc).
@@ -2440,8 +2440,8 @@ static void cdvdWrite16(u8 rt) // SCOMMAND
 
 
 			case 0x0F: // sceCdPowerOff (0:1)- Call74 from Xcdvdman
-				Console.WriteLn(Color_StrongBlack, "sceCdPowerOff called. Resetting VM.");
-				VMManager::Reset();
+				Console.WriteLn(Color_StrongBlack, "sceCdPowerOff called. Shutting down VM.");
+				Host::RequestVMShutdown(false, false, false);
 				break;
 
 			case 0x12: // sceCdReadILinkId (0:9)


### PR DESCRIPTION
### Description of Changes
Queues a VM shutdown when called via CdPowerOff which is inside a currently running block.

### Rationale behind Changes
Shutting down/Resetting the VM in the middle of executing a block will cause everything to explode (was crashing) as the state gets partially overwritten at the end of the block, so the reset is invalid.  Shutting down also doesn't work as it'll attempt to update sound output etc which will no longer exist.  so it's better to queue it and let it deal with it at a convenient point.

### Suggested Testing Steps
Run the following ELF, make sure it just closes the emulation and goes back to the game list.

[cdvdPowerOff.zip](https://github.com/PCSX2/pcsx2/files/10475155/cdvdPowerOff.zip)

