### PR TITLE
ci: properly fetch release info to make announcement

### DIFF
--- a/.github/workflows/release_cut_new.yml
+++ b/.github/workflows/release_cut_new.yml
@@ -27,8 +27,10 @@ permissions:
 jobs:
   cut-release:
     if: github.repository == 'PCSX2/pcsx2'
-    runs-on: ubuntu-latest
     name: "Create Tag and Release"
+    runs-on: ubuntu-latest
+    outputs:
+      new_tag: ${{ steps.tag_version.outputs.new_tag }}
     steps:
       - uses: actions/checkout@v3
 
@@ -131,6 +133,7 @@ jobs:
   upload_artifacts:
     if: github.repository == 'PCSX2/pcsx2'
     needs:
+      - cut-release
       - build_linux_flatpak
       - build_linux_qt
       - build_windows_qt
@@ -139,10 +142,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-
-      # actions/checkout elides tags, fetch them primarily for releases
-      - name: Fetch Tags
-        run: git fetch --tags --no-recurse-submodules
 
       - name: Prepare Artifact Folder
         run: mkdir ./ci-artifacts/
@@ -169,7 +168,7 @@ jobs:
           SCAN_DIR: ${{ github.WORKSPACE }}/ci-artifacts
           OUT_DIR: ${{ github.WORKSPACE }}/ci-artifacts/out
         run: |
-          TAG_VAL=$(git tag --points-at HEAD)
+          TAG_VAL=${{needs.cut-release.outputs.new_tag}}
           echo "TAG_VAL=${TAG_VAL}"
           gh release list --repo PCSX2/pcsx2
           mkdir -p ${{ github.WORKSPACE }}/ci-artifacts/out
@@ -181,7 +180,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
-          TAG_VAL=$(git tag --points-at HEAD)
+          TAG_VAL=${{needs.cut-release.outputs.new_tag}}
           echo "TAG_VAL=${TAG_VAL}"
           gh release edit ${TAG_VAL} --draft=false --repo PCSX2/pcsx2
 
@@ -191,8 +190,12 @@ jobs:
 
       - name: Announce Release
         env:
+          OWNER: PCSX2
+          REPO: pcsx2
           DISCORD_BUILD_WEBHOOK: ${{ secrets.DISCORD_BUILD_WEBHOOK }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
+          TAG_VAL=${{needs.cut-release.outputs.new_tag}}
           cd ./.github/workflows/scripts/releases/announce-release
           npm ci
-          node index.js
+          TAG_VAL=${TAG_VAL} node index.js

--- a/.github/workflows/scripts/releases/announce-release/index.js
+++ b/.github/workflows/scripts/releases/announce-release/index.js
@@ -1,7 +1,58 @@
 import { MessageEmbed, WebhookClient } from "discord.js";
-import * as github from '@actions/github';
+import { Octokit } from "@octokit/rest";
+import { throttling } from "@octokit/plugin-throttling";
+import { retry } from "@octokit/plugin-retry";
 
-const releaseInfo = github.context.payload.release;
+let owner = process.env.OWNER;
+let repo = process.env.REPO;
+
+Octokit.plugin(throttling);
+Octokit.plugin(retry);
+const octokit = new Octokit({
+  auth: process.env.GITHUB_TOKEN,
+  userAgent: `${owner}/${repo}`,
+  log: {
+    debug: () => { },
+    info: () => { },
+    warn: console.warn,
+    error: console.error
+  },
+  throttle: {
+    onRateLimit: (retryAfter, options) => {
+      octokit.log.warn(
+        `Request quota exhausted for request ${options.method} ${options.url}`
+      );
+
+      // Retry twice after hitting a rate limit error, then give up
+      if (options.request.retryCount <= 2) {
+        console.log(`Retrying after ${retryAfter} seconds!`);
+        return true;
+      }
+    },
+    onAbuseLimit: (retryAfter, options) => {
+      // does not retry, only logs a warning
+      octokit.log.warn(
+        `Abuse detected for request ${options.method} ${options.url}`
+      );
+    },
+  }
+});
+
+if (process.env.TAG_VAL === undefined || process.env.TAG_VAL === "") {
+  console.log(`Not announcing - TAG_VAL not defined`);
+  process.exit(1);
+}
+
+const { data: releaseInfo } = await octokit.rest.repos.getReleaseByTag({
+  owner: owner,
+  repo: repo,
+  tag: process.env.TAG_VAL,
+});
+
+if (releaseInfo === undefined) {
+  console.log(`Not announcing - could not locate release with tag ${process.env.TAG_VAL}`);
+  process.exit(1);
+}
 
 if (!releaseInfo.prerelease) {
   console.log("Not announcing - release was not a pre-release (aka a Nightly)");
@@ -18,6 +69,7 @@ const embed = new MessageEmbed()
     { name: 'Installation Steps', value: '[See Here](https://github.com/PCSX2/pcsx2/wiki/Nightly-Build-Usage-Guide)', inline: true },
     { name: 'Included Changes', value: releaseInfo.body, inline: false }
   );
+console.log(embed);
 
 // Get all webhooks, simple comma-sep string
 const webhookUrls = process.env.DISCORD_BUILD_WEBHOOK.split(",");

--- a/.github/workflows/scripts/releases/announce-release/package-lock.json
+++ b/.github/workflows/scripts/releases/announce-release/package-lock.json
@@ -5,30 +5,14 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "announce-release",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@actions/github": "^5.0.0",
+        "@octokit/plugin-retry": "^3.0.9",
+        "@octokit/plugin-throttling": "^3.5.2",
+        "@octokit/rest": "^18.12.0",
         "discord.js": "^13.2.0"
-      }
-    },
-    "node_modules/@actions/github": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@actions/github/-/github-5.0.0.tgz",
-      "integrity": "sha512-QvE9eAAfEsS+yOOk0cylLBIO/d6WyWIOvsxxzdrPFaud39G6BOkUwScXZn1iBzQzHyu9SBkkLSWlohDWdsasAQ==",
-      "dependencies": {
-        "@actions/http-client": "^1.0.11",
-        "@octokit/core": "^3.4.0",
-        "@octokit/plugin-paginate-rest": "^2.13.3",
-        "@octokit/plugin-rest-endpoint-methods": "^5.1.1"
-      }
-    },
-    "node_modules/@actions/http-client": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-1.0.11.tgz",
-      "integrity": "sha512-VRYHGQV1rqnROJqdMvGUbY/Kn8vriQe/F9HR2AlYHzmKuM/p3kjNuXhmdBfcVgsvRWTz5C5XW5xvndZrVBuAYg==",
-      "dependencies": {
-        "tunnel": "0.0.6"
       }
     },
     "node_modules/@discordjs/builders": {
@@ -131,6 +115,14 @@
         "@octokit/types": "^6.33.0"
       }
     },
