### PR TITLE
GS/HW: Improve target age handling and remember recent EE Writes

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -24387,6 +24387,8 @@ SLKA-15032:
 SLKA-15033:
   name: "Princess Maker 2"
   region: "NTSC-K"
+  gsHWFixes:
+    partialTargetInvalidation: 1 # Fixes full screen C32->C16 frame invalidation.
 SLKA-15043:
   name: "Super Puzzle Bobble Collection Vol 1"
   region: "NTSC-K"
@@ -28599,6 +28601,8 @@ SLPM-62700:
 SLPM-62701:
   name: "Princess Maker 2 [Best Hit Selection]"
   region: "NTSC-J"
+  gsHWFixes:
+    partialTargetInvalidation: 1 # Fixes full screen C32->C16 frame invalidation.
 SLPM-62702:
   name: "Momotaro Densetsu 15"
   region: "NTSC-J"
@@ -37936,6 +37940,8 @@ SLPS-20392:
 SLPS-20393:
   name: "Princess Maker 2"
   region: "NTSC-J"
+  gsHWFixes:
+    partialTargetInvalidation: 1 # Fixes full screen C32->C16 frame invalidation.
 SLPS-20394:
   name: "Suki na Mono wa Sukida Rashouganai + White Flower + Sukisyo!"
   region: "NTSC-J"

--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -26,6 +26,7 @@
 #include <iomanip> // Dump Verticles
 
 int GSState::s_n = 0;
+int GSState::s_last_transfer_draw_n = 0;
 int GSState::s_transfer_n = 0;
 
 static __fi bool IsAutoFlushEnabled()
@@ -1779,6 +1780,7 @@ void GSState::Write(const u8* mem, int len)
 		r.right = r.left + m_env.TRXREG.RRW;
 		r.bottom = r.top + m_env.TRXREG.RRH;
 
+		s_last_transfer_draw_n = s_n;
 		// Store the transfer for preloading new RT's.
 		if ((m_draw_transfers.size() > 0 && blit.DBP == m_draw_transfers.back().blit.DBP))
 		{
@@ -1981,6 +1983,8 @@ void GSState::Move()
 	r.top = m_env.TRXPOS.DSAY;
 	r.right = r.left + m_env.TRXREG.RRW;
 	r.bottom = r.top + m_env.TRXREG.RRH;
+
+	s_last_transfer_draw_n = s_n;
 	// Store the transfer for preloading new RT's.
 	if ((m_draw_transfers.size() > 0 && m_env.BITBLTBUF.DBP == m_draw_transfers.back().blit.DBP))
 	{

--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -235,6 +235,7 @@ public:
 	std::vector<GSUploadQueue> m_draw_transfers;
 
 	static int s_n;
+	static int s_last_transfer_draw_n;
 	static int s_transfer_n;
 
 	static constexpr u32 STATE_VERSION = 8;

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -130,8 +130,25 @@ void GSRendererHW::VSync(u32 field, bool registers_written, bool idle_frame)
 			}
 		}
 	}
