### PR TITLE
GameDB: Various fixes

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -7078,7 +7078,6 @@ SCPS-55024:
   clampModes:
     eeClampMode: 2 # Fixes Abnormal AI behavior.
   gsHWFixes:
-    halfPixelOffset: 1 # Corrects positioning of reflections on player's AC.
     partialTargetInvalidation: 1 # Fixes broken textures.
   memcardFilters:
     - "SCPS-55024"
@@ -12093,7 +12092,6 @@ SLES-50905:
   clampModes:
     eeClampMode: 2 # Fixes Abnormal AI behavior.
   gsHWFixes:
-    halfPixelOffset: 1 # Corrects positioning of reflections on player's AC.
     partialTargetInvalidation: 1 # Fixes broken textures.
   #  Save import option was removed from PAL release.
 SLES-50906:
@@ -38279,7 +38277,6 @@ SLPS-25040:
   clampModes:
     eeClampMode: 2 # Fixes Abnormal AI behavior.
   gsHWFixes:
-    halfPixelOffset: 1 # Corrects positioning of reflections on player's AC.
     partialTargetInvalidation: 1 # Fixes broken textures.
   memcardFilters:
     - "SCPS-55024"
@@ -42179,7 +42176,6 @@ SLPS-73411:
   clampModes:
     eeClampMode: 2 # Fixes Abnormal AI behavior.
   gsHWFixes:
-    halfPixelOffset: 1 # Corrects positioning of reflections on player's AC.
     partialTargetInvalidation: 1 # Fixes broken textures.
   memcardFilters:
     - "SCPS-55024"
@@ -43262,7 +43258,6 @@ SLUS-20249:
   clampModes:
     eeClampMode: 2 # Fixes Abnormal AI behavior.
   gsHWFixes:
-    halfPixelOffset: 1 # Corrects positioning of reflections on player's AC.
     partialTargetInvalidation: 1 # Fixes broken textures.
   memcardFilters: # Can import data from regular Armored Core 2.
     - "SLUS-20249"


### PR DESCRIPTION
### Description of Changes
Removing HPO1 from Armored Core 2: Another Age

### Rationale behind Changes
Fixes broken shadows on a select few levels near the end of the game. This is a partial revert of #8291 , apologies!

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
