### PR TITLE
Counters + DMA: Optimize when internal interrupts run

### DIFF
--- a/pcsx2/Counters.cpp
+++ b/pcsx2/Counters.cpp
@@ -156,7 +156,9 @@ static __fi void cpuRcntSet()
 		_rcntSet( i );
 
 	// sanity check!
-	if( nextCounter < 0 ) nextCounter = 0;
+	if (nextCounter < 0)
+		nextCounter = 0;
+
 	cpuSetNextEvent(nextsCounter, nextCounter); // Need to update on counter resets/target changes
 }
 
@@ -811,8 +813,9 @@ static __fi void _cpuTestOverflow( int i )
 // well forceinline it!
 __fi void rcntUpdate()
 {
-	rcntUpdate_hScanline();
 	rcntUpdate_vSync();
+	// HBlank after as VSync can do error compensation
+	rcntUpdate_hScanline();
 
 	// Update counters so that we can perform overflow and target tests.
 
@@ -835,8 +838,9 @@ __fi void rcntUpdate()
 			counters[i].sCycleT = cpuRegs.cycle - change;
 
 			// Check Counter Targets and Overflows:
-			_cpuTestTarget( i );
+			// Check Overflow first, in case the target is 0
 			_cpuTestOverflow( i );
+			_cpuTestTarget(i);
 		}
 		else counters[i].sCycleT = cpuRegs.cycle;
 	}
@@ -886,8 +890,8 @@ static __fi void rcntStartGate(bool isVblank, u32 sCycle)
 			// currectly by rcntUpdate (since it's not being scheduled for these counters)
 
 			counters[i].count += HBLANK_COUNTER_SPEED;
+			_cpuTestOverflow(i);
 			_cpuTestTarget( i );
-			_cpuTestOverflow( i );
 		}
 
 		if (!(gates & (1<<i))) continue;

--- a/pcsx2/Counters.cpp
+++ b/pcsx2/Counters.cpp
@@ -811,6 +811,7 @@ static __fi void _cpuTestOverflow( int i )
 // well forceinline it!
 __fi void rcntUpdate()
 {
+	rcntUpdate_hScanline();
 	rcntUpdate_vSync();
 
 	// Update counters so that we can perform overflow and target tests.

--- a/pcsx2/Counters.cpp
+++ b/pcsx2/Counters.cpp
@@ -95,6 +95,7 @@ static __fi void _rcntSet( int cntidx )
 	// Stopped or special hsync gate?
 	if (!counter.mode.IsCounting || (counter.mode.ClockSource == 0x3) ) return;
 
+	if (!counter.mode.TargetInterrupt && !counter.mode.OverflowInterrupt) return;
 	// check for special cases where the overflow or target has just passed
 	// (we probably missed it because we're doing/checking other things)
 	if( counter.count > 0x10000 || counter.count > counter.target )
@@ -113,6 +114,7 @@ static __fi void _rcntSet( int cntidx )
 	if (c < nextCounter)
 	{
 		nextCounter = c;
+
 		cpuSetNextEvent( nextsCounter, nextCounter ); // Need to update on counter resets/target changes
 	}
 

--- a/pcsx2/IopCounters.cpp
+++ b/pcsx2/IopCounters.cpp
@@ -379,16 +379,16 @@ void psxCheckStartGate16(int i)
 			(psxCounters[1].mode & stoppedGateCheck) == altSourceCheck)
 		{
 			psxCounters[1].count++;
-			_rcntTestTarget(1);
 			_rcntTestOverflow(1);
+			_rcntTestTarget(1);
 		}
 
 		if ((psxCounters[3].mode & altSourceCheck) == IOPCNT_ALT_SOURCE ||
 			(psxCounters[3].mode & stoppedGateCheck) == altSourceCheck)
 		{
 			psxCounters[3].count++;
-			_rcntTestTarget(3);
 			_rcntTestOverflow(3);
+			_rcntTestTarget(3);
 		}
 	}
 
@@ -488,8 +488,8 @@ void psxRcntUpdate()
 		if (psxCounters[i].mode & IOPCNT_STOPPED)
 			continue;
 
-		_rcntTestTarget(i);
 		_rcntTestOverflow(i);
+		_rcntTestTarget(i);
 
 		// perform second target test because if we overflowed above it's possible we
 		// already shot past our target if it was very near zero.

--- a/pcsx2/IopCounters.cpp
+++ b/pcsx2/IopCounters.cpp
@@ -258,8 +258,8 @@ static __fi void _rcntTestOverflow(int i)
 	// (high bit of the target gets set by rcntWtarget when the target is behind
 	// the counter value, and thus should not be flagged until after an overflow)
 
