### PR TITLE
Host/Mcd: Fix boot order so memcard type is set before loading memcards

### DIFF
--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -1136,6 +1136,8 @@ bool VMManager::Initialize(VMBootParameters boot_params)
 		}
 	}
 
+	FileMcd_EmuOpen();
+
 	Console.WriteLn("Opening CDVD...");
 	if (!DoCDVDopen())
 	{
@@ -1248,8 +1250,6 @@ bool VMManager::Initialize(VMBootParameters boot_params)
 		return false;
 	}
 	ScopedGuard close_fw = []() { FWclose(); };
-
-	FileMcd_EmuOpen();
 
 	// Don't close when we return
 	close_fw.Cancel();


### PR DESCRIPTION
### Description of Changes
Fixes the order of operations when setting up memcards and disc serials

### Rationale behind Changes
Disc serial was being loaded before memcards were initialised, so folder memcards didn't learn about the serial, causing savegames to not work/be missing

### Suggested Testing Steps
check folder memcards
