### PR TITLE
GS: Make resets more deterministic

### DIFF
--- a/pcsx2/Frontend/InputManager.cpp
+++ b/pcsx2/Frontend/InputManager.cpp
@@ -1222,16 +1222,18 @@ void InputManager::ReloadBindings(SettingsInterface& si, SettingsInterface& bind
 	for (u32 pad = 0; pad < PAD::NUM_CONTROLLER_PORTS; pad++)
 		AddPadBindings(binding_si, pad, PAD::GetDefaultPadType(pad));
 
-	const float ui_ctrl_range = 100.0f;
-	const float pointer_sensitivity = 0.05;
+	constexpr float ui_ctrl_range = 100.0f;
+	constexpr float pointer_sensitivity = 0.05f;
 	for (u32 axis = 0; axis <= static_cast<u32>(InputPointerAxis::Y); axis++)
 	{
-		s_pointer_axis_speed[axis]     = si.GetFloatValue("Pad", fmt::format("Pointer{}Speed", s_pointer_axis_names[axis]).c_str(), 40.0f) / ui_ctrl_range * pointer_sensitivity;
-		s_pointer_axis_dead_zone[axis] = std::min(si.GetFloatValue("Pad", fmt::format("Pointer{}DeadZone", s_pointer_axis_names[axis]).c_str(), 20.0f) / ui_ctrl_range, 1.0f);
-		s_pointer_axis_range[axis]     = 1.0f - s_pointer_axis_dead_zone[axis];
+		s_pointer_axis_speed[axis] = si.GetFloatValue("Pad", fmt::format("Pointer{}Speed", s_pointer_axis_names[axis]).c_str(), 40.0f) /
+									 ui_ctrl_range * pointer_sensitivity;
+		s_pointer_axis_dead_zone[axis] = std::min(
+			si.GetFloatValue("Pad", fmt::format("Pointer{}DeadZone", s_pointer_axis_names[axis]).c_str(), 20.0f) / ui_ctrl_range, 1.0f);
+		s_pointer_axis_range[axis] = 1.0f - s_pointer_axis_dead_zone[axis];
 	}
-	s_pointer_inertia = si.GetFloatValue("Pad", fmt::format("PointerInertia").c_str(), 0.0f) / ui_ctrl_range;
-	s_pointer_pos = {0.0f, 0.0f};
+	s_pointer_inertia = si.GetFloatValue("Pad", "PointerInertia", 10.0f) / ui_ctrl_range;
+	s_pointer_pos = {};
 
 	for (u32 port = 0; port < USB::NUM_PORTS; port++)
 		AddUSBBindings(binding_si, port);

--- a/pcsx2/GS/GSLocalMemory.h
+++ b/pcsx2/GS/GSLocalMemory.h
@@ -481,7 +481,7 @@ public:
 	static psm_t m_psm[64];
 	static readImage m_readImageX;
 
-	static const int m_vmsize = 1024 * 1024 * 4;
+	static constexpr int m_vmsize = 1024 * 1024 * 4;
 
 	u8* m_vm8;
 

--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -226,7 +226,7 @@ public:
 	std::unique_ptr<GSDumpBase> m_dump;
 	bool m_nativeres = false;
 	bool m_mipmap = false;
-	bool m_force_preload = false;
+	u8 m_force_preload = 0;
 	u32 m_dirty_gs_regs = 0;
 	int m_backed_up_ctx = 0;
 	std::vector<GSUploadQueue> m_draw_transfers;

--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -35,13 +35,15 @@ public:
 	GSState();
 	virtual ~GSState();
 
+	static constexpr int GetSaveStateSize();
+
 private:
 	// RESTRICT prevents multiple loads of the same part of the register when accessing its bitfields (the compiler is happy to know that memory writes in-between will not go there)
 
 	typedef void (GSState::*GIFPackedRegHandler)(const GIFPackedReg* RESTRICT r);
 
-	GIFPackedRegHandler m_fpGIFPackedRegHandlers[16];
-	GIFPackedRegHandler m_fpGIFPackedRegHandlerXYZ[8][4];
+	GIFPackedRegHandler m_fpGIFPackedRegHandlers[16] = {};
+	GIFPackedRegHandler m_fpGIFPackedRegHandlerXYZ[8][4] = {};
 
 	void CheckFlushes();
 
@@ -58,14 +60,14 @@ private:
 
 	typedef void (GSState::*GIFRegHandler)(const GIFReg* RESTRICT r);
 
-	GIFRegHandler m_fpGIFRegHandlers[256];
-	GIFRegHandler m_fpGIFRegHandlerXYZ[8][4];
+	GIFRegHandler m_fpGIFRegHandlers[256] = {};
+	GIFRegHandler m_fpGIFRegHandlerXYZ[8][4] = {};
 
 	typedef void (GSState::*GIFPackedRegHandlerC)(const GIFPackedReg* RESTRICT r, u32 size);
 
-	GIFPackedRegHandlerC m_fpGIFPackedRegHandlersC[2];
-	GIFPackedRegHandlerC m_fpGIFPackedRegHandlerSTQRGBAXYZF2[8];
-	GIFPackedRegHandlerC m_fpGIFPackedRegHandlerSTQRGBAXYZ2[8];
+	GIFPackedRegHandlerC m_fpGIFPackedRegHandlersC[2] = {};
+	GIFPackedRegHandlerC m_fpGIFPackedRegHandlerSTQRGBAXYZF2[8] = {};
+	GIFPackedRegHandlerC m_fpGIFPackedRegHandlerSTQRGBAXYZ2[8] = {};
 
 	template<u32 prim, bool auto_flush, bool index_swap> void GIFPackedRegHandlerSTQRGBAXYZF2(const GIFPackedReg* RESTRICT r, u32 size);
 	template<u32 prim, bool auto_flush, bool index_swap> void GIFPackedRegHandlerSTQRGBAXYZ2(const GIFPackedReg* RESTRICT r, u32 size);
@@ -117,15 +119,12 @@ private:
 	template<bool auto_flush, bool index_swap>
 	void SetPrimHandlers();
 
-	u32 m_version;
-	int m_sssize;
-
 	struct GSTransferBuffer
 	{
-		int x, y;
-		int start, end, total;
-		u8* buff;
-		GIFRegBITBLTBUF m_blit;
+		int x = 0, y = 0;
+		int start = 0, end = 0, total = 0;
+		u8* buff = nullptr;
+		GIFRegBITBLTBUF m_blit = {};
 
 		GSTransferBuffer();
 		virtual ~GSTransferBuffer();
@@ -139,14 +138,14 @@ private:
 	void CalcAlphaMinMax();
 
 protected:
-	GSVertex m_v;
-	float m_q;
-	GSVector4i m_scissor;
-	GSVector4i m_ofxy;
+	GSVertex m_v = {};
+	float m_q = 1.0f;
+	GSVector4i m_scissor = {};
+	GSVector4i m_ofxy = {};
 
-	u8 m_scanmask_used;
-	bool tex_flushed;
-	bool m_isPackedUV_HackFlag;
+	u8 m_scanmask_used = 0;
+	bool tex_flushed = true;
+	bool m_isPackedUV_HackFlag = false;
 
 	struct
 	{
@@ -154,13 +153,13 @@ protected:
 		u32 head, tail, next, maxcount; // head: first vertex, tail: last vertex + 1, next: last indexed + 1
 		u32 xy_tail;
 		u64 xy[4];
-	} m_vertex;
+	} m_vertex = {};
 
 	struct
 	{
 		u32* buff;
 		u32 tail;
-	} m_index;
+	} m_index = {};
 
 	void UpdateContext();
 	void UpdateScissor();
