### PR TITLE
VU-JIT: Backup non cached VI before writing to it when load != write

### DIFF
--- a/pcsx2/x86/microVU_IR.h
+++ b/pcsx2/x86/microVU_IR.h
@@ -1025,7 +1025,17 @@ public:
 							// allocate a new register for writing to
 							int x = findFreeGPR(viWriteReg);
 							const xRegister32& gprX = xRegister32::GetInstance(x);
+
 							writeBackReg(gprX, true);
+
+							// writeReg not cached, needs backing up
+							if (backup && gprMap[x].VIreg != viWriteReg)
+							{
+								xMOVZX(gprX, ptr16[&getVI(viWriteReg)]);
+								writeVIBackup(gprX);
+								backup = false;
+							}
+
 							if (zext_if_dirty)
 								xMOVZX(gprX, xRegister16(i));
 							else


### PR DESCRIPTION
### Description of Changes
Make sure to back up the VI register being used before copying a new value in to it.

### Rationale behind Changes
If writeReg wasn't currently cached, but the loadReg was cached, it's likely that they weren't the same reg, however there was no path where the current value of writeReg was being backed up for immediately following branches. This caused SPS in World Rally Championship.

### Suggested Testing Steps
Test games generally, but also if you know games which have problems with VU JIT but not int (or the old SuperVU), it may affect them.

World Rally Championship:

Master:
![image](https://user-images.githubusercontent.com/6278726/233762835-c554830a-9a63-47ec-b90a-941dae6a7e2c.png)

PR:
![image](https://user-images.githubusercontent.com/6278726/233762781-00e06098-3d4e-4ad2-88dc-57b5a946f60d.png)
