### PR TITLE
DEV9: Move adapter MAC address code into AdapterUtils

### DIFF
--- a/pcsx2/DEV9/AdapterUtils.cpp
+++ b/pcsx2/DEV9/AdapterUtils.cpp
@@ -46,7 +46,7 @@ using namespace PacketReader;
 using namespace PacketReader::IP;
 
 #ifdef _WIN32
-bool AdapterUtils::GetWin32Adapter(const std::string& name, PIP_ADAPTER_ADDRESSES adapter, AdapterBuffer* buffer)
+bool AdapterUtils::GetAdapter(const std::string& name, Adapter* adapter, AdapterBuffer* buffer)
 {
 	int neededSize = 128;
 	std::unique_ptr<IP_ADAPTER_ADDRESSES[]> adapterInfo = std::make_unique<IP_ADAPTER_ADDRESSES[]>(neededSize);
@@ -95,7 +95,7 @@ bool AdapterUtils::GetWin32Adapter(const std::string& name, PIP_ADAPTER_ADDRESSE
 
 	return false;
 }
-bool AdapterUtils::GetWin32AdapterAuto(PIP_ADAPTER_ADDRESSES adapter, AdapterBuffer* buffer)
+bool AdapterUtils::GetAdapterAuto(Adapter* adapter, AdapterBuffer* buffer)
 {
 	int neededSize = 128;
 	std::unique_ptr<IP_ADAPTER_ADDRESSES[]> adapterInfo = std::make_unique<IP_ADAPTER_ADDRESSES[]>(neededSize);
@@ -172,7 +172,7 @@ bool AdapterUtils::GetWin32AdapterAuto(PIP_ADAPTER_ADDRESSES adapter, AdapterBuf
 	return false;
 }
 #elif defined(__POSIX__)
-bool AdapterUtils::GetIfAdapter(const std::string& name, ifaddrs* adapter, AdapterBuffer* buffer)
+bool AdapterUtils::GetAdapter(const std::string& name, Adapter* adapter, AdapterBuffer* buffer)
 {
 	ifaddrs* ifa;
 	ifaddrs* pAdapter;
@@ -202,7 +202,7 @@ bool AdapterUtils::GetIfAdapter(const std::string& name, ifaddrs* adapter, Adapt
 
 	return false;
 }
-bool AdapterUtils::GetIfAdapterAuto(ifaddrs* adapter, AdapterBuffer* buffer)
+bool AdapterUtils::GetAdapterAuto(Adapter* adapter, AdapterBuffer* buffer)
 {
 	ifaddrs* ifa;
 	ifaddrs* pAdapter;
@@ -250,7 +250,7 @@ bool AdapterUtils::GetIfAdapterAuto(ifaddrs* adapter, AdapterBuffer* buffer)
 
 // AdapterMAC.
 #ifdef _WIN32
-std::optional<MAC_Address> AdapterUtils::GetAdapterMAC(PIP_ADAPTER_ADDRESSES adapter)
+std::optional<MAC_Address> AdapterUtils::GetAdapterMAC(Adapter* adapter)
 {
 	if (adapter != nullptr && adapter->PhysicalAddressLength == 6)
 		return *(MAC_Address*)adapter->PhysicalAddress;
@@ -259,7 +259,7 @@ std::optional<MAC_Address> AdapterUtils::GetAdapterMAC(PIP_ADAPTER_ADDRESSES ada
 }
 #elif defined(__POSIX__)
 #ifdef __linux__
-std::optional<MAC_Address> AdapterUtils::GetAdapterMAC(ifaddrs* adapter)
+std::optional<MAC_Address> AdapterUtils::GetAdapterMAC(Adapter* adapter)
 {
 	struct ifreq ifr;
 	strcpy(ifr.ifr_name, adapter->ifa_name);
@@ -274,7 +274,7 @@ std::optional<MAC_Address> AdapterUtils::GetAdapterMAC(ifaddrs* adapter)
 	return std::nullopt;
 }
 #else
-std::optional<MAC_Address> AdapterUtils::GetAdapterMAC(ifaddrs* adapter)
+std::optional<MAC_Address> AdapterUtils::GetAdapterMAC(Adapter* adapter)
 {
 	Console.Error("DEV9: Unsupported OS, can't get MAC address");
 	return std::nullopt;
@@ -284,7 +284,7 @@ std::optional<MAC_Address> AdapterUtils::GetAdapterMAC(ifaddrs* adapter)
 
 // AdapterIP.
 #ifdef _WIN32
-std::optional<IP_Address> AdapterUtils::GetAdapterIP(PIP_ADAPTER_ADDRESSES adapter)
+std::optional<IP_Address> AdapterUtils::GetAdapterIP(Adapter* adapter)
 {
 	PIP_ADAPTER_UNICAST_ADDRESS address = nullptr;
 	if (adapter != nullptr)
@@ -302,7 +302,7 @@ std::optional<IP_Address> AdapterUtils::GetAdapterIP(PIP_ADAPTER_ADDRESSES adapt
 	return std::nullopt;
 }
 #elif defined(__POSIX__)
-std::optional<IP_Address> AdapterUtils::GetAdapterIP(ifaddrs* adapter)
+std::optional<IP_Address> AdapterUtils::GetAdapterIP(Adapter* adapter)
 {
 	sockaddr* address = nullptr;
 	if (adapter != nullptr)
@@ -322,7 +322,7 @@ std::optional<IP_Address> AdapterUtils::GetAdapterIP(ifaddrs* adapter)
 
 // Gateways.
 #ifdef _WIN32
-std::vector<IP_Address> AdapterUtils::GetGateways(PIP_ADAPTER_ADDRESSES adapter)
+std::vector<IP_Address> AdapterUtils::GetGateways(Adapter* adapter)
 {
 	if (adapter == nullptr)
 		return {};
@@ -344,7 +344,7 @@ std::vector<IP_Address> AdapterUtils::GetGateways(PIP_ADAPTER_ADDRESSES adapter)
 }
 #elif defined(__POSIX__)
 #ifdef __linux__
-std::vector<IP_Address> AdapterUtils::GetGateways(ifaddrs* adapter)
+std::vector<IP_Address> AdapterUtils::GetGateways(Adapter* adapter)
 {
 	// /proc/net/route contains some information about gateway addresses,
 	// and separates the information about by each interface.
@@ -390,7 +390,7 @@ std::vector<IP_Address> AdapterUtils::GetGateways(ifaddrs* adapter)
 	return collection;
 }
 #elif defined(__FreeBSD__) || (__APPLE__)
-std::vector<IP_Address> AdapterUtils::GetGateways(ifaddrs* adapter)
+std::vector<IP_Address> AdapterUtils::GetGateways(Adapter* adapter)
 {
 	if (adapter == nullptr)
 		return {};
@@ -470,7 +470,7 @@ std::vector<IP_Address> AdapterUtils::GetGateways(ifaddrs* adapter)
 	return collection;
 }
 #else
-std::vector<IP_Address> AdapterUtils::GetGateways(ifaddrs* adapter)
+std::vector<IP_Address> AdapterUtils::GetGateways(Adapter* adapter)
 {
 	Console.Error("DEV9: Unsupported OS, can't find Gateway");
 	return {};
@@ -480,7 +480,7 @@ std::vector<IP_Address> AdapterUtils::GetGateways(ifaddrs* adapter)
 
 // DNS.
 #ifdef _WIN32
-std::vector<IP_Address> AdapterUtils::GetDNS(PIP_ADAPTER_ADDRESSES adapter)
+std::vector<IP_Address> AdapterUtils::GetDNS(Adapter* adapter)
 {
 	if (adapter == nullptr)
 		return {};
@@ -501,7 +501,7 @@ std::vector<IP_Address> AdapterUtils::GetDNS(PIP_ADAPTER_ADDRESSES adapter)
 	return collection;
 }
 #elif defined(__POSIX__)
-std::vector<IP_Address> AdapterUtils::GetDNS(ifaddrs* adapter)
+std::vector<IP_Address> AdapterUtils::GetDNS(Adapter* adapter)
 {
 	// On Linux and OSX, DNS is system wide, not adapter specific, so we can ignore the adapter parameter.
 

--- a/pcsx2/DEV9/AdapterUtils.h
+++ b/pcsx2/DEV9/AdapterUtils.h
@@ -32,28 +32,22 @@
 namespace AdapterUtils
 {
 #ifdef _WIN32
+	typedef IP_ADAPTER_ADDRESSES Adapter;
 	typedef std::unique_ptr<IP_ADAPTER_ADDRESSES[]> AdapterBuffer;
-	bool GetWin32Adapter(const std::string& name, PIP_ADAPTER_ADDRESSES adapter, AdapterBuffer* buffer);
-	bool GetWin32AdapterAuto(PIP_ADAPTER_ADDRESSES adapter, std::unique_ptr<IP_ADAPTER_ADDRESSES[]>* buffer);
-
-	std::optional<PacketReader::MAC_Address> GetAdapterMAC(PIP_ADAPTER_ADDRESSES adapter);
-	std::optional<PacketReader::IP::IP_Address> GetAdapterIP(PIP_ADAPTER_ADDRESSES adapter);
-	// Mask.
-	std::vector<PacketReader::IP::IP_Address> GetGateways(PIP_ADAPTER_ADDRESSES adapter);
-	std::vector<PacketReader::IP::IP_Address> GetDNS(PIP_ADAPTER_ADDRESSES adapter);
 #elif defined(__POSIX__)
+	typedef ifaddrs Adapter;
 	struct IfAdaptersDeleter
 	{
 		void operator()(ifaddrs* buffer) const { freeifaddrs(buffer); }
 	};
 	typedef std::unique_ptr<ifaddrs, IfAdaptersDeleter> AdapterBuffer;
-	bool GetIfAdapter(const std::string& name, ifaddrs* adapter, AdapterBuffer* buffer);
-	bool GetIfAdapterAuto(ifaddrs* adapter, AdapterBuffer* buffer);
-
-	std::optional<PacketReader::MAC_Address> GetAdapterMAC(ifaddrs* adapter);
-	std::optional<PacketReader::IP::IP_Address> GetAdapterIP(ifaddrs* adapter);
-	// Mask.
-	std::vector<PacketReader::IP::IP_Address> GetGateways(ifaddrs* adapter);
-	std::vector<PacketReader::IP::IP_Address> GetDNS(ifaddrs* adapter);
 #endif
+	bool GetAdapter(const std::string& name, Adapter* adapter, AdapterBuffer* buffer);
+	bool GetAdapterAuto(Adapter* adapter, AdapterBuffer* buffer);
+
+	std::optional<PacketReader::MAC_Address> GetAdapterMAC(Adapter* adapter);
+	std::optional<PacketReader::IP::IP_Address> GetAdapterIP(Adapter* adapter);
+	// Mask.
+	std::vector<PacketReader::IP::IP_Address> GetGateways(Adapter* adapter);
+	std::vector<PacketReader::IP::IP_Address> GetDNS(Adapter* adapter);
 }; // namespace AdapterUtils

--- a/pcsx2/DEV9/AdapterUtils.h
+++ b/pcsx2/DEV9/AdapterUtils.h
@@ -26,6 +26,7 @@
 #include <string>
 #include <optional>
 
+#include "DEV9/PacketReader/MAC_Address.h"
 #include "DEV9/PacketReader/IP/IP_Address.h"
 
 namespace AdapterUtils
@@ -35,6 +36,7 @@ namespace AdapterUtils
 	bool GetWin32Adapter(const std::string& name, PIP_ADAPTER_ADDRESSES adapter, AdapterBuffer* buffer);
 	bool GetWin32AdapterAuto(PIP_ADAPTER_ADDRESSES adapter, std::unique_ptr<IP_ADAPTER_ADDRESSES[]>* buffer);
 
+	std::optional<PacketReader::MAC_Address> GetAdapterMAC(PIP_ADAPTER_ADDRESSES adapter);
 	std::optional<PacketReader::IP::IP_Address> GetAdapterIP(PIP_ADAPTER_ADDRESSES adapter);
 	// Mask.
 	std::vector<PacketReader::IP::IP_Address> GetGateways(PIP_ADAPTER_ADDRESSES adapter);
@@ -48,6 +50,7 @@ namespace AdapterUtils
 	bool GetIfAdapter(const std::string& name, ifaddrs* adapter, AdapterBuffer* buffer);
 	bool GetIfAdapterAuto(ifaddrs* adapter, AdapterBuffer* buffer);
 
+	std::optional<PacketReader::MAC_Address> GetAdapterMAC(ifaddrs* adapter);
 	std::optional<PacketReader::IP::IP_Address> GetAdapterIP(ifaddrs* adapter);
 	// Mask.
 	std::vector<PacketReader::IP::IP_Address> GetGateways(ifaddrs* adapter);

--- a/pcsx2/DEV9/sockets.cpp
+++ b/pcsx2/DEV9/sockets.cpp
@@ -156,13 +156,12 @@ SocketAdapter::SocketAdapter()
 {
 	bool foundAdapter;
 
-#ifdef _WIN32
-	IP_ADAPTER_ADDRESSES adapter;
+	AdapterUtils::Adapter adapter;
 	AdapterUtils::AdapterBuffer buffer;
 
 	if (strcmp(EmuConfig.DEV9.EthDevice.c_str(), "Auto") != 0)
 	{
-		foundAdapter = AdapterUtils::GetWin32Adapter(EmuConfig.DEV9.EthDevice, &adapter, &buffer);
+		foundAdapter = AdapterUtils::GetAdapter(EmuConfig.DEV9.EthDevice, &adapter, &buffer);
 
 		if (!foundAdapter)
 		{
@@ -181,7 +180,7 @@ SocketAdapter::SocketAdapter()
 	}
 	else
 	{
-		foundAdapter = AdapterUtils::GetWin32AdapterAuto(&adapter, &buffer);
+		foundAdapter = AdapterUtils::GetAdapterAuto(&adapter, &buffer);
 		adapterIP = {};
 
 		if (!foundAdapter)
@@ -190,41 +189,6 @@ SocketAdapter::SocketAdapter()
 			return;
 		}
 	}
-#elif defined(__POSIX__)
-	ifaddrs adapter;
-	AdapterUtils::AdapterBuffer buffer;
-
-	if (strcmp(EmuConfig.DEV9.EthDevice.c_str(), "Auto") != 0)
-	{
-		foundAdapter = AdapterUtils::GetIfAdapter(EmuConfig.DEV9.EthDevice, &adapter, &buffer);
-
-		if (!foundAdapter)
-		{
-			Console.Error("DEV9: Socket: Failed to Get Adapter");
-			return;
-		}
-
-		std::optional<IP_Address> adIP = AdapterUtils::GetAdapterIP(&adapter);
-		if (adIP.has_value())
-			adapterIP = adIP.value();
-		else
-		{
-			Console.Error("DEV9: Socket: Failed To Get Adapter IP");
-			return;
-		}
-	}
-	else
-	{
-		foundAdapter = AdapterUtils::GetIfAdapterAuto(&adapter, &buffer);
-		adapterIP = {0};
-
-		if (!foundAdapter)
-		{
-			Console.Error("DEV9: Socket: Auto Selection Failed, Check You Connection or Manually Specify Adapter");
-			return;
-		}
-	}
-#endif
 
 	//For DHCP, we need to override some settings
 	//DNS settings as per direct adapters
@@ -409,24 +373,14 @@ void SocketAdapter::reset()
 void SocketAdapter::reloadSettings()
 {
 	bool foundAdapter = false;
-#ifdef _WIN32
-	IP_ADAPTER_ADDRESSES adapter;
+
+	AdapterUtils::Adapter adapter;
 	AdapterUtils::AdapterBuffer buffer;
 
 	if (strcmp(EmuConfig.DEV9.EthDevice.c_str(), "Auto") != 0)
-		foundAdapter = AdapterUtils::GetWin32Adapter(EmuConfig.DEV9.EthDevice, &adapter, &buffer);
+		foundAdapter = AdapterUtils::GetAdapter(EmuConfig.DEV9.EthDevice, &adapter, &buffer);
 	else
-		foundAdapter = AdapterUtils::GetWin32AdapterAuto(&adapter, &buffer);
-
-#elif defined(__POSIX__)
-	ifaddrs adapter;
-	AdapterUtils::AdapterBuffer buffer;
-
-	if (strcmp(EmuConfig.DEV9.EthDevice.c_str(), "Auto") != 0)
-		foundAdapter = AdapterUtils::GetIfAdapter(EmuConfig.DEV9.EthDevice, &adapter, &buffer);
-	else
-		foundAdapter = AdapterUtils::GetIfAdapterAuto(&adapter, &buffer);
-#endif
+		foundAdapter = AdapterUtils::GetAdapterAuto(&adapter, &buffer);
 
 	const IP_Address ps2IP = {{{internalIP.bytes[0], internalIP.bytes[1], internalIP.bytes[2], 100}}};
 	const IP_Address subnet{{{255, 255, 255, 0}}};


### PR DESCRIPTION
### Description of Changes
Moves code for getting the adapter MAC address into AdapterUtils.
Unifies the definitions for `GetAdapter*()` methods.
Better handle situations where we fail to get the MAC address.

### Rationale behind Changes
Reduced code duplication.
Makes AdapterUtils a little simpler to use.

### Suggested Testing Steps
Test pcap on Windows & Linux
