### PR TITLE
GS/HW: Improve detection of reverse texture shuffles

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -349,14 +349,14 @@ void GSRendererHW::ConvertSpriteTextureShuffle(bool& write_ba, bool& read_ba)
 	const u32 count = m_vertex.next;
 	GSVertex* v = &m_vertex.buff[0];
 	const GIFRegXYOFFSET& o = m_context->XYOFFSET;
-
+	const GSVertex first_vert = (v[0].XYZ.X <= v[m_vertex.tail - 2].XYZ.X) ? v[0] : v[m_vertex.tail - 2];
 	// vertex position is 8 to 16 pixels, therefore it is the 16-31 bits of the colors
-	const int pos = (v[0].XYZ.X - o.OFX) & 0xFF;
+	const int pos = (first_vert.XYZ.X - o.OFX) & 0xFF;
 	write_ba = (pos > 112 && pos < 136);
 
 	// Read texture is 8 to 16 pixels (same as above)
 	const float tw = static_cast<float>(1u << m_cached_ctx.TEX0.TW);
-	int tex_pos = (PRIM->FST) ? v[0].U : static_cast<int>(tw * v[0].ST.S);
+	int tex_pos = (PRIM->FST) ? first_vert.U : static_cast<int>(tw * first_vert.ST.S);
 	tex_pos &= 0xFF;
 	read_ba = (tex_pos > 112 && tex_pos < 144);
 


### PR DESCRIPTION
### Description of Changes
Fixes detection of reverse texture shuffles

### Rationale behind Changes
Some games (for some reason or another) start the shuffle in the bottom right then work towards the upper left, probably to try and avoid overwriting data accidentally and making use of the texture cache (ps2 one)

### Suggested Testing Steps
Try games, mainly Smugglers Run and Midnight Club 2

Fixes #1958 Smugglers Run Shadows
Fixes #3102 Midnight Club 2 headlights


Midnight Club 2:
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/5fcc769b-ee1b-47be-99f6-353b1c8ae752)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/67f18796-cc6b-4ba6-be70-26f4fd9af619)

Smuggler's Run:
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/dbe747a3-0367-4265-b9f1-d7b9898cb9c7)
![image](https://github.com/PCSX2/pcsx2/assets/6278726/a5c95c8f-6f74-4068-b364-0fb6cecb913e)

PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/0fc06a09-b7ff-46ef-ada8-516e687f4c19)
![image](https://github.com/PCSX2/pcsx2/assets/6278726/1c3a0f34-5c2f-4760-82c5-583bae1a9456)
