### PR TITLE
GameDB: Fixes for "Toy Story 3" & "WALL-E"

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -7005,10 +7005,15 @@ SCUS-21494:
     halfPixelOffset: 2 # Fixes blurriness.
     roundSprite: 2 # Fixes blurriness.
 SCUS-90174:
-  name: "Toy Story 3 [PlayStation 2 Bundle]"
+  name: "Disney-Pixar Toy Story 3 [PlayStation 2 Bundle]"
   region: "NTSC-U"
   roundModes:
     vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
+  gsHWFixes:
+    halfPixelOffset: 2 # Help fixes ghosting.
+    roundSprite: 2 # Help fixes ghosting.
+    skipDrawStart: 1 # Removes the ghosting effect when upscaling.
+    skipDrawEnd: 1 # Removes the ghosting effect when upscaling.
 SCUS-94346:
   name: "SingStar Latino"
   region: "NTSC-U"
@@ -21790,26 +21795,51 @@ SLES-55184:
   region: "PAL-A"
   roundModes:
     vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes blurriness.
+    roundSprite: 2 # Fixes blurriness.
+    skipDrawStart: 1 # Removes the ghosting effect when upscaling.
+    skipDrawEnd: 1 # Removes the ghosting effect when upscaling.
 SLES-55185:
   name: "Disney-Pixar WALL-E"
   region: "PAL-UK"
   roundModes:
     vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes blurriness.
+    roundSprite: 2 # Fixes blurriness.
+    skipDrawStart: 1 # Removes the ghosting effect when upscaling.
+    skipDrawEnd: 1 # Removes the ghosting effect when upscaling.
 SLES-55186:
   name: "Disney-Pixar WALL-E"
   region: "PAL-S-P"
   roundModes:
     vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes blurriness.
+    roundSprite: 2 # Fixes blurriness.
+    skipDrawStart: 1 # Removes the ghosting effect when upscaling.
+    skipDrawEnd: 1 # Removes the ghosting effect when upscaling.
 SLES-55187:
   name: "Disney-Pixar WALL-E"
   region: "PAL-F-G"
   roundModes:
     vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes blurriness.
+    roundSprite: 2 # Fixes blurriness.
+    skipDrawStart: 1 # Removes the ghosting effect when upscaling.
+    skipDrawEnd: 1 # Removes the ghosting effect when upscaling.
 SLES-55188:
   name: "Disney-Pixar WALL-E"
   region: "PAL-G"
   roundModes:
     vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes blurriness.
+    roundSprite: 2 # Fixes blurriness.
+    skipDrawStart: 1 # Removes the ghosting effect when upscaling.
+    skipDrawEnd: 1 # Removes the ghosting effect when upscaling.
 SLES-55189:
   name: "Nick Jr. Go Diego Go! Safari Rescue"
   region: "PAL-E-F"
@@ -21829,21 +21859,41 @@ SLES-55193:
   region: "PAL-R"
   roundModes:
     vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes blurriness.
+    roundSprite: 2 # Fixes blurriness.
+    skipDrawStart: 1 # Removes the ghosting effect when upscaling.
+    skipDrawEnd: 1 # Removes the ghosting effect when upscaling.
 SLES-55194:
   name: "Disney-Pixar WALL-E"
   region: "PAL-SC"
   roundModes:
     vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes blurriness.
+    roundSprite: 2 # Fixes blurriness.
+    skipDrawStart: 1 # Removes the ghosting effect when upscaling.
+    skipDrawEnd: 1 # Removes the ghosting effect when upscaling.
 SLES-55195:
   name: "Disney-Pixar WALL-E"
   region: "PAL-GR-I"
   roundModes:
     vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes blurriness.
+    roundSprite: 2 # Fixes blurriness.
+    skipDrawStart: 1 # Removes the ghosting effect when upscaling.
+    skipDrawEnd: 1 # Removes the ghosting effect when upscaling.
 SLES-55196:
   name: "Disney-Pixar WALL-E"
   region: "PAL-PL-CR"
   roundModes:
     vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes blurriness.
