### PR TITLE
GS: Refactor exclusive fullscreen yet again

### DIFF
--- a/common/Vulkan/Context.h
+++ b/common/Vulkan/Context.h
@@ -63,7 +63,7 @@ namespace Vulkan
 
 		// Helper method to create a Vulkan instance.
 		static VkInstance CreateVulkanInstance(
-			const WindowInfo* wi, bool enable_debug_utils, bool enable_validation_layer);
+			const WindowInfo& wi, bool enable_debug_utils, bool enable_validation_layer);
 
 		// Returns a list of Vulkan-compatible GPUs.
 		using GPUList = std::vector<VkPhysicalDevice>;
@@ -72,9 +72,8 @@ namespace Vulkan
 		static GPUNameList EnumerateGPUNames(VkInstance instance);
 
 		// Creates a new context and sets it up as global.
-		static bool Create(std::string_view gpu_name, const WindowInfo* wi, std::unique_ptr<SwapChain>* out_swap_chain,
-			VkPresentModeKHR preferred_present_mode, bool threaded_presentation, bool enable_debug_utils,
-			bool enable_validation_layer);
+		static bool Create(VkInstance instance, VkSurfaceKHR surface, VkPhysicalDevice physical_device,
+			bool threaded_presentation, bool enable_debug_utils, bool enable_validation_layer);
 
 		// Destroys context.
 		static void Destroy();
@@ -267,7 +266,7 @@ namespace Vulkan
 
 		using ExtensionList = std::vector<const char*>;
 		static bool SelectInstanceExtensions(
-			ExtensionList* extension_list, const WindowInfo* wi, bool enable_debug_utils);
+			ExtensionList* extension_list, const WindowInfo& wi, bool enable_debug_utils);
 		bool SelectDeviceExtensions(ExtensionList* extension_list, bool enable_surface);
 		bool SelectDeviceFeatures(const VkPhysicalDeviceFeatures* required_features);
 		bool CreateDevice(VkSurfaceKHR surface, bool enable_validation_layer, const char** required_device_extensions,

--- a/common/Vulkan/SwapChain.cpp
+++ b/common/Vulkan/SwapChain.cpp
@@ -569,8 +569,8 @@ namespace Vulkan
 		}
 
 		// Select swap chain flags, we only need a colour attachment
