### PR TITLE
Debugger Memory Search: add Array of byte type

### DIFF
--- a/pcsx2-qt/Debugger/CpuWidget.cpp
+++ b/pcsx2-qt/Debugger/CpuWidget.cpp
@@ -625,6 +625,8 @@ std::vector<u32> startWorker(DebugInterface* cpu, int type, u32 start, u32 end, 
 			return searchWorker<double>(cpu, start, end, value.toDouble());
 		case 6:
 			return searchWorkerString(cpu, start, end, value.toStdString());
+		case 7:
+			return searchWorkerString(cpu, start, end, QByteArray::fromHex(value.toUtf8()).toStdString());
 		default:
 			Console.Error("Debugger: Unknown type when doing memory search!");
 			break;
@@ -667,13 +669,24 @@ void CpuWidget::onSearchButtonClicked()
 
 	unsigned long long value;
 
-	if (searchType < 4)
+	switch (searchType)
 	{
-		value = searchValue.toULongLong(&ok, searchHex ? 16 : 10);
-	}
-	else if (searchType != 6)
-	{
-		searchValue.toDouble(&ok);
+		case 0:
+		case 1:
+		case 2:
+		case 3:
+			value = searchValue.toULongLong(&ok, searchHex ? 16 : 10);
+			break;
+		case 4:
+		case 5:
+			searchValue.toDouble(&ok);
+			break;
+		case 6:
+			ok = !searchValue.isEmpty();
+			break;
+		case 7:
+			ok = !searchValue.trimmed().isEmpty();
+			break;
 	}
 
 	if (!ok)
@@ -684,6 +697,7 @@ void CpuWidget::onSearchButtonClicked()
 
 	switch (searchType)
 	{
+		case 7:
 		case 6:
 		case 5:
 		case 4:

--- a/pcsx2-qt/Debugger/CpuWidget.ui
+++ b/pcsx2-qt/Debugger/CpuWidget.ui
@@ -231,6 +231,11 @@
                  <string>String</string>
                 </property>
                </item>
+               <item>
+                <property name="text">
+                 <string>Array of byte</string>
+                </property>
+               </item>
               </widget>
              </item>
              <item row="1" column="2">


### PR DESCRIPTION
### Description of Changes
Added `Array of byte` option to debugger memory search + validation for empty strings

### Rationale behind Changes
- `Array of byte` option was added to allow searching for byte sequences more easily, without bothering with endianness. For example, if you want to find a chunk of bytes from game's source files which is directly loaded into memory and stored there, you can just copy-paste, without using CheatEngine or whatever. CE is now also harder to use due to PS2 memory not having fixed addresses anymore. It should work both with delimiting spaces and without them
- As for validation, if you search for an empty string at the moment, it searches infinitely with memory usage skyrocketing instantly

### Suggested Testing Steps
I've done some regress testing for older options and edge-cases for new ones as well as normal scenarios, but nothing too extensive. I guess smoke-testing all the options should be enough