### PR TITLE
Flatpak: Add project links to the flathub store page

### DIFF
--- a/.github/workflows/scripts/linux/pcsx2-qt.metainfo.xml.in
+++ b/.github/workflows/scripts/linux/pcsx2-qt.metainfo.xml.in
@@ -13,6 +13,11 @@
   </description>
   <url type="homepage">https://pcsx2.net/</url>
   <url type="bugtracker">https://github.com/PCSX2/pcsx2/issues</url>
+  <url type="donation">https://github.com/sponsors/PCSX2</url>
+  <url type="faq">https://pcsx2.net/docs/</url>
+  <url type="help">https://discord.com/invite/TCz3t9k</url>
+  <url type="translate">https://crowdin.com/project/pcsx2-emulator</url>
+  <url type="vcs-browser">https://github.com/PCSX2/pcsx2</url>
   <screenshots>
     <screenshot type="default">
       <image>https://raw.githubusercontent.com/PCSX2/pcsx2/master/.github/workflows/scripts/linux/flatpak/screenshots/screenshot1.png</image>


### PR DESCRIPTION
### Description of Changes
Now [the flathub page](https://flathub.org/apps/net.pcsx2.PCSX2) should show links for donations, FAQ and translations.

### Rationale behind Changes
More accessibility to those options.

### Suggested Testing Steps
Only applicable after merging; make sure said links appear in [the flathub page](https://flathub.org/apps/net.pcsx2.PCSX2)
