### PR TITLE
VMManager: Refactor and improve boot process

### DIFF
--- a/pcsx2-gsrunner/Main.cpp
+++ b/pcsx2-gsrunner/Main.cpp
@@ -293,8 +293,8 @@ void Host::OnVMResumed()
 {
 }
 
-void Host::OnGameChanged(const std::string& disc_path, const std::string& elf_override, const std::string& game_serial,
-	const std::string& game_name, u32 game_crc)
+void Host::OnGameChanged(const std::string& title, const std::string& elf_override, const std::string& disc_path,
+	const std::string& disc_serial, u32 disc_crc, u32 current_crc)
 {
 }
 

--- a/pcsx2-qt/MainWindow.h
+++ b/pcsx2-qt/MainWindow.h
@@ -179,7 +179,8 @@ private Q_SLOTS:
 	void onVMResumed();
 	void onVMStopped();
 
-	void onGameChanged(const QString& path, const QString& elf_override, const QString& serial, const QString& name, quint32 crc);
+	void onGameChanged(const QString& title, const QString& elf_override, const QString& disc_path,
+		const QString& serial, quint32 disc_crc, quint32 crc);
 
 protected:
 	void showEvent(QShowEvent* event) override;
@@ -279,11 +280,12 @@ private:
 
 	QMenu* m_settings_toolbar_menu = nullptr;
 
-	QString m_current_disc_path;
+	QString m_current_title;
 	QString m_current_elf_override;
-	QString m_current_game_serial;
-	QString m_current_game_name;
-	quint32 m_current_game_crc;
+	QString m_current_disc_path;
+	QString m_current_disc_serial;
+	quint32 m_current_disc_crc;
+	quint32 m_current_running_crc;
 
 	bool m_display_created = false;
 	bool m_relative_mouse_mode = false;

--- a/pcsx2-qt/QtHost.cpp
+++ b/pcsx2-qt/QtHost.cpp
@@ -667,14 +667,7 @@ void EmuThread::reloadPatches()
 		return;
 	}
 
-	if (!VMManager::HasValidVM())
-		return;
-
-	Patch::ReloadPatches(true, false, true, true);
-
-	// Might change widescreen mode.
-	if (Patch::ReloadPatchAffectingOptions())
-		applySettings();
+	VMManager::ReloadPatches(true, false, true, true);
 }
 
 void EmuThread::reloadInputSources()
@@ -968,11 +961,11 @@ void Host::OnVMResumed()
 	emit g_emu_thread->onVMResumed();
 }
 
-void Host::OnGameChanged(const std::string& disc_path, const std::string& elf_override, const std::string& game_serial,
-	const std::string& game_name, u32 game_crc)
+void Host::OnGameChanged(const std::string& title, const std::string& elf_override, const std::string& disc_path,
+	const std::string& disc_serial, u32 disc_crc, u32 current_crc)
 {
-	emit g_emu_thread->onGameChanged(QString::fromStdString(disc_path), QString::fromStdString(elf_override),
-		QString::fromStdString(game_serial), QString::fromStdString(game_name), game_crc);
+	emit g_emu_thread->onGameChanged(QString::fromStdString(title), QString::fromStdString(elf_override),
+		QString::fromStdString(disc_path), QString::fromStdString(disc_serial), disc_crc, current_crc);
 }
 
 void EmuThread::updatePerformanceMetrics(bool force)
@@ -1124,7 +1117,7 @@ void Host::VSyncOnCPUThread()
 
 void Host::RunOnCPUThread(std::function<void()> function, bool block /* = false */)
 {
-	if (g_emu_thread->isOnEmuThread())
+	if (block && g_emu_thread->isOnEmuThread())
 	{
 		// probably shouldn't ever happen, but just in case..
 		function();

--- a/pcsx2-qt/QtHost.h
+++ b/pcsx2-qt/QtHost.h
@@ -137,7 +137,8 @@ Q_SIGNALS:
 	void onVMStopped();
 
 	/// Provided by the host; called when the running executable changes.
-	void onGameChanged(const QString& path, const QString& elf_override, const QString& serial, const QString& name, quint32 crc);
+	void onGameChanged(const QString& title, const QString& elf_override, const QString& disc_path,
+		const QString& serial, quint32 disc_crc, quint32 crc);
 
 	void onInputDevicesEnumerated(const QList<QPair<QString, QString>>& devices);
 	void onInputDeviceConnected(const QString& identifier, const QString& device_name);

--- a/pcsx2-qt/Settings/BIOSSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/BIOSSettingsWidget.cpp
@@ -30,23 +30,29 @@
 
 BIOSSettingsWidget::BIOSSettingsWidget(SettingsDialog* dialog, QWidget* parent)
 	: QWidget(parent)
+	, m_dialog(dialog)
 {
 	SettingsInterface* sif = dialog->getSettingsInterface();
 
 	m_ui.setupUi(this);
 
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.fastBoot, "EmuCore", "EnableFastBoot", true);
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.fastBootFastForward, "EmuCore", "EnableFastBootFastForward", false);
 	SettingWidgetBinder::BindWidgetToFolderSetting(sif, m_ui.searchDirectory, m_ui.browseSearchDirectory, m_ui.openSearchDirectory,
 		m_ui.resetSearchDirectory, "Folders", "Bios", Path::Combine(EmuFolders::DataRoot, "bios"));
 
 	dialog->registerWidgetHelp(m_ui.fastBoot, tr("Fast Boot"), tr("Checked"),
 		tr("Patches the BIOS to skip the console's boot animation."));
 
+	dialog->registerWidgetHelp(m_ui.fastBoot, tr("Fast Forward Boot"), tr("Unchecked"),
+		tr("Removes emulation speed throttle until the game starts to reduce startup time."));
+
 	refreshList();
 
 	connect(m_ui.searchDirectory, &QLineEdit::textChanged, this, &BIOSSettingsWidget::refreshList);
 	connect(m_ui.refresh, &QPushButton::clicked, this, &BIOSSettingsWidget::refreshList);
 	connect(m_ui.fileList, &QTreeWidget::currentItemChanged, this, &BIOSSettingsWidget::listItemChanged);
+	connect(m_ui.fastBoot, &QCheckBox::stateChanged, this, &BIOSSettingsWidget::fastBootChanged);
 }
 
 BIOSSettingsWidget::~BIOSSettingsWidget()
@@ -137,6 +143,12 @@ void BIOSSettingsWidget::listItemChanged(const QTreeWidgetItem* current, const Q
 	Host::CommitBaseSettingChanges();
 
 	g_emu_thread->applySettings();
+}
+
+void BIOSSettingsWidget::fastBootChanged()
+{
+	const bool enabled = m_dialog->getEffectiveBoolValue("EmuCore", "EnableFastBoot", true);
+	m_ui.fastBootFastForward->setEnabled(enabled);
 }
 
 BIOSSettingsWidget::RefreshThread::RefreshThread(BIOSSettingsWidget* parent, const QString& directory)

--- a/pcsx2-qt/Settings/BIOSSettingsWidget.h
+++ b/pcsx2-qt/Settings/BIOSSettingsWidget.h
@@ -52,8 +52,11 @@ private Q_SLOTS:
 	void listItemChanged(const QTreeWidgetItem* current, const QTreeWidgetItem* previous);
 	void listRefreshed(const QVector<BIOSInfo>& items);
 
+	void fastBootChanged();
+
 private:
 	Ui::BIOSSettingsWidget m_ui;
