### PR TITLE
GS/HW: Simplify m_vertex/m_index

### DIFF
--- a/pcsx2/GS/Renderers/Common/GSDevice.cpp
+++ b/pcsx2/GS/Renderers/Common/GSDevice.cpp
@@ -187,14 +187,6 @@ std::unique_ptr<GSDownloadTexture> GSDevice::CreateDownloadTexture(u32 width, u3
 	return {};
 }
 
-void GSDevice::EndScene()
-{
-	m_vertex.start += m_vertex.count;
-	m_vertex.count = 0;
-	m_index.start += m_index.count;
-	m_index.count = 0;
-}
-
 void GSDevice::Recycle(GSTexture* t)
 {
 	if (!t)

--- a/pcsx2/GS/Renderers/Common/GSDevice.h
+++ b/pcsx2/GS/Renderers/Common/GSDevice.h
@@ -744,11 +744,11 @@ protected:
 
 	struct
 	{
-		size_t stride, start, count, limit;
+		u32 start, count;
 	} m_vertex = {};
 	struct
 	{
-		size_t start, count, limit;
+		u32 start, count;
 	} m_index = {};
 	unsigned int m_frame = 0; // for ageing the pool
 	bool m_rbswapped = false;
@@ -798,9 +798,6 @@ public:
 
 	virtual void ResetAPIState();
 	virtual void RestoreAPIState();
-
-	virtual void BeginScene() {}
-	virtual void EndScene();
 
 	virtual void ClearRenderTarget(GSTexture* t, const GSVector4& c) {}
 	virtual void ClearRenderTarget(GSTexture* t, u32 c) {}

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
@@ -272,6 +272,27 @@ bool GSDevice11::Create()
 	if (!m_shadeboost.ps)
 		return false;
 
+	// Vertex/Index Buffer
+	bd = {};
+	bd.ByteWidth = VERTEX_BUFFER_SIZE;
+	bd.Usage = D3D11_USAGE_DYNAMIC;
+	bd.BindFlags = D3D11_BIND_VERTEX_BUFFER;
+	bd.CPUAccessFlags = D3D11_CPU_ACCESS_WRITE;
+	if (FAILED(m_dev->CreateBuffer(&bd, nullptr, m_vb.put())))
+	{
+		Console.Error("Failed to create vertex buffer.");
+		return false;
+	}
+
+	bd.ByteWidth = INDEX_BUFFER_SIZE;
+	bd.BindFlags = D3D11_BIND_INDEX_BUFFER;
+	if (FAILED(m_dev->CreateBuffer(&bd, nullptr, m_ib.put())))
+	{
+		Console.Error("Failed to create index buffer.");
+		return false;
+	}
+	m_ctx->IASetIndexBuffer(m_ib.get(), DXGI_FORMAT_R32_UINT, 0);
+
 	//
 
 	memset(&rd, 0, sizeof(rd));
@@ -369,10 +390,9 @@ void GSDevice11::ResetAPIState()
 
 void GSDevice11::RestoreAPIState()
 {
-	const UINT vb_stride = static_cast<UINT>(m_state.vb_stride);
 	const UINT vb_offset = 0;
-	m_ctx->IASetVertexBuffers(0, 1, &m_state.vb, &vb_stride, &vb_offset);
-	m_ctx->IASetIndexBuffer(m_state.ib, DXGI_FORMAT_R32_UINT, 0);
+	m_ctx->IASetVertexBuffers(0, 1, m_vb.addressof(), &m_state.vb_stride, &vb_offset);
+	m_ctx->IASetIndexBuffer(m_ib.get(), DXGI_FORMAT_R32_UINT, 0);
 	m_ctx->IASetInputLayout(m_state.layout);
 	m_ctx->IASetPrimitiveTopology(m_state.topology);
 	m_ctx->VSSetShader(m_state.vs, nullptr, 0);
@@ -616,8 +636,6 @@ void GSDevice11::StretchRect(GSTexture* sTex, const GSVector4& sRect, GSTexture*
 
 	const bool draw_in_depth = dTex && dTex->IsDepthStencil();
 
-	BeginScene();
-
 	GSVector2i ds;
 	if (dTex)
 	{
@@ -686,16 +704,12 @@ void GSDevice11::StretchRect(GSTexture* sTex, const GSVector4& sRect, GSTexture*
 
 	//
 
-	EndScene();
-
 	PSSetShaderResources(nullptr, nullptr);
 }
 
 void GSDevice11::PresentRect(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect, PresentShader shader, float shaderTime, bool linear)
 {
 	ASSERT(sTex);
-
-	BeginScene();
 
 	GSVector2i ds;
 	if (dTex)
@@ -762,8 +776,6 @@ void GSDevice11::PresentRect(GSTexture* sTex, const GSVector4& sRect, GSTexture*
 	DrawPrimitive();
 
 	//
-
-	EndScene();
 
 	PSSetShaderResources(nullptr, nullptr);
 }
@@ -945,8 +957,6 @@ void GSDevice11::SetupDATE(GSTexture* rt, GSTexture* ds, const GSVertexPT1* vert
 {
 	// sfex3 (after the capcom logo), vf4 (first menu fading in), ffxii shadows, rumble roses shadows, persona4 shadows
 
-	BeginScene();
-
 	ClearStencil(ds, 0);
 
 	// om
@@ -979,156 +989,69 @@ void GSDevice11::SetupDATE(GSTexture* rt, GSTexture* ds, const GSVertexPT1* vert
 	DrawPrimitive();
 
 	//
-
-	EndScene();
 }
 
-void GSDevice11::IASetVertexBuffer(const void* vertex, size_t stride, size_t count)
+bool GSDevice11::IASetVertexBuffer(const void* vertex, u32 stride, u32 count)
 {
-	void* ptr = nullptr;
-
-	if (IAMapVertexBuffer(&ptr, stride, count))
-	{
-		GSVector4i::storent(ptr, vertex, count * stride);
-
-		IAUnmapVertexBuffer();
-	}
-}
-
-bool GSDevice11::IAMapVertexBuffer(void** vertex, size_t stride, size_t count)
-{
-	ASSERT(m_vertex.count == 0);
-
-	if (count * stride > m_vertex.limit * m_vertex.stride)
-	{
-		m_vb.reset();
-
-		m_vertex.start = 0;
-		m_vertex.limit = std::max<int>(count * 3 / 2, 11000);
-	}
-
-	if (m_vb == nullptr)
-	{
-		D3D11_BUFFER_DESC bd;
-
-		memset(&bd, 0, sizeof(bd));
-
-		bd.Usage = D3D11_USAGE_DYNAMIC;
-		bd.ByteWidth = m_vertex.limit * stride;
-		bd.BindFlags = D3D11_BIND_VERTEX_BUFFER;
-		bd.CPUAccessFlags = D3D11_CPU_ACCESS_WRITE;
-
-		const HRESULT hr = m_dev->CreateBuffer(&bd, nullptr, m_vb.put());
-
-		if (FAILED(hr))
-			return false;
-	}
+	const u32 size = stride * count;
+	if (size > VERTEX_BUFFER_SIZE)
+		return false;
 
 	D3D11_MAP type = D3D11_MAP_WRITE_NO_OVERWRITE;
 
-	if (m_vertex.start + count > m_vertex.limit || stride != m_vertex.stride)
+	m_vertex.start = (m_vb_pos + (stride - 1)) / stride;
+	m_vb_pos = (m_vertex.start * stride) + size;
+	if (m_vb_pos > VERTEX_BUFFER_SIZE)
 	{
 		m_vertex.start = 0;
-
+		m_vb_pos = size;
 		type = D3D11_MAP_WRITE_DISCARD;
 	}
 
 	D3D11_MAPPED_SUBRESOURCE m;
-
 	if (FAILED(m_ctx->Map(m_vb.get(), 0, type, 0, &m)))
-	{
 		return false;
+
+	GSVector4i::storent(static_cast<u8*>(m.pData) + m_vertex.start * stride, vertex, count * stride);
+
+	m_ctx->Unmap(m_vb.get(), 0);
+
+	if (m_state.vb_stride != stride)
+	{
+		m_state.vb_stride = stride;
+		const UINT vb_offset = 0;
+		m_ctx->IASetVertexBuffers(0, 1, m_vb.addressof(), &stride, &vb_offset);
 	}
 
-	*vertex = (u8*)m.pData + m_vertex.start * stride;
-
 	m_vertex.count = count;
-	m_vertex.stride = stride;
-
 	return true;
 }
 
-void GSDevice11::IAUnmapVertexBuffer()
+bool GSDevice11::IASetIndexBuffer(const void* index, u32 count)
 {
-	m_ctx->Unmap(m_vb.get(), 0);
-
-	IASetVertexBuffer(m_vb.get(), m_vertex.stride);
-}
-
-void GSDevice11::IASetVertexBuffer(ID3D11Buffer* vb, size_t stride)
-{
-	if (m_state.vb != vb || m_state.vb_stride != stride)
-	{
-		m_state.vb = vb;
-		m_state.vb_stride = stride;
-
-		const u32 stride2 = stride;
-		const u32 offset = 0;
-
-		m_ctx->IASetVertexBuffers(0, 1, &vb, &stride2, &offset);
-	}
-}
-
-void GSDevice11::IASetIndexBuffer(const void* index, size_t count)
-{
-	ASSERT(m_index.count == 0);
-
-	if (count > m_index.limit)
-	{
-		m_ib.reset();
-
-		m_index.start = 0;
-		m_index.limit = std::max<int>(count * 3 / 2, 11000);
-	}
-
-	if (m_ib == nullptr)
-	{
-		D3D11_BUFFER_DESC bd;
-
-		memset(&bd, 0, sizeof(bd));
-
-		bd.Usage = D3D11_USAGE_DYNAMIC;
-		bd.ByteWidth = m_index.limit * sizeof(u32);
-		bd.BindFlags = D3D11_BIND_INDEX_BUFFER;
-		bd.CPUAccessFlags = D3D11_CPU_ACCESS_WRITE;
-
-		HRESULT hr = m_dev->CreateBuffer(&bd, nullptr, m_ib.put());
-
-		if (FAILED(hr))
-			return;
-	}
+	if (count > (INDEX_BUFFER_SIZE / sizeof(u32)))
+		return false;
 
 	D3D11_MAP type = D3D11_MAP_WRITE_NO_OVERWRITE;
 
-	if (m_index.start + count > m_index.limit)
+	m_index.start = m_ib_pos;
+	m_ib_pos += count;
+
+	if (m_ib_pos > (INDEX_BUFFER_SIZE / sizeof(u32)))
 	{
 		m_index.start = 0;
-
+		m_ib_pos = count;
 		type = D3D11_MAP_WRITE_DISCARD;
 	}
 
 	D3D11_MAPPED_SUBRESOURCE m;
+	if (FAILED(m_ctx->Map(m_ib.get(), 0, type, 0, &m)))
+		return false;
 
-	if (SUCCEEDED(m_ctx->Map(m_ib.get(), 0, type, 0, &m)))
-	{
-		memcpy((u8*)m.pData + m_index.start * sizeof(u32), index, count * sizeof(u32));
-
-		m_ctx->Unmap(m_ib.get(), 0);
-	}
-
+	std::memcpy((u8*)m.pData + m_index.start * sizeof(u32), index, count * sizeof(u32));
+	m_ctx->Unmap(m_ib.get(), 0);
 	m_index.count = count;
-
-	IASetIndexBuffer(m_ib.get());
-}
-
-void GSDevice11::IASetIndexBuffer(ID3D11Buffer* ib)
-{
-	if (m_state.ib != ib)
-	{
-		m_state.ib = ib;
-
-		m_ctx->IASetIndexBuffer(ib, DXGI_FORMAT_R32_UINT, 0);
-	}
+	return true;
 }
 
 void GSDevice11::IASetInputLayout(ID3D11InputLayout* layout)
@@ -1407,17 +1330,15 @@ void GSDevice11::RenderHW(GSHWDrawConfig& config)
 		// Warning: StretchRect must be called before BeginScene otherwise
 		// vertices will be overwritten. Trust me you don't want to do that.
 		StretchRect(config.rt, sRect, hdr_rt, dRect, ShaderConvert::HDR_INIT, false);
+		g_perfmon.Put(GSPerfMon::TextureCopies, 1);
 	}
 
-	BeginScene();
-
-	void* ptr = nullptr;
-	if (IAMapVertexBuffer(&ptr, sizeof(*config.verts), config.nverts))
+	if (!IASetVertexBuffer(config.verts, sizeof(*config.verts), config.nverts) ||
+		!IASetIndexBuffer(config.indices, config.nindices))
 	{
-		GSVector4i::storent(ptr, config.verts, config.nverts * sizeof(*config.verts));
-		IAUnmapVertexBuffer();
+		Console.Error("Failed to upload vertices/indices (%u/%u)", config.nverts, config.nindices);
+		return;
 	}
-	IASetIndexBuffer(config.indices, config.nindices);
 	D3D11_PRIMITIVE_TOPOLOGY topology = D3D11_PRIMITIVE_TOPOLOGY_UNDEFINED;
 	switch (config.topology)
 	{
@@ -1526,8 +1447,6 @@ void GSDevice11::RenderHW(GSHWDrawConfig& config)
 		}
 	}
 
-	EndScene();
-
 	if (rt_copy)
 		Recycle(rt_copy);
 	if (ds_copy)
@@ -1541,6 +1460,7 @@ void GSDevice11::RenderHW(GSHWDrawConfig& config)
 		const GSVector4 dRect(config.drawarea);
 		const GSVector4 sRect = dRect / GSVector4(size.x, size.y).xyxy();
 		StretchRect(hdr_rt, sRect, config.rt, dRect, ShaderConvert::HDR_RESOLVE, false);
+		g_perfmon.Put(GSPerfMon::TextureCopies, 1);
 		Recycle(hdr_rt);
 	}
 }

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.h
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.h
@@ -22,6 +22,7 @@
 #include <unordered_map>
 #include <wil/com.h>
 #include <dxgi1_3.h>
+#include <d3d11_1.h>
 
 struct GSVertexShader11
 {
@@ -130,6 +131,7 @@ private:
 
 	wil::com_ptr_nothrow<ID3D11Device> m_dev;
 	wil::com_ptr_nothrow<ID3D11DeviceContext> m_ctx;
+	wil::com_ptr_nothrow<ID3DUserDefinedAnnotation> m_annotation;
 	wil::com_ptr_nothrow<IDXGISwapChain1> m_swapchain;
 	wil::com_ptr_nothrow<ID3D11Buffer> m_vb;
 	wil::com_ptr_nothrow<ID3D11Buffer> m_ib;
@@ -256,6 +258,10 @@ public:
 	void ClearRenderTarget(GSTexture* t, u32 c) override;
 	void ClearDepth(GSTexture* t) override;
 	void ClearStencil(GSTexture* t, u8 c) override;
+
+	void PushDebugGroup(const char* fmt, ...) override;
+	void PopDebugGroup() override;
+	void InsertDebugMessage(DebugMessageCategory category, const char* fmt, ...) override;
 
 	void CloneTexture(GSTexture* src, GSTexture** dest, const GSVector4i& rect);
 

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.h
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.h
@@ -110,8 +110,13 @@ public:
 	};
 
 private:
-	static constexpr u32 MAX_TEXTURES = 4;
-	static constexpr u32 MAX_SAMPLERS = 1;
+	enum : u32
+	{
+		MAX_TEXTURES = 4,
+		MAX_SAMPLERS = 1,
+		VERTEX_BUFFER_SIZE = 32 * 1024 * 1024,
+		INDEX_BUFFER_SIZE = 16 * 1024 * 1024,
+	};
 
 	int m_d3d_texsize;
 
@@ -135,12 +140,11 @@ private:
 	wil::com_ptr_nothrow<IDXGISwapChain1> m_swapchain;
 	wil::com_ptr_nothrow<ID3D11Buffer> m_vb;
 	wil::com_ptr_nothrow<ID3D11Buffer> m_ib;
+	u32 m_vb_pos = 0; // bytes
+	u32 m_ib_pos = 0; // indices/sizeof(u32)
 
 	struct
 	{
-		ID3D11Buffer* vb;
-		size_t vb_stride;
-		ID3D11Buffer* ib;
 		ID3D11InputLayout* layout;
 		D3D11_PRIMITIVE_TOPOLOGY topology;
 		ID3D11VertexShader* vs;
@@ -153,6 +157,7 @@ private:
 		std::array<ID3D11SamplerState*, MAX_SAMPLERS> ps_ss;
 		GSVector2i viewport;
 		GSVector4i scissor;
+		u32 vb_stride;
 		ID3D11DepthStencilState* dss;
 		u8 sref;
 		ID3D11BlendState* bs;
@@ -276,12 +281,8 @@ public:
 
 	void SetupDATE(GSTexture* rt, GSTexture* ds, const GSVertexPT1* vertices, bool datm);
 
-	void IASetVertexBuffer(const void* vertex, size_t stride, size_t count);
-	bool IAMapVertexBuffer(void** vertex, size_t stride, size_t count);
-	void IAUnmapVertexBuffer();
-	void IASetVertexBuffer(ID3D11Buffer* vb, size_t stride);
-	void IASetIndexBuffer(const void* index, size_t count);
-	void IASetIndexBuffer(ID3D11Buffer* ib);
+	bool IASetVertexBuffer(const void* vertex, u32 stride, u32 count);
+	bool IASetIndexBuffer(const void* index, u32 count);
 	void IASetInputLayout(ID3D11InputLayout* layout);
 	void IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY topology);
 

--- a/pcsx2/GS/Renderers/DX12/GSDevice12.h
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.h
@@ -264,8 +264,6 @@ public:
 	GSTexture12* SetupPrimitiveTrackingDATE(GSHWDrawConfig& config, PipelineSelector& pipe);
 
 	void IASetVertexBuffer(const void* vertex, size_t stride, size_t count);
-	bool IAMapVertexBuffer(void** vertex, size_t stride, size_t count);
-	void IAUnmapVertexBuffer();
 	void IASetIndexBuffer(const void* index, size_t count);
 
 	void PSSetShaderResource(int i, GSTexture* sr, bool check_state);

--- a/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
+++ b/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
@@ -1127,8 +1127,6 @@ void GSDeviceMTL::CopyRect(GSTexture* sTex, GSTexture* dTex, const GSVector4i& r
 
 void GSDeviceMTL::DoStretchRect(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect, id<MTLRenderPipelineState> pipeline, bool linear, LoadAction load_action, void* frag_uniform, size_t frag_uniform_len)
 {
-	BeginScene();
-
 	FlushClears(sTex);
 
 	GSTextureMTL* sT = static_cast<GSTextureMTL*>(sTex);
@@ -1164,8 +1162,6 @@ void GSDeviceMTL::DoStretchRect(GSTexture* sTex, const GSVector4& sRect, GSTextu
 	MRESetSampler(linear ? SamplerSelector::Linear() : SamplerSelector::Point());
 
 	DrawStretchRect(sRect, dRect, ds);
-
-	EndScene();
 }
 
 void GSDeviceMTL::DrawStretchRect(const GSVector4& sRect, const GSVector4& dRect, const GSVector2i& ds)
@@ -1609,7 +1605,6 @@ static_assert(offsetof(GSHWDrawConfig::PSConstantBuffer, DitherMatrix)     == of
 
 void GSDeviceMTL::SetupDestinationAlpha(GSTexture* rt, GSTexture* ds, const GSVector4i& r, bool datm)
 {
-	BeginScene();
 	FlushClears(rt);
 	BeginRenderPass(@"Destination Alpha Setup", nullptr, MTLLoadActionDontCare, nullptr, MTLLoadActionDontCare, ds, MTLLoadActionDontCare);
 	[m_current_render.encoder setStencilReferenceValue:1];
@@ -1617,7 +1612,6 @@ void GSDeviceMTL::SetupDestinationAlpha(GSTexture* rt, GSTexture* ds, const GSVe
 	RenderCopy(nullptr, m_stencil_clear_pipeline, r);
 	MRESetDSS(m_dss_stencil_write);
 	RenderCopy(rt, m_datm_pipeline[datm], r);
-	EndScene();
 }
 
 static id<MTLTexture> getTexture(GSTexture* tex)
@@ -1696,7 +1690,6 @@ void GSDeviceMTL::RenderHW(GSHWDrawConfig& config)
 			break;
 	}
 
-	BeginScene();
 	GSTexture* hdr_rt = nullptr;
 	if (config.ps.hdr)
 	{

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -1093,7 +1093,6 @@ void GSDeviceOGL::BlitRect(GSTexture* sTex, const GSVector4i& r, const GSVector2
 
 	const GSVector4 float_r(r);
 
-	BeginScene();
 	m_convert.ps[static_cast<int>(ShaderConvert::COPY)].Bind();
 	OMSetDepthStencilState(m_convert.dss);
 	OMSetBlendState();
@@ -1101,7 +1100,6 @@ void GSDeviceOGL::BlitRect(GSTexture* sTex, const GSVector4i& r, const GSVector2
 	PSSetShaderResource(0, sTex);
 	PSSetSamplerState(linear ? m_convert.ln : m_convert.pt);
 	DrawStretchRect(float_r / (GSVector4(sTex->GetSize()).xyxy()), float_r, dsize);
-	EndScene();
 
 	glEnable(GL_SCISSOR_TEST);
 }
@@ -1190,8 +1188,6 @@ void GSDeviceOGL::StretchRect(GSTexture* sTex, const GSVector4& sRect, GSTexture
 	// Init
 	// ************************************
 
-	BeginScene();
-
 	GL_PUSH("StretchRect from %d to %d", sTex->GetID(), dTex->GetID());
 	if (draw_in_depth)
 		OMSetRenderTargets(NULL, dTex);
@@ -1223,19 +1219,11 @@ void GSDeviceOGL::StretchRect(GSTexture* sTex, const GSVector4& sRect, GSTexture
 	// Draw
 	// ************************************
 	DrawStretchRect(sRect, dRect, dTex->GetSize());
-
-	// ************************************
-	// End
-	// ************************************
-
-	EndScene();
 }
 
 void GSDeviceOGL::PresentRect(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect, PresentShader shader, float shaderTime, bool linear)
 {
 	ASSERT(sTex);
-
-	BeginScene();
 
 	const GSVector2i ds(dTex ? dTex->GetSize() : GSVector2i(g_host_display->GetWindowWidth(), g_host_display->GetWindowHeight()));
 	DisplayConstantBuffer cb;
@@ -1269,14 +1257,10 @@ void GSDeviceOGL::PresentRect(GSTexture* sTex, const GSVector4& sRect, GSTexture
 	// Only flipping the backbuffer is transparent (I hope)...
 	const GSVector4 flip_sr(sRect.xwzy());
 	DrawStretchRect(flip_sr, dRect, ds);
-
-	EndScene();
 }
 
 void GSDeviceOGL::UpdateCLUTTexture(GSTexture* sTex, u32 offsetX, u32 offsetY, GSTexture* dTex, u32 dOffset, u32 dSize)
 {
-	BeginScene();
-
 	const ShaderConvert shader = (dSize == 16) ? ShaderConvert::CLUT_4 : ShaderConvert::CLUT_8;
 	GL::Program& prog = m_convert.ps[static_cast<int>(shader)];
 	prog.Bind();
@@ -1293,8 +1277,6 @@ void GSDeviceOGL::UpdateCLUTTexture(GSTexture* sTex, u32 offsetX, u32 offsetY, G
 
 	const GSVector4 dRect(0, 0, dSize, 1);
 	DrawStretchRect(GSVector4::zero(), dRect, dTex->GetSize());
-
-	EndScene();
 }
 
 void GSDeviceOGL::DrawStretchRect(const GSVector4& sRect, const GSVector4& dRect, const GSVector2i& ds)
@@ -1458,8 +1440,6 @@ void GSDeviceOGL::SetupDATE(GSTexture* rt, GSTexture* ds, const GSVertexPT1* ver
 
 	// sfex3 (after the capcom logo), vf4 (first menu fading in), ffxii shadows, rumble roses shadows, persona4 shadows
 
-	BeginScene();
-
 	ClearStencil(ds, 0);
 
 	m_convert.ps[static_cast<int>(datm ? ShaderConvert::DATM_1 : ShaderConvert::DATM_0)].Bind();
@@ -1490,8 +1470,6 @@ void GSDeviceOGL::SetupDATE(GSTexture* rt, GSTexture* ds, const GSVertexPT1* ver
 	{
 		glEnable(GL_BLEND);
 	}
-
-	EndScene();
 }
 
 void GSDeviceOGL::IASetVertexBuffer(const void* vertices, size_t count)
@@ -1894,8 +1872,6 @@ void GSDeviceOGL::RenderHW(GSHWDrawConfig& config)
 		CopyRect(config.rt, draw_rt_clone, config.drawarea, config.drawarea.left, config.drawarea.top);
 	}
 
-	BeginScene();
-
 	IASetVertexBuffer(config.verts, config.nverts);
 	IASetIndexBuffer(config.indices, config.nindices);
 	GLenum topology = 0;
@@ -2047,10 +2023,6 @@ void GSDeviceOGL::RenderHW(GSHWDrawConfig& config)
 	if (draw_rt_clone)
 		Recycle(draw_rt_clone);
 
-	EndScene();
-
-	// Warning: EndScene must be called before StretchRect otherwise
-	// vertices will be overwritten. Trust me you don't want to do that.
 	if (hdr_rt)
 	{
 		GSVector2i size = config.rt->GetSize();

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h
@@ -247,8 +247,6 @@ public:
 	GSTextureVK* SetupPrimitiveTrackingDATE(GSHWDrawConfig& config);
 
 	void IASetVertexBuffer(const void* vertex, size_t stride, size_t count);
-	bool IAMapVertexBuffer(void** vertex, size_t stride, size_t count);
-	void IAUnmapVertexBuffer();
 	void IASetIndexBuffer(const void* index, size_t count);
 
 	void PSSetShaderResource(int i, GSTexture* sr, bool check_state);


### PR DESCRIPTION
### Description of Changes

Switches DX11 to a larger streaming buffer, adds missing texture copy counter for colclip.

### Rationale behind Changes

Less code? Potentially a tiny bit more performance on bad drivers.

### Suggested Testing Steps

Test all renderers, make sure they're not obviously broken.
