### PR TITLE
CI/Linux: Add Flatpak build files

### DIFF
--- a/.github/workflows/linux_build_flatpak.yml
+++ b/.github/workflows/linux_build_flatpak.yml
@@ -1,0 +1,90 @@
+name: Flatpak Build Steps
+
+on:
+  workflow_call:
+    inputs:
+      jobName:
+        required: true
+        type: string
+      os:
+        required: false
+        type: string
+        default: ubuntu-22.04
+      platform:
+        required: false
+        type: string
+        default: x64
+      compiler:
+        required: true
+        type: string
+      cmakeflags:
+        required: true
+        type: string
+      publish:
+        required: false
+        type: boolean
+        default: false
+      detail:
+        required: false
+        type: string
+        default: ""
+      patches_url:
+        required: false
+        type: string
+        default: https://github.com/PCSX2/pcsx2_patches/releases/latest/download
+
+jobs:
+  build_linux:
+    name: ${{ inputs.jobName }}
+    runs-on: ${{ inputs.os }}
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Prepare Artifact Metadata
+        id: artifact-metadata
+        shell: bash
+        env:
+          OS: linux
+          GUI_FRAMEWORK: QT
+          BUILD_SYSTEM: flatpak
+          ARCH: ${{ inputs.platform }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_NUM: ${{ github.event.pull_request.number }}
+          PR_SHA: ${{ github.event.pull_request.head.sha }}
+        run: ./.github/workflows/scripts/common/name-artifacts.sh
+
+      - name: Install Packages
+        env:
+          COMPILER: ${{ inputs.compiler }}
+        run: .github/workflows/scripts/linux/install-packages-flatpak.sh
+
+      - name: Download patches
+        run: |
+          cd bin/resources
+          aria2c -Z "${{ inputs.patches_url }}/patches.zip"
+
+      - name: Generate AppStream XML
+        run: |
+          ./.github/workflows/scripts/linux/generate-metainfo.sh .github/workflows/scripts/linux/flatpak/net.pcsx2.PCSX2.metainfo.xml
+          cat .github/workflows/scripts/linux/flatpak/net.pcsx2.PCSX2.metainfo.xml
+          appstream-util validate .github/workflows/scripts/linux/flatpak/net.pcsx2.PCSX2.metainfo.xml
+
+      - name: Build Flatpak
+        uses: flatpak/flatpak-github-actions/flatpak-builder@v6.1
+        with:
+          bundle: ${{ steps.artifact-metadata.outputs.artifact-name }}.flatpak
+          manifest-path: .github/workflows/scripts/linux/flatpak/net.pcsx2.PCSX2.json
+          arch: x86_64
+          build-bundle: true
+          verbose: true
+          cache: true
+          restore-cache: true
+          cache-key: ${{ inputs.os }} ${{ inputs.platform }} ${{ inputs.compiler }} ${{ inputs.detail }} flatpak ${{ hashFiles('.github/workflows/scripts/linux/flatpak/**/*.json') }}
+
+      # TODO: Push to flathub

--- a/.github/workflows/linux_build_matrix.yml
+++ b/.github/workflows/linux_build_matrix.yml
@@ -18,3 +18,11 @@ jobs:
       cmakeflags: ""
       buildAppImage: true
     secrets: inherit
+  build_linux_flatpak:
+    name: "Flatpak"
+    uses: ./.github/workflows/linux_build_flatpak.yml
+    with:
+      jobName: "Qt"
+      compiler: clang
+      cmakeflags: ""
+      publish: false

--- a/.github/workflows/linux_build_qt.yml
+++ b/.github/workflows/linux_build_qt.yml
@@ -102,7 +102,10 @@ jobs:
         env:
           COMPILER: ${{ inputs.compiler }}
           ADDITIONAL_CMAKE_ARGS: ${{ inputs.cmakeflags }}
-        run: .github/workflows/scripts/linux/generate-cmake-qt.sh
+          CLANG_PATH: /usr/bin/clang-12
+          CLANGXX_PATH: /usr/bin/clang++-12
+        run: |
+          DEPS_PREFIX="$HOME/deps" .github/workflows/scripts/linux/generate-cmake-qt.sh
 
       - name: Build PCSX2
         working-directory: build

--- a/.github/workflows/release_pipeline.yml
+++ b/.github/workflows/release_pipeline.yml
@@ -18,6 +18,16 @@ jobs:
       cmakeflags: ""
       buildAppImage: true
     secrets: inherit
+  build_linux_flatpak:
+    if: github.repository == 'PCSX2/pcsx2'
+    name: "Linux"
+    uses: ./.github/workflows/linux_build_flatpak.yml
+    with:
+      jobName: "Flatpak"
+      compiler: clang
+      cmakeflags: ""
+      publish: true
+    secrets: inherit
 
   # Windows
   build_windows_qt:
@@ -45,6 +55,7 @@ jobs:
   upload_artifacts:
     if: github.repository == 'PCSX2/pcsx2'
     needs:
+      - build_linux_flatpak
       - build_linux_qt
       - build_windows_qt
       - build_macos_qt

--- a/.github/workflows/scripts/common/name-artifacts.sh
+++ b/.github/workflows/scripts/common/name-artifacts.sh
@@ -30,7 +30,7 @@ fi
 # Add cmake if used to differentate it from msbuild builds
 # Else the two artifacts will have the same name and the files will be merged
 if [[ ! -z "${BUILD_SYSTEM}" ]]; then
-  if [ "${BUILD_SYSTEM}" == "cmake" ]; then
+  if [[ "${BUILD_SYSTEM}" == "cmake" ]] || [[ "${BUILD_SYSTEM}" == "flatpak" ]]; then
     NAME="${NAME}-${BUILD_SYSTEM}"
   fi
 fi

--- a/.github/workflows/scripts/linux/flatpak/modules/10-libpcap.json
+++ b/.github/workflows/scripts/linux/flatpak/modules/10-libpcap.json
@@ -1,0 +1,24 @@
+{
+  "name": "libpcap",
+  "buildsystem": "cmake-ninja",
+  "build-options": {
+    "strip": true
+  },
+  "sources": [
+    {
+      "type": "git",
+      "url": "https://github.com/the-tcpdump-group/libpcap.git",
+      "tag": "libpcap-1.10.4",
+      "commit": "104271ba4a14de6743e43bcf87536786d8fddea4"
+    }
+  ],
+  "cleanup": [
+    "/bin",
+    "/include",
+    "/lib/*.a",
+    "/lib/*.la",
+    "/lib/pkgconfig",
+    "/share/man"
+  ]
+}
+

--- a/.github/workflows/scripts/linux/flatpak/modules/11-libaio.json
+++ b/.github/workflows/scripts/linux/flatpak/modules/11-libaio.json
@@ -1,0 +1,24 @@
+{
+  "name": "libaio",
+  "no-autogen": true,
+  "make-install-args": [
+    "prefix=/app"
+  ],
+  "build-options": {
+    "strip": true
+  },
+  "sources": [
+    {
+      "type": "git",
+      "url": "https://pagure.io/libaio.git",
+      "tag": "libaio-0.3.113",
+      "commit": "1b18bfafc6a2f7b9fa2c6be77a95afed8b7be448"
+    }
+  ],
+  "cleanup": [
+    "/include",
+    "/lib/*.a",
+    "/lib/*.la"
+  ]
+}
+

--- a/.github/workflows/scripts/linux/flatpak/modules/12-soundtouch.json
+++ b/.github/workflows/scripts/linux/flatpak/modules/12-soundtouch.json
@@ -1,0 +1,25 @@
+{
+  "name": "soundtouch",
+  "buildsystem": "cmake-ninja",
+  "build-options": {
+    "strip": true
+  },
+  "sources": [
+    {
+      "type": "git",
+      "url": "https://codeberg.org/soundtouch/soundtouch.git",
+      "tag": "2.3.2",
+      "commit": "29fba832a7920a04eab956b3990c50e13d8c93f9"
+    }
+  ],
+  "cleanup": [
+    "/bin",
+    "/include",
+    "/lib/*.a",
+    "/lib/*.la",
+    "/lib/cmake",
+    "/lib/pkgconfig",
+    "/share/doc"
+  ]
+}
+

--- a/.github/workflows/scripts/linux/flatpak/modules/20-sdl2.json
+++ b/.github/workflows/scripts/linux/flatpak/modules/20-sdl2.json
@@ -1,0 +1,45 @@
+{
+  "name": "sdl2",
+  "buildsystem": "autotools",
+  "no-autogen": true,
+  "config-opts": [
+    "--disable-dbus",
+    "--without-x",
+    "--disable-video-opengl",
+    "--disable-video-opengles",
+    "--disable-video-vulkan",
+    "--disable-wayland-shared",
+    "--disable-ime",
+    "--disable-oss",
+    "--disable-alsa",
+    "--disable-jack",
+    "--disable-esd",
+    "--disable-pipewire",
+    "--disable-pulseaudio",
+    "--disable-arts",
+    "--disable-nas",
+    "--disable-sndio",
+    "--disable-fusionsound",
+    "--disable-diskaudio"
+  ],
+  "build-options": {
+    "strip": true
+  },
+  "sources": [
+    {
+      "type": "archive",
+      "url": "https://libsdl.org/release/SDL2-2.26.5.tar.gz",
+      "sha256": "ad8fea3da1be64c83c45b1d363a6b4ba8fd60f5bde3b23ec73855709ec5eabf7"
+    }
+  ],
+  "cleanup": [
+    "/bin",
+    "/include",
+    "/lib/*.a",
+    "/lib/*.la",
+    "/lib/cmake",
+    "/lib/pkgconfig",
+    "/share/aclocal"
+  ]
+}
+

--- a/.github/workflows/scripts/linux/flatpak/modules/21-libbacktrace.json
+++ b/.github/workflows/scripts/linux/flatpak/modules/21-libbacktrace.json
@@ -1,0 +1,22 @@
+{
+    "name": "libbacktrace",
+    "buildsystem": "autotools",
+    "no-autogen": true,
+    "build-options": {
+      "strip": false,
+      "no-debuginfo": true
+    },
+    "sources": [
+      {
+        "type": "git",
+        "url": "https://github.com/ianlancetaylor/libbacktrace.git",
+        "commit": "ad106d5fdd5d960bd33fae1c48a351af567fd075"
+      }
+    ],
+    "cleanup": [
+      "/include",
+      "/lib/*.a",
+      "/lib/*.la"
+    ]
+  }
+  

--- a/.github/workflows/scripts/linux/flatpak/net.pcsx2.PCSX2.json
+++ b/.github/workflows/scripts/linux/flatpak/net.pcsx2.PCSX2.json
@@ -1,0 +1,67 @@
+{
+  "app-id": "net.pcsx2.PCSX2",
+  "runtime": "org.kde.Platform",
+  "runtime-version": "6.5",
+  "sdk": "org.kde.Sdk",
+  "sdk-extensions": [
+    "org.freedesktop.Sdk.Extension.llvm16"
+  ],
+  "add-build-extensions": {
+    "org.freedesktop.Platform.ffmpeg-full": {
+      "directory": "lib/ffmpeg",
+      "version": "22.08",
+      "add-ld-path": "."
+    }
+  },
+  "command": "pcsx2-qt",
+  "finish-args": [
+    "--device=all",
+    "--share=network",
+    "--share=ipc",
+    "--socket=fallback-x11",
+    "--socket=wayland",
+    "--socket=pulseaudio",
+    "--filesystem=host:ro"
+  ],
+  "modules": [
+    "modules/10-libpcap.json",
+    "modules/11-libaio.json",
+    "modules/12-soundtouch.json",
+    "modules/20-sdl2.json",
+    "modules/21-libbacktrace.json",
+    {
+      "name": "pcsx2",
+      "buildsystem": "simple",
+      "build-options": {
+        "strip": false,
+        "no-debuginfo": true,
+        "env": {
+          "DEPS_PREFIX": "/app",
+          "COMPILER": "clang",
+          "CLANG_PATH": "/usr/lib/sdk/llvm16/bin/clang",
+          "CLANGXX_PATH": "/usr/lib/sdk/llvm16/bin/clang++",
+          "ADDITIONAL_CMAKE_ARGS": "-DUSE_LINKED_FFMPEG=ON"
+        }
+      },
+      "sources": [
+        {
+          "type": "dir",
+          "path": "../../../../.."
+        }
+      ],
+      "build-commands": [
+        ".github/workflows/scripts/linux/generate-cmake-qt.sh",
+        "cd build && ../.github/workflows/scripts/linux/compile.sh && cd ..",
+        "cp -a build/bin ${FLATPAK_DEST}",
+        "cd build && ninja unittests && cd .."
+      ],
+      "post-install": [
+        "install -Dm644 bin/resources/icons/AppIconLarge.png ${FLATPAK_DEST}/share/icons/hicolor/256x256/apps/net.pcsx2.PCSX2.png",
+        "install -Dm644 .github/workflows/scripts/linux/pcsx2-qt.desktop ${FLATPAK_DEST}/share/applications/net.pcsx2.PCSX2.desktop",
+        "desktop-file-edit --set-key=Icon --set-value=net.pcsx2.PCSX2 ${FLATPAK_DEST}/share/applications/net.pcsx2.PCSX2.desktop",
+        "install -Dm644 .github/workflows/scripts/linux/flatpak/net.pcsx2.PCSX2.metainfo.xml ${FLATPAK_DEST}/share/metainfo/net.pcsx2.PCSX2.metainfo.xml"
+      ]
+    }
+  ]
+}
+

--- a/.github/workflows/scripts/linux/generate-cmake-qt.sh
+++ b/.github/workflows/scripts/linux/generate-cmake-qt.sh
@@ -2,16 +2,28 @@
 
 set -e
 
+if [[ -z "${DEPS_PREFIX}" ]]; then
+  echo "DEPS_PREFIX is not set."
+  exit 1
+fi
+
+echo "Using build dependencies from: ${DEPS_PREFIX}"
+
 if [ "${COMPILER}" = "clang" ]; then
+  if [[ -z "${CLANG_PATH}" ]] || [[ -z "${CLANGXX_PATH}" ]]; then
+    echo "CLANG_PATH or CLANGXX_PATH is not set."
+    exit 1
+  fi
+
 	echo "Using clang toolchain"
-	cat > "$HOME/clang-toolchain.cmake" << EOF
-set(CMAKE_C_COMPILER /usr/bin/clang-12)
-set(CMAKE_CXX_COMPILER /usr/bin/clang++-12)
+	cat > "clang-toolchain.cmake" << EOF
+set(CMAKE_C_COMPILER "${CLANG_PATH}")
+set(CMAKE_CXX_COMPILER "${CLANGXX_PATH}")
 set(CMAKE_EXE_LINKER_FLAGS_INIT "-fuse-ld=lld")
 set(CMAKE_MODULE_LINKER_FLAGS_INIT "-fuse-ld=lld")
 set(CMAKE_SHARED_LINKER_FLAGS_INIT "-fuse-ld=lld")
 EOF
-	ADDITIONAL_CMAKE_ARGS="$ADDITIONAL_CMAKE_ARGS -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_TOOLCHAIN_FILE=$HOME/clang-toolchain.cmake"
+	ADDITIONAL_CMAKE_ARGS="$ADDITIONAL_CMAKE_ARGS -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_TOOLCHAIN_FILE=clang-toolchain.cmake"
 fi
 
 echo "Additional CMake Args - ${ADDITIONAL_CMAKE_ARGS}"
@@ -31,7 +43,7 @@ cmake \
 	-DX11_API=ON \
 	-DWAYLAND_API=ON \
 	-DENABLE_SETCAP=OFF \
-	-DCMAKE_PREFIX_PATH="$HOME/deps" \
+	-DCMAKE_PREFIX_PATH="${DEPS_PREFIX}" \
 	-DUSE_SYSTEM_SDL2=ON \
 	-DUSE_SYSTEM_ZSTD=OFF \
 	-DDISABLE_ADVANCE_SIMD=TRUE

--- a/.github/workflows/scripts/linux/generate-metainfo.sh
+++ b/.github/workflows/scripts/linux/generate-metainfo.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+SCRIPTDIR=$(dirname "${BASH_SOURCE[0]}")
+
+if [[ $# -lt 1 ]]; then
+    echo "Output file must be provided as a parameter"
+    exit 1
+fi
+
+OUTFILE=$1
+GIT_DATE=$(git log -1 --pretty=%cd --date=short)
+GIT_VERSION=$(git tag --points-at HEAD)
+
+if [[ "${GIT_VERSION}" == "" ]]; then
+    GIT_VERSION=$(git rev-parse HEAD)
+fi
+
+echo "GIT_DATE: ${GIT_DATE}"
+echo "GIT_VERSION: ${GIT_VERSION}"
+
+cp "${SCRIPTDIR}"/pcsx2-qt.metainfo.xml.in "${OUTFILE}"
+
+sed -i -e "s/@GIT_VERSION@/${GIT_VERSION}/" "${OUTFILE}"
+sed -i -e "s/@GIT_DATE@/${GIT_DATE}/" "${OUTFILE}"

--- a/.github/workflows/scripts/linux/install-packages-flatpak.sh
+++ b/.github/workflows/scripts/linux/install-packages-flatpak.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+SCRIPTDIR=$(dirname "${BASH_SOURCE[0]}")
+source "$SCRIPTDIR/functions.sh"
+
+set -e
+
+ARCH=x86_64
+KDE_BRANCH=6.5
+BRANCH=22.08
+
+# Build packages.
+declare -a BUILD_PACKAGES=(
+  "flatpak"
+  "flatpak-builder"
+  "appstream-util"
+)
+
+# Flatpak runtimes and SDKs.
+declare -a FLATPAK_PACKAGES=(
+  "org.kde.Platform/${ARCH}/${KDE_BRANCH}"
+  "org.kde.Sdk/${ARCH}/${KDE_BRANCH}"
+  "org.freedesktop.Platform.ffmpeg-full/${ARCH}/${BRANCH}"
+  "org.freedesktop.Sdk.Extension.llvm16/${ARCH}/${BRANCH}"
+)
+
+retry_command sudo apt-get -qq update
+
+# Install packages needed for building
+echo "Will install the following packages for building - ${BUILD_PACKAGES[*]}"
+retry_command sudo apt-get -y install "${BUILD_PACKAGES[@]}"
+
+sudo flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+
+# Install packages needed for building
+echo "Will install the following packages for building - ${FLATPAK_PACKAGES[*]}"
+retry_command sudo flatpak -y install "${FLATPAK_PACKAGES[@]}"
+

--- a/.github/workflows/scripts/linux/pcsx2-qt.metainfo.xml.in
+++ b/.github/workflows/scripts/linux/pcsx2-qt.metainfo.xml.in
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop">
+  <id>net.pcsx2.PCSX2</id>
+  <launchable type="desktop-id">net.pcsx2.PCSX2.desktop</launchable>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-3.0</project_license>
+  <name>PCSX2</name>
+  <developer_name>PCSX2</developer_name>
+  <summary>PlayStation 2 Emulator</summary>
+  <description>
+    <p>PCSX2 is a free and open-source PlayStation 2 (PS2) emulator. Its purpose is to emulate the PS2's hardware, using a combination of MIPS CPU Interpreters, Recompilers and a Virtual Machine which manages hardware states and PS2 system memory. This allows you to play PS2 games on your PC, with many additional features and benefits.</p>
+    <p>PlayStation 2 and PS2 are registered trademarks of Sony Interactive Entertainment. This application is not affiliated in any way with Sony Interactive Entertainment.</p>
+  </description>
+  <url type="homepage">https://pcsx2.net/</url>
+  <url type="bugtracker">https://github.com/PCSX2/pcsx2/issues</url>
+  <content_rating type="oars-1.1"/>
+  <update_contact>pcsx2_AT_pcsx2.net</update_contact>
+  <releases>
+    <release version="@GIT_VERSION@" date="@GIT_DATE@" />
+  </releases>
+</component>

--- a/.github/workflows/scripts/releases/rename-release-assets.py
+++ b/.github/workflows/scripts/releases/rename-release-assets.py
@@ -4,7 +4,7 @@ import shutil
 tag = os.environ['TAG'].split("refs/tags/")[1]
 scan_dir = os.environ['SCAN_DIR']
 output_dir = os.environ['OUT_DIR']
-accepted_exts = ["AppImage", "tar.xz", "7z"]
+accepted_exts = ["AppImage", "flatpak", "tar.xz", "7z"]
 
 
 for dir_name in os.listdir(scan_dir):
@@ -12,7 +12,10 @@ for dir_name in os.listdir(scan_dir):
   if "macos" in dir_name.lower():
     asset_name += "-macos"
   elif "linux" in dir_name.lower():
-    asset_name += "-linux-AppImage-64bit"
+    if "flatpak" in dir_name.lower():
+      asset_name += "-linux-Flatpak-64bit"
+    else:
+      asset_name += "-linux-AppImage-64bit"
   elif "windows" in dir_name.lower():
     asset_name += "-windows-64bit"
   else:

--- a/cmake/BuildParameters.cmake
+++ b/cmake/BuildParameters.cmake
@@ -36,6 +36,7 @@ if(UNIX AND NOT APPLE)
 	option(X11_API "Enable X11 support" ON)
 	option(WAYLAND_API "Enable Wayland support" ON)
 	option(DBUS_API "Enable DBus support for screensaver inhibiting" ON)
+	option(USE_LINKED_FFMPEG "Links with ffmpeg instead of using dynamic loading" OFF)
 endif()
 
 if(APPLE)

--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -51,6 +51,11 @@ if(USE_LEGACY_USER_DIRECTORY)
 	target_compile_definitions(PCSX2_FLAGS INTERFACE USE_LEGACY_USER_DIRECTORY)
 endif()
 
+if(USE_LINKED_FFMPEG)
+	target_compile_definitions(PCSX2_FLAGS INTERFACE USE_LINKED_FFMPEG)
+	target_link_libraries(PCSX2_FLAGS INTERFACE FFMPEG::avcodec FFMPEG::avformat FFMPEG::avutil FFMPEG::swscale FFMPEG::swresample)
+endif()
+
 if(TARGET SDL2::SDL2 OR TARGET SDL2::SDL2-static)
 	target_compile_definitions(PCSX2_FLAGS INTERFACE SDL_BUILD)
 	if ("${SDL2_TYPE}" STREQUAL Bundled)


### PR DESCRIPTION
### Description of Changes

This PR adds a Flatpak build to our CI, using (almost) the same configuration as the AppImage.

Thanks to @charlesthobe for the assistance with putting the manifest together.

The current flatpak package was created without any discussion with us, and has several issues:
 - Out of sync with releases.
 - Built with gcc instead of clang (up to 15% slower in some games).
 - Until recently, disabled inlining => significant speed loss.
 - Not maintained by us, so we cannot debug or fix any problems with it.
 - No notification of updates.
 - Probably doesn't have working ffmpeg (at least not for all formats).

So, instead, I'm proposing we provide this package ourselves. I've been able to work around most of my grievances with the format (mainly by not having to confirm to flathub builder limitations listed below), overall it's definitely still a bit clunky (e.g. flatpak-builder crashes on syntax errors, and type errors are silently ignored), but it mostly works.

For several reasons, we can't use the flathub builders, including:
 - No internet access in the build environment (needed to download deps and patches).
 - Not in sync with our releases here, have to be manually updated.
 - Impossible for users to download pull request builds to test potential fixes.
 - Patches repo builds a zip, which doesn't have a fixed hash.

To make support easier, and minimize the chances of flatpak-specific issues, the flatpak follows the exact same build process as the AppImage (less using clang 16 instead of clang 12, because 12 isn't available on 22.08).

~~There's still a couple of issues I need to resolve~~, but we can get some discussion going, and see if anyone has any opposition for us doing this in the first place in the meantime.

Still TODO, but this will be post-merge:
 - Hook up publishing to flathub.
 - Make the automatic updater shell out to flatpak update, or whatever.

On the last point, that is a potential issue. We'll need to get a token from the flathub admins, so we can push releases from our CI to their repo. Hopefully that is something which can be arranged, if not, we'll have to run our own repo, or something..

~~As for the others, switching to the kde platform would probably fix them. I wanted to use the same qt libs as the appimage for consistency, and to reduce user's download sizes, but it might be less painful in the future to just switch over. Thankfully, we don't patch any qt code, only the build system, so that lowers the risk of different behaviour (although the KDE platform patches qt..)~~

### Rationale behind Changes

There's a non-trivial number of users using the flatpak. We want to provide the same experience regardless of which packaging format they use.

### Suggested Testing Steps

Test flatpak build (I'll do this, I don't think any of our testers have it installed).

Make sure the AppImage still works.
