### PR TITLE
Translations: Fix missing context marker on Manual Hardware Fixes string

### DIFF
--- a/pcsx2-qt/Translations/pcsx2-qt_en.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_en.ts
@@ -3796,6 +3796,11 @@ You can adjust the blending level in Game Properties to improve
 graphical quality, but this will increase system requirements.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../../pcsx2/GameDatabase.cpp" line="912"/>
+        <source>Manual GS hardware renderer fixes are enabled, automatic fixes were not applied:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GameFixSettingsWidget</name>
@@ -9106,6 +9111,11 @@ This action cannot be reversed, and you will lose any saves on the card.</source
     <message>
         <location filename="../../pcsx2/Patch.cpp" line="596"/>
         <source>{}{} cheat patches</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../pcsx2/Patch.cpp" line="608"/>
+        <source>{} are active.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/pcsx2/GameDatabase.cpp
+++ b/pcsx2/GameDatabase.cpp
@@ -909,8 +909,8 @@ u32 GameDatabaseSchema::GameEntry::applyGSHardwareFixes(Pcsx2Config::GSOptions& 
 	{
 		Host::AddKeyedOSDMessage("HWFixesWarning",
 			fmt::format(ICON_FA_MAGIC " {}\n{}",
-				TRANSLATE_SV("Manual GS hardware renderer fixes are enabled, automatic fixes were not applied:",
-					disabled_fixes)),
+				TRANSLATE_SV("GameDatabase", "Manual GS hardware renderer fixes are enabled, automatic fixes were not applied:"),
+					disabled_fixes),
 			Host::OSD_ERROR_DURATION);
 	}
 	else

--- a/pcsx2/Patch.cpp
+++ b/pcsx2/Patch.cpp
@@ -605,7 +605,7 @@ void Patch::UpdateActivePatches(bool reload_enabled_list, bool verbose, bool ver
 		if (!message.empty())
 		{
 			Host::AddIconOSDMessage("LoadPatches", ICON_FA_FILE_CODE,
-				fmt::format(TRANSLATE_SV("{} are active.", message)), Host::OSD_INFO_DURATION);
+				fmt::format(TRANSLATE_SV("Patch", "{} are active."), message), Host::OSD_INFO_DURATION);
 		}
 		else
 		{


### PR DESCRIPTION
### Description of Changes
Fixes CTD on Manual Hardware Fixes enabled

### Rationale behind Changes
Fixes CTD on Manual Hardware Fixes enabled

### Suggested Testing Steps
Enable Manual Hardware Fixes, make sure game not commit die
