### PR TITLE
GS/Vulkan: Split command buffer submission and presentation

### DIFF
--- a/pcsx2/GS.cpp
+++ b/pcsx2/GS.cpp
@@ -363,13 +363,13 @@ void gsIrq() {
 //These are done at VSync Start.  Drawing is done when VSync is off, then output the screen when Vsync is on
 //The GS needs to be told at the start of a vsync else it loses half of its picture (could be responsible for some halfscreen issues)
 //We got away with it before i think due to our awful GS timing, but now we have it right (ish)
-void gsPostVsyncStart()
+void gsPostVsyncStart(u64 present_time)
 {
 	//gifUnit.FlushToMTGS();  // Needed for some (broken?) homebrew game loaders
 
 	const bool registers_written = s_GSRegistersWritten;
 	s_GSRegistersWritten = false;
-	GetMTGS().PostVsyncStart(registers_written);
+	GetMTGS().PostVsyncStart(registers_written, present_time);
 }
 
 void SaveStateBase::gsFreeze()

--- a/pcsx2/GS.h
+++ b/pcsx2/GS.h
@@ -404,7 +404,7 @@ public:
 
 	u8* GetDataPacketPtr() const;
 	void SetEvent();
-	void PostVsyncStart(bool registers_written);
+	void PostVsyncStart(bool registers_written, u64 present_time);
 	void InitAndReadFIFO(u8* mem, u32 qwc);
 
 	void RunOnGSThread(AsyncCallType func);
@@ -445,7 +445,7 @@ extern SysMtgsThread& GetMTGS();
 
 extern void gsReset();
 extern void gsSetVideoMode(GS_VideoMode mode);
-extern void gsPostVsyncStart();
+extern void gsPostVsyncStart(u64 present_time);
 extern void gsUpdateFrequency(Pcsx2Config& config);
 
 extern void gsWrite8(u32 mem, u8 value);

--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -461,11 +461,11 @@ void GSgifTransfer3(u8* mem, u32 size)
 	}
 }
 
-void GSvsync(u32 field, bool registers_written)
+void GSvsync(u32 field, bool registers_written, u64 present_time)
 {
 	try
 	{
-		g_gs_renderer->VSync(field, registers_written, g_gs_renderer->IsIdleFrame());
+		g_gs_renderer->VSync(field, registers_written, g_gs_renderer->IsIdleFrame(), present_time);
 	}
 	catch (GSRecoverableError)
 	{

--- a/pcsx2/GS/GS.h
+++ b/pcsx2/GS/GS.h
@@ -83,7 +83,7 @@ void GSgifTransfer(const u8* mem, u32 size);
 void GSgifTransfer1(u8* mem, u32 addr);
 void GSgifTransfer2(u8* mem, u32 size);
 void GSgifTransfer3(u8* mem, u32 size);
-void GSvsync(u32 field, bool registers_written);
+void GSvsync(u32 field, bool registers_written, u64 present_time);
 int GSfreeze(FreezeAction mode, freezeData* data);
 std::string GSGetBaseSnapshotFilename();
 std::string GSGetBaseVideoFilename();

--- a/pcsx2/GS/Renderers/Common/GSDevice.h
+++ b/pcsx2/GS/Renderers/Common/GSDevice.h
@@ -860,7 +860,7 @@ public:
 	virtual PresentResult BeginPresent(bool frame_skip) = 0;
 
 	/// Presents the frame to the display.
-	virtual void EndPresent() = 0;
+	virtual void EndPresent(u64 present_time) = 0;
 
 	/// Changes vsync mode for this display.
 	virtual void SetVSync(VsyncMode mode) = 0;
@@ -873,9 +873,6 @@ public:
 
 	/// Enables/disables GPU frame timing.
 	virtual bool SetGPUTimingEnabled(bool enabled) = 0;
-
-	/// Returns the amount of GPU time utilized since the last time this method was called.
-	virtual float GetAndResetAccumulatedGPUTime() = 0;
 
 	virtual void ClearRenderTarget(GSTexture* t, const GSVector4& c) = 0;
 	virtual void ClearRenderTarget(GSTexture* t, u32 c) = 0;

--- a/pcsx2/GS/Renderers/Common/GSRenderer.h
+++ b/pcsx2/GS/Renderers/Common/GSRenderer.h
@@ -24,7 +24,7 @@ class GSRenderer : public GSState
 private:
 	bool Merge(int field);
 	bool BeginPresentFrame(bool frame_skip);
-	void EndPresentFrame();
+	void EndPresentFrame(u64 present_time);
 
 	u64 m_shader_time_start = 0;
 
@@ -52,7 +52,7 @@ public:
 
 	virtual void Destroy();
 
-	virtual void VSync(u32 field, bool registers_written, bool idle_frame);
+	virtual void VSync(u32 field, bool registers_written, bool idle_frame, u64 present_time);
 	virtual bool CanUpscale() { return false; }
 	virtual float GetUpscaleMultiplier() { return 1.0f; }
 	virtual float GetTextureScaleFactor() { return 1.0f; }

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
@@ -21,6 +21,7 @@
 #include "GS/GSPerfMon.h"
 #include "GS/GSUtil.h"
 #include "Host.h"
+#include "PerformanceMetrics.h"
 
 #include "common/Align.h"
 #include "common/Path.h"
@@ -886,7 +887,7 @@ GSDevice::PresentResult GSDevice11::BeginPresent(bool frame_skip)
 	return PresentResult::OK;
 }
 
-void GSDevice11::EndPresent()
+void GSDevice11::EndPresent(u64 present_time)
 {
 	RenderImGui();
 
@@ -899,6 +900,9 @@ void GSDevice11::EndPresent()
 		m_swap_chain->Present(0, DXGI_PRESENT_ALLOW_TEARING);
 	else
 		m_swap_chain->Present(static_cast<UINT>(vsync_on), 0);
+
+	PerformanceMetrics::OnGPUPresent(m_accumulated_gpu_time);
+	m_accumulated_gpu_time = 0.0f;
 
 	if (m_gpu_timing_enabled)
 		KickTimestampQuery();
@@ -1012,13 +1016,6 @@ bool GSDevice11::SetGPUTimingEnabled(bool enabled)
 		DestroyTimestampQueries();
 		return true;
 	}
-}
-
-float GSDevice11::GetAndResetAccumulatedGPUTime()
-{
-	const float value = m_accumulated_gpu_time;
-	m_accumulated_gpu_time = 0.0f;
-	return value;
 }
 
 void GSDevice11::DrawPrimitive()

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.h
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.h
@@ -300,10 +300,9 @@ public:
 	void SetVSync(VsyncMode mode) override;
 
 	PresentResult BeginPresent(bool frame_skip) override;
