### PR TITLE
GS/HW: Add a new option to try to make Snowblind games faster

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -6982,6 +6982,8 @@ SCPS-56016:
   region: "NTSC-K"
   gameFixes:
     - GIFFIFOHack
+  gsHWFixes:
+    estimateTextureRegion: 1 # Improves performance.
 SCUS-21295:
   name: "Tony Hawk's American Wasteland Collector's Edition"
   region: "NTSC-U"
@@ -10901,8 +10903,7 @@ SLES-50672:
   region: "PAL-M5"
   compat: 5
   gsHWFixes:
-    texturePreloading: 1 # Performs much better with partial preload.
-    disablePartialInvalidation: 1 # Fixes performance issues.
+    estimateTextureRegion: 1 # Improves performance.
 SLES-50677:
   name: "Shadow Hearts"
   region: "PAL-E"
@@ -14240,14 +14241,14 @@ SLES-52187:
   compat: 5
   gsHWFixes:
     roundSprite: 1 # Fixes lines in sprites but still some lines left.
-    texturePreloading: 1 # Performs much better with partial preload.
+    estimateTextureRegion: 1 # Improves performance.
 SLES-52188:
   name: "Baldur's Gate - Dark Alliance II"
   region: "PAL-M3"
   compat: 5
   gsHWFixes:
     roundSprite: 1 # Fixes lines in sprites but still some lines left.
-    texturePreloading: 1 # Performs much better with partial preload.
+    estimateTextureRegion: 1 # Improves performance.
 SLES-52190:
   name: "RPM Tuning"
   region: "PAL-M6"
@@ -14531,8 +14532,7 @@ SLES-52325:
   name: "Champions of Norrath - Realms of EverQuest"
   region: "PAL-M3"
   gsHWFixes:
-    texturePreloading: 1 # Performs much better with partial preload.
-    disablePartialInvalidation: 1 # Fixes performance issues.
+    estimateTextureRegion: 1 # Improves performance.
 SLES-52326:
   name: "Spawn - Armageddon"
   region: "PAL-M5"
@@ -14625,7 +14625,7 @@ SLES-52373:
   name: "Champions of Norrath"
   region: "PAL-E-S"
   gsHWFixes:
-    texturePreloading: 1 # Performs much better with partial preload.
+    estimateTextureRegion: 1 # Improves performance.
 SLES-52374:
   name: "Fight Night 2004"
   region: "PAL-M3"
@@ -16375,8 +16375,7 @@ SLES-53039:
   region: "PAL-M4"
   compat: 5
   gsHWFixes:
-    texturePreloading: 1 # Performs much better with partial preload.
-    disablePartialInvalidation: 1 # Fixes performance issues.
+    estimateTextureRegion: 1 # Improves performance.
   memcardFilters: # Allows import of characters from first game.
     - "SLES-53039"
     - "SLES-52325"
@@ -16566,6 +16565,7 @@ SLES-53124:
   region: "PAL-M4"
   gsHWFixes:
     mipmap: 1
+    estimateTextureRegion: 1 # Improves performance.
 SLES-53125:
   name: "Enthusia - Professional Racing"
   region: "PAL-M5"
@@ -18590,6 +18590,7 @@ SLES-53904:
   gsHWFixes:
     mipmap: 1
     autoFlush: 1
+    estimateTextureRegion: 1 # Improves performance.
 SLES-53906:
   name: "50 Cent - Bulletproof"
   region: "PAL-F"
@@ -30496,7 +30497,7 @@ SLPM-65845:
   compat: 5
   gsHWFixes:
     roundSprite: 1 # Fixes lines in sprites but still some lines left.
-    texturePreloading: 1 # Performs much better with partial preload.
+    estimateTextureRegion: 1 # Improves performance.
 SLPM-65846:
   name: "Lord of the Rings, The - Uchitsu Kuni Daisanki"
   region: "NTSC-J"
@@ -37274,7 +37275,7 @@ SLPS-25139:
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
-    texturePreloading: 1 # Performs much better with partial preload.
+    estimateTextureRegion: 1 # Improves performance.
 SLPS-25141:
   name: "Pac-Man World 2"
   region: "NTSC-J"
