### PR TITLE
GS/HW: Skip draws on reset until scissor is set

### DIFF
--- a/pcsx2/GS/GSDrawingContext.h
+++ b/pcsx2/GS/GSDrawingContext.h
@@ -40,7 +40,6 @@ public:
 	{
 		GSVector4 in;
 		GSVector4i ex;
-		GSVector4 ofex;
 		GSVector4i ofxy;
 	} scissor;
 
@@ -82,12 +81,6 @@ public:
 		scissor.ex.U16[1] = (u16)((SCISSOR.SCAY0 << 4) + XYOFFSET.OFY - 0x8000);
 		scissor.ex.U16[2] = (u16)((SCISSOR.SCAX1 << 4) + XYOFFSET.OFX - 0x8000);
 		scissor.ex.U16[3] = (u16)((SCISSOR.SCAY1 << 4) + XYOFFSET.OFY - 0x8000);
-
-		scissor.ofex = GSVector4(
-			(int)((SCISSOR.SCAX0 << 4) + XYOFFSET.OFX),
-			(int)((SCISSOR.SCAY0 << 4) + XYOFFSET.OFY),
-			(int)((SCISSOR.SCAX1 << 4) + XYOFFSET.OFX),
-			(int)((SCISSOR.SCAY1 << 4) + XYOFFSET.OFY));
 
 		scissor.in = GSVector4(
 			(int)SCISSOR.SCAX0,


### PR DESCRIPTION
### Description of Changes

~~My **guess** is that the drawing environment registers get left alone, and only the privileged registers are reset.~~

See the notes in the diff/source.

```
// Basically, GOW does a 32x448 draw after resetting the GS, thinking the PSM for the framebuffer is going to be set to C24,
// therefore the alpha bits get left alone. Because of the reset, in PCSX2, it ends up as C32, and the TC gets confused,
// leading to a later texture load using this render target instead of local memory. It's a problem because the game uploads
// texture data on startup to the beginning of VRAM, and never overwrites it.
//
// In the software renderer, if we let the draw happen, it gets scissored to 1x1 (because the scissor is inclusive of the
// upper bounds). This doesn't seem to destroy the chest texture, presumably it's further out in memory.
//
// Hardware test show that VRAM gets corrupted on CSR reset, but the first page remains intact. We're guessing this has something
// to do with DRAM refresh, and perhaps the internal counters used for refresh also getting reset. We're obviously not going
// to emulate this, but to work around the aforementioned issue, in the hardware renderers, we set the scissor to an out of
// bounds value. This means that draws get skipped until the game sets a proper scissor up, which is definitely going to happen
// after reset (otherwise it'd only ever render 1x1).
```

### Rationale behind Changes

Closes #8602.

### Suggested Testing Steps

Test progressive switches in various games. It seems to also fix the garbage frame you might see.

~~However, this needs to be hardware tested, to confirm whether the environment resets or not. If it does, then we have a more serious issue...~~
