### PR TITLE
Achievements: Fix race in notifications

### DIFF
--- a/pcsx2-qt/Settings/AchievementSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/AchievementSettingsWidget.cpp
@@ -105,14 +105,13 @@ void AchievementSettingsWidget::updateEnableState()
 {
 	const bool enabled = m_dialog->getEffectiveBoolValue("Achievements", "Enabled", false);
 	const bool challenge = m_dialog->getEffectiveBoolValue("Achievements", "ChallengeMode", false);
-	const bool notifications = m_dialog->getEffectiveBoolValue("Achievements", "Notifications", true);
 	m_ui.testMode->setEnabled(enabled);
 	m_ui.unofficialTestMode->setEnabled(enabled);
 	m_ui.richPresence->setEnabled(enabled);
 	m_ui.challengeMode->setEnabled(enabled);
 	m_ui.leaderboards->setEnabled(enabled && challenge);
 	m_ui.notifications->setEnabled(enabled);
-	m_ui.soundEffects->setEnabled(enabled && notifications);
+	m_ui.soundEffects->setEnabled(enabled);
 	m_ui.primedIndicators->setEnabled(enabled);
 }
 

--- a/pcsx2/Frontend/FullscreenUI.cpp
+++ b/pcsx2/Frontend/FullscreenUI.cpp
@@ -6759,7 +6759,6 @@ void FullscreenUI::DrawAchievementsSettingsPage(std::unique_lock<std::mutex>& se
 
 	const bool enabled = bsi->GetBoolValue("Achievements", "Enabled", false);
 	const bool challenge = bsi->GetBoolValue("Achievements", "ChallengeMode", false);
-	const bool notifications = bsi->GetBoolValue("Achievements", "Notifications", true);
 
 	DrawToggleSetting(bsi, ICON_FA_USER_FRIENDS " Rich Presence",
 		"When enabled, rich presence information will be collected and sent to the server where supported.", "Achievements", "RichPresence",
@@ -6774,7 +6773,7 @@ void FullscreenUI::DrawAchievementsSettingsPage(std::unique_lock<std::mutex>& se
 		enabled);
 	DrawToggleSetting(bsi, ICON_FA_HEADPHONES " Sound Effects",
 		"Plays sound effects for events such as achievement unlocks and leaderboard submissions.", "Achievements", "SoundEffects", true,
-		enabled && notifications);
+		enabled);
 	DrawToggleSetting(bsi, ICON_FA_MAGIC " Show Challenge Indicators",
 		"Shows icons in the lower-right corner of the screen when a challenge/primed achievement is active.", "Achievements",
 		"PrimedIndicators", true, enabled);


### PR DESCRIPTION
### Description of Changes

GS thread might not initialize fullscreen UI before data finishes parsing.

### Rationale behind Changes

race conditions aren't fun

### Suggested Testing Steps

yolo because who cares?

