### PR TITLE
GS-HW: Fix annoying NASCAR offsets in PCRTC using HW mode

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -44531,6 +44531,7 @@ SLUS-20535:
   compat: 5
   gsHWFixes:
     roundSprite: 1 # Fix horizontal and vertical lines when racing.
+    deinterlace: 8 # Fixes misdetection of game deinterlace.
 SLUS-20536:
   name: "NBA Live 2003"
   region: "NTSC-U"
@@ -45618,6 +45619,9 @@ SLUS-20753:
 SLUS-20754:
   name: "NASCAR Thunder 2004"
   region: "NTSC-U"
+  gsHWFixes:
+    roundSprite: 1 # Fix horizontal and vertical lines when racing.
+    deinterlace: 8 # Fixes misdetection of game deinterlace.
   memcardFilters:
     - "PSCD10088" # Enables EA Sports BIO.
     - "SLUS-20754"
@@ -45948,6 +45952,9 @@ SLUS-20823:
 SLUS-20824:
   name: "NASCAR Thunder 2004"
   region: "NTSC-U"
+  gsHWFixes:
+    roundSprite: 1 # Fix horizontal and vertical lines when racing.
+    deinterlace: 8 # Fixes misdetection of game deinterlace.
   memcardFilters:
     - "PSCD10088" # Enables EA Sports BIO.
     - "SLUS-20824"

