### PR TITLE
GameDB: Missing Korean entries + maintenance

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -6056,6 +6056,9 @@ SCKA-10006:
 SCKA-10007:
   name: "EyeToy - Tales"
   region: "NTSC-K"
+SCKA-10008:
+  name: "Come on Baby"
+  region: "NTSC-K"
 SCKA-14001:
   name: "Gangcheol Gigap Sadan - Online Battlefield"
   region: "NTSC-K"
@@ -6110,6 +6113,9 @@ SCKA-20011:
     partialTargetInvalidation: 1 # Fixes broken pause screen.
 SCKA-20012:
   name: "Arc the Lad - Jeongryeongui Hwanghon"
+  region: "NTSC-K"
+SCKA-20013:
+  name: "SOCOM - U.S. Navy SEALs"
   region: "NTSC-K"
 SCKA-20014:
   name: "Dark Cloud 2"
@@ -6317,6 +6323,9 @@ SCKA-20045:
   region: "NTSC-K"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
+SCKA-20046:
+  name: "Ratchet & Clank - Going Commando"
+  region: "NTSC-K"
 SCKA-20047:
   name: "Armored Core - Nine Breaker"
   region: "NTSC-K"
@@ -6511,6 +6520,12 @@ SCKA-20073:
   region: "NTSC-K"
   gsHWFixes:
     partialTargetInvalidation: 1 # Fixes broken textures.
+SCKA-20074:
+  name: "Sly Cooper 2 - Goedo Brothers Daejakjeon!"
+  region: "NTSC-K"
+SCKA-20075:
+  name: "Dark Cloud 2"
+  region: "NTSC-K"
 SCKA-20078:
   name: "Killzone [PlayStation 2 Big Hit Series]"
   region: "NTSC-K"
@@ -6550,6 +6565,12 @@ SCKA-20082:
     alignSprite: 1 # Fixes vertical lines.
     mergeSprite: 1 # Fixes vertical lines.
     cpuCLUTRender: 1 # Fixes sun occlusion.
+SCKA-20084:
+  name: "Monster House"
+  region: "NTSC-K"
+SCKA-20085:
+  name: "Minna no Tennis"
+  region: "NTSC-K"
 SCKA-20086:
   name: "Shin Onimusha - Dawn of Dreams [Disc 1 of 2]"
   region: "NTSC-K"
@@ -6597,6 +6618,9 @@ SCKA-20093:
     halfPixelOffset: 2 # Reduces blooming misalignment.
     wildArmsHack: 1 # Reduces blooming misalignment.
     autoFlush: 2 # Fixes glows.
+SCKA-20094:
+  name: "Okami"
+  region: "NTSC-K"
 SCKA-20095:
   name: "Okami"
   region: "NTSC-K"
@@ -6610,6 +6634,9 @@ SCKA-20096:
     mipmap: 2 # Base mip level isn't always used.
     autoFlush: 2 # Needed for recursive mipmap rendering.
     getSkipCount: "GSC_BlueTongueGames" # Render mipmaps on the CPU.
+SCKA-20097:
+  name: "Super Robot Taisen OG - Original Generations"
+  region: "NTSC-K"
 SCKA-20098:
   name: "Nickelodeon SpongeBob SquarePants - Creature from the Krusty Krab"
   region: "NTSC-K"
@@ -6621,15 +6648,27 @@ SCKA-20099:
   region: "NTSC-K"
   gsHWFixes:
     mipmap: 1
+SCKA-20100:
+  name: "Tales of Destiny"
+  region: "NTSC-K"
 SCKA-20101:
   name: "Seiken Densetsu 4"
   region: "NTSC-K"
   compat: 5
+SCKA-20104:
+  name: "Genji"
+  region: "NTSC-K"
 SCKA-20105:
   name: "Everybody's Golf 4"
   region: "NTSC-K"
+SCKA-20106:
+  name: "Wander to Kyozou"
+  region: "NTSC-K"
 SCKA-20107:
   name: "Odin Sphere"
+  region: "NTSC-K"
+SCKA-20108:
+  name: "Ratchet - Deadlocked"
   region: "NTSC-K"
 SCKA-20109:
   name: "Persona 3 FES [Independent Starting Version]"
@@ -6639,6 +6678,12 @@ SCKA-20109:
   memcardFilters:
     - "SCKA-20109"
     - "SCKA-20099"
+SCKA-20111:
+  name: "Sly Cooper 3 - Choehu-ui Daedo"
+  region: "NTSC-K"
+SCKA-20112:
+  name: "Persona 3 FES"
+  region: "NTSC-K"
 SCKA-20114:
   name: "Obscure II - The Aftermath"
   region: "NTSC-K"
@@ -6646,14 +6691,44 @@ SCKA-20114:
     - EETimingHack # For stripes on FMVs and crashes on scenes.
   clampModes:
     vuClampMode: 3 # Fixes Lock picking pin.
+SCKA-20115:
+  name: "Cyber Troopers - Virtual-On Marz"
+  region: "NTSC-K"
 SCKA-20117:
   name: "Super Robot Taisen OG - Original Generations Gaiden"
+  region: "NTSC-K"
+SCKA-20118:
+  name: "Disgaea - Hour of Darkness"
+  region: "NTSC-K"
+SCKA-20119:
+  name: "Tales of Destiny - Director's Cut"
   region: "NTSC-K"
 SCKA-20120:
   name: "Ratchet & Clank - Size Matters"
   region: "NTSC-K"
   gsHWFixes:
     mipmap: 1
+SCKA-20124:
+  name: "Piposarugetchu 3" # Ape Escape 3
+  region: "NTSC-K"
+SCKA-20125:
+  name: "Katamari Damacy"
+  region: "NTSC-K"
+SCKA-20126:
+  name: "Persona 3 FES"
+  region: "NTSC-K"
+SCKA-20127:
+  name: "Zero" # Project Zero
+  region: "NTSC-K"
+SCKA-20128:
+  name: "Zero - Akai Chou" # Project Zero 2 Crimson Butterfly
+  region: "NTSC-K"
+SCKA-20129:
+  name: "Tales of Legendia"
+  region: "NTSC-K"
+SCKA-20130:
+  name: "Minna no Tennis"
+  region: "NTSC-K"
 SCKA-20131:
   name: "Super Robot Taisen Z"
   region: "NTSC-J-K"
@@ -6661,16 +6736,46 @@ SCKA-20132:
   name: "Shin Megami Tensei - Persona 4"
   region: "NTSC-K"
   compat: 5
+SCKA-20133:
+  name: "Ace Combat Zero - The Belkan War"
+  region: "NTSC-K"
+SCKA-20134:
+  name: "Drag-on Dragoon 2"
+  region: "NTSC-K"
+SCKA-20135:
+  name: "Minna Daisuki Katamari Damacy"
+  region: "NTSC-K"
 SCKA-20136:
   name: "Super Robot Taisen Z - Special Disc"
   region: "NTSC-J-K"
+SCKA-20137:
+  name: "Evangelion - Jo"
+  region: "NTSC-K"
 SCKA-20138:
   name: "Final Fantasy XII [Ultimate Hits International Zodiac Job System]"
   region: "NTSC-K"
   gsHWFixes:
     partialTargetInvalidation: 1 # Fixes broken textures.
