### PR TITLE
GS/HW: Swap OI_JakGames CRC hack for CPU sprite render

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -3976,11 +3976,12 @@ SCES-53286:
   region: "PAL-M7"
   gsHWFixes:
     roundSprite: 1 # Fix lines in the sky.
-    textureInsideRT: 1 # Fixes broken character models.
     autoFlush: 1 # Fixes lighting.
-    mipmap: 2 # Fixes bad textures.
-    trilinearFiltering: 1 # Fixes smooths texture transitions.
-    beforeDraw: "OI_JakX"
+    mipmap: 2 # Fixes broken textures.
+    trilinearFiltering: 1 # Fixes water textures.
+    cpuSpriteRenderBW: 2 # Fixes water textures. Can't use BW 4 here because of post effects.
+    cpuSpriteRenderLevel: 2 # Needed for above.
+    textureInsideRT: 1 # Fixes broken character models.
   memcardFilters: # Reads Ratchet Gladiator data.
     - "SCES-53286"
     - "SCES-53285"
@@ -8063,11 +8064,10 @@ SCUS-97374:
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
-    roundSprite: 1 # Fix lines in the sky.
-    mipmap: 1 # Fixes broken textures.
-    textureInsideRT: 1 # Fixes broken character models.
-    autoFlush: 1 # Fixes lighting.
-    beforeDraw: "OI_JakX"
+    mipmap: 2 # Fixes broken textures.
+    trilinearFiltering: 1 # Fixes water textures.
+    cpuSpriteRenderBW: 4 # Fixes character and water textures.
+    cpuSpriteRenderLevel: 2 # Needed for above.
 SCUS-97377:
   name: "Syphon Filter - The Omega Strain [Regular Demo]"
   region: "NTSC-U"
@@ -8261,11 +8261,12 @@ SCUS-97429:
   compat: 5
   gsHWFixes:
     roundSprite: 1 # Fix lines in the sky.
-    textureInsideRT: 1 # Fixes broken character models.
     autoFlush: 1 # Fixes lighting.
-    mipmap: 2 # Fixes bad textures.
-    trilinearFiltering: 1 # Fixes smooths texture transitions.
-    beforeDraw: "OI_JakX"
+    mipmap: 2 # Fixes broken textures.
+    trilinearFiltering: 1 # Fixes water textures.
+    cpuSpriteRenderBW: 2 # Fixes water textures. Can't use BW 4 here because of post effects.
+    cpuSpriteRenderLevel: 2 # Needed for above.
+    textureInsideRT: 1 # Fixes broken character models.
   memcardFilters:
     - "SCUS-97429"
     - "SCUS-97465"
@@ -8534,11 +8535,12 @@ SCUS-97486:
   region: "NTSC-U"
   gsHWFixes:
     roundSprite: 1 # Fix lines in the sky.
-    textureInsideRT: 1 # Fixes broken character models.
     autoFlush: 1 # Fixes lighting.
-    mipmap: 2 # Fixes bad textures.
-    trilinearFiltering: 1 # Fixes smooths texture transitions.
-    beforeDraw: "OI_JakX"
+    mipmap: 2 # Fixes broken textures.
+    trilinearFiltering: 1 # Fixes water textures.
+    cpuSpriteRenderBW: 2 # Fixes water textures. Can't use BW 4 here because of post effects.
+    cpuSpriteRenderLevel: 2 # Needed for above.
+    textureInsideRT: 1 # Fixes broken character models.
 SCUS-97487:
   name: "Ratchet - Deadlocked [Public Beta v.1]"
   region: "NTSC-U"
@@ -8556,11 +8558,12 @@ SCUS-97488:
   compat: 5
   gsHWFixes:
     roundSprite: 1 # Fix lines in the sky.
-    textureInsideRT: 1 # Fixes broken character models.
     autoFlush: 1 # Fixes lighting.
-    mipmap: 2 # Fixes bad textures.
-    trilinearFiltering: 1 # Fixes smooths texture transitions.
-    beforeDraw: "OI_JakX"
+    mipmap: 2 # Fixes broken textures.
+    trilinearFiltering: 1 # Fixes water textures.
+    cpuSpriteRenderBW: 2 # Fixes water textures. Can't use BW 4 here because of post effects.
+    cpuSpriteRenderLevel: 2 # Needed for above.
+    textureInsideRT: 1 # Fixes broken character models.
 SCUS-97489:
   name: "SOCOM 3 - U.S. Navy SEALs [Public Beta v.1]"
   region: "NTSC-U"
@@ -8857,11 +8860,12 @@ SCUS-97574:
   region: "NTSC-U"
   gsHWFixes:
     roundSprite: 1 # Fix lines in the sky.
-    textureInsideRT: 1 # Fixes broken character models.
     autoFlush: 1 # Fixes lighting.
-    mipmap: 2 # Fixes bad textures.
-    trilinearFiltering: 1 # Fixes smooths texture transitions.
-    beforeDraw: "OI_JakX"
+    mipmap: 2 # Fixes broken textures.
+    trilinearFiltering: 1 # Fixes water textures.
+    cpuSpriteRenderBW: 2 # Fixes water textures. Can't use BW 4 here because of post effects.
+    cpuSpriteRenderLevel: 2 # Needed for above.
+    textureInsideRT: 1 # Fixes broken character models.
 SCUS-97579:
   name: "ATV Offroad Fury 4 [Demo]"
   region: "NTSC-U"
@@ -51887,11 +51891,12 @@ TCES-53286:
   compat: 5
   gsHWFixes:
     roundSprite: 1 # Fix lines in the sky.
-    textureInsideRT: 1 # Fixes broken character models.
     autoFlush: 1 # Fixes lighting.
-    mipmap: 2 # Fixes bad textures.
-    trilinearFiltering: 1 # Fixes smooths texture transitions.
-    beforeDraw: "OI_JakX"
+    mipmap: 2 # Fixes broken textures.
+    trilinearFiltering: 1 # Fixes water textures.
+    cpuSpriteRenderBW: 2 # Fixes water textures. Can't use BW 4 here because of post effects.
+    cpuSpriteRenderLevel: 2 # Needed for above.
+    textureInsideRT: 1 # Fixes broken character models.
 TCPS-10058:
   name: "Densha de Go! Shinkansen [with Controller]"
   region: "NTSC-J"

--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -121,16 +121,18 @@ PAPX-90222:
   name: "Jak x Daxter - Kyuu Sekai no Isan [Demo, Taikenban]"
   region: "NTSC-J"
   gsHWFixes:
