### PR TITLE
GS/HW: Add render fix for complex moves

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -23117,7 +23117,7 @@ SLES-55215:
   region: "PAL-E"
   compat: 5
   gsHWFixes:
-    textureInsideRT: 1 # Fixes character layering issue.
+    moveHandler: "MV_Growlanser" # Fixes precomputed depth buffer.
 SLES-55216:
   name: "Baroque"
   region: "PAL-E"
@@ -26716,7 +26716,7 @@ SLPM-61148:
   name: "Growlanser V - Generations [Taikenban Demo]"
   region: "NTSC-J"
   gsHWFixes:
-    textureInsideRT: 1 # Fixes character layering issue.
+    moveHandler: "MV_Growlanser" # Fixes precomputed depth buffer.
 SLPM-61153:
   name: "Dengeki PS2 PlayStation D92"
   region: "NTSC-J"
@@ -33555,7 +33555,7 @@ SLPM-66249:
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
-    textureInsideRT: 1 # Fixes character layering issue.
+    moveHandler: "MV_Growlanser" # Fixes precomputed depth buffer.
 SLPM-66250:
   name: "Choro Q HG 4 [Takara Best]"
   region: "NTSC-J"
@@ -34179,7 +34179,7 @@ SLPM-66418:
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
-    textureInsideRT: 1 # Fixes character layering issue.
+    moveHandler: "MV_Growlanser" # Fixes precomputed depth buffer.
 SLPM-66419:
   name: "Valkyrie Profile 2 - Silmeria"
   region: "NTSC-J"
@@ -35399,7 +35399,7 @@ SLPM-66716:
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
-    textureInsideRT: 1 # Fixes character layering issue.
+    moveHandler: "MV_Growlanser" # Fixes precomputed depth buffer.
 SLPM-66717:
   name: "Standard Daisenryaku - Dengekisen [Sega the Best]"
   region: "NTSC-J"
@@ -50466,7 +50466,7 @@ SLUS-21571:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    textureInsideRT: 1 # Fixes character layering issue.
+    moveHandler: "MV_Growlanser" # Fixes precomputed depth buffer.
 SLUS-21572:
   name: "Surf's Up"
   region: "NTSC-U"

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -748,6 +748,7 @@ struct Pcsx2Config
 		u8 TVShader = 0;
 		s16 GetSkipCountFunctionId = -1;
 		s16 BeforeDrawFunctionId = -1;
+		s16 MoveHandlerFunctionId = -1;
 		int SkipDrawStart = 0;
 		int SkipDrawEnd = 0;
 

--- a/pcsx2/Docs/gamedb-schema.json
+++ b/pcsx2/Docs/gamedb-schema.json
@@ -287,6 +287,9 @@
             },
             "beforeDraw": {
               "type": "string"
+            },
+            "moveHandler": {
+              "type": "string"
             }
           },
           "additionalProperties": false

--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -717,7 +717,8 @@ void GSUpdateConfig(const Pcsx2Config::GSOptions& new_config)
 	if (GSConfig.UserHacks_DisableRenderFixes != old_config.UserHacks_DisableRenderFixes ||
 		GSConfig.UpscaleMultiplier != old_config.UpscaleMultiplier ||
 		GSConfig.GetSkipCountFunctionId != old_config.GetSkipCountFunctionId ||
-		GSConfig.BeforeDrawFunctionId != old_config.BeforeDrawFunctionId)
+		GSConfig.BeforeDrawFunctionId != old_config.BeforeDrawFunctionId ||
+		GSConfig.MoveHandlerFunctionId != old_config.MoveHandlerFunctionId)
 	{
 		g_gs_renderer->UpdateCRCHacks();
 	}

--- a/pcsx2/GS/GS.h
+++ b/pcsx2/GS/GS.h
@@ -68,6 +68,7 @@ class HostDisplay;
 // Returns the ID for the specified function, otherwise -1.
 s16 GSLookupGetSkipCountFunctionId(const std::string_view& name);
 s16 GSLookupBeforeDrawFunctionId(const std::string_view& name);
