### PR TITLE
GS-TC: Use the expected rect to expand the target when Tex is RT.

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -852,8 +852,7 @@ GSTextureCache::Source* GSTextureCache::LookupSource(const GIFRegTEX0& TEX0, con
 					// If the source is reading the rt, make sure it's big enough.
 					if (t && GSUtil::HasCompatibleBits(psm, t->m_TEX0.PSM))
 					{
-						GSVector4i dirty_rect = t->m_dirty.GetTotalRect(t->m_TEX0, GSVector2i(new_rect.z, new_rect.w));
-						const GSVector2i size_delta = { (dirty_rect.z - t->m_valid.z), (dirty_rect.w - t->m_valid.w) };
+						const GSVector2i size_delta = { (new_rect.z - t->m_valid.z), (new_rect.w - t->m_valid.w) };
 						if (size_delta.x > 0 || size_delta.y > 0)
 						{
 							RGBAMask rgba;


### PR DESCRIPTION
### Description of Changes
Expands RT's which overlap the source based on the rect size not the dirty size

### Rationale behind Changes
This wasn't correctly expanding the source when a target is used but is smaller than the requested size. This was evident in Final Fantasy X-2 if you went in to the menu and config, then back out.

### Suggested Testing Steps
Test games, FFX-2 (press triangle then config, then back out), and just random stuff, make sure VRAM doesn't explode etc.

Fixes #8643