### PR TITLE
GS/HW: Allow auto flush to be applied only to sprites

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -171,12 +171,12 @@ PAPX-90516:
     trilinearFiltering: 1 # Fixes water textures.
     cpuSpriteRenderBW: 4 # Fixes character and water textures.
     cpuSpriteRenderLevel: 2 # Needed for above.
-    autoFlush: 1 # Fixes lighting.
+    autoFlush: 2 # Fixes lighting.
 PAPX-90517:
   name: "Prince of Persia - Jikan no Suna [Trial]"
   region: "NTSC-J"
   gsHWFixes:
-    autoFlush: 1 # Reduces post-processing misalignment.
+    autoFlush: 2 # Reduces post-processing misalignment.
 PBGP-0061:
   name: "Suika A.S+ Eternal Name [First Press Limited Edition]"
   region: "NTSC-J"
@@ -408,7 +408,7 @@ PCPX-98017:
     mipmap: 1
     partialTargetInvalidation: 1 # Fixes broken pause screen.
     halfPixelOffset: 2 # Fixes misaligned bloom.
-    autoFlush: 1 # Helps fix misaligned bloom.
+    autoFlush: 2 # Helps fix misaligned bloom.
 PDPX-99109:
   name: "DVD Player Version 3.04"
   region: "NTSC-J"
@@ -515,7 +515,7 @@ SCAJ-20008:
   region: "NTSC-Unk"
   gsHWFixes:
     preloadFrameData: 1 # Fixes fog and make lights on cars work again.
-    autoFlush: 1 # Fixes sun luminosity and penetration of objects.
+    autoFlush: 2 # Fixes sun luminosity and penetration of objects.
   gameFixes:
     - EETimingHack # Fixes random graphical corruption.
 SCAJ-20009:
@@ -663,7 +663,7 @@ SCAJ-20041:
   name: "Energy Airforce - Aim Strike!"
   region: "NTSC-Unk"
   gsHWFixes:
-    autoFlush: 1 # Corrects post-processing effect on jet exhausts.
+    autoFlush: 2 # Corrects post-processing effect on jet exhausts.
 SCAJ-20043:
   name: "ChainDive"
   region: "NTSC-Unk"
@@ -671,7 +671,7 @@ SCAJ-20044:
   name: "Tomb Raider - The Angel of Darkness"
   region: "NTSC-Unk"
   gsHWFixes:
-    autoFlush: 1 # Fixes lava effect.
+    autoFlush: 2 # Fixes lava effect.
 SCAJ-20045:
   name: "Shadow Tower Abyss"
   region: "NTSC-Unk"
@@ -800,7 +800,7 @@ SCAJ-20073:
     trilinearFiltering: 1 # Fixes water textures.
     cpuSpriteRenderBW: 4 # Fixes character and water textures.
     cpuSpriteRenderLevel: 2 # Needed for above.
-    autoFlush: 1 # Fixes lighting.
+    autoFlush: 2 # Fixes lighting.
 SCAJ-20074:
   name: "King of Fighters 2002, The"
   region: "NTSC-Unk"
@@ -878,7 +878,7 @@ SCAJ-20086:
   name: "Xenosaga Episode II - Jenseits von Gut und Bose [Disc 1 of 2]"
   region: "NTSC-Unk"
   gsHWFixes:
-    autoFlush: 1 # Fixes shadows in cutscenes.
+    autoFlush: 2 # Fixes shadows in cutscenes.
     halfPixelOffset: 2 # Fixes lighting misalignment and shadows.
     roundSprite: 2 # Fixes font artifacts.
   memcardFilters:
@@ -892,7 +892,7 @@ SCAJ-20087:
   name: "Xenosaga Episode II - Jenseits von Gut und Bose [Disc 2 of 2]"
   region: "NTSC-Unk"
   gsHWFixes:
-    autoFlush: 1 # Fixes shadows in cutscenes.
+    autoFlush: 2 # Fixes shadows in cutscenes.
     halfPixelOffset: 2 # Fixes lighting misalignment and shadows.
     roundSprite: 2 # Fixes font artifacts.
   memcardFilters:
@@ -992,12 +992,12 @@ SCAJ-20109:
     disablePartialInvalidation: 1 # Prevents the situation that a level (Aquatos) doesn't render characters and geometry.
     partialTargetInvalidation: 1 # Fixes broken pause screen.
     halfPixelOffset: 2 # Fixes misaligned bloom.
-    autoFlush: 1 # Helps fix misaligned bloom.
+    autoFlush: 2 # Helps fix misaligned bloom.
 SCAJ-20110:
   name: "Dragon Quest VIII - Sora to Daichi to Norowareshi Himegimi"
   region: "NTSC-Unk"
   gsHWFixes:
-    autoFlush: 1 # Fixes missing bloom from surfaces like windows.
+    autoFlush: 2 # Fixes missing bloom from surfaces like windows.
     # halfPixelOffset: 1 # Aligns shadows properly, but causes grid lines to appear in sea travel.
     halfPixelOffset: 2 # Sharpens world in far distances, aligns some bloom better.
     roundSprite: 1 # Fixes font artifacts.
@@ -1178,7 +1178,7 @@ SCAJ-20138:
     mipmap: 2 # Fixes miptrick texture effects.
     trilinearFiltering: 1 # Fixes miptrick blending.
     halfPixelOffset: 2 # Fixes misaligned blur.
-    autoFlush: 1 # Fixes corruption in cutscenes and brightens the image.
+    autoFlush: 2 # Fixes corruption in cutscenes and brightens the image.
 SCAJ-20139:
   name: "Zero - Shisei no Koe" # Fatal Frame - Rei - Irezumi no Sei
   region: "NTSC-Unk"
@@ -1206,7 +1206,7 @@ SCAJ-20144:
     mipmap: 2 # Fixes miptrick texture effects.
     trilinearFiltering: 1 # Fixes miptrick blending.
     halfPixelOffset: 2 # Fixes misaligned blur.
-    autoFlush: 1 # Fixes corruption in cutscenes and brightens the image.
+    autoFlush: 2 # Fixes corruption in cutscenes and brightens the image.
 SCAJ-20145:
   name: "Tales of Legendia"
   region: "NTSC-J"
@@ -1260,7 +1260,7 @@ SCAJ-20154:
   name: "Prince of Persia - Warrior Within"
   region: "NTSC-Unk"
   gsHWFixes:
-    autoFlush: 1 # Reduces post-processing misalignment.
+    autoFlush: 2 # Reduces post-processing misalignment.
 SCAJ-20155:
   name: "Yoshitsune Eiyuuden Shura - The Story of Hero Yoshitsune Shura"
   region: "NTSC-Unk"
@@ -1277,14 +1277,14 @@ SCAJ-20157:
     disablePartialInvalidation: 1 # Prevents world geometry and some models from vanishing when pausing or opening vendor.
     partialTargetInvalidation: 1 # Fixes bad textures being read back during scene transitions.
     halfPixelOffset: 2 # Fixes misaligned bloom.
-    autoFlush: 1 # Helps fix misaligned bloom.
+    autoFlush: 2 # Helps fix misaligned bloom.
 SCAJ-20158:
   name: "Ikusa Gami"
   region: "NTSC-Unk"
   gameFixes:
     - VIF1StallHack # Fixes black screen on boot.
   gsHWFixes:
-    autoFlush: 1 # Fixes missing bloom effects.
+    autoFlush: 2 # Fixes missing bloom effects.
     halfPixelOffset: 2 # Fixes misaligned lighting and bloom.
 SCAJ-20159:
   name: "Soul Calibur III"
@@ -1313,7 +1313,7 @@ SCAJ-20162:
   name: "Rogue Galaxy"
   region: "NTSC-Unk"
   gsHWFixes:
-    autoFlush: 1 # Fix glow effects from lamps.
+    autoFlush: 2 # Fix glow effects from lamps.
     roundSprite: 1 # Fix mini-map and field menu.
     preloadFrameData: 1 # Fixes corrupt textures especially on water.
     disablePartialInvalidation: 1 # Prevents UI and subtitles from disappearing.
@@ -1323,12 +1323,12 @@ SCAJ-20163:
   region: "NTSC-Unk"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
-    autoFlush: 1 # Fixes post lighting.
+    autoFlush: 2 # Fixes post lighting.
 SCAJ-20164:
   name: "Kingdom Hearts II"
   region: "NTSC-Unk"
   gsHWFixes:
-    autoFlush: 1 # Fixes effects.
+    autoFlush: 2 # Fixes effects.
     roundSprite: 2 # Fixes upscaling artifacts.
 SCAJ-20165:
   name: "Bleach - Hanatareshi Yabou"
@@ -1354,7 +1354,7 @@ SCAJ-20169:
   name: "Dirge of Cerberus - Final Fantasy VII"
   region: "NTSC-Unk"
   gsHWFixes:
-    autoFlush: 1 # Fixes lighting.
+    autoFlush: 2 # Fixes lighting.
 SCAJ-20170:
   name: "Tourist Trophy"
   region: "NTSC-Ch"
@@ -1417,7 +1417,7 @@ SCAJ-20179:
   name: "Xenosaga Episode III - Also Sprach Zarathustra [Disc 1 of 2]"
   region: "NTSC-Unk"
   gsHWFixes:
-    autoFlush: 1 # Fixes shadows in cutscenes.
+    autoFlush: 2 # Fixes shadows in cutscenes.
     halfPixelOffset: 1 # Fixes lighting misalignment and reduces ground shadows (probably texture cache issue).
     roundSprite: 2 # Fixes font artifacts.
     textureInsideRT: 1 # Fixes bad crystal surfaces.
@@ -1426,7 +1426,7 @@ SCAJ-20180:
   name: "Xenosaga Episode III - Also Sprach Zarathustra [Disc 2 of 2]"
   region: "NTSC-Unk"
   gsHWFixes:
-    autoFlush: 1 # Fixes shadows in cutscenes.
+    autoFlush: 2 # Fixes shadows in cutscenes.
     halfPixelOffset: 1 # Fixes lighting misalignment and reduces ground shadows (probably texture cache issue).
     roundSprite: 2 # Fixes font artifacts.
     textureInsideRT: 1 # Fixes bad crystal surfaces.
@@ -1487,7 +1487,7 @@ SCAJ-20195:
     mipmap: 2 # Fixes miptrick texture effects.
     trilinearFiltering: 1 # Fixes miptrick blending.
     halfPixelOffset: 2 # Fixes misaligned blur.
-    autoFlush: 1 # Fixes corruption in cutscenes and brightens the image.
+    autoFlush: 2 # Fixes corruption in cutscenes and brightens the image.
 SCAJ-20196:
   name: "Wang Da Yu Ju Xiang [PlayStation 2 The Best]"
   region: "NTSC-Ch"
@@ -1555,7 +1555,7 @@ SCAJ-25037:
   roundModes:
     eeRoundMode: 0 # Fixes character behaviour.
   gsHWFixes:
-    autoFlush: 1 # Fixes flame bloom.
+    autoFlush: 2 # Fixes flame bloom.
 SCAJ-25045:
   name: "Sakura Taisen V - Episode 0"
   region: "NTSC-Unk"
@@ -1567,7 +1567,7 @@ SCAJ-30001:
   region: "NTSC-Unk"
   compat: 5
   gsHWFixes:
-    autoFlush: 1 # Fixes shadows in cutscenes.
+    autoFlush: 2 # Fixes shadows in cutscenes.
     halfPixelOffset: 2 # Removes puppet lines shadows.
     roundSprite: 2 # Fixes font artifacts.
 SCAJ-30002:
@@ -2149,7 +2149,7 @@ SCED-51700:
     trilinearFiltering: 1 # Fixes water textures.
     cpuSpriteRenderBW: 4 # Fixes character and water textures.
     cpuSpriteRenderLevel: 2 # Needed for above.
-    autoFlush: 1 # Fixes lighting.
+    autoFlush: 2 # Fixes lighting.
 SCED-51899:
   name: "PlayStation Experience [Demo]"
   region: "PAL-E"
@@ -2256,7 +2256,7 @@ SCED-52141:
     - XGKickHack # Fixes SPS.
   gsHWFixes:
     roundSprite: 2 # Correct misaligned font, better aligns car shadow.
-    autoFlush: 1 # Fixes sun luminosity.
+    autoFlush: 2 # Fixes sun luminosity.
 SCED-52160:
   name: "Official PlayStation 2 Magazine Demo 45"
   region: "PAL-M5"
@@ -2415,7 +2415,7 @@ SCED-52869:
         patch=0,EE,005fffec,double,24e7100024c60080
         patch=0,EE,005ffff4,double,00c7e8200818000c
   gsHWFixes:
-    autoFlush: 1 # Fixes sun luminosity and car shadows.
+    autoFlush: 2 # Fixes sun luminosity and car shadows.
     roundSprite: 1 # Fixes misaligned text.
     halfPixelOffset: 2 # Fixes minor ghosting on objects.
   roundModes:
@@ -2426,7 +2426,7 @@ SCED-52880:
   gameFixes:
     - XGKickHack # Fixes SPS.
   gsHWFixes:
-    autoFlush: 1 # Fixes sun luminosity and car shadows.
+    autoFlush: 2 # Fixes sun luminosity and car shadows.
     roundSprite: 1 # Fixes misaligned text.
     halfPixelOffset: 2 # Fixes minor ghosting on objects.
   roundModes:
@@ -2452,7 +2452,7 @@ SCED-52945:
   gameFixes:
     - XGKickHack # Fixes SPS.
   gsHWFixes:
-    autoFlush: 1 # Fixes sun luminosity and car shadows.
+    autoFlush: 2 # Fixes sun luminosity and car shadows.
     roundSprite: 1 # Fixes misaligned text.
     halfPixelOffset: 2 # Fixes minor ghosting on objects.
   roundModes:
@@ -2475,7 +2475,7 @@ SCED-52952:
     trilinearFiltering: 1 # Fixes water textures.
     cpuSpriteRenderBW: 4 # Fixes character and water textures.
     cpuSpriteRenderLevel: 2 # Needed for above.
-    autoFlush: 1 # Fixes lighting.
+    autoFlush: 2 # Fixes lighting.
 SCED-52970:
   name: "SCEE Hits Demo"
   region: "PAL-M5"
@@ -2643,7 +2643,7 @@ SCED-53622:
   clampModes:
     vuClampMode: 2 # Fixes mini-map HUD.
   gsHWFixes:
-    autoFlush: 1 # Fixes pause menu backgrounds.
+    autoFlush: 2 # Fixes pause menu backgrounds.
     roundSprite: 1 # Corrects proportions of fonts and pause-screen lines, adjusts display closer to software.
 SCED-53660:
   name: "Jak X & Ratchet Gladiator [Demo]"
@@ -3497,7 +3497,7 @@ SCES-51607:
     - EETimingHack # Fixes DMA errors.
   gsHWFixes:
     mipmap: 1
-    autoFlush: 1
+    autoFlush: 2
     partialTargetInvalidation: 1 # Fixes broken pause screen.
   dynaPatches:
     - pattern:
@@ -3519,7 +3519,7 @@ SCES-51608:
     trilinearFiltering: 1 # Fixes water textures.
     cpuSpriteRenderBW: 4 # Fixes character and water textures.
     cpuSpriteRenderLevel: 2 # Needed for above.
-    autoFlush: 1 # Fixes lighting.
+    autoFlush: 2 # Fixes lighting.
 SCES-51610:
   name: "This is Football 2004 [Red Devils 2004]"
   region: "PAL-BE"
@@ -3546,7 +3546,7 @@ SCES-51635:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes lighting/shadows.
     preloadFrameData: 1 # Fixes sun flickering.
-    autoFlush: 1 # Fixes sun through objects.
+    autoFlush: 2 # Fixes sun through objects.
     bilinearUpscale: 1 # Smooths out sun glare textures like native.
 SCES-51648:
   name: "Everquest - Online Adventures"
@@ -3564,7 +3564,7 @@ SCES-51684:
     - XGKickHack # Fixes SPS.
   gsHWFixes:
     roundSprite: 2 # Correct misaligned font, better aligns car shadow.
-    autoFlush: 1 # Fixes sun luminosity.
+    autoFlush: 2 # Fixes sun luminosity.
 SCES-51685:
   name: "Primal"
   region: "PAL-E-R"
@@ -3649,7 +3649,7 @@ SCES-52033:
   region: "PAL-M5"
   compat: 5
   gsHWFixes:
-    autoFlush: 1 # Fixes lights going through walls.
+    autoFlush: 2 # Fixes lights going through walls.
     preloadFrameData: 1 # Fixes light flicker.
     halfPixelOffset: 2 # Corrects light position.
   gameFixes:
@@ -3754,7 +3754,7 @@ SCES-52389:
         patch=0,EE,005fffec,double,24e7100024c60080
         patch=0,EE,005ffff4,double,00c7e8200818000c
   gsHWFixes:
-    autoFlush: 1 # Fixes sun luminosity and car shadows.
+    autoFlush: 2 # Fixes sun luminosity and car shadows.
     roundSprite: 1 # Fixes misaligned text.
     halfPixelOffset: 2 # Fixes minor ghosting on objects.
   roundModes:
@@ -3839,7 +3839,7 @@ SCES-52456:
     disablePartialInvalidation: 1 # Prevents the situation that a level (Aquatos) doesn't render characters and geometry.
     partialTargetInvalidation: 1 # Fixes broken pause screen.
     halfPixelOffset: 2 # Fixes misaligned bloom.
-    autoFlush: 1 # Helps fix misaligned bloom.
+    autoFlush: 2 # Helps fix misaligned bloom.
   memcardFilters: # Reads Ratchet 1 & 2 data.
     - "SCES-52456"
     - "SCES-51607"
@@ -3855,7 +3855,7 @@ SCES-52460:
     trilinearFiltering: 1 # Fixes water textures.
     cpuSpriteRenderBW: 4 # Fixes character and water textures.
     cpuSpriteRenderLevel: 2 # Needed for above.
-    autoFlush: 1 # Fixes lighting.
+    autoFlush: 2 # Fixes lighting.
 SCES-52529:
   name: "Sly 2 - Band of Thieves"
   region: "PAL-M11"
@@ -4033,7 +4033,7 @@ SCES-53247:
     eeClampMode: 2 # Fixes rare bug causing player to respawn when starting the race or during certain car crashes.
   gsHWFixes:
     roundSprite: 1 # Fixes misaligned text.
-    autoFlush: 1 # Fixes sun luminosity.
+    autoFlush: 2 # Fixes sun luminosity.
   patches:
     CBBC2E7F:
       content: |-
@@ -4052,13 +4052,13 @@ SCES-53285:
     disablePartialInvalidation: 1 # Prevents world geometry and some models from vanishing when pausing or opening vendor.
     partialTargetInvalidation: 1 # Fixes bad textures being read back during scene transitions.
     halfPixelOffset: 2 # Fixes misaligned bloom.
-    autoFlush: 1 # Helps fix misaligned bloom.
+    autoFlush: 2 # Helps fix misaligned bloom.
 SCES-53286:
   name: "Jak X - Combat Racing"
   region: "PAL-M7"
   gsHWFixes:
     roundSprite: 1 # Fix lines in the sky.
-    autoFlush: 1 # Fixes lighting.
+    autoFlush: 2 # Fixes lighting.
     mipmap: 2 # Fixes broken textures.
     trilinearFiltering: 1 # Fixes water textures.
     cpuSpriteRenderBW: 2 # Fixes water textures. Can't use BW 4 here because of post effects.
@@ -4130,7 +4130,7 @@ SCES-53358:
   clampModes:
     vuClampMode: 2 # Fixes mini-map HUD.
   gsHWFixes:
-    autoFlush: 1 # Fixes pause menu backgrounds.
+    autoFlush: 2 # Fixes pause menu backgrounds.
     roundSprite: 1 # Corrects proportions of fonts and pause-screen lines, adjusts display closer to software.
 SCES-53372:
   name: "Tourist Trophy - The Real Riding Simulator"
@@ -4196,7 +4196,7 @@ SCES-53642:
     mipmap: 2 # Fixes miptrick texture effects.
     trilinearFiltering: 1 # Fixes miptrick blending.
     halfPixelOffset: 2 # Fixes misaligned blur.
-    autoFlush: 1 # Fixes corruption in cutscenes and brightens the image.
+    autoFlush: 2 # Fixes corruption in cutscenes and brightens the image.
 SCES-53663:
   name: "Buzz! The Music Quiz"
   region: "PAL-M3"
@@ -4210,7 +4210,7 @@ SCES-53680:
     - XGKickHack # Fixes SPS.
   gsHWFixes:
     roundSprite: 1 # Fixes misaligned text.
-    autoFlush: 1 # Fixes sun luminosity.
+    autoFlush: 2 # Fixes sun luminosity.
   patches:
     79BAD675:
       content: |-
@@ -4512,7 +4512,7 @@ SCES-54552:
   name: "Rogue Galaxy"
   region: "PAL-M5"
   gsHWFixes:
-    autoFlush: 1 # Fix glow effects from lamps.
+    autoFlush: 2 # Fix glow effects from lamps.
     roundSprite: 1 # Fix mini-map and field menu.
     preloadFrameData: 1 # Fixes corrupt textures especially on water.
     disablePartialInvalidation: 1 # Prevents UI and subtitles from disappearing.
@@ -4617,7 +4617,7 @@ SCES-54794:
   name: "Syphon Filter - Dark Mirror"
   region: "PAL-M5"
   gsHWFixes:
-    autoFlush: 1
+    autoFlush: 2
 SCES-54823:
   name: "SingStar Bollywood"
   region: "PAL-E"
@@ -4971,14 +4971,14 @@ SCES-82034:
   name: "Xenosaga II - Jenseits von Gut und Bose [Disc 1]"
   region: "PAL-M3"
   gsHWFixes:
-    autoFlush: 1
+    autoFlush: 2
   memcardFilters:
     - "SLES-82034"
 SCES-82035:
   name: "Xenosaga II - Jenseits von Gut und Bose [Disc 2]"
   region: "PAL-M3"
   gsHWFixes:
-    autoFlush: 1
+    autoFlush: 2
   memcardFilters:
     - "SLES-82034"
     - "SCES-82034"
@@ -5031,7 +5031,7 @@ SCKA-20010:
     trilinearFiltering: 1 # Fixes water textures.
     cpuSpriteRenderBW: 4 # Fixes character and water textures.
     cpuSpriteRenderLevel: 2 # Needed for above.
-    autoFlush: 1 # Fixes lighting.
+    autoFlush: 2 # Fixes lighting.
 SCKA-20011:
   name: "Ratchet & Clank 2"
   region: "NTSC-K"
@@ -5149,7 +5149,7 @@ SCKA-20032:
   name: "Syphon Filter - The Omega Virus"
   region: "NTSC-K"
   gsHWFixes:
-    autoFlush: 1 # Fixes lights going through walls.
+    autoFlush: 2 # Fixes lights going through walls.
     preloadFrameData: 1 # Fixes light flicker.
     halfPixelOffset: 2 # Corrects light position.
   gameFixes:
@@ -5188,7 +5188,7 @@ SCKA-20037:
     disablePartialInvalidation: 1 # Prevents the situation that a level (Aquatos) doesn't render characters and geometry.
     partialTargetInvalidation: 1 # Fixes broken pause screen.
     halfPixelOffset: 2 # Fixes misaligned bloom.
-    autoFlush: 1 # Helps fix misaligned bloom.
+    autoFlush: 2 # Helps fix misaligned bloom.
   memcardFilters:
     - "SCKA-20037"
     - "SCKA-20011"
@@ -5211,7 +5211,7 @@ SCKA-20040:
     trilinearFiltering: 1 # Fixes water textures.
     cpuSpriteRenderBW: 4 # Fixes character and water textures.
     cpuSpriteRenderLevel: 2 # Needed for above.
-    autoFlush: 1 # Fixes lighting.
+    autoFlush: 2 # Fixes lighting.
 SCKA-20041:
   name: "EyeToy - Play 2"
   region: "NTSC-K"
@@ -5324,7 +5324,7 @@ SCKA-20060:
     disablePartialInvalidation: 1 # Prevents world geometry and some models from vanishing when pausing or opening vendor.
     partialTargetInvalidation: 1 # Fixes bad textures being read back during scene transitions.
     halfPixelOffset: 2 # Fixes misaligned bloom.
-    autoFlush: 1 # Helps fix misaligned bloom.
+    autoFlush: 2 # Helps fix misaligned bloom.
 SCKA-20061:
   name: "Wanda to Kyozou"
   region: "NTSC-K"
@@ -5346,7 +5346,7 @@ SCKA-20062:
     mipmap: 2 # Fixes miptrick texture effects.
     trilinearFiltering: 1 # Fixes miptrick blending.
     halfPixelOffset: 2 # Fixes misaligned blur.
-    autoFlush: 1 # Fixes corruption in cutscenes and brightens the image.
+    autoFlush: 2 # Fixes corruption in cutscenes and brightens the image.
 SCKA-20063:
   name: "Sly 3 - Honor Among Thieves"
   region: "NTSC-K"
@@ -5487,7 +5487,7 @@ SCKA-20093:
   gsHWFixes:
     halfPixelOffset: 2 # Reduces blooming misalignment.
     wildArmsHack: 1 # Reduces blooming misalignment.
-    autoFlush: 1 # Fixes glows.
+    autoFlush: 2 # Fixes glows.
 SCKA-20095:
   name: "Okami"
   region: "NTSC-K"
@@ -5500,7 +5500,7 @@ SCKA-20096:
   gsHWFixes:
     halfPixelOffset: 2 # Fix text and post blur.
     mipmap: 2 # Base mip level isn't always used.
-    autoFlush: 1 # Needed for recursive mipmap rendering.
+    autoFlush: 2 # Needed for recursive mipmap rendering.
     getSkipCount: "GSC_BlueTongueGames" # Render mipmaps on the CPU.
 SCKA-20098:
   name: "Nickelodeon SpongeBob SquarePants - Creature from the Krusty Krab"
@@ -5578,6 +5578,7 @@ SCKA-30006:
     alignSprite: 1 # Fixes water vertical lines.
     halfPixelOffset: 2 # Fixes misaligned bloom.
     roundSprite: 1 # Fixes chromatic effect.
+    autoFlush: 1 # Fixes sun occlusion.
 SCPM-85101:
   name: "McDonald's Original Happy Disc"
   region: "NTSC-J"
@@ -6016,7 +6017,7 @@ SCPS-15057:
     trilinearFiltering: 1 # Fixes water textures.
     cpuSpriteRenderBW: 4 # Fixes character and water textures.
     cpuSpriteRenderLevel: 2 # Needed for above.
-    autoFlush: 1 # Fixes lighting.
+    autoFlush: 2 # Fixes lighting.
 SCPS-15058:
   name: "Arc the Lad - Generation"
   region: "NTSC-J"
@@ -6090,7 +6091,7 @@ SCPS-15066:
   name: "Prince of Persia - The Sands of Time"
   region: "NTSC-J"
   gsHWFixes:
-    autoFlush: 1 # Reduces post-processing misalignment.
+    autoFlush: 2 # Reduces post-processing misalignment.
 SCPS-15067:
   name: "Dokodemo Issyo - Toro to Nagare Boshi"
   region: "NTSC-J"
