### PR TITLE
GS: Preload whenever it matches an upload. GUI option forces preloads.

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -1494,6 +1494,10 @@ SCAJ-25034:
 SCAJ-25037:
   name: "Astro Boy Atom"
   region: "NTSC-Unk"
+  roundModes:
+    eeRoundMode: 0 # Fixes character behaviour.
+  gsHWFixes:
+    autoFlush: 1 # Fixes flame bloom.
 SCAJ-25045:
   name: "Sakura Taisen V - Episode 0"
   region: "NTSC-Unk"
@@ -8933,6 +8937,10 @@ SLAJ-25035:
 SLAJ-25037:
   name: "Astro Boy Atom"
   region: "NTSC-Unk"
+  roundModes:
+    eeRoundMode: 0 # Fixes character behaviour.
+  gsHWFixes:
+    autoFlush: 1 # Fixes flame bloom.
 SLAJ-25039:
   name: "Beni no Umi 2"
   region: "NTSC-Unk"
@@ -9291,6 +9299,8 @@ SLED-52485:
   region: "PAL-E"
   gsHWFixes:
     cpuCLUTRender: 1 # Fixes lights penetrating objects.
+    autoFlush: 1 # Helps with the light penetration problem.
+    cpuSpriteRenderBW: 1 # Fixes light glows.
 SLED-52488:
   name: "Suffering, The [Demo]"
   region: "PAL-E"
@@ -13403,11 +13413,15 @@ SLES-51821:
   region: "PAL-M5"
   gsHWFixes:
     cpuCLUTRender: 1 # Fixes lights penetrating objects.
+    autoFlush: 1 # Helps with the light penetration problem.
+    cpuSpriteRenderBW: 1 # Fixes light glows.
 SLES-51822:
   name: "Alias"
   region: "PAL-I"
   gsHWFixes:
     cpuCLUTRender: 1 # Fixes lights penetrating objects.
+    autoFlush: 1 # Helps with the light penetration problem.
+    cpuSpriteRenderBW: 1 # Fixes light glows.
 SLES-51823:
   name: "Hunter - The Reckoning Wayward"
   region: "PAL-M3"
@@ -14840,6 +14854,8 @@ SLES-52486:
   region: "PAL-M5"
   roundModes:
     eeRoundMode: 0 # Fixes character behaviour.
+  gsHWFixes:
+    autoFlush: 1 # Fixes flame bloom.
 SLES-52490:
   name: "Dance UK - Extra Trax"
   region: "PAL-E"
@@ -23724,6 +23740,8 @@ SLKA-25159:
   region: "NTSC-K"
   roundModes:
     eeRoundMode: 0 # Fixes character behaviour.
+  gsHWFixes:
+    autoFlush: 1 # Fixes flame bloom.
 SLKA-25160:
   name: "Shin Megami Tensei III - Nocturne Maniax"
   region: "NTSC-K"
@@ -29457,6 +29475,8 @@ SLPM-65551:
   region: "NTSC-J"
   roundModes:
     eeRoundMode: 0 # Fixes character behaviour.
+  gsHWFixes:
+    autoFlush: 1 # Fixes flame bloom.
 SLPM-65552:
   name: "Metal Wolf Rev [Limited Edition]"
   region: "NTSC-J"
@@ -43737,6 +43757,8 @@ SLUS-20673:
   compat: 5
   gsHWFixes:
     cpuCLUTRender: 1 # Fixes lights penetrating objects.
+    autoFlush: 1 # Helps with the light penetration problem.
+    cpuSpriteRenderBW: 1 # Fixes light glows.
 SLUS-20674:
   name: "Cyber Troopers - Virtual-On Marz"
   region: "NTSC-U"
@@ -44650,6 +44672,8 @@ SLUS-20867:
   compat: 5
   roundModes:
     eeRoundMode: 0 # Fixes character behaviour.
+  gsHWFixes:
+    autoFlush: 1 # Fixes flame bloom.
 SLUS-20868:
   name: "MVP Baseball 2004"
   region: "NTSC-U"

--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -209,6 +209,7 @@ public:
 	struct GSUploadQueue
 	{
 		GIFRegBITBLTBUF blit;
+		GSVector4i rect;
 		int draw;
 	};
 

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -166,10 +166,15 @@ void GSRendererHW::VSync(u32 field, bool registers_written)
 				if ((s_n - iter->draw) > 5)
 					iter = m_draw_transfers.erase(iter);
 				else
