### PR TITLE
USB: Remove force feedback logspam

### DIFF
--- a/pcsx2/USB/usb-pad/usb-pad-ff.cpp
+++ b/pcsx2/USB/usb-pad/usb-pad-ff.cpp
@@ -98,11 +98,11 @@ namespace usb_pad
 	{
 		if (!mFFdev)
 			return;
-
+#if defined(PCSX2_DEVBUILD) || defined(_DEBUG)
 		DevCon.WriteLn("FFB %02X, %02X, %02X, %02X : %02X, %02X, %02X, %02X",
 			ffdata->cmdslot, ffdata->type, ffdata->u.params[0], ffdata->u.params[1],
 			ffdata->u.params[2], ffdata->u.params[3], ffdata->u.params[4], ffdata->padd0);
-
+#endif
 		if (ffdata->cmdslot != CMD_EXTENDED_CMD)
 		{
 			uint8_t slots = (ffdata->cmdslot & 0xF0) >> 4;

--- a/pcsx2/USB/usb-pad/usb-pad-sdl-ff.cpp
+++ b/pcsx2/USB/usb-pad/usb-pad-sdl-ff.cpp
@@ -188,17 +188,18 @@ namespace usb_pad
 			return;
 
 		const s16 new_level = static_cast<s16>(std::clamp(level, -32768, 32767));
-		if (m_constant_effect.constant.level != level)
+		if (m_constant_effect.constant.level != new_level)
 		{
 			m_constant_effect.constant.level = new_level;
 			if (SDL_HapticUpdateEffect(m_haptic, m_constant_effect_id, &m_constant_effect) != 0)
 				Console.Warning("SDL_HapticUpdateEffect() for constant failed: %s", SDL_GetError());
 		}
 
-		if (!m_constant_effect_running && SDL_HapticRunEffect(m_haptic, m_constant_effect_id, SDL_HAPTIC_INFINITY) == 0)
-			m_constant_effect_running = true;
-		else
-			Console.Error("SDL_HapticRunEffect() for constant failed: %s", SDL_GetError());
+		if (!m_constant_effect_running)
+			if (SDL_HapticRunEffect(m_haptic, m_constant_effect_id, SDL_HAPTIC_INFINITY) == 0)
+				m_constant_effect_running = true;
+			else
+				Console.Error("SDL_HapticRunEffect() for constant failed: %s", SDL_GetError());
 	}
 
 	template <typename T>
@@ -222,10 +223,11 @@ namespace usb_pad
 		if (SDL_HapticUpdateEffect(m_haptic, m_spring_effect_id, &m_spring_effect) != 0)
 			Console.Warning("SDL_HapticUpdateEffect() for spring failed: %s", SDL_GetError());
 
-		if (!m_spring_effect_running && SDL_HapticRunEffect(m_haptic, m_spring_effect_id, SDL_HAPTIC_INFINITY) == 0)
-			m_spring_effect_running = true;
-		else
-			Console.Warning("SDL_HapticRunEffect() for spring failed: %s", SDL_GetError());
+		if (!m_spring_effect_running)
+			if (SDL_HapticRunEffect(m_haptic, m_spring_effect_id, SDL_HAPTIC_INFINITY) == 0)
+				m_spring_effect_running = true;
+			else 
+				Console.Error("SDL_HapticRunEffect() for spring failed: %s", SDL_GetError());		
 	}
 
 	void SDLFFDevice::SetDamperForce(const parsed_ff_data& ff)
@@ -243,10 +245,11 @@ namespace usb_pad
 		if (SDL_HapticUpdateEffect(m_haptic, m_damper_effect_id, &m_damper_effect) != 0)
 			Console.Warning("SDL_HapticUpdateEffect() for damper failed: %s", SDL_GetError());
 
-		if (!m_damper_effect_running && SDL_HapticRunEffect(m_haptic, m_damper_effect_id, SDL_HAPTIC_INFINITY) == 0)
-			m_damper_effect_running = true;
-		else
-			Console.Warning("SDL_HapticRunEffect() for damper failed: %s", SDL_GetError());
+		if (!m_damper_effect_running)
+			if (SDL_HapticRunEffect (m_haptic, m_damper_effect_id, SDL_HAPTIC_INFINITY) == 0)
+				m_damper_effect_running = true;
+			else
+				Console.Error("SDL_HapticRunEffect() for damper failed: %s", SDL_GetError());
 	}
 
 	void SDLFFDevice::SetFrictionForce(const parsed_ff_data& ff)
@@ -262,12 +265,10 @@ namespace usb_pad
 		m_friction_effect.condition.center[0] = ClampU16(ff.u.condition.center);
 
 		if (SDL_HapticUpdateEffect(m_haptic, m_friction_effect_id, &m_friction_effect) != 0)
-			Console.Warning("SDL_HapticUpdateEffect() for friction failed: %s", SDL_GetError());
-
-		if (!m_friction_effect_running && SDL_HapticRunEffect(m_haptic, m_friction_effect_id, SDL_HAPTIC_INFINITY) == 0)
-			m_friction_effect_running = true;
-		else
-			Console.Warning("SDL_HapticRunEffect() for friction failed: %s", SDL_GetError());
+			if (!m_friction_effect_running && SDL_HapticRunEffect(m_haptic, m_friction_effect_id, SDL_HAPTIC_INFINITY) == 0)
+				m_friction_effect_running = true;
+			else
+				Console.Error("SDL_HapticUpdateEffect() for friction failed: %s", SDL_GetError());
 	}
 
 	void SDLFFDevice::SetAutoCenter(int value)


### PR DESCRIPTION
### Description of Changes
Removes some incorrect logspam from the set force methods. The second call to each set ends up always hitting the else condition and spits out whatever the last internal SDL error message is sitting in it's buffer.
Also gates off the FF packet dump behind DEBUG ifdef because thats way too verbose for normal use.

### Rationale behind Changes
Logspam bad. Logspam with irrelevent errors, even worse.

### Suggested Testing Steps
Should be safe. CI pass and look for cleaner logs with force feedback devices are in use.
