### PR TITLE
Qt: Add Setup Wizard

### DIFF
--- a/pcsx2-qt/CMakeLists.txt
+++ b/pcsx2-qt/CMakeLists.txt
@@ -25,6 +25,9 @@ target_sources(pcsx2-qt PRIVATE
 	PrecompiledHeader.cpp
 	PrecompiledHeader.h
 	SettingWidgetBinder.h
+	SetupWizardDialog.cpp
+	SetupWizardDialog.h
+	SetupWizardDialog.ui
 	Themes.cpp
 	Translations.cpp
 	QtHost.cpp

--- a/pcsx2-qt/QtHost.cpp
+++ b/pcsx2-qt/QtHost.cpp
@@ -21,6 +21,7 @@
 #include "MainWindow.h"
 #include "QtHost.h"
 #include "QtUtils.h"
+#include "SetupWizardDialog.h"
 #include "svnrev.h"
 
 #include "pcsx2/CDVD/CDVDcommon.h"
@@ -79,6 +80,8 @@ namespace QtHost
 	static bool InitializeConfig();
 	static void SaveSettings();
 	static void HookSignals();
+	static void RegisterTypes();
+	static bool RunSetupWizard();
 } // namespace QtHost
 
 //////////////////////////////////////////////////////////////////////////
@@ -91,6 +94,7 @@ static bool s_nogui_mode = false;
 static bool s_start_fullscreen_ui = false;
 static bool s_start_fullscreen_ui_fullscreen = false;
 static bool s_test_config_and_exit = false;
+static bool s_run_setup_wizard = false;
 static bool s_boot_and_debug = false;
 
 //////////////////////////////////////////////////////////////////////////
@@ -591,7 +595,11 @@ void Host::LoadSettings(SettingsInterface& si, std::unique_lock<std::mutex>& loc
 
 void EmuThread::checkForSettingChanges(const Pcsx2Config& old_config)
 {
-	QMetaObject::invokeMethod(g_main_window, &MainWindow::checkForSettingChanges, Qt::QueuedConnection);
+	if (g_main_window)
+	{
+		QMetaObject::invokeMethod(g_main_window, &MainWindow::checkForSettingChanges, Qt::QueuedConnection);
+		updatePerformanceMetrics(true);
+	}
 
 	if (GetMTGS().IsOpen())
 	{
@@ -603,8 +611,6 @@ void EmuThread::checkForSettingChanges(const Pcsx2Config& old_config)
 			GetMTGS().WaitGS();
 		}
 	}
-
-	updatePerformanceMetrics(true);
 }
 
 void Host::CheckForSettingsChanges(const Pcsx2Config& old_config)
@@ -1199,6 +1205,7 @@ bool QtHost::InitializeConfig()
 	CrashHandler::SetWriteDirectory(EmuFolders::DataRoot);
 
 	const std::string path(Path::Combine(EmuFolders::Settings, "PCSX2.ini"));
+	s_run_setup_wizard = s_run_setup_wizard || !FileSystem::FileExists(path.c_str());
 	Console.WriteLn("Loading config from %s.", path.c_str());
 
 	s_base_settings_interface = std::make_unique<INISettingsInterface>(std::move(path));
@@ -1215,8 +1222,15 @@ bool QtHost::InitializeConfig()
 		}
 
 		VMManager::SetDefaultSettings(*s_base_settings_interface, true, true, true, true, true);
-		SaveSettings();
+		
+		// Don't save if we're running the setup wizard. We want to run it next time if they don't finish it.
+		if (!s_run_setup_wizard)
+			SaveSettings();
 	}
+
+	// Setup wizard was incomplete last time?
+	s_run_setup_wizard =
+		s_run_setup_wizard || s_base_settings_interface->GetBoolValue("UI", "SetupWizardIncomplete", false);
 
 	LogSink::SetBlockSystemConsole(QtHost::InNoGUIMode());
 	VMManager::Internal::LoadStartupSettings();
@@ -1536,6 +1550,7 @@ void QtHost::PrintCommandLineHelp(const std::string_view& progname)
 	std::fprintf(stderr, "  -bigpicture: Forces PCSX2 to use the Big Picture mode (useful for controller-only and couch play).\n");
 	std::fprintf(stderr, "  -earlyconsolelog: Forces logging of early console messages to console.\n");
 	std::fprintf(stderr, "  -testconfig: Initializes configuration and checks version, then exits.\n");
+	std::fprintf(stderr, "  -setupwizard: Forces initial setup wizard to run.\n");
 	std::fprintf(stderr, "  -debugger: Open debugger and break on entry point.\n");
 #ifdef ENABLE_RAINTEGRATION
 	std::fprintf(stderr, "  -raintegration: Use RAIntegration instead of built-in achievement support.\n");
@@ -1659,6 +1674,11 @@ bool QtHost::ParseCommandLineOptions(const QStringList& args, std::shared_ptr<VM
 				s_test_config_and_exit = true;
 				continue;
 			}
