### PR TITLE
GS/Metal: Don't end up with two encoders on readback

### DIFF
--- a/pcsx2/GS/Renderers/Metal/GSTextureMTL.mm
+++ b/pcsx2/GS/Renderers/Metal/GSTextureMTL.mm
@@ -194,8 +194,8 @@ void GSDownloadTextureMTL::CopyFromTexture(
 		GetTransferPitch(use_transfer_pitch ? static_cast<u32>(drc.width()) : m_width, PITCH_ALIGNMENT);
 	GetTransferSize(drc, &copy_offset, &copy_size, &copy_rows);
 
-	m_dev->EndRenderPass();
 	mtlTex->FlushClears();
+	m_dev->EndRenderPass();
 	g_perfmon.Put(GSPerfMon::Readbacks, 1);
 
 	m_copy_cmdbuffer = MRCRetain(m_dev->GetRenderCmdBuf());


### PR DESCRIPTION
### Description of Changes

Klona 2, and maybe other games download a cleared buffer. FlushClears() will start a render pass (encoder) in this case, which means there's two encoders after the copy encoder is created, which is a no-no.

### Rationale behind Changes

Fixes Klona 2 crashing on new game, maybe others?

### Suggested Testing Steps

Check affected games.
