### PR TITLE
GameDB: Fixes for 187 Ride or Die

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -9392,6 +9392,9 @@ SLED-53512:
 SLED-53537:
   name: "187 - Ride or Die [Demo]"
   region: "PAL-E"
+  gsHWFixes:
+    autoFlush: 1 # Softens bloom on objects and cars.
+    halfPixelOffset: 2 # Fixes misalgined bloom on objects and cars.
 SLED-53673:
   name: "007 - From Russia with Love [Demo]"
   region: "PAL-E"
@@ -14327,6 +14330,9 @@ SLES-52276:
   name: "187 - Ride or Die"
   region: "PAL-M5"
   compat: 5
+  gsHWFixes:
+    autoFlush: 1 # Softens bloom on objects and cars.
+    halfPixelOffset: 2 # Fixes misalgined bloom on objects and cars.
 SLES-52277:
   name: "Riding Spirits 2"
   region: "PAL-M5"
@@ -15519,7 +15525,7 @@ SLES-52745:
   region: "PAL-M4"
 SLES-52746:
   name: "Hugo - Cannon Cruise"
-  region: "PAL-M4"
+  region: "PAL-SC"
 SLES-52747:
   name: "Dukes of Hazzard, The - The Return of General Lee"
   region: "PAL-E"
@@ -15705,7 +15711,7 @@ SLES-52816:
     cpuCLUTRender: 1 # Fixes duplicated post processing.
 SLES-52820:
   name: "Incredibles, The"
-  region: "PAL-M4"
+  region: "PAL-SC"
   gsHWFixes:
     halfPixelOffset: 1 # Fixes offset post processing.
     cpuCLUTRender: 1 # Fixes duplicated post processing.
@@ -18815,7 +18821,7 @@ SLES-54013:
   region: "PAL-E"
 SLES-54015:
   name: "Disney-Pixar's Cars"
-  region: "PAL-M3"
+  region: "PAL-SC"
 SLES-54016:
   name: "AND 1 Streetball"
   region: "PAL-M5"
@@ -45938,6 +45944,9 @@ SLUS-21116:
   name: "187 - Ride or Die"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    autoFlush: 1 # Softens bloom on objects and cars.
+    halfPixelOffset: 2 # Fixes misalgined bloom on objects and cars.
 SLUS-21117:
   name: "World Soccer - Winning Eleven 8 - International"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
Adds autoflush to soften bloom and HPO Special Texture to fix misaligned bloom.

### Rationale behind Changes
Misaligned bloom is gross.

### Suggested Testing Steps
Make sure CI is happy.
