### PR TITLE
Build: Enable RTTI for Clang debug builds

### DIFF
--- a/pcsx2-qt/Settings/ControllerGlobalSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/ControllerGlobalSettingsWidget.cpp
@@ -151,7 +151,7 @@ void ControllerLEDSettingsDialog::linkButton(ColorPickerButton* button, u32 play
 	const u32 current_value = SDLInputSource::ParseRGBForPlayerId(m_dialog->getStringValue("SDLExtra", key.c_str(), ""), player_id);
 	button->setColor(current_value);
 
-	connect(button, &ColorPickerButton::colorChanged, this, [this, player_id, key = std::move(key)](u32 new_rgb) {
+	connect(button, &ColorPickerButton::colorChanged, this, [this, key = std::move(key)](u32 new_rgb) {
 		m_dialog->setStringValue("SDLExtra", key.c_str(), fmt::format("{:06X}", new_rgb).c_str());
 	});
 #endif

--- a/pcsx2-qt/pcsx2-qt.vcxproj
+++ b/pcsx2-qt/pcsx2-qt.vcxproj
@@ -71,6 +71,8 @@
       <FloatingPointModel>Precise</FloatingPointModel>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <ConformanceMode>true</ConformanceMode>
+      <!-- Current Qt debug builds assert on RTTI. Remove this once we next build Qt. -->
+      <RuntimeTypeInfo Condition="$(Configuration.Contains(Clang)) And $(Configuration.Contains(Debug))">true</RuntimeTypeInfo>
       <AdditionalOptions>/Zc:__cplusplus /Zo /utf-8%(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>


### PR DESCRIPTION
### Description of Changes

Qt tries to dynamic_cast as part of an assertion, which aborts at runtime. When we next rebuild Qt, we'll disable RTTI in Qt, so this will be a non-issue. But until then, this change makes debug clang builds usable.

### Rationale behind Changes

Clang debug builds currently abort at runtime.

### Suggested Testing Steps

None needed, CI doesn't generate debug builds.
