### PR TITLE
GS-HW: Avoid clears with new targets

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -10656,6 +10656,8 @@ SLES-50247:
   name: "Onimusha - Warlords"
   region: "PAL-M3"
   compat: 5
+  gameFixes:
+    - SoftwareRendererFMVHack # Fixes flashing FMVs (Req EE cycle rate 50% for them to run).
   gsHWFixes:
     texturePreloading: 1 # Performs much better with partial preload.
 SLES-50248:

--- a/pcsx2/GS/GSLocalMemory.h
+++ b/pcsx2/GS/GSLocalMemory.h
@@ -546,6 +546,7 @@ public:
 	GSPixelOffset4* GetPixelOffset4(const GIFRegFRAME& FRAME, const GIFRegZBUF& ZBUF);
 	std::vector<GSVector2i>* GetPage2TileMap(const GIFRegTEX0& TEX0);
 	static bool IsPageAligned(u32 psm, const GSVector4i& rc);
+	static u32 GetEndBlockAddress(u32 bp, u32 bw, u32 psm, GSVector4i rect);
 
 	// address
 

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -1681,14 +1681,17 @@ void GSRendererHW::Draw()
 				m_vertex.buff[1].RGBAQ.U32[0] :
 				(m_vertex.buff[1].RGBAQ.U32[0] & ~0xFF000000)) == 0) && m_cached_ctx.FRAME.FBMSK == 0 && IsBlendedOrOpaque();
 
-			const u32 rt_end = GSLocalMemory::m_psm[m_cached_ctx.FRAME.PSM].info.bn(m_r.z - 1, m_r.w - 1, m_cached_ctx.FRAME.Block(), m_cached_ctx.FRAME.FBW);
 			const bool req_z = m_cached_ctx.FRAME.FBP != m_cached_ctx.ZBUF.ZBP && !m_cached_ctx.ZBUF.ZMSK;
 			bool no_target_found = false;
 
 			// This is behind the if just to reduce lookups.
 			if (is_zero_clear && !clear_height_valid)
-				no_target_found = !g_texture_cache->GetExactTarget(m_cached_ctx.FRAME.Block(), m_cached_ctx.FRAME.FBW, GSTextureCache::RenderTarget, rt_end) &&
-								  !g_texture_cache->GetExactTarget(m_cached_ctx.FRAME.Block(), m_cached_ctx.FRAME.FBW, GSTextureCache::DepthStencil, rt_end);
+			{
+				const u32 target_end = GSLocalMemory::GetEndBlockAddress(m_cached_ctx.FRAME.Block(), m_cached_ctx.FRAME.FBW, m_cached_ctx.FRAME.PSM, m_r);
+
+				no_target_found = !g_texture_cache->GetExactTarget(m_cached_ctx.FRAME.Block(), m_cached_ctx.FRAME.FBW, GSTextureCache::RenderTarget, target_end) &&
+								  !g_texture_cache->GetExactTarget(m_cached_ctx.FRAME.Block(), m_cached_ctx.FRAME.FBW, GSTextureCache::DepthStencil, target_end);
+			}
 
 			if (is_zero_clear && OI_GsMemClear() && (clear_height_valid || (!req_z && no_target_found)))
 			{

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -1681,12 +1681,23 @@ void GSRendererHW::Draw()
 				m_vertex.buff[1].RGBAQ.U32[0] :
 				(m_vertex.buff[1].RGBAQ.U32[0] & ~0xFF000000)) == 0) && m_cached_ctx.FRAME.FBMSK == 0 && IsBlendedOrOpaque();
 
