### PR TITLE
GS/HW: VS expand instead of GS for DX/GL/Vulkan

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -20199,32 +20199,27 @@ SLES-54354:
   compat: 5
   gsHWFixes:
     getSkipCount: "GSC_FFXGames"
-    beforeDraw: "OI_FFXII"
 SLES-54355:
   name: "Final Fantasy XII"
   region: "PAL-F"
   gsHWFixes:
     getSkipCount: "GSC_FFXGames"
-    beforeDraw: "OI_FFXII"
 SLES-54356:
   name: "Final Fantasy XII"
   region: "PAL-G"
   gsHWFixes:
     getSkipCount: "GSC_FFXGames"
-    beforeDraw: "OI_FFXII"
 SLES-54357:
   name: "Final Fantasy XII"
   region: "PAL-I"
   gsHWFixes:
     getSkipCount: "GSC_FFXGames"
-    beforeDraw: "OI_FFXII"
 SLES-54358:
   name: "Final Fantasy XII"
   region: "PAL-S"
   compat: 5
   gsHWFixes:
     getSkipCount: "GSC_FFXGames"
-    beforeDraw: "OI_FFXII"
 SLES-54359:
   name: "Legend of Spyro, The - A New Beginning"
   region: "PAL-M6"

--- a/common/D3D11/ShaderCache.cpp
+++ b/common/D3D11/ShaderCache.cpp
@@ -337,16 +337,6 @@ bool D3D11::ShaderCache::GetVertexShaderAndInputLayout(ID3D11Device* device,
 	return true;
 }
 
-wil::com_ptr_nothrow<ID3D11GeometryShader> D3D11::ShaderCache::GetGeometryShader(ID3D11Device* device,
-	const std::string_view& shader_code, const D3D_SHADER_MACRO* macros /* = nullptr */, const char* entry_point /* = "main" */)
-{
-	wil::com_ptr_nothrow<ID3DBlob> blob = GetShaderBlob(ShaderCompiler::Type::Geometry, shader_code, macros, entry_point);
-	if (!blob)
-		return {};
-
-	return D3D11::ShaderCompiler::CreateGeometryShader(device, blob.get());
-}
-
 wil::com_ptr_nothrow<ID3D11PixelShader> D3D11::ShaderCache::GetPixelShader(ID3D11Device* device,
 	const std::string_view& shader_code, const D3D_SHADER_MACRO* macros /* = nullptr */, const char* entry_point /* = "main" */)
 {

--- a/common/D3D11/ShaderCache.h
+++ b/common/D3D11/ShaderCache.h
@@ -51,9 +51,6 @@ namespace D3D11
 			const D3D11_INPUT_ELEMENT_DESC* layout, size_t layout_size,
 			const std::string_view& shader_code, const D3D_SHADER_MACRO* macros = nullptr, const char* entry_point = "main");
 
-		wil::com_ptr_nothrow<ID3D11GeometryShader> GetGeometryShader(ID3D11Device* device, const std::string_view& shader_code,
-			const D3D_SHADER_MACRO* macros = nullptr, const char* entry_point = "main");
-
 		wil::com_ptr_nothrow<ID3D11PixelShader> GetPixelShader(ID3D11Device* device, const std::string_view& shader_code,
 			const D3D_SHADER_MACRO* macros = nullptr, const char* entry_point = "main");
 

