### PR TITLE
GS/HW: Rewrite invalidation function

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -18834,6 +18834,7 @@ SLES-53028:
   clampModes:
     vuClampMode: 0 # Fixes bump mapping issues.
   gsHWFixes:
+    textureInsideRT: 1 # Fixes post processing.
     getSkipCount: "GSC_HitmanBloodMoney"
 SLES-53029:
   name: "Hitman - Blood Money"
@@ -18841,6 +18842,7 @@ SLES-53029:
   clampModes:
     vuClampMode: 0 # Fixes bump mapping issues.
   gsHWFixes:
+    textureInsideRT: 1 # Fixes post processing.
     getSkipCount: "GSC_HitmanBloodMoney"
 SLES-53030:
   name: "Hitman - Blood Money"
@@ -18848,6 +18850,7 @@ SLES-53030:
   clampModes:
     vuClampMode: 0 # Fixes bump mapping issues.
   gsHWFixes:
+    textureInsideRT: 1 # Fixes post processing.
     getSkipCount: "GSC_HitmanBloodMoney"
 SLES-53031:
   name: "Hitman - Blood Money"
@@ -18855,6 +18858,7 @@ SLES-53031:
   clampModes:
     vuClampMode: 0 # Fixes bump mapping issues.
   gsHWFixes:
+    textureInsideRT: 1 # Fixes post processing.
     getSkipCount: "GSC_HitmanBloodMoney"
 SLES-53032:
   name: "Hitman - Blood Money"
@@ -18862,6 +18866,7 @@ SLES-53032:
   clampModes:
     vuClampMode: 0 # Fixes bump mapping issues.
   gsHWFixes:
+    textureInsideRT: 1 # Fixes post processing.
     getSkipCount: "GSC_HitmanBloodMoney"
 SLES-53035:
   name: "Masters of the Universe - He-Man - Defender of Greyskull"
@@ -52595,6 +52600,8 @@ SLUS-21108:
   compat: 5
   clampModes:
     vuClampMode: 0 # Fixes bump mapping issues
+  gsHWFixes:
+    textureInsideRT: 1 # Fixes post processing.
 SLUS-21109:
   name: "Drive to Survive"
   region: "NTSC-U"
@@ -57855,6 +57862,8 @@ SLUS-29191:
   region: "NTSC-U"
   clampModes:
     vuClampMode: 0 # Fixes bump mapping issues
+  gsHWFixes:
+    textureInsideRT: 1 # Fixes post processing.
 SLUS-29192:
   name: "Test Drive Unlimited [Public Beta Vol.1.0]"
   region: "NTSC-U"

--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -18833,26 +18833,36 @@ SLES-53028:
   region: "PAL-E"
   clampModes:
     vuClampMode: 0 # Fixes bump mapping issues.
+  gsHWFixes:
+    getSkipCount: "GSC_HitmanBloodMoney"
 SLES-53029:
   name: "Hitman - Blood Money"
   region: "PAL-F"
   clampModes:
     vuClampMode: 0 # Fixes bump mapping issues.
+  gsHWFixes:
+    getSkipCount: "GSC_HitmanBloodMoney"
 SLES-53030:
   name: "Hitman - Blood Money"
   region: "PAL-G"
   clampModes:
     vuClampMode: 0 # Fixes bump mapping issues.
+  gsHWFixes:
+    getSkipCount: "GSC_HitmanBloodMoney"
 SLES-53031:
   name: "Hitman - Blood Money"
   region: "PAL-I"
   clampModes:
     vuClampMode: 0 # Fixes bump mapping issues.
+  gsHWFixes:
+    getSkipCount: "GSC_HitmanBloodMoney"
 SLES-53032:
   name: "Hitman - Blood Money"
   region: "PAL-S"
   clampModes:
     vuClampMode: 0 # Fixes bump mapping issues.
+  gsHWFixes:
+    getSkipCount: "GSC_HitmanBloodMoney"
 SLES-53035:
   name: "Masters of the Universe - He-Man - Defender of Greyskull"
   region: "PAL-E"

--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -246,7 +246,6 @@ PAPX-90506:
     eeClampMode: 3 # Fixes textbox.
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
-    partialTargetInvalidation: 1 # Fixes clown suit textures.
 PAPX-90507:
   name: "Official Disc 2003"
   region: "NTSC-J"
@@ -450,7 +449,6 @@ PBPX-95516:
     eeRoundMode: 0 # Fixes Hydrodisplacer behaviour.
   gsHWFixes:
     mipmap: 1
-    partialTargetInvalidation: 1 # Fixes broken pause screen.
 PBPX-95517:
   name: "Network Adapter Start-Up Disc"
   region: "NTSC-U"
@@ -740,7 +738,6 @@ PCPX-98017:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
     mipmap: 1
-    partialTargetInvalidation: 1 # Fixes broken pause screen.
     halfPixelOffset: 2 # Fixes misaligned bloom.
     autoFlush: 2 # Helps fix misaligned bloom.
 PCPX-98041:
@@ -821,7 +818,6 @@ SCAJ-20001:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
     mipmap: 1
-    partialTargetInvalidation: 1 # Fixes broken pause screen.
 SCAJ-20002:
   name: "Gallop Racer 6 - Revolution"
   region: "NTSC-Unk"
@@ -875,7 +871,6 @@ SCAJ-20011:
   region: "NTSC-HK"
   gsHWFixes:
     halfPixelOffset: 2 # Corrects positioning of reflections on suit's surfaces.
-    partialTargetInvalidation: 1 # Fixes corrupted textures.
   memcardFilters:
     - "SCAJ-20011"
     - "SCPS-55014"
@@ -1015,8 +1010,6 @@ SCAJ-20044:
 SCAJ-20045:
   name: "Shadow Tower Abyss"
   region: "NTSC-Unk"
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes broken textures.
 SCAJ-20046:
   name: "Siren"
   region: "NTSC-Unk"
@@ -1079,8 +1072,6 @@ SCAJ-20063:
 SCAJ-20064:
   name: "Nebula - Echo Night"
   region: "NTSC-Unk"
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes broken textures.
 SCAJ-20065:
   name: "EyeToy - Play [with Camera]"
   region: "NTSC-Unk"
@@ -1155,7 +1146,6 @@ SCAJ-20076:
   region: "NTSC-Unk"
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
-    partialTargetInvalidation: 1 # Fixes broken textures.
     recommendedBlendingLevel: 3 # Fixes level brightness.
   memcardFilters:
     - "SCAJ-20076"
@@ -1169,7 +1159,6 @@ SCAJ-20077:
   region: "NTSC-Unk"
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
-    partialTargetInvalidation: 1 # Fixes broken textures.
     recommendedBlendingLevel: 3 # Fixes level brightness.
   memcardFilters:
     - "SCAJ-20076"
@@ -1189,7 +1178,6 @@ SCAJ-20078:
   gsHWFixes:
     halfPixelOffset: 2 # Reduces ghosting.
     preloadFrameData: 1 # Fixes red cracklines on walls.
-    partialTargetInvalidation: 1 # Fixes broken textures.
 SCAJ-20079:
   name: "Katamari Damacy"
   region: "NTSC-Unk"
@@ -1320,7 +1308,6 @@ SCAJ-20105:
   region: "NTSC-Unk"
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
-    partialTargetInvalidation: 1 # Fixes broken textures.
     recommendedBlendingLevel: 3 # Fixes level brightness.
 SCAJ-20107:
   name: "Bakufuu Slash! Kizna Arashi"
@@ -1336,7 +1323,6 @@ SCAJ-20109:
   gsHWFixes:
     mipmap: 1 # Fixes garbage textures in the distance.
     disablePartialInvalidation: 1 # Prevents the situation that a level (Aquatos) doesn't render characters and geometry.
-    partialTargetInvalidation: 1 # Fixes broken pause screen.
     halfPixelOffset: 2 # Fixes misaligned bloom.
     autoFlush: 2 # Helps fix misaligned bloom.
 SCAJ-20110:
@@ -1366,8 +1352,6 @@ SCAJ-20114:
 SCAJ-20115:
   name: "Yoshitsune Eiyuuden"
   region: "NTSC-Unk"
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes broken textures.
 SCAJ-20116:
   name: "Death by Degrees - Tekken - Nina Williams"
   region: "NTSC-C-J"
@@ -1409,7 +1393,6 @@ SCAJ-20121:
   region: "NTSC-Unk"
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
-    partialTargetInvalidation: 1 # Fixes broken textures.
     cpuSpriteRenderBW: 1 # Fixes broken shadow caused by HPO 1.
     cpuSpriteRenderLevel: 2 # Needed for above.
 SCAJ-20122:
@@ -1548,7 +1531,6 @@ SCAJ-20143:
     cpuSpriteRenderBW: 2 # Fixes glow effects, but breaks shadows of certain objects.
     cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects shadow alignment and reduces blurriness.
-    partialTargetInvalidation: 1 # Fixes broken textures.
     recommendedBlendingLevel: 3 # Fixes level and map menu brightness.
 SCAJ-20144:
   name: "Zhuo Hou La 3"
@@ -1627,7 +1609,6 @@ SCAJ-20157:
   gsHWFixes:
     mipmap: 1 # Fixes broken textures.
     disablePartialInvalidation: 1 # Prevents world geometry and some models from vanishing when pausing or opening vendor.
-    partialTargetInvalidation: 1 # Fixes bad textures being read back during scene transitions.
     halfPixelOffset: 2 # Fixes misaligned bloom.
     autoFlush: 2 # Helps fix misaligned bloom.
 SCAJ-20158:
@@ -1660,7 +1641,6 @@ SCAJ-20161:
   gsHWFixes:
     mergeSprite: 1 # Fixes vertical lines in-game.
     preloadFrameData: 1 # Fixes some missing effects.
-    partialTargetInvalidation: 1 # Fixes offset invalidation for post effect.
 SCAJ-20162:
   name: "Rogue Galaxy"
   region: "NTSC-Unk"
@@ -1669,7 +1649,6 @@ SCAJ-20162:
     roundSprite: 1 # Fix mini-map and field menu.
     preloadFrameData: 1 # Fixes corrupt textures especially on water.
     disablePartialInvalidation: 1 # Prevents UI and subtitles from disappearing.
-    partialTargetInvalidation: 1 # Fixes broken character color.
 SCAJ-20163:
   name: "Tales of the Abyss"
   region: "NTSC-Unk"
@@ -1698,7 +1677,6 @@ SCAJ-20167:
   gsHWFixes:
     mergeSprite: 1 # Fixes vertical lines in-game.
     preloadFrameData: 1 # Fixes some missing effects.
-    partialTargetInvalidation: 1 # Fixes offset invalidation for post effect.
 SCAJ-20168:
   name: "Rule of Rose"
   region: "NTSC-Unk"
@@ -1723,8 +1701,6 @@ SCAJ-20171:
 SCAJ-20172:
   name: "Final Fantasy XII"
   region: "NTSC-Unk"
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes broken textures.
 SCAJ-20173:
   name: "Ace Combat Zero - The Belkan War"
   region: "NTSC-Unk"
@@ -1809,8 +1785,6 @@ SCAJ-20185:
 SCAJ-20188:
   name: "Final Fantasy XII - International - Zodiac Job System"
   region: "NTSC-Unk"
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes broken textures.
 SCAJ-20190:
   name: "God of War II"
   region: "NTSC-Unk"
@@ -2059,8 +2033,6 @@ SCCS-40010:
 SCCS-40011:
   name: "Armored Core 2 - Another Age"
   region: "NTSC-C"
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes broken textures.
 SCCS-40014:
   name: "World Soccer Winning Eleven 7 - International"
   region: "NTSC-C"
@@ -2192,8 +2164,6 @@ SCED-50404:
 SCED-50449:
   name: "This is Football 2002 [Demo]"
   region: "PAL-M6"
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes broken loading screen and menus.
 SCED-50450:
   name: "Le Monde des Bleus 2002 [Demo]"
   region: "PAL-F"
@@ -2386,7 +2356,6 @@ SCED-50916:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
     mipmap: 1
-    partialTargetInvalidation: 1 # Fixes broken pause screen.
 SCED-50932:
   name: "Smash Court Tennis - Pro Tournament [Demo]"
   region: "PAL-M5"
@@ -2411,7 +2380,6 @@ SCED-51075:
     eeRoundMode: 0 # Fixes Hydrodisplacer behaviour.
   gsHWFixes:
     mipmap: 1
-    partialTargetInvalidation: 1 # Fixes broken pause screen.
 SCED-51111:
   name: "Magazine Ufficiale PlayStation 2 Demo Italia 08-02"
   region: "PAL-M5"
@@ -3115,7 +3083,6 @@ SCED-52847:
   gsHWFixes:
     mipmap: 1 # Fixes garbage textures in the distance.
     disablePartialInvalidation: 1 # Prevents the situation that a level (Aquatos) doesn't render characters and geometry.
-    partialTargetInvalidation: 1 # Fixes broken pause screen.
     halfPixelOffset: 2 # Fixes misaligned bloom.
     autoFlush: 2 # Helps fix misaligned bloom.
 SCED-52848:
@@ -3913,13 +3880,9 @@ SCES-50241:
 SCES-50244:
   name: "This is Football 2002"
   region: "PAL-M6"
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes broken loading screen and menus.
 SCES-50245:
   name: "Le Monde des Bleus 2002"
   region: "PAL-F"
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes broken loading screen and menus.
 SCES-50246:
   name: "AirBlade"
   region: "PAL-M5"
@@ -3939,7 +3902,6 @@ SCES-50295:
   compat: 5
   gsHWFixes:
     mipmap: 2 # Fixes mipmapping.
-    partialTargetInvalidation: 1 # Fixes textures.
     trilinearFiltering: 1 # Smoothes out mipmapping.
     halfPixelOffset: 2 # Distance is less blurry, game has reduced LOD so it will still look blurry.
 SCES-50300:
@@ -4212,7 +4174,6 @@ SCES-50916:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
     mipmap: 1
-    partialTargetInvalidation: 1 # Fixes broken pause screen.
 SCES-50917:
   name: "Sly Raccoon"
   region: "PAL-M5"
@@ -4373,7 +4334,6 @@ SCES-51190:
     eeClampMode: 3 # Fixes textbox.
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
-    partialTargetInvalidation: 1 # Fixes clown suit textures.
 SCES-51224:
   name: "War of the Monsters"
   region: "PAL-E"
@@ -4449,7 +4409,6 @@ SCES-51607:
   gsHWFixes:
     mipmap: 1
     autoFlush: 2
-    partialTargetInvalidation: 1 # Fixes broken pause screen.
   dynaPatches:
     - pattern:
         - { offset: 0x0, value: 0x0280202d }
@@ -4788,7 +4747,6 @@ SCES-52456:
   gsHWFixes:
     mipmap: 1 # Fixes garbage textures in the distance.
     disablePartialInvalidation: 1 # Prevents the situation that a level (Aquatos) doesn't render characters and geometry.
-    partialTargetInvalidation: 1 # Fixes broken pause screen.
     halfPixelOffset: 2 # Fixes misaligned bloom.
     autoFlush: 2 # Helps fix misaligned bloom.
   memcardFilters: # Reads Ratchet 1 & 2 data.
@@ -5004,7 +4962,6 @@ SCES-53285:
   gsHWFixes:
     mipmap: 1 # Fixes broken textures.
     disablePartialInvalidation: 1 # Prevents world geometry and some models from vanishing when pausing or opening vendor.
-    partialTargetInvalidation: 1 # Fixes bad textures being read back during scene transitions.
     halfPixelOffset: 2 # Fixes misaligned bloom.
     autoFlush: 2 # Helps fix misaligned bloom.
 SCES-53286:
@@ -5030,7 +4987,6 @@ SCES-53300:
     vuClampMode: 3 # Fixes SPS ingame and prevents flickering or invisible characters.
   gsHWFixes:
     minimumBlendingLevel: 4 # Mitigates grayer text font in bottom left.
-    partialTargetInvalidation: 1 # Fixes loading screen picture.
 SCES-53304:
   name: "Buzz! The Music Quiz"
   region: "PAL-E"
@@ -5201,7 +5157,6 @@ SCES-53851:
   gsHWFixes:
     mergeSprite: 1 # Fixes vertical lines in-game.
     preloadFrameData: 1 # Fixes some missing effects.
-    partialTargetInvalidation: 1 # Fixes offset invalidation for post effect.
   patches:
     default:
       content: |-
@@ -5447,7 +5402,6 @@ SCES-54477:
     vuClampMode: 3 # Fixes SPS ingame and prevents flickering or invisible characters.
   gsHWFixes:
     recommendedBlendingLevel: 4 # Mitigates grayer text font in bottom left but stuff in front can lower or increase opacity.
-    partialTargetInvalidation: 1 # Fixes loading screen picture.
 SCES-54496:
   name: "Buzz! The Mega Quiz"
   region: "PAL-E"
@@ -5498,7 +5452,6 @@ SCES-54552:
     roundSprite: 1 # Fix mini-map and field menu.
     preloadFrameData: 1 # Fixes corrupt textures especially on water.
     disablePartialInvalidation: 1 # Prevents UI and subtitles from disappearing.
-    partialTargetInvalidation: 1 # Fixes broken character color.
   patches:
     CBB4B383:
       content: |-
@@ -6110,7 +6063,6 @@ SCKA-20011:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
     mipmap: 1
-    partialTargetInvalidation: 1 # Fixes broken pause screen.
 SCKA-20012:
   name: "Arc the Lad - Jeongryeongui Hwanghon"
   region: "NTSC-K"
@@ -6125,7 +6077,6 @@ SCKA-20014:
     eeClampMode: 3 # Fixes textbox.
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
-    partialTargetInvalidation: 1 # Fixes clown suit textures.
 SCKA-20015:
   name: "Time Crisis 3"
   region: "NTSC-K"
@@ -6267,7 +6218,6 @@ SCKA-20037:
   gsHWFixes:
     mipmap: 1 # Fixes garbage textures in the distance.
     disablePartialInvalidation: 1 # Prevents the situation that a level (Aquatos) doesn't render characters and geometry.
-    partialTargetInvalidation: 1 # Fixes broken pause screen.
     halfPixelOffset: 2 # Fixes misaligned bloom.
     autoFlush: 2 # Helps fix misaligned bloom.
   memcardFilters:
@@ -6331,7 +6281,6 @@ SCKA-20047:
   region: "NTSC-K"
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
-    partialTargetInvalidation: 1 # Fixes broken textures.
     recommendedBlendingLevel: 3 # Fixes level brightness.
   memcardFilters:
     - "SCKA-20047"
@@ -6419,7 +6368,6 @@ SCKA-20060:
   gsHWFixes:
     mipmap: 1 # Fixes broken textures.
     disablePartialInvalidation: 1 # Prevents world geometry and some models from vanishing when pausing or opening vendor.
-    partialTargetInvalidation: 1 # Fixes bad textures being read back during scene transitions.
     halfPixelOffset: 2 # Fixes misaligned bloom.
     autoFlush: 2 # Helps fix misaligned bloom.
 SCKA-20061:
@@ -6461,7 +6409,6 @@ SCKA-20064:
     vuClampMode: 3 # Fixes SPS ingame and prevents flickering or invisible characters.
   gsHWFixes:
     minimumBlendingLevel: 4 # Mitigates grayer text font in bottom left.
-    partialTargetInvalidation: 1 # Fixes loading screen picture.
 SCKA-20065:
   name: "Urban Reign"
   region: "NTSC-K"
@@ -6488,7 +6435,6 @@ SCKA-20069:
   gsHWFixes:
     mergeSprite: 1 # Fixes vertical lines in-game.
     preloadFrameData: 1 # Fixes some missing effects.
-    partialTargetInvalidation: 1 # Fixes offset invalidation for post effect.
 SCKA-20070:
   name: "Ace Combat Zero - The Belkan War"
   region: "NTSC-K"