+    roundSprite: 2 # Fixes blurriness.
+    skipDrawStart: 1 # Removes the ghosting effect when upscaling.
+    skipDrawEnd: 1 # Removes the ghosting effect when upscaling.
 SLES-55197:
   name: "Dancing Stage SuperNOVA 2"
   region: "PAL-M5"
@@ -22745,11 +22795,21 @@ SLES-55622:
   compat: 5
   roundModes:
     vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
+  gsHWFixes:
+    halfPixelOffset: 2 # Help fixes ghosting.
+    roundSprite: 2 # Help fixes ghosting.
+    skipDrawStart: 1 # Removes the ghosting effect when upscaling.
+    skipDrawEnd: 1 # Removes the ghosting effect when upscaling.
 SLES-55623:
   name: "Disney-Pixar Toy Story 3"
   region: "PAL-R"
   roundModes:
     vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
+  gsHWFixes:
+    halfPixelOffset: 2 # Help fixes ghosting.
+    roundSprite: 2 # Help fixes ghosting.
+    skipDrawStart: 1 # Removes the ghosting effect when upscaling.
+    skipDrawEnd: 1 # Removes the ghosting effect when upscaling.
 SLES-55625:
   name: "Despicable Me - The Game"
   region: "PAL-M9"
@@ -48963,11 +49023,16 @@ SLUS-21735:
   gsHWFixes:
     roundSprite: 1 # Fixes misalignment of textures in the Pause Menu.
 SLUS-21736:
-  name: "Wall-E"
+  name: "Disney-Pixar WALL-E"
   region: "NTSC-U"
   compat: 5
   roundModes:
     vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes blurriness.
+    roundSprite: 2 # Fixes blurriness.
+    skipDrawStart: 1 # Removes the ghosting effect when upscaling.
+    skipDrawEnd: 1 # Removes the ghosting effect when upscaling.
 SLUS-21737:
   name: "Riding Star"
   region: "NTSC-U"
@@ -49816,10 +49881,15 @@ SLUS-21930:
   gsHWFixes:
     getSkipCount: "GSC_SakuraWarsSoLongMyLove"
 SLUS-21931:
-  name: "Toy Story 3"
+  name: "Disney-Pixar Toy Story 3"
   region: "NTSC-U"
   roundModes:
     vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
+  gsHWFixes:
+    halfPixelOffset: 2 # Help fixes ghosting.
+    roundSprite: 2 # Help fixes ghosting.
+    skipDrawStart: 1 # Removes the ghosting effect when upscaling.
+    skipDrawEnd: 1 # Removes the ghosting effect when upscaling.
 SLUS-21932:
   name: "NCAA Football 11"
   region: "NTSC-U"

--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -7010,10 +7010,8 @@ SCUS-90174:
   roundModes:
     vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
   gsHWFixes:
-    halfPixelOffset: 2 # Help fixes ghosting.
-    roundSprite: 2 # Help fixes ghosting.
-    skipDrawStart: 1 # Removes the ghosting effect when upscaling.
-    skipDrawEnd: 1 # Removes the ghosting effect when upscaling.
+    halfPixelOffset: 2 # Reduces the ghosting effect.
+    wildArmsHack: 1 # Reduces the ghosting effect.
 SCUS-94346:
   name: "SingStar Latino"
   region: "NTSC-U"
@@ -21796,50 +21794,40 @@ SLES-55184:
   roundModes:
     vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes blurriness.
-    roundSprite: 2 # Fixes blurriness.
-    skipDrawStart: 1 # Removes the ghosting effect when upscaling.
-    skipDrawEnd: 1 # Removes the ghosting effect when upscaling.
+    halfPixelOffset: 2 # Reduces the ghosting effect.
+    wildArmsHack: 1 # Reduces the ghosting effect.
 SLES-55185:
   name: "Disney-Pixar WALL-E"
   region: "PAL-UK"
   roundModes:
     vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes blurriness.
