### PR TITLE
GS/HW: Don't try to dirty targets which don't overlap

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -1330,7 +1330,8 @@ void GSRendererHW::Draw()
 	// We trigger the sw prim render here super early, to avoid creating superfluous render targets.
 	if (CanUseSwPrimRender(no_rt, no_ds, draw_sprite_tex) && SwPrimRender(*this, true))
 	{
-		GL_CACHE("Possible texture decompression, drawn with SwPrimRender()");
+		GL_CACHE("Possible texture decompression, drawn with SwPrimRender() (BP %x BW %u TBP0 %x TBW %u)",
+			m_context->FRAME.Block(), m_context->FRAME.FBMSK, m_context->TEX0.TBP0, m_context->TEX0.TBW);
 		return;
 	}
 

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -1671,7 +1671,10 @@ bool GSTextureCache::Move(u32 SBP, u32 SBW, u32 SPSM, int sx, int sy, u32 DBP, u
 		const GSVector2 scale(src->m_texture->GetScale());
 		dst = LookupTarget(new_TEX0, GSVector2i(static_cast<int>(w * scale.x), static_cast<int>(real_height * scale.y)), src->m_type, true);
 		if (dst)
+		{
 			dst->m_texture->SetScale(scale);
+			dst->UpdateValidity(GSVector4i(dx, dy, dx + w, dy + h));
+		}
 	}
 
 	if (!src || !dst || src->m_texture->GetScale() != dst->m_texture->GetScale())

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -1345,8 +1345,6 @@ void GSTextureCache::InvalidateVideoMem(const GSOffset& off, const GSVector4i& r
 							GL_CACHE("TC: Dirty After Target(%s) %d (0x%x)", to_string(type),
 								t->m_texture ? t->m_texture->GetID() : 0,
 								t->m_TEX0.TBP0);
-							// TODO: do not add this rect above too
-							t->m_TEX0.TBW = bw;
 
 							if (eewrite)
 								t->m_age = 0;
@@ -1381,8 +1379,6 @@ void GSTextureCache::InvalidateVideoMem(const GSOffset& off, const GSVector4i& r
 
 						if (eewrite)
 							t->m_age = 0;
-
-						t->m_TEX0.TBW = bw;
 
 						const GSVector4i dirty_r = GSVector4i(r.left, r.top + y, r.right, r.bottom + y);
 						AddDirtyRectTarget(t, dirty_r, psm, bw);

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.h
@@ -248,6 +248,13 @@ public:
 		Target(const GIFRegTEX0& TEX0, const bool depth_supported, const int type);
 		~Target();
 
+		/// Returns true if the target wraps around the end of GS memory.
+		bool Wraps() const { return (m_end_block < m_TEX0.TBP0); }
+
+		/// Returns the end block for the target, but doesn't wrap at 0x3FFF.
+		/// Can be used for overlap tests.
+		u32 UnwrappedEndBlock() const { return (m_end_block + (Wraps() ? MAX_BLOCKS : 0)); }
+
 		void ResizeValidity(const GSVector4i& rect);
 		void UpdateValidity(const GSVector4i& rect);
 


### PR DESCRIPTION
### Description of Changes

The current invalidation code sucks, but at least this stops things which are blatently wrong from happening.

TC:NYC will have some slight glitches after this PR, I'll fix that in a follow-up.

Fixes rainbow vomit in COD2, haunting ground mirror, glitched textures in rally fustion, maybe others..

### Rationale behind Changes

![Untitled](https://user-images.githubusercontent.com/11288319/220635405-54d5a156-aca0-4c75-98ea-8ba09fe0245b.jpg)

Fixes #5431.

### Suggested Testing Steps

Test affected games.

