### PR TITLE
GS/HW: Make readback-on-close a HW fix

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -12860,6 +12860,8 @@ SLES-51504:
 SLES-51507:
   name: "Futurama"
   region: "PAL-M5"
+  gsHWFixes:
+    readTCOnClose: 1 # Fixes render to target getting lost on state/switch.
 SLES-51508:
   name: "Hulk, The"
   region: "PAL-M5"
@@ -42646,6 +42648,8 @@ SLUS-20439:
   name: "Futurama"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    readTCOnClose: 1 # Fixes render to target getting lost on state/switch.
 SLUS-20440:
   name: "Kya - Dark Lineage"
   region: "NTSC-U"

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -198,6 +198,7 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsDialog* dialog, QWidget* 
 	SettingWidgetBinder::BindWidgetToBoolSetting(
 		sif, m_ui.disablePartialInvalidation, "EmuCore/GS", "UserHacks_DisablePartialInvalidation", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.textureInsideRt, "EmuCore/GS", "UserHacks_TextureInsideRt", false);
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.readTCOnClose, "EmuCore/GS", "UserHacks_ReadTCOnClose", false);
 
 	//////////////////////////////////////////////////////////////////////////
 	// HW Upscaling Fixes
@@ -537,6 +538,10 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsDialog* dialog, QWidget* 
 		dialog->registerWidgetHelp(m_ui.textureInsideRt, tr("Texture Inside RT"), tr("Unchecked"),
 			tr("Allows the texture cache to reuse as an input texture the inner portion of a previous framebuffer. "
 			   "In some selected games this is enabled by default regardless of this setting."));
+
+		dialog->registerWidgetHelp(m_ui.readTCOnClose, tr("Read Targets When Closing"), tr("Unchecked"),
+			tr("Flushes all targets in the texture cache back to local memory when shutting down. Can prevent lost visuals when saving "
+			   "state or switching renderers, but can also cause graphical corruption."));
 	}
 
 	// Upscaling Fixes tab

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
@@ -947,17 +947,17 @@
        </item>
        <item row="5" column="0" colspan="2">
         <layout class="QGridLayout" name="gridLayout">
-         <item row="0" column="0">
-          <widget class="QCheckBox" name="hwAutoFlush">
-           <property name="text">
-            <string>Auto Flush</string>
-           </property>
-          </widget>
-         </item>
          <item row="0" column="1">
           <widget class="QCheckBox" name="frameBufferConversion">
            <property name="text">
             <string>Frame Buffer Conversion</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="0">
+          <widget class="QCheckBox" name="hwAutoFlush">
+           <property name="text">
+            <string>Auto Flush</string>
            </property>
           </widget>
          </item>
@@ -968,10 +968,10 @@
            </property>
           </widget>
          </item>
-         <item row="2" column="0">
-          <widget class="QCheckBox" name="disableSafeFeatures">
+         <item row="1" column="1">
+          <widget class="QCheckBox" name="preloadFrameData">
            <property name="text">
-            <string>Disable Safe Features</string>
+            <string>Preload Frame Data</string>
            </property>
           </widget>
          </item>
@@ -982,10 +982,10 @@
            </property>
           </widget>
          </item>
-         <item row="1" column="1">
-          <widget class="QCheckBox" name="preloadFrameData">
+         <item row="2" column="0">
+          <widget class="QCheckBox" name="disableSafeFeatures">
            <property name="text">
-            <string>Preload Frame Data</string>
+            <string>Disable Safe Features</string>
            </property>
           </widget>
          </item>
@@ -993,6 +993,13 @@
           <widget class="QCheckBox" name="textureInsideRt">
            <property name="text">
             <string>Texture Inside RT</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="1">
+          <widget class="QCheckBox" name="readTCOnClose">
+           <property name="text">
+            <string>Read Targets When Closing</string>
            </property>
           </widget>
          </item>

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -664,6 +664,7 @@ struct Pcsx2Config
 					UserHacks_AlignSpriteX : 1,
 					UserHacks_AutoFlush : 1,
 					UserHacks_CPUFBConversion : 1,
+					UserHacks_ReadTCOnClose : 1,
 					UserHacks_DisableDepthSupport : 1,
 					UserHacks_DisablePartialInvalidation : 1,
 					UserHacks_DisableSafeFeatures : 1,

--- a/pcsx2/Docs/gamedb-schema.json
+++ b/pcsx2/Docs/gamedb-schema.json
@@ -126,6 +126,11 @@
               "minimum": 0,
               "maximum": 1
             },
