### PR TITLE
GS: Fix crash on shutdown when using software renderer

### DIFF
--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -108,6 +108,8 @@ void GSshutdown()
 
 void GSclose()
 {
+	GSTextureReplacements::Shutdown();
+
 	if (g_gs_renderer)
 	{
 		g_gs_renderer->Destroy();
@@ -290,6 +292,7 @@ bool GSreopen(bool recreate_display, bool recreate_renderer, const Pcsx2Config::
 	const u32 gamecrc = g_gs_renderer->GetGameCRC();
 	if (recreate_renderer)
 	{
+		GSTextureReplacements::Shutdown();
 		g_gs_renderer->Destroy();
 		g_gs_renderer.reset();
 	}
@@ -773,7 +776,8 @@ void GSUpdateConfig(const Pcsx2Config::GSOptions& new_config)
 		g_gs_device->ClearSamplerCache();
 
 	// texture dumping/replacement options
-	GSTextureReplacements::UpdateConfig(old_config);
+	if (GSConfig.UseHardwareRenderer())
+		GSTextureReplacements::UpdateConfig(old_config);
 
 	// clear the hash texture cache since we might have replacements now
 	// also clear it when dumping changes, since we want to dump everything being used

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -55,7 +55,6 @@ GSRendererHW::~GSRendererHW()
 void GSRendererHW::Destroy()
 {
 	g_texture_cache->RemoveAll();
-	GSTextureReplacements::Shutdown();
 	GSRenderer::Destroy();
 }
 

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -47,8 +47,6 @@ GSTextureCache::GSTextureCache()
 
 GSTextureCache::~GSTextureCache()
 {
-	GSTextureReplacements::Shutdown();
-
 	RemoveAll();
 
 	_aligned_free(s_unswizzle_buffer);


### PR DESCRIPTION
### Description of Changes

UpdateConfig() was being called regardless of whether sw renderer was enabled, which meant it started the worker thread, and it never got joined when PCSX2 closed.

### Rationale behind Changes

Fixes crash on shutdown if sw renderer is selected, but texture replacements were previously enabled in hw.

### Suggested Testing Steps

Already tested, can review changes manually, but it's pretty straightforward.
