### PR TITLE
GameDB: Port patch to PAL Transformers ROTF

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -22686,6 +22686,13 @@ SLES-55520:
     cpuSpriteRenderBW: 2 # Fixes textures.
     halfPixelOffset: 2 # Fixes misaligned bloom.
     autoFlush: 1 # Fixes soft shadows.
+  patches:
+    9E36E023:
+      content: |-
+        //Patched by kozarrov
+        //Fix Pause menu, some hud parts, etc. 
+        patch=1,EE,0016ee38,word,3464fff0
+        patch=1,EE,0016ee58,word,3464fffc
 SLES-55522:
   name: "Disney-Pixar Up"
   region: "PAL-E"


### PR DESCRIPTION
### Description of Changes
Ports a patch over to the PAL version to fix the pause menu hud and other parts.

### Rationale behind Changes
Broken hud and other bits of the game are kinda stinky.

### Suggested Testing Steps
Make sure CI is happy.
