### PR TITLE
GameDB: Fix Japanese KH2 - Final Mix

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -33632,7 +33632,7 @@ SLPM-66675:
   region: "NTSC-J"
   gsHWFixes:
     autoFlush: 1 # Fixes effects.
-    halfPixelOffset: 1 # Fixes upscaling artifacts.
+    roundSprite: 2 # Fixes upscaling artifacts.
   compat: 5
   memcardFilters: # Reads Re:Chain data and vice-versa.
     - "SLPM-66675"


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Change Normal Vertex halfpixel with roundsprite.

- Before:
![Kingdom Hearts II - Final Mix +_SLPM-66675_20230213210557](https://user-images.githubusercontent.com/24227051/218563628-8a9b03e8-7718-4671-b5ea-f8d190ac8080.png)
- After:
![Kingdom Hearts II - Final Mix +_SLPM-66675_20230213210604](https://user-images.githubusercontent.com/24227051/218563641-ecc33d38-310a-47eb-b84d-2dd0a8902ad8.png)


### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Less brokey with upscaley
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test SLPM-66675