+SCKA-20139:
+  name: "SD Gundam - G Generation Wars"
+  region: "NTSC-K"
 SCKA-20140:
   name: "MLB 10 - The Show"
+  region: "NTSC-K"
+SCKA-20141:
+  name: "Persona 4"
+  region: "NTSC-K"
+SCKA-20142:
+  name: "MLB 11 - The Show"
+  region: "NTSC-K"
+SCKA-20171:
+  name: "Let's Bravo Music"
+  region: "NTSC-K"
+SCKA-24004:
+  name: "Sly Cooper and the Thievius Raccoonus"
+  region: "NTSC-K"
+SCKA-24007:
+  name: "Let's Bravo Music"
   region: "NTSC-K"
 SCKA-24008:
   name: "SOCOM - U.S. Navy SEALs"
@@ -6701,6 +6806,9 @@ SCKA-30002:
     autoFlush: 1 # Fixes sun going through walls.
 SCKA-30003:
   name: "God of War - Yeonghonui Banyeokja"
+  region: "NTSC-K"
+SCKA-30004:
+  name: "Gran Turismo 4"
   region: "NTSC-K"
 SCKA-30005:
   name: "Rogue Galaxy"
@@ -25972,11 +26080,14 @@ SLES-82053:
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
   memcardFilters:
     - "SLES-82048"
+SLKA-15001:
+  name: "Barbarian"
+  region: "NTSC-K"
 SLKA-15002:
   name: "Space Raiders"
   region: "NTSC-K"
 SLKA-15003:
-  name: "Shikigami no Shiro II"
+  name: "Siksin-ui Seong II" # Shikigami no Shiro II
   region: "NTSC-K"
 SLKA-15004:
   name: "Gunbird - Premium Package"
@@ -26034,12 +26145,18 @@ SLKA-15019:
   region: "NTSC-K"
   gsHWFixes:
     halfPixelOffset: 1 # Fixes black void when upscaling.
+SLKA-15020:
+  name: "Aliens Versus Predator - Extinction"
+  region: "NTSC-K"
 SLKA-15021:
-  name: "GrowLanser3"
+  name: "Growlanser 3 - The Dual Darkness"
   region: "NTSC-K"
   compat: 5
   gameFixes:
     - OPHFlagHack
+SLKA-15022:
+  name: "Speed Kings"
+  region: "NTSC-K"
 SLKA-15023:
   name: "Assault Suits Valken"
   region: "NTSC-K"
@@ -26067,20 +26184,56 @@ SLKA-15033:
   region: "NTSC-K"
   gsHWFixes:
     partialTargetInvalidation: 1 # Fixes full screen C32->C16 frame invalidation.
+SLKA-15034:
+  name: "Kinnikuman Generations"
+  region: "NTSC-K"
+SLKA-15035:
+  name: "Saiyuuki Reload Gunlock"
+  region: "NTSC-K"
+SLKA-15037:
+  name: "Tengai Premium Package"
+  region: "NTSC-K"
+SLKA-15041:
+  name: "Simple 2000 Series Vol. 55 - The Catfight: Joneko Densetsu"
+  region: "NTSC-K"
+SLKA-15042:
+  name: "Simple 2000 Series Vol. 63 - Mogitate Mizugi! Onna Mamire no: The Suiei Taikai"
+  region: "NTSC-K"
 SLKA-15043:
   name: "Super Puzzle Bobble Collection Vol 1"
   region: "NTSC-K"
 SLKA-15044:
   name: "Super Puzzle Bobble Collection Vol 2"
   region: "NTSC-K"
+SLKA-15045:
+  name: "Simple 2000 Series Vol. 61 - The OneeChambara"
+  region: "NTSC-K"
+SLKA-15051:
+  name: "Yokushin - GigaWing Generations"
+  region: "NTSC-K"
 SLKA-15054:
   name: "Simple 2000 Series - The Daemiin"
+  region: "NTSC-K"
+SLKA-15055:
+  name: "Raiden III"
+  region: "NTSC-K"
+SLKA-15056:
+  name: "Taito Legends"
+  region: "NTSC-K"
+SLKA-15058:
+  name: "Terra Defence Force, The 2"
+  region: "NTSC-K"
+SLKA-15060:
+  name: "Raiden III"
   region: "NTSC-K"
 SLKA-25001:
   name: "Silent Hill 2"
   region: "NTSC-K"
 SLKA-25002:
   name: "Energy Airforce"
+  region: "NTSC-K"
+SLKA-25003:
+  name: "Herdy Gerdy"
   region: "NTSC-K"
 SLKA-25004:
   name: "007 - Nightfire"
@@ -26090,11 +26243,17 @@ SLKA-25004:
 SLKA-25006:
   name: "Twin Caliber"
   region: "NTSC-K"
+SLKA-25007:
+  name: "Spy Fiction"
+  region: "NTSC-K"
 SLKA-25009:
   name: "Kengo 2"
   region: "NTSC-K"
 SLKA-25010:
   name: "Super Battle Bongsin"
+  region: "NTSC-K"
+SLKA-25011:
+  name: "Reign of Fire"
   region: "NTSC-K"
 SLKA-25012:
   name: "Devil May Cry 2 Dante"
@@ -26114,6 +26273,9 @@ SLKA-25015:
   region: "NTSC-K"
 SLKA-25018:
   name: "Sphinx and the Cursed Mummy"
+  region: "NTSC-K"
+SLKA-25020:
+  name: "TimeSplitters 2"
   region: "NTSC-K"
 SLKA-25021:
   name: "Shinobi"
@@ -26136,6 +26298,9 @@ SLKA-25026:
     roundSprite: 2 # Fixes vertical lines and some font artifacts but not completely fixed.
 SLKA-25027:
   name: "NBA Street Vol. 2"
+  region: "NTSC-K"
+SLKA-25028:
+  name: "Mission - Impossible - Operation Surma"
   region: "NTSC-K"
 SLKA-25029:
   name: "MVP Baseball 2003"
@@ -26190,7 +26355,7 @@ SLKA-25041:
     - "SLKA-25041"
     - "SLPM-67524"
 SLKA-25042:
-  name: "Tamamayu Monogatari 2 Horobi no Mushi"
+  name: "Tamamayu Monogatari 2 Horobi no Mushi" # Jade Cocoon 2
   region: "NTSC-K"
 SLKA-25043:
   name: "Virtua Fighter 4 - Evolution"
@@ -26211,7 +26376,7 @@ SLKA-25047:
   name: "Shin Combat Choro Q"
   region: "NTSC-K"
 SLKA-25048:
-  name: "Makai Senki Disgaea"
+  name: "Makai Senki Disgaea" # Disgaea - Hour of Darkness
   region: "NTSC-K"
   compat: 5
 SLKA-25049:
@@ -26229,8 +26394,14 @@ SLKA-25051:
 SLKA-25052:
   name: "Air Ranger 2 - Rescue Helicopter"
   region: "NTSC-K"
+SLKA-25053:
+  name: "Def Jam - Vendetta"
+  region: "NTSC-K"
+SLKA-25054:
+  name: "Grand Prix Challenge"
+  region: "NTSC-K"
 SLKA-25055:
