### PR TITLE
GameList: Support adding custom titles and/or regions to files

### DIFF
--- a/common/SettingsInterface.h
+++ b/common/SettingsInterface.h
@@ -92,31 +92,31 @@ public:
 		return value;
 	}
 
-	__fi std::optional<int> GetOptionalIntValue(const char* section, const char* key, std::optional<int> default_value = std::nullopt)
+	__fi std::optional<int> GetOptionalIntValue(const char* section, const char* key, std::optional<int> default_value = std::nullopt) const
 	{
 		int ret;
 		return GetIntValue(section, key, &ret) ? std::optional<int>(ret) : default_value;
 	}
 
-	__fi std::optional<uint> GetOptionalUIntValue(const char* section, const char* key, std::optional<uint> default_value = std::nullopt)
+	__fi std::optional<uint> GetOptionalUIntValue(const char* section, const char* key, std::optional<uint> default_value = std::nullopt) const
 	{
 		uint ret;
 		return GetUIntValue(section, key, &ret) ? std::optional<uint>(ret) : default_value;
 	}
 
-	__fi std::optional<float> GetOptionalFloatValue(const char* section, const char* key, std::optional<float> default_value = std::nullopt)
+	__fi std::optional<float> GetOptionalFloatValue(const char* section, const char* key, std::optional<float> default_value = std::nullopt) const
 	{
 		float ret;
 		return GetFloatValue(section, key, &ret) ? std::optional<float>(ret) : default_value;
 	}
 
-	__fi std::optional<double> GetOptionalDoubleValue(const char* section, const char* key, std::optional<double> default_value = std::nullopt)
+	__fi std::optional<double> GetOptionalDoubleValue(const char* section, const char* key, std::optional<double> default_value = std::nullopt) const
 	{
 		double ret;
 		return GetDoubleValue(section, key, &ret) ? std::optional<double>(ret) : default_value;
 	}
 
