### PR TITLE
GS/Metal: Align texture upload pitch to 32 bytes

### DIFF
--- a/pcsx2/GS/Renderers/Metal/GSTextureMTL.h
+++ b/pcsx2/GS/Renderers/Metal/GSTextureMTL.h
@@ -93,9 +93,6 @@ public:
 	void Flush() override;
 
 private:
-	// TODO: Is there an optimal transfer pitch alignment for Metal?
-	static constexpr u32 PITCH_ALIGNMENT = 32;
-
 	GSDownloadTextureMTL(GSDeviceMTL* dev, MRCOwned<id<MTLBuffer>> buffer, u32 width, u32 height, GSTexture::Format format);
 
 	GSDeviceMTL* m_dev;


### PR DESCRIPTION
### Description of Changes

Not aligning to 32 bytes can cause exceptions due to unaligned stores in ReadTexture().

### Rationale behind Changes

Fixes #8303 (hopefully).

### Suggested Testing Steps

Test AVX2 with GT4 dump.
