### PR TITLE
GS: Compensate for misaligned partial 24bit local->host transfers

### DIFF
--- a/pcsx2/GS/GSLocalMemory.h
+++ b/pcsx2/GS/GSLocalMemory.h
@@ -460,7 +460,7 @@ public:
 	typedef u32 (GSLocalMemory::*readPixelAddr)(u32 addr) const;
 	typedef u32 (GSLocalMemory::*readTexelAddr)(u32 addr, const GIFRegTEXA& TEXA) const;
 	typedef void (*writeImage)(GSLocalMemory& mem, int& tx, int& ty, const u8* src, int len, GIFRegBITBLTBUF& BITBLTBUF, GIFRegTRXPOS& TRXPOS, GIFRegTRXREG& TRXREG);
-	typedef void (*readImage)(const GSLocalMemory& mem, int& tx, int& ty, u8* dst, int len, GIFRegBITBLTBUF& BITBLTBUF, GIFRegTRXPOS& TRXPOS, GIFRegTRXREG& TRXREG);
+	typedef void (*readImage)(const GSLocalMemory& mem, int& tx, int& ty, int& offset, u8* dst, int len, GIFRegBITBLTBUF& BITBLTBUF, GIFRegTRXPOS& TRXPOS, GIFRegTRXREG& TRXREG);
 	typedef void (*readTexture)(GSLocalMemory& mem, const GSOffset& off, const GSVector4i& r, u8* dst, int dstpitch, const GIFRegTEXA& TEXA);
 	typedef void (*readTextureBlock)(const GSLocalMemory& mem, u32 bp, u8* dst, int dstpitch, const GIFRegTEXA& TEXA);
 
@@ -1123,9 +1123,9 @@ public:
 		return ReadTexel16(PixelAddress16SZ(x, y, TEX0.TBP0, TEX0.TBW), TEXA);
 	}
 
-	__forceinline void ReadImageX(int& tx, int& ty, u8* dst, int len, GIFRegBITBLTBUF& BITBLTBUF, GIFRegTRXPOS& TRXPOS, GIFRegTRXREG& TRXREG) const
+	__forceinline void ReadImageX(int& tx, int& ty, int& offset, u8* dst, int len, GIFRegBITBLTBUF& BITBLTBUF, GIFRegTRXPOS& TRXPOS, GIFRegTRXREG& TRXREG) const
 	{
-		m_readImageX(*this, tx, ty, dst, len, BITBLTBUF, TRXPOS, TRXREG);
+		m_readImageX(*this, tx, ty, offset, dst, len, BITBLTBUF, TRXPOS, TRXREG);
 	}
 
 	void ReadTexture(const GSOffset& off, const GSVector4i& r, u8* dst, int dstpitch, const GIFRegTEXA& TEXA);

--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -1847,7 +1847,9 @@ void GSState::Read(u8* mem, int len)
 	if (!m_tr.Update(w, h, bpp, len))
 		return;
 
-	m_mem.ReadImageX(m_tr.x, m_tr.y, mem, len, m_env.BITBLTBUF, m_env.TRXPOS, m_env.TRXREG);
+	mem += m_tr.offset;
+	len -= m_tr.offset;
+	m_mem.ReadImageX(m_tr.x, m_tr.y, m_tr.offset, mem, len, m_env.BITBLTBUF, m_env.TRXPOS, m_env.TRXREG);
 
 	if (GSConfig.DumpGSData && GSConfig.SaveRT && s_n >= GSConfig.SaveN)
 	{
@@ -2138,7 +2140,9 @@ void GSState::ReadLocalMemoryUnsync(u8* mem, int qwc, GIFRegBITBLTBUF BITBLTBUF,
 	if (!tb.Update(w, h, bpp, len))
 		return;
 
-	m_mem.ReadImageX(tb.x, tb.y, mem, len, BITBLTBUF, TRXPOS, TRXREG);
+	mem += tb.offset;
+	len -= tb.offset;
+	m_mem.ReadImageX(tb.x, tb.y, tb.offset, mem, len, BITBLTBUF, TRXPOS, TRXREG);
 }
 
 void GSState::PurgePool()
@@ -3902,6 +3906,7 @@ void GSState::GSTransferBuffer::Init(int tx, int ty, const GIFRegBITBLTBUF& blit
 	x = tx;
 	y = ty;
 	total = 0;
+	offset = 0;
 	m_blit = blit;
 }
 

--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -123,6 +123,7 @@ private:
 	{
 		int x = 0, y = 0;
 		int start = 0, end = 0, total = 0;
+		int offset = 0;
 		u8* buff = nullptr;
 		GIFRegBITBLTBUF m_blit = {};
 


### PR DESCRIPTION
### Description of Changes
Compensates for misaligned transfers which generally happen with 24bit transfers when the transfer is split.

### Rationale behind Changes
In Keroro Gunso and We Love Katamari it downloads the 24 bit framebuffer in 2 parts, but it ends the first transfer 1 channel in to the 3 channel pixel, meaning it's offset strangely when it does the second part of the transfer.  So to compensate for this we do the whole pixel it ends on, then do an offset on the second part of the transfer, this stops the colours being incorrect as a bar across the bottom.

### Suggested Testing Steps
Test Keroro Gunso - Mero Mero Battle Royale pause screen and We Love Katamari Damacy transition in to the collection.

Keroro Gunso:  (There is another issue I need to solve with HW mode where the download fails first time, need to investigate)
Master:
![image](https://user-images.githubusercontent.com/6278726/226199923-773ab3e2-978d-43b7-9b78-bdb75c92195f.png)

PR:
![image](https://user-images.githubusercontent.com/6278726/226199929-b49ca4ff-eb30-4a4d-b438-6b44ea236c75.png)


We Love Katamari:
Master:
![image](https://user-images.githubusercontent.com/6278726/226199966-7570cb18-b776-470d-ab2d-fef5c3feaabb.png)

PR:
![image](https://user-images.githubusercontent.com/6278726/226199973-e1849d23-8d91-4ebc-9ed2-84b2c0139e06.png)

Fixes #8146
Fixes #8441