### PR TITLE
GameDB: SMT DS Fixes

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -20623,6 +20623,8 @@ SLES-54628:
 SLES-54629:
   name: "Shin Megami Tensei - Devil Summoner - Raidou Kuzunoha vs. the Soulless Army"
   region: "PAL-E"
+  gsHWFixes:
+    minimumBlendingLevel: 3 # Fixes broken effect rendering.
 SLES-54630:
   name: "Chi Vuol Essere Milionario - Party Edition"
   region: "PAL-I"
@@ -32376,6 +32378,8 @@ SLPM-66246:
   name: "Devil Summoner - Kuzunoha Raidou tai Chouriki Heidan"
   region: "NTSC-J"
   compat: 5
+  gsHWFixes:
+    minimumBlendingLevel: 3 # Fixes broken effect rendering.
 SLPM-66247:
   name: "Meine Liebe II - Hokori to Seigi to Ai"
   region: "NTSC-J"
@@ -33858,6 +33862,8 @@ SLPM-66633:
 SLPM-66634:
   name: "Devil Summoner - Kuzunoha Raidou tai Chouriki Heidan [Atlus Best Collection]"
   region: "NTSC-J"
+  gsHWFixes:
+    minimumBlendingLevel: 3 # Fixes broken effect rendering.
 SLPM-66635:
   name: "Wind - A Breath of Heart [Alchemist Best Collection]"
   region: "NTSC-J"
@@ -48332,6 +48338,8 @@ SLUS-21431:
   name: "Shin Megami Tensei - Devil Summoner - Raidou Kuzunoha vs. The Soulless Army"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    minimumBlendingLevel: 3 # Fixes broken effect rendering.
 SLUS-21432:
   name: "NRA Gun Club"
   region: "NTSC-U"
@@ -50844,6 +50852,8 @@ SLUS-28063:
 SLUS-28064:
   name: "Shin Megami Tensei - Devil Summoner [Trade Demo]"
   region: "NTSC-U"
+  gsHWFixes:
+    minimumBlendingLevel: 3 # Fixes broken effect rendering.
 SLUS-28065:
   name: "Odin Sphere [Trade Demo]"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
Fixes broken effects when using lower than high blending.

Master:
![Shin Megami Tensei - Devil Summoner - Raidou Kuzunoha vs  The Soulless Army_SLUS-21431_20230317001353](https://user-images.githubusercontent.com/80843560/225779860-4bf91284-2218-4d09-bed0-2fa8d200d554.png)


PR:
![Shin Megami Tensei - Devil Summoner - Raidou Kuzunoha vs  The Soulless Army_SLUS-21431_20230317001356](https://user-images.githubusercontent.com/80843560/225779873-a10d057a-cb8d-4863-9353-988982c9d649.png)

### Rationale behind Changes
Broken effects bad.

### Suggested Testing Steps
Make sure CI is happy.
