### PR TITLE
GameDB: Xenosaga Ep 1 - Attempt to use quality level 100 as a base

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -7283,7 +7283,7 @@ SCPS-55901:
         // was simply to exit the game completely.
         comment=Save Point Crash Prevention
         author=pandubz, PSI, turtleli
-        patch=1,EE,00285f44,word,2413001e
+        patch=1,EE,00285f44,word,24130064
         patch=1,EE,00285f48,word,8f85ab00
         patch=1,EE,00285f4c,word,26640000
         patch=1,EE,00285f50,word,0c0935a8
@@ -41781,7 +41781,7 @@ SLPS-29001:
         // was simply to exit the game completely.
         comment=Save Point Crash Prevention
         author=pandubz, PSI, turtleli
-        patch=1,EE,00285f44,word,2413001e
+        patch=1,EE,00285f44,word,24130064
         patch=1,EE,00285f48,word,8f85ab00
         patch=1,EE,00285f4c,word,26640000
         patch=1,EE,00285f50,word,0c0935a8
@@ -41806,7 +41806,7 @@ SLPS-29002:
         // was simply to exit the game completely.
         comment=Save Point Crash Prevention
         author=pandubz, PSI, turtleli
-        patch=1,EE,00285f44,word,2413001e
+        patch=1,EE,00285f44,word,24130064
         patch=1,EE,00285f48,word,8f85ab00
         patch=1,EE,00285f4c,word,26640000
         patch=1,EE,00285f50,word,0c0935a8
@@ -42459,7 +42459,7 @@ SLPS-73901:
         // was simply to exit the game completely.
         comment=Save Point Crash Prevention
         author=pandubz, PSI, turtleli
-        patch=1,EE,00285f44,word,2413001e
+        patch=1,EE,00285f44,word,24130064
         patch=1,EE,00285f48,word,8f85ab00
         patch=1,EE,00285f4c,word,26640000
         patch=1,EE,00285f50,word,0c0935a8
@@ -44499,7 +44499,7 @@ SLUS-20469:
         // was simply to exit the game completely.
         comment=Save Point Crash Prevention
         author=pandubz, PSI, turtleli
-        patch=1,EE,00289dac,word,2413001e
+        patch=1,EE,00289dac,word,24130064
         patch=1,EE,00289db0,word,8f85af40
         patch=1,EE,00289db4,word,26640000
         patch=1,EE,00289db8,word,0c093746


### PR DESCRIPTION
Patch still decrements until satisfactory level

### Description of Changes
Use higher quality level as a baseline.

### Rationale behind Changes
Makes thumbnails nicer if the output size can handle it, still shrinks if too big.

### Suggested Testing Steps
Save the game a few times, see what happens.

Side note: Our discovery is the JPEG scuff on the sides of the thumbnails is NOT JPEG scuff. It is GS memory. If you upscale, the GS memory will bleed in to the frame. Don't upscale, no JPEG scuff.