+s16 GSLookupMoveHandlerFunctionId(const std::string_view& name);
 
 void GSinit();
 void GSshutdown();

--- a/pcsx2/GS/GSRegs.h
+++ b/pcsx2/GS/GSRegs.h
@@ -836,6 +836,15 @@ REG_END2
 		// The recast of TBW seems useless but it avoid tons of warning from GCC...
 		return ((u32)TBW << 6u) < (1u << TW);
 	}
+
+	__forceinline static GIFRegTEX0 Create(u32 bp, u32 bw, u32 psm)
+	{
+		GIFRegTEX0 ret = {};
+		ret.TBP0 = bp;
+		ret.TBW = bw;
+		ret.PSM = psm;
+		return ret;
+	}
 REG_END2
 
 REG64_(GIFReg, TEX1)

--- a/pcsx2/GS/Renderers/HW/GSHwHack.h
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.h
@@ -57,6 +57,8 @@ public:
 	static bool OI_Battlefield2(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
 	static bool OI_HauntingGround(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
 
+	static bool MV_Growlanser(GSRendererHW& r);
+
 	template <typename F>
 	struct Entry
 	{
@@ -66,4 +68,5 @@ public:
 
 	static const Entry<GSRendererHW::GSC_Ptr> s_get_skip_count_functions[];
 	static const Entry<GSRendererHW::OI_Ptr> s_before_draw_functions[];
+	static const Entry<GSRendererHW::MV_Ptr> s_move_handler_functions[];
 };

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -1219,6 +1219,12 @@ void GSRendererHW::InvalidateLocalMem(const GIFRegBITBLTBUF& BITBLTBUF, const GS
 
 void GSRendererHW::Move()
 {
+	if (m_mv && m_mv(*this))
+	{
+		// Handled by HW hack.
+		return;
+	}
+
 	const int sx = m_env.TRXPOS.SSAX;
 	const int sy = m_env.TRXPOS.SSAY;
 	const int dx = m_env.TRXPOS.DSAX;

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.h
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.h
@@ -41,6 +41,7 @@ private:
 
 	using GSC_Ptr = bool(*)(GSRendererHW& r, int& skip);	// GSC - Get Skip Count
 	using OI_Ptr = bool(*)(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t); // OI - Before draw
+	using MV_Ptr = bool(*)(GSRendererHW& r); // MV - Move
 
 	// Require special argument
 	bool OI_BlitFMV(GSTextureCache::Target* _rt, GSTextureCache::Source* t, const GSVector4i& r_draw);
@@ -142,6 +143,7 @@ private:
 	bool IsBadFrame();
 	GSC_Ptr m_gsc = nullptr;
 	OI_Ptr m_oi = nullptr;
+	MV_Ptr m_mv = nullptr;
 	int m_skip = 0;
 	int m_skip_offset = 0;
 

--- a/pcsx2/GameDatabase.h
+++ b/pcsx2/GameDatabase.h
@@ -96,6 +96,7 @@ namespace GameDatabaseSchema
 		RecommendedBlendingLevel,
 		GetSkipCount,
 		BeforeDraw,
+		MoveHandler,
 
 		Count
 	};

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -609,6 +609,7 @@ bool Pcsx2Config::GSOptions::OptionsAreEqual(const GSOptions& right) const
 		OpEqu(TVShader) &&
 		OpEqu(GetSkipCountFunctionId) &&
 		OpEqu(BeforeDrawFunctionId) &&
+		OpEqu(MoveHandlerFunctionId) &&
 		OpEqu(SkipDrawEnd) &&
 		OpEqu(SkipDrawStart) &&
 


### PR DESCRIPTION
### Description of Changes

And use it to fix Growlanser. (I'll also use this for Ico later on to avoid readbacks)

### Rationale behind Changes

Regression from #9171.

### Suggested Testing Steps

I only have one GS dump for the series, so I have no idea if this completely fixes the issue. I tried to make the hack fairly generic, so hopefully it'll work cross-region.

@Risae could you check some of these games, and if it's still broken, upload a GS dump please?
