### PR TITLE
GameDB: Force High Blend on later Armored Core games

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -826,7 +826,7 @@ SCAJ-20076:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
     partialTargetInvalidation: 1 # Fixes broken textures.
-    recommendedBlendingLevel: 3 # Fixes level brightness.
+    minimumBlendingLevel: 3 # Fixes level brightness.
   memcardFilters:
     - "SCAJ-20076"
     - "SCAJ-20077"
@@ -840,7 +840,7 @@ SCAJ-20077:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
     partialTargetInvalidation: 1 # Fixes broken textures.
-    recommendedBlendingLevel: 3 # Fixes level brightness.
+    minimumBlendingLevel: 3 # Fixes level brightness.
   memcardFilters:
     - "SCAJ-20076"
     - "SCAJ-20077"
@@ -985,12 +985,12 @@ SCAJ-20104:
     mergeSprite: 1 # Fixes vertical lines.
     cpuCLUTRender: 1 # Fixes sun occlusion.
 SCAJ-20105:
-  name: "Armored Core - Nine breaker"
+  name: "Armored Core - Nine Breaker"
   region: "NTSC-Unk"
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
     partialTargetInvalidation: 1 # Fixes broken textures.
-    recommendedBlendingLevel: 3 # Fixes level brightness.
+    minimumBlendingLevel: 3 # Fixes level brightness.
 SCAJ-20107:
   name: "Bakufuu Slash! Kizna Arashi"
   region: "NTSC-Unk"
@@ -1081,6 +1081,7 @@ SCAJ-20121:
     partialTargetInvalidation: 1 # Fixes broken textures.
     cpuSpriteRenderBW: 1 # Fixes broken shadow caused by HPO 1.
     cpuSpriteRenderLevel: 2 # Needed for above.
+    minimumBlendingLevel: 3 # Fixes level brightness.
 SCAJ-20122:
   name: "Swords of Destiny"
   region: "NTSC-Unk"
@@ -1218,7 +1219,7 @@ SCAJ-20143:
     cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects shadow alignment and reduces blurriness.
     partialTargetInvalidation: 1 # Fixes broken textures.
-    recommendedBlendingLevel: 3 # Fixes level and map menu brightness.
+    minimumBlendingLevel: 3 # Fixes level and map menu brightness.
 SCAJ-20144:
   name: "Zhuo Hou La 3"
   region: "NTSC-Ch"
@@ -5363,7 +5364,7 @@ SCKA-20047:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
     partialTargetInvalidation: 1 # Fixes broken textures.
-    recommendedBlendingLevel: 3 # Fixes level brightness.
+    minimumBlendingLevel: 3 # Fixes level brightness.
   memcardFilters:
     - "SCKA-20047"
     - "SLKA-25201"
@@ -19450,7 +19451,7 @@ SLES-53819:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
     partialTargetInvalidation: 1 # Fixes broken textures.
-    recommendedBlendingLevel: 3 # Fixes level brightness.
+    minimumBlendingLevel: 3 # Fixes level brightness.
   memcardFilters:
     - "SLES-53819"
     - "SLES-82036"
@@ -19463,7 +19464,7 @@ SLES-53820:
     cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects shadow alignment and reduces blurriness.
     partialTargetInvalidation: 1 # Fixes broken textures.
-    recommendedBlendingLevel: 3 # Fixes level and map menu brightness.
+    minimumBlendingLevel: 3 # Fixes level and map menu brightness.
 SLES-53821:
   name: "Radio Helicopter II"
   region: "PAL-E"
@@ -24255,7 +24256,7 @@ SLES-82036:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
     partialTargetInvalidation: 1 # Fixes broken textures.
-    recommendedBlendingLevel: 3 # Fixes level brightness.
+    minimumBlendingLevel: 3 # Fixes level brightness.
   memcardFilters:
     - "SLES-82036"
     - "SLES-82037"
@@ -24265,7 +24266,7 @@ SLES-82037:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
     partialTargetInvalidation: 1 # Fixes broken textures.
-    recommendedBlendingLevel: 3 # Fixes level brightness.
+    minimumBlendingLevel: 3 # Fixes level brightness.
   memcardFilters:
     - "SLES-82036"
     - "SLES-82037"
@@ -25077,7 +25078,7 @@ SLKA-25201:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
     partialTargetInvalidation: 1 # Fixes broken textures.
