### PR TITLE
USB/GunCon2: Fix cursor when starting fullscreen

### DIFF
--- a/pcsx2/ImGui/ImGuiManager.cpp
+++ b/pcsx2/ImGui/ImGuiManager.cpp
@@ -138,9 +138,10 @@ bool ImGuiManager::Initialize()
 	io.BackendUsingLegacyNavInputArray = 0;
 	io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard | ImGuiConfigFlags_NavEnableGamepad;
 
+	s_window_width = static_cast<float>(g_gs_device->GetWindowWidth());
+	s_window_height = static_cast<float>(g_gs_device->GetWindowHeight());
 	io.DisplayFramebufferScale = ImVec2(1, 1); // We already scale things ourselves, this would double-apply scaling
-	io.DisplaySize.x = static_cast<float>(g_gs_device->GetWindowWidth());
-	io.DisplaySize.y = static_cast<float>(g_gs_device->GetWindowHeight());
+	io.DisplaySize = ImVec2(s_window_width, s_window_height);
 
 	SetKeyMap();
 	SetStyle();
@@ -656,7 +657,7 @@ void ImGuiManager::DrawOSDMessages()
 	const float margin = std::ceil(10.0f * scale);
 	const float padding = std::ceil(8.0f * scale);
 	const float rounding = std::ceil(5.0f * scale);
-	const float max_width = ImGui::GetIO().DisplaySize.x - (margin + padding) * 2.0f;
+	const float max_width = s_window_width - (margin + padding) * 2.0f;
 	float position_x = margin;
 	float position_y = margin;
 
@@ -679,7 +680,7 @@ void ImGuiManager::DrawOSDMessages()
 		const float opacity = std::min(time_remaining, 1.0f);
 		const u32 alpha = static_cast<u32>(opacity * 255.0f);
 
-		if (position_y >= ImGui::GetIO().DisplaySize.y)
+		if (position_y >= s_window_height)
 			break;
 
 		const ImVec2 pos(position_x, position_y);

--- a/pcsx2/ImGui/ImGuiOverlays.cpp
+++ b/pcsx2/ImGui/ImGuiOverlays.cpp
@@ -118,9 +118,9 @@ void ImGuiManager::DrawPerformanceOverlay(float& position_y)
 	{ \
 		text_size = font->CalcTextSizeA(font->FontSize, std::numeric_limits<float>::max(), -1.0f, (text), nullptr, nullptr); \
 		dl->AddText(font, font->FontSize, \
-			ImVec2(ImGui::GetIO().DisplaySize.x - margin - text_size.x + shadow_offset, position_y + shadow_offset), \
+			ImVec2(GetWindowWidth() - margin - text_size.x + shadow_offset, position_y + shadow_offset), \
 			IM_COL32(0, 0, 0, 100), (text)); \
-		dl->AddText(font, font->FontSize, ImVec2(ImGui::GetIO().DisplaySize.x - margin - text_size.x, position_y), color, (text)); \
+		dl->AddText(font, font->FontSize, ImVec2(GetWindowWidth() - margin - text_size.x, position_y), color, (text)); \
 		position_y += text_size.y + spacing; \
 	} while (0)
 
