### PR TITLE
Achievements: Log-in explicitly on startup to refresh the token

### DIFF
--- a/pcsx2-gsrunner/Main.cpp
+++ b/pcsx2-gsrunner/Main.cpp
@@ -385,12 +385,15 @@ void Host::RequestVMShutdown(bool allow_confirm, bool allow_save_state, bool def
 	VMManager::SetState(VMState::Stopping);
 }
 
-#ifdef ENABLE_ACHIEVEMENTS
+void Host::OnAchievementsLoginRequested(Achievements::LoginRequestReason reason)
+{
+	// noop
+}
+
 void Host::OnAchievementsRefreshed()
 {
 	// noop
 }
-#endif
 
 std::optional<u32> InputManager::ConvertHostKeyboardStringToCode(const std::string_view& str)
 {

--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -25,6 +25,7 @@
 #include "QtHost.h"
 #include "QtUtils.h"
 #include "SettingWidgetBinder.h"
+#include "Settings/AchievementLoginDialog.h"
 #include "Settings/ControllerSettingsDialog.h"
 #include "Settings/GameListSettingsWidget.h"
 #include "Settings/InterfaceSettingsWidget.h"
@@ -423,6 +424,7 @@ void MainWindow::connectVMThreadSignals(EmuThread* thread)
 	connect(thread, &EmuThread::onGameChanged, this, &MainWindow::onGameChanged);
 	connect(thread, &EmuThread::onCaptureStarted, this, &MainWindow::onCaptureStarted);
 	connect(thread, &EmuThread::onCaptureStopped, this, &MainWindow::onCaptureStopped);
+	connect(thread, &EmuThread::onAchievementsLoginRequested, this, &MainWindow::onAchievementsLoginRequested);
 
 	connect(m_ui.actionReset, &QAction::triggered, thread, &EmuThread::resetVM);
 	connect(m_ui.actionPause, &QAction::toggled, thread, &EmuThread::setVMPaused);
@@ -626,6 +628,14 @@ void MainWindow::onCaptureStopped()
 
 	QSignalBlocker sb(m_ui.actionToolsVideoCapture);
 	m_ui.actionToolsVideoCapture->setChecked(false);
+}
+
+void MainWindow::onAchievementsLoginRequested(Achievements::LoginRequestReason reason)
+{
+	auto lock = pauseAndLockVM();
+
+	AchievementLoginDialog dlg(this, reason);
+	dlg.exec();
 }
 
 void MainWindow::onSettingsTriggeredFromToolbar()

--- a/pcsx2-qt/MainWindow.h
+++ b/pcsx2-qt/MainWindow.h
@@ -39,6 +39,11 @@ class ControllerSettingsDialog;
 
 class EmuThread;
 
+namespace Achievements
+{
+	enum class LoginRequestReason;
+}
+
 namespace GameList
 {
 	struct Entry;
@@ -185,6 +190,8 @@ private Q_SLOTS:
 
 	void onCaptureStarted(const QString& filename);
 	void onCaptureStopped();
+
+	void onAchievementsLoginRequested(Achievements::LoginRequestReason reason);
 
 protected:
 	void showEvent(QShowEvent* event) override;

--- a/pcsx2-qt/QtHost.cpp
+++ b/pcsx2-qt/QtHost.cpp
@@ -1079,6 +1079,11 @@ void Host::OnSaveStateSaved(const std::string_view& filename)
 }
 
 #ifdef ENABLE_ACHIEVEMENTS
+void Host::OnAchievementsLoginRequested(Achievements::LoginRequestReason reason)
+{
+	emit g_emu_thread->onAchievementsLoginRequested(reason);
+}
+
 void Host::OnAchievementsRefreshed()
 {
 	u32 game_id = 0;
@@ -1778,6 +1783,7 @@ void QtHost::RegisterTypes()
 	qRegisterMetaType<InputBindingKey>();
 	qRegisterMetaType<CDVD_SourceType>();
 	qRegisterMetaType<const GameList::Entry*>();
+	qRegisterMetaType<Achievements::LoginRequestReason>();
 }
 
 bool QtHost::RunSetupWizard()

