### PR TITLE
OpenGLHostDisplay: Set colour mask before drawing OSD

### DIFF
--- a/pcsx2/Frontend/OpenGLHostDisplay.cpp
+++ b/pcsx2/Frontend/OpenGLHostDisplay.cpp
@@ -345,6 +345,7 @@ bool OpenGLHostDisplay::BeginPresent(bool frame_skip)
 
 	glDisable(GL_SCISSOR_TEST);
 	glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
+	glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
 	glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
 	glClear(GL_COLOR_BUFFER_BIT);
 	glViewport(0, 0, m_window_info.surface_width, m_window_info.surface_height);


### PR DESCRIPTION
### Description of Changes

Fixes OSD getting messed up when the GS output is turned off.

### Rationale behind Changes

Undefined screen contents isn't ideal.

### Suggested Testing Steps

Easiest one to test is TC:NYC after skipping the intro FMVs. Tested this myself.
