### PR TITLE
USB-Turntable: Default multiplier to 1

### DIFF
--- a/pcsx2/USB/usb-pad/usb-turntable.cpp
+++ b/pcsx2/USB/usb-pad/usb-turntable.cpp
@@ -479,7 +479,7 @@ namespace usb_pad
 		static constexpr const SettingInfo info[] = {
 			{SettingInfo::Type::Float, "TurntableMultiplier", TRANSLATE_NOOP("USB", "Turntable Multiplier"),
 				TRANSLATE_NOOP("USB", "Apply a multiplier to the turntable"),
-				"0.00", "0.00", "100.0", "1.0", "%.0fx", nullptr, nullptr, 1.0f}};
+				"1.00", "0.00", "100.0", "1.0", "%.0fx", nullptr, nullptr, 1.0f}};
 
 		return info;
 	}


### PR DESCRIPTION
### Description of Changes
I've noted that I must have accidentally set the multiplier to 0 by default instead of 1, which means that the turntable velocity would have just been zeroed out by default

### Rationale behind Changes
By default one would expect the turntable to work

### Suggested Testing Steps
Set up a turntable, note that it is defaulted to 1.
