### PR TITLE
GS/HW: Check for Tex in RT's on target invalidation for overlap.

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -2294,18 +2294,29 @@ void GSTextureCache::InvalidateVideoMem(const GSOffset& off, const GSVector4i& r
 						}
 						else
 						{
-							i = list.erase(j);
-							GL_CACHE("TC: Tex in RT Remove Target(%s) (0x%x) TPSM %x PSM %x bp 0x%x x %d y %d z %d w %d", to_string(type),
-								t->m_TEX0.TBP0,
-								t->m_TEX0.PSM,
-								psm,
-								bp,
-								r.x,
-								r.y,
-								r.z,
-								r.w);
-							delete t;
-							continue;
+							// Be careful of textures inside RT's which are outside of what's being invalidated. (Indiana Jones Emperor's Tomb)
+							if (can_translate)
+							{
+								DirtyRectByPage(bp, psm, bw, t, r);
+							}
+							else
+							{
+								SurfaceOffsetKey sok;
+								sok.elems[0].bp = bp;
+								sok.elems[0].bw = bw;
+								sok.elems[0].psm = psm;
+								sok.elems[0].rect = r;
+								sok.elems[1].bp = t->m_TEX0.TBP0;
+								sok.elems[1].bw = t->m_TEX0.TBW;
+								sok.elems[1].psm = t->m_TEX0.PSM;
+								sok.elems[1].rect = t->m_valid;
+
+								const SurfaceOffset so = ComputeSurfaceOffset(sok);
+								if (so.is_valid)
+								{
+									AddDirtyRectTarget(t, so.b2a_offset, t->m_TEX0.PSM, t->m_TEX0.TBW, rgba);
+								}
+							}
 						}
 					}
 					else if (can_translate)


### PR DESCRIPTION
### Description of Changes
Marks a target as dirty instead of deleting it.

### Rationale behind Changes
Indiana Jones and the Emperor's Tomb tends to point to 0x3000 a lot and write a lot of different textures up to 0x3b00, then Tex in RT points a source texture at 0x3800 inside this texture, and a write later comes along to invalidate below this.  Previously this was wiping out the whole target which of course is bad since that data is then gone, so now the target is kept around unless completely overwritten

### Suggested Testing Steps
Test random games, make sure everything is ok (nothing else showed up except Indiana Jones out of 1300 GS dumps), and try Indiana Jones and the Emperor's Tomb

Forbidden Siren 2 is broken, but once Stens clear PR (#8961) merges I'll rebase, and it'll be fine again.

Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/6997784d-b26a-4f5b-a787-821a04128832)

PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/befeeb99-eb19-42ce-a524-cffe56121ab5)

