### PR TITLE
GS/HW: Purge FFX-2 depth clear CRC hack

### DIFF
--- a/pcsx2/GS/GSCrc.cpp
+++ b/pcsx2/GS/GSCrc.cpp
@@ -24,15 +24,6 @@ const CRC::Game CRC::m_games[] =
 {
 	// Note: IDs 0x7ACF7E03, 0x7D4EA48F, 0x37C53760 - shouldn't be added as it's from the multiloaders when packing games.
 	{0x00000000, NoTitle /* NoRegion */},
-	{0x9AAC5309, FFX2 /* EU */},
-	{0x9AAC530C, FFX2 /* FR */},
-	{0x9AAC530A, FFX2 /* ES */},
-	{0x9AAC530D, FFX2 /* DE */},
-	{0x9AAC530B, FFX2 /* IT */},
-	{0x48FE0C71, FFX2 /* US */},
-	{0x8A6D7F14, FFX2 /* JP */},
-	{0xE1FD9A2D, FFX2 /* JP */}, // int.
-	{0x11624CD6, FFX2 /* KO */},
 	{0x08C1ED4D, HauntingGround /* EU */},
 	{0x2CD5794C, HauntingGround /* EU */},
 	{0x867BB945, HauntingGround /* JP */},

--- a/pcsx2/GS/GSCrc.h
+++ b/pcsx2/GS/GSCrc.h
@@ -23,7 +23,6 @@ public:
 	enum Title : u32
 	{
 		NoTitle,
-		FFX2,
 		GetawayGames,
 		HauntingGround,
 		ICO,

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -3088,21 +3088,6 @@ void GSTextureCache::Target::Update(bool reset_age)
 		m_dirty.ClearDirty();
 		return;
 	}
-	else if (m_type == DepthStencil && g_gs_renderer->m_game.title == CRC::FFX2)
-	{
-		GL_INS("ERROR: bad invalidation detected, depth buffer will be cleared");
-		// FFX2 menu. Invalidation of the depth is wrongly done and only the first
-		// page is invalidated. Technically a CRC hack will be better but I don't expect
-		// any games to only upload a single page of data for the depth.
-		//
-		// FFX2 menu got another bug. I'm not sure the top-left is properly written or not. It
-		// could be a gs transfer bug too due to unaligned-page transfer.
-		//
-		// So the quick and dirty solution is just to clean the depth buffer.
-		g_gs_device->ClearDepth(m_texture);
-		m_dirty.ClearDirty();
-		return;
-	}
 
 	GIFRegTEXA TEXA = {};
 


### PR DESCRIPTION
### Description of Changes

Seems with the HLE clear changes we don't need this any more, yay!

It does do a local memory -> depth buffer copy which wasn't the case before (due to the hack), **but** only in the main menu, where you're not going to be GPU bottlenecked in the first place.

### Rationale behind Changes

These hardcoded per-game messes in the TC trigger me so much.

### Suggested Testing Steps

Test FFX-2 in menu and ingame, make sure nothing's broken.