### PR TITLE
GameDB: Add Partial Target Invalidation to Racing Simulation 3

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -14020,6 +14020,8 @@ SLES-51630:
 SLES-51633:
   name: "Racing Simulation 3"
   region: "PAL-M5"
+  gsHWFixes:
+    partialTargetInvalidation: 1 # Fixes crash during loading screen due to bad download.
 SLES-51636:
   name: "XGRA - Extreme G Racing Association"
   region: "PAL-M5"


### PR DESCRIPTION
### Description of Changes
Adds said option to Racing Sim 3

### Rationale behind Changes
Game was crashing on load going ingame due to bad data being downloaded, since invalidation didn't work correctly.

### Suggested Testing Steps
Watch CI
