### PR TITLE
GS/HW: Avoid render pass restarts to turn off RT

### DIFF
--- a/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
@@ -3200,8 +3200,20 @@ void GSDevice12::RenderHW(GSHWDrawConfig& config)
 	}
 
 	// avoid restarting the render pass just to switch from rt+depth to rt and vice versa
-	if (m_in_render_pass && !hdr_rt && !draw_ds && m_current_depth_target && m_current_render_target == draw_rt &&
-		config.tex != m_current_depth_target && m_current_depth_target->GetSize() == draw_rt->GetSize())
+	if (m_in_render_pass && (m_current_render_target == draw_rt || m_current_depth_target == draw_ds))
+	{
+		// avoid restarting the render pass just to switch from rt+depth to rt and vice versa
+		// keep the depth even if doing HDR draws, because the next draw will probably re-enable depth
+		if (!draw_rt && m_current_render_target && config.tex != m_current_render_target &&
+			m_current_render_target->GetSize() == draw_ds->GetSize())
+		{
+			draw_rt = m_current_render_target;
+			m_pipeline_selector.rt = true;
+			m_pipeline_selector.cms.wrgba = 0;
+		}
+	}
+	else if (!draw_ds && m_current_depth_target && config.tex != m_current_depth_target &&
+			 m_current_depth_target->GetSize() == draw_rt->GetSize())
 	{
 		draw_ds = m_current_depth_target;
 		m_pipeline_selector.ds = true;

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -2422,13 +2422,17 @@ void GSDeviceOGL::RenderHW(GSHWDrawConfig& config)
 	OMSetBlendState(config.blend.enable, s_gl_blend_factors[config.blend.src_factor],
 		s_gl_blend_factors[config.blend.dst_factor], s_gl_blend_ops[config.blend.op],
 		config.blend.constant_enable, config.blend.constant);
-	OMSetColorMaskState(config.colormask);
 
 	// avoid changing framebuffer just to switch from rt+depth to rt and vice versa
 	GSTexture* draw_rt = hdr_rt ? hdr_rt : config.rt;
 	GSTexture* draw_ds = config.ds;
-	if (!draw_ds && GLState::ds && GLState::rt == draw_rt && config.tex != GLState::ds &&
-		GLState::ds->GetSize() == draw_rt->GetSize())
+	OMColorMaskSelector draw_colormask = config.colormask;
+	if (!draw_rt && GLState::rt && GLState::ds == draw_ds && GLState::rt->GetSize() == draw_ds->GetSize())
+	{
+		draw_rt = GLState::rt;
+		draw_colormask.wrgba = 0;
+	}
+	else if (!draw_ds && GLState::ds && GLState::rt == draw_rt && GLState::ds->GetSize() == draw_rt->GetSize())
 	{
 		// should already be always-pass.
 		draw_ds = GLState::ds;
@@ -2437,6 +2441,7 @@ void GSDeviceOGL::RenderHW(GSHWDrawConfig& config)
 	}
 
 	OMSetRenderTargets(draw_rt, draw_ds, &config.scissor);
+	OMSetColorMaskState(draw_colormask);
 	SetupOM(config.depth);
 
 	SendHWDraw(config, psel.ps.IsFeedbackLoop());


### PR DESCRIPTION
### Description of Changes

Significantly reduces render passes in Sly 2 (~2,000 to 700 in the intro).

### Rationale behind Changes

Vroom vroom.

### Suggested Testing Steps

Test performance changes in a few games, including Sly 2.
