### PR TITLE
GameDB: Fix Armored Core water and game names

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -533,7 +533,7 @@ SCAJ-20011:
     eeRoundMode: 0 # Fixes Z-Fighting.
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes water rendering.
-	  cpuSpriteRenderLevel: 2 # Needed for above.
+    cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects positioning of reflections on suit's surfaces.
     partialTargetInvalidation: 1 # Fixes corrupted textures.
   memcardFilters:
@@ -812,7 +812,7 @@ SCAJ-20076:
   region: "NTSC-Unk"
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes water rendering.
-	  cpuSpriteRenderLevel: 2 # Needed for above.
+    cpuSpriteRenderLevel: 2 # Needed for above.
     partialTargetInvalidation: 1 # Fixes broken textures.
   memcardFilters:
     - "SCAJ-20076"
@@ -826,7 +826,7 @@ SCAJ-20077:
   region: "NTSC-Unk"
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes water rendering.
-	  cpuSpriteRenderLevel: 2 # Needed for above.
+    cpuSpriteRenderLevel: 2 # Needed for above.
     partialTargetInvalidation: 1 # Fixes broken textures.
   memcardFilters:
     - "SCAJ-20076"
@@ -974,7 +974,7 @@ SCAJ-20105:
   region: "NTSC-Unk"
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes water rendering.
-	  cpuSpriteRenderLevel: 2 # Needed for above.
+    cpuSpriteRenderLevel: 2 # Needed for above.
     partialTargetInvalidation: 1 # Fixes broken textures.
 SCAJ-20107:
   name: "Bakufuu Slash! Kizna Arashi"
@@ -1061,7 +1061,7 @@ SCAJ-20121:
   region: "NTSC-Unk"
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes water rendering.
-	  cpuSpriteRenderLevel: 2 # Needed for above.
+    cpuSpriteRenderLevel: 2 # Needed for above.
     partialTargetInvalidation: 1 # Fixes broken textures.
 SCAJ-20122:
   name: "Swords of Destiny"
@@ -1195,7 +1195,7 @@ SCAJ-20143:
   region: "NTSC-Unk"
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes water rendering.
-	  cpuSpriteRenderLevel: 2 # Needed for above.
+    cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects shadow alignment and reduces blurriness.
     partialTargetInvalidation: 1 # Fixes broken textures.
 SCAJ-20144:
@@ -5234,7 +5234,7 @@ SCKA-20047:
   region: "NTSC-K"
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes water rendering.
-	  cpuSpriteRenderLevel: 2 # Needed for above.
+    cpuSpriteRenderLevel: 2 # Needed for above.
     partialTargetInvalidation: 1 # Fixes broken textures.
   memcardFilters:
     - "SCKA-20047"
@@ -6970,7 +6970,7 @@ SCPS-55014:
     eeRoundMode: 0 # Fixes Z-Fighting.
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes water rendering.
-	  cpuSpriteRenderLevel: 2 # Needed for above.
+    cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects positioning of reflections on suit's surfaces.
     roundSprite: 2 # Reduces garbage on the UI whilst upscaling.
     partialTargetInvalidation: 1 # Fixes corrupted textures.
@@ -13096,7 +13096,7 @@ SLES-51399:
     eeRoundMode: 0 # Fixes Z-Fighting.
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes water rendering.
-	  cpuSpriteRenderLevel: 2 # Needed for above.
+    cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects positioning of reflections on suit's surfaces.
     roundSprite: 2 # Reduces garbage on the UI whilst upscaling.
     partialTargetInvalidation: 1 # Fixes corrupted textures.
@@ -14687,7 +14687,7 @@ SLES-52203:
     eeRoundMode: 0 # Fixes Z-Fighting.
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes water rendering.
-	  cpuSpriteRenderLevel: 2 # Needed for above.
+    cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects positioning of reflections on suit's surfaces.
     partialTargetInvalidation: 1 # Fixes corrupted textures.
   memcardFilters:
@@ -18937,7 +18937,7 @@ SLES-53819:
   region: "PAL-E"
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes water rendering.
-	  cpuSpriteRenderLevel: 2 # Needed for above.
+    cpuSpriteRenderLevel: 2 # Needed for above.
     partialTargetInvalidation: 1 # Fixes broken textures.
   memcardFilters:
     - "SLES-53819"
@@ -18948,7 +18948,7 @@ SLES-53820:
   region: "PAL-E"
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes water rendering.
-	  cpuSpriteRenderLevel: 2 # Needed for above.
+    cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects shadow alignment and reduces blurriness.
     partialTargetInvalidation: 1 # Fixes broken textures.
 SLES-53821:
@@ -23723,7 +23723,7 @@ SLES-82036:
   region: "PAL-M5"
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes water rendering.
-	  cpuSpriteRenderLevel: 2 # Needed for above.
+    cpuSpriteRenderLevel: 2 # Needed for above.
     partialTargetInvalidation: 1 # Fixes broken textures.
   memcardFilters:
     - "SLES-82036"
