### PR TITLE
GS: Show VRAM usage in statistics

### DIFF
--- a/pcsx2/Frontend/ImGuiOverlays.cpp
+++ b/pcsx2/Frontend/ImGuiOverlays.cpp
@@ -180,9 +180,14 @@ void ImGuiManager::DrawPerformanceOverlay()
 
 		if (GSConfig.OsdShowGSStats)
 		{
-			std::string gs_stats;
-			GSgetStats(gs_stats);
-			DRAW_LINE(fixed_font, gs_stats.c_str(), IM_COL32(255, 255, 255, 255));
+			text.clear();
+			GSgetStats(text);
+			DRAW_LINE(fixed_font, text.c_str(), IM_COL32(255, 255, 255, 255));
+
+			text.clear();
+			GSgetMemoryStats(text);
+			if (!text.empty())
+				DRAW_LINE(fixed_font, text.c_str(), IM_COL32(255, 255, 255, 255));
 		}
 
 		if (GSConfig.OsdShowResolution)

--- a/pcsx2/GS/GS.h
+++ b/pcsx2/GS/GS.h
@@ -81,6 +81,7 @@ void GSsetGameCRC(u32 crc);
 GSVideoMode GSgetDisplayMode();
 void GSgetInternalResolution(int* width, int* height);
 void GSgetStats(std::string& info);
+void GSgetMemoryStats(std::string& info);
 void GSgetTitleStats(std::string& info);
 
 /// Converts window position to normalized display coordinates (0..1). A value less than 0 or greater than 1 is

--- a/pcsx2/GS/Renderers/Common/GSDevice.h
+++ b/pcsx2/GS/Renderers/Common/GSDevice.h
@@ -724,6 +724,7 @@ public:
 
 private:
 	FastList<GSTexture*> m_pool;
+	u64 m_pool_memory_usage = 0;
 	static const std::array<HWBlend, 3*3*3*3> m_blendMap;
 	static const std::array<u8, 16> m_replaceDualSrcBlendMap;
 
@@ -772,6 +773,7 @@ public:
 	virtual ~GSDevice();
 
 	__fi unsigned int GetFrameNumber() const { return m_frame; }
+	__fi u64 GetPoolMemoryUsage() const { return m_pool_memory_usage; }
 
 	void Recycle(GSTexture* t);
 
@@ -854,8 +856,6 @@ public:
 	void PurgePool();
 
 	virtual void ClearSamplerCache();
-
-	virtual void PrintMemoryUsage();
 
 	__fi static constexpr bool IsDualSourceBlendFactor(u8 factor)
 	{

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -222,9 +222,6 @@ void GSRendererHW::VSync(u32 field, bool registers_written)
 		GSConfig.TexturePreloading = TexturePreloadingLevel::Partial;
 	}
 
-	m_tc->PrintMemoryUsage();
-	g_gs_device->PrintMemoryUsage();
-
 	m_skip = 0;
 	m_skip_offset = 0;
 }

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.h
@@ -92,9 +92,6 @@ public:
 		void UpdateAge();
 		bool Inside(u32 bp, u32 bw, u32 psm, const GSVector4i& rect);
 		bool Overlaps(u32 bp, u32 bw, u32 psm, const GSVector4i& rect);
-
-		bool ResizeTexture(int new_width, int new_height, bool recycle_old = true);
-		bool ResizeTexture(int new_width, int new_height, GSVector2 new_scale, bool recycle_old = true);
 	};
 
 	struct PaletteKey
@@ -200,6 +197,7 @@ public:
 
 	public:
 		Target(const GIFRegTEX0& TEX0, const bool depth_supported, const int type);
+		~Target();
 
 		void UpdateValidity(const GSVector4i& rect);
 
@@ -207,6 +205,9 @@ public:
 
 		/// Updates the target, if the dirty area intersects with the specified rectangle.
 		void UpdateIfDirtyIntersects(const GSVector4i& rc);
+
+		bool ResizeTexture(int new_width, int new_height, bool recycle_old = true);
+		bool ResizeTexture(int new_width, int new_height, GSVector2 new_scale, bool recycle_old = true);
 	};
 
 	class PaletteMap
@@ -298,15 +299,20 @@ public:
 protected:
 	PaletteMap m_palette_map;
 	SourceMap m_src;
+	u64 m_source_memory_usage = 0;
 	std::unordered_map<HashCacheKey, HashCacheEntry, HashCacheKeyHash> m_hash_cache;
 	u64 m_hash_cache_memory_usage = 0;
-	u64 m_hash_cache_replacement_memory_usage;
+	u64 m_hash_cache_replacement_memory_usage = 0;
+
 	FastList<Target*> m_dst[2];
 	FastList<TargetHeightElem> m_target_heights;
-	static u8* m_temp;
+	u64 m_target_memory_usage = 0;
+
 	constexpr static size_t S_SURFACE_OFFSET_CACHE_MAX_SIZE = std::numeric_limits<u16>::max();
 	std::unordered_map<SurfaceOffsetKey, SurfaceOffset, SurfaceOffsetKeyHash, SurfaceOffsetKeyEqual> m_surface_offset_cache;
+
 	Source* m_temporary_source = nullptr; // invalidated after the draw
+
 	std::unique_ptr<GSDownloadTexture> m_color_download_texture;
 	std::unique_ptr<GSDownloadTexture> m_uint16_download_texture;
 	std::unique_ptr<GSDownloadTexture> m_uint32_download_texture;
@@ -336,6 +342,8 @@ public:
 	__fi u64 GetHashCacheMemoryUsage() const { return m_hash_cache_memory_usage; }
 	__fi u64 GetHashCacheReplacementMemoryUsage() const { return m_hash_cache_replacement_memory_usage; }
 	__fi u64 GetTotalHashCacheMemoryUsage() const { return (m_hash_cache_memory_usage + m_hash_cache_replacement_memory_usage); }
+	__fi u64 GetSourceMemoryUsage() const { return m_source_memory_usage; }
+	__fi u64 GetTargetMemoryUsage() const { return m_target_memory_usage; }
 
 	void Read(Target* t, const GSVector4i& r);
 	void Read(Source* t, const GSVector4i& r);
@@ -371,8 +379,6 @@ public:
 	{
 		return (type == DepthStencil) ? "Depth" : "Color";
 	}
-
-	void PrintMemoryUsage();
 
 	void AttachPaletteToSource(Source* s, u16 pal, bool need_gs_texture);
 	void AttachPaletteToSource(Source* s, GSTexture* gpu_clut);


### PR DESCRIPTION
### Description of Changes

Breaks down VRAM usage into the various pools, making it more obvious when we have spikes.

Legend:
```
S: Sources (including copies of targets).
T: Targets (where we render to, this is generally the main user of VRAM).
H: Hash cache (complete textures).
P: Pool (textures which can be immediately reused without allocation).
```

### Rationale behind Changes

Nice to know when PCSX2 VRAM spikes (e.g. #7952).

### Suggested Testing Steps

Test new stats, make sure they don't underflow past 0 (I think I caught all the allocation sites..).
