### PR TITLE
GameDB: Add VU0 clamping to Naruto Ultimate Ninja 5 (Accel 2)

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -25694,6 +25694,7 @@ SLES-55605:
     halfPixelOffset: 1 # Corrects post processing position.
     cpuCLUTRender: 1 # Reduces the bloomy blur of characters.
   clampModes:
+    vu0ClampMode: 3 # Fixes bad dialog backgrounds.
     vu1ClampMode: 3 # Fixes SPS on characters.
 SLES-55609:
   name: "Scooby-Doo! and the Spooky Swamp"
@@ -40454,6 +40455,7 @@ SLPM-68019:
     halfPixelOffset: 1 # Corrects post processing position.
     cpuCLUTRender: 1 # Reduces the bloomy blur of characters.
   clampModes:
+    vu0ClampMode: 3 # Fixes bad dialog backgrounds.
     vu1ClampMode: 3 # Fixes SPS on characters.
 SLPM-68020:
   name: "Suzumiya Haruhi no Tomadoi - Uchuu-hatsu! Full CG - Odoru SOS-dan (Chou Eizou-ban)"
@@ -45904,6 +45906,7 @@ SLPS-25837:
     halfPixelOffset: 1 # Corrects post processing position.
     cpuCLUTRender: 1 # Reduces the bloomy blur of characters.
   clampModes:
+    vu0ClampMode: 3 # Fixes bad dialog backgrounds.
     vu1ClampMode: 3 # Fixes SPS on characters.
 SLPS-25838:
   name: "Taiheiyou no Arashi - Senkan Yamato, Akatsuki ni Shutsugeki su"


### PR DESCRIPTION
### Description of Changes
Adds VU0 clamping to solve dialogue background problems

### Rationale behind Changes
They were broken

### Suggested Testing Steps
Watch CI, game already tested

Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/0d8b9f8f-859a-45bd-8451-62aa81fe8253)

PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/72bde111-3b96-4eae-b6fd-9f2b2fb89ee2)
