### PR TITLE
GameDB: Add text fix for State of Emergency 2

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -19728,9 +19728,15 @@ SLES-54087:
 SLES-54089:
   name: "State of Emergency 2"
   region: "PAL-M3"
+  gsHWFixes:
+    cpuSpriteRenderBW: 1 # Fixes Text.
+    cpuSpriteRenderLevel: 2 # Needed to fix text.
 SLES-54092:
   name: "State of Emergency 2"
   region: "PAL-M3"
+  gsHWFixes:
+    cpuSpriteRenderBW: 1 # Fixes Text.
+    cpuSpriteRenderLevel: 2 # Needed to fix text.
 SLES-54093:
   name: "Guitar Hero"
   region: "PAL-M5"
@@ -46726,6 +46732,9 @@ SLUS-20966:
   name: "State of Emergency 2"
   region: "NTSC-U"
   compat: 4
+  gsHWFixes:
+    cpuSpriteRenderBW: 1 # Fixes Text.
+    cpuSpriteRenderLevel: 2 # Needed to fix text.
 SLUS-20967:
   name: "Enthusia Professional Racing"
   region: "NTSC-U"
@@ -51926,6 +51935,9 @@ SLUS-28054:
 SLUS-28056:
   name: "State of Emergency 2 [Trade Demo]"
   region: "NTSC-U"
+  gsHWFixes:
+    cpuSpriteRenderBW: 1 # Fixes Text.
+    cpuSpriteRenderLevel: 2 # Needed to fix text.
 SLUS-28059:
   name: "Metal Saga [Trade Demo]"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
Fixes text in state of emergency 2

### Rationale behind Changes
It got broked somewhere.

### Suggested Testing Steps
watch cI

Before:
![image](https://user-images.githubusercontent.com/6278726/236636535-f69af259-5f61-4cc9-9be9-36116b7a9e61.png)

After:
![image](https://user-images.githubusercontent.com/6278726/236636543-e300a3c0-95db-488c-8cbd-920ae1810be1.png)
