### PR TITLE
SIF: Correct junk data behaviour. Fixes True Crime Streets of LA

### DIFF
--- a/pcsx2/Sif.h
+++ b/pcsx2/Sif.h
@@ -50,12 +50,6 @@ struct sifFifo
 			if ((FIFO_SIF_W - size) < words)
 				DevCon.Warning("Not enough space in SIF0 FIFO!\n");
 
-			if (size < 4)
-			{
-				u32 amt = std::min(4 - size, words);
-				memcpy(&junk[size], from, amt << 2);
-			}
-
 			const int wP0 = std::min((FIFO_SIF_W - writePos), words);
 			const int wP1 = words - wP0;
 
@@ -68,22 +62,66 @@ struct sifFifo
 		SIF_LOG("  SIF + %d = %d (pos=%d)", words, size, writePos);
 	}
 
+	// Junk data writing
+	// 
+	// If there is not enough data produced from the IOP, it will always use the previous full quad word to
+	// fill in the missing data.
+	// One thing to note, when the IOP transfers the EE tag, it transfers a whole QW of data, which will include
+	// the EE Tag and the next IOP tag, since the EE reads 1QW of data for DMA tags.
+	//
+	// So the data used will be as follows:
+	// Less than 1QW = Junk data is made up of the EE tag + address (64 bits) and the following IOP tag (64 bits).
+	// More than 1QW = Junk data is made up of the last complete QW of data that was transferred in this packet.
+	//
+	// Data is always offset in to the junk by the amount the IOP actually transferred, so if it sent 2 words
+	// it will read words 3 and 4 out of the junk to fill the space.
+	//
+	// PS2 test results:
+	//
+	// Example of less than 1QW being sent with the only data being set being 0x69
+	//
+	//	addr 0x1500a0 value 0x69        <-- actual data (junk behind this would be the EE tag)
+	//	addr 0x1500a4 value 0x1500a0    <-- EE address
+	//	addr 0x1500a8 value 0x8001a170  <-- following IOP tag
+	//	addr 0x1500ac value 0x10        <-- following IOP tag word count
+	//
+	// Example of more than 1QW being sent with the data going from 0x20 to 0x25
+	//
+	//	addr 0x150080 value 0x21 <-- start of previously completed QW
+	//	addr 0x150084 value 0x22
+	//	addr 0x150088 value 0x23
+	//	addr 0x15008c value 0x24 <-- end of previously completed QW
+	//	addr 0x150090 value 0x25 <-- end of recorded data
+	//	addr 0x150094 value 0x22 <-- from position 2 of the previously completed quadword
+	//	addr 0x150098 value 0x23 <-- from position 3 of the previously completed quadword
+	//	addr 0x15009c value 0x24 <-- from position 4 of the previously completed quadword
+
 	void writeJunk(int words)
 	{
 		if (words > 0)
 		{
-			if ((FIFO_SIF_W - size) < words)
-				DevCon.Warning("Not enough Junk space in SIF0 FIFO!\n");
+			// Get the start position of the previously completed whole QW.
+			// Position is in word (32bit) units.
+			const int transferredWords = 4 - words;
+			const int prevQWPos = (writePos - (4 + transferredWords)) & (FIFO_SIF_W - 1);
+
+			// Read the old data in to our junk array in case of wrapping.
+			const int rP0 = std::min((FIFO_SIF_W - prevQWPos), 4);
+			const int rP1 = 4 - rP0;
+			memcpy(&junk[0], &data[prevQWPos], rP0 << 2);
+			memcpy(&junk[rP0], &data[0], rP1 << 2);
+
+			// Fill the missing words to fill the QW.
 			const int wP0 = std::min((FIFO_SIF_W - writePos), words);
 			const int wP1 = words - wP0;
-
-			memcpy(&data[writePos], &junk[4-words], wP0 << 2);
-			memcpy(&data[0], &junk[(4 - words)+wP0], wP1 << 2);
+			memcpy(&data[writePos], &junk[4- wP0], wP0 << 2);
+			memcpy(&data[0], &junk[wP0], wP1 << 2);
 
 			writePos = (writePos + words) & (FIFO_SIF_W - 1);
 			size += words;
+
+			SIF_LOG("  SIF + %d = %d Junk (pos=%d)", words, size, writePos);
 		}
-		SIF_LOG("  SIF + %d = %d (pos=%d)", words, size, writePos);
 	}
 
 	void read(u32 *to, int words)


### PR DESCRIPTION
### Description of Changes
Fixes the SIF junk behaviour to accurately match what the PS2 console does.

### Rationale behind Changes

To Save repeating myself here's the comment I made in the code.


If there is not enough data produced from the IOP, it will always use the previous full quad word to
fill in the missing data.
One thing to note, when the IOP transfers the EE tag, it transfers a whole QW of data, which will include
the EE Tag and the next IOP tag, since the EE reads 1QW of data for DMA tags.

So the data used will be as follows:
Less than 1QW = Junk data is made up of the EE tag + address (64 bits) and the following IOP tag (64 bits).
More than 1QW = Junk data is made up of the last complete QW of data that was transferred in this packet.

Data is always offset in to the junk by the amount the IOP actually transferred, so if it sent 2 words
it will read words 3 and 4 out of the junk to fill the space.

PS2 test results:
Example of less than 1QW being sent with the only data being set being 0x69

addr 0x1500a0 value 0x69              <-- actual data (junk behind this would be the EE tag)
addr 0x1500a4 value 0x1500a0      <-- EE address
addr 0x1500a8 value 0x8001a170  <-- following IOP tag
addr 0x1500ac value 0x10              <-- following IOP tag word count

Example of more than 1QW being sent with the data going from 0x20 to 0x25.

addr 0x150080 value 0x21 <-- start of previously completed QW
addr 0x150084 value 0x22
addr 0x150088 value 0x23
addr 0x15008c value 0x24 <-- end of previously completed QW
addr 0x150090 value 0x25 <-- end of recorded data
addr 0x150094 value 0x22 <-- from position 2 of the previously completed quadword
addr 0x150098 value 0x23 <-- from position 3 of the previously completed quadword
addr 0x15009c value 0x24 <-- from position 4 of the previously completed quadword


### Suggested Testing Steps
Test some normal games but also test True Crime Streets of L.A. with controller 2 connected or disconnected (shouldn't matter anymore), and PDC Darts Championship 2008 (PAL) with the BIOS daylight savings set to Winter Mode


Fixes #8482 True Crime Streets of L.A.
Fixes #6589 PDC Darts Championship 2008
Fixes Street Racing Syndicate garage crash on version 1.03 of the game.