### PR TITLE
GS-HW: Tighten CLUT detection slightly.

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -4026,8 +4026,8 @@ GSRendererHW::CLUTDrawTestResult GSRendererHW::PossibleCLUTDraw()
 		(PRIM->TME && ((m_regs->DISP[0].DISPFB.Block() == m_context->TEX0.TBP0) || (m_regs->DISP[1].DISPFB.Block() == m_context->TEX0.TBP0)) && !(m_mem.m_clut.IsInvalid() & 2)))
 		return CLUTDrawTestResult::NotCLUTDraw;
 
-	// Ignore recursive/shuffle effects, but possible it will recursively draw, but make sure it's staying in page width
-	if (PRIM->TME && m_context->TEX0.TBP0 == m_context->FRAME.Block() && (m_context->FRAME.FBW != 1 && m_context->TEX0.TBW == m_context->FRAME.FBW))
+	// Ignore large render targets, make sure it's staying in page width.
+	if (PRIM->TME && (m_context->FRAME.FBW != 1 && m_context->TEX0.TBW == m_context->FRAME.FBW))
 		return CLUTDrawTestResult::NotCLUTDraw;
 
 	// Hopefully no games draw a CLUT with a CLUT, that would be evil, most likely a channel shuffle.


### PR DESCRIPTION
### Description of Changes
Tightens CLUT draw detection slightly.

### Rationale behind Changes
Klonoa 2 was detecting the top left corner being drawn (possibly post/shuffle effect?) causing glitching, which became apparent in #8101 The rest of the games on my CLUT list seem to be fine still.

### Suggested Testing Steps
Already checked my list from #7267, Ace Combat 5 sun occlusion is busted again, but not because of this PR.
