### PR TITLE
Misc: Regression fixes from boot PR

### DIFF
--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -1933,7 +1933,7 @@ void MainWindow::relativeMouseModeRequested(bool enabled)
 		return;
 
 	m_relative_mouse_mode = enabled;
-	if (s_vm_valid && !s_vm_paused)
+	if (m_display_widget && !s_vm_paused)
 		updateDisplayWidgetCursor();
 }
 
@@ -2002,6 +2002,7 @@ void MainWindow::destroyDisplayWidget(bool show_game_list)
 
 void MainWindow::updateDisplayWidgetCursor()
 {
+	pxAssertRel(m_display_widget, "Should have a display widget");
 	m_display_widget->updateRelativeMode(s_vm_valid && !s_vm_paused && m_relative_mouse_mode);
 	m_display_widget->updateCursor(s_vm_valid && !s_vm_paused && shouldHideMouseCursor());
 }

--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -2452,20 +2452,8 @@ void MainWindow::doStartFile(std::optional<CDVD_SourceType> source, const QStrin
 
 void MainWindow::doDiscChange(CDVD_SourceType source, const QString& path)
 {
-	const bool is_gs_dump = VMManager::IsGSDumpFileName(path.toStdString());
-	if (is_gs_dump != GSDumpReplayer::IsReplayingDump())
-	{
-		QMessageBox::critical(this, tr("Error"), tr("Cannot switch from game to GS dump or vice versa."));
-		return;
-	}
-	else if (is_gs_dump)
-	{
-		Host::RunOnCPUThread([path = path.toStdString()]() { GSDumpReplayer::ChangeDump(path.c_str()); });
-		return;
-	}
-
 	bool reset_system = false;
-	if (!m_was_disc_change_request)
+	if (!m_was_disc_change_request && !GSDumpReplayer::IsReplayingDump())
 	{
 		QMessageBox message(QMessageBox::Question, tr("Confirm Disc Change"),
 			tr("Do you want to swap discs or boot the new image (via system reset)?"), QMessageBox::NoButton, this);

--- a/pcsx2-qt/Settings/ControllerSettingsDialog.cpp
+++ b/pcsx2-qt/Settings/ControllerSettingsDialog.cpp
@@ -128,6 +128,7 @@ void ControllerSettingsDialog::onNewProfileClicked()
 			// from global
 			auto lock = Host::GetSettingsLock();
 			PAD::CopyConfiguration(&temp_si, *Host::Internal::GetBaseSettingsLayer(), true, true, false);
+			USB::CopyConfiguration(&temp_si, *Host::Internal::GetBaseSettingsLayer(), true, true);
 		}
 		else
 		{
@@ -135,6 +136,7 @@ void ControllerSettingsDialog::onNewProfileClicked()
 			const bool copy_hotkey_bindings = m_profile_interface->GetBoolValue("Pad", "UseProfileHotkeyBindings", false);
 			temp_si.SetBoolValue("Pad", "UseProfileHotkeyBindings", copy_hotkey_bindings);
 			PAD::CopyConfiguration(&temp_si, *m_profile_interface, true, true, copy_hotkey_bindings);
+			USB::CopyConfiguration(&temp_si, *m_profile_interface, true, true);
 		}
 	}
 
@@ -163,6 +165,7 @@ void ControllerSettingsDialog::onLoadProfileClicked()
 	{
 		auto lock = Host::GetSettingsLock();
 		PAD::CopyConfiguration(Host::Internal::GetBaseSettingsLayer(), *m_profile_interface, true, true, false);
+		USB::CopyConfiguration(Host::Internal::GetBaseSettingsLayer(), *m_profile_interface, true, true);
 	}
 	Host::CommitBaseSettingChanges();
 

--- a/pcsx2-qt/Settings/ControllerSettingsDialog.ui
+++ b/pcsx2-qt/Settings/ControllerSettingsDialog.ui
@@ -73,7 +73,20 @@
         </widget>
        </item>
        <item>
-        <widget class="QComboBox" name="currentProfile"/>
+        <widget class="QComboBox" name="currentProfile">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>220</width>
+           <height>0</height>
+          </size>
+         </property>
+        </widget>
        </item>
        <item>
         <widget class="QPushButton" name="newProfile">

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -66,6 +66,10 @@ struct SettingInfo
 	float FloatMinValue() const;
 	float FloatMaxValue() const;
 	float FloatStepValue() const;
+
+	void SetDefaultValue(SettingsInterface* si, const char* section, const char* key) const;
+	void CopyValue(SettingsInterface* dest_si, const SettingsInterface& src_si,
+		const char* section, const char* key) const;
 };
 
 enum class GenericInputBinding : u8;

