### PR TITLE
USB-GunCon2: Support binding to controller

### DIFF
--- a/pcsx2-gsrunner/Main.cpp
+++ b/pcsx2-gsrunner/Main.cpp
@@ -255,7 +255,7 @@ void Host::OnInputDeviceDisconnected(const std::string_view& identifier)
 {
 }
 
-void Host::SetRelativeMouseMode(bool enabled)
+void Host::SetMouseMode(bool relative_mode, bool hide_cursor)
 {
 }
 

--- a/pcsx2-qt/CMakeLists.txt
+++ b/pcsx2-qt/CMakeLists.txt
@@ -133,6 +133,7 @@ target_sources(pcsx2-qt PRIVATE
 	Settings/SettingsDialog.ui
 	Settings/USBBindingWidget_DrivingForce.ui
 	Settings/USBBindingWidget_GTForce.ui
+	Settings/USBBindingWidget_GunCon2.ui
 	Debugger/CpuWidget.cpp
 	Debugger/CpuWidget.h
 	Debugger/CpuWidget.ui

--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -414,7 +414,7 @@ void MainWindow::connectVMThreadSignals(EmuThread* thread)
 	connect(thread, &EmuThread::onAcquireRenderWindowRequested, this, &MainWindow::acquireRenderWindow, Qt::BlockingQueuedConnection);
 	connect(thread, &EmuThread::onReleaseRenderWindowRequested, this, &MainWindow::releaseRenderWindow, Qt::BlockingQueuedConnection);
 	connect(thread, &EmuThread::onResizeRenderWindowRequested, this, &MainWindow::displayResizeRequested);
-	connect(thread, &EmuThread::onRelativeMouseModeRequested, this, &MainWindow::relativeMouseModeRequested);
+	connect(thread, &EmuThread::onMouseModeRequested, this, &MainWindow::mouseModeRequested);
 	connect(thread, &EmuThread::onVMStarting, this, &MainWindow::onVMStarting);
 	connect(thread, &EmuThread::onVMStarted, this, &MainWindow::onVMStarted);
 	connect(thread, &EmuThread::onVMPaused, this, &MainWindow::onVMPaused);
@@ -887,7 +887,8 @@ bool MainWindow::isRenderingToMain() const
 
 bool MainWindow::shouldHideMouseCursor() const
 {
-	return (isRenderingFullscreen() && Host::GetBoolSettingValue("UI", "HideMouseCursor", false)) || m_relative_mouse_mode;
+	return ((isRenderingFullscreen() && Host::GetBoolSettingValue("UI", "HideMouseCursor", false)) ||
+			m_relative_mouse_mode || m_hide_mouse_cursor);
 }
 
 bool MainWindow::shouldHideMainWindow() const
@@ -2003,12 +2004,13 @@ void MainWindow::displayResizeRequested(qint32 width, qint32 height)
 	QtUtils::ResizePotentiallyFixedSizeWindow(this, width, height + extra_height);
 }
 
-void MainWindow::relativeMouseModeRequested(bool enabled)
+void MainWindow::mouseModeRequested(bool relative_mode, bool hide_cursor)
 {
-	if (m_relative_mouse_mode == enabled)
+	if (m_relative_mouse_mode == relative_mode && m_hide_mouse_cursor == hide_cursor)
 		return;
 
-	m_relative_mouse_mode = enabled;
+	m_relative_mouse_mode = relative_mode;
+	m_hide_mouse_cursor = hide_cursor;
 	if (m_display_widget && !s_vm_paused)
 		updateDisplayWidgetCursor();
 }

--- a/pcsx2-qt/MainWindow.h
+++ b/pcsx2-qt/MainWindow.h
@@ -124,7 +124,7 @@ private Q_SLOTS:
 
 	std::optional<WindowInfo> acquireRenderWindow(bool recreate_window, bool fullscreen, bool render_to_main, bool surfaceless);
 	void displayResizeRequested(qint32 width, qint32 height);
-	void relativeMouseModeRequested(bool enabled);
+	void mouseModeRequested(bool relative_mode, bool hide_cursor);
 	void releaseRenderWindow();
 	void focusDisplayWidget();
 
@@ -293,6 +293,7 @@ private:
 
 	bool m_display_created = false;
 	bool m_relative_mouse_mode = false;
+	bool m_hide_mouse_cursor = false;
 	bool m_was_paused_on_surface_loss = false;
 	bool m_was_disc_change_request = false;
 	bool m_is_closing = false;

--- a/pcsx2-qt/QtHost.cpp
+++ b/pcsx2-qt/QtHost.cpp
@@ -1469,9 +1469,9 @@ void Host::OnInputDeviceDisconnected(const std::string_view& identifier)
 	emit g_emu_thread->onInputDeviceDisconnected(identifier.empty() ? QString() : QString::fromUtf8(identifier.data(), identifier.size()));
 }
 
-void Host::SetRelativeMouseMode(bool enabled)
+void Host::SetMouseMode(bool relative_mode, bool hide_cursor)
 {
-	emit g_emu_thread->onRelativeMouseModeRequested(enabled);
+	emit g_emu_thread->onMouseModeRequested(relative_mode, hide_cursor);
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/pcsx2-qt/QtHost.h
+++ b/pcsx2-qt/QtHost.h
@@ -119,7 +119,7 @@ Q_SIGNALS:
 	std::optional<WindowInfo> onAcquireRenderWindowRequested(bool recreate_window, bool fullscreen, bool render_to_main, bool surfaceless);
 	void onResizeRenderWindowRequested(qint32 width, qint32 height);
 	void onReleaseRenderWindowRequested();
-	void onRelativeMouseModeRequested(bool enabled);
+	void onMouseModeRequested(bool relative_mode, bool hide_cursor);
 
 	/// Called when the VM is starting initialization, but has not been completed yet.
 	void onVMStarting();

--- a/pcsx2-qt/Settings/ControllerBindingWidgets.cpp
+++ b/pcsx2-qt/Settings/ControllerBindingWidgets.cpp
@@ -38,6 +38,7 @@
 
 #include "ui_USBBindingWidget_DrivingForce.h"
 #include "ui_USBBindingWidget_GTForce.h"
+#include "ui_USBBindingWidget_GunCon2.h"
 
 ControllerBindingWidget::ControllerBindingWidget(QWidget* parent, ControllerSettingsDialog* dialog, u32 port)
 	: QWidget(parent)
@@ -1239,6 +1240,11 @@ USBBindingWidget* USBBindingWidget::createInstance(
 			Ui::USBBindingWidget_GTForce().setupUi(widget);
 			has_template = true;
 		}
+	}
+	else if (type == "guncon2")
+	{
+		Ui::USBBindingWidget_GunCon2().setupUi(widget);
+		has_template = true;
 	}
 
 	if (has_template)