-  name: "Hitman - Silent Assasin"
+  name: "Hitman 2 - Silent Assasin"
   region: "NTSC-K"
 SLKA-25056:
   name: "Finding Nemo"
@@ -26238,6 +26409,12 @@ SLKA-25056:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
     alignSprite: 1 # Fixes vertical lines.
+SLKA-25057:
+  name: "All-Star Baseball 2004 featuring Derek Jeter"
+  region: "NTSC-K"
+SLKA-25059:
+  name: "Pride FC - Fighting Championships"
+  region: "NTSC-K"
 SLKA-25060:
   name: "I.Q. Remix+ - Intelligent Qube"
   region: "NTSC-K"
@@ -26386,15 +26563,24 @@ SLKA-25097:
 SLKA-25098:
   name: "Lord of the Rings, The - The Return of the King"
   region: "NTSC-K"
+SLKA-25099:
+  name: "The Urbz - Sims in the City"
+  region: "NTSC-K"
 SLKA-25100:
   name: "Dragon Quest V Dragon Quarter"
   region: "NTSC-K"
   compat: 5
+SLKA-25102:
+  name: "Batman - Rise of Sin Tzu"
+  region: "NTSC-K"
 SLKA-25103:
-  name: "Neon Genesis Evangelion 2"
+  name: "Neon Genesis Evangelion 2" # Shin Seiki Evangelion 2 - Evangelions
   region: "NTSC-K"
 SLKA-25105:
   name: "XIII"
+  region: "NTSC-K"
+SLKA-25107:
+  name: "Crouching Tiger, Hidden Dragon"
   region: "NTSC-K"
 SLKA-25108:
   name: "Eve Burst Error Plus"
@@ -26410,6 +26596,9 @@ SLKA-25111:
   region: "NTSC-K"
 SLKA-25112:
   name: "King of Fighters 2001, The"
+  region: "NTSC-K"
+SLKA-25113:
+  name: "Jin Samguk Mussang 2"
   region: "NTSC-K"
 SLKA-25114:
   name: "Jin Samguk Mussang 2 - Maengjangjeon"
@@ -26460,6 +26649,9 @@ SLKA-25125:
 SLKA-25128:
   name: "Sangokushi IX"
   region: "NTSC-K"
+SLKA-25129:
+  name: "007 - Everything or Nothing"
+  region: "NTSC-K"
 SLKA-25130:
   name: "Bloody Roar 4"
   region: "NTSC-K"
@@ -26507,6 +26699,9 @@ SLKA-25140:
 SLKA-25142:
   name: "Tak and the Power of Juju"
   region: "NTSC-K"
+SLKA-25143:
+  name: "Jin Samguk Mussang 4" # Dynasty Warriors 4
+  region: "NTSC-K"
 SLKA-25144:
   name: "Final Fantasy X-2"
   region: "NTSC-K"
@@ -26544,6 +26739,18 @@ SLKA-25152:
 SLKA-25153:
   name: "Winning Eleven 10 - Liveware Edition"
   region: "NTSC-K"
+SLKA-25154:
+  name: "Seven Samurai 20XX"
+  region: "NTSC-K"
+SLKA-25155:
+  name: "Crimson Sea 2"
+  region: "NTSC-K"
+SLKA-25156:
+  name: "Medal of Honor - Vanguard"
+  region: "NTSC-K"
+SLKA-25158:
+  name: "Shining Force EXA"
+  region: "NTSC-K"
 SLKA-25159:
   name: "Astro Boy"
   region: "NTSC-K"
@@ -26578,6 +26785,9 @@ SLKA-25168:
   region: "NTSC-K"
   gsHWFixes:
     partialTargetInvalidation: 1 # Fixes broken text.
+SLKA-25169:
+  name: "UEFA Euro 2004 - Portugal"
+  region: "NTSC-K"
 SLKA-25170:
   name: "SD Gundam G Generation Seed"
   region: "NTSC-K"
@@ -26676,7 +26886,7 @@ SLKA-25198:
   region: "NTSC-K"
   compat: 5
 SLKA-25199:
-  name: "Kengo 3"
+  name: "Geomho 3" # Kengo 3
   region: "NTSC-K"
   compat: 5
 SLKA-25200:
@@ -26744,11 +26954,17 @@ SLKA-25209:
     - GIFFIFOHack # Partially fixes graphical issues also needs EE cycle rate + 3.
   gsHWFixes:
     mipmap: 1
+SLKA-25210:
+  name: "Summer Heat Beach Volleyball"
+  region: "NTSC-K"
 SLKA-25211:
   name: "King of Fighters, The - Maximum Impact"
   region: "NTSC-K"
+SLKA-25212:
+  name: "Jin Samguk Mussang 2"
+  region: "NTSC-K"
 SLKA-25213:
-  name: "Berserk"
+  name: "Berserk" # Berserk - Cheonnyeonjegug-ui mae pyeon Seongmajeongiui Jan
   region: "NTSC-K"
   compat: 5
   gsHWFixes:
@@ -26794,6 +27010,9 @@ SLKA-25219:
     vuClampMode: 3 # Fixes lighting on character models as caves and other locations don't turn mobs into glow-in-the-dark creatures by themselves.
   gsHWFixes:
     maximumBlendingLevel: 0 # Fixes unnecessary load on the GPU.
+SLKA-25220:
+  name: "Viewtiful Joe - A New Hope"
+  region: "NTSC-K"
 SLKA-25221:
   name: "Busin 0 - Wizardry Alternative Neo"
   region: "NTSC-K"
@@ -26835,6 +27054,12 @@ SLKA-25227:
     eeRoundMode: 0 # Reduces FPU calculation errors.
   clampModes:
     eeClampMode: 2 # Reduces FPU calculation errors.
+SLKA-25228:
+  name: "The Lord of the Rings - The Return of the King"
+  region: "NTSC-K"
+SLKA-25230:
+  name: "Def Jam - Fight for NY"
+  region: "NTSC-K"
 SLKA-25232:
   name: "Naruto Narutimett Hero International"
   region: "NTSC-K"
@@ -26842,11 +27067,22 @@ SLKA-25232:
 SLKA-25233:
   name: "Sonic - Mega Collection Plus"
   region: "NTSC-K"
+SLKA-25234:
+  name: "Rumble Roses"
+  region: "NTSC-K"
+SLKA-25235:
+  name: "FIFA Street"
+  region: "NTSC-K"
 SLKA-25237:
   name: "Lord of the Rings, The - The Third Age"
   region: "NTSC-K"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
+SLKA-25240:
+  name: "WWE SmackDown! Shut Your Mouth"
+  region: "NTSC-K"
+  gsHWFixes:
+    partialTargetInvalidation: 1 # Fixes menu corruption.
 SLKA-25241:
   name: "Need for Speed - Underground 2"
   region: "NTSC-K"
@@ -26855,6 +27091,9 @@ SLKA-25241:
     halfPixelOffset: 1 # Fixes misaligned post-processing.
   gameFixes:
     - SoftwareRendererFMVHack # Workaround for strange HPO Normal screen shake.