@@ -6155,7 +6156,7 @@ SCPS-15084:
     disablePartialInvalidation: 1 # Prevents the situation that a level (Aquatos) doesn't render characters and geometry.
     partialTargetInvalidation: 1 # Fixes broken pause screen.
     halfPixelOffset: 2 # Fixes misaligned bloom.
-    autoFlush: 1 # Helps fix misaligned bloom.
+    autoFlush: 2 # Helps fix misaligned bloom.
   memcardFilters:
     - "SCPS-15084"
     - "SCPS-15056"
@@ -6241,7 +6242,7 @@ SCPS-15096:
     mipmap: 2 # Fixes miptrick texture effects.
     trilinearFiltering: 1 # Fixes miptrick blending.
     halfPixelOffset: 2 # Fixes misaligned blur.
-    autoFlush: 1 # Fixes corruption in cutscenes and brightens the image.
+    autoFlush: 2 # Fixes corruption in cutscenes and brightens the image.
 SCPS-15097:
   name: "Wanda to Kyozou"
   region: "NTSC-J"
@@ -6270,7 +6271,7 @@ SCPS-15099:
     disablePartialInvalidation: 1 # Prevents world geometry and some models from vanishing when pausing or opening vendor.
     partialTargetInvalidation: 1 # Fixes bad textures being read back during scene transitions.
     halfPixelOffset: 2 # Fixes misaligned bloom.
-    autoFlush: 1 # Helps fix misaligned bloom.
+    autoFlush: 2 # Helps fix misaligned bloom.
 SCPS-15100:
   name: "Ratchet & Clank 4th - GiriGiri Ginga no Giga Battle"
   region: "NTSC-J"
@@ -6281,7 +6282,7 @@ SCPS-15100:
     disablePartialInvalidation: 1 # Prevents world geometry and some models from vanishing when pausing or opening vendor.
     partialTargetInvalidation: 1 # Fixes bad textures being read back during scene transitions.
     halfPixelOffset: 2 # Fixes misaligned bloom.
-    autoFlush: 1 # Helps fix misaligned bloom.
+    autoFlush: 2 # Helps fix misaligned bloom.
 SCPS-15101:
   name: "Bleach - Hanatareshi Yabou"
   region: "NTSC-J"
@@ -6289,7 +6290,7 @@ SCPS-15102:
   name: "Rogue Galaxy"
   region: "NTSC-J"
   gsHWFixes:
-    autoFlush: 1 # Fix glow effects from lamps.
+    autoFlush: 2 # Fix glow effects from lamps.
     roundSprite: 1 # Fix mini-map and field menu.
     preloadFrameData: 1 # Fixes corrupt textures especially on water.
     disablePartialInvalidation: 1 # Prevents UI and subtitles from disappearing.
@@ -6423,7 +6424,7 @@ SCPS-17013:
   name: "Rogue Galaxy [Director's Cut]"
   region: "NTSC-J"
   gsHWFixes:
-    autoFlush: 1 # Fix glow effects from lamps.
+    autoFlush: 2 # Fix glow effects from lamps.
     roundSprite: 1 # Fix mini-map and field menu.
     preloadFrameData: 1 # Fixes corrupt textures especially on water.
     disablePartialInvalidation: 1 # Prevents UI and subtitles from disappearing.
@@ -6589,7 +6590,7 @@ SCPS-19254:
   name: "Rogue Galaxy [PlayStation 2 The Best]"
   region: "NTSC-J"
   gsHWFixes:
-    autoFlush: 1 # Fix glow effects from lamps.
+    autoFlush: 2 # Fix glow effects from lamps.
     roundSprite: 1 # Fix mini-map and field menu.
     preloadFrameData: 1 # Fixes corrupt textures especially on water.
     disablePartialInvalidation: 1 # Prevents UI and subtitles from disappearing.
@@ -6659,7 +6660,7 @@ SCPS-19309:
     disablePartialInvalidation: 1 # Prevents the situation that a level (Aquatos) doesn't render characters and geometry.
     partialTargetInvalidation: 1 # Fixes broken pause screen.
     halfPixelOffset: 2 # Fixes misaligned bloom.
-    autoFlush: 1 # Helps fix misaligned bloom.
+    autoFlush: 2 # Helps fix misaligned bloom.
 SCPS-19310:
   name: "Ratchet & Clank [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -6676,7 +6677,7 @@ SCPS-19311:
     mipmap: 2 # Fixes miptrick texture effects.
     trilinearFiltering: 1 # Fixes miptrick blending.
     halfPixelOffset: 2 # Fixes misaligned blur.
-    autoFlush: 1 # Fixes corruption in cutscenes and brightens the image.
+    autoFlush: 2 # Fixes corruption in cutscenes and brightens the image.
 SCPS-19312:
   name: "Siren [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -6722,7 +6723,7 @@ SCPS-19317:
   gsHWFixes:
     mipmap: 1
     partialTargetInvalidation: 1 # Fixes broken pause screen.
-    autoFlush: 1
+    autoFlush: 2
   memcardFilters:
     - "SCAJ-20001"
     - "SCPS-15037"
@@ -6765,7 +6766,7 @@ SCPS-19321:
     disablePartialInvalidation: 1 # Prevents world geometry and some models from vanishing when pausing or opening vendor.
     partialTargetInvalidation: 1 # Fixes bad textures being read back during scene transitions.
     halfPixelOffset: 2 # Fixes misaligned bloom.
-    autoFlush: 1 # Helps fix misaligned bloom.
+    autoFlush: 2 # Helps fix misaligned bloom.
 SCPS-19322:
   name: "Wild ARMs - The 4th Detonator [PlayStation 2 The Best - Reprint]"
   region: "NTSC-J"
@@ -6838,7 +6839,7 @@ SCPS-19328:
     disablePartialInvalidation: 1 # Prevents world geometry and some models from vanishing when pausing or opening vendor.
     partialTargetInvalidation: 1 # Fixes bad textures being read back during scene transitions.
     halfPixelOffset: 2 # Fixes misaligned bloom.
-    autoFlush: 1 # Helps fix misaligned bloom.
+    autoFlush: 2 # Helps fix misaligned bloom.
 SCPS-19329:
   name: "Bleach - Blade Battlers [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -6978,7 +6979,7 @@ SCPS-55015:
   name: "Zettai Zetsumei Toshi"
   region: "NTSC-J"
   gsHWFixes:
-    autoFlush: 1 # Fixes incorrect blur effect.
+    autoFlush: 2 # Fixes incorrect blur effect.
 SCPS-55016:
   name: "Jet de Go! 2"
   region: "NTSC-J"
@@ -7146,7 +7147,7 @@ SCPS-55901:
   name: "Xenosaga Episode I - Der Wille zur Macht"
   region: "NTSC-J"
   gsHWFixes:
-    autoFlush: 1 # Fixes shadows in cutscenes.
+    autoFlush: 2 # Fixes shadows in cutscenes.
     halfPixelOffset: 2 # Removes puppet lines shadows.
     roundSprite: 2 # Fixes font artifacts.
   patches:
@@ -7236,7 +7237,7 @@ SCPS-56012:
   region: "NTSC-K"
   gsHWFixes:
     cpuCLUTRender: 1 # Fixes some shading/shadows.
-    autoFlush: 1 # Fixes incorrect blur effect.
+    autoFlush: 2 # Fixes incorrect blur effect.
 SCPS-56013:
   name: "This is Football 2003"
   region: "NTSC-K"
@@ -7256,7 +7257,7 @@ SCPS-56016:
     - GIFFIFOHack
   gsHWFixes:
     mipmap: 1
-    autoFlush: 1
+    autoFlush: 2
     estimateTextureRegion: 1 # Improves performance.
 SCUS-21295:
   name: "Tony Hawk's American Wasteland Collector's Edition"
@@ -7905,7 +7906,7 @@ SCUS-97264:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    autoFlush: 1 # Fixes lights going through walls.
+    autoFlush: 2 # Fixes lights going through walls.
     preloadFrameData: 1 # Fixes light flicker.
     halfPixelOffset: 2 # Corrects light position.
   gameFixes:
@@ -7926,7 +7927,7 @@ SCUS-97265:
     trilinearFiltering: 1 # Fixes water textures.
     cpuSpriteRenderBW: 4 # Fixes character and water textures.
     cpuSpriteRenderLevel: 2 # Needed for above.
-    autoFlush: 1 # Fixes lighting.
+    autoFlush: 2 # Fixes lighting.
 SCUS-97266:
   name: "Final Fantasy XI [Disc 1 of 2]"
   region: "NTSC-U"
@@ -7940,7 +7941,7 @@ SCUS-97268:
   gsHWFixes:
     mipmap: 1
     partialTargetInvalidation: 1 # Fixes broken pause screen.
-    autoFlush: 1
+    autoFlush: 2
   memcardFilters:
     - "SCUS-97268"
     - "SCUS-97199"
@@ -7965,7 +7966,7 @@ SCUS-97273:
     trilinearFiltering: 1 # Fixes water textures.
     cpuSpriteRenderBW: 4 # Fixes character and water textures.
     cpuSpriteRenderLevel: 2 # Needed for above.
-    autoFlush: 1 # Fixes lighting.
+    autoFlush: 2 # Fixes lighting.
 SCUS-97274:
   name: "Jak II [Video Demo]"
   region: "NTSC-U"
@@ -8040,7 +8041,7 @@ SCUS-97322:
   gsHWFixes:
     mipmap: 1
     partialTargetInvalidation: 1 # Fixes broken pause screen.
-    autoFlush: 1
+    autoFlush: 2
 SCUS-97323:
   name: "Ratchet & Clank 2 - Going Commando [Retail Employees Demo]"
   region: "NTSC-U"
@@ -8049,7 +8050,7 @@ SCUS-97323:
   gsHWFixes:
     mipmap: 1
     partialTargetInvalidation: 1 # Fixes broken pause screen.
-    autoFlush: 1
+    autoFlush: 2
 SCUS-97324:
   name: "Kiosk Demo Disc 2.11"
   region: "NTSC-U"
@@ -8093,7 +8094,7 @@ SCUS-97330:
     trilinearFiltering: 1 # Fixes water textures.
     cpuSpriteRenderBW: 4 # Fixes character and water textures.
     cpuSpriteRenderLevel: 2 # Needed for above.
-    autoFlush: 1 # Fixes lighting.
+    autoFlush: 2 # Fixes lighting.
 SCUS-97331:
   name: "Official U.S. PlayStation Magazine Demo Disc 078"
   region: "NTSC-U"
@@ -8151,7 +8152,7 @@ SCUS-97353:
     disablePartialInvalidation: 1 # Prevents the situation that a level (Aquatos) doesn't render characters and geometry.
     partialTargetInvalidation: 1 # Fixes broken pause screen.
     halfPixelOffset: 2 # Fixes misaligned bloom.
-    autoFlush: 1 # Helps fix misaligned bloom.
+    autoFlush: 2 # Helps fix misaligned bloom.
   memcardFilters:
     - "SCUS-97353"
     - "SCUS-97268"
@@ -8176,7 +8177,7 @@ SCUS-97362:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    autoFlush: 1
+    autoFlush: 2
 SCUS-97365:
   name: "World Tour Soccer 2005"
   region: "NTSC-U"
@@ -8224,7 +8225,7 @@ SCUS-97377:
   name: "Syphon Filter - The Omega Strain [Regular Demo]"
   region: "NTSC-U"
   gsHWFixes:
-    autoFlush: 1 # Fixes lights going through walls.
+    autoFlush: 2 # Fixes lights going through walls.
     preloadFrameData: 1 # Fixes light flicker.
     halfPixelOffset: 2 # Corrects light position.
 SCUS-97378:
@@ -8244,7 +8245,7 @@ SCUS-97381:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
     mipmap: 1
-    autoFlush: 1
+    autoFlush: 2
 SCUS-97382:
   name: "NBA Shootout 2004 [Demo]"
   region: "NTSC-U"
@@ -8341,7 +8342,7 @@ SCUS-97411:
     disablePartialInvalidation: 1 # Prevents the situation that a level (Aquatos) doesn't render characters and geometry.
     partialTargetInvalidation: 1 # Fixes broken pause screen.
     halfPixelOffset: 2 # Fixes misaligned bloom.
-    autoFlush: 1 # Helps fix misaligned bloom.
+    autoFlush: 2 # Helps fix misaligned bloom.
 SCUS-97412:
   name: "Jak 3 [Demo]"
   region: "NTSC-U"
@@ -8352,7 +8353,7 @@ SCUS-97412:
     trilinearFiltering: 1 # Fixes water textures.
     cpuSpriteRenderBW: 4 # Fixes character and water textures.
     cpuSpriteRenderLevel: 2 # Needed for above.
-    autoFlush: 1 # Fixes lighting.
+    autoFlush: 2 # Fixes lighting.
 SCUS-97413:
   name: "Ratchet & Clank - Up Your Arsenal [Public Beta v1.0]"
   region: "NTSC-U"
@@ -8363,7 +8364,7 @@ SCUS-97413:
     disablePartialInvalidation: 1 # Prevents the situation that a level (Aquatos) doesn't render characters and geometry.
     partialTargetInvalidation: 1 # Fixes broken pause screen.
     halfPixelOffset: 2 # Fixes misaligned bloom.
-    autoFlush: 1 # Helps fix misaligned bloom.
+    autoFlush: 2 # Helps fix misaligned bloom.
 SCUS-97414:
   name: "EyeToy - AntiGrav"
   region: "NTSC-U"
@@ -8419,7 +8420,7 @@ SCUS-97429:
   compat: 5
   gsHWFixes:
     roundSprite: 1 # Fix lines in the sky.
-    autoFlush: 1 # Fixes lighting.
+    autoFlush: 2 # Fixes lighting.
     mipmap: 2 # Fixes broken textures.
     trilinearFiltering: 1 # Fixes water textures.
     cpuSpriteRenderBW: 2 # Fixes water textures. Can't use BW 4 here because of post effects.
@@ -8480,7 +8481,7 @@ SCUS-97440:
     trilinearFiltering: 1 # Fixes water textures.
     cpuSpriteRenderBW: 4 # Fixes character and water textures.
     cpuSpriteRenderLevel: 2 # Needed for above.
-    autoFlush: 1 # Fixes lighting.
+    autoFlush: 2 # Fixes lighting.
 SCUS-97441:
   name: "Getaway The - Black Monday [Demo]"
   region: "NTSC-U"
@@ -8570,7 +8571,7 @@ SCUS-97465:
     disablePartialInvalidation: 1 # Prevents world geometry and some models from vanishing when pausing or opening vendor.
     partialTargetInvalidation: 1 # Fixes bad textures being read back during scene transitions.
     halfPixelOffset: 2 # Fixes misaligned bloom.
-    autoFlush: 1 # Helps fix misaligned bloom.
+    autoFlush: 2 # Helps fix misaligned bloom.
 SCUS-97466:
   name: "Gretzky NHL '06"
   region: "NTSC-U"
@@ -8687,13 +8688,13 @@ SCUS-97485:
     disablePartialInvalidation: 1 # Prevents world geometry and some models from vanishing when pausing or opening vendor.
     partialTargetInvalidation: 1 # Fixes bad textures being read back during scene transitions.
     halfPixelOffset: 2 # Fixes misaligned bloom.
-    autoFlush: 1 # Helps fix misaligned bloom.
+    autoFlush: 2 # Helps fix misaligned bloom.
 SCUS-97486:
   name: "Jak X - Combat Racing [Regular Demo]"
   region: "NTSC-U"
   gsHWFixes:
     roundSprite: 1 # Fix lines in the sky.
-    autoFlush: 1 # Fixes lighting.
+    autoFlush: 2 # Fixes lighting.
     mipmap: 2 # Fixes broken textures.
     trilinearFiltering: 1 # Fixes water textures.
     cpuSpriteRenderBW: 2 # Fixes water textures. Can't use BW 4 here because of post effects.
@@ -8709,14 +8710,14 @@ SCUS-97487:
     disablePartialInvalidation: 1 # Prevents world geometry and some models from vanishing when pausing or opening vendor.
     partialTargetInvalidation: 1 # Fixes bad textures being read back during scene transitions.
     halfPixelOffset: 2 # Fixes misaligned bloom.
-    autoFlush: 1 # Helps fix misaligned bloom.
+    autoFlush: 2 # Helps fix misaligned bloom.
 SCUS-97488:
   name: "Jak X - Combat Racing [Public Beta v.1]"
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
     roundSprite: 1 # Fix lines in the sky.
-    autoFlush: 1 # Fixes lighting.
+    autoFlush: 2 # Fixes lighting.
     mipmap: 2 # Fixes broken textures.
     trilinearFiltering: 1 # Fixes water textures.
     cpuSpriteRenderBW: 2 # Fixes water textures. Can't use BW 4 here because of post effects.
@@ -8732,7 +8733,7 @@ SCUS-97490:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    autoFlush: 1 # Fix glow effects from lamps.
+    autoFlush: 2 # Fix glow effects from lamps.
     roundSprite: 1 # Fix mini-map and field menu.
     preloadFrameData: 1 # Fixes corrupt textures especially on water.
     disablePartialInvalidation: 1 # Prevents UI and subtitles from disappearing.
@@ -8776,7 +8777,7 @@ SCUS-97501:
     mipmap: 2 # Fixes miptrick texture effects.
     trilinearFiltering: 1 # Fixes miptrick blending.
     halfPixelOffset: 2 # Fixes misaligned blur.
-    autoFlush: 1 # Fixes corruption in cutscenes and brightens the image.
+    autoFlush: 2 # Fixes corruption in cutscenes and brightens the image.
 SCUS-97502:
   name: "Tourist Trophy"
   region: "NTSC-U"
@@ -8810,7 +8811,7 @@ SCUS-97509:
     trilinearFiltering: 1 # Fixes water textures.
     cpuSpriteRenderBW: 4 # Fixes character and water textures.
     cpuSpriteRenderLevel: 2 # Needed for above.
-    autoFlush: 1 # Fixes lighting.
+    autoFlush: 2 # Fixes lighting.
 SCUS-97510:
   name: "ATV Offroad Fury 2 [Greatest Hits]"
   region: "NTSC-U"
@@ -8835,7 +8836,7 @@ SCUS-97513:
   gsHWFixes:
     mipmap: 1
     partialTargetInvalidation: 1 # Fixes broken pause screen.
-    autoFlush: 1
+    autoFlush: 2
 SCUS-97514:
   name: "ATV Offroad Fury 3 [Greatest Hits]"
   region: "NTSC-U"
@@ -8857,7 +8858,7 @@ SCUS-97516:
     trilinearFiltering: 1 # Fixes water textures.
     cpuSpriteRenderBW: 4 # Fixes character and water textures.
     cpuSpriteRenderLevel: 2 # Needed for above.
-    autoFlush: 1 # Fixes lighting.
+    autoFlush: 2 # Fixes lighting.
 SCUS-97517:
   name: "Killzone [Greatest Hits]"
   region: "NTSC-U"
@@ -8875,7 +8876,7 @@ SCUS-97518:
     disablePartialInvalidation: 1 # Prevents the situation that a level (Aquatos) doesn't render characters and geometry.
     partialTargetInvalidation: 1 # Fixes broken pause screen.
     halfPixelOffset: 2 # Fixes misaligned bloom.
-    autoFlush: 1 # Helps fix misaligned bloom.
+    autoFlush: 2 # Helps fix misaligned bloom.
 SCUS-97519:
   name: "Sly 2 - Band of Thieves [Greatest Hits]"
   region: "NTSC-U"
@@ -8885,7 +8886,7 @@ SCUS-97520:
   name: "Syphon Filter - The Omega Strain [Greatest Hits]"
   region: "NTSC-U"
   gsHWFixes:
-    autoFlush: 1 # Fixes lights going through walls.
+    autoFlush: 2 # Fixes lights going through walls.
     preloadFrameData: 1 # Fixes light flicker.
     halfPixelOffset: 2 # Corrects light position.
 SCUS-97523:
@@ -8964,7 +8965,7 @@ SCUS-97548:
     mipmap: 2 # Fixes miptrick texture effects.
     trilinearFiltering: 1 # Fixes miptrick blending.
     halfPixelOffset: 2 # Fixes misaligned blur.
-    autoFlush: 1 # Fixes corruption in cutscenes and brightens the image.
+    autoFlush: 2 # Fixes corruption in cutscenes and brightens the image.
 SCUS-97554:
   name: "NBA '07 featuring The Life Vol.2 [Demo]"
   region: "NTSC-U"
@@ -9012,7 +9013,7 @@ SCUS-97572:
   name: "Rogue Galaxy [Demo]"
   region: "NTSC-U"
   gsHWFixes:
-    autoFlush: 1 # Fix glow effects from lamps.
+    autoFlush: 2 # Fix glow effects from lamps.
     roundSprite: 1 # Fix mini-map and field menu.
     preloadFrameData: 1 # Fixes corrupt textures especially on water.
     disablePartialInvalidation: 1 # Prevents UI and subtitles from disappearing.
@@ -9022,7 +9023,7 @@ SCUS-97574:
   region: "NTSC-U"
   gsHWFixes:
     roundSprite: 1 # Fix lines in the sky.
-    autoFlush: 1 # Fixes lighting.
+    autoFlush: 2 # Fixes lighting.
     mipmap: 2 # Fixes broken textures.
     trilinearFiltering: 1 # Fixes water textures.
     cpuSpriteRenderBW: 2 # Fixes water textures. Can't use BW 4 here because of post effects.
@@ -9041,7 +9042,7 @@ SCUS-97584:
   name: "Syphon Filter - Logan's Shadow"
   region: "NTSC-U"
   gsHWFixes:
-    autoFlush: 1
+    autoFlush: 2
     preloadFrameData: 1
 SCUS-97589:
   name: "NBA '08 featuring The Life Vol.3"
@@ -9104,7 +9105,7 @@ SCUS-97620:
   name: "Syphon Filter - Dark Mirror [Demo]"
   region: "NTSC-U"
   gsHWFixes:
-    autoFlush: 1
+    autoFlush: 2
 SCUS-97621:
   name: "Twisted Metal - Head-On [Extra Twisted Edition]"
   region: "NTSC-U"
@@ -9269,7 +9270,7 @@ SLAJ-25037:
   roundModes:
     eeRoundMode: 0 # Fixes character behaviour.
   gsHWFixes:
-    autoFlush: 1 # Fixes flame bloom.
+    autoFlush: 2 # Fixes flame bloom.
 SLAJ-25039:
   name: "Beni no Umi 2"
   region: "NTSC-Unk"
@@ -9312,7 +9313,7 @@ SLAJ-25053:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes depth lines.
-    autoFlush: 1 # Fixes blur and obscures sun behind objects.
+    autoFlush: 2 # Fixes blur and obscures sun behind objects.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
@@ -9350,7 +9351,7 @@ SLAJ-25066:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes depth lines.
-    autoFlush: 1 # Fixes blur and obscures sun behind objects.
+    autoFlush: 2 # Fixes blur and obscures sun behind objects.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
@@ -9369,7 +9370,7 @@ SLAJ-25068:
   name: "Shin Sangoku Musou 4 - Mushoden"
   region: "NTSC-Unk"
   gsHWFixes:
-    autoFlush: 1 # Fixes sun luminosity.
+    autoFlush: 2 # Fixes sun luminosity.
 SLAJ-25072:
   name: "Matrix, The - Path of Neo"
   region: "NTSC-Unk"
@@ -9428,7 +9429,7 @@ SLAJ-25078:
     vuClampMode: 3 # Fixes SPS.
   gsHWFixes:
     recommendedBlendingLevel: 4 # Improves lighting on buildings and objects.
-    autoFlush: 1 # Properly diffuses light instead of strips of light.
+    autoFlush: 2 # Properly diffuses light instead of strips of light.
     roundSprite: 1 # Fixes lighting misalignment such as the street poles and the sun.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
@@ -9483,7 +9484,7 @@ SLAJ-25094:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes depth lines.
-    autoFlush: 1 # Fixes blur and obscures sun behind objects.
+    autoFlush: 2 # Fixes blur and obscures sun behind objects.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
@@ -9645,7 +9646,7 @@ SLED-52485:
   region: "PAL-E"
   gsHWFixes:
     cpuCLUTRender: 1 # Fixes lights penetrating objects.
-    autoFlush: 1 # Helps with the light penetration problem.
+    autoFlush: 2 # Helps with the light penetration problem.
     cpuSpriteRenderBW: 1 # Fixes light glows.
 SLED-52488:
   name: "Suffering, The [Demo]"
@@ -9660,7 +9661,7 @@ SLED-52597:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes depth lines.
-    autoFlush: 1 # Fixes blur and obscures sun behind objects.
+    autoFlush: 2 # Fixes blur and obscures sun behind objects.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
@@ -9701,7 +9702,7 @@ SLED-52929:
   name: "Prince of Persia - Warrior Within [Demo]"
   region: "PAL-M5"
   gsHWFixes:
-    autoFlush: 1 # Reduces post-processing misalignment.
+    autoFlush: 2 # Reduces post-processing misalignment.
 SLED-53083:
   name: "Monster Hunter [Demo]"
   region: "PAL-M5"
@@ -9739,7 +9740,7 @@ SLED-53512:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes depth lines.
-    autoFlush: 1 # Fixes blur and obscures sun behind objects.
+    autoFlush: 2 # Fixes blur and obscures sun behind objects.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
@@ -9749,7 +9750,7 @@ SLED-53537:
   name: "187 - Ride or Die [Demo]"
   region: "PAL-E"
   gsHWFixes:
-    autoFlush: 1 # Softens bloom on objects and cars.
+    autoFlush: 2 # Softens bloom on objects and cars.
     halfPixelOffset: 2 # Fixes misaligned bloom on objects and cars.
 SLED-53650:
   name: "Need for Speed - Most Wanted"
@@ -9800,7 +9801,7 @@ SLED-53937:
     vuClampMode: 3 # Fixes SPS.
   gsHWFixes:
     recommendedBlendingLevel: 4 # Improves lighting on buildings and objects.
-    autoFlush: 1 # Properly diffuses light instead of strips of light.
+    autoFlush: 2 # Properly diffuses light instead of strips of light.
     roundSprite: 1 # Fixes lighting misalignment such as the street poles and the sun.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
@@ -9844,7 +9845,7 @@ SLED-54401:
     roundSprite: 2 # Fixes misaligned bloom.
     mergeSprite: 1 # Fixes misaligned bloom.
     halfPixelOffset: 2 # Fixes misaligned bloom.
-    autoFlush: 1 # Fixes sun occlusion and brightness.
+    autoFlush: 2 # Fixes sun occlusion and brightness.
 SLES-50003:
   name: "Swap Magic DVD Disc v2.0"
   region: "PAL-Unk"
@@ -11401,7 +11402,7 @@ SLES-50725:
   compat: 5
   gsHWFixes:
     preloadFrameData: 1 # Fixes fog and make lights on cars work again.
-    autoFlush: 1 # Fixes sun luminosity and penetration of objects.
+    autoFlush: 2 # Fixes sun luminosity and penetration of objects.
   gameFixes:
     - EETimingHack # Fixes random graphical corruption.
 SLES-50726:
@@ -11868,7 +11869,7 @@ SLES-50876:
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
-    autoFlush: 1
+    autoFlush: 2
     cpuCLUTRender: 1 # Fixes janky coloured cars.
     gpuTargetCLUT: 1 # Fixes janky coloured cars.
     textureInsideRT: 1 # Fixes car textures.
@@ -12110,7 +12111,7 @@ SLES-51011:
   region: "PAL-M4"
   compat: 5
   gsHWFixes:
-    autoFlush: 1 # Fixes brake lights.
+    autoFlush: 2 # Fixes brake lights.
     preloadFrameData: 1 # Fixes graphical issues.
 SLES-51013:
   name: "Blade II"
@@ -12352,7 +12353,7 @@ SLES-51117:
   region: "PAL-M5"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
-    autoFlush: 1 # Fixes the sun flare.
+    autoFlush: 2 # Fixes the sun flare.
     halfPixelOffset: 2 # Fixes the sun flare.
 SLES-51118:
   name: "Wizardry - Tales of the Forsaken Land"
@@ -12662,7 +12663,7 @@ SLES-51227:
   region: "PAL-M10"
   compat: 5
   gsHWFixes:
-    autoFlush: 1 # Fixes lava effect.
+    autoFlush: 2 # Fixes lava effect.
   patches:
     default:
       content: |-
@@ -12875,7 +12876,7 @@ SLES-51301:
   name: "SOS - The Final Escape"
   region: "PAL-M3"
   gsHWFixes:
-    autoFlush: 1 # Fixes incorrect blur effect.
+    autoFlush: 2 # Fixes incorrect blur effect.
 SLES-51302:
   name: "Bomberman Kart"
   region: "PAL-M3"
@@ -12976,7 +12977,7 @@ SLES-51354:
   region: "PAL-M5"
   compat: 5
   gsHWFixes:
-    autoFlush: 1 # Fixes glows. Also needed for recursive mipmap rendering.
+    autoFlush: 2 # Fixes glows. Also needed for recursive mipmap rendering.
     mipmap: 2 # Better characters and environment but has a texture cache issue that makes it worse.
     trilinearFiltering: 1 # Using mipmaps, so may as well.
     textureInsideRT: 1 # Fixes rainbow lighting for some areas.
@@ -13240,7 +13241,7 @@ SLES-51473:
     - EETimingHack # Fixes smoke effects.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes fog misalignment and depth line.
-    autoFlush: 1 # Fixes sun going through objects.
+    autoFlush: 2 # Fixes sun going through objects.
     preloadFrameData: 1 # Fixes missing sun and sky.
 SLES-51474:
   name: "BloodRayne"
@@ -13336,7 +13337,7 @@ SLES-51541:
   clampModes:
     eeClampMode: 2 # Fixes Game freezes during "Reuniting The Families" mission.
   gsHWFixes:
-    autoFlush: 1
+    autoFlush: 1 # Fixes post processing.
 SLES-51547:
   name: "Next Generation Tennis 2003"
   region: "PAL-M5"
@@ -13863,7 +13864,7 @@ SLES-51820:
   name: "Sniper Elite"
   region: "PAL-M5"
   gsHWFixes:
-    autoFlush: 1 # Fixes bloom misalignment.
+    autoFlush: 2 # Fixes bloom misalignment.
     halfPixelOffset: 2 # Fixes bloom misalignment.
     textureInsideRT: 1 # Fixes sky bloom.
 SLES-51821:
@@ -13871,14 +13872,14 @@ SLES-51821:
   region: "PAL-M5"
   gsHWFixes:
     cpuCLUTRender: 1 # Fixes lights penetrating objects.
-    autoFlush: 1 # Helps with the light penetration problem.
+    autoFlush: 2 # Helps with the light penetration problem.
     cpuSpriteRenderBW: 1 # Fixes light glows.
 SLES-51822:
   name: "Alias"
   region: "PAL-I"
   gsHWFixes:
     cpuCLUTRender: 1 # Fixes lights penetrating objects.
-    autoFlush: 1 # Helps with the light penetration problem.
+    autoFlush: 2 # Helps with the light penetration problem.
     cpuSpriteRenderBW: 1 # Fixes light glows.
 SLES-51823:
   name: "Hunter - The Reckoning Wayward"
@@ -14101,7 +14102,7 @@ SLES-51897:
   gameFixes:
     - FpuNegDivHack # Lens flare appears even when behind objects.
   gsHWFixes:
-    autoFlush: 1 # Fixes missing lens flare.
+    autoFlush: 2 # Fixes missing lens flare.
 SLES-51903:
   name: "AFL Live 2004 - Aussie Rules Football"
   region: "PAL-E"
@@ -14158,7 +14159,7 @@ SLES-51917:
     eeRoundMode: 0 # Fixes SPS with water in some places.
   gsHWFixes:
     textureInsideRT: 1 # Fixes the shape of shadows.
-    autoFlush: 1 # Fixes water rendering.
+    autoFlush: 2 # Fixes water rendering.
     halfPixelOffset: 3 # Fixes bloom misalignment, needs this harsh offset for autoflush.
     cpuFramebufferConversion: 1 # Fixes shield rendering.
 SLES-51918:
@@ -14166,7 +14167,7 @@ SLES-51918:
   region: "PAL-M5"
   compat: 5
   gsHWFixes:
-    autoFlush: 1 # Reduces post-processing misalignment.
+    autoFlush: 2 # Reduces post-processing misalignment.
 SLES-51924:
   name: "World War Zero - Ironstorm"
   region: "PAL-M5"
@@ -14257,7 +14258,7 @@ SLES-51961:
   name: "Prince of Persia - The Sands of Time" # Pre-order Demo
   region: "PAL-E"
   gsHWFixes:
-    autoFlush: 1 # Reduces post-processing misalignment.
+    autoFlush: 2 # Reduces post-processing misalignment.
 SLES-51963:
   name: "FIFA 2004"
   region: "PAL-F-G"
@@ -14414,7 +14415,7 @@ SLES-52034:
   name: "Cat in the Hat, The"
   region: "PAL-M5"
   gsHWFixes:
-    autoFlush: 1
+    autoFlush: 2
 SLES-52036:
   name: "WWE SmackDown! - Here Comes the Pain!"
   region: "PAL-E"
@@ -14635,7 +14636,7 @@ SLES-52153:
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
-    autoFlush: 1
+    autoFlush: 2
     cpuCLUTRender: 1 # Fixes janky coloured cars.
     gpuTargetCLUT: 1 # Fixes janky coloured cars.
     textureInsideRT: 1 # Fixes car textures.
@@ -14795,17 +14796,17 @@ SLES-52265:
   name: "Energy Airforce - Aim Strike!"
   region: "PAL-E"
   gsHWFixes:
-    autoFlush: 1 # Corrects post-processing effect on jet exhausts.
+    autoFlush: 2 # Corrects post-processing effect on jet exhausts.
 SLES-52266:
   name: "Energy Airforce - Aim Strike!"
   region: "PAL-F"
   gsHWFixes:
-    autoFlush: 1 # Corrects post-processing effect on jet exhausts.
+    autoFlush: 2 # Corrects post-processing effect on jet exhausts.
 SLES-52267:
   name: "Energy Airforce - Aim Strike!"
   region: "PAL-I"
   gsHWFixes:
-    autoFlush: 1 # Corrects post-processing effect on jet exhausts.
+    autoFlush: 2 # Corrects post-processing effect on jet exhausts.
 SLES-52275:
   name: "Way of the Samurai 2"
   region: "PAL-M3"
@@ -14815,7 +14816,7 @@ SLES-52276:
   region: "PAL-M5"
   compat: 5
   gsHWFixes:
-    autoFlush: 1 # Softens bloom on objects and cars.
+    autoFlush: 2 # Softens bloom on objects and cars.
     halfPixelOffset: 2 # Fixes misaligned bloom on objects and cars.
 SLES-52277:
   name: "Riding Spirits 2"
@@ -15056,7 +15057,7 @@ SLES-52372:
   region: "PAL-M5"
   gsHWFixes:
     cpuSpriteRenderBW: 1 # Fixes textures.
-    autoFlush: 1 # Fixes the position of the shadow and makes it not blocky.
+    autoFlush: 2 # Fixes the position of the shadow and makes it not blocky.
     halfPixelOffset: 2 # Fixes shadows.
     gpuPaletteConversion: 0 # Stops potential crashes from too many palette textures.
 SLES-52373:
@@ -15177,7 +15178,7 @@ SLES-52418:
   region: "PAL-M5"
   compat: 4
   gsHWFixes:
-    autoFlush: 1
+    autoFlush: 2
   patches:
     52085DF1:
       content: |-
@@ -15224,7 +15225,7 @@ SLES-52447:
   region: "PAL-I"
   gsHWFixes:
     cpuSpriteRenderBW: 1 # Fixes textures.
-    autoFlush: 1 # Fixes the position of the shadow and makes it not blocky.
+    autoFlush: 2 # Fixes the position of the shadow and makes it not blocky.
     halfPixelOffset: 2 # Fixes shadows.
     gpuPaletteConversion: 0 # Stops potential crashes from too many palette textures.
 SLES-52448:
@@ -15331,7 +15332,7 @@ SLES-52486:
   roundModes:
     eeRoundMode: 0 # Fixes character behaviour.
   gsHWFixes:
-    autoFlush: 1 # Fixes flame bloom.
+    autoFlush: 2 # Fixes flame bloom.
 SLES-52490:
   name: "Dance UK - Extra Trax"
   region: "PAL-E"
@@ -15340,7 +15341,7 @@ SLES-52493:
   region: "PAL-E"
   gsHWFixes:
     cpuSpriteRenderBW: 1 # Fixes textures.
-    autoFlush: 1 # Fixes the position of the shadow and makes it not blocky.
+    autoFlush: 2 # Fixes the position of the shadow and makes it not blocky.
     halfPixelOffset: 2 # Fixes shadows.
     gpuPaletteConversion: 0 # Stops potential crashes from too many palette textures.
 SLES-52495:
@@ -15467,7 +15468,7 @@ SLES-52541:
   clampModes:
     eeClampMode: 2 # Fixes Game freezes during "Reuniting The Families" mission.
   gsHWFixes:
-    autoFlush: 1
+    autoFlush: 1 # Fixes post processing.
 SLES-52542:
   name: "All Music Dance!"
   region: "PAL-I"
@@ -15595,7 +15596,7 @@ SLES-52584:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes depth lines.
-    autoFlush: 1 # Fixes blur and obscures sun behind objects.
+    autoFlush: 2 # Fixes blur and obscures sun behind objects.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
@@ -15609,7 +15610,7 @@ SLES-52585:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes depth lines.
-    autoFlush: 1 # Fixes blur and obscures sun behind objects.
+    autoFlush: 2 # Fixes blur and obscures sun behind objects.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
@@ -15624,21 +15625,21 @@ SLES-52588:
   region: "PAL-E"
   gsHWFixes:
     halfBottomOverride: 1 # Bottom screen has wrong colors.
-    autoFlush: 1 # Fixes missing lighting.
+    autoFlush: 2 # Fixes missing lighting.
     # halfPixelOffset: 1 # Fixes lighting misalignment. Do not enable this, it breaks a lot of graphics.
 SLES-52589:
   name: "Mercenaries - Playground of Destruction"
   region: "PAL-F"
   gsHWFixes:
     halfBottomOverride: 1 # Bottom screen has wrong colors.
-    autoFlush: 1 # Fixes missing lighting.
+    autoFlush: 2 # Fixes missing lighting.
     # halfPixelOffset: 1 # Fixes lighting misalignment. Do not enable this, it breaks a lot of graphics.
 SLES-52590:
   name: "Mercenaries - Playground of Destruction"
   region: "PAL-G"
   gsHWFixes:
     halfBottomOverride: 1 # Bottom screen has wrong colors.
-    autoFlush: 1 # Fixes missing lighting.
+    autoFlush: 2 # Fixes missing lighting.
     # halfPixelOffset: 1 # Fixes lighting misalignment. Do not enable this, it breaks a lot of graphics.
 SLES-52591:
   name: "Dynasty Warriors 4 - Empires"
@@ -15735,7 +15736,7 @@ SLES-52636:
   region: "PAL-M5"
   compat: 5
   gsHWFixes:
-    autoFlush: 1 # Fixes incorrect colors.
+    autoFlush: 2 # Fixes incorrect colors.
     alignSprite: 1 # Fixes vertical lines such as in FMVs.
 SLES-52637:
   name: "TOCA Racer Driver 2"
@@ -16244,7 +16245,7 @@ SLES-52822:
   region: "PAL-M6"
   compat: 5
   gsHWFixes:
-    autoFlush: 1 # Reduces post-processing misalignment.
+    autoFlush: 2 # Reduces post-processing misalignment.
 SLES-52824:
   name: "Furry Tales"
   region: "PAL-E-F"
@@ -16490,7 +16491,7 @@ SLES-52927:
   clampModes:
     eeClampMode: 2 # Fixes Game freezes during "Reuniting The Families" mission.
   gsHWFixes:
-    autoFlush: 1
+    autoFlush: 1 # Fixes post processing.
 SLES-52931:
   name: "Legend of Kay"
   region: "PAL-M5"
@@ -16499,7 +16500,7 @@ SLES-52931:
     vuClampMode: 3 # Fixes broken polygons on trees.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misaligned bloom.
-    autoFlush: 1 # Fixes glitchy black rectangles.
+    autoFlush: 2 # Fixes glitchy black rectangles.
 SLES-52934:
   name: "Guilty Gear Isuka [Preview]"
   region: "PAL-E"
@@ -16664,7 +16665,7 @@ SLES-52988:
   name: "Mega Man X8"
   region: "PAL-M5"
   gsHWFixes:
-    autoFlush: 1 # Fixes bloom.
+    autoFlush: 2 # Fixes bloom.
     roundSprite: 1 # Fixes misaligned bloom.
   memcardFilters: # Reads Command Mission save for bonus boss.
     - "SLES-52988"
@@ -16717,7 +16718,7 @@ SLES-53008:
   region: "PAL-I-S"
   gsHWFixes:
     halfBottomOverride: 1 # Bottom screen has wrong colors.
-    autoFlush: 1 # Fixes missing lighting.
+    autoFlush: 2 # Fixes missing lighting.
     # halfPixelOffset: 1 # Fixes lighting misalignment. Do not enable this, it breaks a lot of graphics.
 SLES-53009:
   name: "Dance Factory"
@@ -17014,7 +17015,7 @@ SLES-53098:
   name: "Conspiracy - Weapons of Mass Destruction"
   region: "PAL-M5"
   gsHWFixes:
-    autoFlush: 1 # Fixes lighting misalignment.
+    autoFlush: 2 # Fixes lighting misalignment.
   gameFixes:
     - XGKickHack # Fixes stretched/spikey textures.
 SLES-53099:
@@ -17223,7 +17224,7 @@ SLES-53196:
     roundSprite: 2 # Fixes misaligned bloom.
     mergeSprite: 1 # Fixes misaligned bloom.
     halfPixelOffset: 2 # Fixes misaligned bloom.
-    autoFlush: 1 # Fixes sun occlusion and brightness.
+    autoFlush: 2 # Fixes sun occlusion and brightness.
 SLES-53197:
   name: "Destroy All Humans!"
   region: "PAL-G"
@@ -17234,7 +17235,7 @@ SLES-53197:
     roundSprite: 2 # Fixes misaligned bloom.
     mergeSprite: 1 # Fixes misaligned bloom.
     halfPixelOffset: 2 # Fixes misaligned bloom.
-    autoFlush: 1 # Fixes sun occlusion and brightness.
+    autoFlush: 2 # Fixes sun occlusion and brightness.
 SLES-53199:
   name: "25 to Life"
   region: "PAL-E"
@@ -17570,7 +17571,7 @@ SLES-53387:
   name: "Batman Begins"
   region: "PAL-M7"
   gsHWFixes:
-    autoFlush: 1 # Fixes lighting misalignment.
+    autoFlush: 2 # Fixes lighting misalignment.
     halfPixelOffset: 2 # Fixes lighting misalignment.
 SLES-53388:
   name: "Rhythmic Star!"
@@ -17586,7 +17587,7 @@ SLES-53390:
     partialTargetInvalidation: 1 # Fixes texture distortion.
     mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
     trilinearFiltering: 1
-    autoFlush: 1 # Fixes shadow alignment along with HPO Special (Normal looks better but causes top left glitches).
+    autoFlush: 2 # Fixes shadow alignment along with HPO Special (Normal looks better but causes top left glitches).
     halfPixelOffset: 2
 SLES-53391:
   name: "Ultimate Spider-Man"
@@ -17598,7 +17599,7 @@ SLES-53391:
     partialTargetInvalidation: 1 # Fixes texture distortion.
     mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
     trilinearFiltering: 1
-    autoFlush: 1 # Fixes shadow alignment along with HPO Special (Normal looks better but causes top left glitches).
+    autoFlush: 2 # Fixes shadow alignment along with HPO Special (Normal looks better but causes top left glitches).
     halfPixelOffset: 2
 SLES-53393:
   name: "Spartan - Total Warrior"
@@ -17925,7 +17926,7 @@ SLES-53506:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes depth lines.
-    autoFlush: 1 # Fixes blur and obscures sun behind objects.
+    autoFlush: 2 # Fixes blur and obscures sun behind objects.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
@@ -17946,7 +17947,7 @@ SLES-53507:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes depth lines.
-    autoFlush: 1 # Fixes blur and obscures sun behind objects.
+    autoFlush: 2 # Fixes blur and obscures sun behind objects.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
@@ -17987,7 +17988,7 @@ SLES-53523:
     trilinearFiltering: 1
     textureInsideRT: 1 # Fixes rainbow artifacting around edges of screen.
     halfPixelOffset: 2 # Fixes misalgined bloom.
-    autoFlush: 1 # Fixes missing bloom intensity and alignment.
+    autoFlush: 2 # Fixes missing bloom intensity and alignment.
 SLES-53524:
   name: "Mortal Kombat - Shaolin Monks"
   region: "PAL-M5"
@@ -17998,7 +17999,7 @@ SLES-53526:
   name: "Suffering, The - Ties that Bind"
   region: "PAL-E-F"
   gsHWFixes:
-    autoFlush: 1 # Fixes debris and blending on lower part of screen during monster transformation.
+    autoFlush: 2 # Fixes debris and blending on lower part of screen during monster transformation.
     mipmap: 2
     trilinearFiltering: 1
   memcardFilters:
@@ -18013,7 +18014,7 @@ SLES-53527:
   name: "Suffering, The - Ties that Bind"
   region: "PAL-E-I-S"
   gsHWFixes:
-    autoFlush: 1 # Fixes debris and blending on lower part of screen during monster transformation.
+    autoFlush: 2 # Fixes debris and blending on lower part of screen during monster transformation.
     mipmap: 2
     trilinearFiltering: 1
   memcardFilters:
@@ -18028,7 +18029,7 @@ SLES-53528:
   name: "Suffering, The - Ties that Bind"
   region: "PAL-G"
   gsHWFixes:
-    autoFlush: 1 # Fixes debris and blending on lower part of screen during monster transformation.
+    autoFlush: 2 # Fixes debris and blending on lower part of screen during monster transformation.
     mipmap: 2
     trilinearFiltering: 1
   memcardFilters:
@@ -18236,7 +18237,7 @@ SLES-53563:
   name: "Nickelodeon SpongeBob SquarePants and Friends Unite!"
   region: "PAL-M6"
   gsHWFixes:
-    autoFlush: 1 # Fixes glows. Also needed for recursive mipmap rendering.
+    autoFlush: 2 # Fixes glows. Also needed for recursive mipmap rendering.
     mipmap: 2 # Better characters and environment but has a texture cache issue that makes it worse.
     trilinearFiltering: 1 # Using mipmaps, so may as well.
     textureInsideRT: 1 # Fixes rainbow lighting for some areas.
@@ -18392,7 +18393,7 @@ SLES-53626:
   name: "Suffering, The - Ties that Bind"
   region: "PAL-E-G"
   gsHWFixes:
-    autoFlush: 1 # Fixes debris and blending on lower part of screen during monster transformation.
+    autoFlush: 2 # Fixes debris and blending on lower part of screen during monster transformation.
     mipmap: 2
     trilinearFiltering: 1
   memcardFilters:
@@ -18413,7 +18414,7 @@ SLES-53634:
   name: "Nicktoons Unite!"
   region: "PAL-A"
   gsHWFixes:
-    autoFlush: 1 # Fixes glows. Also needed for recursive mipmap rendering.
+    autoFlush: 2 # Fixes glows. Also needed for recursive mipmap rendering.
     mipmap: 2 # Better characters and environment but has a texture cache issue that makes it worse.
     trilinearFiltering: 1 # Using mipmaps, so may as well.
     textureInsideRT: 1 # Fixes rainbow lighting for some areas.
@@ -18450,7 +18451,7 @@ SLES-53641:
     roundSprite: 2 # Fixes misaligned bloom.
     mergeSprite: 1 # Fixes misaligned bloom.
     halfPixelOffset: 2 # Fixes misaligned bloom.
-    autoFlush: 1 # Fixes sun occlusion and brightness.
+    autoFlush: 2 # Fixes sun occlusion and brightness.
 SLES-53644:
   name: "Gene Troopers"
   region: "PAL-M5"
@@ -18474,7 +18475,7 @@ SLES-53647:
     trilinearFiltering: 1
     textureInsideRT: 1 # Fixes rainbow artifacting around edges of screen.
     halfPixelOffset: 2 # Fixes misalgined bloom.
-    autoFlush: 1 # Fixes missing bloom intensity and alignment.
+    autoFlush: 2 # Fixes missing bloom intensity and alignment.
 SLES-53651:
   name: "WWII - Soldier"
   region: "PAL-E"
@@ -18536,7 +18537,7 @@ SLES-53672:
     partialTargetInvalidation: 1 # Fixes texture distortion.
     mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
     trilinearFiltering: 1
-    autoFlush: 1 # Fixes shadow alignment along with HPO Special (Normal looks better but causes top left glitches).
+    autoFlush: 2 # Fixes shadow alignment along with HPO Special (Normal looks better but causes top left glitches).
     halfPixelOffset: 2
 SLES-53676:
   name: "WWE SmackDown! vs. RAW 2006"
@@ -18722,7 +18723,7 @@ SLES-53729:
   name: "Battlefield 2 - Modern Combat"
   region: "PAL-M4"
   gsHWFixes:
-    autoFlush: 1 # Post-processing.
+    autoFlush: 2 # Post-processing.
     halfPixelOffset: 2 # Offset post-processing.
     texturePreloading: 1 # Spikes all over the place otherwise.
     textureInsideRT: 1 # Fixes light shinging through objects.
@@ -18733,7 +18734,7 @@ SLES-53730:
   name: "Battlefield 2 - Modern Combat"
   region: "PAL-M3"
   gsHWFixes:
-    autoFlush: 1 # Post-processing.
+    autoFlush: 2 # Post-processing.
     halfPixelOffset: 2 # Offset post-processing.
     texturePreloading: 1 # Spikes all over the place otherwise.
     textureInsideRT: 1 # Fixes light shinging through objects.
@@ -18829,7 +18830,7 @@ SLES-53758:
   name: "Sniper Elite [Pre-Production]"
   region: "PAL-E"
   gsHWFixes:
-    autoFlush: 1 # Fixes bloom misalignment.
+    autoFlush: 2 # Fixes bloom misalignment.
     halfPixelOffset: 2 # Fixes bloom misalignment.
     textureInsideRT: 1 # Fixes sky bloom.
 SLES-53759:
@@ -18863,7 +18864,7 @@ SLES-53768:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misaligned bloom.
-    autoFlush: 1 # Fixes misaligned bloom on sun.
+    autoFlush: 2 # Fixes misaligned bloom on sun.
 SLES-53769:
   name: "Suikoden Tactics"
   region: "PAL-M5"
@@ -18888,7 +18889,7 @@ SLES-53777:
   region: "PAL-M5"
   compat: 5
   gsHWFixes:
-    autoFlush: 1 # Reduces post-processing misalignment.
+    autoFlush: 2 # Reduces post-processing misalignment.
     halfPixelOffset: 1 # Reduces post-processing misalignment.
 SLES-53778:
   name: "Jacked"
@@ -19073,17 +19074,17 @@ SLES-53860:
   name: "Dynasty Warriors 5 - Xtreme Legends"
   region: "PAL-E"
   gsHWFixes:
-    autoFlush: 1 # Fixes sun luminosity.
+    autoFlush: 2 # Fixes sun luminosity.
 SLES-53861:
   name: "Dynasty Warriors 5 - Xtreme Legends"
   region: "PAL-F"
   gsHWFixes:
-    autoFlush: 1 # Fixes sun luminosity.
+    autoFlush: 2 # Fixes sun luminosity.
 SLES-53862:
   name: "Dynasty Warriors 5 - Xtreme Legends"
   region: "PAL-G"
   gsHWFixes:
-    autoFlush: 1 # Fixes sun luminosity.
+    autoFlush: 2 # Fixes sun luminosity.
 SLES-53863:
   name: "Pool Paradise - International Edition"
   region: "PAL-M5"
@@ -19137,7 +19138,7 @@ SLES-53886:
     vuClampMode: 3 # Fixes SPS.
   gsHWFixes:
     recommendedBlendingLevel: 4 # Improves lighting on buildings and objects.
-    autoFlush: 1 # Properly diffuses light instead of strips of light.
+    autoFlush: 2 # Properly diffuses light instead of strips of light.
     roundSprite: 1 # Fixes lighting misalignment such as the street poles and the sun.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
@@ -19181,7 +19182,7 @@ SLES-53904:
   gsHWFixes:
     partialTargetInvalidation: 1
     mipmap: 1
-    autoFlush: 1
+    autoFlush: 2
     estimateTextureRegion: 1 # Improves performance.
 SLES-53906:
   name: "50 Cent - Bulletproof"
@@ -19344,7 +19345,7 @@ SLES-53974:
   region: "PAL-M5"
   compat: 5
   gsHWFixes:
-    autoFlush: 1 # Fixes missing bloom from surfaces like windows.
+    autoFlush: 2 # Fixes missing bloom from surfaces like windows.
     textureInsideRT: 1 # Fixes corruption.
     # halfPixelOffset: 1 # Aligns shadows properly, but causes grid lines to appear in sea travel.
     halfPixelOffset: 2 # Sharpens world in far distances, aligns some bloom better.
@@ -19420,7 +19421,7 @@ SLES-53998:
   region: "PAL-M5"
   compat: 5
   gsHWFixes:
-    autoFlush: 1 # Reduces post-processing misalignment.
+    autoFlush: 2 # Reduces post-processing misalignment.
     halfPixelOffset: 2 # Fixes bloom misalignment still a bit misaligned.
     roundSprite: 1 # Fixes bloom misalignment still a bit misaligned + font artifacts.
 SLES-53999:
@@ -19511,7 +19512,7 @@ SLES-54030:
     vuClampMode: 3 # Fixes SPS.
   gsHWFixes:
     recommendedBlendingLevel: 4 # Improves lighting on buildings and objects.
-    autoFlush: 1 # Properly diffuses light instead of strips of light.
+    autoFlush: 2 # Properly diffuses light instead of strips of light.
     roundSprite: 1 # Fixes lighting misalignment such as the street poles and the sun.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
