### PR TITLE
GS/TC: Don't allow tex is rt for PSMT8 on 16bit targets

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -1006,13 +1006,23 @@ GSTextureCache::Source* GSTextureCache::LookupSource(const GIFRegTEX0& TEX0, con
 							}
 						}
 						else
-							dst = t;
+						{
+							// We don't have a shader for this.
+							if (!possible_shuffle && TEX0.PSM == PSMT8 && GSLocalMemory::m_psm[t->m_TEX0.PSM].bpp != 32)
+							{
+								continue;
+							}
+							else
+							{
+								dst = t;
 
-						found_t = true;
-						tex_merge_rt = false;
-						x_offset = 0;
-						y_offset = 0;
-						break;
+								found_t = true;
+								tex_merge_rt = false;
+								x_offset = 0;
+								y_offset = 0;
+								break;
+							}
+						}
 					}
 				}
 				else if (t_clean && (t->m_TEX0.TBW >= 16) && GSUtil::HasSharedBits(bp, psm, t->m_TEX0.TBP0 + t->m_TEX0.TBW * 0x10, t->m_TEX0.PSM))
@@ -1242,7 +1252,12 @@ GSTextureCache::Source* GSTextureCache::LookupSource(const GIFRegTEX0& TEX0, con
 					}
 					else
 					{
-						return LookupDepthSource(TEX0, TEXA, CLAMP, r, possible_shuffle, linear, frame_fbp, true);
+						if (!possible_shuffle && TEX0.PSM == PSMT8 && GSLocalMemory::m_psm[t->m_TEX0.PSM].bpp != 32)
+						{
+							continue;
+						}
+						else
+							return LookupDepthSource(TEX0, TEXA, CLAMP, r, possible_shuffle, linear, frame_fbp, true);
 					}
 				}
 			}


### PR DESCRIPTION
### Description of Changes
Disallow the use/conversion of 16bit targets to PSMT8

### Rationale behind Changes
The swizzle for these is not something the hardware renderer supports and the likelihood is the data it wants is actually coming from memory. In the case of Armored Core it was uploading the indexed texture in to the start of the Z buffer, a part which wasn't being used, and this was confusing the hardware renderer.

### Suggested Testing Steps
Test Armored Core Nexux shop parts screen + smoke test, confirmed GS Dump works.

Fixes #9799

Armored Core Nexus:
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/5f86469b-4135-4094-8c73-203a1cf6cccf)

PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/85dcbdcc-41d0-499b-b82b-b6cb3306645d)
