### PR TITLE
GS: Attempt to recreate device if GPU crashes

### DIFF
--- a/common/D3D12/Context.h
+++ b/common/D3D12/Context.h
@@ -130,7 +130,7 @@ namespace D3D12
 		};
 
 		/// Executes the current command list.
-		void ExecuteCommandList(WaitType wait_for_completion);
+		bool ExecuteCommandList(WaitType wait_for_completion);
 
 		/// Waits for a specific fence.
 		void WaitForFence(u64 fence, bool spin);

--- a/common/Vulkan/Context.cpp
+++ b/common/Vulkan/Context.cpp
@@ -1122,9 +1122,13 @@ namespace Vulkan
 	void Context::WaitForCommandBufferCompletion(u32 index)
 	{
 		// Wait for this command buffer to be completed.
-		VkResult res = vkWaitForFences(m_device, 1, &m_frame_resources[index].fence, VK_TRUE, UINT64_MAX);
+		const VkResult res = vkWaitForFences(m_device, 1, &m_frame_resources[index].fence, VK_TRUE, UINT64_MAX);
 		if (res != VK_SUCCESS)
+		{
 			LOG_VULKAN_ERROR(res, "vkWaitForFences failed: ");
+			m_last_submit_failed.store(true, std::memory_order_release);
+			return;
+		}
 
 		// Clean up any resources for command buffers between the last known completed buffer and this
 		// now-completed command buffer. If we use >2 buffers, this may be more than one buffer.
@@ -1266,11 +1270,12 @@ namespace Vulkan
 			submit_info.pSignalSemaphores = &m_spin_resources[index].semaphore;
 		}
 
-		VkResult res = vkQueueSubmit(m_graphics_queue, 1, &submit_info, resources.fence);
+		const VkResult res = vkQueueSubmit(m_graphics_queue, 1, &submit_info, resources.fence);
 		if (res != VK_SUCCESS)
 		{
 			LOG_VULKAN_ERROR(res, "vkQueueSubmit failed: ");
-			pxFailRel("Failed to submit command buffer.");
+			m_last_submit_failed.store(true, std::memory_order_release);
+			return;
 		}
 
 		if (spin_cycles != 0)
@@ -1286,14 +1291,14 @@ namespace Vulkan
 
 		present_swap_chain->ReleaseCurrentImage();
 
-		VkResult res = vkQueuePresentKHR(m_present_queue, &present_info);
+		const VkResult res = vkQueuePresentKHR(m_present_queue, &present_info);
 		if (res != VK_SUCCESS)
 		{
 			// VK_ERROR_OUT_OF_DATE_KHR is not fatal, just means we need to recreate our swap chain.
 			if (res != VK_ERROR_OUT_OF_DATE_KHR && res != VK_SUBOPTIMAL_KHR)
 				LOG_VULKAN_ERROR(res, "vkQueuePresentKHR failed: ");
 
-			m_last_present_failed.store(true);
+			m_last_present_failed.store(true, std::memory_order_release);
 			return;
 		}
 
@@ -1460,6 +1465,9 @@ namespace Vulkan
 
 	void Context::ExecuteCommandBuffer(WaitType wait_for_completion)
 	{
+		if (m_last_submit_failed.load(std::memory_order_acquire))
+			return;
+
 		// If we're waiting for completion, don't bother waking the worker thread.
 		const u32 current_frame = m_current_frame;
 		SubmitCommandBuffer();
@@ -1481,9 +1489,12 @@ namespace Vulkan
 
 	bool Context::CheckLastPresentFail()
 	{
-		bool res = m_last_present_failed;
-		m_last_present_failed = false;
-		return res;
+		return m_last_present_failed.exchange(false, std::memory_order_acq_rel);
+	}
+
+	bool Context::CheckLastSubmitFail()
+	{
+		return m_last_submit_failed.load(std::memory_order_acquire);
 	}
 
 	void Context::DeferBufferDestruction(VkBuffer object)
@@ -1596,7 +1607,7 @@ namespace Vulkan
 				VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT,
 			DebugMessengerCallback, nullptr};
 
-		VkResult res =
+		const VkResult res =
 			vkCreateDebugUtilsMessengerEXT(m_instance, &messenger_info, nullptr, &m_debug_messenger_callback);
 		if (res != VK_SUCCESS)
 		{
@@ -1688,7 +1699,7 @@ namespace Vulkan
 			subpass_dependency_ptr};
 
 		VkRenderPass pass;
