### PR TITLE
GS/HW: Fix post processing in Tomb Raider games

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -114,6 +114,8 @@ PAPX-90202:
 PAPX-90203:
   name: "Gran Turismo 2000 [Trial]"
   region: "NTSC-J"
+  gsHWFixes:
+    getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 PAPX-90215:
   name: "Ka [Trial]"
   region: "NTSC-J"
@@ -141,6 +143,8 @@ PAPX-90231:
 PAPX-90504:
   name: "Gran Turismo Concept - Airtrek Turbo Special Edition [Demo]"
   region: "NTSC-J"
+  gsHWFixes:
+    getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 PAPX-90505:
   name: "2002 Natsu no Osusume Soft Otameshi Disc"
   region: "NTSC-J"
@@ -158,11 +162,12 @@ PAPX-90512:
   region: "NTSC-J"
   clampModes:
     vuClampMode: 2 # Text in GT mode works.
+    # eeClampMode = 3  Text in races works.
   gsHWFixes:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
     halfPixelOffset: 1 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
-  # eeClampMode = 3  Text in races works.
+    getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 PAPX-90516:
   name: "Jak and Daxter II [Trial]"
   region: "NTSC-J"
@@ -272,6 +277,8 @@ PBPX-95503:
   memcardFilters:
     - "PBPX-95503"
     - "SCUS-97102"
+  gsHWFixes:
+    getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 PBPX-95506:
   name: "PlayStation 2 - Demo Disc 2001"
   region: "PAL-M5"
@@ -311,6 +318,7 @@ PBPX-95523:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
     halfPixelOffset: 1 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
+    getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
   # eeClampMode = 3  Text in races works.
   # vuClampMode = 2  Text in GT mode works.
 PBPX-95524:
@@ -321,6 +329,7 @@ PBPX-95524:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
     halfPixelOffset: 1 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
+    getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
   # eeClampMode = 3  Text in races works.
   # vuClampMode = 2  Text in GT mode works.
 PBPX-95601:
@@ -333,6 +342,7 @@ PBPX-95601:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
     halfPixelOffset: 1 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
+    getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
   memcardFilters:
     - "SCAJ-20066"
     - "SCAJ-30006"
@@ -354,6 +364,8 @@ PCPX-96306:
 PCPX-96311:
   name: "Gran Turismo 3 Trial Disk Volume 1"
   region: "NTSC-J"
+  gsHWFixes:
+    getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 PCPX-96317:
   name: "Ka [Trial]"
   region: "NTSC-J"
@@ -393,12 +405,15 @@ PCPX-96649:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
     halfPixelOffset: 1 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
+    getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
   # eeClampMode = 3  Text in races works.
 PCPX-96660:
   name: "Tourist Trophy [Demo]"
   region: "NTSC-J"
   clampModes:
     vuClampMode: 2 # Fixes SPS in TT Mode menu caused by the moving tooltips.
+  gsHWFixes:
+    getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 PCPX-98017:
   name: "Ratchet & Clank - Giri Giri Ginga no Giga Battle [Demo]"
   region: "NTSC-J"
@@ -749,6 +764,7 @@ SCAJ-20066:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
     halfPixelOffset: 1 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
+    getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
   memcardFilters:
     - "SCAJ-20066"
     - "SCAJ-30006"
@@ -1361,6 +1377,8 @@ SCAJ-20170:
   compat: 5
   clampModes:
     vuClampMode: 2 # Fixes SPS in TT Mode menu caused by the moving tooltips.
+  gsHWFixes:
+    getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 SCAJ-20171:
   name: "Zettai Zetsumei Toshi 2 - Itetsuita Kioku Tachi"
   region: "NTSC-J"
@@ -1602,6 +1620,7 @@ SCAJ-30006:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
     halfPixelOffset: 1 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
+    getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
   memcardFilters:
     - "SCAJ-20066"
     - "SCAJ-30006"
@@ -1620,20 +1639,24 @@ SCAJ-30007:
   compat: 5
   clampModes:
     vuClampMode: 2 # Text in GT mode works.
+    # eeClampMode = 3  Text in races works.
   gsHWFixes:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
     halfPixelOffset: 1 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
-  # eeClampMode = 3  Text in races works.
+    getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 SCAJ-30008:
   name: "Gran Turismo 4 [PlayStation 2 The Best]"
   region: "NTSC-Unk"
   clampModes:
     vuClampMode: 2 # Text in GT mode works.
+    # Comments from old GameIndex.dbf for this Game.
+    # eeClampMode = 3  Text in races works.
   gsHWFixes:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
     halfPixelOffset: 1 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
+    getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
   memcardFilters:
     - "SCAJ-20066"
     - "SCAJ-30006"
@@ -1645,8 +1668,6 @@ SCAJ-30008:
     - "SCPS-19304"
     - "SCPS-15009"
     - "SCPS-55007"
-  # Comments from old GameIndex.dbf for this Game.
-  # eeClampMode = 3  Text in races works.
 SCAJ-30010:
   name: "God of War"
   region: "NTSC-E"
@@ -1742,6 +1763,7 @@ SCCS-60002:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
     halfPixelOffset: 1 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
+    getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 SCED-50041:
   name: "Tekken Tag Tournament [Demo]"
   region: "PAL-E"
@@ -2351,6 +2373,7 @@ SCED-52578:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
     halfPixelOffset: 1 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
+    getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 SCED-52619:
   name: "Official PlayStation 2 Magazine Demo 48"
   region: "PAL-M5"
@@ -2361,6 +2384,7 @@ SCED-52681:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
     halfPixelOffset: 1 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
+    getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 SCED-52687:
   name: "Formula One 04 [Demo]"
   region: "PAL-M11"
@@ -3001,6 +3025,8 @@ SCES-50294:
   name: "Gran Turismo 3 - A-Spec"
   region: "PAL-M5"
   compat: 5
+  gsHWFixes:
+    getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 SCES-50295:
   name: "Dark Cloud"
   region: "PAL-M5"
@@ -3585,15 +3611,16 @@ SCES-51719:
   compat: 5
   clampModes:
     vuClampMode: 2 # Text in GT mode works.
+    # eeClampMode = 3  Text in races works.
   gsHWFixes:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
     halfPixelOffset: 1 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
+    getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
   memcardFilters:
     - "SCES-51719"
     - "SCES-52438"
     - "SCES-50294"
-  # eeClampMode = 3  Text in races works.
 SCES-51725:
   name: "Everquest Online Adventures"
   region: "PAL-M3"
