### PR TITLE
GS: Don't reset CRT mode on reset

### DIFF
--- a/pcsx2/GS.cpp
+++ b/pcsx2/GS.cpp
@@ -86,8 +86,6 @@ static __fi void gsCSRwrite( const tGS_CSR& csr )
 		memzero(g_RealGSMem);
 		GSIMR.reset();
 		CSRreg.Reset();
-		gsVideoMode = GS_VideoMode::Uninitialized;
-		UpdateVSyncRate();
 		GetMTGS().SendSimplePacket(GS_RINGTYPE_RESET, 0, 0, 0);
 	}
 


### PR DESCRIPTION
### Description of Changes
Don't reset the vsync rate etc on CSR reset.

### Rationale behind Changes
This information is controled by GSSetCRT and is handled separately from the usual privilaged registers in PCSX2, so for now it's best we don't change what it was already set to on CSR reset, if the game wants to change it, it will call GSSetCRT.

### Suggested Testing Steps
Nothing much to test, just a small thing I noticed.
