### PR TITLE
VIF: Improve IR setup for skipped unpack inputs/writes

### DIFF
--- a/pcsx2/x86/newVif_UnpackSSE.h
+++ b/pcsx2/x86/newVif_UnpackSSE.h
@@ -48,6 +48,8 @@ public:
 	virtual ~VifUnpackSSE_Base() = default;
 
 	virtual void xUnpack(int upktype) const;
+	virtual bool IsWriteProtectedOp() const = 0;
+	virtual bool IsInputMasked() const = 0;
 	virtual bool IsUnmaskedOp() const = 0;
 	virtual void xMovDest() const;
 
@@ -90,6 +92,8 @@ public:
 	VifUnpackSSE_Simple(bool usn_, bool domask_, int curCycle_);
 	virtual ~VifUnpackSSE_Simple() = default;
 
+	virtual bool IsWriteProtectedOp() const { return false; }
+	virtual bool IsInputMasked() const { return false; }
 	virtual bool IsUnmaskedOp() const { return !doMask; }
 
 protected:
@@ -105,7 +109,9 @@ class VifUnpackSSE_Dynarec : public VifUnpackSSE_Base
 
 public:
 	bool isFill;
-	int  doMode; // two bit value representing... something!
+	int  doMode; // two bit value representing difference mode
+	bool skipProcessing;
+	bool inputMasked;
 
 protected:
 	const nVifStruct& v;   // vif0 or vif1
@@ -125,9 +131,12 @@ public:
 
 	virtual ~VifUnpackSSE_Dynarec() = default;
 
+	virtual bool IsWriteProtectedOp() const { return skipProcessing; }
+	virtual bool IsInputMasked() const { return inputMasked; }
 	virtual bool IsUnmaskedOp() const { return !doMode && !doMask; }
 
 	void ModUnpack(int upknum, bool PostOp);
+	void ProcessMasks();
 	void CompileRoutine();
 
 


### PR DESCRIPTION
### Description of Changes
Improved detection of when rows/cols/write protect are used instead of input data, reducing codegen of the VIF JIT

### Rationale behind Changes
potentially more brr in some places, but not much.

### Suggested Testing Steps
Test games, if it says "Skipping stuff!" in the console, it's hit the new code. Tested Kingdom Hearts 2, Tales of Legendia and Gran Turismo 4 already (the latter two hit it)
