### PR TITLE
GS/HW: Texture cache regression fixes

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -802,11 +802,11 @@ bool GSRendererHW::IsSplitTextureShuffle()
 	// For texture shuffles, the U will be offset by 8.
 	const GSLocalMemory::psm_t& frame_psm = GSLocalMemory::m_psm[m_cached_ctx.FRAME.PSM];
 
-	const GSVector4i pos_rc = GSVector4i(m_vt.m_min.p.upld(m_vt.m_max.p));
+	const GSVector4i pos_rc = GSVector4i(m_vt.m_min.p.upld(m_vt.m_max.p + GSVector4::cxpr(0.5f)));
 	const GSVector4i tex_rc = GSVector4i(m_vt.m_min.t.upld(m_vt.m_max.t));
 
 	// Width/height should match.
-	if (pos_rc.width() != tex_rc.width() || pos_rc.height() != tex_rc.height())
+	if (std::abs(pos_rc.width() - tex_rc.width()) > 8 || pos_rc.height() != tex_rc.height())
 		return false;
 
 	// X might be offset by up to -8/+8, but either the position or UV should be aligned.
@@ -865,7 +865,7 @@ bool GSRendererHW::IsSplitTextureShuffle()
 GSVector4i GSRendererHW::GetSplitTextureShuffleDrawRect() const
 {
 	const GSLocalMemory::psm_t& frame_psm = GSLocalMemory::m_psm[m_cached_ctx.FRAME.PSM];
-	GSVector4i r = GSVector4i(m_vt.m_min.p.upld(m_vt.m_max.p)).rintersect(GSVector4i(m_context->scissor.in));
+	GSVector4i r = GSVector4i(m_vt.m_min.p.upld(m_vt.m_max.p + GSVector4::cxpr(0.5f))).rintersect(GSVector4i(m_context->scissor.in));
 
 	// Some games (e.g. Crash Twinsanity) adjust both FBP and TBP0, so the rectangle will be half the size
 	// of the actual shuffle. Others leave the FBP alone, but only adjust TBP0, and offset the draw rectangle

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -1524,7 +1524,6 @@ void GSRendererHW::Draw()
 			GL_CACHE("Disabling Z buffer because all tests will pass.");
 
 		m_cached_ctx.TEST.ZTST = ZTST_ALWAYS;
-		m_cached_ctx.ZBUF.ZMSK = true;
 	}
 
 	if (no_rt && no_ds)
@@ -2512,9 +2511,9 @@ void GSRendererHW::SetupIA(float target_scale, float sx, float sy)
 	m_conf.nindices = m_index.tail;
 }
 
-void GSRendererHW::EmulateZbuffer()
+void GSRendererHW::EmulateZbuffer(const GSTextureCache::Target* ds)
 {
-	if (m_cached_ctx.TEST.ZTE)
+	if (ds && m_cached_ctx.TEST.ZTE)
 	{
 		m_conf.depth.ztst = m_cached_ctx.TEST.ZTST;
 		// AA1: Z is not written on lines since coverage is always less than 0x80.
@@ -4188,7 +4187,7 @@ __ri void GSRendererHW::DrawPrims(GSTextureCache::Target* rt, GSTextureCache::Ta
 	m_conf.ds = ds ? ds->m_texture : nullptr;
 
 	// Z setup has to come before channel shuffle
-	EmulateZbuffer();
+	EmulateZbuffer(ds);
 
 	// HLE implementation of the channel selection effect
 	//

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.h
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.h
@@ -86,7 +86,7 @@ private:
 		bool& target_region, GSVector2i& unscaled_size, float& scale, GSTexture*& src_copy);
 	bool CanUseTexIsFB(const GSTextureCache::Target* rt, const GSTextureCache::Source* tex) const;
 
-	void EmulateZbuffer();
+	void EmulateZbuffer(const GSTextureCache::Target* ds);
 	void EmulateATST(float& AREF, GSHWDrawConfig::PSSelector& ps, bool pass_2);
 
 	void SetTCOffset();

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -2519,7 +2519,8 @@ bool GSTextureCache::Move(u32 SBP, u32 SBW, u32 SPSM, int sx, int sy, u32 DBP, u
 	// Make sure the copy doesn't go out of bounds (it shouldn't).
 	if ((scaled_dx + scaled_w) > dst->m_texture->GetWidth() || (scaled_dy + scaled_h) > dst->m_texture->GetHeight())
 		return false;
-	GL_CACHE("HW Move 0x%x to 0x%x <%d,%d->%d,%d> -> <%d,%d->%d,%d>", SBP, DBP, sx, sy, sx + w, sy, h, dx, dy, dx + w, dy + h);
+	GL_CACHE("HW Move 0x%x[BW:%u PSM:%s] to 0x%x[BW:%u PSM:%s] <%d,%d->%d,%d> -> <%d,%d->%d,%d>", SBP, SBW,
+		psm_str(SPSM), DBP, DBW, psm_str(DPSM), sx, sy, sx + w, sy + h, dx, dy, dx + w, dy + h);
 	g_gs_device->CopyRect(src->m_texture, dst->m_texture,
 		GSVector4i(scaled_sx, scaled_sy, scaled_sx + scaled_w, scaled_sy + scaled_h),
 		scaled_dx, scaled_dy);

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.h
@@ -444,8 +444,8 @@ public:
 		bool is_frame = false, bool is_clear = false, bool preload = GSConfig.PreloadFrameWithGSData);
 	Target* LookupDisplayTarget(GIFRegTEX0 TEX0, const GSVector2i& size, float scale);
 
-	/// Looks up a target in the cache, and only returns it if the BP/BW/PSM match exactly.
-	Target* GetExactTarget(u32 BP, u32 BW, u32 PSM) const;
+	/// Looks up a target in the cache, and only returns it if the BP/BW match exactly.
+	Target* GetExactTarget(u32 BP, u32 BW, int type);
 	Target* GetTargetWithSharedBits(u32 BP, u32 PSM) const;
 
 	GSVector2i GetTargetSize(u32 bp, u32 fbw, u32 psm, s32 min_width, s32 min_height);


### PR DESCRIPTION
### Description of Changes

Tokyo Xtreme Racer Zero does C32 moves from previously-rendered-as Z32 targets, but with one of them being C32 because it cleared it..

DBZ BT3 PAL offsets its shuffle position by 8 without pushing the texture coordinates out, which failed the current size check. The upper Y bound of the coordinates are also -0.5 what they should be.

### Rationale behind Changes

Closes #8694.
Closes #8691.

### Suggested Testing Steps

Check affected games. Runner says everything else seems to be okay.