### PR TITLE
GameDB: Various recommendations and fixes

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -541,6 +541,10 @@ SCAJ-20012:
 SCAJ-20013:
   name: "MotoGP 3"
   region: "NTSC-Unk"
+  gsHWFixes:
+    roundSprite: 2 # Fixes lines at the edges of the HUD.
+    mipmap: 2 # Mipmap + trilinear, improves road and grass textures to match sw renderer.
+    trilinearFiltering: 1
 SCAJ-20014:
   name: "Time Splitter"
   region: "NTSC-Unk"
@@ -569,6 +573,7 @@ SCAJ-20020:
   gsHWFixes:
     texturePreloading: 1 # Performs better with partial preload because it is slow on locations outside gameplay foremost.
     mergeSprite: 1 # Fixes misaligned white lines.
+    PCRTCOverscan: 1 # Fixes missing HUD.
 SCAJ-20021:
   name: "Metal Slug 3"
   region: "NTSC-Unk"
@@ -760,6 +765,7 @@ SCAJ-20070:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes bloom and ghosting in certain areas.
     roundSprite: 1 # Fixes door transition vertical lines and mini-map artifacts.
+    textureInsideRT: 1 # Fixes missing battle effects.
 SCAJ-20072:
   name: "Ghost in the Shell - Stand Alone Complex"
   region: "NTSC-Unk"
@@ -1862,6 +1868,11 @@ SCED-50749:
 SCED-50750:
   name: "Official PlayStation 2 Magazine Demo 28"
   region: "PAL-M5"
+SCED-50768:
+  name: "Wipeout Fusion"
+  region: "PAL-E"
+  gsHWFixes:
+    PCRTCOffsets: 1 # Fixes viewport shaking.
 SCED-50781:
   name: "Destruction Derby Arenas [Beta]"
   region: "PAL-M5"
@@ -1921,6 +1932,15 @@ SCED-51279:
 SCED-51319:
   name: "Official PlayStation 2 Magazine Demo 27" # German
   region: "PAL-E-G"
+SCED-51351:
+  name: "Getaway, The [Demo]"
+  region: "PAL-E"
+  gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes the fog wall.
+    textureInsideRT: 1
+    texturePreloading: 1 # Performs much better with partial preload.
+    halfPixelOffset: 2 # Fixes outlines around characters.
+    getSkipCount: "GSC_GetawayGames"
 SCED-51352:
   name: "Gran Turismo - Nissan Micra Edition [Demo]"
   region: "PAL-E"
@@ -2323,7 +2343,7 @@ SCED-52869:
   gsHWFixes:
     autoFlush: 1 # Fixes car shadows.
     roundSprite: 1 # Fixes misaligned text.
-    halfPixelOffset: 1 # Fixes minor ghosting on objects.
+    halfPixelOffset: 2 # Fixes minor ghosting on objects.
 SCED-52880:
   name: "WRC 4 - The Official Game of the FIA World Rally Championship [Demo]"
   region: "PAL-E"
@@ -2332,7 +2352,7 @@ SCED-52880:
   gsHWFixes:
     autoFlush: 1 # Fixes car shadows.
     roundSprite: 1 # Fixes misaligned text.
-    halfPixelOffset: 1 # Fixes minor ghosting on objects.
+    halfPixelOffset: 2 # Fixes minor ghosting on objects.
 SCED-52899:
   name: "Killzone [Bonus Disc]"
   region: "PAL-M5"
@@ -2348,6 +2368,23 @@ SCED-52935:
 SCED-52938:
   name: "Official PlayStation 2 Magazine Demo 52"
   region: "PAL-M5"
+SCED-52945:
+  name: "WRC 4 - The Official Game of the FIA World Rally Championship [Ford Fiesta Sports Edition Demo]"
+  region: "PAL-E"
+  gameFixes:
+    - XGKickHack # Fixes SPS.
+  gsHWFixes:
+    autoFlush: 1 # Fixes car shadows.
+    roundSprite: 1 # Fixes misaligned text.
+    halfPixelOffset: 2 # Fixes minor ghosting on objects.
+SCED-52946:
+  name: "Getaway, The - Black Monday [Demo]"
+  region: "PAL-E"
+  gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes the fog wall.
+    textureInsideRT: 1
+    halfPixelOffset: 2 # Fixes outlines on screen edges.
+    getSkipCount: "GSC_GetawayGames"
 SCED-52952:
   name: "Jak 3 [Demo]"
   region: "PAL-M5"
@@ -2817,6 +2854,8 @@ SCES-50005:
   name: "Wipeout Fusion"
   region: "PAL-M5"
   compat: 5
+  gsHWFixes:
+    PCRTCOffsets: 1 # Fixes viewport shaking.
 SCES-50006:
   name: "Drakan - The Ancients' Gates"
   region: "PAL-M5"
@@ -3191,6 +3230,10 @@ SCES-50982:
   name: "MotoGP 3"
   region: "PAL-M5"
   compat: 5
+  gsHWFixes:
+    roundSprite: 2 # Fixes lines at the edges of the HUD.
+    mipmap: 2 # Mipmap + trilinear, improves road and grass textures to match sw renderer.
+    trilinearFiltering: 1
 SCES-50987:
   name: "Resident Evil - Outbreak"
   region: "PAL-Unk"
@@ -3246,6 +3289,7 @@ SCES-51159:
   region: "PAL-M5"
   compat: 5
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes the fog wall.
     textureInsideRT: 1
     texturePreloading: 1 # Performs much better with partial preload.
     halfPixelOffset: 2 # Fixes outlines around characters.
@@ -3296,6 +3340,7 @@ SCES-51426:
   name: "Getaway, The"
   region: "PAL-M5"
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes the fog wall.
     textureInsideRT: 1
     texturePreloading: 1 # Performs much better with partial preload.
     halfPixelOffset: 2 # Fixes outlines around characters.
@@ -3587,7 +3632,7 @@ SCES-52389:
   gsHWFixes:
     autoFlush: 1 # Fixes car shadows.
     roundSprite: 1 # Fixes misaligned text.
-    halfPixelOffset: 1 # Fixes minor ghosting on objects.
+    halfPixelOffset: 2 # Fixes minor ghosting on objects.
 SCES-52405:
   name: "DJ - Decks & FX - House Edition"
   region: "PAL-M9"
@@ -3733,6 +3778,7 @@ SCES-52758:
   name: "Getaway, The - Black Monday"
   region: "PAL-M6"
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes the fog wall.
     textureInsideRT: 1
     halfPixelOffset: 2 # Fixes outlines on screen edges.
     getSkipCount: "GSC_GetawayGames"
@@ -3783,6 +3829,7 @@ SCES-52948:
   name: "Getaway, The - Black Monday"
   region: "PAL-M4"
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes the fog wall.
     textureInsideRT: 1
     halfPixelOffset: 2 # Fixes outlines on screen edges.
     getSkipCount: "GSC_GetawayGames"
@@ -4891,6 +4938,7 @@ SCKA-20018:
   name: "Getaway, The"
   region: "NTSC-K"
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes the fog wall.
     textureInsideRT: 1
     texturePreloading: 1 # Performs much better with partial preload.
     halfPixelOffset: 2 # Fixes outlines around characters.
@@ -6748,6 +6796,7 @@ SCPS-55019:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes bloom and ghosting in certain areas.
     roundSprite: 1 # Fixes door transition vertical lines and mini-map artifacts.
+    textureInsideRT: 1 # Fixes missing battle effects.
 SCPS-55020:
   name: "Kengo 2"
   region: "NTSC-J"
@@ -7518,6 +7567,7 @@ SCUS-97232:
   name: "Getaway [Demo]"
   region: "NTSC-U"
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes the fog wall.
     textureInsideRT: 1
     halfPixelOffset: 2 # Fixes outlines around characters.
     getSkipCount: "GSC_GetawayGames"
@@ -8020,6 +8070,7 @@ SCUS-97408:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes the fog wall.
     textureInsideRT: 1
     halfPixelOffset: 2 # Fixes outlines on screen edges.
     getSkipCount: "GSC_GetawayGames"
@@ -8179,6 +8230,7 @@ SCUS-97441:
   name: "Getaway The - Black Monday [Demo]"
   region: "NTSC-U"
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes the fog wall.
     textureInsideRT: 1
     halfPixelOffset: 2 # Fixes outlines on screen edges.
     getSkipCount: "GSC_GetawayGames"
