### PR TITLE
IsoFS: Create 'hard-links' for non-conforming version suffixes

### DIFF
--- a/pcsx2/CDVD/IsoFS/IsoFS.cpp
+++ b/pcsx2/CDVD/IsoFS/IsoFS.cpp
@@ -146,7 +146,20 @@ void IsoDirectory::Init(const IsoFileDescriptor& directoryEntry)
 
 		dataStream.read(b + 1, b[0] - 1);
 
-		files.push_back(IsoFileDescriptor(b, b[0]));
+		auto isoFile = IsoFileDescriptor(b, b[0]);
+
+		files.push_back(isoFile);
+
+		const std::string::size_type semi_pos = isoFile.name.rfind(';');
+		if (semi_pos != std::string::npos && std::string_view(isoFile.name).substr(semi_pos) != ";1")
+		{
+			const std::string origName = isoFile.name;
+			isoFile.name.erase(semi_pos);
+			isoFile.name += ";1";
+			Console.WriteLn("(IsoFS) Non-conforming version suffix (%s) detected. Creating 'hard-linked' entry (%s)",origName.c_str(), isoFile.name.c_str());
+
+			files.push_back(isoFile);
+		}
 	}
 
 	b[0] = 0;


### PR DESCRIPTION
### Description of Changes
Whenever a version suffix that is **not** `;1` is come across, create an entry of the file _with_ `;1` as well.

For example
```
My.ISO/
├─ SLUS_1234;1
├─ DATA/
│  ├─ SOME_MUSIC;2
│  ├─ PICTURE_OF_CAT;4
│  ├─ PASSWORDS.TXT;1
```

Will be available as:
```
My.ISO/
├─ SLUS_1234;1
├─ DATA/
│  ├─ SOME_MUSIC;2
│  ├─ SOME_MUSIC;1
│  ├─ PICTURE_OF_CAT;4
│  ├─ PICTURE_OF_CAT;1
│  ├─ PASSWORDS.TXT;1
```

### Rationale behind Changes
This is a happy medium so we can continue to behave like CDVDMAN (all files in `cdrom0:` are suffixed with `;1`) while allowing for the possibility of newer CDVDMAN modules, or homebrew modules to utilize this suffix format.

This also allows for the rare chance to support something that loads an ELF with a non-`;1` suffix with a supported CDVDMAN module.

This has an issue with a rare edge case where there are two files named the same thing, with different suffixes.
I doubt that'll be an issue though.
### Suggested Testing Steps
Test games and see if they run.
Try homebrew (ulaunchelf) that supports looking at the cdrom filesystem.

