### PR TITLE
MemoryCardFolder: Initialize hostFilePath

### DIFF
--- a/pcsx2/SIO/Memcard/MemoryCardFolder.cpp
+++ b/pcsx2/SIO/Memcard/MemoryCardFolder.cpp
@@ -2021,6 +2021,7 @@ std::FILE* FileAccessHelper::Open(const std::string_view& folderName, MemoryCard
 	MemoryCardFileHandleStructure handleStruct;
 	handleStruct.fileHandle = file;
 	handleStruct.fileRef = fileRef;
+	handleStruct.hostFilePath = std::move(filename);
 	m_files.emplace(std::move(internalPath), std::move(handleStruct));
 
 	if (writeMetadata)


### PR DESCRIPTION
### Description of Changes

Apparently I didn't initialize the file path field. Which meant that files in the subdirectory weren't closed when the folder was deleted, which meant the path rename failed on Windows.

### Rationale behind Changes

Regression from ea051c6. Nobody noticed in over a year :D

### Suggested Testing Steps

Test deleting a save in the BIOS with a folder memory card and filtering disabled. It should silently fail on master (with a log message about `MoveFileEx()` failing), but succeed on the PR.
