### PR TITLE
GS/HW: Don't drop fractional colour before modulating

### DIFF
--- a/bin/resources/shaders/dx11/tfx.fx
+++ b/bin/resources/shaders/dx11/tfx.fx
@@ -661,7 +661,7 @@ float4 sample_color(float2 st, float uv_w)
 float4 tfx(float4 T, float4 C)
 {
 	float4 C_out;
-	float4 FxT = trunc(trunc(C) * T / 128.0f);
+	float4 FxT = trunc((C * T) / 128.0f);
 
 #if (PS_TFX == 0)
 	C_out = FxT;

--- a/bin/resources/shaders/opengl/tfx_fs.glsl
+++ b/bin/resources/shaders/opengl/tfx_fs.glsl
@@ -614,7 +614,7 @@ vec4 sample_color(vec2 st)
 vec4 tfx(vec4 T, vec4 C)
 {
 	vec4 C_out;
-	vec4 FxT = trunc(trunc(C) * T / 128.0f);
+	vec4 FxT = trunc((C * T) / 128.0f);
 
 #if (PS_TFX == 0)
 	C_out = FxT;

--- a/bin/resources/shaders/vulkan/tfx.glsl
+++ b/bin/resources/shaders/vulkan/tfx.glsl
@@ -849,7 +849,7 @@ vec4 sample_color(vec2 st)
 vec4 tfx(vec4 T, vec4 C)
 {
 	vec4 C_out;
-	vec4 FxT = trunc(trunc(C) * T / 128.0f);
+	vec4 FxT = trunc((C * T) / 128.0f);
 
 #if (PS_TFX == 0)
 	C_out = FxT;

--- a/pcsx2/GS/Renderers/Metal/tfx.metal
+++ b/pcsx2/GS/Renderers/Metal/tfx.metal
@@ -730,7 +730,7 @@ struct PSMain
 	float4 tfx(float4 T, float4 C)
 	{
 		float4 C_out;
-		float4 FxT = trunc(trunc(C) * T / 128.f);
+		float4 FxT = trunc((C * T) / 128.f);
 		if (PS_TFX == 0)
 			C_out = FxT;
 		else if (PS_TFX == 1)

--- a/pcsx2/ShaderCacheVersion.h
+++ b/pcsx2/ShaderCacheVersion.h
@@ -15,4 +15,4 @@
 
 /// Version number for GS and other shaders. Increment whenever any of the contents of the
 /// shaders change, to invalidate the cache.
-static constexpr u32 SHADER_CACHE_VERSION = 28;
+static constexpr u32 SHADER_CACHE_VERSION = 29;


### PR DESCRIPTION
### Description of Changes

Fixes banding in Xenosaga, Tales of the Abyss, Beyond Good and Evil.

### Rationale behind Changes

Closes #7272.

(before followed by after)
![image](https://github.com/PCSX2/pcsx2/assets/11288319/f8903d09-d8da-4f32-b429-0d1e3ec08fe1)
![image](https://github.com/PCSX2/pcsx2/assets/11288319/5cb4962f-b9f8-4ecc-bee8-fe0f3321abe3)
![image](https://github.com/PCSX2/pcsx2/assets/11288319/40841b96-0bac-464e-af1e-e1299f2c9db2)
![image](https://github.com/PCSX2/pcsx2/assets/11288319/04919859-d957-4bd3-a975-4f8221e1ed05)
![image](https://github.com/PCSX2/pcsx2/assets/11288319/56476340-0cdd-4878-a4c5-feb57a2d0fd4)
![image](https://github.com/PCSX2/pcsx2/assets/11288319/54744ced-b5a0-42c5-bffa-2a16275b8a72)
![image](https://github.com/PCSX2/pcsx2/assets/11288319/048ba3a0-ede9-492f-9134-3de9edb0c38b)
![image](https://github.com/PCSX2/pcsx2/assets/11288319/9b5548cb-d83e-4336-8881-ab48fca7c24a)


### Suggested Testing Steps

I've looked through 1,289 changed GS dumps and couldn't see anything which looked worse. The dumps above are a much closer match to sw now. So.. smoke test?