### PR TITLE
Qt: Better handle VM-requesting-shutdown case

### DIFF
--- a/pcsx2-gsrunner/Main.cpp
+++ b/pcsx2-gsrunner/Main.cpp
@@ -373,7 +373,7 @@ void Host::SetFullscreen(bool enabled)
 {
 }
 
-void Host::RequestExit(bool save_state_if_running)
+void Host::RequestExit(bool allow_confirm)
 {
 }
 

--- a/pcsx2-qt/AutoUpdaterDialog.cpp
+++ b/pcsx2-qt/AutoUpdaterDialog.cpp
@@ -465,7 +465,7 @@ void AutoUpdaterDialog::downloadUpdateClicked()
 	else if (result == 1)
 	{
 		// updater started. since we're a modal on the main window, we have to queue this.
-		QMetaObject::invokeMethod(g_main_window, &MainWindow::requestExit, Qt::QueuedConnection);
+		QMetaObject::invokeMethod(g_main_window, "requestExit", Qt::QueuedConnection, Q_ARG(bool, true));
 		done(0);
 	}
 

--- a/pcsx2-qt/DisplayWidget.cpp
+++ b/pcsx2-qt/DisplayWidget.cpp
@@ -156,7 +156,7 @@ void DisplayWidget::handleCloseEvent(QCloseEvent* event)
 	}
 	else
 	{
-		QMetaObject::invokeMethod(g_main_window, &MainWindow::requestExit);
+		QMetaObject::invokeMethod(g_main_window, "requestExit", Q_ARG(bool, true));
 	}
 
 	// Cancel the event from closing the window.

--- a/pcsx2-qt/MainWindow.h
+++ b/pcsx2-qt/MainWindow.h
@@ -117,9 +117,8 @@ public Q_SLOTS:
 	void reportError(const QString& title, const QString& message);
 	bool confirmMessage(const QString& title, const QString& message);
 	void runOnUIThread(const std::function<void()>& func);
-	bool requestShutdown(
-		bool allow_confirm = true, bool allow_save_to_state = true, bool default_save_to_state = true, bool block_until_done = false);
-	void requestExit();
+	bool requestShutdown(bool allow_confirm = true, bool allow_save_to_state = true, bool default_save_to_state = true);
+	void requestExit(bool allow_confirm = true);
 	void checkForSettingChanges();
 	std::optional<WindowInfo> getWindowInfo();
 

--- a/pcsx2/Frontend/FullscreenUI.cpp
+++ b/pcsx2/Frontend/FullscreenUI.cpp
@@ -1062,7 +1062,7 @@ void FullscreenUI::DoChangeDisc()
 
 void FullscreenUI::DoRequestExit()
 {
-	Host::RunOnCPUThread([]() { Host::RequestExit(EmuConfig.SaveStateOnShutdown); });
+	Host::RunOnCPUThread([]() { Host::RequestExit(true); });
 }
 
 void FullscreenUI::DoToggleFullscreen()

--- a/pcsx2/Host.h
+++ b/pcsx2/Host.h
@@ -83,7 +83,7 @@ namespace Host
 
 	/// Requests shut down and exit of the hosting application. This may not actually exit,
 	/// if the user cancels the shutdown confirmation.
-	void RequestExit(bool save_state_if_running);
+	void RequestExit(bool allow_confirm);
 
 	/// Requests shut down of the current virtual machine.
 	void RequestVMShutdown(bool allow_confirm, bool allow_save_state, bool default_save_state);

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -209,6 +209,11 @@ void VMManager::SetState(VMState state)
 		else
 			Host::OnVMResumed();
 	}
+	else if (state == VMState::Stopping)
+	{
+		// If stopping, break execution as soon as possible.
+		Cpu->ExitExecution();
+	}
 }
 
 bool VMManager::HasValidVM()

--- a/pcsx2/x86/ix86-32/iR5900-32.cpp
+++ b/pcsx2/x86/ix86-32/iR5900-32.cpp
@@ -686,7 +686,19 @@ static void recSafeExitExecution()
 
 	// Force an event test at the end of this block.
 	if (!eeEventTestIsActive)
+	{
+		// EE is running.
 		cpuRegs.nextEventCycle = 0;
+	}
+	else
+	{
+		// IOP might be running, so break out if so.
+		if (psxRegs.iopCycleEE > 0)
+		{
+			psxRegs.iopBreak += psxRegs.iopCycleEE; // record the number of cycles the IOP didn't run.
+			psxRegs.iopCycleEE = 0;
+		}
+	}
 }
 
 static void recResetEE()


### PR DESCRIPTION
### Description of Changes

This was a bit wonky in batch mode before. Now all possible exit paths close the application at the same point.

Also immediately stops the IOP running code when the VM enters the stopping state.

### Rationale behind Changes

Improving #7982 and #7940.

### Suggested Testing Steps

Check PCSX2 shuts down correctly in batch/nogui modes.
Check game shutdown from menu and big picture UI.
Check ELF in #7940 works as expected in both normal and nogui mode.
