### PR TITLE
GS/DX12: Add missing clip_control support flag

### DIFF
--- a/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
@@ -210,6 +210,7 @@ bool GSDevice12::CheckFeatures()
 	m_features.line_expand = false;
 	m_features.framebuffer_fetch = false;
 	m_features.dual_source_blend = true;
+	m_features.clip_control = true;
 	m_features.stencil_buffer = true;
 
 	m_features.dxt_textures = g_d3d12_context->SupportsTextureFormat(DXGI_FORMAT_BC1_UNORM) &&


### PR DESCRIPTION
### Description of Changes

Fixes depth inaccuracy in WWE SmackDown! Here Comes the Pain.

### Rationale behind Changes

Mentioned in #3636.

Sadly depth is still kinda broken on Intel. Only happens with zclamp on, i.e. writing depth in the shader. Might be a driver bug.

### Suggested Testing Steps

Test DX12, but it's fairly obvious this was missing, and incorrect MaxDepth was being set in the shader as a result.