### PR TITLE
SPU2: Remove GetLongName() from SndOutModule

### DIFF
--- a/pcsx2/SPU2/SndOut.cpp
+++ b/pcsx2/SPU2/SndOut.cpp
@@ -48,11 +48,6 @@ namespace
 			return "nullout";
 		}
 
-		const char* GetLongName() const override
-		{
-			return "No Sound (Emulate SPU2 only)";
-		}
-
 		const char* const* GetBackendNames() const override
 		{
 			return nullptr;

--- a/pcsx2/SPU2/SndOut.h
+++ b/pcsx2/SPU2/SndOut.h
@@ -326,10 +326,6 @@ public:
 	// (usually just matches the driver's cpp filename)
 	virtual const char* GetIdent() const = 0;
 
-	// Returns the long name / description for this driver.
-	// (for use in configuration screen)
-	virtual const char* GetLongName() const = 0;
-
 	// Returns a null-terminated list of backends, or nullptr.
 	virtual const char* const* GetBackendNames() const = 0;
 

--- a/pcsx2/SPU2/SndOut_Cubeb.cpp
+++ b/pcsx2/SPU2/SndOut_Cubeb.cpp
@@ -378,11 +378,6 @@ public:
 		return "cubeb";
 	}
 
-	const char* GetLongName() const override
-	{
-		return "Cubeb (Cross-platform)";
-	}
-
 	const char* const* GetBackendNames() const override
 	{
 		return cubeb_get_backend_names();

--- a/pcsx2/SPU2/SndOut_XAudio2.cpp
+++ b/pcsx2/SPU2/SndOut_XAudio2.cpp
@@ -359,11 +359,6 @@ public:
 		return "xaudio2";
 	}
 
-	const char* GetLongName() const override
-	{
-		return "XAudio 2 (Recommended)";
-	}
-
 	const char* const* GetBackendNames() const override
 	{
 		return nullptr;


### PR DESCRIPTION
### Description of Changes

Unused since WX.

### Rationale behind Changes

Less code.

### Suggested Testing Steps

Make sure build passes.

