### PR TITLE
GS/HW: Ensure region texture mipmaps don't go out of bounds

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -5127,13 +5127,13 @@ GSTextureCache::SourceRegion GSTextureCache::SourceRegion::AdjustForMipmap(u32 l
 	if (HasX())
 	{
 		const u32 new_minx = GetMinX() >> level;
-		const u32 new_maxx = std::max<u32>(GetMaxX() >> level, new_minx + 1);
+		const u32 new_maxx = new_minx + std::max(GetWidth() >> level, 1u);
 		ret.SetX(new_minx, new_maxx);
 	}
 	if (HasY())
 	{
 		const u32 new_miny = GetMinY() >> level;
-		const u32 new_maxy = std::max<u32>(GetMaxY() >> level, new_miny + 1);
+		const u32 new_maxy = new_miny + std::max(GetHeight() >> level, 1u);
 		ret.SetY(new_miny, new_maxy);
 	}
 	return ret;


### PR DESCRIPTION
### Description of Changes

Happened with odd-sized textures in Shrek 2.

### Rationale behind Changes

Out of bounds crashing the driver/GPU are bad.

### Suggested Testing Steps

Test Shrek 2.