### PR TITLE
Updater: Clarify the error message when the program being runs directly

### DIFF
--- a/updater/Windows/WindowsUpdater.cpp
+++ b/updater/Windows/WindowsUpdater.cpp
@@ -445,7 +445,7 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPWSTR lpCmdLi
 	if (argc != 5)
 	{
 		progress.ModalError("Expected 4 arguments: parent process id, output directory, update zip, program to "
-							"launch.\n\nThis program is not intended to be run manually, please use the Qt frontend and "
+							"launch.\n\nThis program is not intended to be run manually, please use the main PCSX2 application and "
 							"click Help->Check for Updates.");
 		return 1;
 	}


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
This PR makes the error message (that appears when you tries to run the Updater directly) to be more clearer and more user friendly.

This changes "Qt frontend" to "main PCSX2 application"

![Screenshot_20230621_133524](https://github.com/PCSX2/pcsx2/assets/14798312/da1f9556-2fc0-49ff-98f4-850342bc17b5)

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Not everyone knows what "Qt" and "frontend" means.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Make sure the text shows up correctly.
