### PR TITLE
GS/DX11: Require feature level 11.0 

### DIFF
--- a/bin/resources/shaders/dx11/convert.fx
+++ b/bin/resources/shaders/dx11/convert.fx
@@ -13,8 +13,6 @@
  *  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifdef SHADER_MODEL // make safe to include in resource file to enforce dependency
-
 struct VS_INPUT
 {
 	float4 p : POSITION;
@@ -413,5 +411,3 @@ float ps_stencil_image_init_1(PS_INPUT input) : SV_Target
 		c = float(0x7FFFFFFF);
 	return c;
 }
-
-#endif

--- a/bin/resources/shaders/dx11/interlace.fx
+++ b/bin/resources/shaders/dx11/interlace.fx
@@ -13,8 +13,6 @@
  *  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifdef SHADER_MODEL // make safe to include in resource file to enforce dependency
-
 Texture2D Texture;
 SamplerState Sampler;
 
@@ -195,5 +193,3 @@ float4 ps_main4(PS_INPUT input) : SV_Target0
 
 	return float4(0.0f, 0.0f, 0.0f, 0.0f);
 }
-
-#endif

--- a/bin/resources/shaders/dx11/merge.fx
+++ b/bin/resources/shaders/dx11/merge.fx
@@ -13,8 +13,6 @@
  *  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifdef SHADER_MODEL // make safe to include in resource file to enforce dependency
-
 Texture2D Texture;
 SamplerState Sampler;
 
@@ -45,4 +43,3 @@ float4 ps_main1(PS_INPUT input) : SV_Target0
 	c.a = BGColor.a;
 	return c;
 }
-#endif

--- a/bin/resources/shaders/dx11/present.fx
+++ b/bin/resources/shaders/dx11/present.fx
@@ -13,12 +13,6 @@
  *  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifdef SHADER_MODEL // make safe to include in resource file to enforce dependency
-
-#ifndef PS_SCALE_FACTOR
-#define PS_SCALE_FACTOR 1
-#endif
-
 struct VS_INPUT
 {
 	float4 p : POSITION;
@@ -451,5 +445,3 @@ PS_OUTPUT ps_automagical_supersampling(PS_INPUT input)
 	output.c = float4(col / div, 1);
 	return output;
 }
-
-#endif

--- a/bin/resources/shaders/dx11/shadeboost.fx
+++ b/bin/resources/shaders/dx11/shadeboost.fx
@@ -13,8 +13,6 @@
  *  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifdef SHADER_MODEL // make safe to include in resource file to enforce dependency
-
 Texture2D Texture;
 SamplerState Sampler;
 
@@ -64,5 +62,3 @@ float4 ps_main(PS_INPUT input) : SV_Target0
 	float4 c = Texture.Sample(Sampler, input.t);
 	return ContrastSaturationBrightness(c);
 }
-
-#endif

