### PR TITLE
GS-ogl/Build: Cleanup opengl glsl shaders.

### DIFF
--- a/bin/resources/shaders/opengl/convert.glsl
+++ b/bin/resources/shaders/opengl/convert.glsl
@@ -21,10 +21,10 @@ out vec4 PSin_c;
 
 void vs_main()
 {
-    PSin_p = vec4(POSITION, 0.5f, 1.0f);
-    PSin_t = TEXCOORD0;
-    PSin_c = COLOR;
-    gl_Position = vec4(POSITION, 0.5f, 1.0f); // NOTE I don't know if it is possible to merge POSITION_OUT and gl_Position
+	PSin_p = vec4(POSITION, 0.5f, 1.0f);
+	PSin_t = TEXCOORD0;
+	PSin_c = COLOR;
+	gl_Position = vec4(POSITION, 0.5f, 1.0f); // NOTE I don't know if it is possible to merge POSITION_OUT and gl_Position
 }
 
 #endif
@@ -46,20 +46,20 @@ layout(location = 0) out vec4 SV_Target0;
 
 vec4 sample_c()
 {
-    return texture(TextureSampler, PSin_t);
+	return texture(TextureSampler, PSin_t);
 }
 
 #ifdef ps_copy
 void ps_copy()
 {
-    SV_Target0 = sample_c();
+	SV_Target0 = sample_c();
 }
 #endif
 
 #ifdef ps_depth_copy
 void ps_depth_copy()
 {
-  gl_FragDepth = sample_c().r;
+	gl_FragDepth = sample_c().r;
 }
 #endif
 
@@ -67,20 +67,20 @@ void ps_depth_copy()
 // Need to be careful with precision here, it can break games like Spider-Man 3 and Dogs Life
 void ps_convert_rgba8_16bits()
 {
-    highp uvec4 i = uvec4(sample_c() * vec4(255.5f, 255.5f, 255.5f, 255.5f));
+	highp uvec4 i = uvec4(sample_c() * vec4(255.5f, 255.5f, 255.5f, 255.5f));
 
-    SV_Target1 = ((i.x & 0x00F8u) >> 3) | ((i.y & 0x00F8u) << 2) | ((i.z & 0x00f8u) << 7) | ((i.w & 0x80u) << 8);
+	SV_Target1 = ((i.x & 0x00F8u) >> 3) | ((i.y & 0x00F8u) << 2) | ((i.z & 0x00f8u) << 7) | ((i.w & 0x80u) << 8);
 }
 #endif
 
 #ifdef ps_convert_float32_32bits
 void ps_convert_float32_32bits()
 {
-    // Convert a GL_FLOAT32 depth texture into a 32 bits UINT texture
+	// Convert a GL_FLOAT32 depth texture into a 32 bits UINT texture
 #if HAS_CLIP_CONTROL
-    SV_Target1 = uint(exp2(32.0f) * sample_c().r);
+	SV_Target1 = uint(exp2(32.0f) * sample_c().r);
 #else
-    SV_Target1 = uint(exp2(24.0f) * sample_c().r);
+	SV_Target1 = uint(exp2(24.0f) * sample_c().r);
 #endif
 }
 #endif
@@ -88,150 +88,150 @@ void ps_convert_float32_32bits()
 #ifdef ps_convert_float32_rgba8
 void ps_convert_float32_rgba8()
 {
-    // Convert a GL_FLOAT32 depth texture into a RGBA color texture
+	// Convert a GL_FLOAT32 depth texture into a RGBA color texture
 #if HAS_CLIP_CONTROL
-    uint d = uint(sample_c().r * exp2(32.0f));
+	uint d = uint(sample_c().r * exp2(32.0f));
 #else
-    uint d = uint(sample_c().r * exp2(24.0f));
+	uint d = uint(sample_c().r * exp2(24.0f));
 #endif
-    SV_Target0 = vec4(uvec4((d & 0xFFu), ((d >> 8) & 0xFFu), ((d >> 16) & 0xFFu), (d >> 24))) / vec4(255.0);
+	SV_Target0 = vec4(uvec4((d & 0xFFu), ((d >> 8) & 0xFFu), ((d >> 16) & 0xFFu), (d >> 24))) / vec4(255.0);
 }
 #endif
 
 #ifdef ps_convert_float16_rgb5a1
 void ps_convert_float16_rgb5a1()
 {
-    // Convert a GL_FLOAT32 (only 16 lsb) depth into a RGB5A1 color texture
+	// Convert a GL_FLOAT32 (only 16 lsb) depth into a RGB5A1 color texture
 #if HAS_CLIP_CONTROL
-    uint d = uint(sample_c().r * exp2(32.0f));
+	uint d = uint(sample_c().r * exp2(32.0f));
 #else
-    uint d = uint(sample_c().r * exp2(24.0f));
+	uint d = uint(sample_c().r * exp2(24.0f));
 #endif
-    SV_Target0 = vec4(uvec4((d & 0x1Fu), ((d >> 5) & 0x1Fu), ((d >> 10) & 0x1Fu), (d >> 15) & 0x01u)) / vec4(32.0f, 32.0f, 32.0f, 1.0f);
+	SV_Target0 = vec4(uvec4((d & 0x1Fu), ((d >> 5) & 0x1Fu), ((d >> 10) & 0x1Fu), (d >> 15) & 0x01u)) / vec4(32.0f, 32.0f, 32.0f, 1.0f);
 }
 #endif
 
 float rgba8_to_depth32(vec4 unorm)
 {
-    uvec4 c = uvec4(unorm * vec4(255.5f));
+	uvec4 c = uvec4(unorm * vec4(255.5f));
 #if HAS_CLIP_CONTROL
-    return float(c.r | (c.g << 8) | (c.b << 16) | (c.a << 24)) * exp2(-32.0f);
+	return float(c.r | (c.g << 8) | (c.b << 16) | (c.a << 24)) * exp2(-32.0f);
 #else
-    return float(c.r | (c.g << 8) | (c.b << 16) | (c.a << 24)) * exp2(-24.0f);
+	return float(c.r | (c.g << 8) | (c.b << 16) | (c.a << 24)) * exp2(-24.0f);
 #endif
 }
 
 float rgba8_to_depth24(vec4 unorm)
 {
-    uvec3 c = uvec3(unorm.rgb * vec3(255.5f));
+	uvec3 c = uvec3(unorm.rgb * vec3(255.5f));
 #if HAS_CLIP_CONTROL
-    return float(c.r | (c.g << 8) | (c.b << 16)) * exp2(-32.0f);
+	return float(c.r | (c.g << 8) | (c.b << 16)) * exp2(-32.0f);
 #else
-    return float(c.r | (c.g << 8) | (c.b << 16)) * exp2(-24.0f);
+	return float(c.r | (c.g << 8) | (c.b << 16)) * exp2(-24.0f);
 #endif
 }
 
 float rgba8_to_depth16(vec4 unorm)
 {
-    uvec2 c = uvec2(unorm.rg * vec2(255.5f));
+	uvec2 c = uvec2(unorm.rg * vec2(255.5f));
 #if HAS_CLIP_CONTROL
-    return float(c.r | (c.g << 8)) * exp2(-32.0f);
+	return float(c.r | (c.g << 8)) * exp2(-32.0f);
 #else
-    return float(c.r | (c.g << 8)) * exp2(-24.0f);
+	return float(c.r | (c.g << 8)) * exp2(-24.0f);
 #endif
 }
 
 float rgb5a1_to_depth16(vec4 unorm)
 {
-    uvec4 c = uvec4(unorm * vec4(255.5f));
+	uvec4 c = uvec4(unorm * vec4(255.5f));
 #if HAS_CLIP_CONTROL
-    return float(((c.r & 0xF8u) >> 3) | ((c.g & 0xF8u) << 2) | ((c.b & 0xF8u) << 7) | ((c.a & 0x80u) << 8)) * exp2(-32.0f);
+	return float(((c.r & 0xF8u) >> 3) | ((c.g & 0xF8u) << 2) | ((c.b & 0xF8u) << 7) | ((c.a & 0x80u) << 8)) * exp2(-32.0f);
 #else
-    return float(((c.r & 0xF8u) >> 3) | ((c.g & 0xF8u) << 2) | ((c.b & 0xF8u) << 7) | ((c.a & 0x80u) << 8)) * exp2(-24.0f);
+	return float(((c.r & 0xF8u) >> 3) | ((c.g & 0xF8u) << 2) | ((c.b & 0xF8u) << 7) | ((c.a & 0x80u) << 8)) * exp2(-24.0f);
 #endif
 }
 
 #ifdef ps_convert_rgba8_float32
 void ps_convert_rgba8_float32()
 {
-    // Convert an RGBA texture into a float depth texture
-    gl_FragDepth = rgba8_to_depth32(sample_c());
+	// Convert an RGBA texture into a float depth texture
+	gl_FragDepth = rgba8_to_depth32(sample_c());
 }
 #endif
 
 #ifdef ps_convert_rgba8_float24
 void ps_convert_rgba8_float24()
 {
-    // Same as above but without the alpha channel (24 bits Z)
+	// Same as above but without the alpha channel (24 bits Z)
 
-    // Convert an RGBA texture into a float depth texture
-    gl_FragDepth = rgba8_to_depth24(sample_c());
+	// Convert an RGBA texture into a float depth texture
+	gl_FragDepth = rgba8_to_depth24(sample_c());
 }
 #endif
 
 #ifdef ps_convert_rgba8_float16
 void ps_convert_rgba8_float16()
 {
-    // Same as above but without the A/B channels (16 bits Z)
+	// Same as above but without the A/B channels (16 bits Z)
 
-    // Convert an RGBA texture into a float depth texture
-    gl_FragDepth = rgba8_to_depth16(sample_c());
+	// Convert an RGBA texture into a float depth texture
+	gl_FragDepth = rgba8_to_depth16(sample_c());
 }
 #endif
 
 #ifdef ps_convert_rgb5a1_float16
 void ps_convert_rgb5a1_float16()
 {
-    // Convert an RGB5A1 (saved as RGBA8) color to a 16 bit Z
-    gl_FragDepth = rgb5a1_to_depth16(sample_c());
+	// Convert an RGB5A1 (saved as RGBA8) color to a 16 bit Z
+	gl_FragDepth = rgb5a1_to_depth16(sample_c());
 }
 #endif
 
 #define SAMPLE_RGBA_DEPTH_BILN(CONVERT_FN) \
-    ivec2 dims = textureSize(TextureSampler, 0); \
-    vec2 top_left_f = PSin_t * vec2(dims) - 0.5f; \
-    ivec2 top_left = ivec2(floor(top_left_f)); \
-    ivec4 coords = clamp(ivec4(top_left, top_left + 1), ivec4(0), dims.xyxy - 1); \
-    vec2 mix_vals = fract(top_left_f); \
-    float depthTL = CONVERT_FN(texelFetch(TextureSampler, coords.xy, 0)); \
-    float depthTR = CONVERT_FN(texelFetch(TextureSampler, coords.zy, 0)); \
-    float depthBL = CONVERT_FN(texelFetch(TextureSampler, coords.xw, 0)); \
-    float depthBR = CONVERT_FN(texelFetch(TextureSampler, coords.zw, 0)); \
-    gl_FragDepth = mix(mix(depthTL, depthTR, mix_vals.x), mix(depthBL, depthBR, mix_vals.x), mix_vals.y);
+	ivec2 dims = textureSize(TextureSampler, 0); \
+	vec2 top_left_f = PSin_t * vec2(dims) - 0.5f; \
+	ivec2 top_left = ivec2(floor(top_left_f)); \
+	ivec4 coords = clamp(ivec4(top_left, top_left + 1), ivec4(0), dims.xyxy - 1); \
+	vec2 mix_vals = fract(top_left_f); \
+	float depthTL = CONVERT_FN(texelFetch(TextureSampler, coords.xy, 0)); \
+	float depthTR = CONVERT_FN(texelFetch(TextureSampler, coords.zy, 0)); \
+	float depthBL = CONVERT_FN(texelFetch(TextureSampler, coords.xw, 0)); \
+	float depthBR = CONVERT_FN(texelFetch(TextureSampler, coords.zw, 0)); \
+	gl_FragDepth = mix(mix(depthTL, depthTR, mix_vals.x), mix(depthBL, depthBR, mix_vals.x), mix_vals.y);
 
 #ifdef ps_convert_rgba8_float32_biln
 void ps_convert_rgba8_float32_biln()
 {
-    // Convert an RGBA texture into a float depth texture
-    SAMPLE_RGBA_DEPTH_BILN(rgba8_to_depth32);
+	// Convert an RGBA texture into a float depth texture
+	SAMPLE_RGBA_DEPTH_BILN(rgba8_to_depth32);
 }
 #endif
 
 #ifdef ps_convert_rgba8_float24_biln
 void ps_convert_rgba8_float24_biln()
 {
-    // Same as above but without the alpha channel (24 bits Z)
+	// Same as above but without the alpha channel (24 bits Z)
 
-    // Convert an RGBA texture into a float depth texture
-    SAMPLE_RGBA_DEPTH_BILN(rgba8_to_depth24);
+	// Convert an RGBA texture into a float depth texture
+	SAMPLE_RGBA_DEPTH_BILN(rgba8_to_depth24);
 }
 #endif
 
 #ifdef ps_convert_rgba8_float16_biln
 void ps_convert_rgba8_float16_biln()
 {
-    // Same as above but without the A/B channels (16 bits Z)
+	// Same as above but without the A/B channels (16 bits Z)
 
-    // Convert an RGBA texture into a float depth texture
-    SAMPLE_RGBA_DEPTH_BILN(rgba8_to_depth16);
+	// Convert an RGBA texture into a float depth texture
+	SAMPLE_RGBA_DEPTH_BILN(rgba8_to_depth16);
 }
 #endif
 
 #ifdef ps_convert_rgb5a1_float16_biln
 void ps_convert_rgb5a1_float16_biln()
 {
-    // Convert an RGB5A1 (saved as RGBA8) color to a 16 bit Z
-    SAMPLE_RGBA_DEPTH_BILN(rgb5a1_to_depth16);
+	// Convert an RGB5A1 (saved as RGBA8) color to a 16 bit Z
+	SAMPLE_RGBA_DEPTH_BILN(rgb5a1_to_depth16);
 }
 #endif
 