+	psxCounters[i].count -= maxTarget + 1;
 	psxCounters[i].target &= maxTarget;
-	psxCounters[i].count -= maxTarget;
 }
 
 /*

--- a/pcsx2/IopCounters.cpp
+++ b/pcsx2/IopCounters.cpp
@@ -100,6 +100,8 @@ static void _rcntSet(int cntidx)
 	if (counter.mode & IOPCNT_STOPPED || counter.rate == PSXHBLANK)
 		return;
 
+	if (!(counter.mode & (IOPCNT_INT_TARGET | IOPCNT_INT_OVERFLOW)))
+		return;
 	// check for special cases where the overflow or target has just passed
 	// (we probably missed it because we're doing/checking other things)
 	if (counter.count > overflowCap || counter.count > counter.target)

--- a/pcsx2/IopCounters.cpp
+++ b/pcsx2/IopCounters.cpp
@@ -438,8 +438,6 @@ void psxRcntUpdate()
 {
 	int i;
 
-	psxRegs.iopNextEventCycle = psxRegs.cycle + 32;
-
 	psxNextCounter = 0x7fffffff;
 	psxNextsCounter = psxRegs.cycle;
 

--- a/pcsx2/R3000A.cpp
+++ b/pcsx2/R3000A.cpp
@@ -42,6 +42,8 @@ u32 g_psxHasConstReg, g_psxFlushedConstReg;
 // is true, even if it's already running ahead a bit.
 bool iopEventAction = false;
 
+static constexpr uint iopWaitCycles = 384; // Keep inline with EE wait cycle max.
+
 bool iopEventTestIsActive = false;
 
 alignas(16) psxRegisters psxRegs;
@@ -140,13 +142,13 @@ __fi void PSX_INT( IopEventId n, s32 ecycle )
 
 	psxSetNextBranchDelta(ecycle);
 
-	if (psxRegs.iopCycleEE < 0)
+	const s32 iopDelta = (psxRegs.iopNextEventCycle - psxRegs.cycle) * 8;
+
+	if (psxRegs.iopCycleEE < iopDelta)
 	{
 		// The EE called this int, so inform it to branch as needed:
-		// fixme - this doesn't take into account EE/IOP sync (the IOP may be running
-		// ahead or behind the EE as per the EEsCycles value)
-		const s32 iopDelta = (psxRegs.iopNextEventCycle - psxRegs.cycle) * 8;
-		cpuSetNextEventDelta(iopDelta);
+		
+		cpuSetNextEventDelta(iopDelta - psxRegs.iopCycleEE);
 	}
 }
 
@@ -209,6 +211,8 @@ static __fi void _psxTestInterrupts()
 
 __ri void iopEventTest()
 {
+	psxRegs.iopNextEventCycle = psxRegs.cycle + iopWaitCycles;
+
 	if (psxTestCycle(psxNextsCounter, psxNextCounter))
 	{
 		psxRcntUpdate();
@@ -218,7 +222,8 @@ __ri void iopEventTest()
 	{
 		// start the next branch at the next counter event by default
 		// the interrupt code below will assign nearer branches if needed.
-		psxRegs.iopNextEventCycle = psxNextsCounter + psxNextCounter;
+		if (psxNextCounter < (psxRegs.iopNextEventCycle - psxNextsCounter))
+			psxRegs.iopNextEventCycle = psxNextsCounter + psxNextCounter;
 	}
 
 	if (psxRegs.interrupt)

--- a/pcsx2/R3000A.h
+++ b/pcsx2/R3000A.h
@@ -119,7 +119,7 @@ struct psxRegisters {
 	// cycles can be accounted for later.
 	s32 iopBreak;
 
-	// tracks the IOP's current sync status with the EE.  When it dips below zero,
+	// Tracks current number of cycles IOP can run in EE cycles. When it dips below zero,
 	// control is returned to the EE.
 	s32 iopCycleEE;
 

--- a/pcsx2/R5900.cpp
+++ b/pcsx2/R5900.cpp
@@ -397,8 +397,6 @@ __fi void _cpuEventTest_Shared()
 		_cpuTestPERF();
 	}
 
-	rcntUpdate_hScanline();
-
 	_cpuTestTIMR();
 
 	// ---- Interrupts -------------

--- a/pcsx2/R5900.cpp
+++ b/pcsx2/R5900.cpp
@@ -433,8 +433,6 @@ __fi void _cpuEventTest_Shared()
 	if (EEsCycle > 0)
 		iopEventAction = true;
 
-	iopEventTest();
-
 	if (iopEventAction)
 	{
 		//if( EEsCycle < -450 )
@@ -444,6 +442,8 @@ __fi void _cpuEventTest_Shared()
 
 		iopEventAction = false;
 	}
+
+	iopEventTest();
 
 	// ---- VU Sync -------------
 	// We're in a EventTest.  All dynarec registers are flushed
@@ -461,13 +461,12 @@ __fi void _cpuEventTest_Shared()
 		cpuSetNextEventDelta(48);
 		//Console.Warning( "EE ahead of the IOP -- Rapid Event!  %d", EEsCycle );
 	}
-
-	// The IOP could be running ahead/behind of us, so adjust the iop's next branch by its
-	// relative position to the EE (via EEsCycle)
-	cpuSetNextEventDelta(((psxRegs.iopNextEventCycle - psxRegs.cycle) * 8) - EEsCycle);
-
-	// Apply the hsync counter's nextCycle
-	cpuSetNextEvent(hsyncCounter.sCycle, hsyncCounter.CycleT);
+	else
+	{
+		// The IOP could be running ahead/behind of us, so adjust the iop's next branch by its
+		// relative position to the EE (via EEsCycle)
+		cpuSetNextEventDelta(((psxRegs.iopNextEventCycle - psxRegs.cycle) * 8) - EEsCycle);
+	}
 
 	// Apply vsync and other counter nextCycles
 	cpuSetNextEvent(nextsCounter, nextCounter);

--- a/pcsx2/R5900.cpp
+++ b/pcsx2/R5900.cpp
@@ -51,7 +51,7 @@ alignas(16) fpuRegisters fpuRegs;
 alignas(16) tlbs tlb[48];
 R5900cpu *Cpu = NULL;
 
-static const uint eeWaitCycles = 3072;
+static constexpr uint eeWaitCycles = 3072;
 
 bool eeEventTestIsActive = false;
 EE_intProcessStatus eeRunInterruptScan = INT_NOT_RUNNING;
@@ -453,7 +453,9 @@ __fi void _cpuEventTest_Shared()
 
 	// ---- Schedule Next Event Test --------------
 
-	if (EEsCycle > 192)
+	const int nextIopEventDeta = ((psxRegs.iopNextEventCycle - psxRegs.cycle) * 8);
+	// 8 or more cycles behind and there's an event scheduled
+	if (EEsCycle >= nextIopEventDeta)
 	{
 		// EE's running way ahead of the IOP still, so we should branch quickly to give the
 		// IOP extra timeslices in short order.
@@ -463,8 +465,7 @@ __fi void _cpuEventTest_Shared()
 	}
 	else
 	{
-		// The IOP could be running ahead/behind of us, so adjust the iop's next branch by its
-		// relative position to the EE (via EEsCycle)
+		// Otherwise IOP is caught up/not doing anything so we can wait for the next event.
 		cpuSetNextEventDelta(((psxRegs.iopNextEventCycle - psxRegs.cycle) * 8) - EEsCycle);
 	}
 

--- a/pcsx2/R5900.cpp
+++ b/pcsx2/R5900.cpp
@@ -54,6 +54,7 @@ R5900cpu *Cpu = NULL;
 static const uint eeWaitCycles = 3072;
 
 bool eeEventTestIsActive = false;
+EE_intProcessStatus eeRunInterruptScan = INT_NOT_RUNNING;
 
 u32 g_eeloadMain = 0, g_eeloadExec = 0, g_osdsys_str = 0;
 
@@ -277,36 +278,49 @@ static __fi bool _cpuTestInterrupts()
 		//Console.Write("DMAC Disabled or suspended");
 		return false;
 	}
-	/* These are 'pcsx2 interrupts', they handle asynchronous stuff
-	   that depends on the cycle timings */
-	TESTINT(VU_MTVU_BUSY,	MTVUInterrupt);
-	TESTINT(DMAC_VIF1,		vif1Interrupt);
-	TESTINT(DMAC_GIF,		gifInterrupt);
-	TESTINT(DMAC_SIF0,		EEsif0Interrupt);
-	TESTINT(DMAC_SIF1,		EEsif1Interrupt);
-	// Profile-guided Optimization (sorta)
-	// The following ints are rarely called.  Encasing them in a conditional
-	// as follows helps speed up most games.
 
