### PR TITLE
GS-hw: Adjust alpha compensation for blend mix1

### DIFF
--- a/bin/resources/shaders/opengl/tfx_fs.glsl
+++ b/bin/resources/shaders/opengl/tfx_fs.glsl
@@ -686,8 +686,10 @@ void ps_color_clamp_wrap(inout vec3 C)
 #endif
 }
 
-void ps_blend(inout vec4 Color, inout float As)
+void ps_blend(inout vec4 Color, inout vec4 As_rgba)
 {
+float As = As_rgba.a;
+
 #if SW_BLEND
 
     // PABE
@@ -768,16 +770,15 @@ void ps_blend(inout vec4 Color, inout float As)
 #if PS_CLR_HW == 1
     // Replace Af with As so we can do proper compensation for Alpha.
 #if PS_BLEND_C == 2
-    As = Af;
+    As_rgba = vec4(Af);
 #endif
     // Subtract 1 for alpha to compensate for the changed equation,
     // if c.rgb > 255.0f then we further need to adjust alpha accordingly,
     // we pick the lowest overflow from all colors because it's the safest,
     // we divide by 255 the color because we don't know Cd value,
     // changed alpha should only be done for hw blend.
-    float min_color = min(min(Color.r, Color.g), Color.b);
-    float alpha_compensate = max(1.0f, min_color / 255.0f);
-    As -= alpha_compensate;
+    vec3 alpha_compensate = max(vec3(1.0f), Color.rgb / vec3(255.0f));
+    As_rgba.rgb -= alpha_compensate;
 #elif PS_CLR_HW == 2
     // Compensate slightly for Cd*(As + 1) - Cs*As.
     // The initial factor we chose is 1 (0.00392)
@@ -927,9 +928,9 @@ void ps_main()
 
 #if SW_AD_TO_HW
     vec4 RT = trunc(fetch_rt() * 255.0f + 0.1f);
-    float alpha_blend = RT.a / 128.0f;
+    vec4 alpha_blend = vec4(RT.a / 128.0f);
 #else
-    float alpha_blend = C.a / 128.0f;
+    vec4 alpha_blend = vec4(C.a / 128.0f);
 #endif
 
     // Correct the ALPHA value based on the output format
@@ -969,12 +970,12 @@ void ps_main()
     SV_Target0 = C / 255.0f;
 #endif
 #if !defined(DISABLE_DUAL_SOURCE) && !PS_NO_COLOR1
-    SV_Target1 = vec4(alpha_blend);
+    SV_Target1 = alpha_blend;
 #endif
 
 #if PS_NO_ABLEND
     // write alpha blend factor into col0
-    SV_Target0.a = alpha_blend;
+    SV_Target0.a = alpha_blend.a;
 #endif
 #if PS_ONLY_ALPHA
     // rgb isn't used

--- a/pcsx2/GS/Renderers/Common/GSDevice.h
+++ b/pcsx2/GS/Renderers/Common/GSDevice.h
@@ -858,8 +858,8 @@ public:
 
 	__fi static constexpr bool IsDualSourceBlendFactor(u8 factor)
 	{
-		return (factor == SRC1_ALPHA || factor == INV_SRC1_ALPHA
-			/*|| factor == SRC1_COLOR || factor == INV_SRC1_COLOR*/); // not used
+		return (factor == SRC1_ALPHA || factor == INV_SRC1_ALPHA || factor == SRC1_COLOR
+			/* || factor == INV_SRC1_COLOR*/); // not used
 	}
 	__fi static constexpr bool IsConstantBlendFactor(u16 factor)
 	{

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -3092,10 +3092,9 @@ void GSRendererHW::EmulateBlending(bool& DATE_PRIMID, bool& DATE_BARRIER, bool& 
 					// Replace Cs*F + Cd*(1 - F) with Cs*F - Cd*(F - 1).
 					// As - 1 or F - 1 subtraction is only done for the dual source output (hw blending part) since we are changing the equation.
 					// Af will be replaced with As in shader and send it to dual source output.
-					m_conf.blend = {true, GSDevice::CONST_ONE, GSDevice::SRC1_ALPHA, GSDevice::OP_SUBTRACT, false, 0};
+					m_conf.blend = {true, GSDevice::CONST_ONE, GSDevice::SRC1_COLOR, GSDevice::OP_SUBTRACT, false, 0};
 					// clr_hw 1 will disable alpha clamp, we can reuse the old bits.
 					m_conf.ps.clr_hw = 1;
-					//m_conf.ps.blend_mix = 0;
 					// DSB output will always be used.
 					m_conf.ps.no_color1 = false;
 				}

--- a/pcsx2/ShaderCacheVersion.h
+++ b/pcsx2/ShaderCacheVersion.h
@@ -15,4 +15,4 @@
 
 /// Version number for GS and other shaders. Increment whenever any of the contents of the
 /// shaders change, to invalidate the cache.
-static constexpr u32 SHADER_CACHE_VERSION = 13;
+static constexpr u32 SHADER_CACHE_VERSION = 14;


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS-hw: Use rgb color for second output instead of alpha.
We want different alpha value for each channel.
GS-ogl: Check each channel individually if it overflows and do corrections.

We want to check and adjust alpha value based on each channel instead of taking the minimum overflow.
It is more accurate this way, it should've been done earlier but I didn't have a test case.
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Better accuracy using mix of hw/sw blending, allows us better accuracy at lower levels of blending, also useful for dx11 since it doesn't fully support sw blending.
Follow up from #6784
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test the games and dumps mentioned/listed in #6784
Fixes Cat in the Hat's fire effect using lower level of blending.
Need to test metal as well.
Test a bunch of games/dumps, especially dx as it will be more likely to show up there.