### PR TITLE
GS/HW: Split up consecutive channel shuffles

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -1361,7 +1361,10 @@ void GSRendererHW::Draw()
 
 	if (m_channel_shuffle)
 	{
-		m_channel_shuffle = draw_sprite_tex && (m_context->TEX0.PSM == PSM_PSMT8) && single_page;
+		// NFSU2 does consecutive channel shuffles with blending, reducing the alpha channel over time.
+		// Fortunately, it seems to change the FBMSK along the way, so this check alone is sufficient.
+		m_channel_shuffle = draw_sprite_tex && m_context->TEX0.PSM == PSM_PSMT8 && single_page &&
+							m_last_channel_shuffle_fbmsk == m_context->FRAME.FBMSK;
 		if (m_channel_shuffle)
 		{
 			GL_CACHE("Channel shuffle effect detected SKIP");
@@ -1375,6 +1378,7 @@ void GSRendererHW::Draw()
 		{
 			GL_INS("Channel shuffle effect detected");
 			m_channel_shuffle = true;
+			m_last_channel_shuffle_fbmsk = m_context->FRAME.FBMSK;
 		}
 		else
 		{
@@ -1621,6 +1625,7 @@ void GSRendererHW::Draw()
 		{
 			GL_INS("Channel shuffle effect detected (2nd shot)");
 			m_channel_shuffle = true;
+			m_last_channel_shuffle_fbmsk = m_context->FRAME.FBMSK;
 		}
 		else
 		{

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.h
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.h
@@ -107,8 +107,10 @@ private:
 	int m_skip = 0;
 	int m_skip_offset = 0;
 
-	bool m_tex_is_fb = false;
+	u32 m_last_channel_shuffle_fbmsk = 0;
 	bool m_channel_shuffle = false;
+
+	bool m_tex_is_fb = false;
 	bool m_userhacks_tcoffset = false;
 	float m_userhacks_tcoffset_x = 0.0f;
 	float m_userhacks_tcoffset_y = 0.0f;


### PR DESCRIPTION
### Description of Changes

NFSU2 does consecutive channel shuffles with blending, reducing the alpha channel over time.
Fortunately, it seems to change the FBMSK along the way, so this check alone is sufficient.

We were only looking at the PSM/page/sprite before, which meant we skipped everything after the first shuffle...

Before:
<img width="641" alt="Untitled" src="https://user-images.githubusercontent.com/11288319/218795916-4c9cfb16-0702-4ca6-9443-a19792f2835e.png">

After:
<img width="641" alt="Untitled" src="https://user-images.githubusercontent.com/11288319/218795732-23feb832-fff5-4299-a7fa-f2659f4f851e.png">

### Rationale behind Changes

Fixes #7549
Fixes #2279

### Suggested Testing Steps

Test NFSU2.