-    roundSprite: 1 # Fix lines in the sky.
-    mipmap: 1
-    textureInsideRT: 1
+    mipmap: 2 # Fixes broken textures.
+    trilinearFiltering: 1 # Fixes water textures.
+    cpuSpriteRenderBW: 4 # Fixes character and water textures.
+    cpuSpriteRenderLevel: 2 # Needed for above.
 PAPX-90223:
   name: "Jak x Daxter - Kyuu Sekai no Isan [Demo, Taikenban]"
   region: "NTSC-J"
   gsHWFixes:
-    roundSprite: 1 # Fix lines in the sky.
-    mipmap: 1
-    textureInsideRT: 1
+    mipmap: 2 # Fixes broken textures.
+    trilinearFiltering: 1 # Fixes water textures.
+    cpuSpriteRenderBW: 4 # Fixes character and water textures.
+    cpuSpriteRenderLevel: 2 # Needed for above.
 PAPX-90231:
   name: "Kaitou Sly Cooper [Demo, Taikenban]"
   region: "NTSC-J"
@@ -163,11 +165,11 @@ PAPX-90516:
   name: "Jak and Daxter II [Trial]"
   region: "NTSC-J"
   gsHWFixes:
-    roundSprite: 1 # Fix lines in the sky.
-    mipmap: 1 # Fixes broken textures.
-    textureInsideRT: 1 # Fixes broken character models.
+    mipmap: 2 # Fixes broken textures.
+    trilinearFiltering: 1 # Fixes water textures.
+    cpuSpriteRenderBW: 4 # Fixes character and water textures.
+    cpuSpriteRenderLevel: 2 # Needed for above.
     autoFlush: 1 # Fixes lighting.
-    beforeDraw: "OI_JakGames"
 PAPX-90517:
   name: "Prince of Persia - Jikan no Suna [Trial]"
   region: "NTSC-J"
@@ -785,11 +787,11 @@ SCAJ-20073:
   name: "Jak and Daxter II"
   region: "NTSC-Unk"
   gsHWFixes:
-    roundSprite: 1 # Fix lines in the sky.
-    mipmap: 1 # Fixes broken textures.
-    textureInsideRT: 1 # Fixes broken character models.
+    mipmap: 2 # Fixes broken textures.
+    trilinearFiltering: 1 # Fixes water textures.
+    cpuSpriteRenderBW: 4 # Fixes character and water textures.
+    cpuSpriteRenderLevel: 2 # Needed for above.
     autoFlush: 1 # Fixes lighting.
-    beforeDraw: "OI_JakGames"
 SCAJ-20074:
   name: "King of Fighters 2002, The"
   region: "NTSC-Unk"
@@ -1830,9 +1832,10 @@ SCED-50614:
   name: "Jak and Daxter - The Precursor Legacy [Demo]"
   region: "PAL-Unk"
   gsHWFixes:
-    roundSprite: 1 # Fix lines in the sky.
-    mipmap: 1
-    textureInsideRT: 1
+    mipmap: 2 # Fixes broken textures.
+    trilinearFiltering: 1 # Fixes water textures.
+    cpuSpriteRenderBW: 4 # Fixes character and water textures.
+    cpuSpriteRenderLevel: 2 # Needed for above.
 SCED-50622:
   name: "Official PlayStation 2 Magazine Demo 14" # German
   region: "PAL-E-G"
@@ -2110,11 +2113,11 @@ SCED-51700:
   name: "Jak II - Renegade [Demo]"
   region: "PAL-M5"
   gsHWFixes:
-    roundSprite: 1 # Fix lines in the sky.
-    mipmap: 1 # Fixes broken textures.
-    textureInsideRT: 1 # Fixes broken character models.
+    mipmap: 2 # Fixes broken textures.
+    trilinearFiltering: 1 # Fixes water textures.
+    cpuSpriteRenderBW: 4 # Fixes character and water textures.
+    cpuSpriteRenderLevel: 2 # Needed for above.
     autoFlush: 1 # Fixes lighting.
-    beforeDraw: "OI_JakGames"
 SCED-51899:
   name: "PlayStation Experience [Demo]"
   region: "PAL-E"
@@ -2423,11 +2426,11 @@ SCED-52952:
   name: "Jak 3 [Demo]"
   region: "PAL-M5"
   gsHWFixes:
-    roundSprite: 1 # Fix lines in the sky.
-    mipmap: 1
-    textureInsideRT: 1
-    autoFlush: 1
-    beforeDraw: "OI_JakGames"
+    mipmap: 2 # Fixes broken textures.
+    trilinearFiltering: 1 # Fixes water textures.
+    cpuSpriteRenderBW: 4 # Fixes character and water textures.
+    cpuSpriteRenderLevel: 2 # Needed for above.
+    autoFlush: 1 # Fixes lighting.
 SCED-52970:
   name: "SCEE Hits Demo"
   region: "PAL-M5"
@@ -2973,9 +2976,10 @@ SCES-50361:
   region: "PAL-M6"
   compat: 5
   gsHWFixes:
-    roundSprite: 1 # Fix lines in the sky.
-    mipmap: 1
-    textureInsideRT: 1
+    mipmap: 2 # Fixes broken textures.
+    trilinearFiltering: 1 # Fixes water textures.
+    cpuSpriteRenderBW: 4 # Fixes character and water textures.
+    cpuSpriteRenderLevel: 2 # Needed for above.
 SCES-50408:
   name: "PaRappa the Rapper 2"
   region: "PAL-M5"
@@ -3135,9 +3139,10 @@ SCES-50614:
   name: "Jak and Daxter - The Precursor Legacy"
   region: "PAL-Unk"
   gsHWFixes:
-    roundSprite: 1 # Fix lines in the sky.
-    mipmap: 1
-    textureInsideRT: 1
+    mipmap: 2 # Fixes broken textures.
+    trilinearFiltering: 1 # Fixes water textures.
+    cpuSpriteRenderBW: 4 # Fixes character and water textures.
+    cpuSpriteRenderLevel: 2 # Needed for above.
 SCES-50759:
   name: "Virtua Fighter 4"
   region: "PAL-M5"
@@ -3454,11 +3459,11 @@ SCES-51608:
   region: "PAL-M7"
   compat: 5
   gsHWFixes:
-    roundSprite: 1 # Fix lines in the sky.
-    mipmap: 1 # Fixes broken textures.
-    textureInsideRT: 1 # Fixes broken character models.
+    mipmap: 2 # Fixes broken textures.
+    trilinearFiltering: 1 # Fixes water textures.
+    cpuSpriteRenderBW: 4 # Fixes character and water textures.
+    cpuSpriteRenderLevel: 2 # Needed for above.
     autoFlush: 1 # Fixes lighting.
