### PR TITLE
GS: Fix crash when looking up color textures with depth lookups

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -550,7 +550,10 @@ GSTextureCache::Source* GSTextureCache::LookupDepthSource(const GIFRegTEX0& TEX0
 
 	const SourceRegion region = SourceRegion::Create(TEX0, CLAMP);
 	const GSLocalMemory::psm_t& psm_s = GSLocalMemory::m_psm[TEX0.PSM];
-	Source* src = FindSourceInMap(TEX0, TEXA, psm_s, nullptr, nullptr, GSVector2i(0, 0), region,
+	// Yes, this can get called with color PSMs that have palettes
+	const u32* const clut = g_gs_renderer->m_mem.m_clut;
+	GSTexture* const gpu_clut = (psm_s.pal > 0) ? g_gs_renderer->m_mem.m_clut.GetGPUTexture() : nullptr;
+	Source* src = FindSourceInMap(TEX0, TEXA, psm_s, clut, gpu_clut, GSVector2i(0, 0), region,
 		region.IsFixedTEX0(TEX0), m_src.m_map[TEX0.TBP0 >> 5]);
 	if (src)
 	{


### PR DESCRIPTION
### Description of Changes
Fix a crash in MGS2

@stenzek I'm not sure if letting it through like this is the correct thing to do.  The call stack is
https://github.com/PCSX2/pcsx2/blob/aa9a0dca4bc81f0addcc9b544c53eb55e7ae2a47/pcsx2/GS/Renderers/HW/GSTextureCache.cpp#L1076
https://github.com/PCSX2/pcsx2/blob/aa9a0dca4bc81f0addcc9b544c53eb55e7ae2a47/pcsx2/GS/Renderers/HW/GSTextureCache.cpp#L553-L554

Can you confirm/deny if this is the right way to handle it?

Edit: I was being dumb, I can just pass the clut info in from the depth lookup function too

### Rationale behind Changes
Less crash yay

### Suggested Testing Steps
Test [this GSdump](https://tellowkrinkle.com/dl/MGS2Crash.gs.xz) (warning: 92MB compressed, 2GB uncompressed)
