### PR TITLE
FileSystem: Make FILE* unique pointers use a functor deleter

### DIFF
--- a/common/FileSystem.cpp
+++ b/common/FileSystem.cpp
@@ -672,7 +672,7 @@ int FileSystem::OpenFDFile(const char* filename, int flags, int mode, Error* err
 
 FileSystem::ManagedCFilePtr FileSystem::OpenManagedCFile(const char* filename, const char* mode, Error* error)
 {
-	return ManagedCFilePtr(OpenCFile(filename, mode, error), [](std::FILE* fp) { std::fclose(fp); });
+	return ManagedCFilePtr(OpenCFile(filename, mode, error));
 }
 
 std::FILE* FileSystem::OpenSharedCFile(const char* filename, const char* mode, FileShareMode share_mode, Error* error)
@@ -717,7 +717,7 @@ std::FILE* FileSystem::OpenSharedCFile(const char* filename, const char* mode, F
 
 FileSystem::ManagedCFilePtr FileSystem::OpenManagedSharedCFile(const char* filename, const char* mode, FileShareMode share_mode, Error* error)
 {
-	return ManagedCFilePtr(OpenSharedCFile(filename, mode, share_mode, error), [](std::FILE* fp) { std::fclose(fp); });
+	return ManagedCFilePtr(OpenSharedCFile(filename, mode, share_mode, error));
 }
 
 int FileSystem::FSeek64(std::FILE* fp, s64 offset, int whence)

--- a/common/FileSystem.h
+++ b/common/FileSystem.h
@@ -102,8 +102,17 @@ namespace FileSystem
 	/// Rename file
 	bool RenamePath(const char* OldPath, const char* NewPath);
 
+	/// Deleter functor for managed file pointers
+	struct FileDeleter
+	{
+		void operator()(std::FILE* fp)
+		{
+			std::fclose(fp);
+		}
+	};
+
 	/// open files
-	using ManagedCFilePtr = std::unique_ptr<std::FILE, void (*)(std::FILE*)>;
+	using ManagedCFilePtr = std::unique_ptr<std::FILE, FileDeleter>;
 	ManagedCFilePtr OpenManagedCFile(const char* filename, const char* mode, Error* error = nullptr);
 	std::FILE* OpenCFile(const char* filename, const char* mode, Error* error = nullptr);
 	int FSeek64(std::FILE* fp, s64 offset, int whence);


### PR DESCRIPTION
### Description of Changes
This PR changes `ManagedCFilePtr` to use a functor structure instead of a lambda for a deleter.

### Rationale behind Changes
Slimmer `std::unique_ptr`'s, as seen here - notice `static_asserts`:
https://godbolt.org/z/8rTWoe3qd

### Suggested Testing Steps
No idea? This has no chance of breaking if it compiles.
