### PR TITLE
GS-HW: Optimise readback performance for some cases

### DIFF
--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -2923,7 +2923,7 @@ __forceinline void GSState::HandleAutoFlush()
 
 				const GSVector2i offset = GSVector2i(m_context->XYOFFSET.OFX, m_context->XYOFFSET.OFY);
 				const GSVector4i scissor = GSVector4i(m_context->scissor.in);
-				GSVector4i old_tex_rect = GSVector4i(0, 0, 0, 0);
+				GSVector4i old_tex_rect = GSVector4i::zero();
 				int current_draw_end = m_index.tail;
 
 				while (current_draw_end >= n)

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.h
@@ -234,13 +234,15 @@ public:
 	class Target : public Surface
 	{
 	public:
-		const int m_type;
-		bool m_used;
+		const int m_type = 0;
+		bool m_used = false;
 		GSDirtyRectList m_dirty;
-		GSVector4i m_valid;
-		const bool m_depth_supported;
-		bool m_dirty_alpha;
-		bool m_is_frame;
+		GSVector4i m_valid{};
+		GSVector4i m_drawn_since_read{};
+		const bool m_depth_supported = false;
+		bool m_dirty_alpha = true;
+		bool m_is_frame = false;
+		int readbacks_since_draw = 0;
 
 	public:
 		Target(const GIFRegTEX0& TEX0, const bool depth_supported, const int type);


### PR DESCRIPTION
### Description of Changes
Tries to optimise access to a target during local memory invalidation to reduce the number of readbacks in some games. This significantly increases performance in some cases.

### Rationale behind Changes
We were pretty much always downloading a texture even when it wasn't drawn to since the local memory was last invalidated, but also some games were downloading to the EE in tiny chunks and it's more performant to just download the whole thing, so now we check for more than one read between draws.

### Suggested Testing Steps
Test games that normally have a high RB number.

SOCOM 2:

Master (~37fps):
![image](https://user-images.githubusercontent.com/6278726/218589205-9cc33143-dd53-409e-a4e0-0cc3363e1a15.png)

PR (~180fps):
![image](https://user-images.githubusercontent.com/6278726/218589461-9a789d28-b8be-4b19-9a4c-29a079fc9704.png)

Gundam Battle Assault 3:

Master (~44fps):
![image](https://user-images.githubusercontent.com/6278726/218589601-0c705b04-39bc-4974-8090-ff039604bb7f.png)

PR (~200fps): (it was going so quick I couldn't even get the same screenshot lol)
![image](https://user-images.githubusercontent.com/6278726/218589690-c8cf60f1-ec78-4dc9-87be-771db70acb51.png)

Red Faction II:

Master (~350fps):
![image](https://user-images.githubusercontent.com/6278726/218610365-53e355b9-7a89-48de-b5de-8290a3a7f4b5.png)

PR (~820fps):
![image](https://user-images.githubusercontent.com/6278726/218610381-d6270e24-f378-4771-a76f-6a9718fd63fc.png)

Armored Core 3:

Master (~47fps):
![image](https://user-images.githubusercontent.com/6278726/218612966-a6db73cc-78c6-483d-b8db-1b4c8cd342df.png)

PR (~117fps):
![image](https://user-images.githubusercontent.com/6278726/218612990-a98bf394-fba7-4af5-af0d-d9234f56b6a3.png)

