### PR TITLE
GS: Fix output equal check in Merge()

### DIFF
--- a/pcsx2/GS/Renderers/Common/GSDevice.cpp
+++ b/pcsx2/GS/Renderers/Common/GSDevice.cpp
@@ -283,36 +283,8 @@ void GSDevice::ClearCurrent()
 
 void GSDevice::Merge(GSTexture* sTex[3], GSVector4* sRect, GSVector4* dRect, const GSVector2i& fs, const GSRegPMODE& PMODE, const GSRegEXTBUF& EXTBUF, const GSVector4& c)
 {
-	// KH:COM crashes at startup when booting *through the bios* due to m_merge being NULL.
-	// (texture appears to be non-null, and is being re-created at a size around like 1700x340,
-	// dunno if that's relevant) -- air
-
 	if (ResizeTarget(&m_merge, fs.x, fs.y))
-	{
-		GSTexture* tex[3] = {NULL, NULL, NULL};
-
-		for (size_t i = 0; i < std::size(tex); i++)
-		{
-			if (sTex[i] != NULL)
-			{
-				tex[i] = sTex[i];
-			}
-		}
-
-		DoMerge(tex, sRect, m_merge, dRect, PMODE, EXTBUF, c, GSConfig.PCRTCOffsets);
-
-		for (size_t i = 0; i < std::size(tex); i++)
-		{
-			if (tex[i] != sTex[i])
-			{
-				Recycle(tex[i]);
-			}
-		}
-	}
-	else
-	{
-		printf("GS: m_merge is NULL!\n");
-	}
+		DoMerge(sTex, sRect, m_merge, dRect, PMODE, EXTBUF, c, GSConfig.PCRTCOffsets);
 
 	m_current = m_merge;
 }

--- a/pcsx2/GS/Renderers/Common/GSRenderer.cpp
+++ b/pcsx2/GS/Renderers/Common/GSRenderer.cpp
@@ -78,7 +78,7 @@ void GSRenderer::Destroy()
 bool GSRenderer::Merge(int field)
 {
 	GSVector2i fs(0, 0);
-	GSTexture* tex[3] = { NULL, NULL, NULL };
+	GSTexture* tex[3] = { nullptr, nullptr, nullptr };
 	int y_offset[3] = { 0, 0, 0 };
 	const bool feedback_merge = m_regs->EXTWRITE.WRITE == 1;
 
@@ -120,7 +120,6 @@ bool GSRenderer::Merge(int field)
 
 	s_n++;
 
-	GSVector4 src_out_rect[2];
 	GSVector4 src_gs_read[2];
 	GSVector4 dst[3];
 
@@ -202,13 +201,13 @@ bool GSRenderer::Merge(int field)
 
 	m_real_size = GSVector2i(fs.x, fs.y);
 
-	if ((tex[0] == tex[1]) && (src_out_rect[0] == src_out_rect[1]).alltrue() && 
+	if ((tex[0] == tex[1]) && (src_gs_read[0] == src_gs_read[1]).alltrue() && (dst[0] == dst[1]).alltrue() &&
 		(PCRTCDisplays.PCRTCDisplays[0].displayRect == PCRTCDisplays.PCRTCDisplays[1].displayRect).alltrue() &&
 		(PCRTCDisplays.PCRTCDisplays[0].framebufferRect == PCRTCDisplays.PCRTCDisplays[1].framebufferRect).alltrue() &&
 		!feedback_merge && !m_regs->PMODE.SLBG)
 	{
 		// the two outputs are identical, skip drawing one of them (the one that is alpha blended)
-		tex[0] = NULL;
+		tex[0] = nullptr;
 	}
 
 	GSVector4 c = GSVector4((int)m_regs->BGCOLOR.R, (int)m_regs->BGCOLOR.G, (int)m_regs->BGCOLOR.B, (int)m_regs->PMODE.ALP) / 255;


### PR DESCRIPTION
### Description of Changes

`src_out_rect` was never initialized, so equality only happened in debug builds, and it also wasn't testing the source rectangle (from the texture).

### Rationale behind Changes

Gets rid of a redundant framebuffer blit at the end of a frame in games where the two merge inputs are identical, saving a bit of GPU time.

### Suggested Testing Steps

Doing a runner pass to be safe..