### PR TITLE
GS/HW: Don't invalidate alpha on display target lookup

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -1560,14 +1560,6 @@ GSTextureCache::Target* GSTextureCache::LookupTarget(GIFRegTEX0 TEX0, const GSVe
 	if (dst)
 	{
 		dst->m_used |= used;
-
-		if (is_frame)
-		{
-			// TODO: Why are we doing this?!
-			dst->m_valid_alpha_low = false;
-			dst->m_valid_alpha_high = false;
-		}
-
 		dst->readbacks_since_draw = 0;
 
 		assert(dst && dst->m_texture && dst->m_scale == scale);
@@ -1967,6 +1959,7 @@ bool GSTextureCache::CopyRGBFromDepthToColor(Target* dst, Target* depth_src)
 
 	dst->m_unscaled_size = new_size;
 	dst->m_valid_rgb = true;
+	dst->m_32_bits_fmt = true;
 	return true;
 }
 


### PR DESCRIPTION
### Description of Changes

Stop invalidating the buffers of a target just because we're displaying it.

### Rationale behind Changes

This never made sense.

### Suggested Testing Steps

Only dump affected was Grand Prix Challenge, which is slightly improved, but still broken.

So usual smoke test.
