### PR TITLE
GS: Double buffer the EE transfer queue

### DIFF
--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -1498,7 +1498,7 @@ void GSState::FlushWrite()
 	r.right = r.left + m_env.TRXREG.RRW;
 	r.bottom = r.top + m_env.TRXREG.RRH;
 
-	InvalidateVideoMem(m_env.BITBLTBUF, r, true);
+	InvalidateVideoMem(m_env.BITBLTBUF, r);
 
 	const GSLocalMemory::writeImage wi = GSLocalMemory::m_psm[m_env.BITBLTBUF.DPSM].wi;
 
@@ -1806,7 +1806,7 @@ void GSState::Write(const u8* mem, int len)
 		if (len >= m_tr.total)
 		{
 			// received all data in one piece, no need to buffer it
-			InvalidateVideoMem(blit, r, true);
+			InvalidateVideoMem(blit, r);
 
 			psm.wi(m_mem, m_tr.x, m_tr.y, mem, m_tr.total, blit, m_env.TRXPOS, m_env.TRXREG);
 
@@ -1913,7 +1913,7 @@ void GSState::Move()
 			 sx, sy, dx, dy, w, h);
 
 	InvalidateLocalMem(m_env.BITBLTBUF, GSVector4i(sx, sy, sx + w, sy + h));
-	InvalidateVideoMem(m_env.BITBLTBUF, GSVector4i(dx, dy, dx + w, dy + h), true);
+	InvalidateVideoMem(m_env.BITBLTBUF, GSVector4i(dx, dy, dx + w, dy + h));
 
 	int xinc = 1;
 	int yinc = 1;

--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -113,6 +113,7 @@ GSState::GSState()
 	GrowVertexBuffer();
 
 	m_draw_transfers.clear();
+	m_draw_transfers_double_buff.clear();
 
 	PRIM = &m_env.PRIM;
 	//CSR->rREV = 0x20;

--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -918,7 +918,7 @@ public:
 	virtual void PurgePool();
 	virtual void PurgeTextureCache();
 	virtual void ReadbackTextureCache();
-	virtual void InvalidateVideoMem(const GIFRegBITBLTBUF& BITBLTBUF, const GSVector4i& r, bool eewrite = false) {}
+	virtual void InvalidateVideoMem(const GIFRegBITBLTBUF& BITBLTBUF, const GSVector4i& r) {}
 	virtual void InvalidateLocalMem(const GIFRegBITBLTBUF& BITBLTBUF, const GSVector4i& r, bool clut = false) {}
 
 	virtual void Move();

--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -235,6 +235,7 @@ public:
 	u32 m_dirty_gs_regs = 0;
 	int m_backed_up_ctx = 0;
 	std::vector<GSUploadQueue> m_draw_transfers;
+	std::vector<GSUploadQueue> m_draw_transfers_double_buff;
 
 	static int s_n;
 	static int s_last_transfer_draw_n;

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -1050,7 +1050,7 @@ bool GSRendererHW::IsTBPFrameOrZ(u32 tbp) const
 }
 
 
-void GSRendererHW::InvalidateVideoMem(const GIFRegBITBLTBUF& BITBLTBUF, const GSVector4i& r, bool eewrite)
+void GSRendererHW::InvalidateVideoMem(const GIFRegBITBLTBUF& BITBLTBUF, const GSVector4i& r)
 {
 	// printf("[%d] InvalidateVideoMem %d,%d - %d,%d %05x (%d)\n", static_cast<int>(g_perfmon.GetFrame()), r.left, r.top, r.right, r.bottom, static_cast<int>(BITBLTBUF.DBP), static_cast<int>(BITBLTBUF.DPSM));
 

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -119,15 +119,19 @@ void GSRendererHW::VSync(u32 field, bool registers_written, bool idle_frame)
 		m_force_preload--;
 		if (m_force_preload == 0)
 		{
-			for (auto iter = m_draw_transfers.begin(); iter != m_draw_transfers.end();)
+			for (auto iter = m_draw_transfers.rbegin(); iter != m_draw_transfers.rend(); iter++)
 			{
 				if ((s_n - iter->draw) > 5)
-					iter = m_draw_transfers.erase(iter);
-				else
+					break;
+				else // Keep the last 5 draws worth of transfers.
 				{
-					iter++;
+					GSUploadQueue transfer = *iter;
+					m_draw_transfers_double_buff.push_back(transfer);
 				}
 			}
+			m_draw_transfers.clear();
+			// Flip EE queue.
+			m_draw_transfers.swap(m_draw_transfers_double_buff);
 		}
 	}
 	else if (!idle_frame)
