### PR TITLE
GS/HW: Adjust Burnout bloom CRC to work better with upscaling

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSHwHack.cpp
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.cpp
@@ -282,7 +282,8 @@ bool GSHwHack::GSC_BurnoutGames(GSRendererHW& r, int& skip)
 		case 2: // downsample
 		{
 			const GSVector4i downsample_rect = GSVector4i(0, 0, ((main_fb_size.x / 2) - 1), ((main_fb_size.y / 2) - 1));
-			r.ReplaceVerticesWithSprite(downsample_rect, GSVector4i::loadh(main_fb_size), main_fb_size, downsample_rect);
+			const GSVector4i uv_rect = GSVector4i(0, 0, (downsample_rect.z * 2) - std::min(r.GetUpscaleMultiplier()-1.0f, 4.0f) * 3 , (downsample_rect.w * 2) - std::min(r.GetUpscaleMultiplier()-1.0f, 4.0f) * 3);
+			r.ReplaceVerticesWithSprite(downsample_rect, uv_rect, main_fb_size, downsample_rect);
 			downsample_fb = GIFRegTEX0::Create(RFBP, RFBW, RFPSM);
 			state = 3;
 			GL_INS("GSC_BurnoutGames(): Downsampling.");


### PR DESCRIPTION
### Description of Changes
Fudges the CRC hack numbers a little bit to compensate better for upscaling.

### Rationale behind Changes
Upscaling this effect sucks, and there's no *real* solution, but this gets it mostly lined up with all upscales, so it's less annoying.

### Suggested Testing Steps
Test Burnout 3+ games.

Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/f9a20a4a-108b-4089-92b5-1d414e4b438a)

PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/234bb35a-9322-4e3f-997d-ee99f05e9539)

