### PR TITLE
GameDB: Add Blending Accuracy to Spyro: Enter the Dragonfly

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -12626,6 +12626,7 @@ SLES-51043:
   gsHWFixes:
     mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
     trilinearFiltering: 1
+    recommendedBlendingLevel: 3 # Fixes gem reflections.
 SLES-51044:
   name: "Burnout 2 - Point of Impact"
   region: "PAL-M5"
@@ -44103,6 +44104,7 @@ SLUS-20315:
   gsHWFixes:
     mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
     trilinearFiltering: 1
+    recommendedBlendingLevel: 3 # Fixes gem reflections.
 SLUS-20316:
   name: "WWF SmackDown! - Just Bring It!"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
Added Blending Accuracy 3 for Spyro: Enter the Dragonfly

### Rationale behind Changes
Added Blending Accuracy 3 to fix Gems not shining properly.

### Suggested Testing Steps
Just playing the game will show the visual improvement/correction on gems.
