### PR TITLE
GS: Remove CRC hack levels

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -788,7 +788,6 @@ SCAJ-20068:
     - SoftwareRendererFMVHack # Fixes brightness and overlapping subtitles.
   gsHWFixes:
     roundSprite: 1 # Fixes font artifacts.
-    getSkipCount: "GSC_FFXGames"
 SCAJ-20069:
   name: "Gallop Racer - Lucky 7"
   region: "NTSC-Unk"
@@ -1389,7 +1388,6 @@ SCAJ-20172:
   name: "Final Fantasy XII"
   region: "NTSC-Unk"
   gsHWFixes:
-    getSkipCount: "GSC_FFXGames"
     partialTargetInvalidation: 1 # Fixes broken textures.
 SCAJ-20173:
   name: "Ace Combat Zero - The Belkan War"
@@ -1440,7 +1438,6 @@ SCAJ-20179:
     halfPixelOffset: 1 # Fixes lighting misalignment and reduces ground shadows (probably texture cache issue).
     roundSprite: 2 # Fixes font artifacts.
     textureInsideRT: 1 # Fixes bad crystal surfaces.
-    getSkipCount: "GSC_XenosagaE3"
 SCAJ-20180:
   name: "Xenosaga Episode III - Also Sprach Zarathustra [Disc 2 of 2]"
   region: "NTSC-Unk"
@@ -1449,7 +1446,6 @@ SCAJ-20180:
     halfPixelOffset: 1 # Fixes lighting misalignment and reduces ground shadows (probably texture cache issue).
     roundSprite: 2 # Fixes font artifacts.
     textureInsideRT: 1 # Fixes bad crystal surfaces.
-    getSkipCount: "GSC_XenosagaE3"
 SCAJ-20181:
   name: "Minna no Tennis"
   region: "NTSC-Unk"
@@ -1475,7 +1471,6 @@ SCAJ-20188:
   name: "Final Fantasy XII - International - Zodiac Job System"
   region: "NTSC-Unk"
   gsHWFixes:
-    getSkipCount: "GSC_FFXGames"
     partialTargetInvalidation: 1 # Fixes broken textures.
 SCAJ-20190:
   name: "God of War II"
@@ -1560,7 +1555,6 @@ SCAJ-25012:
     - SoftwareRendererFMVHack # Fixes brightness and overlapping subtitles.
   gsHWFixes:
     roundSprite: 1 # Fixes font artifacts.
-    getSkipCount: "GSC_FFXGames"
 SCAJ-25026:
   name: "Kunoichi Shinobi"
   region: "NTSC-Unk"
@@ -1906,7 +1900,6 @@ SCED-50642:
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
     textureInsideRT: 1 # Fixes wrong visuals for the summon Anima and The (Triple) Magus Sisters.
-    getSkipCount: "GSC_FFXGames"
     beforeDraw: "OI_FFX"
 SCED-50675:
   name: "Official PlayStation 2 Magazine Demo 16"
@@ -1985,7 +1978,6 @@ SCED-50907:
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
     textureInsideRT: 1 # Fixes wrong visuals for the summon Anima and The (Triple) Magus Sisters.
-    getSkipCount: "GSC_FFXGames"
     beforeDraw: "OI_FFX"
 SCED-50945:
   name: "Official PlayStation 2 Magazine Demo 20"
@@ -3102,7 +3094,6 @@ SCES-50490:
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
     textureInsideRT: 1 # Fixes wrong visuals for the summon Anima and The (Triple) Magus Sisters.
-    getSkipCount: "GSC_FFXGames"
     beforeDraw: "OI_FFX"
 SCES-50491:
   name: "Final Fantasy X"
@@ -3112,7 +3103,6 @@ SCES-50491:
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
     textureInsideRT: 1 # Fixes wrong visuals for the summon Anima and The (Triple) Magus Sisters.
-    getSkipCount: "GSC_FFXGames"
     beforeDraw: "OI_FFX"
 SCES-50492:
   name: "Final Fantasy X"
@@ -3123,7 +3113,6 @@ SCES-50492:
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
     textureInsideRT: 1 # Fixes wrong visuals for the summon Anima and The (Triple) Magus Sisters..
-    getSkipCount: "GSC_FFXGames"
     beforeDraw: "OI_FFX"
 SCES-50493:
   name: "Final Fantasy X"
@@ -3133,7 +3122,6 @@ SCES-50493:
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
     textureInsideRT: 1 # Fixes wrong visuals for the summon Anima and The (Triple) Magus Sisters.
-    getSkipCount: "GSC_FFXGames"
     beforeDraw: "OI_FFX"
 SCES-50494:
   name: "Final Fantasy X"
@@ -3143,7 +3131,6 @@ SCES-50494:
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
     textureInsideRT: 1 # Fixes wrong visuals for the summon Anima and The (Triple) Magus Sisters.
-    getSkipCount: "GSC_FFXGames"
     beforeDraw: "OI_FFX"
 SCES-50499:
   name: "Ecco the Dolphin - Defender of the Future"
@@ -5450,7 +5437,6 @@ SCKA-20073:
   name: "Final Fantasy XII"
   region: "NTSC-K"
   gsHWFixes:
-    getSkipCount: "GSC_FFXGames"
     partialTargetInvalidation: 1 # Fixes broken textures.
 SCKA-20078:
   name: "Killzone [PlayStation 2 Big Hit Series]"
@@ -5459,7 +5445,6 @@ SCKA-20078:
     vuClampMode: 0 # Resolves I Reg Clamping / performance impact and yellow graphics in certain areas.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
-    getSkipCount: "GSC_FFXGames"
 SCKA-20079:
   name: "Valkyrie Profile 2 - Silmeria"
   region: "NTSC-K"
@@ -5484,13 +5469,11 @@ SCKA-20086:
   region: "NTSC-K"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misalignment and upscaling lines.
-    getSkipCount: "GSC_ShinOnimusha"
 SCKA-20087:
   name: "Shin Onimusha - Dawn of Dreams [Disc 2 of 2]"
   region: "NTSC-K"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misalignment and upscaling lines.
-    getSkipCount: "GSC_ShinOnimusha"
   memcardFilters:
     - "SCKA-20086"
 SCKA-20089:
@@ -5530,7 +5513,6 @@ SCKA-20095:
   region: "NTSC-K"
   gsHWFixes:
     roundSprite: 2 # Reduces misalignment issues but the game is just bad for upscaling.
-    getSkipCount: "GSC_Okami"
 SCKA-20096:
   name: "Barnyard"
   region: "NTSC-K"
@@ -5588,7 +5570,6 @@ SCKA-20138:
   name: "Final Fantasy XII [Ultimate Hits International Zodiac Job System]"
   region: "NTSC-K"
   gsHWFixes:
-    getSkipCount: "GSC_FFXGames"
     partialTargetInvalidation: 1 # Fixes broken textures.
 SCKA-24008:
   name: "SOCOM - U.S. Navy SEALs"
@@ -9304,7 +9285,6 @@ SLAJ-25012:
     - SoftwareRendererFMVHack # Fixes brightness and overlapping subtitles.
   gsHWFixes:
     roundSprite: 1 # Fixes font artifacts.
-    getSkipCount: "GSC_FFXGames"
 SLAJ-25014:
   name: "Cyber Troopers - Virtual-On Marz"
   region: "NTSC-Unk"
@@ -13986,7 +13966,6 @@ SLES-51815:
     - SoftwareRendererFMVHack # Fixes brightness and overlapping subtitles.
   gsHWFixes:
     roundSprite: 1 # Fixes font artifacts.
-    getSkipCount: "GSC_FFXGames"
 SLES-51816:
   name: "Final Fantasy X-2"
   region: "PAL-F"
@@ -13994,7 +13973,6 @@ SLES-51816:
     - SoftwareRendererFMVHack # Fixes brightness and overlapping subtitles.
   gsHWFixes:
     roundSprite: 1 # Fixes font artifacts.
-    getSkipCount: "GSC_FFXGames"
 SLES-51817:
   name: "Final Fantasy X-2"
   region: "PAL-G"
@@ -14003,7 +13981,6 @@ SLES-51817:
     - SoftwareRendererFMVHack # Fixes brightness and overlapping subtitles.
   gsHWFixes:
     roundSprite: 1 # Fixes font artifacts.
-    getSkipCount: "GSC_FFXGames"
 SLES-51818:
   name: "Final Fantasy X-2"
   region: "PAL-I"
@@ -14011,7 +13988,6 @@ SLES-51818:
     - SoftwareRendererFMVHack # Fixes brightness and overlapping subtitles.
   gsHWFixes:
     roundSprite: 1 # Fixes font artifacts.
