### PR TITLE
CI: Switch Windows Qt builds to Clang

### DIFF
--- a/.github/workflows/release_pipeline.yml
+++ b/.github/workflows/release_pipeline.yml
@@ -28,6 +28,7 @@ jobs:
       jobName: Qt
       configuration: CMake
       buildSystem: cmake
+      cmakeFlags: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl
     secrets: inherit
 
   # MacOS


### PR DESCRIPTION
### Description of Changes
Switches the Qt builds over to using Clang by default which should be a bit faster overall.

### Rationale behind Changes
Gotta go fast.

### Suggested Testing Steps
Make sure CI is happy.
