### PR TITLE
GS: Add VS natvis files for FastList and TC Targets

### DIFF
--- a/pcsx2/GS/Renderers/Common/GSFastList.natvis
+++ b/pcsx2/GS/Renderers/Common/GSFastList.natvis
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
+	<Type Name="FastList&lt;*&gt;">
+		<DisplayString>{{ size={m_free_indexes_stack_top} }}</DisplayString>
+		<Expand>
+			<Item Name="[size]" ExcludeView="simple">m_free_indexes_stack_top</Item>
+			<Item Name="[capacity]" ExcludeView="simple">m_capacity - 1</Item>
+
+			<CustomListItems MaxItemsPerView="5000" ExcludeView="simple">
+				<Variable Name="index" InitialValue="m_buffer[0].next_index" />
+
+				<Size>m_free_indexes_stack_top</Size>
+				<Loop>
+					<Item>m_buffer[index].data,na</Item>
+					<Exec>index = m_buffer[index].next_index</Exec>
+				</Loop>
+			</CustomListItems>
+		</Expand>
+	</Type>
+</AutoVisualizer>

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.natvis
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.natvis
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
+	<Type Name="GSTextureCache::Target">
+		<DisplayString Condition="m_type == 0">{{ RT @ BP={m_TEX0.TBP0,X}-{m_end_block,X} BW={m_TEX0.TBW} PSM={m_TEX0.PSM,X} {m_unscaled_size.x}x{m_unscaled_size.y} {m_valid.z},{m_valid.w} }}</DisplayString>
+		<DisplayString Condition="m_type == 1">{{ Depth @ BP={m_TEX0.TBP0,X}-{m_end_block,X} BW={m_TEX0.TBW} PSM={m_TEX0.PSM,X} {m_unscaled_size.x}x{m_unscaled_size.y} {m_valid.z},{m_valid.w} }}</DisplayString>
+	</Type>
+</AutoVisualizer>

--- a/pcsx2/pcsx2core.vcxproj
+++ b/pcsx2/pcsx2core.vcxproj
@@ -854,6 +854,10 @@
       <Project>{c0293b32-5acf-40f0-aa6c-e6da6f3bf33a}</Project>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Natvis Include="GS\Renderers\Common\GSFastList.natvis" />
+    <Natvis Include="GS\Renderers\HW\GSTextureCache.natvis" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets" />
 </Project>

--- a/pcsx2/pcsx2core.vcxproj.filters
+++ b/pcsx2/pcsx2core.vcxproj.filters
@@ -2288,4 +2288,12 @@
       <Filter>System\Ps2\Debug\rdebug</Filter>
     </CustomBuildStep>
   </ItemGroup>
+  <ItemGroup>
+    <Natvis Include="GS\Renderers\Common\GSFastList.natvis">
+      <Filter>System\Ps2\GS</Filter>
+    </Natvis>
+    <Natvis Include="GS\Renderers\HW\GSTextureCache.natvis">
+      <Filter>System\Ps2\GS\Renderers\Hardware</Filter>
+    </Natvis>
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
### Description of Changes

While investigating #8580, I wanted to look at the list of targets present when paused in the debugger, but FastList isn't really capable of doing that. So I wrote some natvis type files for both FastList, as well as targets, to make debugging stuff in the TC a little less pain-inducing.

### Rationale behind Changes

<img width="953" alt="Untitled" src="https://user-images.githubusercontent.com/11288319/230367176-7d1dd52b-f62c-4285-af6d-9993e01542d9.png">

### Suggested Testing Steps

None needed, it only affects running under the debugger.
