### PR TITLE
VIF: Fix assertion error not returning int value.

### DIFF
--- a/pcsx2/x86/newVif_Dynarec.cpp
+++ b/pcsx2/x86/newVif_Dynarec.cpp
@@ -258,7 +258,7 @@ void VifUnpackSSE_Dynarec::ModUnpack(int upknum, bool PostOp)
 		case 3:
 		case 7:
 		case 11:
-			pxFailRel(fmt::format("Vpu/Vif - Invalid Unpack! [%d]", upknum).c_str());
+			pxFailRel(fmt::format("Vpu/Vif - Invalid Unpack! [{}]", upknum).c_str());
 			break;
 	}
 }


### PR DESCRIPTION
also minor misc cleanup

### Description of Changes
Now on a certain assertion error, it will return with:
"Vpu/Vif - Invalid Unpack! [11]" or `[3]` or `[7]`
instead of:
"Vpu/Vif - Invalid Unpack! [%d]"

### Rationale behind Changes
Correct behavior is better.

### Suggested Testing Steps
You can test those packages (once they build) :
[Windows test build](https://github.com/CharlesThobe/pcsx2/actions/runs/4877302358)
[Linux test build](https://github.com/CharlesThobe/pcsx2/actions/runs/4877302355)
[MacOS test build](https://github.com/CharlesThobe/pcsx2/actions/runs/4877302357)
1- Start the VM.
2- The error should appear just like the format above.