### PR TITLE
GS: Fix typo in ResizeTexture which was causing a crash

### DIFF
--- a/pcsx2/GS/Renderers/Common/GSDevice.cpp
+++ b/pcsx2/GS/Renderers/Common/GSDevice.cpp
@@ -563,7 +563,7 @@ bool GSDevice::ResizeTexture(GSTexture** t, GSTexture::Type type, int w, int h, 
 				// TODO: We probably want to make this optional if we're overwriting it...
 				const GSVector4 sRect(0, 0, 1, 1);
 				const GSVector4 dRect(0, 0, t2->GetWidth(), t2->GetHeight());
-				StretchRect(m_current, sRect, new_t, dRect, ShaderConvert::COPY, true);
+				StretchRect(t2, sRect, new_t, dRect, ShaderConvert::COPY, true);
 				Recycle(t2);
 			}
 


### PR DESCRIPTION
### Description of Changes
Fixes a typo where m_current was used instead of the incoming texture.

### Rationale behind Changes
It was wrong and causing things to crash if you booted a game, changed to software mode, then hit reset.

### Suggested Testing Steps
Just make sure nothing crashes running normally, or pressing F9 after loading then pressing reset.