--- a/pcsx2-qt/QtHost.h
+++ b/pcsx2-qt/QtHost.h
@@ -41,11 +41,17 @@ struct VMBootParameters;
 
 enum class CDVD_SourceType : uint8_t;
 
+namespace Achievements
+{
+	enum class LoginRequestReason;
+}
+
 Q_DECLARE_METATYPE(std::shared_ptr<VMBootParameters>);
 Q_DECLARE_METATYPE(std::optional<bool>);
 Q_DECLARE_METATYPE(GSRendererType);
 Q_DECLARE_METATYPE(InputBindingKey);
 Q_DECLARE_METATYPE(CDVD_SourceType);
+Q_DECLARE_METATYPE(Achievements::LoginRequestReason);
 
 class EmuThread : public QThread
 {
@@ -154,6 +160,9 @@ Q_SIGNALS:
 	/// Called when a save state is being created/saved. The compression/write to disk is asynchronous, so this callback
 	/// just signifies that the save has started, not necessarily completed.
 	void onSaveStateSaved(const QString& path);
+
+	/// Called when achievements login is requested.
+	void onAchievementsLoginRequested(Achievements::LoginRequestReason reason);
 
 	/// Called when achievements are reloaded/refreshed (e.g. game change, login, option change).
 	void onAchievementsRefreshed(quint32 id, const QString& game_info_string, quint32 total, quint32 points);

--- a/pcsx2-qt/Settings/AchievementLoginDialog.cpp
+++ b/pcsx2-qt/Settings/AchievementLoginDialog.cpp
@@ -22,12 +22,21 @@
 
 #include <QtWidgets/QMessageBox>
 
-AchievementLoginDialog::AchievementLoginDialog(QWidget* parent)
+AchievementLoginDialog::AchievementLoginDialog(QWidget* parent, Achievements::LoginRequestReason reason)
 	: QDialog(parent)
 {
 	m_ui.setupUi(this);
 	m_ui.loginIcon->setPixmap(QIcon::fromTheme("login-box-line").pixmap(32));
 	setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
+
+	// Adjust text if needed based on reason.
+	if (reason == Achievements::LoginRequestReason::TokenInvalid)
+	{
+		m_ui.instructionText->setText(
+			tr("<strong>Your RetroAchievements login token is no longer valid.</strong> You must re-enter your "
+			   "credentials for achievements to be tracked. Your password will not be saved in PCSX2, an access token "
+			   "will be generated and used instead."));
+	}
 
 	m_login = m_ui.buttonBox->addButton(tr("&Login"), QDialogButtonBox::AcceptRole);
 	m_login->setEnabled(false);

--- a/pcsx2-qt/Settings/AchievementLoginDialog.h
+++ b/pcsx2-qt/Settings/AchievementLoginDialog.h
@@ -18,12 +18,17 @@
 #include <QtWidgets/QDialog>
 #include <QtWidgets/QPushButton>
 
+namespace Achievements
+{
+	enum class LoginRequestReason;
+}
+
 class AchievementLoginDialog : public QDialog
 {
 	Q_OBJECT
 
 public:
-	AchievementLoginDialog(QWidget* parent);
+	AchievementLoginDialog(QWidget* parent, Achievements::LoginRequestReason reason);
 	~AchievementLoginDialog();
 
 private Q_SLOTS:
@@ -38,4 +43,5 @@ private:
 
 	Ui::AchievementLoginDialog m_ui;
 	QPushButton* m_login;
+	Achievements::LoginRequestReason m_reason;
 };

--- a/pcsx2-qt/Settings/AchievementLoginDialog.ui
+++ b/pcsx2-qt/Settings/AchievementLoginDialog.ui
@@ -51,7 +51,7 @@
     </layout>
    </item>
    <item>
-    <widget class="QLabel" name="label_3">
+    <widget class="QLabel" name="instructionText">
      <property name="text">
       <string>Please enter user name and password for retroachievements.org below. Your password will not be saved in PCSX2, an access token will be generated and used instead.</string>
      </property>

--- a/pcsx2-qt/Settings/AchievementSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/AchievementSettingsWidget.cpp
@@ -173,7 +173,7 @@ void AchievementSettingsWidget::onLoginLogoutPressed()
 		return;
 	}
 
-	AchievementLoginDialog login(this);
+	AchievementLoginDialog login(this, Achievements::LoginRequestReason::UserInitiated);
 	int res = login.exec();
 	if (res != 0)
 		return;

--- a/pcsx2/Achievements.cpp
+++ b/pcsx2/Achievements.cpp
@@ -966,7 +966,9 @@ void Achievements::LoginWithTokenCallback(s32 status_code, const std::string& co
 	RAPIResponse<rc_api_login_response_t, rc_api_process_login_response, rc_api_destroy_login_response> response(status_code, data);
 	if (!response)
 	{
-		FormattedError("Login failed. Please check your user name and password, and try again.");
+		lock.unlock();
+		Logout();
+		Host::OnAchievementsLoginRequested(LoginRequestReason::TokenInvalid);
 		return;
 	}
 

--- a/pcsx2/Achievements.h
+++ b/pcsx2/Achievements.h
@@ -88,6 +88,7 @@ namespace Achievements
 
 	bool IsActive();
 	bool IsLoggedIn();
+	bool HasSavedCredentials();
 	bool ChallengeModeActive();
 	bool LeaderboardsActive();
 	bool IsTestModeActive();
@@ -131,6 +132,7 @@ namespace Achievements
 
 	bool LoginAsync(const char* username, const char* password);
 	bool Login(const char* username, const char* password);
+	bool LoginWithTokenAsync(const char* username, const char* api_token);
 	void Logout();
 
 	void GameChanged(u32 disc_crc, u32 crc);

--- a/pcsx2/Achievements.h
+++ b/pcsx2/Achievements.h
@@ -31,6 +31,12 @@
 
 namespace Achievements
 {
+	enum class LoginRequestReason
+	{
+		UserInitiated,
+		TokenInvalid,
+	};
+
 	enum class AchievementCategory : u8
 	{
 		Local = 0,
@@ -255,6 +261,6 @@ namespace Achievements
 /// Functions implemented in the frontend.
 namespace Host
 {
+	void OnAchievementsLoginRequested(Achievements::LoginRequestReason reason);
 	void OnAchievementsRefreshed();
-	void OnAchievementsChallengeModeChanged();
 } // namespace Host

--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -6990,7 +6990,7 @@ void FullscreenUI::DrawAchievementsSettingsPage(std::unique_lock<std::mutex>& se
 			Achievements::ProcessPendingHTTPRequestsFromGSThread();
 
 		MenuHeading("Account");
-		if (Achievements::IsLoggedIn())
+		if (Achievements::HasSavedCredentials())
 		{
 			ImGui::PushStyleColor(ImGuiCol_TextDisabled, ImGui::GetStyle().Colors[ImGuiCol_Text]);
 			ActiveButton(fmt::format(ICON_FA_USER "  Username: {}", Achievements::GetUsername()).c_str(), false, false,

--- a/tests/ctest/core/StubHost.cpp
+++ b/tests/ctest/core/StubHost.cpp
@@ -210,11 +210,13 @@ s32 Host::Internal::GetTranslatedStringImpl(
 	return static_cast<s32>(msg.size());
 }
 
-#ifdef ENABLE_ACHIEVEMENTS
+void Host::OnAchievementsLoginRequested(Achievements::LoginRequestReason reason)
+{
+}
+
 void Host::OnAchievementsRefreshed()
 {
 }
-#endif
 
 std::optional<u32> InputManager::ConvertHostKeyboardStringToCode(const std::string_view& str)
 {


### PR DESCRIPTION
### Description of Changes

Handles RetroAchievements tokens being reset gracefully by prompting the user to re-login.

Also extends the token lifetime by sending a login request each for each PCSX2 instance which uses achievements.

(I plan to move this over to rc_client eventually, but for now it's a band-aid fix for tokens getting reset.)

### Rationale behind Changes

Better UX.

### Suggested Testing Steps

Test invalidating token (done myself).
