### PR TITLE
GameDB: Add SW FMV render to Poinie's Poin

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -5825,6 +5825,8 @@ SCPS-15012:
 SCPS-15013:
   name: "Poinie's Poin"
   region: "NTSC-J"
+  gameFixes:
+    - SoftwareRendererFMVHack # Prevents ingame flicker due to large clears/copies.
   gsHWFixes:
     textureInsideRT: 1 # Fixes text corruption.
 SCPS-15014:
@@ -7157,6 +7159,8 @@ SCPS-55044:
 SCPS-55045:
   name: "Poinie's Poin"
   region: "NTSC-J"
+  gameFixes:
+    - SoftwareRendererFMVHack # Prevents ingame flicker due to large clears/copies
   gsHWFixes:
     textureInsideRT: 1 # Fixes text corruption.
 SCPS-55046:


### PR DESCRIPTION
### Description of Changes

Game does 640x1232 draws to clear out most (but not all) of GS memory, then 224 high draws to 1216 high targets, presumably moving GS memory around. TME is enabled, I don't want to try to HLE this mess.

Enabling SW FMV render isn't needed for the FMV, it's just a convenient way to remove these targets from the TC, as the clearing/copying mess happens before the FMVs play.

### Rationale behind Changes

Closes #8772.

### Suggested Testing Steps

Test affected game (done with the supplied blockdump).