### PR TITLE
GS/HW: Fix repeating edges in shader sampled mode/incorrect target heights

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -3353,8 +3353,8 @@ void GSRendererHW::EmulateTextureSampler(const GSTextureCache::Source* tex)
 	m_conf.cb_vs.texture_scale = GSVector2(tc_oh_ts.x, tc_oh_ts.y);
 
 	// Only enable clamping in CLAMP mode. REGION_CLAMP will be done manually in the shader
-	m_conf.sampler.tau = (wms != CLAMP_CLAMP);
-	m_conf.sampler.tav = (wmt != CLAMP_CLAMP);
+	m_conf.sampler.tau = (wms == CLAMP_REPEAT);
+	m_conf.sampler.tav = (wmt == CLAMP_REPEAT);
 	if (shader_emulated_sampler)
 	{
 		m_conf.sampler.biln = 0;

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.h
@@ -305,10 +305,10 @@ public:
 
 			struct
 			{
-				u32 fbp : 9;
+				u32 fbp : 14;
 				u32 fbw : 6;
 				u32 psm : 6;
-				u32 pad : 11;
+				u32 pad : 6;
 			};
 		};
 


### PR DESCRIPTION
### Description of Changes

Fixes a couple of bugs I found during moving the target lookup before source.

### Rationale behind Changes

![image](https://user-images.githubusercontent.com/11288319/219422841-8580a583-243e-4449-aedf-388cc2e251c3.png)

Fixes #7310.

### Suggested Testing Steps

Test VP2 I guess.