@@ -242,51 +242,51 @@ uniform float ScaleFactor;
 
 void ps_convert_rgba_8i()
 {
-    // Convert a RGBA texture into a 8 bits packed texture
-    // Input column: 8x2 RGBA pixels
-    // 0: 8 RGBA
-    // 1: 8 RGBA
-    // Output column: 16x4 Index pixels
-    // 0: 8 R | 8 B
-    // 1: 8 R | 8 B
-    // 2: 8 G | 8 A
-    // 3: 8 G | 8 A
-    uvec2 pos = uvec2(gl_FragCoord.xy);
+	// Convert a RGBA texture into a 8 bits packed texture
+	// Input column: 8x2 RGBA pixels
+	// 0: 8 RGBA
+	// 1: 8 RGBA
+	// Output column: 16x4 Index pixels
+	// 0: 8 R | 8 B
+	// 1: 8 R | 8 B
+	// 2: 8 G | 8 A
+	// 3: 8 G | 8 A
+	uvec2 pos = uvec2(gl_FragCoord.xy);
 
-    // Collapse separate R G B A areas into their base pixel
-    uvec2 block = (pos & ~uvec2(15u, 3u)) >> 1;
-    uvec2 subblock = pos & uvec2(7u, 1u);
-    uvec2 coord = block | subblock;
+	// Collapse separate R G B A areas into their base pixel
+	uvec2 block = (pos & ~uvec2(15u, 3u)) >> 1;
+	uvec2 subblock = pos & uvec2(7u, 1u);
+	uvec2 coord = block | subblock;
 
-    // Compensate for potentially differing page pitch.
+	// Compensate for potentially differing page pitch.
 	uvec2 block_xy = coord / uvec2(64u, 32u);
 	uint block_num = (block_xy.y * (DBW / 128u)) + block_xy.x;
 	uvec2 block_offset = uvec2((block_num % (SBW / 64u)) * 64u, (block_num / (SBW / 64u)) * 32u);
 	coord = (coord % uvec2(64u, 32u)) + block_offset;
 
-    // Apply offset to cols 1 and 2
-    uint is_col23 = pos.y & 4u;
-    uint is_col13 = pos.y & 2u;
-    uint is_col12 = is_col23 ^ (is_col13 << 1);
-    coord.x ^= is_col12; // If cols 1 or 2, flip bit 3 of x
+	// Apply offset to cols 1 and 2
+	uint is_col23 = pos.y & 4u;
+	uint is_col13 = pos.y & 2u;
+	uint is_col12 = is_col23 ^ (is_col13 << 1);
+	coord.x ^= is_col12; // If cols 1 or 2, flip bit 3 of x
 
-    if (floor(ScaleFactor) != ScaleFactor)
-        coord = uvec2(vec2(coord) * ScaleFactor);
-    else
-        coord *= uvec2(ScaleFactor);
+	if (floor(ScaleFactor) != ScaleFactor)
+		coord = uvec2(vec2(coord) * ScaleFactor);
+	else
+		coord *= uvec2(ScaleFactor);
 
-    vec4 pixel = texelFetch(TextureSampler, ivec2(coord), 0);
-    vec2  sel0 = (pos.y & 2u) == 0u ? pixel.rb : pixel.ga;
-    float sel1 = (pos.x & 8u) == 0u ? sel0.x : sel0.y;
-    SV_Target0 = vec4(sel1);
+	vec4 pixel = texelFetch(TextureSampler, ivec2(coord), 0);
+	vec2 sel0 = (pos.y & 2u) == 0u ? pixel.rb : pixel.ga;
+	float sel1 = (pos.x & 8u) == 0u ? sel0.x : sel0.y;
+	SV_Target0 = vec4(sel1);
 }
 #endif
 
 #ifdef ps_filter_transparency
 void ps_filter_transparency()
 {
-    vec4 c = sample_c();
-    SV_Target0 = vec4(c.rgb, 1.0);
+	vec4 c = sample_c();
+	SV_Target0 = vec4(c.rgb, 1.0);
 }
 #endif
 
@@ -295,8 +295,8 @@ void ps_filter_transparency()
 #ifdef ps_datm1
 void ps_datm1()
 {
-    if(sample_c().a < (127.5f / 255.0f)) // >= 0x80 pass
-        discard;
+	if (sample_c().a < (127.5f / 255.0f)) // >= 0x80 pass
+		discard;
 }
 #endif
 
@@ -305,24 +305,24 @@ void ps_datm1()
 #ifdef ps_datm0
 void ps_datm0()
 {
-    if((127.5f / 255.0f) < sample_c().a) // < 0x80 pass (== 0x80 should not pass)
-        discard;
+	if ((127.5f / 255.0f) < sample_c().a) // < 0x80 pass (== 0x80 should not pass)
+		discard;
 }
 #endif
 
 #ifdef ps_hdr_init
 void ps_hdr_init()
 {
-    vec4 value = sample_c();
-    SV_Target0 = vec4(round(value.rgb * 255.0f) / 65535.0f, value.a);
+	vec4 value = sample_c();
+	SV_Target0 = vec4(round(value.rgb * 255.0f) / 65535.0f, value.a);
 }
 #endif
 
 #ifdef ps_hdr_resolve
 void ps_hdr_resolve()
 {
-    vec4 value = sample_c();
-    SV_Target0 = vec4(vec3(uvec3(value.rgb * 65535.0f) & 255u) / 255.0f, value.a);
+	vec4 value = sample_c();
+	SV_Target0 = vec4(vec3(uvec3(value.rgb * 65535.0f) & 255u) / 255.0f, value.a);
 }
 #endif
 
@@ -366,51 +366,53 @@ uniform ivec2 EMOD;
 
 void ps_yuv()
 {
-    vec4 i = sample_c();
-    vec4 o;
+	vec4 i = sample_c();
+	vec4 o;
 
-    mat3 rgb2yuv; // Value from GS manual
-    rgb2yuv[0] = vec3(0.587, -0.311, -0.419);
-    rgb2yuv[1] = vec3(0.114, 0.500, -0.081);
-    rgb2yuv[2] = vec3(0.299, -0.169, 0.500);
+	mat3 rgb2yuv; // Value from GS manual
+	rgb2yuv[0] = vec3(0.587, -0.311, -0.419);
+	rgb2yuv[1] = vec3(0.114, 0.500, -0.081);
+	rgb2yuv[2] = vec3(0.299, -0.169, 0.500);
 
-    vec3 yuv = rgb2yuv * i.gbr;
+	vec3 yuv = rgb2yuv * i.gbr;
 
-    float Y = float(0xDB)/255.0f * yuv.x + float(0x10)/255.0f;
-    float Cr = float(0xE0)/255.0f * yuv.y + float(0x80)/255.0f;
-    float Cb = float(0xE0)/255.0f * yuv.z + float(0x80)/255.0f;
+	float Y = float(0xDB) / 255.0f * yuv.x + float(0x10) / 255.0f;
+	float Cr = float(0xE0) / 255.0f * yuv.y + float(0x80) / 255.0f;
+	float Cb = float(0xE0) / 255.0f * yuv.z + float(0x80) / 255.0f;
 
-    switch(EMOD.x) {
-        case 0:
-            o.a = i.a;
-            break;
-        case 1:
-            o.a = Y;
-            break;
-        case 2:
-            o.a = Y/2.0f;
-            break;
-        case 3:
-            o.a = 0.0f;
-            break;
-    }
+	switch (EMOD.x)
+	{
+		case 0:
+			o.a = i.a;
+			break;
+		case 1:
+			o.a = Y;
+			break;
+		case 2:
+			o.a = Y / 2.0f;
+			break;
+		case 3:
+			o.a = 0.0f;
+			break;
+	}
 
-    switch(EMOD.y) {
-        case 0:
-            o.rgb = i.rgb;
-            break;
-        case 1:
-            o.rgb = vec3(Y);
-            break;
-        case 2:
-            o.rgb = vec3(Y, Cb, Cr);
-            break;
-        case 3:
-            o.rgb = vec3(i.a);
-            break;
-    }
+	switch (EMOD.y)
+	{
+		case 0:
+			o.rgb = i.rgb;
+			break;
+		case 1:
+			o.rgb = vec3(Y);
+			break;
+		case 2:
+			o.rgb = vec3(Y, Cb, Cr);
+			break;
+		case 3:
+			o.rgb = vec3(i.a);
+			break;
+	}
 
-    SV_Target0 = o;
+	SV_Target0 = o;
 }
 #endif
 
@@ -418,16 +420,16 @@ void ps_yuv()
 
 void main()
 {
-    SV_Target0 = vec4(0x7FFFFFFF);
+	SV_Target0 = vec4(0x7FFFFFFF);
 
-    #ifdef ps_stencil_image_init_0
-        if((127.5f / 255.0f) < sample_c().a) // < 0x80 pass (== 0x80 should not pass)
-            SV_Target0 = vec4(-1);
-    #endif
-    #ifdef ps_stencil_image_init_1
-        if(sample_c().a < (127.5f / 255.0f)) // >= 0x80 pass
-            SV_Target0 = vec4(-1);
-    #endif
+#ifdef ps_stencil_image_init_0
+	if ((127.5f / 255.0f) < sample_c().a) // < 0x80 pass (== 0x80 should not pass)
+		SV_Target0 = vec4(-1);
+#endif
+#ifdef ps_stencil_image_init_1
+	if (sample_c().a < (127.5f / 255.0f)) // >= 0x80 pass
+		SV_Target0 = vec4(-1);
+#endif
 }
 #endif
 

--- a/bin/resources/shaders/opengl/merge.glsl
+++ b/bin/resources/shaders/opengl/merge.glsl
@@ -14,17 +14,17 @@ layout(location = 0) out vec4 SV_Target0;
 
 void ps_main0()
 {
-    vec4 c = texture(TextureSampler, PSin_t);
-    // Note: clamping will be done by fixed unit
-    c.a *= 2.0f;
-    SV_Target0 = c;
+	vec4 c = texture(TextureSampler, PSin_t);
+	// Note: clamping will be done by fixed unit
+	c.a *= 2.0f;
+	SV_Target0 = c;
 }
 
 void ps_main1()
 {
-    vec4 c = texture(TextureSampler, PSin_t);
-    c.a = BGColor.a;
-    SV_Target0 = c;
+	vec4 c = texture(TextureSampler, PSin_t);
+	c.a = BGColor.a;
+	SV_Target0 = c;
 }
 
 #endif

--- a/bin/resources/shaders/opengl/present.glsl
+++ b/bin/resources/shaders/opengl/present.glsl
@@ -75,11 +75,9 @@ void ps_copy()
 #ifdef ps_filter_scanlines
 vec4 ps_scanlines(uint i)
 {
-	vec4 mask[2] = vec4[2]
-	(
+	vec4 mask[2] = vec4[2](
 		vec4(1, 1, 1, 0),
-		vec4(0, 0, 0, 0)
-	);
+		vec4(0, 0, 0, 0));
 
 	return sample_c() * clamp((mask[i] + 0.5f), 0.0f, 1.0f);
 }
@@ -119,10 +117,10 @@ void ps_filter_triangular() // triangular
 #ifdef ps_filter_complex
 void ps_filter_complex()
 {
-    const float PI = 3.14159265359f;
-    vec2 texdim = vec2(textureSize(TextureSampler, 0));
-    float factor = (0.9f - 0.4f * cos(2.0f * PI * PSin_t.y * texdim.y));
-    vec4 c =  factor * texture(TextureSampler, vec2(PSin_t.x, (floor(PSin_t.y * texdim.y) + 0.5f) / texdim.y));
+	const float PI = 3.14159265359f;
+	vec2 texdim = vec2(textureSize(TextureSampler, 0));
+	float factor = (0.9f - 0.4f * cos(2.0f * PI * PSin_t.y * texdim.y));
+	vec4 c = factor * texture(TextureSampler, vec2(PSin_t.x, (floor(PSin_t.y * texdim.y) + 0.5f) / texdim.y));
 
 	SV_Target0 = c;
 }
@@ -130,16 +128,16 @@ void ps_filter_complex()
 
 #ifdef ps_filter_lottes
 