@@ -213,24 +212,24 @@ public:
 		int draw;
 	};
 
-	GIFPath m_path[4];
-	GIFRegPRIM* PRIM;
-	GSPrivRegSet* m_regs;
+	GIFPath m_path[4] = {};
+	GIFRegPRIM* PRIM = nullptr;
+	GSPrivRegSet* m_regs = nullptr;
 	GSLocalMemory m_mem;
-	GSDrawingEnvironment m_env;
-	GSDrawingEnvironment m_backup_env;
-	GSDrawingEnvironment m_prev_env;
-	GSVector4i temp_draw_rect;
-	GSDrawingContext* m_context;
-	u32 m_crc;
-	CRC::Game m_game;
+	GSDrawingEnvironment m_env = {};
+	GSDrawingEnvironment m_backup_env = {};
+	GSDrawingEnvironment m_prev_env = {};
+	GSVector4i temp_draw_rect = {};
+	GSDrawingContext* m_context = nullptr;
+	u32 m_crc = 0;
+	CRC::Game m_game = {};
 	std::unique_ptr<GSDumpBase> m_dump;
-	bool m_nativeres;
-	bool m_mipmap;
-	u32 m_dirty_gs_regs;
-	int m_backed_up_ctx;
+	bool m_nativeres = false;
+	bool m_mipmap = false;
+	bool m_force_preload = false;
+	u32 m_dirty_gs_regs = 0;
+	int m_backed_up_ctx = 0;
 	std::vector<GSUploadQueue> m_draw_transfers;
