### PR TITLE
GS/OGL: Don't leak shader objects when compiling

### DIFF
--- a/bin/resources/shaders/opengl/tfx_vgs.glsl
+++ b/bin/resources/shaders/opengl/tfx_vgs.glsl
@@ -46,12 +46,12 @@ void texture_coord()
 
     // Integer coordinate => normalized
     VSout.t_int.xy = uv * TextureScale;
-#if VS_INT_FST == 1
-    // Some games uses float coordinate for post-processing effect
-    VSout.t_int.zw = st / TextureScale;
-#else
+#if VS_FST
     // Integer coordinate => integral
     VSout.t_int.zw = uv;
+#else
+    // Some games uses float coordinate for post-processing effect
+    VSout.t_int.zw = st / TextureScale;
 #endif
 }
 
@@ -129,7 +129,7 @@ void out_vertex(in vec4 position, in vertex v)
     GSout.t_float  = v.t_float;
     GSout.t_int    = v.t_int;
     // Flat output
-#if GS_POINT == 1
+#if GS_PRIM == 0
     GSout.c        = GSin[0].c;
 #else
     GSout.c        = GSin[1].c;
@@ -139,14 +139,14 @@ void out_vertex(in vec4 position, in vertex v)
     EmitVertex();
 }
 
-#if GS_POINT == 1
+#if GS_PRIM == 0
 layout(points) in;
 #else
 layout(lines) in;
 #endif
 layout(triangle_strip, max_vertices = 4) out;
 
-#if GS_POINT == 1
+#if GS_PRIM == 0
 
 void gs_main()
 {
@@ -172,7 +172,7 @@ void gs_main()
     EndPrimitive();
 }
 
-#elif GS_LINE == 1
+#elif GS_PRIM == 1
 
 void gs_main()
 {
@@ -203,7 +203,7 @@ void gs_main()
     EndPrimitive();
 }
 