-	void EndPresent() override;
+	void EndPresent(u64 present_time) override;
 
 	bool SetGPUTimingEnabled(bool enabled) override;
-	float GetAndResetAccumulatedGPUTime() override;
 
 	void DrawPrimitive();
 	void DrawIndexedPrimitive();

--- a/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
@@ -25,6 +25,7 @@
 #include "GS/Renderers/DX12/D3D12Context.h"
 #include "GS/Renderers/DX12/D3D12ShaderCache.h"
 #include "Host.h"
+#include "PerformanceMetrics.h"
 #include "ShaderCacheVersion.h"
 
 #include "common/Align.h"
@@ -546,7 +547,7 @@ GSDevice::PresentResult GSDevice12::BeginPresent(bool frame_skip)
 	return PresentResult::OK;
 }
 
-void GSDevice12::EndPresent()
+void GSDevice12::EndPresent(u64 present_time)
 {
 	RenderImGui();
 
@@ -567,6 +568,8 @@ void GSDevice12::EndPresent()
 	else
 		m_swap_chain->Present(static_cast<UINT>(vsync), 0);
 
+	PerformanceMetrics::OnGPUPresent(g_d3d12_context->GetAndResetAccumulatedGPUTime());
+
 	InvalidateCachedState();
 }
 
@@ -574,11 +577,6 @@ bool GSDevice12::SetGPUTimingEnabled(bool enabled)
 {
 	g_d3d12_context->SetEnableGPUTiming(enabled);
 	return true;
-}
-
-float GSDevice12::GetAndResetAccumulatedGPUTime()
-{
-	return g_d3d12_context->GetAndResetAccumulatedGPUTime();
 }
 
 void GSDevice12::PushDebugGroup(const char* fmt, ...)

--- a/pcsx2/GS/Renderers/DX12/GSDevice12.h
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.h
@@ -266,10 +266,9 @@ public:
 	void SetVSync(VsyncMode mode) override;
 
 	PresentResult BeginPresent(bool frame_skip) override;
-	void EndPresent() override;
+	void EndPresent(u64 present_time) override;
 
 	bool SetGPUTimingEnabled(bool enabled) override;