-	bool m_force_preload;
 
 	static int s_n;
 
@@ -278,7 +277,7 @@ public:
 		GSREOPEN = 1 << 13,
 	};
 
-	GSFlushReason m_state_flush_reason;
+	GSFlushReason m_state_flush_reason = UNKNOWN;
 
 	enum PRIM_OVERLAP
 	{
@@ -287,7 +286,7 @@ public:
 		PRIM_OVERLAP_NO
 	};
 
-	PRIM_OVERLAP m_prim_overlap;
+	PRIM_OVERLAP m_prim_overlap = PRIM_OVERLAP_UNKNOW;
 	std::vector<size_t> m_drawlist;
 
 	struct GSPCRTCRegs
@@ -297,31 +296,31 @@ public:
 		// these values leave a small black line on the right in a bunch of games, but it's not so bad.
 		// The only conclusion I can come to is there is horizontal overscan expected so there would normally
 		// be black borders either side anyway, or both sides slightly covered.
-		const GSVector4i VideoModeOffsets[6] = {
-			GSVector4i(640, 224, 642, 25),
-			GSVector4i(640, 256, 676, 36),
-			GSVector4i(640, 480, 276, 34),
-			GSVector4i(720, 480, 232, 35),
-			GSVector4i(1280, 720, 302, 24),
-			GSVector4i(1920, 540, 238, 40)
+		static inline constexpr GSVector4i VideoModeOffsets[6] = {
+			GSVector4i::cxpr(640, 224, 642, 25),
+			GSVector4i::cxpr(640, 256, 676, 36),
+			GSVector4i::cxpr(640, 480, 276, 34),
+			GSVector4i::cxpr(720, 480, 232, 35),
+			GSVector4i::cxpr(1280, 720, 302, 24),
+			GSVector4i::cxpr(1920, 540, 238, 40)
 		};
 
-		const GSVector4i VideoModeOffsetsOverscan[6] = {
-			GSVector4i(711, 243, 498, 12),
-			GSVector4i(702, 288, 532, 18),
-			GSVector4i(640, 480, 276, 34),
-			GSVector4i(720, 480, 232, 35),
-			GSVector4i(1280, 720, 302, 24),
-			GSVector4i(1920, 540, 238, 40)
+		static inline constexpr GSVector4i VideoModeOffsetsOverscan[6] = {
+			GSVector4i::cxpr(711, 243, 498, 12),
+			GSVector4i::cxpr(702, 288, 532, 18),
+			GSVector4i::cxpr(640, 480, 276, 34),
+			GSVector4i::cxpr(720, 480, 232, 35),
+			GSVector4i::cxpr(1280, 720, 302, 24),
+			GSVector4i::cxpr(1920, 540, 238, 40)
 		};
 
-		const GSVector4i VideoModeDividers[6] = {
-			GSVector4i(3, 0, 2559, 239),
-			GSVector4i(3, 0, 2559, 287),
-			GSVector4i(1, 0, 1279, 479),
-			GSVector4i(1, 0, 1439, 479),
-			GSVector4i(0, 0, 1279, 719),
-			GSVector4i(0, 0, 1919, 1079)
+		static inline constexpr GSVector4i VideoModeDividers[6] = {
+			GSVector4i::cxpr(3, 0, 2559, 239),
+			GSVector4i::cxpr(3, 0, 2559, 287),
+			GSVector4i::cxpr(1, 0, 1279, 479),
+			GSVector4i::cxpr(1, 0, 1439, 479),
+			GSVector4i::cxpr(0, 0, 1279, 719),
+			GSVector4i::cxpr(0, 0, 1919, 1079)
 		};
 
 		struct PCRTCDisplay
@@ -345,12 +344,12 @@ public:
 			}
 		};
 
-		int videomode;
-		int interlaced;
-		int FFMD;
-		bool PCRTCSameSrc;
-		bool toggling_field;
-		PCRTCDisplay PCRTCDisplays[2];
+		int videomode = 0;
+		int interlaced = 0;
+		int FFMD = 0;
+		bool PCRTCSameSrc = false;
+		bool toggling_field = false;
+		PCRTCDisplay PCRTCDisplays[2] = {};
 
 		bool IsAnalogue()
 		{

--- a/pcsx2/GS/Renderers/Common/GSVertexTrace.cpp
+++ b/pcsx2/GS/Renderers/Common/GSVertexTrace.cpp
@@ -19,10 +19,8 @@
 #include "GS/GSState.h"
 
 GSVertexTrace::GSVertexTrace(const GSState* state, bool provoking_vertex_first)
-	: m_accurate_stq(false), m_state(state), m_primclass(GS_INVALID_CLASS)
+	: m_state(state)
 {
-	memset(&m_alpha, 0, sizeof(m_alpha));
-
 	MULTI_ISA_SELECT(GSVertexTracePopulateFunctions)(*this, provoking_vertex_first);
 }
 

--- a/pcsx2/GS/Renderers/Common/GSVertexTrace.h
+++ b/pcsx2/GS/Renderers/Common/GSVertexTrace.h
@@ -44,7 +44,7 @@ public:
 		int min, max;
 		bool valid;
 	};
-	bool m_accurate_stq;
+	bool m_accurate_stq = false;
 
 protected:
 	const GSState* m_state;
@@ -54,25 +54,25 @@ protected:
 	FindMinMaxPtr m_fmm[2][2][2][2][4];
 
 public:
-	GS_PRIM_CLASS m_primclass;
+	GS_PRIM_CLASS m_primclass = GS_INVALID_CLASS;
 
-	Vertex m_min;
-	Vertex m_max;
-	VertexAlpha m_alpha; // source alpha range after tfx, GSRenderer::GetAlphaMinMax() updates it
+	Vertex m_min = {};
+	Vertex m_max = {};
+	VertexAlpha m_alpha = {}; // source alpha range after tfx, GSRenderer::GetAlphaMinMax() updates it
 
 	union
 	{
 		u32 value;
 		struct { u32 r:4, g:4, b:4, a:4, x:1, y:1, z:1, f:1, s:1, t:1, q:1, _pad:1; };
 		struct { u32 rgba:16, xyzf:4, stq:4; };
-	} m_eq;
+	} m_eq = {};
 
 	union
 	{
 		struct { u32 mmag:1, mmin:1, linear:1, opt_linear:1; };
-	} m_filter;
+	} m_filter = {};
 
