### PR TITLE
GameDB: Fix missing textures in Galerians: Ash

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -13177,6 +13177,17 @@ SLES-51341:
 SLES-51343:
   name: "Galerians - Ash"
   region: "PAL-M5"
+  patches:
+    1AE08CF5:
+      content: |-
+        author=kozarovv
+        // Floats workaround to make HW GSDX mode working.
+        // There is still overflow on GS, but this time GSDX can handle it just fine in HW mode.
+        patch=1,EE,001e7130,word,3c017e00
+        patch=1,EE,001e7138,word,44812800
+        patch=1,EE,001e7150,word,44813000
+        patch=1,EE,001e7160,word,44813800
+        patch=1,EE,001e7170,word,44810000
 SLES-51344:
   name: "Guilty Gear X2"
   region: "PAL-E"
@@ -38675,6 +38686,17 @@ SLPS-25118:
 SLPS-25119:
   name: "Galerians 2"
   region: "NTSC-J"
+  patches:
+    E8E54032:
+      content: |-
+        author=kozarovv, descawed
+        // Floats workaround to make HW GSDX mode working.
+        // There is still overflow on GS, but this time GSDX can handle it just fine in HW mode.
+        patch=1,EE,001da848,word,3c017e00
+        patch=1,EE,001da850,word,44812800
+        patch=1,EE,001da868,word,44813000
+        patch=1,EE,001da878,word,44813800
+        patch=1,EE,001da888,word,44810000
 SLPS-25120:
   name: "Gundam Gihren's Ambition"
   region: "NTSC-J"


### PR DESCRIPTION
### Description of Changes
Added patches for the European and Japanese versions of Galerians: Ash to fix missing textures when using hardware rendering. 

A note on the authors I listed: US and European patches have been on the wiki for some time, but the GameDB only included the US patch, so I added the European patch from the wiki. The author of the US patch in the GameDB is "kozarovv", so I assume that that person also authored the European patch. However, the wiki edit that added the two patches was by user "Red Tv", so I'm not sure if they should be listed as well/instead. For the Japanese patch, I found the addresses myself by referencing the US patch, so I've given kozarovv credit on that one as well.

### Rationale behind Changes
A significant amount of text in the game is unreadable without these patches.

### Suggested Testing Steps
Based on other GameDB PRs, it sounds like all that's necessary is for CI to pass? However, the patches can be tested by attempting to read any file or interact with any object/NPC and making sure the text and/or images appear. I took before and after screenshots from my own tests but GitHub isn't letting me upload images right now. I can try again later if desired.