### PR TITLE
GS/HW: Implement multi stretch for DX11/DX12/OpenGL

### DIFF
--- a/pcsx2/GS/Renderers/Common/GSDevice.cpp
+++ b/pcsx2/GS/Renderers/Common/GSDevice.cpp
@@ -264,12 +264,22 @@ void GSDevice::StretchRect(GSTexture* sTex, GSTexture* dTex, const GSVector4& dR
 	StretchRect(sTex, GSVector4(0, 0, 1, 1), dTex, dRect, shader, linear);
 }
 
-void GSDevice::DrawMultiStretchRects(const MultiStretchRect* rects, u32 num_rects, GSTexture* dTex, ShaderConvert shader)
+void GSDevice::DrawMultiStretchRects(
+	const MultiStretchRect* rects, u32 num_rects, GSTexture* dTex, ShaderConvert shader)
 {
 	for (u32 i = 0; i < num_rects; i++)
 	{
 		const MultiStretchRect& sr = rects[i];
-		g_gs_device->StretchRect(sr.src, sr.src_rect, dTex, sr.dst_rect, shader, sr.linear);
+		pxAssert(shader == ShaderConvert::COPY || rects[0].wmask.wrgba == 0xf);
+		if (rects[0].wmask.wrgba != 0xf)
+		{
+			g_gs_device->StretchRect(sr.src, sr.src_rect, dTex, sr.dst_rect, rects[0].wmask.wr,
+				rects[0].wmask.wg, rects[0].wmask.wb, rects[0].wmask.wa);
+		}
+		else
+		{
+			g_gs_device->StretchRect(sr.src, sr.src_rect, dTex, sr.dst_rect, shader, sr.linear);
+		}
 	}
 }
 

--- a/pcsx2/GS/Renderers/Common/GSDevice.h
+++ b/pcsx2/GS/Renderers/Common/GSDevice.h
@@ -712,10 +712,11 @@ public:
 
 	struct MultiStretchRect
 	{
-		GSTexture* src;
 		GSVector4 src_rect;
 		GSVector4 dst_rect;
+		GSTexture* src;
 		bool linear;
+		GSHWDrawConfig::ColorMaskSelector wmask; // 0xf for all channels by default
 	};
 
 	enum BlendFactor : u8

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.h
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.h
@@ -176,7 +176,7 @@ private:
 		wil::com_ptr_nothrow<ID3D11SamplerState> pt;
 		wil::com_ptr_nothrow<ID3D11DepthStencilState> dss;
 		wil::com_ptr_nothrow<ID3D11DepthStencilState> dss_write;
-		wil::com_ptr_nothrow<ID3D11BlendState> bs;
+		std::array<wil::com_ptr_nothrow<ID3D11BlendState>, 16> bs;
 	} m_convert;
 
 	struct

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.h
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.h
@@ -278,11 +278,19 @@ public:
 	void StretchRect(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect, ID3D11PixelShader* ps, ID3D11Buffer* ps_cb, ID3D11BlendState* bs, bool linear = true);
 	void PresentRect(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect, PresentShader shader, float shaderTime, bool linear) override;
 	void UpdateCLUTTexture(GSTexture* sTex, u32 offsetX, u32 offsetY, GSTexture* dTex, u32 dOffset, u32 dSize) override;
+	void DrawMultiStretchRects(const MultiStretchRect* rects, u32 num_rects, GSTexture* dTex, ShaderConvert shader) override;
+	void DoMultiStretchRects(const MultiStretchRect* rects, u32 num_rects, const GSVector2& ds);
 
 	void SetupDATE(GSTexture* rt, GSTexture* ds, const GSVertexPT1* vertices, bool datm);
 
+	void* IAMapVertexBuffer(u32 stride, u32 count);
+	void IAUnmapVertexBuffer(u32 stride, u32 count);
 	bool IASetVertexBuffer(const void* vertex, u32 stride, u32 count);
