### PR TITLE
GS: Reset performance counters on renderer switch

### DIFF
--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -242,7 +242,6 @@ static bool OpenGSDevice(GSRendererType renderer, bool clear_state_on_fail, bool
 	// Switch to exclusive fullscreen if enabled.
 	UpdateExclusiveFullscreen(false);
 
-	g_perfmon.Reset();
 	return true;
 }
 
@@ -277,6 +276,7 @@ static bool OpenGSRenderer(GSRendererType renderer, u8* basemem)
 
 	g_gs_renderer->SetRegsMem(basemem);
 	g_gs_renderer->ResetPCRTC();
+	g_perfmon.Reset();
 	return true;
 }
 


### PR DESCRIPTION
### Description of Changes
Resets the performance counters on reset.

### Rationale behind Changes
"stop ref getting triggered by phat numbers of TCs"

### Suggested Testing Steps
Make sure CI is happy.
