### PR TITLE
VMManager: Notify MTGS in UpdateDiscDetails()

### DIFF
--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -907,6 +907,8 @@ void VMManager::UpdateDiscDetails(bool booting)
 
 	ReportGameChangeToHost();
 	Achievements::GameChanged(s_disc_crc, s_current_crc);
+	if (MTGS::IsOpen())
+		MTGS::SendGameCRC(s_disc_crc);
 	ReloadPINE();
 	UpdateDiscordPresence(Achievements::GetRichPresenceString());
 


### PR DESCRIPTION
### Description of Changes

MTGS was already opened, so it didn't get the new CRC.

### Rationale behind Changes

Closes #9293.

### Suggested Testing Steps

Start big picture then a game, make sure texture replacements load.
