### PR TITLE
GameDatabase: Fix recommended blending message

### DIFF
--- a/pcsx2/GameDatabase.cpp
+++ b/pcsx2/GameDatabase.cpp
@@ -851,14 +851,14 @@ u32 GameDatabaseSchema::GameEntry::applyGSHardwareFixes(Pcsx2Config::GSOptions& 
 
 			case GSHWFixId::RecommendedBlendingLevel:
 			{
-				if (value >= 0 && value <= static_cast<int>(AccBlendLevel::Maximum) && static_cast<int>(GSConfig.AccurateBlendingUnit) < value)
+				if (value >= 0 && value <= static_cast<int>(AccBlendLevel::Maximum) && static_cast<int>(EmuConfig.GS.AccurateBlendingUnit) < value)
 				{
 					Host::AddKeyedOSDMessage("HWBlendingWarning",
 						fmt::format(ICON_FA_PAINT_BRUSH " Current Blending Accuracy is {}.\n"
 														"Recommended Blending Accuracy for this game is {}.\n"
 														"You can adjust the blending level in Game Properties to improve\n"
 														"graphical quality, but this will increase system requirements.",
-							Pcsx2Config::GSOptions::BlendingLevelNames[static_cast<int>(GSConfig.AccurateBlendingUnit)],
+							Pcsx2Config::GSOptions::BlendingLevelNames[static_cast<int>(EmuConfig.GS.AccurateBlendingUnit)],
 							Pcsx2Config::GSOptions::BlendingLevelNames[value]),
 						Host::OSD_WARNING_DURATION);
 				}


### PR DESCRIPTION
### Description of Changes

It was reading from the GS thread copy instead of the CPU thread config.

### Rationale behind Changes

> it's reading from the gs thread
> so, when you changed it to e.g. high, recommended = high, it still read the old value (e.g. medium), and displayed the warning

### Suggested Testing Steps

Test a game with recommended blending (e.g. Burnout 3).
