### PR TITLE
SPU2: Fix savestate loading setting incorrect variable

### DIFF
--- a/pcsx2/SPU2/spu2freeze.cpp
+++ b/pcsx2/SPU2/spu2freeze.cpp
@@ -152,7 +152,7 @@ s32 SPU2Savestate::ThawIt(DataBlock& spud)
 
 		for (u32 i = 0; i < 2; i++)
 		{
-			V_Core& core = spud.Cores[i];
+			V_Core& core = Cores[i];
 			FIX_POINTER(core.DMAPtr);
 			FIX_POINTER(core.DMARPtr);
 		}


### PR DESCRIPTION
### Description of Changes
Corrects the pointer to the cores used for correcting the DMA pointers when restoring savestates.

### Rationale behind Changes
Pointing at the savestate data instead of the actual core is bad, caused crashes.

### Suggested Testing Steps
try saving states and loading them on a couple of games.

Fixes #8641