### PR TITLE
GameDB: Add basic mipmap to Narc and Tom & Jerry War of the Whiskers.

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -26382,6 +26382,7 @@ SLPM-62449:
   name: "Tom & Jerry - War of the Whiskers"
   region: "NTSC-J"
   gsHWFixes:
+    mipmap: 1 # Cleans up texture detail.
     disableDepthSupport: 1 # Fixes shadow flicker.
 SLPM-62450:
   name: "Karaoke Revolution - Anime Song Selection"
@@ -42013,6 +42014,7 @@ SLUS-20355:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
+    mipmap: 1 # Cleans up texture detail.
     disableDepthSupport: 1 # Fixes shadow flicker.
 SLUS-20356:
   name: "Transworld SURF"
@@ -43801,6 +43803,8 @@ SLUS-20730:
   name: "NARC"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    mipmap: 1 # Fixes textures.
 SLUS-20731:
   name: "Tony Hawk's Underground"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GameDB: Add basic mipmap to Narc and Tom & Jerry War of the Whiskers.
Fixes textures.
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Fixes textures.
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test the dumps from #3180