@@ -3824,6 +3851,7 @@ SCES-52438:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
     halfPixelOffset: 1 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
+    getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
   memcardFilters:
     - "SCES-51719"
     - "SCES-52438"
@@ -4140,6 +4168,8 @@ SCES-53372:
   compat: 5
   clampModes:
     vuClampMode: 2 # Fixes SPS in TT Mode menu caused by the moving tooltips.
+  gsHWFixes:
+    getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 SCES-53397:
   name: "SingStar Pop - World Events Code"
   region: "PAL-Unk"
@@ -5102,6 +5132,7 @@ SCKA-20022:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
     halfPixelOffset: 1 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
+    getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
   # eeClampMode = 3  Text in races works.
   # vuClampMode = 2  Text in GT mode works.
 SCKA-20023:
@@ -5144,6 +5175,8 @@ SCKA-20028:
 SCKA-20029:
   name: "Gran Turismo Concept 2002 Tokyo-Seoul [PlayStation 2 Big Hit Series]"
   region: "NTSC-K"
+  gsHWFixes:
+    getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 SCKA-20030:
   name: "Sly Cooper - Jeonseolui Bibeobseoreul Chajaseo"
   region: "NTSC-K"
@@ -5568,11 +5601,12 @@ SCKA-30001:
   region: "NTSC-K"
   clampModes:
     vuClampMode: 2 # Text in GT mode works.
+    # eeClampMode = 3  Text in races works.
   gsHWFixes:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
     halfPixelOffset: 1 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
-  # eeClampMode = 3  Text in races works.
+    getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 SCKA-30002:
   name: "God of War"
   region: "NTSC-K"
@@ -5596,6 +5630,8 @@ SCPM-85101:
 SCPM-85301:
   name: "Gran Turismo Concept - Copen Special Edition [Demo]"
   region: "NTSC-J"
+  gsHWFixes:
+    getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 SCPN-60101:
   name: "PlayStation BB Navigator - Version 0.10 [Prerelease] [Disc 1]"
   region: "NTSC-J"
@@ -5792,6 +5828,8 @@ SCPS-15008:
 SCPS-15009:
   name: "Gran Turismo 3 - A-Spec"
   region: "NTSC-J"
+  gsHWFixes:
+    getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 SCPS-15010:
   name: "Gran Turismo - Concept 2001 Tokyo"
   region: "NTSC-J"
@@ -5996,6 +6034,7 @@ SCPS-15055:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
     halfPixelOffset: 1 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
+    getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
   memcardFilters:
     - "SCAJ-20066"
     - "SCAJ-30006"
@@ -6317,6 +6356,8 @@ SCPS-15105:
   region: "NTSC-J"
   clampModes:
     vuClampMode: 2 # Fixes SPS in TT Mode menu caused by the moving tooltips.
+  gsHWFixes:
+    getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 SCPS-15106:
   name: "Siren 2"
   region: "NTSC-J"
@@ -6397,10 +6438,12 @@ SCPS-17001:
   compat: 5
   clampModes:
     vuClampMode: 2 # Text in GT mode works.
+    # eeClampMode = 3  Text in races works.
   gsHWFixes:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
     halfPixelOffset: 1 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
+    getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
   memcardFilters:
     - "SCAJ-20066"
     - "SCAJ-30006"
@@ -6412,7 +6455,6 @@ SCPS-17001:
     - "SCPS-19304"
     - "SCPS-15009"
     - "SCPS-55007"
-  # eeClampMode = 3  Text in races works.
 SCPS-17002:
   name: "Wild ARMs - Alter Code F"
   region: "NTSC-J"
@@ -6576,10 +6618,12 @@ SCPS-19252:
   region: "NTSC-J"
   clampModes:
     vuClampMode: 2 # Text in GT mode works.
+    # eeClampMode = 3  Text in races works.
   gsHWFixes:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
     halfPixelOffset: 1 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
+    getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
   memcardFilters:
     - "SCAJ-20066"
     - "SCAJ-30006"
@@ -6591,7 +6635,6 @@ SCPS-19252:
     - "SCPS-19304"
     - "SCPS-15009"
     - "SCPS-55007"
-  # eeClampMode = 3  Text in races works.
 SCPS-19253:
   name: "Wild ARMs - Alter Code F [PlayStation 2 The Best - Reprint]"
   region: "NTSC-J"
@@ -6627,6 +6670,7 @@ SCPS-19304:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
     halfPixelOffset: 1 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
+    getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
   memcardFilters:
     - "SCAJ-20066"
     - "SCAJ-30006"
@@ -6821,6 +6865,8 @@ SCPS-19324:
   region: "NTSC-J"
   clampModes:
     vuClampMode: 2 # Fixes SPS in TT Mode menu caused by the moving tooltips.
+  gsHWFixes:
+    getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 SCPS-19325:
   name: "Ape Escape - Million Monkeys [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -6956,6 +7002,8 @@ SCPS-55006:
 SCPS-55007:
   name: "Gran Turismo 3 - A-Spec"
   region: "NTSC-J"
+  gsHWFixes:
+    getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 SCPS-55008:
   name: "Thunderstrike"
   region: "NTSC-J"
@@ -7214,6 +7262,8 @@ SCPS-56004:
 SCPS-56005:
   name: "Gran Turismo Concept 2002 Tokyo-Seoul"
   region: "NTSC-K"
+  gsHWFixes:
+    getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 SCPS-56006:
   name: "Tekken 4"
   region: "NTSC-K"
@@ -7310,6 +7360,8 @@ SCUS-97102:
   name: "Gran Turismo 3 - A-Spec"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 SCUS-97104:
   name: "ATV Offroad Fury"
   region: "NTSC-U"
@@ -7365,6 +7417,8 @@ SCUS-97114:
 SCUS-97115:
   name: "Gran Turismo 3 - A-Spec [Demo]"
   region: "NTSC-U"
+  gsHWFixes:
+    getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 SCUS-97116:
   name: "Kiosk Demo Disc 2.01"
   region: "NTSC-U"
@@ -7764,6 +7818,8 @@ SCUS-97219:
   memcardFilters:
     - "SCUS-97219"
     - "SCUS-97102"
+  gsHWFixes:
+    getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 SCUS-97220:
   name: "NHL FaceOff 2003"
   region: "NTSC-U"
@@ -8080,17 +8136,18 @@ SCUS-97328:
   compat: 5
   clampModes:
     vuClampMode: 2 # Text in GT mode works.
