### PR TITLE
GS: Only clamp tex co-ords to bounds in hardware.

### DIFF
--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -3514,7 +3514,7 @@ GSState::TextureMinMaxResult GSState::GetTextureMinMax(GIFRegTEX0 TEX0, GIFRegCL
 			// If it's the start of the texture and our little adjustment is all that pushed it over, clamp it to 0.
 			// This stops the border check failing when using repeat but needed less than the full texture
 			// since this was making it take the full texture even though it wasn't needed.
-			if (((m_vt.m_min.t == GSVector4::zero()).mask() & 0x3) == 0x3)
+			if (!clamp_to_tsize && ((m_vt.m_min.t == GSVector4::zero()).mask() & 0x3) == 0x3)
 				st = st.max(GSVector4::zero());
 		}
 		else


### PR DESCRIPTION
### Description of Changes
Only clamp texture co-ords to texture bounds in hardware mode.

### Rationale behind Changes
regressed software mode in #8906, software handles this stuff itself, where hardware mode craps the bed without, so let's keep it for hardware only.

### Suggested Testing Steps
Test Ratchet & Clank - Deadlocked in software mode around lava. Smattering of other games.