-			if (is_zero_clear && OI_GsMemClear() && clear_height_valid)
+			const u32 rt_end = GSLocalMemory::m_psm[m_cached_ctx.FRAME.PSM].info.bn(m_r.z - 1, m_r.w - 1, m_cached_ctx.FRAME.Block(), m_cached_ctx.FRAME.FBW);
+			const bool req_z = m_cached_ctx.FRAME.FBP != m_cached_ctx.ZBUF.ZBP && !m_cached_ctx.ZBUF.ZMSK;
+			bool no_target_found = false;
+
+			// This is behind the if just to reduce lookups.
+			if (is_zero_clear && !clear_height_valid)
+				no_target_found = !g_texture_cache->GetExactTarget(m_cached_ctx.FRAME.Block(), m_cached_ctx.FRAME.FBW, GSTextureCache::RenderTarget, rt_end) &&
+								  !g_texture_cache->GetExactTarget(m_cached_ctx.FRAME.Block(), m_cached_ctx.FRAME.FBW, GSTextureCache::DepthStencil, rt_end);
+
+			if (is_zero_clear && OI_GsMemClear() && (clear_height_valid || (!req_z && no_target_found)))
 			{
 				GL_INS("Clear draw with mem clear and valid clear height, invalidating.");
 
 				g_texture_cache->InvalidateVideoMem(context->offset.fb, m_r, false, true);
 				g_texture_cache->InvalidateVideoMemType(GSTextureCache::RenderTarget, m_cached_ctx.FRAME.Block());
+				if(no_target_found)
+					g_texture_cache->InvalidateVideoMemType(GSTextureCache::DepthStencil, m_cached_ctx.FRAME.Block());
 
 				if (m_cached_ctx.ZBUF.ZMSK == 0)
 				{
@@ -4792,7 +4803,7 @@ GSRendererHW::CLUTDrawTestResult GSRendererHW::PossibleCLUTDraw()
 				return CLUTDrawTestResult::CLUTDrawOnCPU;
 
 			GSTextureCache::Target* tgt = g_texture_cache->GetExactTarget(
-				m_cached_ctx.TEX0.TBP0, m_cached_ctx.TEX0.TBW, GSTextureCache::RenderTarget);
+				m_cached_ctx.TEX0.TBP0, m_cached_ctx.TEX0.TBW, GSTextureCache::RenderTarget, m_cached_ctx.TEX0.TBP0);
 			if (tgt)
 			{
 				bool is_dirty = false;
@@ -5145,19 +5156,18 @@ bool GSRendererHW::OI_GsMemClear()
 		}
 		else if (format == 2)
 		{
-			; // Hack is used for FMV which are likely 24/32 bits. Let's keep the for reference
-#if 0
+			const u16 converted_color = ((vert_color >> 16) & 0x8000) | ((vert_color >> 9) & 0x7C00) | ((vert_color >> 6) & 0x7E0) | ((vert_color >> 3) & 0x1F);
+
 			// Based on WritePixel16
 			for (int y = r.top; y < r.bottom; y++)
 			{
-				auto pa = off.assertSizesMatch(GSLocalMemory::swizzle16).paMulti(m_mem.m_vm16, 0, y);
+				auto pa = off.assertSizesMatch(GSLocalMemory::swizzle16).paMulti(m_mem.vm16(), 0, y);
 
 				for (int x = r.left; x < r.right; x++)
 				{
-					*pa.value(x) = 0; // Here the constant color
+					*pa.value(x) = converted_color; // Here the constant color
 				}
 			}
-#endif
 		}
 
 		return true;

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.h
@@ -455,7 +455,7 @@ public:
 	Target* LookupDisplayTarget(GIFRegTEX0 TEX0, const GSVector2i& size, float scale);
 
 	/// Looks up a target in the cache, and only returns it if the BP/BW match exactly.
-	Target* GetExactTarget(u32 BP, u32 BW, int type);
+	Target* GetExactTarget(u32 BP, u32 BW, int type, u32 end_bp);
 	Target* GetTargetWithSharedBits(u32 BP, u32 PSM) const;
 
 	GSVector2i GetTargetSize(u32 bp, u32 fbw, u32 psm, s32 min_width, s32 min_height);


### PR DESCRIPTION
### Description of Changes
Attempts to avoid clearing targets which don't already exist

### Rationale behind Changes
Before this would create errant targets, sometimes located in the middle of buffers (Armored Core 2), which would later cause misdetection when it actually required those addresses.  This was also causing some blowout of target sizes when it wasn't needed.

### Suggested Testing Steps
Test a whole bunch of games, and especially FMV's

Fixes #8645 Psychonauts weird top screen corruption
Fixes #6604 Front Mission 4 shadows
Fixes #8860 Armored Core 2 FMV flickering
Improves accuracy of Time Crisis 3 menu
Improves accuracy on Cricket 2002 camera view

Psychonauts:
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/a3eaaf0f-819e-4789-b435-c4a9733546e9)

PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/2606ae45-b78c-4244-ba03-2e38157de808)

Front Mission 4:
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/0b0a99a3-1456-41e8-840f-d66550b9dfa3)

PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/823efa90-c8f4-4423-ad57-87eaffb8f2b2)

Cricket 2002:
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/041e5383-a713-46a1-a9d6-7604a1c31b6b)

PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/28809219-9bb5-4395-add9-ce5af80e519d)

Time Crisis 3: (Comapre the honeycomb effect at the bottom centre of the screen, more accurately matches software mode)
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/061ca03f-10de-4dc7-ad65-0efbe694930a)

PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/af3ca62d-0d25-4916-82c9-2a9b0a39942d)
