### PR TITLE
GS-HW: Improve preload frame. Fix missing loading screens/logos, reduce corruption.

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -2063,7 +2063,6 @@ SCED-51700:
     mipmap: 1 # Fixes broken textures.
     textureInsideRT: 1 # Fixes broken character models.
     autoFlush: 1 # Fixes lighting.
-    preloadFrameData: 1 # Fixes Sony splash at boot.
     beforeDraw: "OI_JakGames"
 SCED-51899:
   name: "PlayStation Experience [Demo]"
@@ -2362,7 +2361,6 @@ SCED-52952:
     mipmap: 1
     textureInsideRT: 1
     autoFlush: 1
-    preloadFrameData: 1 # Fixes Sony splash at boot.
     beforeDraw: "OI_JakGames"
 SCED-52970:
   name: "SCEE Hits Demo"
@@ -3373,7 +3371,6 @@ SCES-51608:
     mipmap: 1 # Fixes broken textures.
     textureInsideRT: 1 # Fixes broken character models.
     autoFlush: 1 # Fixes lighting.
-    preloadFrameData: 1 # Fixes Sony splash at boot.
     beforeDraw: "OI_JakGames"
 SCES-51610:
   name: "This is Football 2004 [Red Devils 2004]"
@@ -3681,7 +3678,6 @@ SCES-52460:
     mipmap: 1
     textureInsideRT: 1
     autoFlush: 1
-    preloadFrameData: 1 # Fixes Sony splash at boot.
     beforeDraw: "OI_JakGames"
 SCES-52529:
   name: "Sly 2 - Band of Thieves"
@@ -3883,7 +3879,6 @@ SCES-53286:
     roundSprite: 1 # Fix lines in the sky.
     textureInsideRT: 1 # Fixes broken character models.
     autoFlush: 1 # Fixes lighting.
-    preloadFrameData: 1 # Fixes Sony splash at boot.
     mipmap: 2 # Fixes bad textures.
     trilinearFiltering: 1 # Fixes smooths texture transitions.
     beforeDraw: "OI_JakGames"
@@ -4439,7 +4434,6 @@ SCES-54794:
   region: "PAL-M5"
   gsHWFixes:
     autoFlush: 1
-    preloadFrameData: 1
 SCES-54823:
   name: "SingStar Bollywood"
   region: "PAL-E"
@@ -4854,7 +4848,6 @@ SCKA-20010:
     mipmap: 1 # Fixes broken textures.
     textureInsideRT: 1 # Fixes broken character models.
     autoFlush: 1 # Fixes lighting.
-    preloadFrameData: 1 # Fixes Sony splash at boot.
     beforeDraw: "OI_JakGames"
 SCKA-20011:
   name: "Ratchet & Clank 2"
@@ -5026,7 +5019,6 @@ SCKA-20040:
     mipmap: 1
     textureInsideRT: 1
     autoFlush: 1
-    preloadFrameData: 1 # Fixes Sony splash at boot.
     beforeDraw: "OI_JakGames"
 SCKA-20041:
   name: "EyeToy - Play 2"
@@ -7647,7 +7639,6 @@ SCUS-97265:
     mipmap: 1 # Fixes broken textures.
     textureInsideRT: 1 # Fixes broken character models.
     autoFlush: 1 # Fixes lighting.
-    preloadFrameData: 1 # Fixes Sony splash at boot.
     beforeDraw: "OI_JakGames"
 SCUS-97266:
   name: "Final Fantasy XI [Disc 1 of 2]"
@@ -7686,7 +7677,6 @@ SCUS-97273:
     mipmap: 1 # Fixes broken textures.
     textureInsideRT: 1 # Fixes broken character models.
     autoFlush: 1 # Fixes lighting.
-    preloadFrameData: 1 # Fixes Sony splash at boot.
     beforeDraw: "OI_JakGames"
 SCUS-97274:
   name: "Jak II [Video Demo]"
@@ -7779,13 +7769,9 @@ SCUS-97325:
 SCUS-97326:
   name: "MLB 2005"
   region: "NTSC-U"
-  gsHWFixes:
-    preloadFrameData: 1
 SCUS-97327:
   name: "MLB 2005 [Demo]"
   region: "NTSC-U"
-  gsHWFixes:
-    preloadFrameData: 1
 SCUS-97328:
   name: "Gran Turismo 4"
   region: "NTSC-U"
@@ -7815,7 +7801,6 @@ SCUS-97330:
     mipmap: 1
     textureInsideRT: 1
     autoFlush: 1
-    preloadFrameData: 1 # Fixes Sony splash at boot.
     beforeDraw: "OI_JakGames"
 SCUS-97331:
   name: "Official U.S. PlayStation Magazine Demo Disc 078"
