### PR TITLE
iR5900: Don't limit block sizes to 16 bits

### DIFF
--- a/pcsx2/x86/BaseblockEx.h
+++ b/pcsx2/x86/BaseblockEx.h
@@ -32,10 +32,10 @@ struct BASEBLOCK
 // extra block info (only valid for start of fn)
 struct BASEBLOCKEX
 {
-	u32 startpc;
 	uptr fnptr;
-	u16 size;    // The size in dwords (equivalent to the number of instructions)
-	u16 x86size; // The size in byte of the translated x86 instructions
+	u32 startpc;
+	u32 size;    // The size in dwords (equivalent to the number of instructions)
+	u32 x86size; // The size in byte of the translated x86 instructions
 
 #ifdef PCSX2_DEVBUILD
 	// Could be useful to instrument the block

--- a/pcsx2/x86/ix86-32/iR5900-32.cpp
+++ b/pcsx2/x86/ix86-32/iR5900-32.cpp
@@ -2672,8 +2672,7 @@ StartRecomp:
 
 	pxAssert(xGetPtr() < recMem->GetPtrEnd());
 
-	pxAssert(xGetPtr() - recPtr < _64kb);
-	s_pCurBlockEx->x86size = xGetPtr() - recPtr;
+	s_pCurBlockEx->x86size = static_cast<u32>(xGetPtr() - recPtr);
 
 #if 0
 	// Example: Dump both x86/EE code


### PR DESCRIPTION
### Description of Changes
Stops storing sizes in 16-bit integers
Fixes assertion failures on Crash Team Racing
Fixes #8418 (though please compile your actual builds in release, we don't want issues being made about the terrible performance of debug builds)

### Rationale behind Changes
Less brokenness
We weren't even saving any space with this in 64-bit because of the field ordering

### Suggested Testing Steps
Test Crash Team Racing
Test other games