@@ -6518,8 +6464,6 @@ SCKA-20072:
 SCKA-20073:
   name: "Final Fantasy XII"
   region: "NTSC-K"
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes broken textures.
 SCKA-20074:
   name: "Sly Cooper 2 - Goedo Brothers Daejakjeon!"
   region: "NTSC-K"
@@ -6753,8 +6697,6 @@ SCKA-20137:
 SCKA-20138:
   name: "Final Fantasy XII [Ultimate Hits International Zodiac Job System]"
   region: "NTSC-K"
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes broken textures.
 SCKA-20139:
   name: "SD Gundam - G Generation Wars"
   region: "NTSC-K"
@@ -7046,7 +6988,6 @@ SCPS-15004:
   region: "NTSC-J"
   gsHWFixes:
     mipmap: 2 # Fixes mipmapping.
-    partialTargetInvalidation: 1 # Fixes textures.
     trilinearFiltering: 1 # Smoothes out mipmapping.
     halfPixelOffset: 2 # Distance is less blurry, game has reduced LOD so it will still look blurry.
 SCPS-15005:
@@ -7181,7 +7122,6 @@ SCPS-15033:
     eeClampMode: 3 # Fixes textbox.
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
-    partialTargetInvalidation: 1 # Fixes clown suit textures.
 SCPS-15034:
   name: "This is Football 2003"
   region: "NTSC-J"
@@ -7200,7 +7140,6 @@ SCPS-15037:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
     mipmap: 1
-    partialTargetInvalidation: 1 # Fixes broken pause screen.
 SCPS-15038:
   name: "Operator's Side"
   region: "NTSC-J"
@@ -7297,7 +7236,6 @@ SCPS-15056:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
     mipmap: 1
-    partialTargetInvalidation: 1 # Fixes broken pause screen.
   memcardFilters:
     - "SCPS-15056"
     - "SCPS-15037"
@@ -7446,7 +7384,6 @@ SCPS-15084:
   gsHWFixes:
     mipmap: 1 # Fixes garbage textures in the distance.
     disablePartialInvalidation: 1 # Prevents the situation that a level (Aquatos) doesn't render characters and geometry.
-    partialTargetInvalidation: 1 # Fixes broken pause screen.
     halfPixelOffset: 2 # Fixes misaligned bloom.
     autoFlush: 2 # Helps fix misaligned bloom.
   memcardFilters:
@@ -7561,7 +7498,6 @@ SCPS-15099:
   gsHWFixes:
     mipmap: 1 # Fixes broken textures.
     disablePartialInvalidation: 1 # Prevents world geometry and some models from vanishing when pausing or opening vendor.
-    partialTargetInvalidation: 1 # Fixes bad textures being read back during scene transitions.
     halfPixelOffset: 2 # Fixes misaligned bloom.
     autoFlush: 2 # Helps fix misaligned bloom.
 SCPS-15100:
@@ -7572,7 +7508,6 @@ SCPS-15100:
   gsHWFixes:
     mipmap: 1 # Fixes broken textures.
     disablePartialInvalidation: 1 # Prevents world geometry and some models from vanishing when pausing or opening vendor.
-    partialTargetInvalidation: 1 # Fixes bad textures being read back during scene transitions.
     halfPixelOffset: 2 # Fixes misaligned bloom.
     autoFlush: 2 # Helps fix misaligned bloom.
 SCPS-15101:
@@ -7586,7 +7521,6 @@ SCPS-15102:
     roundSprite: 1 # Fix mini-map and field menu.
     preloadFrameData: 1 # Fixes corrupt textures especially on water.
     disablePartialInvalidation: 1 # Prevents UI and subtitles from disappearing.
-    partialTargetInvalidation: 1 # Fixes broken character color.
 SCPS-15103:
   name: "Gunparade Orchestra - Shiro no Shou - Aomori Penguin Densetsu [Limited Edition]"
   region: "NTSC-J"
@@ -7609,7 +7543,6 @@ SCPS-15106:
   gsHWFixes:
     mergeSprite: 1 # Fixes vertical lines in-game.
     preloadFrameData: 1 # Fixes some missing effects.
-    partialTargetInvalidation: 1 # Fixes offset invalidation for post effect.
   patches:
     626552EB:
       content: |-
@@ -7723,7 +7656,6 @@ SCPS-17013:
     roundSprite: 1 # Fix mini-map and field menu.
     preloadFrameData: 1 # Fixes corrupt textures especially on water.
     disablePartialInvalidation: 1 # Prevents UI and subtitles from disappearing.
-    partialTargetInvalidation: 1 # Fixes broken character color.
   patches:
     CDEE4B19:
       content: |-
@@ -7801,7 +7733,6 @@ SCPS-19203:
   region: "NTSC-J"
   gsHWFixes:
     mipmap: 2 # Fixes mipmapping.
-    partialTargetInvalidation: 1 # Fixes textures.
     trilinearFiltering: 1 # Smoothes out mipmapping.
     halfPixelOffset: 2 # Distance is less blurry, game has reduced LOD so it will still look blurry.
 SCPS-19204:
@@ -7843,7 +7774,6 @@ SCPS-19211:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
     mipmap: 1
-    partialTargetInvalidation: 1 # Fixes broken pause screen.
 SCPS-19213:
   name: "Operator's Side [PlayStation 2 The Best] [with Microphone]"
   region: "NTSC-J"
@@ -7861,7 +7791,6 @@ SCPS-19215:
     eeClampMode: 3 # Fixes textbox.
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
-    partialTargetInvalidation: 1 # Fixes clown suit textures.
 SCPS-19251:
   name: "Wild ARMs - Alter Code F [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -7902,7 +7831,6 @@ SCPS-19254:
     roundSprite: 1 # Fix mini-map and field menu.
     preloadFrameData: 1 # Fixes corrupt textures especially on water.
     disablePartialInvalidation: 1 # Prevents UI and subtitles from disappearing.
-    partialTargetInvalidation: 1 # Fixes broken character color.
 SCPS-19301:
   name: "Minna no Golf 4 [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -7913,7 +7841,6 @@ SCPS-19302:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
     mipmap: 1
-    partialTargetInvalidation: 1 # Fixes broken pause screen.
 SCPS-19303:
   name: "Boku no Natsuyasumi 2 [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -7952,7 +7879,6 @@ SCPS-19306:
     eeClampMode: 3 # Fixes textbox.
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
-    partialTargetInvalidation: 1 # Fixes clown suit textures.
 SCPS-19307:
   name: "Popolocrois - The First Adventure [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -7967,7 +7893,6 @@ SCPS-19309:
   gsHWFixes:
     mipmap: 1 # Fixes garbage textures in the distance.
     disablePartialInvalidation: 1 # Prevents the situation that a level (Aquatos) doesn't render characters and geometry.
-    partialTargetInvalidation: 1 # Fixes broken pause screen.
     halfPixelOffset: 2 # Fixes misaligned bloom.
     autoFlush: 2 # Helps fix misaligned bloom.
 SCPS-19310:
@@ -7977,7 +7902,6 @@ SCPS-19310:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
     mipmap: 1
-    partialTargetInvalidation: 1 # Fixes broken pause screen.
 SCPS-19311:
   name: "Saru Get You 3 [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -8023,7 +7947,6 @@ SCPS-19316:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
     mipmap: 1
-    partialTargetInvalidation: 1 # Fixes broken pause screen.
 SCPS-19317:
   name: "Ratchet & Clank 2 - Going Commando [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -8031,7 +7954,6 @@ SCPS-19317:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
     mipmap: 1
-    partialTargetInvalidation: 1 # Fixes broken pause screen.
     autoFlush: 2
   memcardFilters:
     - "SCAJ-20001"
@@ -8067,7 +7989,6 @@ SCPS-19321:
   gsHWFixes:
     mipmap: 1 # Fixes broken textures.
     disablePartialInvalidation: 1 # Prevents world geometry and some models from vanishing when pausing or opening vendor.
-    partialTargetInvalidation: 1 # Fixes bad textures being read back during scene transitions.
     halfPixelOffset: 2 # Fixes misaligned bloom.
     autoFlush: 2 # Helps fix misaligned bloom.
 SCPS-19322:
@@ -8126,7 +8047,6 @@ SCPS-19326:
   gsHWFixes:
     mergeSprite: 1 # Fixes vertical lines in-game.
     preloadFrameData: 1 # Fixes some missing effects.
-    partialTargetInvalidation: 1 # Fixes offset invalidation for post effect.
 SCPS-19327:
   name: "Ape Escape 3 [PlayStation 2 the Best - Reprint]"
   region: "NTSC-J"
@@ -8142,7 +8062,6 @@ SCPS-19328:
   gsHWFixes:
     mipmap: 1 # Fixes broken textures.
     disablePartialInvalidation: 1 # Prevents world geometry and some models from vanishing when pausing or opening vendor.
-    partialTargetInvalidation: 1 # Fixes bad textures being read back during scene transitions.
     halfPixelOffset: 2 # Fixes misaligned bloom.
     autoFlush: 2 # Helps fix misaligned bloom.
 SCPS-19329:
@@ -8287,7 +8206,6 @@ SCPS-55014:
   gsHWFixes:
     halfPixelOffset: 2 # Corrects positioning of reflections on suit's surfaces.
     roundSprite: 2 # Reduces garbage on the UI whilst upscaling.
-    partialTargetInvalidation: 1 # Fixes corrupted textures.
 SCPS-55015:
   name: "Zettai Zetsumei Toshi"
   region: "NTSC-J"
@@ -8332,8 +8250,6 @@ SCPS-55024:
   region: "NTSC-J"
   clampModes:
     eeClampMode: 2 # Fixes Abnormal AI behavior.
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes broken textures.
   memcardFilters:
     - "SCPS-55024"
     - "SLPS-25007"
@@ -8450,7 +8366,6 @@ SCPS-55048:
     eeClampMode: 3 # Fixes textbox.
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
-    partialTargetInvalidation: 1 # Fixes clown suit textures.
 SCPS-55049:
   name: "King of Fighters 2000, The"
   region: "NTSC-J"
@@ -8689,7 +8604,6 @@ SCUS-97111:
   compat: 5
   gsHWFixes:
     mipmap: 2 # Fixes mipmapping.
-    partialTargetInvalidation: 1 # Fixes textures.
     trilinearFiltering: 1 # Smoothes out mipmapping.
     halfPixelOffset: 2 # Distance is less blurry, game has reduced LOD so it will still look blurry.
 SCUS-97112:
@@ -8866,7 +8780,6 @@ SCUS-97152:
   region: "NTSC-U"
   gsHWFixes:
     mipmap: 2 # Fixes mipmapping.
-    partialTargetInvalidation: 1 # Fixes textures.
     trilinearFiltering: 1 # Smoothes out mipmapping.
     halfPixelOffset: 2 # Distance is less blurry, game has reduced LOD so it will still look blurry.
 SCUS-97153:
@@ -8951,8 +8864,6 @@ SCUS-97171:
 SCUS-97172:
   name: "World Tour Soccer 2002"
   region: "NTSC-U"
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes broken loading screen and menus.
 SCUS-97173:
   name: "Jet X2O"
   region: "NTSC-U"
@@ -9013,8 +8924,6 @@ SCUS-97191:
 SCUS-97192:
   name: "World Tour Soccer 2002 [Demo]"
   region: "NTSC-U"
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes broken loading screen and menus.
 SCUS-97194:
   name: "NFL GameDay 2003"
   region: "NTSC-U"
@@ -9041,7 +8950,6 @@ SCUS-97199:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
     mipmap: 1
-    partialTargetInvalidation: 1 # Fixes broken pause screen.
 SCUS-97200:
   name: "Kiosk Demo Disc 2.05"
   region: "NTSC-U"
@@ -9082,7 +8990,6 @@ SCUS-97209:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
     mipmap: 1
-    partialTargetInvalidation: 1 # Fixes broken pause screen.
 SCUS-97210:
   name: "Sly Cooper and the Thievius Raccoonus [Demo]"
   region: "NTSC-U"
@@ -9104,7 +9011,6 @@ SCUS-97213:
     eeClampMode: 3 # Fixes textbox.
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
-    partialTargetInvalidation: 1 # Fixes clown suit textures.
 SCUS-97214:
   name: "NCAA GameBreaker 2003"
   region: "NTSC-U"
@@ -9163,7 +9069,6 @@ SCUS-97229:
     eeClampMode: 3 # Fixes textbox.
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
-    partialTargetInvalidation: 1 # Fixes clown suit textures.
 SCUS-97230:
   name: "SOCOM - U.S. Navy SEALs"
   region: "NTSC-U"
@@ -9208,7 +9113,6 @@ SCUS-97240:
     eeRoundMode: 0 # Fixes Hydrodisplacer behaviour.
   gsHWFixes:
     mipmap: 1
-    partialTargetInvalidation: 1 # Fixes broken pause screen.
 SCUS-97241:
   name: "Official U.S. PlayStation Magazine Demo Disc 066"
   region: "NTSC-U"
@@ -9314,7 +9218,6 @@ SCUS-97268:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
     mipmap: 1
-    partialTargetInvalidation: 1 # Fixes broken pause screen.
     autoFlush: 2
   memcardFilters:
     - "SCUS-97268"
@@ -9414,7 +9317,6 @@ SCUS-97322:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
     mipmap: 1
-    partialTargetInvalidation: 1 # Fixes broken pause screen.
     autoFlush: 2
 SCUS-97323:
   name: "Ratchet & Clank 2 - Going Commando [Retail Employees Demo]"
@@ -9423,7 +9325,6 @@ SCUS-97323:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
     mipmap: 1
-    partialTargetInvalidation: 1 # Fixes broken pause screen.
     autoFlush: 2
 SCUS-97324:
   name: "Kiosk Demo Disc 2.11"
@@ -9525,7 +9426,6 @@ SCUS-97353:
   gsHWFixes:
     mipmap: 1 # Fixes garbage textures in the distance.
     disablePartialInvalidation: 1 # Prevents the situation that a level (Aquatos) doesn't render characters and geometry.
-    partialTargetInvalidation: 1 # Fixes broken pause screen.
     halfPixelOffset: 2 # Fixes misaligned bloom.
     autoFlush: 2 # Helps fix misaligned bloom.
   memcardFilters:
@@ -9723,7 +9623,6 @@ SCUS-97411:
   gsHWFixes:
     mipmap: 1 # Fixes garbage textures in the distance.
     disablePartialInvalidation: 1 # Prevents the situation that a level (Aquatos) doesn't render characters and geometry.
-    partialTargetInvalidation: 1 # Fixes broken pause screen.
     halfPixelOffset: 2 # Fixes misaligned bloom.
     autoFlush: 2 # Helps fix misaligned bloom.
 SCUS-97412:
@@ -9745,7 +9644,6 @@ SCUS-97413:
   gsHWFixes:
     mipmap: 1 # Fixes garbage textures in the distance.
     disablePartialInvalidation: 1 # Prevents the situation that a level (Aquatos) doesn't render characters and geometry.
-    partialTargetInvalidation: 1 # Fixes broken pause screen.
     halfPixelOffset: 2 # Fixes misaligned bloom.
     autoFlush: 2 # Helps fix misaligned bloom.
 SCUS-97414:
@@ -9955,7 +9853,6 @@ SCUS-97465:
   gsHWFixes:
     mipmap: 1 # Fixes broken textures.
     disablePartialInvalidation: 1 # Prevents world geometry and some models from vanishing when pausing or opening vendor.
-    partialTargetInvalidation: 1 # Fixes bad textures being read back during scene transitions.
     halfPixelOffset: 2 # Fixes misaligned bloom.
     autoFlush: 2 # Helps fix misaligned bloom.
 SCUS-97466:
@@ -10002,7 +9899,6 @@ SCUS-97474:
     vuClampMode: 3 # Fixes SPS ingame and prevents flickering or invisible characters.
   gsHWFixes:
     minimumBlendingLevel: 4 # Mitigates grayer text font in bottom left.
-    partialTargetInvalidation: 1 # Fixes loading screen picture.
   patches:
     75ED4282:
       content: |-
@@ -10018,7 +9914,6 @@ SCUS-97475:
     vuClampMode: 3 # Fixes SPS ingame and prevents flickering or invisible characters.
   gsHWFixes:
     minimumBlendingLevel: 4 # Mitigates grayer text font in bottom left.
-    partialTargetInvalidation: 1 # Fixes loading screen picture.
   patches:
     314F0905:
       content: |-
@@ -10079,7 +9974,6 @@ SCUS-97485:
   gsHWFixes:
     mipmap: 1 # Fixes broken textures.
     disablePartialInvalidation: 1 # Prevents world geometry and some models from vanishing when pausing or opening vendor.
-    partialTargetInvalidation: 1 # Fixes bad textures being read back during scene transitions.
     halfPixelOffset: 2 # Fixes misaligned bloom.
     autoFlush: 2 # Helps fix misaligned bloom.
 SCUS-97486:
@@ -10103,7 +9997,6 @@ SCUS-97487:
   gsHWFixes:
     mipmap: 1 # Fixes broken textures.
     disablePartialInvalidation: 1 # Prevents world geometry and some models from vanishing when pausing or opening vendor.
-    partialTargetInvalidation: 1 # Fixes bad textures being read back during scene transitions.
     halfPixelOffset: 2 # Fixes misaligned bloom.
     autoFlush: 2 # Helps fix misaligned bloom.
 SCUS-97488:
@@ -10127,7 +10020,6 @@ SCUS-97489:
     vuClampMode: 3 # Fixes SPS ingame and prevents flickering or invisible characters.
   gsHWFixes:
     minimumBlendingLevel: 4 # Mitigates grayer text font in bottom left.
-    partialTargetInvalidation: 1 # Fixes loading screen picture.
 SCUS-97490:
   name: "Rogue Galaxy"
   region: "NTSC-U"
@@ -10137,7 +10029,6 @@ SCUS-97490:
     roundSprite: 1 # Fix mini-map and field menu.
     preloadFrameData: 1 # Fixes corrupt textures especially on water.
     disablePartialInvalidation: 1 # Prevents UI and subtitles from disappearing.
-    partialTargetInvalidation: 1 # Fixes broken character color.
   patches:
     0643F90C:
       content: |-
@@ -10239,7 +10130,6 @@ SCUS-97513:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
     mipmap: 1
-    partialTargetInvalidation: 1 # Fixes broken pause screen.
     autoFlush: 2
 SCUS-97514:
   name: "ATV Offroad Fury 3 [Greatest Hits]"
@@ -10278,7 +10168,6 @@ SCUS-97518:
   gsHWFixes:
     mipmap: 1 # Fixes garbage textures in the distance.
     disablePartialInvalidation: 1 # Prevents the situation that a level (Aquatos) doesn't render characters and geometry.
-    partialTargetInvalidation: 1 # Fixes broken pause screen.
     halfPixelOffset: 2 # Fixes misaligned bloom.
     autoFlush: 2 # Helps fix misaligned bloom.
 SCUS-97519:
@@ -10357,7 +10246,6 @@ SCUS-97545:
     vuClampMode: 3 # Fixes SPS ingame and prevents flickering or invisible characters.
   gsHWFixes:
     recommendedBlendingLevel: 4 # Mitigates grayer text font in bottom left but stuff in front can lower or increase opacity.
-    partialTargetInvalidation: 1 # Fixes loading screen picture.
   patches:
     D7CFDCCF:
       content: |-
@@ -10408,7 +10296,6 @@ SCUS-97560:
     vuClampMode: 3 # Fixes SPS ingame and prevents flickering or invisible characters.
   gsHWFixes:
     recommendedBlendingLevel: 4 # Mitigates grayer text font in bottom left but stuff in front can lower or increase opacity.
-    partialTargetInvalidation: 1 # Fixes loading screen picture.
 SCUS-97563:
   name: "Gran Turismo 4"
   region: "NTSC-U"
