### PR TITLE
GS/HW: Use draw for valid height, preload cached size

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSHwHack.cpp
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.cpp
@@ -1142,7 +1142,7 @@ static bool GetMoveTargetPair(GSRendererHW& r, GSTextureCache::Target** src, GIF
 		if (req_target)
 			return false;
 
-		tdst = g_texture_cache->CreateTarget(dst_desc, tsrc->GetUnscaledSize(), tsrc->GetScale(), dst_type, true, 0,
+		tdst = g_texture_cache->CreateTarget(dst_desc, tsrc->GetUnscaledSize(), tsrc->GetUnscaledSize(), tsrc->GetScale(), dst_type, true, 0,
 			false, false, true, tsrc->GetUnscaledRect());
 		if (!tdst)
 			return false;

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -721,7 +721,7 @@ float GSRendererHW::GetTextureScaleFactor()
 	return GetUpscaleMultiplier();
 }
 
-GSVector2i GSRendererHW::GetTargetSize(const GSTextureCache::Source* tex)
+GSVector2i GSRendererHW::GetValidSize(const GSTextureCache::Source* tex)
 {
 	// Don't blindly expand out to the scissor size if we're not drawing to it.
 	// e.g. Burnout 3, God of War II, etc.
@@ -779,7 +779,14 @@ GSVector2i GSRendererHW::GetTargetSize(const GSTextureCache::Source* tex)
 		}
 	}
 
-	return g_texture_cache->GetTargetSize(m_cached_ctx.FRAME.Block(), m_cached_ctx.FRAME.FBW, m_cached_ctx.FRAME.PSM, width, height);
+	return  GSVector2i(width, height);
+}
+
+GSVector2i GSRendererHW::GetTargetSize(const GSTextureCache::Source* tex)
+{
+	const GSVector2i valid_size = GetValidSize(tex);
+
+	return g_texture_cache->GetTargetSize(m_cached_ctx.FRAME.Block(), m_cached_ctx.FRAME.FBW, m_cached_ctx.FRAME.PSM, valid_size.x, valid_size.y);
 }
 
 bool GSRendererHW::IsPossibleChannelShuffle() const
@@ -2169,7 +2176,7 @@ void GSRendererHW::Draw()
 				return;
 			}
 
-			rt = g_texture_cache->CreateTarget(FRAME_TEX0, t_size, target_scale, GSTextureCache::RenderTarget, true,
+			rt = g_texture_cache->CreateTarget(FRAME_TEX0, t_size, GetValidSize(src), target_scale, GSTextureCache::RenderTarget, true,
 				fm, false, force_preload, preserve_rt_color, m_r);
 			if (unlikely(!rt))
 			{
@@ -2193,7 +2200,7 @@ void GSRendererHW::Draw()
 			m_cached_ctx.DepthWrite(), 0, false, force_preload, preserve_depth, m_r);
 		if (!ds)
 		{
-			ds = g_texture_cache->CreateTarget(ZBUF_TEX0, t_size, target_scale, GSTextureCache::DepthStencil,
+			ds = g_texture_cache->CreateTarget(ZBUF_TEX0, t_size, GetValidSize(src), target_scale, GSTextureCache::DepthStencil,
 				m_cached_ctx.DepthWrite(), 0, false, force_preload, preserve_depth, m_r);
 			if (unlikely(!ds))
 			{

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.h
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.h
@@ -195,6 +195,7 @@ public:
 	GSVector4i ComputeBoundingBox(const GSVector2i& rtsize, float rtscale);
 	void MergeSprite(GSTextureCache::Source* tex);
 	float GetTextureScaleFactor() override;
+	GSVector2i GetValidSize(const GSTextureCache::Source* tex = nullptr);
 	GSVector2i GetTargetSize(const GSTextureCache::Source* tex = nullptr);
 
 	void Reset(bool hardware_reset) override;

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.h
@@ -469,7 +469,7 @@ public:
 	Target* LookupTarget(GIFRegTEX0 TEX0, const GSVector2i& size, float scale, int type, bool used = true, u32 fbmask = 0,
 		bool is_frame = false, bool preload = GSConfig.PreloadFrameWithGSData, bool preserve_target = true,
 		const GSVector4i draw_rc = GSVector4i::zero());
-	Target* CreateTarget(GIFRegTEX0 TEX0, const GSVector2i& size, float scale, int type, bool used = true, u32 fbmask = 0,
+	Target* CreateTarget(GIFRegTEX0 TEX0, const GSVector2i& size, const GSVector2i& valid_size,float scale, int type, bool used = true, u32 fbmask = 0,
 		bool is_frame = false, bool preload = GSConfig.PreloadFrameWithGSData, bool preserve_target = true,
 		const GSVector4i draw_rc = GSVector4i::zero());
 	Target* LookupDisplayTarget(GIFRegTEX0 TEX0, const GSVector2i& size, float scale);


### PR DESCRIPTION
### Description of Changes
Sets the valid size of the target to the size of the draw, not the cached size.

### Rationale behind Changes
It is possible a target can get reused as a different size, but before it was invalidly making the valid size the previous height.  This was happening with Shadow Hearts, where the second half of what was a 448 high buffer was now being used to upload new textures, triggering PCSX2 to invalidate that second half of the depth buffer constantly, which made the render passes reset every draw.  This now correctly only marks the valid size to what is actually being drawn.

Also copy the valid size on dst_match in case this needs to be expanded/invalidated.

### Suggested Testing Steps
Test Shadow Hearts and a smattering of a few games.