+    # eeClampMode = 3  Text in races works.
   gsHWFixes:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
     halfPixelOffset: 1 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
+    getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
   memcardFilters: # Allows car imports from GT3 or something.
     - "SCUS-97328"
     - "SCUS-97436"
     - "SCUS-97102"
     - "SCUS-97219"
     - "SCUS-97512"
-  # eeClampMode = 3  Text in races works.
 SCUS-97329:
   name: "Downhill Domination [Demo]"
   region: "NTSC-U"
@@ -8465,17 +8522,18 @@ SCUS-97436:
   region: "NTSC-U"
   clampModes:
     vuClampMode: 2 # Text in GT mode works.
+    # eeClampMode = 3  Text in races works.
   gsHWFixes:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
     halfPixelOffset: 1 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
+    getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
   memcardFilters:
     - "SCUS-97328"
     - "SCUS-97436"
     - "SCUS-97102"
     - "SCUS-97219"
     - "SCUS-97512"
-  # eeClampMode = 3  Text in races works.
 SCUS-97437:
   name: "ATV Offroad Fury 3 [Demo]"
   region: "NTSC-U"
@@ -8675,11 +8733,12 @@ SCUS-97483:
   region: "NTSC-U"
   clampModes:
     vuClampMode: 2 # Text in GT mode works.
+    # eeClampMode = 3  Text in races works.
   gsHWFixes:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
     halfPixelOffset: 1 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
-  # eeClampMode = 3  Text in races works.
+    getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 SCUS-97484:
   name: "Sly 3 - Honor Among Thieves [E3 Demo]"
   region: "NTSC-U"
@@ -8795,6 +8854,8 @@ SCUS-97502:
   compat: 5
   clampModes:
     vuClampMode: 2 # Fixes SPS in TT Mode menu caused by the moving tooltips.
+  gsHWFixes:
+    getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 SCUS-97503:
   name: "MLB '06 - The Show [Demo]"
   region: "NTSC-U"
@@ -8839,6 +8900,8 @@ SCUS-97512:
   memcardFilters:
     - "SCUS-97512"
     - "SCUS-97102"
+  gsHWFixes:
+    getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 SCUS-97513:
   name: "Ratchet & Clank 2 - Going Commando [Greatest Hits]"
   region: "NTSC-U"

--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -16424,6 +16424,7 @@ SLES-52859:
   region: "PAL-E"
   gsHWFixes:
     mipmap: 1
+    textureInsideRT: 1 # Fixes post processing.
 SLES-52861:
   name: "King Arthur"
   region: "PAL-M5"
@@ -17183,6 +17184,7 @@ SLES-53124:
   gsHWFixes:
     mipmap: 1
     estimateTextureRegion: 1 # Improves performance.
+    textureInsideRT: 1 # Fixes post processing.
 SLES-53125:
   name: "Enthusia - Professional Racing"
   region: "PAL-M5"
@@ -47064,6 +47066,7 @@ SLUS-21037:
   compat: 5
   gsHWFixes:
     mipmap: 1
+    textureInsideRT: 1 # Fixes post processing.
 SLUS-21038:
   name: "Pinball Hall of Fame - The Gottlieb Collection"
   region: "NTSC-U"
@@ -52271,6 +52274,7 @@ SLUS-29131:
   gsHWFixes:
     mipmap: 1
     estimateTextureRegion: 1 # Improves performance.
+    textureInsideRT: 1 # Fixes post processing.
 SLUS-29132:
   name: "S.L.A.I. - Steel Lancer Arena International - Phantom Crash [Public Beta Vol.1.0]"
   region: "NTSC-U"

--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -9801,6 +9801,7 @@ SLED-53330:
   region: "PAL"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
+    textureInsideRT: 1 # Fixes reflections.
 SLED-53445:
   name: "Incredible Hulk, The - Ultimate Destruction [Demo]"
   region: "PAL-M3"
@@ -17190,6 +17191,7 @@ SLES-53125:
     vuClampMode: 3 # Stops freezing at race start.
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
+    textureInsideRT: 1 # Fixes reflections.
 SLES-53127:
   name: "Teenage Mutant Ninja Turtles - Mutant Melee"
   region: "PAL-M5"
@@ -31885,6 +31887,7 @@ SLPM-65948:
     vuClampMode: 3 # Fixes Freezing at the start of the race.
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
+    textureInsideRT: 1 # Fixes reflections.
 SLPM-65949:
   name: "Get Ride! AM Driver - The Truth of Xiangke"
   region: "NTSC-J"
@@ -33116,6 +33119,7 @@ SLPM-66257:
     vuClampMode: 3 # Stops freezing at race start.
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
+    textureInsideRT: 1 # Fixes reflections.
 SLPM-66258:
   name: "Magic Teacher Negima - Honor Version [Konami The Best]"
   region: "NTSC-J"
@@ -46652,6 +46656,7 @@ SLUS-20967:
     vuClampMode: 3 # Stops freezing at race start.
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
+    textureInsideRT: 1 # Fixes reflections.
 SLUS-20968:
   name: "Karaoke Revolution Volume 2"
   region: "NTSC-U"

--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -9917,7 +9917,7 @@ SLED-54401:
   gsHWFixes:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
-    textureInsideRT: 2 # Fixes shadow maps.
+    textureInsideRT: 1 # Fixes shadow maps.
     roundSprite: 2 # Fixes misaligned bloom.
     mergeSprite: 1 # Fixes misaligned bloom.
     halfPixelOffset: 2 # Fixes misaligned bloom.
@@ -17333,7 +17333,7 @@ SLES-53196:
   gsHWFixes:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
-    textureInsideRT: 2 # Fixes shadow maps.
+    textureInsideRT: 1 # Fixes shadow maps.
     roundSprite: 2 # Fixes misaligned bloom.
     mergeSprite: 1 # Fixes misaligned bloom.
     halfPixelOffset: 2 # Fixes misaligned bloom.
@@ -17344,7 +17344,7 @@ SLES-53197:
   gsHWFixes:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
-    textureInsideRT: 2 # Fixes shadow maps.
+    textureInsideRT: 1 # Fixes shadow maps.
     roundSprite: 2 # Fixes misaligned bloom.
     mergeSprite: 1 # Fixes misaligned bloom.
     halfPixelOffset: 2 # Fixes misaligned bloom.
@@ -18560,7 +18560,7 @@ SLES-53641:
   gsHWFixes:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
