### PR TITLE
GameDB: Various fixes

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -25653,6 +25653,9 @@ SLPM-55005:
     roundSprite: 1 # Fixes lines in sprites but still some lines left.
   speedHacks:
     mvuFlagSpeedHack: 0 # Fixes missing graphical effects.
+SLPM-55006:
+  name: "Akane-iro ni Somaru Saka - Parallel"
+  region: "NTSC-J"
 SLPM-55008:
   name: "Sengoku Basara X"
   region: "NTSC-J"
@@ -48485,6 +48488,7 @@ SLUS-21236:
   compat: 5
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
+    wildArmsHack: 1 # Fixes double image.
 SLUS-21237:
   name: "AND 1 Streetball"
   region: "NTSC-U"

--- a/pcsx2-qt/Settings/BIOSSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/BIOSSettingsWidget.cpp
@@ -44,7 +44,7 @@ BIOSSettingsWidget::BIOSSettingsWidget(SettingsDialog* dialog, QWidget* parent)
 	dialog->registerWidgetHelp(m_ui.fastBoot, tr("Fast Boot"), tr("Checked"),
 		tr("Patches the BIOS to skip the console's boot animation."));
 
-	dialog->registerWidgetHelp(m_ui.fastBoot, tr("Fast Forward Boot"), tr("Unchecked"),
+	dialog->registerWidgetHelp(m_ui.fastBootFastForward, tr("Fast Forward Boot"), tr("Unchecked"),
 		tr("Removes emulation speed throttle until the game starts to reduce startup time."));
 
 	refreshList();


### PR DESCRIPTION
### Description of Changes
Fixes for double image in Tokyo Xtreme Racer DRIFT and a missing serial also fixes a copy pasta error in fast forward boot.

### Rationale behind Changes
Mistake not very good.

### Suggested Testing Steps
Make sure CI is happy.