+
+	u32* IAMapIndexBuffer(u32 count);
+	void IAUnmapIndexBuffer(u32 count);
 	bool IASetIndexBuffer(const void* index, u32 count);
+
 	void IASetInputLayout(ID3D11InputLayout* layout);
 	void IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY topology);
 

--- a/pcsx2/GS/Renderers/DX12/GSDevice12.h
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.h
@@ -254,8 +254,11 @@ public:
 	void PresentRect(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect,
 		PresentShader shader, float shaderTime, bool linear) override;
 	void UpdateCLUTTexture(GSTexture* sTex, u32 offsetX, u32 offsetY, GSTexture* dTex, u32 dOffset, u32 dSize) override;
+	void DrawMultiStretchRects(const MultiStretchRect* rects, u32 num_rects, GSTexture* dTex, ShaderConvert shader) override;
+	void DoMultiStretchRects(const MultiStretchRect* rects, u32 num_rects, GSTexture12* dTex, ShaderConvert shader);
 
-	void BeginRenderPassForStretchRect(GSTexture12* dTex, const GSVector4i& dtex_rc, const GSVector4i& dst_rc);
+	void BeginRenderPassForStretchRect(
+		GSTexture12* dTex, const GSVector4i& dtex_rc, const GSVector4i& dst_rc, bool allow_discard = true);
 	void DoStretchRect(GSTexture12* sTex, const GSVector4& sRect, GSTexture12* dTex, const GSVector4& dRect,
 		const ID3D12PipelineState* pipeline, bool linear);
 	void DrawStretchRect(const GSVector4& sRect, const GSVector4& dRect, const GSVector2i& ds);

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -2645,8 +2645,8 @@ GSTextureCache::Source* GSTextureCache::CreateMergedSource(GIFRegTEX0 TEX0, GIFR
 
 		// Upload texture -> render target.
 		const bool linear = (scale.x != 1.0f);
-		copy_queue[copy_count++] = {lmtex, GSVector4(rect) / GSVector4(lmtex->GetSize()).xyxy(),
-			GSVector4(rect) * GSVector4(scale).xyxy(), linear};
+		copy_queue[copy_count++] = {GSVector4(rect) / GSVector4(lmtex->GetSize()).xyxy(),
+			GSVector4(rect) * GSVector4(scale).xyxy(), lmtex, linear, 0xf};
 	};
 
 	// The idea: loop through pages that this texture covers, find targets which overlap, and copy them in.
@@ -2766,13 +2766,13 @@ GSTextureCache::Source* GSTextureCache::CreateMergedSource(GIFRegTEX0 TEX0, GIFR
 							}
 
 							GL_INS("  Copy from %d,%d -> %d,%d (%dx%d)", src_x, src_y, dst_x, dst_y, copy_width, copy_height);
-							copy_queue[copy_count++] = {t->m_texture,
+							copy_queue[copy_count++] = {
 								(GSVector4(src_x, src_y, src_x + copy_width, src_y + copy_height) *
 									GSVector4(t->m_texture->GetScale()).xyxy()) /
 									GSVector4(t->m_texture->GetSize()).xyxy(),
 								GSVector4(dst_x, dst_y, dst_x + copy_width, dst_y + copy_height) *
 									GSVector4(scale).xyxy(),
-								linear};
+								t->m_texture, linear, 0xf};
 						}
 
 						row_page++;
@@ -3641,6 +3641,15 @@ void GSTextureCache::Target::Update(bool reset_age)
 	TEXA.TA0 = 0;
 	TEXA.TA1 = 0x80;
 
