### PR TITLE
GS/Counters: Use progressive check, not GSSetCRT for interlace mode

### DIFF
--- a/pcsx2/Counters.cpp
+++ b/pcsx2/Counters.cpp
@@ -327,10 +327,10 @@ double GetVerticalFrequency()
 		return 60.00;
 	case GS_VideoMode::PAL:
 	case GS_VideoMode::DVD_PAL:
-		return gsIsInterlaced ? EmuConfig.GS.FrameratePAL : EmuConfig.GS.FrameratePAL - 0.24f;
+		return (IsProgressiveVideoMode() == false) ? EmuConfig.GS.FrameratePAL : EmuConfig.GS.FrameratePAL - 0.24f;
 	case GS_VideoMode::NTSC:
 	case GS_VideoMode::DVD_NTSC:
-		return gsIsInterlaced ? EmuConfig.GS.FramerateNTSC : EmuConfig.GS.FramerateNTSC - 0.11f;
+		return (IsProgressiveVideoMode() == false) ? EmuConfig.GS.FramerateNTSC : EmuConfig.GS.FramerateNTSC - 0.11f;
 	case GS_VideoMode::SDTV_480P:
 		return 59.94;
 	case GS_VideoMode::HDTV_1080P:

--- a/pcsx2/GS.cpp
+++ b/pcsx2/GS.cpp
@@ -224,6 +224,12 @@ void gsWrite64_page_00( u32 mem, u64 value )
 {
 	s_GSRegistersWritten |= (mem == GS_DISPFB1 || mem == GS_DISPFB2 || mem == GS_PMODE);
 
+	if (mem == GS_SMODE1 || mem == GS_SMODE2)
+	{
+		if (value != *(u64*)PS2GS_BASE(mem))
+			UpdateVSyncRate();
+	}
+
 	gsWrite64_generic( mem, value );
 }
 


### PR DESCRIPTION
### Description of Changes
Uses our progressive check to see if the game is interlaced instead of the GSSetCRT check.

### Rationale behind Changes
Some things can swap between progressive and interlaced without calling GSSetCRT, this makes sure we catch that.

### Suggested Testing Steps
Just make sure the capped framerate of games is okay.
