### PR TITLE
CI/Linux: Publish Flathub builds daily [disabled for now]

### DIFF
--- a/.github/workflows/cron_publish_flatpak.yml
+++ b/.github/workflows/cron_publish_flatpak.yml
@@ -1,0 +1,41 @@
+name: 📦 Publish Flathub Release
+
+on:
+  #schedule:
+  #  - cron: "0 0 * * *" # Every day at 12am UTC.
+  workflow_dispatch: # As well as manually.
+
+jobs:
+  check:
+    if: github.repository == 'PCSX2/pcsx2'
+    name: "Check if release is needed"
+    runs-on: ubuntu-latest
+    outputs:
+      PCSX2_RELEASE: ${{ steps.getinfo.outputs.PCSX2_RELEASE }}
+      FLATHUB_RELEASE: ${{ steps.getinfo.outputs.FLATHUB_RELEASE }}
+    steps:
+      - name: Get latest tag and Flathub release
+        id: getinfo
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PCSX2_RELEASE=$(gh api -H 'Accept: application/vnd.github+json' -H 'X-GitHub-Api-Version: 2022-11-28' /repos/PCSX2/pcsx2/releases | jq -r '.[0].tag_name')
+          FLATHUB_RELEASE=$(curl -L -s https://flathub.org/api/v2/appstream/net.pcsx2.PCSX2 | jq -r '.releases | max_by(.version) | .version')
+          echo "Latest PCSX2 release is: '${PCSX2_RELEASE}'"
+          echo "Latest Flathub release is: '${FLATHUB_RELEASE}'"
+          echo "PCSX2_RELEASE=${PCSX2_RELEASE}" >> "$GITHUB_OUTPUT"
+          echo "FLATHUB_RELEASE=${FLATHUB_RELEASE}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: check
+    if: needs.check.outputs.FLATHUB_RELEASE < needs.check.outputs.PCSX2_RELEASE
+    name: "Build and publish Flatpak"
+    uses: ./.github/workflows/linux_build_flatpak.yml
+    with:
+      jobName: "Qt"
+      compiler: clang
+      cmakeflags: ""
+      publish: true
+      branch: beta
+    secrets: inherit
+

--- a/.github/workflows/linux_build_flatpak.yml
+++ b/.github/workflows/linux_build_flatpak.yml
@@ -73,7 +73,7 @@ jobs:
         run: |
           ./.github/workflows/scripts/linux/generate-metainfo.sh .github/workflows/scripts/linux/flatpak/net.pcsx2.PCSX2.metainfo.xml
           cat .github/workflows/scripts/linux/flatpak/net.pcsx2.PCSX2.metainfo.xml
-          appstream-util validate .github/workflows/scripts/linux/flatpak/net.pcsx2.PCSX2.metainfo.xml
+          flatpak run org.freedesktop.appstream-glib validate .github/workflows/scripts/linux/flatpak/net.pcsx2.PCSX2.metainfo.xml
 
       - name: Build Flatpak
         uses: flatpak/flatpak-github-actions/flatpak-builder@v6.1

--- a/.github/workflows/linux_build_flatpak.yml
+++ b/.github/workflows/linux_build_flatpak.yml
@@ -20,6 +20,10 @@ on:
       cmakeflags:
         required: true
         type: string
+      branch:
+        required: false
+        type: string
+        default: "stable"
       publish:
         required: false
         type: boolean
@@ -84,7 +88,7 @@ jobs:
           build-bundle: true
           verbose: true
           mirror-screenshots-url: https://dl.flathub.org/repo/screenshots
-          branch: beta
+          branch: ${{ inputs.branch }}
           cache: true
           restore-cache: true
           cache-key: ${{ inputs.os }} ${{ inputs.platform }} ${{ inputs.compiler }} ${{ inputs.detail }} flatpak ${{ hashFiles('.github/workflows/scripts/linux/flatpak/**/*.json') }}
@@ -93,10 +97,19 @@ jobs:
         run: |
           ostree commit --repo=repo --canonical-permissions --branch=screenshots/x86_64 .github/workflows/scripts/linux/flatpak/screenshots
 
-      - name: Push to Flathub
-        if: inputs.publish == true
+      - name: Push to Flathub beta
+        if: inputs.publish == true && inputs.branch == 'beta'
         uses: flatpak/flatpak-github-actions/flat-manager@v6.1
         with:
           flat-manager-url: https://hub.flathub.org/
           repository: beta
           token: ${{ secrets.FLATHUB_BETA_TOKEN }}
+
+      - name: Push to Flathub stable
+        if: inputs.publish == true && inputs.branch == 'stable'
+        uses: flatpak/flatpak-github-actions/flat-manager@v6.1
+        with:
+          flat-manager-url: https://hub.flathub.org/
+          repository: stable
+          token: ${{ secrets.FLATHUB_TOKEN }}
+

--- a/.github/workflows/linux_build_matrix.yml
+++ b/.github/workflows/linux_build_matrix.yml
@@ -28,3 +28,4 @@ jobs:
       compiler: clang
       cmakeflags: ""
       publish: false
+    secrets: inherit

--- a/.github/workflows/release_pipeline.yml
+++ b/.github/workflows/release_pipeline.yml
@@ -26,7 +26,8 @@ jobs:
       jobName: "Flatpak"
       compiler: clang
       cmakeflags: ""
-      publish: true
+      branch: "stable"
+      publish: false
     secrets: inherit
 
   # Windows

--- a/.github/workflows/scripts/linux/flatpak/net.pcsx2.PCSX2.json
+++ b/.github/workflows/scripts/linux/flatpak/net.pcsx2.PCSX2.json
@@ -6,11 +6,12 @@
   "sdk-extensions": [
     "org.freedesktop.Sdk.Extension.llvm16"
   ],
-  "add-build-extensions": {
+  "add-extensions": {
     "org.freedesktop.Platform.ffmpeg-full": {
       "directory": "lib/ffmpeg",
       "version": "22.08",
-      "add-ld-path": "."
+      "add-ld-path": ".",
+      "autodownload": true
     }
   },
   "command": "pcsx2-qt",

--- a/.github/workflows/scripts/linux/generate-metainfo.sh
+++ b/.github/workflows/scripts/linux/generate-metainfo.sh
@@ -10,6 +10,7 @@ fi
 OUTFILE=$1
 GIT_DATE=$(git log -1 --pretty=%cd --date=short)
 GIT_VERSION=$(git tag --points-at HEAD)
+GIT_HASH=$(git rev-parse HEAD)
 
 if [[ "${GIT_VERSION}" == "" ]]; then
     GIT_VERSION=$(git rev-parse HEAD)
@@ -17,8 +18,11 @@ fi
 
 echo "GIT_DATE: ${GIT_DATE}"
 echo "GIT_VERSION: ${GIT_VERSION}"
+echo "GIT_HASH: ${GIT_HASH}"
 
 cp "${SCRIPTDIR}"/pcsx2-qt.metainfo.xml.in "${OUTFILE}"
 
 sed -i -e "s/@GIT_VERSION@/${GIT_VERSION}/" "${OUTFILE}"
 sed -i -e "s/@GIT_DATE@/${GIT_DATE}/" "${OUTFILE}"
+sed -i -e "s/@GIT_HASH@/${GIT_HASH}/" "${OUTFILE}"
+

--- a/.github/workflows/scripts/linux/install-packages-flatpak.sh
+++ b/.github/workflows/scripts/linux/install-packages-flatpak.sh
@@ -31,6 +31,7 @@ declare -a FLATPAK_PACKAGES=(
   "org.kde.Sdk/${ARCH}/${KDE_BRANCH}"
   "org.freedesktop.Platform.ffmpeg-full/${ARCH}/${BRANCH}"
   "org.freedesktop.Sdk.Extension.llvm16/${ARCH}/${BRANCH}"
+  "org.freedesktop.appstream-glib/${ARCH}/stable"
 )
 
 retry_command sudo apt-get -qq update

--- a/.github/workflows/scripts/linux/pcsx2-qt.metainfo.xml.in
+++ b/.github/workflows/scripts/linux/pcsx2-qt.metainfo.xml.in
@@ -22,8 +22,11 @@
     </screenshot>
   </screenshots>
   <content_rating type="oars-1.1"/>
-  <update_contact>pcsx2_AT_pcsx2.net</update_contact>
+  <update_contact>stenzek_AT_gmail.com</update_contact>
   <releases>
     <release version="@GIT_VERSION@" date="@GIT_DATE@" />
   </releases>
+  <custom>
+    <value key="flathub::manifest">https://raw.githubusercontent.com/PCSX2/pcsx2/@GIT_HASH@/.github/workflows/scripts/linux/flatpak/net.pcsx2.PCSX2.json</value>
+  </custom>
 </component>


### PR DESCRIPTION
### Description of Changes

As discussed in https://github.com/flathub/flathub/issues/4248.

For now, it's just on the manual trigger, because we don't have push access to the main repo yet, it would just keep building/pushing every day.

### Rationale behind Changes

Next step.

### Suggested Testing Steps

CI passes.