--- a/pcsx2-qt/Settings/USBBindingWidget_GunCon2.ui
+++ b/pcsx2-qt/Settings/USBBindingWidget_GunCon2.ui
@@ -1,0 +1,779 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>USBBindingWidget_GunCon2</class>
+ <widget class="QWidget" name="USBBindingWidget_GunCon2">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>1000</width>
+    <height>400</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>1000</width>
+    <height>400</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string notr="true">Form</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout_16">
+   <item row="2" column="2" colspan="2">
+    <widget class="QGroupBox" name="groupBox_16">
+     <property name="title">
+      <string>Buttons</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_10">
+      <item row="0" column="0">
+       <widget class="QGroupBox" name="groupBox_19">
+        <property name="title">
+         <string>A</string>
+        </property>
+        <layout class="QGridLayout" name="gridLayout_19">
+         <property name="leftMargin">
+          <number>6</number>
+         </property>
+         <property name="topMargin">
+          <number>6</number>
+         </property>
+         <property name="rightMargin">
+          <number>6</number>
+         </property>
+         <property name="bottomMargin">
+          <number>6</number>
+         </property>
+         <item row="0" column="0">
+          <widget class="InputBindingWidget" name="A">
+           <property name="minimumSize">
+            <size>
+             <width>200</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>200</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="text">
+            <string notr="true">PushButton</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item row="0" column="3">
+       <widget class="QGroupBox" name="groupBox_20">
+        <property name="title">
+         <string>C</string>
+        </property>
+        <layout class="QGridLayout" name="gridLayout_20">
+         <property name="leftMargin">
+          <number>6</number>
+         </property>
+         <property name="topMargin">
+          <number>6</number>
+         </property>
+         <property name="rightMargin">
+          <number>6</number>
+         </property>
+         <property name="bottomMargin">
+          <number>6</number>
+         </property>
+         <item row="0" column="0">
+          <widget class="InputBindingWidget" name="C">
+           <property name="minimumSize">
+            <size>
+             <width>200</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>200</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="text">
+            <string notr="true">PushButton</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item row="1" column="0" colspan="2">
+       <widget class="QGroupBox" name="groupBox_23">
+        <property name="title">
+         <string>Start</string>
+        </property>
+        <layout class="QGridLayout" name="gridLayout_23">
+         <property name="leftMargin">
+          <number>6</number>
+         </property>
+         <property name="topMargin">
+          <number>6</number>
+         </property>
+         <property name="rightMargin">
+          <number>6</number>
+         </property>
+         <property name="bottomMargin">
+          <number>6</number>
+         </property>
+         <item row="0" column="0">
+          <widget class="InputBindingWidget" name="Start">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>200</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>200</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="text">
+            <string notr="true">PushButton</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item row="1" column="2" colspan="2">
+       <widget class="QGroupBox" name="groupBox_35">
+        <property name="title">
+         <string>Select</string>
+        </property>
+        <layout class="QGridLayout" name="gridLayout_35">
+         <item row="0" column="0">
+          <widget class="InputBindingWidget" name="Select">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>200</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>200</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="text">
+            <string notr="true">PushButton</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item row="0" column="1" colspan="2">
+       <widget class="QGroupBox" name="groupBox_18">
+        <property name="title">
+         <string>B</string>
+        </property>
+        <layout class="QGridLayout" name="gridLayout_18">
+         <property name="leftMargin">
+          <number>6</number>
+         </property>
+         <property name="topMargin">
+          <number>6</number>
+         </property>
+         <property name="rightMargin">
+          <number>6</number>
+         </property>
+         <property name="bottomMargin">
+          <number>6</number>
+         </property>
+         <item row="0" column="0">
+          <widget class="InputBindingWidget" name="B">
+           <property name="minimumSize">
+            <size>
+             <width>200</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>200</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="text">
+            <string notr="true">PushButton</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="0" column="3" rowspan="2">
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>D-Pad</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_5">
+      <item row="3" column="1" colspan="2">
+       <widget class="QGroupBox" name="groupBox_5">
+        <property name="title">
+         <string>Down</string>
+        </property>
+        <layout class="QGridLayout" name="gridLayout_4">
+         <property name="leftMargin">
+          <number>6</number>
+         </property>
+         <property name="topMargin">
+          <number>6</number>
+         </property>
+         <property name="rightMargin">
+          <number>6</number>
+         </property>
+         <property name="bottomMargin">
+          <number>6</number>
+         </property>
+         <item row="0" column="0">
+          <widget class="InputBindingWidget" name="Down">
+           <property name="minimumSize">
+            <size>
+             <width>125</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>125</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="text">
+            <string notr="true">PushButton</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item row="2" column="0" colspan="2">
+       <widget class="QGroupBox" name="groupBox_3">
+        <property name="title">
+         <string>Left</string>
+        </property>
+        <layout class="QGridLayout" name="gridLayout_2">
+         <property name="leftMargin">
+          <number>6</number>
+         </property>
+         <property name="topMargin">
+          <number>6</number>
+         </property>
+         <property name="rightMargin">
+          <number>6</number>
+         </property>
+         <property name="bottomMargin">
+          <number>6</number>
+         </property>
+         <item row="0" column="0">
+          <widget class="InputBindingWidget" name="Left">
+           <property name="minimumSize">
+            <size>
+             <width>125</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>125</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="text">
+            <string notr="true">PushButton</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item row="0" column="1" colspan="2">
+       <widget class="QGroupBox" name="groupBox_2">
+        <property name="title">
+         <string>Up</string>
+        </property>
+        <layout class="QGridLayout" name="gridLayout">
+         <property name="leftMargin">
+          <number>6</number>
+         </property>
+         <property name="topMargin">
+          <number>6</number>
+         </property>
+         <property name="rightMargin">
+          <number>6</number>
+         </property>
+         <property name="bottomMargin">
+          <number>6</number>
+         </property>
+         <item row="0" column="0">
+          <widget class="InputBindingWidget" name="Up">
+           <property name="minimumSize">
+            <size>
+             <width>125</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>125</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="text">
+            <string notr="true">PushButton</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item row="2" column="2" colspan="2">
+       <widget class="QGroupBox" name="groupBox_4">
+        <property name="title">
+         <string>Right</string>
+        </property>
+        <layout class="QGridLayout" name="gridLayout_3">
+         <property name="leftMargin">
+          <number>6</number>
+         </property>
+         <property name="topMargin">
+          <number>6</number>
+         </property>
+         <property name="rightMargin">
+          <number>6</number>
+         </property>
+         <property name="bottomMargin">
+          <number>6</number>
+         </property>
+         <item row="0" column="0">
+          <widget class="InputBindingWidget" name="Right">
+           <property name="minimumSize">
+            <size>
+             <width>125</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>125</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="text">
+            <string notr="true">PushButton</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QGroupBox" name="groupBox_15">
+     <property name="title">
+      <string>Pointer Setup</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <item>
+       <widget class="QLabel" name="label_2">
+        <property name="text">
+         <string>&lt;p&gt;By default, GunCon2 will use the mouse pointer. To use the mouse, you &lt;strong&gt;do not&lt;/strong&gt; need to configure any bindings apart from the trigger and buttons.&lt;/p&gt;
+
+&lt;p&gt;If you want to use a controller, or lightgun which simulates a controller instead of a mouse, then you should bind it to Relative Aiming. Otherwise, Relative Aiming should be &lt;strong&gt;left unbound&lt;/strong&gt;.&lt;/p&gt;</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="0" column="4" rowspan="3">
+    <spacer name="horizontalSpacer">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="0" column="0" rowspan="3">
+    <spacer name="horizontalSpacer_2">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="0" column="2" rowspan="2">
+    <widget class="QGroupBox" name="groupBox_10">
+     <property name="title">
+      <string extracomment="Try to use Sony's official terminology for this. A good place to start would be in the console or the DualShock 2's manual. If this element was officially translated to your language by Sony in later DualShocks, you may use that term.">Relative Aiming</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_11">
+      <item row="3" column="1" colspan="2">
+       <widget class="QGroupBox" name="groupBox_11">
+        <property name="title">
+         <string>Down</string>
+        </property>
+        <layout class="QGridLayout" name="gridLayout_12">
+         <property name="leftMargin">
+          <number>6</number>
+         </property>
+         <property name="topMargin">
+          <number>6</number>
+         </property>
+         <property name="rightMargin">
+          <number>6</number>
+         </property>
+         <property name="bottomMargin">
+          <number>6</number>
+         </property>
+         <item row="0" column="0">
+          <widget class="InputBindingWidget" name="RelativeDown">
+           <property name="minimumSize">
+            <size>
+             <width>100</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>100</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="text">
+            <string notr="true">PushButton</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item row="2" column="0" colspan="2">
+       <widget class="QGroupBox" name="groupBox_12">
+        <property name="title">
+         <string>Left</string>
+        </property>
+        <layout class="QGridLayout" name="gridLayout_13">
+         <property name="leftMargin">
+          <number>6</number>
+         </property>
+         <property name="topMargin">
+          <number>6</number>
+         </property>
+         <property name="rightMargin">
+          <number>6</number>
+         </property>
+         <property name="bottomMargin">
+          <number>6</number>
+         </property>
+         <item row="0" column="0">
+          <widget class="InputBindingWidget" name="RelativeLeft">
+           <property name="minimumSize">
+            <size>
+             <width>100</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>100</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="text">
+            <string notr="true">PushButton</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item row="0" column="1" colspan="2">
+       <widget class="QGroupBox" name="groupBox_13">
+        <property name="title">
+         <string>Up</string>
+        </property>
+        <layout class="QGridLayout" name="gridLayout_14">
+         <property name="leftMargin">
+          <number>6</number>
+         </property>
+         <property name="topMargin">
+          <number>6</number>
+         </property>
+         <property name="rightMargin">
+          <number>6</number>
+         </property>
+         <property name="bottomMargin">
+          <number>6</number>
+         </property>
+         <item row="0" column="0">
+          <widget class="InputBindingWidget" name="RelativeUp">
+           <property name="minimumSize">
+            <size>
+             <width>100</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>100</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="text">
+            <string notr="true">PushButton</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item row="2" column="2" colspan="2">
+       <widget class="QGroupBox" name="groupBox_14">
+        <property name="title">
+         <string>Right</string>
+        </property>
+        <layout class="QGridLayout" name="gridLayout_15">
+         <property name="leftMargin">
+          <number>6</number>
+         </property>
+         <property name="topMargin">
+          <number>6</number>
+         </property>
+         <property name="rightMargin">
+          <number>6</number>
+         </property>
+         <property name="bottomMargin">
+          <number>6</number>
+         </property>
+         <item row="0" column="0">
+          <widget class="InputBindingWidget" name="RelativeRight">
+           <property name="minimumSize">
+            <size>
+             <width>100</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>100</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="text">
+            <string notr="true">PushButton</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="1" column="1" rowspan="2">
+    <widget class="QGroupBox" name="groupBox_6">
+     <property name="title">
+      <string>Trigger</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_9">
+      <item row="0" column="0">
+       <widget class="QGroupBox" name="groupBox_7">
+        <property name="title">
+         <string>Trigger</string>
+        </property>
+        <layout class="QGridLayout" name="gridLayout_6">
+         <property name="leftMargin">
+          <number>6</number>
+         </property>
+         <property name="topMargin">
+          <number>6</number>
+         </property>
+         <property name="rightMargin">
+          <number>6</number>
+         </property>
+         <property name="bottomMargin">
+          <number>6</number>
+         </property>
+         <item row="0" column="0">
+          <widget class="InputBindingWidget" name="Trigger">
+           <property name="minimumSize">
+            <size>
+             <width>125</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>125</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="text">
+            <string notr="true">PushButton</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QGroupBox" name="groupBox_8">
+        <property name="title">
+         <string>Shoot Offscreen</string>
+        </property>
+        <layout class="QGridLayout" name="gridLayout_7">
+         <property name="leftMargin">
+          <number>6</number>
+         </property>
+         <property name="topMargin">
+          <number>6</number>
+         </property>
+         <property name="rightMargin">
+          <number>6</number>
+         </property>
+         <property name="bottomMargin">
+          <number>6</number>
+         </property>
+         <item row="0" column="0">
+          <widget class="InputBindingWidget" name="ShootOffscreen">
+           <property name="minimumSize">
+            <size>
+             <width>125</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>125</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="text">
+            <string notr="true">PushButton</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item row="1" column="0" colspan="2">
+       <widget class="QGroupBox" name="groupBox_9">
+        <property name="title">
+         <string>Calibration Shot</string>
+        </property>
+        <layout class="QGridLayout" name="gridLayout_8">
+         <item row="0" column="1">
+          <widget class="InputBindingWidget" name="Recalibrate">
+           <property name="minimumSize">
+            <size>
+             <width>125</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>125</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="text">
+            <string notr="true">PushButton</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0" colspan="3">
+          <widget class="QLabel" name="label">
+           <property name="text">
+            <string>Calibration shot is required to pass the setup screen in some games.</string>
+           </property>
+           <property name="wordWrap">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="3" column="0" colspan="5">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>InputBindingWidget</class>
+   <extends>QPushButton</extends>
+   <header>Settings/InputBindingWidget.h</header>
+  </customwidget>
+ </customwidgets>
+ <resources>
+  <include location="../resources/resources.qrc"/>
+ </resources>
+ <connections/>
+</ui>

