### PR TITLE
GameDB: Fix CLUT colors for Kazuku Keikaku (SLPM-65889)

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -32009,7 +32009,7 @@ SLPM-65889:
   name: "Kazoku Keikaku - Kokoro no Kizuna"
   region: "NTSC-J"
   gsHWFixes:
-    beforeDraw: "OI_PointListPalette"
+    gpuTargetCLUT: 1 # Fixes broken colors.
 SLPM-65890:
   name: "Shin Sangoku Musou 4"
   region: "NTSC-J"


### PR DESCRIPTION
### Description of Changes
Correct gamefixes to fix CLUT problems in HW mode

### Rationale behind Changes
Old fix didn't work.

### Suggested Testing Steps
Already tested.

Fixes #9039
