### PR TITLE
GS/HW: Calculate alpha min/max for sources and targets

### DIFF
--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -916,6 +916,62 @@ void GSFreeWrappedMemory(void* ptr, size_t size, size_t repeat)
 
 #endif
 
+std::pair<u8, u8> GSGetRGBA8AlphaMinMax(const void* data, u32 width, u32 height, u32 stride)
+{
+	GSVector4i minc = GSVector4i::xffffffff();
+	GSVector4i maxc = GSVector4i::zero();
+
+	const u8* ptr = static_cast<const u8*>(data);
+	if ((width % 4) == 0)
+	{
+		for (u32 r = 0; r < height; r++)
+		{
+			const u8* rptr = ptr;
+			for (u32 c = 0; c < width; c += 4)
+			{
+				const GSVector4i v = GSVector4i::load<true>(rptr);
+				rptr += sizeof(GSVector4i);
+				minc = minc.min_u32(v);
+				maxc = maxc.max_u32(v);
+			}
+
+			ptr += stride;
+		}
+	}
+	else
+	{
+		const u32 aligned_width = Common::AlignDownPow2(width, 4);
+		static constexpr const GSVector4i masks[3][2] = {
+			{GSVector4i::cxpr(0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0), GSVector4i::cxpr(0, 0, 0, 0xFFFFFFFF)},
+			{GSVector4i::cxpr(0xFFFFFFFF, 0xFFFFFFFF, 0, 0), GSVector4i::cxpr(0, 0, 0xFFFFFFFF, 0xFFFFFFFF)},
+			{GSVector4i::cxpr(0xFFFFFFFF, 0, 0, 0), GSVector4i::cxpr(0, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF)},
+		};
+		const GSVector4i last_mask_and = masks[(width & 3) - 1][0];
+		const GSVector4i last_mask_or = masks[(width & 3) - 1][1];
+
+		for (u32 r = 0; r < height; r++)
+		{
+			const u8* rptr = ptr;
+			for (u32 c = 0; c < aligned_width; c += 4)
+			{
+				const GSVector4i v = GSVector4i::load<true>(rptr);
+				rptr += sizeof(GSVector4i);
+				minc = minc.min_u32(v);
+				maxc = maxc.max_u32(v);
+			}
+
+			const GSVector4i v = GSVector4i::load<true>(rptr);
+			minc = minc.min_u32(v | last_mask_or);
+			maxc = maxc.max_u32(v & last_mask_and);
+
+			ptr += stride;
+		}
+	}
+
+	return std::make_pair<u8, u8>(static_cast<u8>(minc.minv_u32() >> 24),
+		static_cast<u8>(maxc.maxv_u32() >> 24));
+}
+
 static void HotkeyAdjustUpscaleMultiplier(s32 delta)
 {
 	const u32 new_multiplier = static_cast<u32>(std::clamp(static_cast<s32>(EmuConfig.GS.UpscaleMultiplier) + delta, 1, 8));

--- a/pcsx2/GS/GSExtra.h
+++ b/pcsx2/GS/GSExtra.h
@@ -19,6 +19,8 @@
 #include "pcsx2/Config.h"
 #include "common/Align.h"
 
+#include <utility>
+
 /// Like `memcmp(&a, &b, sizeof(T)) == 0` but faster
 template <typename T>
 __forceinline bool BitEqual(const T& a, const T& b)
@@ -128,6 +130,9 @@ __fi static T VectorAlign(T value)
 {
 	return Common::AlignUpPow2(value, VECTOR_ALIGNMENT);
 }
+
+/// Returns the maximum alpha value across a range of data. Assumes stride is 16 byte aligned.
+std::pair<u8, u8> GSGetRGBA8AlphaMinMax(const void* data, u32 width, u32 height, u32 stride);
 
 // clang-format off
 

--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -3667,12 +3667,13 @@ GSState::TextureMinMaxResult GSState::GetTextureMinMax(GIFRegTEX0 TEX0, GIFRegCL
 	return { vr, uses_border };
 }
 
-void GSState::CalcAlphaMinMax()
+void GSState::CalcAlphaMinMax(const int tex_alpha_min, const int tex_alpha_max)
 {
-	if (m_vt.m_alpha.valid)
+	if (m_vt.m_alpha.valid && tex_alpha_min == 0 && tex_alpha_max == 255)
 		return;
 
-	int min = 0, max = 0;
+	// We wanted to force an update as we now know the alpha of the non-indexed texture.
+	int min = tex_alpha_min, max = tex_alpha_max;
 
 	if (IsCoverageAlpha())
 	{
@@ -3690,8 +3691,8 @@ void GSState::CalcAlphaMinMax()
 			switch (GSLocalMemory::m_psm[context->TEX0.PSM].fmt)
 			{
 				case 0:
-					a.y = 0;
-					a.w = 0xff;
+					a.y = min;
+					a.w = max;
 					break;
 				case 1:
 					a.y = env.TEXA.AEM ? 0 : env.TEXA.TA0;

--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -135,9 +135,6 @@ private:
 
 	} m_tr;
 
-private:
-	void CalcAlphaMinMax();
-
 protected:
 	GSVertex m_v = {};
 	float m_q = 1.0f;
@@ -180,7 +177,7 @@ protected:
 	GSVertexTrace::VertexAlpha& GetAlphaMinMax()
 	{
 		if (!m_vt.m_alpha.valid)
-			CalcAlphaMinMax();
+			CalcAlphaMinMax(0, 255);
 		return m_vt.m_alpha;
 	}
 	struct TextureMinMaxResult
@@ -203,6 +200,7 @@ protected:
 	bool IsMipMapDraw();
 	bool IsMipMapActive();
 	bool IsCoverageAlpha();
+	void CalcAlphaMinMax(const int tex_min, const int tex_max);
 
 public:
 	struct GSUploadQueue

--- a/pcsx2/GS/GSVector4i.h
+++ b/pcsx2/GS/GSVector4i.h
@@ -394,6 +394,30 @@ public:
 		return GSVector4i(_mm_max_epu32(m, a));
 	}
 
+	__forceinline u32 minv_s32() const
+	{
+		const __m128i vmin = _mm_min_epi32(m, _mm_shuffle_epi32(m, _MM_SHUFFLE(3, 2, 3, 2)));
+		return std::min<s32>(_mm_extract_epi32(vmin, 0), _mm_extract_epi32(vmin, 1));
+	}
+
+	__forceinline u32 minv_u32() const
+	{
+		const __m128i vmin = _mm_min_epu32(m, _mm_shuffle_epi32(m, _MM_SHUFFLE(3, 2, 3, 2)));
+		return std::min<u32>(_mm_extract_epi32(vmin, 0), _mm_extract_epi32(vmin, 1));
+	}
+
+	__forceinline u32 maxv_s32() const
+	{
+		const __m128i vmax = _mm_max_epi32(m, _mm_shuffle_epi32(m, _MM_SHUFFLE(3, 2, 3, 2)));
+		return std::max<s32>(_mm_extract_epi32(vmax, 0), _mm_extract_epi32(vmax, 1));
+	}
+
+	__forceinline u32 maxv_u32() const
+	{
+		const __m128i vmax = _mm_max_epu32(m, _mm_shuffle_epi32(m, _MM_SHUFFLE(3, 2, 3, 2)));
+		return std::max<u32>(_mm_extract_epi32(vmax, 0), _mm_extract_epi32(vmax, 1));
+	}
+
 	__forceinline static int min_i16(int a, int b)
 	{
 		return store(load(a).min_i16(load(b)));

--- a/pcsx2/GS/Renderers/HW/GSHwHack.cpp
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.cpp
@@ -845,6 +845,8 @@ bool GSHwHack::OI_RozenMaidenGebetGarden(GSRendererHW& r, GSTexture* rt, GSTextu
 			{
 				GL_INS("OI_RozenMaidenGebetGarden FB clear");
 				g_gs_device->ClearRenderTarget(tmp_rt->m_texture, 0);
+				tmp_rt->m_alpha_max = 0;
+				tmp_rt->m_alpha_min = 0;
 			}
 
 			return false;

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -2088,8 +2088,8 @@ void GSRendererHW::Draw()
 			return;
 		}
 
-		if (src->m_target)
-			CalcAlphaMinMax(src->m_from_target->m_alpha_min, src->m_from_target->m_alpha_max);
+		if(GSLocalMemory::m_psm[src->m_TEX0.PSM].pal == 0)
+			CalcAlphaMinMax(src->m_alpha_minmax.first, src->m_alpha_minmax.second);
 	}
 
 	// Estimate size based on the scissor rectangle and height cache.

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -2087,6 +2087,9 @@ void GSRendererHW::Draw()
 			cleanup_cancelled_draw();
 			return;
 		}
+
+		if (src->m_target)
+			CalcAlphaMinMax(src->m_from_target->m_alpha_min, src->m_from_target->m_alpha_max);
 	}
 
 	// Estimate size based on the scissor rectangle and height cache.