--- a/pcsx2-qt/pcsx2-qt.vcxproj
+++ b/pcsx2-qt/pcsx2-qt.vcxproj
@@ -371,6 +371,9 @@
     </QtUi>
   </ItemGroup>
   <ItemGroup>
+    <QtUi Include="Settings\USBBindingWidget_GunCon2.ui">
+      <FileType>Document</FileType>
+    </QtUi>
     <QtUi Include="SetupWizardDialog.ui">
       <FileType>Document</FileType>
     </QtUi>
@@ -392,8 +395,12 @@
     <QtUi Include="Settings\GamePatchSettingsWidget.ui">
       <FileType>Document</FileType>
     </QtUi>
-    <None Include="Settings\USBBindingWidget_DrivingForce.ui" />
-    <None Include="Settings\USBBindingWidget_GTForce.ui" />
+    <QtUi Include="Settings\USBBindingWidget_DrivingForce.ui">
+      <FileType>Document</FileType>
+    </QtUi>
+    <QtUi Include="Settings\USBBindingWidget_GTForce.ui">
+      <FileType>Document</FileType>
+    </QtUi>
     <QtUi Include="Settings\USBDeviceWidget.ui">
       <FileType>Document</FileType>
     </QtUi>

--- a/pcsx2-qt/pcsx2-qt.vcxproj.filters
+++ b/pcsx2-qt/pcsx2-qt.vcxproj.filters
@@ -621,15 +621,18 @@
       <Filter>Settings</Filter>
     </QtUi>
     <QtUi Include="SetupWizardDialog.ui" />