--- a/common/D3D11/ShaderCompiler.cpp
+++ b/common/D3D11/ShaderCompiler.cpp
@@ -31,21 +31,21 @@ wil::com_ptr_nothrow<ID3DBlob> D3D11::ShaderCompiler::CompileShader(Type type, D
 	{
 		case D3D_FEATURE_LEVEL_10_0:
 		{
-			static constexpr std::array<const char*, 4> targets = {{"vs_4_0", "gs_4_0", "ps_4_0", "cs_4_0"}};
+			static constexpr std::array<const char*, 4> targets = {{"vs_4_0", "ps_4_0", "cs_4_0"}};
 			target = targets[static_cast<int>(type)];
 		}
 		break;
 
 		case D3D_FEATURE_LEVEL_10_1:
 		{
-			static constexpr std::array<const char*, 4> targets = {{"vs_4_1", "gs_4_1", "ps_4_1", "cs_4_1"}};
+			static constexpr std::array<const char*, 4> targets = {{"vs_4_1", "ps_4_1", "cs_4_1"}};
 			target = targets[static_cast<int>(type)];
 		}
 		break;
 
 		case D3D_FEATURE_LEVEL_11_0:
 		{
-			static constexpr std::array<const char*, 4> targets = {{"vs_5_0", "gs_5_0", "ps_5_0", "cs_5_0"}};
+			static constexpr std::array<const char*, 4> targets = {{"vs_5_0", "ps_5_0", "cs_5_0"}};
 			target = targets[static_cast<int>(type)];
 		}
 		break;
@@ -53,7 +53,7 @@ wil::com_ptr_nothrow<ID3DBlob> D3D11::ShaderCompiler::CompileShader(Type type, D
 		case D3D_FEATURE_LEVEL_11_1:
 		default:
 		{
-			static constexpr std::array<const char*, 4> targets = {{"vs_5_1", "gs_5_1", "ps_5_1", "cs_5_1"}};
+			static constexpr std::array<const char*, 4> targets = {{"vs_5_1", "ps_5_1", "cs_5_1"}};
 			target = targets[static_cast<int>(type)];
 		}
 		break;
@@ -108,16 +108,6 @@ wil::com_ptr_nothrow<ID3D11VertexShader> D3D11::ShaderCompiler::CompileAndCreate
 	return CreateVertexShader(device, blob.get());
 }
 
-wil::com_ptr_nothrow<ID3D11GeometryShader> D3D11::ShaderCompiler::CompileAndCreateGeometryShader(ID3D11Device* device, bool debug,
-	const std::string_view& code, const D3D_SHADER_MACRO* macros /* = nullptr */, const char* entry_point /* = "main" */)
-{
-	wil::com_ptr_nothrow<ID3DBlob> blob = CompileShader(Type::Geometry, device->GetFeatureLevel(), debug, code, macros, entry_point);
-	if (!blob)
-		return {};
-
-	return CreateGeometryShader(device, blob.get());
-}
-
 wil::com_ptr_nothrow<ID3D11PixelShader> D3D11::ShaderCompiler::CompileAndCreatePixelShader(ID3D11Device* device, bool debug,
 	const std::string_view& code, const D3D_SHADER_MACRO* macros /* = nullptr */, const char* entry_point /* = "main" */)
 {
@@ -154,25 +144,6 @@ wil::com_ptr_nothrow<ID3D11VertexShader> D3D11::ShaderCompiler::CreateVertexShad
 wil::com_ptr_nothrow<ID3D11VertexShader> D3D11::ShaderCompiler::CreateVertexShader(ID3D11Device* device, const ID3DBlob* blob)
 {
 	return CreateVertexShader(device, const_cast<ID3DBlob*>(blob)->GetBufferPointer(),
-		const_cast<ID3DBlob*>(blob)->GetBufferSize());
-}
-
-wil::com_ptr_nothrow<ID3D11GeometryShader> D3D11::ShaderCompiler::CreateGeometryShader(ID3D11Device* device, const void* bytecode, size_t bytecode_length)
-{
-	wil::com_ptr_nothrow<ID3D11GeometryShader> shader;
-	const HRESULT hr = device->CreateGeometryShader(bytecode, bytecode_length, nullptr, shader.put());
-	if (FAILED(hr))
-	{
-		Console.Error("Failed to create geometry shader: 0x%08X", hr);
-		return {};
-	}
-
-	return shader;
-}
-
-wil::com_ptr_nothrow<ID3D11GeometryShader> D3D11::ShaderCompiler::CreateGeometryShader(ID3D11Device* device, const ID3DBlob* blob)
-{
-	return CreateGeometryShader(device, const_cast<ID3DBlob*>(blob)->GetBufferPointer(),
 		const_cast<ID3DBlob*>(blob)->GetBufferSize());
 }
 

--- a/common/D3D11/ShaderCompiler.h
+++ b/common/D3D11/ShaderCompiler.h
@@ -27,7 +27,6 @@ namespace D3D11::ShaderCompiler
 	enum class Type
 	{
 		Vertex,
-		Geometry,
 		Pixel,
 		Compute
 	};
@@ -37,8 +36,6 @@ namespace D3D11::ShaderCompiler
 
 	wil::com_ptr_nothrow<ID3D11VertexShader> CompileAndCreateVertexShader(ID3D11Device* device, bool debug, const std::string_view& code,
 		const D3D_SHADER_MACRO* macros = nullptr, const char* entry_point = "main");
-	wil::com_ptr_nothrow<ID3D11GeometryShader> CompileAndCreateGeometryShader(ID3D11Device* device, bool debug, const std::string_view& code,
-		const D3D_SHADER_MACRO* macros = nullptr, const char* entry_point = "main");
 	wil::com_ptr_nothrow<ID3D11PixelShader> CompileAndCreatePixelShader(ID3D11Device* device, bool debug, const std::string_view& code,
 		const D3D_SHADER_MACRO* macros = nullptr, const char* entry_point = "main");
 	wil::com_ptr_nothrow<ID3D11ComputeShader> CompileAndCreateComputeShader(ID3D11Device* device, bool debug, const std::string_view& code,
@@ -46,8 +43,6 @@ namespace D3D11::ShaderCompiler
 
 	wil::com_ptr_nothrow<ID3D11VertexShader> CreateVertexShader(ID3D11Device* device, const void* bytecode, size_t bytecode_length);
 	wil::com_ptr_nothrow<ID3D11VertexShader> CreateVertexShader(ID3D11Device* device, const ID3DBlob* blob);
-	wil::com_ptr_nothrow<ID3D11GeometryShader> CreateGeometryShader(ID3D11Device* device, const void* bytecode, size_t bytecode_length);
-	wil::com_ptr_nothrow<ID3D11GeometryShader> CreateGeometryShader(ID3D11Device* device, const ID3DBlob* blob);
 	wil::com_ptr_nothrow<ID3D11PixelShader> CreatePixelShader(ID3D11Device* device, const void* bytecode, size_t bytecode_length);
 	wil::com_ptr_nothrow<ID3D11PixelShader> CreatePixelShader(ID3D11Device* device, const ID3DBlob* blob);
 	wil::com_ptr_nothrow<ID3D11ComputeShader> CreateComputeShader(ID3D11Device* device, const void* bytecode, size_t bytecode_length);

--- a/common/D3D12/Context.h
+++ b/common/D3D12/Context.h
@@ -152,6 +152,10 @@ namespace D3D12
 		float GetAndResetAccumulatedGPUTime();
 		void SetEnableGPUTiming(bool enabled);
 
+		// Allocates a temporary CPU staging buffer, fires the callback with it to populate, then copies to a GPU buffer.
+		bool AllocatePreinitializedGPUBuffer(u32 size, ID3D12Resource** gpu_buffer, D3D12MA::Allocation** gpu_allocation,
+			const std::function<void(void*)>& fill_callback);
+
 	private:
 		struct CommandListResources
 		{

--- a/common/D3D12/ShaderCache.cpp
+++ b/common/D3D12/ShaderCache.cpp
@@ -521,9 +521,6 @@ ShaderCache::ComPtr<ID3DBlob> ShaderCache::CompileAndAddShaderBlob(const CacheIn
 		case EntryType::VertexShader:
 			blob = D3D11::ShaderCompiler::CompileShader(D3D11::ShaderCompiler::Type::Vertex, m_feature_level, m_debug, shader_code, macros, entry_point);
 			break;
-		case EntryType::GeometryShader:
-			blob = D3D11::ShaderCompiler::CompileShader(D3D11::ShaderCompiler::Type::Geometry, m_feature_level, m_debug, shader_code, macros, entry_point);
-			break;
 		case EntryType::PixelShader:
 			blob = D3D11::ShaderCompiler::CompileShader(D3D11::ShaderCompiler::Type::Pixel, m_feature_level, m_debug, shader_code, macros, entry_point);
 			break;

--- a/common/D3D12/ShaderCache.h
+++ b/common/D3D12/ShaderCache.h
@@ -37,7 +37,6 @@ namespace D3D12
 		enum class EntryType
 		{
 			VertexShader,
-			GeometryShader,
 			PixelShader,
 			ComputeShader,
 			GraphicsPipeline,
@@ -58,11 +57,6 @@ namespace D3D12
 			const D3D_SHADER_MACRO* macros = nullptr, const char* entry_point = "main")
 		{
 			return GetShaderBlob(EntryType::VertexShader, shader_code, macros, entry_point);
-		}
-		__fi ComPtr<ID3DBlob> GetGeometryShader(std::string_view shader_code,
-			const D3D_SHADER_MACRO* macros = nullptr, const char* entry_point = "main")
-		{
-			return GetShaderBlob(EntryType::GeometryShader, shader_code, macros, entry_point);
 		}
 		__fi ComPtr<ID3DBlob> GetPixelShader(std::string_view shader_code,
 			const D3D_SHADER_MACRO* macros = nullptr, const char* entry_point = "main")

--- a/common/GL/Program.cpp
+++ b/common/GL/Program.cpp
@@ -35,8 +35,6 @@ namespace GL
 		prog.m_program_id = 0;
 		m_vertex_shader_id = prog.m_vertex_shader_id;
 		prog.m_vertex_shader_id = 0;
-		m_geometry_shader_id = prog.m_geometry_shader_id;
-		prog.m_geometry_shader_id = 0;
 		m_fragment_shader_id = prog.m_fragment_shader_id;
 		prog.m_fragment_shader_id = 0;
 		m_uniform_locations = std::move(prog.m_uniform_locations);
@@ -102,20 +100,12 @@ namespace GL
 		s_last_program_id = 0;
 	}
 
-	bool Program::Compile(const std::string_view vertex_shader, const std::string_view geometry_shader,
-		const std::string_view fragment_shader)
+	bool Program::Compile(const std::string_view vertex_shader, const std::string_view fragment_shader)
 	{
 		if (!vertex_shader.empty())
 		{
 			m_vertex_shader_id = CompileShader(GL_VERTEX_SHADER, vertex_shader);
 			if (m_vertex_shader_id == 0)
-				return false;
-		}
-
-		if (!geometry_shader.empty())
-		{
-			m_geometry_shader_id = CompileShader(GL_GEOMETRY_SHADER, geometry_shader);
-			if (m_geometry_shader_id == 0)
 				return false;
 		}
 
@@ -129,8 +119,6 @@ namespace GL
 		m_program_id = glCreateProgram();
 		if (m_vertex_shader_id != 0)
 			glAttachShader(m_program_id, m_vertex_shader_id);
-		if (m_geometry_shader_id != 0)
-			glAttachShader(m_program_id, m_geometry_shader_id);
 		if (m_fragment_shader_id != 0)
 			glAttachShader(m_program_id, m_fragment_shader_id);
 		return true;
@@ -240,9 +228,6 @@ namespace GL
 		if (m_vertex_shader_id != 0)
 			glDeleteShader(m_vertex_shader_id);
 		m_vertex_shader_id = 0;
-		if (m_geometry_shader_id != 0)
-			glDeleteShader(m_geometry_shader_id);
-		m_geometry_shader_id = 0;
 		if (m_fragment_shader_id != 0)
 			glDeleteShader(m_fragment_shader_id);
 		m_fragment_shader_id = 0;
@@ -541,8 +526,6 @@ namespace GL
 		prog.m_program_id = 0;
 		m_vertex_shader_id = prog.m_vertex_shader_id;
 		prog.m_vertex_shader_id = 0;
-		m_geometry_shader_id = prog.m_geometry_shader_id;
-		prog.m_geometry_shader_id = 0;
 		m_fragment_shader_id = prog.m_fragment_shader_id;
 		prog.m_fragment_shader_id = 0;
 		m_uniform_locations = std::move(prog.m_uniform_locations);

--- a/common/GL/Program.h
+++ b/common/GL/Program.h
@@ -34,8 +34,7 @@ namespace GL
 
 		bool IsValid() const { return m_program_id != 0; }
 
-		bool Compile(const std::string_view vertex_shader, const std::string_view geometry_shader,
-			const std::string_view fragment_shader);
+		bool Compile(const std::string_view vertex_shader, const std::string_view fragment_shader);
 
 		bool CompileCompute(const std::string_view glsl);
 
@@ -99,7 +98,6 @@ namespace GL
 
 		GLuint m_program_id = 0;
 		GLuint m_vertex_shader_id = 0;
-		GLuint m_geometry_shader_id = 0;
 		GLuint m_fragment_shader_id = 0;
 
 		std::vector<GLint> m_uniform_locations;

--- a/common/GL/ShaderCache.h
+++ b/common/GL/ShaderCache.h
@@ -38,10 +38,8 @@ namespace GL
 		bool Open(bool is_gles, std::string_view base_path, u32 version);
 		void Close();
 
-		std::optional<Program> GetProgram(const std::string_view vertex_shader, const std::string_view geometry_shader,
-			const std::string_view fragment_shader, const PreLinkCallback& callback = {});
-		bool GetProgram(Program* out_program, const std::string_view vertex_shader, const std::string_view geometry_shader,
-			const std::string_view fragment_shader, const PreLinkCallback& callback = {});
+		std::optional<Program> GetProgram(const std::string_view vertex_shader, const std::string_view fragment_shader, const PreLinkCallback& callback = {});
+		bool GetProgram(Program* out_program, const std::string_view vertex_shader, const std::string_view fragment_shader, const PreLinkCallback& callback = {});
 
 		std::optional<Program> GetComputeProgram(const std::string_view glsl, const PreLinkCallback& callback = {});
 		bool GetComputeProgram(Program* out_program, const std::string_view glsl, const PreLinkCallback& callback = {});
@@ -54,9 +52,6 @@ namespace GL
 			u64 vertex_source_hash_low;
 			u64 vertex_source_hash_high;
 			u32 vertex_source_length;
-			u64 geometry_source_hash_low;
-			u64 geometry_source_hash_high;
-			u32 geometry_source_length;
 			u64 fragment_source_hash_low;
 			u64 fragment_source_hash_high;
 			u32 fragment_source_length;
@@ -72,7 +67,6 @@ namespace GL
 				std::size_t h = 0;
 				HashCombine(h,
 					e.vertex_source_hash_low, e.vertex_source_hash_high, e.vertex_source_length,
-					e.geometry_source_hash_low, e.geometry_source_hash_high, e.geometry_source_length,
 					e.fragment_source_hash_low, e.fragment_source_hash_high, e.fragment_source_length);
 				return h;
 			}
@@ -87,8 +81,7 @@ namespace GL
 
 		using CacheIndex = std::unordered_map<CacheIndexKey, CacheIndexData, CacheIndexEntryHasher>;
 
-		static CacheIndexKey GetCacheKey(const std::string_view& vertex_shader, const std::string_view& geometry_shader,
-			const std::string_view& fragment_shader);
+		static CacheIndexKey GetCacheKey(const std::string_view& vertex_shader, const std::string_view& fragment_shader);
 
 		std::string GetIndexFileName() const;
 		std::string GetBlobFileName() const;
@@ -99,11 +92,10 @@ namespace GL
 
 		bool WriteToBlobFile(const CacheIndexKey& key, const std::vector<u8>& prog_data, u32 prog_format);
 
-		std::optional<Program> CompileProgram(const std::string_view& vertex_shader, const std::string_view& geometry_shader,
+		std::optional<Program> CompileProgram(const std::string_view& vertex_shader,
 			const std::string_view& fragment_shader, const PreLinkCallback& callback,
 			bool set_retrievable);
 		std::optional<Program> CompileAndAddProgram(const CacheIndexKey& key, const std::string_view& vertex_shader,
-			const std::string_view& geometry_shader,
 			const std::string_view& fragment_shader, const PreLinkCallback& callback);
 
 		std::optional<Program> CompileComputeProgram(const std::string_view& glsl, const PreLinkCallback& callback, bool set_retrievable);

--- a/common/Vulkan/Builders.cpp
+++ b/common/Vulkan/Builders.cpp
@@ -698,11 +698,6 @@ namespace Vulkan
 	{
 		pxAssert(m_num_writes < MAX_WRITES && (m_num_image_infos + num_views) < MAX_IMAGE_INFOS);
 
-#if 1
-		// NOTE: This is deliberately split up - updating multiple descriptors in one write is broken on Adreno.
-		for (u32 i = 0; i < num_views; i++)
-			AddCombinedImageSamplerDescriptorWrite(set, binding + i, views[i], samplers[i], layout);
-#else
 		VkWriteDescriptorSet& dw = m_writes[m_num_writes++];
 		dw.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
 		dw.dstSet = set;
@@ -718,7 +713,6 @@ namespace Vulkan
 			ii.sampler = samplers[i];
 			ii.imageLayout = layout;
 		}
-#endif
 	}
 
 	void DescriptorSetUpdateBuilder::AddBufferDescriptorWrite(

--- a/common/Vulkan/Context.h
+++ b/common/Vulkan/Context.h
@@ -56,6 +56,7 @@ namespace Vulkan
 			bool vk_khr_driver_properties : 1;
 			bool vk_arm_rasterization_order_attachment_access : 1;
 			bool vk_khr_fragment_shader_barycentric : 1;
+			bool vk_khr_shader_draw_parameters : 1;
 		};
 
 		~Context();
@@ -237,6 +238,10 @@ namespace Vulkan
 
 		void CountRenderPass() { m_command_buffer_render_passes++; }
 		void NotifyOfReadback();
+
+		// Allocates a temporary CPU staging buffer, fires the callback with it to populate, then copies to a GPU buffer.
+		bool AllocatePreinitializedGPUBuffer(u32 size, VkBuffer* gpu_buffer, VmaAllocation* gpu_allocation,
+			VkBufferUsageFlags gpu_usage, const std::function<void(void*)>& fill_callback);
 
 	private:
 		Context(VkInstance instance, VkPhysicalDevice physical_device);

--- a/common/Vulkan/ShaderCache.cpp
+++ b/common/Vulkan/ShaderCache.cpp
@@ -493,11 +493,6 @@ namespace Vulkan
 		return GetShaderModule(ShaderCompiler::Type::Vertex, std::move(shader_code));
 	}
 
-	VkShaderModule ShaderCache::GetGeometryShader(std::string_view shader_code)
-	{
-		return GetShaderModule(ShaderCompiler::Type::Geometry, std::move(shader_code));
-	}
-
 	VkShaderModule ShaderCache::GetFragmentShader(std::string_view shader_code)
 	{
 		return GetShaderModule(ShaderCompiler::Type::Fragment, std::move(shader_code));

--- a/common/Vulkan/ShaderCache.h
+++ b/common/Vulkan/ShaderCache.h
@@ -47,7 +47,6 @@ namespace Vulkan
 		VkShaderModule GetShaderModule(ShaderCompiler::Type type, std::string_view shader_code);
 
 		VkShaderModule GetVertexShader(std::string_view shader_code);
-		VkShaderModule GetGeometryShader(std::string_view shader_code);
 		VkShaderModule GetFragmentShader(std::string_view shader_code);
 		VkShaderModule GetComputeShader(std::string_view shader_code);
 

--- a/common/Vulkan/ShaderCompiler.cpp
+++ b/common/Vulkan/ShaderCompiler.cpp
@@ -154,11 +154,6 @@ namespace Vulkan::ShaderCompiler
 		return CompileShaderToSPV(EShLangVertex, "vs", source_code, debug);
 	}
 
-	std::optional<SPIRVCodeVector> CompileGeometryShader(std::string_view source_code, bool debug)
-	{
-		return CompileShaderToSPV(EShLangGeometry, "gs", source_code, debug);
-	}
-
 	std::optional<SPIRVCodeVector> CompileFragmentShader(std::string_view source_code, bool debug)
 	{
 		return CompileShaderToSPV(EShLangFragment, "ps", source_code, debug);
@@ -175,9 +170,6 @@ namespace Vulkan::ShaderCompiler
 		{
 			case Type::Vertex:
 				return CompileShaderToSPV(EShLangVertex, "vs", source_code, debug);
-
-			case Type::Geometry:
-				return CompileShaderToSPV(EShLangGeometry, "gs", source_code, debug);
 
 			case Type::Fragment:
 				return CompileShaderToSPV(EShLangFragment, "ps", source_code, debug);

--- a/common/Vulkan/ShaderCompiler.h
+++ b/common/Vulkan/ShaderCompiler.h
@@ -26,7 +26,6 @@ namespace Vulkan::ShaderCompiler
 	enum class Type
 	{
 		Vertex,
-		Geometry,
 		Fragment,
 		Compute
 	};
@@ -39,9 +38,6 @@ namespace Vulkan::ShaderCompiler
 
 	// Compile a vertex shader to SPIR-V.
 	std::optional<SPIRVCodeVector> CompileVertexShader(std::string_view source_code, bool debug);
-
-	// Compile a geometry shader to SPIR-V.
-	std::optional<SPIRVCodeVector> CompileGeometryShader(std::string_view source_code, bool debug);
 
 	// Compile a fragment shader to SPIR-V.
 	std::optional<SPIRVCodeVector> CompileFragmentShader(std::string_view source_code, bool debug);

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -245,7 +245,6 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsDialog* dialog, QWidget* 
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.skipPresentingDuplicateFrames, "EmuCore/GS", "SkipDuplicateFrames", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.threadedPresentation, "EmuCore/GS", "DisableThreadedPresentation", false);
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.overrideTextureBarriers, "EmuCore/GS", "OverrideTextureBarriers", -1, -1);
-	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.overrideGeometryShader, "EmuCore/GS", "OverrideGeometryShaders", -1, -1);
 	SettingWidgetBinder::BindWidgetToIntSetting(
 		sif, m_ui.gsDumpCompression, "EmuCore/GS", "GSDumpCompression", static_cast<int>(GSDumpCompressionMethod::Zstandard));
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.disableFramebufferFetch, "EmuCore/GS", "DisableFramebufferFetch", false);
@@ -693,10 +692,6 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsDialog* dialog, QWidget* 
 	{
 		dialog->registerWidgetHelp(m_ui.overrideTextureBarriers, tr("Override Texture Barriers"), tr("Automatic (Default)"), tr(""));
 
-		dialog->registerWidgetHelp(m_ui.overrideGeometryShader, tr("Override Geometry Shader"), tr("Automatic (Default)"),
-			tr("Allows the GPU instead of just the CPU to transform lines into sprites. "
-			   "This reduces CPU load and bandwidth requirement, but it is heavier on the GPU."));
-
 		dialog->registerWidgetHelp(m_ui.gsDumpCompression, tr("GS Dump Compression"), tr("Zstandard (zst)"),
 			tr("Change the compression algorithm used when creating a GS dump."));
 
@@ -948,7 +943,6 @@ void GraphicsSettingsWidget::updateRendererDependentOptions()
 	m_ui.useBlitSwapChain->setEnabled(is_dx11);
 
 	m_ui.overrideTextureBarriers->setDisabled(is_sw_dx);
-	m_ui.overrideGeometryShader->setDisabled(is_sw_dx);
 
 	m_ui.disableFramebufferFetch->setDisabled(is_sw_dx);
 

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
@@ -2133,33 +2133,7 @@
             </item>
            </widget>
           </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="label_30">
-            <property name="text">
-             <string>Override Geometry Shader:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="QComboBox" name="overrideGeometryShader">
-            <item>
-             <property name="text">
-              <string>Automatic (Default)</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Force Disabled</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Force Enabled</string>
-             </property>
-            </item>
-           </widget>
-          </item>
-          <item row="3" column="0" colspan="2">
+          <item row="2" column="0" colspan="2">
            <layout class="QGridLayout" name="gridLayout_7">
             <item row="1" column="0">
              <widget class="QCheckBox" name="useDebugDevice">

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -760,7 +760,6 @@ struct Pcsx2Config
 		GSTextureInRtMode UserHacks_TextureInsideRt{GSTextureInRtMode::Disabled};
 		TriFiltering TriFilter{TriFiltering::Automatic};
 		int OverrideTextureBarriers{-1};
-		int OverrideGeometryShaders{-1};
 
 		int CAS_Sharpness{50};
 		int ShadeBoost_Brightness{50};

--- a/pcsx2/Frontend/FullscreenUI.cpp
+++ b/pcsx2/Frontend/FullscreenUI.cpp
@@ -3325,8 +3325,6 @@ void FullscreenUI::DrawGraphicsSettingsPage()
 	}
 	DrawIntListSetting(bsi, "Override Texture Barriers", "Forces texture barrier functionality to the specified value.", "EmuCore/GS",
 		"OverrideTextureBarriers", -1, s_generic_options, std::size(s_generic_options), -1);
-	DrawIntListSetting(bsi, "Override Geometry Shaders", "Forces geometry shader functionality to the specified value.", "EmuCore/GS",
-		"OverrideGeometryShaders", -1, s_generic_options, std::size(s_generic_options), -1);
 	DrawIntListSetting(bsi, "GS Dump Compression", "Sets the compression algorithm for GS dumps.", "EmuCore/GS", "GSDumpCompression",
 		static_cast<int>(GSDumpCompressionMethod::LZMA), s_gsdump_compression, std::size(s_gsdump_compression));
 	DrawToggleSetting(bsi, "Disable Framebuffer Fetch", "Prevents the usage of framebuffer fetch when supported by host GPU.", "EmuCore/GS",

--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -278,6 +278,7 @@ public:
 		AUTOFLUSH = 1 << 11,
 		VSYNC  = 1 << 12,
 		GSREOPEN = 1 << 13,
+		VERTEXCOUNT = 1 << 14,
 	};
 
 	GSFlushReason m_state_flush_reason = UNKNOWN;

--- a/pcsx2/GS/Renderers/Common/GSDevice.cpp
+++ b/pcsx2/GS/Renderers/Common/GSDevice.cpp
@@ -163,6 +163,23 @@ std::string GSDevice::GetFullscreenModeString(u32 width, u32 height, float refre
 	return StringUtil::StdStringFromFormat("%u x %u @ %f hz", width, height, refresh_rate);
 }
 
+void GSDevice::GenerateExpansionIndexBuffer(void* buffer)
+{
+	static constexpr u32 MAX_INDEX = std::numeric_limits<u16>::max();
+
+	u32* idx_buffer = static_cast<u32*>(buffer);
+	for (u32 i = 0; i < MAX_INDEX; i++)
+	{
+		const u32 base = i * 4;
+		*(idx_buffer++) = base + 0;
+		*(idx_buffer++) = base + 1;
+		*(idx_buffer++) = base + 2;
+		*(idx_buffer++) = base + 1;
+		*(idx_buffer++) = base + 2;
+		*(idx_buffer++) = base + 3;
+	}
+}
+
 bool GSDevice::Create(const WindowInfo& wi, VsyncMode vsync)
 {
 	m_window_info = wi;

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.h
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.h
@@ -34,7 +34,6 @@ class GSDevice11 final : public GSDevice
 {
 public:
 	using VSSelector = GSHWDrawConfig::VSSelector;
-	using GSSelector = GSHWDrawConfig::GSSelector;
 	using PSSelector = GSHWDrawConfig::PSSelector;
 	using PSSamplerSelector = GSHWDrawConfig::SamplerSelector;
 	using OMDepthStencilSelector = GSHWDrawConfig::DepthStencilSelector;
@@ -150,8 +149,12 @@ private:
 
 	wil::com_ptr_nothrow<ID3D11Buffer> m_vb;
 	wil::com_ptr_nothrow<ID3D11Buffer> m_ib;
+	wil::com_ptr_nothrow<ID3D11Buffer> m_expand_vb;
+	wil::com_ptr_nothrow<ID3D11Buffer> m_expand_ib;
+	wil::com_ptr_nothrow<ID3D11ShaderResourceView> m_expand_vb_srv;
 	u32 m_vb_pos = 0; // bytes
 	u32 m_ib_pos = 0; // indices/sizeof(u32)
+	u32 m_structured_vb_pos = 0; // bytes
 	int m_d3d_texsize = 0;
 
 	bool m_allow_tearing_supported = false;
@@ -162,10 +165,9 @@ private:
 	{
 		ID3D11InputLayout* layout;
 		D3D11_PRIMITIVE_TOPOLOGY topology;
+		ID3D11Buffer* index_buffer;
 		ID3D11VertexShader* vs;
 		ID3D11Buffer* vs_cb;
-		ID3D11GeometryShader* gs;
-		ID3D11Buffer* gs_cb;
 		std::array<ID3D11ShaderResourceView*, MAX_TEXTURES> ps_sr_views;
 		ID3D11PixelShader* ps;
 		ID3D11Buffer* ps_cb;
@@ -339,16 +341,17 @@ public:
 	void* IAMapVertexBuffer(u32 stride, u32 count);
 	void IAUnmapVertexBuffer(u32 stride, u32 count);
 	bool IASetVertexBuffer(const void* vertex, u32 stride, u32 count);
+	bool IASetExpandVertexBuffer(const void* vertex, u32 stride, u32 count);
 
 	u32* IAMapIndexBuffer(u32 count);
 	void IAUnmapIndexBuffer(u32 count);
 	bool IASetIndexBuffer(const void* index, u32 count);
+	void IASetIndexBuffer(ID3D11Buffer* buffer);
 
 	void IASetInputLayout(ID3D11InputLayout* layout);
 	void IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY topology);
 
 	void VSSetShader(ID3D11VertexShader* vs, ID3D11Buffer* vs_cb);
-	void GSSetShader(ID3D11GeometryShader* gs, ID3D11Buffer* gs_cb = nullptr);
 
 	void PSSetShaderResources(GSTexture* sr0, GSTexture* sr1);
 	void PSSetShaderResource(int i, GSTexture* sr);
@@ -364,7 +367,6 @@ public:
 
 	bool CreateTextureFX();
 	void SetupVS(VSSelector sel, const GSHWDrawConfig::VSConstantBuffer* cb);
-	void SetupGS(GSSelector sel);
 	void SetupPS(const PSSelector& sel, const GSHWDrawConfig::PSConstantBuffer* cb, PSSamplerSelector ssel);
 	void SetupOM(OMDepthStencilSelector dssel, OMBlendSelector bsel, u8 afix);
 

--- a/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
@@ -602,7 +602,6 @@ bool GSDevice12::CheckFeatures()
 
 	m_features.texture_barrier = false;
 	m_features.broken_point_sampler = isAMD;
-	m_features.geometry_shader = true;
 	m_features.primitive_id = true;
 	m_features.prefer_new_textures = true;
 	m_features.provoking_vertex_last = false;
@@ -613,6 +612,7 @@ bool GSDevice12::CheckFeatures()
 	m_features.clip_control = true;
 	m_features.stencil_buffer = true;
 	m_features.test_and_sample_depth = false;
+	m_features.vs_expand = true;
 
 	m_features.dxt_textures = g_d3d12_context->SupportsTextureFormat(DXGI_FORMAT_BC1_UNORM) &&
 							  g_d3d12_context->SupportsTextureFormat(DXGI_FORMAT_BC2_UNORM) &&
@@ -1727,6 +1727,13 @@ bool GSDevice12::CreateBuffers()
 		return false;
 	}
 
+	if (!g_d3d12_context->AllocatePreinitializedGPUBuffer(EXPAND_BUFFER_SIZE, &m_expand_index_buffer,
+			&m_expand_index_buffer_allocation, &GSDevice::GenerateExpansionIndexBuffer))
+	{
+		Host::ReportErrorAsync("GS", "Failed to allocate expansion index buffer");
+		return false;
+	}
+
 	return true;
 }
 
@@ -1751,6 +1758,7 @@ bool GSDevice12::CreateRootSignatures()
 	rsb.SetInputAssemblerFlag();
 	rsb.AddCBVParameter(0, D3D12_SHADER_VISIBILITY_ALL);
 	rsb.AddCBVParameter(1, D3D12_SHADER_VISIBILITY_PIXEL);
+	rsb.AddSRVParameter(0, D3D12_SHADER_VISIBILITY_VERTEX);
 	rsb.AddDescriptorTable(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 0, 2, D3D12_SHADER_VISIBILITY_PIXEL);
 	rsb.AddDescriptorTable(D3D12_DESCRIPTOR_RANGE_TYPE_SAMPLER, 0, NUM_TFX_SAMPLERS, D3D12_SHADER_VISIBILITY_PIXEL);
 	rsb.AddDescriptorTable(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 2, 2, D3D12_SHADER_VISIBILITY_PIXEL);
@@ -2094,7 +2102,6 @@ void GSDevice12::DestroyResources()
 		g_d3d12_context->DeferObjectDestruction(it.second.get());
 	m_tfx_pipelines.clear();
 	m_tfx_pixel_shaders.clear();
-	m_tfx_geometry_shaders.clear();
 	m_tfx_vertex_shaders.clear();
 	m_interlace = {};
 	m_merge = {};
@@ -2117,6 +2124,8 @@ void GSDevice12::DestroyResources()
 	g_d3d12_context->DeferDescriptorDestruction(g_d3d12_context->GetSamplerHeapManager(), &m_point_sampler_cpu);
 	g_d3d12_context->InvalidateSamplerGroups();
 
+	m_expand_index_buffer.reset();
+	m_expand_index_buffer_allocation.reset();
 	m_pixel_constant_buffer.Destroy(false);
 	m_vertex_constant_buffer.Destroy(false);
 	m_index_stream_buffer.Destroy(false);
@@ -2137,29 +2146,15 @@ const ID3DBlob* GSDevice12::GetTFXVertexShader(GSHWDrawConfig::VSSelector sel)
 		return it->second.get();
 
 	ShaderMacro sm(m_shader_cache.GetFeatureLevel());
+	sm.AddMacro("VERTEX_SHADER", 1);
 	sm.AddMacro("VS_TME", sel.tme);
 	sm.AddMacro("VS_FST", sel.fst);
 	sm.AddMacro("VS_IIP", sel.iip);
+	sm.AddMacro("VS_EXPAND", static_cast<int>(sel.expand));
 
-	ComPtr<ID3DBlob> vs(m_shader_cache.GetVertexShader(m_tfx_source, sm.GetPtr(), "vs_main"));
+	const char* entry_point = (sel.expand != GSHWDrawConfig::VSExpand::None) ? "vs_main_expand" : "vs_main";
+	ComPtr<ID3DBlob> vs(m_shader_cache.GetVertexShader(m_tfx_source, sm.GetPtr(), entry_point));
 	it = m_tfx_vertex_shaders.emplace(sel.key, std::move(vs)).first;
-	return it->second.get();
-}
-
-const ID3DBlob* GSDevice12::GetTFXGeometryShader(GSHWDrawConfig::GSSelector sel)
-{
-	auto it = m_tfx_geometry_shaders.find(sel.key);
-	if (it != m_tfx_geometry_shaders.end())
-		return it->second.get();
-
-	ShaderMacro sm(m_shader_cache.GetFeatureLevel());
-	sm.AddMacro("GS_IIP", sel.iip);
-	sm.AddMacro("GS_PRIM", static_cast<int>(sel.topology));
-	sm.AddMacro("GS_EXPAND", sel.expand);
-	sm.AddMacro("GS_FORWARD_PRIMID", sel.forward_primid);
-
-	ComPtr<ID3DBlob> gs(m_shader_cache.GetGeometryShader(m_tfx_source, sm.GetPtr(), "gs_main"));
-	it = m_tfx_geometry_shaders.emplace(sel.key, std::move(gs)).first;
 	return it->second.get();
 }
 
@@ -2170,6 +2165,7 @@ const ID3DBlob* GSDevice12::GetTFXPixelShader(const GSHWDrawConfig::PSSelector& 
 		return it->second.get();
 
 	ShaderMacro sm(m_shader_cache.GetFeatureLevel());
+	sm.AddMacro("PIXEL_SHADER", 1);
 	sm.AddMacro("PS_FST", sel.fst);
 	sm.AddMacro("PS_WMS", sel.wms);
 	sm.AddMacro("PS_WMT", sel.wmt);
@@ -2244,9 +2240,8 @@ GSDevice12::ComPtr<ID3D12PipelineState> GSDevice12::CreateTFXPipeline(const Pipe
 	}
 
 	const ID3DBlob* vs = GetTFXVertexShader(p.vs);
-	const ID3DBlob* gs = p.gs.expand ? GetTFXGeometryShader(p.gs) : nullptr;
 	const ID3DBlob* ps = GetTFXPixelShader(pps);
-	if (!vs || (p.gs.expand && !gs) || !ps)
+	if (!vs || !ps)
 		return nullptr;
 
 	// Common state
@@ -2269,18 +2264,19 @@ GSDevice12::ComPtr<ID3D12PipelineState> GSDevice12::CreateTFXPipeline(const Pipe
 
 	// Shaders
 	gpb.SetVertexShader(vs);
-	if (gs)
-		gpb.SetGeometryShader(gs);
 	gpb.SetPixelShader(ps);
 
 	// IA
-	gpb.AddVertexAttribute("TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0, 0);
-	gpb.AddVertexAttribute("COLOR", 0, DXGI_FORMAT_R8G8B8A8_UINT, 0, 8);
-	gpb.AddVertexAttribute("TEXCOORD", 1, DXGI_FORMAT_R32_FLOAT, 0, 12);
-	gpb.AddVertexAttribute("POSITION", 0, DXGI_FORMAT_R16G16_UINT, 0, 16);
-	gpb.AddVertexAttribute("POSITION", 1, DXGI_FORMAT_R32_UINT, 0, 20);
-	gpb.AddVertexAttribute("TEXCOORD", 2, DXGI_FORMAT_R16G16_UINT, 0, 24);
-	gpb.AddVertexAttribute("COLOR", 1, DXGI_FORMAT_R8G8B8A8_UNORM, 0, 28);
+	if (p.vs.expand == GSHWDrawConfig::VSExpand::None)
+	{
+		gpb.AddVertexAttribute("TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0, 0);
+		gpb.AddVertexAttribute("COLOR", 0, DXGI_FORMAT_R8G8B8A8_UINT, 0, 8);
+		gpb.AddVertexAttribute("TEXCOORD", 1, DXGI_FORMAT_R32_FLOAT, 0, 12);
+		gpb.AddVertexAttribute("POSITION", 0, DXGI_FORMAT_R16G16_UINT, 0, 16);
+		gpb.AddVertexAttribute("POSITION", 1, DXGI_FORMAT_R32_UINT, 0, 20);
+		gpb.AddVertexAttribute("TEXCOORD", 2, DXGI_FORMAT_R16G16_UINT, 0, 24);
+		gpb.AddVertexAttribute("COLOR", 1, DXGI_FORMAT_R8G8B8A8_UNORM, 0, 28);
+	}
 
 	// DepthStencil
 	if (p.ds)
@@ -2335,7 +2331,7 @@ GSDevice12::ComPtr<ID3D12PipelineState> GSDevice12::CreateTFXPipeline(const Pipe
 	if (pipeline)
 	{
 		D3D12::SetObjectNameFormatted(
-			pipeline.get(), "TFX Pipeline %08X/%08X/%" PRIX64 "%08X", p.vs.key, p.gs.key, p.ps.key_hi, p.ps.key_lo);
+			pipeline.get(), "TFX Pipeline %08X/%" PRIX64 "%08X", p.vs.key, p.ps.key_hi, p.ps.key_lo);
 	}
 
 	return pipeline;
@@ -2939,6 +2935,11 @@ bool GSDevice12::ApplyTFXState(bool already_execed)
 		cmdlist->SetGraphicsRootConstantBufferView(TFX_ROOT_SIGNATURE_PARAM_VS_CBV, m_tfx_constant_buffers[0]);
 	if (flags & DIRTY_FLAG_PS_CONSTANT_BUFFER_BINDING)
 		cmdlist->SetGraphicsRootConstantBufferView(TFX_ROOT_SIGNATURE_PARAM_PS_CBV, m_tfx_constant_buffers[1]);
+	if (flags & DIRTY_FLAG_VS_VERTEX_BUFFER_BINDING)
+	{
+		cmdlist->SetGraphicsRootShaderResourceView(TFX_ROOT_SIGNATURE_PARAM_VS_SRV,
+			m_vertex_stream_buffer.GetGPUPointer() + m_vertex.start * sizeof(GSVertex));
+	}
 	if (flags & DIRTY_FLAG_TEXTURES_DESCRIPTOR_TABLE)
 		cmdlist->SetGraphicsRootDescriptorTable(TFX_ROOT_SIGNATURE_PARAM_PS_TEXTURES, m_tfx_textures_handle_gpu);
 	if (flags & DIRTY_FLAG_SAMPLERS_DESCRIPTOR_TABLE)
@@ -3068,8 +3069,7 @@ GSTexture12* GSDevice12::SetupPrimitiveTrackingDATE(GSHWDrawConfig& config, Pipe
 
 	// image is now filled with either -1 or INT_MAX, so now we can do the prepass
 	SetPrimitiveTopology(s_primitive_topology_mapping[static_cast<u8>(config.topology)]);
-	IASetVertexBuffer(config.verts, sizeof(GSVertex), config.nverts);
-	IASetIndexBuffer(config.indices, config.nindices);
+	UploadHWDrawVerticesAndIndices(config);
 
 	// cut down the configuration for the prepass, we don't need blending or any feedback loop
 	PipelineSelector init_pipe(m_pipeline_selector);
@@ -3250,10 +3250,7 @@ void GSDevice12::RenderHW(GSHWDrawConfig& config)
 	// VB/IB upload, if we did DATE setup and it's not HDR this has already been done
 	SetPrimitiveTopology(s_primitive_topology_mapping[static_cast<u8>(config.topology)]);
 	if (!date_image || hdr_rt)
-	{
-		IASetVertexBuffer(config.verts, sizeof(GSVertex), config.nverts);
-		IASetIndexBuffer(config.indices, config.nindices);
-	}
+		UploadHWDrawVerticesAndIndices(config);
 
 	// now we can do the actual draw
 	if (BindDrawPipeline(pipe))
@@ -3331,7 +3328,6 @@ void GSDevice12::RenderHW(GSHWDrawConfig& config)
 void GSDevice12::UpdateHWPipelineSelector(GSHWDrawConfig& config)
 {
 	m_pipeline_selector.vs.key = config.vs.key;
-	m_pipeline_selector.gs.key = config.gs.key;
 	m_pipeline_selector.ps.key_hi = config.ps.key_hi;
 	m_pipeline_selector.ps.key_lo = config.ps.key_lo;
 	m_pipeline_selector.dss.key = config.depth.key;
@@ -3341,4 +3337,24 @@ void GSDevice12::UpdateHWPipelineSelector(GSHWDrawConfig& config)
 	m_pipeline_selector.topology = static_cast<u32>(config.topology);
 	m_pipeline_selector.rt = config.rt != nullptr;
 	m_pipeline_selector.ds = config.ds != nullptr;
+}
+
+void GSDevice12::UploadHWDrawVerticesAndIndices(const GSHWDrawConfig& config)
+{
+	IASetVertexBuffer(config.verts, sizeof(GSVertex), config.nverts);
+
+	// Update SRV in root signature directly, rather than using a uniform for base vertex.
+	if (config.vs.expand != GSHWDrawConfig::VSExpand::None)
+		m_dirty_flags |= DIRTY_FLAG_VS_VERTEX_BUFFER_BINDING;
+
+	if (config.vs.UseExpandIndexBuffer())
+	{
+		m_index.start = 0;
+		m_index.count = config.nindices;
+		SetIndexBuffer(m_expand_index_buffer->GetGPUVirtualAddress(), EXPAND_BUFFER_SIZE, DXGI_FORMAT_R32_UINT);
+	}
+	else
+	{
+		IASetIndexBuffer(config.indices, config.nindices);
+	}
 }

--- a/pcsx2/GS/Renderers/HW/GSHwHack.h
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.h
@@ -56,7 +56,6 @@ public:
 	static bool OI_PointListPalette(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
 	static bool OI_BigMuthaTruckers(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
 	static bool OI_DBZBTGames(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
-	static bool OI_FFXII(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
 	static bool OI_FFX(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
 	static bool OI_RozenMaidenGebetGarden(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
 	static bool OI_SonicUnleashed(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.h
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.h
@@ -168,7 +168,7 @@ public:
 	float GetUpscaleMultiplier() override;
 	void Lines2Sprites();
 	bool VerifyIndices();
-	template <GSHWDrawConfig::VSExpand Expand> void ExpandIndices();
+	void ExpandLineIndices();
 	void ConvertSpriteTextureShuffle(bool& write_ba, bool& read_ba);
 	GSVector4 RealignTargetTextureCoordinate(const GSTextureCache::Source* tex);
 	GSVector4i ComputeBoundingBox(const GSVector2i& rtsize, float rtscale);

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -2609,7 +2609,6 @@ bool GSTextureCache::ShuffleMove(u32 BP, u32 BW, u32 PSM, int sx, int sy, int dx
 	config.vs.tme = true;
 	config.vs.iip = true;
 	config.vs.fst = true;
-	config.gs.key = 0;
 	config.ps.key_lo = 0;
 	config.ps.key_hi = 0;
 	config.ps.read_ba = read_ba;

--- a/pcsx2/GS/Renderers/Metal/GSDeviceMTL.h
+++ b/pcsx2/GS/Renderers/Metal/GSDeviceMTL.h
@@ -281,7 +281,7 @@ public:
 	MRCOwned<id<MTLDepthStencilState>> m_dss_stencil_write;
 	MRCOwned<id<MTLDepthStencilState>> m_dss_hw[1 << 5];
 
-	MRCOwned<id<MTLBuffer>> m_texture_download_buf;
+	MRCOwned<id<MTLBuffer>> m_expand_index_buffer;
 	UploadBuffer m_texture_upload_buf;
 	BufferPair m_vertex_upload_buf;
 

--- a/pcsx2/GS/Renderers/OpenGL/GLLoader.h
+++ b/pcsx2/GS/Renderers/OpenGL/GLLoader.h
@@ -31,13 +31,4 @@ namespace GLLoader
 	extern bool vendor_id_intel;
 	extern bool buggy_pbo;
 	extern bool disable_download_pbo;
-
-	// GL
-	extern bool is_gles;
-	extern bool has_clip_control;
-	extern bool has_dual_source_blend;
-	extern bool found_framebuffer_fetch;
-	extern bool found_geometry_shader;
-	extern bool found_GL_ARB_gpu_shader5;
-	extern bool found_GL_ARB_texture_barrier;
 } // namespace GLLoader

--- a/pcsx2/GS/Renderers/OpenGL/GLState.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GLState.cpp
@@ -18,6 +18,7 @@
 
 namespace GLState
 {
+	GLuint vao;
 	GLuint fbo;
 	GSVector2i viewport;
 	GSVector4i scissor;
@@ -49,6 +50,7 @@ namespace GLState
 
 	void Clear()
 	{
+		vao = 0;
 		fbo = 0;
 		viewport = GSVector2i(1, 1);
 		scissor = GSVector4i(0, 0, 1, 1);

--- a/pcsx2/GS/Renderers/OpenGL/GLState.h
+++ b/pcsx2/GS/Renderers/OpenGL/GLState.h
@@ -22,6 +22,7 @@ class GSTextureOGL;
 
 namespace GLState
 {
+	extern GLuint vao; // vertex array object
 	extern GLuint fbo; // frame buffer object
 	extern GSVector2i viewport;
 	extern GSVector4i scissor;

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -2098,6 +2098,10 @@ void GSDeviceOGL::OMSetColorMaskState(OMColorMaskSelector sel)
 
 void GSDeviceOGL::OMUnbindTexture(GSTextureOGL* tex)
 {
+	if (GLState::rt != tex && GLState::ds != tex)
+		return;
+
+	OMSetFBO(m_fbo);
 	if (GLState::rt == tex)
 		OMAttachRt();
 	if (GLState::ds == tex)

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.h
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.h
@@ -121,7 +121,6 @@ class GSDeviceOGL final : public GSDevice
 {
 public:
 	using VSSelector = GSHWDrawConfig::VSSelector;
-	using GSSelector = GSHWDrawConfig::GSSelector;
 	using PSSelector = GSHWDrawConfig::PSSelector;
 	using PSSamplerSelector = GSHWDrawConfig::SamplerSelector;
 	using OMDepthStencilSelector = GSHWDrawConfig::DepthStencilSelector;
@@ -131,7 +130,6 @@ public:
 	{
 		PSSelector ps;
 		VSSelector vs;
-		GSSelector gs;
 		u16 pad;
 
 		__fi bool operator==(const ProgramSelector& p) const { return (std::memcmp(this, &p, sizeof(*this)) == 0); }
@@ -144,7 +142,7 @@ public:
 		__fi std::size_t operator()(const ProgramSelector& p) const noexcept
 		{
 			std::size_t h = 0;
-			HashCombine(h, p.vs.key, p.gs.key, p.ps.key_hi, p.ps.key_lo);
+			HashCombine(h, p.vs.key, p.ps.key_hi, p.ps.key_lo);
 			return h;
 		}
 	};
@@ -160,7 +158,9 @@ private:
 
 	std::unique_ptr<GL::StreamBuffer> m_vertex_stream_buffer;
 	std::unique_ptr<GL::StreamBuffer> m_index_stream_buffer;
-	GLuint m_vertex_array_object = 0;
+	GLuint m_expand_ibo = 0;
+	GLuint m_vao = 0;
+	GLuint m_expand_vao = 0;
 	GLenum m_draw_topology = 0;
 
 	std::unique_ptr<GL::StreamBuffer> m_vertex_uniform_stream_buffer;
@@ -344,6 +344,7 @@ public:
 
 	void SetupDATE(GSTexture* rt, GSTexture* ds, const GSVertexPT1* vertices, bool datm);
 
+	void IASetVAO(GLuint vao);
 	void IASetPrimitiveTopology(GLenum topology);
 	void IASetVertexBuffer(const void* vertices, size_t count);
 	void IASetIndexBuffer(const void* index, size_t count);
@@ -367,7 +368,6 @@ public:
 		const std::string_view& macro_sel = std::string_view());
 	std::string GenGlslHeader(const std::string_view& entry, GLenum type, const std::string_view& macro);
 	std::string GetVSSource(VSSelector sel);
-	std::string GetGSSource(GSSelector sel);
 	std::string GetPSSource(const PSSelector& sel);
 	GLuint CreateSampler(PSSamplerSelector sel);
 	GSDepthStencilOGL* CreateDepthStencil(OMDepthStencilSelector dssel);

--- a/pcsx2/GS/Renderers/OpenGL/GSTextureOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSTextureOGL.cpp
@@ -94,7 +94,7 @@ GSTextureOGL::GSTextureOGL(Type type, int width, int height, int levels, Format 
 		// Depth buffer
 		case Format::DepthStencil:
 		{
-			if (!GLLoader::found_framebuffer_fetch)
+			if (!g_gs_device->Features().framebuffer_fetch)
 			{
 				gl_fmt = GL_DEPTH32F_STENCIL8;
 				m_int_format = GL_DEPTH_STENCIL;

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
@@ -581,17 +581,17 @@ bool GSDeviceVK::CheckFeatures()
 	m_features.framebuffer_fetch = g_vulkan_context->GetOptionalExtensions().vk_arm_rasterization_order_attachment_access && !GSConfig.DisableFramebufferFetch;
 	m_features.texture_barrier = GSConfig.OverrideTextureBarriers != 0;
 	m_features.broken_point_sampler = isAMD;
-	m_features.geometry_shader = features.geometryShader && GSConfig.OverrideGeometryShaders != 0;
 	// Usually, geometry shader indicates primid support
 	// However on Metal (MoltenVK), geometry shader is never available, but primid sometimes is
 	// Officially, it's available on GPUs that support barycentric coordinates (Newer AMD and Apple)
 	// Unofficially, it seems to work on older Intel GPUs (but breaks other things on newer Intel GPUs, see GSMTLDeviceInfo.mm for details)
 	// We'll only enable for the officially supported GPUs here.  We'll leave in the option of force-enabling it with OverrideGeometryShaders though.
-	m_features.primitive_id = features.geometryShader || GSConfig.OverrideGeometryShaders == 1 || g_vulkan_context->GetOptionalExtensions().vk_khr_fragment_shader_barycentric;
+	m_features.primitive_id = features.geometryShader || g_vulkan_context->GetOptionalExtensions().vk_khr_fragment_shader_barycentric;
 	m_features.prefer_new_textures = true;
 	m_features.provoking_vertex_last = g_vulkan_context->GetOptionalExtensions().vk_ext_provoking_vertex;
 	m_features.dual_source_blend = features.dualSrcBlend && !GSConfig.DisableDualSourceBlend;
 	m_features.clip_control = true;
+	m_features.vs_expand = g_vulkan_context->GetOptionalExtensions().vk_khr_shader_draw_parameters;
 
 	if (!m_features.dual_source_blend)
 		Console.Warning("Vulkan driver is missing dual-source blending. This will have an impact on performance.");
@@ -624,9 +624,10 @@ bool GSDeviceVK::CheckFeatures()
 		(features.largePoints && limits.pointSizeRange[0] <= f_upscale && limits.pointSizeRange[1] >= f_upscale);
 	m_features.line_expand =
 		(features.wideLines && limits.lineWidthRange[0] <= f_upscale && limits.lineWidthRange[1] >= f_upscale);
+
 	DevCon.WriteLn("Using %s for point expansion and %s for line expansion.",
-		m_features.point_expand ? "hardware" : "geometry shaders",
-		m_features.line_expand ? "hardware" : "geometry shaders");
+		m_features.point_expand ? "hardware" : "vertex expanding",
+		m_features.line_expand ? "hardware" : "vertex expanding");
 
 	// Check texture format support before we try to create them.
 	for (u32 fmt = static_cast<u32>(GSTexture::Format::Color); fmt < static_cast<u32>(GSTexture::Format::PrimID); fmt++)
@@ -1004,6 +1005,7 @@ void GSDeviceVK::DoMultiStretchRects(
 	m_index.count = icount;
 	m_vertex_stream_buffer.CommitMemory(vcount * sizeof(GSVertexPT1));
 	m_index_stream_buffer.CommitMemory(icount * sizeof(u32));
+	SetIndexBuffer(m_index_stream_buffer.GetBuffer(), 0, VK_INDEX_TYPE_UINT32);
 
 	// Even though we're batching, a cmdbuffer submit could've messed this up.
 	const GSVector4i rc(dTex->GetRect());
@@ -1375,6 +1377,8 @@ void GSDeviceVK::IASetIndexBuffer(const void* index, size_t count)
 
 	std::memcpy(m_index_stream_buffer.GetCurrentHostPointer(), index, size);
 	m_index_stream_buffer.CommitMemory(size);
+
+	SetIndexBuffer(m_index_stream_buffer.GetBuffer(), 0, VK_INDEX_TYPE_UINT32);
 }
 
 void GSDeviceVK::OMSetRenderTargets(GSTexture* rt, GSTexture* ds, const GSVector4i& scissor, FeedbackLoopFlag feedback_loop)
@@ -1489,10 +1493,14 @@ static void AddMacro(std::stringstream& ss, const char* name, int value)
 
 static void AddShaderHeader(std::stringstream& ss)
 {
+	const GSDevice::FeatureSupport features(g_gs_device->Features());
+
 	ss << "#version 460 core\n";
 	ss << "#extension GL_EXT_samplerless_texture_functions : require\n";
 
-	const GSDevice::FeatureSupport features(g_gs_device->Features());
+	if (features.vs_expand)
+		ss << "#extension GL_ARB_shader_draw_parameters : require\n";
+
 	if (!features.texture_barrier)
 		ss << "#define DISABLE_TEXTURE_BARRIER 1\n";
 	if (!features.dual_source_blend)
@@ -1564,7 +1572,9 @@ bool GSDeviceVK::CreateNullTexture()
 
 bool GSDeviceVK::CreateBuffers()
 {
-	if (!m_vertex_stream_buffer.Create(VK_BUFFER_USAGE_VERTEX_BUFFER_BIT, VERTEX_BUFFER_SIZE))
+	if (!m_vertex_stream_buffer.Create(
+			VK_BUFFER_USAGE_VERTEX_BUFFER_BIT | (m_features.vs_expand ? VK_BUFFER_USAGE_STORAGE_BUFFER_BIT : 0),
+			VERTEX_BUFFER_SIZE))
 	{
 		Host::ReportErrorAsync("GS", "Failed to allocate vertex buffer");
 		return false;
@@ -1589,7 +1599,14 @@ bool GSDeviceVK::CreateBuffers()
 	}
 
 	SetVertexBuffer(m_vertex_stream_buffer.GetBuffer(), 0);
-	SetIndexBuffer(m_index_stream_buffer.GetBuffer(), 0, VK_INDEX_TYPE_UINT32);
+
+	if (!g_vulkan_context->AllocatePreinitializedGPUBuffer(EXPAND_BUFFER_SIZE, &m_expand_index_buffer,
+			&m_expand_index_buffer_allocation, VK_BUFFER_USAGE_INDEX_BUFFER_BIT,
+			&GSDevice::GenerateExpansionIndexBuffer))
+	{
+		Host::ReportErrorAsync("GS", "Failed to allocate expansion index buffer");
+		return false;
+	}
 
 	return true;
 }
@@ -1621,6 +1638,8 @@ bool GSDeviceVK::CreatePipelineLayouts()
 	dslb.AddBinding(
 		0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC, 1, VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_GEOMETRY_BIT);
 	dslb.AddBinding(1, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC, 1, VK_SHADER_STAGE_FRAGMENT_BIT);
+	if (m_features.vs_expand)
+		dslb.AddBinding(2, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_VERTEX_BIT);
 	if ((m_tfx_ubo_ds_layout = dslb.Create(dev)) == VK_NULL_HANDLE)
 		return false;
 	Vulkan::Util::SetObjectName(dev, m_tfx_ubo_ds_layout, "TFX UBO descriptor layout");
@@ -2362,9 +2381,6 @@ void GSDeviceVK::RenderImGui()
 
 		g_perfmon.Put(GSPerfMon::DrawCalls, cmd_list->CmdBuffer.Size);
 	}
-
-	// normal draws use 32-bit indices
-	SetIndexBuffer(m_index_stream_buffer.GetBuffer(), 0, VK_INDEX_TYPE_UINT32);
 }
 
 bool GSDeviceVK::DoCAS(GSTexture* sTex, GSTexture* dTex, bool sharpen_only, const std::array<u32, NUM_CAS_CONSTANTS>& constants)
@@ -2445,8 +2461,6 @@ void GSDeviceVK::DestroyResources()
 		Vulkan::Util::SafeDestroyPipeline(it.second);
 	for (auto& it : m_tfx_fragment_shaders)
 		Vulkan::Util::SafeDestroyShaderModule(it.second);
-	for (auto& it : m_tfx_geometry_shaders)
-		Vulkan::Util::SafeDestroyShaderModule(it.second);
 	for (auto& it : m_tfx_vertex_shaders)
 		Vulkan::Util::SafeDestroyShaderModule(it.second);
 	for (VkPipeline& it : m_interlace)
@@ -2502,6 +2516,12 @@ void GSDeviceVK::DestroyResources()
 	m_vertex_uniform_stream_buffer.Destroy(false);
 	m_index_stream_buffer.Destroy(false);
 	m_vertex_stream_buffer.Destroy(false);
+	if (m_expand_index_buffer != VK_NULL_HANDLE)
+	{
+		vmaDestroyBuffer(g_vulkan_context->GetAllocator(), m_expand_index_buffer, m_expand_index_buffer_allocation);
+		m_expand_index_buffer = VK_NULL_HANDLE;
+		m_expand_index_buffer_allocation = VK_NULL_HANDLE;
+	}
 
 	Vulkan::Util::SafeDestroyPipelineLayout(m_tfx_pipeline_layout);
 	Vulkan::Util::SafeDestroyDescriptorSetLayout(m_tfx_rt_texture_ds_layout);
@@ -2526,6 +2546,8 @@ VkShaderModule GSDeviceVK::GetTFXVertexShader(GSHWDrawConfig::VSSelector sel)
 	AddMacro(ss, "VS_FST", sel.fst);
 	AddMacro(ss, "VS_IIP", sel.iip);
 	AddMacro(ss, "VS_POINT_SIZE", sel.point_size);
+	AddMacro(ss, "VS_EXPAND", static_cast<int>(sel.expand));
+	AddMacro(ss, "VS_PROVOKING_VERTEX_LAST", static_cast<int>(m_features.provoking_vertex_last));
 	ss << m_tfx_source;
 
 	VkShaderModule mod = g_vulkan_shader_cache->GetVertexShader(ss.str());
@@ -2533,29 +2555,6 @@ VkShaderModule GSDeviceVK::GetTFXVertexShader(GSHWDrawConfig::VSSelector sel)
 		Vulkan::Util::SetObjectName(g_vulkan_context->GetDevice(), mod, "TFX Vertex %08X", sel.key);
 
 	m_tfx_vertex_shaders.emplace(sel.key, mod);
-	return mod;
-}
-
-VkShaderModule GSDeviceVK::GetTFXGeometryShader(GSHWDrawConfig::GSSelector sel)
-{
-	const auto it = m_tfx_geometry_shaders.find(sel.key);
-	if (it != m_tfx_geometry_shaders.end())
-		return it->second;
-
-	std::stringstream ss;
-	AddShaderHeader(ss);
-	AddShaderStageMacro(ss, false, true, false);
-	AddMacro(ss, "GS_IIP", sel.iip);
-	AddMacro(ss, "GS_PRIM", static_cast<int>(sel.topology));
-	AddMacro(ss, "GS_EXPAND", sel.expand);
-	AddMacro(ss, "GS_FORWARD_PRIMID", sel.forward_primid);
-	ss << m_tfx_source;
-
-	VkShaderModule mod = g_vulkan_shader_cache->GetGeometryShader(ss.str());
-	if (mod)
-		Vulkan::Util::SetObjectName(g_vulkan_context->GetDevice(), mod, "TFX Geometry %08X", sel.key);
-
-	m_tfx_geometry_shaders.emplace(sel.key, mod);
 	return mod;
 }
 
@@ -2647,9 +2646,8 @@ VkPipeline GSDeviceVK::CreateTFXPipeline(const PipelineSelector& p)
 	}
 
 	VkShaderModule vs = GetTFXVertexShader(p.vs);
-	VkShaderModule gs = p.gs.expand ? GetTFXGeometryShader(p.gs) : VK_NULL_HANDLE;
 	VkShaderModule fs = GetTFXFragmentShader(pps);
-	if (vs == VK_NULL_HANDLE || (p.gs.expand && gs == VK_NULL_HANDLE) || fs == VK_NULL_HANDLE)
+	if (vs == VK_NULL_HANDLE || fs == VK_NULL_HANDLE)
 		return VK_NULL_HANDLE;
 
 	Vulkan::GraphicsPipelineBuilder gpb;
@@ -2681,19 +2679,20 @@ VkPipeline GSDeviceVK::CreateTFXPipeline(const PipelineSelector& p)
 
 	// Shaders
 	gpb.SetVertexShader(vs);
-	if (gs != VK_NULL_HANDLE)
-		gpb.SetGeometryShader(gs);
 	gpb.SetFragmentShader(fs);
 
 	// IA
-	gpb.AddVertexBuffer(0, sizeof(GSVertex));
-	gpb.AddVertexAttribute(0, 0, VK_FORMAT_R32G32_SFLOAT, 0); // ST
-	gpb.AddVertexAttribute(1, 0, VK_FORMAT_R8G8B8A8_UINT, 8); // RGBA
-	gpb.AddVertexAttribute(2, 0, VK_FORMAT_R32_SFLOAT, 12); // Q
-	gpb.AddVertexAttribute(3, 0, VK_FORMAT_R16G16_UINT, 16); // XY
-	gpb.AddVertexAttribute(4, 0, VK_FORMAT_R32_UINT, 20); // Z
-	gpb.AddVertexAttribute(5, 0, VK_FORMAT_R16G16_UINT, 24); // UV
-	gpb.AddVertexAttribute(6, 0, VK_FORMAT_R8G8B8A8_UNORM, 28); // FOG
+	if (p.vs.expand == GSHWDrawConfig::VSExpand::None)
+	{
+		gpb.AddVertexBuffer(0, sizeof(GSVertex));
+		gpb.AddVertexAttribute(0, 0, VK_FORMAT_R32G32_SFLOAT, 0); // ST
+		gpb.AddVertexAttribute(1, 0, VK_FORMAT_R8G8B8A8_UINT, 8); // RGBA
+		gpb.AddVertexAttribute(2, 0, VK_FORMAT_R32_SFLOAT, 12); // Q
+		gpb.AddVertexAttribute(3, 0, VK_FORMAT_R16G16_UINT, 16); // XY
+		gpb.AddVertexAttribute(4, 0, VK_FORMAT_R32_UINT, 20); // Z
+		gpb.AddVertexAttribute(5, 0, VK_FORMAT_R16G16_UINT, 24); // UV
+		gpb.AddVertexAttribute(6, 0, VK_FORMAT_R8G8B8A8_UNORM, 28); // FOG
+	}
 
 	// DepthStencil
 	static const VkCompareOp ztst[] = {
@@ -2749,7 +2748,7 @@ VkPipeline GSDeviceVK::CreateTFXPipeline(const PipelineSelector& p)
 	if (pipeline)
 	{
 		Vulkan::Util::SetObjectName(
-			g_vulkan_context->GetDevice(), pipeline, "TFX Pipeline %08X/%08X/%" PRIX64 "%08X", p.vs.key, p.gs.key, p.ps.key_hi, p.ps.key_lo);
+			g_vulkan_context->GetDevice(), pipeline, "TFX Pipeline %08X/%" PRIX64 "%08X", p.vs.key, p.ps.key_hi, p.ps.key_lo);
 	}
 
 	return pipeline;
@@ -2818,6 +2817,11 @@ bool GSDeviceVK::CreatePersistentDescriptorSets()
 		m_vertex_uniform_stream_buffer.GetBuffer(), 0, sizeof(GSHWDrawConfig::VSConstantBuffer));
 	dsub.AddBufferDescriptorWrite(m_tfx_descriptor_sets[0], 1, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC,
 		m_fragment_uniform_stream_buffer.GetBuffer(), 0, sizeof(GSHWDrawConfig::PSConstantBuffer));
+	if (m_features.vs_expand)
+	{
+		dsub.AddBufferDescriptorWrite(m_tfx_descriptor_sets[0], 2, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
+			m_vertex_stream_buffer.GetBuffer(), 0, VERTEX_BUFFER_SIZE);
+	}
 	dsub.Update(dev);
 	Vulkan::Util::SetObjectName(dev, m_tfx_descriptor_sets[0], "Persistent TFX UBO set");
 	return true;
@@ -3472,8 +3476,7 @@ GSTextureVK* GSDeviceVK::SetupPrimitiveTrackingDATE(GSHWDrawConfig& config)
 		DrawPrimitive();
 
 	// image is now filled with either -1 or INT_MAX, so now we can do the prepass
-	IASetVertexBuffer(config.verts, sizeof(GSVertex), config.nverts);
-	IASetIndexBuffer(config.indices, config.nindices);
+	UploadHWDrawVerticesAndIndices(config);
 
 	// cut down the configuration for the prepass, we don't need blending or any feedback loop
 	PipelineSelector& pipe = m_pipeline_selector;
@@ -3718,10 +3721,7 @@ void GSDeviceVK::RenderHW(GSHWDrawConfig& config)
 
 	// VB/IB upload, if we did DATE setup and it's not HDR this has already been done
 	if (!date_image || hdr_rt)
-	{
-		IASetVertexBuffer(config.verts, sizeof(GSVertex), config.nverts);
-		IASetIndexBuffer(config.indices, config.nindices);
-	}
+		UploadHWDrawVerticesAndIndices(config);
 
 	// now we can do the actual draw
 	if (BindDrawPipeline(pipe))
@@ -3814,7 +3814,6 @@ void GSDeviceVK::RenderHW(GSHWDrawConfig& config)
 void GSDeviceVK::UpdateHWPipelineSelector(GSHWDrawConfig& config, PipelineSelector& pipe)
 {
 	pipe.vs.key = config.vs.key;
-	pipe.gs.key = config.gs.key;
 	pipe.ps.key_hi = config.ps.key_hi;
 	pipe.ps.key_lo = config.ps.key_lo;
 	pipe.dss.key = config.depth.key;
@@ -3836,6 +3835,22 @@ void GSDeviceVK::UpdateHWPipelineSelector(GSHWDrawConfig& config, PipelineSelect
 	pipe.vs.point_size |= (config.topology == GSHWDrawConfig::Topology::Point);
 }
 
+void GSDeviceVK::UploadHWDrawVerticesAndIndices(const GSHWDrawConfig& config)
+{
+	IASetVertexBuffer(config.verts, sizeof(GSVertex), config.nverts);
+
+	if (config.vs.UseExpandIndexBuffer())
+	{
+		m_index.start = 0;
+		m_index.count = config.nindices;
+		SetIndexBuffer(m_expand_index_buffer, 0, VK_INDEX_TYPE_UINT32);
+	}
+	else
+	{
+		IASetIndexBuffer(config.indices, config.nindices);
+	}
+}
+
 void GSDeviceVK::SendHWDraw(const GSHWDrawConfig& config, GSTextureVK* draw_rt, bool skip_first_barrier)
 {
 	if (config.drawlist)
@@ -3843,23 +3858,25 @@ void GSDeviceVK::SendHWDraw(const GSHWDrawConfig& config, GSTextureVK* draw_rt, 
 		GL_PUSH("Split the draw (SPRITE)");
 		g_perfmon.Put(GSPerfMon::Barriers, static_cast<u32>(config.drawlist->size()) - static_cast<u32>(skip_first_barrier));
 
-		u32 count = 0;
+		const u32 indices_per_prim = config.indices_per_prim;
+		const u32 draw_list_size = static_cast<u32>(config.drawlist->size());
 		u32 p = 0;
 		u32 n = 0;
 
 		if (skip_first_barrier)
 		{
-			count = (*config.drawlist)[n] * config.indices_per_prim;
+			const u32 count = (*config.drawlist)[n] * indices_per_prim;
 			DrawIndexedPrimitive(p, count);
 			p += count;
 			++n;
 		}
 
-		for (; n < static_cast<u32>(config.drawlist->size()); p += count, ++n)
+		for (; n < draw_list_size; n++)
 		{
-			count = (*config.drawlist)[n] * config.indices_per_prim;
+			const u32 count = (*config.drawlist)[n] * indices_per_prim;
 			ColorBufferBarrier(draw_rt);
 			DrawIndexedPrimitive(p, count);
+			p += count;
 		}
 
 		return;
@@ -3869,21 +3886,22 @@ void GSDeviceVK::SendHWDraw(const GSHWDrawConfig& config, GSTextureVK* draw_rt, 
 	{
 		if (config.require_full_barrier)
 		{
-			GL_PUSH("Split single draw in %d draw", config.nindices / config.indices_per_prim);
-			g_perfmon.Put(GSPerfMon::Barriers, (config.nindices / config.indices_per_prim) - static_cast<u32>(skip_first_barrier));
+			const u32 indices_per_prim = config.indices_per_prim;
 
-			const u32 ipp = config.indices_per_prim;
+			GL_PUSH("Split single draw in %d draw", config.nindices / indices_per_prim);
+			g_perfmon.Put(GSPerfMon::Barriers, (config.nindices / indices_per_prim) - static_cast<u32>(skip_first_barrier));
+
 			u32 p = 0;
 			if (skip_first_barrier)
 			{
-				DrawIndexedPrimitive(p, ipp);
-				p += ipp;
+				DrawIndexedPrimitive(p, indices_per_prim);
+				p += indices_per_prim;
 			}
 
-			for (; p < config.nindices; p += ipp)
+			for (; p < config.nindices; p += indices_per_prim)
 			{
 				ColorBufferBarrier(draw_rt);
-				DrawIndexedPrimitive(p, ipp);
+				DrawIndexedPrimitive(p, indices_per_prim);
 			}
 
 			return;
@@ -3893,11 +3911,8 @@ void GSDeviceVK::SendHWDraw(const GSHWDrawConfig& config, GSTextureVK* draw_rt, 
 		{
 			g_perfmon.Put(GSPerfMon::Barriers, 1);
 			ColorBufferBarrier(draw_rt);
-			DrawIndexedPrimitive();
-			return;
 		}
 	}
 
-	// Don't need any barrier
 	DrawIndexedPrimitive();
 }

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h
@@ -58,7 +58,6 @@ public:
 		};
 
 		GSHWDrawConfig::VSSelector vs;
-		GSHWDrawConfig::GSSelector gs;
 		GSHWDrawConfig::DepthStencilSelector dss;
 		GSHWDrawConfig::ColorMaskSelector cms;
 		GSHWDrawConfig::BlendState bs;
@@ -78,7 +77,7 @@ public:
 		std::size_t operator()(const PipelineSelector& e) const noexcept
 		{
 			std::size_t hash = 0;
-			HashCombine(hash, e.vs.key, e.gs.key, e.ps.key_hi, e.ps.key_lo, e.dss.key, e.cms.key, e.bs.key, e.key);
+			HashCombine(hash, e.vs.key, e.ps.key_hi, e.ps.key_lo, e.dss.key, e.cms.key, e.bs.key, e.key);
 			return hash;
 		}
 	};
@@ -123,6 +122,8 @@ private:
 	Vulkan::StreamBuffer m_index_stream_buffer;
 	Vulkan::StreamBuffer m_vertex_uniform_stream_buffer;
 	Vulkan::StreamBuffer m_fragment_uniform_stream_buffer;
+	VkBuffer m_expand_index_buffer = VK_NULL_HANDLE;
+	VmaAllocation m_expand_index_buffer_allocation = VK_NULL_HANDLE;
 
 	VkSampler m_point_sampler = VK_NULL_HANDLE;
 	VkSampler m_linear_sampler = VK_NULL_HANDLE;
@@ -142,7 +143,6 @@ private:
 	VkPipeline m_shadeboost_pipeline = {};
 
 	std::unordered_map<u32, VkShaderModule> m_tfx_vertex_shaders;
-	std::unordered_map<u32, VkShaderModule> m_tfx_geometry_shaders;
 	std::unordered_map<GSHWDrawConfig::PSSelector, VkShaderModule, GSHWDrawConfig::PSSelectorHash> m_tfx_fragment_shaders;
 	std::unordered_map<PipelineSelector, VkPipeline, PipelineSelectorHash> m_tfx_pipelines;
 
@@ -183,7 +183,6 @@ private:
 	void ClearSamplerCache() final;
 
 	VkShaderModule GetTFXVertexShader(GSHWDrawConfig::VSSelector sel);
-	VkShaderModule GetTFXGeometryShader(GSHWDrawConfig::GSSelector sel);
 	VkShaderModule GetTFXFragmentShader(const GSHWDrawConfig::PSSelector& sel);
 	VkPipeline CreateTFXPipeline(const PipelineSelector& p);
 	VkPipeline GetTFXPipeline(const PipelineSelector& p);
@@ -307,6 +306,7 @@ public:
 
 	void RenderHW(GSHWDrawConfig& config) override;
 	void UpdateHWPipelineSelector(GSHWDrawConfig& config, PipelineSelector& pipe);
+	void UploadHWDrawVerticesAndIndices(const GSHWDrawConfig& config);
 	void SendHWDraw(const GSHWDrawConfig& config, GSTextureVK* draw_rt, bool skip_first_barrier);
 
 	//////////////////////////////////////////////////////////////////////////

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -529,7 +529,6 @@ bool Pcsx2Config::GSOptions::OptionsAreEqual(const GSOptions& right) const
 		OpEqu(UserHacks_GPUTargetCLUTMode) &&
 		OpEqu(UserHacks_TextureInsideRt) &&
 		OpEqu(OverrideTextureBarriers) &&
-		OpEqu(OverrideGeometryShaders) &&
 
 		OpEqu(CAS_Sharpness) &&
 		OpEqu(ShadeBoost_Brightness) &&
@@ -574,8 +573,7 @@ bool Pcsx2Config::GSOptions::RestartOptionsAreEqual(const GSOptions& right) cons
 		   OpEqu(DisableDualSourceBlend) &&
 		   OpEqu(DisableFramebufferFetch) &&
 		   OpEqu(DisableThreadedPresentation) &&
-		   OpEqu(OverrideTextureBarriers) &&
-		   OpEqu(OverrideGeometryShaders);
+		   OpEqu(OverrideTextureBarriers);
 }
 
 void Pcsx2Config::GSOptions::LoadSave(SettingsWrapper& wrap)
@@ -724,7 +722,6 @@ void Pcsx2Config::GSOptions::LoadSave(SettingsWrapper& wrap)
 	GSSettingIntEnumEx(UserHacks_GPUTargetCLUTMode, "UserHacks_GPUTargetCLUTMode");
 	GSSettingIntEnumEx(TriFilter, "TriFilter");
 	GSSettingIntEx(OverrideTextureBarriers, "OverrideTextureBarriers");
-	GSSettingIntEx(OverrideGeometryShaders, "OverrideGeometryShaders");
 
 	GSSettingInt(ShadeBoost_Brightness);
 	GSSettingInt(ShadeBoost_Contrast);

--- a/pcsx2/ShaderCacheVersion.h
+++ b/pcsx2/ShaderCacheVersion.h
@@ -15,4 +15,4 @@
 
 /// Version number for GS and other shaders. Increment whenever any of the contents of the
 /// shaders change, to invalidate the cache.
-static constexpr u32 SHADER_CACHE_VERSION = 23;
+static constexpr u32 SHADER_CACHE_VERSION = 24;


### PR DESCRIPTION
### Description of Changes

Geometry shaders are a bottleneck for many GPUs, so let's do the vertex shader expansion trick instead. Furthermore, for points and sprites, we can omit the index expansion previously done on the CPU, and compute the attributes directly in the vertex shader.

So, we're trading a bunch of CPU overhead and memory bandwidth for 2 fewer post-transform cache hits per 6 indices on the GPU. Worthwhile in my opinion, microbenchmarking the worst case (FMV drawn with points) showed maybe 5% improvement when GPU bottlenecked on Intel, but Intel historically handled geometry shaders fairly well.

Since this is an option for any SM5+ GPUs, we can purge geometry shaders completely and simplify things a bit. For anyone who's still using a SM4 GPU, the CPU fallback is still a thing (at least for sprites, points and lines will suck, but I doubt you're going to be upscaling on such a GPU anyway).

Also fixed mipmapping with the CPU sprite expansion, so it matches the GPU path.

### Rationale behind Changes

Less CPU work.

### Suggested Testing Steps

Test a range of games, with and without upscaling, make sure nothing's broken. Runner says it's okay, but so far I've only checked Vulkan, and only at native resolution.
