### PR TITLE
CrashHandler: Print backtrace on Linux

### DIFF
--- a/.github/workflows/scripts/linux/build-dependencies-qt.sh
+++ b/.github/workflows/scripts/linux/build-dependencies-qt.sh
@@ -6,12 +6,14 @@ INSTALLDIR="$HOME/deps"
 NPROCS="$(getconf _NPROCESSORS_ONLN)"
 SDL=SDL2-2.26.0
 QT=6.3.1
+LIBBACKTRACE=ad106d5fdd5d960bd33fae1c48a351af567fd075
 
 mkdir -p deps-build
 cd deps-build
 
 cat > SHASUMS <<EOF
 8000d7169febce93c84b6bdf376631f8179132fd69f7015d4dadb8b9c2bdb295  $SDL.tar.gz
+fd6f417fe9e3a071cf1424a5152d926a34c4a3c5070745470be6cf12a404ed79  $LIBBACKTRACE.zip
 0a64421d9c2469c2c48490a032ab91d547017c9cc171f3f8070bc31888f24e03  qtbase-everywhere-src-$QT.tar.xz
 7b19f418e6f7b8e23344082dd04440aacf5da23c5a73980ba22ae4eba4f87df7  qtsvg-everywhere-src-$QT.tar.xz
 c412750f2aa3beb93fce5f30517c607f55daaeb7d0407af206a8adf917e126c1  qttools-everywhere-src-$QT.tar.xz
@@ -21,6 +23,7 @@ EOF
 
 curl -L \
 	-O "https://libsdl.org/release/$SDL.tar.gz" \
+	-O "https://github.com/ianlancetaylor/libbacktrace/archive/$LIBBACKTRACE.zip" \
 	-O "https://download.qt.io/official_releases/qt/${QT%.*}/$QT/submodules/qtbase-everywhere-src-$QT.tar.xz" \
 	-O "https://download.qt.io/official_releases/qt/${QT%.*}/$QT/submodules/qtsvg-everywhere-src-$QT.tar.xz" \
 	-O "https://download.qt.io/official_releases/qt/${QT%.*}/$QT/submodules/qttools-everywhere-src-$QT.tar.xz" \
@@ -34,6 +37,14 @@ tar xf "$SDL.tar.gz"
 cd "$SDL"
 ./configure --prefix "$INSTALLDIR" --disable-dbus --without-x --disable-video-opengl --disable-video-opengles --disable-video-vulkan --disable-wayland-shared --disable-ime --disable-oss --disable-alsa --disable-jack --disable-esd --disable-pipewire --disable-pulseaudio --disable-arts --disable-nas --disable-sndio --disable-fusionsound --disable-diskaudio
 make "-j$NPROCS"
+make install
+cd ..
+
+echo "Building libbacktrace..."
+unzip "$LIBBACKTRACE.zip"
+cd "libbacktrace-$LIBBACKTRACE"
+./configure --prefix="$HOME/deps"
+make
 make install
 cd ..
 

--- a/.github/workflows/scripts/linux/build-dependencies-qt.sh
+++ b/.github/workflows/scripts/linux/build-dependencies-qt.sh
@@ -4,21 +4,21 @@ set -e
 
 INSTALLDIR="$HOME/deps"
 NPROCS="$(getconf _NPROCESSORS_ONLN)"
-SDL=SDL2-2.26.0
-QT=6.3.1
+SDL=SDL2-2.26.4
+QT=6.4.3
 LIBBACKTRACE=ad106d5fdd5d960bd33fae1c48a351af567fd075
 
 mkdir -p deps-build
 cd deps-build
 
 cat > SHASUMS <<EOF
-8000d7169febce93c84b6bdf376631f8179132fd69f7015d4dadb8b9c2bdb295  $SDL.tar.gz
+1a0f686498fb768ad9f3f80b39037a7d006eac093aad39cb4ebcc832a8887231  $SDL.tar.gz
 fd6f417fe9e3a071cf1424a5152d926a34c4a3c5070745470be6cf12a404ed79  $LIBBACKTRACE.zip
