### PR TITLE
GS-HW: Fix std::sort comparator for purging hash cache

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -3747,7 +3747,7 @@ void GSTextureCache::AgeHashCache()
 	if (might_need_cache_purge)
 	{
 		std::sort(s_hash_cache_purge_list.begin(), s_hash_cache_purge_list.end(),
-			[](const auto& lhs, const auto& rhs) { return lhs.second - rhs.second; });
+			[](const auto& lhs, const auto& rhs) { return lhs.second > rhs.second; });
 
 		const u32 entries_to_purge = std::min(static_cast<u32>(m_hash_cache.size() - MAX_HASH_CACHE_SIZE),
 			static_cast<u32>(s_hash_cache_purge_list.size()));


### PR DESCRIPTION
### Description of Changes
Fixes the comparator for std::sort when purging the hash cache

### Rationale behind Changes
It wasn't passing back correct values before (should be true/false). Black FMV's were crashing on linux because it couldn't handle it, windows just YOLO'd it.

### Suggested Testing Steps
Test Black works on linux, check other games don't explode hash cache.
