### PR TITLE
MSBuild: Fix lib/pdb output directory

### DIFF
--- a/pcsx2/pcsx2.vcxproj
+++ b/pcsx2/pcsx2.vcxproj
@@ -31,6 +31,8 @@
   <PropertyGroup>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <TargetName>pcsx2</TargetName>
+    <IntDir>$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>$(Platform)\$(Configuration)\</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>


### PR DESCRIPTION
Quick fix so we don't blow up CI build sizes until I finish cleaning up the msbuild props...