@@ -23733,7 +23733,7 @@ SLES-82037:
   region: "PAL-M5"
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes water rendering.
-	  cpuSpriteRenderLevel: 2 # Needed for above.
+    cpuSpriteRenderLevel: 2 # Needed for above.
     partialTargetInvalidation: 1 # Fixes broken textures.
   memcardFilters:
     - "SLES-82036"
@@ -24078,7 +24078,7 @@ SLKA-25041:
     eeRoundMode: 0 # Fixes Z-Fighting.
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes water rendering.
-	  cpuSpriteRenderLevel: 2 # Needed for above.
+    cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects positioning of reflections on suit's surfaces.
     partialTargetInvalidation: 1 # Fixes corrupted textures.
   memcardFilters:
@@ -24525,7 +24525,7 @@ SLKA-25201:
   region: "NTSC-K"
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes water rendering.
-	  cpuSpriteRenderLevel: 2 # Needed for above.
+    cpuSpriteRenderLevel: 2 # Needed for above.
     partialTargetInvalidation: 1 # Fixes broken textures.
   memcardFilters:
     - "SLKA-25201"
@@ -24535,7 +24535,7 @@ SLKA-25202:
   region: "NTSC-K"
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes water rendering.
-	  cpuSpriteRenderLevel: 2 # Needed for above.
+    cpuSpriteRenderLevel: 2 # Needed for above.
     partialTargetInvalidation: 1 # Fixes broken textures.
   memcardFilters:
     - "SLKA-25201"
@@ -24777,7 +24777,7 @@ SLKA-25270:
   region: "NTSC-K"
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes water rendering.
-	  cpuSpriteRenderLevel: 2 # Needed for above.
+    cpuSpriteRenderLevel: 2 # Needed for above.
     partialTargetInvalidation: 1 # Fixes broken textures.
 SLKA-25274:
   name: "Princess Maker 4"
@@ -26044,7 +26044,7 @@ SLPM-61118:
   region: "NTSC-J"
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes water rendering.
-	  cpuSpriteRenderLevel: 2 # Needed for above.
+    cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects shadow alignment and reduces blurriness.
     partialTargetInvalidation: 1 # Fixes broken textures.
 SLPM-61119:
@@ -26052,7 +26052,7 @@ SLPM-61119:
   region: "NTSC-J"
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes water rendering.
-	  cpuSpriteRenderLevel: 2 # Needed for above.
+    cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects shadow alignment and reduces blurriness.
     partialTargetInvalidation: 1 # Fixes broken textures.
 SLPM-61120:
@@ -35853,7 +35853,7 @@ SLPM-67524:
     eeRoundMode: 0 # Fixes Z-Fighting.
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes water rendering.
-	  cpuSpriteRenderLevel: 2 # Needed for above.
+    cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects positioning of reflections on suit's surfaces.
     roundSprite: 2 # Reduces garbage on the UI whilst upscaling.
     partialTargetInvalidation: 1 # Fixes corrupted textures.
@@ -35974,7 +35974,7 @@ SLPM-68520:
   region: "NTSC-J"
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes water rendering.
-	  cpuSpriteRenderLevel: 2 # Needed for above.
+    cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects shadow alignment and reduces blurriness.
     partialTargetInvalidation: 1 # Fixes broken textures.
 SLPM-68521:
@@ -38185,7 +38185,7 @@ SLPS-25112:
     eeRoundMode: 0 # Fixes Z-Fighting.
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes water rendering.
-	  cpuSpriteRenderLevel: 2 # Needed for above.
+    cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects positioning of reflections on suit's surfaces.
     roundSprite: 2 # Reduces garbage on the UI whilst upscaling.
     partialTargetInvalidation: 1 # Fixes corrupted textures.
@@ -38390,7 +38390,7 @@ SLPS-25169:
     eeRoundMode: 0 # Fixes Z-Fighting.
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes water rendering.
-	  cpuSpriteRenderLevel: 2 # Needed for above.
+    cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects positioning of reflections on suit's surfaces.
     partialTargetInvalidation: 1 # Fixes corrupted textures.
   memcardFilters:
@@ -38958,7 +38958,7 @@ SLPS-25338:
   region: "NTSC-J"
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes water rendering.
-	  cpuSpriteRenderLevel: 2 # Needed for above.
+    cpuSpriteRenderLevel: 2 # Needed for above.
     partialTargetInvalidation: 1 # Fixes broken textures.
   memcardFilters:
     - "SCAJ-20076"
@@ -38972,7 +38972,7 @@ SLPS-25339:
   region: "NTSC-J"
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes water rendering.
-	  cpuSpriteRenderLevel: 2 # Needed for above.
+    cpuSpriteRenderLevel: 2 # Needed for above.
     partialTargetInvalidation: 1 # Fixes broken textures.
   memcardFilters:
     - "SCAJ-20076"
