### PR TITLE
GS/HW: Don't break out of target search loop on dirty target

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -735,12 +735,6 @@ GSTextureCache::Source* GSTextureCache::LookupSource(const GIFRegTEX0& TEX0, con
 							if (swizzle_match)
 							{
 								new_rect = TranslateAlignedRectByPage(t, bp, psm, bw, r);
-
-								if (new_rect.eq(GSVector4i::zero()))
-								{
-									rect_clean = false;
-									break;
-								}
 							}
 							else
 							{
@@ -760,6 +754,8 @@ GSTextureCache::Source* GSTextureCache::LookupSource(const GIFRegTEX0& TEX0, con
 								}
 								new_rect = TranslateAlignedRectByPage(t, bp & ~((1 << 5) - 1), psm, bw, new_rect);
 							}
+
+							rect_clean = !new_rect.eq(GSVector4i::zero());
 						}
 						else
 						{
@@ -781,14 +777,17 @@ GSTextureCache::Source* GSTextureCache::LookupSource(const GIFRegTEX0& TEX0, con
 						}
 					}
 
-					for (auto& dirty : t->m_dirty)
+					if (rect_clean)
 					{
-						GSVector4i dirty_rect = dirty.GetDirtyRect(t->m_TEX0);
-						if (!dirty_rect.rintersect(new_rect).rempty())
+						for (auto& dirty : t->m_dirty)
 						{
-							rect_clean = false;
-							partial |= !new_rect.rintersect(dirty_rect).eq(new_rect);
-							break;
+							GSVector4i dirty_rect = dirty.GetDirtyRect(t->m_TEX0);
+							if (!dirty_rect.rintersect(new_rect).rempty())
+							{
+								rect_clean = false;
+								partial |= !new_rect.rintersect(dirty_rect).eq(new_rect);
+								break;
+							}
 						}
 					}
 


### PR DESCRIPTION
### Description of Changes

Gradius does a bunch of moves and then samples from them as described in #8107. This broke some time recently with the page translation stuff, it was looking for a target at 34A0, finding 3440, which was a dirtied target which shouldn't be considered. But instead of continuing to search for the next target (34A0 was at the end of the list), it was exiting early.

### Rationale behind Changes

<img width="1120" alt="Untitled" src="https://user-images.githubusercontent.com/11288319/230374110-bdd11ab7-ab69-4daa-bda4-6ecde01b0387.png">

Closes #8580.

### Suggested Testing Steps

Test Gradius.

