### PR TITLE
GameDB: Fix broken shadow in Armored Core Formula Front

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -826,6 +826,7 @@ SCAJ-20076:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
     partialTargetInvalidation: 1 # Fixes broken textures.
+    recommendedBlendingLevel: 3 # Fixes level brightness.
   memcardFilters:
     - "SCAJ-20076"
     - "SCAJ-20077"
@@ -839,6 +840,7 @@ SCAJ-20077:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
     partialTargetInvalidation: 1 # Fixes broken textures.
+    recommendedBlendingLevel: 3 # Fixes level brightness.
   memcardFilters:
     - "SCAJ-20076"
     - "SCAJ-20077"
@@ -1077,6 +1079,8 @@ SCAJ-20121:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
     partialTargetInvalidation: 1 # Fixes broken textures.
+    cpuSpriteRenderBW: 1 # Fixes broken shadow caused by HPO 1.
+    cpuSpriteRenderLevel: 2 # Needed for above.
 SCAJ-20122:
   name: "Swords of Destiny"
   region: "NTSC-Unk"
@@ -24231,6 +24235,7 @@ SLES-82036:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
     partialTargetInvalidation: 1 # Fixes broken textures.
+    recommendedBlendingLevel: 3 # Fixes level brightness.
   memcardFilters:
     - "SLES-82036"
     - "SLES-82037"
@@ -24240,6 +24245,7 @@ SLES-82037:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
     partialTargetInvalidation: 1 # Fixes broken textures.
+    recommendedBlendingLevel: 3 # Fixes level brightness.
   memcardFilters:
     - "SLES-82036"
     - "SLES-82037"
@@ -25050,6 +25056,7 @@ SLKA-25201:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
     partialTargetInvalidation: 1 # Fixes broken textures.
+    recommendedBlendingLevel: 3 # Fixes level brightness.
   memcardFilters:
     - "SLKA-25201"
     - "SLKA-25202"
@@ -25059,6 +25066,7 @@ SLKA-25202:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
     partialTargetInvalidation: 1 # Fixes broken textures.
+    recommendedBlendingLevel: 3 # Fixes level brightness.
   memcardFilters:
     - "SLKA-25201"
     - "SLKA-25202"
@@ -25300,6 +25308,8 @@ SLKA-25270:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
     partialTargetInvalidation: 1 # Fixes broken textures.
+    cpuSpriteRenderBW: 1 # Fixes broken shadow caused by HPO 1.
+    cpuSpriteRenderLevel: 2 # Needed for above.
 SLKA-25274:
   name: "Princess Maker 4"
   region: "NTSC-K"
@@ -39657,6 +39667,7 @@ SLPS-25338:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
     partialTargetInvalidation: 1 # Fixes broken textures.
+    recommendedBlendingLevel: 3 # Fixes level brightness.
   memcardFilters:
     - "SCAJ-20076"
     - "SCAJ-20077"
@@ -39670,6 +39681,7 @@ SLPS-25339:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
     partialTargetInvalidation: 1 # Fixes broken textures.
+    recommendedBlendingLevel: 3 # Fixes level brightness.
   memcardFilters:
     - "SCAJ-20076"
     - "SCAJ-20077"
@@ -40170,6 +40182,8 @@ SLPS-25461:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
     partialTargetInvalidation: 1 # Fixes broken textures.
+    cpuSpriteRenderBW: 1 # Fixes broken shadow caused by HPO 1.
+    cpuSpriteRenderLevel: 2 # Needed for above.
 SLPS-25462:
   name: "Armored Core - Last Raven"
   region: "NTSC-J"
@@ -42060,6 +42074,7 @@ SLPS-73202:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
     partialTargetInvalidation: 1 # Fixes broken textures.
+    recommendedBlendingLevel: 3 # Fixes level brightness.
   memcardFilters:
     - "SCAJ-20076"
     - "SCAJ-20077"
@@ -42073,6 +42088,7 @@ SLPS-73203:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
     partialTargetInvalidation: 1 # Fixes broken textures.
+    recommendedBlendingLevel: 3 # Fixes level brightness.
   memcardFilters:
     - "SCAJ-20076"
     - "SCAJ-20077"
@@ -47274,6 +47290,7 @@ SLUS-20986:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
     partialTargetInvalidation: 1 # Fixes broken textures.
+    recommendedBlendingLevel: 3 # Fixes level brightness.
   memcardFilters:
     - "SLUS-20986"
     - "SLUS-21079"
@@ -47789,6 +47806,7 @@ SLUS-21079:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
     partialTargetInvalidation: 1 # Fixes broken textures.
+    recommendedBlendingLevel: 3 # Fixes level brightness.
   memcardFilters:
     - "SLUS-20986"
     - "SLUS-21079"


### PR DESCRIPTION
### Description of Changes
Added CPU Sprite Render to Armored Core Formula Front.

### Rationale behind Changes
- HPO Normal was added to fix blur effects, but it breaks shadow rendering in this game.
- CPU Sprite Render can fix it.

### Suggested Testing Steps
Tested ACFF