### PR TITLE
x86/microVU: Elide input clamps when result is already clamped

### DIFF
--- a/pcsx2/x86/microVU_Clamp.inl
+++ b/pcsx2/x86/microVU_Clamp.inl
@@ -36,7 +36,7 @@ alignas(16) const u32 sse4_maxvals[2][4] = {
 // and its faster... so just always make NaNs into positive infinity.
 void mVUclamp1(microVU& mVU, const xmm& reg, const xmm& regT1, int xyzw, bool bClampE = 0)
 {
-	if (((!clampE && CHECK_VU_OVERFLOW(mVU.index)) || (clampE && bClampE)) && mVU.regAlloc->checkVFClamp(reg.Id))
+	if (((!clampE && CHECK_VU_OVERFLOW(mVU.index)) || (clampE && bClampE)) && mVU.regAlloc->isClampNeeded(reg.Id, 1))
 	{
 		switch (xyzw)
 		{
@@ -49,6 +49,7 @@ void mVUclamp1(microVU& mVU, const xmm& reg, const xmm& regT1, int xyzw, bool bC
 				xMAX.PS(reg, ptr32[mVUglob.minvals]);
 				break;
 		}
+		mVU.regAlloc->setRegClamp(reg.Id, 1);
 	}
 }
 
@@ -59,21 +60,23 @@ void mVUclamp1(microVU& mVU, const xmm& reg, const xmm& regT1, int xyzw, bool bC
 // so we just use a temporary mem location for our backup for now... (non-sse4 version only)
 void mVUclamp2(microVU& mVU, const xmm& reg, const xmm& regT1in, int xyzw, bool bClampE = 0)
 {
-	if (((!clampE && CHECK_VU_SIGN_OVERFLOW(mVU.index)) || (clampE && bClampE && CHECK_VU_SIGN_OVERFLOW(mVU.index))) && mVU.regAlloc->checkVFClamp(reg.Id))
+	if (((!clampE && CHECK_VU_SIGN_OVERFLOW(mVU.index)) || (clampE && bClampE && CHECK_VU_SIGN_OVERFLOW(mVU.index))) && mVU.regAlloc->isClampNeeded(reg.Id, 2))
 	{
-		int i = (xyzw == 1 || xyzw == 2 || xyzw == 4 || xyzw == 8) ? 0 : 1;
+		const int i = (xyzw == 1 || xyzw == 2 || xyzw == 4 || xyzw == 8) ? 0 : 1;
 		xPMIN.SD(reg, ptr128[&sse4_maxvals[i][0]]);
 		xPMIN.UD(reg, ptr128[&sse4_minvals[i][0]]);
-		return;
+		mVU.regAlloc->setRegClamp(reg.Id, 2);
 	}
 	else
+	{
 		mVUclamp1(mVU, reg, regT1in, xyzw, bClampE);
+	}
 }
 
 // Used for operand clamping on every SSE instruction (add/sub/mul/div)
 void mVUclamp3(microVU& mVU, const xmm& reg, const xmm& regT1, int xyzw)
 {
-	if (clampE && mVU.regAlloc->checkVFClamp(reg.Id))
+	if (clampE && mVU.regAlloc->isClampNeeded(reg.Id, 3))
 		mVUclamp2(mVU, reg, regT1, xyzw, 1);
 }
 
@@ -85,6 +88,6 @@ void mVUclamp3(microVU& mVU, const xmm& reg, const xmm& regT1, int xyzw)
 // but this clamp is just a precaution just-in-case.
 void mVUclamp4(microVU& mVU, const xmm& reg, const xmm& regT1, int xyzw)
 {
-	if (clampE && !CHECK_VU_SIGN_OVERFLOW(mVU.index) && mVU.regAlloc->checkVFClamp(reg.Id))
+	if (clampE && !CHECK_VU_SIGN_OVERFLOW(mVU.index) && mVU.regAlloc->isClampNeeded(reg.Id, 4))
 		mVUclamp1(mVU, reg, regT1, xyzw, 1);
 }

--- a/pcsx2/x86/microVU_Lower.inl
+++ b/pcsx2/x86/microVU_Lower.inl
@@ -177,6 +177,7 @@ mVUop(mVU_RSQRT)
 		SSE_MULSS(mVU, t2, Fs); \
 		xMOVAPS(t1, t2); \
 		xMUL.SS(t1, ptr32[addr]); \
+		mVU.regAlloc->clearRegClamp(t1.Id); \
 		SSE_ADDSS(mVU, PQ, t1); \
 	}
 
@@ -294,6 +295,7 @@ mVUop(mVU_EATANxz)
 		SSE_MULSS(mVU, t2, Fs); \
 		xMOVAPS(t1, t2); \
 		xMUL.SS(t1, ptr32[addr]); \
+		mVU.regAlloc->clearRegClamp(t1.Id); \
 		SSE_ADDSS(mVU, xmmPQ, t1); \
 	}
 
@@ -321,12 +323,14 @@ mVUop(mVU_EEXP)
 		SSE_MULSS(mVU, t1, Fs);
 		xMOVAPS(t2, t1);
 		xMUL.SS(t1, ptr32[mVUglob.E2]);
+		mVU.regAlloc->clearRegClamp(t1.Id);
 		SSE_ADDSS(mVU, xmmPQ, t1);
 		eexpHelper(&mVUglob.E3);
 		eexpHelper(&mVUglob.E4);
 		eexpHelper(&mVUglob.E5);
 		SSE_MULSS(mVU, t2, Fs);
 		xMUL.SS(t2, ptr32[mVUglob.E6]);
+		mVU.regAlloc->clearRegClamp(t2.Id);
 		SSE_ADDSS(mVU, xmmPQ, t2);
 		SSE_MULSS(mVU, xmmPQ, xmmPQ);
 		SSE_MULSS(mVU, xmmPQ, xmmPQ);
@@ -525,20 +529,24 @@ mVUop(mVU_ESIN)
 		SSE_MULSS(mVU, Fs, xmmPQ); // fs = X^3
 		xMOVAPS       (t2, Fs);    // t2 = X^3
 		xMUL.SS       (Fs, ptr32[mVUglob.S2]); // fs = s2 * X^3
+		mVU.regAlloc->clearRegClamp(Fs.Id);
 		SSE_ADDSS(mVU, xmmPQ, Fs); // pq = X + s2 * X^3
 
 		SSE_MULSS(mVU, t2, t1);    // t2 = X^3 * X^2
 		xMOVAPS       (Fs, t2);    // fs = X^5
 		xMUL.SS       (Fs, ptr32[mVUglob.S3]); // ps = s3 * X^5
+		mVU.regAlloc->clearRegClamp(Fs.Id);
 		SSE_ADDSS(mVU, xmmPQ, Fs); // pq = X + s2 * X^3 + s3 * X^5
 
 		SSE_MULSS(mVU, t2, t1);    // t2 = X^5 * X^2
 		xMOVAPS       (Fs, t2);    // fs = X^7
 		xMUL.SS       (Fs, ptr32[mVUglob.S4]); // fs = s4 * X^7
+		mVU.regAlloc->clearRegClamp(Fs.Id);
 		SSE_ADDSS(mVU, xmmPQ, Fs); // pq = X + s2 * X^3 + s3 * X^5 + s4 * X^7
 
 		SSE_MULSS(mVU, t2, t1);    // t2 = X^7 * X^2
 		xMUL.SS       (t2, ptr32[mVUglob.S5]); // t2 = s5 * X^9
+		mVU.regAlloc->clearRegClamp(t2.Id);
 		SSE_ADDSS(mVU, xmmPQ, t2); // pq = X + s2 * X^3 + s3 * X^5 + s4 * X^7 + s5 * X^9
 		xPSHUF.D      (xmmPQ, xmmPQ, mVUinfo.writeP ? 0x27 : 0xC6); // Flip back
 		mVU.regAlloc->clearNeeded(Fs);

--- a/pcsx2/x86/microVU_Misc.inl
+++ b/pcsx2/x86/microVU_Misc.inl
@@ -430,6 +430,8 @@ void MIN_MAX_PS(microVU& mVU, const xmm& to, const xmm& from, const xmm& t1in, c
 		xPOR     (to, c1);
 	}
 
+	mVU.regAlloc->mergeRegClamp(to.Id, from.Id);
+
 	if (t1 != t1in) mVU.regAlloc->clearNeeded(t1);
 	if (t2 != t2in) mVU.regAlloc->clearNeeded(t2);
 }
