### PR TITLE
GameDB: Various fixes for Armored Core games

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -547,8 +547,6 @@ SCAJ-20011:
   roundModes:
     eeRoundMode: 0 # Fixes Z-Fighting.
   gsHWFixes:
-    cpuSpriteRenderBW: 2 # Fixes water rendering.
-    cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects positioning of reflections on suit's surfaces.
     partialTargetInvalidation: 1 # Fixes corrupted textures.
   memcardFilters:
@@ -826,8 +824,7 @@ SCAJ-20076:
   name: "Armored Core - Nexus [Disc 1]"
   region: "NTSC-Unk"
   gsHWFixes:
-    cpuSpriteRenderBW: 2 # Fixes water rendering.
-    cpuSpriteRenderLevel: 2 # Needed for above.
+    halfPixelOffset: 1 # Fixes misaligned blur..
     partialTargetInvalidation: 1 # Fixes broken textures.
   memcardFilters:
     - "SCAJ-20076"
@@ -840,8 +837,7 @@ SCAJ-20077:
   name: "Armored Core - Nexus [Disc 2]"
   region: "NTSC-Unk"
   gsHWFixes:
-    cpuSpriteRenderBW: 2 # Fixes water rendering.
-    cpuSpriteRenderLevel: 2 # Needed for above.
+    halfPixelOffset: 1 # Fixes misaligned blur..
     partialTargetInvalidation: 1 # Fixes broken textures.
   memcardFilters:
     - "SCAJ-20076"
@@ -990,8 +986,7 @@ SCAJ-20105:
   name: "Armored Core - Nine breaker"
   region: "NTSC-Unk"
   gsHWFixes:
-    cpuSpriteRenderBW: 2 # Fixes water rendering.
-    cpuSpriteRenderLevel: 2 # Needed for above.
+    halfPixelOffset: 1 # Fixes misaligned blur..
     partialTargetInvalidation: 1 # Fixes broken textures.
 SCAJ-20107:
   name: "Bakufuu Slash! Kizna Arashi"
@@ -1079,8 +1074,7 @@ SCAJ-20121:
   name: "Armored Core - Formula Front"
   region: "NTSC-Unk"
   gsHWFixes:
-    cpuSpriteRenderBW: 2 # Fixes water rendering.
-    cpuSpriteRenderLevel: 2 # Needed for above.
+    halfPixelOffset: 1 # Fixes misaligned blur..
     partialTargetInvalidation: 1 # Fixes broken textures.
 SCAJ-20122:
   name: "Swords of Destiny"
@@ -1215,7 +1209,7 @@ SCAJ-20143:
   name: "Armored Core - Last Raven"
   region: "NTSC-Unk"
   gsHWFixes:
-    cpuSpriteRenderBW: 2 # Fixes water rendering.
+    cpuSpriteRenderBW: 2 # Fixes glow effects, but breaks shadows of certain objects.
     cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects shadow alignment and reduces blurriness.
     partialTargetInvalidation: 1 # Fixes broken textures.
@@ -5355,8 +5349,7 @@ SCKA-20047:
   name: "Armored Core - Nine Breaker"
   region: "NTSC-K"
   gsHWFixes:
-    cpuSpriteRenderBW: 2 # Fixes water rendering.
-    cpuSpriteRenderLevel: 2 # Needed for above.
+    halfPixelOffset: 1 # Fixes misaligned blur..
     partialTargetInvalidation: 1 # Fixes broken textures.
   memcardFilters:
     - "SCKA-20047"
@@ -7128,8 +7121,6 @@ SCPS-55014:
   roundModes:
     eeRoundMode: 0 # Fixes Z-Fighting.
   gsHWFixes:
-    cpuSpriteRenderBW: 2 # Fixes water rendering.
-    cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects positioning of reflections on suit's surfaces.
     roundSprite: 2 # Reduces garbage on the UI whilst upscaling.
     partialTargetInvalidation: 1 # Fixes corrupted textures.
@@ -13453,8 +13444,6 @@ SLES-51399:
   roundModes:
     eeRoundMode: 0 # Fixes Z-Fighting.
   gsHWFixes:
-    cpuSpriteRenderBW: 2 # Fixes water rendering.
-    cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects positioning of reflections on suit's surfaces.
     roundSprite: 2 # Reduces garbage on the UI whilst upscaling.
     partialTargetInvalidation: 1 # Fixes corrupted textures.
