### PR TITLE
GameDB: Fixes for battle graphics in Mana Khemia 2

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -24522,6 +24522,8 @@ SLPM-55005:
   region: "NTSC-J"
   gsHWFixes:
     roundSprite: 1 # Fixes lines in sprites but still some lines left.
+  speedHacks:
+    mvuFlagSpeedHack: 0 # Fixes missing graphical effects.
 SLPM-55008:
   name: "Sengoku Basara X"
   region: "NTSC-J"
@@ -24689,6 +24691,8 @@ SLPM-55114:
   region: "NTSC-J"
   gsHWFixes:
     roundSprite: 1 # Fixes lines in sprites but still some lines left.
+  speedHacks:
+    mvuFlagSpeedHack: 0 # Fixes missing graphical effects.
 SLPM-55117:
   name: "beatmania IIDX 15 DJ TROOPERS"
   region: "NTSC-J"
@@ -49863,6 +49867,8 @@ SLUS-21890:
   compat: 5
   gsHWFixes:
     roundSprite: 1 # Fixes lines in sprites but still some lines left.
+  speedHacks:
+    mvuFlagSpeedHack: 0 # Fixes missing graphical effects.
 SLUS-21891:
   name: "G-Force"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
Fixes missing graphical effects in battles by disabling mvu speedhack.

### Rationale behind Changes
My god the shiny lights they are so sparkly.

### Suggested Testing Steps
Make sure CI is a happy boi.
