### PR TITLE
GS: Replace EmuConfig.GS with GSConfig.

### DIFF
--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -189,7 +189,7 @@ static bool OpenGSDevice(GSRendererType renderer, bool clear_state_on_fail, bool
 		return false;
 	}
 
-	GSConfig.OsdShowGPU = EmuConfig.GS.OsdShowGPU && g_gs_device->SetGPUTimingEnabled(true);
+	GSConfig.OsdShowGPU = GSConfig.OsdShowGPU && g_gs_device->SetGPUTimingEnabled(true);
 
 	Console.WriteLn(Color_StrongGreen, "%s Graphics Driver Info:", GSDevice::RenderAPIToString(new_api));
 	Console.Indent().WriteLn(g_gs_device->GetDriverInfo());
@@ -348,7 +348,7 @@ bool GSopen(const Pcsx2Config::GSOptions& config, GSRendererType renderer, u8* b
 		Host::ReportErrorAsync(
 			"Error", fmt::format("Failed to create render device. This may be due to your GPU not supporting the "
 								 "chosen renderer ({}), or because your graphics drivers need to be updated.",
-						 Pcsx2Config::GSOptions::GetRendererName(EmuConfig.GS.Renderer)));
+						 Pcsx2Config::GSOptions::GetRendererName(GSConfig.Renderer)));
 		return false;
 	}
 

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
@@ -602,7 +602,7 @@ bool GSDevice11::CreateSwapChain()
 		m_is_exclusive_fullscreen = false;
 	}
 
-	m_using_flip_model_swap_chain = !EmuConfig.GS.UseBlitSwapChain || m_is_exclusive_fullscreen;
+	m_using_flip_model_swap_chain = !GSConfig.UseBlitSwapChain || m_is_exclusive_fullscreen;
 
 	DXGI_SWAP_CHAIN_DESC1 swap_chain_desc = {};
 	swap_chain_desc.Width = static_cast<u32>(client_rc.right - client_rc.left);

--- a/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
@@ -122,13 +122,13 @@ bool GSDevice12::Create()
 	if (!GSDevice::Create())
 		return false;
 
-	m_dxgi_factory = D3D::CreateFactory(EmuConfig.GS.UseDebugDevice);
+	m_dxgi_factory = D3D::CreateFactory(GSConfig.UseDebugDevice);
 	if (!m_dxgi_factory)
 		return false;
 
-	ComPtr<IDXGIAdapter1> dxgi_adapter = D3D::GetAdapterByName(m_dxgi_factory.get(), EmuConfig.GS.Adapter);
+	ComPtr<IDXGIAdapter1> dxgi_adapter = D3D::GetAdapterByName(m_dxgi_factory.get(), GSConfig.Adapter);
 
-	if (!D3D12Context::Create(m_dxgi_factory.get(), dxgi_adapter.get(), EmuConfig.GS.UseDebugDevice))
+	if (!D3D12Context::Create(m_dxgi_factory.get(), dxgi_adapter.get(), GSConfig.UseDebugDevice))
 	{
 		Console.Error("Failed to create D3D12 context");
 		return false;

--- a/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
+++ b/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
@@ -773,7 +773,7 @@ bool GSDeviceMTL::Create()
 	if (!GSDevice::Create())
 		return false;
 
-	NSString* ns_adapter_name = [NSString stringWithUTF8String:EmuConfig.GS.Adapter.c_str()];
+	NSString* ns_adapter_name = [NSString stringWithUTF8String:GSConfig.Adapter.c_str()];
 	auto devs = MRCTransfer(MTLCopyAllDevices());
 	for (id<MTLDevice> dev in devs.Get())
 	{
@@ -782,8 +782,8 @@ bool GSDeviceMTL::Create()
 	}
 	if (!m_dev.dev)
 	{
-		if (!EmuConfig.GS.Adapter.empty())
-			Console.Warning("Metal: Couldn't find adapter %s, using default", EmuConfig.GS.Adapter.c_str());
+		if (!GSConfig.Adapter.empty())
+			Console.Warning("Metal: Couldn't find adapter %s, using default", GSConfig.Adapter.c_str());
 		m_dev = GSMTLDevice(MRCTransfer(MTLCreateSystemDefaultDevice()));
 		if (!m_dev.dev)
 			Host::ReportErrorAsync("No Metal Devices Available", "No Metal-supporting GPUs were found.  PCSX2 requires a Metal GPU (available on all macs from 2012 onwards).");


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS: Replace EmuConfig.GS with GSConfig.
EmuConfig isn't safe to run on the gs thread.
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Better to use GSConfig.
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Changed configs still work.