### PR TITLE
Pad: Only consider LSB for small motor vibration

### DIFF
--- a/pcsx2/SIO/Pad/PadDualshock2.cpp
+++ b/pcsx2/SIO/Pad/PadDualshock2.cpp
@@ -166,13 +166,16 @@ u8 PadDualshock2::Poll(u8 commandByte)
 					break;
 			}
 
+			// Small motor on the controller is only controlled by the LSB.
+			// Any value can be sent by the software, but only odd numbers
+			// (LSB set) will turn on the motor.
 			switch (this->smallMotorLastConfig)
 			{
 				case 0x00:
-					smallMotor = this->vibrationMotors[0];
+					smallMotor = this->vibrationMotors[0] & 0x01;
 					break;
 				case 0x01:
-					smallMotor = this->vibrationMotors[1];
+					smallMotor = this->vibrationMotors[1] & 0x01;
 					break;
 				default:
 					break;


### PR DESCRIPTION
### Description of Changes
Fixes #9796. Changes small vibration motor to only turn on if LSB is set in the value it was given.

### Rationale behind Changes
Hardware tested. Motor only engages if turned on using a value with LSB set, aka any odd number. Fixes idiotic games like Resident Evil 4, which send 0x02 to the small motor during cutscenes.

### Suggested Testing Steps
* Let Resident Evil 4 boot and idle at the main menu, cutscene will start playing, verify controller does not rumble.
* Try other games known to use the small motor, make sure the motor still turns on when expected.