+    <QtUi Include="Settings\USBBindingWidget_DrivingForce.ui">
+      <Filter>Settings</Filter>
+    </QtUi>
+    <QtUi Include="Settings\USBBindingWidget_GTForce.ui">
+      <Filter>Settings</Filter>
+    </QtUi>
+    <QtUi Include="Settings\USBBindingWidget_GunCon2.ui">
+      <Filter>Settings</Filter>
+    </QtUi>
   </ItemGroup>
   <ItemGroup>
     <None Include="Settings\FolderSettingsWidget.ui">
-      <Filter>Settings</Filter>
-    </None>
-    <None Include="Settings\USBBindingWidget_GTForce.ui">
-      <Filter>Settings</Filter>
-    </None>
-    <None Include="Settings\USBBindingWidget_DrivingForce.ui">
       <Filter>Settings</Filter>
     </None>
   </ItemGroup>

--- a/pcsx2/ImGui/ImGuiManager.cpp
+++ b/pcsx2/ImGui/ImGuiManager.cpp
@@ -90,6 +90,8 @@ static std::vector<u8> s_standard_font_data;
 static std::vector<u8> s_fixed_font_data;
 static std::vector<u8> s_icon_font_data;
 
+static float s_window_width;
+static float s_window_height;
 static Common::Timer s_last_render_time;
 
 // cached copies of WantCaptureKeyboard/Mouse, used to know when to dispatch events
@@ -196,12 +198,24 @@ void ImGuiManager::Shutdown(bool clear_state)
 		UnloadFontData();
 }
 
