### PR TITLE
Qt: Cancel game list refresh before GetSaveStateFileName()

### DIFF
--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -2882,6 +2882,9 @@ void MainWindow::doStartFile(std::optional<CDVD_SourceType> source, const QStrin
 	// we might still be saving a resume state...
 	VMManager::WaitForSaveStateFlush();
 
+	// GetSaveStateFileName() might temporarily mount the ISO to get the serial.
+	cancelGameListRefresh();
+
 	const std::optional<bool> resume(
 		promptForResumeState(QString::fromStdString(VMManager::GetSaveStateFileName(params->filename.c_str(), -1))));
 	if (!resume.has_value())


### PR DESCRIPTION
### Description of Changes

Fixes lockup/crash when starting a file early.

### Rationale behind Changes

Closes #8266.

### Suggested Testing Steps

@RedDevilus knows what to do.
