### PR TITLE
GS/Vulkan: Remove render area heuristics

### DIFF
--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h
@@ -354,7 +354,6 @@ public:
 	void BeginClearRenderPass(VkRenderPass rp, const GSVector4i& rect, const VkClearValue* cv, u32 cv_count);
 	void BeginClearRenderPass(VkRenderPass rp, const GSVector4i& rect, const GSVector4& clear_color);
 	void BeginClearRenderPass(VkRenderPass rp, const GSVector4i& rect, float depth, u8 stencil);
-	bool CheckRenderPassArea(const GSVector4i& rect);
 	void EndRenderPass();
 
 	void SetViewport(const VkViewport& viewport);


### PR DESCRIPTION
### Description of Changes

And just set the render area to the full target every time.

Except colclip draws.

### Rationale behind Changes

Some games render with changing viewports, and it throws the heuristics off. e.g. Transformers was doing over 2,000 render passes. Now down to 13.

It was mainly an optimization for when our target sizes were complete rubbish and always larger than needed. Since they're not anymore, the CPU overhead isn't worthwhile, and the "average" cases don't seem to take a performance hit.

### Suggested Testing Steps

Make sure performance in games which do many render passes is unaffected.
