### PR TITLE
GameDB: Add Game Fix for Scandal

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -5553,6 +5553,8 @@ SCPS-15001:
   name: "Scandal"
   region: "NTSC-J"
   compat: 5
+  gameFixes:
+    - InstantDMAHack # Fixes graphical corruption.
 SCPS-15002:
   name: "TV DJ"
   region: "NTSC-J"


### PR DESCRIPTION
### Description of Changes
Adds Instant DMA hack to Scandal to fix graphical problems.

### Rationale behind Changes
Potentially some cache shenanigans going on meaning DMA's get corrupted, this gets around it.

### Suggested Testing Steps
Run Scandal, make sure everything is displayed as it should be.

Fixes #8053