### PR TITLE
VMManager: Clear host root on booting ISO

### DIFF
--- a/pcsx2/IopBios.cpp
+++ b/pcsx2/IopBios.cpp
@@ -96,6 +96,11 @@ void Hle_SetElfPath(const char* elfFileName)
 	Console.WriteLn("HLE Host: Set 'host:' root path to: %s\n", hostRoot.c_str());
 }
 
+void Hle_ClearElfPath()
+{
+	hostRoot = {};
+}
+
 namespace R3000A
 {
 

--- a/pcsx2/IopBios.h
+++ b/pcsx2/IopBios.h
@@ -86,3 +86,5 @@ namespace R3000A
 } // namespace R3000A
 
 extern void Hle_SetElfPath(const char* elfFileName);
+extern void Hle_ClearElfPath();
+

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -905,6 +905,10 @@ bool VMManager::ApplyBootParameters(VMBootParameters params, std::string* state_
 		Hle_SetElfPath(s_elf_override.c_str());
 		EmuConfig.UseBOOT2Injection = true;
 	}
+	else
+	{
+		Hle_ClearElfPath();
+	}
 
 	return true;
 }


### PR DESCRIPTION
### Description of Changes

Host root doesn't get cleared if you boot an ELF, then an ISO, it will use the ELF's host root.

### Rationale behind Changes

While it's not really escaping the path confinement, it's also not the expected behaviour - booting an iso should not have access to hostfs.

### Suggested Testing Steps

Probably a bit difficult to test since afaik no retail games will poke hostfs, if you have ulaunchelf on an ISO I guess you could.

Make sure elfs still have access to hostfs (should be unaffected).