@@ -136,18 +140,20 @@ void GSRendererHW::VSync(u32 field, bool registers_written, bool idle_frame)
 		// Rocky Legend does this with the main menu FMV's.
 		if (s_last_transfer_draw_n == s_n)
 		{
-			for (auto iter = m_draw_transfers.begin(); iter != m_draw_transfers.end();)
+			for (auto iter = m_draw_transfers.rbegin(); iter != m_draw_transfers.rend(); iter++)
 			{
 				if ((s_n - iter->draw) > 5)
-					iter = m_draw_transfers.erase(iter);
-				else
+					break;
+				else // Keep the last 5 draws worth of transfers.
 				{
-					iter++;
+					GSUploadQueue transfer = *iter;
+					m_draw_transfers_double_buff.push_back(transfer);
 				}
 			}
 		}
-		else
-			m_draw_transfers.clear();
+		m_draw_transfers.clear();
+		// Flip EE queue.
+		m_draw_transfers.swap(m_draw_transfers_double_buff);
 	}
 
 	if (GSConfig.LoadTextureReplacements)

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.h
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.h
@@ -190,7 +190,7 @@ public:
 
 	GSTexture* GetOutput(int i, float& scale, int& y_offset) override;
 	GSTexture* GetFeedbackOutput(float& scale) override;
-	void InvalidateVideoMem(const GIFRegBITBLTBUF& BITBLTBUF, const GSVector4i& r, bool eewrite = false) override;
+	void InvalidateVideoMem(const GIFRegBITBLTBUF& BITBLTBUF, const GSVector4i& r) override;
 	void InvalidateLocalMem(const GIFRegBITBLTBUF& BITBLTBUF, const GSVector4i& r, bool clut = false) override;
 	void Move() override;
 	void Draw() override;

--- a/pcsx2/GS/Renderers/SW/GSRendererSW.cpp
+++ b/pcsx2/GS/Renderers/SW/GSRendererSW.cpp
@@ -616,7 +616,7 @@ void GSRendererSW::Sync(int reason)
 	g_perfmon.Put(GSPerfMon::Fillrate, pixels);
 }
 
-void GSRendererSW::InvalidateVideoMem(const GIFRegBITBLTBUF& BITBLTBUF, const GSVector4i& r, bool eewrite)
+void GSRendererSW::InvalidateVideoMem(const GIFRegBITBLTBUF& BITBLTBUF, const GSVector4i& r)
 {
 	if (LOG)
 	{

--- a/pcsx2/GS/Renderers/SW/GSRendererSW.h
+++ b/pcsx2/GS/Renderers/SW/GSRendererSW.h
@@ -80,7 +80,7 @@ protected:
 	void Draw() override;
 	void Queue(GSRingHeap::SharedPtr<GSRasterizerData>& item);
 	void Sync(int reason);
-	void InvalidateVideoMem(const GIFRegBITBLTBUF& BITBLTBUF, const GSVector4i& r, bool eewrite = false) override;
+	void InvalidateVideoMem(const GIFRegBITBLTBUF& BITBLTBUF, const GSVector4i& r) override;
 	void InvalidateLocalMem(const GIFRegBITBLTBUF& BITBLTBUF, const GSVector4i& r, bool clut = false) override;
 
 	void UsePages(const GSOffset::PageLooper& pages, const int type);


### PR DESCRIPTION
### Description of Changes
Double buffers the EE transfer list for saving only the last 5 draws of transfers.

### Rationale behind Changes
previously it was going through in draw order which could be thousands (Liberty City Stories suffered greatly with 9000+ transfers), now we go in reverse saving the most recent transfers in to a new buffer, then just erase the rest and swap buffer, this proved to be much quicker.

### Suggested Testing Steps
Test Liberty City Stories, maybe some random other stuff as smoke test, dump run on 1300+ showed no changes visually.
