### PR TITLE
COP2: Mask R register on CFC2 reads

### DIFF
--- a/pcsx2/VU0.cpp
+++ b/pcsx2/VU0.cpp
@@ -137,12 +137,18 @@ void CFC2() {
 	}
 	if (_Rt_ == 0) return;
 
-	cpuRegs.GPR.r[_Rt_].UL[0] = VU0.VI[_Fs_].UL;
-
-	if(VU0.VI[_Fs_].UL & 0x80000000)
-		cpuRegs.GPR.r[_Rt_].UL[1] = 0xffffffff;
+	if (_Fs_ == REG_R)
+		cpuRegs.GPR.r[_Rt_].UL[0] = VU0.VI[REG_R].UL & 0x7FFFFF;
 	else
-		cpuRegs.GPR.r[_Rt_].UL[1] = 0;
+	{
+		cpuRegs.GPR.r[_Rt_].UL[0] = VU0.VI[_Fs_].UL;
+
+		if (VU0.VI[_Fs_].UL & 0x80000000)
+			cpuRegs.GPR.r[_Rt_].UL[1] = 0xffffffff;
+		else
+			cpuRegs.GPR.r[_Rt_].UL[1] = 0;
+	}
+
 }
 
 void CTC2() {

--- a/pcsx2/x86/microVU_Macro.inl
+++ b/pcsx2/x86/microVU_Macro.inl
@@ -450,6 +450,11 @@ static void recCFC2()
 			xMOVSX(xRegister64(regt), ptr32[&vu0Regs.VI[_Rd_].UL]);
 		}
 	}
+	else if (_Rd_ == REG_R)
+	{
+		xMOVSX(xRegister64(regt), ptr32[&vu0Regs.VI[REG_R].UL]);
+		xAND(xRegister64(regt), 0x7FFFFF);
+	}
 	else if (_Rd_ >= REG_STATUS_FLAG) // FixMe: Should R-Reg have upper 9 bits 0?
 	{
 		xMOVSX(xRegister64(regt), ptr32[&vu0Regs.VI[_Rd_].UL]);


### PR DESCRIPTION
### Description of Changes
Masks the value of R when reading it from VU0 on to the EE through CFC2

### Rationale behind Changes
the 0x3f800000 (1.0) we add when writing to R is implied on the register, so when reading, the top bits should be zero, this was causing bad AI behaviour in Onimusha Dawn of Dreams.

### Suggested Testing Steps
Test Onimusha Dawn of Dreams, make sure the AI is less braindead.  I guess maybe try other bad AI games, on the offchance it helps. Stuntman is unaffected.
