### PR TITLE
GS/HW: Handle texture shuffles using region repeat (Ace Combat Series)

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -758,11 +758,7 @@ GSVector2i GSRendererHW::GetTargetSize(const GSTextureCache::Source* tex)
 		}
 	}
 
-	const GSVector2i size = g_texture_cache->GetTargetSize(m_cached_ctx.FRAME.Block(), m_cached_ctx.FRAME.FBW, m_cached_ctx.FRAME.PSM, width, height);
-
-	GL_INS("Target size for %x %u %u: %ux%u", m_cached_ctx.FRAME.Block(), m_cached_ctx.FRAME.FBW, m_cached_ctx.FRAME.PSM, size.x, size.y);
-
-	return size;
+	return g_texture_cache->GetTargetSize(m_cached_ctx.FRAME.Block(), m_cached_ctx.FRAME.FBW, m_cached_ctx.FRAME.PSM, width, height);
 }
 
 bool GSRendererHW::IsPossibleChannelShuffle() const

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -4788,7 +4788,8 @@ GSRendererHW::CLUTDrawTestResult GSRendererHW::PossibleCLUTDraw()
 			if (HasEEUpload(r))
 				return CLUTDrawTestResult::CLUTDrawOnCPU;
 
-			GSTextureCache::Target* tgt = g_texture_cache->GetExactTarget(m_cached_ctx.TEX0.TBP0, m_cached_ctx.TEX0.TBW, m_cached_ctx.TEX0.PSM);
+			GSTextureCache::Target* tgt = g_texture_cache->GetExactTarget(
+				m_cached_ctx.TEX0.TBP0, m_cached_ctx.TEX0.TBW, GSTextureCache::RenderTarget);
 			if (tgt)
 			{
 				bool is_dirty = false;

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.h
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.h
@@ -76,7 +76,7 @@ private:
 
 	void ResetStates();
 	void SetupIA(float target_scale, float sx, float sy);
-	void EmulateTextureShuffleAndFbmask();
+	void EmulateTextureShuffleAndFbmask(GSTextureCache::Target* rt);
 	bool EmulateChannelShuffle(GSTextureCache::Target* src, bool test_only);
 	void EmulateBlending(bool& DATE_PRIMID, bool& DATE_BARRIER, bool& blending_alpha_pass);
 

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.h
@@ -208,7 +208,11 @@ public:
 	{
 	public:
 		const int m_type = 0;
-		bool m_dirty_alpha = true;
+
+		// Valid alpha means "we have rendered to the alpha channel of this target".
+		// A false value means that the alpha in local memory is still valid/up-to-date.
+		bool m_valid_alpha = false;
+
 		bool m_is_frame = false;
 		bool m_used = false;
 		float OffsetHack_modxy = 0.0f;
@@ -232,6 +236,9 @@ public:
 
 		/// Updates the target, if the dirty area intersects with the specified rectangle.
 		void UpdateIfDirtyIntersects(const GSVector4i& rc);
+
+		/// Updates the valid alpha flag, based on PSM and fbmsk.
+		void UpdateValidAlpha(u32 psm, u32 fbmsk);
 
 		/// Resizes target texture, DOES NOT RESCALE.
 		bool ResizeTexture(int new_unscaled_width, int new_unscaled_height, bool recycle_old = true);


### PR DESCRIPTION
### Description of Changes

Ace Combat 04 reads RG, writes to RGBA by setting a MINU of 1015.

### Rationale behind Changes

Fixes #1547.
Fixes #1739.
Fixes #1861.
Fixes #6626.

<img width="1091" alt="Untitled" src="https://github.com/PCSX2/pcsx2/assets/11288319/858c5f69-89ea-4726-8402-932c656de0c0">
<img width="1091" alt="Untitled" src="https://github.com/PCSX2/pcsx2/assets/11288319/dc7fc66a-80e0-4534-9871-ac72254b8a4d">
<img width="1148" alt="Untitled" src="https://github.com/PCSX2/pcsx2/assets/11288319/85868b44-cbd7-4a9a-a4b8-f41c664d05fc">
(clouds need CPU CLUT off, breaks them for some reason..)

### Suggested Testing Steps

Test AC games.