+SLKA-25242:
+  name: "Fight Night Round 2"
+  region: "NTSC-K"
 SLKA-25243:
   name: "Medal of Honor - European Assault"
   region: "NTSC-K"
@@ -26871,11 +27110,17 @@ SLKA-25246:
   region: "NTSC-K"
   gsHWFixes:
     estimateTextureRegion: 1 # Improves performance and reduces hash cache size.
+SLKA-25247:
+  name: "Prince of Persia - Warrior Within"
+  region: "NTSC-K"
 SLKA-25249:
   name: "Ys - The Ark of Napishtim [with Guide Book]"
   region: "NTSC-K"
   gameFixes:
     - EETimingHack
+SLKA-25250:
+  name: "GoldenEye - Rogue Agent"
+  region: "NTSC-K"
 SLKA-25251:
   name: "Metal Gear Solid 3 - Snake Eater"
   region: "NTSC-K"
@@ -26944,7 +27189,7 @@ SLKA-25266:
   name: "Sangokushi IX [PlayStation 2 - Big Hit Series]"
   region: "NTSC-K"
 SLKA-25268:
-  name: "Mobile Suit Gundam - Gundam vs. Z-Gundam"
+  name: "Mobile Suit Gundam - Gundam vs. Z-Gundam" # Kidou Senshi Gundam - Gundam vs Z Gundam
   region: "NTSC-K"
 SLKA-25270:
   name: "Armored Core - Formula Front"
@@ -26957,17 +27202,26 @@ SLKA-25270:
 SLKA-25271:
   name: "Harry Potter and the Order of the Phoenix"
   region: "NTSC-K"
+SLKA-25272:
+  name: "Tak 2 - The Staff of Dreams"
+  region: "NTSC-K"
 SLKA-25274:
   name: "Princess Maker 4"
   region: "NTSC-K"
 SLKA-25275:
   name: "King of Fighters 2002-2003, The"
   region: "NTSC-K"
+SLKA-25276:
+  name: "King of Fighters 2003, The"
+  region: "NTSC-K"
 SLKA-25277:
   name: "Brothers In Arms - Road to Hill 30"
   region: "NTSC-K"
   gsHWFixes:
     halfPixelOffset: 2 # Reduces blurriness, there are still ghosting issues for like lighting poles.
+SLKA-25278:
+  name: "MVP Baseball 2005"
+  region: "NTSC-K"
 SLKA-25279:
   name: "Hello Kitty - Rescue Mission"
   region: "NTSC-K"
@@ -26983,6 +27237,9 @@ SLKA-25281:
   memcardFilters:
     - "SLKA-25280"
     - "SLKA-25342"
+SLKA-25282:
+  name: "MX vs. ATV Unleashed"
+  region: "NTSC-K"
 SLKA-25283:
   name: "Juiced"
   region: "NTSC-K"
@@ -27000,7 +27257,10 @@ SLKA-25284:
   region: "NTSC-K"
   compat: 1
 SLKA-25287:
-  name: "Metal Slug 4&5"
+  name: "Metal Slug 4 & 5"
+  region: "NTSC-K"
+SLKA-25288:
+  name: "Metal Slug 5"
   region: "NTSC-K"
 SLKA-25289:
   name: "Jin Samguk Mussang 4"
@@ -27020,7 +27280,7 @@ SLKA-25292:
   name: "Batman Begins"
   region: "NTSC-K"
 SLKA-25296:
-  name: "Inuyasha - Feudal Combat"
+  name: "Inuyasha - Feudal Combat" # Inuyasha - Ougi Ranbu
   region: "NTSC-K"
 SLKA-25297:
   name: "Taito Memories - Joukan [Special Package]"
@@ -27069,6 +27329,12 @@ SLKA-25304:
     bilinearUpscale: 2 # Smooths out sun glare textures like native.
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
+SLKA-25305:
+  name: "Taito Memories - Gekan"
+  region: "NTSC-K"
+SLKA-25306:
+  name: "Evil Dead - Regeneration"
+  region: "NTSC-K"
 SLKA-25307:
   name: "Dragon Ball Z Sparking"
   region: "NTSC-K"
@@ -27076,6 +27342,9 @@ SLKA-25307:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes lines when powering up.
     roundSprite: 2 # Fixes misaligned bloom.
+SLKA-25308:
+  name: "Sonic Gems Collection"
+  region: "NTSC-K"
 SLKA-25309:
   name: "Indigo Prophecy"
   region: "NTSC-K"
@@ -27102,6 +27371,9 @@ SLKA-25314:
     - FpuNegDivHack # Fixes target loss issue.
 SLKA-25315:
   name: "NBA Live 06"
+  region: "NTSC-K"
+SLKA-25316:
+  name: "Disney/Pixar Mr. Incredible - Kyouteki Underminer Toujou"
   region: "NTSC-K"
 SLKA-25317:
   name: "Shin Sangoku Musou 3 [PlayStation 2 - Big Hit Series]"
@@ -27161,11 +27433,14 @@ SLKA-25329:
   region: "NTSC-K"
   gsHWFixes:
     autoFlush: 2 # Fixes sun luminosity.
+SLKA-25330:
+  name: "Battlefield 2 - Modern Combat"
+  region: "NTSC-K"
 SLKA-25331:
   name: "Marc Ecko's Getting Up - Contents Under Pressure"
   region: "NTSC-K"
 SLKA-25332:
-  name: "Marc Ecko's Getting Up - Contents Under Pressure"
+  name: "Guilty Gear XX Slash - The Midnight Carnival"
   region: "NTSC-K"
 SLKA-25333:
   name: "Metal Slug Complete"
@@ -27184,6 +27459,9 @@ SLKA-25335:
   gsHWFixes:
     recommendedBlendingLevel: 4 # Improves smoke rendering.
     halfPixelOffset: 2 # Fixes misaligned lighting.
+SLKA-25337:
+  name: "Peter Jackson's King Kong - The Official Game of the Movie"
+  region: "NTSC-K"
 SLKA-25338:
   name: "Godfather, The"
   region: "NTSC-K"
@@ -27191,6 +27469,12 @@ SLKA-25338:
     gpuTargetCLUT: 1 # Fixes light occlusion.
     skipDrawStart: 1 # Removes mono-colored sepia bottom and vertical sepia bars on top.
     skipDrawEnd: 1 # Removes mono-colored sepia bottom and vertical sepia bars on top.
+SLKA-25339:
+  name: "Jin Samguk Mussang 4"
+  region: "NTSC-K"
+SLKA-25340:
+  name: "Jin Samguk Mussang 4 - Empires"
+  region: "NTSC-K"
 SLKA-25341:
   name: "Driver - Parallel Lines"
   region: "NTSC-K"
@@ -27204,8 +27488,14 @@ SLKA-25341:
 SLKA-25342:
   name: "Ryu ga Gotoku"
   region: "NTSC-K"
+SLKA-25343:
+  name: "Thrillville - Off the Rails"
+  region: "NTSC-K"
 SLKA-25344:
   name: "Tom Clancy's Ghost Recon - Advanced Warfighter"
+  region: "NTSC-K"
+SLKA-25345:
+  name: "Disney's Chicken Little"
   region: "NTSC-K"
 SLKA-25346:
   name: "Prince of Persia - The Two Thrones"
