### PR TITLE
UI: Only allow relative memcard files in memcard interface

### DIFF
--- a/pcsx2/SIO/Memcard/MemoryCardFile.cpp
+++ b/pcsx2/SIO/Memcard/MemoryCardFile.cpp
@@ -888,6 +888,11 @@ std::vector<AvailableMcdInfo> FileMcd_GetAvailableCards(bool include_in_use_card
 				continue;
 		}
 
+		// We only want relevant file types.
+		if (!(StringUtil::EndsWith(fd.FileName, ".ps2") || StringUtil::EndsWith(fd.FileName, ".mcr") ||
+			StringUtil::EndsWith(fd.FileName, ".mcd") || StringUtil::EndsWith(fd.FileName, ".bin")))
+			continue;
+
 		if (fd.Attributes & FILESYSTEM_FILE_ATTRIBUTE_DIRECTORY)
 		{
 			if (!IsMemoryCardFolder(fd.FileName))


### PR DESCRIPTION
### Description of Changes
Only show relative memcard formats in memcard screen.

### Rationale behind Changes
It allowed you to load any file as a memcard, this could be bad if somebody thinks their game iso is a memcard (trust me, this isn't out of the realms of possibility)

### Suggested Testing Steps
put random crap files in your memcard folder, make sure you can only see your ps1/ps2/rawbin files.
