### PR TITLE
GS-HW: Check what channel is being read during a possible split shuffle

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -863,6 +863,10 @@ bool GSRendererHW::IsSplitTextureShuffle()
 		return false;
 	}
 
+	// Different channel being shuffled, so needs to be handled separately (misdetection in 50 Cent)
+	if (m_vertex.buff[m_index.buff[0]].U != m_v.U)
+		return false;
+
 	// Check that both the position and texture coordinates are page aligned, so we can work in pages instead of coordinates.
 	// For texture shuffles, the U will be offset by 8.
 	const GSLocalMemory::psm_t& frame_psm = GSLocalMemory::m_psm[m_context->FRAME.PSM];


### PR DESCRIPTION
### Description of Changes
Check what channel is being read during split shuffle detection.

### Rationale behind Changes
50 Cent Bulletproof was misdetecting this effect as it does 2 shuffles, one for the green channel, the one for the red, but it was being detected as the same shuffle, making the screen very green! So now we change that the first UV's for each shuffle match up.

### Suggested Testing Steps
Test 50 Cent (I've checked GS dumps).

50Cent:
Master:
![image](https://user-images.githubusercontent.com/6278726/228683178-4ca7a6c6-57b4-498e-93c5-c371f88eb79c.png)

PR:
![image](https://user-images.githubusercontent.com/6278726/228683247-e2fc8fc9-72f6-4870-b369-2140cf63b6dd.png)

Fixes #8503
