### PR TITLE
ci: Update labeler debugger directories

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -39,8 +39,8 @@
 'Debugger':
   - 'pcsx2/DebugTools/*'
   - 'pcsx2/DebugTools/**/*'
-  - 'pcsx2/gui/Debugger/*'
-  - 'pcsx2/gui/Debugger/**/*'
+  - 'pcsx2-qt/Debugger/*'
+  - 'pcsx2-qt/Debugger/**/*'
 'IPC':
   - 'pcsx2/IPC*'
   - 'pcsx2/**/IPC*'


### PR DESCRIPTION
They changed when we moved to QT