@@ -8991,6 +9043,7 @@ SLAJ-25053:
   clampModes:
     vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 1 # Fixes blur and obscures sun behind objects.
     mipmap: 2 # Fixes over sharpening.
@@ -9028,6 +9081,7 @@ SLAJ-25066:
   clampModes:
     vuClampMode: 0 # Fixes buggy lighting in the garage.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 1 # Fixes blur and obscures sun behind objects.
     mipmap: 2 # Fixes over sharpening.
@@ -9067,6 +9121,7 @@ SLAJ-25075:
   name: "Need for Speed - Most Wanted [Black Edition]"
   region: "NTSC-Unk"
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes blurriness.
     cpuCLUTRender: 1 # Final colour adjustment LUT.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
@@ -9104,6 +9159,7 @@ SLAJ-25078:
   clampModes:
     vuClampMode: 3 # Fixes SPS.
   gsHWFixes:
+    recommendedBlendingLevel: 4 # Improves lighting on buildings and objects.
     autoFlush: 1 # Properly diffuses light instead of strips of light.
     roundSprite: 1 # Fixes lighting misalignment such as the street poles and the sun.
     mipmap: 2 # Fixes over sharpening.
@@ -9142,6 +9198,7 @@ SLAJ-25091:
   clampModes:
     eeClampMode: 3 # Fixes game hang after opening intro.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves car colour and reflection quality.
     halfPixelOffset: 2 # Fixes blurriness.
     roundSprite: 2 # Fixes blurriness.
 SLAJ-25092:
@@ -9156,6 +9213,7 @@ SLAJ-25094:
   clampModes:
     vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 1 # Fixes blur and obscures sun behind objects.
     mipmap: 2 # Fixes over sharpening.
@@ -9191,6 +9249,8 @@ SLED-50117:
   region: "PAL-E"
   gameFixes:
     - InstantDMAHack # Fixes broken half-bottom artifacts.
+  gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
 SLED-50286:
   name: "Red Faction [Demo]"
   region: "PAL-E"
@@ -9328,6 +9388,7 @@ SLED-52597:
   clampModes:
     vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 1 # Fixes blur and obscures sun behind objects.
     mipmap: 2 # Fixes over sharpening.
@@ -9335,6 +9396,12 @@ SLED-52597:
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
+SLED-52736:
+  name: "Need for Speed - Underground 2 [Demo]"
+  region: "PAL-E"
+  gsHWFixes:
+    minimumBlendingLevel: 2 # Fixes missing post processing.
+    halfPixelOffset: 1 # Fixes misaligned post-processing.
 SLED-52852:
   name: "Forgotten Realms - Demon Stone [Demo]"
   region: "PAL-E"
@@ -9368,6 +9435,8 @@ SLED-53083:
   region: "PAL-M5"
   clampModes:
     vuClampMode: 3 # Fixes lighting on character models as caves and other locations don't turn mobs into glow-in-the-dark creatures by themselves.
+  gsHWFixes:
+    maximumBlendingLevel: 0 # Fixes unnecessary load on the GPU.
 SLED-53097:
   name: "Worms 4 - Mayhem [Demo]"
   region: "PAL-M5"
@@ -9396,6 +9465,7 @@ SLED-53512:
   clampModes:
     vuClampMode: 0 # Fixes buggy lighting in the garage.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 1 # Fixes blur and obscures sun behind objects.
     mipmap: 2 # Fixes over sharpening.
@@ -9409,6 +9479,14 @@ SLED-53537:
   gsHWFixes:
     autoFlush: 1 # Softens bloom on objects and cars.
     halfPixelOffset: 2 # Fixes misaligned bloom on objects and cars.
+SLED-53650:
+  name: "Need for Speed - Most Wanted"
+  region: "PAL-E"
+  gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves car reflections.
+    halfPixelOffset: 2 # Fixes blurriness.
+    cpuCLUTRender: 1 # Final colour adjustment LUT.
+    gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
 SLED-53673:
   name: "007 - From Russia with Love [Demo]"
   region: "PAL-E"
@@ -9449,6 +9527,7 @@ SLED-53937:
   clampModes:
     vuClampMode: 3 # Fixes SPS.
   gsHWFixes:
+    recommendedBlendingLevel: 4 # Improves lighting on buildings and objects.
     autoFlush: 1 # Properly diffuses light instead of strips of light.
     roundSprite: 1 # Fixes lighting misalignment such as the street poles and the sun.
     mipmap: 2 # Fixes over sharpening.
@@ -9480,6 +9559,7 @@ SLED-54312:
   clampModes:
     eeClampMode: 3 # Fixes game hang after opening intro.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves car colour and reflection quality.
     halfPixelOffset: 2 # Fixes blurriness.
     roundSprite: 2 # Fixes blurriness.
 SLED-54401:
@@ -9569,7 +9649,9 @@ SLES-50030:
   name: "SSX Snowboarding"
   region: "PAL-M3"
   roundModes:
-    eeRoundMode: 0 # Fixes riders vanish into the floor
+    eeRoundMode: 0 # Fixes riders vanishing into the floor.
+  gsHWFixes:
+    recommendedBlendingLevel: 4 # Fixes missing lighting.
 SLES-50031:
   name: "X-Squad"
   region: "PAL-E"
@@ -10259,6 +10341,8 @@ SLES-50282:
   name: "Age of Empires II - The Age of Kings"
   region: "PAL-M5"
   compat: 5
+  gsHWFixes:
+    estimateTextureRegion: 1 # Improves performance and reduces hash cache size when moving.
 SLES-50283:
   name: "WTA Tour Tennis"
   region: "PAL-M3"
@@ -10404,16 +10488,22 @@ SLES-50383:
   compat: 5
   gameFixes:
     - InstantDMAHack # Fixes broken half-bottom artifacts.
+  gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
 SLES-50384:
   name: "Metal Gear Solid 2 - Sons of Liberty"
   region: "PAL-I"
   gameFixes:
     - InstantDMAHack # Fixes broken half-bottom artifacts.
+  gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
 SLES-50385:
   name: "Metal Gear Solid 2 - Sons of Liberty"
   region: "PAL-S"
   gameFixes:
     - InstantDMAHack # Fixes broken half-bottom artifacts.
+  gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
 SLES-50386:
   name: "Crash Bandicoot - The Wrath of Cortex"
   region: "PAL-M6"
@@ -11489,6 +11579,8 @@ SLES-50876:
     autoFlush: 1
     halfPixelOffset: 2 # Fixes misaligned lighting.
     cpuCLUTRender: 1 # Fixes janky coloured cars.
+    gpuTargetCLUT: 1 # Fixes janky coloured cars.
+    textureInsideRT: 1 # Fixes car textures.
 SLES-50877:
   name: "TimeSplitters 2"
   region: "PAL-M5"
@@ -11791,6 +11883,9 @@ SLES-51054:
   name: "Midnight Club 2"
   region: "PAL-M5"
   compat: 5
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves road and tree textures to match software.
+    trilinearFiltering: 1
   patches:
     ACB1989A:
       content: |-
@@ -13484,6 +13579,8 @@ SLES-51824:
   region: "PAL-M5"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
+    mipmap: 2 # Mipmap + trilinear, improves road and tree textures to match software.
+    trilinearFiltering: 1
 SLES-51825:
   name: "Pop Idol"
   region: "PAL-E"
@@ -14228,6 +14325,8 @@ SLES-52153:
     autoFlush: 1
     halfPixelOffset: 2 # Fixes misaligned lighting.
     cpuCLUTRender: 1 # Fixes janky coloured cars.
+    gpuTargetCLUT: 1 # Fixes janky coloured cars.
+    textureInsideRT: 1 # Fixes car textures.
 SLES-52155:
   name: "EyeToy - L'Eredita"
   region: "PAL-I"
@@ -14548,6 +14647,7 @@ SLES-52322:
   gsHWFixes:
     texturePreloading: 1 # Performs better with partial preload because it is slow on locations outside gameplay foremost.
     mergeSprite: 1 # Fixes misaligned white lines.
+    PCRTCOverscan: 1 # Fixes missing HUD.
 SLES-52323:
   name: "Richard Burns Rally"
   region: "PAL-M5"
