### PR TITLE
Qt: Implement mouse wheel filter for unfocused widgets

### DIFF
--- a/pcsx2-qt/CMakeLists.txt
+++ b/pcsx2-qt/CMakeLists.txt
@@ -44,6 +44,8 @@ target_sources(pcsx2-qt PRIVATE
 	GameList/GameListRefreshThread.h
 	GameList/GameListWidget.cpp
 	GameList/GameListWidget.h
+	MouseWheelFilter.cpp
+	MouseWheelFilter.h
 	Settings/AdvancedSettingsWidget.cpp
 	Settings/AdvancedSettingsWidget.h
 	Settings/AdvancedSettingsWidget.ui

--- a/pcsx2-qt/Debugger/DebuggerWindow.cpp
+++ b/pcsx2-qt/Debugger/DebuggerWindow.cpp
@@ -22,6 +22,7 @@
 #include "VMManager.h"
 #include "QtHost.h"
 #include "MainWindow.h"
+#include "MouseWheelFilter.h"
 
 DebuggerWindow::DebuggerWindow(QWidget* parent)
 	: QMainWindow(parent)
@@ -61,6 +62,9 @@ DebuggerWindow::DebuggerWindow(QWidget* parent)
 
 	m_ui.cpuTabs->addTab(m_cpuWidget_r5900, "R5900");
 	m_ui.cpuTabs->addTab(m_cpuWidget_r3000, "R3000");
+
+	MouseWheelFilter* wf = new MouseWheelFilter(this);
+	wf->install(this);
 
 	CBreakPoints::SetUpdateHandler(std::bind(&DebuggerWindow::onBreakpointsChanged, this));
 

--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -22,6 +22,7 @@
 #include "GameList/GameListRefreshThread.h"
 #include "GameList/GameListWidget.h"
 #include "MainWindow.h"
+#include "MouseWheelFilter.h"
 #include "QtHost.h"
 #include "QtUtils.h"
 #include "SettingWidgetBinder.h"
@@ -287,6 +288,8 @@ void MainWindow::setupAdditionalUi()
 		m_ui.menu_Tools->insertMenu(m_ui.menuInput_Recording->menuAction(), raMenu);
 	}
 #endif
+	MouseWheelFilter* wf = new MouseWheelFilter(this);
+	wf->install(this);
 }
 
 void MainWindow::connectSignals()

