### PR TITLE
GS/HW: avoid divide by zero's in draw rect calculations

### DIFF
--- a/pcsx2/GS/GSLocalMemory.cpp
+++ b/pcsx2/GS/GSLocalMemory.cpp
@@ -491,7 +491,7 @@ GSVector4i GSLocalMemory::GetRectForPageOffset(u32 base_bp, u32 offset_bp, u32 b
 
 	const u32 page_offset = (offset_bp - base_bp) >> 5;
 	const GSVector2i& pgs = m_psm[psm].pgs;
-	const GSVector2i page_offset_xy = GSVector2i(page_offset % bw, page_offset / bw);
+	const GSVector2i page_offset_xy = GSVector2i(page_offset % bw, page_offset / std::max(1U, bw));
 	return GSVector4i(pgs * page_offset_xy).xyxy() + GSVector4i::loadh(pgs);
 }
 

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -914,7 +914,7 @@ GSVector4i GSRendererHW::GetSplitTextureShuffleDrawRect() const
 GSVector4i GSRendererHW::GetDrawRectForPages(u32 bw, u32 psm, u32 num_pages)
 {
 	const GSVector2i& pgs = GSLocalMemory::m_psm[psm].pgs;
-	const GSVector2i size = GSVector2i(static_cast<int>(bw) * pgs.x, static_cast<int>(num_pages / bw) * pgs.y);
+	const GSVector2i size = GSVector2i(static_cast<int>(bw) * pgs.x, static_cast<int>(num_pages / std::max(1U, bw)) * pgs.y);
 	return GSVector4i::loadh(size);
 }
 


### PR DESCRIPTION
### Description of Changes
Avoids divide by zero errors

### Rationale behind Changes
Dividing by zero is bad. Call of Duty 3 was hitting this with a buffer width of 0

### Suggested Testing Steps
Untested but pretty confident this is better than crashing.
