### PR TITLE
GS-HW: Correct region size when source is in render target

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -2220,8 +2220,11 @@ GSTextureCache::Source* GSTextureCache::CreateSource(const GIFRegTEX0& TEX0, con
 	// clamp rectangle exceeds the TW/TH (which is now unused), we do need to use it. Timesplitters 2 does
 	// its frame blending effect using a smaller TW/TH, *and* triangles instead of sprites just to be extra
 	// annoying.
-	int tw = region.IsFixedTEX0W(1 << TEX0.TW) ? region.GetWidth() : (1 << TEX0.TW);
-	int th = region.IsFixedTEX0H(1 << TEX0.TH) ? region.GetHeight() : (1 << TEX0.TH);
+	// Be careful with offset targets as we can end up sampling the wrong part/not enough, but TW/TH can be nonsense, so we take the biggest one if there is an RT(dst).
+	// DBZ BT3 uses a region clamp offset when processing 2 player split screen and they set it 1 pixel too wide, meaning this code gets triggered.
+	// TS2 has junk small TW and TH, but the region makes more sense for the draw.
+	int tw = std::max(region.IsFixedTEX0W(1 << TEX0.TW) ? static_cast<int>(region.GetWidth()) : (1 << TEX0.TW), dst ? (1 << TEX0.TW) : 0);
+	int th = std::max(region.IsFixedTEX0H(1 << TEX0.TH) ? static_cast<int>(region.GetHeight()) : (1 << TEX0.TH), dst ? (1 << TEX0.TH) : 0);
 
 	int tlevels = 1;
 	if (lod)


### PR DESCRIPTION
### Description of Changes
Corrects the width/height of the source and copy when the source is found in a render target (previous draw).

### Rationale behind Changes
This was errantly taking a restricted region, but in DBZ BT3 it's offset, but when it's a render target, it's not really set up to handle the offset, so we just make sure we take everything we need.

### Suggested Testing Steps
Check DBZ BT3 2 player mode (already checked a GS Dump).

Master:
![image](https://user-images.githubusercontent.com/6278726/226113147-38807a03-5a67-4072-abcd-6ca8b6f50e64.png)

PR:
![image](https://user-images.githubusercontent.com/6278726/226113149-a1195e39-0bf2-458f-81dc-0bcc56f80e16.png)

