### PR TITLE
Debugger: use ulonglong for memory search + fix crash

### DIFF
--- a/pcsx2-qt/Debugger/CpuWidget.cpp
+++ b/pcsx2-qt/Debugger/CpuWidget.cpp
@@ -664,9 +664,11 @@ void CpuWidget::onSearchButtonClicked()
 
 	const QString searchValue = m_ui.txtSearchValue->text();
 
+	unsigned long long value;
+
 	if (searchType < 4)
 	{
-		searchValue.toULongLong(&ok, searchHex ? 16 : 10);
+		value = searchValue.toULongLong(&ok, searchHex ? 16 : 10);
 	}
 	else if (searchType != 6)
 	{
@@ -677,6 +679,29 @@ void CpuWidget::onSearchButtonClicked()
 	{
 		QMessageBox::critical(this, tr("Debugger"), tr("Invalid search value"));
 		return;
+	}
+
+	switch (searchType)
+	{
+		case 6:
+		case 5:
+		case 4:
+			break;
+		case 3:
+			if (value <= std::numeric_limits<unsigned long long>::max())
+				break;
+		case 2:
+			if (value <= std::numeric_limits<unsigned long>::max())
+				break;
+		case 1:
+			if (value <= std::numeric_limits<unsigned short>::max())
+				break;
+		case 0:
+			if (value <= std::numeric_limits<unsigned char>::max())
+				break;
+		default:
+			QMessageBox::critical(this, tr("Debugger"), tr("Value is larger than type"));
+			return;
 	}
 
 	QFutureWatcher<std::vector<u32>>* workerWatcher = new QFutureWatcher<std::vector<u32>>;

--- a/pcsx2-qt/Debugger/CpuWidget.cpp
+++ b/pcsx2-qt/Debugger/CpuWidget.cpp
@@ -666,7 +666,7 @@ void CpuWidget::onSearchButtonClicked()
 
 	if (searchType < 4)
 	{
-		searchValue.toLong(&ok, searchHex ? 16 : 10);
+		searchValue.toULongLong(&ok, searchHex ? 16 : 10);
 	}
 	else if (searchType != 6)
 	{


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Converts the value we're searching for to ulonglong instead of long

Fixes crash caused by searching for a value larger than the type
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Should fix #8420. Long was also not big enough to search for 64 bit values, so longlong should be used instead.
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Search for values greater than 7FFFFFFF in the debugger. It should allow you to now.

An error box should now prevent you from searching for a value higher than the type you're searching for. On master, doing this causes PCSX2 to stop responding and begin rapidly consuming memory until it presumably crashes.