### PR TITLE
GL/OpenGL: Add a hidden [EmuCore/GS] DisableGLDownloadPBO option

### DIFF
--- a/pcsx2/GS/Renderers/OpenGL/GLLoader.h
+++ b/pcsx2/GS/Renderers/OpenGL/GLLoader.h
@@ -29,9 +29,8 @@ namespace GLLoader
 	extern bool vendor_id_amd;
 	extern bool vendor_id_nvidia;
 	extern bool vendor_id_intel;
-	extern bool mesa_driver;
 	extern bool buggy_pbo;
-	extern bool in_replayer;
+	extern bool disable_download_pbo;
 
 	// GL
 	extern bool is_gles;

--- a/pcsx2/GS/Renderers/OpenGL/GSTextureOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSTextureOGL.cpp
@@ -455,7 +455,8 @@ std::unique_ptr<GSDownloadTextureOGL> GSDownloadTextureOGL::Create(u32 width, u3
 {
 	const u32 buffer_size = GetBufferSize(width, height, format, GSTexture::GetCompressedBytesPerBlock(format));
 
-	const bool use_buffer_storage = (GLAD_GL_VERSION_4_4 || GLAD_GL_ARB_buffer_storage || GLAD_GL_EXT_buffer_storage);
+	const bool use_buffer_storage = (GLAD_GL_VERSION_4_4 || GLAD_GL_ARB_buffer_storage || GLAD_GL_EXT_buffer_storage) &&
+									!GLLoader::disable_download_pbo;
 	if (use_buffer_storage)
 	{
 		GLuint buffer_id;


### PR DESCRIPTION
### Description of Changes

.. to disable the use of PBOs when reading back. Apparently they might be slower on some older drivers according to #8074?

On my A750 with the Windows driver, I get 52fps in the Gradius GS dump with PBOs, and 35fps without. Mesa is about the same for both.

### Rationale behind Changes

Older systems I guess

### Suggested Testing Steps

Test Gradius dump with `DisableGLDownloadPBO` option under `EmuCore/GS` set to `true` and `false`, observe performance. You'll need to manually make it, it's a hidden option.
