### PR TITLE
GS/HW: Update vertex trace in ReplaceVerticesWithSprite()

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -5968,6 +5968,9 @@ void GSRendererHW::ReplaceVerticesWithSprite(const GSVector4i& unscaled_rect, co
 
 	v[0].XYZ.X = static_cast<u16>(m_context->XYOFFSET.OFX + fpr.x);
 	v[0].XYZ.Y = static_cast<u16>(m_context->XYOFFSET.OFY + fpr.y);
+	v[0].XYZ.Z = v[1].XYZ.Z;
+	v[0].RGBAQ = v[1].RGBAQ;
+	v[0].FOG = v[1].FOG;
 
 	v[1].XYZ.X = static_cast<u16>(m_context->XYOFFSET.OFX + fpr.z);
 	v[1].XYZ.Y = static_cast<u16>(m_context->XYOFFSET.OFY + fpr.w);
@@ -5985,6 +5988,23 @@ void GSRendererHW::ReplaceVerticesWithSprite(const GSVector4i& unscaled_rect, co
 		GSVector4::storel(&v[0].ST.S, st);
 		GSVector4::storeh(&v[1].ST.S, st);
 	}
+
+	// Fix up vertex trace.
+	m_vt.m_min.p.x = unscaled_rect.x;
+	m_vt.m_min.p.y = unscaled_rect.y;
+	m_vt.m_min.p.z = v[0].XYZ.Z;
+	m_vt.m_max.p.x = unscaled_rect.z;
+	m_vt.m_max.p.y = unscaled_rect.w;
+	m_vt.m_max.p.z = v[0].XYZ.Z;
+	m_vt.m_min.t.x = unscaled_uv_rect.x;
+	m_vt.m_min.t.y = unscaled_uv_rect.y;
+	m_vt.m_max.t.x = unscaled_uv_rect.z;
+	m_vt.m_max.t.y = unscaled_uv_rect.w;
+	m_vt.m_min.c = GSVector4i(v[0].RGBAQ.U32[0]).u8to32();
+	m_vt.m_max.c = m_vt.m_min.c;
+	m_vt.m_eq.rgba = 0xFFFF;
+	m_vt.m_eq.z = true;
+	m_vt.m_eq.f = true;
 
 	m_vertex.head = m_vertex.tail = m_vertex.next = 2;
 	m_index.tail = 2;


### PR DESCRIPTION
### Description of Changes

Some stuff still depends on it if it's done early (e.g. texture min/max).

### Rationale behind Changes

Fixes bloom in Burnout 3 in DX11.

### Suggested Testing Steps

Test Burnout in DX11.
