### PR TITLE
GS/Vulkan: Fix merging non-black targets/work around NV driver issue

### DIFF
--- a/pcsx2/GS/Renderers/Common/GSDevice.cpp
+++ b/pcsx2/GS/Renderers/Common/GSDevice.cpp
@@ -228,6 +228,21 @@ bool GSDevice::GetHostRefreshRate(float* refresh_rate)
 	return WindowInfo::QueryRefreshRateForWindow(m_window_info, refresh_rate);
 }
 
+void GSDevice::ClearRenderTarget(GSTexture* t, u32 c)
+{
+	t->SetClearColor(c);
+}
+
+void GSDevice::ClearDepth(GSTexture* t, float d)
+{
+	t->SetClearDepth(d);
+}
+
+void GSDevice::InvalidateRenderTarget(GSTexture* t)
+{
+	t->SetState(GSTexture::State::Invalidated);
+}
+
 bool GSDevice::UpdateImGuiFontTexture()
 {
 	ImGuiIO& io = ImGui::GetIO();

--- a/pcsx2/GS/Renderers/Common/GSDevice.h
+++ b/pcsx2/GS/Renderers/Common/GSDevice.h
@@ -877,9 +877,9 @@ public:
 	/// Returns the amount of GPU time utilized since the last time this method was called.
 	virtual float GetAndResetAccumulatedGPUTime() = 0;
 
-	virtual void ClearRenderTarget(GSTexture* t, u32 c) = 0;
-	virtual void InvalidateRenderTarget(GSTexture* t) = 0;
-	virtual void ClearDepth(GSTexture* t, float d) = 0;
+	void ClearRenderTarget(GSTexture* t, u32 c);
+	void ClearDepth(GSTexture* t, float d);
+	void InvalidateRenderTarget(GSTexture* t);
 
 	virtual void PushDebugGroup(const char* fmt, ...) = 0;
 	virtual void PopDebugGroup() = 0;

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
@@ -1057,21 +1057,6 @@ void GSDevice11::DrawIndexedPrimitive(int offset, int count)
 	m_ctx->DrawIndexed(count, m_index.start + offset, m_vertex.start);
 }
 
