### PR TITLE
GameDB: Add PCRTC and blending HW fixes

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -20126,6 +20126,8 @@ SLES-54485:
 SLES-54486:
   name: "Xiaolin Showdown"
   region: "PAL-M5"
+  gsHWFixes:
+    PCRTCOffsets: 1 # Stops screen shaking.
 SLES-54487:
   name: "Tokobot Plus - Mysteries of the Karakuri"
   region: "PAL-M5"
@@ -47766,6 +47768,8 @@ SLUS-21405:
   name: "Xiaolin Showdown"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    PCRTCOffsets: 1 # Stops screen shaking.
 SLUS-21406:
   name: "Godfather, The - Collector's Edition"
   region: "NTSC-U"

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -614,6 +614,7 @@ struct Pcsx2Config
 	{
 		static const char* AspectRatioNames[];
 		static const char* FMVAspectRatioSwitchNames[];
+		static const char* BlendingLevelNames[];
 		static const char* CaptureContainers[];
 
 		static const char* GetRendererName(GSRendererType type);

--- a/pcsx2/Docs/gamedb-schema.json
+++ b/pcsx2/Docs/gamedb-schema.json
@@ -181,6 +181,16 @@
               "minimum": 0,
               "maximum": 1
             },
+            "PCRTCOffsets": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 1
+            },
+            "PCRTCOverscan": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 1
+            },
             "mipmap": {
               "type": "integer",
               "minimum": 0,
@@ -245,6 +255,21 @@
               "type": "integer",
               "minimum": 0,
               "maximum": 2
+            },
+            "minimumBlendingLevel": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 5
+            },
+            "maximumBlendingLevel": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 5
+            },
+            "recommendedBlendingLevel": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 5
             },
             "getSkipCount": {
               "type": "string"

--- a/pcsx2/GameDatabase.cpp
+++ b/pcsx2/GameDatabase.cpp
@@ -18,6 +18,7 @@
 #include "GameDatabase.h"
 #include "GS/GS.h"
 #include "Host.h"
+#include "IconsFontAwesome5.h"
 #include "vtlb.h"
 
 #include "common/FileSystem.h"
@@ -353,6 +354,8 @@ static const char* s_gs_hw_fix_names[] = {
 	"mergeSprite",
 	"wildArmsHack",
 	"estimateTextureRegion",
+	"PCRTCOffsets",
+	"PCRTCOverscan",
 	"mipmap",
 	"trilinearFiltering",
 	"skipDrawStart",
@@ -366,8 +369,11 @@ static const char* s_gs_hw_fix_names[] = {
 	"cpuCLUTRender",
 	"gpuTargetCLUT",
 	"gpuPaletteConversion",
+	"minimumBlendingLevel",
+	"maximumBlendingLevel",
+	"recommendedBlendingLevel",
 	"getSkipCount",
-	"beforeDraw",
+	"beforeDraw"
 };
 static_assert(std::size(s_gs_hw_fix_names) == static_cast<u32>(GameDatabaseSchema::GSHWFixId::Count), "HW fix name lookup is correct size");
 
@@ -395,6 +401,11 @@ bool GameDatabaseSchema::isUserHackHWFix(GSHWFixId id)
 		case GSHWFixId::Mipmap:
 		case GSHWFixId::TexturePreloading:
 		case GSHWFixId::TrilinearFiltering:
+		case GSHWFixId::MinimumBlendingLevel:
+		case GSHWFixId::MaximumBlendingLevel:
+		case GSHWFixId::RecommendedBlendingLevel:
+		case GSHWFixId::PCRTCOffsets:
+		case GSHWFixId::PCRTCOverscan:
 		case GSHWFixId::GetSkipCount:
 		case GSHWFixId::BeforeDraw:
 			return false;
@@ -584,6 +595,12 @@ bool GameDatabaseSchema::GameEntry::configMatchesHWFix(const Pcsx2Config::GSOpti
 		case GSHWFixId::EstimateTextureRegion:
 			return (static_cast<int>(config.UserHacks_EstimateTextureRegion) == value);
 
+		case GSHWFixId::PCRTCOffsets:
+			return (static_cast<int>(config.PCRTCOffsets) == value);
+
+		case GSHWFixId::PCRTCOverscan:
+			return (static_cast<int>(config.PCRTCOverscan) == value);
+
 		case GSHWFixId::Mipmap:
 			return (config.HWMipmap == HWMipmapLevel::Automatic || static_cast<int>(config.HWMipmap) == value);
 
@@ -622,6 +639,15 @@ bool GameDatabaseSchema::GameEntry::configMatchesHWFix(const Pcsx2Config::GSOpti
 
 		case GSHWFixId::GPUPaletteConversion:
 			return (config.GPUPaletteConversion == ((value > 1) ? (config.TexturePreloading == TexturePreloadingLevel::Full) : (value != 0)));
+
+		case GSHWFixId::MinimumBlendingLevel:
+			return (static_cast<int>(config.AccurateBlendingUnit) >= value);
+
+		case GSHWFixId::MaximumBlendingLevel:
+			return (static_cast<int>(config.AccurateBlendingUnit) <= value);
+
+		case GSHWFixId::RecommendedBlendingLevel:
+			return true;
 
 		case GSHWFixId::GetSkipCount:
 			return (static_cast<int>(config.GetSkipCountFunctionId) == value);
@@ -713,6 +739,14 @@ u32 GameDatabaseSchema::GameEntry::applyGSHardwareFixes(Pcsx2Config::GSOptions& 
 				config.UserHacks_EstimateTextureRegion = (value > 0);
 				break;
 
+			case GSHWFixId::PCRTCOffsets:
+				config.PCRTCOffsets = (value > 0);
+				break;
+
+			case GSHWFixId::PCRTCOverscan:
+				config.PCRTCOverscan = (value > 0);
+				break;
+
 			case GSHWFixId::Mipmap:
 			{
 				if (value >= 0 && value <= static_cast<int>(HWMipmapLevel::Full))
@@ -801,6 +835,40 @@ u32 GameDatabaseSchema::GameEntry::applyGSHardwareFixes(Pcsx2Config::GSOptions& 
 			}
 			break;
 
+			case GSHWFixId::MinimumBlendingLevel:
+			{
+				if (value >= 0 && value <= static_cast<int>(AccBlendLevel::Maximum))
+					config.AccurateBlendingUnit = std::max(config.AccurateBlendingUnit, static_cast<AccBlendLevel>(value));
+			}
+			break;
+
+			case GSHWFixId::MaximumBlendingLevel:
+			{
+				if (value >= 0 && value <= static_cast<int>(AccBlendLevel::Maximum))
+					config.AccurateBlendingUnit = std::min(config.AccurateBlendingUnit, static_cast<AccBlendLevel>(value));
+			}
+			break;
+
+			case GSHWFixId::RecommendedBlendingLevel:
+			{
+				if (value >= 0 && value <= static_cast<int>(AccBlendLevel::Maximum) && static_cast<int>(GSConfig.AccurateBlendingUnit) < value)
+				{
+					Host::AddKeyedOSDMessage("HWBlendingWarning",
+						fmt::format(ICON_FA_PAINT_BRUSH " Current Blending Accuracy is {}.\n"
+														"Recommended Blending Accuracy for this game is {}.\n"
+														"You can adjust the blending level in Game Properties to improve\n"
+														"graphical quality, but this will increase system requirements.",
+							Pcsx2Config::GSOptions::BlendingLevelNames[static_cast<int>(GSConfig.AccurateBlendingUnit)],
+							Pcsx2Config::GSOptions::BlendingLevelNames[value]),
+						Host::OSD_WARNING_DURATION);
+				}
+				else
+				{
+					Host::RemoveKeyedOSDMessage("HWBlendingWarning");
+				}
+			}
+			break;
+
 			case GSHWFixId::GetSkipCount:
 				config.GetSkipCountFunctionId = static_cast<s16>(value);
 				break;
@@ -823,7 +891,7 @@ u32 GameDatabaseSchema::GameEntry::applyGSHardwareFixes(Pcsx2Config::GSOptions& 
 	if (!disabled_fixes.empty())
 	{
 		Host::AddKeyedOSDMessage("HWFixesWarning",
-			fmt::format("Manual GS hardware renderer fixes are enabled, automatic fixes were not applied:\n{}",
+			fmt::format(ICON_FA_MAGIC " Manual GS hardware renderer fixes are enabled, automatic fixes were not applied:\n{}",
 				disabled_fixes),
 			Host::OSD_ERROR_DURATION);
 	}

--- a/pcsx2/GameDatabase.h
+++ b/pcsx2/GameDatabase.h
@@ -73,6 +73,8 @@ namespace GameDatabaseSchema
 		MergeSprite,
 		WildArmsHack,
 		EstimateTextureRegion,
+		PCRTCOffsets,
+		PCRTCOverscan,
 
 		// integer settings
 		Mipmap,
@@ -88,6 +90,9 @@ namespace GameDatabaseSchema
 		CPUCLUTRender,
 		GPUTargetCLUT,
 		GPUPaletteConversion,
+		MinimumBlendingLevel,
+		MaximumBlendingLevel,
+		RecommendedBlendingLevel,
 		GetSkipCount,
 		BeforeDraw,
 

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -362,6 +362,15 @@ const char* Pcsx2Config::GSOptions::FMVAspectRatioSwitchNames[] = {
 	"16:9",
 	nullptr};
 
+const char* Pcsx2Config::GSOptions::BlendingLevelNames[] = {
+	"Minimum",
+	"Basic",
+	"Medium",
+	"High",
+	"Full",
+	"Maximum",
+	nullptr};
+
 const char* Pcsx2Config::GSOptions::CaptureContainers[] = {
 	"mp4",
 	"mkv",


### PR DESCRIPTION
### Description of Changes

`PCRTCOffsets`:
Enables "Screen Offsets"

`PCRTCOverscan`
Enables "Show Overscan"

`minimumBlendingLevel`:
Forces the blend level to `max(userBlendLevel, minimumBlendLevel)`.
Use **with care**. Only games which are completely broken at lower levels and are lightweight requirements wise should be considered.

`maximumBlendingLevel`:
Forces the blend level to `min(userBlendLevel, maximumBlendLevel)`.
In other words, clamps to the specified level. Can be used for games which are unnecessarily slow at basic (e.g. memester hunter).

`recommendedBlendingLevel`:
Displays a notification when starting the game advising the user that a higher blending level is recommended, but warns of the requirements increases. Use for minor or heavy-hitting games that require higher blending.

![Untitled](https://user-images.githubusercontent.com/11288319/222728237-26f8ec1b-fb28-4317-8630-e6b5eafdf82a.jpg)

### Rationale behind Changes

Improving UX.

### Suggested Testing Steps

Test new options.