--- a/pcsx2/GSDumpReplayer.cpp
+++ b/pcsx2/GSDumpReplayer.cpp
@@ -126,6 +126,12 @@ bool GSDumpReplayer::ChangeDump(const char* filename)
 {
 	Console.WriteLn("(GSDumpReplayer) Switching to '%s'...", filename);
 
+	if (!VMManager::IsGSDumpFileName(filename))
+	{
+		Host::ReportFormattedErrorAsync("GSDumpReplayer", "'%s' is not a GS dump.", filename);
+		return false;
+	}
+
 	std::unique_ptr<GSDumpFile> new_dump(GSDumpFile::OpenGSDump(filename));
 	if (!new_dump || !new_dump->ReadFile())
 	{

--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -3590,6 +3590,7 @@ void FullscreenUI::CopyGlobalControllerSettingsToGame()
 	SettingsInterface* ssi = GetEditingSettingsInterface(false);
 
 	PAD::CopyConfiguration(dsi, *ssi, true, true, false);
+	USB::CopyConfiguration(dsi, *ssi, true, true);
 	SetSettingsChanged(dsi);
 
 	ShowToast(std::string(), "Per-game controller configuration initialized with global settings.");
@@ -3601,6 +3602,7 @@ void FullscreenUI::ResetControllerSettings()
 
 	PAD::SetDefaultControllerConfig(*dsi);
 	PAD::SetDefaultHotkeyConfig(*dsi);
+	USB::SetDefaultConfiguration(dsi);
 	ShowToast(std::string(), "Controller settings reset to default.");
 }
 
@@ -3633,6 +3635,7 @@ void FullscreenUI::DoLoadInputProfile()
 			auto lock = Host::GetSettingsLock();
 			SettingsInterface* dsi = GetEditingSettingsInterface();
 			PAD::CopyConfiguration(dsi, ssi, true, true, IsEditingGameSettings(dsi));
+			USB::CopyConfiguration(dsi, ssi, true, true);
 			SetSettingsChanged(dsi);
 			ShowToast(std::string(), fmt::format("Input profile '{}' loaded.", title));
 			CloseChoiceDialog();
@@ -3646,6 +3649,7 @@ void FullscreenUI::DoSaveInputProfile(const std::string& name)
 	auto lock = Host::GetSettingsLock();
 	SettingsInterface* ssi = GetEditingSettingsInterface();
 	PAD::CopyConfiguration(&dsi, *ssi, true, true, IsEditingGameSettings(ssi));
+	USB::CopyConfiguration(&dsi, *ssi, true, true);
 	if (dsi.Save())
 		ShowToast(std::string(), fmt::format("Input profile '{}' saved.", name));
 	else

--- a/pcsx2/PAD/Host/PAD.cpp
+++ b/pcsx2/PAD/Host/PAD.cpp
@@ -287,26 +287,7 @@ void PAD::SetDefaultControllerConfig(SettingsInterface& si)
 			for (u32 i = 0; i < ci->num_settings; i++)
 			{
 				const SettingInfo& csi = ci->settings[i];
-				switch (csi.type)
-				{
-					case SettingInfo::Type::Boolean:
-						si.SetBoolValue(section.c_str(), csi.name, csi.BooleanDefaultValue());
-						break;
-					case SettingInfo::Type::Integer:
-					case SettingInfo::Type::IntegerList:
-						si.SetIntValue(section.c_str(), csi.name, csi.IntegerDefaultValue());
-						break;
-					case SettingInfo::Type::Float:
-						si.SetFloatValue(section.c_str(), csi.name, csi.FloatDefaultValue());
-						break;
-					case SettingInfo::Type::String:
-					case SettingInfo::Type::StringList:
-					case SettingInfo::Type::Path:
-						si.SetStringValue(section.c_str(), csi.name, csi.StringDefaultValue());
-						break;
-					default:
-						break;
-				}
+				csi.SetDefaultValue(&si, section.c_str(), csi.name);
 			}
 		}
 	}
