### PR TITLE
GS/HW: Re-optimize alpha test after updating direct alpha range

### DIFF
--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -3705,7 +3705,7 @@ void GSState::CalcAlphaMinMax(const int tex_alpha_min, const int tex_alpha_max)
 		return;
 
 	// We wanted to force an update as we now know the alpha of the non-indexed texture.
-	// Limit max to 255 as we send 500 when we don't know, makes calculating 16bit easier.
+	// Limit max to 255 as we send 500 when we don't know, makes calculating 24/16bit easier.
 	int min = tex_alpha_min, max = std::min(tex_alpha_max, 255);
 
 	if (IsCoverageAlpha())
@@ -3728,12 +3728,14 @@ void GSState::CalcAlphaMinMax(const int tex_alpha_min, const int tex_alpha_max)
 					a.w = max;
 					break;
 				case 1:
-					a.y = env.TEXA.AEM ? 0 : env.TEXA.TA0;
-					a.w = env.TEXA.TA0;
+					// If we're using the alpha from the texture, not the whole range, we can just use tex_alpha_min/max.
+					// AEM and TA0 re precomputed with GSBlock::ReadAndExpandBlock24, so already worked out for tex_alpha.
+					a.y = (tex_alpha_max < 500) ? min : (env.TEXA.AEM ? 0 : env.TEXA.TA0);
+					a.w = (tex_alpha_max < 500) ? max : env.TEXA.TA0;
 					break;
 				case 2:
 					// If we're using the alpha from the texture, not the whole range, we can just use tex_alpha_min/max.
-					// TA0/TA1 is precomputed with GSBlock::ReadAndExpandBlock16, so already worked out for tex_alpha.
+					// AEM, TA0 and TA1 are precomputed with GSBlock::ReadAndExpandBlock16, so already worked out for tex_alpha.
 					a.y = (tex_alpha_max < 500) ? min : (env.TEXA.AEM ? 0 : std::min(env.TEXA.TA0, env.TEXA.TA1));
 					a.w = (tex_alpha_max < 500) ? max : std::max(env.TEXA.TA0, env.TEXA.TA1);
 					break;

--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -3705,7 +3705,8 @@ void GSState::CalcAlphaMinMax(const int tex_alpha_min, const int tex_alpha_max)
 		return;
 
 	// We wanted to force an update as we now know the alpha of the non-indexed texture.
-	int min = tex_alpha_min, max = tex_alpha_max;
+	// Limit max to 255 as we send 500 when we don't know, makes calculating 16bit easier.
+	int min = tex_alpha_min, max = std::min(tex_alpha_max, 255);
 
 	if (IsCoverageAlpha())
 	{
@@ -3731,8 +3732,10 @@ void GSState::CalcAlphaMinMax(const int tex_alpha_min, const int tex_alpha_max)
 					a.w = env.TEXA.TA0;
 					break;
 				case 2:
-					a.y = env.TEXA.AEM ? 0 : std::min(env.TEXA.TA0, env.TEXA.TA1);
-					a.w = std::max(env.TEXA.TA0, env.TEXA.TA1);
+					// If we're using the alpha from the texture, not the whole range, we can just use tex_alpha_min/max.
+					// TA0/TA1 is precomputed with GSBlock::ReadAndExpandBlock16, so already worked out for tex_alpha.
+					a.y = (tex_alpha_max < 500) ? min : (env.TEXA.AEM ? 0 : std::min(env.TEXA.TA0, env.TEXA.TA1));
+					a.w = (tex_alpha_max < 500) ? max : std::max(env.TEXA.TA0, env.TEXA.TA1);
 					break;
 				case 3:
 					m_mem.m_clut.GetAlphaMinMax32(a.y, a.w);

--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -176,7 +176,7 @@ protected:
 	GSVertexTrace::VertexAlpha& GetAlphaMinMax()
 	{
 		if (!m_vt.m_alpha.valid)
-			CalcAlphaMinMax(0, 255);
+			CalcAlphaMinMax(0, 500);
 		return m_vt.m_alpha;
 	}
 	struct TextureMinMaxResult

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -4809,6 +4809,12 @@ __ri void GSRendererHW::DrawPrims(GSTextureCache::Target* rt, GSTextureCache::Ta
 			blend_alpha_min = std::min(blend_alpha_min, rt->m_alpha_min);
 			blend_alpha_max = std::max(blend_alpha_max, rt->m_alpha_max);
 		}
+
+		if (!rt->m_32_bits_fmt)
+		{
+			rt->m_alpha_max &= 128;
+			rt->m_alpha_min &= 128;
+		}
 	}
 
 	// Not gonna spend too much time with this, it's not likely to be used much, can't be less accurate than it was.
