### PR TITLE
GameDB: Dance Summit 2001 Fixes

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -25430,6 +25430,8 @@ SLPM-62029:
   name: "Bust A Move - Dance Summit 2001"
   region: "NTSC-J"
   compat: 5
+  gsHWFixes:
+    gpuPaletteConversion: 2 # Improves FPS drastically and reduces HC size massively.
 SLPM-62031:
   name: "Primal Image for Printer"
   region: "NTSC-J"


### PR DESCRIPTION
### Description of Changes
Adds paltex to Dance Summit 2001 to massive increase FPS and reduce hash cache usage dramatically.

Master:
![image](https://user-images.githubusercontent.com/80843560/221438491-7a7d664c-162a-42e8-a069-e91a5ed4e241.png)


PR:
![image](https://user-images.githubusercontent.com/80843560/221438501-9cd616a8-5448-4462-b233-6ededb2a39e5.png)


### Rationale behind Changes
More brrr and less hash cache gooder betterer.

### Suggested Testing Steps
Make sure CI is happy.
