### PR TITLE
GameDB: Various Fixes

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -1910,7 +1910,7 @@ SCAJ-25037:
   roundModes:
     eeRoundMode: 0 # Fixes character behaviour.
   gsHWFixes:
-    autoFlush: 2 # Fixes flame bloom.
+    autoFlush: 1 # Fixes flame bloom.
     halfPixelOffset: 2 # Fixes misaligned bloom.
 SCAJ-25045:
   name: "Sakura Taisen V - Episode 0"
@@ -10725,7 +10725,7 @@ SLAJ-25037:
   roundModes:
     eeRoundMode: 0 # Fixes character behaviour.
   gsHWFixes:
-    autoFlush: 2 # Fixes flame bloom.
+    autoFlush: 1 # Fixes flame bloom.
     halfPixelOffset: 2 # Fixes misaligned bloom.
 SLAJ-25039:
   name: "Beni no Umi 2"
@@ -17299,7 +17299,7 @@ SLES-52486:
   roundModes:
     eeRoundMode: 0 # Fixes character behaviour.
   gsHWFixes:
-    autoFlush: 2 # Fixes flame bloom.
+    autoFlush: 1 # Fixes flame bloom.
     halfPixelOffset: 2 # Fixes misaligned bloom.
 SLES-52490:
   name: "Dance UK - Extra Trax"
@@ -24669,8 +24669,11 @@ SLES-55170:
 SLES-55172:
   name: "Code Lyoko - Quest for Infinity"
   region: "PAL-M4"
+  gameFixes:
+    - FpuNegDivHack # Fixes missing texts on in-game textboxes.
   gsHWFixes:
     deinterlace: 9 # Game requires adaptive bff de-interlacing instead of auto for the UI at native.
+    halfPixelOffset: 1 # Reduces ghosting effects.
 SLES-55174:
   name: "NHL 08"
   region: "PAL-R"
@@ -26816,7 +26819,7 @@ SLKA-25159:
   roundModes:
     eeRoundMode: 0 # Fixes character behaviour.
   gsHWFixes:
-    autoFlush: 2 # Fixes flame bloom.
+    autoFlush: 1 # Fixes flame bloom.
     halfPixelOffset: 2 # Fixes misaligned bloom.
 SLKA-25160:
   name: "Shin Megami Tensei III - Nocturne Maniax"
@@ -34465,7 +34468,7 @@ SLPM-65551:
   roundModes:
     eeRoundMode: 0 # Fixes character behaviour.
   gsHWFixes:
-    autoFlush: 2 # Fixes flame bloom.
+    autoFlush: 1 # Fixes flame bloom.
     halfPixelOffset: 2 # Fixes misaligned bloom.
 SLPM-65552:
   name: "Metal Wolf Rev [Limited Edition]"
@@ -51157,7 +51160,7 @@ SLUS-20867:
   roundModes:
     eeRoundMode: 0 # Fixes character behaviour.
   gsHWFixes:
-    autoFlush: 2 # Fixes flame bloom.
+    autoFlush: 1 # Fixes flame bloom.
     halfPixelOffset: 2 # Fixes misaligned bloom.
 SLUS-20868:
   name: "MVP Baseball 2004"
@@ -55953,8 +55956,11 @@ SLUS-21743:
   name: "Code Lyoko - Quest for Infinity"
   region: "NTSC-U"
   compat: 5
+  gameFixes:
+    - FpuNegDivHack # Fixes missing texts on in-game textboxes.
   gsHWFixes:
     deinterlace: 9 # Game requires adaptive bff de-interlacing instead of auto for the UI at native.
+    halfPixelOffset: 1 # Reduces ghosting effects.
 SLUS-21744:
   name: "NASCAR '09"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
This PR enables `FPU Negative Divide Hack` for Code Lyoko - Quest For Infinity which fixes missing texts on the in-game text box.

In addition it also changes Astro Boy's autoflush to Sprite Only as the fix also works with it.

Before:
![Code Lyoko - Quest for Infinity_SLUS-21743_20230814134819](https://github.com/PCSX2/pcsx2/assets/14798312/848c8bb7-6a1e-4c0e-b9f4-96e945d06168)

After:
![Code Lyoko - Quest for Infinity_SLUS-21743_20230814134833](https://github.com/PCSX2/pcsx2/assets/14798312/b1c63ee9-e856-4d55-bbe2-5d4d65261dbb)

also added HPO Normal  which  fixes the ghosting effects due to upscaling.

Before:
![Code Lyoko - Quest for Infinity_SLUS-21743_20230814134951](https://github.com/PCSX2/pcsx2/assets/14798312/6321b4d8-16bc-4c21-a7e4-41203af17786)


After:
![Code Lyoko - Quest for Infinity_SLUS-21743_20230814145838](https://github.com/PCSX2/pcsx2/assets/14798312/5f0cc713-9c1f-4fae-bce9-d59a2b9e92a1)


Fixes #9790 

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Missing Text is a no no

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Check if the text appears correctly and no other stuff breaks, I've tested several level and nothing seems to break.
