### PR TITLE
Linux/CI: Switch to Ubuntu 22.04 and linuxdeploy

### DIFF
--- a/.github/workflows/linux_build_qt.yml
+++ b/.github/workflows/linux_build_qt.yml
@@ -9,7 +9,7 @@ on:
       os:
         required: false
         type: string
-        default: ubuntu-20.04
+        default: ubuntu-22.04
       platform:
         required: false
         type: string
@@ -120,9 +120,9 @@ jobs:
         env:
           NAME: ${{ steps.artifact-metadata.outputs.artifact-name }}
         run: |
-                .github/workflows/scripts/linux/appimage-qt.sh "$(realpath .)" "$(realpath ./build)" "$HOME/deps" "$NAME"
-                mkdir -p "$GITHUB_WORKSPACE"/ci-artifacts/
-                mv "${NAME}.AppImage" "$GITHUB_WORKSPACE"/ci-artifacts/
+          .github/workflows/scripts/linux/appimage-qt.sh "$(realpath .)" "$(realpath ./build)" "$HOME/deps" "$NAME"
+          mkdir -p "$GITHUB_WORKSPACE"/ci-artifacts/
+          mv "${NAME}.AppImage" "$GITHUB_WORKSPACE"/ci-artifacts/
 
       - name: Upload artifact
         if: inputs.buildAppImage == true

--- a/.github/workflows/scripts/linux/AppRun-qt
+++ b/.github/workflows/scripts/linux/AppRun-qt
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-APPDIR=$(dirname "$0")
-exec "$APPDIR/usr/bin/pcsx2-qt" "$@"

--- a/.github/workflows/scripts/linux/appimage-qt.sh
+++ b/.github/workflows/scripts/linux/appimage-qt.sh
@@ -40,255 +40,94 @@ NAME=$4
 
 BINARY=pcsx2-qt
 APPDIRNAME=PCSX2.AppDir
-STRIP=llvm-strip-12
+STRIP=strip
 
