### PR TITLE
Gamepad like guncon2 and calibration hack timming correction

### DIFF
--- a/.github/workflows/linux_prueba.yml
+++ b/.github/workflows/linux_prueba.yml
@@ -1,0 +1,127 @@
+name: Linux prueba
+
+on:
+  workflow_call:
+    inputs:
+      jobName:
+        required: true
+        type: string
+      os:
+        required: false
+        type: string
+        default: ubuntu-20.04
+      platform:
+        required: false
+        type: string
+        default: x64
+      compiler:
+        required: true
+        type: string
+      cmakeflags:
+        required: true
+        type: string
+      buildAppImage:
+        required: false
+        type: boolean
+        default: false
+      detail:
+        required: false
+        type: string
+        default: ""
+      cheats_url:
+        required: false
+        type: string
+        default: https://github.com/PCSX2/pcsx2_patches/releases/latest/download
+
+jobs:
+  build_linux:
+    name: ${{ inputs.jobName }}
+    runs-on: ${{ inputs.os }}
+    # Set some sort of timeout in the event of run-away builds.  We are limited on concurrent jobs so, get rid of them.
+    timeout-minutes: 60
+    env:
+      CCACHE_BASEDIR: ${{ github.workspace }}
+      CCACHE_DIR: ${{ github.workspace }}/.ccache
+      CCACHE_COMPRESS: true
+      CCACHE_COMPRESSLEVEL: 9
+      CCACHE_MAXSIZE: 100M
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Prepare Artifact Metadata
+        id: artifact-metadata
+        shell: bash
+        env:
+          OS: linux
+          GUI_FRAMEWORK: QT
+          ARCH: ${{ inputs.platform }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_NUM: ${{ github.event.pull_request.number }}
+          PR_SHA: ${{ github.event.pull_request.head.sha }}
+        run: ./.github/workflows/scripts/common/name-artifacts.sh
+
+      # -- SETUP CCACHE - https://cristianadam.eu/20200113/speeding-up-c-plus-plus-github-actions-using-ccache/
+      - name: Prepare ccache timestamp
+        id: ccache_cache_timestamp
+        run: echo "timestamp=$(date -u "+%Y-%m-%d-%H;%M;%S")" >> $GITHUB_OUTPUT
+
+      - name: ccache cache files
+        uses: actions/cache@v3
+        with:
+          path: .ccache
+          key: ${{ inputs.os }} ${{ inputs.platform }} ${{ inputs.compiler }} ${{ inputs.detail }} ccache ${{ steps.ccache_cache_timestamp.outputs.timestamp }}
+          restore-keys: ${{ inputs.os }} ${{ inputs.platform }} ${{ inputs.compiler }} ${{ inputs.detail }} ccache
+
+      - name: Install Packages
+        env:
+          COMPILER: ${{ inputs.compiler }}
+        run: .github/workflows/scripts/linux/install-packages-qt.sh
+
+      - name: Cache Dependencies
+        id: cache-deps
+        uses: actions/cache@v3
+        with:
+          path: ~/deps
+          key: ${{ inputs.os }} ${{ inputs.platform }} ${{ inputs.gui }} deps ${{ hashFiles('.github/workflows/scripts/linux/build-dependencies-qt.sh') }}
+
+      - name: Build Dependencies
+        if: steps.cache-deps.outputs.cache-hit != 'true'
+        run: .github/workflows/scripts/linux/build-dependencies-qt.sh
+
+      - name: Download cheats
+        run: |
+          cd bin/resources
+          aria2c -Z "${{ inputs.cheats_url }}/cheats_ni.zip" "${{ inputs.cheats_url }}/cheats_ws.zip"
+      - name: Generate CMake
+        env:
+          COMPILER: ${{ inputs.compiler }}
+          ADDITIONAL_CMAKE_ARGS: ${{ inputs.cmakeflags }}
+        run: .github/workflows/scripts/linux/generate-cmake-qt.sh
+
+      - name: Build PCSX2
+        working-directory: build
+        run: ../.github/workflows/scripts/linux/compile.sh
+
+      - name: Run Tests
+        working-directory: ./build
+        run: ninja unittests
+
+      - name: Package AppImage
+        if: inputs.buildAppImage == true
+        env:
+          NAME: ${{ steps.artifact-metadata.outputs.artifact-name }}
+        run: |
+                .github/workflows/scripts/linux/appimage-qt.sh "$(realpath .)" "$(realpath ./build)" "$HOME/deps" "$NAME"
+                mkdir -p "$GITHUB_WORKSPACE"/ci-artifacts/
+                mv "${NAME}.AppImage" "$GITHUB_WORKSPACE"/ci-artifacts/
+      - name: Upload artifact
+        if: inputs.buildAppImage == true
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ steps.artifact-metadata.outputs.artifact-name }}
+          path: ci-artifacts

--- a/.github/workflows/release_announce.yml
+++ b/.github/workflows/release_announce.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   announce:
-    if: github.repository == 'PCSX2/pcsx2'
+    if: github.repository == 'pcnimdock/pcsx2'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/release_new_tag.yml
+++ b/.github/workflows/release_new_tag.yml
@@ -53,7 +53,7 @@ jobs:
         env:
           OWNER: pcnimdock
           REPO: pcsx2
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.BOT_PAT }}
           COMMIT_SHA: ${{ github.SHA }}
         run: |
           cd ./.github/workflows/scripts/releases/generate-release-notes

--- a/.github/workflows/release_new_tag.yml
+++ b/.github/workflows/release_new_tag.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           # Workflows cannot trigger other workflows implicitly
           # - https://github.community/t/github-actions-workflow-not-triggering-with-tag-push/17053/7
-          github_token: ${{ secrets.BOT_PAT }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           tag_prefix: v
           default_bump: patch
 
@@ -51,7 +51,7 @@ jobs:
 
       - name: Generate Release Notes
         env:
-          OWNER: PCSX2
+          OWNER: pcnimdock
           REPO: pcsx2
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COMMIT_SHA: ${{ github.SHA }}

--- a/.github/workflows/release_new_tag.yml
+++ b/.github/workflows/release_new_tag.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           # Workflows cannot trigger other workflows implicitly
           # - https://github.community/t/github-actions-workflow-not-triggering-with-tag-push/17053/7
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.BOT_PAT }}
           tag_prefix: v
           default_bump: patch
 

--- a/.github/workflows/release_new_tag.yml
+++ b/.github/workflows/release_new_tag.yml
@@ -23,7 +23,7 @@ on:
 
 jobs:
   cut-release:
-    if: github.repository == 'PCSX2/pcsx2'
+    if: github.repository == 'pcnimdock/pcsx2'
     runs-on: ubuntu-latest
     name: "Create Tag and Release"
     steps:


### PR DESCRIPTION
### Description of Changes
Added gamepad support for guncon2

### Rationale behind Changes
Added a checkbox for use joystick like guncon2. 
Now is possible use 2 ligthgun in gamepad mode
Fixed time frames in calibration hack because in virtua cop the shot is very slow.

### Suggested Testing Steps
In Guncon2 menu, in settings, check "Use gamepad like guncon2" and map the controller
