### PR TITLE
GS: Provide HPO Normal offsets when there is no RT.

### DIFF
--- a/pcsx2/GS/Renderers/Common/GSRenderer.cpp
+++ b/pcsx2/GS/Renderers/Common/GSRenderer.cpp
@@ -246,6 +246,25 @@ GSVector2i GSRenderer::GetInternalResolution()
 	return m_real_size;
 }
 
+float GSRenderer::GetModXYOffset()
+{
+	float mod_xy = 0.0f;
+
+	if (GSConfig.UserHacks_HalfPixelOffset == 1)
+	{
+		mod_xy = GetUpscaleMultiplier();
+		switch (static_cast<int>(std::round(mod_xy)))
+		{
+			case 2: case 4: case 6: case 8: mod_xy += 0.2f; break;
+			case 3: case 7:                 mod_xy += 0.1f; break;
+			case 5:                         mod_xy += 0.3f; break;
+			default:                        mod_xy = 0.0f; break;
+		}
+	}
+
+	return mod_xy;
+}
+
 static float GetCurrentAspectRatioFloat(bool is_progressive)
 {
 	static constexpr std::array<float, static_cast<size_t>(AspectRatioType::MaxCount) + 1> ars = {{4.0f / 3.0f, 4.0f / 3.0f, 4.0f / 3.0f, 16.0f / 9.0f, 3.0f / 2.0f}};

--- a/pcsx2/GS/Renderers/Common/GSRenderer.h
+++ b/pcsx2/GS/Renderers/Common/GSRenderer.h
@@ -52,6 +52,7 @@ public:
 	virtual float GetUpscaleMultiplier() { return 1.0f; }
 	virtual float GetTextureScaleFactor() { return 1.0f; }
 	GSVector2i GetInternalResolution();
+	float GetModXYOffset();
 
 	virtual GSTexture* LookupPaletteSource(u32 CBP, u32 CPSM, u32 CBW, GSVector2i& offset, float* scale, const GSVector2i& size);
 

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -4081,17 +4081,7 @@ void GSRendererHW::DrawPrims(GSTextureCache::Target* rt, GSTextureCache::Target*
 	//but introduces a few bad pixels on the edges.
 	if (!rt)
 	{
-		if (GSConfig.UserHacks_HalfPixelOffset == 1)
-		{
-			mod_xy = g_gs_renderer->GetUpscaleMultiplier();
-			switch (static_cast<int>(std::round(g_gs_renderer->GetUpscaleMultiplier())))
-			{
-				case 2: case 4: case 6: case 8: mod_xy += 0.2f; break;
-				case 3: case 7:                 mod_xy += 0.1f; break;
-				case 5:                         mod_xy += 0.3f; break;
-				default:                        mod_xy = 0.0f; break;
-			}
-		}
+		mod_xy = GetModXYOffset();
 	}
 	else
 		mod_xy = rt->OffsetHack_modxy;

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -4074,16 +4074,32 @@ void GSRendererHW::DrawPrims(GSTextureCache::Target* rt, GSTextureCache::Target*
 	const float oy = static_cast<float>(static_cast<int>(m_context->XYOFFSET.OFY));
 	float ox2 = -1.0f / rtsize.x;
 	float oy2 = -1.0f / rtsize.y;
-
+	float mod_xy = 0.0f;
 	//This hack subtracts around half a pixel from OFX and OFY.
 	//
 	//The resulting shifted output aligns better with common blending / corona / blurring effects,
 	//but introduces a few bad pixels on the edges.
-
-	if (rt && rt->OffsetHack_modxy > 1.0f)
+	if (!rt)
 	{
-		ox2 *= rt->OffsetHack_modxy;
-		oy2 *= rt->OffsetHack_modxy;
+		if (GSConfig.UserHacks_HalfPixelOffset == 1)
+		{
+			mod_xy = g_gs_renderer->GetUpscaleMultiplier();
+			switch (static_cast<int>(std::round(g_gs_renderer->GetUpscaleMultiplier())))
+			{
+				case 2: case 4: case 6: case 8: mod_xy += 0.2f; break;
+				case 3: case 7:                 mod_xy += 0.1f; break;
+				case 5:                         mod_xy += 0.3f; break;
+				default:                        mod_xy = 0.0f; break;
+			}
+		}
+	}
+	else
+		mod_xy = rt->OffsetHack_modxy;
+
+	if (mod_xy > 1.0f)
+	{
+		ox2 *= mod_xy;
+		oy2 *= mod_xy;
 	}
 
 	m_conf.cb_vs.vertex_scale = GSVector2(sx, sy);

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -3155,16 +3155,9 @@ GSTextureCache::Source* GSTextureCache::CreateSource(const GIFRegTEX0& TEX0, con
 		// The offset will be used in Draw().
 		float modxy = 0.0f;
 
-		if (GSConfig.UserHacks_HalfPixelOffset == 1 && hack)
+		if (hack)
 		{
-			modxy = g_gs_renderer->GetUpscaleMultiplier();
-			switch (static_cast<int>(std::round(g_gs_renderer->GetUpscaleMultiplier())))
-			{
-				case 2: case 4: case 6: case 8: modxy += 0.2f; break;
-				case 3: case 7:                 modxy += 0.1f; break;
-				case 5:                         modxy += 0.3f; break;
-				default:                        modxy  = 0.0f; break;
-			}
+			modxy = g_gs_renderer->GetModXYOffset();
 		}
 
 		dst->OffsetHack_modxy = modxy;


### PR DESCRIPTION
### Description of Changes
Provide HPO Normal offsets when there is no Render Target.

### Rationale behind Changes
HPO offsets are usually provided by the Render Target, so if a draw is doing the depth only and no offsets are provided, this is basically undefined behaviour, causing bad draws, this was evident in Kingdom Hearts: Chain of Memories and I believe Rogue Galaxy as reported here: https://forums.pcsx2.net/Thread-Bug-Report-Rogue-Galaxy-NTSC-U

### Suggested Testing Steps
Test Kingdom Hearts and Rogue Galaxy while upscaling.

Kingdom Hearts (the rendering of Sora is the only part of interest here):
Master:
![image](https://user-images.githubusercontent.com/6278726/228384740-5c980346-48f2-4c6e-9c0d-683137858774.png)

PR:
![image](https://user-images.githubusercontent.com/6278726/228384783-5be01e29-7eca-4279-8d69-65611672542b.png)

