### PR TITLE
GSRunner: Release globals on shutdown

### DIFF
--- a/pcsx2-gsrunner/Main.cpp
+++ b/pcsx2-gsrunner/Main.cpp
@@ -644,6 +644,7 @@ int main(int argc, char* argv[])
 
 	InputManager::CloseSources();
 	VMManager::Internal::ReleaseMemory();
+	VMManager::Internal::ReleaseGlobals();
 	PerformanceMetrics::SetCPUThread(Threading::ThreadHandle());
 	GSRunner::DestroyPlatformWindow();
 


### PR DESCRIPTION
### Description of Changes

This was missing, which meant `GSshutdown()` wasn't called, which meant the screenshot threads weren't joined before exiting `main()`.

### Rationale behind Changes

Hopefully sorting out the random-missing-frames when doing regression runs.

### Suggested Testing Steps

Nothing for testers here.
