### PR TITLE
PAD: Fix pressure getting set to 1 after modifier

### DIFF
--- a/pcsx2/PAD/Host/KeyStatus.cpp
+++ b/pcsx2/PAD/Host/KeyStatus.cpp
@@ -170,7 +170,8 @@ void KeyStatus::Set(u32 pad, u32 index, float value)
 					continue;
 
 				// We add 0.5 here so that the round trip between 255->127->255 when applying works as expected.
-				m_button_pressure[pad][i] = static_cast<u8>(std::clamp((static_cast<float>(m_button_pressure[pad][i]) + 0.5f) * adjust_pmod, 0.0f, 255.0f));
+				const float add = (m_button_pressure[pad][i] != 0) ? 0.5f : 0.0f;
+				m_button_pressure[pad][i] = static_cast<u8>(std::clamp((static_cast<float>(m_button_pressure[pad][i]) + add) * adjust_pmod, 0.0f, 255.0f));
 			}
 		}
 	}


### PR DESCRIPTION
### Description of Changes

Whoops.

### Rationale behind Changes

Having all button pressure go to 1 when you release the pressure modifier is not ideal.

### Suggested Testing Steps

Enable input OSD, press and release pressure modifier. No buttons should be pressed. Confirm modifier still works by pressing with any face button.