-    getSkipCount: "GSC_FFXGames"
 SLES-51819:
   name: "Final Fantasy X-2"
   region: "PAL-S"
@@ -14020,7 +13996,6 @@ SLES-51819:
     - SoftwareRendererFMVHack # Fixes brightness and overlapping subtitles.
   gsHWFixes:
     roundSprite: 1 # Fixes font artifacts.
-    getSkipCount: "GSC_FFXGames"
 SLES-51820:
   name: "Sniper Elite"
   region: "PAL-M5"
@@ -15471,8 +15446,6 @@ SLES-52478:
   name: "Red Dead Revolver"
   region: "PAL-M5"
   compat: 4
-  gsHWFixes:
-    getSkipCount: "GSC_RedDeadRevolver"
 SLES-52479:
   name: "Samurai Jack - The Shadow of Aku"
   region: "PAL-M5"
@@ -20498,32 +20471,27 @@ SLES-54354:
   region: "PAL-E"
   compat: 5
   gsHWFixes:
-    getSkipCount: "GSC_FFXGames"
     partialTargetInvalidation: 1 # Fixes broken textures.
 SLES-54355:
   name: "Final Fantasy XII"
   region: "PAL-F"
   gsHWFixes:
-    getSkipCount: "GSC_FFXGames"
     partialTargetInvalidation: 1 # Fixes broken textures.
 SLES-54356:
   name: "Final Fantasy XII"
   region: "PAL-G"
   gsHWFixes:
-    getSkipCount: "GSC_FFXGames"
     partialTargetInvalidation: 1 # Fixes broken textures.
 SLES-54357:
   name: "Final Fantasy XII"
   region: "PAL-I"
   gsHWFixes:
-    getSkipCount: "GSC_FFXGames"
     partialTargetInvalidation: 1 # Fixes broken textures.
 SLES-54358:
   name: "Final Fantasy XII"
   region: "PAL-S"
   compat: 5
   gsHWFixes:
-    getSkipCount: "GSC_FFXGames"
     partialTargetInvalidation: 1 # Fixes broken textures.
 SLES-54359:
   name: "Legend of Spyro, The - A New Beginning"
@@ -20742,7 +20710,6 @@ SLES-54439:
   region: "PAL-M3"
   gsHWFixes:
     roundSprite: 2 # Reduces misalignment issues but the game is just bad for upscaling.
-    getSkipCount: "GSC_Okami"
 SLES-54440:
   name: "GT-R Touring"
   region: "PAL-E"
@@ -24001,14 +23968,12 @@ SLES-82038:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misalignment and upscaling lines.
-    getSkipCount: "GSC_ShinOnimusha"
 SLES-82039:
   name: "Onimusha - Dawn of Dreams [Disc 2 of 2]"
   region: "PAL-M5"
   compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misalignment and upscaling lines.
-    getSkipCount: "GSC_ShinOnimusha"
   memcardFilters:
     - "SLES-82038"
 SLES-82042:
@@ -24634,7 +24599,6 @@ SLKA-25144:
     - SoftwareRendererFMVHack # Fixes brightness and overlapping subtitles.
   gsHWFixes:
     roundSprite: 1 # Fixes font artifacts.
-    getSkipCount: "GSC_FFXGames"
 SLKA-25145:
   name: "dot hack  - Outbreak"
   region: "NTSC-K"
@@ -24865,7 +24829,6 @@ SLKA-25214:
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
     textureInsideRT: 1 # Fixes wrong visuals for the summon Anima and The (Triple) Magus Sisters.
-    getSkipCount: "GSC_FFXGames"
     beforeDraw: "OI_FFX"
 SLKA-25215:
   name: "Shining Wind"
@@ -25538,7 +25501,6 @@ SLPM-55022:
   name: "Final Fantasy XII [Ultimate Hits]"
   region: "NTSC-J"
   gsHWFixes:
-    getSkipCount: "GSC_FFXGames"
     partialTargetInvalidation: 1 # Fixes broken textures.
 SLPM-55024:
   name: "Jikkyou Powerful Pro Yakyuu 15"
@@ -25881,7 +25843,6 @@ SLPM-55210:
   name: "Final Fantasy XII International Zodiac Job System [Ultimate Hits]"
   region: "NTSC-J"
   gsHWFixes:
-    getSkipCount: "GSC_FFXGames"
     partialTargetInvalidation: 1 # Fixes broken textures.
 SLPM-55211:
   name: "Pachislot Higurashi no Naku Koro ni Matsuri"
@@ -26109,7 +26070,6 @@ SLPM-60149:
     alignSprite: 1 # Fixes vertical lines.
     mergeSprite: 1 # Fixes vertical lines.
     gpuTargetCLUT: 1 # Fixes broken sun.
-    getSkipCount: "GSC_AceCombat4"
 SLPM-60172:
   name: "Itadaki Street 3 - Okuman Chouja ni Shiteageru"
   region: "NTSC-J"
@@ -26406,7 +26366,6 @@ SLPM-61147:
     halfPixelOffset: 1 # Fixes lighting misalignment and reduces ground shadows (probably texture cache issue).
     roundSprite: 2 # Fixes font artifacts.
     textureInsideRT: 1 # Fixes bad crystal surfaces.
-    getSkipCount: "GSC_XenosagaE3"
 SLPM-61148:
   name: "Growlanser V - Generations [Taikenban Demo]"
   region: "NTSC-J"
@@ -29152,7 +29111,6 @@ SLPM-65115:
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
     textureInsideRT: 1 # Fixes wrong visuals for the summon Anima and The (Triple) Magus Sisters.
-    getSkipCount: "GSC_FFXGames"
     beforeDraw: "OI_FFX"
 SLPM-65116:
   name: "Lilie no Atelier Plus - Salburg no Renkinjutsushi 3"
@@ -30385,7 +30343,6 @@ SLPM-65478:
     - SoftwareRendererFMVHack # Fixes brightness and overlapping subtitles.
   gsHWFixes:
     roundSprite: 1 # Fixes font artifacts.
-    getSkipCount: "GSC_FFXGames"
 SLPM-65479:
   name: "Sims, The - Bustin' Out"
   region: "NTSC-J"
@@ -31683,8 +31640,6 @@ SLPM-65853:
 SLPM-65854:
   name: "Red Dead Revolver"
   region: "NTSC-J"
-  gsHWFixes:
-    getSkipCount: "GSC_RedDeadRevolver"
 SLPM-65855:
   name: "Girls Bravo - Romance 15's [Deluxe Pack]"
   region: "NTSC-J"
@@ -32705,7 +32660,6 @@ SLPM-66124:
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
     textureInsideRT: 1 # Fixes wrong visuals for the summon Anima and The (Triple) Magus Sisters.
-    getSkipCount: "GSC_FFXGames"
     beforeDraw: "OI_FFX"
 SLPM-66125:
   name: "Final Fantasy X-2 [Ultimate Hits]"
@@ -32714,7 +32668,6 @@ SLPM-66125:
     - SoftwareRendererFMVHack # Fixes brightness and overlapping subtitles.
   gsHWFixes:
     roundSprite: 1 # Fixes font artifacts.
-    getSkipCount: "GSC_FFXGames"
 SLPM-66129:
   name: "Guilty Gear XX #Reload"
   region: "NTSC-J"
@@ -33316,14 +33269,12 @@ SLPM-66275:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misalignment and upscaling lines.
-    getSkipCount: "GSC_ShinOnimusha"
 SLPM-66276:
   name: "Shin Onimusha - Dawn of Dreams [Disc 2 of 2]"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misalignment and upscaling lines.
-    getSkipCount: "GSC_ShinOnimusha"
   memcardFilters:
     - "SLPM-66275"
 SLPM-66277:
@@ -33495,7 +33446,6 @@ SLPM-66320:
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
-    getSkipCount: "GSC_FFXGames"
     partialTargetInvalidation: 1 # Fixes broken textures.
 SLPM-66321:
   name: "Kurogane no Houkou - Warship Gunner 2"
@@ -33706,7 +33656,6 @@ SLPM-66375:
   compat: 5
   gsHWFixes:
     roundSprite: 2 # Reduces misalignment issues but the game is just bad for upscaling.
-    getSkipCount: "GSC_Okami"
 SLPM-66376:
   name: "KimiStar - Kimi to Study [BGM Collection Package]"
   region: "NTSC-J"
@@ -34911,7 +34860,6 @@ SLPM-66677:
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
     textureInsideRT: 1 # Fixes wrong visuals for the summon Anima and The (Triple) Magus Sisters.