-    recommendedBlendingLevel: 3 # Fixes level brightness.
+    minimumBlendingLevel: 3 # Fixes level brightness.
   memcardFilters:
     - "SLKA-25201"
     - "SLKA-25202"
@@ -25087,7 +25088,7 @@ SLKA-25202:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
     partialTargetInvalidation: 1 # Fixes broken textures.
-    recommendedBlendingLevel: 3 # Fixes level brightness.
+    minimumBlendingLevel: 3 # Fixes level brightness.
   memcardFilters:
     - "SLKA-25201"
     - "SLKA-25202"
@@ -25331,6 +25332,7 @@ SLKA-25270:
     partialTargetInvalidation: 1 # Fixes broken textures.
     cpuSpriteRenderBW: 1 # Fixes broken shadow caused by HPO 1.
     cpuSpriteRenderLevel: 2 # Needed for above.
+    minimumBlendingLevel: 3 # Fixes level brightness.
 SLKA-25274:
   name: "Princess Maker 4"
   region: "NTSC-K"
@@ -26662,7 +26664,7 @@ SLPM-61118:
     cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects shadow alignment and reduces blurriness.
     partialTargetInvalidation: 1 # Fixes broken textures.
-    recommendedBlendingLevel: 3 # Fixes level and map menu brightness.
+    minimumBlendingLevel: 3 # Fixes level and map menu brightness.
 SLPM-61119:
   name: "Armored Core - Last Raven [Trial]"
   region: "NTSC-J"
@@ -26671,7 +26673,7 @@ SLPM-61119:
     cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects shadow alignment and reduces blurriness.
     partialTargetInvalidation: 1 # Fixes broken textures.
-    recommendedBlendingLevel: 3 # Fixes level and map menu brightness.
+    minimumBlendingLevel: 3 # Fixes level and map menu brightness.
 SLPM-61120:
   name: "Drag-on Dragoon 2 - Fuuin no Aka, Haitoku no Kuro [Trial Version]"
   region: "NTSC-J"
@@ -36677,7 +36679,7 @@ SLPM-68520:
     cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects shadow alignment and reduces blurriness.
     partialTargetInvalidation: 1 # Fixes broken textures.
-    recommendedBlendingLevel: 3 # Fixes level and map menu brightness.
+    minimumBlendingLevel: 3 # Fixes level and map menu brightness.
 SLPM-68521:
   name: "Dot Hack Fraegment [Senkou Release-ban]"
   region: "NTSC-J"
@@ -39703,7 +39705,7 @@ SLPS-25338:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
     partialTargetInvalidation: 1 # Fixes broken textures.
-    recommendedBlendingLevel: 3 # Fixes level brightness.
+    minimumBlendingLevel: 3 # Fixes level brightness.
   memcardFilters:
     - "SCAJ-20076"
     - "SCAJ-20077"
@@ -39717,7 +39719,7 @@ SLPS-25339:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
     partialTargetInvalidation: 1 # Fixes broken textures.
-    recommendedBlendingLevel: 3 # Fixes level brightness.
+    minimumBlendingLevel: 3 # Fixes level brightness.
   memcardFilters:
     - "SCAJ-20076"
     - "SCAJ-20077"
@@ -40014,7 +40016,7 @@ SLPS-25408:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
     partialTargetInvalidation: 1 # Fixes broken textures.
-    recommendedBlendingLevel: 3 # Fixes level brightness.
+    minimumBlendingLevel: 3 # Fixes level brightness.
   memcardFilters:
     - "SLPS-25408"
     - "SCAJ-20076"
@@ -40220,6 +40222,7 @@ SLPS-25461:
     partialTargetInvalidation: 1 # Fixes broken textures.
     cpuSpriteRenderBW: 1 # Fixes broken shadow caused by HPO 1.
     cpuSpriteRenderLevel: 2 # Needed for above.
+    minimumBlendingLevel: 3 # Fixes level brightness.
 SLPS-25462:
   name: "Armored Core - Last Raven"
   region: "NTSC-J"
@@ -40228,7 +40231,7 @@ SLPS-25462:
     cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects shadow alignment and reduces blurriness.
     partialTargetInvalidation: 1 # Fixes broken textures.
