### PR TITLE
GameDB: NFS UG1 Blending

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -7544,6 +7544,7 @@ SCUS-97117:
   name: "PlayStation 2 Demo Disc Version 2.1 [Need for Speed - Underground]"
   region: "NTSC-U"
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves reflection quality.
     halfPixelOffset: 2 # Fixes misaligned post-processing.
 SCUS-97118:
   name: "NFL GameDay 2001 [Demo]"
@@ -9839,6 +9840,7 @@ SLED-51975:
   gameFixes:
     - EETimingHack # Fixes broken textures.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves reflection quality.
     halfPixelOffset: 2 # Fixes misaligned post-processing.
     PCRTCOverscan: 1 # Fixes image alignment.
 SLED-52014:
@@ -14686,6 +14688,7 @@ SLES-51967:
   gameFixes:
     - EETimingHack # Fixes broken textures.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves reflection quality.
     halfPixelOffset: 2 # Fixes misaligned post-processing.
     PCRTCOverscan: 1 # Fixes image alignment.
 SLES-51968:
@@ -24892,6 +24895,7 @@ SLKA-25136:
   gameFixes:
     - EETimingHack # Fixes broken textures.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves reflection quality.
     halfPixelOffset: 2 # Fixes misaligned post-processing.
 SLKA-25137:
   name: "Sims, The - Bustin' Out"
@@ -46379,6 +46383,7 @@ SLUS-20811:
   gameFixes:
     - EETimingHack # Broken textures.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves reflection quality.
     halfPixelOffset: 2 # Fixes misaligned post-processing.
 SLUS-20812:
   name: "Dynasty Warriors 4 - Extreme Edition"


### PR DESCRIPTION
### Description of Changes
Recommend **Blending Accuracy** set to **High** for **Need for Speed: Underground 1**

### Rationale behind Changes
Road/Sidewalk reflections look better
### Basic
![Need for Speed - Underground_SLUS-20811_20230709172245](https://github.com/PCSX2/pcsx2/assets/4414625/0940db79-6b6f-4a22-8cf5-101114c229fe)
### High
![Need for Speed - Underground_SLUS-20811_20230709172253](https://github.com/PCSX2/pcsx2/assets/4414625/9b638c25-fe28-4170-a4ac-a63f399be80c)

### Suggested Testing Steps
CI passes, game looks better!