### PR TITLE
EE: Correct FPU_MUL_HACK result value

### DIFF
--- a/pcsx2/x86/iFPU.cpp
+++ b/pcsx2/x86/iFPU.cpp
@@ -537,7 +537,7 @@ void FPU_MUL(int regd, int regt, bool reverseOperands)
 		// 	else
 		// 		return 0;
 
-		alignas(16) static constexpr const u32 result[4] = { 0x3e800000 };
+		alignas(16) static constexpr const u32 result[4] = { 0x3f490fda };
 
 		xMOVD(ecx, xRegisterSSE(reverseOperands ? regt : regd));
 		xMOVD(edx, xRegisterSSE(reverseOperands ? regd : regt));

--- a/pcsx2/x86/iFPUd.cpp
+++ b/pcsx2/x86/iFPUd.cpp
@@ -420,7 +420,7 @@ void FPU_MUL(int info, int regd, int sreg, int treg, bool acc)
 		// 	else
 		// 		return 0;
 
-		alignas(16) static constexpr const u32 result[4] = { 0x3e800000 };
+		alignas(16) static constexpr const u32 result[4] = { 0x3f490fda };
 
 		xMOVD(ecx, xRegisterSSE(sreg));
 		xMOVD(edx, xRegisterSSE(treg));


### PR DESCRIPTION
### Description of Changes
Fixes the FPU_MUL_HACK for Tales of Destiny

### Rationale behind Changes
When it was converted from the old style the wrong value was set for the result, causing the towns in Tales of Destiny to softlock.

### Suggested Testing Steps
Already had somebody test Tales.