-    beforeDraw: "OI_JakGames"
 SCES-51610:
   name: "This is Football 2004 [Red Devils 2004]"
   region: "PAL-BE"
@@ -3765,11 +3770,11 @@ SCES-52460:
   region: "PAL-M7"
   compat: 5
   gsHWFixes:
-    roundSprite: 1 # Fix lines in the sky.
-    mipmap: 1
-    textureInsideRT: 1
-    autoFlush: 1
-    beforeDraw: "OI_JakGames"
+    mipmap: 2 # Fixes broken textures.
+    trilinearFiltering: 1 # Fixes water textures.
+    cpuSpriteRenderBW: 4 # Fixes character and water textures.
+    cpuSpriteRenderLevel: 2 # Needed for above.
+    autoFlush: 1 # Fixes lighting.
 SCES-52529:
   name: "Sly 2 - Band of Thieves"
   region: "PAL-M11"
@@ -3975,7 +3980,7 @@ SCES-53286:
     autoFlush: 1 # Fixes lighting.
     mipmap: 2 # Fixes bad textures.
     trilinearFiltering: 1 # Fixes smooths texture transitions.
-    beforeDraw: "OI_JakGames"
+    beforeDraw: "OI_JakX"
   memcardFilters: # Reads Ratchet Gladiator data.
     - "SCES-53286"
     - "SCES-53285"
@@ -4936,11 +4941,11 @@ SCKA-20010:
   name: "Jak II"
   region: "NTSC-K"
   gsHWFixes:
-    roundSprite: 1 # Fix lines in the sky.
-    mipmap: 1 # Fixes broken textures.
-    textureInsideRT: 1 # Fixes broken character models.
+    mipmap: 2 # Fixes broken textures.
+    trilinearFiltering: 1 # Fixes water textures.
+    cpuSpriteRenderBW: 4 # Fixes character and water textures.
+    cpuSpriteRenderLevel: 2 # Needed for above.
     autoFlush: 1 # Fixes lighting.
-    beforeDraw: "OI_JakGames"
 SCKA-20011:
   name: "Ratchet & Clank 2"
   region: "NTSC-K"
@@ -5109,11 +5114,11 @@ SCKA-20040:
   name: "Jak 3"
   region: "NTSC-K"
   gsHWFixes:
-    roundSprite: 1 # Fix lines in the sky.
-    mipmap: 1
-    textureInsideRT: 1
-    autoFlush: 1
-    beforeDraw: "OI_JakGames"
+    mipmap: 2 # Fixes broken textures.
+    trilinearFiltering: 1 # Fixes water textures.
+    cpuSpriteRenderBW: 4 # Fixes character and water textures.
+    cpuSpriteRenderLevel: 2 # Needed for above.
+    autoFlush: 1 # Fixes lighting.
 SCKA-20041:
   name: "EyeToy - Play 2"
   region: "NTSC-K"
@@ -5730,9 +5735,10 @@ SCPS-15021:
   name: "Jak x Daxter - Kyuusekai no Isan"
   region: "NTSC-J"
   gsHWFixes:
-    roundSprite: 1 # Fix lines in the sky.
-    mipmap: 1
-    textureInsideRT: 1
+    mipmap: 2 # Fixes broken textures.
+    trilinearFiltering: 1 # Fixes water textures.
+    cpuSpriteRenderBW: 4 # Fixes character and water textures.
+    cpuSpriteRenderLevel: 2 # Needed for above.
 SCPS-15022:
   name: "Dual Hearts"
   region: "NTSC-J"
@@ -5904,11 +5910,11 @@ SCPS-15057:
   name: "Jak and Daxter II"
   region: "NTSC-J"
   gsHWFixes:
-    roundSprite: 1 # Fix lines in the sky.
-    mipmap: 1
-    textureInsideRT: 1
-    autoFlush: 1
-    beforeDraw: "OI_JakGames"
+    mipmap: 2 # Fixes broken textures.
+    trilinearFiltering: 1 # Fixes water textures.
+    cpuSpriteRenderBW: 4 # Fixes character and water textures.
+    cpuSpriteRenderLevel: 2 # Needed for above.
+    autoFlush: 1 # Fixes lighting.
 SCPS-15058:
   name: "Arc the Lad - Generation"
   region: "NTSC-J"
@@ -6413,9 +6419,10 @@ SCPS-19210:
   name: "Jak x Daxter - Kyuusekai no Isan [PlayStation 2 The Best]"
   region: "NTSC-J"
   gsHWFixes:
-    roundSprite: 1 # Fix lines in the sky.
-    mipmap: 1
-    textureInsideRT: 1
+    mipmap: 2 # Fixes broken textures.
+    trilinearFiltering: 1 # Fixes water textures.
+    cpuSpriteRenderBW: 4 # Fixes character and water textures.
+    cpuSpriteRenderLevel: 2 # Needed for above.
 SCPS-19211:
   name: "Ratchet & Clank [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -6796,9 +6803,10 @@ SCPS-55004:
   name: "Jak x Daxter - Kyuusekai no Isan"
   region: "NTSC-J"
   gsHWFixes:
-    roundSprite: 1 # Fix lines in the sky.
-    mipmap: 1
-    textureInsideRT: 1
+    mipmap: 2 # Fixes broken textures.
+    trilinearFiltering: 1 # Fixes water textures.
+    cpuSpriteRenderBW: 4 # Fixes character and water textures.
+    cpuSpriteRenderLevel: 2 # Needed for above.
 SCPS-55005:
   name: "Gran Turismo - Concept 2001 Tokyo"
   region: "NTSC-J"
@@ -7049,9 +7057,10 @@ SCPS-56003:
   name: "Jak and Daxter - The Precursor Legacy"
   region: "NTSC-K"
   gsHWFixes:
-    roundSprite: 1 # Fix lines in the sky.
-    mipmap: 1
-    textureInsideRT: 1
+    mipmap: 2 # Fixes broken textures.
+    trilinearFiltering: 1 # Fixes water textures.
+    cpuSpriteRenderBW: 4 # Fixes character and water textures.
+    cpuSpriteRenderLevel: 2 # Needed for above.
 SCPS-56004:
   name: "Otostaz"
   region: "NTSC-K"
@@ -7224,9 +7233,10 @@ SCUS-97124:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    roundSprite: 1 # Fix lines in the sky.
-    mipmap: 1
-    textureInsideRT: 1
+    mipmap: 2 # Fixes broken textures.
+    trilinearFiltering: 1 # Fixes water textures.
+    cpuSpriteRenderBW: 4 # Fixes character and water textures.
+    cpuSpriteRenderLevel: 2 # Needed for above.
 SCUS-97125:
   name: "Frequency"
   region: "NTSC-U"
