### PR TITLE
GS/Vulkan: Make VK_EXT_provoking_vertex optional again

### DIFF
--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h
@@ -47,6 +47,7 @@ public:
 
 	struct OptionalExtensions
 	{
+		bool vk_ext_provoking_vertex : 1;
 		bool vk_ext_memory_budget : 1;
 		bool vk_ext_calibrated_timestamps : 1;
 		bool vk_ext_rasterization_order_attachment_access : 1;


### PR DESCRIPTION
### Description of Changes

RenderDoc doesn't support it.

So, until it does, has to be optional. At least for this one, it won't result in incorrect rendering, just a changed index order, unlike e.g. line rasterization.

### Rationale behind Changes

Making renderdoc work again.

### Suggested Testing Steps

Smoke test