@@ -4817,6 +4823,12 @@ __ri void GSRendererHW::DrawPrims(GSTextureCache::Target* rt, GSTextureCache::Ta
 		ds->m_alpha_max = std::max(ds->m_alpha_max, static_cast<int>(m_vt.m_max.p.z) >> 24);
 		ds->m_alpha_min = std::min(ds->m_alpha_min, static_cast<int>(m_vt.m_min.p.z) >> 24);
 		GL_INS("New DS Alpha Range: %d-%d", ds->m_alpha_min, ds->m_alpha_max);
+
+		if (GSLocalMemory::m_psm[ds->m_TEX0.PSM].bpp == 16)
+		{
+			ds->m_alpha_max &= 128;
+			ds->m_alpha_min &= 128;
+		}
 	}
 
 	bool blending_alpha_pass = false;
@@ -5607,6 +5619,12 @@ bool GSRendererHW::TryTargetClear(GSTextureCache::Target* rt, GSTextureCache::Ta
 			g_gs_device->ClearRenderTarget(rt->m_texture, c);
 			rt->m_alpha_max = c >> 24;
 			rt->m_alpha_min = c >> 24;
+
+			if (!rt->m_32_bits_fmt)
+			{
+				rt->m_alpha_max &= 128;
+				rt->m_alpha_min &= 128;
+			}
 		}
 		else
 		{
@@ -5625,6 +5643,12 @@ bool GSRendererHW::TryTargetClear(GSTextureCache::Target* rt, GSTextureCache::Ta
 			g_gs_device->ClearDepth(ds->m_texture, d);
 			ds->m_alpha_max = z >> 24;
 			ds->m_alpha_min = z >> 24;
+
+			if (GSLocalMemory::m_psm[ds->m_TEX0.PSM].bpp == 16)
+			{
+				ds->m_alpha_max &= 128;
+				ds->m_alpha_min &= 128;
+			}
 		}
 		else
 		{

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -3646,17 +3646,25 @@ GSTextureCache::Source* GSTextureCache::CreateSource(const GIFRegTEX0& TEX0, con
 		src->m_target = true;
 		src->m_from_target = dst;
 		src->m_from_target_TEX0 = dst->m_TEX0;
-		src->m_alpha_minmax.first = dst->m_alpha_min;
-		src->m_alpha_minmax.second = dst->m_alpha_max;
 
-		// This is a bit rough, since if AEM is on, without rescanning the whole texture, we don't know if anything is transparent, so just go the hard way.
-		if (!dst->m_32_bits_fmt)
+		if ((src->m_TEX0.PSM & 0xf) == PSMCT24)
 		{
-			const bool using_both = (src->m_alpha_minmax.first ^ src->m_alpha_minmax.second) & 128;
-			const bool using_ta1 = (src->m_alpha_minmax.second & 128);
+			src->m_alpha_minmax.first = TEXA.AEM ? 0 : TEXA.TA0;
+			src->m_alpha_minmax.second = TEXA.TA0;
+		}
+		else
+		{
+			src->m_alpha_minmax.first = dst->m_alpha_min;
+			src->m_alpha_minmax.second = dst->m_alpha_max;
 
-			src->m_alpha_minmax.first = TEXA.AEM ? 0 : (using_both ? std::min(TEXA.TA1, TEXA.TA0) : (using_ta1 ? TEXA.TA1 : TEXA.TA0));
-			src->m_alpha_minmax.second = (using_both ? std::max(TEXA.TA1, TEXA.TA0) : (using_ta1 ? TEXA.TA1 : TEXA.TA0));
+			if (!dst->m_32_bits_fmt)
+			{
+				const bool using_both = (src->m_alpha_minmax.first ^ src->m_alpha_minmax.second) & 128;
+				const bool using_ta1 = (src->m_alpha_minmax.second & 128);
+
+				src->m_alpha_minmax.first = TEXA.AEM ? 0 : (using_both ? std::min(TEXA.TA1, TEXA.TA0) : (using_ta1 ? TEXA.TA1 : TEXA.TA0));
+				src->m_alpha_minmax.second = (using_both ? std::max(TEXA.TA1, TEXA.TA0) : (using_ta1 ? TEXA.TA1 : TEXA.TA0));
+			}
 		}
 
 		if (psm.pal > 0)
@@ -3698,17 +3706,25 @@ GSTextureCache::Source* GSTextureCache::CreateSource(const GIFRegTEX0& TEX0, con
 		src->m_from_target_TEX0 = dst->m_TEX0;
 		src->m_valid_rect = dst->m_valid;
 		src->m_end_block = dst->m_end_block;
-		src->m_alpha_minmax.first = dst->m_alpha_min;
-		src->m_alpha_minmax.second = dst->m_alpha_max;
 
-		// This is a bit rough, since if AEM is on, without rescanning the whole texture, we don't know if anything is transparent, so just go the hard way.
-		if (!dst->m_32_bits_fmt)
+		if ((src->m_TEX0.PSM & 0xf) == PSMCT24)
 		{
-			const bool using_both = (src->m_alpha_minmax.first ^ src->m_alpha_minmax.second) & 128;
-			const bool using_ta1 = (src->m_alpha_minmax.second & 128);
+			src->m_alpha_minmax.first = TEXA.AEM ? 0 : TEXA.TA0;
+			src->m_alpha_minmax.second = TEXA.TA0;
+		}
+		else
+		{
+			src->m_alpha_minmax.first = dst->m_alpha_min;
+			src->m_alpha_minmax.second = dst->m_alpha_max;
 
-			src->m_alpha_minmax.first = TEXA.AEM ? 0 : (using_both ? std::min(TEXA.TA1, TEXA.TA0) : (using_ta1 ? TEXA.TA1 : TEXA.TA0));
-			src->m_alpha_minmax.second = (using_both ? std::max(TEXA.TA1, TEXA.TA0) : (using_ta1 ? TEXA.TA1 : TEXA.TA0));
+			if (!dst->m_32_bits_fmt)
+			{
+				const bool using_both = (src->m_alpha_minmax.first ^ src->m_alpha_minmax.second) & 128;
+				const bool using_ta1 = (src->m_alpha_minmax.second & 128);
+
+				src->m_alpha_minmax.first = TEXA.AEM ? 0 : (using_both ? std::min(TEXA.TA1, TEXA.TA0) : (using_ta1 ? TEXA.TA1 : TEXA.TA0));
+				src->m_alpha_minmax.second = (using_both ? std::max(TEXA.TA1, TEXA.TA0) : (using_ta1 ? TEXA.TA1 : TEXA.TA0));
+			}
 		}
 
 		dst->Update();
@@ -5210,8 +5226,16 @@ void GSTextureCache::Target::Update()
 		g_gs_device->DrawMultiStretchRects(drects, ndrects, m_texture, shader);
 	}
 
-	m_alpha_min = 0;
-	m_alpha_max = m_32_bits_fmt ? 255 : 128;
+	if ((m_TEX0.PSM & 0xf) == PSMCT24)
+	{
+		m_alpha_min = 128;
+		m_alpha_max = 128;
+	}
+	else
+	{
+		m_alpha_min = 0;
+		m_alpha_max = m_32_bits_fmt ? 255 : 128;
+	}
 	g_gs_device->Recycle(t);
 	m_dirty.clear();
 }

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -5211,7 +5211,7 @@ void GSTextureCache::Target::Update()
 	}
 
 	m_alpha_min = 0;
-	m_alpha_max = 255;
+	m_alpha_max = m_32_bits_fmt ? 255 : 128;
 	g_gs_device->Recycle(t);
 	m_dirty.clear();
 }

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -3649,6 +3649,16 @@ GSTextureCache::Source* GSTextureCache::CreateSource(const GIFRegTEX0& TEX0, con
 		src->m_alpha_minmax.first = dst->m_alpha_min;
 		src->m_alpha_minmax.second = dst->m_alpha_max;
 
+		// This is a bit rough, since if AEM is on, without rescanning the whole texture, we don't know if anything is transparent, so just go the hard way.
+		if (!dst->m_32_bits_fmt)
+		{
+			const bool using_both = (src->m_alpha_minmax.first ^ src->m_alpha_minmax.second) & 128;
+			const bool using_ta1 = (src->m_alpha_minmax.second & 128);
+
+			src->m_alpha_minmax.first = TEXA.AEM ? 0 : (using_both ? std::min(TEXA.TA1, TEXA.TA0) : (using_ta1 ? TEXA.TA1 : TEXA.TA0));
+			src->m_alpha_minmax.second = (using_both ? std::max(TEXA.TA1, TEXA.TA0) : (using_ta1 ? TEXA.TA1 : TEXA.TA0));
+		}
+
 		if (psm.pal > 0)
 		{
 			// Attach palette for GPU texture conversion
@@ -3690,6 +3700,16 @@ GSTextureCache::Source* GSTextureCache::CreateSource(const GIFRegTEX0& TEX0, con
 		src->m_end_block = dst->m_end_block;
 		src->m_alpha_minmax.first = dst->m_alpha_min;
 		src->m_alpha_minmax.second = dst->m_alpha_max;
+
+		// This is a bit rough, since if AEM is on, without rescanning the whole texture, we don't know if anything is transparent, so just go the hard way.
+		if (!dst->m_32_bits_fmt)
+		{
+			const bool using_both = (src->m_alpha_minmax.first ^ src->m_alpha_minmax.second) & 128;
+			const bool using_ta1 = (src->m_alpha_minmax.second & 128);
+
+			src->m_alpha_minmax.first = TEXA.AEM ? 0 : (using_both ? std::min(TEXA.TA1, TEXA.TA0) : (using_ta1 ? TEXA.TA1 : TEXA.TA0));
+			src->m_alpha_minmax.second = (using_both ? std::max(TEXA.TA1, TEXA.TA0) : (using_ta1 ? TEXA.TA1 : TEXA.TA0));
+		}
 
 		dst->Update();
 


### PR DESCRIPTION
### Description of Changes
First started and conceived by Stenzek, I continued his work while he slept :D  This PR will correctly use the alpha values for 16 bit and 24bit textures to improve the alpha min/max trace to help us optimise draws better, also rechecks if we require an alpha test.

### Rationale behind Changes
Cool little idea to make the numbers better.

### Suggested Testing Steps
Test games, make sure nothing is broken.

### Noteable changes:

### Numerical improvements:

Barnyard:
Draw Calls: -462 [2285=>1823] in one scene

Primal Image:
Draw Calls: -6712 [14796=>8084]
Barriers: -3483 [6967=>3484]

Syphon Filter (Omega Strain, I think):
Draw Calls: -290 [946=>656]

### Visual Differences (closer match software in both cases)

Go Go Golf
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/c63b7475-5230-4b3e-ab81-2d78cedbff40)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/6a2a1f5f-c7dd-4ea5-b1e8-107d4328cb78)

SOCOM 2:
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/671652f4-4b83-46a6-8750-f404f26c9c72)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/35995d0a-82a7-4f53-8d98-20aea3de607d)
