### PR TITLE
GS/HW: Don't preload large framebuffer alpha textures

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -3701,7 +3701,7 @@ GSTextureCache::HashCacheEntry* GSTextureCache::LookupHashCache(const GIFRegTEX0
 	const bool dump = GSConfig.DumpReplaceableTextures && (!FMVstarted || GSConfig.DumpTexturesWithFMVActive) &&
 					  (clut ? GSConfig.DumpPaletteTextures : GSConfig.DumpDirectTextures);
 	const bool replace = GSConfig.LoadTextureReplacements && GSTextureReplacements::HasAnyReplacementTextures();
-	bool can_cache = CanCacheTextureSize(TEX0.TW, TEX0.TH);
+	bool can_cache = (TEX0.PSM >= PSMT8H && TEX0.PSM <= PSMT4HH) ? CanPreloadTextureSize(TEX0.TW, TEX0.TH) : CanCacheTextureSize(TEX0.TW, TEX0.TH);
 	if (!dump && !replace && !can_cache)
 		return nullptr;
 


### PR DESCRIPTION
### Description of Changes

Tekken Tag Tournament, Star Ocean and probably other games put their font texture in the alpha channel of the framebuffer, then use P8H/P4HL/P4HH to pluck it out.

The problem is, they also set the texture size to 1024x1024, and don't use any region clamping. Hashing 1024x1024 **hurts**, since it has to expand the indices out, then hash a ton of data.

So, instead, use the partial preloading heuristics in this case. Partial invalidation works, but because the font part of the texture doesn't get invalidated, there's no texture uploads, no hashing, everyone wins.

Before:
![image](https://github.com/PCSX2/pcsx2/assets/11288319/41da2576-88a0-4fe8-b0f2-8100ea4ff986)

After:
![image](https://github.com/PCSX2/pcsx2/assets/11288319/149c3e85-6175-4f6e-8659-712f1890e146)

### Rationale behind Changes

In devel:
 - Star Ocean GS dump went from 364fps to over 2,200fps.
 - TTT went from 139fps to 210fps.

Better solution than #8910.

### Suggested Testing Steps

Check affected games. I'm doing a dump run to see what else pops up..
