### PR TITLE
crowdin: update automatic PR title so squash merge has the right format

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,4 +1,4 @@
-pull_request_title: "[ci skip] Syncing Crowdin translations"
+pull_request_title: "translations: Syncing Crowdin translations"
 commit_message: "[ci skip]"
 files:
   - source: pcsx2-qt/Translations/pcsx2-qt_en.ts


### PR DESCRIPTION
Just to make it more difficult to make the mistake i just made (forgot to put a prefix in the squash merged commit)

I also realized that i need to remove the `ci skip` from the title of the PR (which becomes the master merge commit), or the release workflows won't run