### PR TITLE
GS: Enable API debug logging in Devel builds

### DIFF
--- a/pcsx2/GS/GSGL.h
+++ b/pcsx2/GS/GSGL.h
@@ -1,5 +1,5 @@
 /*  PCSX2 - PS2 Emulator for PCs
- *  Copyright (C) 2002-2021 PCSX2 Dev Team
+ *  Copyright (C) 2002-2023 PCSX2 Dev Team
  *
  *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU Lesser General Public License as published by the Free Software Found-
@@ -18,27 +18,27 @@
 #include "GS/Renderers/Common/GSDevice.h"
 #include "GS/GSExtra.h"
 
-#if !defined(NDEBUG) || defined(_DEBUG) || defined(_DEVEL)
-#define ENABLE_OGL_DEBUG // Create a debug context and check opengl command status. Allow also to dump various textures/states.
-  //#define ENABLE_TRACE_REG // print GS reg write
- //#define ENABLE_EXTRA_LOG // print extra log
+#if defined(_DEBUG) || defined(PCSX2_DEVBUILD)
+#define ENABLE_OGL_DEBUG // enable GS debug logging
+//#define ENABLE_TRACE_REG // print GS reg write
+//#define ENABLE_EXTRA_LOG // print extra log
 #endif
 
 // Note: GL messages are present in common code, so in all renderers.
 
-#if defined(_DEBUG)
+#ifdef ENABLE_OGL_DEBUG
 	#define GL_CACHE(...) g_gs_device->InsertDebugMessage(GSDevice::DebugMessageCategory::Cache, __VA_ARGS__)
 #else
 	#define GL_CACHE(...) (void)(0)
 #endif
 
-#if defined(ENABLE_TRACE_REG) && defined(_DEBUG)
+#if defined(ENABLE_OGL_DEBUG) && defined(ENABLE_TRACE_REG)
 	#define GL_REG(...) g_gs_device->InsertDebugMessage(GSDevice::DebugMessageCategory::Reg, __VA_ARGS__)
 #else
 	#define GL_REG(...) (void)(0)
 #endif
 
-#if defined(ENABLE_EXTRA_LOG) && defined(_DEBUG)
+#if defined(ENABLE_OGL_DEBUG) && defined(_DEBUG)
 	#define GL_DBG(...) g_gs_device->InsertDebugMessage(GSDevice::DebugMessageCategory::Debug, __VA_ARGS__)
 #else
 	#define GL_DBG(...) (void)(0)

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -1262,10 +1262,6 @@ void GSDeviceOGL::CopyRect(GSTexture* sTex, GSTexture* dTex, const GSVector4i& r
 
 	GL_PUSH("CopyRect from %d to %d", sid, did);
 
-#ifdef ENABLE_OGL_DEBUG
-	PSSetShaderResource(6, sTex);
-#endif
-
 	g_perfmon.Put(GSPerfMon::TextureCopies, 1);
 
 	if (GLAD_GL_VERSION_4_3 || GLAD_GL_ARB_copy_image)

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
@@ -491,7 +491,7 @@ static std::array<float, 3> Palette(float phase, const std::array<float, 3>& a, 
 void GSDeviceVK::PushDebugGroup(const char* fmt, ...)
 {
 #ifdef ENABLE_OGL_DEBUG
-	if (!vkCmdBeginDebugUtilsLabelEXT)
+	if (!vkCmdBeginDebugUtilsLabelEXT || !GSConfig.UseDebugDevice)
 		return;
 
 	std::va_list ap;
@@ -515,7 +515,7 @@ void GSDeviceVK::PushDebugGroup(const char* fmt, ...)
 void GSDeviceVK::PopDebugGroup()
 {
 #ifdef ENABLE_OGL_DEBUG
-	if (!vkCmdEndDebugUtilsLabelEXT)
+	if (!vkCmdEndDebugUtilsLabelEXT || !GSConfig.UseDebugDevice)
 		return;
 
 	s_debug_scope_depth = (s_debug_scope_depth == 0) ? 0 : (s_debug_scope_depth - 1u);
@@ -527,7 +527,7 @@ void GSDeviceVK::PopDebugGroup()
 void GSDeviceVK::InsertDebugMessage(DebugMessageCategory category, const char* fmt, ...)
 {
 #ifdef ENABLE_OGL_DEBUG
-	if (!vkCmdInsertDebugUtilsLabelEXT)
+	if (!vkCmdInsertDebugUtilsLabelEXT || !GSConfig.UseDebugDevice)
 		return;
 
 	std::va_list ap;


### PR DESCRIPTION
### Description of Changes

Debug is too slow to actually run games.

The performance hit from the extra virtual calls is fairly minimal. Obviously we don't want it in Release, but Devel turns off inlining and other things which make a non-trivial difference, so what's another thing.

### Rationale behind Changes

Saves me constantly applying this patch locally.

### Suggested Testing Steps

Make sure Release build performance is unaffected. Carbon's a good test.
