### PR TITLE
GameDB: Add Mipmap and Trilinear to Spyro: Enter the Dragonfly

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -11865,6 +11865,9 @@ SLES-51043:
   name: "Spyro - Enter the Dragonfly"
   region: "PAL-M6"
   compat: 5
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
   patches:
     0EF1D4BA:
       content: |-
@@ -42485,6 +42488,9 @@ SLUS-20315:
   name: "Spyro the Dragon - Enter the Dragonfly"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
   patches:
     4B8E0DE8:
       content: |-


### PR DESCRIPTION
### Description of Changes
I have added Mipmap and Trilinear for Spyro: Enter the Dragonfly

### Rationale behind Changes
The mountain's textures were looking very sharp without it.
[Spyro - Enter the Dragonfly_SLES-51043_20230315134521.gs.zip](https://github.com/PCSX2/pcsx2/files/10978796/Spyro.-.Enter.the.Dragonfly_SLES-51043_20230315134521.gs.zip)


### Suggested Testing Steps
Check the GS dump I have added, just to confirm that the game truly needs it.
