### PR TITLE
Qt: Recreate new window immediately when switching APIs

### DIFF
--- a/pcsx2-gsrunner/Main.cpp
+++ b/pcsx2-gsrunner/Main.cpp
@@ -254,13 +254,14 @@ void Host::SetRelativeMouseMode(bool enabled)
 {
 }
 
-std::optional<WindowInfo> Host::AcquireRenderWindow(RenderAPI api)
+std::optional<WindowInfo> Host::AcquireRenderWindow()
 {
 	return GSRunner::GetPlatformWindowInfo();
 }
 
-std::optional<WindowInfo> Host::UpdateRenderWindow()
+std::optional<WindowInfo> Host::UpdateRenderWindow(bool recreate_window)
 {
+	// We shouldn't ever recreate with the runner, so this is okay..
 	return GSRunner::GetPlatformWindowInfo();
 }
 

--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -2233,23 +2233,24 @@ std::optional<WindowInfo> MainWindow::createDisplayWindow(bool fullscreen, bool 
 	return wi;
 }
 
-std::optional<WindowInfo> MainWindow::updateDisplayWindow(bool fullscreen, bool render_to_main, bool surfaceless)
+std::optional<WindowInfo> MainWindow::updateDisplayWindow(bool recreate_window, bool fullscreen, bool render_to_main, bool surfaceless)
 {
-	DevCon.WriteLn("updateDisplayWindow() fullscreen=%s render_to_main=%s surfaceless=%s", fullscreen ? "true" : "false",
-		render_to_main ? "true" : "false", surfaceless ? "true" : "false");
+	DevCon.WriteLn("updateDisplayWindow() recreate=%s fullscreen=%s render_to_main=%s surfaceless=%s", recreate_window ? "true" : "false",
+		fullscreen ? "true" : "false", render_to_main ? "true" : "false", surfaceless ? "true" : "false");
 
 	QWidget* container = m_display_container ? static_cast<QWidget*>(m_display_container) : static_cast<QWidget*>(m_display_widget);
 	const bool is_fullscreen = isRenderingFullscreen();
 	const bool is_rendering_to_main = isRenderingToMain();
 	const bool changing_surfaceless = (!m_display_widget != surfaceless);
-	if (fullscreen == is_fullscreen && is_rendering_to_main == render_to_main && !changing_surfaceless)
+	if (!recreate_window && fullscreen == is_fullscreen && is_rendering_to_main == render_to_main && !changing_surfaceless)
 		return m_display_widget->getWindowInfo();
 
 	// Skip recreating the surface if we're just transitioning between fullscreen and windowed with render-to-main off.
 	// .. except on Wayland, where everything tends to break if you don't recreate.
 	const bool has_container = (m_display_container != nullptr);
 	const bool needs_container = DisplayContainer::isNeeded(fullscreen, render_to_main);
-	if (!is_rendering_to_main && !render_to_main && has_container == needs_container && !needs_container && !changing_surfaceless)
+	if (!recreate_window && !is_rendering_to_main && !render_to_main && has_container == needs_container && !needs_container &&
+		!changing_surfaceless)
 	{
 		DevCon.WriteLn("Toggling to %s without recreating surface", (fullscreen ? "fullscreen" : "windowed"));
 

--- a/pcsx2-qt/MainWindow.h
+++ b/pcsx2-qt/MainWindow.h
@@ -129,7 +129,7 @@ private Q_SLOTS:
 	void onUpdateCheckComplete();
 
 	std::optional<WindowInfo> createDisplayWindow(bool fullscreen, bool render_to_main);
-	std::optional<WindowInfo> updateDisplayWindow(bool fullscreen, bool render_to_main, bool surfaceless);
+	std::optional<WindowInfo> updateDisplayWindow(bool recreate_window, bool fullscreen, bool render_to_main, bool surfaceless);
 	void displayResizeRequested(qint32 width, qint32 height);
 	void relativeMouseModeRequested(bool enabled);
 	void destroyDisplay();

--- a/pcsx2-qt/QtHost.cpp
+++ b/pcsx2-qt/QtHost.cpp
@@ -901,9 +901,9 @@ std::optional<WindowInfo> EmuThread::acquireRenderWindow()
 	return emit onCreateDisplayRequested(m_is_fullscreen, m_is_rendering_to_main);
 }
 
-std::optional<WindowInfo> EmuThread::updateRenderWindow()
+std::optional<WindowInfo> EmuThread::updateRenderWindow(bool recreate_window)
 {
-	return emit onUpdateDisplayRequested(m_is_fullscreen, !m_is_fullscreen && m_is_rendering_to_main, m_is_surfaceless);
+	return emit onUpdateDisplayRequested(recreate_window, m_is_fullscreen, !m_is_fullscreen && m_is_rendering_to_main, m_is_surfaceless);
 }
 
 void EmuThread::releaseRenderWindow()
@@ -911,14 +911,14 @@ void EmuThread::releaseRenderWindow()
 	emit onDestroyDisplayRequested();
 }
 
-std::optional<WindowInfo> Host::AcquireRenderWindow(RenderAPI api)
+std::optional<WindowInfo> Host::AcquireRenderWindow()
 {
 	return g_emu_thread->acquireRenderWindow();
 }
 
