### PR TITLE
GS/HW: Support alpha in RT concurrently with Z

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -20343,6 +20343,7 @@ SLES-54159:
     mipmap: 2 # Cleans up texture detail.
     trilinearFiltering: 1 # Smoothes out mipmapping.
     halfPixelOffset: 2 # Fixes post processing misalignment.
+    recommendedBlendingLevel: 3 # Improves reflection quality.
 SLES-54160:
   name: "Eragon"
   region: "PAL-R"
@@ -20350,6 +20351,7 @@ SLES-54160:
     mipmap: 2 # Cleans up texture detail.
     trilinearFiltering: 1 # Smoothes out mipmapping.
     halfPixelOffset: 2 # Fixes post processing misalignment.
+    recommendedBlendingLevel: 3 # Improves reflection quality.
 SLES-54161:
   name: "Super Dragon Ball Z"
   region: "PAL-E"
@@ -49340,6 +49342,7 @@ SLUS-21322:
     mipmap: 2 # Cleans up texture detail.
     trilinearFiltering: 1 # Smoothes out mipmapping.
     halfPixelOffset: 2 # Fixes post processing misalignment.
+    recommendedBlendingLevel: 3 # Improves reflection quality.
 SLUS-21323:
   name: "Rampage - Total Destruction"
   region: "NTSC-U"

--- a/pcsx2/GS/GSCrc.cpp
+++ b/pcsx2/GS/GSCrc.cpp
@@ -46,14 +46,6 @@ const CRC::Game CRC::m_games[] =
 	{0x47BA9034, SMTNocturne /* JP */}, // SMTNocturne Maniacs Chronicle
 	{0xD3FFC263, SMTNocturne /* KO */},
 	{0x84D1A8DA, SMTNocturne /* KO */},
-	{0xE21404E2, GetawayGames /* US */}, // Getaway
-	{0xE8249852, GetawayGames /* JP */}, // Getaway
-	{0x458485EF, GetawayGames /* EU */}, // Getaway
-	{0x5DFBE144, GetawayGames /* EU */}, // Getaway
-	{0xE78971DF, GetawayGames /* US */}, // GetawayBlackMonday
-	{0x342D97FA, GetawayGames /* US */}, // GetawayBlackMonday Demo
-	{0xE8C0AD1A, GetawayGames /* JP */}, // GetawayBlackMonday
-	{0x09C3DF79, GetawayGames /* EU */}, // GetawayBlackMonday
 };
 
 const CRC::Game& CRC::Lookup(u32 crc)

--- a/pcsx2/GS/GSCrc.h
+++ b/pcsx2/GS/GSCrc.h
@@ -23,7 +23,6 @@ public:
 	enum Title : u32
 	{
 		NoTitle,
-		GetawayGames,
 		ICO,
 		SMTNocturne,
 		Tekken5,

--- a/pcsx2/GS/GSLocalMemory.cpp
+++ b/pcsx2/GS/GSLocalMemory.cpp
@@ -485,6 +485,12 @@ u32 GSLocalMemory::GetEndBlockAddress(u32 bp, u32 bw, u32 psm, GSVector4i rect)
 	return result;
 }
 
+u32 GSLocalMemory::GetUnwrappedEndBlockAddress(u32 bp, u32 bw, u32 psm, GSVector4i rect)
+{
+	const u32 result = GetEndBlockAddress(bp, bw, psm, rect);
+	return (result < bp) ? (result + MAX_BLOCKS) : result;
+}
+
 GSVector4i GSLocalMemory::GetRectForPageOffset(u32 base_bp, u32 offset_bp, u32 bw, u32 psm)
 {
 	pxAssert((base_bp % BLOCKS_PER_PAGE) == 0 && (offset_bp % BLOCKS_PER_PAGE) == 0);

--- a/pcsx2/GS/GSLocalMemory.h
+++ b/pcsx2/GS/GSLocalMemory.h
@@ -549,6 +549,7 @@ public:
 	static bool IsPageAligned(u32 psm, const GSVector4i& rc);
 	static u32 GetStartBlockAddress(u32 bp, u32 bw, u32 psm, GSVector4i rect);
 	static u32 GetEndBlockAddress(u32 bp, u32 bw, u32 psm, GSVector4i rect);
+	static u32 GetUnwrappedEndBlockAddress(u32 bp, u32 bw, u32 psm, GSVector4i rect);
 	static GSVector4i GetRectForPageOffset(u32 base_bp, u32 offset_bp, u32 bw, u32 psm);
 
 	// address

--- a/pcsx2/GS/GSVector.h
+++ b/pcsx2/GS/GSVector.h
@@ -83,6 +83,16 @@ public:
 	{
 		return { x / v.x, y / v.y };
 	}
+
+	GSVector2T min(const GSVector2T& v) const
+	{
+		return { std::min(x, v.x), std::min(y, v.y) };
+	}
+
+	GSVector2T max(const GSVector2T& v) const
+	{
+		return { std::max(x, v.x), std::max(y, v.y) };
+	}
 };
 
 typedef GSVector2T<float> GSVector2;