@@ -15050,8 +15039,6 @@ SLES-52203:
   roundModes:
     eeRoundMode: 0 # Fixes Z-Fighting.
   gsHWFixes:
-    cpuSpriteRenderBW: 2 # Fixes water rendering.
-    cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects positioning of reflections on suit's surfaces.
     partialTargetInvalidation: 1 # Fixes corrupted textures.
   memcardFilters:
@@ -19391,8 +19378,7 @@ SLES-53819:
   name: "Armored Core - Nine Breaker"
   region: "PAL-E"
   gsHWFixes:
-    cpuSpriteRenderBW: 2 # Fixes water rendering.
-    cpuSpriteRenderLevel: 2 # Needed for above.
+    halfPixelOffset: 1 # Fixes misaligned blur..
     partialTargetInvalidation: 1 # Fixes broken textures.
   memcardFilters:
     - "SLES-53819"
@@ -19402,7 +19388,7 @@ SLES-53820:
   name: "Armored Core - Last Raven"
   region: "PAL-E"
   gsHWFixes:
-    cpuSpriteRenderBW: 2 # Fixes water rendering.
+    cpuSpriteRenderBW: 2 # Fixes glow effects, but breaks shadows of certain objects.
     cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects shadow alignment and reduces blurriness.
     partialTargetInvalidation: 1 # Fixes broken textures.
@@ -24195,8 +24181,7 @@ SLES-82036:
   name: "Armored Core - Nexus [Disc 1]"
   region: "PAL-M5"
   gsHWFixes:
-    cpuSpriteRenderBW: 2 # Fixes water rendering.
-    cpuSpriteRenderLevel: 2 # Needed for above.
+    halfPixelOffset: 1 # Fixes misaligned blur..
     partialTargetInvalidation: 1 # Fixes broken textures.
   memcardFilters:
     - "SLES-82036"
@@ -24205,8 +24190,7 @@ SLES-82037:
   name: "Armored Core - Nexus [Disc 2]"
   region: "PAL-M5"
   gsHWFixes:
-    cpuSpriteRenderBW: 2 # Fixes water rendering.
-    cpuSpriteRenderLevel: 2 # Needed for above.
+    halfPixelOffset: 1 # Fixes misaligned blur..
     partialTargetInvalidation: 1 # Fixes broken textures.
   memcardFilters:
     - "SLES-82036"
@@ -24562,8 +24546,6 @@ SLKA-25041:
   roundModes:
     eeRoundMode: 0 # Fixes Z-Fighting.
   gsHWFixes:
-    cpuSpriteRenderBW: 2 # Fixes water rendering.
-    cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects positioning of reflections on suit's surfaces.
     partialTargetInvalidation: 1 # Fixes corrupted textures.
   memcardFilters:
@@ -25018,8 +25000,7 @@ SLKA-25201:
   name: "Armored Core - Nexus [Disc 1]"
   region: "NTSC-K"
   gsHWFixes:
-    cpuSpriteRenderBW: 2 # Fixes water rendering.
-    cpuSpriteRenderLevel: 2 # Needed for above.
+    halfPixelOffset: 1 # Fixes misaligned blur..
     partialTargetInvalidation: 1 # Fixes broken textures.
   memcardFilters:
     - "SLKA-25201"
@@ -25028,8 +25009,7 @@ SLKA-25202:
   name: "Armored Core - Nexus [Disc 2]"
   region: "NTSC-K"
   gsHWFixes:
-    cpuSpriteRenderBW: 2 # Fixes water rendering.
-    cpuSpriteRenderLevel: 2 # Needed for above.
+    halfPixelOffset: 1 # Fixes misaligned blur..
     partialTargetInvalidation: 1 # Fixes broken textures.
   memcardFilters:
     - "SLKA-25201"
@@ -25270,8 +25250,7 @@ SLKA-25270:
   name: "Armored Core - Formula Front"
   region: "NTSC-K"
   gsHWFixes:
-    cpuSpriteRenderBW: 2 # Fixes water rendering.
-    cpuSpriteRenderLevel: 2 # Needed for above.
+    halfPixelOffset: 1 # Fixes misaligned blur..
     partialTargetInvalidation: 1 # Fixes broken textures.
 SLKA-25274:
   name: "Princess Maker 4"
