### PR TITLE
GS/HW: Be more strict with double half clear detection

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -16447,6 +16447,8 @@ SLES-52761:
   name: "Rocky - Legends"
   region: "PAL-M3"
   compat: 5
+  gsHWFixes:
+    preloadFrameData: 1 # Fixes background FMV flicker.
 SLES-52766:
   name: "Godzilla - Save The Earth"
   region: "PAL-M5"
@@ -46714,6 +46716,8 @@ SLUS-20890:
   name: "Rocky - Legends"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    preloadFrameData: 1 # Fixes background FMV flicker.
 SLUS-20891:
   name: "Star Ocean 3 - Till the End of Time [Disc 2 of 2]"
   region: "NTSC-U"

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -1935,24 +1935,10 @@ void GSRendererHW::Draw()
 		}
 
 		const bool is_zero_clear = (GetConstantDirectWriteMemClearColor() == 0 && !preserve_rt_color);
-		const bool req_z = m_cached_ctx.FRAME.FBP != m_cached_ctx.ZBUF.ZBP && !m_cached_ctx.ZBUF.ZMSK;
-		bool no_target_found = false;
-
-		// This is behind the if just to reduce lookups.
-		if (is_zero_clear && !clear_height_valid)
-		{
-			const u32 fbw = m_cached_ctx.FRAME.FBW;
-			const u32 frame_start = m_cached_ctx.FRAME.Block();
-			const u32 frame_end = GSLocalMemory::GetEndBlockAddress(frame_start, fbw, m_cached_ctx.FRAME.PSM, m_r);
-			no_target_found =
-				!g_texture_cache->GetExactTarget(frame_start, fbw, GSTextureCache::RenderTarget, frame_end) &&
-				!g_texture_cache->GetExactTarget(frame_start, fbw, GSTextureCache::DepthStencil, frame_end);
-		}
 
 		// If it's an invalid-sized draw, do the mem clear on the CPU, we don't want to create huge targets.
 		// If clearing to zero, don't bother creating the target. Games tend to clear more than they use, wasting VRAM/bandwidth.
