### PR TITLE
GS: Improve capture robustness

### DIFF
--- a/pcsx2-gsrunner/Main.cpp
+++ b/pcsx2-gsrunner/Main.cpp
@@ -334,6 +334,14 @@ void Host::SetFullscreen(bool enabled)
 {
 }
 
+void Host::OnCaptureStarted(const std::string& filename)
+{
+}
+
+void Host::OnCaptureStopped()
+{
+}
+
 void Host::RequestExit(bool allow_confirm)
 {
 }

--- a/pcsx2-qt/MainWindow.h
+++ b/pcsx2-qt/MainWindow.h
@@ -183,6 +183,9 @@ private Q_SLOTS:
 	void onGameChanged(const QString& title, const QString& elf_override, const QString& disc_path,
 		const QString& serial, quint32 disc_crc, quint32 crc);
 
+	void onCaptureStarted(const QString& filename);
+	void onCaptureStopped();
+
 protected:
 	void showEvent(QShowEvent* event) override;
 	void closeEvent(QCloseEvent* event) override;

--- a/pcsx2-qt/QtHost.cpp
+++ b/pcsx2-qt/QtHost.cpp
@@ -1186,6 +1186,16 @@ void Host::SetFullscreen(bool enabled)
 	g_emu_thread->setFullscreen(enabled, true);
 }
 
+void Host::OnCaptureStarted(const std::string& filename)
+{
+	emit g_emu_thread->onCaptureStarted(QString::fromStdString(filename));
+}
+
+void Host::OnCaptureStopped()
+{
+	emit g_emu_thread->onCaptureStopped();
+}
+
 bool QtHost::InitializeConfig()
 {
 	if (!EmuFolders::InitializeCriticalFolders())

--- a/pcsx2-qt/QtHost.h
+++ b/pcsx2-qt/QtHost.h
@@ -158,6 +158,10 @@ Q_SIGNALS:
 	/// Called when achievements are reloaded/refreshed (e.g. game change, login, option change).
 	void onAchievementsRefreshed(quint32 id, const QString& game_info_string, quint32 total, quint32 points);
 
+	/// Called when video capture starts/stops.
+	void onCaptureStarted(const QString& filename);
+	void onCaptureStopped();
+
 protected:
 	void run();
 

--- a/pcsx2/GS/GS.h
+++ b/pcsx2/GS/GS.h
@@ -139,4 +139,8 @@ namespace Host
 
 	/// Returns the desired vsync mode, depending on the runtime environment.
 	VsyncMode GetEffectiveVSyncMode();
+
+	/// Called when video capture starts or stops. Called on the MTGS thread.
+	void OnCaptureStarted(const std::string& filename);
+	void OnCaptureStopped();
 }

--- a/pcsx2/GS/GSCapture.cpp
+++ b/pcsx2/GS/GSCapture.cpp
@@ -794,6 +794,9 @@ bool GSCapture::BeginCapture(float fps, GSVector2i recommendedResolution, float 
 
 	s_capturing.store(true, std::memory_order_release);
 	StartEncoderThread();
+
+	lock.unlock();
+	Host::OnCaptureStarted(s_filename);
 	return true;
 }
 
@@ -1300,8 +1303,12 @@ void GSCapture::InternalEndCapture(std::unique_lock<std::mutex>& lock)
 
 void GSCapture::EndCapture()
 {
-	std::unique_lock<std::mutex> lock(s_lock);
-	InternalEndCapture(lock);
+	{
+		std::unique_lock<std::mutex> lock(s_lock);
+		InternalEndCapture(lock);
+	}
+
+	Host::OnCaptureStopped();
 }
 
 bool GSCapture::IsCapturing()

--- a/pcsx2/GS/GSCapture.h
+++ b/pcsx2/GS/GSCapture.h
@@ -40,6 +40,8 @@ namespace GSCapture
 	bool IsCapturingAudio();
 	const Threading::ThreadHandle& GetEncoderThreadHandle();
 	GSVector2i GetSize();
+	std::string GetNextCaptureFileName();
+	void Flush();
 
 	using CodecName = std::pair<std::string, std::string>; // shortname,longname
 	using CodecList = std::vector<CodecName>;

--- a/pcsx2/GS/Renderers/Common/GSRenderer.h
+++ b/pcsx2/GS/Renderers/Common/GSRenderer.h
@@ -70,7 +70,7 @@ public:
 	void StopGSDump();
 	void PresentCurrentFrame();
 
-	bool BeginCapture(std::string filename);
+	bool BeginCapture(std::string filename, const GSVector2i& size = GSVector2i(0, 0));
 	void EndCapture();
 };
 

--- a/tests/ctest/core/StubHost.cpp
+++ b/tests/ctest/core/StubHost.cpp
@@ -178,6 +178,14 @@ void Host::SetFullscreen(bool enabled)
 {
 }
 
+void Host::OnCaptureStarted(const std::string& filename)
+{
+}
+
+void Host::OnCaptureStopped()
+{
+}
+
 void Host::RequestExit(bool save_state_if_running)
 {
 }


### PR DESCRIPTION
### Description of Changes

Automatically restart capture on renderer or hardware reset.

Syncs video capture checkbox to "real" state.

### Rationale behind Changes

Closes #9176.
Closes #8904.

### Suggested Testing Steps

Check loading state when capturing video+audio.
Check resetting while doing the same.
