### PR TITLE
GameDB: Fix blurriness in Sitting Ducks and Fog Line in Over the Hedge

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -14400,8 +14400,10 @@ SLES-52111:
   region: "PAL-M6"
   compat: 5
 SLES-52116:
-  name: "Sitting Duck"
+  name: "Sitting Ducks"
   region: "PAL-M6"
+  gsHWFixes:
+    wildArmsHack: 1 # Fixes blurriness.
 SLES-52117:
   name: "Go Go Copter"
   region: "PAL-M3"
@@ -45653,6 +45655,8 @@ SLUS-20885:
 SLUS-20886:
   name: "Sitting Ducks"
   region: "NTSC-U"
+  gsHWFixes:
+    wildArmsHack: 1 # Fixes blurriness.
 SLUS-20887:
   name: "Adventures of Jimmy Neutron, The - Boy Genius - Attack of the Twonkies"
   region: "NTSC-U"

--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -18909,6 +18909,8 @@ SLES-53863:
 SLES-53866:
   name: "Over the Hedge"
   region: "PAL-E"
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes fog line.
   speedHacks:
     MTVUSpeedHack: 0 # Fixes bad graphics due to bad T-Bit handling.
 SLES-53867:
@@ -19202,11 +19204,15 @@ SLES-53987:
 SLES-53988:
   name: "Over the Hedge"
   region: "PAL-E-G"
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes fog line.
   speedHacks:
     MTVUSpeedHack: 0 # Fixes bad graphics due to bad T-Bit handling.
 SLES-53989:
   name: "Over the Hedge"
   region: "PAL-NL"
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes fog line.
   speedHacks:
     MTVUSpeedHack: 0 # Fixes bad graphics due to bad T-Bit handling.
 SLES-53991:
@@ -19653,6 +19659,8 @@ SLES-54172:
 SLES-54173:
   name: "Over The Hedge"
   region: "PAL-SW"
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes fog line.
   speedHacks:
     MTVUSpeedHack: 0 # Fixes bad graphics due to bad T-Bit handling.
 SLES-54174:
@@ -47952,6 +47960,8 @@ SLUS-21300:
   name: "Over the Hedge"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes fog line.
   speedHacks:
     MTVUSpeedHack: 0 # Fixes bad graphics due to bad T-Bit handling.
 SLUS-21301:


### PR DESCRIPTION
### Description of Changes
Fixes blurriness in Sitting Ducks.

### Rationale behind Changes
Sitting Ducks does not look as sharp as it should without this fix applied.
Over the Hedge has an unnecessary line drawn in the Woods main area.

Sitting Ducks Before (Master):
![SD_without_fix](https://user-images.githubusercontent.com/78033856/229146124-0c807c72-f9e9-45ac-a1d0-2d993fb62829.png)

Sitting Ducks After (Pull Request):
![SD_with_WildArmsHack](https://user-images.githubusercontent.com/78033856/229146239-1067ab44-a763-4ef1-8fa8-52c3461095f2.png)

Over the Hedge Before (Master):
![OtH_without_fix](https://user-images.githubusercontent.com/78033856/229158669-eeaacd96-9ada-45fc-8ecb-f294ec859919.png)

Over the Hedge After (Pull Request):
![OtH_with_halfPixelOffset](https://user-images.githubusercontent.com/78033856/229158688-ca596304-c8eb-4a35-a5e0-0670c61c153e.png)

### Suggested Testing Steps
No suggested testing steps.
