### PR TITLE
GS/Metal: Fix crash when Z write is on second pass

### DIFF
--- a/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
+++ b/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
@@ -2141,8 +2141,6 @@ void GSDeviceMTL::RenderHW(GSHWDrawConfig& config)
 	}
 
 	// Try to reduce render pass restarts
-	if (!stencil && config.depth.key == DepthStencilSelector::NoDepth().key && (m_current_render.color_target != rt || m_current_render.depth_target != config.ds))
-		config.ds = nullptr;
 	if (!config.ds && m_current_render.color_target == rt && stencil == m_current_render.stencil_target && m_current_render.depth_target != config.tex)
 		config.ds = m_current_render.depth_target;
 	if (!rt && config.ds == m_current_render.depth_target && m_current_render.color_target != config.tex)


### PR DESCRIPTION
### Description of Changes

Happens in Crash: WoC. Z writes only happens on the second pass, and the condition I removed only checks the first pass.

I'm not sure on rationale behind this check, nulling out the depth buffer to avoid render pass restarts sounds like it'll cause the opposite, because it's likely that subsequent draws are going to use said depth buffer if it was supplied. The base class (GSRendererHW::Draw) takes care of disabling it in most cases.

### Rationale behind Changes

Fixes #9734.

### Suggested Testing Steps

Test Crash WoC Level 4. I've only checked the AS build, since I still haven't bothered to figure out how to cross-compile. Will grab the CI build once it's up.
