### PR TITLE
GS: Flush targets back to GS memory when swapping renderers

### DIFF
--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -800,6 +800,8 @@ void GSSwitchRenderer(GSRendererType new_renderer)
 	if (existing_api == RenderAPI::OpenGLES)
 		existing_api = RenderAPI::OpenGL;
 
+	g_gs_renderer->PurgeTextureCache();
+
 	const bool is_software_switch = (new_renderer == GSRendererType::SW || GSConfig.Renderer == GSRendererType::SW);
 	const bool recreate_display = (!is_software_switch && existing_api != GetAPIForRenderer(new_renderer));
 	const Pcsx2Config::GSOptions old_config(GSConfig);

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -72,7 +72,7 @@ void GSRendererHW::Destroy()
 void GSRendererHW::PurgeTextureCache()
 {
 	GSRenderer::PurgeTextureCache();
-	m_tc->RemoveAll();
+	m_tc->RemoveAll(true);
 }
 
 GSTexture* GSRendererHW::LookupPaletteSource(u32 CBP, u32 CPSM, u32 CBW, GSVector2i& offset, const GSVector2i& size)

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -46,14 +46,18 @@ GSTextureCache::~GSTextureCache()
 	_aligned_free(s_unswizzle_buffer);
 }
 
-void GSTextureCache::RemoveAll()
+void GSTextureCache::RemoveAll(bool readback_targets)
 {
 	m_src.RemoveAll();
 
 	for (int type = 0; type < 2; type++)
 	{
 		for (auto t : m_dst[type])
+		{
+			if (readback_targets)
+				Read(t, t->m_drawn_since_read);
 			delete t;
+		}
 
 		m_dst[type].clear();
 	}

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.h
@@ -396,7 +396,7 @@ public:
 
 	void Read(Target* t, const GSVector4i& r);
 	void Read(Source* t, const GSVector4i& r);
-	void RemoveAll();
+	void RemoveAll(bool readback_targets = false);
 	void AddDirtyRectTarget(Target* target, GSVector4i rect, u32 psm, u32 bw);
 
 	GSTexture* LookupPaletteSource(u32 CBP, u32 CPSM, u32 CBW, GSVector2i& offset, const GSVector2i& size);


### PR DESCRIPTION
### Description of Changes
Flushes the targets from the hardware texture cache back to memory when swapping renderer, reopening the GS.

### Rationale behind Changes
This was a problem in games where things were only ever rendered on the GPU, then you changed config or changed to the software renderer, it would lose that information, resulting in graphical errors.

### Suggested Testing Steps
Make sure Futurama lets you load ingame with Hardware mode, switch to software and back again without any texture corruptions.

Fixes #6918 probably