### PR TITLE
x86/iFPU: Inline FPU_MUL_HACK to dynarec

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -1532,7 +1532,7 @@ void GSRendererHW::Draw()
 		{
 			// Force enable preloading if any of the existing data is needed.
 			// e.g. NFSMW only writes the alpha channel, and needs the RGB preloaded.
-			if ((fm & fm_mask) != 0 && ((fm & fm_mask) != fm_mask) || // Some channels masked
+			if (((fm & fm_mask) != 0 && ((fm & fm_mask) != fm_mask)) || // Some channels masked
 				!IsOpaque()) // Blending enabled
 			{
 				GL_INS("Forcing preload due to partial/blended CLUT draw");

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -292,7 +292,7 @@ GSVector4i GSTextureCache::TranslateAlignedRectByPage(Target* t, u32 sbp, u32 sp
 				if (!is_invalidation)
 					return GSVector4i::zero();
 
-				const u32 offset = rect_pages.z - (dst_pgw);
+				// const u32 offset = rect_pages.z - (dst_pgw);
 				new_rect.x = 0;
 				new_rect.z = dst_pgw * dst_page_size.x;
 				new_rect.w += dst_page_size.y;
@@ -457,7 +457,7 @@ void GSTextureCache::DirtyRectByPage(u32 sbp, u32 spsm, u32 sbw, Target* t, GSVe
 			// Kinda scary but covering the whole row and the next one should be okay? :/ (Check with MVP 07, sbp == 0x39a0)
 			if (rect_pages.z > static_cast<int>(dst_pgw))
 			{
-				u32 offset = rect_pages.z - (dst_pgw);
+				// u32 offset = rect_pages.z - (dst_pgw);
 				new_rect.x = 0;
 				new_rect.z = dst_pgw * dst_page_size.x;
 				new_rect.w += dst_page_size.y;
@@ -699,7 +699,6 @@ GSTextureCache::Source* GSTextureCache::LookupSource(const GIFRegTEX0& TEX0, con
 		// else.)
 
 		bool found_t = false;
-		bool tex_in_rt = false;
 		bool tex_merge_rt = false;
 		for (auto t : m_dst[RenderTarget])
 		{
@@ -853,7 +852,6 @@ GSTextureCache::Source* GSTextureCache::LookupSource(const GIFRegTEX0& TEX0, con
 							dst = t;
 
 						found_t = true;
-						tex_in_rt = false;
 						tex_merge_rt = false;
 						x_offset = 0;
 						y_offset = 0;
@@ -868,7 +866,6 @@ GSTextureCache::Source* GSTextureCache::LookupSource(const GIFRegTEX0& TEX0, con
 					half_right = true;
 					dst = t;
 					found_t = true;
-					tex_in_rt = false;
 					tex_merge_rt = false;
 					x_offset = 0;
 					y_offset = 0;
@@ -945,7 +942,6 @@ GSTextureCache::Source* GSTextureCache::LookupSource(const GIFRegTEX0& TEX0, con
 							x_offset = rect.x;
 							y_offset = rect.y;
 							dst = t;
-							tex_in_rt = true;
 							tex_merge_rt = false;
 							found_t = true;
 							continue;
@@ -965,7 +961,6 @@ GSTextureCache::Source* GSTextureCache::LookupSource(const GIFRegTEX0& TEX0, con
 								// Offset from Target to Source in Target coords.
 								x_offset = so.b2a_offset.x;
 								y_offset = so.b2a_offset.y;
-								tex_in_rt = true;
 								tex_merge_rt = false;
 								found_t = true;
 								// Keep looking, just in case there is an exact match (Situation: Target frame drawn inside target frame, current makes a separate texture)
@@ -978,7 +973,6 @@ GSTextureCache::Source* GSTextureCache::LookupSource(const GIFRegTEX0& TEX0, con
 						dst = t;
 						x_offset = 0;
 						y_offset = 0;
-						tex_in_rt = false;
 						tex_merge_rt = true;
 
 						// Prefer a target inside over a target outside.

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
@@ -1135,11 +1135,6 @@ void GSDeviceVK::ClearSamplerCache()
 	m_tfx_sampler = m_point_sampler;
 }
 
-static void AddMacro(std::stringstream& ss, const char* name, const char* value)
-{
-	ss << "#define " << name << " " << value << "\n";
-}
-
 static void AddMacro(std::stringstream& ss, const char* name, int value)
 {
 	ss << "#define " << name << " " << value << "\n";

--- a/pcsx2/x86/iFPU.cpp
+++ b/pcsx2/x86/iFPU.cpp
@@ -526,26 +526,29 @@ void FPU_SUB(int regd, int regt)
 // or SMALLER (by 0x1). (this means that x86's other rounding modes are only less similar to PS2's mul)
 //------------------------------------------------------------------
 
-u32 FPU_MUL_HACK(u32 s, u32 t)
-{
-	if ((s == 0x3e800000) && (t == 0x40490fdb))
-		return 0x3f490fda; // needed for Tales of Destiny Remake (only in a very specific room late-game)
-	else
-		return 0;
-}
-
 void FPU_MUL(int regd, int regt, bool reverseOperands)
 {
 	u8 *endMul = nullptr;
 
 	if (CHECK_FPUMULHACK)
 	{
+		// 	if ((s == 0x3e800000) && (t == 0x40490fdb))
+		// 		return 0x3f490fda; // needed for Tales of Destiny Remake (only in a very specific room late-game)
+		// 	else
+		// 		return 0;
+
+		alignas(16) static constexpr const u32 result[4] = { 0x3e800000 };
+
 		xMOVD(ecx, xRegisterSSE(reverseOperands ? regt : regd));
 		xMOVD(edx, xRegisterSSE(reverseOperands ? regd : regt));
-		xFastCall((void*)(uptr)&FPU_MUL_HACK, ecx, edx); //returns the hacked result or 0
-		xTEST(eax, eax);
-		u8* noHack = JZ8(0);
-			xMOVDZX(xRegisterSSE(regd), eax);
+
+		// if (((s ^ 0x3e800000) | (t ^ 0x40490fdb)) != 0) { hack; }
+		xXOR(ecx, 0x3e800000);
+		xXOR(edx, 0x40490fdb);
+		xOR(edx, ecx);
+
+		u8* noHack = JNZ8(0);
+			xMOVAPS(xRegisterSSE(regd), ptr128[result]);
 			endMul = JMP8(0);
 		x86SetJ8(noHack);
 	}

--- a/pcsx2/x86/iFPUd.cpp
+++ b/pcsx2/x86/iFPUd.cpp
@@ -63,8 +63,6 @@ namespace Dynarec {
 namespace OpcodeImpl {
 namespace COP1 {
 
-u32 FPU_MUL_HACK(u32 s, u32 t);
-
 namespace DOUBLE {
 
 //------------------------------------------------------------------
@@ -413,17 +411,28 @@ void FPU_ADD_SUB(int tempd, int tempt) //tempd and tempt are overwritten, they a
 
 void FPU_MUL(int info, int regd, int sreg, int treg, bool acc)
 {
-	u32* endMul = nullptr;
+	u8* endMul = nullptr;
 
 	if (CHECK_FPUMULHACK)
 	{
-		xMOVD(arg1regd, xRegisterSSE(sreg));
-		xMOVD(arg2regd, xRegisterSSE(treg));
-		xFastCall((void*)(uptr)&FPU_MUL_HACK, arg1regd, arg2regd); //returns the hacked result or 0
-		xTEST(eax, eax);
-		u8* noHack = JZ8(0);
-			xMOVDZX(xRegisterSSE(regd), eax);
-			endMul = JMP32(0);
+		// 	if ((s == 0x3e800000) && (t == 0x40490fdb))
+		// 		return 0x3f490fda; // needed for Tales of Destiny Remake (only in a very specific room late-game)
+		// 	else
+		// 		return 0;
+
+		alignas(16) static constexpr const u32 result[4] = { 0x3e800000 };
+
+		xMOVD(ecx, xRegisterSSE(sreg));
+		xMOVD(edx, xRegisterSSE(treg));
+
+		// if (((s ^ 0x3e800000) | (t ^ 0x40490fdb)) != 0) { hack; }
+		xXOR(ecx, 0x3e800000);
+		xXOR(edx, 0x40490fdb);
+		xOR(edx, ecx);
+
+		u8* noHack = JNZ8(0);
+			xMOVAPS(xRegisterSSE(regd), ptr128[result]);
+			endMul = JMP8(0);
 		x86SetJ8(noHack);
 	}
 
@@ -433,7 +442,7 @@ void FPU_MUL(int info, int regd, int sreg, int treg, bool acc)
 	xMOVSS(xRegisterSSE(regd), xRegisterSSE(sreg));
 
 	if (CHECK_FPUMULHACK)
-		x86SetJ32(endMul);
+		x86SetJ8(endMul);
 }
 
 //------------------------------------------------------------------


### PR DESCRIPTION
### Description of Changes

Fixes Tales of Destiny crashing on clang builds (clang was using r8, which was allocated by a caller, msvc was not).

Also cleans up some new warnings it was spewing.

### Rationale behind Changes

Has been a bug since my dynarec optimizations, but nobody noticed.

### Suggested Testing Steps

Test Tales of Destiny on clang build.
