### PR TITLE
Counters: Present at VSync End (round 2)

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -148,7 +148,7 @@ GSTextureCache::Source* GSTextureCache::LookupDepthSource(const GIFRegTEX0& TEX0
 		for (auto t : m_dst[RenderTarget])
 		{
 			// FIXME: do I need to allow m_age == 1 as a potential match (as DepthStencil) ???
-			if (!t->m_age && t->m_used && t->m_dirty.empty() && GSUtil::HasSharedBits(bp, psm, t->m_TEX0.TBP0, t->m_TEX0.PSM))
+			if (t->m_age <= 1 && t->m_used && t->m_dirty.empty() && GSUtil::HasSharedBits(bp, psm, t->m_TEX0.TBP0, t->m_TEX0.PSM))
 			{
 				ASSERT(GSLocalMemory::m_psm[t->m_TEX0.PSM].depth);
 				dst = t;
@@ -504,7 +504,7 @@ GSTextureCache::Source* GSTextureCache::LookupSource(const GIFRegTEX0& TEX0, con
 			// 1/ Check only current frame, I guess it is only used as a postprocessing effect
 			for (auto t : m_dst[DepthStencil])
 			{
-				if (!t->m_age && t->m_used && t->m_dirty.empty() && GSUtil::HasSharedBits(bp, psm, t->m_TEX0.TBP0, t->m_TEX0.PSM))
+				if (t->m_age <= 1 && t->m_used && t->m_dirty.empty() && GSUtil::HasSharedBits(bp, psm, t->m_TEX0.TBP0, t->m_TEX0.PSM))
 				{
 					GL_INS("TC: Warning depth format read as color format. Pixels will be scrambled");
 					// Let's fetch a depth format texture. Rational, it will avoid the texture allocation and the


### PR DESCRIPTION
### Description of Changes

Same as #5922, except rebased, and with the issue which caused garbage post-processing in Black hopefully fixed.

### Rationale behind Changes

Quoting refraction:
> Previously we were basically presenting the previous frame at the beginning of the next vsync start as a result of how things were working previously, we had to, however this will move it to VSync end, so the framebuffer pointers will have changed to the "just rendered" frame, which in theory should potentially reduce input lag by 1 frame.

### Suggested Testing Steps

> I can't remember what 2D fighting game used to have a problem with it this way around, but it's worth testing any you have.
Aside from that, test games for input lag (probably better on Qt) and make sure you don't get any black frame flashing that wasn't there previously.

Check Black (both PAL and NTSC).
