### PR TITLE
GS/DX11: Fix incorrect UBO for P8 conversion

### DIFF
--- a/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
@@ -789,6 +789,7 @@ void GSDevice11::ConvertToIndexedTexture(GSTexture* sTex, float sScale, u32 offs
 	struct Uniforms
 	{
 		float scale;
+		float pad1[3];
 		u32 SBW, DBW, pad3;
 	};
 


### PR DESCRIPTION
### Description of Changes

Regression from #8336.

### Rationale behind Changes

P8 conversions turning into black breaks games.

Closes #8415.

### Suggested Testing Steps

Already tested, issue is fairly obvious (storing integer data in a float4).
