### PR TITLE
Qt: Removes hyperlink color override from Rcheevos

### DIFF
--- a/pcsx2-qt/Settings/AchievementSettingsWidget.ui
+++ b/pcsx2-qt/Settings/AchievementSettingsWidget.ui
@@ -157,7 +157,7 @@
    <item>
     <widget class="QLabel" name="label">
      <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;justify&quot;&gt;PCSX2 uses RetroAchievements as an achievement database and for tracking progress. To use achievements, please sign up for an account at &lt;a href=&quot;https://retroachievements.org/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#4169e1;&quot;&gt;retroachievements.org&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;p align=&quot;justify&quot;&gt;To view the achievement list in-game, press the hotkey for &lt;span style=&quot; font-weight:600;&quot;&gt;Open Pause Menu&lt;/span&gt; and select &lt;span style=&quot; font-weight:600;&quot;&gt;Achievements&lt;/span&gt; from the menu.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;justify&quot;&gt;PCSX2 uses RetroAchievements as an achievement database and for tracking progress. To use achievements, please sign up for an account at &lt;a href=&quot;https://retroachievements.org/&quot;&gt;retroachievements.org&lt;/a&gt;.&lt;/p&gt;&lt;p align=&quot;justify&quot;&gt;To view the achievement list in-game, press the hotkey for &lt;span style=&quot; font-weight:600;&quot;&gt;Open Pause Menu&lt;/span&gt; and select &lt;span style=&quot; font-weight:600;&quot;&gt;Achievements&lt;/span&gt; from the menu.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="textFormat">
       <enum>Qt::RichText</enum>


### PR DESCRIPTION
### Description of Changes
As was discussed in https://github.com/PCSX2/pcsx2/issues/9046#issuecomment-1605271962, this PR removes the color style attribute override from hyperlink on Rcheevos so it follows the currently applied style/theme.
![image](https://github.com/PCSX2/pcsx2/assets/14798312/373402c5-34cc-4801-b1eb-089bc54ae7cf)

NOTE: I noticed that the hyperlink color itself doesn't change fully on theme/style changes, meaning you have to fully restart PCSX2 for the change to take effect, a small issue but worth keeping in mind

NOTE #2: Another thing i noticed is that the translation file also contains color attributes override as well, @stenzek do we need to do something about it, or leave it as is?
![image](https://github.com/PCSX2/pcsx2/assets/14798312/79d9218b-6eb3-44c4-8f22-33c6725cdc88)



### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Readability 100
and Consistency, dude. 

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Check if the links are readable on each themes.