### PR TITLE
GS-HW: Resize RT used as larger source

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -18710,6 +18710,7 @@ SLES-53825:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 1 # Reduces blurriness.
+    partialTargetInvalidation: 1 # Fixes corruption after taking a picture.
 SLES-53826:
   name: "Tom Clancy's Splinter Cell - Double Agent"
   region: "PAL-M5"
@@ -41300,6 +41301,9 @@ SLPS-73256:
 SLPS-73257:
   name: "Fatal Frame III - The Tormented [PlayStation 2 the Best - Reprint]"
   region: "NTSC-J"
+  gsHWFixes:
+    halfPixelOffset: 1 # Reduces blurriness.
+    partialTargetInvalidation: 1 # Fixes corruption after taking a picture.
 SLPS-73258:
   name: "Kenka Banchou 2 - Full Throttle [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -47438,11 +47442,12 @@ SLUS-21243:
   memcardFilters:
     - "SLUS-21359"
 SLUS-21244:
-  name: "Fatal Frame 3 - The Tormented"
+  name: "Fatal Frame III - The Tormented"
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
     halfPixelOffset: 1 # Reduces blurriness.
+    partialTargetInvalidation: 1 # Fixes corruption after taking a picture.
 SLUS-21245:
   name: "Suikoden Tactics"
   region: "NTSC-U"

--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -11114,6 +11114,8 @@ SLES-50677:
   compat: 5
   clampModes:
     eeClampMode: 3 # Fixes invisible characters in various scenes.
+  gsHWFixes:
+    partialTargetInvalidation: 1 # Fixes black screens on judgement wheel.
 SLES-50679:
   name: "Tenchu 3 - Wrath of Heaven"
   region: "PAL-E"
@@ -11485,6 +11487,8 @@ SLES-50822:
   region: "PAL-M3"
   clampModes:
     eeClampMode: 3 # Fixes invisible characters in various scenes.
+  gsHWFixes:
+    partialTargetInvalidation: 1 # Fixes black screens on judgement wheel.
 SLES-50826:
   name: "Star Wars - Clone Wars"
   region: "PAL-E"
@@ -37532,6 +37536,8 @@ SLPS-25041:
   region: "NTSC-J"
   clampModes:
     eeClampMode: 3 # Fixes invisible characters in various scenes.
+  gsHWFixes:
+    partialTargetInvalidation: 1 # Fixes black screens on judgement wheel.
 SLPS-25042:
   name: "Maken Shao [Limited Edition]"
   region: "NTSC-J"
@@ -41400,6 +41406,8 @@ SLPS-73418:
   region: "NTSC-J"
   clampModes:
     eeClampMode: 3 # Fixes invisible characters in various scenes.
+  gsHWFixes:
+    partialTargetInvalidation: 1 # Fixes black screens on judgement wheel.
 SLPS-73419:
   name: "Lupin III - Majutsu-Ou no Isan [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -42878,6 +42886,8 @@ SLUS-20347:
   compat: 5
   clampModes:
     eeClampMode: 3 # Fixes invisible characters in various scenes.
+  gsHWFixes:
+    partialTargetInvalidation: 1 # Fixes black screens on judgement wheel.
 SLUS-20348:
   name: "Monopoly Party"
   region: "NTSC-U"

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -1574,8 +1574,9 @@ void GSRendererHW::Draw()
 		}
 	}
 
