### PR TITLE
GS/HW: Replace Ico CRC hack with move handler

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -383,6 +383,7 @@ PCPX-96322:
   gsHWFixes:
     mipmap: 1
     halfPixelOffset: 1 # Fixes effect misalignment.
+    moveHandler: "MV_Ico" # Fixes depth buffer post-processing.
 PCPX-96328:
   name: "3 Title Special Disc (Saru! Get You! 2 - PoPoLoCrois: Hajimari no Bouken - Boku no Natsuyasumi 2)"
   region: "NTSC-J"
@@ -959,6 +960,7 @@ SCAJ-20099:
   gsHWFixes:
     mipmap: 1
     halfPixelOffset: 1 # Fixes effect misalignment.
+    moveHandler: "MV_Ico" # Fixes depth buffer post-processing.
 SCAJ-20100:
   name: "Tenchu Kurenai"
   region: "NTSC-Ch-J"
@@ -1711,6 +1713,7 @@ SCCS-40005:
   gsHWFixes:
     mipmap: 1
     halfPixelOffset: 1 # Fixes effect misalignment.
+    moveHandler: "MV_Ico" # Fixes depth buffer post-processing.
 SCCS-40006:
   name: "Zhen Sanguo Wushuang 2"
   region: "NTSC-C"
@@ -2030,6 +2033,7 @@ SCED-50844:
   gsHWFixes:
     mipmap: 1
     halfPixelOffset: 1 # Fixes effect misalignment.
+    moveHandler: "MV_Ico" # Fixes depth buffer post-processing.
 SCED-50907:
   name: "Final Fantasy X [Bonus Disc - Beyond Final Fantasy]"
   region: "PAL-Unk"
@@ -3387,6 +3391,7 @@ SCES-50760:
   gsHWFixes:
     mipmap: 1
     halfPixelOffset: 1 # Fixes effect misalignment.
+    moveHandler: "MV_Ico" # Fixes depth buffer post-processing.
 SCES-50781:
   name: "Destruction Derby Arenas [Beta, Promo, & Full Retail]"
   region: "PAL-M6"
@@ -5325,6 +5330,7 @@ SCKA-20028:
   gsHWFixes:
     mipmap: 1
     halfPixelOffset: 1 # Fixes effect misalignment.
+    moveHandler: "MV_Ico" # Fixes depth buffer post-processing.
 SCKA-20029:
   name: "Gran Turismo - Concept 2002 Tokyo-Seoul [PlayStation 2 Big Hit Series]"
   region: "NTSC-K"
@@ -5847,6 +5853,7 @@ SCPS-11003:
   gsHWFixes:
     mipmap: 1
     halfPixelOffset: 1 # Fixes effect misalignment.
+    moveHandler: "MV_Ico" # Fixes depth buffer post-processing.
 SCPS-11004:
   name: "Bikkuri Mouse"
   region: "NTSC-J"
@@ -6688,6 +6695,7 @@ SCPS-19103:
   gsHWFixes:
     mipmap: 1
     halfPixelOffset: 1 # Fixes effect misalignment.
+    moveHandler: "MV_Ico" # Fixes depth buffer post-processing.
 SCPS-19104:
   name: "Pipo Saru 2001 [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -6704,6 +6712,7 @@ SCPS-19151:
   gsHWFixes:
     mipmap: 1
     halfPixelOffset: 1 # Fixes effect misalignment.
+    moveHandler: "MV_Ico" # Fixes depth buffer post-processing.
 SCPS-19152:
   name: "Saru Get You! 2 [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -7155,6 +7164,7 @@ SCPS-55001:
   gsHWFixes:
     mipmap: 1
     halfPixelOffset: 1 # Fixes effect misalignment.
+    moveHandler: "MV_Ico" # Fixes depth buffer post-processing.
 SCPS-55002:
   name: "Zero"
   region: "NTSC-J"
@@ -7427,6 +7437,7 @@ SCPS-56001:
   gsHWFixes:
     mipmap: 1
     halfPixelOffset: 1 # Fixes effect misalignment.
+    moveHandler: "MV_Ico" # Fixes depth buffer post-processing.
 SCPS-56002:
   name: "Tekken Tag Tournament"
   region: "NTSC-K"
@@ -7602,6 +7613,7 @@ SCUS-97113:
   gsHWFixes:
     mipmap: 1
     halfPixelOffset: 1 # Fixes effect misalignment.
