### PR TITLE
GS-HW: Queue preloads from Local->Local moves on CPU also

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -1260,6 +1260,7 @@ SCAJ-20161:
     - SoftwareRendererFMVHack # Fixes vertical lines in FMVs that aren't fixed with merge sprite.
   gsHWFixes:
     mergeSprite: 1 # Fixes vertical lines in-game.
+    preloadFrameData: 1 # Fixes some missing effects.
 SCAJ-20162:
   name: "Rogue Galaxy"
   region: "NTSC-Unk"
@@ -1296,6 +1297,7 @@ SCAJ-20167:
     - SoftwareRendererFMVHack # Fixes vertical lines in FMVs that aren't fixed with merge sprite.
   gsHWFixes:
     mergeSprite: 1 # Fixes vertical lines in-game.
+    preloadFrameData: 1 # Fixes some missing effects.
 SCAJ-20168:
   name: "Rule of Rose"
   region: "NTSC-Unk"
@@ -4058,6 +4060,7 @@ SCES-53851:
     - SoftwareRendererFMVHack # Fixes vertical lines in FMVs that aren't fixed with merge sprite.
   gsHWFixes:
     mergeSprite: 1 # Fixes vertical lines in-game.
+    preloadFrameData: 1 # Fixes some missing effects.
   patches:
     default:
       content: |-
@@ -5192,6 +5195,7 @@ SCKA-20069:
     - SoftwareRendererFMVHack # Fixes vertical lines in FMVs that aren't fixed with merge sprite.
   gsHWFixes:
     mergeSprite: 1 # Fixes vertical lines in-game.
+    preloadFrameData: 1 # Fixes some missing effects.
 SCKA-20070:
   name: "Ace Combat Zero - The Belkan War"
   region: "NTSC-K"
@@ -6099,6 +6103,7 @@ SCPS-15106:
     - SoftwareRendererFMVHack # Fixes vertical lines in FMVs that aren't fixed with merge sprite.
   gsHWFixes:
     mergeSprite: 1 # Fixes vertical lines in-game.
+    preloadFrameData: 1 # Fixes some missing effects.
   patches:
     626552EB:
       content: |-
@@ -6572,6 +6577,7 @@ SCPS-19326:
     - SoftwareRendererFMVHack # Fixes vertical lines in FMVs that aren't fixed with merge sprite.
   gsHWFixes:
     mergeSprite: 1 # Fixes vertical lines in-game.
+    preloadFrameData: 1 # Fixes some missing effects.
 SCPS-19327:
   name: "Ape Escape 3 [PlayStation 2 the Best - Reprint]"
   region: "NTSC-J"

--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -2154,6 +2154,16 @@ void GSState::Move()
 	{
 		Flush(GSFlushReason::LOCALTOLOCALMOVE);
 	}
+
+	if (GSConfig.PreloadFrameWithGSData)
+	{
+		// Store the transfer for preloading new RT's.
+		if (m_draw_transfers.size() == 0 || (m_draw_transfers.size() > 0 && dbp != m_draw_transfers.back().blit.DBP))
+		{
+			GSUploadQueue new_transfer = { m_env.BITBLTBUF, s_n };
+			m_draw_transfers.push_back(new_transfer);
+		}
+	}
 	// Invalid the CLUT if it crosses paths.
 	m_mem.m_clut.InvalidateRange(write_start_bp, write_end_bp);
 


### PR DESCRIPTION
### Description of Changes
Adds the preloading check to local moves, which may get done before the hw renderer picks them up.

### Rationale behind Changes
Missed them in my previous PR, which was relied upon by Siren 2 when using preload frame.

### Suggested Testing Steps
Test Siren 2, not sure what else benefits.

Siren 2:

Before:
![image](https://user-images.githubusercontent.com/6278726/216498004-f541a253-08ea-484d-bd44-83d1bc41e8e9.png)

After:
![image](https://user-images.githubusercontent.com/6278726/216498041-48c81060-f828-4cae-bb0e-114d3c04bbd3.png)
