### PR TITLE
EE/COP2: Increase likely clear sync

### DIFF
--- a/pcsx2/x86/iR5900Analysis.cpp
+++ b/pcsx2/x86/iR5900Analysis.cpp
@@ -276,8 +276,8 @@ void COP2MicroFinishPass::Run(u32 start, u32 end, EEINST* inst_cache)
 		const bool is_lqc_sqc = (_Opcode_ == 066 || _Opcode_ == 076);
 		const bool is_non_interlocked_move = (_Opcode_ == 022 && _Rs_ < 020 && ((cpuRegs.code & 1) == 0));
 		// Moving zero to the VU registers, so likely removing a loop/lock.
-		const bool likely_clear = _Opcode_ == 022 && _Rs_ > 004 && _Rt_ == 000;
-		if (needs_vu0_sync && (is_lqc_sqc || is_non_interlocked_move))
+		const bool likely_clear = _Opcode_ == 022 && _Rs_ < 020 && _Rs_ > 004 && _Rt_ == 000;
+		if ((needs_vu0_sync && (is_lqc_sqc || is_non_interlocked_move)) || likely_clear)
 		{
 			bool following_needs_finish = false;
 			ForEachInstruction(apc + 4, end, inst_cache + 1, [&following_needs_finish](u32 apc2, EEINST* inst2) {


### PR DESCRIPTION
### Description of Changes
Increases the sync when a clear is likely happening on COP2

### Rationale behind Changes
Ratchet broke more in other ways, I guess we need even more sync. There is a small performance impact here, between 2-5%, but I dont' see any other way around it, at least it's not as bad as it used to be still lol.

### Suggested Testing Steps
Test Ratchet & Clank games.
