### PR TITLE
GameDB: Change halfPixelOffset to Spyro: A Hero's Tail

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -16074,7 +16074,7 @@ SLES-52569:
   region: "PAL-M6"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 1 # Fixes misaligned bloom effects that streak on-screen, causes occasional trash shadows at places.
+    halfPixelOffset: 2 # Fixes misaligned bloom effects that streak on-screen, causes occasional trash shadows at places.
 SLES-52570:
   name: "Area 51"
   region: "PAL-M5"
@@ -46928,7 +46928,7 @@ SLUS-20884:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 1 # Fixes misaligned bloom effects that streak on-screen, causes occasional trash shadows at places.
+    halfPixelOffset: 2 # Fixes misaligned bloom effects that streak on-screen, causes occasional trash shadows at places.
 SLUS-20885:
   name: "Red Star, The"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
Changed halfPixelOffset from 1 to 2 for Spyro: A Hero's Tail

### Rationale behind Changes
This fixes some effects (like blackscreens when loading stuff in the background) still being missaligned with halfPixelOffset=1 and others are also better aligned.
Example, it's a bit hard to notice, but you can see one line of pixels not being black at the top:
![Spyro - A Hero's Tail_SLES-52569_20230723113200](https://github.com/PCSX2/pcsx2/assets/126416290/a372725f-4b6b-41d2-add1-3c78439f55fa)

### Suggested Testing Steps
Starting up the game and seeing the black screen right before the main menu loads, and also you can see the glow effect on the black gem in the background of the main menu.
