### PR TITLE
GS/HW: Allow hardware sampling when clamp_max is larger

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -3121,10 +3121,10 @@ void GSRendererHW::EmulateTextureSampler(const GSTextureCache::Source* tex)
 	const u8 wms = EffectiveClamp(m_context->CLAMP.WMS, tex->m_region.HasX() || redundant_wms);
 	const u8 wmt = EffectiveClamp(m_context->CLAMP.WMT, tex->m_region.HasY() || redundant_wmt);
 	const bool complex_wms_wmt = !!((wms | wmt) & 2);
-	GL_CACHE("WMS: %s [%s%s] WMT: %s [%s%s] Complex: %d MINU: %d MINV: %d MINV: %d MAXV: %d",
+	GL_CACHE("WMS: %s [%s%s] WMT: %s [%s%s] Complex: %d MINU: %d MAXU: %d MINV: %d MAXV: %d",
 		clamp_modes[m_context->CLAMP.WMS], redundant_wms ? "redundant," : "", clamp_modes[wms],
 		clamp_modes[m_context->CLAMP.WMT], redundant_wmt ? "redundant," : "", clamp_modes[wmt],
-		complex_wms_wmt, m_context->CLAMP.MINU, m_context->CLAMP.MINV, m_context->CLAMP.MAXU, m_context->CLAMP.MAXV);
+		complex_wms_wmt, m_context->CLAMP.MINU, m_context->CLAMP.MAXU, m_context->CLAMP.MINV, m_context->CLAMP.MAXV);
 
 	const bool need_mipmap = IsMipMapDraw();
 	const bool shader_emulated_sampler = tex->m_palette || cpsm.fmt != 0 || complex_wms_wmt || psm.depth;

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -3090,7 +3090,7 @@ __ri static constexpr bool IsRedundantClamp(u8 clamp, u32 clamp_min, u32 clamp_m
 	// That way trilinear etc still works.
 	const u32 textent = (1u << tsize) - 1u;
 	if (clamp == CLAMP_REGION_CLAMP)
-		return (clamp_min == 0 && clamp_max == textent);
+		return (clamp_min == 0 && clamp_max >= textent);
 	else if (clamp == CLAMP_REGION_REPEAT)
 		return (clamp_max == 0 && clamp_min == textent);
 	else

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -279,7 +279,7 @@ GSTextureCache::Source* GSTextureCache::LookupSource(const GIFRegTEX0& TEX0, con
 	{
 		// Another Lupin case here, it uses region clamp with UV (not ST), puts a clamp region further
 		// into the texture, but a smaller TW/TH. Catch this by looking for a clamp range above TW.
-		const u32 rw = CLAMP.MAXU - CLAMP.MAXU + 1;
+		const u32 rw = CLAMP.MAXU - CLAMP.MINU + 1;
 		if (rw < (1u << TEX0.TW) || CLAMP.MAXU >= (1u << TEX0.TW))
 		{
 			region.SetX(CLAMP.MINU, CLAMP.MAXU + 1);


### PR DESCRIPTION
### Description of Changes

GT4 sets region clamp to 0..127, 0..255 on a 64x128 texture. Shader sampling is redundant here, and no trilinear means it looks shit.

### Rationale behind Changes

Fixes some mipmapping issues in GT4.

<img width="1030" alt="Untitled" src="https://user-images.githubusercontent.com/11288319/219613197-e0c58439-105f-4b14-98e5-896c76e20f8c.png">
<img width="1028" alt="Untitled" src="https://user-images.githubusercontent.com/11288319/219636819-ad938673-170f-4c88-aa89-cc2032cca5ed.png">


### Suggested Testing Steps

Test GT4?

