### PR TITLE
gitignore: Don't include TXT files generated by crash dumps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ Thumbs.db
 Debug.txt
 install_log.txt
 bad_shader_*
+crash-*.txt
 
 Debug
 Release


### PR DESCRIPTION
### Description of Changes
Don't include txt files that are generated when PCSX2 crashes as part of git changes.

### Rationale behind Changes
Cleanliness, stop Git from being annoying

### Suggested Testing Steps
N/A