-		VkResult res = vkCreateRenderPass(m_device, &pass_info, nullptr, &pass);
+		const VkResult res = vkCreateRenderPass(m_device, &pass_info, nullptr, &pass);
 		if (res != VK_SUCCESS)
 		{
 			LOG_VULKAN_ERROR(res, "vkCreateRenderPass failed: ");
@@ -1894,9 +1905,14 @@ void main()
 		SpinResources& resources = m_spin_resources[index];
 		if (!resources.in_progress)
 			return;
-		VkResult res = vkWaitForFences(m_device, 1, &resources.fence, VK_TRUE, UINT64_MAX);
+
+		const VkResult res = vkWaitForFences(m_device, 1, &resources.fence, VK_TRUE, UINT64_MAX);
 		if (res != VK_SUCCESS)
+		{
 			LOG_VULKAN_ERROR(res, "vkWaitForFences failed: ");
+			m_last_submit_failed.store(true, std::memory_order_release);
+			return;
+		}
 		SpinCommandCompleted(index);
 	}
 
@@ -1906,7 +1922,7 @@ void main()
 		resources.in_progress = false;
 		const u32 timestamp_base = (index + NUM_COMMAND_BUFFERS) * 2;
 		std::array<u64, 2> timestamps;
-		VkResult res = vkGetQueryPoolResults(m_device, m_timestamp_query_pool, timestamp_base, static_cast<u32>(timestamps.size()),
+		const VkResult res = vkGetQueryPoolResults(m_device, m_timestamp_query_pool, timestamp_base, static_cast<u32>(timestamps.size()),
 			sizeof(timestamps), timestamps.data(), sizeof(u64), VK_QUERY_RESULT_64_BIT);
 		if (res == VK_SUCCESS)
 		{
@@ -2014,7 +2030,7 @@ void main()
 		constexpr u64 MAX_MAX_DEVIATION = 100000; // 100µs
 		for (int i = 0; i < 4; i++) // 4 tries to get under MAX_MAX_DEVIATION
 		{
-			VkResult res = vkGetCalibratedTimestampsEXT(m_device, std::size(infos), infos, timestamps, &maxDeviation);
+			const VkResult res = vkGetCalibratedTimestampsEXT(m_device, std::size(infos), infos, timestamps, &maxDeviation);
 			if (res != VK_SUCCESS)
 			{
 				LOG_VULKAN_ERROR(res, "vkGetCalibratedTimestampsEXT failed: ");

--- a/common/Vulkan/Context.h
+++ b/common/Vulkan/Context.h
@@ -209,6 +209,7 @@ namespace Vulkan
 
 		// Was the last present submitted to the queue a failure? If so, we must recreate our swapchain.
 		bool CheckLastPresentFail();
+		bool CheckLastSubmitFail();
 
 		// Schedule a vulkan resource for destruction later on. This will occur when the command buffer
 		// is next re-used, and the GPU has finished working with the specified resource.
@@ -373,6 +374,7 @@ namespace Vulkan
 
 		StreamBuffer m_texture_upload_buffer;
 
+		std::atomic_bool m_last_submit_failed{false};
 		std::atomic_bool m_last_present_failed{false};
 		std::atomic_bool m_present_done{true};
 		std::mutex m_present_mutex;

--- a/pcsx2-gsrunner/Main.cpp
+++ b/pcsx2-gsrunner/Main.cpp
@@ -280,7 +280,7 @@ void Host::ReleaseHostDisplay(bool clear_state)
 	g_host_display.reset();
 }
 
-bool Host::BeginPresentFrame(bool frame_skip)
+HostDisplay::PresentResult Host::BeginPresentFrame(bool frame_skip)
 {
 	if (s_loop_number == 0)
 	{
@@ -291,12 +291,15 @@ bool Host::BeginPresentFrame(bool frame_skip)
 		std::string dump_path(fmt::format("{}_frame{}.png", s_output_prefix, s_dump_frame_number));
 		GSQueueSnapshot(dump_path);
 	}
-	if (g_host_display->BeginPresent(frame_skip))
-		return true;
 
-	// don't render imgui
-	ImGuiManager::NewFrame();
-	return false;
+	const HostDisplay::PresentResult result = g_host_display->BeginPresent(frame_skip);
+	if (result != HostDisplay::PresentResult::OK)
+	{
+		// don't render imgui
+		ImGuiManager::SkipFrame();
+	}
+
+	return result;
 }
 
 void Host::EndPresentFrame()

--- a/pcsx2-qt/QtHost.cpp
+++ b/pcsx2-qt/QtHost.cpp
@@ -967,17 +967,17 @@ void Host::ReleaseHostDisplay(bool clear_state)
 	g_emu_thread->releaseHostDisplay(clear_state);
 }
 
-bool Host::BeginPresentFrame(bool frame_skip)
+HostDisplay::PresentResult Host::BeginPresentFrame(bool frame_skip)
 {
-	if (!g_host_display->BeginPresent(frame_skip))
+	const HostDisplay::PresentResult result = g_host_display->BeginPresent(frame_skip);
+	if (result != HostDisplay::PresentResult::OK)
 	{
 		// if we're skipping a frame, we need to reset imgui's state, since
 		// we won't be calling EndPresentFrame().
-		ImGuiManager::NewFrame();
-		return false;
+		ImGuiManager::SkipFrame();
 	}
 
-	return true;
+	return result;
 }
 
 void Host::EndPresentFrame()

--- a/pcsx2/Frontend/D3D11HostDisplay.cpp
+++ b/pcsx2/Frontend/D3D11HostDisplay.cpp
@@ -641,13 +641,10 @@ bool D3D11HostDisplay::UpdateImGuiFontTexture()
 	return true;
 }
 
-bool D3D11HostDisplay::BeginPresent(bool frame_skip)
+HostDisplay::PresentResult D3D11HostDisplay::BeginPresent(bool frame_skip)
 {
 	if (frame_skip || !m_swap_chain)
-	{
-		ImGui::EndFrame();
-		return false;
-	}
+		return PresentResult::FrameSkipped;
 
 	// When using vsync, the time here seems to include the time for the buffer to become available.
 	// This blows our our GPU usage number considerably, so read the timestamp before the final blit
@@ -664,7 +661,7 @@ bool D3D11HostDisplay::BeginPresent(bool frame_skip)
 	const CD3D11_RECT scissor(0, 0, m_window_info.surface_width, m_window_info.surface_height);
 	m_context->RSSetViewports(1, &vp);
 	m_context->RSSetScissorRects(1, &scissor);
-	return true;
+	return PresentResult::OK;
 }
 
 void D3D11HostDisplay::EndPresent()

--- a/pcsx2/Frontend/D3D11HostDisplay.h
+++ b/pcsx2/Frontend/D3D11HostDisplay.h
@@ -65,7 +65,7 @@ public:
 
 	void SetVSync(VsyncMode mode) override;
 
-	bool BeginPresent(bool frame_skip) override;
+	PresentResult BeginPresent(bool frame_skip) override;
 	void EndPresent() override;
 
 	bool SetGPUTimingEnabled(bool enabled) override;

--- a/pcsx2/Frontend/D3D12HostDisplay.h
+++ b/pcsx2/Frontend/D3D12HostDisplay.h
@@ -71,7 +71,7 @@ public:
 
 	void SetVSync(VsyncMode mode) override;
 
-	bool BeginPresent(bool frame_skip) override;
+	PresentResult BeginPresent(bool frame_skip) override;
 	void EndPresent() override;
 
 	bool SetGPUTimingEnabled(bool enabled) override;
@@ -97,4 +97,5 @@ protected:
 
 	bool m_allow_tearing_supported = false;
 	bool m_using_allow_tearing = false;
+	bool m_device_lost = false;
 };

