### PR TITLE
GS/HW: Update target in new format when reinterpreting 

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -5022,6 +5022,7 @@ void GSRendererHW::OI_DoubleHalfClear(GSTextureCache::Target*& rt, GSTextureCach
 
 				// Copy channels being masked.
 				g_gs_device->StretchRect(target->m_texture, GSVector4(0.0f,0.0f,1.0f,1.0f), tex, drect, keep_r, keep_g, keep_b, keep_a);
+				g_perfmon.Put(GSPerfMon::TextureCopies, 1);
 				delete target->m_texture;
 
 				target->m_texture = tex;
@@ -5084,6 +5085,7 @@ void GSRendererHW::OI_DoubleHalfClear(GSTextureCache::Target*& rt, GSTextureCach
 
 			// Copy channels being masked.
 			g_gs_device->StretchRect(target->m_texture, GSVector4(0, 0, 1, 1), tex, drect, keep_r, keep_g, keep_b, keep_a);
+			g_perfmon.Put(GSPerfMon::TextureCopies, 1);
 			delete target->m_texture;
 
 			target->m_texture = tex;
@@ -5218,10 +5220,13 @@ bool GSRendererHW::OI_BlitFMV(GSTextureCache::Target* _rt, GSTextureCache::Sourc
 			const GSVector4i r_full(0, 0, tw, th);
 
 			g_gs_device->CopyRect(tex->m_texture, rt, r_full, 0, 0);
+			g_perfmon.Put(GSPerfMon::TextureCopies, 1);
 
 			g_gs_device->StretchRect(tex->m_texture, sRect, rt, dRect);
+			g_perfmon.Put(GSPerfMon::TextureCopies, 1);
 
 			g_gs_device->CopyRect(rt, tex->m_texture, r_full, 0, 0);
+			g_perfmon.Put(GSPerfMon::TextureCopies, 1);
 
 			g_gs_device->Recycle(rt);
 		}


### PR DESCRIPTION
### Description of Changes

DBZ Budokai 3 downloads the depth buffer from 0xe00, then does a bunch of draws with 0xe00 as a depth buffer. Then it reuploads the old 512x448 C32 target back to 0xe00, then uses it as FRAME.

Because our last use was as depth, we update the old target as Z24, scrambling the blocks.

This PR changes the order so that the update happens on the new target (and associated format) instead of the old. The old is going to get tossed away anyway, so no need to keep the dirty list around. Furthermore, if the whole target is dirty, we can skip the copying-of-the-old-target-back-in step.

### Rationale behind Changes

<img width="1031" alt="Untitled" src="https://user-images.githubusercontent.com/11288319/230349552-65a59b60-f470-46a2-9c1f-eb42afd9f799.png">

Closes #8579.

### Suggested Testing Steps

Dump runner says it's okay.