+    moveHandler: "MV_Ico" # Fixes depth buffer post-processing.
 SCUS-97114:
   name: "NBA ShootOut 2001"
   region: "NTSC-U"
@@ -7787,6 +7799,7 @@ SCUS-97159:
   gsHWFixes:
     mipmap: 1
     halfPixelOffset: 1 # Fixes effect misalignment.
+    moveHandler: "MV_Ico" # Fixes depth buffer post-processing.
 SCUS-97160:
   name: "Extermination [Demo]"
   region: "NTSC-U"

--- a/pcsx2/GS/GSCrc.cpp
+++ b/pcsx2/GS/GSCrc.cpp
@@ -26,13 +26,6 @@ const CRC::Game CRC::m_games[] =
 {
 	// Note: IDs 0x7ACF7E03, 0x7D4EA48F, 0x37C53760 - shouldn't be added as it's from the multiloaders when packing games.
 	{0x00000000, NoTitle /* NoRegion */},
-	{0x6F8545DB, ICO /* US */},
-	{0x48CDF317, ICO /* US */}, // Demo
-	{0xB01A4C95, ICO /* JP */},
-	{0x2DF2C1EA, ICO /* KO */},
-	{0x5C991F4E, ICO /* EU */},
-	{0x788D8B4F, ICO /* EU */},
-	{0x29C28734, ICO /* CH */},
 	{0xFC46EA61, Tekken5 /* JP */},
 	{0x1F88EE37, Tekken5 /* EU */},
 	{0x1F88BECD, Tekken5 /* EU */}, // language selector...

--- a/pcsx2/GS/GSCrc.h
+++ b/pcsx2/GS/GSCrc.h
@@ -23,7 +23,6 @@ public:
 	enum Title : u32
 	{
 		NoTitle,
-		ICO,
 		SMTNocturne,
 		Tekken5,
 		TitleCount,

--- a/pcsx2/GS/Renderers/HW/GSHwHack.h
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.h
@@ -58,6 +58,7 @@ public:
 	static bool OI_HauntingGround(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
 
 	static bool MV_Growlanser(GSRendererHW& r);
+	static bool MV_Ico(GSRendererHW& r);
 
 	template <typename F>
 	struct Entry

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.h
@@ -181,7 +181,7 @@ public:
 		std::pair<u8, u8> m_alpha_minmax;
 
 	public:
-		Palette(u16 pal, bool need_gs_texture);
+		Palette(const u32* clut, u16 pal, bool need_gs_texture);
 		~Palette();
 
 		__fi std::pair<u8, u8> GetAlphaMinMax() const { return m_alpha_minmax; }
@@ -335,6 +335,7 @@ public:
 
 		// Retrieves a shared pointer to a valid Palette from m_maps or creates a new one adding it to the data structure
 		std::shared_ptr<Palette> LookupPalette(u16 pal, bool need_gs_texture);
+		std::shared_ptr<Palette> LookupPalette(const u32* clut, u16 pal, bool need_gs_texture);
 
 		void Clear(); // Clears m_maps, thus deletes Palette objects
 	};
@@ -470,7 +471,7 @@ public:
 	void DirtyRectByPage(u32 sbp, u32 spsm, u32 sbw, Target* t, GSVector4i src_r);
 
 	GSTexture* LookupPaletteSource(u32 CBP, u32 CPSM, u32 CBW, GSVector2i& offset, float* scale, const GSVector2i& size);
-	std::shared_ptr<Palette> LookupPaletteObject(u16 pal, bool need_gs_texture);
+	std::shared_ptr<Palette> LookupPaletteObject(const u32* clut, u16 pal, bool need_gs_texture);
 
 	Source* LookupSource(const GIFRegTEX0& TEX0, const GIFRegTEXA& TEXA, const GIFRegCLAMP& CLAMP, const GSVector4i& r, const GSVector2i* lod, const bool possible_shuffle);
 	Source* LookupDepthSource(const GIFRegTEX0& TEX0, const GIFRegTEXA& TEXA, const GIFRegCLAMP& CLAMP, const GSVector4i& r, const bool possible_shuffle, bool palette = false);


### PR DESCRIPTION
### Description of Changes

Current Ico CRC hack is disgusting. New way intercepts it at the move level instead, which is slightly less disgusting, but more importantly, doesn't have an unnecessary readback (bad for perf).

### Rationale behind Changes

Vroom vroom.
Closer to getting rid of GSCrc

### Suggested Testing Steps

Make sure Ico isn't broken ingame.
