### PR TITLE
CDVD: Fix FreeBSD compile.

### DIFF
--- a/pcsx2/CDVD/Darwin/IOCtlSrc.cpp
+++ b/pcsx2/CDVD/Darwin/IOCtlSrc.cpp
@@ -66,6 +66,7 @@ bool IOCtlSrc::Reopen()
 
 void IOCtlSrc::SetSpindleSpeed(bool restore_defaults) const
 {
+#ifdef __APPLE__
 	u16 speed = restore_defaults ? 0xFFFF : m_media_type >= 0 ? 5540 :
 																3600;
 	int ioctl_code = m_media_type >= 0 ? DKIOCDVDSETSPEED : DKIOCCDSETSPEED;
@@ -77,6 +78,10 @@ void IOCtlSrc::SetSpindleSpeed(bool restore_defaults) const
 	{
 		DevCon.WriteLn("CDVD: Spindle speed set to %d", speed);
 	}
+#else
+	// FIXME: FreeBSD equivalent for DKIOCDVDSETSPEED DKIOCCDSETSPEED.
+	DevCon.Warning("CDVD: Setting spindle speed not supported!");
+#endif
 }
 
 u32 IOCtlSrc::GetSectorCount() const


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
CDVD: Fix FreeBSD compile.
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
No physical disc support on FreeBSD, DKIOCDVDSETSPEED DKIOCCDSETSPEED are apple only.
Regression from #7603
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
FreeBSD compiles, ci passes.