### PR TITLE
GS: Reduce MAD buffering draw size 

### DIFF
--- a/bin/resources/shaders/dx11/interlace.fx
+++ b/bin/resources/shaders/dx11/interlace.fx
@@ -66,15 +66,11 @@ float4 ps_main3(PS_INPUT input) : SV_Target0
 	const int    vres   = int(ZrH.z) >> 1;                           // vertical resolution of source texture
 	const int    lofs   = ((((vres + 1) >> 1) << 1) - vres) & bank;  // line alignment offset for bank 1
 	const int    vpos   = int(input.p.y) + lofs;                     // vertical position of destination texture
-	const float2 bofs   = float2(0.0f, 0.5f * bank);                 // vertical offset of the current bank relative to source texture size
-	const float2 vscale = float2(1.0f, 2.0f);                        // scaling factor from source to destination texture
-	const float2 optr   = input.t - bofs;                            // used to check if the current destination line is within the current bank
-	const float2 iptr   = optr * vscale;                             // pointer to the current pixel in the source texture
 
 	// if the index of current destination line belongs to the current fiels we update it, otherwise
 	// we leave the old line in the destination buffer
-	if ((optr.y >= 0.0f) && (optr.y < 0.5f) && ((vpos & 1) == field))
-		return Texture.SampleLevel(Sampler, iptr, 0);
+	if ((vpos & 1) == field)
+		return Texture.SampleLevel(Sampler, input.t, 0);
 	else
 		discard;
 

--- a/bin/resources/shaders/dx11/interlace.fx
+++ b/bin/resources/shaders/dx11/interlace.fx
@@ -23,7 +23,7 @@ float4 ps_main0(PS_INPUT input) : SV_Target0
 	const int vpos  = int(input.p.y); // vertical position of destination texture
 
 	if ((vpos & 1) == field)
-		return Texture.Sample(Sampler, input.t);
+		return Texture.SampleLevel(Sampler, input.t, 0);
 	else
 		discard;
 
@@ -34,7 +34,7 @@ float4 ps_main0(PS_INPUT input) : SV_Target0
 // Bob shader
 float4 ps_main1(PS_INPUT input) : SV_Target0
 {
-	return Texture.Sample(Sampler, input.t);
+	return Texture.SampleLevel(Sampler, input.t, 0);
 }
 
 
@@ -42,9 +42,9 @@ float4 ps_main1(PS_INPUT input) : SV_Target0
 float4 ps_main2(PS_INPUT input) : SV_Target0
 {
 	float2 vstep = float2(0.0f, ZrH.y);
-	float4 c0 = Texture.Sample(Sampler, input.t - vstep);
-	float4 c1 = Texture.Sample(Sampler, input.t);
-	float4 c2 = Texture.Sample(Sampler, input.t + vstep);
+	float4 c0 = Texture.SampleLevel(Sampler, input.t - vstep, 0);
+	float4 c1 = Texture.SampleLevel(Sampler, input.t, 0);
+	float4 c2 = Texture.SampleLevel(Sampler, input.t + vstep, 0);
 
 	return (c0 + c1 * 2 + c2) / 4;
 }
@@ -74,7 +74,7 @@ float4 ps_main3(PS_INPUT input) : SV_Target0
 	// if the index of current destination line belongs to the current fiels we update it, otherwise
 	// we leave the old line in the destination buffer
 	if ((optr.y >= 0.0f) && (optr.y < 0.5f) && ((vpos & 1) == field))
-		return Texture.Sample(Sampler, iptr);
+		return Texture.SampleLevel(Sampler, iptr, 0);
 	else
 		discard;
 
@@ -133,13 +133,13 @@ float4 ps_main4(PS_INPUT input) : SV_Target0
 
 	// calculating motion, only relevant for missing lines where the "center line" is pointed by p_t1
 
-	float4 hn = Texture.Sample(Sampler, p_t0 - lofs); // new high pixel
-	float4 cn = Texture.Sample(Sampler, p_t1);        // new center pixel
-	float4 ln = Texture.Sample(Sampler, p_t0 + lofs); // new low pixel
+	float4 hn = Texture.SampleLevel(Sampler, p_t0 - lofs, 0); // new high pixel
+	float4 cn = Texture.SampleLevel(Sampler, p_t1, 0);        // new center pixel
+	float4 ln = Texture.SampleLevel(Sampler, p_t0 + lofs, 0); // new low pixel
 
