### PR TITLE
GS/HW: Update drawn area and full valid bits on hardware move

### DIFF
--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -1798,9 +1798,9 @@ void GSState::Write(const u8* mem, int len)
 		}
 
 		GL_CACHE("Write! %u ...  => 0x%x W:%d F:%s (DIR %d%d), dPos(%d %d) size(%d %d)", s_transfer_n,
-			blit.DBP, blit.DBW, psm_str(blit.DPSM),
-			m_env.TRXPOS.DIRX, m_env.TRXPOS.DIRY,
-			m_env.TRXPOS.DSAX, m_env.TRXPOS.DSAY, w, h);
+				blit.DBP, blit.DBW, psm_str(blit.DPSM),
+				m_env.TRXPOS.DIRX, m_env.TRXPOS.DIRY,
+				m_env.TRXPOS.DSAX, m_env.TRXPOS.DSAY, w, h);
 
 		if (len >= m_tr.total)
 		{


### PR DESCRIPTION
### Description of Changes
Updates more of the destination target information when a move is done in hardware mode

### Rationale behind Changes
Before we weren't updating the drawn area, which is technically all of it here as it is all dirty compared to local mem, but also we were using the source valid bits but this certainly isn't true as there could be data from local mem which is stored on the texture being copied, but also there could be dirty data under the new target if the valid bits don't cover the entire pixel colour.

### Suggested Testing Steps
Uhh smoke test, I guess, not much uses this. Armored Core, Bust a Move (both tested), stuff like that.

Fixes #9042

Cross Channel - To All People (slightly different frame, which is why one is darker)

Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/2ed894d0-99d7-4557-851c-94ee71278a20)

PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/a3d83f3f-0f96-4ea8-ab0f-abcf9f604f7c)