@@ -444,6 +446,7 @@ void MIN_MAX_SS(mV, const xmm& to, const xmm& from, const xmm& t1in, bool min)
 	xPSHUF.D(t1, to, 0xee);
 	if (min) xMIN.PD(to, t1);
 	else	 xMAX.PD(to, t1);
+	mVU.regAlloc->mergeRegClamp(to.Id, from.Id);
 	if (t1 != t1in)
 		mVU.regAlloc->clearNeeded(t1);
 }
@@ -503,6 +506,8 @@ void ADD_SS_Single_Guard_Bit(microVU& mVU, const xmm& to, const xmm& from, const
 	case_end4.SetTarget();
 
 	xADD.SS(to, from);
+	mVU.regAlloc->clearRegClamp(to.Id);
+
 	if (t1 != t1in)
 		mVU.regAlloc->clearNeeded(t1);
 }
@@ -535,6 +540,7 @@ void ADD_SS_TriAceHack(microVU& mVU, const xmm& to, const xmm& from)
 	case_end2.SetTarget();
 
 	xADD.SS(to, from);
+	mVU.regAlloc->clearRegClamp(to.Id);
 }
 
 #define clampOp(opX, isPS) \
@@ -542,6 +548,7 @@ void ADD_SS_TriAceHack(microVU& mVU, const xmm& to, const xmm& from)
 		mVUclamp3(mVU, to, t1, (isPS) ? 0xf : 0x8); \
 		mVUclamp3(mVU, from, t1, (isPS) ? 0xf : 0x8); \
 		opX(to, from); \