--- a/pcsx2/Frontend/ImGuiManager.cpp
+++ b/pcsx2/Frontend/ImGuiManager.cpp
@@ -229,6 +229,12 @@ void ImGuiManager::NewFrame()
 	}
 }
 
+void ImGuiManager::SkipFrame()
+{
+	ImGui::EndFrame();
+	NewFrame();
+}
+
 void ImGuiManager::SetStyle()
 {
 	ImGuiStyle& style = ImGui::GetStyle();

--- a/pcsx2/Frontend/ImGuiManager.h
+++ b/pcsx2/Frontend/ImGuiManager.h
@@ -40,6 +40,9 @@ namespace ImGuiManager
 	/// Call at the beginning of the frame to set up ImGui state.
 	void NewFrame();
 
+	/// Call when skipping rendering a frame, to update internal state.
+	void SkipFrame();
+
 	/// Renders any on-screen display elements.
 	void RenderOSD();
 

--- a/pcsx2/Frontend/MetalHostDisplay.h
+++ b/pcsx2/Frontend/MetalHostDisplay.h
@@ -81,7 +81,7 @@ public:
 	std::unique_ptr<HostDisplayTexture> CreateTexture(u32 width, u32 height, const void* data, u32 data_stride, bool dynamic = false) override;
 	void UpdateTexture(id<MTLTexture> texture, u32 x, u32 y, u32 width, u32 height, const void* data, u32 data_stride);
 	void UpdateTexture(HostDisplayTexture* texture, u32 x, u32 y, u32 width, u32 height, const void* data, u32 data_stride) override;
-	bool BeginPresent(bool frame_skip) override;
+	PresentResult BeginPresent(bool frame_skip) override;
 	void EndPresent() override;
 	void SetVSync(VsyncMode mode) override;
 

--- a/pcsx2/Frontend/OpenGLHostDisplay.cpp
+++ b/pcsx2/Frontend/OpenGLHostDisplay.cpp
@@ -335,13 +335,10 @@ bool OpenGLHostDisplay::UpdateImGuiFontTexture()
 	return ImGui_ImplOpenGL3_CreateFontsTexture();
 }
 
