### PR TITLE
GameDB: Add missing quatation marks in memcardFilters

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -38371,13 +38371,13 @@ SLPS-25462:
   gsHWFixes:
     roundSprite: 2 # Fixes HUD artifacts.
   memcardFilters:
-    - SLPS-25338
-    - SLPS-25339
-    - SLPS-73202
-    - SLPS-73203
-    - SLPS-25408
-    - SLPS-25462
-    - SLPS-73247
+    - "SLPS-25338"
+    - "SLPS-25339"
+    - "SLPS-73202"
+    - "SLPS-73203"
+    - "SLPS-25408"
+    - "SLPS-25462"
+    - "SLPS-73247"
 SLPS-25463:
   name: "My Home o Tsukurou 2! Takumi"
   region: "NTSC-J"
@@ -40541,13 +40541,13 @@ SLPS-73247:
   gsHWFixes:
     roundSprite: 2 # Fixes HUD artifacts.
   memcardFilters:
-    - SLPS-25338
-    - SLPS-25339
-    - SLPS-73202
-    - SLPS-73203
-    - SLPS-25408
-    - SLPS-25462
-    - SLPS-73247
+    - "SLPS-25338"
+    - "SLPS-25339"
+    - "SLPS-73202"
+    - "SLPS-73203"
+    - "SLPS-25408"
+    - "SLPS-25462"
+    - "SLPS-73247"
 SLPS-73248:
   name: "Kagero 2 - Dark Illusion [PlayStation 2 The Best]"
   region: "NTSC-J"


### PR DESCRIPTION
### Description of Changes
Added missing `"` (quatation mark) for `memcardFilters:`.
- Armored Core Last Raven is only the game missing `"`.

### Rationale behind Changes
It could solve something but I'm not sure.
- My saves of Armored Core Nexus are already importable before this change...

### Suggested Testing Steps
Make sure if some saves can be imported to Armored Core Last Raven.
