### PR TITLE
GS: Correct alpha test for RGB Only and non-32bit colours

### DIFF
--- a/pcsx2/GS/GSRegs.h
+++ b/pcsx2/GS/GSRegs.h
@@ -792,6 +792,7 @@ REG_END2
 	__forceinline bool DoFirstPass() const { return !ATE || ATST != ATST_NEVER; } // not all pixels fail automatically
 	__forceinline bool DoSecondPass() const { return ATE && ATST != ATST_ALWAYS && AFAIL != AFAIL_KEEP; } // pixels may fail, write fb/z
 	__forceinline bool NoSecondPass() const { return ATE && ATST != ATST_ALWAYS && AFAIL == AFAIL_KEEP; } // pixels may fail, no output
+	__forceinline u32 GetAFAIL(u32 fpsm) const { return (AFAIL == AFAIL_RGB_ONLY && (fpsm & 0xF) != 0) ? AFAIL_FB_ONLY : AFAIL; } // FB Only when not 32bit Framebuffer
 REG_END2
 
 REG64_(GIFReg, TEX0)

--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -3788,9 +3788,10 @@ bool GSState::TryAlphaTest(u32& fm, const u32 fm_mask, u32& zm)
 
 	const u32 framemask = GSLocalMemory::m_psm[m_context->FRAME.PSM].fmsk;
 	const u32 framemaskalpha = GSLocalMemory::m_psm[m_context->FRAME.PSM].fmsk & 0xFF000000;
+	const u32 fail_type = m_context->TEST.GetAFAIL(m_context->FRAME.PSM);
 	// Alpha test can only control the write of some channels. If channels are already masked
 	// the alpha test is therefore a nop.
-	switch (m_context->TEST.AFAIL)
+	switch (fail_type)
 	{
 		case AFAIL_KEEP:
 			break;
@@ -3803,7 +3804,7 @@ bool GSState::TryAlphaTest(u32& fm, const u32 fm_mask, u32& zm)
 				return true;
 			break;
 		case AFAIL_RGB_ONLY:
-			if (zm == 0xFFFFFFFF && ((fm & framemaskalpha) == framemaskalpha || GSLocalMemory::m_psm[m_context->FRAME.PSM].fmt == 1))
+			if (zm == 0xFFFFFFFF && (fm & framemaskalpha) == framemaskalpha)
 				return true;
 			break;
 		default:
@@ -3887,7 +3888,7 @@ bool GSState::TryAlphaTest(u32& fm, const u32 fm_mask, u32& zm)
 
 	if (!pass)
 	{
-		switch (m_context->TEST.AFAIL)
+		switch (fail_type)
 		{
 			case AFAIL_KEEP:
 				fm = zm = 0xffffffff;

--- a/pcsx2/GS/Renderers/HW/GSRendererHWMultiISA.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHWMultiISA.cpp
@@ -132,7 +132,7 @@ bool GSRendererHWFunctions::SwPrimRender(GSRendererHW& hw, bool invalidate_tc, b
 		if (!hw.TryAlphaTest(fm, fm_mask, zm))
 		{
 			gd.sel.atst = context->TEST.ATST;
-			gd.sel.afail = context->TEST.AFAIL;
+			gd.sel.afail = context->TEST.GetAFAIL(context->FRAME.PSM);
 
 			gd.aref = GSVector4i((int)context->TEST.AREF);
 

--- a/pcsx2/GS/Renderers/SW/GSRendererSW.cpp
+++ b/pcsx2/GS/Renderers/SW/GSRendererSW.cpp
@@ -990,7 +990,7 @@ bool GSRendererSW::GetScanlineGlobalData(SharedData* data)
 		if (!TryAlphaTest(fm, fm_mask, zm))
 		{
 			gd.sel.atst = context->TEST.ATST;
-			gd.sel.afail = context->TEST.AFAIL;
+			gd.sel.afail = context->TEST.GetAFAIL(context->FRAME.PSM);
 
 			gd.aref = GSVector4i((int)context->TEST.AREF);
 


### PR DESCRIPTION
### Description of Changes
Fixes the alpha test control result when AFAIL is RGB_ONLY and the framebuffer is not 32bit.

### Rationale behind Changes
RGB_ONLY is only active when the framebuffer format is 32bits, in any other mode the control method will be FB_ONLY meaning 16bit will write to the alpha channel.

### Suggested Testing Steps
Test random stuff (or games listed below) make sure nothing is funny. Results test against PS2.

Fixes shadows in DNA - Dark Native Apostle
Fixes Fog/Lighting in Shrek 2
Fixes distant lighting in True Crime - Streets of LA

DNA:
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/ff0ff683-506b-4e3b-8669-a3792867e4c9)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/104dac9a-a9e8-4bb7-84a1-fecf79138418)

Shrek 2:
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/5cb01287-328f-42a0-8933-8754f56f4dc0)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/4db43cda-7621-45a7-9411-5f7500592e59)

True Crime - Streets of LA:
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/31e7ec29-bd5d-4f1f-978c-ffa26517ee82)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/b090c12c-b4b9-40cc-aa16-af1488f5a886)