-	if (cpuRegs.interrupt & ((1 << DMAC_VIF0) | (1 << DMAC_FROM_IPU) | (1 << DMAC_TO_IPU)
-		| (1 << DMAC_FROM_SPR) | (1 << DMAC_TO_SPR) | (1 << DMAC_MFIFO_VIF) | (1 << DMAC_MFIFO_GIF)
-		| (1 << VIF_VU0_FINISH) | (1 << VIF_VU1_FINISH) | (1 << IPU_PROCESS)))
+	eeRunInterruptScan = INT_RUNNING;
+
+	while (eeRunInterruptScan == INT_RUNNING)
 	{
-		TESTINT(DMAC_VIF0,		vif0Interrupt);
+		/* These are 'pcsx2 interrupts', they handle asynchronous stuff
+		   that depends on the cycle timings */
+		TESTINT(VU_MTVU_BUSY, MTVUInterrupt);
+		TESTINT(DMAC_VIF1, vif1Interrupt);
+		TESTINT(DMAC_GIF, gifInterrupt);
+		TESTINT(DMAC_SIF0, EEsif0Interrupt);
+		TESTINT(DMAC_SIF1, EEsif1Interrupt);
+		// Profile-guided Optimization (sorta)
+		// The following ints are rarely called.  Encasing them in a conditional
+		// as follows helps speed up most games.
 
-		TESTINT(DMAC_FROM_IPU,	ipu0Interrupt);
-		TESTINT(DMAC_TO_IPU,	ipu1Interrupt);
-		TESTINT(IPU_PROCESS,	ipuCMDProcess);
+		if (cpuRegs.interrupt & ((1 << DMAC_VIF0) | (1 << DMAC_FROM_IPU) | (1 << DMAC_TO_IPU)
+			| (1 << DMAC_FROM_SPR) | (1 << DMAC_TO_SPR) | (1 << DMAC_MFIFO_VIF) | (1 << DMAC_MFIFO_GIF)
+			| (1 << VIF_VU0_FINISH) | (1 << VIF_VU1_FINISH) | (1 << IPU_PROCESS)))
+		{
+			TESTINT(DMAC_VIF0, vif0Interrupt);
 
-		TESTINT(DMAC_FROM_SPR,	SPRFROMinterrupt);
-		TESTINT(DMAC_TO_SPR,	SPRTOinterrupt);
+			TESTINT(DMAC_FROM_IPU, ipu0Interrupt);
+			TESTINT(DMAC_TO_IPU, ipu1Interrupt);
+			TESTINT(IPU_PROCESS, ipuCMDProcess);
 
-		TESTINT(DMAC_MFIFO_VIF, vifMFIFOInterrupt);
-		TESTINT(DMAC_MFIFO_GIF, gifMFIFOInterrupt);
+			TESTINT(DMAC_FROM_SPR, SPRFROMinterrupt);
+			TESTINT(DMAC_TO_SPR, SPRTOinterrupt);
 
-		TESTINT(VIF_VU0_FINISH, vif0VUFinish);
-		TESTINT(VIF_VU1_FINISH, vif1VUFinish);
+			TESTINT(DMAC_MFIFO_VIF, vifMFIFOInterrupt);
+			TESTINT(DMAC_MFIFO_GIF, gifMFIFOInterrupt);
+
+			TESTINT(VIF_VU0_FINISH, vif0VUFinish);
+			TESTINT(VIF_VU1_FINISH, vif1VUFinish);
+		}
+
+		if (eeRunInterruptScan == INT_REQ_LOOP)
+			eeRunInterruptScan = INT_RUNNING;
+		else
+			break;
 	}
