### PR TITLE
Qt: Add missing bigpicture parameter to help text

### DIFF
--- a/pcsx2-qt/QtHost.cpp
+++ b/pcsx2-qt/QtHost.cpp
@@ -1539,6 +1539,7 @@ void QtHost::PrintCommandLineHelp(const std::string_view& progname)
 	std::fprintf(stderr, "  -statefile <filename>: Loads state from the specified filename.\n");
 	std::fprintf(stderr, "  -fullscreen: Enters fullscreen mode immediately after starting.\n");
 	std::fprintf(stderr, "  -nofullscreen: Prevents fullscreen mode from triggering if enabled.\n");
+	std::fprintf(stderr, "  -bigpicture: Forces PCSX2 to use the Big Picture mode (useful for controller-only and couch play).\n");
 	std::fprintf(stderr, "  -earlyconsolelog: Forces logging of early console messages to console.\n");
 	std::fprintf(stderr, "  -testconfig: Initializes configuration and checks version, then exits.\n");
 	std::fprintf(stderr, "  -debugger: Open debugger and break on entry point.\n");


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Add the missing `-bigpicture` CLI parameter to the CLI help text.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Align output of the CLI `-help` command to the available parameters documented on the wiki to ensure that the parameters on the wiki are still valid: https://wiki.pcsx2.net/Command-line_support#General_Options_QT

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Parameter should be listed when running `pcsx2-qt -help`.