### PR TITLE
GS/HW: Detect clears spanning multiple sprites

### DIFF
--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -388,6 +388,40 @@ float GSState::GetTvRefreshRate()
 	__assume(0); // unreachable
 }
 
+const char* GSState::GetFlushReasonString(GSFlushReason reason)
+{
+	switch (reason)
+	{
+		case GSFlushReason::RESET:
+			return "RESET";
+		case GSFlushReason::CONTEXTCHANGE:
+			return "CONTEXT CHANGE";
+		case GSFlushReason::CLUTCHANGE:
+			return "CLUT CHANGE (RELOAD REQ)";
+		case GSFlushReason::GSTRANSFER:
+			return "GS TRANSFER";
+		case GSFlushReason::UPLOADDIRTYTEX:
+			return "GS UPLOAD OVERWRITES CURRENT TEXTURE OR CLUT";
+		case GSFlushReason::LOCALTOLOCALMOVE:
+			return "GS LOCAL TO LOCAL OVERWRITES CURRENT TEXTURE OR CLUT";
+		case GSFlushReason::DOWNLOADFIFO:
+			return "DOWNLOAD FIFO";
+		case GSFlushReason::SAVESTATE:
+			return "SAVESTATE";
+		case GSFlushReason::LOADSTATE:
+			return "LOAD SAVESTATE";
+		case GSFlushReason::AUTOFLUSH:
+			return "AUTOFLUSH OVERLAP DETECTED";
+		case GSFlushReason::VSYNC:
+			return "VSYNC";
+		case GSFlushReason::GSREOPEN:
+			return "GS REOPEN";
+		case GSFlushReason::UNKNOWN:
+		default:
+			return "UNKNOWN";
+	}
+}
+
 void GSState::DumpVertices(const std::string& filename)
 {
 	std::ofstream file(filename);
@@ -395,51 +429,7 @@ void GSState::DumpVertices(const std::string& filename)
 	if (!file.is_open())
 		return;
 
-	file << "FLUSH REASON: ";
-
-	switch (m_state_flush_reason)
-	{
-		case GSFlushReason::RESET:
-			file << "RESET";
-			break;
-		case GSFlushReason::CONTEXTCHANGE:
-			file << "CONTEXT CHANGE";
-			break;
-		case GSFlushReason::CLUTCHANGE:
-			file << "CLUT CHANGE (RELOAD REQ)";
-			break;
-		case GSFlushReason::GSTRANSFER:
-			file << "GS TRANSFER";
-			break;
-		case GSFlushReason::UPLOADDIRTYTEX:
-			file << "GS UPLOAD OVERWRITES CURRENT TEXTURE OR CLUT";
-			break;
-		case GSFlushReason::LOCALTOLOCALMOVE:
-			file << "GS LOCAL TO LOCAL OVERWRITES CURRENT TEXTURE OR CLUT";
-			break;
-		case GSFlushReason::DOWNLOADFIFO:
-			file << "DOWNLOAD FIFO";
-			break;
-		case GSFlushReason::SAVESTATE:
-			file << "SAVESTATE";
-			break;
-		case GSFlushReason::LOADSTATE:
-			file << "LOAD SAVESTATE";
-			break;
-		case GSFlushReason::AUTOFLUSH:
-			file << "AUTOFLUSH OVERLAP DETECTED";
-			break;
-		case GSFlushReason::VSYNC:
-			file << "VSYNC";
-			break;
-		case GSFlushReason::GSREOPEN:
-			file << "GS REOPEN";
-			break;
-		case GSFlushReason::UNKNOWN:
-		default:
-			file << "UNKNOWN";
-			break;
-	}
+	file << "FLUSH REASON: " << GetFlushReasonString(m_state_flush_reason);
 
 	if (m_state_flush_reason != GSFlushReason::CONTEXTCHANGE && m_dirty_gs_regs)
 		file << " AND POSSIBLE CONTEXT CHANGE";

--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -870,6 +870,9 @@ public:
 	/// Expands dither matrix, suitable for software renderer.
 	static void ExpandDIMX(GSVector4i* dimx, const GIFRegDIMX DIMX);
 
+	/// Returns a string representing the flush reason.
+	static const char* GetFlushReasonString(GSFlushReason reason);
+
 	void ResetHandlers();
 	void ResetPCRTC();
 

--- a/pcsx2/GS/Renderers/HW/GSHwHack.cpp
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.cpp
@@ -1111,7 +1111,7 @@ bool GSHwHack::OI_HauntingGround(GSRendererHW& r, GSTexture* rt, GSTexture* ds, 
 {
 	// Haunting Ground clears two targets by doing a 256x448 direct colour write at 0x3000, covering a target at 0x3380.
 	// This currently isn't handled in our HLE clears, so we need to manually remove the other target.
-	if (rt && !ds && !t && r.IsConstantDirectWriteMemClear(true))
+	if (rt && !ds && !t && r.IsConstantDirectWriteMemClear())
 	{
 		GL_CACHE("GSHwHack::OI_HauntingGround()");
 		g_texture_cache->InvalidateVideoMemTargets(GSTextureCache::RenderTarget, RFRAME.Block(), RFRAME.FBW, RFRAME.PSM, r.m_r);

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -1433,6 +1433,9 @@ void GSRendererHW::Draw()
 	}
 
 	GL_PUSH("HW Draw %d (Context %u)", s_n, PRIM->CTXT);
+	GL_INS("FLUSH REASON: %s%s", GetFlushReasonString(m_state_flush_reason),
+		(m_state_flush_reason != GSFlushReason::CONTEXTCHANGE && m_dirty_gs_regs) ? " AND POSSIBLE CONTEXT CHANGE" :
+																					"");
 
 	// When the format is 24bit (Z or C), DATE ceases to function.
 	// It was believed that in 24bit mode all pixels pass because alpha doesn't exist

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.h
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.h
@@ -54,6 +54,7 @@ private:
 	bool CanUseSwSpriteRender();
 	bool IsConstantDirectWriteMemClear();
 	bool IsBlendedOrOpaque();
+	bool PrimitiveCoversWithoutGaps() const;
 
 	enum class CLUTDrawTestResult
 	{

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.h
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.h
@@ -52,7 +52,7 @@ private:
 	float alpha1(int L, int X0, int X1);
 	void SwSpriteRender();
 	bool CanUseSwSpriteRender();
-	bool IsConstantDirectWriteMemClear(bool include_zero);
+	bool IsConstantDirectWriteMemClear();
 	bool IsBlendedOrOpaque();
 
 	enum class CLUTDrawTestResult


### PR DESCRIPTION
### Description of Changes

GT4 clears the entirety of GS memory shortly after startup with a 1024x1024 draw, but it's split over several sprites, so the current detection doesn't pick it up.

Same with its framebuffer clears. So let's detect it and handle accordingly.

Also makes the blur effect in Midnight Club 3 not so overly exaggerated. Obviously it's still semi-broken, because it's page offset evilness, but if you compared it to software, it was much more obvious than it should have been.. because it was loading garbage from local memory which should've been cleared.

### Rationale behind Changes

Stops the target size and VRAM usage blowing out.

### Suggested Testing Steps

Check GT4 VRAM usage.  @JordanTheToaster knows how to reproduce it.

Test Splinter Cell Double Agent. It showed up in the runner, but only on frame 1, so might just be a false positive.