+
+	eeRunInterruptScan = INT_NOT_RUNNING;
 
 	if ((cpuRegs.interrupt & 0x1FFFF) & ~cpuRegs.dmastall)
 		return true;
@@ -391,17 +405,20 @@ __fi void _cpuEventTest_Shared()
 	// These are basically just DMAC-related events, which also piggy-back the same bits as
 	// the PS2's own DMA channel IRQs and IRQ Masks.
 
-	// This is a BIOS hack because the coding in the BIOS is terrible but the bug is masked by Data Cache
-	// where a DMA buffer is overwritten without waiting for the transfer to end, which causes the fonts to get all messed up
-	// so to fix it, we run all the DMA's instantly when in the BIOS.
-	// Only use the lower 17 bits of the cpuRegs.interrupt as the upper bits are for VU0/1 sync which can't be done in a tight loop
-	if (CHECK_INSTANTDMAHACK && dmacRegs.ctrl.DMAE && !(psHu8(DMAC_ENABLER + 2) & 1) && (cpuRegs.interrupt & 0x1FFFF))
+	if (cpuRegs.interrupt)
 	{
-		while ((cpuRegs.interrupt & 0x1FFFF) && _cpuTestInterrupts())
-			;
+		// This is a BIOS hack because the coding in the BIOS is terrible but the bug is masked by Data Cache
+		// where a DMA buffer is overwritten without waiting for the transfer to end, which causes the fonts to get all messed up
+		// so to fix it, we run all the DMA's instantly when in the BIOS.
+		// Only use the lower 17 bits of the cpuRegs.interrupt as the upper bits are for VU0/1 sync which can't be done in a tight loop
+		if (CHECK_INSTANTDMAHACK && dmacRegs.ctrl.DMAE && !(psHu8(DMAC_ENABLER + 2) & 1) && (cpuRegs.interrupt & 0x1FFFF))
+		{
+			while ((cpuRegs.interrupt & 0x1FFFF) && _cpuTestInterrupts())
+				;
+		}
+		else
+			_cpuTestInterrupts();
 	}