@@ -15172,6 +15272,7 @@ SLES-52584:
   clampModes:
     vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 1 # Fixes blur and obscures sun behind objects.
     mipmap: 2 # Fixes over sharpening.
@@ -15185,6 +15286,7 @@ SLES-52585:
   clampModes:
     vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 1 # Fixes blur and obscures sun behind objects.
     mipmap: 2 # Fixes over sharpening.
@@ -15493,6 +15595,8 @@ SLES-52707:
   compat: 5
   clampModes:
     vuClampMode: 3 # Fixes lighting on character models as caves and other locations don't turn mobs into glow-in-the-dark creatures by themselves.
+  gsHWFixes:
+    maximumBlendingLevel: 0 # Fixes unnecessary load on the GPU.
 SLES-52709:
   name: "TY the Tasmanian Tiger 2 - Bush Rescue"
   region: "PAL-M7"
@@ -15547,6 +15651,7 @@ SLES-52725:
   region: "PAL-M8"
   compat: 5
   gsHWFixes:
+    minimumBlendingLevel: 2 # Fixes missing post processing.
     halfPixelOffset: 1 # Fixes misaligned post-processing.
 SLES-52726:
   name: "NBA Live 2005"
@@ -17194,6 +17299,8 @@ SLES-53415:
   gsHWFixes:
     roundSprite: 1 # Fixes lines in sprites.
     cpuSpriteRenderBW: 1 # Fixes textures.
+    mipmap: 2 # Mipmap + trilinear, improves ground and building textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-53416:
   name: "Call of Duty 2 - Big Red One"
   region: "PAL-M3"
@@ -17203,6 +17310,8 @@ SLES-53416:
   gsHWFixes:
     roundSprite: 1 # Fixes lines in sprites.
     cpuSpriteRenderBW: 1 # Fixes textures.
+    mipmap: 2 # Mipmap + trilinear, improves ground and building textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-53417:
   name: "Call of Duty 2 - Big Red One"
   region: "PAL-G"
@@ -17212,6 +17321,8 @@ SLES-53417:
   gsHWFixes:
     roundSprite: 1 # Fixes lines in sprites.
     cpuSpriteRenderBW: 1 # Fixes textures.
+    mipmap: 2 # Mipmap + trilinear, improves ground and building textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-53418:
   name: "Tak - The Great JuJu Challenge"
   region: "PAL-A"
@@ -17255,6 +17366,8 @@ SLES-53439:
   region: "PAL-M6"
   gameFixes:
     - IbitHack # Fixes constant recompilation problems.
+  gsHWFixes:
+    PCRTCOverscan: 1 # Fixes offscreen image.
 SLES-53441:
   name: "Heroes of the Pacific"
   region: "PAL-M5"
@@ -17417,6 +17530,7 @@ SLES-53506:
   clampModes:
     vuClampMode: 0 # Fixes buggy lighting in the garage.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 1 # Fixes blur and obscures sun behind objects.
     mipmap: 2 # Fixes over sharpening.
@@ -17437,6 +17551,7 @@ SLES-53507:
   clampModes:
     vuClampMode: 0 # Fixes buggy lighting in the garage.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 1 # Fixes blur and obscures sun behind objects.
     mipmap: 2 # Fixes over sharpening.
@@ -17474,6 +17589,7 @@ SLES-53523:
   roundModes:
     vu1RoundMode: 0 # Fixes textures and crashes.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes broken light and shadow rendering.
     mipmap: 2 # Mipmap + trilinear, improves ground textures and water textures and reflections.
     trilinearFiltering: 1
     textureInsideRT: 1 # Fixes rainbow artifacting around edges of screen.
@@ -17625,6 +17741,7 @@ SLES-53542:
   name: "Shadow the Hedgehog"
   region: "PAL-M5"
   gsHWFixes:
+    recommendedBlendingLevel: 4 # Improves smoke rendering.
     halfPixelOffset: 2 # Fixes misaligned lighting.
 SLES-53544:
   name: "Pro Evolution Soccer 5"
@@ -17666,6 +17783,7 @@ SLES-53557:
   region: "PAL-E"
   compat: 5
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes blurriness.
     cpuCLUTRender: 1 # Final colour adjustment LUT.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
@@ -17679,6 +17797,7 @@ SLES-53558:
   name: "Need for Speed - Most Wanted"
   region: "PAL-M8"
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes blurriness.
     cpuCLUTRender: 1 # Final colour adjustment LUT.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
@@ -17692,6 +17811,7 @@ SLES-53559:
   name: "Need for Speed - Most Wanted"
   region: "PAL-M3"
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes blurriness.
     cpuCLUTRender: 1 # Final colour adjustment LUT.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
@@ -17946,6 +18066,7 @@ SLES-53647:
   roundModes:
     vu1RoundMode: 0 # Fixes textures and crashes.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes broken light and shadow rendering.
     mipmap: 2 # Mipmap + trilinear, improves ground textures and water textures and reflections.
     trilinearFiltering: 1
     textureInsideRT: 1 # Fixes rainbow artifacting around edges of screen.
@@ -18163,6 +18284,8 @@ SLES-53722:
   gsHWFixes:
     roundSprite: 1 # Fixes lines in sprites.
     cpuSpriteRenderBW: 1 # Fixes textures.
+    mipmap: 2 # Mipmap + trilinear, improves ground and building textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-53724:
   name: "World Series of Poker"
   region: "PAL-E"
@@ -18517,6 +18640,7 @@ SLES-53857:
   name: "Need for Speed - Most Wanted [Black Edition]"
   region: "PAL-M3"
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes blurriness.
     cpuCLUTRender: 1 # Final colour adjustment LUT.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
@@ -18591,6 +18715,7 @@ SLES-53886:
   clampModes:
     vuClampMode: 3 # Fixes SPS.
   gsHWFixes:
+    recommendedBlendingLevel: 4 # Improves lighting on buildings and objects.
     autoFlush: 1 # Properly diffuses light instead of strips of light.
     roundSprite: 1 # Fixes lighting misalignment such as the street poles and the sun.
     mipmap: 2 # Fixes over sharpening.
@@ -18959,6 +19084,7 @@ SLES-54030:
   clampModes:
     vuClampMode: 3 # Fixes SPS.
   gsHWFixes:
+    recommendedBlendingLevel: 4 # Improves lighting on buildings and objects.
     autoFlush: 1 # Properly diffuses light instead of strips of light.
     roundSprite: 1 # Fixes lighting misalignment such as the street poles and the sun.
     mipmap: 2 # Fixes over sharpening.
@@ -19610,6 +19736,7 @@ SLES-54321:
   clampModes:
     eeClampMode: 3 # Fixes game hang after opening intro.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves car colour and reflection quality.
     halfPixelOffset: 2 # Fixes blurriness.
     roundSprite: 2 # Fixes blurriness.
 SLES-54322:
@@ -19618,6 +19745,7 @@ SLES-54322:
   clampModes:
     eeClampMode: 3 # Fixes game hang after opening intro.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves car colour and reflection quality.
     halfPixelOffset: 2 # Fixes blurriness.
     roundSprite: 2 # Fixes blurriness.
 SLES-54323:
@@ -19626,6 +19754,7 @@ SLES-54323:
   clampModes:
     eeClampMode: 3 # Fixes game hang after opening intro.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves car colour and reflection quality.
     halfPixelOffset: 2 # Fixes blurriness.
     roundSprite: 2 # Fixes blurriness.
 SLES-54324:
@@ -19634,6 +19763,7 @@ SLES-54324:
   clampModes:
     eeClampMode: 3 # Fixes game hang after opening intro.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves car colour and reflection quality.
     halfPixelOffset: 2 # Fixes blurriness.
     roundSprite: 2 # Fixes blurriness.
 SLES-54326:
@@ -19900,6 +20030,7 @@ SLES-54402:
   clampModes:
     eeClampMode: 3 # Fixes game hang after opening intro.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves car colour and reflection quality.
     halfPixelOffset: 2 # Fixes blurriness.
     roundSprite: 2 # Fixes blurriness.
 SLES-54420:
@@ -20154,6 +20285,7 @@ SLES-54492:
   clampModes:
     eeClampMode: 3 # Fixes game hang after opening intro.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves car colour and reflection quality.
     halfPixelOffset: 2 # Fixes blurriness.
     roundSprite: 2 # Fixes blurriness.
 SLES-54493:
@@ -20162,6 +20294,7 @@ SLES-54493:
   clampModes:
     eeClampMode: 3 # Fixes game hang after opening intro.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves car colour and reflection quality.
     halfPixelOffset: 2 # Fixes blurriness.
     roundSprite: 2 # Fixes blurriness.
 SLES-54494:
@@ -20411,6 +20544,8 @@ SLES-54615:
 SLES-54616:
   name: "Fantastic Four - Rise of the Silver Surfer"
   region: "PAL-M5"
+  gsHWFixes:
+    roundSprite: 2 # Fixes edge depth bleeding during power attacks and misalgined bloom.
 SLES-54617:
   name: "Action Man A.T.O.M. - Alpha Teens on Machines"
   region: "PAL-M9"
@@ -20444,6 +20579,7 @@ SLES-54627:
   clampModes:
     vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 1 # Fixes blur and obscures sun behind objects.
     mipmap: 2 # Fixes over sharpening.
@@ -20616,6 +20752,7 @@ SLES-54681:
   clampModes:
     vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 1 # Fixes blur and obscures sun behind objects.
     mipmap: 2 # Fixes over sharpening.
@@ -20867,6 +21004,8 @@ SLES-54774:
 SLES-54776:
   name: "Fantastic Four - Rise of the Silver Surfer"
   region: "PAL-E-I"
+  gsHWFixes:
+    roundSprite: 2 # Fixes edge depth bleeding during power attacks and misalgined bloom.
 SLES-54778:
   name: "Harry Potter and the Order of the Phoenix"
   region: "PAL-E"
@@ -23062,6 +23201,7 @@ SLES-82028:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes bloom and ghosting in certain areas.
     roundSprite: 1 # Fixes door transition vertical lines and mini-map artifacts.
+    textureInsideRT: 1 # Fixes missing battle effects.
 SLES-82029:
   name: "Star Ocean 3 - Till the End of Time [Disc 2 of 2]"
   region: "PAL-E"
@@ -23071,6 +23211,7 @@ SLES-82029:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes bloom and ghosting in certain areas.
     roundSprite: 1 # Fixes door transition vertical lines and mini-map artifacts.
+    textureInsideRT: 1 # Fixes missing battle effects.
   memcardFilters:
     - "SLES-82028"
 SLES-82030:
@@ -23905,6 +24046,8 @@ SLKA-25196:
     autoFlush: 1
     halfPixelOffset: 2 # Fixes misaligned lighting.
     cpuCLUTRender: 1 # Fixes janky coloured cars.
+    gpuTargetCLUT: 1 # Fixes janky coloured cars.
+    textureInsideRT: 1 # Fixes car textures.
 SLKA-25198:
   name: "Tenchu Kurenai"
   region: "NTSC-K"
@@ -23946,6 +24089,7 @@ SLKA-25206:
   clampModes:
     vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 1 # Fixes blur and obscures sun behind objects.
     mipmap: 2 # Fixes over sharpening.
@@ -23977,6 +24121,7 @@ SLKA-25213:
   gsHWFixes:
     preloadFrameData: 1 # Partially fixes HUD elements.
     halfPixelOffset: 1 # Fixes misaligned blur around objects and enemies.
+    PCRTCOverscan: 1 # Fixes offscreen image.
   gameFixes:
     - SoftwareRendererFMVHack # Fixes subtitles not showing during FMVs.
 SLKA-25214:
@@ -24067,6 +24212,7 @@ SLKA-25241:
   name: "Need for Speed - Underground 2"
   region: "NTSC-K"
   gsHWFixes:
+    minimumBlendingLevel: 2 # Fixes missing post processing.
     halfPixelOffset: 1 # Fixes misaligned post-processing.
 SLKA-25243:
   name: "Medal of Honor - European Assault"
@@ -24245,6 +24391,7 @@ SLKA-25304:
   clampModes:
     vuClampMode: 0 # Fixes buggy lighting in the garage.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 1 # Fixes blur and obscures sun behind objects.
     mipmap: 2 # Fixes over sharpening.
@@ -24345,6 +24492,7 @@ SLKA-25334:
   name: "Need for Speed - Most Wanted"
   region: "NTSC-K"
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes blurriness.
     cpuCLUTRender: 1 # Final colour adjustment LUT.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
@@ -24352,6 +24500,7 @@ SLKA-25335:
   name: "Shadow the Hedgehog"
   region: "NTSC-K"
   gsHWFixes:
+    recommendedBlendingLevel: 4 # Improves smoke rendering.
     halfPixelOffset: 2 # Fixes misaligned lighting.
 SLKA-25338:
   name: "Godfather, The"
@@ -24583,12 +24732,21 @@ SLPM-20436:
   name: "Sakigake!! Otokojuku"
   region: "NTSC-J"
   compat: 5
+SLPM-55003:
+  name: "Need for Speed - Most Wanted [EASY 1980]"
+  region: "NTSC-J"
+  gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves car reflections.
+    halfPixelOffset: 2 # Fixes blurriness.
+    cpuCLUTRender: 1 # Final colour adjustment LUT.
+    gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
 SLPM-55004:
   name: "Burnout Revenge (EASY 1980)"
   region: "NTSC-J"
   clampModes:
     vuClampMode: 0 # Fixes buggy lighting in the garage.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 1 # Fixes blur and obscures sun behind objects.
     mipmap: 2 # Fixes over sharpening.
@@ -24631,6 +24789,7 @@ SLPM-55036:
   clampModes:
     vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 1 # Fixes blur and obscures sun behind objects.
     mipmap: 2 # Fixes over sharpening.
@@ -24674,6 +24833,7 @@ SLPM-55061:
   clampModes:
     eeClampMode: 3 # Fixes game hang after opening intro.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves car colour and reflection quality.
     halfPixelOffset: 2 # Fixes blurriness.
     roundSprite: 2 # Fixes blurriness.
 SLPM-55062:
@@ -24713,6 +24873,7 @@ SLPM-55080:
   gsHWFixes:
     texturePreloading: 1 # Performs better with partial preload because it is slow on locations outside gameplay foremost.
     mergeSprite: 1 # Fixes misaligned white lines.
+    PCRTCOverscan: 1 # Fixes missing HUD.
 SLPM-55081:
   name: "Drag-on Dragoon 2 - Fuuin no Aka, Haitoku no Kuro [Ultimate Hits]"
   region: "NTSC-J"
@@ -25186,6 +25347,13 @@ SLPM-60172:
 SLPM-60183:
   name: "Energy Airforce [Trial]"
   region: "NTSC-J"
+SLPM-60198:
+  name: "MotoGP 3 [Trial]"
+  region: "NTSC-J"
+  gsHWFixes:
+    roundSprite: 2 # Fixes lines at the edges of the HUD.
+    mipmap: 2 # Mipmap + trilinear, improves road and grass textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-60207:
   name: "Rockman X7"
   region: "NTSC-J"
@@ -25217,6 +25385,7 @@ SLPM-60246:
   clampModes:
     vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 1 # Fixes blur and obscures sun behind objects.
     mipmap: 2 # Fixes over sharpening.
@@ -25224,6 +25393,12 @@ SLPM-60246:
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
+SLPM-60250:
+  name: "Need for Speed - Underground 2 [Trial]"
+  region: "NTSC-J"
+  gsHWFixes:
+    minimumBlendingLevel: 2 # Fixes missing post processing.
+    halfPixelOffset: 1 # Fixes misaligned post-processing.
 SLPM-60251:
   name: "Devil May Cry 3 [Trial Version]"
   region: "NTSC-J"
@@ -25362,6 +25537,17 @@ SLPM-61090:
   gsHWFixes:
     wildArmsHack: 1 # Fixes blurriness.
     mergeSprite: 1 # Fixes misaligned lights.
