### PR TITLE
CI: Prevent double builds on pushes to pcsx2 repo

### DIFF
--- a/.github/workflows/linux_build_matrix.yml
+++ b/.github/workflows/linux_build_matrix.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   build_linux_qt:
     name: "AppImage"
+    if: github.repository != 'PCSX2/pcsx2' || github.event_name == 'pull_request'
     uses: ./.github/workflows/linux_build_qt.yml
     with:
       jobName: "Qt"
@@ -20,6 +21,7 @@ jobs:
     secrets: inherit
   build_linux_flatpak:
     name: "Flatpak"
+    if: github.repository != 'PCSX2/pcsx2' || github.event_name == 'pull_request'
     uses: ./.github/workflows/linux_build_flatpak.yml
     with:
       jobName: "Qt"

--- a/.github/workflows/macos_build_matrix.yml
+++ b/.github/workflows/macos_build_matrix.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   build_macos_qt:
     name: "Defaults"
+    if: github.repository != 'PCSX2/pcsx2' || github.event_name == 'pull_request'
     uses: ./.github/workflows/macos_build.yml
     with:
       jobName: "Qt"

--- a/.github/workflows/windows_build_matrix.yml
+++ b/.github/workflows/windows_build_matrix.yml
@@ -12,6 +12,7 @@ jobs:
   # MSBUILD
   lint_vs_proj_files:
     name: Lint VS Project Files
+    if: github.repository != 'PCSX2/pcsx2' || github.event_name == 'pull_request'
     runs-on: windows-2019
     steps:
       - name: Checkout Repository
@@ -22,6 +23,7 @@ jobs:
   build_qt_sse4:
     needs: lint_vs_proj_files
     name: "SSE4"
+    if: github.repository != 'PCSX2/pcsx2' || github.event_name == 'pull_request'
     uses: ./.github/workflows/windows_build_qt.yml
     with:
       jobName: Qt
@@ -32,6 +34,7 @@ jobs:
   build_qt_avx2:
     needs: lint_vs_proj_files
     name: "AVX2"
+    if: github.repository != 'PCSX2/pcsx2' || github.event_name == 'pull_request'
     uses: ./.github/workflows/windows_build_qt.yml
     with:
       jobName: Qt
@@ -40,6 +43,7 @@ jobs:
 
   build_qt_cmake:
     name: "CMake"
+    if: github.repository != 'PCSX2/pcsx2' || github.event_name == 'pull_request'
     uses: ./.github/workflows/windows_build_qt.yml
     with:
       jobName: Qt
@@ -50,6 +54,7 @@ jobs:
   build_qt_clang_sse4:
     needs: lint_vs_proj_files
     name: "SSE4"
+    if: github.repository != 'PCSX2/pcsx2' || github.event_name == 'pull_request'
     uses: ./.github/workflows/windows_build_qt.yml
     with:
       jobName: Qt Clang
@@ -60,6 +65,7 @@ jobs:
   build_qt_clang_avx2:
     needs: lint_vs_proj_files
     name: "AVX2"
+    if: github.repository != 'PCSX2/pcsx2' || github.event_name == 'pull_request'
     uses: ./.github/workflows/windows_build_qt.yml
     with:
       jobName: Qt Clang
@@ -68,6 +74,7 @@ jobs:
 
   build_qt_cmake_clang:
     name: "CMake"
+    if: github.repository != 'PCSX2/pcsx2' || github.event_name == 'pull_request'
     uses: ./.github/workflows/windows_build_qt.yml
     with:
       jobName: Qt Clang


### PR DESCRIPTION
### Description of Changes

Currently, if you push a branch to the PCSX2 repo, then make a pull request, it builds it twice - once for the branch push, and another for the pull request. This just holds up the CI and is duplicating effort.

Similar thing for releases - merging runs the release pipeline, as well as the (wasted) branch push.

I changed the matrix workflows to only run when it's a pull request, because we obviously want that, or if it's a repo other than main PCSX2. I brought the up months ago, and I think it was Tellow (sorry if I'm misremembering) who said they wanted the ability to continue to run the CI on their fork without any extra effort, so this change shouldn't prevent that from happening.

If there's a cleaner way to do it, then I'll change things, because having to duplicate it on each job is kinda nasty... but from a quick glance I couldn't see a way to add a custom condition into the on:push section.

### Rationale behind Changes

Making the CI waste less time.

### Suggested Testing Steps

Make sure CI only runs once.