-	float GetAndResetAccumulatedGPUTime() override;
 
 	void PushDebugGroup(const char* fmt, ...) override;
 	void PopDebugGroup() override;

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -112,7 +112,7 @@ void GSRendererHW::UpdateSettings(const Pcsx2Config::GSOptions& old_config)
 	SetTCOffset();
 }
 
-void GSRendererHW::VSync(u32 field, bool registers_written, bool idle_frame)
+void GSRendererHW::VSync(u32 field, bool registers_written, bool idle_frame, u64 present_time)
 {
 	if (m_force_preload > 0)
 	{
@@ -147,7 +147,7 @@ void GSRendererHW::VSync(u32 field, bool registers_written, bool idle_frame)
 		g_texture_cache->IncAge();
 	}
 
-	GSRenderer::VSync(field, registers_written, idle_frame);
+	GSRenderer::VSync(field, registers_written, idle_frame, present_time);
 
 	if (g_texture_cache->GetHashCacheMemoryUsage() > 1024 * 1024 * 1024)
 	{

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.h
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.h
@@ -175,7 +175,7 @@ public:
 
 	void Reset(bool hardware_reset) override;
 	void UpdateSettings(const Pcsx2Config::GSOptions& old_config) override;
-	void VSync(u32 field, bool registers_written, bool idle_frame) override;
+	void VSync(u32 field, bool registers_written, bool idle_frame, u64 present_time) override;
 
 	GSTexture* GetOutput(int i, float& scale, int& y_offset) override;
 	GSTexture* GetFeedbackOutput(float& scale) override;

--- a/pcsx2/GS/Renderers/Metal/GSDeviceMTL.h
+++ b/pcsx2/GS/Renderers/Metal/GSDeviceMTL.h
@@ -396,13 +396,13 @@ public:
 	void UpdateTexture(id<MTLTexture> texture, u32 x, u32 y, u32 width, u32 height, const void* data, u32 data_stride);
 
 	PresentResult BeginPresent(bool frame_skip) override;
-	void EndPresent() override;
+	void EndPresent(u64 present_time) override;
 	void SetVSync(VsyncMode mode) override;
 
 	bool GetHostRefreshRate(float* refresh_rate) override;
 
 	bool SetGPUTimingEnabled(bool enabled) override;
-	float GetAndResetAccumulatedGPUTime() override;
+	float GetAndResetAccumulatedGPUTime();
 	void AccumulateCommandBufferTime(id<MTLCommandBuffer> buffer);
 
 	void ClearRenderTarget(GSTexture* t, const GSVector4& c) override;

--- a/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
+++ b/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
@@ -20,6 +20,7 @@
 #include "GS/Renderers/Metal/GSDeviceMTL.h"
 #include "GS/Renderers/Metal/GSTextureMTL.h"
 #include "GS/GSPerfMon.h"
+#include "PerformanceMetrics.h"
 
 #include "imgui.h"
 
@@ -1276,7 +1277,7 @@ GSDevice::PresentResult GSDeviceMTL::BeginPresent(bool frame_skip)
 	return PresentResult::OK;
 }}
 
-void GSDeviceMTL::EndPresent()
+void GSDeviceMTL::EndPresent(u64 present_time)
 { @autoreleasepool {
 	pxAssertDev(m_current_render.encoder && m_current_render_cmdbuf, "BeginPresent cmdbuf was destroyed");
 	ImGui::Render();
@@ -1294,6 +1295,9 @@ void GSDeviceMTL::EndPresent()
 				[drawable present];
 			}];
 	}
+
+	PerformanceMetrics::OnGPUPresent(GetAndResetAccumulatedGPUTime());
+
 	FlushEncoders();
 	FrameCompleted();
 	m_current_drawable = nullptr;

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -22,6 +22,7 @@
 #include "GS/GSGL.h"
 #include "GS/GSUtil.h"
 #include "Host.h"
+#include "PerformanceMetrics.h"
 
 #include "common/StringUtil.h"
 
@@ -736,7 +737,7 @@ GSDevice::PresentResult GSDeviceOGL::BeginPresent(bool frame_skip)
 	return PresentResult::OK;
 }
 