-bool OpenGLHostDisplay::BeginPresent(bool frame_skip)
+HostDisplay::PresentResult OpenGLHostDisplay::BeginPresent(bool frame_skip)
 {
 	if (frame_skip || m_window_info.type == WindowInfo::Type::Surfaceless)
-	{
-		ImGui::EndFrame();
-		return false;
-	}
+		return PresentResult::FrameSkipped;
 
 	glDisable(GL_SCISSOR_TEST);
 	glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
@@ -350,7 +347,7 @@ bool OpenGLHostDisplay::BeginPresent(bool frame_skip)
 	glClear(GL_COLOR_BUFFER_BIT);
 	glViewport(0, 0, m_window_info.surface_width, m_window_info.surface_height);
 
-	return true;
+	return PresentResult::OK;
 }
 
 void OpenGLHostDisplay::EndPresent()

--- a/pcsx2/Frontend/OpenGLHostDisplay.h
+++ b/pcsx2/Frontend/OpenGLHostDisplay.h
@@ -58,7 +58,7 @@ public:
 
 	void SetVSync(VsyncMode mode) override;
 
-	bool BeginPresent(bool frame_skip) override;
+	PresentResult BeginPresent(bool frame_skip) override;
 	void EndPresent() override;
 
 	bool SetGPUTimingEnabled(bool enabled) override;

--- a/pcsx2/Frontend/VulkanHostDisplay.h
+++ b/pcsx2/Frontend/VulkanHostDisplay.h
@@ -47,7 +47,7 @@ public:
 
 	void SetVSync(VsyncMode mode) override;
 
-	bool BeginPresent(bool frame_skip) override;
+	PresentResult BeginPresent(bool frame_skip) override;
 	void EndPresent() override;
 
 	bool SetGPUTimingEnabled(bool enabled) override;

--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -209,15 +209,15 @@ static bool DoGSOpen(GSRendererType renderer, u8* basemem)
 			return false;
 	}
 
-	try
+	if (!g_gs_device->Create())
 	{
-		if (!g_gs_device->Create())
-		{
-			g_gs_device->Destroy();
-			g_gs_device.reset();
-			return false;
-		}
+		g_gs_device->Destroy();
+		g_gs_device.reset();
+		return false;
+	}
 
+	if (!g_gs_renderer)
+	{
 		if (renderer == GSRendererType::Null)
 		{
 			g_gs_renderer = std::make_unique<GSRendererNull>();
@@ -230,55 +230,67 @@ static bool DoGSOpen(GSRendererType renderer, u8* basemem)
 		{
 			g_gs_renderer = std::unique_ptr<GSRenderer>(MULTI_ISA_SELECT(makeGSRendererSW)(GSConfig.SWExtraThreads));
 		}
+
+		g_gs_renderer->SetRegsMem(basemem);
 	}
-	catch (std::exception& ex)
+	else
 	{
-		Host::ReportFormattedErrorAsync("GS", "GS error: Exception caught in GSopen: %s", ex.what());
-		g_gs_renderer.reset();
-		g_gs_device->Destroy();
-		g_gs_device.reset();
-		return false;
+		Console.Warning("(DoGSOpen) Using existing renderer.");
 	}
 
 	GSConfig.OsdShowGPU = EmuConfig.GS.OsdShowGPU && g_host_display->SetGPUTimingEnabled(true);
 
-	g_gs_renderer->SetRegsMem(basemem);
 	g_perfmon.Reset();
 	return true;
 }
 