--- a/pcsx2/GS/Renderers/DX11/D3D.cpp
+++ b/pcsx2/GS/Renderers/DX11/D3D.cpp
@@ -421,20 +421,6 @@ wil::com_ptr_nothrow<ID3DBlob> D3D::CompileShader(D3D::ShaderType type, D3D_FEAT
 	const char* target;
 	switch (feature_level)
 	{
-		case D3D_FEATURE_LEVEL_10_0:
-		{
-			static constexpr std::array<const char*, 4> targets = {{"vs_4_0", "ps_4_0", "cs_4_0"}};
-			target = targets[static_cast<int>(type)];
-		}
-		break;
-
-		case D3D_FEATURE_LEVEL_10_1:
-		{
-			static constexpr std::array<const char*, 4> targets = {{"vs_4_1", "ps_4_1", "cs_4_1"}};
-			target = targets[static_cast<int>(type)];
-		}
-		break;
-
 		case D3D_FEATURE_LEVEL_11_0:
 		{
 			static constexpr std::array<const char*, 4> targets = {{"vs_5_0", "ps_5_0", "cs_5_0"}};
@@ -477,6 +463,12 @@ wil::com_ptr_nothrow<ID3DBlob> D3D::CompileShader(D3D::ShaderType type, D3D_FEAT
 			ofs << code;
 			ofs << "\n\nCompile as " << target << " failed: " << hr << "\n";
 			ofs.write(error_string.c_str(), error_string.size());
+			ofs << "\n";
+			if (macros)
+			{
+				for (const D3D_SHADER_MACRO* macro = macros; macro->Name != nullptr; macro++)
+					ofs << "#define " << macro->Name << " " << macro->Definition << "\n";
+			}
 			ofs.close();
 		}
 

--- a/pcsx2/GS/Renderers/DX11/D3D11ShaderCache.cpp
+++ b/pcsx2/GS/Renderers/DX11/D3D11ShaderCache.cpp
@@ -217,12 +217,6 @@ std::string D3D11ShaderCache::GetCacheBaseFileName(D3D_FEATURE_LEVEL feature_lev
 
 	switch (feature_level)
 	{
-		case D3D_FEATURE_LEVEL_10_0:
-			base_filename += "sm40";
-			break;
-		case D3D_FEATURE_LEVEL_10_1:
-			base_filename += "sm41";
-			break;
 		case D3D_FEATURE_LEVEL_11_0:
 			base_filename += "sm50";
 			break;

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
@@ -67,6 +67,7 @@ GSDevice11::GSDevice11()
 	m_features.dual_source_blend = true;
 	m_features.stencil_buffer = true;
 	m_features.clip_control = true;
+	m_features.cas_sharpening = true;
 	m_features.test_and_sample_depth = false;
 }
 
@@ -92,8 +93,8 @@ bool GSDevice11::Create()
 
 	wil::com_ptr_nothrow<IDXGIAdapter1> dxgi_adapter = D3D::GetAdapterByName(m_dxgi_factory.get(), GSConfig.Adapter);
 
-	static constexpr std::array<D3D_FEATURE_LEVEL, 3> requested_feature_levels = {
-		{D3D_FEATURE_LEVEL_11_0, D3D_FEATURE_LEVEL_10_1, D3D_FEATURE_LEVEL_10_0}};
+	static constexpr std::array<D3D_FEATURE_LEVEL, 1> requested_feature_levels = {
+		{D3D_FEATURE_LEVEL_11_0}};
 
 	wil::com_ptr_nothrow<ID3D11Device> temp_dev;
 	wil::com_ptr_nothrow<ID3D11DeviceContext> temp_ctx;
@@ -103,15 +104,12 @@ bool GSDevice11::Create()
 			nullptr, create_flags, requested_feature_levels.data(), static_cast<UINT>(requested_feature_levels.size()),
 			D3D11_SDK_VERSION, temp_dev.put(), nullptr, temp_ctx.put());
 
-	if (FAILED(hr))
+	if (FAILED(hr) || !temp_dev.try_query_to(&m_dev) || !temp_ctx.try_query_to(&m_ctx))
 	{
-		Console.Error("Failed to create D3D device: 0x%08X", hr);
-		return false;
-	}
-
-	if (!temp_dev.try_query_to(&m_dev) || !temp_ctx.try_query_to(&m_ctx))
-	{
-		Console.Error("Direct3D 11.1 is required and not supported.");
+		Host::ReportErrorAsync("GS",
+			fmt::format(
+				"Failed to create D3D device: 0x{:08X}. A GPU which supports Direct3D Feature Level 11.0 is required.",
+				hr));
 		return false;
 	}
 
@@ -166,16 +164,9 @@ bool GSDevice11::Create()
 	if (GSConfig.UseDebugDevice)
 		m_annotation = m_ctx.try_query<ID3DUserDefinedAnnotation>();
 	level = m_dev->GetFeatureLevel();
-	const bool support_feature_level_11_0 = (level >= D3D_FEATURE_LEVEL_11_0);
 
 	if (!m_shader_cache.Open(m_dev->GetFeatureLevel(), GSConfig.UseDebugDevice))
 		Console.Warning("Shader cache failed to open.");
-
-	// Set maximum texture size limit based on supported feature level.
-	if (support_feature_level_11_0)
-		m_d3d_texsize = D3D11_REQ_TEXTURE2D_U_OR_V_DIMENSION;
-	else
-		m_d3d_texsize = D3D10_REQ_TEXTURE2D_U_OR_V_DIMENSION;
 
 	{
 		// HACK: check AMD
@@ -205,20 +196,18 @@ bool GSDevice11::Create()
 		{"COLOR", 0, DXGI_FORMAT_R8G8B8A8_UNORM, 0, 28, D3D11_INPUT_PER_VERTEX_DATA, 0},
 	};
 
-	ShaderMacro sm_model(m_shader_cache.GetFeatureLevel());
-
 	std::optional<std::string> convert_hlsl = Host::ReadResourceFileToString("shaders/dx11/convert.fx");
 	if (!convert_hlsl.has_value())
 		return false;
 	if (!m_shader_cache.GetVertexShaderAndInputLayout(m_dev.get(), m_convert.vs.put(), m_convert.il.put(),
-			il_convert, std::size(il_convert), *convert_hlsl, sm_model.GetPtr(), "vs_main"))
+			il_convert, std::size(il_convert), *convert_hlsl, nullptr, "vs_main"))
 	{
 		return false;
 	}
 
 	for (size_t i = 0; i < std::size(m_convert.ps); i++)
 	{
-		m_convert.ps[i] = m_shader_cache.GetPixelShader(m_dev.get(), *convert_hlsl, sm_model.GetPtr(), shaderName(static_cast<ShaderConvert>(i)));
+		m_convert.ps[i] = m_shader_cache.GetPixelShader(m_dev.get(), *convert_hlsl, nullptr, shaderName(static_cast<ShaderConvert>(i)));
 		if (!m_convert.ps[i])
 			return false;
 	}
@@ -227,14 +216,14 @@ bool GSDevice11::Create()
 	if (!shader.has_value())
 		return false;
 	if (!m_shader_cache.GetVertexShaderAndInputLayout(m_dev.get(), m_present.vs.put(), m_present.il.put(),
-			il_convert, std::size(il_convert), *shader, sm_model.GetPtr(), "vs_main"))
+			il_convert, std::size(il_convert), *shader, nullptr, "vs_main"))
 	{
 		return false;
 	}
 
 	for (size_t i = 0; i < std::size(m_present.ps); i++)
 	{
-		m_present.ps[i] = m_shader_cache.GetPixelShader(m_dev.get(), *shader, sm_model.GetPtr(), shaderName(static_cast<PresentShader>(i)));
+		m_present.ps[i] = m_shader_cache.GetPixelShader(m_dev.get(), *shader, nullptr, shaderName(static_cast<PresentShader>(i)));
 		if (!m_present.ps[i])
 			return false;
 	}
