### PR TITLE
GS: Unify D3D device creation paths

### DIFF
--- a/common/D3D12/Context.h
+++ b/common/D3D12/Context.h
@@ -22,6 +22,7 @@
 
 #include <array>
 #include <d3d12.h>
+#include <dxgi1_5.h>
 #include <memory>
 #include <vector>
 #include <wil/com.h>
@@ -60,7 +61,7 @@ namespace D3D12
 		~Context();
 
 		/// Creates new device and context.
-		static bool Create(IDXGIFactory* dxgi_factory, u32 adapter_index, bool enable_debug_layer);
+		static bool Create(IDXGIFactory5* dxgi_factory, IDXGIAdapter1* adapter, bool enable_debug_layer);
 
 		/// Destroys active context.
 		static void Destroy();
@@ -167,7 +168,7 @@ namespace D3D12
 
 		Context();
 
-		bool CreateDevice(IDXGIFactory* dxgi_factory, u32 adapter_index, bool enable_debug_layer);
+		bool CreateDevice(IDXGIFactory5* dxgi_factory, IDXGIAdapter1* adapter, bool enable_debug_layer);
 		bool CreateCommandQueue();
 		bool CreateAllocator();
 		bool CreateFence();

--- a/pcsx2/Frontend/D3D11HostDisplay.h
+++ b/pcsx2/Frontend/D3D11HostDisplay.h
@@ -20,7 +20,7 @@
 #include "common/WindowInfo.h"
 #include <array>
 #include <d3d11.h>
-#include <dxgi.h>
+#include <dxgi1_5.h>
 #include <memory>
 #include <string>
 #include <string_view>
@@ -77,7 +77,7 @@ protected:
 	static constexpr u32 DISPLAY_CONSTANT_BUFFER_SIZE = 16;
 	static constexpr u8 NUM_TIMESTAMP_QUERIES = 5;
 
-	static AdapterAndModeList GetAdapterAndModeList(IDXGIFactory* dxgi_factory);
+	static AdapterAndModeList GetAdapterAndModeList(IDXGIFactory5* dxgi_factory);
 
 	bool CreateImGuiContext() override;
 	void DestroyImGuiContext() override;
@@ -94,8 +94,8 @@ protected:
 	ComPtr<ID3D11Device> m_device;
 	ComPtr<ID3D11DeviceContext> m_context;
 
-	ComPtr<IDXGIFactory> m_dxgi_factory;
-	ComPtr<IDXGISwapChain> m_swap_chain;
+	ComPtr<IDXGIFactory5> m_dxgi_factory;
+	ComPtr<IDXGISwapChain1> m_swap_chain;
 	ComPtr<ID3D11RenderTargetView> m_swap_chain_rtv;
 
 	bool m_allow_tearing_supported = false;

--- a/pcsx2/Frontend/D3D12HostDisplay.h
+++ b/pcsx2/Frontend/D3D12HostDisplay.h
@@ -25,7 +25,7 @@
 #include "HostDisplay.h"
 
 #include <d3d12.h>
-#include <dxgi.h>
+#include <dxgi1_5.h>
 #include <memory>
 #include <string>
 #include <string_view>
@@ -80,7 +80,7 @@ public:
 	static AdapterAndModeList StaticGetAdapterAndModeList();
 
 protected:
-	static AdapterAndModeList GetAdapterAndModeList(IDXGIFactory* dxgi_factory);
+	static AdapterAndModeList GetAdapterAndModeList(IDXGIFactory5* dxgi_factory);
 
 	bool CreateImGuiContext() override;
 	void DestroyImGuiContext() override;
@@ -90,8 +90,8 @@ protected:
 	bool CreateSwapChainRTV();
 	void DestroySwapChainRTVs();
 
-	ComPtr<IDXGIFactory> m_dxgi_factory;
-	ComPtr<IDXGISwapChain> m_swap_chain;
+	ComPtr<IDXGIFactory5> m_dxgi_factory;
+	ComPtr<IDXGISwapChain1> m_swap_chain;
 	std::vector<D3D12::Texture> m_swap_chain_buffers;
 	u32 m_current_swap_chain_buffer = 0;
 

