### PR TITLE
GS-HW: Preserve width of frame textures

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -618,7 +618,18 @@ GSTextureCache::Target* GSTextureCache::LookupTarget(const GIFRegTEX0& TEX0, con
 				dst = t;
 
 				dst->m_32_bits_fmt |= (psm_s.bpp != 16);
-				dst->m_TEX0 = TEX0;
+				// Nicktoons Unite tries to change the width from 10 to 8 and breaks FMVs.
+				// Haunting ground has some messed textures if you don't modify the rest.
+				if (!dst->m_is_frame)
+				{
+					dst->m_TEX0 = TEX0;
+				}
+				else
+				{
+					u32 width = dst->m_TEX0.TBW;
+					dst->m_TEX0 = TEX0;
+					dst->m_TEX0.TBW = width;
+				}
 
 				break;
 			}
@@ -695,7 +706,10 @@ GSTextureCache::Target* GSTextureCache::LookupTarget(const GIFRegTEX0& TEX0, con
 		}
 
 		if (dst)
+		{
 			dst->m_TEX0.TBW = TEX0.TBW; // Fix Jurassic Park - Operation Genesis loading disk logo.
+			dst->m_is_frame |= is_frame; // Nicktoons Unite tries to change the width from 10 to 8 and breaks FMVs.
+		}
 	}
 
 	if (dst)


### PR DESCRIPTION
### Description of Changes
Preserve the width of textures used as the frame output.

### Rationale behind Changes
The texture cache was changing the size of the textures for some draw, and then the frame was after a different size, causing the picture to desync and get messy.

### Suggested Testing Steps
Test Nicktoons Unite, maybe a spatter of random games. Already done a GS Dump run on 1000+ dumps.

Fixes the intro FMV's in Nicktoons Unite.

Master;
![image](https://user-images.githubusercontent.com/6278726/219827574-19636e59-2e29-44f7-b71b-25c7b648e334.png)

PR:
![image](https://user-images.githubusercontent.com/6278726/219827578-9ef7e941-4164-4d2f-9ba9-47930a48ab86.png)

