### PR TITLE
DEV9: Sockets, Treat UDP connections with nearby src/dst ports as fixed 

### DIFF
--- a/pcsx2/DEV9/Sessions/TCP_Session/TCP_Session_In.cpp
+++ b/pcsx2/DEV9/Sessions/TCP_Session/TCP_Session_In.cpp
@@ -168,7 +168,7 @@ namespace Sessions
 					}
 					return nullptr;
 				}
-				DevCon.WriteLn("DEV9: TCP: [SRV]Sending %d bytes", recived);
+				DevCon.WriteLn("DEV9: TCP: [SRV] Sending %d bytes", recived);
 
 				PayloadData* recivedData = new PayloadData(recived);
 				memcpy(recivedData->data.get(), buffer.get(), recived);

--- a/pcsx2/DEV9/Sessions/UDP_Session/UDP_FixedPort.cpp
+++ b/pcsx2/DEV9/Sessions/UDP_Session/UDP_FixedPort.cpp
@@ -116,7 +116,7 @@ namespace Sessions
 		if (ret == SOCKET_ERROR)
 		{
 			hasData = false;
-			Console.WriteLn("DEV9: UDP: select failed. Error Code: %d",
+			Console.Error("DEV9: UDP: select failed. Error Code: %d",
 #ifdef _WIN32
 				WSAGetLastError());
 #elif defined(__POSIX__)

--- a/pcsx2/DEV9/sockets.cpp
+++ b/pcsx2/DEV9/sockets.cpp
@@ -563,7 +563,7 @@ bool SocketAdapter::SendUDP(ConnectionKey Key, IP_Packet* ipPkt)
 	{
 		UDP_Session* s = nullptr;
 
-		if (udp.sourcePort == udp.destinationPort || //Used for LAN games that assume the destination port
+		if (abs(udp.sourcePort - udp.destinationPort) <= 10 || //Used for games that assume the destination/source port
 			ipPkt->destinationIP == dhcpServer.broadcastIP || //Broadcast packets
 			ipPkt->destinationIP == IP_Address{{{255, 255, 255, 255}}} || //Limited Broadcast packets
 			(ipPkt->destinationIP.bytes[0] & 0xF0) == 0xE0) //Multicast address start with 0b1110

--- a/pcsx2/DEV9/sockets.cpp
+++ b/pcsx2/DEV9/sockets.cpp
@@ -582,7 +582,7 @@ bool SocketAdapter::SendUDP(ConnectionKey Key, IP_Packet* ipPkt)
 				fKey.ps2Port = udp.sourcePort;
 				fKey.srvPort = 0;
 
-				Console.WriteLn("DEV9: Socket: Creating New UDPFixedPort with port %d", udp.destinationPort);
+				Console.WriteLn("DEV9: Socket: Creating New UDPFixedPort with port %d", udp.sourcePort);
 
 				fPort = new UDP_FixedPort(fKey, adapterIP, udp.sourcePort);
 				fPort->AddConnectionClosedHandler([&](BaseSession* session) { HandleFixedPortClosed(session); });
@@ -594,7 +594,7 @@ bool SocketAdapter::SendUDP(ConnectionKey Key, IP_Packet* ipPkt)
 				fixedUDPPorts.Add(udp.sourcePort, fPort);
 			}
 
-			Console.WriteLn("DEV9: Socket: Creating New UDP Connection from FixedPort %d", udp.destinationPort);
+			Console.WriteLn("DEV9: Socket: Creating New UDP Connection from FixedPort %d to %d", udp.sourcePort, udp.destinationPort);
 			s = fPort->NewClientSession(Key,
 				ipPkt->destinationIP == dhcpServer.broadcastIP || ipPkt->destinationIP == IP_Address{{{255, 255, 255, 255}}},
 				(ipPkt->destinationIP.bytes[0] & 0xF0) == 0xE0);


### PR DESCRIPTION
### Description of Changes
Bind source port of UDP connections with nearby source & destination ports.

### Rationale behind Changes
In the sockets backend, UDP connections are by default treated as using ephemeral source ports.
Heuristics are used to determine when a UDP connection should be bind to the source port,
This proved too strict for some games using different (but nearby) ports for source/destination.

### Suggested Testing Steps
Test online games that use UDP packets for network communication, such as Twisted Metal:Black Online.