### PR TITLE
GS/HW: Fix crash with AVX2 due to unaligned pitch

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -3116,7 +3116,7 @@ void GSTextureCache::Target::Update(bool reset_age)
 		}
 		else
 		{
-			int pitch = ((r.width()+3) & ~3) * 4;
+			const int pitch = Common::AlignUpPow2(r.width() * sizeof(u32), 32);
 			g_gs_renderer->m_mem.ReadTexture(off, r, s_unswizzle_buffer, pitch, TEXA);
 
 			t->Update(r, s_unswizzle_buffer, pitch);


### PR DESCRIPTION
### Description of Changes

Mainly in DX11 when the staging buffer was used.

### Rationale behind Changes

Crash bad.

### Suggested Testing Steps

You'd need a game with an odd framebuffer size and to use DX11. Or can just yolo since it's an obvious change.

