### PR TITLE
GameDB/Config: Don't apply GS upscaling fixes in native resolution

### DIFF
--- a/pcsx2/GameDatabase.h
+++ b/pcsx2/GameDatabase.h
@@ -124,11 +124,11 @@ namespace GameDatabaseSchema
 		const std::string* findPatch(u32 crc) const;
 		const char* compatAsString() const;
 
-		/// Applies Core game fixes to an existing config. Returns the number of applied fixes.
-		u32 applyGameFixes(Pcsx2Config& config, bool applyAuto) const;
+		/// Applies Core game fixes to an existing config.
+		void applyGameFixes(Pcsx2Config& config, bool applyAuto) const;
 
-		/// Applies GS hardware fixes to an existing config. Returns the number of applied fixes.
-		u32 applyGSHardwareFixes(Pcsx2Config::GSOptions& config) const;
+		/// Applies GS hardware fixes to an existing config.
+		void applyGSHardwareFixes(Pcsx2Config::GSOptions& config) const;
 
 		/// Returns true if the current config value for the specified hw fix id matches the value.
 		static bool configMatchesHWFix(const Pcsx2Config::GSOptions& config, GSHWFixId id, int value);

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -874,7 +874,7 @@ void Pcsx2Config::GSOptions::MaskUserHacks()
 
 void Pcsx2Config::GSOptions::MaskUpscalingHacks()
 {
-	if (UpscaleMultiplier > 1.0f && ManualUserHacks)
+	if (UpscaleMultiplier > 1.0f)
 		return;
 
 	UserHacks_AlignSpriteX = false;


### PR DESCRIPTION
### Description of Changes
Stops upscaling hacks loading from the gamedb in native resolution

### Rationale behind Changes
These should not apply in native res.

### Suggested Testing Steps
Test games with upscaling fixes in the gamedb, make sure they don't enable.
