### PR TITLE
Achievements: Implement the ELF suffix hack from CDVD when hashing

### DIFF
--- a/pcsx2/Achievements.cpp
+++ b/pcsx2/Achievements.cpp
@@ -1359,8 +1359,19 @@ std::optional<std::vector<u8>> Achievements::ReadELFFromCurrentDisc(const std::s
 	std::optional<std::vector<u8>> ret;
 	try
 	{
+		// ELF suffix hack. Taken from CDVD::loadElf
+		// MLB2k6 has an elf whose suffix is actually ;2
+		std::string filepath(elf_path);
+		const std::string::size_type semi_pos = filepath.rfind(';');
+		if (semi_pos != std::string::npos && std::string_view(filepath).substr(semi_pos) != ";1")
+		{
+			Console.Warning("(Achievements) Non-conforming version suffix (%s) detected and replaced.", elf_path.c_str());
+			filepath.erase(semi_pos);
+			filepath += ";1";
+		}
+
 		IsoFSCDVD isofs;
-		IsoFile file(isofs, elf_path);
+		IsoFile file(isofs, filepath);
 		const u32 size = file.getLength();
 
 		ret = std::vector<u8>();


### PR DESCRIPTION
### Description of Changes
Due to some reason I can't explain, our ISO filesystem code will read any ELF version suffix as ;1.
This was worked around for our main CDVD code here: https://github.com/pcsx2/pcsx2/commit/d36bb196126408068fbb1feb7f22cc5e0d7f6b1f,
but was not passed onto the Achievements ELF hashing code.
All this does is copy that workaround to the Achievements hashing routine.

### Rationale behind Changes
Fixes #8889
The Achievements hashing code was looking for the 'correct' ELF file `SLUS_212.35;2` taken from `SYSTEM.CNF;1`.
This would cause it to fail.

### Suggested Testing Steps
Test games that have known ELF version suffixes that are **not** `;1`
[MLB 2K6](http://redump.org/disc/20905/) is one example.