@@ -39263,7 +39263,7 @@ SLPS-25408:
   region: "NTSC-J"
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes water rendering.
-	  cpuSpriteRenderLevel: 2 # Needed for above.
+    cpuSpriteRenderLevel: 2 # Needed for above.
     partialTargetInvalidation: 1 # Fixes broken textures.
   memcardFilters:
     - "SLPS-25408"
@@ -39465,14 +39465,14 @@ SLPS-25461:
   region: "NTSC-J"
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes water rendering.
-	  cpuSpriteRenderLevel: 2 # Needed for above.
+    cpuSpriteRenderLevel: 2 # Needed for above.
     partialTargetInvalidation: 1 # Fixes broken textures.
 SLPS-25462:
   name: "Armored Core - Last Raven"
   region: "NTSC-J"
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes water rendering.
-	  cpuSpriteRenderLevel: 2 # Needed for above.
+    cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects shadow alignment and reduces blurriness.
     partialTargetInvalidation: 1 # Fixes broken textures.
   memcardFilters:
@@ -40489,7 +40489,7 @@ SLPS-25730:
   region: "NTSC-J"
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes water rendering.
-	  cpuSpriteRenderLevel: 2 # Needed for above.
+    cpuSpriteRenderLevel: 2 # Needed for above.
     partialTargetInvalidation: 1 # Fixes broken textures.
 SLPS-25731:
   name: "Armored Core 2 [Machine Side Box]"
@@ -40501,7 +40501,7 @@ SLPS-25732:
   region: "NTSC-J"
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes water rendering.
-	  cpuSpriteRenderLevel: 2 # Needed for above.
+    cpuSpriteRenderLevel: 2 # Needed for above.
     partialTargetInvalidation: 1 # Fixes broken textures.
 SLPS-25733:
   name: "Super Robot Taisen OG - Original Generations"
@@ -41355,7 +41355,7 @@ SLPS-73202:
   region: "NTSC-J"
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes water rendering.
-	  cpuSpriteRenderLevel: 2 # Needed for above.
+    cpuSpriteRenderLevel: 2 # Needed for above.
     partialTargetInvalidation: 1 # Fixes broken textures.
   memcardFilters:
     - "SCAJ-20076"
@@ -41369,7 +41369,7 @@ SLPS-73203:
   region: "NTSC-J"
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes water rendering.
-	  cpuSpriteRenderLevel: 2 # Needed for above.
+    cpuSpriteRenderLevel: 2 # Needed for above.
     partialTargetInvalidation: 1 # Fixes broken textures.
   memcardFilters:
     - "SCAJ-20076"
@@ -41657,7 +41657,7 @@ SLPS-73247:
   region: "NTSC-J"
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes water rendering.
-	  cpuSpriteRenderLevel: 2 # Needed for above.
+    cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects shadow alignment and reduces blurriness.
     partialTargetInvalidation: 1 # Fixes broken textures.
   memcardFilters:
@@ -41835,7 +41835,7 @@ SLPS-73417:
     eeRoundMode: 0 # Fixes Z-Fighting.
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes water rendering.
-	  cpuSpriteRenderLevel: 2 # Needed for above.
+    cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects positioning of reflections on suit's surfaces.
     roundSprite: 2 # Reduces garbage on the UI whilst upscaling.
     partialTargetInvalidation: 1 # Fixes corrupted textures.
@@ -41856,7 +41856,7 @@ SLPS-73420:
     eeRoundMode: 0 # Fixes Z-Fighting.
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes water rendering.
-	  cpuSpriteRenderLevel: 2 # Needed for above.
+    cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects positioning of reflections on suit's surfaces.
     partialTargetInvalidation: 1 # Fixes corrupted textures.
   memcardFilters:
@@ -43750,7 +43750,7 @@ SLUS-20435:
     eeRoundMode: 0 # Fixes Z-Fighting.
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes water rendering.
-	  cpuSpriteRenderLevel: 2 # Needed for above.
+    cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects positioning of reflections on suit's surfaces.
     roundSprite: 2 # Reduces garbage on the UI whilst upscaling.
     partialTargetInvalidation: 1 # Fixes corrupted textures.
@@ -44777,7 +44777,7 @@ SLUS-20644:
     eeRoundMode: 0 # Fixes Z-Fighting.
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes water rendering.
-	  cpuSpriteRenderLevel: 2 # Needed for above.
+    cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects positioning of reflections on suit's surfaces.
     partialTargetInvalidation: 1 # Fixes corrupted textures.
   memcardFilters: # Can import data from AC3.
