### PR TITLE
FSUI: Fix light mode colors

### DIFF
--- a/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
+++ b/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
@@ -2407,6 +2407,8 @@ void GSDeviceMTL::RenderImGui(ImDrawData* data)
 		{
 			if (cmd.UserCallback)
 				[NSException raise:@"Unimplemented" format:@"UserCallback not implemented"];
+			if (!cmd.ElemCount)
+				continue;
 
 			simd::float4 clip_rect = (ToSimd(cmd.ClipRect) - clip_off.xyxy) * clip_scale.xyxy;
 			simd::float2 clip_min = clip_rect.xy;

--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -4407,7 +4407,8 @@ void FullscreenUI::DrawPauseMenu(MainWindowType type)
 {
 	ImDrawList* dl = ImGui::GetBackgroundDrawList();
 	const ImVec2 display_size(ImGui::GetIO().DisplaySize);
-	dl->AddRectFilled(ImVec2(0.0f, 0.0f), display_size, IM_COL32(0x21, 0x21, 0x21, 200));
+	const ImU32 text_color = IM_COL32(UIBackgroundTextColor.x * 255, UIBackgroundTextColor.y * 255, UIBackgroundTextColor.z * 255, 255);
+	dl->AddRectFilled(ImVec2(0.0f, 0.0f), display_size, IM_COL32(UIBackgroundColor.x * 255, UIBackgroundColor.y * 255, UIBackgroundColor.z * 255, 200));
 
 	// title info
 	{
@@ -4438,13 +4439,13 @@ void FullscreenUI::DrawPauseMenu(MainWindowType type)
 
 		float rp_height = 0.0f;
 
-		DrawShadowedText(dl, g_large_font, title_pos, IM_COL32(255, 255, 255, 255), s_current_game_title.c_str());
+		DrawShadowedText(dl, g_large_font, title_pos, text_color, s_current_game_title.c_str());
 		if (!path_string.empty())
 		{
 			DrawShadowedText(
-				dl, g_medium_font, path_pos, IM_COL32(255, 255, 255, 255), path_string.data(), path_string.data() + path_string.length());
+				dl, g_medium_font, path_pos, text_color, path_string.data(), path_string.data() + path_string.length());
 		}
-		DrawShadowedText(dl, g_medium_font, subtitle_pos, IM_COL32(255, 255, 255, 255), s_current_game_subtitle.c_str());
+		DrawShadowedText(dl, g_medium_font, subtitle_pos, text_color, s_current_game_subtitle.c_str());
 
 #ifdef ENABLE_ACHIEVEMENTS
 		if (has_rich_presence)
@@ -4467,7 +4468,7 @@ void FullscreenUI::DrawPauseMenu(MainWindowType type)
 				path_pos.y -= rp_height;
 				subtitle_pos.y -= rp_height;
 
-				DrawShadowedText(dl, g_medium_font, rp_pos, IM_COL32(255, 255, 255, 255), rp.data(), rp.data() + rp.size(), wrap_width);
+				DrawShadowedText(dl, g_medium_font, rp_pos, text_color, rp.data(), rp.data() + rp.size(), wrap_width);
 			}
 		}
 #endif
@@ -4496,7 +4497,7 @@ void FullscreenUI::DrawPauseMenu(MainWindowType type)
 
 		const ImVec2 time_size(g_large_font->CalcTextSizeA(g_large_font->FontSize, std::numeric_limits<float>::max(), -1.0f, buf));
 		const ImVec2 time_pos(display_size.x - LayoutScale(10.0f) - time_size.x, LayoutScale(10.0f));
-		DrawShadowedText(dl, g_large_font, time_pos, IM_COL32(255, 255, 255, 255), buf);
+		DrawShadowedText(dl, g_large_font, time_pos, text_color, buf);
 
 		if (!s_current_disc_serial.empty())
 		{
@@ -4509,13 +4510,13 @@ void FullscreenUI::DrawPauseMenu(MainWindowType type)
 			const ImVec2 session_size(g_medium_font->CalcTextSizeA(g_medium_font->FontSize, std::numeric_limits<float>::max(), -1.0f, buf));
 			const ImVec2 session_pos(
 				display_size.x - LayoutScale(10.0f) - session_size.x, time_pos.y + g_large_font->FontSize + LayoutScale(4.0f));
-			DrawShadowedText(dl, g_medium_font, session_pos, IM_COL32(255, 255, 255, 255), buf);
+			DrawShadowedText(dl, g_medium_font, session_pos, text_color, buf);
 
 			std::snprintf(buf, std::size(buf), "All Time: %s", played_time_str.c_str());
 			const ImVec2 total_size(g_medium_font->CalcTextSizeA(g_medium_font->FontSize, std::numeric_limits<float>::max(), -1.0f, buf));
 			const ImVec2 total_pos(
 				display_size.x - LayoutScale(10.0f) - total_size.x, session_pos.y + g_medium_font->FontSize + LayoutScale(4.0f));
-			DrawShadowedText(dl, g_medium_font, total_pos, IM_COL32(255, 255, 255, 255), buf);
+			DrawShadowedText(dl, g_medium_font, total_pos, text_color, buf);
 		}
 	}
 

