### PR TITLE
CI: Remove redundant GUI variables

### DIFF
--- a/.github/workflows/linux_build_flatpak.yml
+++ b/.github/workflows/linux_build_flatpak.yml
@@ -28,10 +28,6 @@ on:
         required: false
         type: boolean
         default: false
-      detail:
-        required: false
-        type: string
-        default: ""
       patches_url:
         required: false
         type: string
@@ -61,7 +57,6 @@ jobs:
         shell: bash
         env:
           OS: linux
-          GUI_FRAMEWORK: QT
           BUILD_SYSTEM: flatpak
           ARCH: ${{ inputs.platform }}
           EVENT_NAME: ${{ github.event_name }}
@@ -98,7 +93,7 @@ jobs:
           branch: ${{ inputs.branch }}
           cache: true
           restore-cache: true
-          cache-key: ${{ inputs.os }} ${{ inputs.platform }} ${{ inputs.compiler }} ${{ inputs.detail }} flatpak ${{ hashFiles('.github/workflows/scripts/linux/flatpak/**/*.json') }}
+          cache-key: ${{ inputs.os }} ${{ inputs.platform }} ${{ inputs.compiler }} flatpak ${{ hashFiles('.github/workflows/scripts/linux/flatpak/**/*.json') }}
 
       - name: Commit screenshots to OSTree
         run: |

--- a/.github/workflows/linux_build_matrix.yml
+++ b/.github/workflows/linux_build_matrix.yml
@@ -14,7 +14,7 @@ jobs:
     if: github.repository != 'PCSX2/pcsx2' || github.event_name == 'pull_request'
     uses: ./.github/workflows/linux_build_qt.yml
     with:
-      jobName: "Qt"
+      jobName: "AppImage Build"
       compiler: clang
       cmakeflags: ""
       buildAppImage: true
@@ -24,7 +24,7 @@ jobs:
     if: github.repository != 'PCSX2/pcsx2' || github.event_name == 'pull_request'
     uses: ./.github/workflows/linux_build_flatpak.yml
     with:
-      jobName: "Qt"
+      jobName: "Flatpak Build"
       compiler: clang
       cmakeflags: ""
       publish: false

--- a/.github/workflows/linux_build_qt.yml
+++ b/.github/workflows/linux_build_qt.yml
@@ -57,7 +57,6 @@ jobs:
         shell: bash
         env:
           OS: linux
-          GUI_FRAMEWORK: QT
           ARCH: ${{ inputs.platform }}
           EVENT_NAME: ${{ github.event_name }}
           PR_TITLE: ${{ github.event.pull_request.title }}
@@ -87,7 +86,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/deps
-          key: ${{ inputs.os }} ${{ inputs.platform }} ${{ inputs.gui }} deps ${{ hashFiles('.github/workflows/scripts/linux/build-dependencies-qt.sh') }}
+          key: ${{ inputs.os }} ${{ inputs.platform }} deps ${{ hashFiles('.github/workflows/scripts/linux/build-dependencies-qt.sh') }}
 
       - name: Build Dependencies
         if: steps.cache-deps.outputs.cache-hit != 'true'

--- a/.github/workflows/macos_build.yml
+++ b/.github/workflows/macos_build.yml
@@ -10,13 +10,6 @@ on:
         required: false
         type: string
         default: macos-13
-      platform:
-        required: false
-        type: string
-        default: x64
-      gui:
-        required: true
-        type: string
       patches_url:
         required: false
         type: string
@@ -50,8 +43,6 @@ jobs:
         shell: bash
         env:
           OS: macos
-          GUI_FRAMEWORK: ${{ inputs.gui }}
-          ARCH: ${{ inputs.platform }}
           EVENT_NAME: ${{ github.event_name }}
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_NUM: ${{ github.event.pull_request.number }}
@@ -60,7 +51,7 @@ jobs:
 
       - name: Install Packages
         env:
-          PLATFORM: ${{ inputs.platform }}
+          PLATFORM: "x64"
           HOMEBREW_NO_INSTALL_CLEANUP: 1
           HOMEBREW_NO_ANALYTICS: 1
         run: |
@@ -77,12 +68,10 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/deps
-          key: ${{ inputs.os }} ${{ inputs.platform }} ${{ inputs.gui }} deps ${{ hashFiles('.github/workflows/scripts/macos/build-dependencies.sh') }}
+          key: ${{ inputs.os }} deps ${{ hashFiles('.github/workflows/scripts/macos/build-dependencies.sh') }}
 
       - name: Build Dependencies
         if: steps.cache-deps.outputs.cache-hit != 'true'