@@ -46509,7 +46509,7 @@ SLUS-20986:
   compat: 5
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes water rendering.
-	  cpuSpriteRenderLevel: 2 # Needed for above.
+    cpuSpriteRenderLevel: 2 # Needed for above.
     partialTargetInvalidation: 1 # Fixes broken textures.
   memcardFilters:
     - "SLUS-20986"
@@ -47024,7 +47024,7 @@ SLUS-21079:
   region: "NTSC-U"
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes water rendering.
-	  cpuSpriteRenderLevel: 2 # Needed for above.
+    cpuSpriteRenderLevel: 2 # Needed for above.
     partialTargetInvalidation: 1 # Fixes broken textures.
   memcardFilters:
     - "SLUS-20986"
@@ -47621,7 +47621,7 @@ SLUS-21200:
   compat: 5
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes water rendering.
-	  cpuSpriteRenderLevel: 2 # Needed for above.
+    cpuSpriteRenderLevel: 2 # Needed for above.
     partialTargetInvalidation: 1 # Fixes broken textures.
   memcardFilters: # Can import data from AC:Nexus.
     - "SLUS-21200"
@@ -48477,7 +48477,7 @@ SLUS-21338:
   compat: 5
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes water rendering.
-	  cpuSpriteRenderLevel: 2 # Needed for above.
+    cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects shadow alignment and reduces blurriness.
     partialTargetInvalidation: 1 # Fixes broken textures.
 SLUS-21339:

--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -532,6 +532,8 @@ SCAJ-20011:
   roundModes:
     eeRoundMode: 0 # Fixes Z-Fighting.
   gsHWFixes:
+    cpuSpriteRenderBW: 2 # Fixes water rendering.
+	  cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects positioning of reflections on suit's surfaces.
     partialTargetInvalidation: 1 # Fixes corrupted textures.
   memcardFilters:
@@ -809,6 +811,8 @@ SCAJ-20076:
   name: "Armored Core - Nexus [Disc 1]"
   region: "NTSC-Unk"
   gsHWFixes:
+    cpuSpriteRenderBW: 2 # Fixes water rendering.
+	  cpuSpriteRenderLevel: 2 # Needed for above.
     partialTargetInvalidation: 1 # Fixes broken textures.
   memcardFilters:
     - "SCAJ-20076"
@@ -821,6 +825,8 @@ SCAJ-20077:
   name: "Armored Core - Nexus [Disc 2]"
   region: "NTSC-Unk"
   gsHWFixes:
+    cpuSpriteRenderBW: 2 # Fixes water rendering.
+	  cpuSpriteRenderLevel: 2 # Needed for above.
     partialTargetInvalidation: 1 # Fixes broken textures.
   memcardFilters:
     - "SCAJ-20076"
@@ -967,6 +973,8 @@ SCAJ-20105:
   name: "Armored Core - Nine breaker"
   region: "NTSC-Unk"
   gsHWFixes:
+    cpuSpriteRenderBW: 2 # Fixes water rendering.
+	  cpuSpriteRenderLevel: 2 # Needed for above.
     partialTargetInvalidation: 1 # Fixes broken textures.
 SCAJ-20107:
   name: "Bakufuu Slash! Kizna Arashi"
@@ -1052,6 +1060,8 @@ SCAJ-20121:
   name: "Armored Core - Formula Front"
   region: "NTSC-Unk"
   gsHWFixes:
+    cpuSpriteRenderBW: 2 # Fixes water rendering.
+	  cpuSpriteRenderLevel: 2 # Needed for above.
     partialTargetInvalidation: 1 # Fixes broken textures.
 SCAJ-20122:
   name: "Swords of Destiny"
@@ -1184,6 +1194,8 @@ SCAJ-20143:
   name: "Armored Core - Last Raven"
   region: "NTSC-Unk"
   gsHWFixes:
+    cpuSpriteRenderBW: 2 # Fixes water rendering.
+	  cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects shadow alignment and reduces blurriness.
     partialTargetInvalidation: 1 # Fixes broken textures.
 SCAJ-20144:
@@ -5221,6 +5233,8 @@ SCKA-20047:
   name: "Armored Core - Nine Breaker"
   region: "NTSC-K"
   gsHWFixes:
+    cpuSpriteRenderBW: 2 # Fixes water rendering.
+	  cpuSpriteRenderLevel: 2 # Needed for above.
     partialTargetInvalidation: 1 # Fixes broken textures.
   memcardFilters:
     - "SCKA-20047"
@@ -6955,6 +6969,8 @@ SCPS-55014:
   roundModes:
     eeRoundMode: 0 # Fixes Z-Fighting.
   gsHWFixes:
+    cpuSpriteRenderBW: 2 # Fixes water rendering.
+	  cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects positioning of reflections on suit's surfaces.
     roundSprite: 2 # Reduces garbage on the UI whilst upscaling.
     partialTargetInvalidation: 1 # Fixes corrupted textures.
