### PR TITLE
Qt: Hide manual hardware fixes from global settings

### DIFF
--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -80,6 +80,15 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsDialog* dialog, QWidget* 
 
 	m_ui.setupUi(this);
 
+#ifndef PCSX2_DEVBUILD
+	if (!m_dialog->isPerGameSettings())
+	{
+		// We removed hardware fixes from global settings, but people in the past did set this stuff globally.
+		// So, just reset it all. We can remove this code at some point in the future.
+		resetManualHardwareFixes();
+	}
+#endif
+
 	//////////////////////////////////////////////////////////////////////////
 	// Global Settings
 	//////////////////////////////////////////////////////////////////////////
@@ -167,10 +176,7 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsDialog* dialog, QWidget* 
 	SettingWidgetBinder::BindWidgetToIntSetting(
 		sif, m_ui.mipmapping, "EmuCore/GS", "mipmap_hw", static_cast<int>(HWMipmapLevel::Automatic), -1);
 	SettingWidgetBinder::BindWidgetToIntSetting(
-		sif, m_ui.crcFixLevel, "EmuCore/GS", "crc_hack_level", static_cast<int>(CRCHackLevel::Automatic), -1);
-	SettingWidgetBinder::BindWidgetToIntSetting(
 		sif, m_ui.blending, "EmuCore/GS", "accurate_blending_unit", static_cast<int>(AccBlendLevel::Basic));
-	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.gpuPaletteConversion, "EmuCore/GS", "paltex", false);
 	SettingWidgetBinder::BindWidgetToIntSetting(
 		sif, m_ui.texturePreloading, "EmuCore/GS", "texture_preloading", static_cast<int>(TexturePreloadingLevel::Off));
 
@@ -187,6 +193,7 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsDialog* dialog, QWidget* 
 	//////////////////////////////////////////////////////////////////////////
 	// HW Renderer Fixes
 	//////////////////////////////////////////////////////////////////////////
+	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.crcFixLevel, "EmuCore/GS", "crc_hack_level", static_cast<int>(CRCHackLevel::Automatic), -1);
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.halfScreenFix, "EmuCore/GS", "UserHacks_Half_Bottom_Override", -1, -1);
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.cpuSpriteRenderBW, "EmuCore/GS", "UserHacks_CPUSpriteRenderBW", 0);
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.cpuCLUTRender, "EmuCore/GS", "UserHacks_CPUCLUTRender", 0);
@@ -205,6 +212,7 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsDialog* dialog, QWidget* 
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.readTCOnClose, "EmuCore/GS", "UserHacks_ReadTCOnClose", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.targetPartialInvalidation, "EmuCore/GS", "UserHacks_TargetPartialInvalidation", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.estimateTextureRegion, "EmuCore/GS", "UserHacks_EstimateTextureRegion", false);
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.gpuPaletteConversion, "EmuCore/GS", "paltex", false);
 
 	//////////////////////////////////////////////////////////////////////////
 	// HW Upscaling Fixes
@@ -296,13 +304,11 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsDialog* dialog, QWidget* 
 		m_ui.advancedOptionsFormLayout->removeRow(0);
 		m_ui.gsDownloadMode = nullptr;
 
-		// Remove texture offset and skipdraw range for global settings.
-		m_ui.upscalingFixesLayout->removeRow(2);
-		m_ui.hardwareFixesLayout->removeRow(5);
-		m_ui.skipDrawStart = nullptr;
-		m_ui.skipDrawEnd = nullptr;
-		m_ui.textureOffsetX = nullptr;
-		m_ui.textureOffsetY = nullptr;
+		// Don't allow setting hardware fixes globally.
+		// Too many stupid youtube "best settings" guides, that break other games.
+		m_ui.hardwareRenderingOptionsLayout->removeWidget(m_ui.enableHWFixes);
+		delete m_ui.enableHWFixes;
+		m_ui.enableHWFixes = nullptr;
 	}
 #endif
 
