### PR TITLE
GS: Don't do CLUT auto flush test on invalid PRIM

### DIFF
--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -3455,7 +3455,7 @@ __forceinline void GSState::VertexKick(u32 skip)
 			break;
 		case GS_INVALID:
 			m_vertex.tail = head;
-			break;
+			return;
 		default:
 			__assume(0);
 	}


### PR DESCRIPTION
### Description of Changes

Fixes OOB array access in Xenosaga I's cutscenes. m_index.tail is zero, therefore the loop afterwards will access `index[-1]`, and crash if whatever happened to be before the buffer was larger than the vertex buffer array.

This snippet was pretty slow before, and since it's executed for every primitive, I went ahead and vectorized it.

Looks like a ~2% performance boost in the xenosaga cutscene dump

### Rationale behind Changes

UB is bad.

### Suggested Testing Steps

~~Tested myself, but if you want, run xenosaga through its first cutscene. But the crash isn't reliable to produce on master.~~

Test games which relied on CLUT auto flush.