--- a/pcsx2-qt/MouseWheelFilter.cpp
+++ b/pcsx2-qt/MouseWheelFilter.cpp
@@ -1,0 +1,52 @@
+/*  PCSX2 - PS2 Emulator for PCs
+ *  Copyright (C) 2002-2023  PCSX2 Dev Team
+ *
+ *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU Lesser General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  PCSX2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with PCSX2.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "PrecompiledHeader.h"
+
+#include "MouseWheelFilter.h"
+
+#include <QtCore/QEvent>
+#include <QtWidgets/QComboBox>
+#include <QtWidgets/QSlider>
+#include <QtWidgets/QSpinBox>
+
+MouseWheelFilter::MouseWheelFilter(QObject* parent) : QObject(parent){}
+
+void MouseWheelFilter::install(QObject* target_widget_parent)
+{
+	QListIterator<QWidget*> WidgetIterator(target_widget_parent->findChildren<QWidget*>());
+	while (WidgetIterator.hasNext())
+	{
+		QWidget* iteration = WidgetIterator.next();
+		if(qobject_cast<QComboBox*>(iteration) || qobject_cast<QSpinBox*>(iteration) || qobject_cast<QDoubleSpinBox*>(iteration) || qobject_cast<QSlider*>(iteration))
+		 {
+			iteration->setFocusPolicy(Qt::StrongFocus);
+			iteration->installEventFilter(this);
+		 }
+	}
+}
+
+bool MouseWheelFilter::eventFilter(QObject* object, QEvent* event)
+{
+	if (event->type() != QEvent::Wheel)
+		return false;
+
+	QWidget* widget = qobject_cast<QWidget*>(object);
+	if(!widget || widget->hasFocus())
+		return false;
+
+	event->ignore();
+	return true;
+}

--- a/pcsx2-qt/MouseWheelFilter.h
+++ b/pcsx2-qt/MouseWheelFilter.h
@@ -1,0 +1,30 @@
+/*  PCSX2 - PS2 Emulator for PCs
+ *  Copyright (C) 2002-2023  PCSX2 Dev Team
+ *
+ *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU Lesser General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  PCSX2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with PCSX2.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <QtCore/QObject>
+
+class MouseWheelFilter : public QObject
+{
+	Q_OBJECT
+
+public:
+	MouseWheelFilter(QObject* parent);
+	void install(QObject* target_widget_parent);
+
+protected:
+    bool eventFilter(QObject* object, QEvent* event) override;
+};

--- a/pcsx2-qt/Settings/ControllerSettingsDialog.cpp
+++ b/pcsx2-qt/Settings/ControllerSettingsDialog.cpp
@@ -15,6 +15,7 @@
 
 #include "PrecompiledHeader.h"
 
+#include "MouseWheelFilter.h"
 #include "QtHost.h"
 #include "Settings/ControllerSettingsDialog.h"
 #include "Settings/ControllerGlobalSettingsWidget.h"
@@ -442,6 +443,9 @@ void ControllerSettingsDialog::createWidgets()
 		m_hotkey_settings = new HotkeySettingsWidget(m_ui.settingsContainer, this);
 		m_ui.settingsContainer->addWidget(m_hotkey_settings);
 	}
+
+	MouseWheelFilter* wf = new MouseWheelFilter(this);
+	wf->install(this);
 
 	m_ui.loadProfile->setEnabled(isEditingProfile());
 	m_ui.deleteProfile->setEnabled(isEditingProfile());

--- a/pcsx2-qt/Settings/MemoryCardConvertDialog.cpp
+++ b/pcsx2-qt/Settings/MemoryCardConvertDialog.cpp
@@ -16,6 +16,7 @@
 #include "PrecompiledHeader.h"
 
 #include "MemoryCardConvertDialog.h"
+#include "MouseWheelFilter.h"
 
 #include <QtWidgets/QMessageBox>
 #include <QtWidgets/QPushButton>
@@ -30,6 +31,8 @@ MemoryCardConvertDialog::MemoryCardConvertDialog(QWidget* parent, QString select
 	: QDialog(parent)
 {
 	m_ui.setupUi(this);
+	MouseWheelFilter* wf = new MouseWheelFilter(this);
+	wf->install(this);
 
 	// For some reason, setting these in the .ui doesn't work..
 	m_ui.conversionTypeDescription->setFrameStyle(QFrame::Sunken);

--- a/pcsx2-qt/Settings/SettingsDialog.cpp
+++ b/pcsx2-qt/Settings/SettingsDialog.cpp
@@ -16,6 +16,7 @@
 #include "PrecompiledHeader.h"
 
 #include "MainWindow.h"
+#include "MouseWheelFilter.h"
 #include "QtHost.h"
 #include "QtUtils.h"
 #include "Settings/AchievementSettingsWidget.h"
@@ -206,6 +207,9 @@ void SettingsDialog::setupUi(const GameList::Entry* game)
 			   "<strong>Do not modify unless you know what you are doing</strong>, it will cause significant slowdown, and can waste large "
 			   "amounts of disk space."));
 	}
+
+	MouseWheelFilter* wf = new MouseWheelFilter(this);
+	wf->install(this);
 
 	m_ui.settingsCategory->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Minimum);
 	m_ui.settingsCategory->setCurrentRow(0);

--- a/pcsx2-qt/SetupWizardDialog.cpp
+++ b/pcsx2-qt/SetupWizardDialog.cpp
@@ -16,6 +16,7 @@
 #include "PrecompiledHeader.h"
 
 #include "pcsx2/SIO/Pad/Pad.h"
+#include "MouseWheelFilter.h"
 #include "QtHost.h"
 #include "QtUtils.h"
 #include "SettingWidgetBinder.h"
@@ -189,6 +190,9 @@ void SetupWizardDialog::setupUi()
 	setupBIOSPage();
 	setupGameListPage();
 	setupControllerPage();
+	
+	MouseWheelFilter* wf = new MouseWheelFilter(this);
+	wf->install(this);
 }
 
 void SetupWizardDialog::setupLanguagePage()

--- a/pcsx2-qt/pcsx2-qt.vcxproj
+++ b/pcsx2-qt/pcsx2-qt.vcxproj
@@ -137,6 +137,7 @@
     <ClCompile Include="DisplayWidget.cpp" />
     <ClCompile Include="QtHost.cpp" />
     <ClCompile Include="MainWindow.cpp" />
+    <ClCompile Include="MouseWheelFilter.cpp" />
     <ClCompile Include="PrecompiledHeader.cpp">
       <PrecompiledHeader>Create</PrecompiledHeader>
     </ClCompile>
@@ -201,6 +202,7 @@
     <QtMoc Include="AutoUpdaterDialog.h" />
     <QtMoc Include="CoverDownloadDialog.h" />
     <QtMoc Include="MainWindow.h" />
+    <QtMoc Include="MouseWheelFilter.h" />
     <QtMoc Include="DisplayWidget.h" />
   </ItemGroup>
   <ItemGroup>
@@ -255,6 +257,7 @@
     <ClCompile Include="$(IntDir)moc_CoverDownloadDialog.cpp" />
     <ClCompile Include="$(IntDir)moc_DisplayWidget.cpp" />
     <ClCompile Include="$(IntDir)moc_MainWindow.cpp" />
+    <ClCompile Include="$(IntDir)moc_MouseWheelFilter.cpp" />
     <ClCompile Include="$(IntDir)moc_QtHost.cpp" />
     <ClCompile Include="$(IntDir)moc_QtProgressCallback.cpp" />
     <ClCompile Include="$(IntDir)moc_SetupWizardDialog.cpp" />

--- a/pcsx2-qt/pcsx2-qt.vcxproj.filters
+++ b/pcsx2-qt/pcsx2-qt.vcxproj.filters
@@ -46,6 +46,10 @@
     <ClCompile Include="$(IntDir)moc_DisplayWidget.cpp">
       <Filter>moc</Filter>
     </ClCompile>
+    <ClCompile Include="MouseWheelFilter.cpp" />
+    <ClCompile Include="$(IntDir)moc_MouseWheelFilter.cpp">
+      <Filter>moc</Filter>
+    </ClCompile>
     <ClCompile Include="QtUtils.cpp" />
     <ClCompile Include="$(IntDir)moc_QtHost.cpp">
       <Filter>moc</Filter>
@@ -359,6 +363,7 @@
   <ItemGroup>
     <QtMoc Include="MainWindow.h" />
     <QtMoc Include="DisplayWidget.h" />
+    <QtMoc Include="MouseWheelFilter.h" />
     <QtMoc Include="Settings\BIOSSettingsWidget.h">
       <Filter>Settings</Filter>
     </QtMoc>


### PR DESCRIPTION
### Description of Changes
Now when spinning the mouse wheel while the cursor is hovering above combo and spin boxes the scroll event is passed through to the parent widget instead of being captured by the boxes.

### Rationale behind Changes
Better user experience.

### Suggested Testing Steps
test the behavior of said boxes.
