### PR TITLE
GS/HW: Regression fixes and GIF Fix for Puzzle Quest/Motocross Mania 3

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -2339,13 +2339,20 @@ void GSRendererHW::Draw()
 	if (process_texture)
 	{
 		GIFRegCLAMP MIP_CLAMP = m_cached_ctx.CLAMP;
-		const u32 draw_end = GSLocalMemory::GetEndBlockAddress(m_cached_ctx.FRAME.Block(), m_cached_ctx.FRAME.FBW, m_cached_ctx.FRAME.PSM, m_r)+1;
-		const bool draw_uses_target = src->m_from_target && ((src->m_from_target_TEX0.TBP0 <= m_cached_ctx.FRAME.Block() && 
-									src->m_from_target->UnwrappedEndBlock() > m_cached_ctx.FRAME.Block()) || 
-									(m_cached_ctx.FRAME.Block() < src->m_from_target_TEX0.TBP0 && draw_end > src->m_from_target_TEX0.TBP0));
-		
+		const GSVertex* v = &m_vertex.buff[0];
+
 		if (rt)
 		{
+			// Hypothesis: texture shuffle is used as a postprocessing effect so texture will be an old target.
+			// Initially code also tested the RT but it gives too much false-positive
+			const int first_x = (v[0].XYZ.X + 8) >> 4;
+			const int first_u = PRIM->FST ? ((v[0].U + 8) >> 4) : static_cast<int>(((1 << m_cached_ctx.TEX0.TW) * (v[0].ST.S / v[1].RGBAQ.Q)) + 0.5f);
+			const bool shuffle_coords = (first_x ^ first_u) & 8;
+			const u32 draw_end = GSLocalMemory::GetEndBlockAddress(m_cached_ctx.FRAME.Block(), m_cached_ctx.FRAME.FBW, m_cached_ctx.FRAME.PSM, m_r) + 1;
+			const bool draw_uses_target = src->m_from_target && ((src->m_from_target_TEX0.TBP0 <= m_cached_ctx.FRAME.Block() &&
+				src->m_from_target->UnwrappedEndBlock() > m_cached_ctx.FRAME.Block()) ||
+				(m_cached_ctx.FRAME.Block() < src->m_from_target_TEX0.TBP0 && draw_end > src->m_from_target_TEX0.TBP0));
+
 			// copy of a 16bit source in to this target, make sure it's opaque and not bilinear to reduce false positives.
 			m_copy_16bit_to_target_shuffle = m_cached_ctx.TEX0.TBP0 != m_cached_ctx.FRAME.Block() && rt->m_32_bits_fmt == true && IsOpaque()
 											&& !(context->TEX1.MMIN & 1) && !src->m_32_bits_fmt && m_cached_ctx.FRAME.FBMSK;
@@ -2353,22 +2360,13 @@ void GSRendererHW::Draw()
 			// It's not actually possible to do a C16->C16 texture shuffle of B to A as they are the same group
 			// However you can do it by using C32 and offsetting the target verticies to point to B A, then mask as appropriate.
 			m_same_group_texture_shuffle = draw_uses_target && (m_cached_ctx.TEX0.PSM & 0xE) == PSMCT32 && (m_cached_ctx.FRAME.PSM & 0x7) == PSMCT16 && (m_vt.m_min.p.x == 8.0f);
-		}
-		const GSVertex* v = &m_vertex.buff[0];
-		// Hypothesis: texture shuffle is used as a postprocessing effect so texture will be an old target.
-		// Initially code also tested the RT but it gives too much false-positive
-		const int first_x = (v[0].XYZ.X + 8) >> 4;
-		const int first_u = PRIM->FST ? ((v[0].U + 8) >> 4) : static_cast<int>(((1 << m_cached_ctx.TEX0.TW) * (v[0].ST.S / v[1].RGBAQ.Q)) + 0.5f);
-		const bool shuffle_coords = (first_x ^ first_u) & 8;
-		// Both input and output are 16 bits and texture was initially 32 bits! Same for the target, Sonic Unleash makes a new target which really is 16bit.
-		m_texture_shuffle = ((m_same_group_texture_shuffle || (tex_psm.bpp == 16)) && (GSLocalMemory::m_psm[m_cached_ctx.FRAME.PSM].bpp == 16) &&
-			(shuffle_coords || rt->m_32_bits_fmt))
-			&& draw_sprite_tex && (src->m_32_bits_fmt || m_copy_16bit_to_target_shuffle);
-	/*	const bool old_shuffle = ((m_same_group_texture_shuffle || (tex_psm.bpp == 16)) && (GSLocalMemory::m_psm[m_cached_ctx.FRAME.PSM].bpp == 16))
-			&& draw_sprite_tex && (src->m_32_bits_fmt || m_copy_16bit_to_target_shuffle);
 
-		if (old_shuffle && !m_texture_shuffle)
-			DevCon.Warning("Here draw %d", s_n);*/
+			// Both input and output are 16 bits and texture was initially 32 bits! Same for the target, Sonic Unleash makes a new target which really is 16bit.
+			m_texture_shuffle = ((m_same_group_texture_shuffle || (tex_psm.bpp == 16)) && (GSLocalMemory::m_psm[m_cached_ctx.FRAME.PSM].bpp == 16) &&
+				(shuffle_coords || rt->m_32_bits_fmt))
+				&& draw_sprite_tex && (src->m_32_bits_fmt || m_copy_16bit_to_target_shuffle);
+		};
+
 		// Okami mustn't call this code
 		if (m_texture_shuffle && m_vertex.next < 3 && PRIM->FST && ((m_cached_ctx.FRAME.FBMSK & fm_mask) == 0))
 		{

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -2573,7 +2573,7 @@ void GSRendererHW::Draw()
 		// We need to adjust the size if it's a texture shuffle as we could end up making the RT twice the size.
 		if (rt && m_texture_shuffle && m_split_texture_shuffle_pages == 0)
 		{
-			if (new_size.x > rt->m_valid.z || new_size.y > rt->m_valid.w)
+			if ((new_size.x > rt->m_valid.z && m_vt.m_max.p.x == new_size.x) || (new_size.y > rt->m_valid.w && m_vt.m_max.p.y == new_size.y))
 			{
 				if (new_size.y <= rt->m_valid.w && (rt->m_TEX0.TBW != m_cached_ctx.FRAME.FBW))
 					new_size.x /= 2;

--- a/pcsx2/Gif.cpp
+++ b/pcsx2/Gif.cpp
@@ -329,7 +329,7 @@ static u32 WRITERING_DMA(u32* pMem, u32 qwc)
 		// so we can get away with transferring "most" of it when it's a big packet.
 		// Use Wallace and Gromit Project Zoo or The Suffering for testing
 		if (qwc > 64)
-			qwc = qwc - 64;
+			qwc = qwc * 0.5f;
 		else
 			qwc = std::min(qwc, 8u);
 	}


### PR DESCRIPTION
### Description of Changes
Stops it halfing the height on a shuffle by accident.
Fixes problem where it could try and read a null RT
Adjusted how GIF Intermittent packets split.

### Rationale behind Changes
Was too horny with the halving, so in some cases the actual size got halved, not just the doubled shuffle size.
Regression from #9745
null RT was possible if there was no RT but it was still reading a texture, possibly in an Alpha tested Z write situation.
Adjusted GIF intermittent packet timing to be a bit kinder to games without sacrificing speed.

### Suggested Testing Steps
Test Onimusha 3, Wallace & Gromit Project Zoo, Puzzle Quest, Motocross Mania 3. Make sure nothing is broken.

Fixes #6733 Puzzle Quest flickering graphics
Fixes Motocross Mania 3 flickering textures
Fixes Onimusha 3 bad height on shuffle, plus some invisible bad height changes in Haunting Ground and Sniper Elite.

Onimusha 3:
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/a5bf129a-a050-48ec-afc3-e2f21ca81415)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/2a7bca41-a7e1-4eeb-af4d-215ec515c037)

Motocross Mania 3:

Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/7dcc58c4-c278-4308-8be1-6498c9d52acf)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/64eeea43-838c-48b3-a15d-2b4bc67cd2ae)

Puzzle Quest:
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/af34ab6e-5d82-40e5-b1ea-045707f02694)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/815a0c01-09f4-43e2-95fc-7610e5907414)