-void GSDeviceOGL::EndPresent()
+void GSDeviceOGL::EndPresent(u64 present_time)
 {
 	RenderImGui();
 
@@ -744,6 +745,9 @@ void GSDeviceOGL::EndPresent()
 		PopTimestampQuery();
 
 	m_gl_context->SwapBuffers();
+
+	PerformanceMetrics::OnGPUPresent(m_accumulated_gpu_time);
+	m_accumulated_gpu_time = 0.0f;
 
 	if (m_gpu_timing_enabled)
 		KickTimestampQuery();
@@ -819,13 +823,6 @@ bool GSDeviceOGL::SetGPUTimingEnabled(bool enabled)
 		DestroyTimestampQueries();
 
 	return true;
-}
-
-float GSDeviceOGL::GetAndResetAccumulatedGPUTime()
-{
-	const float value = m_accumulated_gpu_time;
-	m_accumulated_gpu_time = 0.0f;
-	return value;
 }
 
 void GSDeviceOGL::DrawPrimitive()

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.h
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.h
@@ -301,10 +301,9 @@ public:
 	void SetVSync(VsyncMode mode) override;
 
 	PresentResult BeginPresent(bool frame_skip) override;
-	void EndPresent() override;
+	void EndPresent(u64 present_time) override;
 
 	bool SetGPUTimingEnabled(bool enabled) override;
-	float GetAndResetAccumulatedGPUTime() override;
 
 	void DrawPrimitive();
 	void DrawIndexedPrimitive();

--- a/pcsx2/GS/Renderers/SW/GSRendererSW.cpp
+++ b/pcsx2/GS/Renderers/SW/GSRendererSW.cpp
@@ -78,7 +78,7 @@ void GSRendererSW::Destroy()
 	m_output = nullptr;
 }
 
-void GSRendererSW::VSync(u32 field, bool registers_written, bool idle_frame)
+void GSRendererSW::VSync(u32 field, bool registers_written, bool idle_frame, u64 present_time)
 {
 	Sync(0); // IncAge might delete a cached texture in use
 
@@ -99,7 +99,7 @@ void GSRendererSW::VSync(u32 field, bool registers_written, bool idle_frame)
 	//
 	*/
 
-	GSRenderer::VSync(field, registers_written, idle_frame);
+	GSRenderer::VSync(field, registers_written, idle_frame, present_time);
 
 	m_tc->IncAge();
 

--- a/pcsx2/GS/Renderers/SW/GSRendererSW.h
+++ b/pcsx2/GS/Renderers/SW/GSRendererSW.h
@@ -73,7 +73,7 @@ protected:
 	GSVector4i m_dimx[8] = {};
 
 	void Reset(bool hardware_reset) override;
-	void VSync(u32 field, bool registers_written, bool idle_frame) override;
+	void VSync(u32 field, bool registers_written, bool idle_frame, u64 present_time) override;
 	GSTexture* GetOutput(int i, float& scale, int& y_offset) override;
 	GSTexture* GetFeedbackOutput(float& scale) override;
 

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
@@ -423,6 +423,13 @@ GSDevice::PresentResult GSDeviceVK::BeginPresent(bool frame_skip)
 		}
 	}
 
+	if (const VkFence fence = m_swap_chain->GetImageAcquireFence(); fence != VK_NULL_HANDLE)
+	{
+		res = vkWaitForFences(g_vulkan_context->GetDevice(), 1, &fence, VK_TRUE, UINT64_MAX);
+		if (res != VK_SUCCESS)
+			LOG_VULKAN_ERROR(res, "vkWaitForFences() for image acquire failed: ");
+	}
+
 	VkCommandBuffer cmdbuffer = g_vulkan_context->GetCurrentCommandBuffer();
 
 	// Swap chain images start in undefined
@@ -2467,6 +2474,13 @@ void GSDeviceVK::RenderBlankFrame()
 	{
 		Console.Error("Failed to acquire image for blank frame present");
 		return;
+	}
+
+	if (const VkFence fence = m_swap_chain->GetImageAcquireFence(); fence != VK_NULL_HANDLE)
+	{
+		res = vkWaitForFences(g_vulkan_context->GetDevice(), 1, &fence, VK_TRUE, UINT64_MAX);
+		if (res != VK_SUCCESS)
+			LOG_VULKAN_ERROR(res, "vkWaitForFences() for image acquire failed: ");
 	}
 
 	VkCommandBuffer cmdbuffer = g_vulkan_context->GetCurrentCommandBuffer();

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h
@@ -252,10 +252,9 @@ public:
 	void SetVSync(VsyncMode mode) override;
 
 	PresentResult BeginPresent(bool frame_skip) override;
