### PR TITLE
GS-hw: Fix invert rounding for accumulation blend on OpenGL.

### DIFF
--- a/bin/resources/shaders/dx11/tfx.fx
+++ b/bin/resources/shaders/dx11/tfx.fx
@@ -743,7 +743,7 @@ void ps_dither(inout float3 C, float2 pos_xy)
 			fpos = int2(pos_xy / (float)PS_SCALE_FACTOR);
 
 		float value = DitherMatrix[fpos.x & 3][fpos.y & 3];
-		if (PS_ROUND_INV != 0)
+		if (PS_ROUND_INV)
 			C -= value;
 		else
 			C += value;
@@ -756,7 +756,7 @@ void ps_color_clamp_wrap(inout float3 C)
 	// so we need to limit the color depth on dithered items
 	if (SW_BLEND || PS_DITHER || PS_FBMASK)
 	{
-		if (PS_DFMT == FMT_16 && PS_BLEND_MIX == 0 && PS_ROUND_INV != 0)
+		if (PS_DFMT == FMT_16 && PS_BLEND_MIX == 0 && PS_ROUND_INV)
 			C += 7.0f; // Need to round up, not down since the shader will invert
 
 		// Standard Clamp

--- a/bin/resources/shaders/opengl/tfx_fs.glsl
+++ b/bin/resources/shaders/opengl/tfx_fs.glsl
@@ -669,8 +669,8 @@ void ps_color_clamp_wrap(inout vec3 C)
     // so we need to limit the color depth on dithered items
 #if SW_BLEND || PS_DITHER || PS_FBMASK
 
-#if PS_DFMT == FMT_16 && PS_BLEND_MIX == 0
-    C += 7.f; // Need to round up, not down since the shader will invert
+#if PS_DFMT == FMT_16 && PS_BLEND_MIX == 0 && PS_ROUND_INV
+    C += 7.0f; // Need to round up, not down since the shader will invert
 #endif
 
     // Correct the Color value based on the output format

--- a/bin/resources/shaders/vulkan/tfx.glsl
+++ b/bin/resources/shaders/vulkan/tfx.glsl
@@ -985,7 +985,7 @@ void ps_color_clamp_wrap(inout vec3 C)
 	// so we need to limit the color depth on dithered items
 #if SW_BLEND || PS_DITHER || PS_FBMASK
 
-#if PS_DFMT == FMT_16 && PS_BLEND_MIX == 0 && PS_ROUND_INV != 0
+#if PS_DFMT == FMT_16 && PS_BLEND_MIX == 0 && PS_ROUND_INV
 	C += 7.0f; // Need to round up, not down since the shader will invert
 #endif
 

--- a/pcsx2/ShaderCacheVersion.h
+++ b/pcsx2/ShaderCacheVersion.h
@@ -15,4 +15,4 @@
 
 /// Version number for GS and other shaders. Increment whenever any of the contents of the
 /// shaders change, to invalidate the cache.
-static constexpr u32 SHADER_CACHE_VERSION = 17;
+static constexpr u32 SHADER_CACHE_VERSION = 18;


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS-hw: Fix invert rounding for accumulation blend on gl.
Also make the checks consistent for all renderers.
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Bugfix, regression from #8250
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Tested, should be fine, change is obvious, can test the dump below.
[destroyallhumans_zfight.gs.zip](https://github.com/PCSX2/pcsx2/files/10902262/destroyallhumans_zfight.gs.zip)