@@ -27213,6 +27503,9 @@ SLKA-25346:
   gsHWFixes:
     autoFlush: 2 # Reduces post-processing misalignment.
     halfPixelOffset: 1 # Reduces post-processing misalignment.
+SLKA-25349:
+  name: "Jacked"
+  region: "NTSC-K"
 SLKA-25351:
   name: "One Piece Pirates Carnival"
   region: "NTSC-K"
@@ -27256,14 +27549,23 @@ SLKA-25355:
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
   memcardFilters:
     - "SLKA-25353"
+SLKA-25358:
+  name: "Sonic Riders"
+  region: "NTSC-K"
 SLKA-25359:
   name: "Winning Eleven 9 - Liveware Edition"
+  region: "NTSC-K"
+SLKA-25360:
+  name: "Samurai Champloo"
   region: "NTSC-K"
 SLKA-25361:
   name: "Keroro Gunsou MeroMero Battle Royale Z"
   region: "NTSC-K"
   gsHWFixes:
     preloadFrameData: 1 # Fixes invisible text.
+SLKA-25362:
+  name: "Sega Rally 2006"
+  region: "NTSC-K"
 SLKA-25363:
   name: "Guitar Hero III - Legends of Rock"
   region: "NTSC-K"
@@ -27278,7 +27580,7 @@ SLKA-25365:
   gsHWFixes:
     partialTargetInvalidation: 1 # Fixes broken text.
 SLKA-25366:
-  name: "Naruto - Uzumaki Chronicles 2"
+  name: "Naruto - Uzumaki Chronicles 2" # Naruto: Konoha Spirits!!"
   region: "NTSC-K"
   compat: 5
   gameFixes:
@@ -27286,8 +27588,17 @@ SLKA-25366:
 SLKA-25367:
   name: "Superman Returns"
   region: "NTSC-K"
+SLKA-25368:
+  name: "Full Spectrum Warrior - Ten Hammers"
+  region: "NTSC-K"
 SLKA-25371:
   name: "Arangjeon - Breakblow"
+  region: "NTSC-K"
+SLKA-25372:
+  name: "Black"
+  region: "NTSC-K"
+SLKA-25373:
+  name: "Fight Night Round 3"
   region: "NTSC-K"
 SLKA-25374:
   name: "FIFA Street 2"
@@ -27302,14 +27613,23 @@ SLKA-25375:
   gsHWFixes:
     mipmap: 2 # Cleans up texture detail.
     trilinearFiltering: 1 # Smoothes out texture transitions.
+SLKA-25377:
+  name: "OutRun 2006 - Coast 2 Coast"
+  region: "NTSC-K"
 SLKA-25378:
-  name: "FIFA world cup 2006"
+  name: "FIFA World Cup Germany 2006"
+  region: "NTSC-K"
+SLKA-25379:
+  name: "Jeonguk Mussang 2"
   region: "NTSC-K"
 SLKA-25380:
   name: "WinBack 2 - Project Poseidon"
   region: "NTSC-K"
 SLKA-25381:
   name: "Winning Eleven 10"
+  region: "NTSC-K"
+SLKA-25382:
+  name: "Chronicles of Narnia, The - The Lion, the Witch and the Wardrobe"
   region: "NTSC-K"
 SLKA-25384:
   name: "Blazing Souls"
@@ -27336,6 +27656,15 @@ SLKA-25389:
 SLKA-25390:
   name: "Jin Samguk Mussang 4 - Empires"
   region: "NTSC-K"
+SLKA-25391:
+  name: "Jin Samguk Mussang 3 - Empires"
+  region: "NTSC-K"
+SLKA-25393:
+  name: "Metal Slug 6"
+  region: "NTSC-K"
+SLKA-25394:
+  name: "King of Fighters, The - Maximum Impact 2"
+  region: "NTSC-K"
 SLKA-25395:
   name: "NBA Live 07"
   region: "NTSC-K"
@@ -27350,6 +27679,12 @@ SLKA-25397:
   compat: 5
   gsHWFixes:
     beforeDraw: "OI_DBZBTGames"
+SLKA-25398:
+  name: "Jeonguk Mussang 2 - Empires"
+  region: "NTSC-K"
+SLKA-25399:
+  name: "The Sims 2 - Pets"
+  region: "NTSC-K"
 SLKA-25401:
   name: "FlatOut 2"
   region: "NTSC-K"
@@ -27357,6 +27692,12 @@ SLKA-25401:
   gsHWFixes:
     mipmap: 1
     halfPixelOffset: 2 # Corrects most vertical lines.
+SLKA-25402:
+  name: "Devil May Cry 3"
+  region: "NTSC-K"
+SLKA-25404:
+  name: "NBA Live 08"
+  region: "NTSC-K"
 SLKA-25405:
   name: "GrimGrimoire"
   region: "NTSC-J-K"
@@ -27376,12 +27717,18 @@ SLKA-25409:
   name: "World Soccer Winning Eleven 2008"
   region: "NTSC-J-K"
 SLKA-25410:
-  name: "BioHazard 4"
+  name: "BioHazard 4" # Resident Evil 4
   region: "NTSC-K"
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
+SLKA-25411:
+  name: "Need for Speed - ProStreet"
+  region: "NTSC-K"
+SLKA-25412:
+  name: "Sengoku Basara 2 - Heroes"
+  region: "NTSC-K"
 SLKA-25413:
   name: "SD Gundam G - Generation Spirits"
   region: "NTSC-K"
@@ -27392,6 +27739,9 @@ SLKA-25414:
     vu1RoundMode: 0 # Crashes without.
   gsHWFixes:
     textureInsideRT: 1 # Crowd textures.
+SLKA-25417:
+  name: "Jin Samguk Mussang 4 - Empires"
+  region: "NTSC-K"
 SLKA-25422:
   name: "Silent Hill - Origins"
   region: "NTSC-K"
@@ -27399,8 +27749,38 @@ SLKA-25422:
   gsHWFixes:
     disablePartialInvalidation: 1 # Fixes black textures and flashlight circle not working.
     halfPixelOffset: 2 # Fixes ghosting.
+SLKA-25423:
+  name: "Sega Rally 2006"
+  region: "NTSC-K"
 SLKA-25424:
   name: "SNK Arcade Classics Vol.1"
+  region: "NTSC-K"
+SLKA-25425:
+  name: "Shining Tears"
+  region: "NTSC-K"
+SLKA-25427:
+  name: "Virtua Fighter 4 - Evolution"
+  region: "NTSC-K"
+SLKA-25428:
+  name: "Sonic Riders"
+  region: "NTSC-K"
+SLKA-25429:
+  name: "Sonic Mega Collection Plus"
+  region: "NTSC-K"
+SLKA-25430:
+  name: "Ryuu ga Gotoku"
+  region: "NTSC-K"
+SLKA-25431:
+  name: "Tantei Jinguuji Saburou - Innocent Black"
+  region: "NTSC-K"
+SLKA-25432:
+  name: "King of Fighters '98, The - Ultimate Match"
+  region: "NTSC-K"
+SLKA-25433:
+  name: "Samurai Spirits - 6beonui Seungbu"
+  region: "NTSC-K"
+SLKA-25434:
+  name: "Guitar Hero - Aerosmith"
   region: "NTSC-K"
 SLKA-25435:
   name: "Sengoku Basara X"