@@ -7895,7 +7880,6 @@ SCUS-97362:
   compat: 5
   gsHWFixes:
     autoFlush: 1
-    preloadFrameData: 1
 SCUS-97365:
   name: "World Tour Soccer 2005"
   region: "NTSC-U"
@@ -7939,7 +7923,6 @@ SCUS-97374:
     mipmap: 1 # Fixes broken textures.
     textureInsideRT: 1 # Fixes broken character models.
     autoFlush: 1 # Fixes lighting.
-    preloadFrameData: 1 # Fixes Sony splash at boot.
     beforeDraw: "OI_JakGames"
 SCUS-97377:
   name: "Syphon Filter - The Omega Strain [Regular Demo]"
@@ -8065,7 +8048,6 @@ SCUS-97412:
     mipmap: 1
     textureInsideRT: 1
     autoFlush: 1
-    preloadFrameData: 1 # Fixes Sony splash at boot.
     beforeDraw: "OI_JakGames"
 SCUS-97413:
   name: "Ratchet & Clank - Up Your Arsenal [Public Beta v1.0]"
@@ -8134,7 +8116,6 @@ SCUS-97429:
     roundSprite: 1 # Fix lines in the sky.
     textureInsideRT: 1 # Fixes broken character models.
     autoFlush: 1 # Fixes lighting.
-    preloadFrameData: 1 # Fixes Sony splash at boot.
     mipmap: 2 # Fixes bad textures.
     trilinearFiltering: 1 # Fixes smooths texture transitions.
     beforeDraw: "OI_JakGames"
@@ -8404,7 +8385,6 @@ SCUS-97486:
     roundSprite: 1 # Fix lines in the sky.
     textureInsideRT: 1 # Fixes broken character models.
     autoFlush: 1 # Fixes lighting.
-    preloadFrameData: 1 # Fixes Sony splash at boot.
     mipmap: 2 # Fixes bad textures.
     trilinearFiltering: 1 # Fixes smooths texture transitions.
     beforeDraw: "OI_JakGames"
@@ -8426,7 +8406,6 @@ SCUS-97488:
     roundSprite: 1 # Fix lines in the sky.
     textureInsideRT: 1 # Fixes broken character models.
     autoFlush: 1 # Fixes lighting.
-    preloadFrameData: 1 # Fixes Sony splash at boot.
     mipmap: 2 # Fixes bad textures.
     trilinearFiltering: 1 # Fixes smooths texture transitions.
     beforeDraw: "OI_JakGames"
@@ -8517,7 +8496,6 @@ SCUS-97509:
     mipmap: 1 # Fixes broken textures.
     textureInsideRT: 1 # Fixes broken character models.
     autoFlush: 1 # Fixes lighting.
-    preloadFrameData: 1 # Fixes Sony splash at boot.
     beforeDraw: "OI_JakGames"
 SCUS-97510:
   name: "ATV Offroad Fury 2 [Greatest Hits]"
@@ -8562,7 +8540,6 @@ SCUS-97516:
     mipmap: 1
     textureInsideRT: 1
     autoFlush: 1
-    preloadFrameData: 1 # Fixes Sony splash at boot.
     beforeDraw: "OI_JakGames"
 SCUS-97517:
   name: "Killzone [Greatest Hits]"
@@ -8794,7 +8771,6 @@ SCUS-97620:
   region: "NTSC-U"
   gsHWFixes:
     autoFlush: 1
-    preloadFrameData: 1
 SCUS-97621:
   name: "Twisted Metal - Head-On [Extra Twisted Edition]"
   region: "NTSC-U"
@@ -11199,35 +11175,30 @@ SLES-50804:
   gsHWFixes:
     roundSprite: 1 # Fixes lines in HUD and text boxes.
     texturePreloading: 1 # Performs much better with partial.
-    preloadFrameData: 1 # Fixes loading screen images being cut off two thirds.
 SLES-50805:
   name: "Deus Ex"
   region: "PAL-G"
   gsHWFixes:
     roundSprite: 1 # Fixes lines in HUD and text boxes.
     texturePreloading: 1 # Performs much better with partial.
-    preloadFrameData: 1 # Fixes loading screen images being cut off two thirds.
 SLES-50806:
   name: "Deus Ex"
   region: "PAL-F"
   gsHWFixes:
     roundSprite: 1 # Fixes lines in HUD and text boxes.
     texturePreloading: 1 # Performs much better with partial.
-    preloadFrameData: 1 # Fixes loading screen images being cut off two thirds.
 SLES-50807:
   name: "Deus Ex"
   region: "PAL-I"
   gsHWFixes:
     roundSprite: 1 # Fixes lines in HUD and text boxes.
     texturePreloading: 1 # Performs much better with partial.