--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -85,8 +85,8 @@ using ImGuiFullscreen::UIPrimaryLightColor;
 using ImGuiFullscreen::UIPrimaryLineColor;
 using ImGuiFullscreen::UIPrimaryTextColor;
 using ImGuiFullscreen::UISecondaryColor;
-using ImGuiFullscreen::UISecondaryDarkColor;
-using ImGuiFullscreen::UISecondaryLightColor;
+using ImGuiFullscreen::UISecondaryWeakColor;
+using ImGuiFullscreen::UISecondaryStrongColor;
 using ImGuiFullscreen::UISecondaryTextColor;
 using ImGuiFullscreen::UITextHighlightColor;
 

--- a/pcsx2/ImGui/ImGuiFullscreen.cpp
+++ b/pcsx2/ImGui/ImGuiFullscreen.cpp
@@ -510,11 +510,12 @@ void ImGuiFullscreen::PushResetLayout()
 	ImGui::PushStyleColor(ImGuiCol_ScrollbarGrab, UIPrimaryColor);
 	ImGui::PushStyleColor(ImGuiCol_ScrollbarGrabHovered, UIPrimaryLightColor);
 	ImGui::PushStyleColor(ImGuiCol_ScrollbarGrabActive, UIPrimaryDarkColor);
+	ImGui::PushStyleColor(ImGuiCol_PopupBg, ModAlpha(UIBackgroundColor, 0.95f));
 }
 
 void ImGuiFullscreen::PopResetLayout()
 {
-	ImGui::PopStyleColor(10);
+	ImGui::PopStyleColor(11);
 	ImGui::PopStyleVar(12);
 }
 

--- a/pcsx2/ImGui/ImGuiFullscreen.cpp
+++ b/pcsx2/ImGui/ImGuiFullscreen.cpp
@@ -83,8 +83,8 @@ namespace ImGuiFullscreen
 	ImVec4 UITextHighlightColor;
 	ImVec4 UIPrimaryLineColor;
 	ImVec4 UISecondaryColor;
-	ImVec4 UISecondaryLightColor;
-	ImVec4 UISecondaryDarkColor;
+	ImVec4 UISecondaryStrongColor;
+	ImVec4 UISecondaryWeakColor;
 	ImVec4 UISecondaryTextColor;
 
 	static u32 s_menu_button_index = 0;
@@ -1144,7 +1144,7 @@ bool ImGuiFullscreen::ToggleButton(
 	}
 	else
 	{
-		col_bg = ImGui::GetColorU32(ImLerp(HEX_TO_IMVEC4(0x8C8C8C, 0xff), UISecondaryLightColor, t));
+		col_bg = ImGui::GetColorU32(ImLerp(HEX_TO_IMVEC4(0x8C8C8C, 0xff), UISecondaryStrongColor, t));
 		col_knob = IM_COL32(255, 255, 255, 255);
 	}
 
@@ -1220,10 +1220,10 @@ bool ImGuiFullscreen::ThreeWayToggleButton(
 		col_bg = IM_COL32(0x75, 0x75, 0x75, 0xff);
 	else if (hovered)
 		col_bg = ImGui::GetColorU32(
-			ImLerp(v->has_value() ? HEX_TO_IMVEC4(0xf05100, 0xff) : HEX_TO_IMVEC4(0x9e9e9e, 0xff), UISecondaryLightColor, color_t));
+			ImLerp(v->has_value() ? HEX_TO_IMVEC4(0xf05100, 0xff) : HEX_TO_IMVEC4(0x9e9e9e, 0xff), UISecondaryStrongColor, color_t));
 	else
 		col_bg = ImGui::GetColorU32(
-			ImLerp(v->has_value() ? HEX_TO_IMVEC4(0xc45100, 0xff) : HEX_TO_IMVEC4(0x757575, 0xff), UISecondaryLightColor, color_t));
+			ImLerp(v->has_value() ? HEX_TO_IMVEC4(0xc45100, 0xff) : HEX_TO_IMVEC4(0x757575, 0xff), UISecondaryStrongColor, color_t));
 
 	dl->AddRectFilled(toggle_pos, ImVec2(toggle_pos.x + toggle_width, toggle_pos.y + toggle_height), col_bg, toggle_height * 0.5f);
 	dl->AddCircleFilled(ImVec2(toggle_pos.x + toggle_radius + t * (toggle_width - toggle_radius * 2.0f), toggle_pos.y + toggle_radius),
@@ -2219,7 +2219,7 @@ void ImGuiFullscreen::DrawBackgroundProgressDialogs(ImVec2& position, float spac
 	const float window_height = LayoutScale(75.0f);
 
 	ImGui::PushStyleColor(ImGuiCol_WindowBg, UIPrimaryDarkColor);
-	ImGui::PushStyleColor(ImGuiCol_PlotHistogram, UISecondaryLightColor);
+	ImGui::PushStyleColor(ImGuiCol_PlotHistogram, UISecondaryStrongColor);
 	ImGui::PushStyleVar(ImGuiStyleVar_PopupRounding, LayoutScale(4.0f));
 	ImGui::PushStyleVar(ImGuiStyleVar_PopupBorderSize, LayoutScale(1.0f));
 	ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, LayoutScale(10.0f, 10.0f));
@@ -2479,8 +2479,8 @@ void ImGuiFullscreen::SetTheme(bool light)
 		UITextHighlightColor = HEX_TO_IMVEC4(0x90caf9, 0xff);
 		UIPrimaryLineColor = HEX_TO_IMVEC4(0xffffff, 0xff);
 		UISecondaryColor = HEX_TO_IMVEC4(0x0d47a1, 0xff);
-		UISecondaryLightColor = HEX_TO_IMVEC4(0x63a4ff, 0xff);
-		UISecondaryDarkColor = HEX_TO_IMVEC4(0x002171, 0xff);
+		UISecondaryStrongColor = HEX_TO_IMVEC4(0x63a4ff, 0xff);
+		UISecondaryWeakColor = HEX_TO_IMVEC4(0x002171, 0xff);
 		UISecondaryTextColor = HEX_TO_IMVEC4(0xffffff, 0xff);
 	}
 	else
