### PR TITLE
GS/HW: Update Blue Tongue CRC and remove frame width hacks

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -25854,6 +25854,8 @@ SLKA-25359:
 SLKA-25361:
   name: "Keroro Gunsou MeroMero Battle Royale Z"
   region: "NTSC-K"
+  gsHWFixes:
+    preloadFrameData: 1 # Fixes invisible text.
 SLKA-25363:
   name: "Guitar Hero III - Legends of Rock"
   region: "NTSC-K"
@@ -40910,6 +40912,8 @@ SLPS-25567:
 SLPS-25568:
   name: "Keroro Gunsou - Mero Mero Battle Royale [Bandai The Best]"
   region: "NTSC-J"
+  gsHWFixes:
+    preloadFrameData: 1 # Fixes invisible text.
 SLPS-25569:
   name: "Kidou Senshi Gundam SEED - Rengou vs. Z.A.F.T."
   region: "NTSC-J"
@@ -40936,6 +40940,8 @@ SLPS-25575:
   name: "Keroro Gunsou - Mero Mero Battle Royale Z"
   region: "NTSC-J"
   compat: 5
+  gsHWFixes:
+    preloadFrameData: 1 # Fixes invisible text.
 SLPS-25576:
   name: "One Piece - Pirates Carnival"
   region: "NTSC-J"

--- a/pcsx2/Achievements.cpp
+++ b/pcsx2/Achievements.cpp
@@ -634,7 +634,7 @@ void Achievements::SetChallengeMode(bool enabled)
 	s_challenge_mode = enabled;
 
 	if (HasActiveGame())
-		ImGuiFullscreen::ShowToast(std::string(), enabled ? "Hardcore mode is now enabled." : "Hardcore mode is now disabled.", 10.0f);
+		ImGuiFullscreen::ShowToast(std::string(), enabled ? TRANSLATE("Achievements", "Hardcore mode is now enabled.") : TRANSLATE("Achievements", "Hardcore mode is now disabled."), 10.0f);
 
 	if (HasActiveGame() && !IsTestModeActive())
 	{

--- a/pcsx2/GS/Renderers/HW/GSHwHack.cpp
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.cpp
@@ -721,6 +721,48 @@ bool GSHwHack::GSC_BlueTongueGames(GSRendererHW& r, int& skip)
 {
 	GSDrawingContext* context = r.m_context;
 
+	// Nicktoons does its weird dithered depth pattern during FMV's also, which really screws the frame width up, which is wider for FMV's
+	// and so fails to work correctly in the HW renderer and makes a mess of the width, so let's expand the draw to match the proper width.
+	if (RPRIM->TME && RTEX0.TW == 3 && RTEX0.TH == 3 && RTEX0.PSM == 0 && RFRAME.FBMSK == 0x00FFFFFF && RFRAME.FBW == 8 && r.PCRTCDisplays.GetResolution().x > 512)
+	{
+		// Check we are drawing stripes
+		for (int i = 1; i < r.m_vertex.tail; i+=2)
+		{
+			int value = (((r.m_vertex.buff[i].XYZ.X - r.m_vertex.buff[i - 1].XYZ.X) + 8) >> 4);
+			if (value != 32)
+				return false;
+		}
+
+		r.m_r.x = r.m_vt.m_min.p.x;
+		r.m_r.y = r.m_vt.m_min.p.y;
+		r.m_r.z = r.PCRTCDisplays.GetResolution().x;
+		r.m_r.w = r.m_vt.m_max.p.y;
+
+		for (int vert = 32; vert < 40; vert+=2)
+		{
+			r.m_vertex.buff[vert].XYZ.X = context->XYOFFSET.OFX + (((vert * 16) << 4) - 8);
+			r.m_vertex.buff[vert].XYZ.Y = context->XYOFFSET.OFY;
+			r.m_vertex.buff[vert].U = (vert * 16) << 4;
+			r.m_vertex.buff[vert].V = 0;
+			r.m_vertex.buff[vert+1].XYZ.X = context->XYOFFSET.OFX + ((((vert * 16) + 32) << 4) - 8);
+			r.m_vertex.buff[vert+1].XYZ.Y = context->XYOFFSET.OFY + 8184; //511.5
+			r.m_vertex.buff[vert+1].U = ((vert * 16) + 32) << 4;
+			r.m_vertex.buff[vert+1].V = 512 << 4;
+		}
+
+		/*r.m_vertex.head = r.m_vertex.tail = r.m_vertex.next = 2;
+		r.m_index.tail = 2;*/
+
+		r.m_vt.m_max.p.x = r.m_r.z;
+		r.m_vt.m_max.p.y = r.m_r.w;
+		r.m_vt.m_max.t.x = r.m_r.z;
+		r.m_vt.m_max.t.y = r.m_r.w;
+		context->scissor.in.z = r.m_r.z;
+		context->scissor.in.w = r.m_r.w;
+
+		RFRAME.FBW = 10;
+	}
+
 	// Whoever wrote this was kinda nuts. They draw a stipple/dither pattern to a framebuffer, then reuse that as
 	// the depth buffer. Textures are then drawn repeatedly on top of one another, each with a slight offset.
 	// Depth testing is enabled, and that determines which pixels make it into the final texture. Kinda like an

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -2383,6 +2383,15 @@ void GSRendererHW::Draw()
 	{
 		if (rt && (!is_possible_mem_clear || rt->m_TEX0.PSM != FRAME_TEX0.PSM))
 		{
+			if (rt->m_TEX0.TBW != FRAME_TEX0.TBW && !m_cached_ctx.ZBUF.ZMSK && (m_cached_ctx.FRAME.FBMSK & 0xFF000000))
+			{
+				// Alpha could be a font, and since the width is changing it's no longer valid.
+				// Be careful of downsize copies or other effects, checking Z MSK should hopefully be enough.. (Okami).
+				if (m_cached_ctx.FRAME.FBMSK & 0x0F000000)
+					rt->m_valid_alpha_low = false;
+				if (m_cached_ctx.FRAME.FBMSK & 0xF0000000)
+					rt->m_valid_alpha_high = false;
+			}
 			rt->m_TEX0 = FRAME_TEX0;
 		}
 

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -2381,25 +2381,12 @@ void GSRendererHW::Draw()
 	const bool can_update_size = !is_possible_mem_clear && !m_texture_shuffle && !m_channel_shuffle;
 	if (!m_texture_shuffle && !m_channel_shuffle)
 	{
-		if (rt)
+		if (rt && (!is_possible_mem_clear || rt->m_TEX0.PSM != FRAME_TEX0.PSM))
 		{
-			// Nicktoons Unite tries to change the width from 640 to 512 and breaks FMVs.
-			// Haunting ground has some messed textures if you don't modify the rest.
-			// Champions of Norrath expands the width from 512 to 1024, picture cut in half if you don't.
-			// The safest option is to probably let it expand but not retract.
-			if (!rt->m_is_frame || rt->m_TEX0.TBW < FRAME_TEX0.TBW)
-			{
-				rt->m_TEX0 = FRAME_TEX0;
-			}
-			else
-			{
-				const u32 width = rt->m_TEX0.TBW;
-				rt->m_TEX0 = FRAME_TEX0;
-				rt->m_TEX0.TBW = std::max(width, FRAME_TEX0.TBW);
-			}
+			rt->m_TEX0 = FRAME_TEX0;
 		}
 
-		if (ds)
+		if (ds && (!is_possible_mem_clear || ds->m_TEX0.PSM != ZBUF_TEX0.PSM))
 			ds->m_TEX0 = ZBUF_TEX0;
 	}
 	else if (!m_texture_shuffle)

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -1353,12 +1353,6 @@ GSTextureCache::Target* GSTextureCache::LookupTarget(GIFRegTEX0 TEX0, const GSVe
 				}
 			}
 		}
-
-		if (dst)
-		{
-			dst->m_TEX0.TBW = TEX0.TBW; // Fix Jurassic Park - Operation Genesis loading disk logo.
-			dst->m_is_frame |= is_frame; // Nicktoons Unite tries to change the width from 10 to 8 and breaks FMVs.
-		}
 	}
 
 	if (dst)

