### PR TITLE
GS/HW: Modify Burnout IO CRC hack to not affect online mode screen

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSHwHack.cpp
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.cpp
@@ -1054,6 +1054,8 @@ bool GSHwHack::OI_BurnoutGames(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GS
 	if (!r.CanUseSwSpriteRender())
 		return true;
 
+	if (!r.PRIM->TME)
+		return true;
 	// Render palette via CPU.
 	r.SwSpriteRender();
 


### PR DESCRIPTION
### Description of Changes
Modify burnout OI hack to break the online mode less.

### Rationale behind Changes
It was more brokerer

### Suggested Testing Steps
Test burnout online mode (and normal burnout games)

Fixes #9635
