### PR TITLE
GS:MTL: Fix ICE on macOS 10.15

### DIFF
--- a/pcsx2/GS/Renderers/Metal/tfx.metal
+++ b/pcsx2/GS/Renderers/Metal/tfx.metal
@@ -610,10 +610,11 @@ struct PSMain
 			t = fetch_c(uv) * 255.f;
 		}
 
+		// macOS 10.15 ICE's on bool3(t.rgb), so use != 0 instead
 		if (PS_AEM_FMT == FMT_24)
-			t.a = (!PS_AEM || any(bool3(t.rgb))) ? 255.f * cb.ta.x : 0.f;
+			t.a = (!PS_AEM || any(t.rgb != 0)) ? 255.f * cb.ta.x : 0.f;
 		else if (PS_AEM_FMT == FMT_16)
-			t.a = t.a >= 128.f ? 255.f * cb.ta.y : (!PS_AEM || any(bool3(t.rgb))) ? 255.f * cb.ta.x : 0.f;
+			t.a = t.a >= 128.f ? 255.f * cb.ta.y : (!PS_AEM || any(t.rgb != 0)) ? 255.f * cb.ta.x : 0.f;
 
 		return t;
 	}
@@ -708,10 +709,11 @@ struct PSMain
 
 		for (int i = 0; i < 4; i++)
 		{
+			// macOS 10.15 ICE's on bool3(c[i].rgb), so use != 0 instead
 			if (PS_AEM_FMT == FMT_24)
-				c[i].a = !PS_AEM || any(bool3(c[i].rgb)) ? cb.ta.x : 0.f;
+				c[i].a = !PS_AEM || any(c[i].rgb != 0) ? cb.ta.x : 0.f;
 			else if (PS_AEM_FMT == FMT_16)
-				c[i].a = c[i].a >= 0.5 ? cb.ta.y : !PS_AEM || any(bool3(c[i].rgb)) ? cb.ta.x : 0.f;
+				c[i].a = c[i].a >= 0.5 ? cb.ta.y : !PS_AEM || any(c[i].rgb != 0) ? cb.ta.x : 0.f;
 		}
 
 		if (PS_LTF)


### PR DESCRIPTION
### Description of Changes
Apparently the Catalina Intel UHD 630 backend compiler ICE's on use of the bool3 constructor over a float3... (Weirdly this happens on the Metal22 metallib compiled for 10.15 but not on the one compiled for 10.13... we do still want PrimID support if possible so I'd rather not remove it if I don't have to)

Fixes #8379

### Rationale behind Changes
Less broken

### Suggested Testing Steps
Test the gsdump mentioned in #8379 on Catalina