-0a64421d9c2469c2c48490a032ab91d547017c9cc171f3f8070bc31888f24e03  qtbase-everywhere-src-$QT.tar.xz
-7b19f418e6f7b8e23344082dd04440aacf5da23c5a73980ba22ae4eba4f87df7  qtsvg-everywhere-src-$QT.tar.xz
-c412750f2aa3beb93fce5f30517c607f55daaeb7d0407af206a8adf917e126c1  qttools-everywhere-src-$QT.tar.xz
-d7bdd55e2908ded901dcc262157100af2a490bf04d31e32995f6d91d78dfdb97  qttranslations-everywhere-src-$QT.tar.xz
-6f14fea2d172a5b4170be3efcb0e58535f6605b61bcd823f6d5c9d165bb8c0f0  qtwayland-everywhere-src-$QT.tar.xz
+5087c9e5b0165e7bc3c1a4ab176b35d0cd8f52636aea903fa377bdba00891a60  qtbase-everywhere-src-$QT.tar.xz
+88315f886cf81898705e487cedba6e6160724359d23c518c92c333c098879a4a  qtsvg-everywhere-src-$QT.tar.xz
+867df829cd5cd3ae8efe62e825503123542764b13c96953511e567df70c5a091  qttools-everywhere-src-$QT.tar.xz
+79e56b7800d49649a8a8010818538c367a829e0b7a09d5f60bd3aecf5abe972c  qttranslations-everywhere-src-$QT.tar.xz
+c6b161da8f4c01e48c10b7b558a0a01ac07dba9b907b13a98ff5d89f46bc4789  qtwayland-everywhere-src-$QT.tar.xz
 EOF
 
 curl -L \
@@ -76,19 +76,6 @@ cd ../../
 echo "Building Qt Wayland..."
 tar xf "qtwayland-everywhere-src-$QT.tar.xz"
 cd "qtwayland-everywhere-src-$QT"
-# qtwayland does not build without qml/qtdeclarative in 6.3.1. Work around it.
-patch -u src/compositor/CMakeLists.txt <<EOF
---- src/compositor/CMakeLists.txt	2022-06-08 13:44:30.000000000 +1000
-+++ src/compositor/CMakeLists.txt	2022-07-17 20:05:25.461881785 +1000
-@@ -46,7 +46,6 @@
-         global/qtwaylandcompositorglobal.h
-         global/qtwaylandqmlinclude.h
-         global/qwaylandcompositorextension.cpp global/qwaylandcompositorextension.h global/qwaylandcompositorextension_p.h
--        global/qwaylandquickextension.cpp global/qwaylandquickextension.h
-         global/qwaylandutils_p.h
-         hardware_integration/qwlclientbufferintegration.cpp hardware_integration/qwlclientbufferintegration_p.h
-         wayland_wrapper/qwlbuffermanager.cpp wayland_wrapper/qwlbuffermanager_p.h
-EOF
 mkdir build
 cd build
 cmake -G Ninja -DCMAKE_PREFIX_PATH="$INSTALLDIR" -DCMAKE_INSTALL_PREFIX="$INSTALLDIR" -DCMAKE_BUILD_TYPE=Release ..
@@ -114,6 +101,30 @@ patch -u src/linguist/CMakeLists.txt <<EOF
      add_subdirectory(linguist)
  endif()
 EOF
+
+# Also force disable clang scanning, it gets very confused.
+patch -u configure.cmake <<EOF
+--- configure.cmake
++++ configure.cmake
+@@ -14,12 +14,12 @@
+ # Presumably because 6.0 ClangConfig.cmake files are not good enough?
+ # In any case explicitly request a minimum version of 8.x for now, otherwise
+ # building with CMake will fail at compilation time.
+-qt_find_package(WrapLibClang 8 PROVIDED_TARGETS WrapLibClang::WrapLibClang)
++#qt_find_package(WrapLibClang 8 PROVIDED_TARGETS WrapLibClang::WrapLibClang)
+ # special case end
+
+-if(TARGET WrapLibClang::WrapLibClang)
+-    set(TEST_libclang "ON" CACHE BOOL "Required libclang version found." FORCE)
+-endif()
++#if(TARGET WrapLibClang::WrapLibClang)
++#    set(TEST_libclang "ON" CACHE BOOL "Required libclang version found." FORCE)
++#endif()
+
+
+
+EOF
+
 mkdir build
 cd build
 cmake -G Ninja -DCMAKE_PREFIX_PATH="$INSTALLDIR" -DCMAKE_INSTALL_PREFIX="$INSTALLDIR" -DCMAKE_BUILD_TYPE=Release -DFEATURE_assistant=OFF -DFEATURE_clang=OFF -DFEATURE_designer=OFF -DFEATURE_kmap2qmap=OFF -DFEATURE_pixeltool=OFF -DFEATURE_pkg_config=OFF -DFEATURE_qev=OFF -DFEATURE_qtattributionsscanner=OFF -DFEATURE_qtdiag=OFF -DFEATURE_qtplugininfo=OFF ..

