### PR TITLE
GameDB: Add Disable InstantVU to MGS 3 Subsistence

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -23058,6 +23058,8 @@ SLES-82042:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
+  speedHacks:
+    InstantVU1SpeedHack: 0 # Fixes missing letters in text such as E.
 SLES-82043:
   name: "Metal Gear Solid 3 - Subsistence [Disc 2 of 3]"
   region: "PAL-E-F"
@@ -23065,6 +23067,8 @@ SLES-82043:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
+  speedHacks:
+    InstantVU1SpeedHack: 0 # Fixes missing letters in text such as E.
   memcardFilters:
     - "SLES-82042"
 SLES-82044:
@@ -23074,6 +23078,8 @@ SLES-82044:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
+  speedHacks:
+    InstantVU1SpeedHack: 0 # Fixes missing letters in text such as E.
 SLES-82045:
   name: "Metal Gear Solid 3 - Subsistence [Disc 2 of 3]"
   region: "PAL-I"
@@ -23081,6 +23087,8 @@ SLES-82045:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
+  speedHacks:
+    InstantVU1SpeedHack: 0 # Fixes missing letters in text such as E.
   memcardFilters:
     - "SLES-82044"
 SLES-82046:
@@ -23090,6 +23098,8 @@ SLES-82046:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
+  speedHacks:
+    InstantVU1SpeedHack: 0 # Fixes missing letters in text such as E.
 SLES-82047:
   name: "Metal Gear Solid 3 - Subsistence [Disc 2 of 3]"
   region: "PAL-G"
@@ -23097,6 +23107,8 @@ SLES-82047:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
+  speedHacks:
+    InstantVU1SpeedHack: 0 # Fixes missing letters in text such as E.
   memcardFilters:
     - "SLES-82046"
 SLES-82048:
@@ -23106,6 +23118,8 @@ SLES-82048:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
+  speedHacks:
+    InstantVU1SpeedHack: 0 # Fixes missing letters in text such as E.
 SLES-82049:
   name: "Metal Gear Solid 3 - Subsistence [Disc 2 of 3]"
   region: "PAL-S"
@@ -23113,6 +23127,8 @@ SLES-82049:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
+  speedHacks:
+    InstantVU1SpeedHack: 0 # Fixes missing letters in text such as E.
   memcardFilters:
     - "SLES-82048"
 SLES-82050:
@@ -23122,6 +23138,8 @@ SLES-82050:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
+  speedHacks:
+    InstantVU1SpeedHack: 0 # Fixes missing letters in text such as E.
   memcardFilters:
     - "SLES-82042"
 SLES-82051:
@@ -23131,6 +23149,8 @@ SLES-82051:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
+  speedHacks:
+    InstantVU1SpeedHack: 0 # Fixes missing letters in text such as E.
   memcardFilters:
     - "SLES-82044"
 SLES-82052:
@@ -23140,6 +23160,8 @@ SLES-82052:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
+  speedHacks:
+    InstantVU1SpeedHack: 0 # Fixes missing letters in text such as E.
   memcardFilters:
     - "SLES-82046"
 SLES-82053:
@@ -23149,6 +23171,8 @@ SLES-82053:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
+  speedHacks:
+    InstantVU1SpeedHack: 0 # Fixes missing letters in text such as E.
   memcardFilters:
     - "SLES-82048"
 SLKA-15002:
@@ -24222,21 +24246,37 @@ SLKA-25352:
   name: "Full Metal Alchemist - Dream Carnival"
   region: "NTSC-K"
 SLKA-25353:
-  name: "Metal Gear Solid 3 - Subsistence [Limited Edition] [Disc 1 of 2]"
+  name: "Metal Gear Solid 3 - Subsistence [Limited Edition] [Disc 1 of 3]"
   region: "NTSC-K"
   compat: 5
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
+  speedHacks:
+    InstantVU1SpeedHack: 0 # Fixes missing letters in text such as E.
 SLKA-25354:
-  name: "Metal Gear Solid 3 - Subsistence [Limited Edition] [Disc 2 of 2]"
+  name: "Metal Gear Solid 3 - Subsistence [Limited Edition] [Disc 2 of 3]"
   region: "NTSC-K"
   compat: 5
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
+  speedHacks:
+    InstantVU1SpeedHack: 0 # Fixes missing letters in text such as E.
+  memcardFilters:
+    - "SLKA-25353"
+SLKA-25355:
+  name: "Metal Gear Solid 3 - Subsistence [Limited Edition] [Disc 3 of 3]"
+  region: "NTSC-K"
+  compat: 5
+  gameFixes:
+    - BlitInternalFPSHack # Fixes internal FPS detection.
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes blurriness.
+  speedHacks:
+    InstantVU1SpeedHack: 0 # Fixes missing letters in text such as E.
   memcardFilters:
     - "SLKA-25353"
 SLKA-25359:
@@ -31327,12 +31367,32 @@ SLPM-66116:
   name: "NBA Live 2005 [EA Best Hits]"
   region: "NTSC-J"
 SLPM-66117:
