### PR TITLE
GS: Detect double width texture shuffles

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -797,8 +797,20 @@ GSVector2i GSRendererHW::GetTargetSize(const GSTextureCache::Source* tex)
 					m_context->FRAME.FBMSK && m_tc->Has32BitTarget(m_context->FRAME.Block()))));
 	if (possible_texture_shuffle)
 	{
-		GL_CACHE("Halving height due to texture shuffle, %dx%d -> %dx%d", width, min_height, width, min_height / 2);
-		min_height /= 2;
+		const u32 tex_width_pgs = (tex->m_target ? tex->m_from_target_TEX0.TBW : tex->m_TEX0.TBW);
+		const u32 half_draw_width_pgs = ((width + (frame_psm.pgs.x - 1)) / frame_psm.pgs.x) >> 1;
+
+		// Games such as Midnight Club 3 draw headlights with a texture shuffle, but instead of doubling the height, they doubled the width.
+		if (tex_width_pgs == half_draw_width_pgs)
+		{
+			GL_CACHE("Halving width due to texture shuffle with double width, %dx%d -> %dx%d", width, min_height, width / 2, min_height);
+			width /= 2;
+		}
+		else
+		{
+			GL_CACHE("Halving height due to texture shuffle, %dx%d -> %dx%d", width, min_height, width, min_height / 2);
+			min_height /= 2;
+		}
 	}
 
 	u32 height = m_tc->GetTargetHeight(m_context->FRAME.Block(), m_context->FRAME.FBW, m_context->FRAME.PSM, min_height);


### PR DESCRIPTION
### Description of Changes
Detects when games do texture shuffles with double width instead of double height (how dare you)

### Rationale behind Changes
Usually when shuffling a 32bit texture as 16bit, you would double the height as the page size is double for 16bit, however some gamedevs thought they were clever and would double it horizontally instead, this messed up our height correction/detection when a shuffle happened.

Kind of a regression from #8336 however it was never really handled properly, but hacked in until said PR.

### Suggested Testing Steps
Test Midnight Club 3, maybe a spatter of other games doing texture shuffles, just to make sure things are okay. I did a GS Dump run on my 1100 dumps, and everything else seemed to be okay.

Midnight Club 3:

Master:
![image](https://user-images.githubusercontent.com/6278726/225002386-c1ad0831-6fc3-421d-8a08-711bf5de097a.png)

PR:
![image](https://user-images.githubusercontent.com/6278726/225002419-000f2f70-03cc-4392-a671-343d00ea101d.png)

