### PR TITLE
GS-TC: Give option to match target on exact memory addresses

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -2255,7 +2255,8 @@ void GSTextureCache::InvalidateLocalMem(const GSOffset& off, const GSVector4i& r
 				// Check exact match first
 				const bool bpp_match = GSLocalMemory::m_psm[t->m_TEX0.PSM].bpp == GSLocalMemory::m_psm[psm].bpp;
 				const u32 page_mask = ((1 << 5) - 1);
-				const bool expecting_this_tex = bpp_match && bw == t->m_TEX0.TBW && (((read_start & ~page_mask) == t->m_TEX0.TBP0) || (bp >= t->m_TEX0.TBP0 && ((read_end + page_mask) & ~page_mask) <= ((t->m_end_block + page_mask) & ~page_mask)));
+				const bool exact_mem_match = (read_start & ~page_mask) == (t->m_TEX0.TBP0 & ~page_mask) && ((read_end + page_mask) & ~page_mask) == ((t->m_end_block + page_mask) & ~page_mask);
+				const bool expecting_this_tex = exact_mem_match || (bpp_match && bw == t->m_TEX0.TBW && (((read_start & ~page_mask) == t->m_TEX0.TBP0) || (bp >= t->m_TEX0.TBP0 && ((read_end + page_mask) & ~page_mask) <= ((t->m_end_block + page_mask) & ~page_mask))));
 
 				if (!expecting_this_tex)
 					continue;


### PR DESCRIPTION
### Description of Changes
On Local Mem invalidations, if the start/end address of the read matches the entire RT, then it's pretty certain that's the same one.

### Rationale behind Changes
Metal Gear Solid 2 still didn't work properly, mainly because I was an idiot, we won't speak of this again.

### Suggested Testing Steps
Test MGS2 Substance cutscenes (already checked it, and made sure I didn't accidentally leave old override settings on this time.)
