### PR TITLE
Revert "Patches: Don't reload GameDB when crc is 0."

### DIFF
--- a/pcsx2/GameDatabase.cpp
+++ b/pcsx2/GameDatabase.cpp
@@ -986,19 +986,6 @@ const GameDatabaseSchema::GameEntry* GameDatabase::findGame(const std::string_vi
 {
 	GameDatabase::ensureLoaded();
 
-	std::string serialLower = StringUtil::toLower(serial);
-
-	if (serialLower.empty())
-		return nullptr;
-
-	Console.WriteLn(fmt::format("[GameDB] Searching for '{}' in GameDB", serialLower));
-	const auto gameEntry = s_game_db.find(serialLower);
-	if (gameEntry != s_game_db.end())
-	{
-		Console.WriteLn(fmt::format("[GameDB] Found '{}' in GameDB", serialLower));
-		return &gameEntry->second;
-	}
-
-	Console.Error(fmt::format("[GameDB] Could not find '{}' in GameDB", serialLower));
-	return nullptr;
+	auto iter = s_game_db.find(StringUtil::toLower(serial));
+	return (iter != s_game_db.end()) ? &iter->second : nullptr;
 }

--- a/pcsx2/Patch.cpp
+++ b/pcsx2/Patch.cpp
@@ -526,8 +526,8 @@ void Patch::ReloadPatches(std::string serial, u32 crc, bool force_reload_files, 
 	s_patches_crc = crc;
 	s_patches_serial = std::move(serial);
 
-	// Skip reloading gamedb patches if the serial hasn't changed, or the crc is 0.
-	if (serial_changed && (s_patches_crc != 0))
+	// Skip reloading gamedb patches if the serial hasn't changed.
+	if (serial_changed)
 	{
 		s_gamedb_patches.clear();
 

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -707,7 +707,9 @@ void VMManager::UpdateRunningGame(UpdateGameReason reason)
 		std::string memcardFilters;
 
 		if (s_game_crc == 0)
+		{
 			s_game_name = "Booting PS2 BIOS...";
+		}
 		else if (const GameDatabaseSchema::GameEntry* game = GameDatabase::findGame(s_game_serial))
 		{
 			if (!s_elf_override.empty())
@@ -716,6 +718,10 @@ void VMManager::UpdateRunningGame(UpdateGameReason reason)
 				s_game_name = game->name;
 
 			memcardFilters = game->memcardFiltersAsString();
+		}
+		else
+		{
+			Console.Warning(fmt::format("Serial '{}' not found in GameDB.", s_game_serial));
 		}
 
 		sioSetGameSerial(memcardFilters.empty() ? s_game_serial : memcardFilters);


### PR DESCRIPTION
### Description of Changes

This caused patches to not get unloaded when resetting the system, resulting in GameDB patches getting applied while the kernel was initializing/loading the elf. Potentially not good.

Given the goal of that commit was to get rid of the erroneous logging, I just removed all the logging from `findGame()` completely. It makes no sense to log every time you look up a game, especially since it happens in multiple places. Instead, I log a warning if an unknown serial is booted, once at boot, in VMManager.

### Rationale behind Changes

Regression from #8945.

### Suggested Testing Steps

Test resetting system correctly unloads patches. You can't really see this happen, but I've verified myself with a debugger.