-	float4 ho = Texture.Sample(Sampler, p_t2 - lofs); // old high pixel
-	float4 co = Texture.Sample(Sampler, p_t3);        // old center pixel
-	float4 lo = Texture.Sample(Sampler, p_t2 + lofs); // old low pixel
+	float4 ho = Texture.SampleLevel(Sampler, p_t2 - lofs, 0); // old high pixel
+	float4 co = Texture.SampleLevel(Sampler, p_t3, 0);        // old center pixel
+	float4 lo = Texture.SampleLevel(Sampler, p_t2 + lofs, 0); // old low pixel
 
 	float3 mh = hn.rgb - ho.rgb; // high pixel motion
 	float3 mc = cn.rgb - co.rgb; // center pixel motion
@@ -164,7 +164,7 @@ float4 ps_main4(PS_INPUT input) : SV_Target0
 	if ((vpos & 1) == field)
 	{
 		// output coordinate present on current field
-		return Texture.Sample(Sampler, p_t0);
+		return Texture.SampleLevel(Sampler, p_t0, 0);
 	}
 	else if ((iptr.y > 0.5f - lofs.y) || (iptr.y < 0.0 + lofs.y))
 	{

--- a/bin/resources/shaders/opengl/interlace.glsl
+++ b/bin/resources/shaders/opengl/interlace.glsl
@@ -19,7 +19,7 @@ void ps_main0()
 	int vpos  = int(gl_FragCoord.y); // vertical position of destination texture
 
 	if ((vpos & 1) == field)
-		SV_Target0 = texture(TextureSampler, PSin_t);
+		SV_Target0 = textureLod(TextureSampler, PSin_t, 0);
 	else
 		discard;
 }
@@ -28,7 +28,7 @@ void ps_main0()
 // Bob shader
 void ps_main1()
 {
-	SV_Target0 = texture(TextureSampler, PSin_t);
+	SV_Target0 = textureLod(TextureSampler, PSin_t, 0);
 }
 
 
@@ -36,9 +36,9 @@ void ps_main1()
 void ps_main2()
 {
 	vec2 vstep = vec2(0.0f, ZrH.y);
-	vec4 c0 = texture(TextureSampler, PSin_t - vstep);
-	vec4 c1 = texture(TextureSampler, PSin_t);
-	vec4 c2 = texture(TextureSampler, PSin_t + vstep);
+	vec4 c0 = textureLod(TextureSampler, PSin_t - vstep, 0);
+	vec4 c1 = textureLod(TextureSampler, PSin_t, 0);
+	vec4 c2 = textureLod(TextureSampler, PSin_t + vstep, 0);
 
 	SV_Target0 = (c0 + c1 * 2.0f + c2) / 4.0f;
 }
@@ -68,7 +68,7 @@ void ps_main3()
 	// if the index of current destination line belongs to the current fiels we update it, otherwise
 	// we leave the old line in the destination buffer
 	if ((optr.y >= 0.0f) && (optr.y < 0.5f) && ((vpos & 1) == field))
-		SV_Target0 = texture(TextureSampler, iptr);
+		SV_Target0 = textureLod(TextureSampler, iptr, 0);
 	else
 		discard;
 }
@@ -126,13 +126,13 @@ void ps_main4()
 	// calculating motion, only relevant for missing lines where the "center line" is pointed
 	// by p_t1
 
-	vec4 hn = texture(TextureSampler, p_t0 - lofs); // new high pixel
-	vec4 cn = texture(TextureSampler, p_t1);        // new center pixel
-	vec4 ln = texture(TextureSampler, p_t0 + lofs); // new low pixel
+	vec4 hn = textureLod(TextureSampler, p_t0 - lofs, 0); // new high pixel
+	vec4 cn = textureLod(TextureSampler, p_t1, 0);        // new center pixel
+	vec4 ln = textureLod(TextureSampler, p_t0 + lofs, 0); // new low pixel
 
-	vec4 ho = texture(TextureSampler, p_t2 - lofs); // old high pixel
-	vec4 co = texture(TextureSampler, p_t3);        // old center pixel
-	vec4 lo = texture(TextureSampler, p_t2 + lofs); // old low pixel
+	vec4 ho = textureLod(TextureSampler, p_t2 - lofs, 0); // old high pixel
+	vec4 co = textureLod(TextureSampler, p_t3, 0);        // old center pixel
+	vec4 lo = textureLod(TextureSampler, p_t2 + lofs, 0); // old low pixel
 
 	vec3 mh = hn.rgb - ho.rgb; // high pixel motion
 	vec3 mc = cn.rgb - co.rgb; // center pixel motion
