### PR TITLE
DEV9: Perform a null check on ifa_addr when searching adapters

### DIFF
--- a/pcsx2/DEV9/AdapterUtils.cpp
+++ b/pcsx2/DEV9/AdapterUtils.cpp
@@ -187,7 +187,9 @@ bool AdapterUtils::GetAdapter(const std::string& name, Adapter* adapter, Adapter
 
 	do
 	{
-		if (pAdapter->ifa_addr->sa_family == AF_INET && strcmp(pAdapter->ifa_name, name.c_str()) == 0)
+		if (pAdapter->ifa_addr != nullptr &&
+			pAdapter->ifa_addr->sa_family == AF_INET &&
+			strcmp(pAdapter->ifa_name, name.c_str()) == 0)
 			break;
 
 		pAdapter = pAdapter->ifa_next;


### PR DESCRIPTION
### Description of Changes
Adds a nullcheck for ifa_addr when searching for the selected adapter on Linux

### Rationale behind Changes
Hopefully fixes #9616

### Suggested Testing Steps
Test Sockets adapter on Linux
