### PR TITLE
GameDB: Timesplitters Series + minor maintenance

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -9237,7 +9237,7 @@ SLED-50884:
   name: "TimeSplitters 2 [Demo]"
   region: "PAL-E"
   gsHWFixes:
-    halfPixelOffset: 1 # Fixes texture slight misalignment.
+    halfPixelOffset: 2 # Fixes texture slight misalignment.
 SLED-50895:
   name: "Medal of Honor - Frontline [Demo]"
   region: "PAL-E"
@@ -11486,7 +11486,7 @@ SLES-50877:
   region: "PAL-M5"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 1 # Fixes texture slight misalignment.
+    halfPixelOffset: 2 # Fixes texture slight misalignment.
 SLES-50879:
   name: "Paris-Dakar 2"
   region: "PAL-M5"
@@ -16204,7 +16204,7 @@ SLES-52993:
   name: "TimeSplitters - Future Perfect"
   region: "PAL-M5"
   gsHWFixes:
-    halfPixelOffset: 3 # Removes ghosting of distant objects.
+    halfPixelOffset: 2 # Removes ghosting of distant objects.
 SLES-52998:
   name: "Sonic Mega Collection Plus"
   region: "PAL-M5"
@@ -42126,7 +42126,7 @@ SLUS-20314:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 1 # Fixes texture slight misalignment.
+    halfPixelOffset: 2 # Fixes texture slight misalignment.
 SLUS-20315:
   name: "Spyro the Dragon - Enter the Dragonfly"
   region: "NTSC-U"
@@ -46256,7 +46256,7 @@ SLUS-21148:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 3 # Removes ghosting of distant objects.
+    halfPixelOffset: 2 # Removes ghosting of distant objects.
 SLUS-21149:
   name: "Yourself! Fitness"
   region: "NTSC-U"
@@ -49773,7 +49773,7 @@ SLUS-21841:
   region: "NTSC-U"
   compat: 5
 SLUS-21842:
-  name: "Dragon Ball Z Infinite World"
+  name: "Dragon Ball Z - Infinite World"
   region: "NTSC-U"
   compat: 5
 SLUS-21843:


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
- Timesplitters 2 (normal vertex screwing up bottom)
- Before:
![TimeSplitters 2_SLUS-20314_20230226011306](https://user-images.githubusercontent.com/24227051/221385402-391d79ba-12ce-4ec8-9ab3-567c6562617b.png)
- After:
![TimeSplitters 2_SLUS-20314_20230226011310](https://user-images.githubusercontent.com/24227051/221385404-829e7e96-3ae8-4d8a-b494-5a489842bf3e.png)

- Timesplitters Future Perfect (remove depth lines)
- Before:
![TimeSplitters - Future Perfect_SLES-52993_20230226005147](https://user-images.githubusercontent.com/24227051/221385359-c78d6684-daa2-4ba7-8078-afec49f9d13f.png)
- After:
![TimeSplitters - Future Perfect_SLES-52993_20230226005150](https://user-images.githubusercontent.com/24227051/221385362-96e5e341-2e20-4049-8651-3bc2768955d6.png)
- Dragon Ball Z - Infinite World (dash)
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Less tinkering
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test relevant games.