-    preloadFrameData: 1 # Fixes loading screen images being cut off two thirds.
 SLES-50808:
   name: "Deus Ex"
   region: "PAL-S"
   gsHWFixes:
     roundSprite: 1 # Fixes lines in HUD and text boxes.
     texturePreloading: 1 # Performs much better with partial.
-    preloadFrameData: 1 # Fixes loading screen images being cut off two thirds.
 SLES-50809:
   name: "Next Generation Tennis"
   region: "PAL-M6"
@@ -12216,8 +12187,6 @@ SLES-51220:
   name: "TY the Tasmanian Tiger"
   region: "PAL-M5"
   compat: 5
-  gsHWFixes:
-    preloadFrameData: 1 # Fixes missing splash logo at boot.
 SLES-51222:
   name: "Rayman 3 - Hoodlum Havoc"
   region: "PAL-M5"
@@ -13742,8 +13711,6 @@ SLES-51931:
 SLES-51932:
   name: "Adventures of Jimmy Neutron, The - Boy Genius - Jet Fusion"
   region: "PAL-E"
-  gsHWFixes:
-    preloadFrameData: 1 # Fixes missing splash logo at boot.
 SLES-51933:
   name: "Gregory Horror Show"
   region: "PAL-M3"
@@ -15464,7 +15431,6 @@ SLES-52709:
   region: "PAL-M7"
   compat: 5
   gsHWFixes:
-    preloadFrameData: 1 # Fixes missing splash logo at boot.
     halfPixelOffset: 1 # Fixes visible lines in water textures.
 SLES-52710:
   name: "McFarlane's Evil Prophecy"
@@ -15823,8 +15789,6 @@ SLES-52861:
   name: "King Arthur"
   region: "PAL-M5"
   compat: 5
-  gsHWFixes:
-    preloadFrameData: 1 # Fixes missing splash logo at boot.
 SLES-52863:
   name: "Pinball Hall of Fame"
   region: "PAL-M6"
@@ -17857,7 +17821,6 @@ SLES-53636:
   roundModes:
     eeRoundMode: 0 # Fixes story mission to make it completable.
   gsHWFixes:
-    preloadFrameData: 1 # Fixes missing splash logo at boot.
     halfPixelOffset: 1 # Fixes visible lines in water textures.
 SLES-53638:
   name: "Ski Racing 2006"
@@ -19678,15 +19641,14 @@ SLES-54359:
   name: "Legend of Spyro, The - A New Beginning"
   region: "PAL-M6"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes lighting on mushrooms + others.
   patches:
     0EE5646B:
       content: |-
         comment=Patch by kozarovv and refraction
         // Fixes HUD and menu display.
         patch=1,EE,001849b8,word,00000000
-  gsHWFixes:
-    preloadFrameData: 1 # Fixes missing splash logo at boot.
-    halfPixelOffset: 2 # Fixes lighting on mushrooms + others.
 SLES-54360:
   name: "Pro Evolution Soccer 6"
   region: "PAL-F"
@@ -20464,8 +20426,6 @@ SLES-54658:
         // Patch replace values passed to FPU to workaround x86 rounding issues.
         patch=1,EE,0017cb84,word,3464fff0
         patch=1,EE,0017cb90,word,3463fffc
-  gsHWFixes:
-    preloadFrameData: 1 # Fixes missing splash logo at boot.
 SLES-54659:
   name: "Star Wars - The Force Unleashed"
   region: "PAL-M4"
@@ -20478,8 +20438,6 @@ SLES-54659:
         // Patch replace values passed to FPU to workaround x86 rounding issues.
         patch=1,EE,0017cb84,word,3464fff0
         patch=1,EE,0017cb90,word,3463fffc
-  gsHWFixes:
-    preloadFrameData: 1 # Fixes missing splash logo at boot.
 SLES-54663:
   name: "Jackass - The Game"
   region: "PAL-M5"
@@ -20887,28 +20845,26 @@ SLES-54815:
   name: "Legend of Spyro, The - The Eternal Night"
   region: "PAL-M6"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes lighting on mushrooms + others.
   patches:
     8AE9536D:
       content: |-
         comment=Patch by kozarovv and refraction
         // Fixes HUD and menu display.
         patch=1,EE,00173c38,word,00000000
-  gsHWFixes:
-    preloadFrameData: 1 # Fixes missing splash logo at boot.
-    halfPixelOffset: 2 # Fixes lighting on mushrooms + others.
 SLES-54816:
   name: "Legend of Spyro, The - The Eternal Night"
   region: "PAL-R"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes lighting on mushrooms + others.
   patches:
     C95F0198:
       content: |-
         comment=Patch by kozarovv and refraction
         // Fixes HUD and menu display.
         patch=1,EE,00173bb8,word,00000000
