### PR TITLE
GS/HW: Make Haunting Ground render fix invalidate depth as well

### DIFF
--- a/pcsx2/GS/GSUtil.cpp
+++ b/pcsx2/GS/GSUtil.cpp
@@ -196,6 +196,16 @@ u32 GSUtil::GetChannelMask(u32 spsm)
 	}
 }
 
+u32 GSUtil::GetChannelMask(u32 spsm, u32 fbmsk)
+{
+	u32 mask = GetChannelMask(spsm);
+	mask &= (fbmsk & 0xFF) ? (~0x1 & 0xf) : 0xf;
+	mask &= (fbmsk & 0xFF00) ? (~0x2 & 0xf) : 0xf;
+	mask &= (fbmsk & 0xFF0000) ? (~0x4 & 0xf) : 0xf;
+	mask &= (fbmsk & 0xFF000000) ? (~0x8 & 0xf) : 0xf;
+	return mask;
+}
+
 GSRendererType GSUtil::GetPreferredRenderer()
 {
 #if defined(__APPLE__)

--- a/pcsx2/GS/GSUtil.h
+++ b/pcsx2/GS/GSUtil.h
@@ -34,6 +34,7 @@ public:
 	static bool HasCompatibleBits(u32 spsm, u32 dpsm);
 	static bool HasSameSwizzleBits(u32 spsm, u32 dpsm);
 	static u32 GetChannelMask(u32 spsm);
+	static u32 GetChannelMask(u32 spsm, u32 fbmsk);
 
 	static GSRendererType GetPreferredRenderer();
 };

--- a/pcsx2/GS/Renderers/Common/GSDirtyRect.h
+++ b/pcsx2/GS/Renderers/Common/GSDirtyRect.h
@@ -19,6 +19,7 @@
 
 union RGBAMask
 {
+	u32 _u32;
 	struct
 	{
 		u32 r : 1;
@@ -26,7 +27,6 @@ union RGBAMask
 		u32 b : 1;
 		u32 a : 1;
 	} c;
-	u32 _u32;
 };
 
 class GSDirtyRect

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -2924,29 +2924,6 @@ void GSTextureCache::InvalidateVideoMemSubTarget(GSTextureCache::Target* rt)
 	}
 }
 
-void GSTextureCache::InvalidateVideoMemTargets(int type, u32 bp, u32 bw, u32 psm, const GSVector4i& r)
-{
-	auto& list = m_dst[type];
-
-	for (auto i = list.begin(); i != list.end();)
-	{
-		GSTextureCache::Target* t = *i;
-		auto ei = i++;
-
-		if (t->m_TEX0.TBP0 != bp && t->Overlaps(bp, bw, psm, r))
-		{
-			GL_CACHE("InvalidateVideoMemTargets(%x, %u, %s, %d,%d => %d,%d): Removing target at %x %u %s", bp, bw,
-				psm_str(psm), r.x, r.y, r.z, r.w, t->m_TEX0.TBP0, t->m_TEX0.TBW, psm_str(t->m_TEX0.PSM));
-
-			// Need to also remove any sources which reference this target.
-			InvalidateSourcesFromTarget(t);
-
-			list.erase(ei);
-			delete t;
-		}
-	}
-}
-
 void GSTextureCache::InvalidateSourcesFromTarget(const Target* t)
 {
 	for (auto it = m_src.m_surfaces.begin(); it != m_src.m_surfaces.end();)

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.h
@@ -22,6 +22,8 @@
 #include "GS/Renderers/Common/GSDirtyRect.h"
 #include <unordered_set>
 
+class GSHwHack;
+
 // Only for debugging. Reads back every target to local memory after drawing, effectively
 // disabling caching between draws.
 //#define DISABLE_HW_TEXTURE_CACHE
@@ -29,6 +31,8 @@
 class GSTextureCache
 {
 public:
+	friend GSHwHack;
+
 	enum
 	{
 		RenderTarget,
@@ -466,9 +470,6 @@ public:
 	void InvalidateVideoMemSubTarget(GSTextureCache::Target* rt);
 	void InvalidateVideoMem(const GSOffset& off, const GSVector4i& r, bool eewrite = false, bool target = true);
 	void InvalidateLocalMem(const GSOffset& off, const GSVector4i& r, bool full_flush = false);
-
-	/// Removes any targets overlapping the specified BP and rectangle.
-	void InvalidateVideoMemTargets(int type, u32 bp, u32 bw, u32 psm, const GSVector4i& r);
 
 	/// Removes any sources which point to the specified target.
 	void InvalidateSourcesFromTarget(const Target* t);


### PR DESCRIPTION
### Description of Changes

Fixes depth leaking into the image.

Game's an ass. See the comment in the source.

Note to myself: my clear PR currently doesn't negate the need for this fix... need to dig further into why.

### Rationale behind Changes

Closes #8976.

### Suggested Testing Steps

Test Haunting Ground. The 3 dumps I have seem okay.