### PR TITLE
SDLInputSource: SDL raw input as config option.

### DIFF
--- a/pcsx2-qt/Settings/ControllerGlobalSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/ControllerGlobalSettingsWidget.cpp
@@ -37,11 +37,13 @@ ControllerGlobalSettingsWidget::ControllerGlobalSettingsWidget(QWidget* parent, 
 #ifdef SDL_BUILD
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.enableSDLSource, "InputSources", "SDL", true);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.enableSDLEnhancedMode, "InputSources", "SDLControllerEnhancedMode", false);
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.enableSDLRawInput, "InputSources", "SDLRawInput", false);
 	connect(m_ui.enableSDLSource, &QCheckBox::stateChanged, this, &ControllerGlobalSettingsWidget::updateSDLOptionsEnabled);
 	connect(m_ui.ledSettings, &QToolButton::clicked, this, &ControllerGlobalSettingsWidget::ledSettingsClicked);
 #else
 	m_ui.enableSDLSource->setEnabled(false);
 	m_ui.ledSettings->setEnabled(false);
+	m_ui.enableSDLRawInput->setEnabled(false);
 #endif
 
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.enableMouseMapping, "UI", "EnableMouseMapping", false);
@@ -113,6 +115,7 @@ void ControllerGlobalSettingsWidget::updateSDLOptionsEnabled()
 	const bool enabled = m_ui.enableSDLSource->isChecked();
 	m_ui.enableSDLEnhancedMode->setEnabled(enabled);
 	m_ui.ledSettings->setEnabled(enabled);
+	m_ui.enableSDLRawInput->setEnabled(enabled);
 }
 
 void ControllerGlobalSettingsWidget::ledSettingsClicked()

--- a/pcsx2-qt/Settings/ControllerGlobalSettingsWidget.ui
+++ b/pcsx2-qt/Settings/ControllerGlobalSettingsWidget.ui
@@ -58,6 +58,13 @@
       <string>SDL Input Source</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_2">
+      <item row="1" column="0">
+       <widget class="QCheckBox" name="enableSDLSource">
+        <property name="text">
+         <string>Enable SDL Input Source</string>
+        </property>
+       </widget>
+      </item>
       <item row="0" column="0" colspan="2">
        <widget class="QLabel" name="label_2">
         <property name="text">
@@ -65,13 +72,6 @@
         </property>
         <property name="wordWrap">
          <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QCheckBox" name="enableSDLSource">
-        <property name="text">
-         <string>Enable SDL Input Source</string>
         </property>
        </widget>
       </item>
@@ -96,6 +96,13 @@
          </widget>
         </item>
        </layout>
+      </item>
+      <item row="2" column="0">
+       <widget class="QCheckBox" name="enableSDLRawInput">
+        <property name="text">
+         <string>Enable SDL Raw Input</string>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>

--- a/pcsx2/Frontend/FullscreenUI.cpp
+++ b/pcsx2/Frontend/FullscreenUI.cpp
@@ -3741,6 +3741,9 @@ void FullscreenUI::DrawControllerSettingsPage()
 	DrawToggleSetting(bsi, ICON_FA_WIFI " SDL DualShock 4 / DualSense Enhanced Mode",
 		"Provides vibration and LED control support over Bluetooth.", "InputSources", "SDLControllerEnhancedMode", false,
 		bsi->GetBoolValue("InputSources", "SDL", true), false);
+	DrawToggleSetting(bsi, ICON_FA_COG " SDL Raw Input",
+		"Allow SDL to use raw access to input devices.", "InputSources", "SDLRawInput", false,
+		bsi->GetBoolValue("InputSources", "SDL", true), false);
 #endif
 #ifdef _WIN32
 	DrawToggleSetting(bsi, ICON_FA_COG " Enable XInput Input Source",

--- a/pcsx2/Frontend/SDLInputSource.cpp
+++ b/pcsx2/Frontend/SDLInputSource.cpp
@@ -142,10 +142,11 @@ bool SDLInputSource::Initialize(SettingsInterface& si, std::unique_lock<std::mut
 void SDLInputSource::UpdateSettings(SettingsInterface& si, std::unique_lock<std::mutex>& settings_lock)
 {
 	const bool old_controller_enhanced_mode = m_controller_enhanced_mode;
+	const bool old_controller_raw_mode = m_controller_raw_mode;
 
 	LoadSettings(si);
 
-	if (m_controller_enhanced_mode != old_controller_enhanced_mode)
+	if (m_controller_enhanced_mode != old_controller_enhanced_mode || m_controller_raw_mode != old_controller_raw_mode)
 	{
 		settings_lock.unlock();
 		ShutdownSubsystem();
@@ -170,6 +171,7 @@ void SDLInputSource::Shutdown()
 void SDLInputSource::LoadSettings(SettingsInterface& si)
 {
 	m_controller_enhanced_mode = si.GetBoolValue("InputSources", "SDLControllerEnhancedMode", false);
+	m_controller_raw_mode = si.GetBoolValue("InputSources", "SDLRawInput", false);
 	m_sdl_hints = si.GetKeyValueList("SDLHints");
 
   for (u32 i = 0; i < MAX_LED_COLORS; i++)
@@ -208,6 +210,7 @@ u32 SDLInputSource::ParseRGBForPlayerId(const std::string_view& str, u32 player_
 
 void SDLInputSource::SetHints()
 {
+	SDL_SetHint(SDL_HINT_JOYSTICK_RAWINPUT, m_controller_raw_mode ? "1" : "0");
 	SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_PS4_RUMBLE, m_controller_enhanced_mode ? "1" : "0");
 	SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_PS5_RUMBLE, m_controller_enhanced_mode ? "1" : "0");
 	// Enable Wii U Pro Controller support

--- a/pcsx2/Frontend/SDLInputSource.h
+++ b/pcsx2/Frontend/SDLInputSource.h
@@ -97,6 +97,7 @@ private:
 
 	bool m_sdl_subsystem_initialized = false;
 	bool m_controller_enhanced_mode = false;
+	bool m_controller_raw_mode = false;
 	std::array<u32, MAX_LED_COLORS> m_led_colors{};
 	std::vector<std::pair<std::string, std::string>> m_sdl_hints;
 };


### PR DESCRIPTION
### Description of Changes
Expose SDL raw input as configuration option.

### Rationale behind Changes
#8518 has had a side effect of disabling the previous sdl raw input default. This brings the behaviour back as a togglable option for those that enjoyed it randomly turing off xinput pads while in sdl mode. May also have compatbility advantages for less common pads with it as user option.

### Suggested Testing Steps
Tested locally with switch pro, wired 360, xbox elite 2 and f430 wheel plus steam deck with no issues.
