### PR TITLE
Pad: Change button query response depending on current mode

### DIFF
--- a/pcsx2/SIO/Pad/PadDualshock2.cpp
+++ b/pcsx2/SIO/Pad/PadDualshock2.cpp
@@ -110,18 +110,32 @@ u8 PadDualshock2::Mystery(u8 commandByte)
 
 u8 PadDualshock2::ButtonQuery(u8 commandByte)
 {
-	switch (commandBytesReceived)
+	switch (this->currentMode)
 	{
-		case 3:
-		case 4:
-			return 0xff;
-		case 5:
-			return 0x03;
-		case 8:
-			g_Sio0.SetAcknowledge(false);
-			return 0x5a;
+		case Pad::Mode::DUALSHOCK2:
+		case Pad::Mode::ANALOG:
+			switch (commandBytesReceived)
+			{
+				case 3:
+				case 4:
+					return 0xff;
+				case 5:
+					return 0x03;
+				case 8:
+					g_Sio0.SetAcknowledge(false);
+					return 0x5a;
+				default:
+					return 0x00;
+			}
 		default:
-			return 0x00;
+			switch (commandBytesReceived)
+			{
+				case 8:
+					g_Sio0.SetAcknowledge(false);
+					return 0x5a;
+				default:
+					return 0x00;
+			}
 	}
 }
 


### PR DESCRIPTION

### Description of Changes
Changes Button Query command to respond depending on the current mode, rather than always reporting a full DS2 button layout.

### Rationale behind Changes
Fixes CoD 3 not understanding which buttons the controller has available, perhaps others.

### Suggested Testing Steps
Test if games still accept input. Basic tests will do, e.g. pressing X on menu buttons or flipping through menus with the d-pad and analog sticks.
