### PR TITLE
GS: Fix sub-page addressing of Z formats

### DIFF
--- a/pcsx2/GS/GSClut.cpp
+++ b/pcsx2/GS/GSClut.cpp
@@ -256,13 +256,14 @@ template <int n>
 void GSClut::WriteCLUT32_CSM2(const GIFRegTEX0& TEX0, const GIFRegTEXCLUT& TEXCLUT)
 {
 	GSOffset off = GSOffset::fromKnownPSM(TEX0.CBP, TEXCLUT.CBW, PSMCT32);
-	auto pa = off.paMulti(m_mem->vm32(), TEXCLUT.COU << 4, TEXCLUT.COV);
+	GSOffset::PAHelper pa = off.paMulti(TEXCLUT.COU << 4, TEXCLUT.COV);
 
+	u32* vm = m_mem->vm32();
 	u16* RESTRICT clut = m_clut + ((TEX0.CSA & 15) << 4);
 
 	for (int i = 0; i < n; i++)
 	{
-		u32 c = *pa.value(i);
+		u32 c = vm[pa.value(i)];
 
 		clut[i] = (u16)(c & 0xffff);
 		clut[i + 256] = (u16)(c >> 16);
@@ -273,13 +274,14 @@ template <int n>
 void GSClut::WriteCLUT16_CSM2(const GIFRegTEX0& TEX0, const GIFRegTEXCLUT& TEXCLUT)
 {
 	GSOffset off = GSOffset::fromKnownPSM(TEX0.CBP, TEXCLUT.CBW, PSMCT16);
-	auto pa = off.paMulti(m_mem->vm16(), TEXCLUT.COU << 4, TEXCLUT.COV);
+	GSOffset::PAHelper pa = off.paMulti(TEXCLUT.COU << 4, TEXCLUT.COV);
 
+	u16* vm = m_mem->vm16();
 	u16* RESTRICT clut = m_clut + (TEX0.CSA << 4);
 
 	for (int i = 0; i < n; i++)
 	{
-		clut[i] = *pa.value(i);
+		clut[i] = vm[pa.value(i)];
 	}
 }
 
@@ -287,13 +289,14 @@ template <int n>
 void GSClut::WriteCLUT16S_CSM2(const GIFRegTEX0& TEX0, const GIFRegTEXCLUT& TEXCLUT)
 {
 	GSOffset off = GSOffset::fromKnownPSM(TEX0.CBP, TEXCLUT.CBW, PSMCT16S);
-	auto pa = off.paMulti(m_mem->vm16(), TEXCLUT.COU << 4, TEXCLUT.COV);
+	GSOffset::PAHelper pa = off.paMulti(TEXCLUT.COU << 4, TEXCLUT.COV);
 
+	u16* vm = m_mem->vm16();
 	u16* RESTRICT clut = m_clut + (TEX0.CSA << 4);
 
 	for (int i = 0; i < n; i++)
 	{
-		clut[i] = *pa.value(i);
+		clut[i] = vm[pa.value(i)];
 	}
 }
 

--- a/pcsx2/GS/GSLocalMemory.cpp
+++ b/pcsx2/GS/GSLocalMemory.cpp
@@ -737,10 +737,7 @@ GSOffset::PageLooper GSOffset::pageLooperForRect(const GSVector4i& rect) const
 	//   e.g. if bp is 1 on PSMCT32, the top left tile uses page 1 if the rect covers the bottom right block, and uses page 0 if the rect covers any block other than the bottom right
 	// - Center tiles (ones that aren't first or last) cover all blocks that the first and last do in a row
 	//   Therefore, if the first tile in a row touches the higher of its two pages, subsequent non-last tiles will at least touch the higher of their pages as well (and same for center to last, etc)
-	//   Therefore, with the exception of row covering two pages in a z swizzle (which could touch e.g. pages 1 and 3 but not 2), all rows touch contiguous pages
-	//   For now, we won't deal with that case as it's rare (only possible with a thin, unaligned rect on an unaligned bp on a z swizzle), and the worst issue looping too many pages could cause is unneccessary cache invalidation
-	//   If code is added later to deal with the case, you'll need to change loopPagesWithBreak's block deduplication code, as it currently works by forcing the page number to increase monotonically which could cause blocks to be missed if e.g. the first row touches 1 and 3, and the second row touches 2 and 4
-	// - Based on the above assumption, we calculate the range of pages a row could touch with full coverage, then add one to the start if the first tile doesn't touch its lower page, and subtract one from the end if the last tile doesn't touch its upper page
+	// - Based on the above, we calculate the range of pages a row could touch with full coverage, then add one to the start if the first tile doesn't touch its lower page, and subtract one from the end if the last tile doesn't touch its upper page
 	// - This is done separately for the first and last rows in the y axis, as they may not have the same coverage as a row in the middle
 
 	PageLooper out;

--- a/pcsx2/GS/GSTables.cpp
+++ b/pcsx2/GS/GSTables.cpp
@@ -37,14 +37,6 @@ static constexpr u8 _blockTable32[4][8] =
 	{ 10, 11, 14, 15, 26, 27, 30, 31}
 };
 
-static constexpr u8 _blockTable32Z[4][8] =
-{
-	{ 24, 25, 28, 29,  8,  9, 12, 13},
-	{ 26, 27, 30, 31, 10, 11, 14, 15},
-	{ 16, 17, 20, 21,  0,  1,  4,  5},
-	{ 18, 19, 22, 23,  2,  3,  6,  7}
-};
-
 static constexpr u8 _blockTable16[8][4] =
 {
 	{  0,  2,  8, 10 },
@@ -69,30 +61,6 @@ static constexpr u8 _blockTable16S[8][4] =
 	{ 13, 15, 29, 31 }
 };
 
-static constexpr u8 _blockTable16Z[8][4] =
-{
-	{ 24, 26, 16, 18 },
-	{ 25, 27, 17, 19 },
-	{ 28, 30, 20, 22 },
-	{ 29, 31, 21, 23 },
-	{  8, 10,  0,  2 },
-	{  9, 11,  1,  3 },
-	{ 12, 14,  4,  6 },
-	{ 13, 15,  5,  7 }
-};
-
-static constexpr u8 _blockTable16SZ[8][4] =
-{
-	{ 24, 26,  8, 10 },
-	{ 25, 27,  9, 11 },
-	{ 16, 18,  0,  2 },
-	{ 17, 19,  1,  3 },
-	{ 28, 30, 12, 14 },
-	{ 29, 31, 13, 15 },
-	{ 20, 22,  4,  6 },
-	{ 21, 23,  5,  7 }
-};
-
 static constexpr u8 _blockTable8[4][8] =
 {
 	{  0,  1,  4,  5, 16, 17, 20, 21},
@@ -114,11 +82,8 @@ static constexpr u8 _blockTable4[8][4] =
 };
 
 constexpr GSSizedBlockSwizzleTable<4, 8> blockTable32   = makeSwizzleTable(_blockTable32);
-constexpr GSSizedBlockSwizzleTable<4, 8> blockTable32Z  = makeSwizzleTable(_blockTable32Z);
 constexpr GSSizedBlockSwizzleTable<8, 4> blockTable16   = makeSwizzleTable(_blockTable16);
 constexpr GSSizedBlockSwizzleTable<8, 4> blockTable16S  = makeSwizzleTable(_blockTable16S);
-constexpr GSSizedBlockSwizzleTable<8, 4> blockTable16Z  = makeSwizzleTable(_blockTable16Z);
-constexpr GSSizedBlockSwizzleTable<8, 4> blockTable16SZ = makeSwizzleTable(_blockTable16SZ);
 constexpr GSSizedBlockSwizzleTable<4, 8> blockTable8    = makeSwizzleTable(_blockTable8);
 constexpr GSSizedBlockSwizzleTable<8, 4> blockTable4    = makeSwizzleTable(_blockTable4);
 
@@ -328,20 +293,14 @@ constexpr GSSizedPixelRowOffsetTable<BlocksWide * ColWidth> makeRowOffsetTable(c
 }
 
 constexpr GSPixelColOffsetTable< 32> pixelColOffset32   = makeColOffsetTable(_blockTable32,   columnTable32);
-constexpr GSPixelColOffsetTable< 32> pixelColOffset32Z  = makeColOffsetTable(_blockTable32Z,  columnTable32);
 constexpr GSPixelColOffsetTable< 64> pixelColOffset16   = makeColOffsetTable(_blockTable16,   columnTable16);
 constexpr GSPixelColOffsetTable< 64> pixelColOffset16S  = makeColOffsetTable(_blockTable16S,  columnTable16);
-constexpr GSPixelColOffsetTable< 64> pixelColOffset16Z  = makeColOffsetTable(_blockTable16Z,  columnTable16);
-constexpr GSPixelColOffsetTable< 64> pixelColOffset16SZ = makeColOffsetTable(_blockTable16SZ, columnTable16);
 constexpr GSPixelColOffsetTable< 64> pixelColOffset8    = makeColOffsetTable(_blockTable8,    columnTable8);
 constexpr GSPixelColOffsetTable<128> pixelColOffset4    = makeColOffsetTable(_blockTable4,    columnTable4);
 // These can't be constexpr due to a GCC bug: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=99901
 CONSTINIT const GSSizedPixelRowOffsetTable< 64> GSTables::_pixelRowOffset32   = makeRowOffsetTable(_blockTable32,   columnTable32, 0);
-CONSTINIT const GSSizedPixelRowOffsetTable< 64> GSTables::_pixelRowOffset32Z  = makeRowOffsetTable(_blockTable32Z,  columnTable32, 0);
 CONSTINIT const GSSizedPixelRowOffsetTable< 64> GSTables::_pixelRowOffset16   = makeRowOffsetTable(_blockTable16,   columnTable16, 0);
 CONSTINIT const GSSizedPixelRowOffsetTable< 64> GSTables::_pixelRowOffset16S  = makeRowOffsetTable(_blockTable16S,  columnTable16, 0);
-CONSTINIT const GSSizedPixelRowOffsetTable< 64> GSTables::_pixelRowOffset16Z  = makeRowOffsetTable(_blockTable16Z,  columnTable16, 0);
-CONSTINIT const GSSizedPixelRowOffsetTable< 64> GSTables::_pixelRowOffset16SZ = makeRowOffsetTable(_blockTable16SZ, columnTable16, 0);
 CONSTINIT const GSSizedPixelRowOffsetTable<128> GSTables::_pixelRowOffset8[2] =
 {
 	makeRowOffsetTable(_blockTable8, columnTable8, 0),
@@ -354,10 +313,7 @@ CONSTINIT const GSSizedPixelRowOffsetTable<128> GSTables::_pixelRowOffset4[2] =
 };
 
 constexpr GSPixelRowOffsetTableList< 64, 0> GSTables::pixelRowOffset32;
-constexpr GSPixelRowOffsetTableList< 64, 0> GSTables::pixelRowOffset32Z;
 constexpr GSPixelRowOffsetTableList< 64, 0> GSTables::pixelRowOffset16;
 constexpr GSPixelRowOffsetTableList< 64, 0> GSTables::pixelRowOffset16S;
-constexpr GSPixelRowOffsetTableList< 64, 0> GSTables::pixelRowOffset16Z;
-constexpr GSPixelRowOffsetTableList< 64, 0> GSTables::pixelRowOffset16SZ;
 constexpr GSPixelRowOffsetTableList<128, 7> GSTables::pixelRowOffset8;
 constexpr GSPixelRowOffsetTableList<128, 7> GSTables::pixelRowOffset4;

--- a/pcsx2/GS/GSTables.h
+++ b/pcsx2/GS/GSTables.h
@@ -102,11 +102,8 @@ makeSwizzleTableList(
 }
 
 extern const GSSizedBlockSwizzleTable<4, 8> blockTable32;
-extern const GSSizedBlockSwizzleTable<4, 8> blockTable32Z;
 extern const GSSizedBlockSwizzleTable<8, 4> blockTable16;
 extern const GSSizedBlockSwizzleTable<8, 4> blockTable16S;
-extern const GSSizedBlockSwizzleTable<8, 4> blockTable16Z;
-extern const GSSizedBlockSwizzleTable<8, 4> blockTable16SZ;
 extern const GSSizedBlockSwizzleTable<4, 8> blockTable8;
 extern const GSSizedBlockSwizzleTable<8, 4> blockTable4;
 extern const u8 columnTable32[8][8];
@@ -118,11 +115,8 @@ extern const u8 clutTableT32I4[16];
 extern const u8 clutTableT16I8[32];
 extern const u8 clutTableT16I4[16];
 extern const GSPixelColOffsetTable< 32> pixelColOffset32;
-extern const GSPixelColOffsetTable< 32> pixelColOffset32Z;
 extern const GSPixelColOffsetTable< 64> pixelColOffset16;
 extern const GSPixelColOffsetTable< 64> pixelColOffset16S;
-extern const GSPixelColOffsetTable< 64> pixelColOffset16Z;
-extern const GSPixelColOffsetTable< 64> pixelColOffset16SZ;
 extern const GSPixelColOffsetTable< 64> pixelColOffset8;
 extern const GSPixelColOffsetTable<128> pixelColOffset4;
 
@@ -145,29 +139,20 @@ constexpr GSPixelRowOffsetTableList<PageWidth, 7> makeRowOffsetTableList(
 struct GSTables
 {
 	static const GSSizedPixelRowOffsetTable< 64> _pixelRowOffset32;
-	static const GSSizedPixelRowOffsetTable< 64> _pixelRowOffset32Z;
 	static const GSSizedPixelRowOffsetTable< 64> _pixelRowOffset16;
 	static const GSSizedPixelRowOffsetTable< 64> _pixelRowOffset16S;
-	static const GSSizedPixelRowOffsetTable< 64> _pixelRowOffset16Z;
-	static const GSSizedPixelRowOffsetTable< 64> _pixelRowOffset16SZ;
 	static const GSSizedPixelRowOffsetTable<128> _pixelRowOffset8[2];
 	static const GSSizedPixelRowOffsetTable<128> _pixelRowOffset4[2];
 
 	static constexpr auto pixelRowOffset32   = makeRowOffsetTableList(&_pixelRowOffset32);
-	static constexpr auto pixelRowOffset32Z  = makeRowOffsetTableList(&_pixelRowOffset32Z);
 	static constexpr auto pixelRowOffset16   = makeRowOffsetTableList(&_pixelRowOffset16);
 	static constexpr auto pixelRowOffset16S  = makeRowOffsetTableList(&_pixelRowOffset16S);
-	static constexpr auto pixelRowOffset16Z  = makeRowOffsetTableList(&_pixelRowOffset16Z);
-	static constexpr auto pixelRowOffset16SZ = makeRowOffsetTableList(&_pixelRowOffset16SZ);
 	static constexpr auto pixelRowOffset8 = makeRowOffsetTableList(&_pixelRowOffset8[0], &_pixelRowOffset8[1]);
 	static constexpr auto pixelRowOffset4 = makeRowOffsetTableList(&_pixelRowOffset4[0], &_pixelRowOffset4[1]);
 };
 
 constexpr auto swizzleTables32   = makeSwizzleTableList(blockTable32,   pixelColOffset32,   GSTables::pixelRowOffset32  );
-constexpr auto swizzleTables32Z  = makeSwizzleTableList(blockTable32Z,  pixelColOffset32Z,  GSTables::pixelRowOffset32Z );
 constexpr auto swizzleTables16   = makeSwizzleTableList(blockTable16,   pixelColOffset16,   GSTables::pixelRowOffset16  );
-constexpr auto swizzleTables16Z  = makeSwizzleTableList(blockTable16Z,  pixelColOffset16Z,  GSTables::pixelRowOffset16Z );
 constexpr auto swizzleTables16S  = makeSwizzleTableList(blockTable16S,  pixelColOffset16S,  GSTables::pixelRowOffset16S );
-constexpr auto swizzleTables16SZ = makeSwizzleTableList(blockTable16SZ, pixelColOffset16SZ, GSTables::pixelRowOffset16SZ);
 constexpr auto swizzleTables8    = makeSwizzleTableList(blockTable8,    pixelColOffset8,    GSTables::pixelRowOffset8   );
 constexpr auto swizzleTables4    = makeSwizzleTableList(blockTable4,    pixelColOffset4,    GSTables::pixelRowOffset4   );

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -1399,22 +1399,23 @@ void GSRendererHW::SwSpriteRender()
 
 	for (int y = 0; y < h; y++, ++sy, ++dy)
 	{
-		const auto& spa = spo.paMulti(m_mem.vm32(), sx, sy);
-		const auto& dpa = dpo.paMulti(m_mem.vm32(), dx, dy);
+		u32* vm = m_mem.vm32();
+		const GSOffset::PAHelper spa = spo.paMulti(sx, sy);
+		const GSOffset::PAHelper dpa = dpo.paMulti(dx, dy);
 
 		ASSERT(w % 2 == 0);
 
 		for (int x = 0; x < w; x += 2)
 		{
-			u32* di = dpa.value(x);
-			ASSERT(di + 1 == dpa.value(x + 1)); // Destination pixel pair is adjacent in memory
+			u32* di = &vm[dpa.value(x)];
+			ASSERT(di + 1 == &vm[dpa.value(x + 1)]); // Destination pixel pair is adjacent in memory
 
 			GSVector4i sc = {};
 			if (texture_mapping_enabled)
 			{
-				const u32* si = spa.value(x);
+				const u32* si = &vm[spa.value(x)];
 				// Read 2 source pixel colors
-				ASSERT(si + 1 == spa.value(x + 1)); // Source pixel pair is adjacent in memory
+				ASSERT(si + 1 == &vm[spa.value(x + 1)]); // Source pixel pair is adjacent in memory
 				sc = GSVector4i::loadl(si).u8to16(); // 0x00AA00BB00GG00RR00aa00bb00gg00rr
 
 				// Apply TFX
@@ -1444,10 +1445,11 @@ void GSRendererHW::SwSpriteRender()
 				// Blending
 				const GSVector4i A = alpha_a == 0 ? sc : alpha_a == 1 ? dc0 : GSVector4i::zero();
 				const GSVector4i B = alpha_b == 0 ? sc : alpha_b == 1 ? dc0 : GSVector4i::zero();
-				const GSVector4i C = alpha_c == 2 ? GSVector4i(alpha_fix).xxxx().ps32() : (alpha_c == 0 ? sc : dc0).yyww() // 0x00AA00BB00AA00BB00aa00bb00aa00bb
-																							  .srl32(16) // 0x000000AA000000AA000000aa000000aa
-																							  .ps32() // 0x00AA00AA00aa00aa00AA00AA00aa00aa
-																							  .xxyy(); // 0x00AA00AA00AA00AA00aa00aa00aa00aa
+				const GSVector4i C = alpha_c == 2 ? GSVector4i(alpha_fix).xxxx().ps32()
+				                                  : (alpha_c == 0 ? sc : dc0).yyww()    // 0x00AA00BB00AA00BB00aa00bb00aa00bb
+				                                                             .srl32(16) // 0x000000AA000000AA000000aa000000aa
+				                                                             .ps32()    // 0x00AA00AA00aa00aa00AA00AA00aa00aa
+				                                                             .xxyy();   // 0x00AA00AA00AA00AA00aa00aa00aa00aa
 				const GSVector4i D = alpha_d == 0 ? sc : alpha_d == 1 ? dc0 : GSVector4i::zero();
 				dc = A.sub16(B).mul16l(C).sra16(7).add16(D); // (((A - B) * C) >> 7) + D, must use sra16 due to signed 16 bit values.
 				// dc alpha channels (dc.u16[3], dc.u16[7]) dirty
@@ -5953,24 +5955,26 @@ void GSRendererHW::ClearGSLocalMemory(const GSOffset& off, const GSVector4i& r, 
 	if (format == 0)
 	{
 		// Based on WritePixel32
+		u32* vm = m_mem.vm32();
 		for (int y = top; y < bottom; y++)
 		{
-			auto pa = off.assertSizesMatch(GSLocalMemory::swizzle32).paMulti(m_mem.vm32(), 0, y);
+			GSOffset::PAHelper pa = off.assertSizesMatch(GSLocalMemory::swizzle32).paMulti(0, y);
 
 			for (int x = left; x < right; x++)
-				*pa.value(x) = vert_color;
+				vm[pa.value(x)] = vert_color;
 		}
 	}
 	else if (format == 1)
 	{
 		// Based on WritePixel24
+		u32* vm = m_mem.vm32();
 		const u32 write_color = vert_color & 0xffffffu;
 		for (int y = top; y < bottom; y++)
 		{
-			auto pa = off.assertSizesMatch(GSLocalMemory::swizzle32).paMulti(m_mem.vm32(), 0, y);
+			GSOffset::PAHelper pa = off.assertSizesMatch(GSLocalMemory::swizzle32).paMulti(0, y);
 
 			for (int x = left; x < right; x++)
-				*pa.value(x) = (*pa.value(x) & 0xff000000u) | write_color;
+				vm[pa.value(x)] = (vm[pa.value(x)] & 0xff000000u) | write_color;
 		}
 	}
 	else if (format == 2)
@@ -5978,12 +5982,13 @@ void GSRendererHW::ClearGSLocalMemory(const GSOffset& off, const GSVector4i& r, 
 		const u16 converted_color = ((vert_color >> 16) & 0x8000) | ((vert_color >> 9) & 0x7C00) | ((vert_color >> 6) & 0x7E0) | ((vert_color >> 3) & 0x1F);
 
 		// Based on WritePixel16
+		u16* vm = m_mem.vm16();
 		for (int y = top; y < bottom; y++)
 		{
-			auto pa = off.assertSizesMatch(GSLocalMemory::swizzle16).paMulti(m_mem.vm16(), 0, y);
+			GSOffset::PAHelper pa = off.assertSizesMatch(GSLocalMemory::swizzle16).paMulti(0, y);
 
 			for (int x = left; x < right; x++)
-				*pa.value(x) = converted_color;
+				vm[pa.value(x)] = converted_color;
 		}
 	}
 }

--- a/pcsx2/GS/Renderers/SW/GSDrawScanline.cpp
+++ b/pcsx2/GS/Renderers/SW/GSDrawScanline.cpp
@@ -1749,11 +1749,11 @@ __ri static void FillRect(const GSOffset& off, const GSVector4i& r, u32 c, u32 m
 
 	for (int y = r.y; y < r.w; y++)
 	{
-		auto pa = off.paMulti(vm, 0, y);
+		GSOffset::PAHelper pa = off.paMulti(0, y);
 
 		for (int x = r.x; x < r.z; x++)
 		{
-			T& d = *pa.value(x);
+			T& d = vm[pa.value(x)];
 			d = (T)(!masked ? c : (c | (d & m)));
 		}
 	}
@@ -1799,11 +1799,11 @@ __ri static void FillBlock(const GSOffset& off, const GSVector4i& r, const GSVec
 
 	for (int y = r.y; y < r.w; y += 8)
 	{
-		auto pa = off.paMulti(vm, 0, y);
+		GSOffset::PAHelper pa = off.paMulti(0, y);
 
 		for (int x = r.x; x < r.z; x += 8 * 4 / sizeof(T))
 		{
-			GSVector4i* RESTRICT p = (GSVector4i*)pa.value(x);
+			GSVector4i* RESTRICT p = (GSVector4i*)&vm[pa.value(x)];
 
 			for (int i = 0; i < 16; i += 4)
 			{


### PR DESCRIPTION
### Description of Changes
They aren't just an offset of the base value like the color formats, but instead an xor of the associated color format

For example, PSMZ32 bp=16, what address is the block at (4, 0)?  The equivalent for CT32 would be (16+16 = 32).  Our old algorithm would do (16+(16^0x18) = 24).  But the actual value is (16+16)^0x18 = 56.

Note: This removes an optimization we had, as it's not compatible with the real GS algorithm.  RIP.  Hopefully it doesn't hurt performance too much, but if it does, I don't think there's much we can do about it.

Fixes #4309
Fixes #804

### Rationale behind Changes
More accurate

### Suggested Testing Steps
- Test [FFX-DepthXor.gs.xz.zip](https://github.com/PCSX2/pcsx2/files/12135947/FFX-DepthXor.gs.xz.zip)
- Test other dumps in case I broke something in the refactor
- Test performance and (maybe) be sad
