### PR TITLE
GS/HW: Get rid of 2 frame forced preload

### DIFF
--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -228,7 +228,6 @@ public:
 	bool m_isPackedUV_HackFlag = false;
 	bool m_channel_shuffle = false;
 	u8 m_scanmask_used = 0;
-	u8 m_force_preload = 0;
 	u32 m_dirty_gs_regs = 0;
 	int m_backed_up_ctx = 0;
 	std::vector<GSUploadQueue> m_draw_transfers;

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -94,15 +94,11 @@ float GSRendererHW::GetUpscaleMultiplier()
 
 void GSRendererHW::Reset(bool hardware_reset)
 {
-	// Force targets to preload for 2 frames (for 30fps games).
-	static constexpr u8 TARGET_PRELOAD_FRAMES = 2;
-
 	// Read back on CSR Reset, conditional downloading on render swap etc handled elsewhere.
 	if (!hardware_reset)
 		g_texture_cache->ReadbackAll();
 
 	g_texture_cache->RemoveAll();
-	m_force_preload = TARGET_PRELOAD_FRAMES;
 
 	GSRenderer::Reset(hardware_reset);
 }
@@ -116,22 +112,10 @@ void GSRendererHW::UpdateSettings(const Pcsx2Config::GSOptions& old_config)
 
 void GSRendererHW::VSync(u32 field, bool registers_written, bool idle_frame)
 {
-	if (m_force_preload > 0)
-	{
-		m_force_preload--;
-		if (m_force_preload == 0)
-		{
-			for (auto iter = m_draw_transfers.rbegin(); iter != m_draw_transfers.rend(); iter++)
-			{
-				if ((s_n - iter->draw) > 5)
-				{
-					m_draw_transfers.erase(m_draw_transfers.begin(), std::next(iter).base());
-					break;
-				}
-			}
-		}
-	}
-	else if (!idle_frame)
+	if (GSConfig.LoadTextureReplacements)
+		GSTextureReplacements::ProcessAsyncLoadedTextures();
+
+	if (!idle_frame)
 	{
 		// If it did draws very recently, we should keep the recent stuff in case it hasn't been preloaded/used yet.
 		// Rocky Legend does this with the main menu FMV's.
@@ -150,23 +134,15 @@ void GSRendererHW::VSync(u32 field, bool registers_written, bool idle_frame)
 		{
 			m_draw_transfers.clear();
 		}
-	}
 
-	if (GSConfig.LoadTextureReplacements)
-		GSTextureReplacements::ProcessAsyncLoadedTextures();
-
-	// Don't age the texture cache when no draws or EE writes have occurred.
-	// Xenosaga needs its targets kept around while it's loading, because it uses them for a fade transition.
-	if (idle_frame)
-	{
-		GL_INS("No draws or transfers, not aging TC");
+		g_texture_cache->IncAge();
 	}
 	else
 	{
-		g_texture_cache->IncAge();
+		// Don't age the texture cache when no draws or EE writes have occurred.
+		// Xenosaga needs its targets kept around while it's loading, because it uses them for a fade transition.
+		GL_INS("No draws or transfers, not aging TC");
 	}
-
-	GSRenderer::VSync(field, registers_written, idle_frame);
 
 	if (g_texture_cache->GetHashCacheMemoryUsage() > 1024 * 1024 * 1024)
 	{
@@ -181,6 +157,8 @@ void GSRendererHW::VSync(u32 field, bool registers_written, bool idle_frame)
 
 	m_skip = 0;
 	m_skip_offset = 0;
+
+	GSRenderer::VSync(field, registers_written, idle_frame);
 }
 
 GSTexture* GSRendererHW::GetOutput(int i, float& scale, int& y_offset)

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -1641,7 +1641,6 @@ void GSTextureCache::PreloadTarget(GIFRegTEX0 TEX0, const GSVector2i& size, cons
 
 	if (TEX0.TBW > 0 && supported_fmt)
 	{
-		const bool forced_preload = GSRendererHW::GetInstance()->m_force_preload > 0;
 		const GSVector4i newrect = GSVector4i::loadh(size);
 		const u32 rect_end = GSLocalMemory::GetUnwrappedEndBlockAddress(TEX0.TBP0, TEX0.TBW, TEX0.PSM, newrect);
 
@@ -1649,7 +1648,7 @@ void GSTextureCache::PreloadTarget(GIFRegTEX0 TEX0, const GSVector2i& size, cons
 		rgba._u32 = GSUtil::GetChannelMask(TEX0.PSM);
 		dst->UpdateValidity(GSVector4i::loadh(valid_size));
 
-		if (!is_frame && !forced_preload && !preload)
+		if (!is_frame && !preload)
 		{
 			if (preserve_target || !draw_rect.eq(dst->m_valid))
 			{


### PR DESCRIPTION
### Description of Changes

This was a thing for some game which stored texture data in the upper 8 bits of the framebuffer.

I hope our invalidation is better now, and we don't need the hack anymore. It's really annoying when debugging GS dumps.

(the target's alpha should not be valid, so it should always load from local memory in these cases).

### Rationale behind Changes

Easier debugging, fewer uploads when saving state, more deterministic from loading state versus continuing.

### Suggested Testing Steps

Start a couple of games, smoke test.
