### PR TITLE
USB: Refactor subtype operations

### DIFF
--- a/pcsx2/Frontend/FullscreenUI.cpp
+++ b/pcsx2/Frontend/FullscreenUI.cpp
@@ -3967,7 +3967,7 @@ void FullscreenUI::DrawControllerSettingsPage()
 			continue;
 		}
 
-		const u32 subtype = USB::GetConfigSubType(*bsi, port, type);
+		const u32 subtype = USB::GetConfigSubType(*bsi, port);
 		const gsl::span<const char*> subtypes(USB::GetDeviceSubtypes(type));
 		if (!subtypes.empty())
 		{
@@ -3986,7 +3986,7 @@ void FullscreenUI::DrawControllerSettingsPage()
 
 						auto lock = Host::GetSettingsLock();
 						SettingsInterface* bsi = GetEditingSettingsInterface(game_settings);
-						USB::SetConfigSubType(*bsi, port, type.c_str(), static_cast<u32>(index));
+						USB::SetConfigSubType(*bsi, port, static_cast<u32>(index));
 						SetSettingsChanged(bsi);
 						CloseChoiceDialog();
 					});

--- a/pcsx2/Frontend/InputManager.cpp
+++ b/pcsx2/Frontend/InputManager.cpp
@@ -716,7 +716,7 @@ void InputManager::AddUSBBindings(SettingsInterface& si, u32 port)
 		return;
 
 	const std::string section(USB::GetConfigSection(port));
-	const u32 subtype = USB::GetConfigSubType(si, port, device);
+	const u32 subtype = USB::GetConfigSubType(si, port);
 	for (const InputBindingInfo& bi : USB::GetDeviceBindings(device, subtype))
 	{
 		const std::string bind_name(USB::GetConfigSubKey(device, bi.name));

--- a/pcsx2/USB/USB.cpp
+++ b/pcsx2/USB/USB.cpp
@@ -655,14 +655,20 @@ void USB::SetConfigDevice(SettingsInterface& si, u32 port, const char* devname)
 	si.SetStringValue(GetConfigSection(port).c_str(), "Type", devname);
 }
 
-u32 USB::GetConfigSubType(const SettingsInterface& si, u32 port, const std::string_view& devname)
-{
-	return si.GetUIntValue(GetConfigSection(port).c_str(), fmt::format("{}_subtype", devname).c_str(), 0u);
+std::string SubTypeKeyForDevice(const std::string_view devname) {
+	return fmt::format("{}_subtype", devname);
 }
 
-void USB::SetConfigSubType(SettingsInterface& si, u32 port, const std::string_view& devname, u32 subtype)
+u32 USB::GetConfigSubType(const SettingsInterface& si, u32 port)
 {
-	si.SetUIntValue(GetConfigSection(port).c_str(), fmt::format("{}_subtype", devname).c_str(), subtype);
+	const std::string device_type(GetConfigDevice(si, port));
+	return si.GetUIntValue(GetConfigSection(port).c_str(), SubTypeKeyForDevice(device_type).c_str(), 0u);
+}
+
+void USB::SetConfigSubType(SettingsInterface& si, u32 port, u32 subtype)
+{
+	const std::string device_type(GetConfigDevice(si, port));
+	si.SetUIntValue(GetConfigSection(port).c_str(), SubTypeKeyForDevice(device_type).c_str(), subtype);
 }
 
 std::string USB::GetConfigSubKey(const std::string_view& device, const std::string_view& bind_name)
@@ -729,7 +735,7 @@ bool USB::MapDevice(SettingsInterface& si, u32 port, const std::vector<std::pair
 {
 	const std::string section(GetConfigSection(port));
 	const std::string type(GetConfigDevice(si, port));
-	const u32 subtype = GetConfigSubType(si, port, type);
+	const u32 subtype = GetConfigSubType(si, port);
 	const DeviceProxy* dev = RegisterDevice::instance().Device(type);
 	if (!dev)
 		return false;
@@ -750,7 +756,7 @@ void USB::ClearPortBindings(SettingsInterface& si, u32 port)
 {
 	const std::string section(GetConfigSection(port));
 	const std::string type(GetConfigDevice(si, port));
-	const u32 subtype = GetConfigSubType(si, port, type);
+	const u32 subtype = GetConfigSubType(si, port);
 	const DeviceProxy* dev = RegisterDevice::instance().Device(type);
 	if (!dev)
 		return;

--- a/pcsx2/USB/USB.h
+++ b/pcsx2/USB/USB.h
@@ -58,8 +58,8 @@ namespace USB
 	std::string GetConfigSection(int port);
 	std::string GetConfigDevice(const SettingsInterface& si, u32 port);
 	void SetConfigDevice(SettingsInterface& si, u32 port, const char* devname);
-	u32 GetConfigSubType(const SettingsInterface& si, u32 port, const std::string_view& devname);
-	void SetConfigSubType(SettingsInterface& si, u32 port, const std::string_view& devname, u32 subtype);
+	u32 GetConfigSubType(const SettingsInterface& si, u32 port);
+	void SetConfigSubType(SettingsInterface& si, u32 port, u32 subtype);
 
 	/// Returns the configuration key for the specified bind and device type.
 	std::string GetConfigSubKey(const std::string_view& device, const std::string_view& bind_name);


### PR DESCRIPTION
### Description of Changes
Refactor the USB::GetConfigSubType and USB::SetConfigSubType functions to lookup the device type instead of requiring it as a parameter

### Rationale behind Changes
This change makes the code easier to read since uses of the function only require the minimum arguments. This also protects against potential bugs where the incorrect device type may be passed on accident.