-declare -a SYSLIBS=(
-	"libaio.so.1"
-	"libz.so.1"
-	"libuuid.so.1"
-	"libapparmor.so.1"
-	"libblkid.so.1"
-	"libbsd.so.0"
-	"libdbus-1.so.3"
-	"libgcrypt.so.20"
-	"liblzma.so.5"
-	"libmount.so.1"
-	"libnsl.so.1"
-	"libpcre.so.3"
-	"libselinux.so.1"
-	"libsystemd.so.0"
-	"libudev.so.1"
-	"libwrap.so.0"
-	"libharfbuzz.so.0"
-	"libFLAC.so.8"
-	"libXau.so.6"
-	"libXcomposite.so.1"
-	"libXcursor.so.1"
-	"libXdamage.so.1"
-	"libXdmcp.so.6"
-	"libXext.so.6"
-	"libXfixes.so.3"
-	"libXi.so.6"
-	"libXinerama.so.1"
-	"libXrandr.so.2"
-	"libXrender.so.1"
-	"libXxf86vm.so.1"
-	"libasyncns.so.0"
-	"libcrypto.so.1.1"
-	"libjpeg.so.8"
-	"liblz4.so.1"
-	"libogg.so.0"
-	"libpcap.so.0.8"
-	"libpng16.so.16"
-	"libpulse.so.0"
-	"libsamplerate.so.0"
-	"libsndfile.so.1"
-	"libvorbis.so.0"
-	"libvorbisenc.so.2"
-	"libxcb.so.1"
-	"libxcb-cursor.so.0"
-	"libxcb-render.so.0"
-	"libxcb-shm.so.0"
-	"libxkbcommon.so.0"
-	"libxkbcommon-x11.so.0"
-	"pulseaudio/libpulsecommon-13.99.so"
-	"libasound.so.2"
-	"libfreetype.so.6"
-	"libpcre2-16.so.0"
-	"libexpat.so.1"
-	"libffi.so.7"
-	"libgraphite2.so.3"
-	"libresolv.so.2"
-	"libgpg-error.so.0"
-	"libpcre2-16.so.0"
-	"libpng16.so.16"
-	"libxcb-icccm.so.4"
-	"libxcb-image.so.0"
-	"libxcb-keysyms.so.1"
-	"libxcb-randr.so.0"
-	"libxcb-render.so.0"
-	"libxcb-render-util.so.0"
-	"libxcb-shape.so.0"
-	"libxcb-sync.so.1"
-	"libxcb-util.so.1"
-	"libxcb-xfixes.so.0"
-	"libxcb-xkb.so.1"
-	"libevdev.so.2"
-	"libgudev-1.0.so.0"
-	"libinput.so.10"
-	"libjpeg.so.8"
-	"libmtdev.so.1"
-	"libpng16.so.16"
-	"libudev.so.1"
-	"libuuid.so.1"
-	"libcurl.so.4"
-	"libnghttp2.so.14"
-	"libidn2.so.0"
-	"librtmp.so.1"
-	"libssh.so.4"
-	"libpsl.so.5"
-	"libssl.so.1.1"
-	"libnettle.so.7"
-	"libgnutls.so.30"
-	"libgssapi_krb5.so.2"
-	"libldap_r-2.4.so.2"
-	"liblber-2.4.so.2"
-	"libbrotlidec.so.1"
-	"libunistring.so.2"
-	"libhogweed.so.5"
-	"libgmp.so.10"
-	"libp11-kit.so.0"
-	"libtasn1.so.6"
-	"libkrb5.so.3"
-	"libk5crypto.so.3"
-	"libcom_err.so.2"
-	"libkrb5support.so.0"
-	"libsasl2.so.2"
-	"libgssapi.so.3"
-	"libbrotlicommon.so.1"
-	"libkeyutils.so.1"
-	"libheimntlm.so.0"
-	"libkrb5.so.26"
-	"libasn1.so.8"
-	"libhcrypto.so.4"
-	"libroken.so.18"
-	"libwind.so.0"
-	"libheimbase.so.1"
-	"libhx509.so.5"
-	"libsqlite3.so.0"
-	"libcrypt.so.1"
-	"libdbus-1.so.3"
-)
-
-declare -a DEPLIBS=(
-	"libSDL2-2.0.so.0"
-)
-
-declare -a QTLIBS=(
-	"libQt6Core.so.6"
-	"libQt6Gui.so.6"
-	"libQt6Network.so.6"
-	"libQt6OpenGL.so.6"
-	"libQt6Svg.so.6"
-	"libQt6WaylandClient.so.6"
-	"libQt6WaylandCompositor.so.6"
+declare -a MANUAL_QT_LIBS=(
 	"libQt6WaylandEglClientHwIntegration.so.6"
-	"libQt6WaylandEglCompositorHwIntegration.so.6"
-	"libQt6Widgets.so.6"
-	"libQt6XcbQpa.so.6"
 )
 
-declare -a QTPLUGINS=(
-	"plugins/iconengines"
-	"plugins/imageformats"
-	"plugins/platforms"
-	#"plugins/platformthemes" # Enable this if we want to ship GTK+ themes at any point.
-	"plugins/tls"
-	"plugins/wayland-decoration-client"
-	"plugins/wayland-graphics-integration-client"
-	"plugins/wayland-graphics-integration-server"
-	"plugins/wayland-shell-integration"
-	"plugins/xcbglintegrations"
+declare -a MANUAL_QT_PLUGINS=(
+	"wayland-decoration-client"
+	"wayland-graphics-integration-client"
+	"wayland-shell-integration"
 )
 
 set -e
 
-if [ ! -f appimagetool-x86_64.AppImage ]; then
-	retry_command wget -O appimagetool-x86_64.AppImage https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage
-	chmod +x appimagetool-x86_64.AppImage
+LINUXDEPLOY=./linuxdeploy-x86_64.AppImage
+LINUXDEPLOY_PLUGIN_QT=./linuxdeploy-plugin-qt-x86_64.AppImage
+APPIMAGETOOL=./appimagetool-x86_64.AppImage
+PATCHELF=patchelf
+
+if [ ! -f "$LINUXDEPLOY" ]; then
+	retry_command wget -O "$LINUXDEPLOY" https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage
+	chmod +x "$LINUXDEPLOY"
+fi
+
+if [ ! -f "$LINUXDEPLOY_PLUGIN_QT" ]; then
+	retry_command wget -O "$LINUXDEPLOY_PLUGIN_QT" https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-x86_64.AppImage
+	chmod +x "$LINUXDEPLOY_PLUGIN_QT"
+fi
+
+if [ ! -f "$APPIMAGETOOL" ]; then
+	retry_command wget -O "$APPIMAGETOOL" https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage
+	chmod +x "$APPIMAGETOOL"
 fi
 
 OUTDIR=$(realpath "./$APPDIRNAME")
 SCRIPTDIR=$(dirname "${BASH_SOURCE[0]}")
 rm -fr "$OUTDIR"
-mkdir "$OUTDIR"
-mkdir "$OUTDIR/usr"
 
-echo "Copying binary and resources..."
-cp -a "$BUILDDIR/bin" "$OUTDIR/usr"
+echo "Copying desktop file..."
+cp "$PCSX2DIR/.github/workflows/scripts/linux/pcsx2-qt.desktop" .
+cp "$PCSX2DIR/bin/resources/icons/AppIconLarge.png" "PCSX2.png"
 
-# Get rid of unit tests, we don't want them bloating the squashfs.
-rm -fv "$OUTDIR"/usr/bin/*_test
+echo "Running linuxdeploy to create AppDir..."
+EXTRA_QT_PLUGINS="core;gui;network;svg;waylandclient;widgets;xcbqpa" \
+EXTRA_PLATFORM_PLUGINS="libqwayland-egl.so;libqwayland-generic.so" \
+QMAKE="$DEPSDIR/bin/qmake" \
+$LINUXDEPLOY --plugin qt --appdir="$OUTDIR" --executable="$BUILDDIR/bin/pcsx2-qt" \
+--desktop-file="pcsx2-qt.desktop" --icon-file="PCSX2.png"
 
-# Patch RPATH so the binary goes hunting for shared libraries in the AppDir instead of system.
-echo "Patching RPATH in ${BINARY}..."
-patchelf --set-rpath '$ORIGIN/../lib' "$OUTDIR/usr/bin/$BINARY"
+echo "Copying resources into AppDir..."
+cp -a "$BUILDDIR/bin/resources" "$OUTDIR/usr/bin"
 
-# Currently we leave the main binary unstripped, uncomment if this is not desired.
-#$STRIP "$OUTDIR/usr/bin/$BINARY"
-
-# Libraries we pull in from the system.
-echo "Copying system libraries..."
-mkdir -p "$OUTDIR/usr/lib" "$OUTDIR/usr/lib/pulseaudio"
-for lib in "${SYSLIBS[@]}"; do
-	blib=$(basename "$lib")
-	if [ -f "/lib/x86_64-linux-gnu/$lib" ]; then
-		cp "/lib/x86_64-linux-gnu/$lib" "$OUTDIR/usr/lib/$blib"
-	elif [ -f "$CHROOT/usr/lib/x86_64-linux-gnu/$lib" ]; then
-		cp "$CHROOT/usr/lib/x86_64-linux-gnu/$lib" "$OUTDIR/usr/lib/$blib"
-	elif [ -f "$CHROOT/lib/$lib" ]; then
-		cp "$CHROOT/lib/$lib" "$OUTDIR/usr/lib/$blib"
-	elif [ -f "$CHROOT/usr/lib/$lib" ]; then
-		cp "$CHROOT/usr/lib/$lib" "$OUTDIR/usr/lib/$blib"
-	else
-		echo "*** Failed to find '$blib'"
-		exit 1
-	fi
-
-	$STRIP "$OUTDIR/usr/lib/$blib"
+# LinuxDeploy's Qt plugin doesn't include Wayland support. So manually copy in the additional Wayland libraries.
+echo "Copying Qt Wayland libraries..."
+for lib in "${MANUAL_QT_LIBS[@]}"; do
+	srcpath="$DEPSDIR/lib/$lib"
+	dstpath="$OUTDIR/usr/lib/$lib"
+	echo "  $srcpath -> $dstpath"
+	cp "$srcpath" "$dstpath"
+	$PATCHELF --set-rpath '$ORIGIN' "$dstpath"
+	$STRIP "$dstpath"
 done
 
-# Dependencies we built, at this point it's just SDL.
-echo "Copying dependency libraries..."
-for lib in "${DEPLIBS[@]}"; do
-	blib=$(basename "$lib")
-	if [ -f "$DEPSDIR/lib/$lib" ]; then
-		cp "$DEPSDIR/lib/$lib" "$OUTDIR/usr/lib/$blib"
-	else
-		echo "*** Failed to find '$blib'"
-		exit 1
-	fi
+# .. and plugins.
+echo "Copying Qt Wayland plugins..."
+for GROUP in "${MANUAL_QT_PLUGINS[@]}"; do
+	srcpath="$DEPSDIR/plugins/$GROUP"
+	dstpath="$OUTDIR/usr/plugins/$GROUP"
+	echo "  $srcpath -> $dstpath"
+	mkdir -p "$dstpath"
 
-	$STRIP "$OUTDIR/usr/lib/$blib"
+	for srcsopath in $(find "$DEPSDIR/plugins/$GROUP" -iname '*.so'); do
+		# This is ../../ because it's usually plugins/group/name.so
+		soname=$(basename "$srcsopath")
+		dstsopath="$dstpath/$soname"
+		echo "    $srcsopath -> $dstsopath"
+		cp "$srcsopath" "$dstsopath"
+		$PATCHELF --set-rpath '$ORIGIN/../../lib:$ORIGIN' "$dstsopath"
+		$STRIP "$dstsopath"
+	done
 done
 
-echo "Copying Qt libraries..."
-for lib in "${QTLIBS[@]}"; do
-	cp -aL "$DEPSDIR/lib/$lib" "$OUTDIR/usr/lib"
-	$STRIP "$OUTDIR/usr/lib/$lib"
-done
+# Fix up translations.
+rm -fr "$OUTDIR/usr/bin/translations"
+mv "$OUTDIR/usr/translations" "$OUTDIR/usr/bin"
+cp -a "$BUILDDIR/bin/translations" "$OUTDIR/usr/bin"
 
-echo "Copying Qt plugins..."
-mkdir -p "$OUTDIR/usr/lib/plugins"
-for plugin in "${QTPLUGINS[@]}"; do
-	mkdir -p "$OUTDIR/usr/lib/$plugin"
-	cp -aL "$DEPSDIR/$plugin"/*.so "$OUTDIR/usr/lib/$plugin/"
-done
+echo "Generating AppImage..."
+rm -f "$NAME.AppImage"
+$APPIMAGETOOL -v "$OUTDIR" "$NAME.AppImage"
 
-for so in $(find "$OUTDIR/usr/lib/plugins" -iname '*.so'); do
-	# This is ../../ because it's usually plugins/group/name.so
-	echo "Patching RPATH in ${so}..."
-	patchelf --set-rpath '$ORIGIN/../..' "$so"
-	$STRIP "$so"
-done
-
-for so in $(find "$OUTDIR/usr/lib" -maxdepth 1); do
-	if [ -f "$so" ]; then
-		echo "Patching RPATH in ${so}"
-		patchelf --set-rpath '$ORIGIN' "$so"
-	fi
-done
-
-echo "Creating qt.conf..."
-cat > "$OUTDIR/usr/bin/qt.conf" << EOF
-[Paths]
-Plugins = ../lib/plugins
-EOF
-
-echo "Copy desktop/icon..."
-cp "$PCSX2DIR/bin/resources/icons/AppIconLarge.png" "$OUTDIR/PCSX2.png"
-cp "$SCRIPTDIR/pcsx2-qt.desktop" "$OUTDIR/PCSX2.desktop"
-cp "$SCRIPTDIR/AppRun-qt" "$OUTDIR/AppRun"
-
-echo "Generate AppImage"
-./appimagetool-x86_64.AppImage -v "$OUTDIR" "$NAME.AppImage"

--- a/.github/workflows/scripts/linux/install-packages-qt.sh
+++ b/.github/workflows/scripts/linux/install-packages-qt.sh
@@ -8,14 +8,13 @@ set -e
 # Packages - Build and Qt
 declare -a BUILD_PACKAGES=(
 	"build-essential"
+	"g++"
 	"git"
 	"cmake"
 	"ccache"
 	"ninja-build"
-	"libclang-dev" # Qt goes hunting for libclang-11 specifically.
-	"libclang-11-dev"
-	"libclang-12-dev"
 	"patchelf"
+	"libfuse2"
 	"libglib2.0-dev"
 	"libfontconfig1-dev"
 	"libharfbuzz-dev"
@@ -64,16 +63,12 @@ declare -a PCSX2_PACKAGES=(
 	"zlib1g-dev"
 )
 
-if [ "${COMPILER}" = "gcc" ]; then
-	BUILD_PACKAGES+=("g++-10")
-else
+if [ "${COMPILER}" = "clang" ]; then
 	BUILD_PACKAGES+=("llvm-16" "lld-16" "clang-16")
 
-	# Ubuntu 20.04 doesn't ship with LLVM 16, so we need to pull it from the llvm.org repos.
+	# Ubuntu 22.04 doesn't ship with LLVM 16, so we need to pull it from the llvm.org repos.
 	retry_command wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-	sudo apt-add-repository -n 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-16 main'
-	retry_command sudo apt-get update
-	retry_command sudo apt-get install clang-16 lld-16
+	sudo apt-add-repository -n 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-16 main'
 fi
 
 retry_command sudo apt-get -qq update && break


### PR DESCRIPTION
### Description of Changes

Moves the Linux builder to Ubuntu 22.04 so we can use C++20.

Switches from manual AppImage creation to using linuxdeploy, but we have to do some post steps because the Qt plugin there doesn't support Wayland... of frickin course. Gotta love the Linux desktop experience.

~~Adds libstdc++ into the appimage so hopefully it'll still run on Ubuntu 20.04. With any luck the libc is the same.....~~

### Rationale behind Changes

Moves the Linux builder to Ubuntu 22.04 so we can use C++20.

### Suggested Testing Steps

Make sure AppImage works on a few distros in both brokeland and xorg.
