### PR TITLE
Pad: Revert back to old Constant 1 behavior

### DIFF
--- a/pcsx2/SIO/Pad/PadDualshock2.cpp
+++ b/pcsx2/SIO/Pad/PadDualshock2.cpp
@@ -231,14 +231,25 @@ u8 PadDualshock2::Constant1(u8 commandByte)
 		case 3:
 			stage = commandByte;
 			return 0x00;
+		case 5:
+			return 0x01;
 		case 6:
 			if (stage)
 			{
-				return 0x00;
+				return 0x01;
 			}
 			else
 			{
 				return 0x02;
+			}
+		case 7:
+			if (stage)
+			{
+				return 0x01;
+			}
+			else
+			{
+				return 0x00;
 			}
 		case 8:
 			g_Sio0.SetAcknowledge(false);


### PR DESCRIPTION

### Description of Changes
Reverts back to older behavior for pad command 0x46. Puts back some 1's where I thought we could put 0's.

Will need to do a deeper dive at a later time to understand what these bytes are truly doing, but games seem happier this way.

### Rationale behind Changes
Fixes pad detection in NBA 2K7, possibly others.

### Suggested Testing Steps
Boot a game, see if the pad is responsive at all. Thorough tests not required, if there is a problem the game will either report no controllers are connected, or be completely unresponsive to inputs.
