### PR TITLE
GameDB: Port COP2 patch for Disneys Cars

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -18828,6 +18828,13 @@ SLES-54013:
 SLES-54015:
   name: "Disney-Pixar's Cars"
   region: "PAL-SC"
+  patches:
+    B36778F5:
+      content: |-
+        author=refraction ported by jordanthetoast
+        // COP2 Rearrangement. Fixes broken collisions.
+        patch=1,EE,00203df8,word,484e9000
+        patch=1,EE,00203dfc,word,4bdbd9ff
 SLES-54016:
   name: "AND 1 Streetball"
   region: "PAL-M5"


### PR DESCRIPTION
### Description of Changes
Ports patch to fix broken collisions to PAL Disney's Cars

### Rationale behind Changes
SPS is bad and gross.

### Suggested Testing Steps
Make sure the SPS is fixed and the game functions correctly.
