### PR TITLE
VIF-JIT: Clean up pointless code, optimise protected vector copies

### DIFF
--- a/pcsx2/x86/newVif.h
+++ b/pcsx2/x86/newVif.h
@@ -30,6 +30,7 @@ typedef void (*nVifrecCall)(uptr dest, uptr src);
 #include "newVif_HashBucket.h"
 
 extern void  mVUmergeRegs(const xRegisterSSE& dest, const xRegisterSSE& src,  int xyzw, bool modXYZW = 0);
+extern void  mVUsaveReg(const xRegisterSSE& reg, xAddressVoid ptr, int xyzw, bool modXYZW);
 extern void _nVifUnpack  (int idx, const u8* data, uint mode, bool isFill);
 extern void  dVifReserve (int idx);
 extern void  dVifReset   (int idx);

--- a/pcsx2/x86/newVif_Dynarec.cpp
+++ b/pcsx2/x86/newVif_Dynarec.cpp
@@ -278,6 +278,10 @@ void VifUnpackSSE_Dynarec::CompileRoutine()
 	// Value passed determines # of col regs we need to load
 	SetMasks(isFill ? blockSize : cycleSize);
 
+	// Need a zero register for V2_32/V3 unpacks.
+	if ((upkNum >= 8 && upkNum <= 10) || upkNum == 4)
+		xXOR.PS(zeroReg, zeroReg);
+
 	while (vNum)
 	{
 		ShiftDisplacementWindow(dstIndirect, arg1reg);

--- a/pcsx2/x86/newVif_UnpackSSE.cpp
+++ b/pcsx2/x86/newVif_UnpackSSE.cpp
@@ -77,7 +77,6 @@ void VifUnpackSSE_Base::xPMOVXX16(const xRegisterSSE& regX) const
 
 void VifUnpackSSE_Base::xUPK_S_32() const
 {
-
 	switch (UnpkLoopIteration)
 	{
 		case 0:
@@ -98,7 +97,6 @@ void VifUnpackSSE_Base::xUPK_S_32() const
 
 void VifUnpackSSE_Base::xUPK_S_16() const
 {
-
 	switch (UnpkLoopIteration)
 	{
 		case 0:
@@ -119,7 +117,6 @@ void VifUnpackSSE_Base::xUPK_S_16() const
 
 void VifUnpackSSE_Base::xUPK_S_8() const
 {
-
 	switch (UnpkLoopIteration)
 	{
 		case 0:
@@ -145,7 +142,6 @@ void VifUnpackSSE_Base::xUPK_S_8() const
 
 void VifUnpackSSE_Base::xUPK_V2_32() const
 {
-
 	if (UnpkLoopIteration == 0)
 	{
 		xMOV128(workReg, ptr32[srcIndirect]);
@@ -163,7 +159,6 @@ void VifUnpackSSE_Base::xUPK_V2_32() const
 
 void VifUnpackSSE_Base::xUPK_V2_16() const
 {
-
 	if (UnpkLoopIteration == 0)
 	{
 		xPMOVXX16(workReg);
@@ -177,7 +172,6 @@ void VifUnpackSSE_Base::xUPK_V2_16() const
 
 void VifUnpackSSE_Base::xUPK_V2_8() const
 {
-
 	if (UnpkLoopIteration == 0)
 	{
 		xPMOVXX8(workReg);
@@ -191,7 +185,6 @@ void VifUnpackSSE_Base::xUPK_V2_8() const
 
 void VifUnpackSSE_Base::xUPK_V3_32() const
 {
-
 	xMOV128(destReg, ptr128[srcIndirect]);
 	if (UnpkLoopIteration != IsAligned)
 		xAND.PS(destReg, ptr128[SSEXYZWMask[0]]);
@@ -199,7 +192,6 @@ void VifUnpackSSE_Base::xUPK_V3_32() const
 
 void VifUnpackSSE_Base::xUPK_V3_16() const
 {
-
 	xPMOVXX16(destReg);
 
 	//With V3-16, it takes the first vector from the next position as the W vector
@@ -216,7 +208,6 @@ void VifUnpackSSE_Base::xUPK_V3_16() const
 
 void VifUnpackSSE_Base::xUPK_V3_8() const
 {
-
 	xPMOVXX8(destReg);
 	if (UnpkLoopIteration != IsAligned)
 		xAND.PS(destReg, ptr128[SSEXYZWMask[0]]);
@@ -239,7 +230,6 @@ void VifUnpackSSE_Base::xUPK_V4_8() const
 
 void VifUnpackSSE_Base::xUPK_V4_5() const
 {
-
 	xMOV16      (workReg, ptr32[srcIndirect]);
 	xPSHUF.D    (workReg, workReg, _v0);
 	xPSLL.D     (workReg, 3);           // ABG|R5.000
@@ -278,7 +268,6 @@ void VifUnpackSSE_Base::xUnpack(int upknum) const
 		case 14: xUPK_V4_8();  break;
 		case 15: xUPK_V4_5();  break;
 
-
 		case 3:
 		case 7:
 		case 11:
@@ -313,7 +302,6 @@ void VifUnpackSSE_Simple::doMaskWrite(const xRegisterSSE& regX) const
 // ecx = dest, edx = src
 static void nVifGen(int usn, int mask, int curCycle)
 {
-
 	int usnpart  = usn * 2 * 16;
 	int maskpart = mask * 16;
 

--- a/pcsx2/x86/newVif_UnpackSSE.cpp
+++ b/pcsx2/x86/newVif_UnpackSSE.cpp
@@ -35,12 +35,6 @@ alignas(16) static const u32 SSEXYZWMask[4][4] =
 //alignas(__pagesize) static u8 nVifUpkExec[__pagesize*4];
 static RecompiledCodeReserve* nVifUpkExec = NULL;
 
-// Merges xmm vectors without modifying source reg
-void mergeVectors(xRegisterSSE dest, xRegisterSSE src, xRegisterSSE temp, int xyzw)
-{
-	mVUmergeRegs(dest, src, xyzw);
-}
-
 // =====================================================================================================
 //  VifUnpackSSE_Base Section
 // =====================================================================================================

--- a/pcsx2/x86/newVif_UnpackSSE.h
+++ b/pcsx2/x86/newVif_UnpackSSE.h
@@ -39,6 +39,7 @@ public:
 protected:
 	xAddressVoid dstIndirect;
 	xAddressVoid srcIndirect;
+	xRegisterSSE zeroReg;
 	xRegisterSSE workReg;
 	xRegisterSSE destReg;
 

--- a/pcsx2/x86/newVif_UnpackSSE.h
+++ b/pcsx2/x86/newVif_UnpackSSE.h
@@ -23,8 +23,6 @@
 
 using namespace x86Emitter;
 
-extern void mergeVectors(xRegisterSSE dest, xRegisterSSE src, xRegisterSSE temp, int xyzw);
-
 // --------------------------------------------------------------------------------------
 //  VifUnpackSSE_Base
 // --------------------------------------------------------------------------------------


### PR DESCRIPTION
### Description of Changes
Gets rid of some pointless function abstraction, hangover from having SSE2. Also use mVU functions for copying if some target vectors are protected.

### Rationale behind Changes
Cleaner more optimal code, very marginally faster in games protecting vectors during VIF unpacks, GT4 comparison below shows a marginal improvement when MTVU is off.

### Suggested Testing Steps
Test a few games, make sure nothing is broke, should be fine, tested a few myself.

GT4 example, ran each one twice to make sure the results were mostly consistent
![image](https://user-images.githubusercontent.com/6278726/235412310-b4e369e2-0b0d-45c9-ad85-829ecff4f5ab.png)