--- a/cmake/BuildParameters.cmake
+++ b/cmake/BuildParameters.cmake
@@ -169,6 +169,12 @@ if(WIN32)
 	list(APPEND PCSX2_DEFS TIXML_USE_STL _SCL_SECURE_NO_WARNINGS _UNICODE UNICODE)
 endif()
 
+# Enable debug information in release builds for Linux.
+# Makes the backtrace actually meaningful.
+if(UNIX AND NOT APPLE)
+	add_compile_options($<$<CONFIG:Release>:-g>)
+endif()
+
 if(MSVC)
 	# Enable PDB generation in release builds
 	add_compile_options(

--- a/cmake/FindLibbacktrace.cmake
+++ b/cmake/FindLibbacktrace.cmake
@@ -1,0 +1,31 @@
+# - Try to find libbacktrace
+# Once done this will define
+#  LIBBACKTRACE_FOUND - System has libbacktrace
+#  LIBBACKTRACE_INCLUDE_DIRS - The libbacktrace include directories
+#  LIBBACKTRACE_LIBRARIES - The libraries needed to use libbacktrace
+
+FIND_PATH(
+    LIBBACKTRACE_INCLUDE_DIR backtrace.h
+    HINTS /usr/include /usr/local/include
+    ${LIBBACKTRACE_PATH_INCLUDES}
+)
+
+FIND_LIBRARY(
+    LIBBACKTRACE_LIBRARY
+    NAMES backtrace
+    PATHS ${ADDITIONAL_LIBRARY_PATHS} ${LIBBACKTRACE_PATH_LIB}
+)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Libbacktrace DEFAULT_MSG
+                                  LIBBACKTRACE_LIBRARY LIBBACKTRACE_INCLUDE_DIR)
+
+if(LIBBACKTRACE_FOUND)
+    add_library(libbacktrace::libbacktrace UNKNOWN IMPORTED)
+    set_target_properties(libbacktrace::libbacktrace PROPERTIES
+        IMPORTED_LOCATION ${LIBBACKTRACE_LIBRARY}
+        INTERFACE_INCLUDE_DIRECTORIES ${LIBBACKTRACE_INCLUDE_DIR}
+    )
+endif()
+
+mark_as_advanced(LIBBACKTRACE_INCLUDE_DIR LIBBACKTRACE_LIBRARY)

--- a/cmake/SearchForStuff.cmake
+++ b/cmake/SearchForStuff.cmake
@@ -86,6 +86,8 @@ else()
 		if(WAYLAND_API)
 			find_package(Wayland REQUIRED)
 		endif()
+
+		find_package(Libbacktrace)
 	endif()
 endif(WIN32)
 

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -288,6 +288,11 @@ if(NOT WIN32 AND (QT_BUILD OR NOGUI_BUILD))
 	target_link_libraries(common PRIVATE CURL::libcurl)
 endif()
 
