### PR TITLE
GS/HW: Use GetUnwrappedEndBlockAddress() where appropriate

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -4456,7 +4456,7 @@ bool GSRendererHW::CanUseTexIsFB(const GSTextureCache::Target* rt, const GSTextu
 		}
 		else if (clamp == CLAMP_REGION_REPEAT)
 		{
-			const u32 req_tbits = (tmax > 1) ? std::bit_ceil(static_cast<u32>(tmax - 1) - 1) : 0x1;
+			const u32 req_tbits = (tmax > 1) ? (std::bit_ceil(static_cast<u32>(tmax - 1)) - 1) : 0x1;
 			if ((min & req_tbits) != req_tbits)
 			{
 				GL_CACHE("Can't use tex-is-fb because of REGION_REPEAT [%d, %d] with TMM of [%d, %d] and tbits of %d",


### PR DESCRIPTION
### Description of Changes

Actually fixes the invalidate check when the target wraps.

And a regression from #9297.

### Rationale behind Changes

See above.

### Suggested Testing Steps

Smoke test, dump run looks fine.