-	// The rectangle of the draw
-	m_r = GSVector4i(m_vt.m_min.p.xyxy(m_vt.m_max.p)).rintersect(GSVector4i(context->scissor.in));
+	// The rectangle of the draw rounded up.
+	const GSVector4 rect = m_vt.m_min.p.xyxy(m_vt.m_max.p) + GSVector4(0.0f, 0.0f, 0.5f, 0.5f);
+	m_r = GSVector4i(rect).rintersect(GSVector4i(context->scissor.in));
 
 	if (m_channel_shuffle)
 	{

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -817,8 +817,30 @@ GSTextureCache::Source* GSTextureCache::LookupSource(const GIFRegTEX0& TEX0, con
 
 					const u32 channel_mask = GSUtil::GetChannelMask(psm);
 					const u32 channels = t->m_dirty.GetDirtyChannels() & channel_mask;
+
+					// If the source is reading the rt, make sure it's big enough.
+					if (t && GSUtil::HasCompatibleBits(psm, t->m_TEX0.PSM))
+					{
+						GSVector4i dirty_rect = t->m_dirty.GetTotalRect(t->m_TEX0, GSVector2i(new_rect.z, new_rect.w));
+						const GSVector2i size_delta = { (dirty_rect.z - t->m_valid.z), (dirty_rect.w - t->m_valid.w) };
+						if (size_delta.x > 0 || size_delta.y > 0)
+						{
+							RGBAMask rgba;
+							rgba._u32 = GSUtil::GetChannelMask(t->m_TEX0.PSM);
+							// Dirty the expanded areas.
+							AddDirtyRectTarget(t, GSVector4i(t->m_valid.x, t->m_valid.w, t->m_valid.z + std::max(0, size_delta.x), t->m_valid.w + std::max(0, size_delta.y)), t->m_TEX0.PSM, t->m_TEX0.TBW, rgba);
+							AddDirtyRectTarget(t, GSVector4i(t->m_valid.z, t->m_valid.y, t->m_valid.z + std::max(0, size_delta.x), t->m_valid.w + std::max(0, size_delta.y)), t->m_TEX0.PSM, t->m_TEX0.TBW, rgba);
+							const GSVector4i valid_rect = { t->m_valid.x, t->m_valid.y, t->m_valid.z + std::max(0, size_delta.x), t->m_valid.w + std::max(0, size_delta.y) };
+							t->UpdateValidity(valid_rect);
+							t->UpdateValidBits(GSLocalMemory::m_psm[t->m_TEX0.PSM].fmsk);
+							GetTargetHeight(TEX0.TBP0, TEX0.TBW, TEX0.PSM, t->m_valid.w);
+							const int new_w = std::max(t->m_unscaled_size.x, t->m_valid.z);
+							const int new_h = std::max(t->m_unscaled_size.y, t->m_valid.w);
+							t->ResizeTexture(new_w, new_h);
+						}
+					}
 					// If not all channels are clean/dirty or only part of the rect is dirty, we need to update the target.
-					if (((channels & channel_mask) != channel_mask || partial) && !rect_clean)
+					if (((channels & channel_mask) != channel_mask || partial))
 						t->Update(false);
 				}
 				else
@@ -992,22 +1014,6 @@ GSTextureCache::Source* GSTextureCache::LookupSource(const GIFRegTEX0& TEX0, con
 			}
 		}
 
-		// If the source is reading the rt, make sure it's big enough.
-		
-		if (dst && GSUtil::HasCompatibleBits(psm, dst->m_TEX0.PSM))
-		{
-			const GSVector2i size_delta = { (r.z - dst->m_valid.z), (r.w - dst->m_valid.w) };
-
-			if (size_delta.x > 0 || size_delta.y > 0)
-			{
-				const GSVector4i valid_rect = { dst->m_valid.x, dst->m_valid.y, dst->m_valid.z + std::max(0, size_delta.x), dst->m_valid.w + std::max(0, size_delta.y) };
-				dst->UpdateValidity(valid_rect);
-
-				const int new_w = std::max(dst->m_unscaled_size.x, dst->m_valid.z);
-				const int new_h = std::max(dst->m_unscaled_size.y, dst->m_valid.w);
-				dst->ResizeTexture(new_w, new_h);
-			}
-		}
 		// Pure depth texture format will be fetched by LookupDepthSource.
 		// However guess what, some games (GoW) read the depth as a standard
 		// color format (instead of a depth format). All pixels are scrambled


### PR DESCRIPTION
### Description of Changes
This does a few things:
If a render target is used as a source it will check if what it reads is going to be bigger and resizes it to match.
The drawing rect for hardware mode draws is rounded up as to make sure it draws all required pixels.

### Rationale behind Changes
In order of things:
- Games such as Armored Core will use a render target which is much smaller than what it requires, causing the render target to repeat across the who draw, this was also an issue with the water in Wave Race (though that has a different issue, but the reflections are better now).

- The drawn rect was not big enough for calculating the draws, meaning the drawn area we were recording was incorrect, meaning Dogs Life didn't download all the data it needed, leaving a line of beads in Jake's head.

### Suggested Testing Steps
Test above mentioned games, make sure everything is okay, and a nice spattering of other games.
Did a GS Runner run on 1148 dumps, a LOT of things showed up with very minor single pixel differences.  ICO's shadow changed, now matches SW, Wave Race changed water colour but fixed the reflections, no other notable changes.

Fixes #8194
Fixes #8450
Seems to also fix the Killzone background movies when putting PAL in to NTSC mode, regression from #8444 (though I'm not 100% sure why this fixes it, possibly the target expansion, ain't the texture cache fun?)