### PR TITLE
Core: Use auto for ryml noderefs

### DIFF
--- a/pcsx2/GameDatabase.cpp
+++ b/pcsx2/GameDatabase.cpp
@@ -177,7 +177,7 @@ void GameDatabase::parseAndInsert(const std::string_view& serial, const c4::yml:
 	// Validate game fixes, invalid ones will be dropped!
 	if (node.has_child("gameFixes") && node["gameFixes"].has_children())
 	{
-		for (const ryml::NodeRef& n : node["gameFixes"].children())
+		for (const auto& n : node["gameFixes"].children())
 		{
 			bool fixValidated = false;
 			auto fix = std::string(n.val().str, n.val().len);
@@ -208,7 +208,7 @@ void GameDatabase::parseAndInsert(const std::string_view& serial, const c4::yml:
 	// Validate speed hacks, invalid ones will be dropped!
 	if (node.has_child("speedHacks") && node["speedHacks"].has_children())
 	{
-		for (const ryml::NodeRef& n : node["speedHacks"].children())
+		for (const auto& n : node["speedHacks"].children())
 		{
 			bool speedHackValidated = false;
 			auto speedHack = std::string(n.key().str, n.key().len);
@@ -238,7 +238,7 @@ void GameDatabase::parseAndInsert(const std::string_view& serial, const c4::yml:
 
 	if (node.has_child("gsHWFixes"))
 	{
-		for (const ryml::NodeRef& n : node["gsHWFixes"].children())
+		for (const auto& n : node["gsHWFixes"].children())
 		{
 			const std::string_view id_name(n.key().data(), n.key().size());
 			std::optional<GameDatabaseSchema::GSHWFixId> id = GameDatabaseSchema::parseHWFixName(id_name);
@@ -275,7 +275,7 @@ void GameDatabase::parseAndInsert(const std::string_view& serial, const c4::yml:
 	// - currently they are used as a '\n' delimited string in the app
 	if (node.has_child("memcardFilters") && node["memcardFilters"].has_children())
 	{
-		for (const ryml::NodeRef& n : node["memcardFilters"].children())
+		for (const auto& n : node["memcardFilters"].children())
 		{
 			auto memcardFilter = std::string(n.val().str, n.val().len);
 			gameEntry.memcardFilters.emplace_back(std::move(memcardFilter));
@@ -285,7 +285,7 @@ void GameDatabase::parseAndInsert(const std::string_view& serial, const c4::yml:
 	// Game Patches
 	if (node.has_child("patches") && node["patches"].has_children())
 	{
-		for (const ryml::NodeRef& n : node["patches"].children())
+		for (const auto& n : node["patches"].children())
 		{
 			// use a crc of 0 for default patches
 			const std::string_view crc_str(n.key().str, n.key().len);
@@ -310,13 +310,13 @@ void GameDatabase::parseAndInsert(const std::string_view& serial, const c4::yml:
 
 	if (node.has_child("dynaPatches") && node["dynaPatches"].has_children())
 	{
-		for (const ryml::NodeRef& n : node["dynaPatches"].children())
+		for (const auto& n : node["dynaPatches"].children())
 		{
 			DynamicPatch patch;
 
 			if (n.has_child("pattern") && n["pattern"].has_children())
 			{
-				for (const ryml::NodeRef& db_pattern : n["pattern"].children())
+				for (const auto& db_pattern : n["pattern"].children())
 				{
 					DynamicPatchEntry entry;
 					db_pattern["offset"] >> entry.offset;
@@ -324,7 +324,7 @@ void GameDatabase::parseAndInsert(const std::string_view& serial, const c4::yml:
 
 					patch.pattern.push_back(entry);
 				}
-				for (const ryml::NodeRef& db_replacement : n["replacement"].children())
+				for (const auto& db_replacement : n["replacement"].children())
 				{
 					DynamicPatchEntry entry;
 					db_replacement["offset"] >> entry.offset;
@@ -919,7 +919,7 @@ void GameDatabase::initDatabase()
 		ryml::Tree tree = ryml::parse_in_arena(c4::to_csubstr(buf.value()));
 		ryml::NodeRef root = tree.rootref();
 
-		for (const ryml::NodeRef& n : root.children())
+		for (const auto& n : root.children())
 		{
 			auto serial = StringUtil::toLower(std::string(n.key().str, n.key().len));
 

--- a/pcsx2/MemoryCardFolder.cpp
+++ b/pcsx2/MemoryCardFolder.cpp
@@ -1819,13 +1819,13 @@ std::vector<FolderMemoryCard::EnumeratedFileEntry> FolderMemoryCard::GetOrderedF
 				if (yaml.has_value() && !yaml.value().empty())
 				{
 					ryml::NodeRef index = yaml.value().rootref();
-					for (const ryml::NodeRef& n : index.children())
+					for (const auto& n : index.children())
 					{
 						auto key = std::string(n.key().str, n.key().len);
 					}
 					if (index.has_child(c4::to_csubstr(fd.FileName)))
 					{
-						const ryml::NodeRef& node = index[c4::to_csubstr(fd.FileName)];
+						const auto& node = index[c4::to_csubstr(fd.FileName)];
 						if (node.has_child("timeCreated"))
 						{
 							node["timeCreated"] >> entry.m_timeCreated;
@@ -1871,7 +1871,7 @@ std::vector<FolderMemoryCard::EnumeratedFileEntry> FolderMemoryCard::GetOrderedF
 						// NOTE - working around a rapidyaml issue that needs to get resolved upstream
 						// '%' is a directive in YAML and it's not being quoted, this makes the memcards backwards compatible
 						// switched from '%' to '$'
-						const ryml::NodeRef& node = indexForDirectory["%ROOT"];
+						const auto& node = indexForDirectory["%ROOT"];
 						if (node.has_child("timeCreated"))
 						{
 							node["timeCreated"] >> entry.m_timeCreated;
@@ -1883,7 +1883,7 @@ std::vector<FolderMemoryCard::EnumeratedFileEntry> FolderMemoryCard::GetOrderedF
 					}
 					else if (indexForDirectory.has_child("$ROOT"))
 					{
-						const ryml::NodeRef& node = indexForDirectory["$ROOT"];
+						const auto& node = indexForDirectory["$ROOT"];
 						if (node.has_child("timeCreated"))
 						{
 							node["timeCreated"] >> entry.m_timeCreated;
@@ -2105,7 +2105,7 @@ void FileAccessHelper::WriteIndex(const std::string& baseFolderName, MemoryCardF
 			ryml::NodeRef newNode = index[key];
 			newNode |= ryml::MAP;
 			unsigned int maxOrder = 0;
-			for (const ryml::NodeRef& n : index.children())
+			for (const auto& n : index.children())
 			{
 				unsigned int currOrder = 0; // NOTE - this limits the usefulness of making the order an int64
 				if (n.is_map() && n.has_child("order"))


### PR DESCRIPTION
### Description of Changes
The return type switched between 0.4 and 0.5, so this will be compatible with both
Fixes #8427

### Rationale behind Changes
Better compatibility with multiple ryml versions

### Suggested Testing Steps
Try building with ryml 0.5
