### PR TITLE
GS/HW: Allow strip channel shuffles to be detected

### DIFF
--- a/pcsx2/GS/GSLocalMemory.cpp
+++ b/pcsx2/GS/GSLocalMemory.cpp
@@ -446,6 +446,13 @@ std::vector<GSVector2i>* GSLocalMemory::GetPage2TileMap(const GIFRegTEX0& TEX0)
 	return p2t;
 }
 
+bool GSLocalMemory::IsPageAligned(u32 psm, const GSVector4i& rc)
+{
+	const psm_t& psm_s = m_psm[psm];
+	const GSVector4i pgmsk = GSVector4i(psm_s.pgs).xyxy() - GSVector4i(1);
+	return (rc & pgmsk).eq(GSVector4i::zero());
+}
+
 ///////////////////
 
 void GSLocalMemory::ReadTexture(const GSOffset& off, const GSVector4i& r, u8* dst, int dstpitch, const GIFRegTEXA& TEXA)

--- a/pcsx2/GS/GSLocalMemory.h
+++ b/pcsx2/GS/GSLocalMemory.h
@@ -541,6 +541,7 @@ public:
 	GSPixelOffset* GetPixelOffset(const GIFRegFRAME& FRAME, const GIFRegZBUF& ZBUF);
 	GSPixelOffset4* GetPixelOffset4(const GIFRegFRAME& FRAME, const GIFRegZBUF& ZBUF);
 	std::vector<GSVector2i>* GetPage2TileMap(const GIFRegTEX0& TEX0);
+	static bool IsPageAligned(u32 psm, const GSVector4i& rc);
 
 	// address
 

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.h
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.h
@@ -97,6 +97,7 @@ private:
 
 	void SetTCOffset();
 
+	bool IsPossibleChannelShuffle() const;
 	bool IsSplitTextureShuffle();
 	GSVector4i GetSplitTextureShuffleDrawRect() const;
 


### PR DESCRIPTION
### Description of Changes

Fixes fog wall in WRC 4.

Before:
<img width="599" alt="Untitled" src="https://user-images.githubusercontent.com/11288319/227949478-5d668fff-57d1-4451-a854-765eea592893.png">

After:
<img width="599" alt="Untitled" src="https://user-images.githubusercontent.com/11288319/227949165-76bf9f90-f0eb-41cb-a41b-0c22e1f60ef0.png">

### Rationale behind Changes

Instead of the normal channel shuffle where it draws one page at a time, WRC 4 draws a single page in width, but an entire vertical strip (512 high). I guess because it's not a recursive draw, they can get away with it... although assuming the triangles were in the correct order (left->right then top->bottom) I guess it'd be okay even recursively, since it'd hit the cache.

### Suggested Testing Steps

Test WRC 4. Haven't found any other games affected.