@@ -26592,7 +26571,7 @@ SLPM-61118:
   name: "Armored Core - Last Raven [Famitsu Special Trial Version]"
   region: "NTSC-J"
   gsHWFixes:
-    cpuSpriteRenderBW: 2 # Fixes water rendering.
+    cpuSpriteRenderBW: 2 # Fixes glow effects, but breaks shadows of certain objects.
     cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects shadow alignment and reduces blurriness.
     partialTargetInvalidation: 1 # Fixes broken textures.
@@ -26600,7 +26579,7 @@ SLPM-61119:
   name: "Armored Core - Last Raven [Trial]"
   region: "NTSC-J"
   gsHWFixes:
-    cpuSpriteRenderBW: 2 # Fixes water rendering.
+    cpuSpriteRenderBW: 2 # Fixes glow effects, but breaks shadows of certain objects.
     cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects shadow alignment and reduces blurriness.
     partialTargetInvalidation: 1 # Fixes broken textures.
@@ -36473,8 +36452,6 @@ SLPM-67524:
   roundModes:
     eeRoundMode: 0 # Fixes Z-Fighting.
   gsHWFixes:
-    cpuSpriteRenderBW: 2 # Fixes water rendering.
-    cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects positioning of reflections on suit's surfaces.
     roundSprite: 2 # Reduces garbage on the UI whilst upscaling.
     partialTargetInvalidation: 1 # Fixes corrupted textures.
@@ -36603,7 +36580,7 @@ SLPM-68520:
   name: "Armored Core - Last Raven [Monthly Champion magazine Special Edition]"
   region: "NTSC-J"
   gsHWFixes:
-    cpuSpriteRenderBW: 2 # Fixes water rendering.
+    cpuSpriteRenderBW: 2 # Fixes glow effects, but breaks shadows of certain objects.
     cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects shadow alignment and reduces blurriness.
     partialTargetInvalidation: 1 # Fixes broken textures.
@@ -38843,8 +38820,6 @@ SLPS-25112:
   roundModes:
     eeRoundMode: 0 # Fixes Z-Fighting.
   gsHWFixes:
-    cpuSpriteRenderBW: 2 # Fixes water rendering.
-    cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects positioning of reflections on suit's surfaces.
     roundSprite: 2 # Reduces garbage on the UI whilst upscaling.
     partialTargetInvalidation: 1 # Fixes corrupted textures.
@@ -39062,8 +39037,6 @@ SLPS-25169:
   roundModes:
     eeRoundMode: 0 # Fixes Z-Fighting.
   gsHWFixes:
-    cpuSpriteRenderBW: 2 # Fixes water rendering.
-    cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects positioning of reflections on suit's surfaces.
     partialTargetInvalidation: 1 # Fixes corrupted textures.
   memcardFilters:
@@ -39631,8 +39604,7 @@ SLPS-25338:
   name: "Armored Core - Nexus [Disc 1]"
   region: "NTSC-J"
   gsHWFixes:
-    cpuSpriteRenderBW: 2 # Fixes water rendering.
-    cpuSpriteRenderLevel: 2 # Needed for above.
+    halfPixelOffset: 1 # Fixes misaligned blur..
     partialTargetInvalidation: 1 # Fixes broken textures.
   memcardFilters:
     - "SCAJ-20076"
@@ -39645,8 +39617,7 @@ SLPS-25339:
   name: "Armored Core - Nexus [Disc 2]"
   region: "NTSC-J"
   gsHWFixes:
-    cpuSpriteRenderBW: 2 # Fixes water rendering.
-    cpuSpriteRenderLevel: 2 # Needed for above.
+    halfPixelOffset: 1 # Fixes misaligned blur..
     partialTargetInvalidation: 1 # Fixes broken textures.
   memcardFilters:
     - "SCAJ-20076"
@@ -39942,8 +39913,7 @@ SLPS-25408:
   name: "Armored Core - Nine Breaker"
   region: "NTSC-J"
   gsHWFixes:
-    cpuSpriteRenderBW: 2 # Fixes water rendering.
-    cpuSpriteRenderLevel: 2 # Needed for above.
+    halfPixelOffset: 1 # Fixes misaligned blur..
     partialTargetInvalidation: 1 # Fixes broken textures.
   memcardFilters:
     - "SLPS-25408"
