### PR TITLE
GSRunner: Fix log file writing

### DIFF
--- a/pcsx2-gsrunner/Main.cpp
+++ b/pcsx2-gsrunner/Main.cpp
@@ -644,6 +644,7 @@ int main(int argc, char* argv[])
 
 	VMManager::Internal::CPUThreadShutdown();
 	GSRunner::DestroyPlatformWindow();
+	LogSink::CloseFileLog();
 
 	return EXIT_SUCCESS;
 }

--- a/pcsx2-qt/QtHost.cpp
+++ b/pcsx2-qt/QtHost.cpp
@@ -1837,11 +1837,7 @@ int main(int argc, char* argv[])
 		s_base_settings_interface->Save();
 
 	// Ensure emulog is flushed.
-	if (emuLog)
-	{
-		std::fclose(emuLog);
-		emuLog = nullptr;
-	}
+	LogSink::CloseFileLog();
 
 	return result;
 }

--- a/pcsx2/LogSink.cpp
+++ b/pcsx2/LogSink.cpp
@@ -383,6 +383,15 @@ void LogSink::SetFileLogPath(std::string path)
 	}
 }
 
+void LogSink::CloseFileLog()
+{
+	if (!emuLog)
+		return;
+
+	std::fclose(emuLog);
+	emuLog = nullptr;
+}
+
 void LogSink::SetBlockSystemConsole(bool block)
 {
 	s_block_system_console = block;

--- a/pcsx2/LogSink.h
+++ b/pcsx2/LogSink.h
@@ -22,6 +22,9 @@ namespace LogSink
 	/// Overrides the filename used for the file log.
 	void SetFileLogPath(std::string path);
 
+	/// Ensures file log is flushed and closed.
+	void CloseFileLog();
+
 	/// Prevents the system console from being displayed.
 	void SetBlockSystemConsole(bool block);
 


### PR DESCRIPTION
### Description of Changes

Wasn't getting flushed/closed on shutdown.

### Rationale behind Changes

No logs makes figuring out which dumps do funky stuff kinda difficult.

### Suggested Testing Steps

Make sure file logging still works in Qt.
