### PR TITLE
GS/HW: Don't age texture cache on idle frames

### DIFF
--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -26,6 +26,7 @@
 #include <iomanip> // Dump Verticles
 
 int GSState::s_n = 0;
+int GSState::s_transfer_n = 0;
 
 static __fi bool IsAutoFlushEnabled()
 {
@@ -1520,6 +1521,7 @@ void GSState::FlushWrite()
 	m_tr.start += len;
 
 	g_perfmon.Put(GSPerfMon::Swizzle, len);
+	s_transfer_n++;
 }
 
 // This function decides if the context has changed in a way which warrants flushing the draw.
@@ -1788,6 +1790,7 @@ void GSState::Write(const u8* mem, int len)
 		m_tr.start = m_tr.end = m_tr.total;
 
 		g_perfmon.Put(GSPerfMon::Swizzle, len);
+		s_transfer_n++;
 	}
 	else
 	{
@@ -1854,6 +1857,7 @@ void GSState::Move()
 {
 	// ffxii uses this to move the top/bottom of the scrolling menus offscreen and then blends them back over the text to create a shading effect
 	// guitar hero copies the far end of the board to do a similar blend too
+	s_transfer_n++;
 
 	int sx = m_env.TRXPOS.SSAX;
 	int sy = m_env.TRXPOS.SSAY;

--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -232,6 +232,7 @@ public:
 	std::vector<GSUploadQueue> m_draw_transfers;
 
 	static int s_n;
+	static int s_transfer_n;
 
 	static constexpr u32 STATE_VERSION = 8;
 

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.h
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.h
@@ -122,6 +122,10 @@ private:
 	std::unique_ptr<GSTextureCacheSW::Texture> m_sw_texture[7 + 1];
 	std::unique_ptr<GSVirtualAlignedClass<32>> m_sw_rasterizer;
 
+	// Tracking draw counters for idle frame detection.
+	int m_last_draw_n = 0;
+	int m_last_transfer_n = 0;
+
 public:
 	GSRendererHW();
 	virtual ~GSRendererHW() override;


### PR DESCRIPTION
### Description of Changes

Xenosaga does its moves for the fade transition between scenes, but since it's all handled in hw now, when there's a loading screen longer than 400 frames/6.6 seconds, it removes the target, which means junk from local memory gets loaded.

This PR changes the TC aging so that it only increments when there were actually draws/transfers in the frame. In other words, during Xenosaga's black loading screens, it won't age the targets, and the fade transition should be correct.

### Rationale behind Changes

Fixes #6625.

Fixes flicker in loading screen fade in WWE SmackDown Here Comes the Pain.

Partially fixes menu background in King's Field.

### Suggested Testing Steps

Test Xenosaga loading screen transitions, not just cutscene transitions.