+				{
 					iter++;
+				}
+
 			}
 		}
 	}
+	else
+		m_draw_transfers.clear();
 
 	if (GSConfig.LoadTextureReplacements)
 		GSTextureReplacements::ProcessAsyncLoadedTextures();
@@ -1328,7 +1333,7 @@ void GSRendererHW::Draw()
 	}
 
 	// SW CLUT Render enable.
-	bool preload = GSConfig.PreloadFrameWithGSData | (m_force_preload > 0);
+	bool force_preload = GSConfig.PreloadFrameWithGSData;
 	if (GSConfig.UserHacks_CPUCLUTRender > 0 || GSConfig.UserHacks_GPUTargetCLUTMode != GSGPUTargetCLUTMode::Disabled)
 	{
 		const CLUTDrawTestResult result = (GSConfig.UserHacks_CPUCLUTRender == 2) ? PossibleCLUTDrawAggressive() : PossibleCLUTDraw();
@@ -1349,7 +1354,7 @@ void GSRendererHW::Draw()
 				!IsOpaque()) // Blending enabled
 			{
 				GL_INS("Forcing preload due to partial/blended CLUT draw");
-				preload = m_force_preload = true;
+				force_preload = true;
 			}
 		}
 	}
@@ -1556,7 +1561,7 @@ void GSRendererHW::Draw()
 
 	GSTextureCache::Target* rt = nullptr;
 	if (!no_rt)
-		rt = m_tc->LookupTarget(TEX0, t_size, GSTextureCache::RenderTarget, true, fm, false, unscaled_target_size.x, unscaled_target_size.y, preload);
+		rt = m_tc->LookupTarget(TEX0, t_size, GSTextureCache::RenderTarget, true, fm, false, unscaled_target_size.x, unscaled_target_size.y, force_preload);
 
 	TEX0.TBP0 = context->ZBUF.Block();
 	TEX0.TBW = context->FRAME.FBW;
@@ -1564,7 +1569,7 @@ void GSRendererHW::Draw()
 
 	GSTextureCache::Target* ds = nullptr;
 	if (!no_ds)
-		ds = m_tc->LookupTarget(TEX0, t_size, GSTextureCache::DepthStencil, context->DepthWrite(), 0, false, 0, 0, preload);
+		ds = m_tc->LookupTarget(TEX0, t_size, GSTextureCache::DepthStencil, context->DepthWrite(), 0, false, unscaled_target_size.x, unscaled_target_size.y, force_preload);
 
 	if (process_texture)
 	{


### PR DESCRIPTION
### Description of Changes
Forces preloads to work regardless of the GUI option, but only if an EE upload matches perfectly (or m_force_preload is enabled), the GUI option now forces preloads on everything.

### Rationale behind Changes
Before it was only preloading during the force period or if the option was enabled, but some games require this to work correctly, such as Astro with its jet packs.

### Suggested Testing Steps
Test games, make sure nothing is busted.

Fixes #6565

Astro
Master:
![image](https://user-images.githubusercontent.com/6278726/218530933-fd05e35b-1b06-4f93-bcf1-9e75af9014de.png)

PR:
![image](https://user-images.githubusercontent.com/6278726/218530954-e8ba3773-9a59-4ee3-82f8-a6d3b62c2631.png)


Other minor changes:

Juiced (lights on back of car)
Master:
![image](https://user-images.githubusercontent.com/6278726/218531088-6f6e0ede-9bed-47f2-8239-9009ecf435dd.png)

PR:
![image](https://user-images.githubusercontent.com/6278726/218531111-4517794a-9279-41b2-991f-fddd66e412e3.png)

Kunoichi (not a fix as shadows are still missing, but makes it look less annoying):
Master:
![image](https://user-images.githubusercontent.com/6278726/218531215-f460c276-1394-4023-a289-0f1cc34e919a.png)

PR:
![image](https://user-images.githubusercontent.com/6278726/218531236-92fa2ad3-d8ec-440f-b616-e711e328548c.png)

Sakura Taisen/Wars (idk which one) (as above, not a fix as shadows are still missing, but makes it look less annoying):
Master:
![image](https://user-images.githubusercontent.com/6278726/218531574-ff33fcaa-254d-4654-af30-f3d7a56887f7.png)

PR:
![image](https://user-images.githubusercontent.com/6278726/218531630-cca4e48d-53b9-47d3-b817-eca1759b72d1.png)
