### PR TITLE
GS: Skip autoflush optimisation when pending texflush

### DIFF
--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -2841,7 +2841,7 @@ template<u32 prim, bool index_swap>
 __forceinline void GSState::HandleAutoFlush()
 {
 	// Kind of a cheat, making the assumption that 2 consecutive fan/strip triangles won't overlap each other (*should* be safe)
-	if ((m_index.tail & 1) && (prim == GS_TRIANGLESTRIP || prim == GS_TRIANGLEFAN))
+	if ((m_index.tail & 1) && (prim == GS_TRIANGLESTRIP || prim == GS_TRIANGLEFAN) && !m_texflush_flag)
 		return;
 
 	// To briefly explain what's going on here, what we are checking for is draws over a texture when the source and destination are themselves.


### PR DESCRIPTION
### Description of Changes
Skips using the Autoflush optmisation when TEXFLUSH is pending.

### Rationale behind Changes
This with the combination of not flushing on tex flush, a previous optimisation from #8723 and skipping checks on odd numbers of verticals (which was an optimisation made a while back), this meant that flushes which needed to be done didn't happen, and as a result the shadows in Jak & Daxter (although only on software for some reason) broke.  This fixes it.

### Suggested Testing Steps
Check Jak & Daxter games in software mode, make sure the shadows are fine.

@stenzek can you check this doesn't make things explode from TEXFLUSH again? Thanks :D

Jak 3:

Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/223215b1-c0c3-4783-b11b-8cbb9a23285a)

PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/ce30f87b-5b62-48de-8317-8f8f1087257a)
