### PR TITLE
GS/OGL: Fix depth state in MultiStretchRects

### DIFF
--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -1634,7 +1634,7 @@ void GSDeviceOGL::DrawMultiStretchRects(
 {
 	IASetVAO(m_vao);
 	IASetPrimitiveTopology(GL_TRIANGLE_STRIP);
-	OMSetDepthStencilState(m_convert.dss);
+	OMSetDepthStencilState(HasDepthOutput(shader) ? m_convert.dss_write : m_convert.dss);
 	OMSetBlendState(false);
 	OMSetColorMaskState();
 	if (!dTex->IsDepthStencil())


### PR DESCRIPTION
### Description of Changes
Fixes depth state in multistretchrect function for OpenGL

### Rationale behind Changes
It was killing the depth test, which was used in SMT Lucifer's Call

### Suggested Testing Steps
Test above game (already done)

All changes courtesy of Stenzek

Look at the shadow

Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/c0f42a29-6bab-4669-bbce-13092d955eb5)

PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/9e3dc8af-0d93-436b-915b-c2f063e8fba5)

