### PR TITLE
GS: Move VSync flush to caller

### DIFF
--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -389,6 +389,9 @@ void GSgifTransfer3(u8* mem, u32 size)
 
 void GSvsync(u32 field, bool registers_written)
 {
+	// Do not move the flush into the VSync() method. It's here because EE transfers
+	// get cleared in HW VSync, and may be needed for a buffered draw (FFX FMVs).
+	g_gs_renderer->Flush(GSState::VSYNC);
 	g_gs_renderer->VSync(field, registers_written, g_gs_renderer->IsIdleFrame());
 }
 

--- a/pcsx2/GS/Renderers/Common/GSRenderer.cpp
+++ b/pcsx2/GS/Renderers/Common/GSRenderer.cpp
@@ -536,8 +536,6 @@ void GSRenderer::EndPresentFrame()
 
 void GSRenderer::VSync(u32 field, bool registers_written, bool idle_frame)
 {
-	Flush(GSFlushReason::VSYNC);
-
 	if (GSConfig.DumpGSData && s_n >= GSConfig.SaveN)
 	{
 		m_regs->Dump(GetDrawDumpPath("vsync_%05d_f%lld_gs_reg.txt", s_n, g_perfmon.GetFrame()));


### PR DESCRIPTION
### Description of Changes

FFX's FMVs writes to the render target (annoyingly with a Y offset to push it to the second buffer, but alas).

The draw where it alpha tests+copies what I'm guessing is the subtitle text over the top gets buffered, and flushed at VSync time. Problem is the EE transfer list got cleared in GSRendererHW::VSync(), before the flush happened, so it doesn't know it needs to preload.

So reverse the order of operations.

### Rationale behind Changes

Fixes FMV flicker in FFX.

### Suggested Testing Steps

Check FFX FMV.