### PR TITLE
Flatpak: Add the talk-name flag for org.freedesktop.Screensaver

### DIFF
--- a/.github/workflows/scripts/linux/flatpak/net.pcsx2.PCSX2.json
+++ b/.github/workflows/scripts/linux/flatpak/net.pcsx2.PCSX2.json
@@ -22,7 +22,8 @@
     "--socket=fallback-x11",
     "--socket=wayland",
     "--socket=pulseaudio",
-    "--filesystem=host:ro"
+    "--filesystem=host:ro",
+    "--talk-name=org.freedesktop.ScreenSaver"
   ],
   "modules": [
     "modules/10-libpcap.json",


### PR DESCRIPTION
This brings the functionality in line with the old Flatpak release. This allows PCSX2 to inhibit the screensaver or screen blanking without needing to touch the mouse/keyboard while the VM is running.

### Description of Changes
Adds one flag to the to the flatpak packaging json file.

### Rationale behind Changes
The old Flatpak packaging used this finish-arg to allow the screensaver inhibitor to function. Without this flag the screensaver will come up during a play session because gamepad inputs don't prevent screen blanking.

### Suggested Testing Steps
If you want to manually test this flag without committing the easiest way is to use Flatseal and then add `org.freedesktop.ScreenSaver` to PCSX2 under the Talks subsection in the Session Bus section. Wait for your screen saver or screen blank timeout and observe. You can also observe the inhibition and uninhibition by monitoring the output of the following command `dbus-monitor --session | grep -e Session -e Screen -e login`