### PR TITLE
Revert "Qt: Hide manual hardware fixes from global settings"

### DIFF
--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.h
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.h
@@ -54,7 +54,6 @@ private Q_SLOTS:
 private:
 	GSRendererType getEffectiveRenderer() const;
 	void updateRendererDependentOptions();
-	void resetManualHardwareFixes();
 
 	SettingsDialog* m_dialog;
 

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
@@ -600,13 +600,54 @@
         </widget>
        </item>
        <item row="6" column="0">
+        <widget class="QLabel" name="label_7">
+         <property name="text">
+          <string>CRC Fix Level:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="1">
+        <widget class="QComboBox" name="crcFixLevel">
+         <item>
+          <property name="text">
+           <string>Automatic (Default)</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>None (Debug)</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Minimum (Debug)</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Partial (OpenGL)</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Full (Direct3D)</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Aggressive</string>
+          </property>
+         </item>
+        </widget>
+       </item>
+       <item row="7" column="0">
         <widget class="QLabel" name="label_8">
          <property name="text">
           <string>Blending Accuracy:</string>
          </property>
         </widget>
        </item>
-       <item row="6" column="1">
+       <item row="7" column="1">
         <widget class="QComboBox" name="blending">
          <item>
           <property name="text">
@@ -640,14 +681,14 @@
          </item>
         </widget>
        </item>
-       <item row="7" column="0">
+       <item row="8" column="0">
         <widget class="QLabel" name="label_20">
          <property name="text">
           <string>Texture Preloading:</string>
          </property>
         </widget>
        </item>
-       <item row="7" column="1">
+       <item row="8" column="1">
         <widget class="QComboBox" name="texturePreloading">
          <item>
           <property name="text">
@@ -666,7 +707,7 @@
          </item>
         </widget>
        </item>
-       <item row="8" column="0" colspan="2">
+       <item row="9" column="0" colspan="2">
         <layout class="QGridLayout" name="basicCheckboxGridLayout">
          <item row="0" column="0">
           <widget class="QCheckBox" name="spinGPUDuringReadbacks">
@@ -780,14 +821,14 @@
        <string>Hardware Fixes</string>
       </attribute>
       <layout class="QFormLayout" name="hardwareFixesLayout">
-       <item row="1" column="0">
+       <item row="0" column="0">
         <widget class="QLabel" name="label_10">
          <property name="text">
           <string>Half Screen Fix:</string>
          </property>
         </widget>
        </item>
-       <item row="1" column="1">
+       <item row="0" column="1">
         <widget class="QComboBox" name="halfScreenFix">
          <item>
           <property name="text">
@@ -806,14 +847,14 @@
          </item>
         </widget>
        </item>
-       <item row="2" column="0">
+       <item row="1" column="0">
         <widget class="QLabel" name="label_36">
          <property name="text">
           <string>CPU Sprite Render Size:</string>
          </property>
         </widget>
        </item>
-       <item row="2" column="1">
+       <item row="1" column="1">
         <widget class="QComboBox" name="cpuSpriteRenderBW">
          <item>
           <property name="text">
@@ -872,14 +913,14 @@
          </item>
         </widget>
        </item>
-       <item row="3" column="0">
+       <item row="2" column="0">
         <widget class="QLabel" name="label_16">
          <property name="text">
           <string>Software CLUT Render:</string>
          </property>
         </widget>
        </item>
-       <item row="3" column="1">
+       <item row="2" column="1">
         <widget class="QComboBox" name="cpuCLUTRender">
          <property name="currentText">
           <string extracomment="0 (Disabled)">0 (Disabled)</string>
@@ -904,14 +945,14 @@
          </item>
         </widget>
        </item>
-       <item row="4" column="0">
+       <item row="3" column="0">
         <widget class="QLabel" name="label_47">
          <property name="text">
           <string>GPU Target CLUT:</string>
          </property>
         </widget>
        </item>
-       <item row="4" column="1">
+       <item row="3" column="1">
         <widget class="QComboBox" name="gpuTargetCLUTMode">
          <item>
           <property name="text">
@@ -931,39 +972,13 @@
         </widget>
        </item>
        <item row="5" column="0">
