### PR TITLE
GS-TC: mask target rect with drawn area before download.

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -2418,7 +2418,7 @@ void GSTextureCache::InvalidateLocalMem(const GSOffset& off, const GSVector4i& r
 				{
 					t->m_drawn_since_read = GSVector4i::zero();
 				}
-				else if (targetr.width() == t->m_drawn_since_read.width()
+				else if (targetr.xzxz().eq(t->m_drawn_since_read.xzxz())
 					&& targetr.w >= t->m_drawn_since_read.y)
 				{
 					if (targetr.y <= t->m_drawn_since_read.y)
@@ -2426,7 +2426,7 @@ void GSTextureCache::InvalidateLocalMem(const GSOffset& off, const GSVector4i& r
 					else if (targetr.w >= t->m_drawn_since_read.w)
 						t->m_drawn_since_read.w = targetr.y;
 				}
-				else if (targetr.height() == t->m_drawn_since_read.height()
+				else if (targetr.ywyw().eq(t->m_drawn_since_read.ywyw())
 					&& targetr.z >= t->m_drawn_since_read.x)
 				{
 					if (targetr.x <= t->m_drawn_since_read.x)


### PR DESCRIPTION
### Description of Changes
On local mem invalidation, make sure we mask the target with the drawn area for that target before we try to download from it.

### Rationale behind Changes
This was causing a misdetection in Shadow Hearts - From The New World, as the game starts trying to double buffer, then decides to use offsets instead, and we don't handle "draw inside RT" style draws currently, so it kinda gets in to a mess. While this isn't the perfect solution here, it's still correct to check the area drawn is what we need from the current target.

### Suggested Testing Steps
Test Shadow Hearts - From The New World, I  guess a spattering of other games which do readbacks (Though I'm not expecting any change anywhere else, this was still happening, just later, in the wrong place)
