### PR TITLE
Patches: Don't reload GameDB when crc is 0.

### DIFF
--- a/pcsx2/Patch.cpp
+++ b/pcsx2/Patch.cpp
@@ -526,8 +526,8 @@ void Patch::ReloadPatches(std::string serial, u32 crc, bool force_reload_files, 
 	s_patches_crc = crc;
 	s_patches_serial = std::move(serial);
 
-	// Skip reloading gamedb patches if the serial hasn't changed.
-	if (serial_changed)
+	// Skip reloading gamedb patches if the serial hasn't changed, or the crc is 0.
+	if (serial_changed && (s_patches_crc != 0))
 	{
 		s_gamedb_patches.clear();
 


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Patches: Don't reload GameDB when crc is 0.
Bios uses crc 0, spams useless log that bios serial is not in the gamedb.
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Bugfix.
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
CI builds, db isn't reloaded on bios.