### PR TITLE
GameDB: Tony Hawk's post-processing fixes

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -7276,6 +7276,9 @@ SCUS-21295:
   compat: 5
   roundModes:
     vu1RoundMode: 0 # Crashes without.
+  gsHWFixes:
+    wildArmsHack: 1 # Reduces post-processing misalignment.
+    mergeSprite: 1 # Reduces post-processing misalignment.
 SCUS-21494:
   name: "Need for Speed - Carbon Collector's Edition"
   region: "NTSC-U"
@@ -15751,6 +15754,8 @@ SLES-52621:
     recommendedBlendingLevel: 3 # Fixes water and grass textures.
     mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
     trilinearFiltering: 1
+    wildArmsHack: 1 # Reduces post-processing misalignment.
+    mergeSprite: 1 # Reduces post-processing misalignment.
 SLES-52622:
   name: "Tony Hawk's Underground 2"
   region: "PAL-M4"
@@ -15760,6 +15765,8 @@ SLES-52622:
     recommendedBlendingLevel: 3 # Fixes water and grass textures.
     mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
     trilinearFiltering: 1
+    wildArmsHack: 1 # Reduces post-processing misalignment.
+    mergeSprite: 1 # Reduces post-processing misalignment.
 SLES-52624:
   name: "X-Men Legends"
   region: "PAL-E"
@@ -18121,11 +18128,17 @@ SLES-53534:
   compat: 5
   roundModes:
     vu1RoundMode: 0 # Crashes without.
+  gsHWFixes:
+    wildArmsHack: 1 # Reduces post-processing misalignment.
+    mergeSprite: 1 # Reduces post-processing misalignment.
 SLES-53535:
   name: "Tony Hawk's American Wasteland"
   region: "PAL-M4"
   roundModes:
     vu1RoundMode: 0 # Crashes without.
+  gsHWFixes:
+    wildArmsHack: 1 # Reduces post-processing misalignment.
+    mergeSprite: 1 # Reduces post-processing misalignment.
 SLES-53536:
   name: "London Racer - Police Madness"
   region: "PAL-M3"
@@ -46574,6 +46587,8 @@ SLUS-20965:
     recommendedBlendingLevel: 3 # Fixes water and grass textures.
     mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
     trilinearFiltering: 1
+    wildArmsHack: 1 # Reduces post-processing misalignment.
+    mergeSprite: 1 # Reduces post-processing misalignment.
 SLUS-20966:
   name: "State of Emergency 2"
   region: "NTSC-U"
@@ -47853,6 +47868,9 @@ SLUS-21208:
   compat: 5
   roundModes:
     vu1RoundMode: 0 # Crashes without.
+  gsHWFixes:
+    wildArmsHack: 1 # Reduces post-processing misalignment.
+    mergeSprite: 1 # Reduces post-processing misalignment.
 SLUS-21209:
   name: "Urban Reign"
   region: "NTSC-U"
@@ -48405,6 +48423,9 @@ SLUS-21295:
   compat: 5
   roundModes:
     vu1RoundMode: 0 # Crashes without.
+  gsHWFixes:
+    wildArmsHack: 1 # Reduces post-processing misalignment.
+    mergeSprite: 1 # Reduces post-processing misalignment.
   memcardFilters: # Game saves use the normal edition serial.
     - "SLUS-21208"
 SLUS-21296:


### PR DESCRIPTION
### Description of Changes
Fixes post-processing effects in the following games:
- Tony Hawk's Underground 2 (SLES-52621, SLES-52622, SLUS-20965)
- Tony Hawk's American Wasteland (SLES-53534, SLES-53535, SLUS-21208, SLUS-21295)

### Rationale behind Changes
When upscaling, post-processing effects, such as depth of field and bloom, are currently rendering with a very large offset from where they should be. These GS fixes correct this issue for these games.

### Suggested Testing Steps
GS Dumps for both games are provided:
[Tony Hawk's Underground 2_SLUS-20965_20230429203445.zip](https://github.com/PCSX2/pcsx2/files/11360342/Tony.Hawk.s.Underground.2_SLUS-20965_20230429203445.zip)
[Tony Hawk's American Wasteland_SLUS-21208_20230429202141.zip](https://github.com/PCSX2/pcsx2/files/11360343/Tony.Hawk.s.American.Wasteland_SLUS-21208_20230429202141.zip)
