### PR TITLE
Qt: Fix main window closing on fullscreen shutdown

### DIFF
--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -1146,12 +1146,18 @@ void MainWindow::updateEmulationActions(bool starting, bool running, bool stoppi
 
 	m_ui.actionToolsVideoCapture->setEnabled(running);
 	if (!running && m_ui.actionToolsVideoCapture->isChecked())
+	{
+		QSignalBlocker sb(m_ui.actionToolsVideoCapture);
 		m_ui.actionToolsVideoCapture->setChecked(false);
+	}
 
 	m_game_list_widget->setDisabled(starting && !running);
 
 	if (!starting && !running)
+	{
+		QSignalBlocker sb(m_ui.actionPause);
 		m_ui.actionPause->setChecked(false);
+	}
 
 	// scanning needs to be disabled while running
 	m_ui.actionScanForNewGames->setDisabled(starting_or_running || stopping);


### PR DESCRIPTION
### Description of Changes

Unchecking the pause button was unpausing the VM, before it shut down, which re-hid the main window.

### Rationale behind Changes

Fixes #8466.

### Suggested Testing Steps

Test confirm VM shutdown while fullscreen (done myself).