+SLPM-61092:
+  name: "Driv3r [Trial]"
+  region: "NTSC-J"
+  gameFixes:
+    - BlitInternalFPSHack # Fixes internal FPS detection.
+  gsHWFixes:
+    autoFlush: 1
+    halfPixelOffset: 2 # Fixes misaligned lighting.
+    cpuCLUTRender: 1 # Fixes janky coloured cars.
+    gpuTargetCLUT: 1 # Fixes janky coloured cars.
+    textureInsideRT: 1 # Fixes car textures.
 SLPM-61117:
   name: "Musashiden II - Blademaster [Trial]"
   region: "NTSC-J"
@@ -25538,6 +25724,13 @@ SLPM-62040:
 SLPM-62041:
   name: "ESPN National Hockey Night"
   region: "NTSC-J"
+SLPM-62043:
+  name: "Metal Gear Solid 2 - Sons of Liberty [Trial version]"
+  region: "NTSC-J"
+  gameFixes:
+    - InstantDMAHack # Fixes broken half-bottom artifacts.
+  gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
 SLPM-62044:
   name: "RC Revenge Pro"
   region: "NTSC-J"
@@ -25620,6 +25813,8 @@ SLPM-62075:
 SLPM-62076:
   name: "Age of Empires II - The Age of Kings"
   region: "NTSC-J"
+  gsHWFixes:
+    estimateTextureRegion: 1 # Improves performance and reduces hash cache size when moving.
 SLPM-62077:
   name: "Maestro Music 2, The"
   region: "NTSC-J"
@@ -28000,6 +28195,8 @@ SLPM-65077:
   region: "NTSC-J"
   gameFixes:
     - InstantDMAHack # Fixes broken half-bottom artifacts.
+  gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
   memcardFilters:
     - "SLPM-65078"
     - "SLPM-65077"
@@ -28008,6 +28205,8 @@ SLPM-65078:
   region: "NTSC-J"
   gameFixes:
     - InstantDMAHack # Fixes broken half-bottom artifacts.
+  gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
   memcardFilters:
     - "SLPM-65078"
     - "SLPM-65077"
@@ -28374,6 +28573,7 @@ SLPM-65209:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes bloom and ghosting in certain areas.
     roundSprite: 1 # Fixes door transition vertical lines and mini-map artifacts.
+    textureInsideRT: 1 # Fixes missing battle effects.
   patches:
     BEC32D49:
       content: |-
@@ -28638,6 +28838,7 @@ SLPM-65266:
   gsHWFixes:
     texturePreloading: 1 # Performs better with partial preload because it is slow on locations outside gameplay foremost.
     mergeSprite: 1 # Fixes misaligned white lines.
+    PCRTCOverscan: 1 # Fixes missing HUD.
 SLPM-65267:
   name: "Kurogane no Houkou 2 - Warship Gunner"
   region: "NTSC-J"
@@ -29092,6 +29293,7 @@ SLPM-65410:
   name: "Getaway, The"
   region: "NTSC-J"
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes the fog wall.
     textureInsideRT: 1
     texturePreloading: 1 # Performs much better with partial preload.
     halfPixelOffset: 2 # Fixes outlines around characters.
@@ -29198,6 +29400,7 @@ SLPM-65438:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes bloom and ghosting in certain areas.
     roundSprite: 1 # Fixes door transition vertical lines and mini-map artifacts.
+    textureInsideRT: 1 # Fixes missing battle effects.
 SLPM-65439:
   name: "Star Ocean 3 [Director's Cut] [Disc 2 of 2]"
   region: "NTSC-J"
@@ -29207,6 +29410,7 @@ SLPM-65439:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes bloom and ghosting in certain areas.
     roundSprite: 1 # Fixes door transition vertical lines and mini-map artifacts.
+    textureInsideRT: 1 # Fixes missing battle effects.
   memcardFilters:
     - "SLPM-65438"
 SLPM-65441:
@@ -29388,6 +29592,8 @@ SLPM-65495:
   region: "NTSC-J"
   clampModes:
     vuClampMode: 3 # Fixes lighting on character models as caves and other locations don't turn mobs into glow-in-the-dark creatures by themselves.
+  gsHWFixes:
+    maximumBlendingLevel: 0 # Fixes unnecessary load on the GPU.
 SLPM-65496:
   name: "Hyper Street Fighter"
   region: "NTSC-J"
@@ -30002,6 +30208,7 @@ SLPM-65686:
   gsHWFixes:
     preloadFrameData: 1 # Partially fixes HUD elements.
     halfPixelOffset: 1 # Fixes misaligned blur around objects and enemies.
+    PCRTCOverscan: 1 # Fixes offscreen image.
   gameFixes:
     - SoftwareRendererFMVHack # Fixes subtitles not showing during FMVs.
 SLPM-65687:
@@ -30121,6 +30328,7 @@ SLPM-65719:
   clampModes:
     vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 1 # Fixes blur and obscures sun behind objects.
     mipmap: 2 # Fixes over sharpening.
@@ -30220,6 +30428,8 @@ SLPM-65741:
     autoFlush: 1
     halfPixelOffset: 2 # Fixes misaligned lighting.
     cpuCLUTRender: 1 # Fixes janky coloured cars.
+    gpuTargetCLUT: 1 # Fixes janky coloured cars.
+    textureInsideRT: 1 # Fixes car textures.
 SLPM-65742:
   name: "Cool Girl [Konami the Best]"
   region: "NTSC-J"
@@ -30262,6 +30472,10 @@ SLPM-65753:
 SLPM-65754:
   name: "Metal Gear Solid 2 [Konami Dendou Collection]"
   region: "NTSC-J"
+  gameFixes:
+    - InstantDMAHack # Fixes broken half-bottom artifacts.
+  gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
 SLPM-65755:
   name: "Samurai Western - Katsugeki Samurai-dou"
   region: "NTSC-J"
@@ -30307,6 +30521,9 @@ SLPM-65765:
 SLPM-65766:
   name: "Need for Speed Underground 2"
   region: "NTSC-J"
+  gsHWFixes:
+    minimumBlendingLevel: 2 # Fixes missing post processing.
+    halfPixelOffset: 1 # Fixes misaligned post-processing.
 SLPM-65767:
   name: "NBA Starting Five 2005"
   region: "NTSC-J"
@@ -30723,6 +30940,7 @@ SLPM-65888:
     # halfPixelOffset: 1 # Aligns shadows properly, but causes grid lines to appear in sea travel.
     halfPixelOffset: 2 # Sharpens world in far distances, aligns some bloom better.
     roundSprite: 1 # Fixes font artifacts.
+    PCRTCOverscan: 1 # Fixes offscreen image.
 SLPM-65889:
   name: "Kazoku Keikaku - Kokoro no Kizuna"
   region: "NTSC-J"
@@ -30958,6 +31176,7 @@ SLPM-65958:
   clampModes:
     vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 1 # Fixes blur and obscures sun behind objects.
     mipmap: 2 # Fixes over sharpening.
@@ -31041,7 +31260,7 @@ SLPM-65975:
   gsHWFixes:
     autoFlush: 1 # Fixes car shadows.
     roundSprite: 1 # Fixes misaligned text.
-    halfPixelOffset: 1 # Fixes minor ghosting on objects.
+    halfPixelOffset: 2 # Fixes minor ghosting on objects.
 SLPM-65976:
   name: "Grandia III [Disc 1 of 2]"
   region: "NTSC-J"
@@ -31305,6 +31524,9 @@ SLPM-66050:
 SLPM-66051:
   name: "Need for Speed Underground 2 [EA Best Hits]"
   region: "NTSC-J"
+  gsHWFixes:
+    minimumBlendingLevel: 2 # Fixes missing post processing.
+    halfPixelOffset: 1 # Fixes misaligned post-processing.
 SLPM-66052:
   name: "Miko Mai - Eien no Omoi"
   region: "NTSC-J"
@@ -31438,6 +31660,8 @@ SLPM-66089:
 SLPM-66090:
   name: "Crash Bandicoot - Gacchanko World"
   region: "NTSC-J"
+  gsHWFixes:
+    PCRTCOverscan: 1 # Fixes offscreen image.
 SLPM-66091:
   name: "Shinobido Imashime"
   region: "NTSC-J"
@@ -31509,6 +31733,7 @@ SLPM-66108:
   clampModes:
     vuClampMode: 0 # Fixes buggy lighting in the garage.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 1 # Fixes blur and obscures sun behind objects.
     mipmap: 2 # Fixes over sharpening.
