### PR TITLE
GameDB: Add nativePaletteDraw and halfPixelOffset to Crash Tag Team R…

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -18368,6 +18368,8 @@ SLES-53439:
     - IbitHack # Fixes constant recompilation problems.
   gsHWFixes:
     PCRTCOverscan: 1 # Fixes offscreen image.
+    nativePaletteDraw: 1 # Fixes the look of screen effects.
+    halfPixelOffset: 2 # Corrects the alignment of screen effects.
 SLES-53441:
   name: "Heroes of the Pacific"
   region: "PAL-M5"
@@ -33112,6 +33114,8 @@ SLPM-66090:
   region: "NTSC-J"
   gsHWFixes:
     PCRTCOverscan: 1 # Fixes offscreen image.
+    nativePaletteDraw: 1 # Fixes the look of screen effects.
+    halfPixelOffset: 2 # Corrects the alignment of screen effects.
 SLPM-66091:
   name: "Shinobido Imashime"
   region: "NTSC-J"
@@ -48752,6 +48756,8 @@ SLUS-21191:
     - IbitHack # Fixes constant recompilation problems.
   gsHWFixes:
     PCRTCOverscan: 1 # Fixes offscreen image.
+    nativePaletteDraw: 1 # Fixes the look of screen effects.
+    halfPixelOffset: 2 # Corrects the alignment of screen effects.
 SLUS-21192:
   name: "Cabela's Outdoor Adventures 2006"
   region: "NTSC-U"


### PR DESCRIPTION
…acing

### Description of Changes
Added nativePaletteDraw and halfPixelOffset to Crash Tag Team Racing

### Rationale behind Changes
This fixes screen effects looking distorted and misaligned. Before:
![Crash Tag Team Racing_SLES-53439_20230723175707](https://github.com/PCSX2/pcsx2/assets/126416290/2a8ae4f4-31ff-4b34-b065-f837d5f9ccaf)

After (you can see that Crash, the crates and the coins have a certain glow, but no more garbage graphics):
![Crash Tag Team Racing_SLES-53439_20230723175543](https://github.com/PCSX2/pcsx2/assets/126416290/a3d4d7bb-91a2-444c-b2ca-9f4fa8d8b4e7)


### Suggested Testing Steps
Start a new game, go into single player, enter park, and keep going until you find a Wumpa Whip, collecting it shows the effects on screen.
