### PR TITLE
MCD: Stop Memcard Folders spamming the console/OSD when saving a game

### DIFF
--- a/pcsx2/MemoryCardFolder.cpp
+++ b/pcsx2/MemoryCardFolder.cpp
@@ -89,6 +89,7 @@ static void SaveYAMLToFile(const char* filename, const ryml::NodeRef& node)
 }
 
 static constexpr time_t MEMORY_CARD_FILE_ENTRY_DATE_TIME_OFFSET = 60 * 60 * 9; // 9 hours from UTC
+static auto last = std::chrono::time_point<std::chrono::system_clock>();
 
 MemoryCardFileEntryDateTime MemoryCardFileEntryDateTime::FromTime(time_t time)
 {
@@ -2353,9 +2354,16 @@ s32 FolderMemoryCardAggregator::Save(uint slot, const u8* src, u32 adr, int size
 	const s32 saveResult = m_cards[slot].Save(src, adr, size);
 	if (saveResult)
 	{
-		const std::string_view filename = Path::GetFileName(m_cards[slot].GetFolderName());
-		Host::AddIconOSDMessage(fmt::format("MemoryCardSave{}", slot), ICON_FA_SD_CARD,
-			fmt::format("Memory card '{}' was saved to storage.", filename), Host::OSD_INFO_DURATION);
+		std::chrono::duration<float> elapsed = std::chrono::system_clock::now() - last;
+		if (elapsed > std::chrono::seconds(5))
+		{
+			const std::string_view filename = Path::GetFileName(m_cards[slot].GetFolderName());
+			Host::AddIconOSDMessage(fmt::format("MemoryCardSave{}", slot), ICON_FA_SD_CARD,
+				fmt::format("Memory card '{}' was saved to storage.", filename), Host::OSD_INFO_DURATION);
+
+			last = std::chrono::system_clock::now();
+		}
+		
 	}
 
 	return saveResult;


### PR DESCRIPTION
### Description of Changes
Stops the OSD spam when saving a game to a memcard folder

### Rationale behind Changes
Every write triggered an OSD message, and there could be hundreds, this stops it happening more than once every 5 seconds.

### Suggested Testing Steps
Save your game with a folder memcard inserted, maybe with the console window open so you can see the green messages.
