### PR TITLE
GS-HW: Drop to CPU CLUT w/e invalidate only if dirty covers whole tex

### DIFF
--- a/pcsx2/GS/GSUtil.cpp
+++ b/pcsx2/GS/GSUtil.cpp
@@ -130,16 +130,23 @@ bool GSUtil::HasSharedBits(u32 spsm, const u32* RESTRICT ptr)
 	return (ptr[spsm >> 5] & (1 << (spsm & 0x1f))) == 0;
 }
 
+// Pixels can NOT coexist in the same 32bits of space.
+// Example: Using PSMT8H or PSMT4HL/HH with CT24 would fail this check.
 bool GSUtil::HasSharedBits(u32 spsm, u32 dpsm)
 {
 	return (s_maps.SharedBitsField[dpsm][spsm >> 5] & (1 << (spsm & 0x1f))) == 0;
 }
 
+// Pixels can NOT coexist in the same 32bits of space.
+// Example: Using PSMT8H or PSMT4HL/HH with CT24 would fail this check.
+// SBP and DBO must match.
 bool GSUtil::HasSharedBits(u32 sbp, u32 spsm, u32 dbp, u32 dpsm)
 {
 	return ((sbp ^ dbp) | (s_maps.SharedBitsField[dpsm][spsm >> 5] & (1 << (spsm & 0x1f)))) == 0;
 }
 
+// Shares bit depths, only detects 16/24/32 bit formats.
+// 24/32bit cross compatible, 16bit compatbile with 16bit.
 bool GSUtil::HasCompatibleBits(u32 spsm, u32 dpsm)
 {
 	return (s_maps.CompatibleBitsField[spsm][dpsm >> 5] & (1 << (dpsm & 0x1f))) != 0;

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.h
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.h
@@ -75,6 +75,7 @@ private:
 		CLUTDrawOnGPU,
 	};
 
+	bool HasEEUpload(GSVector4i r);
 	CLUTDrawTestResult PossibleCLUTDraw();
 	CLUTDrawTestResult PossibleCLUTDrawAggressive();
 	bool CanUseSwPrimRender(bool no_rt, bool no_ds, bool draw_sprite_tex);

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.h
@@ -416,7 +416,7 @@ public:
 	Source* LookupDepthSource(const GIFRegTEX0& TEX0, const GIFRegTEXA& TEXA, const GIFRegCLAMP& CLAMP, const GSVector4i& r, bool palette = false);
 
 	Target* FindTargetOverlap(u32 bp, u32 end_block, int type, int psm);
-	Target* LookupTarget(const GIFRegTEX0& TEX0, const GSVector2i& size, int type, bool used, u32 fbmask = 0, const bool is_frame = false, const int real_w = 0, const int real_h = 0, bool preload = GSConfig.PreloadFrameWithGSData);
+	Target* LookupTarget(const GIFRegTEX0& TEX0, const GSVector2i& size, int type, bool used, u32 fbmask = 0, const bool is_frame = false, const int real_w = 0, const int real_h = 0, bool preload = GSConfig.PreloadFrameWithGSData, bool is_clear = false);
 	Target* LookupDisplayTarget(const GIFRegTEX0& TEX0, const GSVector2i& size, const int real_w, const int real_h);
 
 	/// Looks up a target in the cache, and only returns it if the BP/BW/PSM match exactly.


### PR DESCRIPTION
### Description of Changes
Correct the check for CPU CLUT draw checks if there has been writes from the EE, make sure all of the texture is invalid before skipping the local memory invalidation.

Also fix up readback behaviour for Local->Host transfers

### Rationale behind Changes
The invalidation thing was wrong, so this is more correct, fixes games where we use CPU CLUT to fix post processing.

Readbacks just needed some more work, but also some games  like Ratchet Gladiator would upload a texture, then immediately download it, but if there was still an old target hanging around the download would pick that, so I now detect that.  I also handled the wrap around 2048 correctly.

### Suggested Testing Steps
Check Brave, Futurama, Dave Mirra's Freestyle BMX 2 with SW switches. For the CLUT thing check LEGO Star Wars. For readbacks, check Ratchet Gladiator, Fatal Frame, GT4 etc.

Fixes #8201
Fix for textures (not boosters) in #8194 