### PR TITLE
GS/HW: Allow translating targets for depth sources

### DIFF
--- a/bin/resources/shaders/dx11/tfx.fx
+++ b/bin/resources/shaders/dx11/tfx.fx
@@ -437,8 +437,12 @@ int2 clamp_wrap_uv_depth(int2 uv)
 float4 sample_depth(float2 st, float2 pos)
 {
 	float2 uv_f = (float2)clamp_wrap_uv_depth(int2(st)) * (float2)ScaledScaleFactor;
-	int2 uv = (int2)uv_f;
 
+#if PS_REGION_RECT == 1
+	uv_f = clamp(uv_f + STRange.xy, STRange.xy, STRange.zw);
+#endif
+
+	int2 uv = (int2)uv_f;
 	float4 t = (float4)(0.0f);
 
 	if (PS_TALES_OF_ABYSS_HLE == 1)

--- a/bin/resources/shaders/opengl/tfx_fs.glsl
+++ b/bin/resources/shaders/opengl/tfx_fs.glsl
@@ -376,9 +376,14 @@ ivec2 clamp_wrap_uv_depth(ivec2 uv)
 vec4 sample_depth(vec2 st)
 {
     vec2 uv_f = vec2(clamp_wrap_uv_depth(ivec2(st))) * vec2(ScaledScaleFactor);
-    ivec2 uv = ivec2(uv_f);
 
+    #if PS_REGION_RECT == 1
+        uv_f = clamp(uv_f + STRange.xy, STRange.xy, STRange.zw);
+    #endif
+
+    ivec2 uv = ivec2(uv_f);
     vec4 t = vec4(0.0f);
+
 #if PS_TALES_OF_ABYSS_HLE == 1
     // Warning: UV can't be used in channel effect
     int depth = fetch_raw_depth();

--- a/bin/resources/shaders/vulkan/tfx.glsl
+++ b/bin/resources/shaders/vulkan/tfx.glsl
@@ -684,8 +684,12 @@ ivec2 clamp_wrap_uv_depth(ivec2 uv)
 vec4 sample_depth(vec2 st, ivec2 pos)
 {
 	vec2 uv_f = vec2(clamp_wrap_uv_depth(ivec2(st))) * vec2(ScaledScaleFactor);
-	ivec2 uv = ivec2(uv_f);
 
+	#if PS_REGION_RECT == 1
+		uv_f = clamp(uv_f + STRange.xy, STRange.xy, STRange.zw);
+	#endif
+
+	ivec2 uv = ivec2(uv_f);
 	vec4 t = vec4(0.0f);
 
 	#if (PS_TALES_OF_ABYSS_HLE == 1)

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -2057,6 +2057,10 @@ void GSRendererHW::Draw()
 		rt->m_32_bits_fmt = m_texture_shuffle || (GSLocalMemory::m_psm[m_cached_ctx.FRAME.PSM].bpp != 16);
 	}
 
+	// Do the same for the depth target. Jackie Chan Adventures swaps from C32 to Z16 after a clear.
+	if (ds)
+		ds->m_32_bits_fmt = (GSLocalMemory::m_psm[m_cached_ctx.ZBUF.PSM].bpp != 16);
+
 	// Deferred update of TEX0. We don't want to change it when we're doing a shuffle/clear, because it
 	// may increase the buffer width, or change PSM, which breaks P8 conversion amongst other things.
 	const bool is_mem_clear = IsConstantDirectWriteMemClear(false);

--- a/pcsx2/GS/Renderers/Metal/tfx.metal
+++ b/pcsx2/GS/Renderers/Metal/tfx.metal
@@ -563,9 +563,13 @@ struct PSMain
 	float4 sample_depth(float2 st)
 	{
 		float2 uv_f = float2(clamp_wrap_uv_depth(ushort2(st))) * float2(cb.scale_factor.x);
-		ushort2 uv = ushort2(uv_f);
 
+		if (PS_REGION_RECT)
+			uv_f = clamp(uv_f + cb.st_range.xy, cb.st_range.xy, cb.st_range.zw);
+
+		ushort2 uv = ushort2(uv_f);
 		float4 t = float4(0);
+
 		if (PS_TALES_OF_ABYSS_HLE)
 		{
 			// Warning: UV can't be used in channel effect


### PR DESCRIPTION
### Description of Changes

Fixes broken half screen in Miami Vice and 10 Pin - Champions Alley.

### Rationale behind Changes

<img width="1157" alt="Untitled" src="https://user-images.githubusercontent.com/11288319/230712155-eab711fc-1dee-4f04-988b-d40e6413048f.png">

Closes #8313.
Closes #1824.

### Suggested Testing Steps

Test affected games.