-	__fi std::optional<bool> GetOptionalBoolValue(const char* section, const char* key, std::optional<bool> default_value = std::nullopt)
+	__fi std::optional<bool> GetOptionalBoolValue(const char* section, const char* key, std::optional<bool> default_value = std::nullopt) const
 	{
 		bool ret;
 		return GetBoolValue(section, key, &ret) ? std::optional<bool>(ret) : default_value;

--- a/pcsx2-qt/Settings/GameSummaryWidget.h
+++ b/pcsx2-qt/Settings/GameSummaryWidget.h
@@ -47,6 +47,10 @@ private:
 	void populateDiscPath(const GameList::Entry* entry);
 	void populateTrackList(const GameList::Entry* entry);
 	void setVerifyResult(QString error);
+	void repopulateCurrentDetails();
+
+	void setCustomTitle(const std::string& text);
+	void setCustomRegion(int region);
 
 	Ui::GameSummaryWidget m_ui;
 	SettingsDialog* m_dialog;

--- a/pcsx2-qt/Settings/GameSummaryWidget.ui
+++ b/pcsx2-qt/Settings/GameSummaryWidget.ui
@@ -34,11 +34,25 @@
     </widget>
    </item>
    <item row="0" column="1">
-    <widget class="QLineEdit" name="title">
-     <property name="readOnly">
-      <bool>true</bool>
-     </property>
-    </widget>
+    <layout class="QHBoxLayout" name="horizontalLayout_6">
+     <item>
+      <widget class="QLineEdit" name="title">
+       <property name="placeholderText">
+        <string>Clear the line to restore the original title...</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="restoreTitle">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="text">
+        <string>Restore</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
    <item row="1" column="0">
     <widget class="QLabel" name="label_2">
@@ -140,170 +154,178 @@
     </widget>
    </item>
    <item row="5" column="1">
-    <widget class="QComboBox" name="region">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="editable">
-      <bool>true</bool>
-     </property>
-     <item>
-      <property name="text">
-       <string extracomment="Leave the code as-is, translate the country's name.">NTSC-B (Brazil)</string>
-      </property>
+    <layout class="QHBoxLayout" name="horizontalLayout_6">
+      <item>
+        <widget class="QComboBox" name="region">
+        <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+          </sizepolicy>
+        </property>
+        <item>
+          <property name="text">
+          <string extracomment="Leave the code as-is, translate the country's name.">NTSC-B (Brazil)</string>
+          </property>
+        </item>
+        <item>
+          <property name="text">
+          <string extracomment="Leave the code as-is, translate the country's name.">NTSC-C (China)</string>
+          </property>
+        </item>
+        <item>
+          <property name="text">
+          <string extracomment="Leave the code as-is, translate the country's name.">NTSC-HK (Hong Kong)</string>
+          </property>
+        </item>
+        <item>
+          <property name="text">
+          <string extracomment="Leave the code as-is, translate the country's name.">NTSC-J (Japan)</string>
+          </property>
+        </item>
+        <item>
+          <property name="text">
+          <string extracomment="Leave the code as-is, translate the country's name.">NTSC-K (Korea)</string>
+          </property>
+        </item>
+        <item>
+          <property name="text">
+          <string extracomment="Leave the code as-is, translate the country's name.">NTSC-T (Taiwan)</string>
+          </property>
+        </item>
+        <item>
+          <property name="text">
+          <string extracomment="Leave the code as-is, translate the country's name.">NTSC-U (US)</string>
+          </property>
+        </item>
+        <item>
+          <property name="text">
+          <string>Other</string>
+          </property>
+        </item>
+        <item>
+          <property name="text">
+          <string extracomment="Leave the code as-is, translate the country's name.">PAL-A (Australia)</string>
+          </property>
+        </item>
+        <item>
+          <property name="text">
+          <string extracomment="Leave the code as-is, translate the country's name.">PAL-AF (South Africa)</string>
+          </property>
+        </item>
+        <item>
+          <property name="text">
+          <string extracomment="Leave the code as-is, translate the country's name.">PAL-AU (Austria)</string>
+          </property>
+        </item>
+        <item>
+          <property name="text">
+          <string extracomment="Leave the code as-is, translate the country's name.">PAL-BE (Belgium)</string>
+          </property>
+        </item>
+        <item>
+          <property name="text">
+          <string extracomment="Leave the code as-is, translate the country's name.">PAL-E (Europe/Australia)</string>
+          </property>
+        </item>
+        <item>
+          <property name="text">
+          <string extracomment="Leave the code as-is, translate the country's name.">PAL-F (France)</string>
+          </property>
+        </item>
+        <item>
+          <property name="text">
+          <string extracomment="Leave the code as-is, translate the country's name.">PAL-FI (Finland)</string>
+          </property>
+        </item>
+        <item>
+          <property name="text">
+          <string extracomment="Leave the code as-is, translate the country's name.">PAL-G (Germany)</string>
+          </property>
+        </item>
+        <item>
+          <property name="text">
+          <string extracomment="Leave the code as-is, translate the country's name.">PAL-GR (Greece)</string>
+          </property>
+        </item>
+        <item>
+          <property name="text">
+          <string extracomment="Leave the code as-is, translate the country's name.">PAL-I (Italy)</string>
+          </property>
+        </item>
+        <item>
+          <property name="text">
+          <string extracomment="Leave the code as-is, translate the country's name.">PAL-IN (India)</string>
+          </property>
+        </item>
+        <item>
+          <property name="text">
+          <string extracomment="Leave the code as-is, translate the country's name.">PAL-M (Europe/Australia)</string>
+          </property>
+        </item>
+        <item>
+          <property name="text">
+          <string extracomment="Leave the code as-is, translate the country's name.">PAL-NL (Netherlands)</string>
+          </property>
+        </item>
+        <item>
+          <property name="text">
+          <string extracomment="Leave the code as-is, translate the country's name.">PAL-NO (Norway)</string>
+          </property>
+        </item>
+        <item>
+          <property name="text">
+          <string extracomment="Leave the code as-is, translate the country's name.">PAL-P (Portugal)</string>
+          </property>
+        </item>
+        <item>
+          <property name="text">
+          <string extracomment="Leave the code as-is, translate the country's name.">PAL-PL (Poland)</string>
+          </property>
+        </item>
+        <item>
+          <property name="text">
+          <string extracomment="Leave the code as-is, translate the country's name.">PAL-R (Russia)</string>
+          </property>
+        </item>
+        <item>
+          <property name="text">
+          <string extracomment="Leave the code as-is, translate the country's name.">PAL-S (Spain)</string>
+          </property>
+        </item>
+        <item>
+          <property name="text">
+          <string extracomment="Leave the code as-is, translate the country's name.">PAL-SC (Scandinavia)</string>
+          </property>
+        </item>
+        <item>
+          <property name="text">
+          <string extracomment="Leave the code as-is, translate the country's name.">PAL-SW (Sweden)</string>
+          </property>
+        </item>
+        <item>
+          <property name="text">
+          <string extracomment="Leave the code as-is, translate the country's name.">PAL-SWI (Switzerland)</string>
+          </property>
+        </item>
+        <item>
+          <property name="text">
+          <string extracomment="Leave the code as-is, translate the country's name.">PAL-UK (United Kingdom)</string>
+          </property>
+        </item>
+        </widget>
+      </item>
+      <item>
+      <widget class="QPushButton" name="restoreRegion">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="text">
+        <string>Restore</string>
+       </property>
+      </widget>
      </item>
-     <item>
-      <property name="text">
-       <string extracomment="Leave the code as-is, translate the country's name.">NTSC-C (China)</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string extracomment="Leave the code as-is, translate the country's name.">NTSC-HK (Hong Kong)</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string extracomment="Leave the code as-is, translate the country's name.">NTSC-J (Japan)</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string extracomment="Leave the code as-is, translate the country's name.">NTSC-K (Korea)</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string extracomment="Leave the code as-is, translate the country's name.">NTSC-T (Taiwan)</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string extracomment="Leave the code as-is, translate the country's name.">NTSC-U (US)</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Other</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string extracomment="Leave the code as-is, translate the country's name.">PAL-A (Australia)</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string extracomment="Leave the code as-is, translate the country's name.">PAL-AF (South Africa)</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string extracomment="Leave the code as-is, translate the country's name.">PAL-AU (Austria)</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string extracomment="Leave the code as-is, translate the country's name.">PAL-BE (Belgium)</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string extracomment="Leave the code as-is, translate the country's name.">PAL-E (Europe/Australia)</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string extracomment="Leave the code as-is, translate the country's name.">PAL-F (France)</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string extracomment="Leave the code as-is, translate the country's name.">PAL-FI (Finland)</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string extracomment="Leave the code as-is, translate the country's name.">PAL-G (Germany)</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string extracomment="Leave the code as-is, translate the country's name.">PAL-GR (Greece)</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string extracomment="Leave the code as-is, translate the country's name.">PAL-I (Italy)</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string extracomment="Leave the code as-is, translate the country's name.">PAL-IN (India)</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string extracomment="Leave the code as-is, translate the country's name.">PAL-M (Europe/Australia)</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string extracomment="Leave the code as-is, translate the country's name.">PAL-NL (Netherlands)</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string extracomment="Leave the code as-is, translate the country's name.">PAL-NO (Norway)</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string extracomment="Leave the code as-is, translate the country's name.">PAL-P (Portugal)</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string extracomment="Leave the code as-is, translate the country's name.">PAL-PL (Poland)</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string extracomment="Leave the code as-is, translate the country's name.">PAL-R (Russia)</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string extracomment="Leave the code as-is, translate the country's name.">PAL-S (Spain)</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string extracomment="Leave the code as-is, translate the country's name.">PAL-SC (Scandinavia)</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string extracomment="Leave the code as-is, translate the country's name.">PAL-SW (Sweden)</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string extracomment="Leave the code as-is, translate the country's name.">PAL-SWI (Switzerland)</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string extracomment="Leave the code as-is, translate the country's name.">PAL-UK (United Kingdom)</string>
-      </property>
-     </item>
-    </widget>
+    </layout>
    </item>
    <item row="6" column="0">
     <widget class="QLabel" name="label_7">
@@ -488,21 +510,21 @@
            <height>60</height>
           </size>
          </property>
-         <property name="readOnly">
-          <bool>true</bool>
-         </property>
          <property name="visible">
           <bool>false</bool>
+         </property>
+         <property name="readOnly">
+          <bool>true</bool>
          </property>
         </widget>
        </item>
        <item row="1" column="2">
         <widget class="QPushButton" name="searchHash">
-         <property name="text">
-          <string>Search on Redump.org...</string>
-         </property>
          <property name="visible">
           <bool>false</bool>
+         </property>
+         <property name="text">
+          <string>Search on Redump.org...</string>
          </property>
         </widget>
        </item>

--- a/pcsx2-qt/Settings/SettingsDialog.h
+++ b/pcsx2-qt/Settings/SettingsDialog.h
@@ -51,7 +51,7 @@ class SettingsDialog final : public QDialog
 
 public:
 	explicit SettingsDialog(QWidget* parent);
-	SettingsDialog(QWidget* parent, std::unique_ptr<SettingsInterface> sif, const GameList::Entry* game, std::string serial, u32 disc_crc);
+	SettingsDialog(QWidget* parent, std::unique_ptr<SettingsInterface> sif, const GameList::Entry* game, std::string serial, u32 disc_crc, QString filename = QString());
 	~SettingsDialog();
 
 	static void openGamePropertiesDialog(const GameList::Entry* game, const std::string_view& title, std::string serial, u32 disc_crc);
@@ -78,6 +78,8 @@ public:
 
 	void registerWidgetHelp(QObject* object, QString title, QString recommended_value, QString text);
 	bool eventFilter(QObject* object, QEvent* event) override;
+
+	void setWindowTitle(const QString& title);
 
 	QString getCategory() const;
 	void setCategory(const char* category);
@@ -144,6 +146,8 @@ private:
 
 	QObject* m_current_help_widget = nullptr;
 	QMap<QObject*, QString> m_widget_help_text_map;
+
+	QString m_filename;
 
 	std::string m_serial;
 	u32 m_disc_crc;

--- a/pcsx2/GameList.h
+++ b/pcsx2/GameList.h
@@ -154,4 +154,10 @@ namespace GameList
 	/// the use_serial parameter. save_callback optionall takes the entry and the path the new cover is saved to.
 	bool DownloadCovers(const std::vector<std::string>& url_templates, bool use_serial = false, ProgressCallback* progress = nullptr,
 		std::function<void(const Entry*, std::string)> save_callback = {});
+
+	// Custom properties support
+	void CheckCustomAttributesForPath(const std::string& path, bool& has_custom_title, bool& has_custom_region);
+	void SaveCustomTitleForPath(const std::string& path, const std::string& custom_title);
+	void SaveCustomRegionForPath(const std::string& path, int custom_region);
+	std::string GetCustomTitleForPath(const std::string& path);
 } // namespace GameList

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -849,19 +849,22 @@ void VMManager::UpdateDiscDetails(bool booting)
 
 		SaveSessionTime(old_serial);
 
