### PR TITLE
Qt: Fix compatibility string

### DIFF
--- a/pcsx2-qt/GameList/GameListWidget.cpp
+++ b/pcsx2-qt/GameList/GameListWidget.cpp
@@ -488,7 +488,7 @@ void GameListWidget::resizeTableViewColumnsToFit()
 														 80, // last played
 														 80, // size
 														 60, // region
-														 100 // compatibility
+														 120 // compatibility
 													 });
 }
 

--- a/pcsx2-qt/Settings/GameSummaryWidget.ui
+++ b/pcsx2-qt/Settings/GameSummaryWidget.ui
@@ -348,6 +348,11 @@
      </item>
      <item>
       <property name="text">
+       <string>Playable</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
        <string>Perfect</string>
       </property>
      </item>


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->

Playable rating was missing which is the most common rating for PCSX2. There are some other issues like the images look bad for star rating and some other stuff. Also resize the compatibility table width a bit.

Per-game properties
- Before:
![image](https://user-images.githubusercontent.com/24227051/216513378-979dd4eb-c3c9-49e1-9cbe-3b741a4441a9.png)
- After:
![image](https://user-images.githubusercontent.com/24227051/216513264-bcd6a768-a546-437b-a00d-e7aec2f617ff.png)

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Makes PCSX2 more consistent and correct.
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Just scanning gamelist should be enough or you can check the per-game properties as well.