### PR TITLE
GS/HW: Use minimum UV as a channel shuffle heuristic 

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -5785,6 +5785,8 @@ SCPS-11008:
   name: "Boku to Mao"
   region: "NTSC-J"
   compat: 5
+  gsHWFixes:
+    autoFlush: 1 # Depth of field blur is incorrect without it.
 SCPS-11009:
   name: "Ka"
   region: "NTSC-J"
@@ -6594,6 +6596,8 @@ SCPS-19101:
 SCPS-19102:
   name: "Boku to Maou [PlayStation 2 The Best]"
   region: "NTSC-J"
+  gsHWFixes:
+    autoFlush: 1 # Depth of field blur is incorrect without it.
 SCPS-19103:
   name: "ICO [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -7570,6 +7574,8 @@ SCUS-97129:
   name: "Okage - Shadow King"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    autoFlush: 1 # Depth of field blur is incorrect without it.
 SCUS-97130:
   name: "Hot Shots Golf 3"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes

Used by Ape Escape 2, Everybody's Tennis/Golf, Okage, and Valkyrie Profile 2.

Unfortunately the player shadows are still missing in tennis/golf - it does a P4HH -> P4 move to create a texture which later gets drawn to the FB which gets channel shuffled... I swear I can smell something... like... epoxy... now I have a feeling of writing an overengineered shadow renderer...

Sadly none of the other currently-broken channel shuffles seem to work with this heuristic.

### Rationale behind Changes

Closes #9161.
Closes #5342.

![image](https://github.com/PCSX2/pcsx2/assets/11288319/ec3b7927-2054-403e-97ae-6eef8463bca0)
![image](https://github.com/PCSX2/pcsx2/assets/11288319/681fc40e-1a60-4fd0-a6f1-5b9c73fc0364)
![image](https://github.com/PCSX2/pcsx2/assets/11288319/56c5a464-744d-48c8-b144-38115a522b2e)


### Suggested Testing Steps

Check affected games.