--- a/pcsx2/GameDatabase.cpp
+++ b/pcsx2/GameDatabase.cpp
@@ -1200,7 +1200,7 @@ const GameDatabase::HashDatabaseEntry* GameDatabase::lookupHash(
 		if (getTrackIndex(candidate->tracks.data(), candidate->tracks.size(), tracks[track]) != track)
 		{
 			fmt::format_to(std::back_inserter(*match_error),
-				TRANSLATE_FS("GameDatabase", "Track {} with hash {} does not match database track..\n"), track + 1,
+				TRANSLATE_FS("GameDatabase", "Track {} with hash {} does not match database track.\n"), track + 1,
 				tracks[track].toString());
 			tracks_matched[track] = false;
 			all_okay = false;

--- a/pcsx2/SIO/Pad/PadDualshock2.cpp
+++ b/pcsx2/SIO/Pad/PadDualshock2.cpp
@@ -641,10 +641,8 @@ void PadDualshock2::Set(u32 index, float value)
 				const auto [port, slot] = sioConvertPadToPortAndSlot(unifiedSlot);
 				
 				Host::AddKeyedOSDMessage(fmt::format("PadAnalogButtonChange{}{}", port, slot),
-					fmt::format(TRANSLATE_FS("Pad", "Analog light is now {} for port {} / slot {}"),
-						(this->analogLight ? "On" : "Off"),
-						port + 1,
-						slot + 1),
+					this->analogLight ? fmt::format(TRANSLATE_FS("Pad", "Analog light is now on for port {} / slot {}"), port + 1, slot + 1) :
+										fmt::format(TRANSLATE_FS("Pad", "Analog light is now off for port {} / slot {}"), port + 1, slot + 1),
 					Host::OSD_INFO_DURATION);
 			}
 		}


### PR DESCRIPTION
### Description of Changes
removes some old frame width hacks for blue tongue games, added to part of the CRC.

### Rationale behind Changes
These hacks were breaking other games, namely Keroro Gunsou - Mero Mero Battle Royale.  Nicktoons Unite! amongst the others changes the width from 640 to 512, then uses the target temporarily as a Z buffer of a different size, then goes back to using it as a framebuffer, but this draw never really worked properly and was already being partially thrown on to the SW renderer.

### Suggested Testing Steps
Test some random games, make sure everything is okay, along with any Blue Tongue games (Jurassic Park, Nictoons Unite/Spongebob Volcano Island, Barnyard), and also Keroro Gunsou.

Fixes #9004 width problem with Keroro Gunsou - Mero Mero Battle Royale