@@ -10433,7 +10320,6 @@ SCUS-97572:
     roundSprite: 1 # Fix mini-map and field menu.
     preloadFrameData: 1 # Fixes corrupt textures especially on water.
     disablePartialInvalidation: 1 # Prevents UI and subtitles from disappearing.
-    partialTargetInvalidation: 1 # Fixes broken character color.
 SCUS-97574:
   name: "Jak X - Combat Racing [Greatest Hits]"
   region: "NTSC-U"
@@ -11000,7 +10886,6 @@ SLED-50117:
     - InstantDMAHack # Fixes broken half-bottom artifacts.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
-    partialTargetInvalidation: 1 # Fixes cutscene blur effects.
 SLED-50286:
   name: "Red Faction [Demo]"
   region: "PAL-E"
@@ -11125,8 +11010,6 @@ SLED-51364:
 SLED-51380:
   name: "Zone of the Enders - The 2nd Runner [Demo]"
   region: "PAL"
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes cutscene blur effects.
 SLED-51472:
   name: "Tom Clancy's Splinter Cell"
   region: "PAL-Unk"
@@ -11801,8 +11684,6 @@ SLES-50050:
   name: "Evergrace"
   region: "PAL-M5"
   compat: 5
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes corrupted textures.
 SLES-50051:
   name: "Eternal Ring"
   region: "PAL-E"
@@ -11810,7 +11691,6 @@ SLES-50051:
     eeRoundMode: 0 # Fixes FPU errors causing instant death in Limestone Cave.
   gsHWFixes:
     disablePartialInvalidation: 1 # Fixes graphics issues.
-    partialTargetInvalidation: 1 # Fixes corrupted textures.
 SLES-50052:
   name: "Pool Master"
   region: "PAL-M3"
@@ -11835,18 +11715,12 @@ SLES-50056:
 SLES-50057:
   name: "Dynasty Warriors 2"
   region: "PAL-E"
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes invisible text.
 SLES-50058:
   name: "Dynasty Warriors 2"
   region: "PAL-F"
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes invisible text.
 SLES-50059:
   name: "Dynasty Warriors 2"
   region: "PAL-G"
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes invisible text.
 SLES-50060:
   name: "International Superstar Soccer"
   region: "PAL-M3"
@@ -12230,8 +12104,6 @@ SLES-50224:
   compat: 5
   speedHacks:
     mtvu: 0 # Prevents broken textures and graphics.
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes broken textures.
 SLES-50225:
   name: "Escape from Monkey Island"
   region: "PAL-E"
@@ -12587,7 +12459,6 @@ SLES-50383:
     - InstantDMAHack # Fixes broken half-bottom artifacts.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
-    partialTargetInvalidation: 1 # Fixes cutscene blur effects.
 SLES-50384:
   name: "Metal Gear Solid 2 - Sons of Liberty"
   region: "PAL-I"
@@ -12595,7 +12466,6 @@ SLES-50384:
     - InstantDMAHack # Fixes broken half-bottom artifacts.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
-    partialTargetInvalidation: 1 # Fixes cutscene blur effects.
 SLES-50385:
   name: "Metal Gear Solid 2 - Sons of Liberty"
   region: "PAL-S"
@@ -12603,7 +12473,6 @@ SLES-50385:
     - InstantDMAHack # Fixes broken half-bottom artifacts.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
-    partialTargetInvalidation: 1 # Fixes cutscene blur effects.
 SLES-50386:
   name: "Crash Bandicoot - The Wrath of Cortex"
   region: "PAL-M6"
@@ -13164,8 +13033,6 @@ SLES-50677:
   compat: 5
   clampModes:
     eeClampMode: 3 # Fixes invisible characters in various scenes.
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes black screens on judgement wheel.
 SLES-50679:
   name: "Tenchu 3 - Wrath of Heaven"
   region: "PAL-E"
@@ -13564,8 +13431,6 @@ SLES-50822:
   region: "PAL-M3"
   clampModes:
     eeClampMode: 3 # Fixes invisible characters in various scenes.
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes black screens on judgement wheel.
 SLES-50826:
   name: "Star Wars - Clone Wars"
   region: "PAL-E"
@@ -13825,9 +13690,7 @@ SLES-50905:
   region: "PAL-E"
   clampModes:
     eeClampMode: 2 # Fixes Abnormal AI behavior.
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes broken textures.
-  #  Save import option was removed from PAL release.
+  # Save import option was removed from PAL release.
 SLES-50906:
   name: "Master Rally"
   region: "PAL-M6"
@@ -13848,7 +13711,6 @@ SLES-50920:
   gsHWFixes:
     preloadFrameData: 1 # Fixes invisible lava, there is another issue that needs skipdraw 1 for blurry font but it removes much brightness.
     halfPixelOffset: 2 # Fixes font rendering.
-    partialTargetInvalidation: 1 # Fixes broken textures.
   patches:
     401F4726:
       content: |-
@@ -14242,8 +14104,6 @@ SLES-51113:
   compat: 5
   gameFixes:
     - InstantDMAHack # Fixes cut-off text.
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes cutscene blur effects.
 SLES-51114:
   name: "Pro Evolution Soccer 2"
   region: "PAL-M5"
@@ -14741,8 +14601,6 @@ SLES-51282:
 SLES-51283:
   name: "WWE SmackDown! Shut Your Mouth"
   region: "PAL-E"
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes menu corruption.
 SLES-51284:
   name: "Contra - Shattered Soldier"
   region: "PAL-M3"
@@ -14750,8 +14608,6 @@ SLES-51285:
   name: "Spongebob SquarePants - Revenge of the Flying Dutchman"
   region: "PAL-E"
   compat: 5
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes game returning to main menu on selecting new game.
 SLES-51286:
   name: "X-Men 2 - Wolverine's Revenge"
   region: "PAL-E"
@@ -15054,7 +14910,6 @@ SLES-51399:
   gsHWFixes:
     halfPixelOffset: 2 # Corrects positioning of reflections on suit's surfaces.
     roundSprite: 2 # Reduces garbage on the UI whilst upscaling.
-    partialTargetInvalidation: 1 # Fixes corrupted textures.
 SLES-51400:
   name: "Tenchu - Wrath of Heaven"
   region: "PAL-S"
@@ -15351,8 +15206,6 @@ SLES-51595:
 SLES-51600:
   name: "WWE Crush Hour"
   region: "PAL-E"
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes menu corruption.
 SLES-51602:
   name: "All-Star Baseball 2004 featuring Derek Jeter"
   region: "PAL-E"
@@ -15415,8 +15268,6 @@ SLES-51630:
 SLES-51633:
   name: "Racing Simulation 3"
   region: "PAL-M5"
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes crash during loading screen due to bad download.
 SLES-51636:
   name: "XGRA - Extreme G Racing Association"
   region: "PAL-M5"
@@ -16384,8 +16235,6 @@ SLES-52036:
   name: "WWE SmackDown! - Here Comes the Pain!"
   region: "PAL-E"
   compat: 5
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes menu corruption.
 SLES-52038:
   name: "Terminator 3 - Rebellion der Maschinen"
   region: "PAL-G"
@@ -16670,7 +16519,6 @@ SLES-52203:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Corrects positioning of reflections on suit's surfaces.
-    partialTargetInvalidation: 1 # Fixes corrupted textures.
   memcardFilters:
     - "SLES-51399"
     - "SLES-52203"
@@ -18072,8 +17920,6 @@ SLES-52779:
 SLES-52781:
   name: "WWE SmackDown! vs. RAW"
   region: "PAL-E"
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes menu corruption.
 SLES-52782:
   name: "Call of Duty - Finest Hour"
   region: "PAL-E"
@@ -18187,7 +18033,6 @@ SLES-52812:
     trilinearFiltering: 1
     halfPixelOffset: 2 # Fixes bloom misalignment when upscaling.
     cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling.
-    partialTargetInvalidation: 1 # Helps align bloom when upscaling.
 SLES-52813:
   name: "Incredibles, The"
   region: "PAL-NL-F"
@@ -18197,7 +18042,6 @@ SLES-52813:
     trilinearFiltering: 1
     halfPixelOffset: 2 # Fixes bloom misalignment when upscaling.
     cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling.
-    partialTargetInvalidation: 1 # Helps align bloom when upscaling.
 SLES-52814:
   name: "Incredibles, The"
   region: "PAL-I"
@@ -18206,7 +18050,6 @@ SLES-52814:
     trilinearFiltering: 1
     halfPixelOffset: 2 # Fixes bloom misalignment when upscaling.
     cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling.
-    partialTargetInvalidation: 1 # Helps align bloom when upscaling.
 SLES-52815:
   name: "Disney-Pixar's The Incredibles"
   region: "PAL-G"
@@ -18215,7 +18058,6 @@ SLES-52815:
     trilinearFiltering: 1
     halfPixelOffset: 2 # Fixes bloom misalignment when upscaling.
     cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling.
-    partialTargetInvalidation: 1 # Helps align bloom when upscaling.
 SLES-52816:
   name: "Increíbles, Los"
   region: "PAL-S"
@@ -18224,7 +18066,6 @@ SLES-52816:
     trilinearFiltering: 1
     halfPixelOffset: 2 # Fixes bloom misalignment when upscaling.
     cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling.
-    partialTargetInvalidation: 1 # Helps align bloom when upscaling.
 SLES-52820:
   name: "Incredibles, The"
   region: "PAL-SC"
@@ -18233,7 +18074,6 @@ SLES-52820:
     trilinearFiltering: 1
     halfPixelOffset: 2 # Fixes bloom misalignment when upscaling.
     cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling.
-    partialTargetInvalidation: 1 # Helps align bloom when upscaling.
 SLES-52821:
   name: "Incredibles, The"
   region: "PAL-P"
@@ -18242,7 +18082,6 @@ SLES-52821:
     trilinearFiltering: 1
     halfPixelOffset: 2 # Fixes bloom misalignment when upscaling.
     cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling.
-    partialTargetInvalidation: 1 # Helps align bloom when upscaling.
 SLES-52822:
   name: "Prince of Persia - Warrior Within"
   region: "PAL-M6"
@@ -18399,7 +18238,6 @@ SLES-52895:
     trilinearFiltering: 1
     halfPixelOffset: 2 # Fixes bloom misalignment when upscaling.
     cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling.
-    partialTargetInvalidation: 1 # Helps align bloom when upscaling.
 SLES-52896:
   name: "Spongebob SquarePants - The Movie"
   region: "PAL-F-G"
@@ -18408,7 +18246,6 @@ SLES-52896:
     trilinearFiltering: 1
     halfPixelOffset: 2 # Fixes bloom misalignment when upscaling.
     cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling.
-    partialTargetInvalidation: 1 # Helps align bloom when upscaling.
 SLES-52897:
   name: "Spongebob SquarePants - The Movie"
   region: "PAL-I"
@@ -18417,7 +18254,6 @@ SLES-52897:
     trilinearFiltering: 1
     halfPixelOffset: 2 # Fixes bloom misalignment when upscaling.
     cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling.
-    partialTargetInvalidation: 1 # Helps align bloom when upscaling.
 SLES-52898:
   name: "King of Fighters - Maximum Impact"
   region: "PAL-E-JP"
@@ -18668,7 +18504,6 @@ SLES-52985:
     trilinearFiltering: 1
     halfPixelOffset: 2 # Fixes bloom misalignment when upscaling.
     cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling.
-    partialTargetInvalidation: 1 # Helps align bloom when upscaling.
 SLES-52986:
   name: "Bob Esponja - La Película"
   region: "PAL-S"
@@ -18677,7 +18512,6 @@ SLES-52986:
     trilinearFiltering: 1
     halfPixelOffset: 2 # Fixes bloom misalignment when upscaling.
     cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling.
-    partialTargetInvalidation: 1 # Helps align bloom when upscaling.
 SLES-52988:
   name: "Mega Man X8"
   region: "PAL-M5"
@@ -19449,7 +19283,6 @@ SLES-53300:
     vuClampMode: 3 # Fixes SPS ingame and prevents flickering or invisible characters.
   gsHWFixes:
     minimumBlendingLevel: 4 # Mitigates grayer text font in bottom left.
-    partialTargetInvalidation: 1 # Fixes loading screen picture.
 SLES-53301:
   name: "Bomberman Hardball"
   region: "PAL-E"
@@ -19669,7 +19502,6 @@ SLES-53390:
     vu1ClampMode: 0 # Fixes Spider-Man's eye texture colour.
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes textures.
-    partialTargetInvalidation: 1 # Fixes texture distortion.
     mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
     trilinearFiltering: 1
     autoFlush: 2 # Fixes shadow alignment along with HPO Special (Normal looks better but causes top left glitches).
@@ -19681,7 +19513,6 @@ SLES-53391:
     vu1ClampMode: 0 # Fixes Spider-Man's eye texture colour.
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes textures.
-    partialTargetInvalidation: 1 # Fixes texture distortion.
     mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
     trilinearFiltering: 1
     autoFlush: 2 # Fixes shadow alignment along with HPO Special (Normal looks better but causes top left glitches).
@@ -19758,7 +19589,6 @@ SLES-53411:
   gsHWFixes:
     halfPixelOffset: 2 # Reduces ghosting.
     preloadFrameData: 1 # Fixes red cracklines on walls.
-    partialTargetInvalidation: 1 # Fixes broken textures.
 SLES-53413:
   name: "Rebel Raiders - Operation Nighthawk"
   region: "PAL-M5"
@@ -19766,8 +19596,6 @@ SLES-53414:
   name: "Echo Night - Beyond"
   region: "PAL-E"
   compat: 5
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes broken textures.
 SLES-53415:
   name: "Call of Duty 2 - Big Red One"
   region: "PAL-E"
@@ -19926,7 +19754,6 @@ SLES-53473:
     trilinearFiltering: 1
     halfPixelOffset: 2 # Fixes bloom misalignment when upscaling.
     cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling.
-    partialTargetInvalidation: 1 # Helps align bloom when upscaling.
 SLES-53474:
   name: "Incredibles, The - Rise of the Underminer"
   region: "PAL-M3"
@@ -19935,7 +19762,6 @@ SLES-53474:
     trilinearFiltering: 1
     halfPixelOffset: 2 # Fixes bloom misalignment when upscaling.
     cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling.
-    partialTargetInvalidation: 1 # Helps align bloom when upscaling.
 SLES-53480:
   name: "Harvest Moon - A Wonderful Life [Special Edition]"
   region: "PAL-E"
@@ -20470,7 +20296,6 @@ SLES-53616:
     eeRoundMode: 0 # Fixes scene switching in intro.
   gsHWFixes:
     cpuSpriteRenderBW: 1 # Fixes textures.
-    partialTargetInvalidation: 1 # Needed due to procedural textures overlapping EE writes.
     preloadFrameData: 1 # Fixes numberplates and ensures above targets are valid.
     roundSprite: 1 # Fixes lines in some post-effects.
     gpuTargetCLUT: 1 # Fixes light occlusion.
@@ -20485,7 +20310,6 @@ SLES-53617:
     eeRoundMode: 0 # Fixes scene switching in intro.
   gsHWFixes:
     cpuSpriteRenderBW: 1 # Fixes textures.
-    partialTargetInvalidation: 1 # Needed due to procedural textures overlapping EE writes.
     preloadFrameData: 1 # Fixes numberplates and ensures above targets are valid.
     roundSprite: 1 # Fixes lines in some post-effects.
     gpuTargetCLUT: 1 # Fixes light occlusion.
@@ -20500,7 +20324,6 @@ SLES-53618:
     eeRoundMode: 0 # Fixes scene switching in intro.
   gsHWFixes:
     cpuSpriteRenderBW: 1 # Fixes textures.
-    partialTargetInvalidation: 1 # Needed due to procedural textures overlapping EE writes.
     preloadFrameData: 1 # Fixes numberplates and ensures above targets are valid.
     roundSprite: 1 # Fixes lines in some post-effects.
     gpuTargetCLUT: 1 # Fixes light occlusion.
@@ -20636,7 +20459,6 @@ SLES-53658:
     trilinearFiltering: 1
     halfPixelOffset: 2 # Fixes bloom misalignment when upscaling.
     cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling.
-    partialTargetInvalidation: 1 # Helps align bloom when upscaling.
 SLES-53659:
   name: "Brothers In Arms - Earned in Blood"
   region: "PAL-M5"
@@ -20664,7 +20486,6 @@ SLES-53672:
     vu1ClampMode: 0 # Fixes Fixes Spider-Man's eye texture colour.
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes textures.
-    partialTargetInvalidation: 1 # Fixes texture distortion.
     mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
     trilinearFiltering: 1
     autoFlush: 2 # Fixes shadow alignment along with HPO Special (Normal looks better but causes top left glitches).
@@ -20673,13 +20494,9 @@ SLES-53676:
   name: "WWE SmackDown! vs. RAW 2006"
   region: "PAL-E"
   compat: 5
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes menu corruption.
 SLES-53677:
   name: "WWE SmackDown! vs. RAW 2006"
   region: "PAL-I"
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes menu corruption.
 SLES-53682:
   name: "James Pond - Codename Robocod"
   region: "PAL-E"
@@ -21117,7 +20934,6 @@ SLES-53819:
   region: "PAL-E"
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
-    partialTargetInvalidation: 1 # Fixes broken textures.
     recommendedBlendingLevel: 3 # Fixes level brightness.
   memcardFilters:
     - "SLES-53819"
@@ -21130,7 +20946,6 @@ SLES-53820:
     cpuSpriteRenderBW: 2 # Fixes glow effects, but breaks shadows of certain objects.
     cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects shadow alignment and reduces blurriness.
-    partialTargetInvalidation: 1 # Fixes broken textures.
     recommendedBlendingLevel: 3 # Fixes level and map menu brightness.
 SLES-53821:
   name: "Radio Helicopter II"
@@ -21145,7 +20960,6 @@ SLES-53825:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 1 # Reduces blurriness.
-    partialTargetInvalidation: 1 # Fixes corruption after taking a picture.
 SLES-53826:
   name: "Tom Clancy's Splinter Cell - Double Agent"
   region: "PAL-M5"
@@ -21328,7 +21142,6 @@ SLES-53904:
   clampModes:
     vuClampMode: 0 # Fixes black artifacts on tracks
   gsHWFixes:
-    partialTargetInvalidation: 1
     mipmap: 1
     autoFlush: 2
     estimateTextureRegion: 1 # Improves performance.
@@ -22450,29 +22263,19 @@ SLES-54354:
   name: "Final Fantasy XII"
   region: "PAL-E"
   compat: 5
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes broken textures.
 SLES-54355:
   name: "Final Fantasy XII"
   region: "PAL-F"
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes broken textures.
 SLES-54356:
   name: "Final Fantasy XII"
   region: "PAL-G"
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes broken textures.
 SLES-54357:
   name: "Final Fantasy XII"
   region: "PAL-I"
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes broken textures.
 SLES-54358:
   name: "Final Fantasy XII"
   region: "PAL-S"
   compat: 5
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes broken textures.
 SLES-54359:
   name: "Legend of Spyro, The - A New Beginning"
   region: "PAL-M6"
@@ -22868,14 +22671,10 @@ SLES-54487:
 SLES-54488:
   name: "WWE SmackDown! vs. RAW 2007"
   region: "PAL-I"
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes broken text.
 SLES-54489:
   name: "WWE SmackDown! vs. RAW 2007"
   region: "PAL-E"
   compat: 5
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes broken text.
 SLES-54490:
   name: "God Hand"
   region: "PAL-M5"
@@ -23689,8 +23488,6 @@ SLES-54793:
   name: "WWE SmackDown vs. Raw 2008"
   region: "PAL-E"
   compat: 5
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes broken text.
 SLES-54795:
   name: "Falling Stars"
   region: "PAL-M6"
@@ -23908,8 +23705,6 @@ SLES-54878:
 SLES-54879:
   name: "WWE SmackDown vs. Raw 2008"
   region: "PAL-M5"
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes broken text.
 SLES-54880:
   name: "NBA 2K8"
   region: "PAL-M5"
