### PR TITLE
emitter: Ignore Wmissing-braces warnings on clang.

### DIFF
--- a/common/emitter/avx.cpp
+++ b/common/emitter/avx.cpp
@@ -16,6 +16,12 @@
 #include "common/emitter/internal.h"
 #include "common/emitter/tools.h"
 
+// warning: suggest braces around initialization of subobject [-Wmissing-braces]
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmissing-braces"
+#endif
+
 namespace x86Emitter
 {
 	const xImplAVX_Move xVMOVAPS = {0x00, 0x28, 0x29};


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
emitter: Ignore Wmissing-braces warnings on clang.
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Ignore warnings.
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Warnings are gone from clang builds.