### PR TITLE
Qt: Fix game properties for unscanned files

### DIFF
--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -1126,8 +1126,9 @@ void MainWindow::onGameListEntryContextMenuRequested(const QPoint& point)
 		if (action->isEnabled())
 		{
 			connect(action, &QAction::triggered, [entry]() {
-				SettingsDialog::openGamePropertiesDialog(
-					entry, (entry->type != GameList::EntryType::ELF) ? std::string_view(entry->serial) : std::string_view(), entry->crc);
+				SettingsDialog::openGamePropertiesDialog(entry, entry->title,
+					(entry->type != GameList::EntryType::ELF) ? entry->serial : std::string(),
+					entry->crc);
 			});
 		}
 
@@ -1319,13 +1320,15 @@ void MainWindow::onViewGamePropertiesActionTriggered()
 		return;
 
 	// prefer to use a game list entry, if we have one, that way the summary is populated
-	if (!m_current_disc_path.isEmpty() && m_current_elf_override.isEmpty())
+	if (!m_current_disc_path.isEmpty() || !m_current_elf_override.isEmpty())
 	{
 		auto lock = GameList::GetLock();
-		const GameList::Entry* entry = GameList::GetEntryForPath(m_current_disc_path.toUtf8().constData());
+		const QString& path = (m_current_elf_override.isEmpty() ? m_current_disc_path : m_current_elf_override);
+		const GameList::Entry* entry = GameList::GetEntryForPath(path.toUtf8().constData());
 		if (entry)
 		{
-			SettingsDialog::openGamePropertiesDialog(entry, entry->serial, entry->crc);
+			SettingsDialog::openGamePropertiesDialog(
+				entry, entry->title, m_current_elf_override.isEmpty() ? entry->serial : std::string(), entry->crc);
 			return;
 		}
 	}
@@ -1339,9 +1342,15 @@ void MainWindow::onViewGamePropertiesActionTriggered()
 
 	// can't use serial for ELFs, because they might have a disc set
 	if (m_current_elf_override.isEmpty())
-		SettingsDialog::openGamePropertiesDialog(nullptr, m_current_disc_serial.toStdString(), m_current_disc_crc);
+	{
+		SettingsDialog::openGamePropertiesDialog(
+			nullptr, m_current_title.toStdString(), m_current_disc_serial.toStdString(), m_current_disc_crc);
+	}
 	else
-		SettingsDialog::openGamePropertiesDialog(nullptr, std::string_view(), m_current_disc_crc);
+	{
+		SettingsDialog::openGamePropertiesDialog(
+			nullptr, m_current_title.toStdString(), std::string(), m_current_disc_crc);
+	}
 }
 
 void MainWindow::onGitHubRepositoryActionTriggered()

--- a/pcsx2-qt/Settings/GameCheatSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GameCheatSettingsWidget.cpp
@@ -27,10 +27,8 @@
 
 #include "common/HeterogeneousContainers.h"
 
-GameCheatSettingsWidget::GameCheatSettingsWidget(const GameList::Entry* entry, SettingsDialog* dialog, QWidget* parent)
+GameCheatSettingsWidget::GameCheatSettingsWidget(SettingsDialog* dialog, QWidget* parent)
 	: m_dialog(dialog)
