### PR TITLE
VIF: Add missing internal DMA stall flag

### DIFF
--- a/pcsx2/Vif1_Dma.cpp
+++ b/pcsx2/Vif1_Dma.cpp
@@ -170,6 +170,7 @@ __fi void vif1SetupTransfer()
 			//DevCon.Warning("VIF1 DMA Stall");
 			// stalled
 			hwDmacIrq(DMAC_STALL_SIS);
+			CPU_SET_DMASTALL(DMAC_VIF1, true);
 			return;
 		}
 	}


### PR DESCRIPTION
### Description of Changes
Adds missing internal DMA stall flag

### Rationale behind Changes
This would have caused the DMA to infinite loop in instant DMA mode and the new DMA changes, causing a regression in games that use it, like Parappa the Rapper 2

### Suggested Testing Steps
Already tested

Fixes #9212
