### PR TITLE
GameDB: Fix WRC 4 car discolouration

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -2382,6 +2382,8 @@ SCED-52869:
     autoFlush: 1 # Fixes car shadows.
     roundSprite: 1 # Fixes misaligned text.
     halfPixelOffset: 2 # Fixes minor ghosting on objects.
+  roundModes:
+    eeRoundMode: 2 # Fixes rainbow highlighting on cars.
 SCED-52880:
   name: "WRC 4 - The Official Game of the FIA World Rally Championship [Demo]"
   region: "PAL-E"
@@ -2391,6 +2393,8 @@ SCED-52880:
     autoFlush: 1 # Fixes car shadows.
     roundSprite: 1 # Fixes misaligned text.
     halfPixelOffset: 2 # Fixes minor ghosting on objects.
+  roundModes:
+    eeRoundMode: 2 # Fixes rainbow highlighting on cars.
 SCED-52899:
   name: "Killzone [Bonus Disc]"
   region: "PAL-M5"
@@ -2415,6 +2419,8 @@ SCED-52945:
     autoFlush: 1 # Fixes car shadows.
     roundSprite: 1 # Fixes misaligned text.
     halfPixelOffset: 2 # Fixes minor ghosting on objects.
+  roundModes:
+    eeRoundMode: 2 # Fixes rainbow highlighting on cars.
 SCED-52946:
   name: "Getaway, The - Black Monday [Demo]"
   region: "PAL-E"
@@ -3681,6 +3687,8 @@ SCES-52389:
     autoFlush: 1 # Fixes car shadows.
     roundSprite: 1 # Fixes misaligned text.
     halfPixelOffset: 2 # Fixes minor ghosting on objects.
+  roundModes:
+    eeRoundMode: 2 # Fixes rainbow highlighting on cars.
 SCES-52405:
   name: "DJ - Decks & FX - House Edition"
   region: "PAL-M9"
@@ -31490,6 +31498,8 @@ SLPM-65975:
     autoFlush: 1 # Fixes car shadows.
     roundSprite: 1 # Fixes misaligned text.
     halfPixelOffset: 2 # Fixes minor ghosting on objects.
+  roundModes:
+    eeRoundMode: 2 # Fixes rainbow highlighting on cars.
 SLPM-65976:
   name: "Grandia III [Disc 1 of 2]"
   region: "NTSC-J"
@@ -32922,6 +32932,8 @@ SLPM-66334:
     autoFlush: 1 # Fixes car shadows.
     roundSprite: 1 # Fixes misaligned text.
     halfPixelOffset: 2 # Fixes minor ghosting on objects.
+  roundModes:
+    eeRoundMode: 2 # Fixes rainbow highlighting on cars.
 SLPM-66336:
   name: "Shinseiki Evangelion - Koutetsu no Girlfriend [Special Edition]"
   region: "NTSC-J"


### PR DESCRIPTION
### Description of Changes
Adds ee nearest rounding mode to gamedb to fix the rainbow specular highlighting that can appear on the car models.
Before:
![WRC 4_SCES-52389_20230328210803](https://user-images.githubusercontent.com/8155719/228359126-dd077dfd-eb6f-4baf-ae62-1f398c6893c0.png)

After:
![WRC 4_SCES-52389_20230328210805](https://user-images.githubusercontent.com/8155719/228359218-7aaae183-5d43-439a-9776-6d7e6c24188c.png)

### Rationale behind Changes
Weird colour changes and iridescent sheens are not right.

### Suggested Testing Steps
Tested locally and it hasn't had any detrimental effect on the games physics after running though a couple of rallies and has fixed the colour issues on all out of the box unlocked cars.