--- a/pcsx2/GS/Renderers/Common/GSDevice.cpp
+++ b/pcsx2/GS/Renderers/Common/GSDevice.cpp
@@ -42,6 +42,7 @@ const char* shaderName(ShaderConvert value)
 		case ShaderConvert::FLOAT32_TO_16_BITS:     return "ps_convert_float32_32bits";
 		case ShaderConvert::FLOAT32_TO_32_BITS:     return "ps_convert_float32_32bits";
 		case ShaderConvert::FLOAT32_TO_RGBA8:       return "ps_convert_float32_rgba8";
+		case ShaderConvert::FLOAT32_TO_RGB8:        return "ps_convert_float32_rgba8";
 		case ShaderConvert::FLOAT16_TO_RGB5A1:      return "ps_convert_float16_rgb5a1";
 		case ShaderConvert::RGBA8_TO_FLOAT32:       return "ps_convert_rgba8_float32";
 		case ShaderConvert::RGBA8_TO_FLOAT24:       return "ps_convert_rgba8_float24";

--- a/pcsx2/GS/Renderers/Common/GSDevice.h
+++ b/pcsx2/GS/Renderers/Common/GSDevice.h
@@ -37,6 +37,7 @@ enum class ShaderConvert
 	FLOAT32_TO_16_BITS,
 	FLOAT32_TO_32_BITS,
 	FLOAT32_TO_RGBA8,
+	FLOAT32_TO_RGB8,
 	FLOAT16_TO_RGB5A1,
 	RGBA8_TO_FLOAT32,
 	RGBA8_TO_FLOAT24,
@@ -120,6 +121,17 @@ static inline bool SupportsBilinear(ShaderConvert shader)
 			return false;
 		default:
 			return true;
