### PR TITLE
GS:Mac: Add ffmpeg

### DIFF
--- a/.github/workflows/macos_build.yml
+++ b/.github/workflows/macos_build.yml
@@ -67,9 +67,9 @@ jobs:
           brew unlink libjpeg || true # Conflicts with our self-built dependencies
           brew unlink libpng || true
           # Unlike other packages, brew's MoltenVK build uses MoltenVK's minimum macOS version of 10.13 so we can use it
-          if ! brew install molten-vk ccache; then
+          if ! brew install molten-vk ccache nasm; then
             brew update
-            brew install molten-vk ccache
+            brew install molten-vk ccache nasm
           fi
 
       - name: Cache Dependencies
@@ -109,6 +109,7 @@ jobs:
                 -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON \
                 -DUSE_SYSTEM_LIBS=OFF \
                 -DUSE_SYSTEM_SDL2=ON \
+                -DUSE_LINKED_FFMPEG=ON \
                 -DCMAKE_C_COMPILER_LAUNCHER=ccache \
                 -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
                 -DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON \

--- a/.github/workflows/scripts/macos/build-dependencies.sh
+++ b/.github/workflows/scripts/macos/build-dependencies.sh
@@ -10,6 +10,7 @@ SDL=SDL2-2.28.1
 PNG=1.6.37
 JPG=9e
 SOUNDTOUCH=soundtouch-2.3.1
+FFMPEG=6.0
 QT=6.4.3
 
 mkdir deps-build
@@ -25,6 +26,7 @@ cat > SHASUMS <<EOF
 505e70834d35383537b6491e7ae8641f1a4bed1876dbfe361201fc80868d88ca  libpng-$PNG.tar.xz
 4077d6a6a75aeb01884f708919d25934c93305e49f7e3f36db9129320e6f4f3d  jpegsrc.v$JPG.tar.gz
 6900996607258496ce126924a19fe9d598af9d892cf3f33d1e4daaa9b42ae0b1  $SOUNDTOUCH.tar.gz
+57be87c22d9b49c112b6d24bc67d42508660e6b718b3db89c44e47e289137082  ffmpeg-$FFMPEG.tar.xz
 5087c9e5b0165e7bc3c1a4ab176b35d0cd8f52636aea903fa377bdba00891a60  qtbase-everywhere-src-$QT.tar.xz
 88315f886cf81898705e487cedba6e6160724359d23c518c92c333c098879a4a  qtsvg-everywhere-src-$QT.tar.xz
 867df829cd5cd3ae8efe62e825503123542764b13c96953511e567df70c5a091  qttools-everywhere-src-$QT.tar.xz
@@ -36,6 +38,7 @@ curl -L \
 	-O "https://downloads.sourceforge.net/project/libpng/libpng16/$PNG/libpng-$PNG.tar.xz" \
 	-O "https://www.ijg.org/files/jpegsrc.v$JPG.tar.gz" \
 	-O "https://www.surina.net/soundtouch/$SOUNDTOUCH.tar.gz" \
+	-O "https://ffmpeg.org/releases/ffmpeg-$FFMPEG.tar.xz" \
 	-O "https://download.qt.io/official_releases/qt/${QT%.*}/$QT/submodules/qtbase-everywhere-src-$QT.tar.xz" \
 	-O "https://download.qt.io/official_releases/qt/${QT%.*}/$QT/submodules/qtsvg-everywhere-src-$QT.tar.xz" \
 	-O "https://download.qt.io/official_releases/qt/${QT%.*}/$QT/submodules/qttools-everywhere-src-$QT.tar.xz" \
@@ -75,6 +78,18 @@ make -C build "-j$NPROCS"
 make -C build install
 cd ..
 
+echo "Installing FFmpeg..."
+tar xf "ffmpeg-$FFMPEG.tar.xz"
+cd "ffmpeg-$FFMPEG"
+./configure --prefix="$INSTALLDIR" --disable-all --disable-autodetect --disable-static --enable-shared \
+	--enable-avcodec --enable-avformat --enable-avutil --enable-swresample --enable-swscale \
+	--enable-audiotoolbox --enable-videotoolbox \
+	--enable-encoder=ffv1,qtrle,pcm_s16be,pcm_s16le,*_at,*_videotoolbox \
+	--enable-muxer=avi,matroska,mov,mp3,mp4,wav \
+	--enable-protocol=file
+make "-j$NPROCS"
+make install
+cd ..
 
 echo "Installing Qt Base..."
 tar xf "qtbase-everywhere-src-$QT.tar.xz"