@@ -7409,16 +7419,18 @@ SCUS-97170:
   name: "Jak and Daxter - The Precursor Legacy [Cingular Wireless Demo]"
   region: "NTSC-U"
   gsHWFixes:
-    roundSprite: 1 # Fix lines in the sky.
-    mipmap: 1
-    textureInsideRT: 1
+    mipmap: 2 # Fixes broken textures.
+    trilinearFiltering: 1 # Fixes water textures.
+    cpuSpriteRenderBW: 4 # Fixes character and water textures.
+    cpuSpriteRenderLevel: 2 # Needed for above.
 SCUS-97171:
   name: "Jak and Daxter - The Precursor Legacy [PS Underground Demo]"
   region: "NTSC-U"
   gsHWFixes:
-    roundSprite: 1 # Fix lines in the sky.
-    mipmap: 1
-    textureInsideRT: 1
+    mipmap: 2 # Fixes broken textures.
+    trilinearFiltering: 1 # Fixes water textures.
+    cpuSpriteRenderBW: 4 # Fixes character and water textures.
+    cpuSpriteRenderLevel: 2 # Needed for above.
 SCUS-97172:
   name: "World Tour Soccer 2002"
   region: "NTSC-U"
@@ -7763,11 +7775,11 @@ SCUS-97265:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    roundSprite: 1 # Fix lines in the sky.
-    mipmap: 1 # Fixes broken textures.
-    textureInsideRT: 1 # Fixes broken character models.
+    mipmap: 2 # Fixes broken textures.
+    trilinearFiltering: 1 # Fixes water textures.
+    cpuSpriteRenderBW: 4 # Fixes character and water textures.
+    cpuSpriteRenderLevel: 2 # Needed for above.
     autoFlush: 1 # Fixes lighting.
-    beforeDraw: "OI_JakGames"
 SCUS-97266:
   name: "Final Fantasy XI [Disc 1 of 2]"
   region: "NTSC-U"
@@ -7802,11 +7814,11 @@ SCUS-97273:
   name: "Jak II [Demo]"
   region: "NTSC-U"
   gsHWFixes:
-    roundSprite: 1 # Fix lines in the sky.
-    mipmap: 1 # Fixes broken textures.
-    textureInsideRT: 1 # Fixes broken character models.
+    mipmap: 2 # Fixes broken textures.
+    trilinearFiltering: 1 # Fixes water textures.
+    cpuSpriteRenderBW: 4 # Fixes character and water textures.
+    cpuSpriteRenderLevel: 2 # Needed for above.
     autoFlush: 1 # Fixes lighting.
-    beforeDraw: "OI_JakGames"
 SCUS-97274:
   name: "Jak II [Video Demo]"
   region: "NTSC-U"
@@ -7928,11 +7940,11 @@ SCUS-97330:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    roundSprite: 1 # Fix lines in the sky.
-    mipmap: 1
-    textureInsideRT: 1
-    autoFlush: 1
-    beforeDraw: "OI_JakGames"
+    mipmap: 2 # Fixes broken textures.
+    trilinearFiltering: 1 # Fixes water textures.
+    cpuSpriteRenderBW: 4 # Fixes character and water textures.
+    cpuSpriteRenderLevel: 2 # Needed for above.
+    autoFlush: 1 # Fixes lighting.
 SCUS-97331:
   name: "Official U.S. PlayStation Magazine Demo Disc 078"
   region: "NTSC-U"
@@ -8055,7 +8067,7 @@ SCUS-97374:
     mipmap: 1 # Fixes broken textures.
     textureInsideRT: 1 # Fixes broken character models.
     autoFlush: 1 # Fixes lighting.
-    beforeDraw: "OI_JakGames"
+    beforeDraw: "OI_JakX"
 SCUS-97377:
   name: "Syphon Filter - The Omega Strain [Regular Demo]"
   region: "NTSC-U"
@@ -8178,11 +8190,11 @@ SCUS-97412:
   name: "Jak 3 [Demo]"
   region: "NTSC-U"
   gsHWFixes:
-    roundSprite: 1 # Fix lines in the sky.
-    mipmap: 1
-    textureInsideRT: 1
-    autoFlush: 1
-    beforeDraw: "OI_JakGames"
+    mipmap: 2 # Fixes broken textures.
+    trilinearFiltering: 1 # Fixes water textures.
+    cpuSpriteRenderBW: 4 # Fixes character and water textures.
+    cpuSpriteRenderLevel: 2 # Needed for above.
+    autoFlush: 1 # Fixes lighting.
 SCUS-97413:
   name: "Ratchet & Clank - Up Your Arsenal [Public Beta v1.0]"
   region: "NTSC-U"
@@ -8253,7 +8265,7 @@ SCUS-97429:
     autoFlush: 1 # Fixes lighting.
     mipmap: 2 # Fixes bad textures.
     trilinearFiltering: 1 # Fixes smooths texture transitions.
-    beforeDraw: "OI_JakGames"
+    beforeDraw: "OI_JakX"
   memcardFilters:
     - "SCUS-97429"
     - "SCUS-97465"
@@ -8305,10 +8317,11 @@ SCUS-97440:
   name: "Jak and Daxter Trilogy [Demo]"
   region: "NTSC-U"
   gsHWFixes:
-    roundSprite: 1 # Fix lines in the sky.
-    mipmap: 1
-    textureInsideRT: 1
-    autoFlush: 1
+    mipmap: 2 # Fixes broken textures.
+    trilinearFiltering: 1 # Fixes water textures.
+    cpuSpriteRenderBW: 4 # Fixes character and water textures.
+    cpuSpriteRenderLevel: 2 # Needed for above.
+    autoFlush: 1 # Fixes lighting.
 SCUS-97441:
   name: "Getaway The - Black Monday [Demo]"
   region: "NTSC-U"
@@ -8525,7 +8538,7 @@ SCUS-97486:
     autoFlush: 1 # Fixes lighting.
     mipmap: 2 # Fixes bad textures.
     trilinearFiltering: 1 # Fixes smooths texture transitions.
-    beforeDraw: "OI_JakGames"
+    beforeDraw: "OI_JakX"
 SCUS-97487:
   name: "Ratchet - Deadlocked [Public Beta v.1]"
   region: "NTSC-U"