+	}
+}
+
+static inline u32 ShaderConvertWriteMask(ShaderConvert shader)
+{
+	switch (shader)
+	{
+		case ShaderConvert::FLOAT32_TO_RGB8:
+			return 0x7;
+		default:
+			return 0xf;
 	}
 }
 

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
@@ -1207,7 +1207,8 @@ void GSDevice11::StretchRect(GSTexture* sTex, const GSVector4& sRect, GSTexture*
 {
 	pxAssert(dTex->IsDepthStencil() == HasDepthOutput(shader));
 	pxAssert(linear ? SupportsBilinear(shader) : SupportsNearest(shader));
-	StretchRect(sTex, sRect, dTex, dRect, m_convert.ps[static_cast<int>(shader)].get(), nullptr, linear);
+	StretchRect(sTex, sRect, dTex, dRect, m_convert.ps[static_cast<int>(shader)].get(), nullptr,
+		m_convert.bs[ShaderConvertWriteMask(shader)].get(), linear);
 }
 
 void GSDevice11::StretchRect(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect, ID3D11PixelShader* ps, ID3D11Buffer* ps_cb, bool linear)

--- a/pcsx2/GS/Renderers/DX12/D3D12Builders.cpp
+++ b/pcsx2/GS/Renderers/DX12/D3D12Builders.cpp
@@ -193,6 +193,11 @@ void D3D12::GraphicsPipelineBuilder::SetBlendState(u32 rt, bool blend_enable, D3
 		m_desc.BlendState.IndependentBlendEnable = TRUE;
 }
 
+void D3D12::GraphicsPipelineBuilder::SetColorWriteMask(u32 rt, u8 write_mask /* = D3D12_COLOR_WRITE_ENABLE_ALL */)
+{
+	m_desc.BlendState.RenderTarget[rt].RenderTargetWriteMask = write_mask;
+}
+
 void D3D12::GraphicsPipelineBuilder::SetNoBlendingState()
 {
 	SetBlendState(0, false, D3D12_BLEND_ONE, D3D12_BLEND_ZERO, D3D12_BLEND_OP_ADD, D3D12_BLEND_ONE, D3D12_BLEND_ZERO,

--- a/pcsx2/GS/Renderers/DX12/D3D12Builders.h
+++ b/pcsx2/GS/Renderers/DX12/D3D12Builders.h
@@ -105,6 +105,7 @@ namespace D3D12
 		void SetBlendState(u32 rt, bool blend_enable, D3D12_BLEND src_factor, D3D12_BLEND dst_factor, D3D12_BLEND_OP op,
 			D3D12_BLEND alpha_src_factor, D3D12_BLEND alpha_dst_factor, D3D12_BLEND_OP alpha_op,
 			u8 write_mask = D3D12_COLOR_WRITE_ENABLE_ALL);
+		void SetColorWriteMask(u32 rt, u8 write_mask = D3D12_COLOR_WRITE_ENABLE_ALL);
 
 		void SetNoBlendingState();
 

--- a/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
@@ -1341,7 +1341,8 @@ void GSDevice12::StretchRect(GSTexture* sTex, const GSVector4& sRect, GSTexture*
 		int(dRect.right - dRect.left), int(dRect.bottom - dRect.top));
 
 	DoStretchRect(static_cast<GSTexture12*>(sTex), sRect, static_cast<GSTexture12*>(dTex), dRect,
-		dTex ? m_convert[static_cast<int>(shader)].get() : m_present[static_cast<int>(shader)].get(), linear, true);
+		dTex ? m_convert[static_cast<int>(shader)].get() : m_present[static_cast<int>(shader)].get(), linear,
+		ShaderConvertWriteMask(shader) == 0xf);
 }
 
 void GSDevice12::StretchRect(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect, bool red,
@@ -2375,6 +2376,8 @@ bool GSDevice12::CompileConvertPipelines()
 			gpb.SetDepthState(depth, depth, D3D12_COMPARISON_FUNC_ALWAYS);
 			gpb.SetNoStencilState();
 		}
+
+		gpb.SetColorWriteMask(0, ShaderConvertWriteMask(i));
 
 		ComPtr<ID3DBlob> ps(GetUtilityPixelShader(*shader, shaderName(i)));
 		if (!ps)

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.h
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.h
@@ -104,6 +104,7 @@ private:
 	bool IsPossibleChannelShuffle() const;
 	bool IsSplitTextureShuffle();
 	GSVector4i GetSplitTextureShuffleDrawRect() const;
+	u32 GetEffectiveTextureShuffleFbmsk() const;
 
 	static GSVector4i GetDrawRectForPages(u32 bw, u32 psm, u32 num_pages);
 	bool TryToResolveSinglePageFramebuffer(GIFRegFRAME& FRAME, bool only_next_draw);

--- a/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
+++ b/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
@@ -1117,14 +1117,23 @@ bool GSDeviceMTL::Create()
 			case ShaderConvert::RGBA_TO_8I: // Yes really
 			case ShaderConvert::TRANSPARENCY_FILTER:
 			case ShaderConvert::FLOAT32_TO_RGBA8:
+			case ShaderConvert::FLOAT32_TO_RGB8:
 			case ShaderConvert::FLOAT16_TO_RGB5A1:
 			case ShaderConvert::YUV:
 				pdesc.colorAttachments[0].pixelFormat = ConvertPixelFormat(GSTexture::Format::Color);
 				pdesc.depthAttachmentPixelFormat = MTLPixelFormatInvalid;
 				break;
 		}
+		const u32 scmask = ShaderConvertWriteMask(conv);
+		MTLColorWriteMask mask = MTLColorWriteMaskNone;
+		if (scmask & 1) mask |= MTLColorWriteMaskRed;
+		if (scmask & 2) mask |= MTLColorWriteMaskGreen;
+		if (scmask & 4) mask |= MTLColorWriteMaskBlue;
+		if (scmask & 8) mask |= MTLColorWriteMaskAlpha;
+		pdesc.colorAttachments[0].writeMask = mask;
 		m_convert_pipeline[i] = MakePipeline(pdesc, vs_convert, LoadShader(name), name);
 	}
+	pdesc.colorAttachments[0].writeMask = MTLColorWriteMaskAll;
 	pdesc.depthAttachmentPixelFormat = MTLPixelFormatInvalid;
 	for (size_t i = 0; i < std::size(m_present_pipeline); i++)
 	{

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -1454,7 +1454,7 @@ void GSDeviceOGL::StretchRect(GSTexture* sTex, const GSVector4& sRect, GSTexture
 {
 	pxAssert(dTex->IsDepthStencil() == HasDepthOutput(shader));
 	pxAssert(linear ? SupportsBilinear(shader) : SupportsNearest(shader));
-	StretchRect(sTex, sRect, dTex, dRect, m_convert.ps[(int)shader], linear);
+	StretchRect(sTex, sRect, dTex, dRect, m_convert.ps[(int)shader], false, OMColorMaskSelector(ShaderConvertWriteMask(shader)), linear);
 }
 
 void GSDeviceOGL::StretchRect(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect, const GLProgram& ps, bool linear)

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
@@ -2867,7 +2867,8 @@ void GSDeviceVK::StretchRect(GSTexture* sTex, const GSVector4& sRect, GSTexture*
 		int(dRect.right - dRect.left), int(dRect.bottom - dRect.top));
 
 	DoStretchRect(static_cast<GSTextureVK*>(sTex), sRect, static_cast<GSTextureVK*>(dTex), dRect,
-		dTex ? m_convert[static_cast<int>(shader)] : m_present[static_cast<int>(shader)], linear, true);
+		dTex ? m_convert[static_cast<int>(shader)] : m_present[static_cast<int>(shader)], linear,
+		ShaderConvertWriteMask(shader) == 0xf);
 }
 
 void GSDeviceVK::StretchRect(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect, bool red,
@@ -3902,6 +3903,8 @@ bool GSDeviceVK::CompileConvertPipelines()
 			gpb.SetDepthState(depth, depth, VK_COMPARE_OP_ALWAYS);
 			gpb.SetNoStencilState();
 		}
