### PR TITLE
Qt: Skipdraw shouldn't be visible in global settings

### DIFF
--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -296,7 +296,7 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsDialog* dialog, QWidget* 
 
 		// Remove texture offset and skipdraw range for global settings.
 		m_ui.upscalingFixesLayout->removeRow(2);
-		m_ui.hardwareFixesLayout->removeRow(3);
+		m_ui.hardwareFixesLayout->removeRow(4);
 		m_ui.skipDrawStart = nullptr;
 		m_ui.skipDrawEnd = nullptr;
 		m_ui.textureOffsetX = nullptr;


### PR DESCRIPTION
### Description of Changes

I think I stuffed this up when I added GPU CLUT, it got hidden instead.

### Rationale behind Changes

Silly users following "youtube settings" then whinging that stuff is broken

### Suggested Testing Steps

yolo