+			else if (CHECK_ARG(QStringLiteral("-setupwizard")))
+			{
+				s_run_setup_wizard = true;
+				continue;
+			}
 			else if (CHECK_ARG(QStringLiteral("-debugger")))
 			{
 				s_boot_and_debug = true;
@@ -1738,7 +1758,7 @@ static bool PerformEarlyHardwareChecks()
 
 #endif
 
-static void RegisterTypes()
+void QtHost::RegisterTypes()
 {
 	qRegisterMetaType<std::optional<bool>>();
 	qRegisterMetaType<std::optional<WindowInfo>>("std::optional<WindowInfo>()");
@@ -1757,12 +1777,28 @@ static void RegisterTypes()
 	qRegisterMetaType<const GameList::Entry*>();
 }
 
+bool QtHost::RunSetupWizard()
+{
+	// Set a flag in the config so that even though we created the ini, we'll run the wizard next time.
+	Host::SetBaseBoolSettingValue("UI", "SetupWizardIncomplete", true);
+	Host::CommitBaseSettingChanges();
+
+	SetupWizardDialog dialog;
+	if (dialog.exec() == QDialog::Rejected)
+		return false;
+
+	// Remove the flag.
+	Host::SetBaseBoolSettingValue("UI", "SetupWizardIncomplete", false);
+	Host::CommitBaseSettingChanges();
+	return true;
+}
+
 int main(int argc, char* argv[])
 {
 	CrashHandler::Install();
 
 	QGuiApplication::setHighDpiScaleFactorRoundingPolicy(Qt::HighDpiScaleFactorRoundingPolicy::PassThrough);
-	RegisterTypes();
+	QtHost::RegisterTypes();
 
 	QApplication app(argc, argv);
 
@@ -1785,24 +1821,32 @@ int main(int argc, char* argv[])
 
 	// Set theme before creating any windows.
 	QtHost::UpdateApplicationTheme();
-	MainWindow* main_window = new MainWindow();
 
 	// Start up the CPU thread.
 	QtHost::HookSignals();
 	EmuThread::start();
 
+	// Optionally run setup wizard.
+	int result;
+	if (s_run_setup_wizard && !QtHost::RunSetupWizard())
+	{
+		result = EXIT_FAILURE;
+		goto shutdown_and_exit;
+	}
+
 	// Create all window objects, the emuthread might still be starting up at this point.
-	main_window->initialize();
+	g_main_window = new MainWindow();
+	g_main_window->initialize();
 
 	// When running in batch mode, ensure game list is loaded, but don't scan for any new files.
 	if (!s_batch_mode)
-		main_window->refreshGameList(false);
+		g_main_window->refreshGameList(false);
 	else
 		GameList::Refresh(false, true);
 
 	// Don't bother showing the window in no-gui mode.
 	if (!s_nogui_mode)
-		main_window->show();
+		g_main_window->show();
 
 	// Initialize big picture mode if requested.
 	if (s_start_fullscreen_ui)
@@ -1811,18 +1855,19 @@ int main(int argc, char* argv[])
 	if (s_boot_and_debug)
 	{
 		DebugInterface::setPauseOnEntry(true);
-		main_window->openDebugger();
+		g_main_window->openDebugger();
 	}
 
 	// Skip the update check if we're booting a game directly.
 	if (autoboot)
 		g_emu_thread->startVM(std::move(autoboot));
 	else if (!s_nogui_mode)
-		main_window->startupUpdateCheck();
+		g_main_window->startupUpdateCheck();
 
 	// This doesn't return until we exit.
-	const int result = app.exec();
+	result = app.exec();
 
+shutdown_and_exit:
 	// Shutting down.
 	EmuThread::stop();
 	if (g_main_window)

--- a/pcsx2-qt/Settings/BIOSSettingsWidget.h
+++ b/pcsx2-qt/Settings/BIOSSettingsWidget.h
@@ -46,6 +46,21 @@ public:
 	BIOSSettingsWidget(SettingsDialog* dialog, QWidget* parent);
 	~BIOSSettingsWidget();
 
+	class RefreshThread final : public QThread
+	{
+	public:
+		RefreshThread(QWidget* parent, const QString& directory);
+		~RefreshThread();
+
+	protected:
+		void run() override;
+
+	private:
+		QString m_directory;
+	};
+
+	static void populateList(QTreeWidget* list, const QVector<BIOSInfo>& items);
+
 private Q_SLOTS:
 	void refreshList();
 
@@ -57,20 +72,6 @@ private Q_SLOTS:
 private:
 	Ui::BIOSSettingsWidget m_ui;
 	SettingsDialog* m_dialog;
-
-	class RefreshThread final : public QThread
-	{
-	public:
-		RefreshThread(BIOSSettingsWidget* parent, const QString& directory);
-		~RefreshThread();
-
-	protected:
-		void run() override;
-
-	private:
-		BIOSSettingsWidget* m_parent;
-		QString m_directory;
-	};
 
 	RefreshThread* m_refresh_thread = nullptr;
 };

--- a/pcsx2-qt/Settings/InterfaceSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/InterfaceSettingsWidget.cpp
@@ -22,7 +22,7 @@
 #include "SettingsDialog.h"
 #include "QtHost.h"
 
-static const char* THEME_NAMES[] = {
+const char* InterfaceSettingsWidget::THEME_NAMES[] = {
 	QT_TRANSLATE_NOOP("InterfaceSettingsWidget", "Native"),
 	//: Ignore what Crowdin says in this string about "[Light]/[Dark]" being untouchable here, these are not variables in this case and must be translated.
 	QT_TRANSLATE_NOOP("InterfaceSettingsWidget", "Fusion [Light/Dark]"),
@@ -52,7 +52,7 @@ static const char* THEME_NAMES[] = {
 	QT_TRANSLATE_NOOP("InterfaceSettingsWidget", "Custom.qss [Drop in PCSX2 Folder]"),
 	nullptr};
 
-static const char* THEME_VALUES[] = {
+const char* InterfaceSettingsWidget::THEME_VALUES[] = {
 	"",
 	"fusion",
 	"darkfusion",

--- a/pcsx2-qt/Settings/InterfaceSettingsWidget.h
+++ b/pcsx2-qt/Settings/InterfaceSettingsWidget.h
@@ -40,4 +40,8 @@ private:
 	void populateLanguages();
 
 	Ui::InterfaceSettingsWidget m_ui;
+
+public:
+	static const char* THEME_NAMES[];
+	static const char* THEME_VALUES[];
 };

--- a/pcsx2-qt/SetupWizardDialog.cpp
+++ b/pcsx2-qt/SetupWizardDialog.cpp
@@ -1,0 +1,506 @@
+/*  PCSX2 - PS2 Emulator for PCs
+ *  Copyright (C) 2002-2023 PCSX2 Dev Team
+ *
+ *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU Lesser General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  PCSX2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with PCSX2.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "PrecompiledHeader.h"
+
+#include "PAD/Host/PAD.h"
+#include "QtHost.h"
+#include "QtUtils.h"
+#include "SettingWidgetBinder.h"
+#include "Settings/ControllerSettingWidgetBinder.h"
+#include "Settings/InterfaceSettingsWidget.h"
+#include "SetupWizardDialog.h"
+
+#include <QtWidgets/QMessageBox>
+
+SetupWizardDialog::SetupWizardDialog()
+{
+	setupUi();
+	updatePageLabels(-1);
+	updatePageButtons();
+}
+
+SetupWizardDialog::~SetupWizardDialog()
+{
+	if (m_bios_refresh_thread)
+	{
+		m_bios_refresh_thread->wait();
+		delete m_bios_refresh_thread;
+	}
+}
+
+void SetupWizardDialog::resizeEvent(QResizeEvent* event)
+{
+	QDialog::resizeEvent(event);
+	resizeDirectoryListColumns();
+}
+
+bool SetupWizardDialog::canShowNextPage()
+{
+	const int current_page = m_ui.pages->currentIndex();
+
+	switch (current_page)
+	{
+		case Page_BIOS:
+		{
+			if (!m_ui.biosList->currentItem())
+			{
+				if (QMessageBox::question(this, tr("Warning"),
+						tr("A BIOS image has not been selected. PCSX2 <strong>will not</strong> be able to run games "
+						   "without a BIOS image.<br><br>Are you sure you wish to continue without selecting a BIOS "
+						   "image?")) != QMessageBox::Yes)
+				{
+					return false;
+				}
+			}
+		}
+		break;
+
+		case Page_GameList:
+		{
+			if (m_ui.searchDirectoryList->rowCount() == 0)
+			{
+				if (QMessageBox::question(this, tr("Warning"),
+						tr("No game directories have been selected. You will have to manually open any game dumps you "
+						   "want to play, PCSX2's list will be empty.\n\nAre you sure you want to continue?")) !=
+					QMessageBox::Yes)
+				{
+					return false;
+				}
+			}
+		}
+		break;
+
+		default:
+			break;
+	}
+
+	return true;
+}
+
+void SetupWizardDialog::previousPage()
+{
+	const int current_page = m_ui.pages->currentIndex();
+	if (current_page == 0)
+		return;
+
+	m_ui.pages->setCurrentIndex(current_page - 1);
+	updatePageLabels(current_page);
+	updatePageButtons();
+}
+
+void SetupWizardDialog::nextPage()
+{
+	const int current_page = m_ui.pages->currentIndex();
+	if (current_page == Page_Complete)
+	{
+		accept();
+		return;
+	}
+
+	if (!canShowNextPage())
+		return;
+
+	const int new_page = current_page + 1;
+	m_ui.pages->setCurrentIndex(new_page);
+	updatePageLabels(current_page);
+	updatePageButtons();
+	pageChangedTo(new_page);
+}
+
+void SetupWizardDialog::pageChangedTo(int page)
+{
+	switch (page)
+	{
+		case Page_GameList:
+			resizeDirectoryListColumns();
+			break;
+
+		default:
+			break;
+	}
+}
+
+void SetupWizardDialog::updatePageLabels(int prev_page)
+{
+	if (prev_page >= 0)
+	{
+		QFont prev_font = m_page_labels[prev_page]->font();
+		prev_font.setBold(false);
+		m_page_labels[prev_page]->setFont(prev_font);
+	}
+
+	const int page = m_ui.pages->currentIndex();
+	QFont font = m_page_labels[page]->font();
+	font.setBold(true);
+	m_page_labels[page]->setFont(font);
+}
+
+void SetupWizardDialog::updatePageButtons()
+{
+	const int page = m_ui.pages->currentIndex();
+	m_ui.next->setText((page == Page_Complete) ? "&Finish" : "&Next");
+	m_ui.back->setEnabled(page > 0);
+}
+
+void SetupWizardDialog::confirmCancel()
+{
+	if (QMessageBox::question(this, tr("Cancel Setup"),
+			tr("Are you sure you want to cancel PCSX2 setup?\n\nAny changes have been saved, and the wizard will run "
+			   "again next time you start PCSX2.")) != QMessageBox::Yes)
+	{
+		return;
+	}
+
+	reject();
+}
+
+void SetupWizardDialog::setupUi()
+{
+	setWindowIcon(QIcon(QStringLiteral("%1/icons/AppIconLarge.png").arg(QtHost::GetResourcesBasePath())));
+
+	m_ui.setupUi(this);
+
+	m_ui.pages->setCurrentIndex(0);
+
+	m_page_labels[Page_Language] = m_ui.labelLanguage;
+	m_page_labels[Page_BIOS] = m_ui.labelBIOS;
+	m_page_labels[Page_GameList] = m_ui.labelGameList;
+	m_page_labels[Page_Controller] = m_ui.labelController;
+	m_page_labels[Page_Complete] = m_ui.labelComplete;
+
+	connect(m_ui.back, &QPushButton::clicked, this, &SetupWizardDialog::previousPage);
+	connect(m_ui.next, &QPushButton::clicked, this, &SetupWizardDialog::nextPage);
+	connect(m_ui.cancel, &QPushButton::clicked, this, &SetupWizardDialog::confirmCancel);
+
+	setupLanguagePage();
+	setupBIOSPage();
+	setupGameListPage();
+	setupControllerPage();
+}
+
+void SetupWizardDialog::setupLanguagePage()
+{
+	SettingWidgetBinder::BindWidgetToEnumSetting(nullptr, m_ui.theme, "UI", "Theme",
+		InterfaceSettingsWidget::THEME_NAMES, InterfaceSettingsWidget::THEME_VALUES, QtHost::GetDefaultThemeName());
+	connect(m_ui.theme, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &SetupWizardDialog::themeChanged);
+
+	for (const std::pair<QString, QString>& it : QtHost::GetAvailableLanguageList())
+		m_ui.language->addItem(it.first, it.second);
+	SettingWidgetBinder::BindWidgetToStringSetting(
+		nullptr, m_ui.language, "UI", "Language", QtHost::GetDefaultLanguage());
+	connect(
+		m_ui.language, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &SetupWizardDialog::languageChanged);
+
+	SettingWidgetBinder::BindWidgetToBoolSetting(
+		nullptr, m_ui.autoUpdateEnabled, "AutoUpdater", "CheckAtStartup", true);
+}
+
+void SetupWizardDialog::themeChanged()
+{
+	// Main window gets recreated at the end here anyway, so it's fine to just yolo it.
+	QtHost::UpdateApplicationTheme();
+}
+
+void SetupWizardDialog::languageChanged()
+{
+	// Skip the recreation, since we don't have many dynamic UI elements.
+	QtHost::InstallTranslator();
+	m_ui.retranslateUi(this);
+}
+
+void SetupWizardDialog::setupBIOSPage()
+{
+	SettingWidgetBinder::BindWidgetToFolderSetting(nullptr, m_ui.biosSearchDirectory, m_ui.browseBiosSearchDirectory,
+		m_ui.openBiosSearchDirectory, m_ui.resetBiosSearchDirectory, "Folders", "Bios",
+		Path::Combine(EmuFolders::DataRoot, "bios"));
+
+	refreshBiosList();
+
+	connect(m_ui.biosSearchDirectory, &QLineEdit::textChanged, this, &SetupWizardDialog::refreshBiosList);
+	connect(m_ui.refreshBiosList, &QPushButton::clicked, this, &SetupWizardDialog::refreshBiosList);
+	connect(m_ui.biosList, &QTreeWidget::currentItemChanged, this, &SetupWizardDialog::biosListItemChanged);
+}
+
+void SetupWizardDialog::refreshBiosList()
+{
+	if (m_bios_refresh_thread)
+	{
+		m_bios_refresh_thread->wait();
+		delete m_bios_refresh_thread;
+	}
+
+	QSignalBlocker blocker(m_ui.biosList);
+	m_ui.biosList->clear();
+	m_ui.biosList->setEnabled(false);
+
+	m_bios_refresh_thread = new BIOSSettingsWidget::RefreshThread(this, m_ui.biosSearchDirectory->text());
+	m_bios_refresh_thread->start();
+}
+
+void SetupWizardDialog::biosListItemChanged(const QTreeWidgetItem* current, const QTreeWidgetItem* previous)
+{
+	Host::SetBaseStringSettingValue("Filenames", "BIOS", current->text(0).toUtf8().constData());
+	Host::CommitBaseSettingChanges();
+	g_emu_thread->applySettings();
+}
+
+void SetupWizardDialog::listRefreshed(const QVector<BIOSInfo>& items)
+{
+	QSignalBlocker sb(m_ui.biosList);
+	BIOSSettingsWidget::populateList(m_ui.biosList, items);
+	m_ui.biosList->setEnabled(true);
+}
+
+void SetupWizardDialog::setupGameListPage()
+{
+	m_ui.searchDirectoryList->setSelectionMode(QAbstractItemView::SingleSelection);
+	m_ui.searchDirectoryList->setSelectionBehavior(QAbstractItemView::SelectRows);
+	m_ui.searchDirectoryList->setAlternatingRowColors(true);
+	m_ui.searchDirectoryList->setShowGrid(false);
+	m_ui.searchDirectoryList->horizontalHeader()->setHighlightSections(false);
+	m_ui.searchDirectoryList->verticalHeader()->hide();
+	m_ui.searchDirectoryList->setCurrentIndex({});
+	m_ui.searchDirectoryList->setContextMenuPolicy(Qt::ContextMenuPolicy::CustomContextMenu);
+
+	connect(m_ui.searchDirectoryList, &QTableWidget::customContextMenuRequested, this,
+		&SetupWizardDialog::onDirectoryListContextMenuRequested);
+	connect(m_ui.addSearchDirectoryButton, &QPushButton::clicked, this,
+		&SetupWizardDialog::onAddSearchDirectoryButtonClicked);
+	connect(m_ui.removeSearchDirectoryButton, &QPushButton::clicked, this,
+		&SetupWizardDialog::onRemoveSearchDirectoryButtonClicked);
+
+	refreshDirectoryList();
+}
+
+void SetupWizardDialog::onDirectoryListContextMenuRequested(const QPoint& point)
+{
+	QModelIndexList selection = m_ui.searchDirectoryList->selectionModel()->selectedIndexes();
+	if (selection.size() < 1)
+		return;
+
+	const int row = selection[0].row();
+
+	QMenu menu;
+	menu.addAction(tr("Remove"), [this]() { onRemoveSearchDirectoryButtonClicked(); });
+	menu.addSeparator();
+	menu.addAction(tr("Open Directory..."),
+		[this, row]() { QtUtils::OpenURL(this, QUrl::fromLocalFile(m_ui.searchDirectoryList->item(row, 0)->text())); });
+	menu.exec(m_ui.searchDirectoryList->mapToGlobal(point));
+}
+
+void SetupWizardDialog::onAddSearchDirectoryButtonClicked()
+{
+	QString dir = QDir::toNativeSeparators(QFileDialog::getExistingDirectory(this, tr("Select Search Directory")));
+
+	if (dir.isEmpty())
+		return;
+
+	QMessageBox::StandardButton selection = QMessageBox::question(this, tr("Scan Recursively?"),
+		tr("Would you like to scan the directory \"%1\" recursively?\n\nScanning recursively takes "
+		   "more time, but will identify files in subdirectories.")
+			.arg(dir),
+		QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel);
+	if (selection == QMessageBox::Cancel)
+		return;
+
+	const bool recursive = (selection == QMessageBox::Yes);
+	const std::string spath = dir.toStdString();
+	Host::RemoveBaseValueFromStringList("GameList", recursive ? "Paths" : "RecursivePaths", spath.c_str());
+	Host::AddBaseValueToStringList("GameList", recursive ? "RecursivePaths" : "Paths", spath.c_str());
+	Host::CommitBaseSettingChanges();
+	refreshDirectoryList();
+}
+
+void SetupWizardDialog::onRemoveSearchDirectoryButtonClicked()
+{
+	const int row = m_ui.searchDirectoryList->currentRow();
+	std::unique_ptr<QTableWidgetItem> item((row >= 0) ? m_ui.searchDirectoryList->takeItem(row, 0) : nullptr);
+	if (!item)
+		return;
+
+	const std::string spath = item->text().toStdString();
+	if (!Host::RemoveBaseValueFromStringList("GameList", "Paths", spath.c_str()) &&
+		!Host::RemoveBaseValueFromStringList("GameList", "RecursivePaths", spath.c_str()))
+	{
+		return;
+	}
+
+	Host::CommitBaseSettingChanges();
+	refreshDirectoryList();
+}
+
+void SetupWizardDialog::addPathToTable(const std::string& path, bool recursive)
+{
+	const int row = m_ui.searchDirectoryList->rowCount();
+	m_ui.searchDirectoryList->insertRow(row);
+
+	QTableWidgetItem* item = new QTableWidgetItem();
+	item->setText(QString::fromStdString(path));
+	item->setFlags(item->flags() & ~(Qt::ItemIsEditable));
+	m_ui.searchDirectoryList->setItem(row, 0, item);
+
+	QCheckBox* cb = new QCheckBox(m_ui.searchDirectoryList);
+	m_ui.searchDirectoryList->setCellWidget(row, 1, cb);
+	cb->setChecked(recursive);
+
+	connect(cb, &QCheckBox::stateChanged, [item](int state) {
+		const std::string path(item->text().toStdString());
+		if (state == Qt::Checked)
+		{
+			Host::RemoveBaseValueFromStringList("GameList", "Paths", path.c_str());
+			Host::AddBaseValueToStringList("GameList", "RecursivePaths", path.c_str());
+		}
+		else
+		{
+			Host::RemoveBaseValueFromStringList("GameList", "RecursivePaths", path.c_str());
+			Host::AddBaseValueToStringList("GameList", "Paths", path.c_str());
+		}
+		Host::CommitBaseSettingChanges();
+	});
+}
+
+void SetupWizardDialog::refreshDirectoryList()
+{
+	QSignalBlocker sb(m_ui.searchDirectoryList);
+	while (m_ui.searchDirectoryList->rowCount() > 0)
+		m_ui.searchDirectoryList->removeRow(0);
+
+	std::vector<std::string> path_list = Host::GetBaseStringListSetting("GameList", "Paths");
+	for (const std::string& entry : path_list)
+		addPathToTable(entry, false);
+
+	path_list = Host::GetBaseStringListSetting("GameList", "RecursivePaths");
+	for (const std::string& entry : path_list)
+		addPathToTable(entry, true);
+
+	m_ui.searchDirectoryList->sortByColumn(0, Qt::AscendingOrder);
+}
+
+void SetupWizardDialog::resizeDirectoryListColumns()
+{
+	QtUtils::ResizeColumnsForTableView(m_ui.searchDirectoryList, {-1, 100});
+}
+
+void SetupWizardDialog::setupControllerPage()
+{
+	static constexpr u32 NUM_PADS = 2;
+
+	struct PadWidgets
+	{
+		QComboBox* type_combo;
+		QLabel* mapping_result;
+		QToolButton* mapping_button;
+	};
+	const PadWidgets pad_widgets[NUM_PADS] = {
+		{m_ui.controller1Type, m_ui.controller1Mapping, m_ui.controller1AutomaticMapping},
+		{m_ui.controller2Type, m_ui.controller2Mapping, m_ui.controller2AutomaticMapping},
+	};
+
+	for (u32 port = 0; port < NUM_PADS; port++)
+	{
+		const std::string section = fmt::format("Pad{}", port + 1);
+		const PadWidgets& w = pad_widgets[port];
+
+		for (const auto& [name, display_name] : PAD::GetControllerTypeNames())
+			w.type_combo->addItem(qApp->translate("Pad", display_name), QString::fromStdString(name));
+		ControllerSettingWidgetBinder::BindWidgetToInputProfileString(
+			nullptr, w.type_combo, section, "Type", PAD::GetDefaultPadType(port));
+
+		w.mapping_result->setText((port == 0) ? tr("Default (Keyboard)") : tr("Default (None)"));
+
+		connect(w.mapping_button, &QAbstractButton::clicked, this,
+			[this, port, label = w.mapping_result]() { openAutomaticMappingMenu(port, label); });
+	}
+
+	// Trigger enumeration to populate the device list.
+	connect(g_emu_thread, &EmuThread::onInputDevicesEnumerated, this, &SetupWizardDialog::onInputDevicesEnumerated);
+	connect(g_emu_thread, &EmuThread::onInputDeviceConnected, this, &SetupWizardDialog::onInputDeviceConnected);
+	connect(g_emu_thread, &EmuThread::onInputDeviceDisconnected, this, &SetupWizardDialog::onInputDeviceDisconnected);
+	g_emu_thread->enumerateInputDevices();
+}
+
+void SetupWizardDialog::openAutomaticMappingMenu(u32 port, QLabel* update_label)
+{
+	QMenu menu(this);
+	bool added = false;
+
+	for (const QPair<QString, QString>& dev : m_device_list)
+	{
+		// we set it as data, because the device list could get invalidated while the menu is up
+		QAction* action = menu.addAction(QStringLiteral("%1 (%2)").arg(dev.first).arg(dev.second));
+		action->setData(dev.first);
+		connect(action, &QAction::triggered, this, [this, port, update_label, action]() {
+			doDeviceAutomaticBinding(port, update_label, action->data().toString());
+		});
+		added = true;
+	}
+
+	if (!added)
+	{
+		QAction* action = menu.addAction(tr("No devices available"));
+		action->setEnabled(false);
+	}
+
+	menu.exec(QCursor::pos());
+}
+
+void SetupWizardDialog::doDeviceAutomaticBinding(u32 port, QLabel* update_label, const QString& device)
+{
+	std::vector<std::pair<GenericInputBinding, std::string>> mapping =
+		InputManager::GetGenericBindingMapping(device.toStdString());
+	if (mapping.empty())
+	{
+		QMessageBox::critical(this, tr("Automatic Binding"),
+			tr("No generic bindings were generated for device '%1'. The controller/source may not support automatic "
+			   "mapping.")
+				.arg(device));
+		return;
+	}
+
+	bool result;
+	{
+		auto lock = Host::GetSettingsLock();
+		result = PAD::MapController(*Host::Internal::GetBaseSettingsLayer(), port, mapping);
+	}
+	if (!result)
+		return;
+
+	Host::CommitBaseSettingChanges();
+
+	update_label->setText(device);
+}
+
+void SetupWizardDialog::onInputDevicesEnumerated(const QList<QPair<QString, QString>>& devices)
+{
+	m_device_list = devices;
+}
+
+void SetupWizardDialog::onInputDeviceConnected(const QString& identifier, const QString& device_name)
+{
+	m_device_list.emplace_back(identifier, device_name);
+}
+
+void SetupWizardDialog::onInputDeviceDisconnected(const QString& identifier)
+{
+	for (auto iter = m_device_list.begin(); iter != m_device_list.end(); ++iter)
+	{
+		if (iter->first == identifier)
+		{
+			m_device_list.erase(iter);
+			break;
+		}
+	}
+}

--- a/pcsx2-qt/SetupWizardDialog.h
+++ b/pcsx2-qt/SetupWizardDialog.h
@@ -1,0 +1,96 @@
+/*  PCSX2 - PS2 Emulator for PCs
+ *  Copyright (C) 2002-2023 PCSX2 Dev Team
+ *
+ *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU Lesser General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  PCSX2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with PCSX2.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "Settings/BIOSSettingsWidget.h"
+
+#include "ui_SetupWizardDialog.h"
+
+#include <QtCore/QList>
+#include <QtCore/QString>
+#include <QtCore/QVector>
+#include <QtWidgets/QDialog>
+
+#include "common/Pcsx2Defs.h"
+
+class SetupWizardDialog final : public QDialog
+{
+	Q_OBJECT
+
+public:
+	SetupWizardDialog();
+	~SetupWizardDialog();
+
+private Q_SLOTS:
+	bool canShowNextPage();
+	void previousPage();
+	void nextPage();
+	void confirmCancel();
+
+	void themeChanged();
+	void languageChanged();
+
+	void refreshBiosList();
+	void biosListItemChanged(const QTreeWidgetItem* current, const QTreeWidgetItem* previous);
+	void listRefreshed(const QVector<BIOSInfo>& items);
+
+	void onDirectoryListContextMenuRequested(const QPoint& point);
+	void onAddSearchDirectoryButtonClicked();
+	void onRemoveSearchDirectoryButtonClicked();
+	void refreshDirectoryList();
+	void resizeDirectoryListColumns();
+
+	void onInputDevicesEnumerated(const QList<QPair<QString, QString>>& devices);
+	void onInputDeviceConnected(const QString& identifier, const QString& device_name);
+	void onInputDeviceDisconnected(const QString& identifier);
+
+protected:
+	void resizeEvent(QResizeEvent* event);
+
+private:
+	enum Page : u32
+	{
+		Page_Language,
+		Page_BIOS,
+		Page_GameList,
+		Page_Controller,
+		Page_Complete,
+		Page_Count,
+	};
+
+	void setupUi();
+	void setupLanguagePage();
+	void setupBIOSPage();
+	void setupGameListPage();
+	void setupControllerPage();
+
+	void pageChangedTo(int page);
+	void updatePageLabels(int prev_page);
+	void updatePageButtons();
+
+	void addPathToTable(const std::string& path, bool recursive);
+
+	void openAutomaticMappingMenu(u32 port, QLabel* update_label);
+	void doDeviceAutomaticBinding(u32 port, QLabel* update_label, const QString& device);
+
+	Ui::SetupWizardDialog m_ui;
+
+	std::array<QLabel*, Page_Count> m_page_labels;
+
+	BIOSSettingsWidget::RefreshThread* m_bios_refresh_thread = nullptr;
+
+	QList<QPair<QString, QString>> m_device_list;
+};

--- a/pcsx2-qt/SetupWizardDialog.ui
+++ b/pcsx2-qt/SetupWizardDialog.ui
@@ -1,0 +1,661 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>SetupWizardDialog</class>
+ <widget class="QDialog" name="SetupWizardDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>760</width>
+    <height>389</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>PCSX2 Setup Wizard</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <property name="horizontalSpacing">
+    <number>10</number>
+   </property>
+   <item row="0" column="0">
+    <layout class="QVBoxLayout" name="verticalLayout_2">
+     <item>
+      <widget class="QLabel" name="label">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>128</width>
+         <height>128</height>
+        </size>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="pixmap">
+        <pixmap resource="resources/resources.qrc">:/icons/AppIcon.png</pixmap>
+       </property>
+       <property name="scaledContents">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <property name="spacing">
+        <number>20</number>
+       </property>
+       <item>
+        <widget class="QLabel" name="labelLanguage">
+         <property name="font">
+          <font>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>Language</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="labelBIOS">
+         <property name="text">
+          <string>BIOS Image</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="labelGameList">
+         <property name="text">
+          <string>Game Directories</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="labelController">
+         <property name="text">
+          <string>Controller Setup</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="labelComplete">
+         <property name="text">
+          <string>Complete</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <spacer name="verticalSpacer">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>20</width>
+         <height>40</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item row="0" column="1">
+    <widget class="QStackedWidget" name="pages">
+     <property name="currentIndex">
+      <number>0</number>
+     </property>
+     <widget class="QWidget" name="page">
+      <layout class="QVBoxLayout" name="verticalLayout_3">
+       <property name="spacing">
+        <number>10</number>
+       </property>
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="QLabel" name="label_2">
+         <property name="text">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;h1 style=&quot; margin-top:18px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:xx-large; font-weight:700;&quot;&gt;Welcome to PCSX2!&lt;/span&gt;&lt;/h1&gt;&lt;p&gt;This wizard will help guide you through the configuration steps required to use the application. It is recommended if this is your first time installing PCSX2 that you view the setup guide at &lt;a href=&quot;https://pcsx2.net/docs/usage/setup/&quot;&gt;https://pcsx2.net/docs/usage/setup/&lt;/a&gt;.&lt;/p&gt;&lt;p&gt;By default, PCSX2 will connect to the server at &lt;a href=&quot;https://pcsx2.net/&quot;&gt;pcsx2.net&lt;/a&gt; to check for updates, and if available and confirmed, download update packages from &lt;a href=&quot;https://github.com/&quot;&gt;github.com&lt;/a&gt;. If you do not wish for PCSX2 to make any network connections on startup, you should uncheck the Automatic Updates option now. The Automatic Update setting can be changed later at any time in Interface Settings.&lt;/p&gt;&lt;p&gt;Please choose a language and theme to begin.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <layout class="QFormLayout" name="formLayout_3">
+         <item row="0" column="0">
+          <widget class="QLabel" name="label_3">
+           <property name="text">
+            <string>Language:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QComboBox" name="language">
+           <property name="minimumSize">
+            <size>
+             <width>200</width>
+             <height>0</height>
+            </size>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="label_5">
+           <property name="text">
+            <string>Theme:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QComboBox" name="theme"/>
+         </item>
+         <item row="3" column="1">
+          <spacer name="verticalSpacer_3">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>40</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item row="2" column="0" colspan="2">
+          <widget class="QCheckBox" name="autoUpdateEnabled">
+           <property name="text">
+            <string>Enable Automatic Updates</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="page_2">
+      <layout class="QVBoxLayout" name="verticalLayout_4">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="QLabel" name="label_4">
+         <property name="text">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;PCSX2 requires a PS2 BIOS in order to run.&lt;/p&gt;&lt;p&gt;For legal reasons, you must obtain a BIOS &lt;strong&gt;from an actual PS2 unit that you own&lt;/strong&gt; (borrowing doesn't count).&lt;/p&gt;&lt;p&gt;Once dumped, this BIOS image should be placed in the bios folder within the data directory shown below, or you can instruct PCSX2 to scan an alternative directory.&lt;/p&gt;&lt;p&gt;A guide for dumping your BIOS can be found at &lt;a href=&quot;https://pcsx2.net/docs/usage/setup/#how-to-dump-your-ps2-bios&quot;&gt;pcsx2.net&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_3">
+         <item>
+          <widget class="QLabel" name="label_10">
+           <property name="text">
+            <string>BIOS Directory:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLineEdit" name="biosSearchDirectory"/>
+         </item>
+         <item>
+          <widget class="QPushButton" name="browseBiosSearchDirectory">
+           <property name="text">
+            <string>Browse...</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="resetBiosSearchDirectory">
+           <property name="text">
+            <string>Reset</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <widget class="QTreeWidget" name="biosList">
+         <property name="rootIsDecorated">
+          <bool>false</bool>
+         </property>
+         <attribute name="headerMinimumSectionSize">
+          <number>250</number>
+         </attribute>
+         <attribute name="headerDefaultSectionSize">
+          <number>250</number>
+         </attribute>
+         <column>
+          <property name="text">
+           <string>Filename</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>Version</string>
+          </property>
+         </column>
+        </widget>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_2">
+         <item>
+          <spacer name="horizontalSpacer_4">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QPushButton" name="openBiosSearchDirectory">
+           <property name="text">
+            <string>Open in Explorer...</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="refreshBiosList">
+           <property name="text">
+            <string>Refresh List</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="page_3">
+      <layout class="QVBoxLayout" name="verticalLayout_5">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="QLabel" name="label_6">
+         <property name="text">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;PCSX2 will automatically scan and identify games from the selected directories below, and populate the game list.&lt;br&gt;These games should be dumped from discs you own. Guides for dumping discs can be found at &lt;a href=&quot;https://pcsx2.net/docs/usage/setup/#dumping-ps2-discs-via-imgburn&quot;&gt;pcsx2.net&lt;/a&gt;.&lt;/p&gt;&lt;p&gt;Supported formats for dumps include:&lt;/p&gt;&lt;p&gt;&lt;ul&gt;&lt;li&gt;.bin/.iso (ISO Disc Images)&lt;/li&gt;&lt;li&gt;.mdf (Media Descriptor File)&lt;/li&gt;&lt;li&gt;.chd (Compressed Hunks of Data)&lt;/li&gt;&lt;li&gt;.cso (Compressed ISO)&lt;/li&gt;&lt;li&gt;.gz (Gzip Compressed ISO)&lt;/li&gt;&lt;/ul&gt;&lt;/p&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_4">
+         <item>
+          <widget class="QLabel" name="label_7">
+           <property name="text">
+            <string>Search Directories (will be scanned for games)</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_5">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QToolButton" name="addSearchDirectoryButton">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Add</string>
+           </property>
+           <property name="icon">
+            <iconset theme="folder-add-line">
+             <normaloff>.</normaloff>.</iconset>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QToolButton" name="removeSearchDirectoryButton">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Remove</string>
+           </property>
+           <property name="icon">
+            <iconset theme="folder-reduce-line">
+             <normaloff>.</normaloff>.</iconset>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <widget class="QTableWidget" name="searchDirectoryList">
+         <column>
+          <property name="text">
+           <string>Search Directory</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>Scan Recursively</string>
+          </property>
+         </column>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="page_4">
+      <layout class="QVBoxLayout" name="verticalLayout_6">
+       <property name="spacing">
+        <number>10</number>
+       </property>
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="QLabel" name="label_8">
+         <property name="text">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;By default, PCSX2 will map your keyboard to the virtual PS2 controller.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;To use an external controller, you must map it first. &lt;/span&gt;On this screen, you can automatically map any controller which is currently connected. If your controller is not currently connected, you can plug it in now.&lt;/p&gt;&lt;p&gt;To change controller bindings in more detail, or use multi-tap, open the Settings menu and choose Controllers once you have completed the Setup Wizard.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="groupBox">
+         <property name="title">
+          <string>Controller Port 1</string>
+         </property>
+         <layout class="QFormLayout" name="formLayout">
+          <item row="0" column="1">
+           <widget class="QComboBox" name="controller1Type"/>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_12">
+            <property name="text">
+             <string>Controller Mapped To:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_11">
+            <property name="text">
+             <string>Controller Type:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <layout class="QHBoxLayout" name="horizontalLayout_5">
+            <item>
+             <widget class="QLabel" name="controller1Mapping">
+              <property name="text">
+               <string>Default (Keyboard)</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer_6">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
+             <widget class="QToolButton" name="controller1AutomaticMapping">
+              <property name="text">
+               <string>Automatic Mapping</string>
+              </property>
+              <property name="icon">
+               <iconset theme="controller-line">
+                <normaloff>Settings</normaloff>Settings</iconset>
+              </property>
+              <property name="toolButtonStyle">
+               <enum>Qt::ToolButtonTextBesideIcon</enum>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="groupBox_2">
+         <property name="title">
+          <string>Controller Port 2</string>
+         </property>
+         <layout class="QFormLayout" name="formLayout_2">
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_13">
+            <property name="text">
+             <string>Controller Type:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QComboBox" name="controller2Type"/>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_14">
+            <property name="text">
+             <string>Controller Mapped To:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <layout class="QHBoxLayout" name="horizontalLayout_6">
+            <item>
+             <widget class="QLabel" name="controller2Mapping">
+              <property name="text">
+               <string>Default (Keyboard)</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer_8">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
+             <widget class="QToolButton" name="controller2AutomaticMapping">
+              <property name="text">
+               <string>Automatic Mapping</string>
+              </property>
+              <property name="icon">
+               <iconset theme="controller-line">
+                <normaloff>Settings</normaloff>Settings</iconset>
+              </property>
+              <property name="toolButtonStyle">
+               <enum>Qt::ToolButtonTextBesideIcon</enum>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_4">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="page_5">
+      <layout class="QVBoxLayout" name="verticalLayout_7">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="QLabel" name="label_9">
+         <property name="text">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;h1 style=&quot; margin-top:18px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:xx-large; font-weight:700;&quot;&gt;Setup Complete!&lt;/span&gt;&lt;/h1&gt;&lt;p&gt;You are now ready to run games.&lt;/p&gt;&lt;p&gt;Further options are available under the settings menu. You can also use the Big Picture UI for navigation entirely with a gamepad.&lt;/p&gt;&lt;p&gt;We hope you enjoy using PCSX2.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+   <item row="1" column="0" colspan="2">
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <property name="spacing">
+      <number>6</number>
+     </property>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="back">
+       <property name="text">
+        <string>&amp;Back</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="next">
+       <property name="text">
+        <string>&amp;Next</string>
+       </property>
+       <property name="default">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="cancel">
+       <property name="text">
+        <string>&amp;Cancel</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources>
+  <include location="resources/resources.qrc"/>
+  <include location="resources/resources.qrc"/>
+ </resources>
+ <connections/>
+</ui>

--- a/pcsx2-qt/pcsx2-qt.vcxproj
+++ b/pcsx2-qt/pcsx2-qt.vcxproj
@@ -88,6 +88,7 @@
     <ClCompile Include="Settings\GameCheatSettingsWidget.cpp" />
     <ClCompile Include="Settings\GamePatchSettingsWidget.cpp" />
     <ClCompile Include="Settings\MemoryCardConvertWorker.cpp" />
+    <ClCompile Include="SetupWizardDialog.cpp" />
     <ClCompile Include="Themes.cpp" />
     <ClCompile Include="Tools\InputRecording\InputRecordingViewer.cpp" />
     <ClCompile Include="Tools\InputRecording\NewInputRecordingDlg.cpp" />
@@ -142,6 +143,7 @@
     <ClCompile Include="Translations.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <QtMoc Include="SetupWizardDialog.h" />
     <QtMoc Include="Settings\InterfaceSettingsWidget.h" />
     <QtMoc Include="Settings\GameListSettingsWidget.h" />
     <QtMoc Include="Settings\BIOSSettingsWidget.h" />
@@ -253,6 +255,7 @@
     <ClCompile Include="$(IntDir)moc_MainWindow.cpp" />
     <ClCompile Include="$(IntDir)moc_QtHost.cpp" />
     <ClCompile Include="$(IntDir)moc_QtProgressCallback.cpp" />
+    <ClCompile Include="$(IntDir)moc_SetupWizardDialog.cpp" />
     <ClCompile Include="$(IntDir)Tools\InputRecording\moc_NewInputRecordingDlg.cpp" />
     <ClCompile Include="$(IntDir)Tools\InputRecording\moc_InputRecordingViewer.cpp" />
     <ClCompile Include="$(IntDir)qrc_resources.cpp">
@@ -367,6 +370,9 @@
     </QtUi>
   </ItemGroup>
   <ItemGroup>
+    <QtUi Include="SetupWizardDialog.ui">
+      <FileType>Document</FileType>
+    </QtUi>
     <QtTs Include="Translations\pcsx2-qt_en.ts">
       <FileType>Document</FileType>
     </QtTs>

--- a/pcsx2-qt/pcsx2-qt.vcxproj.filters
+++ b/pcsx2-qt/pcsx2-qt.vcxproj.filters
@@ -332,6 +332,10 @@
       <Filter>moc</Filter>
     </ClCompile>
     <ClCompile Include="Translations.cpp" />
+    <ClCompile Include="SetupWizardDialog.cpp" />
+    <ClCompile Include="$(IntDir)moc_SetupWizardDialog.cpp">
+      <Filter>moc</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Manifest Include="..\pcsx2\windows\PCSX2.manifest">
@@ -479,8 +483,13 @@
       <Filter>Debugger\Models</Filter>
     </QtMoc>
     <QtMoc Include="ColorPickerButton.h" />
-    <QtMoc Include="Settings\GameCheatSettingsWidget.h" />
-    <QtMoc Include="Settings\GamePatchSettingsWidget.h" />
+    <QtMoc Include="SetupWizardDialog.h" />
+    <QtMoc Include="Settings\GameCheatSettingsWidget.h">
+      <Filter>Settings</Filter>
+    </QtMoc>
+    <QtMoc Include="Settings\GamePatchSettingsWidget.h">
+      <Filter>Settings</Filter>
+    </QtMoc>
   </ItemGroup>
   <ItemGroup>
     <QtResource Include="resources\resources.qrc">
@@ -611,6 +620,7 @@
     <QtUi Include="Settings\GamePatchSettingsWidget.ui">
       <Filter>Settings</Filter>
     </QtUi>
+    <QtUi Include="SetupWizardDialog.ui" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Settings\FolderSettingsWidget.ui">


### PR DESCRIPTION
### Description of Changes

Adds a setup wizard to Qt, like wx used to have.

You can force the wizard to run by adding `-setupwizard` to the CLI. 

Note: I'm aware the icon is low-res and looks like ass on hidpi, we need a better one.

![image](https://github.com/PCSX2/pcsx2/assets/11288319/090555af-facd-4c92-9858-bf1ccf791282)
![image](https://github.com/PCSX2/pcsx2/assets/11288319/be4e7cee-9c28-4421-8932-c35360e2c0b3)
![image](https://github.com/PCSX2/pcsx2/assets/11288319/f20a7ba5-11f3-4377-b261-c7db8bb83917)
![image](https://github.com/PCSX2/pcsx2/assets/11288319/19d0ecb7-167c-4174-b00e-dbb28a45d6f3)
![image](https://github.com/PCSX2/pcsx2/assets/11288319/4b77c624-6bed-4b30-8366-178de2ade4b8)

### Rationale behind Changes

Making it easier for users to set up PCSX2.

### Suggested Testing Steps

Test setup wizard on a clean copy of PCSX2. Make sure all functionality works as expected (can check by visually inspecting the ini).
Make sure cancelling setup makes it run again next time.
Make sure existing inis don't trigger setup wizard.
