### PR TITLE
Qt: Remove backup AppImage on next launch

### DIFF
--- a/pcsx2-qt/AutoUpdaterDialog.h
+++ b/pcsx2-qt/AutoUpdaterDialog.h
@@ -37,6 +37,7 @@ public:
 	static std::string getDefaultTag();
 	static QString getCurrentVersion();
 	static QString getCurrentVersionDate();
+	static void cleanupAfterUpdate();
 
 Q_SIGNALS:
 	void updateCheckCompleted();

--- a/pcsx2-qt/QtHost.cpp
+++ b/pcsx2-qt/QtHost.cpp
@@ -56,6 +56,7 @@
 
 #include "fmt/core.h"
 
+#include "AutoUpdaterDialog.h"
 #include "DisplayWidget.h"
 #include "GameList/GameListWidget.h"
 #include "MainWindow.h"
@@ -1753,6 +1754,13 @@ bool QtHost::ParseCommandLineOptions(const QStringList& args, std::shared_ptr<VM
 			else if (CHECK_ARG(QStringLiteral("-debugger")))
 			{
 				s_boot_and_debug = true;
+				continue;
+			}
+			else if (CHECK_ARG(QStringLiteral("-updatecleanup")))
+			{
+				if (AutoUpdaterDialog::isSupported())
+					AutoUpdaterDialog::cleanupAfterUpdate();
+
 				continue;
 			}
 #ifdef ENABLE_RAINTEGRATION


### PR DESCRIPTION
### Description of Changes

Does what the title says.

### Rationale behind Changes

Stops users complaining about having multiple AppImages lying around.

### Suggested Testing Steps

Can't really test this in PR form, but I've ran all the components independently and it behaves as expected.