-	else
-		m_draw_transfers.clear();
+	else if (!idle_frame)
+	{
+		// If it did draws very recently, we should keep the recent stuff in case it hasn't been preloaded/used yet.
+		// Rocky Legend does this with the main menu FMV's.
+		if (s_last_transfer_draw_n == s_n)
+		{
+			for (auto iter = m_draw_transfers.begin(); iter != m_draw_transfers.end();)
+			{
+				if ((s_n - iter->draw) > 5)
+					iter = m_draw_transfers.erase(iter);
+				else
+				{
+					iter++;
+				}
+			}
+		}
+		else
+			m_draw_transfers.clear();
+	}
 
 	if (GSConfig.LoadTextureReplacements)
 		GSTextureReplacements::ProcessAsyncLoadedTextures();

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -183,7 +183,7 @@ GSTexture* GSRendererHW::GetOutput(int i, float& scale, int& y_offset)
 
 	if (GSTextureCache::Target* rt = g_texture_cache->LookupDisplayTarget(TEX0, framebufferSize, GetTextureScaleFactor()))
 	{
-		rt->Update(false);
+		rt->Update();
 		t = rt->m_texture;
 		scale = rt->m_scale;
 
@@ -224,7 +224,7 @@ GSTexture* GSRendererHW::GetFeedbackOutput(float& scale)
 	if (!rt)
 		return nullptr;
 
-	rt->Update(false);
+	rt->Update();
 	GSTexture* t = rt->m_texture;
 	scale = rt->m_scale;
 
@@ -993,7 +993,7 @@ void GSRendererHW::FinishSplitClear()
 	OI_DoGsMemClear(clear_off, rect, m_split_clear_color);
 
 	// Invalidate any targets in this range.
-	g_texture_cache->InvalidateVideoMem(clear_off, rect, false, true);
+	g_texture_cache->InvalidateVideoMem(clear_off, rect, true);
 
 	m_split_clear_start.U64 = 0;
 	m_split_clear_pages = 0;
@@ -1047,7 +1047,7 @@ void GSRendererHW::InvalidateVideoMem(const GIFRegBITBLTBUF& BITBLTBUF, const GS
 	}
 	if (loop_h || loop_w)
 	{
-		g_texture_cache->InvalidateVideoMem(m_mem.GetOffset(BITBLTBUF.DBP, BITBLTBUF.DBW, BITBLTBUF.DPSM), rect, eewrite);
+		g_texture_cache->InvalidateVideoMem(m_mem.GetOffset(BITBLTBUF.DBP, BITBLTBUF.DBW, BITBLTBUF.DPSM), rect);
 		if (loop_h)
 		{
 			rect.y = 0;
@@ -1058,10 +1058,10 @@ void GSRendererHW::InvalidateVideoMem(const GIFRegBITBLTBUF& BITBLTBUF, const GS
 			rect.x = 0;
 			rect.z = r.z - 2048;
 		}
-		g_texture_cache->InvalidateVideoMem(m_mem.GetOffset(BITBLTBUF.DBP, BITBLTBUF.DBW, BITBLTBUF.DPSM), rect, eewrite);
+		g_texture_cache->InvalidateVideoMem(m_mem.GetOffset(BITBLTBUF.DBP, BITBLTBUF.DBW, BITBLTBUF.DPSM), rect);
 	}
 	else
-		g_texture_cache->InvalidateVideoMem(m_mem.GetOffset(BITBLTBUF.DBP, BITBLTBUF.DBW, BITBLTBUF.DPSM), r, eewrite);
+		g_texture_cache->InvalidateVideoMem(m_mem.GetOffset(BITBLTBUF.DBP, BITBLTBUF.DBW, BITBLTBUF.DPSM), r);
 }
 
 void GSRendererHW::InvalidateLocalMem(const GIFRegBITBLTBUF& BITBLTBUF, const GSVector4i& r, bool clut)
@@ -1828,14 +1828,14 @@ void GSRendererHW::Draw()
 			{
 				GL_INS("Clear draw with mem clear and valid clear height, invalidating.");
 
-				g_texture_cache->InvalidateVideoMem(context->offset.fb, m_r, false, true);
+				g_texture_cache->InvalidateVideoMem(context->offset.fb, m_r, true);
 				g_texture_cache->InvalidateVideoMemType(GSTextureCache::RenderTarget, m_cached_ctx.FRAME.Block());
 				if(no_target_found)
 					g_texture_cache->InvalidateVideoMemType(GSTextureCache::DepthStencil, m_cached_ctx.FRAME.Block());
 
 				if (m_cached_ctx.ZBUF.ZMSK == 0)
 				{
-					g_texture_cache->InvalidateVideoMem(context->offset.zb, m_r, false, false);
+					g_texture_cache->InvalidateVideoMem(context->offset.zb, m_r, false);
 					g_texture_cache->InvalidateVideoMemType(GSTextureCache::DepthStencil, m_cached_ctx.ZBUF.Block());
 				}
 
@@ -2084,7 +2084,7 @@ void GSRendererHW::Draw()
 			// If TEX0 == FBP, we're going to have a source left in the TC.
 			// That source will get used in the actual draw unsafely, so kick it out.
 			if (m_cached_ctx.FRAME.Block() == m_cached_ctx.TEX0.TBP0)
-				g_texture_cache->InvalidateVideoMem(context->offset.fb, m_r, false, false);
+				g_texture_cache->InvalidateVideoMem(context->offset.fb, m_r, false);
 
 			cleanup_cancelled_draw();
 			return;
@@ -2252,9 +2252,9 @@ void GSRendererHW::Draw()
 		}
 	}
 	if (rt)
