### PR TITLE
Qt: Add trigger and per-bind deadzone/sensitivity settings

### DIFF
--- a/pcsx2-qt/SettingWidgetBinder.h
+++ b/pcsx2-qt/SettingWidgetBinder.h
@@ -595,7 +595,7 @@ namespace SettingWidgetBinder
 	/// Binds a widget's value to a setting, updating it when the value changes.
 
 	template <typename WidgetType>
-	static void BindWidgetToBoolSetting(
+	static inline void BindWidgetToBoolSetting(
 		SettingsInterface* sif, WidgetType* widget, std::string section, std::string key, bool default_value)
 	{
 		using Accessor = SettingAccessor<WidgetType>;
@@ -636,7 +636,7 @@ namespace SettingWidgetBinder
 	}
 
 	template <typename WidgetType>
-	static void BindWidgetToIntSetting(
+	static inline void BindWidgetToIntSetting(
 		SettingsInterface* sif, WidgetType* widget, std::string section, std::string key, int default_value, int option_offset = 0)
 	{
 		using Accessor = SettingAccessor<WidgetType>;
@@ -677,7 +677,7 @@ namespace SettingWidgetBinder
 	}
 
 	template <typename WidgetType>
-	static void BindWidgetToFloatSetting(
+	static inline void BindWidgetToFloatSetting(
 		SettingsInterface* sif, WidgetType* widget, std::string section, std::string key, float default_value)
 	{
 		using Accessor = SettingAccessor<WidgetType>;
@@ -718,7 +718,7 @@ namespace SettingWidgetBinder
 	}
 
 	template <typename WidgetType>
-	static void BindWidgetToNormalizedSetting(
+	static inline void BindWidgetToNormalizedSetting(
 		SettingsInterface* sif, WidgetType* widget, std::string section, std::string key, float range, float default_value)
 	{
 		using Accessor = SettingAccessor<WidgetType>;
@@ -759,7 +759,7 @@ namespace SettingWidgetBinder
 	}
 
 	template <typename WidgetType>
-	static void BindWidgetToStringSetting(
+	static inline void BindWidgetToStringSetting(
 		SettingsInterface* sif, WidgetType* widget, std::string section, std::string key, std::string default_value = std::string())
 	{
 		using Accessor = SettingAccessor<WidgetType>;
@@ -804,7 +804,7 @@ namespace SettingWidgetBinder
 	}
 
 	template <typename WidgetType, typename DataType>
-	static void BindWidgetToEnumSetting(SettingsInterface* sif, WidgetType* widget, std::string section, std::string key,
+	static inline void BindWidgetToEnumSetting(SettingsInterface* sif, WidgetType* widget, std::string section, std::string key,
 		std::optional<DataType> (*from_string_function)(const char* str), const char* (*to_string_function)(DataType value),
 		DataType default_value)
 	{
@@ -866,7 +866,7 @@ namespace SettingWidgetBinder
 	}
 
 	template <typename WidgetType, typename DataType>
-	static void BindWidgetToEnumSetting(
+	static inline void BindWidgetToEnumSetting(
 		SettingsInterface* sif, WidgetType* widget, std::string section, std::string key, const char** enum_names, DataType default_value)
 	{
 		using Accessor = SettingAccessor<WidgetType>;
@@ -928,7 +928,7 @@ namespace SettingWidgetBinder
 	}
 
 	template <typename WidgetType>
-	static void BindWidgetToEnumSetting(SettingsInterface* sif, WidgetType* widget, std::string section, std::string key,
+	static inline void BindWidgetToEnumSetting(SettingsInterface* sif, WidgetType* widget, std::string section, std::string key,
 		const char** enum_names, const char** enum_values, const char* default_value)
 	{
 		using Accessor = SettingAccessor<WidgetType>;
@@ -992,7 +992,7 @@ namespace SettingWidgetBinder
 	}
 
 	template <typename WidgetType>
-	static void BindWidgetToFolderSetting(SettingsInterface* sif, WidgetType* widget, QAbstractButton* browse_button,
+	static inline void BindWidgetToFolderSetting(SettingsInterface* sif, WidgetType* widget, QAbstractButton* browse_button,
 		QAbstractButton* open_button, QAbstractButton* reset_button, std::string section, std::string key, std::string default_value,
 		bool use_relative = true)
 	{
@@ -1068,7 +1068,7 @@ namespace SettingWidgetBinder
 		}
 	}
 
-	[[maybe_unused]] static void BindSliderToIntSetting(SettingsInterface* sif, QSlider* slider, QLabel* label, const QString& label_suffix,
+	static inline void BindSliderToIntSetting(SettingsInterface* sif, QSlider* slider, QLabel* label, const QString& label_suffix,
 		std::string section, std::string key, s32 default_value)
 	{
 		const s32 global_value = Host::GetBaseIntSettingValue(section.c_str(), key.c_str(), default_value);
@@ -1109,8 +1109,8 @@ namespace SettingWidgetBinder
 				});
 
 			slider->connect(slider, &QSlider::valueChanged, slider,
-				[sif, label, label_suffix, section = std::move(section), key = std::move(key),
-					orig_font = std::move(orig_font), bold_font = std::move(bold_font)](int value) {
+				[sif, label, label_suffix, section = std::move(section), key = std::move(key), orig_font = std::move(orig_font),
+					bold_font = std::move(bold_font)](int value) {
 					label->setText(QStringLiteral("%1%2").arg(value).arg(label_suffix));
 
 					if (label->font() != bold_font)

--- a/pcsx2-qt/Settings/ControllerBindingWidgets.h
+++ b/pcsx2-qt/Settings/ControllerBindingWidgets.h
@@ -139,7 +139,7 @@ class ControllerCustomSettingsWidget : public QWidget
 
 public:
 	ControllerCustomSettingsWidget(gsl::span<const SettingInfo> settings, std::string config_section, std::string config_prefix,
-		const QString& group_title, const char* translation_ctx, ControllerSettingsDialog* dialog, QWidget* parent_widget);
+		const char* translation_ctx, ControllerSettingsDialog* dialog, QWidget* parent_widget);
 	~ControllerCustomSettingsWidget();
 
 private Q_SLOTS:

--- a/pcsx2-qt/Settings/ControllerSettingWidgetBinder.h
+++ b/pcsx2-qt/Settings/ControllerSettingWidgetBinder.h
@@ -38,7 +38,7 @@ namespace ControllerSettingWidgetBinder
 {
 	/// Interface specific method of BindWidgetToBoolSetting().
 	template <typename WidgetType>
-	static void BindWidgetToInputProfileBool(
+	static inline void BindWidgetToInputProfileBool(
 		SettingsInterface* sif, WidgetType* widget, std::string section, std::string key, bool default_value)
 	{
 		using Accessor = SettingWidgetBinder::SettingAccessor<WidgetType>;
@@ -71,7 +71,7 @@ namespace ControllerSettingWidgetBinder
 
 	/// Interface specific method of BindWidgetToIntSetting().
 	template <typename WidgetType>
-	static void BindWidgetToInputProfileInt(
+	static inline void BindWidgetToInputProfileInt(
 		SettingsInterface* sif, WidgetType* widget, std::string section, std::string key, s32 default_value, s32 option_offset = 0)
 	{
 		using Accessor = SettingWidgetBinder::SettingAccessor<WidgetType>;
@@ -104,7 +104,7 @@ namespace ControllerSettingWidgetBinder
 
 	/// Interface specific method of BindWidgetToFloatSetting().
 	template <typename WidgetType>
-	static void BindWidgetToInputProfileFloat(
+	static inline void BindWidgetToInputProfileFloat(
 		SettingsInterface* sif, WidgetType* widget, std::string section, std::string key, float default_value, float multiplier = 1.0f)
 	{
 		using Accessor = SettingWidgetBinder::SettingAccessor<WidgetType>;
@@ -137,11 +137,10 @@ namespace ControllerSettingWidgetBinder
 
 	/// Interface specific method of BindWidgetToNormalizedSetting().
 	template <typename WidgetType>
-	static void BindWidgetToInputProfileNormalized(
+	static inline void BindWidgetToInputProfileNormalized(
 		SettingsInterface* sif, WidgetType* widget, std::string section, std::string key, float range, float default_value)
 	{
 		using Accessor = SettingWidgetBinder::SettingAccessor<WidgetType>;
-
 
 		if (sif)
 		{
@@ -171,7 +170,7 @@ namespace ControllerSettingWidgetBinder
 
 	/// Interface specific method of BindWidgetToStringSetting().
 	template <typename WidgetType>
-	static void BindWidgetToInputProfileString(
+	static inline void BindWidgetToInputProfileString(
 		SettingsInterface* sif, WidgetType* widget, std::string section, std::string key, std::string default_value = std::string())
 	{
 		using Accessor = SettingWidgetBinder::SettingAccessor<WidgetType>;

--- a/pcsx2-qt/Settings/InputBindingDialog.h
+++ b/pcsx2-qt/Settings/InputBindingDialog.h
@@ -41,6 +41,9 @@ protected Q_SLOTS:
 	void onInputListenTimerTimeout();
 	void inputManagerHookCallback(InputBindingKey key, float value);
 
+	void onSensitivityChanged(int value);
+	void onDeadzoneChanged(int value);
+
 protected:
 	enum : u32
 	{

--- a/pcsx2-qt/Settings/InputBindingDialog.ui
+++ b/pcsx2-qt/Settings/InputBindingDialog.ui
@@ -10,7 +10,7 @@
     <x>0</x>
     <y>0</y>
     <width>533</width>
-    <height>283</height>
+    <height>266</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -29,6 +29,93 @@
    </item>
    <item>
     <widget class="QListWidget" name="bindingList"/>
+   </item>
+   <item>
+    <widget class="QWidget" name="sensitivityWidget" native="true">
+     <layout class="QGridLayout" name="sensitivityLayout">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item row="0" column="0">
+       <widget class="QLabel" name="sensitivityLabel">
+        <property name="text">
+         <string>Sensitivity:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QSlider" name="sensitivity">
+        <property name="minimum">
+         <number>1</number>
+        </property>
+        <property name="maximum">
+         <number>200</number>
+        </property>
+        <property name="value">
+         <number>100</number>
+        </property>
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="tickPosition">
+         <enum>QSlider::TicksBelow</enum>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="2">
+       <widget class="QLabel" name="sensitivityValue">
+        <property name="text">
+         <string>100%</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="deadzoneLabel">
+        <property name="text">
+         <string>Deadzone:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QSlider" name="deadzone">
+        <property name="minimum">
+         <number>0</number>
+        </property>
+        <property name="maximum">
+         <number>100</number>
+        </property>
+        <property name="value">
+         <number>1</number>
+        </property>
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="tickPosition">
+         <enum>QSlider::TicksBelow</enum>
+        </property>
+        <property name="tickInterval">
+         <number>5</number>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="2">
+       <widget class="QLabel" name="deadzoneValue">
+        <property name="text">
+         <string>100%</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
    </item>
    <item>
     <widget class="QLabel" name="status">

--- a/pcsx2/PAD/Host/KeyStatus.cpp
+++ b/pcsx2/PAD/Host/KeyStatus.cpp
@@ -118,8 +118,8 @@ void KeyStatus::Set(u32 pad, u32 index, float value)
 			}
 			else
 			{
-				pos_x = m_analog[pad].invert_lx ? MERGE_F(pad, PAD_R_LEFT, PAD_R_RIGHT) : MERGE_F(pad, PAD_R_RIGHT, PAD_R_LEFT);
-				pos_y = m_analog[pad].invert_ly ? MERGE_F(pad, PAD_R_UP, PAD_R_DOWN) : MERGE_F(pad, PAD_R_DOWN, PAD_R_UP);
+				pos_x = m_analog[pad].invert_rx ? MERGE_F(pad, PAD_R_LEFT, PAD_R_RIGHT) : MERGE_F(pad, PAD_R_RIGHT, PAD_R_LEFT);
+				pos_y = m_analog[pad].invert_ry ? MERGE_F(pad, PAD_R_UP, PAD_R_DOWN) : MERGE_F(pad, PAD_R_DOWN, PAD_R_UP);
 			}
 
 			// No point checking if we're at dead center (usually keyboard with no buttons pressed).

--- a/pcsx2/PAD/Host/KeyStatus.h
+++ b/pcsx2/PAD/Host/KeyStatus.h
@@ -40,6 +40,7 @@ namespace PAD
 		u8 m_button_pressure[NUM_CONTROLLER_PORTS][MAX_KEYS];
 		PADAnalog m_analog[NUM_CONTROLLER_PORTS];
 		float m_axis_scale[NUM_CONTROLLER_PORTS][2];
+		float m_trigger_scale[NUM_CONTROLLER_PORTS][2];
 		float m_vibration_scale[NUM_CONTROLLER_PORTS][2];
 		float m_pressure_modifier[NUM_CONTROLLER_PORTS];
 		float m_button_deadzone[NUM_CONTROLLER_PORTS];
@@ -65,6 +66,11 @@ namespace PAD
 		{
 			m_axis_scale[pad][0] = deadzone;
 			m_axis_scale[pad][1] = scale;
+		}
+		__fi void SetTriggerScale(u32 pad, float deadzone, float scale)
+		{
+			m_trigger_scale[pad][0] = deadzone;
+			m_trigger_scale[pad][1] = scale;
 		}
 		__fi float GetVibrationScale(u32 pad, u32 motor) const { return m_vibration_scale[pad][motor]; }
 		__fi void SetVibrationScale(u32 pad, u32 motor, float scale) { m_vibration_scale[pad][motor] = scale; }

--- a/pcsx2/PAD/Host/PAD.cpp
+++ b/pcsx2/PAD/Host/PAD.cpp
@@ -412,7 +412,7 @@ static const SettingInfo s_dualshock2_settings[] = {
 		"Sets the analog stick deadzone, i.e. the fraction of the stick movement which will be ignored.",
 		"0.00", "0.00", "1.00", "0.01", "%.0f%%", nullptr, nullptr, 100.0f},
 	{SettingInfo::Type::Float, "AxisScale", "Analog Sensitivity",
-		"Sets the analog stick axis scaling factor. A value between 1.30 and 1.40 is recommended when using recent "
+		"Sets the analog stick axis scaling factor. A value between 130% and 140% is recommended when using recent "
 		"controllers, e.g. DualShock 4, Xbox One Controller.",
 		"1.33", "0.01", "2.00", "0.01", "%.0f%%", nullptr, nullptr, 100.0f},
 	{SettingInfo::Type::Float, "LargeMotorScale", "Large Motor Vibration Scale",

--- a/pcsx2/PAD/Host/PAD.cpp
+++ b/pcsx2/PAD/Host/PAD.cpp
@@ -504,7 +504,12 @@ void PAD::ClearPortBindings(SettingsInterface& si, u32 port)
 		return;
 
 	for (u32 i = 0; i < info->num_bindings; i++)
-		si.DeleteValue(section.c_str(), info->bindings[i].name);
+	{
+		const InputBindingInfo& bi = info->bindings[i];
+		si.DeleteValue(section.c_str(), bi.name);
+		si.DeleteValue(section.c_str(), fmt::format("{}Scale", bi.name).c_str());
+		si.DeleteValue(section.c_str(), fmt::format("{}Deadzone", bi.name).c_str());
+	}
 }
 
 void PAD::CopyConfiguration(SettingsInterface* dest_si, const SettingsInterface& src_si,
@@ -545,6 +550,8 @@ void PAD::CopyConfiguration(SettingsInterface* dest_si, const SettingsInterface&
 			{
 				const InputBindingInfo& bi = info->bindings[i];
 				dest_si->CopyStringListValue(src_si, section.c_str(), bi.name);
+				dest_si->CopyFloatValue(src_si, section.c_str(), fmt::format("{}Sensitivity", bi.name).c_str());
+				dest_si->CopyFloatValue(src_si, section.c_str(), fmt::format("{}Deadzone", bi.name).c_str());
 			}
 
 			for (u32 i = 0; i < NUM_MACRO_BUTTONS_PER_CONTROLLER; i++)
@@ -601,8 +608,8 @@ void PAD::CopyConfiguration(SettingsInterface* dest_si, const SettingsInterface&
 }
 
 static u32 TryMapGenericMapping(SettingsInterface& si, const std::string& section,
-	const InputManager::GenericInputBindingMapping& mapping, GenericInputBinding generic_name,
-	const char* bind_name)
+	const InputManager::GenericInputBindingMapping& mapping, InputBindingInfo::Type bind_type,
+	GenericInputBinding generic_name, const char* bind_name)
 {
 	// find the mapping it corresponds to
 	const std::string* found_mapping = nullptr;
@@ -613,6 +620,14 @@ static u32 TryMapGenericMapping(SettingsInterface& si, const std::string& sectio
 			found_mapping = &it.second;
 			break;
 		}
+	}
+
+	// Remove previously-set binding scales.
+	if (bind_type == InputBindingInfo::Type::Button || bind_type == InputBindingInfo::Type::Axis ||
+		bind_type == InputBindingInfo::Type::HalfAxis)
+	{
+		si.DeleteValue(section.c_str(), fmt::format("{}Scale", bind_name).c_str());
+		si.DeleteValue(section.c_str(), fmt::format("{}Deadzone", bind_name).c_str());
 	}
 
 	if (found_mapping)
@@ -645,17 +660,17 @@ bool PAD::MapController(SettingsInterface& si, u32 controller,
 		if (bi.generic_mapping == GenericInputBinding::Unknown)
 			continue;
 
-		num_mappings += TryMapGenericMapping(si, section, mapping, bi.generic_mapping, bi.name);
+		num_mappings += TryMapGenericMapping(si, section, mapping, bi.bind_type, bi.generic_mapping, bi.name);
 	}
 	if (info->vibration_caps == VibrationCapabilities::LargeSmallMotors)
 	{
-		num_mappings += TryMapGenericMapping(si, section, mapping, GenericInputBinding::SmallMotor, "SmallMotor");
-		num_mappings += TryMapGenericMapping(si, section, mapping, GenericInputBinding::LargeMotor, "LargeMotor");
+		num_mappings += TryMapGenericMapping(si, section, mapping, InputBindingInfo::Type::Motor, GenericInputBinding::SmallMotor, "SmallMotor");
+		num_mappings += TryMapGenericMapping(si, section, mapping, InputBindingInfo::Type::Motor, GenericInputBinding::LargeMotor, "LargeMotor");
 	}
 	else if (info->vibration_caps == VibrationCapabilities::SingleMotor)
 	{
-		if (TryMapGenericMapping(si, section, mapping, GenericInputBinding::LargeMotor, "Motor") == 0)
-			num_mappings += TryMapGenericMapping(si, section, mapping, GenericInputBinding::SmallMotor, "Motor");
+		if (TryMapGenericMapping(si, section, mapping, InputBindingInfo::Type::Motor, GenericInputBinding::LargeMotor, "Motor") == 0)
+			num_mappings += TryMapGenericMapping(si, section, mapping, InputBindingInfo::Type::Motor, GenericInputBinding::SmallMotor, "Motor");
 		else
 			num_mappings++;
 	}

--- a/pcsx2/PAD/Host/PAD.cpp
+++ b/pcsx2/PAD/Host/PAD.cpp
@@ -217,8 +217,11 @@ void PAD::LoadConfig(const SettingsInterface& si)
 
 		const float axis_deadzone = si.GetFloatValue(section.c_str(), "Deadzone", DEFAULT_STICK_DEADZONE);
 		const float axis_scale = si.GetFloatValue(section.c_str(), "AxisScale", DEFAULT_STICK_SCALE);
+		const float trigger_deadzone = si.GetFloatValue(section.c_str(), "TriggerDeadzone", DEFAULT_TRIGGER_DEADZONE);
+		const float trigger_scale = si.GetFloatValue(section.c_str(), "TriggerDeadzone", DEFAULT_TRIGGER_SCALE);
 		const float button_deadzone = si.GetFloatValue(section.c_str(), "ButtonDeadzone", DEFAULT_BUTTON_DEADZONE);
 		g_key_status.SetAxisScale(i, axis_deadzone, axis_scale);
+		g_key_status.SetTriggerScale(i, trigger_deadzone, trigger_scale);
 		g_key_status.SetButtonDeadzone(i, button_deadzone);
 
 		if (ci->vibration_caps != VibrationCapabilities::NoVibration)
@@ -415,6 +418,12 @@ static const SettingInfo s_dualshock2_settings[] = {
 		"Sets the analog stick axis scaling factor. A value between 130% and 140% is recommended when using recent "
 		"controllers, e.g. DualShock 4, Xbox One Controller.",
 		"1.33", "0.01", "2.00", "0.01", "%.0f%%", nullptr, nullptr, 100.0f},
+	{SettingInfo::Type::Float, "TriggerDeadzone", "Trigger Deadzone",
+		"Sets the analog stick deadzone, i.e. the fraction of the stick movement which will be ignored.",
+		"0.00", "0.00", "1.00", "0.01", "%.0f%%", nullptr, nullptr, 100.0f},
+	{SettingInfo::Type::Float, "TriggerScale", "Trigger Sensitivity",
+		"Sets the trigger scaling factor.",
+		"1.00", "0.01", "2.00", "0.01", "%.0f%%", nullptr, nullptr, 100.0f},
 	{SettingInfo::Type::Float, "LargeMotorScale", "Large Motor Vibration Scale",
 		"Increases or decreases the intensity of low frequency vibration sent by the game.",
 		"1.00", "0.00", "2.00", "0.01", "%.0f%%", nullptr, nullptr, 100.0f},
@@ -564,14 +573,6 @@ void PAD::CopyConfiguration(SettingsInterface* dest_si, const SettingsInterface&
 
 		if (copy_pad_config)
 		{
-			dest_si->CopyFloatValue(src_si, section.c_str(), "AxisScale");
-
-			if (info->vibration_caps != VibrationCapabilities::NoVibration)
-			{
-				dest_si->CopyFloatValue(src_si, section.c_str(), "LargeMotorScale");
-				dest_si->CopyFloatValue(src_si, section.c_str(), "SmallMotorScale");
-			}
-
 			for (u32 i = 0; i < info->num_settings; i++)
 			{
 				const SettingInfo& csi = info->settings[i];

--- a/pcsx2/PAD/Host/PAD.h
+++ b/pcsx2/PAD/Host/PAD.h
@@ -76,6 +76,8 @@ namespace PAD
 	/// Default stick deadzone/sensitivity.
 	static constexpr float DEFAULT_STICK_DEADZONE = 0.0f;
 	static constexpr float DEFAULT_STICK_SCALE = 1.33f;
+	static constexpr float DEFAULT_TRIGGER_DEADZONE = 0.0f;
+	static constexpr float DEFAULT_TRIGGER_SCALE = 1.0f;
 	static constexpr float DEFAULT_MOTOR_SCALE = 1.0f;
 	static constexpr float DEFAULT_PRESSURE_MODIFIER = 0.5f;
 	static constexpr float DEFAULT_BUTTON_DEADZONE = 0.0f;


### PR DESCRIPTION
### Description of Changes

Thought of a way to make this which doesn't look disgusting UI-wise. To set per-bind sensitivity/deadzone, shift-click the binding (same as making multiple bindings).

Also adds multiplier parsing to controller settings, so e.g. sensitivity will be shown as 130% instead of 1.3 (better UX).

### Rationale behind Changes

Something which has been asked for on numerous occasions, but I couldn't think of a way to present it in the UI which wasn't gross. And the multiplier thing has been on my todo list for a while.

Closes #6629.
Closes #4055.
Closes #8029.

### Suggested Testing Steps

Test per-bind sensitivity/deadzone.
Test trigger sensitivity/deadzone.
Test stick sensitivity/deadzone,  make sure I didn't break it.