+		mVU.regAlloc->clearRegClamp(to.Id); \
 		mVUclamp4(mVU, to, t1, (isPS) ? 0xf : 0x8); \
 	} while (0)
 

--- a/pcsx2/x86/microVU_Upper.inl
+++ b/pcsx2/x86/microVU_Upper.inl
@@ -205,7 +205,8 @@ static void setupFtReg(microVU& mVU, xmm& Ft, xmm& tempFt, int opCase, int clamp
 	opCase1
 	{
 		// Based on mVUclamp2 -> mVUclamp1 below.
-		const bool willClamp = (clampE || ((clampType & cFt) && !clampE && (CHECK_VU_OVERFLOW(mVU.index) || CHECK_VU_SIGN_OVERFLOW(mVU.index))));
+		// TODO: This can be further improved by checking whether we have _Ft_ cached and already clamped.
+		const bool willClamp = _Ft_ != 0 && (clampE || ((clampType & cFt) && !clampE && (CHECK_VU_OVERFLOW(mVU.index) || CHECK_VU_SIGN_OVERFLOW(mVU.index))));
 
 		if (_XYZW_SS2)      { Ft = mVU.regAlloc->allocReg(_Ft_, 0, _X_Y_Z_W); tempFt = Ft; }
 		else if (willClamp) { Ft = mVU.regAlloc->allocReg(_Ft_, 0, 0xf);      tempFt = Ft; }


### PR DESCRIPTION
### Description of Changes

Attempt to reduce the number of clamps when the inputs to an operation have already been clamped.

### Rationale behind Changes

Burnout 3 sees an almost 5% reduction in CPU usage on the VU thread.

### Suggested Testing Steps

Test games sensitive to clamping, particularly the sign/extra modes (that's where I mostly saw it triggering).
