### PR TITLE
[SAVEVERSION+] Remove old trigger deadzone references, replace with button deadzone

### DIFF
--- a/pcsx2/SIO/Pad/Pad.cpp
+++ b/pcsx2/SIO/Pad/Pad.cpp
@@ -109,11 +109,8 @@ void Pad::LoadConfig(const SettingsInterface& si)
 
 		const float axis_deadzone = si.GetFloatValue(section.c_str(), "Deadzone", Pad::DEFAULT_STICK_DEADZONE);
 		const float axis_scale = si.GetFloatValue(section.c_str(), "AxisScale", Pad::DEFAULT_STICK_SCALE);
-		const float trigger_deadzone = si.GetFloatValue(section.c_str(), "TriggerDeadzone", Pad::DEFAULT_TRIGGER_DEADZONE);
-		const float trigger_scale = si.GetFloatValue(section.c_str(), "TriggerScale", Pad::DEFAULT_TRIGGER_SCALE);
 		const float button_deadzone = si.GetFloatValue(section.c_str(), "ButtonDeadzone", Pad::DEFAULT_BUTTON_DEADZONE);
 		pad->SetAxisScale(axis_deadzone, axis_scale);
-		pad->SetTriggerScale(trigger_deadzone, trigger_scale);
 		pad->SetButtonDeadzone(button_deadzone);
 
 		if (ci->vibration_caps != Pad::VibrationCapabilities::NoVibration)

--- a/pcsx2/SIO/Pad/PadBase.h
+++ b/pcsx2/SIO/Pad/PadBase.h
@@ -45,7 +45,6 @@ public: // Public members
 	virtual void Set(u32 index, float value) = 0;
 	virtual void SetRawAnalogs(const std::tuple<u8, u8> left, const std::tuple<u8, u8> right) = 0;
 	virtual void SetAxisScale(float deadzone, float scale) = 0;
-	virtual void SetTriggerScale(float deadzone, float scale) = 0;
 	virtual float GetVibrationScale(u32 motor) const = 0;
 	virtual void SetVibrationScale(u32 motor, float scale) = 0;
 	virtual float GetPressureModifier() const = 0;

--- a/pcsx2/SIO/Pad/PadDualshock2.cpp
+++ b/pcsx2/SIO/Pad/PadDualshock2.cpp
@@ -639,8 +639,8 @@ void PadDualshock2::Set(u32 index, float value)
 	}
 	else if (IsTriggerKey(index))
 	{
-		const float s_value = std::clamp(value * this->triggerScale, 0.0f, 1.0f);
-		const float dz_value = (this->triggerDeadzone > 0.0f && s_value < this->triggerDeadzone) ? 0.0f : s_value;
+		const float s_value = std::clamp(value, 0.0f, 1.0f);
+		const float dz_value = (this->buttonDeadzone > 0.0f && s_value < this->buttonDeadzone) ? 0.0f : s_value;
 		this->rawInputs[index] = static_cast<u8>(dz_value * 255.0f);
 		if (dz_value > 0.0f)
 			this->buttons &= ~(1u << bitmaskMapping[index]);
@@ -725,12 +725,6 @@ void PadDualshock2::SetAxisScale(float deadzone, float scale)
 {
 	this->axisDeadzone = deadzone;
 	this->axisScale = scale;
-}
-
-void PadDualshock2::SetTriggerScale(float deadzone, float scale)
-{
-	this->triggerDeadzone = deadzone;
-	this->triggerScale = scale;
 }
 
 float PadDualshock2::GetVibrationScale(u32 motor) const
@@ -828,8 +822,6 @@ bool PadDualshock2::Freeze(StateWrapper& sw)
 	sw.Do(&vibrationMotors);
 	sw.Do(&axisScale);
 	sw.Do(&axisDeadzone);
-	sw.Do(&triggerScale);
-	sw.Do(&triggerDeadzone);
 	sw.Do(&vibrationScale);
 	sw.Do(&pressureModifier);
 	sw.Do(&buttonDeadzone);

--- a/pcsx2/SIO/Pad/PadDualshock2.h
+++ b/pcsx2/SIO/Pad/PadDualshock2.h
@@ -88,8 +88,6 @@ private:
 	std::array<u8, VIBRATION_MOTORS> vibrationMotors;
 	float axisScale;
 	float axisDeadzone;
-	float triggerScale;
-	float triggerDeadzone;
 	std::array<float, 2> vibrationScale;
 	// When the pressure modifier binding is activated, this is multiplied against
 	// all values in pressures, to artificially reduce pressures and give players
@@ -133,7 +131,6 @@ public:
 	void Set(u32 index, float value) override;
 	void SetRawAnalogs(const std::tuple<u8, u8> left, const std::tuple<u8, u8> right) override;
 	void SetAxisScale(float deadzone, float scale) override;
-	void SetTriggerScale(float deadzone, float scale) override;
 	float GetVibrationScale(u32 motor) const override;
 	void SetVibrationScale(u32 motor, float scale) override;
 	float GetPressureModifier() const override;

--- a/pcsx2/SIO/Pad/PadGuitar.cpp
+++ b/pcsx2/SIO/Pad/PadGuitar.cpp
@@ -337,11 +337,6 @@ void PadGuitar::SetAxisScale(float deadzone, float scale)
 	this->whammyAxisScale = scale;
 }
 