@@ -2498,8 +2498,8 @@ void ImGuiFullscreen::SetTheme(bool light)
 		UITextHighlightColor = HEX_TO_IMVEC4(0x8e8e8e, 0xff);
 		UIPrimaryLineColor = HEX_TO_IMVEC4(0x000000, 0xff);
 		UISecondaryColor = HEX_TO_IMVEC4(0x3d5afe, 0xff);
-		UISecondaryLightColor = HEX_TO_IMVEC4(0xc0cfff, 0xff);
-		UISecondaryDarkColor = HEX_TO_IMVEC4(0x0031ca, 0xff);
+		UISecondaryStrongColor = HEX_TO_IMVEC4(0x0031ca, 0xff);
+		UISecondaryWeakColor = HEX_TO_IMVEC4(0xc0cfff, 0xff);
 		UISecondaryTextColor = HEX_TO_IMVEC4(0x000000, 0xff);
 	}
 }

--- a/pcsx2/ImGui/ImGuiFullscreen.cpp
+++ b/pcsx2/ImGui/ImGuiFullscreen.cpp
@@ -578,20 +578,6 @@ void ImGuiFullscreen::PopPrimaryColor()
 	ImGui::PopStyleColor(5);
 }
 
-void ImGuiFullscreen::PushSecondaryColor()
-{
-	ImGui::PushStyleColor(ImGuiCol_Text, UISecondaryTextColor);
-	ImGui::PushStyleColor(ImGuiCol_Button, UISecondaryDarkColor);
-	ImGui::PushStyleColor(ImGuiCol_ButtonActive, UISecondaryColor);
-	ImGui::PushStyleColor(ImGuiCol_ButtonHovered, UISecondaryLightColor);
-	ImGui::PushStyleColor(ImGuiCol_Border, UISecondaryLightColor);
-}
-
-void ImGuiFullscreen::PopSecondaryColor()
-{
-	ImGui::PopStyleColor(5);
-}
-
 bool ImGuiFullscreen::BeginFullscreenColumns(const char* title, float pos_y, bool expand_to_screen_width)
 {
 	ImGui::SetNextWindowPos(ImVec2(expand_to_screen_width ? 0.0f : g_layout_padding_left, pos_y));

--- a/pcsx2/ImGui/ImGuiFullscreen.h
+++ b/pcsx2/ImGui/ImGuiFullscreen.h
@@ -136,8 +136,6 @@ namespace ImGuiFullscreen
 
 	void PushPrimaryColor();
 	void PopPrimaryColor();
-	void PushSecondaryColor();
-	void PopSecondaryColor();
 
 	void DrawWindowTitle(const char* title);
 

--- a/pcsx2/ImGui/ImGuiFullscreen.h
+++ b/pcsx2/ImGui/ImGuiFullscreen.h
@@ -63,8 +63,8 @@ namespace ImGuiFullscreen
 	extern ImVec4 UITextHighlightColor;
 	extern ImVec4 UIPrimaryLineColor;
 	extern ImVec4 UISecondaryColor;
-	extern ImVec4 UISecondaryLightColor;
-	extern ImVec4 UISecondaryDarkColor;
+	extern ImVec4 UISecondaryStrongColor;
+	extern ImVec4 UISecondaryWeakColor;
 	extern ImVec4 UISecondaryTextColor;
 
 	static __fi float DPIScale(float v) { return ImGui::GetIO().DisplayFramebufferScale.x * v; }


### PR DESCRIPTION
### Description of Changes
Fixes big picture light mode colors so you don't get black text on black backgrounds
Also switches the switch color to look less disabled in light mode

### Rationale behind Changes
Usable light mode

### Suggested Testing Steps
Look at the About PCSX2 window in big picture
Look at settings toggles
Look at the pause menu