@@ -8547,7 +8560,7 @@ SCUS-97488:
     autoFlush: 1 # Fixes lighting.
     mipmap: 2 # Fixes bad textures.
     trilinearFiltering: 1 # Fixes smooths texture transitions.
-    beforeDraw: "OI_JakGames"
+    beforeDraw: "OI_JakX"
 SCUS-97489:
   name: "SOCOM 3 - U.S. Navy SEALs [Public Beta v.1]"
   region: "NTSC-U"
@@ -8631,11 +8644,11 @@ SCUS-97509:
   name: "Jak II [Greatest Hits]"
   region: "NTSC-U"
   gsHWFixes:
-    roundSprite: 1 # Fix lines in the sky.
-    mipmap: 1 # Fixes broken textures.
-    textureInsideRT: 1 # Fixes broken character models.
+    mipmap: 2 # Fixes broken textures.
+    trilinearFiltering: 1 # Fixes water textures.
+    cpuSpriteRenderBW: 4 # Fixes character and water textures.
+    cpuSpriteRenderLevel: 2 # Needed for above.
     autoFlush: 1 # Fixes lighting.
-    beforeDraw: "OI_JakGames"
 SCUS-97510:
   name: "ATV Offroad Fury 2 [Greatest Hits]"
   region: "NTSC-U"
@@ -8676,11 +8689,11 @@ SCUS-97516:
   name: "Jak 3 [Greatest Hits]"
   region: "NTSC-U"
   gsHWFixes:
-    roundSprite: 1 # Fix lines in the sky.
-    mipmap: 1
-    textureInsideRT: 1
-    autoFlush: 1
-    beforeDraw: "OI_JakGames"
+    mipmap: 2 # Fixes broken textures.
+    trilinearFiltering: 1 # Fixes water textures.
+    cpuSpriteRenderBW: 4 # Fixes character and water textures.
+    cpuSpriteRenderLevel: 2 # Needed for above.
+    autoFlush: 1 # Fixes lighting.
 SCUS-97517:
   name: "Killzone [Greatest Hits]"
   region: "NTSC-U"
@@ -8797,10 +8810,10 @@ SCUS-97555:
   name: "Jak and Daxter Complete Trilogy [Demo]"
   region: "NTSC-U"
   gsHWFixes:
-    roundSprite: 1 # Fix lines in the sky.
-    mipmap: 1
-    textureInsideRT: 1
-    beforeDraw: "OI_JakGames"
+    mipmap: 2 # Fixes broken textures.
+    trilinearFiltering: 1 # Fixes water textures.
+    cpuSpriteRenderBW: 4 # Fixes character and water textures.
+    cpuSpriteRenderLevel: 2 # Needed for above.
 SCUS-97556:
   name: "MLB '07 - The Show"
   region: "NTSC-U"
@@ -8848,7 +8861,7 @@ SCUS-97574:
     autoFlush: 1 # Fixes lighting.
     mipmap: 2 # Fixes bad textures.
     trilinearFiltering: 1 # Fixes smooths texture transitions.
-    beforeDraw: "OI_JakGames"
+    beforeDraw: "OI_JakX"
 SCUS-97579:
   name: "ATV Offroad Fury 4 [Demo]"
   region: "NTSC-U"
@@ -51878,7 +51891,7 @@ TCES-53286:
     autoFlush: 1 # Fixes lighting.
     mipmap: 2 # Fixes bad textures.
     trilinearFiltering: 1 # Fixes smooths texture transitions.
-    beforeDraw: "OI_JakGames"
+    beforeDraw: "OI_JakX"
 TCPS-10058:
   name: "Densha de Go! Shinkansen [with Controller]"
   region: "NTSC-J"

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -186,16 +186,9 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsDialog* dialog, QWidget* 
 		sif, m_ui.blending, "EmuCore/GS", "accurate_blending_unit", static_cast<int>(AccBlendLevel::Basic));
 	SettingWidgetBinder::BindWidgetToIntSetting(
 		sif, m_ui.texturePreloading, "EmuCore/GS", "texture_preloading", static_cast<int>(TexturePreloadingLevel::Off));
-
 	connect(m_ui.trilinearFiltering, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
 		&GraphicsSettingsWidget::onTrilinearFilteringChanged);
-	connect(m_ui.gpuPaletteConversion, QOverload<int>::of(&QCheckBox::stateChanged), this,
-		&GraphicsSettingsWidget::onGpuPaletteConversionChanged);
-	connect(m_ui.textureInsideRt, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
-		&GraphicsSettingsWidget::onTextureInsideRtChanged);
 	onTrilinearFilteringChanged();
-	onGpuPaletteConversionChanged(m_ui.gpuPaletteConversion->checkState());
-	onTextureInsideRtChanged();
 
 	//////////////////////////////////////////////////////////////////////////
 	// HW Renderer Fixes
@@ -203,6 +196,7 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsDialog* dialog, QWidget* 
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.crcFixLevel, "EmuCore/GS", "crc_hack_level", static_cast<int>(CRCHackLevel::Automatic), -1);
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.halfScreenFix, "EmuCore/GS", "UserHacks_Half_Bottom_Override", -1, -1);
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.cpuSpriteRenderBW, "EmuCore/GS", "UserHacks_CPUSpriteRenderBW", 0);
+	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.cpuSpriteRenderLevel, "EmuCore/GS", "UserHacks_CPUSpriteRenderLevel", 0);
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.cpuCLUTRender, "EmuCore/GS", "UserHacks_CPUCLUTRender", 0);
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.gpuTargetCLUTMode, "EmuCore/GS", "UserHacks_GPUTargetCLUTMode", 0);
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.skipDrawStart, "EmuCore/GS", "UserHacks_SkipDraw_Start", 0);
@@ -220,6 +214,15 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsDialog* dialog, QWidget* 
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.targetPartialInvalidation, "EmuCore/GS", "UserHacks_TargetPartialInvalidation", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.estimateTextureRegion, "EmuCore/GS", "UserHacks_EstimateTextureRegion", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.gpuPaletteConversion, "EmuCore/GS", "paltex", false);
+	connect(m_ui.cpuSpriteRenderBW, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
+		&GraphicsSettingsWidget::onCPUSpriteRenderBWChanged);
+	connect(m_ui.textureInsideRt, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
+		&GraphicsSettingsWidget::onTextureInsideRtChanged);
+	connect(m_ui.gpuPaletteConversion, QOverload<int>::of(&QCheckBox::stateChanged), this,
+		&GraphicsSettingsWidget::onGpuPaletteConversionChanged);
+	onCPUSpriteRenderBWChanged();
+	onTextureInsideRtChanged();
+	onGpuPaletteConversionChanged(m_ui.gpuPaletteConversion->checkState());
 
 	//////////////////////////////////////////////////////////////////////////
 	// HW Upscaling Fixes
