### PR TITLE
Pad/Counters: Rearrange Pad/Core updates on VSync

### DIFF
--- a/pcsx2/Counters.cpp
+++ b/pcsx2/Counters.cpp
@@ -602,9 +602,9 @@ static __fi void frameLimit()
 static __fi void VSyncStart(u32 sCycle)
 {
 	// Update vibration at the end of a frame.
+	VSyncUpdateCore();
 	PAD::Update();
 
-	VSyncUpdateCore();
 	frameLimit(); // limit FPS
 	gsPostVsyncStart(); // MUST be after framelimit; doing so before causes funk with frame times!
 	VSyncCheckExit();


### PR DESCRIPTION
### Description of Changes
Rearrange pad/core updates in vsync to avoid some weird pad input lag/missed inputs issue.
Apparently this gets around some weird input lag issue.

### Rationale behind Changes
Was introduced in #8101 as an issue, did some tests on discord with the user reporting it (along with a trap test to make sure they weren't lying) and checks out, this apparently fixes it, so there we go..

### Suggested Testing Steps
Kinda already been tested.