@@ -27408,9 +27788,21 @@ SLKA-25435:
 SLKA-25436:
   name: "DreamWorks Kung Fu Panda"
   region: "NTSC-K"
+SLKA-25437:
+  name: "Street Fighter Anniversary Collection"
+  region: "NTSC-K"
+SLKA-25438:
+  name: "Taito Memories II - Joukan"
+  region: "NTSC-K"
+SLKA-25439:
+  name: "Taito Memories II - Gekan"
+  region: "NTSC-K"
 SLKA-25441:
   name: "Kidou Senshi Gundam 00 - Gundam Meisters"
   region: "NTSC-J-K"
+SLKA-25442:
+  name: "007 - Quantum of Solace"
+  region: "NTSC-K"
 SLKA-25443:
   name: "Musou Orochi Maou Sairin"
   region: "NTSC-K"
@@ -27424,6 +27816,17 @@ SLKA-25446:
 SLKA-25447:
   name: "FIFA 09"
   region: "NTSC-K"
+SLKA-25448:
+  name: "WWE SmackDown vs. Raw 2009"
+  region: "NTSC-K"
+  gsHWFixes:
+    partialTargetInvalidation: 1 # Fixes menu corruption.
+SLKA-25449:
+  name: "Call of Duty - World at War - Final Fronts"
+  region: "NTSC-K"
+SLKA-25450:
+  name: "Jikkyou Powerful Major League 3"
+  region: "NTSC-K"
 SLKA-25451:
   name: "WWE SmackDown! vs. Raw 2008"
   region: "NTSC-K"
@@ -27432,26 +27835,79 @@ SLKA-25451:
 SLKA-25452:
   name: "Viewtiful Joe - A New Hope"
   region: "NTSC-K"
+SLKA-25453:
+  name: "Shin Onimusha - Dawn of Dreams [Disc 1 of 2]"
+  region: "NTSC-K"
+SLKA-25454:
+  name: "Shin Onimusha - Dawn of Dreams [Disc 2 of 2]"
+  region: "NTSC-K"
+SLKA-25455:
+  name: "World Soccer Winning Eleven 2009"
+  region: "NTSC-K"
+SLKA-25456:
+  name: "Jikkyou Powerful Major League 2009"
+  region: "NTSC-K"
+SLKA-25457:
+  name: "King of Fighters 2002, The - Unlimited Match"
+  region: "NTSC-K"
+SLKA-25458:
+  name: "King of Fighters Collection, The - The Orochi Saga"
+  region: "NTSC-K"
 SLKA-25459:
   name: "Transformers - Revenge of the Fallen"
   region: "NTSC-K"
   compat: 5
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes textures.
+SLKA-25463:
+  name: "WWE SmackDown vs. Raw 2010"
+  region: "NTSC-K"
+  gsHWFixes:
+    partialTargetInvalidation: 1 # Fixes menu corruption.
 SLKA-25464:
   name: "FIFA 10"
+  region: "NTSC-K"
+SLKA-25465:
+  name: "Silent Hill - Shattered Memories"
+  region: "NTSC-K"
+SLKA-25466:
+  name: "Beatmania IIDX 16 Empress + Premium Best [Disc 1 of 2 - Empress Disc]"
+  region: "NTSC-K"
+SLKA-25467:
+  name: "Beatmania IIDX 16 Empress + Premium Best [Disc 2 of 2 - Premium Best Disc]"
+  region: "NTSC-K"
+SLKA-25468:
+  name: "World Soccer Winning Eleven 2010"
   region: "NTSC-K"
 SLKA-25470:
   name: "Zone of the Enders - The 2nd Runner - Special Edition"
   region: "NTSC-K"
+SLKA-25471:
+  name: "Metal Gear Solid 2 - Sons of Liberty"
+  region: "NTSC-K"
+SLKA-25472:
+  name: "Metal Gear Solid 3 - Snake Eater"
+  region: "NTSC-K"
+SLKA-25475:
+  name: "FIFA 11"
+  region: "NTSC-K"
 SLKA-25477:
+  name: "World Soccer Winning Eleven 2011"
+  region: "NTSC-K"
+SLKA-25478:
   name: "World Soccer Winning Eleven 2011"
   region: "NTSC-K"
 SLKA-25480:
   name: "World Soccer Winning Eleven 2012"
   region: "NTSC-K"
+SLKA-29012:
+  name: "TimeSplitters 2"
+  region: "NTSC-K"
 SLKA-29017:
   name: "SSX Tricky"
+  region: "NTSC-K"
+SLKA-29027:
+  name: "NBA Live 2004"
   region: "NTSC-K"
 SLKA-35001:
   name: "Metal Gear Solid 2 Substance"
@@ -27823,7 +28279,7 @@ SLPM-55115:
   name: "Dokapon Kingdom"
   region: "NTSC-J"
 SLPM-55117:
-  name: "beatmania IIDX 15 DJ TROOPERS"
+  name: "Beatmania IIDX 15 - DJ Troopers"
   region: "NTSC-J"
 SLPM-55118:
   name: "Galaxy Angel II - Eigou Kaiki no Koku [Disc 1 of 2]"
@@ -28121,10 +28577,10 @@ SLPM-55220:
   gsHWFixes:
     texturePreloading: 1 # Fixes poor performance.
 SLPM-55221:
-  name: "beatmania IIDX 16 EMPRESS + PREMIUM BEST [Disc 1 of 2 - EMPRESS DISC]"
+  name: "Beatmania IIDX 16 Empress + Premium Best [Disc 1 of 2 - Empress Disc]"
   region: "NTSC-J"
 SLPM-55222:
-  name: "beatmania IIDX 16 EMPRESS + PREMIUM BEST [Disc 2 of 2 - PREMIUM BEST DISC]"
+  name: "Beatmania IIDX 16 Empress + Premium Best [Disc 2 of 2 - Premium Best Disc]"
   region: "NTSC-J"
 SLPM-55223:
   name: "NadePro!! Kisama mo Seiyuu Yatte Miro!"
@@ -28196,6 +28652,8 @@ SLPM-55250:
 SLPM-55251:
   name: "WWE SmackDown vs. Raw 2009"
   region: "NTSC-J"
+  gsHWFixes:
+    partialTargetInvalidation: 1 # Fixes menu corruption.
 SLPM-55252:
   name: "Pro Yakyuu Spirits 2010"
   region: "NTSC-J"
@@ -29487,7 +29945,7 @@ SLPM-62051:
   name: "Yanya Caballista - featuring Gawoo"
   region: "NTSC-J"
 SLPM-62052:
-  name: "beatmania Da Da Da!!"
+  name: "Beatmania Da Da Da!!"
   region: "NTSC-J"
 SLPM-62053:
   name: "World Soccer Winning Eleven 5"
@@ -29841,7 +30299,7 @@ SLPM-62174:
   name: "Simple 2000 Honkaku Shikou Series Vol. 3 - The Chess"
   region: "NTSC-J"
 SLPM-62175:
-  name: "beatmania Da Da Da!! THE BEST Da"
+  name: "Beatmania Da Da Da!! The Best Da"
   region: "NTSC-J"
 SLPM-62176:
   name: "EGBrowser BB"
@@ -30203,7 +30661,7 @@ SLPM-62287:
   gameFixes:
     - InstantDMAHack # Fixes bad ring/UI textures.
 SLPM-62288:
-  name: "pop'n music Best Hits!"
+  name: "Pop'n music Best Hits!"
   region: "NTSC-J"
 SLPM-62290:
   name: "TV Kuraemon"
@@ -31788,6 +32246,9 @@ SLPM-64509:
   gsHWFixes:
     nativePaletteDraw: 1
     autoFlush: 2 # Fixes refraction effect.
+SLPM-64510:
+  name: "International Superstar Soccer 2"
+  region: "NTSC-K"
 SLPM-64512:
   name: "Super Puzzle Bobble"
   region: "NTSC-K"
@@ -31799,6 +32260,9 @@ SLPM-64513:
     autoFlush: 2 # Fixes refraction effect.
 SLPM-64514:
   name: "Legends of Wrestling"
+  region: "NTSC-K"
+SLPM-64517:
+  name: "Freekstyle Motocross"
   region: "NTSC-K"
 SLPM-64519:
   name: "Woody Woodpecker"
@@ -31853,6 +32317,12 @@ SLPM-64534:
 SLPM-64535:
   name: "High Heat Major League Baseball 2003"
   region: "NTSC-K"
+SLPM-64537:
+  name: "Dark Angel - Vampire Apocalypse"
+  region: "NTSC-K"
+SLPM-64539:
+  name: "UFC - Ultimate Fighting Championship 2 - Tapout"
+  region: "NTSC-K"
 SLPM-64540:
   name: "Sims, The"
   region: "NTSC-K"
@@ -31898,7 +32368,7 @@ SLPM-65005:
   name: "I am the Coach"
   region: "NTSC-J"
 SLPM-65006:
-  name: "beatmania IIDX 3rd style"
+  name: "Beatmania IIDX 3rd Style"
   region: "NTSC-J"
 SLPM-65007:
   name: "Roadsters Trophy 2000"
@@ -31997,7 +32467,7 @@ SLPM-65025:
   name: "BioHazard - 5th Anniversary Package - Nightmare Returns [Disc 2 of 2]"
   region: "NTSC-J"
 SLPM-65026:
-  name: "beatmania IIDX 4th style -new songs collection-"
+  name: "Beatmania IIDX 4th Style - New Songs Collection"
   region: "NTSC-J"
 SLPM-65027:
   name: "Anime Eikaiwa - 15 Shounen Hyouryuuki - Hitomi no Naka no Shounen"
@@ -32095,7 +32565,7 @@ SLPM-65048:
   name: "Kinniku Banzuke - Muscle Wars 21"
   region: "NTSC-J"
 SLPM-65049:
-  name: "beatmania IIDX 5th style -new songs collection-"
+  name: "Beatmania IIDX 5th Style - New Songs Collection"
   region: "NTSC-J"
 SLPM-65050:
   name: "Yu-Gi-Oh! Shin Duel Monsters 2"
@@ -32448,7 +32918,7 @@ SLPM-65155:
   name: "Rumbling Hearts"
   region: "NTSC-J"
 SLPM-65156:
-  name: "beatmania IIDX 6th style -new songs collection-"
+  name: "Beatmania IIDX 6th Style - New Songs Collection"
   region: "NTSC-J"
 SLPM-65158:
   name: "Riding Spirits"
@@ -32619,7 +33089,7 @@ SLPM-65207:
   name: "Chou Battle Houshin"
   region: "NTSC-J"
 SLPM-65208:
-  name: "pop'n music 7"
+  name: "Pop'n music 7"
   region: "NTSC-J"
 SLPM-65209:
   name: "Star Ocean 3 [Limited Edition]"
@@ -33070,7 +33540,7 @@ SLPM-65315:
   region: "NTSC-J"
   compat: 5
 SLPM-65316:
-  name: "pop'n music 8"
+  name: "Pop'n music 8"
   region: "NTSC-J"
 SLPM-65317:
   name: "Jikkyou Powerful Pro Yakyuu 10"
@@ -33755,7 +34225,7 @@ SLPM-65507:
   name: "Cool Girl (Disc 2) (Aska Side)"
   region: "NTSC-J"
 SLPM-65508:
-  name: "pop'n music 9"
+  name: "Pop'n music 9"
   region: "NTSC-J"
 SLPM-65509:
   name: "Prince of Tennis - Love of Prince - Sweet"
@@ -34023,7 +34493,7 @@ SLPM-65592:
   name: "Lost Aya Sophia"
   region: "NTSC-J"
 SLPM-65593:
-  name: "beatmania IIDX 7th style"
+  name: "Beatmania IIDX 7th Style"
   region: "NTSC-J"
 SLPM-65594:
   name: "Iris no Atelier - Eternal Mana"
@@ -34675,13 +35145,13 @@ SLPM-65767:
   name: "NBA Starting Five 2005"
   region: "NTSC-J"
 SLPM-65768:
-  name: "beatmania IIDX 8th style"
+  name: "Beatmania IIDX 8th Style"
   region: "NTSC-J"
 SLPM-65769:
-  name: "pop'n music 10 [Controller Set]"
+  name: "Pop'n music 10 [Controller Set]"
   region: "NTSC-J"
 SLPM-65770:
-  name: "pop'n music 10"
+  name: "Pop'n music 10"
   region: "NTSC-J"
 SLPM-65771:
   name: "Natural 2 Duo - Sakurairo no Kisetsu [Deluxe Pack]"
@@ -35307,7 +35777,7 @@ SLPM-65945:
   name: "Red Ninja - End of Honor"
   region: "NTSC-J"
 SLPM-65946:
-  name: "beatmania IIDX 9th style"
+  name: "Beatmania IIDX 9th Style"
   region: "NTSC-J"
   compat: 5
 SLPM-65947:
@@ -35759,7 +36229,7 @@ SLPM-66064:
   name: "Tough - Dark Fight"
   region: "NTSC-J"
 SLPM-66065:
-  name: "pop'n music 11"
+  name: "Pop'n music 11"
   region: "NTSC-J"
 SLPM-66066:
   name: "Yu-Gi-Oh! Capsule Monster Coliseum"
@@ -36260,13 +36730,13 @@ SLPM-66177:
     halfPixelOffset: 2 # Fix effects upscaling.
     autoFlush: 1 # Fixes broken post processing.
 SLPM-66178:
-  name: "pop'n music 7 [Konami The Best]"
+  name: "Pop'n music 7 [Konami The Best]"
   region: "NTSC-J"
 SLPM-66179:
-  name: "pop'n music 8 [Konami The Best]"
+  name: "Pop'n music 8 [Konami The Best]"
   region: "NTSC-J"
 SLPM-66180:
-  name: "beatmania IIDX 10th style"
+  name: "Beatmania IIDX 10th Style"
   region: "NTSC-J"
 SLPM-66181:
   name: "Beat Down - Fists of Vengeance"
