### PR TITLE
GS/Vulkan: Make primid not require barycentric extension

### DIFF
--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
@@ -684,12 +684,14 @@ bool GSDeviceVK::CheckFeatures()
 	m_features.framebuffer_fetch = g_vulkan_context->GetOptionalExtensions().vk_ext_rasterization_order_attachment_access && !GSConfig.DisableFramebufferFetch;
 	m_features.texture_barrier = GSConfig.OverrideTextureBarriers != 0;
 	m_features.broken_point_sampler = isAMD;
-	// Usually, geometry shader indicates primid support
-	// However on Metal (MoltenVK), geometry shader is never available, but primid sometimes is
+#ifdef __APPLE__
+	// On Metal (MoltenVK), primid is sometimes available, but broken on some older GPUs and MacOS versions.
 	// Officially, it's available on GPUs that support barycentric coordinates (Newer AMD and Apple)
 	// Unofficially, it seems to work on older Intel GPUs (but breaks other things on newer Intel GPUs, see GSMTLDeviceInfo.mm for details)
-	// We'll only enable for the officially supported GPUs here.  We'll leave in the option of force-enabling it with OverrideGeometryShaders though.
-	m_features.primitive_id = features.geometryShader || g_vulkan_context->GetOptionalExtensions().vk_khr_fragment_shader_barycentric;
+	m_features.primitive_id = g_vulkan_context->GetOptionalExtensions().vk_khr_fragment_shader_barycentric;
+#else
+	m_features.primitive_id = true;
+#endif
 	m_features.prefer_new_textures = true;
 	m_features.provoking_vertex_last = g_vulkan_context->GetOptionalExtensions().vk_ext_provoking_vertex;
 	m_features.dual_source_blend = features.dualSrcBlend && !GSConfig.DisableDualSourceBlend;


### PR DESCRIPTION
### Description of Changes

My Intel A750 GPU apparently doesn't support `VK_KHR_fragment_shader_barycentric`, and since we removed geometry shaders completely, resulted in primid not being enabled.

Which lead GT4 to issue thousands of barriers, for DATE.

Based on what I read from Tellow's notes, it seems the combination of older GPUs and drivers is broken on Macs? So I left the barycentric extension intact, but only for MacOS.

### Rationale behind Changes

Fixes GT4 struggling even at 1x on Arc.

### Suggested Testing Steps

I've tested it fixes the issue. Don't think anyone else has an Arc GPU :-)
