### PR TITLE
Add 60FPS/DNAS Patch Functionality to Frontend

### DIFF
--- a/pcsx2-qt/Settings/EmulationSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/EmulationSettingsWidget.cpp
@@ -84,7 +84,6 @@ EmulationSettingsWidget::EmulationSettingsWidget(SettingsDialog* dialog, QWidget
 		m_dialog->setIntSettingValue("EmuCore/Speedhacks", "EECycleRate", value);
 	});
 
-	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.cheats, "EmuCore", "EnableCheats", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.hostFilesystem, "EmuCore", "HostFs", false);
 
 	dialog->registerWidgetHelp(m_ui.normalSpeed, tr("Normal Speed"), "100%",
@@ -118,17 +117,17 @@ EmulationSettingsWidget::EmulationSettingsWidget(SettingsDialog* dialog, QWidget
 		   "Safe for most games, but a few games may exhibit graphical errors."));
 	dialog->registerWidgetHelp(m_ui.fastCDVD, tr("Enable Fast CDVD"), tr("Unchecked"),
 		tr("Fast disc access, less loading times. Check HDLoader compatibility lists for known games that have issues with this."));
-	dialog->registerWidgetHelp(m_ui.cheats, tr("Enable Cheats"), tr("Unchecked"),
-		tr("Automatically loads and applies cheats on game start."));
 	dialog->registerWidgetHelp(m_ui.hostFilesystem, tr("Enable Host Filesystem"), tr("Unchecked"),
 		tr("Allows games and homebrew to access files / folders directly on the host computer."));
 
-	
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.cheats, "EmuCore", "EnableCheats", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.widescreenPatches, "EmuCore", "EnableWideScreenPatches", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.noInterlacingPatches, "EmuCore", "EnableNoInterlacingPatches", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.fpsPatches, "EmuCore", "Enable60FPSPatches", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.DNASPatches, "EmuCore", "EnableDNASPatches", false);
 
+	dialog->registerWidgetHelp(m_ui.cheats, tr("Enable Cheats"), tr("Unchecked"),
+		tr("Automatically loads and applies cheats on game start."));
 	dialog->registerWidgetHelp(m_ui.widescreenPatches, tr("Enable Widescreen Patches"), tr("Unchecked"),
 		tr("Automatically loads and applies widescreen patches on game start. Can cause issues."));
 	dialog->registerWidgetHelp(m_ui.noInterlacingPatches, tr("Enable No-Interlacing Patches"), tr("Unchecked"),

--- a/pcsx2-qt/Settings/EmulationSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/EmulationSettingsWidget.cpp
@@ -123,6 +123,22 @@ EmulationSettingsWidget::EmulationSettingsWidget(SettingsDialog* dialog, QWidget
 	dialog->registerWidgetHelp(m_ui.hostFilesystem, tr("Enable Host Filesystem"), tr("Unchecked"),
 		tr("Allows games and homebrew to access files / folders directly on the host computer."));
 
+	
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.widescreenPatches, "EmuCore", "EnableWideScreenPatches", false);
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.noInterlacingPatches, "EmuCore", "EnableNoInterlacingPatches", false);
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.fpsPatches, "EmuCore", "Enable60FPSPatches", false);
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.DNASPatches, "EmuCore", "EnableDNASPatches", false);
+
+	dialog->registerWidgetHelp(m_ui.widescreenPatches, tr("Enable Widescreen Patches"), tr("Unchecked"),
+		tr("Automatically loads and applies widescreen patches on game start. Can cause issues."));
+	dialog->registerWidgetHelp(m_ui.noInterlacingPatches, tr("Enable No-Interlacing Patches"), tr("Unchecked"),
+		tr("Automatically loads and applies no-interlacing patches on game start. Can cause issues."));
+	dialog->registerWidgetHelp(m_ui.fpsPatches, tr("Enable 60FPS Patches"), tr("Unchecked"),
+		tr("Automatically loads and applies 60FPS patches on game start. Can cause issues."));
+	dialog->registerWidgetHelp(m_ui.DNASPatches, tr("Enable DNAS Patches"), tr("Unchecked"),
+		tr("Automatically loads and applies DNAS patches on game start. Can cause issues."));
+		
+
 	dialog->registerWidgetHelp(m_ui.optimalFramePacing, tr("Optimal Frame Pacing"), tr("Unchecked"),
 		tr("Sets the VSync queue size to 0, making every frame be completed and presented by the GS before input is polled and the next frame begins. "
 		   "Using this setting can reduce input lag at the cost of measurably higher CPU and GPU requirements."));

