### PR TITLE
VMManager: Defer reset when running

### DIFF
--- a/pcsx2-qt/QtHost.cpp
+++ b/pcsx2-qt/QtHost.cpp
@@ -429,6 +429,10 @@ void EmuThread::executeVM()
 				VMManager::Execute();
 				continue;
 
+			case VMState::Resetting:
+				VMManager::Reset();
+				continue;
+
 			case VMState::Stopping:
 				destroyVM();
 				m_event_loop->processEvents(QEventLoop::AllEvents);

--- a/pcsx2/VMManager.h
+++ b/pcsx2/VMManager.h
@@ -35,6 +35,7 @@ enum class VMState
 	Initializing,
 	Running,
 	Paused,
+	Resetting,
 	Stopping,
 };
 


### PR DESCRIPTION
### Description of Changes

Stops us resetting during the event test, which can leave things in a pretty messed up state.

### Rationale behind Changes

Things get pretty messed up.

### Suggested Testing Steps

Easiest one to test is TC: NYC - skip the intro FMV, wait for the logo to be displayed, reset the VM. Skip the FMV again, PCSX2 should no longer crash.