@@ -282,7 +271,7 @@ bool GSDevice11::Create()
 	for (size_t i = 0; i < std::size(m_merge.ps); i++)
 	{
 		const std::string entry_point(StringUtil::StdStringFromFormat("ps_main%d", i));
-		m_merge.ps[i] = m_shader_cache.GetPixelShader(m_dev.get(), *shader, sm_model.GetPtr(), entry_point.c_str());
+		m_merge.ps[i] = m_shader_cache.GetPixelShader(m_dev.get(), *shader, nullptr, entry_point.c_str());
 		if (!m_merge.ps[i])
 			return false;
 	}
@@ -316,7 +305,7 @@ bool GSDevice11::Create()
 	for (size_t i = 0; i < std::size(m_interlace.ps); i++)
 	{
 		const std::string entry_point(StringUtil::StdStringFromFormat("ps_main%d", i));
-		m_interlace.ps[i] = m_shader_cache.GetPixelShader(m_dev.get(), *shader, sm_model.GetPtr(), entry_point.c_str());
+		m_interlace.ps[i] = m_shader_cache.GetPixelShader(m_dev.get(), *shader, nullptr, entry_point.c_str());
 		if (!m_interlace.ps[i])
 			return false;
 	}
@@ -333,7 +322,7 @@ bool GSDevice11::Create()
 	shader = Host::ReadResourceFileToString("shaders/dx11/shadeboost.fx");
 	if (!shader.has_value())
 		return false;
