### PR TITLE
GameList: Add an option to exclude entire directories

### DIFF
--- a/pcsx2-qt/Settings/GameListSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GameListSettingsWidget.cpp
@@ -51,6 +51,7 @@ GameListSettingsWidget::GameListSettingsWidget(SettingsDialog* dialog, QWidget* 
 		&GameListSettingsWidget::onAddSearchDirectoryButtonClicked);
 	connect(m_ui.removeSearchDirectoryButton, &QPushButton::clicked, this,
 		&GameListSettingsWidget::onRemoveSearchDirectoryButtonClicked);
+	connect(m_ui.addExcludedFile, &QPushButton::clicked, this, &GameListSettingsWidget::onAddExcludedFileButtonClicked);
 	connect(m_ui.addExcludedPath, &QPushButton::clicked, this, &GameListSettingsWidget::onAddExcludedPathButtonClicked);
 	connect(m_ui.removeExcludedPath, &QPushButton::clicked, this,
 		&GameListSettingsWidget::onRemoveExcludedPathButtonClicked);
@@ -215,10 +216,21 @@ void GameListSettingsWidget::onRemoveSearchDirectoryButtonClicked()
 	delete item;
 }
 
+void GameListSettingsWidget::onAddExcludedFileButtonClicked()
+{
+	QString path =
+		QDir::toNativeSeparators(QFileDialog::getOpenFileName(QtUtils::GetRootWidget(this), tr("Select File")));
+	if (path.isEmpty())
+		return;
+
+	addExcludedPath(path.toStdString());
+}
+
 void GameListSettingsWidget::onAddExcludedPathButtonClicked()
 {
 	QString path =
-		QDir::toNativeSeparators(QFileDialog::getOpenFileName(QtUtils::GetRootWidget(this), tr("Select Path")));
+		QDir::toNativeSeparators(QFileDialog::getExistingDirectory(QtUtils::GetRootWidget(this), tr("Select Directory")));
+
 	if (path.isEmpty())
 		return;
 

--- a/pcsx2-qt/Settings/GameListSettingsWidget.h
+++ b/pcsx2-qt/Settings/GameListSettingsWidget.h
@@ -39,6 +39,7 @@ private Q_SLOTS:
 	void onDirectoryListContextMenuRequested(const QPoint& point);
 	void onAddSearchDirectoryButtonClicked();
 	void onRemoveSearchDirectoryButtonClicked();
+	void onAddExcludedFileButtonClicked();
 	void onAddExcludedPathButtonClicked();
 	void onRemoveExcludedPathButtonClicked();
 	void onScanForNewGamesClicked();

--- a/pcsx2-qt/Settings/GameListSettingsWidget.ui
+++ b/pcsx2-qt/Settings/GameListSettingsWidget.ui
@@ -57,11 +57,14 @@
         </sizepolicy>
        </property>
        <property name="text">
-        <string>Add</string>
+        <string>Add...</string>
        </property>
        <property name="icon">
         <iconset theme="folder-add-line">
          <normaloff>.</normaloff>.</iconset>
+       </property>
+       <property name="toolButtonStyle">
+        <enum>Qt::ToolButtonTextBesideIcon</enum>
        </property>
       </widget>
      </item>
@@ -79,6 +82,9 @@
        <property name="icon">
         <iconset theme="folder-reduce-line">
          <normaloff>.</normaloff>.</iconset>
+       </property>
+       <property name="toolButtonStyle">
+        <enum>Qt::ToolButtonTextBesideIcon</enum>
        </property>
       </widget>
      </item>
@@ -129,11 +135,34 @@
         </sizepolicy>
        </property>
        <property name="text">
-        <string>Add</string>
+        <string>Directory...</string>
+       </property>
+       <property name="icon">
+        <iconset theme="folder-add-line">
+         <normaloff>.</normaloff>.</iconset>
+       </property>
+       <property name="toolButtonStyle">
+        <enum>Qt::ToolButtonTextBesideIcon</enum>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="addExcludedFile">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>File...</string>
        </property>
        <property name="icon">
         <iconset theme="file-add-line">
          <normaloff>.</normaloff>.</iconset>
+       </property>
+       <property name="toolButtonStyle">
+        <enum>Qt::ToolButtonTextBesideIcon</enum>
        </property>
       </widget>
      </item>
@@ -151,6 +180,9 @@
        <property name="icon">
         <iconset theme="file-reduce-line">
          <normaloff>.</normaloff>.</iconset>
+       </property>
+       <property name="toolButtonStyle">
+        <enum>Qt::ToolButtonTextBesideIcon</enum>
        </property>
       </widget>
      </item>

--- a/pcsx2-qt/SetupWizardDialog.ui
+++ b/pcsx2-qt/SetupWizardDialog.ui
@@ -371,11 +371,14 @@
             </sizepolicy>
            </property>
            <property name="text">
-            <string>Add</string>
+            <string>Add...</string>
            </property>
            <property name="icon">
             <iconset theme="folder-add-line">
              <normaloff>.</normaloff>.</iconset>
+           </property>
+           <property name="toolButtonStyle">
+            <enum>Qt::ToolButtonTextBesideIcon</enum>
            </property>
           </widget>
          </item>
@@ -393,6 +396,9 @@
            <property name="icon">
             <iconset theme="folder-reduce-line">
              <normaloff>.</normaloff>.</iconset>
+           </property>
+           <property name="toolButtonStyle">
+            <enum>Qt::ToolButtonTextBesideIcon</enum>
            </property>
           </widget>
          </item>

--- a/pcsx2/GameList.cpp
+++ b/pcsx2/GameList.cpp
@@ -582,7 +582,7 @@ void GameList::RewriteCacheFile()
 
 static bool IsPathExcluded(const std::vector<std::string>& excluded_paths, const std::string& path)
 {
-	return (std::find(excluded_paths.begin(), excluded_paths.end(), path) != excluded_paths.end());
+	return std::find_if(excluded_paths.begin(), excluded_paths.end(), [&path](const std::string& entry) { return path.starts_with(entry); }) != excluded_paths.end();
 }
 
 void GameList::ScanDirectory(const char* path, bool recursive, bool only_cache, const std::vector<std::string>& excluded_paths,
@@ -596,7 +596,7 @@ void GameList::ScanDirectory(const char* path, bool recursive, bool only_cache, 
 	FileSystem::FindResultsArray files;
 	FileSystem::FindFiles(path, "*",
 		recursive ? (FILESYSTEM_FIND_FILES | FILESYSTEM_FIND_HIDDEN_FILES | FILESYSTEM_FIND_RECURSIVE) :
-                    (FILESYSTEM_FIND_FILES | FILESYSTEM_FIND_HIDDEN_FILES),
+					(FILESYSTEM_FIND_FILES | FILESYSTEM_FIND_HIDDEN_FILES),
 		&files);
 
 	u32 files_scanned = 0;
@@ -808,7 +808,7 @@ bool GameList::RescanPath(const std::string& path)
 	{
 		// cancel if excluded
 		const std::vector<std::string> excluded_paths(Host::GetBaseStringListSetting("GameList", "ExcludedPaths"));
-		if (std::find(excluded_paths.begin(), excluded_paths.end(), path) != excluded_paths.end())
+		if (IsPathExcluded(excluded_paths, path))
 			return false;
 	}
 


### PR DESCRIPTION
### Description of Changes
This PR adds an option to add entire directories to Excluded Paths, and not only the individual files.

![image](https://github.com/PCSX2/pcsx2/assets/7947461/c9dad5b9-6d95-4221-a01b-d405cf642372)

Resolves #7126.

### Rationale behind Changes
It's a reasonable request and might be useful if you scan recursively but want to exclude specific subdirectories.

### Suggested Testing Steps
1. Add a recursive search directory.
2. Add an excluded directory that is one of the subdirectories of the above directory.
3. Rescan.
4. Verify that the games from the excluded directory do **NOT** show on the game list.