+if(UNIX AND NOT APPLE AND TARGET libbacktrace::libbacktrace)
+	target_compile_definitions(common PRIVATE "HAS_LIBBACKTRACE=1")
+	target_link_libraries(common PRIVATE libbacktrace::libbacktrace)
+endif()
+
 target_link_libraries(common PRIVATE
 	${LIBC_LIBRARIES}
 	PNG::PNG

--- a/common/CrashHandler.cpp
+++ b/common/CrashHandler.cpp
@@ -1,5 +1,5 @@
 /*  PCSX2 - PS2 Emulator for PCs
- *  Copyright (C) 2002-2022  PCSX2 Dev Team
+ *  Copyright (C) 2002-2023  PCSX2 Dev Team
  *
  *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU Lesser General Public License as published by the Free Software Found-
@@ -214,6 +214,199 @@ void CrashHandler::Uninstall()
 		s_dbghelp_module = nullptr;
 	}
 }
+
+#elif defined(HAS_LIBBACKTRACE)
+
+#include "FileSystem.h"
+
+#include <backtrace.h>
+#include <signal.h>
+#include <sys/mman.h>
+#include <unistd.h>
+#include <cstdarg>
+#include <cstdio>
+#include <mutex>
+
+namespace CrashHandler
+{
+	struct BacktraceBuffer
+	{
+		char* buffer;
+		size_t used;
+		size_t size;
+	};
+
+	static const char* GetSignalName(int signal_no);
+	static void AllocateBuffer(BacktraceBuffer* buf);
+	static void FreeBuffer(BacktraceBuffer* buf);
+	static void AppendToBuffer(BacktraceBuffer* buf, const char* format, ...);
+	static int BacktraceFullCallback(void* data, uintptr_t pc, const char* filename, int lineno, const char* function);
+	static void CallExistingSignalHandler(int signal, siginfo_t* siginfo, void* ctx);
+	static void CrashSignalHandler(int signal, siginfo_t* siginfo, void* ctx);
+
+	static std::recursive_mutex s_crash_mutex;
+	static bool s_in_signal_handler = false;
+
+	static backtrace_state* s_backtrace_state = nullptr;
+	static struct sigaction s_old_sigbus_action;
+	static struct sigaction s_old_sigsegv_action;
+}
+
+const char* CrashHandler::GetSignalName(int signal_no)
+{
+	switch (signal_no)
+	{
+		// Don't need to list all of them, there's only a couple we register.
+		// clang-format off
+		case SIGSEGV: return "SIGSEGV";
+		case SIGBUS: return "SIGBUS";
+		default: return "UNKNOWN";
+		// clang-format on
+	}
+}
+
+void CrashHandler::AllocateBuffer(BacktraceBuffer* buf)
+{
+	buf->used = 0;
+	buf->size = __pagesize;
+	buf->buffer = static_cast<char*>(mmap(nullptr, buf->size, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0));
+	if (buf->buffer == static_cast<char*>(MAP_FAILED))
+	{
+		buf->buffer = nullptr;
+		buf->size = 0;
+	}
+}
+
+void CrashHandler::FreeBuffer(BacktraceBuffer* buf)
+{
+	if (buf->buffer)
+		munmap(buf->buffer, buf->size);
+}
+
+void CrashHandler::AppendToBuffer(BacktraceBuffer* buf, const char* format, ...)
+{
+	std::va_list ap;
+	va_start(ap, format);
+
+	// Hope this doesn't allocate memory... it *can*, but hopefully unlikely since
+	// it won't be the first call, and we're providing the buffer.
+	if (buf->size > 0 && buf->used < (buf->size - 1))
+	{
+		const int written = std::vsnprintf(buf->buffer + buf->used, buf->size - buf->used, format, ap);
+		if (written > 0)
+			buf->used += static_cast<size_t>(written);
+	}
+
+	va_end(ap);
+}
+
+int CrashHandler::BacktraceFullCallback(void* data, uintptr_t pc, const char* filename, int lineno, const char* function)
+{
+	BacktraceBuffer* buf = static_cast<BacktraceBuffer*>(data);
+	AppendToBuffer(buf, "  %016p", pc);
+	if (function)
+		AppendToBuffer(buf, " %s", function);
+	if (filename)
+		AppendToBuffer(buf, " [%s:%d]", filename, lineno);
+	
+	AppendToBuffer(buf, "\n");
+	return 0;
+}
+
+void CrashHandler::CallExistingSignalHandler(int signal, siginfo_t* siginfo, void* ctx)
+{
+	const struct sigaction& sa = (signal == SIGBUS) ? s_old_sigbus_action : s_old_sigsegv_action;
+	if (sa.sa_flags & SA_SIGINFO)
+	{
+		sa.sa_sigaction(signal, siginfo, ctx);
+	}
+	else if (sa.sa_handler == SIG_DFL)
+	{
+		// Re-raising the signal would just queue it, and since we'd restore the handler back to us,
+		// we'd end up right back here again. So just abort, because that's probably what it'd do anyway.
+		abort();
+	}
+	else if (sa.sa_handler != SIG_IGN)
+	{
+		sa.sa_handler(signal);
+	}
+}
+
+void CrashHandler::CrashSignalHandler(int signal, siginfo_t* siginfo, void* ctx)
+{
+	std::unique_lock lock(s_crash_mutex);
+	
+	// If we crash somewhere in libbacktrace, don't bother trying again.
+	if (!s_in_signal_handler)
+	{
+		s_in_signal_handler = true;
+
+#if defined(__APPLE__) && defined(__x86_64__)
+		void* const exception_pc = reinterpret_cast<void*>(static_cast<ucontext_t*>(ctx)->uc_mcontext->__ss.__rip);
+#elif defined(__FreeBSD__) && defined(__x86_64__)
+		void* const exception_pc = reinterpret_cast<void*>(static_cast<ucontext_t*>(ctx)->uc_mcontext.mc_rip);
+#elif defined(__x86_64__)
+		void* const exception_pc = reinterpret_cast<void*>(static_cast<ucontext_t*>(ctx)->uc_mcontext.gregs[REG_RIP]);
+#else
+		void* const exception_pc = nullptr;
+#endif
+
+		BacktraceBuffer buf;
+		AllocateBuffer(&buf);
+		AppendToBuffer(&buf, "*************** Unhandled %s at %p ***************\n", GetSignalName(signal), exception_pc);
+
+		const int rc = backtrace_full(s_backtrace_state, 0, BacktraceFullCallback, nullptr, &buf);
+		if (rc != 0)
+			AppendToBuffer(&buf, "  backtrace_full() failed: %d\n");
+
+		AppendToBuffer(&buf, "*******************************************************************\n");
+
+		if (buf.used > 0)
+			write(STDERR_FILENO, buf.buffer, buf.used);
+
+		FreeBuffer(&buf);
+
+		s_in_signal_handler = false;
+	}
+
+	// Chances are we're not going to have anything else to call, but just in case.
+	lock.unlock();
+	CallExistingSignalHandler(signal, siginfo, ctx);
+}
+
+bool CrashHandler::Install()
+{
+	const std::string progpath = FileSystem::GetProgramPath();
+	s_backtrace_state = backtrace_create_state(progpath.empty() ? nullptr : progpath.c_str(), 0, nullptr, nullptr);
+	if (!s_backtrace_state)
+		return false;
+	
+	struct sigaction sa;
+
+	sigemptyset(&sa.sa_mask);
+	sa.sa_flags = SA_SIGINFO | SA_NODEFER;
+	sa.sa_sigaction = CrashSignalHandler;
+	if (sigaction(SIGBUS, &sa, &s_old_sigbus_action) != 0)
+		return false;
+	if (sigaction(SIGSEGV, &sa, &s_old_sigsegv_action) != 0)
+		return false;
+
+	return true;
+}
+
+void CrashHandler::SetWriteDirectory(const std::string_view& dump_directory)
+{
+}
+
+void CrashHandler::WriteDumpForCaller()
+{
+}
+
+void CrashHandler::Uninstall()
+{
+	// We can't really unchain the signal handlers... so, YOLO.
+}
+
 
 #else
 


### PR DESCRIPTION
### Description of Changes

Uses libbacktrace to get a backtrace when we crash on Linux.

Also updates Qt to 6.4.3 and SDL2 to 2.26.4, since I'm modifying the dependencies script, and it'll take a while to build/cache.

### Rationale behind Changes

Helps support and bug reports, since users don't want to (or don't know how to) use gdb.

![image](https://user-images.githubusercontent.com/11288319/226188347-29f98d0c-e1a7-4ffb-8fbf-8e70e7e70ab8.png)

Can't do demangling, because the gcc function allocates memory, and we don't want to be doing that if we crashed because we had a screwed up heap.

### Suggested Testing Steps

Kinda difficult, unless you know how to make pcsx2 crash, in which case we should fix it :P

But the Linux guys can make sure that the AppImage still works with updated Qt/SDL.
