### PR TITLE
GameIndex: Add Fatal Frame 1 Boss Hang Fix to more regions.

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -7085,6 +7085,13 @@ SCPS-55043:
   gsHWFixes:
     halfPixelOffset: 2 # Reduces blurriness.
     alignSprite: 1 # Fixes vertical lines on hidden ghosts.
+  patches:
+    339A0B8C:
+      content: |-
+        author=WeirdBeardGame, TellowKrinkle, CheeseyBurrito.
+        // Wraps sceVu0ScaleVector in if statement to prevent bad divide by zero behaviour.
+        patch=1,EE,0011f0cc,word,46156032
+        patch=1,EE,0011f0d0,word,45010002
 SCPS-55044:
   name: "Energy Airforce"
   region: "NTSC-J"
@@ -7188,6 +7195,13 @@ SCPS-56008:
   gsHWFixes:
     halfPixelOffset: 2 # Reduces blurriness.
     alignSprite: 1 # Fixes vertical lines on hidden ghosts.
+  patches:
+    339A0B8C:
+      content: |-
+        author=WeirdBeardGame, TellowKrinkle, CheeseyBurrito.
+        // Wraps sceVu0ScaleVector in if statement to prevent bad divide by zero behaviour.
+        patch=1,EE,0011f3ac,word,46156032
+        patch=1,EE,0011f3b0,word,45010002
 SCPS-56009:
   name: "Smash Court Pro Tournament"
   region: "NTSC-K"


### PR DESCRIPTION
Added Kirie hang fix to Fatal Frame Korea and Asia.

### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Add PNACH fix to Fatal Frame 1 preventing Kirie final boss hang that occurs on real hardware.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Mo regions, mo able to beat game without glitch

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! --> 
Already been tested