+		std::string custom_title = GameList::GetCustomTitleForPath(CDVDsys_GetFile(CDVDsys_GetSourceType()));
 		if (serial_is_valid)
 		{
 			if (const GameDatabaseSchema::GameEntry* game = GameDatabase::findGame(s_disc_serial))
 			{
+				std::string game_title = custom_title.empty() ? game->name : std::move(custom_title);
+
 				// Append the ELF override if we're using it with a disc.
 				if (!s_elf_override.empty())
 				{
 					title = fmt::format(
-						"{} [{}]", game->name, Path::GetFileTitle(FileSystem::GetDisplayNameFromPath(s_elf_override)));
+						"{} [{}]", game_title, Path::GetFileTitle(FileSystem::GetDisplayNameFromPath(s_elf_override)));
 				}
 				else
 				{
-					title = game->name;
+					title = std::move(game_title);
 				}
 
 				memcardFilters = game->memcardFiltersAsString();
@@ -870,6 +873,11 @@ void VMManager::UpdateDiscDetails(bool booting)
 			{
 				Console.Warning(fmt::format("Serial '{}' not found in GameDB.", s_disc_serial));
 			}
+		}
+
+		if (title.empty())
+		{
+			title = std::move(custom_title);
 		}
 
 		if (title.empty())


