### PR TITLE
GS/HW: Add NativePaletteDraw upscaling fix

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -10656,7 +10656,7 @@ SLES-50386:
   region: "PAL-M6"
   compat: 5
   gsHWFixes:
-    getSkipCount: "GSC_CrashBandicootWoC"
+    nativePaletteDraw: 1
 SLES-50390:
   name: "Driven"
   region: "PAL-M5"
@@ -26193,7 +26193,7 @@ SLPM-62114:
   name: "Crash Bandicoot 4 - Sakuretsu! Majin Power"
   region: "NTSC-J"
   gsHWFixes:
-    getSkipCount: "GSC_CrashBandicootWoC"
+    nativePaletteDraw: 1
 SLPM-62115:
   name: "EX Jinsei Game [Doukonban]"
   region: "NTSC-J"
@@ -28124,12 +28124,12 @@ SLPM-64509:
   name: "Crash Bandicoot - Return of the Demon King [English Dub Edition]" # Wrath of Cortex
   region: "NTSC-K"
   gsHWFixes:
-    getSkipCount: "GSC_CrashBandicootWoC"
+    nativePaletteDraw: 1
 SLPM-64513:
   name: "Crash Bandicoot - Mawangui Buwhal" # Wrath of Cortex
   region: "NTSC-K"
   gsHWFixes:
-    getSkipCount: "GSC_CrashBandicootWoC"
+    nativePaletteDraw: 1
 SLPM-64514:
   name: "Legends of Wrestling"
   region: "NTSC-K"
@@ -35774,7 +35774,7 @@ SLPM-74003:
   name: "Crash Bandicoot 4 - Sakuretsu! Majin Power! [PlayStation 2 The Best]"
   region: "NTSC-J"
   gsHWFixes:
-    getSkipCount: "GSC_CrashBandicootWoC"
+    nativePaletteDraw: 1
 SLPM-74004:
   name: "Maximo - Ghosts to Glory [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -42565,7 +42565,7 @@ SLUS-20238:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    getSkipCount: "GSC_CrashBandicootWoC"
+    nativePaletteDraw: 1
 SLUS-20239:
   name: "Driven"
   region: "NTSC-U"
@@ -51333,7 +51333,7 @@ SLUS-29010:
   name: "Crash Bandicoot - The Wrath of Cortex [Demo]"
   region: "NTSC-U"
   gsHWFixes:
-    getSkipCount: "GSC_CrashBandicootWoC"
+    nativePaletteDraw: 1
 SLUS-29011:
   name: "WWF SmackDown! - Just Bring It [Demo]"
   region: "NTSC-U"
@@ -52236,9 +52236,9 @@ VW067-J1:
   name: "Crash Bandicoot 4 - Sakuretsu! Majin Power!"
   region: "NTSC-J"
   gsHWFixes:
-    getSkipCount: "GSC_CrashBandicootWoC"
+    nativePaletteDraw: 1
 VW067-J2:
   name: "Crash Bandicoot 4 - Sakuretsu! Majin Power! [PlayStation 2 The Best]"
   region: "NTSC-J"
   gsHWFixes:
-    getSkipCount: "GSC_CrashBandicootWoC"
+    nativePaletteDraw: 1

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -235,6 +235,7 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsDialog* dialog, QWidget* 
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.mergeSprite, "EmuCore/GS", "UserHacks_merge_pp_sprite", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.wildHack, "EmuCore/GS", "UserHacks_WildHack", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.bilinearHack, "EmuCore/GS", "UserHacks_BilinearHack", false);
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.nativePaletteDraw, "EmuCore/GS", "UserHacks_NativePaletteDraw", false);
 	//////////////////////////////////////////////////////////////////////////
 	// Texture Replacements
 	//////////////////////////////////////////////////////////////////////////

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
@@ -1224,13 +1224,6 @@
        </item>
        <item row="3" column="0" colspan="2">
         <layout class="QGridLayout" name="gridLayout_3">
-         <item row="0" column="1">
-          <widget class="QCheckBox" name="mergeSprite">
-           <property name="text">
-            <string>Merge Sprite</string>
-           </property>
-          </widget>
-         </item>
          <item row="0" column="0">
           <widget class="QCheckBox" name="alignSprite">
            <property name="text">
@@ -1249,6 +1242,20 @@
           <widget class="QCheckBox" name="bilinearHack">
            <property name="text">
             <string>Bilinear Dirty Upscale</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QCheckBox" name="mergeSprite">