+	// Bilinear filtering this is probably not a good thing, at least in native, but upscaling Nearest can be gross and messy.
+	// It's needed for depth, though.. filtering depth doesn't make much sense, but SMT3 needs it..
+	const bool upscaled = (m_texture->GetScale().x > 1.0f);
+	const bool linear = (m_type == RenderTarget && upscaled);
+
+	GSDevice::MultiStretchRect* drects = static_cast<GSDevice::MultiStretchRect*>(
+		alloca(sizeof(GSDevice::MultiStretchRect) * static_cast<u32>(m_dirty.size())));
+	u32 ndrects = 0;
+
 	const GSOffset off(g_gs_renderer->m_mem.GetOffset(m_TEX0.TBP0, m_TEX0.TBW, m_TEX0.PSM));
 	for (size_t i = 0; i < m_dirty.size(); i++)
 	{
@@ -3661,41 +3670,35 @@ void GSTextureCache::Target::Update(bool reset_age)
 
 			t->Update(t_r, s_unswizzle_buffer, pitch);
 		}
+
+		GSDevice::MultiStretchRect& drect = drects[ndrects++];
+		drect.src = t;
+		drect.src_rect = GSVector4(r - t_offset) / t_sizef;
+		drect.dst_rect = GSVector4(r) * GSVector4(m_texture->GetScale()).xyxy();
+		drect.linear = linear;
+		// Copy the new GS memory content into the destination texture.
+		if (m_type == RenderTarget)
+		{
+			GL_INS("ERROR: Update RenderTarget 0x%x bw:%d (%d,%d => %d,%d)", m_TEX0.TBP0, m_TEX0.TBW, r.x, r.y, r.z, r.w);
+			drect.wmask = static_cast<u8>(m_dirty[i].rgba._u32);
+		}
+		else if (m_type == DepthStencil)
+		{
+			GL_INS("ERROR: Update DepthStencil 0x%x", m_TEX0.TBP0);
+			drect.wmask = 0xF;
+		}
 	}
 
 	if (mapped)
 		t->Unmap();
 
-	for (size_t i = 0; i < m_dirty.size(); i++)
+	if (ndrects > 0)
 	{
-		const GSVector4i r(m_dirty.GetDirtyRect(i, m_TEX0, total_rect));
-
-		if (r.rempty())
-			continue;
-
-		const GSVector4 sRect(GSVector4(r - t_offset) / t_sizef);
-		const GSVector4 dRect(GSVector4(r) * GSVector4(m_texture->GetScale()).xyxy());
-		// Copy the new GS memory content into the destination texture.
-		if (m_type == RenderTarget)
-		{
-			GL_INS("ERROR: Update RenderTarget 0x%x bw:%d (%d,%d => %d,%d)", m_TEX0.TBP0, m_TEX0.TBW, r.x, r.y, r.z, r.w);
-			if (m_dirty[i].rgba._u32 != 0xf)
-			{
-				g_gs_device->StretchRect(t, sRect, m_texture, dRect, m_dirty[i].rgba.c.r, m_dirty[i].rgba.c.g, m_dirty[i].rgba.c.b, m_dirty[i].rgba.c.a);
-			}
-			else
-			{
-				// Bilinear filtering this is probably not a good thing, at least in native, but upscaling Nearest can be gross and messy.
-				g_gs_device->StretchRect(t, sRect, m_texture, dRect, ShaderConvert::COPY, g_gs_renderer->CanUpscale());
-			}
-		}
-		else if (m_type == DepthStencil)
-		{
-			GL_INS("ERROR: Update DepthStencil 0x%x", m_TEX0.TBP0);
-
-			// FIXME linear or not?
-			g_gs_device->StretchRect(t, sRect, m_texture, dRect, ShaderConvert::RGBA8_TO_FLOAT32_BILN);
-		}
+		// No need to sort here, it's all the one texture.
+		const ShaderConvert shader = (m_type == RenderTarget) ? ShaderConvert::COPY :
+																(upscaled ? ShaderConvert::RGBA8_TO_FLOAT32 :
+																			ShaderConvert::RGBA8_TO_FLOAT32_BILN);
+		g_gs_device->DrawMultiStretchRects(drects, ndrects, m_texture, shader);
 	}
 
 	UpdateValidity(total_rect);

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -1310,6 +1310,90 @@ void GSDeviceOGL::DrawStretchRect(const GSVector4& sRect, const GSVector4& dRect
 	DrawPrimitive();
 }
 