--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -635,21 +635,45 @@ public:
 		{
 			if (GSConfig.PCRTCAntiBlur && PCRTCSameSrc && !scanmask)
 			{
-				if (abs(PCRTCDisplays[1].framebufferOffsets.y - PCRTCDisplays[0].framebufferOffsets.y) == 1
+				GSVector2i fb0 = GSVector2i(PCRTCDisplays[0].framebufferOffsets.x, PCRTCDisplays[0].framebufferOffsets.y);
+				GSVector2i fb1 = GSVector2i(PCRTCDisplays[1].framebufferOffsets.x, PCRTCDisplays[1].framebufferOffsets.y);
+
+				if (fb0.x + PCRTCDisplays[0].displayRect.z > 2048)
+				{
+					fb0.x -= 2048;
+					fb0.x = abs(fb0.x);
+				}
+				if (fb0.y + PCRTCDisplays[0].displayRect.w > 2048)
+				{
+					fb0.y -= 2048;
+					fb0.y = abs(fb0.y);
+				}
+				if (fb1.x + PCRTCDisplays[1].displayRect.z > 2048)
+				{
+					fb1.x -= 2048;
+					fb1.x = abs(fb1.x);
+				}
+				if (fb1.y + PCRTCDisplays[1].displayRect.w > 2048)
+				{
+					fb1.y -= 2048;
+					fb1.y = abs(fb1.y);
+				}
+
+				if (abs(fb1.y - fb0.y) == 1
 					&& PCRTCDisplays[0].displayRect.y == PCRTCDisplays[1].displayRect.y)
 				{
-					if (PCRTCDisplays[1].framebufferOffsets.y < PCRTCDisplays[0].framebufferOffsets.y)
-						PCRTCDisplays[0].framebufferOffsets.y = PCRTCDisplays[1].framebufferOffsets.y;
+					if (fb1.y < fb0.y)
+						PCRTCDisplays[0].framebufferOffsets.y = fb1.y;
 					else
-						PCRTCDisplays[1].framebufferOffsets.y = PCRTCDisplays[0].framebufferOffsets.y;
+						PCRTCDisplays[1].framebufferOffsets.y = fb0.y;
 				}
-				if (abs(PCRTCDisplays[1].framebufferOffsets.x - PCRTCDisplays[0].framebufferOffsets.x) == 1
+				if (abs(fb1.x - fb0.x) == 1
 					&& PCRTCDisplays[0].displayRect.x == PCRTCDisplays[1].displayRect.x)
 				{
-					if (PCRTCDisplays[1].framebufferOffsets.x < PCRTCDisplays[0].framebufferOffsets.x)
-						PCRTCDisplays[0].framebufferOffsets.x = PCRTCDisplays[1].framebufferOffsets.x;
+					if (fb1.x < fb0.x)
+						PCRTCDisplays[0].framebufferOffsets.x = fb1.x;
 					else
-						PCRTCDisplays[1].framebufferOffsets.x = PCRTCDisplays[0].framebufferOffsets.x;
+						PCRTCDisplays[1].framebufferOffsets.x = fb0.x;
 				}
 			}
 			PCRTCDisplays[0].framebufferRect.x += PCRTCDisplays[0].framebufferOffsets.x;

--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -542,16 +542,10 @@ public:
 				GSVector4i out_rect = PCRTCDisplays[display].framebufferRect;
 
 				if (out_rect.z >= 2048)
-				{
-					out_rect.z -= GSConfig.UseHardwareRenderer() ? 2048 : out_rect.x;
-					out_rect.x = 0;
-				}
+					out_rect.z -= out_rect.x;
 
 				if (out_rect.w >= 2048)
-				{
-					out_rect.w -= GSConfig.UseHardwareRenderer() ? 2048 : out_rect.y;
-					out_rect.y = 0;
-				}
+					out_rect.w -= out_rect.y;
 
 				// Cap the framebuffer read to the maximum display height, otherwise the hardware renderer gets messy.
 				const int min_mag = std::max(1, PCRTCDisplays[display].magnification.y);
@@ -565,12 +559,6 @@ public:
 				offset = (max_height / min_mag) - offset;
 				out_rect.w = std::min(out_rect.w, offset);
 
-				// Hardware mode needs a wider framebuffer as it can't offset the read.
-				if (GSConfig.UseHardwareRenderer())
-				{
-					out_rect.z += PCRTCDisplays[display].framebufferOffsets.x;
-					out_rect.w += PCRTCDisplays[display].framebufferOffsets.y;
-				}
 				return GSVector2i(out_rect.z, out_rect.w);
 			}
 		}
@@ -685,11 +673,15 @@ public:
 				{
 					if (PCRTCDisplays[display].framebufferRect.z >= 2048)
 					{
+						PCRTCDisplays[display].displayRect.x += 2048 - PCRTCDisplays[display].framebufferRect.x;
+						PCRTCDisplays[display].displayRect.z += 2048 - PCRTCDisplays[display].framebufferRect.x;
 						PCRTCDisplays[display].framebufferRect.x = 0;
 						PCRTCDisplays[display].framebufferRect.z -= 2048;
 					}
 					if (PCRTCDisplays[display].framebufferRect.w >= 2048)
 					{
+						PCRTCDisplays[display].displayRect.y += 2048 - PCRTCDisplays[display].framebufferRect.y;
+						PCRTCDisplays[display].displayRect.w += 2048 - PCRTCDisplays[display].framebufferRect.y;
 						PCRTCDisplays[display].framebufferRect.y = 0;
 						PCRTCDisplays[display].framebufferRect.w -= 2048;
 					}

--- a/pcsx2/GS/Renderers/SW/GSRendererSW.cpp
+++ b/pcsx2/GS/Renderers/SW/GSRendererSW.cpp
@@ -124,11 +124,13 @@ GSTexture* GSRendererSW::GetOutput(int i, float& scale, int& y_offset)
 		constexpr int pitch = 1024 * 4;
 		// Should really be framebufferOffsets rather than framebufferRect but this might be compensated with anti-blur in some games.
 		const int off_x = (framebufferRect.x & 0x7ff) & ~(psm.bs.x-1);
+		const int off_x_end = ((framebufferRect.x & 0x7ff) + (psm.bs.x - 1)) & ~(psm.bs.x - 1);
 		const int off_y = (framebufferRect.y & 0x7ff) & ~(psm.bs.y-1);
+		const int off_y_end = ((framebufferRect.y & 0x7ff) + (psm.bs.y - 1)) & ~(psm.bs.y - 1);
 		const GSVector4i out_r(0, 0, w, h);
-		GSVector4i r(off_x, off_y, w + off_x, h + off_y);
-		GSVector4i rh(off_x, off_y, w + off_x, (h + off_y) & 0x7FF);
-		GSVector4i rw(off_x, off_y, (w + off_x) & 0x7FF, h + off_y);
+		GSVector4i r(off_x, off_y, w + off_x_end, h + off_y_end);
+		GSVector4i rh(off_x, off_y, w + off_x_end, (h + off_y_end) & 0x7FF);
+		GSVector4i rw(off_x, off_y, (w + off_x_end) & 0x7FF, h + off_y_end);
 		bool h_wrap = false;
 		bool w_wrap = false;
 
@@ -155,9 +157,6 @@ GSTexture* GSRendererSW::GetOutput(int i, float& scale, int& y_offset)
 		texa.AEM = 0;
 		texa.TA0 = (curFramebuffer.PSM == PSMCT24 || curFramebuffer.PSM == PSGPU24) ? 0x80 : 0;
 		texa.TA1 = 0x80;
-
-		// Top left rect
-		psm.rtx(m_mem, m_mem.GetOffset(curFramebuffer.Block(), curFramebuffer.FBW, curFramebuffer.PSM), r.ralign<Align_Outside>(psm.bs), m_output, pitch, texa);
 
 		// Top left rect
 		psm.rtx(m_mem, m_mem.GetOffset(curFramebuffer.Block(), curFramebuffer.FBW, curFramebuffer.PSM), r.ralign<Align_Outside>(psm.bs), m_output, pitch, texa);


### PR DESCRIPTION
### Description of Changes
Fix the large PCRTC offsets used by NASCAR games. Also force deinterlacing mode to Adaptive TTF, due to misdetection of games own deinterlacing.

### Rationale behind Changes
Epilepsy is bad.

### Suggested Testing Steps
Already tested, just make sure CI passes
