### PR TITLE
GS: Fixes shader initialization warnings.

### DIFF
--- a/bin/resources/shaders/dx11/cas.hlsl
+++ b/bin/resources/shaders/dx11/cas.hlsl
@@ -56,7 +56,7 @@ void main(uint3 LocalThreadId : SV_GroupThreadID, uint3 WorkGroupId : SV_GroupID
 #endif
 
   // Filter.
-  AF3 c;
+  AF3 c = (float4)0.0f;
 
   CasFilter(c.r, c.g, c.b, gxy, const0, const1, sharpenOnly);
   OutputTexture[ASU2(gxy)] = AF4(c, 1);

--- a/bin/resources/shaders/opengl/cas.glsl
+++ b/bin/resources/shaders/opengl/cas.glsl
@@ -46,7 +46,7 @@ void main()
 	AU2 gxy = ARmp8x8(gl_LocalInvocationID.x)+AU2(gl_WorkGroupID.x<<4u,gl_WorkGroupID.y<<4u);
 
 	// Filter.
-	AF4 c;
+	AF4 c = vec4(0.0f);
 	CasFilter(c.r, c.g, c.b, gxy, const0, const1, CAS_SHARPEN_ONLY);
 	imageStore(imgDst, ASU2(gxy), c);
 	gxy.x += 8u;

--- a/bin/resources/shaders/opengl/convert.glsl
+++ b/bin/resources/shaders/opengl/convert.glsl
@@ -367,7 +367,7 @@ uniform ivec2 EMOD;
 void ps_yuv()
 {
 	vec4 i = sample_c();
-	vec4 o;
+	vec4 o = vec4(0.0f);
 
 	mat3 rgb2yuv; // Value from GS manual
 	rgb2yuv[0] = vec3(0.587, -0.311, -0.419);
@@ -380,7 +380,8 @@ void ps_yuv()
 	float Cr = float(0xE0)/255.0f * yuv.y + float(0x80)/255.0f;
 	float Cb = float(0xE0)/255.0f * yuv.z + float(0x80)/255.0f;
 
-	switch(EMOD.x) {
+	switch(EMOD.x)
+	{
 		case 0:
 			o.a = i.a;
 			break;
@@ -395,7 +396,8 @@ void ps_yuv()
 			break;
 	}
 
-	switch(EMOD.y) {
+	switch(EMOD.y)
+	{
 		case 0:
 			o.rgb = i.rgb;
 			break;

--- a/bin/resources/shaders/vulkan/cas.glsl
+++ b/bin/resources/shaders/vulkan/cas.glsl
@@ -53,7 +53,7 @@ void main()
     AU2 gxy = ARmp8x8(gl_LocalInvocationID.x)+AU2(gl_WorkGroupID.x<<4u,gl_WorkGroupID.y<<4u);
 
     // Filter.
-    AF4 c;
+    AF4 c = vec4(0.0f);
     CasFilter(c.r, c.g, c.b, gxy, const0, const1, sharpenOnly != 0);
     imageStore(imgDst, ASU2(gxy), c);
     gxy.x += 8u;

--- a/bin/resources/shaders/vulkan/convert.glsl
+++ b/bin/resources/shaders/vulkan/convert.glsl
@@ -348,7 +348,7 @@ layout(push_constant) uniform cb10
 void ps_yuv()
 {
 	vec4 i = sample_c(v_tex);
-	vec4 o;
+	vec4 o = vec4(0.0f);
 
 	mat3 rgb2yuv;
 	rgb2yuv[0] = vec3(0.587, -0.311, -0.419);
@@ -361,7 +361,8 @@ void ps_yuv()
 	float Cr = float(0xE0)/255.0f * yuv.y + float(0x80)/255.0f;
 	float Cb = float(0xE0)/255.0f * yuv.z + float(0x80)/255.0f;
 
-	switch(EMODA) {
+	switch(EMODA)
+	{
 		case 0:
 			o.a = i.a;
 			break;
@@ -376,7 +377,8 @@ void ps_yuv()
 			break;
 	}
 
-	switch(EMODC) {
+	switch(EMODC)
+	{
 		case 0:
 			o.rgb = i.rgb;
 			break;

--- a/pcsx2/GS/Renderers/Metal/convert.metal
+++ b/pcsx2/GS/Renderers/Metal/convert.metal
@@ -321,7 +321,7 @@ fragment float4 ps_yuv(ConvertShaderData data [[stage_in]], ConvertPSRes res,
 	constant GSMTLConvertPSUniform& uniform [[buffer(GSMTLBufferIndexUniforms)]])
 {
 	float4 i = res.sample(data.t);
-	float4 o;
+	float4 o = float4(0);
 
 	// Value from GS manual
 	const float3x3 rgb2yuv =

--- a/pcsx2/ShaderCacheVersion.h
+++ b/pcsx2/ShaderCacheVersion.h
@@ -15,4 +15,4 @@
 
 /// Version number for GS and other shaders. Increment whenever any of the contents of the
 /// shaders change, to invalidate the cache.
-static constexpr u32 SHADER_CACHE_VERSION = 27;
+static constexpr u32 SHADER_CACHE_VERSION = 28;


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS: Fixes shader initialization warnings.
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Fixes these shader initialization warnings on GL.
![image](https://github.com/PCSX2/pcsx2/assets/18107717/0c9aecc1-deb7-4672-a115-ffab4eacf819)
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Delete shader cache, run opengl, make sure the warnings are gone, also make sure other renderers still work.