+void GSDeviceOGL::DrawMultiStretchRects(
+	const MultiStretchRect* rects, u32 num_rects, GSTexture* dTex, ShaderConvert shader)
+{
+	IASetPrimitiveTopology(GL_TRIANGLE_STRIP);
+	OMSetDepthStencilState(m_convert.dss);
+	OMSetBlendState(false);
+	OMSetColorMaskState();
+	OMSetRenderTargets(dTex, nullptr);
+	m_convert.ps[static_cast<int>(shader)].Bind();
+
+	const GSVector2 ds(static_cast<float>(dTex->GetWidth()), static_cast<float>(dTex->GetHeight()));
+	GSTexture* last_tex = rects[0].src;
+	bool last_linear = rects[0].linear;
+
+	u32 first = 0;
+	u32 count = 1;
+
+	for (u32 i = 1; i < num_rects; i++)
+	{
+		if (rects[i].src == last_tex && rects[i].linear == last_linear)
+		{
+			count++;
+			continue;
+		}
+
+		DoMultiStretchRects(rects + first, count, ds);
+		last_tex = rects[i].src;
+		last_linear = rects[i].linear;
+		first += count;
+		count = 1;
+	}
+
+	DoMultiStretchRects(rects + first, count, ds);
+}
+
+void GSDeviceOGL::DoMultiStretchRects(const MultiStretchRect* rects, u32 num_rects, const GSVector2& ds)
+{
+	const u32 vertex_reserve_size = num_rects * 4 * sizeof(GSVertexPT1);
+	const u32 index_reserve_size = num_rects * 6 * sizeof(u32);
+	auto vertex_map = m_vertex_stream_buffer->Map(sizeof(GSVertexPT1), vertex_reserve_size);
+	auto index_map = m_index_stream_buffer->Map(sizeof(u32), index_reserve_size);
+	m_vertex.start = vertex_map.index_aligned;
+	m_index.start = index_map.index_aligned;
+
+	// Don't use primitive restart here, it ends up slower on some drivers.
+	GSVertexPT1* verts = reinterpret_cast<GSVertexPT1*>(vertex_map.pointer);
+	u32* idx = reinterpret_cast<u32*>(index_map.pointer);
+	u32 icount = 0;
+	u32 vcount = 0;
+	for (u32 i = 0; i < num_rects; i++)
+	{
+		const GSVector4& sRect = rects[i].src_rect;
+		const GSVector4& dRect = rects[i].dst_rect;
+		const float left = dRect.x * 2 / ds.x - 1.0f;
+		const float right = dRect.z * 2 / ds.x - 1.0f;
+		const float top = -1.0f + dRect.y * 2 / ds.y;
+		const float bottom = -1.0f + dRect.w * 2 / ds.y;
+
+		const u32 vstart = vcount;
+		verts[vcount++] = { GSVector4(left  , top   , 0.0f, 0.0f) , GSVector2(sRect.x , sRect.y) };
+		verts[vcount++] = { GSVector4(right , top   , 0.0f, 0.0f) , GSVector2(sRect.z , sRect.y) };
+		verts[vcount++] = { GSVector4(left  , bottom, 0.0f, 0.0f) , GSVector2(sRect.x , sRect.w) };
+		verts[vcount++] = { GSVector4(right , bottom, 0.0f, 0.0f) , GSVector2(sRect.z , sRect.w) };
+
+		if (i > 0)
+			idx[icount++] = vstart;
+
+		idx[icount++] = vstart;
+		idx[icount++] = vstart + 1;
+		idx[icount++] = vstart + 2;
+		idx[icount++] = vstart + 3;
+		idx[icount++] = vstart + 3;
+	};
+
+	m_vertex.count = vcount;
+	m_index.count = icount;
+	m_vertex_stream_buffer->Unmap(vcount * sizeof(GSVertexPT1));
+	m_index_stream_buffer->Unmap(icount * sizeof(u32));
+
+	PSSetShaderResource(0, rects[0].src);
+	PSSetSamplerState(rects[0].linear ? m_convert.ln : m_convert.pt);
+	DrawIndexedPrimitive();
+}
+
 void GSDeviceOGL::DoMerge(GSTexture* sTex[3], GSVector4* sRect, GSTexture* dTex, GSVector4* dRect, const GSRegPMODE& PMODE, const GSRegEXTBUF& EXTBUF, const GSVector4& c, const bool linear)
 {
 	GL_PUSH("DoMerge");

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -1323,13 +1323,14 @@ void GSDeviceOGL::DrawMultiStretchRects(
 	const GSVector2 ds(static_cast<float>(dTex->GetWidth()), static_cast<float>(dTex->GetHeight()));
 	GSTexture* last_tex = rects[0].src;
 	bool last_linear = rects[0].linear;
+	u8 last_wmask = rects[0].wmask.wrgba;
 
 	u32 first = 0;
 	u32 count = 1;
 
 	for (u32 i = 1; i < num_rects; i++)
 	{
-		if (rects[i].src == last_tex && rects[i].linear == last_linear)
+		if (rects[i].src == last_tex && rects[i].linear == last_linear || rects[i].wmask.wrgba != last_wmask)
 		{
 			count++;
 			continue;
@@ -1338,6 +1339,7 @@ void GSDeviceOGL::DrawMultiStretchRects(
 		DoMultiStretchRects(rects + first, count, ds);
 		last_tex = rects[i].src;
 		last_linear = rects[i].linear;
+		last_wmask = rects[i].wmask.wrgba;
 		first += count;
 		count = 1;
 	}
@@ -1391,6 +1393,7 @@ void GSDeviceOGL::DoMultiStretchRects(const MultiStretchRect* rects, u32 num_rec
 
 	PSSetShaderResource(0, rects[0].src);
 	PSSetSamplerState(rects[0].linear ? m_convert.ln : m_convert.pt);
+	OMSetColorMaskState(rects[0].wmask);
 	DrawIndexedPrimitive();
 }
 

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.h
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.h
@@ -338,6 +338,8 @@ public:
 	void StretchRect(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect, const GL::Program& ps, bool alpha_blend, OMColorMaskSelector cms, bool linear = true);
 	void PresentRect(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect, PresentShader shader, float shaderTime, bool linear) final;
 	void UpdateCLUTTexture(GSTexture* sTex, u32 offsetX, u32 offsetY, GSTexture* dTex, u32 dOffset, u32 dSize) final;
+	void DrawMultiStretchRects(const MultiStretchRect* rects, u32 num_rects, GSTexture* dTex, ShaderConvert shader) final;
+	void DoMultiStretchRects(const MultiStretchRect* rects, u32 num_rects, const GSVector2& ds);
 
 	void RenderHW(GSHWDrawConfig& config) final;
 	void SendHWDraw(const GSHWDrawConfig& config, bool needs_barrier);

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
@@ -651,7 +651,7 @@ void GSDeviceVK::DoMultiStretchRects(
 
 	// Even though we're batching, a cmdbuffer submit could've messed this up.
 	const GSVector4i rc(dTex->GetRect());
-	OMSetRenderTargets(dTex, nullptr, dTex->GetRect(), false);
+	OMSetRenderTargets(dTex, nullptr, rc, false);
 	if (!InRenderPass() || !CheckRenderPassArea(rc))
 		BeginRenderPassForStretchRect(dTex, rc, rc, false);
 	SetUtilityTexture(rects[0].src, rects[0].linear ? m_linear_sampler : m_point_sampler);


### PR DESCRIPTION
### Description of Changes

And use it for preloading.

### Rationale behind Changes

Saves a few draw calls.

### Suggested Testing Steps

Test a few preload needing games in each renderer.
