### PR TITLE
GS/HW: Fix incorrect hashing of non-palette textures

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -5112,9 +5112,10 @@ static void HashTextureLevel(const GIFRegTEX0& TEX0, const GIFRegTEXA& TEXA, GST
 	if (tw < bs.x || th < bs.y || psm.fmsk != 0xFFFFFFFFu || region.GetMaxX() > 0 || region.GetMinY() > 0)
 	{
 		// Expand texture indices. Align to 32 bytes for AVX2.
-		const u32 pitch = Common::AlignUpPow2(static_cast<u32>(block_rect.z), 32);
-		const u32 row_size = static_cast<u32>(tw);
-		const GSLocalMemory::readTexture rtx = psm.rtxP;
+		const bool palette = (psm.pal > 0);
+		const u32 pitch = Common::AlignUpPow2(static_cast<u32>(block_rect.z) << (palette ? 0 : 2), 32);
+		const u32 row_size = static_cast<u32>(tw) << (palette ? 0 : 2);
+		const GSLocalMemory::readTexture rtx = palette ? psm.rtxP : psm.rtx;
 
 		// Use temp buffer for expanding, since we may not need to update.
 		rtx(mem, off, block_rect, temp, pitch, TEXA);


### PR DESCRIPTION
### Description of Changes

Direct textures were using the indexed/palette read routine, leading to hash collisions when there shouldn't have been one.

### Rationale behind Changes

<img width="1064" alt="Untitled" src="https://user-images.githubusercontent.com/11288319/230085893-cdfdfb0b-4c33-4018-be54-9f40c3decc2f.png">

### Suggested Testing Steps

Test a texture pack to make sure it didn't break. It shouldn't, since palette textures which are the most common would be unaffected.
