### PR TITLE
GSDumpReplayer: Update serial on dump load

### DIFF
--- a/pcsx2/GSDumpReplayer.cpp
+++ b/pcsx2/GSDumpReplayer.cpp
@@ -213,6 +213,9 @@ static void GSDumpReplayerLoadInitialState()
 	std::memcpy(PS2MEM_GS, s_dump_file->GetRegsData().data(),
 		std::min(Ps2MemSize::GSregs, static_cast<u32>(s_dump_file->GetRegsData().size())));
 
+	// update serial to load hw fixes
+	VMManager::Internal::GameStartingOnCPUThread();
+
 	// load GS state
 	freezeData fd = {static_cast<int>(s_dump_file->GetStateData().size()),
 		const_cast<u8*>(s_dump_file->GetStateData().data())};


### PR DESCRIPTION
### Description of Changes

Fixes title and HW fixes not applying when dragging a new GS dump onto a running PCSX2.

### Rationale behind Changes

It's confusing without HW fixes.

### Suggested Testing Steps

Test dragging a GS dump over PCSX2 while one is already open, it should change serial/title.
