### PR TITLE
GS: Use 16-bit indices instead of 32-bit

### DIFF
--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -2616,31 +2616,31 @@ void GSState::GrowVertexBuffer()
 {
 	const u32 maxcount = std::max<u32>(m_vertex.maxcount * 3 / 2, 10000);
 
-	GSVertex* vertex = (GSVertex*)_aligned_malloc(sizeof(GSVertex) * maxcount, 32);
+	GSVertex* vertex = static_cast<GSVertex*>(_aligned_malloc(sizeof(GSVertex) * maxcount, 32));
 	// Worst case index list is a list of points with vs expansion, 6 indices per point
-	u32* index = (u32*)_aligned_malloc(sizeof(u32) * maxcount * 6, 32);
+	u16* index = static_cast<u16*>(_aligned_malloc(sizeof(u16) * maxcount * 6, 32));
 
-	if (vertex == NULL || index == NULL)
+	if (!vertex || !index)
 	{
 		const u32 vert_byte_count = sizeof(GSVertex) * maxcount;
-		const u32 idx_byte_count = sizeof(u32) * maxcount * 3;
+		const u32 idx_byte_count = sizeof(u16) * maxcount * 3;
 
-		Console.Error("GS: failed to allocate %zu bytes for verticles and %zu for indices.",
+		Console.Error("GS: failed to allocate %zu bytes for vertices and %zu for indices.",
 			vert_byte_count, idx_byte_count);
 
 		throw GSError();
 	}
 
-	if (m_vertex.buff != NULL)
+	if (m_vertex.buff)
 	{
-		memcpy(vertex, m_vertex.buff, sizeof(GSVertex) * m_vertex.tail);
+		std::memcpy(vertex, m_vertex.buff, sizeof(GSVertex) * m_vertex.tail);
 
 		_aligned_free(m_vertex.buff);
 	}
 
-	if (m_index.buff != NULL)
+	if (m_index.buff)
 	{
-		memcpy(index, m_index.buff, sizeof(u32) * m_index.tail);
+		std::memcpy(index, m_index.buff, sizeof(u16) * m_index.tail);
 
 		_aligned_free(m_index.buff);
 	}
@@ -3041,21 +3041,24 @@ static constexpr u32 MaxVerticesForPrim(u32 prim)
 {
 	switch (prim)
 	{
+			// Four indices per 1 vertex.
 		case GS_POINTLIST:
 		case GS_INVALID:
-			// Needed due to expansion in hardware renderers.
+
+			// Indices are shifted left by 2 to form quads.
+		case GS_LINELIST:
+		case GS_LINESTRIP:
 			return (std::numeric_limits<u16>::max() / 4) - 4;
 
+			// Four indices per two vertices.
 		case GS_SPRITE:
 			return (std::numeric_limits<u16>::max() / 2) - 2;
 
-		case GS_LINELIST:
-		case GS_LINESTRIP:
 		case GS_TRIANGLELIST:
 		case GS_TRIANGLESTRIP:
 		case GS_TRIANGLEFAN:
 		default:
-			return 0;
+			return (std::numeric_limits<u16>::max() - 3);
 	}
 }
 
@@ -3207,19 +3210,19 @@ __forceinline void GSState::VertexKick(u32 skip)
 		m_backed_up_ctx = m_env.PRIM.CTXT;
 	}
 
-	u32* RESTRICT buff = &m_index.buff[m_index.tail];
+	u16* RESTRICT buff = &m_index.buff[m_index.tail];
 
 	switch (prim)
 	{
 		case GS_POINTLIST:
-			buff[0] = head + 0;
+			buff[0] = static_cast<u16>(head + 0);
 			m_vertex.head = head + 1;
 			m_vertex.next = head + 1;
 			m_index.tail += 1;
 			break;
 		case GS_LINELIST:
-			buff[0] = head + (index_swap ? 1 : 0);
-			buff[1] = head + (index_swap ? 0 : 1);
+			buff[0] = static_cast<u16>(head + (index_swap ? 1 : 0));
+			buff[1] = static_cast<u16>(head + (index_swap ? 0 : 1));
 			m_vertex.head = head + 2;
 			m_vertex.next = head + 2;
 			m_index.tail += 2;
@@ -3232,16 +3235,16 @@ __forceinline void GSState::VertexKick(u32 skip)
 				head = next;
 				m_vertex.tail = next + 2;
 			}
-			buff[0] = head + (index_swap ? 1 : 0);
-			buff[1] = head + (index_swap ? 0 : 1);
+			buff[0] = static_cast<u16>(head + (index_swap ? 1 : 0));
+			buff[1] = static_cast<u16>(head + (index_swap ? 0 : 1));
 			m_vertex.head = head + 1;
 			m_vertex.next = head + 2;
 			m_index.tail += 2;
 			break;
 		case GS_TRIANGLELIST:
-			buff[0] = head + (index_swap ? 2 : 0);
-			buff[1] = head + 1;
-			buff[2] = head + (index_swap ? 0 : 2);
+			buff[0] = static_cast<u16>(head + (index_swap ? 2 : 0));
+			buff[1] = static_cast<u16>(head + 1);
+			buff[2] = static_cast<u16>(head + (index_swap ? 0 : 2));
 			m_vertex.head = head + 3;
 			m_vertex.next = head + 3;
 			m_index.tail += 3;
@@ -3255,24 +3258,24 @@ __forceinline void GSState::VertexKick(u32 skip)
 				head = next;
 				m_vertex.tail = next + 3;
 			}
