### PR TITLE
GS/DX11: Disable multisampling in rasterizer state

### DIFF
--- a/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
@@ -305,7 +305,7 @@ bool GSDevice11::Create()
 	rd.SlopeScaledDepthBias = 0;
 	rd.DepthClipEnable = false; // ???
 	rd.ScissorEnable = true;
-	rd.MultisampleEnable = true;
+	rd.MultisampleEnable = false;
 	rd.AntialiasedLineEnable = false;
 
 	m_dev->CreateRasterizerState(&rd, m_rs.put());


### PR DESCRIPTION
### Description of Changes

Causes off-by-one rasterization differences with lines.

### Rationale behind Changes

Fixes xenosaga shadows gs dump.

### Suggested Testing Steps

It was clearly wrong before.

