### PR TITLE
GameDB: Move Haunting Ground over to HPO Special + Round Sprite Half

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -16925,7 +16925,8 @@ SLES-52877:
   region: "PAL-M5"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 1 # Fixes blurriness.
+    halfPixelOffset: 2 # Reduces blurriness. Normal Vertex works better, but causes some lights to disappear.
+    roundSprite: 1 # Further reduces blurriness.
     beforeDraw: "OI_HauntingGround" # Fix bloom.
 SLES-52882:
   name: "Stolen"
@@ -48190,7 +48191,8 @@ SLUS-21075:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 1 # Fixes blurriness.
+    halfPixelOffset: 2 # Reduces blurriness. Normal Vertex works better, but causes some lights to disappear.
+    roundSprite: 1 # Further reduces blurriness.
     beforeDraw: "OI_HauntingGround" # Fix bloom.
 SLUS-21076:
   name: "Atari Anthology"


### PR DESCRIPTION
### Description of Changes
Moves Haunting Ground over to different upscaling hacks

### Rationale behind Changes
HPO Normal Vertex broke on this game with a recent update #9171 however this is more likely a properly with HPO that a problem with that PR (native is absolutely fine).

### Suggested Testing Steps
Watch CI