-    roundSprite: 2 # Fixes blurriness.
-    skipDrawStart: 1 # Removes the ghosting effect when upscaling.
-    skipDrawEnd: 1 # Removes the ghosting effect when upscaling.
+    halfPixelOffset: 2 # Reduces the ghosting effect.
+    wildArmsHack: 1 # Reduces the ghosting effect.
 SLES-55186:
   name: "Disney-Pixar WALL-E"
   region: "PAL-S-P"
   roundModes:
     vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes blurriness.
-    roundSprite: 2 # Fixes blurriness.
-    skipDrawStart: 1 # Removes the ghosting effect when upscaling.
-    skipDrawEnd: 1 # Removes the ghosting effect when upscaling.
+    halfPixelOffset: 2 # Reduces the ghosting effect.
+    wildArmsHack: 1 # Reduces the ghosting effect.
 SLES-55187:
   name: "Disney-Pixar WALL-E"
   region: "PAL-F-G"
   roundModes:
     vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes blurriness.
-    roundSprite: 2 # Fixes blurriness.
-    skipDrawStart: 1 # Removes the ghosting effect when upscaling.
-    skipDrawEnd: 1 # Removes the ghosting effect when upscaling.
+    halfPixelOffset: 2 # Reduces the ghosting effect.
+    wildArmsHack: 1 # Reduces the ghosting effect.
 SLES-55188:
   name: "Disney-Pixar WALL-E"
   region: "PAL-G"
   roundModes:
     vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes blurriness.
-    roundSprite: 2 # Fixes blurriness.
-    skipDrawStart: 1 # Removes the ghosting effect when upscaling.
-    skipDrawEnd: 1 # Removes the ghosting effect when upscaling.
+    halfPixelOffset: 2 # Reduces the ghosting effect.
+    wildArmsHack: 1 # Reduces the ghosting effect.
 SLES-55189:
   name: "Nick Jr. Go Diego Go! Safari Rescue"
   region: "PAL-E-F"
@@ -21860,40 +21848,32 @@ SLES-55193:
   roundModes:
     vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes blurriness.
-    roundSprite: 2 # Fixes blurriness.
-    skipDrawStart: 1 # Removes the ghosting effect when upscaling.
-    skipDrawEnd: 1 # Removes the ghosting effect when upscaling.
+    halfPixelOffset: 2 # Reduces the ghosting effect.
+    wildArmsHack: 1 # Reduces the ghosting effect.
 SLES-55194:
   name: "Disney-Pixar WALL-E"
   region: "PAL-SC"
   roundModes:
     vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes blurriness.
-    roundSprite: 2 # Fixes blurriness.
-    skipDrawStart: 1 # Removes the ghosting effect when upscaling.
-    skipDrawEnd: 1 # Removes the ghosting effect when upscaling.
+    halfPixelOffset: 2 # Reduces the ghosting effect.
+    wildArmsHack: 1 # Reduces the ghosting effect.
 SLES-55195:
   name: "Disney-Pixar WALL-E"
   region: "PAL-GR-I"
   roundModes:
     vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes blurriness.
-    roundSprite: 2 # Fixes blurriness.
-    skipDrawStart: 1 # Removes the ghosting effect when upscaling.
-    skipDrawEnd: 1 # Removes the ghosting effect when upscaling.
+    halfPixelOffset: 2 # Reduces the ghosting effect.
+    wildArmsHack: 1 # Reduces the ghosting effect.
 SLES-55196:
   name: "Disney-Pixar WALL-E"
   region: "PAL-PL-CR"
   roundModes:
     vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes blurriness.
-    roundSprite: 2 # Fixes blurriness.
-    skipDrawStart: 1 # Removes the ghosting effect when upscaling.
-    skipDrawEnd: 1 # Removes the ghosting effect when upscaling.
+    halfPixelOffset: 2 # Reduces the ghosting effect.
+    wildArmsHack: 1 # Reduces the ghosting effect.
 SLES-55197:
   name: "Dancing Stage SuperNOVA 2"
   region: "PAL-M5"
@@ -22796,20 +22776,16 @@ SLES-55622:
   roundModes:
     vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
   gsHWFixes:
-    halfPixelOffset: 2 # Help fixes ghosting.
-    roundSprite: 2 # Help fixes ghosting.
-    skipDrawStart: 1 # Removes the ghosting effect when upscaling.
-    skipDrawEnd: 1 # Removes the ghosting effect when upscaling.
+    halfPixelOffset: 2 # Reduces the ghosting effect.
+    wildArmsHack: 1 # Reduces the ghosting effect.
 SLES-55623:
   name: "Disney-Pixar Toy Story 3"
   region: "PAL-R"
   roundModes:
     vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
   gsHWFixes:
-    halfPixelOffset: 2 # Help fixes ghosting.
-    roundSprite: 2 # Help fixes ghosting.
-    skipDrawStart: 1 # Removes the ghosting effect when upscaling.
-    skipDrawEnd: 1 # Removes the ghosting effect when upscaling.
+    halfPixelOffset: 2 # Reduces the ghosting effect.
+    wildArmsHack: 1 # Reduces the ghosting effect.
 SLES-55625:
   name: "Despicable Me - The Game"
   region: "PAL-M9"
@@ -49029,10 +49005,8 @@ SLUS-21736:
   roundModes:
     vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes blurriness.
-    roundSprite: 2 # Fixes blurriness.
-    skipDrawStart: 1 # Removes the ghosting effect when upscaling.
-    skipDrawEnd: 1 # Removes the ghosting effect when upscaling.
+    halfPixelOffset: 2 # Reduces the ghosting effect.
+    wildArmsHack: 1 # Reduces the ghosting effect.
 SLUS-21737:
   name: "Riding Star"
   region: "NTSC-U"
@@ -49886,10 +49860,8 @@ SLUS-21931:
   roundModes:
     vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
   gsHWFixes:
-    halfPixelOffset: 2 # Help fixes ghosting.
-    roundSprite: 2 # Help fixes ghosting.
-    skipDrawStart: 1 # Removes the ghosting effect when upscaling.
-    skipDrawEnd: 1 # Removes the ghosting effect when upscaling.
+    halfPixelOffset: 2 # Reduces the ghosting effect.
+    wildArmsHack: 1 # Reduces the ghosting effect.
 SLUS-21932:
   name: "NCAA Football 11"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
This PR aim to fix ghosting effects on the Toy Story 3 and WALL-E game. it is an upscaling issue and the more you increase the multiplier, the more apparent the issue were, GS Dump are also provided. This also applies the fixes to other region of the game as well as adjusting the name for the NTSC-U region to match other region name for consistency.

### Rationale behind Changes
WALL-E suffers from ghosting effects In-Game, here is comparison:

Before:
![Wall-E_SLUS-21736_20230204162204](https://user-images.githubusercontent.com/14798312/216759646-5b33dd96-cc30-4b73-9299-a63dd5cad357.png)

After:
![Wall-E_SLUS-21736_20230204162304](https://user-images.githubusercontent.com/14798312/216759669-adfc56bc-24a8-4f55-be44-3f5e47009399.png)

GS Dump for WALL-E:
[Wall-E_SLUS-21736_20230204162204.zip](https://github.com/PCSX2/pcsx2/files/10608306/Wall-E_SLUS-21736_20230204162204.zip)

Toy Story 3 also seems to suffer from the same problem although to a lesser extent, another comparison:

Before:
![Toy Story 3_SLUS-21931_20230204162024](https://user-images.githubusercontent.com/14798312/216759851-cddebc24-ef25-496c-85a4-402d754e3eaf.png)

After:
![Toy Story 3_SLUS-21931_20230204162040](https://user-images.githubusercontent.com/14798312/216759870-97f7ba07-2a3c-4af8-8afe-53db6d2c5d05.png)

GS Dump for Toy Story 3:
[Toy Story 3_SLUS-21931_20230204162024.zip](https://github.com/PCSX2/pcsx2/files/10608315/Toy.Story.3_SLUS-21931_20230204162024.zip)


### Suggested Testing Steps
Fire up each game, go straight to the story mode and make sure there's no more ghosting effect.
And make sure CI gang is vibin :P

I have also tested it myself:
![Screenshot_20230204_163215](https://user-images.githubusercontent.com/14798312/216760074-6a28ba8e-7ad3-4892-a284-5af38c82a3ee.png)