--- a/cmake/BuildParameters.cmake
+++ b/cmake/BuildParameters.cmake
@@ -36,6 +36,9 @@ if(UNIX AND NOT APPLE)
 	option(X11_API "Enable X11 support" ON)
 	option(WAYLAND_API "Enable Wayland support" ON)
 	option(DBUS_API "Enable DBus support for screensaver inhibiting" ON)
+endif()
+
+if(UNIX)
 	option(USE_LINKED_FFMPEG "Links with ffmpeg instead of using dynamic loading" OFF)
 endif()
 

--- a/pcsx2/GS/GSCapture.cpp
+++ b/pcsx2/GS/GSCapture.cpp
@@ -1114,7 +1114,7 @@ bool GSCapture::ProcessAudioPackets(s64 video_pts)
 			else
 			{
 				// Direct copy - optimal.
-				std::memcpy(s_converted_audio_frame->data[0] + s_audio_frame_pos * s_audio_frame_bps,
+				std::memcpy(s_converted_audio_frame->data[0] + s_audio_frame_pos * s_audio_frame_bps * AUDIO_CHANNELS,
 					&s_audio_buffer[s_audio_buffer_read_pos * AUDIO_CHANNELS], this_batch * sizeof(s16) * AUDIO_CHANNELS);
 			}
 		}

--- a/pcsx2/GS/GSCapture.cpp
+++ b/pcsx2/GS/GSCapture.cpp
@@ -95,6 +95,7 @@ extern "C" {
 	X(av_strerror) \
 	X(av_reduce) \
 	X(av_dict_parse_string) \
+	X(av_dict_get) \
 	X(av_dict_free) \
 	X(av_opt_set_int) \
 	X(av_opt_set_sample_fmt) \
@@ -528,6 +529,8 @@ bool GSCapture::BeginCapture(float fps, GSVector2i recommendedResolution, float 
 		if (output_format->flags & AVFMT_GLOBALHEADER)
 			s_video_codec_context->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
 
+		bool has_pixel_format_override = wrap_av_dict_get(s_video_codec_arguments, "pixel_format", nullptr, 0);
+
 		res = wrap_avcodec_open2(s_video_codec_context, vcodec, &s_video_codec_arguments);
 		if (res < 0)
 		{
@@ -535,6 +538,10 @@ bool GSCapture::BeginCapture(float fps, GSVector2i recommendedResolution, float 
 			InternalEndCapture(lock);
 			return false;
 		}
+
+		// If the user overrode the pixel format, get that now
+		if (has_pixel_format_override)
+			sw_pix_fmt = s_video_codec_context->pix_fmt;
 
 		s_converted_video_frame = wrap_av_frame_alloc();
 		s_hw_video_frame = IsUsingHardwareVideoEncoding() ? wrap_av_frame_alloc() : nullptr;

--- a/pcsx2/GS/GSCapture.cpp
+++ b/pcsx2/GS/GSCapture.cpp
@@ -409,8 +409,14 @@ bool GSCapture::BeginCapture(float fps, GSVector2i recommendedResolution, float 
 					fmt::format("Video codec {} not found, using default.", GSConfig.VideoCaptureCodec), Host::OSD_ERROR_DURATION);
 			}
 		}
+
+		// FFmpeg decides whether mp4, mkv, etc should use h264 or mpeg4 as their default codec by whether x264 was enabled
+		// But there's a lot of other h264 encoders (e.g. hardware encoders) we may want to use instead
+		if (!vcodec && wrap_avformat_query_codec(output_format, AV_CODEC_ID_H264, FF_COMPLIANCE_NORMAL))
+			vcodec = wrap_avcodec_find_encoder(AV_CODEC_ID_H264);
 		if (!vcodec)
 			vcodec = wrap_avcodec_find_encoder(output_format->video_codec);
+
 		if (!vcodec)
 		{
 			Host::AddIconOSDMessage("GSCaptureError", ICON_FA_CAMERA, "Failed to find video encoder.", Host::OSD_ERROR_DURATION);

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -461,6 +461,7 @@ const char* Pcsx2Config::GSOptions::BlendingLevelNames[] = {
 const char* Pcsx2Config::GSOptions::CaptureContainers[] = {
 	"mp4",
 	"mkv",
+	"mov",
 	"avi",
 	"wav",
 	"mp3",


### PR DESCRIPTION
### Description of Changes
- Adds a minimal (~3MB) copy of ffmpeg to Mac builds (includes a few small lossless codecs and the interface to macOS's system encoding libraries)
- Fixes a bug where s16 codecs would get their audio mangled
- Fixes a bug where setting a pixel format with `pixel_format=fmt` in the extra arguments would break things

### Rationale behind Changes
Capture support on macOS

### Suggested Testing Steps
Try recording things on macOS