### PR TITLE
Qt: Defer application quit on window close

### DIFF
--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -209,7 +209,7 @@ void VMManager::SetState(VMState state)
 		else
 			Host::OnVMResumed();
 	}
-	else if (state == VMState::Stopping)
+	else if (state == VMState::Stopping && old_state == VMState::Running)
 	{
 		// If stopping, break execution as soon as possible.
 		Cpu->ExitExecution();


### PR DESCRIPTION
### Description of Changes

Fixes a crash on shutdown on Macs, the Metal renderer tries to clear the layer on a window which has been destroyed already.

Also fixes crash when shutting down while paused in the interpreter.

### Rationale behind Changes

Crash bad.

### Suggested Testing Steps

Make sure confirm shutdown is enabled, disable recompiler, start game (or load state), exit pcsx2 by closing the window, confirm exit. should no crashie

