### PR TITLE
Pad: Set data low when no pad present

### DIFF
--- a/pcsx2/SIO/Pad/PadNotConnected.cpp
+++ b/pcsx2/SIO/Pad/PadNotConnected.cpp
@@ -127,5 +127,5 @@ u8 PadNotConnected::GetPressure(u32 index) const
 
 u8 PadNotConnected::SendCommandByte(u8 commandByte)
 {
-	return 0xff;
+	return 0x00;
 }


### PR DESCRIPTION

### Description of Changes
Switches disconnected pad from simulating 0xff on the data line to 0x00.

### Rationale behind Changes
Fixes uLaunchELF spinning waiting for second pad to come online.

### Suggested Testing Steps
Boot any game or ELF known to probe second controller, with no second controller plugged. Game should finish boot and accept input from first pad.