+            "readTCOnClose": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 1
+            },
             "disableDepthSupport": {
               "type": "integer",
               "minimum": 0,

--- a/pcsx2/Frontend/FullscreenUI.cpp
+++ b/pcsx2/Frontend/FullscreenUI.cpp
@@ -3196,6 +3196,9 @@ void FullscreenUI::DrawGraphicsSettingsPage()
 			DrawToggleSetting(bsi, "Texture Inside Render Target",
 				"Allows the texture cache to reuse as an input texture the inner portion of a previous framebuffer.", "EmuCore/GS",
 				"UserHacks_TextureInsideRt", false, manual_hw_fixes);
+			DrawToggleSetting(bsi, "Read Targets When Closing",
+				"Flushes all targets in the texture cache back to local memory when shutting down.", "EmuCore/GS",
+				"UserHacks_ReadTCOnClose", false, manual_hw_fixes);
 
 			MenuHeading("Upscaling Fixes");
 			DrawIntListSetting(bsi, "Half-Pixel Offset", "Adjusts vertices relative to upscaling.", "EmuCore/GS",

--- a/pcsx2/Frontend/ImGuiOverlays.cpp
+++ b/pcsx2/Frontend/ImGuiOverlays.cpp
@@ -421,6 +421,8 @@ void ImGuiManager::DrawSettingsOverlay()
 			APPEND("AF ");
 		if (GSConfig.UserHacks_CPUFBConversion)
 			APPEND("FBC ");
+		if (GSConfig.UserHacks_ReadTCOnClose)
+			APPEND("FTC ");
 		if(GSConfig.UserHacks_DisableDepthSupport)
 			APPEND("DDE ");
 		if (GSConfig.UserHacks_DisablePartialInvalidation)

--- a/pcsx2/GS/GSLocalMemory.h
+++ b/pcsx2/GS/GSLocalMemory.h
@@ -981,10 +981,15 @@ public:
 		off.loopPixels(r, vm32(), (u32*)src, pitch, [&](u32* dst, u32* src) { *dst = *src; });
 	}
 
+	void WritePixel32(u8* RESTRICT src, u32 pitch, const GSOffset& off, const GSVector4i& r, u32 write_mask)
+	{
+		off.loopPixels(r, vm32(), (u32*)src, pitch, [&](u32* dst, u32* src) { *dst = (*dst & ~write_mask) | (*src & write_mask); });
+	}
+
 	void WritePixel24(u8* RESTRICT src, u32 pitch, const GSOffset& off, const GSVector4i& r)
 	{
 		off.loopPixels(r, vm32(), (u32*)src, pitch,
-		[&](u32* dst, u32* src)
+			[&](u32* dst, u32* src)
 		{
 			*dst = (*dst & 0xff000000) | (*src & 0x00ffffff);
 		});

--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -2126,6 +2126,19 @@ void GSState::ReadLocalMemoryUnsync(u8* mem, int qwc, GIFRegBITBLTBUF BITBLTBUF,
 	m_mem.ReadImageX(tb.x, tb.y, mem, len, BITBLTBUF, TRXPOS, TRXREG);
 }
 
+void GSState::PurgePool()
+{
+	g_gs_device->PurgePool();
+}
+
+void GSState::PurgeTextureCache()
+{
+}
+
+void GSState::ReadbackTextureCache()
+{
+}
+
 template void GSState::Transfer<0>(const u8* mem, u32 size);
 template void GSState::Transfer<1>(const u8* mem, u32 size);
 template void GSState::Transfer<2>(const u8* mem, u32 size);
@@ -2344,6 +2357,9 @@ int GSState::Freeze(freezeData* fd, bool sizeonly)
 		return -1;
 
 	Flush(GSFlushReason::SAVESTATE);
+
+	if (GSConfig.UserHacks_ReadTCOnClose)
+		ReadbackTextureCache();
 
 	u8* data = fd->data;
 	const u32 version = STATE_VERSION;

--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -886,7 +886,9 @@ public:
 	bool TestDrawChanged();
 	void FlushWrite();
 	virtual void Draw() = 0;
-	virtual void PurgePool() = 0;
+	virtual void PurgePool();
+	virtual void PurgeTextureCache();
+	virtual void ReadbackTextureCache();
 	virtual void InvalidateVideoMem(const GIFRegBITBLTBUF& BITBLTBUF, const GSVector4i& r, bool eewrite = false) {}
 	virtual void InvalidateLocalMem(const GIFRegBITBLTBUF& BITBLTBUF, const GSVector4i& r, bool clut = false) {}
 	virtual void ExpandTarget(const GIFRegBITBLTBUF& BITBLTBUF, const GSVector4i& r) {}

--- a/pcsx2/GS/Renderers/Common/GSRenderer.cpp
+++ b/pcsx2/GS/Renderers/Common/GSRenderer.cpp
@@ -829,15 +829,6 @@ void GSRenderer::EndCapture()
 	GSCapture::EndCapture();
 }
 
-void GSRenderer::PurgePool()
-{
-	g_gs_device->PurgePool();
-}
-
-void GSRenderer::PurgeTextureCache()
-{
-}
-
 GSTexture* GSRenderer::LookupPaletteSource(u32 CBP, u32 CPSM, u32 CBW, GSVector2i& offset, const GSVector2i& size)
 {
 	return nullptr;

--- a/pcsx2/GS/Renderers/Common/GSRenderer.h
+++ b/pcsx2/GS/Renderers/Common/GSRenderer.h
@@ -53,9 +53,6 @@ public:
 	virtual GSVector2 GetTextureScaleFactor() { return { 1.0f, 1.0f }; }
 	GSVector2i GetInternalResolution();
 
-	virtual void PurgePool() override;
-	virtual void PurgeTextureCache();
-
 	virtual GSTexture* LookupPaletteSource(u32 CBP, u32 CPSM, u32 CBW, GSVector2i& offset, const GSVector2i& size);
 
 	bool SaveSnapshotToMemory(u32 window_width, u32 window_height, bool apply_aspect, bool crop_borders,

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -71,8 +71,12 @@ void GSRendererHW::Destroy()
 
 void GSRendererHW::PurgeTextureCache()
 {
-	GSRenderer::PurgeTextureCache();
-	m_tc->RemoveAll(true);
+	m_tc->RemoveAll();
+}
+
+void GSRendererHW::ReadbackTextureCache()
+{
+	m_tc->ReadbackAll();
 }
 
 GSTexture* GSRendererHW::LookupPaletteSource(u32 CBP, u32 CPSM, u32 CBW, GSVector2i& offset, const GSVector2i& size)

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -1959,6 +1959,8 @@ void GSRendererHW::Draw()
 		if(can_update_size)
 			rt->UpdateValidity(m_r);
 
+		rt->UpdateValidBits(~fm & fm_mask);
+
 		m_tc->InvalidateVideoMem(context->offset.fb, m_r, false, false);
 
 		m_tc->InvalidateVideoMemType(GSTextureCache::DepthStencil, context->FRAME.Block());
@@ -1970,6 +1972,8 @@ void GSRendererHW::Draw()
 		// Shouldn't be a problem as Z will be masked.
 		if (can_update_size)
 			ds->UpdateValidity(m_r);
+
+		ds->UpdateValidBits(GSLocalMemory::m_psm[context->ZBUF.PSM].fmsk);
 
 		m_tc->InvalidateVideoMem(context->offset.zb, m_r, false, false);
 

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.h
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.h
@@ -166,6 +166,7 @@ public:
 	void Draw() override;
 
 	void PurgeTextureCache() override;
+	void ReadbackTextureCache() override;
 	GSTexture* LookupPaletteSource(u32 CBP, u32 CPSM, u32 CBW, GSVector2i& offset, const GSVector2i& size) override;
 
 	// Called by the texture cache to know if current texture is useful

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -46,18 +46,23 @@ GSTextureCache::~GSTextureCache()
 	_aligned_free(s_unswizzle_buffer);
 }
 
-void GSTextureCache::RemoveAll(bool readback_targets)
+void GSTextureCache::ReadbackAll()
+{
+	for (int type = 0; type < 2; type++)
+	{
+		for (auto t : m_dst[type])
+			Read(t, t->m_drawn_since_read);
+	}
+}
+
+void GSTextureCache::RemoveAll()
 {
 	m_src.RemoveAll();
 
 	for (int type = 0; type < 2; type++)
 	{
 		for (auto t : m_dst[type])
-		{
-			if (readback_targets)
-				Read(t, t->m_drawn_since_read);
 			delete t;
-		}
 
 		m_dst[type].clear();
 	}

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.h
@@ -235,13 +235,14 @@ public:
 	{
 	public:
 		const int m_type = 0;
+		const bool m_depth_supported = false;
+		bool m_dirty_alpha = true;
+		bool m_is_frame = false;
 		bool m_used = false;
 		GSDirtyRectList m_dirty;
 		GSVector4i m_valid{};
 		GSVector4i m_drawn_since_read{};
-		const bool m_depth_supported = false;
-		bool m_dirty_alpha = true;
-		bool m_is_frame = false;
+		u32 m_valid_bits = 0;
 		int readbacks_since_draw = 0;
 
 	public:
@@ -257,6 +258,7 @@ public:
 
 		void ResizeValidity(const GSVector4i& rect);
 		void UpdateValidity(const GSVector4i& rect, bool can_resize = true);
+		void UpdateValidBits(u32 bits_written);
 
 		void Update(bool reset_age);
 

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.h
@@ -406,7 +406,8 @@ public:
 
 	void Read(Target* t, const GSVector4i& r);
 	void Read(Source* t, const GSVector4i& r);
-	void RemoveAll(bool readback_targets = false);
+	void RemoveAll();
+	void ReadbackAll();
 	void AddDirtyRectTarget(Target* target, GSVector4i rect, u32 psm, u32 bw);
 
 	GSTexture* LookupPaletteSource(u32 CBP, u32 CPSM, u32 CBW, GSVector2i& offset, const GSVector2i& size);

--- a/pcsx2/GameDatabase.cpp
+++ b/pcsx2/GameDatabase.cpp
@@ -342,6 +342,7 @@ void GameDatabase::parseAndInsert(const std::string_view& serial, const c4::yml:
 static const char* s_gs_hw_fix_names[] = {
 	"autoFlush",
 	"cpuFramebufferConversion",
+	"readTCOnClose",
 	"disableDepthSupport",
 	"wrapGSMem",
 	"preloadFrameData",
@@ -548,6 +549,9 @@ bool GameDatabaseSchema::GameEntry::configMatchesHWFix(const Pcsx2Config::GSOpti
 		case GSHWFixId::CPUFramebufferConversion:
 			return (static_cast<int>(config.UserHacks_CPUFBConversion) == value);
 
+		case GSHWFixId::FlushTCOnClose:
+			return (static_cast<int>(config.UserHacks_ReadTCOnClose) == value);
+
 		case GSHWFixId::DisableDepthSupport:
 			return (static_cast<int>(config.UserHacks_DisableDepthSupport) == value);
 
@@ -652,6 +656,10 @@ u32 GameDatabaseSchema::GameEntry::applyGSHardwareFixes(Pcsx2Config::GSOptions& 
 
 			case GSHWFixId::CPUFramebufferConversion:
 				config.UserHacks_CPUFBConversion = (value > 0);
+				break;
+
+			case GSHWFixId::FlushTCOnClose:
+				config.UserHacks_ReadTCOnClose = (value > 0);
 				break;
 
 			case GSHWFixId::DisableDepthSupport:

--- a/pcsx2/GameDatabase.h
+++ b/pcsx2/GameDatabase.h
@@ -62,6 +62,7 @@ namespace GameDatabaseSchema
 		// boolean settings
 		AutoFlush,
 		CPUFramebufferConversion,
+		FlushTCOnClose,
 		DisableDepthSupport,
 		WrapGSMem,
 		PreloadFrameData,

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -429,6 +429,7 @@ Pcsx2Config::GSOptions::GSOptions()
 	UserHacks_AlignSpriteX = false;
 	UserHacks_AutoFlush = false;
 	UserHacks_CPUFBConversion = false;
+	UserHacks_ReadTCOnClose = false;
 	UserHacks_DisableDepthSupport = false;
 	UserHacks_DisablePartialInvalidation = false;
 	UserHacks_DisableSafeFeatures = false;
@@ -640,6 +641,7 @@ void Pcsx2Config::GSOptions::LoadSave(SettingsWrapper& wrap)
 	GSSettingBoolEx(UserHacks_AlignSpriteX, "UserHacks_align_sprite_X");
 	GSSettingBoolEx(UserHacks_AutoFlush, "UserHacks_AutoFlush");
 	GSSettingBoolEx(UserHacks_CPUFBConversion, "UserHacks_CPU_FB_Conversion");
+	GSSettingBoolEx(UserHacks_ReadTCOnClose, "UserHacks_ReadTCOnClose");
 	GSSettingBoolEx(UserHacks_DisableDepthSupport, "UserHacks_DisableDepthSupport");
 	GSSettingBoolEx(UserHacks_DisablePartialInvalidation, "UserHacks_DisablePartialInvalidation");
 	GSSettingBoolEx(UserHacks_DisableSafeFeatures, "UserHacks_Disable_Safe_Features");
@@ -770,6 +772,7 @@ void Pcsx2Config::GSOptions::MaskUserHacks()
 	UserHacks_DisablePartialInvalidation = false;
 	UserHacks_DisableDepthSupport = false;
 	UserHacks_CPUFBConversion = false;
+	UserHacks_ReadTCOnClose = false;
 	UserHacks_TextureInsideRt = false;
 	UserHacks_TCOffsetX = 0;
 	UserHacks_TCOffsetY = 0;


### PR DESCRIPTION
### Description of Changes

Unfortunately it's too risky to enable by default all the time. So, we'll make it a hw fix, and hopefully one day can make it default on.

Also makes save states readback the TC as well.

Also fixes Burnout 3's sky getting corrupted when the option is on.

### Rationale behind Changes

Fixing Burnout's sky, probably other random corruption.

### Suggested Testing Steps

Test Burnout and save states and/or renderer switches.

Test a few games which need readbacks to make sure they still work.
