### PR TITLE
GS/HW: Fix Final Fantasy XII CRC hack

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSHwHack.cpp
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.cpp
@@ -920,6 +920,7 @@ bool GSHwHack::OI_FFXII(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GSTexture
 			if (r.m_vertex.next >= 16 * 512)
 			{
 				// incoming pixels are stored in columns, one column is 16x512, total res 448x512 or 448x454
+				GL_INS("OI_FFXII() Buffering pixels");
 
 				if (!video)
 					video = new u32[512 * 512];
@@ -952,12 +953,11 @@ bool GSHwHack::OI_FFXII(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GSTexture
 			{
 				// normally, this step would copy the video onto screen with 512 texture mapped horizontal lines,
 				// but we use the stored video data to create a new texture, and replace the lines with two triangles
+				GL_INS("OI_FFXII() replace lines with a quad");
 
-				g_gs_device->Recycle(t->m_texture);
-
-				t->m_texture = g_gs_device->CreateTexture(512, 512, 1, GSTexture::Format::Color);
-
-				t->m_texture->Update(GSVector4i(0, 0, 448, lines), video, 448 * 4);
+				GSTexture* tex = g_gs_device->CreateTexture(512, 512, 1, GSTexture::Format::Color);
+				tex->Update(GSVector4i(0, 0, 448, lines), video, 448 * 4);
+				g_texture_cache->ReplaceSourceTexture(t, tex, 1.0f, tex->GetSize(), nullptr, false);
 
 				r.m_vertex.buff[2] = r.m_vertex.buff[r.m_vertex.next - 2];
 				r.m_vertex.buff[3] = r.m_vertex.buff[r.m_vertex.next - 1];

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.h
@@ -458,6 +458,10 @@ public:
 	/// Removes any sources which point to the specified target.
 	void InvalidateSourcesFromTarget(const Target* t);
 
+	/// Replaces a source's texture externally. Required for some CRC hacks.
+	void ReplaceSourceTexture(Source* s, GSTexture* new_texture, float new_scale, const GSVector2i& new_unscaled_size,
+		HashCacheEntry* hc_entry, bool new_texture_is_shared);
+
 	bool Move(u32 SBP, u32 SBW, u32 SPSM, int sx, int sy, u32 DBP, u32 DBW, u32 DPSM, int dx, int dy, int w, int h);
 	bool ShuffleMove(u32 BP, u32 BW, u32 PSM, int sx, int sy, int dx, int dy, int w, int h);
 


### PR DESCRIPTION
### Description of Changes

FF12 apparently does a whacky point draw for FMVs (not that uncommon) but then copies it with textured lines?

And the cheeky CRC hack screws with the texture cache's fields unsafely.

### Rationale behind Changes

Regression from #8209 and #8336.

### Suggested Testing Steps

Test FF12 PAL (done with a block dump).