### PR TITLE
Qt: Open fullscreen window on same display as main

### DIFF
--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -2258,7 +2258,12 @@ void MainWindow::createDisplayWidget(bool fullscreen, bool render_to_main, bool 
 		// Don't risk doing this on Wayland, it really doesn't like window state changes,
 		// and positioning has no effect anyway.
 		if (!s_use_central_widget)
-			restoreDisplayWindowGeometryFromConfig();
+		{
+			if (isVisible() && g_emu_thread->shouldRenderToMain())
+				container->move(pos());
+			else
+				restoreDisplayWindowGeometryFromConfig();
+		}
 
 		if (!is_exclusive_fullscreen)
 			container->showFullScreen();


### PR DESCRIPTION
### Description of Changes

Currently, it'll open whereever the separate window was last positioned, or some default OS-specified location, which is a bit confusing in multiple monitor setups.

So, prefer the monitor where the main PCSX2 window is.

Sorry wayland users, your protocol or compositors are fundamentally broken and every compositor I've tried blatantly ignores window positioning requests.

### Rationale behind Changes

Having PCSX2's fullscreen window open on a different display isn't ideal.

Closes #8055.

### Suggested Testing Steps

Test fullscreen with PCSX2 on different monitors.
