### PR TITLE
Qt: Theme Polishes for Pizza and Cobalt

### DIFF
--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -680,32 +680,32 @@ void MainWindow::setStyleFromSettings()
 		// Alternative light theme.
 		qApp->setStyle(QStyleFactory::create("Fusion"));
 
-		const QColor gray(192, 192, 192);
+		const QColor gray(128, 128, 128);
 		const QColor extr(248, 192, 88);
 		const QColor main(233, 187, 147);
 		const QColor comp(248, 230, 213);
+		const QColor highlight(188, 100, 60);
 
-		QPalette darkPalette;
-		darkPalette.setColor(QPalette::Window, main);
-		darkPalette.setColor(QPalette::WindowText, Qt::black);
-		darkPalette.setColor(QPalette::Base, comp);
-		darkPalette.setColor(QPalette::AlternateBase, extr);
-		darkPalette.setColor(QPalette::ToolTipBase, comp);
-		darkPalette.setColor(QPalette::ToolTipText, Qt::black);
-		darkPalette.setColor(QPalette::Text, Qt::black);
-		darkPalette.setColor(QPalette::Button, extr);
-		darkPalette.setColor(QPalette::ButtonText, Qt::black);
-		darkPalette.setColor(QPalette::Link, Qt::black);
-		darkPalette.setColor(QPalette::Highlight, extr);
-		darkPalette.setColor(QPalette::HighlightedText, Qt::black);
+		QPalette standardPalette;
+		standardPalette.setColor(QPalette::Window, main);
+		standardPalette.setColor(QPalette::WindowText, Qt::black);
+		standardPalette.setColor(QPalette::Base, comp);
+		standardPalette.setColor(QPalette::AlternateBase, extr);
+		standardPalette.setColor(QPalette::ToolTipBase, comp);
+		standardPalette.setColor(QPalette::ToolTipText, Qt::black);
+		standardPalette.setColor(QPalette::Text, Qt::black);
+		standardPalette.setColor(QPalette::Button, extr);
+		standardPalette.setColor(QPalette::ButtonText, Qt::black);
+		standardPalette.setColor(QPalette::Link, Qt::black);
+		standardPalette.setColor(QPalette::Highlight, highlight);
+		standardPalette.setColor(QPalette::HighlightedText, Qt::white);
+		standardPalette.setColor(QPalette::Active, QPalette::Button, extr);
+		standardPalette.setColor(QPalette::Disabled, QPalette::ButtonText, gray.darker());
+		standardPalette.setColor(QPalette::Disabled, QPalette::WindowText, gray.darker());
+		standardPalette.setColor(QPalette::Disabled, QPalette::Text, Qt::gray);
+		standardPalette.setColor(QPalette::Disabled, QPalette::Light, gray.lighter());
 
-		darkPalette.setColor(QPalette::Active, QPalette::Button, extr);
-		darkPalette.setColor(QPalette::Disabled, QPalette::ButtonText, gray.darker());
-		darkPalette.setColor(QPalette::Disabled, QPalette::WindowText, gray.darker());
-		darkPalette.setColor(QPalette::Disabled, QPalette::Text, Qt::gray);
-		darkPalette.setColor(QPalette::Disabled, QPalette::Light, gray.lighter());
-
-		qApp->setPalette(darkPalette);
+		qApp->setPalette(standardPalette);
 
 		qApp->setStyleSheet("QToolTip { color: #ffffff; background-color: #cc3f18; border: 1px solid white; }");
 	}
@@ -789,26 +789,27 @@ void MainWindow::setStyleFromSettings()
 		const QColor gray(192, 192, 192);
 		const QColor royalBlue(29, 41, 81);
 		const QColor darkishBlue(17, 30, 108);
+		const QColor highlight(36, 93, 218);
 
 		QPalette darkPalette;
 		darkPalette.setColor(QPalette::Window, royalBlue);
 		darkPalette.setColor(QPalette::WindowText, Qt::white);
 		darkPalette.setColor(QPalette::Base, royalBlue.lighter());
-		darkPalette.setColor(QPalette::AlternateBase, royalBlue);
+		darkPalette.setColor(QPalette::AlternateBase, darkishBlue);
 		darkPalette.setColor(QPalette::ToolTipBase, darkishBlue);
 		darkPalette.setColor(QPalette::ToolTipText, Qt::white);
 		darkPalette.setColor(QPalette::Text, Qt::white);
 		darkPalette.setColor(QPalette::Button, darkishBlue);
 		darkPalette.setColor(QPalette::ButtonText, Qt::white);
 		darkPalette.setColor(QPalette::Link, Qt::white);
