### PR TITLE
GS/OGL: Fix incorrect binding in multi stretch rect

### DIFF
--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -1286,7 +1286,10 @@ void GSDeviceOGL::DrawMultiStretchRects(
 	OMSetDepthStencilState(m_convert.dss);
 	OMSetBlendState(false);
 	OMSetColorMaskState();
-	OMSetRenderTargets(dTex, nullptr);
+	if (!dTex->IsDepthStencil())
+		OMSetRenderTargets(dTex, nullptr);
+	else
+		OMSetRenderTargets(nullptr, dTex);
 	m_convert.ps[static_cast<int>(shader)].Bind();
 
 	const GSVector2 ds(static_cast<float>(dTex->GetWidth()), static_cast<float>(dTex->GetHeight()));


### PR DESCRIPTION
### Description of Changes

Was trying to bind a depth stencil target as a render target...

### Rationale behind Changes

Framebuffer was not complete, sad driver

### Suggested Testing Steps

This showed up in Tekken 5, but it was clearly wrong