### PR DESCRIPTION
### Description of Changes
This PR adds an ability to override game names and regions on the list, which can be useful when using romhacks. With this change, two previously "identical" entries can be given unique names and/or regions. These attributes are being saved into a new `custom_properties.ini` file, where each **section** name is a full path to a file.

![image](https://github.com/PCSX2/pcsx2/assets/7947461/95519c1e-9c52-4c98-9c7c-ddb0dfa3e846)

A new "Restore" buttons have been added to the Game Summary which restore the original property. Deleting the custom Title restores the default one.

![image](https://github.com/PCSX2/pcsx2/assets/7947461/da3e2a7b-cc49-43c5-84db-d628bfeff45c)



To-do and/or agree on:
* ~~Should this be only possible for titles or also serials and regions?~~ It is titles and regions now.
* ~~Is an Edit button a good UX? Maybe those fields should just become editable as-is?~~ It is Restore instead now.
* Should the Game List sort again after quitting the summary? Right now it doesn't.
* Should custom names be marked somehow on the Game List?

### Rationale behind Changes
Less ambiguity when using romhacks or multiple versions of the same game in general.

### Suggested Testing Steps
1. Create multiple copies of the same game ISO, or use romhacks.
2. Make them all listed on the Game List.
3. Go to Game Properties -> Edit the title and region.
4. Verify that a custom title shows as expected and persists across sessions.