@@ -4676,6 +4679,52 @@ __ri void GSRendererHW::DrawPrims(GSTextureCache::Target* rt, GSTextureCache::Ta
 	}
 
 	// Blend
+	if (rt)
+	{
+		if (!m_channel_shuffle && !m_texture_shuffle)
+		{
+			const int fba_value = m_prev_env.CTXT[m_prev_env.PRIM.CTXT].FBA.FBA * 128;
+			if ((m_cached_ctx.FRAME.FBMSK & 0xff000000) == 0)
+			{
+				if (rt->m_valid.rintersect(m_r).eq(rt->m_valid) && PrimitiveCoversWithoutGaps() && !(m_cached_ctx.TEST.DATE || m_cached_ctx.TEST.ATE || m_cached_ctx.TEST.ZTST != ZTST_ALWAYS))
+				{
+					rt->m_alpha_max = GetAlphaMinMax().max | fba_value;
+					rt->m_alpha_min = GetAlphaMinMax().min | fba_value;
+				}
+				else
+				{
+					rt->m_alpha_max = std::max(GetAlphaMinMax().max | fba_value, rt->m_alpha_max);
+					rt->m_alpha_min = std::min(GetAlphaMinMax().min | fba_value, rt->m_alpha_min);
+				}
+			}
+			else if ((m_cached_ctx.FRAME.FBMSK & 0xff000000) != 0xff000000) // We can't be sure of the alpha if it's partially masked.
+			{
+				rt->m_alpha_max |= std::max(GetAlphaMinMax().max | fba_value, rt->m_alpha_max);
+				rt->m_alpha_min = std::min(GetAlphaMinMax().min | fba_value, rt->m_alpha_min);
+			}
+			else
+			{
+				// If both are zero then we probably don't know what the alpha is.
+				if (rt->m_alpha_max == 0 && rt->m_alpha_min == 0)
+				{
+					rt->m_alpha_max = 255;
+					rt->m_alpha_min = 0;
+				}
+			}
+		}
+		else if ((m_texture_shuffle && m_conf.ps.write_rg == false) || m_channel_shuffle)
+		{
+			rt->m_alpha_max = 255;
+			rt->m_alpha_min = 0;
+		}
+	}
+
+	// Not gonna spend too much time with this, it's not likely to be used much, can't be less accurate than it was.
+	if (ds)
+	{
+		ds->m_alpha_max = std::max(ds->m_alpha_max, static_cast<int>(m_vt.m_max.p.z) >> 24);
+		ds->m_alpha_min = std::min(ds->m_alpha_min, static_cast<int>(m_vt.m_min.p.z) >> 24);
+	}
 
 	bool blending_alpha_pass = false;
 	if ((!IsOpaque() || m_context->ALPHA.IsBlack()) && rt && (m_conf.colormask.wrgba & 0x7))