--- a/pcsx2-qt/Settings/EmulationSettingsWidget.ui
+++ b/pcsx2-qt/Settings/EmulationSettingsWidget.ui
@@ -243,7 +243,44 @@
      </layout>
     </widget>
    </item>
-   <item>
+	<item>
+	 <widget class="QGroupBox" name="patchesGroup">
+	  <property name="title">
+	   <string>Patches</string>
+		</property>
+		 <layout class="QGridLayout" name="gridLayout_6">
+		  <item row="0" column="0">
+			<widget class="QCheckBox" name="widescreenPatches">
+			 <property name="text">
+		    <string>Enable Widescreen Patches</string>
+		  </property>
+		 </widget>
+		</item>
+		  <item row="0" column="1">
+			<widget class="QCheckBox" name="noInterlacingPatches">
+			 <property name="text">
+		    <string>Enable No-Interlacing Patches</string>
+		  </property>
+		 </widget>
+	    </item>
+	    <item row="1" column="0">
+			<widget class="QCheckBox" name="fpsPatches">
+			 <property name="text">
+		    <string>Enable 60FPS Patches</string>
+		  </property>
+		 </widget>
+		</item>
+	    <item row="1" column="1">
+			<widget class="QCheckBox" name="DNASPatches">
+			 <property name="text">
+		    <string>Enable DNAS Patches</string>
+		  </property>
+		 </widget>
+		</item>
+	   </layout>
+	  </widget>	  
+	 </item>
+	<item>
     <widget class="QGroupBox" name="basicGroupBox">
      <property name="title">
       <string>Frame Pacing / Latency Control</string>

--- a/pcsx2-qt/Settings/EmulationSettingsWidget.ui
+++ b/pcsx2-qt/Settings/EmulationSettingsWidget.ui
@@ -87,13 +87,6 @@
           </property>
          </widget>
         </item>
-        <item row="1" column="0">
-         <widget class="QCheckBox" name="cheats">
-          <property name="text">
-           <string>Enable Cheats</string>
-          </property>
-         </widget>
-        </item>
         <item row="0" column="0">
          <widget class="QCheckBox" name="MTVU">
           <property name="text">
@@ -101,7 +94,7 @@
           </property>
          </widget>
         </item>
-        <item row="1" column="1">
+        <item row="0" column="2">
          <widget class="QCheckBox" name="hostFilesystem">
           <property name="text">
            <string>Enable Host Filesystem</string>
@@ -250,13 +243,20 @@
 		</property>
 		 <layout class="QGridLayout" name="gridLayout_6">
 		  <item row="0" column="0">
+           <widget class="QCheckBox" name="cheats">
+             <property name="text">
+              <string>Enable Cheats</string>
+             </property>
+            </widget>
+           </item>  
+		  <item row="0" column="1">
 			<widget class="QCheckBox" name="widescreenPatches">
 			 <property name="text">
 		    <string>Enable Widescreen Patches</string>
 		  </property>
 		 </widget>
 		</item>
-		  <item row="0" column="1">
+		  <item row="0" column="2">
 			<widget class="QCheckBox" name="noInterlacingPatches">
 			 <property name="text">
 		    <string>Enable No-Interlacing Patches</string>

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -103,8 +103,6 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsDialog* dialog, QWidget* 
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.interlacing, "EmuCore/GS", "deinterlace_mode", DEFAULT_INTERLACE_MODE);
 	SettingWidgetBinder::BindWidgetToIntSetting(
 		sif, m_ui.bilinearFiltering, "EmuCore/GS", "linear_present_mode", static_cast<int>(GSPostBilinearMode::BilinearSmooth));
