### PR TITLE
Qt: Clear the status text after gamelist scanning

### DIFF
--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -1363,6 +1363,7 @@ void MainWindow::onGameListRefreshProgress(const QString& status, int current, i
 
 void MainWindow::onGameListRefreshComplete()
 {
+	m_ui.statusBar->clearMessage();
 	clearProgressBar();
 }
 


### PR DESCRIPTION
### Description of Changes
Adds a missing cleanup call in `MainWindow::onGameListRefreshComplete()`, so now the status text in the bottom bar vanishes after game scanning is complete.

### Rationale behind Changes
Improves UI parity with DuckStation.

### Suggested Testing Steps
Notice that "Scanning directory X..." is not lingering after starting PCSX2 anymore.
