### PR TITLE
Memcard: Remove erroneous auto eject decrement

### DIFF
--- a/pcsx2/SIO/Sio2.cpp
+++ b/pcsx2/SIO/Sio2.cpp
@@ -212,17 +212,6 @@ void Sio2::Memcard()
 			g_Sio2FifoOut.push_back(0x00);
 		}
 
-		mcd->autoEjectTicks--;
-
-		if (mcd->autoEjectTicks == 0)
-		{
-			Host::AddKeyedOSDMessage(fmt::format("AutoEjectSlotClear{}{}", port, slot),
-				fmt::format(TRANSLATE_FS("MemoryCard", "Memory card in port {} / slot {} reinserted"),
-					port + 1,
-					slot + 1),
-				Host::OSD_INFO_DURATION);
-		}
-
 		return;
 	}
 


### PR DESCRIPTION
### Description of Changes
Remove erroneous auto eject decrement that was causing the system to not detect the card as removed.

### Rationale behind Changes
Fixes issues with memory card swaps and savestate loads possibly causing inconsistent memory card states.

### Suggested Testing Steps
BACKUP YOUR MEMORY CARDS FIRST.
Boot BIOS or a game. Swap memory cards between slots, insert cards, eject cards. Game should recognize the card is being ejected and/or moved.
Create a savestate with one card inserted, switch your config to another card. Load the state, card should immediately eject, and insert a moment after.
