### PR TITLE
GS-hw: Blend fixes and cleanup.

### DIFF
--- a/bin/resources/shaders/dx11/tfx.fx
+++ b/bin/resources/shaders/dx11/tfx.fx
@@ -831,7 +831,7 @@ void ps_blend(inout float4 Color, inout float4 As_rgba, float2 pos_xy)
 			float3 alpha_compensate = max((float3)1.0f, Color.rgb / (float3)255.0f);
 			As_rgba.rgb -= alpha_compensate;
 		}
-		else if (PS_CLR_HW == 2)
+		else if (PS_CLR_HW == 2 || PS_CLR_HW == 4)
 		{
 			// Compensate slightly for Cd*(As + 1) - Cs*As.
 			// The initial factor we chose is 1 (0.00392)
@@ -841,7 +841,7 @@ void ps_blend(inout float4 Color, inout float4 As_rgba, float2 pos_xy)
 			float color_compensate = 1.0f * (C + 1.0f);
 			Color.rgb -= (float3)color_compensate;
 		}
-		else if (PS_CLR_HW == 3)
+		else if (PS_CLR_HW == 3 || PS_CLR_HW == 5)
 		{
 			// As, Ad or Af clamped.
 			As_rgba.rgb = (float3)C_clamped;

--- a/bin/resources/shaders/opengl/tfx_fs.glsl
+++ b/bin/resources/shaders/opengl/tfx_fs.glsl
@@ -786,7 +786,7 @@ float As = As_rgba.a;
     // changed alpha should only be done for hw blend.
     vec3 alpha_compensate = max(vec3(1.0f), Color.rgb / vec3(255.0f));
     As_rgba.rgb -= alpha_compensate;
-#elif PS_CLR_HW == 2
+#elif PS_CLR_HW == 2 || PS_CLR_HW == 4
     // Compensate slightly for Cd*(As + 1) - Cs*As.
     // The initial factor we chose is 1 (0.00392)
     // as that is the minimum color Cd can be,
@@ -794,7 +794,7 @@ float As = As_rgba.a;
     // blended value it can be.
     float color_compensate = 1.0f * (C + 1.0f);
     Color.rgb -= vec3(color_compensate);
-#elif PS_CLR_HW == 3
+#elif PS_CLR_HW == 3 || PS_CLR_HW == 5
     // As, Ad or Af clamped.
     As_rgba.rgb = vec3(C_clamped);
     // Cs*(Alpha + 1) might overflow, if it does then adjust alpha value

--- a/bin/resources/shaders/vulkan/tfx.glsl
+++ b/bin/resources/shaders/vulkan/tfx.glsl
@@ -1105,7 +1105,7 @@ void ps_blend(inout vec4 Color, inout vec4 As_rgba)
 			// changed alpha should only be done for hw blend.
 			vec3 alpha_compensate = max(vec3(1.0f), Color.rgb / vec3(255.0f));
 			As_rgba.rgb -= alpha_compensate;
-		#elif PS_CLR_HW == 2
+		#elif PS_CLR_HW == 2 || PS_CLR_HW == 4
 			// Compensate slightly for Cd*(As + 1) - Cs*As.
 			// The initial factor we chose is 1 (0.00392)
 			// as that is the minimum color Cd can be,
@@ -1113,7 +1113,7 @@ void ps_blend(inout vec4 Color, inout vec4 As_rgba)
 			// blended value it can be.
 			float color_compensate = 1.0f * (C + 1.0f);
 			Color.rgb -= vec3(color_compensate);
-		#elif PS_CLR_HW == 3
+		#elif PS_CLR_HW == 3 || PS_CLR_HW == 5
 			// As, Ad or Af clamped.
 			As_rgba.rgb = vec3(C_clamped);
 			// Cs*(Alpha + 1) might overflow, if it does then adjust alpha value

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -3134,7 +3134,7 @@ void GSRendererHW::EmulateBlending(bool& DATE_PRIMID, bool& DATE_BARRIER, bool& 
 				{
 					// Compensate slightly for Cd*(As + 1) - Cs*As.
 					// Try to compensate a bit with subtracting 1 (0.00392) * (Alpha + 1) from Cs.
-					m_conf.ps.clr_hw = 2;
+					m_conf.ps.clr_hw = blend_ad_alpha_masked ? 4 : 2;
 				}
 
 				m_conf.ps.blend_a = 0;
@@ -3146,7 +3146,7 @@ void GSRendererHW::EmulateBlending(bool& DATE_PRIMID, bool& DATE_BARRIER, bool& 
 				// Allow to compensate when Cs*(Alpha + 1) overflows, to compensate we change
 				// the alpha output value for Cd*Alpha.
 				m_conf.blend = {true, GSDevice::CONST_ONE, GSDevice::SRC1_COLOR, blend.op, false, 0};
-				m_conf.ps.clr_hw = 3;
+				m_conf.ps.clr_hw = blend_ad_alpha_masked ? 5 : 3;
 				m_conf.ps.no_color1 = false;
 
 				m_conf.ps.blend_a = 0;
@@ -3165,7 +3165,9 @@ void GSRendererHW::EmulateBlending(bool& DATE_PRIMID, bool& DATE_BARRIER, bool& 
 			{
 				m_conf.require_one_barrier |= true;
 				// Swap Ad with As for hw blend
-				m_conf.ps.clr_hw = 6;
+				// Check if blend mix 1 or 2 already enabled clr
+				if (m_conf.ps.clr_hw == 0)
+					m_conf.ps.clr_hw = 6;
 			}
 		}
 		else

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -3198,33 +3198,21 @@ void GSRendererHW::EmulateBlending(bool& DATE_PRIMID, bool& DATE_BARRIER, bool& 
 		if (blend_flag & BLEND_C_CLR1)
 		{
 			if (blend_ad_alpha_masked)
-			{
-				m_conf.ps.blend_c = 1;
 				m_conf.ps.clr_hw = 5;
-				m_conf.require_one_barrier |= true;
-			}
 			else
-			{
 				m_conf.ps.clr_hw = 1;
-			}
 		}
-		else if (blend_flag & (BLEND_C_CLR2_AF | BLEND_C_CLR2_AS))
+		else if (blend_flag & (BLEND_C_CLR2_AS | BLEND_C_CLR2_AF))
 		{
 			if (blend_ad_alpha_masked)
 			{
-				m_conf.ps.blend_c = 1;
 				m_conf.ps.clr_hw = 4;
-				m_conf.require_one_barrier |= true;
 			}
-			else if (m_conf.ps.blend_c == 2)
+			else
 			{
-				m_conf.ps.blend_c = 2;
-				m_conf.cb_ps.TA_MaxDepth_Af.a = static_cast<float>(AFIX) / 128.0f;
-				m_conf.ps.clr_hw = 2;
-			}
-			else // m_conf.ps.blend_c == 0
-			{
-				m_conf.ps.blend_c = 0;
+				if (m_conf.ps.blend_c == 2)
+					m_conf.cb_ps.TA_MaxDepth_Af.a = static_cast<float>(AFIX) / 128.0f;
+
 				m_conf.ps.clr_hw = 2;
 			}
 		}
@@ -3234,10 +3222,11 @@ void GSRendererHW::EmulateBlending(bool& DATE_PRIMID, bool& DATE_BARRIER, bool& 
 		}
 		else if (blend_ad_alpha_masked)
 		{
-			m_conf.ps.blend_c = 1;
 			m_conf.ps.clr_hw = 6;
-			m_conf.require_one_barrier |= true;
 		}
+
+		m_conf.require_one_barrier |= blend_ad_alpha_masked;
+
 		const HWBlend blend(GSDevice::GetBlend(blend_index, replace_dual_src));
 		m_conf.blend = {true, blend.src, blend.dst, blend.op, m_conf.ps.blend_c == 2, AFIX};
 

--- a/pcsx2/GS/Renderers/Metal/tfx.metal
+++ b/pcsx2/GS/Renderers/Metal/tfx.metal
@@ -891,7 +891,7 @@ struct PSMain
 				float3 alpha_compensate = max(float3(1.f), Color.rgb / float3(255.f));
 				As_rgba.rgb -= alpha_compensate;
 			}
-			else if (PS_CLR_HW == 2)
+			else if (PS_CLR_HW == 2 || PS_CLR_HW == 4)
 			{
 				// Compensate slightly for Cd*(As + 1) - Cs*As.
 				// The initial factor we chose is 1 (0.00392)
@@ -901,7 +901,7 @@ struct PSMain
 				float color_compensate = 1.f * (C + 1.f);
 				Color.rgb -= float3(color_compensate);
 			}
-			else if (PS_CLR_HW == 3)
+			else if (PS_CLR_HW == 3 || PS_CLR_HW == 5)
 			{
 				// As, Ad or Af clamped.
 				As_rgba.rgb = float3(C_clamped);

--- a/pcsx2/ShaderCacheVersion.h
+++ b/pcsx2/ShaderCacheVersion.h
@@ -15,4 +15,4 @@
 
 /// Version number for GS and other shaders. Increment whenever any of the contents of the
 /// shaders change, to invalidate the cache.
-static constexpr u32 SHADER_CACHE_VERSION = 18;
+static constexpr u32 SHADER_CACHE_VERSION = 19;


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS-hw: Support Ad masked alpha on blend mix 1 and 2 clr cases.

GS-hw: Cleanup hw blend clr cases.
Cleanup redundant Blend C sets, they are already set properly beforehand.
Cleanup multiple barrier sets for Ad cases, set one at the end instead.
Cleanup conditions, reduce and cleanup the code.
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Cleanup, possible regression fix for blend mix 2.
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Dump runner doesn't show any changes (maybe Blockus_depth2, Burnout Revenge - impact screen as they showed up in the compare but didn't spot any diff) for blend mix 1 and 2 cases, maybe there's a game out there that uses it?