### PR TITLE
GS/HW: Adjust Burnout CRC to fully skip broken post effect

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSHwHack.cpp
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.cpp
@@ -266,6 +266,12 @@ bool GSHwHack::GSC_TombRaiderUnderWorld(GSRendererHW& r, int& skip)
 
 bool GSHwHack::GSC_BurnoutGames(GSRendererHW& r, int& skip)
 {
+	if (RFBW == 2 && std::abs(static_cast<int>(RFBP) - static_cast<int>(RZBP)) <= BLOCKS_PER_PAGE)
+	{
+		skip = 2;
+		return true;
+	}
+
 	// We don't check if we already have a skip here, because it gets confused when auto flush is on.
 	if (RTME && (RFBP == 0x01dc0 || RFBP == 0x01c00 || RFBP == 0x01f00 || RFBP == 0x01d40 || RFBP == 0x02200 || RFBP == 0x02000) && RFPSM == RTPSM && (RTBP0 == 0x01dc0 || RTBP0 == 0x01c00 || RTBP0 == 0x01f00 || RTBP0 == 0x01d40 || RTBP0 == 0x02200 || RTBP0 == 0x02000) && RTPSM == PSMCT32)
 	{


### PR DESCRIPTION
### Description of Changes

Skips the broken post effect completely, rather than doing a bunch of pointless copies and draws to screen-sized targets which don't get used.

> source is 8c0, the main color buffer
> but yeah, it's just interleaved
> so the first row will write to 1a40 for color, 1a60 for depth, the next will write to 1a80 for color, 1aa0 for depth, and so on
> so that ends up as black
> then it takes this interleaved s**t and writes it to 1dc0 with FBW 5
> which is... 28 pages after 1a40
> so directly after these interleaved draws
> problem obviously is, we're not interleaving 1a40+1a60
> although.. I don't know if it's actually reading it
> need to dump the draws..
>     min t (x,y,z,w): 1.000000, 1.000000, 16.000000, 16.000000
>     max t (x,y,z,w): 65.000000, 449.000000, 1040.000000, 7184.000000
> so it's only reading the leftmost page
> because tbw is 2
> so only what it wrote through color
>     min p (x,y,z,w): 0.000000, 0.000000, 0.000000, 0.000000
>     max p (x,y,z,w): 32.000000, 224.000000, 0.000000, 0.000000
> the position isn't offset, so the bottom-right will read 64,448 here 
> then it jumps back to reading from the main fb
> but this time it swaps the interleaved FBP and ZBP pointers around
> and of course that is blended
> but since it's only doing one page wide, that should still be okay
> oh, and these swapped pointers also change the swizzle
> so the second one had color at 1a60 and depth at 1a40, so it'd be scrambled when blending 
> then it takes the depth at 1a40 with a C32 swizzle instead of Z32, and draws it to 1dc0
> so.. it's expecting the swapped draw to be scrambled? 🤔
> and for added insult to injury, the depth draw was Z24 not Z32
> f**k it, I give up, this s**t is whack
> if I could actually see wtf it was doing, I'd replace it with a HLE shader, but all I can tell is it's some sort of post-processing effect

### Rationale behind Changes

Vroom vroom

### Suggested Testing Steps

Test Burnout games which use the CRC hack, make sure nothing broke.
