### PR TITLE
GS-HW: Improve Local->Host and preload accuracy. Per channel dirtying targets.

### DIFF
--- a/pcsx2/GS/GSUtil.cpp
+++ b/pcsx2/GS/GSUtil.cpp
@@ -152,6 +152,22 @@ bool GSUtil::HasCompatibleBits(u32 spsm, u32 dpsm)
 	return (s_maps.CompatibleBitsField[spsm][dpsm >> 5] & (1 << (dpsm & 0x1f))) != 0;
 }
 
+u32 GSUtil::GetChannelMask(u32 spsm)
+{
+	switch (spsm)
+	{
+		case PSM_PSMCT24:
+		case PSM_PSMZ24:
+			return 0x7;
+		case PSM_PSMT8H:
+		case PSM_PSMT4HH: // This sucks, I'm sorry, but we don't have a way to do half channels
+		case PSM_PSMT4HL: // So uuhh TODO I guess.
+			return 0x8;
+		default:
+			return 0xf;
+	}
+}
+
 CRCHackLevel GSUtil::GetRecommendedCRCHackLevel(GSRendererType type)
 {
 	return (type == GSRendererType::DX11 || type == GSRendererType::DX12) ? CRCHackLevel::Full : CRCHackLevel::Partial;

--- a/pcsx2/GS/GSUtil.h
+++ b/pcsx2/GS/GSUtil.h
@@ -32,6 +32,7 @@ public:
 	static bool HasSharedBits(u32 spsm, u32 dpsm);
 	static bool HasSharedBits(u32 sbp, u32 spsm, u32 dbp, u32 dpsm);
 	static bool HasCompatibleBits(u32 spsm, u32 dpsm);
+	static u32 GetChannelMask(u32 spsm);
 
 	static CRCHackLevel GetRecommendedCRCHackLevel(GSRendererType type);
 	static GSRendererType GetPreferredRenderer();

--- a/pcsx2/GS/Renderers/Common/GSDirtyRect.cpp
+++ b/pcsx2/GS/Renderers/Common/GSDirtyRect.cpp
@@ -20,14 +20,16 @@
 GSDirtyRect::GSDirtyRect() :
 	r(GSVector4i::zero()),
 	psm(PSM_PSMCT32),
-	bw(1)
+	bw(1),
+	rgba({})
 {
 }
 
-GSDirtyRect::GSDirtyRect(GSVector4i& r, u32 psm, u32 bw) :
+GSDirtyRect::GSDirtyRect(GSVector4i& r, u32 psm, u32 bw, RGBAMask rgba) :
 	r(r),
 	psm(psm),
-	bw(bw)
+	bw(bw),
+	rgba(rgba)
 {
 }
 
@@ -71,6 +73,21 @@ GSVector4i GSDirtyRectList::GetTotalRect(GIFRegTEX0 TEX0, const GSVector2i& size
 	}
 
 	return GSVector4i::zero();
+}
+
+u32 GSDirtyRectList::GetDirtyChannels()
+{
+	u32 channels = 0;
+
+	if (!empty())
+	{
+		for (auto& dirty_rect : *this)
+		{
+			channels |= dirty_rect.rgba._u32;
+		}
+	}
+
+	return channels;
 }
 
 GSVector4i GSDirtyRectList::GetDirtyRect(size_t index, GIFRegTEX0 TEX0, const GSVector4i& clamp) const

--- a/pcsx2/GS/Renderers/Common/GSDirtyRect.h
+++ b/pcsx2/GS/Renderers/Common/GSDirtyRect.h
@@ -17,15 +17,28 @@
 
 #include "GS/GSLocalMemory.h"
 
+union RGBAMask
+{
+	struct
+	{
+		u32 r : 1;
+		u32 g : 1;
+		u32 b : 1;
+		u32 a : 1;
+	} c;
+	u32 _u32;
+};
+
 class GSDirtyRect
 {
 public:
 	GSVector4i r;
 	u32 psm;
 	u32 bw;
+	RGBAMask rgba;
 
 	GSDirtyRect();
-	GSDirtyRect(GSVector4i& r, u32 psm, u32 bw);
+	GSDirtyRect(GSVector4i& r, u32 psm, u32 bw, RGBAMask rgba);
 	GSVector4i GetDirtyRect(GIFRegTEX0 TEX0) const;
 };
 
@@ -34,5 +47,6 @@ class GSDirtyRectList : public std::vector<GSDirtyRect>
 public:
 	GSDirtyRectList() {}
 	GSVector4i GetTotalRect(GIFRegTEX0 TEX0, const GSVector2i& size) const;
+	u32 GetDirtyChannels();
 	GSVector4i GetDirtyRect(size_t index, GIFRegTEX0 TEX0, const GSVector4i& clamp) const;
 };

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -1530,7 +1530,7 @@ void GSTextureCache::InvalidateLocalMem(const GSOffset& off, const GSVector4i& r
 				Read(t, draw_rect);
 
 				t->readbacks_since_draw++;
-				if(draw_rect.rintersect(t->m_drawn_since_read).eq(t->m_drawn_since_read))
+				if (draw_rect.rintersect(t->m_drawn_since_read).eq(t->m_drawn_since_read))
 					t->m_drawn_since_read = GSVector4i::zero();
 			}
 		}
