### PR TITLE
IPU: Reset threshold on IPU reset.

### DIFF
--- a/pcsx2/IPU/IPU.cpp
+++ b/pcsx2/IPU/IPU.cpp
@@ -317,6 +317,8 @@ void ipuSoftReset()
 	memzero(g_BP);
 
 	coded_block_pattern = 0;
+	g_ipu_thresh[0] = 0;
+	g_ipu_thresh[1] = 0;
 
 	ipuRegs.ctrl.reset();
 	ipuRegs.top = 0;


### PR DESCRIPTION
### Description of Changes
Reset alpha thresholds on IPU reset. While i don't have ability to test this on real hardware now, this seems to be correct undocumented behavior.

### Rationale behind Changes
Fixes https://github.com/PCSX2/pcsx2/issues/6057
Game set 0x100 translucency threshold, and soon after that reset IPU. Manual mention only that "data being decoded inside ipu is abandoned" on IPU reset, but it seems this mean also alpha th.
```
[   17.2204] write32: IPU_CMD=0x91000000
[   17.2214] SETTH (Set threshold value)command 1000000.
[   17.2258] read32: IPU_CTRL=0x00000000
[   17.2270] write32: IPU_CTRL=0x00800000
[   17.2287] write32: IPU_CTRL=0x40000000
```

### Suggested Testing Steps
Watch Berwick Saga intro. Test other games, specially Hype Time Quest, and Perfect Ace 2, also FMVs in other games.