### PR TITLE
GSDumpReplayer: Fix resetting

### DIFF
--- a/pcsx2/GSDumpReplayer.cpp
+++ b/pcsx2/GSDumpReplayer.cpp
@@ -144,11 +144,6 @@ bool GSDumpReplayer::ChangeDump(const char* filename)
 	return true;
 }
 
-void GSDumpReplayer::Reset()
-{
-	GSDumpReplayerCpuReset();
-}
-
 void GSDumpReplayer::Shutdown()
 {
 	Console.WriteLn("(GSDumpReplayer) Shutting down.");
@@ -204,7 +199,6 @@ void GSDumpReplayerCpuReset()
 	s_needs_state_loaded = true;
 	s_current_packet = 0;
 	s_dump_frame_number = 0;
-	hwReset();
 }
 
 static void GSDumpReplayerLoadInitialState()

--- a/pcsx2/GSDumpReplayer.h
+++ b/pcsx2/GSDumpReplayer.h
@@ -31,7 +31,6 @@ void SetIsDumpRunner(bool is_runner);
 
 bool Initialize(const char* filename);
 bool ChangeDump(const char* filename);
-void Reset();
 void Shutdown();
 
 std::string GetDumpSerial();

--- a/pcsx2/R5900.cpp
+++ b/pcsx2/R5900.cpp
@@ -34,6 +34,7 @@
 #include "CDVD/CDVD.h"
 #include "Patch.h"
 #include "GameDatabase.h"
+#include "GSDumpReplayer.h"
 
 #include "DebugTools/Breakpoints.h"
 #include "DebugTools/MIPSAnalyst.h"
@@ -78,7 +79,8 @@ void cpuReset()
 	if (GetMTGS().IsOpen())
 		GetMTGS().WaitGS();		// GS better be done processing before we reset the EE, just in case.
 
-	GetVmMemory().Reset();
+	if (!GSDumpReplayer::IsReplayingDump())
+		GetVmMemory().Reset();
 
 	memzero(cpuRegs);
 	memzero(fpuRegs);

--- a/pcsx2/System.cpp
+++ b/pcsx2/System.cpp
@@ -303,6 +303,15 @@ BaseVUmicroCPU* CpuVU1 = nullptr;
 
 void SysCpuProviderPack::ApplyConfig() const
 {
+	if (GSDumpReplayer::IsReplayingDump())
+	{
+		Cpu = &GSDumpReplayerCpu;
+		psxCpu = &psxInt;
+		CpuVU0 = &CpuIntVU0;
+		CpuVU1 = &CpuIntVU1;
+		return;
+	}
+
 	Cpu = CHECK_EEREC ? &recCpu : &intCpu;
 	psxCpu = CHECK_IOPREC ? &psxRec : &psxInt;
 
@@ -314,9 +323,6 @@ void SysCpuProviderPack::ApplyConfig() const
 
 	if (EmuConfig.Cpu.Recompiler.EnableVU1)
 		CpuVU1 = &CpuMicroVU1;
-
-	if (GSDumpReplayer::IsReplayingDump())
-		Cpu = &GSDumpReplayerCpu;
 }
 
 // Resets all PS2 cpu execution caches, which does not affect that actual PS2 state/condition.


### PR DESCRIPTION
### Description of Changes

And get rid of memory reset, it's never used.

### Rationale behind Changes

Resetting while a GS dump was running would sometimes crash.

### Suggested Testing Steps

Test resetting while playing a GS dump.
