### PR TITLE
GS/HW: Require FBW=1 for Jak OI fix

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSHwHack.cpp
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.cpp
@@ -1122,7 +1122,7 @@ bool GSHwHack::OI_ArTonelico2(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GST
 
 bool GSHwHack::OI_JakGames(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t)
 {
-	if (!(r.m_r == GSVector4i(0, 0, 16, 16)).alltrue())
+	if (RCONTEXT->FRAME.FBW != 1 || !(r.m_r == GSVector4i(0, 0, 16, 16)).alltrue())
 		return true; // Only 16x16 draws.
 
 	if (!r.CanUseSwSpriteRender())


### PR DESCRIPTION
### Description of Changes

The legit palette draws all seem to use FBW 1.

There's a couple of draws which use the alpha channel of the FB which are currently falsely triggering.

### Rationale behind Changes

Closes #8320.

### Suggested Testing Steps

Check Jak games which were flickering before, make sure Jak 3 isn't borked, sensitive bugger.