-	GSVector2 m_lod; // x = min, y = max
+	GSVector2 m_lod = {}; // x = min, y = max
 
 public:
 	GSVertexTrace(const GSState* state, bool provoking_vertex_first);

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -24,14 +24,6 @@
 GSRendererHW::GSRendererHW()
 	: GSRenderer()
 	, m_tc(new GSTextureCache())
-	, m_src(nullptr)
-	, m_reset(false)
-	, m_tex_is_fb(false)
-	, m_channel_shuffle(false)
-	, m_userhacks_tcoffset(false)
-	, m_userhacks_tcoffset_x(0)
-	, m_userhacks_tcoffset_y(0)
-	, m_lod(GSVector2i(0, 0))
 {
 	MULTI_ISA_SELECT(GSRendererHWPopulateFunctions)(*this);
 	m_mipmap = (GSConfig.HWMipmap >= HWMipmapLevel::Basic);
@@ -44,7 +36,6 @@ GSRendererHW::GSRendererHW()
 
 	memset(&m_conf, 0, sizeof(m_conf));
 
-	m_prim_overlap = PRIM_OVERLAP_UNKNOW;
 	ResetStates();
 }
 

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.h
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.h
@@ -97,8 +97,8 @@ private:
 	void SetTCOffset();
 
 	GSTextureCache* m_tc;
-	GSVector4i m_r;
-	GSTextureCache::Source* m_src;
+	GSVector4i m_r = {};
+	GSTextureCache::Source* m_src = nullptr;
 
 	// CRC Hacks
 	bool IsBadFrame();
@@ -107,16 +107,16 @@ private:
 	int m_skip = 0;
 	int m_skip_offset = 0;
 
-	bool m_reset;
-	bool m_tex_is_fb;
-	bool m_channel_shuffle;
-	bool m_userhacks_tcoffset;
-	float m_userhacks_tcoffset_x;
-	float m_userhacks_tcoffset_y;
+	bool m_reset = false;
+	bool m_tex_is_fb = false;
+	bool m_channel_shuffle = false;
+	bool m_userhacks_tcoffset = false;
+	float m_userhacks_tcoffset_x = 0.0f;
+	float m_userhacks_tcoffset_y = 0.0f;
 
