### PR TITLE
VMManager: Fix "X widescreen patches loaded" text when loading from files

### DIFF
--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -591,7 +591,7 @@ void VMManager::LoadPatches(const std::string& serial, u32 crc, bool show_messag
 	// wide screen patches
 	if (EmuConfig.EnableWideScreenPatches && crc != 0)
 	{
-		if (!Achievements::ChallengeModeActive() && (s_active_widescreen_patches = LoadPatchesFromDir(crc_string, EmuFolders::CheatsWS, "Widescreen hacks", false) > 0))
+		if (!Achievements::ChallengeModeActive() && (s_active_widescreen_patches = LoadPatchesFromDir(crc_string, EmuFolders::CheatsWS, "Widescreen hacks", false)) > 0)
 		{
 			Console.WriteLn(Color_Gray, "Found widescreen patches in the cheats_ws folder --> skipping cheats_ws.zip");
 		}


### PR DESCRIPTION
### Description of Changes
A misplaced parenthesis caused `s_active_widescreen_patches` to evaluate only ever to `0` or `1`. No interlace patches had it right, widescreen ones did not.

### Rationale behind Changes
Make UI not lie.

### Suggested Testing Steps
1. Put any widescreen cheat in `cheats_ws`.
2. Load the game.
3. Observe that "X widescreen cheats loaded" does not lie about the amount of loaded patch lines like it used to.