@@ -261,7 +261,7 @@ void ImGuiManager::DrawPerformanceOverlay(float& position_y)
 		{
 			const ImVec2 history_size(200.0f * scale, 50.0f * scale);
 			ImGui::SetNextWindowSize(ImVec2(history_size.x, history_size.y));
-			ImGui::SetNextWindowPos(ImVec2(ImGui::GetIO().DisplaySize.x - margin - history_size.x, position_y));
+			ImGui::SetNextWindowPos(ImVec2(GetWindowWidth() - margin - history_size.x, position_y));
 			ImGui::PushStyleColor(ImGuiCol_WindowBg, ImVec4(0.0f, 0.0f, 0.0f, 0.25f));
 			ImGui::PushStyleColor(ImGuiCol_FrameBg, ImVec4(0.0f, 0.0f, 0.0f, 0.0f));
 			ImGui::PushStyleColor(ImGuiCol_PlotLines, ImVec4(1.0f, 1.0f, 1.0f, 1.0f));
@@ -451,15 +451,15 @@ void ImGuiManager::DrawSettingsOverlay()
 	const float shadow_offset = 1.0f * scale;
 	const float margin = 10.0f * scale;
 	ImFont* font = ImGuiManager::GetFixedFont();
-	const float position_y = ImGui::GetIO().DisplaySize.y - margin - font->FontSize;
+	const float position_y = GetWindowHeight() - margin - font->FontSize;
 
 	ImDrawList* dl = ImGui::GetBackgroundDrawList();
 	ImVec2 text_size =
 		font->CalcTextSizeA(font->FontSize, std::numeric_limits<float>::max(), -1.0f, text.c_str(), text.c_str() + text.length(), nullptr);
 	dl->AddText(font, font->FontSize,
-		ImVec2(ImGui::GetIO().DisplaySize.x - margin - text_size.x + shadow_offset, position_y + shadow_offset), IM_COL32(0, 0, 0, 100),
+		ImVec2(GetWindowWidth() - margin - text_size.x + shadow_offset, position_y + shadow_offset), IM_COL32(0, 0, 0, 100),
 		text.c_str(), text.c_str() + text.length());
-	dl->AddText(font, font->FontSize, ImVec2(ImGui::GetIO().DisplaySize.x - margin - text_size.x, position_y), IM_COL32(255, 255, 255, 255),
+	dl->AddText(font, font->FontSize, ImVec2(GetWindowWidth() - margin - text_size.x, position_y), IM_COL32(255, 255, 255, 255),
 		text.c_str(), text.c_str() + text.length());
 }
 
@@ -631,9 +631,9 @@ void ImGuiManager::DrawInputRecordingOverlay(float& position_y)
 	{ \
 		text_size = font->CalcTextSizeA(font->FontSize, std::numeric_limits<float>::max(), -1.0f, (text), nullptr, nullptr); \
 		dl->AddText(font, font->FontSize, \
-			ImVec2(ImGui::GetIO().DisplaySize.x - margin - text_size.x + shadow_offset, position_y + shadow_offset), \
+			ImVec2(GetWindowWidth() - margin - text_size.x + shadow_offset, position_y + shadow_offset), \
 			IM_COL32(0, 0, 0, 100), (text)); \
-		dl->AddText(font, font->FontSize, ImVec2(ImGui::GetIO().DisplaySize.x - margin - text_size.x, position_y), color, (text)); \
+		dl->AddText(font, font->FontSize, ImVec2(GetWindowWidth() - margin - text_size.x, position_y), color, (text)); \
 		position_y += text_size.y + spacing; \
 	} while (0)
 	// TODO - icon list that would be nice to add

--- a/pcsx2/USB/usb-lightgun/guncon2.cpp
+++ b/pcsx2/USB/usb-lightgun/guncon2.cpp
@@ -536,14 +536,19 @@ namespace usb_lightgun
 				ImGuiManager::ClearSoftwareCursor(prev_pointer_index);
 
 			// Pointer changed, so need to update software cursor.
-			if (!cursor_path.empty())
-				ImGuiManager::SetSoftwareCursor(new_pointer_index, cursor_path, cursor_scale, cursor_color);
-			else if (!s->cursor_path.empty())
-				ImGuiManager::ClearSoftwareCursor(new_pointer_index);
-
+			const bool had_software_cursor = !s->cursor_path.empty();
 			s->cursor_path = std::move(cursor_path);
 			s->cursor_scale = cursor_scale;
 			s->cursor_color = cursor_color;
+			if (!s->cursor_path.empty())
+			{
+				ImGuiManager::SetSoftwareCursor(new_pointer_index, s->cursor_path, s->cursor_scale, s->cursor_color);
+				s->UpdateSoftwarePointerPosition();
+			}
+			else if (had_software_cursor)
+			{
+				ImGuiManager::ClearSoftwareCursor(new_pointer_index);
+			}
 		}
 	}
 


### PR DESCRIPTION
### Description of Changes

Also fixes it showing the cursor in the top-left instead of the middle, before the first position update comes in.

### Rationale behind Changes

It wasn't usable without a windowed switch before.

### Suggested Testing Steps

Test relative mode in GunCon2 with start windowed and fullscreen.