@@ -24108,28 +23903,24 @@ SLES-54947:
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
     halfPixelOffset: 1 # Fixes bloom misalignment.
-    partialTargetInvalidation: 1 # Fixes black sqaures effect.
 SLES-54948:
   name: "Dogz"
   region: "PAL-M9"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
     halfPixelOffset: 1 # Fixes bloom misalignment.
-    partialTargetInvalidation: 1 # Fixes black sqaures effect.
 SLES-54949:
   name: "Catz"
   region: "PAL-M6"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
     halfPixelOffset: 1 # Fixes bloom misalignment.
-    partialTargetInvalidation: 1 # Fixes black sqaures effect.
 SLES-54950:
   name: "Catz"
   region: "PAL-M9"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
     halfPixelOffset: 1 # Fixes bloom misalignment.
-    partialTargetInvalidation: 1 # Fixes black sqaures effect.
 SLES-54951:
   name: "Ben 10 - Protector of Earth"
   region: "PAL-M5"
@@ -24976,14 +24767,10 @@ SLES-55249:
 SLES-55250:
   name: "WWE SmackDown vs. Raw 2009"
   region: "PAL-A"
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes broken text.
 SLES-55251:
   name: "WWE SmackDown vs. Raw 2009"
   region: "PAL-M5"
   compat: 5
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes broken text.
 SLES-55252:
   name: "NHL 2K9"
   region: "PAL-M5"
@@ -25604,8 +25391,6 @@ SLES-55545:
   name: "WWE SmackDown vs. Raw 2010"
   region: "PAL-M5"
   compat: 5
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes broken text.
 SLES-55546:
   name: "Secret Saturdays, The - Beasts of the 5th Sun"
   region: "PAL-M5"
@@ -25758,8 +25543,6 @@ SLES-55635:
   name: "WWE SmackDown vs. Raw 2011"
   region: "PAL-M4"
   compat: 5
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes broken text.
 SLES-55636:
   name: "Pro Evolution Soccer 2011"
   region: "PAL-M5"
@@ -25790,8 +25573,6 @@ SLES-55648:
   name: "WWE All-Stars"
   region: "PAL-M5"
   compat: 5
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes menu corruption.
 SLES-55652:
   name: "FIFA 12"
   region: "PAL-M4"
@@ -25869,7 +25650,6 @@ SLES-82009:
     - InstantDMAHack # Fixes broken half-bottom artifacts.
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
-    partialTargetInvalidation: 1 # Fixes cutscene blur effects.
     recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
 SLES-82010:
   name: "Metal Gear Solid 2, Document of"
@@ -26005,7 +25785,6 @@ SLES-82036:
   region: "PAL-M5"
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
-    partialTargetInvalidation: 1 # Fixes broken textures.
     recommendedBlendingLevel: 3 # Fixes level brightness.
   memcardFilters:
     - "SLES-82036"
@@ -26015,7 +25794,6 @@ SLES-82037:
   region: "PAL-M5"
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
-    partialTargetInvalidation: 1 # Fixes broken textures.
     recommendedBlendingLevel: 3 # Fixes level brightness.
   memcardFilters:
     - "SLES-82036"
@@ -26272,8 +26050,6 @@ SLKA-15032:
 SLKA-15033:
   name: "Princess Maker 2"
   region: "NTSC-K"
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes full screen C32->C16 frame invalidation.
 SLKA-15034:
   name: "Kinnikuman Generations"
   region: "NTSC-K"
@@ -26400,8 +26176,6 @@ SLKA-25029:
 SLKA-25030:
   name: "WWE SmackDown! Shut Your Mouth"
   region: "NTSC-K"
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes menu corruption.
 SLKA-25031:
   name: "Tom Clancy's Ghost Recon"
   region: "NTSC-K"
@@ -26443,7 +26217,6 @@ SLKA-25041:
   region: "NTSC-K"
   gsHWFixes:
     halfPixelOffset: 2 # Corrects positioning of reflections on suit's surfaces.
-    partialTargetInvalidation: 1 # Fixes corrupted textures.
   memcardFilters:
     - "SLKA-25041"
     - "SLPM-67524"
@@ -26539,8 +26312,6 @@ SLKA-25066:
   name: "Zone of the Enders - The 2nd Runner SE"
   region: "NTSC-K"
   compat: 5
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes cutscene blur effects.
 SLKA-25067:
   name: "Unlimited Saga"
   region: "NTSC-K"
@@ -26707,8 +26478,6 @@ SLKA-25115:
 SLKA-25116:
   name: "WWE SmackDown! Here Comes the Pain"
   region: "NTSC-K"
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes menu corruption.
 SLKA-25117:
   name: "World Soccer Winning Eleven 7 International"
   region: "NTSC-K"
@@ -26876,8 +26645,6 @@ SLKA-25167:
 SLKA-25168:
   name: "WWE SmackDown! vs. RAW 2007"
   region: "NTSC-K"
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes broken text.
 SLKA-25169:
   name: "UEFA Euro 2004 - Portugal"
   region: "NTSC-K"
@@ -26896,7 +26663,6 @@ SLKA-25171:
   gsHWFixes:
     halfPixelOffset: 2 # Reduces ghosting.
     preloadFrameData: 1 # Fixes red cracklines on walls.
-    partialTargetInvalidation: 1 # Fixes broken textures.
 SLKA-25172:
   name: "Harry Potter and the Prisoner of Azkaban"
   region: "NTSC-K"
@@ -27001,7 +26767,6 @@ SLKA-25201:
   region: "NTSC-K"
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
-    partialTargetInvalidation: 1 # Fixes broken textures.
     recommendedBlendingLevel: 3 # Fixes level brightness.
   memcardFilters:
     - "SLKA-25201"
@@ -27011,7 +26776,6 @@ SLKA-25202:
   region: "NTSC-K"
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
-    partialTargetInvalidation: 1 # Fixes broken textures.
     recommendedBlendingLevel: 3 # Fixes level brightness.
   memcardFilters:
     - "SLKA-25201"
@@ -27146,7 +26910,6 @@ SLKA-25226:
     trilinearFiltering: 1
     halfPixelOffset: 2 # Fixes bloom misalignment when upscaling.
     cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling.
-    partialTargetInvalidation: 1 # Helps align bloom when upscaling.
 SLKA-25227:
   name: "Neo Contra"
   region: "NTSC-K"
@@ -27181,8 +26944,6 @@ SLKA-25237:
 SLKA-25240:
   name: "WWE SmackDown! Shut Your Mouth"
   region: "NTSC-K"
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes menu corruption.
 SLKA-25241:
   name: "Need for Speed - Underground 2"
   region: "NTSC-K"
@@ -27200,8 +26961,6 @@ SLKA-25243:
 SLKA-25244:
   name: "WWE SmackDown! vs. Raw"
   region: "NTSC-K"
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes menu corruption.
 SLKA-25245:
   name: "Spongebob SquarePants - Movin' With Friends"
   region: "NTSC-K"
@@ -27254,8 +27013,6 @@ SLKA-25258:
   name: "Story of the Hero Yoshitsune, The"
   region: "NTSC-K"
   compat: 5
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes broken textures.
 SLKA-25259:
   name: "Swords of Destiny"
   region: "NTSC-K"
@@ -27296,7 +27053,6 @@ SLKA-25270:
   region: "NTSC-K"
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
-    partialTargetInvalidation: 1 # Fixes broken textures.
     cpuSpriteRenderBW: 1 # Fixes broken shadow caused by HPO 1.
     cpuSpriteRenderLevel: 2 # Needed for above.
 SLKA-25271:
@@ -27481,8 +27237,6 @@ SLKA-25317:
 SLKA-25318:
   name: "WWE SmackDown! vs. RAW 2006"
   region: "NTSC-K"
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes menu corruption.
 SLKA-25319:
   name: "Spongebob SquarePants - Lights, Camera, PANTS"
   region: "NTSC-K"
@@ -27690,8 +27444,6 @@ SLKA-25364:
 SLKA-25365:
   name: "WWE Smack Down Vs RAW 2008"
   region: "NTSC-K"
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes broken text.
 SLKA-25366:
   name: "Naruto - Uzumaki Chronicles 2" # Naruto: Konoha Spirits!!"
   region: "NTSC-K"
@@ -27932,8 +27684,6 @@ SLKA-25447:
 SLKA-25448:
   name: "WWE SmackDown vs. Raw 2009"
   region: "NTSC-K"
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes menu corruption.
 SLKA-25449:
   name: "Call of Duty - World at War - Final Fronts"
   region: "NTSC-K"
@@ -27943,8 +27693,6 @@ SLKA-25450:
 SLKA-25451:
   name: "WWE SmackDown! vs. Raw 2008"
   region: "NTSC-K"
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes broken text.
 SLKA-25452:
   name: "Viewtiful Joe - A New Hope"
   region: "NTSC-K"
@@ -27975,8 +27723,6 @@ SLKA-25459:
 SLKA-25463:
   name: "WWE SmackDown vs. Raw 2010"
   region: "NTSC-K"
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes menu corruption.
 SLKA-25464:
   name: "FIFA 10"
   region: "NTSC-K"
@@ -28030,7 +27776,6 @@ SLKA-35001:
     - InstantDMAHack # Fixes broken half-bottom artifacts.
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
-    partialTargetInvalidation: 1 # Fixes cutscene blur effects.
     recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
 SLKA-35003:
   name: "Sakura Taisen - Atsuki Chishioni"
@@ -28140,8 +27885,6 @@ SLPM-55021:
 SLPM-55022:
   name: "Final Fantasy XII [Ultimate Hits]"
   region: "NTSC-J"
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes broken textures.
 SLPM-55023:
   name: "Dragon Quest & Final Fantasy in Itadaki Street Special"
   region: "NTSC-J"
@@ -28664,8 +28407,6 @@ SLPM-55209:
 SLPM-55210:
   name: "Final Fantasy XII International Zodiac Job System [Ultimate Hits]"
   region: "NTSC-J"
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes broken textures.
 SLPM-55211:
   name: "Pachislot Higurashi no Naku Koro ni Matsuri"
   region: "NTSC-J"
@@ -28776,8 +28517,6 @@ SLPM-55250:
 SLPM-55251:
   name: "WWE SmackDown vs. Raw 2009"
   region: "NTSC-J"
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes menu corruption.
 SLPM-55252:
   name: "Pro Yakyuu Spirits 2010"
   region: "NTSC-J"
@@ -28980,8 +28719,6 @@ SLPM-60127:
   region: "NTSC-J"
   speedHacks:
     mtvu: 0 # Prevents broken textures and graphics.
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes broken textures.
 SLPM-60128:
   name: "Sidewinder Max"
   region: "NTSC-J"
@@ -29157,8 +28894,6 @@ SLPM-60195:
 SLPM-60197:
   name: "Exciting Pro Wres 4"
   region: "NTSC-J"
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes menu corruption.
 SLPM-60198:
   name: "MotoGP 3 [Trial]"
   region: "NTSC-J"
@@ -29683,8 +29418,6 @@ SLPM-61097:
 SLPM-61098:
   name: "Exciting Pro Wres 6 - WWE SmackDown! vs. Raw"
   region: "NTSC-J"
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes menu corruption.
 SLPM-61100:
   name: "Juuouki - Project Altered Beast"
   region: "NTSC-J"
@@ -29755,7 +29488,6 @@ SLPM-61118:
     cpuSpriteRenderBW: 2 # Fixes glow effects, but breaks shadows of certain objects.
     cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects shadow alignment and reduces blurriness.
-    partialTargetInvalidation: 1 # Fixes broken textures.
     recommendedBlendingLevel: 3 # Fixes level and map menu brightness.
 SLPM-61119:
   name: "Armored Core - Last Raven [Trial]"
@@ -29764,7 +29496,6 @@ SLPM-61119:
     cpuSpriteRenderBW: 2 # Fixes glow effects, but breaks shadows of certain objects.
     cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects shadow alignment and reduces blurriness.
-    partialTargetInvalidation: 1 # Fixes broken textures.
     recommendedBlendingLevel: 3 # Fixes level and map menu brightness.
 SLPM-61120:
   name: "Drag-on Dragoon 2 - Fuuin no Aka, Haitoku no Kuro [Trial Version]"
@@ -29939,8 +29670,6 @@ SLPM-62004:
 SLPM-62005:
   name: "Shin Sangoku Musou"
   region: "NTSC-J"
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes invisible text.
 SLPM-62006:
   name: "Eisei Meijin 4"
   region: "NTSC-J"
@@ -30057,7 +29786,6 @@ SLPM-62043:
     - InstantDMAHack # Fixes broken half-bottom artifacts.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
-    partialTargetInvalidation: 1 # Fixes cutscene blur effects.
 SLPM-62044:
   name: "RC Revenge Pro"
   region: "NTSC-J"
@@ -31710,8 +31438,6 @@ SLPM-62567:
 SLPM-62568:
   name: "Shin Sangoku Musou [Koei The Best]"
   region: "NTSC-J"
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes invisible text.
 SLPM-62569:
   name: "PC Genjin [Hudson The Best]"
   region: "NTSC-J"
@@ -32117,8 +31843,6 @@ SLPM-62700:
 SLPM-62701:
   name: "Princess Maker 2 [Best Hit Selection]"
   region: "NTSC-J"
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes full screen C32->C16 frame invalidation.
 SLPM-62702:
   name: "Momotaro Densetsu 15"
   region: "NTSC-J"
@@ -32162,8 +31886,6 @@ SLPM-62713:
 SLPM-62714:
   name: "Shin Sangoku Musou Series Collection Joukan"
   region: "NTSC-J"
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes invisible text.
 SLPM-62715:
   name: "Shin Sangoku Musou Series Collection Joukan Saikyou Data"
   region: "NTSC-J"
@@ -32366,8 +32088,6 @@ SLPM-62785:
 SLPM-64501:
   name: "Jin Samguk Mussang"
   region: "NTSC-K"
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes invisible text.
 SLPM-64502:
   name: "Winback"
   region: "NTSC-K"
@@ -32817,7 +32537,6 @@ SLPM-65077:
     - InstantDMAHack # Fixes broken half-bottom artifacts.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
-    partialTargetInvalidation: 1 # Fixes cutscene blur effects.
   memcardFilters:
     - "SLPM-65078"
     - "SLPM-65077"
@@ -32828,7 +32547,6 @@ SLPM-65078:
     - InstantDMAHack # Fixes broken half-bottom artifacts.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
-    partialTargetInvalidation: 1 # Fixes cutscene blur effects.
   memcardFilters:
     - "SLPM-65078"
     - "SLPM-65077"
@@ -33079,8 +32797,6 @@ SLPM-65162:
 SLPM-65163:
   name: "Zhen San Guo Wu Shuang 2"
   region: "NTSC-T"
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes invisible text.
   patches:
     397F3835:
       content: |-
@@ -33388,8 +33104,6 @@ SLPM-65235:
 SLPM-65236:
   name: "Anubis - Zone of the Enders"
   region: "NTSC-J"
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes cutscene blur effects.
 SLPM-65237:
   name: "Z.O.E. - Zone of the Enders [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -33846,8 +33560,6 @@ SLPM-65361:
   name: "Anubis - Zone of the Enders Special Edition [Limited Edition]"
   region: "NTSC-J"
   compat: 5
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes cutscene blur effects.
 SLPM-65362:
   name: "NHK Tensai Bit-Kun - Guramon Battle"
   region: "NTSC-J"
@@ -34346,8 +34058,6 @@ SLPM-65499:
 SLPM-65500:
   name: "Anubis - Zone of the Enders Special Edition"
   region: "NTSC-J"
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes cutscene blur effects.
 SLPM-65501:
   name: "Frogger Rescue"
   region: "NTSC-J"
@@ -35253,7 +34963,6 @@ SLPM-65754:
     - InstantDMAHack # Fixes broken half-bottom artifacts.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
-    partialTargetInvalidation: 1 # Fixes cutscene blur effects.
 SLPM-65755:
   name: "Samurai Western - Katsugeki Samurai-dou"
   region: "NTSC-J"
@@ -35280,7 +34989,6 @@ SLPM-65759:
     trilinearFiltering: 1
     halfPixelOffset: 2 # Fixes bloom misalignment when upscaling.
     cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling.
-    partialTargetInvalidation: 1 # Helps align bloom when upscaling.
 SLPM-65760:
   name: "Grand Theft Auto III [Capcom The Best]"
   region: "NTSC-J"
@@ -35346,8 +35054,6 @@ SLPM-65778:
 SLPM-65779:
   name: "Exciting Pro Wrestling 5 [Yuke's the Best]"
   region: "NTSC-J"
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes menu corruption.
 SLPM-65780:
   name: "Kessen III [Treasure Box]"
   region: "NTSC-J"
@@ -35718,8 +35424,6 @@ SLPM-65880:
 SLPM-65881:
   name: "SmackDown vs. Raw - Exciting Professional Wrestling 6"
   region: "NTSC-J"
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes menu corruption.
 SLPM-65882:
   name: "Duel Masters"
   region: "NTSC-J"
@@ -36130,8 +35834,6 @@ SLPM-65990:
 SLPM-65991:
   name: "Anubis - Zone of the Enders Special Edition [Konami Dendou Collection]"
   region: "NTSC-J"
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes cutscene blur effects.
 SLPM-65994:
   name: "Remember 11 - The Age of Infinity [Superlite 2000 Series]"
   region: "NTSC-J"
@@ -36950,8 +36652,6 @@ SLPM-66186:
 SLPM-66187:
   name: "Exciting Pro Wrestling 6 - SmackDown vs. RAW [Yuke's the Best]"
   region: "NTSC-J"
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes menu corruption.
 SLPM-66188:
   name: "Exciting Pro Wres 7"
   region: "NTSC-J"
@@ -37228,7 +36928,6 @@ SLPM-66248:
     trilinearFiltering: 1
     halfPixelOffset: 2 # Fixes bloom misalignment when upscaling.
     cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling.
-    partialTargetInvalidation: 1 # Helps align bloom when upscaling.
 SLPM-66249:
   name: "Growlanser V - Generations [Limited Edition]"
   region: "NTSC-J"
@@ -37305,8 +37004,6 @@ SLPM-66267:
 SLPM-66268:
   name: "Smackdown! vs. Raw 2006 - Exciting Pro Wrestling 7"
   region: "NTSC-J"
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes menu corruption.
 SLPM-66269:
   name: "Blazing Souls [Limited Edition]"
   region: "NTSC-J"
@@ -37523,8 +37220,6 @@ SLPM-66320:
   name: "Final Fantasy XII"
   region: "NTSC-J"
   compat: 5
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes broken textures.
 SLPM-66321:
   name: "Kurogane no Houkou - Warship Gunner 2"
   region: "NTSC-J"
@@ -37863,7 +37558,6 @@ SLPM-66404:
     vu1ClampMode: 0 # Fixes Spider-Man's eye texture colour.
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes textures.
-    partialTargetInvalidation: 1 # Fixes texture distortion.
     mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
     trilinearFiltering: 1
     autoFlush: 2 # Fixes shadow alignment along with HPO Special (Normal looks better but causes top left glitches).
@@ -38167,7 +37861,6 @@ SLPM-66473:
     eeRoundMode: 0 # Fixes scene switching in intro.
   gsHWFixes:
     cpuSpriteRenderBW: 1 # Fixes textures.
-    partialTargetInvalidation: 1 # Needed due to procedural textures overlapping EE writes.
     preloadFrameData: 1 # Fixes numberplates and ensures above targets are valid.
     roundSprite: 1 # Fixes lines in some post-effects.
     gpuTargetCLUT: 1 # Fixes light occlusion.
@@ -38312,7 +38005,6 @@ SLPM-66503:
     - DMABusyHack # Fixes broken half-bottom artifacts.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
