### PR TITLE
GS/Vulkan: Avoid incorrect-layout RT descriptor

### DIFF
--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
@@ -5638,6 +5638,10 @@ void GSDeviceVK::RenderHW(GSHWDrawConfig& config)
 	{
 		pxAssertMsg(m_features.texture_barrier, "Texture barriers enabled");
 		PSSetShaderResource(2, draw_rt, false);
+
+		// If this is the first draw to the target as a feedback loop, make sure we re-generate the texture descriptor.
+		// Otherwise, we might have a previous descriptor left over, that has the RT in a different state.
+		m_dirty_flags |= (skip_first_barrier ? DIRTY_FLAG_TFX_TEXTURE_RT : 0);
 	}
 
 	// Begin render pass if new target or out of the area.


### PR DESCRIPTION
### Description of Changes

If this is the first draw to the target as a feedback loop, make sure we re-generate the texture descriptor.
Otherwise, we might have a previous descriptor left over, that has the RT in a different state.

### Rationale behind Changes

Happens in Dragon Quest 8.

### Suggested Testing Steps

Smoke test, dump runner says it's okay.