@@ -37771,7 +37772,7 @@ SLPS-25291:
   compat: 5
   gsHWFixes:
     texturePreloading: 1 # Performs much better with partial preload.
-    disablePartialInvalidation: 1 # Fixes perforamnce issues.
+    estimateTextureRegion: 1 # Improves performance.
 SLPS-25292:
   name: "D-A - Black"
   region: "NTSC-J"
@@ -40923,8 +40924,7 @@ SLUS-20035:
   gameFixes:
     - SoftwareRendererFMVHack # Fixes FMVs.
   gsHWFixes:
-    texturePreloading: 1 # Performs much better with partial preload.
-    disablePartialInvalidation: 1 # Fixes performance issues.
+    estimateTextureRegion: 1 # Improves performance.
 SLUS-20037:
   name: "Run Like Hell - Hunt or Be Hunted"
   region: "NTSC-U"
@@ -43255,8 +43255,7 @@ SLUS-20565:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    texturePreloading: 1 # Performs much better with partial preload.
-    disablePartialInvalidation: 1 # Fixes performance issues.
+    estimateTextureRegion: 1 # Improves performance.
 SLUS-20566:
   name: "Buffy the Vampire Slayer - Chaos Bleeds"
   region: "NTSC-U"
@@ -43787,7 +43786,7 @@ SLUS-20675:
     - SoftwareRendererFMVHack # Fixes FMVs.
   gsHWFixes:
     roundSprite: 1 # Fixes lines in sprites but still some lines left.
-    texturePreloading: 1 # Performs much better with partial preload.
+    estimateTextureRegion: 1 # Improves performance.
 SLUS-20676:
   name: "Lowrider"
   region: "NTSC-U"
@@ -45256,8 +45255,7 @@ SLUS-20973:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    texturePreloading: 1 # Performs much better with partial preload.
-    disablePartialInvalidation: 1 # Fixes performance issues.
+    estimateTextureRegion: 1 # Improves performance.
   memcardFilters:
     - "SLUS-20973"
     - "SLUS-20565"
@@ -45899,6 +45897,7 @@ SLUS-21095:
   gsHWFixes:
     mipmap: 1
     autoFlush: 1
+    estimateTextureRegion: 1 # Improves performance.
 SLUS-21096:
   name: "Ape Escape - Pumped & Primed"
   region: "NTSC-U"
@@ -50613,8 +50612,7 @@ SLUS-29088:
   name: "Champions of Norrath - Realms of EverQuest [Demo]"
   region: "NTSC-U"
   gsHWFixes:
-    texturePreloading: 1 # Performs much better with partial preload.
-    disablePartialInvalidation: 1
+    estimateTextureRegion: 1 # Improves performance.
 SLUS-29089:
   name: "Resident Evil Outbreak [Public Beta 1.0]"
   region: "NTSC-U"
@@ -50723,8 +50721,7 @@ SLUS-29126:
   region: "NTSC-U"
   compat: 4
   gsHWFixes:
-    texturePreloading: 1 # Performs much better with partial preload.
-    disablePartialInvalidation: 1 # Fixes perfromance issues.
+    estimateTextureRegion: 1 # Improves performance.
 SLUS-29127:
   name: "FIFA Soccer 2005 [Demo]"
   region: "NTSC-U"
@@ -50739,6 +50736,7 @@ SLUS-29131:
   region: "NTSC-U"
   gsHWFixes:
     mipmap: 1
+    estimateTextureRegion: 1 # Improves performance.
 SLUS-29132:
   name: "S.L.A.I. - Steel Lancer Arena International - Phantom Crash [Public Beta Vol.1.0]"
   region: "NTSC-U"

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -203,6 +203,7 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsDialog* dialog, QWidget* 
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.textureInsideRt, "EmuCore/GS", "UserHacks_TextureInsideRt", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.readTCOnClose, "EmuCore/GS", "UserHacks_ReadTCOnClose", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.targetPartialInvalidation, "EmuCore/GS", "UserHacks_TargetPartialInvalidation", false);
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.estimateTextureRegion, "EmuCore/GS", "UserHacks_EstimateTextureRegion", false);
 
 	//////////////////////////////////////////////////////////////////////////
 	// HW Upscaling Fixes
