### PR TITLE
GS/Vulkan: Don't skip barrier with colclip+readwrite date

### DIFF
--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
@@ -3155,8 +3155,9 @@ void GSDeviceVK::RenderHW(GSHWDrawConfig& config)
 	}
 
 	// We don't need the very first barrier if this is the first draw after switching to feedback loop,
-	// because the layout change in itself enforces the execution dependency.
-	const bool skip_first_barrier = (draw_rt && draw_rt->GetLayout() != VK_IMAGE_LAYOUT_GENERAL);
+	// because the layout change in itself enforces the execution dependency. HDR needs a barrier between
+	// setup and the first draw to read it. TODO: Make HDR use subpasses instead.
+	const bool skip_first_barrier = (draw_rt && draw_rt->GetLayout() != VK_IMAGE_LAYOUT_GENERAL && !pipe.ps.hdr);
 
 	OMSetRenderTargets(draw_rt, draw_ds, config.scissor, pipe.feedback_loop);
 	if (pipe.feedback_loop)


### PR DESCRIPTION
### Description of Changes

Value written from HDR setup must be visible for any DATE reads.

### Rationale behind Changes

Fixes flickering in DBZ BT2.

### Suggested Testing Steps

Test DBZ BT2 I guess. GS dump is on Discord.