-	else
-		_cpuTestInterrupts();
 
 	// ---- IOP -------------
 	// * It's important to run a iopEventTest before calling ExecuteBlock. This
@@ -523,6 +540,17 @@ __fi void CPU_SET_DMASTALL(EE_EventType n, bool set)
 
 __fi void CPU_INT( EE_EventType n, s32 ecycle)
 {
+	// If it's retunning too quick, just rerun the DMA, there's no point in running the EE for < 4 cycles.
+	// This causes a huge uplift in performance for ONI FMV's.
+	if (ecycle < 4 && !(cpuRegs.dmastall & (1 << n)) && eeRunInterruptScan != INT_NOT_RUNNING)
+	{
+		eeRunInterruptScan = INT_REQ_LOOP;
+		cpuRegs.interrupt |= 1 << n;
+		cpuRegs.sCycle[n] = cpuRegs.cycle;
+		cpuRegs.eCycle[n] = 0;
+		return;
+	}
+
 	// EE events happen 8 cycles in the future instead of whatever was requested.
 	// This can be used on games with PATH3 masking issues for example, or when
 	// some FMV look bad.

--- a/pcsx2/R5900.h
+++ b/pcsx2/R5900.h
@@ -333,6 +333,13 @@ extern R5900cpu *Cpu;
 extern R5900cpu intCpu;
 extern R5900cpu recCpu;
 
+enum EE_intProcessStatus
+{
+	INT_NOT_RUNNING = 0,
+	INT_RUNNING,
+	INT_REQ_LOOP
+};
+
 enum EE_EventType
 {
 	DMAC_VIF0	= 0,

--- a/pcsx2/Vif1_Dma.cpp
+++ b/pcsx2/Vif1_Dma.cpp
@@ -341,7 +341,10 @@ __fi void vif1Interrupt()
 	}
 
 	if (!vif1ch.chcr.STR)
+	{
 		Console.WriteLn("Vif1 running when CHCR == %x", vif1ch.chcr._u32);
+		return;
+	}
 
 	if (vif1.irq && vif1.vifstalled.enabled && vif1.vifstalled.value == VIF_IRQ_STALL)
 	{


### PR DESCRIPTION
### Description of Changes
Optimise when internal interrupts run, reducing exits from the EE, improving performance.
Also improved the EE/IOP sync to split more efficiently.

### Rationale behind Changes
More brrr

### Suggested Testing Steps
Test games, feel free to compare to master :) Make sure nothing broke in the process.

Examples of performance improvements.  FMV's around 10-30% faster, ingame anywhere from 1-7% faster (in testing)

FMV's
![image](https://github.com/PCSX2/pcsx2/assets/6278726/b5236050-9cf0-41dd-a50f-33af8ee77454)
![image](https://github.com/PCSX2/pcsx2/assets/6278726/c2a726b5-5f3a-4a32-98a4-f818b7a50099)

Ingame benchmarks
![image](https://github.com/PCSX2/pcsx2/assets/6278726/89f68088-52d5-414b-b0c3-4e30cae4b8e5)
![image](https://github.com/PCSX2/pcsx2/assets/6278726/13e0b5bc-8e86-4850-abfa-9607bdbb6d06)
![image](https://github.com/PCSX2/pcsx2/assets/6278726/c2ec87b1-4f5c-4833-bccf-6b8995156689)
![image](https://github.com/PCSX2/pcsx2/assets/6278726/4233646d-24d8-4c2a-a785-47c74caa3fd7)
![image](https://github.com/PCSX2/pcsx2/assets/6278726/f8141849-a6f0-42a8-a46e-3b7ade2fe8bb)
![image](https://github.com/PCSX2/pcsx2/assets/6278726/ddbb8b31-2f6e-4a41-a96b-e7acdab68134)
![image](https://github.com/PCSX2/pcsx2/assets/6278726/a08942c2-8026-4044-ad34-daa7ad0100c3)