-		VkImageUsageFlags image_usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
-		if (!(surface_capabilities.supportedUsageFlags & VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT))
+		VkImageUsageFlags image_usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
+		if ((surface_capabilities.supportedUsageFlags & image_usage) != image_usage)
 		{
 			Console.Error("Vulkan: Swap chain does not support usage as color attachment");
 			return false;

--- a/pcsx2-gsrunner/Main.cpp
+++ b/pcsx2-gsrunner/Main.cpp
@@ -254,14 +254,8 @@ void Host::SetRelativeMouseMode(bool enabled)
 {
 }
 
-std::optional<WindowInfo> Host::AcquireRenderWindow()
+std::optional<WindowInfo> Host::AcquireRenderWindow(bool recreate_window)
 {
-	return GSRunner::GetPlatformWindowInfo();
-}
-
-std::optional<WindowInfo> Host::UpdateRenderWindow(bool recreate_window)
-{
-	// We shouldn't ever recreate with the runner, so this is okay..
 	return GSRunner::GetPlatformWindowInfo();
 }
 

--- a/pcsx2-qt/MainWindow.h
+++ b/pcsx2-qt/MainWindow.h
@@ -69,7 +69,7 @@ public:
 		void cancelResume();
 
 	private:
-		VMLock(QWidget* dialog_parent, bool was_paused, bool was_fullscreen);
+		VMLock(QWidget* dialog_parent, bool was_paused, bool was_exclusive_fullscreen);
 		friend MainWindow;
 
 		QWidget* m_dialog_parent;
@@ -122,11 +122,10 @@ public Q_SLOTS:
 private Q_SLOTS:
 	void onUpdateCheckComplete();
 
-	std::optional<WindowInfo> createDisplayWindow(bool fullscreen, bool render_to_main);
-	std::optional<WindowInfo> updateDisplayWindow(bool recreate_window, bool fullscreen, bool render_to_main, bool surfaceless);
+	std::optional<WindowInfo> acquireRenderWindow(bool recreate_window, bool fullscreen, bool render_to_main, bool surfaceless);
 	void displayResizeRequested(qint32 width, qint32 height);
 	void relativeMouseModeRequested(bool enabled);
-	void destroyDisplay();
+	void releaseRenderWindow();
 	void focusDisplayWidget();
 
 	void onGameListRefreshComplete();

--- a/pcsx2-qt/QtHost.h
+++ b/pcsx2-qt/QtHost.h
@@ -61,6 +61,7 @@ public:
 
 	__fi QEventLoop* getEventLoop() const { return m_event_loop; }
 	__fi bool isFullscreen() const { return m_is_fullscreen; }
+	__fi bool isExclusiveFullscreen() const { return m_is_exclusive_fullscreen; }
 	__fi bool isRenderingToMain() const { return m_is_rendering_to_main; }
 	__fi bool isSurfaceless() const { return m_is_surfaceless; }
 	__fi bool isRunningFullscreenUI() const { return m_run_fullscreen_ui; }
@@ -69,8 +70,7 @@ public:
 	bool shouldRenderToMain() const;
 
 	/// Called back from the GS thread when the display state changes (e.g. fullscreen, render to main).
-	std::optional<WindowInfo> acquireRenderWindow();
-	std::optional<WindowInfo> updateRenderWindow(bool recreate_window);
+	std::optional<WindowInfo> acquireRenderWindow(bool recreate_window);
 	void connectDisplaySignals(DisplayWidget* widget);
 	void releaseRenderWindow();
 
@@ -93,7 +93,7 @@ public Q_SLOTS:
 	void saveState(const QString& filename);
 	void saveStateToSlot(qint32 slot);
 	void toggleFullscreen();
-	void setFullscreen(bool fullscreen);
+	void setFullscreen(bool fullscreen, bool allow_render_to_main);
 	void setSurfaceless(bool surfaceless);
 	void applySettings();
 	void reloadGameSettings();
@@ -117,10 +117,9 @@ public Q_SLOTS:
 Q_SIGNALS:
 	bool messageConfirmed(const QString& title, const QString& message);
 
-	std::optional<WindowInfo> onCreateDisplayRequested(bool fullscreen, bool render_to_main);
-	std::optional<WindowInfo> onUpdateDisplayRequested(bool recreate_window, bool fullscreen, bool render_to_main, bool surfaceless);
-	void onResizeDisplayRequested(qint32 width, qint32 height);
-	void onDestroyDisplayRequested();
+	std::optional<WindowInfo> onAcquireRenderWindowRequested(bool recreate_window, bool fullscreen, bool render_to_main, bool surfaceless);
+	void onResizeRenderWindowRequested(qint32 width, qint32 height);
+	void onReleaseRenderWindowRequested();
 	void onRelativeMouseModeRequested(bool enabled);
 
 	/// Called when the VM is starting initialization, but has not been completed yet.
@@ -195,6 +194,7 @@ private:
 	bool m_run_fullscreen_ui = false;
 	bool m_is_rendering_to_main = false;
 	bool m_is_fullscreen = false;
+	bool m_is_exclusive_fullscreen = false;
 	bool m_is_surfaceless = false;
 	bool m_save_state_on_shutdown = false;
 	bool m_pause_on_focus_loss = false;

--- a/pcsx2/GS/GS.h
+++ b/pcsx2/GS/GS.h
@@ -99,6 +99,7 @@ void GSResizeDisplayWindow(int width, int height, float scale);
 void GSUpdateDisplayWindow();
 void GSSetVSyncMode(VsyncMode mode);
 
+bool GSWantsExclusiveFullscreen();
 bool GSGetHostRefreshRate(float* refresh_rate);
 void GSGetAdaptersAndFullscreenModes(
 	GSRendererType renderer, std::vector<std::string>* adapters, std::vector<std::string>* fullscreen_modes);
@@ -128,11 +129,8 @@ struct GSRecoverableError : GSError
 namespace Host
 {
 	/// Called when the GS is creating a render device.
-	std::optional<WindowInfo> AcquireRenderWindow();
-
-	/// Called on the MTGS thread when a request to update the display is received.
-	/// This could be a fullscreen transition, for example.
-	std::optional<WindowInfo> UpdateRenderWindow(bool recreate_window);
+	/// This could also be fullscreen transition.
+	std::optional<WindowInfo> AcquireRenderWindow(bool recreate_window);
 
 	/// Called before drawing the OSD and other display elements.
 	void BeginPresentFrame();

--- a/pcsx2/GS/Renderers/Common/GSDevice.h
+++ b/pcsx2/GS/Renderers/Common/GSDevice.h
@@ -779,6 +779,9 @@ protected:
 	bool m_rbswapped = false;
 	FeatureSupport m_features;
 
+	bool AcquireWindow(bool recreate_window);
+	void ReleaseWindow();
+
 	virtual GSTexture* CreateSurface(GSTexture::Type type, int width, int height, int levels, GSTexture::Format format) = 0;
 	GSTexture* FetchSurface(GSTexture::Type type, int width, int height, int levels, GSTexture::Format format, bool clear, bool prefer_reuse);
 
@@ -800,8 +803,8 @@ public:
 	/// Returns a string representing the specified API.
 	static const char* RenderAPIToString(RenderAPI api);
 
-	/// Parses a fullscreen mode into its components (width * height @ refresh hz)
-	static bool ParseFullscreenMode(const std::string_view& mode, u32* width, u32* height, float* refresh_rate);
+	/// Parses the configured fullscreen mode into its components (width * height @ refresh hz)
+	static bool GetRequestedExclusiveFullscreenMode(u32* width, u32* height, float* refresh_rate);
 
 	/// Converts a fullscreen mode to a string.
 	static std::string GetFullscreenModeString(u32 width, u32 height, float refresh_rate);
@@ -830,7 +833,7 @@ public:
 	/// Recreates the font, call when the window scaling changes.
 	bool UpdateImGuiFontTexture();
 
-	virtual bool Create(const WindowInfo& wi, VsyncMode vsync);
+	virtual bool Create();
 	virtual void Destroy();
 
 	/// Returns the graphics API used by this device.
@@ -843,19 +846,13 @@ public:
 	virtual void DestroySurface() = 0;
 
 	/// Switches to a new window/surface.
-	virtual bool ChangeWindow(const WindowInfo& wi) = 0;
+	virtual bool UpdateWindow() = 0;
 
 	/// Call when the window size changes externally to recreate any resources.
 	virtual void ResizeWindow(s32 new_window_width, s32 new_window_height, float new_window_scale) = 0;
 
 	/// Returns true if exclusive fullscreen is supported.
 	virtual bool SupportsExclusiveFullscreen() const = 0;
-
-	/// Returns true if exclusive fullscreen is active.
-	virtual bool IsExclusiveFullscreen() = 0;
-
-	/// Attempts to switch to the specified mode in exclusive fullscreen.
-	virtual bool SetExclusiveFullscreen(bool fullscreen, u32 width, u32 height, float refresh_rate) = 0;
 
 	/// Returns false if the window was completely occluded. If frame_skip is set, the frame won't be
 	/// displayed, but the GPU command queue will still be flushed.

--- a/pcsx2/GS/Renderers/DX11/D3D.h
+++ b/pcsx2/GS/Renderers/DX11/D3D.h
@@ -36,6 +36,10 @@ namespace D3D
 	// returns a list of fullscreen modes for the specified adapter
 	std::vector<std::string> GetFullscreenModes(IDXGIFactory5* factory, const std::string_view& adapter_name);
 
+	// returns the fullscreen mode to use for the specified dimensions
+	bool GetRequestedExclusiveFullscreenModeDesc(IDXGIFactory5* factory, const RECT& window_rect, u32 width, u32 height,
+		float refresh_rate, DXGI_FORMAT format, DXGI_MODE_DESC* fullscreen_mode, IDXGIOutput** output);
+
 	// get an adapter based on name
 	wil::com_ptr_nothrow<IDXGIAdapter1> GetAdapterByName(IDXGIFactory5* factory, const std::string_view& name);
 

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.h
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.h
@@ -120,8 +120,9 @@ private:
 
 	void SetFeatures();
 
-	bool CreateSwapChain(const DXGI_MODE_DESC* fullscreen_mode);
+	bool CreateSwapChain();
 	bool CreateSwapChainRTV();
+	void DestroySwapChain();
 
 	bool CreateTimestampQueries();
 	void DestroyTimestampQueries();
@@ -160,6 +161,7 @@ private:
 	bool m_allow_tearing_supported = false;
 	bool m_using_flip_model_swap_chain = true;
 	bool m_using_allow_tearing = false;
+	bool m_is_exclusive_fullscreen = false;
 
 	struct
 	{
@@ -281,16 +283,14 @@ public:
 	__fi ID3D11Device1* GetD3DDevice() const { return m_dev.get(); }
 	__fi ID3D11DeviceContext1* GetD3DContext() const { return m_ctx.get(); }
 
-	bool Create(const WindowInfo& wi, VsyncMode vsync) override;
+	bool Create() override;
 	void Destroy() override;
 
 	RenderAPI GetRenderAPI() const override;
 
-	bool ChangeWindow(const WindowInfo& new_wi) override;
+	bool UpdateWindow() override;
 	void ResizeWindow(s32 new_window_width, s32 new_window_height, float new_window_scale) override;
 	bool SupportsExclusiveFullscreen() const override;
-	bool IsExclusiveFullscreen() override;
-	bool SetExclusiveFullscreen(bool fullscreen, u32 width, u32 height, float refresh_rate) override;
 	bool HasSurface() const override;
 	void DestroySurface() override;
 	std::string GetDriverInfo() const override;

--- a/pcsx2/GS/Renderers/DX12/GSDevice12.h
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.h
@@ -145,6 +145,7 @@ private:
 
 	bool m_allow_tearing_supported = false;
 	bool m_using_allow_tearing = false;
+	bool m_is_exclusive_fullscreen = false;
 	bool m_device_lost = false;
 
 	ComPtr<ID3D12RootSignature> m_tfx_root_signature;
@@ -191,9 +192,10 @@ private:
 
 	void LookupNativeFormat(GSTexture::Format format, DXGI_FORMAT* d3d_format, DXGI_FORMAT* srv_format, DXGI_FORMAT* rtv_format, DXGI_FORMAT* dsv_format) const;
 
-	bool CreateSwapChain(const DXGI_MODE_DESC* fullscreen_mode);
+	bool CreateSwapChain();
 	bool CreateSwapChainRTV();
 	void DestroySwapChainRTVs();
+	void DestroySwapChain();
 
 	GSTexture* CreateSurface(GSTexture::Type type, int width, int height, int levels, GSTexture::Format format) override;
 
@@ -243,14 +245,12 @@ public:
 	RenderAPI GetRenderAPI() const override;
 	bool HasSurface() const override;
 
-	bool Create(const WindowInfo& wi, VsyncMode vsync) override;
+	bool Create() override;
 	void Destroy() override;
 
-	bool ChangeWindow(const WindowInfo& new_wi) override;
+	bool UpdateWindow() override;
 	void ResizeWindow(s32 new_window_width, s32 new_window_height, float new_window_scale) override;
 	bool SupportsExclusiveFullscreen() const override;
-	bool IsExclusiveFullscreen() override;
-	bool SetExclusiveFullscreen(bool fullscreen, u32 width, u32 height, float refresh_rate) override;
 	void DestroySurface() override;
 	std::string GetDriverInfo() const override;
 

--- a/pcsx2/GS/Renderers/Metal/GSDeviceMTL.h
+++ b/pcsx2/GS/Renderers/Metal/GSDeviceMTL.h
@@ -378,7 +378,7 @@ public:
 	MRCOwned<id<MTLFunction>> LoadShader(NSString* name);
 	MRCOwned<id<MTLRenderPipelineState>> MakePipeline(MTLRenderPipelineDescriptor* desc, id<MTLFunction> vertex, id<MTLFunction> fragment, NSString* name);
 	MRCOwned<id<MTLComputePipelineState>> MakeComputePipeline(id<MTLFunction> compute, NSString* name);
-	bool Create(const WindowInfo& wi, VsyncMode vsync) override;
+	bool Create() override;
 	void Destroy() override;
 
 	void AttachSurfaceOnMainThread();
@@ -387,10 +387,8 @@ public:
 	RenderAPI GetRenderAPI() const override;
 	bool HasSurface() const override;
 	void DestroySurface() override;
-	bool ChangeWindow(const WindowInfo& wi) override;
+	bool UpdateWindow() override;
 	bool SupportsExclusiveFullscreen() const override;
-	bool IsExclusiveFullscreen() override;
-	bool SetExclusiveFullscreen(bool fullscreen, u32 width, u32 height, float refresh_rate) override;
 	std::string GetDriverInfo() const override;
 
 	void ResizeWindow(s32 new_window_width, s32 new_window_height, float new_window_scale) override;

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.h
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.h
@@ -262,6 +262,7 @@ private:
 
 	bool CreateImGuiProgram();
 	void RenderImGui();
+	void RenderBlankFrame();
 
 	void OMAttachRt(GSTextureOGL* rt = nullptr);
 	void OMAttachDs(GSTextureOGL* ds = nullptr);
@@ -286,14 +287,12 @@ public:
 	RenderAPI GetRenderAPI() const override;
 	bool HasSurface() const override;
 
-	bool Create(const WindowInfo& wi, VsyncMode vsync) override;
+	bool Create() override;
 	void Destroy() override;
 
-	bool ChangeWindow(const WindowInfo& new_wi) override;
+	bool UpdateWindow() override;
 	void ResizeWindow(s32 new_window_width, s32 new_window_height, float new_window_scale) override;
 	bool SupportsExclusiveFullscreen() const override;
-	bool IsExclusiveFullscreen() override;
-	bool SetExclusiveFullscreen(bool fullscreen, u32 width, u32 height, float refresh_rate) override;
 	void DestroySurface() override;
 	std::string GetDriverInfo() const override;
 

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h
@@ -190,6 +190,7 @@ private:
 	VkShaderModule GetUtilityVertexShader(const std::string& source, const char* replace_main);
 	VkShaderModule GetUtilityFragmentShader(const std::string& source, const char* replace_main);
 
+	bool CreateDeviceAndSwapChain();
 	bool CheckFeatures();
 	bool CreateNullTexture();
 	bool CreateBuffers();
@@ -205,6 +206,7 @@ private:
 
 	bool CompileImGuiPipeline();
 	void RenderImGui();
+	void RenderBlankFrame();
 
 	void DestroyResources();
 
@@ -230,14 +232,12 @@ public:
 	RenderAPI GetRenderAPI() const override;
 	bool HasSurface() const override;
 
-	bool Create(const WindowInfo& wi, VsyncMode vsync) override;
+	bool Create() override;
 	void Destroy() override;
 
-	bool ChangeWindow(const WindowInfo& new_wi) override;
+	bool UpdateWindow() override;
 	void ResizeWindow(s32 new_window_width, s32 new_window_height, float new_window_scale) override;
 	bool SupportsExclusiveFullscreen() const override;
-	bool IsExclusiveFullscreen() override;
-	bool SetExclusiveFullscreen(bool fullscreen, u32 width, u32 height, float refresh_rate) override;
 	void DestroySurface() override;
 	std::string GetDriverInfo() const override;
 

--- a/tests/ctest/core/StubHost.cpp
+++ b/tests/ctest/core/StubHost.cpp
@@ -105,12 +105,7 @@ void Host::SetRelativeMouseMode(bool enabled)
 {
 }
 
-std::optional<WindowInfo> Host::AcquireRenderWindow()
-{
-	return std::nullopt;
-}
-
-std::optional<WindowInfo> Host::UpdateRenderWindow(bool recreate_window)
+std::optional<WindowInfo> Host::AcquireRenderWindow(bool recreate_window)
 {
 	return std::nullopt;
 }


### PR DESCRIPTION
### Description of Changes

Hopefully for the last time?

To switch out of fullscreen when displaying a popup, or not to?
For Windows, with driver's direct scanout, what renders behind tends to be hit and miss.
We can't draw anything over exclusive fullscreen, so get out of it in that case.
Wayland's a pain as usual, we need to recreate the window, which means there'll be a brief period when there's no window, and Qt might shut us down. So avoid it there.
On MacOS, it forces a workspace switch, which is kinda jarring.

Refactors GS startup to present a blank frame as soon as possible. That way the grey screen instead of the game list getting left over isn't displayed for as long.

### Rationale behind Changes

Closes #8709.
Closes #8704.

### Suggested Testing Steps

Hammer the heck out of fullscreen in DX11 and 12, GL or Vulkan.
