### PR TITLE
GS: Fix up overscan offsets. Stop using 3:2 for overscan.

### DIFF
--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -312,8 +312,8 @@ public:
 		};
 
 		static inline constexpr GSVector4i VideoModeOffsetsOverscan[6] = {
-			GSVector4i::cxpr(711, 243, 498, 12),
-			GSVector4i::cxpr(702, 288, 532, 18),
+			GSVector4i::cxpr(711, 240, 498, 17),
+			GSVector4i::cxpr(711, 288, 532, 21),
 			GSVector4i::cxpr(640, 480, 276, 34),
 			GSVector4i::cxpr(720, 480, 232, 35),
 			GSVector4i::cxpr(1280, 720, 302, 24),

--- a/pcsx2/GS/Renderers/Common/GSRenderer.cpp
+++ b/pcsx2/GS/Renderers/Common/GSRenderer.cpp
@@ -603,7 +603,7 @@ void GSRenderer::VSync(u32 field, bool registers_written, bool idle_frame)
 		src_uv = GSVector4(src_rect) / GSVector4(current->GetSize()).xyxy();
 		draw_rect = CalculateDrawDstRect(g_gs_device->GetWindowWidth(), g_gs_device->GetWindowHeight(),
 			src_rect, current->GetSize(), s_display_alignment, g_gs_device->UsesLowerLeftOrigin(),
-			GetVideoMode() == GSVideoMode::SDTV_480P || (GSConfig.PCRTCOverscan && GSConfig.PCRTCOffsets));
+			GetVideoMode() == GSVideoMode::SDTV_480P);
 		s_last_draw_rect = draw_rect;
 
 		if (GSConfig.CASMode != GSCASMode::Disabled)
@@ -850,7 +850,7 @@ void GSRenderer::PresentCurrentFrame()
 			const GSVector4 src_uv(GSVector4(src_rect) / GSVector4(current->GetSize()).xyxy());
 			const GSVector4 draw_rect(CalculateDrawDstRect(g_gs_device->GetWindowWidth(), g_gs_device->GetWindowHeight(),
 				src_rect, current->GetSize(), s_display_alignment, g_gs_device->UsesLowerLeftOrigin(),
-				GetVideoMode() == GSVideoMode::SDTV_480P || (GSConfig.PCRTCOverscan && GSConfig.PCRTCOffsets)));
+				GetVideoMode() == GSVideoMode::SDTV_480P));
 			s_last_draw_rect = draw_rect;
 
 			const u64 current_time = Common::Timer::GetCurrentValue();
@@ -893,7 +893,7 @@ bool GSRenderer::BeginCapture(std::string filename)
 											GSVector2i(GSConfig.VideoCaptureWidth, GSConfig.VideoCaptureHeight));
 
 	return GSCapture::BeginCapture(GetTvRefreshRate(), capture_resolution,
-		GetCurrentAspectRatioFloat(GetVideoMode() == GSVideoMode::SDTV_480P || (GSConfig.PCRTCOverscan && GSConfig.PCRTCOffsets)),
+		GetCurrentAspectRatioFloat(GetVideoMode() == GSVideoMode::SDTV_480P),
 		std::move(filename));
 }
 
@@ -927,7 +927,7 @@ bool GSRenderer::SaveSnapshotToMemory(u32 window_width, u32 window_height, bool 
 	const GSVector4i src_rect(CalculateDrawSrcRect(current));
 	const GSVector4 src_uv(GSVector4(src_rect) / GSVector4(current->GetSize()).xyxy());
 
-	const bool is_progressive = (GetVideoMode() == GSVideoMode::SDTV_480P || (GSConfig.PCRTCOverscan && GSConfig.PCRTCOffsets));
+	const bool is_progressive = (GetVideoMode() == GSVideoMode::SDTV_480P);
 	GSVector4 draw_rect;
 	if (window_width == 0 || window_height == 0)
 	{

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -550,7 +550,7 @@ void VMManager::RequestDisplaySize(float scale /*= 0.0f*/)
 	switch (GSConfig.AspectRatio)
 	{
 		case AspectRatioType::RAuto4_3_3_2:
-			if (GSgetDisplayMode() == GSVideoMode::SDTV_480P || (GSConfig.PCRTCOverscan && GSConfig.PCRTCOffsets))
+			if (GSgetDisplayMode() == GSVideoMode::SDTV_480P)
 				x_scale = (3.0f / 2.0f) / (static_cast<float>(iwidth) / static_cast<float>(iheight));
 			else
 				x_scale = (4.0f / 3.0f) / (static_cast<float>(iwidth) / static_cast<float>(iheight));


### PR DESCRIPTION
### Description of Changes
Fixes up the offsets for overscan modes and correctly stays in 4:3 when overscanning, closer matching the PS2

### Rationale behind Changes
Numbers were quite a bit off, causing a weird vertical offset.  and I don't know where I hit my head to think I needed to change aspect. Closer matches PS2 output now.

### Suggested Testing Steps
None really, just PRing for the CI then merge, already gone through it on Discord with Nicknine.


Before:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/b3fd6dde-2d34-4a23-a62d-8080d4045241)

After:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/8107a7db-9fc9-4f04-9db7-d6300fd8c186)

PS2 output through capture (with exagerated gamma/greenness so you can see the borders):
![image](https://github.com/PCSX2/pcsx2/assets/6278726/740d57a5-e8f5-4134-8f04-8ee36819073c)


