### PR TITLE
GS/HW: Fix blue screen in GT4 transitions

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -2763,8 +2763,11 @@ __ri bool GSRendererHW::EmulateChannelShuffle(GSTextureCache::Target* src, bool 
 		{
 			// Since test_only gets executed when creating a source, before target lookup, we can hack
 			// the FBP here to point to the source, which is where it will eventually be copied back to.
+			// We need to force it to PSMCT24, the crossfade draw ends up reading the RT instead of local
+			// memory, which ends up with blue rubbish becuase the shuffle isn't correctly emulated.
 			pxAssertMsg((m_context->TEX0.TBP0 & 31) == 0, "TEX0 should be page aligned");
 			m_context->FRAME.FBP = m_context->TEX0.TBP0 >> 5;
+			m_context->FRAME.PSM = PSM_PSMCT24;
 			return true;
 		}
 


### PR DESCRIPTION
### Description of Changes

The effect still isn't correctly emulated, it's meant to fade between the previous frame and current.. but that's not working correctly, because the RT is C24 not C32, and the channel shuffle effect isn't correctly emulated, and I don't feel like going down that rabbit hole today.

But it gets it back to where it was.

### Rationale behind Changes

Regression from #8209.

### Suggested Testing Steps

Test GT4 fade transition (start a race).
