### PR TITLE
GS/Vulkan: Use VK_EXT_attachment_feedback_loop_layout when supported

### DIFF
--- a/bin/resources/shaders/vulkan/tfx.glsl
+++ b/bin/resources/shaders/vulkan/tfx.glsl
@@ -336,12 +336,12 @@ layout(set = 1, binding = 1) uniform texture2D Palette;
 #endif
 
 #if PS_FEEDBACK_LOOP_IS_NEEDED
-	#ifndef DISABLE_TEXTURE_BARRIER
-		layout(input_attachment_index = 0, set = 2, binding = 0) uniform subpassInput RtSampler;
-		vec4 sample_from_rt() { return subpassLoad(RtSampler); }
-	#else
+	#if defined(DISABLE_TEXTURE_BARRIER) || defined(HAS_FEEDBACK_LOOP_LAYOUT)
 		layout(set = 2, binding = 0) uniform texture2D RtSampler;
 		vec4 sample_from_rt() { return texelFetch(RtSampler, ivec2(gl_FragCoord.xy), 0); }
+	#else
+		layout(input_attachment_index = 0, set = 2, binding = 0) uniform subpassInput RtSampler;
+		vec4 sample_from_rt() { return subpassLoad(RtSampler); }
 	#endif
 #endif
 
@@ -1218,7 +1218,7 @@ void main()
 #endif
 
 #if (SW_AD_TO_HW)
-	vec4 RT = trunc(subpassLoad(RtSampler) * 255.0f + 0.1f);
+	vec4 RT = trunc(sample_from_rt() * 255.0f + 0.1f);
 	vec4 alpha_blend = vec4(RT.a / 128.0f);
 #else
 	vec4 alpha_blend = vec4(C.a / 128.0f);

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h
@@ -309,6 +309,8 @@ public:
 	void RenderHW(GSHWDrawConfig& config) override;
 	void UpdateHWPipelineSelector(GSHWDrawConfig& config, PipelineSelector& pipe);
 	void UploadHWDrawVerticesAndIndices(const GSHWDrawConfig& config);
+	VkImageMemoryBarrier GetColorBufferBarrier(GSTextureVK* rt) const;
+	VkDependencyFlags GetColorBufferBarrierFlags() const;
 	void SendHWDraw(const GSHWDrawConfig& config, GSTextureVK* draw_rt, bool skip_first_barrier);
 
 	//////////////////////////////////////////////////////////////////////////
@@ -395,6 +397,7 @@ private:
 	// Which bindings/state has to be updated before the next draw.
 	u32 m_dirty_flags = 0;
 	FeedbackLoopFlag m_current_framebuffer_feedback_loop = FeedbackLoopFlag_None;
+	bool m_has_feedback_loop_layout = false;
 	bool m_warned_slow_spin = false;
 
 	// input assembly

--- a/pcsx2/ShaderCacheVersion.h
+++ b/pcsx2/ShaderCacheVersion.h
@@ -15,4 +15,4 @@
 
 /// Version number for GS and other shaders. Increment whenever any of the contents of the
 /// shaders change, to invalidate the cache.
-static constexpr u32 SHADER_CACHE_VERSION = 26;
+static constexpr u32 SHADER_CACHE_VERSION = 27;


### PR DESCRIPTION
### Description of Changes

Makes sense to use the extension, since it's what we're doing.

### Rationale behind Changes

Enables us to use dynamic rendering everywhere later on (needed for ROV).

### Suggested Testing Steps

Compare performance (no change expected), check games.
