### PR TITLE
GS/HW: Replace old offset invalidation functions with by page

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.h
@@ -444,7 +444,7 @@ public:
 	void ReadbackAll();
 	void AddDirtyRectTarget(Target* target, GSVector4i rect, u32 psm, u32 bw, RGBAMask rgba, bool req_linear = false);
 	void ResizeTarget(Target* t, GSVector4i rect, u32 tbp, u32 psm, u32 tbw);
-	bool FullRectDirty(Target* target);
+	bool FullRectDirty(Target* target, bool clear = false);
 	bool CanTranslate(u32 bp, u32 bw, u32 spsm, GSVector4i r, u32 dbp, u32 dpsm, u32 dbw);
 	GSVector4i TranslateAlignedRectByPage(Target* t, u32 sbp, u32 spsm, u32 sbw, GSVector4i src_r, bool is_invalidation = false);
 	void DirtyRectByPage(u32 sbp, u32 spsm, u32 sbw, Target* t, GSVector4i src_r);


### PR DESCRIPTION
### Description of Changes
Replace old hackier invalidation functions with new by page translation.

### Rationale behind Changes
Old stuff was gross. However some games rely on the invalidation failing, so there may be some regressions from this (Rugby 08 is the only one I know of).

Also fixed some bugs in the by page translation.

### Suggested Testing Steps
Test general games, the runner showed up a whole bunch of not really visible changes, plus a couple of breaks which I can either not reproduce manually, or doing a render swap on the dump fixes it.

Fixes #9143 MGS3 garbage
Also seems to fix the mess with the Radiata Stories fireplace as shown in #8883 (please test)
Fixes regression on Dark Cloud 2 faces