### PR TITLE
GS/HW: Allow double clear when base is lowest bitsize denominator

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -5518,7 +5518,7 @@ bool GSRendererHW::DetectDoubleHalfClear(bool& no_rt, bool& no_ds)
 	const bool clear_depth = (m_cached_ctx.FRAME.FBP > m_cached_ctx.ZBUF.ZBP);
 	const u32 base = clear_depth ? m_cached_ctx.ZBUF.ZBP : m_cached_ctx.FRAME.FBP;
 	const u32 half = clear_depth ? m_cached_ctx.FRAME.FBP : m_cached_ctx.ZBUF.ZBP;
-
+	const bool enough_bits = clear_depth ? (frame_psm.trbpp >= zbuf_psm.trbpp) : (zbuf_psm.trbpp >= frame_psm.trbpp);
 	// Size of the current draw
 	const u32 w_pages = (m_r.z + (frame_psm.pgs.x - 1)) / frame_psm.pgs.x;
 	const u32 h_pages = (m_r.w + (frame_psm.pgs.y - 1)) / frame_psm.pgs.y;
@@ -5532,7 +5532,7 @@ bool GSRendererHW::DetectDoubleHalfClear(bool& no_rt, bool& no_ds)
 	// GTA: LCS does this setup, along with a few other games. Thankfully if it's a zero clear, we'll clear both
 	// separately, and the end result is the same because it gets invalidated. That's better than falsely detecting
 	// double half clears, and ending up with 1024 high render targets which really shouldn't be.
-	if ((frame_psm.fmt != zbuf_psm.fmt && m_cached_ctx.FRAME.FBMSK != ((zbuf_psm.fmt == 1) ? 0xFF000000u : 0)) ||
+	if ((!enough_bits && frame_psm.fmt != zbuf_psm.fmt && m_cached_ctx.FRAME.FBMSK != ((zbuf_psm.fmt == 1) ? 0xFF000000u : 0)) ||
 		!GSUtil::HasCompatibleBits(m_cached_ctx.FRAME.PSM & ~0x30, m_cached_ctx.ZBUF.PSM & ~0x30)) // Bit depth is not the same (i.e. 32bit + 16bit).
 	{
 		GL_INS("Inconsistent FRAME [%s, %08x] and ZBUF [%s] formats, not using double-half clear.",


### PR DESCRIPTION
### Description of Changes
Changes the Double Half Clear code to use the first part format as the "master" format, so for example if the bit depth is 24, and the second half is 32bit, this works fine, but not the other way around as the base needs 32bits.

~~Also added a GSC pass for the depth clear to fix up an issue the hardware renderer can't handle in Tiger Woods 2002~~

### Rationale behind Changes
Spiderman - Web of Shadows was clearing the Z with this double half clear but using different bit depths for some reason, when the Z is only 24 bit in this game anyway.

~~the Tiger Woods 2002 situation is an annoying one I'm calling a "flipped clear", as the game only uses the Z on the menu for drawing Tiger Woods, which is 256x512, but then when it clears it, it does 512x256, which our hardware renderer doesn't understand correctly and only clears the top half of the buffer, making it wider in the process, so I added a pass to clear the whole buffer, Tiger was missing the bottom half of his body due to it comparing to the old depth value.~~

### Suggested Testing Steps
Test ~~Tiger Woods 2002 and~~ Spiderman - Web of Shadows (have already checked with GS dumps).

~~If there are more Tiger Woods games which do this, let me know, and I should be able to add them, I tried to keep it generic.~~
Edit: Tiger Woods 2002 has a better fix in the form of #9745 I just didn't realise it fixed it as I didn't have a GS dump before.

Spiderman - Web of Shadows:
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/72d68716-649f-4e74-970b-0c1c3b74a791)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/13999522-3408-4841-a1b3-efa6804b1d38)


