### PR TITLE
SDLInputSource: Enable joystick hats for controllers

### DIFF
--- a/pcsx2/Frontend/SDLInputSource.cpp
+++ b/pcsx2/Frontend/SDLInputSource.cpp
@@ -612,13 +612,9 @@ bool SDLInputSource::OpenDevice(int index, bool is_gamecontroller)
 		for (size_t i = 0; i < std::size(s_sdl_button_names); i++)
 			mark_bind(SDL_GameControllerGetBindForButton(gcontroller, static_cast<SDL_GameControllerButton>(i)));
 	}
-	else
-	{
-		// GC doesn't have the concept of hats, so we only need to do this for joysticks.
-		const int num_hats = SDL_JoystickNumHats(joystick);
-		if (num_hats > 0)
-			cd.last_hat_state.resize(static_cast<size_t>(num_hats), u8(0));
-	}
+	const int num_hats = SDL_JoystickNumHats(joystick);
+	if (num_hats > 0)
+		cd.last_hat_state.resize(static_cast<size_t>(num_hats), u8(0));
 
 	cd.use_game_controller_rumble = (gcontroller && SDL_GameControllerRumble(gcontroller, 0, 0, 0) == 0);
 	if (cd.use_game_controller_rumble)


### PR DESCRIPTION
### Description of Changes
Initialize the last_hat_state in SDLInputSource for controllers. This used to only be enabled for joysticks.

### Rationale behind Changes
Long story here: https://github.com/PCSX2/pcsx2/issues/8483 (I also closed it again since I found the culprit)
Short story is:
This is needed, because some controllers like the xbox wireless game controller handle the dpad inputs over the joystick hats. https://github.com/PCSX2/pcsx2/commit/4ebb5a87b2e4b015bccdccfecddf6581aa160409 added a last_hat_state vector. This is only initialized for joysticks but not for game controllers. This is a problem because SDLInputSource::HandleJoystickHatEvent checks for the last_hat_state and thus no dpad input is possible.

### Suggested Testing Steps
I tested this on linux using my Xbox controller (ID 045e:0b12 Microsoft Corp. Xbox Wireless Controller (model 1914)). I also tested this on my switch pro controller (ID 057e:2009 Nintendo Co., Ltd Switch Pro Controller).  The switch pro controller does not use hats for the dpad but uses normal buttons instead.
I did not test this on windows yet! I plan to in the coming days when I setup msvc. 
To test, simply connect a controller and open pcsx2. Then go to Settings -> Controllers -> 
Controller Port 1 DualShock 2. Click on any mapping and try to map the dpad of the controller. Then launch any game and try the mapped input. (Also check for double inputs!) For me it worked normally with both of my controllers, just like before https://github.com/PCSX2/pcsx2/commit/4ebb5a87b2e4b015bccdccfecddf6581aa160409. 