### PR TITLE
UI: Fix masking of Target Partial Invalidation with Tex in RT

### DIFF
--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -871,8 +871,7 @@ void GraphicsSettingsWidget::onGpuPaletteConversionChanged(int state)
 
 void GraphicsSettingsWidget::onTextureInsideRtChanged()
 {
-	const bool disabled = static_cast<GSTextureInRtMode>(m_dialog->getEffectiveIntValue("EmuCore/GS", "UserHacks_TextureInsideRt",
-							  static_cast<int>(GSTextureInRtMode::Disabled))) >= GSTextureInRtMode::InsideTargets;
+	const bool disabled = static_cast<GSTextureInRtMode>(m_ui.textureInsideRt->currentIndex()) >= GSTextureInRtMode::InsideTargets;
 
 	m_ui.targetPartialInvalidation->setDisabled(disabled);
 }


### PR DESCRIPTION
### Description of Changes
Fixes the masking of the Target Partial Invalidation setting when modifying the Texture in RT dropdown value.

### Rationale behind Changes
The event was using the INI setting, which hadn't been set by this point, so the value was always behind what had just been selected, so this will use the current UI value instead of the INI value. The two aren't mutually exclusive, so it should be enabled when Tex in RT is disabled, and visa versa.

### Suggested Testing Steps
Go in to the graphics settings, enable manual hw fixes (so per game, or use a dev build) and mess with the Tex in RT dropdown.