@@ -19627,7 +19628,7 @@ SLES-54114:
   name: "Kingdom Hearts II"
   region: "PAL-E"
   gsHWFixes:
-    autoFlush: 1 # Fixes effects.
+    autoFlush: 2 # Fixes effects.
     roundSprite: 2 # Fixes upscaling artifacts.
   compat: 5
 SLES-54115:
@@ -19866,7 +19867,7 @@ SLES-54182:
   gameFixes:
     - IbitHack
   gsHWFixes:
-    autoFlush: 1 # Fixes post processing overlay.
+    autoFlush: 2 # Fixes post processing overlay.
     roundSprite: 1 # Greatly reduces chromatic effect when upscaling.
 SLES-54183:
   name: "Scarface - The World is Yours"
@@ -19874,7 +19875,7 @@ SLES-54183:
   gameFixes:
     - IbitHack
   gsHWFixes:
-    autoFlush: 1 # Fixes post processing overlay.
+    autoFlush: 2 # Fixes post processing overlay.
     roundSprite: 1 # Greatly reduces chromatic effect when upscaling.
 SLES-54184:
   name: "Scarface - The World is Yours"
@@ -19882,14 +19883,14 @@ SLES-54184:
   gameFixes:
     - IbitHack
   gsHWFixes:
-    autoFlush: 1 # Fixes post processing overlay.
+    autoFlush: 2 # Fixes post processing overlay.
     roundSprite: 1 # Greatly reduces chromatic effect when upscaling.
 SLES-54185:
   name: "Dirge of Cerberus - Final Fantasy VII"
   region: "PAL-M5"
   compat: 5
   gsHWFixes:
-    autoFlush: 1 # Fixes lighting.
+    autoFlush: 2 # Fixes lighting.
 SLES-54186:
   name: "Devil May Cry 3 - Dante's Awakening [Special Edition]"
   region: "PAL-M5"
@@ -20006,25 +20007,25 @@ SLES-54232:
   name: "Kingdom Hearts II"
   region: "PAL-F"
   gsHWFixes:
-    autoFlush: 1 # Fixes effects.
+    autoFlush: 2 # Fixes effects.
     roundSprite: 2 # Fixes upscaling artifacts.
 SLES-54233:
   name: "Kingdom Hearts II"
   region: "PAL-G"
   gsHWFixes:
-    autoFlush: 1 # Fixes effects.
+    autoFlush: 2 # Fixes effects.
     roundSprite: 2 # Fixes upscaling artifacts.
 SLES-54234:
   name: "Kingdom Hearts II"
   region: "PAL-I"
   gsHWFixes:
-    autoFlush: 1 # Fixes effects.
+    autoFlush: 2 # Fixes effects.
     roundSprite: 2 # Fixes upscaling artifacts.
 SLES-54235:
   name: "Kingdom Hearts II"
   region: "PAL-S"
   gsHWFixes:
-    autoFlush: 1 # Fixes effects.
+    autoFlush: 2 # Fixes effects.
     roundSprite: 2 # Fixes upscaling artifacts.
 SLES-54237:
   name: "Pirates of the Caribbean - The Legend of Jack Sparrow"
@@ -20104,7 +20105,7 @@ SLES-54271:
   gameFixes:
     - IbitHack
   gsHWFixes:
-    autoFlush: 1 # Fixes post processing overlay.
+    autoFlush: 2 # Fixes post processing overlay.
     roundSprite: 1 # Greatly reduces chromatic effect when upscaling.
 SLES-54305:
   name: "Demon Chaos"
@@ -20113,7 +20114,7 @@ SLES-54305:
   gameFixes:
     - VIF1StallHack # Fixes black screen on boot.
   gsHWFixes:
-    autoFlush: 1 # Fixes missing bloom effects.
+    autoFlush: 2 # Fixes missing bloom effects.
     halfPixelOffset: 2 # Fixes misaligned lighting and bloom.
 SLES-54306:
   name: "Cartoon Network Racing"
@@ -20360,7 +20361,7 @@ SLES-54376:
   gsHWFixes:
     halfPixelOffset: 2 # Fix text and post blur.
     mipmap: 2 # Base mip level isn't always used.
-    autoFlush: 1 # Needed for recursive mipmap rendering.
+    autoFlush: 2 # Needed for recursive mipmap rendering.
     getSkipCount: "GSC_BlueTongueGames" # Render mipmaps on the CPU.
 SLES-54377:
   name: "Barnyard"
@@ -20368,7 +20369,7 @@ SLES-54377:
   gsHWFixes:
     halfPixelOffset: 2 # Fix text and post blur.
     mipmap: 2 # Base mip level isn't always used.
-    autoFlush: 1 # Needed for recursive mipmap rendering.
+    autoFlush: 2 # Needed for recursive mipmap rendering.
     getSkipCount: "GSC_BlueTongueGames" # Render mipmaps on the CPU.
 SLES-54378:
   name: "Barnyard"
@@ -20376,7 +20377,7 @@ SLES-54378:
   gsHWFixes:
     halfPixelOffset: 2 # Fix text and post blur.
     mipmap: 2 # Base mip level isn't always used.
-    autoFlush: 1 # Needed for recursive mipmap rendering.
+    autoFlush: 2 # Needed for recursive mipmap rendering.
     getSkipCount: "GSC_BlueTongueGames" # Render mipmaps on the CPU.
 SLES-54379:
   name: "NFL Street 3"
@@ -20406,7 +20407,7 @@ SLES-54384:
     roundSprite: 2 # Fixes misaligned bloom.
     mergeSprite: 1 # Fixes misaligned bloom.
     halfPixelOffset: 2 # Fixes misaligned bloom.
-    autoFlush: 1 # Fixes sun occlusion and brightness.
+    autoFlush: 2 # Fixes sun occlusion and brightness.
 SLES-54385:
   name: "Atelier Iris 2 - The Azoth of Destiny"
   region: "PAL-E"
@@ -20773,7 +20774,7 @@ SLES-54521:
   gsHWFixes:
     mipmap: 2 # Better characters and environment.
     trilinearFiltering: 1 # Using mipmaps, so may as well.
-    autoFlush: 1 # Fixes texture corruptions.
+    autoFlush: 2 # Fixes texture corruptions.
     getSkipCount: "GSC_BlueTongueGames" # Mipmap rendering on CPU.
 SLES-54527:
   name: "Flushed Away"
@@ -20787,7 +20788,7 @@ SLES-54534:
   gameFixes:
     - IbitHack
   gsHWFixes:
-    autoFlush: 1 # Fixes post processing overlay.
+    autoFlush: 2 # Fixes post processing overlay.
     roundSprite: 1 # Greatly reduces chromatic effect when upscaling.
 SLES-54536:
   name: "Big Idea's VeggieTales - LarryBoy and the Bad Apple"
@@ -20856,7 +20857,7 @@ SLES-54559:
   name: "Free Running"
   region: "PAL-E"
   gsHWFixes:
-    autoFlush: 1 # Reduces post-processing misalignment.
+    autoFlush: 2 # Reduces post-processing misalignment.
     halfPixelOffset: 1 # Reduces lighting misalignment but doesn't fully fix it.
   patches:
     D6A0A3EF:
@@ -21015,7 +21016,7 @@ SLES-54627:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes depth lines.
-    autoFlush: 1 # Fixes blur and obscures sun behind objects.
+    autoFlush: 2 # Fixes blur and obscures sun behind objects.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
@@ -21195,7 +21196,7 @@ SLES-54681:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes depth lines.
-    autoFlush: 1 # Fixes blur and obscures sun behind objects.
+    autoFlush: 2 # Fixes blur and obscures sun behind objects.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
@@ -21313,7 +21314,7 @@ SLES-54733:
   gsHWFixes:
     halfPixelOffset: 2 # Reduces blooming misalignment.
     wildArmsHack: 1 # Reduces blooming misalignment.
-    autoFlush: 1 # Fixes glows.
+    autoFlush: 2 # Fixes glows.
 SLES-54734:
   name: "Disney-Pixar Ratatouille"
   region: "PAL-F"
@@ -21322,7 +21323,7 @@ SLES-54734:
   gsHWFixes:
     halfPixelOffset: 2 # Reduces blooming misalignment.
     wildArmsHack: 1 # Reduces blooming misalignment.
-    autoFlush: 1 # Fixes glows.
+    autoFlush: 2 # Fixes glows.
 SLES-54735:
   name: "Disney-Pixar Ratatouille"
   region: "PAL-G"
@@ -21332,7 +21333,7 @@ SLES-54735:
   gsHWFixes:
     halfPixelOffset: 2 # Reduces blooming misalignment.
     wildArmsHack: 1 # Reduces blooming misalignment.
-    autoFlush: 1 # Fixes glows.
+    autoFlush: 2 # Fixes glows.
 SLES-54736:
   name: "Disney-Pixar Ratatouille"
   region: "PAL-SCA"
@@ -21342,7 +21343,7 @@ SLES-54736:
   gsHWFixes:
     halfPixelOffset: 2 # Reduces blooming misalignment.
     wildArmsHack: 1 # Reduces blooming misalignment.
-    autoFlush: 1 # Fixes glows.
+    autoFlush: 2 # Fixes glows.
 SLES-54737:
   name: "Disney-Pixar Ratatouille"
   region: "PAL-R"
@@ -21352,7 +21353,7 @@ SLES-54737:
   gsHWFixes:
     halfPixelOffset: 2 # Reduces blooming misalignment.
     wildArmsHack: 1 # Reduces blooming misalignment.
-    autoFlush: 1 # Fixes glows.
+    autoFlush: 2 # Fixes glows.
 SLES-54738:
   name: "Thunderbirds"
   region: "PAL-M11"
@@ -21365,7 +21366,7 @@ SLES-54744:
   gsHWFixes:
     halfPixelOffset: 2 # Reduces blooming misalignment.
     wildArmsHack: 1 # Reduces blooming misalignment.
-    autoFlush: 1 # Fixes glows.
+    autoFlush: 2 # Fixes glows.
 SLES-54745:
   name: "Disney-Pixar Ratatouille"
   region: "PAL-I"
@@ -21375,7 +21376,7 @@ SLES-54745:
   gsHWFixes:
     halfPixelOffset: 2 # Reduces blooming misalignment.
     wildArmsHack: 1 # Reduces blooming misalignment.
-    autoFlush: 1 # Fixes glows.
+    autoFlush: 2 # Fixes glows.
 SLES-54746:
   name: "Disney-Pixar Ratatouille"
   region: "PAL-G"
@@ -21385,7 +21386,7 @@ SLES-54746:
   gsHWFixes:
     halfPixelOffset: 2 # Reduces blooming misalignment.
     wildArmsHack: 1 # Reduces blooming misalignment.
-    autoFlush: 1 # Fixes glows.
+    autoFlush: 2 # Fixes glows.
 SLES-54747:
   name: "Disney-Pixar Ratatouille"
   region: "PAL-P-S"
@@ -21395,7 +21396,7 @@ SLES-54747:
   gsHWFixes:
     halfPixelOffset: 2 # Reduces blooming misalignment.
     wildArmsHack: 1 # Reduces blooming misalignment.
-    autoFlush: 1 # Fixes glows.
+    autoFlush: 2 # Fixes glows.
 SLES-54755:
   name: "Transformers - The Game"
   region: "PAL-E"
@@ -22063,7 +22064,7 @@ SLES-54992:
   name: "PDC World Championship Darts 2008"
   region: "PAL-M6"
   gsHWFixes:
-    autoFlush: 1 # Fixes lights not appearing.
+    autoFlush: 2 # Fixes lights not appearing.
     cpuCLUTRender: 1 # Fixes lights going through darts players.
 SLES-54994:
   name: "Pippa Funnell - Ranch Rescue"
@@ -22385,7 +22386,7 @@ SLES-55126:
   name: "Artlist Collection - The Dog Island"
   region: "PAL-M6"
   gsHWFixes:
-    autoFlush: 1 # Fixes certains font colors.
+    autoFlush: 2 # Fixes certains font colors.
     halfPixelOffset: 2 # Fixes lighting misalignment.
     alignSprite: 1 # Fixes almost all vertical lines.
 SLES-55129:
@@ -22857,7 +22858,7 @@ SLES-55294:
   name: "Ferrari Challenge - Trofeo Pirelli"
   region: "PAL-M5"
   gsHWFixes:
-    autoFlush: 1 # Fixes lack of bloom intensity.
+    autoFlush: 2 # Fixes lack of bloom intensity.
     halfPixelOffset: 1 # Fixes misaligned bloom and rainbow garbage at edges.
 SLES-55295:
   name: "Score International Baja 1000 - World Championship Off Road Racing"
@@ -23006,13 +23007,13 @@ SLES-55367:
   name: "Call of Duty - World at War - Final Fronts"
   region: "PAL-M4"
   gsHWFixes:
-    autoFlush: 1 # Fixes bloom misalignment.
+    autoFlush: 2 # Fixes bloom misalignment.
     halfPixelOffset: 2 # Fixes lighting misalignment and depth lines.
 SLES-55369:
   name: "Call of Duty - World at War - Final Fronts"
   region: "PAL-G"
   gsHWFixes:
-    autoFlush: 1 # Fixes bloom misalignment.
+    autoFlush: 2 # Fixes bloom misalignment.
     halfPixelOffset: 2 # Fixes lighting misalignment and depth lines.
 SLES-55371:
   name: "Barbie Horse Adventures - Riding Camp"
@@ -23311,7 +23312,7 @@ SLES-55520:
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes textures.
     halfPixelOffset: 2 # Fixes misaligned bloom.
-    autoFlush: 1 # Fixes soft shadows.
+    autoFlush: 2 # Fixes soft shadows.
   patches:
     9E36E023:
       content: |-
@@ -23650,7 +23651,7 @@ SLES-82013:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurry characters.
-    autoFlush: 1 # Fixes lens flare.
+    autoFlush: 2 # Fixes lens flare.
 SLES-82018:
   name: "Cy Girls [Ice Disc]"
   region: "PAL-E-F-S"
@@ -23674,7 +23675,7 @@ SLES-82024:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurry characters.
-    autoFlush: 1 # Fixes lens flare.
+    autoFlush: 2 # Fixes lens flare.
 SLES-82026:
   name: "Metal Gear Solid 3 - Snake Eater"
   region: "PAL-S"
@@ -23682,7 +23683,7 @@ SLES-82026:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurry characters.
-    autoFlush: 1 # Fixes lens flare.
+    autoFlush: 2 # Fixes lens flare.
 SLES-82028:
   name: "Star Ocean 3 - Till the End of Time [Disc 1 of 2]"
   region: "PAL-E"
@@ -23712,7 +23713,7 @@ SLES-82030:
     halfPixelOffset: 2 # Fixes blurrines, preload frame for FMV breaks visuals with this setting.
     disablePartialInvalidation: 1 # Fixes shadows when upscaling.
     roundSprite: 2 # Fixes the position of monster sprites and reduces garbage in the UI.
-    autoFlush: 1 # Makes the shadow monsters appear.
+    autoFlush: 2 # Makes the shadow monsters appear.
 SLES-82031:
   name: "Shadow Hearts - Covenant [Disc 2 of 2]"
   region: "PAL-M3"
@@ -23720,7 +23721,7 @@ SLES-82031:
     halfPixelOffset: 2 # Fixes blurrines, preload frame for FMV breaks visuals with this setting.
     disablePartialInvalidation: 1 # Fixes shadows when upscaling.
     roundSprite: 2 # Fixes the position of monster sprites and reduces garbage in the UI.
-    autoFlush: 1 # Makes the shadow monsters appear.
+    autoFlush: 2 # Makes the shadow monsters appear.
   memcardFilters:
     - "SLES-82030"
 SLES-82032:
@@ -23730,12 +23731,12 @@ SLES-82032:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurry characters.
-    autoFlush: 1 # Fixes lens flare.
+    autoFlush: 2 # Fixes lens flare.
 SLES-82034:
   name: "Xenosaga Episode II [Disc 1 of 2]"
   region: "PAL-M3"
   gsHWFixes:
-    autoFlush: 1 # Fixes shadows in cutscenes.
+    autoFlush: 2 # Fixes shadows in cutscenes.
     halfPixelOffset: 2 # Fixes lighting misalignment and shadows.
     roundSprite: 2 # Fixes font artifacts.
   memcardFilters:
@@ -23745,7 +23746,7 @@ SLES-82035:
   name: "Xenosaga Episode II [Disc 2 of 2]"
   region: "PAL-M3"
   gsHWFixes:
-    autoFlush: 1 # Fixes shadows in cutscenes.
+    autoFlush: 2 # Fixes shadows in cutscenes.
     halfPixelOffset: 2 # Fixes lighting misalignment and shadows.
     roundSprite: 2 # Fixes font artifacts.
   memcardFilters:
@@ -23794,7 +23795,7 @@ SLES-82042:
     - BlitInternalFPSHack # Fixes internal FPS detection.
     - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
-    autoFlush: 1 # Fixes lens flare.
+    autoFlush: 2 # Fixes lens flare.
     halfPixelOffset: 2 # Fixes blurriness.
 SLES-82043:
   name: "Metal Gear Solid 3 - Subsistence [Disc 2 of 3]"
@@ -23803,7 +23804,7 @@ SLES-82043:
     - BlitInternalFPSHack # Fixes internal FPS detection.
     - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
-    autoFlush: 1 # Fixes lens flare.
+    autoFlush: 2 # Fixes lens flare.
     halfPixelOffset: 2 # Fixes blurriness.
   memcardFilters:
     - "SLES-82042"
@@ -23814,7 +23815,7 @@ SLES-82044:
     - BlitInternalFPSHack # Fixes internal FPS detection.
     - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
-    autoFlush: 1 # Fixes lens flare.
+    autoFlush: 2 # Fixes lens flare.
     halfPixelOffset: 2 # Fixes blurriness.
 SLES-82045:
   name: "Metal Gear Solid 3 - Subsistence [Disc 2 of 3]"
@@ -23823,7 +23824,7 @@ SLES-82045:
     - BlitInternalFPSHack # Fixes internal FPS detection.
     - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
-    autoFlush: 1 # Fixes lens flare.
+    autoFlush: 2 # Fixes lens flare.
     halfPixelOffset: 2 # Fixes blurriness.
   memcardFilters:
     - "SLES-82044"
@@ -23834,7 +23835,7 @@ SLES-82046:
     - BlitInternalFPSHack # Fixes internal FPS detection.
     - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
-    autoFlush: 1 # Fixes lens flare.
+    autoFlush: 2 # Fixes lens flare.
     halfPixelOffset: 2 # Fixes blurriness.
 SLES-82047:
   name: "Metal Gear Solid 3 - Subsistence [Disc 2 of 3]"
@@ -23843,7 +23844,7 @@ SLES-82047:
     - BlitInternalFPSHack # Fixes internal FPS detection.
     - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
-    autoFlush: 1 # Fixes lens flare.
+    autoFlush: 2 # Fixes lens flare.
     halfPixelOffset: 2 # Fixes blurriness.
   memcardFilters:
     - "SLES-82046"
@@ -23854,7 +23855,7 @@ SLES-82048:
     - BlitInternalFPSHack # Fixes internal FPS detection.
     - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
-    autoFlush: 1 # Fixes lens flare.
+    autoFlush: 2 # Fixes lens flare.
     halfPixelOffset: 2 # Fixes blurriness.
 SLES-82049:
   name: "Metal Gear Solid 3 - Subsistence [Disc 2 of 3]"
@@ -23863,7 +23864,7 @@ SLES-82049:
     - BlitInternalFPSHack # Fixes internal FPS detection.
     - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
-    autoFlush: 1 # Fixes lens flare.
+    autoFlush: 2 # Fixes lens flare.
     halfPixelOffset: 2 # Fixes blurriness.
   memcardFilters:
     - "SLES-82048"
@@ -23874,7 +23875,7 @@ SLES-82050:
     - BlitInternalFPSHack # Fixes internal FPS detection.
     - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
-    autoFlush: 1 # Fixes lens flare.
+    autoFlush: 2 # Fixes lens flare.
     halfPixelOffset: 2 # Fixes blurriness.
   memcardFilters:
     - "SLES-82042"
@@ -23885,7 +23886,7 @@ SLES-82051:
     - BlitInternalFPSHack # Fixes internal FPS detection.
     - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
-    autoFlush: 1 # Fixes lens flare.
+    autoFlush: 2 # Fixes lens flare.
     halfPixelOffset: 2 # Fixes blurriness.
   memcardFilters:
     - "SLES-82044"
@@ -23896,7 +23897,7 @@ SLES-82052:
     - BlitInternalFPSHack # Fixes internal FPS detection.
     - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
-    autoFlush: 1 # Fixes lens flare.
+    autoFlush: 2 # Fixes lens flare.
     halfPixelOffset: 2 # Fixes blurriness.
   memcardFilters:
     - "SLES-82046"
@@ -23907,7 +23908,7 @@ SLES-82053:
     - BlitInternalFPSHack # Fixes internal FPS detection.
     - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
-    autoFlush: 1 # Fixes lens flare.
+    autoFlush: 2 # Fixes lens flare.
     halfPixelOffset: 2 # Fixes blurriness.
   memcardFilters:
     - "SLES-82048"
@@ -23930,7 +23931,7 @@ SLKA-15006:
   name: "Knight Rider - The Game"
   region: "NTSC-K"
   gsHWFixes:
-    autoFlush: 1 # Fixes brake lights.
+    autoFlush: 2 # Fixes brake lights.
     preloadFrameData: 1 # Fixes graphical issues.
 SLKA-15007:
   name: "GrowLanser2"
@@ -24215,7 +24216,7 @@ SLKA-25073:
   name: "Tomb Raider - The Angel of Darkness"
   region: "NTSC-K"
   gsHWFixes:
-    autoFlush: 1 # Fixes lava effect.
+    autoFlush: 2 # Fixes lava effect.
 SLKA-25076:
   name: "Shin Megami Tensei 3"
   region: "NTSC-K"
@@ -24338,7 +24339,7 @@ SLKA-25120:
   name: "Prince of Persia - The Sands of Time"
   region: "NTSC-K"
   gsHWFixes:
-    autoFlush: 1 # Reduces post-processing misalignment.
+    autoFlush: 2 # Reduces post-processing misalignment.
 SLKA-25121:
   name: "Vexx"
   region: "NTSC-K"
@@ -24441,7 +24442,7 @@ SLKA-25159:
   roundModes:
     eeRoundMode: 0 # Fixes character behaviour.
   gsHWFixes:
-    autoFlush: 1 # Fixes flame bloom.
+    autoFlush: 2 # Fixes flame bloom.
 SLKA-25160:
   name: "Shin Megami Tensei III - Nocturne Maniax"
   region: "NTSC-K"
@@ -24508,7 +24509,7 @@ SLKA-25181:
   name: "Energy Airforce Aim Strike"
   region: "NTSC-K"
   gsHWFixes:
-    autoFlush: 1 # Corrects post-processing effect on jet exhausts.
+    autoFlush: 2 # Corrects post-processing effect on jet exhausts.
 SLKA-25182:
   name: "Hajime no Ippo2 Victorious Road"
   region: "NTSC-K"
@@ -24536,7 +24537,7 @@ SLKA-25196:
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
-    autoFlush: 1
+    autoFlush: 2
     gpuTargetCLUT: 1 # Fixes janky coloured cars.
     textureInsideRT: 1 # Fixes car textures.
 SLKA-25198:
@@ -24590,7 +24591,7 @@ SLKA-25206:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes depth lines.
-    autoFlush: 1 # Fixes blur and obscures sun behind objects.
+    autoFlush: 2 # Fixes blur and obscures sun behind objects.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
@@ -24666,13 +24667,13 @@ SLKA-25221:
   region: "NTSC-K"
   compat: 5
   gsHWFixes:
-    autoFlush: 1 # Corrects blur effects in menus.
+    autoFlush: 2 # Corrects blur effects in menus.
     roundSprite: 2 # Aligns some text/graphics when upscaling.
 SLKA-25222:
   name: "Rockman X8"
   region: "NTSC-K"
   gsHWFixes:
-    autoFlush: 1 # Fixes bloom.
+    autoFlush: 2 # Fixes bloom.
     roundSprite: 1 # Fixes misaligned bloom.
 SLKA-25223:
   name: "K.League - Winning Eleven 8 - Asia Championship"
@@ -24746,7 +24747,7 @@ SLKA-25251:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
-    autoFlush: 1 # Fixes lens flare.
+    autoFlush: 2 # Fixes lens flare.
 SLKA-25252:
   name: "Forgotten Realms - Demon Stone"
   region: "NTSC-K"
@@ -24858,7 +24859,7 @@ SLKA-25291:
   region: "NTSC-K"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misaligned bloom.
-    autoFlush: 1 # Fixes misaligned bloom on sun.
+    autoFlush: 2 # Fixes misaligned bloom on sun.
 SLKA-25296:
   name: "Inuyasha - Feudal Combat"
   region: "NTSC-K"
@@ -24901,7 +24902,7 @@ SLKA-25304:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes depth lines.
-    autoFlush: 1 # Fixes blur and obscures sun behind objects.
+    autoFlush: 2 # Fixes blur and obscures sun behind objects.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
@@ -24951,7 +24952,7 @@ SLKA-25320:
   gameFixes:
     - VIF1StallHack # Fixes black screen on boot.
   gsHWFixes:
-    autoFlush: 1 # Fixes missing bloom effects.
+    autoFlush: 2 # Fixes missing bloom effects.
     halfPixelOffset: 2 # Fixes misaligned lighting and bloom.
 SLKA-25321:
   name: "K.League - Winning Eleven 9 - Asia Championship"
@@ -24986,7 +24987,7 @@ SLKA-25329:
   name: "Shin Sangoku Musou 4 - Mushoden"
   region: "NTSC-K"
   gsHWFixes:
-    autoFlush: 1 # Fixes sun luminosity.
+    autoFlush: 2 # Fixes sun luminosity.
 SLKA-25331:
   name: "Marc Ecko's Getting Up - Contents Under Pressure"
   region: "NTSC-K"
@@ -25034,7 +25035,7 @@ SLKA-25346:
   name: "Prince of Persia - The Two Thrones"
   region: "NTSC-K"
   gsHWFixes:
-    autoFlush: 1 # Reduces post-processing misalignment.
+    autoFlush: 2 # Reduces post-processing misalignment.
     halfPixelOffset: 1 # Reduces post-processing misalignment.
 SLKA-25351:
   name: "One Piece Pirates Carnival"
@@ -25050,7 +25051,7 @@ SLKA-25353:
     - BlitInternalFPSHack # Fixes internal FPS detection.
     - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
-    autoFlush: 1 # Fixes lens flare.
+    autoFlush: 2 # Fixes lens flare.
     halfPixelOffset: 2 # Fixes blurriness.
 SLKA-25354:
   name: "Metal Gear Solid 3 - Subsistence [Limited Edition] [Disc 2 of 3]"
@@ -25060,7 +25061,7 @@ SLKA-25354:
     - BlitInternalFPSHack # Fixes internal FPS detection.
     - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