-		rt->Update(true);
+		rt->Update();
 	if (ds)
-		ds->Update(true);
+		ds->Update();
 
 	const GSVector2i resolution = PCRTCDisplays.GetResolution();
 	GSTextureCache::Target* old_rt = nullptr;
@@ -2484,7 +2484,7 @@ void GSRendererHW::Draw()
 
 		rt->UpdateValidBits(~fm & fm_mask);
 
-		g_texture_cache->InvalidateVideoMem(context->offset.fb, m_r, false, false);
+		g_texture_cache->InvalidateVideoMem(context->offset.fb, m_r, false);
 
 		if (can_invalidate)
 			g_texture_cache->InvalidateVideoMemType(GSTextureCache::DepthStencil, m_cached_ctx.FRAME.Block());
@@ -2498,7 +2498,7 @@ void GSRendererHW::Draw()
 
 		ds->UpdateValidBits(GSLocalMemory::m_psm[m_cached_ctx.ZBUF.PSM].fmsk);
 
-		g_texture_cache->InvalidateVideoMem(context->offset.zb, m_r, false, false);
+		g_texture_cache->InvalidateVideoMem(context->offset.zb, m_r, false);
 
 		if (can_invalidate)
 			g_texture_cache->InvalidateVideoMemType(GSTextureCache::RenderTarget, m_cached_ctx.ZBUF.Block());

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -99,7 +99,7 @@ bool GSTextureCache::FullRectDirty(Target* target)
 	RGBAMask rgba;
 	rgba._u32 = GSUtil::GetChannelMask(target->m_TEX0.PSM);
 	// One complete dirty rect, not pieces (Add dirty rect function should be able to join these all together).
-	if (target->m_age > 2 && target->m_dirty.size() == 1 && rgba._u32 == target->m_dirty[0].rgba._u32 && target->m_valid.rintersect(target->m_dirty[0].r).eq(target->m_valid))
+	if (target->m_age != 0 && target->m_dirty.size() == 1 && rgba._u32 == target->m_dirty[0].rgba._u32 && target->m_valid.rintersect(target->m_dirty[0].r).eq(target->m_valid))
 	{
 		return true;
 	}

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.h
@@ -236,7 +236,7 @@ public:
 		void UpdateValidity(const GSVector4i& rect, bool can_resize = true);
 		void UpdateValidBits(u32 bits_written);
 
-		void Update(bool reset_age);
+		void Update();
 
 		/// Updates the target, if the dirty area intersects with the specified rectangle.
 		void UpdateIfDirtyIntersects(const GSVector4i& rc);
@@ -468,7 +468,7 @@ public:
 
 	void InvalidateVideoMemType(int type, u32 bp);
 	void InvalidateVideoMemSubTarget(GSTextureCache::Target* rt);
-	void InvalidateVideoMem(const GSOffset& off, const GSVector4i& r, bool eewrite = false, bool target = true);
+	void InvalidateVideoMem(const GSOffset& off, const GSVector4i& r, bool target = true);
 	void InvalidateLocalMem(const GSOffset& off, const GSVector4i& r, bool full_flush = false);
 
 	/// Removes any sources which point to the specified target.


### PR DESCRIPTION
### Description of Changes
Removes some old age hack code and improves the age handling of full dirty targets. Plus remembers recent EE writes done just before VSync.

### Rationale behind Changes
The setting age to 0 on EE write was never really right, but it was a means to an end when it was done, now it's no longer required.  This then allows us to tighten the age check for removing fully dirtied targets.

Also made it remember recent writes from the EE if the most recent one was on the same draw number as VSync occurs on, this can happen with videos.

### Suggested Testing Steps
Test random things, see if anything explodes.