@@ -887,6 +890,12 @@ void GraphicsSettingsWidget::onGpuPaletteConversionChanged(int state)
 		state == Qt::CheckState::PartiallyChecked ? Host::GetBaseBoolSettingValue("EmuCore/GS", "paltex", false) : (state != 0);
 
 	m_ui.anisotropicFiltering->setDisabled(disabled);
+}
+
+void GraphicsSettingsWidget::onCPUSpriteRenderBWChanged()
+{
+	const int value = m_dialog->getEffectiveIntValue("EmuCore/GS", "UserHacks_CPUSpriteRenderBW", 0);
+	m_ui.cpuSpriteRenderLevel->setEnabled(value != 0);
 }
 
 void GraphicsSettingsWidget::onTextureInsideRtChanged()

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.h
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.h
@@ -41,6 +41,7 @@ private Q_SLOTS:
 	void onAdapterChanged(int index);
 	void onTrilinearFilteringChanged();
 	void onGpuPaletteConversionChanged(int state);
+	void onCPUSpriteRenderBWChanged();
 	void onTextureInsideRtChanged();
 	void onFullscreenModeChanged(int index);
 	void onShadeBoostChanged();

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
@@ -813,65 +813,6 @@
          </property>
         </widget>
        </item>
-       <item row="2" column="1">
-        <widget class="QComboBox" name="cpuSpriteRenderBW">
-         <item>
-          <property name="text">
-           <string>0 (Disabled)</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>1 (64 Max Width)</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>2 (128 Max Width)</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>3 (192 Max Width)</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>4 (256 Max Width)</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>5 (320 Max Width)</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>6 (384 Max Width)</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>7 (448 Max Width)</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>8 (512 Max Width)</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>9 (576 Max Width)</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>10 (640 Max Width)</string>
-          </property>
-         </item>
-        </widget>
-       </item>
        <item row="3" column="0">
         <widget class="QLabel" name="label_16">
          <property name="text">
@@ -1095,6 +1036,88 @@
           </property>
          </item>
         </widget>
+       </item>
+       <item row="2" column="1">
+        <layout class="QHBoxLayout" name="horizontalLayout_5" stretch="1,0">
+         <item>
+          <widget class="QComboBox" name="cpuSpriteRenderBW">
+           <item>
+            <property name="text">
+             <string>0 (Disabled)</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>1 (64 Max Width)</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>2 (128 Max Width)</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>3 (192 Max Width)</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>4 (256 Max Width)</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>5 (320 Max Width)</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>6 (384 Max Width)</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>7 (448 Max Width)</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>8 (512 Max Width)</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>9 (576 Max Width)</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>10 (640 Max Width)</string>
+            </property>
+           </item>
+          </widget>
+         </item>
+         <item>
+          <widget class="QComboBox" name="cpuSpriteRenderLevel">
+           <item>
+            <property name="text">
+             <string>Sprites Only</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Sprites/Triangles</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Blended Sprites/Triangles</string>
+            </property>
+           </item>
+          </widget>
+         </item>
+        </layout>
        </item>
       </layout>
      </widget>

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -753,7 +753,8 @@ struct Pcsx2Config
 		int UserHacks_TCOffsetX{0};
 		int UserHacks_TCOffsetY{0};
 		int UserHacks_CPUSpriteRenderBW{0};
-		int UserHacks_CPUCLUTRender{ 0 };
+		int UserHacks_CPUSpriteRenderLevel{0};
+		int UserHacks_CPUCLUTRender{0};
 		GSGPUTargetCLUTMode UserHacks_GPUTargetCLUTMode{GSGPUTargetCLUTMode::Disabled};
 		GSTextureInRtMode UserHacks_TextureInsideRt{GSTextureInRtMode::Disabled};
 		TriFiltering TriFilter{TriFiltering::Automatic};

--- a/pcsx2/Docs/gamedb-schema.json
+++ b/pcsx2/Docs/gamedb-schema.json
@@ -241,6 +241,11 @@
               "minimum": 1,
               "maximum": 10
             },
