### PR TITLE
GameDB: correct an entry

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -30936,7 +30936,7 @@ SLPM-65470:
   name: "Firefighter F.D. 18"
   region: "NTSC-J"
 SLPM-65471:
-  name: "Firefighter F.D. 18"
+  name: "Need for Speed - Underground"
   region: "NTSC-J"
 SLPM-65472:
   name: "Train Simulator & Densha de Go! Tokyo Kyuukouhen"


### PR DESCRIPTION
"Need for Speed - Underground" NTSC-J has SLPM-65471.
https://wiki.pcsx2.net/Need_for_Speed:_Underground
http://redump.org/disc/33880/

"Firefighter F.D. 18" NTSC-J has SLPM-65470:
https://wiki.pcsx2.net/Firefighter_F.D._18
http://redump.org/disc/38733/