-std::optional<WindowInfo> Host::UpdateRenderWindow()
+std::optional<WindowInfo> Host::UpdateRenderWindow(bool recreate_window)
 {
-	return g_emu_thread->updateRenderWindow();
+	return g_emu_thread->updateRenderWindow(recreate_window);
 }
 
 void Host::ReleaseRenderWindow()

--- a/pcsx2-qt/QtHost.h
+++ b/pcsx2-qt/QtHost.h
@@ -70,7 +70,7 @@ public:
 
 	/// Called back from the GS thread when the display state changes (e.g. fullscreen, render to main).
 	std::optional<WindowInfo> acquireRenderWindow();
-	std::optional<WindowInfo> updateRenderWindow();
+	std::optional<WindowInfo> updateRenderWindow(bool recreate_window);
 	void connectDisplaySignals(DisplayWidget* widget);
 	void releaseRenderWindow();
 
@@ -118,7 +118,7 @@ Q_SIGNALS:
 	bool messageConfirmed(const QString& title, const QString& message);
 
 	std::optional<WindowInfo> onCreateDisplayRequested(bool fullscreen, bool render_to_main);
-	std::optional<WindowInfo> onUpdateDisplayRequested(bool fullscreen, bool render_to_main, bool surfaceless);
+	std::optional<WindowInfo> onUpdateDisplayRequested(bool recreate_window, bool fullscreen, bool render_to_main, bool surfaceless);
 	void onResizeDisplayRequested(qint32 width, qint32 height);
 	void onDestroyDisplayRequested();
 	void onRelativeMouseModeRequested(bool enabled);

--- a/pcsx2/GS/GS.h
+++ b/pcsx2/GS/GS.h
@@ -32,8 +32,7 @@ enum class RenderAPI
 	Metal,
 	D3D12,
 	Vulkan,
-	OpenGL,
-	OpenGLES
+	OpenGL
 };
 
 // ST_WRITE is defined in libc, avoid this
@@ -129,11 +128,11 @@ struct GSRecoverableError : GSError
 namespace Host
 {
 	/// Called when the GS is creating a render device.
-	std::optional<WindowInfo> AcquireRenderWindow(RenderAPI api);
+	std::optional<WindowInfo> AcquireRenderWindow();
 
 	/// Called on the MTGS thread when a request to update the display is received.
 	/// This could be a fullscreen transition, for example.
-	std::optional<WindowInfo> UpdateRenderWindow();
+	std::optional<WindowInfo> UpdateRenderWindow(bool recreate_window);
 
 	/// Called before drawing the OSD and other display elements.
 	void BeginPresentFrame();

--- a/pcsx2/GS/Renderers/Common/GSDevice.cpp
+++ b/pcsx2/GS/Renderers/Common/GSDevice.cpp
@@ -105,7 +105,6 @@ const char* GSDevice::RenderAPIToString(RenderAPI api)
 		CASE(Metal);
 		CASE(Vulkan);
 		CASE(OpenGL);
-		CASE(OpenGLES);
 #undef CASE
 		// clang-format on
 	default:
@@ -323,7 +322,7 @@ void GSDevice::Recycle(GSTexture* t)
 bool GSDevice::UsesLowerLeftOrigin() const
 {
 	const RenderAPI api = GetRenderAPI();
-	return (api == RenderAPI::OpenGL || api == RenderAPI::OpenGLES);
+	return (api == RenderAPI::OpenGL);
 }
 
 void GSDevice::AgePool()

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -60,7 +60,7 @@ GSTexture* GSDeviceOGL::CreateSurface(GSTexture::Type type, int width, int heigh
 
 RenderAPI GSDeviceOGL::GetRenderAPI() const
 {
-	return m_gl_context->IsGLES() ? RenderAPI::OpenGLES : RenderAPI::OpenGL;
+	return RenderAPI::OpenGL;
 }
 
 bool GSDeviceOGL::HasSurface() const

--- a/tests/ctest/core/StubHost.cpp
+++ b/tests/ctest/core/StubHost.cpp
@@ -105,12 +105,12 @@ void Host::SetRelativeMouseMode(bool enabled)
 {
 }
 
-std::optional<WindowInfo> Host::AcquireRenderWindow(RenderAPI api)
+std::optional<WindowInfo> Host::AcquireRenderWindow()
 {
 	return std::nullopt;
 }
 
-std::optional<WindowInfo> Host::UpdateRenderWindow()
+std::optional<WindowInfo> Host::UpdateRenderWindow(bool recreate_window)
 {
 	return std::nullopt;
 }


### PR DESCRIPTION
### Description of Changes

Renderer switches had a very brief moment where there was no window on screen -> Qt thought "no windows left, better shut down", which deadlocked waiting for the CPU thread to shut down -> waiting for GS thread -> GS thread waiting for main window to create new render window.

This PR creates the new window at the same time as destroying the old one. Why do we need to do this? Renderer switches to/from DirectX, particularly when flip mode gets engaged.

### Rationale behind Changes

Closes #8592.

### Suggested Testing Steps

Test linked issue.
