### PR TITLE
GS/HW: Fix off by one in estimate texture region

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -19863,8 +19863,7 @@ SLES-54423:
   name: "Justice League Heroes"
   region: "PAL-M5"
   gsHWFixes:
-    texturePreloading: 1 # Performs much better with partial preload.
-    disablePartialInvalidation: 1 # Fixes performamce issues.
+    estimateTextureRegion: 1 # Improves performance.
   clampModes:
     vuClampMode: 2 # Fixes ingame SPS for the capes.
 SLES-54424:
@@ -47053,8 +47052,7 @@ SLUS-21304:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    texturePreloading: 1 # Performs much better with partial preload.
-    disablePartialInvalidation: 1 # Fixes performance issues.
+    estimateTextureRegion: 1 # Improves performance.
   clampModes:
     vuClampMode: 2 # Ingame capes become SPS mess with lower than extra VU clamp.
 SLUS-21305:

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -1652,9 +1652,11 @@ void GSRendererHW::Draw()
 			MIP_CLAMP.WMS = CLAMP_REGION_CLAMP;
 			MIP_CLAMP.WMT = CLAMP_REGION_CLAMP;
 			MIP_CLAMP.MINU = 0;
-			MIP_CLAMP.MAXU = (maxt.x - 1) >> m_lod.x;
+			MIP_CLAMP.MAXU = maxt.x >> m_lod.x;
 			MIP_CLAMP.MINV = 0;
-			MIP_CLAMP.MAXV = (maxt.y - 1) >> m_lod.x;
+			MIP_CLAMP.MAXV = maxt.y >> m_lod.x;
+			GL_CACHE("Estimated texture region: %u,%u -> %u,%u", MIP_CLAMP.MINU, MIP_CLAMP.MINV, MIP_CLAMP.MAXU + 1,
+				MIP_CLAMP.MAXV + 1);
 		}
 
 		m_src = tex_psm.depth ? m_tc->LookupDepthSource(TEX0, env.TEXA, MIP_CLAMP, tmm.coverage) :


### PR DESCRIPTION
### Description of Changes

And enable it for Justice League.

### Rationale behind Changes

Can double the frame rate, at least in the GS dumps.

### Suggested Testing Steps

Test Justice League, make sure snowblind perf didn't regress.