+	SettingsDialog* m_dialog;
 
 	class RefreshThread final : public QThread
 	{

--- a/pcsx2-qt/Settings/BIOSSettingsWidget.ui
+++ b/pcsx2-qt/Settings/BIOSSettingsWidget.ui
@@ -136,11 +136,22 @@
      </property>
      <layout class="QVBoxLayout" name="verticalLayout">
       <item>
-       <widget class="QCheckBox" name="fastBoot">
-        <property name="text">
-         <string>Fast Boot</string>
-        </property>
-       </widget>
+       <layout class="QHBoxLayout" name="horizontalLayout_3">
+        <item>
+         <widget class="QCheckBox" name="fastBoot">
+          <property name="text">
+           <string>Fast Boot</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="fastBootFastForward">
+          <property name="text">
+           <string>Fast Forward Boot</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </item>
      </layout>
     </widget>

--- a/pcsx2/Achievements.h
+++ b/pcsx2/Achievements.h
@@ -62,7 +62,9 @@ namespace Achievements
 		u32 id;
 		std::string title;
 		std::string description;
+		std::string memaddr;
 		int format;
+		bool active;
 	};
 
 	struct LeaderboardEntry
@@ -131,7 +133,7 @@ namespace Achievements
 	bool Login(const char* username, const char* password);
 	void Logout();
 
-	void GameChanged(u32 crc);
+	void GameChanged(u32 disc_crc, u32 crc);
 
 	const std::string& GetGameTitle();
 	const std::string& GetGameIcon();

--- a/pcsx2/CDVD/CDVD.h
+++ b/pcsx2/CDVD/CDVD.h
@@ -17,8 +17,11 @@
 
 #include "CDVDcommon.h"
 
+#include <memory>
 #include <string>
 #include <string_view>
+
+class ElfObject;
 
 #define btoi(b) ((b) / 16 * 10 + (b) % 16) /* BCD to u_char */
 #define itob(i) ((i) / 10 * 16 + (i) % 10) /* u_char to BCD */
@@ -74,6 +77,13 @@ struct cdvdRTC
 	u8 day;
 	u8 month;
 	u8 year;
+};
+
+enum class CDVDDiscType : u8
+{
+	Other,
+	PS1Disc,
+	PS2Disc
 };
 
 enum TrayStates
@@ -176,9 +186,11 @@ extern void cdvdNewDiskCB();
 extern u8 cdvdRead(u8 key);
 extern void cdvdWrite(u8 key, u8 rt);
 
-extern void cdvdReloadElfInfo(std::string elfoverride = std::string());
+extern void cdvdGetDiscInfo(std::string* out_serial, std::string* out_elf_path, std::string* out_version, u32* out_crc,
+	CDVDDiscType* out_disc_type);
 extern u32 cdvdGetElfCRC(const std::string& path);
+extern std::unique_ptr<ElfObject> cdvdLoadElf(std::string filename, bool isPSXElf);
+
 extern s32 cdvdCtrlTrayOpen();
 extern s32 cdvdCtrlTrayClose();
 
-extern std::string DiscSerial;

--- a/pcsx2/CDVD/CDVDcommon.h
+++ b/pcsx2/CDVD/CDVDcommon.h
@@ -158,6 +158,7 @@ extern void CDVDsys_ChangeSource(CDVD_SourceType type);
 extern void CDVDsys_SetFile(CDVD_SourceType srctype, std::string newfile);
 extern const std::string& CDVDsys_GetFile(CDVD_SourceType srctype);
 extern CDVD_SourceType CDVDsys_GetSourceType();
+extern void CDVDsys_ClearFiles();
 
 extern bool DoCDVDopen();
 extern void DoCDVDclose();

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -1244,14 +1244,15 @@ struct Pcsx2Config
 		EnablePINE : 1, // enables inter-process communication
 		EnableWideScreenPatches : 1,
 		EnableNoInterlacingPatches : 1,
+		EnableFastBoot : 1,
+		EnableFastBootFastForward : 1,
+		EnablePerGameSettings : 1,
 		// TODO - Vaser - where are these settings exposed in the Qt UI?
 		EnableRecordingTools : 1,
 		EnableGameFixes : 1, // enables automatic game fixes
 		SaveStateOnShutdown : 1, // default value for saving state on shutdown
 		EnableDiscordPresence : 1, // enables discord rich presence integration
 		InhibitScreensaver : 1,
-		// when enabled uses BOOT2 injection, skipping sony bios splashes
-		UseBOOT2Injection : 1,
 		BackupSavestate : 1,
 		SavestateZstdCompression : 1,
 		// enables simulated ejection of memory cards when loading savestates

--- a/pcsx2/Elfheader.cpp
+++ b/pcsx2/Elfheader.cpp
@@ -22,40 +22,54 @@
 #include "Elfheader.h"
 #include "DebugTools/SymbolMap.h"
 
-u32 ElfCRC;
-u32 ElfEntry;
-std::pair<u32,u32> ElfTextRange;
-std::string LastELF;
-bool isPSXElf;
-std::string ElfVersion;
+#pragma pack(push, 1)
+struct PSXEXEHeader
+{
+	char id[8]; // 0x000-0x007 PS-X EXE
+	char pad1[8]; // 0x008-0x00F
+	u32 initial_pc; // 0x010
+	u32 initial_gp; // 0x014
+	u32 load_address; // 0x018
+	u32 file_size; // 0x01C excluding 0x800-byte header
+	u32 unk0; // 0x020
+	u32 unk1; // 0x024
+	u32 memfill_start; // 0x028
+	u32 memfill_size; // 0x02C
+	u32 initial_sp_base; // 0x030
+	u32 initial_sp_offset; // 0x034
+	u32 reserved[5]; // 0x038-0x04B
+	char marker[0x7B4]; // 0x04C-0x7FF
+};
+static_assert(sizeof(PSXEXEHeader) == 0x800);
+#pragma pack(pop)
 
 // All of ElfObjects functions.
-ElfObject::ElfObject(std::string srcfile, IsoFile& isofile, bool isPSXElf)
+ElfObject::ElfObject(std::string srcfile, IsoFile& isofile, bool isPSXElf_)
 	: data(isofile.getLength(), "ELF headers")
-	, filename(std::move(srcfile))
 	, header(*(ELF_HEADER*)data.GetPtr())
+	, filename(std::move(srcfile))
+	, isPSXElf(isPSXElf_)
 {
 	checkElfSize(data.GetSizeInBytes());
 	readIso(isofile);
-	initElfHeaders(isPSXElf);
+	initElfHeaders();
 }
 
-ElfObject::ElfObject(std::string srcfile, u32 hdrsize, bool isPSXElf)
+ElfObject::ElfObject(std::string srcfile, u32 hdrsize, bool isPSXElf_)
 	: data(hdrsize, "ELF headers")
-	, filename(std::move(srcfile))
 	, header(*(ELF_HEADER*)data.GetPtr())
+	, filename(std::move(srcfile))
+	, isPSXElf(isPSXElf_)
 {
 	checkElfSize(data.GetSizeInBytes());
 	readFile();
-	initElfHeaders(isPSXElf);
+	initElfHeaders();
 }
 
-void ElfObject::initElfHeaders(bool isPSXElf)
+void ElfObject::initElfHeaders()
 {
 	if (isPSXElf)
-	{
 		return;
-	}
 
 	DevCon.WriteLn("Initializing Elf: %d bytes", data.GetSizeInBytes());
 
@@ -133,19 +147,57 @@ void ElfObject::initElfHeaders(bool isPSXElf)
 	//applyPatches();
 }
 
+bool ElfObject::hasValidPSXHeader()
+{
+	if (data.GetSizeInBytes() < sizeof(PSXEXEHeader))
+		return false;
+
+	const PSXEXEHeader* header = reinterpret_cast<const PSXEXEHeader*>(data.GetPtr());
+
+	static constexpr char expected_id[] = {'P', 'S', '-', 'X', ' ', 'E', 'X', 'E'};
+	if (std::memcmp(header->id, expected_id, sizeof(expected_id)) != 0)
+		return false;
+
+	if ((header->file_size + sizeof(PSXEXEHeader)) > data.GetSizeInBytes())
+	{
+		Console.Warning("Incorrect file size in PS-EXE header: %u bytes should not be greater than %u bytes",
+			header->file_size, static_cast<unsigned>(data.GetSizeInBytes() - sizeof(PSXEXEHeader)));
+	}
+
+	return true;
+}
+
 bool ElfObject::hasProgramHeaders() { return (proghead != NULL); }
 bool ElfObject::hasSectionHeaders() { return (secthead != NULL); }
 bool ElfObject::hasHeaders() { return (hasProgramHeaders() && hasSectionHeaders()); }
 