-    partialTargetInvalidation: 1 # Fixes cutscene blur effects.
 SLPM-66504:
   name: "Onimusha 2 [Mega Hits]"
   region: "NTSC-J"
@@ -38772,8 +38464,6 @@ SLPM-66626:
 SLPM-66627:
   name: "WWE SmackDown! vs. RAW 2007"
   region: "NTSC-J"
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes broken text.
 SLPM-66628:
   name: "OutRun 2 SP [First Print Limited Edition]"
   region: "NTSC-J"
@@ -39319,8 +39009,6 @@ SLPM-66750:
   name: "Final Fantasy XII International - Zodiac Job System [with Bonus DVD]"
   region: "NTSC-J"
   compat: 5
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes broken textures.
 SLPM-66751:
   name: "Mahoroba Stories"
   region: "NTSC-J"
@@ -39478,7 +39166,6 @@ SLPM-66792:
     - InstantDMAHack # Fixes broken half-bottom artifacts.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
-    partialTargetInvalidation: 1 # Fixes cutscene blur effects.
 SLPM-66793:
   name: "Metal Gear Solid 2 - Sons of Liberty [20th Anniversary Edition] [Disc 2 of 2]"
   region: "NTSC-J"
@@ -39486,7 +39173,6 @@ SLPM-66793:
     - InstantDMAHack # Fixes broken half-bottom artifacts.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
-    partialTargetInvalidation: 1 # Fixes cutscene blur effects.
 SLPM-66794:
   name: "Metal Gear Solid 3 - Snake Eater [20th Anniversary Edition]"
   region: "NTSC-J"
@@ -39717,8 +39403,6 @@ SLPM-66862:
 SLPM-66863:
   name: "WWE SmackDown vs. RAW 2008"
   region: "NTSC-J"
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes broken text.
 SLPM-66864:
   name: "Umisho"
   region: "NTSC-J"
@@ -40199,7 +39883,6 @@ SLPM-67002:
     - InstantDMAHack # Fixes broken half-bottom artifacts.
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
-    partialTargetInvalidation: 1 # Fixes cutscene blur effects.
     recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
 SLPM-67003:
   name: "Sakura Taisen - Atsuki Chishioni"
@@ -40230,7 +39913,6 @@ SLPM-67008:
     - InstantDMAHack # Fixes broken half-bottom artifacts.
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
-    partialTargetInvalidation: 1 # Fixes cutscene blur effects.
     recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
 SLPM-67009:
   name: "Sakura Taisen V - Saraba Itoshiki Hito Yo"
@@ -40341,7 +40023,6 @@ SLPM-67515:
     - InstantDMAHack # Fixes broken half-bottom artifacts.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
-    partialTargetInvalidation: 1 # Fixes cutscene blur effects.
 SLPM-67516:
   name: "Soul Reaver 2"
   region: "NTSC-K"
@@ -40376,7 +40057,6 @@ SLPM-67524:
   gsHWFixes:
     halfPixelOffset: 2 # Corrects positioning of reflections on suit's surfaces.
     roundSprite: 2 # Reduces garbage on the UI whilst upscaling.
-    partialTargetInvalidation: 1 # Fixes corrupted textures.
 SLPM-67525:
   name: "Medal of Honor - Frontline"
   region: "NTSC-K"
@@ -40524,7 +40204,6 @@ SLPM-68503:
     - InstantDMAHack # Fixes broken half-bottom artifacts.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
-    partialTargetInvalidation: 1 # Fixes cutscene blur effects.
 SLPM-68504:
   name: "Tokimeki Memorial 3 - Special Sound Track"
   region: "NTSC-J"
@@ -40567,7 +40246,6 @@ SLPM-68520:
     cpuSpriteRenderBW: 2 # Fixes glow effects, but breaks shadows of certain objects.
     cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects shadow alignment and reduces blurriness.
-    partialTargetInvalidation: 1 # Fixes broken textures.
     recommendedBlendingLevel: 3 # Fixes level and map menu brightness.
 SLPM-68521:
   name: "Dot Hack Fraegment [Senkou Release-ban]"
@@ -40599,8 +40277,6 @@ SLPM-74001:
 SLPM-74002:
   name: "Shin Sangoku Musou [PlayStation 2 The Best]"
   region: "NTSC-J"
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes invisible text.
 SLPM-74003:
   name: "Crash Bandicoot 4 - Sakuretsu! Majin Power! [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -40810,7 +40486,6 @@ SLPM-74243:
     eeRoundMode: 0 # Fixes scene switching in intro.
   gsHWFixes:
     cpuSpriteRenderBW: 1 # Fixes textures.
-    partialTargetInvalidation: 1 # Needed due to procedural textures overlapping EE writes.
     preloadFrameData: 1 # Fixes numberplates and ensures above targets are valid.
     roundSprite: 1 # Fixes lines in some post-effects.
     gpuTargetCLUT: 1 # Fixes light occlusion.
@@ -40890,7 +40565,6 @@ SLPM-74255:
     - InstantDMAHack # Fixes broken half-bottom artifacts.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
-    partialTargetInvalidation: 1 # Fixes cutscene blur effects.
 SLPM-74256:
   name: "Metal Gear Solid 2 - Sons of Liberty [PlayStation 2 The Best] [Disc 2 of 2]"
   region: "NTSC-J"
@@ -40898,7 +40572,6 @@ SLPM-74256:
     - InstantDMAHack # Fixes broken half-bottom artifacts.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
-    partialTargetInvalidation: 1 # Fixes cutscene blur effects.
 SLPM-74257:
   name: "Metal Gear Solid 3 - Subsistence (Disc 1) (Subsistence)"
   region: "NTSC-J"
@@ -41067,7 +40740,6 @@ SLPM-74901:
     - InstantDMAHack # Fixes broken half-bottom artifacts.
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
-    partialTargetInvalidation: 1 # Fixes cutscene blur effects.
     recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
 SLPM-84075:
   name: "Anubis Zone of Enders Special Edition [Konami Dendou Selection]"
@@ -42273,8 +41945,6 @@ SLPS-20392:
 SLPS-20393:
   name: "Princess Maker 2"
   region: "NTSC-J"
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes full screen C32->C16 frame invalidation.
 SLPS-20394:
   name: "Suki na Mono wa Sukida Rashouganai + White Flower + Sukisyo!"
   region: "NTSC-J"
@@ -42661,7 +42331,6 @@ SLPS-25001:
     eeRoundMode: 0 # Fixes FPU errors causing instant death in Limestone Cave.
   gsHWFixes:
     disablePartialInvalidation: 1 # Fixes raphics issues.
-    partialTargetInvalidation: 1 # Fixes corrupted textures.
 SLPS-25002:
   name: "Dead or Alive 2"
   region: "NTSC-J"
@@ -42691,8 +42360,6 @@ SLPS-25003:
   region: "NTSC-J"
   clampModes:
     eeClampMode: 3 # Fixes hanging before going in-game.
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes corrupted textures.
 SLPS-25004:
   name: "Kensetsu Juuki Kenka Battle - Buchigire Kongou!!"
   region: "NTSC-J"
@@ -42732,8 +42399,6 @@ SLPS-25013:
   region: "NTSC-J"
   speedHacks:
     mtvu: 0 # Prevents broken textures and graphics.
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes broken textures.
 SLPS-25014:
   name: "Choro Q HG [Jenny Hi-Grade Box]"
   region: "NTSC-J"
@@ -42856,8 +42521,6 @@ SLPS-25040:
   compat: 5
   clampModes:
     eeClampMode: 2 # Fixes Abnormal AI behavior.
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes broken textures.
   memcardFilters:
     - "SCPS-55024"
     - "SLPS-25007"
@@ -42869,8 +42532,6 @@ SLPS-25041:
   region: "NTSC-J"
   clampModes:
     eeClampMode: 3 # Fixes invisible characters in various scenes.
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes black screens on judgement wheel.
 SLPS-25042:
   name: "Maken Shao [Limited Edition]"
   region: "NTSC-J"
@@ -42890,7 +42551,6 @@ SLPS-25044:
     textureInsideRT: 1 # Fixes missing effects.
     mipmap: 2 # Fixes shimmering noisy textures
     trilinearFiltering: 1 # Fixes shimmering noisy textures
-    partialTargetInvalidation: 1 # Fixes broken textures.
 SLPS-25045:
   name: "Lilie no Atelier - Salburg no Renkinjutsushi 3"
   region: "NTSC-J"
@@ -42947,7 +42607,6 @@ SLPS-25057:
   gsHWFixes:
     preloadFrameData: 1 # Fixes invisible lava, there is another issue that needs skipdraw 1 for blurry font but it removes much brightness.
     halfPixelOffset: 2 # Fixes font rendering.
-    partialTargetInvalidation: 1 # Fixes broken textures.
   patches:
     04C3765E:
       content: |-
@@ -43154,7 +42813,6 @@ SLPS-25112:
   gsHWFixes:
     halfPixelOffset: 2 # Corrects positioning of reflections on suit's surfaces.
     roundSprite: 2 # Reduces garbage on the UI whilst upscaling.
-    partialTargetInvalidation: 1 # Fixes corrupted textures.
 SLPS-25113:
   name: "Zettai Zetsumei Toshi"
   region: "NTSC-J"
@@ -43386,7 +43044,6 @@ SLPS-25169:
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Corrects positioning of reflections on suit's surfaces.
-    partialTargetInvalidation: 1 # Fixes corrupted textures.
   memcardFilters:
     - "SCAJ-20011"
     - "SCPS-55014"
@@ -43554,8 +43211,6 @@ SLPS-25209:
 SLPS-25210:
   name: "Exciting Pro Wres 4"
   region: "NTSC-J"
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes menu corruption.
 SLPS-25212:
   name: "Giren no Yabou - Zeon Dokuritsu Sensouden"
   region: "NTSC-J"
@@ -43576,8 +43231,6 @@ SLPS-25217:
   name: "Shadow Tower Abyss"
   region: "NTSC-J"
   compat: 5
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes broken textures.
 SLPS-25219:
   name: "Canary"
   region: "NTSC-J"
@@ -43879,8 +43532,6 @@ SLPS-25308:
 SLPS-25309:
   name: "Exciting Pro Wrestling 4 [Yuke's The Best]"
   region: "NTSC-J"
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes menu corruption.
 SLPS-25310:
   name: "Disney-Pixar's Finding Nemo"
   region: "NTSC-J"
@@ -43900,8 +43551,6 @@ SLPS-25314:
   name: "Nebula - Echo Night"
   region: "NTSC-J"
   compat: 5
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes broken textures.
 SLPS-25315:
   name: "One Piece - Grand Battle 3"
   region: "NTSC-J"
@@ -43946,13 +43595,9 @@ SLPS-25324:
 SLPS-25326:
   name: "WWE Smackdown! Here Comes the Pain - Exciting Pro Wrestling 5 [Limited Edition]"
   region: "NTSC-J"
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes menu corruption.
 SLPS-25327:
   name: "Exciting Pro Wres 5"
   region: "NTSC-J"
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes menu corruption.
 SLPS-25329:
   name: "Kuon"
   region: "NTSC-J"
@@ -43965,7 +43610,6 @@ SLPS-25329:
   gsHWFixes:
     halfPixelOffset: 2 # Reduces ghosting.
     preloadFrameData: 1 # Fixes red cracklines on walls.
-    partialTargetInvalidation: 1 # Fixes broken textures.
 SLPS-25330:
   name: "Dragon Ball Z - Budokai 2"
   region: "NTSC-J"
@@ -44006,7 +43650,6 @@ SLPS-25338:
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
-    partialTargetInvalidation: 1 # Fixes broken textures.
     recommendedBlendingLevel: 3 # Fixes level brightness.
   memcardFilters:
     - "SCAJ-20076"
@@ -44020,7 +43663,6 @@ SLPS-25339:
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
-    partialTargetInvalidation: 1 # Fixes broken textures.
     recommendedBlendingLevel: 3 # Fixes level brightness.
   memcardFilters:
     - "SCAJ-20076"
@@ -44263,8 +43905,6 @@ SLPS-25393:
 SLPS-25394:
   name: "Another Century's Episode"
   region: "NTSC-J"
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes broken textures.
 SLPS-25395:
   name: "Sentimental Prelude"
   region: "NTSC-J"
@@ -44323,7 +43963,6 @@ SLPS-25408:
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
-    partialTargetInvalidation: 1 # Fixes broken textures.
     recommendedBlendingLevel: 3 # Fixes level brightness.
   memcardFilters:
     - "SLPS-25408"
@@ -44501,8 +44140,6 @@ SLPS-25453:
 SLPS-25454:
   name: "Daisenryaku VII Exceed"
   region: "NTSC-J"
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes broken textures.
 SLPS-25455:
   name: "Sanyo Pachinko Paradise 11"
   region: "NTSC-J"
@@ -44533,7 +44170,6 @@ SLPS-25461:
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
-    partialTargetInvalidation: 1 # Fixes broken textures.
     cpuSpriteRenderBW: 1 # Fixes broken shadow caused by HPO 1.
     cpuSpriteRenderLevel: 2 # Needed for above.
 SLPS-25462:
@@ -44543,7 +44179,6 @@ SLPS-25462:
     cpuSpriteRenderBW: 2 # Fixes glow effects, but breaks shadows of certain objects.
     cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects shadow alignment and reduces blurriness.
-    partialTargetInvalidation: 1 # Fixes broken textures.
     recommendedBlendingLevel: 3 # Fixes level and map menu brightness.
   memcardFilters:
     - "SLPS-25338"
@@ -45107,8 +44742,6 @@ SLPS-25623:
   name: "Another Century's Episode 2"
   region: "NTSC-J"
   compat: 5
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes broken textures.
 SLPS-25624:
   name: "Futakoi-Futakoi Island Collection"
   region: "NTSC-J"
@@ -45583,18 +45216,13 @@ SLPS-25730:
     cpuSpriteRenderBW: 2 # Fixes glow effects, but breaks shadows of certain objects.
     cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects shadow alignment and reduces blurriness.
-    partialTargetInvalidation: 1 # Fixes broken textures.
     recommendedBlendingLevel: 3 # Fixes level and map menu brightness.
 SLPS-25731:
   name: "Armored Core 2 [Machine Side Box]"
   region: "NTSC-J"
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes broken textures.
 SLPS-25732:
   name: "Armored Core 3 [Machine Side Box]"
   region: "NTSC-J"
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes broken textures.
 SLPS-25733:
   name: "Super Robot Taisen OG - Original Generations"
   region: "NTSC-J"
@@ -45780,8 +45408,6 @@ SLPS-25784:
   region: "NTSC-J"
   clampModes:
     vuClampMode: 3 # Was used to fix game crash, but not sure it's required anymore.
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes broken textures.
 SLPS-25786:
   name: "Hisshou Pachinko-Pachislot Kouryaku Series Vol.10 - CR Shinseiki Evangelion - Kiseki no kachi Ha"
   region: "NTSC-J"
@@ -45935,8 +45561,6 @@ SLPS-25828:
 SLPS-25829:
   name: "Another Century's Episode 2 [Special Vocal Version]"
   region: "NTSC-J"
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes broken textures.
 SLPS-25830:
   name: "Zero no Tsukaima - Muma ga Tsumugu Yokaze no Gensoukyoku [Limited Edition]"
   region: "NTSC-J"
@@ -46588,7 +46212,6 @@ SLPS-73202:
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
-    partialTargetInvalidation: 1 # Fixes broken textures.
     recommendedBlendingLevel: 3 # Fixes level brightness.
   memcardFilters:
     - "SCAJ-20076"
@@ -46602,7 +46225,6 @@ SLPS-73203:
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
-    partialTargetInvalidation: 1 # Fixes broken textures.
     recommendedBlendingLevel: 3 # Fixes level brightness.
   memcardFilters:
     - "SCAJ-20076"
@@ -46756,8 +46378,6 @@ SLPS-73226:
 SLPS-73227:
   name: "Another Century's Episode [PlayStation 2 The Best]"
   region: "NTSC-J"
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes broken textures.
 SLPS-73228:
   name: "Fuuun Bakumatsuden [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -46897,7 +46517,6 @@ SLPS-73247:
     cpuSpriteRenderBW: 2 # Fixes glow effects, but breaks shadows of certain objects.
     cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects shadow alignment and reduces blurriness.
-    partialTargetInvalidation: 1 # Fixes broken textures.
     recommendedBlendingLevel: 3 # Fixes level and map menu brightness.
   memcardFilters:
     - "SLPS-25338"
@@ -46973,7 +46592,6 @@ SLPS-73257:
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 1 # Reduces blurriness.
-    partialTargetInvalidation: 1 # Fixes corruption after taking a picture.
 SLPS-73258:
   name: "Kenka Banchou 2 - Full Throttle [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -47070,8 +46688,6 @@ SLPS-73411:
   region: "NTSC-J"
   clampModes:
     eeClampMode: 2 # Fixes Abnormal AI behavior.
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes broken textures.
   memcardFilters:
     - "SCPS-55024"
     - "SLPS-25007"
@@ -47098,14 +46714,11 @@ SLPS-73417:
   gsHWFixes:
     halfPixelOffset: 2 # Corrects positioning of reflections on suit's surfaces.
     roundSprite: 2 # Reduces garbage on the UI whilst upscaling.
-    partialTargetInvalidation: 1 # Fixes corrupted textures.
 SLPS-73418:
   name: "Shadow Hearts [PlayStation 2 The Best]"
   region: "NTSC-J"
   clampModes:
     eeClampMode: 3 # Fixes invisible characters in various scenes.
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes black screens on judgement wheel.
 SLPS-73419:
   name: "Lupin III - Majutsu-Ou no Isan [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -47114,7 +46727,6 @@ SLPS-73420:
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Corrects positioning of reflections on suit's surfaces.
-    partialTargetInvalidation: 1 # Fixes corrupted textures.
   memcardFilters:
     - "SCAJ-20011"
     - "SCPS-55014"
@@ -47239,13 +46851,10 @@ SLUS-20015:
     eeRoundMode: 0 # Fixes FPU errors causing instant death in Limestone Cave.
   gsHWFixes:
     disablePartialInvalidation: 1 # Fixes graphics issues.
-    partialTargetInvalidation: 1 # Fixes corrupted textures.
 SLUS-20016:
   name: "Evergrace"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes corrupted textures.
 SLUS-20017:
   name: "Maximo - Ghosts to Glory"
   region: "NTSC-U"
@@ -47479,8 +47088,6 @@ SLUS-20078:
 SLUS-20079:
   name: "Dynasty Warriors 2"
   region: "NTSC-U"
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes invisible text.
 SLUS-20080:
   name: "GunGriffon Blaze"
   region: "NTSC-U"
@@ -47684,7 +47291,6 @@ SLUS-20144:
     - InstantDMAHack # Fixes broken half-bottom artifacts.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
-    partialTargetInvalidation: 1 # Fixes cutscene blur effects.
 SLUS-20145:
   name: "Ring of Red"
   region: "NTSC-U"
@@ -48172,8 +47778,6 @@ SLUS-20249:
   region: "NTSC-U"
   clampModes:
     eeClampMode: 2 # Fixes Abnormal AI behavior.
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes broken textures.
   memcardFilters: # Can import data from regular Armored Core 2.
     - "SLUS-20249"
     - "SLUS-20014"
@@ -48472,7 +48076,6 @@ SLUS-20318:
   gsHWFixes:
     preloadFrameData: 1 # Fixes invisible lava, there is another issue that needs skipdraw 1 for blurry font but it removes much brightness.
     halfPixelOffset: 2 # Fixes font rendering.
-    partialTargetInvalidation: 1 # Fixes broken textures.
   patches:
     36E02E91:
       content: |-
@@ -48591,7 +48194,6 @@ SLUS-20343:
     textureInsideRT: 1 # Fixes missing effects.
     mipmap: 2 # Fixes shimmering noisy textures
     trilinearFiltering: 1 # Fixes shimmering noisy textures
