### PR TITLE
GameDB: Various fixes

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -11407,6 +11407,7 @@ SLES-50592:
   name: "No One Lives Forever"
   region: "PAL-M5"
   gsHWFixes:
+    recommendedBlendingLevel: 4 # Fixes missing lighting.
     mipmap: 2 # Fixes miptrick texture effects.
     trilinearFiltering: 1 # Fixes miptrick blending and also needs Full Blending to fix the lighting.
 SLES-50606:
@@ -13094,6 +13095,8 @@ SLES-51285:
   name: "Spongebob SquarePants - Revenge of the Flying Dutchman"
   region: "PAL-E"
   compat: 5
+  gsHWFixes:
+    partialTargetInvalidation: 1 # Fixes game returning to main menu on selecting new game.
 SLES-51286:
   name: "X-Men 2 - Wolverine's Revenge"
   region: "PAL-E"
@@ -42573,6 +42576,7 @@ SLUS-20028:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
+    recommendedBlendingLevel: 4 # Fixes missing lighting.
     mipmap: 2 # Fixes miptrick texture effects.
     trilinearFiltering: 1 # Fixes miptrick blending and also needs Full Blending to fix the lighting.
 SLUS-20029:


### PR DESCRIPTION
### Description of Changes
Recommended blending for No One Lives Forever to fix missing lighting and somehow fixes Spongebob Revenge of The Flying Dutchman not starting a new game in the PAL version.

Master:
![No One Lives Forever_SLES-50592_20230605120539](https://github.com/PCSX2/pcsx2/assets/80843560/f4afdaf7-5fbc-4300-a736-85aa56ffb68d)

PR:
![No One Lives Forever_SLES-50592_20230605120542](https://github.com/PCSX2/pcsx2/assets/80843560/dfc64229-ca74-4301-9b76-ff933a23f362)


### Rationale behind Changes
Not being able to start a game because of some ultra instinct tier glue is bad.

### Suggested Testing Steps
Make sure CI is happy.
