### PR TITLE
GS-TC: On invalidate of the alpha of 32bit, drop back to 24bit

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -1376,11 +1376,22 @@ void GSTextureCache::InvalidateVideoMem(const GSOffset& off, const GSVector4i& r
 
 					if (can_erase)
 					{
-						i = list.erase(j);
-						GL_CACHE("TC: Remove Target(%s) %d (0x%x)", to_string(type),
-							t->m_texture ? t->m_texture->GetID() : 0,
-							t->m_TEX0.TBP0);
-						delete t;
+						// If it's a 32bit value and only the alpha channel is being killed
+						// instead of losing the RGB data, drop it back to 24bit.
+						if (rgba._u32 == 0x8 && t->m_TEX0.PSM == PSM_PSMCT32)
+						{
+							t->m_TEX0.PSM = PSM_PSMCT24;
+							t->m_dirty_alpha = false;
+							++i;
+						}
+						else
+						{
+							i = list.erase(j);
+							GL_CACHE("TC: Remove Target(%s) %d (0x%x)", to_string(type),
+								t->m_texture ? t->m_texture->GetID() : 0,
+								t->m_TEX0.TBP0);
+							delete t;
+						}
 					}
 					else
 					{


### PR DESCRIPTION
### Description of Changes
If the alpha channel of a C32 texture gets overwritten, instead of erasing the whole texture, make it a 24bit texture so it no longer uses alpha.

### Rationale behind Changes
This was previously erasing it and destroying the RGB data along with it, which in Shadow Hearts later got reused, but instead of getting this data since it was gone, it got garbage from memory.  This is a heuristic so it *might* break something, but hopefully it's safe.

### Suggested Testing Steps
Test Shadow Hearts as per the issue below, test general games. GS Dump runner seemed to not affect anything.

Fixes #6959 Shadow Hearts Covenant broken fusion effect
Fixes #909 Primal black screen in HW mode.
Mobile Suit Gundam - One Year War also shows some improvement, but is still unfortunately unplayable in hardware.

Master:
![image](https://user-images.githubusercontent.com/6278726/221727644-d7dbbc61-40b3-43e2-9ae5-030f73b43726.png)

PR:
![image](https://user-images.githubusercontent.com/6278726/221727680-d05d3223-fd1c-45b6-a01f-ac7c8c02956b.png)