-    partialTargetInvalidation: 1 # Fixes broken textures.
 SLUS-20344:
   name: "Rez"
   region: "NTSC-U"
@@ -48614,8 +48216,6 @@ SLUS-20347:
   compat: 5
   clampModes:
     eeClampMode: 3 # Fixes invisible characters in various scenes.
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes black screens on judgement wheel.
   patches:
     default:
       content: |-
@@ -48644,7 +48244,6 @@ SLUS-20353:
   gsHWFixes:
     preloadFrameData: 1 # Fixes invisible lava, there is another issue that needs skipdraw 1 for blurry font but it removes much brightness.
     halfPixelOffset: 2 # Fixes font rendering.
-    partialTargetInvalidation: 1 # Fixes broken textures.
 SLUS-20354:
   name: "Red Card Soccer 2003"
   region: "NTSC-U"
@@ -48797,8 +48396,6 @@ SLUS-20385:
   name: "WWE Crush Hour"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes menu corruption.
 SLUS-20386:
   name: "Lethal Skies - Elite Pilot - Team SW"
   region: "NTSC-U"
@@ -49064,7 +48661,6 @@ SLUS-20435:
   gsHWFixes:
     halfPixelOffset: 2 # Corrects positioning of reflections on suit's surfaces.
     roundSprite: 2 # Reduces garbage on the UI whilst upscaling.
-    partialTargetInvalidation: 1 # Fixes corrupted textures.
 SLUS-20436:
   name: "Guilty Gear X2"
   region: "NTSC-U"
@@ -49294,8 +48890,6 @@ SLUS-20483:
   name: "WWE SmackDown! Shut Your Mouth"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes menu corruption.
 SLUS-20484:
   name: "Devil May Cry 2 [Disc 1 of 2]"
   region: "NTSC-U"
@@ -49593,8 +49187,6 @@ SLUS-20545:
   name: "Zone of the Enders - The 2nd Runner"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes cutscene blur effects.
 SLUS-20546:
   name: "Evolution Snowboarding"
   region: "NTSC-U"
@@ -49644,7 +49236,6 @@ SLUS-20554:
     - InstantDMAHack # Fixes broken half-bottom artifacts.
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
-    partialTargetInvalidation: 1 # Fixes cutscene blur effects.
     recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
 SLUS-20555:
   name: "Reel Fishing 3"
@@ -50124,7 +49715,6 @@ SLUS-20644:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Corrects positioning of reflections on suit's surfaces.
-    partialTargetInvalidation: 1 # Fixes corrupted textures.
   memcardFilters: # Can import data from AC3.
     - "SLUS-20435"
     - "SLUS-20644"
@@ -50858,8 +50448,6 @@ SLUS-20787:
   name: "WWE SmackDown! Here Comes the Pain"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes menu corruption.
 SLUS-20788:
   name: "Ford Racing 2"
   region: "NTSC-U"
@@ -51245,7 +50833,6 @@ SLUS-20870:
     vu1ClampMode: 0 # Fixes wrong texture colour.
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes textures.
-    partialTargetInvalidation: 1 # Fixes texture distortion.
     mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
     trilinearFiltering: 1
     autoFlush: 2 # Fixes shadow alignment along with HPO Special (Normal looks better but causes top left glitches).
@@ -51437,7 +51024,6 @@ SLUS-20904:
     trilinearFiltering: 1
     halfPixelOffset: 2 # Fixes bloom misalignment when upscaling.
     cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling.
-    partialTargetInvalidation: 1 # Helps align bloom when upscaling.
 SLUS-20905:
   name: "Incredibles, The"
   region: "NTSC-U"
@@ -51447,7 +51033,6 @@ SLUS-20905:
     trilinearFiltering: 1
     halfPixelOffset: 2 # Fixes bloom misalignment when upscaling.
     cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling.
-    partialTargetInvalidation: 1 # Helps align bloom when upscaling.
 SLUS-20906:
   name: "Fight Night 2004"
   region: "NTSC-U"
@@ -51590,8 +51175,6 @@ SLUS-20928:
   name: "Echo Night - Beyond"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes broken textures.
 SLUS-20929:
   name: "Battle Assault 3 featuring Gundam Seed"
   region: "NTSC-U"
@@ -51777,8 +51360,6 @@ SLUS-20963:
   name: "Final Fantasy XII"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes broken textures.
 SLUS-20964:
   name: "Devil May Cry 3 - Dante's Awakening"
   region: "NTSC-U"
@@ -51919,7 +51500,6 @@ SLUS-20986:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
-    partialTargetInvalidation: 1 # Fixes broken textures.
     recommendedBlendingLevel: 3 # Fixes level brightness.
   memcardFilters:
     - "SLUS-20986"
@@ -52065,7 +51645,6 @@ SLUS-21007:
   gsHWFixes:
     halfPixelOffset: 2 # Reduces ghosting.
     preloadFrameData: 1 # Fixes red cracklines on walls.
-    partialTargetInvalidation: 1 # Fixes broken textures.
 SLUS-21008:
   name: "Katamari Damacy"
   region: "NTSC-U"
@@ -52363,8 +51942,6 @@ SLUS-21060:
   name: "WWE SmackDown! vs. RAW"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes menu corruption.
 SLUS-21062:
   name: "Jaws Unleashed"
   region: "NTSC-U"
@@ -52453,7 +52030,6 @@ SLUS-21079:
   region: "NTSC-U"
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
-    partialTargetInvalidation: 1 # Fixes broken textures.
     recommendedBlendingLevel: 3 # Fixes level brightness.
   memcardFilters:
     - "SLUS-20986"
@@ -52520,7 +52096,6 @@ SLUS-21095:
   gsHWFixes:
     mipmap: 1
     autoFlush: 2
-    partialTargetInvalidation: 1
     estimateTextureRegion: 1 # Improves performance.
 SLUS-21096:
   name: "Ape Escape - Pumped & Primed"
@@ -52584,7 +52159,6 @@ SLUS-21106:
     eeRoundMode: 0 # Fixes scene switching in intro.
   gsHWFixes:
     cpuSpriteRenderBW: 1 # Fixes textures.
-    partialTargetInvalidation: 1 # Needed due to procedural textures overlapping EE writes.
     preloadFrameData: 1 # Fixes numberplates and ensures above targets are valid.
     roundSprite: 1 # Fixes lines in some post-effects.
     gpuTargetCLUT: 1 # Fixes light occlusion.
@@ -53064,7 +52638,6 @@ SLUS-21200:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
-    partialTargetInvalidation: 1 # Fixes broken textures.
     recommendedBlendingLevel: 3 # Fixes level brightness.
   memcardFilters: # Can import data from AC:Nexus.
     - "SLUS-21200"
@@ -53183,7 +52756,6 @@ SLUS-21217:
     trilinearFiltering: 1
     halfPixelOffset: 2 # Fixes bloom misalignment when upscaling.
     cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling.
-    partialTargetInvalidation: 1 # Helps align bloom when upscaling.
 SLUS-21218:
   name: "Tak - The Great Juju Challenge"
   region: "NTSC-U"
@@ -53375,7 +52947,6 @@ SLUS-21244:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 1 # Reduces blurriness.
-    partialTargetInvalidation: 1 # Fixes corruption after taking a picture.
 SLUS-21245:
   name: "Suikoden Tactics"
   region: "NTSC-U"
@@ -53640,7 +53211,6 @@ SLUS-21285:
     vu1ClampMode: 0 # Fixes Spider-Man's eyes texture.
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes textures.
-    partialTargetInvalidation: 1 # Fixes texture distortion.
     mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
     trilinearFiltering: 1
     autoFlush: 2 # Fixes shadow alignment along with HPO Special (Normal looks better but causes top left glitches).
@@ -53649,8 +53219,6 @@ SLUS-21286:
   name: "WWE SmackDown! vs. RAW 2006"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes menu corruption.
 SLUS-21287:
   name: "Prince of Persia - The Two Thrones"
   region: "NTSC-U"
@@ -53965,7 +53533,6 @@ SLUS-21338:
     cpuSpriteRenderBW: 2 # Fixes glow effects, but breaks shadows of certain objects.
     cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects shadow alignment and reduces blurriness.
-    partialTargetInvalidation: 1 # Fixes broken textures.
     recommendedBlendingLevel: 3 # Fixes level and map menu brightness.
 SLUS-21339:
   name: "Puzzle Collection - Crosswords & More!"
@@ -54544,8 +54111,6 @@ SLUS-21427:
   name: "WWE SmackDown! vs. RAW 2007"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes broken text.
 SLUS-21428:
   name: "Bionicle Heroes"
   region: "NTSC-U"
@@ -54796,8 +54361,6 @@ SLUS-21475:
   name: "Final Fantasy XII [Collector's Edition]"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes broken textures.
 SLUS-21476:
   name: "Madden NFL '07"
   region: "NTSC-U"
@@ -55552,8 +55115,6 @@ SLUS-21645:
   name: "WWE SmackDown! vs. Raw 2008"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes broken text.
 SLUS-21646:
   name: "Tiger Woods PGA Tour 08"
   region: "NTSC-U"
@@ -55677,7 +55238,6 @@ SLUS-21674:
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
     halfPixelOffset: 1 # Fixes bloom misalignment.
-    partialTargetInvalidation: 1 # Fixes black sqaures effect.
 SLUS-21675:
   name: "Petz - Catz 2"
   region: "NTSC-U"
@@ -55685,7 +55245,6 @@ SLUS-21675:
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
     halfPixelOffset: 1 # Fixes bloom misalignment.
-    partialTargetInvalidation: 1 # Fixes black sqaures effect.
 SLUS-21676:
   name: "Dancing with the Stars"
   region: "NTSC-U"
@@ -56367,8 +55926,6 @@ SLUS-21810:
   name: "WWE SmackDown vs. Raw 2009"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes broken text.
 SLUS-21811:
   name: "MotoGP 08"
   region: "NTSC-U"
@@ -56758,8 +56315,6 @@ SLUS-21901:
   name: "WWE SmackDown vs. Raw 2010"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes broken text.
 SLUS-21902:
   name: "Bakugan - Battle Brawlers"
   region: "NTSC-U"
@@ -56925,14 +56480,10 @@ SLUS-21939:
   name: "WWE SmackDown vs. Raw 2011"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes broken text.
 SLUS-21940:
   name: "WWE All-Stars"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes menu corruption.
 SLUS-21941:
   name: "FIFA Soccer 11"
   region: "NTSC-U"
@@ -56993,8 +56544,6 @@ SLUS-21955:
 SLUS-27014:
   name: "WWE SmackDown vs Raw - Superstar Series [Bundle]"
   region: "NTSC-U"
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes menu corruption.
 SLUS-27029:
   name: "Disney Sing It [Bundle]"
   region: "NTSC-U"
@@ -57204,7 +56753,6 @@ SLUS-29003:
     - InstantDMAHack # Fixes broken half-bottom artifacts.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
-    partialTargetInvalidation: 1 # Fixes cutscene blur effects.
 SLUS-29004:
   name: "Unison & Dead or Alive 2 Hardcore [Demo]"
   region: "NTSC-U"
@@ -57550,8 +57098,6 @@ SLUS-29113:
 SLUS-29116:
   name: "WWE SmackDown! vs. RAW [Public Beta Vol.1.0]"
   region: "NTSC-U"
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes menu corruption.
 SLUS-29117:
   name: "Battlefield 2 - Modern Combat [Public Beta Vol.1.0]"
   region: "NTSC-U"
@@ -57780,8 +57326,6 @@ SLUS-29170:
 SLUS-29171:
   name: "Final Fantasy XII [Demo]"
   region: "NTSC-U"
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes broken textures.
 SLUS-29172:
   name: "Battlefield 2 - Modern Combat [Demo]"
   region: "NTSC-U"
@@ -58006,7 +57550,6 @@ TCES-52456:
   gsHWFixes:
     mipmap: 1 # Fixes garbage textures in the distance.
     disablePartialInvalidation: 1 # Prevents the situation that a level (Aquatos) doesn't render characters and geometry.
-    partialTargetInvalidation: 1 # Fixes broken pause screen.
     halfPixelOffset: 2 # Fixes misaligned bloom.
     autoFlush: 2 # Helps fix misaligned bloom.
 TCES-52582:
@@ -58136,7 +57679,6 @@ TCPS-10158:
     vu1ClampMode: 0 # Fixes Spider-Man's eye texture colour.
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes textures.
-    partialTargetInvalidation: 1 # Fixes texture distortion.
     mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
     trilinearFiltering: 1
     autoFlush: 2 # Fixes shadow alignment along with HPO Special (Normal looks better but causes top left glitches).
@@ -58186,8 +57728,6 @@ TLES-52768:
 TLES-52781:
   name: "WWE - Smackdown Vs Raw Beta Trial Code"
   region: "PAL-E"
-  gsHWFixes:
-    partialTargetInvalidation: 1 # Fixes menu corruption.
 TLES-52940:
   name: "S.L.A.I. Phantom Crash Beta Trial Code"
   region: "PAL-E"

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -198,18 +198,13 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsDialog* dialog, QWidget* 
 	SettingWidgetBinder::BindWidgetToIntSetting(
 		sif, m_ui.textureInsideRt, "EmuCore/GS", "UserHacks_TextureInsideRt", static_cast<int>(GSTextureInRtMode::Disabled));
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.readTCOnClose, "EmuCore/GS", "UserHacks_ReadTCOnClose", false);
-	SettingWidgetBinder::BindWidgetToBoolSetting(
-		sif, m_ui.targetPartialInvalidation, "EmuCore/GS", "UserHacks_TargetPartialInvalidation", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.estimateTextureRegion, "EmuCore/GS", "UserHacks_EstimateTextureRegion", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.gpuPaletteConversion, "EmuCore/GS", "paltex", false);
 	connect(m_ui.cpuSpriteRenderBW, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
 		&GraphicsSettingsWidget::onCPUSpriteRenderBWChanged);
-	connect(
-		m_ui.textureInsideRt, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &GraphicsSettingsWidget::onTextureInsideRtChanged);
 	connect(m_ui.gpuPaletteConversion, QOverload<int>::of(&QCheckBox::stateChanged), this,
 		&GraphicsSettingsWidget::onGpuPaletteConversionChanged);
 	onCPUSpriteRenderBWChanged();
-	onTextureInsideRtChanged();
 	onGpuPaletteConversionChanged(m_ui.gpuPaletteConversion->checkState());
 
 	//////////////////////////////////////////////////////////////////////////
@@ -559,10 +554,6 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsDialog* dialog, QWidget* 
 			tr("Flushes all targets in the texture cache back to local memory when shutting down. Can prevent lost visuals when saving "
 			   "state or switching renderers, but can also cause graphical corruption."));
 
-		dialog->registerWidgetHelp(m_ui.targetPartialInvalidation, tr("Target Partial Invalidation"), tr("Unchecked"),
-			tr("Allows partial invalidation of render targets, which can fix graphical errors in some games. Texture Inside Render Target "
-			   "automatically enables this option."));
-
 		dialog->registerWidgetHelp(m_ui.estimateTextureRegion, tr("Estimate Texture Region"), tr("Unchecked"),
 			tr("Attempts to reduce the texture size when games do not set it themselves (e.g. Snowblind games)."));
 	}
@@ -889,13 +880,6 @@ void GraphicsSettingsWidget::onCPUSpriteRenderBWChanged()
 	m_ui.cpuSpriteRenderLevel->setEnabled(value != 0);
 }
 
-void GraphicsSettingsWidget::onTextureInsideRtChanged()
-{
-	const bool disabled = static_cast<GSTextureInRtMode>(m_ui.textureInsideRt->currentIndex()) >= GSTextureInRtMode::InsideTargets;
-
-	m_ui.targetPartialInvalidation->setDisabled(disabled);
-}
-
 GSRendererType GraphicsSettingsWidget::getEffectiveRenderer() const
 {
 	const GSRendererType type =
@@ -1060,7 +1044,6 @@ void GraphicsSettingsWidget::resetManualHardwareFixes()
 		check_bool("EmuCore/GS", "UserHacks_DisablePartialInvalidation", false);
 		check_int("EmuCore/GS", "UserHacks_TextureInsideRt", static_cast<int>(GSTextureInRtMode::Disabled));
 		check_bool("EmuCore/GS", "UserHacks_ReadTCOnClose", false);
-		check_bool("EmuCore/GS", "UserHacks_TargetPartialInvalidation", false);
 		check_bool("EmuCore/GS", "UserHacks_EstimateTextureRegion", false);
 		check_bool("EmuCore/GS", "paltex", false);
 		check_int("EmuCore/GS", "UserHacks_HalfPixelOffset", 0);

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.h
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.h
@@ -42,7 +42,6 @@ private Q_SLOTS:
 	void onTrilinearFilteringChanged();
 	void onGpuPaletteConversionChanged(int state);
 	void onCPUSpriteRenderBWChanged();
-	void onTextureInsideRtChanged();
 	void onFullscreenModeChanged(int index);
 	void onShadeBoostChanged();
 	void onCaptureContainerChanged();

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
@@ -1027,13 +1027,6 @@
            </property>
           </widget>
          </item>
-         <item row="4" column="1">
-          <widget class="QCheckBox" name="targetPartialInvalidation">
-           <property name="text">
-            <string>Target Partial Invalidation</string>
-           </property>
-          </widget>
-         </item>
          <item row="3" column="1">
           <widget class="QCheckBox" name="readTCOnClose">
            <property name="text">

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -697,7 +697,6 @@ struct Pcsx2Config
 					UserHacks_MergePPSprite : 1,
 					UserHacks_WildHack : 1,
 					UserHacks_NativePaletteDraw : 1,
-					UserHacks_TargetPartialInvalidation : 1,
 					UserHacks_EstimateTextureRegion : 1,
 					FXAA : 1,
 					ShadeBoost : 1,

--- a/pcsx2/GS/GSRegs.h
+++ b/pcsx2/GS/GSRegs.h
@@ -544,6 +544,7 @@ REG_END2
 
 	// output will be Cd, Cs is discarded
 	__forceinline bool IsCdOutput() const { return (C == 2 && D != 1 && FIX == 0x00); }
+	__forceinline bool IsUsingCs() const { return (A == 0 || B == 0 || D == 0); }
 
 	__forceinline bool IsBlack() const { return ((C == 2 && FIX == 0) || (A == 2 && A == B)) && D == 2; }
 REG_END2

--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -1808,8 +1808,11 @@ void GSState::CheckWriteOverlap(bool req_write, bool req_read)
 		}
 	}
 
-	// Invalid the CLUT if it crosses paths.
-	m_mem.m_clut.InvalidateRange(write_start_bp, write_end_bp);
+	if (req_write)
+	{
+		// Invalid the CLUT if it crosses paths.
+		m_mem.m_clut.InvalidateRange(write_start_bp, write_end_bp);
+	}
 }
 
 void GSState::Write(const u8* mem, int len)

--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -1852,11 +1852,12 @@ void GSState::Write(const u8* mem, int len)
 			m_draw_transfers.pop_back();
 			transfer.rect = transfer.rect.runion(r);
 			transfer.draw = s_n;
+			transfer.zero_clear = false;
 			m_draw_transfers.push_back(transfer);
 		}
 		else
 		{
-			GSUploadQueue new_transfer = { blit, r, s_n };
+			GSUploadQueue new_transfer = { blit, r, s_n, false };
 			m_draw_transfers.push_back(new_transfer);
 		}
 
@@ -2042,11 +2043,12 @@ void GSState::Move()
 		m_draw_transfers.pop_back();
 		transfer.rect = transfer.rect.runion(r);
 		transfer.draw = s_n;
