### PR TITLE
GameDB: Add Mipmap and Trilinear to Tony Hawk's Underground 2

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -15383,6 +15383,9 @@ SLES-52621:
   region: "PAL-E"
   roundModes:
     vu1RoundMode: 0 # Crashes without.
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-52622:
   name: "Tony Hawk's Underground 2"
   region: "PAL-M4"
@@ -45665,6 +45668,9 @@ SLUS-20965:
   compat: 5
   roundModes:
     vu1RoundMode: 0 # Crashes without.
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-20966:
   name: "State of Emergency 2"
   region: "NTSC-U"


### PR DESCRIPTION

### Rationale behind Changes
It fixes this chain gate thingy on the left side. I really am oblivious as to what I should be calling it.
[Tony Hawk's Underground 2.zip](https://github.com/PCSX2/pcsx2/files/10949394/Tony.Hawk.s.Underground.2.zip)


### Suggested Testing Steps
Nothing. These 2 fixes are always safe to add.
