### PR TITLE
GameDB: Added missing fixes for Crash Bandicoot 5

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -1023,6 +1023,8 @@ SCAJ-20111:
   region: "NTSC-Unk"
   gameFixes:
     - XGKickHack # Fixes bad Geometry.
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes depth lines.
 SCAJ-20112:
   name: "Tales of Rebirth"
   region: "NTSC-Unk"
@@ -31674,6 +31676,8 @@ SLPM-65801:
   compat: 5
   gameFixes:
     - XGKickHack # Fixes bad geometry.
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes depth lines.
 SLPM-65802:
   name: "Def Jam - Vendetta [EA Best Hits]"
   region: "NTSC-J"


### PR DESCRIPTION
### Description of Changes
Added gsHWFixes for the Asian versions.

### Rationale behind Changes
PAL and NTSC-U version had these fixes already but NTSC-J didn't.

### Suggested Testing Steps
N/A
