### PR TITLE
GS/HW: Use 1023 for skip-target-creation threshold

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -9109,7 +9109,7 @@ SLAJ-25080:
   name: "Godfather, The"
   region: "NTSC-Unk"
   gsHWFixes:
-    cpuCLUTRender: 1 # Fixes light occlusion.
+    gpuTargetCLUT: 1 # Fixes light occlusion.
     skipDrawStart: 1 # Removes mono-colored sepia bottom and vertical sepia bars on top.
     skipDrawEnd: 1 # Removes mono-colored sepia bottom and vertical sepia bars on top.
 SLAJ-25081:
@@ -18729,7 +18729,7 @@ SLES-53967:
   name: "Godfather, The"
   region: "PAL-M6"
   gsHWFixes:
-    cpuCLUTRender: 1 # Fixes light occlusion.
+    gpuTargetCLUT: 1 # Fixes light occlusion.
     skipDrawStart: 1 # Removes mono-colored sepia bottom and vertical sepia bars on top.
     skipDrawEnd: 1 # Removes mono-colored sepia bottom and vertical sepia bars on top.
 SLES-53968:
@@ -24351,7 +24351,7 @@ SLKA-25338:
   name: "Godfather, The"
   region: "NTSC-K"
   gsHWFixes:
-    cpuCLUTRender: 1 # Fixes light occlusion.
+    gpuTargetCLUT: 1 # Fixes light occlusion.
     skipDrawStart: 1 # Removes mono-colored sepia bottom and vertical sepia bars on top.
     skipDrawEnd: 1 # Removes mono-colored sepia bottom and vertical sepia bars on top.
 SLKA-25341:
@@ -33870,7 +33870,7 @@ SLPM-66710:
   name: "Godfather, The"
   region: "NTSC-J"
   gsHWFixes:
-    cpuCLUTRender: 1 # Fixes light occlusion.
+    gpuTargetCLUT: 1 # Fixes light occlusion.
     skipDrawStart: 1 # Removes mono-colored sepia bottom and vertical sepia bars on top.
     skipDrawEnd: 1 # Removes mono-colored sepia bottom and vertical sepia bars on top.
 SLPM-66712:
@@ -34748,7 +34748,7 @@ SLPM-66966:
   name: "Godfather, The [EA-SY! 1980]"
   region: "NTSC-J"
   gsHWFixes:
-    cpuCLUTRender: 1 # Fixes light occlusion.
+    gpuTargetCLUT: 1 # Fixes light occlusion.
     skipDrawStart: 1 # Removes mono-colored sepia bottom and vertical sepia bars on top.
     skipDrawEnd: 1 # Removes mono-colored sepia bottom and vertical sepia bars on top.
 SLPM-66967:
@@ -47626,7 +47626,7 @@ SLUS-21385:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    cpuCLUTRender: 1 # Fixes light occlusion.
+    gpuTargetCLUT: 1 # Fixes light occlusion.
     skipDrawStart: 1 # Removes mono-colored sepia bottom and vertical sepia bars on top.
     skipDrawEnd: 1 # Removes mono-colored sepia bottom and vertical sepia bars on top.
 SLUS-21386:
@@ -47738,7 +47738,7 @@ SLUS-21406:
   name: "Godfather, The - Collector's Edition"
   region: "NTSC-U"
   gsHWFixes:
-    cpuCLUTRender: 1 # Fixes light occlusion.
+    gpuTargetCLUT: 1 # Fixes light occlusion.
     skipDrawStart: 1 # Removes mono-colored sepia bottom and vertical sepia bars on top.
     skipDrawEnd: 1 # Removes mono-colored sepia bottom and vertical sepia bars on top.
 SLUS-21407:

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -1626,7 +1626,10 @@ void GSRendererHW::Draw()
 	GSTextureCache::Target* rt = nullptr;
 	if (!no_rt)
 	{
-		const bool is_square = (unscaled_target_size.y == unscaled_target_size.x) && m_r.w >= 1024 && m_vertex.next;
+		// Normally we would use 1024 here to match the clear above, but The Godfather does a 1023x1023 draw instead
+		// (very close to 1024x1024, but apparently the GS rounds down..). So, catch that here, we don't want to
+		// create that target, because the clear isn't black, it'll hang around and never get invalidated.
+		const bool is_square = (unscaled_target_size.y == unscaled_target_size.x) && m_r.w >= 1023 && m_vertex.next == 2;
 		rt = m_tc->LookupTarget(TEX0, t_size, GSTextureCache::RenderTarget, true, fm, false, unscaled_target_size.x, unscaled_target_size.y, force_preload, IsConstantDirectWriteMemClear(false) && is_square);
 
 		// Draw skipped because it was a clear and there was no target.


### PR DESCRIPTION
### Description of Changes

Normally we would use 1024 here to match the clear above, but The Godfather does a 1023x1023 draw instead (very close to 1024x1024, but apparently the GS rounds down..). So, catch that case, we don't want to create that target, because the clear isn't black, it'll hang around and never get invalidated.

### Rationale behind Changes

That 1024x1024 target gets read back with CPU CLUT enabled, blowing away the entirety of local memory, including texture data.

### Suggested Testing Steps

Test Godfather (booting from fresh, not a state). Open menu, should be fine.
