### PR TITLE
VMManager: Fix WS patch not applying auto aspect ratio

### DIFF
--- a/pcsx2/Hotkeys.cpp
+++ b/pcsx2/Hotkeys.cpp
@@ -41,7 +41,8 @@ void VMManager::Internal::ResetVMHotkeyState()
 static void HotkeyAdjustTargetSpeed(double delta)
 {
 	const double min_speed = Achievements::ChallengeModeActive() ? 1.0 : 0.1;
-	EmuConfig.Framerate.NominalScalar = std::max(min_speed, EmuConfig.GS.LimitScalar + delta);
+	EmuConfig.Framerate.NominalScalar = std::max(min_speed, EmuConfig.Framerate.NominalScalar + delta);
+	EmuConfig.LimiterMode = LimiterModeType::Unlimited; // force update
 	VMManager::SetLimiterMode(LimiterModeType::Nominal);
 	Host::AddIconOSDMessage("SpeedChanged", ICON_FA_CLOCK,
 		fmt::format("Target speed set to {:.0f}%.", std::round(EmuConfig.Framerate.NominalScalar * 100.0)), Host::OSD_QUICK_DURATION);

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -463,7 +463,6 @@ void VMManager::LoadSettings()
 	InputManager::ReloadSources(*si, lock);
 	InputManager::ReloadBindings(*si, *Host::GetSettingsInterfaceForBindings());
 	LogSink::UpdateLogging(*si);
-	Patch::ApplyPatchSettingOverrides();
 
 	if (HasValidOrInitializingVM())
 	{
@@ -476,6 +475,7 @@ void VMManager::LoadCoreSettings(SettingsInterface* si)
 {
 	SettingsLoadWrapper slw(*si);
 	EmuConfig.LoadSave(slw);
+	Patch::ApplyPatchSettingOverrides();
 
 	// Achievements hardcore mode disallows setting some configuration options.
 	EnforceAchievementsChallengeModeSettings();


### PR DESCRIPTION
### Description of Changes

And cleanup boot init a little.

Also makes GS dumps not open memory cards (useful for two instances).

### Rationale behind Changes

Regression.

### Suggested Testing Steps

Make sure ws patches change the aspect ratio (checked myself).
