### PR TITLE
GS-Config: Remove remnants of the WrapMem setting.

### DIFF
--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -666,7 +666,6 @@ struct Pcsx2Config
 					GPUPaletteConversion : 1,
 					AutoFlushSW : 1,
 					PreloadFrameWithGSData : 1,
-					WrapGSMem : 1,
 					Mipmap : 1,
 					ManualUserHacks : 1,
 					UserHacks_AlignSpriteX : 1,

--- a/pcsx2/Docs/gamedb-schema.json
+++ b/pcsx2/Docs/gamedb-schema.json
@@ -136,11 +136,6 @@
               "minimum": 0,
               "maximum": 1
             },
-            "wrapGSMem": {
-              "type": "integer",
-              "minimum": 0,
-              "maximum": 1
-            },
             "preloadFrameData": {
               "type": "integer",
               "minimum": 0,

--- a/pcsx2/Frontend/ImGuiOverlays.cpp
+++ b/pcsx2/Frontend/ImGuiOverlays.cpp
@@ -431,8 +431,6 @@ void ImGuiManager::DrawSettingsOverlay()
 			APPEND("TPV ");
 		if (GSConfig.UserHacks_DisableSafeFeatures)
 			APPEND("DSF ");
-		if (GSConfig.WrapGSMem)
-			APPEND("WGSM ");
 		if (GSConfig.PreloadFrameWithGSData)
 			APPEND("PLFD ");
 	}

--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -756,7 +756,6 @@ void GSUpdateConfig(const Pcsx2Config::GSOptions& new_config)
 		GSConfig.TriFilter != old_config.TriFilter ||
 		GSConfig.GPUPaletteConversion != old_config.GPUPaletteConversion ||
 		GSConfig.PreloadFrameWithGSData != old_config.PreloadFrameWithGSData ||
-		GSConfig.WrapGSMem != old_config.WrapGSMem ||
 		GSConfig.UserHacks_CPUFBConversion != old_config.UserHacks_CPUFBConversion ||
 		GSConfig.UserHacks_DisableDepthSupport != old_config.UserHacks_DisableDepthSupport ||
 		GSConfig.UserHacks_DisablePartialInvalidation != old_config.UserHacks_DisablePartialInvalidation ||

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -3369,23 +3369,18 @@ void GSTextureCache::Source::Update(const GSVector4i& rect, int level)
 			for (int x = r.left; x < r.right; bn.nextBlockX(), x += bs.x)
 			{
 				const int i = (bn.blkY() << 7) + bn.blkX();
-				const u32 block = bn.valueNoWrap();
+				const u32 addr = i % MAX_BLOCKS;
 
-				if (block < MAX_BLOCKS || GSConfig.WrapGSMem)
+				const u32 row = addr >> 5u;
+				const u32 col = 1 << (addr & 31u);
+
+				if ((m_valid[row] & col) == 0)
 				{
-					const u32 addr = i % MAX_BLOCKS;
+					m_valid[row] |= col;
 
-					const u32 row = addr >> 5u;
-					const u32 col = 1 << (addr & 31u);
+					Write(GSVector4i(x, y, x + bs.x, y + bs.y), level);
 
-					if ((m_valid[row] & col) == 0)
-					{
-						m_valid[row] |= col;
-
-						Write(GSVector4i(x, y, x + bs.x, y + bs.y), level);
-
-						blocks++;
-					}
+					blocks++;
 				}
 			}
 		}
@@ -3396,23 +3391,17 @@ void GSTextureCache::Source::Update(const GSVector4i& rect, int level)
 		{
 			for (int x = r.left; x < r.right; x += bs.x, bn.nextBlockX())
 			{
-				u32 block = bn.valueNoWrap();
+				const u32 block = bn.value();
+				const u32 row = block >> 5u;
+				const u32 col = 1 << (block & 31u);
 
-				if (block < MAX_BLOCKS || GSConfig.WrapGSMem)
+				if ((m_valid[row] & col) == 0)
 				{
-					block %= MAX_BLOCKS;
+					m_valid[row] |= col;
 
-					const u32 row = block >> 5u;
-					const u32 col = 1 << (block & 31u);
+					Write(GSVector4i(x, y, x + bs.x, y + bs.y), level);
 
-					if ((m_valid[row] & col) == 0)
-					{
-						m_valid[row] |= col;
-
-						Write(GSVector4i(x, y, x + bs.x, y + bs.y), level);
-
-						blocks++;
-					}
+					blocks++;
 				}
 			}
 		}

--- a/pcsx2/GameDatabase.cpp
+++ b/pcsx2/GameDatabase.cpp
@@ -345,7 +345,6 @@ static const char* s_gs_hw_fix_names[] = {
 	"cpuFramebufferConversion",
 	"readTCOnClose",
 	"disableDepthSupport",
-	"wrapGSMem",
 	"preloadFrameData",
 	"disablePartialInvalidation",
 	"partialTargetInvalidation",
@@ -568,9 +567,6 @@ bool GameDatabaseSchema::GameEntry::configMatchesHWFix(const Pcsx2Config::GSOpti
 		case GSHWFixId::DisableDepthSupport:
 			return (static_cast<int>(config.UserHacks_DisableDepthSupport) == value);
 
-		case GSHWFixId::WrapGSMem:
-			return (static_cast<int>(config.WrapGSMem) == value);
-
 		case GSHWFixId::PreloadFrameData:
 			return (static_cast<int>(config.PreloadFrameWithGSData) == value);
 
@@ -698,10 +694,6 @@ u32 GameDatabaseSchema::GameEntry::applyGSHardwareFixes(Pcsx2Config::GSOptions& 
 
 			case GSHWFixId::DisableDepthSupport:
 				config.UserHacks_DisableDepthSupport = (value > 0);
-				break;
-
-			case GSHWFixId::WrapGSMem:
-				config.WrapGSMem = (value > 0);
 				break;
 
 			case GSHWFixId::PreloadFrameData:

--- a/pcsx2/GameDatabase.h
+++ b/pcsx2/GameDatabase.h
@@ -64,7 +64,6 @@ namespace GameDatabaseSchema
 		CPUFramebufferConversion,
 		FlushTCOnClose,
 		DisableDepthSupport,
-		WrapGSMem,
 		PreloadFrameData,
 		DisablePartialInvalidation,
 		TargetPartialInvalidation,

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -431,7 +431,6 @@ Pcsx2Config::GSOptions::GSOptions()
 	GPUPaletteConversion = false;
 	AutoFlushSW = true;
 	PreloadFrameWithGSData = false;
-	WrapGSMem = false;
 	Mipmap = true;
 
 	ManualUserHacks = false;
@@ -780,7 +779,6 @@ void Pcsx2Config::GSOptions::MaskUserHacks()
 	UserHacks_RoundSprite = 0;
 	UserHacks_AutoFlush = false;
 	PreloadFrameWithGSData = false;
-	WrapGSMem = false;
 	UserHacks_DisablePartialInvalidation = false;
 	UserHacks_DisableDepthSupport = false;
 	UserHacks_CPUFBConversion = false;


### PR DESCRIPTION
### Description of Changes
Removes the last parts of WrapGSMem left.

### Rationale behind Changes
It's not an option anymore and we haven't needed it, behaviour is permanently on.

### Suggested Testing Steps
Give it a cursory check, especially on games which used to need WrapGSMem (if you know them), as behaviour may have changed here, not 100% sure on the effect.