+    "node_modules/@octokit/plugin-request-log": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
+      "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
+      "peerDependencies": {
+        "@octokit/core": ">=3"
+      }
+    },
     "node_modules/@octokit/plugin-rest-endpoint-methods": {
       "version": "5.12.1",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.12.1.tgz",
@@ -138,6 +130,27 @@
       "dependencies": {
         "@octokit/types": "^6.33.0",
         "deprecation": "^2.3.1"
+      }
+    },
+    "node_modules/@octokit/plugin-retry": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-3.0.9.tgz",
+      "integrity": "sha512-r+fArdP5+TG6l1Rv/C9hVoty6tldw6cE2pRHNGmFPdyfrc696R6JjrQ3d7HdVqGwuzfyrcaLAKD7K8TX8aehUQ==",
+      "dependencies": {
+        "@octokit/types": "^6.0.3",
+        "bottleneck": "^2.15.3"
+      }
+    },
+    "node_modules/@octokit/plugin-throttling": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-3.7.0.tgz",
+      "integrity": "sha512-qrKT1Yl/KuwGSC6/oHpLBot3ooC9rq0/ryDYBCpkRtoj+R8T47xTMDT6Tk2CxWopFota/8Pi/2SqArqwC0JPow==",
+      "dependencies": {
+        "@octokit/types": "^6.0.1",
+        "bottleneck": "^2.15.3"
+      },
+      "peerDependencies": {
+        "@octokit/core": "^3.5.0"
       }
     },
     "node_modules/@octokit/request": {
@@ -161,6 +174,17 @@
         "@octokit/types": "^6.0.3",
         "deprecation": "^2.0.0",
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/@octokit/rest": {
+      "version": "18.12.0",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.12.0.tgz",
+      "integrity": "sha512-gDPiOHlyGavxr72y0guQEhLsemgVjwRePayJ+FcKc2SJqKUbxbkvf5kAZEWA/MKvsfYlQAMVzNJE3ezQcxMJ2Q==",
+      "dependencies": {
+        "@octokit/core": "^3.5.1",
+        "@octokit/plugin-paginate-rest": "^2.16.8",
+        "@octokit/plugin-request-log": "^1.0.4",
+        "@octokit/plugin-rest-endpoint-methods": "^5.12.0"
       }
     },
     "node_modules/@octokit/types": {
@@ -213,6 +237,11 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.2.tgz",
       "integrity": "sha512-3pZEU3NT5BFUo/AD5ERPWOgQOCZITni6iavr5AUw5AUwQjMlI0kzu5btnyD39AF0gUEsDPwJT+oY1ORBJijPjQ=="
+    },
+    "node_modules/bottleneck": {
+      "version": "2.19.5",
+      "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
+      "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw=="
     },
     "node_modules/callsites": {
       "version": "3.1.0",
@@ -388,14 +417,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
-    "node_modules/tunnel": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
-      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
-      "engines": {
-        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
-      }
-    },
     "node_modules/type-fest": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
