### PR TITLE
Qt: Clear all keyboard bind states when focus is lost

### DIFF
--- a/pcsx2/Frontend/InputManager.cpp
+++ b/pcsx2/Frontend/InputManager.cpp
@@ -923,6 +923,71 @@ bool InputManager::ProcessEvent(InputBindingKey key, float value, bool skip_butt
 	return true;
 }
 
+void InputManager::ClearBindStateFromSource(InputBindingKey key)
+{
+	// Why are we doing it this way? Because any of the bindings could cause a reload and invalidate our iterators :(.
+	// Axis handlers should be fine, so we'll do those as a first pass.
+	for (const auto& [match_key, binding] : s_binding_map)
+	{
+		if (key.source_type != match_key.source_type || key.source_subtype != match_key.source_subtype ||
+			key.source_index != match_key.source_index || !IsAxisHandler(binding->handler))
+		{
+			continue;
+		}
+
+		for (u32 i = 0; i < binding->num_keys; i++)
+		{
+			if (binding->keys[i].MaskDirection() != match_key)
+				continue;
+
+			std::get<InputAxisEventHandler>(binding->handler)(0.0f);
+			break;
+		}
+	}
+
+	// Now go through the button handlers, and pick them off.
+	bool matched;
+	do
+	{
+		matched = false;
+
+		for (const auto& [match_key, binding] : s_binding_map)
+		{
+			if (key.source_type != match_key.source_type || key.source_subtype != match_key.source_subtype ||
+				key.source_index != match_key.source_index || IsAxisHandler(binding->handler))
+			{
+				continue;
+			}
+
+			for (u32 i = 0; i < binding->num_keys; i++)
+			{
+				if (binding->keys[i].MaskDirection() != match_key)
+					continue;
+
+				// Skip if we weren't pressed.
+				const u8 bit = static_cast<u8>(1) << i;
+				if ((binding->current_mask & bit) == 0)
+					continue;
+
+				// Only fire handler if we're changing from active state.
+				const u8 current_mask = binding->current_mask;
+				binding->current_mask &= ~bit;
+
+				if (current_mask == binding->full_mask)
+				{
+					std::get<InputButtonEventHandler>(binding->handler)(0.0f);
+					matched = true;
+					break;
+				}
+			}
+
+			// Need to start again, might've reloaded.
+			if (matched)
+				break;
+		}
+	} while (matched);
+}
+
 bool InputManager::PreprocessEvent(InputBindingKey key, float value, GenericInputBinding generic_key)
 {
 	// does imgui want the event?

--- a/pcsx2/Frontend/InputManager.h
+++ b/pcsx2/Frontend/InputManager.h
@@ -257,6 +257,9 @@ namespace InputManager
 	/// Returns true if anything was bound to this key, otherwise false.
 	bool InvokeEvents(InputBindingKey key, float value, GenericInputBinding generic_key = GenericInputBinding::Unknown);
 
+	/// Clears internal state for any binds with a matching source/index.
+	void ClearBindStateFromSource(InputBindingKey key);
+
 	/// Sets a hook which can be used to intercept events before they're processed by the normal bindings.
 	/// This is typically used when binding new controls to detect what gets pressed.
 	void SetHook(InputInterceptHook::Callback callback);


### PR DESCRIPTION
### Description of Changes

Stops binds getting stuck and having to manually press/release them, if you give focus to another window, release the key, and then go back to PCSX2.

### Rationale behind Changes

It was annoying.

### Suggested Testing Steps

Test switching to another window with keybinds pressed and unpressed, make sure PCSX2 doesn't go into an infinite loop (see the comments as to my reasoning).