-void GSDevice11::ClearRenderTarget(GSTexture* t, u32 c)
-{
-	t->SetClearColor(c);
-}
-
-void GSDevice11::InvalidateRenderTarget(GSTexture* t)
-{
-	t->SetState(GSTexture::State::Invalidated);
-}
-
-void GSDevice11::ClearDepth(GSTexture* t, float d)
-{
-	t->SetClearDepth(d);
-}
-
 void GSDevice11::CommitClear(GSTexture* t)
 {
 	GSTexture11* T = static_cast<GSTexture11*>(t);

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.h
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.h
@@ -309,10 +309,6 @@ public:
 	void DrawIndexedPrimitive();
 	void DrawIndexedPrimitive(int offset, int count);
 
-	void ClearRenderTarget(GSTexture* t, u32 c) override;
-	void InvalidateRenderTarget(GSTexture* t) override;
-	void ClearDepth(GSTexture* t, float v) override;
-
 	void PushDebugGroup(const char* fmt, ...) override;
 	void PopDebugGroup() override;
 	void InsertDebugMessage(DebugMessageCategory category, const char* fmt, ...) override;

--- a/pcsx2/GS/Renderers/DX12/D3D12Context.cpp
+++ b/pcsx2/GS/Renderers/DX12/D3D12Context.cpp
@@ -650,7 +650,7 @@ bool D3D12Context::AllocatePreinitializedGPUBuffer(u32 size, ID3D12Resource** gp
 	const D3D12MA::ALLOCATION_DESC gpu_ad = {D3D12MA::ALLOCATION_FLAG_COMMITTED, D3D12_HEAP_TYPE_DEFAULT};
 
 	hr = m_allocator->CreateResource(
-		&gpu_ad, &rd, D3D12_RESOURCE_STATE_COPY_DEST, nullptr, gpu_allocation, IID_PPV_ARGS(gpu_buffer));
+		&gpu_ad, &rd, D3D12_RESOURCE_STATE_COMMON, nullptr, gpu_allocation, IID_PPV_ARGS(gpu_buffer));
 	pxAssertMsg(SUCCEEDED(hr), "Allocate GPU buffer");
 	if (FAILED(hr))
 		return false;
@@ -660,7 +660,7 @@ bool D3D12Context::AllocatePreinitializedGPUBuffer(u32 size, ID3D12Resource** gp
 	D3D12_RESOURCE_BARRIER rb = {D3D12_RESOURCE_BARRIER_TYPE_TRANSITION, D3D12_RESOURCE_BARRIER_FLAG_NONE};
 	rb.Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
 	rb.Transition.pResource = *gpu_buffer;
-	rb.Transition.StateBefore = D3D12_RESOURCE_STATE_COPY_DEST;
+	rb.Transition.StateBefore = D3D12_RESOURCE_STATE_COPY_DEST; // COMMON -> COPY_DEST at first use.
 	rb.Transition.StateAfter = D3D12_RESOURCE_STATE_INDEX_BUFFER;
 	GetInitCommandList()->ResourceBarrier(1, &rb);
 

--- a/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
@@ -639,30 +639,6 @@ void GSDevice12::DrawIndexedPrimitive(int offset, int count)
 	g_d3d12_context->GetCommandList()->DrawIndexedInstanced(count, 1, m_index.start + offset, m_vertex.start, 0);
 }
 
-void GSDevice12::ClearRenderTarget(GSTexture* t, u32 c)
-{
-	if (m_current_render_target == t)
-		EndRenderPass();
-
-	t->SetClearColor(c);
-}
-
-void GSDevice12::InvalidateRenderTarget(GSTexture* t)
-{
-	if (m_current_render_target == t || m_current_depth_target == t)
-		EndRenderPass();
-
-	t->SetState(GSTexture::State::Invalidated);
-}
-
-void GSDevice12::ClearDepth(GSTexture* t, float d)
-{
-	if (m_current_depth_target == t)
-		EndRenderPass();
-
-	t->SetClearDepth(d);
-}
-
 void GSDevice12::LookupNativeFormat(GSTexture::Format format, DXGI_FORMAT* d3d_format, DXGI_FORMAT* srv_format,
 	DXGI_FORMAT* rtv_format, DXGI_FORMAT* dsv_format) const
 {

--- a/pcsx2/GS/Renderers/DX12/GSDevice12.h
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.h
@@ -279,10 +279,6 @@ public:
 	void DrawIndexedPrimitive();
 	void DrawIndexedPrimitive(int offset, int count);
 
-	void ClearRenderTarget(GSTexture* t, u32 c) override;
-	void InvalidateRenderTarget(GSTexture* t) override;
-	void ClearDepth(GSTexture* t, float d) override;
-
 	std::unique_ptr<GSDownloadTexture> CreateDownloadTexture(u32 width, u32 height, GSTexture::Format format) override;
 
 	void CopyRect(GSTexture* sTex, GSTexture* dTex, const GSVector4i& r, u32 destX, u32 destY) override;

--- a/pcsx2/GS/Renderers/Metal/GSDeviceMTL.h
+++ b/pcsx2/GS/Renderers/Metal/GSDeviceMTL.h
@@ -404,10 +404,6 @@ public:
 	float GetAndResetAccumulatedGPUTime() override;
 	void AccumulateCommandBufferTime(id<MTLCommandBuffer> buffer);
 
-	void ClearRenderTarget(GSTexture* t, u32 c) override;
-	void ClearDepth(GSTexture* t, float d) override;
-	void InvalidateRenderTarget(GSTexture* t) override;
-
 	std::unique_ptr<GSDownloadTexture> CreateDownloadTexture(u32 width, u32 height, GSTexture::Format format) override;
 
 	void ClearSamplerCache() override;

--- a/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
+++ b/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
@@ -1424,21 +1424,6 @@ void GSDeviceMTL::AccumulateCommandBufferTime(id<MTLCommandBuffer> buffer)
 #pragma clang diagnostic pop
 }
 
-void GSDeviceMTL::ClearRenderTarget(GSTexture* t, uint32 c)
-{
-	t->SetClearColor(c);
-}
-
-void GSDeviceMTL::ClearDepth(GSTexture* t, float d)
-{
-	t->SetClearDepth(d);
-}
-
-void GSDeviceMTL::InvalidateRenderTarget(GSTexture* t)
-{
-	t->SetState(GSTexture::State::Invalidated);
-}
-
 std::unique_ptr<GSDownloadTexture> GSDeviceMTL::CreateDownloadTexture(u32 width, u32 height, GSTexture::Format format)
 {
 	return GSDownloadTextureMTL::Create(this, width, height, format);

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -961,21 +961,6 @@ void GSDeviceOGL::CommitClear(GSTexture* t, bool use_write_fbo)
 	}
 }
 
