### PR TITLE
Counters: Retool UpdateVSyncRate

### DIFF
--- a/pcsx2-qt/QtHost.cpp
+++ b/pcsx2-qt/QtHost.cpp
@@ -511,7 +511,7 @@ void EmuThread::setFullscreen(bool fullscreen)
 	GetMTGS().WaitGS();
 
 	// If we're using exclusive fullscreen, the refresh rate may have changed.
-	UpdateVSyncRate();
+	UpdateVSyncRate(true);
 }
 
 void EmuThread::setSurfaceless(bool surfaceless)

--- a/pcsx2/Counters.h
+++ b/pcsx2/Counters.h
@@ -145,6 +145,6 @@ extern u32	rcntRcount(int index);
 template< uint page > extern bool rcntWrite32( u32 mem, mem32_t& value );
 template< uint page > extern u16 rcntRead32( u32 mem );		// returns u16 by design! (see implementation for details)
 
-extern u32 UpdateVSyncRate();
+extern void UpdateVSyncRate(bool force);
 extern void frameLimitReset();
 

--- a/pcsx2/GS.cpp
+++ b/pcsx2/GS.cpp
@@ -31,7 +31,7 @@ static bool s_GSRegistersWritten = false;
 void gsSetVideoMode(GS_VideoMode mode)
 {
 	gsVideoMode = mode;
-	UpdateVSyncRate();
+	UpdateVSyncRate(false);
 }
 
 // Make sure framelimiter options are in sync with GS capabilities.
@@ -40,7 +40,7 @@ void gsReset()
 	GetMTGS().ResetGS(true);
 	gsVideoMode = GS_VideoMode::Uninitialized;
 	memzero(g_RealGSMem);
-	UpdateVSyncRate();
+	UpdateVSyncRate(true);
 }
 
 void gsUpdateFrequency(Pcsx2Config& config)
@@ -71,7 +71,7 @@ void gsUpdateFrequency(Pcsx2Config& config)
 	}
 
 	GetMTGS().UpdateVSyncMode();
-	UpdateVSyncRate();
+	UpdateVSyncRate(true);
 }
 
 static __fi void gsCSRwrite( const tGS_CSR& csr )
@@ -227,7 +227,7 @@ void gsWrite64_page_00( u32 mem, u64 value )
 	if (mem == GS_SMODE1 || mem == GS_SMODE2)
 	{
 		if (value != *(u64*)PS2GS_BASE(mem))
-			UpdateVSyncRate();
+			UpdateVSyncRate(false);
 	}
 
 	gsWrite64_generic( mem, value );

--- a/pcsx2/SaveState.cpp
+++ b/pcsx2/SaveState.cpp
@@ -91,7 +91,7 @@ static void PostLoadPrep()
 	CBreakPoints::SetSkipFirst(BREAKPOINT_EE, 0);
 	CBreakPoints::SetSkipFirst(BREAKPOINT_IOP, 0);
 
-	UpdateVSyncRate();
+	UpdateVSyncRate(true);
 }
 
 // --------------------------------------------------------------------------------------

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -1196,7 +1196,7 @@ void VMManager::Reset()
 
 	SysClearExecutionCache();
 	memBindConditionalHandlers();
-	UpdateVSyncRate();
+	UpdateVSyncRate(true);
 	frameLimitReset();
 	cpuReset();
 
@@ -1701,7 +1701,7 @@ void VMManager::CheckForGSConfigChanges(const Pcsx2Config& old_config)
 		EmuConfig.LimiterMode = GetInitialLimiterMode();
 
 	gsUpdateFrequency(EmuConfig);
-	UpdateVSyncRate();
+	UpdateVSyncRate(true);
 	frameLimitReset();
 	GetMTGS().ApplySettings();
 }
@@ -1713,7 +1713,7 @@ void VMManager::CheckForFramerateConfigChanges(const Pcsx2Config& old_config)
 
 	Console.WriteLn("Updating frame rate configuration");
 	gsUpdateFrequency(EmuConfig);
-	UpdateVSyncRate();
+	UpdateVSyncRate(true);
 	frameLimitReset();
 }
 


### PR DESCRIPTION
### Description of Changes
Retools how UpdateVSync works to be less prone to errornous updates.

### Rationale behind Changes
Kind of a regression/highlighted problem from #8552 brought up by the progressive mode in Fatal Frame 3, where it was constantly toggling the interlace bit in progressive mode (this does nothing), but it was causing the ticks/counters to reset, starting the current frame over, making them longer, which in turn made the framerate too low.

I figured I'd retool things a bit so it wasn't doing any work it didn't have to while I was at it.

### Suggested Testing Steps
Test Fatal Frame 3 progressive mode, check it's 59.94. Maybe check a spatter of other games, especially if the framerate wasn't quite sitting where it should be.
