### PR TITLE
Core: Use 2MB stacks for µVU

### DIFF
--- a/pcsx2-qt/QtHost.cpp
+++ b/pcsx2-qt/QtHost.cpp
@@ -116,6 +116,7 @@ void EmuThread::start()
 	pxAssertRel(!g_emu_thread, "Emu thread does not exist");
 
 	g_emu_thread = new EmuThread(QThread::currentThread());
+	g_emu_thread->setStackSize(VMManager::EMU_THREAD_STACK_SIZE);
 	g_emu_thread->QThread::start();
 	g_emu_thread->m_started_semaphore.acquire();
 	g_emu_thread->moveToThread(g_emu_thread);

--- a/pcsx2/MTVU.cpp
+++ b/pcsx2/MTVU.cpp
@@ -18,6 +18,7 @@
 #include "Common.h"
 #include "Gif_Unit.h"
 #include "MTVU.h"
+#include "VMManager.h"
 #include "x86/newVif.h"
 
 #include <thread>
@@ -107,6 +108,7 @@ void VU_Thread::Open()
 	Reset();
 	semaEvent.Reset();
 	m_shutdown_flag.store(false, std::memory_order_release);
+	m_thread.SetStackSize(VMManager::EMU_THREAD_STACK_SIZE);
 	m_thread.Start([this]() { ExecuteRingBuffer(); });
 }
 

--- a/pcsx2/VMManager.h
+++ b/pcsx2/VMManager.h
@@ -56,6 +56,9 @@ namespace VMManager
 	/// The number of usable save state slots.
 	static constexpr s32 NUM_SAVE_STATE_SLOTS = 10;
 
+	/// The stack size to use for threads running recompilers
+	static constexpr std::size_t EMU_THREAD_STACK_SIZE = 2 * 1024 * 1024; // µVU likes recursion
+
 	/// Makes sure that AVX2 is available if we were compiled with it.
 	bool PerformEarlyHardwareChecks(const char** error);
 


### PR DESCRIPTION
### Description of Changes
Forces use of 2MB stacks for threads that may run µVU recompilers (macOS defaults to 512kb)

Fixes crashes in Garfield: Saving Arlene on macOS

### Rationale behind Changes
Less crashy more runny

### Suggested Testing Steps
Test Garfield: Saving Arlene on macOS
Test other things