+            "cpuSpriteRenderLevel": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 2
+            },
             "cpuCLUTRender": {
               "type": "integer",
               "minimum": 1,

--- a/pcsx2/Frontend/FullscreenUI.cpp
+++ b/pcsx2/Frontend/FullscreenUI.cpp
@@ -3170,6 +3170,8 @@ void FullscreenUI::DrawGraphicsSettingsPage()
 			static constexpr const char* s_cpu_sprite_render_bw_options[] = {"0 (Disabled)", "1 (64 Max Width)", "2 (128 Max Width)",
 				"3 (192 Max Width)", "4 (256 Max Width)", "5 (320 Max Width)", "6 (384 Max Width)", "7 (448 Max Width)",
 				"8 (512 Max Width)", "9 (576 Max Width)", "10 (640 Max Width)"};
+			static constexpr const char* s_cpu_sprite_render_level_options[] = {
+				"Sprites Only", "Sprites/Triangles", "Blended Sprites/Triangles"};
 			static constexpr const char* s_cpu_clut_render_options[] = {"0 (Disabled)", "1 (Normal)", "2 (Aggressive)"};
 			static constexpr const char* s_texture_inside_rt_options[] = {"Disabled", "Inside Target", "Merge Targets"};
 			static constexpr const char* s_half_pixel_offset_options[] = {
@@ -3182,6 +3184,8 @@ void FullscreenUI::DrawGraphicsSettingsPage()
 				"UserHacks_Half_Bottom_Override", -1, s_generic_options, std::size(s_generic_options), -1);
 			DrawIntListSetting(bsi, "CPU Sprite Render Size", "Uses software renderer to draw texture decompression-like sprites.",
 				"EmuCore/GS", "UserHacks_CPUSpriteRenderBW", 0, s_cpu_sprite_render_bw_options, std::size(s_cpu_sprite_render_bw_options));
+			DrawIntListSetting(bsi, "CPU Sprite Render Level", "Determines filter level for CPU sprite render.", "EmuCore/GS",
+				"UserHacks_CPUSpriteRenderLevel", 0, s_cpu_sprite_render_level_options, std::size(s_cpu_sprite_render_level_options));
 			DrawIntListSetting(bsi, "Software CLUT Render", "Uses software renderer to draw texture CLUT points/sprites.", "EmuCore/GS",
 				"UserHacks_CPUCLUTRender", 0, s_cpu_clut_render_options, std::size(s_cpu_clut_render_options));
 			DrawIntSpinBoxSetting(

--- a/pcsx2/Frontend/ImGuiOverlays.cpp
+++ b/pcsx2/Frontend/ImGuiOverlays.cpp
@@ -404,7 +404,7 @@ void ImGuiManager::DrawSettingsOverlay()
 		if (GSConfig.UserHacks_TCOffsetX != 0 || GSConfig.UserHacks_TCOffsetY != 0)
 			APPEND("TCO={}/{} ", GSConfig.UserHacks_TCOffsetX, GSConfig.UserHacks_TCOffsetY);
 		if (GSConfig.UserHacks_CPUSpriteRenderBW != 0)
-			APPEND("CSBW={} ", GSConfig.UserHacks_CPUSpriteRenderBW);
+			APPEND("CSBW={}/{} ", GSConfig.UserHacks_CPUSpriteRenderBW, GSConfig.UserHacks_CPUSpriteRenderLevel);
 		if (GSConfig.UserHacks_CPUCLUTRender != 0)
 			APPEND("CCLUT={} ", GSConfig.UserHacks_CPUCLUTRender);
 		if (GSConfig.UserHacks_GPUTargetCLUTMode != GSGPUTargetCLUTMode::Disabled)

--- a/pcsx2/GS/Renderers/HW/GSHwHack.cpp
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.cpp
@@ -1094,7 +1094,7 @@ bool GSHwHack::OI_ArTonelico2(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GST
 	return true;
 }
 
-bool GSHwHack::OI_JakGames(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t)
+bool GSHwHack::OI_JakX(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t)
 {
 	if (RCONTEXT->FRAME.FBW != 1 || !(r.m_r == GSVector4i(0, 0, 16, 16)).alltrue())
 		return true; // Only 16x16 draws.
@@ -1236,7 +1236,7 @@ const GSHwHack::Entry<GSRendererHW::OI_Ptr> GSHwHack::s_before_draw_functions[] 
 	CRC_F(OI_RozenMaidenGebetGarden, CRCHackLevel::Minimum),
 	CRC_F(OI_SonicUnleashed, CRCHackLevel::Minimum),
 	CRC_F(OI_ArTonelico2, CRCHackLevel::Minimum),
-	CRC_F(OI_JakGames, CRCHackLevel::Minimum),
+	CRC_F(OI_JakX, CRCHackLevel::Minimum),
 	CRC_F(OI_BurnoutGames, CRCHackLevel::Minimum),
 	CRC_F(OI_Battlefield2, CRCHackLevel::Minimum),
 };

--- a/pcsx2/GS/Renderers/HW/GSHwHack.cpp
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.cpp
@@ -1094,20 +1094,6 @@ bool GSHwHack::OI_ArTonelico2(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GST
 	return true;
 }
 
-bool GSHwHack::OI_JakX(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t)
-{
-	if (RCONTEXT->FRAME.FBW != 1 || !(r.m_r == GSVector4i(0, 0, 16, 16)).alltrue())
-		return true; // Only 16x16 draws.
-
-	if (!r.CanUseSwSpriteRender())
-		return true;
-
-	// Render 16x16 palette via CPU.
-	r.SwSpriteRender();
-
-	return false; // Skip current draw.
-}
-
 bool GSHwHack::OI_BurnoutGames(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t)
 {
 	if (!OI_PointListPalette(r, rt, ds, t))
@@ -1236,7 +1222,6 @@ const GSHwHack::Entry<GSRendererHW::OI_Ptr> GSHwHack::s_before_draw_functions[] 
 	CRC_F(OI_RozenMaidenGebetGarden, CRCHackLevel::Minimum),
 	CRC_F(OI_SonicUnleashed, CRCHackLevel::Minimum),
 	CRC_F(OI_ArTonelico2, CRCHackLevel::Minimum),
-	CRC_F(OI_JakX, CRCHackLevel::Minimum),
 	CRC_F(OI_BurnoutGames, CRCHackLevel::Minimum),
 	CRC_F(OI_Battlefield2, CRCHackLevel::Minimum),
 };

--- a/pcsx2/GS/Renderers/HW/GSHwHack.h
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.h
@@ -61,7 +61,6 @@ public:
 	static bool OI_RozenMaidenGebetGarden(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
 	static bool OI_SonicUnleashed(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
 	static bool OI_ArTonelico2(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
-	static bool OI_JakX(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
 	static bool OI_BurnoutGames(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
 
 	static bool OI_Battlefield2(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);

--- a/pcsx2/GS/Renderers/HW/GSHwHack.h
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.h
@@ -61,7 +61,7 @@ public:
 	static bool OI_RozenMaidenGebetGarden(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
 	static bool OI_SonicUnleashed(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
 	static bool OI_ArTonelico2(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
-	static bool OI_JakGames(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
+	static bool OI_JakX(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
 	static bool OI_BurnoutGames(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
 
 	static bool OI_Battlefield2(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -4553,40 +4553,42 @@ GSRendererHW::CLUTDrawTestResult GSRendererHW::PossibleCLUTDrawAggressive()
 bool GSRendererHW::CanUseSwPrimRender(bool no_rt, bool no_ds, bool draw_sprite_tex)
 {
 	// Master enable.
-	if (GSConfig.UserHacks_CPUSpriteRenderBW == 0)
+	const int bw = GSConfig.UserHacks_CPUSpriteRenderBW;
+	const int level = GSConfig.UserHacks_CPUSpriteRenderLevel;
+	if (bw == 0)
 		return false;
 
 	// We don't ever want to do this when we have a depth buffer, and only for textured sprites.
-	if (no_rt || !no_ds || !draw_sprite_tex)
+	if (no_rt || !no_ds || (level == 0 && !draw_sprite_tex))
 		return false;
 
 	// Check the size threshold. Spider-man 2 uses a FBW of 32 for some silly reason...
-	if (m_context->FRAME.FBW > static_cast<u32>(GSConfig.UserHacks_CPUSpriteRenderBW) && m_context->FRAME.FBW != 32)
+	if (m_context->FRAME.FBW > static_cast<u32>(bw) && m_context->FRAME.FBW != 32)
 		return false;
 
 	// We shouldn't be using mipmapping, and this shouldn't be a blended draw.
-	// TODO: Jak 3 builds textures semi-procedurally using blending, and would be a good candidate here.
-	if (IsMipMapActive() || !IsOpaque())
+	if (level < 2 && (IsMipMapActive() || !IsOpaque()))
 		return false;
 
 	// Make sure this isn't something we've actually rendered to (e.g. a texture shuffle).
-	// We do this by checking the texture block width against the target's block width, as all the decompression draws
-	// will use a much smaller block size than the framebuffer.
-	GSTextureCache::Target* src_target = m_tc->GetTargetWithSharedBits(m_context->TEX0.TBP0, m_context->TEX0.PSM);
-	if (src_target && src_target->m_TEX0.TBW == m_context->TEX0.TBW)
+	if (PRIM->TME)
 	{
-		// If the EE has written over our sample area, we're fine to do this on the CPU, despite the target.
-		if (!src_target->m_dirty.empty())
+		GSTextureCache::Target* src_target = m_tc->GetTargetWithSharedBits(m_context->TEX0.TBP0, m_context->TEX0.PSM);
+		if (src_target)
 		{
-			const GSVector4i tr(GetTextureMinMax(m_context->TEX0, m_context->CLAMP, m_vt.IsLinear()).coverage);
-			for (GSDirtyRect& rc : src_target->m_dirty)
+			// If the EE has written over our sample area, we're fine to do this on the CPU, despite the target.
+			if (!src_target->m_dirty.empty())
 			{
-				if (!rc.GetDirtyRect(m_context->TEX0).rintersect(tr).rempty())
-					return true;
+				const GSVector4i tr(GetTextureMinMax(m_context->TEX0, m_context->CLAMP, m_vt.IsLinear()).coverage);
+				for (GSDirtyRect& rc : src_target->m_dirty)
+				{
+					if (!rc.GetDirtyRect(m_context->TEX0).rintersect(tr).rempty())
+						return true;
+				}
 			}
-		}
 
-		return false;
+			return false;
+		}
 	}
 
 	// We can use the sw prim render path!

--- a/pcsx2/GameDatabase.cpp
+++ b/pcsx2/GameDatabase.cpp
@@ -366,6 +366,7 @@ static const char* s_gs_hw_fix_names[] = {
 	"texturePreloading",
 	"deinterlace",
 	"cpuSpriteRenderBW",
+	"cpuSpriteRenderLevel",
 	"cpuCLUTRender",
 	"gpuTargetCLUT",
 	"gpuPaletteConversion",
@@ -631,6 +632,9 @@ bool GameDatabaseSchema::GameEntry::configMatchesHWFix(const Pcsx2Config::GSOpti
 		case GSHWFixId::CPUSpriteRenderBW:
 			return (config.UserHacks_CPUSpriteRenderBW == value);
 
+		case GSHWFixId::CPUSpriteRenderLevel:
+			return (config.UserHacks_CPUSpriteRenderLevel == value);
+
 		case GSHWFixId::CPUCLUTRender:
 			return (config.UserHacks_CPUCLUTRender == value);
 
@@ -812,6 +816,10 @@ u32 GameDatabaseSchema::GameEntry::applyGSHardwareFixes(Pcsx2Config::GSOptions& 
 
 			case GSHWFixId::CPUSpriteRenderBW:
 				config.UserHacks_CPUSpriteRenderBW = value;
+				break;
+
+			case GSHWFixId::CPUSpriteRenderLevel:
+				config.UserHacks_CPUSpriteRenderLevel = value;
 				break;
 
 			case GSHWFixId::CPUCLUTRender:

--- a/pcsx2/GameDatabase.h
+++ b/pcsx2/GameDatabase.h
@@ -87,6 +87,7 @@ namespace GameDatabaseSchema
 		TexturePreloading,
 		Deinterlace,
 		CPUSpriteRenderBW,
+		CPUSpriteRenderLevel,
 		CPUCLUTRender,
 		GPUTargetCLUT,
 		GPUPaletteConversion,

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -524,6 +524,7 @@ bool Pcsx2Config::GSOptions::OptionsAreEqual(const GSOptions& right) const
 		OpEqu(UserHacks_TCOffsetX) &&
 		OpEqu(UserHacks_TCOffsetY) &&
 		OpEqu(UserHacks_CPUSpriteRenderBW) &&
+		OpEqu(UserHacks_CPUSpriteRenderLevel) &&
 		OpEqu(UserHacks_CPUCLUTRender) &&
 		OpEqu(UserHacks_GPUTargetCLUTMode) &&
 		OpEqu(UserHacks_TextureInsideRt) &&
@@ -717,6 +718,7 @@ void Pcsx2Config::GSOptions::LoadSave(SettingsWrapper& wrap)
 	GSSettingIntEx(UserHacks_TCOffsetX, "UserHacks_TCOffsetX");
 	GSSettingIntEx(UserHacks_TCOffsetY, "UserHacks_TCOffsetY");
 	GSSettingIntEx(UserHacks_CPUSpriteRenderBW, "UserHacks_CPUSpriteRenderBW");
+	GSSettingIntEx(UserHacks_CPUSpriteRenderLevel, "UserHacks_CPUSpriteRenderLevel");
 	GSSettingIntEx(UserHacks_CPUCLUTRender, "UserHacks_CPUCLUTRender");
 	GSSettingIntEnumEx(UserHacks_GPUTargetCLUTMode, "UserHacks_GPUTargetCLUTMode");
 	GSSettingIntEnumEx(TriFilter, "TriFilter");
@@ -792,6 +794,7 @@ void Pcsx2Config::GSOptions::MaskUserHacks()
 	UserHacks_TCOffsetX = 0;
 	UserHacks_TCOffsetY = 0;
 	UserHacks_CPUSpriteRenderBW = 0;
+	UserHacks_CPUSpriteRenderLevel = 0;
 	UserHacks_CPUCLUTRender = 0;
 	UserHacks_GPUTargetCLUTMode = GSGPUTargetCLUTMode::Disabled;
 	SkipDrawStart = 0;


### PR DESCRIPTION
### Description of Changes

Jak uses colloquially known as "mip tricks" for its water, giving it a different appearance the more it's minified based on how large the texture appears on screen.

We can't texture-inside-RT for mip chains at the moment, so punting it to the CPU is realistically the only option to handle this for now.

Unfortunately the CRC hack still has to stay there for Jak X.. sprite render ends up with a box in the top-left corner.

### Rationale behind Changes

Before:
<img width="601" alt="Untitled" src="https://user-images.githubusercontent.com/11288319/226176405-1d6a1841-2ad4-405e-a27a-804c6f8511fb.png">

After:
<img width="599" alt="Untitled" src="https://user-images.githubusercontent.com/11288319/226176305-9d120f8b-52e7-4855-8644-5ba7294620b9.png">

### Suggested Testing Steps

Need to test a bit more of all three Jak games to make sure this isn't triggering incorrectly. If it does, please post a GS dump so I can investigate.