### PR TITLE
GameDB: Various Tekken fixes

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -1678,8 +1678,8 @@ SCED-50041:
   name: "Tekken Tag Tournament [Demo]"
   region: "PAL-E"
   gsHWFixes:
-    alignSprite: 1
-    texturePreloading: 1
+    alignSprite: 1 # Fixes vertical lines.
+    texturePreloading: 0 # Performs much better with no preloading.
 SCED-50065:
   name: "Official PlayStation 2 Magazine Demo 1"
   region: "PAL-M5"
@@ -2786,8 +2786,8 @@ SCES-50001:
   region: "PAL-M5"
   compat: 5
   gsHWFixes:
-    alignSprite: 1
-    texturePreloading: 1
+    alignSprite: 1 # Fixes vertical lines.
+    texturePreloading: 0 # Performs much better with no preloading.
 SCES-50002:
   name: "FantaVision"
   region: "PAL-M5"
@@ -3101,8 +3101,8 @@ SCES-50878:
   region: "PAL-M5"
   compat: 5
   gsHWFixes:
-    alignSprite: 1
-    texturePreloading: 1 # Performs much better with partial preload.
+    alignSprite: 1 # Fixes vertical lines.
+    texturePreloading: 0 # Performs much better with no preloading.
 SCES-50885:
   name: "Ape Escape 2"
   region: "PAL-E"
@@ -5038,6 +5038,12 @@ SCKA-20044:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes chromatic effect.
+SCKA-20045:
+  name: "Tekken 4"
+  region: "NTSC-K"
+  gsHWFixes:
+    alignSprite: 1 # Fixes vertical lines.
+    texturePreloading: 0 # Performs much better with no preloading.
 SCKA-20047:
   name: "Armored Core Nine Breaker"
   region: "NTSC-K"
@@ -6732,7 +6738,7 @@ SCPS-55017:
   compat: 3
   gsHWFixes:
     alignSprite: 1
-    texturePreloading: 1 # Performs much better with partial preload.
+    texturePreloading: 0 # Performs much better with no preloading.
 SCPS-55018:
   name: "Kingdom of Scribbling"
   region: "NTSC-J"
@@ -6920,7 +6926,8 @@ SCPS-56002:
   region: "NTSC-K"
   compat: 5
   gsHWFixes:
-    alignSprite: 1
+    alignSprite: 1 # Fixes vertical lines.
+    texturePreloading: 0 # Performs much better with no preloading.
 SCPS-56003:
   name: "Jak and Daxter - The Precursor Legacy"
   region: "NTSC-K"
@@ -6940,7 +6947,7 @@ SCPS-56006:
   compat: 5
   gsHWFixes:
     alignSprite: 1
-    texturePreloading: 1 # Performs much better with partial preload.
+    texturePreloading: 0 # Performs much better with no preloading.
 SCPS-56008:
   name: "Fatal Frame"
   region: "NTSC-K"
@@ -35250,7 +35257,8 @@ SLPS-20015:
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
-    alignSprite: 1
+    alignSprite: 1 # Fixes vertical lines.
+    texturePreloading: 0 # Performs much better with no preloading.
 SLPS-20016:
   name: "Dream Audition"
   region: "NTSC-J"
@@ -36896,7 +36904,7 @@ SLPS-25100:
   compat: 5
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
-    texturePreloading: 1 # Performs much better with partial preload.
+    texturePreloading: 0 # Performs much better with no preloading.
 SLPS-25102:
   name: "Project Arms"
   region: "NTSC-J"
@@ -39979,6 +39987,12 @@ SLPS-29005:
     autoFlush: 1 # Fixes shadows in cutscenes.
     halfPixelOffset: 2 # Removes puppet lines shadows.
     roundSprite: 2 # Fixes font artifacts.
+SLPS-71501:
+  name: "Tekken Tag Tournament [Mega Hits]"
+  region: "NTSC-J"
+  gsHWFixes:
+    alignSprite: 1 # Fixes vertical lines.
+    texturePreloading: 0 # Performs much better with no preloading.
 SLPS-72501:
   name: "Final Fantasy X [Mega Hits]"
   region: "NTSC-J"
@@ -40016,6 +40030,7 @@ SLPS-73104:
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
+    texturePreloading: 0 # Performs much better with no preloading.
 SLPS-73105:
   name: "Kinnikuman Generations [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -40094,7 +40109,7 @@ SLPS-73209:
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
-    texturePreloading: 1 # Performs much better with partial preload.
+    texturePreloading: 0 # Performs much better with no preloading.
 SLPS-73210:
   name: "Katamari Damacy [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -40578,6 +40593,7 @@ SLUS-20001:
   compat: 5
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
+    texturePreloading: 0 # Performs much better with no preloading.
 SLUS-20002:
   name: "Ridge Racer V"
   region: "NTSC-U"
@@ -41883,7 +41899,7 @@ SLUS-20328:
   compat: 5
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
-    texturePreloading: 1 # Performs much better with partial preload.
+    texturePreloading: 0 # Performs much better with no preloading.
 SLUS-20329:
   name: "Pro Race Driver"
   region: "NTSC-U"
@@ -49934,7 +49950,7 @@ SLUS-28012:
   region: "NTSC-U"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
-    texturePreloading: 1 # Performs much better with partial preload.
+    texturePreloading: 0 # Performs much better with no preloading.
 SLUS-28013:
   name: "Dual Hearts [Trade Demo]"
   region: "NTSC-U"
@@ -50183,7 +50199,7 @@ SLUS-29034:
   region: "NTSC-U"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
-    texturePreloading: 1 # Performs much better with partial preload.
+    texturePreloading: 0 # Performs much better with no preloading.
 SLUS-29035:
   name: "Eidos Demo Disc"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
Disables preloading entirely on Tekken Tag Tournament and Tekken 4 and adds missing fix comments and missing db entry's for both games.

### Rationale behind Changes
Games being slow is bad.

### Suggested Testing Steps
Make sure CI is happy.