-	GSVector2i m_lod; // Min & Max level of detail
+	GSVector2i m_lod = {}; // Min & Max level of detail
 
-	GSHWDrawConfig m_conf;
+	GSHWDrawConfig m_conf = {};
 
 	// software sprite renderer state
 	std::vector<GSVertexSW> m_sw_vertex_buffer;

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.h
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.h
@@ -107,7 +107,6 @@ private:
 	int m_skip = 0;
 	int m_skip_offset = 0;
 
-	bool m_reset = false;
 	bool m_tex_is_fb = false;
 	bool m_channel_shuffle = false;
 	bool m_userhacks_tcoffset = false;

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -43,22 +43,7 @@ GSTextureCache::~GSTextureCache()
 
 	RemoveAll();
 
-	m_surface_offset_cache.clear();
-
 	_aligned_free(s_unswizzle_buffer);
-}
-
-void GSTextureCache::RemovePartial()
-{
-	//m_src.RemoveAll();
-
-	for (int type = 0; type < 2; type++)
-	{
-		for (auto t : m_dst[type])
-			delete t;
-
-		m_dst[type].clear();
-	}
 }
 
 void GSTextureCache::RemoveAll()
@@ -85,6 +70,8 @@ void GSTextureCache::RemoveAll()
 
 	m_source_memory_usage = 0;
 	m_target_memory_usage = 0;
+
+	m_surface_offset_cache.clear();
 }
 
 void GSTextureCache::AddDirtyRectTarget(Target* target, GSVector4i rect, u32 psm, u32 bw)

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -775,16 +775,17 @@ GSTextureCache::Target* GSTextureCache::LookupTarget(const GIFRegTEX0& TEX0, con
 		// From a performance point of view, it might cost a little on big upscaling
 		// but normally few RT are miss so it must remain reasonable.
 		const bool supported_fmt = !GSConfig.UserHacks_DisableDepthSupport || psm_s.depth == 0;
-		const bool forced_preload = static_cast<GSRendererHW*>(g_gs_renderer.get())->m_force_preload;
+		const bool forced_preload = GSRendererHW::GetInstance()->m_force_preload > 0;
 		if ((is_frame || preload || forced_preload) && TEX0.TBW > 0 && supported_fmt)
 		{
 			if (!is_frame && !forced_preload)
 			{
 				std::vector<GSState::GSUploadQueue>::iterator iter;
-				for (iter = static_cast<GSRendererHW*>(g_gs_renderer.get())->m_draw_transfers.begin(); iter != static_cast<GSRendererHW*>(g_gs_renderer.get())->m_draw_transfers.end(); ) {
+				for (iter = GSRendererHW::GetInstance()->m_draw_transfers.begin(); iter != GSRendererHW::GetInstance()->m_draw_transfers.end(); )
+				{
 					if (iter->blit.DBP == TEX0.TBP0 && GSUtil::HasSharedBits(iter->blit.DPSM, TEX0.PSM))
 					{
-						iter = static_cast<GSRendererHW*>(g_gs_renderer.get())->m_draw_transfers.erase(iter);
+						GSRendererHW::GetInstance()->m_draw_transfers.erase(iter);
 						GL_INS("Preloading the RT DATA");
 						const GSVector4i newrect = GSVector4i(0, 0, real_w, real_h);
 						AddDirtyRectTarget(dst, newrect, TEX0.PSM, TEX0.TBW);

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.h
@@ -395,7 +395,6 @@ public:
 	void Read(Target* t, const GSVector4i& r);
 	void Read(Source* t, const GSVector4i& r);
 	void RemoveAll();
-	void RemovePartial();
 	void AddDirtyRectTarget(Target* target, GSVector4i rect, u32 psm, u32 bw);
 
 	GSTexture* LookupPaletteSource(u32 CBP, u32 CPSM, u32 CBW, GSVector2i& offset, const GSVector2i& size);


### PR DESCRIPTION
### Description of Changes

Cleanup of GSState, making sure everything is initialized.

Also get rid of RemovePartial(), it's never called.

### Rationale behind Changes

Everything should be reset when we, well, reset, or load state.

PCSX2 should be deterministic :P

### Suggested Testing Steps

Make sure load state works. Check games sensitive to target preloading.
