### PR TITLE
Qt: Remove/don't set default adapter string.

### DIFF
--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -974,13 +974,13 @@ void GraphicsSettingsWidget::updateRendererDependentOptions()
 		std::string current_adapter = Host::GetBaseStringSettingValue("EmuCore/GS", "Adapter", "");
 		m_ui.adapter->clear();
 		m_ui.adapter->setEnabled(!adapters.empty());
-		m_ui.adapter->addItem(tr("(Default)"));
+		m_ui.adapter->addItem(tr(""));
 		m_ui.adapter->setCurrentIndex(0);
 
 		if (m_dialog->isPerGameSettings())
 		{
 			m_ui.adapter->insertItem(
-				0, tr("Use Global Setting [%1]").arg(current_adapter.empty() ? tr("(Default)") : QString::fromStdString(current_adapter)));
+				0, tr("Use Global Setting [%1]").arg(current_adapter.empty() ? tr("") : QString::fromStdString(current_adapter)));
 			if (!m_dialog->getSettingsInterface()->GetStringValue("EmuCore/GS", "Adapter", &current_adapter))
 			{
 				// clear the adapter so we don't set it to the global value


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Qt: Remove/don't set default adapter string.
This caused the string (Default) to be read as an adapter which is invalid.
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Bugfix.
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test any renderer except GL, make sure log about (Default) adapter not being found is gone.