### PR TITLE
GS/Vulkan: Fix RT being left bound as texture

### DIFF
--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
@@ -3020,9 +3020,8 @@ void GSDeviceVK::RenderHW(GSHWDrawConfig& config)
 		}
 	}
 	// clear texture binding when it's bound to RT or DS
-	if (!config.tex && m_tfx_textures[0] &&
-		((!pipe.feedback_loop && config.rt && static_cast<GSTextureVK*>(config.rt)->GetView() == m_tfx_textures[0]) ||
-			(config.ds && static_cast<GSTextureVK*>(config.ds)->GetView() == m_tfx_textures[0])))
+	if (!config.tex && ((config.rt && static_cast<GSTextureVK*>(config.rt)->GetView() == m_tfx_textures[0]) ||
+						   (config.ds && static_cast<GSTextureVK*>(config.ds)->GetView() == m_tfx_textures[0])))
 	{
 		PSSetShaderResource(0, nullptr, false);
 	}


### PR DESCRIPTION
### Description of Changes

Probably not going to be fatal since the texture wasn't sampled in the case I saw this, but a validation error nonetheless.

### Rationale behind Changes

Validation layer errors are bad.

### Suggested Testing Steps

Runner says it's okay.
