### PR TITLE
GS: Update fixes for Sacred Blaze

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -40890,6 +40890,8 @@ SLPS-25917:
   name: "Sacred Blaze"
   region: "NTSC-J"
   gsHWFixes:
+    cpuSpriteRenderBW: 1 # Fixes half screen effects.
+    cpuSpriteRenderLevel: 1 # Needed for above.
     getSkipCount: "GSC_SacredBlaze"
 SLPS-25922:
   name: "Vitamin Z [Limited Edition]"

--- a/pcsx2/GS/Renderers/HW/GSHwHack.cpp
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.cpp
@@ -110,11 +110,17 @@ bool GSHwHack::GSC_Manhunt2(GSRendererHW& r, const GSFrameInfo& fi, int& skip)
 
 bool GSHwHack::GSC_SacredBlaze(GSRendererHW& r, const GSFrameInfo& fi, int& skip)
 {
-	//Fix Sacred Blaze rendering glitches
+	// Fix Sacred Blaze rendering glitches.
+	// The game renders a mask for the glow effect during battles, but it offsets the target, something the TC doesn't support.
+	// So let's throw it at the SW renderer to deal with.
 	if (skip == 0)
 	{
-		if (fi.TME && (fi.FBP == 0x0000 || fi.FBP == 0x0e00) && (fi.TBP0 == 0x2880 || fi.TBP0 == 0x2a80) && fi.FPSM == fi.TPSM && fi.TPSM == PSM_PSMCT32 && fi.FBMSK == 0x0)
+		const GIFRegFRAME& FRAME = RCONTEXT->FRAME;
+
+		if ((fi.FBP == 0x2680 || fi.FBP == 0x26c0 || fi.FBP == 0x2780 || fi.FBP == 0x2880 || fi.FBP == 0x2a80) && fi.TPSM == PSM_PSMCT32 && FRAME.FBW <= 2 &&
+			(!fi.TME || (fi.TBP0 == 0x0 || fi.TBP0 == 0xe00 || fi.TBP0 == 0x3e00)))
 		{
+			r.SwPrimRender(r, fi.TBP0 > 0x1000);
 			skip = 1;
 		}
 	}


### PR DESCRIPTION
### Description of Changes
Updates CRC hack to actually render the special effects and add GameDB entry for some half screen effects.

### Rationale behind Changes
The old CRC hack just killed the special effect, which is rendered by offsetting in to the render target, which we don't support. So punting it to the SW renderer is a better choice.

### Suggested Testing Steps
Test Sacred Blaze and make sure fancy light effects (and the memcard/options screens in the main menu) all work ok.

Master:
![image](https://user-images.githubusercontent.com/6278726/229368246-976a8112-f527-4537-a41c-6e71322edcec.png)

PR:
![image](https://user-images.githubusercontent.com/6278726/229368261-347406fb-d02b-4429-8c6a-ee8c2c0e4c75.png)

Software (for reference):
![image](https://user-images.githubusercontent.com/6278726/229368272-c27ef5eb-5063-4075-ae6a-738e63b4daa9.png)