@@ -158,7 +158,7 @@ void ps_main4()
 	if ((vpos & 1) == field)
 	{
 		// output coordinate present on current field
-		SV_Target0 = texture(TextureSampler, p_t0);
+		SV_Target0 = textureLod(TextureSampler, p_t0, 0);
 	}
 	else if ((iptr.y > 0.5f - lofs.y) || (iptr.y < 0.0 + lofs.y))
 	{

--- a/bin/resources/shaders/opengl/interlace.glsl
+++ b/bin/resources/shaders/opengl/interlace.glsl
@@ -60,15 +60,11 @@ void ps_main3()
 	int  vres   = int(ZrH.z) >> 1;                           // vertical resolution of source texture
 	int  lofs   = ((((vres + 1) >> 1) << 1) - vres) & bank;  // line alignment offset for bank 1
 	int  vpos   = int(gl_FragCoord.y) + lofs;                // vertical position of destination texture
-	vec2 bofs   = vec2(0.0f, 0.5f * float(bank));            // vertical offset of the current bank relative to source texture size
-	vec2 vscale = vec2(1.0f, 2.0f);                          // scaling factor from source to destination texture
-	vec2 optr   = PSin_t - bofs;                             // used to check if the current destination line is within the current bank
-	vec2 iptr   = optr * vscale;                             // pointer to the current pixel in the source texture
 
 	// if the index of current destination line belongs to the current fiels we update it, otherwise
 	// we leave the old line in the destination buffer
-	if ((optr.y >= 0.0f) && (optr.y < 0.5f) && ((vpos & 1) == field))
-		SV_Target0 = textureLod(TextureSampler, iptr, 0);
+	if ((vpos & 1) == field)
+		SV_Target0 = textureLod(TextureSampler, PSin_t, 0);
 	else
 		discard;
 }

--- a/bin/resources/shaders/vulkan/interlace.glsl
+++ b/bin/resources/shaders/vulkan/interlace.glsl
@@ -35,7 +35,7 @@ void ps_main0()
 	const int vpos  = int(gl_FragCoord.y); // vertical position of destination texture
 
 	if ((vpos & 1) == field)
-		o_col0 = texture(samp0, v_tex);
+		o_col0 = textureLod(samp0, v_tex, 0);
 	else
 		discard;
 }
@@ -46,7 +46,7 @@ void ps_main0()
 #ifdef ps_main1
 void ps_main1()
 {
-	o_col0 = texture(samp0, v_tex);
+	o_col0 = textureLod(samp0, v_tex, 0);
 }
 #endif
 
@@ -56,9 +56,9 @@ void ps_main1()
 void ps_main2()
 {
 	vec2 vstep = vec2(0.0f, ZrH.y);
-	vec4 c0 = texture(samp0, v_tex - vstep);
-	vec4 c1 = texture(samp0, v_tex);
-	vec4 c2 = texture(samp0, v_tex + vstep);
+	vec4 c0 = textureLod(samp0, v_tex - vstep, 0);
+	vec4 c1 = textureLod(samp0, v_tex, 0);
+	vec4 c2 = textureLod(samp0, v_tex + vstep, 0);
 
 	o_col0 = (c0 + c1 * 2.0f + c2) / 4.0f;
 }
@@ -90,7 +90,7 @@ void ps_main3()
 	// if the index of current destination line belongs to the current fiels we update it, otherwise
 	// we leave the old line in the destination buffer
 	if ((optr.y >= 0.0f) && (optr.y < 0.5f) && ((vpos & 1) == field))
-		o_col0 = texture(samp0, iptr);
+		o_col0 = textureLod(samp0, iptr, 0);
 	else
 		discard;
 }
@@ -150,13 +150,13 @@ void ps_main4()
 
 	// calculating motion, only relevant for missing lines where the "center line" is pointed by p_t1
 
-	vec4 hn = texture(samp0, p_t0 - lofs); // new high pixel
-	vec4 cn = texture(samp0, p_t1);        // new center pixel
-	vec4 ln = texture(samp0, p_t0 + lofs); // new low pixel
+	vec4 hn = textureLod(samp0, p_t0 - lofs, 0); // new high pixel
+	vec4 cn = textureLod(samp0, p_t1, 0);        // new center pixel
+	vec4 ln = textureLod(samp0, p_t0 + lofs, 0); // new low pixel
 
