### PR TITLE
GS: Various fixes

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -5456,18 +5456,21 @@ bool GSRendererHW::PrimitiveCoversWithoutGaps() const
 	// Check that the height matches. Xenosaga 3 draws a letterbox around
 	// the FMV with a sprite at the top and bottom of the framebuffer.
 	const GSVertex* v = &m_vertex.buff[0];
-	const int first_dpY = v[1].XYZ.Y - v[0].XYZ.Y;
-	const int first_dpX = v[1].XYZ.X - v[0].XYZ.X;
+	const u32 first_dpY = v[1].XYZ.Y - v[0].XYZ.Y;
+	const u32 first_dpX = v[1].XYZ.X - v[0].XYZ.X;
 
 	// Horizontal Match.
 	if ((first_dpX >> 4) == m_r.z)
 	{
 		// Borrowed from MergeSprite() modified to calculate heights.
-		for (u32 i = 0; i < m_vertex.next; i += 2)
+		u32 last_pY = v[1].XYZ.Y;
+		for (u32 i = 2; i < m_vertex.next; i += 2)
 		{
-			const int dpY = v[i + 1].XYZ.Y - v[i].XYZ.Y;
-			if (dpY != first_dpY)
+			const u32 dpY = v[i + 1].XYZ.Y - v[i].XYZ.Y;
+			if (dpY != first_dpY || v[i].XYZ.Y != last_pY)
 				return false;
+
+			last_pY = v[i + 1].XYZ.Y;
 		}
 
 		return true;
@@ -5477,11 +5480,14 @@ bool GSRendererHW::PrimitiveCoversWithoutGaps() const
 	if ((first_dpY >> 4) == m_r.w)
 	{
 		// Borrowed from MergeSprite().
-		for (u32 i = 0; i < m_vertex.next; i += 2)
+		u32 last_pX = v[1].XYZ.X;
+		for (u32 i = 2; i < m_vertex.next; i += 2)
 		{
-			const int dpX = v[i + 1].XYZ.X - v[i].XYZ.X;
-			if (dpX != first_dpX)
+			const u32 dpX = v[i + 1].XYZ.X - v[i].XYZ.X;
+			if (dpX != first_dpX || v[i].XYZ.X != last_pX)
 				return false;
+
+			last_pX = v[i + 1].XYZ.X;
 		}
 
 		return true;

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -5102,7 +5102,7 @@ void GSRendererHW::OI_DoubleHalfClear(GSTextureCache::Target*& rt, GSTextureCach
 			// Take the vertex colour, but check if the blending would make it black.
 			u32 vert_color = v[1].RGBAQ.U32[0];
 			if (PRIM->ABE && m_context->ALPHA.IsBlack())
-				vert_color &= ~0xFF000000;
+				vert_color &= 0xFF000000;
 			const u32 color = vert_color;
 			const bool clear_depth = (m_cached_ctx.FRAME.FBP > m_cached_ctx.ZBUF.ZBP);
 
@@ -5246,7 +5246,7 @@ bool GSRendererHW::OI_GsMemClear()
 		// Take the vertex colour, but check if the blending would make it black.
 		u32 vert_color = m_vertex.buff[1].RGBAQ.U32[0];
 		if (PRIM->ABE && m_context->ALPHA.IsBlack())
-			vert_color &= ~0xFF000000;
+			vert_color &= 0xFF000000;
 
 		OI_DoGsMemClear(off, r, vert_color);
 		return true;

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.h
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.h
@@ -54,7 +54,7 @@ private:
 	void SwSpriteRender();
 	bool CanUseSwSpriteRender();
 	bool IsConstantDirectWriteMemClear();
-	bool IsBlendedOrOpaque();
+	bool IsDiscardingDstColor();
 	bool PrimitiveCoversWithoutGaps() const;
 
 	enum class CLUTDrawTestResult

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.h
@@ -452,7 +452,7 @@ public:
 
 	Target* FindTargetOverlap(u32 bp, u32 end_block, int type, int psm);
 	Target* LookupTarget(GIFRegTEX0 TEX0, const GSVector2i& size, float scale, int type, bool used = true, u32 fbmask = 0,
-		bool is_frame = false, bool is_clear = false, bool preload = GSConfig.PreloadFrameWithGSData);
+		bool is_frame = false, bool is_clear = false, bool preload = GSConfig.PreloadFrameWithGSData, bool preload_uploads = true);
 	Target* LookupDisplayTarget(GIFRegTEX0 TEX0, const GSVector2i& size, float scale);
 
 	/// Looks up a target in the cache, and only returns it if the BP/BW match exactly.

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
@@ -3847,7 +3847,7 @@ void GSDeviceVK::RenderHW(GSHWDrawConfig& config)
 		else
 		{
 			BeginRenderPass(GetTFXRenderPass(true, pipe.ds, false, DATE_RENDER_PASS_NONE, pipe.IsRTFeedbackLoop(),
-								pipe.IsTestingAndSamplingDepth(), VK_ATTACHMENT_LOAD_OP_DONT_CARE,
+								pipe.IsTestingAndSamplingDepth(), VK_ATTACHMENT_LOAD_OP_LOAD,
 								pipe.ds ? VK_ATTACHMENT_LOAD_OP_LOAD : VK_ATTACHMENT_LOAD_OP_DONT_CARE),
 				draw_rt->GetRect());
 		}


### PR DESCRIPTION
### Description of Changes
 
GS/Vulkan: Colclip drawback shouldn't use DONT_CARE load:
 - Regression from #8921.

GS/HW: Fix PrimitiveCoversWithoutGaps returning true with gaps
 - Previously it only checked that all sprites matched in size, not that there wasn't actually any gaps between them.
 - Needed for better clears to not break.

GS/HW: Black blending should preserve RGB, not A
 - Self-explanatory. Stops mem clears writing back black instead of black plus some non-zero alpha (needed for memosaga)

GS/HW: Rename IsBlendedOrOpaque() to IsDiscardingDstColor()
 - And remove the dst color output case, this is clearly wrong when we're using this to try to identify clears.
 
GS-HW: Only preload targets when data is needed
 - Changes LookupTarget to only reload data if there are gaps in the draw, blending with Dst Colour or recursive drawing. Brings a bit of brr.

### Rationale behind Changes

Unfortunately not directly fixing any games, but stacked with some other changes it does. Correctness? :)

### Suggested Testing Steps

Just test a few of your usual games. Runner says it's okay.
