### PR TITLE
R5900: Fully get rid of exceptions

### DIFF
--- a/pcsx2/Interpreter.cpp
+++ b/pcsx2/Interpreter.cpp
@@ -525,6 +525,7 @@ static void intExecute()
 			// Avoid reloading every instruction.
 			u32 elf_entry_point = VMManager::Internal::GetCurrentELFEntryPoint();
 			u32 eeload_main = g_eeloadMain;
+			u32 eeload_exec = g_eeloadExec;
 
 			while (true)
 			{
@@ -539,7 +540,7 @@ static void intExecute()
 
 					eeload_main = g_eeloadMain;
 				}
-				else if (cpuRegs.pc == g_eeloadMain)
+				else if (cpuRegs.pc == eeload_main)
 				{
 					eeloadHook();
 					if (VMManager::Internal::IsFastBootInProgress())
@@ -555,11 +556,13 @@ static void intExecute()
 							g_eeloadExec = EELOAD_START + 0x170;
 						else
 							Console.WriteLn("intExecute: Could not enable launch arguments for fast boot mode; unidentified BIOS version! Please report this to the PCSX2 developers.");
+
+						eeload_exec = g_eeloadExec;
 					}
 
 					elf_entry_point = VMManager::Internal::GetCurrentELFEntryPoint();
 				}
-				else if (cpuRegs.pc == g_eeloadExec)
+				else if (cpuRegs.pc == eeload_exec)
 				{
 					eeloadHook2();
 				}

--- a/pcsx2/R5900.h
+++ b/pcsx2/R5900.h
@@ -1,5 +1,5 @@
 /*  PCSX2 - PS2 Emulator for PCs
- *  Copyright (C) 2002-2010  PCSX2 Dev Team
+ *  Copyright (C) 2002-2023 PCSX2 Dev Team
  *
  *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU Lesser General Public License as published by the Free Software Found-
@@ -15,34 +15,7 @@
 
 #pragma once
 
-#include "common/Exceptions.h"
-
-class BaseR5900Exception;
-
-// --------------------------------------------------------------------------------------
-//  Recompiler Stuffs
-// --------------------------------------------------------------------------------------
-// This code section contains recompiler vars that are used in "shared" code. Placing
-// them in iR5900.h would mean having to include that into more files than I care to
-// right now, so we're sticking them here for now until a better solution comes along.
-
-namespace Exception
-{
-	// Implementation Note: this exception has no meaningful type information and we don't
-	// care to have it be caught by any BaseException handlers lying about, so let's not
-	// derive from BaseException :D
-	class ExitCpuExecute
-	{
-	public:
-		explicit ExitCpuExecute() { }
-	};
-
-	class CancelInstruction
-	{
-	public:
-		explicit CancelInstruction() { }
-	};
-}
+#include "common/Pcsx2Defs.h"
 
 // --------------------------------------------------------------------------------------
 //  EE Bios function name tables.
@@ -213,18 +186,6 @@ struct tlbs
 };
 
 #ifndef _PC_
-
-/*#define _i64(x) (s64)x
-#define _u64(x) (u64)x
-
-#define _i32(x) (s32)x
-#define _u32(x) (u32)x
-
-#define _i16(x) (s16)x
-#define _u16(x) (u16)x
-
-#define _i8(x) (s8)x
-#define _u8(x) (u8)x*/
 
 ////////////////////////////////////////////////////////////////////
 // R5900 Instruction Macros

--- a/pcsx2/Sio.cpp
+++ b/pcsx2/Sio.cpp
@@ -907,14 +907,15 @@ void AutoEject::CountDownTicks()
 			if (mcds[port][slot].autoEjectTicks > 0)
 			{
 				if (--mcds[port][slot].autoEjectTicks == 0)
-				{
-					Host::AddKeyedOSDMessage(fmt::format("AutoEjectSlotClear{}{}", port, slot),
-						fmt::format(TRANSLATE_SV("MemoryCard", "Memory card in port {} / slot {} reinserted"),
-							port + 1, slot + 1),
-						Host::OSD_INFO_DURATION);
-				}
+					reinserted |= EmuConfig.Mcd[sioConvertPortAndSlotToPad(port, slot)].Enabled;
 			}
 		}
+	}
+
+	if (reinserted)
+	{
+		Host::AddIconOSDMessage("AutoEjectAllSet", ICON_FA_SD_CARD,
+			TRANSLATE_SV("MemoryCard", "Memory Cards reinserted."), Host::OSD_INFO_DURATION);
 	}
 }
 


### PR DESCRIPTION
### Description of Changes

What the title says. Also cleans up a warning in the EE int, and gets rid of the spam when using multiple memory cards and loading state.

### Rationale behind Changes

Cleanup/less spam.

### Suggested Testing Steps

Make sure int still boots a game.