-    autoFlush: 1 # Fixes lens flare.
+    autoFlush: 2 # Fixes lens flare.
     halfPixelOffset: 2 # Fixes blurriness.
   memcardFilters:
     - "SLKA-25353"
@@ -25072,7 +25073,7 @@ SLKA-25355:
     - BlitInternalFPSHack # Fixes internal FPS detection.
     - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
-    autoFlush: 1 # Fixes lens flare.
+    autoFlush: 2 # Fixes lens flare.
     halfPixelOffset: 2 # Fixes blurriness.
   memcardFilters:
     - "SLKA-25353"
@@ -25259,7 +25260,7 @@ SLPM-55004:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes depth lines.
-    autoFlush: 1 # Fixes blur and obscures sun behind objects.
+    autoFlush: 2 # Fixes blur and obscures sun behind objects.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
@@ -25302,7 +25303,7 @@ SLPM-55036:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes depth lines.
-    autoFlush: 1 # Fixes blur and obscures sun behind objects.
+    autoFlush: 2 # Fixes blur and obscures sun behind objects.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
@@ -25412,7 +25413,7 @@ SLPM-55092:
   clampModes:
     eeClampMode: 2 # Fixes Game freezes during "Reuniting The Families" mission.
   gsHWFixes:
-    autoFlush: 1
+    autoFlush: 1 # Fixes post processing.
 SLPM-55096:
   name: "ThunderForce VI"
   region: "NTSC-J"
@@ -25496,7 +25497,7 @@ SLPM-55141:
     roundSprite: 2 # Fixes misaligned bloom.
     mergeSprite: 1 # Fixes misaligned bloom.
     halfPixelOffset: 2 # Fixes misaligned bloom.
-    autoFlush: 1 # Fixes sun occlusion and brightness.
+    autoFlush: 2 # Fixes sun occlusion and brightness.
 SLPM-55146:
   name: "Jikkyou Powerful Pro Yakyuu 2009"
   region: "NTSC-J"
@@ -25766,7 +25767,7 @@ SLPM-55292:
   clampModes:
     eeClampMode: 2 # Fixes Game freezes during "Reuniting The Families" mission.
   gsHWFixes:
-    autoFlush: 1
+    autoFlush: 1 # Fixes post processing.
 SLPM-55294:
   name: "World Soccer Winning Eleven 2012"
   region: "NTSC-J"
@@ -25903,7 +25904,7 @@ SLPM-60246:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes depth lines.
-    autoFlush: 1 # Fixes blur and obscures sun behind objects.
+    autoFlush: 2 # Fixes blur and obscures sun behind objects.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
@@ -26069,7 +26070,7 @@ SLPM-61092:
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
-    autoFlush: 1
+    autoFlush: 2
     gpuTargetCLUT: 1 # Fixes janky coloured cars.
     textureInsideRT: 1 # Fixes car textures.
 SLPM-61117:
@@ -26111,7 +26112,7 @@ SLPM-61130:
   gameFixes:
     - VIF1StallHack # Fixes black screen on boot.
   gsHWFixes:
-    autoFlush: 1 # Fixes missing bloom effects.
+    autoFlush: 2 # Fixes missing bloom effects.
     halfPixelOffset: 2 # Fixes misaligned lighting and bloom.
 SLPM-61132:
   name: "Ikusa Gami [Trial Version]"
@@ -26119,7 +26120,7 @@ SLPM-61132:
   gameFixes:
     - VIF1StallHack # Fixes black screen on boot.
   gsHWFixes:
-    autoFlush: 1 # Fixes missing bloom effects.
+    autoFlush: 2 # Fixes missing bloom effects.
     halfPixelOffset: 2 # Fixes misaligned lighting and bloom.
 SLPM-61133:
   name: "Soul Calibur III [Trial Version]"
@@ -26143,7 +26144,7 @@ SLPM-61147:
   name: "Xenosaga Episode III - Also Sprach Zarathustra [Demo]"
   region: "NTSC-J"
   gsHWFixes:
-    autoFlush: 1 # Fixes shadows in cutscenes.
+    autoFlush: 2 # Fixes shadows in cutscenes.
     halfPixelOffset: 1 # Fixes lighting misalignment and reduces ground shadows (probably texture cache issue).
     roundSprite: 2 # Fixes font artifacts.
     textureInsideRT: 1 # Fixes bad crystal surfaces.
@@ -27079,7 +27080,7 @@ SLPM-62346:
   name: "Keiei Simulation - Jurassic Park [Konami the Best]"
   region: "NTSC-J"
   gsHWFixes:
-    autoFlush: 1 # Fixes glows. Also needed for recursive mipmap rendering.
+    autoFlush: 2 # Fixes glows. Also needed for recursive mipmap rendering.
     mipmap: 2 # Better characters and environment but has a texture cache issue that makes it worse.
     trilinearFiltering: 1 # Using mipmaps, so may as well.
     textureInsideRT: 1 # Fixes rainbow lighting for some areas.
@@ -27503,7 +27504,7 @@ SLPM-62490:
   name: "Dragon Quest VIII [Premium Disc]"
   region: "NTSC-J"
   gsHWFixes:
-    autoFlush: 1 # Fixes missing bloom from surfaces like windows.
+    autoFlush: 2 # Fixes missing bloom from surfaces like windows.
     textureInsideRT: 1 # Fixes corruption.
     # halfPixelOffset: 1 # Aligns shadows properly, but causes grid lines to appear in sea travel.
     halfPixelOffset: 2 # Sharpens world in far distances, aligns some bloom better.
@@ -27572,7 +27573,7 @@ SLPM-62512:
   name: "Keiei Simulation - Jurassic Park [Konami The Best]"
   region: "NTSC-J"
   gsHWFixes:
-    autoFlush: 1 # Fixes glows. Also needed for recursive mipmap rendering.
+    autoFlush: 2 # Fixes glows. Also needed for recursive mipmap rendering.
     mipmap: 2 # Better characters and environment but has a texture cache issue that makes it worse.
     trilinearFiltering: 1 # Using mipmaps, so may as well.
     textureInsideRT: 1 # Fixes rainbow lighting for some areas.
@@ -29083,7 +29084,7 @@ SLPM-65191:
   region: "NTSC-J"
   gsHWFixes:
     preloadFrameData: 1 # Fixes fog and make lights on cars work again.
-    autoFlush: 1 # Fixes sun luminosity and penetration of objects.
+    autoFlush: 2 # Fixes sun luminosity and penetration of objects.
   gameFixes:
     - EETimingHack # Fixes random graphical corruption.
 SLPM-65192:
@@ -29761,7 +29762,7 @@ SLPM-65374:
     InstantVU1SpeedHack: 0 # Fixes hanging while going ingame.
     MTVUSpeedHack: 0
   gsHWFixes:
-    autoFlush: 1 # Corrects post-processing effect on jet exhausts.
+    autoFlush: 2 # Corrects post-processing effect on jet exhausts.
 SLPM-65375:
   name: "Shin Sangoku Musou 3 - Mushoden [Premium Pack]"
   region: "NTSC-J"
@@ -29772,7 +29773,7 @@ SLPM-65378:
   name: "Busin 0 - Wizardry Alternative Neo"
   region: "NTSC-J"
   gsHWFixes:
-    autoFlush: 1 # Corrects blur effects in menus.
+    autoFlush: 2 # Corrects blur effects in menus.
     roundSprite: 2 # Aligns some text/graphics when upscaling.
 SLPM-65379:
   name: "Baseball 2003, The - Battle Ball Park Sengen - Perfect Play Pro Yakyuu - Shuukigou"
@@ -30315,7 +30316,7 @@ SLPM-65539:
   region: "NTSC-J"
   gsHWFixes:
     preloadFrameData: 1 # Fixes fog and make lights on cars work again.
-    autoFlush: 1 # Fixes sun luminosity and penetration of objects.
+    autoFlush: 2 # Fixes sun luminosity and penetration of objects.
   gameFixes:
     - EETimingHack # Fixes random graphical corruption.
 SLPM-65540:
@@ -30354,7 +30355,7 @@ SLPM-65551:
   roundModes:
     eeRoundMode: 0 # Fixes character behaviour.
   gsHWFixes:
-    autoFlush: 1 # Fixes flame bloom.
+    autoFlush: 2 # Fixes flame bloom.
 SLPM-65552:
   name: "Metal Wolf Rev [Limited Edition]"
   region: "NTSC-J"
@@ -30454,7 +30455,7 @@ SLPM-65583:
     - XGKickHack # Fixes SPS.
   gsHWFixes:
     roundSprite: 2 # Correct misaligned font, better aligns car shadow.
-    autoFlush: 1 # Fixes sun luminosity.
+    autoFlush: 2 # Fixes sun luminosity.
 SLPM-65585:
   name: "Princess Holiday"
   region: "NTSC-J"
@@ -30705,7 +30706,7 @@ SLPM-65662:
   region: "NTSC-J"
   gsHWFixes:
     cpuSpriteRenderBW: 1 # Fixes textures.
-    autoFlush: 1 # Fixes the position of the shadow and makes it not blocky.
+    autoFlush: 2 # Fixes the position of the shadow and makes it not blocky.
     halfPixelOffset: 2 # Fixes shadows.
     gpuPaletteConversion: 0 # Stops potential crashes from too many palette textures.
 SLPM-65663:
@@ -30909,7 +30910,7 @@ SLPM-65719:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes depth lines.
-    autoFlush: 1 # Fixes blur and obscures sun behind objects.
+    autoFlush: 2 # Fixes blur and obscures sun behind objects.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
@@ -30962,7 +30963,7 @@ SLPM-65730:
   name: "Rockman X8"
   region: "NTSC-J"
   gsHWFixes:
-    autoFlush: 1 # Fixes bloom.
+    autoFlush: 2 # Fixes bloom.
     roundSprite: 1 # Fixes misaligned bloom.
   gameFixes:
     - SoftwareRendererFMVHack # Flickering and wrong textures in FMV.
@@ -31007,7 +31008,7 @@ SLPM-65741:
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
-    autoFlush: 1
+    autoFlush: 2
     cpuCLUTRender: 1 # Fixes janky coloured cars.
     gpuTargetCLUT: 1 # Fixes janky coloured cars.
     textureInsideRT: 1 # Fixes car textures.
@@ -31177,7 +31178,7 @@ SLPM-65789:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
-    autoFlush: 1 # Fixes lens flare.
+    autoFlush: 2 # Fixes lens flare.
 SLPM-65790:
   name: "Metal Gear Solid 3 - Snake Eater"
   region: "NTSC-J"
@@ -31185,7 +31186,7 @@ SLPM-65790:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
-    autoFlush: 1 # Fixes lens flare.
+    autoFlush: 2 # Fixes lens flare.
 SLPM-65791:
   name: "S.L.A.I. - Steel Lancer Arena International"
   region: "NTSC-J"
@@ -31488,7 +31489,7 @@ SLPM-65876:
   name: "Busin 0 - Wizardry Alternative Neo [Atlus Best Collection]"
   region: "NTSC-J"
   gsHWFixes:
-    autoFlush: 1 # Corrects blur effects in menus.
+    autoFlush: 2 # Corrects blur effects in menus.
     roundSprite: 2 # Aligns some text/graphics when upscaling.
 SLPM-65878:
   name: "Galaxy Angel - Eternal Lovers"
@@ -31533,7 +31534,7 @@ SLPM-65888:
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
-    autoFlush: 1 # Fixes missing bloom from surfaces like windows.
+    autoFlush: 2 # Fixes missing bloom from surfaces like windows.
     textureInsideRT: 1 # Fixes corruption.
     # halfPixelOffset: 1 # Aligns shadows properly, but causes grid lines to appear in sea travel.
     halfPixelOffset: 2 # Sharpens world in far distances, aligns some bloom better.
@@ -31718,7 +31719,7 @@ SLPM-65942:
   region: "NTSC-J"
   gsHWFixes:
     halfBottomOverride: 1 # Bottom screen has wrong colors.
-    autoFlush: 1 # Fixes missing lighting.
+    autoFlush: 2 # Fixes missing lighting.
     # halfPixelOffset: 1 # Fixes lighting misalignment. Do not enable this, it breaks a lot of graphics.
 SLPM-65943:
   name: "Angel's Feather"
@@ -31777,7 +31778,7 @@ SLPM-65958:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes depth lines.
-    autoFlush: 1 # Fixes blur and obscures sun behind objects.
+    autoFlush: 2 # Fixes blur and obscures sun behind objects.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
@@ -31857,7 +31858,7 @@ SLPM-65975:
         patch=0,EE,005fffec,double,24e7100024c60080
         patch=0,EE,005ffff4,double,00c7e8200818000c
   gsHWFixes:
-    autoFlush: 1 # Fixes sun luminosity and car shadows.
+    autoFlush: 2 # Fixes sun luminosity and car shadows.
     roundSprite: 1 # Fixes misaligned text.
     halfPixelOffset: 2 # Fixes minor ghosting on objects.
   roundModes:
@@ -31891,7 +31892,7 @@ SLPM-65984:
   clampModes:
     eeClampMode: 2 # Fixes Game freezes during "Reuniting The Families" mission.
   gsHWFixes:
-    autoFlush: 1
+    autoFlush: 1 # Fixes post processing.
 SLPM-65985:
   name: "Iris no Atelier - Eternal Mana 2"
   region: "NTSC-J"
@@ -31963,7 +31964,7 @@ SLPM-66002:
   name: "Prince of Persia - Warrior Within"
   region: "NTSC-J"
   gsHWFixes:
-    autoFlush: 1 # Reduces post-processing misalignment.
+    autoFlush: 2 # Reduces post-processing misalignment.
 SLPM-66006:
   name: "Angelique Trois - Aizouhen [Koei Selection]"
   region: "NTSC-J"
@@ -32075,7 +32076,7 @@ SLPM-66033:
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misaligned bloom.
-    autoFlush: 1 # Fixes misaligned bloom on sun.
+    autoFlush: 2 # Fixes misaligned bloom on sun.
 SLPM-66034:
   name: "Grand Theft Auto - Vice City"
   region: "NTSC-J"
@@ -32302,7 +32303,7 @@ SLPM-66101:
   name: "Shin Sangoku Musou 4 - Mushoden"
   region: "NTSC-J"
   gsHWFixes:
-    autoFlush: 1 # Fixes sun luminosity.
+    autoFlush: 2 # Fixes sun luminosity.
 SLPM-66102:
   name: "Zwei!! [Taito the Best]"
   region: "NTSC-J"
@@ -32316,7 +32317,7 @@ SLPM-66103:
     - XGKickHack # Fixes SPS.
   gsHWFixes:
     roundSprite: 2 # Correct misaligned font, better aligns car shadow.
-    autoFlush: 1 # Fixes sun luminosity.
+    autoFlush: 2 # Fixes sun luminosity.
 SLPM-66104:
   name: "Puyo Puyo Fever 2"
   region: "NTSC-J"
@@ -32342,7 +32343,7 @@ SLPM-66108:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes depth lines.
-    autoFlush: 1 # Fixes blur and obscures sun behind objects.
+    autoFlush: 2 # Fixes blur and obscures sun behind objects.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
@@ -32388,7 +32389,7 @@ SLPM-66117:
     - BlitInternalFPSHack # Fixes internal FPS detection.
     - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
-    autoFlush: 1 # Fixes lens flare.
+    autoFlush: 2 # Fixes lens flare.
     halfPixelOffset: 2 # Fixes blurriness.
 SLPM-66118:
   name: "Metal Gear Solid 3 - Subsistence [with Headset] [Disc 2 of 3]"
@@ -32397,7 +32398,7 @@ SLPM-66118:
     - BlitInternalFPSHack # Fixes internal FPS detection.
     - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
-    autoFlush: 1 # Fixes lens flare.
+    autoFlush: 2 # Fixes lens flare.
     halfPixelOffset: 2 # Fixes blurriness.
 SLPM-66119:
   name: "Metal Gear Solid 3 - Subsistence [with Headset] [Disc 3 of 3]"
@@ -32406,14 +32407,14 @@ SLPM-66119:
     - BlitInternalFPSHack # Fixes internal FPS detection.
     - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
-    autoFlush: 1 # Fixes lens flare.
+    autoFlush: 2 # Fixes lens flare.
     halfPixelOffset: 2 # Fixes blurriness.
 SLPM-66121:
   name: "Spider-Man 2 [Taito Best]"
   region: "NTSC-J"
   gsHWFixes:
     cpuSpriteRenderBW: 1 # Fixes textures.
-    autoFlush: 1 # Fixes the position of the shadow and makes it not blocky.
+    autoFlush: 2 # Fixes the position of the shadow and makes it not blocky.
     halfPixelOffset: 2 # Fixes shadows.
     gpuPaletteConversion: 0 # Stops potential crashes from too many palette textures.
 SLPM-66122:
@@ -32662,7 +32663,7 @@ SLPM-66184:
   gameFixes:
     - VIF1StallHack # Fixes black screen on boot.
   gsHWFixes:
-    autoFlush: 1 # Fixes missing bloom effects.
+    autoFlush: 2 # Fixes missing bloom effects.
     halfPixelOffset: 2 # Fixes misaligned lighting and bloom.
 SLPM-66185:
   name: "Game ni Nattayo! Dokuro-chan [Limited Edition]"
@@ -32745,7 +32746,7 @@ SLPM-66206:
   name: "Battlefield 2 - Modern Combat"
   region: "NTSC-J"
   gsHWFixes:
-    autoFlush: 1 # Post-processing.
+    autoFlush: 2 # Post-processing.
     halfPixelOffset: 2 # Offset post-processing.
     texturePreloading: 1 # Spikes all over the place otherwise.
     textureInsideRT: 1 # Fixes light shinging through objects.
@@ -32803,7 +32804,7 @@ SLPM-66220:
     - BlitInternalFPSHack # Fixes internal FPS detection.
     - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
-    autoFlush: 1 # Fixes lens flare.
+    autoFlush: 2 # Fixes lens flare.
     halfPixelOffset: 2 # Fixes blurriness.
   memcardFilters:
     - "SLPM-66117"
@@ -32814,7 +32815,7 @@ SLPM-66221:
     - BlitInternalFPSHack # Fixes internal FPS detection.
     - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
-    autoFlush: 1 # Fixes lens flare.
+    autoFlush: 2 # Fixes lens flare.
     halfPixelOffset: 2 # Fixes blurriness.
   memcardFilters:
     - "SLPM-66117"
@@ -32825,7 +32826,7 @@ SLPM-66222:
     - BlitInternalFPSHack # Fixes internal FPS detection.
     - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
-    autoFlush: 1 # Fixes lens flare.
+    autoFlush: 2 # Fixes lens flare.
     halfPixelOffset: 2 # Fixes blurriness.
   memcardFilters:
     - "SLPM-66117"
@@ -32836,7 +32837,7 @@ SLPM-66223:
     - BlitInternalFPSHack # Fixes internal FPS detection.
     - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
-    autoFlush: 1 # Fixes lens flare.
+    autoFlush: 2 # Fixes lens flare.
     halfPixelOffset: 2 # Fixes blurriness.
   memcardFilters:
     - "SLPM-66117"
@@ -32847,7 +32848,7 @@ SLPM-66224:
     - BlitInternalFPSHack # Fixes internal FPS detection.
     - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
-    autoFlush: 1 # Fixes lens flare.
+    autoFlush: 2 # Fixes lens flare.
     halfPixelOffset: 2 # Fixes blurriness.
   memcardFilters:
     - "SLPM-66117"
@@ -32888,7 +32889,7 @@ SLPM-66233:
   name: "Kingdom Hearts II"
   region: "NTSC-J"
   gsHWFixes:
-    autoFlush: 1 # Fixes effects.
+    autoFlush: 2 # Fixes effects.
     roundSprite: 2 # Fixes upscaling artifacts.
   compat: 5
 SLPM-66234:
@@ -32989,7 +32990,7 @@ SLPM-66261:
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misaligned bloom.
-    autoFlush: 1 # Fixes misaligned bloom on sun.
+    autoFlush: 2 # Fixes misaligned bloom on sun.
 SLPM-66262:
   name: "Tom Clancy's Rainbow Six 3 [Ubisoft The Best]"
   region: "NTSC-J"
@@ -33024,7 +33025,7 @@ SLPM-66271:
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
-    autoFlush: 1 # Fixes lighting.
+    autoFlush: 2 # Fixes lighting.
 SLPM-66272:
   name: "I-O"
   region: "NTSC-J"
@@ -33293,7 +33294,7 @@ SLPM-66334:
         patch=0,EE,005fffec,double,24e7100024c60080
         patch=0,EE,005ffff4,double,00c7e8200818000c
   gsHWFixes:
-    autoFlush: 1 # Fixes sun luminosity and car shadows.
+    autoFlush: 2 # Fixes sun luminosity and car shadows.
     roundSprite: 1 # Fixes misaligned text.
     halfPixelOffset: 2 # Fixes minor ghosting on objects.
   roundModes:
@@ -33354,7 +33355,7 @@ SLPM-66354:
     vuClampMode: 3 # Fixes SPS.
   gsHWFixes:
     recommendedBlendingLevel: 4 # Improves lighting on buildings and objects.
-    autoFlush: 1 # Properly diffuses light instead of strips of light.
+    autoFlush: 2 # Properly diffuses light instead of strips of light.
     roundSprite: 1 # Fixes lighting misalignment such as the street poles and the sun.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
@@ -33476,7 +33477,7 @@ SLPM-66391:
   name: "Prince of Persia - The Two Thrones"
   region: "NTSC-J"
   gsHWFixes:
-    autoFlush: 1 # Reduces post-processing misalignment.
+    autoFlush: 2 # Reduces post-processing misalignment.
     halfPixelOffset: 1 # Reduces post-processing misalignment.
 SLPM-66393:
   name: "Final Fantasy XI - Aht Urhgan no Hihou [All-in-One Pack]"
@@ -33533,7 +33534,7 @@ SLPM-66404:
     partialTargetInvalidation: 1 # Fixes texture distortion.
     mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
     trilinearFiltering: 1
-    autoFlush: 1 # Fixes shadow alignment along with HPO Special (Normal looks better but causes top left glitches).
+    autoFlush: 2 # Fixes shadow alignment along with HPO Special (Normal looks better but causes top left glitches).
     halfPixelOffset: 2
 SLPM-66405:
   name: "Radirgy Precious"
@@ -33625,7 +33626,7 @@ SLPM-66430:
     roundSprite: 2 # Fixes misaligned bloom.
     mergeSprite: 1 # Fixes misaligned bloom.
     halfPixelOffset: 2 # Fixes misaligned bloom.
-    autoFlush: 1 # Fixes sun occlusion and brightness.
+    autoFlush: 2 # Fixes sun occlusion and brightness.
 SLPM-66431:
   name: "WinBack 2 - Project Poseidon"
   region: "NTSC-J"
@@ -33786,7 +33787,7 @@ SLPM-66465:
   region: "NTSC-J"
   gsHWFixes:
     halfBottomOverride: 1 # Bottom screen has wrong colors.
-    autoFlush: 1 # Fixes missing lighting.
+    autoFlush: 2 # Fixes missing lighting.
     # halfPixelOffset: 1 # Fixes lighting misalignment. Do not enable this, it breaks a lot of graphics.
 SLPM-66467:
   name: "Midway Arcade Treasures - The Game Center of USA"
@@ -33867,7 +33868,7 @@ SLPM-66481:
   name: "Dragon Quest VIII [Ultimate Hits]"
   region: "NTSC-J"
   gsHWFixes:
-    autoFlush: 1 # Fixes missing bloom from surfaces like windows.
+    autoFlush: 2 # Fixes missing bloom from surfaces like windows.
     textureInsideRT: 1 # Fixes corruption.
     # halfPixelOffset: 1 # Aligns shadows properly, but causes grid lines to appear in sea travel.
     halfPixelOffset: 2 # Sharpens world in far distances, aligns some bloom better.
@@ -34407,14 +34408,14 @@ SLPM-66628:
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
-    autoFlush: 1 # Reduces post-processing misalignment.
+    autoFlush: 2 # Reduces post-processing misalignment.
     halfPixelOffset: 2 # Fixes bloom misalignment still a bit misaligned.
     roundSprite: 1 # Fixes bloom misalignment still a bit misaligned + font artifacts.
 SLPM-66629:
   name: "Dirge of Cerberus - Final Fantasy VII International"
   region: "NTSC-J"
   gsHWFixes:
-    autoFlush: 1 # Fixes lighting.
+    autoFlush: 2 # Fixes lighting.
 SLPM-66630:
   name: "Melheaven - Arm Fight Dream [Konami the Best]"
   region: "NTSC-J"
@@ -34463,7 +34464,7 @@ SLPM-66643:
   name: "OutRun 2 SP"
   region: "NTSC-J"
   gsHWFixes:
-    autoFlush: 1 # Reduces post-processing misalignment.
+    autoFlush: 2 # Reduces post-processing misalignment.
     halfPixelOffset: 2 # Fixes bloom misalignment still a bit misaligned.
     roundSprite: 1 # Fixes bloom misalignment still a bit misaligned + font artifacts.
 SLPM-66644:
@@ -34485,7 +34486,7 @@ SLPM-66651:
   name: "Battlefield 2 - Modern Combat [EA Best Hits]"
   region: "NTSC-J"
   gsHWFixes:
-    autoFlush: 1 # Post-processing.
+    autoFlush: 2 # Post-processing.
     halfPixelOffset: 2 # Offset post-processing.
     texturePreloading: 1 # Spikes all over the place otherwise.
     textureInsideRT: 1 # Fixes light shinging through objects.
@@ -34500,7 +34501,7 @@ SLPM-66652:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes depth lines.
-    autoFlush: 1 # Fixes blur and obscures sun behind objects.
+    autoFlush: 2 # Fixes blur and obscures sun behind objects.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
@@ -34547,7 +34548,7 @@ SLPM-66662:
   name: "Dog Island, The - Hitotsu no Hana no Monogatari"
   region: "NTSC-J"
   gsHWFixes:
-    autoFlush: 1 # Fixes certains font colors.
+    autoFlush: 2 # Fixes certains font colors.
     halfPixelOffset: 2 # Fixes lighting misalignment.
     alignSprite: 1 # Fixes almost all vertical lines.
 SLPM-66663:
@@ -34593,7 +34594,7 @@ SLPM-66673:
   name: "Prince of Persia - Warrior Within [Ubisoft the Best]"
   region: "NTSC-J"
   gsHWFixes:
-    autoFlush: 1 # Reduces post-processing misalignment.
+    autoFlush: 2 # Reduces post-processing misalignment.
 SLPM-66674:
   name: "Tiger Woods PGA Tour 07"
   region: "NTSC-J"
@@ -34603,7 +34604,7 @@ SLPM-66675:
   name: "Kingdom Hearts II - Final Mix +"
   region: "NTSC-J"
   gsHWFixes:
-    autoFlush: 1 # Fixes effects.
+    autoFlush: 2 # Fixes effects.
     roundSprite: 2 # Fixes upscaling artifacts.
   compat: 5
   memcardFilters: # Reads Re:Chain data and vice-versa.
@@ -34614,7 +34615,7 @@ SLPM-66676:
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
-    autoFlush: 1 # Fixes double image.
+    autoFlush: 2 # Fixes double image.
     halfPixelOffset: 1 # Fixes misaligned bloom.
   memcardFilters:
     - "SLPM-66675"
