### PR TITLE
Qt: Disable framebuffer fetch option on d3d.

### DIFF
--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -921,10 +921,12 @@ void GraphicsSettingsWidget::updateRendererDependentOptions()
 	else if (is_hardware && prev_tab == 2)
 		m_ui.tabs->setCurrentIndex(1);
 
+	m_ui.useBlitSwapChain->setEnabled(is_dx11);
+
 	m_ui.overrideTextureBarriers->setDisabled(is_sw_dx);
 	m_ui.overrideGeometryShader->setDisabled(is_sw_dx);
 
-	m_ui.useBlitSwapChain->setEnabled(is_dx11);
+	m_ui.disableFramebufferFetch->setDisabled(is_sw_dx);
 
 	// populate adapters
 	HostDisplay::AdapterAndModeList modes;


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Qt: Disable framebuffer fetch option on d3d.
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Option shouldn't be toggleable on d3d.
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
On d3d option shouldn't be toggleable.