### PR TITLE
GameDB: Adding Cop 2 patches for French & German versions of Kessen II

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -11598,9 +11598,27 @@ SLES-50578:
 SLES-50579:
   name: "Kessen II"
   region: "PAL-F"
+  patches:
+    FD4E2837:
+      content: |-
+        comment=COP2 flag instance patch by refraction
+        // A mac flag check just after a vsub which gets in the way, rearranging.
+        patch=0,EE,00171190,word,48438800
+        patch=0,EE,00171194,word,4BE521AC
+        patch=0,EE,00171198,word,30848000
+        patch=0,EE,0017119c,word,4BE72B3C
 SLES-50580:
   name: "Kessen II"
   region: "PAL-G"
+    patches:
+    33611180:
+      content: |-
+        comment=COP2 flag instance patch by refraction
+        // A mac flag check just after a vsub which gets in the way, rearranging.
+        patch=0,EE,001710e0,word,48438800
+        patch=0,EE,001710e4,word,4BE521AC
+        patch=0,EE,001710e8,word,30848000
+        patch=0,EE,001710ec,word,4BE72B3C
 SLES-50584:
   name: "G1 Jockey"
   region: "PAL-M3"


### PR DESCRIPTION
### Description of Changes
Adding COP2 patches for French & German versions of Kessen II

### Rationale behind Changes
These patches were missing from gamedb. It fixes COP2 timing issues with the game.

### Suggested Testing Steps
Run the French & German versions of this game. Check that weird SPS caused by COP2 timing issues are fixed.