@@ -1018,4 +1024,59 @@ void GraphicsSettingsWidget::updateRendererDependentOptions()
 				m_ui.fullscreenModes->setCurrentIndex(m_ui.fullscreenModes->count() - 1);
 		}
 	}
+}
+
+void GraphicsSettingsWidget::resetManualHardwareFixes()
+{
+	bool changed = false;
+	{
+		auto lock = Host::GetSettingsLock();
+		SettingsInterface* const si = Host::Internal::GetBaseSettingsLayer();
+
+		auto check_bool = [&](const char* section, const char* key, bool expected) {
+			if (si->GetBoolValue(section, key, expected) != expected)
+			{
+				si->SetBoolValue(section, key, expected);
+				changed = true;
+			}
+		};
+		auto check_int = [&](const char* section, const char* key, s32 expected) {
+			if (si->GetIntValue(section, key, expected) != expected)
+			{
+				si->SetIntValue(section, key, expected);
+				changed = true;
+			}
+		};
+
+		check_bool("EmuCore/GS", "UserHacks", false);
+
+		check_int("EmuCore/GS", "crc_hack_level", static_cast<int>(CRCHackLevel::Automatic));
+		check_int("EmuCore/GS", "UserHacks_Half_Bottom_Override", -1);
+		check_int("EmuCore/GS", "UserHacks_CPUSpriteRenderBW", 0);
+		check_int("EmuCore/GS", "UserHacks_CPUCLUTRender", 0);
+		check_int("EmuCore/GS", "UserHacks_GPUTargetCLUTMode", 0);
+		check_int("EmuCore/GS", "UserHacks_SkipDraw_Start", 0);
+		check_int("EmuCore/GS", "UserHacks_SkipDraw_End", 0);
+		check_bool("EmuCore/GS", "UserHacks_AutoFlush", false);
+		check_bool("EmuCore/GS", "UserHacks_CPU_FB_Conversion", false);
+		check_bool("EmuCore/GS", "UserHacks_DisableDepthSupport", false);
+		check_bool("EmuCore/GS", "UserHacks_Disable_Safe_Features", false);
+		check_bool("EmuCore/GS", "preload_frame_with_gs_data", false);
+		check_bool("EmuCore/GS", "UserHacks_DisablePartialInvalidation", false);
+		check_int("EmuCore/GS", "UserHacks_TextureInsideRt", static_cast<int>(GSTextureInRtMode::Disabled));
+		check_bool("EmuCore/GS", "UserHacks_ReadTCOnClose", false);
+		check_bool("EmuCore/GS", "UserHacks_TargetPartialInvalidation", false);
+		check_bool("EmuCore/GS", "UserHacks_EstimateTextureRegion", false);
+		check_bool("EmuCore/GS", "paltex", false);
+		check_int("EmuCore/GS", "UserHacks_HalfPixelOffset", 0);
+		check_int("EmuCore/GS", "UserHacks_round_sprite_offset", 0);
+		check_int("EmuCore/GS", "UserHacks_TCOffsetX", 0);
+		check_int("EmuCore/GS", "UserHacks_TCOffsetY", 0);
+		check_bool("EmuCore/GS", "UserHacks_align_sprite_X", false);
+		check_bool("EmuCore/GS", "UserHacks_merge_pp_sprite", false);
+		check_bool("EmuCore/GS", "UserHacks_WildHack", false);
+	}
+
+	if (changed)
+		Host::CommitBaseSettingChanges();
 }

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.h
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.h
@@ -54,6 +54,7 @@ private Q_SLOTS:
 private:
 	GSRendererType getEffectiveRenderer() const;
 	void updateRendererDependentOptions();
+	void resetManualHardwareFixes();
 
 	SettingsDialog* m_dialog;
 

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
@@ -710,27 +710,20 @@
        <item row="9" column="0" colspan="2">
         <layout class="QGridLayout" name="basicCheckboxGridLayout">
          <item row="0" column="0">