@@ -36400,10 +36870,10 @@ SLPM-66208:
   name: "Sakura Taisen V - Episode 0 - Samurai Girl of Wild [Sega the Best]"
   region: "NTSC-J"
 SLPM-66209:
-  name: "pop'n music 9 [Konami The Best]"
+  name: "Pop'n music 9 [Konami The Best]"
   region: "NTSC-J"
 SLPM-66210:
-  name: "pop'n music 10 [Konami The Best]"
+  name: "Pop'n music 10 [Konami The Best]"
   region: "NTSC-J"
 SLPM-66211:
   name: "King Kong, Peter Jackson's - The Official Game of the Movie"
@@ -36858,7 +37328,7 @@ SLPM-66313:
   region: "NTSC-J"
   compat: 5
 SLPM-66314:
-  name: "pop'n music 12 Iroha"
+  name: "Pop'n music 12 Iroha"
   region: "NTSC-J"
   compat: 5
 SLPM-66315:
@@ -37306,7 +37776,7 @@ SLPM-66425:
   name: "Nobunaga no Yabou - Soutenroku with Power-Up Kit"
   region: "NTSC-J"
 SLPM-66426:
-  name: "beatmania IIDX 11 IIDX RED"
+  name: "Beatmania IIDX 11 - IIDX Red"
   region: "NTSC-J"
 SLPM-66427:
   name: "Full Spectrum Warrior - Ten Hammers"
@@ -37764,7 +38234,7 @@ SLPM-66532:
   name: "Mizu no Senritsu 2"
   region: "NTSC-J"
 SLPM-66533:
-  name: "pop'n music 13 Carnival"
+  name: "Pop'n music 13 Carnival"
   region: "NTSC-J"
 SLPM-66534:
   name: "Ryu Koku [Limited Edition]"
@@ -38110,7 +38580,7 @@ SLPM-66620:
   name: "Higurashi no Naku Koro ni Matsuri"
   region: "NTSC-J"
 SLPM-66621:
-  name: "beatmania IIDX 12 HAPPY SKY"
+  name: "Beatmania IIDX 12 - Happy Sky"
   region: "NTSC-J"
 SLPM-66622:
   name: "Tom Clancy's Ghost Recon 2 [Ubisoft Best]"
@@ -38638,7 +39108,7 @@ SLPM-66741:
   name: "Sentou Kokka Kai - Legend"
   region: "NTSC-J"
 SLPM-66742:
-  name: "pop'n music 14 FEVER!"
+  name: "Pop'n music 14 FEVER!"
   region: "NTSC-J"
   compat: 5
 SLPM-66743:
@@ -38957,7 +39427,7 @@ SLPM-66827:
   name: "Youki Hime Den"
   region: "NTSC-J"
 SLPM-66828:
-  name: "beatmania IIDX 13 DistorteD"
+  name: "Beatmania IIDX 13 - DistorteD"
   region: "NTSC-J"
 SLPM-66829:
   name: "Major League Baseball 2K7"
@@ -39519,7 +39989,7 @@ SLPM-66994:
     - DMABusyHack
     - SoftwareRendererFMVHack # Vertical lines in FMV.
 SLPM-66995:
-  name: "beatmania IIDX 14 GOLD"
+  name: "Beatmania IIDX 14 - Gold"
   region: "NTSC-J"
 SLPM-66996:
   name: "Shuumatsu Otome Gensou Alicematic Apocalypse [Limited Edition]"
@@ -39637,6 +40107,9 @@ SLPM-67505:
   compat: 5
   clampModes:
     vuClampMode: 2 # Fixes corrupt textures.
+SLPM-67506:
+  name: "Thunder Strike - Operation Phoenix"
+  region: "NTSC-K"
 SLPM-67507:
   name: "Onimusha - Warlords"
   region: "NTSC-K"
@@ -39682,6 +40155,12 @@ SLPM-67515:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
     partialTargetInvalidation: 1 # Fixes cutscene blur effects.
+SLPM-67516:
+  name: "Soul Reaver 2"
+  region: "NTSC-K"
+SLPM-67517:
+  name: "Capcom vs. SNK 2 - Mark of the Millennium 2001"
+  region: "NTSC-K"
 SLPM-67518:
   name: "Onimusha 2 Samurai's Destiny"
   region: "NTSC-K"
@@ -39691,7 +40170,7 @@ SLPM-67519:
   roundModes:
     eeRoundMode: 0 # Fixes game hanging in the "Clark running away" ingame cutscene.
 SLPM-67520:
-  name: "Disney's Tarzan - Freeride"
+  name: "Disney's Tarzan - Untamed"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 1 # Fixes blurriness and misaligned shadows.
@@ -39734,6 +40213,9 @@ SLPM-67528:
 SLPM-67529:
   name: "Gun Survivor 3 Dino Crisis"
   region: "NTSC-K"
+SLPM-67530:
+  name: "NHL 2003"
+  region: "NTSC-K"
 SLPM-67531:
   name: "Kessen 2"
   region: "NTSC-K"
@@ -39775,6 +40257,9 @@ SLPM-67540:
   compat: 5
 SLPM-67541:
   name: "NBA Live 2003"
+  region: "NTSC-K"
+SLPM-67543:
+  name: "Star Wars - Jedi Starfighter"
   region: "NTSC-K"
 SLPM-67545:
   name: "Project Minerva"
@@ -52619,7 +53104,7 @@ SLUS-21238:
   region: "NTSC-U"
   compat: 5
 SLUS-21239:
-  name: "beatmania"
+  name: "Beatmania"
   region: "NTSC-U"
   compat: 5
 SLUS-21240:
@@ -56275,6 +56760,8 @@ SLUS-21955:
 SLUS-27014:
   name: "WWE SmackDown vs Raw - Superstar Series [Bundle]"
   region: "NTSC-U"
+  gsHWFixes:
+    partialTargetInvalidation: 1 # Fixes menu corruption.
 SLUS-27029:
   name: "Disney Sing It [Bundle]"
   region: "NTSC-U"
@@ -56830,6 +57317,8 @@ SLUS-29113:
 SLUS-29116:
   name: "WWE SmackDown! vs. RAW [Public Beta Vol.1.0]"
   region: "NTSC-U"
+  gsHWFixes:
+    partialTargetInvalidation: 1 # Fixes menu corruption.
 SLUS-29117:
   name: "Battlefield 2 - Modern Combat [Public Beta Vol.1.0]"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Based on:
https://github.com/PCSX2/pcsx2/pull/9671#issuecomment-1657337888

I do see a lot of the missing entries actually come from the PCSX2 wiki, and the csv was mostly duplicates but I checked and cleaned it up while looking at other things to potentially fix.

GGeneration is faulty naming though, G Genereration needs a space.

There are also 2 reasons why we don't fully follow redump: For starters Windows uses specific characters in their code and following that would make it impossible to make covers for them and some other things The other thing is when The blablabla  turns into blablabla, The for filtering purposes.

![image](https://github.com/PCSX2/pcsx2/assets/24227051/66d68f9b-9f59-4857-b341-1697dbe76a91)

In future we should probably have a display language for specific languages, ex. Korean entries show Japanese, English or others

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Easier for compiling as much information and fixes in future
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Not much besides rescanning.