-	vec4 ho = texture(samp0, p_t2 - lofs); // old high pixel
-	vec4 co = texture(samp0, p_t3);        // old center pixel
-	vec4 lo = texture(samp0, p_t2 + lofs); // old low pixel
+	vec4 ho = textureLod(samp0, p_t2 - lofs, 0); // old high pixel
+	vec4 co = textureLod(samp0, p_t3, 0);        // old center pixel
+	vec4 lo = textureLod(samp0, p_t2 + lofs, 0); // old low pixel
 
 	vec3 mh = hn.rgb - ho.rgb; // high pixel motion
 	vec3 mc = cn.rgb - co.rgb; // center pixel motion
@@ -181,7 +181,7 @@ void ps_main4()
 	if ((vpos & 1) == field) // output coordinate present on current field
 	{
 		// output coordinate present on current field
-		o_col0 = texture(samp0, p_t0);
+		o_col0 = textureLod(samp0, p_t0, 0);
 	}
 	else if ((iptr.y > 0.5f - lofs.y) || (iptr.y < 0.0 + lofs.y))
 	{

--- a/bin/resources/shaders/vulkan/interlace.glsl
+++ b/bin/resources/shaders/vulkan/interlace.glsl
@@ -82,15 +82,11 @@ void ps_main3()
 	const int  vres   = int(ZrH.z) >> 1;                          // vertical resolution of source texture
 	const int  lofs   = ((((vres + 1) >> 1) << 1) - vres) & bank; // line alignment offset for bank 1
 	const int  vpos   = int(gl_FragCoord.y) + lofs;               // vertical position of destination texture
-	const vec2 bofs   = vec2(0.0f, 0.5f * bank);                  // vertical offset of the current bank relative to source texture size
-	const vec2 vscale = vec2(1.0f, 2.0f);                         // scaling factor from source to destination texture
-	const vec2 optr   = v_tex - bofs;                             // used to check if the current destination line is within the current bank
-	const vec2 iptr   = optr * vscale;                            // pointer to the current pixel in the source texture
 
 	// if the index of current destination line belongs to the current fiels we update it, otherwise
 	// we leave the old line in the destination buffer
-	if ((optr.y >= 0.0f) && (optr.y < 0.5f) && ((vpos & 1) == field))
-		o_col0 = textureLod(samp0, iptr, 0);
+	if ((vpos & 1) == field)
+		o_col0 = textureLod(samp0, v_tex, 0);
 	else
 		discard;
 }

--- a/pcsx2/GS/Renderers/Common/GSDevice.h
+++ b/pcsx2/GS/Renderers/Common/GSDevice.h
@@ -55,6 +55,16 @@ enum class ShaderConvert
 	Count
 };
 
+enum class ShaderInterlace
+{
+	WEAVE = 0,
+	BOB = 1,
+	BLEND = 2,
+	MAD_BUFFER = 3,
+	MAD_RECONSTRUCT = 4,
+	Count
+};
+
 static inline bool HasDepthOutput(ShaderConvert shader)
 {
 	switch (shader)
@@ -192,7 +202,6 @@ class InterlaceConstantBuffer
 {
 public:
 	GSVector4 ZrH; // data passed to the shader
-	InterlaceConstantBuffer() { memset(this, 0, sizeof(*this)); }
 };
 
 #pragma pack(pop)
@@ -773,7 +782,7 @@ protected:
 	GSTexture* FetchSurface(GSTexture::Type type, int width, int height, int levels, GSTexture::Format format, bool clear, bool prefer_reuse);
 
 	virtual void DoMerge(GSTexture* sTex[3], GSVector4* sRect, GSTexture* dTex, GSVector4* dRect, const GSRegPMODE& PMODE, const GSRegEXTBUF& EXTBUF, const GSVector4& c, const bool linear) = 0;
-	virtual void DoInterlace(GSTexture* sTex, GSTexture* dTex, int shader, bool linear, float yoffset, int bufIdx) = 0;
+	virtual void DoInterlace(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect, ShaderInterlace shader, bool linear, const InterlaceConstantBuffer& cb) = 0;
 	virtual void DoFXAA(GSTexture* sTex, GSTexture* dTex) {}
 	virtual void DoShadeBoost(GSTexture* sTex, GSTexture* dTex, const float params[4]) {}
 

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
@@ -935,20 +935,11 @@ void GSDevice11::DoMerge(GSTexture* sTex[3], GSVector4* sRect, GSTexture* dTex, 
 	}
 }
 
