### PR TITLE
Qt: Add Video Capture Button to the Toolbar

### DIFF
--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -389,7 +389,7 @@ void MainWindow::connectSignals()
 	connect(m_ui.actionSaveBlockDump, &QAction::toggled, this, &MainWindow::onBlockDumpActionToggled);
 	connect(m_ui.actionShowAdvancedSettings, &QAction::toggled, this, &MainWindow::onShowAdvancedSettingsToggled);
 	connect(m_ui.actionSaveGSDump, &QAction::triggered, this, &MainWindow::onSaveGSDumpActionTriggered);
-	connect(m_ui.actionToolsVideoCapture, &QAction::toggled, this, &MainWindow::onToolsVideoCaptureToggled);
+	connect(m_ui.actionVideoCapture, &QAction::toggled, this, &MainWindow::onVideoCaptureToggled);
 
 	// Input Recording
 	connect(m_ui.actionInputRecNew, &QAction::triggered, this, &MainWindow::onInputRecNewActionTriggered);
@@ -786,7 +786,7 @@ void MainWindow::setStyleFromSettings()
 		// Alternative dark theme.
 		qApp->setStyle(QStyleFactory::create("Fusion"));
 
-		const QColor gray(192, 192, 192);
+		const QColor gray(150, 150, 150);
 		const QColor royalBlue(29, 41, 81);
 		const QColor darkishBlue(17, 30, 108);
 		const QColor highlight(36, 93, 218);
@@ -1029,7 +1029,7 @@ void MainWindow::onShowAdvancedSettingsToggled(bool checked)
 		recreateSettings();
 }
 