@@ -5432,6 +5481,8 @@ bool GSRendererHW::TryTargetClear(GSTextureCache::Target* rt, GSTextureCache::Ta
 			const u32 c = GetConstantDirectWriteMemClearColor();
 			GL_INS("TryTargetClear(): RT at %x <= %08X", rt->m_TEX0.TBP0, c);
 			g_gs_device->ClearRenderTarget(rt->m_texture, c);
+			rt->m_alpha_max = c >> 24;
+			rt->m_alpha_min = c >> 24;
 		}
 		else
 		{
@@ -5448,6 +5499,8 @@ bool GSRendererHW::TryTargetClear(GSTextureCache::Target* rt, GSTextureCache::Ta
 			const float d = static_cast<float>(z) * (g_gs_device->Features().clip_control ? 0x1p-32f : 0x1p-24f);
 			GL_INS("TryTargetClear(): DS at %x <= %f", ds->m_TEX0.TBP0, d);
 			g_gs_device->ClearDepth(ds->m_texture, d);
+			ds->m_alpha_max = z >> 24;
+			ds->m_alpha_min = z >> 24;
 		}
 		else
 		{

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -4610,7 +4610,7 @@ __ri void GSRendererHW::DrawPrims(GSTextureCache::Target* rt, GSTextureCache::Ta
 			GL_PERF("DATE: Fast with FBA, all pixels will be >= 128");
 			DATE_one = !m_cached_ctx.TEST.DATM;
 		}
-		else if (m_conf.colormask.wa && !m_cached_ctx.TEST.ATE)
+		else if (m_conf.colormask.wa && !m_cached_ctx.TEST.ATE && !(m_cached_ctx.FRAME.FBMSK & 0x80000000))
 		{
 			// Performance note: check alpha range with GetAlphaMinMax()
 			// Note: all my dump are already above 120fps, but it seems to reduce GPU load

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -3363,6 +3363,8 @@ GSTextureCache::Source* GSTextureCache::CreateSource(const GIFRegTEX0& TEX0, con
 		src->m_target = true;
 		src->m_from_target = dst;
 		src->m_from_target_TEX0 = dst->m_TEX0;
+		src->m_alpha_minmax.first = dst->m_alpha_min;
+		src->m_alpha_minmax.second = dst->m_alpha_max;
 
 		if (psm.pal > 0)
 		{
@@ -3403,6 +3405,8 @@ GSTextureCache::Source* GSTextureCache::CreateSource(const GIFRegTEX0& TEX0, con
 		src->m_from_target_TEX0 = dst->m_TEX0;
 		src->m_valid_rect = dst->m_valid;
 		src->m_end_block = dst->m_end_block;
+		src->m_alpha_minmax.first = dst->m_alpha_min;
+		src->m_alpha_minmax.second = dst->m_alpha_max;
 
 		dst->Update();
 
@@ -3614,6 +3618,8 @@ GSTextureCache::Source* GSTextureCache::CreateSource(const GIFRegTEX0& TEX0, con
 		if ((src->m_from_hash_cache = LookupHashCache(TEX0, TEXA, paltex, clut, lod, region)) != nullptr)
 		{
 			src->m_texture = src->m_from_hash_cache->texture;
+			src->m_alpha_minmax = src->m_from_hash_cache->alpha_minmax;
+
 			if (gpu_clut)
 				AttachPaletteToSource(src, gpu_clut);
 			else if (psm.pal > 0)
@@ -4000,12 +4006,14 @@ GSTextureCache::HashCacheEntry* GSTextureCache::LookupHashCache(const GIFRegTEX0
 	if (replace)
 	{
 		bool replacement_texture_pending = false;
-		GSTexture* replacement_tex = GSTextureReplacements::LookupReplacementTexture(key, lod != nullptr, &replacement_texture_pending);
+		std::pair<u8, u8> alpha_minmax;
+		GSTexture* replacement_tex = GSTextureReplacements::LookupReplacementTexture(key, lod != nullptr,
+			&replacement_texture_pending, &alpha_minmax);
 		if (replacement_tex)
 		{
 			// found a replacement texture! insert it into the hash cache, and clear paltex (since it's not indexed)
 			paltex = false;
-			const HashCacheEntry entry{ replacement_tex, 1u, 0u, true };
+			const HashCacheEntry entry{ replacement_tex, 1u, 0u, alpha_minmax, true };
 			m_hash_cache_replacement_memory_usage += entry.texture->GetMemUsage();
 			return &m_hash_cache.emplace(key, entry).first->second;
 		}
@@ -4057,7 +4065,9 @@ GSTextureCache::HashCacheEntry* GSTextureCache::LookupHashCache(const GIFRegTEX0
 	}
 
 	// upload base level
-	PreloadTexture(TEX0, TEXA, region, g_gs_renderer->m_mem, paltex, tex, 0);
+	const bool is_direct = (GSLocalMemory::m_psm[TEX0.PSM].pal == 0);
+	std::pair<u8, u8> alpha_minmax = {0u, 255u};
+	PreloadTexture(TEX0, TEXA, region, g_gs_renderer->m_mem, paltex, tex, 0, is_direct ? &alpha_minmax : nullptr);
 
 	// upload mips if present
 	if (lod)
@@ -4066,8 +4076,15 @@ GSTextureCache::HashCacheEntry* GSTextureCache::LookupHashCache(const GIFRegTEX0
 		const int nmips = lod->y - lod->x + 1;
 		for (int mip = 1; mip < nmips; mip++)
 		{
-			const GIFRegTEX0 MIP_TEX0{ g_gs_renderer->GetTex0Layer(basemip + mip) };
-			PreloadTexture(MIP_TEX0, TEXA, region.AdjustForMipmap(mip), g_gs_renderer->m_mem, paltex, tex, mip);
+			const GIFRegTEX0 MIP_TEX0{g_gs_renderer->GetTex0Layer(basemip + mip)};
+			std::pair<u8, u8> mip_alpha_minmax;
+			PreloadTexture(MIP_TEX0, TEXA, region.AdjustForMipmap(mip), g_gs_renderer->m_mem, paltex, tex, mip,
+				is_direct ? &mip_alpha_minmax : nullptr);
+			if (!is_direct)
+			{
+				alpha_minmax.first = std::min(alpha_minmax.first, mip_alpha_minmax.first);
+				alpha_minmax.second = std::max(alpha_minmax.second, mip_alpha_minmax.second);
+			}
 		}
 	}
 
@@ -4076,7 +4093,7 @@ GSTextureCache::HashCacheEntry* GSTextureCache::LookupHashCache(const GIFRegTEX0
 		key.RemoveCLUTHash();
 
 	// insert into the cache cache, and we're done
-	const HashCacheEntry entry{ tex, 1u, 0u, false };
+	const HashCacheEntry entry{tex, 1u, 0u, alpha_minmax, false};
 	m_hash_cache_memory_usage += tex->GetMemUsage();
 	return &m_hash_cache.emplace(key, entry).first->second;
 }
@@ -4465,6 +4482,11 @@ GSTextureCache::Source::~Source()
 	}
 }
 
+bool GSTextureCache::Source::IsPaletteFormat() const
+{
+	return (GSLocalMemory::m_psm[m_TEX0.PSM].pal > 0);
+}
+
 void GSTextureCache::Source::SetPages()
 {
 	const int tw = 1 << m_TEX0.TW;
@@ -4721,7 +4743,19 @@ void GSTextureCache::Source::PreloadLevel(int level)
 	m_layer_hash[level] = hash;
 
 	// And upload the texture.
-	PreloadTexture(m_TEX0, m_TEXA, m_region.AdjustForMipmap(level), g_gs_renderer->m_mem, m_palette != nullptr, m_texture, level);
+	if (IsPaletteFormat())
+	{
+		PreloadTexture(m_TEX0, m_TEXA, m_region.AdjustForMipmap(level), g_gs_renderer->m_mem, m_palette != nullptr,
+			m_texture, level, nullptr);
+	}
+	else
+	{
+		std::pair<u8, u8> mip_alpha_minmax;
+		PreloadTexture(m_TEX0, m_TEXA, m_region.AdjustForMipmap(level), g_gs_renderer->m_mem, m_palette != nullptr,
+			m_texture, level, &mip_alpha_minmax);
+		m_alpha_minmax.first = std::min(m_alpha_minmax.first, mip_alpha_minmax.first);
+		m_alpha_minmax.second = std::min(m_alpha_minmax.second, mip_alpha_minmax.second);
+	}
 }
 
 bool GSTextureCache::Source::ClutMatch(const PaletteKey& palette_key)
@@ -5083,12 +5117,17 @@ void GSTextureCache::AttachPaletteToSource(Source* s, u16 pal, bool need_gs_text
 {
 	s->m_palette_obj = m_palette_map.LookupPalette(pal, need_gs_texture);
 	s->m_palette = need_gs_texture ? s->m_palette_obj->GetPaletteGSTexture() : nullptr;
+	s->m_alpha_minmax = s->m_palette_obj->GetAlphaMinMax();
 }
 
 void GSTextureCache::AttachPaletteToSource(Source* s, GSTexture* gpu_clut)
 {
 	s->m_palette_obj = nullptr;
 	s->m_palette = gpu_clut;
+
+	// Unknown.
+	s->m_alpha_minmax.first = 0;
+	s->m_alpha_minmax.second = 255;
 }
 
 GSTextureCache::SurfaceOffset GSTextureCache::ComputeSurfaceOffset(const GSOffset& off, const GSVector4i& r, const Target* t)
@@ -5286,7 +5325,7 @@ void GSTextureCache::InvalidateTemporarySource()
 	m_temporary_source = nullptr;
 }
 
-void GSTextureCache::InjectHashCacheTexture(const HashCacheKey& key, GSTexture* tex)
+void GSTextureCache::InjectHashCacheTexture(const HashCacheKey& key, GSTexture* tex, const std::pair<u8, u8>& alpha_minmax)
 {
 	// When we insert we update memory usage. Old texture gets removed below.
 	m_hash_cache_replacement_memory_usage += tex->GetMemUsage();
@@ -5296,13 +5335,14 @@ void GSTextureCache::InjectHashCacheTexture(const HashCacheKey& key, GSTexture* 
 	{
 		// We must've got evicted before we finished loading. No matter, add it in there anyway;
 		// if it's not used again, it'll get tossed out later.
-		const HashCacheEntry entry{tex, 1u, 0u, true};
+		const HashCacheEntry entry{tex, 1u, 0u, alpha_minmax, true};
 		m_hash_cache.emplace(key, entry);
 		return;
 	}
 
 	// Reset age so we don't get thrown out too early.
 	it->second.age = 0;
+	it->second.alpha_minmax = alpha_minmax;
 
 	// Update memory usage, swap the textures, and recycle the old one for reuse.
 	if (!it->second.is_replacement)
@@ -5328,6 +5368,8 @@ GSTextureCache::Palette::Palette(u16 pal, bool need_gs_texture)
 	{
 		InitializeTexture();
 	}
+
+	m_alpha_minmax = GSGetRGBA8AlphaMinMax(m_clut, pal, 1, 0);
 }
 
 GSTextureCache::Palette::~Palette()
@@ -5718,7 +5760,8 @@ GSTextureCache::HashType GSTextureCache::HashTexture(const GIFRegTEX0& TEX0, con
 	return FinishBlockHash(hash_st);
 }
 
-void GSTextureCache::PreloadTexture(const GIFRegTEX0& TEX0, const GIFRegTEXA& TEXA, SourceRegion region, GSLocalMemory& mem, bool paltex, GSTexture* tex, u32 level)
+void GSTextureCache::PreloadTexture(const GIFRegTEX0& TEX0, const GIFRegTEXA& TEXA, SourceRegion region, GSLocalMemory& mem,
+	bool paltex, GSTexture* tex, u32 level, std::pair<u8, u8>* alpha_minmax)
 {
 	// m_TEX0 is adjusted for mips (messy, should be changed).
 	const GSLocalMemory::psm_t& psm = GSLocalMemory::m_psm[TEX0.PSM];
@@ -5742,7 +5785,7 @@ void GSTextureCache::PreloadTexture(const GIFRegTEX0& TEX0, const GIFRegTEXA& TE
 	// If we can stream it directly to GPU memory, do so, otherwise go through a temp buffer.
 	const GSVector4i unoffset_rect(0, 0, tw, th);
 	GSTexture::GSMap map;
-	if (rect.eq(block_rect) && tex->Map(map, &unoffset_rect, level))
+	if (rect.eq(block_rect) && !alpha_minmax && tex->Map(map, &unoffset_rect, level))
 	{
 		rtx(mem, off, block_rect, map.bits, map.pitch, TEXA);
 		tex->Unmap();
@@ -5756,6 +5799,11 @@ void GSTextureCache::PreloadTexture(const GIFRegTEX0& TEX0, const GIFRegTEXA& TE
 
 		const u8* ptr = buff + (pitch * static_cast<u32>(rect.top - block_rect.top)) +
 						(static_cast<u32>(rect.left - block_rect.left) << (paltex ? 0 : 2));
+		if (alpha_minmax)
+		{
+			pxAssert(GSLocalMemory::m_psm[TEX0.PSM].pal == 0);
+			*alpha_minmax = GSGetRGBA8AlphaMinMax(buff, unoffset_rect.width(), unoffset_rect.height(), pitch);
+		}
 		tex->Update(unoffset_rect, ptr, pitch, level);
 	}
 }

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.h
@@ -212,6 +212,8 @@ public:
 	{
 	public:
 		const int m_type = 0;
+		int m_alpha_max = 0;
+		int m_alpha_min = 0;
 
 		// Valid alpha means "we have rendered to the alpha channel of this target".
 		// A false value means that the alpha in local memory is still valid/up-to-date.

--- a/pcsx2/GS/Renderers/HW/GSTextureReplacements.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureReplacements.h
@@ -17,6 +17,8 @@
 
 #include "GS/Renderers/HW/GSTextureCache.h"
 
+#include <utility>
+
 namespace GSTextureReplacements
 {
 	struct ReplacementTexture
@@ -24,6 +26,7 @@ namespace GSTextureReplacements
 		u32 width;
 		u32 height;
 		GSTexture::Format format;
+		std::pair<u8, u8> alpha_minmax;
 
 		u32 pitch;
 		std::vector<u8> data;
@@ -48,7 +51,7 @@ namespace GSTextureReplacements
 
 	bool HasAnyReplacementTextures();
 	bool HasReplacementTextureWithOtherPalette(const GSTextureCache::HashCacheKey& hash);
-	GSTexture* LookupReplacementTexture(const GSTextureCache::HashCacheKey& hash, bool mipmap, bool* pending);
+	GSTexture* LookupReplacementTexture(const GSTextureCache::HashCacheKey& hash, bool mipmap, bool* pending, std::pair<u8, u8>* alpha_minmax);
 	GSTexture* CreateReplacementTexture(const ReplacementTexture& rtex, bool mipmap);
 	void ProcessAsyncLoadedTextures();
 


### PR DESCRIPTION
### Description of Changes
Calculate and remember the alpha values of RT's when drawing.
Also fix a bug in DATE where it was using the optimised shortcut (incorrectly) even if the Alpha to 1.0 (0x80) was masked.

Added stenzek's changes to also calculate the alpha values for sources.

### Rationale behind Changes
RT's can be unpacked from indexed textures, where we do know the alpha, then read as C32 normal images, where we don't normally know the alpha. Doing this means we can't usually know the alpha in advance, meaning we miss out on potential blending optimisations and using hardware blending.

Also DATE_one is an optimisation to say if the data being written is above/below the threshold for DATE, then all pixels after the first pass will fail. This was wrong when the alpha at 1.0 (0x80) isn't written, so it now checks for the FBMASK and chooses the slower route.

### Suggested Testing Steps
Test games, some might perform faster if GPU limited, not sure if it will be noticeable or not.  Did a dump run, there were some minor differences in games like GT4, Jak 3, Midnight Club 3, Beyond Good and Evil, one of the .Hack games, due to basic blending and HW blending Vs SW blending, but we're talking off by 1 differences on a single colour channel (might be an Nvidia only problem). There was however one proper fix, as noted below.

Fixes The Sims 2 - Pets text in the text boxes

Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/9e15f1c5-7ff8-4b6c-ad85-31616c13e9ea)

PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/701d7741-617f-4f53-aafb-740d54bc7691)