-		if ((is_zero_clear || clear_height_valid) && TryGSMemClear(no_rt, no_ds) &&
-			(clear_height_valid || (!req_z && no_target_found)))
+		if ((is_zero_clear || clear_height_valid) && TryGSMemClear())
 		{
 			GL_INS("Skipping (%d,%d=>%d,%d) draw at FBP %x/ZBP %x due to invalid height or zero clear.", m_r.x, m_r.y,
 				m_r.z, m_r.w, m_cached_ctx.FRAME.Block(), m_cached_ctx.ZBUF.Block());
@@ -2148,7 +2134,7 @@ void GSRendererHW::Draw()
 			{
 				GL_INS("Clear draw with no target, skipping.");
 				cleanup_cancelled_draw();
-				TryGSMemClear(no_rt, no_ds);
+				TryGSMemClear();
 				return;
 			}
 
@@ -5338,13 +5324,24 @@ bool GSRendererHW::DetectDoubleHalfClear(bool& no_rt, bool& no_ds)
 	const u32 half = clear_depth ? m_cached_ctx.FRAME.FBP : m_cached_ctx.ZBUF.ZBP;
 
 	// Size of the current draw
-	const u32 w_pages = static_cast<u32>(roundf(m_vt.m_max.p.x / frame_psm.pgs.x));
-	const u32 h_pages = static_cast<u32>(roundf(m_vt.m_max.p.y / frame_psm.pgs.y));
+	const u32 w_pages = (m_r.z + (frame_psm.pgs.x - 1)) / frame_psm.pgs.x;
+	const u32 h_pages = (m_r.w + (frame_psm.pgs.y - 1)) / frame_psm.pgs.y;
 	const u32 written_pages = w_pages * h_pages;
 
 	// If both buffers are side by side we can expect a fast clear in on-going
 	if (half != (base + written_pages))
 		return false;
+
+	// Don't allow double half clear to go through when the number of bits written through FRAME and Z are different.
+	// GTA: LCS does this setup, along with a few other games. Thankfully if it's a zero clear, we'll clear both
+	// separately, and the end result is the same because it gets invalidated. That's better than falsely detecting
+	// double half clears, and ending up with 1024 high render targets which really shouldn't be.
+	if (frame_psm.fmt != zbuf_psm.fmt && m_cached_ctx.FRAME.FBMSK != ((zbuf_psm.fmt == 1) ? 0xFF000000u : 0))
+	{
+		GL_INS("Inconsistent FRAME [%s, %08x] and ZBUF [%s] formats, not using double-half clear.",
+			psm_str(m_cached_ctx.FRAME.PSM), m_cached_ctx.FRAME.FBMSK, psm_str(m_cached_ctx.ZBUF.PSM));
+		return false;
+	}
 
 	// Try peeking ahead to confirm whether this is a "normal" clear, where the two buffers just happen to be
 	// bang up next to each other, or a double half clear. The two are really difficult to differentiate.
@@ -5389,13 +5386,6 @@ bool GSRendererHW::DetectDoubleHalfClear(bool& no_rt, bool& no_ds)
 	GL_INS("DetectDoubleHalfClear(): Clearing %s, fbp=%x, zbp=%x, pages=%u, base=%x, half=%x, rect=(%d,%d=>%d,%d)",
 		clear_depth ? "depth" : "color", m_cached_ctx.FRAME.Block(), m_cached_ctx.ZBUF.Block(), written_pages,
 		base * BLOCKS_PER_PAGE, half * BLOCKS_PER_PAGE, m_r.x, m_r.y, m_r.z, m_r.w);
-
-	// Warn, but not fatal if the clear is inconsistent across FRAME and Z pages.
-	if (frame_psm.fmt != zbuf_psm.fmt && m_cached_ctx.FRAME.FBMSK != ((zbuf_psm.fmt == 1) ? 0xFF000000u : 0))
-	{
-		GL_INS("Inconsistent FRAME [%s, %08x] and ZBUF [%s] formats in double-half clear.",
-			psm_str(m_cached_ctx.FRAME.PSM), m_cached_ctx.FRAME.FBMSK, psm_str(m_cached_ctx.ZBUF.PSM));
-	}
 
 	// Double the clear rect.
 	if (horizontal)
@@ -5465,7 +5455,7 @@ bool GSRendererHW::TryTargetClear(GSTextureCache::Target* rt, GSTextureCache::Ta
 	return skip;
 }
 
-bool GSRendererHW::TryGSMemClear(bool no_rt, bool no_ds)
+bool GSRendererHW::TryGSMemClear()
 {
 	if (!PrimitiveCoversWithoutGaps())
 		return false;
@@ -5476,17 +5466,21 @@ bool GSRendererHW::TryGSMemClear(bool no_rt, bool no_ds)
 		return false;
 
 	// Don't mem clear one of frame or z, only do both.
-	const u32 fbmsk = (m_cached_ctx.FRAME.FBMSK & GSLocalMemory::m_psm[m_cached_ctx.FRAME.PSM].fmsk);
-	if ((!no_rt && (fbmsk != 0 || m_vt.m_eq.rgba != 0xFFFF)) ||
-		(!no_ds && (m_cached_ctx.ZBUF.ZMSK != 0 || !m_vt.m_eq.z)))
+	const u32 fmsk = GSLocalMemory::m_psm[m_cached_ctx.FRAME.PSM].fmsk;
+	const u32 fbmsk = (m_cached_ctx.FRAME.FBMSK & fmsk);
+	const bool clear_rt = (fbmsk & fmsk) != fmsk;
+	const bool clear_z = (m_cached_ctx.ZBUF.ZMSK == 0);
+	if ((clear_rt && ((fbmsk != 0 && (m_cached_ctx.FRAME.PSM != PSMCT32 || fbmsk != 0xFF000000u)) ||
+						 m_vt.m_eq.rgba != 0xFFFF)) ||
+		(clear_z && (m_cached_ctx.ZBUF.ZMSK != 0 && !m_vt.m_eq.z)))
 	{
 		return false;
 	}
 
-	if (!no_rt)
+	if (clear_rt)
 		ClearGSLocalMemory(m_context->offset.fb, m_r, GetConstantDirectWriteMemClearColor());
 
-	if (!no_ds)
+	if (clear_z)
 		ClearGSLocalMemory(m_context->offset.zb, m_r, m_vertex.buff[1].XYZ.Z);
 
 	return true;
@@ -5497,7 +5491,8 @@ void GSRendererHW::ClearGSLocalMemory(const GSOffset& off, const GSVector4i& r, 
 	GL_INS(
 		"ClearGSLocalMemory(): %08X %d,%d => %d,%d @ BP %x BW %u", vert_color, r.x, r.y, r.z, r.w, off.bp(), off.bw());
 
-	const int format = GSLocalMemory::m_psm[off.psm()].fmt;
+	const u32 psm = (off.psm() == PSMCT32 && m_cached_ctx.FRAME.FBMSK == 0xFF000000u) ? PSMCT24 : off.psm();
+	const int format = GSLocalMemory::m_psm[psm].fmt;
 
 	const int left = r.left;
 	const int right = r.right;
@@ -5510,7 +5505,7 @@ void GSRendererHW::ClearGSLocalMemory(const GSOffset& off, const GSVector4i& r, 
 
 	const u32 fbw = m_cached_ctx.FRAME.FBW;
 	const u32 pages_wide = r.z / 64u;
-	const GSVector2i& pgs = GSLocalMemory::m_psm[off.psm()].pgs;
+	const GSVector2i& pgs = GSLocalMemory::m_psm[psm].pgs;
 	if (left == 0 && top == 0 && (right & (pgs.x - 1)) == 0 && pages_wide <= fbw)
 	{
 		const u32 pixels_per_page = pgs.x * pgs.y;

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.h
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.h
@@ -44,7 +44,7 @@ private:
 
 	// Require special argument
 	bool OI_BlitFMV(GSTextureCache::Target* _rt, GSTextureCache::Source* t, const GSVector4i& r_draw);
-	bool TryGSMemClear(bool no_rt, bool no_ds);
+	bool TryGSMemClear();
 	void ClearGSLocalMemory(const GSOffset& off, const GSVector4i& r, u32 vert_color);
 	bool DetectDoubleHalfClear(bool& no_rt, bool& no_ds);
 	bool DetectStripedDoubleClear(bool& no_rt, bool& no_ds);


### PR DESCRIPTION
### Description of Changes

Further improvements to clear detection. Fixes a few games, breaks a couple of others:

 - sf3ex: Effect is broken anyway, but now flickers on alternate frames because of false double buffer detection.
 - Growlanser: Heritage of War: Game uploads a Z buffer, moves to swizzle it, but in C32 instead of Z32 so it doesn't get uploaded, because the target got purged. Needs EE transfer handling to be improved.

Not sure if we should hold off on merging until I solve the above.. the first two weren't working correctly anyway. And were sorta working only by chance...

### Rationale behind Changes

Fixes #8672.
Fixes #9167.
Fixes #9163.
Fixes #9170.

### Suggested Testing Steps

Check affected games.
