### PR TITLE
Pad: Fix vibration motors backwards and too low power delivery to small motor

### DIFF
--- a/pcsx2/SIO/Pad/PadDualshock2.h
+++ b/pcsx2/SIO/Pad/PadDualshock2.h
@@ -96,6 +96,10 @@ private:
 	// a way to simulate pressure sensitive controls.
 	float pressureModifier;
 	float buttonDeadzone;
+	// Used to store the last vibration mapping request the PS2 made for the small motor.
+	u8 smallMotorLastConfig = 0xff;
+	// Used to store the last vibration mapping request the PS2 made for the large motor.
+	u8 largeMotorLastConfig = 0xff;
 
 	u8 Mystery(u8 commandByte);
 	u8 ButtonQuery(u8 commandByte);

--- a/pcsx2/SaveState.h
+++ b/pcsx2/SaveState.h
@@ -37,7 +37,7 @@ enum class FreezeAction
 // [SAVEVERSION+]
 // This informs the auto updater that the users savestates will be invalidated.
 
-static const u32 g_SaveVersion = (0x9A3B << 16) | 0x0000;
+static const u32 g_SaveVersion = (0x9A3C << 16) | 0x0000;
 
 
 // the freezing data between submodules and core


### PR DESCRIPTION

### Description of Changes
Fix vibration motors backwards and too low power delivery to small motor. Also fix inconsequential but (technically) incorrect return values for vibration mapping command. Fixes #9622 

### Rationale behind Changes
Vibration motors were only partially working, but mostly broken.

### Suggested Testing Steps
Play games known to have vibration. Make sure your hands shake.
