### PR TITLE
Qt: Hide SDL Raw option on non win32 builds

### DIFF
--- a/pcsx2-qt/Settings/ControllerGlobalSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/ControllerGlobalSettingsWidget.cpp
@@ -62,6 +62,7 @@ ControllerGlobalSettingsWidget::ControllerGlobalSettingsWidget(QWidget* parent, 
 	m_ui.mainLayout->removeWidget(m_ui.dinputGroup);
 	m_ui.dinputGroup->deleteLater();
 	m_ui.dinputGroup = nullptr;
+	m_ui.enableSDLRawInput->hide();
 #endif
 
 	if (dialog->isEditingProfile())


### PR DESCRIPTION
### Description of Changes
Hide the option introduced in #8526 when not applicable.

### Rationale behind Changes
Has no effect on non win32 SDL builds to makes sense to hide it.

### Suggested Testing Steps
Controller config shouldn't go boom and everyone but windows users should not see it.
