### PR TITLE
GS/HW: Track target sources in all pages

### DIFF
--- a/pcsx2/GS/GSLocalMemory.h
+++ b/pcsx2/GS/GSLocalMemory.h
@@ -180,6 +180,12 @@ public:
 		return BNHelper(*this, x, y).value();
 	}
 
+	/// Get the block number of the given pixel, without wrapping to MAX_BLOCKS
+	u32 bnNoWrap(int x, int y) const
+	{
+		return BNHelper(*this, x, y).valueNoWrap();
+	}
+
 	/// Get a helper class for efficiently calculating multiple block numbers
 	BNHelper bnMulti(int x, int y) const
 	{

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -2978,7 +2978,7 @@ void GSTextureCache::Source::SetPages()
 
 	m_repeating = !m_from_hash_cache && m_TEX0.IsRepeating() && !m_region.IsFixedTEX0(tw, th);
 
-	if (m_repeating && !CanPreload())
+	if (m_repeating && !m_target && !CanPreload())
 	{
 		// TODO: wrong for lupin/invalid tex0
 		m_p2t = g_gs_renderer->m_mem.GetPage2TileMap(m_TEX0);
@@ -3512,18 +3512,6 @@ void GSTextureCache::SourceMap::Add(Source* s, const GIFRegTEX0& TEX0, const GSO
 {
 	m_surfaces.insert(s);
 
-	if (s->m_target)
-	{
-		// TODO
-
-		// GH: I don't know why but it seems we only consider the first page for a render target
-		const size_t page = TEX0.TBP0 >> 5;
-
-		s->m_erase_it[page] = m_map[page].InsertFront(s);
-
-		return;
-	}
-
 	// The source pointer will be stored/duplicated in all m_map[array of pages]
 	s->m_pages.loopPages([this, s](u32 page)
 	{
@@ -3561,18 +3549,10 @@ void GSTextureCache::SourceMap::RemoveAt(Source* s)
 		s->m_texture ? s->m_texture->GetID() : 0,
 		s->m_TEX0.TBP0);
 
-	if (s->m_target)
+	s->m_pages.loopPages([this, s](u32 page)
 	{
-		const size_t page = s->m_TEX0.TBP0 >> 5;
 		m_map[page].EraseIndex(s->m_erase_it[page]);
-	}
-	else
-	{
-		s->m_pages.loopPages([this, s](u32 page)
-		{
-			m_map[page].EraseIndex(s->m_erase_it[page]);
-		});
-	}
+	});
 
 	if (s->m_from_hash_cache)
 	{

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.h
@@ -132,6 +132,13 @@ public:
 		Surface();
 		virtual ~Surface();
 
+		/// Returns true if the target wraps around the end of GS memory.
+		bool Wraps() const { return (m_end_block < m_TEX0.TBP0); }
+
+		/// Returns the end block for the target, but doesn't wrap at 0x3FFF.
+		/// Can be used for overlap tests.
+		u32 UnwrappedEndBlock() const { return (m_end_block + (Wraps() ? MAX_BLOCKS : 0)); }
+
 		void UpdateAge();
 		bool Inside(u32 bp, u32 bw, u32 psm, const GSVector4i& rect);
 		bool Overlaps(u32 bp, u32 bw, u32 psm, const GSVector4i& rect);
@@ -248,13 +255,6 @@ public:
 	public:
 		Target(const GIFRegTEX0& TEX0, const bool depth_supported, const int type);
 		~Target();
-
-		/// Returns true if the target wraps around the end of GS memory.
-		bool Wraps() const { return (m_end_block < m_TEX0.TBP0); }
-
-		/// Returns the end block for the target, but doesn't wrap at 0x3FFF.
-		/// Can be used for overlap tests.
-		u32 UnwrappedEndBlock() const { return (m_end_block + (Wraps() ? MAX_BLOCKS : 0)); }
 
 		void ResizeValidity(const GSVector4i& rect);
 		void UpdateValidity(const GSVector4i& rect, bool can_resize = true);


### PR DESCRIPTION
### Description of Changes

Track target sources in all pages instead of just the first page it falls within.

Not really sure on the justification behind this, but I need source invalidation out of the origin page for fixing Destroy All Humans.

### Rationale behind Changes

Enabling future TC functionality.

### Suggested Testing Steps

Test regular games.. runner says it's okay.
