### PR TITLE
GameDB: Add blending for Clannad and Clover Heart's VNs

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -32975,8 +32975,10 @@ SLPM-66136:
   name: "SuperLite 2000 Vol. 34 - Akai Ito"
   region: "NTSC-J"
 SLPM-66137:
-  name: "Clover Heart's Looking for Happiness [The Best]"
+  name: "Clover Heart's - Looking for Happiness [The Best]"
   region: "NTSC-J"
+  gsHWFixes:
+    minimumBlendingLevel: 4 # Fixes transparancy.
 SLPM-66138:
   name: "Desire [Best Version]"
   region: "NTSC-J"
@@ -33668,7 +33670,8 @@ SLPM-66302:
   name: "Clannad"
   region: "NTSC-J"
   gsHWFixes:
-    cpuCLUTRender: 1 # Fixes colours.
+    gpuTargetCLUT: 1 # Fixes colours.
+    minimumBlendingLevel: 4 # Fixes transparancy.
 SLPM-66307:
   name: "Sengoku Musou 2"
   region: "NTSC-J"
@@ -39834,11 +39837,15 @@ SLPS-25389:
   name: "Gundam Seed - Never Ending Tomorrow"
   region: "NTSC-J"
 SLPS-25390:
-  name: "Clover's Heart - Looking for Happiness [Limited Edition]"
+  name: "Clover Heart's - Looking for Happiness [Limited Edition]"
   region: "NTSC-J"
+  gsHWFixes:
+    minimumBlendingLevel: 4 # Fixes transparancy.
 SLPS-25391:
-  name: "Clover's Heart - Looking for Happiness"
+  name: "Clover Heart's - Looking for Happiness"
   region: "NTSC-J"
+  gsHWFixes:
+    minimumBlendingLevel: 4 # Fixes transparancy.
 SLPS-25392:
   name: "Desire"
   region: "NTSC-J"


### PR DESCRIPTION
### Description of Changes
Add high blending for a couple of VN's

### Rationale behind Changes
transparent is bad

### Suggested Testing Steps
No need

Fixes #9080
Fixes #9061 however it still has an unsolvable upscaling issue, but as per the templates, we don't take reports for upscaling issues (unless the GameDB can fix it)