--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -127,24 +127,6 @@ void GSclose()
 
 static RenderAPI GetAPIForRenderer(GSRendererType renderer)
 {
-#if defined(_WIN32)
-	// On Windows, we use DX11 for software, since it's always available.
-	constexpr RenderAPI default_api = RenderAPI::D3D11;
-#elif defined(__APPLE__)
-	// For Macs, default to Metal.
-	constexpr RenderAPI default_api = RenderAPI::Metal;
-#else
-	// For Linux, default to OpenGL (because of hardware compatibility), if we
-	// have it, otherwise Vulkan (if we have it).
-#if defined(ENABLE_OPENGL)
-	constexpr RenderAPI default_api = RenderAPI::OpenGL;
-#elif defined(ENABLE_VULKAN)
-	constexpr RenderAPI default_api = RenderAPI::Vulkan;
-#else
-	constexpr RenderAPI default_api = RenderAPI::None;
-#endif
-#endif
-
 	switch (renderer)
 	{
 		case GSRendererType::OGL:
@@ -167,7 +149,7 @@ static RenderAPI GetAPIForRenderer(GSRendererType renderer)
 #endif
 
 		default:
-			return default_api;
+			return GetAPIForRenderer(GSUtil::GetPreferredRenderer());
 	}
 }
 

--- a/pcsx2/GS/GSUtil.cpp
+++ b/pcsx2/GS/GSUtil.cpp
@@ -203,25 +203,14 @@ GSRendererType GSUtil::GetPreferredRenderer()
 	// Mac: Prefer Metal hardware.
 	return GSRendererType::Metal;
 #elif defined(_WIN32)
-	const u8 preferred = D3D::ShouldPreferRenderer();
-#if defined(ENABLE_VULKAN)
-	if (preferred == D3D::Renderer::Vulkan)
-		return GSRendererType::VK;
-#endif
-#if defined(ENABLE_OPENGL)
-	if (preferred == D3D::Renderer::OpenGL)
-		return GSRendererType::OGL;
-#endif
-	if (preferred == D3D::Renderer::Direct3D12)
-		return GSRendererType::DX12;
-
-	return GSRendererType::DX11;
+	// Use D3D device info to select renderer.
+	return D3D::GetPreferredRenderer();
 #else
 	// Linux: Prefer GL/Vulkan, whatever is available.
 #if defined(ENABLE_OPENGL)
 	return GSRendererType::OGL;
 #elif defined(ENABLE_VULKAN)
-	return GSRendererType::Vulkan;
+	return GSRendererType::VK;
 #else
 	return GSRendererType::SW;
 #endif

--- a/pcsx2/GS/Renderers/DX11/D3D.cpp
+++ b/pcsx2/GS/Renderers/DX11/D3D.cpp
@@ -17,194 +17,278 @@
 #include "GS/Renderers/DX11/D3D.h"
 #include "GS/GSExtra.h"
 
+#include "common/Console.h"
 #include "common/StringUtil.h"
 
 #include <d3d11.h>
 
 #include "fmt/format.h"
 
