### PR TITLE
GS-TC: Allow TBW expansion

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -682,9 +682,11 @@ GSTextureCache::Target* GSTextureCache::LookupTarget(const GIFRegTEX0& TEX0, con
 				dst = t;
 
 				dst->m_32_bits_fmt |= (psm_s.bpp != 16);
-				// Nicktoons Unite tries to change the width from 10 to 8 and breaks FMVs.
+				// Nicktoons Unite tries to change the width from 640 to 512 and breaks FMVs.
 				// Haunting ground has some messed textures if you don't modify the rest.
-				if (!dst->m_is_frame)
+				// Champions of Norrath expands the width from 512 to 1024, picture cut in half if you don't.
+				// The safest option is to probably let it expand but not retract.
+				if (!dst->m_is_frame || dst->m_TEX0.TBW < TEX0.TBW)
 				{
 					dst->m_TEX0 = TEX0;
 				}


### PR DESCRIPTION
### Description of Changes
Allows the texture TBW to expand, if it's an output framebuffer.

### Rationale behind Changes
Changes from 1.7.4114 for Nicktoons Unite! broke Champions of Norrath which attempts to double the width from 512 to 1024

### Suggested Testing Steps
Test Champions of Norrath and Nicktoons Unite! (I've actually already done this)

Fixes #8287

Master:
![image](https://user-images.githubusercontent.com/6278726/222954457-484022db-4e00-47be-8f54-c90b719d9969.png)

PR:
![image](https://user-images.githubusercontent.com/6278726/222954461-d477150d-f21f-42b7-b8fe-bd9fa915cdf1.png)
