### PR TITLE
GS/TextureCache: Allow tex-in-rt for 16/24/32-bit targets

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -1352,6 +1352,7 @@ SCAJ-20177:
   gsHWFixes:
     halfPixelOffset: 1 # Reduces bloom misalignment.
     roundSprite: 1 # Fixes area transition vertical lines and lessens red forest vertical lines.
+    textureInsideRT: 1 # Required for swirl battle transition.
 SCAJ-20178:
   name: "Ape Escape - Million Monkeys"
   region: "NTSC-Unk"
@@ -1452,6 +1453,7 @@ SCAJ-20197:
   gsHWFixes:
     halfPixelOffset: 1 # Reduces bloom misalignment.
     roundSprite: 1 # Fixes area transition vertical lines and lessens red forest vertical lines.
+    textureInsideRT: 1 # Required for swirl battle transition.
 SCAJ-20198:
   name: "Everybody's Tennis [PlayStation 2 The Best]"
   region: "NTSC-Unk"
@@ -5224,6 +5226,7 @@ SCKA-20079:
   gsHWFixes:
     halfPixelOffset: 1 # Reduces bloom misalignment.
     roundSprite: 1 # Fixes area transition vertical lines and lessens red forest vertical lines.
+    textureInsideRT: 1 # Required for swirl battle transition.
 SCKA-20081:
   name: "Tekken 5 [PlayStation 2 Big Hit Series]"
   region: "NTSC-K"
@@ -10477,6 +10480,8 @@ SLES-50438:
 SLES-50443:
   name: "LEGO Racers 2"
   region: "PAL-M8"
+  gsHWFixes:
+    textureInsideRT: 1 # Fixes top left corner rendering.
 SLES-50444:
   name: "Portal Runner"
   region: "PAL-M4"
@@ -20382,6 +20387,7 @@ SLES-54644:
   gsHWFixes:
     halfPixelOffset: 1 # Reduces bloom misalignment.
     roundSprite: 1 # Fixes area transition vertical lines and lessens red forest vertical lines.
+    textureInsideRT: 1 # Required for swirl battle transition.
 SLES-54645:
   name: "Valkyrie Profile 2 - Silmeria"
   region: "PAL-F"
@@ -20390,6 +20396,7 @@ SLES-54645:
   gsHWFixes:
     halfPixelOffset: 1 # Reduces bloom misalignment.
     roundSprite: 1 # Fixes area transition vertical lines and lessens red forest vertical lines.
+    textureInsideRT: 1 # Required for swirl battle transition.
 SLES-54646:
   name: "Valkyrie Profile 2 - Silmeria"
   region: "PAL-G"
@@ -20399,6 +20406,7 @@ SLES-54646:
   gsHWFixes:
     halfPixelOffset: 1 # Reduces bloom misalignment.
     roundSprite: 1 # Fixes area transition vertical lines and lessens red forest vertical lines.
+    textureInsideRT: 1 # Required for swirl battle transition.
 SLES-54647:
   name: "Valkyrie Profile 2 - Silmeria"
   region: "PAL-I"
@@ -20408,6 +20416,7 @@ SLES-54647:
   gsHWFixes:
     halfPixelOffset: 1 # Reduces bloom misalignment.
     roundSprite: 1 # Fixes area transition vertical lines and lessens red forest vertical lines.
+    textureInsideRT: 1 # Required for swirl battle transition.
 SLES-54648:
   name: "Valkyrie Profile 2 - Silmeria"
   region: "PAL-S"
@@ -20416,6 +20425,7 @@ SLES-54648:
   gsHWFixes:
     halfPixelOffset: 1 # Reduces bloom misalignment.
     roundSprite: 1 # Fixes area transition vertical lines and lessens red forest vertical lines.
+    textureInsideRT: 1 # Required for swirl battle transition.
 SLES-54653:
   name: "Freak Out - Extreme Freeride"
   region: "PAL-M5"
@@ -25804,6 +25814,8 @@ SLPM-62203:
 SLPM-62204:
   name: "LEGO Racers 2"
   region: "NTSC-J"
+  gsHWFixes:
+    textureInsideRT: 1 # Fixes top left corner rendering.
 SLPM-62205:
   name: "Virtua Cop Re-Birth"
   region: "NTSC-J"
