### PR TITLE
GS: Kill SMT Nocturne CRC hack

### DIFF
--- a/pcsx2/GS/GSCrc.cpp
+++ b/pcsx2/GS/GSCrc.cpp
@@ -31,14 +31,6 @@ const CRC::Game CRC::m_games[] =
 	{0x1F88BECD, Tekken5 /* EU */}, // language selector...
 	{0x652050D2, Tekken5 /* US */},
 	{0xEA64EF39, Tekken5 /* KO */},
-	{0xE8FCF8EC, SMTNocturne /* US */},
-	{0xF0A31EE3, SMTNocturne /* EU */}, // SMTNocturne (Lucifers Call in EU)
-	{0xAE0DE7B7, SMTNocturne /* EU */}, // SMTNocturne (Lucifers Call in EU)
-	{0xD60DA6D4, SMTNocturne /* JP */}, // SMTNocturne
-	{0x0E762E8D, SMTNocturne /* JP */}, // SMTNocturne Maniacs
-	{0x47BA9034, SMTNocturne /* JP */}, // SMTNocturne Maniacs Chronicle
-	{0xD3FFC263, SMTNocturne /* KO */},
-	{0x84D1A8DA, SMTNocturne /* KO */},
 };
 
 const CRC::Game& CRC::Lookup(u32 crc)

--- a/pcsx2/GS/GSCrc.h
+++ b/pcsx2/GS/GSCrc.h
@@ -23,7 +23,6 @@ public:
 	enum Title : u32
 	{
 		NoTitle,
-		SMTNocturne,
 		Tekken5,
 		TitleCount,
 	};

--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -1696,28 +1696,6 @@ void GSState::Write(const u8* mem, int len)
 	GIFRegBITBLTBUF& blit = m_tr.m_blit;
 	const GSLocalMemory::psm_t& psm = GSLocalMemory::m_psm[blit.DPSM];
 
-	// The game uses a resolution of 512x244. RT is located at 0x700 and depth at 0x0
-	//
-	// #Bug number 1. (bad top bar)
-	// The game saves the depth buffer in the EE but with a resolution of
-	// 512x255. So it is ending to 0x7F8, ouch it saves the top of the RT too.
-	//
-	// #Bug number 2. (darker screen)
-	// The game will restore the previously saved buffer at position 0x0 to
-	// 0x7F8.  Because of the extra RT pixels, GS will partialy invalidate
-	// the texture located at 0x700. Next access will generate a cache miss
-	//
-	// The no-solution: instead to handle garbage (aka RT) at the end of the
-	// depth buffer. Let's reduce the size of the transfer
-	if (m_game.title == CRC::SMTNocturne) // TODO: hack
-	{
-		if (blit.DBP == 0 && blit.DPSM == PSMZ32 && w == 512 && h > 224)
-		{
-			h = 224;
-			m_env.TRXREG.RRH = 224;
-		}
-	}
-
 	if (!m_tr.Update(w, h, psm.trbpp, len))
 		return;
 

--- a/pcsx2/GS/Renderers/HW/GSHwHack.cpp
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.cpp
@@ -727,7 +727,7 @@ bool GSHwHack::GSC_BlueTongueGames(GSRendererHW& r, int& skip)
 	if (RPRIM->TME && RTEX0.TW == 3 && RTEX0.TH == 3 && RTEX0.PSM == 0 && RFRAME.FBMSK == 0x00FFFFFF && RFRAME.FBW == 8 && r.PCRTCDisplays.GetResolution().x > 512)
 	{
 		// Check we are drawing stripes
-		for (int i = 1; i < r.m_vertex.tail; i+=2)
+		for (u32 i = 1; i < r.m_vertex.tail; i+=2)
 		{
 			int value = (((r.m_vertex.buff[i].XYZ.X - r.m_vertex.buff[i - 1].XYZ.X) + 8) >> 4);
 			if (value != 32)


### PR DESCRIPTION
### Description of Changes
Removes old CRC hack for Shin Megami Tensei - Nocturne

### Rationale behind Changes
Doesn't seem to fix anything anymore, so no point in it being there.

### Suggested Testing Steps
Try Nocturne, make sure nothing is broke.


1 CRC hack left to get rid of..