-        <widget class="QLabel" name="label_45">
-         <property name="text">
-          <string>Texture Inside RT:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="5" column="1">
-        <widget class="QComboBox" name="textureInsideRt">
-         <item>
-          <property name="text">
-           <string>Disabled (Default)</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Inside Target</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Merge Targets</string>
-          </property>
-         </item>
-        </widget>
-       </item>
-       <item row="6" column="0">
         <widget class="QLabel" name="label_12">
          <property name="text">
           <string>Skipdraw Range:</string>
          </property>
         </widget>
        </item>
-       <item row="6" column="1">
+       <item row="5" column="1">
         <layout class="QHBoxLayout" name="horizontalLayout">
          <item>
           <widget class="QSpinBox" name="skipDrawStart">
@@ -981,7 +996,7 @@
          </item>
         </layout>
        </item>
-       <item row="7" column="0" colspan="2">
+       <item row="6" column="0" colspan="2">
         <layout class="QGridLayout" name="gridLayout">
          <item row="0" column="0">
           <widget class="QCheckBox" name="hwAutoFlush">
@@ -1055,43 +1070,28 @@
          </item>
         </layout>
        </item>
-       <item row="0" column="0">
-        <widget class="QLabel" name="label_7">
+       <item row="4" column="0">
+        <widget class="QLabel" name="label_45">
          <property name="text">
-          <string>CRC Fix Level:</string>
+          <string>Texture Inside RT:</string>
          </property>
         </widget>
        </item>
-       <item row="0" column="1">
-        <widget class="QComboBox" name="crcFixLevel">
+       <item row="4" column="1">
+        <widget class="QComboBox" name="textureInsideRt">
          <item>
           <property name="text">
-           <string>Automatic (Default)</string>
+           <string>Disabled (Default)</string>
           </property>
          </item>
          <item>
           <property name="text">
-           <string>None (Debug)</string>
+           <string>Inside Target</string>
           </property>
          </item>
          <item>
           <property name="text">
-           <string>Minimum (Debug)</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Partial (OpenGL)</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Full (Direct3D)</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Aggressive</string>
+           <string>Merge Targets</string>
           </property>
          </item>
         </widget>

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
@@ -710,20 +710,27 @@
        <item row="9" column="0" colspan="2">
         <layout class="QGridLayout" name="basicCheckboxGridLayout">
          <item row="0" column="0">
-          <widget class="QCheckBox" name="spinGPUDuringReadbacks">
+          <widget class="QCheckBox" name="gpuPaletteConversion">
            <property name="text">
-            <string>Spin GPU During Readbacks</string>
+            <string>GPU Palette Conversion</string>
            </property>
           </widget>
          </item>
-         <item row="1" column="0">
+         <item row="0" column="1">
           <widget class="QCheckBox" name="enableHWFixes">
            <property name="text">
             <string>Manual Hardware Renderer Fixes</string>
            </property>
           </widget>
          </item>
-         <item row="0" column="1">
+         <item row="1" column="0">
+          <widget class="QCheckBox" name="spinGPUDuringReadbacks">
+           <property name="text">
+            <string>Spin GPU During Readbacks</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
           <widget class="QCheckBox" name="spinCPUDuringReadbacks">
            <property name="text">
             <string>Spin CPU During Readbacks</string>
@@ -1058,13 +1065,6 @@
           <widget class="QCheckBox" name="estimateTextureRegion">
            <property name="text">
             <string>Estimate Texture Region</string>
-           </property>
-          </widget>
-         </item>
-         <item row="4" column="1">
-          <widget class="QCheckBox" name="gpuPaletteConversion">
-           <property name="text">
-            <string>GPU Palette Conversion</string>
            </property>
           </widget>
          </item>

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
@@ -667,7 +667,7 @@
         </widget>
        </item>
        <item row="8" column="0" colspan="2">
-        <layout class="QGridLayout" name="hardwareRenderingOptionsLayout">
+        <layout class="QGridLayout" name="basicCheckboxGridLayout">
          <item row="0" column="0">
           <widget class="QCheckBox" name="spinGPUDuringReadbacks">
            <property name="text">


### PR DESCRIPTION
Reverts PCSX2/pcsx2#8381

Reason: We need it to debug gs dumps.