### PR TITLE
FullscreenUI: Add patches/cheats to game settings

### DIFF
--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -3331,6 +3331,8 @@ void FullscreenUI::DrawGraphicsSettingsPage()
 		"EmuCore/GS", "DisableDualSourceBlend", false);
 	DrawToggleSetting(bsi, "Disable Shader Cache", "Prevents the loading and saving of shaders/pipelines to disk.", "EmuCore/GS",
 		"DisableShaderCache", false);
+	DrawToggleSetting(bsi, "Disable Vertex Shader Expand", "Falls back to the CPU for expanding sprites/lines.", "EmuCore/GS",
+		"DisableVertexShaderExpand", false);
 
 	EndMenuButtons();
 }

--- a/pcsx2/Patch.cpp
+++ b/pcsx2/Patch.cpp
@@ -444,7 +444,7 @@ std::string_view Patch::PatchInfo::GetNameParentPart() const
 	return ret;
 }
 
-Patch::PatchInfoList Patch::GetPatchInfo(const std::string& serial, u32 crc, bool cheats, u32* num_unlabelled_patches)
+Patch::PatchInfoList Patch::GetPatchInfo(const std::string_view& serial, u32 crc, bool cheats, u32* num_unlabelled_patches)
 {
 	PatchInfoList ret;
 

--- a/pcsx2/Patch.h
+++ b/pcsx2/Patch.h
@@ -93,7 +93,7 @@ namespace Patch
 	extern const char* CHEATS_CONFIG_SECTION;
 	extern const char* PATCH_ENABLE_CONFIG_KEY;
 
-	extern PatchInfoList GetPatchInfo(const std::string& serial, u32 crc, bool cheats, u32* num_unlabelled_patches);
+	extern PatchInfoList GetPatchInfo(const std::string_view& serial, u32 crc, bool cheats, u32* num_unlabelled_patches);
 
 	/// Reloads cheats/patches. If verbose is set, the number of patches loaded will be shown in the OSD.
 	extern void ReloadPatches(const std::string& serial, u32 crc, bool reload_files, bool reload_enabled_list, bool verbose, bool verbose_if_changed);


### PR DESCRIPTION
### Description of Changes

Self-explanatory. Was in the Qt side but not big picture.

### Rationale behind Changes

Feature parity.

### Suggested Testing Steps

Check patch/cheats menu in big picture UI.