@@ -40146,14 +40116,13 @@ SLPS-25461:
   name: "Armored Core - Formula Front"
   region: "NTSC-J"
   gsHWFixes:
-    cpuSpriteRenderBW: 2 # Fixes water rendering.
-    cpuSpriteRenderLevel: 2 # Needed for above.
+    halfPixelOffset: 1 # Fixes misaligned blur..
     partialTargetInvalidation: 1 # Fixes broken textures.
 SLPS-25462:
   name: "Armored Core - Last Raven"
   region: "NTSC-J"
   gsHWFixes:
-    cpuSpriteRenderBW: 2 # Fixes water rendering.
+    cpuSpriteRenderBW: 2 # Fixes glow effects, but breaks shadows of certain objects.
     cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects shadow alignment and reduces blurriness.
     partialTargetInvalidation: 1 # Fixes broken textures.
@@ -41171,7 +41140,7 @@ SLPS-25730:
   name: "Armored Core - Last Raven [Machine Side Box]"
   region: "NTSC-J"
   gsHWFixes:
-    cpuSpriteRenderBW: 2 # Fixes water rendering.
+    cpuSpriteRenderBW: 2 # Fixes glow effects, but breaks shadows of certain objects.
     cpuSpriteRenderLevel: 2 # Needed for above.
     partialTargetInvalidation: 1 # Fixes broken textures.
 SLPS-25731:
@@ -41183,8 +41152,6 @@ SLPS-25732:
   name: "Armored Core 3 [Machine Side Box]"
   region: "NTSC-J"
   gsHWFixes:
-    cpuSpriteRenderBW: 2 # Fixes water rendering.
-    cpuSpriteRenderLevel: 2 # Needed for above.
     partialTargetInvalidation: 1 # Fixes broken textures.
 SLPS-25733:
   name: "Super Robot Taisen OG - Original Generations"
@@ -42036,8 +42003,7 @@ SLPS-73202:
   name: "Armored Core - Nexus [Disc 1] [PlayStation 2 The Best]"
   region: "NTSC-J"
   gsHWFixes:
-    cpuSpriteRenderBW: 2 # Fixes water rendering.
-    cpuSpriteRenderLevel: 2 # Needed for above.
+    halfPixelOffset: 1 # Fixes misaligned blur..
     partialTargetInvalidation: 1 # Fixes broken textures.
   memcardFilters:
     - "SCAJ-20076"
@@ -42050,8 +42016,7 @@ SLPS-73203:
   name: "Armored Core - Nexus [Disc 2] [PlayStation 2 The Best]"
   region: "NTSC-J"
   gsHWFixes:
-    cpuSpriteRenderBW: 2 # Fixes water rendering.
-    cpuSpriteRenderLevel: 2 # Needed for above.
+    halfPixelOffset: 1 # Fixes misaligned blur..
     partialTargetInvalidation: 1 # Fixes broken textures.
   memcardFilters:
     - "SCAJ-20076"
@@ -42342,7 +42307,7 @@ SLPS-73247:
   name: "Armored Core - Last Raven [PlayStation 2 The Best]"
   region: "NTSC-J"
   gsHWFixes:
-    cpuSpriteRenderBW: 2 # Fixes water rendering.
+    cpuSpriteRenderBW: 2 # Fixes glow effects, but breaks shadows of certain objects.
     cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects shadow alignment and reduces blurriness.
     partialTargetInvalidation: 1 # Fixes broken textures.
@@ -42524,8 +42489,6 @@ SLPS-73417:
   roundModes:
     eeRoundMode: 0 # Fixes Z-Fighting.
   gsHWFixes:
-    cpuSpriteRenderBW: 2 # Fixes water rendering.
-    cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects positioning of reflections on suit's surfaces.
     roundSprite: 2 # Reduces garbage on the UI whilst upscaling.
     partialTargetInvalidation: 1 # Fixes corrupted textures.
@@ -42545,8 +42508,6 @@ SLPS-73420:
   roundModes:
     eeRoundMode: 0 # Fixes Z-Fighting.
   gsHWFixes:
-    cpuSpriteRenderBW: 2 # Fixes water rendering.
-    cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects positioning of reflections on suit's surfaces.
     partialTargetInvalidation: 1 # Fixes corrupted textures.
   memcardFilters:
@@ -44454,8 +44415,6 @@ SLUS-20435:
   roundModes:
     eeRoundMode: 0 # Fixes Z-Fighting.
   gsHWFixes:
-    cpuSpriteRenderBW: 2 # Fixes water rendering.
-    cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects positioning of reflections on suit's surfaces.
     roundSprite: 2 # Reduces garbage on the UI whilst upscaling.
     partialTargetInvalidation: 1 # Fixes corrupted textures.
@@ -45483,14 +45442,12 @@ SLUS-20643BD:
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
 SLUS-20644:
-  name: "Armored Core - Silent Line"
+  name: "Armored Core 3 - Silent Line"
   region: "NTSC-U"
   compat: 5
   roundModes:
     eeRoundMode: 0 # Fixes Z-Fighting.
   gsHWFixes:
-    cpuSpriteRenderBW: 2 # Fixes water rendering.
-    cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects positioning of reflections on suit's surfaces.
     partialTargetInvalidation: 1 # Fixes corrupted textures.
   memcardFilters: # Can import data from AC3.
@@ -47259,8 +47216,7 @@ SLUS-20986:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    cpuSpriteRenderBW: 2 # Fixes water rendering.
-    cpuSpriteRenderLevel: 2 # Needed for above.
+    halfPixelOffset: 1 # Fixes misaligned blur..
     partialTargetInvalidation: 1 # Fixes broken textures.
   memcardFilters:
     - "SLUS-20986"
@@ -47775,8 +47731,7 @@ SLUS-21079:
   name: "Armored Core - Nexus [Disc 2]"
   region: "NTSC-U"
   gsHWFixes:
-    cpuSpriteRenderBW: 2 # Fixes water rendering.
-    cpuSpriteRenderLevel: 2 # Needed for above.
+    halfPixelOffset: 1 # Fixes misaligned blur..
     partialTargetInvalidation: 1 # Fixes broken textures.
   memcardFilters:
     - "SLUS-20986"
@@ -48373,8 +48328,7 @@ SLUS-21200:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    cpuSpriteRenderBW: 2 # Fixes water rendering.
-    cpuSpriteRenderLevel: 2 # Needed for above.
+    halfPixelOffset: 1 # Fixes misaligned blur..
     partialTargetInvalidation: 1 # Fixes broken textures.
   memcardFilters: # Can import data from AC:Nexus.
     - "SLUS-21200"
@@ -49252,7 +49206,7 @@ SLUS-21338:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    cpuSpriteRenderBW: 2 # Fixes water rendering.
+    cpuSpriteRenderBW: 2 # Fixes glow effects, but breaks shadows of certain objects.
     cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects shadow alignment and reduces blurriness.
     partialTargetInvalidation: 1 # Fixes broken textures.


### PR DESCRIPTION
### Description of Changes
- Remove unnecessary CPU Sprite Render Size from bunch of Armored Core games besides Last Raven.
- Update comments of CPU Sprite Render Size for Armored Core Last Raven.
- Add HPO Normal for fixing misaligned blur in Armored Core Nexus, Nine Breaker, and Formula Front.

### Rationale behind Changes
- The water rendering issue doesn't occur without CPU Sprite Render Size since v1.7.4665, so this is no longer needed for the Armored Core games.
- But hardware renderers have another issue (glowing effects disapper) on Last Raven without CPU Sprite Render Size,  so I changed comment of those line as:
```yaml
    cpuSpriteRenderBW: 2 # Fixes glow effects, but breaks shadows of certain objects.
```
- As a side note, that glow issue has persisted for a while. It occurs even on v1.6.0

### Suggested Testing Steps
Already tested on v1.7.4666
- Found a fact, `cpuSpriteRenderBW: 1` can fix **_some_** glow effects without shadows broken.

Here are GS dumps from Armored Core Last Raven: 
- Glow issue : [Armored Core - Last Raven_SLPS-25462_20230701125433.gs.zip](https://github.com/PCSX2/pcsx2/files/11924441/Armored.Core.-.Last.Raven_SLPS-25462_20230701125433.gs.zip)
- Shadow issue : [Armored Core - Last Raven_SLPS-25462_20230701131617.gs.zip](https://github.com/PCSX2/pcsx2/files/11924445/Armored.Core.-.Last.Raven_SLPS-25462_20230701131617.gs.zip)
