### PR TITLE
GS/HW: Improve draw rect accuracy and remove covered targets

### DIFF
--- a/pcsx2/GS/GSLocalMemory.cpp
+++ b/pcsx2/GS/GSLocalMemory.cpp
@@ -453,6 +453,22 @@ bool GSLocalMemory::IsPageAligned(u32 psm, const GSVector4i& rc)
 	return (rc & pgmsk).eq(GSVector4i::zero());
 }
 
+u32 GSLocalMemory::GetStartBlockAddress(u32 bp, u32 bw, u32 psm, GSVector4i rect)
+{
+	u32 result = m_psm[psm].info.bn(rect.x, rect.y, bp, bw); // Valid only for color formats
+
+	// If rect is page aligned, we can assume it's the start of the page. Z formats don't place block 0
+	// in the top-left, so we have to round them down.
+	const GSVector2i page_size = GSLocalMemory::m_psm[psm].pgs;
+	if ((rect.x & (page_size.x - 1)) == 0 && (rect.y & (page_size.y - 1)) == 0)
+	{
+		constexpr u32 page_mask = (1 << 5) - 1;
+		result &= ~page_mask;
+	}
+
+	return result;
+}
+
 u32 GSLocalMemory::GetEndBlockAddress(u32 bp, u32 bw, u32 psm, GSVector4i rect)
 {
 	u32 result = m_psm[psm].info.bn(rect.z - 1, rect.w - 1, bp, bw); // Valid only for color formats

--- a/pcsx2/GS/GSLocalMemory.h
+++ b/pcsx2/GS/GSLocalMemory.h
@@ -546,6 +546,7 @@ public:
 	GSPixelOffset4* GetPixelOffset4(const GIFRegFRAME& FRAME, const GIFRegZBUF& ZBUF);
 	std::vector<GSVector2i>* GetPage2TileMap(const GIFRegTEX0& TEX0);
 	static bool IsPageAligned(u32 psm, const GSVector4i& rc);
+	static u32 GetStartBlockAddress(u32 bp, u32 bw, u32 psm, GSVector4i rect);
 	static u32 GetEndBlockAddress(u32 bp, u32 bw, u32 psm, GSVector4i rect);
 
 	// address

--- a/pcsx2/GS/Renderers/HW/GSHwHack.cpp
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.cpp
@@ -737,7 +737,7 @@ bool GSHwHack::OI_PointListPalette(GSRendererHW& r, GSTexture* rt, GSTexture* ds
 	{
 		const u32 FBP = r.m_cached_ctx.FRAME.Block();
 		const u32 FBW = r.m_cached_ctx.FRAME.FBW;
-		GL_INS("PointListPalette - m_r = <%d, %d => %d, %d>, n_vertices = %zu, FBP = 0x%x, FBW = %u", r.m_r.x, r.m_r.y, r.m_r.z, r.m_r.w, n_vertices, FBP, FBW);
+		GL_INS("PointListPalette - m_r = <%d, %d => %d, %d>, n_vertices = %u, FBP = 0x%x, FBW = %u", r.m_r.x, r.m_r.y, r.m_r.z, r.m_r.w, n_vertices, FBP, FBW);
 		const GSVertex* RESTRICT v = r.m_vertex.buff;
 		const int ox(r.m_context->XYOFFSET.OFX);
 		const int oy(r.m_context->XYOFFSET.OFY);

--- a/pcsx2/GS/Renderers/HW/GSHwHack.cpp
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.cpp
@@ -135,7 +135,7 @@ bool GSHwHack::GSC_SacredBlaze(GSRendererHW& r, int& skip)
 		if ((RFBP == 0x2680 || RFBP == 0x26c0 || RFBP == 0x2780 || RFBP == 0x2880 || RFBP == 0x2a80) && RTPSM == PSMCT32 && RFBW <= 2 &&
 			(!RTME || (RTBP0 == 0x0 || RTBP0 == 0xe00 || RTBP0 == 0x3e00)))
 		{
-			r.SwPrimRender(r, RTBP0 > 0x1000);
+			r.SwPrimRender(r, RTBP0 > 0x1000, false);
 			skip = 1;
 		}
 	}
@@ -253,7 +253,7 @@ bool GSHwHack::GSC_BlackAndBurnoutSky(GSRendererHW& r, int& skip)
 			// the clouds on top of the sky at each frame.
 			// Burnout 3 PAL 50Hz: 0x3ba0 => 0x1e80.
 			GL_INS("OO_BurnoutGames - Readback clouds renderered from TEX0.TBP0 = 0x%04x (TEX0.CBP = 0x%04x) to FBP = 0x%04x", TEX0.TBP0, TEX0.CBP, FRAME.Block());
-			r.SwPrimRender(r, true);
+			r.SwPrimRender(r, true, false);
 			skip = 1;
 		}
 		if (TEX0.TBW == 2 && TEX0.TW == 7 && ((TEX0.PSM == PSMT4 && FRAME.FBW == 3) || (TEX0.PSM == PSMT8 && FRAME.FBW == 2)) && TEX0.TH == 6 && (FRAME.FBMSK & 0xFFFFFF) == 0xFFFFFF)
@@ -261,7 +261,7 @@ bool GSHwHack::GSC_BlackAndBurnoutSky(GSRendererHW& r, int& skip)
 			// Rendering of the glass smashing effect and some chassis decal in to the alpha channel of the FRAME on boot (before the menu).
 			// This gets ejected from the texture cache due to old age, but never gets written back.
 			GL_INS("OO_BurnoutGames - Render glass smash from TEX0.TBP0 = 0x%04x (TEX0.CBP = 0x%04x) to FBP = 0x%04x", TEX0.TBP0, TEX0.CBP, FRAME.Block());
-			r.SwPrimRender(r, true);
+			r.SwPrimRender(r, true, false);
 			skip = 1;
 		}
 	}