-    textureInsideRT: 2 # Fixes shadow maps.
+    textureInsideRT: 1 # Fixes shadow maps.
     roundSprite: 2 # Fixes misaligned bloom.
     mergeSprite: 1 # Fixes misaligned bloom.
     halfPixelOffset: 2 # Fixes misaligned bloom.
@@ -20269,7 +20269,7 @@ SLES-54319:
   name: "Biker Mice from Mars"
   region: "PAL-M5"
   gsHWFixes:
-    textureInsideRT: 2 # Fixes shadow maps.
+    textureInsideRT: 1 # Fixes shadow maps.
 SLES-54320:
   name: "Championship Manager 2007"
   region: "PAL-M5"
@@ -20521,7 +20521,7 @@ SLES-54384:
   gsHWFixes:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
-    textureInsideRT: 2 # Fixes shadow maps.
+    textureInsideRT: 1 # Fixes shadow maps.
     roundSprite: 2 # Fixes misaligned bloom.
     mergeSprite: 1 # Fixes misaligned bloom.
     halfPixelOffset: 2 # Fixes misaligned bloom.
@@ -21612,7 +21612,7 @@ SLES-54788:
   name: "Aqua Teen Hunger Force - Zombie Ninja Pro-Am"
   region: "PAL-E"
   gsHWFixes:
-    textureInsideRT: 2 # Fixes shadows.
+    textureInsideRT: 1 # Fixes shadows.
 SLES-54789:
   name: "Beta Bloc"
   region: "PAL-E"
@@ -25619,7 +25619,7 @@ SLPM-55141:
   gsHWFixes:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
-    textureInsideRT: 2 # Fixes shadow maps.
+    textureInsideRT: 1 # Fixes shadow maps.
     roundSprite: 2 # Fixes misaligned bloom.
     mergeSprite: 1 # Fixes misaligned bloom.
     halfPixelOffset: 2 # Fixes misaligned bloom.
@@ -33763,7 +33763,7 @@ SLPM-66430:
   gsHWFixes:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
-    textureInsideRT: 2 # Fixes shadow maps.
+    textureInsideRT: 1 # Fixes shadow maps.
     roundSprite: 2 # Fixes misaligned bloom.
     mergeSprite: 1 # Fixes misaligned bloom.
     halfPixelOffset: 2 # Fixes misaligned bloom.
@@ -46517,7 +46517,7 @@ SLUS-20945:
   gsHWFixes:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
-    textureInsideRT: 2 # Fixes shadow maps.
+    textureInsideRT: 1 # Fixes shadow maps.
     roundSprite: 2 # Fixes misaligned bloom.
     mergeSprite: 1 # Fixes misaligned bloom.
     halfPixelOffset: 2 # Fixes misaligned bloom.
@@ -49355,7 +49355,7 @@ SLUS-21439:
   gsHWFixes:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
-    textureInsideRT: 2 # Fixes shadow maps.
+    textureInsideRT: 1 # Fixes shadow maps.
     roundSprite: 2 # Fixes misaligned bloom.
     mergeSprite: 1 # Fixes misaligned bloom.
     halfPixelOffset: 2 # Fixes misaligned bloom.
@@ -49911,7 +49911,7 @@ SLUS-21578:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    textureInsideRT: 2 # Fixes shadow maps.
+    textureInsideRT: 1 # Fixes shadow maps.
 SLUS-21579:
   name: "Barbie in The 12 Dancing Princesses"
   region: "NTSC-U"
@@ -50220,7 +50220,7 @@ SLUS-21633:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    textureInsideRT: 2 # Fixes shadows.
+    textureInsideRT: 1 # Fixes shadows.
 SLUS-21634:
   name: "Crazy Frog Racer 2"
   region: "NTSC-U"
@@ -52316,7 +52316,7 @@ SLUS-29150:
   gsHWFixes:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
-    textureInsideRT: 2 # Fixes shadow maps.
+    textureInsideRT: 1 # Fixes shadow maps.
     roundSprite: 2 # Fixes misaligned bloom.
     mergeSprite: 1 # Fixes misaligned bloom.
     halfPixelOffset: 2 # Fixes misaligned bloom.
@@ -52515,7 +52515,7 @@ SLUS-29196:
   gsHWFixes:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
-    textureInsideRT: 2 # Fixes shadow maps.
+    textureInsideRT: 1 # Fixes shadow maps.
     roundSprite: 2 # Fixes misaligned bloom.
     mergeSprite: 1 # Fixes misaligned bloom.
     halfPixelOffset: 2 # Fixes misaligned bloom.

--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -19308,7 +19308,7 @@ SLES-53908:
   compat: 5
   gsHWFixes:
     mipmap: 1 # Fixes distant characters and models but there are still some flickering textures.
-    getSkipCount: "GSC_TombRaiderLegend"
+    textureInsideRT: 1 # Needed for post processing effects.
 SLES-53909:
   name: "Full Spectrum Warrior - Ten Hammers"
   region: "PAL-G"
@@ -21295,7 +21295,7 @@ SLES-54674:
   compat: 5
   gsHWFixes:
     mipmap: 1
-    getSkipCount: "GSC_TombRaiderAnniversary"
+    textureInsideRT: 1 # Needed for post processing effects.
 SLES-54675:
   name: "Street Warrior"
   region: "PAL-E"
@@ -23263,7 +23263,7 @@ SLES-55442:
   region: "PAL-M8"
   compat: 5
   gsHWFixes:
-    getSkipCount: "GSC_TombRaiderUnderWorld"
+    textureInsideRT: 1 # Needed for post processing effects.
 SLES-55443:
   name: "Mana Khemia - Alchemists of Al-Revis"
   region: "PAL-E"
@@ -34269,7 +34269,7 @@ SLPM-66558:
   region: "NTSC-J"
   gsHWFixes:
     mipmap: 1 # Fixes distant characters and models but there are still some flickering textures.
-    getSkipCount: "GSC_TombRaiderLegend"
+    textureInsideRT: 1 # Needed for post processing effects.
 SLPM-66559:
   name: "Winning Post 6 [KOEI Selection]"
   region: "NTSC-J"
@@ -41170,7 +41170,7 @@ SLPS-25856:
   region: "NTSC-J"
   gsHWFixes:
     mipmap: 1
-    getSkipCount: "GSC_TombRaiderAnniversary"
+    textureInsideRT: 1 # Needed for post processing effects.
 SLPS-25858:
   name: "Dengeki SP - Shakugan no Shana"
   region: "NTSC-J"
