### PR TITLE
GS/HW: Don't try to use forced trilinear on shuffles

### DIFF
--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -1198,11 +1198,6 @@ void GSState::GIFRegHandlerALPHA(const GIFReg* RESTRICT r)
 
 void GSState::GIFRegHandlerDIMX(const GIFReg* RESTRICT r)
 {
-	bool update = false;
-
-	if (r->DIMX != m_env.DIMX)
-		update = true;
-
 	m_env.DIMX = r->DIMX;
 
 	if (m_prev_env.DIMX != m_env.DIMX)
@@ -1443,8 +1438,6 @@ void GSState::Flush(GSFlushReason reason)
 
 		if (m_dirty_gs_regs)
 		{
-			const int ctx = m_prev_env.PRIM.CTXT;
-
 			m_draw_env = &m_prev_env;
 			PRIM = &m_prev_env.PRIM;
 			UpdateContext();
@@ -1616,9 +1609,8 @@ void GSState::FlushPrim()
 
 		// If the PSM format of Z is invalid, but it is masked (no write) and ZTST is set to ALWAYS pass (no test, just allow)
 		// we can ignore the Z format, since it won't be used in the draw (Star Ocean 3 transitions)
-		const bool ignoreZ = m_context->ZBUF.ZMSK && m_context->TEST.ZTST == 1;
-
 #ifdef PCSX2_DEVBUILD
+		const bool ignoreZ = m_context->ZBUF.ZMSK && m_context->TEST.ZTST == 1;
 		if (GSLocalMemory::m_psm[m_context->FRAME.PSM].fmt >= 3 || (GSLocalMemory::m_psm[m_context->ZBUF.PSM].fmt >= 3 && !ignoreZ))
 		{
 			Console.Warning("GS: Possible invalid draw, Frame PSM %x ZPSM %x", m_context->FRAME.PSM, m_context->ZBUF.PSM);

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -3670,7 +3670,7 @@ __ri void GSRendererHW::EmulateTextureSampler(const GSTextureCache::Target* rt, 
 			// We don't need to check for HWMipmapLevel::Off here, because forced trilinear implies forced mipmaps.
 			bilinear = true;
 			trilinear = static_cast<u8>(GS_MIN_FILTER::Linear_Mipmap_Linear);
-			trilinear_auto = !need_mipmap || GSConfig.HWMipmap != HWMipmapLevel::Full;
+			trilinear_auto = !tex->m_target && (!need_mipmap || GSConfig.HWMipmap != HWMipmapLevel::Full);
 		}
 		break;
 
@@ -3680,7 +3680,7 @@ __ri void GSRendererHW::EmulateTextureSampler(const GSTextureCache::Target* rt, 
 			if (need_mipmap && GSConfig.HWMipmap != HWMipmapLevel::Off)
 			{
 				trilinear = m_context->TEX1.MMIN;
-				trilinear_auto = GSConfig.HWMipmap != HWMipmapLevel::Full;
+				trilinear_auto = !tex->m_target && GSConfig.HWMipmap != HWMipmapLevel::Full;
 			}
 		}
 		break;
@@ -3884,7 +3884,7 @@ __ri void GSRendererHW::EmulateTextureSampler(const GSTextureCache::Target* rt, 
 	}
 	else if (trilinear_auto)
 	{
-		m_conf.tex->GenerateMipmapsIfNeeded();
+		tex->m_texture->GenerateMipmapsIfNeeded();
 	}
 
 	// TC Offset Hack

--- a/pcsx2/USB/usb-pad/usb-pad-sdl-ff.cpp
+++ b/pcsx2/USB/usb-pad/usb-pad-sdl-ff.cpp
@@ -196,10 +196,12 @@ namespace usb_pad
 		}
 
 		if (!m_constant_effect_running)
+		{
 			if (SDL_HapticRunEffect(m_haptic, m_constant_effect_id, SDL_HAPTIC_INFINITY) == 0)
 				m_constant_effect_running = true;
 			else
 				Console.Error("SDL_HapticRunEffect() for constant failed: %s", SDL_GetError());
+		}
 	}
 
 	template <typename T>
@@ -224,10 +226,12 @@ namespace usb_pad
 			Console.Warning("SDL_HapticUpdateEffect() for spring failed: %s", SDL_GetError());
 
 		if (!m_spring_effect_running)
+		{
 			if (SDL_HapticRunEffect(m_haptic, m_spring_effect_id, SDL_HAPTIC_INFINITY) == 0)
 				m_spring_effect_running = true;
-			else 
-				Console.Error("SDL_HapticRunEffect() for spring failed: %s", SDL_GetError());		
+			else
+				Console.Error("SDL_HapticRunEffect() for spring failed: %s", SDL_GetError());
+		}
 	}
 
 	void SDLFFDevice::SetDamperForce(const parsed_ff_data& ff)
@@ -246,10 +250,12 @@ namespace usb_pad
 			Console.Warning("SDL_HapticUpdateEffect() for damper failed: %s", SDL_GetError());
 
 		if (!m_damper_effect_running)
-			if (SDL_HapticRunEffect (m_haptic, m_damper_effect_id, SDL_HAPTIC_INFINITY) == 0)
+		{
+			if (SDL_HapticRunEffect(m_haptic, m_damper_effect_id, SDL_HAPTIC_INFINITY) == 0)
 				m_damper_effect_running = true;
 			else
 				Console.Error("SDL_HapticRunEffect() for damper failed: %s", SDL_GetError());
+		}
 	}
 
 	void SDLFFDevice::SetFrictionForce(const parsed_ff_data& ff)
@@ -265,10 +271,12 @@ namespace usb_pad
 		m_friction_effect.condition.center[0] = ClampU16(ff.u.condition.center);
 
 		if (SDL_HapticUpdateEffect(m_haptic, m_friction_effect_id, &m_friction_effect) != 0)
+		{
 			if (!m_friction_effect_running && SDL_HapticRunEffect(m_haptic, m_friction_effect_id, SDL_HAPTIC_INFINITY) == 0)
 				m_friction_effect_running = true;
 			else
 				Console.Error("SDL_HapticUpdateEffect() for friction failed: %s", SDL_GetError());
+		}
 	}
 
 	void SDLFFDevice::SetAutoCenter(int value)

--- a/pcsx2/vtlb.cpp
+++ b/pcsx2/vtlb.cpp
@@ -647,7 +647,7 @@ void vtlb_MapHandler(vtlbHandler handler, u32 start, u32 size)
 	verify(0 == (size & VTLB_PAGE_MASK) && size > 0);
 
 	u32 end = start + (size - VTLB_PAGE_SIZE);
-	pxAssume((end >> VTLB_PAGE_BITS) < std::size(vtlbdata.pmap));
+	pxAssume((end >> VTLB_PAGE_BITS) < (sizeof(vtlbdata.pmap) / sizeof(vtlbdata.pmap[0])));
 
 	while (start <= end)
 	{


### PR DESCRIPTION
### Description of Changes

Was probably trying to do it on a shuffle or another target source

### Rationale behind Changes

People are silly

### Suggested Testing Steps

Yolo because the option is silly

The warning fixes are just whitespace/braces so will be safe