@@ -652,7 +652,7 @@ bool GSHwHack::GSC_BlueTongueGames(GSRendererHW& r, int& skip)
 	// Also used for Nicktoons Unite, same engine it appears.
 	if ((context->FRAME.PSM == PSMCT16S || context->FRAME.PSM <= PSMCT24) && context->FRAME.FBW <= 5)
 	{
-		r.SwPrimRender(r, true);
+		r.SwPrimRender(r, true, false);
 		skip = 1;
 		return true;
 	}
@@ -661,7 +661,7 @@ bool GSHwHack::GSC_BlueTongueGames(GSRendererHW& r, int& skip)
 	// rendered on both.
 	if (context->FRAME.FBW == 8 && r.m_index.tail == 32 && r.PRIM->TME && context->TEX0.TBW == 1)
 	{
-		r.SwPrimRender(r, false);
+		r.SwPrimRender(r, false, false);
 		return false;
 	}
 

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -1715,7 +1715,8 @@ void GSRendererHW::Draw()
 			}
 		}
 	}
-	else if (((fm & fm_mask) != 0) || // Some channels masked
+
+	if (((fm & fm_mask) != 0) || // Some channels masked
 		!IsDiscardingDstColor() || !PrimitiveCoversWithoutGaps() || // Using Dst Color or draw has gaps
 		(process_texture && m_cached_ctx.TEX0.TBP0 >= m_cached_ctx.FRAME.Block() && m_cached_ctx.TEX0.TBP0 < frame_end_bp)) // Tex is RT
 	{

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -1667,9 +1667,24 @@ void GSRendererHW::Draw()
 		return;
 	}
 
-	// The rectangle of the draw rounded up.
-	const GSVector4 rect = m_vt.m_min.p.upld(m_vt.m_max.p + GSVector4::cxpr(0.5f));
-	m_r = GSVector4i(rect).rintersect(context->scissor.in);
+	// GS doesn't fill the right or bottom edges of sprites/triangles, and for a pixel to be shaded, the vertex
+	// must cross the center. In other words, the range is equal to the floor of coordinates +0.5. Except for
+	// the case where the minimum equals the maximum, because at least one pixel is filled per line.
+	// Test cases for the math:
+	//                                --------------------------------------
+	//                                | Position range | Draw Range | Size |
+	//                                |       -0.5,0.0 |        0-0 |    1 |
+	//                                |       -0.5,0.5 |        0-0 |    1 |
+	//                                |            0,1 |        0-0 |    1 |
+	//                                |          0,1.5 |        0-1 |    2 |
+	//                                |        0.5,1.5 |        1-1 |    1 |
+	//                                |       0.5,1.75 |        1-1 |    1 |
+	//                                |       0.5,2.25 |        1-1 |    1 |
+	//                                |        0.5,2.5 |        1-2 |    2 |
+	//                                --------------------------------------
+	m_r = GSVector4i(m_vt.m_min.p.upld(m_vt.m_max.p) + GSVector4::cxpr(0.5f));
+	m_r = m_r.blend8(m_r + GSVector4i::cxpr(0, 0, 1, 1), (m_r.xyxy() == m_r.zwzw()));
+	m_r = m_r.rintersect(context->scissor.in);
 
 	const bool process_texture = PRIM->TME && !(PRIM->ABE && m_context->ALPHA.IsBlack() && !m_cached_ctx.TEX0.TCC);
 	const u32 frame_end_bp = GSLocalMemory::GetEndBlockAddress(m_cached_ctx.FRAME.Block(), m_cached_ctx.FRAME.FBW, m_cached_ctx.FRAME.PSM, m_r);

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -1660,7 +1660,7 @@ void GSRendererHW::Draw()
 	const bool draw_sprite_tex = PRIM->TME && (m_vt.m_primclass == GS_SPRITE_CLASS);
 
 	// We trigger the sw prim render here super early, to avoid creating superfluous render targets.
-	if (CanUseSwPrimRender(no_rt, no_ds, draw_sprite_tex) && SwPrimRender(*this, true))
+	if (CanUseSwPrimRender(no_rt, no_ds, draw_sprite_tex) && SwPrimRender(*this, true, true))
 	{
 		GL_CACHE("Possible texture decompression, drawn with SwPrimRender() (BP %x BW %u TBP0 %x TBW %u)",
 			m_cached_ctx.FRAME.Block(), m_cached_ctx.FRAME.FBMSK, m_cached_ctx.TEX0.TBP0, m_cached_ctx.TEX0.TBW);
@@ -1697,7 +1697,7 @@ void GSRendererHW::Draw()
 		m_mem.m_clut.ClearDrawInvalidity();
 		if (result == CLUTDrawTestResult::CLUTDrawOnCPU && GSConfig.UserHacks_CPUCLUTRender > 0)
 		{
-			if (SwPrimRender(*this, true))
+			if (SwPrimRender(*this, true, true))
 			{
 				GL_CACHE("Possible clut draw, drawn with SwPrimRender()");
 				return;

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.h
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.h
@@ -68,7 +68,7 @@ private:
 	CLUTDrawTestResult PossibleCLUTDraw();
 	CLUTDrawTestResult PossibleCLUTDrawAggressive();
 	bool CanUseSwPrimRender(bool no_rt, bool no_ds, bool draw_sprite_tex);
-	bool (*SwPrimRender)(GSRendererHW&, bool invalidate_tc);
+	bool (*SwPrimRender)(GSRendererHW&, bool invalidate_tc, bool add_ee_transfer);
 
 	template <bool linear>
 	void RoundSpriteOffset();

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -1711,9 +1711,9 @@ void GSTextureCache::InvalidateVideoMemType(int type, u32 bp)
 // Called each time you want to write to the GS memory
 void GSTextureCache::InvalidateVideoMem(const GSOffset& off, const GSVector4i& rect, bool eewrite, bool target)
 {
-	u32 bp = off.bp();
-	u32 bw = off.bw();
-	u32 psm = off.psm();
+	const u32 bp = off.bp();
+	const u32 bw = off.bw();
+	const u32 psm = off.psm();
 
 	if (!target)
 	{
@@ -1823,8 +1823,11 @@ void GSTextureCache::InvalidateVideoMem(const GSOffset& off, const GSVector4i& r
 	if (!target)
 		return;
 
-	// Handle the case where the transfer wrapped around the end of GS memory.
-	const u32 end_bp = off.bnNoWrap(rect.z - 1, rect.w - 1);
+	// Get the bounds that we're invalidating in blocks, so we can remove any targets which are completely contained.
+	// Unfortunately sometimes the draw rect is incorrect, and since the end block gets the rect -1, it'll underflow,
+	// so we need to prevent that from happening. Just make it a single block in that case, and hope for the best.
+	const u32 start_bp = GSLocalMemory::GetStartBlockAddress(off.bp(), off.bw(), off.psm(), rect);
+	const u32 end_bp = rect.rempty() ? start_bp : GSLocalMemory::GetEndBlockAddress(off.bp(), off.bw(), off.psm(), rect);
 
 	// Ideally in the future we can turn this on unconditionally, but for now it breaks too much.
 	const bool check_inside_target = (GSConfig.UserHacks_TargetPartialInvalidation ||
@@ -2063,6 +2066,26 @@ void GSTextureCache::InvalidateVideoMem(const GSOffset& off, const GSVector4i& r
 			// TODO Use ComputeSurfaceOffset below.
 			if (GSUtil::HasSharedBits(psm, t->m_TEX0.PSM))
 			{
+				if (t->m_TEX0.TBP0 >= start_bp && t->m_end_block <= end_bp)
+				{
+					// If we're clearing C24 but the target is C32, then we need to dirty instead.
+					if (rgba._u32 != GSUtil::GetChannelMask(t->m_TEX0.PSM))
+					{
+						GL_CACHE("TC: Dirty whole target(%s) (0x%x) due to being contained within the invalidate range",
+							to_string(type), t->m_TEX0.TBP0);
+						AddDirtyRectTarget(t, t->GetUnscaledRect(), t->m_TEX0.PSM, t->m_TEX0.TBW, rgba);
+						continue;
+					}
+					else
+					{
+						i = list.erase(j);
+						GL_CACHE("TC: Remove Target(%s) (0x%x) due to being contained within the invalidate range",
+							to_string(type), t->m_TEX0.TBP0);
+						delete t;
+						continue;
+					}
+				}
+
 				if (bp < t->m_TEX0.TBP0)
 				{
 					const u32 rowsize = bw * 8192;


### PR DESCRIPTION
### Description of Changes

Slightly riskier part of my clear PR.

Adjusts draw rectangle in hw based on what we know about the GS's rasterizer.

Since the draw rectangle is a little better now, we can use it to invalidate targets when the draw completely covers the target.

### Rationale behind Changes

Small steps to improving invalidation.

### Suggested Testing Steps

Test a few games, including Burnout 3 and Jak 3 (it seems to be sensitive to these changes).