@@ -32595,6 +32607,7 @@ SLPM-66419:
   gsHWFixes:
     halfPixelOffset: 1 # Reduces bloom misalignment.
     roundSprite: 1 # Fixes area transition vertical lines and lessens red forest vertical lines.
+    textureInsideRT: 1 # Required for swirl battle transition.
 SLPM-66420:
   name: "Front Mission 4 [Ultimate Hits]"
   region: "NTSC-J"
@@ -34048,6 +34061,7 @@ SLPM-66782:
   gsHWFixes:
     halfPixelOffset: 1 # Reduces bloom misalignment.
     roundSprite: 1 # Fixes area transition vertical lines and lessens red forest vertical lines.
+    textureInsideRT: 1 # Required for swirl battle transition.
 SLPM-66783:
   name: "Idol Janshi Suchie-Pai 4 [Limited Edition]"
   region: "NTSC-J"
@@ -40905,6 +40919,8 @@ SLUS-20042:
   name: "LEGO Racers 2"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    textureInsideRT: 1 # Fixes top left corner rendering.
 SLUS-20043:
   name: "Star Wars - Super Bombad Racing"
   region: "NTSC-U"
@@ -47878,6 +47894,7 @@ SLUS-21452:
   gsHWFixes:
     halfPixelOffset: 1 # Reduces bloom misalignment.
     roundSprite: 1 # Fixes area transition vertical lines.
+    textureInsideRT: 1 # Required for swirl battle transition.
 SLUS-21453:
   name: "Disney's Meet the Robinsons"
   region: "NTSC-U"

--- a/pcsx2/GS/Renderers/Common/GSDirtyRect.cpp
+++ b/pcsx2/GS/Renderers/Common/GSDirtyRect.cpp
@@ -31,7 +31,7 @@ GSDirtyRect::GSDirtyRect(GSVector4i& r, u32 psm, u32 bw) :
 {
 }
 
-GSVector4i GSDirtyRect::GetDirtyRect(GIFRegTEX0& TEX0)
+GSVector4i GSDirtyRect::GetDirtyRect(GIFRegTEX0 TEX0) const
 {
 	GSVector4i _r;
 
@@ -54,7 +54,7 @@ GSVector4i GSDirtyRect::GetDirtyRect(GIFRegTEX0& TEX0)
 	return _r;
 }
 
