### PR TITLE
GameDB: Various fixes

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -9490,6 +9490,7 @@ SLED-54401:
     trilinearFiltering: 1
     textureInsideRT: 2 # Fixes shadow maps.
     roundSprite: 2 # Fixes misalgined bloom.
+    mergeSprite: 1 # Fixes misalgined bloom.
     halfPixelOffset: 2 # Fixes misalgined bloom.
     autoFlush: 1 # Fixes sun occlusion and brightness.
 SLES-50003:
@@ -9758,6 +9759,8 @@ SLES-50079:
   region: "PAL-E"
   clampModes:
     eeClampMode: 2 # Fixes Abnormal AI behavior.
+  gsHWFixes:
+    textureInsideRT: 1 # Fixes texture corruption.
 SLES-50080:
   name: "NBA Hoopz"
   region: "PAL-M3"
@@ -16739,6 +16742,7 @@ SLES-53196:
     trilinearFiltering: 1
     textureInsideRT: 2 # Fixes shadow maps.
     roundSprite: 2 # Fixes misalgined bloom.
+    mergeSprite: 1 # Fixes misalgined bloom.
     halfPixelOffset: 2 # Fixes misalgined bloom.
     autoFlush: 1 # Fixes sun occlusion and brightness.
 SLES-53197:
@@ -16749,6 +16753,7 @@ SLES-53197:
     trilinearFiltering: 1
     textureInsideRT: 2 # Fixes shadow maps.
     roundSprite: 2 # Fixes misalgined bloom.
+    mergeSprite: 1 # Fixes misalgined bloom.
     halfPixelOffset: 2 # Fixes misalgined bloom.
     autoFlush: 1 # Fixes sun occlusion and brightness.
 SLES-53199:
@@ -17917,6 +17922,7 @@ SLES-53641:
     trilinearFiltering: 1
     textureInsideRT: 2 # Fixes shadow maps.
     roundSprite: 2 # Fixes misalgined bloom.
+    mergeSprite: 1 # Fixes misalgined bloom.
     halfPixelOffset: 2 # Fixes misalgined bloom.
     autoFlush: 1 # Fixes sun occlusion and brightness.
 SLES-53644:
@@ -19833,6 +19839,7 @@ SLES-54384:
     trilinearFiltering: 1
     textureInsideRT: 2 # Fixes shadow maps.
     roundSprite: 2 # Fixes misalgined bloom.
+    mergeSprite: 1 # Fixes misalgined bloom.
     halfPixelOffset: 2 # Fixes misalgined bloom.
     autoFlush: 1 # Fixes sun occlusion and brightness.
 SLES-54385:
@@ -24813,6 +24820,7 @@ SLPM-55141:
     trilinearFiltering: 1
     textureInsideRT: 2 # Fixes shadow maps.
     roundSprite: 2 # Fixes misalgined bloom.
+    mergeSprite: 1 # Fixes misalgined bloom.
     halfPixelOffset: 2 # Fixes misalgined bloom.
     autoFlush: 1 # Fixes sun occlusion and brightness.
 SLPM-55146:
@@ -32754,6 +32762,7 @@ SLPM-66430:
     trilinearFiltering: 1
     textureInsideRT: 2 # Fixes shadow maps.
     roundSprite: 2 # Fixes misalgined bloom.
+    mergeSprite: 1 # Fixes misalgined bloom.
     halfPixelOffset: 2 # Fixes misalgined bloom.
     autoFlush: 1 # Fixes sun occlusion and brightness.
 SLPM-66431:
@@ -36860,6 +36869,8 @@ SLPS-25007:
   region: "NTSC-J"
   clampModes:
     eeClampMode: 2 # Fixes Abnormal AI behavior.
+  gsHWFixes:
+    textureInsideRT: 1 # Fixes texture corruption.
 SLPS-25008:
   name: "Sorcerous Stabber Orphen"
   region: "NTSC-J"
@@ -40742,6 +40753,8 @@ SLPS-73403:
   region: "NTSC-J"
   clampModes:
     eeClampMode: 2 # Fixes Abnormal AI behavior.
+  gsHWFixes:
+    textureInsideRT: 1 # Fixes texture corruption.
 SLPS-73404:
   name: "Klonoa 2 [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -40931,6 +40944,8 @@ SLUS-20014:
   compat: 5
   clampModes:
     eeClampMode: 2 # Fixes Abnormal AI behavior.
+  gsHWFixes:
+    textureInsideRT: 1 # Fixes texture corruption.
 SLUS-20015:
   name: "Eternal Ring"
   region: "NTSC-U"
@@ -45177,6 +45192,7 @@ SLUS-20945:
     trilinearFiltering: 1
     textureInsideRT: 2 # Fixes shadow maps.
     roundSprite: 2 # Fixes misalgined bloom.
+    mergeSprite: 1 # Fixes misalgined bloom.
     halfPixelOffset: 2 # Fixes misalgined bloom.
     autoFlush: 1 # Fixes sun occlusion and brightness.
 SLUS-20946:
@@ -47950,6 +47966,7 @@ SLUS-21439:
     trilinearFiltering: 1
     textureInsideRT: 2 # Fixes shadow maps.
     roundSprite: 2 # Fixes misalgined bloom.
+    mergeSprite: 1 # Fixes misalgined bloom.
     halfPixelOffset: 2 # Fixes misalgined bloom.
     autoFlush: 1 # Fixes sun occlusion and brightness.
 SLUS-21440:
@@ -50868,6 +50885,7 @@ SLUS-29150:
     trilinearFiltering: 1
     textureInsideRT: 2 # Fixes shadow maps.
     roundSprite: 2 # Fixes misalgined bloom.
+    mergeSprite: 1 # Fixes misalgined bloom.
     halfPixelOffset: 2 # Fixes misalgined bloom.
     autoFlush: 1 # Fixes sun occlusion and brightness.
 SLUS-29152:
@@ -51063,6 +51081,7 @@ SLUS-29196:
     trilinearFiltering: 1
     textureInsideRT: 2 # Fixes shadow maps.
     roundSprite: 2 # Fixes misalgined bloom.
+    mergeSprite: 1 # Fixes misalgined bloom.
     halfPixelOffset: 2 # Fixes misalgined bloom.
     autoFlush: 1 # Fixes sun occlusion and brightness.
 SLUS-29197:


### PR DESCRIPTION
### Description of Changes
Adds Tex In RT 2 to Armoured Core 2 to fix texture corruption in future and adds merge sprite to Destroy All Humans 1&2 to further fix misaligned bloom.

### Rationale behind Changes
Corruption bad bloom smells.

### Suggested Testing Steps
Make sure CI is happy boi.
