### PR TITLE
VU-JIT: Avoid writeReg stealing loadReg GPR

### DIFF
--- a/pcsx2/x86/microVU_IR.h
+++ b/pcsx2/x86/microVU_IR.h
@@ -1015,6 +1015,9 @@ public:
 				microMapGPR& mapI = gprMap[i];
 				if (mapI.VIreg == viLoadReg)
 				{
+					// Do this first, there is a case where when loadReg != writeReg, the findFreeGPR can steal the loadReg
+					gprMap[i].count = this_counter;
+
 					if (viWriteReg >= 0) // Reg will be modified
 					{
 						if (viLoadReg != viWriteReg)
@@ -1058,7 +1061,7 @@ public:
 						xMOVZX(xRegister32(i), xRegister16(i));
 						gprMap[i].isZeroExtended = true;
 					}
-					gprMap[i].count = this_counter;
+
 					gprMap[i].isNeeded = true;
 
 					if (backup)


### PR DESCRIPTION
### Description of Changes
Avoids a situation where we can find the loadReg when allocating a GPR then the writeReg stealing it.

### Rationale behind Changes
The above was happening then it was overwriting the value when it needed to backup the VI register. This broke Gauntlet and Star Wars Episode 3

### Suggested Testing Steps
Test above mentioned games and WRC 4 (I've already done this but you're welcome to try that + others)
