### PR TITLE
GameDB: Destroy All Humans 1&2 Fixes

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -9482,6 +9482,16 @@ SLED-54312:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
     roundSprite: 2 # Fixes blurriness.
+SLED-54401:
+  name: "Destroy All Humans 2 [Demo]"
+  region: "PAL-E"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
+    textureInsideRT: 2 # Fixes shadow maps.
+    roundSprite: 2 # Fixes misalgined bloom.
+    halfPixelOffset: 2 # Fixes misalgined bloom.
+    autoFlush: 1 # Fixes sun occlusion and brightness.
 SLES-50003:
   name: "Swap Magic DVD Disc v2.0"
   region: "PAL-Unk"
@@ -16725,6 +16735,9 @@ SLES-53196:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
     textureInsideRT: 2 # Fixes shadow maps.
+    roundSprite: 2 # Fixes misalgined bloom.
+    halfPixelOffset: 2 # Fixes misalgined bloom.
+    autoFlush: 1 # Fixes sun occlusion and brightness.
 SLES-53197:
   name: "Destroy All Humans!"
   region: "PAL-G"
@@ -16732,6 +16745,9 @@ SLES-53197:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
     textureInsideRT: 2 # Fixes shadow maps.
+    roundSprite: 2 # Fixes misalgined bloom.
+    halfPixelOffset: 2 # Fixes misalgined bloom.
+    autoFlush: 1 # Fixes sun occlusion and brightness.
 SLES-53199:
   name: "25 to Life"
   region: "PAL-E"
@@ -17897,6 +17913,9 @@ SLES-53641:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
     textureInsideRT: 2 # Fixes shadow maps.
+    roundSprite: 2 # Fixes misalgined bloom.
+    halfPixelOffset: 2 # Fixes misalgined bloom.
+    autoFlush: 1 # Fixes sun occlusion and brightness.
 SLES-53644:
   name: "Gene Troopers"
   region: "PAL-M5"
@@ -19810,6 +19829,9 @@ SLES-54384:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
     textureInsideRT: 2 # Fixes shadow maps.
+    roundSprite: 2 # Fixes misalgined bloom.
+    halfPixelOffset: 2 # Fixes misalgined bloom.
+    autoFlush: 1 # Fixes sun occlusion and brightness.
 SLES-54385:
   name: "Atelier Iris 2 - The Azoth of Destiny"
   region: "PAL-E"
@@ -24772,6 +24794,16 @@ SLPM-55140:
     mvuFlagSpeedHack: 0 # Fixes invisible wall in front of the door leading to East 3F in the 2nd visit of Apartment world preventing Eileen's Nurse Outfit.
   gsHWFixes:
     halfPixelOffset: 1 # Fixes dark sides.
+SLPM-55141:
+  name: "Destroy All Humans! [THQ Collection]"
+  region: "NTSC-J"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
+    textureInsideRT: 2 # Fixes shadow maps.
+    roundSprite: 2 # Fixes misalgined bloom.
+    halfPixelOffset: 2 # Fixes misalgined bloom.
+    autoFlush: 1 # Fixes sun occlusion and brightness.
 SLPM-55146:
   name: "Jikkyou Powerful Pro Yakyuu 2009"
   region: "NTSC-J"
@@ -32710,6 +32742,9 @@ SLPM-66430:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
     textureInsideRT: 2 # Fixes shadow maps.
+    roundSprite: 2 # Fixes misalgined bloom.
+    halfPixelOffset: 2 # Fixes misalgined bloom.
+    autoFlush: 1 # Fixes sun occlusion and brightness.
 SLPM-66431:
   name: "WinBack 2 - Project Poseidon"
   region: "NTSC-J"
@@ -45130,6 +45165,9 @@ SLUS-20945:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
     textureInsideRT: 2 # Fixes shadow maps.
+    roundSprite: 2 # Fixes misalgined bloom.
+    halfPixelOffset: 2 # Fixes misalgined bloom.
+    autoFlush: 1 # Fixes sun occlusion and brightness.
 SLUS-20946:
   name: "Grand Theft Auto - San Andreas"
   region: "NTSC-U"
@@ -47900,6 +47938,9 @@ SLUS-21439:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
     textureInsideRT: 2 # Fixes shadow maps.
+    roundSprite: 2 # Fixes misalgined bloom.
+    halfPixelOffset: 2 # Fixes misalgined bloom.
+    autoFlush: 1 # Fixes sun occlusion and brightness.
 SLUS-21440:
   name: "Big Idea's VeggieTales - LarryBoy and the Bad Apple"
   region: "NTSC-U"
@@ -50815,6 +50856,9 @@ SLUS-29150:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
     textureInsideRT: 2 # Fixes shadow maps.
+    roundSprite: 2 # Fixes misalgined bloom.
+    halfPixelOffset: 2 # Fixes misalgined bloom.
+    autoFlush: 1 # Fixes sun occlusion and brightness.
 SLUS-29152:
   name: "Battlefield 2 - Modern Combat [Regular Demo]"
   region: "NTSC-U"
@@ -51007,6 +51051,9 @@ SLUS-29196:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
     textureInsideRT: 2 # Fixes shadow maps.
+    roundSprite: 2 # Fixes misalgined bloom.
+    halfPixelOffset: 2 # Fixes misalgined bloom.
+    autoFlush: 1 # Fixes sun occlusion and brightness.
 SLUS-29197:
   name: "Flushed Away [Demo]"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
Fixes for misaligned bloom and sun occlusion and intensity in Destroy All Humans 1 and 2.

### Rationale behind Changes
Misaligned bloom is gross and the sun going through objects is silly.

### Suggested Testing Steps
Make sure CI is happy.
