### PR TITLE
Debugger: Fix a few breakpoint and memorycheck issues

### DIFF
--- a/pcsx2-qt/Debugger/Models/BreakpointModel.cpp
+++ b/pcsx2-qt/Debugger/Models/BreakpointModel.cpp
@@ -319,8 +319,12 @@ bool BreakpointModel::insertBreakpointRows(int row, int count, std::vector<Break
 	if (breakpoints.size() != static_cast<size_t>(count))
 		return false;
 
-	beginInsertRows(index, row, row + count);
+	beginInsertRows(index, row, row + (count - 1));
 
+	// After endInsertRows, Qt will try and validate our new rows
+	// Because we add the breakpoints off of the UI thread, our new rows may not be visible yet
+	// To prevent the (seemingly harmless?) warning emitted by enderInsertRows, add the breakpoints manually here as well
+	m_breakpoints.insert(m_breakpoints.begin(), breakpoints.begin(), breakpoints.end());
 	for (const auto& bp_mc : breakpoints)
 	{
 		if (const auto* bp = std::get_if<BreakPoint>(&bp_mc))

--- a/pcsx2/Interpreter.cpp
+++ b/pcsx2/Interpreter.cpp
@@ -56,7 +56,7 @@ void intBreakpoint(bool memcheck)
 
 	CBreakPoints::SetBreakpointTriggered(true);
 	VMManager::SetPaused(true);
-	throw Exception::ExitCpuExecute();
+	Cpu->ExitExecution();
 }
 
 void intMemcheck(u32 op, u32 bits, bool store)

--- a/pcsx2/x86/iR3000A.cpp
+++ b/pcsx2/x86/iR3000A.cpp
@@ -1388,7 +1388,18 @@ static void psxRecMemcheck(u32 op, u32 bits, bool store)
 		if (checks[i].result & MEMCHECK_LOG)
 		{
 			xMOV(edx, store);
-			xFastCall((void*)psxDynarecMemLogcheck, ecx, edx);
+
+			// Refer to the EE recompiler for an explaination
+			if(!(checks[i].result & MEMCHECK_BREAK))
+			{
+				xPUSH(eax); xPUSH(ebx); xPUSH(ecx); xPUSH(edx);
+				xFastCall((void*)psxDynarecMemLogcheck, ecx, edx);
+				xPOP(edx); xPOP(ecx); xPOP(ebx); xPOP(eax);
+			}
+			else
+			{
+				xFastCall((void*)psxDynarecMemLogcheck, ecx, edx);
+			}
 		}
 		if (checks[i].result & MEMCHECK_BREAK)
 		{


### PR DESCRIPTION
### Description of Changes
Fixes memory checks for both the IOP and EE recompiler when n > 1 and one or more **only** log.
This would cause an issue where the first memory check would log, then the second would trigger because the opcode target address and size would be clobbered. 

Fixes a warning when breakpoints or memory checks are added. The insert logic was incorrect and didn't account for multi-thread latency. (This had no known side effect besides the runtime warning)

Fixes EE interpreter breakpoints and memory checks. I assume the exception changes that have happened lately were the cause of this. In essence; there was an uncaught exception being thrown.
This would cause a SIGTERM and crash.

I ask that @stenzek verify that calling `Cpu->ExitExecution();` in that context is the correct approach.
### Suggested Testing Steps
Test memory checks and breakpoints on the IOP and EE. Both with the interpreter and recompiler (interpreter requires a dev build).
