### PR TITLE
GS-TC: Only stop checking for RT's if whole read is inside that RT.

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -2217,7 +2217,7 @@ void GSTextureCache::InvalidateLocalMem(const GSOffset& off, const GSVector4i& r
 				{
 					Read(t, draw_rect);
 
-					z_found = true;
+					z_found = read_start >= t->m_TEX0.TBP0 && read_end <= t->m_end_block;
 
 					if (draw_rect.rintersect(t->m_drawn_since_read).eq(t->m_drawn_since_read))
 						t->m_drawn_since_read = GSVector4i::zero();
@@ -2377,7 +2377,7 @@ void GSTextureCache::InvalidateLocalMem(const GSOffset& off, const GSVector4i& r
 						t->m_drawn_since_read.z = targetr.x;
 				}
 
-				if (targetr.rintersect(t->m_valid).eq(targetr))
+				if (read_start >= t->m_TEX0.TBP0 && read_end <= t->m_end_block)
 					return;
 			}
 		}


### PR DESCRIPTION
### Description of Changes
Checks that the LocalMem invalidation is inside that render target, otherwise look for more render targets.

### Rationale behind Changes
Metal Gear Solid 2 Substance was getting false positives during the cutscene, causing it to download garbage.

### Suggested Testing Steps
Test readbacky stuff.