@@ -34838,7 +34839,7 @@ SLPM-66731:
     vuClampMode: 3 # Fixes SPS.
   gsHWFixes:
     recommendedBlendingLevel: 4 # Improves lighting on buildings and objects.
-    autoFlush: 1 # Properly diffuses light instead of strips of light.
+    autoFlush: 2 # Properly diffuses light instead of strips of light.
     roundSprite: 1 # Fixes lighting misalignment such as the street poles and the sun.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
@@ -34887,7 +34888,7 @@ SLPM-66739:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes depth lines.
-    autoFlush: 1 # Fixes blur and obscures sun behind objects.
+    autoFlush: 2 # Fixes blur and obscures sun behind objects.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
@@ -35079,7 +35080,7 @@ SLPM-66788:
   clampModes:
     eeClampMode: 2 # Fixes Game freezes during "Reuniting The Families" mission.
   gsHWFixes:
-    autoFlush: 1
+    autoFlush: 1 # Fixes post processing.
 SLPM-66789:
   name: "Grand Theft Auto III [Best Price]"
   region: "NTSC-J"
@@ -35112,7 +35113,7 @@ SLPM-66794:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
-    autoFlush: 1 # Fixes lens flare.
+    autoFlush: 2 # Fixes lens flare.
 SLPM-66796:
   name: "Metal Gear Solid - 20th Anniversary Collection"
   region: "NTSC-J"
@@ -35146,7 +35147,7 @@ SLPM-66807:
   gsHWFixes:
     halfPixelOffset: 2 # Reduces blooming misalignment.
     wildArmsHack: 1 # Reduces blooming misalignment.
-    autoFlush: 1 # Fixes glows.
+    autoFlush: 2 # Fixes glows.
 SLPM-66808:
   name: "Tom Clancy's Ghost Recon - Advanced Warfighter [Ubisoft the Best]"
   region: "NTSC-J"
@@ -35429,7 +35430,7 @@ SLPM-66897:
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
-    autoFlush: 1 # Fixes post lighting.
+    autoFlush: 2 # Fixes post lighting.
 SLPM-66898:
   name: "Spectral Gene [Limited Edition]"
   region: "NTSC-J"
@@ -35630,7 +35631,7 @@ SLPM-66961:
     vuClampMode: 3 # Fixes SPS.
   gsHWFixes:
     recommendedBlendingLevel: 4 # Improves lighting on buildings and objects.
-    autoFlush: 1 # Properly diffuses light instead of strips of light.
+    autoFlush: 2 # Properly diffuses light instead of strips of light.
     roundSprite: 1 # Fixes lighting misalignment such as the street poles and the sun.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
@@ -35644,7 +35645,7 @@ SLPM-66962:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes depth lines.
-    autoFlush: 1 # Fixes blur and obscures sun behind objects.
+    autoFlush: 2 # Fixes blur and obscures sun behind objects.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
@@ -36024,7 +36025,7 @@ SLPM-68516:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
-    autoFlush: 1 # Fixes lens flare.
+    autoFlush: 2 # Fixes lens flare.
 SLPM-68520:
   name: "Armored Core - Last Raven [Monthly Champion magazine Special Edition]"
   region: "NTSC-J"
@@ -36165,7 +36166,7 @@ SLPM-74227:
   gameFixes:
     - VIF1StallHack # Fixes black screen on boot.
   gsHWFixes:
-    autoFlush: 1 # Fixes missing bloom effects.
+    autoFlush: 2 # Fixes missing bloom effects.
     halfPixelOffset: 2 # Fixes misaligned lighting and bloom.
 SLPM-74228:
   name: "Fuuun Bakumatsu-den [PlayStation 2 The Best]"
@@ -36303,7 +36304,7 @@ SLPM-74250:
   name: "Shin Sangoku Musou 4 Mushoden [PlayStation 2 The Best]"
   region: "NTSC-J"
   gsHWFixes:
-    autoFlush: 1 # Fixes sun luminosity.
+    autoFlush: 2 # Fixes sun luminosity.
 SLPM-74251:
   name: "Shin Onimusha - Dawn of Dreams [PlayStation 2 the Best - Reprint Disc 1]"
   region: "NTSC-J"
@@ -38268,7 +38269,7 @@ SLPS-25113:
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
-    autoFlush: 1 # Fixes incorrect blur effect.
+    autoFlush: 2 # Fixes incorrect blur effect.
 SLPS-25114:
   name: "G-Breaker - Daisanshi Cloudia Taisen"
   region: "NTSC-J"
@@ -38686,7 +38687,7 @@ SLPS-25235:
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
-    autoFlush: 1 # Fixes double image.
+    autoFlush: 2 # Fixes double image.
 SLPS-25236:
   name: "Fantastic Fortune 2"
   region: "NTSC-J"
@@ -38724,7 +38725,7 @@ SLPS-25246:
   name: "Tomb Raider - The Angel of Darkness"
   region: "NTSC-J"
   gsHWFixes:
-    autoFlush: 1 # Fixes lava effect.
+    autoFlush: 2 # Fixes lava effect.
 SLPS-25247:
   name: "R-Type Final"
   region: "NTSC-J"
@@ -38952,7 +38953,7 @@ SLPS-25317:
     halfPixelOffset: 2 # Fixes blurrines, preload frame for FMV breaks visuals with this setting.
     disablePartialInvalidation: 1 # Fixes shadows when upscaling.
     roundSprite: 2 # Fixes the position of monster sprites and reduces garbage in the UI.
-    autoFlush: 1 # Makes the shadow monsters appear.
+    autoFlush: 2 # Makes the shadow monsters appear.
 SLPS-25318:
   name: "Shadow Hearts 2 [Deluxe Pack] [Disc 2 of 2]"
   region: "NTSC-J"
@@ -38960,7 +38961,7 @@ SLPS-25318:
     halfPixelOffset: 2 # Fixes blurrines, preload frame for FMV breaks visuals with this setting.
     disablePartialInvalidation: 1 # Fixes shadows when upscaling.
     roundSprite: 2 # Fixes the position of monster sprites and reduces garbage in the UI.
-    autoFlush: 1 # Makes the shadow monsters appear.
+    autoFlush: 2 # Makes the shadow monsters appear.
   memcardFilters:
     - "SLPS-25317"
 SLPS-25319:
@@ -39010,7 +39011,7 @@ SLPS-25334:
     halfPixelOffset: 2 # Fixes blurrines, preload frame for FMV breaks visuals with this setting.
     disablePartialInvalidation: 1 # Fixes shadows when upscaling.
     roundSprite: 2 # Fixes the position of monster sprites and reduces garbage in the UI.
-    autoFlush: 1 # Makes the shadow monsters appear.
+    autoFlush: 2 # Makes the shadow monsters appear.
 SLPS-25335:
   name: "Shadow Hearts 2 [Disc 2 of 2]"
   region: "NTSC-J"
@@ -39018,7 +39019,7 @@ SLPS-25335:
     halfPixelOffset: 2 # Fixes blurrines, preload frame for FMV breaks visuals with this setting.
     disablePartialInvalidation: 1 # Fixes shadows when upscaling.
     roundSprite: 2 # Fixes the position of monster sprites and reduces garbage in the UI.
-    autoFlush: 1 # Makes the shadow monsters appear.
+    autoFlush: 2 # Makes the shadow monsters appear.
   memcardFilters:
     - "SLPS-25334"
 SLPS-25336:
@@ -39151,7 +39152,7 @@ SLPS-25366:
   name: "Xenosaga Episode II - Jenseits von Gut und Bose [Premium Box] [Disc 1 of 2]"
   region: "NTSC-J"
   gsHWFixes:
-    autoFlush: 1 # Fixes shadows in cutscenes.
+    autoFlush: 2 # Fixes shadows in cutscenes.
     halfPixelOffset: 2 # Fixes lighting misalignment and shadows.
     roundSprite: 2 # Fixes font artifacts.
   memcardFilters:
@@ -39165,7 +39166,7 @@ SLPS-25367:
   name: "Xenosaga Episode II - Jenseits von Gut und Bose [Premium Box] [Disc 2 of 2]"
   region: "NTSC-J"
   gsHWFixes:
-    autoFlush: 1 # Fixes shadows in cutscenes.
+    autoFlush: 2 # Fixes shadows in cutscenes.
     halfPixelOffset: 2 # Fixes lighting misalignment and shadows.
     roundSprite: 2 # Fixes font artifacts.
   memcardFilters:
@@ -39179,7 +39180,7 @@ SLPS-25368:
   name: "Xenosaga Episode II - Jenseits von Gut und Bose [Disc 1 of 2]"
   region: "NTSC-J"
   gsHWFixes:
-    autoFlush: 1 # Fixes shadows in cutscenes.
+    autoFlush: 2 # Fixes shadows in cutscenes.
     halfPixelOffset: 2 # Fixes lighting misalignment and shadows.
     roundSprite: 2 # Fixes font artifacts.
   memcardFilters: # Allows import of Xenosaga I, Xenosaga I Reloaded, and Xenosaga Freaks data.
@@ -39193,7 +39194,7 @@ SLPS-25369:
   name: "Xenosaga Episode II - Jenseits von Gut und Bose [Disc 2 of 2]"
   region: "NTSC-J"
   gsHWFixes:
-    autoFlush: 1 # Fixes shadows in cutscenes.
+    autoFlush: 2 # Fixes shadows in cutscenes.
     halfPixelOffset: 2 # Fixes lighting misalignment and shadows.
     roundSprite: 2 # Fixes font artifacts.
   memcardFilters:
@@ -39981,7 +39982,7 @@ SLPS-25586:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
-    autoFlush: 1 # Fixes post lighting.
+    autoFlush: 2 # Fixes post lighting.
 SLPS-25587:
   name: "Sugar Sugar Rune - Koi mo Oshare mo Pick-Up"
   region: "NTSC-J"
@@ -40175,7 +40176,7 @@ SLPS-25640:
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
-    autoFlush: 1 # Fixes shadows in cutscenes.
+    autoFlush: 2 # Fixes shadows in cutscenes.
     halfPixelOffset: 1 # Fixes lighting misalignment and reduces ground shadows (probably texture cache issue).
     roundSprite: 2 # Fixes font artifacts.
     textureInsideRT: 1 # Fixes bad crystal surfaces.
@@ -40188,7 +40189,7 @@ SLPS-25641:
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
-    autoFlush: 1 # Fixes shadows in cutscenes.
+    autoFlush: 2 # Fixes shadows in cutscenes.
     halfPixelOffset: 1 # Fixes lighting misalignment and reduces ground shadows (probably texture cache issue).
     roundSprite: 2 # Fixes font artifacts.
     textureInsideRT: 1 # Fixes bad crystal surfaces.
@@ -40226,7 +40227,7 @@ SLPS-25649:
   name: "Space Sheriff Spirits"
   region: "NTSC-J"
   gsHWFixes:
-    autoFlush: 1 # Fixes black stages.
+    autoFlush: 2 # Fixes black stages.
 SLPS-25650:
   name: "Metal Slug 3D"
   region: "NTSC-J"
@@ -40305,7 +40306,7 @@ SLPS-25657:
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
-    autoFlush: 1 # Helps ghosting.
+    autoFlush: 2 # Helps ghosting.
     halfPixelOffset: 2 # Helps ghosting when upscaling.
 SLPS-25658:
   name: "Binchou-Tan - Shiwase Goyomi [Shokai Genteiban]"
@@ -41288,7 +41289,7 @@ SLPS-29001:
   name: "Xenosaga Episode 1 - Der Wille zur Macht [Premium Box]"
   region: "NTSC-J"
   gsHWFixes:
-    autoFlush: 1 # Fixes shadows in cutscenes.
+    autoFlush: 2 # Fixes shadows in cutscenes.
     halfPixelOffset: 2 # Removes puppet lines shadows.
     roundSprite: 2 # Fixes font artifacts.
   patches:
@@ -41313,7 +41314,7 @@ SLPS-29002:
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
-    autoFlush: 1 # Fixes shadows in cutscenes.
+    autoFlush: 2 # Fixes shadows in cutscenes.
     halfPixelOffset: 2 # Removes puppet lines shadows.
     roundSprite: 2 # Fixes font artifacts.
   patches:
@@ -41352,7 +41353,7 @@ SLPS-29005:
   name: "Xenosaga Episode 1 - Der Wille zur Macht [Reloaded]"
   region: "NTSC-J"
   gsHWFixes:
-    autoFlush: 1 # Fixes shadows in cutscenes.
+    autoFlush: 2 # Fixes shadows in cutscenes.
     halfPixelOffset: 2 # Removes puppet lines shadows.
     roundSprite: 2 # Fixes font artifacts.
 SLPS-71501:
@@ -41456,7 +41457,7 @@ SLPS-73204:
   name: "Zettai Zetsumei Toshi [PlayStation 2 The Best]"
   region: "NTSC-J"
   gsHWFixes:
-    autoFlush: 1 # Fixes incorrect blur effect.
+    autoFlush: 2 # Fixes incorrect blur effect.
 SLPS-73205:
   name: "Ace Combat 04 - Shattered Skies [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -41505,7 +41506,7 @@ SLPS-73214:
     halfPixelOffset: 2 # Fixes blurrines, preload frame for FMV breaks visuals with this setting.
     disablePartialInvalidation: 1 # Fixes shadows when upscaling.
     roundSprite: 2 # Fixes the position of monster sprites and reduces garbage in the UI.
-    autoFlush: 1 # Makes the shadow monsters appear.
+    autoFlush: 2 # Makes the shadow monsters appear.
 SLPS-73215:
   name: "Shadow Hearts 2 [Director's Cut] [PlayStation 2 The Best] [Disc 2 of 2]"
   region: "NTSC-J"
@@ -41513,7 +41514,7 @@ SLPS-73215:
     halfPixelOffset: 2 # Fixes blurrines, preload frame for FMV breaks visuals with this setting.
     disablePartialInvalidation: 1 # Fixes shadows when upscaling.
     roundSprite: 2 # Fixes the position of monster sprites and reduces garbage in the UI.
-    autoFlush: 1 # Makes the shadow monsters appear.
+    autoFlush: 2 # Makes the shadow monsters appear.
   memcardFilters:
     - "SLPS-73214"
 SLPS-73216:
@@ -41562,7 +41563,7 @@ SLPS-73224:
   name: "Xenosaga Episode II - Jenseits von Gut und Bose [PlayStation 2 The Best] [Disc 1 of 2]"
   region: "NTSC-J"
   gsHWFixes:
-    autoFlush: 1 # Fixes shadows in cutscenes.
+    autoFlush: 2 # Fixes shadows in cutscenes.
     halfPixelOffset: 2 # Fixes lighting misalignment and shadows.
     roundSprite: 2 # Fixes font artifacts.
   memcardFilters:
@@ -41576,7 +41577,7 @@ SLPS-73225:
   name: "Xenosaga Episode II - Jenseits von Gut und Bose [PlayStation 2 The Best] [Disc 2 of 2]"
   region: "NTSC-J"
   gsHWFixes:
-    autoFlush: 1 # Fixes shadows in cutscenes.
+    autoFlush: 2 # Fixes shadows in cutscenes.
     halfPixelOffset: 2 # Fixes lighting misalignment and shadows.
     roundSprite: 2 # Fixes font artifacts.
   memcardFilters:
@@ -41782,7 +41783,7 @@ SLPS-73252:
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
-    autoFlush: 1 # Fixes post lighting.
+    autoFlush: 2 # Fixes post lighting.
 SLPS-73253:
   name: "Rurouni Kenshin - Enjou! Kyoto Rinne [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -41959,7 +41960,7 @@ SLPS-73901:
   name: "Xenosaga Episode 1 - Der Wille zur Macht [PlayStation 2 The Best]"
   region: "NTSC-J"
   gsHWFixes:
-    autoFlush: 1 # Fixes shadows in cutscenes.
+    autoFlush: 2 # Fixes shadows in cutscenes.
     halfPixelOffset: 2 # Removes puppet lines shadows.
     roundSprite: 2 # Fixes font artifacts.
   patches:
@@ -43543,7 +43544,7 @@ SLUS-20380:
   name: "Jurassic Park - Operation Genesis"
   region: "NTSC-U"
   gsHWFixes:
-    autoFlush: 1 # Fixes glows. Also needed for recursive mipmap rendering.
+    autoFlush: 2 # Fixes glows. Also needed for recursive mipmap rendering.
     mipmap: 2 # Better characters and environment but has a texture cache issue that makes it worse.
     trilinearFiltering: 1 # Using mipmaps, so may as well.
     textureInsideRT: 1 # Fixes rainbow lighting for some areas.
@@ -43858,7 +43859,7 @@ SLUS-20440:
     - EETimingHack # Fixes smoke effects.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes fog misalignment and depth line.
-    autoFlush: 1 # Fixes sun going through objects.
+    autoFlush: 2 # Fixes sun going through objects.
     preloadFrameData: 1 # Fixes missing sun and sky.
 SLUS-20441:
   name: "NASCAR - Dirt to Daytona"
@@ -43979,7 +43980,7 @@ SLUS-20467:
         // in the BIOS configuration - a gamebug, not an emulator bug.
         patch=1,EE,0020520C,word,24020001 // 0C0882C8
   gsHWFixes:
-    autoFlush: 1 # Fixes lava effect.
+    autoFlush: 2 # Fixes lava effect.
 SLUS-20468:
   name: "Dynasty Tactics"
   region: "NTSC-U"
@@ -43988,7 +43989,7 @@ SLUS-20469:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    autoFlush: 1 # Fixes shadows in cutscenes.
+    autoFlush: 2 # Fixes shadows in cutscenes.
     halfPixelOffset: 2 # Removes puppet lines shadows.
     roundSprite: 2 # Fixes font artifacts.
   patches:
@@ -44127,7 +44128,7 @@ SLUS-20496:
   compat: 5
   gsHWFixes:
     preloadFrameData: 1 # Fixes fog and make lights on cars work again.
-    autoFlush: 1 # Fixes sun luminosity and penetration of objects.
+    autoFlush: 2 # Fixes sun luminosity and penetration of objects.
   gameFixes:
     - EETimingHack # Fixes random graphical corruption.
 SLUS-20497:
@@ -44155,7 +44156,7 @@ SLUS-20502:
   compat: 5
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
-    autoFlush: 1 # Fixes the sun flare.
+    autoFlush: 2 # Fixes the sun flare.
     halfPixelOffset: 2 # Fixes the sun flare.
 SLUS-20504:
   name: "Tony Hawk's Pro Skater 4"
@@ -44434,7 +44435,7 @@ SLUS-20561:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    autoFlush: 1 # Fixes incorrect blur effect.
+    autoFlush: 2 # Fixes incorrect blur effect.
 SLUS-20562:
   name: "dot hack - Mutation Part 2"
   region: "NTSC-U"
@@ -44583,7 +44584,7 @@ SLUS-20587:
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
-    autoFlush: 1
+    autoFlush: 2
     cpuCLUTRender: 1 # Fixes janky coloured cars.
     gpuTargetCLUT: 1 # Fixes janky coloured cars.
     textureInsideRT: 1 # Fixes car textures.
@@ -44750,7 +44751,7 @@ SLUS-20624:
   gameFixes:
     - FpuNegDivHack # Lens flare appears even when behind objects.
   gsHWFixes:
-    autoFlush: 1 # Fixes missing lens flare.
+    autoFlush: 2 # Fixes missing lens flare.
 SLUS-20625:
   name: "MotoGP 3"
   region: "NTSC-U"
@@ -44996,7 +44997,7 @@ SLUS-20673:
   compat: 5
   gsHWFixes:
     cpuCLUTRender: 1 # Fixes lights penetrating objects.
-    autoFlush: 1 # Helps with the light penetration problem.
+    autoFlush: 2 # Helps with the light penetration problem.
     cpuSpriteRenderBW: 1 # Fixes light glows.
 SLUS-20674:
   name: "Cyber Troopers - Virtual-On Marz"
@@ -45321,7 +45322,7 @@ SLUS-20743:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    autoFlush: 1 # Reduces post-processing misalignment.
+    autoFlush: 2 # Reduces post-processing misalignment.
 SLUS-20744:
   name: "EverQuest - Online Adventures - Frontiers"
   region: "NTSC-U"
@@ -45458,7 +45459,7 @@ SLUS-20763:
     eeRoundMode: 0 # Fixes SPS with water in some places.
   gsHWFixes:
     textureInsideRT: 1 # Fixes the shape of shadows.
-    autoFlush: 1 # Fixes water rendering.
+    autoFlush: 2 # Fixes water rendering.
     halfPixelOffset: 3 # Fixes bloom misalignment, needs this harsh offset for autoflush.
     cpuFramebufferConversion: 1 # Fixes shield rendering.
 SLUS-20764:
@@ -45522,7 +45523,7 @@ SLUS-20776:
   compat: 5
   gsHWFixes:
     cpuSpriteRenderBW: 1 # Fixes textures.
-    autoFlush: 1 # Fixes the position of the shadow and makes it not blocky.
+    autoFlush: 2 # Fixes the position of the shadow and makes it not blocky.
     halfPixelOffset: 2 # Fixes shadows.
     gpuPaletteConversion: 0 # Stops potential crashes from too many palette textures.
 SLUS-20777:
@@ -45604,7 +45605,7 @@ SLUS-20797:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    autoFlush: 1
+    autoFlush: 2
 SLUS-20798:
   name: "Starcraft - Ghost"
   region: "NTSC-U"
@@ -45838,7 +45839,7 @@ SLUS-20852:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    autoFlush: 1 # Fixes environment lights visible through player model.
+    autoFlush: 2 # Fixes environment lights visible through player model.
 SLUS-20853:
   name: "Looney Tunes - Back in Action"
   region: "NTSC-U"
@@ -45919,7 +45920,7 @@ SLUS-20867:
   roundModes:
     eeRoundMode: 0 # Fixes character behaviour.
   gsHWFixes:
-    autoFlush: 1 # Fixes flame bloom.
+    autoFlush: 2 # Fixes flame bloom.
 SLUS-20868:
   name: "MVP Baseball 2004"
   region: "NTSC-U"
@@ -45941,7 +45942,7 @@ SLUS-20870:
     partialTargetInvalidation: 1 # Fixes texture distortion.
     mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
     trilinearFiltering: 1
-    autoFlush: 1 # Fixes shadow alignment along with HPO Special (Normal looks better but causes top left glitches).
+    autoFlush: 2 # Fixes shadow alignment along with HPO Special (Normal looks better but causes top left glitches).
     halfPixelOffset: 2
 SLUS-20871:
   name: "Naval Ops - Commander"
@@ -46055,7 +46056,7 @@ SLUS-20892:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    autoFlush: 1 # Fixes shadows in cutscenes.
+    autoFlush: 2 # Fixes shadows in cutscenes.
     halfPixelOffset: 2 # Fixes lighting misalignment and shadows.
     roundSprite: 2 # Fixes font artifacts.
   memcardFilters: # Allows import of Xenosaga I data.
@@ -46181,7 +46182,7 @@ SLUS-20915:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
-    autoFlush: 1 # Fixes lens flare.
+    autoFlush: 2 # Fixes lens flare.
 SLUS-20916:
   name: "Dance Dance Revolution EXTREME"
   region: "NTSC-U"
@@ -46289,7 +46290,7 @@ SLUS-20932:
   compat: 5
   gsHWFixes:
     halfBottomOverride: 1 # Bottom screen has wrong colors.
-    autoFlush: 1 # Fixes missing lighting.
+    autoFlush: 2 # Fixes missing lighting.
     # halfPixelOffset: 1 # Fixes lighting misalignment. Do not enable this, it breaks a lot of graphics.
 SLUS-20933:
   name: "Smash Court Pro Tournament Tennis 2"
@@ -46357,7 +46358,7 @@ SLUS-20945:
     roundSprite: 2 # Fixes misaligned bloom.
     mergeSprite: 1 # Fixes misaligned bloom.
     halfPixelOffset: 2 # Fixes misaligned bloom.
-    autoFlush: 1 # Fixes sun occlusion and brightness.
+    autoFlush: 2 # Fixes sun occlusion and brightness.
 SLUS-20946:
   name: "Grand Theft Auto - San Andreas"
   region: "NTSC-U"
@@ -46365,7 +46366,7 @@ SLUS-20946:
   clampModes:
     eeClampMode: 2 # Fixes Game freezes during "Reuniting The Families" mission.
   gsHWFixes:
-    autoFlush: 1
+    autoFlush: 1 # Fixes post processing.
 SLUS-20947:
   name: "WinBack 2 - Project Poseidon"
   region: "NTSC-U"
@@ -46431,7 +46432,7 @@ SLUS-20960:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    autoFlush: 1 # Fixes bloom.
+    autoFlush: 2 # Fixes bloom.
     roundSprite: 1 # Fixes misaligned bloom.
     deinterlace: 6 # Game requires blend tff de-interlacing when auto for 'fixing' subtitles flickering or half weaved.
   memcardFilters:
@@ -46537,7 +46538,7 @@ SLUS-20978:
   region: "NTSC-U"
   compat: 4
   gsHWFixes:
-    autoFlush: 1
+    autoFlush: 2
   patches:
     42E15DEF:
       content: |-
@@ -46669,7 +46670,7 @@ SLUS-21005:
   name: "Kingdom Hearts II"
   region: "NTSC-U"
   gsHWFixes:
-    autoFlush: 1 # Fixes effects.
+    autoFlush: 2 # Fixes effects.
     roundSprite: 2 # Fixes upscaling artifacts.
   compat: 5
 SLUS-21006:
@@ -46800,7 +46801,7 @@ SLUS-21022:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    autoFlush: 1 # Reduces post-processing misalignment.
+    autoFlush: 2 # Reduces post-processing misalignment.
 SLUS-21025:
   name: "Madden NFL 2005 [Special Collectors Edition]"
   region: "NTSC-U"
@@ -46811,7 +46812,7 @@ SLUS-21026:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    autoFlush: 1 # Post-processing.
+    autoFlush: 2 # Post-processing.
     halfPixelOffset: 2 # Offset post-processing.
     texturePreloading: 1 # Spikes all over the place otherwise.
     textureInsideRT: 1 # Fixes light shinging through objects.
@@ -46916,7 +46917,7 @@ SLUS-21041:
     halfPixelOffset: 2 # Fixes blurrines, preload frame for FMV breaks visuals with this setting.
     disablePartialInvalidation: 1 # Fixes shadows when upscaling.
     roundSprite: 2 # Fixes the position of monster sprites and reduces garbage in the UI.
-    autoFlush: 1 # Makes the shadow monsters appear.
+    autoFlush: 2 # Makes the shadow monsters appear.
 SLUS-21042:
   name: "Darkwatch"
   region: "NTSC-U"
@@ -46933,7 +46934,7 @@ SLUS-21044:
     halfPixelOffset: 2 # Fixes blurrines, preload frame for FMV breaks visuals with this setting.
     disablePartialInvalidation: 1 # Fixes shadows when upscaling.
     roundSprite: 2 # Fixes the position of monster sprites and reduces garbage in the UI.
