### PR TITLE
IPU: Improve DMA/IPU call locations to reduce looping

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -13252,9 +13252,12 @@ SLES-50726:
   patches:
     9E159E95:
       content: |-
-        // Gives the IPU more time to process the textures
-        // CPU does a wait loop then starts copying the output of the IPU
-        patch=0,EE,001f02a0,word,24027fff
+        // Waits for IPU command to finish.
+        // Replaces wait loop that had a very short wait period.
+        patch=0,EE,001f02A0,word,3C021000
+        patch=0,EE,001f02A4,word,34422010
+        patch=0,EE,001f02A8,word,8c430000
+        patch=0,EE,001f02B8,word,0460FFFA
   gameFixes:
     - EETimingHack # Speeds up IPU DMA's
 SLES-50727:
@@ -48851,9 +48854,12 @@ SLUS-20434:
   patches:
     75DB04A3:
       content: |-
-        // Gives the IPU more time to process the textures
-        // CPU does a wait loop then starts copying the output of the IPU
-        patch=0,EE,001f0030,word,24027fff
+        // Waits for IPU command to finish.
+        // Replaces wait loop that had a very short wait period.
+        patch=0,EE,001f0030,word,3C021000
+        patch=0,EE,001f0034,word,34422010
+        patch=0,EE,001f0038,word,8c430000
+        patch=0,EE,001f0048,word,0460FFFA
   gameFixes:
     - EETimingHack # Speeds up IPU DMA's
 SLUS-20435:

--- a/pcsx2/IPU/IPU.cpp
+++ b/pcsx2/IPU/IPU.cpp
@@ -95,7 +95,7 @@ __fi void IPUProcessInterrupt()
 	if (ipuRegs.ctrl.BUSY && !CommandExecuteQueued)
 		IPUWorker();
 
-	if (ipuRegs.ctrl.BUSY)
+	if (ipuRegs.ctrl.BUSY && !IPU1Status.DataRequested && !(cpuRegs.interrupt & 1 << IPU_PROCESS))
 	{
 		CPU_INT(IPU_PROCESS, ProcessedData ? ProcessedData : 64);
 	}

--- a/pcsx2/IPU/IPU_Fifo.cpp
+++ b/pcsx2/IPU/IPU_Fifo.cpp
@@ -93,6 +93,8 @@ int IPU_Fifo_Input::write(const u32* pMem, int size)
 	if (g_BP.IFC == 8)
 		IPU1Status.DataRequested = false;
 
+	CPU_INT(IPU_PROCESS, transfer_size * BIAS);
+
 	return transfer_size;
 }
 
@@ -106,7 +108,7 @@ int IPU_Fifo_Input::read(void *value)
 
 		if(ipu1ch.chcr.STR && cpuRegs.eCycle[4] == 0x9999)
 		{
-			CPU_INT( DMAC_TO_IPU, 4);
+			CPU_INT( DMAC_TO_IPU, std::min(8U, ipu1ch.qwc));
 		}
 
 		if (g_BP.IFC == 0) return 0;
@@ -183,7 +185,7 @@ void WriteFIFO_IPUin(const mem128_t* value)
 	{
 		if (ipuRegs.ctrl.BUSY && !CommandExecuteQueued)
 		{
-			CommandExecuteQueued = true;
+			CommandExecuteQueued = false;
 			CPU_INT(IPU_PROCESS, 8);
 		}
 	}

--- a/pcsx2/IPU/IPUdma.cpp
+++ b/pcsx2/IPU/IPUdma.cpp
@@ -149,12 +149,6 @@ void IPU1dma()
 		}
 	}
 
-	if (ipuRegs.ctrl.BUSY && !CommandExecuteQueued)
-	{
-		CommandExecuteQueued = true;
-		CPU_INT(IPU_PROCESS, totalqwc * BIAS);
-	}
-
 	IPU_LOG("Completed Call IPU1 DMA QWC Remaining %x Finished %d In Progress %d tadr %x", ipu1ch.qwc, IPU1Status.DMAFinished, IPU1Status.InProgress, ipu1ch.tadr);
 }
 
@@ -198,13 +192,14 @@ void IPU0dma()
 		dmacRegs.stadr.ADDR = ipu0ch.madr;
 	}
 
-	IPU_INT_FROM( readsize * BIAS );
+	if (!ipu0ch.qwc)
+		IPU_INT_FROM(readsize * BIAS);
 
 	if (ipuRegs.ctrl.BUSY && !CommandExecuteQueued)
 	{
-		CommandExecuteQueued = true;
+		CommandExecuteQueued = false;
 		CPU_SET_DMASTALL(DMAC_FROM_IPU, true);
-		CPU_INT(IPU_PROCESS, readsize * BIAS);
+		IPUProcessInterrupt();
 	}
 }
 


### PR DESCRIPTION
### Description of Changes
Improves internal flow of data in the IPU and properly delays IPU before decoding.

### Rationale behind Changes
I noticed Harley Davidson videos were running really laggy and freezing up, so it was obviously getting confused, so I tidied up the flow between the DMA's and IPU a little.

Also improved the Myst 3 patch to just wait until IPU is no longer busy instead of using some arbitrary number.

### Suggested Testing Steps
Test videos in games, make sure nothing is broken more than it was.
