### PR TITLE
DInputSource: Use wil on m_dinput_module

### DIFF
--- a/pcsx2/Frontend/DInputSource.cpp
+++ b/pcsx2/Frontend/DInputSource.cpp
@@ -32,13 +32,7 @@ using PFNGETDFDIJOYSTICK = LPCDIDATAFORMAT(WINAPI*)();
 
 DInputSource::DInputSource() = default;
 
-DInputSource::~DInputSource()
-{
-	m_controllers.clear();
-	m_dinput.reset();
-	if (m_dinput_module)
-		FreeLibrary(m_dinput_module);
-}
+DInputSource::~DInputSource() = default;
 
 std::array<bool, DInputSource::NUM_HAT_DIRECTIONS> DInputSource::GetHatButtons(DWORD hat)
 {
@@ -69,15 +63,15 @@ static constexpr std::array<const char*, DInputSource::NUM_HAT_DIRECTIONS> s_hat
 
 bool DInputSource::Initialize(SettingsInterface& si, std::unique_lock<std::mutex>& settings_lock)
 {
-	m_dinput_module = LoadLibraryW(L"dinput8");
+	m_dinput_module.reset(LoadLibraryW(L"dinput8"));
 	if (!m_dinput_module)
 	{
 		Console.Error("Failed to load DInput module.");
 		return false;
 	}
 
-	PFNDIRECTINPUT8CREATE create = reinterpret_cast<PFNDIRECTINPUT8CREATE>(GetProcAddress(m_dinput_module, "DirectInput8Create"));
-	PFNGETDFDIJOYSTICK get_joystick_data_format = reinterpret_cast<PFNGETDFDIJOYSTICK>(GetProcAddress(m_dinput_module, "GetdfDIJoystick"));
+	PFNDIRECTINPUT8CREATE create = reinterpret_cast<PFNDIRECTINPUT8CREATE>(GetProcAddress(m_dinput_module.get(), "DirectInput8Create"));
+	PFNGETDFDIJOYSTICK get_joystick_data_format = reinterpret_cast<PFNGETDFDIJOYSTICK>(GetProcAddress(m_dinput_module.get(), "GetdfDIJoystick"));
 	if (!create || !get_joystick_data_format)
 	{
 		Console.Error("Failed to get DInput function pointers.");

--- a/pcsx2/Frontend/DInputSource.h
+++ b/pcsx2/Frontend/DInputSource.h
@@ -24,6 +24,8 @@
 #include <mutex>
 #include <vector>
 
+#include <wil/resource.h>
+
 class DInputSource final : public InputSource
 {
 public:
@@ -83,10 +85,11 @@ private:
 
 	void CheckForStateChanges(size_t index, const DIJOYSTATE& new_state);
 
-	ControllerDataArray m_controllers;
-
-	HMODULE m_dinput_module{};
+	// Those must go first in the class so they are destroyed last
+	wil::unique_hmodule m_dinput_module;
 	wil::com_ptr_nothrow<IDirectInput8W> m_dinput;
 	LPCDIDATAFORMAT m_joystick_data_format{};
-	HWND m_toplevel_window = NULL;
+	HWND m_toplevel_window = nullptr;
+
+	ControllerDataArray m_controllers;
 };


### PR DESCRIPTION
### Description of Changes
Replaces a manual `FreeLibrary` in `DInputSource` with WIL.

### Rationale behind Changes
RAII is good.

### Suggested Testing Steps
Make sure that DirectInput source initializes and shuts down correctly and without crashes, and the source itself is still functional.