### PR TITLE
GameDB: Lego Drome Racers blackscreen fix

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -13351,6 +13351,9 @@ SLES-51302:
 SLES-51303:
   name: "LEGO Dome Racers"
   region: "PAL-M8"
+  gsHWFixes:
+    textureInsideRT: 1 # Fixes black screen in races.
+    autoFlush: 1 # Fixes shadow rendering.
 SLES-51307:
   name: "Wild ARMs 3"
   region: "PAL-E"
@@ -45334,6 +45337,9 @@ SLUS-20577:
   name: "Drome Racers"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    textureInsideRT: 1 # Fixes black screen in races.
+    autoFlush: 1 # Fixes shadow rendering.
 SLUS-20578:
   name: "Lord of the Rings, The - The Two Towers"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
Fixes lego drome racers having a black screen in hardware mode.

Before:
![LEGO Dome Racers_SLES-51303_20230717190046](https://github.com/PCSX2/pcsx2/assets/80843560/fcd46f06-10bf-4942-8912-71f6a088c295)

After:
![Black_SLES-54030_20230717190102](https://github.com/PCSX2/pcsx2/assets/80843560/01264200-b065-484b-abea-2b34d3990cd6)

Fixes #9270 

### Rationale behind Changes
Blackscreen in hardware mode bad.

### Suggested Testing Steps
Make sure CI is happy.
