### PR TITLE
DEV9: Deduplicate sparse file assert code

### DIFF
--- a/pcsx2/DEV9/ATA/ATA.h
+++ b/pcsx2/DEV9/ATA/ATA.h
@@ -222,6 +222,9 @@ private:
 	bool IO_SparseZero(u64 byteOffset, u64 byteSize);
 	void IO_SparseCacheUpdateLocation(u64 Offset);
 	void IO_SparseCacheLoad();
+#if defined(PCSX2_DEBUG) || defined(PCSX2_DEVBUILD)
+	void IO_SparseCacheAssertFileZeros(u64 hddSparseBlockSizeReadable);
+#endif
 	bool IsAllZero(const void* data, size_t len);
 	void HDD_ReadAsync(void (ATA::*drqCMD)());
 	void HDD_ReadSync(void (ATA::*drqCMD)());


### PR DESCRIPTION
### Description of Changes
Deduplicates the code asserting that the sparse/allocated apis and FileSystem apis are in sync.
This moves back the assert talked about here https://github.com/PCSX2/pcsx2/pull/8992#discussion_r1232734269 as its intention was to protect this debug only code from being unable to restore the file pointer.
The error handling mentioned https://github.com/PCSX2/pcsx2/pull/8992#discussion_r1234689894 is retained as it protects non-debug code.

### Rationale behind Changes
Addresses https://github.com/PCSX2/pcsx2/pull/8992#discussion_r1232748845
Less duplicated code, hopefully code is clearer in intent

### Suggested Testing Steps
DEV9 works as expected, CI passes.
