### PR TITLE
Add command line boot and debug option

### DIFF
--- a/pcsx2-qt/MainWindow.h
+++ b/pcsx2-qt/MainWindow.h
@@ -110,6 +110,8 @@ public:
 	/// Rescans a single file. NOTE: Happens on UI thread.
 	void rescanFile(const std::string& path);
 
+	void openDebugger();
+
 public Q_SLOTS:
 	void checkForUpdates(bool display_message, bool force_check);
 	void refreshGameList(bool invalidate_cache);
@@ -241,7 +243,6 @@ private:
 	void updateInputRecordingActions(bool started);
 
 	DebuggerWindow* getDebuggerWindow();
-	void openDebugger();
 
 	ControllerSettingsDialog* getControllerSettingsDialog();
 	void doControllerSettings(ControllerSettingsDialog::Category category = ControllerSettingsDialog::Category::Count);

--- a/pcsx2-qt/QtHost.cpp
+++ b/pcsx2-qt/QtHost.cpp
@@ -96,6 +96,7 @@ static bool s_nogui_mode = false;
 static bool s_start_fullscreen_ui = false;
 static bool s_start_fullscreen_ui_fullscreen = false;
 static bool s_test_config_and_exit = false;
+static bool s_boot_and_debug = false;
 
 //////////////////////////////////////////////////////////////////////////
 // CPU Thread
@@ -1621,6 +1622,7 @@ void QtHost::PrintCommandLineHelp(const std::string_view& progname)
 	std::fprintf(stderr, "  -nofullscreen: Prevents fullscreen mode from triggering if enabled.\n");
 	std::fprintf(stderr, "  -earlyconsolelog: Forces logging of early console messages to console.\n");
 	std::fprintf(stderr, "  -testconfig: Initializes configuration and checks version, then exits.\n");
+	std::fprintf(stderr, "  -debugger: Open debugger and break on entry point.\n");
 #ifdef ENABLE_RAINTEGRATION
 	std::fprintf(stderr, "  -raintegration: Use RAIntegration instead of built-in achievement support.\n");
 #endif
@@ -1741,6 +1743,11 @@ bool QtHost::ParseCommandLineOptions(const QStringList& args, std::shared_ptr<VM
 			else if (CHECK_ARG(QStringLiteral("-testconfig")))
 			{
 				s_test_config_and_exit = true;
+				continue;
+			}
+			else if (CHECK_ARG(QStringLiteral("-debugger")))
+			{
+				s_boot_and_debug = true;
 				continue;
 			}
 #ifdef ENABLE_RAINTEGRATION
@@ -1879,6 +1886,12 @@ int main(int argc, char* argv[])
 	// Initialize big picture mode if requested.
 	if (s_start_fullscreen_ui)
 		g_emu_thread->startFullscreenUI(s_start_fullscreen_ui_fullscreen);
+
+	if (s_boot_and_debug)
+	{
+		DebugInterface::setPauseOnEntry(true);
+		main_window->openDebugger();
+	}
 
 	// Skip the update check if we're booting a game directly.
 	if (autoboot)


### PR DESCRIPTION
### Description of Changes
Adds a `-debugger` command line option for the Boot and Debug functionality.

### Rationale behind Changes
It's nice to have :)

### Suggested Testing Steps
Start games with the `-debugger` option, the debugger should open and execution should pause on the entry point.