-        env:
-          GUI: ${{ inputs.gui }}
         run: .github/workflows/scripts/macos/build-dependencies.sh
 
       - name: Download patches
@@ -99,8 +88,8 @@ jobs:
         uses: actions/cache@v3
         with:
           path: .ccache
-          key: ${{ inputs.os }} ${{ inputs.platform }} ${{ inputs.gui }} ccache ${{ steps.ccache_cache_timestamp.outputs.timestamp }}
-          restore-keys: ${{ inputs.os }} ${{ inputs.platform }} ${{ inputs.gui }} ccache
+          key: ${{ inputs.os }} ccache ${{ steps.ccache_cache_timestamp.outputs.timestamp }}
+          restore-keys: ${{ inputs.os }} ccache
 
       - name: Generate CMake Files
         run: |
@@ -133,7 +122,6 @@ jobs:
           done
 
       - name: Run Tests
-        if: inputs.gui == 'Qt'
         working-directory: build
         run: make -j$(getconf _NPROCESSORS_ONLN) unittests
 
@@ -149,7 +137,7 @@ jobs:
           mv build/pcsx2*/PCSX2.app "$APPNAME.app"
           tar --options xz:compression-level=9 -cvJf "${{ steps.artifact-metadata.outputs.artifact-name }}.tar.xz" "$APPNAME.app"
           mkdir ci-artifacts
-          cp "${{ steps.artifact-metadata.outputs.artifact-name }}.tar.xz" ci-artifacts/macOS-${{ inputs.gui }}.tar.xz
+          cp "${{ steps.artifact-metadata.outputs.artifact-name }}.tar.xz" ci-artifacts/macOS.tar.xz
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/macos_build_matrix.yml
+++ b/.github/workflows/macos_build_matrix.yml
@@ -14,6 +14,5 @@ jobs:
     if: github.repository != 'PCSX2/pcsx2' || github.event_name == 'pull_request'
     uses: ./.github/workflows/macos_build.yml
     with:
-      jobName: "Qt"
-      gui: "Qt"
+      jobName: "MacOS Build"
     secrets: inherit

--- a/.github/workflows/release_pipeline.yml
+++ b/.github/workflows/release_pipeline.yml
@@ -13,7 +13,7 @@ jobs:
     name: "Linux"
     uses: ./.github/workflows/linux_build_qt.yml
     with:
-      jobName: "Qt"
+      jobName: "AppImage Build"
       compiler: clang
       cmakeflags: ""
       buildAppImage: true
@@ -23,7 +23,7 @@ jobs:
     name: "Linux"
     uses: ./.github/workflows/linux_build_flatpak.yml
     with:
-      jobName: "Flatpak"
+      jobName: "Flatpak Build"
       compiler: clang
       cmakeflags: ""
       branch: "stable"
@@ -36,7 +36,7 @@ jobs:
     name: "Windows"
     uses: ./.github/workflows/windows_build_qt.yml
     with:
-      jobName: Qt
+      jobName: "Windows Build"
       configuration: CMake
       buildSystem: cmake
       cmakeFlags: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl
@@ -48,8 +48,7 @@ jobs:
     name: "MacOS"
     uses: ./.github/workflows/macos_build.yml
     with:
-      jobName: "Qt"
-      gui: "Qt"
+      jobName: "MacOS Build"
     secrets: inherit
 
   # Upload the Artifacts

--- a/.github/workflows/scripts/common/name-artifacts.sh
+++ b/.github/workflows/scripts/common/name-artifacts.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Artifact Naming Scheme:
-# PCSX2-<OS>-<GUI>-[ARCH]-[SIMD]-[pr\[PR_NUM\]]-[title|sha\[SHA|PR_TITLE\]
+# PCSX2-<OS>-[ARCH]-[SIMD]-[pr\[PR_NUM\]]-[title|sha\[SHA|PR_TITLE\]
 # -- limited to 200 chars
 # Outputs:
 # - artifact-name
@@ -9,7 +9,6 @@
 # Inputs as env-vars
 # OS
 # BUILD_SYSTEM
-# GUI_FRAMEWORK
 # ARCH
 # SIMD
 # EVENT_NAME
@@ -20,11 +19,12 @@
 NAME=""
 
 if [ "${OS}" == "macos" ]; then
-  NAME="PCSX2-${OS}-${GUI_FRAMEWORK}"
+  # MacOS has combined binaries for x64 and ARM64.
+  NAME="PCSX2-${OS}"
 elif [[ ("${OS}" == "windows" && "$BUILD_SYSTEM" != "cmake") ]]; then
-  NAME="PCSX2-${OS}-${GUI_FRAMEWORK}-${ARCH}-${SIMD}"
+  NAME="PCSX2-${OS}-${ARCH}-${SIMD}"
 else