@@ -31757,6 +31982,7 @@ SLPM-66166:
   name: "Shadow the Hedgehog"
   region: "NTSC-J"
   gsHWFixes:
+    recommendedBlendingLevel: 4 # Improves smoke rendering.
     halfPixelOffset: 2 # Fixes misaligned lighting.
 SLPM-66167:
   name: "God of War"
@@ -31824,6 +32050,7 @@ SLPM-66183:
   name: "Getaway, The - Black Monday"
   region: "NTSC-J"
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes the fog wall.
     textureInsideRT: 1
     halfPixelOffset: 2 # Fixes outlines on screen edges.
     getSkipCount: "GSC_GetawayGames"
@@ -32049,6 +32276,7 @@ SLPM-66232:
   name: "Need for Speed - Most Wanted"
   region: "NTSC-J"
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes blurriness.
     cpuCLUTRender: 1 # Final colour adjustment LUT.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
@@ -32412,6 +32640,8 @@ SLPM-66328:
   gsHWFixes:
     roundSprite: 1 # Fixes lines in sprites.
     cpuSpriteRenderBW: 1 # Fixes textures.
+    mipmap: 2 # Mipmap + trilinear, improves ground and building textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-66329:
   name: "Mahou Sensei Negima! Kagai Jugyou"
   region: "NTSC-J"
@@ -32457,7 +32687,7 @@ SLPM-66334:
   gsHWFixes:
     autoFlush: 1 # Fixes car shadows.
     roundSprite: 1 # Fixes misaligned text.
-    halfPixelOffset: 1 # Fixes minor ghosting on objects.
+    halfPixelOffset: 2 # Fixes minor ghosting on objects.
 SLPM-66336:
   name: "Shinseiki Evangelion - Koutetsu no Girlfriend [Special Edition]"
   region: "NTSC-J"
@@ -32513,6 +32743,7 @@ SLPM-66354:
   clampModes:
     vuClampMode: 3 # Fixes SPS.
   gsHWFixes:
+    recommendedBlendingLevel: 4 # Improves lighting on buildings and objects.
     autoFlush: 1 # Properly diffuses light instead of strips of light.
     roundSprite: 1 # Fixes lighting misalignment such as the street poles and the sun.
     mipmap: 2 # Fixes over sharpening.
@@ -32999,6 +33230,7 @@ SLPM-66478:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes bloom and ghosting in certain areas.
     roundSprite: 1 # Fixes door transition vertical lines and mini-map artifacts.
+    textureInsideRT: 1 # Fixes missing battle effects.
 SLPM-66479:
   name: "Star Ocean 3 - Till the End of Time [Ultimate Hits] [Disc 2 of 2]"
   region: "NTSC-J"
@@ -33008,6 +33240,7 @@ SLPM-66479:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes bloom and ghosting in certain areas.
     roundSprite: 1 # Fixes door transition vertical lines and mini-map artifacts.
+    textureInsideRT: 1 # Fixes missing battle effects.
   memcardFilters:
     - "SLPM-66478"
 SLPM-66480:
@@ -33108,6 +33341,8 @@ SLPM-66503:
   region: "NTSC-J"
   gameFixes:
     - DMABusyHack # Fixes broken half-bottom artifacts.
+  gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
 SLPM-66504:
   name: "Onimusha 2 [Mega Hits]"
   region: "NTSC-J"
@@ -33289,6 +33524,7 @@ SLPM-66562:
   name: "Need for Speed - Most Wanted [EA Best Hits]"
   region: "NTSC-J"
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes blurriness.
     cpuCLUTRender: 1 # Final colour adjustment LUT.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
@@ -33518,6 +33754,7 @@ SLPM-66617:
   clampModes:
     eeClampMode: 3 # Fixes game hang after opening intro.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves car colour and reflection quality.
     halfPixelOffset: 2 # Fixes blurriness.
     roundSprite: 2 # Fixes blurriness.
 SLPM-66618:
@@ -33641,6 +33878,7 @@ SLPM-66652:
   clampModes:
     vuClampMode: 0 # Fixes buggy lighting in the garage.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 1 # Fixes blur and obscures sun behind objects.
     mipmap: 2 # Fixes over sharpening.
@@ -33979,6 +34217,7 @@ SLPM-66731:
   clampModes:
     vuClampMode: 3 # Fixes SPS.
   gsHWFixes:
+    recommendedBlendingLevel: 4 # Improves lighting on buildings and objects.
     autoFlush: 1 # Properly diffuses light instead of strips of light.
     roundSprite: 1 # Fixes lighting misalignment such as the street poles and the sun.
     mipmap: 2 # Fixes over sharpening.
@@ -34026,6 +34265,7 @@ SLPM-66739:
   clampModes:
     vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 1 # Fixes blur and obscures sun behind objects.
     mipmap: 2 # Fixes over sharpening.
@@ -34229,10 +34469,19 @@ SLPM-66791:
   name: "Memories Off #5 Encore"
   region: "NTSC-J"
 SLPM-66792:
-  name: "Metal Gear Solid 2 - Sons of Liberty [20th Anniversary Edition]"
+  name: "Metal Gear Solid 2 - Sons of Liberty [20th Anniversary Edition] [Disc 1 of 2]"
   region: "NTSC-J"
   gameFixes:
     - InstantDMAHack # Fixes broken half-bottom artifacts.
+  gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
+SLPM-66793:
+  name: "Metal Gear Solid 2 - Sons of Liberty [20th Anniversary Edition] [Disc 2 of 2]"
+  region: "NTSC-J"
+  gameFixes:
+    - InstantDMAHack # Fixes broken half-bottom artifacts.
+  gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
 SLPM-66794:
   name: "Metal Gear Solid 3 - Snake Eater [20th Anniversary Edition]"
   region: "NTSC-J"
@@ -34459,6 +34708,7 @@ SLPM-66869:
   clampModes:
     eeClampMode: 3 # Fixes game hang after opening intro.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves car colour and reflection quality.
     halfPixelOffset: 2 # Fixes blurriness.
     roundSprite: 2 # Fixes blurriness.
 SLPM-66870:
@@ -34744,6 +34994,7 @@ SLPM-66960:
   name: "Need for Speed - Underground 2 [EA-SY! 1980]"
   region: "NTSC-J"
   gsHWFixes:
+    minimumBlendingLevel: 2 # Fixes missing post processing.
     halfPixelOffset: 1 # Fixes misaligned post-processing.
 SLPM-66961:
   name: "Black [EA-SY! 1980]"
@@ -34751,6 +35002,7 @@ SLPM-66961:
   clampModes:
     vuClampMode: 3 # Fixes SPS.
   gsHWFixes:
+    recommendedBlendingLevel: 4 # Improves lighting on buildings and objects.
     autoFlush: 1 # Properly diffuses light instead of strips of light.
     roundSprite: 1 # Fixes lighting misalignment such as the street poles and the sun.
     mipmap: 2 # Fixes over sharpening.
@@ -34763,6 +35015,7 @@ SLPM-66962:
   clampModes:
     vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 1 # Fixes blur and obscures sun behind objects.
     mipmap: 2 # Fixes over sharpening.
@@ -34998,6 +35251,8 @@ SLPM-67515:
   region: "NTSC-K"
   gameFixes:
     - InstantDMAHack # Fixes broken half-bottom artifacts.
+  gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
 SLPM-67518:
   name: "Onimusha 2 Samurai's Destiny"
   region: "NTSC-K"
@@ -35114,6 +35369,8 @@ SLPM-68503:
   region: "NTSC-J"
   gameFixes:
     - InstantDMAHack # Fixes broken half-bottom artifacts.
+  gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
 SLPM-68504:
   name: "Tokimeki Memorial 3 - Special Sound Track"
   region: "NTSC-J"
@@ -35413,6 +35670,20 @@ SLPM-74253:
 SLPM-74254:
   name: "EX Jinsei Game II [PlayStation 2 the Best - Reprint]"
   region: "NTSC-J"
