### PR TITLE
GS: Handle index swap case for auto flush

### DIFF
--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -3035,6 +3035,7 @@ __forceinline void GSState::CLUTAutoFlush()
 	}
 }
 
+template<bool index_swap>
 __forceinline void GSState::HandleAutoFlush()
 {
 	// Kind of a cheat, making the assumption that 2 consecutive fan/strip triangles won't overlap each other (*should* be safe)
@@ -3126,7 +3127,7 @@ __forceinline void GSState::HandleAutoFlush()
 		}
 
 		// Get the last texture position from the last draw.
-		const GSVertex* v = &m_vertex.buff[m_index.buff[m_index.tail - 1]];
+		const GSVertex* v = &m_vertex.buff[m_index.buff[m_index.tail - (index_swap ? n : 1)]];
 
 		if (PRIM->FST)
 		{
@@ -3260,7 +3261,7 @@ __forceinline void GSState::VertexKick(u32 skip)
 
 	if (auto_flush && skip == 0 && m_index.tail > 0 && ((m_vertex.tail + 1) - m_vertex.head) >= n)
 	{
-		HandleAutoFlush();
+		HandleAutoFlush<index_swap>();
 	}
 
 	size_t head = m_vertex.head;

--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -155,7 +155,7 @@ void GSState::Reset(bool hardware_reset)
 
 	m_env.UpdateDIMX();
 
-	for (size_t i = 0; i < 2; i++)
+	for (u32 i = 0; i < 2; i++)
 	{
 		m_env.CTXT[i].UpdateScissor();
 
@@ -683,14 +683,14 @@ void GSState::DumpVertices(const std::string& filename)
 
 	file << std::endl << std::endl;
 
-	const size_t count = m_index.tail;
+	const u32 count = m_index.tail;
 	GSVertex* buffer = &m_vertex.buff[0];
 
 	const char* DEL = ", ";
 
 	file << "VERTEX COORDS (XYZ)" << std::endl;
 	file << std::fixed << std::setprecision(4);
-	for (size_t i = 0; i < count; ++i)
+	for (u32 i = 0; i < count; ++i)
 	{
 		file << "\t" << "v" << i << ": ";
 		GSVertex v = buffer[m_index.buff[i]];
@@ -708,7 +708,7 @@ void GSState::DumpVertices(const std::string& filename)
 
 	file << "VERTEX COLOR (RGBA)" << std::endl;
 	file << std::fixed << std::setprecision(6);
-	for (size_t i = 0; i < count; ++i)
+	for (u32 i = 0; i < count; ++i)
 	{
 		file << "\t" << "v" << i << ": ";
 		GSVertex v = buffer[m_index.buff[i]];
@@ -726,7 +726,7 @@ void GSState::DumpVertices(const std::string& filename)
 	const std::string qualifier = use_uv ? "UV" : "STQ";
 
 	file << "TEXTURE COORDS (" << qualifier << ")" << std::endl;;
-	for (size_t i = 0; i < count; ++i)
+	for (u32 i = 0; i < count; ++i)
 	{
 		file << "\t" << "v" << i << ": ";
 		const GSVertex v = buffer[m_index.buff[i]];
@@ -1853,10 +1853,10 @@ void GSState::FlushPrim()
 		GSVertex buff[2];
 		s_n++;
 
-		const size_t head = m_vertex.head;
-		const size_t tail = m_vertex.tail;
-		const size_t next = m_vertex.next;
-		size_t unused = 0;
+		const u32 head = m_vertex.head;
+		const u32 tail = m_vertex.tail;
+		const u32 next = m_vertex.next;
+		u32 unused = 0;
 
 		if (tail > head)
 		{
@@ -1873,7 +1873,7 @@ void GSState::FlushPrim()
 					break;
 				case GS_TRIANGLELIST:
 				case GS_TRIANGLESTRIP:
-					unused = std::min<size_t>(tail - head, 2);
+					unused = std::min<u32>(tail - head, 2);
 					memcpy(buff, &m_vertex.buff[tail - unused], sizeof(GSVertex) * 2);
 					break;
 				case GS_TRIANGLEFAN:
@@ -1941,7 +1941,7 @@ void GSState::FlushPrim()
 			// Jak 3 shadows get spikey (with autoflush) if you don't.
 			if (PRIM->PRIM == GS_TRIANGLEFAN)
 			{
-				for (size_t i = 0; i < unused; i++)
+				for (u32 i = 0; i < unused; i++)
 				{
 					GSVector4i* RESTRICT vert_ptr = (GSVector4i*)&m_vertex.buff[i];
 					GSVector4i v = vert_ptr[1];
@@ -2760,7 +2760,7 @@ int GSState::Defrost(const freezeData* fd)
 
 	m_env.UpdateDIMX();
 
-	for (size_t i = 0; i < 2; i++)
+	for (u32 i = 0; i < 2; i++)
 	{
 		m_env.CTXT[i].UpdateScissor();
 
@@ -2829,7 +2829,7 @@ void GSState::UpdateVertexKick()
 
 void GSState::GrowVertexBuffer()
 {
-	const size_t maxcount = std::max<size_t>(m_vertex.maxcount * 3 / 2, 10000);
+	const u32 maxcount = std::max<u32>(m_vertex.maxcount * 3 / 2, 10000);
 
 	GSVertex* vertex = (GSVertex*)_aligned_malloc(sizeof(GSVertex) * maxcount, 32);
 	// Worst case index list is a list of points with vs expansion, 6 indices per point
@@ -2837,8 +2837,8 @@ void GSState::GrowVertexBuffer()
 
 	if (vertex == NULL || index == NULL)
 	{
-		const size_t vert_byte_count = sizeof(GSVertex) * maxcount;
-		const size_t idx_byte_count = sizeof(u32) * maxcount * 3;
+		const u32 vert_byte_count = sizeof(GSVertex) * maxcount;
+		const u32 idx_byte_count = sizeof(u32) * maxcount * 3;
 
 		Console.Error("GS: failed to allocate %zu bytes for verticles and %zu for indices.",
 			vert_byte_count, idx_byte_count);
@@ -2876,12 +2876,12 @@ GSState::PRIM_OVERLAP GSState::PrimitiveOverlap()
 		return PRIM_OVERLAP_UNKNOW; // maybe, maybe not
 
 	// Check intersection of sprite primitive only
-	const size_t count = m_vertex.next;
+	const u32 count = m_vertex.next;
 	PRIM_OVERLAP overlap = PRIM_OVERLAP_NO;
 	const GSVertex* v = m_vertex.buff;
 
 	m_drawlist.clear();
-	size_t i = 0;
+	u32 i = 0;
 	while (i < count)
 	{
 		// In order to speed up comparison a bounding-box is accumulated. It removes a
@@ -2895,7 +2895,7 @@ GSState::PRIM_OVERLAP GSState::PrimitiveOverlap()
 		GSVector4i all = GSVector4i(v[i].m[1]).upl16(GSVector4i(v[i + 1].m[1])).upl16().xzyw();
 		all = all.xyxy().blend(all.zwzw(), all > all.zwxy());
 
-		size_t j = i + 2;
+		u32 j = i + 2;
 		while (j < count)
 		{
 			GSVector4i sprite = GSVector4i(v[j].m[1]).upl16(GSVector4i(v[j + 1].m[1])).upl16().xzyw();
@@ -2933,12 +2933,12 @@ GSState::PRIM_OVERLAP GSState::PrimitiveOverlap()
 	// Some safe-guard will be added in the outer-loop to avoid corruption with a limited perf impact
 	if (v[1].XYZ.Y < v[0].XYZ.Y) {
 		// First vertex is Top-Left
-		for (size_t i = 0; i < count; i += 2) {
+		for (u32 i = 0; i < count; i += 2) {
 			if (v[i + 1].XYZ.Y > v[i].XYZ.Y) {
 				return PRIM_OVERLAP_UNKNOW;
 			}
 			GSVector4i vi(v[i].XYZ.X, v[i + 1].XYZ.Y, v[i + 1].XYZ.X, v[i].XYZ.Y);
-			for (size_t j = i + 2; j < count; j += 2) {
+			for (u32 j = i + 2; j < count; j += 2) {
 				GSVector4i vj(v[j].XYZ.X, v[j + 1].XYZ.Y, v[j + 1].XYZ.X, v[j].XYZ.Y);
 				GSVector4i inter = vi.rintersect(vj);
 				if (!inter.rempty()) {
@@ -2949,12 +2949,12 @@ GSState::PRIM_OVERLAP GSState::PrimitiveOverlap()
 	}
 	else {
 		// First vertex is Bottom-Left
-		for (size_t i = 0; i < count; i += 2) {
+		for (u32 i = 0; i < count; i += 2) {
 			if (v[i + 1].XYZ.Y < v[i].XYZ.Y) {
 				return PRIM_OVERLAP_UNKNOW;
 			}
 			GSVector4i vi(v[i].XYZ.X, v[i].XYZ.Y, v[i + 1].XYZ.X, v[i + 1].XYZ.Y);
-			for (size_t j = i + 2; j < count; j += 2) {
+			for (u32 j = i + 2; j < count; j += 2) {
 				GSVector4i vj(v[j].XYZ.X, v[j].XYZ.Y, v[j + 1].XYZ.X, v[j + 1].XYZ.Y);
 				GSVector4i inter = vi.rintersect(vj);
 				if (!inter.rempty()) {
@@ -2992,7 +2992,7 @@ __forceinline void GSState::CLUTAutoFlush(u32 prim)
 	if (m_mem.m_clut.IsInvalid() & 2)
 		return;
 
-	size_t  n = 1;
+	u32 n = 1;
 
 	switch (prim)
 	{
@@ -3048,9 +3048,9 @@ __forceinline void GSState::HandleAutoFlush()
 	if (IsAutoFlushDraw())
 	{
 		int  n = 1;
-		size_t buff[3];
-		const size_t head = m_vertex.head;
-		const size_t tail = m_vertex.tail;
+		u32 buff[3];
+		const u32 head = m_vertex.head;
+		const u32 tail = m_vertex.tail;
 
 		switch (prim)
 		{
@@ -3232,7 +3232,7 @@ __forceinline void GSState::HandleAutoFlush()
 	}
 }
 
-static constexpr size_t NumIndicesForPrim(u32 prim)
+static constexpr u32 NumIndicesForPrim(u32 prim)
 {
 	switch (prim)
 	{
@@ -3255,7 +3255,7 @@ static constexpr size_t NumIndicesForPrim(u32 prim)
 template <u32 prim, bool auto_flush, bool index_swap>
 __forceinline void GSState::VertexKick(u32 skip)
 {
-	constexpr size_t n = NumIndicesForPrim(prim);
+	constexpr u32 n = NumIndicesForPrim(prim);
 	static_assert(n > 0);
 
 	ASSERT(m_vertex.tail < m_vertex.maxcount + 3);
@@ -3265,10 +3265,10 @@ __forceinline void GSState::VertexKick(u32 skip)
 		HandleAutoFlush<prim, index_swap>();
 	}
 
-	size_t head = m_vertex.head;
-	size_t tail = m_vertex.tail;
-	size_t next = m_vertex.next;
-	size_t xy_tail = m_vertex.xy_tail;
+	u32 head = m_vertex.head;
+	u32 tail = m_vertex.tail;
+	u32 next = m_vertex.next;
+	u32 xy_tail = m_vertex.xy_tail;
 
 	// callers should write XYZUVF to m_v.m[1] in one piece to have this load store-forwarded, either by the cpu or the compiler when this function is inlined
 
@@ -3287,7 +3287,7 @@ __forceinline void GSState::VertexKick(u32 skip)
 	m_vertex.tail = ++tail;
 	m_vertex.xy_tail = ++xy_tail;
 
-	const size_t m = tail - head;
+	const u32 m = tail - head;
 
 	if (m < n)
 		return;

--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -169,6 +169,7 @@ protected:
 
 	void GrowVertexBuffer();
 	bool IsAutoFlushDraw();
+	template<bool index_swap>
 	void HandleAutoFlush();
 	void CLUTAutoFlush();
 

--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -169,9 +169,9 @@ protected:
 
 	void GrowVertexBuffer();
 	bool IsAutoFlushDraw();
-	template<bool index_swap>
+	template<u32 prim, bool index_swap>
 	void HandleAutoFlush();
-	void CLUTAutoFlush();
+	void CLUTAutoFlush(u32 prim);
 
 	template <u32 prim, bool auto_flush, bool index_swap>
 	void VertexKick(u32 skip);

--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -151,15 +151,15 @@ protected:
 	struct
 	{
 		GSVertex* buff;
-		size_t head, tail, next, maxcount; // head: first vertex, tail: last vertex + 1, next: last indexed + 1
-		size_t xy_tail;
+		u32 head, tail, next, maxcount; // head: first vertex, tail: last vertex + 1, next: last indexed + 1
+		u32 xy_tail;
 		u64 xy[4];
 	} m_vertex;
 
 	struct
 	{
 		u32* buff;
-		size_t tail;
+		u32 tail;
 	} m_index;
 
 	void UpdateContext();

--- a/pcsx2/GS/Renderers/HW/GSHwHack.cpp
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.cpp
@@ -838,7 +838,7 @@ bool GSHwHack::GSC_BlueTongueGames(GSRendererHW& r, const GSFrameInfo& fi, int& 
 
 bool GSHwHack::OI_PointListPalette(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t)
 {
-	const size_t n_vertices = r.m_vertex.next;
+	const u32 n_vertices = r.m_vertex.next;
 	const int w = r.m_r.width();
 	const int h = r.m_r.height();
 	const bool is_copy = !r.PRIM->ABE || (

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -333,7 +333,7 @@ void GSRendererHW::Lines2Sprites()
 
 	if (m_vertex.next >= 2)
 	{
-		const size_t count = m_vertex.next;
+		const u32 count = m_vertex.next;
 
 		int i = static_cast<int>(count) * 2 - 4;
 		GSVertex* s = &m_vertex.buff[count - 2];
@@ -403,7 +403,7 @@ void GSRendererHW::Lines2Sprites()
 template <GSHWDrawConfig::VSExpand Expand>
 void GSRendererHW::ExpandIndices()
 {
-	size_t process_count = (m_index.tail + 3) / 4 * 4;
+	u32 process_count = (m_index.tail + 3) / 4 * 4;
 	if (Expand == GSHWDrawConfig::VSExpand::Point)
 	{
 		// Make sure we have space for writing off the end slightly
@@ -465,7 +465,7 @@ void GSRendererHW::ExpandIndices()
 // Fix the vertex position/tex_coordinate from 16 bits color to 32 bits color
 void GSRendererHW::ConvertSpriteTextureShuffle(bool& write_ba, bool& read_ba)
 {
-	const size_t count = m_vertex.next;
+	const u32 count = m_vertex.next;
 	GSVertex* v = &m_vertex.buff[0];
 	const GIFRegXYOFFSET& o = m_context->XYOFFSET;
 
@@ -516,7 +516,7 @@ void GSRendererHW::ConvertSpriteTextureShuffle(bool& write_ba, bool& read_ba)
 
 			int maxvert = 0;
 			int minvert = 4096;
-			for (size_t i = 0; i < count; i ++)
+			for (u32 i = 0; i < count; i ++)
 			{
 				int YCord = 0;
 
@@ -539,7 +539,7 @@ void GSRendererHW::ConvertSpriteTextureShuffle(bool& write_ba, bool& read_ba)
 	{
 		GL_INS("First vertex is  P: %d => %d    T: %d => %d", v[0].XYZ.X, v[1].XYZ.X, v[0].U, v[1].U);
 
-		for (size_t i = 0; i < count; i += 2)
+		for (u32 i = 0; i < count; i += 2)
 		{
 			if (write_ba)
 				v[i].XYZ.X   -= 128u;
@@ -572,7 +572,7 @@ void GSRendererHW::ConvertSpriteTextureShuffle(bool& write_ba, bool& read_ba)
 		const float offset_8pix = 8.0f / tw;
 		GL_INS("First vertex is  P: %d => %d    T: %f => %f (offset %f)", v[0].XYZ.X, v[1].XYZ.X, v[0].ST.S, v[1].ST.S, offset_8pix);
 
-		for (size_t i = 0; i < count; i += 2)
+		for (u32 i = 0; i < count; i += 2)
 		{
 			if (write_ba)
 				v[i].XYZ.X   -= 128u;
@@ -722,7 +722,7 @@ void GSRendererHW::MergeSprite(GSTextureCache::Source* tex)
 			// SSE optimization: shuffle m[1] to have (4*32 bits) X, Y, U, V
 			const int first_dpX = v[1].XYZ.X - v[0].XYZ.X;
 			const int first_dpU = v[1].U - v[0].U;
-			for (size_t i = 0; i < m_vertex.next; i += 2)
+			for (u32 i = 0; i < m_vertex.next; i += 2)
 			{
 				const int dpX = v[i + 1].XYZ.X - v[i].XYZ.X;
 				const int dpU = v[i + 1].U - v[i].U;
@@ -1125,10 +1125,10 @@ void GSRendererHW::RoundSpriteOffset()
 #if defined(DEBUG_V) || defined(DEBUG_U)
 	bool debug = linear;
 #endif
-	const size_t count = m_vertex.next;
+	const u32 count = m_vertex.next;
 	GSVertex* v = &m_vertex.buff[0];
 
-	for (size_t i = 0; i < count; i += 2)
+	for (u32 i = 0; i < count; i += 2)
 	{
 		// Performance note: if it had any impact on perf, someone would port it to SSE (AKA GSVector)
 
@@ -1837,7 +1837,7 @@ void GSRendererHW::Draw()
 	// Note: second hack corrects only the texture coordinate
 	if (CanUpscale() && (m_vt.m_primclass == GS_SPRITE_CLASS))
 	{
-		const size_t count = m_vertex.next;
+		const u32 count = m_vertex.next;
 		GSVertex* v = &m_vertex.buff[0];
 
 		// Hack to avoid vertical black line in various games (ace combat/tekken)
@@ -1854,7 +1854,7 @@ void GSRendererHW::Draw()
 				// Normaly vertex are aligned on full pixels and texture in half
 				// pixels. Let's extend the coverage of an half-pixel to avoid
 				// hole after upscaling
-				for (size_t i = 0; i < count; i += 2)
+				for (u32 i = 0; i < count; i += 2)
 				{
 					v[i + 1].XYZ.X += 8;
 					// I really don't know if it is a good idea. Neither what to do for !PRIM->FST
@@ -1965,7 +1965,7 @@ bool GSRendererHW::VerifyIndices()
 			[[fallthrough]];
 		case GS_POINT_CLASS:
 			// Expect indices to be flat increasing
-			for (size_t i = 0; i < m_index.tail; i++)
+			for (u32 i = 0; i < m_index.tail; i++)
 			{
 				if (m_index.buff[i] != i)
 					return false;
@@ -1978,7 +1978,7 @@ bool GSRendererHW::VerifyIndices()
 			// VS expand relies on this!
 			if (g_gs_device->Features().provoking_vertex_last)
 			{
-				for (size_t i = 0; i < m_index.tail; i += 2)
+				for (u32 i = 0; i < m_index.tail; i += 2)
 				{
 					if (m_index.buff[i] + 1 != m_index.buff[i + 1])
 						return false;
@@ -1986,7 +1986,7 @@ bool GSRendererHW::VerifyIndices()
 			}
 			else
 			{
-				for (size_t i = 0; i < m_index.tail; i += 2)
+				for (u32 i = 0; i < m_index.tail; i += 2)
 				{
 					if (m_index.buff[i] != m_index.buff[i + 1] + 1)
 						return false;
@@ -2009,7 +2009,7 @@ void GSRendererHW::SetupIA(const float& sx, const float& sy)
 
 	if (GSConfig.UserHacks_WildHack && !m_isPackedUV_HackFlag && PRIM->TME && PRIM->FST)
 	{
-		for (unsigned int i = 0; i < m_vertex.next; i++)
+		for (u32 i = 0; i < m_vertex.next; i++)
 			m_vertex.buff[i].UV &= 0x3FEF3FEF;
 	}
 	const bool unscale_pt_ln = !GSConfig.UserHacks_DisableSafeFeatures && (GetUpscaleMultiplier() != 1.0f);

--- a/pcsx2/GS/Renderers/SW/GSRendererSW.cpp
+++ b/pcsx2/GS/Renderers/SW/GSRendererSW.cpp
@@ -245,7 +245,7 @@ void GSVertexSW::InitStatic()
 MULTI_ISA_UNSHARED_START
 
 template <u32 primclass, u32 tme, u32 fst, u32 q_div>
-void ConvertVertexBuffer(const GSDrawingContext* RESTRICT ctx, GSVertexSW* RESTRICT dst, const GSVertex* RESTRICT src, size_t count)
+void ConvertVertexBuffer(const GSDrawingContext* RESTRICT ctx, GSVertexSW* RESTRICT dst, const GSVertex* RESTRICT src, u32 count)
 {
 	// FIXME q_div wasn't added to AVX2 code path.
 

--- a/pcsx2/GS/Renderers/SW/GSVertexSW.h
+++ b/pcsx2/GS/Renderers/SW/GSVertexSW.h
@@ -246,7 +246,7 @@ struct alignas(32) GSVertexSW
 #endif
 	}
 
-	typedef void (*ConvertVertexBufferPtr)(const GSDrawingContext* RESTRICT ctx, GSVertexSW* RESTRICT dst, const GSVertex* RESTRICT src, size_t count);
+	typedef void (*ConvertVertexBufferPtr)(const GSDrawingContext* RESTRICT ctx, GSVertexSW* RESTRICT dst, const GSVertex* RESTRICT src, u32 count);
 
 	static ConvertVertexBufferPtr s_cvb[4][2][2][2];
 


### PR DESCRIPTION
### Description of Changes

DirectX and OpenGL no longer have different draw splitting.

Also swaps out the size_t fields in GSState for u32s, packs a bit more in the cache line, and ever-so-slightly smaller code size (likely no observable perf difference).

### Rationale behind Changes

Consistency.

### Suggested Testing Steps

Test a couple of auto flush games. I've done a GS runner pass and it's all good.
