### PR TITLE
VMManager: Fix patches OSD not getting shown in some cases

### DIFF
--- a/pcsx2-qt/QtHost.cpp
+++ b/pcsx2-qt/QtHost.cpp
@@ -670,7 +670,7 @@ void EmuThread::reloadPatches()
 	if (!VMManager::HasValidVM())
 		return;
 
-	Patch::ReloadPatches(true, false, true);
+	Patch::ReloadPatches(true, false, true, true);
 
 	// Might change widescreen mode.
 	if (Patch::ReloadPatchAffectingOptions())

--- a/pcsx2/Patch.cpp
+++ b/pcsx2/Patch.cpp
@@ -520,7 +520,7 @@ u32 Patch::EnablePatches(const PatchList& patches, const EnablePatchList& enable
 	return count;
 }
 
-void Patch::ReloadPatches(std::string serial, u32 crc, bool force_reload_files, bool reload_enabled_list, bool verbose)
+void Patch::ReloadPatches(std::string serial, u32 crc, bool force_reload_files, bool reload_enabled_list, bool verbose, bool verbose_if_changed)
 {
 	const bool serial_changed = (s_patches_serial != serial);
 	s_patches_crc = crc;
@@ -546,10 +546,10 @@ void Patch::ReloadPatches(std::string serial, u32 crc, bool force_reload_files, 
 		}
 	}
 
-	ReloadPatches(serial_changed, reload_enabled_list, verbose);
+	ReloadPatches(serial_changed, reload_enabled_list, verbose, verbose_if_changed);
 }
 
-void Patch::ReloadPatches(bool force_reload_files, bool reload_enabled_list, bool verbose)
+void Patch::ReloadPatches(bool force_reload_files, bool reload_enabled_list, bool verbose, bool verbose_if_changed)
 {
 	if (force_reload_files)
 	{
@@ -570,7 +570,7 @@ void Patch::ReloadPatches(bool force_reload_files, bool reload_enabled_list, boo
 			});
 	}
 
-	UpdateActivePatches(reload_enabled_list, verbose, false);
+	UpdateActivePatches(reload_enabled_list, verbose, verbose_if_changed);
 }
 
 void Patch::UpdateActivePatches(bool reload_enabled_list, bool verbose, bool verbose_if_changed)

--- a/pcsx2/Patch.h
+++ b/pcsx2/Patch.h
@@ -96,8 +96,8 @@ namespace Patch
 	extern PatchInfoList GetPatchInfo(const std::string& serial, u32 crc, bool cheats, u32* num_unlabelled_patches);
 
 	/// Reloads cheats/patches. If verbose is set, the number of patches loaded will be shown in the OSD.
-	extern void ReloadPatches(std::string serial, u32 crc, bool force_reload_files, bool reload_enabled_list, bool verbose);
-	extern void ReloadPatches(bool force_reload_files, bool reload_enabled_list, bool verbose);
+	extern void ReloadPatches(std::string serial, u32 crc, bool force_reload_files, bool reload_enabled_list, bool verbose, bool verbose_if_changed);
+	extern void ReloadPatches(bool force_reload_files, bool reload_enabled_list, bool verbose, bool verbose_if_changed);
 
 	extern void UpdateActivePatches(bool reload_enabled_list, bool verbose, bool verbose_if_changed);
 	extern void ApplyPatchSettingOverrides();

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -514,7 +514,7 @@ void VMManager::Internal::UpdateEmuFolders()
 	if (VMManager::HasValidVM())
 	{
 		if (EmuFolders::Cheats != old_cheats_directory || EmuFolders::Patches != old_patches_directory)
-			Patch::ReloadPatches(s_game_serial, s_game_crc, true, false, true);
+			Patch::ReloadPatches(s_game_serial, s_game_crc, true, false, true, true);
 
 		if (EmuFolders::MemoryCards != old_memcards_directory)
 		{
@@ -739,7 +739,7 @@ void VMManager::UpdateRunningGame(UpdateGameReason reason)
 
 	// When resetting, patches need to get removed here, because there's no entry point being compiled.
 	if (reason == UpdateGameReason::Resetting || reason == UpdateGameReason::LoadingState)
-		Patch::ReloadPatches(s_game_serial, s_game_crc, false, false, false);	
+		Patch::ReloadPatches(s_game_serial, s_game_crc, false, false, false, false);
 
 	UpdateGameSettingsLayer();
 
@@ -1628,7 +1628,7 @@ void VMManager::Internal::EntryPointCompilingOnCPUThread()
 	// until the game entry point actually runs, because that can update settings, which
 	// can flush the JIT, etc. But we need to apply patches for games where the entry
 	// point is in the patch (e.g. WRC 4). So. Gross, but the only way to handle it really.
-	Patch::ReloadPatches(SysGetDiscID(), ElfCRC, false, false, false);
+	Patch::ReloadPatches(SysGetDiscID(), ElfCRC, false, false, false, true);
 	Patch::ApplyLoadedPatches(Patch::PPT_ONCE_ON_LOAD);
 }
 


### PR DESCRIPTION
### Description of Changes

In some cases (e.g. global cheat enable, global WS patches enable), the OSD message indicating how many patches were active was not getting shown.

### Rationale behind Changes

Regression from my patch PR.

### Suggested Testing Steps

Test every combination of global/per-game/specific patch enabling and make sure the message displays, or doesn't display when appropriate.

Make sure message doesn't say "no patches loaded" when you reboot.