@@ -41359,7 +41359,7 @@ SLPS-25927:
   name: "Tomb Raider - Underworld"
   region: "NTSC-J"
   gsHWFixes:
-    getSkipCount: "GSC_TombRaiderUnderWorld"
+    textureInsideRT: 1 # Needed for post processing effects.
 SLPS-25930:
   name: "Major League Baseball 2K9"
   region: "NTSC-J"
@@ -47889,7 +47889,7 @@ SLUS-21203:
   compat: 5
   gsHWFixes:
     mipmap: 1 # Fixes distant characters and models but there are still some flickering textures.
-    getSkipCount: "GSC_TombRaiderLegend"
+    textureInsideRT: 1 # Needed for post processing effects.
 SLUS-21204:
   name: "Victorious Boxers 2 - Fighting Spirit"
   region: "NTSC-U"
@@ -49810,7 +49810,7 @@ SLUS-21555:
   compat: 5
   gsHWFixes:
     mipmap: 1
-    getSkipCount: "GSC_TombRaiderAnniversary"
+    textureInsideRT: 1 # Needed for post processing effects.
 SLUS-21556:
   name: "Konami Kids Playground - Dinosaur Shapes & Colors"
   region: "NTSC-U"
@@ -51256,7 +51256,7 @@ SLUS-21858:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    getSkipCount: "GSC_TombRaiderUnderWorld"
+    textureInsideRT: 1 # Needed for post processing effects.
 SLUS-21860:
   name: "Bigs 2, The"
   region: "NTSC-U"

--- a/pcsx2/GS/GS.natvis
+++ b/pcsx2/GS/GS.natvis
@@ -33,4 +33,8 @@
 		<DisplayString Condition="m_type == 0">{{ RT @ BP={m_TEX0.TBP0,X}-{m_end_block,X} BW={m_TEX0.TBW} PSM={m_TEX0.PSM,X} {m_unscaled_size.x}x{m_unscaled_size.y} {m_valid.z},{m_valid.w} }}</DisplayString>
 		<DisplayString Condition="m_type == 1">{{ Depth @ BP={m_TEX0.TBP0,X}-{m_end_block,X} BW={m_TEX0.TBW} PSM={m_TEX0.PSM,X} {m_unscaled_size.x}x{m_unscaled_size.y} {m_valid.z},{m_valid.w} }}</DisplayString>
 	</Type>
+
+	<Type Name="GSTextureCache::SourceRegion">
+		<DisplayString>{{ Min=({(s16)(bits &amp; 0xFFFF)},{(s16)((bits >> 32) &amp; 0xFFFF)}} Max={(s16)((bits >> 16) &amp; 0xFFFF)},{(s16)((bits >> 48) &amp; 0xFFFF)}) }}</DisplayString>
+	</Type>
 </AutoVisualizer>

--- a/pcsx2/GS/GSCrc.cpp
+++ b/pcsx2/GS/GSCrc.cpp
@@ -31,42 +31,6 @@ const CRC::Game CRC::m_games[] =
 	{0x5C991F4E, ICO /* EU */},
 	{0x788D8B4F, ICO /* EU */},
 	{0x29C28734, ICO /* CH */},
-	{0x60013EBD, PolyphonyDigitalGames /* EU */}, // Gran Turismo Concept
-	{0x6810C3BC, PolyphonyDigitalGames /* CH */}, // Gran Turismo Concept 2002 Tokyo-Geneva
-	{0x0EEF32A3, PolyphonyDigitalGames /* KO */}, // Gran Turismo Concept 2002 Tokyo-Seoul
-	{0x3E9D448A, PolyphonyDigitalGames /* CH */}, // GT3
-	{0xAD66643C, PolyphonyDigitalGames /* CH */}, // GT3
-	{0x85AE91B3, PolyphonyDigitalGames /* US */}, // GT3
-	{0x8AA991B0, PolyphonyDigitalGames /* US */}, // GT3
-	{0xC220951A, PolyphonyDigitalGames /* JP */}, // GT3
-	{0x9DE5CF65, PolyphonyDigitalGames /* JP */}, // GT3
-	{0x706DFF80, PolyphonyDigitalGames /* JP */}, // GT3 Store Disc Vol. 2
-	{0x55CE5111, PolyphonyDigitalGames /* JP */}, // Gran Turismo 2000 Body Omen
-	{0xE9A7E08D, PolyphonyDigitalGames /* JP */}, // Gran Turismo 2000 Body Omen
-	{0xB590CE04, PolyphonyDigitalGames /* EU */}, // GT3
-	{0xC02C653E, PolyphonyDigitalGames /* CH */}, // GT4
-	{0x7ABDBB5E, PolyphonyDigitalGames /* CH */}, // GT4
-	{0xAEAD1CA3, PolyphonyDigitalGames /* JP */}, // GT4
-	{0xA3AF15A0, PolyphonyDigitalGames /* JP */}, // GT4 PS2 Racing Pack
-	{0xE906EA37, PolyphonyDigitalGames /* JP */}, // GT4 First Preview
-	{0xCA6243B9, PolyphonyDigitalGames /* JP */}, // GT4 Prologue
-	{0xDD764BBE, PolyphonyDigitalGames /* JP */}, // GT4 Prologue
-	{0xE1258846, PolyphonyDigitalGames /* JP */}, // GT4 Prologue
-	{0x27B8F05F, PolyphonyDigitalGames /* JP */}, // GT4 Prius Trial Version
-	{0x30E41D93, PolyphonyDigitalGames /* KO */}, // GT4
-	{0x715CF2EC, PolyphonyDigitalGames /* EU */}, // GT4
-	{0x44A61C8F, PolyphonyDigitalGames /* EU */}, // GT4
-	{0x0086E35B, PolyphonyDigitalGames /* EU */}, // GT4
-	{0x3FB69323, PolyphonyDigitalGames /* EU */}, // GT4 Prologue
-	{0x77E61C8A, PolyphonyDigitalGames /* US */}, // GT4
-	{0x33C6E35E, PolyphonyDigitalGames /* US */}, // GT4
-	{0x70538747, PolyphonyDigitalGames /* US */}, // GT4 Toyota Prius Trial
-	{0x32A1C752, PolyphonyDigitalGames /* US */}, // GT4 Online Beta
-	{0x2A84A1E2, PolyphonyDigitalGames /* US */}, // GT4 Mazda MX-5 Edition
-	{0x0087EEC4, PolyphonyDigitalGames /* NoRegion */}, // GT4 Online Beta, JP and US versions have the same CRC
-	{0x5AC7E79C, PolyphonyDigitalGames /* CH */}, // TouristTrophy
-	{0xFF9C0E93, PolyphonyDigitalGames /* US */}, // TouristTrophy
-	{0xCA9AA903, PolyphonyDigitalGames /* EU */}, // TouristTrophy
 	{0xFC46EA61, Tekken5 /* JP */},
 	{0x1F88EE37, Tekken5 /* EU */},
 	{0x1F88BECD, Tekken5 /* EU */}, // language selector...

