### PR TITLE
GS-TC: Fix bugs with target resize and borders in texture min max

### DIFF
--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -3484,6 +3484,12 @@ GSState::TextureMinMaxResult GSState::GetTextureMinMax(GIFRegTEX0 TEX0, GIFRegCL
 		if (linear)
 		{
 			st += GSVector4(-0.5f, 0.5f).xxyy();
+			
+			// If it's the start of the texture and our little adjustment is all that pushed it over, clamp it to 0.
+			// This stops the border check failing when using repeat but needed less than the full texture
+			// since this was making it take the full texture even though it wasn't needed.
+			if (((m_vt.m_min.t == GSVector4::zero()).mask() & 0x3) == 0x3)
+				st = st.max(GSVector4::zero());
 		}
 		else
 		{

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -1957,9 +1957,9 @@ void GSRendererHW::Draw()
 			GL_CACHE("Estimated texture region: %u,%u -> %u,%u", MIP_CLAMP.MINU, MIP_CLAMP.MINV, MIP_CLAMP.MAXU + 1,
 				MIP_CLAMP.MAXV + 1);
 		}
-
-		src = tex_psm.depth ? g_texture_cache->LookupDepthSource(TEX0, env.TEXA, MIP_CLAMP, tmm.coverage) :
-								g_texture_cache->LookupSource(TEX0, env.TEXA, MIP_CLAMP, tmm.coverage, (GSConfig.HWMipmap >= HWMipmapLevel::Basic || GSConfig.TriFilter == TriFiltering::Forced) ? &hash_lod_range : nullptr);
+		const bool possible_shuffle = m_cached_ctx.FRAME.Block() == m_cached_ctx.TEX0.TBP0 || IsPossibleChannelShuffle();
+		src = tex_psm.depth ? g_texture_cache->LookupDepthSource(TEX0, env.TEXA, MIP_CLAMP, tmm.coverage, possible_shuffle) :
+								g_texture_cache->LookupSource(TEX0, env.TEXA, MIP_CLAMP, tmm.coverage, (GSConfig.HWMipmap >= HWMipmapLevel::Basic || GSConfig.TriFilter == TriFiltering::Forced) ? &hash_lod_range : nullptr, possible_shuffle);
 	}
 
 	// Estimate size based on the scissor rectangle and height cache.

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.h
@@ -438,6 +438,7 @@ public:
 	void RemoveAll();
 	void ReadbackAll();
 	void AddDirtyRectTarget(Target* target, GSVector4i rect, u32 psm, u32 bw, RGBAMask rgba, bool req_linear = false);
+	void ResizeTarget(Target* t, GSVector4i rect, u32 tbp, u32 psm, u32 tbw);
 	bool FullRectDirty(Target* target);
 	bool CanTranslate(u32 bp, u32 bw, u32 spsm, GSVector4i r, u32 dbp, u32 dpsm, u32 dbw);
 	GSVector4i TranslateAlignedRectByPage(Target* t, u32 sbp, u32 spsm, u32 sbw, GSVector4i src_r, bool is_invalidation = false);
@@ -446,8 +447,8 @@ public:
 	GSTexture* LookupPaletteSource(u32 CBP, u32 CPSM, u32 CBW, GSVector2i& offset, float* scale, const GSVector2i& size);
 	std::shared_ptr<Palette> LookupPaletteObject(u16 pal, bool need_gs_texture);
 
-	Source* LookupSource(const GIFRegTEX0& TEX0, const GIFRegTEXA& TEXA, const GIFRegCLAMP& CLAMP, const GSVector4i& r, const GSVector2i* lod);
-	Source* LookupDepthSource(const GIFRegTEX0& TEX0, const GIFRegTEXA& TEXA, const GIFRegCLAMP& CLAMP, const GSVector4i& r, bool palette = false);
+	Source* LookupSource(const GIFRegTEX0& TEX0, const GIFRegTEXA& TEXA, const GIFRegCLAMP& CLAMP, const GSVector4i& r, const GSVector2i* lod, const bool possible_shuffle);
+	Source* LookupDepthSource(const GIFRegTEX0& TEX0, const GIFRegTEXA& TEXA, const GIFRegCLAMP& CLAMP, const GSVector4i& r, const bool possible_shuffle, bool palette = false);
 
 	Target* FindTargetOverlap(u32 bp, u32 end_block, int type, int psm);
 	Target* LookupTarget(GIFRegTEX0 TEX0, const GSVector2i& size, float scale, int type, bool used = true, u32 fbmask = 0,


### PR DESCRIPTION
### Description of Changes
Fix some resizing bugs when tex is RT and it needs to resize the target, and don't resize when shuffles are involved.
Also fix an annoyance with texture min/max calculation.

### Rationale behind Changes
The resizing was resizing down if it was reading strips of an RT but growing in the other direction, but also we weren't resizing if the BP's matched. Also if it was a shuffle/recursive draw there's no need to resize the texture (this breaks 50 Cent)

The scenario in Texture Min/Max was that it was doing a bilinear draw, so we add -0.5/0.5 to the coordinates to make sure we get whole pixels, however if the min X and Y was 0 they ended up as -1 (because we do floor(-0.5) on them, basically), causing the border check to think it was wrapping when this isn't the case.

### Suggested Testing Steps
Just test an array of games, including the intro for Splinter Cell Pandora Tomorrow.  

Dump runner showed a lot of differences again, however I think it was just reversing whatever happened in #8454 as they were all changes you couldn't really see.

Fixes Pandora Tomorrow intro screen.

Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/df3521d5-831c-40fc-b015-dd87c1e5283e)

PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/a4a1b208-1c6e-4bf0-9edd-15633152070e)



