### PR TITLE
Vif: Fix up Instant DMA behaviour

### DIFF
--- a/pcsx2/Vif1_Dma.cpp
+++ b/pcsx2/Vif1_Dma.cpp
@@ -316,6 +316,7 @@ __fi void vif1Interrupt()
 			CPU_INT(DMAC_VIF1, 128);
 			if (gifRegs.stat.APATH == 3)
 				vif1Regs.stat.VGW = 1; //We're waiting for path 3. Gunslinger II
+			CPU_SET_DMASTALL(DMAC_VIF1, true);
 			return;
 		}
 		vif1Regs.stat.VGW = 0; //Path 3 isn't busy so we don't need to wait for it.

--- a/pcsx2/Vif_Codes.cpp
+++ b/pcsx2/Vif_Codes.cpp
@@ -83,7 +83,10 @@ static __fi void vuExecMicro(int idx, u32 addr, bool requires_wait)
 
 	vifFlush(idx);
 	if (GetVifX.waitforvu)
+	{
+		CPU_SET_DMASTALL(idx ? DMAC_VIF1 : DMAC_VIF0, true);
 		return;
+	}
 
 	if (vifRegs.itops > (idx ? 0x3ffu : 0xffu))
 	{
@@ -220,7 +223,10 @@ vifOp(vifCode_Flush)
 		}
 
 		if (vif1.waitforvu || vif1Regs.stat.VGW)
+		{
+			CPU_SET_DMASTALL(DMAC_VIF1, true);
 			return 0;
+		}
 
 		vif1.cmd = 0;
 		vif1.pass = 0;
@@ -250,7 +256,10 @@ vifOp(vifCode_FlushA)
 		}
 
 		if (vif1.waitforvu || vif1Regs.stat.VGW)
+		{
+			CPU_SET_DMASTALL(DMAC_VIF1, true);
 			return 0;
+		}
 
 		vif1.cmd = 0;
 		vif1.pass = 0;
@@ -268,7 +277,10 @@ vifOp(vifCode_FlushE)
 		vifFlush(idx);
 
 		if (vifX.waitforvu)
+		{
+			CPU_SET_DMASTALL(idx ? DMAC_VIF1 : DMAC_VIF0, true);
 			return 0;
+		}
 
 		vifX.cmd = 0;
 		vifX.pass = 0;
@@ -373,7 +385,10 @@ vifOp(vifCode_MPG)
 		vifFlush(idx);
 
 		if (vifX.waitforvu)
+		{
+			CPU_SET_DMASTALL(idx ? DMAC_VIF1 : DMAC_VIF0, true);
 			return 0;
+		}
 		else
 		{
 			vifX.pass = 1;
@@ -418,7 +433,10 @@ vifOp(vifCode_MSCAL)
 		vifFlush(idx);
 
 		if (vifX.waitforvu)
+		{
+			CPU_SET_DMASTALL(idx ? DMAC_VIF1 : DMAC_VIF0, true);
 			return 0;
+		}
 
 		vuExecMicro(idx, (u16)(vifXRegs.code), false);
 		vifX.cmd = 0;
@@ -454,7 +472,10 @@ vifOp(vifCode_MSCALF)
 		}
 
 		if (vifX.waitforvu || vif1Regs.stat.VGW)
+		{
+			CPU_SET_DMASTALL(idx ? DMAC_VIF1 : DMAC_VIF0, true);
 			return 0;
+		}
 
 		vuExecMicro(idx, (u16)(vifXRegs.code), true);
 		vifX.cmd = 0;
@@ -473,7 +494,10 @@ vifOp(vifCode_MSCNT)
 		vifFlush(idx);
 
 		if (vifX.waitforvu)
+		{
+			CPU_SET_DMASTALL(idx ? DMAC_VIF1 : DMAC_VIF0, true);
 			return 0;
+		}
 
 		vuExecMicro(idx, -1, false);
 		vifX.cmd = 0;


### PR DESCRIPTION
### Description of Changes
Fixes VIF1 stall behaviour when InstantDMA is enabled.

### Rationale behind Changes
It was getting in to infinite loops when used with Metal Gear Solid 3

### Suggested Testing Steps
Test MGS3 and other games with InstantDMA enabled (check the gamedb if you're unsure)
