### PR TITLE
Update GameIndex.yaml

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -40607,10 +40607,10 @@ SLPS-25679:
   name: "Utawareru Mono"
   region: "NTSC-J"
 SLPS-25680:
-  name: "Mai-Kinoto Hime [Limited Edition]"
+  name: "Mai-Otome Hime [Limited Edition]"
   region: "NTSC-J"
 SLPS-25681:
-  name: "Mai-Kinoto Hime"
+  name: "Mai-Otome Hime"
   region: "NTSC-J"
 SLPS-25682:
   name: "Sanyo Pachinko Paradise 13"


### PR DESCRIPTION

### Description of Changes
corrected romanization for Mai-Otome. Mai-Kinoto is a (machine?)translation error.

### Rationale behind Changes
That is the correct romanization of the series https://mai.fandom.com/wiki/Mai-Otome

### Suggested Testing Steps
Game list name updated