+u32 ElfObject::getEntryPoint()
+{
+	if (isPSXElf)
+	{
+		if (hasValidPSXHeader())
+			return reinterpret_cast<const PSXEXEHeader*>(data.GetPtr())->initial_pc;
+		else
+			return 0xFFFFFFFFu;
+	}
+	else
+	{
+		return header.e_entry;
+	}
+}
+
 std::pair<u32,u32> ElfObject::getTextRange()
 {
-	for (int i = 0; i < header.e_phnum; i++)
+	if (isPSXElf && hasProgramHeaders())
 	{
-		u32 start = proghead[i].p_vaddr;
-		u32 size = proghead[i].p_memsz;
+		for (int i = 0; i < header.e_phnum; i++)
+		{
+			const u32 start = proghead[i].p_vaddr;
+			const u32 size = proghead[i].p_memsz;
 
-		if (start <= header.e_entry && (start+size) > header.e_entry)
-			return std::make_pair(start,size);
+			if (start <= header.e_entry && (start + size) > header.e_entry)
+				return std::make_pair(start, size);
+		}
 	}
 
 	return std::make_pair(0,0);
@@ -310,82 +362,9 @@ void ElfObject::loadSectionHeaders()
 
 void ElfObject::loadHeaders()
 {
+	if (isPSXElf)
+		return;
+
 	loadProgramHeaders();
 	loadSectionHeaders();
-}
-
-// return value:
-//   0 - Invalid or unknown disc.
-//   1 - PS1 CD
-//   2 - PS2 CD
-int GetPS2ElfName( std::string& name )
-{
-	int retype = 0;
-
-	try {
-		IsoFSCDVD isofs;
-		IsoFile file( isofs, "SYSTEM.CNF;1");
-
-		int size = file.getLength();
-		if( size == 0 ) return 0;
-
-		while( !file.eof() )
-		{
-			const std::string line(file.readLine());
-			std::string_view key, value;
-			if (!StringUtil::ParseAssignmentString(line, &key, &value))
-				continue;
-
-			if( value.empty() && file.getLength() != file.getSeekPos() )
-			{ // Some games have a character on the last line of the file, don't print the error in those cases.
-				Console.Warning( "(SYSTEM.CNF) Unusual or malformed entry in SYSTEM.CNF ignored:" );
-				Console.Indent().WriteLn(line);
-				continue;
-			}
-
-			if( key == "BOOT2" )
-			{
-				Console.WriteLn( Color_StrongBlue, "(SYSTEM.CNF) Detected PS2 Disc = %.*s",
-					static_cast<int>(value.size()), value.data());
-				name = value;
-				retype = 2;
-			}
-			else if( key == "BOOT" )
-			{
-				Console.WriteLn( Color_StrongBlue, "(SYSTEM.CNF) Detected PSX/PSone Disc = %.*s",
-					static_cast<int>(value.size()), value.data());
-				name = value;
-				retype = 1;
-			}
-			else if( key == "VMODE" )
-			{
-				Console.WriteLn( Color_Blue, "(SYSTEM.CNF) Disc region type = %.*s",
-					static_cast<int>(value.size()), value.data());
-			}
-			else if( key == "VER" )
-			{
-				Console.WriteLn( Color_Blue, "(SYSTEM.CNF) Software version = %.*s",
-					static_cast<int>(value.size()), value.data());
-				ElfVersion = value;
-			}
-		}
-
-		if( retype == 0 )
-		{
-			Console.Error("(GetElfName) Disc image is *not* a PlayStation or PS2 game!");
-			return 0;
-		}
-	}
-	catch( Exception::FileNotFound& )
-	{
-		//Console.Warning(ex.FormatDiagnosticMessage());
-		return 0;		// no SYSTEM.CNF, not a PS1/PS2 disc.
-	}
-	catch (Exception::BadStream& ex)
-	{
-		Console.Error(ex.FormatDiagnosticMessage());
-		return 0;		// ISO error
-	}
-
-	return retype;
 }

--- a/pcsx2/Elfheader.h
+++ b/pcsx2/Elfheader.h
@@ -122,24 +122,23 @@ class ElfObject
 {
 	private:
 		SafeArray<u8> data;
+		ELF_HEADER& header;
 		ELF_PHR* proghead = nullptr;
 		ELF_SHR* secthead = nullptr;
 		std::string filename;
+		bool isPSXElf;
 
-		void initElfHeaders(bool isPSXElf);
+		void initElfHeaders();
+		bool hasValidPSXHeader();
 		void readIso(IsoFile& file);
 		void readFile();
 		void checkElfSize(s64 elfsize);
 
 	public:
-		ELF_HEADER& header;
+		ElfObject(std::string srcfile, IsoFile& isofile, bool isPSXElf_);
+		ElfObject(std::string srcfile, u32 hdrsize, bool isPSXElf_);
 
-		// Destructor!
-		// C++ does all the cleanup automagically for us.
-		virtual ~ElfObject() = default;
-
-		ElfObject(std::string srcfile, IsoFile& isofile, bool isPSXElf);
-		ElfObject(std::string srcfile, u32 hdrsize, bool isPSXElf);
+		bool IsPSXElf() const { return isPSXElf; }
 
 		void loadProgramHeaders();
 		void loadSectionHeaders();
@@ -150,17 +149,8 @@ class ElfObject
 		bool hasHeaders();
 
 		std::pair<u32,u32> getTextRange();
+		u32 getEntryPoint();
 		u32 getCRC();
 };
 
 //-------------------
-extern void loadElfFile(const std::string& filename);
-extern int  GetPS2ElfName( std::string& dest );
-
-
-extern u32 ElfCRC;
-extern u32 ElfEntry;
-extern std::pair<u32,u32> ElfTextRange;
-extern std::string LastELF;
-extern bool isPSXElf;
-extern std::string ElfVersion;

--- a/pcsx2/GS.cpp
+++ b/pcsx2/GS.cpp
@@ -21,6 +21,7 @@
 #include "Gif_Unit.h"
 #include "Counters.h"
 #include "Config.h"
+#include "VMManager.h"
 
 using namespace Threading;
 using namespace R5900;
@@ -45,7 +46,8 @@ void gsReset()
 
 void gsUpdateFrequency(Pcsx2Config& config)
 {
-	if (config.GS.FrameLimitEnable)
+	if (config.GS.FrameLimitEnable &&
+		(!config.EnableFastBootFastForward || !VMManager::Internal::IsFastBootInProgress()))
 	{
 		switch (config.LimiterMode)
 		{

--- a/pcsx2/GS/Renderers/Common/GSRenderer.cpp
+++ b/pcsx2/GS/Renderers/Common/GSRenderer.cpp
@@ -667,7 +667,7 @@ void GSRenderer::VSync(u32 field, bool registers_written, bool idle_frame)
 			std::string_view compression_str;
 			if (GSConfig.GSDumpCompression == GSDumpCompressionMethod::Uncompressed)
 			{
-				m_dump = std::unique_ptr<GSDumpBase>(new GSDumpUncompressed(m_snapshot, VMManager::GetGameSerial(), m_crc,
+				m_dump = std::unique_ptr<GSDumpBase>(new GSDumpUncompressed(m_snapshot, VMManager::GetDiscSerial(), m_crc,
 					screenshot_width, screenshot_height,
 					screenshot_pixels.empty() ? nullptr : screenshot_pixels.data(),
 					fd, m_regs));
@@ -675,7 +675,7 @@ void GSRenderer::VSync(u32 field, bool registers_written, bool idle_frame)
 			}
 			else if (GSConfig.GSDumpCompression == GSDumpCompressionMethod::LZMA)
 			{
-				m_dump = std::unique_ptr<GSDumpBase>(new GSDumpXz(m_snapshot, VMManager::GetGameSerial(), m_crc,
+				m_dump = std::unique_ptr<GSDumpBase>(new GSDumpXz(m_snapshot, VMManager::GetDiscSerial(), m_crc,
 					screenshot_width, screenshot_height,
 					screenshot_pixels.empty() ? nullptr : screenshot_pixels.data(),
 					fd, m_regs));
@@ -683,7 +683,7 @@ void GSRenderer::VSync(u32 field, bool registers_written, bool idle_frame)
 			}
 			else
 			{
-				m_dump = std::unique_ptr<GSDumpBase>(new GSDumpZst(m_snapshot, VMManager::GetGameSerial(), m_crc,
+				m_dump = std::unique_ptr<GSDumpBase>(new GSDumpZst(m_snapshot, VMManager::GetDiscSerial(), m_crc,
 					screenshot_width, screenshot_height,
 					screenshot_pixels.empty() ? nullptr : screenshot_pixels.data(),
 					fd, m_regs));
@@ -780,14 +780,14 @@ static std::string GSGetBaseFilename()
 	std::string filename;
 
 	// append the game serial and title
-	if (std::string name(VMManager::GetGameName()); !name.empty())
+	if (std::string name(VMManager::GetTitle()); !name.empty())
 	{
 		Path::SanitizeFileName(&name);
 		if (name.length() > 219)
 			name.resize(219);
 		filename += name;
 	}
-	if (std::string serial(VMManager::GetGameSerial()); !serial.empty())
+	if (std::string serial = VMManager::GetDiscSerial(); !serial.empty())
 	{
 		Path::SanitizeFileName(&serial);
 		filename += '_';

--- a/pcsx2/GS/Renderers/HW/GSTextureReplacements.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureReplacements.cpp
@@ -303,7 +303,7 @@ std::string GSTextureReplacements::GetDumpFilename(const TextureName& name, u32 
 
 void GSTextureReplacements::Initialize()
 {
-	s_current_serial = VMManager::GetGameSerial();
+	s_current_serial = VMManager::GetDiscSerial();
 
 	if (GSConfig.DumpReplaceableTextures || GSConfig.LoadTextureReplacements)
 		StartWorkerThread();
@@ -313,7 +313,7 @@ void GSTextureReplacements::Initialize()
 
 void GSTextureReplacements::GameChanged()
 {
-	std::string new_serial(VMManager::GetGameSerial());
+	std::string new_serial = VMManager::GetDiscSerial();
 	if (s_current_serial == new_serial)
 		return;
 

--- a/pcsx2/GSDumpReplayer.cpp
+++ b/pcsx2/GSDumpReplayer.cpp
@@ -204,9 +204,6 @@ static void GSDumpReplayerLoadInitialState()
 	std::memcpy(PS2MEM_GS, s_dump_file->GetRegsData().data(),
 		std::min(Ps2MemSize::GSregs, static_cast<u32>(s_dump_file->GetRegsData().size())));
 
-	// update serial to load hw fixes
-	VMManager::Internal::GameStartingOnCPUThread();
-
 	// load GS state
 	freezeData fd = {static_cast<int>(s_dump_file->GetStateData().size()),
 		const_cast<u8*>(s_dump_file->GetStateData().data())};

--- a/pcsx2/GameDatabase.cpp
+++ b/pcsx2/GameDatabase.cpp
@@ -60,22 +60,17 @@ std::string GameDatabaseSchema::GameEntry::memcardFiltersAsString() const
 
 const std::string* GameDatabaseSchema::GameEntry::findPatch(u32 crc) const
 {
-	Console.WriteLn(fmt::format("[GameDB] Searching for patch with CRC '{:08X}'", crc));
+	if (crc == 0)
+		return nullptr;
 
 	auto it = patches.find(crc);
 	if (it != patches.end())
-	{
-		Console.WriteLn(fmt::format("[GameDB] Found patch with CRC '{:08X}'", crc));
 		return &it->second;
-	}
 
 	it = patches.find(0);
 	if (it != patches.end())
-	{
-		Console.WriteLn("[GameDB] Found and falling back to default patch");
 		return &it->second;
-	}
-	Console.WriteLn("[GameDB] No CRC-specific patch or default patch found");
+
 	return nullptr;
 }
 

--- a/pcsx2/GameList.cpp
+++ b/pcsx2/GameList.cpp
@@ -173,19 +173,10 @@ bool GameList::GetIsoSerialAndCRC(const std::string& path, s32* disc_type, std::
 	if (CDVD->open(path.c_str()) != 0)
 		return false;
 
+	// TODO: we could include the version in the game list?
 	*disc_type = DoCDVDdetectDiskType();
-	cdvdReloadElfInfo();
-
-	*serial = DiscSerial;
-	*crc = ElfCRC;
-
+	cdvdGetDiscInfo(serial, nullptr, nullptr, crc, nullptr);
 	DoCDVDclose();
-
-	// TODO(Stenzek): These globals are **awful**. Clean it up.
-	DiscSerial.clear();
-	ElfCRC = 0;
-	ElfEntry = -1;
-	LastELF.clear();
 	return true;
 }
 

--- a/pcsx2/ImGui/FullscreenUI.h
+++ b/pcsx2/ImGui/FullscreenUI.h
@@ -29,7 +29,7 @@ namespace FullscreenUI
 	void CheckForConfigChanges(const Pcsx2Config& old_config);
 	void OnVMStarted();
 	void OnVMDestroyed();
-	void GameChanged(std::string path, std::string serial, std::string title, u32 crc);
+	void GameChanged(std::string title, std::string path, std::string serial, u32 disc_crc, u32 crc);
 	void OpenPauseMenu();
 	void OpenAchievementsWindow();
 	void OpenLeaderboardsWindow();

--- a/pcsx2/MTGS.cpp
+++ b/pcsx2/MTGS.cpp
@@ -268,7 +268,7 @@ bool SysMtgsThread::TryOpenGS()
 	if (!GSopen(EmuConfig.GS, EmuConfig.GS.Renderer, RingBuffer.Regs))
 		return false;
 
-	GSSetGameCRC(ElfCRC);
+	GSSetGameCRC(VMManager::GetDiscCRC());
 	return true;
 }
 

--- a/pcsx2/Memory.cpp
+++ b/pcsx2/Memory.cpp
@@ -48,8 +48,6 @@ BIOS
 
 #include "common/AlignedMalloc.h"
 
-#include "GSDumpReplayer.h"
-
 #ifdef ENABLECACHE
 #include "Cache.h"
 #endif
@@ -841,11 +839,7 @@ void eeMemoryReserve::Reset()
 	vtlb_VMap(0x00000000,0x00000000,0x20000000);
 	vtlb_VMapUnmap(0x20000000,0x60000000);
 
-	const bool needs_bios = !GSDumpReplayer::IsReplayingDump();
-
-	// TODO(Stenzek): Move BIOS loading out and far away...
-	if (needs_bios && !LoadBIOS())
-		pxFailRel("Failed to load BIOS");
+	CopyBIOSToMemory();
 }
 
 void eeMemoryReserve::Release()

--- a/pcsx2/PINE.cpp
+++ b/pcsx2/PINE.cpp
@@ -437,7 +437,7 @@ PINEServer::IPCBuffer PINEServer::ParseCommand(gsl::span<u8> buf, std::vector<u8
 			{
 				if (!VMManager::HasValidVM())
 					goto error;
-				const std::string gameName = VMManager::GetGameName();
+				const std::string gameName = VMManager::GetTitle();
 				const u32 size = gameName.size() + 1;
 				if (!SafetyChecks(buf_cnt, 0, ret_cnt, size + 4, buf_size))
 					goto error;
@@ -451,7 +451,7 @@ PINEServer::IPCBuffer PINEServer::ParseCommand(gsl::span<u8> buf, std::vector<u8
 			{
 				if (!VMManager::HasValidVM())
 					goto error;
-				const std::string gameSerial = VMManager::GetGameSerial();
+				const std::string gameSerial = VMManager::GetDiscSerial();
 				const u32 size = gameSerial.size() + 1;
 				if (!SafetyChecks(buf_cnt, 0, ret_cnt, size + 4, buf_size))
 					goto error;
@@ -465,7 +465,7 @@ PINEServer::IPCBuffer PINEServer::ParseCommand(gsl::span<u8> buf, std::vector<u8
 			{
 				if (!VMManager::HasValidVM())
 					goto error;
-				const std::string crc(fmt::format("{:08x}", VMManager::GetGameCRC()));
+				const std::string crc = fmt::format("{:08x}", VMManager::GetDiscCRC());
 				const u32 size = crc.size() + 1;
 				if (!SafetyChecks(buf_cnt, 0, ret_cnt, size + 4, buf_size))
 					goto error;
@@ -479,6 +479,8 @@ PINEServer::IPCBuffer PINEServer::ParseCommand(gsl::span<u8> buf, std::vector<u8
 			{
 				if (!VMManager::HasValidVM())
 					goto error;
+
+				const std::string ElfVersion = VMManager::GetDiscVersion();
 				const u32 size = ElfVersion.size() + 1;
 				if (!SafetyChecks(buf_cnt, 0, ret_cnt, size + 4, buf_size))
 					goto error;

--- a/pcsx2/Patch.h
+++ b/pcsx2/Patch.h
@@ -96,8 +96,7 @@ namespace Patch
 	extern PatchInfoList GetPatchInfo(const std::string& serial, u32 crc, bool cheats, u32* num_unlabelled_patches);
 
 	/// Reloads cheats/patches. If verbose is set, the number of patches loaded will be shown in the OSD.
-	extern void ReloadPatches(std::string serial, u32 crc, bool force_reload_files, bool reload_enabled_list, bool verbose, bool verbose_if_changed);
-	extern void ReloadPatches(bool force_reload_files, bool reload_enabled_list, bool verbose, bool verbose_if_changed);
+	extern void ReloadPatches(const std::string& serial, u32 crc, bool reload_files, bool reload_enabled_list, bool verbose, bool verbose_if_changed);
 
 	extern void UpdateActivePatches(bool reload_enabled_list, bool verbose, bool verbose_if_changed);
 	extern void ApplyPatchSettingOverrides();

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -1305,6 +1305,8 @@ Pcsx2Config::Pcsx2Config()
 	McdEnableEjection = true;
 	McdFolderAutoManage = true;
 	EnablePatches = true;
+	EnableFastBoot = true;
+	EnablePerGameSettings = true;
 	EnableRecordingTools = true;
 	EnableGameFixes = true;
 	InhibitScreensaver = true;
@@ -1348,6 +1350,9 @@ void Pcsx2Config::LoadSave(SettingsWrapper& wrap)
 	SettingsWrapBitBool(EnablePINE);
 	SettingsWrapBitBool(EnableWideScreenPatches);
 	SettingsWrapBitBool(EnableNoInterlacingPatches);
+	SettingsWrapBitBool(EnableFastBoot);
+	SettingsWrapBitBool(EnableFastBootFastForward);
+	SettingsWrapBitBool(EnablePerGameSettings);
 	SettingsWrapBitBool(EnableRecordingTools);
 	SettingsWrapBitBool(EnableGameFixes);
 	SettingsWrapBitBool(SaveStateOnShutdown);
@@ -1472,7 +1477,6 @@ bool Pcsx2Config::operator==(const Pcsx2Config& right) const
 void Pcsx2Config::CopyRuntimeConfig(Pcsx2Config& cfg)
 {
 	GS.LimitScalar = cfg.GS.LimitScalar;
-	UseBOOT2Injection = cfg.UseBOOT2Injection;
 	CurrentBlockdump = std::move(cfg.CurrentBlockdump);
 	CurrentIRX = std::move(cfg.CurrentIRX);
 	CurrentGameArgs = std::move(cfg.CurrentGameArgs);

--- a/pcsx2/R5900.h
+++ b/pcsx2/R5900.h
@@ -26,10 +26,6 @@ class BaseR5900Exception;
 // them in iR5900.h would mean having to include that into more files than I care to
 // right now, so we're sticking them here for now until a better solution comes along.
 
-extern bool g_SkipBiosHack;
-extern bool g_GameStarted;
-extern bool g_GameLoading;
-
 namespace Exception
 {
 	// Implementation Note: this exception has no meaningful type information and we don't
@@ -276,7 +272,6 @@ const u32 EELOAD_START		= 0x82000;
 const u32 EELOAD_SIZE		= 0x20000; // overestimate for searching
 extern u32 g_eeloadMain, g_eeloadExec;
 
-extern void eeGameStarting();
 extern void eeloadHook();
 extern void eeloadHook2();
 

--- a/pcsx2/R5900OpcodeImpl.cpp
+++ b/pcsx2/R5900OpcodeImpl.cpp
@@ -969,7 +969,7 @@ void SYSCALL()
 			AllowParams1 = true;
 			break;
 		case Syscall::GetOsdConfigParam:
-			if(!NoOSD && g_SkipBiosHack && !AllowParams1)
+			if(!NoOSD && !AllowParams1)
 			{
 				u32 memaddr = cpuRegs.GPR.n.a0.UL[0];
 				u8 params[16];
@@ -993,7 +993,7 @@ void SYSCALL()
 			AllowParams2 = true;
 			break;
 		case Syscall::GetOsdConfigParam2:
-			if (!NoOSD && g_SkipBiosHack && !AllowParams2)
+			if (!NoOSD && !AllowParams2)
 			{
 				u32 memaddr = cpuRegs.GPR.n.a0.UL[0];
 				u8 params[16];

--- a/pcsx2/Recording/InputRecording.cpp
+++ b/pcsx2/Recording/InputRecording.cpp
@@ -78,7 +78,7 @@ bool InputRecording::create(const std::string& fileName, const bool fromSaveStat
 
 	m_file.setEmulatorVersion();
 	m_file.setAuthor(authorName);
-	m_file.setGameName(resolveGameName());
+	m_file.setGameName(VMManager::GetTitle());
 	m_file.writeHeader();
 	initializeState();
 	InputRec::log("Started new input recording");
@@ -129,9 +129,9 @@ bool InputRecording::play(const std::string& filename)
 	initializeState();
 	InputRec::log("Replaying input recording");
 	m_file.logRecordingMetadata();
-	if (resolveGameName() != m_file.getGameName())
+	if (VMManager::GetTitle() != m_file.getGameName())
 	{
-		InputRec::consoleLog(fmt::format("Input recording was possibly constructed for a different game. Expected: {}, Actual: {}", m_file.getGameName(), resolveGameName()));
+		InputRec::consoleLog(fmt::format("Input recording was possibly constructed for a different game. Expected: {}, Actual: {}", m_file.getGameName(), VMManager::GetTitle()));
 	}
 	return true;
 }
@@ -227,21 +227,6 @@ void InputRecording::processRecordQueue()
 		m_recordingQueue.front()();
 		m_recordingQueue.pop();
 	}
-}
-
-std::string InputRecording::resolveGameName()
-{
-	std::string gameName;
-	const std::string gameKey = SysGetDiscID();
-	if (!gameKey.empty())
-	{
-		auto game = GameDatabase::findGame(gameKey);
-		if (game)
-		{
-			gameName = fmt::format("{} ({})", game->name, game->region);
-		}
-	}
-	return !gameName.empty() ? gameName : VMManager::GetGameName();
 }
 
 void InputRecording::incFrameCounter()

--- a/pcsx2/Recording/InputRecording.h
+++ b/pcsx2/Recording/InputRecording.h
@@ -70,11 +70,6 @@ private:
 	void initializeState();
 	void setStartingFrame(u32 startingFrame);
 	void closeActiveFile();
-
-private:
-	// Resolve the name and region of the game currently loaded using the GameDB
-	// If the game cannot be found in the DB, the fallback is the ISO filename
-	std::string resolveGameName();
 };
 
 extern InputRecording g_InputRecording;

--- a/pcsx2/SaveState.cpp
+++ b/pcsx2/SaveState.cpp
@@ -174,10 +174,10 @@ SaveStateBase& SaveStateBase::FreezeBios()
 
 SaveStateBase& SaveStateBase::FreezeInternals()
 {
-	const u32 previousCRC = ElfCRC;
-
 	// Print this until the MTVU problem in gifPathFreeze is taken care of (rama)
 	if (THREAD_VU1) Console.Warning("MTVU speedhack is enabled, saved states may not be stable");
+
+	vmFreeze();
 
 	// Second Block - Various CPU Registers and States
 	// -----------------------------------------------
@@ -188,30 +188,7 @@ SaveStateBase& SaveStateBase::FreezeInternals()
 	Freeze(tlb);			// tlbs
 	Freeze(AllowParams1);	//OSDConfig written (Fast Boot)
 	Freeze(AllowParams2);
-	Freeze(g_GameStarted);
-	Freeze(g_GameLoading);
-	Freeze(ElfCRC);
-
-	char localDiscSerial[256];
-	StringUtil::Strlcpy(localDiscSerial, DiscSerial.c_str(), sizeof(localDiscSerial));
-	Freeze(localDiscSerial);
-	if (IsLoading())
-	{
-		DiscSerial = localDiscSerial;
-
-		if (ElfCRC != previousCRC)
-		{
-			// HACK: LastELF isn't in the save state... Load it before we go too far into restoring state.
-			// When we next bump save states, we should include it. We need this for achievements, because
-			// we want to load and activate achievements before restoring any of their tracked state.
-			if (const std::string& elf_override = VMManager::Internal::GetElfOverride(); !elf_override.empty())
-				cdvdReloadElfInfo(fmt::format("host:{}", elf_override));
-			else
-				cdvdReloadElfInfo();
-		}
-	}
-
-
+	
 	// Third Block - Cycle Timers and Events
 	// -------------------------------------
 	FreezeTag( "Cycles" );

--- a/pcsx2/SaveState.h
+++ b/pcsx2/SaveState.h
@@ -36,7 +36,7 @@ enum class FreezeAction
 // [SAVEVERSION+]
 // This informs the auto updater that the users savestates will be invalidated.
 
-static const u32 g_SaveVersion = (0x9A36 << 16) | 0x0000;
+static const u32 g_SaveVersion = (0x9A37 << 16) | 0x0000;
 
 
 // the freezing data between submodules and core
@@ -147,6 +147,18 @@ public:
 		}
 	}
 
+	void FreezeString(std::string& s)
+	{
+		// overwritten when loading
+		u32 length = static_cast<u32>(s.length());
+		Freeze(length);
+
+		if (IsLoading())
+			s.resize(length);
+
+		FreezeMem(s.data(), length);
+	}
+
 	uint GetCurrentPos() const
 	{
 		return m_idx;
@@ -189,8 +201,7 @@ public:
 protected:
 	void Init( VmStateBuffer* memblock );
 
-	// Load/Save functions for the various components of our glorious emulator!
-
+	void vmFreeze();
 	void mtvuFreeze();
 	void rcntFreeze();
 	void vuMicroFreeze();

--- a/pcsx2/System.cpp
+++ b/pcsx2/System.cpp
@@ -346,34 +346,3 @@ void SysClearExecutionCache()
 		dVifReset(1);
 	}
 }
-
-// This function returns part of EXTINFO data of the BIOS rom
-// This module contains information about Sony build environment at offst 0x10
-// first 15 symbols is build date/time that is unique per rom and can be used as unique serial
-// Example for romver 0160EC20010704
-// 20010704-160707,ROMconf,PS20160EC20010704.bin,kuma@rom-server/~/f10k/g/app/rom
-// 20010704-160707 can be used as unique ID for Bios
-std::string SysGetBiosDiscID()
-{
-	if (!BiosSerial.empty())
-		return BiosSerial;
-	else
-		return {};
-}
-
-// This function always returns a valid DiscID -- using the Sony serial when possible, and
-// falling back on the CRC checksum of the ELF binary if the PS2 software being run is
-// homebrew or some other serial-less item.
-std::string SysGetDiscID()
-{
-	if (!DiscSerial.empty())
-		return DiscSerial;
-
-	if (!ElfCRC)
-	{
-		// system is currently running the BIOS
-		return SysGetBiosDiscID();
-	}
-
-	return StringUtil::StdStringFromFormat("%08x", ElfCRC);
-}

--- a/pcsx2/System.h
+++ b/pcsx2/System.h
@@ -144,9 +144,6 @@ extern SysCpuProviderPack& GetCpuProviders();
 extern void SysLogMachineCaps();		// Detects cpu type and fills cpuInfo structs.
 extern void SysClearExecutionCache();	// clears recompiled execution caches!
 
-extern std::string SysGetBiosDiscID();
-extern std::string SysGetDiscID();
-
 extern SysMainMemory& GetVmMemory();
 
 extern void SetCPUState(SSE_MXCSR sseMXCSR, SSE_MXCSR sseVU0MXCSR, SSE_MXCSR sseVU1MXCSR);

--- a/pcsx2/USB/usb-lightgun/guncon2.cpp
+++ b/pcsx2/USB/usb-lightgun/guncon2.cpp
@@ -332,7 +332,7 @@ namespace usb_lightgun
 
 	void GunCon2State::AutoConfigure()
 	{
-		const std::string serial(VMManager::GetGameSerial());
+		const std::string serial = VMManager::GetDiscSerial();
 		for (const GameConfig& gc : s_game_config)
 		{
 			if (serial != gc.serial)

--- a/pcsx2/VMManager.h
+++ b/pcsx2/VMManager.h
@@ -74,14 +74,23 @@ namespace VMManager
 	/// Returns the path of the disc currently running.
 	std::string GetDiscPath();
 
-	/// Returns the crc of the executable currently running.
-	u32 GetGameCRC();
+	/// Returns the serial of the disc currently running.
+	std::string GetDiscSerial();
 
-	/// Returns the serial of the disc/executable currently running.
-	std::string GetGameSerial();
+	/// Returns the path of the main ELF of the disc currently running.
+	std::string GetDiscELF();
 
 	/// Returns the name of the disc/executable currently running.
-	std::string GetGameName();
+	std::string GetTitle();
+
+	/// Returns the CRC for the main ELF of the disc currently running.
+	u32 GetDiscCRC();
+
+	/// Returns the version of the disc currently running.
+	std::string GetDiscVersion();
+
+	/// Returns the crc of the executable currently running.
+	u32 GetCurrentCRC();
 
 	/// Loads global settings (i.e. EmuConfig).
 	void LoadSettings();
@@ -106,6 +115,9 @@ namespace VMManager
 
 	/// Reloads game specific settings, and applys any changes present.
 	bool ReloadGameSettings();
+
+	/// Reloads game patches.
+	void ReloadPatches(bool reload_files, bool reload_enabled_list, bool verbose, bool verbose_if_changed);
 
 	/// Returns the save state filename for the given game serial/crc.
 	std::string GetSaveStateFileName(const char* game_serial, u32 game_crc, s32 slot);
@@ -215,11 +227,22 @@ namespace VMManager
 		/// Updates the variables in the EmuFolders namespace, reloading subsystems if needed.
 		void UpdateEmuFolders();
 
-		const std::string& GetElfOverride();
+		/// Returns true if fast booting is active (requested but ELF not started).
+		bool IsFastBootInProgress();
+
+		/// Disables fast boot if it was requested, and found to be incompatible.
+		void DisableFastBoot();
+
+		/// Returns true if the current ELF has started executing.
+		bool HasBootedELF();
+
+		/// Returns the PC of the currently-executing ELF's entry point.
+		u32 GetCurrentELFEntryPoint();
+
+		const std::string& GetELFOverride();
 		bool IsExecutionInterrupted();
+		void ELFLoadingOnCPUThread(std::string elf_path);
 		void EntryPointCompilingOnCPUThread();
-		void GameStartingOnCPUThread();
-		void SwappingGameOnCPUThread();
 		void VSyncOnCPUThread();
 	} // namespace Internal
 } // namespace VMManager
@@ -262,8 +285,8 @@ namespace Host
 	void OnSaveStateSaved(const std::string_view& filename);
 
 	/// Provided by the host; called when the running executable changes.
-	void OnGameChanged(const std::string& disc_path, const std::string& elf_override, const std::string& game_serial,
-		const std::string& game_name, u32 game_crc);
+	void OnGameChanged(const std::string& title, const std::string& elf_override, const std::string& disc_path,
+		const std::string& disc_serial, u32 disc_crc, u32 current_crc);
 
 	/// Provided by the host; called once per frame at guest vsync.
 	void VSyncOnCPUThread();

--- a/pcsx2/ps2/BiosTools.cpp
+++ b/pcsx2/ps2/BiosTools.cpp
@@ -54,9 +54,11 @@ bool NoOSD;
 bool AllowParams1;
 bool AllowParams2;
 std::string BiosDescription;
+std::string BiosZone;
 std::string BiosSerial;
 std::string BiosPath;
 BiosDebugInformation CurrentBiosInformation;
+std::vector<u8> BiosRom;
 
 static bool LoadBiosVersion(std::FILE* fp, u32& version, std::string& description, u32& region, std::string& zone, std::string& serial)
 {
@@ -177,12 +179,12 @@ static bool LoadBiosVersion(std::FILE* fp, u32& version, std::string& descriptio
 	return true;
 }
 
-template <size_t _size>
-void ChecksumIt(u32& result, const u8 (&srcdata)[_size])
+static void ChecksumIt(u32& result, u32 offset, u32 size)
 {
-	pxAssume((_size & 3) == 0);
-	for (size_t i = 0; i < _size / 4; ++i)
-		result ^= ((u32*)srcdata)[i];
+	const u8* srcdata = &BiosRom[offset];
+	pxAssume((size & 3) == 0);
+	for (size_t i = 0; i < size / 4; ++i)
+		result ^= reinterpret_cast<const u32*>(srcdata)[i];
 }
 
 // Attempts to load a BIOS rom sub-component, by trying multiple combinations of base
@@ -192,8 +194,7 @@ void ChecksumIt(u32& result, const u8 (&srcdata)[_size])
 // Parameters:
 //   ext - extension of the sub-component to load. Valid options are rom1 and rom2.
 //
-template <size_t _size>
-static void LoadExtraRom(const char* ext, u8 (&dest)[_size])
+static void LoadExtraRom(const char* ext, u32 offset, u32 size)
 {
 	// Try first a basic extension concatenation (normally results in something like name.bin.rom1)
 	std::string Bios1(StringUtil::StdStringFromFormat("%s.%s", BiosPath.c_str(), ext));
@@ -210,8 +211,10 @@ static void LoadExtraRom(const char* ext, u8 (&dest)[_size])
 		}
 	}
 
+	BiosRom.resize(offset + size);
+
 	auto fp = FileSystem::OpenManagedCFile(Bios1.c_str(), "rb");
-	if (!fp || std::fread(dest, static_cast<size_t>(std::min<s64>(_size, filesize)), 1, fp.get()) != 1)
+	if (!fp || std::fread(&BiosRom[offset], static_cast<size_t>(std::min<s64>(size, filesize)), 1, fp.get()) != 1)
 	{
 		Console.Warning("BIOS Warning: %s could not be read (permission denied?)", ext);
 		return;
@@ -261,6 +264,29 @@ static std::string FindBiosImage()
 	return std::string();
 }
 
+bool IsBIOS(const char* filename, u32& version, std::string& description, u32& region, std::string& zone)
+{
+	std::string serial;
+	const auto fp = FileSystem::OpenManagedCFile(filename, "rb");
+	if (!fp)
+		return false;
+
+	// FPS2BIOS is smaller and of variable size
+	//if (inway.Length() < 512*1024) return false;
+	return LoadBiosVersion(fp.get(), version, description, region, zone, serial);
+}
+
+bool IsBIOSAvailable(const std::string& full_path)
+{
+	// We can't use EmuConfig here since it may not be loaded yet.
+	if (!full_path.empty() && FileSystem::FileExists(full_path.c_str()))
+		return true;
+
+	// No bios configured or the configured name is missing, check for one in the BIOS directory.
+	const std::string auto_path(FindBiosImage());
+	return !auto_path.empty() && FileSystem::FileExists(auto_path.c_str());
+}
+
 // Loads the configured bios rom file into PS2 memory.  PS2 memory must be allocated prior to
 // this method being called.
 //
@@ -297,11 +323,12 @@ bool LoadBIOS()
 	if (filesize <= 0)
 		return false;
 
-	std::string zone;
-	LoadBiosVersion(fp.get(), BiosVersion, BiosDescription, BiosRegion, zone, BiosSerial);
+	LoadBiosVersion(fp.get(), BiosVersion, BiosDescription, BiosRegion, BiosZone, BiosSerial);
+
+	BiosRom.resize(Ps2MemSize::Rom);
 
 	if (FileSystem::FSeek64(fp.get(), 0, SEEK_SET) ||
-		std::fread(eeMem->ROM, static_cast<size_t>(std::min<s64>(Ps2MemSize::Rom, filesize)), 1, fp.get()) != 1)
+		std::fread(BiosRom.data(), static_cast<size_t>(std::min<s64>(Ps2MemSize::Rom, filesize)), 1, fp.get()) != 1)
 	{
 		return false;
 	}
@@ -314,40 +341,31 @@ bool LoadBIOS()
 		NoOSD = false;
 
 	BiosChecksum = 0;
-	ChecksumIt(BiosChecksum, eeMem->ROM);
+	ChecksumIt(BiosChecksum, 0, Ps2MemSize::Rom);
 	BiosPath = std::move(path);
 
 	//injectIRX("host.irx");	//not fully tested; still buggy
 
-	LoadExtraRom("rom1", eeMem->ROM1);
-	LoadExtraRom("rom2", eeMem->ROM2);
+	LoadExtraRom("rom1", Ps2MemSize::Rom, Ps2MemSize::Rom1);
+	LoadExtraRom("rom2", Ps2MemSize::Rom + Ps2MemSize::Rom1, Ps2MemSize::Rom2);
+	return true;
+}
+
+void CopyBIOSToMemory()
+{
+	if (BiosRom.size() >= Ps2MemSize::Rom)
+	{
+		std::memcpy(eeMem->ROM, BiosRom.data(), sizeof(eeMem->ROM));
+		if (BiosRom.size() >= (Ps2MemSize::Rom + Ps2MemSize::Rom1))
+		{
+			std::memcpy(eeMem->ROM1, BiosRom.data() + Ps2MemSize::Rom, sizeof(eeMem->ROM1));
+			if (BiosRom.size() >= (Ps2MemSize::Rom + Ps2MemSize::Rom1 + Ps2MemSize::Rom2))
+				std::memcpy(eeMem->ROM2, BiosRom.data() + Ps2MemSize::Rom + Ps2MemSize::Rom1, sizeof(eeMem->ROM2));
+		}
+	}
 
 	if (EmuConfig.CurrentIRX.length() > 3)
 		LoadIrx(EmuConfig.CurrentIRX, &eeMem->ROM[0x3C0000], sizeof(eeMem->ROM) - 0x3C0000);
 
 	CurrentBiosInformation.eeThreadListAddr = 0;
-	return true;
-}
-
-bool IsBIOS(const char* filename, u32& version, std::string& description, u32& region, std::string& zone)
-{
-	std::string serial;
-	const auto fp = FileSystem::OpenManagedCFile(filename, "rb");
-	if (!fp)
-		return false;
-
-	// FPS2BIOS is smaller and of variable size
-	//if (inway.Length() < 512*1024) return false;
-	return LoadBiosVersion(fp.get(), version, description, region, zone, serial);
-}
-
-bool IsBIOSAvailable(const std::string& full_path)
-{
-	// We can't use EmuConfig here since it may not be loaded yet.
-	if (!full_path.empty() && FileSystem::FileExists(full_path.c_str()))
-		return true;
-
-	// No bios configured or the configured name is missing, check for one in the BIOS directory.
-	const std::string auto_path(FindBiosImage());
-	return !auto_path.empty() && FileSystem::FileExists(auto_path.c_str());
 }

--- a/pcsx2/ps2/BiosTools.h
+++ b/pcsx2/ps2/BiosTools.h
@@ -1,5 +1,5 @@
 /*  PCSX2 - PS2 Emulator for PCs
- *  Copyright (C) 2002-2010  PCSX2 Dev Team
+ *  Copyright (C) 2002-2023  PCSX2 Dev Team
  *
  *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU Lesser General Public License as published by the Free Software Found-
@@ -14,7 +14,9 @@
  */
 
 #pragma once
+
 #include <string>
+#include <vector>
 
 const u32 ThreadListInstructions[3] =
 {
@@ -30,6 +32,7 @@ struct BiosDebugInformation
 	u32 iopModListAddr;
 };
 
+// TODO: namespace this
 extern BiosDebugInformation CurrentBiosInformation;
 extern u32 BiosVersion;		// Used by CDVD
 extern u32 BiosRegion;		// Used by CDVD
@@ -38,9 +41,23 @@ extern bool AllowParams1;
 extern bool AllowParams2;
 extern u32 BiosChecksum;
 extern std::string BiosDescription;
+extern std::string BiosZone;
+
+// This function returns part of EXTINFO data of the BIOS rom
+// This module contains information about Sony build environment at offst 0x10
+// first 15 symbols is build date/time that is unique per rom and can be used as unique serial
+// Example for romver 0160EC20010704
+// 20010704-160707,ROMconf,PS20160EC20010704.bin,kuma@rom-server/~/f10k/g/app/rom
+// 20010704-160707 can be used as unique ID for Bios
 extern std::string BiosSerial;
 extern std::string BiosPath;
-extern bool LoadBIOS();
+
+// Copies of the BIOS ROM. Because the EE can write to the ROM area, we need to copy it on reset.
+// If we ever support read-only physical mappings, we can remove this.
+extern std::vector<u8> BiosRom;
+
 extern bool IsBIOS(const char* filename, u32& version, std::string& description, u32& region, std::string& zone);
 extern bool IsBIOSAvailable(const std::string& full_path);
 
+extern bool LoadBIOS();
+extern void CopyBIOSToMemory();

--- a/pcsx2/x86/ix86-32/iR5900-32.cpp
+++ b/pcsx2/x86/ix86-32/iR5900-32.cpp
@@ -2220,6 +2220,9 @@ static void recRecompile(const u32 startpc)
 	if (recPtr >= (recMem->GetPtrEnd() - _64kb))
 		eeRecNeedsReset = true;
 
+	if (HWADDR(startpc) == VMManager::Internal::GetCurrentELFEntryPoint())
+		VMManager::Internal::EntryPointCompilingOnCPUThread();
+
 	if (eeRecNeedsReset)
 	{
 		eeRecNeedsReset = false;
@@ -2228,9 +2231,6 @@ static void recRecompile(const u32 startpc)
 
 	xSetPtr(recPtr);
 	recPtr = xGetAlignedCallTarget();
-
-	if (0x8000d618 == startpc)
-		DbgCon.WriteLn("Compiling block @ 0x%08x", startpc);
 
 	s_pCurBlock = PC_GETBLOCK(startpc);
 
@@ -2254,7 +2254,7 @@ static void recRecompile(const u32 startpc)
 	if (g_eeloadMain && HWADDR(startpc) == HWADDR(g_eeloadMain))
 	{
 		xFastCall((void*)eeloadHook);
-		if (g_SkipBiosHack)
+		if (VMManager::Internal::IsFastBootInProgress())
 		{
 			// There are four known versions of EELOAD, identifiable by the location of the 'jal' to the EELOAD function which
 			// calls ExecPS2(). The function itself is at the same address in all BIOSs after v1.00-v1.10.
@@ -2273,14 +2273,6 @@ static void recRecompile(const u32 startpc)
 
 	if (g_eeloadExec && HWADDR(startpc) == HWADDR(g_eeloadExec))
 		xFastCall((void*)eeloadHook2);
-
-	// this is the only way patches get applied, doesn't depend on a hack
-	if (g_GameLoading && HWADDR(startpc) == ElfEntry)
-	{
-		Console.WriteLn("Elf entry point @ 0x%08x about to get recompiled. Load patches first.", startpc);
-		xFastCall((void*)eeGameStarting);
-		VMManager::Internal::EntryPointCompilingOnCPUThread();
-	}
 
 	g_branch = 0;
 

--- a/tests/ctest/core/StubHost.cpp
+++ b/tests/ctest/core/StubHost.cpp
@@ -137,8 +137,8 @@ void Host::OnVMResumed()
 {
 }
 
-void Host::OnGameChanged(const std::string& disc_path, const std::string& elf_override, const std::string& game_serial,
-	const std::string& game_name, u32 game_crc)
+void Host::OnGameChanged(const std::string& title, const std::string& elf_override, const std::string& disc_path,
+		const std::string& disc_serial, u32 disc_crc, u32 current_crc)
 {
 }
 


### PR DESCRIPTION
### Description of Changes

 - Serial/title is now linked to disc, instead of running ELF.
 - Save states can be created during BIOS boot.
 - Patches now apply based on the executing CRC, and only after the entry point starts executing (fixes multi-game discs).
 - Add "Fast Forward Boot" option.
 - Split achievements download and activation, downloads occur on initialization, but are not activated until after the ELF loads.
 - Prevent HostFS access while in PS1 mode.
 - Remove multiple sources of truth for ELF/CRC/etc.
 - Move ELF state from global scope to VMManager.
 - Prevent game fixes and hw fixes being active while booting game.
 - Simplify game update.
 - Flush recompilers after ELF loads. No point keeping boot code around which gets overwritten.

### Rationale behind Changes

More wx cleanup. Less jank.

Stops games like Burnout 3's NFSU2 demo from crashing if you have widescreen patches enabled.

Gets rid of confusing "Booting PS2 BIOS" which is a holdout from the wx days, instead we load game settings at boot time.

### Suggested Testing Steps

 - Test cheats and ws patches.
 - Test demo discs (e.g. Burnout above).
 - Test achievements, make sure they still work.
 - Make sure per-game settings still work, including per-game renderer.
 - Hammer save states a bit. Try save stating while booting.
 - Make sure the interpreter still works. I haven't tested that.
 - Make sure disc swapping still works.