-#else
+#else // GS_PRIM == 3
 
 void gs_main()
 {

--- a/common/GL/Program.cpp
+++ b/common/GL/Program.cpp
@@ -35,6 +35,8 @@ namespace GL
 		prog.m_program_id = 0;
 		m_vertex_shader_id = prog.m_vertex_shader_id;
 		prog.m_vertex_shader_id = 0;
+		m_geometry_shader_id = prog.m_geometry_shader_id;
+		prog.m_geometry_shader_id = 0;
 		m_fragment_shader_id = prog.m_fragment_shader_id;
 		prog.m_fragment_shader_id = 0;
 		m_uniform_locations = std::move(prog.m_uniform_locations);
@@ -103,40 +105,34 @@ namespace GL
 	bool Program::Compile(const std::string_view vertex_shader, const std::string_view geometry_shader,
 		const std::string_view fragment_shader)
 	{
-		GLuint vertex_shader_id = 0;
 		if (!vertex_shader.empty())
 		{
-			vertex_shader_id = CompileShader(GL_VERTEX_SHADER, vertex_shader);
-			if (vertex_shader_id == 0)
+			m_vertex_shader_id = CompileShader(GL_VERTEX_SHADER, vertex_shader);
+			if (m_vertex_shader_id == 0)
 				return false;
 		}
 
-		GLuint geometry_shader_id = 0;
 		if (!geometry_shader.empty())
 		{
-			geometry_shader_id = CompileShader(GL_GEOMETRY_SHADER, geometry_shader);
-			if (geometry_shader_id == 0)
+			m_geometry_shader_id = CompileShader(GL_GEOMETRY_SHADER, geometry_shader);
+			if (m_geometry_shader_id == 0)
 				return false;
 		}
 
-		GLuint fragment_shader_id = 0;
 		if (!fragment_shader.empty())
 		{
-			fragment_shader_id = CompileShader(GL_FRAGMENT_SHADER, fragment_shader);
-			if (fragment_shader_id == 0)
-			{
-				glDeleteShader(vertex_shader_id);
+			m_fragment_shader_id = CompileShader(GL_FRAGMENT_SHADER, fragment_shader);
+			if (m_fragment_shader_id == 0)
 				return false;
-			}
 		}
 
 		m_program_id = glCreateProgram();
-		if (vertex_shader_id != 0)
-			glAttachShader(m_program_id, vertex_shader_id);
-		if (geometry_shader_id != 0)
-			glAttachShader(m_program_id, geometry_shader_id);
-		if (fragment_shader_id != 0)
-			glAttachShader(m_program_id, fragment_shader_id);
+		if (m_vertex_shader_id != 0)
+			glAttachShader(m_program_id, m_vertex_shader_id);
+		if (m_geometry_shader_id != 0)
+			glAttachShader(m_program_id, m_geometry_shader_id);
+		if (m_fragment_shader_id != 0)
+			glAttachShader(m_program_id, m_fragment_shader_id);
 		return true;
 	}
 
@@ -244,6 +240,9 @@ namespace GL
 		if (m_vertex_shader_id != 0)
 			glDeleteShader(m_vertex_shader_id);
 		m_vertex_shader_id = 0;
+		if (m_geometry_shader_id != 0)
+			glDeleteShader(m_geometry_shader_id);
+		m_geometry_shader_id = 0;
 		if (m_fragment_shader_id != 0)
 			glDeleteShader(m_fragment_shader_id);
 		m_fragment_shader_id = 0;
@@ -542,6 +541,8 @@ namespace GL
 		prog.m_program_id = 0;
 		m_vertex_shader_id = prog.m_vertex_shader_id;
 		prog.m_vertex_shader_id = 0;
+		m_geometry_shader_id = prog.m_geometry_shader_id;
+		prog.m_geometry_shader_id = 0;
 		m_fragment_shader_id = prog.m_fragment_shader_id;
 		prog.m_fragment_shader_id = 0;
 		m_uniform_locations = std::move(prog.m_uniform_locations);

--- a/common/GL/Program.h
+++ b/common/GL/Program.h
@@ -99,6 +99,7 @@ namespace GL
 
 		GLuint m_program_id = 0;
 		GLuint m_vertex_shader_id = 0;
+		GLuint m_geometry_shader_id = 0;
 		GLuint m_fragment_shader_id = 0;
 
 		std::vector<GLint> m_uniform_locations;

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.h
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.h
@@ -120,60 +120,8 @@ public:
 class GSDeviceOGL final : public GSDevice
 {
 public:
-	struct VSSelector
-	{
-		union
-		{
-			struct
-			{
-				u8 int_fst : 1;
-				u8 iip : 1;
-				u8 point_size : 1;
-				u8 _free : 5;
-			};
-
-			u8 key;
-		};
-
-		VSSelector()
-			: key(0)
-		{
-		}
-		VSSelector(u8 k)
-			: key(k)
-		{
-		}
-	};
-
-	struct GSSelector
-	{
-		union
-		{
-			struct
-			{
-				u8 sprite : 1;
-				u8 point  : 1;
-				u8 line   : 1;
-				u8 iip    : 1;
-
-				u8 _free : 4;
-			};
-
-			u8 key;
-		};
-
-		operator u32() const { return key; }
-
-		GSSelector()
-			: key(0)
-		{
-		}
-		GSSelector(u8 k)
-			: key(k)
-		{
-		}
-	};
-
+	using VSSelector = GSHWDrawConfig::VSSelector;
+	using GSSelector = GSHWDrawConfig::GSSelector;
 	using PSSelector = GSHWDrawConfig::PSSelector;
 	using PSSamplerSelector = GSHWDrawConfig::SamplerSelector;
 	using OMDepthStencilSelector = GSHWDrawConfig::DepthStencilSelector;


### PR DESCRIPTION
### Description of Changes

Bug inherited from the DuckStation code I pulled in ages ago.

Plus gets rid of the GL-specific selector, we don't need it and can just use the base class.

### Rationale behind Changes

Leaks are bad.

### Suggested Testing Steps

Make sure the OpenGL renderer still works.