@@ -461,25 +482,6 @@
     }
   },
   "dependencies": {
-    "@actions/github": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@actions/github/-/github-5.0.0.tgz",
-      "integrity": "sha512-QvE9eAAfEsS+yOOk0cylLBIO/d6WyWIOvsxxzdrPFaud39G6BOkUwScXZn1iBzQzHyu9SBkkLSWlohDWdsasAQ==",
-      "requires": {
-        "@actions/http-client": "^1.0.11",
-        "@octokit/core": "^3.4.0",
-        "@octokit/plugin-paginate-rest": "^2.13.3",
-        "@octokit/plugin-rest-endpoint-methods": "^5.1.1"
-      }
-    },
-    "@actions/http-client": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-1.0.11.tgz",
-      "integrity": "sha512-VRYHGQV1rqnROJqdMvGUbY/Kn8vriQe/F9HR2AlYHzmKuM/p3kjNuXhmdBfcVgsvRWTz5C5XW5xvndZrVBuAYg==",
-      "requires": {
-        "tunnel": "0.0.6"
-      }
-    },
     "@discordjs/builders": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-0.6.0.tgz",
@@ -569,6 +571,12 @@
         "@octokit/types": "^6.33.0"
       }
     },
+    "@octokit/plugin-request-log": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
+      "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
+      "requires": {}
+    },
     "@octokit/plugin-rest-endpoint-methods": {
       "version": "5.12.1",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.12.1.tgz",
@@ -576,6 +584,24 @@
       "requires": {
         "@octokit/types": "^6.33.0",
         "deprecation": "^2.3.1"
+      }
+    },
+    "@octokit/plugin-retry": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-3.0.9.tgz",
+      "integrity": "sha512-r+fArdP5+TG6l1Rv/C9hVoty6tldw6cE2pRHNGmFPdyfrc696R6JjrQ3d7HdVqGwuzfyrcaLAKD7K8TX8aehUQ==",
+      "requires": {
+        "@octokit/types": "^6.0.3",
+        "bottleneck": "^2.15.3"
+      }
+    },
+    "@octokit/plugin-throttling": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-3.7.0.tgz",
+      "integrity": "sha512-qrKT1Yl/KuwGSC6/oHpLBot3ooC9rq0/ryDYBCpkRtoj+R8T47xTMDT6Tk2CxWopFota/8Pi/2SqArqwC0JPow==",
+      "requires": {
+        "@octokit/types": "^6.0.1",
+        "bottleneck": "^2.15.3"
       }
     },
     "@octokit/request": {
@@ -599,6 +625,17 @@
         "@octokit/types": "^6.0.3",
         "deprecation": "^2.0.0",
         "once": "^1.4.0"
+      }
+    },
+    "@octokit/rest": {
+      "version": "18.12.0",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.12.0.tgz",
+      "integrity": "sha512-gDPiOHlyGavxr72y0guQEhLsemgVjwRePayJ+FcKc2SJqKUbxbkvf5kAZEWA/MKvsfYlQAMVzNJE3ezQcxMJ2Q==",
+      "requires": {
+        "@octokit/core": "^3.5.1",
+        "@octokit/plugin-paginate-rest": "^2.16.8",
+        "@octokit/plugin-request-log": "^1.0.4",
+        "@octokit/plugin-rest-endpoint-methods": "^5.12.0"
       }
     },
     "@octokit/types": {
@@ -641,6 +678,11 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.2.tgz",
       "integrity": "sha512-3pZEU3NT5BFUo/AD5ERPWOgQOCZITni6iavr5AUw5AUwQjMlI0kzu5btnyD39AF0gUEsDPwJT+oY1ORBJijPjQ=="
+    },
+    "bottleneck": {
+      "version": "2.19.5",
+      "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
+      "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw=="
     },
     "callsites": {
       "version": "3.1.0",
@@ -764,11 +806,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
-    },
-    "tunnel": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
-      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
     },
     "type-fest": {
       "version": "1.4.0",

--- a/.github/workflows/scripts/releases/announce-release/package.json
+++ b/.github/workflows/scripts/releases/announce-release/package.json
@@ -10,7 +10,9 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@actions/github": "^5.0.0",
+    "@octokit/plugin-retry": "^3.0.9",
+    "@octokit/plugin-throttling": "^3.5.2",
+    "@octokit/rest": "^18.12.0",
     "discord.js": "^13.2.0"
   }
 }


### PR DESCRIPTION
Fixes previous attempt.  Overlooked the fact that it was able to grab the release info via the event payload (kicked off by a `released` event).  That's no longer the case, so the release has to be grabbed manually from the API.

I actually tested it this time - https://github.com/xTVaser/pcsx2-rr/actions/runs/5746987049/job/15577646112#step:10:19