+
+		gpb.SetColorWriteMask(0, ShaderConvertWriteMask(i));
 
 		VkShaderModule ps = GetUtilityFragmentShader(*shader, shaderName(i));
 		if (ps == VK_NULL_HANDLE)

--- a/pcsx2/GS/Renderers/Vulkan/VKBuilders.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/VKBuilders.cpp
@@ -485,6 +485,14 @@ void Vulkan::GraphicsPipelineBuilder::SetBlendAttachment(u32 attachment, bool bl
 	}
 }
 
+void Vulkan::GraphicsPipelineBuilder::SetColorWriteMask(u32 attachment, VkColorComponentFlags write_mask)
+{
+	pxAssert(attachment < MAX_ATTACHMENTS);
+
+	VkPipelineColorBlendAttachmentState& bs = m_blend_attachments[attachment];
+	bs.colorWriteMask = write_mask;
+}
+
 void Vulkan::GraphicsPipelineBuilder::AddBlendFlags(u32 flags)
 {
 	m_blend_state.flags |= flags;

--- a/pcsx2/GS/Renderers/Vulkan/VKBuilders.h
+++ b/pcsx2/GS/Renderers/Vulkan/VKBuilders.h
@@ -130,6 +130,9 @@ namespace Vulkan
 			VkBlendOp op, VkBlendFactor alpha_src_factor, VkBlendFactor alpha_dst_factor, VkBlendOp alpha_op,
 			VkColorComponentFlags write_mask = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT |
 											   VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT);
+		void SetColorWriteMask(
+			u32 attachment, VkColorComponentFlags write_mask = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT |
+															   VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT);
 		void AddBlendFlags(u32 flags);
 		void ClearBlendAttachments();
 


### PR DESCRIPTION
### Description of Changes

Currently, PCSX2 removes any Z targets when you write to the RT at an address, or vice versa. Hence the gross CRC hack for Getaway. Let's get rid of that, which also fixes a bunch of other issues.

 - Fixes lens flare and DoF in True Crime: NYC.
 - Fixes reflections in Eragon.
 - Fixes floor in Area 51.
 - Fixes flickering in Transformers.
 - Improves fog effect in Forgotten Realms - Demon Stone.

### Rationale behind Changes

Fixes lens flare noted in #8242.
Gets rid of 1/4 of the remaining GSCrc entries.
Fixes #3986.

### Suggested Testing Steps

Test affected games.
Make sure DBZ BT2/3 didn't take a non-trivial speed hit.

### Changes (before, after)

![image](https://github.com/PCSX2/pcsx2/assets/11288319/ede5e9c9-8090-4ba0-81c6-4ec50dc679e0)
![image](https://github.com/PCSX2/pcsx2/assets/11288319/1801e647-17c0-4799-8e33-252e52b8324f)

![image](https://github.com/PCSX2/pcsx2/assets/11288319/6c0cf919-eb56-4ee9-a9a4-7d9f9ba8cc7e)
![image](https://github.com/PCSX2/pcsx2/assets/11288319/83721e90-e0f3-419f-b37f-f72bf9f8a858)

(needs high blending for fog wall)
![image](https://github.com/PCSX2/pcsx2/assets/11288319/84227eef-bb83-4ea7-bab0-2828347c1a62)
![image](https://github.com/PCSX2/pcsx2/assets/11288319/8b20ad56-adcf-445c-ad9e-0e315df54529)

![image](https://github.com/PCSX2/pcsx2/assets/11288319/18974bb5-0607-48e9-95fb-ae2c7f1defcc)
![image](https://github.com/PCSX2/pcsx2/assets/11288319/24742bd9-4eeb-49c0-82be-0fa81e28a82a)

![image](https://github.com/PCSX2/pcsx2/assets/11288319/cbcbbc64-ae20-41eb-8efe-be38e976f7ad)
![image](https://github.com/PCSX2/pcsx2/assets/11288319/eae0d49e-23c2-4a95-a7c7-c868dd71d1a5)
