### PR TITLE
GS: Rename bad_shader files to pcsx2_bad_shader for linux clarity

### DIFF
--- a/common/D3D11/ShaderCompiler.cpp
+++ b/common/D3D11/ShaderCompiler.cpp
@@ -79,7 +79,7 @@ wil::com_ptr_nothrow<ID3DBlob> D3D11::ShaderCompiler::CompileShader(Type type, D
 	{
 		Console.WriteLn("Failed to compile '%s':\n%s", target, error_string.c_str());
 
-		std::ofstream ofs(StringUtil::StdStringFromFormat("bad_shader_%u.txt", s_next_bad_shader_id++).c_str(),
+		std::ofstream ofs(StringUtil::StdStringFromFormat("pcsx2_bad_shader_%u.txt", s_next_bad_shader_id++).c_str(),
 			std::ofstream::out | std::ofstream::binary);
 		if (ofs.is_open())
 		{

--- a/common/GL/Program.cpp
+++ b/common/GL/Program.cpp
@@ -77,7 +77,7 @@ namespace GL
 			{
 				Console.Error("Shader failed to compile:\n%s", info_log.c_str());
 
-				std::ofstream ofs(StringUtil::StdStringFromFormat("bad_shader_%u.txt", s_next_bad_shader_id++).c_str(),
+				std::ofstream ofs(StringUtil::StdStringFromFormat("pcsx2_bad_shader_%u.txt", s_next_bad_shader_id++).c_str(),
 					std::ofstream::out | std::ofstream::binary);
 				if (ofs.is_open())
 				{

--- a/common/Vulkan/ShaderCompiler.cpp
+++ b/common/Vulkan/ShaderCompiler.cpp
@@ -55,7 +55,7 @@ namespace Vulkan::ShaderCompiler
 		shader->setStringsWithLengths(&pass_source_code, &pass_source_code_length, 1);
 
 		auto DumpBadShader = [&](const char* msg) {
-			std::string filename = StringUtil::StdStringFromFormat("bad_shader_%u.txt", s_next_bad_shader_id++);
+			std::string filename = StringUtil::StdStringFromFormat("pcsx2_bad_shader_%u.txt", s_next_bad_shader_id++);
 			Console.Error("CompileShaderToSPV: %s, writing to %s", msg, filename.c_str());
 
 			std::ofstream ofs(filename.c_str(), std::ofstream::out | std::ofstream::binary);


### PR DESCRIPTION
### Description of Changes
renames bad shader files so it's more obvious on linux where they came from.

### Rationale behind Changes
seeing "bad_shader" files in your home directory isn't clear what it's from.

### Suggested Testing Steps
No real need, just a filename change.