-	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.widescreenPatches, "EmuCore", "EnableWideScreenPatches", false);
-	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.noInterlacingPatches, "EmuCore", "EnableNoInterlacingPatches", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.integerScaling, "EmuCore/GS", "IntegerScaling", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.PCRTCOffsets, "EmuCore/GS", "pcrtc_offsets", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.PCRTCOverscan, "EmuCore/GS", "pcrtc_overscan", false);
@@ -373,12 +371,6 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsDialog* dialog, QWidget* 
 
 	// Display tab
 	{
-		dialog->registerWidgetHelp(m_ui.widescreenPatches, tr("Enable Widescreen Patches"), tr("Unchecked"),
-			tr("Automatically loads and applies widescreen patches on game start. Can cause issues."));
-
-		dialog->registerWidgetHelp(m_ui.noInterlacingPatches, tr("Enable No-Interlacing Patches"), tr("Unchecked"),
-			tr("Automatically loads and applies no-interlacing patches on game start. Can cause issues."));
-
 		dialog->registerWidgetHelp(m_ui.DisableInterlaceOffset, tr("Disable Interlace Offset"), tr("Unchecked"),
 			tr("Disables interlacing offset which may reduce blurring in some situations."));
 

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
@@ -328,45 +328,31 @@
        </item>
        <item row="8" column="0" colspan="2">
         <layout class="QGridLayout" name="gridLayout_5">
-         <item row="3" column="0">
+         <item row="2" column="0">
           <widget class="QCheckBox" name="PCRTCOffsets">
            <property name="text">
             <string>Screen Offsets</string>
            </property>
           </widget>
          </item>
-         <item row="1" column="1">
+         <item row="0" column="1">
           <widget class="QCheckBox" name="integerScaling">
            <property name="text">
             <string>Integer Scaling</string>
            </property>
           </widget>
          </item>
-         <item row="2" column="0">
+         <item row="0" column="0">
           <widget class="QCheckBox" name="vsync">
            <property name="text">
             <string>VSync</string>
            </property>
           </widget>
          </item>
-         <item row="3" column="1">
+         <item row="2" column="1">
           <widget class="QCheckBox" name="PCRTCOverscan">
            <property name="text">
             <string>Show Overscan</string>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="0">
-          <widget class="QCheckBox" name="widescreenPatches">
-           <property name="text">
-            <string>Enable Widescreen Patches</string>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="1">
-          <widget class="QCheckBox" name="noInterlacingPatches">
-           <property name="text">
-            <string>Enable No-Interlacing Patches</string>
            </property>
           </widget>
          </item>
@@ -380,7 +366,7 @@
            </property>
           </widget>
          </item>
-         <item row="2" column="1">
+         <item row="1" column="1">
           <widget class="QCheckBox" name="DisableInterlaceOffset">
            <property name="text">
             <string>Disable Interlace Offset</string>

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -1240,7 +1240,9 @@ struct Pcsx2Config
 		EnableCheats : 1, // enables cheat detection and application
 		EnablePINE : 1, // enables inter-process communication
 		EnableWideScreenPatches : 1,
-		EnableNoInterlacingPatches : 1,
+		EnableNoInterlacingPatches : 1, 
+		Enable60FPSPatches : 1,
+		EnableDNASPatches : 1,
 		// TODO - Vaser - where are these settings exposed in the Qt UI?
 		EnableRecordingTools : 1,
 		EnableGameFixes : 1, // enables automatic game fixes
@@ -1337,6 +1339,8 @@ namespace EmuFolders
 	extern std::string Cheats;
 	extern std::string CheatsWS;
 	extern std::string CheatsNI;
+	extern std::string Cheats60;
+	extern std::string CheatsDNAS;
 	extern std::string Resources;
 	extern std::string Cache;
 	extern std::string Covers;

--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -2869,12 +2869,12 @@ void FullscreenUI::DrawEmulationSettingsPage()
 	DrawToggleSetting(bsi, "Enable Instant VU1",
 		"Reduces timeslicing between VU1 and EE recompilers, effectively running VU1 at an infinite clock speed.", "EmuCore/Speedhacks",
 		"vu1Instant", true);
-	DrawToggleSetting(bsi, "Enable Cheats", "Enables loading cheats from pnach files.", "EmuCore", "EnableCheats", false);
 	DrawToggleSetting(bsi, "Enable Host Filesystem", "Enables access to files from the host: namespace in the virtual machine.", "EmuCore",
 		"HostFs", false);
 
 	MenuHeading("Patches");
-	
+
+	DrawToggleSetting(bsi, "Enable Cheats", "Enables loading cheats from pnach files.", "EmuCore", "EnableCheats", false);
 	DrawToggleSetting(bsi, "Enable Widescreen Patches", "Enables loading widescreen patches from pnach files.", "EmuCore",
 		"EnableWideScreenPatches", false);
 	DrawToggleSetting(bsi, "Enable No-Interlacing Patches", "Enables loading no-interlacing patches from pnach files.", "EmuCore",

--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -2873,6 +2873,17 @@ void FullscreenUI::DrawEmulationSettingsPage()
 	DrawToggleSetting(bsi, "Enable Host Filesystem", "Enables access to files from the host: namespace in the virtual machine.", "EmuCore",
 		"HostFs", false);
 
+	MenuHeading("Patches");
+	
+	DrawToggleSetting(bsi, "Enable Widescreen Patches", "Enables loading widescreen patches from pnach files.", "EmuCore",
+		"EnableWideScreenPatches", false);
+	DrawToggleSetting(bsi, "Enable No-Interlacing Patches", "Enables loading no-interlacing patches from pnach files.", "EmuCore",
+		"EnableNoInterlacingPatches", false);
+	DrawToggleSetting(bsi, "Enable 60FPS Patches", "Enables loading 60fps patches from pnach files.", "EmuCore",
+		"Enable60FPSPatches", false);
+	DrawToggleSetting(bsi, "Enable DNAS Patches", "Enables loading DNAS patches from pnach files.", "EmuCore",
+		"EnableDNASPatches", false);
+
 	if (IsEditingGameSettings(bsi))
 	{
 		DrawToggleSetting(
@@ -3100,10 +3111,6 @@ void FullscreenUI::DrawGraphicsSettingsPage()
 		100, 10, 300, "%d%%");
 	DrawIntRectSetting(bsi, "Crop", "Crops the image, while respecting aspect ratio.", "EmuCore/GS", "CropLeft", 0, "CropTop", 0,
 		"CropRight", 0, "CropBottom", 0, 0, 720, 1, "%dpx");
-	DrawToggleSetting(bsi, "Enable Widescreen Patches", "Enables loading widescreen patches from pnach files.", "EmuCore",
-		"EnableWideScreenPatches", false);
-	DrawToggleSetting(bsi, "Enable No-Interlacing Patches", "Enables loading no-interlacing patches from pnach files.", "EmuCore",
-		"EnableNoInterlacingPatches", false);
 	DrawIntListSetting(bsi, "Bilinear Upscaling", "Smooths out the image when upscaling the console to the screen.", "EmuCore/GS",
 		"linear_present_mode", static_cast<int>(GSPostBilinearMode::BilinearSharp), s_bilinear_present_options,
 		std::size(s_bilinear_present_options));
@@ -4098,8 +4105,10 @@ void FullscreenUI::DrawFoldersSettingsPage()
 	DrawFolderSetting(bsi, ICON_FA_WRENCH " Game Settings Directory", "Folders", "GameSettings", EmuFolders::GameSettings);
 	DrawFolderSetting(bsi, ICON_FA_GAMEPAD " Input Profile Directory", "Folders", "InputProfiles", EmuFolders::InputProfiles);
 	DrawFolderSetting(bsi, ICON_FA_FROWN " Cheats Directory", "Folders", "Cheats", EmuFolders::Cheats);
-	DrawFolderSetting(bsi, ICON_FA_TV " Widescreen Cheats Directory", "Folders", "CheatsWS", EmuFolders::CheatsWS);
-	DrawFolderSetting(bsi, ICON_FA_MAGIC " No-Interlace Cheats Directory", "Folders", "CheatsNI", EmuFolders::CheatsNI);
+	DrawFolderSetting(bsi, ICON_FA_TV " Widescreen Patches Directory", "Folders", "CheatsWS", EmuFolders::CheatsWS);
+	DrawFolderSetting(bsi, ICON_FA_MAGIC " No-Interlace Patches Directory", "Folders", "CheatsNI", EmuFolders::CheatsNI);
+	DrawFolderSetting(bsi, ICON_FA_CLOCK " 60FPS Patches Directory", "Folders", "Cheats60", EmuFolders::Cheats60);
+	DrawFolderSetting(bsi, ICON_FA_WIFI " DNAS Patches Directory", "Folders", "CheatsDNAS", EmuFolders::CheatsDNAS);
 	DrawFolderSetting(bsi, ICON_FA_SLIDERS_H "Texture Replacements Directory", "Folders", "Textures", EmuFolders::Textures);
 	DrawFolderSetting(bsi, ICON_FA_SLIDERS_H "Video Dumping Directory", "Folders", "Videos", EmuFolders::Videos);
 

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -102,6 +102,8 @@ namespace EmuFolders
 	std::string Cheats;
 	std::string CheatsWS;
 	std::string CheatsNI;
+	std::string Cheats60;
+	std::string CheatsDNAS;
 	std::string Resources;
 	std::string Cache;
 	std::string Covers;
@@ -1349,6 +1351,8 @@ void Pcsx2Config::LoadSave(SettingsWrapper& wrap)
 	SettingsWrapBitBool(EnablePINE);
 	SettingsWrapBitBool(EnableWideScreenPatches);
 	SettingsWrapBitBool(EnableNoInterlacingPatches);
+	SettingsWrapBitBool(Enable60FPSPatches);
+	SettingsWrapBitBool(EnableDNASPatches);
 	SettingsWrapBitBool(EnableRecordingTools);
 	SettingsWrapBitBool(EnableGameFixes);
 	SettingsWrapBitBool(SaveStateOnShutdown);
@@ -1615,6 +1619,8 @@ void EmuFolders::SetDefaults(SettingsInterface& si)
 	si.SetStringValue("Folders", "Cheats", "cheats");
 	si.SetStringValue("Folders", "CheatsWS", "cheats_ws");
 	si.SetStringValue("Folders", "CheatsNI", "cheats_ni");
+	si.SetStringValue("Folders", "Cheats60", "cheats_60");
+	si.SetStringValue("Folders", "CheatsDNAS", "cheats_dnas");
 	si.SetStringValue("Folders", "Cache", "cache");
 	si.SetStringValue("Folders", "Textures", "textures");
 	si.SetStringValue("Folders", "InputProfiles", "inputprofiles");
@@ -1639,6 +1645,8 @@ void EmuFolders::LoadConfig(SettingsInterface& si)
 	Cheats = LoadPathFromSettings(si, DataRoot, "Cheats", "cheats");
 	CheatsWS = LoadPathFromSettings(si, DataRoot, "CheatsWS", "cheats_ws");
 	CheatsNI = LoadPathFromSettings(si, DataRoot, "CheatsNI", "cheats_ni");
+	Cheats60 = LoadPathFromSettings(si, DataRoot, "Cheats60", "cheats_60");
+	CheatsDNAS = LoadPathFromSettings(si, DataRoot, "CheatsDNAS", "cheats_dnas");
 	Covers = LoadPathFromSettings(si, DataRoot, "Covers", "covers");
 	GameSettings = LoadPathFromSettings(si, DataRoot, "GameSettings", "gamesettings");
 	Cache = LoadPathFromSettings(si, DataRoot, "Cache", "cache");
@@ -1654,6 +1662,8 @@ void EmuFolders::LoadConfig(SettingsInterface& si)
 	Console.WriteLn("Cheats Directory: %s", Cheats.c_str());
 	Console.WriteLn("CheatsWS Directory: %s", CheatsWS.c_str());
 	Console.WriteLn("CheatsNI Directory: %s", CheatsNI.c_str());
+	Console.WriteLn("Cheats60 Directory: %s", Cheats60.c_str());
+	Console.WriteLn("CheatsDNAS Directory: %s", CheatsDNAS.c_str());
 	Console.WriteLn("Covers Directory: %s", Covers.c_str());
 	Console.WriteLn("Game Settings Directory: %s", GameSettings.c_str());
 	Console.WriteLn("Cache Directory: %s", Cache.c_str());
@@ -1673,6 +1683,8 @@ bool EmuFolders::EnsureFoldersExist()
 	result = FileSystem::CreateDirectoryPath(Cheats.c_str(), false) && result;
 	result = FileSystem::CreateDirectoryPath(CheatsWS.c_str(), false) && result;
 	result = FileSystem::CreateDirectoryPath(CheatsNI.c_str(), false) && result;
+	result = FileSystem::CreateDirectoryPath(Cheats60.c_str(), false) && result;
+	result = FileSystem::CreateDirectoryPath(CheatsDNAS.c_str(), false) && result;
 	result = FileSystem::CreateDirectoryPath(Covers.c_str(), false) && result;
 	result = FileSystem::CreateDirectoryPath(GameSettings.c_str(), false) && result;
 	result = FileSystem::CreateDirectoryPath(Cache.c_str(), false) && result;

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -157,6 +157,12 @@ static std::vector<u8> s_no_interlacing_cheats_data;
 static bool s_no_interlacing_cheats_loaded = false;
 static s32 s_active_widescreen_patches = 0;
 static u32 s_active_no_interlacing_patches = 0;
+static std::vector<u8> s_60fps_cheats_data;
+static bool s_60fps_cheats_loaded = false;
+static std::vector<u8> s_dnas_cheats_data;
+static bool s_dnas_cheats_loaded = false;
+static s32 s_active_60fps_patches = 0;
+static u32 s_active_dnas_patches = 0;
 static u32 s_frame_advance_count = 0;
 static u32 s_mxcsr_saved;
 static bool s_gs_open_on_initialize = false;
@@ -515,6 +521,8 @@ void VMManager::Internal::UpdateEmuFolders()
 	const std::string old_cheats_directory(EmuFolders::Cheats);
 	const std::string old_cheats_ws_directory(EmuFolders::CheatsWS);
 	const std::string old_cheats_ni_directory(EmuFolders::CheatsNI);
+	const std::string old_cheats_60_directory(EmuFolders::Cheats60);
+	const std::string old_cheats_dnas_directory(EmuFolders::CheatsDNAS);
 	const std::string old_memcards_directory(EmuFolders::MemoryCards);
 	const std::string old_textures_directory(EmuFolders::Textures);
 	const std::string old_videos_directory(EmuFolders::Videos);
@@ -526,7 +534,8 @@ void VMManager::Internal::UpdateEmuFolders()
 	if (VMManager::HasValidVM())
 	{
 		if (EmuFolders::Cheats != old_cheats_directory || EmuFolders::CheatsWS != old_cheats_ws_directory ||
-			EmuFolders::CheatsNI != old_cheats_ni_directory)
+			EmuFolders::CheatsNI != old_cheats_ni_directory || EmuFolders::Cheats60 != old_cheats_60_directory ||
+			EmuFolders::CheatsDNAS != old_cheats_dnas_directory)
 		{
 			VMManager::ReloadPatches(true, true);
 		}
@@ -694,6 +703,8 @@ void VMManager::LoadPatches(const std::string& serial, u32 crc, bool show_messag
 	s_patches_crc = crc;
 	s_active_widescreen_patches = 0;
 	s_active_no_interlacing_patches = 0;
+	s_active_60fps_patches = 0;
+	s_active_dnas_patches = 0;
 	ForgetLoadedPatches();
 
 	std::string message;
@@ -812,9 +823,81 @@ void VMManager::LoadPatches(const std::string& serial, u32 crc, bool show_messag
 		s_active_no_interlacing_patches = 0;
 	}
 
+	// 60fps patches
+	if (EmuConfig.Enable60FPSPatches && crc != 0)
+	{
+		if (!Achievements::ChallengeModeActive() && (s_active_60fps_patches = LoadPatchesFromDir(crc_string, EmuFolders::Cheats60, "60FPS patches", false)) > 0)
+		{
+			Console.WriteLn(Color_Gray, "Found 60FPS patches in the cheats_60 folder --> skipping cheats_60.zip");
+		}
+		else
+		{
+			// No 60fps cheat files found at the cheats_60 folder, try the 60fps cheats zip file.
+			if (!s_60fps_cheats_loaded)
+			{
+				s_60fps_cheats_loaded = true;
+
+				std::optional<std::vector<u8>> data = Host::ReadResourceFile("cheats_60.zip");
+				if (data.has_value())
+					s_60fps_cheats_data = std::move(data.value());
+			}
+
+			if (!s_60fps_cheats_data.empty())
+			{
+				s_active_60fps_patches = LoadPatchesFromZip(crc_string, s_60fps_cheats_data.data(), s_60fps_cheats_data.size());
+				PatchesCon->WriteLn(Color_Green, "(60FPS Cheats DB) Patches Loaded: %d", s_active_60fps_patches);
+			}
+		}
+
+		if (s_active_60fps_patches > 0)
+		{
+			fmt::format_to(std::back_inserter(message), "{}{} 60fps patches", (patch_count > 0 || cheat_count > 0 || s_active_widescreen_patches > 0 || s_active_no_interlacing_patches > 0) ? " and " : "", s_active_60fps_patches);
+		}
+	}
+	else
+	{
+		s_active_60fps_patches = 0;
+	}
+
+	// DNAS bypass patches
+	if (EmuConfig.EnableDNASPatches && crc != 0)
+	{
+		if (!Achievements::ChallengeModeActive() && (s_active_dnas_patches = LoadPatchesFromDir(crc_string, EmuFolders::CheatsDNAS, "DNAS patches", false)) > 0)
+		{
+			Console.WriteLn(Color_Gray, "Found DNAS patches in the cheats_dnas folder --> skipping cheats_dnas.zip");
+		}
+		else
+		{
+			// No dnas cheat files found at the cheats_dnas folder, try the dnas cheats zip file.
+			if (!s_dnas_cheats_loaded)
+			{
+				s_dnas_cheats_loaded = true;
+
+				std::optional<std::vector<u8>> data = Host::ReadResourceFile("cheats_dnas.zip");
+				if (data.has_value())
+					s_dnas_cheats_data = std::move(data.value());
+			}
+
+			if (!s_dnas_cheats_data.empty())
+			{
+				s_active_dnas_patches = LoadPatchesFromZip(crc_string, s_dnas_cheats_data.data(), s_dnas_cheats_data.size());
+				PatchesCon->WriteLn(Color_Green, "(DNAS Cheats DB) Patches Loaded: %d", s_active_dnas_patches);
+			}
+		}
+
+		if (s_active_dnas_patches > 0)
+		{
+			fmt::format_to(std::back_inserter(message), "{}{} DNAS patches", (patch_count > 0 || cheat_count > 0 || s_active_widescreen_patches > 0 || s_active_no_interlacing_patches > 0 || s_active_60fps_patches > 0) ? " and " : "", s_active_dnas_patches);
+		}
+	}
+	else
+	{
+		s_active_dnas_patches = 0;
+	}
+
 	if (show_messages)
 	{
-		if (cheat_count > 0 || s_active_widescreen_patches > 0 || s_active_no_interlacing_patches > 0)
+		if (cheat_count > 0 || s_active_widescreen_patches > 0 || s_active_no_interlacing_patches > 0 || s_active_60fps_patches > 0 || s_active_dnas_patches > 0)
 		{
 			message += " are active.";
 			Host::AddIconOSDMessage("LoadPatches", ICON_FA_FILE_CODE, message, Host::OSD_INFO_DURATION);


### PR DESCRIPTION
### Description of Changes
- Enabled using 60FPS and DNAS Patches in the Frontend, both in Qt and Big Picture.

- Implement reading pnach files from either cheats_60/cheats_dnas folders or the respective zip files.

- Moved all "Enable Patch" options to the Emulation Settings under a "Patches" header for ease of use in both Qt and Big Picture.

Qt:
![2023-05-18 20_34_43-PCSX2 Settings](https://github.com/PCSX2/pcsx2/assets/27123572/2f46cbd8-70af-4ad8-beaf-0452ba8c5dc6)

Big Picture:
![2023-05-18 20_35_21-](https://github.com/PCSX2/pcsx2/assets/27123572/0b733732-0aa0-44dc-8ff1-9c07cfb7e44c)

### Rationale behind Changes
The changes above were made for ease of use, having both 60FPS and DNAS bypass patches available in PCSX2 makes things more straightforward for the end user as opposed to them being read as standard cheats files.