-			buff[0] = head + (index_swap ? 2 : 0);
-			buff[1] = head + 1;
-			buff[2] = head + (index_swap ? 0 : 2);
+			buff[0] = static_cast<u16>(head + (index_swap ? 2 : 0));
+			buff[1] = static_cast<u16>(head + 1);
+			buff[2] = static_cast<u16>(head + (index_swap ? 0 : 2));
 			m_vertex.head = head + 1;
 			m_vertex.next = head + 3;
 			m_index.tail += 3;
 			break;
 		case GS_TRIANGLEFAN:
 			// TODO: remove gaps, next == head && head < tail - 3 || next > head && next < tail - 2 (very rare)
-			buff[0] = index_swap ? (tail - 1) : (head + 0);
-			buff[1] = tail - 2;
-			buff[2] = index_swap ? (head + 0) : (tail - 1);
+			buff[0] = static_cast<u16>(index_swap ? (tail - 1) : (head + 0));
+			buff[1] = static_cast<u16>(tail - 2);
+			buff[2] = static_cast<u16>(index_swap ? (head + 0) : (tail - 1));
 			m_vertex.next = tail;
 			m_index.tail += 3;
 			break;
 		case GS_SPRITE:
-			buff[0] = head + 0;
-			buff[1] = head + 1;
+			buff[0] = static_cast<u16>(head + 0);
+			buff[1] = static_cast<u16>(head + 1);
 			m_vertex.head = head + 2;
 			m_vertex.next = head + 2;
 			m_index.tail += 2;

--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -158,7 +158,7 @@ protected:
 
 	struct
 	{
-		u32* buff;
+		u16* buff;
 		u32 tail;
 	} m_index = {};
 

--- a/pcsx2/GS/GSVector4i.h
+++ b/pcsx2/GS/GSVector4i.h
@@ -28,6 +28,16 @@ class alignas(16) GSVector4i
 	{
 	}
 
+	constexpr GSVector4i(cxpr_init_tag, short s0, short s1, short s2, short s3, short s4, short s5, short s6, short s7)
+		: I16{s0, s1, s2, s3, s4, s5, s6, s7}
+	{
+	}
+
+	constexpr GSVector4i(cxpr_init_tag, char b0, char b1, char b2, char b3, char b4, char b5, char b6, char b7, char b8, char b9, char b10, char b11, char b12, char b13, char b14, char b15)
+		: I8{b0, b1, b2, b3, b4, b5, b6, b7, b8, b9, b10, b11, b12, b13, b14, b15}
+	{
+	}
+
 public:
 	union
 	{
@@ -60,6 +70,16 @@ public:
 	constexpr static GSVector4i cxpr(int x)
 	{
 		return GSVector4i(cxpr_init, x, x, x, x);
+	}
+
+	constexpr static GSVector4i cxpr16(short s0, short s1, short s2, short s3, short s4, short s5, short s6, short s7)
+	{
+		return GSVector4i(cxpr_init, s0, s1, s2, s3, s4, s5, s6, s7);
+	}
+
+	constexpr static GSVector4i cxpr8(char b0, char b1, char b2, char b3, char b4, char b5, char b6, char b7, char b8, char b9, char b10, char b11, char b12, char b13, char b14, char b15)
+	{
+		return GSVector4i(cxpr_init, b0, b1, b2, b3, b4, b5, b6, b7, b8, b9, b10, b11, b12, b13, b14, b15);
 	}
 
 	__forceinline GSVector4i(int x, int y, int z, int w)
@@ -2001,6 +2021,10 @@ public:
 		return v;
 	}
 
+	__forceinline static GSVector4i broadcast16(u16 value)
+	{
+		return GSVector4i(_mm_set1_epi16(value));
+	}
 
 	__forceinline static GSVector4i zero() { return GSVector4i(_mm_setzero_si128()); }
 

--- a/pcsx2/GS/Renderers/Common/GSDevice.cpp
+++ b/pcsx2/GS/Renderers/Common/GSDevice.cpp
@@ -18,6 +18,7 @@
 #include "GS/GSGL.h"
 #include "GS/GS.h"
 #include "Host.h"
+#include "common/Align.h"
 #include "common/StringUtil.h"
 
 #include "imgui.h"
