### PR TITLE
EE/COP2: Check for likely zero clears in COP2 synced ops

### DIFF
--- a/pcsx2/x86/iR5900Analysis.cpp
+++ b/pcsx2/x86/iR5900Analysis.cpp
@@ -275,6 +275,8 @@ void COP2MicroFinishPass::Run(u32 start, u32 end, EEINST* inst_cache)
 		//
 		const bool is_lqc_sqc = (_Opcode_ == 066 || _Opcode_ == 076);
 		const bool is_non_interlocked_move = (_Opcode_ == 022 && _Rs_ < 020 && ((cpuRegs.code & 1) == 0));
+		// Moving zero to the VU registers, so likely removing a loop/lock.
+		const bool likely_clear = _Opcode_ == 022 && _Rs_ > 004 && _Rt_ == 000;
 		if (needs_vu0_sync && (is_lqc_sqc || is_non_interlocked_move))
 		{
 			bool following_needs_finish = false;
@@ -304,7 +306,7 @@ void COP2MicroFinishPass::Run(u32 start, u32 end, EEINST* inst_cache)
 			else
 			{
 				inst->info |= EEINST_COP2_FLUSH_VU0_REGISTERS | EEINST_COP2_SYNC_VU0;
-				needs_vu0_sync = block_interlocked;
+				needs_vu0_sync = block_interlocked || (is_non_interlocked_move && likely_clear);
 				needs_vu0_finish = true;
 			}
 


### PR DESCRIPTION
### Description of Changes
When checking the EE program for recompilation, checks if it's setting something on the VU's to zero, which is likely being used a lock/loop sync

### Rationale behind Changes
This optimisation was too loose for Ratchet & Clank games, so there was some SPS still, this should clear it up.  This doesn't seem to cause any FPS loss, which was of course a worry.

### Suggested Testing Steps
Test Ratchet & Clank games for SPS on default settings (I don't care if overclocking/underclocking the EE causes problems, that's to be expected)

Up Your Arsenal: (Look at his feet, ear, tail)

Master:
![image](https://user-images.githubusercontent.com/6278726/230748944-4d643166-1519-43ea-9767-0720f9dab186.png)

PR:
![image](https://user-images.githubusercontent.com/6278726/230748959-11ab23ca-4830-4689-8da9-e4157e8e4227.png)
