### PR TITLE
GS/HW: Don't attempt to colour copy into depth target

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -4933,16 +4933,15 @@ void GSRendererHW::OI_DoubleHalfClear(GSTextureCache::Target*& rt, GSTextureCach
 				clear_depth ? "depth" : "target", base << 5, half << 5, w_pages, h_pages, m_cached_ctx.FRAME.FBW, color);
 
 			// If some of the channels are masked, we need to keep them.
-			if (m_cached_ctx.FRAME.FBMSK != 0)
+			if (!clear_depth && m_cached_ctx.FRAME.FBMSK != 0)
 			{
 				GSTexture* tex = nullptr;
 				GSTextureCache::Target* target = clear_depth ? ds : rt;
 				const GSVector2 size = GSVector2(static_cast<float>(target->GetUnscaledWidth()) * target->m_scale, static_cast<float>(target->GetUnscaledHeight()) * target->m_scale);
+				pxAssert(!target->m_texture->IsDepthStencil());
 				try
 				{
-					tex = target->m_texture->IsDepthStencil() ?
-						g_gs_device->CreateDepthStencil(size.x, size.y, target->m_texture->GetFormat(), true) :
-						g_gs_device->CreateRenderTarget(size.x, size.y, target->m_texture->GetFormat(), true);
+					tex = g_gs_device->CreateRenderTarget(size.x, size.y, target->m_texture->GetFormat(), false);
 				}
 				catch (const std::bad_alloc&)
 				{


### PR DESCRIPTION
### Description of Changes

This was causing validation errors, and could possibly make a GPU/driver crash.

@refractionpcsx2 I didn't think enough to say whether we _should_ be trying to preserve some of the depth bits here, but if so, we'd need a separate shader.

### Rationale behind Changes

This is an invalid draw.

### Suggested Testing Steps

Test GT4 (this is where I saw it).
