### PR TITLE
Qt: Don't display updater if running a game or fullscreen

### DIFF
--- a/pcsx2-qt/AutoUpdaterDialog.cpp
+++ b/pcsx2-qt/AutoUpdaterDialog.cpp
@@ -495,6 +495,16 @@ void AutoUpdaterDialog::checkIfUpdateNeeded()
 
 	Console.WriteLn(Color_StrongRed, "Update needed.");
 
+	// Don't show the dialog if a game started while the update info was downloading. Some people have
+	// really slow connections, apparently. If we're a manual triggered update check, then display
+	// regardless. This will fall through and signal main to delete us.
+	if (!m_display_messages &&
+		(QtHost::IsVMValid() || (g_emu_thread->isRunningFullscreenUI() && g_emu_thread->isFullscreen())))
+	{
+		Console.WriteLn(Color_StrongRed, "Not showing update dialog due to active VM.");
+		return;
+	}
+
 	m_ui.currentVersion->setText(tr("Current Version: %1 (%2)").arg(getCurrentVersion()).arg(getCurrentVersionDate()));
 	m_ui.newVersion->setText(tr("New Version: %1 (%2)").arg(m_latest_version).arg(m_latest_version_timestamp.toString()));
 	m_ui.updateNotes->setText(tr("Loading..."));


### PR DESCRIPTION
### Description of Changes

Both can be annoying if the update check takes a long time, and it takes focus away from the game or big picture UI.

Manual update checks will still display regardless of whether a game is running.

### Rationale behind Changes

Closes #8196.

### Suggested Testing Steps

Bit difficult to test this, because the updater isn't enabled on PR builds. But I've done my best to simulate the scenarios, and the logic is simple enough to follow.