-void GSDeviceOGL::ClearRenderTarget(GSTexture* t, u32 c)
-{
-	t->SetClearColor(c);
-}
-
-void GSDeviceOGL::InvalidateRenderTarget(GSTexture* t)
-{
-	t->SetState(GSTexture::State::Invalidated);
-}
-
-void GSDeviceOGL::ClearDepth(GSTexture* t, float d)
-{
-	t->SetClearDepth(d);
-}
-
 std::unique_ptr<GSDownloadTexture> GSDeviceOGL::CreateDownloadTexture(u32 width, u32 height, GSTexture::Format format)
 {
 	return GSDownloadTextureOGL::Create(width, height, format);

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.h
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.h
@@ -311,10 +311,6 @@ public:
 	void DrawIndexedPrimitive();
 	void DrawIndexedPrimitive(int offset, int count);
 
-	void ClearRenderTarget(GSTexture* t, u32 c) override;
-	void InvalidateRenderTarget(GSTexture* t) override;
-	void ClearDepth(GSTexture* t, float d) override;
-
 	std::unique_ptr<GSDownloadTexture> CreateDownloadTexture(u32 width, u32 height, GSTexture::Format format) override;
 
 	GSTexture* InitPrimDateTexture(GSTexture* rt, const GSVector4i& area, bool datm);

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
@@ -790,21 +790,6 @@ void GSDeviceVK::DrawIndexedPrimitive(int offset, int count)
 	vkCmdDrawIndexed(g_vulkan_context->GetCurrentCommandBuffer(), count, 1, m_index.start + offset, m_vertex.start, 0);
 }
 
-void GSDeviceVK::ClearRenderTarget(GSTexture* t, u32 c)
-{
-	t->SetClearColor(c);
-}
-
-void GSDeviceVK::InvalidateRenderTarget(GSTexture* t)
-{
-	t->SetState(GSTexture::State::Invalidated);
-}
-
-void GSDeviceVK::ClearDepth(GSTexture* t, float d)
-{
-	t->SetClearDepth(d);
-}
-
 VkFormat GSDeviceVK::LookupNativeFormat(GSTexture::Format format) const
 {
 	static constexpr std::array<VkFormat, static_cast<int>(GSTexture::Format::BC7) + 1> s_format_mapping = {{

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h
@@ -265,10 +265,6 @@ public:
 	void DrawIndexedPrimitive();
 	void DrawIndexedPrimitive(int offset, int count);
 
-	void ClearRenderTarget(GSTexture* t, u32 c) override;
-	void InvalidateRenderTarget(GSTexture* t) override;
-	void ClearDepth(GSTexture* t, float d) override;
-
 	std::unique_ptr<GSDownloadTexture> CreateDownloadTexture(u32 width, u32 height, GSTexture::Format format) override;
 
 	void CopyRect(GSTexture* sTex, GSTexture* dTex, const GSVector4i& r, u32 destX, u32 destY) override;

--- a/pcsx2/GS/Renderers/Vulkan/VKContext.h
+++ b/pcsx2/GS/Renderers/Vulkan/VKContext.h
@@ -128,6 +128,9 @@ public:
 		return m_device_properties.limits.maxImageDimension2D;
 	}
 
+	/// Returns true if running on an NVIDIA GPU.
+	__fi bool IsDeviceNVIDIA() const { return (m_device_properties.vendorID == 0x10DE); }
+
 	// Creates a simple render pass.
 	__ri VkRenderPass GetRenderPass(VkFormat color_format, VkFormat depth_format,
 		VkAttachmentLoadOp color_load_op = VK_ATTACHMENT_LOAD_OP_LOAD,


### PR DESCRIPTION
### Description of Changes

Merge didn't blit non-black targets, causing black screens in some transitions in Persona 3.

NVIDIA drivers appear to return random garbage when sampling the RT via a feedback loop, if the load op for the render pass is CLEAR. Using vkCmdClearAttachments() doesn't work, so we have to clear the image instead. This caused garbage in the flags in WRC Rally Evolved's language select screen.

I'm not sure if this is a spec violation, or what we're doing just happens to be undefined. Given attachment clear doesn't work, I'm inclined to go with the former. The spec does note:

> If the first use of an attachment in this render pass is as an input attachment, and the attachment is not also used as a color or depth/stencil attachment in the same subpass, then loadOp must not be VK_ATTACHMENT_LOAD_OP_CLEAR

But we **are** using the attachment as a colour attachment in the same render pass.

### Rationale behind Changes

Regression fixes.

### Suggested Testing Steps

Test affected games.