-		darkPalette.setColor(QPalette::Highlight, darkishBlue.lighter());
+		darkPalette.setColor(QPalette::Highlight, highlight);
 		darkPalette.setColor(QPalette::HighlightedText, Qt::white);
 
 		darkPalette.setColor(QPalette::Active, QPalette::Button, darkishBlue);
 		darkPalette.setColor(QPalette::Disabled, QPalette::ButtonText, gray);
 		darkPalette.setColor(QPalette::Disabled, QPalette::WindowText, gray);
 		darkPalette.setColor(QPalette::Disabled, QPalette::Text, gray);
-		darkPalette.setColor(QPalette::Disabled, QPalette::Light, gray.darker());
+		darkPalette.setColor(QPalette::Disabled, QPalette::Light, gray);
 
 		qApp->setPalette(darkPalette);
 

--- a/pcsx2-qt/Settings/InterfaceSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/InterfaceSettingsWidget.cpp
@@ -34,7 +34,7 @@ static const char* THEME_NAMES[] = {
 	//: Ignore what Crowdin says in this string about "[Light]/[Dark]" being untouchable here, these are not variables in this case and must be translated.
 	QT_TRANSLATE_NOOP("InterfaceSettingsWidget", "Baby Pastel (Pink) [Light]"),
 	//: Ignore what Crowdin says in this string about "[Light]/[Dark]" being untouchable here, these are not variables in this case and must be translated.
-	QT_TRANSLATE_NOOP("InterfaceSettingsWidget", "Pizza Time! (Brownish/Peachy White) [Light]"),
+	QT_TRANSLATE_NOOP("InterfaceSettingsWidget", "Pizza Time! (Brown-ish/Creamy White) [Light]"),
 	//: Ignore what Crowdin says in this string about "[Light]/[Dark]" being untouchable here, these are not variables in this case and must be translated.
 	QT_TRANSLATE_NOOP("InterfaceSettingsWidget", "PCSX2 (White/Blue) [Light]"),
 	//: Ignore what Crowdin says in this string about "[Light]/[Dark]" being untouchable here, these are not variables in this case and must be translated.
@@ -42,7 +42,7 @@ static const char* THEME_NAMES[] = {
 	//: Ignore what Crowdin says in this string about "[Light]/[Dark]" being untouchable here, these are not variables in this case and must be translated.
 	QT_TRANSLATE_NOOP("InterfaceSettingsWidget", "Violet Angel (Blue/Purple) [Dark]"),
 	//: Ignore what Crowdin says in this string about "[Light]/[Dark]" being untouchable here, these are not variables in this case and must be translated.
-	QT_TRANSLATE_NOOP("InterfaceSettingsWidget", "Cobalt Sky (Royal Blue) [Dark]"),
+	QT_TRANSLATE_NOOP("InterfaceSettingsWidget", "Cobalt Sky (Blue) [Dark]"),
 	//: Ignore what Crowdin says in this string about "[Light]/[Dark]" being untouchable here, these are not variables in this case and must be translated.
 	QT_TRANSLATE_NOOP("InterfaceSettingsWidget", "Ruby (Black/Red) [Dark]"),
 	//: Ignore what Crowdin says in this string about "[Light]/[Dark]" being untouchable here, these are not variables in this case and must be translated.


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->

- Adjusted Highlight color of buttons to improve its contrast and readability for both Pizza and Cobalt Theme.
- Simplified the theme name a little bit.
- Tweaks the variable names for consistency with other themes (Copy paste fail moment).

#### Pizza Time

Before:
![Screenshot_20230331_224436](https://user-images.githubusercontent.com/14798312/229167816-5a26ea9f-6be0-4366-97a7-18e08e819f9c.png)

After:
![Screenshot_20230331_224509](https://user-images.githubusercontent.com/14798312/229167983-3030700f-3199-4680-888e-92ef81d88d70.png)

#### Cobalt Sky

Before: 
![Screenshot_20230331_224853](https://user-images.githubusercontent.com/14798312/229168863-f2a1d564-271a-4b7a-9d84-8da60617af43.png)

After:
![Screenshot_20230331_224913](https://user-images.githubusercontent.com/14798312/229168909-a4f1bf6f-4c07-47b8-875e-e71b90f331a0.png)


### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->

Readability++
Contrast++ 

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Make sure the button and highlights are still readable elsewhere!
Feedback are appreciated!