### PR TITLE
Qt: Restore main menu settings button

### DIFF
--- a/pcsx2-qt/MainWindow.ui
+++ b/pcsx2-qt/MainWindow.ui
@@ -79,6 +79,7 @@
     <addaction name="menuLoadState"/>
     <addaction name="menuSaveState"/>
     <addaction name="separator"/>
+    <addaction name="actionSettings"/> <!-- Please consult with macOS users before removing -->
     <addaction name="actionExit"/>
    </widget>
    <widget class="QMenu" name="menuSettings">


### PR DESCRIPTION
### Description of Changes
Restores the preferences menu option from the system menu that disappeared in #8297

### Rationale behind Changes
Required for expected behavior on macOS (both from a "users expect it to be there" perspective, and a "removing it breaks the standard settings keyboard shortcut" perspective)

### Suggested Testing Steps
- Make sure you can ⌘, your way to settings