### PR TITLE
GameDB: Add Paltex to Gacharoku

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -5522,6 +5522,8 @@ SCPS-11025:
 SCPS-11026:
   name: "Gacharoku"
   region: "NTSC-J"
+  gsHWFixes:
+    gpuPaletteConversion: 2 # Fixes hash cache exploding.
 SCPS-11027:
   name: "Mawaza"
   region: "NTSC-J"


### PR DESCRIPTION
### Description of Changes
Stops the hash cache from being silly and exploding.

### Rationale behind Changes
Stupid game using 600MB of VRAM is stupid.

### Suggested Testing Steps
Make sure CI is happy.
