### PR TITLE
GS-TC: Delete fully dirtied old targets

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.h
@@ -438,6 +438,7 @@ public:
 	void RemoveAll();
 	void ReadbackAll();
 	void AddDirtyRectTarget(Target* target, GSVector4i rect, u32 psm, u32 bw, RGBAMask rgba, bool req_linear = false);
+	bool FullRectDirty(Target* target);
 	bool CanTranslate(u32 bp, u32 bw, u32 spsm, GSVector4i r, u32 dbp, u32 dpsm, u32 dbw);
 	GSVector4i TranslateAlignedRectByPage(Target* t, u32 sbp, u32 spsm, u32 sbw, GSVector4i src_r, bool is_invalidation = false);
 	void DirtyRectByPage(u32 sbp, u32 spsm, u32 sbw, Target* t, GSVector4i src_r);


### PR DESCRIPTION
### Description of Changes
Deletes fully dirtied old targets

### Rationale behind Changes
Keeping around old targets is just asking for trouble, and it was causing trouble.

### Suggested Testing Steps
Just test a bunch of Texture Cache sensitive games.

Fixes corrupted lights in Syphon Filter Omega Strain
