### PR TITLE
Qt: Fix skipdraw not being hidden globally again

### DIFF
--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -298,7 +298,7 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsDialog* dialog, QWidget* 
 
 		// Remove texture offset and skipdraw range for global settings.
 		m_ui.upscalingFixesLayout->removeRow(2);
-		m_ui.hardwareFixesLayout->removeRow(4);
+		m_ui.hardwareFixesLayout->removeRow(5);
 		m_ui.skipDrawStart = nullptr;
 		m_ui.skipDrawEnd = nullptr;
 		m_ui.textureOffsetX = nullptr;

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
@@ -1005,24 +1005,10 @@
        </item>
        <item row="6" column="0" colspan="2">
         <layout class="QGridLayout" name="gridLayout">
-         <item row="1" column="1">
-          <widget class="QCheckBox" name="preloadFrameData">
+         <item row="0" column="0">
+          <widget class="QCheckBox" name="hwAutoFlush">
            <property name="text">
-            <string>Preload Frame Data</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="0">
-          <widget class="QCheckBox" name="disableDepthEmulation">
-           <property name="text">
-            <string>Disable Depth Emulation</string>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="0">
-          <widget class="QCheckBox" name="disablePartialInvalidation">
-           <property name="text">
-            <string>Disable Partial Source Invalidation</string>
+            <string>Auto Flush</string>
            </property>
           </widget>
          </item>
@@ -1033,10 +1019,10 @@
            </property>
           </widget>
          </item>
-         <item row="3" column="1">
-          <widget class="QCheckBox" name="targetPartialInvalidation">
+         <item row="1" column="0">
+          <widget class="QCheckBox" name="disableDepthEmulation">
            <property name="text">
-            <string>Target Partial Invalidation</string>
+            <string>Disable Depth Emulation</string>
            </property>
           </widget>
          </item>
@@ -1047,13 +1033,6 @@
            </property>
           </widget>
          </item>
-         <item row="0" column="0">
-          <widget class="QCheckBox" name="hwAutoFlush">
-           <property name="text">
-            <string>Auto Flush</string>
-           </property>
-          </widget>
-         </item>
          <item row="2" column="1">
           <widget class="QCheckBox" name="readTCOnClose">
            <property name="text">
@@ -1061,7 +1040,28 @@
            </property>
           </widget>
          </item>
-         <item row="4" column="1">
+         <item row="3" column="0">
+          <widget class="QCheckBox" name="disablePartialInvalidation">
+           <property name="text">
+            <string>Disable Partial Source Invalidation</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="1">
+          <widget class="QCheckBox" name="targetPartialInvalidation">
+           <property name="text">
+            <string>Target Partial Invalidation</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QCheckBox" name="preloadFrameData">
+           <property name="text">
+            <string>Preload Frame Data</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="0">
           <widget class="QCheckBox" name="estimateTextureRegion">
            <property name="text">
             <string>Estimate Texture Region</string>

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -2812,7 +2812,7 @@ GSTextureCache::Source* GSTextureCache::CreateMergedSource(GIFRegTEX0 TEX0, GIFR
 		page_x++;
 		if (page_x == width_in_pages)
 		{
-			start_TBP0 += row_page_increment * page_blocks;
+			start_TBP0 += page_block_increment;
 			current_TBP0 = start_TBP0;
 			page_x = 0;
 			page_y++;


### PR DESCRIPTION
### Description of Changes

And slience a warning in TC.

### Rationale behind Changes

PR merge order funsies..

### Suggested Testing Steps

Make sure skipdraw is gorn