-	void EndPresent() override;
+	void EndPresent(u64 present_time) override;
 
 	bool SetGPUTimingEnabled(bool enabled) override;
-	float GetAndResetAccumulatedGPUTime() override;
 
 	void PushDebugGroup(const char* fmt, ...) override;
 	void PopDebugGroup() override;

--- a/pcsx2/GS/Renderers/Vulkan/VKContext.h
+++ b/pcsx2/GS/Renderers/Vulkan/VKContext.h
@@ -52,6 +52,7 @@ public:
 		bool vk_ext_line_rasterization : 1;
 		bool vk_ext_rasterization_order_attachment_access : 1;
 		bool vk_ext_full_screen_exclusive : 1;
+		bool vk_ext_surface_maintenance1 : 1;
 		bool vk_khr_driver_properties : 1;
 		bool vk_khr_fragment_shader_barycentric : 1;
 		bool vk_khr_shader_draw_parameters : 1;

--- a/pcsx2/GS/Renderers/Vulkan/VKSwapChain.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/VKSwapChain.cpp
@@ -323,11 +323,11 @@ bool VKSwapChain::CreateSwapChain()
 	}
 
 	// Select number of images in swap chain, we prefer one buffer in the background to work on
-	u32 image_count = std::max(surface_capabilities.minImageCount + 1u, 2u);
-
-	// maxImageCount can be zero, in which case there isn't an upper limit on the number of buffers.
-	if (surface_capabilities.maxImageCount > 0)
-		image_count = std::min(image_count, surface_capabilities.maxImageCount);
+	const u32 image_count = std::clamp(IsPresentModeSynchronizing() ? 2u : 3u, surface_capabilities.minImageCount,
+		(surface_capabilities.maxImageCount == 0) ? std::numeric_limits<uint32_t>::max() :
+													surface_capabilities.maxImageCount);
+	DevCon.WriteLn("(SwapChain) minImageCount=%u, maxImageCount=%u, image_count=%u", surface_capabilities.minImageCount,
+		surface_capabilities.maxImageCount, image_count);
 
 	// Determine the dimensions of the swap chain. Values of -1 indicate the size we specify here
 	// determines window size?

--- a/pcsx2/GS/Renderers/Vulkan/VKSwapChain.h
+++ b/pcsx2/GS/Renderers/Vulkan/VKSwapChain.h
@@ -67,6 +67,7 @@ public:
 	{
 		return &m_semaphores[m_current_semaphore].rendering_finished_semaphore;
 	}
+	__fi VkFence GetImageAcquireFence() const { return m_image_ready_fence; }
 
 	// Returns true if the current present mode is synchronizing (adaptive or hard).
 	__fi bool IsPresentModeSynchronizing() const { return (m_vsync_mode != VsyncMode::Off); }
@@ -113,6 +114,9 @@ private:
 	VsyncMode m_vsync_mode = VsyncMode::Off;
 	u32 m_current_image = 0;
 	u32 m_current_semaphore = 0;
+
+	VkFence m_image_ready_fence = VK_NULL_HANDLE;
+	bool m_image_ready_fence_signaled = false;
 
 	std::optional<VkResult> m_image_acquire_result;
 	std::optional<bool> m_exclusive_fullscreen_control;

--- a/pcsx2/GS/Renderers/Vulkan/VKUtil.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/VKUtil.cpp
@@ -24,27 +24,6 @@
 
 #include <cmath>
 