-	m_shadeboost.ps = m_shader_cache.GetPixelShader(m_dev.get(), *shader, sm_model.GetPtr(), "ps_main");
+	m_shadeboost.ps = m_shader_cache.GetPixelShader(m_dev.get(), *shader, nullptr, "ps_main");
 	if (!m_shadeboost.ps)
 		return false;
 
@@ -466,12 +455,13 @@ bool GSDevice11::Create()
 	for (size_t i = 0; i < std::size(m_date.primid_init_ps); i++)
 	{
 		const std::string entry_point(StringUtil::StdStringFromFormat("ps_stencil_image_init_%d", i));
-		m_date.primid_init_ps[i] = m_shader_cache.GetPixelShader(m_dev.get(), *convert_hlsl, sm_model.GetPtr(), entry_point.c_str());
+		m_date.primid_init_ps[i] = m_shader_cache.GetPixelShader(m_dev.get(), *convert_hlsl, nullptr, entry_point.c_str());
 		if (!m_date.primid_init_ps[i])
 			return false;
 	}
 
-	m_features.cas_sharpening = support_feature_level_11_0 && CreateCASShaders();
+	if (!CreateCASShaders())
+		return false;
 
 	if (!CreateImGuiResources())
 		return false;
@@ -788,8 +778,6 @@ std::string GSDevice11::GetDriverInfo() const
 	std::string ret = "Unknown Feature Level";
 
 	static constexpr std::array<std::tuple<D3D_FEATURE_LEVEL, const char*>, 4> feature_level_names = {{
-		{D3D_FEATURE_LEVEL_10_0, "D3D_FEATURE_LEVEL_10_0"},
-		{D3D_FEATURE_LEVEL_10_0, "D3D_FEATURE_LEVEL_10_1"},
 		{D3D_FEATURE_LEVEL_11_0, "D3D_FEATURE_LEVEL_11_0"},
 		{D3D_FEATURE_LEVEL_11_1, "D3D_FEATURE_LEVEL_11_1"},
 	}};
@@ -1121,8 +1109,8 @@ GSTexture* GSDevice11::CreateSurface(GSTexture::Type type, int width, int height
 	D3D11_TEXTURE2D_DESC desc = {};
 
 	// Texture limit for D3D10/11 min 1, max 8192 D3D10, max 16384 D3D11.
-	desc.Width = std::clamp(width, 1, m_d3d_texsize);
-	desc.Height = std::clamp(height, 1, m_d3d_texsize);
+	desc.Width = std::clamp(width, 1, D3D11_REQ_TEXTURE2D_U_OR_V_DIMENSION);
+	desc.Height = std::clamp(height, 1, D3D11_REQ_TEXTURE2D_U_OR_V_DIMENSION);
 	desc.Format = GSTexture11::GetDXGIFormat(format);
 	desc.MipLevels = levels;
 	desc.ArraySize = 1;
@@ -1551,16 +1539,14 @@ void GSDevice11::DoFXAA(GSTexture* sTex, GSTexture* dTex)
 			return;
 		}
 
-		ShaderMacro sm(m_shader_cache.GetFeatureLevel());
-		m_fxaa_ps = m_shader_cache.GetPixelShader(m_dev.get(), *shader, sm.GetPtr(), "ps_main");
+		ShaderMacro sm;
+		sm.AddMacro("FXAA_HLSL_5", "1");
+		m_fxaa_ps = m_shader_cache.GetPixelShader(m_dev.get(), *shader, sm.GetPtr(), "main");
 		if (!m_fxaa_ps)
 			return;
 	}
 
 	StretchRect(sTex, sRect, dTex, dRect, m_fxaa_ps.get(), nullptr, true);
