### PR TITLE
Patches: Fix parsing of double words. Expand error log.

### DIFF
--- a/pcsx2/Patch.cpp
+++ b/pcsx2/Patch.cpp
@@ -262,15 +262,15 @@ namespace PatchFunc
 
 		std::string_view addr_end, data_end;
 		const std::optional<u32> addr = StringUtil::FromChars<u32>(pieces[2], 16, &addr_end);
-		const std::optional<u32> data = StringUtil::FromChars<u32>(pieces[4], 16, &data_end);
+		const std::optional<u64> data = StringUtil::FromChars<u64>(pieces[4], 16, &data_end);
 		if (!addr.has_value() || !addr_end.empty())
 		{
-			PATCH_ERROR("Malformed address '%.*s', a hex number is expected", static_cast<int>(pieces[2].size()), pieces[2].data());
+			PATCH_ERROR("Malformed address '%.*s', a hex number without prefix (e.g. 0123ABCD) is expected", static_cast<int>(pieces[2].size()), pieces[2].data());
 			return;
 		}
 		else if (!data.has_value() || !data_end.empty())
 		{
-			PATCH_ERROR("Malformed data '%.*s', a hex number is expected", static_cast<int>(pieces[4].size()), pieces[4].data());
+			PATCH_ERROR("Malformed data '%.*s', a hex number without prefix (e.g. 0123ABCD) is expected", static_cast<int>(pieces[4].size()), pieces[4].data());
 			return;
 		}
 


### PR DESCRIPTION
### Description of Changes
Fixes the parsing of `double` values in patches, also expand the log to give an example of how a hex string should be presented.

### Rationale behind Changes
Double thing got broken by accident.
Log message was a bit ambiguous only saying "a hex number is expected" when 0x1234ABCD is provided, so I've expanded to to explain without any prefixes and gave an example to give the user clarity on their error.

### Suggested Testing Steps
Already tested, watch CI
