### PR TITLE
GS/HW: Don't try to draw with invalid TEX0 configuration

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -330,6 +330,13 @@ GSTextureCache::Source* GSTextureCache::LookupSource(const GIFRegTEX0& TEX0, con
 		}
 	}
 
+	// Prevent everything going to rubbish if a game somehow sends a TW/TH above 10, and region isn't being used.
+	if ((TEX0.TW > 10 && !region.HasX()) || (TEX0.TH > 10 && !region.HasY()))
+	{
+		GL_CACHE("Invalid TEX0 size %ux%u without region, aborting draw.", TEX0.TW, TEX0.TH);
+		throw GSRecoverableError();
+	}
+
 	const GSVector2i compare_lod(lod ? *lod : GSVector2i(0, 0));
 	Source* src = nullptr;
 


### PR DESCRIPTION
### Description of Changes

Fixes the texture cache falling apart in 007: Everything or Nothing.

### Rationale behind Changes

Stops PCSX2 crashing.

Closes #8260.

### Suggested Testing Steps

Test EoN.