-    getSkipCount: "GSC_FFXGames"
     beforeDraw: "OI_FFX"
 SLPM-66678:
   name: "Final Fantasy X-2 - International + Last Mission [Ultimate Hits]"
@@ -34920,7 +34868,6 @@ SLPM-66678:
     - SoftwareRendererFMVHack # Fixes brightness and overlapping subtitles.
   gsHWFixes:
     roundSprite: 1 # Fixes font artifacts.
-    getSkipCount: "GSC_FFXGames"
 SLPM-66679:
   name: "Devil Summoner - Kuzunoha Raidou tai Abaddon Ou [Plus]"
   region: "NTSC-J"
@@ -35223,7 +35170,6 @@ SLPM-66750:
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
-    getSkipCount: "GSC_FFXGames"
     partialTargetInvalidation: 1 # Fixes broken textures.
 SLPM-66751:
   name: "Mahoroba Stories"
@@ -36159,7 +36105,6 @@ SLPM-67513:
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
     textureInsideRT: 1 # Fixes wrong visuals for the summon Anima and The (Triple) Magus Sisters.
-    getSkipCount: "GSC_FFXGames"
     beforeDraw: "OI_FFX"
 SLPM-67514:
   name: "Kessen"
@@ -36484,7 +36429,6 @@ SLPM-74232:
     - SoftwareRendererFMVHack # Wrong white textures in FMV.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misalignment and upscaling lines.
-    getSkipCount: "GSC_ShinOnimusha"
   memcardFilters:
     - "SLPM-66275"
 SLPM-74233:
@@ -36492,7 +36436,6 @@ SLPM-74233:
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misalignment and upscaling lines.
-    getSkipCount: "GSC_ShinOnimusha"
   memcardFilters:
     - "SLPM-74232"
 SLPM-74234:
@@ -36515,7 +36458,6 @@ SLPM-74239:
   region: "NTSC-J"
   gsHWFixes:
     roundSprite: 2 # Reduces misalignment issues but the game is just bad for upscaling.
-    getSkipCount: "GSC_Okami"
 SLPM-74240:
   name: "Tengai Makyou III - Namida [Best Version]"
   region: "NTSC-J"
@@ -36601,7 +36543,6 @@ SLPM-74251:
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misalignment and upscaling lines.
-    getSkipCount: "GSC_ShinOnimusha"
   memcardFilters:
     - "SLPM-66275"
 SLPM-74252:
@@ -36609,7 +36550,6 @@ SLPM-74252:
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misalignment and upscaling lines.
-    getSkipCount: "GSC_ShinOnimusha"
   memcardFilters:
     - "SLPM-74251"
 SLPM-74253:
@@ -38332,7 +38272,6 @@ SLPS-25050:
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
     textureInsideRT: 1 # Fixes wrong visuals for the summon Anima and The (Triple) Magus Sisters.
-    getSkipCount: "GSC_FFXGames"
     beforeDraw: "OI_FFX"
 SLPS-25051:
   name: "Missing Blue"
@@ -38347,7 +38286,6 @@ SLPS-25052:
     alignSprite: 1 # Fixes vertical lines.
     mergeSprite: 1 # Fixes vertical lines.
     gpuTargetCLUT: 1 # Fixes broken sun.
-    getSkipCount: "GSC_AceCombat4"
 SLPS-25053:
   name: "Eikan wa Kimi ni - Koushien no Hasha"
   region: "NTSC-J"
@@ -38473,7 +38411,6 @@ SLPS-25088:
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
     textureInsideRT: 1 # Fixes wrong visuals for the summon Anima and The (Triple) Magus Sisters.
-    getSkipCount: "GSC_FFXGames"
     beforeDraw: "OI_FFX"
 SLPS-25089:
   name: "Salt Lake 2002"
@@ -39032,7 +38969,6 @@ SLPS-25250:
     - SoftwareRendererFMVHack # Fixes brightness and overlapping subtitles.
   gsHWFixes:
     roundSprite: 1 # Fixes font artifacts.
-    getSkipCount: "GSC_FFXGames"
 SLPS-25251:
   name: "MVP Baseball 2003"
   region: "NTSC-J"
@@ -40472,7 +40408,6 @@ SLPS-25640:
     halfPixelOffset: 1 # Fixes lighting misalignment and reduces ground shadows (probably texture cache issue).
     roundSprite: 2 # Fixes font artifacts.
     textureInsideRT: 1 # Fixes bad crystal surfaces.
-    getSkipCount: "GSC_XenosagaE3"
   memcardFilters: # Allows import of Xenosaga II save data.
     - "SLPS-25640"
     - "SLPS-25368"
@@ -40485,7 +40420,6 @@ SLPS-25641:
     halfPixelOffset: 1 # Fixes lighting misalignment and reduces ground shadows (probably texture cache issue).
     roundSprite: 2 # Fixes font artifacts.
     textureInsideRT: 1 # Fixes bad crystal surfaces.
-    getSkipCount: "GSC_XenosagaE3"
   memcardFilters:
     - "SLPS-25640"
     - "SLPS-25368"
@@ -41661,7 +41595,6 @@ SLPS-72501:
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
     textureInsideRT: 1 # Fixes wrong visuals for the summon Anima and The (Triple) Magus Sisters.
-    getSkipCount: "GSC_FFXGames"
     beforeDraw: "OI_FFX"
 SLPS-72502:
   name: "Tales of Destiny 2 [Mega Hits]"
@@ -41759,7 +41692,6 @@ SLPS-73205:
     alignSprite: 1 # Fixes vertical lines.
     mergeSprite: 1 # Fixes vertical lines.
     gpuTargetCLUT: 1 # Fixes broken sun.
-    getSkipCount: "GSC_AceCombat4"
 SLPS-73206:
   name: "Super Robot Taisen Alpha 2nd [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -42169,7 +42101,6 @@ SLPS-73410:
     alignSprite: 1 # Fixes vertical lines.
     mergeSprite: 1 # Fixes vertical lines.
     gpuTargetCLUT: 1 # Fixes broken sun.
-    getSkipCount: "GSC_AceCombat4"
 SLPS-73411:
   name: "Armored Core 2 - Another Age [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -42833,7 +42764,6 @@ SLUS-20152:
     alignSprite: 1 # Fixes vertical lines.
     mergeSprite: 1 # Fixes vertical lines.
     gpuTargetCLUT: 1 # Fixes broken sun.
-    getSkipCount: "GSC_AceCombat4"
   patches:
     A32F7CD0:
       content: |-
@@ -43523,7 +43453,6 @@ SLUS-20312:
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
     textureInsideRT: 1 # Fixes wrong visuals for the summon Anima and The (Triple) Magus Sisters.
-    getSkipCount: "GSC_FFXGames"
     beforeDraw: "OI_FFX"
 SLUS-20313:
   name: "Wave Rally"
@@ -44441,8 +44370,6 @@ SLUS-20500:
   name: "Red Dead Revolver"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    getSkipCount: "GSC_RedDeadRevolver"
 SLUS-20502:
   name: "Colin McRae Rally 3"
   region: "NTSC-U"
@@ -45294,7 +45221,6 @@ SLUS-20672:
     - SoftwareRendererFMVHack # Fixes brightness and overlapping subtitles.
   gsHWFixes:
     roundSprite: 1 # Fixes font artifacts.
-    getSkipCount: "GSC_FFXGames"
 SLUS-20673:
   name: "Alias"
   region: "NTSC-U"
@@ -46768,7 +46694,6 @@ SLUS-20963:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    getSkipCount: "GSC_FFXGames"
     partialTargetInvalidation: 1 # Fixes broken textures.
 SLUS-20964:
   name: "Devil May Cry 3 - Dante's Awakening"
@@ -47606,7 +47531,6 @@ SLUS-21115:
   compat: 5
   gsHWFixes:
     roundSprite: 2 # Reduces misalignment issues but the game is just bad for upscaling.
-    getSkipCount: "GSC_Okami"
 SLUS-21116:
   name: "187 - Ride or Die"
   region: "NTSC-U"
@@ -47922,7 +47846,6 @@ SLUS-21180:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misalignment and upscaling lines.
-    getSkipCount: "GSC_ShinOnimusha"
 SLUS-21181:
   name: "D.I.C.E. - DNA Integrated Cybernetic Enterprises"
   region: "NTSC-U"
@@ -49055,7 +48978,6 @@ SLUS-21362:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misalignment and upscaling lines.
-    getSkipCount: "GSC_ShinOnimusha"
   memcardFilters:
     - "SLUS-21180"
 SLUS-21363:
@@ -49228,7 +49150,6 @@ SLUS-21389:
     halfPixelOffset: 1 # Fixes lighting misalignment and reduces ground shadows.
     roundSprite: 2 # Fixes font artifacts.
     textureInsideRT: 1 # Fixes bad crystal surfaces.
-    getSkipCount: "GSC_XenosagaE3"
   memcardFilters: # Allows import of Xenosaga II save data.
     - "SLUS-21389"
     - "SLUS-20892"
@@ -49378,7 +49299,6 @@ SLUS-21417:
     halfPixelOffset: 1 # Fixes lighting misalignment and reduces ground shadows.
     roundSprite: 2 # Fixes font artifacts.
     textureInsideRT: 1 # Fixes bad crystal surfaces.
-    getSkipCount: "GSC_XenosagaE3"
   memcardFilters:
     - "SLUS-21389"
     - "SLUS-20892"
@@ -49709,7 +49629,6 @@ SLUS-21475:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    getSkipCount: "GSC_FFXGames"
     partialTargetInvalidation: 1 # Fixes broken textures.
 SLUS-21476:
   name: "Madden NFL '07"
@@ -52607,7 +52526,6 @@ SLUS-29171:
   name: "Final Fantasy XII [Demo]"
   region: "NTSC-U"
   gsHWFixes:
-    getSkipCount: "GSC_FFXGames"
     partialTargetInvalidation: 1 # Fixes broken textures.
 SLUS-29172:
   name: "Battlefield 2 - Modern Combat [Demo]"

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -181,8 +181,6 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsDialog* dialog, QWidget* 
 	//////////////////////////////////////////////////////////////////////////
 	// HW Renderer Fixes
 	//////////////////////////////////////////////////////////////////////////
-	SettingWidgetBinder::BindWidgetToIntSetting(
-		sif, m_ui.crcFixLevel, "EmuCore/GS", "crc_hack_level", static_cast<int>(CRCHackLevel::Automatic), -1);
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.halfScreenFix, "EmuCore/GS", "UserHacks_Half_Bottom_Override", -1, -1);
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.cpuSpriteRenderBW, "EmuCore/GS", "UserHacks_CPUSpriteRenderBW", 0);
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.cpuSpriteRenderLevel, "EmuCore/GS", "UserHacks_CPUSpriteRenderLevel", 0);
@@ -194,6 +192,7 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsDialog* dialog, QWidget* 
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.frameBufferConversion, "EmuCore/GS", "UserHacks_CPU_FB_Conversion", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.disableDepthEmulation, "EmuCore/GS", "UserHacks_DisableDepthSupport", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.disableSafeFeatures, "EmuCore/GS", "UserHacks_Disable_Safe_Features", false);
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.disableRenderFixes, "EmuCore/GS", "UserHacks_DisableRenderFixes", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.preloadFrameData, "EmuCore/GS", "preload_frame_with_gs_data", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(
 		sif, m_ui.disablePartialInvalidation, "EmuCore/GS", "UserHacks_DisablePartialInvalidation", false);
@@ -471,9 +470,6 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsDialog* dialog, QWidget* 
 			   "Unscaled: Native Dithering / Lowest dithering effect does not increase size of squares when upscaling.<br> "
 			   "Scaled: Upscaling-aware / Highest dithering effect."));
 
-		dialog->registerWidgetHelp(m_ui.crcFixLevel, tr("CRC Fix Level"), tr("Automatic (Default)"),
-			tr("Control the number of Auto-CRC fixes and hacks applied to games."));
-
 		dialog->registerWidgetHelp(m_ui.blending, tr("Blending Accuracy"), tr("Basic (Recommended)"),
 			tr("Control the accuracy level of the GS blending unit emulation.<br> "
 			   "The higher the setting, the more blending is emulated in the shader accurately, and the higher the speed penalty will "
@@ -544,6 +540,9 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsDialog* dialog, QWidget* 
 			   "Disables accurate Unscale Point and Line rendering which can help Xenosaga games. "
 			   "Disables accurate GS Memory Clearing to be done on the CPU, and let the GPU handle it, which can help Kingdom Hearts "
 			   "games."));