-    autoFlush: 1 # Makes the shadow monsters appear.
+    autoFlush: 2 # Makes the shadow monsters appear.
   memcardFilters:
     - "SLUS-21041"
 SLUS-21045:
@@ -46965,7 +46966,7 @@ SLUS-21050:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes depth lines.
-    autoFlush: 1 # Fixes blur and obscures sun behind objects.
+    autoFlush: 2 # Fixes blur and obscures sun behind objects.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
@@ -47166,7 +47167,7 @@ SLUS-21095:
   compat: 5
   gsHWFixes:
     mipmap: 1
-    autoFlush: 1
+    autoFlush: 2
     partialTargetInvalidation: 1
     estimateTextureRegion: 1 # Improves performance.
 SLUS-21096:
@@ -47262,7 +47263,7 @@ SLUS-21111:
   gameFixes:
     - IbitHack
   gsHWFixes:
-    autoFlush: 1 # Fixes post processing overlay.
+    autoFlush: 2 # Fixes post processing overlay.
     roundSprite: 1 # Greatly reduces chromatic effect when upscaling.
 SLUS-21112:
   name: "L.A. Rush"
@@ -47290,7 +47291,7 @@ SLUS-21116:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    autoFlush: 1 # Softens bloom on objects and cars.
+    autoFlush: 2 # Softens bloom on objects and cars.
     halfPixelOffset: 2 # Fixes misaligned bloom on objects and cars.
 SLUS-21117:
   name: "World Soccer - Winning Eleven 8 - International"
@@ -47337,7 +47338,7 @@ SLUS-21127:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes lighting/shadows.
     preloadFrameData: 1 # Fixes sun flickering.
-    autoFlush: 1 # Fixes sun through objects.
+    autoFlush: 2 # Fixes sun through objects.
     bilinearUpscale: 1 # Smooths out sun glare textures like native.
 SLUS-21128:
   name: "Blitz - The League"
@@ -47364,7 +47365,7 @@ SLUS-21133:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    autoFlush: 1 # Fixes shadows in cutscenes.
+    autoFlush: 2 # Fixes shadows in cutscenes.
     halfPixelOffset: 2 # Fixes lighting misalignment and shadows.
     roundSprite: 2 # Fixes font artifacts.
   memcardFilters: # Allows import of Xenosaga I data.
@@ -47405,7 +47406,7 @@ SLUS-21139:
     trilinearFiltering: 1
     textureInsideRT: 1 # Fixes rainbow artifacting around edges of screen.
     halfPixelOffset: 2 # Fixes misalgined bloom.
-    autoFlush: 1 # Fixes missing bloom intensity and alignment.
+    autoFlush: 2 # Fixes missing bloom intensity and alignment.
 SLUS-21140:
   name: "Mobile Suit Gundam Seed - Never Ending Tomorrow"
   region: "NTSC-U"
@@ -47639,7 +47640,7 @@ SLUS-21189:
   speedHacks:
     InstantVU1SpeedHack: 1 # Fixes SPS.
   gsHWFixes:
-    autoFlush: 1 # Fixes debris and blending on lower part of screen during monster transformation.
+    autoFlush: 2 # Fixes debris and blending on lower part of screen during monster transformation.
     mipmap: 2
     trilinearFiltering: 1
   memcardFilters:
@@ -47690,7 +47691,7 @@ SLUS-21198:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    autoFlush: 1 # Fixes lighting misalignment.
+    autoFlush: 2 # Fixes lighting misalignment.
     halfPixelOffset: 2 # Fixes lighting misalignment.
 SLUS-21199:
   name: "Medal of Honor - European Assault"
@@ -47742,7 +47743,7 @@ SLUS-21207:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    autoFlush: 1 # Fixes missing bloom from surfaces like windows.
+    autoFlush: 2 # Fixes missing bloom from surfaces like windows.
     textureInsideRT: 1 # Fixes corruption.
     # halfPixelOffset: 1 # Aligns shadows properly, but causes grid lines to appear in sea travel.
     halfPixelOffset: 2 # Sharpens world in far distances, aligns some bloom better.
@@ -47887,7 +47888,7 @@ SLUS-21231:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    autoFlush: 1 # Fixes bloom misalignment.
+    autoFlush: 2 # Fixes bloom misalignment.
     halfPixelOffset: 2 # Fixes bloom misalignment.
     textureInsideRT: 1 # Fixes sky bloom.
 SLUS-21232:
@@ -47966,7 +47967,7 @@ SLUS-21242:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes depth lines.
-    autoFlush: 1 # Fixes blur and obscures sun behind objects.
+    autoFlush: 2 # Fixes blur and obscures sun behind objects.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
@@ -47984,7 +47985,7 @@ SLUS-21243:
     - BlitInternalFPSHack # Fixes internal FPS detection.
     - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
-    autoFlush: 1 # Fixes lens flare.
+    autoFlush: 2 # Fixes lens flare.
     halfPixelOffset: 2 # Fixes blurriness.
   memcardFilters:
     - "SLUS-21359"
@@ -48017,7 +48018,7 @@ SLUS-21248:
     vuClampMode: 3 # Fixes broken polygons on trees.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misaligned bloom.
-    autoFlush: 1 # Fixes glitchy black rectangles.
+    autoFlush: 2 # Fixes glitchy black rectangles.
 SLUS-21249:
   name: "Yourself! Fitness - Lifestyle"
   region: "NTSC-U"
@@ -48142,7 +48143,7 @@ SLUS-21268:
   clampModes:
     vuClampMode: 2 # Fixes mini-map HUD.
   gsHWFixes:
-    autoFlush: 1 # Fixes pause menu backgrounds.
+    autoFlush: 2 # Fixes pause menu backgrounds.
     roundSprite: 1 # Corrects proportions of fonts and pause-screen lines, adjusts display closer to software.
 SLUS-21269:
   name: "Bully"
@@ -48187,7 +48188,7 @@ SLUS-21274:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    autoFlush: 1 # Reduces post-processing misalignment.
+    autoFlush: 2 # Reduces post-processing misalignment.
     halfPixelOffset: 2 # Fixes bloom misalignment still a bit misaligned.
     roundSprite: 1 # Fixes bloom misalignment still a bit misaligned + font artifacts.
 SLUS-21275:
@@ -48205,7 +48206,7 @@ SLUS-21277:
   gsHWFixes:
     halfPixelOffset: 2 # Fix text and post blur.
     mipmap: 2 # Base mip level isn't always used.
-    autoFlush: 1 # Needed for recursive mipmap rendering.
+    autoFlush: 2 # Needed for recursive mipmap rendering.
     getSkipCount: "GSC_BlueTongueGames" # Render mipmaps on the CPU.
 SLUS-21278:
   name: "SSX on Tour"
@@ -48235,7 +48236,7 @@ SLUS-21284:
   name: "Nicktoons Unite!"
   region: "NTSC-U"
   gsHWFixes:
-    autoFlush: 1 # Fixes glows. Also needed for recursive mipmap rendering.
+    autoFlush: 2 # Fixes glows. Also needed for recursive mipmap rendering.
     mipmap: 2 # Better characters and environment but has a texture cache issue that makes it worse.
     trilinearFiltering: 1 # Using mipmaps, so may as well.
     textureInsideRT: 1 # Fixes rainbow lighting for some areas.
@@ -48250,7 +48251,7 @@ SLUS-21285:
     partialTargetInvalidation: 1 # Fixes texture distortion.
     mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
     trilinearFiltering: 1
-    autoFlush: 1 # Fixes shadow alignment along with HPO Special (Normal looks better but causes top left glitches).
+    autoFlush: 2 # Fixes shadow alignment along with HPO Special (Normal looks better but causes top left glitches).
     halfPixelOffset: 2
 SLUS-21286:
   name: "WWE SmackDown! vs. RAW 2006"
@@ -48261,7 +48262,7 @@ SLUS-21287:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    autoFlush: 1 # Reduces post-processing misalignment.
+    autoFlush: 2 # Reduces post-processing misalignment.
     halfPixelOffset: 1 # Reduces post-processing misalignment.
 SLUS-21288:
   name: "American Chopper 2"
@@ -48325,7 +48326,7 @@ SLUS-21299:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    autoFlush: 1 # Fixes sun luminosity.
+    autoFlush: 2 # Fixes sun luminosity.
 SLUS-21300:
   name: "Over the Hedge"
   region: "NTSC-U"
@@ -48693,7 +48694,7 @@ SLUS-21359:
     - BlitInternalFPSHack # Fixes internal FPS detection.
     - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
-    autoFlush: 1 # Fixes lens flare.
+    autoFlush: 2 # Fixes lens flare.
     halfPixelOffset: 2 # Fixes blurriness.
 SLUS-21360:
   name: "Metal Gear Solid 3 - Subsistence [Disc 3 of 3]"
@@ -48702,7 +48703,7 @@ SLUS-21360:
     - BlitInternalFPSHack # Fixes internal FPS detection.
     - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
-    autoFlush: 1 # Fixes lens flare.
+    autoFlush: 2 # Fixes lens flare.
     halfPixelOffset: 2 # Fixes blurriness.
   memcardFilters:
     - "SLUS-21359"
@@ -48799,7 +48800,7 @@ SLUS-21376:
     vuClampMode: 3 # Fixes SPS.
   gsHWFixes:
     recommendedBlendingLevel: 4 # Improves lighting on buildings and objects.
-    autoFlush: 1 # Properly diffuses light instead of strips of light.
+    autoFlush: 2 # Properly diffuses light instead of strips of light.
     roundSprite: 1 # Fixes lighting misalignment such as the street poles and the sun.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
@@ -48874,7 +48875,7 @@ SLUS-21386:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
-    autoFlush: 1 # Fixes post lighting.
+    autoFlush: 2 # Fixes post lighting.
 SLUS-21387:
   name: "Warship Gunner 2"
   region: "NTSC-U"
@@ -48890,7 +48891,7 @@ SLUS-21389:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    autoFlush: 1
+    autoFlush: 2
     halfPixelOffset: 1 # Fixes lighting misalignment and reduces ground shadows.
     roundSprite: 2 # Fixes font artifacts.
     textureInsideRT: 1 # Fixes bad crystal surfaces.
@@ -49040,7 +49041,7 @@ SLUS-21417:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    autoFlush: 1
+    autoFlush: 2
     halfPixelOffset: 1 # Fixes lighting misalignment and reduces ground shadows.
     roundSprite: 2 # Fixes font artifacts.
     textureInsideRT: 1 # Fixes bad crystal surfaces.
@@ -49077,7 +49078,7 @@ SLUS-21419:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    autoFlush: 1 # Fixes lighting.
+    autoFlush: 2 # Fixes lighting.
 SLUS-21420:
   name: "Disney's Chicken Little - Ace in Action"
   region: "NTSC-U"
@@ -49194,7 +49195,7 @@ SLUS-21439:
     roundSprite: 2 # Fixes misaligned bloom.
     mergeSprite: 1 # Fixes misaligned bloom.
     halfPixelOffset: 2 # Fixes misaligned bloom.
-    autoFlush: 1 # Fixes sun occlusion and brightness.
+    autoFlush: 2 # Fixes sun occlusion and brightness.
 SLUS-21440:
   name: "Big Idea's VeggieTales - LarryBoy and the Bad Apple"
   region: "NTSC-U"
@@ -49350,7 +49351,7 @@ SLUS-21469:
   gsHWFixes:
     mipmap: 2 # Better characters and environment.
     trilinearFiltering: 1 # Using mipmaps, so may as well.
-    autoFlush: 1 # Fixes texture corruptions.
+    autoFlush: 2 # Fixes texture corruptions.
     getSkipCount: "GSC_BlueTongueGames" # Render mipmaps on the CPU.
 SLUS-21470:
   name: "Bratz - Forever Diamondz"
@@ -49488,7 +49489,7 @@ SLUS-21492:
   gameFixes:
     - IbitHack
   gsHWFixes:
-    autoFlush: 1 # Fixes post processing overlay.
+    autoFlush: 2 # Fixes post processing overlay.
     roundSprite: 1 # Greatly reduces chromatic effect when upscaling.
 SLUS-21493:
   name: "Need for Speed - Carbon"
@@ -49579,7 +49580,7 @@ SLUS-21541:
   gsHWFixes:
     halfPixelOffset: 2 # Reduces blooming misalignment.
     wildArmsHack: 1 # Reduces blooming misalignment.
-    autoFlush: 1 # Fixes glows.
+    autoFlush: 2 # Fixes glows.
 SLUS-21542:
   name: "Sega Genesis Collection"
   region: "NTSC-U"
@@ -49619,7 +49620,7 @@ SLUS-21551:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    autoFlush: 1 # Fixes certains font colors.
+    autoFlush: 2 # Fixes certains font colors.
     halfPixelOffset: 2 # Fixes lighting misalignment.
     alignSprite: 1 # Fixes almost all vertical lines.
 SLUS-21552:
@@ -49828,7 +49829,7 @@ SLUS-21596:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes depth lines.
-    autoFlush: 1 # Fixes blur and obscures sun behind objects.
+    autoFlush: 2 # Fixes blur and obscures sun behind objects.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
@@ -50603,7 +50604,7 @@ SLUS-21746:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    autoFlush: 1 # Fixes bloom misalignment.
+    autoFlush: 2 # Fixes bloom misalignment.
     halfPixelOffset: 2 # Fixes lighting misalignment and depth lines.
 SLUS-21748:
   name: "MLB Power Pros 2008"
@@ -50729,7 +50730,7 @@ SLUS-21773:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    autoFlush: 1 # Fixes lights not appearing.
+    autoFlush: 2 # Fixes lights not appearing.
     cpuCLUTRender: 1 # Fixes lights going through darts players.
 SLUS-21774:
   name: "Dynasty Warriors 6"
@@ -50766,7 +50767,7 @@ SLUS-21780:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    autoFlush: 1 # Fixes lack of bloom intensity.
+    autoFlush: 2 # Fixes lack of bloom intensity.
     halfPixelOffset: 1 # Fixes misaligned bloom and rainbow garbage at edges.
 SLUS-21781:
   name: "Guitar Hero - World Tour"
@@ -50853,7 +50854,7 @@ SLUS-21799:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    autoFlush: 1 # Fixes double image.
+    autoFlush: 2 # Fixes double image.
     halfPixelOffset: 1 # Fixes misaligned bloom.
 SLUS-21800:
   name: "Rock Band 2"
@@ -51196,7 +51197,7 @@ SLUS-21881:
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes textures.
     halfPixelOffset: 2 # Fixes misaligned bloom.
-    autoFlush: 1 # Fixes soft shadows.
+    autoFlush: 2 # Fixes soft shadows.
   patches:
     137C792E:
       content: |-
@@ -51586,7 +51587,7 @@ SLUS-28025:
   name: "Disaster Report [Trade Demo]"
   region: "NTSC-U"
   gsHWFixes:
-    autoFlush: 1 # Fixes incorrect blur effect.
+    autoFlush: 2 # Fixes incorrect blur effect.
 SLUS-28026:
   name: "Everquest Online Adventures [Beta Vol.3.0]"
   region: "NTSC-U"
@@ -51612,7 +51613,7 @@ SLUS-28037:
     - EETimingHack # Fixes smoke effects.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes fog misalignment and depth line.
-    autoFlush: 1 # Fixes sun going through objects.
+    autoFlush: 2 # Fixes sun going through objects.
     preloadFrameData: 1 # Fixes missing sun and sky.
 SLUS-28039:
   name: "Rogue Ops [Trade Demo]"
@@ -51896,7 +51897,7 @@ SLUS-29069:
   name: "Prince of Persia - The Sands of Time [Demo]"
   region: "NTSC-U"
   gsHWFixes:
-    autoFlush: 1 # Reduces post-processing misalignment.
+    autoFlush: 2 # Reduces post-processing misalignment.
 SLUS-29070:
   name: "XIII [Demo]"
   region: "NTSC-U"
@@ -51940,7 +51941,7 @@ SLUS-29082:
     eeRoundMode: 0 # Fixes SPS with water in some places.
   gsHWFixes:
     textureInsideRT: 1 # Fixes the shape of shadows.
-    autoFlush: 1 # Fixes water rendering.
+    autoFlush: 2 # Fixes water rendering.
     halfPixelOffset: 3 # Fixes bloom misalignment, needs this harsh offset for autoflush.
     cpuFramebufferConversion: 1 # Fixes shield rendering.
 SLUS-29083:
@@ -52036,7 +52037,7 @@ SLUS-29113:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes depth lines.
-    autoFlush: 1 # Fixes blur and obscures sun behind objects.
+    autoFlush: 2 # Fixes blur and obscures sun behind objects.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
@@ -52049,7 +52050,7 @@ SLUS-29117:
   name: "Battlefield 2 - Modern Combat [Public Beta Vol.1.0]"
   region: "NTSC-U"
   gsHWFixes:
-    autoFlush: 1 # Post-processing.
+    autoFlush: 2 # Post-processing.
     halfPixelOffset: 2 # Offset post-processing.
     texturePreloading: 1 # Spikes all over the place otherwise.
     textureInsideRT: 1 # Fixes light shinging through objects.
@@ -52114,7 +52115,7 @@ SLUS-29137:
   region: "NTSC-U"
   gsHWFixes:
     halfBottomOverride: 1 # Bottom screen has wrong colors.
-    autoFlush: 1 # Fixes missing lighting.
+    autoFlush: 2 # Fixes missing lighting.
     # halfPixelOffset: 1 # Fixes lighting misalignment. Do not enable this, it breaks a lot of graphics.
 SLUS-29138:
   name: "Punisher, The [Demo]"
@@ -52154,12 +52155,12 @@ SLUS-29150:
     roundSprite: 2 # Fixes misaligned bloom.
     mergeSprite: 1 # Fixes misaligned bloom.
     halfPixelOffset: 2 # Fixes misaligned bloom.
-    autoFlush: 1 # Fixes sun occlusion and brightness.
+    autoFlush: 2 # Fixes sun occlusion and brightness.
 SLUS-29152:
   name: "Battlefield 2 - Modern Combat [Regular Demo]"
   region: "NTSC-U"
   gsHWFixes:
-    autoFlush: 1 # Post-processing.
+    autoFlush: 2 # Post-processing.
     halfPixelOffset: 2 # Offset post-processing.
     texturePreloading: 1 # Spikes all over the place otherwise.
     textureInsideRT: 1 # Fixes light shinging through objects.
@@ -52174,7 +52175,7 @@ SLUS-29153:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes depth lines.
-    autoFlush: 1 # Fixes blur and obscures sun behind objects.
+    autoFlush: 2 # Fixes blur and obscures sun behind objects.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
@@ -52198,7 +52199,7 @@ SLUS-29157:
   name: "Dragon Quest VIII - Journey of the Cursed King [Demo]"
   region: "NTSC-U"
   gsHWFixes:
-    autoFlush: 1 # Fixes missing bloom from surfaces like windows.
+    autoFlush: 2 # Fixes missing bloom from surfaces like windows.
     textureInsideRT: 1 # Fixes corruption.
     # halfPixelOffset: 1 # Aligns shadows properly, but causes grid lines to appear in sea travel.
     halfPixelOffset: 2 # Sharpens world in far distances, aligns some bloom better.
@@ -52252,7 +52253,7 @@ SLUS-29172:
   name: "Battlefield 2 - Modern Combat [Demo]"
   region: "NTSC-U"
   gsHWFixes:
-    autoFlush: 1 # Post-processing.
+    autoFlush: 2 # Post-processing.
     halfPixelOffset: 2 # Offset post-processing.
     texturePreloading: 1 # Spikes all over the place otherwise.
     textureInsideRT: 1 # Fixes light shinging through objects.
@@ -52285,7 +52286,7 @@ SLUS-29180:
     vuClampMode: 3 # Fixes SPS.
   gsHWFixes:
     recommendedBlendingLevel: 4 # Improves lighting on buildings and objects.
-    autoFlush: 1 # Properly diffuses light instead of strips of light.
+    autoFlush: 2 # Properly diffuses light instead of strips of light.
     roundSprite: 1 # Fixes lighting misalignment such as the street poles and the sun.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
@@ -52352,7 +52353,7 @@ SLUS-29196:
     roundSprite: 2 # Fixes misaligned bloom.
     mergeSprite: 1 # Fixes misaligned bloom.
     halfPixelOffset: 2 # Fixes misaligned bloom.
-    autoFlush: 1 # Fixes sun occlusion and brightness.
+    autoFlush: 2 # Fixes sun occlusion and brightness.
 SLUS-29197:
   name: "Flushed Away [Demo]"
   region: "NTSC-U"
@@ -52418,7 +52419,7 @@ TCES-52033:
   name: "Syphon Filter - The Omega Strain Beta Trial Code"
   region: "PAL-E"
   gsHWFixes:
-    autoFlush: 1 # Fixes lights going through walls.
+    autoFlush: 2 # Fixes lights going through walls.
     preloadFrameData: 1 # Fixes light flicker.
     halfPixelOffset: 2 # Corrects light position.
   gameFixes:
@@ -52437,7 +52438,7 @@ TCES-52389:
   name: "World Rally Championship 4 Beta Trial Code"
   region: "PAL-E"
   gsHWFixes:
-    autoFlush: 1 # Fixes sun luminosity and car shadows.
+    autoFlush: 2 # Fixes sun luminosity and car shadows.
     roundSprite: 1 # Fixes misaligned text.
     halfPixelOffset: 2 # Fixes minor ghosting on objects.
 TCES-52456:
@@ -52450,7 +52451,7 @@ TCES-52456:
     disablePartialInvalidation: 1 # Prevents the situation that a level (Aquatos) doesn't render characters and geometry.
     partialTargetInvalidation: 1 # Fixes broken pause screen.
     halfPixelOffset: 2 # Fixes misaligned bloom.
-    autoFlush: 1 # Helps fix misaligned bloom.
+    autoFlush: 2 # Helps fix misaligned bloom.
 TCES-52582:
   name: "Everybody's Golf 4 Beta Trial Code"
   region: "PAL-E"
@@ -52464,14 +52465,14 @@ TCES-53247:
     - XGKickHack # Fixes SPS.
   gsHWFixes:
     roundSprite: 1 # Fixes misaligned text.
-    autoFlush: 1 # Fixes sun luminosity.
+    autoFlush: 2 # Fixes sun luminosity.
 TCES-53286:
   name: "Jak X Beta Trial Code"
   region: "PAL-E"
   compat: 5
   gsHWFixes:
     roundSprite: 1 # Fix lines in the sky.
-    autoFlush: 1 # Fixes lighting.
+    autoFlush: 2 # Fixes lighting.
     mipmap: 2 # Fixes broken textures.
     trilinearFiltering: 1 # Fixes water textures.
     cpuSpriteRenderBW: 2 # Fixes water textures. Can't use BW 4 here because of post effects.
@@ -52579,7 +52580,7 @@ TCPS-10158:
     partialTargetInvalidation: 1 # Fixes texture distortion.
     mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
     trilinearFiltering: 1
-    autoFlush: 1 # Fixes shadow alignment along with HPO Special (Normal looks better but causes top left glitches).
+    autoFlush: 2 # Fixes shadow alignment along with HPO Special (Normal looks better but causes top left glitches).
     halfPixelOffset: 2
 TCPS-10159:
   name: "Suzuki TT Super Bikes - Real Road Racing"
@@ -52639,7 +52640,7 @@ TLES-82043:
     - BlitInternalFPSHack # Fixes internal FPS detection.
     - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
-    autoFlush: 1 # Fixes lens flare.
+    autoFlush: 2 # Fixes lens flare.
     halfPixelOffset: 2 # Fixes blurriness.
 VW067-J1:
   name: "Crash Bandicoot 4 - Sakuretsu! Majin Power!"

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -189,7 +189,7 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsDialog* dialog, QWidget* 
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.gpuTargetCLUTMode, "EmuCore/GS", "UserHacks_GPUTargetCLUTMode", 0);
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.skipDrawStart, "EmuCore/GS", "UserHacks_SkipDraw_Start", 0);
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.skipDrawEnd, "EmuCore/GS", "UserHacks_SkipDraw_End", 0);
-	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.hwAutoFlush, "EmuCore/GS", "UserHacks_AutoFlush", false);
+	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.hwAutoFlush, "EmuCore/GS", "UserHacks_AutoFlushLevel", 0);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.frameBufferConversion, "EmuCore/GS", "UserHacks_CPU_FB_Conversion", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.disableDepthEmulation, "EmuCore/GS", "UserHacks_DisableDepthSupport", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.disableSafeFeatures, "EmuCore/GS", "UserHacks_Disable_Safe_Features", false);

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>720</width>
-    <height>476</height>
+    <height>498</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -780,222 +780,6 @@
        <string>Hardware Fixes</string>
       </attribute>
       <layout class="QFormLayout" name="hardwareFixesLayout">
-       <item row="1" column="0">
-        <widget class="QLabel" name="label_10">
-         <property name="text">
-          <string>Half Screen Fix:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="1">
-        <widget class="QComboBox" name="halfScreenFix">
-         <item>
-          <property name="text">
-           <string>Automatic (Default)</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Force Disabled</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Force Enabled</string>
-          </property>
-         </item>
-        </widget>
-       </item>
-       <item row="2" column="0">
-        <widget class="QLabel" name="label_36">
-         <property name="text">
-          <string>CPU Sprite Render Size:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="0">
-        <widget class="QLabel" name="label_16">
-         <property name="text">
-          <string>Software CLUT Render:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="1">
-        <widget class="QComboBox" name="cpuCLUTRender">
-         <property name="currentText">
-          <string extracomment="0 (Disabled)">0 (Disabled)</string>
-         </property>
-         <property name="currentIndex">
-          <number>0</number>
-         </property>
-         <item>
-          <property name="text">
-           <string>0 (Disabled)</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>1 (Normal)</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>2 (Aggressive)</string>
-          </property>
-         </item>
-        </widget>
-       </item>
-       <item row="4" column="0">
-        <widget class="QLabel" name="label_47">
-         <property name="text">
-          <string extracomment="CLUT: Color Look Up Table, often referred to as a palette in non-PS2 things.  GPU Target CLUT: GPU handling of when a game uses data from a render target as a CLUT.">GPU Target CLUT:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="1">
-        <widget class="QComboBox" name="gpuTargetCLUTMode">
-         <item>
-          <property name="text">
-           <string>Disabled (Default)</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Enabled (Exact Match)</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Enabled (Check Inside Target)</string>
-          </property>
-         </item>
-        </widget>
-       </item>
-       <item row="5" column="0">
-        <widget class="QLabel" name="label_45">
-         <property name="text">
-          <string>Texture Inside RT:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="5" column="1">
-        <widget class="QComboBox" name="textureInsideRt">
-         <item>
-          <property name="text">
-           <string>Disabled (Default)</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Inside Target</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Merge Targets</string>
-          </property>
-         </item>
-        </widget>
-       </item>
-       <item row="6" column="0">
-        <widget class="QLabel" name="label_12">
-         <property name="text">
-          <string>Skipdraw Range:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="6" column="1">
-        <layout class="QHBoxLayout" name="horizontalLayout">
-         <item>
-          <widget class="QSpinBox" name="skipDrawStart">
-           <property name="maximum">
-            <number>10000</number>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QSpinBox" name="skipDrawEnd">
-           <property name="maximum">
-            <number>10000</number>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item row="7" column="0" colspan="2">
-        <layout class="QGridLayout" name="gridLayout">
-         <item row="0" column="0">
-          <widget class="QCheckBox" name="hwAutoFlush">
-           <property name="text">
-            <string>Auto Flush</string>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="0">
-          <widget class="QCheckBox" name="disableSafeFeatures">
-           <property name="text">
-            <string>Disable Safe Features</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="0">
-          <widget class="QCheckBox" name="disableDepthEmulation">
-           <property name="text">
-            <string>Disable Depth Emulation</string>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="1">
-          <widget class="QCheckBox" name="frameBufferConversion">
-           <property name="text">
-            <string>Frame Buffer Conversion</string>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="1">
-          <widget class="QCheckBox" name="readTCOnClose">
-           <property name="text">
-            <string>Read Targets When Closing</string>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="0">
-          <widget class="QCheckBox" name="disablePartialInvalidation">
-           <property name="text">
-            <string>Disable Partial Source Invalidation</string>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="1">
-          <widget class="QCheckBox" name="targetPartialInvalidation">
-           <property name="text">
-            <string>Target Partial Invalidation</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="1">
-          <widget class="QCheckBox" name="preloadFrameData">
-           <property name="text">
-            <string>Preload Frame Data</string>
-           </property>
-          </widget>
-         </item>
-         <item row="4" column="0">
-          <widget class="QCheckBox" name="estimateTextureRegion">
-           <property name="text">
-            <string>Estimate Texture Region</string>
-           </property>
-          </widget>
-         </item>
-         <item row="4" column="1">
-          <widget class="QCheckBox" name="gpuPaletteConversion">
-           <property name="text">
-            <string>GPU Palette Conversion</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
        <item row="0" column="0">
         <widget class="QLabel" name="label_7">
          <property name="text">
