### PR TITLE
GS/HW: Only force shader sampling for non-32bit targets

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -3613,7 +3613,8 @@ __ri void GSRendererHW::EmulateTextureSampler(const GSTextureCache::Target* rt, 
 		m_cached_ctx.CLAMP.MINU, m_cached_ctx.CLAMP.MAXU, m_cached_ctx.CLAMP.MINV, m_cached_ctx.CLAMP.MAXV);
 
 	const bool need_mipmap = IsMipMapDraw();
-	const bool shader_emulated_sampler = tex->m_palette || cpsm.fmt != 0 || complex_wms_wmt || psm.depth || target_region;
+	const bool shader_emulated_sampler = tex->m_palette || (tex->m_target && !m_conf.ps.shuffle && cpsm.fmt != 0) ||
+										 complex_wms_wmt || psm.depth || target_region;
 	const bool trilinear_manual = need_mipmap && GSConfig.HWMipmap == HWMipmapLevel::Full;
 
 	bool bilinear = m_vt.IsLinear();


### PR DESCRIPTION
### Description of Changes

Not sources. They already have AEM resolved.

### Rationale behind Changes

Closes #8640.

Before:
<img width="599" alt="Untitled" src="https://user-images.githubusercontent.com/11288319/232234924-1b5df6d6-f0a6-4f67-bbd1-768f2cc54eda.png">

After:
<img width="599" alt="Untitled" src="https://user-images.githubusercontent.com/11288319/232227624-d20d6cca-0309-4ec1-88af-583fe1a6e599.png">

Weirdly... also seems to fix the post-processing in Shrek 2...

<img width="1124" alt="Untitled" src="https://user-images.githubusercontent.com/11288319/232227665-7c734806-03c9-4d77-8076-3072f7b7bc54.png">

### Suggested Testing Steps

Test dump/texture in linked issue (already done).

Unfortunately this seemed to have almost every bloody dump in the collection show up as a diff. But I went through them and the only one with any noticeable difference was Shrek 2 above.