-void MainWindow::onToolsVideoCaptureToggled(bool checked)
+void MainWindow::onVideoCaptureToggled(bool checked)
 {
 	if (!s_vm_valid)
 		return;
@@ -1048,8 +1048,8 @@ void MainWindow::onToolsVideoCaptureToggled(bool checked)
 	path = QFileDialog::getSaveFileName(this, tr("Video Capture"), path, filter);
 	if (path.isEmpty())
 	{
-		QSignalBlocker sb(m_ui.actionToolsVideoCapture);
-		m_ui.actionToolsVideoCapture->setChecked(false);
+		QSignalBlocker sb(m_ui.actionVideoCapture);
+		m_ui.actionVideoCapture->setChecked(false);
 		return;
 	}
 
@@ -1144,11 +1144,11 @@ void MainWindow::updateEmulationActions(bool starting, bool running, bool stoppi
 
 	m_ui.actionViewGameProperties->setEnabled(running);
 
-	m_ui.actionToolsVideoCapture->setEnabled(running);
-	if (!running && m_ui.actionToolsVideoCapture->isChecked())
+	m_ui.actionVideoCapture->setEnabled(running);
+	if (!running && m_ui.actionVideoCapture->isChecked())
 	{
-		QSignalBlocker sb(m_ui.actionToolsVideoCapture);
-		m_ui.actionToolsVideoCapture->setChecked(false);
+		QSignalBlocker sb(m_ui.actionVideoCapture);
+		m_ui.actionVideoCapture->setChecked(false);
 	}
 
 	m_game_list_widget->setDisabled(starting && !running);

--- a/pcsx2-qt/MainWindow.h
+++ b/pcsx2-qt/MainWindow.h
@@ -170,7 +170,7 @@ private Q_SLOTS:
 	void onSaveGSDumpActionTriggered();
 	void onBlockDumpActionToggled(bool checked);
 	void onShowAdvancedSettingsToggled(bool checked);
-	void onToolsVideoCaptureToggled(bool checked);
+	void onVideoCaptureToggled(bool checked);
 	void onSettingsTriggeredFromToolbar();
 
 	// Input Recording

--- a/pcsx2-qt/MainWindow.ui
+++ b/pcsx2-qt/MainWindow.ui
@@ -191,7 +191,7 @@
     <addaction name="actionToggleSoftwareRendering"/>
     <addaction name="actionReloadPatches"/>
     <addaction name="menuInput_Recording"/>
-    <addaction name="actionToolsVideoCapture"/>
+    <addaction name="actionVideoCapture"/>
     <addaction name="separator"/>
     <addaction name="actionEnableSystemConsole"/>
     <addaction name="actionEnableFileLogging"/>
@@ -239,7 +239,9 @@
    <addaction name="actionReset"/>
    <addaction name="actionPause"/>
    <addaction name="actionChangeDisc"/>
+   <addaction name="separator"/>
    <addaction name="actionScreenshot"/>
+   <addaction name="actionVideoCapture"/>
    <addaction name="separator"/>
    <addaction name="actionLoadState"/>
    <addaction name="actionSaveState"/>
@@ -919,9 +921,13 @@
     <string>Recording Viewer</string>
    </property>
   </action>
-  <action name="actionToolsVideoCapture">
+  <action name="actionVideoCapture">
    <property name="checkable">
     <bool>true</bool>
+   </property>
+   <property name="icon">
+    <iconset theme="camera-video">
+     <normaloff>.</normaloff>.</iconset>
    </property>
    <property name="text">
     <string>Video Capture</string>

--- a/pcsx2-qt/resources/icons/black/svg/camera-video.svg
+++ b/pcsx2-qt/resources/icons/black/svg/camera-video.svg
@@ -1,0 +1,3 @@
+<?xml version="1.0" standalone="no"?>
+        <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" 
+        "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-camera-video" viewBox="0 0 16 16"> <path fill-rule="evenodd" d="M0 5a2 2 0 0 1 2-2h7.5a2 2 0 0 1 1.983 1.738l3.11-1.382A1 1 0 0 1 16 4.269v7.462a1 1 0 0 1-1.406.913l-3.111-1.382A2 2 0 0 1 9.5 13H2a2 2 0 0 1-2-2V5zm11.5 5.175 3.5 1.556V4.269l-3.5 1.556v4.35zM2 4a1 1 0 0 0-1 1v6a1 1 0 0 0 1 1h7.5a1 1 0 0 0 1-1V5a1 1 0 0 0-1-1H2z"/> </svg>  

--- a/pcsx2-qt/resources/icons/white/svg/camera-video.svg
+++ b/pcsx2-qt/resources/icons/white/svg/camera-video.svg
@@ -1,0 +1,3 @@
+<?xml version="1.0" standalone="no"?>
+        <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" 
+        "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd"> <svg style="color: white" xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-camera-video" viewBox="0 0 16 16"> <path fill-rule="evenodd" d="M0 5a2 2 0 0 1 2-2h7.5a2 2 0 0 1 1.983 1.738l3.11-1.382A1 1 0 0 1 16 4.269v7.462a1 1 0 0 1-1.406.913l-3.111-1.382A2 2 0 0 1 9.5 13H2a2 2 0 0 1-2-2V5zm11.5 5.175 3.5 1.556V4.269l-3.5 1.556v4.35zM2 4a1 1 0 0 0-1 1v6a1 1 0 0 0 1 1h7.5a1 1 0 0 0 1-1V5a1 1 0 0 0-1-1H2z" fill="white"></path> </svg> 

--- a/pcsx2-qt/resources/resources.qrc
+++ b/pcsx2-qt/resources/resources.qrc
@@ -8,6 +8,7 @@
 		<file>icons/black/svg/artboard-2-line.svg</file>
 		<file>icons/black/svg/book-open-line.svg</file>
 		<file>icons/black/svg/brush-line.svg</file>
+		<file>icons/black/svg/camera-video.svg</file>
 		<file>icons/black/svg/checkbox-multiple-blank-line.svg</file>
 		<file>icons/black/svg/close-line.svg</file>
 		<file>icons/black/svg/dashboard-line.svg</file>
@@ -70,6 +71,7 @@
 		<file>icons/white/svg/artboard-2-line.svg</file>
 		<file>icons/white/svg/book-open-line.svg</file>
 		<file>icons/white/svg/brush-line.svg</file>
+		<file>icons/white/svg/camera-video.svg</file>
 		<file>icons/white/svg/checkbox-multiple-blank-line.svg</file>
 		<file>icons/white/svg/close-line.svg</file>
 		<file>icons/white/svg/dashboard-line.svg</file>


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
This PR adds the Video Capture Button to the Toolbar for easier access, the old way of accessing it through the Tools menu remains unchanged. I have also added a custom icon for it.

List of changes:

- Adjusted the name of the variables to better match the context since there are now more than one way to access the Video Capture feature.
- Added Custom icon to go with the new button.

- Even more polish to the Cobalt Theme (made the inactive text label a bit darker to better distinguish it).

Here's a preview:
![Screenshot_20230421_213406](https://user-images.githubusercontent.com/14798312/233663039-7bd50c3a-4220-4096-be84-972433a304a7.png)


### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Having the button in the toolbar made accessing it easier and potentially allows more people to discover it's existence!
And not having to open the Tools menu everytime to access the feature is a time saver!

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Tests if the buttons are working properly! ;)
I have tested it myself (they're working great!) but if you found any issues please do let me know! :D