### PR TITLE
GS/HW: Avoid tex-is-fb when incompatible clamp is used

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.h
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.h
@@ -93,7 +93,8 @@ private:
 	void HandleTextureHazards(const GSTextureCache::Target* rt, const GSTextureCache::Target* ds,
 		const GSTextureCache::Source* tex, const TextureMinMaxResult& tmm, GSTextureCache::SourceRegion& source_region,
 		bool& target_region, GSVector2i& unscaled_size, float& scale, GSTexture*& src_copy);
-	bool CanUseTexIsFB(const GSTextureCache::Target* rt, const GSTextureCache::Source* tex) const;
+	bool CanUseTexIsFB(const GSTextureCache::Target* rt, const GSTextureCache::Source* tex,
+		const TextureMinMaxResult& tmm) const;
 
 	void EmulateZbuffer(const GSTextureCache::Target* ds);
 	void EmulateATST(float& AREF, GSHWDrawConfig::PSSelector& ps, bool pass_2);


### PR DESCRIPTION
### Description of Changes

Parappa draws a fullscreen quad with the texture pointing at the framebuffer, but uses a region repeat of 1008, 0, to drop the bottom 4 bits of the UV's Y, producing a mosaic effect.

We weren't testing for this before, so it was using barriers to read the FB without overlap, which meant the UVs weren't mutated.

### Rationale behind Changes

Fixes #9216.

![image](https://github.com/PCSX2/pcsx2/assets/11288319/da8e3b89-38f0-40ee-b729-367094ed5fdd)

### Suggested Testing Steps

Check parappa dump.
No other games except parappa hit this in the dump collection, should be safe.