-GSVector4i GSDirtyRectList::GetTotalRect(GIFRegTEX0& TEX0, const GSVector2i& size)
+GSVector4i GSDirtyRectList::GetTotalRect(GIFRegTEX0 TEX0, const GSVector2i& size) const
 {
 	if (!empty())
 	{
@@ -73,31 +73,12 @@ GSVector4i GSDirtyRectList::GetTotalRect(GIFRegTEX0& TEX0, const GSVector2i& siz
 	return GSVector4i::zero();
 }
 
-GSVector4i GSDirtyRectList::GetDirtyRect(GIFRegTEX0& TEX0, const GSVector2i& size, bool clear)
+GSVector4i GSDirtyRectList::GetDirtyRect(size_t index, GIFRegTEX0 TEX0, const GSVector4i& clamp) const
 {
-	if (!empty())
-	{
-		const std::vector<GSDirtyRect>::iterator &it = begin();
-		const GSVector4i r = it[0].GetDirtyRect(TEX0);
+	const GSVector4i r = (*this)[index].GetDirtyRect(TEX0);
 
-		if (clear)
-			erase(it);
+	GSVector2i bs = GSLocalMemory::m_psm[TEX0.PSM].bs;
 
-		GSVector2i bs = GSLocalMemory::m_psm[TEX0.PSM].bs;
-
-		return r.ralign<Align_Outside>(bs).rintersect(GSVector4i(0, 0, size.x, size.y));
-	}
-
-	return GSVector4i::zero();
+	return r.ralign<Align_Outside>(bs).rintersect(clamp);
 }
 
-GSVector4i GSDirtyRectList::GetDirtyRectAndClear(GIFRegTEX0& TEX0, const GSVector2i& size)
-{
-	const GSVector4i r = GetDirtyRect(TEX0, size, true);
-	return r;
-}
-
-void GSDirtyRectList::ClearDirty()
-{
-	clear();
-}

--- a/pcsx2/GS/Renderers/Common/GSDirtyRect.h
+++ b/pcsx2/GS/Renderers/Common/GSDirtyRect.h
@@ -26,15 +26,13 @@ public:
 
 	GSDirtyRect();
 	GSDirtyRect(GSVector4i& r, u32 psm, u32 bw);
-	GSVector4i GetDirtyRect(GIFRegTEX0& TEX0);
+	GSVector4i GetDirtyRect(GIFRegTEX0 TEX0) const;
 };
 
 class GSDirtyRectList : public std::vector<GSDirtyRect>
 {
 public:
 	GSDirtyRectList() {}
-	GSVector4i GetTotalRect(GIFRegTEX0& TEX0, const GSVector2i& size);
-	GSVector4i GetDirtyRect(GIFRegTEX0& TEX0, const GSVector2i& size, bool clear = false);
-	GSVector4i GetDirtyRectAndClear(GIFRegTEX0& TEX0, const GSVector2i& size);
-	void ClearDirty();
+	GSVector4i GetTotalRect(GIFRegTEX0 TEX0, const GSVector2i& size) const;
+	GSVector4i GetDirtyRect(size_t index, GIFRegTEX0 TEX0, const GSVector4i& clamp) const;
 };

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -1347,13 +1347,23 @@ void GSTextureCache::InvalidateVideoMem(const GSOffset& off, const GSVector4i& r
 				}
 				else if (GSConfig.UserHacks_TextureInsideRt && t->Overlaps(bp, bw, psm, rect) && GSUtil::HasCompatibleBits(psm, t->m_TEX0.PSM))
 				{
-					const SurfaceOffset so = ComputeSurfaceOffset(off, r, t);
+					SurfaceOffsetKey sok;
+					sok.elems[0].bp = bp;
+					sok.elems[0].bw = bw;
+					sok.elems[0].psm = psm;
+					sok.elems[0].rect = r;
+					sok.elems[1].bp = t->m_TEX0.TBP0;
+					sok.elems[1].bw = t->m_TEX0.TBW;
+					sok.elems[1].psm = t->m_TEX0.PSM;
+					sok.elems[1].rect = t->m_valid;
+
+					const SurfaceOffset so = ComputeSurfaceOffset(sok);
 					if (so.is_valid)
 					{
 						if (eewrite)
 							t->m_age = 0;
 
-						AddDirtyRectTarget(t, so.b2a_offset, psm, bw);
+						AddDirtyRectTarget(t, so.b2a_offset, t->m_TEX0.PSM, t->m_TEX0.TBW);
 					}
 				}
 #endif

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -416,7 +416,7 @@ GSTextureCache::Source* GSTextureCache::LookupSource(const GIFRegTEX0& TEX0, con
 				}
 				// Make sure the texture actually is INSIDE the RT, it's possibly not valid if it isn't.
 				// Also check BP >= TBP, create source isn't equpped to expand it backwards and all data comes from the target. (GH3)
-				else if (GSConfig.UserHacks_TextureInsideRt && psm == PSM_PSMCT32 && t->m_TEX0.PSM == psm &&
+				else if (GSConfig.UserHacks_TextureInsideRt && psm >= PSM_PSMCT32 && psm <= PSM_PSMCT16S && t->m_TEX0.PSM == psm &&
 						(t->Overlaps(bp, bw, psm, r) || t_wraps) && t->m_age <= 1 && !found_t && bp >= t->m_TEX0.TBP0)
 				{
 					// Only PSMCT32 to limit false hits.


### PR DESCRIPTION
### Description of Changes

What the title says.

~~NOTE: I still need to give this a GS runner pass, haven't hit any cases that do offset updates yet to verify that this part still works.~~

The tex-in-rt invalidation was using the incoming (usually an EE write) PSM/BW, but dirtying a rectangle in the target's coordinate space. This lead to a bunch of large dirty rects with a BW of 1 in VP2, which caused corruption during the battle fade transition.

### Rationale behind Changes

Fewer texture uploads makes Intel GPUs happy.

Fixes swirl battle transition in Valkyrie Profile 2.
Fixes top-left screen rendering in Lego Racers 2.

Fixes track in GH3 (crowds are still broken).
![image](https://user-images.githubusercontent.com/11288319/218294450-695b1115-1816-46f9-8f91-5b265b51eb21.png)

Need to confirm if it `fixes` #4349.

Fixes #4816.

### Suggested Testing Steps

Test games which use RT updates.