-
-	//sTex->Save("c:\\temp1\\1.bmp");
-	//dTex->Save("c:\\temp1\\2.bmp");
 }
 
 void GSDevice11::DoShadeBoost(GSTexture* sTex, GSTexture* dTex, const float params[4])
@@ -1593,9 +1579,11 @@ bool GSDevice11::CreateCASShaders()
 	m_cas.cs_sharpen = m_shader_cache.GetComputeShader(m_dev.get(), cas_source.value(), sharpen_only_macros, "main");
 	m_cas.cs_upscale = m_shader_cache.GetComputeShader(m_dev.get(), cas_source.value(), nullptr, "main");
 	if (!m_cas.cs_sharpen || !m_cas.cs_upscale)
+	{
+		Console.Error("Failed to create CAS compute shaders.");
 		return false;
+	}
 
-	m_features.cas_sharpening = true;
 	return true;
 }
 
@@ -2113,23 +2101,6 @@ void GSDevice11::SetScissor(const GSVector4i& scissor)
 	}
 }
 
-GSDevice11::ShaderMacro::ShaderMacro(D3D_FEATURE_LEVEL fl)
-{
-	switch (fl)
-	{
-	case D3D_FEATURE_LEVEL_10_0:
-		mlist.emplace_back("SHADER_MODEL", "0x400");
-		break;
-	case D3D_FEATURE_LEVEL_10_1:
-		mlist.emplace_back("SHADER_MODEL", "0x401");
-		break;
-	case D3D_FEATURE_LEVEL_11_0:
-	default:
-		mlist.emplace_back("SHADER_MODEL", "0x500");
-		break;
-	}
-}
-
 void GSDevice11::ShaderMacro::AddMacro(const char* n, int d)
 {
 	AddMacro(n, std::to_string(d));
@@ -2140,7 +2111,7 @@ void GSDevice11::ShaderMacro::AddMacro(const char* n, std::string d)
 	mlist.emplace_back(n, std::move(d));
 }
 
-D3D_SHADER_MACRO* GSDevice11::ShaderMacro::GetPtr(void)
+D3D_SHADER_MACRO* GSDevice11::ShaderMacro::GetPtr()
 {
 	mout.clear();
 

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.h
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.h
@@ -102,10 +102,9 @@ public:
 		std::vector<mcstr> mout;
 
 	public:
-		ShaderMacro(D3D_FEATURE_LEVEL fl);
 		void AddMacro(const char* n, int d);
 		void AddMacro(const char* n, std::string d);
-		D3D_SHADER_MACRO* GetPtr(void);
+		D3D_SHADER_MACRO* GetPtr();
 	};
 
 private:
@@ -156,7 +155,6 @@ private:
 	u32 m_vb_pos = 0; // bytes
 	u32 m_ib_pos = 0; // indices/sizeof(u32)
 	u32 m_structured_vb_pos = 0; // bytes
-	int m_d3d_texsize = 0;
 
 	bool m_allow_tearing_supported = false;
 	bool m_using_flip_model_swap_chain = true;

