### PR TITLE
Updater:Mac: Delay launch of new application until the old one exits

### DIFF
--- a/common/CocoaTools.h
+++ b/common/CocoaTools.h
@@ -33,8 +33,8 @@ namespace CocoaTools
 	std::optional<std::string> GetNonTranslocatedBundlePath();
 	/// Move the given file to the trash, and return the path to its new location
 	std::optional<std::string> MoveToTrash(std::string_view file);
-	/// Launch the given application
-	bool LaunchApplication(std::string_view file);
+	/// Launch the given application once this one quits
+	bool DelayedLaunch(std::string_view file);
 }
 
 #endif // __APPLE__

--- a/pcsx2-qt/AutoUpdaterDialog.cpp
+++ b/pcsx2-qt/AutoUpdaterDialog.cpp
@@ -804,7 +804,8 @@ bool AutoUpdaterDialog::processUpdate(const QByteArray& update_data, QProgressDi
 		}
 		QDir(QString::fromStdString(*trashed_path)).removeRecursively();
 	}
-	if (!CocoaTools::LaunchApplication(open_path.toStdString()))
+	// For some reason if I use QProcess the shell gets killed immediately with SIGKILL, but NSTask is fine...
+	if (!CocoaTools::DelayedLaunch(open_path.toStdString()))
 	{
 		reportError("Failed to start new application");
 		return false;


### PR DESCRIPTION
### Description of Changes
When launching the new PCSX2 after an update, the Mac updater now uses a shell script to wait until the old PCSX2 has closed before launching the new one

### Rationale behind Changes
With the old flow, since new PCSX2 was launched while the old one was still open, it would get a separate dock icon, which meant that if the user had PCSX2 pinned in the dock, the new one wouldn't use the pinned dock icon

### Suggested Testing Steps
Tested locally (PR builds don't have the updater enabled)
