### PR TITLE
GameDB: Delete Mipmap and Add Blending Accuracy to Spyro: Enter the D…

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -11872,8 +11872,8 @@ SLES-51043:
   region: "PAL-M6"
   compat: 5
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
+    trilinearFiltering: 1 # Trilinear, improves some textures.
+    recommendedBlendingLevel: 3 # Fixes gem reflections.
   patches:
     0EF1D4BA:
       content: |-
@@ -42513,8 +42513,8 @@ SLUS-20315:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
+    trilinearFiltering: 1 # Trilinear, improves some textures.
+    recommendedBlendingLevel: 3 # Fixes gem reflections.
   patches:
     4B8E0DE8:
       content: |-


### PR DESCRIPTION
…ragonfly

### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
I got rid of the forced Mipmap and added Blending Accuracy 3 for Spyro: Enter the Dragonfly

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Mipmap imposition was removed since it downgrades the game graphics severely without adding/fixing anything, and makes everything look unnecessarily blurry. It also breaks compatibility with Texture-Packs. Added Blending Accuracy 3 to fix Gems not shining properly.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Just playing the game will show the visual improvements/corrections.