### PR TITLE
GameDB: PAL ZoE 2 Text fix

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -12288,7 +12288,7 @@ SLES-51113:
   region: "PAL-M5"
   compat: 5
   gameFixes:
-    - DMABusyHack # Fixes the corrupted fade effect in cutscenes.
+    - InstantDMAHack # Fixes cut-off text.
   gsHWFixes:
     partialTargetInvalidation: 1 # Fixes cutscene blur effects.
 SLES-51114:


### PR DESCRIPTION
### Description of Changes
Fixes cut off text in PAL versions of Zone of the Enders 2.

Fixes #4091 

### Rationale behind Changes
Cut off text is ba

### Suggested Testing Steps
Make sure CI is happy.