+SLPM-74255:
+  name: "Metal Gear Solid 2 - Sons of Liberty [PlayStation 2 The Best] [Disc 1 of 2]"
+  region: "NTSC-J"
+  gameFixes:
+    - InstantDMAHack # Fixes broken half-bottom artifacts.
+  gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
+SLPM-74256:
+  name: "Metal Gear Solid 2 - Sons of Liberty [PlayStation 2 The Best] [Disc 2 of 2]"
+  region: "NTSC-J"
+  gameFixes:
+    - InstantDMAHack # Fixes broken half-bottom artifacts.
+  gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
 SLPM-74259:
   name: "Odin Sphere [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -35610,7 +35881,9 @@ SLPS-20025:
   name: "SSX - Snowboard Supercross"
   region: "NTSC-J"
   roundModes:
-    eeRoundMode: 0 # Fixes riders vanish into the floor
+    eeRoundMode: 0 # Fixes riders vanishing into the floor.
+  gsHWFixes:
+    recommendedBlendingLevel: 4 # Fixes missing lighting.
 SLPS-20027:
   name: "Aquaqua"
   region: "NTSC-J"
@@ -37618,6 +37891,10 @@ SLPS-25203:
 SLPS-25204:
   name: "MotoGP3"
   region: "NTSC-J"
+  gsHWFixes:
+    roundSprite: 2 # Fixes lines at the edges of the HUD.
+    mipmap: 2 # Mipmap + trilinear, improves road and grass textures to match sw renderer.
+    trilinearFiltering: 1
 SLPS-25205:
   name: "Ys I-II - Eternal Story [Limited Edition]"
   region: "NTSC-J"
@@ -41262,7 +41539,9 @@ SLUS-20095:
   region: "NTSC-U"
   compat: 5
   roundModes:
-    eeRoundMode: 0 # Fixes riders vanish into the floor
+    eeRoundMode: 0 # Fixes riders vanishing into the floor.
+  gsHWFixes:
+    recommendedBlendingLevel: 4 # Fixes missing lighting.
 SLUS-20096:
   name: "Swing Away Golf"
   region: "NTSC-U"
@@ -41399,6 +41678,8 @@ SLUS-20144:
   compat: 5
   gameFixes:
     - InstantDMAHack # Fixes broken half-bottom artifacts.
+  gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
 SLUS-20145:
   name: "Ring of Red"
   region: "NTSC-U"
@@ -41422,7 +41703,9 @@ SLUS-20149:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    mipmap: 1
+    recommendedBlendingLevel: 3 # Improves reflections on weapons and metalic surfaces.
+    mipmap: 2 # Mipmap + trilinear, improves ground and building textures to match sw renderer.
+    trilinearFiltering: 1
     roundSprite: 1 # Fixes font artifacts.
 SLUS-20150:
   name: "Knockout Kings 2001"
@@ -41653,6 +41936,9 @@ SLUS-20209:
   name: "Midnight Club II"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves road and tree textures to match software.
+    trilinearFiltering: 1
   patches:
     E5F2DF38:
       content: |-
@@ -42841,6 +43127,8 @@ SLUS-20462:
   name: "Wipeout Fusion"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    PCRTCOffsets: 1 # Fixes viewport shaking.
 SLUS-20463:
   name: "Dropship - United Peace Force"
   region: "NTSC-U"
@@ -42988,6 +43276,7 @@ SLUS-20488:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes bloom and ghosting in certain areas.
     roundSprite: 1 # Fixes door transition vertical lines and mini-map artifacts.
+    textureInsideRT: 1 # Fixes missing battle effects.
 SLUS-20489:
   name: "Whirl Tour"
   region: "NTSC-U"
@@ -43476,6 +43765,8 @@ SLUS-20587:
     autoFlush: 1
     halfPixelOffset: 2 # Fixes misaligned lighting.
     cpuCLUTRender: 1 # Fixes janky coloured cars.
+    gpuTargetCLUT: 1 # Fixes janky coloured cars.
+    textureInsideRT: 1 # Fixes car textures.
 SLUS-20588:
   name: "Activision Anthology"
   region: "NTSC-U"
@@ -43641,6 +43932,10 @@ SLUS-20624:
 SLUS-20625:
   name: "MotoGP 3"
   region: "NTSC-U"
+  gsHWFixes:
+    roundSprite: 2 # Fixes lines at the edges of the HUD.
+    mipmap: 2 # Mipmap + trilinear, improves road and grass textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-20626:
   name: "Deer Hunter"
   region: "NTSC-U"
@@ -43837,6 +44132,8 @@ SLUS-20669:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
+    PCRTCOverscan: 1 # Shows full image frame.
+    PCRTCOffsets: 1 # Shows full image frame.
     halfPixelOffset: 1 # Fixes character offset with flashlight and blurriness.
     alignSprite: 1 # Fixes vertical lines.
     roundSprite: 2 # Fixes font artifacts.
@@ -44155,6 +44452,7 @@ SLUS-20732:
   gsHWFixes:
     texturePreloading: 1 # Performs better with partial preload because it is slow on locations outside gameplay foremost.
     mergeSprite: 1 # Fixes misaligned white lines.
+    PCRTCOverscan: 1 # Fixes missing HUD.
 SLUS-20733:
   name: "Castlevania - Lament of Innocence"
   region: "NTSC-U"
@@ -44915,6 +45213,7 @@ SLUS-20891:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes bloom and ghosting in certain areas.
     roundSprite: 1 # Fixes door transition vertical lines and mini-map artifacts.
+    textureInsideRT: 1 # Fixes missing battle effects.
   memcardFilters:
     - "SLUS-20488"
 SLUS-20892:
@@ -44950,6 +45249,8 @@ SLUS-20896:
   compat: 5
   clampModes:
     vuClampMode: 3 # Fixes lighting on character models as caves and other locations don't turn mobs into glow-in-the-dark creatures by themselves.
+  gsHWFixes:
+    maximumBlendingLevel: 0 # Fixes unnecessary load on the GPU.
 SLUS-20897:
   name: "Swords of Yi"
   region: "NTSC-U"
@@ -45809,6 +46110,7 @@ SLUS-21050:
   clampModes:
     vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 1 # Fixes blur and obscures sun behind objects.
     mipmap: 2 # Fixes over sharpening.
@@ -45879,6 +46181,7 @@ SLUS-21065:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
+    minimumBlendingLevel: 2 # Fixes missing post processing.
     halfPixelOffset: 1 # Fixes misaligned post-processing.
 SLUS-21066:
   name: "Urbz, The - Sims in the City"
@@ -46235,6 +46538,7 @@ SLUS-21139:
   roundModes:
     vu1RoundMode: 0 # Fixes textures and crashes.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes broken light and shadow rendering.
     mipmap: 2 # Mipmap + trilinear, improves ground textures and water textures and reflections.
     trilinearFiltering: 1
     textureInsideRT: 1 # Fixes rainbow artifacting around edges of screen.
@@ -46487,6 +46791,8 @@ SLUS-21191:
   compat: 5
   gameFixes:
     - IbitHack # Fixes constant recompilation problems.
+  gsHWFixes:
+    PCRTCOverscan: 1 # Fixes offscreen image.
 SLUS-21192:
   name: "Cabela's Outdoor Adventures 2006"
   region: "NTSC-U"
@@ -46684,6 +46990,8 @@ SLUS-21228:
   gsHWFixes:
     roundSprite: 1 # Fixes lines in sprites.
     cpuSpriteRenderBW: 1 # Fixes textures.
+    mipmap: 2 # Mipmap + trilinear, improves ground and building textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-21229:
   name: "Motocross Mania 3"
   region: "NTSC-U"
@@ -46785,6 +47093,7 @@ SLUS-21242:
   clampModes:
     vuClampMode: 0 # Fixes buggy lighting in the garage.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 1 # Fixes blur and obscures sun behind objects.
     mipmap: 2 # Fixes over sharpening.
@@ -46909,6 +47218,7 @@ SLUS-21261:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
+    recommendedBlendingLevel: 4 # Improves smoke rendering.
     halfPixelOffset: 2 # Fixes misaligned lighting.
 SLUS-21262:
   name: "Radiata Stories"
@@ -46946,6 +47256,7 @@ SLUS-21267:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes blurriness.
     cpuCLUTRender: 1 # Final colour adjustment LUT.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
@@ -47248,6 +47559,8 @@ SLUS-21318:
   gsHWFixes:
     roundSprite: 1 # Fixes lines in sprites.
     cpuSpriteRenderBW: 1 # Fixes textures.
+    mipmap: 2 # Mipmap + trilinear, improves ground and building textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-21319:
   name: "Flow - Urban Dance Uprising"
   region: "NTSC-U"