+		transfer.zero_clear = false;
 		m_draw_transfers.push_back(transfer);
 	}
 	else
 	{
-		GSUploadQueue new_transfer = { m_env.BITBLTBUF, r, s_n };
+		GSUploadQueue new_transfer = { m_env.BITBLTBUF, r, s_n, false };
 		m_draw_transfers.push_back(new_transfer);
 	}
 
@@ -3685,7 +3687,7 @@ GSState::TextureMinMaxResult GSState::GetTextureMinMax(GIFRegTEX0 TEX0, GIFRegCL
 			// If it's the start of the texture and our little adjustment is all that pushed it over, clamp it to 0.
 			// This stops the border check failing when using repeat but needed less than the full texture
 			// since this was making it take the full texture even though it wasn't needed.
-			if (!clamp_to_tsize && ((m_vt.m_min.t == GSVector4::zero()).mask() & 0x3) == 0x3)
+			if (!clamp_to_tsize && ((m_vt.m_min.t.floor() == GSVector4::zero()).mask() & 0x3) == 0x3)
 				st = st.max(GSVector4::zero());
 		}
 		else

--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -206,6 +206,7 @@ public:
 		GIFRegBITBLTBUF blit;
 		GSVector4i rect;
 		int draw;
+		bool zero_clear;
 	};
 
 	GIFPath m_path[4] = {};

--- a/pcsx2/GS/Renderers/Common/GSDirtyRect.cpp
+++ b/pcsx2/GS/Renderers/Common/GSDirtyRect.cpp
@@ -62,16 +62,16 @@ GSVector4i GSDirtyRectList::GetTotalRect(GIFRegTEX0 TEX0, const GSVector2i& size
 {
 	if (!empty())
 	{
-		GSVector4i r(INT_MAX, INT_MAX, 0, 0);
+		GSVector4i r = GSVector4i::cxpr(INT_MAX, INT_MAX, 0, 0);
 
 		for (auto& dirty_rect : *this)
 		{
 			r = r.runion(dirty_rect.GetDirtyRect(TEX0));
 		}
 
-		const GSVector2i bs = GSLocalMemory::m_psm[TEX0.PSM].bs;
+		const GSVector2i& bs = GSLocalMemory::m_psm[TEX0.PSM].bs;
 
-		return r.ralign<Align_Outside>(bs).rintersect(GSVector4i(0, 0, size.x, size.y));
+		return r.ralign<Align_Outside>(bs).rintersect(GSVector4i::loadh(size));
 	}
 
 	return GSVector4i::zero();

--- a/pcsx2/GS/Renderers/HW/GSHwHack.cpp
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.cpp
@@ -889,6 +889,23 @@ bool GSHwHack::GSC_BigMuthaTruckers(GSRendererHW& r, int& skip)
 	return true;
 }
 
+bool GSHwHack::GSC_HitmanBloodMoney(GSRendererHW& r, int& skip)
+{
+	// The game does a stupid thing where it backs up the last 2 pages of the framebuffer with shuffles, uploads a CT32 texture to it
+	// then copies the RGB back (keeping the new alpha only). It's pretty gross, I have no idea why they didn't just upload a new alpha.
+	// This is a real pain to emulate with the current state of things, so let's just clear the dirty area from the upload and pretend it wasn't there.
+	
+	// Catch the first draw of the copy back.
+	if (RFBP > 0 && RTPSM == PSMT8H && RFPSM == PSMCT32)
+	{
+		GSTextureCache::Target* target = g_texture_cache->FindOverlappingTarget(RFBP, RFBP + 1);
+		if (target)
+			target->m_dirty.clear();
+	}
+
+	return false;
+}
+
 bool GSHwHack::OI_PointListPalette(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t)
 {
 	const u32 n_vertices = r.m_vertex.next;
@@ -1458,6 +1475,7 @@ const GSHwHack::Entry<GSRendererHW::GSC_Ptr> GSHwHack::s_get_skip_count_function
 	CRC_F(GSC_NFSUndercover),
 	CRC_F(GSC_PolyphonyDigitalGames),
 	CRC_F(GSC_MetalGearSolid3),
+	CRC_F(GSC_HitmanBloodMoney),
 
 	// Channel Effect
 	CRC_F(GSC_GiTS),

--- a/pcsx2/GS/Renderers/HW/GSHwHack.cpp
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.cpp
@@ -996,6 +996,7 @@ bool GSHwHack::OI_RozenMaidenGebetGarden(GSRendererHW& r, GSTexture* rt, GSTextu
 			{
 				GL_INS("OI_RozenMaidenGebetGarden FB clear");
 				g_gs_device->ClearRenderTarget(tmp_rt->m_texture, 0);
+				tmp_rt->UpdateDrawn(tmp_rt->m_valid);
 				tmp_rt->m_alpha_max = 0;
 				tmp_rt->m_alpha_min = 0;
 			}
@@ -1061,9 +1062,10 @@ bool GSHwHack::OI_SonicUnleashed(GSRendererHW& r, GSTexture* rt, GSTexture* ds, 
 		{
 			GSVector2i new_size = GSVector2i(std::max(rt_again->m_unscaled_size.x, src->m_unscaled_size.x),
 									std::max(rt_again->m_unscaled_size.y, src->m_unscaled_size.y));
-			rt_again->ResizeTexture(new_size.x,	new_size.y);
+			rt_again->ResizeTexture(new_size.x, new_size.y);
 			rt = rt_again->m_texture;
 			rt_size = new_size;
+			rt_again->UpdateDrawn(GSVector4i::loadh(rt_size));
 		}
 	}
 
@@ -1318,6 +1320,9 @@ static bool GetMoveTargetPair(GSRendererHW& r, GSTextureCache::Target** src, GIF
 
 	*src = tsrc;
 	*dst = tdst;
+
+	tdst->UpdateDrawn(tdst->m_valid);
+
 	return true;
 }
 

--- a/pcsx2/GS/Renderers/HW/GSHwHack.h
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.h
@@ -45,6 +45,7 @@ public:
 	static bool GSC_PolyphonyDigitalGames(GSRendererHW& r, int& skip);
 	static bool GSC_MetalGearSolid3(GSRendererHW& r, int& skip);
 	static bool GSC_BigMuthaTruckers(GSRendererHW& r, int& skip);
+	static bool GSC_HitmanBloodMoney(GSRendererHW& r, int& skip);
 
 	static bool OI_PointListPalette(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
 	static bool OI_DBZBTGames(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -2518,7 +2518,7 @@ void GSRendererHW::Draw()
 			rt->m_TEX0 = FRAME_TEX0;
 		}
 
-		if (ds && (!is_possible_mem_clear || ds->m_TEX0.PSM != ZBUF_TEX0.PSM))
+		if (ds && (!is_possible_mem_clear || ds->m_TEX0.PSM != ZBUF_TEX0.PSM || (rt && ds->m_TEX0.TBW != rt->m_TEX0.TBW)))
 			ds->m_TEX0 = ZBUF_TEX0;
 	}
 	else if (!m_texture_shuffle)
@@ -2781,12 +2781,6 @@ void GSRendererHW::Draw()
 
 	// Temporary source *must* be invalidated before normal, because otherwise it'll be double freed.
 	g_texture_cache->InvalidateTemporarySource();
-
-	// Set the RT format back to 32bits after the shuffle.
-	if (rt && m_texture_shuffle && rt->m_32_bits_fmt)
-	{
-		rt->m_TEX0.PSM = PSMCT32;
-	}
 
 	// Invalidation of old targets when changing to double-buffering.
 	if (old_rt)

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -1878,7 +1878,7 @@ void GSRendererHW::Draw()
 					   (tex_is_rt && GSLocalMemory::m_psm[m_cached_ctx.TEX0.PSM].trbpp != 24)));
 	bool preserve_rt_color = preserve_rt_rgb || preserve_rt_alpha;
 	bool preserve_depth =
-		preserve_rt_color || (!no_ds && (!all_depth_tests_pass || !m_cached_ctx.DepthWrite() || m_cached_ctx.TEST.ATE));
+		not_writing_to_all || (!no_ds && (!all_depth_tests_pass || !m_cached_ctx.DepthWrite() || m_cached_ctx.TEST.ATE));
 
 	// SW CLUT Render enable.
 	bool force_preload = GSConfig.PreloadFrameWithGSData;
@@ -2007,11 +2007,12 @@ void GSRendererHW::Draw()
 			height_invalid = false;
 		}
 
-		const bool is_zero_clear = (GetConstantDirectWriteMemClearColor() == 0 && !preserve_rt_color);
+		const bool is_zero_color_clear = (GetConstantDirectWriteMemClearColor() == 0 && !preserve_rt_color);
+		const bool is_zero_depth_clear = (GetConstantDirectWriteMemClearDepth() == 0 && !preserve_depth);
 
 		// If it's an invalid-sized draw, do the mem clear on the CPU, we don't want to create huge targets.
 		// If clearing to zero, don't bother creating the target. Games tend to clear more than they use, wasting VRAM/bandwidth.
-		if (is_zero_clear || height_invalid)
+		if (is_zero_color_clear || is_zero_depth_clear || height_invalid)
 		{
 			const u32 rt_end_bp = GSLocalMemory::GetUnwrappedEndBlockAddress(
 				m_cached_ctx.FRAME.Block(), m_cached_ctx.FRAME.FBW, m_cached_ctx.FRAME.PSM, m_r);
@@ -2031,40 +2032,13 @@ void GSRendererHW::Draw()
 						 GSTextureCache::DepthStencil, ds_end_bp)) == nullptr ||
 					m_r.rintersect(tgt->m_valid).eq(tgt->m_valid));
 
-			if (overwriting_whole_rt && overwriting_whole_ds && TryGSMemClear())
+			if (overwriting_whole_rt && overwriting_whole_ds &&
+				TryGSMemClear(no_rt, preserve_rt_color, is_zero_color_clear, rt_end_bp,
+					no_ds, preserve_depth, is_zero_depth_clear, ds_end_bp))
 			{
 				GL_INS("Skipping (%d,%d=>%d,%d) draw at FBP %x/ZBP %x due to invalid height or zero clear.", m_r.x, m_r.y,
 					m_r.z, m_r.w, m_cached_ctx.FRAME.Block(), m_cached_ctx.ZBUF.Block());
 
-				if (!no_rt)
-				{
-					g_texture_cache->InvalidateVideoMem(m_context->offset.fb, m_r, false);
-					g_texture_cache->InvalidateContainedTargets(
-						GSLocalMemory::GetStartBlockAddress(
-							m_cached_ctx.FRAME.Block(), m_cached_ctx.FRAME.FBW, m_cached_ctx.FRAME.PSM, m_r),
-						rt_end_bp, m_cached_ctx.FRAME.PSM);
-				}
-
-				if (!no_ds && m_cached_ctx.ZBUF.ZMSK == 0)
-				{
-					g_texture_cache->InvalidateVideoMem(m_context->offset.zb, m_r, false);
-					g_texture_cache->InvalidateContainedTargets(
-						GSLocalMemory::GetStartBlockAddress(
-							m_cached_ctx.ZBUF.Block(), m_cached_ctx.FRAME.FBW, m_cached_ctx.ZBUF.PSM, m_r),
-						ds_end_bp, m_cached_ctx.ZBUF.PSM);
-				}
-
-				if (!no_rt && is_zero_clear)
-				{
-					GSUploadQueue clear_queue;
-					clear_queue.draw = s_n;
-					clear_queue.rect = m_r;
-					clear_queue.blit.DBP = m_cached_ctx.FRAME.Block();
-					clear_queue.blit.DBW = m_cached_ctx.FRAME.FBW;
-					clear_queue.blit.DPSM = m_cached_ctx.FRAME.PSM;
-					clear_queue.zero_clear = true;
-					m_draw_transfers.push_back(clear_queue);
-				}
 				CleanupDraw(false);
 				return;
 			}
@@ -2296,8 +2270,17 @@ void GSRendererHW::Draw()
 			if (is_clear)
 			{
 				GL_INS("Clear draw with no target, skipping.");
+
+				const bool is_zero_color_clear = (GetConstantDirectWriteMemClearColor() == 0 && !preserve_rt_color);
+				const bool is_zero_depth_clear = (GetConstantDirectWriteMemClearDepth() == 0 && !preserve_depth);
+				const u32 rt_end_bp = GSLocalMemory::GetUnwrappedEndBlockAddress(
+					m_cached_ctx.FRAME.Block(), m_cached_ctx.FRAME.FBW, m_cached_ctx.FRAME.PSM, m_r);
+				const u32 ds_end_bp = GSLocalMemory::GetUnwrappedEndBlockAddress(
+					m_cached_ctx.ZBUF.Block(), m_cached_ctx.FRAME.FBW, m_cached_ctx.ZBUF.PSM, m_r);
+				TryGSMemClear(no_rt, preserve_rt_color, is_zero_color_clear, rt_end_bp,
+					no_ds, preserve_depth, is_zero_depth_clear, ds_end_bp);
+
 				CleanupDraw(true);
-				TryGSMemClear();
 				return;
 			}
 
@@ -5844,7 +5827,8 @@ bool GSRendererHW::TryTargetClear(GSTextureCache::Target* rt, GSTextureCache::Ta
 	return skip;
 }
 
-bool GSRendererHW::TryGSMemClear()
+bool GSRendererHW::TryGSMemClear(bool no_rt, bool preserve_rt, bool invalidate_rt, u32 rt_end_bp,
+	bool no_ds, bool preserve_z, bool invalidate_z, u32 ds_end_bp)
 {
 	if (!PrimitiveCoversWithoutGaps())
 		return false;
@@ -5854,25 +5838,44 @@ bool GSRendererHW::TryGSMemClear()
 	if (m_r.width() < ((static_cast<int>(m_cached_ctx.FRAME.FBW) - 1) * 64))
 		return false;
 
-	// Don't mem clear one of frame or z, only do both.
-	const u32 fmsk = GSLocalMemory::m_psm[m_cached_ctx.FRAME.PSM].fmsk;
-	const u32 fbmsk = (m_cached_ctx.FRAME.FBMSK & fmsk);
-	const bool clear_rt = (fbmsk & fmsk) != fmsk;
-	const bool clear_z = (m_cached_ctx.ZBUF.ZMSK == 0);
-	if ((clear_rt && ((fbmsk != 0 && (m_cached_ctx.FRAME.PSM != PSMCT32 || fbmsk != 0xFF000000u)) ||
-						 m_vt.m_eq.rgba != 0xFFFF)) ||
-		(clear_z && (m_cached_ctx.ZBUF.ZMSK != 0 && !m_vt.m_eq.z)))
+	if (!no_rt && !preserve_rt)
 	{
-		return false;
-	}
-
-	if (clear_rt)
 		ClearGSLocalMemory(m_context->offset.fb, m_r, GetConstantDirectWriteMemClearColor());
 
-	if (clear_z)
+		if (invalidate_rt)
+		{
+			g_texture_cache->InvalidateVideoMem(m_context->offset.fb, m_r, false);
+			g_texture_cache->InvalidateContainedTargets(
+				GSLocalMemory::GetStartBlockAddress(
+					m_cached_ctx.FRAME.Block(), m_cached_ctx.FRAME.FBW, m_cached_ctx.FRAME.PSM, m_r),
+				rt_end_bp, m_cached_ctx.FRAME.PSM);
+
+			GSUploadQueue clear_queue;
+			clear_queue.draw = s_n;
+			clear_queue.rect = m_r;
+			clear_queue.blit.DBP = m_cached_ctx.FRAME.Block();
+			clear_queue.blit.DBW = m_cached_ctx.FRAME.FBW;
+			clear_queue.blit.DPSM = m_cached_ctx.FRAME.PSM;
+			clear_queue.zero_clear = true;
+			m_draw_transfers.push_back(clear_queue);
+		}
+	}
+
+	if (!no_ds && !preserve_z)
+	{
 		ClearGSLocalMemory(m_context->offset.zb, m_r, m_vertex.buff[1].XYZ.Z);
 
-	return true;
+		if (invalidate_z)
+		{
+			g_texture_cache->InvalidateVideoMem(m_context->offset.zb, m_r, false);
+			g_texture_cache->InvalidateContainedTargets(
+				GSLocalMemory::GetStartBlockAddress(
+					m_cached_ctx.ZBUF.Block(), m_cached_ctx.FRAME.FBW, m_cached_ctx.ZBUF.PSM, m_r),
+				ds_end_bp, m_cached_ctx.ZBUF.PSM);
+		}
+	}
+
+	return ((invalidate_rt || no_rt) && (invalidate_z || no_ds));
 }
 
 void GSRendererHW::ClearGSLocalMemory(const GSOffset& off, const GSVector4i& r, u32 vert_color)
@@ -6198,6 +6201,12 @@ u32 GSRendererHW::GetConstantDirectWriteMemClearColor() const
 		vert_color &= 0x80F8F8F8u;
 
 	return vert_color;
+}
+
+u32 GSRendererHW::GetConstantDirectWriteMemClearDepth() const
+{
+	const u32 max_z = (0xFFFFFFFF >> (GSLocalMemory::m_psm[m_cached_ctx.ZBUF.PSM].fmt * 8));
+	return std::min(m_vertex.buff[1].XYZ.Z, max_z);
 }
 
 bool GSRendererHW::IsReallyDithered() const

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -2054,6 +2054,17 @@ void GSRendererHW::Draw()
 						ds_end_bp, m_cached_ctx.ZBUF.PSM);
 				}
 
+				if (!no_rt && is_zero_clear)
+				{
+					GSUploadQueue clear_queue;
+					clear_queue.draw = s_n;
+					clear_queue.rect = m_r;
+					clear_queue.blit.DBP = m_cached_ctx.FRAME.Block();
+					clear_queue.blit.DBW = m_cached_ctx.FRAME.FBW;
+					clear_queue.blit.DPSM = m_cached_ctx.FRAME.PSM;
+					clear_queue.zero_clear = true;
+					m_draw_transfers.push_back(clear_queue);
+				}
 				CleanupDraw(false);
 				return;
 			}
@@ -2197,9 +2208,12 @@ void GSRendererHW::Draw()
 			tgt = nullptr;
 		}
 		const bool possible_shuffle = ((rt_32bit && GSLocalMemory::m_psm[m_cached_ctx.FRAME.PSM].bpp == 16) || m_cached_ctx.FRAME.Block() == m_cached_ctx.TEX0.TBP0) || IsPossibleChannelShuffle();
+		const bool req_color = m_context->ALPHA.IsUsingCs();
+		const bool req_alpha = m_context->TEX0.TCC && (m_cached_ctx.FRAME.FBMSK & (fm_mask & 0xFF000000)) != (fm_mask & 0xFF000000);
 
