### PR TITLE
GS: Fix some Scanmask situations in PCRTC

### DIFF
--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -642,9 +642,9 @@ public:
 
 		// Calculate framebuffer read offsets, should be considered if only one circuit is enabled, or difference is more than 1 line.
 		// Only considered if "Anti-blur" is enabled.
-		void CalculateFramebufferOffset()
+		void CalculateFramebufferOffset(bool scanmask)
 		{
-			if (GSConfig.PCRTCAntiBlur && PCRTCSameSrc)
+			if (GSConfig.PCRTCAntiBlur && PCRTCSameSrc && !scanmask)
 			{
 				if (abs(PCRTCDisplays[1].framebufferOffsets.y - PCRTCDisplays[0].framebufferOffsets.y) == 1
 					&& PCRTCDisplays[0].displayRect.y == PCRTCDisplays[1].displayRect.y)
@@ -785,12 +785,12 @@ public:
 					offset.x = (PCRTCDisplays[1 - zeroDisplay.x].displayOffset.x - PCRTCDisplays[zeroDisplay.x].displayOffset.x) / (VideoModeDividers[videomode].x + 1);
 					offset.y = (PCRTCDisplays[1 - zeroDisplay.y].displayOffset.y - PCRTCDisplays[zeroDisplay.y].displayOffset.y) / (VideoModeDividers[videomode].y + 1);
 
-					if (offset.x >= 4 || !GSConfig.PCRTCAntiBlur)
+					if (offset.x >= 4 || !GSConfig.PCRTCAntiBlur || scanmask)
 					{
 						PCRTCDisplays[1 - zeroDisplay.x].displayRect.x += offset.x;
 						PCRTCDisplays[1 - zeroDisplay.x].displayRect.z += offset.x;
 					}
-					if (offset.y >= 4 || !GSConfig.PCRTCAntiBlur)
+					if (offset.y >= 4 || !GSConfig.PCRTCAntiBlur || scanmask)
 					{
 						PCRTCDisplays[1 - zeroDisplay.y].displayRect.y += offset.y - int_off[1 - zeroDisplay.y];
 						PCRTCDisplays[1 - zeroDisplay.y].displayRect.w += offset.y - int_off[1 - zeroDisplay.y];

--- a/pcsx2/GS/Renderers/Common/GSRenderer.cpp
+++ b/pcsx2/GS/Renderers/Common/GSRenderer.cpp
@@ -97,7 +97,7 @@ bool GSRenderer::Merge(int field)
 	PCRTCDisplays.SetRects(0, m_regs->DISP[0].DISPLAY, m_regs->DISP[0].DISPFB);
 	PCRTCDisplays.SetRects(1, m_regs->DISP[1].DISPLAY, m_regs->DISP[1].DISPFB);
 	PCRTCDisplays.CalculateDisplayOffset(m_scanmask_used);
-	PCRTCDisplays.CalculateFramebufferOffset();
+	PCRTCDisplays.CalculateFramebufferOffset(m_scanmask_used);
 
 	// Only need to check the right/bottom on software renderer, hardware always gets the full texture then cuts a bit out later.
 	if (PCRTCDisplays.FrameRectMatch() && !PCRTCDisplays.FrameWrap() && !feedback_merge)


### PR DESCRIPTION
### Description of Changes
Fixes scanmask usage situations which break with antiblur enabled.

### Rationale behind Changes
Final Fantasy X-2 was using scanmask for shadows, and anti-blur was breaking them.

### Suggested Testing Steps
Test FFX-2, Metal Gear Solid 2 (water/radar) & 3 (windows), Alpine Racer 3, or any other Scanmask games you might know.

Fixes #8227
