### PR TITLE
GS-HW: Set scale on temporary depth stencil

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -3793,6 +3793,7 @@ void GSRendererHW::DrawPrims(GSTexture* rt, GSTexture* ds, GSTextureCache::Sourc
 		m_conf.destination_alpha <= GSHWDrawConfig::DestinationAlphaMode::StencilOne && !m_conf.ds)
 	{
 		temp_ds = g_gs_device->CreateDepthStencil(rt->GetWidth(), rt->GetHeight(), GSTexture::Format::DepthStencil, false);
+		temp_ds->SetScale(m_conf.rt->GetScale());
 		m_conf.ds = temp_ds;
 	}
 


### PR DESCRIPTION
### Description of Changes
Sets the scale for the temp depth stencil for when upscaling is active.

### Rationale behind Changes
This was a regression from #8242 which affected The Sims Bustin' Out when upscaled

### Suggested Testing Steps
Test the sims
