### PR TITLE
DEV9: QT Per-game settings fixes

### DIFF
--- a/pcsx2-qt/Settings/DEV9SettingsWidget.cpp
+++ b/pcsx2-qt/Settings/DEV9SettingsWidget.cpp
@@ -686,7 +686,7 @@ void DEV9SettingsWidget::onEthHostEdit(QStandardItem* item)
 
 void DEV9SettingsWidget::onHddEnabledChanged(int state)
 {
-	const bool enabled = state == Qt::CheckState::PartiallyChecked ? m_dialog->getEffectiveBoolValue("DEV9/Hdd", "HddEnable", false) : state;
+	const bool enabled = state == Qt::CheckState::PartiallyChecked ? Host::GetBaseBoolSettingValue("DEV9/Hdd", "HddEnable", false) : state;
 
 	m_ui.hddFile->setEnabled(enabled);
 	m_ui.hddFileLabel->setEnabled(enabled);

--- a/pcsx2-qt/Settings/DEV9SettingsWidget.cpp
+++ b/pcsx2-qt/Settings/DEV9SettingsWidget.cpp
@@ -274,18 +274,27 @@ DEV9SettingsWidget::DEV9SettingsWidget(SettingsDialog* dialog, QWidget* parent)
 
 	if (m_dialog->isPerGameSettings())
 	{
+		std::optional<int> sizeOpt = std::nullopt;
+		if (size > 0)
+			sizeOpt = size;
 		const int sizeGlobal = (u64)Host::GetBaseIntSettingValue("DEV9/Hdd", "HddSizeSectors", 0) * 512 / (1024 * 1024 * 1024);
-		m_ui.hddSizeSpinBox->setMinimum(39);
-		m_ui.hddSizeSpinBox->setSpecialValueText(tr("Global [%1]").arg(sizeGlobal));
+
+		SettingWidgetBinder::SettingAccessor<QSpinBox>::makeNullableInt(m_ui.hddSizeSpinBox, sizeGlobal);
+		SettingWidgetBinder::SettingAccessor<QSpinBox>::setNullableIntValue(m_ui.hddSizeSpinBox, sizeOpt);
+
+		m_ui.hddSizeSlider->setValue(sizeOpt.value_or(sizeGlobal));
+
+		m_ui.hddSizeSlider->setContextMenuPolicy(Qt::CustomContextMenu);
+		connect(m_ui.hddSizeSlider, &QSlider::customContextMenuRequested, this, &DEV9SettingsWidget::onHddSizeSliderContext);
+	}
+	else
+	{
+		m_ui.hddSizeSlider->setValue(size);
+		SettingWidgetBinder::SettingAccessor<QSpinBox>::setIntValue(m_ui.hddSizeSpinBox, size);
 	}
 
-	// clang-format off
-	m_ui.hddSizeSlider ->setValue(size);
-	m_ui.hddSizeSpinBox->setValue(size);
-
-	connect(m_ui.hddSizeSlider,  QOverload<int>::of(&QSlider ::valueChanged), this, &DEV9SettingsWidget::onHddSizeSlide);
-	connect(m_ui.hddSizeSpinBox, QOverload<int>::of(&QSpinBox::valueChanged), this, &DEV9SettingsWidget::onHddSizeSpin );
-	// clang-format on
+	connect(m_ui.hddSizeSlider, QOverload<int>::of(&QSlider::valueChanged), this, &DEV9SettingsWidget::onHddSizeSlide);
+	SettingWidgetBinder::SettingAccessor<QSpinBox>::connectValueChanged(m_ui.hddSizeSpinBox, [&]() { onHddSizeAccessorSpin(); });
 
 	connect(m_ui.hddCreate, &QPushButton::clicked, this, &DEV9SettingsWidget::onHddCreateClicked);
 }
@@ -749,22 +758,49 @@ void DEV9SettingsWidget::onHddFileEdit()
 
 void DEV9SettingsWidget::onHddSizeSlide(int i)
 {
+	// We have to call onHddSizeAccessorSpin() ourself, as the value could still be considered null when the valueChanged signal is fired
 	QSignalBlocker sb(m_ui.hddSizeSpinBox);
-	m_ui.hddSizeSpinBox->setValue(i);
-
-	m_dialog->setIntSettingValue("DEV9/Hdd", "HddSizeSectors", (int)((s64)i * 1024 * 1024 * 1024 / 512));
+	SettingWidgetBinder::SettingAccessor<QSpinBox>::setNullableIntValue(m_ui.hddSizeSpinBox, i);
+	onHddSizeAccessorSpin();
 }
 
