### PR TITLE
GS/HW: HLE the Burnout games bloom effect

### DIFF
--- a/pcsx2-gsrunner/Main.cpp
+++ b/pcsx2-gsrunner/Main.cpp
@@ -85,11 +85,13 @@ static double s_last_render_passes = 0;
 static double s_last_barriers = 0;
 static double s_last_copies = 0;
 static double s_last_uploads = 0;
+static double s_last_readbacks = 0;
 static u64 s_total_draws = 0;
 static u64 s_total_render_passes = 0;
 static u64 s_total_barriers = 0;
 static u64 s_total_copies = 0;
 static u64 s_total_uploads = 0;
+static u64 s_total_readbacks = 0;
 static u32 s_total_frames = 0;
 
 bool GSRunner::InitializeConfig()
@@ -293,6 +295,7 @@ void Host::BeginPresentFrame()
 		update_stat(GSPerfMon::Barriers, s_total_barriers, s_last_barriers);
 		update_stat(GSPerfMon::TextureCopies, s_total_copies, s_last_copies);
 		update_stat(GSPerfMon::TextureUploads, s_total_uploads, s_last_uploads);
+		update_stat(GSPerfMon::Readbacks, s_total_readbacks, s_last_readbacks);
 		s_total_frames++;
 		std::atomic_thread_fence(std::memory_order_release);
 	}
@@ -641,6 +644,7 @@ void GSRunner::DumpStats()
 	Console.WriteLn(fmt::format("@HWSTAT@ Barriers: {} (avg {})", s_total_barriers, static_cast<u64>(std::ceil(s_total_barriers / static_cast<double>(s_total_frames)))));
 	Console.WriteLn(fmt::format("@HWSTAT@ Copies: {} (avg {})", s_total_copies, static_cast<u64>(std::ceil(s_total_copies / static_cast<double>(s_total_frames)))));
 	Console.WriteLn(fmt::format("@HWSTAT@ Uploads: {} (avg {})", s_total_uploads, static_cast<u64>(std::ceil(s_total_uploads / static_cast<double>(s_total_frames)))));
+	Console.WriteLn(fmt::format("@HWSTAT@ Readbacks: {} (avg {})", s_total_readbacks, static_cast<u64>(std::ceil(s_total_readbacks / static_cast<double>(s_total_frames)))));
 	Console.WriteLn("============================================");
 }
 

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -5241,12 +5241,12 @@ GSRendererHW::CLUTDrawTestResult GSRendererHW::PossibleCLUTDraw()
 			if (HasEEUpload(r))
 				return CLUTDrawTestResult::CLUTDrawOnCPU;
 
-			GSTextureCache::Target* tgt = g_texture_cache->GetExactTarget(
-				m_cached_ctx.TEX0.TBP0, m_cached_ctx.TEX0.TBW, GSTextureCache::RenderTarget, m_cached_ctx.TEX0.TBP0);
+			const GSTextureCache::Target* tgt = g_texture_cache->FindOverlappingTarget(
+				m_cached_ctx.TEX0.TBP0, m_cached_ctx.TEX0.TBW, m_cached_ctx.TEX0.PSM, r);
 			if (tgt)
 			{
 				bool is_dirty = false;
-				for (GSDirtyRect& rc : tgt->m_dirty)
+				for (const GSDirtyRect& rc : tgt->m_dirty)
 				{
 					if (!rc.GetDirtyRect(m_cached_ctx.TEX0).rintersect(r).rempty())
 					{

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -3339,6 +3339,26 @@ GSTextureCache::Target* GSTextureCache::GetTargetWithSharedBits(u32 BP, u32 PSM)
 	return nullptr;
 }
 
+GSTextureCache::Target* GSTextureCache::FindOverlappingTarget(u32 BP, u32 end_bp) const
+{
+	for (int i = 0; i < 2; i++)
+	{
+		for (Target* tgt : m_dst[i])
+		{
+			if (CheckOverlap(tgt->m_TEX0.TBP0, tgt->m_end_block, BP, end_bp))
+				return tgt;
+		}
+	}
+
+	return nullptr;
+}
+
+GSTextureCache::Target* GSTextureCache::FindOverlappingTarget(u32 BP, u32 BW, u32 PSM, GSVector4i rc) const
+{
+	const u32 end_bp = GSLocalMemory::GetUnwrappedEndBlockAddress(BP, BW, PSM, rc);
+	return FindOverlappingTarget(BP, end_bp);
+}
+
 GSVector2i GSTextureCache::GetTargetSize(u32 bp, u32 fbw, u32 psm, s32 min_width, s32 min_height)
 {
 	TargetHeightElem search = {};

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.h
@@ -488,6 +488,8 @@ public:
 	/// Looks up a target in the cache, and only returns it if the BP/BW match exactly.
 	Target* GetExactTarget(u32 BP, u32 BW, int type, u32 end_bp);
 	Target* GetTargetWithSharedBits(u32 BP, u32 PSM) const;
+	Target* FindOverlappingTarget(u32 BP, u32 end_bp) const;
+	Target* FindOverlappingTarget(u32 BP, u32 BW, u32 PSM, GSVector4i rc) const;
 
 	GSVector2i GetTargetSize(u32 bp, u32 fbw, u32 psm, s32 min_width, s32 min_height);
 	bool Has32BitTarget(u32 bp);


### PR DESCRIPTION
### Description of Changes

Shamelessly stolen from the source because I can't be bothered to re-type it.

Burnout has a... creative way of achieving its bloom effect, to avoid horizontal page breaks.

First they double strip clear a single page column to (191, 191, 191), then blend the main framebuffer into this column, with (Cs - Cd) * 2. So anything lower than 191 clamps to zero, and anything larger boosts up a bit. Then that column gets downsampled to half size, makes sense right?

The fun bit is when they move to the next page, instead of being sensible and using another double strip clear, they write Z to the next page as part of the blended draw, setting it to 191 (in Z24 terms). Then the buffers are swapped for the next column, 0x1a40 and 0x1a60 in US.

We _could_ handle that, except for the fact that instead of pointing the texture at 0x1a60 for the downsample of the second column, they point it at 0x1a40, and offset the coordinates by a page. This would need "tex outside RT", and no way that's happening.

So, I present to you, dear reader, the first state machine within a CRC hack, in all its disgusting glory. This effectively reduces the multi-pass effect to a single pass, by replacing the column-wide draws with a fullscreen sprite, and skipping the extra passes.

After this, they do a blur on the buffer, which is fine, because all the buffer swap BS has finished, so we can return to normal.

### Rationale behind Changes

Closes #1415.
Closes #5602.

Before without CRC hack:
![image](https://github.com/PCSX2/pcsx2/assets/11288319/8687b07b-c047-4e97-9ea7-26ca4f001ad5)

Before with CRC hack:
![image](https://github.com/PCSX2/pcsx2/assets/11288319/2f993ff7-d4eb-4cff-ae5b-dfa8cb6535d2)

After:
![image](https://github.com/PCSX2/pcsx2/assets/11288319/edd810c0-bdbe-4b71-adef-d03970d8f9ee)

### Suggested Testing Steps

Test burnout games. I've tried to make the hack general, so hopefully it'll work across the series for both PAL and NTSC, assuming the effect is implemented relatively similarly.