@@ -13079,6 +13095,8 @@ SLES-51399:
   roundModes:
     eeRoundMode: 0 # Fixes Z-Fighting.
   gsHWFixes:
+    cpuSpriteRenderBW: 2 # Fixes water rendering.
+	  cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects positioning of reflections on suit's surfaces.
     roundSprite: 2 # Reduces garbage on the UI whilst upscaling.
     partialTargetInvalidation: 1 # Fixes corrupted textures.
@@ -14668,6 +14686,8 @@ SLES-52203:
   roundModes:
     eeRoundMode: 0 # Fixes Z-Fighting.
   gsHWFixes:
+    cpuSpriteRenderBW: 2 # Fixes water rendering.
+	  cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects positioning of reflections on suit's surfaces.
     partialTargetInvalidation: 1 # Fixes corrupted textures.
   memcardFilters:
@@ -18916,6 +18936,8 @@ SLES-53819:
   name: "Armored Core - Nine Breaker"
   region: "PAL-E"
   gsHWFixes:
+    cpuSpriteRenderBW: 2 # Fixes water rendering.
+	  cpuSpriteRenderLevel: 2 # Needed for above.
     partialTargetInvalidation: 1 # Fixes broken textures.
   memcardFilters:
     - "SLES-53819"
@@ -18925,6 +18947,8 @@ SLES-53820:
   name: "Armored Core - Last Raven"
   region: "PAL-E"
   gsHWFixes:
+    cpuSpriteRenderBW: 2 # Fixes water rendering.
+	  cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects shadow alignment and reduces blurriness.
     partialTargetInvalidation: 1 # Fixes broken textures.
 SLES-53821:
@@ -23698,6 +23722,8 @@ SLES-82036:
   name: "Armored Core - Nexus [Disc 1]"
   region: "PAL-M5"
   gsHWFixes:
+    cpuSpriteRenderBW: 2 # Fixes water rendering.
+	  cpuSpriteRenderLevel: 2 # Needed for above.
     partialTargetInvalidation: 1 # Fixes broken textures.
   memcardFilters:
     - "SLES-82036"
@@ -23706,6 +23732,8 @@ SLES-82037:
   name: "Armored Core - Nexus [Disc 2]"
   region: "PAL-M5"
   gsHWFixes:
+    cpuSpriteRenderBW: 2 # Fixes water rendering.
+	  cpuSpriteRenderLevel: 2 # Needed for above.
     partialTargetInvalidation: 1 # Fixes broken textures.
   memcardFilters:
     - "SLES-82036"
@@ -24049,6 +24077,8 @@ SLKA-25041:
   roundModes:
     eeRoundMode: 0 # Fixes Z-Fighting.
   gsHWFixes:
+    cpuSpriteRenderBW: 2 # Fixes water rendering.
+	  cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects positioning of reflections on suit's surfaces.
     partialTargetInvalidation: 1 # Fixes corrupted textures.
   memcardFilters:
@@ -24494,6 +24524,8 @@ SLKA-25201:
   name: "Armored Core - Nexus [Disc 1]"
   region: "NTSC-K"
   gsHWFixes:
+    cpuSpriteRenderBW: 2 # Fixes water rendering.
+	  cpuSpriteRenderLevel: 2 # Needed for above.
     partialTargetInvalidation: 1 # Fixes broken textures.
   memcardFilters:
     - "SLKA-25201"
@@ -24502,6 +24534,8 @@ SLKA-25202:
   name: "Armored Core - Nexus [Disc 2]"
   region: "NTSC-K"
   gsHWFixes:
+    cpuSpriteRenderBW: 2 # Fixes water rendering.
+	  cpuSpriteRenderLevel: 2 # Needed for above.
     partialTargetInvalidation: 1 # Fixes broken textures.
   memcardFilters:
     - "SLKA-25201"
@@ -24742,6 +24776,8 @@ SLKA-25270:
   name: "Armored Core - Formula Front"
   region: "NTSC-K"
   gsHWFixes:
+    cpuSpriteRenderBW: 2 # Fixes water rendering.
+	  cpuSpriteRenderLevel: 2 # Needed for above.
     partialTargetInvalidation: 1 # Fixes broken textures.
 SLKA-25274:
   name: "Princess Maker 4"
@@ -26007,12 +26043,16 @@ SLPM-61118:
   name: "Armored Core - Last Raven [Famitsu Special Trial Version]"
   region: "NTSC-J"
   gsHWFixes:
+    cpuSpriteRenderBW: 2 # Fixes water rendering.
+	  cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects shadow alignment and reduces blurriness.
     partialTargetInvalidation: 1 # Fixes broken textures.
 SLPM-61119:
   name: "Armored Core - Last Raven [Trial]"
   region: "NTSC-J"
   gsHWFixes:
+    cpuSpriteRenderBW: 2 # Fixes water rendering.
+	  cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects shadow alignment and reduces blurriness.
     partialTargetInvalidation: 1 # Fixes broken textures.
 SLPM-61120:
@@ -35812,6 +35852,8 @@ SLPM-67524:
   roundModes:
     eeRoundMode: 0 # Fixes Z-Fighting.
   gsHWFixes:
+    cpuSpriteRenderBW: 2 # Fixes water rendering.
+	  cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects positioning of reflections on suit's surfaces.
     roundSprite: 2 # Reduces garbage on the UI whilst upscaling.
     partialTargetInvalidation: 1 # Fixes corrupted textures.
@@ -35931,6 +35973,8 @@ SLPM-68520:
   name: "Armored Core - Last Raven [Monthly Champion magazine Special Edition]"
   region: "NTSC-J"
   gsHWFixes:
+    cpuSpriteRenderBW: 2 # Fixes water rendering.
+	  cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects shadow alignment and reduces blurriness.
     partialTargetInvalidation: 1 # Fixes broken textures.
 SLPM-68521:
@@ -38140,6 +38184,8 @@ SLPS-25112:
   roundModes:
     eeRoundMode: 0 # Fixes Z-Fighting.
   gsHWFixes:
+    cpuSpriteRenderBW: 2 # Fixes water rendering.
+	  cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects positioning of reflections on suit's surfaces.
     roundSprite: 2 # Reduces garbage on the UI whilst upscaling.
     partialTargetInvalidation: 1 # Fixes corrupted textures.
@@ -38343,6 +38389,8 @@ SLPS-25169:
   roundModes:
     eeRoundMode: 0 # Fixes Z-Fighting.
   gsHWFixes:
+    cpuSpriteRenderBW: 2 # Fixes water rendering.
+	  cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects positioning of reflections on suit's surfaces.
     partialTargetInvalidation: 1 # Fixes corrupted textures.
   memcardFilters:
@@ -38909,6 +38957,8 @@ SLPS-25338:
   name: "Armored Core - Nexus [Disc 1]"
   region: "NTSC-J"
   gsHWFixes:
+    cpuSpriteRenderBW: 2 # Fixes water rendering.
+	  cpuSpriteRenderLevel: 2 # Needed for above.
     partialTargetInvalidation: 1 # Fixes broken textures.
   memcardFilters:
     - "SCAJ-20076"
@@ -38921,6 +38971,8 @@ SLPS-25339:
   name: "Armored Core - Nexus [Disc 2]"
   region: "NTSC-J"
   gsHWFixes:
+    cpuSpriteRenderBW: 2 # Fixes water rendering.
+	  cpuSpriteRenderLevel: 2 # Needed for above.
     partialTargetInvalidation: 1 # Fixes broken textures.
   memcardFilters:
     - "SCAJ-20076"
@@ -39210,6 +39262,8 @@ SLPS-25408:
   name: "Armored Core - Nine Breaker"
   region: "NTSC-J"
   gsHWFixes:
+    cpuSpriteRenderBW: 2 # Fixes water rendering.
+	  cpuSpriteRenderLevel: 2 # Needed for above.
     partialTargetInvalidation: 1 # Fixes broken textures.
   memcardFilters:
     - "SLPS-25408"
@@ -39410,11 +39464,15 @@ SLPS-25461:
   name: "Armored Core - Formula Front"
   region: "NTSC-J"
   gsHWFixes:
+    cpuSpriteRenderBW: 2 # Fixes water rendering.
+	  cpuSpriteRenderLevel: 2 # Needed for above.
     partialTargetInvalidation: 1 # Fixes broken textures.
 SLPS-25462:
   name: "Armored Core - Last Raven"
   region: "NTSC-J"
   gsHWFixes:
+    cpuSpriteRenderBW: 2 # Fixes water rendering.
+	  cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects shadow alignment and reduces blurriness.
     partialTargetInvalidation: 1 # Fixes broken textures.
   memcardFilters:
@@ -40430,6 +40488,8 @@ SLPS-25730:
   name: "Armored Core - Last Raven [Machine Side Box]"
   region: "NTSC-J"
   gsHWFixes:
+    cpuSpriteRenderBW: 2 # Fixes water rendering.
+	  cpuSpriteRenderLevel: 2 # Needed for above.
     partialTargetInvalidation: 1 # Fixes broken textures.
 SLPS-25731:
   name: "Armored Core 2 [Machine Side Box]"
@@ -40440,6 +40500,8 @@ SLPS-25732:
   name: "Armored Core 3 [Machine Side Box]"
   region: "NTSC-J"
   gsHWFixes:
+    cpuSpriteRenderBW: 2 # Fixes water rendering.
+	  cpuSpriteRenderLevel: 2 # Needed for above.
     partialTargetInvalidation: 1 # Fixes broken textures.
 SLPS-25733:
   name: "Super Robot Taisen OG - Original Generations"
