### PR TITLE
OSD: Input recording overlap fixed

### DIFF
--- a/pcsx2/ImGui/ImGuiOverlays.cpp
+++ b/pcsx2/ImGui/ImGuiOverlays.cpp
@@ -620,7 +620,7 @@ void ImGuiManager::DrawInputRecordingOverlay(float& position_y)
 	const float shadow_offset = std::ceil(1.0f * scale);
 	const float margin = std::ceil(10.0f * scale);
 	const float spacing = std::ceil(5.0f * scale);
-	position_y = margin;
+	position_y += margin;
 
 	ImFont* const fixed_font = ImGuiManager::GetFixedFont();
 	ImFont* const standard_font = ImGuiManager::GetStandardFont();
@@ -665,7 +665,7 @@ void ImGuiManager::DrawInputRecordingOverlay(float& position_y)
 
 void ImGuiManager::RenderOverlays()
 {
-	float position_y;
+	float position_y = 0;
 	DrawInputRecordingOverlay(position_y);
 	DrawPerformanceOverlay(position_y);
 	DrawSettingsOverlay();

--- a/pcsx2/ImGui/ImGuiOverlays.cpp
+++ b/pcsx2/ImGui/ImGuiOverlays.cpp
@@ -51,15 +51,13 @@
 #include <tuple>
 #include <unordered_map>
 
-float position_y = 0;
-
 namespace ImGuiManager
 {
 	static void FormatProcessorStat(std::string& text, double usage, double time);
-	static void DrawPerformanceOverlay();
+	static void DrawPerformanceOverlay(float& position_y);
 	static void DrawSettingsOverlay();
 	static void DrawInputsOverlay();
-	static void DrawInputRecordingOverlay();
+	static void DrawInputRecordingOverlay(float& position_y);
 } // namespace ImGuiManager
 
 static std::tuple<float, float> GetMinMax(gsl::span<const float> values)
@@ -99,7 +97,7 @@ void ImGuiManager::FormatProcessorStat(std::string& text, double usage, double t
 		fmt::format_to(std::back_inserter(text), "{:.1f}% ({:.2f}ms)", usage, time);
 }
 
-void ImGuiManager::DrawPerformanceOverlay()
+void ImGuiManager::DrawPerformanceOverlay(float& position_y)
 {
 	const float scale = ImGuiManager::GetGlobalScale();
 	const float shadow_offset = std::ceil(1.0f * scale);
@@ -616,7 +614,7 @@ void ImGuiManager::DrawInputsOverlay()
 	}
 }
 
-void ImGuiManager::DrawInputRecordingOverlay()
+void ImGuiManager::DrawInputRecordingOverlay(float& position_y)
 {
 	const float scale = ImGuiManager::GetGlobalScale();
 	const float shadow_offset = std::ceil(1.0f * scale);
@@ -667,8 +665,9 @@ void ImGuiManager::DrawInputRecordingOverlay()
 
 void ImGuiManager::RenderOverlays()
 {
-	DrawInputRecordingOverlay();
-	DrawPerformanceOverlay();
+	float position_y;
+	DrawInputRecordingOverlay(position_y);
+	DrawPerformanceOverlay(position_y);
 	DrawSettingsOverlay();
 	DrawInputsOverlay();
 }

--- a/pcsx2/ImGui/ImGuiOverlays.cpp
+++ b/pcsx2/ImGui/ImGuiOverlays.cpp
@@ -51,6 +51,8 @@
 #include <tuple>
 #include <unordered_map>
 
+float position_y = 0;
+
 namespace ImGuiManager
 {
 	static void FormatProcessorStat(std::string& text, double usage, double time);
@@ -103,7 +105,6 @@ void ImGuiManager::DrawPerformanceOverlay()
 	const float shadow_offset = std::ceil(1.0f * scale);
 	const float margin = std::ceil(10.0f * scale);
 	const float spacing = std::ceil(5.0f * scale);
-	float position_y = margin;
 
 	ImFont* const fixed_font = ImGuiManager::GetFixedFont();
 	ImFont* const standard_font = ImGuiManager::GetStandardFont();
@@ -621,7 +622,7 @@ void ImGuiManager::DrawInputRecordingOverlay()
 	const float shadow_offset = std::ceil(1.0f * scale);
 	const float margin = std::ceil(10.0f * scale);
 	const float spacing = std::ceil(5.0f * scale);
-	float position_y = margin;
+	position_y = margin;
 
 	ImFont* const fixed_font = ImGuiManager::GetFixedFont();
 	ImFont* const standard_font = ImGuiManager::GetStandardFont();
@@ -666,8 +667,8 @@ void ImGuiManager::DrawInputRecordingOverlay()
 
 void ImGuiManager::RenderOverlays()
 {
-	DrawPerformanceOverlay();
 	DrawInputRecordingOverlay();
+	DrawPerformanceOverlay();
 	DrawSettingsOverlay();
 	DrawInputsOverlay();
 }


### PR DESCRIPTION
### Description of Changes
Draws the input recording overlay first and then the performance overlays.

### Rationale behind Changes
Closes #8330.

### Suggested Testing Steps
Check by playing an input recording while all OSD settings are on.