+
+		dialog->registerWidgetHelp(
+			m_ui.disableRenderFixes, tr("Disable Render Fixes"), tr("Unchecked"), tr("This option disables game-specific render fixes."));
 
 		dialog->registerWidgetHelp(m_ui.disablePartialInvalidation, tr("Disable Partial Source Invalidation"), tr("Unchecked"),
 			tr("By default, the texture cache handles partial invalidations. Unfortunately it is very costly to compute CPU wise. "
@@ -1051,7 +1050,6 @@ void GraphicsSettingsWidget::resetManualHardwareFixes()
 
 		check_bool("EmuCore/GS", "UserHacks", false);
 
-		check_int("EmuCore/GS", "crc_hack_level", static_cast<int>(CRCHackLevel::Automatic));
 		check_int("EmuCore/GS", "UserHacks_Half_Bottom_Override", -1);
 		check_int("EmuCore/GS", "UserHacks_CPUSpriteRenderBW", 0);
 		check_int("EmuCore/GS", "UserHacks_CPUCLUTRender", 0);
@@ -1062,6 +1060,7 @@ void GraphicsSettingsWidget::resetManualHardwareFixes()
 		check_bool("EmuCore/GS", "UserHacks_CPU_FB_Conversion", false);
 		check_bool("EmuCore/GS", "UserHacks_DisableDepthSupport", false);
 		check_bool("EmuCore/GS", "UserHacks_Disable_Safe_Features", false);
+		check_bool("EmuCore/GS", "UserHacks_DisableRenderFixes", false);
 		check_bool("EmuCore/GS", "preload_frame_with_gs_data", false);
 		check_bool("EmuCore/GS", "UserHacks_DisablePartialInvalidation", false);
 		check_int("EmuCore/GS", "UserHacks_TextureInsideRt", static_cast<int>(GSTextureInRtMode::Disabled));

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
@@ -781,54 +781,13 @@
       </attribute>
       <layout class="QFormLayout" name="hardwareFixesLayout">
        <item row="0" column="0">
-        <widget class="QLabel" name="label_7">
-         <property name="text">
-          <string>CRC Fix Level:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="1">
-        <widget class="QComboBox" name="crcFixLevel">
-         <item>
-          <property name="text">
-           <string>Automatic (Default)</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>None (Debug)</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Minimum (Debug)</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Partial (OpenGL)</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Full (Direct3D)</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Aggressive</string>
-          </property>
-         </item>
-        </widget>
-       </item>
-       <item row="1" column="0">
         <widget class="QLabel" name="label_10">
          <property name="text">
           <string>Half Screen Fix:</string>
          </property>
         </widget>
        </item>
-       <item row="1" column="1">
+       <item row="0" column="1">
         <widget class="QComboBox" name="halfScreenFix">
          <item>
           <property name="text">
@@ -847,14 +806,14 @@
          </item>
         </widget>
        </item>
-       <item row="2" column="0">
+       <item row="1" column="0">
         <widget class="QLabel" name="label_36">
          <property name="text">
           <string>CPU Sprite Render Size:</string>
          </property>
         </widget>
        </item>
-       <item row="2" column="1">
+       <item row="1" column="1">
         <layout class="QHBoxLayout" name="horizontalLayout_5" stretch="1,0">
          <item>
           <widget class="QComboBox" name="cpuSpriteRenderBW">
@@ -936,14 +895,14 @@
          </item>
         </layout>
        </item>
-       <item row="3" column="0">
+       <item row="2" column="0">
         <widget class="QLabel" name="label_16">
          <property name="text">
           <string>Software CLUT Render:</string>
          </property>
         </widget>
        </item>
-       <item row="3" column="1">
+       <item row="2" column="1">
         <widget class="QComboBox" name="cpuCLUTRender">
          <property name="currentText">
           <string extracomment="0 (Disabled)">0 (Disabled)</string>
@@ -968,14 +927,14 @@
          </item>
         </widget>
        </item>
-       <item row="4" column="0">
+       <item row="3" column="0">
         <widget class="QLabel" name="label_47">
          <property name="text">
           <string extracomment="CLUT: Color Look Up Table, often referred to as a palette in non-PS2 things.  GPU Target CLUT: GPU handling of when a game uses data from a render target as a CLUT.">GPU Target CLUT:</string>
          </property>
         </widget>
        </item>
-       <item row="4" column="1">
+       <item row="3" column="1">
         <widget class="QComboBox" name="gpuTargetCLUTMode">
          <item>
           <property name="text">
@@ -994,40 +953,14 @@
          </item>
         </widget>
        </item>
-       <item row="6" column="0">
-        <widget class="QLabel" name="label_45">
-         <property name="text">
-          <string>Texture Inside RT:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="6" column="1">
-        <widget class="QComboBox" name="textureInsideRt">
-         <item>
-          <property name="text">
-           <string>Disabled (Default)</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Inside Target</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Merge Targets</string>
-          </property>
-         </item>
-        </widget>
-       </item>
-       <item row="5" column="0">
+       <item row="4" column="0">
         <widget class="QLabel" name="label_30">
          <property name="text">
           <string>Auto Flush:</string>
          </property>
         </widget>
        </item>
-       <item row="5" column="1">
+       <item row="4" column="1">
         <widget class="QComboBox" name="hwAutoFlush">
          <item>
           <property name="text">
@@ -1046,14 +979,40 @@
          </item>
         </widget>
        </item>
-       <item row="7" column="0">
+       <item row="5" column="0">
+        <widget class="QLabel" name="label_45">
+         <property name="text">
+          <string>Texture Inside RT:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="1">
+        <widget class="QComboBox" name="textureInsideRt">
+         <item>
+          <property name="text">
+           <string>Disabled (Default)</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Inside Target</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Merge Targets</string>
+          </property>
+         </item>
+        </widget>
+       </item>
+       <item row="6" column="0">
         <widget class="QLabel" name="label_12">
          <property name="text">
           <string>Skipdraw Range:</string>
          </property>
         </widget>
        </item>
-       <item row="7" column="1">
+       <item row="6" column="1">
         <layout class="QHBoxLayout" name="horizontalLayout">
          <item>
           <widget class="QSpinBox" name="skipDrawStart">
@@ -1071,7 +1030,7 @@
          </item>
         </layout>
        </item>
-       <item row="8" column="0" colspan="2">
+       <item row="7" column="0" colspan="2">
         <layout class="QGridLayout" name="gridLayout">
          <item row="0" column="0">
           <widget class="QCheckBox" name="disableDepthEmulation">
@@ -1094,45 +1053,52 @@
            </property>
           </widget>
          </item>
-         <item row="3" column="0">
-          <widget class="QCheckBox" name="estimateTextureRegion">
+         <item row="4" column="1">
+          <widget class="QCheckBox" name="targetPartialInvalidation">
            <property name="text">
-            <string>Estimate Texture Region</string>
+            <string>Target Partial Invalidation</string>
            </property>
           </widget>
          </item>
-         <item row="4" column="0">
-          <widget class="QCheckBox" name="frameBufferConversion">
-           <property name="text">
-            <string>Frame Buffer Conversion</string>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="1">
-          <widget class="QCheckBox" name="gpuPaletteConversion">
-           <property name="text">
-            <string>GPU Palette Conversion</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="1">
-          <widget class="QCheckBox" name="preloadFrameData">
-           <property name="text">
-            <string>Preload Frame Data</string>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="1">
+         <item row="3" column="1">
           <widget class="QCheckBox" name="readTCOnClose">
            <property name="text">
             <string>Read Targets When Closing</string>
            </property>
           </widget>
          </item>
-         <item row="3" column="1">
-          <widget class="QCheckBox" name="targetPartialInvalidation">
+         <item row="2" column="1">
+          <widget class="QCheckBox" name="preloadFrameData">
            <property name="text">
-            <string>Target Partial Invalidation</string>
+            <string>Preload Frame Data</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QCheckBox" name="gpuPaletteConversion">
+           <property name="text">
+            <string>GPU Palette Conversion</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QCheckBox" name="frameBufferConversion">
+           <property name="text">
+            <string>Frame Buffer Conversion</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="0">
+          <widget class="QCheckBox" name="estimateTextureRegion">
+           <property name="text">
+            <string>Estimate Texture Region</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="0">
+          <widget class="QCheckBox" name="disableRenderFixes">
+           <property name="text">
+            <string>Disable Render Fixes</string>
            </property>
           </widget>
          </item>

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -288,16 +288,6 @@ enum class HWMipmapLevel : s8
 	Full
 };
 
-enum class CRCHackLevel : s8
-{
-	Automatic = -1,
-	Off,
-	Minimum,
-	Partial,
-	Full,
-	Aggressive
-};
-
 enum class AccBlendLevel : u8
 {
 	Minimum,
@@ -685,6 +675,7 @@ struct Pcsx2Config
 					UserHacks_DisableDepthSupport : 1,
 					UserHacks_DisablePartialInvalidation : 1,
 					UserHacks_DisableSafeFeatures : 1,
+					UserHacks_DisableRenderFixes : 1,
 					UserHacks_MergePPSprite : 1,
 					UserHacks_WildHack : 1,
 					UserHacks_BilinearHack : 1,
@@ -742,7 +733,6 @@ struct Pcsx2Config
 
 		HWMipmapLevel HWMipmap = HWMipmapLevel::Automatic;
 		AccBlendLevel AccurateBlendingUnit = AccBlendLevel::Basic;
-		CRCHackLevel CRCHack = CRCHackLevel::Automatic;
 		BiFiltering TextureFiltering = BiFiltering::PS2;
 		TexturePreloadingLevel TexturePreloading = TexturePreloadingLevel::Full;
 		GSDumpCompressionMethod GSDumpCompression = GSDumpCompressionMethod::Zstandard;

--- a/pcsx2/Frontend/FullscreenUI.cpp
+++ b/pcsx2/Frontend/FullscreenUI.cpp
@@ -3185,9 +3185,6 @@ void FullscreenUI::DrawGraphicsSettingsPage()
 			static constexpr const char* s_auto_flush_options[] = {
 				"Disabled (Default)", "Enabled (Sprites Only)", "Enabled (All Primitives)"};
 
-			DrawIntListSetting(bsi, "CRC Fix Level", "Applies manual fixes to difficult-to-emulate effects in the hardware renderers.",
-				"EmuCore/GS", "crc_hack_level", static_cast<int>(CRCHackLevel::Automatic), s_crc_fix_options, std::size(s_crc_fix_options),
-				-1);
 			DrawIntListSetting(bsi, "Half-Bottom Override", "Control the half-screen fix detection on texture shuffling.", "EmuCore/GS",
 				"UserHacks_Half_Bottom_Override", -1, s_generic_options, std::size(s_generic_options), -1);
 			DrawIntListSetting(bsi, "CPU Sprite Render Size", "Uses software renderer to draw texture decompression-like sprites.",
@@ -3208,6 +3205,8 @@ void FullscreenUI::DrawGraphicsSettingsPage()
 				"UserHacks_DisableDepthSupport", false, manual_hw_fixes);
 			DrawToggleSetting(bsi, "Disable Safe Features", "This option disables multiple safe features.", "EmuCore/GS",
 				"UserHacks_Disable_Safe_Features", false, manual_hw_fixes);
+			DrawToggleSetting(bsi, "Disable Render Features", "This option disables game-specific render fixes.", "EmuCore/GS",
+				"UserHacks_DisableRenderFixes", false, manual_hw_fixes);
 			DrawToggleSetting(bsi, "Preload Frame", "Uploads GS data when rendering a new frame to reproduce some effects accurately.",
 				"EmuCore/GS", "preload_frame_with_gs_data", false, manual_hw_fixes);
 			DrawToggleSetting(bsi, "Disable Partial Invalidation",

--- a/pcsx2/Frontend/ImGuiOverlays.cpp
+++ b/pcsx2/Frontend/ImGuiOverlays.cpp
@@ -392,8 +392,6 @@ void ImGuiManager::DrawSettingsOverlay()
 			APPEND("AF={} ", EmuConfig.GS.MaxAnisotropy);
 		if (GSConfig.Dithering != 2)
 			APPEND("DI={} ", GSConfig.Dithering);
-		if (EmuConfig.GS.CRCHack != CRCHackLevel::Automatic)
-			APPEND("CRC={} ", static_cast<unsigned>(EmuConfig.GS.CRCHack));
 		if (GSConfig.UserHacks_HalfBottomOverride >= 0)
 			APPEND("HBO={} ", GSConfig.UserHacks_HalfBottomOverride);
 		if (GSConfig.UserHacks_HalfPixelOffset > 0)
@@ -436,6 +434,8 @@ void ImGuiManager::DrawSettingsOverlay()
 			APPEND("TPI ");
 		if (GSConfig.UserHacks_DisableSafeFeatures)
 			APPEND("DSF ");
+		if (GSConfig.UserHacks_DisableRenderFixes)
+			APPEND("DRF ");
 		if (GSConfig.PreloadFrameWithGSData)
 			APPEND("PLFD ");
 		if (GSConfig.UserHacks_EstimateTextureRegion)

--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -774,8 +774,7 @@ void GSUpdateConfig(const Pcsx2Config::GSOptions& new_config)
 	}
 
 	// Options which aren't using the global struct yet, so we need to recreate all GS objects.
-	if (
-		GSConfig.SWExtraThreads != old_config.SWExtraThreads ||
+	if (GSConfig.SWExtraThreads != old_config.SWExtraThreads ||
 		GSConfig.SWExtraThreadsHeight != old_config.SWExtraThreadsHeight)
 	{
 		if (!GSreopen(false, true, old_config))
@@ -784,10 +783,7 @@ void GSUpdateConfig(const Pcsx2Config::GSOptions& new_config)
 		return;
 	}
 
-	// This is where we would do finer-grained checks in the future.
-	// For example, flushing the texture cache when mipmap settings change.
-
-	if (GSConfig.CRCHack != old_config.CRCHack ||
+	if (GSConfig.UserHacks_DisableRenderFixes != old_config.UserHacks_DisableRenderFixes ||
 		GSConfig.UpscaleMultiplier != old_config.UpscaleMultiplier ||
 		GSConfig.GetSkipCountFunctionId != old_config.GetSkipCountFunctionId ||
 		GSConfig.BeforeDrawFunctionId != old_config.BeforeDrawFunctionId)

--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -2587,7 +2587,7 @@ void GSState::SetGameCRC(u32 crc)
 
 void GSState::UpdateCRCHacks()
 {
-	m_game = CRC::Lookup((GSConfig.CRCHack != CRCHackLevel::Off) ? m_crc : 0);
+	m_game = CRC::Lookup(GSConfig.UserHacks_DisableRenderFixes ? 0 : m_crc);
 }
 
 //

--- a/pcsx2/GS/GSUtil.cpp
+++ b/pcsx2/GS/GSUtil.cpp
@@ -196,11 +196,6 @@ u32 GSUtil::GetChannelMask(u32 spsm)
 	}
 }
 
-CRCHackLevel GSUtil::GetRecommendedCRCHackLevel(GSRendererType type)
-{
-	return (type == GSRendererType::DX11 || type == GSRendererType::DX12) ? CRCHackLevel::Full : CRCHackLevel::Partial;
-}
-
 GSRendererType GSUtil::GetPreferredRenderer()
 {
 #if defined(__APPLE__)

--- a/pcsx2/GS/GSUtil.h
+++ b/pcsx2/GS/GSUtil.h
@@ -35,7 +35,6 @@ public:
 	static bool HasSameSwizzleBits(u32 spsm, u32 dpsm);
 	static u32 GetChannelMask(u32 spsm);
 
-	static CRCHackLevel GetRecommendedCRCHackLevel(GSRendererType type);
 	static GSRendererType GetPreferredRenderer();
 };
 

--- a/pcsx2/GS/Renderers/HW/GSHwHack.cpp
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.cpp
@@ -542,150 +542,16 @@ bool GSHwHack::GSC_SteambotChronicles(GSRendererHW& r, int& skip)
 	return true;
 }
 
-////////////////////////////////////////////////////////////////////////////////
-// Full level, correctly emulated on OpenGL/Vulkan but can be used as potential speed hack
-////////////////////////////////////////////////////////////////////////////////
-
 bool GSHwHack::GSC_GetawayGames(GSRendererHW& r, int& skip)
 {
+	if (GSConfig.AccurateBlendingUnit >= AccBlendLevel::High)
+		return true;
+
 	if (skip == 0)
 	{
 		if ((RFBP == 0 || RFBP == 0x1180 || RFBP == 0x1400) && RTPSM == PSMT8H && RFBMSK == 0)
 		{
 			skip = 1; // Removes fog wall.
-		}
-	}
-
-	return true;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-// Aggressive only hack
-////////////////////////////////////////////////////////////////////////////////
-
-bool GSHwHack::GSC_AceCombat4(GSRendererHW& r, int& skip)
-{
-	// Removes clouds for a good speed boost, removes both 3D clouds(invisible with Hardware renderers, but cause slowdown) and 2D background clouds.
-	// Removes blur from player airplane.
-	// This hack also removes rockets, shows explosions(invisible without CRC hack) as garbage data,
-	// causes flickering issues with the HUD, and in some (night) missions removes the HUD altogether.
-
-	if (skip == 0)
-	{
-		if (RTME && RFBP == 0x02a00 && RFPSM == PSMZ24 && RTBP0 == 0x01600 && RTPSM == PSMZ24)
-		{
-			skip = 71; // clouds (z, 16-bit)
-		}
-	}
-
-	return true;
-}
-
-bool GSHwHack::GSC_FFXGames(GSRendererHW& r, int& skip)
-{
-	if (skip == 0)
-	{
-		if (RTME)
-		{
-			// depth textures (bully, mgs3s1 intro, Front Mission 5)
-			if ((RTPSM == PSMZ32 || RTPSM == PSMZ24 || RTPSM == PSMZ16 || RTPSM == PSMZ16S) ||
-				// General, often problematic post processing
-				(GSUtil::HasSharedBits(RFBP, RFPSM, RTBP0, RTPSM)))
-			{
-				skip = 1;
-			}
-		}
-	}
-
-	return true;
-}
-
-bool GSHwHack::GSC_Okami(GSRendererHW& r, int& skip)
-{
-	if (skip == 0)
-	{
-		if (RTME && RFBP == 0x00e00 && RFPSM == PSMCT32 && RTBP0 == 0x00000 && RTPSM == PSMCT32)
-		{
-			skip = 1000;
-		}
-	}
-	else
-	{
-		if (RTME && RFBP == 0x00e00 && RFPSM == PSMCT32 && RTBP0 == 0x03800 && RTPSM == PSMT4)
-		{
-			skip = 0;
-		}
-	}
-
-	return true;
-}
-
-bool GSHwHack::GSC_RedDeadRevolver(GSRendererHW& r, int& skip)
-{
-	if (skip == 0)
-	{
-		if (RFBP == 0x03700 && RFPSM == PSMCT32 && RTPSM == PSMCT24)
-		{
-			skip = 2; // Blur
-		}
-	}
-
-	return true;
-}
-
-bool GSHwHack::GSC_ShinOnimusha(GSRendererHW& r, int& skip)
-{
-	if (skip == 0)
-	{
-		if (RTME && RFBP == 0x001000 && (RTBP0 == 0 || RTBP0 == 0x0800) && RTPSM == PSMT8H && RFBMSK == 0x00FFFFFF)
-		{
-			skip = 0; // Water ripple not needed ?
-		}
-		else if (RTPSM == PSMCT24 && RTME && RFBP == 0x01000) // || GSC_FBP == 0x00000
-		{
-			skip = 28; //28 30 56 64
-		}
-		else if (RFBP && RTPSM == PSMT8H && RFBMSK == 0xFFFFFF)
-		{
-			skip = 0; //24 33 40 9
-		}
-		else if (RTPSM == PSMT8H && RFBMSK == 0xFF000000)
-		{
-			skip = 1; // White fog when picking up things
-		}
-		else if (RTME && (RTBP0 == 0x1400 || RTBP0 == 0x1000 || RTBP0 == 0x1200) && (RTPSM == PSMCT32 || RTPSM == PSMCT24))
-		{
-			skip = 1; // Eliminate excessive flooding, water and other light and shadow
-		}
-	}
-
-	return true;
-}
-
-bool GSHwHack::GSC_XenosagaE3(GSRendererHW& r, int& skip)
-{
-	if (skip == 0)
-	{
-		if (RTPSM == PSMT8H && RFBMSK >= 0xEFFFFFFF)
-		{
-			skip = 73; // Animation
-		}
-		else if (RTME && RFBP == 0x03800 && RTBP0 && RTPSM == 0 && RFBMSK == 0)
-		{
-			skip = 1; // Ghosting
-		}
-		else
-		{
-			if (RTME)
-			{
-				// depth textures (bully, mgs3s1 intro, Front Mission 5)
-				if ((RTPSM == PSMZ32 || RTPSM == PSMZ24 || RTPSM == PSMZ16 || RTPSM == PSMZ16S) ||
-					// General, often problematic post processing
-					(GSUtil::HasSharedBits(RFBP, RFPSM, RTBP0, RTPSM)))
-				{
-					skip = 1;
-				}
-			}
 		}
 	}
 
@@ -1186,16 +1052,7 @@ const GSHwHack::Entry<GSRendererHW::GSC_Ptr> GSHwHack::s_get_skip_count_function
 	CRC_F(GSC_UltramanFightingEvolution, CRCHackLevel::Partial),
 
 	// Accurate Blending
-	CRC_F(GSC_GetawayGames, CRCHackLevel::Full), // Blending High
-
-	CRC_F(GSC_AceCombat4, CRCHackLevel::Aggressive),
-	CRC_F(GSC_FFXGames, CRCHackLevel::Aggressive),
-	CRC_F(GSC_RedDeadRevolver, CRCHackLevel::Aggressive),
-	CRC_F(GSC_ShinOnimusha, CRCHackLevel::Aggressive),
-	CRC_F(GSC_XenosagaE3, CRCHackLevel::Aggressive),
-
-	// Upscaling issues
-	CRC_F(GSC_Okami, CRCHackLevel::Aggressive),
+	CRC_F(GSC_GetawayGames, CRCHackLevel::Partial),
 };
 
 const GSHwHack::Entry<GSRendererHW::OI_Ptr> GSHwHack::s_before_draw_functions[] = {

--- a/pcsx2/GS/Renderers/HW/GSHwHack.cpp
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.cpp
@@ -19,11 +19,6 @@
 #include "GS/GSGL.h"
 
 static bool s_nativeres;
-static CRCHackLevel s_crc_hack_level = CRCHackLevel::Full;
-
-#define CRC_Partial (s_crc_hack_level >= CRCHackLevel::Partial)
-#define CRC_Full (s_crc_hack_level >= CRCHackLevel::Full)
-#define CRC_Aggressive (s_crc_hack_level >= CRCHackLevel::Aggressive)
 
 #define RPRIM r.PRIM
 #define RCONTEXT r.m_context
@@ -64,11 +59,13 @@ bool GSHwHack::GSC_DeathByDegreesTekkenNinaWilliams(GSRendererHW& r, int& skip)
 			// Upscaling issue similar to Tekken 5.
 			skip = 1; // Animation pane
 		}
-		else if (CRC_Aggressive && RFBP == 0x3500 && RTPSM == PSMT8 && RFBMSK == 0xFFFF00FF)
+#if 0
+		else if (RFBP == 0x3500 && RTPSM == PSMT8 && RFBMSK == 0xFFFF00FF)
 		{
 			// Needs to be further tested so put it on Aggressive for now, likely channel shuffle.
 			skip = 4; // Underwater white fog
 		}
+#endif
 	}
 	else
 	{
@@ -531,10 +528,6 @@ bool GSHwHack::GSC_SteambotChronicles(GSRendererHW& r, int& skip)
 			else if (RFBP == 0)
 			{
 				skip = 100; // deletes most others(too high deletes the buggy sea completely;c, too low causes glitches to be visible)
-			}
-			else if (CRC_Aggressive && RFBP != 0)
-			{
-				skip = 19; // "speedhack", makes the game very light, vaporized water can disappear when not looked at directly, possibly some interface still, other value to try: 6 breaks menu background, possibly nothing(?) during gameplay, but it's slower, hence not much of a speedhack anymore
 			}
 		}
 	}
