### PR TITLE
GS: Retool downloads to buffer full read

### DIFF
--- a/pcsx2/GS/GSLocalMemory.h
+++ b/pcsx2/GS/GSLocalMemory.h
@@ -460,7 +460,7 @@ public:
 	typedef u32 (GSLocalMemory::*readPixelAddr)(u32 addr) const;
 	typedef u32 (GSLocalMemory::*readTexelAddr)(u32 addr, const GIFRegTEXA& TEXA) const;
 	typedef void (*writeImage)(GSLocalMemory& mem, int& tx, int& ty, const u8* src, int len, GIFRegBITBLTBUF& BITBLTBUF, GIFRegTRXPOS& TRXPOS, GIFRegTRXREG& TRXREG);
-	typedef void (*readImage)(const GSLocalMemory& mem, int& tx, int& ty, int& offset, u8* dst, int len, GIFRegBITBLTBUF& BITBLTBUF, GIFRegTRXPOS& TRXPOS, GIFRegTRXREG& TRXREG);
+	typedef void (*readImage)(const GSLocalMemory& mem, int& tx, int& ty, u8* dst, int len, GIFRegBITBLTBUF& BITBLTBUF, GIFRegTRXPOS& TRXPOS, GIFRegTRXREG& TRXREG);
 	typedef void (*readTexture)(GSLocalMemory& mem, const GSOffset& off, const GSVector4i& r, u8* dst, int dstpitch, const GIFRegTEXA& TEXA);
 	typedef void (*readTextureBlock)(const GSLocalMemory& mem, u32 bp, u8* dst, int dstpitch, const GIFRegTEXA& TEXA);
 
@@ -1124,9 +1124,9 @@ public:
 		return ReadTexel16(PixelAddress16SZ(x, y, TEX0.TBP0, TEX0.TBW), TEXA);
 	}
 
-	__forceinline void ReadImageX(int& tx, int& ty, int& offset, u8* dst, int len, GIFRegBITBLTBUF& BITBLTBUF, GIFRegTRXPOS& TRXPOS, GIFRegTRXREG& TRXREG) const
+	__forceinline void ReadImageX(int& tx, int& ty, u8* dst, int len, GIFRegBITBLTBUF& BITBLTBUF, GIFRegTRXPOS& TRXPOS, GIFRegTRXREG& TRXREG) const
 	{
-		m_readImageX(*this, tx, ty, offset, dst, len, BITBLTBUF, TRXPOS, TRXREG);
+		m_readImageX(*this, tx, ty, dst, len, BITBLTBUF, TRXPOS, TRXREG);
 	}
 
 	void ReadTexture(const GSOffset& off, const GSVector4i& r, u8* dst, int dstpitch, const GIFRegTEXA& TEXA);

--- a/pcsx2/GS/GSLocalMemoryMultiISA.cpp
+++ b/pcsx2/GS/GSLocalMemoryMultiISA.cpp
@@ -87,7 +87,7 @@ class CURRENT_ISA::GSLocalMemoryFunctions
 	static void ReadTexture(GSLocalMemory& mem, const GSOffset& off, const GSVector4i& r, u8* dst, int dstpitch, const GIFRegTEXA& TEXA);
 
 public:
-	static void ReadImageX(const GSLocalMemory& mem, int& tx, int& ty, int& offset, u8* dst, int len, GIFRegBITBLTBUF& BITBLTBUF, GIFRegTRXPOS& TRXPOS, GIFRegTRXREG& TRXREG);
+	static void ReadImageX(const GSLocalMemory& mem, int& tx, int& ty, u8* dst, int len, GIFRegBITBLTBUF& BITBLTBUF, GIFRegTRXPOS& TRXPOS, GIFRegTRXREG& TRXREG);
 
 	static void PopulateFunctions(GSLocalMemory& mem);
 };
@@ -931,7 +931,7 @@ void GSLocalMemoryFunctions::WriteImageX(GSLocalMemory& mem, int& tx, int& ty, c
 
 //
 
-void GSLocalMemoryFunctions::ReadImageX(const GSLocalMemory& mem, int& tx, int& ty, int& offset, u8* dst, int len, GIFRegBITBLTBUF& BITBLTBUF, GIFRegTRXPOS& TRXPOS, GIFRegTRXREG& TRXREG)
+void GSLocalMemoryFunctions::ReadImageX(const GSLocalMemory& mem, int& tx, int& ty, u8* dst, int len, GIFRegBITBLTBUF& BITBLTBUF, GIFRegTRXPOS& TRXPOS, GIFRegTRXREG& TRXREG)
 {
 	if (len <= 0)
 		return;
@@ -1005,22 +1005,15 @@ void GSLocalMemoryFunctions::ReadImageX(const GSLocalMemory& mem, int& tx, int& 
 
 		case PSMCT24:
 		case PSMZ24:
-		{
-			const int length = len / 3;
-			if ((length * 3) != len)
+			readWriteHelper(mem.vm32(), tx, ty, len / 3, 1, sx, w, off.assertSizesMatch(GSLocalMemory::swizzle32), [&](auto& pa, int x)
 			{
-				offset = (len - (length * 3));
-			}
-			readWriteHelper(mem.vm32(), tx, ty, length, 1, sx, w, off.assertSizesMatch(GSLocalMemory::swizzle32), [&](auto& pa, int x)
-				{
-					u32 c = *pa.value(x);
-					pb[0] = (u8)(c);
-					pb[1] = (u8)(c >> 8);
-					pb[2] = (u8)(c >> 16);
-					pb += 3;
-				});
+				u32 c = *pa.value(x);
+				pb[0] = (u8)(c);
+				pb[1] = (u8)(c >> 8);
+				pb[2] = (u8)(c >> 16);
+				pb += 3;
+			});
 			break;
-		}
 		case PSMCT16:
 		case PSMCT16S:
 		case PSMZ16:

--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -123,14 +123,14 @@ private:
 	{
 		int x = 0, y = 0;
 		int start = 0, end = 0, total = 0;
-		int offset = 0;
 		u8* buff = nullptr;
 		GIFRegBITBLTBUF m_blit = {};
+		bool write = false;
 
 		GSTransferBuffer();
 		virtual ~GSTransferBuffer();
 
-		void Init(int tx, int ty, const GIFRegBITBLTBUF& blit);
+		void Init(int tx, int ty, const GIFRegBITBLTBUF& blit, bool write);
 		bool Update(int tw, int th, int bpp, int& len);
 
 	} m_tr;


### PR DESCRIPTION
### Description of Changes
Retools GS downloads (Local -> Host) to buffer the entire read before downloading.

As a bonus, unsync'd reads might also be slightly more reliable if they were split in to two or more reads, not sure how frequent this is.

### Rationale behind Changes
Split transfers are kinda gross and messing with offsets to the memory/length is just dangerous and we ended up with stack and heap corruption in some cases, so it's better if we just buffer the lot so we can read it off in 8 bit increments and get the exact data it's expecting.

### Suggested Testing Steps
Test any games with readbacks, make sure they're okay, especially FFX-2 and Keroro Gunsou - Mero Mero Battle Royale (though  I've already tested this and a sprinkle of other games)
