### PR TITLE
CI/Linux: Use clang 16 for AppImage

### DIFF
--- a/.github/workflows/linux_build_qt.yml
+++ b/.github/workflows/linux_build_qt.yml
@@ -102,8 +102,8 @@ jobs:
         env:
           COMPILER: ${{ inputs.compiler }}
           ADDITIONAL_CMAKE_ARGS: ${{ inputs.cmakeflags }}
-          CLANG_PATH: /usr/bin/clang-12
-          CLANGXX_PATH: /usr/bin/clang++-12
+          CLANG_PATH: /usr/bin/clang-16
+          CLANGXX_PATH: /usr/bin/clang++-16
         run: |
           DEPS_PREFIX="$HOME/deps" .github/workflows/scripts/linux/generate-cmake-qt.sh
 

--- a/.github/workflows/scripts/linux/install-packages-qt.sh
+++ b/.github/workflows/scripts/linux/install-packages-qt.sh
@@ -67,7 +67,13 @@ declare -a PCSX2_PACKAGES=(
 if [ "${COMPILER}" = "gcc" ]; then
 	BUILD_PACKAGES+=("g++-10")
 else
-	BUILD_PACKAGES+=("llvm-12" "lld-12" "clang-12")
+	BUILD_PACKAGES+=("llvm-16" "lld-16" "clang-16")
+
+	# Ubuntu 20.04 doesn't ship with LLVM 16, so we need to pull it from the llvm.org repos.
+	retry_command wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+	sudo apt-add-repository -n 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-16 main'
+	retry_command sudo apt-get update
+	retry_command sudo apt-get install clang-16 lld-16
 fi
 
 retry_command sudo apt-get -qq update && break


### PR DESCRIPTION
### Description of Changes

clang v12 generates the wrong instruction for https://github.com/PCSX2/pcsx2/blob/faa25f2a960c07a6804c49e9fdf61e48f52e8165/pcsx2/GS/GSState.cpp#L3260

Bad:

![image](https://github.com/PCSX2/pcsx2/assets/11288319/8c3b8bfe-b936-419f-8e06-3eb87b8212d7)

Good:

![image](https://github.com/PCSX2/pcsx2/assets/11288319/69fa51fb-2136-4037-9cf1-7666e78c8e11)

Ignore the fact that one is sprites and one's tris, the issue is present in both.

The `& 0xff` gets optimized out, because it's emitting `vmovmskps` instead of `vpmovmskb`, which is a 4-bit mask instead of a 16-bit mask.

Seems to be a documented issue: https://bugs.llvm.org/show_bug.cgi?id=52567 "The _mm_movemask_epi8 intrinsic will sometimes call pmovmskb and will other times call movmskps"

Only real way around it seems to be to upgrade the compiler. None of my attempts to massage it into difference codegen made any difference. So I pulled LLVM 16 in from the llvm.org apt repo.

Note that this will make the AppImage lose symbols in the gdb which ships with Ubuntu 20.04. It just spits out
```
Reading symbols from ./bin/pcsx2-qt...
Dwarf Error: DW_FORM_strx1 found in non-DWO CU [in module /home/user/pcsx2/build13/bin/pcsx2-qt]
(No debugging symbols found in ./bin/pcsx2-qt)
```

The built-in backtraces still work fine, though.

What a mess. Thanks Linux.

### Rationale behind Changes

Closes #9045.

### Suggested Testing Steps

Test AppImage.