-void GSDevice11::DoInterlace(GSTexture* sTex, GSTexture* dTex, int shader, bool linear, float yoffset, int bufIdx)
+void GSDevice11::DoInterlace(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect, ShaderInterlace shader, bool linear, const InterlaceConstantBuffer& cb)
 {
-	const GSVector4 ds = GSVector4(dTex->GetSize());
-
-	const GSVector4 sRect(0, 0, 1, 1);
-	const GSVector4 dRect(0.0f, yoffset, ds.x, ds.y + yoffset);
-
-	InterlaceConstantBuffer cb;
-
-	cb.ZrH = GSVector4(static_cast<float>(bufIdx), 1.0f / ds.y, ds.y, MAD_SENSITIVITY);
-
 	m_ctx->UpdateSubresource(m_interlace.cb.get(), 0, nullptr, &cb, 0, 0);
 
-	StretchRect(sTex, sRect, dTex, dRect, m_interlace.ps[shader].get(), m_interlace.cb.get(), linear);
+	StretchRect(sTex, sRect, dTex, dRect, m_interlace.ps[static_cast<int>(shader)].get(), m_interlace.cb.get(), linear);
 }
 
 void GSDevice11::DoFXAA(GSTexture* sTex, GSTexture* dTex)

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.h
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.h
@@ -127,7 +127,7 @@ private:
 	std::unique_ptr<GSDownloadTexture> CreateDownloadTexture(u32 width, u32 height, GSTexture::Format format) final;
 
 	void DoMerge(GSTexture* sTex[3], GSVector4* sRect, GSTexture* dTex, GSVector4* dRect, const GSRegPMODE& PMODE, const GSRegEXTBUF& EXTBUF, const GSVector4& c, const bool linear) final;
-	void DoInterlace(GSTexture* sTex, GSTexture* dTex, int shader, bool linear, float yoffset = 0, int bufIdx = 0) final;
+	void DoInterlace(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect, ShaderInterlace shader, bool linear, const InterlaceConstantBuffer& cb) final;
 	void DoFXAA(GSTexture* sTex, GSTexture* dTex) final;
 	void DoShadeBoost(GSTexture* sTex, GSTexture* dTex, const float params[4]) final;
 

