### PR TITLE
CDVD: Don't report host error on iso detect fail 

### DIFF
--- a/pcsx2/CDVD/GzippedFileReader.cpp
+++ b/pcsx2/CDVD/GzippedFileReader.cpp
@@ -293,7 +293,7 @@ bool GzippedFileReader::OkIndex()
 	Console.Warning("This may take a while (but only once). Scanning compressed file to generate a quick access index...");
 
 	const s64 prevoffset = FileSystem::FTell64(m_src);
-	Access* index;
+	Access* index = nullptr;
 	int len = build_index(m_src, GZFILE_SPAN_DEFAULT, &index);
 	printf("\n"); // build_index prints progress without \n's
 	FileSystem::FSeek64(m_src, prevoffset, SEEK_SET);

--- a/pcsx2/CDVD/InputIsoFile.cpp
+++ b/pcsx2/CDVD/InputIsoFile.cpp
@@ -21,7 +21,6 @@
 #include "Host.h"
 
 #include "common/Assertions.h"
-#include "common/Exceptions.h"
 
 #include "fmt/format.h"
 
@@ -254,7 +253,7 @@ bool InputIsoFile::Open(std::string srcfile, bool testOnly)
 
 	if (!detected)
 	{
-		Host::ReportErrorAsync("Unrecognized ISO image file format", "ISO mounting failed: PCSX2 is unable to identify the ISO image type.");
+		Console.Error(fmt::format("Unable to identify the ISO image type for '{}'", srcfile));
 		Close();
 		return false;
 	}

--- a/pcsx2/Frontend/GameList.cpp
+++ b/pcsx2/Frontend/GameList.cpp
@@ -306,11 +306,6 @@ bool GameList::GetIsoListEntry(const std::string& path, GameList::Entry* entry)
 	if (!FileSystem::StatFile(path.c_str(), &sd))
 		return false;
 
-	// This isn't great, we really want to make it all thread-local...
-	CDVD = &CDVDapi_Iso;
-	if (CDVD->open(path.c_str()) != 0)
-		return false;
-
 	s32 disc_type;
 	if (!GetIsoSerialAndCRC(path, &disc_type, &entry->serial, &entry->crc))
 		return false;


### PR DESCRIPTION
### Description of Changes

Possible regression from #7965, although I couldn't reproduce PCSX2 crashing. Regardless, spamming an error popup during game list scan is a bad thing.

### Rationale behind Changes

Unneeded popups if you happened to scan bad files.

### Suggested Testing Steps

Test game list scanning, opening valid+invalid files, make sure nothing crashes.