-VkFormat Vulkan::GetLinearFormat(VkFormat format)
-{
-	switch (format)
-	{
-		case VK_FORMAT_R8_SRGB:
-			return VK_FORMAT_R8_UNORM;
-		case VK_FORMAT_R8G8_SRGB:
-			return VK_FORMAT_R8G8_UNORM;
-		case VK_FORMAT_R8G8B8_SRGB:
-			return VK_FORMAT_R8G8B8_UNORM;
-		case VK_FORMAT_R8G8B8A8_SRGB:
-			return VK_FORMAT_R8G8B8A8_UNORM;
-		case VK_FORMAT_B8G8R8_SRGB:
-			return VK_FORMAT_B8G8R8_UNORM;
-		case VK_FORMAT_B8G8R8A8_SRGB:
-			return VK_FORMAT_B8G8R8A8_UNORM;
-		default:
-			return format;
-	}
-}
-
 void Vulkan::SafeDestroyFramebuffer(VkFramebuffer& fb)
 {
 	if (fb != VK_NULL_HANDLE)
@@ -246,33 +225,6 @@ const char* Vulkan::VkResultToString(VkResult res)
 
 		default:
 			return "UNKNOWN_VK_RESULT";
-	}
-}
-
-const char* Vulkan::PresentModeToString(VkPresentModeKHR mode)
-{
-	switch (mode)
-	{
-		case VK_PRESENT_MODE_IMMEDIATE_KHR:
-			return "VK_PRESENT_MODE_IMMEDIATE_KHR";
-
-		case VK_PRESENT_MODE_MAILBOX_KHR:
-			return "VK_PRESENT_MODE_MAILBOX_KHR";
-
-		case VK_PRESENT_MODE_FIFO_KHR:
-			return "VK_PRESENT_MODE_FIFO_KHR";
-
-		case VK_PRESENT_MODE_FIFO_RELAXED_KHR:
-			return "VK_PRESENT_MODE_FIFO_RELAXED_KHR";
-
-		case VK_PRESENT_MODE_SHARED_DEMAND_REFRESH_KHR:
-			return "VK_PRESENT_MODE_SHARED_DEMAND_REFRESH_KHR";
-
-		case VK_PRESENT_MODE_SHARED_CONTINUOUS_REFRESH_KHR:
-			return "VK_PRESENT_MODE_SHARED_CONTINUOUS_REFRESH_KHR";
-
-		default:
-			return "UNKNOWN_VK_PRESENT_MODE";
 	}
 }
 

--- a/pcsx2/GS/Renderers/Vulkan/VKUtil.h
+++ b/pcsx2/GS/Renderers/Vulkan/VKUtil.h
@@ -26,8 +26,6 @@
 
 namespace Vulkan
 {
-	VkFormat GetLinearFormat(VkFormat format);
-
 	// Safe destroy helpers
 	void SafeDestroyFramebuffer(VkFramebuffer& fb);
 	void SafeDestroyShaderModule(VkShaderModule& sm);
@@ -49,7 +47,6 @@ namespace Vulkan
 	void AddPointerToChain(void* head, const void* ptr);
 
 	const char* VkResultToString(VkResult res);
-	const char* PresentModeToString(VkPresentModeKHR mode);
 	void LogVulkanResult(const char* func_name, VkResult res, const char* msg, ...) /*printflike(4, 5)*/;
 
 #define LOG_VULKAN_ERROR(res, ...) ::Vulkan::LogVulkanResult(__func__, res, __VA_ARGS__)

--- a/pcsx2/GSDumpReplayer.cpp
+++ b/pcsx2/GSDumpReplayer.cpp
@@ -317,7 +317,7 @@ void GSDumpReplayerCpuStep()
 			s_dump_frame_number++;
 			GSDumpReplayerUpdateFrameLimit();
 			GSDumpReplayerFrameLimit();
-			GetMTGS().PostVsyncStart(false);
+			GetMTGS().PostVsyncStart(false, 0);
 			VMManager::Internal::VSyncOnCPUThread();
 			if (VMManager::Internal::IsExecutionInterrupted())
 				GSDumpReplayerExitExecution();

--- a/pcsx2/PerformanceMetrics.h
+++ b/pcsx2/PerformanceMetrics.h
@@ -32,7 +32,7 @@ namespace PerformanceMetrics
 
 	void Clear();
 	void Reset();
-	void Update(bool gs_register_write, bool fb_blit, bool is_skipping_present);
+	void OnGSFrame(bool gs_register_write, bool fb_blit);
 	void OnGPUPresent(float gpu_time);
 
 	/// Sets the EE thread for CPU usage calculations.


### PR DESCRIPTION
### Description of Changes

Attempting to further improve frame pacing. The current frame times are a bit of a lie with Vulkan, because it's the time the GS thread kicked it to the submit thread, not after the frame actually finished being queued.

This gives us a window of time where we can potentially do some per-frame readbacks as well.

It can potentially improve performance too in GPU-bound scenarios, where the time to render the frame varies from frame to frame, since we're submitting `16ms - EE_TIME` earlier than we otherwise would have.

Currently only implemented in Vulkan, but it's possible in DX12 too (and Metal, but I lack hardware).

### Rationale behind Changes

Improving frame pacing.

### Suggested Testing Steps

See if there's any differences with frame timing/pacing, possibly try with externals too, PCSX2's readings should be fairly close now.
