### PR TITLE
USB/usb-mic: Fix buffer handling

### DIFF
--- a/pcsx2/USB/shared/ringbuffer.cpp
+++ b/pcsx2/USB/shared/ringbuffer.cpp
@@ -162,7 +162,7 @@ void RingBuffer::write(size_t bytes)
 
 	// push m_begin forward if m_end overlaps it
 	if ((m_end < m_begin && m_end + bytes > m_begin) ||
-		m_end + bytes > m_begin + m_capacity)
+		m_end + bytes >= m_begin + m_capacity)
 	{
 		m_overrun = true;
 		m_begin = (m_end + bytes) % m_capacity;

--- a/pcsx2/USB/usb-mic/audiodev-cubeb.h
+++ b/pcsx2/USB/usb-mic/audiodev-cubeb.h
@@ -51,6 +51,7 @@ namespace usb_mic
 
 			u32 mSampleRate = 48000;
 			u32 mLatency = 50;
+			u32 mStreamLatency = 0;
 			cubeb* mContext;
 			cubeb_stream* mStream = nullptr;
 			std::string mDeviceName;


### PR DESCRIPTION
### Description of Changes

 - RingBuffer would store a size of zero if you wrote the entire the entire buffer in one call.

 - ResetBuffers() should be called before starting the stream, otherwise you risk a race where the callback happens before the buffer is allocated.

 - Fix incorrect latency being passed into Cubeb.

Side note: that ring buffer class is pretty awful. But I don't care enough to rewrite it.

### Rationale behind Changes

Closes #8974.

### Suggested Testing Steps

Test usb-mic.