--- a/pcsx2/GS/Renderers/DX11/GSTextureFX11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSTextureFX11.cpp
@@ -64,7 +64,7 @@ void GSDevice11::SetupVS(VSSelector sel, const GSHWDrawConfig::VSConstantBuffer*
 
 	if (i == m_vs.end())
 	{
-		ShaderMacro sm(m_shader_cache.GetFeatureLevel());
+		ShaderMacro sm;
 
 		sm.AddMacro("VERTEX_SHADER", 1);
 		sm.AddMacro("VS_TME", sel.tme);
@@ -113,7 +113,7 @@ void GSDevice11::SetupPS(const PSSelector& sel, const GSHWDrawConfig::PSConstant
 
 	if (i == m_ps.end())
 	{
-		ShaderMacro sm(m_shader_cache.GetFeatureLevel());
+		ShaderMacro sm;
 
 		sm.AddMacro("PIXEL_SHADER", 1);
 		sm.AddMacro("PS_FST", sel.fst);

--- a/pcsx2/GS/Renderers/DX12/D3D12ShaderCache.cpp
+++ b/pcsx2/GS/Renderers/DX12/D3D12ShaderCache.cpp
@@ -275,12 +275,6 @@ std::string D3D12ShaderCache::GetCacheBaseFileName(const std::string_view& type,
 
 	switch (feature_level)
 	{
-		case D3D_FEATURE_LEVEL_10_0:
-			base_filename += "sm40";
-			break;
-		case D3D_FEATURE_LEVEL_10_1:
-			base_filename += "sm41";
-			break;
 		case D3D_FEATURE_LEVEL_11_0:
 			base_filename += "sm50";
 			break;

--- a/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
@@ -66,21 +66,8 @@ static D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE GetLoadOpForTexture(GSTexture12* 
 	// clang-format on
 }
 
-GSDevice12::ShaderMacro::ShaderMacro(D3D_FEATURE_LEVEL fl)
+GSDevice12::ShaderMacro::ShaderMacro()
 {
-	switch (fl)
-	{
-		case D3D_FEATURE_LEVEL_10_0:
-			mlist.emplace_back("SHADER_MODEL", "0x400");
-			break;
-		case D3D_FEATURE_LEVEL_10_1:
-			mlist.emplace_back("SHADER_MODEL", "0x401");
-			break;
-		case D3D_FEATURE_LEVEL_11_0:
-		default:
-			mlist.emplace_back("SHADER_MODEL", "0x500");
-			break;
-	}
 	mlist.emplace_back("DX12", "1");
 }
 
@@ -999,8 +986,6 @@ std::string GSDevice12::GetDriverInfo() const
 	std::string ret = "Unknown Feature Level";
 
 	static constexpr std::array<std::tuple<D3D_FEATURE_LEVEL, const char*>, 4> feature_level_names = {{
-		{D3D_FEATURE_LEVEL_10_0, "D3D_FEATURE_LEVEL_10_0"},
-		{D3D_FEATURE_LEVEL_10_0, "D3D_FEATURE_LEVEL_10_1"},
 		{D3D_FEATURE_LEVEL_11_0, "D3D_FEATURE_LEVEL_11_0"},
 		{D3D_FEATURE_LEVEL_11_1, "D3D_FEATURE_LEVEL_11_1"},
 	}};
@@ -1151,6 +1136,7 @@ bool GSDevice12::CheckFeatures()
 	m_features.dual_source_blend = true;
 	m_features.clip_control = true;
 	m_features.stencil_buffer = true;
+	m_features.cas_sharpening = true;
 	m_features.test_and_sample_depth = false;
 	m_features.vs_expand = !GSConfig.DisableVertexShaderExpand;
 
@@ -1833,9 +1819,11 @@ bool GSDevice12::CompileCASPipelines()
 	cpb.SetShader(cs_sharpen->GetBufferPointer(), cs_sharpen->GetBufferSize());
 	m_cas_sharpen_pipeline = cpb.Create(m_device.get(), m_shader_cache, false);
 	if (!m_cas_upscale_pipeline || !m_cas_sharpen_pipeline)
+	{
+		Console.Error("Failed to create CAS pipelines");
 		return false;
+	}
 
-	m_features.cas_sharpening = true;
 	return true;
 }
 
@@ -2212,13 +2200,13 @@ static void AddUtilityVertexAttributes(D3D12::GraphicsPipelineBuilder& gpb)
 
 GSDevice12::ComPtr<ID3DBlob> GSDevice12::GetUtilityVertexShader(const std::string& source, const char* entry_point)
 {
-	ShaderMacro sm_model(m_shader_cache.GetFeatureLevel());
+	ShaderMacro sm_model;
 	return m_shader_cache.GetVertexShader(source, sm_model.GetPtr(), entry_point);
 }
 
 GSDevice12::ComPtr<ID3DBlob> GSDevice12::GetUtilityPixelShader(const std::string& source, const char* entry_point)
 {
-	ShaderMacro sm_model(m_shader_cache.GetFeatureLevel());
+	ShaderMacro sm_model;
 	return m_shader_cache.GetPixelShader(source, sm_model.GetPtr(), entry_point);
 }
 
@@ -2595,7 +2583,9 @@ bool GSDevice12::CompilePostProcessingPipelines()
 			return false;
 		}
 
-		ComPtr<ID3DBlob> ps(GetUtilityPixelShader(*shader, "ps_main"));
+		ShaderMacro sm;
+		sm.AddMacro("FXAA_HLSL_5", "1");
+		ComPtr<ID3DBlob> ps = m_shader_cache.GetPixelShader(*shader, sm.GetPtr());
 		if (!ps)
 			return false;
 
@@ -2710,7 +2700,7 @@ const ID3DBlob* GSDevice12::GetTFXVertexShader(GSHWDrawConfig::VSSelector sel)
 	if (it != m_tfx_vertex_shaders.end())
 		return it->second.get();
 
-	ShaderMacro sm(m_shader_cache.GetFeatureLevel());
+	ShaderMacro sm;
 	sm.AddMacro("VERTEX_SHADER", 1);
 	sm.AddMacro("VS_TME", sel.tme);
 	sm.AddMacro("VS_FST", sel.fst);
@@ -2729,7 +2719,7 @@ const ID3DBlob* GSDevice12::GetTFXPixelShader(const GSHWDrawConfig::PSSelector& 
 	if (it != m_tfx_pixel_shaders.end())
 		return it->second.get();
 
-	ShaderMacro sm(m_shader_cache.GetFeatureLevel());
+	ShaderMacro sm;
 	sm.AddMacro("PIXEL_SHADER", 1);
 	sm.AddMacro("PS_FST", sel.fst);
 	sm.AddMacro("PS_WMS", sel.wms);

--- a/pcsx2/GS/Renderers/DX12/GSDevice12.h
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.h
@@ -257,7 +257,7 @@ public:
 		std::vector<mcstr> mout;
 
 	public:
-		ShaderMacro(D3D_FEATURE_LEVEL fl);
+		ShaderMacro();
 		void AddMacro(const char* n, int d);
 		void AddMacro(const char* n, std::string d);
 		D3D_SHADER_MACRO* GetPtr(void);

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -1794,13 +1794,6 @@ void GSDeviceOGL::DoInterlace(GSTexture* sTex, const GSVector4& sRect, GSTexture
 
 bool GSDeviceOGL::CompileFXAAProgram()
 {
-	// Needs ARB_gpu_shader5 for gather.
-	if (!GLAD_GL_ARB_gpu_shader5)
-	{
-		Console.Warning("FXAA is not supported with the current GPU");
-		return true;
-	}
-
 	const std::string_view fxaa_macro = "#define FXAA_GLSL_130 1\n";
 	std::optional<std::string> shader = Host::ReadResourceFileToString("shaders/common/fxaa.fx");
 	if (!shader.has_value())

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -1809,7 +1809,7 @@ bool GSDeviceOGL::CompileFXAAProgram()
 		return false;
 	}
 
-	const std::string ps(GetShaderSource("ps_main", GL_FRAGMENT_SHADER, shader->c_str(), fxaa_macro));
+	const std::string ps(GetShaderSource("main", GL_FRAGMENT_SHADER, shader->c_str(), fxaa_macro));
 	std::optional<GLProgram> prog = m_shader_cache.GetProgram(m_convert.vs, ps);
 	if (!prog.has_value())
 	{


### PR DESCRIPTION
### Description of Changes

Feature level 11.0 GPUs were first released in 2009, almost 14 years ago now. Older GPUs have not had drivers released in a long time, and are known to be buggy.

None of us have hardware this old, so it's impossible for us to support it. And even then, there's no guarantee that we'll be able to work around whatever issue it is.

PCSX2 is not going to run well on this sort of hardware. But if for some reason you are silly enough to want to do this, you can always use the WARP device, probably in combination with the software renderer. But I doubt it'll run fast enough anyway.

### Rationale behind Changes

Less dead code which we can't test/maintain.

### Suggested Testing Steps

Make sure FXAA in all renderers still works (I removed some unused bits there).