+float ImGuiManager::GetWindowWidth()
+{
+	return s_window_width;
+}
+
+float ImGuiManager::GetWindowHeight()
+{
+	return s_window_height;
+}
+
 void ImGuiManager::WindowResized()
 {
 	const u32 new_width = g_gs_device ? g_gs_device->GetWindowWidth() : 0;
 	const u32 new_height = g_gs_device ? g_gs_device->GetWindowHeight() : 0;
 
-	ImGui::GetIO().DisplaySize = ImVec2(static_cast<float>(new_width), static_cast<float>(new_height));
+	s_window_width = static_cast<float>(new_width);
+	s_window_height = static_cast<float>(new_height);
+	ImGui::GetIO().DisplaySize = ImVec2(s_window_width, s_window_height);
 
 	UpdateScale();
 

--- a/pcsx2/ImGui/ImGuiManager.cpp
+++ b/pcsx2/ImGui/ImGuiManager.cpp
@@ -38,6 +38,7 @@
 #include "fmt/core.h"
 #include "imgui.h"
 #include "imgui_internal.h"
+#include "common/Image.h"
 
 #include <chrono>
 #include <cmath>
@@ -47,6 +48,17 @@
 
 namespace ImGuiManager
 {
+	struct SoftwareCursor
+	{
+		std::string image_path;
+		std::unique_ptr<GSTexture> texture;
+		u32 color;
+		float scale;
+		float extent_x;
+		float extent_y;
+		std::pair<float, float> pos;
+	};
+
 	static void SetStyle();
 	static void SetKeyMap();
 	static bool LoadFontData();
@@ -57,6 +69,11 @@ namespace ImGuiManager
 	static bool AddIconFonts(float size);
 	static void AcquirePendingOSDMessages();
 	static void DrawOSDMessages();
+	static void CreateSoftwareCursorTextures();
+	static void UpdateSoftwareCursorTexture(u32 index);
+	static void DestroySoftwareCursorTextures();
+	static void DrawSoftwareCursor(const SoftwareCursor& sc, const std::pair<float, float>& pos);
+	static void DrawSoftwareCursors();
 } // namespace ImGuiManager
 
 static float s_global_scale = 1.0f;
@@ -85,6 +102,8 @@ static std::unordered_map<u32, ImGuiKey> s_imgui_key_map;
 
 // need to keep track of this, so we can reinitialize on renderer switch
 static bool s_fullscreen_ui_was_initialized = false;
+
+static std::array<ImGuiManager::SoftwareCursor, InputManager::MAX_SOFTWARE_CURSORS> s_software_cursors = {};
 
 void ImGuiManager::SetFontPath(std::string path)
 {
@@ -146,6 +165,7 @@ bool ImGuiManager::Initialize()
 	if (add_fullscreen_fonts)
 		InitializeFullscreenUI();
 
+	CreateSoftwareCursorTextures();
 	return true;
 }
 
@@ -157,6 +177,8 @@ bool ImGuiManager::InitializeFullscreenUI()
 
 void ImGuiManager::Shutdown(bool clear_state)
 {
+	DestroySoftwareCursorTextures();
+
 	FullscreenUI::Shutdown(clear_state);
 	ImGuiFullscreen::SetFonts(nullptr, nullptr, nullptr);
 	if (clear_state)
@@ -672,6 +694,7 @@ void ImGuiManager::RenderOSD()
 
 	AcquirePendingOSDMessages();
 	DrawOSDMessages();
+	DrawSoftwareCursors();
 }
 
 float ImGuiManager::GetGlobalScale()
@@ -809,4 +832,113 @@ bool ImGuiManager::ProcessGenericInputEvent(GenericInputBinding key, float value
 		[key = key_map[static_cast<u32>(key)], value]() { ImGui::GetIO().AddKeyAnalogEvent(key, (value > 0.0f), value); });
 
 	return true;
+}
+
+void ImGuiManager::CreateSoftwareCursorTextures()
+{
+	for (u32 i = 0; i < InputManager::MAX_POINTER_DEVICES; i++)
+	{
+		if (!s_software_cursors[i].image_path.empty())
+			UpdateSoftwareCursorTexture(i);
+	}
+}
+
+void ImGuiManager::DestroySoftwareCursorTextures()
+{
+	for (u32 i = 0; i < InputManager::MAX_POINTER_DEVICES; i++)
+	{
+		s_software_cursors[i].texture.reset();
+	}
+}
+
+void ImGuiManager::UpdateSoftwareCursorTexture(u32 index)
+{
+	SoftwareCursor& sc = s_software_cursors[index];
+	if (sc.image_path.empty())
+	{
+		sc.texture.reset();
+		return;
+	}
+
+	Common::RGBA8Image image;
+	if (!image.LoadFromFile(sc.image_path.c_str()))
+	{
+		Console.Error("Failed to load software cursor %u image '%s'", index, sc.image_path.c_str());
+		return;
+	}
+	sc.texture = std::unique_ptr<GSTexture>(g_gs_device->CreateTexture(image.GetWidth(), image.GetHeight(), 1, GSTexture::Format::Color));
+	if (!sc.texture)
+	{
+		Console.Error(
+			"Failed to upload %ux%u software cursor %u image '%s'", image.GetWidth(), image.GetHeight(), index, sc.image_path.c_str());
+		return;
+	}
+	sc.texture->Update(GSVector4i(0, 0, image.GetWidth(), image.GetHeight()), image.GetPixels(), image.GetByteStride(), 0);
+
+	sc.extent_x = std::ceil(static_cast<float>(image.GetWidth()) * sc.scale * s_global_scale) / 2.0f;
+	sc.extent_y = std::ceil(static_cast<float>(image.GetHeight()) * sc.scale * s_global_scale) / 2.0f;
+}
+
+void ImGuiManager::DrawSoftwareCursor(const SoftwareCursor& sc, const std::pair<float, float>& pos)
+{
+	if (!sc.texture)
+		return;
+
+	const ImVec2 min(pos.first - sc.extent_x, pos.second - sc.extent_y);
+	const ImVec2 max(pos.first + sc.extent_x, pos.second + sc.extent_y);
+
+	ImDrawList* dl = ImGui::GetForegroundDrawList();
+
+	dl->AddImage(
+		reinterpret_cast<ImTextureID>(sc.texture.get()->GetNativeHandle()), min, max, ImVec2(0.0f, 0.0f), ImVec2(1.0f, 1.0f), sc.color);
+}
+
+void ImGuiManager::DrawSoftwareCursors()
+{
+	// This one's okay to race, worst that happens is we render the wrong number of cursors for a frame.
+	const u32 pointer_count = InputManager::MAX_POINTER_DEVICES;
+	for (u32 i = 0; i < pointer_count; i++)
+		DrawSoftwareCursor(s_software_cursors[i], InputManager::GetPointerAbsolutePosition(i));
+
+	for (u32 i = InputManager::MAX_POINTER_DEVICES; i < InputManager::MAX_SOFTWARE_CURSORS; i++)
+		DrawSoftwareCursor(s_software_cursors[i], s_software_cursors[i].pos);
+}
+
+void ImGuiManager::SetSoftwareCursor(u32 index, std::string image_path, float image_scale, u32 multiply_color)
+{
+	MTGS::RunOnGSThread([index, image_path = std::move(image_path), image_scale, multiply_color]() {
+		pxAssert(index < std::size(s_software_cursors));
+		SoftwareCursor& sc = s_software_cursors[index];
+		sc.color = multiply_color | 0xFF000000;
+		if (sc.image_path == image_path && sc.scale == image_scale)
+			return;
+
+		const bool is_hiding_or_showing = (image_path.empty() != sc.image_path.empty());
+		sc.image_path = std::move(image_path);
+		sc.scale = image_scale;
+		if (MTGS::IsOpen())
+			UpdateSoftwareCursorTexture(index);
+
+		// Hide the system cursor when we activate a software cursor.
+		if (is_hiding_or_showing && index == 0)
+			Host::RunOnCPUThread(&InputManager::UpdateHostMouseMode);
+	});
+}
+
+bool ImGuiManager::HasSoftwareCursor(u32 index)
+{
+	return (index < s_software_cursors.size() && !s_software_cursors[index].image_path.empty());
+}
+
+void ImGuiManager::ClearSoftwareCursor(u32 index)
+{
+	SetSoftwareCursor(index, std::string(), 0.0f, 0);
+}
+
+void ImGuiManager::SetSoftwareCursorPosition(u32 index, float pos_x, float pos_y)
+{
+	pxAssert(index >= InputManager::MAX_POINTER_DEVICES);
+	SoftwareCursor& sc = s_software_cursors[index];
+	sc.pos.first = pos_x;
+	sc.pos.second = pos_y;
 }

--- a/pcsx2/ImGui/ImGuiManager.h
+++ b/pcsx2/ImGui/ImGuiManager.h
@@ -41,6 +41,10 @@ namespace ImGuiManager
 	/// Frees all ImGui resources.
 	void Shutdown(bool clear_state);
 
+	/// Returns the size of the display window. Can be safely called from any thread.
+	float GetWindowWidth();
+	float GetWindowHeight();
+
 	/// Updates internal state when the window is size.
 	void WindowResized();
 

--- a/pcsx2/ImGui/ImGuiManager.h
+++ b/pcsx2/ImGui/ImGuiManager.h
@@ -102,6 +102,14 @@ namespace ImGuiManager
 
 	/// Called on the CPU thread when any input event fires. Allows imgui to take over controller navigation.
 	bool ProcessGenericInputEvent(GenericInputBinding key, float value);
