### PR TITLE
Remove explicit save state cache invalidation and add a distinct error when a save state file doesn't exist

### DIFF
--- a/pcsx2-gsrunner/Main.cpp
+++ b/pcsx2-gsrunner/Main.cpp
@@ -351,10 +351,6 @@ void Host::OnSaveStateSaved(const std::string_view& filename)
 {
 }
 
-void Host::InvalidateSaveStateCache()
-{
-}
-
 void Host::RunOnCPUThread(std::function<void()> function, bool block /* = false */)
 {
 	pxFailRel("Not implemented");

--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -157,7 +157,7 @@ void MainWindow::initialize()
 	restoreStateFromConfig();
 	switchToGameListView();
 	updateWindowTitle();
-	updateSaveStateMenus(QString(), QString(), 0);
+	updateSaveStateMenusEnableState(false);
 
 #ifdef _WIN32
 	registerForDeviceNotifications();
@@ -1259,11 +1259,6 @@ void MainWindow::cancelGameListRefresh()
 	m_game_list_widget->cancelRefresh();
 }
 
-void MainWindow::invalidateSaveStateCache()
-{
-	m_save_states_invalidated = true;
-}
-
 void MainWindow::reportError(const QString& title, const QString& message)
 {
 	QMessageBox::critical(this, title, message);
@@ -1372,11 +1367,6 @@ std::optional<WindowInfo> MainWindow::getWindowInfo()
 		return QtUtils::GetWindowInfoForWidget(widget);
 	else
 		return std::nullopt;
-}
-
-void Host::InvalidateSaveStateCache()
-{
-	QMetaObject::invokeMethod(g_main_window, &MainWindow::invalidateSaveStateCache, Qt::QueuedConnection);
 }
 
 void MainWindow::onGameListRefreshProgress(const QString& status, int current, int total)
@@ -1581,14 +1571,14 @@ void MainWindow::onChangeDiscMenuAboutToHide()
 
 void MainWindow::onLoadStateMenuAboutToShow()
 {
-	if (m_save_states_invalidated)
-		updateSaveStateMenus(m_current_disc_path, m_current_game_serial, m_current_game_crc);
+	updateSaveStateMenusEnableState(!m_current_game_serial.isEmpty());
+	populateLoadStateMenu(m_ui.menuLoadState, m_current_disc_path, m_current_game_serial, m_current_game_crc);
 }
 
 void MainWindow::onSaveStateMenuAboutToShow()
 {
-	if (m_save_states_invalidated)
-		updateSaveStateMenus(m_current_disc_path, m_current_game_serial, m_current_game_crc);
+	updateSaveStateMenusEnableState(!m_current_game_serial.isEmpty());
+	populateSaveStateMenu(m_ui.menuSaveState, m_current_game_serial, m_current_game_crc);
 }
 
 void MainWindow::onViewToolbarActionToggled(bool checked)
@@ -1890,7 +1880,7 @@ void MainWindow::onVMStarting()
 	updateWindowTitle();
 
 	// prevent loading state until we're fully initialized
-	updateSaveStateMenus(QString(), QString(), 0);
+	updateSaveStateMenusEnableState(false);
 }
 
 void MainWindow::onVMStarted()
@@ -1970,7 +1960,7 @@ void MainWindow::onGameChanged(const QString& path, const QString& elf_override,
 	m_current_game_name = name;
 	m_current_game_crc = crc;
 	updateWindowTitle();
-	updateSaveStateMenus(path, serial, crc);
+	updateSaveStateMenusEnableState(!serial.isEmpty());
 }
 
 void MainWindow::showEvent(QShowEvent* event)
