### PR TITLE
GameDB: Add full mipmap with ps2 trilinear to ESPN NFL 2K5.

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -16818,6 +16818,9 @@ SLES-52942:
 SLES-52943:
   name: "ESPN NFL 2K5"
   region: "PAL-E"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
+    trilinearFiltering: 1
   patches:
     7D5403E1:
       content: |-
@@ -46680,6 +46683,9 @@ SLUS-20919:
   name: "ESPN - NFL 2K5"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
+    trilinearFiltering: 1
   patches:
     42F9D5AF:
       content: |-


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GameDB: Add full mipmap with ps2 trilinear to ESPN NFL 2K5.
Improves textures to match sw renderer.
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Improves #5627
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
CI passes.