--- a/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
@@ -823,30 +823,17 @@ void GSDevice12::DoMerge(GSTexture* sTex[3], GSVector4* sRect, GSTexture* dTex, 
 	static_cast<GSTexture12*>(dTex)->TransitionToState(D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
 }
 
-void GSDevice12::DoInterlace(GSTexture* sTex, GSTexture* dTex, int shader, bool linear, float yoffset, int bufIdx)
+void GSDevice12::DoInterlace(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect, ShaderInterlace shader, bool linear, const InterlaceConstantBuffer& cb)
 {
-	const GSVector2i ds_i = dTex->GetSize();
-	const GSVector4  ds   = GSVector4(ds_i);
-	
-
-	const GSVector4 sRect(0, 0, 1, 1);
-	const GSVector4 dRect(0.0f, yoffset, ds.x, ds.y + yoffset);
-
-	InterlaceConstantBuffer cb;
-
-	cb.ZrH = GSVector4(static_cast<float>(bufIdx), 1.0f / ds.y, ds.y, MAD_SENSITIVITY);
-
-	GL_PUSH("DoInterlace %dx%d Shader:%d Linear:%d", ds_i.x, ds_i.y, shader, linear);
-
 	static_cast<GSTexture12*>(dTex)->TransitionToState(D3D12_RESOURCE_STATE_RENDER_TARGET);
 
-	const GSVector4i rc(0, 0, ds_i.x, ds_i.y);
+	const GSVector4i rc = GSVector4i(dRect);
 	EndRenderPass();
 	OMSetRenderTargets(dTex, nullptr, rc);
 	SetUtilityRootSignature();
 	SetUtilityTexture(sTex, linear ? m_linear_sampler_cpu : m_point_sampler_cpu);
-	BeginRenderPassForStretchRect(static_cast<GSTexture12*>(dTex), rc, rc, false);
-	SetPipeline(m_interlace[shader].get());
+	BeginRenderPassForStretchRect(static_cast<GSTexture12*>(dTex), dTex->GetRect(), rc, false);
+	SetPipeline(m_interlace[static_cast<int>(shader)].get());
 	SetUtilityPushConstants(&cb, sizeof(cb));
 	DrawStretchRect(sRect, dRect, dTex->GetSize());
 	EndRenderPass();

--- a/pcsx2/GS/Renderers/DX12/GSDevice12.h
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.h
@@ -184,7 +184,7 @@ private:
 
 	void DoMerge(GSTexture* sTex[3], GSVector4* sRect, GSTexture* dTex, GSVector4* dRect, const GSRegPMODE& PMODE,
 		const GSRegEXTBUF& EXTBUF, const GSVector4& c, const bool linear) final;
-	void DoInterlace(GSTexture* sTex, GSTexture* dTex, int shader, bool linear, float yoffset = 0, int bufIdx = 0) final;
+	void DoInterlace(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect, ShaderInterlace shader, bool linear, const InterlaceConstantBuffer& cb) final;
 	void DoShadeBoost(GSTexture* sTex, GSTexture* dTex, const float params[4]) final;
 	void DoFXAA(GSTexture* sTex, GSTexture* dTex) final;
 

--- a/pcsx2/GS/Renderers/Metal/GSDeviceMTL.h
+++ b/pcsx2/GS/Renderers/Metal/GSDeviceMTL.h
@@ -352,7 +352,7 @@ public:
 	GSTexture* CreateSurface(GSTexture::Type type, int width, int height, int levels, GSTexture::Format format) override;
 
 	void DoMerge(GSTexture* sTex[3], GSVector4* sRect, GSTexture* dTex, GSVector4* dRect, const GSRegPMODE& PMODE, const GSRegEXTBUF& EXTBUF, const GSVector4& c, const bool linear) override;
-	void DoInterlace(GSTexture* sTex, GSTexture* dTex, int shader, bool linear, float yoffset, int bufIdx) override;
+	void DoInterlace(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect, ShaderInterlace shader, bool linear, const InterlaceConstantBuffer& cb) override;
 	void DoFXAA(GSTexture* sTex, GSTexture* dTex) override;
 	void DoShadeBoost(GSTexture* sTex, GSTexture* dTex, const float params[4]) override;
 
@@ -371,7 +371,7 @@ public:
 	std::unique_ptr<GSDownloadTexture> CreateDownloadTexture(u32 width, u32 height, GSTexture::Format format) override;
 
 	void CopyRect(GSTexture* sTex, GSTexture* dTex, const GSVector4i& r, u32 destX, u32 destY) override;
-	void DoStretchRect(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect, id<MTLRenderPipelineState> pipeline, bool linear, LoadAction load_action, void* frag_uniform, size_t frag_uniform_len);
+	void DoStretchRect(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect, id<MTLRenderPipelineState> pipeline, bool linear, LoadAction load_action, const void* frag_uniform, size_t frag_uniform_len);
 	void DrawStretchRect(const GSVector4& sRect, const GSVector4& dRect, const GSVector2i& ds);
 	/// Copy from a position in sTex to the same position in the currently active render encoder using the given fs pipeline and rect
 	void RenderCopy(GSTexture* sTex, id<MTLRenderPipelineState> pipeline, const GSVector4i& rect);

--- a/pcsx2/GS/Renderers/Metal/GSMTLShaderCommon.h
+++ b/pcsx2/GS/Renderers/Metal/GSMTLShaderCommon.h
@@ -33,6 +33,10 @@ struct ConvertPSRes
 	{
 		return texture.sample(s, coord);
 	}
+	float4 sample_level(float2 coord, float lod)
+	{
+		return texture.sample(s, coord, level(lod));
+	}
 };
 
 struct ConvertPSDepthRes

--- a/pcsx2/GS/Renderers/Metal/interlace.metal
+++ b/pcsx2/GS/Renderers/Metal/interlace.metal
@@ -27,7 +27,7 @@ fragment float4 ps_interlace0(ConvertShaderData data [[stage_in]], ConvertPSRes 
 	const int vpos  = int(data.p.y);      // vertical position of destination texture
 
 	if ((vpos & 1) == field)
-		return res.sample(data.t);
+		return res.sample_level(data.t, 0);
 	else
 		discard_fragment();
 
@@ -38,7 +38,7 @@ fragment float4 ps_interlace0(ConvertShaderData data [[stage_in]], ConvertPSRes 
 // Bob shader
 fragment float4 ps_interlace1(ConvertShaderData data [[stage_in]], ConvertPSRes res)
 {
-	return res.sample(data.t);
+	return res.sample_level(data.t);
 }
 
 
@@ -47,9 +47,9 @@ fragment float4 ps_interlace2(ConvertShaderData data [[stage_in]], ConvertPSRes 
 	constant GSMTLInterlacePSUniform& uniform [[buffer(GSMTLBufferIndexUniforms)]])
 {
 	float2 vstep = float2(0.0f, uniform.ZrH.y);
-	float4 c0 = res.sample(data.t - vstep);
-	float4 c1 = res.sample(data.t);
-	float4 c2 = res.sample(data.t + vstep);
+	float4 c0 = res.sample_level(data.t - vstep, 0);
+	float4 c1 = res.sample_level(data.t, 0);
+	float4 c2 = res.sample_level(data.t + vstep, 0);
 	return (c0 + c1 * 2.f + c2) / 4.f;
 }
 
@@ -79,7 +79,7 @@ fragment float4 ps_interlace3(ConvertShaderData data [[stage_in]], ConvertPSRes 
 	// if the index of current destination line belongs to the current fiels we update it, otherwise
 	// we leave the old line in the destination buffer
 	if ((optr.y >= 0.0f) && (optr.y < 0.5f) && ((vpos & 1) == field))
-		return res.sample(iptr);
+		return res.sample_level(iptr, 0);
 	else
 		discard_fragment();
 
@@ -137,13 +137,13 @@ fragment float4 ps_interlace4(ConvertShaderData data [[stage_in]], ConvertPSRes 
 
 	// calculating motion, only relevant for missing lines where the "center line" is pointed by p_t1
 
-	float4 hn = res.sample(p_t0 - lofs); // new high pixel
-	float4 cn = res.sample(p_t1);        // new center pixel
-	float4 ln = res.sample(p_t0 + lofs); // new low pixel
+	float4 hn = res.sample_level(p_t0 - lofs, 0); // new high pixel
+	float4 cn = res.sample_level(p_t1, 0);        // new center pixel
+	float4 ln = res.sample_level(p_t0 + lofs, 0); // new low pixel
 
-	float4 ho = res.sample(p_t2 - lofs); // old high pixel
-	float4 co = res.sample(p_t3);        // old center pixel
-	float4 lo = res.sample(p_t2 + lofs); // old low pixel
+	float4 ho = res.sample_level(p_t2 - lofs, 0); // old high pixel
+	float4 co = res.sample_level(p_t3, 0);        // old center pixel
+	float4 lo = res.sample_level(p_t2 + lofs, 0); // old low pixel
 
 	float3 mh = hn.rgb - ho.rgb;
 	float3 mc = cn.rgb - co.rgb;
@@ -168,7 +168,7 @@ fragment float4 ps_interlace4(ConvertShaderData data [[stage_in]], ConvertPSRes 
 	if ((vpos & 1) == field)
 	{
 		// output coordinate present on current field
-		return res.sample(p_t0);
+		return res.sample_level(p_t0, 0);
 	}
 	else if ((iptr.y > 0.5f - lofs.y) || (iptr.y < 0.0 + lofs.y))
 	{

--- a/pcsx2/GS/Renderers/Metal/interlace.metal
+++ b/pcsx2/GS/Renderers/Metal/interlace.metal
@@ -38,7 +38,7 @@ fragment float4 ps_interlace0(ConvertShaderData data [[stage_in]], ConvertPSRes 
 // Bob shader
 fragment float4 ps_interlace1(ConvertShaderData data [[stage_in]], ConvertPSRes res)
 {
-	return res.sample_level(data.t);
+	return res.sample_level(data.t, 0);
 }
 
 
@@ -71,15 +71,11 @@ fragment float4 ps_interlace3(ConvertShaderData data [[stage_in]], ConvertPSRes 
 	const int    vres     = int(uniform.ZrH.z) >> 1;                  // vertical resolution of source texture
 	const int    lofs     = ((((vres + 1) >> 1) << 1) - vres) & bank; // line alignment offset for bank 1
 	const int    vpos     = int(data.p.y) + lofs;                     // vertical position of destination texture
-	const float2 bofs     = float2(0.0f, 0.5f * bank);                // vertical offset of the current bank relative to source texture size
-	const float2 vscale   = float2(1.0f, 2.0f);                       // scaling factor from source to destination texture
-	const float2 optr     = data.t - bofs;                            // used to check if the current destination line is within the current bank
-	const float2 iptr     = optr * vscale;                            // pointer to the current pixel in the source texture
 
 	// if the index of current destination line belongs to the current fiels we update it, otherwise
 	// we leave the old line in the destination buffer
-	if ((optr.y >= 0.0f) && (optr.y < 0.5f) && ((vpos & 1) == field))
-		return res.sample_level(iptr, 0);
+	if ((vpos & 1) == field)
+		return res.sample_level(data.t, 0);
 	else
 		discard_fragment();
 

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -1453,21 +1453,14 @@ void GSDeviceOGL::DoMerge(GSTexture* sTex[3], GSVector4* sRect, GSTexture* dTex,
 		StretchRect(dTex, full_r, sTex[2], dRect[2], ShaderConvert::YUV, linear);
 }
 
-void GSDeviceOGL::DoInterlace(GSTexture* sTex, GSTexture* dTex, int shader, bool linear, float yoffset, int bufIdx)
+void GSDeviceOGL::DoInterlace(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect, ShaderInterlace shader, bool linear, const InterlaceConstantBuffer& cb)
 {
-	GL_PUSH("DoInterlace");
-
 	OMSetColorMaskState();
 
-	const GSVector4 ds = GSVector4(dTex->GetSize());
+	m_interlace.ps[static_cast<int>(shader)].Bind();
+	m_interlace.ps[static_cast<int>(shader)].Uniform4fv(0, cb.ZrH.F32);
 
-	const GSVector4 sRect(0, 0, 1, 1);
-	const GSVector4 dRect(0.0f, yoffset, ds.x, ds.y + yoffset);
-
-	m_interlace.ps[shader].Bind();
-	m_interlace.ps[shader].Uniform4f(0, bufIdx, 1.0f / ds.y, ds.y, MAD_SENSITIVITY);
-
-	StretchRect(sTex, sRect, dTex, dRect, m_interlace.ps[shader], linear);
+	StretchRect(sTex, sRect, dTex, dRect, m_interlace.ps[static_cast<int>(shader)], linear);
 }
 
 void GSDeviceOGL::DoFXAA(GSTexture* sTex, GSTexture* dTex)

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.h
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.h
@@ -277,7 +277,7 @@ private:
 	GSTexture* CreateSurface(GSTexture::Type type, int width, int height, int levels, GSTexture::Format format) final;
 
 	void DoMerge(GSTexture* sTex[3], GSVector4* sRect, GSTexture* dTex, GSVector4* dRect, const GSRegPMODE& PMODE, const GSRegEXTBUF& EXTBUF, const GSVector4& c, const bool linear) final;
-	void DoInterlace(GSTexture* sTex, GSTexture* dTex, int shader, bool linear, float yoffset = 0, int bufIdx = 0) final;
+	void DoInterlace(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect, ShaderInterlace shader, bool linear, const InterlaceConstantBuffer& cb) final;
 	void DoFXAA(GSTexture* sTex, GSTexture* dTex) final;
 	void DoShadeBoost(GSTexture* sTex, GSTexture* dTex, const float params[4]) final;
 

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h
@@ -155,7 +155,7 @@ private:
 
 	void DoMerge(GSTexture* sTex[3], GSVector4* sRect, GSTexture* dTex, GSVector4* dRect, const GSRegPMODE& PMODE,
 		const GSRegEXTBUF& EXTBUF, const GSVector4& c, const bool linear) final;
-	void DoInterlace(GSTexture* sTex, GSTexture* dTex, int shader, bool linear, float yoffset = 0, int bufIdx = 0) final;
+	void DoInterlace(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect, ShaderInterlace shader, bool linear, const InterlaceConstantBuffer& cb) final;
 	void DoShadeBoost(GSTexture* sTex, GSTexture* dTex, const float params[4]) final;
 	void DoFXAA(GSTexture* sTex, GSTexture* dTex) final;
 


### PR DESCRIPTION
### Description of Changes

It's silly to draw to the whole double-sized render target, but discard half the pixels.

Also centralizes the constant setup, get rid of the duplication.

Lastly, forces LOD 0 sampling in these shaders, since you can't use normal sampling because the derivates are undefined in
non-uniform control flow.

### Rationale behind Changes

Small performance boost at high upscaling.

### Suggested Testing Steps

Make sure MAD works as expected in all renderers.
