### PR TITLE
GameDB: Add InstantDMA to Jak 3 for holes in face geometry

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -2452,6 +2452,8 @@ SCED-52946:
 SCED-52952:
   name: "Jak 3 [Demo]"
   region: "PAL-M5"
+  gameFixes:
+    - InstantDMAHack # Fixes holes in face geometry.
   gsHWFixes:
     mipmap: 2 # Fixes broken textures.
     trilinearFiltering: 1 # Fixes water textures.
@@ -3827,6 +3829,8 @@ SCES-52460:
   name: "Jak 3"
   region: "PAL-M7"
   compat: 5
+  gameFixes:
+    - InstantDMAHack # Fixes holes in face geometry.
   gsHWFixes:
     mipmap: 2 # Fixes broken textures.
     trilinearFiltering: 1 # Fixes water textures.
@@ -5179,6 +5183,8 @@ SCKA-20039:
 SCKA-20040:
   name: "Jak 3"
   region: "NTSC-K"
+  gameFixes:
+    - InstantDMAHack # Fixes holes in face geometry.
   gsHWFixes:
     mipmap: 2 # Fixes broken textures.
     trilinearFiltering: 1 # Fixes water textures.
@@ -8034,6 +8040,8 @@ SCUS-97330:
   name: "Jak 3"
   region: "NTSC-U"
   compat: 5
+  gameFixes:
+    - InstantDMAHack # Fixes holes in face geometry.
   gsHWFixes:
     mipmap: 2 # Fixes broken textures.
     trilinearFiltering: 1 # Fixes water textures.
@@ -8291,6 +8299,8 @@ SCUS-97411:
 SCUS-97412:
   name: "Jak 3 [Demo]"
   region: "NTSC-U"
+  gameFixes:
+    - InstantDMAHack # Fixes holes in face geometry.
   gsHWFixes:
     mipmap: 2 # Fixes broken textures.
     trilinearFiltering: 1 # Fixes water textures.
@@ -8794,6 +8804,8 @@ SCUS-97515:
 SCUS-97516:
   name: "Jak 3 [Greatest Hits]"
   region: "NTSC-U"
+  gameFixes:
+    - InstantDMAHack # Fixes holes in face geometry.
   gsHWFixes:
     mipmap: 2 # Fixes broken textures.
     trilinearFiltering: 1 # Fixes water textures.


### PR DESCRIPTION
### Description of Changes
Adds Instant DMA to Jak 3 

### Rationale behind Changes
Due to timing problems, there ends up being holes in the face geometry without it.  Turning off instant VU was another possible fix but that has performance implications where this is free/potentially faster.

### Suggested Testing Steps
Test Jak 3, make sure nothing is broke.

Master:
![image](https://user-images.githubusercontent.com/6278726/230749363-8683349f-3b22-4c67-892f-a40e99b00dab.png)

PR:
![image](https://user-images.githubusercontent.com/6278726/230749367-52d576ab-887f-478a-9b67-f6f7e5090fdc.png)
