### PR TITLE
GameDB: Replace Tex in RT with Partial Target Invalidation, Dark Cloud 2

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -150,7 +150,7 @@ PAPX-90506:
     eeClampMode: 3 # Fixes textbox.
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
-    textureInsideRT: 1 # Fixes clown suit textures.
+    partialTargetInvalidation: 1 # Fixes clown suit textures.
 PAPX-90512:
   name: "Gran Turismo 4 - Toyota Prius [Trial]"
   region: "NTSC-J"
@@ -3392,7 +3392,7 @@ SCES-51190:
     eeClampMode: 3 # Fixes textbox.
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
-    textureInsideRT: 1 # Fixes clown suit textures.
+    partialTargetInvalidation: 1 # Fixes clown suit textures.
 SCES-51224:
   name: "War of the Monsters"
   region: "PAL-E"
@@ -4995,7 +4995,7 @@ SCKA-20014:
     eeClampMode: 3 # Fixes textbox.
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
-    textureInsideRT: 1 # Fixes clown suit textures.
+    partialTargetInvalidation: 1 # Fixes clown suit textures.
 SCKA-20015:
   name: "Time Crisis 3"
   region: "NTSC-K"
@@ -5822,7 +5822,7 @@ SCPS-15033:
     eeClampMode: 3 # Fixes textbox.
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
-    textureInsideRT: 1 # Fixes clown suit textures.
+    partialTargetInvalidation: 1 # Fixes clown suit textures.
 SCPS-15034:
   name: "This is Football 2003"
   region: "NTSC-J"
@@ -6481,7 +6481,7 @@ SCPS-19215:
     eeClampMode: 3 # Fixes textbox.
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
-    textureInsideRT: 1 # Fixes clown suit textures.
+    partialTargetInvalidation: 1 # Fixes clown suit textures.
 SCPS-19251:
   name: "Wild ARMs - Alter Code F [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -6566,7 +6566,7 @@ SCPS-19306:
     eeClampMode: 3 # Fixes textbox.
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
-    textureInsideRT: 1 # Fixes clown suit textures.
+    partialTargetInvalidation: 1 # Fixes clown suit textures.
 SCPS-19307:
   name: "Popolocrois - The First Adventure [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -7044,7 +7044,7 @@ SCPS-55048:
     eeClampMode: 3 # Fixes textbox.
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
-    textureInsideRT: 1 # Fixes clown suit textures.
+    partialTargetInvalidation: 1 # Fixes clown suit textures.
 SCPS-55049:
   name: "King of Fighters 2000, The"
   region: "NTSC-J"
@@ -7628,7 +7628,7 @@ SCUS-97213:
     eeClampMode: 3 # Fixes textbox.
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
-    textureInsideRT: 1 # Fixes clown suit textures.
+    partialTargetInvalidation: 1 # Fixes clown suit textures.
 SCUS-97214:
   name: "NCAA GameBreaker 2003"
   region: "NTSC-U"
@@ -7685,7 +7685,7 @@ SCUS-97229:
     eeClampMode: 3 # Fixes textbox.
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
-    textureInsideRT: 1 # Fixes clown suit textures.
+    partialTargetInvalidation: 1 # Fixes clown suit textures.
 SCUS-97230:
   name: "SOCOM - U.S. Navy SEALs"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
Replace Texture inside RT with Partial Target Invalidation

### Rationale behind Changes
It was breaking lights.

### Suggested Testing Steps
Check CI

Fixes #8562
