### PR TITLE
GS:MTL: Don't start render passes with no targets

### DIFF
--- a/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
+++ b/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
@@ -1710,6 +1710,15 @@ void GSDeviceMTL::RenderHW(GSHWDrawConfig& config)
 		config.ds = nullptr;
 	if (!config.ds && m_current_render.color_target == rt && stencil == m_current_render.stencil_target && m_current_render.depth_target != config.tex)
 		config.ds = m_current_render.depth_target;
+	if (!rt && !config.ds)
+	{
+		// If we were rendering depth-only and depth gets cleared by the above check, that turns into rendering nothing, which should be a no-op
+		pxAssertDev(0, "RenderHW was given a completely useless draw call!");
+		[m_current_render.encoder insertDebugSignpost:@"Skipped no-color no-depth draw"];
+		if (primid_tex)
+			Recycle(primid_tex);
+		return;
+	}
 
 	BeginRenderPass(@"RenderHW", rt, MTLLoadActionLoad, config.ds, MTLLoadActionLoad, stencil, MTLLoadActionLoad);
 	id<MTLRenderCommandEncoder> mtlenc = m_current_render.encoder;


### PR DESCRIPTION
### Description of Changes
Avoids trying to start render passes with no target (and no dimensions, which are otherwise pulled from the target if not available)
Fixes #8238

### Rationale behind Changes
Less crashy

### Suggested Testing Steps
Make sure nothing broke
#8238 was fixed by 40ee0e2aa7d38f29c329fdb3d3e3b8d576f63227, so this case really shouldn't be hit, but it's nice to be safe
