### PR TITLE
CI:macOS: Use xz for distribution

### DIFF
--- a/.github/workflows/macos_build.yml
+++ b/.github/workflows/macos_build.yml
@@ -144,12 +144,12 @@ jobs:
             APPNAME="PCSX2-$TAG"
           fi
           mv build/pcsx2*/PCSX2.app "$APPNAME.app"
-          tar cvzf "${{ steps.artifact-metadata.outputs.artifact-name }}.tar.gz" "$APPNAME.app"
+          tar --options xz:compression-level=9 -cvJf "${{ steps.artifact-metadata.outputs.artifact-name }}.tar.xz" "$APPNAME.app"
           mkdir ci-artifacts
-          cp "${{ steps.artifact-metadata.outputs.artifact-name }}.tar.gz" ci-artifacts/macOS-${{ inputs.gui }}.tar.gz
+          cp "${{ steps.artifact-metadata.outputs.artifact-name }}.tar.xz" ci-artifacts/macOS-${{ inputs.gui }}.tar.xz
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v3
         with:
           name: ${{ steps.artifact-metadata.outputs.artifact-name }}
-          path: "*.tar.gz"
+          path: "*.tar.xz"

--- a/.github/workflows/scripts/releases/rename-release-assets.py
+++ b/.github/workflows/scripts/releases/rename-release-assets.py
@@ -4,7 +4,7 @@ import shutil
 tag = os.environ['TAG'].split("refs/tags/")[1]
 scan_dir = os.environ['SCAN_DIR']
 output_dir = os.environ['OUT_DIR']
-accepted_exts = ["AppImage", "tar.gz", "7z"]
+accepted_exts = ["AppImage", "tar.xz", "7z"]
 
 
 for dir_name in os.listdir(scan_dir):


### PR DESCRIPTION
### Description of Changes
macOS 10.14 fixed a bug where Archive Utility couldn't decompress .tar.xz files, and we now use a minimum version of 10.14 so we might as well use them

### Rationale behind Changes
Save a few mb on the download

### Suggested Testing Steps
Make sure you can still unzip builds

@xTVaser there's nothing on the website side of things that would dislike this change, right?