### PR TITLE
GS: Use 32-bit vertex positions for culling

### DIFF
--- a/pcsx2/GS/GSDrawingContext.h
+++ b/pcsx2/GS/GSDrawingContext.h
@@ -39,8 +39,8 @@ public:
 	struct
 	{
 		GSVector4i in;
-		GSVector4i ex;
-		GSVector4i ofxy;
+		GSVector4i cull;
+		GSVector4i xyof;
 	} scissor;
 
 	struct
@@ -50,50 +50,11 @@ public:
 		GSPixelOffset4* fzb4;
 	} offset;
 
-	GSDrawingContext()
-	{
-		memset(&offset, 0, sizeof(offset));
+	GSDrawingContext();
 
-		Reset();
-	}
+	void Reset();
 
-	void Reset()
-	{
-		memset(&XYOFFSET, 0, sizeof(XYOFFSET));
-		memset(&TEX0, 0, sizeof(TEX0));
-		memset(&TEX1, 0, sizeof(TEX1));
-		memset(&CLAMP, 0, sizeof(CLAMP));
-		memset(&MIPTBP1, 0, sizeof(MIPTBP1));
-		memset(&MIPTBP2, 0, sizeof(MIPTBP2));
-		memset(&SCISSOR, 0, sizeof(SCISSOR));
-		memset(&ALPHA, 0, sizeof(ALPHA));
-		memset(&TEST, 0, sizeof(TEST));
-		memset(&FBA, 0, sizeof(FBA));
-		memset(&FRAME, 0, sizeof(FRAME));
-		memset(&ZBUF, 0, sizeof(ZBUF));
-	}
-
-	void UpdateScissor()
-	{
-		ASSERT(XYOFFSET.OFX <= 0xf800 && XYOFFSET.OFY <= 0xf800);
-
-		scissor.ex.U16[0] = (u16)((SCISSOR.SCAX0 << 4) + XYOFFSET.OFX - 0x8000);
-		scissor.ex.U16[1] = (u16)((SCISSOR.SCAY0 << 4) + XYOFFSET.OFY - 0x8000);
-		scissor.ex.U16[2] = (u16)((SCISSOR.SCAX1 << 4) + XYOFFSET.OFX - 0x8000);
-		scissor.ex.U16[3] = (u16)((SCISSOR.SCAY1 << 4) + XYOFFSET.OFY - 0x8000);
-
-		scissor.in = GSVector4i(
-			(int)SCISSOR.SCAX0,
-			(int)SCISSOR.SCAY0,
-			(int)SCISSOR.SCAX1 + 1,
-			(int)SCISSOR.SCAY1 + 1);
-
-		scissor.ofxy = GSVector4i(
-			0x8000,
-			0x8000,
-			(int)XYOFFSET.OFX - 15,
-			(int)XYOFFSET.OFY - 15);
-	}
+	void UpdateScissor();
 
 	GIFRegTEX0 GetSizeFixedTEX0(const GSVector4& st, bool linear, bool mipmap = false) const;
 

--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -141,15 +141,17 @@ private:
 protected:
 	GSVertex m_v = {};
 	float m_q = 1.0f;
-	GSVector4i m_scissor = {};
-	GSVector4i m_ofxy = {};
+	GSVector4i m_scissor_cull_min = {};
+	GSVector4i m_scissor_cull_max = {};
+	GSVector4i m_xyof = {};
 
 	struct
 	{
 		GSVertex* buff;
 		u32 head, tail, next, maxcount; // head: first vertex, tail: last vertex + 1, next: last indexed + 1
 		u32 xy_tail;
-		u64 xy[4];
+		GSVector4i xy[4];
+		GSVector4i xyhead;
 	} m_vertex = {};
 
 	struct

--- a/pcsx2/GS/GSVector4i.h
+++ b/pcsx2/GS/GSVector4i.h
@@ -969,6 +969,11 @@ public:
 		return GSVector4i(_mm_cmpeq_epi32(m, v.m));
 	}
 
+	__forceinline GSVector4i eq64(const GSVector4i& v) const
+	{
+		return GSVector4i(_mm_cmpeq_epi64(m, v.m));
+	}
+
 	__forceinline GSVector4i neq8(const GSVector4i& v) const
 	{
 		return ~eq8(v);


### PR DESCRIPTION
### Description of Changes

More accurate, stops it passing through vertices which are off-screen and coordinates overflowed.

Differences versus current have been manually verified to be correct.

### Rationale behind Changes

Correctness.
Speed boost.
Progress in stopping zero-area primitives causing invalidation issues.

### Suggested Testing Steps

Check performance in GS/vertex-heavy games, make sure it hasn't regressed (it should be slightly faster if anything).
Make sure upscaling doesn't have holes in geometry.
