### PR TITLE
GameDB: Adjust de-interlacing for Pac-Man World 2

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -3116,6 +3116,8 @@ SCES-50887:
 SCES-50888:
   name: "Pac-Man World 2"
   region: "PAL-M5"
+  gsHWFixes:
+    deinterlace: 6 # Game looks better with Blend tff when auto, especially during FMVs and also gameplay as it is slightly noticable.
   gameFixes:
     - EETimingHack # Fixes hanging in Butane Pain, Ghost Bayou, Pinky's Revenge and Clyde in the Caldera levels.
 SCES-50889:
@@ -6821,6 +6823,8 @@ SCPS-55035:
 SCPS-55038:
   name: "Pac-Man World 2"
   region: "NTSC-J"
+  gsHWFixes:
+    deinterlace: 6 # Game looks better with Blend tff when auto, especially during FMVs and also gameplay as it is slightly noticable.
   gameFixes:
     - EETimingHack # Fixes hanging in Butane Pain, Ghost Bayou, Pinky's Revenge and Clyde in the Caldera levels.
 SCPS-55040:
@@ -37282,6 +37286,8 @@ SLPS-25139:
 SLPS-25141:
   name: "Pac-Man World 2"
   region: "NTSC-J"
+  gsHWFixes:
+    deinterlace: 6 # Game looks better with Blend tff when auto, especially during FMVs and also gameplay as it is slightly noticable.
   gameFixes:
     - EETimingHack # Fixes hanging in Butane Pain, Ghost Bayou, Pinky's Revenge and Clyde in the Caldera levels.
 SLPS-25142:
@@ -41653,6 +41659,8 @@ SLUS-20224:
   name: "Pac-Man World 2"
   region: "NTSC-U"
   compat: 4
+  gsHWFixes:
+    deinterlace: 6 # Game looks better with Blend tff when auto, especially during FMVs and also gameplay as it is slightly noticable.
   gameFixes:
     - EETimingHack # Fixes hanging in Butane Pain, Ghost Bayou, Pinky's Revenge and Clyde in the Caldera levels.
 SLUS-20225:


### PR DESCRIPTION
### Description of Changes
This PR aims to tweak the de-interlacing mode that were in-use on Pac-Man World 2 to blend tff.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
When auto were selected, it seems that adaptive tff were used instead. Based on some of my testing, adaptive tff causes some slightly subtle de-interlacing artifacts.

This changes the de-interlacing mode to blend tff which noticeably looks better.

Before:
![Screenshot_20230228_234932](https://user-images.githubusercontent.com/14798312/221925840-1e5f1832-9f51-4a21-a770-47fe4d9e9a9f.png)

After:
![Screenshot_20230228_234954](https://user-images.githubusercontent.com/14798312/221926645-eae4a502-89c3-4b89-86a2-2bcf63268a85.png)


### Suggested Testing Steps
I have tested several levels, it seems to help with the de-interlacing and there we no apparent issues that crops up.
