### PR TITLE
Qt: Fix arrow key handling on macOS

### DIFF
--- a/pcsx2-qt/QtKeyCodes.cpp
+++ b/pcsx2-qt/QtKeyCodes.cpp
@@ -513,5 +513,22 @@ std::optional<std::string> InputManager::ConvertHostKeyboardCodeToString(u32 cod
 
 u32 QtUtils::KeyEventToCode(const QKeyEvent* ev)
 {
-	return static_cast<u32>(ev->key()) | (static_cast<u32>(ev->modifiers()) & static_cast<u32>(Qt::KeypadModifier));
+	int key = ev->key();
+	Qt::KeyboardModifiers modifiers = ev->modifiers();
+
+#ifdef __APPLE__
+	// On macOS, Qt applies the Keypad modifier regardless of whether the arrow keys, or numpad was pressed.
+	// The only way to differentiate between the keypad and the arrow keys is by the text.
+	// Hopefully some keyboard layouts don't change the numpad positioning...
+	if (modifiers & Qt::KeypadModifier && key >= Qt::Key_Insert && key <= Qt::Key_PageDown)
+	{
+		if (ev->text().isEmpty())
+		{
+			// Drop the modifier, because it's probably not actually a numpad push.
+			modifiers &= ~Qt::KeypadModifier;
+		}
+	}
+#endif
+
+	return static_cast<u32>(key) | (static_cast<u32>(modifiers) & static_cast<u32>(Qt::KeypadModifier));
 }


### PR DESCRIPTION
### Description of Changes

On macOS, Qt applies the Keypad modifier regardless of whether the arrow keys, or numpad was pressed.
The only way to differentiate between the keypad and the arrow keys is by the text.

### Rationale behind Changes

Fixes #8690.

### Suggested Testing Steps

Test key mapping in MacOS.