+           <property name="text">
+            <string>Merge Sprite</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QCheckBox" name="nativePaletteDraw">
+           <property name="text">
+            <string>Unscaled Palette Texture Draws</string>
            </property>
           </widget>
          </item>

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -678,6 +678,7 @@ struct Pcsx2Config
 					UserHacks_MergePPSprite : 1,
 					UserHacks_WildHack : 1,
 					UserHacks_BilinearHack : 1,
+					UserHacks_NativePaletteDraw : 1,
 					UserHacks_TargetPartialInvalidation : 1,
 					UserHacks_EstimateTextureRegion : 1,
 					FXAA : 1,

--- a/pcsx2/Docs/gamedb-schema.json
+++ b/pcsx2/Docs/gamedb-schema.json
@@ -176,6 +176,11 @@
               "minimum": 0,
               "maximum": 1
             },
+            "nativePaletteDraw": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 1
+            },
             "estimateTextureRegion": {
               "type": "integer",
               "minimum": 0,

--- a/pcsx2/Frontend/FullscreenUI.cpp
+++ b/pcsx2/Frontend/FullscreenUI.cpp
@@ -3241,6 +3241,8 @@ void FullscreenUI::DrawGraphicsSettingsPage()
 			DrawToggleSetting(bsi, "Bilinear Upscale",
 				"Can smooth out textures due to be bilinear filtered when upscaling. E.g. Brave sun glare.", "EmuCore/GS",
 				"UserHacks_BilinearHack", false, manual_hw_fixes);
+			DrawToggleSetting(bsi, "Unscaled Palette Texture Draws", "Can fix some broken effects which rely on pixel perfect precision.",
+				"EmuCore/GS", "UserHacks_NativePaletteDraw", false, manual_hw_fixes);
 		}
 	}
 

--- a/pcsx2/Frontend/ImGuiOverlays.cpp
+++ b/pcsx2/Frontend/ImGuiOverlays.cpp
@@ -417,6 +417,8 @@ void ImGuiManager::DrawSettingsOverlay()
 			APPEND("WA ");
 		if (GSConfig.UserHacks_BilinearHack)
 			APPEND("BLU ");
+		if (GSConfig.UserHacks_NativePaletteDraw)
+			APPEND("NPD ");
 		if (GSConfig.UserHacks_MergePPSprite)
 			APPEND("MS ");
 		if (GSConfig.UserHacks_AlignSpriteX)

