### PR TITLE
GS/HW: Fix target memory usage underflowing

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -1913,6 +1913,8 @@ bool GSTextureCache::CopyRGBFromDepthToColor(Target* dst, Target* depth_src)
 			new_size != dst->m_unscaled_size || new_size != depth_src->m_unscaled_size);
 		if (!tex)
 			return false;
+
+		m_target_memory_usage = (m_target_memory_usage - dst->m_texture->GetMemUsage()) + tex->GetMemUsage();
 	}
 
 	// Remove any dirty rectangles contained by this update, we don't want to pull from local memory.


### PR DESCRIPTION
### Description of Changes

Forgot to update the memory usage here..

### Rationale behind Changes

Stops target memory usage stat underflowing in Ratchet.

### Suggested Testing Steps

CI passes - already checked it fixes it.