@@ -1006,66 +999,62 @@ bool GSHwHack::OI_HauntingGround(GSRendererHW& r, GSTexture* rt, GSTexture* ds, 
 #undef RZMSK
 #undef RZTST
 
-#undef CRC_Partial
-#undef CRC_Full
-#undef CRC_Aggressive
-
 ////////////////////////////////////////////////////////////////////////////////
 
-#define CRC_F(name, level) { #name, &GSHwHack::name, level }
+#define CRC_F(name) { #name, &GSHwHack::name }
 
 const GSHwHack::Entry<GSRendererHW::GSC_Ptr> GSHwHack::s_get_skip_count_functions[] = {
-	CRC_F(GSC_GodHand, CRCHackLevel::Partial),
-	CRC_F(GSC_KnightsOfTheTemple2, CRCHackLevel::Partial),
-	CRC_F(GSC_Kunoichi, CRCHackLevel::Partial),
-	CRC_F(GSC_Manhunt2, CRCHackLevel::Partial),
-	CRC_F(GSC_MidnightClub3, CRCHackLevel::Partial),
-	CRC_F(GSC_SacredBlaze, CRCHackLevel::Partial),
-	CRC_F(GSC_SakuraTaisen, CRCHackLevel::Partial),
-	CRC_F(GSC_SakuraWarsSoLongMyLove, CRCHackLevel::Partial),
-	CRC_F(GSC_Simple2000Vol114, CRCHackLevel::Partial),
-	CRC_F(GSC_SFEX3, CRCHackLevel::Partial),
-	CRC_F(GSC_TalesOfLegendia, CRCHackLevel::Partial),
-	CRC_F(GSC_TalesofSymphonia, CRCHackLevel::Partial),
-	CRC_F(GSC_UrbanReign, CRCHackLevel::Partial),
-	CRC_F(GSC_ZettaiZetsumeiToshi2, CRCHackLevel::Partial),
-	CRC_F(GSC_BlackAndBurnoutSky, CRCHackLevel::Partial),
-	CRC_F(GSC_BlueTongueGames, CRCHackLevel::Partial),
-	CRC_F(GSC_Battlefield2, CRCHackLevel::Partial),
-	CRC_F(GSC_NFSUndercover, CRCHackLevel::Partial),
-	CRC_F(GSC_PolyphonyDigitalGames, CRCHackLevel::Partial),
+	CRC_F(GSC_GodHand),
+	CRC_F(GSC_KnightsOfTheTemple2),
+	CRC_F(GSC_Kunoichi),
+	CRC_F(GSC_Manhunt2),
+	CRC_F(GSC_MidnightClub3),
+	CRC_F(GSC_SacredBlaze),
+	CRC_F(GSC_SakuraTaisen),
+	CRC_F(GSC_SakuraWarsSoLongMyLove),
+	CRC_F(GSC_Simple2000Vol114),
+	CRC_F(GSC_SFEX3),
+	CRC_F(GSC_TalesOfLegendia),
+	CRC_F(GSC_TalesofSymphonia),
+	CRC_F(GSC_UrbanReign),
+	CRC_F(GSC_ZettaiZetsumeiToshi2),
+	CRC_F(GSC_BlackAndBurnoutSky),
+	CRC_F(GSC_BlueTongueGames),
+	CRC_F(GSC_Battlefield2),
+	CRC_F(GSC_NFSUndercover),
+	CRC_F(GSC_PolyphonyDigitalGames),
 
 	// Channel Effect
-	CRC_F(GSC_GiTS, CRCHackLevel::Partial),
-	CRC_F(GSC_SteambotChronicles, CRCHackLevel::Partial),
+	CRC_F(GSC_GiTS),
+	CRC_F(GSC_SteambotChronicles),
 
 	// Depth Issue
-	CRC_F(GSC_BurnoutGames, CRCHackLevel::Partial),
+	CRC_F(GSC_BurnoutGames),
 
 	// Half Screen bottom issue
-	CRC_F(GSC_Tekken5, CRCHackLevel::Partial),
+	CRC_F(GSC_Tekken5),
 
 	// Texture shuffle
-	CRC_F(GSC_DeathByDegreesTekkenNinaWilliams, CRCHackLevel::Partial), // + Upscaling issues
+	CRC_F(GSC_DeathByDegreesTekkenNinaWilliams), // + Upscaling issues
 
 	// Upscaling hacks
-	CRC_F(GSC_UltramanFightingEvolution, CRCHackLevel::Partial),
+	CRC_F(GSC_UltramanFightingEvolution),
 
 	// Accurate Blending
-	CRC_F(GSC_GetawayGames, CRCHackLevel::Partial),
+	CRC_F(GSC_GetawayGames),
 };
 
 const GSHwHack::Entry<GSRendererHW::OI_Ptr> GSHwHack::s_before_draw_functions[] = {
-	CRC_F(OI_PointListPalette, CRCHackLevel::Minimum),
-	CRC_F(OI_BigMuthaTruckers, CRCHackLevel::Minimum),
-	CRC_F(OI_DBZBTGames, CRCHackLevel::Minimum),
-	CRC_F(OI_FFX, CRCHackLevel::Minimum),
-	CRC_F(OI_RozenMaidenGebetGarden, CRCHackLevel::Minimum),
-	CRC_F(OI_SonicUnleashed, CRCHackLevel::Minimum),
-	CRC_F(OI_ArTonelico2, CRCHackLevel::Minimum),
-	CRC_F(OI_BurnoutGames, CRCHackLevel::Minimum),
-	CRC_F(OI_Battlefield2, CRCHackLevel::Minimum),
-	CRC_F(OI_HauntingGround, CRCHackLevel::Minimum)
+	CRC_F(OI_PointListPalette),
+	CRC_F(OI_BigMuthaTruckers),
+	CRC_F(OI_DBZBTGames),
+	CRC_F(OI_FFX),
+	CRC_F(OI_RozenMaidenGebetGarden),
+	CRC_F(OI_SonicUnleashed),
+	CRC_F(OI_ArTonelico2),
+	CRC_F(OI_BurnoutGames),
+	CRC_F(OI_Battlefield2),
+	CRC_F(OI_HauntingGround)
 };
 
 #undef CRC_F
@@ -1096,28 +1085,22 @@ void GSRendererHW::UpdateCRCHacks()
 {
 	GSRenderer::UpdateCRCHacks();
 
-	const CRCHackLevel real_level = (GSConfig.CRCHack == CRCHackLevel::Automatic) ?
-		GSUtil::GetRecommendedCRCHackLevel(GSConfig.Renderer) : GSConfig.CRCHack;
-
 	m_nativeres = (GSConfig.UpscaleMultiplier == 1.0f);
 	s_nativeres = m_nativeres;
-	s_crc_hack_level = real_level;
 
 	m_gsc = nullptr;
 	m_oi = nullptr;
 
-	if (real_level != CRCHackLevel::Off)
+	if (!GSConfig.UserHacks_DisableRenderFixes)
 	{
 		if (GSConfig.GetSkipCountFunctionId >= 0 &&
-			static_cast<size_t>(GSConfig.GetSkipCountFunctionId) < std::size(GSHwHack::s_get_skip_count_functions) &&
-			real_level >= GSHwHack::s_get_skip_count_functions[GSConfig.GetSkipCountFunctionId].level)
+			static_cast<size_t>(GSConfig.GetSkipCountFunctionId) < std::size(GSHwHack::s_get_skip_count_functions))
 		{
 			m_gsc = GSHwHack::s_get_skip_count_functions[GSConfig.GetSkipCountFunctionId].ptr;
 		}
 
 		if (GSConfig.BeforeDrawFunctionId >= 0 &&
-			static_cast<size_t>(GSConfig.BeforeDrawFunctionId) < std::size(GSHwHack::s_before_draw_functions) &&
-			real_level >= GSHwHack::s_before_draw_functions[GSConfig.BeforeDrawFunctionId].level)
+			static_cast<size_t>(GSConfig.BeforeDrawFunctionId) < std::size(GSHwHack::s_before_draw_functions))
 		{
 			m_oi = GSHwHack::s_before_draw_functions[GSConfig.BeforeDrawFunctionId].ptr;
 		}

--- a/pcsx2/GS/Renderers/HW/GSHwHack.h
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.h
@@ -61,7 +61,6 @@ public:
 	{
 		const char* name;
 		F ptr;
-		CRCHackLevel level;
 	};
 
 	static const Entry<GSRendererHW::GSC_Ptr> s_get_skip_count_functions[];

--- a/pcsx2/GS/Renderers/HW/GSHwHack.h
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.h
@@ -40,12 +40,6 @@ public:
 	static bool GSC_UrbanReign(GSRendererHW& r, int& skip);
 	static bool GSC_SteambotChronicles(GSRendererHW& r, int& skip);
 	static bool GSC_GetawayGames(GSRendererHW& r, int& skip);
-	static bool GSC_AceCombat4(GSRendererHW& r, int& skip);
-	static bool GSC_FFXGames(GSRendererHW& r, int& skip);
-	static bool GSC_Okami(GSRendererHW& r, int& skip);
-	static bool GSC_RedDeadRevolver(GSRendererHW& r, int& skip);
-	static bool GSC_ShinOnimusha(GSRendererHW& r, int& skip);
-	static bool GSC_XenosagaE3(GSRendererHW& r, int& skip);
 	static bool GSC_BlueTongueGames(GSRendererHW& r, int& skip);
 	static bool GSC_Battlefield2(GSRendererHW& r, int& skip);
 	static bool GSC_NFSUndercover(GSRendererHW& r, int& skip);

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -445,6 +445,7 @@ Pcsx2Config::GSOptions::GSOptions()
 	UserHacks_DisableDepthSupport = false;
 	UserHacks_DisablePartialInvalidation = false;
 	UserHacks_DisableSafeFeatures = false;
+	UserHacks_DisableRenderFixes = false;
 	UserHacks_MergePPSprite = false;
 	UserHacks_WildHack = false;
 	UserHacks_BilinearHack = false;
@@ -506,7 +507,6 @@ bool Pcsx2Config::GSOptions::OptionsAreEqual(const GSOptions& right) const
 
 		OpEqu(HWMipmap) &&
 		OpEqu(AccurateBlendingUnit) &&
-		OpEqu(CRCHack) &&
 		OpEqu(TextureFiltering) &&
 		OpEqu(TexturePreloading) &&
 		OpEqu(GSDumpCompression) &&
@@ -662,6 +662,7 @@ void Pcsx2Config::GSOptions::LoadSave(SettingsWrapper& wrap)
 	GSSettingBoolEx(UserHacks_DisableDepthSupport, "UserHacks_DisableDepthSupport");
 	GSSettingBoolEx(UserHacks_DisablePartialInvalidation, "UserHacks_DisablePartialInvalidation");
 	GSSettingBoolEx(UserHacks_DisableSafeFeatures, "UserHacks_Disable_Safe_Features");
+	GSSettingBoolEx(UserHacks_DisableRenderFixes, "UserHacks_DisableRenderFixes");
 	GSSettingBoolEx(UserHacks_MergePPSprite, "UserHacks_merge_pp_sprite");
 	GSSettingBoolEx(UserHacks_WildHack, "UserHacks_WildHack");
 	GSSettingBoolEx(UserHacks_BilinearHack, "UserHacks_BilinearHack");
@@ -703,7 +704,6 @@ void Pcsx2Config::GSOptions::LoadSave(SettingsWrapper& wrap)
 
 	GSSettingIntEnumEx(HWMipmap, "mipmap_hw");
 	GSSettingIntEnumEx(AccurateBlendingUnit, "accurate_blending_unit");
-	GSSettingIntEnumEx(CRCHack, "crc_hack_level");
 	GSSettingIntEnumEx(TextureFiltering, "filter");
 	GSSettingIntEnumEx(TexturePreloading, "texture_preloading");
 	GSSettingIntEnumEx(GSDumpCompression, "GSDumpCompression");
@@ -787,6 +787,7 @@ void Pcsx2Config::GSOptions::MaskUserHacks()
 	UserHacks_BilinearHack = false;
 	UserHacks_NativePaletteDraw = false;
 	UserHacks_DisableSafeFeatures = false;
+	UserHacks_DisableRenderFixes = false;
 	UserHacks_HalfBottomOverride = -1;
 	UserHacks_HalfPixelOffset = 0;
 	UserHacks_RoundSprite = 0;

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -1949,8 +1949,6 @@ void VMManager::WarnAboutUnsafeSettings()
 		messages += ICON_FA_PAGER " Trilinear filtering is not set to automatic. This may break rendering in some games.\n";
 	if (EmuConfig.GS.AccurateBlendingUnit <= AccBlendLevel::Minimum)
 		messages += ICON_FA_BLENDER " Blending is below basic, this may break effects in some games.\n";
-	if (EmuConfig.GS.CRCHack != CRCHackLevel::Automatic)
-		messages += ICON_FA_FIRST_AID " CRC Fix Level is not set to default, this may break effects in some games.\n";
 	if (EmuConfig.GS.HWDownloadMode != GSHardwareDownloadMode::Enabled)
 		messages += ICON_FA_DOWNLOAD " Hardware Download Mode is not set to Accurate, this may break rendering in some games.\n";
 	if (EmuConfig.Cpu.sseMXCSR.GetRoundMode() != SSEround_Chop)


### PR DESCRIPTION
### Description of Changes

Replace it with a boolean "Disable Render Fixes" option.

Most of them didn't do anything, and the aggressive CRC hacks are not needed anymore.

GSC_AceCombat4 - couldn't get this to trigger.
GSC_FFXGames - dunno what this did, but FFX has been fine for some time.
GSC_Okami - breaks a bunch of the game's effects, downsample is intentional.
GSC_RedDeadRevolver - working as intended, patch on forums.
GSC_ShinOnimusha - breaks effects, only saves 5-10% GPU at 8x.
GSC_XenosagaE3 - breaks cutscenes, minimal perf difference.

### Rationale behind Changes

Freeing up a row so the settings dialog isn't so large.

Helping reduce the perception that PCSX2 is "full of hacks".

### Suggested Testing Steps

Make sure option breaks games which need render fixes.