-void DEV9SettingsWidget::onHddSizeSpin(int i)
+void DEV9SettingsWidget::onHddSizeSliderContext(const QPoint& pt)
 {
-	QSignalBlocker sb(m_ui.hddSizeSlider);
-	m_ui.hddSizeSlider->setValue(i);
+	QMenu menu(m_ui.hddSizeSlider);
+	connect(menu.addAction(qApp->translate("SettingWidgetBinder", "Reset")), &QAction::triggered, this, &DEV9SettingsWidget::onHddSizeSliderReset);
+	menu.exec(m_ui.hddSizeSlider->mapToGlobal(pt));
+}
 
-	//TODO: need a setUintSettingValue for if 48bit support occurs
-	if (i == 39)
-		m_dialog->setIntSettingValue("DEV9/Hdd", "HddSizeSectors", std::nullopt);
+void DEV9SettingsWidget::onHddSizeSliderReset([[maybe_unused]] bool checked)
+{
+	// We have to call onHddSizeAccessorSpin() ourself, as the value could still be considered non-null when the valueChanged signal is fired
+	QSignalBlocker sb(m_ui.hddSizeSpinBox);
+	SettingWidgetBinder::SettingAccessor<QSpinBox>::setNullableIntValue(m_ui.hddSizeSpinBox, std::nullopt);
+	onHddSizeAccessorSpin();
+}
+
+void DEV9SettingsWidget::onHddSizeAccessorSpin()
+{
+	//TODO: need a getUintValue for if 48bit support occurs
+	QSignalBlocker sb(m_ui.hddSizeSlider);
+	if (m_dialog->isPerGameSettings())
+	{
+		std::optional<int> new_value = SettingWidgetBinder::SettingAccessor<QSpinBox>::getNullableIntValue(m_ui.hddSizeSpinBox);
+
+		const int sizeGlobal = (u64)Host::GetBaseIntSettingValue("DEV9/Hdd", "HddSizeSectors", 0) * 512 / (1024 * 1024 * 1024);
+		m_ui.hddSizeSlider->setValue(new_value.value_or(sizeGlobal));
+
+		if (new_value.has_value())
+			m_dialog->setIntSettingValue("DEV9/Hdd", "HddSizeSectors", new_value.value() * (1024 * 1024 * 1024 / 512));
+		else
+			m_dialog->setIntSettingValue("DEV9/Hdd", "HddSizeSectors", std::nullopt);
+	}
 	else
-		m_dialog->setIntSettingValue("DEV9/Hdd", "HddSizeSectors", i * (1024 * 1024 * 1024 / 512));
+	{
+		const int new_value = SettingWidgetBinder::SettingAccessor<QSpinBox>::getIntValue(m_ui.hddSizeSpinBox);
+		m_ui.hddSizeSlider->setValue(new_value);
+		m_dialog->setIntSettingValue("DEV9/Hdd", "HddSizeSectors", new_value * (1024 * 1024 * 1024 / 512));
+	}
 }
 
 void DEV9SettingsWidget::onHddCreateClicked()

--- a/pcsx2-qt/Settings/DEV9SettingsWidget.cpp
+++ b/pcsx2-qt/Settings/DEV9SettingsWidget.cpp
@@ -260,9 +260,13 @@ DEV9SettingsWidget::DEV9SettingsWidget(SettingsDialog* dialog, QWidget* parent)
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.hddEnabled, "DEV9/Hdd", "HddEnable", false);
 
 	connect(m_ui.hddFile, &QLineEdit::editingFinished, this, &DEV9SettingsWidget::onHddFileEdit);
-	SettingWidgetBinder::BindWidgetToStringSetting(sif, m_ui.hddFile, "DEV9/Hdd", "HddFile", "DEV9hdd.raw");
 	if (m_dialog->isPerGameSettings())
+	{
+		m_ui.hddFile->setText(QString::fromUtf8(m_dialog->getStringValue("DEV9/Hdd", "HddFile", "").value().c_str()));
 		m_ui.hddFile->setPlaceholderText(QString::fromUtf8(Host::GetBaseStringSettingValue("DEV9/Hdd", "HddFile", "DEV9hdd.raw")));
+	}
+	else
+		m_ui.hddFile->setText(QString::fromUtf8(m_dialog->getStringValue("DEV9/Hdd", "HddFile", "DEV9hdd.raw").value().c_str()));
 	connect(m_ui.hddBrowseFile, &QPushButton::clicked, this, &DEV9SettingsWidget::onHddBrowseFileClicked);
 
 	//TODO: need a getUintValue for if 48bit support occurs
