### PR TITLE
Mcd-Folder: Prevent crash trying to delete non-existent node.

### DIFF
--- a/pcsx2/MemoryCardFolder.cpp
+++ b/pcsx2/MemoryCardFolder.cpp
@@ -1919,10 +1919,13 @@ void FolderMemoryCard::DeleteFromIndex(const std::string& filePath, const std::s
 	if (yaml.has_value() && !yaml.value().empty())
 	{
 		ryml::NodeRef index = yaml.value().rootref();
-		index.remove_child(c4::csubstr(entry.data(), entry.length()));
-
-		// Write out the changes
-		SaveYAMLToFile(indexName.c_str(), index);
+		
+		if (index.has_child(c4::csubstr(entry.data(), entry.length())))
+		{
+			index.remove_child(c4::csubstr(entry.data(), entry.length()));
+			// Write out the changes
+			SaveYAMLToFile(indexName.c_str(), index);
+		}
 	}
 }
 


### PR DESCRIPTION
### Description of Changes
Prevents crashing in YAML code by trying to delete a node entry which doesn't exist.

### Rationale behind Changes
This was causing Ecco the Dolphin to crash during saving. This is really a symptom of a bigger problem with folder memcards but it seems to recover well enough to at least save, from what I can tell.  It beats CTDing anyway.

### Suggested Testing Steps
Load Ecco the Dolphin with a folder memory card (don't forget to make a player), kill yourself and let the continue timer run out, it should save and continue, instead of crashing.
