### PR TITLE
Debugger: Fix 'run-to-cursor' context action ft. warning fixes

### DIFF
--- a/common/TextureDecompress.cpp
+++ b/common/TextureDecompress.cpp
@@ -643,7 +643,9 @@ bool unpack_bc7_mode0_2(uint32_t mode, const uint64_t* data_chunks, color_rgba* 
 	const uint32_t ENDPOINT_BITS = (mode == 0) ? 4 : 5;
 	const uint32_t ENDPOINT_MASK = (1 << ENDPOINT_BITS) - 1;
 	const uint32_t PBITS = (mode == 0) ? 6 : 0;
+#ifndef BC7DECOMP_USE_SSE2
 	const uint32_t WEIGHT_VALS = 1 << WEIGHT_BITS;
+#endif
 	const uint32_t PART_BITS = (mode == 0) ? 4 : 6;
 	const uint32_t PART_MASK = (1 << PART_BITS) - 1;
 
@@ -740,7 +742,9 @@ bool unpack_bc7_mode1_3_7(uint32_t mode, const uint64_t* data_chunks, color_rgba
 	const uint32_t ENDPOINT_MASK = (1 << ENDPOINT_BITS) - 1;
 	const uint32_t PBITS = (mode == 1) ? 2 : 4;
 	const uint32_t SHARED_PBITS = (mode == 1) ? true : false;
+#ifndef BC7DECOMP_USE_SSE2
 	const uint32_t WEIGHT_VALS = 1 << WEIGHT_BITS;
+#endif
 
 	const uint64_t low_chunk = data_chunks[0];
 	const uint64_t high_chunk = data_chunks[1];

--- a/pcsx2-qt/Debugger/CpuWidget.cpp
+++ b/pcsx2-qt/Debugger/CpuWidget.cpp
@@ -589,7 +589,7 @@ static std::vector<u32> searchWorkerByteArray(DebugInterface* cpu, u32 start, u3
 		bool hit = true;
 		for (qsizetype i = 0; i < value.length(); i++)
 		{
-			if (cpu->read8(addr + i) != value[i])
+			if (static_cast<char>(cpu->read8(addr + i)) != value[i])
 			{
 				hit = false;
 				break;

--- a/pcsx2-qt/Debugger/DisassemblyWidget.cpp
+++ b/pcsx2-qt/Debugger/DisassemblyWidget.cpp
@@ -151,9 +151,10 @@ void DisassemblyWidget::contextNoopInstruction()
 
 void DisassemblyWidget::contextRunToCursor()
 {
-	Host::RunOnCPUThread([&] { CBreakPoints::AddBreakPoint(m_cpu->getCpuType(), m_selectedAddressStart); });
-
-	m_cpu->resumeCpu();
+	Host::RunOnCPUThread([&] {
+		CBreakPoints::AddBreakPoint(m_cpu->getCpuType(), m_selectedAddressStart, true);
+		m_cpu->resumeCpu();
+	});
 }
 
 void DisassemblyWidget::contextJumpToCursor()

--- a/pcsx2-qt/Debugger/Models/BreakpointModel.cpp
+++ b/pcsx2-qt/Debugger/Models/BreakpointModel.cpp
@@ -78,7 +78,7 @@ QVariant BreakpointModel::data(const QModelIndex& index, int role) const
 				{
 					QString type("");
 					type += (mc->cond & MEMCHECK_READ) ? tr("Read") : "";
-					type += ((mc->cond & MEMCHECK_BOTH) == MEMCHECK_BOTH) ? ", " : " ";
+					type += ((mc->cond & MEMCHECK_READWRITE) == MEMCHECK_READWRITE) ? ", " : " ";
 					//: (C) = changes, as in "look for changes".
 					type += (mc->cond & MEMCHECK_WRITE) ? (mc->cond & MEMCHECK_WRITE_ONCHANGE) ? tr("Write(C)") : tr("Write") : "";
 					return type;

--- a/pcsx2/CDVD/IsoHasher.h
+++ b/pcsx2/CDVD/IsoHasher.h
@@ -42,7 +42,7 @@ public:
 
 	static std::string_view GetTrackTypeString(u32 type);
 
-	const u32 GetTrackCount() const { return static_cast<u32>(m_tracks.size()); }
+	u32 GetTrackCount() const { return static_cast<u32>(m_tracks.size()); }
 	const Track& GetTrack(u32 n) const { return m_tracks.at(n); }
 	const std::vector<Track>& GetTracks() const { return m_tracks; }
 	bool IsCD() const { return m_is_cd; }


### PR DESCRIPTION
### Description of Changes
Fixes #9230
Decided to add some stuff as well
Fixes `-Wunused-variable` warnings
Fixes `-Wdeprecated-enum-enum-conversion` warning
Fixes `-Wsign-compare` warning
Fixes `-Wignored-qualifiers` warning

### Rationale behind Changes
Debugger function was broken and caused a deadlock (not good)
Warnings are not desirable and should be addressed 

### Suggested Testing Steps
Does the `run-to-cursor` context menu action work?
Does the memory search function still work?