@@ -583,26 +564,7 @@ void PAD::CopyConfiguration(SettingsInterface* dest_si, const SettingsInterface&
 			for (u32 i = 0; i < info->num_settings; i++)
 			{
 				const SettingInfo& csi = info->settings[i];
-				switch (csi.type)
-				{
-					case SettingInfo::Type::Boolean:
-						dest_si->CopyBoolValue(src_si, section.c_str(), csi.name);
-						break;
-					case SettingInfo::Type::Integer:
-					case SettingInfo::Type::IntegerList:
-						dest_si->CopyIntValue(src_si, section.c_str(), csi.name);
-						break;
-					case SettingInfo::Type::Float:
-						dest_si->CopyFloatValue(src_si, section.c_str(), csi.name);
-						break;
-					case SettingInfo::Type::String:
-					case SettingInfo::Type::StringList:
-					case SettingInfo::Type::Path:
-						dest_si->CopyStringValue(src_si, section.c_str(), csi.name);
-						break;
-					default:
-						break;
-				}
+				csi.CopyValue(dest_si, src_si, section.c_str(), csi.name);
 			}
 		}
 	}

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -88,6 +88,55 @@ float SettingInfo::FloatStepValue() const
 	return step_value ? StringUtil::FromChars<float>(step_value).value_or(fallback_value) : fallback_value;
 }
 