-  name: "Metal Gear Solid 3 - Subsistence [with Headset]"
+  name: "Metal Gear Solid 3 - Subsistence [with Headset] [Disc 1 of 3]"
   region: "NTSC-J"
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
+  speedHacks:
+    InstantVU1SpeedHack: 0 # Fixes missing letters in text such as E.
+SLPM-66118:
+  name: "Metal Gear Solid 3 - Subsistence [with Headset] [Disc 2 of 3]"
+  region: "NTSC-J"
+  gameFixes:
+    - BlitInternalFPSHack # Fixes internal FPS detection.
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes blurriness.
+  speedHacks:
+    InstantVU1SpeedHack: 0 # Fixes missing letters in text such as E.
+SLPM-66119:
+  name: "Metal Gear Solid 3 - Subsistence [with Headset] [Disc 3 of 3]"
+  region: "NTSC-J"
+  gameFixes:
+    - BlitInternalFPSHack # Fixes internal FPS detection.
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes blurriness.
+  speedHacks:
+    InstantVU1SpeedHack: 0 # Fixes missing letters in text such as E.
 SLPM-66122:
   name: "Kingdom Hearts [Ultimate Hits]"
   region: "NTSC-J"
@@ -31718,6 +31778,8 @@ SLPM-66220:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
+  speedHacks:
+    InstantVU1SpeedHack: 0 # Fixes missing letters in text such as E.
   memcardFilters:
     - "SLPM-66117"
 SLPM-66221:
@@ -31727,6 +31789,8 @@ SLPM-66221:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
+  speedHacks:
+    InstantVU1SpeedHack: 0 # Fixes missing letters in text such as E.
   memcardFilters:
     - "SLPM-66117"
 SLPM-66222:
@@ -31736,6 +31800,8 @@ SLPM-66222:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
+  speedHacks:
+    InstantVU1SpeedHack: 0 # Fixes missing letters in text such as E.
   memcardFilters:
     - "SLPM-66117"
 SLPM-66223:
@@ -31745,6 +31811,8 @@ SLPM-66223:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
+  speedHacks:
+    InstantVU1SpeedHack: 0 # Fixes missing letters in text such as E.
   memcardFilters:
     - "SLPM-66117"
 SLPM-66224:
@@ -31754,6 +31822,8 @@ SLPM-66224:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
+  speedHacks:
+    InstantVU1SpeedHack: 0 # Fixes missing letters in text such as E.
   memcardFilters:
     - "SLPM-66117"
 SLPM-66225:
@@ -36762,6 +36832,12 @@ SLPS-25043:
 SLPS-25044:
   name: "Evergrace 2"
   region: "NTSC-J"
+  gsHWFixes:
+    preloadFrameData: 1 # Fixes textures and flickering such as the wall and sky.
+    roundSprite: 2 # Fixes black lines in character sprites.
+    textureInsideRT: 1 # Fixes missing effects.
+    mipmap: 2 # Fixes shimmering noisy textures
+    trilinearFiltering: 1 # Fixes shimmering noisy textures
 SLPS-25045:
   name: "Lilie no Atelier - Salburg no Renkinjutsushi 3"
   region: "NTSC-J"
@@ -41991,7 +42067,10 @@ SLUS-20343:
   compat: 5
   gsHWFixes:
     preloadFrameData: 1 # Fixes textures and flickering such as the wall and sky.
-    cpuFramebufferConversion: 1 # Fixes character shadows.
+    roundSprite: 2 # Fixes black lines in character sprites.
+    textureInsideRT: 1 # Fixes missing effects.
+    mipmap: 2 # Fixes shimmering noisy textures
+    trilinearFiltering: 1 # Fixes shimmering noisy textures
 SLUS-20344:
   name: "Rez"
   region: "NTSC-U"
@@ -46493,6 +46572,8 @@ SLUS-21243:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
+  speedHacks:
+    InstantVU1SpeedHack: 0 # Fixes missing letters in text such as E.
   memcardFilters:
     - "SLUS-21359"
 SLUS-21244:
@@ -47184,6 +47265,8 @@ SLUS-21359:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
+  speedHacks:
+    InstantVU1SpeedHack: 0 # Fixes missing letters in text such as E.
 SLUS-21360:
   name: "Metal Gear Solid 3 - Subsistence [Disc 3 of 3]"
   region: "NTSC-U"
@@ -47191,6 +47274,8 @@ SLUS-21360:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
+  speedHacks:
+    InstantVU1SpeedHack: 0 # Fixes missing letters in text such as E.
   memcardFilters:
     - "SLUS-21359"
 SLUS-21361:


### PR DESCRIPTION
### Description of Changes
Disables InstantVU1 to fix missing letters in text such as the letter E also adds more fixes and missing fixes for Forever Kingdom / Evergrace 2.

### Rationale behind Changes
Missing l tt rs ar bad,

### Suggested Testing Steps
Make sure CI is happy.
