### PR TITLE
UI: Expand Achievement login box height slightly

### DIFF
--- a/pcsx2-qt/Settings/AchievementLoginDialog.ui
+++ b/pcsx2-qt/Settings/AchievementLoginDialog.ui
@@ -10,19 +10,19 @@
     <x>0</x>
     <y>0</y>
     <width>410</width>
-    <height>190</height>
+    <height>215</height>
    </rect>
   </property>
   <property name="minimumSize">
    <size>
     <width>410</width>
-    <height>190</height>
+    <height>215</height>
    </size>
   </property>
   <property name="maximumSize">
    <size>
     <width>410</width>
-    <height>190</height>
+    <height>215</height>
    </size>
   </property>
   <property name="windowTitle">


### PR DESCRIPTION
### Description of Changes
Makes the Achievements login box slightly bigger to avoid weird jumping around on windows due to the size being smaller than the text allowed.

### Rationale behind Changes
It was kinda janky on windows, this also leaves an extra line in case translations are slightly longer

### Suggested Testing Steps
Look at the achievements login box, move it around, make sure it doesn't jiggle violently.