-		src = tex_psm.depth ? g_texture_cache->LookupDepthSource(TEX0, env.TEXA, MIP_CLAMP, tmm.coverage, possible_shuffle, m_vt.IsLinear(), m_cached_ctx.FRAME.Block()) :
-								g_texture_cache->LookupSource(TEX0, env.TEXA, MIP_CLAMP, tmm.coverage, (GSConfig.HWMipmap >= HWMipmapLevel::Basic || GSConfig.TriFilter == TriFiltering::Forced) ? &hash_lod_range : nullptr, possible_shuffle, m_vt.IsLinear(), m_cached_ctx.FRAME.Block());
+		src = tex_psm.depth ? g_texture_cache->LookupDepthSource(TEX0, env.TEXA, MIP_CLAMP, tmm.coverage, possible_shuffle, m_vt.IsLinear(), m_cached_ctx.FRAME.Block(), req_color, req_alpha) :
+								g_texture_cache->LookupSource(TEX0, env.TEXA, MIP_CLAMP, tmm.coverage, (GSConfig.HWMipmap >= HWMipmapLevel::Basic || GSConfig.TriFilter == TriFiltering::Forced) ? &hash_lod_range : nullptr,
+															possible_shuffle, m_vt.IsLinear(), m_cached_ctx.FRAME.Block(), req_color, req_alpha);
 
 		if (unlikely(!src))
 		{

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -428,7 +428,7 @@ void GSRendererHW::ConvertSpriteTextureShuffle(bool& write_ba, bool& read_ba, GS
 			// No super source of truth here, since the width can get batted around, the valid is probably our best bet.
 			const int tex_width = tex->m_target ? tex->m_from_target->m_valid.z : (tex->m_TEX0.TBW * 64);
 			const int tex_tbw = tex->m_target ? tex->m_from_target_TEX0.TBW : tex->m_TEX0.TBW;
-			if (static_cast<int>(m_cached_ctx.TEX0.TBW * 64) >= std::min(tex_width * 2, 1024) && tex_tbw != m_cached_ctx.TEX0.TBW || (m_cached_ctx.TEX0.TBW * 64) < floor(m_vt.m_max.t.x))
+			if ((static_cast<int>(m_cached_ctx.TEX0.TBW * 64) >= std::min(tex_width * 2, 1024) && tex_tbw != m_cached_ctx.TEX0.TBW) || (m_cached_ctx.TEX0.TBW * 64) < floor(m_vt.m_max.t.x))
 			{
 				half_right_uv = false;
 				half_right_vert = false;
@@ -2802,7 +2802,7 @@ void GSRendererHW::Draw()
 	{
 		//ds->m_valid = ds->m_valid.runion(r);
 		// Limit to 2x the vertical height of the resolution (for double buffering)
-		ds->UpdateValidity(m_r, can_update_size || m_r.w <= (resolution.y * 2) && !m_texture_shuffle);
+		ds->UpdateValidity(m_r, can_update_size || (m_r.w <= (resolution.y * 2) && !m_texture_shuffle));
 
 		g_texture_cache->InvalidateVideoMem(context->offset.zb, m_r, false);
 

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.h
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.h
@@ -123,7 +123,7 @@ private:
 	
 	// We modify some of the context registers to optimize away unnecessary operations.
 	// Instead of messing with the real context, we copy them and use those instead.
-	struct
+	struct HWCachedCtx
 	{
 		GIFRegTEX0 TEX0;
 		GIFRegCLAMP CLAMP;
@@ -143,7 +143,7 @@ private:
 
 			return ZBUF.ZMSK == 0 && TEST.ZTE != 0; // ZTE == 0 is bug on the real hardware, write is blocked then
 		}
-	} m_cached_ctx;
+	};
 
 	// CRC Hacks
 	bool IsBadFrame();
@@ -174,6 +174,7 @@ private:
 	GSVector2i m_lod = {}; // Min & Max level of detail
 
 	GSHWDrawConfig m_conf = {};
+	HWCachedCtx m_cached_ctx;
 
 	// software sprite renderer state
 	std::vector<GSVertexSW> m_sw_vertex_buffer;
@@ -185,7 +186,7 @@ public:
 	virtual ~GSRendererHW() override;
 
 	__fi static GSRendererHW* GetInstance() { return static_cast<GSRendererHW*>(g_gs_renderer.get()); }
-
+	__fi HWCachedCtx* GetCachedCtx() { return &m_cached_ctx; }
 	void Destroy() override;
 
 	void UpdateRenderFixes() override;

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.h
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.h
@@ -45,7 +45,8 @@ private:
 
 	// Require special argument
 	bool OI_BlitFMV(GSTextureCache::Target* _rt, GSTextureCache::Source* t, const GSVector4i& r_draw);
-	bool TryGSMemClear();
+	bool TryGSMemClear(bool no_rt, bool preserve_rt, bool invalidate_rt, u32 rt_end_bp, bool no_ds,
+		bool preserve_z, bool invalidate_z, u32 ds_end_bp);
 	void ClearGSLocalMemory(const GSOffset& off, const GSVector4i& r, u32 vert_color);
 	bool DetectDoubleHalfClear(bool& no_rt, bool& no_ds);
 	bool DetectStripedDoubleClear(bool& no_rt, bool& no_ds);
@@ -60,6 +61,7 @@ private:
 	bool CanUseSwSpriteRender();
 	bool IsConstantDirectWriteMemClear();
 	u32 GetConstantDirectWriteMemClearColor() const;
+	u32 GetConstantDirectWriteMemClearDepth() const;
 	bool IsReallyDithered() const;
 	bool IsDiscardingDstColor();
 	bool IsDiscardingDstRGB();

--- a/pcsx2/GS/Renderers/HW/GSRendererHWMultiISA.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHWMultiISA.cpp
@@ -567,6 +567,7 @@ bool GSRendererHWFunctions::SwPrimRender(GSRendererHW& hw, bool invalidate_tc, b
 		uq.blit.DPSM = hw.m_cached_ctx.FRAME.PSM;
 		uq.draw = GSState::s_n;
 		uq.rect = bbox;
+		uq.zero_clear = false;
 		hw.m_draw_transfers.push_back(uq);
 	}
 

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -2837,7 +2837,9 @@ void GSTextureCache::InvalidateLocalMem(const GSOffset& off, const GSVector4i& r
 
 					Read(t, draw_rect);
 
-					z_found = read_start >= t->m_TEX0.TBP0 && read_end <= t->m_end_block;
+					// Getaway (J) stores a Z texture at 0x2800 which it uses and the next frame it stores the reflection map in
+					// 0x2800, so this will misdetect. So if it's not expecting a Z, check for RT's too.
+					z_found = read_start >= t->m_TEX0.TBP0 && read_end <= t->m_end_block && GSLocalMemory::m_psm[psm].depth == GSLocalMemory::m_psm[t->m_TEX0.PSM].depth;
 
 					if (draw_rect.rintersect(t->m_drawn_since_read).eq(t->m_drawn_since_read))
 						t->m_drawn_since_read = GSVector4i::zero();

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -4008,6 +4008,13 @@ GSTextureCache::Source* GSTextureCache::CreateSource(const GIFRegTEX0& TEX0, con
 	}
 	else
 	{
+		if (GSUtil::GetChannelMask(TEX0.PSM) == 0xf && TEX0.TBP0 != GSRendererHW::GetInstance()->GetCachedCtx()->FRAME.Block() && TEX0.TBP0 != GSRendererHW::GetInstance()->GetCachedCtx()->ZBUF.Block())
+		{
+			// Kill any possible targets we missed, they might be wrong now.
+			g_texture_cache->InvalidateVideoMemType(GSTextureCache::RenderTarget, TEX0.TBP0, TEX0.PSM, GSRendererHW::GetInstance()->GetCachedCtx()->FRAME.FBMSK, true);
+			g_texture_cache->InvalidateVideoMemType(GSTextureCache::DepthStencil, TEX0.TBP0, TEX0.PSM, GSRendererHW::GetInstance()->GetCachedCtx()->FRAME.FBMSK, true);
+		}
+
 		// maintain the clut even when paltex is on for the dump/replacement texture lookup
 		bool paltex = (GSConfig.GPUPaletteConversion && psm.pal > 0) || gpu_clut;
 		const u32* clut = (psm.pal > 0) ? static_cast<const u32*>(g_gs_renderer->m_mem.m_clut) : nullptr;

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.h
@@ -479,7 +479,7 @@ public:
 	Target* FindTargetOverlap(Target* target, int type, int psm);
 	Target* LookupTarget(GIFRegTEX0 TEX0, const GSVector2i& size, float scale, int type, bool used = true, u32 fbmask = 0,
 		bool is_frame = false, bool preload = GSConfig.PreloadFrameWithGSData, bool preserve_rgb = true, bool preserve_alpha = true,
-		const GSVector4i draw_rc = GSVector4i::zero());
+		const GSVector4i draw_rc = GSVector4i::zero(), bool is_shuffle = false);
 	Target* CreateTarget(GIFRegTEX0 TEX0, const GSVector2i& size, const GSVector2i& valid_size,float scale, int type, bool used = true, u32 fbmask = 0,
 		bool is_frame = false, bool preload = GSConfig.PreloadFrameWithGSData, bool preserve_target = true,
 		const GSVector4i draw_rc = GSVector4i::zero(), GSTextureCache::Source* src = nullptr);

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.h
@@ -241,7 +241,7 @@ public:
 		static Target* Create(GIFRegTEX0 TEX0, int w, int h, float scale, int type, bool clear);
 
 		__fi bool HasValidAlpha() const { return (m_valid_alpha_low | m_valid_alpha_high); }
-		bool HasValidBitsForFormat(u32 psm) const;
+		bool HasValidBitsForFormat(u32 psm, bool req_color, bool req_alpha);
 
 		void ResizeDrawn(const GSVector4i& rect);
 		void UpdateDrawn(const GSVector4i& rect, bool can_resize = true);
@@ -423,7 +423,7 @@ protected:
 
 	Source* CreateSource(const GIFRegTEX0& TEX0, const GIFRegTEXA& TEXA, Target* t, bool half_right, int x_offset, int y_offset, const GSVector2i* lod, const GSVector4i* src_range, GSTexture* gpu_clut, SourceRegion region);
 
-	void PreloadTarget(GIFRegTEX0 TEX0, const GSVector2i& size, const GSVector2i& valid_size, bool is_frame,
+	bool PreloadTarget(GIFRegTEX0 TEX0, const GSVector2i& size, const GSVector2i& valid_size, bool is_frame,
 		bool preload, bool preserve_target, const GSVector4i draw_rect, Target* dst, GSTextureCache::Source* src = nullptr);
 
 	// Returns scaled texture size.
@@ -473,8 +473,8 @@ public:
 	GSTexture* LookupPaletteSource(u32 CBP, u32 CPSM, u32 CBW, GSVector2i& offset, float* scale, const GSVector2i& size);
 	std::shared_ptr<Palette> LookupPaletteObject(const u32* clut, u16 pal, bool need_gs_texture);
 
-	Source* LookupSource(const GIFRegTEX0& TEX0, const GIFRegTEXA& TEXA, const GIFRegCLAMP& CLAMP, const GSVector4i& r, const GSVector2i* lod, const bool possible_shuffle, const bool linear, const u32 frame_fbp = 0xFFFFFFFF);
-	Source* LookupDepthSource(const GIFRegTEX0& TEX0, const GIFRegTEXA& TEXA, const GIFRegCLAMP& CLAMP, const GSVector4i& r, const bool possible_shuffle, const bool linear, const u32 frame_fbp = 0xFFFFFFFF, bool palette = false);
+	Source* LookupSource(const GIFRegTEX0& TEX0, const GIFRegTEXA& TEXA, const GIFRegCLAMP& CLAMP, const GSVector4i& r, const GSVector2i* lod, const bool possible_shuffle, const bool linear, const u32 frame_fbp = 0xFFFFFFFF, bool req_color = true, bool req_alpha = true);
+	Source* LookupDepthSource(const GIFRegTEX0& TEX0, const GIFRegTEXA& TEXA, const GIFRegCLAMP& CLAMP, const GSVector4i& r, const bool possible_shuffle, const bool linear, const u32 frame_fbp = 0xFFFFFFFF, bool req_color = true, bool req_alpha = true, bool palette = false);
 
 	Target* FindTargetOverlap(Target* target, int type, int psm);
 	Target* LookupTarget(GIFRegTEX0 TEX0, const GSVector2i& size, float scale, int type, bool used = true, u32 fbmask = 0,

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.h
@@ -495,7 +495,7 @@ public:
 	bool Has32BitTarget(u32 bp);
 
 	void InvalidateContainedTargets(u32 start_bp, u32 end_bp, u32 write_psm = PSMCT32);
-	void InvalidateVideoMemType(int type, u32 bp, u32 write_psm = PSMCT32, u32 write_fbmsk = 0);
+	void InvalidateVideoMemType(int type, u32 bp, u32 write_psm = PSMCT32, u32 write_fbmsk = 0, bool dirty_only = false);
 	void InvalidateVideoMemSubTarget(GSTextureCache::Target* rt);
 	void InvalidateVideoMem(const GSOffset& off, const GSVector4i& r, bool target = true);
 	void InvalidateLocalMem(const GSOffset& off, const GSVector4i& r, bool full_flush = false);

--- a/pcsx2/GameDatabase.cpp
+++ b/pcsx2/GameDatabase.cpp
@@ -339,7 +339,6 @@ static const char* s_gs_hw_fix_names[] = {
 	"disableDepthSupport",
 	"preloadFrameData",
 	"disablePartialInvalidation",
-	"partialTargetInvalidation",
 	"textureInsideRT",
 	"alignSprite",
 	"mergeSprite",
@@ -559,9 +558,6 @@ bool GameDatabaseSchema::GameEntry::configMatchesHWFix(const Pcsx2Config::GSOpti
 		case GSHWFixId::DisablePartialInvalidation:
 			return (static_cast<int>(config.UserHacks_DisablePartialInvalidation) == value);
 
-		case GSHWFixId::TargetPartialInvalidation:
-			return (static_cast<int>(config.UserHacks_TargetPartialInvalidation) == value);
-
 		case GSHWFixId::TextureInsideRT:
 			return (static_cast<int>(config.UserHacks_TextureInsideRt) == value);
 
@@ -699,10 +695,6 @@ void GameDatabaseSchema::GameEntry::applyGSHardwareFixes(Pcsx2Config::GSOptions&
 
 			case GSHWFixId::DisablePartialInvalidation:
 				config.UserHacks_DisablePartialInvalidation = (value > 0);
-				break;
-
-			case GSHWFixId::TargetPartialInvalidation:
-				config.UserHacks_TargetPartialInvalidation = (value > 0);
 				break;
 
 			case GSHWFixId::TextureInsideRT:

--- a/pcsx2/GameDatabase.h
+++ b/pcsx2/GameDatabase.h
@@ -66,7 +66,6 @@ namespace GameDatabaseSchema
 		DisableDepthSupport,
 		PreloadFrameData,
 		DisablePartialInvalidation,
-		TargetPartialInvalidation,
 		TextureInsideRT,
 		AlignSprite,
 		MergeSprite,

--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -3260,10 +3260,6 @@ void FullscreenUI::DrawGraphicsSettingsPage()
 			DrawIntListSetting(bsi, "Texture Inside Render Target",
 				"Allows the texture cache to reuse as an input texture the inner portion of a previous framebuffer.", "EmuCore/GS",
 				"UserHacks_TextureInsideRt", 0, s_texture_inside_rt_options, std::size(s_texture_inside_rt_options), 0, manual_hw_fixes);
-			DrawToggleSetting(bsi, "Target Partial Invalidation",
-				"Allows partial invalidation of render targets, which can fix graphical errors in some games.", "EmuCore/GS",
-				"UserHacks_TargetPartialInvalidation", false,
-				!GetEffectiveBoolSetting(bsi, "EmuCore/GS", "UserHacks_TextureInsideRt", false));
 			DrawToggleSetting(bsi, "Read Targets When Closing",
 				"Flushes all targets in the texture cache back to local memory when shutting down.", "EmuCore/GS",
 				"UserHacks_ReadTCOnClose", false, manual_hw_fixes);

--- a/pcsx2/ImGui/ImGuiOverlays.cpp
+++ b/pcsx2/ImGui/ImGuiOverlays.cpp
@@ -426,8 +426,6 @@ void ImGuiManager::DrawSettingsOverlay()
 			APPEND("DDE ");
 		if (GSConfig.UserHacks_DisablePartialInvalidation)
 			APPEND("DPIV ");
-		if (GSConfig.UserHacks_TargetPartialInvalidation)
-			APPEND("TPI ");
 		if (GSConfig.UserHacks_DisableSafeFeatures)
 			APPEND("DSF ");
 		if (GSConfig.UserHacks_DisableRenderFixes)

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -762,7 +762,6 @@ void Pcsx2Config::GSOptions::LoadSave(SettingsWrapper& wrap)
 	GSSettingIntEnumEx(UserHacks_BilinearHack, "UserHacks_BilinearHack");
 	GSSettingBoolEx(UserHacks_NativePaletteDraw, "UserHacks_NativePaletteDraw");
 	GSSettingIntEnumEx(UserHacks_TextureInsideRt, "UserHacks_TextureInsideRt");
-	GSSettingBoolEx(UserHacks_TargetPartialInvalidation, "UserHacks_TargetPartialInvalidation");
 	GSSettingBoolEx(UserHacks_EstimateTextureRegion, "UserHacks_EstimateTextureRegion");
 	GSSettingBoolEx(FXAA, "fxaa");
 	GSSettingBool(ShadeBoost);
@@ -889,7 +888,6 @@ void Pcsx2Config::GSOptions::MaskUserHacks()
 	UserHacks_CPUFBConversion = false;
 	UserHacks_ReadTCOnClose = false;
 	UserHacks_TextureInsideRt = GSTextureInRtMode::Disabled;
-	UserHacks_TargetPartialInvalidation = false;
 	UserHacks_EstimateTextureRegion = false;
 	UserHacks_TCOffsetX = 0;
 	UserHacks_TCOffsetY = 0;


### PR DESCRIPTION
### Description of Changes
Overhauls a bunch of the GPU invalidation to try and make it suck less.

### Rationale behind Changes
It wasn't brilliant and broke down in many places.

### Suggested Testing Steps
Test anything you like, reports of broken games are welcome (and GS dumps) but this is WIP for now.

### TODO's
- [x] Remove the "Partial Target Invalidation" option from the UI, this option no longer does anything.
- [x] Remove above entries from GameDB

### Fixed things:

Fixes Indiana Jones as originally noted here #8971.
Fixes https://github.com/PCSX2/pcsx2/issues/9143 MGS3 garbage.
Fixes #8883 Radiata Stories fireplace shadows.
Fixes regression on Dark Cloud 2 faces.
Fixes Kung Fu Panda FMV's.
~~Fixes DNA - Dark Native Apostle shadows (now match SW)~~ This was still broken, but fixed in another PR which merged.
~~Fixes subtle bug in True Crime NYC~~ Fixed by another PR which merged.
Improves Z invalidation (required for FFX once #9302 merges).
Fixes #9791 by deleting old targets which are no longer valid.
Fixes problem with the "Winner" screen in Naruto Ultimate Ninja 3 (problem was exposed by v1.7.4882).
Improves reliability of Dragon Quest 8 rendering.
Improves Dog's Life, stop Jake turning in to a clown randomly.
Fixes #3351 shadows in Everybody's Golf/Tennis.
Mostly corrects the black screen in Katamari 2 player split screen #8353.
Fixes #9132 Wrestle Kingdom health bars breaking when doing a rematch.

### Broken things (currently):

~~Hitman Blood Money - Shows some rainbow texture in bottom right~~ Added hack, explained in [comments](https://github.com/PCSX2/pcsx2/pull/9315#issuecomment-1656810774)

### Broken and won't be fixed:
TOCA 3 reflections - It tries to read a misaligned target, so this is technically broken on master too, it just looks worse here, but the game is kinda broken anyway.
ATV Offroad Fury 2 - Will hang going ingame if you use hardware mode, this has *never* really worked, it just by some fluke didn't completely die. The game does complex moving between the frame and z buffer, then downloads it, this doesn't work in PCSX2, so the game doesn't know how to handle it. I recommend you use software mode for this game until it can be fixed/worked around.

### Dump runner shows broken but is fine normally:

MGS 3 - Depth of Field blur is missing in runner but is fine when run normally
Ape Escape 3 - Runner shows corrupted sky, looks fine normally

### Glamour shots:

Kung Fu Panda
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/54be9d6a-89b4-4a94-976f-a3d332e4e7a3)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/35a9c898-a0bd-43e9-b39a-5f0f57ef55fa)

Dark Cloud 2
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/c85a5f6c-67dc-4ab1-9db2-6ba99c10e344)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/2c70941f-19f6-4bb0-88a6-ac75206ec7d6)

Radiata Stories
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/1b78b5e7-a264-42a9-b3d1-7d7a19580dc1)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/703873b3-72c6-4406-9359-2f7119b82ea2)

Indiana Jones
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/27bc32a2-a425-4b58-9d1f-100203e0c48f)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/d6e32e86-cea0-4480-9d1c-3d67c18b54d0)
