### PR TITLE
GameDB: Add Mipmap and Trilinear to Colin McRae Rally 2005

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -15603,6 +15603,8 @@ SLES-52636:
   region: "PAL-M5"
   compat: 5
   gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
     autoFlush: 1 # Fixes incorrect colors.
     alignSprite: 1 # Fixes vertical lines such as in FMVs.
 SLES-52637:


### PR DESCRIPTION

### Rationale behind Changes
Improves some textures including the trees and such.
