### PR TITLE
USB: Improve FFB for steering wheels

### DIFF
--- a/pcsx2/USB/usb-pad/usb-pad-sdl-ff.cpp
+++ b/pcsx2/USB/usb-pad/usb-pad-sdl-ff.cpp
@@ -77,7 +77,7 @@ namespace usb_pad
 		if (supported & SDL_HAPTIC_CONSTANT)
 		{
 			m_constant_effect.type = SDL_HAPTIC_CONSTANT;
-			m_constant_effect.constant.direction.type = SDL_HAPTIC_CARTESIAN;
+			m_constant_effect.constant.direction.type = SDL_HAPTIC_STEERING_AXIS;
 			m_constant_effect.constant.length = length;
 
 			m_constant_effect_id = SDL_HapticNewEffect(m_haptic, &m_constant_effect);
@@ -92,7 +92,7 @@ namespace usb_pad
 		if (supported & SDL_HAPTIC_SPRING)
 		{
 			m_spring_effect.type = SDL_HAPTIC_SPRING;
-			m_spring_effect.condition.direction.type = SDL_HAPTIC_CARTESIAN;
+			m_spring_effect.condition.direction.type = SDL_HAPTIC_STEERING_AXIS;
 			m_spring_effect.condition.length = length;
 
 			m_spring_effect_id = SDL_HapticNewEffect(m_haptic, &m_spring_effect);
@@ -107,7 +107,7 @@ namespace usb_pad
 		if (supported & SDL_HAPTIC_DAMPER)
 		{
 			m_damper_effect.type = SDL_HAPTIC_DAMPER;
-			m_damper_effect.condition.direction.type = SDL_HAPTIC_CARTESIAN;
+			m_damper_effect.condition.direction.type = SDL_HAPTIC_STEERING_AXIS;
 			m_damper_effect.condition.length = length;
 
 			m_damper_effect_id = SDL_HapticNewEffect(m_haptic, &m_damper_effect);
@@ -122,7 +122,7 @@ namespace usb_pad
 		if (supported & SDL_HAPTIC_FRICTION)
 		{
 			m_friction_effect.type = SDL_HAPTIC_FRICTION;
-			m_friction_effect.condition.direction.type = SDL_HAPTIC_CARTESIAN;
+			m_friction_effect.condition.direction.type = SDL_HAPTIC_STEERING_AXIS;
 			m_friction_effect.condition.length = length;
 
 			m_friction_effect_id = SDL_HapticNewEffect(m_haptic, &m_friction_effect);
@@ -211,7 +211,13 @@ namespace usb_pad
 	template <typename T>
 	static u16 ClampU16(T val)
 	{
-		return static_cast<u16>(std::clamp<T>(val, 0, 0xFFFF));
+		return static_cast<u16>(std::clamp<T>(val, 0, 65535));
+	}
+
+	template <typename T>
+	static u16 ClampS16(T val)
+	{
+		return static_cast<s16>(std::clamp<T>(val, -32768, 32767));
 	}
 
 	void SDLFFDevice::SetSpringForce(const parsed_ff_data& ff)
@@ -220,11 +226,11 @@ namespace usb_pad
 			return;
 
 		m_spring_effect.condition.left_sat[0] = ClampU16(ff.u.condition.left_saturation);
-		m_spring_effect.condition.left_coeff[0] = ClampU16(ff.u.condition.left_coeff);
+		m_spring_effect.condition.left_coeff[0] = ClampS16(ff.u.condition.left_coeff);
 		m_spring_effect.condition.right_sat[0] = ClampU16(ff.u.condition.right_saturation);
-		m_spring_effect.condition.right_coeff[0] = ClampU16(ff.u.condition.right_coeff);
+		m_spring_effect.condition.right_coeff[0] = ClampS16(ff.u.condition.right_coeff);
 		m_spring_effect.condition.deadband[0] = ClampU16(ff.u.condition.deadband);
-		m_spring_effect.condition.center[0] = ClampU16(ff.u.condition.center);
+		m_spring_effect.condition.center[0] = ClampS16(ff.u.condition.center);
 
 		if (SDL_HapticUpdateEffect(m_haptic, m_spring_effect_id, &m_spring_effect) != 0)
 			Console.Warning("SDL_HapticUpdateEffect() for spring failed: %s", SDL_GetError());
@@ -244,11 +250,11 @@ namespace usb_pad
 			return;
 
 		m_damper_effect.condition.left_sat[0] = ClampU16(ff.u.condition.left_saturation);
-		m_damper_effect.condition.left_coeff[0] = ClampU16(ff.u.condition.left_coeff);
+		m_damper_effect.condition.left_coeff[0] = ClampS16(ff.u.condition.left_coeff);
 		m_damper_effect.condition.right_sat[0] = ClampU16(ff.u.condition.right_saturation);
-		m_damper_effect.condition.right_coeff[0] = ClampU16(ff.u.condition.right_coeff);
+		m_damper_effect.condition.right_coeff[0] = ClampS16(ff.u.condition.right_coeff);
 		m_damper_effect.condition.deadband[0] = ClampU16(ff.u.condition.deadband);
-		m_damper_effect.condition.center[0] = ClampU16(ff.u.condition.center);
+		m_damper_effect.condition.center[0] = ClampS16(ff.u.condition.center);
 
 		if (SDL_HapticUpdateEffect(m_haptic, m_damper_effect_id, &m_damper_effect) != 0)
 			Console.Warning("SDL_HapticUpdateEffect() for damper failed: %s", SDL_GetError());
@@ -268,11 +274,11 @@ namespace usb_pad
 			return;
 
 		m_friction_effect.condition.left_sat[0] = ClampU16(ff.u.condition.left_saturation);
-		m_friction_effect.condition.left_coeff[0] = ClampU16(ff.u.condition.left_coeff);
+		m_friction_effect.condition.left_coeff[0] = ClampS16(ff.u.condition.left_coeff);
 		m_friction_effect.condition.right_sat[0] = ClampU16(ff.u.condition.right_saturation);
-		m_friction_effect.condition.right_coeff[0] = ClampU16(ff.u.condition.right_coeff);
+		m_friction_effect.condition.right_coeff[0] = ClampS16(ff.u.condition.right_coeff);
 		m_friction_effect.condition.deadband[0] = ClampU16(ff.u.condition.deadband);
-		m_friction_effect.condition.center[0] = ClampU16(ff.u.condition.center);
+		m_friction_effect.condition.center[0] = ClampS16(ff.u.condition.center);
 
 		if (SDL_HapticUpdateEffect(m_haptic, m_friction_effect_id, &m_friction_effect) != 0)
 		{

--- a/pcsx2/USB/usb-pad/usb-pad-sdl-ff.cpp
+++ b/pcsx2/USB/usb-pad/usb-pad-sdl-ff.cpp
@@ -31,6 +31,10 @@ namespace usb_pad
 	SDLFFDevice::SDLFFDevice(SDL_Haptic* haptic)
 		: m_haptic(haptic)
 	{
+		std::memset(&m_constant_effect, 0, sizeof(m_constant_effect));
+		std::memset(&m_spring_effect, 0, sizeof(m_spring_effect));
+		std::memset(&m_damper_effect, 0, sizeof(m_damper_effect));
+		std::memset(&m_friction_effect, 0, sizeof(m_friction_effect));
 	}
 
 	SDLFFDevice::~SDLFFDevice()

--- a/pcsx2/USB/usb-pad/usb-pad-sdl-ff.cpp
+++ b/pcsx2/USB/usb-pad/usb-pad-sdl-ff.cpp
@@ -71,7 +71,7 @@ namespace usb_pad
 
 	void SDLFFDevice::CreateEffects(const std::string_view& device)
 	{
-		constexpr u32 length = 1000; // good enough?
+		constexpr u32 length = 10000; // 10 seconds since NFS games seem to not issue new commands while rotating.
 
 		const unsigned int supported = SDL_HapticQuery(m_haptic);
 		if (supported & SDL_HAPTIC_CONSTANT)

--- a/pcsx2/USB/usb-pad/usb-pad-sdl-ff.h
+++ b/pcsx2/USB/usb-pad/usb-pad-sdl-ff.h
@@ -45,19 +45,19 @@ namespace usb_pad
 
 		SDL_Haptic* m_haptic = nullptr;
 
-		SDL_HapticEffect m_constant_effect = {};
+		SDL_HapticEffect m_constant_effect;
 		int m_constant_effect_id = -1;
 		bool m_constant_effect_running = false;
 
-		SDL_HapticEffect m_spring_effect = {};
+		SDL_HapticEffect m_spring_effect;
 		int m_spring_effect_id = -1;
 		bool m_spring_effect_running = false;
 
-		SDL_HapticEffect m_damper_effect = {};
+		SDL_HapticEffect m_damper_effect;
 		int m_damper_effect_id = -1;
 		bool m_damper_effect_running = false;
 
-		SDL_HapticEffect m_friction_effect = {};
+		SDL_HapticEffect m_friction_effect;
 		int m_friction_effect_id = -1;
 		bool m_friction_effect_running = false;
 

--- a/pcsx2/USB/usb-pad/usb-pad.cpp
+++ b/pcsx2/USB/usb-pad/usb-pad.cpp
@@ -892,7 +892,7 @@ namespace usb_pad
 	void PadDevice::InputDeviceConnected(USBDevice* dev, const std::string_view& identifier) const
 	{
 		PadState* s = USB_CONTAINER_OF(dev, PadState, dev);
-		if (s->mFFdevName == identifier)
+		if (s->mFFdevName == identifier && s->HasFF())
 			s->OpenFFDevice();
 	}
 


### PR DESCRIPTION
### Description of Changes
Makes some changes to fix some bugs and give SDL a better hint to what kind of directional feedback to give, lengthen time for FFB to run.

### Rationale behind Changes
Before we were clamping to U16 on S16 registers, but also the feedback type was seemingly for controller pads rather than wheels.

I have also changed the initialisation to use a memset as described in the SDL documentation (also thanks to Stenzek for diagnosing this),  since doing `thing = {};` is fine on structs, etc, on Unions this will only initialise the first variable if it isn't the largest in the union, which is true in this case, this leaves the rest of the union completely uninitialized, which was then passing garbage to the SDL effect functions.

### Suggested Testing Steps
Check wheel supporting games like GT4, NFS (not sure which one), Enthusia etc.

Should improve GT4 and Enthusia dramatically, with the second commit the NFS games should be good too.

Currently there seems to be a problem where FFB doesn't work in Clang builds, investigating.

~~Update: I suspect this might be an SDL strict aliasing problem with the sdl_hapticeffect struct but can't currently prove it. Changed were tested to be working with a standard cmake and msvc avx2 build~~

Update: Clang problem fixed and explained above