### PR TITLE
CDVD: Reload game data when swapping discs to reflect new name.

### DIFF
--- a/pcsx2/CDVD/CDVD.cpp
+++ b/pcsx2/CDVD/CDVD.cpp
@@ -1452,7 +1452,7 @@ void cdvdUpdateTrayState()
 					if (g_GameStarted)
 					{
 						cdvdReloadElfInfo();
-						VMManager::Internal::GameStartingOnCPUThread();
+						VMManager::Internal::SwappingGameOnCPUThread();
 					}
 					break;
 				case CDVD_DISC_SEEKING:

--- a/pcsx2/CDVD/CDVD.cpp
+++ b/pcsx2/CDVD/CDVD.cpp
@@ -18,6 +18,7 @@
 #include "Common.h"
 #include "IopHw.h"
 #include "IopDma.h"
+#include "VMManager.h"
 
 #include <cctype>
 #include <ctime>
@@ -1447,6 +1448,12 @@ void cdvdUpdateTrayState()
 					cdvd.Tray.trayState = CDVD_DISC_SEEKING;
 					cdvdUpdateStatus(CDVD_STATUS_SEEK);
 					cdvd.Tray.cdvdActionSeconds = 2;
+					// If we're swapping disc, reload the elf, patches etc to reflect the new disc.
+					if (g_GameStarted)
+					{
+						cdvdReloadElfInfo();
+						VMManager::Internal::GameStartingOnCPUThread();
+					}
 					break;
 				case CDVD_DISC_SEEKING:
 					cdvd.Spinning = true;

--- a/pcsx2/VMManager.h
+++ b/pcsx2/VMManager.h
@@ -207,6 +207,7 @@ namespace VMManager
 		bool IsExecutionInterrupted();
 		void EntryPointCompilingOnCPUThread();
 		void GameStartingOnCPUThread();
+		void SwappingGameOnCPUThread();
 		void VSyncOnCPUThread();
 	} // namespace Internal
 } // namespace VMManager


### PR DESCRIPTION
### Description of Changes
Reloads disc information when a disc swap occurs

### Rationale behind Changes
Some people were asking for it so they could see what disc they were on (and discord rich presence ofc).
Also if you do a savestate after swapping disc, it wouldn't let you reload it unless you restart the game.

Funny side effect on Monster Rancher 4 when using Saucer Discs is that it will show the name for the game you insert if there are any, but it shouldn't load any new patches, but it will load gamefixes which might cause it to crash, but it's the best I could do.  However if a game requires a patch, you won't be able to load it with codebreaker, I'm sorry but I can't risk loading patches, it could completely break games like Monster Rancher.

### Suggested Testing Steps
Test games with disc swaps and make sure the name etc changes and savestates are related to the disc you have in.

Fixes #8275