### PR TITLE
GS/HW: When page aligned, dirty page rects instead of SO

### DIFF
--- a/pcsx2/GS/GSLocalMemory.cpp
+++ b/pcsx2/GS/GSLocalMemory.cpp
@@ -485,6 +485,16 @@ u32 GSLocalMemory::GetEndBlockAddress(u32 bp, u32 bw, u32 psm, GSVector4i rect)
 	return result;
 }
 
+GSVector4i GSLocalMemory::GetRectForPageOffset(u32 base_bp, u32 offset_bp, u32 bw, u32 psm)
+{
+	pxAssert((base_bp % BLOCKS_PER_PAGE) == 0 && (offset_bp % BLOCKS_PER_PAGE) == 0);
+
+	const u32 page_offset = (offset_bp - base_bp) >> 5;
+	const GSVector2i& pgs = m_psm[psm].pgs;
+	const GSVector2i page_offset_xy = GSVector2i(page_offset % bw, page_offset / bw);
+	return GSVector4i(pgs * page_offset_xy).xyxy() + GSVector4i::loadh(pgs);
+}
+
 ///////////////////
 
 void GSLocalMemory::ReadTexture(const GSOffset& off, const GSVector4i& r, u8* dst, int dstpitch, const GIFRegTEXA& TEXA)

--- a/pcsx2/GS/GSLocalMemory.h
+++ b/pcsx2/GS/GSLocalMemory.h
@@ -549,6 +549,7 @@ public:
 	static bool IsPageAligned(u32 psm, const GSVector4i& rc);
 	static u32 GetStartBlockAddress(u32 bp, u32 bw, u32 psm, GSVector4i rect);
 	static u32 GetEndBlockAddress(u32 bp, u32 bw, u32 psm, GSVector4i rect);
+	static GSVector4i GetRectForPageOffset(u32 base_bp, u32 offset_bp, u32 bw, u32 psm);
 
 	// address
 


### PR DESCRIPTION
### Description of Changes

Onimusha 3 moves texture data to a previous render target location (e00), then copies it back with a 1-line offset, to "scroll" the texture upwards. Of course this is done with P8.

Surface offsets got the dirty rect wrong, and it ended up reading back garbage. So instead, when it's page aligned (the first one is in this case), figure out the rectangle for each page in the **target's** PSM/coordinate space, and dirty that instead. Better than surface offsets, which gets it wrong (of course..).

In addition, we can do the same for avoiding some readbacks - if all the pages we're invalidating are within the dirty area, we can skip reading back, since local memory is valid. I do have a slight concern with this - since it uses the union of the dirty area instead of iterating through them, but nothing seems to break.

We could extend this to other cases when the BP doesn't match, but it's better to be conservative when dealing with invalidation...

### Rationale behind Changes

Fixes broken scrolling effects in Onimusha 3.

Closes #8983.

### Suggested Testing Steps

Check Onimusha 3. It won't fix the broken dumps, but the scrolling should work.

afproblem showed up in the run, but that's garbage anyway.
Radiata Stories fireplace showed up, it's more consistently broken? but still broken.
