### PR TITLE
GS/HW: Fix fixed/invalid TEX0 case in TimeSplitters 2

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.h
@@ -65,6 +65,8 @@ public:
 
 		/// Returns true if the area of the region exceeds the TW/TH size (i.e. "fixed tex0").
 		bool IsFixedTEX0(int tw, int th) const;
+		bool IsFixedTEX0W(int tw) const;
+		bool IsFixedTEX0H(int th) const;
 
 		/// Returns the rectangle relative to the texture base pointer that the region occupies.
 		GSVector4i GetRect(int tw, int th) const;


### PR DESCRIPTION
### Description of Changes

Silly game does a post effect using triangles and invalid/fixed tex0.

I can make this more efficient in the future, but for now this just fixes the regression.

### Rationale behind Changes

Regression from #8015.

### Suggested Testing Steps

Test TS2. I've done a runner pass and nothing else seems affected.
