### PR TITLE
GS-TC: Fix up page translation logic, clean up variables

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.h
@@ -425,8 +425,8 @@ public:
 	void ReadbackAll();
 	void AddDirtyRectTarget(Target* target, GSVector4i rect, u32 psm, u32 bw, RGBAMask rgba, bool req_linear = false);
 	bool CanTranslate(u32 bp, u32 bw, u32 spsm, GSVector4i r, u32 dbp, u32 dpsm, u32 dbw);
-	GSVector4i TranslateAlignedRectByPage(u32 sbp, u32 spsm, u32 sbw, GSVector4i src_r, u32 dbp, u32 dpsm, u32 bw, bool is_invalidation = false);
-	void DirtyRectByPage(u32 sbp, u32 spsm, u32 sbw, Target* t, GSVector4i src_r, u32 dbp, u32 dpsm, u32 bw);
+	GSVector4i TranslateAlignedRectByPage(Target* t, u32 sbp, u32 spsm, u32 sbw, GSVector4i src_r, bool is_invalidation = false);
+	void DirtyRectByPage(u32 sbp, u32 spsm, u32 sbw, Target* t, GSVector4i src_r);
 
 	GSTexture* LookupPaletteSource(u32 CBP, u32 CPSM, u32 CBW, GSVector2i& offset, float* scale, const GSVector2i& size);
 


### PR DESCRIPTION
### Description of Changes
Fixes up Translate by page behaviour and clean up required variables.
Also only abort local mem invalidate on exact match.

### Rationale behind Changes
When I originally did this, I assumed buffer width was in pages, it isn't, which gave incorrect results.  It flukely got away with it, but it wasn't right so now it's fixed up.
Gran Turismo 3 seems to be getting multiple overlapping targets on boot, causing it to invalidate the memory with incorrect data. Now it will only complete the invalidation early if the target matches exactly.

### Suggested Testing Steps
Test games, especially those which require Tex in RT. No known fixes/breakages however. Also GT3

Fixes the split time car sprites in Gran Turismo 3.
