### PR TITLE
GSDumpReplayer: Fix widescreen patch crashing on GS dump load

### DIFF
--- a/pcsx2/R5900.cpp
+++ b/pcsx2/R5900.cpp
@@ -79,8 +79,7 @@ void cpuReset()
 	if (GetMTGS().IsOpen())
 		GetMTGS().WaitGS();		// GS better be done processing before we reset the EE, just in case.
 
-	if (!GSDumpReplayer::IsReplayingDump())
-		GetVmMemory().Reset();
+	GetVmMemory().Reset();
 
 	memzero(cpuRegs);
 	memzero(fpuRegs);


### PR DESCRIPTION
### Description of Changes
Fixes a regression which caused PCSX2 to crash if you loaded a dump with widescreen patches enabled.

Regression from #8341 

### Rationale behind Changes 
Crashes are bad mkay.

### Suggested Testing Steps
Make sure dump loading works correctly with widescreen patches enabled and the CI is a happy boy.
