### PR TITLE
IPU: Slow down BDEC and IDEC so they don't outstrip DMA data writes

### DIFF
--- a/pcsx2/IPU/IPU.cpp
+++ b/pcsx2/IPU/IPU.cpp
@@ -94,6 +94,13 @@ __fi void IPUProcessInterrupt()
 {
 	if (ipuRegs.ctrl.BUSY && !CommandExecuteQueued)
 		IPUWorker();
+
+	if (ipuRegs.ctrl.BUSY)
+	{
+		CPU_INT(IPU_PROCESS, ProcessedData ? ProcessedData : 64);
+	}
+	else
+		ProcessedData = 0;
 }
 
 /////////////////////////////////////////////////////////
@@ -460,7 +467,7 @@ __fi void IPUCMD_WRITE(u32 val)
 {
 	// don't process anything if currently busy
 	//if (ipuRegs.ctrl.BUSY) Console.WriteLn("IPU BUSY!"); // wait for thread
-
+	ProcessedData = 0;
 	ipuRegs.ctrl.ECD = 0;
 	ipuRegs.ctrl.SCD = 0;
 	ipu_cmd.clear();

--- a/pcsx2/IPU/IPU.h
+++ b/pcsx2/IPU/IPU.h
@@ -294,6 +294,7 @@ extern bool EnableFMV;
 alignas(16) extern tIPU_cmd ipu_cmd;
 extern uint eecount_on_last_vdec;
 extern bool CommandExecuteQueued;
+extern u32 ProcessedData;
 
 extern void ipuReset();
 

--- a/pcsx2/IPU/IPU_Fifo.cpp
+++ b/pcsx2/IPU/IPU_Fifo.cpp
@@ -184,7 +184,7 @@ void WriteFIFO_IPUin(const mem128_t* value)
 		if (ipuRegs.ctrl.BUSY && !CommandExecuteQueued)
 		{
 			CommandExecuteQueued = true;
-			CPU_INT(IPU_PROCESS, 1 * BIAS);
+			CPU_INT(IPU_PROCESS, 8);
 		}
 	}
 }

--- a/pcsx2/IPU/IPU_MultiISA.cpp
+++ b/pcsx2/IPU/IPU_MultiISA.cpp
@@ -1116,7 +1116,9 @@ __ri static bool mpeg2sliceIDEC()
 					ipu_dither(rgb32, rgb16, decoder.dte);
 					decoder.SetOutputTo(rgb16);
 				}
-				[[fallthrough]];
+				ProcessedData += decoder.ipu0_data;
+				ipu_cmd.pos[1] = 2;
+				return false;
 
 			case 2:
 			{
@@ -1498,7 +1500,9 @@ __fi static bool mpeg2_slice()
 		coded_block_pattern = decoder.coded_block_pattern;
 
 		decoder.SetOutputTo(mb16);
-		[[fallthrough]];
+		ProcessedData += decoder.ipu0_data;
+		ipu_cmd.pos[0] = 3;
+		return false;
 
 	case 3:
 	{

--- a/pcsx2/IPU/IPUdma.cpp
+++ b/pcsx2/IPU/IPUdma.cpp
@@ -21,12 +21,14 @@
 
 IPUStatus IPU1Status;
 bool CommandExecuteQueued;
+u32 ProcessedData;
 
 void ipuDmaReset()
 {
 	IPU1Status.InProgress	= false;
 	IPU1Status.DMAFinished	= true;
 	CommandExecuteQueued	= false;
+	ProcessedData			= 0;
 }
 
 void SaveStateBase::ipuDmaFreeze()
@@ -199,7 +201,7 @@ void IPU0dma()
 	{
 		CommandExecuteQueued = true;
 		CPU_SET_DMASTALL(DMAC_FROM_IPU, true);
-		CPU_INT(IPU_PROCESS, 4);
+		CPU_INT(IPU_PROCESS, readsize * BIAS);
 	}
 }
 
@@ -281,6 +283,7 @@ __fi void dmaIPU1() // toIPU
 void ipuCMDProcess()
 {
 	CommandExecuteQueued = false;
+	ProcessedData = 0;
 	IPUProcessInterrupt();
 }
 


### PR DESCRIPTION
### Description of Changes
Try to slow down IDEC and BDEC based on how much data they have transferred, and use a base amount of delay of 64 to begin processing.

### Rationale behind Changes
These numbers aren't exact, they're just something so it doesn't go insanely fast, there are situations where a DMA will start to drain an IDEC and it will go so fast, the data hasn't been written by the time the IPU gets to it, so this will simulate the encoding time, at least a little.  In the future it would be nice to run some tests on a PS2 get some good numbers, but doing IPU Stuff is difficult.

### Suggested Testing Steps
Test videos, make sure nothing is broken, also check Lord of the Rings - Return of the King (PAL)

Fixes #7073 Lord of the Rings - Return of the King
