### PR TITLE
GS: Avoid modifying single QW downloads as they go to a register

### DIFF
--- a/pcsx2/GS/GSLocalMemoryMultiISA.cpp
+++ b/pcsx2/GS/GSLocalMemoryMultiISA.cpp
@@ -1008,11 +1008,11 @@ void GSLocalMemoryFunctions::ReadImageX(const GSLocalMemory& mem, int& tx, int& 
 		{
 			const int length = len / 3;
 			const int aligned_length = (len + 2) / 3;
-			if (length != aligned_length)
+			if ((length * 3) != len)
 			{
-				offset = 3 - (len - (length * 3));
+				offset = (len - (length * 3));
 			}
-			readWriteHelper(mem.vm32(), tx, ty, aligned_length, 1, sx, w, off.assertSizesMatch(GSLocalMemory::swizzle32), [&](auto& pa, int x)
+			readWriteHelper(mem.vm32(), tx, ty, length, 1, sx, w, off.assertSizesMatch(GSLocalMemory::swizzle32), [&](auto& pa, int x)
 				{
 					u32 c = *pa.value(x);
 					pb[0] = (u8)(c);

--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -1804,8 +1804,13 @@ void GSState::Read(u8* mem, int len)
 	if (!m_tr.Update(w, h, bpp, len))
 		return;
 
-	mem += m_tr.offset;
-	len -= m_tr.offset;
+	// If it's 1 QW the destination is likely a register, so don't mess with this, else it can cause stack corruption.
+	// TODO: Change the FIFO downloads to just read off the whole transfer from memory to a temp buffer so we can read it in byte level chunks.
+	if (len > 16)
+	{
+		mem -= m_tr.offset;
+		len += m_tr.offset;
+	}
 	m_mem.ReadImageX(m_tr.x, m_tr.y, m_tr.offset, mem, len, m_env.BITBLTBUF, m_env.TRXPOS, m_env.TRXREG);
 
 	if (GSConfig.DumpGSData && GSConfig.SaveRT && s_n >= GSConfig.SaveN)


### PR DESCRIPTION


### Description of Changes
Avoid modifying the memory address and length when the request is only 1 QW as it likely is going in to a CPU register, also avoid downloading more than requested.

### Rationale behind Changes
This was causing stack corruption which could have manifested in crashes.  This PR is a temp measure until my lazy ass properly redoes the download function to copy this in to a temp buffer instead of reading it off in chunks like this, which would give accurate results.

### Suggested Testing Steps
Probably won't see it but I guess make sure FFX-2 doesn't crash coming out of the fight with Yuna at the beginning (white screen transition).
