### PR TITLE
Mac: Better crash reports on assertion failures

### DIFF
--- a/common/Misc.cpp
+++ b/common/Misc.cpp
@@ -110,7 +110,7 @@ struct crash_info_t
 	u64 reserved;
 	u64 reserved2;
 };
-#define CRASH_ANNOTATION __attribute__((section("__DATA,__crash_info")))
+#define CRASH_ANNOTATION __attribute__((used, section("__DATA,__crash_info")))
 #define CRASH_VERSION 4
 extern "C" crash_info_t gCRAnnotations CRASH_ANNOTATION = { CRASH_VERSION };
 #endif

--- a/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
+++ b/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
@@ -673,7 +673,7 @@ MRCOwned<id<MTLFunction>> GSDeviceMTL::LoadShader(NSString* name)
 	{
 		NSString* msg = [NSString stringWithFormat:@"Failed to load shader %@: %@", name, [err localizedDescription]];
 		Console.Error("%s", [msg UTF8String]);
-		pxFailRel("Failed to load shader, check the log for more details.");
+		pxFailRel([msg UTF8String]);
 	}
 	return fn;
 }
@@ -689,7 +689,7 @@ MRCOwned<id<MTLRenderPipelineState>> GSDeviceMTL::MakePipeline(MTLRenderPipeline
 	{
 		NSString* msg = [NSString stringWithFormat:@"Failed to create pipeline %@: %@", name, [err localizedDescription]];
 		Console.Error("%s", [msg UTF8String]);
-		pxFailRel("Failed to create pipeline, check the log for more details.");
+		pxFailRel([msg UTF8String]);
 	}
 	return res;
 }
@@ -709,7 +709,7 @@ MRCOwned<id<MTLComputePipelineState>> GSDeviceMTL::MakeComputePipeline(id<MTLFun
 	{
 		NSString* msg = [NSString stringWithFormat:@"Failed to create pipeline %@: %@", name, [err localizedDescription]];
 		Console.Error("%s", [msg UTF8String]);
-		pxFailRel("Failed to create pipeline, check the log for more details.");
+		pxFailRel([msg UTF8String]);
 	}
 	return res;
 }


### PR DESCRIPTION
### Description of Changes
Fixes a bug where assertion failure messages weren't included in crash reports thanks to LTO optimizing out the crash report info

### Rationale behind Changes
Better crash reports

### Suggested Testing Steps
~~Purposefully crash PCSX2~~ Hopefully there aren't any known ways to do this, or we should be fixing those
