### PR TITLE
Qt: Support changing running GS dump by drag/dropping

### DIFF
--- a/pcsx2-qt/MainWindow.h
+++ b/pcsx2-qt/MainWindow.h
@@ -213,7 +213,7 @@ private:
 	void saveStateToConfig();
 	void restoreStateFromConfig();
 
-	void updateEmulationActions(bool starting, bool running);
+	void updateEmulationActions(bool starting, bool running, bool stopping);
 	void updateDisplayRelatedActions(bool has_surface, bool render_to_main, bool fullscreen);
 	void updateStatusBarWidgetVisibility();
 	void updateWindowTitle();

--- a/pcsx2/GSDumpReplayer.h
+++ b/pcsx2/GSDumpReplayer.h
@@ -30,6 +30,7 @@ bool IsRunner();
 void SetIsDumpRunner(bool is_runner);
 
 bool Initialize(const char* filename);
+bool ChangeDump(const char* filename);
 void Reset();
 void Shutdown();
 


### PR DESCRIPTION
### Description of Changes

And stops the crash when spam clicking shutdown.

### Rationale behind Changes

Making testing easier, maybe.

### Suggested Testing Steps

Start GS dump, drag new GS dump over, it should switch.

Spam shutdown and try to crash.
