### PR TITLE
CI/Mac: Bump OS image to macos-12.0

### DIFF
--- a/.github/workflows/macos_build.yml
+++ b/.github/workflows/macos_build.yml
@@ -9,7 +9,7 @@ on:
       os:
         required: false
         type: string
-        default: macos-11.0
+        default: macos-12.0
       platform:
         required: false
         type: string


### PR DESCRIPTION
### Description of Changes

macos-12.0 includes clang-14 which should include the fix for the issue below.

Just a question of whether apple's fork includes it... iirc they use different versioning.

### Rationale behind Changes

Hoping this might resolve #9090 / #9092 due to the compiler bug mentioned in #9047.

### Suggested Testing Steps

Test Mac builds with affected games.

This GS dump shows it easily: https://github.com/PCSX2/pcsx2/files/11848529/Tokyo.Xtreme.Racer.Drift.2_SLUS-21394_20230623223948.gs.zip