--- a/pcsx2/GS/GSCrc.h
+++ b/pcsx2/GS/GSCrc.h
@@ -25,7 +25,6 @@ public:
 		NoTitle,
 		GetawayGames,
 		ICO,
-		PolyphonyDigitalGames,
 		SMTNocturne,
 		Tekken5,
 		TitleCount,

--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -827,7 +827,15 @@ void GSState::ApplyTEX0(GIFRegTEX0& TEX0)
 			m_mem.m_clut.ClearDrawInvalidity();
 			CLUTAutoFlush(PRIM->PRIM);
 		}
+
 		Flush(GSFlushReason::CLUTCHANGE);
+
+		// Abort any channel shuffle skipping, since this is likely part of a new shuffle.
+		// Test case: Tomb Raider series. This is gated by the CBP actually changing, because
+		// Urban Chaos writes to the memory backing the CLUT in the middle of a shuffle, and
+		// it's unclear whether the CLUT would actually get reloaded in that case.
+		if (TEX0.CBP != m_mem.m_clut.GetCLUTCBP())
+			m_channel_shuffle = false;
 	}
 
 	TEX0.CPSM &= 0xa; // 1010b

--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -226,6 +226,7 @@ public:
 	bool m_mipmap = false;
 	bool m_texflush_flag = false;
 	bool m_isPackedUV_HackFlag = false;
+	bool m_channel_shuffle = false;
 	u8 m_scanmask_used = 0;
 	u8 m_force_preload = 0;
 	u32 m_dirty_gs_regs = 0;

--- a/pcsx2/GS/Renderers/HW/GSHwHack.cpp
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.cpp
@@ -216,54 +216,6 @@ bool GSHwHack::GSC_Tekken5(GSRendererHW& r, int& skip)
 	return true;
 }
 
