### PR TITLE
Qt: Make incompatible savestate message translatable

### DIFF
--- a/pcsx2-qt/SetupWizardDialog.cpp
+++ b/pcsx2-qt/SetupWizardDialog.cpp
@@ -151,7 +151,7 @@ void SetupWizardDialog::updatePageLabels(int prev_page)
 void SetupWizardDialog::updatePageButtons()
 {
 	const int page = m_ui.pages->currentIndex();
-	m_ui.next->setText((page == Page_Complete) ? "&Finish" : "&Next");
+	m_ui.next->setText((page == Page_Complete) ? tr("&Finish") : tr("&Next"));
 	m_ui.back->setEnabled(page > 0);
 }
 

--- a/pcsx2/SaveState.cpp
+++ b/pcsx2/SaveState.cpp
@@ -1065,10 +1065,10 @@ static bool CheckVersion(const std::string& filename, zip_t* zf, Error* error)
 	// than the emulator recognizes.  99% chance that trying to load it will just corrupt emulation or crash.
 	if (savever > g_SaveVersion || (savever >> 16) != (g_SaveVersion >> 16))
 	{
-		Error::SetString(error, fmt::format("The state is an unsupported version. (PCSX2 ver={:x}, state ver={:x}).\n"
-											"Option 1: Download PCSX2 {} from pcsx2.net and make a memcard save like on the physical PS2.\n"
-											"Option 2: Delete the savestates.",
-									g_SaveVersion, savever, version_string));
+		Error::SetString(error, fmt::format(TRANSLATE_FS("SaveState","This savestate is an unsupported version and cannot be used.\n\n"
+											"You can download PCSX2 {} from pcsx2.net and make a normal memory card save.\n"
+											"Otherwise delete the savestate and do a fresh boot."),
+											version_string));
 		return false;
 	}
 


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
This PR attempts to make the incompatible savestate message translatable, and adding clarification about the existing memory card.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
More translation, the better

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Make sure CI passes and the text looks right.