+
+	/// Sets an image and scale for a software cursor. Software cursors can be used for things like crosshairs.
+	void SetSoftwareCursor(u32 index, std::string image_path, float image_scale, u32 multiply_color = 0xFFFFFF);
+	bool HasSoftwareCursor(u32 index);
+	void ClearSoftwareCursor(u32 index);
+
+	/// Sets the position of a software cursor, used when we have relative coordinates such as controllers.
+	void SetSoftwareCursorPosition(u32 index, float pos_x, float pos_y);
 } // namespace ImGuiManager
 
 namespace Host

--- a/pcsx2/Input/InputManager.cpp
+++ b/pcsx2/Input/InputManager.cpp
@@ -1308,6 +1308,11 @@ void InputManager::ReloadBindings(SettingsInterface& si, SettingsInterface& bind
 	for (u32 port = 0; port < USB::NUM_PORTS; port++)
 		AddUSBBindings(binding_si, port);
 
+	UpdateHostMouseMode();
+}
+
+void InputManager::UpdateHostMouseMode()
+{
 	// Check for relative mode bindings, and enable if there's anything using it.
 	bool has_relative_mode_bindings = !s_pointer_move_callbacks.empty();
 	if (!has_relative_mode_bindings)
@@ -1323,7 +1328,9 @@ void InputManager::ReloadBindings(SettingsInterface& si, SettingsInterface& bind
 			}
 		}
 	}
-	Host::SetRelativeMouseMode(has_relative_mode_bindings);
+
+	const bool has_software_cursor = ImGuiManager::HasSoftwareCursor(0);
+	Host::SetMouseMode(has_relative_mode_bindings, has_relative_mode_bindings || has_software_cursor);
 }
 
 // ------------------------------------------------------------------------

--- a/pcsx2/Input/InputManager.h
+++ b/pcsx2/Input/InputManager.h
@@ -170,6 +170,10 @@ namespace InputManager
 	static constexpr u32 MAX_POINTER_DEVICES = 1;
 	static constexpr u32 MAX_POINTER_BUTTONS = 3;
 
+	/// Maximum number of software cursors. We allocate an extra two for USB devices with
+	/// positioning data from the controller instead of a mouse.
+	static constexpr u32 MAX_SOFTWARE_CURSORS = MAX_POINTER_BUTTONS + 2;
+
 	/// Returns a pointer to the external input source class, if present.
 	InputSource* GetInputSourceInterface(InputSourceType type);
 
@@ -287,6 +291,9 @@ namespace InputManager
 	/// Updates relative pointer position. Can call from the UI thread, use when host supports relative coordinate reporting.
 	void UpdatePointerRelativeDelta(u32 index, InputPointerAxis axis, float d, bool raw_input = false);
 
+	/// Updates host mouse mode (relative/cursor hiding).
+	void UpdateHostMouseMode();
+
 	/// Called when a new input device is connected.
 	void OnInputDeviceConnected(const std::string_view& identifier, const std::string_view& device_name);
 
@@ -305,6 +312,6 @@ namespace Host
 	/// Called when an input device is disconnected.
 	void OnInputDeviceDisconnected(const std::string_view& identifier);
 
-	/// Enables relative mouse mode in the host.
-	void SetRelativeMouseMode(bool enabled);
+	/// Enables relative mouse mode in the host, and/or hides the cursor.
+	void SetMouseMode(bool relative_mode, bool hide_cursor);
 } // namespace Host