@@ -1035,6 +819,39 @@
            <string>Aggressive</string>
           </property>
          </item>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="label_10">
+         <property name="text">
+          <string>Half Screen Fix:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="QComboBox" name="halfScreenFix">
+         <item>
+          <property name="text">
+           <string>Automatic (Default)</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Force Disabled</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Force Enabled</string>
+          </property>
+         </item>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="QLabel" name="label_36">
+         <property name="text">
+          <string>CPU Sprite Render Size:</string>
+         </property>
         </widget>
        </item>
        <item row="2" column="1">
@@ -1115,6 +932,208 @@
              <string>Blended Sprites/Triangles</string>
             </property>
            </item>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item row="3" column="0">
+        <widget class="QLabel" name="label_16">
+         <property name="text">
+          <string>Software CLUT Render:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="1">
+        <widget class="QComboBox" name="cpuCLUTRender">
+         <property name="currentText">
+          <string extracomment="0 (Disabled)">0 (Disabled)</string>
+         </property>
+         <property name="currentIndex">
+          <number>0</number>
+         </property>
+         <item>
+          <property name="text">
+           <string>0 (Disabled)</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>1 (Normal)</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>2 (Aggressive)</string>
+          </property>
+         </item>
+        </widget>
+       </item>
+       <item row="4" column="0">
+        <widget class="QLabel" name="label_47">
+         <property name="text">
+          <string extracomment="CLUT: Color Look Up Table, often referred to as a palette in non-PS2 things.  GPU Target CLUT: GPU handling of when a game uses data from a render target as a CLUT.">GPU Target CLUT:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="1">
+        <widget class="QComboBox" name="gpuTargetCLUTMode">
+         <item>
+          <property name="text">
+           <string>Disabled (Default)</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Enabled (Exact Match)</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Enabled (Check Inside Target)</string>
+          </property>
+         </item>
+        </widget>
+       </item>
+       <item row="6" column="0">
+        <widget class="QLabel" name="label_45">
+         <property name="text">
+          <string>Texture Inside RT:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="1">
+        <widget class="QComboBox" name="textureInsideRt">
+         <item>
+          <property name="text">
+           <string>Disabled (Default)</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Inside Target</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Merge Targets</string>
+          </property>
+         </item>
+        </widget>
+       </item>
+       <item row="5" column="0">
+        <widget class="QLabel" name="label_30">
+         <property name="text">
+          <string>Auto Flush:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="1">
+        <widget class="QComboBox" name="hwAutoFlush">
+         <item>
+          <property name="text">
+           <string>Disabled (Default)</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Enabled (Sprites Only)</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Enabled (All Primitives)</string>
+          </property>
+         </item>
+        </widget>
+       </item>
+       <item row="7" column="0">
+        <widget class="QLabel" name="label_12">
+         <property name="text">
+          <string>Skipdraw Range:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="7" column="1">
+        <layout class="QHBoxLayout" name="horizontalLayout">
+         <item>
+          <widget class="QSpinBox" name="skipDrawStart">
+           <property name="maximum">
+            <number>10000</number>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QSpinBox" name="skipDrawEnd">
+           <property name="maximum">
+            <number>10000</number>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item row="8" column="0" colspan="2">
+        <layout class="QGridLayout" name="gridLayout">
+         <item row="0" column="1">
+          <widget class="QCheckBox" name="frameBufferConversion">
+           <property name="text">
+            <string>Frame Buffer Conversion</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="QCheckBox" name="readTCOnClose">
+           <property name="text">
+            <string>Read Targets When Closing</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="1">
+          <widget class="QCheckBox" name="targetPartialInvalidation">
+           <property name="text">
+            <string>Target Partial Invalidation</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QCheckBox" name="preloadFrameData">
+           <property name="text">
+            <string>Preload Frame Data</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="0">
+          <widget class="QCheckBox" name="disableDepthEmulation">
+           <property name="text">
+            <string>Disable Depth Emulation</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QCheckBox" name="disableSafeFeatures">
+           <property name="text">
+            <string>Disable Safe Features</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QCheckBox" name="disablePartialInvalidation">
+           <property name="text">
+            <string>Disable Partial Source Invalidation</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="0">
+          <widget class="QCheckBox" name="estimateTextureRegion">
+           <property name="text">
+            <string>Estimate Texture Region</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="0">
+          <widget class="QCheckBox" name="gpuPaletteConversion">
+           <property name="text">
+            <string>GPU Palette Conversion</string>
+           </property>
           </widget>
          </item>
         </layout>

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -350,6 +350,13 @@ enum class GSCASMode : u8
 	SharpenAndResize,
 };
 
+enum class GSHWAutoFlushLevel : u8
+{
+	Disabled,
+	SpritesOnly,
+	Enabled,
+};
+
 enum class GSGPUTargetCLUTMode : u8
 {
 	Disabled,
@@ -669,7 +676,6 @@ struct Pcsx2Config
 					Mipmap : 1,
 					ManualUserHacks : 1,
 					UserHacks_AlignSpriteX : 1,
-					UserHacks_AutoFlush : 1,
 					UserHacks_CPUFBConversion : 1,
 					UserHacks_ReadTCOnClose : 1,
 					UserHacks_DisableDepthSupport : 1,
@@ -704,85 +710,87 @@ struct Pcsx2Config
 			};
 		};
 
-		int VsyncQueueSize{2};
+		int VsyncQueueSize = 2;
 
 		// forces the MTGS to execute tags/tasks in fully blocking/synchronous
 		// style. Useful for debugging potential bugs in the MTGS pipeline.
-		bool SynchronousMTGS{false};
-		bool FrameLimitEnable{true};
+		bool SynchronousMTGS = false;
+		bool FrameLimitEnable = true;
 
-		VsyncMode VsyncEnable{VsyncMode::Off};
+		VsyncMode VsyncEnable = VsyncMode::Off;
 
-		float LimitScalar{1.0f};
-		float FramerateNTSC{DEFAULT_FRAME_RATE_NTSC};
-		float FrameratePAL{DEFAULT_FRAME_RATE_PAL};
+		float LimitScalar = 1.0f;
+		float FramerateNTSC = DEFAULT_FRAME_RATE_NTSC;
+		float FrameratePAL = DEFAULT_FRAME_RATE_PAL;
 
-		AspectRatioType AspectRatio{AspectRatioType::RAuto4_3_3_2};
-		FMVAspectRatioSwitchType FMVAspectRatioSwitch{FMVAspectRatioSwitchType::Off};
-		GSInterlaceMode InterlaceMode{GSInterlaceMode::Automatic};
-		GSPostBilinearMode LinearPresent{ GSPostBilinearMode::BilinearSmooth };
+		AspectRatioType AspectRatio = AspectRatioType::RAuto4_3_3_2;
+		FMVAspectRatioSwitchType FMVAspectRatioSwitch = FMVAspectRatioSwitchType::Off;
+		GSInterlaceMode InterlaceMode = GSInterlaceMode::Automatic;
+		GSPostBilinearMode LinearPresent = GSPostBilinearMode::BilinearSmooth;
 
-		float StretchY{100.0f};
-		int Crop[4]{};
+		float StretchY = 100.0f;
+		int Crop[4] = {};
 
-		float OsdScale{100.0};
+		float OsdScale = 100.0;
 
-		GSRendererType Renderer{GSRendererType::Auto};
-		float UpscaleMultiplier{1.0f};
+		GSRendererType Renderer = GSRendererType::Auto;
+		float UpscaleMultiplier = 1.0f;
 
-		HWMipmapLevel HWMipmap{HWMipmapLevel::Automatic};
-		AccBlendLevel AccurateBlendingUnit{AccBlendLevel::Basic};
-		CRCHackLevel CRCHack{CRCHackLevel::Automatic};
-		BiFiltering TextureFiltering{BiFiltering::PS2};
-		TexturePreloadingLevel TexturePreloading{TexturePreloadingLevel::Full};
-		GSDumpCompressionMethod GSDumpCompression{GSDumpCompressionMethod::Zstandard};
-		GSHardwareDownloadMode HWDownloadMode{GSHardwareDownloadMode::Enabled};
-		GSCASMode CASMode{GSCASMode::Disabled};
-		int Dithering{2};
-		int MaxAnisotropy{0};
-		int SWExtraThreads{2};
-		int SWExtraThreadsHeight{4};
-		int TVShader{0};
-		s16 GetSkipCountFunctionId{-1};
-		s16 BeforeDrawFunctionId{-1};
-		int SkipDrawStart{0};
-		int SkipDrawEnd{0};
+		HWMipmapLevel HWMipmap = HWMipmapLevel::Automatic;
+		AccBlendLevel AccurateBlendingUnit = AccBlendLevel::Basic;
+		CRCHackLevel CRCHack = CRCHackLevel::Automatic;
+		BiFiltering TextureFiltering = BiFiltering::PS2;
+		TexturePreloadingLevel TexturePreloading = TexturePreloadingLevel::Full;
+		GSDumpCompressionMethod GSDumpCompression = GSDumpCompressionMethod::Zstandard;
+		GSHardwareDownloadMode HWDownloadMode = GSHardwareDownloadMode::Enabled;
+		GSCASMode CASMode = GSCASMode::Disabled;
+		u8 Dithering = 2;
+		u8 MaxAnisotropy = 0;
+		u8 TVShader = 0;
+		s16 GetSkipCountFunctionId = -1;
+		s16 BeforeDrawFunctionId = -1;
+		int SkipDrawStart = 0;
+		int SkipDrawEnd = 0;
 
-		int UserHacks_HalfBottomOverride{-1};
-		int UserHacks_HalfPixelOffset{0};
-		int UserHacks_RoundSprite{0};
-		int UserHacks_TCOffsetX{0};
-		int UserHacks_TCOffsetY{0};
-		int UserHacks_CPUSpriteRenderBW{0};
-		int UserHacks_CPUSpriteRenderLevel{0};
-		int UserHacks_CPUCLUTRender{0};
-		GSGPUTargetCLUTMode UserHacks_GPUTargetCLUTMode{GSGPUTargetCLUTMode::Disabled};
-		GSTextureInRtMode UserHacks_TextureInsideRt{GSTextureInRtMode::Disabled};
-		TriFiltering TriFilter{TriFiltering::Automatic};
-		int OverrideTextureBarriers{-1};
+		GSHWAutoFlushLevel UserHacks_AutoFlush = GSHWAutoFlushLevel::Disabled;
+		s8 UserHacks_HalfBottomOverride = -1;
+		s8 UserHacks_HalfPixelOffset = 0;
+		s8 UserHacks_RoundSprite = 0;
+		s32 UserHacks_TCOffsetX = 0;
+		s32 UserHacks_TCOffsetY = 0;
+		u8 UserHacks_CPUSpriteRenderBW = 0;
+		u8 UserHacks_CPUSpriteRenderLevel = 0;
+		u8 UserHacks_CPUCLUTRender = 0;
+		GSGPUTargetCLUTMode UserHacks_GPUTargetCLUTMode = GSGPUTargetCLUTMode::Disabled;
+		GSTextureInRtMode UserHacks_TextureInsideRt = GSTextureInRtMode::Disabled;
+		TriFiltering TriFilter = TriFiltering::Automatic;
+		s8 OverrideTextureBarriers = -1;
 
-		int CAS_Sharpness{50};
-		int ShadeBoost_Brightness{50};
-		int ShadeBoost_Contrast{50};
-		int ShadeBoost_Saturation{50};
-		int PNGCompressionLevel{1};
+		u8 CAS_Sharpness = 50;
+		u8 ShadeBoost_Brightness = 50;
+		u8 ShadeBoost_Contrast = 50;
+		u8 ShadeBoost_Saturation = 50;
+		u8 PNGCompressionLevel = 1;
 
-		int SaveN{0};
-		int SaveL{5000};
+		u16 SWExtraThreads = 2;
+		u16 SWExtraThreadsHeight = 4;
 
-		GSScreenshotSize ScreenshotSize{GSScreenshotSize::WindowResolution};
-		GSScreenshotFormat ScreenshotFormat{GSScreenshotFormat::PNG};
-		int ScreenshotQuality{50};
+		int SaveN = 0;
+		int SaveL = 5000;
 
-		std::string CaptureContainer{DEFAULT_CAPTURE_CONTAINER};
+		GSScreenshotSize ScreenshotSize = GSScreenshotSize::WindowResolution;
+		GSScreenshotFormat ScreenshotFormat = GSScreenshotFormat::PNG;
+		int ScreenshotQuality = 50;
+
+		std::string CaptureContainer = DEFAULT_CAPTURE_CONTAINER;
 		std::string VideoCaptureCodec;
 		std::string VideoCaptureParameters;
 		std::string AudioCaptureCodec;
 		std::string AudioCaptureParameters;
-		int VideoCaptureBitrate{DEFAULT_VIDEO_CAPTURE_BITRATE};
-		int VideoCaptureWidth{DEFAULT_VIDEO_CAPTURE_WIDTH};
-		int VideoCaptureHeight{DEFAULT_VIDEO_CAPTURE_HEIGHT};
-		int AudioCaptureBitrate{DEFAULT_AUDIO_CAPTURE_BITRATE};
+		int VideoCaptureBitrate = DEFAULT_VIDEO_CAPTURE_BITRATE;
+		int VideoCaptureWidth = DEFAULT_VIDEO_CAPTURE_WIDTH;
+		int VideoCaptureHeight = DEFAULT_VIDEO_CAPTURE_HEIGHT;
+		int AudioCaptureBitrate = DEFAULT_AUDIO_CAPTURE_BITRATE;
 
 		std::string Adapter;
 		std::string HWDumpDirectory;

--- a/pcsx2/Docs/gamedb-schema.json
+++ b/pcsx2/Docs/gamedb-schema.json
@@ -115,7 +115,7 @@
             "autoFlush": {
               "type": "integer",
               "minimum": 0,
-              "maximum": 1
+              "maximum": 2
             },
             "conservativeFramebuffer": {
               "type": "integer",

--- a/pcsx2/Frontend/FullscreenUI.cpp
+++ b/pcsx2/Frontend/FullscreenUI.cpp
@@ -3182,6 +3182,8 @@ void FullscreenUI::DrawGraphicsSettingsPage()
 			static constexpr const char* s_half_pixel_offset_options[] = {
 				"Off (Default)", "Normal (Vertex)", "Special (Texture)", "Special (Texture - Aggressive)"};
 			static constexpr const char* s_round_sprite_options[] = {"Off (Default)", "Half", "Full"};
+			static constexpr const char* s_auto_flush_options[] = {
+				"Disabled (Default)", "Enabled (Sprites Only)", "Enabled (All Primitives)"};
 
 			DrawIntListSetting(bsi, "CRC Fix Level", "Applies manual fixes to difficult-to-emulate effects in the hardware renderers.",
 				"EmuCore/GS", "crc_hack_level", static_cast<int>(CRCHackLevel::Automatic), s_crc_fix_options, std::size(s_crc_fix_options),
@@ -3198,8 +3200,8 @@ void FullscreenUI::DrawGraphicsSettingsPage()
 				bsi, "Skip Draw Start", "Object range to skip drawing.", "EmuCore/GS", "UserHacks_SkipDraw_Start", 0, 0, 5000, 1);
 			DrawIntSpinBoxSetting(
 				bsi, "Skip Draw End", "Object range to skip drawing.", "EmuCore/GS", "UserHacks_SkipDraw_End", 0, 0, 5000, 1);
-			DrawToggleSetting(bsi, "Auto Flush (Hardware)", "Force a primitive flush when a framebuffer is also an input texture.",
-				"EmuCore/GS", "UserHacks_AutoFlush", false, manual_hw_fixes);
+			DrawIntListSetting(bsi, "Auto Flush (Hardware)", "Force a primitive flush when a framebuffer is also an input texture.",
+				"EmuCore/GS", "UserHacks_AutoFlushLevel", 0, s_auto_flush_options, std::size(s_auto_flush_options), 0, manual_hw_fixes);
 			DrawToggleSetting(bsi, "CPU Framebuffer Conversion", "Convert 4-bit and 8-bit frame buffer on the CPU instead of the GPU.",
 				"EmuCore/GS", "UserHacks_CPU_FB_Conversion", false, manual_hw_fixes);
 			DrawToggleSetting(bsi, "Disable Depth Support", "Disable the support of depth buffer in the texture cache.", "EmuCore/GS",

--- a/pcsx2/Frontend/ImGuiOverlays.cpp
+++ b/pcsx2/Frontend/ImGuiOverlays.cpp
@@ -407,11 +407,11 @@ void ImGuiManager::DrawSettingsOverlay()
 		if (GSConfig.UserHacks_CPUCLUTRender != 0)
 			APPEND("CCLUT={} ", GSConfig.UserHacks_CPUCLUTRender);
 		if (GSConfig.UserHacks_GPUTargetCLUTMode != GSGPUTargetCLUTMode::Disabled)
-			APPEND("GCLUT={} ", static_cast<int>(GSConfig.UserHacks_GPUTargetCLUTMode));
+			APPEND("GCLUT={} ", static_cast<unsigned>(GSConfig.UserHacks_GPUTargetCLUTMode));
 		if (GSConfig.SkipDrawStart != 0 || GSConfig.SkipDrawEnd != 0)
 			APPEND("SD={}/{} ", GSConfig.SkipDrawStart, GSConfig.SkipDrawEnd);
 		if (GSConfig.UserHacks_TextureInsideRt != GSTextureInRtMode::Disabled)
-			APPEND("TexRT={} ", static_cast<int>(GSConfig.UserHacks_TextureInsideRt));
+			APPEND("TexRT={} ", static_cast<unsigned>(GSConfig.UserHacks_TextureInsideRt));
 		if (GSConfig.UserHacks_WildHack)
 			APPEND("WA ");
 		if (GSConfig.UserHacks_BilinearHack)
@@ -422,8 +422,8 @@ void ImGuiManager::DrawSettingsOverlay()
 			APPEND("MS ");
 		if (GSConfig.UserHacks_AlignSpriteX)
 			APPEND("AS ");
-		if (GSConfig.UserHacks_AutoFlush)
-			APPEND("ATFL ");
+		if (GSConfig.UserHacks_AutoFlush != GSHWAutoFlushLevel::Disabled)
+			APPEND("ATFL={} ", static_cast<unsigned>(GSConfig.UserHacks_AutoFlush));
 		if (GSConfig.UserHacks_CPUFBConversion)
 			APPEND("FBC ");
 		if (GSConfig.UserHacks_ReadTCOnClose)

--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -144,10 +144,6 @@ protected:
 	GSVector4i m_scissor = {};
 	GSVector4i m_ofxy = {};
 
-	u8 m_scanmask_used = 0;
-	bool tex_flushed = true;
-	bool m_isPackedUV_HackFlag = false;
-
 	struct
 	{
 		GSVertex* buff;
@@ -228,6 +224,9 @@ public:
 	std::unique_ptr<GSDumpBase> m_dump;
 	bool m_nativeres = false;
 	bool m_mipmap = false;
+	bool m_texflush_flag = false;
+	bool m_isPackedUV_HackFlag = false;
+	u8 m_scanmask_used = 0;
 	u8 m_force_preload = 0;
 	u32 m_dirty_gs_regs = 0;
 	int m_backed_up_ctx = 0;
@@ -268,17 +267,16 @@ public:
 		RESET = 1 << 1,
 		CONTEXTCHANGE = 1 << 2,
 		CLUTCHANGE = 1 << 3,
-		TEXFLUSH = 1 << 4,
-		GSTRANSFER = 1 << 5,
-		UPLOADDIRTYTEX = 1 << 6,
-		LOCALTOLOCALMOVE = 1 << 7,
-		DOWNLOADFIFO = 1 << 8,
-		SAVESTATE = 1 << 9,
-		LOADSTATE = 1 << 10,
-		AUTOFLUSH = 1 << 11,
-		VSYNC  = 1 << 12,
-		GSREOPEN = 1 << 13,
-		VERTEXCOUNT = 1 << 14,
+		GSTRANSFER = 1 << 4,
+		UPLOADDIRTYTEX = 1 << 5,
+		LOCALTOLOCALMOVE = 1 << 6,
+		DOWNLOADFIFO = 1 << 7,
+		SAVESTATE = 1 << 8,
+		LOADSTATE = 1 << 9,
+		AUTOFLUSH = 1 << 10,
+		VSYNC  = 1 << 11,
+		GSREOPEN = 1 << 12,
+		VERTEXCOUNT = 1 << 13,
 	};
 
 	GSFlushReason m_state_flush_reason = UNKNOWN;

--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -168,7 +168,7 @@ protected:
 	void UpdateVertexKick();
 
 	void GrowVertexBuffer();
-	bool IsAutoFlushDraw();
+	bool IsAutoFlushDraw(u32 prim);
 	template<u32 prim, bool index_swap>
 	void HandleAutoFlush();
 	void CLUTAutoFlush(u32 prim);

--- a/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
@@ -1610,7 +1610,7 @@ bool GSDevice12::GetSampler(D3D12::DescriptorHandle* cpu_handle, GSHWDrawConfig:
 	sd.AddressW = D3D12_TEXTURE_ADDRESS_MODE_CLAMP;
 	sd.MinLOD = 0.0f;
 	sd.MaxLOD = (ss.lodclamp || !ss.UseMipmapFiltering()) ? 0.25f : FLT_MAX;
-	sd.MaxAnisotropy = std::clamp(GSConfig.MaxAnisotropy, 1, 16);
+	sd.MaxAnisotropy = std::clamp<u8>(GSConfig.MaxAnisotropy, 1, 16);
 	sd.ComparisonFunc = D3D12_COMPARISON_FUNC_NEVER;
 
 	if (!g_d3d12_context->GetSamplerHeapManager().Allocate(cpu_handle))

--- a/pcsx2/GameDatabase.cpp
+++ b/pcsx2/GameDatabase.cpp
@@ -693,8 +693,11 @@ u32 GameDatabaseSchema::GameEntry::applyGSHardwareFixes(Pcsx2Config::GSOptions& 
 		switch (id)
 		{
 			case GSHWFixId::AutoFlush:
-				config.UserHacks_AutoFlush = (value > 0);
-				break;
+			{
+				if (value >= 0 && value <= static_cast<int>(GSHWAutoFlushLevel::Enabled))
+					config.UserHacks_AutoFlush = static_cast<GSHWAutoFlushLevel>(value);
+			}
+			break;
 
 			case GSHWFixId::CPUFramebufferConversion:
 				config.UserHacks_CPUFBConversion = (value > 0);

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -434,7 +434,7 @@ Pcsx2Config::GSOptions::GSOptions()
 
 	ManualUserHacks = false;
 	UserHacks_AlignSpriteX = false;
-	UserHacks_AutoFlush = false;
+	UserHacks_AutoFlush = GSHWAutoFlushLevel::Disabled;
 	UserHacks_CPUFBConversion = false;
 	UserHacks_ReadTCOnClose = false;
 	UserHacks_DisableDepthSupport = false;
@@ -518,6 +518,7 @@ bool Pcsx2Config::GSOptions::OptionsAreEqual(const GSOptions& right) const
 		OpEqu(SkipDrawEnd) &&
 		OpEqu(SkipDrawStart) &&
 
+		OpEqu(UserHacks_AutoFlush) &&
 		OpEqu(UserHacks_HalfBottomOverride) &&
 		OpEqu(UserHacks_HalfPixelOffset) &&
 		OpEqu(UserHacks_RoundSprite) &&
@@ -648,7 +649,7 @@ void Pcsx2Config::GSOptions::LoadSave(SettingsWrapper& wrap)
 	GSSettingBoolEx(Mipmap, "mipmap");
 	GSSettingBoolEx(ManualUserHacks, "UserHacks");
 	GSSettingBoolEx(UserHacks_AlignSpriteX, "UserHacks_align_sprite_X");
-	GSSettingBoolEx(UserHacks_AutoFlush, "UserHacks_AutoFlush");
+	GSSettingIntEnumEx(UserHacks_AutoFlush, "UserHacks_AutoFlushLevel");
 	GSSettingBoolEx(UserHacks_CPUFBConversion, "UserHacks_CPU_FB_Conversion");
 	GSSettingBoolEx(UserHacks_ReadTCOnClose, "UserHacks_ReadTCOnClose");
 	GSSettingBoolEx(UserHacks_DisableDepthSupport, "UserHacks_DisableDepthSupport");
@@ -781,7 +782,7 @@ void Pcsx2Config::GSOptions::MaskUserHacks()
 	UserHacks_HalfBottomOverride = -1;
 	UserHacks_HalfPixelOffset = 0;
 	UserHacks_RoundSprite = 0;
-	UserHacks_AutoFlush = false;
+	UserHacks_AutoFlush = GSHWAutoFlushLevel::Disabled;
 	PreloadFrameWithGSData = false;
 	UserHacks_DisablePartialInvalidation = false;
 	UserHacks_DisableDepthSupport = false;


### PR DESCRIPTION
### Description of Changes

God of War (2) explicitly flushes the GS's texture cache when drawing the trails of red things, whatever they are. This causes up to 500 texture copies, which gets pretty slow, especially on GPUs like M1.

So, let's add a new level to autoflush - only apply it to sprites. This cuts the copies (and draws) down to approximately 10-ish, without needing to disable auto flush. It's potentially beneficial to other games too, but I haven't looked at any aside from GTA:SA and GOW.

### Rationale behind Changes

Vroom vroom

### Suggested Testing Steps

Test a few autoflush games, make sure I didn't break it. Test GOW/2 to make sure it looks correct.
