### PR TITLE
GameDB: Add patch for Shadow Hearts NTSC-U bad clip arrangement

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -44409,6 +44409,15 @@ SLUS-20347:
     eeClampMode: 3 # Fixes invisible characters in various scenes.
   gsHWFixes:
     partialTargetInvalidation: 1 # Fixes black screens on judgement wheel.
+  patches:
+    default:
+      content: |-
+        author=refraction
+        // Fixes bad clip flag arrangement
+        patch=1,EE,00249e10,word,48509000
+        patch=1,EE,00249e14,word,4BDD69FF
+        patch=1,EE,00249e9c,word,48509000
+        patch=1,EE,00249ea0,word,4BDD69FF
 SLUS-20348:
   name: "Monopoly Party"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
Fixes a COP2 clip flag arrangement

### Rationale behind Changes
it was incorrect, and may have been causing black screens in some situations (both renderers), so best to eliminate it.

### Suggested Testing Steps
Watch CI, patch already tested to make sure it doesn't explode