--- a/pcsx2/LayeredSettingsInterface.cpp
+++ b/pcsx2/LayeredSettingsInterface.cpp
@@ -155,7 +155,7 @@ bool LayeredSettingsInterface::ContainsValue(const char* section, const char* ke
 	{
 		if (SettingsInterface* sif = m_layers[layer])
 		{
-			if (sif->ContainsValue(key, section))
+			if (sif->ContainsValue(section, key))
 				return true;
 		}
 	}

--- a/pcsx2/USB/USB.cpp
+++ b/pcsx2/USB/USB.cpp
@@ -671,6 +671,12 @@ std::string USB::GetConfigSubKey(const std::string_view& device, const std::stri
 	return fmt::format("{}_{}", device, bind_name);
 }
 
+bool USB::ConfigKeyExists(SettingsInterface& si, u32 port, const char* devname, const char* key)
+{
+	const std::string real_key(fmt::format("{}_{}", devname, key));
+	return si.ContainsValue(GetConfigSection(port).c_str(), real_key.c_str());
+}
+
 bool USB::GetConfigBool(SettingsInterface& si, u32 port, const char* devname, const char* key, bool default_value)
 {
 	const std::string real_key(fmt::format("{}_{}", devname, key));

--- a/pcsx2/USB/USB.h
+++ b/pcsx2/USB/USB.h
@@ -79,6 +79,9 @@ namespace USB
 	/// Identifies any device/subtype changes and recreates devices.
 	void CheckForConfigChanges(const Pcsx2Config& old_config);
 
+	/// Returns true if a device-specific configuration key exists.
+	bool ConfigKeyExists(SettingsInterface& si, u32 port, const char* devname, const char* key);
+
 	/// Reads a device-specific configuration boolean.
 	bool GetConfigBool(SettingsInterface& si, u32 port, const char* devname, const char* key, bool default_value);
 

--- a/pcsx2/USB/usb-lightgun/guncon2.cpp
+++ b/pcsx2/USB/usb-lightgun/guncon2.cpp
@@ -17,6 +17,7 @@
 
 #include "GS/GS.h"
 #include "Host.h"
+#include "ImGui/ImGuiManager.h"
 #include "Input/InputManager.h"
 #include "StateWrapper.h"
 #include "USB/USB.h"
@@ -25,6 +26,8 @@
 #include "USB/qemu-usb/desc.h"
 #include "USB/usb-lightgun/guncon2.h"
 #include "VMManager.h"
+
+#include "common/StringUtil.h"
 
 #include <tuple>
 
@@ -52,6 +55,10 @@ namespace usb_lightgun
 		BID_START = 15,
 		BID_SHOOT_OFFSCREEN = 16,
 		BID_RECALIBRATE = 17,
+		BID_RELATIVE_LEFT = 18,
+		BID_RELATIVE_RIGHT = 19,
+		BID_RELATIVE_UP = 20,
+		BID_RELATIVE_DOWN = 21,
 	};
 
 	// Right pain in the arse. Different games seem to have different scales..
@@ -133,6 +140,7 @@ namespace usb_lightgun
 		//////////////////////////////////////////////////////////////////////////
 		// Configuration
 		//////////////////////////////////////////////////////////////////////////
+		bool has_relative_binds = false;
 		bool custom_config = false;
 		u32 screen_width = 640;
 		u32 screen_height = 240;
@@ -145,6 +153,10 @@ namespace usb_lightgun
 		// Host State (Not Saved)
 		//////////////////////////////////////////////////////////////////////////
 		u32 button_state = 0;
+		std::string cursor_path;
+		float cursor_scale = 1.0f;
+		u32 cursor_color = 0xFFFFFFFF;
+		float relative_pos[4] = {};
 
 		//////////////////////////////////////////////////////////////////////////
 		// Device State (Saved)
@@ -162,6 +174,11 @@ namespace usb_lightgun
 		void AutoConfigure();
 
 		std::tuple<s16, s16> CalculatePosition();
+
+		// 0..1, not -1..1.
+		std::pair<float, float> GetAbsolutePositionFromRelativeAxes() const;
+		u32 GetSoftwarePointerIndex() const;
+		void UpdateSoftwarePointerPosition();
 	};
 
 	static const USBDescStrings desc_strings = {
@@ -323,6 +340,10 @@ namespace usb_lightgun
 	static void usb_hid_unrealize(USBDevice* dev)
 	{
 		GunCon2State* us = USB_CONTAINER_OF(dev, GunCon2State, dev);
+
+		if (!us->cursor_path.empty())
+			ImGuiManager::ClearSoftwareCursor(us->GetSoftwarePointerIndex());
+
 		delete us;
 	}
 
@@ -359,8 +380,9 @@ namespace usb_lightgun
 	std::tuple<s16, s16> GunCon2State::CalculatePosition()
 	{
 		float pointer_x, pointer_y;
-		const std::pair<float, float> abs_pos(InputManager::GetPointerAbsolutePosition(0));
-		GSTranslateWindowToDisplayCoordinates(abs_pos.first, abs_pos.second, &pointer_x, &pointer_y);
+		const auto& [window_x, window_y] =
+			(has_relative_binds) ? GetAbsolutePositionFromRelativeAxes() : InputManager::GetPointerAbsolutePosition(0);
+		GSTranslateWindowToDisplayCoordinates(window_x, window_y, &pointer_x, &pointer_y);
 
 		s16 pos_x, pos_y;
 		if (pointer_x < 0.0f || pointer_y < 0.0f)
@@ -403,6 +425,29 @@ namespace usb_lightgun
 		return std::tie(pos_x, pos_y);
 	}
 
+	std::pair<float, float> GunCon2State::GetAbsolutePositionFromRelativeAxes() const
+	{
+		const float screen_rel_x = (((relative_pos[1] > 0.0f) ? relative_pos[1] : -relative_pos[0]) + 1.0f) * 0.5f;
+		const float screen_rel_y = (((relative_pos[3] > 0.0f) ? relative_pos[3] : -relative_pos[2]) + 1.0f) * 0.5f;
+		return std::make_pair(
+			screen_rel_x * ImGuiManager::GetWindowWidth(), screen_rel_y * ImGuiManager::GetWindowHeight());
+	}
+
+	u32 GunCon2State::GetSoftwarePointerIndex() const
+	{
+		return has_relative_binds ? (InputManager::MAX_POINTER_DEVICES + port) : 0;
+	}
+
+	void GunCon2State::UpdateSoftwarePointerPosition()
+	{
+		pxAssert(has_relative_binds);
+		if (cursor_path.empty())
+			return;
+
+		const auto& [window_x, window_y] = GetAbsolutePositionFromRelativeAxes();
+		ImGuiManager::SetSoftwareCursorPosition(GetSoftwarePointerIndex(), window_x, window_y);
+	}
+
 	const char* GunCon2Device::Name() const
 	{
 		return TRANSLATE_NOOP("USB", "GunCon 2");
@@ -435,6 +480,8 @@ namespace usb_lightgun
 		usb_desc_init(&s->dev);
 		usb_ep_init(&s->dev);
 
+		UpdateSettings(&s->dev, si);
+
 		return &s->dev;
 	fail:
 		usb_hid_unrealize(&s->dev);
@@ -457,6 +504,47 @@ namespace usb_lightgun
 			s->scale_x = USB::GetConfigFloat(si, s->port, TypeName(), "scale_x", DEFAULT_SCALE_X) / 100.0f;
 			s->scale_y = USB::GetConfigFloat(si, s->port, TypeName(), "scale_y", DEFAULT_SCALE_Y) / 100.0f;
 		}
+
+		// Pointer settings.
+		const std::string pointer_binding = USB::GetConfigString(si, s->port, TypeName(), "Pointer", "");
+		std::string cursor_path(USB::GetConfigString(si, s->port, TypeName(), "cursor_path"));
+		const float cursor_scale = USB::GetConfigFloat(si, s->port, TypeName(), "cursor_scale", 1.0f);
+		u32 cursor_color = 0xFFFFFF;
+		if (std::string cursor_color_str(USB::GetConfigString(si, s->port, TypeName(), "cursor_color")); !cursor_color_str.empty())
+		{
+			// Strip the leading hash, if it's a CSS style colour.
+			const std::optional<u32> cursor_color_opt(
+				StringUtil::FromChars<u32>(cursor_color_str[0] == '#' ?
+					std::string_view(cursor_color_str).substr(1) : std::string_view(cursor_color_str), 16));
+			if (cursor_color_opt.has_value())
+				cursor_color = cursor_color_opt.value();
+		}
+
+		const s32 prev_pointer_index = s->GetSoftwarePointerIndex();
+
+		s->has_relative_binds = (USB::ConfigKeyExists(si, s->port, TypeName(), "RelativeLeft") ||
+			USB::ConfigKeyExists(si, s->port, TypeName(), "RelativeRight") ||
+			USB::ConfigKeyExists(si, s->port, TypeName(), "RelativeUp") ||
+			USB::ConfigKeyExists(si, s->port, TypeName(), "RelativeDown"));
+
+		const s32 new_pointer_index = s->GetSoftwarePointerIndex();
+
+		if (prev_pointer_index != new_pointer_index || s->cursor_path != cursor_path ||
+			s->cursor_scale != cursor_scale || s->cursor_color != cursor_color)
+		{
+			if (prev_pointer_index != new_pointer_index)
+				ImGuiManager::ClearSoftwareCursor(prev_pointer_index);
+
+			// Pointer changed, so need to update software cursor.
+			if (!cursor_path.empty())
+				ImGuiManager::SetSoftwareCursor(new_pointer_index, cursor_path, cursor_scale, cursor_color);
+			else if (!s->cursor_path.empty())
+				ImGuiManager::ClearSoftwareCursor(new_pointer_index);
+
+			s->cursor_path = std::move(cursor_path);
+			s->cursor_scale = cursor_scale;
+			s->cursor_color = cursor_color;
+		}
 	}
 
 	float GunCon2Device::GetBindingValue(const USBDevice* dev, u32 bind_index) const
