### PR TITLE
vtlb: Remove upper/lower 32-bit unmapped split

### DIFF
--- a/pcsx2/SingleRegisterTypes.h
+++ b/pcsx2/SingleRegisterTypes.h
@@ -89,17 +89,3 @@ __forceinline static u128 r128_to_u128(r128 val)
 	_mm_store_si128(reinterpret_cast<r128*>(&ret), val);
 	return ret;
 }
-
-template <typename u>
-struct rhelper;
-
-template <>
-struct rhelper<u128>
-{
-	using r = r128;
-	__forceinline static r load(void* ptr) { return r128_load(ptr); }
-	__forceinline static r zero() { return r128_zero(); }
-};
-
-template <typename u>
-using u_to_r = typename rhelper<u>::r;


### PR DESCRIPTION
### Description of Changes

This was only necessary on 32-bit because the sign bit was abused for representing handlers. Since we're 64-bit only, we use bit 63, which won't clash with the guest's 32-bit virtual address.

### Rationale behind Changes

Cleaner code. VTLB's already difficult enough to understand :-).

### Suggested Testing Steps

Test a few games, make sure they still run. Anything which doesn't TLB miss won't be affected, and I have tested with a couple of ELFs which do, and they still report the correct address.
