### PR TITLE
Patch: Add "bytes" type and improve logging

### DIFF
--- a/pcsx2/IopMem.h
+++ b/pcsx2/IopMem.h
@@ -83,6 +83,11 @@ extern void iopMemWrite8 (u32 mem, u8 value);
 extern void iopMemWrite16(u32 mem, u16 value);
 extern void iopMemWrite32(u32 mem, u32 value);
 
+// NOTE: Does not call MMIO handlers.
+extern int iopMemSafeCmpBytes(u32 mem, const void* src, u32 size);
+extern bool iopMemSafeReadBytes(u32 mem, void* dst, u32 size);
+extern bool iopMemSafeWriteBytes(u32 mem, const void* src, u32 size);
+
 std::string iopMemReadString(u32 mem, int maxlen = 65536);
 
 namespace IopMemory

--- a/pcsx2/Patch.h
+++ b/pcsx2/Patch.h
@@ -55,7 +55,7 @@ namespace Patch
 	// - There's no "place" value which indicates to apply both once on startup
 	//   and then also continuously, however such behavior can be achieved by
 	//   duplicating the line where one has a 0 place and the other has a 1 place.
-	enum patch_place_type
+	enum patch_place_type : u8
 	{
 		PPT_ONCE_ON_LOAD = 0,
 		PPT_CONTINUOUSLY = 1,

--- a/pcsx2/vtlb.h
+++ b/pcsx2/vtlb.h
@@ -110,6 +110,11 @@ extern DataType vtlb_ramRead(u32 mem);
 template <typename DataType>
 extern bool vtlb_ramWrite(u32 mem, const DataType& value);
 
+// NOTE: Does not call MMIO handlers.
+extern int vtlb_memSafeCmpBytes(u32 mem, const void* src, u32 size);
+extern bool vtlb_memSafeReadBytes(u32 mem, void* dst, u32 size);
+extern bool vtlb_memSafeWriteBytes(u32 mem, const void* src, u32 size);
+
 using vtlb_ReadRegAllocCallback = int(*)();
 extern int vtlb_DynGenReadNonQuad(u32 bits, bool sign, bool xmm, int addr_reg, vtlb_ReadRegAllocCallback dest_reg_alloc = nullptr);
 extern int vtlb_DynGenReadNonQuad_Const(u32 bits, bool sign, bool xmm, u32 addr_const, vtlb_ReadRegAllocCallback dest_reg_alloc = nullptr);


### PR DESCRIPTION
### Description of Changes

Allows patching an arbitrary range of bytes, as opposed to a maximum of 8 via doubleword.

Example:
```
patch=1,EE,206211E8,bytes,0000010014000600
```

would write `00 00 01 00 14 00 06 00` to `0x206211E8`.

Makes logging a bit less confusing. Instead of printing out all patches when they're parsed (loaded), they're only printed when they're actually active.

### Rationale behind Changes

Makes code patching a bit cleaner.

### Suggested Testing Steps

@CookiePLMonster do you have any other test cases? (preferably patching more than 8 bytes)
