### PR TITLE
SPU2: Small tweaks to ADSR and IRQ address triggers

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -12108,11 +12108,6 @@ SLES-51043:
   gsHWFixes:
     mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
     trilinearFiltering: 1
-  patches:
-    0EF1D4BA:
-      content: |-
-        comment=Spyro PAL startup fix
-        patch=1,EE,001E763C,word,24020001
 SLES-51044:
   name: "Burnout 2 - Point of Impact"
   region: "PAL-M5"
@@ -43061,17 +43056,12 @@ SLUS-20314:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes texture slight misalignment.
 SLUS-20315:
-  name: "Spyro the Dragon - Enter the Dragonfly"
+  name: "Spyro - Enter the Dragonfly"
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
     mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
     trilinearFiltering: 1
-  patches:
-    4B8E0DE8:
-      content: |-
-        comment=Spyro NTSC startup fix
-        patch=1,EE,001e71dc,word,24020001
 SLUS-20316:
   name: "WWF SmackDown! - Just Bring It!"
   region: "NTSC-U"

--- a/pcsx2/SPU2/ADSR.cpp
+++ b/pcsx2/SPU2/ADSR.cpp
@@ -34,7 +34,8 @@ void InitADSR() // INIT ADSR
 		else
 			rate <<= shift;
 
-		PsxRates[i] = (int)std::min(rate, (s64)0x3fffffffLL);
+		// Maximum rate is 0x4000.
+		PsxRates[i] = (int)std::min(rate, (s64)0x40000000LL);
 	}
 }
 

--- a/pcsx2/SPU2/Dma.cpp
+++ b/pcsx2/SPU2/Dma.cpp
@@ -258,7 +258,6 @@ void V_Core::FinishDMAwrite()
 #endif
 
 	u32 buff1end = ActiveTSA + std::min(ReadSize, (u32)0x100 + std::abs(DMAICounter / 4));
-	u32 start = ActiveTSA;
 	u32 buff2end = 0;
 	if (buff1end > 0x100000)
 	{
@@ -298,6 +297,7 @@ void V_Core::FinishDMAwrite()
 		// memory below 0x2800 (registers and such)
 		//const u32 endpt2 = (buff2end + roundUp) / indexer_scalar;
 		//memset( pcm_cache_flags, 0, endpt2 );
+		const u32 start = ActiveTSA;
 		TDA = buff1end;
 
 		DMAPtr += TDA - ActiveTSA;
@@ -323,7 +323,7 @@ void V_Core::FinishDMAwrite()
 			// understanding would trigger the interrupt early causing it to switch buffers again immediately
 			// and an interrupt never fires again, leaving the voices looping the same samples forever.
 
-			if (Cores[i].IRQEnable && (Cores[i].IRQA > start || Cores[i].IRQA <= TDA))
+			if (Cores[i].IRQEnable && (Cores[i].IRQA > start || Cores[i].IRQA < TDA))
 			{
 				//ConLog("DMAwrite Core %d: IRQ Called (IRQ passed). IRQA = %x Cycles = %d\n", i, Cores[i].IRQA, Cycles );
 				SetIrqCallDMA(i);
@@ -341,7 +341,7 @@ void V_Core::FinishDMAwrite()
 		// Important: Test both core IRQ settings for either DMA!
 		for (int i = 0; i < 2; i++)
 		{
-			if (Cores[i].IRQEnable && (Cores[i].IRQA > ActiveTSA && Cores[i].IRQA <= TDA))
+			if (Cores[i].IRQEnable && (Cores[i].IRQA > ActiveTSA && Cores[i].IRQA < TDA))
 			{
 				//ConLog("DMAwrite Core %d: IRQ Called (IRQ passed). IRQA = %x Cycles = %d\n", i, Cores[i].IRQA, Cycles );
 				SetIrqCallDMA(i);
@@ -373,7 +373,6 @@ void V_Core::FinishDMAwrite()
 void V_Core::FinishDMAread()
 {
 	u32 buff1end = ActiveTSA + std::min(ReadSize, (u32)0x100 + std::abs(DMAICounter / 4));
-	u32 start = ActiveTSA;
 	u32 buff2end = 0;
 
 	if (buff1end > 0x100000)
@@ -396,7 +395,7 @@ void V_Core::FinishDMAread()
 
 	if (buff2end > 0)
 	{
-
+		const u32 start = ActiveTSA;
 		TDA = buff1end;
 
 		DMARPtr += TDA - ActiveTSA;
@@ -415,7 +414,7 @@ void V_Core::FinishDMAread()
 
 		for (int i = 0; i < 2; i++)
 		{
-			if (Cores[i].IRQEnable && (Cores[i].IRQA > start || Cores[i].IRQA <= TDA))
+			if (Cores[i].IRQEnable && (Cores[i].IRQA > start || Cores[i].IRQA < TDA))
 			{
 				SetIrqCallDMA(i);
 			}
@@ -433,7 +432,7 @@ void V_Core::FinishDMAread()
 
 		for (int i = 0; i < 2; i++)
 		{
-			if (Cores[i].IRQEnable && (Cores[i].IRQA > ActiveTSA && Cores[i].IRQA <= TDA))
+			if (Cores[i].IRQEnable && (Cores[i].IRQA > ActiveTSA && Cores[i].IRQA < TDA))
 			{
 				SetIrqCallDMA(i);
 			}


### PR DESCRIPTION
### Description of Changes
Adjusts the maximum value the ADSR can adjust by and the inclusiveness of the IRQ addressing.

### Rationale behind Changes
ADSR can adjust by 0x4000 per tick, not 0x3fff as we had it clamped to before, this was incorrect, causing Spyro Enter the Dragonfly to hang.

IRQ addressing was including the end address when testing if an IRQ should fire, however the end address isn't read, so it doesn't make much sense that it would trigger it, plus it was causing Fatal Frame/Project Zero 2 speech not to work correctly. Limited testing has shown it wouldn't trigger.

### Suggested Testing Steps
Test Spyro - Enter the Dragonfly and Fatal Frame/Project Zero 2, plus a bunch of other games which are sensitive to SPU2 stuff in the past https://github.com/PCSX2/pcsx2/issues?q=is%3Aissue+sort%3Aupdated-desc+spu2+is%3Aclosed+label%3ASPU2

Thanks to Goatman13 and Ziemas for their efforts in debugging/testing said changes :)

Fixes #2314