-#define MaskingType 4                      //[1|2|3|4] The type of CRT shadow masking used. 1: compressed TV style, 2: Aperture-grille, 3: Stretched VGA style, 4: VGA style.
-#define ScanBrightness -8.00               //[-16.0 to 1.0] The overall brightness of the scanline effect. Lower for darker, higher for brighter.
-#define FilterCRTAmount -1.00              //[-4.0 to 1.0] The amount of filtering used, to replicate the TV CRT look. Lower for less, higher for more.
-#define HorizontalWarp 0.00                //[0.0 to 0.1] The distortion warping effect for the horizontal (x) axis of the screen. Use small increments.
-#define VerticalWarp 0.00                  //[0.0 to 0.1] The distortion warping effect for the verticle (y) axis of the screen. Use small increments.
-#define MaskAmountDark 0.80                //[0.0 to 1.0] The value of the dark masking line effect used. Lower for darker lower end masking, higher for brighter.
-#define MaskAmountLight 1.50               //[0.0 to 2.0] The value of the light masking line effect used. Lower for darker higher end masking, higher for brighter.
-#define ResolutionScale 2.00               //[0.1 to 4.0] The scale of the image resolution. Lowering this can give off a nice retro TV look. Raising it can clear up the image.
-#define MaskResolutionScale 0.80           //[0.1 to 2.0] The scale of the CRT mask resolution. Use this for balancing the scanline mask scale for difference resolution scaling.
-#define UseShadowMask 1                    //[0 or 1] Enables, or disables the use of the CRT shadow mask. 0 is disabled, 1 is enabled.
+#define MaskingType 4            // [1|2|3|4] The type of CRT shadow masking used. 1: compressed TV style, 2: Aperture-grille, 3: Stretched VGA style, 4: VGA style.
+#define ScanBrightness -8.00     // [-16.0 to 1.0] The overall brightness of the scanline effect. Lower for darker, higher for brighter.
+#define FilterCRTAmount -1.00    // [-4.0 to 1.0] The amount of filtering used, to replicate the TV CRT look. Lower for less, higher for more.
+#define HorizontalWarp 0.00      // [0.0 to 0.1] The distortion warping effect for the horizontal (x) axis of the screen. Use small increments.
+#define VerticalWarp 0.00        // [0.0 to 0.1] The distortion warping effect for the verticle (y) axis of the screen. Use small increments.
+#define MaskAmountDark 0.80      // [0.0 to 1.0] The value of the dark masking line effect used. Lower for darker lower end masking, higher for brighter.
+#define MaskAmountLight 1.50     // [0.0 to 2.0] The value of the light masking line effect used. Lower for darker higher end masking, higher for brighter.
+#define ResolutionScale 2.00     // [0.1 to 4.0] The scale of the image resolution. Lowering this can give off a nice retro TV look. Raising it can clear up the image.
+#define MaskResolutionScale 0.80 // [0.1 to 2.0] The scale of the CRT mask resolution. Use this for balancing the scanline mask scale for difference resolution scaling.
+#define UseShadowMask 1          // [0 or 1] Enables, or disables the use of the CRT shadow mask. 0 is disabled, 1 is enabled.
 
 #define saturate(x) clamp(x, 0.0, 1.0)
 

--- a/bin/resources/shaders/opengl/shadeboost.glsl
+++ b/bin/resources/shaders/opengl/shadeboost.glsl
@@ -24,33 +24,33 @@ layout(location = 0) out vec4 SV_Target0;
 // For all settings: 1.0 = 100% 0.5=50% 1.5 = 150%
 vec4 ContrastSaturationBrightness(vec4 color)
 {
-    float brt = params.x;
-    float con = params.y;
-    float sat = params.z;
+	float brt = params.x;
+	float con = params.y;
+	float sat = params.z;
 
-    // Increase or decrease these values to adjust r, g and b color channels separately
-    const float AvgLumR = 0.5;
-    const float AvgLumG = 0.5;
-    const float AvgLumB = 0.5;
+	// Increase or decrease these values to adjust r, g and b color channels separately
+	const float AvgLumR = 0.5;
+	const float AvgLumG = 0.5;
+	const float AvgLumB = 0.5;
 
-    const vec3 LumCoeff = vec3(0.2125, 0.7154, 0.0721);
+	const vec3 LumCoeff = vec3(0.2125, 0.7154, 0.0721);
 
-    vec3 AvgLumin = vec3(AvgLumR, AvgLumG, AvgLumB);
-    vec3 brtColor = color.rgb * brt;
-    float dot_intensity = dot(brtColor, LumCoeff);
-    vec3 intensity = vec3(dot_intensity, dot_intensity, dot_intensity);
-    vec3 satColor = mix(intensity, brtColor, sat);
-    vec3 conColor = mix(AvgLumin, satColor, con);
+	vec3 AvgLumin = vec3(AvgLumR, AvgLumG, AvgLumB);
+	vec3 brtColor = color.rgb * brt;
+	float dot_intensity = dot(brtColor, LumCoeff);
+	vec3 intensity = vec3(dot_intensity, dot_intensity, dot_intensity);
+	vec3 satColor = mix(intensity, brtColor, sat);
+	vec3 conColor = mix(AvgLumin, satColor, con);
 
-    color.rgb = conColor;
-    return color;
+	color.rgb = conColor;
+	return color;
 }
 
 
 void ps_main()
 {
-    vec4 c = texture(TextureSampler, PSin_t);
-    SV_Target0 = ContrastSaturationBrightness(c);
+	vec4 c = texture(TextureSampler, PSin_t);
+	SV_Target0 = ContrastSaturationBrightness(c);
 }
 
 

--- a/bin/resources/shaders/opengl/tfx_fs.glsl
+++ b/bin/resources/shaders/opengl/tfx_fs.glsl
@@ -23,69 +23,70 @@
 
 layout(std140, binding = 0) uniform cb21
 {
-    vec3 FogColor;
-    float AREF;
+	vec3 FogColor;
+	float AREF;
 
-    vec4 WH;
+	vec4 WH;
 
-    vec2 TA;
-    float MaxDepthPS;
-    float Af;
+	vec2 TA;
+	float MaxDepthPS;
+	float Af;
 
-    uvec4 FbMask;
+	uvec4 FbMask;
 
-    vec4 HalfTexel;
+	vec4 HalfTexel;
 
-    vec4 MinMax;
-    vec4 STRange;
+	vec4 MinMax;
+	vec4 STRange;
 
-    ivec4 ChannelShuffle;
+	ivec4 ChannelShuffle;
 
-    vec2 TC_OffsetHack;
-    vec2 STScale;
+	vec2 TC_OffsetHack;
+	vec2 STScale;
 
-    mat4 DitherMatrix;
+	mat4 DitherMatrix;
 
-    float ScaledScaleFactor;
-    float RcpScaleFactor;
+	float ScaledScaleFactor;
+	float RcpScaleFactor;
 };
 
 in SHADER
 {
-    vec4 t_float;
-    vec4 t_int;
+	vec4 t_float;
+	vec4 t_int;
 
-    #if PS_IIP != 0
-      vec4 c;
-    #else
-      flat vec4 c;
-    #endif
-} PSin;
+#if PS_IIP != 0
+	vec4 c;
+#else
+	flat vec4 c;
+#endif
+}
+PSin;
 
 #define TARGET_0_QUALIFIER out
 
 // Only enable framebuffer fetch when we actually need it.
 #if HAS_FRAMEBUFFER_FETCH && NEEDS_RT
-  // We need to force the colour to be defined here, to read from it.
-  // Basically the only scenario where this'll happen is RGBA masked and DATE is active.
-  #undef PS_NO_COLOR
-  #define PS_NO_COLOR 0
-  #if defined(GL_EXT_shader_framebuffer_fetch)
-    #undef TARGET_0_QUALIFIER
-    #define TARGET_0_QUALIFIER inout
-    #define LAST_FRAG_COLOR SV_Target0
-  #elif defined(GL_ARM_shader_framebuffer_fetch)
-    #define LAST_FRAG_COLOR gl_LastFragColorARM
-  #endif
+// We need to force the colour to be defined here, to read from it.
+// Basically the only scenario where this'll happen is RGBA masked and DATE is active.
+#undef PS_NO_COLOR
+#define PS_NO_COLOR 0
+#if defined(GL_EXT_shader_framebuffer_fetch)
+#undef TARGET_0_QUALIFIER
+#define TARGET_0_QUALIFIER inout
+#define LAST_FRAG_COLOR SV_Target0
+#elif defined(GL_ARM_shader_framebuffer_fetch)
+#define LAST_FRAG_COLOR gl_LastFragColorARM
+#endif
 #endif
 
 #if !PS_NO_COLOR
 #if !defined(DISABLE_DUAL_SOURCE) && !PS_NO_COLOR1
-  // Same buffer but 2 colors for dual source blending
-  layout(location = 0, index = 0) TARGET_0_QUALIFIER vec4 SV_Target0;
-  layout(location = 0, index = 1) out vec4 SV_Target1;
+// Same buffer but 2 colors for dual source blending
+layout(location = 0, index = 0) TARGET_0_QUALIFIER vec4 SV_Target0;
+layout(location = 0, index = 1) out vec4 SV_Target1;
 #else
-  layout(location = 0) TARGET_0_QUALIFIER vec4 SV_Target0;
+layout(location = 0) TARGET_0_QUALIFIER vec4 SV_Target0;
 #endif
 #endif
 
@@ -108,11 +109,11 @@ layout(binding = 3) uniform sampler2D img_prim_min;
 vec4 fetch_rt()
 {
 #if !NEEDS_RT
-    return vec4(0.0);
+	return vec4(0.0);
 #elif HAS_FRAMEBUFFER_FETCH
-    return LAST_FRAG_COLOR;
+	return LAST_FRAG_COLOR;
 #else
-    return texelFetch(RtSampler, ivec2(gl_FragCoord.xy), 0);
+	return texelFetch(RtSampler, ivec2(gl_FragCoord.xy), 0);
 #endif
 }
 