-          <widget class="QCheckBox" name="gpuPaletteConversion">
-           <property name="text">
-            <string>GPU Palette Conversion</string>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="1">
-          <widget class="QCheckBox" name="enableHWFixes">
-           <property name="text">
-            <string>Manual Hardware Renderer Fixes</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="0">
           <widget class="QCheckBox" name="spinGPUDuringReadbacks">
            <property name="text">
             <string>Spin GPU During Readbacks</string>
            </property>
           </widget>
          </item>
-         <item row="1" column="1">
+         <item row="1" column="0">
+          <widget class="QCheckBox" name="enableHWFixes">
+           <property name="text">
+            <string>Manual Hardware Renderer Fixes</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
           <widget class="QCheckBox" name="spinCPUDuringReadbacks">
            <property name="text">
             <string>Spin CPU During Readbacks</string>
@@ -1065,6 +1058,13 @@
           <widget class="QCheckBox" name="estimateTextureRegion">
            <property name="text">
             <string>Estimate Texture Region</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="1">
+          <widget class="QCheckBox" name="gpuPaletteConversion">
+           <property name="text">
+            <string>GPU Palette Conversion</string>
            </property>
           </widget>
          </item>

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
@@ -600,54 +600,13 @@
         </widget>
        </item>
        <item row="6" column="0">
-        <widget class="QLabel" name="label_7">
-         <property name="text">
-          <string>CRC Fix Level:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="6" column="1">
-        <widget class="QComboBox" name="crcFixLevel">
-         <item>
-          <property name="text">
-           <string>Automatic (Default)</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>None (Debug)</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Minimum (Debug)</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Partial (OpenGL)</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Full (Direct3D)</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Aggressive</string>
-          </property>
-         </item>
-        </widget>
-       </item>
-       <item row="7" column="0">
         <widget class="QLabel" name="label_8">
          <property name="text">
           <string>Blending Accuracy:</string>
          </property>
         </widget>
        </item>
-       <item row="7" column="1">
+       <item row="6" column="1">
         <widget class="QComboBox" name="blending">
          <item>
           <property name="text">
@@ -681,14 +640,14 @@
          </item>
         </widget>
        </item>
-       <item row="8" column="0">
+       <item row="7" column="0">
         <widget class="QLabel" name="label_20">
          <property name="text">
           <string>Texture Preloading:</string>
          </property>
         </widget>
        </item>
-       <item row="8" column="1">
+       <item row="7" column="1">
         <widget class="QComboBox" name="texturePreloading">
          <item>
           <property name="text">
@@ -707,7 +666,7 @@
          </item>
         </widget>
        </item>
-       <item row="9" column="0" colspan="2">
+       <item row="8" column="0" colspan="2">
         <layout class="QGridLayout" name="basicCheckboxGridLayout">
          <item row="0" column="0">
           <widget class="QCheckBox" name="spinGPUDuringReadbacks">
@@ -821,14 +780,14 @@
        <string>Hardware Fixes</string>
       </attribute>
       <layout class="QFormLayout" name="hardwareFixesLayout">
-       <item row="0" column="0">
+       <item row="1" column="0">
         <widget class="QLabel" name="label_10">
          <property name="text">
           <string>Half Screen Fix:</string>
          </property>
         </widget>
        </item>
-       <item row="0" column="1">
+       <item row="1" column="1">
         <widget class="QComboBox" name="halfScreenFix">
          <item>
           <property name="text">
@@ -847,14 +806,14 @@
          </item>
         </widget>
        </item>
-       <item row="1" column="0">
+       <item row="2" column="0">
         <widget class="QLabel" name="label_36">
          <property name="text">
           <string>CPU Sprite Render Size:</string>
          </property>
         </widget>
        </item>
-       <item row="1" column="1">
+       <item row="2" column="1">
         <widget class="QComboBox" name="cpuSpriteRenderBW">
          <item>
           <property name="text">
@@ -913,14 +872,14 @@
          </item>
         </widget>
        </item>
-       <item row="2" column="0">
+       <item row="3" column="0">
         <widget class="QLabel" name="label_16">
          <property name="text">
           <string>Software CLUT Render:</string>
          </property>
         </widget>
        </item>