-bool GSHwHack::GSC_TombRaiderAnniversary(GSRendererHW& r, int& skip)
-{
-	if (skip == 0)
-	{
-		if (RTME && RFBP == 0x01000 && RFPSM == RTPSM && RTPSM == PSMCT32)
-		{
-			skip = 1; // Garbage TC
-		}
-	}
-
-	return true;
-}
-
-bool GSHwHack::GSC_TombRaiderLegend(GSRendererHW& r, int& skip)
-{
-	if (skip == 0)
-	{
-		// ||GSC_TBP0 ==0x2F00
-		if (RTME && RFBP == 0x01000 && RFPSM == RTPSM && RTPSM == PSMCT32 && (RTBP0 == 0x2b60 || RTBP0 == 0x2b80 || RTBP0 == 0x2E60 || RTBP0 == 0x3020 || RTBP0 == 0x3200 || RTBP0 == 0x3320))
-		{
-			skip = 1; // Garbage TC
-		}
-		else if (RTPSM == PSMCT32 && (RTPSM | RFBP) == 0x2fa0 && (RTBP0 == 0x2bc0) && RFBMSK == 0)
-		{
-			skip = 2; // Underwater black screen
-		}
-	}
-
-	return true;
-}
-
-bool GSHwHack::GSC_TombRaiderUnderWorld(GSRendererHW& r, int& skip)
-{
-	if (skip == 0)
-	{
-		if (RTME && RFBP == 0x01000 && RFPSM == RTPSM && RTPSM == PSMCT32 && (RTBP0 == 0x2B60 /*|| GSC_TBP0 == 0x2EFF || GSC_TBP0 ==0x2F00 || GSC_TBP0 == 0x3020*/ || (RTBP0 >= 0x2C01 && RTBP0 != 0x3029 && RTBP0 != 0x302d)))
-		{
-			skip = 1; // Garbage TC
-		}
-		else if (RTPSM == PSMCT32 && (RTPSM | RFBP) == 0x2c00 && (RTBP0 == 0x0ee0) && RFBMSK == 0)
-		{
-			skip = 2; // Underwater black screen
-		}
-	}
-
-	return true;
-}
-
 bool GSHwHack::GSC_BurnoutGames(GSRendererHW& r, int& skip)
 {
 	if (RFBW == 2 && std::abs(static_cast<int>(RFBP) - static_cast<int>(RZBP)) <= static_cast<int>(BLOCKS_PER_PAGE))
@@ -1209,9 +1161,6 @@ const GSHwHack::Entry<GSRendererHW::GSC_Ptr> GSHwHack::s_get_skip_count_function
 	CRC_F(GSC_SFEX3, CRCHackLevel::Partial),
 	CRC_F(GSC_TalesOfLegendia, CRCHackLevel::Partial),
 	CRC_F(GSC_TalesofSymphonia, CRCHackLevel::Partial),
-	CRC_F(GSC_TombRaiderAnniversary, CRCHackLevel::Partial),
-	CRC_F(GSC_TombRaiderLegend, CRCHackLevel::Partial),
-	CRC_F(GSC_TombRaiderUnderWorld, CRCHackLevel::Partial),
 	CRC_F(GSC_UrbanReign, CRCHackLevel::Partial),
 	CRC_F(GSC_ZettaiZetsumeiToshi2, CRCHackLevel::Partial),
 	CRC_F(GSC_BlackAndBurnoutSky, CRCHackLevel::Partial),

--- a/pcsx2/GS/Renderers/HW/GSHwHack.h
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.h
@@ -25,9 +25,6 @@ public:
 	static bool GSC_SakuraTaisen(GSRendererHW& r, int& skip);
 	static bool GSC_SFEX3(GSRendererHW& r, int& skip);
 	static bool GSC_Tekken5(GSRendererHW& r, int& skip);
-	static bool GSC_TombRaiderAnniversary(GSRendererHW& r, int& skip);
-	static bool GSC_TombRaiderLegend(GSRendererHW& r, int& skip);
-	static bool GSC_TombRaiderUnderWorld(GSRendererHW& r, int& skip);
 	static bool GSC_BurnoutGames(GSRendererHW& r, int& skip);
 	static bool GSC_BlackAndBurnoutSky(GSRendererHW& r, int& skip);
 	static bool GSC_MidnightClub3(GSRendererHW& r, int& skip);

--- a/pcsx2/GS/Renderers/HW/GSHwHack.h
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.h
@@ -52,6 +52,7 @@ public:
 	static bool GSC_BlueTongueGames(GSRendererHW& r, int& skip);
 	static bool GSC_Battlefield2(GSRendererHW& r, int& skip);
 	static bool GSC_NFSUndercover(GSRendererHW& r, int& skip);
+	static bool GSC_PolyphonyDigitalGames(GSRendererHW& r, int& skip);
 
 	static bool OI_PointListPalette(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
 	static bool OI_BigMuthaTruckers(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -1415,6 +1415,8 @@ void GSRendererHW::Draw()
 	{
 		// NFSU2 does consecutive channel shuffles with blending, reducing the alpha channel over time.
 		// Fortunately, it seems to change the FBMSK along the way, so this check alone is sufficient.
+		// Tomb Raider: Underworld does similar, except with R, G, B in separate palettes, therefore
+		// we need to split on those too.
 		m_channel_shuffle = IsPossibleChannelShuffle() && m_last_channel_shuffle_fbmsk == m_context->FRAME.FBMSK;
 
 #ifdef ENABLE_OGL_DEBUG

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.h
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.h
@@ -193,4 +193,11 @@ public:
 
 	/// Returns true if the specified texture address matches the frame or Z buffer.
 	bool IsTBPFrameOrZ(u32 tbp) const;
+
+	/// Starts a HLE'ed hardware draw, which can be further customized by the caller.
+	GSHWDrawConfig& BeginHLEHardwareDraw(
+		GSTexture* rt, GSTexture* ds, float rt_scale, GSTexture* tex, float tex_scale, const GSVector4i& unscaled_rect);
+
+	/// Submits a previously set up HLE hardware draw, copying any textures as needed if there's hazards.
+	void EndHLEHardwareDraw(bool force_copy_on_hazard = false);
 };

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.h
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.h
@@ -135,7 +135,6 @@ private:
 	u32 m_split_texture_shuffle_start_TBP = 0;
 
 	u32 m_last_channel_shuffle_fbmsk = 0;
-	bool m_channel_shuffle = false;
 
 	bool m_userhacks_tcoffset = false;
 	float m_userhacks_tcoffset_x = 0.0f;

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -937,8 +937,8 @@ GSTextureCache::Source* GSTextureCache::LookupSource(const GIFRegTEX0& TEX0, con
 				// Make sure the texture actually is INSIDE the RT, it's possibly not valid if it isn't.
 				// Also check BP >= TBP, create source isn't equpped to expand it backwards and all data comes from the target. (GH3)
 				else if (GSConfig.UserHacks_TextureInsideRt >= GSTextureInRtMode::InsideTargets && psm >= PSMCT32 &&
-						 psm <= PSMCT16S && t->m_TEX0.PSM == psm && (t->Overlaps(bp, bw, psm, r) || t->Wraps()) &&
-						 t->m_age <= 1 && !found_t)
+						 psm <= PSMCT16S && GSUtil::HasCompatibleBits(t->m_TEX0.PSM, psm) && (t->Overlaps(bp, bw, psm, r) || t->Wraps()) &&
+						 t->m_age <= 1 && (!found_t || dst->m_TEX0.TBW < bw))
 				{
 					// PSM equality needed because CreateSource does not handle PSM conversion.
 					// Only inclusive hit to limit false hits.
@@ -3311,7 +3311,7 @@ GSTextureCache::Source* GSTextureCache::CreateMergedSource(GIFRegTEX0 TEX0, GIFR
 		for (auto i = m_dst[RenderTarget].begin(); i != m_dst[RenderTarget].end(); ++i)
 		{
 			Target* const t = *i;
-			if (this_start_block >= t->m_TEX0.TBP0 && this_end_block <= t->m_end_block && t->m_TEX0.PSM == TEX0.PSM)
+			if (this_start_block >= t->m_TEX0.TBP0 && this_end_block <= t->m_end_block && GSUtil::HasCompatibleBits(t->m_TEX0.PSM, TEX0.PSM))
 			{
 				GL_INS("  Candidate at BP %x BW %d PSM %d", t->m_TEX0.TBP0, t->m_TEX0.TBW, t->m_TEX0.PSM);
 
@@ -4221,8 +4221,8 @@ void GSTextureCache::Source::Flush(u32 count, int layer, const GSOffset& off)
 	const SourceRegion region((layer == 0) ? m_region : m_region.AdjustForMipmap(layer));
 
 	// For the invalid tex0 case, the region might be larger than TEX0.TW/TH.
-	const int tw = std::max(region.GetWidth(), 1u << m_TEX0.TW);
-	const int th = std::max(region.GetHeight(), 1u << m_TEX0.TH);
+	const int tw = std::max(region.GetWidth(), 1 << m_TEX0.TW);
+	const int th = std::max(region.GetHeight(), 1 << m_TEX0.TH);
 	const GSVector4i tex_r(region.GetRect(tw, th));
 
 	int pitch = std::max(tw, psm.bs.x) * sizeof(u32);
@@ -5120,12 +5120,12 @@ bool GSTextureCache::SourceRegion::IsFixedTEX0(int tw, int th) const
 
 bool GSTextureCache::SourceRegion::IsFixedTEX0W(int tw) const
 {
-	return (GetMaxX() > static_cast<u32>(tw));
+	return (GetMaxX() > tw);
 }
 
 bool GSTextureCache::SourceRegion::IsFixedTEX0H(int th) const
 {
-	return (GetMaxY() > static_cast<u32>(th));
+	return (GetMaxY() > th);
 }
 
 GSVector2i GSTextureCache::SourceRegion::GetSize(int tw, int th) const
@@ -5140,8 +5140,8 @@ GSVector4i GSTextureCache::SourceRegion::GetRect(int tw, int th) const
 
 GSVector4i GSTextureCache::SourceRegion::GetOffset(int tw, int th) const
 {
-	const int xoffs = (GetMaxX() > static_cast<u32>(tw)) ? static_cast<int>(GetMinX()) : 0;
-	const int yoffs = (GetMaxY() > static_cast<u32>(th)) ? static_cast<int>(GetMinY()) : 0;
+	const int xoffs = (GetMaxX() > tw) ? GetMinX() : 0;
+	const int yoffs = (GetMaxY() > th) ? GetMinY() : 0;
 	return GSVector4i(xoffs, yoffs, xoffs, yoffs);
 }
 
@@ -5151,14 +5151,14 @@ GSTextureCache::SourceRegion GSTextureCache::SourceRegion::AdjustForMipmap(u32 l
 	SourceRegion ret = {};
 	if (HasX())
 	{
-		const u32 new_minx = GetMinX() >> level;
-		const u32 new_maxx = new_minx + std::max(GetWidth() >> level, 1u);
+		const s32 new_minx = GetMinX() >> level;
+		const s32 new_maxx = new_minx + std::max(GetWidth() >> level, 1);
 		ret.SetX(new_minx, new_maxx);
 	}
 	if (HasY())
 	{
-		const u32 new_miny = GetMinY() >> level;
-		const u32 new_maxy = new_miny + std::max(GetHeight() >> level, 1u);
+		const s32 new_miny = GetMinY() >> level;
+		const s32 new_maxy = new_miny + std::max(GetHeight() >> level, 1);
 		ret.SetY(new_miny, new_maxy);
 	}
 	return ret;

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.h
@@ -52,16 +52,16 @@ public:
 		bool HasY() const { return static_cast<u32>(bits >> 32) != 0; }
 		bool HasEither() const { return (bits != 0); }
 
-		void SetX(u32 min, u32 max) { bits |= (min | (max << 16)); }
-		void SetY(u32 min, u32 max) { bits |= ((static_cast<u64>(min) << 32) | (static_cast<u64>(max) << 48)); }
+		void SetX(s32 min, s32 max) { bits |= (static_cast<u64>(static_cast<u16>(min)) | (static_cast<u64>(static_cast<u16>(max) << 16))); }
+		void SetY(s32 min, s32 max) { bits |= ((static_cast<u64>(static_cast<u16>(min)) << 32) | (static_cast<u64>(static_cast<u16>(max)) << 48)); }
 
-		u32 GetMinX() const { return static_cast<u32>(bits) & 0xFFFFu; }
-		u32 GetMaxX() const { return static_cast<u32>(bits >> 16) & 0xFFFFu; }
-		u32 GetMinY() const { return static_cast<u32>(bits >> 32) & 0xFFFFu; }
-		u32 GetMaxY() const { return static_cast<u32>(bits >> 48); }
+		s32 GetMinX() const { return static_cast<s16>(bits); }
+		s32 GetMaxX() const { return static_cast<s16>((bits >> 16) & 0xFFFFu); }
+		s32 GetMinY() const { return static_cast<s16>((bits >> 32) & 0xFFFFu); }
+		s32 GetMaxY() const { return static_cast<s16>(bits >> 48); }
 
-		u32 GetWidth() const { return (GetMaxX() - GetMinX()); }
-		u32 GetHeight() const { return (GetMaxY() - GetMinY()); }
+		s32 GetWidth() const { return (GetMaxX() - GetMinX()); }
+		s32 GetHeight() const { return (GetMaxY() - GetMinY()); }
 
 		/// Returns true if the area of the region exceeds the TW/TH size (i.e. "fixed tex0").
 		bool IsFixedTEX0(GIFRegTEX0 TEX0) const;

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.h
@@ -142,6 +142,7 @@ public:
 		bool m_32_bits_fmt = false; // Allow to detect the casting of 32 bits as 16 bits texture
 		bool m_shared_texture = false;
 
+		__fi GSTexture* GetTexture() const { return m_texture; }
 		__fi int GetUnscaledWidth() const { return m_unscaled_size.x; }
 		__fi int GetUnscaledHeight() const { return m_unscaled_size.y; }
 		__fi const GSVector2i& GetUnscaledSize() const { return m_unscaled_size; }
@@ -435,6 +436,7 @@ public:
 	void DirtyRectByPage(u32 sbp, u32 spsm, u32 sbw, Target* t, GSVector4i src_r);
 
 	GSTexture* LookupPaletteSource(u32 CBP, u32 CPSM, u32 CBW, GSVector2i& offset, float* scale, const GSVector2i& size);
+	std::shared_ptr<Palette> LookupPaletteObject(u16 pal, bool need_gs_texture);
 
 	Source* LookupSource(const GIFRegTEX0& TEX0, const GIFRegTEXA& TEXA, const GIFRegCLAMP& CLAMP, const GSVector4i& r, const GSVector2i* lod);
 	Source* LookupDepthSource(const GIFRegTEX0& TEX0, const GIFRegTEXA& TEXA, const GIFRegCLAMP& CLAMP, const GSVector4i& r, bool palette = false);


### PR DESCRIPTION
### Description of Changes

Some games, such as Tomb Raider: Underworld, and Destroy All Humans shift the texture pointer back behind the framebuffer, but then offset their texture coordinates to compensate. Why they do this, I have no idea... but it's usually only a page wide/high of an offset.

Thankfully, they also seem to set region clamp with the offset as well, so we can use that to find the target that they're expecting to read from. Example from Tomb Raider: TBP0 0xee0 with a TBW of 8, MINU/V of 64,32, which means 9 pages down, or 0x1000, which lines up with the main framebuffer.

~~Marked as a draft because the channel shuffle change breaks the GT4 hack. I need to think of another way to do it, probably as an OI hack instead.~~

### Rationale behind Changes

Closes #8270.

Before:
![image](https://user-images.githubusercontent.com/11288319/235953160-e242c654-0144-4352-bcb3-0cf3742f2d17.png)
After:
![image](https://user-images.githubusercontent.com/11288319/235953176-120208fc-7081-4e28-b269-c82eaa2a1363.png)

Before:
![image](https://user-images.githubusercontent.com/11288319/235953245-9fecb7c8-17f5-44df-8060-89867fcb2b64.png)
After:
![image](https://user-images.githubusercontent.com/11288319/235953261-787630d6-f67a-46b3-b406-2ff46d5aa3fb.png)


### Suggested Testing Steps

Test Tomb Raider games. I noticed an issue in Legend with what looks like alpha on some of the foliage textures, which I suspect is unrelated.

Make sure shadows are still working in Destroy All Humans/2.

Make sure Gran Turismo and Tourist Trophy games aren't broken.

Make sure FF12 shadows still work (it uses the HLE helper too).