@@ -47446,6 +47759,7 @@ SLUS-21351:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes blurriness.
     cpuCLUTRender: 1 # Final colour adjustment LUT.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
@@ -47607,6 +47921,7 @@ SLUS-21376:
   clampModes:
     vuClampMode: 3 # Fixes SPS.
   gsHWFixes:
+    recommendedBlendingLevel: 4 # Improves lighting on buildings and objects.
     autoFlush: 1 # Properly diffuses light instead of strips of light.
     roundSprite: 1 # Fixes lighting misalignment such as the street poles and the sun.
     mipmap: 2 # Fixes over sharpening.
@@ -48294,6 +48609,7 @@ SLUS-21493:
   clampModes:
     eeClampMode: 3 # Fixes game hang after opening intro.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves car colour and reflection quality.
     halfPixelOffset: 2 # Fixes blurriness.
     roundSprite: 2 # Fixes blurriness.
 SLUS-21494:
@@ -48302,6 +48618,7 @@ SLUS-21494:
   clampModes:
     eeClampMode: 3 # Fixes game hang after opening intro.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves car colour and reflection quality.
     halfPixelOffset: 2 # Fixes blurriness.
     roundSprite: 2 # Fixes blurriness.
 SLUS-21495:
@@ -48387,6 +48704,8 @@ SLUS-21544:
   name: "Fantastic 4 - Rise of Silver Surfer"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    roundSprite: 2 # Fixes edge depth bleeding during power attacks and misalgined bloom.
 SLUS-21545:
   name: "Pirates of the Caribbean - At World's End"
   region: "NTSC-U"
@@ -48617,6 +48936,7 @@ SLUS-21596:
   clampModes:
     vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 1 # Fixes blur and obscures sun behind objects.
     mipmap: 2 # Fixes over sharpening.
@@ -50476,6 +50796,8 @@ SLUS-29003:
   compat: 5
   gameFixes:
     - InstantDMAHack # Fixes broken half-bottom artifacts.
+  gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
 SLUS-29004:
   name: "Unison & Dead or Alive 2 Hardcore [Demo]"
   region: "NTSC-U"
@@ -50791,6 +51113,8 @@ SLUS-29110:
   region: "NTSC-U"
   clampModes:
     vuClampMode: 3 # Fixes lighting on character models as caves and other locations don't turn mobs into glow-in-the-dark creatures by themselves.
+  gsHWFixes:
+    maximumBlendingLevel: 0 # Fixes unnecessary load on the GPU.
 SLUS-29111:
   name: "Asterix & Obelix - Kick Buttix [Demo]"
   region: "NTSC-U"
@@ -50800,6 +51124,7 @@ SLUS-29113:
   clampModes:
     vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 1 # Fixes blur and obscures sun behind objects.
     mipmap: 2 # Fixes over sharpening.
@@ -50825,6 +51150,7 @@ SLUS-29118:
   name: "Need for Speed - Underground 2 [Demo]"
   region: "NTSC-U"
   gsHWFixes:
+    minimumBlendingLevel: 2 # Fixes missing post processing.
     halfPixelOffset: 1 # Fixes misaligned post-processing.
 SLUS-29123:
   name: "Ghost in the Shell - Stand Alone Complex [Demo]"
@@ -50932,6 +51258,7 @@ SLUS-29153:
   clampModes:
     vuClampMode: 0 # Fixes buggy lighting in the garage.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 1 # Fixes blur and obscures sun behind objects.
     mipmap: 2 # Fixes over sharpening.
@@ -50946,6 +51273,7 @@ SLUS-29155:
   name: "Need for Speed - Most Wanted [Demo]"
   region: "NTSC-U"
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes blurriness.
     cpuCLUTRender: 1 # Final colour adjustment LUT.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
@@ -51042,6 +51370,7 @@ SLUS-29180:
   clampModes:
     vuClampMode: 3 # Fixes SPS.
   gsHWFixes:
+    recommendedBlendingLevel: 4 # Improves lighting on buildings and objects.
     autoFlush: 1 # Properly diffuses light instead of strips of light.
     roundSprite: 1 # Fixes lighting misalignment such as the street poles and the sun.
     mipmap: 2 # Fixes over sharpening.
@@ -51139,6 +51468,7 @@ SLUS-97133:
   name: "Getaway, The"
   region: "NTSC-U"
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes the fog wall.
     textureInsideRT: 1
     texturePreloading: 1 # Performs much better with partial preload.
     halfPixelOffset: 2 # Fixes outlines around characters.
@@ -51197,6 +51527,7 @@ TCES-52389:
   gsHWFixes:
     autoFlush: 1 # Fixes car shadows.
     roundSprite: 1 # Fixes misaligned text.
+    halfPixelOffset: 2 # Fixes minor ghosting on objects.
 TCES-52456:
   name: "Ratchet and Clank 3 Beta Trial Code"
   region: "PAL-E"
@@ -51360,6 +51691,8 @@ TLES-52707:
   region: "PAL-E"
   clampModes:
     vuClampMode: 3 # Fixes lighting on character models as caves and other locations don't turn mobs into glow-in-the-dark creatures by themselves.
+  gsHWFixes:
+    maximumBlendingLevel: 0 # Fixes unnecessary load on the GPU.
 TLES-52781:
   name: "WWE - Smackdown Vs Raw Beta Trial Code"
   region: "PAL-E"


### PR DESCRIPTION
### Description of Changes
Adds a variety of fixes and recommendation's for users to ignore.

### Rationale behind Changes
Better performance or quality, what's not to love.

Some screenshots so Red doesn't starve from lack of content for the Q1 2023 report.

Star Ocean 3 Master:
![Star Ocean 3 - Till the End of Time  Disc 2 of 2 _SLUS-20891_20230303203106](https://user-images.githubusercontent.com/80843560/222823889-1797394c-b1d0-4b45-87ee-2d8c056e2eaa.png)


PR;
![Star Ocean 3 - Till the End of Time  Disc 2 of 2 _SLUS-20891_20230303203111](https://user-images.githubusercontent.com/80843560/222823901-00d3dda7-868e-4c99-b764-32248b45a1e9.png)

Monster Hunter Master:
![image](https://user-images.githubusercontent.com/80843560/222826478-23dd7cbe-2578-40e2-a143-8f0cb7232f18.png)


PR:
![image](https://user-images.githubusercontent.com/80843560/222826518-52a31928-952e-423d-a8b0-a194517871c9.png)

Driver Master:
![Driv3r_SLES-50876_20230303235118](https://user-images.githubusercontent.com/80843560/222857044-14027c8c-3a7a-4627-9228-e8b4275933eb.png)


PR:
![Driv3r_SLES-50876_20230303235121](https://user-images.githubusercontent.com/80843560/222857052-149573d7-8272-4bf5-ab2b-f49cd965affd.png)

Underground 2 Master:
![Need for Speed - Underground 2_SLES-52725_20230304013915](https://user-images.githubusercontent.com/80843560/222869209-a9145326-7392-4466-ae4d-978e7ee2aebf.png)


PR:
![Need for Speed - Underground 2_SLES-52725_20230304013919](https://user-images.githubusercontent.com/80843560/222869215-44b74337-b4a2-44cc-87fb-1c836d89cc81.png)


Shadow The Edgehog Master:
![Shadow the Hedgehog_SLES-53542_20230304040940](https://user-images.githubusercontent.com/80843560/222875094-93f9acb4-5caf-4623-85c4-81400d331981.png)


PR:
![Shadow the Hedgehog_SLES-53542_20230304040944](https://user-images.githubusercontent.com/80843560/222875100-cd5b835f-57f1-4b13-bf3a-94d4831b526d.png)


Tribes Aerial Assault Master:
 ![Tribes - Aerial Assault_SLUS-20149_20230304041954](https://user-images.githubusercontent.com/80843560/222875393-725678f4-58b3-4861-996f-356fba5c59cc.png)


PR:
![Tribes - Aerial Assault_SLUS-20149_20230304041959](https://user-images.githubusercontent.com/80843560/222875400-68e76818-fc8b-4143-a4e9-a63a8465b5d8.png)




### Suggested Testing Steps
Make sure I didn't make the CI whinge that I misspelt something obvious.