-  gsHWFixes:
-    preloadFrameData: 1 # Fixes missing splash logo at boot.
-    halfPixelOffset: 2 # Fixes lighting on mushrooms + others.
 SLES-54817:
   name: "Garfield - Lasagna World Tour"
   region: "PAL-M5"
@@ -22595,7 +22551,6 @@ SLES-55520:
   compat: 5
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes textures.
-    preloadFrameData: 1 # Fixes missing splash logo at boot.
 SLES-55522:
   name: "Disney-Pixar Up"
   region: "PAL-E"
@@ -23234,8 +23189,6 @@ SLKA-15032:
 SLKA-15033:
   name: "Princess Maker 2"
   region: "NTSC-K"
-  gsHWFixes:
-    preloadFrameData: 1 # Fixes black screen.
 SLKA-15043:
   name: "Super Puzzle Bobble Collection Vol 1"
   region: "NTSC-K"
@@ -24362,7 +24315,6 @@ SLKA-25459:
   compat: 5
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes textures.
-    preloadFrameData: 1 # Fixes missing splash logo at boot.
 SLKA-25477:
   name: "World Soccer Winning Eleven 2011"
   region: "NTSC-K"
@@ -27194,8 +27146,6 @@ SLPM-62700:
 SLPM-62701:
   name: "Princess Maker 2 [Best Hit Selection]"
   region: "NTSC-J"
-  gsHWFixes:
-    preloadFrameData: 1 # Fixes black screen.
 SLPM-62702:
   name: "Momotaro Densetsu 15"
   region: "NTSC-J"
@@ -36184,8 +36134,6 @@ SLPS-20392:
 SLPS-20393:
   name: "Princess Maker 2"
   region: "NTSC-J"
-  gsHWFixes:
-    preloadFrameData: 1 # Fixes black screen.
 SLPS-20394:
   name: "Suki na Mono wa Sukida Rashouganai + White Flower + Sukisyo!"
   region: "NTSC-J"
@@ -38688,8 +38636,6 @@ SLPS-25589:
 SLPS-25590:
   name: "Namco Museum Arcade Hits"
   region: "NTSC-J"
-  gsHWFixes:
-    preloadFrameData: 1 # Fixes black screen when prompted to load from memory card.
 SLPS-25591:
   name: "Last Escort - Shinya no Kokuchou Monogatari"
   region: "NTSC-J"
@@ -39797,8 +39743,6 @@ SLPS-25888:
         // Patch replace values passed to FPU to workaround x86 rounding issues.
         patch=1,EE,0017d454,word,3464fff0
         patch=1,EE,0017d460,word,3463fffc
-  gsHWFixes:
-    preloadFrameData: 1 # Fixes missing splash logo at boot.
 SLPS-25889:
   name: "Guitar Hero - Aerosmith"
   region: "NTSC-J"
@@ -41045,8 +40989,6 @@ SLUS-20111:
   compat: 5
   gsHWFixes:
     roundSprite: 1 # Fixes lines in HUD and text boxes.
-    texturePreloading: 1 # Performs much better with partial.
-    preloadFrameData: 1 # Fixes loading screen images being cut off two thirds.
 SLUS-20112:
   name: "Star Trek - Shattered Universe"
   region: "NTSC-U"
@@ -41689,8 +41631,6 @@ SLUS-20273:
   name: "Namco Museum"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    preloadFrameData: 1 # Fixes black screen when prompted to load from memory card.
 SLUS-20274:
   name: "City Crisis"
   region: "NTSC-U"
@@ -43096,8 +43036,6 @@ SLUS-20571:
   name: "TY the Tasmanian Tiger"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    preloadFrameData: 1 # Fixes missing splash logo at boot.
 SLUS-20572:
   name: "Tiger Woods PGA Tour 2003"
   region: "NTSC-U"
@@ -43696,10 +43634,8 @@ SLUS-20695:
     alignSprite: 1 # Fixes green vertical lines.
     roundSprite: 2 # Fixes vertical lines and some font artifacts but not completely fixed.
 SLUS-20696:
-  name: "Adventures of Jimmy Neutron, The - Boy Genius - Jet Fusion"
+  name: "Nickelodeon Jimmy Neutron - Boy Genius - Jet Fusion"
   region: "NTSC-U"
-  gsHWFixes:
-    preloadFrameData: 1 # Fixes missing splash logo at boot.
 SLUS-20697:
   name: "Cy Girls [Disc 1 of 2]"
   region: "NTSC-U"