+void SettingInfo::SetDefaultValue(SettingsInterface* si, const char* section, const char* key) const
+{
+	switch (type)
+	{
+		case SettingInfo::Type::Boolean:
+			si->SetBoolValue(section, key, BooleanDefaultValue());
+			break;
+		case SettingInfo::Type::Integer:
+		case SettingInfo::Type::IntegerList:
+			si->SetIntValue(section, key, IntegerDefaultValue());
+			break;
+		case SettingInfo::Type::Float:
+			si->SetFloatValue(section, key, FloatDefaultValue());
+			break;
+		case SettingInfo::Type::String:
+		case SettingInfo::Type::StringList:
+		case SettingInfo::Type::Path:
+			si->SetStringValue(section, key, StringDefaultValue());
+			break;
+		default:
+			break;
+	}
+}
+
+void SettingInfo::CopyValue(SettingsInterface* dest_si, const SettingsInterface& src_si,
+	const char* section, const char* key) const
+{
+	switch (type)
+	{
+		case SettingInfo::Type::Boolean:
+			dest_si->CopyBoolValue(src_si, section, key);
+			break;
+		case SettingInfo::Type::Integer:
+		case SettingInfo::Type::IntegerList:
+			dest_si->CopyIntValue(src_si, section, key);
+			break;
+		case SettingInfo::Type::Float:
+			dest_si->CopyFloatValue(src_si, section, key);
+			break;
+		case SettingInfo::Type::String:
+		case SettingInfo::Type::StringList:
+		case SettingInfo::Type::Path:
+			dest_si->CopyStringValue(src_si, section, key);
+			break;
+		default:
+			break;
+	}
+}
+
 namespace EmuFolders
 {
 	std::string AppRoot;

--- a/pcsx2/USB/USB.h
+++ b/pcsx2/USB/USB.h
@@ -70,6 +70,13 @@ namespace USB
 	/// Clears all bindings for a given port.
 	void ClearPortBindings(SettingsInterface& si, u32 port);
 
+	/// Copies configuration between two profiles.
+	void CopyConfiguration(SettingsInterface* dest_si, const SettingsInterface& src_si, bool copy_devices = true,
+		bool copy_bindings = true);
+
+	/// Resets configuration for all ports.
+	void SetDefaultConfiguration(SettingsInterface* si);
+
 	/// Identifies any device/subtype changes and recreates devices.
 	void CheckForConfigChanges(const Pcsx2Config& old_config);
 

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -995,8 +995,6 @@ bool VMManager::Initialize(VMBootParameters boot_params)
 
 	std::string state_to_load;
 
-	s_fast_boot_requested = boot_params.fast_boot.value_or(static_cast<bool>(EmuConfig.EnableFastBoot));
-
 	s_elf_override = std::move(boot_params.elf_override);
 	if (!boot_params.save_state.empty())
 		state_to_load = std::move(boot_params.save_state);
@@ -1077,6 +1075,12 @@ bool VMManager::Initialize(VMBootParameters boot_params)
 
 	// Figure out which game we're running! This also loads game settings.
 	UpdateDiscDetails(true);
+
+	// Read fast boot setting late so it can be overridden per-game.
+	// ELFs must be fast booted, and GS dumps are never fast booted.
+	s_fast_boot_requested =
+		(boot_params.fast_boot.value_or(static_cast<bool>(EmuConfig.EnableFastBoot)) || !s_elf_override.empty()) &&
+		!GSDumpReplayer::IsReplayingDump();
 
 	if (!s_elf_override.empty())
 	{

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -1663,6 +1663,20 @@ void VMManager::FrameAdvance(u32 num_frames /*= 1*/)
 
 bool VMManager::ChangeDisc(CDVD_SourceType source, std::string path)
 {
+	if (GSDumpReplayer::IsReplayingDump())
+	{
+		if (!GSDumpReplayer::ChangeDump(path.c_str()))
+			return false;
+
+		UpdateDiscDetails(false);
+		return true;
+	}
+	else if (IsGSDumpFileName(path))
+	{
+		Host::ReportErrorAsync("Error", "Cannot change from game to GS dump without shutting down first.");
+		return false;
+	}
+
 	const CDVD_SourceType old_type = CDVDsys_GetSourceType();
 	const std::string old_path(CDVDsys_GetFile(old_type));
 

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -443,7 +443,10 @@ void VMManager::SetDefaultSettings(
 		LogSink::SetDefaultLoggingSettings(si);
 	}
 	if (controllers)
+	{
 		PAD::SetDefaultControllerConfig(si);
+		USB::SetDefaultConfiguration(&si);
+	}
 	if (hotkeys)
 		PAD::SetDefaultHotkeyConfig(si);
 	if (ui)

--- a/pcsx2/VMManager.h
+++ b/pcsx2/VMManager.h
@@ -92,9 +92,6 @@ namespace VMManager
 	/// Returns the crc of the executable currently running.
 	u32 GetCurrentCRC();
 
-	/// Loads global settings (i.e. EmuConfig).
-	void LoadSettings();
-
 	/// Initializes all system components.
 	bool Initialize(VMBootParameters boot_params);
 


### PR DESCRIPTION
### Description of Changes

**VMManager: Fix dump playback adding to play time**
Self-explanatory.

**VMManager: Fix title updates when switching GS dumps**
Self-explanatory.

**VMManager: Fix fast forward boot with GS dumps**
Regression from boot PR - the option would cause GS dumps to play at unthrottled speed.

**Qt: Fix crash booting with mouse mapping**
Regression from boot PR - fix crash on startup if pointer is bound to controller.

**VMManager: Only reload core settings on ELF load** 
We don't need to reload e.g. input sources, bindings, etc, after booting the game.

**USB: Copy configuration when creating input profile** 
This was previously missing, you had to manually bring across USB settings.
Also clears the USB settings when you reset to defaults.

**Qt: Fix size of input profile dropdown**
It was too small for longer names.

### Rationale behind Changes

See above.

### Suggested Testing Steps

Make sure all fixes listed above, well, fixed the issues.
