### PR TITLE
GS/CRC: Fix Ar Tonelico 2 CRC hack to check DS exists

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSHwHack.cpp
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.cpp
@@ -945,7 +945,7 @@ bool GSHwHack::OI_ArTonelico2(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GST
 
 	const GSVertex* v = &r.m_vertex.buff[0];
 
-	if (r.m_vertex.next == 2 && !RPRIM->TME && RFRAME.FBW == 10 && v->XYZ.Z == 0 && RTEST.ZTST == ZTST_ALWAYS)
+	if (ds && r.m_vertex.next == 2 && !RPRIM->TME && RFRAME.FBW == 10 && v->XYZ.Z == 0 && RTEST.ZTST == ZTST_ALWAYS)
 	{
 		GL_INS("OI_ArTonelico2");
 		g_gs_device->ClearDepth(ds, 0.0f);


### PR DESCRIPTION
### Description of Changes
Checks DS (depth stencil) exists before trying to clear it.

### Rationale behind Changes
Trying to clear null is bad.

### Suggested Testing Steps
Already tested.

Fixes #9015
