### PR TITLE
GameDB: correct an entry

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -40642,7 +40642,7 @@ SLPS-25453:
   name: "Digimon World X"
   region: "NTSC-J"
 SLPS-25454:
-  name: "Daisenryaku VII Exceed"
+  name: "Yoshitsune Eiyuuden - The Story of Hero Yoshitsune"
   region: "NTSC-J"
   gsHWFixes:
     partialTargetInvalidation: 1 # Fixes broken textures.


### PR DESCRIPTION
Yoshitsune Eiyuuden: The Story of Hero Yoshitsune
NTSC-J: SLPS-25454 & SCAJ-20115
https://wiki.pcsx2.net/Yoshitsune_Eiyuuden:_The_Story_of_Hero_Yoshitsune
http://redump.org/disc/38707/

Dai Senryaku VII: Exceed
NTSC-J: SLPS-25464 & SLPS-25953
https://wiki.pcsx2.net/Dai_Senryaku_VII:_Exceed
http://redump.org/disc/43371/ - SLPS-25464 not in database