@@ -45493,8 +45429,6 @@ SLUS-21046:
   name: "King Arthur"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    preloadFrameData: 1 # Fixes missing splash logo at boot.
 SLUS-21047:
   name: "Cold Fear"
   region: "NTSC-U"
@@ -45550,7 +45484,6 @@ SLUS-21057:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    preloadFrameData: 1 # Fixes missing splash logo at boot.
     halfPixelOffset: 1 # Fixes visible lines in water textures.
 SLUS-21058:
   name: "NBA Live 2005"
@@ -46567,7 +46500,6 @@ SLUS-21253:
   roundModes:
     eeRoundMode: 0 # Fixes story mission to make it completable.
   gsHWFixes:
-    preloadFrameData: 1 # Fixes missing splash logo at boot.
     halfPixelOffset: 1 # Fixes visible lines in water textures.
 SLUS-21254:
   name: "Zatch Bell! Mamodo Battles"
@@ -47268,15 +47200,14 @@ SLUS-21372:
   name: "Legend of Spyro, The - A New Beginning"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes lighting on mushrooms + others.
   patches:
     D03D4C77:
       content: |-
         comment=Patch by kozarovv and refraction
         // Fixes HUD and menu display.
         patch=1,EE,001849b8,word,00000000
-  gsHWFixes:
-    preloadFrameData: 1 # Fixes missing splash logo at boot.
-    halfPixelOffset: 2 # Fixes lighting on mushrooms + others.
 SLUS-21373:
   name: "Drakengard 2"
   region: "NTSC-U"
@@ -48384,15 +48315,14 @@ SLUS-21607:
   name: "Legend of Spyro, The - The Eternal Night"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes lighting on mushrooms + others.
   patches:
     B80CE8EC:
       content: |-
         comment=Patch by kozarovv and refraction
         // Fixes HUD and menu display.
         patch=1,EE,00173cb8,word,00000000
-  gsHWFixes:
-    preloadFrameData: 1 # Fixes missing splash logo at boot.
-    halfPixelOffset: 2 # Fixes lighting on mushrooms + others.
 SLUS-21608:
   name: "Dance Dance Revolution SuperNOVA 2"
   region: "NTSC-U"
@@ -48430,8 +48360,6 @@ SLUS-21614:
         // Patch replace values passed to FPU to workaround x86 rounding issues.
         patch=1,EE,0017cf24,word,3464fff0
         patch=1,EE,0017cf30,word,3463fffc
-  gsHWFixes:
-    preloadFrameData: 1 # Fixes missing splash logo at boot.
 SLUS-21615:
   name: "Wild ARMs 5"
   region: "NTSC-U"
@@ -49656,7 +49584,6 @@ SLUS-21881:
   compat: 5
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes textures.
-    preloadFrameData: 1 # Fixes missing splash logo at boot.
   patches:
     137C792E:
       content: |-
@@ -49798,8 +49725,6 @@ SLUS-21913:
         // This can be fixed on the GS side but the software renderer is impossible to fix.
         // So this patch corrects the issue on the EE side.
         patch=1,EE,00173328,word,3464fffd
-  gsHWFixes:
-    preloadFrameData: 1 # Fixes missing splash logo at boot.
 SLUS-21914:
   name: "NHL 2K10"
   region: "NTSC-U"
@@ -50905,7 +50830,6 @@ TCES-53286:
     roundSprite: 1 # Fix lines in the sky.
     textureInsideRT: 1 # Fixes broken character models.
     autoFlush: 1 # Fixes lighting.
-    preloadFrameData: 1 # Fixes Sony splash at boot.
     mipmap: 2 # Fixes bad textures.
     trilinearFiltering: 1 # Fixes smooths texture transitions.
     beforeDraw: "OI_JakGames"

--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -36452,7 +36452,7 @@ SLPS-20489:
   name: "Simple 2000 Series Vol. 114 - The Onna Okappichi Torimonochou - Oharu-chan GoGoGo!"
   region: "NTSC-J"
   gsHWFixes:
-    preloadFrameData: 1 # Fixes black screen in-game.
+    disableDepthSupport: 1 # Fixes black screen in-game.
     getSkipCount: "GSC_Simple2000Vol114"
 SLPS-20490:
   name: "Pachi-Slot Club Collection - IM Juggler EX - Juggler Selection"

