### PR TITLE
Translations: Add Latvija to the menu

### DIFF
--- a/pcsx2-qt/Translations.cpp
+++ b/pcsx2-qt/Translations.cpp
@@ -258,6 +258,7 @@ std::vector<std::pair<QString, QString>> QtHost::GetAvailableLanguageList()
 		{QStringLiteral("Italiano (it-IT)"), QStringLiteral("it-IT")},
 		{QStringLiteral("日本語 (ja-JP)"), QStringLiteral("ja-JP")},
 		{QStringLiteral("한국어 (ko-KR)"), QStringLiteral("ko-KR")},
+		{QStringLiteral("Latvija (lv-LV)"), QStringLiteral("lv-LV")},
 		{QStringLiteral("Nederlands (nl-NL)"), QStringLiteral("nl-NL")},
 		{QStringLiteral("Norsk (no-NO)"), QStringLiteral("no-NO")},
 		{QStringLiteral("Polski (pl-PL)"), QStringLiteral("pl-PL")},


### PR DESCRIPTION
### Description of Changes
Adds missing Latvija option to the menu of selectable languages.

### Rationale behind Changes
Missing languages are baaad.

### Suggested Testing Steps
Cerams, ka dators nesprāgst
