### PR TITLE
GSDumpRunner: Small tweaks for speed + ability to do manual hardware fixes

### DIFF
--- a/pcsx2-gsrunner/Main.cpp
+++ b/pcsx2-gsrunner/Main.cpp
@@ -522,6 +522,27 @@ static bool ParseCommandLineArgs(int argc, char* argv[], VMBootParameters& param
 				s_settings_interface.SetIntValue("EmuCore/GS", "Renderer", static_cast<int>(type));
 				continue;
 			}
+			else if (CHECK_ARG_PARAM("-renderhacks"))
+			{
+				std::string str(argv[++i]);
+
+				s_settings_interface.SetBoolValue("EmuCore/GS", "UserHacks", true);
+
+				if(str.find("af") != std::string::npos)
+					s_settings_interface.SetBoolValue("EmuCore/GS", "UserHacks_AutoFlush", true);
+				if (str.find("cpufb") != std::string::npos)
+					s_settings_interface.SetBoolValue("EmuCore/GS", "UserHacks_CPU_FB_Conversion ", true);
+				if (str.find("dds") != std::string::npos)
+					s_settings_interface.SetBoolValue("EmuCore/GS", "UserHacks_DisableDepthSupport ", true);
+				if (str.find("dpi") != std::string::npos)
+					s_settings_interface.SetBoolValue("EmuCore/GS", "UserHacks_DisablePartialInvalidation ", true);
+				if (str.find("dsf") != std::string::npos)
+					s_settings_interface.SetBoolValue("EmuCore/GS", "UserHacks_DisableSafeFeatures ", true);
+				if (str.find("tinrt") != std::string::npos)
+					s_settings_interface.SetBoolValue("EmuCore/GS", "UserHacks_TextureInsideRt ", true);
+
+				continue;
+			}
 			else if (CHECK_ARG_PARAM("-logfile"))
 			{
 				const char* logfile = argv[++i];

--- a/pcsx2-gsrunner/Main.cpp
+++ b/pcsx2-gsrunner/Main.cpp
@@ -79,6 +79,7 @@ static std::optional<bool> s_use_window;
 
 // Owned by the GS thread.
 static u32 s_dump_frame_number = 0;
+static u32 s_loop_number = s_loop_count;
 
 bool GSRunner::InitializeConfig()
 {
@@ -273,13 +274,15 @@ void Host::ReleaseHostDisplay(bool clear_state)
 
 bool Host::BeginPresentFrame(bool frame_skip)
 {
-	// when we wrap around, don't race other files
-	GSJoinSnapshotThreads();
+	if (s_loop_number == 0)
+	{
+		// when we wrap around, don't race other files
+		GSJoinSnapshotThreads();
 
-	// queue dumping of this frame
-	std::string dump_path(fmt::format("{}_frame{}.png", s_output_prefix, s_dump_frame_number));
-	GSQueueSnapshot(dump_path);
-
+		// queue dumping of this frame
+		std::string dump_path(fmt::format("{}_frame{}.png", s_output_prefix, s_dump_frame_number));
+		GSQueueSnapshot(dump_path);
+	}
 	if (g_host_display->BeginPresent(frame_skip))
 		return true;
 
@@ -627,6 +630,7 @@ int main(int argc, char* argv[])
 
 	// apply new settings (e.g. pick up renderer change)
 	VMManager::ApplySettings();
+	GSDumpReplayer::SetIsDumpRunner(true);
 
 	if (VMManager::Initialize(params))
 	{
@@ -651,6 +655,7 @@ void Host::CPUThreadVSync()
 {
 	// update GS thread copy of frame number
 	GetMTGS().RunOnGSThread([frame_number = GSDumpReplayer::GetFrameNumber()]() { s_dump_frame_number = frame_number; });
+	GetMTGS().RunOnGSThread([loop_number = GSDumpReplayer::GetLoopCount()]() { s_loop_number = loop_number; });
 
 	// process any window messages (but we shouldn't really have any)
 	GSRunner::PumpPlatformMessages();

--- a/pcsx2/GSDumpReplayer.cpp
+++ b/pcsx2/GSDumpReplayer.cpp
@@ -58,6 +58,7 @@ static bool s_dump_running = false;
 static bool s_needs_state_loaded = false;
 static u64 s_frame_ticks = 0;
 static u64 s_next_frame_time = 0;
+static bool s_is_dump_runner = false;
 
 R5900cpu GSDumpReplayerCpu = {
 	GSDumpReplayerCpuReserve,
@@ -77,9 +78,24 @@ bool GSDumpReplayer::IsReplayingDump()
 	return static_cast<bool>(s_dump_file);
 }
 
+bool GSDumpReplayer::IsRunner()
+{
+	return s_is_dump_runner;
+}
+
+void GSDumpReplayer::SetIsDumpRunner(bool is_runner)
+{
+	s_is_dump_runner = is_runner;
+}
+
 void GSDumpReplayer::SetLoopCount(s32 loop_count)
 {
 	s_dump_loop_count = loop_count - 1;
+}
+
+int GSDumpReplayer::GetLoopCount()
+{
+	return s_dump_loop_count;
 }
 
 bool GSDumpReplayer::Initialize(const char* filename)

--- a/pcsx2/GSDumpReplayer.h
+++ b/pcsx2/GSDumpReplayer.h
@@ -25,6 +25,9 @@ bool IsReplayingDump();
 
 /// If set, playback will repeat once it reaches the last frame.
 void SetLoopCount(s32 loop_count = 0);
+int GetLoopCount();
+bool IsRunner();
+void SetIsDumpRunner(bool is_runner);
 
 bool Initialize(const char* filename);
 void Reset();


### PR DESCRIPTION
### Description of Changes
Reduced console spam to stop the console lagging out the system, plus made it so only the last loop actually saved any pictures.  Also added the ability to use hardware hacks by using the `-renderhacks` parameter followed by the following

af = AutoFlush
cpufb = CPU Framebuffer Conversion
dds = Disable Depth Support
dpi = Disable Partial Invalidation
dsf = Disable Safe Features
tinrt = Texture in Render Target

You can string them together like `afcpufbddsdpidsftinrt` and it will split them out.

### Rationale behind Changes
Console spam was annoying, normal config doesn't load so it's nice to be able to set these manually for testing.

### Suggested Testing Steps
Already tested and working fine.