-  NAME="PCSX2-${OS}-${GUI_FRAMEWORK}-${ARCH}"
+  NAME="PCSX2-${OS}-${ARCH}"
 fi
 
 # Add cmake if used to differentate it from msbuild builds

--- a/.github/workflows/scripts/releases/rename-release-assets.py
+++ b/.github/workflows/scripts/releases/rename-release-assets.py
@@ -13,11 +13,11 @@ for dir_name in os.listdir(scan_dir):
     asset_name += "-macos"
   elif "linux" in dir_name.lower():
     if "flatpak" in dir_name.lower():
-      asset_name += "-linux-Flatpak-64bit"
+      asset_name += "-linux-flatpak-x64"
     else:
-      asset_name += "-linux-AppImage-64bit"
+      asset_name += "-linux-appimage-x64"
   elif "windows" in dir_name.lower():
-    asset_name += "-windows-64bit"
+    asset_name += "-windows-x64"
   else:
     continue;
 
@@ -25,8 +25,6 @@ for dir_name in os.listdir(scan_dir):
     asset_name += "-AVX2"
   elif "sse4" in dir_name.lower():
     asset_name += "-SSE4"
-
-  asset_name += "-Qt"
 
   if "symbols" in dir_name.lower():
     asset_name += "-symbols"

--- a/.github/workflows/windows_build_matrix.yml
+++ b/.github/workflows/windows_build_matrix.yml
@@ -26,7 +26,7 @@ jobs:
     if: github.repository != 'PCSX2/pcsx2' || github.event_name == 'pull_request'
     uses: ./.github/workflows/windows_build_qt.yml
     with:
-      jobName: Qt
+      jobName: "MSVC SSE4"
       configuration: Release
       simd: "SSE4"
     secrets: inherit
@@ -37,7 +37,7 @@ jobs:
     if: github.repository != 'PCSX2/pcsx2' || github.event_name == 'pull_request'
     uses: ./.github/workflows/windows_build_qt.yml
     with:
-      jobName: Qt
+      jobName: "MSVC AVX2"
       configuration: Release AVX2
     secrets: inherit
 
@@ -46,7 +46,7 @@ jobs:
     if: github.repository != 'PCSX2/pcsx2' || github.event_name == 'pull_request'
     uses: ./.github/workflows/windows_build_qt.yml
     with:
-      jobName: Qt
+      jobName: "CMake MSVC"
       configuration: CMake
       buildSystem: cmake
     secrets: inherit
@@ -57,7 +57,7 @@ jobs:
     if: github.repository != 'PCSX2/pcsx2' || github.event_name == 'pull_request'
     uses: ./.github/workflows/windows_build_qt.yml
     with:
-      jobName: Qt Clang
+      jobName: "Clang SSE4"
       configuration: Release Clang
       simd: "SSE4"
     secrets: inherit
@@ -68,7 +68,7 @@ jobs:
     if: github.repository != 'PCSX2/pcsx2' || github.event_name == 'pull_request'
     uses: ./.github/workflows/windows_build_qt.yml
     with:
-      jobName: Qt Clang
+      jobName: "Clang AVX2"
       configuration: Release Clang AVX2
     secrets: inherit
 
@@ -77,7 +77,7 @@ jobs:
     if: github.repository != 'PCSX2/pcsx2' || github.event_name == 'pull_request'
     uses: ./.github/workflows/windows_build_qt.yml
     with:
-      jobName: Qt Clang
+      jobName: "CMake Clang"
       configuration: CMake
       buildSystem: cmake
       cmakeFlags: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DPCSX2_EXE_NAME=pcsx2-qt-clang

--- a/.github/workflows/windows_build_qt.yml
+++ b/.github/workflows/windows_build_qt.yml
@@ -63,7 +63,6 @@ jobs:
         env:
           OS: windows
           BUILD_SYSTEM: ${{ inputs.buildSystem }}
-          GUI_FRAMEWORK: Qt
           ARCH: ${{ inputs.platform }}
           SIMD: ${{ inputs.simd }}
           EVENT_NAME: ${{ github.event_name }}


### PR DESCRIPTION
### Description of Changes

And adjust release filenames.

### Rationale behind Changes

Consistency, and there's no need to put Qt in the filenames, Qt is our only option now.

Also hopefully will stop Linux builds from missing the cache every time.. there was a double space in the key, and GH seems to have changed something recently that strips them.

### Suggested Testing Steps

Make sure CI passes.
~~I'm also going to run the release pipeline on my fork to make sure that side works.~~ Seems fine
