### PR TITLE
GS/DX11: Commit clear before clearing stencil

### DIFF
--- a/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
@@ -1776,6 +1776,9 @@ void GSDevice11::SetupDATE(GSTexture* rt, GSTexture* ds, const GSVertexPT1* vert
 {
 	// sfex3 (after the capcom logo), vf4 (first menu fading in), ffxii shadows, rumble roses shadows, persona4 shadows
 
+	CommitClear(rt);
+	CommitClear(ds);
+
 	m_ctx->ClearDepthStencilView(*static_cast<GSTexture11*>(ds), D3D11_CLEAR_STENCIL, 0.0f, 0);
 
 	// om


### PR DESCRIPTION
### Description of Changes

Saw this when checking #9787. Stops the discard happening later, and blowing away the cleared value.

### Rationale behind Changes

Doesn't fix the actual issue (it needs autoflush+copies for DX, slowwww), but stops us reading undefined data, which is never good.

### Suggested Testing Steps

Smoke test. Didn't bother with a dump run, because DX is unreliable there on NV.
