### PR TITLE
GameDB: Remove accidental addition Growlanser 5+6

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -24635,7 +24635,6 @@ SLES-55215:
   compat: 5
   gsHWFixes:
     moveHandler: "MV_Growlanser" # Fixes precomputed depth buffer.
-    textureInsideRT: 1 # Fixes character layering issue.
 SLES-55216:
   name: "Baroque"
   region: "PAL-E"
@@ -29252,7 +29251,6 @@ SLPM-61148:
   region: "NTSC-J"
   gsHWFixes:
     moveHandler: "MV_Growlanser" # Fixes precomputed depth buffer.
-    textureInsideRT: 1 # Fixes character layering issue.
 SLPM-61149:
   name: "Dengeki PS2 PlayStation D91"
   region: "NTSC-J"
@@ -36563,7 +36561,6 @@ SLPM-66249:
   compat: 5
   gsHWFixes:
     moveHandler: "MV_Growlanser" # Fixes precomputed depth buffer.
-    textureInsideRT: 1 # Fixes character layering issue.
 SLPM-66250:
   name: "Choro Q HG 4 [Takara Best]"
   region: "NTSC-J"
@@ -37238,7 +37235,6 @@ SLPM-66418:
   compat: 5
   gsHWFixes:
     moveHandler: "MV_Growlanser" # Fixes precomputed depth buffer.
-    textureInsideRT: 1 # Fixes character layering issue.
 SLPM-66419:
   name: "Valkyrie Profile 2 - Silmeria"
   region: "NTSC-J"
@@ -38491,7 +38487,6 @@ SLPM-66716:
   compat: 5
   gsHWFixes:
     moveHandler: "MV_Growlanser" # Fixes precomputed depth buffer.
-    textureInsideRT: 1 # Fixes character layering issue.
 SLPM-66717:
   name: "Standard Daisenryaku - Dengekisen [Sega the Best]"
   region: "NTSC-J"
@@ -54376,7 +54371,6 @@ SLUS-21571:
   compat: 5
   gsHWFixes:
     moveHandler: "MV_Growlanser" # Fixes precomputed depth buffer.
-    textureInsideRT: 1 # Fixes character layering issue.
 SLUS-21572:
   name: "Surf's Up"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Texture Inside RT was fixed in https://github.com/PCSX2/pcsx2/pull/9187
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
I'm an idiot sandwhich with rebase.
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test growlanser 5 and 6.