### PR TITLE
GS-HW: Invalidate local mem for whole texture on local->local copy. Allow HW recursive moves.

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -32235,6 +32235,8 @@ SLPM-65998:
   name: "Vampire Darkstalkers Collection"
   region: "NTSC-J"
   compat: 5
+  gsHWFixes:
+    roundSprite: 1 # Fixes squares around sprites when upscaling.
 SLPM-65999:
   name: "Drag-on Dragoon 2 - Fuuin no Aka, Haitoku no Kuro"
   region: "NTSC-J"
@@ -34739,6 +34741,8 @@ SLPM-66636:
 SLPM-66637:
   name: "Vampire Darkstalkers Collection [Capcom the Best]"
   region: "NTSC-J"
+  gsHWFixes:
+    roundSprite: 1 # Fixes squares around sprites when upscaling.
 SLPM-66638:
   name: "Demento [CapKore]"
   region: "NTSC-J"

--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -19822,6 +19822,8 @@ SLES-54084:
 SLES-54085:
   name: "Street Fighter Alpha Anthology"
   region: "PAL-E"
+  gsHWFixes:
+    roundSprite: 1 # Fixes squares around sprites when upscaling.
 SLES-54087:
   name: "Suikoden V"
   region: "PAL-M5"
@@ -33852,6 +33854,8 @@ SLPM-66409:
   name: "Street Fighter Zero - Fighters Generation"
   region: "NTSC-J"
   compat: 5
+  gsHWFixes:
+    roundSprite: 1 # Fixes squares around sprites when upscaling.
 SLPM-66410:
   name: "Brothers In Arms - Meiyo no Daishou"
   region: "NTSC-J"
@@ -35583,6 +35587,8 @@ SLPM-66853:
 SLPM-66854:
   name: "Street Fighter Zero - Fighters Generation [Best Price]"
   region: "NTSC-J"
+  gsHWFixes:
+    roundSprite: 1 # Fixes squares around sprites when upscaling.
 SLPM-66855:
   name: "Togainu no Chi - True Blood [Limited Edition]"
   region: "NTSC-J"
@@ -48769,6 +48775,8 @@ SLUS-21317:
   name: "Street Fighter Alpha Anthology"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    roundSprite: 1 # Fixes squares around sprites when upscaling.
 SLUS-21318:
   name: "Call of Duty 2 - Big Red One [Collector's Edition]"
   region: "NTSC-U"

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -979,8 +979,11 @@ void GSRendererHW::InvalidateLocalMem(const GIFRegBITBLTBUF& BITBLTBUF, const GS
 		break;
 	}
 
-	if(!skip)
-		g_texture_cache->InvalidateLocalMem(m_mem.GetOffset(BITBLTBUF.SBP, BITBLTBUF.SBW, BITBLTBUF.SPSM), r);
+	if (!skip)
+	{
+		const bool recursive_copy = (BITBLTBUF.SBP == BITBLTBUF.DBP) && (m_env.TRXDIR.XDIR == 2);
+		g_texture_cache->InvalidateLocalMem(m_mem.GetOffset(BITBLTBUF.SBP, BITBLTBUF.SBW, BITBLTBUF.SPSM), r, recursive_copy);
+	}
 }
 
 void GSRendererHW::Move()

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -2165,8 +2165,9 @@ void GSTextureCache::InvalidateVideoMem(const GSOffset& off, const GSVector4i& r
 }
 
 // Goal: retrive the data from the GPU to the GS memory.
-// Called each time you want to read from the GS memory
-void GSTextureCache::InvalidateLocalMem(const GSOffset& off, const GSVector4i& r)
+// Called each time you want to read from the GS memory.
+// full_flush is set when it's a Local->Local stransfer and both src and destination are the same.
+void GSTextureCache::InvalidateLocalMem(const GSOffset& off, const GSVector4i& r, bool full_flush)
 {
 	const u32 bp = off.bp();
 	const u32 psm = off.psm();
@@ -2219,7 +2220,7 @@ void GSTextureCache::InvalidateLocalMem(const GSOffset& off, const GSVector4i& r
 				const bool swizzle_match = GSLocalMemory::m_psm[psm].depth == GSLocalMemory::m_psm[t->m_TEX0.PSM].depth;
 				// Calculate the rect offset if the BP doesn't match.
 				GSVector4i targetr = {};
-				if (t->readbacks_since_draw > 1)
+				if (full_flush || t->readbacks_since_draw > 1)
 				{
 					targetr = t->m_drawn_since_read;
 				}
@@ -2353,7 +2354,7 @@ void GSTextureCache::InvalidateLocalMem(const GSOffset& off, const GSVector4i& r
 			const bool swizzle_match = GSLocalMemory::m_psm[psm].depth == GSLocalMemory::m_psm[t->m_TEX0.PSM].depth;
 			// Calculate the rect offset if the BP doesn't match.
 			GSVector4i targetr = {};
-			if (t->readbacks_since_draw > 1)
+			if (full_flush || t->readbacks_since_draw > 1)
 			{
 				targetr = t->m_drawn_since_read;
 			}

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.h
@@ -438,6 +438,7 @@ public:
 	void RemoveAll();
 	void ReadbackAll();
 	void AddDirtyRectTarget(Target* target, GSVector4i rect, u32 psm, u32 bw, RGBAMask rgba, bool req_linear = false);
+	bool FullRectDirty(Target* target);
 	bool CanTranslate(u32 bp, u32 bw, u32 spsm, GSVector4i r, u32 dbp, u32 dpsm, u32 dbw);
 	GSVector4i TranslateAlignedRectByPage(Target* t, u32 sbp, u32 spsm, u32 sbw, GSVector4i src_r, bool is_invalidation = false);
 	void DirtyRectByPage(u32 sbp, u32 spsm, u32 sbw, Target* t, GSVector4i src_r);
@@ -463,7 +464,7 @@ public:
 	void InvalidateVideoMemType(int type, u32 bp);
 	void InvalidateVideoMemSubTarget(GSTextureCache::Target* rt);
 	void InvalidateVideoMem(const GSOffset& off, const GSVector4i& r, bool eewrite = false, bool target = true);
-	void InvalidateLocalMem(const GSOffset& off, const GSVector4i& r);
+	void InvalidateLocalMem(const GSOffset& off, const GSVector4i& r, bool full_flush = false);
 
 	/// Removes any targets overlapping the specified BP and rectangle.
 	void InvalidateVideoMemTargets(int type, u32 bp, u32 bw, u32 psm, const GSVector4i& r);


### PR DESCRIPTION
### Description of Changes
Forces local mem invalidation to invalidate the whole RT when doing a local->local copy to itself on the CPU.
Also allow moves within the same RT/depth stencil to happen.

### Rationale behind Changes
The game is doing local->local copies, usually from 192->512 to 0->384 on the X (moving the image left), line by line, This was causing things to get out of whack and the RT was ending up with the wrong data, causing glitches on the screen in Vampire Darkstalkers.

The HW copies of the same render target/depth stencil wasn't allowed before as it's a validation error, but it's fine with a temporary texture in the middle.  This saves a readback on Vampire Darkstalkers (about 30fps faster).

### Suggested Testing Steps
Test Vampire Darkstalkers and make sure it works fine.

Fixes #3481 

Master:  (Look in the top left)
![image](https://github.com/PCSX2/pcsx2/assets/6278726/b4fe69a0-0f24-412e-a1fe-086de58d76ec)

PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/ff1a27aa-9f87-4068-9ff1-a9dcbb1289d9)
