### PR TITLE
x86/microVU: Reference StateEnd instead of inlining state

### DIFF
--- a/pcsx2/x86/microVU_Compile.inl
+++ b/pcsx2/x86/microVU_Compile.inl
@@ -472,31 +472,12 @@ void mVUtestCycles(microVU& mVU, microFlagCycles& mFC)
 
 	xForwardJNS32 skip;
 
-	u8* writeback = x86Ptr;
-	xLoadFarAddr(rax, x86Ptr);
-	xFastCall((void*)mVU.copyPLState);
+	xLoadFarAddr(rax, &mVUpBlock->pState);
+	xCALL((void*)mVU.copyPLState);
 
 	if (EmuConfig.Gamefixes.VUSyncHack || EmuConfig.Gamefixes.FullVU0SyncHack)
 		xMOV(ptr32[&mVU.regs().nextBlockCycles], mVUcycles);
 	mVUendProgram(mVU, &mFC, 0);
-
-	{
-		if(x86caps.hasAVX2)
-			xAlignPtr(32);
-		else
-			xAlignPtr(16);
-
-		u8* curx86Ptr = x86Ptr;
-		x86SetPtr(writeback);
-		xLoadFarAddr(rax, curx86Ptr);
-		x86SetPtr(curx86Ptr);
-
-		static_assert((sizeof(microRegInfo) % 4) == 0);
-		const u32* lpPtr = reinterpret_cast<const u32*>(&mVU.prog.lpState);
-		const u32* lpEnd = lpPtr + (sizeof(microRegInfo) / 4);
-		while (lpPtr != lpEnd)
-			xWrite32(*(lpPtr++));
-	}
 
 	skip.SetTarget();
 


### PR DESCRIPTION
### Description of Changes

Instead of emitting a copy of the pipeline state at the end of the block's code, we can simply reference back to the block itself.

This will reduce icache pressure ever-so-slightly, since the pipeline state is 96 bytes.

I don't expect this to make a measurable difference on its own, but all the tiny things do add up.

### Rationale behind Changes

Ongoing performance work.

### Suggested Testing Steps

Check some games sensitive to M-bit, this previously wasn't using the fast copy routine. I _think_ I've done this correctly, but don't know which games hit this path.
