### PR TITLE
Debugger: Properly initialize primitive class members

### DIFF
--- a/pcsx2-qt/Debugger/MemoryViewWidget.cpp
+++ b/pcsx2-qt/Debugger/MemoryViewWidget.cpp
@@ -377,7 +377,11 @@ void MemoryViewWidget::customMenuRequested(QPoint pos)
 	{
 		m_contextMenu = new QMenu(this);
 
-		QAction* action = new QAction(tr("Go to in disassembly"));
+		QAction* action = new QAction(tr("Copy Address"));
+		m_contextMenu->addAction(action);
+		connect(action, &QAction::triggered, this, [this]() { QApplication::clipboard()->setText(QString::number(m_table.selectedAddress, 16).toUpper()); });
+
+		action = new QAction(tr("Go to in disassembly"));
 		m_contextMenu->addAction(action);
 		connect(action, &QAction::triggered, this, [this]() { emit gotoInDisasm(m_table.selectedAddress); });
 

--- a/pcsx2-qt/Debugger/RegisterWidget.cpp
+++ b/pcsx2-qt/Debugger/RegisterWidget.cpp
@@ -231,7 +231,7 @@ void RegisterWidget::customMenuRequested(QPoint pos)
 	else
 		m_contextMenu->clear();
 
-	int categoryIndex = ui.registerTabs->currentIndex();
+	const int categoryIndex = ui.registerTabs->currentIndex();
 
 	QAction* action = 0;
 

--- a/pcsx2-qt/Debugger/RegisterWidget.h
+++ b/pcsx2-qt/Debugger/RegisterWidget.h
@@ -86,6 +86,6 @@ private:
 	s32 m_selected128Field = 0; // Values are from 0 to 3
 
 	// TODO: Save this configuration ??
-	bool m_showVU0FFloat;
-	bool m_showFPRFloat;
+	bool m_showVU0FFloat = false;
+	bool m_showFPRFloat = false;
 };


### PR DESCRIPTION
### Description of Changes
Initialize primitive class members that would otherwise be of unknown values 
Also implement the "Copy Address" context menu for the memory view
### Rationale behind Changes
It's my best idea to fix the indeterminate behaviour causing #9813

### Suggested Testing Steps
Try the FPR and VU0 register "show as hex" context menu options.
