### PR TITLE
GS-TC: Improve handing of wrapping targets & double half clear

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -46231,6 +46231,8 @@ SLUS-20978:
   name: "Power Drome"
   region: "NTSC-U"
   compat: 4
+  gsHWFixes:
+    autoFlush: 1
   patches:
     42E15DEF:
       content: |-

--- a/pcsx2/GS/Renderers/DX12/GSDevice12.h
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.h
@@ -262,7 +262,7 @@ public:
 	void BeginRenderPassForStretchRect(
 		GSTexture12* dTex, const GSVector4i& dtex_rc, const GSVector4i& dst_rc, bool allow_discard = true);
 	void DoStretchRect(GSTexture12* sTex, const GSVector4& sRect, GSTexture12* dTex, const GSVector4& dRect,
-		const ID3D12PipelineState* pipeline, bool linear);
+		const ID3D12PipelineState* pipeline, bool linear, bool allow_discard);
 	void DrawStretchRect(const GSVector4& sRect, const GSVector4& dRect, const GSVector2i& ds);
 
 	void SetupDATE(GSTexture* rt, GSTexture* ds, bool datm, const GSVector4i& bbox);

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -95,6 +95,10 @@ void GSRendererHW::Reset(bool hardware_reset)
 	// Force targets to preload for 2 frames (for 30fps games).
 	static constexpr u8 TARGET_PRELOAD_FRAMES = 2;
 
+	// Read back on CSR Reset, conditional downloading on render swap etc handled elsewhere.
+	if (!hardware_reset)
+		g_texture_cache->ReadbackAll();
+
 	g_texture_cache->RemoveAll();
 	m_force_preload = TARGET_PRELOAD_FRAMES;
 

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h
@@ -248,7 +248,7 @@ public:
 	void BeginRenderPassForStretchRect(
 		GSTextureVK* dTex, const GSVector4i& dtex_rc, const GSVector4i& dst_rc, bool allow_discard = true);
 	void DoStretchRect(GSTextureVK* sTex, const GSVector4& sRect, GSTextureVK* dTex, const GSVector4& dRect,
-		VkPipeline pipeline, bool linear);
+		VkPipeline pipeline, bool linear, bool allow_discard);
 	void DrawStretchRect(const GSVector4& sRect, const GSVector4& dRect, const GSVector2i& ds);
 
 	void BlitRect(GSTexture* sTex, const GSVector4i& sRect, u32 sLevel, GSTexture* dTex, const GSVector4i& dRect,


### PR DESCRIPTION
### Description of Changes
Improves the use of source in target when the target wraps (issue with King's Field pause screen)
Improves Double Half Clear to also work per channel, so if some channels are masked, it retains the old data (Lord of the Rings + Ninja Assault)
Adds reading back targets to the GS memory when a GS CSR reset is performed (for the Jak games when changing to Progressive mode)
Also add Auto Flush to Power Drome US, apparently it wasn't there.

### Rationale behind Changes
Wrapping wasn't being handled right, so the results of tests were incorrect, causing it to pull data from local memory, which is garbage.
Double half clear was too stringent and needed to be loosened off in some cases, but was also very rigid in how it worked, now it can be a bit less so.
Flushing the targets on CSR reset flushes the targets to GS memory when a software reset is done (different from the render switch one I did previously). as some games like Jak will reset the GS on a progressive scan switch for example, then try and use previous information for the background.

### Suggested Testing Steps
Test games which do double half clear like Power Drome (already done), King's Field (maybe other From Soft games) too, and any game listed below. Also check the Jak games switching to progressive.

Thanks to Stenzek for fixing per channel stretchrects in vulkan and dx12.

Fixes #857
Fixes #2004
Fixes #4050

Lord of the Rings The Third Age:

Master:
![image](https://user-images.githubusercontent.com/6278726/229943685-41df43c9-525c-44cc-adf4-32153e608878.png)

PR:
![image](https://user-images.githubusercontent.com/6278726/229943695-752c50a8-5bc4-4f36-9da4-58fbd79e6ea4.png)

Siren:

Master:
![image](https://user-images.githubusercontent.com/6278726/229959268-8afa0b37-65eb-422e-bc1b-38c2cb22d96c.png)

PR:
![image](https://user-images.githubusercontent.com/6278726/229959286-90a297ef-4b1a-4e4c-8f9c-7d15a128749a.png)

Band Hero:
Master:
![image](https://user-images.githubusercontent.com/6278726/230047811-0edaeb6d-fc09-4f34-9348-cded097930d9.png)

PR:
![image](https://user-images.githubusercontent.com/6278726/230047677-681737c8-cf05-4069-b928-57799ea81535.png)

Guitar Hero 3 (slight improvement):
Master:
![image](https://user-images.githubusercontent.com/6278726/229959406-a8aee67b-0819-44a8-b51f-a358b9943913.png)

PR:
![image](https://user-images.githubusercontent.com/6278726/229959418-216ef6be-5471-4c0d-ab6b-9359fca28056.png)
