### PR TITLE
GS/HW: Added new Half-Pixel Offset option Bilinear Scaled (Testing Only)

### DIFF
--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
@@ -1140,6 +1140,11 @@
            <string>Special (Texture - Aggressive)</string>
           </property>
          </item>
+          <item>
+            <property name="text">
+              <string>Bilinear Scaled (Vertex)</string>
+            </property>
+          </item>
         </widget>
        </item>
        <item row="1" column="0">

--- a/pcsx2/GS/Renderers/Common/GSRenderer.cpp
+++ b/pcsx2/GS/Renderers/Common/GSRenderer.cpp
@@ -272,7 +272,27 @@ float GSRenderer::GetModXYOffset()
 {
 	float mod_xy = 0.0f;
 
-	if (GSConfig.UserHacks_HalfPixelOffset == 1)
+	// Scaled Bilinear HPO depending on the gradient.
+	if (GSConfig.UserHacks_HalfPixelOffset == 4)
+	{
+		const GSVector2 pos_range(m_vt.m_max.p.x - m_vt.m_min.p.x, m_vt.m_max.p.y - m_vt.m_min.p.y);
+		const GSVector2 uv_range(m_vt.m_max.t.x - m_vt.m_min.t.x, m_vt.m_max.t.y - m_vt.m_min.t.y);
+		const GSVector2 grad(uv_range / pos_range);
+		const float avg_grad = (grad.x + grad.y) / 2;
+
+		if (avg_grad >= 0.5f && m_draw_env->CTXT[m_draw_env->PRIM.CTXT].TEX1.MMIN == 1)
+		{
+			mod_xy = GetUpscaleMultiplier();
+			switch (static_cast<int>(std::round(mod_xy)))
+			{
+				case 2: case 4: case 6: case 8: mod_xy += (mod_xy / 2.0f) * avg_grad; break;
+				case 3: case 7:                 mod_xy += (mod_xy / 2.0f) * avg_grad; break;
+				case 5:                         mod_xy += (mod_xy / 2.0f) * avg_grad; break;
+				default:                        mod_xy = 0.0f; break;
+			}
+		}
+	}
+	else if (GSConfig.UserHacks_HalfPixelOffset == 1)
 	{
 		mod_xy = GetUpscaleMultiplier();
 		switch (static_cast<int>(std::round(mod_xy)))

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -582,7 +582,7 @@ void GSRendererHW::ConvertSpriteTextureShuffle(bool& write_ba, bool& read_ba)
 
 GSVector4 GSRendererHW::RealignTargetTextureCoordinate(const GSTextureCache::Source* tex)
 {
-	if (GSConfig.UserHacks_HalfPixelOffset <= 1 || GetUpscaleMultiplier() == 1.0f)
+	if (GSConfig.UserHacks_HalfPixelOffset <= 1 || GSConfig.UserHacks_HalfPixelOffset >= 4 || GetUpscaleMultiplier() == 1.0f)
 		return GSVector4(0.0f);
 
 	const GSVertex* v = &m_vertex.buff[0];

--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -3225,7 +3225,7 @@ void FullscreenUI::DrawGraphicsSettingsPage()
 			static constexpr const char* s_cpu_clut_render_options[] = {"0 (Disabled)", "1 (Normal)", "2 (Aggressive)"};
 			static constexpr const char* s_texture_inside_rt_options[] = {"Disabled", "Inside Target", "Merge Targets"};
 			static constexpr const char* s_half_pixel_offset_options[] = {
-				"Off (Default)", "Normal (Vertex)", "Special (Texture)", "Special (Texture - Aggressive)"};
+				"Off (Default)", "Normal (Vertex)", "Special (Texture)", "Special (Texture - Aggressive)", "Bilinear Scaled (Vertex)"};
 			static constexpr const char* s_round_sprite_options[] = {"Off (Default)", "Half", "Full"};
 			static constexpr const char* s_auto_flush_options[] = {
 				"Disabled (Default)", "Enabled (Sprites Only)", "Enabled (All Primitives)"};


### PR DESCRIPTION
### Description of Changes
Adds a new HPO option Bilinear Scaled, which only affects bilinear draws where the gradient is of a reasonable amount (not too small)

### Rationale behind Changes
Can be useful for games doing post bloom effects. So far it seems to work well with Yakuza 2 and Kingdom Hearts Final Mix with no other upscaling fixes required.  Tekken 5 looks arguably better upscaled with the rendering fixes disabled, but there is still some lines.

### Suggested Testing Steps
Test games which work well with HPO Normal (Vertex) but suffer from garbage around the edges of the screen, or the offset isn't quite enough/correct.

Not sure if I'm going to merge this yet or not, I want to gauge it's usefulness first.

Some shots at x8:

Yakuza 2:
HPO Normal:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/c16cfe61-845a-49fe-81eb-91799757d739)

Bilinear Scaled:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/47a9e5e9-727f-4ffd-a6a1-7d97dcce86e4)


KH2:
HPO Normal + Round Sprite Full:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/1bdc456b-0ecd-4210-bc9d-33ef54213390)

Bilinear Scaled:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/a9e93f5a-7254-4708-b7b2-7579007d6111)

Driving Emotion Type-S:
HPO Normal:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/24da64ad-af76-4bab-937f-52be3a779baa)

Bilinear Scaled:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/be9daebc-266a-413f-816c-648010ad9277)
