### PR TITLE
GameDB: Add VU Sync hack to Salt Lake 2002

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -10328,8 +10328,10 @@ SLES-50355:
   gsHWFixes:
     halfPixelOffset: 3 # Fixes ghosting on Batman
 SLES-50356:
-  name: "ESPN International Winter Sports"
+  name: "Salt Lake 2002"
   region: "PAL-E"
+  gameFixes:
+    - VUSyncHack # Fixes flickering and missing textures.
 SLES-50358:
   name: "Devil May Cry"
   region: "PAL-M5"
@@ -10835,8 +10837,10 @@ SLES-50639:
   region: "PAL-E"
   compat: 5
 SLES-50640:
-  name: "Salt Lake City 2002 Olympic Winter Games"
+  name: "Salt Lake 2002"
   region: "PAL-M4"
+  gameFixes:
+    - VUSyncHack # Fixes flickering and missing textures.
 SLES-50641:
   name: "Dynasty Warriors 3"
   region: "PAL-M3"
@@ -37149,6 +37153,11 @@ SLPS-25088:
     textureInsideRT: 1 # Fixes wrong visuals for the summon Anima and The (Triple) Magus Sisters.
     getSkipCount: "GSC_FFXGames"
     beforeDraw: "OI_FFX"
+SLPS-25089:
+  name: "Salt Lake 2002"
+  region: "NTSC-J"
+  gameFixes:
+    - VUSyncHack # Fixes flickering and missing textures.
 SLPS-25094:
   name: "Reveal Fantasia"
   region: "NTSC-J"
@@ -42368,6 +42377,8 @@ SLUS-20377:
 SLUS-20378:
   name: "Salt Lake 2002"
   region: "NTSC-U"
+  gameFixes:
+    - VUSyncHack # Fixes flickering and missing textures.
   patches:
     466D1C13:
       content: |-


### PR DESCRIPTION
### Description of Changes
Fixes the awful flickering and missing textures that happens all over the game.

### Rationale behind Changes
Awful game needs silly hacks to function correctly because the devs snorted epoxy.

### Suggested Testing Steps
Make sure CI is happy.