@@ -1586,7 +1586,7 @@ void GSTextureCache::InvalidateLocalMem(const GSOffset& off, const GSVector4i& r
 
 			// Calculate the rect offset if the BP doesn't match.
 			const GSVector4i targetr = GSVector4i((format_match) ? r.rintersect(t->m_valid) : ComputeSurfaceOffset(sok).b2a_offset).rintersect(t->m_drawn_since_read);
-			
+
 			if (!targetr.rempty())
 			{
 				// GH Note: Read will do a StretchRect and then will sizzle data to the GS memory
@@ -2927,8 +2927,13 @@ bool GSTextureCache::Surface::Inside(u32 bp, u32 bw, u32 psm, const GSVector4i& 
 bool GSTextureCache::Surface::Overlaps(u32 bp, u32 bw, u32 psm, const GSVector4i& rect)
 {
 	// Valid only for color formats.
-	const u32 end_block = GSLocalMemory::m_psm[psm].info.bn(rect.z - 1, rect.w - 1, bp, bw);
-	const u32 start_block = GSLocalMemory::m_psm[psm].info.bn(rect.x, rect.y, bp, bw);
+	u32 end_block = GSLocalMemory::m_psm[psm].info.bn(rect.z - 1, rect.w - 1, bp, bw);
+	u32 start_block = GSLocalMemory::m_psm[psm].info.bn(rect.x, rect.y, bp, bw);
+	// Due to block ordering, end can be below start in a page, so if it's within a page, swap them.
+	if (end_block < start_block && ((start_block - end_block) < (1 << 5)))
+	{
+		std::swap(start_block, end_block);
+	}
 	const bool overlap = GSTextureCache::CheckOverlap(m_TEX0.TBP0, m_end_block, start_block, end_block);
 	return overlap;
 }

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.h
@@ -408,7 +408,7 @@ public:
 	void Read(Source* t, const GSVector4i& r);
 	void RemoveAll();
 	void ReadbackAll();
-	void AddDirtyRectTarget(Target* target, GSVector4i rect, u32 psm, u32 bw);
+	void AddDirtyRectTarget(Target* target, GSVector4i rect, u32 psm, u32 bw, RGBAMask rgba);
 
 	GSTexture* LookupPaletteSource(u32 CBP, u32 CPSM, u32 CBW, GSVector2i& offset, const GSVector2i& size);
 


### PR DESCRIPTION
### Description of Changes
Improves the local memory invalidation skipping, and target selection for invalidation, but also fixes some bugs with preloading memory in to target.

Also support per channel dirtying of target textures.

### Rationale behind Changes
This wasn't quite right, there were edge cases and it was a bit fast and loose in some scenarios, this tries to be heuristically more accurate.
Some games also update just alpha channels on a 32bit colour, and previously we'd wipe out the RGB also and load it from local memory, this would of course load in garbage, so now it will attempt to only reload the necessary channels.

Overlap check also needed a fix as if the start and end pixel are within the same page, it's entirely possible due to the PS2 memory swizzling that the start block is higher than the end block, which will cause the validation check to fail, so now I check if they are within a page apart, if so then swap them.

### Suggested Testing Steps
Test games with readbacks (From Software games, Dog's Life, Busin 0, Ratchet Gladiator, Chaos Legion, Red Faction 2, SOCOM 2, Final Fantasy X, Kingdom Hearts 2, though I have briefly tested these myself), plus general stuff in terms of the dirtying.

Fixes Dog's Life regression with smell-o-vision (Download invalidation stuff)
Fixes #914 Ratchet & Clank pause screen background (Preload changes)
Fixes RTX Red Rock menu and textures (Dirty channels)
Fixes Driving Emotion Type S overlay properly (Dirty channels) will require further upscaling fixes to make it look good.
Fixes #4086 X-Men Wolverine black bars on the picture (Dirty channels), not 100% right, but good enough.
Fixes #5750 Shadow Hearts 2 flickering cutscenes. Not quite sure which, possibly the GS Download behaviour.
Fixes regression on Kingdom Hearts 2 (Overlap fix)

*might* fix Eternal Ring textures.

Ratchet & Clank pause screen:
![image](https://user-images.githubusercontent.com/6278726/221333711-77bf39db-515a-4fae-b1ed-bee4a9d3a834.png)

Eternal Ring textures:
![image](https://user-images.githubusercontent.com/6278726/221333785-bee6485a-b338-480f-a6cc-cdbd342de422.png)

Driving Emotion Type-S:

Master:
![image](https://user-images.githubusercontent.com/6278726/221352751-68aac782-795b-4d15-8e3c-ae618105b68f.png)

PR:
![image](https://user-images.githubusercontent.com/6278726/221352755-ba0fd2c7-7444-4eee-b0c8-e46f5e59484d.png)

RTX Red Rock:

Master:
![image](https://user-images.githubusercontent.com/6278726/221352786-c8d44fdf-a385-4c2a-9b10-8964e7150414.png)

PR:
![image](https://user-images.githubusercontent.com/6278726/221352789-f22415ce-1b98-49ed-a1a7-e62f888b2f19.png)

Ingame looks good too! :)
![image](https://user-images.githubusercontent.com/6278726/221353025-ae74ba9d-a89c-4fe0-9e4c-46ea90ce949b.png)

X-Men Wolverine:

Master:
![image](https://user-images.githubusercontent.com/6278726/221352812-bc44dd85-ef4a-49ec-b52d-595ac5f2509e.png)

PR:
![image](https://user-images.githubusercontent.com/6278726/221352818-b645759c-41ce-4748-9b95-2ee77f762c60.png)

