### PR TITLE
CMake: Swap -g for -g1 in Linux Release builds

### DIFF
--- a/cmake/BuildParameters.cmake
+++ b/cmake/BuildParameters.cmake
@@ -172,7 +172,7 @@ endif()
 # Enable debug information in release builds for Linux.
 # Makes the backtrace actually meaningful.
 if(UNIX AND NOT APPLE)
-	add_compile_options($<$<CONFIG:Release>:-g>)
+	add_compile_options($<$<CONFIG:Release>:-g1>)
 endif()
 
 if(MSVC)


### PR DESCRIPTION
### Description of Changes

-g tends to blow the AppImage sizes up a bit too much, and we don't need the stack frame/variable information for user backtraces.

### Rationale behind Changes

AppImage went from ~40MB to ~100MB...

### Suggested Testing Steps

See how much the AppImage gets reduced.
