### PR TITLE
GameDB: entry correction

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -27107,10 +27107,10 @@ SLKA-25322:
   name: "Guilty Gear XX - Slash"
   region: "NTSC-K"
 SLKA-25323:
-  name: "SSX On Tour"
-  region: "NTSC-J"
+  name: "FIFA '06"
+  region: "NTSC-K"
   gsHWFixes:
-    recommendedBlendingLevel: 4 # Fixes missing lighting and makes snow not look like snow sludge.
+    halfPixelOffset: 2 # Reduces blurriness.
 SLKA-25325:
   name: "SSX On Tour"
   region: "NTSC-K"


### PR DESCRIPTION
"SLKA-25323" is "FIFA 06", not "SSX on Tour".
"SSX on Tour" is misprinted as "SLKA-25323" on the game DVD cover,
 so most Internet websites display "SSX on Tour" as "SLKA-25323", but this is clearly an error.
The DVD itself is clearly marked "SLKA-25325".

https://forums.pcsx2.net/Thread-Bug-Report-Serial-ID-SLKA-25323-its-name-is-incorrect