-bool GSreopen(bool recreate_display, const Pcsx2Config::GSOptions& old_config)
+bool GSreopen(bool recreate_display, bool recreate_renderer, const Pcsx2Config::GSOptions& old_config)
 {
 	Console.WriteLn("Reopening GS with %s display", recreate_display ? "new" : "existing");
 
-	g_gs_renderer->Flush(GSState::GSFlushReason::GSREOPEN);
+	if (recreate_renderer)
+		g_gs_renderer->Flush(GSState::GSFlushReason::GSREOPEN);
 
 	freezeData fd = {};
-	if (g_gs_renderer->Freeze(&fd, true) != 0)
+	std::unique_ptr<u8[]> fd_data;
+	if (recreate_renderer)
 	{
-		Console.Error("(GSreopen) Failed to get GS freeze size");
-		return false;
-	}
+		if (g_gs_renderer->Freeze(&fd, true) != 0)
+		{
+			Console.Error("(GSreopen) Failed to get GS freeze size");
+			return false;
+		}
 
-	std::unique_ptr<u8[]> fd_data = std::make_unique<u8[]>(fd.size);
-	fd.data = fd_data.get();
-	if (g_gs_renderer->Freeze(&fd, false) != 0)
+		fd_data = std::make_unique<u8[]>(fd.size);
+		fd.data = fd_data.get();
+		if (g_gs_renderer->Freeze(&fd, false) != 0)
+		{
+			Console.Error("(GSreopen) Failed to freeze GS");
+			return false;
+		}
+	}
+	else
 	{
-		Console.Error("(GSreopen) Failed to freeze GS");
-		return false;
+		// Make sure nothing is left over.
+		g_gs_renderer->PurgePool();
+		g_gs_renderer->PurgeTextureCache();
 	}
 
 	if (recreate_display)
 	{
 		g_gs_device->ResetAPIState();
-		if (Host::BeginPresentFrame(true))
+		if (Host::BeginPresentFrame(false) == HostDisplay::PresentResult::OK)
 			Host::EndPresentFrame();
 	}
 
 	u8* basemem = g_gs_renderer->GetRegsMem();
 	const u32 gamecrc = g_gs_renderer->GetGameCRC();
-	g_gs_renderer->Destroy();
-	g_gs_renderer.reset();
+	if (recreate_renderer)
+	{
+		g_gs_renderer->Destroy();
+		g_gs_renderer.reset();
+	}
+
 	g_gs_device->Destroy();
 	g_gs_device.reset();
 
@@ -327,13 +339,17 @@ bool GSreopen(bool recreate_display, const Pcsx2Config::GSOptions& old_config)
 		}
 	}
 
-	if (g_gs_renderer->Defrost(&fd) != 0)
+	if (recreate_renderer)
 	{
-		Console.Error("(GSreopen) Failed to defrost");
-		return false;
+		if (g_gs_renderer->Defrost(&fd) != 0)
+		{
+			Console.Error("(GSreopen) Failed to defrost");
+			return false;
+		}
+
+		g_gs_renderer->SetGameCRC(gamecrc);
 	}
 
-	g_gs_renderer->SetGameCRC(gamecrc);
 	return true;
 }
 
@@ -698,7 +714,7 @@ void GSUpdateConfig(const Pcsx2Config::GSOptions& new_config)
 			GSConfig.DisableShaderCache != old_config.DisableShaderCache ||
 			GSConfig.DisableThreadedPresentation != old_config.DisableThreadedPresentation
 		);
-		if (!GSreopen(do_full_restart, old_config))
+		if (!GSreopen(do_full_restart, true, old_config))
 			pxFailRel("Failed to do full GS reopen");
 		return;
 	}
