### PR TITLE
USB-Turntable: Implement Freeze()

### DIFF
--- a/pcsx2/USB/usb-pad/usb-turntable.cpp
+++ b/pcsx2/USB/usb-pad/usb-turntable.cpp
@@ -282,6 +282,17 @@ namespace usb_pad
 		return nullptr;
 	}
 
+	bool DJTurntableDevice::Freeze(USBDevice* dev, StateWrapper& sw) const
+	{
+		TurntableState* s = USB_CONTAINER_OF(dev, TurntableState, dev);
+		
+		if (!sw.DoMarker("DJTurntableDevice"))
+			return false;
+
+		sw.Do(&s->data.euphoria_led_state);
+		return !sw.HasError();
+	}
+
 	void DJTurntableDevice::UpdateSettings(USBDevice* dev, SettingsInterface& si) const
 	{
 		USB_CONTAINER_OF(dev, TurntableState, dev)->UpdateSettings(si, TypeName());

--- a/pcsx2/USB/usb-pad/usb-turntable.h
+++ b/pcsx2/USB/usb-pad/usb-turntable.h
@@ -100,6 +100,7 @@ namespace usb_pad
 		const char* TypeName() const override;
 		float GetBindingValue(const USBDevice* dev, u32 bind_index) const override;
 		void SetBindingValue(USBDevice* dev, u32 bind_index, float value) const override;
+		bool Freeze(USBDevice* dev, StateWrapper& sw) const override;
 		void UpdateSettings(USBDevice* dev, SettingsInterface& si) const override;
 		std::span<const InputBindingInfo> Bindings(u32 subtype) const override;
 		std::span<const SettingInfo> Settings(u32 subtype) const override;


### PR DESCRIPTION
### Description of Changes

I missed this during review.

### Rationale behind Changes

Prevents save states being created with the device connected.

### Suggested Testing Steps

CI passes.

