### PR TITLE
GS: Clear Privilage registers on GS Reset via CSR

### DIFF
--- a/pcsx2/Counters.cpp
+++ b/pcsx2/Counters.cpp
@@ -445,6 +445,10 @@ u32 UpdateVSyncRate()
 
 	if (vSyncInfo.Framerate != frames_per_second || vSyncInfo.VideoMode != gsVideoMode)
 	{
+		// NBA Jam 2004 PAL will fail to display 3D on the menu if this value isn't correct on reset.
+		if (video_mode_initialized && vSyncInfo.VideoMode != gsVideoMode)
+			CSRreg.FIELD = 1;
+
 		vSyncInfo.VideoMode = gsVideoMode;
 
 		vSyncInfoCalc(&vSyncInfo, frames_per_second, total_scanlines);

--- a/pcsx2/Counters.cpp
+++ b/pcsx2/Counters.cpp
@@ -461,7 +461,9 @@ u32 UpdateVSyncRate()
 
 		hsyncCounter.CycleT = vSyncInfo.hRender; // Amount of cycles before the counter will be updated
 		vsyncCounter.CycleT = vSyncInfo.Render;  // Amount of cycles before the counter will be updated
-
+		hsyncCounter.sCycle = cpuRegs.cycle;
+		vsyncCounter.sCycle = cpuRegs.cycle;
+		vsyncCounter.Mode = MODE_VRENDER;
 		cpuRcntSet();
 	}
 

--- a/pcsx2/GS.cpp
+++ b/pcsx2/GS.cpp
@@ -85,6 +85,8 @@ static __fi void gsCSRwrite( const tGS_CSR& csr )
 		//Console.Warning( "csr.RESET" );
 		//gifUnit.Reset(true); // Don't think gif should be reset...
 		gifUnit.gsSIGNAL.queued = false;
+		// Privilage registers also reset.
+		memset(PS2MEM_GS, 0, sizeof(PS2MEM_GS));
 		GetMTGS().SendSimplePacket(GS_RINGTYPE_RESET, 0, 0, 0);
 		const u32 field = CSRreg.FIELD;
 		CSRreg.Reset();

--- a/pcsx2/GS.cpp
+++ b/pcsx2/GS.cpp
@@ -32,19 +32,15 @@ void gsSetVideoMode(GS_VideoMode mode)
 {
 	gsVideoMode = mode;
 	UpdateVSyncRate();
-	CSRreg.FIELD = 1;
 }
 
 // Make sure framelimiter options are in sync with GS capabilities.
 void gsReset()
 {
 	GetMTGS().ResetGS(true);
-
-	UpdateVSyncRate();
+	gsVideoMode = GS_VideoMode::Uninitialized;
 	memzero(g_RealGSMem);
-
-	CSRreg.Reset();
-	GSIMR.reset();
+	UpdateVSyncRate();
 }
 
 void gsUpdateFrequency(Pcsx2Config& config)
@@ -85,13 +81,12 @@ static __fi void gsCSRwrite( const tGS_CSR& csr )
 		//Console.Warning( "csr.RESET" );
 		//gifUnit.Reset(true); // Don't think gif should be reset...
 		gifUnit.gsSIGNAL.queued = false;
+		gifUnit.gsFINISH.gsFINISHFired = true;
 		// Privilage registers also reset.
-		memset(PS2MEM_GS, 0, sizeof(PS2MEM_GS));
+		memzero(g_RealGSMem);
+		gsVideoMode = GS_VideoMode::Uninitialized;
+		UpdateVSyncRate();
 		GetMTGS().SendSimplePacket(GS_RINGTYPE_RESET, 0, 0, 0);
-		const u32 field = CSRreg.FIELD;
-		CSRreg.Reset();
-		GSIMR.reset();
-		CSRreg.FIELD = field;
 	}
 
 	if(csr.FLUSH)


### PR DESCRIPTION
### Description of Changes
Resets the GS Privilage Registers (ones which handle the display outputs) on GS Reset via the CSR register.

### Rationale behind Changes
This is console accurate emulation, the real hardware also resets these, we confirmed this with a test.

### Suggested Testing Steps
run some games and make sure the displays come on, even try via the bios in software mode, where it used to leave a bit of logo at the bottom.

Fixes #3485 (Bios logo being left at the bottom)
Also fixed junk screens between loading games in the Capcom Classics Collection discs.