--- a/pcsx2/GS/Renderers/HW/GSHwHack.cpp
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.cpp
@@ -996,7 +996,7 @@ bool GSHwHack::OI_RozenMaidenGebetGarden(GSRendererHW& r, GSTexture* rt, GSTextu
 			TEX0.TBW = RCONTEXT->FRAME.FBW;
 			TEX0.PSM = RCONTEXT->FRAME.PSM;
 
-			if (GSTextureCache::Target* tmp_rt = g_texture_cache->LookupTarget(TEX0, r.GetTargetSize(), r.GetTextureScaleFactor(), GSTextureCache::RenderTarget, true))
+			if (GSTextureCache::Target* tmp_rt = g_texture_cache->LookupTarget(TEX0, r.GetTargetSize(), r.GetTextureScaleFactor(), GSTextureCache::RenderTarget))
 			{
 				GL_INS("OI_RozenMaidenGebetGarden FB clear");
 				g_gs_device->ClearRenderTarget(tmp_rt->m_texture, 0);
@@ -1014,7 +1014,7 @@ bool GSHwHack::OI_RozenMaidenGebetGarden(GSRendererHW& r, GSTexture* rt, GSTextu
 			TEX0.TBW = RCONTEXT->FRAME.FBW;
 			TEX0.PSM = RCONTEXT->ZBUF.PSM;
 
-			if (GSTextureCache::Target* tmp_ds = g_texture_cache->LookupTarget(TEX0, r.GetTargetSize(), r.GetTextureScaleFactor(), GSTextureCache::DepthStencil, true))
+			if (GSTextureCache::Target* tmp_ds = g_texture_cache->LookupTarget(TEX0, r.GetTargetSize(), r.GetTextureScaleFactor(), GSTextureCache::DepthStencil))
 			{
 				GL_INS("OI_RozenMaidenGebetGarden ZB clear");
 				g_gs_device->ClearDepth(tmp_ds->m_texture);
@@ -1047,7 +1047,7 @@ bool GSHwHack::OI_SonicUnleashed(GSRendererHW& r, GSTexture* rt, GSTexture* ds, 
 
 	GL_INS("OI_SonicUnleashed replace draw by a copy");
 
-	GSTextureCache::Target* src = g_texture_cache->LookupTarget(Texture, GSVector2i(1, 1), r.GetTextureScaleFactor(), GSTextureCache::RenderTarget, true);
+	GSTextureCache::Target* src = g_texture_cache->LookupTarget(Texture, GSVector2i(1, 1), r.GetTextureScaleFactor(), GSTextureCache::RenderTarget);
 
 	const GSVector2i src_size(src->m_texture->GetSize());
 	GSVector2i rt_size(rt->GetSize());
@@ -1055,7 +1055,7 @@ bool GSHwHack::OI_SonicUnleashed(GSRendererHW& r, GSTexture* rt, GSTexture* ds, 
 	// This is awful, but so is the CRC hack... it's a texture shuffle split horizontally instead of vertically.
 	if (rt_size.x < src_size.x || rt_size.y < src_size.y)
 	{
-		GSTextureCache::Target* rt_again = g_texture_cache->LookupTarget(Frame, src_size, src->m_scale, GSTextureCache::RenderTarget, true);
+		GSTextureCache::Target* rt_again = g_texture_cache->LookupTarget(Frame, src_size, src->m_scale, GSTextureCache::RenderTarget);
 		if (rt_again->m_unscaled_size.x < src->m_unscaled_size.x || rt_again->m_unscaled_size.y < src->m_unscaled_size.y)
 		{
 			rt_again->ResizeTexture(std::max(rt_again->m_unscaled_size.x, src->m_unscaled_size.x),
@@ -1137,7 +1137,7 @@ bool GSHwHack::GSC_Battlefield2(GSRendererHW& r, const GSFrameInfo& fi, int& ski
 			GIFRegTEX0 TEX0 = {};
 			TEX0.TBP0 = fi.FBP;
 			TEX0.TBW = 8;
-			GSTextureCache::Target* dst = g_texture_cache->LookupTarget(TEX0, r.GetTargetSize(), r.GetTextureScaleFactor(), GSTextureCache::DepthStencil, true);
+			GSTextureCache::Target* dst = g_texture_cache->LookupTarget(TEX0, r.GetTargetSize(), r.GetTextureScaleFactor(), GSTextureCache::DepthStencil);
 			if (dst)
 			{
 				g_gs_device->ClearDepth(dst->m_texture);

--- a/pcsx2/GS/Renderers/HW/GSHwHack.cpp
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.cpp
@@ -108,39 +108,6 @@ bool GSHwHack::GSC_Manhunt2(GSRendererHW& r, const GSFrameInfo& fi, int& skip)
 	return true;
 }
 
-bool GSHwHack::GSC_CrashBandicootWoC(GSRendererHW& r, const GSFrameInfo& fi, int& skip)
-{
-	if (s_nativeres)
-		return false;
-
-	// Channel effect not properly supported - Removes fog to fix the fog wall issue on Direct3D at any resolution, and while upscaling on every Hardware renderer.
-	if (skip == 0)
-	{
-		if (fi.TME && (fi.FBP == 0x00000 || fi.FBP == 0x008c0 || fi.FBP == 0x00a00) && (fi.TBP0 == 0x00000 || fi.TBP0 == 0x008c0 || fi.TBP0 == 0x00a00) && fi.FBP == fi.TBP0 && fi.FPSM == PSM_PSMCT32 && fi.FPSM == fi.TPSM)
-		{
-			return false; // allowed
-		}
-
-		if (fi.TME && (fi.FBP == 0x01e40 || fi.FBP == 0x02200) && fi.FPSM == PSM_PSMZ24 && (fi.TBP0 == 0x01180 || fi.TBP0 == 0x01400) && fi.TPSM == PSM_PSMZ24)
-		{
-			skip = 42;
-		}
-	}
-	else
-	{
-		if (fi.TME && (fi.FBP == 0x00000 || fi.FBP == 0x008c0 || fi.FBP == 0x00a00) && fi.FPSM == PSM_PSMCT32 && fi.TBP0 == 0x03c00 && fi.TPSM == PSM_PSMCT32)
-		{
-			skip = 0;
-		}
-		else if (!fi.TME && (fi.FBP == 0x00000 || fi.FBP == 0x008c0 || fi.FBP == 0x00a00))
-		{
-			skip = 0;
-		}
-	}
-
-	return true;
-}
-
 bool GSHwHack::GSC_SacredBlaze(GSRendererHW& r, const GSFrameInfo& fi, int& skip)
 {
 	//Fix Sacred Blaze rendering glitches
@@ -1212,7 +1179,6 @@ const GSHwHack::Entry<GSRendererHW::GSC_Ptr> GSHwHack::s_get_skip_count_function
 	CRC_F(GSC_Battlefield2, CRCHackLevel::Partial),
 
 	// Channel Effect
-	CRC_F(GSC_CrashBandicootWoC, CRCHackLevel::Partial),
 	CRC_F(GSC_GiTS, CRCHackLevel::Partial),
 	CRC_F(GSC_SteambotChronicles, CRCHackLevel::Partial),
 

--- a/pcsx2/GS/Renderers/HW/GSHwHack.h
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.h
@@ -21,7 +21,6 @@ public:
 	static bool GSC_DeathByDegreesTekkenNinaWilliams(GSRendererHW& r, const GSFrameInfo& fi, int& skip);
 	static bool GSC_GiTS(GSRendererHW& r, const GSFrameInfo& fi, int& skip);
 	static bool GSC_Manhunt2(GSRendererHW& r, const GSFrameInfo& fi, int& skip);
-	static bool GSC_CrashBandicootWoC(GSRendererHW& r, const GSFrameInfo& fi, int& skip);
 	static bool GSC_SacredBlaze(GSRendererHW& r, const GSFrameInfo& fi, int& skip);
 	static bool GSC_SakuraTaisen(GSRendererHW& r, const GSFrameInfo& fi, int& skip);
 	static bool GSC_SFEX3(GSRendererHW& r, const GSFrameInfo& fi, int& skip);

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -2733,7 +2733,8 @@ bool GSRendererHW::TestChannelShuffle(GSTextureCache::Target* src)
 		(((m_vt.m_max.p - m_vt.m_min.p) <= GSVector4(64.0f)).mask() & 0x3) == 0x3); // single_page
 
 	// This is a little redundant since it'll get called twice, but the only way to stop us wasting time on copies.
-	return (shuffle && EmulateChannelShuffle(src, true));
+	m_channel_shuffle = (shuffle && EmulateChannelShuffle(src, true));
+	return m_channel_shuffle;
 }
 
 __ri bool GSRendererHW::EmulateChannelShuffle(GSTextureCache::Target* src, bool test_only)

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -1794,6 +1794,18 @@ void GSRendererHW::Draw()
 	// Ensure draw rect is clamped to framebuffer size. Necessary for updating valid area.
 	m_r = m_r.rintersect(GSVector4i::loadh(t_size));
 
+	float target_scale = GetTextureScaleFactor();
+
+	// This upscaling hack is for games which construct P8 textures by drawing a bunch of small sprites in C32,
+	// then reinterpreting it as P8. We need to keep the off-screen intermediate textures at native resolution,
+	// but not propagate that through to the normal render targets. Test Case: Crash Wrath of Cortex.
+	if (no_ds && src && !m_channel_shuffle && GSConfig.UserHacks_NativePaletteDraw && src->m_from_target &&
+		src->m_scale == 1.0f && (src->m_TEX0.PSM == PSM_PSMT8 || src->m_TEX0.TBP0 == m_context->FRAME.Block()))
+	{
+		GL_CACHE("Using native resolution for target based on texture source");
+		target_scale = 1.0f;
+	}
+
 	GSTextureCache::Target* rt = nullptr;
 	GIFRegTEX0 FRAME_TEX0;
 	if (!no_rt)

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -1883,9 +1883,6 @@ void GSRendererHW::Draw()
 			return;
 		}
 
-		// Texture shuffle is not yet supported with strange clamp mode
-		ASSERT(!m_texture_shuffle || (context->CLAMP.WMS < 3 && context->CLAMP.WMT < 3));
-
 		if (src->m_target && IsPossibleChannelShuffle())
 		{
 			GL_INS("Channel shuffle effect detected (2nd shot)");

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -1483,7 +1483,7 @@ void GSRendererHW::Draw()
 						|| (!context->TEST.DATE && (context->FRAME.FBMSK & GSLocalMemory::m_psm[context->FRAME.PSM].fmsk) == GSLocalMemory::m_psm[context->FRAME.PSM].fmsk);
 	const bool no_ds = (
 		// Depth is always pass/fail (no read) and write are discarded.
-		(zm != 0 && context->TEST.ZTST <= ZTST_ALWAYS) ||
+		(zm != 0 && (!context->TEST.ZTE || context->TEST.ZTST <= ZTST_ALWAYS)) ||
 		// Depth test will always pass
 		(zm != 0 && context->TEST.ZTST == ZTST_GEQUAL && m_vt.m_eq.z && std::min(m_vertex.buff[0].XYZ.Z, max_z) == max_z) ||
 		// Depth will be written through the RT

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -1807,7 +1807,9 @@ void GSRendererHW::Draw()
 		// (very close to 1024x1024, but apparently the GS rounds down..). So, catch that here, we don't want to
 		// create that target, because the clear isn't black, it'll hang around and never get invalidated.
 		const bool is_square = (t_size.y == t_size.x) && m_r.w >= 1023 && m_vertex.next == 2;
-		rt = g_texture_cache->LookupTarget(FRAME_TEX0, t_size, GetTextureScaleFactor(), GSTextureCache::RenderTarget, true, fm, false, force_preload, IsConstantDirectWriteMemClear(false) && is_square);
+		const bool is_clear = IsConstantDirectWriteMemClear(false) && is_square;
+		rt = g_texture_cache->LookupTarget(FRAME_TEX0, t_size, target_scale, GSTextureCache::RenderTarget, true,
+			fm, false, is_clear, force_preload);
 
 		// Draw skipped because it was a clear and there was no target.
 		if (!rt)
@@ -1827,7 +1829,8 @@ void GSRendererHW::Draw()
 		ZBUF_TEX0.TBW = context->FRAME.FBW;
 		ZBUF_TEX0.PSM = context->ZBUF.PSM;
 
-		ds = g_texture_cache->LookupTarget(ZBUF_TEX0, t_size, GetTextureScaleFactor(), GSTextureCache::DepthStencil, context->DepthWrite(), 0, false, force_preload);
+		ds = g_texture_cache->LookupTarget(ZBUF_TEX0, t_size, target_scale, GSTextureCache::DepthStencil,
+			context->DepthWrite(), 0, false, false, force_preload);
 	}
 
 	if (process_texture)
@@ -2030,7 +2033,6 @@ void GSRendererHW::Draw()
 	GSTextureCache::Target* old_ds = nullptr;
 	{
 		// We still need to make sure the dimensions of the targets match.
-		const float up_s = GetTextureScaleFactor();
 		const int new_w = std::max(t_size.x, std::max(rt ? rt->m_unscaled_size.x : 0, ds ? ds->m_unscaled_size.x : 0));
 		const int new_h = std::max(t_size.y, std::max(rt ? rt->m_unscaled_size.y : 0, ds ? ds->m_unscaled_size.y : 0));
 
@@ -2041,7 +2043,7 @@ void GSRendererHW::Draw()
 			const bool new_height = new_h > rt->GetUnscaledHeight();
 			const int old_height = rt->m_texture->GetHeight();
 
-			pxAssert(rt->GetScale() == up_s);
+			pxAssert(rt->GetScale() == target_scale);
 			rt->ResizeTexture(new_w, new_h);
 
 			if (!m_texture_shuffle && !m_channel_shuffle)
@@ -2081,7 +2083,7 @@ void GSRendererHW::Draw()
 			const bool new_height = new_h > ds->GetUnscaledHeight();
 			const int old_height = ds->m_texture->GetHeight();
 
-			pxAssert(ds->GetScale() == up_s);
+			pxAssert(ds->GetScale() == target_scale);
 			ds->ResizeTexture(new_w, new_h);
 
 			if (!m_texture_shuffle && !m_channel_shuffle)

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -2806,6 +2806,7 @@ GSTextureCache::Source* GSTextureCache::CreateSource(const GIFRegTEX0& TEX0, con
 	}
 
 	bool hack = false;
+	bool channel_shuffle = false;
 
 	if (dst && (x_offset != 0 || y_offset != 0))
 	{
@@ -2868,9 +2869,9 @@ GSTextureCache::Source* GSTextureCache::CreateSource(const GIFRegTEX0& TEX0, con
 		// TODO: clean up this mess
 
 		ShaderConvert shader = dst->m_type != RenderTarget ? ShaderConvert::FLOAT32_TO_RGBA8 : ShaderConvert::COPY;
-		const bool channel_shuffle = GSRendererHW::GetInstance()->TestChannelShuffle(dst);
-		const bool is_8bits = TEX0.PSM == PSM_PSMT8 && !channel_shuffle;
+		channel_shuffle = GSRendererHW::GetInstance()->TestChannelShuffle(dst);
 
+		const bool is_8bits = TEX0.PSM == PSM_PSMT8 && !channel_shuffle;
 		if (is_8bits)
 		{
 			GL_INS("Reading RT as a packed-indexed 8 bits format");
@@ -3134,7 +3135,7 @@ GSTextureCache::Source* GSTextureCache::CreateSource(const GIFRegTEX0& TEX0, con
 	ASSERT(src->m_texture);
 	ASSERT(src->m_target == (dst != nullptr));
 	ASSERT(src->m_from_target == dst);
-	ASSERT(src->m_scale == ((!dst || TEX0.PSM == PSM_PSMT8) ? 1.0f : dst->m_scale));
+	ASSERT(src->m_scale == ((!dst || (TEX0.PSM == PSM_PSMT8 && !channel_shuffle)) ? 1.0f : dst->m_scale));
 
 	if (src != m_temporary_source)
 	{

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -1072,7 +1072,8 @@ GSTextureCache::Target* GSTextureCache::FindTargetOverlap(u32 bp, u32 end_block,
 	return nullptr;
 }
 
-GSTextureCache::Target* GSTextureCache::LookupTarget(GIFRegTEX0 TEX0, const GSVector2i& size, float scale, int type, bool used, u32 fbmask, const bool is_frame, bool preload, bool is_clear)
+GSTextureCache::Target* GSTextureCache::LookupTarget(GIFRegTEX0 TEX0, const GSVector2i& size, float scale, int type,
+	bool used, u32 fbmask, bool is_frame, bool is_clear, bool preload)
 {
 	const GSLocalMemory::psm_t& psm_s = GSLocalMemory::m_psm[TEX0.PSM];
 	const u32 bp = TEX0.TBP0;
@@ -1388,10 +1389,9 @@ GSTextureCache::Target* GSTextureCache::LookupTarget(GIFRegTEX0 TEX0, const GSVe
 		}
 		dst->m_is_frame = is_frame;
 	}
-	if (used)
-	{
-		dst->m_used = true;
-	}
+
+	dst->m_used |= used;
+
 	if (is_frame)
 		dst->m_dirty_alpha = false;
 
@@ -2341,7 +2341,7 @@ bool GSTextureCache::Move(u32 SBP, u32 SBW, u32 SPSM, int sx, int sy, u32 DBP, u
 		new_TEX0.PSM = DPSM;
 
 		const GSVector2i target_size = GetTargetSize(DBP, DBW, DPSM, Common::AlignUpPow2(w, 64), h);
-		dst = LookupTarget(new_TEX0, target_size, src->m_scale, src->m_type, true);
+		dst = LookupTarget(new_TEX0, target_size, src->m_scale, src->m_type);
 		if (dst)
 		{
 			dst->UpdateValidity(GSVector4i(dx, dy, dx + w, dy + h));
@@ -3020,12 +3020,7 @@ GSTextureCache::Source* GSTextureCache::CreateSource(const GIFRegTEX0& TEX0, con
 			src->m_scale = dst->m_scale;
 			src->m_unscaled_size = dst->m_unscaled_size;
 			src->m_shared_texture = true;
-			src->m_target = true; // So renderer can check if a conversion is required
-			src->m_from_target = dst; // avoid complex condition on the renderer
-			src->m_from_target_TEX0 = dst->m_TEX0;
 			src->m_32_bits_fmt = dst->m_32_bits_fmt;
-			src->m_valid_rect = dst->m_valid;
-			src->m_end_block = dst->m_end_block;
 
 			// if the size doesn't match, we need to engage shader sampling.
 			if (new_size != dst_texture_size)
@@ -3579,7 +3574,7 @@ GSTextureCache::Target* GSTextureCache::CreateTarget(const GIFRegTEX0& TEX0, int
 
 	// TODO: This leaks if memory allocation fails. Use a unique_ptr so it gets freed, but these
 	// exceptions really need to get lost.
-	std::unique_ptr<Target> t = std::make_unique<Target>(TEX0, !GSConfig.UserHacks_DisableDepthSupport, type);
+	std::unique_ptr<Target> t = std::make_unique<Target>(TEX0, type);
 	t->m_unscaled_size = GSVector2i(w, h);
 	t->m_scale = scale;
 
@@ -4131,9 +4126,8 @@ bool GSTextureCache::Source::ClutMatch(const PaletteKey& palette_key)
 
 // GSTextureCache::Target
 
-GSTextureCache::Target::Target(const GIFRegTEX0& TEX0, const bool depth_supported, const int type)
+GSTextureCache::Target::Target(const GIFRegTEX0& TEX0, const int type)
 	: m_type(type)
-	, m_depth_supported(depth_supported)
 	, m_used(false)
 	, m_valid(GSVector4i::zero())
 {
@@ -4183,7 +4177,7 @@ void GSTextureCache::Target::Update(bool reset_age)
 		return;
 
 	// No handling please
-	if ((m_type == DepthStencil) && !m_depth_supported)
+	if (m_type == DepthStencil && GSConfig.UserHacks_DisableDepthSupport)
 	{
 		// do the most likely thing a direct write would do, clear it
 		GL_INS("ERROR: Update DepthStencil dummy");

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.h
@@ -205,7 +205,6 @@ public:
 	{
 	public:
 		const int m_type = 0;
-		const bool m_depth_supported = false;
 		bool m_dirty_alpha = true;
 		bool m_is_frame = false;
 		bool m_used = false;
@@ -217,7 +216,7 @@ public:
 		int readbacks_since_draw = 0;
 
 	public:
-		Target(const GIFRegTEX0& TEX0, const bool depth_supported, const int type);
+		Target(const GIFRegTEX0& TEX0, const int type);
 		~Target();
 
 		void ResizeDrawn(const GSVector4i& rect);
@@ -437,7 +436,8 @@ public:
 	Source* LookupDepthSource(const GIFRegTEX0& TEX0, const GIFRegTEXA& TEXA, const GIFRegCLAMP& CLAMP, const GSVector4i& r, bool palette = false);
 
 	Target* FindTargetOverlap(u32 bp, u32 end_block, int type, int psm);
-	Target* LookupTarget(GIFRegTEX0 TEX0, const GSVector2i& size, float scale, int type, bool used, u32 fbmask = 0, const bool is_frame = false, bool preload = GSConfig.PreloadFrameWithGSData, bool is_clear = false);
+	Target* LookupTarget(GIFRegTEX0 TEX0, const GSVector2i& size, float scale, int type, bool used = true, u32 fbmask = 0,
+		bool is_frame = false, bool is_clear = false, bool preload = GSConfig.PreloadFrameWithGSData);
 	Target* LookupDisplayTarget(GIFRegTEX0 TEX0, const GSVector2i& size, float scale);
 
 	/// Looks up a target in the cache, and only returns it if the BP/BW/PSM match exactly.

--- a/pcsx2/GameDatabase.cpp
+++ b/pcsx2/GameDatabase.cpp
@@ -353,6 +353,7 @@ static const char* s_gs_hw_fix_names[] = {
 	"mergeSprite",
 	"wildArmsHack",
 	"bilinearUpscale",
+	"nativePaletteDraw",
 	"estimateTextureRegion",
 	"PCRTCOffsets",
 	"PCRTCOverscan",
@@ -593,6 +594,9 @@ bool GameDatabaseSchema::GameEntry::configMatchesHWFix(const Pcsx2Config::GSOpti
 		case GSHWFixId::BilinearUpscale:
 			return (config.UpscaleMultiplier <= 1.0f || static_cast<int>(config.UserHacks_BilinearHack) == value);
 
+		case GSHWFixId::NativePaletteDraw:
+			return (config.UpscaleMultiplier <= 1.0f || static_cast<int>(config.UserHacks_NativePaletteDraw) == value);
+
 		case GSHWFixId::EstimateTextureRegion:
 			return (static_cast<int>(config.UserHacks_EstimateTextureRegion) == value);
 
@@ -737,6 +741,10 @@ u32 GameDatabaseSchema::GameEntry::applyGSHardwareFixes(Pcsx2Config::GSOptions& 
 
 			case GSHWFixId::BilinearUpscale:
 				config.UserHacks_BilinearHack = (value > 0);
+				break;
+
+			case GSHWFixId::NativePaletteDraw:
+				config.UserHacks_NativePaletteDraw = (value > 0);
 				break;
 
 			case GSHWFixId::EstimateTextureRegion:

--- a/pcsx2/GameDatabase.h
+++ b/pcsx2/GameDatabase.h
@@ -72,6 +72,7 @@ namespace GameDatabaseSchema
 		MergeSprite,
 		WildArmsHack,
 		BilinearUpscale,
+		NativePaletteDraw,
 		EstimateTextureRegion,
 		PCRTCOffsets,
 		PCRTCOverscan,

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -444,6 +444,7 @@ Pcsx2Config::GSOptions::GSOptions()
 	UserHacks_MergePPSprite = false;
 	UserHacks_WildHack = false;
 	UserHacks_BilinearHack = false;
+	UserHacks_NativePaletteDraw = false;
 
 	DumpReplaceableTextures = false;
 	DumpReplaceableMipmaps = false;
@@ -659,6 +660,7 @@ void Pcsx2Config::GSOptions::LoadSave(SettingsWrapper& wrap)
 	GSSettingBoolEx(UserHacks_MergePPSprite, "UserHacks_merge_pp_sprite");
 	GSSettingBoolEx(UserHacks_WildHack, "UserHacks_WildHack");
 	GSSettingBoolEx(UserHacks_BilinearHack, "UserHacks_BilinearHack");
+	GSSettingBoolEx(UserHacks_NativePaletteDraw, "UserHacks_NativePaletteDraw");
 	GSSettingIntEnumEx(UserHacks_TextureInsideRt, "UserHacks_TextureInsideRt");
 	GSSettingBoolEx(UserHacks_TargetPartialInvalidation, "UserHacks_TargetPartialInvalidation");
 	GSSettingBoolEx(UserHacks_EstimateTextureRegion, "UserHacks_EstimateTextureRegion");
@@ -778,6 +780,7 @@ void Pcsx2Config::GSOptions::MaskUserHacks()
 	UserHacks_MergePPSprite = false;
 	UserHacks_WildHack = false;
 	UserHacks_BilinearHack = false;
+	UserHacks_NativePaletteDraw = false;
 	UserHacks_DisableSafeFeatures = false;
 	UserHacks_HalfBottomOverride = -1;
 	UserHacks_HalfPixelOffset = 0;
@@ -810,6 +813,7 @@ void Pcsx2Config::GSOptions::MaskUpscalingHacks()
 	UserHacks_MergePPSprite = false;
 	UserHacks_WildHack = false;
 	UserHacks_BilinearHack = false;
+	UserHacks_NativePaletteDraw = false;
 	UserHacks_HalfPixelOffset = 0;
 	UserHacks_RoundSprite = 0;
 	UserHacks_TCOffsetX = 0;


### PR DESCRIPTION
### Description of Changes

Required for Crash Bandicoot: The Wrath of Cortex.

It constructs a new P8 texture in local memory based on the depth buffer, by reinterpreting it as C8, then draws a bunch of tiny sprites to C32, then reinterprets _this_ as P8. Any single pixel being off breaks the effect, which is why it didn't work with upscaling before.

<img width="1920" alt="Untitled" src="https://user-images.githubusercontent.com/11288319/229132503-480ed6d5-ecd0-4b07-bca6-0e5f0994b29d.png">

So, this PR adds a new upscaling hack to force these palette texture draws to native resolution instead. WoC looks fairly good, the edges are still a bit rubbish, but they are at native in the software renderer too. The effect just.. isn't fantastic.

Before:
<img width="599" alt="Untitled" src="https://user-images.githubusercontent.com/11288319/229133388-997c351a-32c1-4f13-a49d-101f56f616ac.png">
After:
<img width="599" alt="Untitled" src="https://user-images.githubusercontent.com/11288319/229133456-d379c964-5cd3-4fe6-bf4c-bbd5eeb44ca4.png">

It also helps Driv3r's glitched out text (similar method to draw), punting that to the CPU would be ideal, but that introduces other issues.

### Rationale behind Changes

Closes #2380.
Closes #6006.

### Suggested Testing Steps

Test Crash WoC.