-namespace D3D
+wil::com_ptr_nothrow<IDXGIFactory5> D3D::CreateFactory(bool debug)
 {
-	wil::com_ptr_nothrow<IDXGIFactory2> CreateFactory(bool debug)
+	UINT flags = 0;
+	if (debug)
+		flags |= DXGI_CREATE_FACTORY_DEBUG;
+
+	wil::com_ptr_nothrow<IDXGIFactory5> factory;
+	const HRESULT hr = CreateDXGIFactory2(flags, IID_PPV_ARGS(factory.put()));
+	if (FAILED(hr))
+		Console.Error("D3D: Failed to create DXGI factory: %08X", hr);
+
+	return factory;
+}
+
+static std::string FixupDuplicateAdapterNames(const std::vector<std::string>& adapter_names, std::string adapter_name)
+{
+	if (std::any_of(adapter_names.begin(), adapter_names.end(),
+			[&adapter_name](const std::string& other) { return (adapter_name == other); }))
 	{
-		UINT flags = 0;
-		if (debug)
-			flags |= DXGI_CREATE_FACTORY_DEBUG;
+		std::string original_adapter_name = std::move(adapter_name);
 
-		// we use CreateDXGIFactory2 because we assume at least windows 8.1 anyway
-		wil::com_ptr_nothrow<IDXGIFactory2> factory;
-		HRESULT hr = CreateDXGIFactory2(flags, IID_PPV_ARGS(factory.put()));
-
-		// if we failed to create a factory with debug support
-		// try one without
-		if (FAILED(hr) && debug)
+		u32 current_extra = 2;
+		do
 		{
-			fprintf(stderr, "D3D: failed to create debug dxgi factory, trying without debugging\n");
-			hr = CreateDXGIFactory2(0, IID_PPV_ARGS(factory.put()));;
-		}
+			adapter_name = StringUtil::StdStringFromFormat("%s (%u)", original_adapter_name.c_str(), current_extra);
+			current_extra++;
+		} while (std::any_of(adapter_names.begin(), adapter_names.end(),
+			[&adapter_name](const std::string& other) { return (adapter_name == other); }));
+	}
+
+	return adapter_name;
+}
+
+std::vector<std::string> D3D::GetAdapterNames(IDXGIFactory5* factory)
+{
+	std::vector<std::string> adapter_names;
+
+	wil::com_ptr_nothrow<IDXGIAdapter1> adapter;
+	for (u32 index = 0;; index++)
+	{
+		const HRESULT hr = factory->EnumAdapters1(index, adapter.put());
+		if (hr == DXGI_ERROR_NOT_FOUND)
+			break;
 
 		if (FAILED(hr))
 		{
-			fprintf(stderr, "D3D: failed to create dxgi factory\n"
-				"check that your system meets our minimum requirements:\n"
-				"https://github.com/PCSX2/pcsx2#system-requirements\n");
+			Console.Error(fmt::format("IDXGIFactory2::EnumAdapters() returned %08X", hr));
+			continue;
 		}
 
-		return factory;
+		adapter_names.push_back(FixupDuplicateAdapterNames(adapter_names, GetAdapterName(adapter.get())));
 	}
 
-	wil::com_ptr_nothrow<IDXGIAdapter1> GetAdapterFromIndex(IDXGIFactory2* factory, int index)
-	{
-		ASSERT(factory);
+	return adapter_names;
+}
 
-		wil::com_ptr_nothrow<IDXGIAdapter1> adapter;
-		if (index < 0 || factory->EnumAdapters1(index, adapter.put()) == DXGI_ERROR_NOT_FOUND)
+wil::com_ptr_nothrow<IDXGIAdapter1> D3D::GetAdapterByName(IDXGIFactory5* factory, const std::string_view& name)
+{
+	if (name.empty())
+		return {};
+
+	// This might seem a bit odd to cache the names.. but there's a method to the madness.
+	// We might have two GPUs with the same name... :)
+	std::vector<std::string> adapter_names;
+
+	wil::com_ptr_nothrow<IDXGIAdapter1> adapter;
+	for (u32 index = 0;; index++)
+	{
+		const HRESULT hr = factory->EnumAdapters1(index, adapter.put());
+		if (hr == DXGI_ERROR_NOT_FOUND)
+			break;
+
+		if (FAILED(hr))
 		{
-			// try index 0 (default adapter)
-			if (index >= 0)
-				fprintf(stderr, "D3D: adapter not found, falling back to the default\n");
-			if (FAILED(factory->EnumAdapters1(0, adapter.put())))
-			{
-				// either there are no adapters connected or something major is wrong with the system
-				fprintf(stderr, "D3D: failed to EnumAdapters\n");
-			}
+			Console.Error(fmt::format("IDXGIFactory2::EnumAdapters() returned %08X", hr));
+			continue;
 		}
 
-		return adapter;
+		std::string adapter_name = FixupDuplicateAdapterNames(adapter_names, GetAdapterName(adapter.get()));
+		if (adapter_name == name)
+		{
+			Console.WriteLn(fmt::format("D3D: Found adapter '{}'", adapter_name));
+			return adapter;
+		}
+
+		adapter_names.push_back(std::move(adapter_name));
 	}
 
-	std::string GetDriverVersionFromLUID(const LUID& luid)
-	{
-		std::string ret;
+	Console.Warning(fmt::format("Adapter '{}' not found.", name));
+	return {};
+}
 
-		HKEY hKey;
-		if (RegOpenKeyExW(HKEY_LOCAL_MACHINE, L"SOFTWARE\\Microsoft\\DirectX", 0, KEY_READ, &hKey) == ERROR_SUCCESS)
+wil::com_ptr_nothrow<IDXGIAdapter1> D3D::GetFirstAdapter(IDXGIFactory5* factory)
+{
+	wil::com_ptr_nothrow<IDXGIAdapter1> adapter;
+	HRESULT hr = factory->EnumAdapters1(0, adapter.put());
+	if (FAILED(hr))
+		Console.Error(fmt::format("IDXGIFactory2::EnumAdapters() for first adapter returned %08X", hr));
+
+	return adapter;
+}
+
+wil::com_ptr_nothrow<IDXGIAdapter1> D3D::GetChosenOrFirstAdapter(IDXGIFactory5* factory, const std::string_view& name)
+{
+	wil::com_ptr_nothrow<IDXGIAdapter1> adapter = GetAdapterByName(factory, name);
+	if (!adapter)
+		adapter = GetFirstAdapter(factory);
+
+	return adapter;
+}
+
+std::string D3D::GetAdapterName(IDXGIAdapter1* adapter)
+{
+	std::string ret;
+
+	DXGI_ADAPTER_DESC1 desc;
+	HRESULT hr = adapter->GetDesc1(&desc);
+	if (SUCCEEDED(hr))
+	{
+		ret = StringUtil::WideStringToUTF8String(desc.Description);
+	}
+	else
+	{
+		Console.Error(fmt::format("IDXGIAdapter1::GetDesc() returned {:08X}", hr));
+	}
+
+	if (ret.empty())
+		ret = "(Unknown)";
+
+	return ret;
+}
+
+std::string D3D::GetDriverVersionFromLUID(const LUID& luid)
+{
+	std::string ret;
+
+	HKEY hKey;
+	if (RegOpenKeyExW(HKEY_LOCAL_MACHINE, L"SOFTWARE\\Microsoft\\DirectX", 0, KEY_READ, &hKey) == ERROR_SUCCESS)
+	{
+		DWORD max_key_len = 0, adapter_count = 0;
+		if (RegQueryInfoKeyW(hKey, nullptr, nullptr, nullptr, &adapter_count, &max_key_len, nullptr, nullptr, nullptr,
+				nullptr, nullptr, nullptr) == ERROR_SUCCESS)
 		{
-			DWORD max_key_len = 0, adapter_count = 0;
-			if (RegQueryInfoKeyW(hKey, nullptr, nullptr, nullptr, &adapter_count, &max_key_len, nullptr, nullptr,
-					nullptr, nullptr, nullptr, nullptr) == ERROR_SUCCESS)
+			std::vector<TCHAR> current_name(max_key_len + 1);
+			for (DWORD i = 0; i < adapter_count; ++i)
 			{
-				std::vector<TCHAR> current_name(max_key_len + 1);
-				for (DWORD i = 0; i < adapter_count; ++i)
+				DWORD subKeyLength = static_cast<DWORD>(current_name.size());
+				if (RegEnumKeyExW(hKey, i, current_name.data(), &subKeyLength, nullptr, nullptr, nullptr, nullptr) ==
+					ERROR_SUCCESS)
 				{
-					DWORD subKeyLength = static_cast<DWORD>(current_name.size());
-					if (RegEnumKeyExW(hKey, i, current_name.data(), &subKeyLength, nullptr, nullptr, nullptr,
-							nullptr) == ERROR_SUCCESS)
+					LUID current_luid = {};
+					DWORD current_luid_size = sizeof(uint64_t);
+					if (RegGetValueW(hKey, current_name.data(), L"AdapterLuid", RRF_RT_QWORD, nullptr, &current_luid,
+							&current_luid_size) == ERROR_SUCCESS &&
+						current_luid.HighPart == luid.HighPart && current_luid.LowPart == luid.LowPart)
 					{
-						LUID current_luid = {};
-						DWORD current_luid_size = sizeof(uint64_t);
-						if (RegGetValueW(hKey, current_name.data(), L"AdapterLuid", RRF_RT_QWORD, nullptr,
-								&current_luid, &current_luid_size) == ERROR_SUCCESS &&
-							current_luid.HighPart == luid.HighPart && current_luid.LowPart == luid.LowPart)
+						LARGE_INTEGER driver_version = {};
+						DWORD driver_version_size = sizeof(driver_version);
+						if (RegGetValueW(hKey, current_name.data(), L"DriverVersion", RRF_RT_QWORD, nullptr,
+								&driver_version, &driver_version_size) == ERROR_SUCCESS)
 						{
-							LARGE_INTEGER driver_version = {};
-							DWORD driver_version_size = sizeof(driver_version);
-							if (RegGetValueW(hKey, current_name.data(), L"DriverVersion", RRF_RT_QWORD, nullptr,
-									&driver_version, &driver_version_size) == ERROR_SUCCESS)
-							{
-								WORD nProduct = HIWORD(driver_version.HighPart);
-								WORD nVersion = LOWORD(driver_version.HighPart);
-								WORD nSubVersion = HIWORD(driver_version.LowPart);
-								WORD nBuild = LOWORD(driver_version.LowPart);
-								ret = fmt::format("{}.{}.{}.{}", nProduct, nVersion, nSubVersion, nBuild);
-							}
+							WORD nProduct = HIWORD(driver_version.HighPart);
+							WORD nVersion = LOWORD(driver_version.HighPart);
+							WORD nSubVersion = HIWORD(driver_version.LowPart);
+							WORD nBuild = LOWORD(driver_version.LowPart);
+							ret = fmt::format("{}.{}.{}.{}", nProduct, nVersion, nSubVersion, nBuild);
 						}
 					}
 				}
 			}
-
-			RegCloseKey(hKey);
 		}
 
-		return ret;
+		RegCloseKey(hKey);
 	}
 
-	u8 Vendor()
+	return ret;
+}
+
+D3D::VendorID D3D::GetVendorID(IDXGIAdapter1* adapter)
+{
+	DXGI_ADAPTER_DESC1 desc;
+	const HRESULT hr = adapter->GetDesc1(&desc);
+	if (FAILED(hr))
 	{
-		auto factory = CreateFactory(false);
-		auto adapter = GetAdapterFromIndex(factory.get(), 0);
+		Console.Error(fmt::format("IDXGIAdapter1::GetDesc() returned {:08X}", hr));
+		return VendorID::Unknown;
+	}
 
-		ASSERT(adapter);
-
-		DXGI_ADAPTER_DESC1 desc = {};
-		if (FAILED(adapter->GetDesc1(&desc)))
-		{
-			fprintf(stderr, "D3D: failed to get the adapter description\n");
+	switch (desc.VendorId)
+	{
+		case 0x10DE:
+			return VendorID::Nvidia;
+		case 0x1002:
+		case 0x1022:
+			return VendorID::AMD;
+		case 0x163C:
+		case 0x8086:
+		case 0x8087:
+			return VendorID::Intel;
+		default:
 			return VendorID::Unknown;
-		}
+	}
+}
 
-		switch (desc.VendorId)
-		{
-			case 0x10DE:
-				return VendorID::Nvidia;
-			case 0x1002:
-			case 0x1022:
-				return VendorID::AMD;
-			case 0x163C:
-			case 0x8086:
-			case 0x8087:
-				return VendorID::Intel;
-			default:
-				return VendorID::Unknown;
-		}
+GSRendererType D3D::GetPreferredRenderer()
+{
+	auto factory = CreateFactory(false);
+	auto adapter = GetChosenOrFirstAdapter(factory.get(), GSConfig.Adapter);
+
+	// If we somehow can't get a D3D11 device, it's unlikely any of the renderers are going to work.
+	if (!adapter)
+		return GSRendererType::DX11;
+
+	D3D_FEATURE_LEVEL feature_level;
+
+	static const D3D_FEATURE_LEVEL check[] = {
+		D3D_FEATURE_LEVEL_12_0,
+		D3D_FEATURE_LEVEL_11_0,
+	};
+
+	const HRESULT hr = D3D11CreateDevice(adapter.get(), D3D_DRIVER_TYPE_UNKNOWN, nullptr, 0, std::data(check),
+		std::size(check), D3D11_SDK_VERSION, nullptr, &feature_level, nullptr);
+
+	if (FAILED(hr))
+	{
+		// See note above.
+		return GSRendererType::DX11;
 	}
 
-	u8 ShouldPreferRenderer()
+	switch (GetVendorID(adapter.get()))
 	{
-		auto factory = CreateFactory(false);
-		auto adapter = GetAdapterFromIndex(factory.get(), 0);
-
-		ASSERT(adapter);
-
-		D3D_FEATURE_LEVEL feature_level;
-
-		static const D3D_FEATURE_LEVEL check[] = {
-			D3D_FEATURE_LEVEL_12_0,
-			D3D_FEATURE_LEVEL_11_0,
-		};
-
-		const HRESULT hr = D3D11CreateDevice(
-			adapter.get(), D3D_DRIVER_TYPE_UNKNOWN, nullptr, 0,
-			std::data(check), std::size(check), D3D11_SDK_VERSION, nullptr, &feature_level, nullptr
-		);
-
-		if (FAILED(hr))
-			return Renderer::Default;
-
-		switch (Vendor())
+		case VendorID::Nvidia:
 		{
-			case VendorID::Nvidia:
-			{
-				if (feature_level == D3D_FEATURE_LEVEL_12_0)
-					return Renderer::Vulkan;
-				else if (feature_level == D3D_FEATURE_LEVEL_11_0)
-					return Renderer::OpenGL;
-				else
-					return Renderer::Direct3D11;
-			}
+			if (feature_level == D3D_FEATURE_LEVEL_12_0)
+				return GSRendererType::VK;
+			else if (feature_level == D3D_FEATURE_LEVEL_11_0)
+				return GSRendererType::OGL;
+			else
+				return GSRendererType::DX11;
+		}
 
-			case VendorID::AMD:
-			{
-				if (feature_level == D3D_FEATURE_LEVEL_12_0)
-					return Renderer::Vulkan;
-				else
-					return Renderer::Direct3D11;
-			}
+		case VendorID::AMD:
+		{
+			if (feature_level == D3D_FEATURE_LEVEL_12_0)
+				return GSRendererType::VK;
+			else
+				return GSRendererType::DX11;
+		}
 
-			case VendorID::Intel:
-			{
-				// Older Intel GPUs prior to Xe seem to have broken OpenGL drivers which choke
-				// on some of our shaders, causing what appears to be GPU timeouts+device removals.
-				// Vulkan has broken barriers, also prior to Xe. So just fall back to DX11 everywhere,
-				// unless we can find some way of differentiating Xe.
-				return Renderer::Direct3D11;
-			}
+		case VendorID::Intel:
+		{
+			// Older Intel GPUs prior to Xe seem to have broken OpenGL drivers which choke
+			// on some of our shaders, causing what appears to be GPU timeouts+device removals.
+			// Vulkan has broken barriers, also prior to Xe. So just fall back to DX11 everywhere,
+			// unless we have Arc, which is easy to identify.
+			if (StringUtil::StartsWith(GetAdapterName(adapter.get()), "Intel(R) Arc(TM) "))
+				return GSRendererType::VK;
+			else
+				return GSRendererType::DX11;
+		}
 
-			default:
-			{
-				// Default is D3D11
-				return Renderer::Direct3D11;
-			}
+		default:
+		{
+			// Default is D3D11
+			return GSRendererType::DX11;
 		}
 	}
 }

--- a/pcsx2/GS/Renderers/DX11/D3D.h
+++ b/pcsx2/GS/Renderers/DX11/D3D.h
@@ -18,26 +18,39 @@
 #include "common/RedtapeWindows.h"
 #include "common/RedtapeWilCom.h"
 
-#include <dxgi1_3.h>
-#include <vector>
+#include "pcsx2/Config.h"
+
+#include <dxgi1_5.h>
 #include <string>
+#include <string_view>
+#include <vector>
 
 namespace D3D
 {
 	// create a dxgi factory
-	wil::com_ptr_nothrow<IDXGIFactory2> CreateFactory(bool debug);
+	wil::com_ptr_nothrow<IDXGIFactory5> CreateFactory(bool debug);
 
-	// get an adapter based on position
-	// assuming no one removes/moves it, it should always have the same id
-	// however in the event that the adapter is not found due to the above, use the default
-	wil::com_ptr_nothrow<IDXGIAdapter1> GetAdapterFromIndex(IDXGIFactory2* factory, int index);
+	// returns a list of all adapter names
+	std::vector<std::string> GetAdapterNames(IDXGIFactory5* factory);
+
+	// get an adapter based on name
+	wil::com_ptr_nothrow<IDXGIAdapter1> GetAdapterByName(IDXGIFactory5* factory, const std::string_view& name);
+
+	// returns the first adapter in the system
+	wil::com_ptr_nothrow<IDXGIAdapter1> GetFirstAdapter(IDXGIFactory5* factory);
+
+	// returns the adapter specified in the configuration, or the default
+	wil::com_ptr_nothrow<IDXGIAdapter1> GetChosenOrFirstAdapter(IDXGIFactory5* factory, const std::string_view& name);
+
+	// returns a utf-8 string of the specified adapter's name
+	std::string GetAdapterName(IDXGIAdapter1* adapter);
 
 	// returns the driver version from the registry as a string
 	std::string GetDriverVersionFromLUID(const LUID& luid);
 
 	// this is sort of a legacy thing that doesn't have much to do with d3d (just the easiest way)
 	// checks to see if the adapter at 0 is NV and thus we should prefer OpenGL
-	enum VendorID
+	enum class VendorID
 	{
 		Unknown,
 		Nvidia,
@@ -45,15 +58,6 @@ namespace D3D
 		Intel
 	};
 
-	enum Renderer
-	{
-		Default,
-		OpenGL,
-		Vulkan,
-		Direct3D11,
-		Direct3D12
-	};
-
-	u8 Vendor();
-	u8 ShouldPreferRenderer();
-};
+	VendorID GetVendorID(IDXGIAdapter1* adapter);
+	GSRendererType GetPreferredRenderer();
+}; // namespace D3D

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
@@ -119,7 +119,13 @@ bool GSDevice11::Create()
 	{
 		// HACK: check AMD
 		// Broken point sampler should be enabled only on AMD.
-		m_features.broken_point_sampler = (D3D::Vendor() == D3D::VendorID::AMD);
+		wil::com_ptr_nothrow<IDXGIDevice> dxgi_device;
+		wil::com_ptr_nothrow<IDXGIAdapter1> dxgi_adapter;
+		if (SUCCEEDED(m_dev->QueryInterface(dxgi_device.put())) &&
+			SUCCEEDED(dxgi_device->GetParent(IID_PPV_ARGS(dxgi_adapter.put()))))
+		{
+			m_features.broken_point_sampler = (D3D::GetVendorID(dxgi_adapter.get()) == D3D::VendorID::AMD);
+		}
 	}
 
 	SetFeatures();


### PR DESCRIPTION
### Description of Changes

Also makes Vulkan the device for Intel Arc GPUs.

Software will now use the preferred API for the system, in other words, Vulkan for NV/AMD, or DX11 for Arc. Works around NVIDIA driver issues and our interlacing shaders...

### Rationale behind Changes

Less code, I'm going to ditch HostDisplay completely, since it's kinda redundant now, but one thing at a time.

### Suggested Testing Steps

Test D3D renderers and default renderer.
