### PR TITLE
GameDB: Secret Agent Clank compat and bloom fix

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -4845,6 +4845,9 @@ SCES-55489:
 SCES-55496:
   name: "Secret Agent Clank"
   region: "PAL-M12"
+  compat: 5
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes misaligned bloom.
 SCES-55510:
   name: "Jak and Daxter - The Lost Frontier"
   region: "PAL-M12"
@@ -9140,6 +9143,8 @@ SCUS-97623:
   name: "Secret Agent Clank"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes misaligned bloom.
 SCUS-97625:
   name: "NBA 09 - The Inside"
   region: "NTSC-U"
@@ -23369,6 +23374,9 @@ SLES-55495:
 SLES-55496:
   name: "Secret Agent Clank"
   region: "PAL-Unk"
+  compat: 5
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes misaligned bloom.
 SLES-55499:
   name: "Disney G-Force"
   region: "PAL-M4"


### PR DESCRIPTION
### Description of Changes
Mitigates bloom misalignment when upscaling Secret Agent Clank, and applies its NTSC-U 4-star compatibility rating to the PAL versions.

### Rationale behind Changes
Aligned bloom is better than misaligned bloom, easily noticeable around the player and the top-right lights in the below screenshots. The PAL-M12 version runs fine for me across the whole game, and the NTSC-U version already had a 4-star rating, so I unified the PAL ratings in the process.

|Before, 4x resolution|After, 4x resolution|
|-|-|
|![image](https://user-images.githubusercontent.com/14360666/236320857-18aadf6e-66b1-4e57-bb82-6f1b2ebf845c.png)|![image](https://user-images.githubusercontent.com/14360666/236320893-66a0b645-a964-4a01-8399-1913725ad18e.png)|

### Suggested Testing Steps
Make sure that Secret Agent CI is happy.