@@ -2723,6 +2713,8 @@ static QString formatTimestampForSaveStateMenu(time_t timestamp)
 
 void MainWindow::populateLoadStateMenu(QMenu* menu, const QString& filename, const QString& serial, quint32 crc)
 {
+	menu->clear();
+
 	if (serial.isEmpty())
 		return;
 
@@ -2797,6 +2789,8 @@ void MainWindow::populateLoadStateMenu(QMenu* menu, const QString& filename, con
 
 void MainWindow::populateSaveStateMenu(QMenu* menu, const QString& serial, quint32 crc)
 {
+	menu->clear();
+
 	if (serial.isEmpty())
 		return;
 
@@ -2826,21 +2820,14 @@ void MainWindow::populateSaveStateMenu(QMenu* menu, const QString& serial, quint
 	}
 }
 
-void MainWindow::updateSaveStateMenus(const QString& filename, const QString& serial, quint32 crc)
+void MainWindow::updateSaveStateMenusEnableState(bool enable)
 {
-	const bool load_enabled = !serial.isEmpty();
-	const bool save_enabled = !serial.isEmpty() && s_vm_valid;
-	m_ui.menuLoadState->clear();
+	const bool load_enabled = enable;
+	const bool save_enabled = enable && s_vm_valid;
 	m_ui.menuLoadState->setEnabled(load_enabled);
 	m_ui.actionLoadState->setEnabled(load_enabled);
-	m_ui.menuSaveState->clear();
 	m_ui.menuSaveState->setEnabled(save_enabled);
 	m_ui.actionSaveState->setEnabled(save_enabled);
-	m_save_states_invalidated = false;
-	if (load_enabled)
-		populateLoadStateMenu(m_ui.menuLoadState, filename, serial, crc);
-	if (save_enabled)
-		populateSaveStateMenu(m_ui.menuSaveState, serial, crc);
 }
 
 void MainWindow::doStartFile(std::optional<CDVD_SourceType> source, const QString& path)

--- a/pcsx2-qt/MainWindow.h
+++ b/pcsx2-qt/MainWindow.h
@@ -114,7 +114,6 @@ public Q_SLOTS:
 	void checkForUpdates(bool display_message);
 	void refreshGameList(bool invalidate_cache);
 	void cancelGameListRefresh();
-	void invalidateSaveStateCache();
 	void reportError(const QString& title, const QString& message);
 	bool confirmMessage(const QString& title, const QString& message);
 	void runOnUIThread(const std::function<void()>& func);
@@ -261,7 +260,7 @@ private:
 	void loadSaveStateFile(const QString& filename, const QString& state_filename);
 	void populateLoadStateMenu(QMenu* menu, const QString& filename, const QString& serial, quint32 crc);
 	void populateSaveStateMenu(QMenu* menu, const QString& serial, quint32 crc);
-	void updateSaveStateMenus(const QString& filename, const QString& serial, quint32 crc);
+	void updateSaveStateMenusEnableState(bool enable);
 	void doStartFile(std::optional<CDVD_SourceType> source, const QString& path);
 	void doDiscChange(CDVD_SourceType source, const QString& path);
 
@@ -293,7 +292,6 @@ private:
 
 	bool m_display_created = false;
 	bool m_relative_mouse_mode = false;
-	bool m_save_states_invalidated = false;
 	bool m_was_paused_on_surface_loss = false;
 	bool m_was_disc_change_request = false;
 	bool m_is_closing = false;

--- a/pcsx2/SaveState.cpp
+++ b/pcsx2/SaveState.cpp
@@ -1059,9 +1059,18 @@ void SaveState_UnzipFromDisk(const std::string& filename)
 	if (!zf)
 	{
 		Console.Error("Failed to open zip file '%s' for save state load: %s", filename.c_str(), zip_error_strerror(&ze));
-		throw Exception::SaveStateLoadError(filename)
-			.SetDiagMsg("Savestate file is not a valid gzip archive.")
-			.SetUserMsg("This savestate cannot be loaded because it is not a valid gzip archive.  It may have been created by an older unsupported version of PCSX2, or it may be corrupted.");
+		if (zip_error_code_zip(&ze) == ZIP_ER_NOENT)
+		{
+			throw Exception::SaveStateLoadError(filename)
+				.SetDiagMsg("Savestate file does not exist.")
+				.SetUserMsg("This savestate cannot be loaded because the file does not exist.");
+		}
+		else
+		{
+			throw Exception::SaveStateLoadError(filename)
+				.SetDiagMsg("Savestate file is not a valid gzip archive.")
+				.SetUserMsg("This savestate cannot be loaded because it is not a valid gzip archive. It may have been created by an older unsupported version of PCSX2, or it may be corrupted.");
+		}
 	}
 
 	// look for version and screenshot information in the zip stream:

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -1339,8 +1339,6 @@ void VMManager::ZipSaveState(std::unique_ptr<ArchiveEntryList> elist,
 	}
 
 	DevCon.WriteLn("Zipping save state to '%s' took %.2f ms", filename, timer.GetTimeMilliseconds());
-
-	Host::InvalidateSaveStateCache();
 }
 
 void VMManager::ZipSaveStateOnThread(std::unique_ptr<ArchiveEntryList> elist, std::unique_ptr<SaveStateScreenshotData> screenshot,

--- a/pcsx2/VMManager.h
+++ b/pcsx2/VMManager.h
@@ -258,7 +258,4 @@ namespace Host
 
 	/// Provided by the host; called once per frame at guest vsync.
 	void CPUThreadVSync();
-
-	/// Provided by the host; called when a state is saved, and the frontend should invalidate its save state cache.
-	void InvalidateSaveStateCache();
 } // namespace Host

--- a/tests/ctest/core/StubHost.cpp
+++ b/tests/ctest/core/StubHost.cpp
@@ -176,10 +176,6 @@ void Host::OnSaveStateSaved(const std::string_view& filename)
 {
 }
 
-void Host::InvalidateSaveStateCache()
-{
-}
-
 void Host::RunOnCPUThread(std::function<void()> function, bool block /* = false */)
 {
 }


### PR DESCRIPTION
### Description of Changes
This PR fixes two distinct issues related to #7945:
1. Deleting states from the dropdown did not refresh the list of save states, so it was possible to attempt to load an inexistant save state. Now any "cache" has been removed and dropdowns are just being repopulated as the menu is about to show, because it's a lightweight operation anyway and it closes virtually any edge cases. Also comes with an added bonus of pre-emptively protecting against cases where the save state was removed from Explorer.
2. Adds a distinct error message when the save state load fails specifically because the file doesn't exist, instead of giving a generic "corrupted or invalid gzip archive" message.
![image](https://user-images.githubusercontent.com/7947461/214418885-0288a49f-8fd4-4b8b-a035-04f76173a23b.png)


### Rationale behind Changes
UI bugs ew.

### Suggested Testing Steps
* Make sure that #7945 is fixed.
* Make sure that save states populate dropdowns correctly still.

Fixes #7945.