-    recommendedBlendingLevel: 3 # Fixes level and map menu brightness.
+    minimumBlendingLevel: 3 # Fixes level and map menu brightness.
   memcardFilters:
     - "SLPS-25338"
     - "SLPS-25339"
@@ -41247,7 +41250,7 @@ SLPS-25730:
     cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects shadow alignment and reduces blurriness.
     partialTargetInvalidation: 1 # Fixes broken textures.
-    recommendedBlendingLevel: 3 # Fixes level and map menu brightness.
+    minimumBlendingLevel: 3 # Fixes level and map menu brightness.
 SLPS-25731:
   name: "Armored Core 2 [Machine Side Box]"
   region: "NTSC-J"
@@ -42110,7 +42113,7 @@ SLPS-73202:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
     partialTargetInvalidation: 1 # Fixes broken textures.
-    recommendedBlendingLevel: 3 # Fixes level brightness.
+    minimumBlendingLevel: 3 # Fixes level brightness.
   memcardFilters:
     - "SCAJ-20076"
     - "SCAJ-20077"
@@ -42124,7 +42127,7 @@ SLPS-73203:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
     partialTargetInvalidation: 1 # Fixes broken textures.
-    recommendedBlendingLevel: 3 # Fixes level brightness.
+    minimumBlendingLevel: 3 # Fixes level brightness.
   memcardFilters:
     - "SCAJ-20076"
     - "SCAJ-20077"
@@ -42418,7 +42421,7 @@ SLPS-73247:
     cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects shadow alignment and reduces blurriness.
     partialTargetInvalidation: 1 # Fixes broken textures.
-    recommendedBlendingLevel: 3 # Fixes level and map menu brightness.
+    minimumBlendingLevel: 3 # Fixes level and map menu brightness.
   memcardFilters:
     - "SLPS-25338"
     - "SLPS-25339"
@@ -47332,7 +47335,7 @@ SLUS-20986:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
     partialTargetInvalidation: 1 # Fixes broken textures.
-    recommendedBlendingLevel: 3 # Fixes level brightness.
+    minimumBlendingLevel: 3 # Fixes level brightness.
   memcardFilters:
     - "SLUS-20986"
     - "SLUS-21079"
@@ -47848,7 +47851,7 @@ SLUS-21079:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
     partialTargetInvalidation: 1 # Fixes broken textures.
-    recommendedBlendingLevel: 3 # Fixes level brightness.
+    minimumBlendingLevel: 3 # Fixes level brightness.
   memcardFilters:
     - "SLUS-20986"
     - "SLUS-21079"
@@ -48446,7 +48449,7 @@ SLUS-21200:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
     partialTargetInvalidation: 1 # Fixes broken textures.
-    recommendedBlendingLevel: 3 # Fixes level brightness.
+    minimumBlendingLevel: 3 # Fixes level brightness.
   memcardFilters: # Can import data from AC:Nexus.
     - "SLUS-21200"
     - "SLUS-20986"
@@ -49327,7 +49330,7 @@ SLUS-21338:
     cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects shadow alignment and reduces blurriness.
     partialTargetInvalidation: 1 # Fixes broken textures.
-    recommendedBlendingLevel: 3 # Fixes level and map menu brightness.
+    minimumBlendingLevel: 3 # Fixes level and map menu brightness.
 SLUS-21339:
   name: "Puzzle Collection - Crosswords & More!"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
Update to #9166
Changed recommended blending accuracy to minimum blending accuracy.
Added High Blending Accuracy to ACFF.

### Rationale behind Changes
Changed recommended blend to minimum blend, as in my tests using High Blending gives no noticeable performance impact.
![blend](https://github.com/PCSX2/pcsx2/assets/53349573/ee0a6fb7-085f-46c1-be3c-8f8971691eaa)

As shown in the linked PR, level lighting is inconsistent without High Blending. On top of that, on D3D renderer the game looks very poor without High Blending.
![blend2](https://github.com/PCSX2/pcsx2/assets/53349573/b4453808-1efe-4dbe-a3a2-5b3736b8f64d)



### Suggested Testing Steps
N/A

### Logs & Dumps
[Armored Core - Last Raven_SLUS-21338_20230709223134.gs.zip](https://github.com/PCSX2/pcsx2/files/11997523/Armored.Core.-.Last.Raven_SLUS-21338_20230709223134.gs.zip)

