### PR TITLE
FileSystem: Partial revert of c82f800

### DIFF
--- a/common/FileSystem.cpp
+++ b/common/FileSystem.cpp
@@ -748,13 +748,6 @@ s64 FileSystem::FTell64(std::FILE* fp)
 
 s64 FileSystem::FSize64(std::FILE* fp)
 {
-#ifdef _WIN32
-	const int fd = _fileno(fp);
-	if (fd >= 0)
-	{
-		return _filelengthi64(fd);
-	}
-#else
 	const s64 pos = FTell64(fp);
 	if (pos >= 0)
 	{
@@ -765,7 +758,6 @@ s64 FileSystem::FSize64(std::FILE* fp)
 				return size;
 		}
 	}
-#endif
 
 	return -1;
 }


### PR DESCRIPTION
### Description of Changes

Most of the credit here goes to @RedPanda4552 for debugging the folder memory card corruption.

stdio/std::FILE tends to defer flushing the write to the underlying OS file (FD). This is great, but becomes a problem when the file is being extended. See the following test code:

```cpp
  std::FILE* fp = FileSystem::OpenCFile("D:\\foo.txt", "wb");
  for (int i = 0; i < 512; i++)
  {
    char c = 0xff;
    std::fwrite(&c, 1, 1, fp);
  }
  // std::fflush(fp);
  s64 size = FileSystem::FSize64(fp);
  std::fclose(fp);
```

When using filelength(), FSize64 returns 0, because the 512 byte write has been buffered, and not flushed to the file. Internally, filelength() does the same seek/tell/seek dance that we're doing manually, as seen here:

![image](https://github.com/PCSX2/pcsx2/assets/11288319/76820e51-98d0-40a1-80a3-ea88ed971d6d)

Adding the fflush above does fix the problem. But really, we may as well not bother, since that's going to incur extra system calls, and filelength() does the exact same thing we're doing.

### Rationale behind Changes

Mixing stdio and raw FD access is a bad thing, filelength() isn't going to return correct results when extending a file has been buffered.

Fixes folder memory card corruption.

### Suggested Testing Steps

Check folder memory cards.
