### PR TITLE
GameDB: Add full mipmap + trilinear to matrix, add Silent Scope 3 db entry.

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -9052,6 +9052,8 @@ SLAJ-25072:
   name: "Matrix, The - Path of Neo"
   region: "NTSC-Unk"
   gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
     halfPixelOffset: 2 # Fix effects upscaling.
 SLAJ-25073:
   name: "Resident Evil 4"
@@ -9437,6 +9439,8 @@ SLED-53845:
   name: "Matrix, The - Path of Neo [Demo]"
   region: "PAL-E"
   gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
     halfPixelOffset: 2 # Fix effects upscaling.
 SLED-53937:
   name: "Black [Demo]"
@@ -17267,6 +17271,8 @@ SLES-53462:
   name: "Matrix, The - Path of Neo"
   region: "PAL-M5"
   gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
     halfPixelOffset: 2 # Fix effects upscaling.
 SLES-53463:
   name: "NHL '06"
@@ -18260,6 +18266,8 @@ SLES-53759:
   name: "Matrix, The - Path of Neo"
   region: "PAL-M5"
   gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
     halfPixelOffset: 2 # Fix effects upscaling.
 SLES-53760:
   name: "Rugby Challenge 2006"
@@ -18347,6 +18355,8 @@ SLES-53799:
   region: "PAL-M4"
   compat: 5
   gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
     halfPixelOffset: 2 # Fix effects upscaling.
 SLES-53800:
   name: "Rampage - Total Destruction"
@@ -24212,6 +24222,8 @@ SLKA-25303:
   name: "Matrix, The - Path of Neo"
   region: "NTSC-K"
   gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
     halfPixelOffset: 2 # Fix effects upscaling.
 SLKA-25304:
   name: "Burnout Revenge"
@@ -31761,6 +31773,8 @@ SLPM-66177:
   name: "Matrix, The - Path of Neo"
   region: "NTSC-J"
   gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
     halfPixelOffset: 2 # Fix effects upscaling.
 SLPM-66178:
   name: "pop'n music 7 [Konami The Best]"
@@ -46943,6 +46957,8 @@ SLUS-21273:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
     halfPixelOffset: 2 # Fix effects upscaling.
 SLUS-21274:
   name: "OutRun 2006 - Coast 2 Coast"

--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -27666,6 +27666,9 @@ SLPM-64544:
 SLPM-64549:
   name: "Siksin-ui Seong"
   region: "NTSC-K"
+SLPM-64552:
+  name: "Silent Scope 3"
+  region: "NTSC-K"
 SLPM-65001:
   name: "Kessen"
   region: "NTSC-J"


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GameDB: Add full mipmap with ps2 trilinear to Matrix, The - Path of Neo.
Improves ground textures to match sw renderer.
GameDB: Add missing db entry for Silent Scope 3.
Korean version.
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Better rendering, missing entries.
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Already tested.