### PR TITLE
Context.cpp: fix minor typo

### DIFF
--- a/common/GL/Context.cpp
+++ b/common/GL/Context.cpp
@@ -119,7 +119,7 @@ namespace GL
 		if (!context)
 			return nullptr;
 
-		Console.WriteLn("Created a %s context", context->IsGLES() ? "OpenGL ES" : "OpenGL");
+		Console.WriteLn("Created an %s context", context->IsGLES() ? "OpenGL ES" : "OpenGL");
 
 		// NOTE: Not thread-safe. But this is okay, since we're not going to be creating more than one context at a time.
 		static Context* context_being_created;


### PR DESCRIPTION
### Description of Changes
Changed "Created a Open ES/OpenGL context" to "Created an Open ES/OpenGL context".

### Rationale behind Changes
Minor grammar mistake.

### Suggested Testing Steps
Say it out loud and see which one sounds better.
