### PR TITLE
GameDB: Add VU Clamping to Motorstorm

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -4984,6 +4984,8 @@ SCES-55571:
 SCES-55573:
   name: "MotorStorm - Arctic Edge"
   region: "PAL-M14"
+  clampModes:
+    vu1ClampMode: 3 # Fixes bad polys in menu.
 SCES-55591:
   name: "Street Cricket Champions"
   region: "PAL-IN"
@@ -9330,9 +9332,11 @@ SCUS-97653:
   region: "NTSC-U"
   compat: 5
 SCUS-97654:
-  name: "MotorStorm Arctic Edge"
+  name: "MotorStorm - Arctic Edge"
   region: "NTSC-U"
   compat: 5
+  clampModes:
+    vu1ClampMode: 3 # Fixes bad polys in menu.
 SCUS-97657:
   name: "MLB 11 - The Show"
   region: "NTSC-U"
@@ -23757,8 +23761,10 @@ SLES-55572:
   gameFixes:
     - EETimingHack # Broken textures.
 SLES-55573:
-  name: "MotorStorm Arctic Edge"
+  name: "MotorStorm - Arctic Edge"
   region: "PAL-M14"
+  clampModes:
+    vu1ClampMode: 3 # Fixes bad polys in menu.
 SLES-55574:
   name: "Lord of the Rings, The - Aragorn's Quest"
   region: "PAL-M6"


### PR DESCRIPTION
### Description of Changes
Adds VU clamping to Motorstorm to fix the menu graphics, not sure if it has any positive effect ingame, it generally looks fine,.

### Rationale behind Changes
bad polys are bad polys

### Suggested Testing Steps
Check motorstorm (already done)

Before:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/cc525a8c-f056-4973-a118-ec4d927f3410)

After:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/f0dc3013-d8cb-4ffe-adc2-a6b326ab8524)
