### PR TITLE
GameDB: Fix texture-flickering of Armored Core Nexus

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -784,6 +784,8 @@ SCAJ-20075:
 SCAJ-20076:
   name: "Armored Core - Nexus [Disc 1]"
   region: "NTSC-Unk"
+  roundModes:
+    eeRoundMode: 0 # Fixes Z-Fighting.
   memcardFilters:
     - "SCAJ-20076"
     - "SCAJ-20077"
@@ -794,6 +796,8 @@ SCAJ-20076:
 SCAJ-20077:
   name: "Armored Core - Nexus [Disc 2]"
   region: "NTSC-Unk"
+  roundModes:
+    eeRoundMode: 0 # Fixes Z-Fighting.
   memcardFilters:
     - "SCAJ-20076"
     - "SCAJ-20077"
@@ -22980,12 +22984,16 @@ SLES-82035:
 SLES-82036:
   name: "Armored Core - Nexus [Disc 1 of 2 - Evolution Disc]"
   region: "PAL-M5"
+  roundModes:
+    eeRoundMode: 0 # Fixes Z-Fighting.
   memcardFilters:
     - "SLES-82036"
     - "SLES-82037"
 SLES-82037:
   name: "Armored Core - Nexus [Disc 2 of 2 - Revolution Disc]"
   region: "PAL-M5"
+  roundModes:
+    eeRoundMode: 0 # Fixes Z-Fighting.
   memcardFilters:
     - "SLES-82036"
     - "SLES-82037"
@@ -23721,12 +23729,16 @@ SLKA-25200:
 SLKA-25201:
   name: "Armored Core Nexus Evolution [Disc 1]"
   region: "NTSC-K"
+  roundModes:
+    eeRoundMode: 0 # Fixes Z-Fighting.
   memcardFilters:
     - "SLKA-25201"
     - "SLKA-25202"
 SLKA-25202:
   name: "Armored Core Nexus Revolution [Disc 2]"
   region: "NTSC-K"
+  roundModes:
+    eeRoundMode: 0 # Fixes Z-Fighting.
   memcardFilters:
     - "SLKA-25201"
     - "SLKA-25202"
@@ -37683,6 +37695,8 @@ SLPS-25337:
 SLPS-25338:
   name: "Armored Core - Nexus [Disc 1]"
   region: "NTSC-J"
+  roundModes:
+    eeRoundMode: 0 # Fixes Z-Fighting.
   memcardFilters:
     - "SCAJ-20076"
     - "SCAJ-20077"
@@ -37693,6 +37707,8 @@ SLPS-25338:
 SLPS-25339:
   name: "Armored Core - Nexus [Disc 2]"
   region: "NTSC-J"
+  roundModes:
+    eeRoundMode: 0 # Fixes Z-Fighting.
   memcardFilters:
     - "SCAJ-20076"
     - "SCAJ-20077"
@@ -40052,6 +40068,8 @@ SLPS-73201:
 SLPS-73202:
   name: "Armored Core - Nexus [PlayStation 2 The Best] [Disc 1]"
   region: "NTSC-J"
+  roundModes:
+    eeRoundMode: 0 # Fixes Z-Fighting.
   memcardFilters:
     - "SCAJ-20076"
     - "SCAJ-20077"
@@ -40062,6 +40080,8 @@ SLPS-73202:
 SLPS-73203:
   name: "Armored Core - Nexus [PlayStation 2 The Best] [Disc 2]"
   region: "NTSC-J"
+  roundModes:
+    eeRoundMode: 0 # Fixes Z-Fighting.
   memcardFilters:
     - "SCAJ-20076"
     - "SCAJ-20077"
@@ -45071,6 +45091,8 @@ SLUS-20985:
 SLUS-20986:
   name: "Armored Core Nexus [Evolution Disc]"
   region: "NTSC-U"
+  roundModes:
+    eeRoundMode: 0 # Fixes Z-Fighting.
   compat: 5
   memcardFilters:
     - "SLUS-20986"
@@ -45582,6 +45604,8 @@ SLUS-21078:
 SLUS-21079:
   name: "Armored Core Nexus [Revolution Disc]"
   region: "NTSC-U"
+  roundModes:
+    eeRoundMode: 0 # Fixes Z-Fighting.
   memcardFilters:
     - "SLUS-20986"
     - "SLUS-21079"


### PR DESCRIPTION
### Description of Changes
Added following lines to all the 12 titles of Armored Core Nexus.
``` yaml
  roundModes:
    eeRoundMode: 0 #Fixes Z-Fighting.

```

### Rationale behind Changes
This change solves texture-flickering on Armored Core Nexus.

### Suggested Testing Steps
Go a mission that has texture-flickering.
- In most missions, looking down causes flicker.
- For disc 1, the cutscene of "Eliminate Crest AC" is the most clearly example.

I only tested `SLPS-25338` and `SLPS-25339` (NTSC-J), so it's needed to test following games as well:
```
SCAJ-20076 SCAJ-20077 | NTSC-Unk
SLES-82036 SLES-82037 |  PAL-M5
SLKA-25201 SLKA-25202 | NTSC-K
SLPS-73202 SLPS-73203 | NTSC-J (PS2 the best)
SLUS-20976 SLUS-21079 | NTSC-U
```
