### PR TITLE
Qt: Connect close instead of accept for the close button

### DIFF
--- a/pcsx2-qt/Settings/SettingsDialog.cpp
+++ b/pcsx2-qt/Settings/SettingsDialog.cpp
@@ -191,7 +191,7 @@ void SettingsDialog::setupUi(const GameList::Entry* game)
 	m_ui.settingsContainer->setCurrentIndex(0);
 	m_ui.helpText->setText(m_category_help_text[0]);
 	connect(m_ui.settingsCategory, &QListWidget::currentRowChanged, this, &SettingsDialog::onCategoryCurrentRowChanged);
-	connect(m_ui.closeButton, &QPushButton::clicked, this, &SettingsDialog::accept);
+	connect(m_ui.closeButton, &QPushButton::clicked, this, &SettingsDialog::close);
 	connect(m_ui.restoreDefaultsButton, &QPushButton::clicked, this, &SettingsDialog::onRestoreDefaultsClicked);
 }
 


### PR DESCRIPTION
### Description of Changes
In the settings dialog, connect the close button to close, instead of accept 

### Rationale behind Changes
In the following situation
Opening per-game settings then closing per-game settings (using the close button)
Opening global settings and changing settings then closing global settings
Opening per-game settings (for the same game), without this change would display outdated global values.

### Suggested Testing Steps
Perform the above steps and see if global values are updated correctly in per-game settings.
