### PR TITLE
GS/HW: Use bitfield extract for VS expand (GL/VK)

### DIFF
--- a/bin/resources/shaders/opengl/tfx_vgs.glsl
+++ b/bin/resources/shaders/opengl/tfx_vgs.glsl
@@ -128,11 +128,12 @@ ProcessedVertex load_vertex(uint index)
 #endif
 
     vec2 i_st = rvtx.ST;
-    vec4 i_c = vec4(uvec4(rvtx.RGBA & 0xFFu, (rvtx.RGBA >> 8) & 0xFFu, (rvtx.RGBA >> 16) & 0xFFu, rvtx.RGBA >> 24));
+    vec4 i_c = vec4(uvec4(bitfieldExtract(rvtx.RGBA, 0, 8), bitfieldExtract(rvtx.RGBA, 8, 8),
+	                      bitfieldExtract(rvtx.RGBA, 16, 8), bitfieldExtract(rvtx.RGBA, 24, 8)));
     float i_q = rvtx.Q;
-    uvec2 i_p = uvec2(rvtx.XY & 0xFFFFu, rvtx.XY >> 16);
+    uvec2 i_p = uvec2(bitfieldExtract(rvtx.XY, 0, 16), bitfieldExtract(rvtx.XY, 16, 16));
     uint i_z = rvtx.Z;
-    uvec2 i_uv = uvec2(rvtx.UV & 0xFFFFu, rvtx.UV >> 16);
+    uvec2 i_uv = uvec2(bitfieldExtract(rvtx.UV, 0, 16), bitfieldExtract(rvtx.UV, 16, 16));
     vec4 i_f = unpackUnorm4x8(rvtx.FOG);
 
     ProcessedVertex vtx;

--- a/bin/resources/shaders/vulkan/tfx.glsl
+++ b/bin/resources/shaders/vulkan/tfx.glsl
@@ -113,11 +113,12 @@ ProcessedVertex load_vertex(uint index)
 	RawVertex rvtx = vertex_buffer[gl_BaseVertexARB + index];
 
 	vec2 a_st = rvtx.ST;
-	uvec4 a_c = uvec4(rvtx.RGBA & 0xFFu, (rvtx.RGBA >> 8) & 0xFFu, (rvtx.RGBA >> 16) & 0xFFu, rvtx.RGBA >> 24);
+	uvec4 a_c = uvec4(bitfieldExtract(rvtx.RGBA, 0, 8), bitfieldExtract(rvtx.RGBA, 8, 8),
+	                  bitfieldExtract(rvtx.RGBA, 16, 8), bitfieldExtract(rvtx.RGBA, 24, 8));
 	float a_q = rvtx.Q;
-	uvec2 a_p = uvec2(rvtx.XY & 0xFFFFu, rvtx.XY >> 16);
+	uvec2 a_p = uvec2(bitfieldExtract(rvtx.XY, 0, 16), bitfieldExtract(rvtx.XY, 16, 16));
 	uint a_z = rvtx.Z;
-	uvec2 a_uv = uvec2(rvtx.UV & 0xFFFFu, rvtx.UV >> 16);
+	uvec2 a_uv = uvec2(bitfieldExtract(rvtx.UV, 0, 16), bitfieldExtract(rvtx.UV, 16, 16));
 	vec4 a_f = unpackUnorm4x8(rvtx.FOG);
 
 	ProcessedVertex vtx;

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -163,7 +163,7 @@ bool GSDeviceOGL::Create(const WindowInfo& wi, VsyncMode vsync)
 		GLint max_vertex_ssbos = 0;
 		glGetIntegerv(GL_MAX_VERTEX_SHADER_STORAGE_BLOCKS, &max_vertex_ssbos);
 		DevCon.WriteLn("GL_MAX_VERTEX_SHADER_STORAGE_BLOCKS: %d", max_vertex_ssbos);
-		m_features.vs_expand = (max_vertex_ssbos > 0);
+		m_features.vs_expand = (max_vertex_ssbos > 0 && GLAD_GL_ARB_gpu_shader5);
 	}
 	if (!m_features.vs_expand)
 		Console.Warning("Vertex expansion is not supported. This will reduce performance.");
@@ -1134,7 +1134,9 @@ std::string GSDeviceOGL::GenGlslHeader(const std::string_view& entry, GLenum typ
 	else
 	{
 		header = "#version 330 core\n";
-		header += "#extension GL_ARB_shading_language_420pack: require\n";
+		header += "#extension GL_ARB_shading_language_420pack : require\n";
+		if (GLAD_GL_ARB_gpu_shader5)
+			header += "#extension GL_ARB_gpu_shader5 : require\n";
 		if (m_features.vs_expand)
 			header += "#extension GL_ARB_shader_storage_buffer_object: require\n";
 	}


### PR DESCRIPTION
### Description of Changes

Only exists in GLSL.

### Rationale behind Changes

Just in case the compiler doesn't make this transformation.

### Suggested Testing Steps

Try VK/GL.