-void PadGuitar::SetTriggerScale(float deadzone, float scale)
-{
-
-}
-
 float PadGuitar::GetVibrationScale(u32 motor) const
 {
 	return 0;

--- a/pcsx2/SIO/Pad/PadGuitar.h
+++ b/pcsx2/SIO/Pad/PadGuitar.h
@@ -70,7 +70,6 @@ public:
 	void Set(u32 index, float value) override;
 	void SetRawAnalogs(const std::tuple<u8, u8> left, const std::tuple<u8, u8> right) override;
 	void SetAxisScale(float deadzone, float scale) override;
-	void SetTriggerScale(float deadzone, float scale) override;
 	float GetVibrationScale(u32 motor) const override;
 	void SetVibrationScale(u32 motor, float scale) override;
 	float GetPressureModifier() const override;

--- a/pcsx2/SIO/Pad/PadNotConnected.cpp
+++ b/pcsx2/SIO/Pad/PadNotConnected.cpp
@@ -60,11 +60,6 @@ void PadNotConnected::SetAxisScale(float deadzone, float scale)
 
 }
 
-void PadNotConnected::SetTriggerScale(float deadzone, float scale)
-{
-
-}
-
 float PadNotConnected::GetVibrationScale(u32 motor) const
 {
 	return 0;

--- a/pcsx2/SIO/Pad/PadNotConnected.h
+++ b/pcsx2/SIO/Pad/PadNotConnected.h
@@ -29,7 +29,6 @@ public:
 	void Set(u32 index, float value) override;
 	void SetRawAnalogs(const std::tuple<u8, u8> left, const std::tuple<u8, u8> right) override;
 	void SetAxisScale(float deadzone, float scale) override;
-	void SetTriggerScale(float deadzone, float scale) override;
 	float GetVibrationScale(u32 motor) const override;
 	void SetVibrationScale(u32 motor, float scale) override;
 	float GetPressureModifier() const override;

--- a/pcsx2/SIO/Pad/PadTypes.h
+++ b/pcsx2/SIO/Pad/PadTypes.h
@@ -109,8 +109,6 @@ namespace Pad
 	// Default stick deadzone/sensitivity.
 	static constexpr float DEFAULT_STICK_DEADZONE = 0.0f;
 	static constexpr float DEFAULT_STICK_SCALE = 1.33f;
-	static constexpr float DEFAULT_TRIGGER_DEADZONE = 0.0f;
-	static constexpr float DEFAULT_TRIGGER_SCALE = 1.0f;
 	static constexpr float DEFAULT_MOTOR_SCALE = 1.0f;
 	static constexpr float DEFAULT_PRESSURE_MODIFIER = 0.5f;
 	static constexpr float DEFAULT_BUTTON_DEADZONE = 0.0f;

--- a/pcsx2/SaveState.h
+++ b/pcsx2/SaveState.h
@@ -37,7 +37,7 @@ enum class FreezeAction
 // [SAVEVERSION+]
 // This informs the auto updater that the users savestates will be invalidated.
 
-static const u32 g_SaveVersion = (0x9A3C << 16) | 0x0000;
+static const u32 g_SaveVersion = (0x9A3D << 16) | 0x0000;
 
 
 // the freezing data between submodules and core


### PR DESCRIPTION

### Description of Changes
Switches triggers to use the normal button deadzone value. They were left behind after the old separate trigger deadzone UI option was removed. 

### Rationale behind Changes
Fixes #9744, button deadzones will work again for triggers.

### Suggested Testing Steps
Boot the pad tester elf, test that the triggers now respect deadzone.
