### PR TITLE
GS/Vulkan: Add missing chain to exclusive fullscreen control

### DIFF
--- a/bin/resources/shaders/dx11/present.fx
+++ b/bin/resources/shaders/dx11/present.fx
@@ -29,7 +29,6 @@ cbuffer cb0 : register(b0)
 	float2 u_source_resolution;
 	float2 u_rcp_source_resolution; // 1 / u_source_resolution
 	float u_time;
-	float3 cb0_pad0;
 };
 
 Texture2D Texture;

--- a/bin/resources/shaders/opengl/present.glsl
+++ b/bin/resources/shaders/opengl/present.glsl
@@ -40,7 +40,6 @@ uniform vec2 u_rcp_target_resolution; // 1 / u_target_resolution
 uniform vec2 u_source_resolution;
 uniform vec2 u_rcp_source_resolution; // 1 / u_source_resolution
 uniform float u_time;
-uniform vec3 cb0_pad0;
 
 in vec4 PSin_p;
 in vec2 PSin_t;

--- a/bin/resources/shaders/vulkan/present.glsl
+++ b/bin/resources/shaders/vulkan/present.glsl
@@ -26,7 +26,6 @@ layout(push_constant) uniform cb10
 	vec2 u_source_resolution;
 	vec2 u_rcp_source_resolution; // 1 / u_source_resolution
 	float u_time;
-	vec3 cb0_pad0;
 };
 
 layout(location = 0) in vec2 v_tex;


### PR DESCRIPTION
### Description of Changes

Stops the validation layer complaining.

Other commit also fixes another validation layer error - it wasn't a real issue, since the padding never gets read, but nonetheless it's better to be correct.

### Rationale behind Changes

Validation layer reports are there for a good reason.

### Suggested Testing Steps

Make sure exclusive fullscreen control still works (i.e. allowed -> volume overlay is not visible).