@@ -711,10 +715,16 @@ void DEV9SettingsWidget::onHddBrowseFileClicked()
 
 void DEV9SettingsWidget::onHddFileEdit()
 {
-	//Check if file exists, if so set HddSize to correct value
+	// Check if file exists, if so set HddSize to correct value.
+	// Also save the hddPath setting
 	std::string hddPath(m_ui.hddFile->text().toStdString());
 	if (hddPath.empty())
+	{
+		m_dialog->setStringSettingValue("DEV9/Hdd", "HddFile", std::nullopt);
 		return;
+	}
+	else
+		m_dialog->setStringSettingValue("DEV9/Hdd", "HddFile", hddPath.c_str());
 
 	if (!Path::IsAbsolute(hddPath))
 		hddPath = Path::Combine(EmuFolders::Settings, hddPath);

--- a/pcsx2-qt/Settings/DEV9SettingsWidget.cpp
+++ b/pcsx2-qt/Settings/DEV9SettingsWidget.cpp
@@ -703,8 +703,8 @@ void DEV9SettingsWidget::onHddBrowseFileClicked()
 {
 	QString path =
 		QDir::toNativeSeparators(QFileDialog::getSaveFileName(QtUtils::GetRootWidget(this), tr("HDD Image File"),
-			!m_ui.hddFile->text().isEmpty() ? m_ui.hddFile->text() : "DEV9hdd.raw", tr("HDD (*.raw)"), nullptr,
-			QFileDialog::DontConfirmOverwrite));
+			!m_ui.hddFile->text().isEmpty() ? m_ui.hddFile->text() : (!m_ui.hddFile->placeholderText().isEmpty() ? m_ui.hddFile->placeholderText() : "DEV9hdd.raw"),
+			tr("HDD (*.raw)"), nullptr, QFileDialog::DontConfirmOverwrite));
 
 	if (path.isEmpty())
 		return;

--- a/pcsx2-qt/Settings/DEV9SettingsWidget.cpp
+++ b/pcsx2-qt/Settings/DEV9SettingsWidget.cpp
@@ -784,7 +784,7 @@ void DEV9SettingsWidget::onHddCreateClicked()
 	if (!Path::IsAbsolute(hddPath))
 		hddPath = Path::Combine(EmuFolders::Settings, hddPath);
 
-	if (!FileSystem::FileExists(hddPath.c_str()))
+	if (FileSystem::FileExists(hddPath.c_str()))
 	{
 		//GHC uses UTF8 on all platforms
 		QMessageBox::StandardButton selection =

--- a/pcsx2-qt/Settings/DEV9SettingsWidget.h
+++ b/pcsx2-qt/Settings/DEV9SettingsWidget.h
@@ -49,7 +49,11 @@ private Q_SLOTS:
 	void onHddBrowseFileClicked();
 	void onHddFileEdit();
 	void onHddSizeSlide(int i);
-	void onHddSizeSpin(int i);
+	// Per game only.
+	void onHddSizeSliderContext(const QPoint& pt);
+	void onHddSizeSliderReset(bool checked = false);
+	//
+	void onHddSizeAccessorSpin();
 	void onHddCreateClicked();
 
 public:


### PR DESCRIPTION
### Description of Changes
Fix handling of per-game HDD path,
Fix HDD overwrite check condition being flipped.
In per game, populate the HDD file browser with the global HDD path if no per game file is set.
Fix the HDD Enable toggle not behaving correctly in per-game settings.
Rewrite the code for handling HDD size, making its UI in per game settings more constant with other settings panels.

### Rationale behind Changes
The HDD size UI per-game settings didn't behave like other per game sliders or spinboxes, as it was written before https://github.com/PCSX2/pcsx2/pull/6780 & https://github.com/PCSX2/pcsx2/pull/7764
Use `SettingAccessor` for spinboxes as `BindWidgetToIntSetting` doesn't cover this use case
`BindSliderToIntSetting` doesn't cover this use case, so handle the context menu ourself.

Other fixes where made along the way.

### Suggested Testing Steps
Test HDD settings with both global and per-game settings.
