### PR TITLE
GS/HW: Fix pipeline/shader duplication

### DIFF
--- a/pcsx2/GS/Renderers/Common/GSDevice.h
+++ b/pcsx2/GS/Renderers/Common/GSDevice.h
@@ -264,6 +264,7 @@ struct alignas(16) GSHWDrawConfig
 		/// Returns true if the fixed index buffer should be used.
 		__fi bool UseExpandIndexBuffer() const { return (expand == VSExpand::Point || expand == VSExpand::Sprite); }
 	};
+	static_assert(sizeof(VSSelector) == 1, "VSSelector is a single byte");
 #pragma pack(pop)
 #pragma pack(push, 4)
 	struct PSSelector
@@ -382,6 +383,7 @@ struct alignas(16) GSHWDrawConfig
 			no_color = no_color1 = 1;
 		}
 	};
+	static_assert(sizeof(PSSelector) == 12, "PSSelector is 12 bytes");
 #pragma pack(pop)
 	struct PSSelectorHash
 	{

--- a/pcsx2/GS/Renderers/DX12/GSDevice12.h
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.h
@@ -51,15 +51,16 @@ public:
 			u32 key;
 		};
 
+		GSHWDrawConfig::BlendState bs;
 		GSHWDrawConfig::VSSelector vs;
 		GSHWDrawConfig::DepthStencilSelector dss;
 		GSHWDrawConfig::ColorMaskSelector cms;
-		GSHWDrawConfig::BlendState bs;
+		u8 pad;
 
-		__fi bool operator==(const PipelineSelector& p) const { return (memcmp(this, &p, sizeof(p)) == 0); }
-		__fi bool operator!=(const PipelineSelector& p) const { return (memcmp(this, &p, sizeof(p)) != 0); }
+		__fi bool operator==(const PipelineSelector& p) const { return BitEqual(*this, p); }
+		__fi bool operator!=(const PipelineSelector& p) const { return !BitEqual(*this, p); }
 
-		__fi PipelineSelector() { memset(this, 0, sizeof(*this)); }
+		__fi PipelineSelector() { std::memset(this, 0, sizeof(*this)); }
 	};
 	static_assert(sizeof(PipelineSelector) == 24, "Pipeline selector is 24 bytes");
 

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -2396,7 +2396,7 @@ void GSDeviceOGL::RenderHW(GSHWDrawConfig& config)
 	psel.vs = config.vs;
 	psel.ps.key_hi = config.ps.key_hi;
 	psel.ps.key_lo = config.ps.key_lo;
-	psel.pad = 0;
+	std::memset(psel.pad, 0, sizeof(psel.pad));
 
 	SetupPipeline(psel);
 

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.h
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.h
@@ -130,10 +130,10 @@ public:
 	{
 		PSSelector ps;
 		VSSelector vs;
-		u16 pad;
+		u8 pad[3];
 
-		__fi bool operator==(const ProgramSelector& p) const { return (std::memcmp(this, &p, sizeof(*this)) == 0); }
-		__fi bool operator!=(const ProgramSelector& p) const { return (std::memcmp(this, &p, sizeof(*this)) != 0); }
+		__fi bool operator==(const ProgramSelector& p) const { return BitEqual(*this, p); }
+		__fi bool operator!=(const ProgramSelector& p) const { return !BitEqual(*this, p); }
 	};
 	static_assert(sizeof(ProgramSelector) == 16, "Program selector is 16 bytes");
 

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h
@@ -57,15 +57,16 @@ public:
 			u32 key;
 		};
 
+		GSHWDrawConfig::BlendState bs;
 		GSHWDrawConfig::VSSelector vs;
 		GSHWDrawConfig::DepthStencilSelector dss;
 		GSHWDrawConfig::ColorMaskSelector cms;
-		GSHWDrawConfig::BlendState bs;
+		u8 pad;
 
-		__fi bool operator==(const PipelineSelector& p) const { return (memcmp(this, &p, sizeof(p)) == 0); }
-		__fi bool operator!=(const PipelineSelector& p) const { return (memcmp(this, &p, sizeof(p)) != 0); }
+		__fi bool operator==(const PipelineSelector& p) const { return BitEqual(*this, p); }
+		__fi bool operator!=(const PipelineSelector& p) const { return !BitEqual(*this, p); }
 
-		__fi PipelineSelector() { memset(this, 0, sizeof(*this)); }
+		__fi PipelineSelector() { std::memset(this, 0, sizeof(*this)); }
 
 		__fi bool IsRTFeedbackLoop() const { return ((feedback_loop_flags & FeedbackLoopFlag_ReadAndWriteRT) != 0); }
 		__fi bool IsTestingAndSamplingDepth() const { return ((feedback_loop_flags & FeedbackLoopFlag_ReadDS) != 0); }

--- a/pcsx2/ShaderCacheVersion.h
+++ b/pcsx2/ShaderCacheVersion.h
@@ -15,4 +15,4 @@
 
 /// Version number for GS and other shaders. Increment whenever any of the contents of the
 /// shaders change, to invalidate the cache.
-static constexpr u32 SHADER_CACHE_VERSION = 24;
+static constexpr u32 SHADER_CACHE_VERSION = 25;


### PR DESCRIPTION
### Description of Changes

Programs/pipelines were duplicating due to padding bits, most noticeable in OpenGL.

### Rationale behind Changes

Regression from #8613.

### Suggested Testing Steps

@JordanTheToaster knows what to do.