@@ -549,6 +550,9 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsDialog* dialog, QWidget* 
 		dialog->registerWidgetHelp(m_ui.targetPartialInvalidation, tr("Target Partial Invalidation"), tr("Unchecked"),
 			tr("Allows partial invalidation of render targets, which can fix graphical errors in some games. Texture Inside Render Target "
 			   "automatically enables this option."));
+
+		dialog->registerWidgetHelp(m_ui.estimateTextureRegion, tr("Estimate Texture Region"), tr("Unchecked"),
+			tr("Attempts to reduce the texture size when games do not set it themselves (e.g. Snowblind games)."));
 	}
 
 	// Upscaling Fixes tab

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
@@ -1068,6 +1068,13 @@
            </property>
           </widget>
          </item>
+         <item row="4" column="1">
+          <widget class="QCheckBox" name="estimateTextureRegion">
+           <property name="text">
+            <string>Estimate Texture Region</string>
+           </property>
+          </widget>
+         </item>
         </layout>
        </item>
       </layout>

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -672,6 +672,7 @@ struct Pcsx2Config
 					UserHacks_WildHack : 1,
 					UserHacks_TextureInsideRt : 1,
 					UserHacks_TargetPartialInvalidation : 1,
+					UserHacks_EstimateTextureRegion : 1,
 					FXAA : 1,
 					ShadeBoost : 1,
 					DumpGSData : 1,

--- a/pcsx2/Docs/gamedb-schema.json
+++ b/pcsx2/Docs/gamedb-schema.json
@@ -176,6 +176,11 @@
               "minimum": 0,
               "maximum": 1
             },
