### PR TITLE
GameDB: Add pnach fix to Fatal Frame 1 / Project Zero

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -11266,6 +11266,13 @@ SLES-50821:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
     disablePartialInvalidation: 1 # Fixes ghost rendering.
+  patches:
+    "22E91837":
+      content: |-
+        author=WeirdBeardGame, TellowKrinkle, CheeseyBurrito.
+        // Wraps sceVu0ScaleVector in if statement to prevent bad divide by zero behaviour.
+        patch=1,EE,0011f3b4,word,46156032
+        patch=1,EE,0011f3b8,word,45010002
 SLES-50822:
   name: "Shadow Hearts"
   region: "PAL-M3"
@@ -37101,6 +37108,13 @@ SLPS-25074:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
     disablePartialInvalidation: 1 # Fixes ghost rendering.
+  patches:
+    9883194E:
+      content: |-
+        author=WeirdBeardGame, TellowKrinkle, CheeseyBurrito.
+        // Wraps sceVu0ScaleVector in if statement to prevent bad divide by zero behaviour.
+        patch=1,EE,0011de3c,word,46156032
+        patch=1,EE,0011de40,word,45010002
 SLPS-25075:
   name: "Sidewinder F"
   region: "NTSC-J"
@@ -42430,6 +42444,13 @@ SLUS-20388:
   gsHWFixes:
     halfPixelOffset: 2 # Reduces blurriness.
     disablePartialInvalidation: 1 # Fixes ghost rendering.
+  patches:
+    339A0B8C:
+      content: |-
+        author=WeirdBeardGame, TellowKrinkle, CheeseyBurrito.
+        // Wraps sceVu0ScaleVector in if statement to prevent bad divide by zero behaviour.
+        patch=1,EE,0011f0cc,word,46156032
+        patch=1,EE,0011f0d0,word,45010002
 SLUS-20389:
   name: "Endgame"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Add bug fix to prevent divide-by-zero behaviors when SubDither3 is active during the final battle or other battles with onscreen effects related to SubDither3
```
  sceVu0ApplyMatrix(&vtw,(Vector4 *)&slm,&vt);
  // vtw.w will be zero... Oops!
  sceVu0ScaleVector(1.0 / vtw.w,&vtw,&vtw);
```
Thanks to Tellow and Cheesey for their inputs into this fix

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Division by zero is bad. It hangs.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
It's been tested to prevent the hang already.