### PR TITLE
Github: Update issue template regardiing crash dumps

### DIFF
--- a/.github/ISSUE_TEMPLATE/app_bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/app_bug_report.yaml
@@ -27,7 +27,6 @@ body:
           - If your bug is the result of upscaling please use the forums or discord for assistance with various upscaling workarounds. Additionally, the unofficial PCSX2 [Wiki](https://wiki.pcsx2.net/Main_Page) often lists various fixes for upscaling issues.
         - We do **not** accept issues relating to Widescreen/no-interlace patches at this time.
           - Any issues pertaining to Widescreen/no-interlace patches please forward them to the [patches repository](https://github.com/PCSX2/pcsx2_patches). 
-        -If PCSX2 crashed, please post crash logs and the .dmp file if appropiate.
 
   - type: textarea
     id: desc
@@ -78,5 +77,14 @@ body:
     attributes:
       label: If Linux - Specify Distro
       placeholder: "Example: Arch"
+    validations:
+      required: false
+  - type: textarea
+    id: logsDumps
+    attributes:
+      label: "Logs & Dumps"
+      description: |
+        Please feel free to attach any logs here.
+        If PCSX2 crashed, please post crash logs and the .dmp file (in a zip file) if appropriate.
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/emu_bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/emu_bug_report.yaml
@@ -140,7 +140,7 @@ body:
       label: "Logs & Dumps"
       description: |
         Please feel free to attach any logs, block dumps, GSdump, etc here.
-        If PCSX2 crashed, please post crash logs and the .dmp file if appropiate.
+        If PCSX2 crashed, please post crash logs and the .dmp file (in a zip file) if appropriate.
         If your problem is graphical in nature it is highly recommended that you provide a GSdump. [GSdump Guide](https://forums.pcsx2.net/Thread-How-to-create-a-proper-GS-dump)
     validations:
       required: false


### PR DESCRIPTION
### Description of Changes
Corrects spelling of appropriate
Adds text area for logs/dumps for the application template
Clarifies that dumps should be in a zip file

### Rationale behind Changes
Improves templates

### Suggested Testing Steps
Read the text
Github can preview issues templates (as a beta feature), so you may be able to preview the template on my branch
[App template](https://github.com/PCSX2/pcsx2/blob/90ce710372c11bb5f0f4f288c9d0922ae32497a5/.github/ISSUE_TEMPLATE/app_bug_report.yaml)
[Emu template](https://github.com/PCSX2/pcsx2/blob/90ce710372c11bb5f0f4f288c9d0922ae32497a5/.github/ISSUE_TEMPLATE/emu_bug_report.yaml)