@@ -41292,6 +41354,8 @@ SLPS-73202:
   name: "Armored Core - Nexus [Disc 1] [PlayStation 2 The Best]"
   region: "NTSC-J"
   gsHWFixes:
+    cpuSpriteRenderBW: 2 # Fixes water rendering.
+	  cpuSpriteRenderLevel: 2 # Needed for above.
     partialTargetInvalidation: 1 # Fixes broken textures.
   memcardFilters:
     - "SCAJ-20076"
@@ -41304,6 +41368,8 @@ SLPS-73203:
   name: "Armored Core - Nexus [Disc 2] [PlayStation 2 The Best]"
   region: "NTSC-J"
   gsHWFixes:
+    cpuSpriteRenderBW: 2 # Fixes water rendering.
+	  cpuSpriteRenderLevel: 2 # Needed for above.
     partialTargetInvalidation: 1 # Fixes broken textures.
   memcardFilters:
     - "SCAJ-20076"
@@ -41590,6 +41656,8 @@ SLPS-73247:
   name: "Armored Core - Last Raven [PlayStation 2 The Best]"
   region: "NTSC-J"
   gsHWFixes:
+    cpuSpriteRenderBW: 2 # Fixes water rendering.
+	  cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects shadow alignment and reduces blurriness.
     partialTargetInvalidation: 1 # Fixes broken textures.
   memcardFilters:
@@ -41766,6 +41834,8 @@ SLPS-73417:
   roundModes:
     eeRoundMode: 0 # Fixes Z-Fighting.
   gsHWFixes:
+    cpuSpriteRenderBW: 2 # Fixes water rendering.
+	  cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects positioning of reflections on suit's surfaces.
     roundSprite: 2 # Reduces garbage on the UI whilst upscaling.
     partialTargetInvalidation: 1 # Fixes corrupted textures.
@@ -41785,6 +41855,8 @@ SLPS-73420:
   roundModes:
     eeRoundMode: 0 # Fixes Z-Fighting.
   gsHWFixes:
+    cpuSpriteRenderBW: 2 # Fixes water rendering.
+	  cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects positioning of reflections on suit's surfaces.
     partialTargetInvalidation: 1 # Fixes corrupted textures.
   memcardFilters:
@@ -43677,6 +43749,8 @@ SLUS-20435:
   roundModes:
     eeRoundMode: 0 # Fixes Z-Fighting.
   gsHWFixes:
+    cpuSpriteRenderBW: 2 # Fixes water rendering.
+	  cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects positioning of reflections on suit's surfaces.
     roundSprite: 2 # Reduces garbage on the UI whilst upscaling.
     partialTargetInvalidation: 1 # Fixes corrupted textures.
@@ -44702,6 +44776,8 @@ SLUS-20644:
   roundModes:
     eeRoundMode: 0 # Fixes Z-Fighting.
   gsHWFixes:
+    cpuSpriteRenderBW: 2 # Fixes water rendering.
+	  cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects positioning of reflections on suit's surfaces.
     partialTargetInvalidation: 1 # Fixes corrupted textures.
   memcardFilters: # Can import data from AC3.
@@ -46432,6 +46508,8 @@ SLUS-20986:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
+    cpuSpriteRenderBW: 2 # Fixes water rendering.
+	  cpuSpriteRenderLevel: 2 # Needed for above.
     partialTargetInvalidation: 1 # Fixes broken textures.
   memcardFilters:
     - "SLUS-20986"
@@ -46945,6 +47023,8 @@ SLUS-21079:
   name: "Armored Core - Nexus [Disc 2]"
   region: "NTSC-U"
   gsHWFixes:
+    cpuSpriteRenderBW: 2 # Fixes water rendering.
+	  cpuSpriteRenderLevel: 2 # Needed for above.
     partialTargetInvalidation: 1 # Fixes broken textures.
   memcardFilters:
     - "SLUS-20986"
@@ -47540,6 +47620,8 @@ SLUS-21200:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
+    cpuSpriteRenderBW: 2 # Fixes water rendering.
+	  cpuSpriteRenderLevel: 2 # Needed for above.
     partialTargetInvalidation: 1 # Fixes broken textures.
   memcardFilters: # Can import data from AC:Nexus.
     - "SLUS-21200"
@@ -48394,6 +48476,8 @@ SLUS-21338:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
+    cpuSpriteRenderBW: 2 # Fixes water rendering.
+	  cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects shadow alignment and reduces blurriness.
     partialTargetInvalidation: 1 # Fixes broken textures.
 SLUS-21339:

--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -5218,7 +5218,7 @@ SCKA-20045:
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
 SCKA-20047:
-  name: "Armored Core Nine Breaker"
+  name: "Armored Core - Nine Breaker"
   region: "NTSC-K"
   gsHWFixes:
     partialTargetInvalidation: 1 # Fixes broken textures.