@@ -165,9 +166,9 @@ std::string GSDevice::GetFullscreenModeString(u32 width, u32 height, float refre
 
 void GSDevice::GenerateExpansionIndexBuffer(void* buffer)
 {
-	static constexpr u32 MAX_INDEX = std::numeric_limits<u16>::max();
+	static constexpr u32 MAX_INDEX = EXPAND_BUFFER_SIZE / 6 / sizeof(u16);
 
-	u32* idx_buffer = static_cast<u32*>(buffer);
+	u16* idx_buffer = static_cast<u16*>(buffer);
 	for (u32 i = 0; i < MAX_INDEX; i++)
 	{
 		const u32 base = i * 4;

--- a/pcsx2/GS/Renderers/Common/GSDevice.h
+++ b/pcsx2/GS/Renderers/Common/GSDevice.h
@@ -627,7 +627,7 @@ struct alignas(16) GSHWDrawConfig
 	GSTexture* tex;       ///< Source texture
 	GSTexture* pal;       ///< Palette texture
 	const GSVertex* verts;///< Vertices to draw
-	const u32* indices;   ///< Indices to draw
+	const u16* indices;   ///< Indices to draw
 	u32 nverts;           ///< Number of vertices
 	u32 nindices;         ///< Number of indices
 	u32 indices_per_prim; ///< Number of indices that make up one primitive
@@ -749,7 +749,7 @@ protected:
 	static constexpr float MAD_SENSITIVITY = 0.08f;
 	static constexpr u32   MAX_POOLED_TEXTURES = 300;
 	static constexpr u32   NUM_CAS_CONSTANTS = 12; // 8 plus src offset x/y, 16 byte alignment
-	static constexpr u32   EXPAND_BUFFER_SIZE = sizeof(u32) * std::numeric_limits<u16>::max() * 6;
+	static constexpr u32   EXPAND_BUFFER_SIZE = sizeof(u16) * 65532 * 6;
 
 	WindowInfo m_window_info;
 	VsyncMode m_vsync_mode = VsyncMode::Off;

--- a/pcsx2/GS/Renderers/Common/GSVertexTrace.cpp
+++ b/pcsx2/GS/Renderers/Common/GSVertexTrace.cpp
@@ -24,7 +24,7 @@ GSVertexTrace::GSVertexTrace(const GSState* state, bool provoking_vertex_first)
 	MULTI_ISA_SELECT(GSVertexTracePopulateFunctions)(*this, provoking_vertex_first);
 }
 
-void GSVertexTrace::Update(const void* vertex, const u32* index, int v_count, int i_count, GS_PRIM_CLASS primclass)
+void GSVertexTrace::Update(const void* vertex, const u16* index, int v_count, int i_count, GS_PRIM_CLASS primclass)
 {
 	if (i_count == 0)
 		return;
@@ -43,7 +43,7 @@ void GSVertexTrace::Update(const void* vertex, const u32* index, int v_count, in
 	// that feel big enough.
 	if (!fst && !m_accurate_stq && m_min.t.z > 1e30)
 	{
-		fprintf(stderr, "Vertex Trace: float overflow detected ! min %e max %e\n", m_min.t.z, m_max.t.z);
+		Console.Warning("Vertex Trace: float overflow detected ! min %e max %e", m_min.t.z, m_max.t.z);
 		m_accurate_stq = true;
 	}
 

--- a/pcsx2/GS/Renderers/Common/GSVertexTrace.h
+++ b/pcsx2/GS/Renderers/Common/GSVertexTrace.h
@@ -49,7 +49,7 @@ public:
 protected:
 	const GSState* m_state;
 
-	typedef void (*FindMinMaxPtr)(GSVertexTrace& vt, const void* vertex, const u32* index, int count);
+	typedef void (*FindMinMaxPtr)(GSVertexTrace& vt, const void* vertex, const u16* index, int count);
 
 	FindMinMaxPtr m_fmm[2][2][2][2][4];
 
@@ -77,7 +77,7 @@ public:
 public:
 	GSVertexTrace(const GSState* state, bool provoking_vertex_first);
 
-	void Update(const void* vertex, const u32* index, int v_count, int i_count, GS_PRIM_CLASS primclass);
+	void Update(const void* vertex, const u16* index, int v_count, int i_count, GS_PRIM_CLASS primclass);
 
 	bool IsLinear() const { return m_filter.opt_linear; }
 	bool IsRealLinear() const { return m_filter.linear; }

--- a/pcsx2/GS/Renderers/Common/GSVertexTraceFMM.cpp
+++ b/pcsx2/GS/Renderers/Common/GSVertexTraceFMM.cpp
@@ -22,7 +22,7 @@ class CURRENT_ISA::GSVertexTraceFMM
 	static constexpr GSVector4 s_minmax = GSVector4::cxpr(FLT_MAX, -FLT_MAX, 0.f, 0.f);
 
 	template <GS_PRIM_CLASS primclass, u32 iip, u32 tme, u32 fst, u32 color, bool flat_swapped>
-	static void FindMinMax(GSVertexTrace& vt, const void* vertex, const u32* index, int count);
+	static void FindMinMax(GSVertexTrace& vt, const void* vertex, const u16* index, int count);
 
 	template <GS_PRIM_CLASS primclass, u32 iip, u32 tme, u32 fst, u32 color>
 	static constexpr GSVertexTrace::FindMinMaxPtr GetFMM(bool provoking_vertex_first);
@@ -76,7 +76,7 @@ void GSVertexTraceFMM::Populate(GSVertexTrace& vt, bool provoking_vertex_first)
 }
 
 template <GS_PRIM_CLASS primclass, u32 iip, u32 tme, u32 fst, u32 color, bool flat_swapped>
-void GSVertexTraceFMM::FindMinMax(GSVertexTrace& vt, const void* vertex, const u32* index, int count)
+void GSVertexTraceFMM::FindMinMax(GSVertexTrace& vt, const void* vertex, const u16* index, int count)
 {
 	const GSDrawingContext* context = vt.m_state->m_context;
 

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.h
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.h
@@ -343,7 +343,7 @@ public:
 	bool IASetVertexBuffer(const void* vertex, u32 stride, u32 count);
 	bool IASetExpandVertexBuffer(const void* vertex, u32 stride, u32 count);
 
-	u32* IAMapIndexBuffer(u32 count);
+	u16* IAMapIndexBuffer(u32 count);
 	void IAUnmapIndexBuffer(u32 count);
 	bool IASetIndexBuffer(const void* index, u32 count);
 	void IASetIndexBuffer(ID3D11Buffer* buffer);

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -2576,7 +2576,7 @@ bool GSTextureCache::ShuffleMove(u32 BP, u32 BW, u32 PSM, int sx, int sy, int dx
 
 #undef V
 
-	static constexpr u32 indices[6] = { 0, 1, 2, 2, 1, 3 };
+	static constexpr u16 indices[6] = { 0, 1, 2, 2, 1, 3 };
 
 	// If we ever do this sort of thing somewhere else, extract this to a helper function.
 	GSHWDrawConfig config;

--- a/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
+++ b/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
@@ -2178,7 +2178,7 @@ void GSDeviceMTL::SendHWDraw(GSHWDrawConfig& config, id<MTLRenderCommandEncoder>
 			textureBarrier(enc);
 			[enc drawIndexedPrimitives:topology
 			                indexCount:count
-			                 indexType:MTLIndexTypeUInt32
+			                 indexType:MTLIndexTypeUInt16
 			               indexBuffer:buffer
 			         indexBufferOffset:off + p * sizeof(*config.indices)];
 			p += count;
@@ -2200,7 +2200,7 @@ void GSDeviceMTL::SendHWDraw(GSHWDrawConfig& config, id<MTLRenderCommandEncoder>
 			textureBarrier(enc);
 			[enc drawIndexedPrimitives:topology
 			                indexCount:config.indices_per_prim
-			                 indexType:MTLIndexTypeUInt32
+			                 indexType:MTLIndexTypeUInt16
 			               indexBuffer:buffer
 			         indexBufferOffset:off + p * sizeof(*config.indices)];
 		}
@@ -2217,7 +2217,7 @@ void GSDeviceMTL::SendHWDraw(GSHWDrawConfig& config, id<MTLRenderCommandEncoder>
 
 	[enc drawIndexedPrimitives:topology
 	                indexCount:config.nindices
-	                 indexType:MTLIndexTypeUInt32
+	                 indexType:MTLIndexTypeUInt16
 	               indexBuffer:buffer
 	         indexBufferOffset:off];
 

--- a/pcsx2/GS/Renderers/SW/GSDrawScanline.cpp
+++ b/pcsx2/GS/Renderers/SW/GSDrawScanline.cpp
@@ -452,9 +452,13 @@ __ri static void WritePixel(const T& src, int addr, int i, u32 psm, const GSScan
 
 void GSDrawScanline::CDrawScanline(int pixels, int left, int top, const GSVertexSW& scan, GSScanlineLocalData& local)
 {
+	CDrawScanline(pixels, left, top, scan, local, GlobalFromLocal(local).sel);
+}
+
+__ri void GSDrawScanline::CDrawScanline(int pixels, int left, int top, const GSVertexSW& scan, GSScanlineLocalData& local, GSScanlineSelector sel)
+{
 	const GSScanlineGlobalData& global = GlobalFromLocal(local);
 
-	GSScanlineSelector sel = global.sel;
 	constexpr int vlen = sizeof(VectorF) / sizeof(float);
 
 #if _M_SSE < 0x501
@@ -1729,17 +1733,10 @@ void GSDrawScanline::CDrawScanline(int pixels, int left, int top, const GSVertex
 
 void GSDrawScanline::CDrawEdge(int pixels, int left, int top, const GSVertexSW& scan, GSScanlineLocalData& local)
 {
-	// This sucks. But so does not jitting!
-	const GSScanlineGlobalData* old_gd = local.gd;
-	GSScanlineGlobalData gd;
-	std::memcpy(&gd, &local.gd, sizeof(gd));
-	gd.sel.zwrite = 0;
-	gd.sel.edge = 1;
-	local.gd = &gd;
-
-	CDrawScanline(pixels, left, top, scan, local);
-
-	local.gd = old_gd;
+	GSScanlineSelector sel = local.gd->sel;
+	sel.zwrite = 0;
+	sel.edge = 1;
+	CDrawScanline(pixels, left, top, scan, local, sel);
 }
 
 template <class T, bool masked>

--- a/pcsx2/GS/Renderers/SW/GSDrawScanline.cpp
+++ b/pcsx2/GS/Renderers/SW/GSDrawScanline.cpp
@@ -161,7 +161,7 @@ typedef GSVector4  VectorF;
 #define LOCAL_STEP local.d4
 #endif
 
-void GSDrawScanline::CSetupPrim(const GSVertexSW* vertex, const u32* index, const GSVertexSW& dscan, GSScanlineLocalData& local)
+void GSDrawScanline::CSetupPrim(const GSVertexSW* vertex, const u16* index, const GSVertexSW& dscan, GSScanlineLocalData& local)
 {
 	const GSScanlineGlobalData& global = GlobalFromLocal(local);
 	GSScanlineSelector sel = global.sel;

--- a/pcsx2/GS/Renderers/SW/GSDrawScanline.h
+++ b/pcsx2/GS/Renderers/SW/GSDrawScanline.h
@@ -63,6 +63,7 @@ private:
 	static void CSetupPrim(const GSVertexSW* vertex, const u16* index, const GSVertexSW& dscan, GSScanlineLocalData& local);
 	static void CDrawScanline(int pixels, int left, int top, const GSVertexSW& scan, GSScanlineLocalData& local);
 	static void CDrawEdge(int pixels, int left, int top, const GSVertexSW& scan, GSScanlineLocalData& local);
+	__ri static void CDrawScanline(int pixels, int left, int top, const GSVertexSW& scan, GSScanlineLocalData& local, GSScanlineSelector sel);
 };
 
 MULTI_ISA_UNSHARED_END

--- a/pcsx2/GS/Renderers/SW/GSDrawScanline.h
+++ b/pcsx2/GS/Renderers/SW/GSDrawScanline.h
@@ -38,7 +38,7 @@ public:
 	~GSDrawScanline() override;
 
 	/// Function pointer types which we call back into.
-	using SetupPrimPtr = void(*)(const GSVertexSW* vertex, const u32* index, const GSVertexSW& dscan, GSScanlineLocalData& local);
+	using SetupPrimPtr = void(*)(const GSVertexSW* vertex, const u16* index, const GSVertexSW& dscan, GSScanlineLocalData& local);
 	using DrawScanlinePtr = void(*)(int pixels, int left, int top, const GSVertexSW& scan, GSScanlineLocalData& local);
 
 	/// Flushes the code cache, forcing everything to be recompiled.
@@ -60,7 +60,7 @@ private:
 	GSCodeGeneratorFunctionMap<GSSetupPrimCodeGenerator, u64, SetupPrimPtr> m_sp_map;
 	GSCodeGeneratorFunctionMap<GSDrawScanlineCodeGenerator, u64, DrawScanlinePtr> m_ds_map;
 
-	static void CSetupPrim(const GSVertexSW* vertex, const u32* index, const GSVertexSW& dscan, GSScanlineLocalData& local);
+	static void CSetupPrim(const GSVertexSW* vertex, const u16* index, const GSVertexSW& dscan, GSScanlineLocalData& local);
 	static void CDrawScanline(int pixels, int left, int top, const GSVertexSW& scan, GSScanlineLocalData& local);
 	static void CDrawEdge(int pixels, int left, int top, const GSVertexSW& scan, GSScanlineLocalData& local);
 };

--- a/pcsx2/GS/Renderers/SW/GSDrawScanlineCodeGenerator.cpp
+++ b/pcsx2/GS/Renderers/SW/GSDrawScanlineCodeGenerator.cpp
@@ -91,7 +91,8 @@ GSDrawScanlineCodeGenerator::GSDrawScanlineCodeGenerator(u64 key, void* code, si
 
 	if (shouldUseCDrawScanline(key))
 	{
-		jmp(reinterpret_cast<const void*>(&GSDrawScanline::CDrawScanline));
+		jmp(reinterpret_cast<const void*>(static_cast<void (*)(int, int, int, const GSVertexSW&, GSScanlineLocalData&)>(
+			&GSDrawScanline::CDrawScanline)));
 		return;
 	}
 

--- a/pcsx2/GS/Renderers/SW/GSRasterizer.cpp
+++ b/pcsx2/GS/Renderers/SW/GSRasterizer.cpp
@@ -154,10 +154,10 @@ void GSRasterizer::Draw(GSRasterizerData& data)
 	const GSVertexSW* vertex = data.vertex;
 	const GSVertexSW* vertex_end = data.vertex + data.vertex_count;
 
-	const u32* index = data.index;
-	const u32* index_end = data.index + data.index_count;
+	const u16* index = data.index;
+	const u16* index_end = data.index + data.index_count;
 
-	u32 tmp_index[] = {0, 1, 2};
+	static constexpr u16 tmp_index[] = {0, 1, 2};
 
 	bool scissor_test = !data.bbox.eq(data.bbox.rintersect(data.scissor));
 
@@ -261,7 +261,7 @@ void GSRasterizer::Draw(GSRasterizerData& data)
 }
 
 template <bool scissor_test>
-void GSRasterizer::DrawPoint(const GSVertexSW* vertex, int vertex_count, const u32* index, int index_count)
+void GSRasterizer::DrawPoint(const GSVertexSW* vertex, int vertex_count, const u16* index, int index_count)
 {
 	m_primcount++;
 
@@ -286,7 +286,7 @@ void GSRasterizer::DrawPoint(const GSVertexSW* vertex, int vertex_count, const u
 	}
 	else
 	{
-		u32 tmp_index[1] = {0};
+		static constexpr u16 tmp_index[1] = {0};
 
 		for (int i = 0; i < vertex_count; i++, vertex++)
 		{
@@ -307,7 +307,7 @@ void GSRasterizer::DrawPoint(const GSVertexSW* vertex, int vertex_count, const u
 	}
 }
 
-void GSRasterizer::DrawLine(const GSVertexSW* vertex, const u32* index)
+void GSRasterizer::DrawLine(const GSVertexSW* vertex, const u16* index)
 {
 	m_primcount++;
 
@@ -425,7 +425,7 @@ static const u8 s_ysort[8][4] =
 
 #if _M_SSE >= 0x501
 
-void GSRasterizer::DrawTriangle(const GSVertexSW* vertex, const u32* index)
+void GSRasterizer::DrawTriangle(const GSVertexSW* vertex, const u16* index)
 {
 	m_primcount++;
 
@@ -606,7 +606,7 @@ void GSRasterizer::DrawTriangleSection(int top, int bottom, GSVertexSW2& RESTRIC
 
 #else
 
-void GSRasterizer::DrawTriangle(const GSVertexSW* vertex, const u32* index)
+void GSRasterizer::DrawTriangle(const GSVertexSW* vertex, const u16* index)
 {
 	m_primcount++;
 
@@ -784,7 +784,7 @@ void GSRasterizer::DrawTriangleSection(int top, int bottom, GSVertexSW& RESTRICT
 
 #endif
 
-void GSRasterizer::DrawSprite(const GSVertexSW* vertex, const u32* index)
+void GSRasterizer::DrawSprite(const GSVertexSW* vertex, const u16* index)
 {
 	m_primcount++;
 
@@ -1082,7 +1082,7 @@ void GSRasterizer::AddScanline(GSVertexSW* e, int pixels, int left, int top, con
 	AddScanlineInfo(e, pixels, left, top);
 }
 
-void GSRasterizer::Flush(const GSVertexSW* vertex, const u32* index, const GSVertexSW& dscan, bool edge /* = false */)
+void GSRasterizer::Flush(const GSVertexSW* vertex, const u16* index, const GSVertexSW& dscan, bool edge /* = false */)
 {
 	// TODO: on win64 this could be the place where xmm6-15 are preserved (not by each DrawScanline)
 

--- a/pcsx2/GS/Renderers/SW/GSRasterizer.h
+++ b/pcsx2/GS/Renderers/SW/GSRasterizer.h
@@ -38,7 +38,7 @@ public:
 	u8* buff;
 	GSVertexSW* vertex;
 	int vertex_count;
-	u32* index;
+	u16* index;
 	int index_count;
 	u64 frame;
 	u64 start;
@@ -101,10 +101,10 @@ protected:
 	__forceinline bool HasEdge() const { return (m_draw_edge != nullptr); }
 
 	template <bool scissor_test>
-	void DrawPoint(const GSVertexSW* vertex, int vertex_count, const u32* index, int index_count);
-	void DrawLine(const GSVertexSW* vertex, const u32* index);
-	void DrawTriangle(const GSVertexSW* vertex, const u32* index);
-	void DrawSprite(const GSVertexSW* vertex, const u32* index);
+	void DrawPoint(const GSVertexSW* vertex, int vertex_count, const u16* index, int index_count);
+	void DrawLine(const GSVertexSW* vertex, const u16* index);
+	void DrawTriangle(const GSVertexSW* vertex, const u16* index);
+	void DrawSprite(const GSVertexSW* vertex, const u16* index);
 
 #if _M_SSE >= 0x501
 	__forceinline void DrawTriangleSection(int top, int bottom, GSVertexSW2& RESTRICT edge, const GSVertexSW2& RESTRICT dedge, const GSVertexSW2& RESTRICT dscan, const GSVector4& RESTRICT p0);
@@ -115,7 +115,7 @@ protected:
 	void DrawEdge(const GSVertexSW& v0, const GSVertexSW& v1, const GSVertexSW& dv, int orientation, int side);
 
 	__forceinline void AddScanline(GSVertexSW* e, int pixels, int left, int top, const GSVertexSW& scan);
-	__forceinline void Flush(const GSVertexSW* vertex, const u32* index, const GSVertexSW& dscan, bool edge = false);
+	__forceinline void Flush(const GSVertexSW* vertex, const u16* index, const GSVertexSW& dscan, bool edge = false);
 
 	__forceinline void DrawScanline(int pixels, int left, int top, const GSVertexSW& scan);
 	__forceinline void DrawEdge(int pixels, int left, int top, const GSVertexSW& scan);

--- a/pcsx2/GS/Renderers/SW/GSRendererSW.cpp
+++ b/pcsx2/GS/Renderers/SW/GSRendererSW.cpp
@@ -343,7 +343,7 @@ void GSRendererSW::Draw()
 	sd->buff = (u8*)m_vertex_heap.alloc(sizeof(GSVertexSW) * ((m_vertex.next + 1) & ~1) + sizeof(u32) * m_index.tail, 64);
 	sd->vertex = (GSVertexSW*)sd->buff;
 	sd->vertex_count = m_vertex.next;
-	sd->index = (u32*)(sd->buff + sizeof(GSVertexSW) * ((m_vertex.next + 1) & ~1));
+	sd->index = (u16*)(sd->buff + sizeof(GSVertexSW) * ((m_vertex.next + 1) & ~1));
 	sd->index_count = m_index.tail;
 	sd->scanmsk_value = m_draw_env->SCANMSK.MSK;
 
@@ -354,7 +354,7 @@ void GSRendererSW::Draw()
 
 	GSVertexSW::s_cvb[m_vt.m_primclass][PRIM->TME][PRIM->FST][q_div](m_context, sd->vertex, m_vertex.buff, m_vertex.next);
 
-	memcpy(sd->index, m_index.buff, sizeof(u32) * m_index.tail);
+	std::memcpy(sd->index, m_index.buff, sizeof(u16) * m_index.tail);
 
 	GSVector4i scissor = GSVector4i(context->scissor.in);
 	GSVector4i bbox = GSVector4i(m_vt.m_min.p.floor().xyxy(m_vt.m_max.p.ceil()));

--- a/pcsx2/GS/Renderers/SW/GSSetupPrimCodeGenerator.all.cpp
+++ b/pcsx2/GS/Renderers/SW/GSSetupPrimCodeGenerator.all.cpp
@@ -210,7 +210,7 @@ void GSSetupPrimCodeGenerator2::Depth_XMM()
 	{
 		// GSVector4 p = vertex[index[1]].p;
 
-		mov(eax, ptr[_index + sizeof(u32) * 1]);
+		movzx(eax, word[_index + sizeof(u16) * 1]);
 		shl(eax, 6); // * sizeof(GSVertexSW)
 		add(rax, _64_vertex);
 
@@ -299,7 +299,7 @@ void GSSetupPrimCodeGenerator2::Depth_YMM()
 	{
 		// GSVector4 p = vertex[index[1]].p;
 
-		mov(eax, ptr[_index + sizeof(u32) * 1]);
+		movzx(eax, word[_index + sizeof(u16) * 1]);
 		shl(eax, 6); // * sizeof(GSVertexSW)
 		add(rax, _64_vertex);
 
@@ -504,7 +504,7 @@ void GSSetupPrimCodeGenerator2::Color()
 
 		if (!(m_sel.prim == GS_SPRITE_CLASS && (m_en.z || m_en.f))) // if this is a sprite, the last vertex was already loaded in Depth()
 		{
-			mov(eax, ptr[_index + sizeof(u32) * last]);
+			movzx(eax, word[_index + sizeof(u16) * last]);
 			shl(eax, 6); // * sizeof(GSVertexSW)
 			add(rax, _64_vertex);
 		}

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
@@ -955,13 +955,13 @@ void GSDeviceVK::DoMultiStretchRects(
 {
 	// Set up vertices first.
 	const u32 vertex_reserve_size = num_rects * 4 * sizeof(GSVertexPT1);
-	const u32 index_reserve_size = num_rects * 6 * sizeof(u32);
+	const u32 index_reserve_size = num_rects * 6 * sizeof(u16);
 	if (!m_vertex_stream_buffer.ReserveMemory(vertex_reserve_size, sizeof(GSVertexPT1)) ||
-		!m_index_stream_buffer.ReserveMemory(index_reserve_size, sizeof(u32)))
+		!m_index_stream_buffer.ReserveMemory(index_reserve_size, sizeof(u16)))
 	{
 		ExecuteCommandBufferAndRestartRenderPass(false, "Uploading bytes to vertex buffer");
 		if (!m_vertex_stream_buffer.ReserveMemory(vertex_reserve_size, sizeof(GSVertexPT1)) ||
-			!m_index_stream_buffer.ReserveMemory(index_reserve_size, sizeof(u32)))
+			!m_index_stream_buffer.ReserveMemory(index_reserve_size, sizeof(u16)))
 		{
 			pxFailRel("Failed to reserve space for vertices");
 		}
@@ -971,7 +971,7 @@ void GSDeviceVK::DoMultiStretchRects(
 	// Don't use primitive restart here, it ends up slower on some drivers.
 	const GSVector2 ds(static_cast<float>(dTex->GetWidth()), static_cast<float>(dTex->GetHeight()));
 	GSVertexPT1* verts = reinterpret_cast<GSVertexPT1*>(m_vertex_stream_buffer.GetCurrentHostPointer());
-	u32* idx = reinterpret_cast<u32*>(m_index_stream_buffer.GetCurrentHostPointer());
+	u16* idx = reinterpret_cast<u16*>(m_index_stream_buffer.GetCurrentHostPointer());
 	u32 icount = 0;
 	u32 vcount = 0;
 	for (u32 i = 0; i < num_rects; i++)
@@ -1001,11 +1001,11 @@ void GSDeviceVK::DoMultiStretchRects(
 
 	m_vertex.start = m_vertex_stream_buffer.GetCurrentOffset() / sizeof(GSVertexPT1);
 	m_vertex.count = vcount;
-	m_index.start = m_index_stream_buffer.GetCurrentOffset() / sizeof(u32);
+	m_index.start = m_index_stream_buffer.GetCurrentOffset() / sizeof(u16);
 	m_index.count = icount;
 	m_vertex_stream_buffer.CommitMemory(vcount * sizeof(GSVertexPT1));
-	m_index_stream_buffer.CommitMemory(icount * sizeof(u32));
-	SetIndexBuffer(m_index_stream_buffer.GetBuffer(), 0, VK_INDEX_TYPE_UINT32);
+	m_index_stream_buffer.CommitMemory(icount * sizeof(u16));
+	SetIndexBuffer(m_index_stream_buffer.GetBuffer(), 0, VK_INDEX_TYPE_UINT16);
 
 	// Even though we're batching, a cmdbuffer submit could've messed this up.
 	const GSVector4i rc(dTex->GetRect());
@@ -1368,21 +1368,21 @@ void GSDeviceVK::IASetVertexBuffer(const void* vertex, size_t stride, size_t cou
 
 void GSDeviceVK::IASetIndexBuffer(const void* index, size_t count)
 {
-	const u32 size = sizeof(u32) * static_cast<u32>(count);
-	if (!m_index_stream_buffer.ReserveMemory(size, sizeof(u32)))
+	const u32 size = sizeof(u16) * static_cast<u32>(count);
+	if (!m_index_stream_buffer.ReserveMemory(size, sizeof(u16)))
 	{
 		ExecuteCommandBufferAndRestartRenderPass(false, "Uploading bytes to index buffer");
-		if (!m_index_stream_buffer.ReserveMemory(size, sizeof(u32)))
+		if (!m_index_stream_buffer.ReserveMemory(size, sizeof(u16)))
 			pxFailRel("Failed to reserve space for vertices");
 	}
 
-	m_index.start = m_index_stream_buffer.GetCurrentOffset() / sizeof(u32);
+	m_index.start = m_index_stream_buffer.GetCurrentOffset() / sizeof(u16);
 	m_index.count = count;
 
 	std::memcpy(m_index_stream_buffer.GetCurrentHostPointer(), index, size);
 	m_index_stream_buffer.CommitMemory(size);
 
-	SetIndexBuffer(m_index_stream_buffer.GetBuffer(), 0, VK_INDEX_TYPE_UINT32);
+	SetIndexBuffer(m_index_stream_buffer.GetBuffer(), 0, VK_INDEX_TYPE_UINT16);
 }
 
 void GSDeviceVK::OMSetRenderTargets(GSTexture* rt, GSTexture* ds, const GSVector4i& scissor, FeedbackLoopFlag feedback_loop)
@@ -2319,9 +2319,6 @@ void GSDeviceVK::RenderImGui()
 		m_dirty_flags |= DIRTY_FLAG_UTILITY_TEXTURE;
 	}
 
-	// imgui uses 16-bit indices
-	SetIndexBuffer(m_index_stream_buffer.GetBuffer(), 0, VK_INDEX_TYPE_UINT16);
-
 	// this is for presenting, we don't want to screw with the viewport/scissor set by display
 	m_dirty_flags &= ~(DIRTY_FLAG_VIEWPORT | DIRTY_FLAG_SCISSOR);
 
@@ -2343,19 +2340,8 @@ void GSDeviceVK::RenderImGui()
 			m_vertex_stream_buffer.CommitMemory(size);
 		}
 
-		u32 index_offset;
-		{
-			const u32 size = sizeof(ImDrawIdx) * static_cast<u32>(cmd_list->IdxBuffer.Size);
-			if (!m_index_stream_buffer.ReserveMemory(size, sizeof(ImDrawIdx)))
-			{
-				Console.Warning("Skipping ImGui draw because of no vertex buffer space");
-				return;
-			}
-
-			index_offset = m_index_stream_buffer.GetCurrentOffset() / sizeof(ImDrawIdx);
-			std::memcpy(m_index_stream_buffer.GetCurrentHostPointer(), cmd_list->IdxBuffer.Data, size);
-			m_index_stream_buffer.CommitMemory(size);
-		}
+		static_assert(sizeof(ImDrawIdx) == sizeof(u16));
+		IASetIndexBuffer(cmd_list->IdxBuffer.Data, cmd_list->IdxBuffer.Size);
 
 		for (int cmd_i = 0; cmd_i < cmd_list->CmdBuffer.Size; cmd_i++)
 		{
@@ -2379,7 +2365,7 @@ void GSDeviceVK::RenderImGui()
 			if (ApplyUtilityState())
 			{
 				vkCmdDrawIndexed(g_vulkan_context->GetCurrentCommandBuffer(), pcmd->ElemCount, 1,
-					index_offset + pcmd->IdxOffset, vertex_offset + pcmd->VtxOffset, 0);
+					m_index.start + pcmd->IdxOffset, vertex_offset + pcmd->VtxOffset, 0);
 			}
 		}
 
@@ -2786,7 +2772,7 @@ void GSDeviceVK::InitializeState()
 	m_vertex_buffer_offset = 0;
 	m_index_buffer = m_index_stream_buffer.GetBuffer();
 	m_index_buffer_offset = 0;
-	m_index_type = VK_INDEX_TYPE_UINT32;
+	m_index_type = VK_INDEX_TYPE_UINT16;
 	m_current_framebuffer = VK_NULL_HANDLE;
 	m_current_render_pass = VK_NULL_HANDLE;
 
@@ -3847,7 +3833,7 @@ void GSDeviceVK::UploadHWDrawVerticesAndIndices(const GSHWDrawConfig& config)
 	{
 		m_index.start = 0;
 		m_index.count = config.nindices;
-		SetIndexBuffer(m_expand_index_buffer, 0, VK_INDEX_TYPE_UINT32);
+		SetIndexBuffer(m_expand_index_buffer, 0, VK_INDEX_TYPE_UINT16);
 	}
 	else
 	{


### PR DESCRIPTION
### Description of Changes

Most draws don't come close to 65535 vertices.

### Rationale behind Changes

Save some bandwidth.

### Suggested Testing Steps

Make sure all renderers work. Dump run says it's okay.