@@ -471,11 +559,23 @@ namespace usb_lightgun
 	{
 		GunCon2State* s = USB_CONTAINER_OF(dev, GunCon2State, dev);
 
-		const u32 bit = 1u << bind_index;
-		if (value >= 0.5f)
-			s->button_state |= bit;
-		else
-			s->button_state &= ~bit;
+		if (bind_index < BID_RELATIVE_LEFT)
+		{
+			const u32 bit = 1u << bind_index;
+			if (value >= 0.5f)
+				s->button_state |= bit;
+			else
+				s->button_state &= ~bit;
+		}
+		else if (bind_index <= BID_RELATIVE_DOWN)
+		{
+			const u32 rel_index = bind_index - BID_RELATIVE_LEFT;
+			if (s->relative_pos[rel_index] != value)
+			{
+				s->relative_pos[rel_index] = value;
+				s->UpdateSoftwarePointerPosition();
+			}
+		}
 	}
 
 	std::span<const InputBindingInfo> GunCon2Device::Bindings(u32 subtype) const
@@ -497,6 +597,10 @@ namespace usb_lightgun
 			{"C", TRANSLATE_NOOP("USB", "C"), InputBindingInfo::Type::Button, BID_C, GenericInputBinding::Triangle},
 			{"Select", TRANSLATE_NOOP("USB", "Select"), InputBindingInfo::Type::Button, BID_SELECT, GenericInputBinding::Select},
 			{"Start", TRANSLATE_NOOP("USB", "Start"), InputBindingInfo::Type::Button, BID_START, GenericInputBinding::Start},
+			{"RelativeLeft", TRANSLATE_NOOP("USB", "Relative Left"), InputBindingInfo::Type::HalfAxis, BID_RELATIVE_LEFT, GenericInputBinding::Unknown},
+			{"RelativeRight", TRANSLATE_NOOP("USB", "Relative Right"), InputBindingInfo::Type::HalfAxis, BID_RELATIVE_RIGHT, GenericInputBinding::Unknown},
+			{"RelativeUp", TRANSLATE_NOOP("USB", "Relative Up"), InputBindingInfo::Type::HalfAxis, BID_RELATIVE_UP, GenericInputBinding::Unknown},
+			{"RelativeDown", TRANSLATE_NOOP("USB", "Relative Down"), InputBindingInfo::Type::HalfAxis, BID_RELATIVE_DOWN, GenericInputBinding::Unknown},
 		};
 
 		return bindings;
@@ -505,16 +609,27 @@ namespace usb_lightgun
 	std::span<const SettingInfo> GunCon2Device::Settings(u32 subtype) const
 	{
 		static constexpr const SettingInfo info[] = {
+			{SettingInfo::Type::Path, "cursor_path", "Cursor Path",
+				TRANSLATE_NOOP("USB", "Sets the crosshair image that this lightgun will use. Setting a crosshair image "
+									  "will disable the system cursor."),
+				""},
+			{SettingInfo::Type::Float, "cursor_scale", TRANSLATE_NOOP("USB", "Cursor Scale"),
+				TRANSLATE_NOOP("USB", "Scales the crosshair image set above."), "1", "0.01", "10", "0.01", "%.0f%%",
+				nullptr, nullptr, 100.0f},
+			{SettingInfo::Type::String, "cursor_color", TRANSLATE_NOOP("USB", "Cursor Color"),
+				TRANSLATE_NOOP("USB", "Applys a color to the chosen crosshair images, can be used for multiple "
+									  "players. Specify in HTML/CSS format (e.g. #aabbcc)"),
+				"#ffffff"},
 			{SettingInfo::Type::Boolean, "custom_config", TRANSLATE_NOOP("USB", "Manual Screen Configuration"),
 				TRANSLATE_NOOP("USB",
 					"Forces the use of the screen parameters below, instead of automatic parameters if available."),
 				"false"},
 			{SettingInfo::Type::Float, "scale_x", TRANSLATE_NOOP("USB", "X Scale (Sensitivity)"),
-				"Scales the position to simulate CRT curvature.", "100", "0", "200", "0.1", "%.2f%%", nullptr, nullptr,
-				1.0f},
+				TRANSLATE_NOOP("USB", "Scales the position to simulate CRT curvature."), "100", "0", "200", "0.1",
+				"%.2f%%", nullptr, nullptr, 1.0f},
 			{SettingInfo::Type::Float, "scale_y", TRANSLATE_NOOP("USB", "Y Scale (Sensitivity)"),
-				"Scales the position to simulate CRT curvature.", "100", "0", "200", "0.1", "%.2f%%", nullptr, nullptr,
-				1.0f},
+				TRANSLATE_NOOP("USB", "Scales the position to simulate CRT curvature."), "100", "0", "200", "0.1",
+				"%.2f%%", nullptr, nullptr, 1.0f},
 			{SettingInfo::Type::Float, "center_x", TRANSLATE_NOOP("USB", "Center X"),
 				TRANSLATE_NOOP("USB", "Sets the horizontal center position of the simulated screen."), "320", "0",
 				"1024", "1", "%.0fpx", nullptr, nullptr, 1.0f},

--- a/tests/ctest/core/StubHost.cpp
+++ b/tests/ctest/core/StubHost.cpp
@@ -95,7 +95,7 @@ void Host::OnInputDeviceDisconnected(const std::string_view& identifier)
 {
 }
 
-void Host::SetRelativeMouseMode(bool enabled)
+void Host::SetMouseMode(bool relative_mode, bool hide_cursor)
 {
 }
 


### PR DESCRIPTION
### Description of Changes

Smaller version of #8437.

In addition to the default pointer-based configuration, this PR allows you to bind a controller to aiming instead, which apparently some lightguns use.

Also adds custom cursors/crosshairs, which will hide the system cursor when active.

![image](https://github.com/PCSX2/pcsx2/assets/11288319/43b4b2ef-b714-4c31-8631-a0959db7bc9a)
![image](https://github.com/PCSX2/pcsx2/assets/11288319/c2b288f1-a00a-4d40-8c77-9356d9cc8541)


### Rationale behind Changes

Closes #7891.
Closes #9256.

### Suggested Testing Steps

To test this with a controller, simply bind all four relative directions to e.g. an analog stick, and pick a crosshair image, so you can see where you're aiming.

Make sure mouse based aiming still works (clear all four relative axes by right clicking the bindings).