@@ -14662,7 +14662,7 @@ SLES-52202:
   region: "PAL-M5"
   compat: 5
 SLES-52203:
-  name: "Armored Core - Silent Line"
+  name: "Armored Core 3 - Silent Line"
   region: "PAL-E"
   compat: 5
   roundModes:
@@ -23695,7 +23695,7 @@ SLES-82035:
     - "SLES-82034"
     - "SCES-82034"
 SLES-82036:
-  name: "Armored Core - Nexus [Disc 1 of 2 - Evolution Disc]"
+  name: "Armored Core - Nexus [Disc 1]"
   region: "PAL-M5"
   gsHWFixes:
     partialTargetInvalidation: 1 # Fixes broken textures.
@@ -23703,7 +23703,7 @@ SLES-82036:
     - "SLES-82036"
     - "SLES-82037"
 SLES-82037:
-  name: "Armored Core - Nexus [Disc 2 of 2 - Revolution Disc]"
+  name: "Armored Core - Nexus [Disc 2]"
   region: "PAL-M5"
   gsHWFixes:
     partialTargetInvalidation: 1 # Fixes broken textures.
@@ -24044,7 +24044,7 @@ SLKA-25039:
   roundModes:
     vu1RoundMode: 1 # Bright lights in cars.
 SLKA-25041:
-  name: "Armored Core 3 Silent Line"
+  name: "Armored Core 3 - Silent Line"
   region: "NTSC-K"
   roundModes:
     eeRoundMode: 0 # Fixes Z-Fighting.
@@ -24491,7 +24491,7 @@ SLKA-25200:
     textureInsideRT: 1 # Fixes rainbow effect in the pause menu before a jump.
     halfPixelOffset: 2 # Fixes depth lines.
 SLKA-25201:
-  name: "Armored Core Nexus Evolution [Disc 1]"
+  name: "Armored Core - Nexus [Disc 1]"
   region: "NTSC-K"
   gsHWFixes:
     partialTargetInvalidation: 1 # Fixes broken textures.
@@ -24499,7 +24499,7 @@ SLKA-25201:
     - "SLKA-25201"
     - "SLKA-25202"
 SLKA-25202:
-  name: "Armored Core Nexus Revolution [Disc 2]"
+  name: "Armored Core - Nexus [Disc 2]"
   region: "NTSC-K"
   gsHWFixes:
     partialTargetInvalidation: 1 # Fixes broken textures.
@@ -40427,7 +40427,7 @@ SLPS-25729:
   name: "Kujibiki Unbalance"
   region: "NTSC-J"
 SLPS-25730:
-  name: "Armored Core [Machine Side Box]"
+  name: "Armored Core - Last Raven [Machine Side Box]"
   region: "NTSC-J"
   gsHWFixes:
     partialTargetInvalidation: 1 # Fixes broken textures.
@@ -41289,7 +41289,7 @@ SLPS-73201:
   name: "Fatal Frame II - Crimson Butterfly [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPS-73202:
-  name: "Armored Core - Nexus [PlayStation 2 The Best] [Disc 1]"
+  name: "Armored Core - Nexus [Disc 1] [PlayStation 2 The Best]"
   region: "NTSC-J"
   gsHWFixes:
     partialTargetInvalidation: 1 # Fixes broken textures.
@@ -41301,7 +41301,7 @@ SLPS-73202:
     - "SLPS-73202"
     - "SLPS-73203"
 SLPS-73203:
-  name: "Armored Core - Nexus [PlayStation 2 The Best] [Disc 2]"
+  name: "Armored Core - Nexus [Disc 2] [PlayStation 2 The Best]"
   region: "NTSC-J"
   gsHWFixes:
     partialTargetInvalidation: 1 # Fixes broken textures.
@@ -46428,7 +46428,7 @@ SLUS-20985:
   name: "Under the Skin"
   region: "NTSC-U"
 SLUS-20986:
-  name: "Armored Core Nexus [Evolution Disc]"
+  name: "Armored Core - Nexus [Disc 1]"
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
@@ -46942,7 +46942,7 @@ SLUS-21078:
   gsHWFixes:
     halfPixelOffset: 1 # Reduces lighting misalignment but doesn't fully fix it.
 SLUS-21079:
-  name: "Armored Core Nexus [Revolution Disc]"
+  name: "Armored Core - Nexus [Disc 2]"
   region: "NTSC-U"
   gsHWFixes:
     partialTargetInvalidation: 1 # Fixes broken textures.


### PR DESCRIPTION
### Description of Changes
- Made names of Armored Core games uniform.
- Add CPU Sprite Render Size to bunch of Armored Core games for fixing #2397

### Rationale behind Changes
- Makes easy to look for Armored Core games in GameIndex.yaml
- Fixes #2397
- Only for Last Raven, this change causes z-fighting on some shadow rendering.

### Suggested Testing Steps
I'm not sure.
