### PR TITLE
Make Game Properties accessible from the toolbar

### DIFF
--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -254,6 +254,10 @@ void MainWindow::setupAdditionalUi()
 	m_status_vps_widget->setFixedSize(125, 16);
 	m_status_vps_widget->hide();
 
+	m_settings_toolbar_menu = new QMenu(m_ui.toolBar);
+	m_settings_toolbar_menu->addAction(m_ui.actionSettings);
+	m_settings_toolbar_menu->addAction(m_ui.actionViewGameProperties);
+
 	for (u32 scale = 0; scale <= 10; scale++)
 	{
 		QAction* action = m_ui.menuWindowSize->addAction((scale == 0) ? tr("Internal Resolution") : tr("%1x Scale").arg(scale));
@@ -316,6 +320,7 @@ void MainWindow::connectSignals()
 	connect(m_ui.menuLoadState, &QMenu::aboutToShow, this, &MainWindow::onLoadStateMenuAboutToShow);
 	connect(m_ui.menuSaveState, &QMenu::aboutToShow, this, &MainWindow::onSaveStateMenuAboutToShow);
 	connect(m_ui.actionSettings, &QAction::triggered, [this]() { doSettings(); });
+	connect(m_ui.actionSettings2, &QAction::triggered, this, &MainWindow::onSettingsTriggeredFromToolbar);
 	connect(m_ui.actionInterfaceSettings, &QAction::triggered, [this]() { doSettings("Interface"); });
 	connect(m_ui.actionGameListSettings, &QAction::triggered, [this]() { doSettings("Game List"); });
 	connect(m_ui.actionEmulationSettings, &QAction::triggered, [this]() { doSettings("Emulation"); });
@@ -1011,6 +1016,18 @@ void MainWindow::onToolsVideoCaptureToggled(bool checked)
 	}
 
 	g_emu_thread->beginCapture(path);
+}
+
+void MainWindow::onSettingsTriggeredFromToolbar()
+{
+	if (s_vm_valid)
+	{
+		m_settings_toolbar_menu->exec(QCursor::pos());
+	}
+	else
+	{
+		doSettings();
+	}
 }
 
 void MainWindow::saveStateToConfig()

--- a/pcsx2-qt/MainWindow.h
+++ b/pcsx2-qt/MainWindow.h
@@ -19,6 +19,7 @@
 
 #include <QtWidgets/QLabel>
 #include <QtWidgets/QMainWindow>
+#include <QtWidgets/QMenu>
 #include <functional>
 #include <optional>
 
@@ -170,6 +171,7 @@ private Q_SLOTS:
 	void onBlockDumpActionToggled(bool checked);
 	void onShowAdvancedSettingsToggled(bool checked);
 	void onToolsVideoCaptureToggled(bool checked);
+	void onSettingsTriggeredFromToolbar();
 
 	// Input Recording
 	void onInputRecNewActionTriggered();
@@ -282,6 +284,8 @@ private:
 	QLabel* m_status_fps_widget = nullptr;
 	QLabel* m_status_vps_widget = nullptr;
 	QLabel* m_status_resolution_widget = nullptr;
+
+	QMenu* m_settings_toolbar_menu = nullptr;
 
 	QString m_current_disc_path;
 	QString m_current_elf_override;

--- a/pcsx2-qt/MainWindow.ui
+++ b/pcsx2-qt/MainWindow.ui
@@ -86,6 +86,8 @@
     <property name="title">
      <string>S&amp;ettings</string>
     </property>
+    <addaction name="actionViewGameProperties"/>
+    <addaction name="separator"/>
     <addaction name="actionInterfaceSettings"/>
     <addaction name="actionGameListSettings"/>
     <addaction name="actionBIOSSettings"/>
@@ -156,7 +158,6 @@
     <addaction name="actionViewGameList"/>
     <addaction name="actionViewGameGrid"/>
     <addaction name="actionViewSystemDisplay"/>
-    <addaction name="actionViewGameProperties"/>
     <addaction name="separator"/>
     <addaction name="actionFullscreen"/>
     <addaction name="menuWindowSize"/>

--- a/pcsx2-qt/MainWindow.ui
+++ b/pcsx2-qt/MainWindow.ui
@@ -79,7 +79,6 @@
     <addaction name="menuLoadState"/>
     <addaction name="menuSaveState"/>
     <addaction name="separator"/>
-    <addaction name="actionSettings"/>
     <addaction name="actionExit"/>
    </widget>
    <widget class="QMenu" name="menuSettings">
@@ -246,7 +245,7 @@
    <addaction name="separator"/>
    <addaction name="actionFullscreen"/>
    <addaction name="separator"/>
-   <addaction name="actionSettings"/>
+   <addaction name="actionSettings2"/>
    <addaction name="actionControllerSettings"/>
   </widget>
   <widget class="QStatusBar" name="statusBar"/>
@@ -523,7 +522,19 @@
      <normaloff>.</normaloff>.</iconset>
    </property>
    <property name="text">
-    <string>&amp;Settings...</string>
+    <string>&amp;Settings</string>
+   </property>
+   <property name="menuRole">
+    <enum>QAction::PreferencesRole</enum>
+   </property>
+  </action>
+  <action name="actionSettings2">
+   <property name="icon">
+    <iconset theme="settings-3-line">
+     <normaloff>.</normaloff>.</iconset>
+   </property>
+   <property name="text">
+    <string>&amp;Settings</string>
    </property>
    <property name="menuRole">
     <enum>QAction::PreferencesRole</enum>


### PR DESCRIPTION
### Description of Changes
This PR changes the behaviour of the toolbar's `Settings` button:
* When the game is not running, open Global Settings (same as it is now).
* When the game is running, open a small context menu that allows the user to open Global Settings or Game Properties.

![image](https://user-images.githubusercontent.com/7947461/221946714-fae304f4-8bfd-4164-a517-af8757e15af7.png)

It also removes `File -> Settings` for consistency with DuckStation, besides a whole Settings menu is right next to it.

### Rationale behind Changes
More intuitive access to Game Properties, also signaling clearly what is what - currently it may be unclear whether clicking `Settings` changes global or per-game settings.

### Suggested Testing Steps
Make sure UI works as described.