@@ -709,7 +725,7 @@ void GSUpdateConfig(const Pcsx2Config::GSOptions& new_config)
 		GSConfig.SWExtraThreads != old_config.SWExtraThreads ||
 		GSConfig.SWExtraThreadsHeight != old_config.SWExtraThreadsHeight)
 	{
-		if (!GSreopen(false, old_config))
+		if (!GSreopen(false, true, old_config))
 			pxFailRel("Failed to do quick GS reopen");
 
 		return;
@@ -787,7 +803,7 @@ void GSSwitchRenderer(GSRendererType new_renderer)
 	const bool recreate_display = (!is_software_switch && existing_api != GetAPIForRenderer(new_renderer));
 	const Pcsx2Config::GSOptions old_config(GSConfig);
 	GSConfig.Renderer = new_renderer;
-	if (!GSreopen(recreate_display, old_config))
+	if (!GSreopen(recreate_display, true, old_config))
 		pxFailRel("Failed to reopen GS for renderer switch.");
 }
 

--- a/pcsx2/GS/GS.h
+++ b/pcsx2/GS/GS.h
@@ -53,7 +53,7 @@ s16 GSLookupBeforeDrawFunctionId(const std::string_view& name);
 int GSinit();
 void GSshutdown();
 bool GSopen(const Pcsx2Config::GSOptions& config, GSRendererType renderer, u8* basemem);
-bool GSreopen(bool recreate_display, const Pcsx2Config::GSOptions& old_config);
+bool GSreopen(bool recreate_display, bool recreate_renderer, const Pcsx2Config::GSOptions& old_config);
 void GSreset(bool hardware_reset);
 void GSclose();
 void GSgifSoftReset(u32 mask);

--- a/pcsx2/GS/Renderers/Common/GSRenderer.h
+++ b/pcsx2/GS/Renderers/Common/GSRenderer.h
@@ -23,6 +23,7 @@ class GSRenderer : public GSState
 {
 private:
 	bool Merge(int field);
+	bool BeginPresentFrame(bool frame_skip);
 
 	u64 m_shader_time_start = 0;
 

--- a/pcsx2/HostDisplay.h
+++ b/pcsx2/HostDisplay.h
@@ -60,6 +60,13 @@ public:
 		RightOrBottom
 	};
 
+	enum class PresentResult
+	{
+		OK,
+		FrameSkipped,
+		DeviceLost
+	};
+
 	struct AdapterAndModeList
 	{
 		std::vector<std::string> adapter_names;
@@ -137,7 +144,7 @@ public:
 
 	/// Returns false if the window was completely occluded. If frame_skip is set, the frame won't be
 	/// displayed, but the GPU command queue will still be flushed.
-	virtual bool BeginPresent(bool frame_skip) = 0;
+	virtual PresentResult BeginPresent(bool frame_skip) = 0;
 
 	/// Presents the frame to the display, and renders OSD elements.
 	virtual void EndPresent() = 0;
@@ -184,7 +191,7 @@ namespace Host
 
 	/// Returns false if the window was completely occluded. If frame_skip is set, the frame won't be
 	/// displayed, but the GPU command queue will still be flushed.
-	bool BeginPresentFrame(bool frame_skip);
+	HostDisplay::PresentResult BeginPresentFrame(bool frame_skip);
 
 	/// Presents the frame to the display, and renders OSD elements.
 	void EndPresentFrame();

--- a/tests/ctest/core/StubHost.cpp
+++ b/tests/ctest/core/StubHost.cpp
@@ -114,9 +114,9 @@ void Host::ReleaseHostDisplay(bool clear_state)
 {
 }
 
-bool Host::BeginPresentFrame(bool frame_skip)
+HostDisplay::PresentResult Host::BeginPresentFrame(bool frame_skip)
 {
-	return false;
+	return HostDisplay::PresentResult::FrameSkipped;
 }
 
 void Host::EndPresentFrame()


### PR DESCRIPTION
### Description of Changes

Currently, if `vkQueueSubmit()` or `vkWaitForFences()` fails, e.g. due to an invalid GPU command or driver bug, PCSX2 just panics/crashes. This isn't ideal.

Since we have most of the needed data stored in local memory, we can attempt to recover by tossing away all data on the GPU, and starting fresh. You'll probably get broken rendering for a frame or longer, but it's better than crashing, and might give you enough time to get to a save point. I wouldn't recommend making a save state after a GPU crash though :-).

For the case where a single object keeps crashing the GPU, it's limited to one reset per 15 seconds. That way we don't keep endlessly resetting the GPU and potentially hanging the user's PC.

### Rationale behind Changes

Making PCSX2 more reliable.

### Suggested Testing Steps

I don't know of any way to crash the renderers currently, but as long as Vulkan/DX12 aren't broken after these changes, should be fine. Brief test of all renderers though.
