### PR TITLE
GS/HW: Fix regressions in Xenosaga III

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -5212,8 +5212,14 @@ bool GSRendererHW::PrimitiveCoversWithoutGaps() const
 	if (m_index.tail == 2)
 		return true;
 
-	// Borrowed from MergeSprite().
+	// Check that the height matches. Xenosaga 3 draws a letterbox around
+	// the FMV with a sprite at the top and bottom of the framebuffer.
 	const GSVertex* v = &m_vertex.buff[0];
+	const int first_dpY = v[1].XYZ.Y - v[0].XYZ.Y;
+	if ((first_dpY >> 4) != m_r.w)
+		return false;
+
+	// Borrowed from MergeSprite().
 	const int first_dpX = v[1].XYZ.X - v[0].XYZ.X;
 	for (u32 i = 0; i < m_vertex.next; i += 2)
 	{


### PR DESCRIPTION
### Description of Changes

Xenosaga 3 has tex-in-RT, offsetting a source from a larger target, but the invalidation kills the target but not the source otherwise. Which means if it got used, we'd go boom.

Also fixes m_from_target_TEX0 being tested when it might not be valid.

Memclear was wiping out local memory, which just got the FMV written into it, by the letterbox draw.

### Rationale behind Changes

I broke them.

### Suggested Testing Steps

Test Xenosaga 3, all FMVs should show on new game.

The source asset only trips in devbuilds, but I've checked myself that it no longer does.