+            "estimateTextureRegion": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 1
+            },
             "mipmap": {
               "type": "integer",
               "minimum": 0,

--- a/pcsx2/Frontend/FullscreenUI.cpp
+++ b/pcsx2/Frontend/FullscreenUI.cpp
@@ -3203,6 +3203,9 @@ void FullscreenUI::DrawGraphicsSettingsPage()
 			DrawToggleSetting(bsi, "Read Targets When Closing",
 				"Flushes all targets in the texture cache back to local memory when shutting down.", "EmuCore/GS",
 				"UserHacks_ReadTCOnClose", false, manual_hw_fixes);
+			DrawToggleSetting(bsi, "Estimate Texture Region",
+				"Attempts to reduce the texture size when games do not set it themselves (e.g. Snowblind games).", "EmuCore/GS",
+				"UserHacks_EstimateTextureRegion", false, manual_hw_fixes);
 
 			MenuHeading("Upscaling Fixes");
 			DrawIntListSetting(bsi, "Half-Pixel Offset", "Adjusts vertices relative to upscaling.", "EmuCore/GS",

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -1766,7 +1766,7 @@ bool GSTextureCache::Move(u32 SBP, u32 SBW, u32 SPSM, int sx, int sy, u32 DBP, u
 	// Beware of the case where a game might create a larger texture by moving a bunch of chunks around.
 	// We use dx/dy == 0 and the TBW check as a safeguard to make sure these go through to local memory.
 	// Good test case for this is the Xenosaga I cutscene transitions, or Gradius V.
-	if (src && !dst && dx == 0 && dy == 0 && ((static_cast<u32>(w) + 63) / 64) == DBW)
+	if (src && !dst && dx == 0 && dy == 0 && ((static_cast<u32>(w) + 63) / 64) <= DBW)
 	{
 		GIFRegTEX0 new_TEX0 = {};
 		new_TEX0.TBP0 = DBP;
@@ -1775,7 +1775,8 @@ bool GSTextureCache::Move(u32 SBP, u32 SBW, u32 SPSM, int sx, int sy, u32 DBP, u
 
 		const int real_height = GetTargetHeight(DBP, DBW, DPSM, h);
 		const GSVector2 scale(src->m_texture->GetScale());
-		dst = LookupTarget(new_TEX0, GSVector2i(static_cast<int>(w * scale.x), static_cast<int>(real_height * scale.y)), src->m_type, true);
+		dst = LookupTarget(new_TEX0, GSVector2i(static_cast<int>(Common::AlignUpPow2(w, 64) * scale.x),
+			static_cast<int>(real_height * scale.y)), src->m_type, true);
 		if (dst)
 		{
 			dst->m_texture->SetScale(scale);

--- a/pcsx2/GameDatabase.cpp
+++ b/pcsx2/GameDatabase.cpp
@@ -352,6 +352,7 @@ static const char* s_gs_hw_fix_names[] = {
 	"alignSprite",
 	"mergeSprite",
 	"wildArmsHack",
+	"estimateTextureRegion",
 	"mipmap",
 	"trilinearFiltering",
 	"skipDrawStart",
@@ -580,6 +581,9 @@ bool GameDatabaseSchema::GameEntry::configMatchesHWFix(const Pcsx2Config::GSOpti
 		case GSHWFixId::WildArmsHack:
 			return (config.UpscaleMultiplier <= 1.0f || static_cast<int>(config.UserHacks_WildHack) == value);
 
+		case GSHWFixId::EstimateTextureRegion:
+			return (static_cast<int>(config.UserHacks_EstimateTextureRegion) == value);
+
 		case GSHWFixId::Mipmap:
 			return (config.HWMipmap == HWMipmapLevel::Automatic || static_cast<int>(config.HWMipmap) == value);
 
@@ -700,6 +704,10 @@ u32 GameDatabaseSchema::GameEntry::applyGSHardwareFixes(Pcsx2Config::GSOptions& 
 
 			case GSHWFixId::WildArmsHack:
 				config.UserHacks_WildHack = (value > 0);
+				break;
+
+			case GSHWFixId::EstimateTextureRegion:
+				config.UserHacks_EstimateTextureRegion = (value > 0);
 				break;
 
 			case GSHWFixId::Mipmap:

--- a/pcsx2/GameDatabase.h
+++ b/pcsx2/GameDatabase.h
@@ -72,6 +72,7 @@ namespace GameDatabaseSchema
 		AlignSprite,
 		MergeSprite,
 		WildArmsHack,
+		EstimateTextureRegion,
 
 		// integer settings
 		Mipmap,

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -649,6 +649,7 @@ void Pcsx2Config::GSOptions::LoadSave(SettingsWrapper& wrap)
 	GSSettingBoolEx(UserHacks_WildHack, "UserHacks_WildHack");
 	GSSettingBoolEx(UserHacks_TextureInsideRt, "UserHacks_TextureInsideRt");
 	GSSettingBoolEx(UserHacks_TargetPartialInvalidation, "UserHacks_TargetPartialInvalidation");
+	GSSettingBoolEx(UserHacks_EstimateTextureRegion, "UserHacks_EstimateTextureRegion");
 	GSSettingBoolEx(FXAA, "fxaa");
 	GSSettingBool(ShadeBoost);
 	GSSettingBoolEx(DumpGSData, "dump");
@@ -776,6 +777,7 @@ void Pcsx2Config::GSOptions::MaskUserHacks()
 	UserHacks_ReadTCOnClose = false;
 	UserHacks_TextureInsideRt = false;
 	UserHacks_TargetPartialInvalidation = false;
+	UserHacks_EstimateTextureRegion = false;
 	UserHacks_TCOffsetX = 0;
 	UserHacks_TCOffsetY = 0;
 	UserHacks_CPUSpriteRenderBW = 0;

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -1997,6 +1997,8 @@ void VMManager::WarnAboutUnsafeSettings()
 		messages += ICON_FA_EXCLAMATION_CIRCLE " GPU Palette Conversion is enabled, this may reduce performance.\n";
 	if (EmuConfig.GS.TexturePreloading != TexturePreloadingLevel::Full)
 		messages += ICON_FA_EXCLAMATION_CIRCLE " Texture Preloading is not Full, this may reduce performance.\n";
+	if (EmuConfig.GS.UserHacks_EstimateTextureRegion)
+		messages += ICON_FA_EXCLAMATION_CIRCLE " Estimate texture region is enabled, this may reduce performance.\n";
 
 	if (!messages.empty())
 	{


### PR DESCRIPTION
### Description of Changes

Games set TW/TH to 1024, and use UVs for smaller textures inside that.
Such textures usually contain junk in local memory, so try to make them smaller based on UVs.

Gets rid of the readbacks by relaxing the hw move checks a bit, I need to test this more thoroughly.

### Rationale behind Changes

dey slow

### Suggested Testing Steps

Compare snowblind game performance, add whatever's missing in gamedb
