### PR TITLE
UI: Add controller binding tooltips for additional controls

### DIFF
--- a/pcsx2-qt/Settings/InputBindingWidget.cpp
+++ b/pcsx2-qt/Settings/InputBindingWidget.cpp
@@ -74,9 +74,14 @@ void InputBindingWidget::initialize(
 
 void InputBindingWidget::updateText()
 {
+	const QString binding_tip(tr("\n\nLeft click to assign a new button\nShift + left click for additional bindings"));
+	const QString binding_clear_tip(tr("\nRight click to clear binding"));
+
 	if (m_bindings.empty())
 	{
 		setText(QString());
+
+		setToolTip(tr("No bindings registered") + binding_tip);
 	}
 	else if (m_bindings.size() > 1)
 	{
@@ -93,12 +98,12 @@ void InputBindingWidget::updateText()
 				ss << "\n";
 			ss << binding;
 		}
-		setToolTip(QString::fromStdString(ss.str()));
+		setToolTip(QString::fromStdString(ss.str()) + binding_tip + binding_clear_tip);
 	}
 	else
 	{
 		QString binding_text(QString::fromStdString(m_bindings[0]));
-		setToolTip(binding_text);
+		setToolTip(binding_text + binding_tip + binding_clear_tip);
 
 		// fix up accelerators, and if it's too long, ellipsise it
 		if (binding_text.contains('&'))


### PR DESCRIPTION
### Description of Changes
Adds tooltips to controller bindings to say what controls you need to add/clear bindings.

### Rationale behind Changes
Users weren't really aware of adding additional bindings, for example, so this could inform at least some users.

### Suggested Testing Steps
Mess about with the controller UI


![image](https://github.com/PCSX2/pcsx2/assets/6278726/45852bcf-eb36-4e7d-a2bf-be778be09787)
![image](https://github.com/PCSX2/pcsx2/assets/6278726/2a16dd86-2e10-48fa-9061-d4133e51ee19)
![image](https://github.com/PCSX2/pcsx2/assets/6278726/e817d3da-bf0d-43fb-a0b0-9a85a53a8cc5)