-	, m_serial(entry->serial)
-	, m_crc(entry->crc)
 {
 	m_ui.setupUi(this);
 	QtUtils::ResizeColumnsForTreeView(m_ui.cheatList, {300, 100, -1});
@@ -154,7 +152,7 @@ void GameCheatSettingsWidget::setStateRecursively(QTreeWidgetItem* parent, bool 
 void GameCheatSettingsWidget::reloadList()
 {
 	u32 num_unlabelled_codes = 0;
-	m_patches = Patch::GetPatchInfo(m_serial, m_crc, true, &num_unlabelled_codes);
+	m_patches = Patch::GetPatchInfo(m_dialog->getSerial(), m_dialog->getDiscCRC(), true, &num_unlabelled_codes);
 	m_enabled_patches =
 		m_dialog->getSettingsInterface()->GetStringList(Patch::CHEATS_CONFIG_SECTION, Patch::PATCH_ENABLE_CONFIG_KEY);
 

--- a/pcsx2-qt/Settings/GameCheatSettingsWidget.h
+++ b/pcsx2-qt/Settings/GameCheatSettingsWidget.h
@@ -39,7 +39,7 @@ class GameCheatSettingsWidget : public QWidget
 	Q_OBJECT
 
 public:
-	GameCheatSettingsWidget(const GameList::Entry* entry, SettingsDialog* dialog, QWidget* parent);
+	GameCheatSettingsWidget(SettingsDialog* dialog, QWidget* parent);
 	~GameCheatSettingsWidget();
 
 private Q_SLOTS:
@@ -58,9 +58,6 @@ private:
 
 	Ui::GameCheatSettingsWidget m_ui;
 	SettingsDialog* m_dialog;
-
-	std::string m_serial;
-	u32 m_crc;
 
 	UnorderedStringMap<QTreeWidgetItem*> m_parent_map;
 	std::vector<Patch::PatchInfo> m_patches;

--- a/pcsx2-qt/Settings/GamePatchSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GamePatchSettingsWidget.cpp
@@ -59,10 +59,8 @@ void GamePatchDetailsWidget::onEnabledStateChanged(int state)
 	g_emu_thread->reloadGameSettings();
 }
 
-GamePatchSettingsWidget::GamePatchSettingsWidget(const GameList::Entry* entry, SettingsDialog* dialog, QWidget* parent)
+GamePatchSettingsWidget::GamePatchSettingsWidget(SettingsDialog* dialog, QWidget* parent)
 	: m_dialog(dialog)
-	, m_serial(entry->serial)
-	, m_crc(entry->crc)
 {
 	m_ui.setupUi(this);
 	m_ui.scrollArea->setFrameShape(QFrame::WinPanel);
@@ -86,7 +84,7 @@ void GamePatchSettingsWidget::onReloadClicked()
 void GamePatchSettingsWidget::reloadList()
 {
 	// Patches shouldn't have any unlabelled patch groups, because they're new.
-	std::vector<Patch::PatchInfo> patches = Patch::GetPatchInfo(m_serial, m_crc, false, nullptr);
+	std::vector<Patch::PatchInfo> patches = Patch::GetPatchInfo(m_dialog->getSerial(), m_dialog->getDiscCRC(), false, nullptr);
 	std::vector<std::string> enabled_list =
 		m_dialog->getSettingsInterface()->GetStringList(Patch::PATCHES_CONFIG_SECTION, Patch::PATCH_ENABLE_CONFIG_KEY);
 

--- a/pcsx2-qt/Settings/GamePatchSettingsWidget.h
+++ b/pcsx2-qt/Settings/GamePatchSettingsWidget.h
@@ -52,7 +52,7 @@ class GamePatchSettingsWidget : public QWidget
 	Q_OBJECT
 
 public:
-	GamePatchSettingsWidget(const GameList::Entry* entry, SettingsDialog* dialog, QWidget* parent);
+	GamePatchSettingsWidget(SettingsDialog* dialog, QWidget* parent);
 	~GamePatchSettingsWidget();
 
 private Q_SLOTS:
@@ -63,7 +63,4 @@ private:
 
 	Ui::GamePatchSettingsWidget m_ui;
 	SettingsDialog* m_dialog;
-
-	std::string m_serial;
-	u32 m_crc;
 };

--- a/pcsx2-qt/Settings/SettingsDialog.cpp
+++ b/pcsx2-qt/Settings/SettingsDialog.cpp
@@ -53,15 +53,17 @@ static QList<SettingsDialog*> s_open_game_properties_dialogs;
 
 SettingsDialog::SettingsDialog(QWidget* parent)
 	: QDialog(parent)
-	, m_game_crc(0)
+	, m_disc_crc(0)
 {
 	setupUi(nullptr);
 }
 
-SettingsDialog::SettingsDialog(QWidget* parent, std::unique_ptr<SettingsInterface> sif, const GameList::Entry* game, u32 game_crc)
+SettingsDialog::SettingsDialog(QWidget* parent, std::unique_ptr<SettingsInterface> sif, const GameList::Entry* game,
+	std::string serial, u32 disc_crc)
 	: QDialog(parent)
 	, m_sif(std::move(sif))
-	, m_game_crc(game_crc)
+	, m_serial(std::move(serial))
+	, m_disc_crc(disc_crc)
 {
 	setupUi(game);
 
@@ -77,10 +79,19 @@ void SettingsDialog::setupUi(const GameList::Entry* game)
 
 	if (isPerGameSettings())
 	{
+		QString summary = tr("<strong>Summary</strong><hr>Eventually this will be where we can see patches and compute "
+							 "hashes/verify dumps/etc.");
 		if (game)
 		{
-			addWidget(new GameSummaryWidget(game, this, m_ui.settingsContainer), tr("Summary"), QStringLiteral("file-list-line"),
-				tr("<strong>Summary</strong><hr>Eventually this will be where we can see patches and compute hashes/verify dumps/etc."));
+			addWidget(new GameSummaryWidget(game, this, m_ui.settingsContainer), tr("Summary"),
+				QStringLiteral("file-list-line"), std::move(summary));
+		}
+		else
+		{
+			QLabel* placeholder_label =
+				new QLabel(tr("Summary is unavailable for files not present in game list."), m_ui.settingsContainer);
+			placeholder_label->setAlignment(Qt::AlignLeft | Qt::AlignTop);
+			addWidget(placeholder_label, tr("Summary"), QStringLiteral("file-list-line"), std::move(summary));
 		}
 
 		m_ui.restoreDefaultsButton->setVisible(false);
@@ -108,13 +119,13 @@ void SettingsDialog::setupUi(const GameList::Entry* game)
 		tr("<strong>Emulation Settings</strong><hr>These options determine the configuration of frame pacing and game "
 		   "settings.<br><br>Mouse over an option for additional information."));
 
-	if (isPerGameSettings() && game && game->crc != 0)
+	if (isPerGameSettings())
 	{
-		addWidget(m_game_patch_settings_widget = new GamePatchSettingsWidget(game, this, m_ui.settingsContainer),
+		addWidget(m_game_patch_settings_widget = new GamePatchSettingsWidget(this, m_ui.settingsContainer),
 			tr("Patches"), QStringLiteral("band-aid-line"),
 			tr("<strong>Patches</strong><hr>This section allows you to select optional patches to apply to the game, "
 			   "which may provide performance, visual, or gameplay improvements."));
-		addWidget(m_game_cheat_settings_widget = new GameCheatSettingsWidget(game, this, m_ui.settingsContainer),
+		addWidget(m_game_cheat_settings_widget = new GameCheatSettingsWidget(this, m_ui.settingsContainer),
 			tr("Cheats"), QStringLiteral("cheats-line"),
 			tr("<strong>Cheats</strong><hr>This section allows you to select which cheats you wish to enable. You "
 			   "cannot enable/disable cheats without labels for old-format pnach files, those will automatically "
@@ -517,12 +528,12 @@ void SettingsDialog::removeSettingValue(const char* section, const char* key)
 	}
 }
 
-void SettingsDialog::openGamePropertiesDialog(const GameList::Entry* game, const std::string_view& serial, u32 crc)
+void SettingsDialog::openGamePropertiesDialog(const GameList::Entry* game, const std::string_view& title, std::string serial, u32 disc_crc)
 {
 	// check for an existing dialog with this crc
 	for (SettingsDialog* dialog : s_open_game_properties_dialogs)
 	{
-		if (dialog->m_game_crc == crc)
+		if (dialog->m_disc_crc == disc_crc)
 		{
 			dialog->show();
 			dialog->setFocus();
@@ -530,16 +541,16 @@ void SettingsDialog::openGamePropertiesDialog(const GameList::Entry* game, const
 		}
 	}
 
-	std::string filename(VMManager::GetGameSettingsPath(serial, crc));
+	std::string filename(VMManager::GetGameSettingsPath(serial, disc_crc));
 	std::unique_ptr<INISettingsInterface> sif = std::make_unique<INISettingsInterface>(std::move(filename));
 	if (FileSystem::FileExists(sif->GetFileName().c_str()))
 		sif->Load();
 
 	const QString window_title(tr("%1 [%2]")
-								   .arg(game ? QtUtils::StringViewToQString(game->title) : QStringLiteral("<UNKNOWN>"))
+								   .arg(QtUtils::StringViewToQString(title))
 								   .arg(QtUtils::StringViewToQString(Path::GetFileName(sif->GetFileName()))));
 
-	SettingsDialog* dialog = new SettingsDialog(g_main_window, std::move(sif), game, crc);
+	SettingsDialog* dialog = new SettingsDialog(g_main_window, std::move(sif), game, std::move(serial), disc_crc);
 	dialog->setWindowTitle(window_title);
 	dialog->setModal(false);
 	dialog->show();

--- a/pcsx2-qt/Settings/SettingsDialog.h
+++ b/pcsx2-qt/Settings/SettingsDialog.h
@@ -51,13 +51,15 @@ class SettingsDialog final : public QDialog
 
 public:
 	explicit SettingsDialog(QWidget* parent);
-	SettingsDialog(QWidget* parent, std::unique_ptr<SettingsInterface> sif, const GameList::Entry* game, u32 game_crc);
+	SettingsDialog(QWidget* parent, std::unique_ptr<SettingsInterface> sif, const GameList::Entry* game, std::string serial, u32 disc_crc);
 	~SettingsDialog();
 
-	static void openGamePropertiesDialog(const GameList::Entry* game, const std::string_view& serial, u32 crc);
+	static void openGamePropertiesDialog(const GameList::Entry* game, const std::string_view& title, std::string serial, u32 disc_crc);
 
-	__fi bool isPerGameSettings() const { return static_cast<bool>(m_sif); }
 	__fi SettingsInterface* getSettingsInterface() const { return m_sif.get(); }
+	__fi bool isPerGameSettings() const { return static_cast<bool>(m_sif); }
+	__fi const std::string& getSerial() const { return m_serial; }
+	__fi u32 getDiscCRC() const { return m_disc_crc; }
 
 	__fi InterfaceSettingsWidget* getInterfaceSettingsWidget() const { return m_interface_settings; }
 	__fi GameListSettingsWidget* getGameListSettingsWidget() const { return m_game_list_settings; }
@@ -143,5 +145,6 @@ private:
 	QObject* m_current_help_widget = nullptr;
 	QMap<QObject*, QString> m_widget_help_text_map;
 
-	u32 m_game_crc;
+	std::string m_serial;
+	u32 m_disc_crc;
 };


### PR DESCRIPTION
### Description of Changes

Because CDVD sucks and you can't open two images concurrently, we can't populate the summary page.
But we can still populate the window title, and game fixes/cheats.

### Rationale behind Changes

Closes #9283.

### Suggested Testing Steps

Check game properties on scanned and unscanned files.