-       <item row="2" column="1">
+       <item row="3" column="1">
         <widget class="QComboBox" name="cpuCLUTRender">
          <property name="currentText">
           <string extracomment="0 (Disabled)">0 (Disabled)</string>
@@ -945,14 +904,14 @@
          </item>
         </widget>
        </item>
-       <item row="3" column="0">
+       <item row="4" column="0">
         <widget class="QLabel" name="label_47">
          <property name="text">
           <string>GPU Target CLUT:</string>
          </property>
         </widget>
        </item>
-       <item row="3" column="1">
+       <item row="4" column="1">
         <widget class="QComboBox" name="gpuTargetCLUTMode">
          <item>
           <property name="text">
@@ -972,13 +931,39 @@
         </widget>
        </item>
        <item row="5" column="0">
+        <widget class="QLabel" name="label_45">
+         <property name="text">
+          <string>Texture Inside RT:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="1">
+        <widget class="QComboBox" name="textureInsideRt">
+         <item>
+          <property name="text">
+           <string>Disabled (Default)</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Inside Target</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Merge Targets</string>
+          </property>
+         </item>
+        </widget>
+       </item>
+       <item row="6" column="0">
         <widget class="QLabel" name="label_12">
          <property name="text">
           <string>Skipdraw Range:</string>
          </property>
         </widget>
        </item>
-       <item row="5" column="1">
+       <item row="6" column="1">
         <layout class="QHBoxLayout" name="horizontalLayout">
          <item>
           <widget class="QSpinBox" name="skipDrawStart">
@@ -996,7 +981,7 @@
          </item>
         </layout>
        </item>
-       <item row="6" column="0" colspan="2">
+       <item row="7" column="0" colspan="2">
         <layout class="QGridLayout" name="gridLayout">
          <item row="0" column="0">
           <widget class="QCheckBox" name="hwAutoFlush">
@@ -1070,28 +1055,43 @@
          </item>
         </layout>
        </item>
-       <item row="4" column="0">
-        <widget class="QLabel" name="label_45">
+       <item row="0" column="0">
+        <widget class="QLabel" name="label_7">
          <property name="text">
-          <string>Texture Inside RT:</string>
+          <string>CRC Fix Level:</string>
          </property>
         </widget>
        </item>
-       <item row="4" column="1">
-        <widget class="QComboBox" name="textureInsideRt">
+       <item row="0" column="1">
+        <widget class="QComboBox" name="crcFixLevel">
          <item>
           <property name="text">
-           <string>Disabled (Default)</string>
+           <string>Automatic (Default)</string>
           </property>
          </item>
          <item>
           <property name="text">
-           <string>Inside Target</string>
+           <string>None (Debug)</string>
           </property>
          </item>
          <item>
           <property name="text">
-           <string>Merge Targets</string>
+           <string>Minimum (Debug)</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Partial (OpenGL)</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Full (Direct3D)</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Aggressive</string>
           </property>
          </item>
         </widget>

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
@@ -667,7 +667,7 @@
         </widget>
        </item>
        <item row="8" column="0" colspan="2">
-        <layout class="QGridLayout" name="basicCheckboxGridLayout">
+        <layout class="QGridLayout" name="hardwareRenderingOptionsLayout">
          <item row="0" column="0">
           <widget class="QCheckBox" name="spinGPUDuringReadbacks">
            <property name="text">


### PR DESCRIPTION
### Description of Changes

Moves paltex and crc hacks into the hardware fixes section, and then removes the manual hardware fixes override from global settings completely.

Anyone who had global settings for hardware fixes will have those settings cleared/reset, so to not conflict when creating per-game configuration.

Option is still available globally in devbuilds.

### Rationale behind Changes

Too many moronic youtubers and their stupid settings guides making people break other games.

### Suggested Testing Steps

Make sure manual hw fixes still works per-game, and that it's gone from global settings.

I've verified the clear logic works as expected.
