### PR TITLE
GameDB: NFS U2 Name fix

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -32716,7 +32716,7 @@ SLPM-66050:
   name: "Daisan Teikoku Koubouki II - Aufstieg und Fall des Dritten Reich"
   region: "NTSC-J"
 SLPM-66051:
-  name: "Need for Speed Underground 2 [EA Best Hits]"
+  name: "Need for Speed Underground 2 - SHA_DO"
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves reflection quality and map opacity.


### PR DESCRIPTION
### Description of Changes
Quick fix for an incorrect name for NFS U2

### Rationale behind Changes
Incorrect name bad

### Suggested Testing Steps
CI good
