### PR TITLE
GS: Reduce cutoff for PrimID destination alpha

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -4687,7 +4687,7 @@ __ri void GSRendererHW::DrawPrims(GSTextureCache::Target* rt, GSTextureCache::Ta
 				GL_PERF("DATE: Fast with alpha %d-%d", GetAlphaMinMax().min, GetAlphaMinMax().max);
 				DATE_one = true;
 			}
-			else if (features.texture_barrier && ((m_vt.m_primclass == GS_SPRITE_CLASS && m_drawlist.size() < 50) || (m_index.tail < 100)))
+			else if (features.texture_barrier && ((m_vt.m_primclass == GS_SPRITE_CLASS && m_drawlist.size() < 10) || (m_index.tail < 30)))
 			{
 				// texture barrier will split the draw call into n draw call. It is very efficient for
 				// few primitive draws. Otherwise it sucks.

--- a/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
+++ b/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
@@ -907,7 +907,7 @@ bool GSDeviceMTL::Create()
 	m_features.prefer_new_textures = true;
 	m_features.dxt_textures = true;
 	m_features.bptc_textures = true;
-	m_features.framebuffer_fetch = m_dev.features.framebuffer_fetch;
+	m_features.framebuffer_fetch = m_dev.features.framebuffer_fetch && !GSConfig.DisableFramebufferFetch;
 	m_features.dual_source_blend = true;
 	m_features.clip_control = true;
 	m_features.stencil_buffer = true;


### PR DESCRIPTION
### Description of Changes
Reduces the cutoff for preferring PrimID destination alpha over barriers
Also wires up the disable fbfetch checkbox on the Metal renderer

### Rationale behind Changes
The old number was decided back when we had an OpenGL renderer that used texture atomics for the PrimID algorithm.

New one was tested based on performance of [NBAStreetVol2-SLUS-20651-DATE.zip](https://github.com/PCSX2/pcsx2/files/12035718/NBAStreetVol2-SLUS-20651-DATE.zip), which seems to have a lot of medium-size batches of destination alpha draws.

<details>
<summary>Test results</summary>
Note: Render pass count is approximately equal to 2x the number of PrimID passes

On the Metal renderer:

| Cutoff | # Barriers | # Render Passes | FPS (Intel UHD 630 @ 2x) | FPS (AMD Radeon Pro 5600M @ 4x) |
|---:|---:|---:|---:|---:|
| 0 | 17 | 861 | 74 | 87 |
| 30 | 116 | 832 | 70 | 85 |
| 50 | 340 | 798 | 63 | 80 |
| 70 | 887 | 745 | 53 | 65 |
| 80 | 2433 | 623 | 42 | 40 |
| 90 | 5409 | 411 | 35 | 22 |
| 100 | 10627 | 75 | 31 | 12 |

(Side note: The UHD 630 gets 150fps with fbfetch.  fbfetch is nice.)

Stenzek also provided some values from his GTX 1080 @ 8x Vulkan:

![image](https://github.com/PCSX2/pcsx2/assets/3315070/dee5daba-da3b-42fb-bc29-b2700d0d5de4)

</details>

Based on this, I put the cutoff at 10 barriers (30 triangle vertices).  Nvidia would probably like it a little higher, AMD a little lower, but it's a lot better than 100 for all GPUs.  (2x better on Nvidia and Intel, 7x better on AMD)

### Suggested Testing Steps
- Test [NBAStreetVol2-SLUS-20651-DATE.zip](https://github.com/PCSX2/pcsx2/files/12035718/NBAStreetVol2-SLUS-20651-DATE.zip)
- Test any other destination alpha games