--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -2001,8 +2001,11 @@ void GSState::Write(const u8* mem, int len)
 	if (GSConfig.PreloadFrameWithGSData)
 	{
 		// Store the transfer for preloading new RT's.
-		if(m_draw_transfers.size() == 0 || (m_draw_transfers.size() > 0 && blit.DBP != m_draw_transfers.front().DBP))
-			m_draw_transfers.push_front(blit);
+		if (m_draw_transfers.size() == 0 || (m_draw_transfers.size() > 0 && blit.DBP != m_draw_transfers.back().blit.DBP))
+		{
+			GSUploadQueue new_transfer = { blit, s_n };
+			m_draw_transfers.push_back(new_transfer);
+		}
 	}
 
 	GL_CACHE("Write! ...  => 0x%x W:%d F:%s (DIR %d%d), dPos(%d %d) size(%d %d)",

--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -147,6 +147,8 @@ void GSState::Reset(bool hardware_reset)
 
 	m_env.Reset();
 
+	m_draw_transfers.clear();
+
 	PRIM = &m_env.PRIM;
 
 	UpdateContext();
@@ -1984,7 +1986,11 @@ void GSState::Write(const u8* mem, int len)
 	if (!m_tr.Update(w, h, psm.trbpp, len))
 		return;
 
-	
+	if (GSConfig.PreloadFrameWithGSData)
+	{
+		// Store the transfer for preloading new RT's.
+		m_draw_transfers.push_front(blit);
+	}
 
 	GIFRegTEX0& prev_tex0 = m_prev_env.CTXT[m_prev_env.PRIM.CTXT].TEX0;
 

--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -222,6 +222,7 @@ public:
 	bool m_mipmap;
 	u32 m_dirty_gs_regs;
 	int m_backed_up_ctx;
+	std::list<GIFRegBITBLTBUF> m_draw_transfers;
 
 	static int s_n;
 

--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -206,6 +206,12 @@ protected:
 	bool IsCoverageAlpha();
 
 public:
+	struct GSUploadQueue
+	{
+		GIFRegBITBLTBUF blit;
+		int draw;
+	};
+
 	GIFPath m_path[4];
 	GIFRegPRIM* PRIM;
 	GSPrivRegSet* m_regs;
@@ -222,7 +228,7 @@ public:
 	bool m_mipmap;
 	u32 m_dirty_gs_regs;
 	int m_backed_up_ctx;
-	std::list<GIFRegBITBLTBUF> m_draw_transfers;
+	std::vector<GSUploadQueue> m_draw_transfers;
 	bool m_force_preload;
 
 	static int s_n;

--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -223,6 +223,7 @@ public:
 	u32 m_dirty_gs_regs;
 	int m_backed_up_ctx;
 	std::list<GIFRegBITBLTBUF> m_draw_transfers;
+	bool m_force_preload;
 
 	static int s_n;
 

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -202,9 +202,13 @@ void GSRendererHW::VSync(u32 field, bool registers_written)
 {
 	if (m_reset)
 	{
-		m_tc->InvalidateFrameAge();
+		m_tc->RemoveAll();
 		m_reset = false;
+		m_force_preload = true;
 	}
+	else
+		m_force_preload = false;
+
 
 	if (GSConfig.LoadTextureReplacements)
 		GSTextureReplacements::ProcessAsyncLoadedTextures();
@@ -1363,7 +1367,7 @@ void GSRendererHW::Draw()
 	}
 
 	// SW CLUT Render enable.
-	bool preload = GSConfig.PreloadFrameWithGSData;
+	bool preload = GSConfig.PreloadFrameWithGSData | m_force_preload;
 	if (GSConfig.UserHacks_CPUCLUTRender > 0 || GSConfig.UserHacks_GPUTargetCLUTMode != GSGPUTargetCLUTMode::Disabled)
 	{
 		const CLUTDrawTestResult result = (GSConfig.UserHacks_CPUCLUTRender == 2) ? PossibleCLUTDrawAggressive() : PossibleCLUTDraw();

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -1704,7 +1704,7 @@ void GSRendererHW::Draw()
 
 	GSTextureCache::Target* rt = nullptr;
 	if (!no_rt)
-		rt = m_tc->LookupTarget(TEX0, t_size, GSTextureCache::RenderTarget, true, fm, false, 0, 0, preload);
+		rt = m_tc->LookupTarget(TEX0, t_size, GSTextureCache::RenderTarget, true, fm, false, unscaled_size.x, unscaled_size.y, preload);
 
 	TEX0.TBP0 = context->ZBUF.Block();
 	TEX0.TBW = context->FRAME.FBW;

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -202,16 +202,17 @@ void GSRendererHW::VSync(u32 field, bool registers_written)
 {
 	if (m_reset)
 	{
-		m_tc->RemoveAll();
+		m_tc->InvalidateFrameAge();
 		m_reset = false;
 	}
 
 	if (GSConfig.LoadTextureReplacements)
 		GSTextureReplacements::ProcessAsyncLoadedTextures();
 
+	m_tc->IncAge();
+
 	GSRenderer::VSync(field, registers_written);
 
-	m_tc->IncAge();
 
 	if (m_tc->GetHashCacheMemoryUsage() > 1024 * 1024 * 1024)
 	{

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -61,6 +61,19 @@ void GSTextureCache::RemovePartial()
 	}
 }
 
+// Causes old frames to be flushed
+void GSTextureCache::InvalidateFrameAge()
+{
+	for (int type = 0; type < 2; type++)
+	{
+		for (auto t : m_dst[type])
+		{
+			if (t->m_is_frame)
+				t->m_age = 9999;
+		}
+	}
+}
+
 void GSTextureCache::RemoveAll()
 {
 	m_src.RemoveAll();
@@ -728,8 +741,8 @@ GSTextureCache::Target* GSTextureCache::LookupTarget(const GIFRegTEX0& TEX0, con
 				AddDirtyRectTarget(dst, newrect, TEX0.PSM, TEX0.TBW);
 				dst->Update(true);
 			}
+			static_cast<GSRendererHW*>(g_gs_renderer.get())->m_draw_transfers.clear();
 		}
-		static_cast<GSRendererHW*>(g_gs_renderer.get())->m_draw_transfers.clear();
 	}
 	if (used)
 	{
@@ -737,6 +750,8 @@ GSTextureCache::Target* GSTextureCache::LookupTarget(const GIFRegTEX0& TEX0, con
 	}
 	if (is_frame)
 		dst->m_dirty_alpha = false;
+	dst->m_is_frame |= is_frame;
+
 	assert(dst && dst->m_texture && dst->m_texture->GetScale() == new_s);
 	assert(dst && dst->m_dirty.empty());
 	return dst;

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -706,16 +706,18 @@ GSTextureCache::Target* GSTextureCache::LookupTarget(const GIFRegTEX0& TEX0, con
 		{
 			if (!is_frame && !forced_preload)
 			{
-				for (auto transfer : static_cast<GSRendererHW*>(g_gs_renderer.get())->m_draw_transfers)
-				{
-					if (transfer.DBP == TEX0.TBP0 && GSUtil::HasSharedBits(transfer.DPSM, TEX0.PSM))
+				std::vector<GSState::GSUploadQueue>::iterator iter;
+				for (iter = static_cast<GSRendererHW*>(g_gs_renderer.get())->m_draw_transfers.begin(); iter != static_cast<GSRendererHW*>(g_gs_renderer.get())->m_draw_transfers.end(); ) {
+					if (iter->blit.DBP == TEX0.TBP0 && GSUtil::HasSharedBits(iter->blit.DPSM, TEX0.PSM))
 					{
+						iter = static_cast<GSRendererHW*>(g_gs_renderer.get())->m_draw_transfers.erase(iter);
 						GL_INS("Preloading the RT DATA");
 						const GSVector4i newrect = GSVector4i(0, 0, real_w, real_h);
 						AddDirtyRectTarget(dst, newrect, TEX0.PSM, TEX0.TBW);
 						dst->Update(true);
 						break;
 					}
+					iter++;
 				}
 			}
 			else

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -706,12 +706,9 @@ GSTextureCache::Target* GSTextureCache::LookupTarget(const GIFRegTEX0& TEX0, con
 		{
 			if (!is_frame && !forced_preload)
 			{
-				// Check for an EE transfer that matches our RT.
-				while (static_cast<GSRendererHW*>(g_gs_renderer.get())->m_draw_transfers.size() > 0)
+				for (auto transfer : static_cast<GSRendererHW*>(g_gs_renderer.get())->m_draw_transfers)
 				{
-					const GIFRegBITBLTBUF* transfer = &static_cast<GSRendererHW*>(g_gs_renderer.get())->m_draw_transfers.front();
-
-					if (transfer->DBP == TEX0.TBP0 && GSUtil::HasSharedBits(transfer->DPSM, TEX0.PSM))
+					if (transfer.DBP == TEX0.TBP0 && GSUtil::HasSharedBits(transfer.DPSM, TEX0.PSM))
 					{
 						GL_INS("Preloading the RT DATA");
 						const GSVector4i newrect = GSVector4i(0, 0, real_w, real_h);
@@ -719,7 +716,6 @@ GSTextureCache::Target* GSTextureCache::LookupTarget(const GIFRegTEX0& TEX0, con
 						dst->Update(true);
 						break;
 					}
-					static_cast<GSRendererHW*>(g_gs_renderer.get())->m_draw_transfers.pop_front();
 				}
 			}
 			else
@@ -729,7 +725,6 @@ GSTextureCache::Target* GSTextureCache::LookupTarget(const GIFRegTEX0& TEX0, con
 				AddDirtyRectTarget(dst, newrect, TEX0.PSM, TEX0.TBW);
 				dst->Update(true);
 			}
-			static_cast<GSRendererHW*>(g_gs_renderer.get())->m_draw_transfers.clear();
 		}
 	}
 	if (used)

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -700,7 +700,7 @@ GSTextureCache::Target* GSTextureCache::LookupTarget(const GIFRegTEX0& TEX0, con
 		// From a performance point of view, it might cost a little on big upscaling
 		// but normally few RT are miss so it must remain reasonable.
 		bool supported_fmt = !GSConfig.UserHacks_DisableDepthSupport || psm_s.depth == 0;
-		if (preload && TEX0.TBW > 0 && supported_fmt)
+		if ((is_frame || preload) && TEX0.TBW > 0 && supported_fmt)
 		{
 			GL_INS("Preloading the RT DATA");
 			// RT doesn't have height but if we use a too big value, we will read outside of the GS memory.

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.h
@@ -353,7 +353,6 @@ public:
 	void Read(Target* t, const GSVector4i& r);
 	void Read(Source* t, const GSVector4i& r);
 	void RemoveAll();
-	void InvalidateFrameAge();
 	void RemovePartial();
 	void AddDirtyRectTarget(Target* target, GSVector4i rect, u32 psm, u32 bw);
 

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.h
@@ -198,6 +198,7 @@ public:
 		GSVector4i m_valid;
 		const bool m_depth_supported;
 		bool m_dirty_alpha;
+		bool m_is_frame;
 
 	public:
 		Target(const GIFRegTEX0& TEX0, const bool depth_supported, const int type);
@@ -352,6 +353,7 @@ public:
 	void Read(Target* t, const GSVector4i& r);
 	void Read(Source* t, const GSVector4i& r);
 	void RemoveAll();
+	void InvalidateFrameAge();
 	void RemovePartial();
 	void AddDirtyRectTarget(Target* target, GSVector4i rect, u32 psm, u32 bw);
 

--- a/pcsx2/GS/Renderers/SW/GSRendererSW.cpp
+++ b/pcsx2/GS/Renderers/SW/GSRendererSW.cpp
@@ -119,6 +119,7 @@ void GSRendererSW::VSync(u32 field, bool registers_written)
 
 	m_tc->IncAge();
 
+	m_draw_transfers.clear();
 	// if((m_perfmon.GetFrame() & 255) == 0) m_rl->PrintStats();
 }
 


### PR DESCRIPTION
### Description of Changes
Sets the PCRTC (output circuit) to always preload the frame from the GS memory if no texture matching has been created.

Late Edition: Modifies Preload Frame to match related EE Uploads.

### Rationale behind Changes
Many games will just draw the loading screen firstly direct from the EE and by default we create blank new textures, but this will never get updated, since the game may only write once, or it will do some sort of alpha blend (with what is now a blank texture). This resolves these situations.

Late addition: I've modified preload frame to be slightly less gross also, so it should only trigger if there's a related EE upload that frame, otherwise it won't preload, which should bring more reliable behaviour.

Late late addition and the entrance of scope creep: I also made it so the first frame after a GS reset (and TC reset) it preloads any textures it uses, but only for the first frame, unless preload is enabled, this should fix a bunch of mode swapping problems and savestate loading in some cases.

Late late late addition: Small optimisation for SW CLUT to check if the texture has been uploaded this frame, if it has, then no need to invalidate the local memory and download from the GPU.

### Suggested Testing Steps
Test games listed below, or any you know have missing loading screens in hardware but not software.

Known affected games (and fixes removed from the GameDB):
Note: Some of these were also missing menu/ingame graphics due to this, Prince Maker 2 for example.

Crash N Burn
Deus Ex / The Conspiracy
EyeToy - Play Sports
Jak games - Fixes #5502, Fixes #5486 (as Preload no longer required, breaking the eyes)
King Arthur
Legend of Spyro, The - A New Beginning
Legend of Spyro, The - The Eternal Night
Mercenaries
MLB 2005 (maybe other MLB games also)
Namco Museum / Arcade Hits
Nickelodeon Jimmy Neutron - Boy Genius - Jet Fusion
Princess Maker 2
Star Wars - The Clone Wars - Republic Heroes
Star Wars - The Force Unleashed
Syphon Filter - Dark Mirror
Transformers - Revenge of the Fallen
Tony Hawk's Project 8 - Fixes #5318
TY the Tasmanian Tiger
TY the Tasmanian Tiger 2 - Bush Rescue
TY the Tasmanian Tiger 3 - Night of the Quinkan

Possibly fixed (if you can test, enable manual hardware fixes but tick nothing inside the fixes section):
Namco Museum 50th Anniversary - Apparently when the game prompts you to load a save, couldn't get it to save.