@@ -121,52 +122,52 @@ vec4 fetch_rt()
 vec4 sample_c(vec2 uv)
 {
 #if PS_TEX_IS_FB == 1
-    return fetch_rt();
+	return fetch_rt();
 #elif PS_REGION_RECT
 	return texelFetch(TextureSampler, ivec2(uv), 0);
 #else
 
 #if PS_POINT_SAMPLER
-    // Weird issue with ATI/AMD cards,
-    // it looks like they add 127/128 of a texel to sampling coordinates
-    // occasionally causing point sampling to erroneously round up.
-    // I'm manually adjusting coordinates to the centre of texels here,
-    // though the centre is just paranoia, the top left corner works fine.
-    // As of 2018 this issue is still present.
-    uv = (trunc(uv * WH.zw) + vec2(0.5, 0.5)) / WH.zw;
+	// Weird issue with ATI/AMD cards,
+	// it looks like they add 127/128 of a texel to sampling coordinates
+	// occasionally causing point sampling to erroneously round up.
+	// I'm manually adjusting coordinates to the centre of texels here,
+	// though the centre is just paranoia, the top left corner works fine.
+	// As of 2018 this issue is still present.
+	uv = (trunc(uv * WH.zw) + vec2(0.5, 0.5)) / WH.zw;
 #endif
 #if !PS_ADJS && !PS_ADJT
 	uv *= STScale;
 #else
-	#if PS_ADJS
-		uv.x = (uv.x - STRange.x) * STRange.z;
-	#else
-		uv.x = uv.x * STScale.x;
-	#endif
-	#if PS_ADJT
-		uv.y = (uv.y - STRange.y) * STRange.w;
-	#else
-		uv.y = uv.y * STScale.y;
-	#endif
+#if PS_ADJS
+	uv.x = (uv.x - STRange.x) * STRange.z;
+#else
+	uv.x = uv.x * STScale.x;
+#endif
+#if PS_ADJT
+	uv.y = (uv.y - STRange.y) * STRange.w;
+#else
+	uv.y = uv.y * STScale.y;
+#endif
 #endif
 
 #if PS_AUTOMATIC_LOD == 1
-    return texture(TextureSampler, uv);
+	return texture(TextureSampler, uv);
 #elif PS_MANUAL_LOD == 1
-    // FIXME add LOD: K - ( LOG2(Q) * (1 << L))
-    float K = MinMax.x;
-    float L = MinMax.y;
-    float bias = MinMax.z;
-    float max_lod = MinMax.w;
+	// FIXME add LOD: K - ( LOG2(Q) * (1 << L))
+	float K = MinMax.x;
+	float L = MinMax.y;
+	float bias = MinMax.z;
+	float max_lod = MinMax.w;
 
-    float gs_lod = K - log2(abs(PSin.t_float.w)) * L;
-    // FIXME max useful ?
-    //float lod = max(min(gs_lod, max_lod) - bias, 0.0f);
-    float lod = min(gs_lod, max_lod) - bias;
+	float gs_lod = K - log2(abs(PSin.t_float.w)) * L;
+	// FIXME max useful ?
+	//float lod = max(min(gs_lod, max_lod) - bias, 0.0f);
+	float lod = min(gs_lod, max_lod) - bias;
 
-    return textureLod(TextureSampler, uv, lod);
+	return textureLod(TextureSampler, uv, lod);
 #else
-    return textureLod(TextureSampler, uv, 0.0f); // No lod
+	return textureLod(TextureSampler, uv, 0.0f); // No lod
 #endif
 
 #endif
@@ -184,8 +185,8 @@ vec4 sample_p_norm(float u)
 
 vec4 clamp_wrap_uv(vec4 uv)
 {
-    vec4 uv_out = uv;
-    vec4 tex_size = WH.xyxy;
+	vec4 uv_out = uv;
+	vec4 tex_size = WH.xyxy;
 
 #if PS_WMS == PS_WMT
 
@@ -194,14 +195,14 @@ vec4 clamp_wrap_uv(vec4 uv)
 #elif PS_REGION_RECT == 1 && PS_WMS == 1
 	uv_out = clamp(uv, vec4(0.0f), vec4(1.0f));
 #elif PS_WMS == 2
-    uv_out = clamp(uv, MinMax.xyxy, MinMax.zwzw);
+	uv_out = clamp(uv, MinMax.xyxy, MinMax.zwzw);
 #elif PS_WMS == 3
-    #if PS_FST == 0
-    // wrap negative uv coords to avoid an off by one error that shifted
-    // textures. Fixes Xenosaga's hair issue.
-    uv = fract(uv);
-    #endif
-    uv_out = vec4((uvec4(uv * tex_size) & floatBitsToUint(MinMax.xyxy)) | floatBitsToUint(MinMax.zwzw)) / tex_size;
+#if PS_FST == 0
+	// wrap negative uv coords to avoid an off by one error that shifted
+	// textures. Fixes Xenosaga's hair issue.
+	uv = fract(uv);
+#endif
+	uv_out = vec4((uvec4(uv * tex_size) & floatBitsToUint(MinMax.xyxy)) | floatBitsToUint(MinMax.zwzw)) / tex_size;
 #endif
 
 #else // PS_WMS != PS_WMT
@@ -213,13 +214,13 @@ vec4 clamp_wrap_uv(vec4 uv)
 	uv.xz = clamp(uv.xz, vec2(0.0f), vec2(1.0f));
 
 #elif PS_WMS == 2
-    uv_out.xz = clamp(uv.xz, MinMax.xx, MinMax.zz);
+	uv_out.xz = clamp(uv.xz, MinMax.xx, MinMax.zz);
 
 #elif PS_WMS == 3
-    #if PS_FST == 0
-    uv.xz = fract(uv.xz);
-    #endif
-    uv_out.xz = vec2((uvec2(uv.xz * tex_size.xx) & floatBitsToUint(MinMax.xx)) | floatBitsToUint(MinMax.zz)) / tex_size.xx;
+#if PS_FST == 0
+	uv.xz = fract(uv.xz);
+#endif
+	uv_out.xz = vec2((uvec2(uv.xz * tex_size.xx) & floatBitsToUint(MinMax.xx)) | floatBitsToUint(MinMax.zz)) / tex_size.xx;
 
 #endif
 
@@ -230,109 +231,108 @@ vec4 clamp_wrap_uv(vec4 uv)
 	uv_out.yw = clamp(uv.yw, vec2(0.0f), vec2(1.0f));
 
 #elif PS_WMT == 2
-    uv_out.yw = clamp(uv.yw, MinMax.yy, MinMax.ww);
+	uv_out.yw = clamp(uv.yw, MinMax.yy, MinMax.ww);
 
 #elif PS_WMT == 3
-    #if PS_FST == 0
-    uv.yw = fract(uv.yw);
-    #endif
-    uv_out.yw = vec2((uvec2(uv.yw * tex_size.yy) & floatBitsToUint(MinMax.yy)) | floatBitsToUint(MinMax.ww)) / tex_size.yy;
+#if PS_FST == 0
+	uv.yw = fract(uv.yw);
+#endif
+	uv_out.yw = vec2((uvec2(uv.yw * tex_size.yy) & floatBitsToUint(MinMax.yy)) | floatBitsToUint(MinMax.ww)) / tex_size.yy;
 #endif
 
 #endif
 
 #if PS_REGION_RECT == 1
-    // Normalized -> Integer Coordinates.
+	// Normalized -> Integer Coordinates.
 	uv_out = clamp(uv_out * WH.zwzw + STRange.xyxy, STRange.xyxy, STRange.zwzw);
 #endif
 
-    return uv_out;
+	return uv_out;
 }
 
 mat4 sample_4c(vec4 uv)
 {
-    mat4 c;
+	mat4 c;
 
-    // Note: texture gather can't be used because of special clamping/wrapping
-    // Also it doesn't support lod
-    c[0] = sample_c(uv.xy);
-    c[1] = sample_c(uv.zy);
-    c[2] = sample_c(uv.xw);
-    c[3] = sample_c(uv.zw);
+	// Note: texture gather can't be used because of special clamping/wrapping
+	// Also it doesn't support lod
+	c[0] = sample_c(uv.xy);
+	c[1] = sample_c(uv.zy);
+	c[2] = sample_c(uv.xw);
+	c[3] = sample_c(uv.zw);
 
-    return c;
+	return c;
 }
 
 uvec4 sample_4_index(vec4 uv)
 {
-    vec4 c;
+	vec4 c;
 
-    // Either GS will send a texture that contains a single channel
-    // in this case the red channel is remapped as alpha channel
-    //
-    // Or we have an old RT (ie RGBA8) that contains index (4/8) in the alpha channel
+	// Either GS will send a texture that contains a single channel
+	// in this case the red channel is remapped as alpha channel
+	//
+	// Or we have an old RT (ie RGBA8) that contains index (4/8) in the alpha channel
 
-    // Note: texture gather can't be used because of special clamping/wrapping
-    // Also it doesn't support lod
-    c.x = sample_c(uv.xy).a;
-    c.y = sample_c(uv.zy).a;
-    c.z = sample_c(uv.xw).a;
-    c.w = sample_c(uv.zw).a;
+	// Note: texture gather can't be used because of special clamping/wrapping
+	// Also it doesn't support lod
+	c.x = sample_c(uv.xy).a;
+	c.y = sample_c(uv.zy).a;
+	c.z = sample_c(uv.xw).a;
+	c.w = sample_c(uv.zw).a;
 
-    uvec4 i = uvec4(c * 255.5f); // Denormalize value
+	uvec4 i = uvec4(c * 255.5f); // Denormalize value
 
 #if PS_PAL_FMT == 1
-    // 4HL
-    return i & 0xFu;
+	// 4HL
+	return i & 0xFu;
 #elif PS_PAL_FMT == 2
-    // 4HH
-    return i >> 4u;
+	// 4HH
+	return i >> 4u;
 #else
-    // 8
-    return i;
+	// 8
+	return i;
 #endif
-
 }
 
 mat4 sample_4p(uvec4 u)
 {
-    mat4 c;
+	mat4 c;
 
-    c[0] = sample_p(u.x);
-    c[1] = sample_p(u.y);
-    c[2] = sample_p(u.z);
-    c[3] = sample_p(u.w);
+	c[0] = sample_p(u.x);
+	c[1] = sample_p(u.y);
+	c[2] = sample_p(u.z);
+	c[3] = sample_p(u.w);
 
-    return c;
+	return c;
 }
 
 int fetch_raw_depth()
 {
 #if HAS_CLIP_CONTROL
-    float multiplier = exp2(32.0f);
+	float multiplier = exp2(32.0f);
 #else
-    float multiplier = exp2(24.0f);
+	float multiplier = exp2(24.0f);
 #endif
 
 #if PS_TEX_IS_FB == 1
-    return int(fetch_rt().r * multiplier);
+	return int(fetch_rt().r * multiplier);
 #else
-    return int(texelFetch(TextureSampler, ivec2(gl_FragCoord.xy), 0).r * multiplier);
+	return int(texelFetch(TextureSampler, ivec2(gl_FragCoord.xy), 0).r * multiplier);
 #endif
 }
 
 vec4 fetch_raw_color()
 {
 #if PS_TEX_IS_FB == 1
-    return fetch_rt();
+	return fetch_rt();
 #else
-    return texelFetch(TextureSampler, ivec2(gl_FragCoord.xy), 0);
+	return texelFetch(TextureSampler, ivec2(gl_FragCoord.xy), 0);
 #endif
 }
 
 vec4 fetch_c(ivec2 uv)
 {
-    return texelFetch(TextureSampler, ivec2(uv), 0);
+	return texelFetch(TextureSampler, ivec2(uv), 0);
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -340,113 +340,114 @@ vec4 fetch_c(ivec2 uv)
 //////////////////////////////////////////////////////////////////////
 ivec2 clamp_wrap_uv_depth(ivec2 uv)
 {
-    ivec2 uv_out = uv;
+	ivec2 uv_out = uv;
 
-    // Keep the full precision
-    // It allow to multiply the ScalingFactor before the 1/16 coeff
-    ivec4 mask = floatBitsToInt(MinMax) << 4;
+	// Keep the full precision
+	// It allow to multiply the ScalingFactor before the 1/16 coeff
+	ivec4 mask = floatBitsToInt(MinMax) << 4;
 
 #if PS_WMS == PS_WMT
 
 #if PS_WMS == 2
-    uv_out = clamp(uv, mask.xy, mask.zw);
+	uv_out = clamp(uv, mask.xy, mask.zw);
 #elif PS_WMS == 3
-    uv_out = (uv & mask.xy) | mask.zw;
+	uv_out = (uv & mask.xy) | mask.zw;
 #endif
 
 #else // PS_WMS != PS_WMT
 
 #if PS_WMS == 2
-    uv_out.x = clamp(uv.x, mask.x, mask.z);
+	uv_out.x = clamp(uv.x, mask.x, mask.z);
 #elif PS_WMS == 3
-    uv_out.x = (uv.x & mask.x) | mask.z;
+	uv_out.x = (uv.x & mask.x) | mask.z;
 #endif
 
 #if PS_WMT == 2
-    uv_out.y = clamp(uv.y, mask.y, mask.w);
+	uv_out.y = clamp(uv.y, mask.y, mask.w);
 #elif PS_WMT == 3
-    uv_out.y = (uv.y & mask.y) | mask.w;
+	uv_out.y = (uv.y & mask.y) | mask.w;
 #endif
 
 #endif
 
-    return uv_out;
+	return uv_out;
 }
 
 vec4 sample_depth(vec2 st)
 {
-    vec2 uv_f = vec2(clamp_wrap_uv_depth(ivec2(st))) * vec2(ScaledScaleFactor);
+	vec2 uv_f = vec2(clamp_wrap_uv_depth(ivec2(st))) * vec2(ScaledScaleFactor);
 
-    #if PS_REGION_RECT == 1
-        uv_f = clamp(uv_f + STRange.xy, STRange.xy, STRange.zw);
-    #endif
+#if PS_REGION_RECT == 1
+	uv_f = clamp(uv_f + STRange.xy, STRange.xy, STRange.zw);
+#endif
 
-    ivec2 uv = ivec2(uv_f);
-    vec4 t = vec4(0.0f);
+	ivec2 uv = ivec2(uv_f);
+	vec4 t = vec4(0.0f);
 
 #if PS_TALES_OF_ABYSS_HLE == 1
-    // Warning: UV can't be used in channel effect
-    int depth = fetch_raw_depth();
+	// Warning: UV can't be used in channel effect
+	int depth = fetch_raw_depth();
 
-    // Convert msb based on the palette
-    t = texelFetch(PaletteSampler, ivec2((depth >> 8) & 0xFF, 0), 0) * 255.0f;
+	// Convert msb based on the palette
+	t = texelFetch(PaletteSampler, ivec2((depth >> 8) & 0xFF, 0), 0) * 255.0f;
 
 #elif PS_URBAN_CHAOS_HLE == 1
-    // Depth buffer is read as a RGB5A1 texture. The game try to extract the green channel.
-    // So it will do a first channel trick to extract lsb, value is right-shifted.
-    // Then a new channel trick to extract msb which will shifted to the left.
-    // OpenGL uses a FLOAT32 format for the depth so it requires a couple of conversion.
-    // To be faster both steps (msb&lsb) are done in a single pass.
+	// Depth buffer is read as a RGB5A1 texture. The game try to extract the green channel.
+	// So it will do a first channel trick to extract lsb, value is right-shifted.
+	// Then a new channel trick to extract msb which will shifted to the left.
+	// OpenGL uses a FLOAT32 format for the depth so it requires a couple of conversion.
+	// To be faster both steps (msb&lsb) are done in a single pass.
 
-    // Warning: UV can't be used in channel effect
-    int depth = fetch_raw_depth();
+	// Warning: UV can't be used in channel effect
+	int depth = fetch_raw_depth();
 
-    // Convert lsb based on the palette
-    t = texelFetch(PaletteSampler, ivec2((depth & 0xFF), 0), 0) * 255.0f;
+	// Convert lsb based on the palette
+	t = texelFetch(PaletteSampler, ivec2((depth & 0xFF), 0), 0) * 255.0f;
 
-    // Msb is easier
-    float green = float((depth >> 8) & 0xFF) * 36.0f;
-    green = min(green, 255.0f);
+	// Msb is easier
+	float green = float((depth >> 8) & 0xFF) * 36.0f;
+	green = min(green, 255.0f);
 
-    t.g += green;
+	t.g += green;
 
 
 #elif PS_DEPTH_FMT == 1
-    // Based on ps_convert_float32_rgba8 of convert
-    // Convert a GL_FLOAT32 depth texture into a RGBA color texture
-    #if HAS_CLIP_CONTROL
-      uint d = uint(fetch_c(uv).r * exp2(32.0f));
-    #else
-      uint d = uint(fetch_c(uv).r * exp2(24.0f));
-    #endif
-    t = vec4(uvec4((d & 0xFFu), ((d >> 8) & 0xFFu), ((d >> 16) & 0xFFu), (d >> 24)));
+// Based on ps_convert_float32_rgba8 of convert
+// Convert a GL_FLOAT32 depth texture into a RGBA color texture
+#if HAS_CLIP_CONTROL
+	uint d = uint(fetch_c(uv).r * exp2(32.0f));
+#else
+	uint d = uint(fetch_c(uv).r * exp2(24.0f));
+#endif
+	t = vec4(uvec4((d & 0xFFu), ((d >> 8) & 0xFFu), ((d >> 16) & 0xFFu), (d >> 24)));
 
 #elif PS_DEPTH_FMT == 2
-    // Based on ps_convert_float16_rgb5a1 of convert
-    // Convert a GL_FLOAT32 (only 16 lsb) depth into a RGB5A1 color texture
-    #if HAS_CLIP_CONTROL
-      uint d = uint(fetch_c(uv).r * exp2(32.0f));
-    #else
-      uint d = uint(fetch_c(uv).r * exp2(24.0f));
-    #endif
-    t = vec4(uvec4((d & 0x1Fu), ((d >> 5) & 0x1Fu), ((d >> 10) & 0x1Fu), (d >> 15) & 0x01u)) * vec4(8.0f, 8.0f, 8.0f, 128.0f);
+// Based on ps_convert_float16_rgb5a1 of convert
+// Convert a GL_FLOAT32 (only 16 lsb) depth into a RGB5A1 color texture
+#if HAS_CLIP_CONTROL
+	uint d = uint(fetch_c(uv).r * exp2(32.0f));
+#else
+	uint d = uint(fetch_c(uv).r * exp2(24.0f));
+#endif
+	t = vec4(uvec4((d & 0x1Fu), ((d >> 5) & 0x1Fu), ((d >> 10) & 0x1Fu), (d >> 15) & 0x01u)) * vec4(8.0f, 8.0f, 8.0f, 128.0f);
 
 #elif PS_DEPTH_FMT == 3
-    // Convert a RGBA/RGB5A1 color texture into a RGBA/RGB5A1 color texture
-    t = fetch_c(uv) * 255.0f;
+	// Convert a RGBA/RGB5A1 color texture into a RGBA/RGB5A1 color texture
+	t = fetch_c(uv) * 255.0f;
 
 #endif
 
 
-    // warning t ranges from 0 to 255
+	// warning t ranges from 0 to 255
 #if (PS_AEM_FMT == FMT_24)
-    t.a = ( (PS_AEM == 0) || any(bvec3(t.rgb))  ) ? 255.0f * TA.x : 0.0f;
+	t.a = ((PS_AEM == 0) || any(bvec3(t.rgb))) ? 255.0f * TA.x : 0.0f;
 #elif (PS_AEM_FMT == FMT_16)
-    t.a = t.a >= 128.0f ? 255.0f * TA.y : ( (PS_AEM == 0) || any(bvec3(t.rgb)) ) ? 255.0f * TA.x : 0.0f;
+	t.a = t.a >= 128.0f ? 255.0f * TA.y : ((PS_AEM == 0) || any(bvec3(t.rgb))) ? 255.0f * TA.x :
+																				 0.0f;
 #endif
 
 
-    return t;
+	return t;
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -455,60 +456,60 @@ vec4 sample_depth(vec2 st)
 vec4 fetch_red()
 {
 #if PS_DEPTH_FMT == 1 || PS_DEPTH_FMT == 2
-    int depth = (fetch_raw_depth()) & 0xFF;
-    vec4 rt = vec4(depth) / 255.0f;
+	int depth = (fetch_raw_depth()) & 0xFF;
+	vec4 rt = vec4(depth) / 255.0f;
 #else
-    vec4 rt = fetch_raw_color();
+	vec4 rt = fetch_raw_color();
 #endif
-    return sample_p_norm(rt.r) * 255.0f;
+	return sample_p_norm(rt.r) * 255.0f;
 }
 
 vec4 fetch_green()
 {
 #if PS_DEPTH_FMT == 1 || PS_DEPTH_FMT == 2
-    int depth = (fetch_raw_depth() >> 8) & 0xFF;
-    vec4 rt = vec4(depth) / 255.0f;
+	int depth = (fetch_raw_depth() >> 8) & 0xFF;
+	vec4 rt = vec4(depth) / 255.0f;
 #else
-    vec4 rt = fetch_raw_color();
+	vec4 rt = fetch_raw_color();
 #endif
-    return sample_p_norm(rt.g) * 255.0f;
+	return sample_p_norm(rt.g) * 255.0f;
 }
 
 vec4 fetch_blue()
 {
 #if PS_DEPTH_FMT == 1 || PS_DEPTH_FMT == 2
-    int depth = (fetch_raw_depth() >> 16) & 0xFF;
-    vec4 rt = vec4(depth) / 255.0f;
+	int depth = (fetch_raw_depth() >> 16) & 0xFF;
+	vec4 rt = vec4(depth) / 255.0f;
 #else
-    vec4 rt = fetch_raw_color();
+	vec4 rt = fetch_raw_color();
 #endif
-    return sample_p_norm(rt.b) * 255.0f;
+	return sample_p_norm(rt.b) * 255.0f;
 }
 
 vec4 fetch_alpha()
 {
-    vec4 rt = fetch_raw_color();
-    return sample_p_norm(rt.a) * 255.0f;
+	vec4 rt = fetch_raw_color();
+	return sample_p_norm(rt.a) * 255.0f;
 }
 
 vec4 fetch_rgb()
 {
-    vec4 rt = fetch_raw_color();
-    vec4 c = vec4(sample_p_norm(rt.r).r, sample_p_norm(rt.g).g, sample_p_norm(rt.b).b, 1.0f);
-    return c * 255.0f;
+	vec4 rt = fetch_raw_color();
+	vec4 c = vec4(sample_p_norm(rt.r).r, sample_p_norm(rt.g).g, sample_p_norm(rt.b).b, 1.0f);
+	return c * 255.0f;
 }
 
 vec4 fetch_gXbY()
 {
 #if PS_DEPTH_FMT == 1 || PS_DEPTH_FMT == 2
-    int depth = fetch_raw_depth();
-    int bg = (depth >> (8 + ChannelShuffle.w)) & 0xFF;
-    return vec4(bg);
+	int depth = fetch_raw_depth();
+	int bg = (depth >> (8 + ChannelShuffle.w)) & 0xFF;
+	return vec4(bg);
 #else
-    ivec4 rt = ivec4(fetch_raw_color() * 255.0f);
-    int green = (rt.g >> ChannelShuffle.w) & ChannelShuffle.z;
-    int blue  = (rt.b << ChannelShuffle.y) & ChannelShuffle.x;
-    return vec4(green | blue);
+	ivec4 rt = ivec4(fetch_raw_color() * 255.0f);
+	int green = (rt.g >> ChannelShuffle.w) & ChannelShuffle.z;
+	int blue = (rt.b << ChannelShuffle.y) & ChannelShuffle.x;
+	return vec4(green | blue);
 #endif
 }
 
@@ -517,235 +518,240 @@ vec4 fetch_gXbY()
 vec4 sample_color(vec2 st)
 {
 #if (PS_TCOFFSETHACK == 1)
-    st += TC_OffsetHack.xy;
+	st += TC_OffsetHack.xy;
 #endif
 
-    vec4 t;
-    mat4 c;
-    vec2 dd;
+	vec4 t;
+	mat4 c;
+	vec2 dd;
 
-    // FIXME I'm not sure this condition is useful (I think code will be optimized)
+	// FIXME I'm not sure this condition is useful (I think code will be optimized)
 #if (PS_LTF == 0 && PS_AEM_FMT == FMT_32 && PS_PAL_FMT == 0 && PS_REGION_RECT == 0 && PS_WMS < 2 && PS_WMT < 2)
-    // No software LTF and pure 32 bits RGBA texure without special texture wrapping
-    c[0] = sample_c(st);
+	// No software LTF and pure 32 bits RGBA texure without special texture wrapping
+	c[0] = sample_c(st);
 #ifdef TEX_COORD_DEBUG
-    c[0].rg = st.xy;
+	c[0].rg = st.xy;
 #endif
 
 #else
-    vec4 uv;
+	vec4 uv;
 
-    if(PS_LTF != 0)
-    {
-        uv = st.xyxy + HalfTexel;
-        dd = fract(uv.xy * WH.zw);
+	if (PS_LTF != 0)
+	{
+		uv = st.xyxy + HalfTexel;
+		dd = fract(uv.xy * WH.zw);
 #if (PS_FST == 0)
-        // Background in Shin Megami Tensei Lucifers
-        // I suspect that uv isn't a standard number, so fract is outside of the [0;1] range
-        // Note: it is free on GPU but let's do it only for float coordinate
-        dd = clamp(dd, vec2(0.0f), vec2(1.0f));
+		// Background in Shin Megami Tensei Lucifers
+		// I suspect that uv isn't a standard number, so fract is outside of the [0;1] range
+		// Note: it is free on GPU but let's do it only for float coordinate
+		dd = clamp(dd, vec2(0.0f), vec2(1.0f));
 #endif
-    }
-    else
-    {
-        uv = st.xyxy;
-    }
+	}
+	else
+	{
+		uv = st.xyxy;
+	}
 
-    uv = clamp_wrap_uv(uv);
+	uv = clamp_wrap_uv(uv);
 
 #if PS_PAL_FMT != 0
-    c = sample_4p(sample_4_index(uv));
+	c = sample_4p(sample_4_index(uv));
 #else
-    c = sample_4c(uv);
+	c = sample_4c(uv);
 #endif
 
 #ifdef TEX_COORD_DEBUG
-    c[0].rg = uv.xy;
-    c[1].rg = uv.xy;
-    c[2].rg = uv.xy;
-    c[3].rg = uv.xy;
+	c[0].rg = uv.xy;
+	c[1].rg = uv.xy;
+	c[2].rg = uv.xy;
+	c[3].rg = uv.xy;
 #endif
 
 #endif
 
-    // PERF note: using dot product reduces by 1 the number of instruction
-    // but I'm not sure it is equivalent neither faster.
-    for (int i = 0; i < 4; i++)
-    {
-        //float sum = dot(c[i].rgb, vec3(1.0f));
+	// PERF note: using dot product reduces by 1 the number of instruction
+	// but I'm not sure it is equivalent neither faster.
+	for (int i = 0; i < 4; i++)
+	{
+		//float sum = dot(c[i].rgb, vec3(1.0f));
 #if (PS_AEM_FMT == FMT_24)
-            c[i].a = ( (PS_AEM == 0) || any(bvec3(c[i].rgb))  ) ? TA.x : 0.0f;
-            //c[i].a = ( (PS_AEM == 0) || (sum > 0.0f) ) ? TA.x : 0.0f;
+		c[i].a = ((PS_AEM == 0) || any(bvec3(c[i].rgb))) ? TA.x : 0.0f;
+		//c[i].a = ( (PS_AEM == 0) || (sum > 0.0f) ) ? TA.x : 0.0f;
 #elif (PS_AEM_FMT == FMT_16)
-            c[i].a = c[i].a >= 0.5 ? TA.y : ( (PS_AEM == 0) || any(bvec3(c[i].rgb)) ) ? TA.x : 0.0f;
-            //c[i].a = c[i].a >= 0.5 ? TA.y : ( (PS_AEM == 0) || (sum > 0.0f) ) ? TA.x : 0.0f;
+		c[i].a = c[i].a >= 0.5 ? TA.y : ((PS_AEM == 0) || any(bvec3(c[i].rgb))) ? TA.x :
+																				  0.0f;
+		//c[i].a = c[i].a >= 0.5 ? TA.y : ( (PS_AEM == 0) || (sum > 0.0f) ) ? TA.x : 0.0f;
 #endif
-    }
+	}
 
-#if(PS_LTF != 0)
-    t = mix(mix(c[0], c[1], dd.x), mix(c[2], c[3], dd.x), dd.y);
+#if (PS_LTF != 0)
+	t = mix(mix(c[0], c[1], dd.x), mix(c[2], c[3], dd.x), dd.y);
 #else
-    t = c[0];
+	t = c[0];
 #endif
 
-    // The 0.05f helps to fix the overbloom of sotc
-    // I think the issue is related to the rounding of texture coodinate. The linear (from fixed unit)
-    // interpolation could be slightly below the correct one.
-    return trunc(t * 255.0f + 0.05f);
+	// The 0.05f helps to fix the overbloom of sotc
+	// I think the issue is related to the rounding of texture coodinate. The linear (from fixed unit)
+	// interpolation could be slightly below the correct one.
+	return trunc(t * 255.0f + 0.05f);
 }
 
 #endif // NEEDS_TEX
 
 vec4 tfx(vec4 T, vec4 C)
 {
-    vec4 C_out;
-    vec4 FxT = trunc(trunc(C) * T / 128.0f);
+	vec4 C_out;
+	vec4 FxT = trunc(trunc(C) * T / 128.0f);
 
 #if (PS_TFX == 0)
-    C_out = FxT;
+	C_out = FxT;
 #elif (PS_TFX == 1)
-    C_out = T;
+	C_out = T;
 #elif (PS_TFX == 2)
-    C_out.rgb = FxT.rgb + C.a;
-    C_out.a = T.a + C.a;
+	C_out.rgb = FxT.rgb + C.a;
+	C_out.a = T.a + C.a;
 #elif (PS_TFX == 3)
-    C_out.rgb = FxT.rgb + C.a;
-    C_out.a = T.a;
+	C_out.rgb = FxT.rgb + C.a;
+	C_out.a = T.a;
 #else
-    C_out = C;
+	C_out = C;
 #endif
 
 #if (PS_TCC == 0)
-    C_out.a = C.a;
+	C_out.a = C.a;
 #endif
 
 #if (PS_TFX == 0) || (PS_TFX == 2) || (PS_TFX == 3)
-    // Clamp only when it is useful
-    C_out = min(C_out, 255.0f);
+	// Clamp only when it is useful
+	C_out = min(C_out, 255.0f);
 #endif
 
-    return C_out;
+	return C_out;
 }
 
 void atst(vec4 C)
 {
-    float a = C.a;
+	float a = C.a;
 
 #if (PS_ATST == 0)
-    // nothing to do
+	// nothing to do
 #elif (PS_ATST == 1)
-    if (a > AREF) discard;
+	if (a > AREF)
+		discard;
 #elif (PS_ATST == 2)
-    if (a < AREF) discard;
+	if (a < AREF)
+		discard;
 #elif (PS_ATST == 3)
-    if (abs(a - AREF) > 0.5f) discard;
+	if (abs(a - AREF) > 0.5f)
+		discard;
 #elif (PS_ATST == 4)
-    if (abs(a - AREF) < 0.5f) discard;
+	if (abs(a - AREF) < 0.5f)
+		discard;
 #endif
 }
 
 void fog(inout vec4 C, float f)
 {
 #if PS_FOG != 0
-    C.rgb = trunc(mix(FogColor, C.rgb, f));
+	C.rgb = trunc(mix(FogColor, C.rgb, f));
 #endif
 }
 
 vec4 ps_color()
 {
-    //FIXME: maybe we can set gl_Position.w = q in VS
+	//FIXME: maybe we can set gl_Position.w = q in VS
 #if (PS_FST == 0)
-    vec2 st = PSin.t_float.xy / vec2(PSin.t_float.w);
-    vec2 st_int = PSin.t_int.zw / vec2(PSin.t_float.w);
+	vec2 st = PSin.t_float.xy / vec2(PSin.t_float.w);
+	vec2 st_int = PSin.t_int.zw / vec2(PSin.t_float.w);
 #else
-    // Note xy are normalized coordinate
-    vec2 st = PSin.t_int.xy;
-    vec2 st_int = PSin.t_int.zw;
+	// Note xy are normalized coordinate
+	vec2 st = PSin.t_int.xy;
+	vec2 st_int = PSin.t_int.zw;
 #endif
 
 #if !NEEDS_TEX
-    vec4 T = vec4(0.0);
+	vec4 T = vec4(0.0);
 #elif PS_CHANNEL_FETCH == 1
-    vec4 T = fetch_red();
+	vec4 T = fetch_red();
 #elif PS_CHANNEL_FETCH == 2
-    vec4 T = fetch_green();
+	vec4 T = fetch_green();
 #elif PS_CHANNEL_FETCH == 3
-    vec4 T = fetch_blue();
+	vec4 T = fetch_blue();
 #elif PS_CHANNEL_FETCH == 4
-    vec4 T = fetch_alpha();
+	vec4 T = fetch_alpha();
 #elif PS_CHANNEL_FETCH == 5
-    vec4 T = fetch_rgb();
+	vec4 T = fetch_rgb();
 #elif PS_CHANNEL_FETCH == 6
-    vec4 T = fetch_gXbY();
+	vec4 T = fetch_gXbY();
 #elif PS_DEPTH_FMT > 0
-    // Integral coordinate
-    vec4 T = sample_depth(st_int);
+	// Integral coordinate
+	vec4 T = sample_depth(st_int);
 #else
-    vec4 T = sample_color(st);
+	vec4 T = sample_color(st);
 #endif
 
-    vec4 C = tfx(T, PSin.c);
+	vec4 C = tfx(T, PSin.c);
 
-    atst(C);
+	atst(C);
 
-    fog(C, PSin.t_float.z);
+	fog(C, PSin.t_float.z);
 
-    return C;
+	return C;
 }
 
 void ps_fbmask(inout vec4 C)
 {
-    // FIXME do I need special case for 16 bits
+	// FIXME do I need special case for 16 bits
 #if PS_FBMASK
-    vec4 RT = trunc(fetch_rt() * 255.0f + 0.1f);
-    C = vec4((uvec4(C) & ~FbMask) | (uvec4(RT) & FbMask));
+	vec4 RT = trunc(fetch_rt() * 255.0f + 0.1f);
+	C = vec4((uvec4(C) & ~FbMask) | (uvec4(RT) & FbMask));
 #endif
 }
 
 void ps_dither(inout vec3 C)
 {
 #if PS_DITHER
-    #if PS_DITHER == 2
-    ivec2 fpos = ivec2(gl_FragCoord.xy);
-    #else
-    ivec2 fpos = ivec2(gl_FragCoord.xy * RcpScaleFactor);
-    #endif
-    float value = DitherMatrix[fpos.y&3][fpos.x&3];
-    #if PS_ROUND_INV
-    C -= value;
-    #else
-    C += value;
-    #endif
+#if PS_DITHER == 2
+	ivec2 fpos = ivec2(gl_FragCoord.xy);
+#else
+	ivec2 fpos = ivec2(gl_FragCoord.xy * RcpScaleFactor);
+#endif
+	float value = DitherMatrix[fpos.y & 3][fpos.x & 3];
+#if PS_ROUND_INV
+	C -= value;
+#else
+	C += value;
+#endif
 #endif
 }
 
 void ps_color_clamp_wrap(inout vec3 C)
 {
-    // When dithering the bottom 3 bits become meaningless and cause lines in the picture
-    // so we need to limit the color depth on dithered items
+	// When dithering the bottom 3 bits become meaningless and cause lines in the picture
+	// so we need to limit the color depth on dithered items
 #if SW_BLEND || PS_DITHER || PS_FBMASK
 
 #if PS_DFMT == FMT_16 && PS_BLEND_MIX == 0 && PS_ROUND_INV
-    C += 7.0f; // Need to round up, not down since the shader will invert
+	C += 7.0f; // Need to round up, not down since the shader will invert
 #endif
 
-    // Correct the Color value based on the output format
+	// Correct the Color value based on the output format
 #if PS_COLCLIP == 0 && PS_HDR == 0
-    // Standard Clamp
-    C = clamp(C, vec3(0.0f), vec3(255.0f));
+	// Standard Clamp
+	C = clamp(C, vec3(0.0f), vec3(255.0f));
 #endif
 
-    // FIXME rouding of negative float?
-    // compiler uses trunc but it might need floor
+	// FIXME rouding of negative float?
+	// compiler uses trunc but it might need floor
 
-    // Warning: normally blending equation is mult(A, B) = A * B >> 7. GPU have the full accuracy
-    // GS: Color = 1, Alpha = 255 => output 1
-    // GPU: Color = 1/255, Alpha = 255/255 * 255/128 => output 1.9921875
+	// Warning: normally blending equation is mult(A, B) = A * B >> 7. GPU have the full accuracy
+	// GS: Color = 1, Alpha = 255 => output 1
+	// GPU: Color = 1/255, Alpha = 255/255 * 255/128 => output 1.9921875
 #if PS_DFMT == FMT_16 && PS_BLEND_MIX == 0
-    // In 16 bits format, only 5 bits of colors are used. It impacts shadows computation of Castlevania
-    C = vec3(ivec3(C) & ivec3(0xF8));
+	// In 16 bits format, only 5 bits of colors are used. It impacts shadows computation of Castlevania
+	C = vec3(ivec3(C) & ivec3(0xF8));
 #elif PS_COLCLIP == 1 || PS_HDR == 1
-    C = vec3(ivec3(C) & ivec3(0xFF));
+	C = vec3(ivec3(C) & ivec3(0xFF));
 #endif
 
 #endif
@@ -753,70 +759,70 @@ void ps_color_clamp_wrap(inout vec3 C)
 
 void ps_blend(inout vec4 Color, inout vec4 As_rgba)
 {
-float As = As_rgba.a;
+	float As = As_rgba.a;
 
 #if SW_BLEND
 
-    // PABE
+	// PABE
 #if PS_PABE
-    // No blending so early exit
-    if (As < 1.0f)
-        return;
+	// No blending so early exit
+	if (As < 1.0f)
+		return;
 #endif
 
-    vec3 Cs = Color.rgb;
+	vec3 Cs = Color.rgb;
 
 #if SW_BLEND_NEEDS_RT
-    vec4 RT = trunc(fetch_rt() * 255.0f + 0.1f);
-    // FIXME FMT_16 case
-    // FIXME Ad or Ad * 2?
-    float Ad = RT.a / 128.0f;
+	vec4 RT = trunc(fetch_rt() * 255.0f + 0.1f);
+	// FIXME FMT_16 case
+	// FIXME Ad or Ad * 2?
+	float Ad = RT.a / 128.0f;
 
-    // Let the compiler do its jobs !
-    vec3 Cd = RT.rgb;
+	// Let the compiler do its jobs !
+	vec3 Cd = RT.rgb;
 #endif
 
 #if PS_BLEND_A == 0
-    vec3 A = Cs;
+	vec3 A = Cs;
 #elif PS_BLEND_A == 1
-    vec3 A = Cd;
+	vec3 A = Cd;
 #else
-    vec3 A = vec3(0.0f);
+	vec3 A = vec3(0.0f);
 #endif
 
 #if PS_BLEND_B == 0
-    vec3 B = Cs;
+	vec3 B = Cs;
 #elif PS_BLEND_B == 1
-    vec3 B = Cd;
+	vec3 B = Cd;
 #else
-    vec3 B = vec3(0.0f);
+	vec3 B = vec3(0.0f);
 #endif
 
 #if PS_BLEND_C == 0
-    float C = As;
+	float C = As;
 #elif PS_BLEND_C == 1
-    float C = Ad;
+	float C = Ad;
 #else
-    float C = Af;
+	float C = Af;
 #endif
 
 #if PS_BLEND_D == 0
-    vec3 D = Cs;
+	vec3 D = Cs;
 #elif PS_BLEND_D == 1
-    vec3 D = Cd;
+	vec3 D = Cd;
 #else
-    vec3 D = vec3(0.0f);
+	vec3 D = vec3(0.0f);
 #endif
 
-    // As/Af clamp alpha for Blend mix
-    // We shouldn't clamp blend mix with blend hw 1 as we want alpha higher
-    float C_clamped = C;
+	// As/Af clamp alpha for Blend mix
+	// We shouldn't clamp blend mix with blend hw 1 as we want alpha higher
+	float C_clamped = C;
 #if PS_BLEND_MIX > 0 && PS_BLEND_HW != 1
-    C_clamped = min(C_clamped, 1.0f);
+	C_clamped = min(C_clamped, 1.0f);
 #endif
 
 #if PS_BLEND_A == PS_BLEND_B
-    Color.rgb = D;
+	Color.rgb = D;
 // In blend_mix, HW adds on some alpha factor * dst.
 // Truncating here wouldn't quite get the right result because it prevents the <1 bit here from combining with a <1 bit in dst to form a ≥1 amount that pushes over the truncation.
 // Instead, apply an offset to convert HW's round to a floor.
@@ -825,65 +831,65 @@ float As = As_rgba.a;
 // Based on the scripts at the above link, the ideal choice for Intel GPUs is 126/256, AMD 120/256.  Nvidia is a lost cause.
 // 124/256 seems like a reasonable compromise, providing the correct answer 99.3% of the time on Intel (vs 99.6% for 126/256), and 97% of the time on AMD (vs 97.4% for 120/256).
 #elif PS_BLEND_MIX == 2
-    Color.rgb = ((A - B) * C_clamped + D) + (124.0f/256.0f);
+	Color.rgb = ((A - B) * C_clamped + D) + (124.0f / 256.0f);
 #elif PS_BLEND_MIX == 1
-    Color.rgb = ((A - B) * C_clamped + D) - (124.0f/256.0f);
+	Color.rgb = ((A - B) * C_clamped + D) - (124.0f / 256.0f);
 #else
-    Color.rgb = trunc((A - B) * C + D);
+	Color.rgb = trunc((A - B) * C + D);
 #endif
 
 #if PS_BLEND_HW == 1
-    // As or Af
-    As_rgba.rgb = vec3(C);
-    // Subtract 1 for alpha to compensate for the changed equation,
-    // if c.rgb > 255.0f then we further need to adjust alpha accordingly,
-    // we pick the lowest overflow from all colors because it's the safest,
-    // we divide by 255 the color because we don't know Cd value,
-    // changed alpha should only be done for hw blend.
-    vec3 alpha_compensate = max(vec3(1.0f), Color.rgb / vec3(255.0f));
-    As_rgba.rgb -= alpha_compensate;
+	// As or Af
+	As_rgba.rgb = vec3(C);
+	// Subtract 1 for alpha to compensate for the changed equation,
+	// if c.rgb > 255.0f then we further need to adjust alpha accordingly,
+	// we pick the lowest overflow from all colors because it's the safest,
+	// we divide by 255 the color because we don't know Cd value,
+	// changed alpha should only be done for hw blend.
+	vec3 alpha_compensate = max(vec3(1.0f), Color.rgb / vec3(255.0f));
+	As_rgba.rgb -= alpha_compensate;
 #elif PS_BLEND_HW == 2
-    // Compensate slightly for Cd*(As + 1) - Cs*As.
-    // The initial factor we chose is 1 (0.00392)
-    // as that is the minimum color Cd can be,
-    // then we multiply by alpha to get the minimum
-    // blended value it can be.
-    float color_compensate = 1.0f * (C + 1.0f);
-    Color.rgb -= vec3(color_compensate);
+	// Compensate slightly for Cd*(As + 1) - Cs*As.
+	// The initial factor we chose is 1 (0.00392)
+	// as that is the minimum color Cd can be,
+	// then we multiply by alpha to get the minimum
+	// blended value it can be.
+	float color_compensate = 1.0f * (C + 1.0f);
+	Color.rgb -= vec3(color_compensate);
 #elif PS_BLEND_HW == 3
-    // As, Ad or Af clamped.
-    As_rgba.rgb = vec3(C_clamped);
-    // Cs*(Alpha + 1) might overflow, if it does then adjust alpha value
-    // that is sent on second output to compensate.
-    vec3 overflow_check = (Color.rgb - vec3(255.0f)) / 255.0f;
-    vec3 alpha_compensate = max(vec3(0.0f), overflow_check);
-    As_rgba.rgb -= alpha_compensate;
+	// As, Ad or Af clamped.
+	As_rgba.rgb = vec3(C_clamped);
+	// Cs*(Alpha + 1) might overflow, if it does then adjust alpha value
+	// that is sent on second output to compensate.
+	vec3 overflow_check = (Color.rgb - vec3(255.0f)) / 255.0f;
+	vec3 alpha_compensate = max(vec3(0.0f), overflow_check);
+	As_rgba.rgb -= alpha_compensate;
 #endif
 
 #else
-    // Needed for Cd * (As/Ad/F + 1) blending modes
+	// Needed for Cd * (As/Ad/F + 1) blending modes
 #if PS_BLEND_HW == 1
-    Color.rgb = vec3(255.0f);
+	Color.rgb = vec3(255.0f);
 #elif PS_BLEND_HW == 2
-    // Cd*As,Cd*Ad or Cd*F
+	// Cd*As,Cd*Ad or Cd*F
 
 #if PS_BLEND_C == 2
-    float Alpha = Af;
+	float Alpha = Af;
 #else
-    float Alpha = As;
+	float Alpha = As;
 #endif
 
-    Color.rgb = max(vec3(0.0f), (Alpha - vec3(1.0f)));
-    Color.rgb *= vec3(255.0f);
+	Color.rgb = max(vec3(0.0f), (Alpha - vec3(1.0f)));
+	Color.rgb *= vec3(255.0f);
 #elif PS_BLEND_HW == 3
-    // Needed for Cs*Ad, Cs*Ad + Cd, Cd - Cs*Ad
-    // Multiply Color.rgb by (255/128) to compensate for wrong Ad/255 value when rgb are below 128.
-    // When any color channel is higher than 128 then adjust the compensation automatically
-    // to give us more accurate colors, otherwise they will be wrong.
-    // The higher the value (>128) the lower the compensation will be.
-    float max_color = max(max(Color.r, Color.g), Color.b);
-    float color_compensate = 255.0f / max(128.0f, max_color);
-    Color.rgb *= vec3(color_compensate);
+	// Needed for Cs*Ad, Cs*Ad + Cd, Cd - Cs*Ad
+	// Multiply Color.rgb by (255/128) to compensate for wrong Ad/255 value when rgb are below 128.
+	// When any color channel is higher than 128 then adjust the compensation automatically
+	// to give us more accurate colors, otherwise they will be wrong.
+	// The higher the value (>128) the lower the compensation will be.
+	float max_color = max(max(Color.r, Color.g), Color.b);
+	float color_compensate = 255.0f / max(128.0f, max_color);
+	Color.rgb *= vec3(color_compensate);
 #endif
 
 #endif
@@ -892,49 +898,51 @@ float As = As_rgba.a;
 void ps_main()
 {
 #if PS_SCANMSK & 2
-    // fail depth test on prohibited lines
- 	if ((int(gl_FragCoord.y) & 1) == (PS_SCANMSK & 1))
- 	 	discard;
+	// fail depth test on prohibited lines
+	if ((int(gl_FragCoord.y) & 1) == (PS_SCANMSK & 1))
+		discard;
 #endif
 
 #if PS_DATE >= 5
 
 #if PS_WRITE_RG == 1
-    // Pseudo 16 bits access.
-    float rt_a = fetch_rt().g;
+	// Pseudo 16 bits access.
+	float rt_a = fetch_rt().g;
 #else
-    float rt_a = fetch_rt().a;
+	float rt_a = fetch_rt().a;
 #endif
 
 #if (PS_DATE & 3) == 1
-    // DATM == 0: Pixel with alpha equal to 1 will failed
-    bool bad = (127.5f / 255.0f) < rt_a;
+	// DATM == 0: Pixel with alpha equal to 1 will failed
+	bool bad = (127.5f / 255.0f) < rt_a;
 #elif (PS_DATE & 3) == 2
-    // DATM == 1: Pixel with alpha equal to 0 will failed
-    bool bad = rt_a < (127.5f / 255.0f);
+	// DATM == 1: Pixel with alpha equal to 0 will failed
+	bool bad = rt_a < (127.5f / 255.0f);
 #endif
 
-    if (bad) {
-        discard;
-    }
+	if (bad)
+	{
+		discard;
+	}
 
 #endif
 
 #if PS_DATE == 3
-    int stencil_ceil = int(texelFetch(img_prim_min, ivec2(gl_FragCoord.xy), 0).r);
-    // Note gl_PrimitiveID == stencil_ceil will be the primitive that will update
-    // the bad alpha value so we must keep it.
+	int stencil_ceil = int(texelFetch(img_prim_min, ivec2(gl_FragCoord.xy), 0).r);
+	// Note gl_PrimitiveID == stencil_ceil will be the primitive that will update
+	// the bad alpha value so we must keep it.
 
-    if (gl_PrimitiveID > stencil_ceil) {
-        discard;
-    }
+	if (gl_PrimitiveID > stencil_ceil)
+	{
+		discard;
+	}
 #endif
 
-    vec4 C = ps_color();
+	vec4 C = ps_color();
 
 #if PS_SHUFFLE
-    uvec4 denorm_c = uvec4(C);
-    uvec2 denorm_TA = uvec2(vec2(TA.xy) * 255.0f + 0.5f);
+	uvec4 denorm_c = uvec4(C);
+	uvec2 denorm_TA = uvec2(vec2(TA.xy) * 255.0f + 0.5f);
 #if PS_READ16_SRC
 	C.rb = vec2(float((denorm_c.r >> 3) | (((denorm_c.g >> 3) & 0x7u) << 5)));
 	if (bool(denorm_c.a & 0x80u))
@@ -942,107 +950,108 @@ void ps_main()
 	else
 		C.ga = vec2(float((denorm_c.g >> 6) | ((denorm_c.b >> 3) << 2) | (denorm_TA.x & 0x80u)));
 #else
-    // Write RB part. Mask will take care of the correct destination
+	// Write RB part. Mask will take care of the correct destination
 #if PS_READ_BA
-    C.rb = C.bb;
+	C.rb = C.bb;
 #else
-    C.rb = C.rr;
+	C.rb = C.rr;
 #endif
 
-    // FIXME precompute my_TA & 0x80
+	// FIXME precompute my_TA & 0x80
 
-    // Write GA part. Mask will take care of the correct destination
-    // Note: GLSL 4.50/GL_EXT_shader_integer_mix support a mix instruction to select a component\n"
-    // However Nvidia emulate it with an if (at least on kepler arch) ...\n"
+	// Write GA part. Mask will take care of the correct destination
+	// Note: GLSL 4.50/GL_EXT_shader_integer_mix support a mix instruction to select a component\n"
+	// However Nvidia emulate it with an if (at least on kepler arch) ...\n"
 #if PS_READ_BA
-    // bit field operation requires GL4 HW. Could be nice to merge it with step/mix below
-    // uint my_ta = (bool(bitfieldExtract(denorm_c.a, 7, 1))) ? denorm_TA.y : denorm_TA.x;
-    // denorm_c.a = bitfieldInsert(denorm_c.a, bitfieldExtract(my_ta, 7, 1), 7, 1);
-    // c.ga = vec2(float(denorm_c.a));
+	// bit field operation requires GL4 HW. Could be nice to merge it with step/mix below
+	// uint my_ta = (bool(bitfieldExtract(denorm_c.a, 7, 1))) ? denorm_TA.y : denorm_TA.x;
+	// denorm_c.a = bitfieldInsert(denorm_c.a, bitfieldExtract(my_ta, 7, 1), 7, 1);
+	// c.ga = vec2(float(denorm_c.a));
 
-    if (bool(denorm_c.a & 0x80u))
-        C.ga = vec2(float((denorm_c.a & 0x7Fu) | (denorm_TA.y & 0x80u)));
-    else
-        C.ga = vec2(float((denorm_c.a & 0x7Fu) | (denorm_TA.x & 0x80u)));
+	if (bool(denorm_c.a & 0x80u))
+		C.ga = vec2(float((denorm_c.a & 0x7Fu) | (denorm_TA.y & 0x80u)));
+	else
+		C.ga = vec2(float((denorm_c.a & 0x7Fu) | (denorm_TA.x & 0x80u)));
 
 #else
-    if (bool(denorm_c.g & 0x80u))
-        C.ga = vec2(float((denorm_c.g & 0x7Fu) | (denorm_TA.y & 0x80u)));
-    else
-        C.ga = vec2(float((denorm_c.g & 0x7Fu) | (denorm_TA.x & 0x80u)));
+	if (bool(denorm_c.g & 0x80u))
+		C.ga = vec2(float((denorm_c.g & 0x7Fu) | (denorm_TA.y & 0x80u)));
+	else
+		C.ga = vec2(float((denorm_c.g & 0x7Fu) | (denorm_TA.x & 0x80u)));
 
-    // Nice idea but step/mix requires 4 instructions
-    // set / trunc / I2F / Mad
-    //
-    // float sel = step(128.0f, c.g);
-    // vec2 c_shuffle = vec2((denorm_c.gg & 0x7Fu) | (denorm_TA & 0x80u));
-    // c.ga = mix(c_shuffle.xx, c_shuffle.yy, sel);
+		// Nice idea but step/mix requires 4 instructions
+		// set / trunc / I2F / Mad
+		//
+		// float sel = step(128.0f, c.g);
+		// vec2 c_shuffle = vec2((denorm_c.gg & 0x7Fu) | (denorm_TA & 0x80u));
+		// c.ga = mix(c_shuffle.xx, c_shuffle.yy, sel);
 #endif // PS_READ_BA
 
 #endif // READ16_SRC
 #endif // PS_SHUFFLE
 
-    // Must be done before alpha correction
+		// Must be done before alpha correction
 
-   // AA (Fixed one) will output a coverage of 1.0 as alpha
+		// AA (Fixed one) will output a coverage of 1.0 as alpha
 #if PS_FIXED_ONE_A
-   C.a = 128.0f;
+	C.a = 128.0f;
 #endif
 
 #if SW_AD_TO_HW
-    vec4 RT = trunc(fetch_rt() * 255.0f + 0.1f);
-    vec4 alpha_blend = vec4(RT.a / 128.0f);
+	vec4 RT = trunc(fetch_rt() * 255.0f + 0.1f);
+	vec4 alpha_blend = vec4(RT.a / 128.0f);
 #else
-    vec4 alpha_blend = vec4(C.a / 128.0f);
+	vec4 alpha_blend = vec4(C.a / 128.0f);
 #endif
 
-    // Correct the ALPHA value based on the output format
+	// Correct the ALPHA value based on the output format
 #if (PS_DFMT == FMT_16)
-    float A_one = 128.0f; // alpha output will be 0x80
-    C.a = (PS_FBA != 0) ? A_one : step(128.0f, C.a) * A_one;
+	float A_one = 128.0f; // alpha output will be 0x80
+	C.a = (PS_FBA != 0) ? A_one : step(128.0f, C.a) * A_one;
 #elif (PS_DFMT == FMT_32) && (PS_FBA != 0)
-    if(C.a < 128.0f) C.a += 128.0f;
+	if (C.a < 128.0f)
+		C.a += 128.0f;
 #endif
 
-    // Get first primitive that will write a failling alpha value
+	// Get first primitive that will write a failling alpha value
 #if PS_DATE == 1
-    // DATM == 0
-    // Pixel with alpha equal to 1 will failed (128-255)
-    SV_Target0 = (C.a > 127.5f) ? vec4(gl_PrimitiveID) : vec4(0x7FFFFFFF);
-    return;
+	// DATM == 0
+	// Pixel with alpha equal to 1 will failed (128-255)
+	SV_Target0 = (C.a > 127.5f) ? vec4(gl_PrimitiveID) : vec4(0x7FFFFFFF);
+	return;
 #elif PS_DATE == 2
-    // DATM == 1
-    // Pixel with alpha equal to 0 will failed (0-127)
-    SV_Target0 = (C.a < 127.5f) ? vec4(gl_PrimitiveID) : vec4(0x7FFFFFFF);
-    return;
+	// DATM == 1
+	// Pixel with alpha equal to 0 will failed (0-127)
+	SV_Target0 = (C.a < 127.5f) ? vec4(gl_PrimitiveID) : vec4(0x7FFFFFFF);
+	return;
 #endif
 
-    ps_blend(C, alpha_blend);
+	ps_blend(C, alpha_blend);
 
-    ps_dither(C.rgb);
+	ps_dither(C.rgb);
 
-    // Color clamp/wrap needs to be done after sw blending and dithering
-    ps_color_clamp_wrap(C.rgb);
+	// Color clamp/wrap needs to be done after sw blending and dithering
+	ps_color_clamp_wrap(C.rgb);
 
-    ps_fbmask(C);
+	ps_fbmask(C);
 
 #if !PS_NO_COLOR
 #if PS_HDR == 1
-    SV_Target0 = vec4(C.rgb / 65535.0f, C.a / 255.0f);
+	SV_Target0 = vec4(C.rgb / 65535.0f, C.a / 255.0f);
 #else
-    SV_Target0 = C / 255.0f;
+	SV_Target0 = C / 255.0f;
 #endif
 #if !defined(DISABLE_DUAL_SOURCE) && !PS_NO_COLOR1
-    SV_Target1 = alpha_blend;
+	SV_Target1 = alpha_blend;
 #endif
 
 #if PS_NO_ABLEND
-    // write alpha blend factor into col0
-    SV_Target0.a = alpha_blend.a;
+	// write alpha blend factor into col0
+	SV_Target0.a = alpha_blend.a;
 #endif
 #if PS_ONLY_ALPHA
-    // rgb isn't used
-    SV_Target0.rgb = vec3(0.0f);
+	// rgb isn't used
+	SV_Target0.rgb = vec3(0.0f);
 #endif
 #endif
 

--- a/bin/resources/shaders/opengl/tfx_vgs.glsl
+++ b/bin/resources/shaders/opengl/tfx_vgs.glsl
@@ -2,93 +2,94 @@
 
 layout(std140, binding = 1) uniform cb20
 {
-    vec2  VertexScale;
-    vec2  VertexOffset;
+	vec2 VertexScale;
+	vec2 VertexOffset;
 
-    vec2  TextureScale;
-    vec2  TextureOffset;
+	vec2 TextureScale;
+	vec2 TextureOffset;
 
-    vec2  PointSize;
-    uint  MaxDepth;
-    uint  pad_cb20;
+	vec2 PointSize;
+	uint MaxDepth;
+	uint pad_cb20;
 };
 
 #ifdef VERTEX_SHADER
-layout(location = 0) in vec2  i_st;
-layout(location = 2) in vec4  i_c;
+layout(location = 0) in vec2 i_st;
+layout(location = 2) in vec4 i_c;
 layout(location = 3) in float i_q;
 layout(location = 4) in uvec2 i_p;
-layout(location = 5) in uint  i_z;
+layout(location = 5) in uint i_z;
 layout(location = 6) in uvec2 i_uv;
-layout(location = 7) in vec4  i_f;
+layout(location = 7) in vec4 i_f;
 
 out SHADER
 {
-    vec4 t_float;
-    vec4 t_int;
-    #if VS_IIP != 0
-      vec4 c;
-    #else
-      flat vec4 c;
-    #endif
-} VSout;
+	vec4 t_float;
+	vec4 t_int;
+#if VS_IIP != 0
+	vec4 c;
+#else
+	flat vec4 c;
+#endif
+}
+VSout;
 
 const float exp_min32 = exp2(-32.0f);
 
 void texture_coord()
 {
-    vec2 uv = vec2(i_uv) - TextureOffset;
-    vec2 st = i_st - TextureOffset;
+	vec2 uv = vec2(i_uv) - TextureOffset;
+	vec2 st = i_st - TextureOffset;
 
-    // Float coordinate
-    VSout.t_float.xy = st;
-    VSout.t_float.w  = i_q;
+	// Float coordinate
+	VSout.t_float.xy = st;
+	VSout.t_float.w = i_q;
 
-    // Integer coordinate => normalized
-    VSout.t_int.xy = uv * TextureScale;
+	// Integer coordinate => normalized
+	VSout.t_int.xy = uv * TextureScale;
 #if VS_FST
-    // Integer coordinate => integral
-    VSout.t_int.zw = uv;
+	// Integer coordinate => integral
+	VSout.t_int.zw = uv;
 #else
-    // Some games uses float coordinate for post-processing effect
-    VSout.t_int.zw = st / TextureScale;
+	// Some games uses float coordinate for post-processing effect
+	VSout.t_int.zw = st / TextureScale;
 #endif
 }
 
 void vs_main()
 {
-    // Clamp to max depth, gs doesn't wrap
-    highp uint z = min(i_z, MaxDepth);
+	// Clamp to max depth, gs doesn't wrap
+	highp uint z = min(i_z, MaxDepth);
 
-    // pos -= 0.05 (1/320 pixel) helps avoiding rounding problems (integral part of pos is usually 5 digits, 0.05 is about as low as we can go)
-    // example: ceil(afterseveralvertextransformations(y = 133)) => 134 => line 133 stays empty
-    // input granularity is 1/16 pixel, anything smaller than that won't step drawing up/left by one pixel
-    // example: 133.0625 (133 + 1/16) should start from line 134, ceil(133.0625 - 0.05) still above 133
-    vec4 p;
+	// pos -= 0.05 (1/320 pixel) helps avoiding rounding problems (integral part of pos is usually 5 digits, 0.05 is about as low as we can go)
+	// example: ceil(afterseveralvertextransformations(y = 133)) => 134 => line 133 stays empty
+	// input granularity is 1/16 pixel, anything smaller than that won't step drawing up/left by one pixel
+	// example: 133.0625 (133 + 1/16) should start from line 134, ceil(133.0625 - 0.05) still above 133
+	vec4 p;
 
-    p.xy = vec2(i_p) - vec2(0.05f, 0.05f);
-    p.xy = p.xy * VertexScale - VertexOffset;
-    p.w = 1.0f;
+	p.xy = vec2(i_p) - vec2(0.05f, 0.05f);
+	p.xy = p.xy * VertexScale - VertexOffset;
+	p.w = 1.0f;
 
 #if HAS_CLIP_CONTROL
-    p.z = float(z) * exp_min32;
+	p.z = float(z) * exp_min32;
 #else
-    // GLES doesn't support ARB_clip_control, so remap it to -1..1. We also reduce the range from 32 bits
-    // to 24 bits, which means some games with very large depth ranges will not render correctly. But,
-    // for most, it's okay, and really, the best we can do.
-    p.z = min(float(z) * exp2(-23.0f), 2.0f) - 1.0f;
+	// GLES doesn't support ARB_clip_control, so remap it to -1..1. We also reduce the range from 32 bits
+	// to 24 bits, which means some games with very large depth ranges will not render correctly. But,
+	// for most, it's okay, and really, the best we can do.
+	p.z = min(float(z) * exp2(-23.0f), 2.0f) - 1.0f;
 #endif
 
-    gl_Position = p;
+	gl_Position = p;
 
-    texture_coord();
+	texture_coord();
 
-    VSout.c = i_c;
-    VSout.t_float.z = i_f.x; // pack for with texture
+	VSout.c = i_c;
+	VSout.t_float.z = i_f.x; // pack for with texture
 
-    #if VS_POINT_SIZE
-        gl_PointSize = PointSize.x;
-    #endif
+#if VS_POINT_SIZE
+	gl_PointSize = PointSize.x;
+#endif
 }
 
 #endif
@@ -97,46 +98,48 @@ void vs_main()
 
 in SHADER
 {
-    vec4 t_float;
-    vec4 t_int;
-    #if GS_IIP != 0
-      vec4 c;
-    #else
-      flat vec4 c;
-    #endif
-} GSin[];
+	vec4 t_float;
+	vec4 t_int;
+#if GS_IIP != 0
+	vec4 c;
+#else
+	flat vec4 c;
+#endif
+}
+GSin[];
 
 out SHADER
 {
-    vec4 t_float;
-    vec4 t_int;
-    #if GS_IIP != 0
-      vec4 c;
-    #else
-      flat vec4 c;
-    #endif
-} GSout;
+	vec4 t_float;
+	vec4 t_int;
+#if GS_IIP != 0
+	vec4 c;
+#else
+	flat vec4 c;
+#endif
+}
+GSout;
 
 struct vertex
 {
-    vec4 t_float;
-    vec4 t_int;
-    vec4 c;
+	vec4 t_float;
+	vec4 t_int;
+	vec4 c;
 };
 
 void out_vertex(in vec4 position, in vertex v)
 {
-    GSout.t_float  = v.t_float;
-    GSout.t_int    = v.t_int;
-    // Flat output
+	GSout.t_float = v.t_float;
+	GSout.t_int = v.t_int;
+	// Flat output
 #if GS_PRIM == 0
-    GSout.c        = GSin[0].c;
+	GSout.c = GSin[0].c;
 #else
-    GSout.c        = GSin[1].c;
+	GSout.c = GSin[1].c;
 #endif
-    gl_Position = position;
-    gl_PrimitiveID = gl_PrimitiveIDIn;
-    EmitVertex();
+	gl_Position = position;
+	gl_PrimitiveID = gl_PrimitiveIDIn;
+	EmitVertex();
 }
 
 #if GS_PRIM == 0
@@ -150,102 +153,102 @@ layout(triangle_strip, max_vertices = 4) out;
 
 void gs_main()
 {
-    // Transform a point to a NxN sprite
-    vertex point = vertex(GSin[0].t_float, GSin[0].t_int, GSin[0].c);
+	// Transform a point to a NxN sprite
+	vertex point = vertex(GSin[0].t_float, GSin[0].t_int, GSin[0].c);
 
-    // Get new position
-    vec4 lt_p = gl_in[0].gl_Position;
-    vec4 rb_p = gl_in[0].gl_Position + vec4(PointSize.x, PointSize.y, 0.0f, 0.0f);
-    vec4 lb_p = rb_p;
-    vec4 rt_p = rb_p;
-    lb_p.x    = lt_p.x;
-    rt_p.y    = lt_p.y;
+	// Get new position
+	vec4 lt_p = gl_in[0].gl_Position;
+	vec4 rb_p = gl_in[0].gl_Position + vec4(PointSize.x, PointSize.y, 0.0f, 0.0f);
+	vec4 lb_p = rb_p;
+	vec4 rt_p = rb_p;
+	lb_p.x = lt_p.x;
+	rt_p.y = lt_p.y;
 
-    out_vertex(lt_p, point);
+	out_vertex(lt_p, point);
 
-    out_vertex(lb_p, point);
+	out_vertex(lb_p, point);
 
-    out_vertex(rt_p, point);
+	out_vertex(rt_p, point);
 
-    out_vertex(rb_p, point);
+	out_vertex(rb_p, point);
 
-    EndPrimitive();
+	EndPrimitive();
 }
 
 #elif GS_PRIM == 1
 
 void gs_main()
 {
-    // Transform a line to a thick line-sprite
-    vertex left  = vertex(GSin[0].t_float, GSin[0].t_int, GSin[0].c);
-    vertex right = vertex(GSin[1].t_float, GSin[1].t_int, GSin[1].c);
-    vec4 lt_p = gl_in[0].gl_Position;
-    vec4 rt_p = gl_in[1].gl_Position;
+	// Transform a line to a thick line-sprite
+	vertex left = vertex(GSin[0].t_float, GSin[0].t_int, GSin[0].c);
+	vertex right = vertex(GSin[1].t_float, GSin[1].t_int, GSin[1].c);
+	vec4 lt_p = gl_in[0].gl_Position;
+	vec4 rt_p = gl_in[1].gl_Position;
 
-    // Potentially there is faster math
-    vec2 line_vector = normalize(rt_p.xy - lt_p.xy);
-    vec2 line_normal = vec2(line_vector.y, -line_vector.x);
-    vec2 line_width  = (line_normal * PointSize) / 2.0f;
+	// Potentially there is faster math
+	vec2 line_vector = normalize(rt_p.xy - lt_p.xy);
+	vec2 line_normal = vec2(line_vector.y, -line_vector.x);
+	vec2 line_width = (line_normal * PointSize) / 2.0f;
 
-    lt_p.xy -= line_width;
-    rt_p.xy -= line_width;
-    vec4 lb_p = gl_in[0].gl_Position + vec4(line_width, 0.0f, 0.0f);
-    vec4 rb_p = gl_in[1].gl_Position + vec4(line_width, 0.0f, 0.0f);
+	lt_p.xy -= line_width;
+	rt_p.xy -= line_width;
+	vec4 lb_p = gl_in[0].gl_Position + vec4(line_width, 0.0f, 0.0f);
+	vec4 rb_p = gl_in[1].gl_Position + vec4(line_width, 0.0f, 0.0f);
 
-    out_vertex(lt_p, left);
+	out_vertex(lt_p, left);
 
-    out_vertex(lb_p, left);
+	out_vertex(lb_p, left);
 
-    out_vertex(rt_p, right);
+	out_vertex(rt_p, right);
 
-    out_vertex(rb_p, right);
+	out_vertex(rb_p, right);
 
-    EndPrimitive();
+	EndPrimitive();
 }
 
 #else // GS_PRIM == 3
 
 void gs_main()
 {
-    // left top     => GSin[0];
-    // right bottom => GSin[1];
-    vertex rb = vertex(GSin[1].t_float, GSin[1].t_int, GSin[1].c);
-    vertex lt = vertex(GSin[0].t_float, GSin[0].t_int, GSin[0].c);
+	// left top	 => GSin[0];
+	// right bottom => GSin[1];
+	vertex rb = vertex(GSin[1].t_float, GSin[1].t_int, GSin[1].c);
+	vertex lt = vertex(GSin[0].t_float, GSin[0].t_int, GSin[0].c);
 
-    vec4 rb_p = gl_in[1].gl_Position;
-    vec4 lb_p = rb_p;
-    vec4 rt_p = rb_p;
-    vec4 lt_p = gl_in[0].gl_Position;
+	vec4 rb_p = gl_in[1].gl_Position;
+	vec4 lb_p = rb_p;
+	vec4 rt_p = rb_p;
+	vec4 lt_p = gl_in[0].gl_Position;
 
-    // flat depth
-    lt_p.z = rb_p.z;
-    // flat fog and texture perspective
-    lt.t_float.zw = rb.t_float.zw;
-    // flat color
-    lt.c = rb.c;
+	// flat depth
+	lt_p.z = rb_p.z;
+	// flat fog and texture perspective
+	lt.t_float.zw = rb.t_float.zw;
+	// flat color
+	lt.c = rb.c;
 
-    // Swap texture and position coordinate
-    vertex lb    = rb;
-    lb.t_float.x = lt.t_float.x;
-    lb.t_int.x   = lt.t_int.x;
-    lb.t_int.z   = lt.t_int.z;
-    lb_p.x       = lt_p.x;
+	// Swap texture and position coordinate
+	vertex lb = rb;
+	lb.t_float.x = lt.t_float.x;
+	lb.t_int.x = lt.t_int.x;
+	lb.t_int.z = lt.t_int.z;
+	lb_p.x = lt_p.x;
 
-    vertex rt    = rb;
-    rt_p.y       = lt_p.y;
-    rt.t_float.y = lt.t_float.y;
-    rt.t_int.y   = lt.t_int.y;
-    rt.t_int.w   = lt.t_int.w;
+	vertex rt = rb;
+	rt_p.y = lt_p.y;
+	rt.t_float.y = lt.t_float.y;
+	rt.t_int.y = lt.t_int.y;
+	rt.t_int.w = lt.t_int.w;
 
-    out_vertex(lt_p, lt);
+	out_vertex(lt_p, lt);
 
-    out_vertex(lb_p, lb);
+	out_vertex(lb_p, lb);
 
-    out_vertex(rt_p, rt);
+	out_vertex(rt_p, rt);
 
-    out_vertex(rb_p, rb);
+	out_vertex(rb_p, rb);
 
-    EndPrimitive();
+	EndPrimitive();
 }
 
 #endif

--- a/pcsx2/pcsx2core.vcxproj
+++ b/pcsx2/pcsx2core.vcxproj
@@ -88,7 +88,6 @@
     <None Include="..\bin\resources\shaders\vulkan\interlace.glsl" />
     <None Include="..\bin\resources\shaders\vulkan\merge.glsl" />
     <None Include="..\bin\resources\shaders\vulkan\tfx.glsl" />
-    <None Include="..\bin\resources\shaders\opengl\common_header.glsl" />
     <None Include="..\bin\resources\shaders\opengl\convert.glsl" />
     <None Include="..\bin\resources\shaders\opengl\interlace.glsl" />
     <None Include="..\bin\resources\shaders\opengl\merge.glsl" />

--- a/pcsx2/pcsx2core.vcxproj.filters
+++ b/pcsx2/pcsx2core.vcxproj.filters
@@ -336,9 +336,6 @@
     <None Include="..\bin\resources\shaders\opengl\shadeboost.glsl">
       <Filter>System\Ps2\GS\Shaders\OpenGL</Filter>
     </None>
-    <None Include="..\bin\resources\shaders\opengl\common_header.glsl">
-      <Filter>System\Ps2\GS\Shaders\OpenGL</Filter>
-    </None>
     <None Include="..\bin\resources\shaders\common\fxaa.fx">
       <Filter>System\Ps2\GS\Shaders\Common</Filter>
     </None>


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS/Build: Cleanup opengl glsl shaders.
Clang format and remove common_header.glsl mention from filter list, no longer exists.
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Cleanup.
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Opengl still works.