### PR TITLE
GameDB: Add minimum blending level for Snow (SLPS 25342 & 25332)

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -39527,6 +39527,8 @@ SLPS-25330:
 SLPS-25332:
   name: "Snow [First Limited Edition]"
   region: "NTSC-J"
+  gsHWFixes:
+    minimumBlendingLevel: 4 # Fixes transparancy.
 SLPS-25333:
   name: "Gallop Racer Lucky 7"
   region: "NTSC-J"
@@ -39591,6 +39593,8 @@ SLPS-25341:
 SLPS-25342:
   name: "Snow"
   region: "NTSC-J"
+  gsHWFixes:
+    minimumBlendingLevel: 4 # Fixes transparancy.
 SLPS-25343:
   name: "Gunslinger Girl Vol.1"
   region: "NTSC-J"


### PR DESCRIPTION
### Description of Changes
Fixes transparency in Japanese game Snow

### Rationale behind Changes
Transparency bad

### Suggested Testing Steps
Watch CI

Fixes #9043