### PR TITLE
GameDB: Remove EE Round Mode from Armored Core 3 games

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -873,8 +873,6 @@ SCAJ-20010:
 SCAJ-20011:
   name: "Armored Core 3 - Silent Line"
   region: "NTSC-HK"
-  roundModes:
-    eeRoundMode: 0 # Fixes Z-Fighting.
   gsHWFixes:
     halfPixelOffset: 2 # Corrects positioning of reflections on suit's surfaces.
     partialTargetInvalidation: 1 # Fixes corrupted textures.
@@ -8286,8 +8284,6 @@ SCPS-55013:
 SCPS-55014:
   name: "Armored Core 3"
   region: "NTSC-J"
-  roundModes:
-    eeRoundMode: 0 # Fixes Z-Fighting.
   gsHWFixes:
     halfPixelOffset: 2 # Corrects positioning of reflections on suit's surfaces.
     roundSprite: 2 # Reduces garbage on the UI whilst upscaling.
@@ -15055,8 +15051,6 @@ SLES-51398:
 SLES-51399:
   name: "Armored Core 3"
   region: "PAL-E"
-  roundModes:
-    eeRoundMode: 0 # Fixes Z-Fighting.
   gsHWFixes:
     halfPixelOffset: 2 # Corrects positioning of reflections on suit's surfaces.
     roundSprite: 2 # Reduces garbage on the UI whilst upscaling.
@@ -16674,8 +16668,6 @@ SLES-52203:
   name: "Armored Core 3 - Silent Line"
   region: "PAL-E"
   compat: 5
-  roundModes:
-    eeRoundMode: 0 # Fixes Z-Fighting.
   gsHWFixes:
     halfPixelOffset: 2 # Corrects positioning of reflections on suit's surfaces.
     partialTargetInvalidation: 1 # Fixes corrupted textures.
@@ -26433,8 +26425,6 @@ SLKA-25039:
 SLKA-25041:
   name: "Armored Core 3 - Silent Line"
   region: "NTSC-K"
-  roundModes:
-    eeRoundMode: 0 # Fixes Z-Fighting.
   gsHWFixes:
     halfPixelOffset: 2 # Corrects positioning of reflections on suit's surfaces.
     partialTargetInvalidation: 1 # Fixes corrupted textures.
@@ -40367,8 +40357,6 @@ SLPM-67523:
 SLPM-67524:
   name: "Armored Core 3"
   region: "NTSC-K"
-  roundModes:
-    eeRoundMode: 0 # Fixes Z-Fighting.
   gsHWFixes:
     halfPixelOffset: 2 # Corrects positioning of reflections on suit's surfaces.
     roundSprite: 2 # Reduces garbage on the UI whilst upscaling.
@@ -43147,8 +43135,6 @@ SLPS-25112:
   name: "Armored Core 3"
   region: "NTSC-J"
   compat: 5
-  roundModes:
-    eeRoundMode: 0 # Fixes Z-Fighting.
   gsHWFixes:
     halfPixelOffset: 2 # Corrects positioning of reflections on suit's surfaces.
     roundSprite: 2 # Reduces garbage on the UI whilst upscaling.
@@ -43382,8 +43368,6 @@ SLPS-25168:
 SLPS-25169:
   name: "Armored Core 3 - Silent Line"
   region: "NTSC-J"
-  roundModes:
-    eeRoundMode: 0 # Fixes Z-Fighting.
   gsHWFixes:
     halfPixelOffset: 2 # Corrects positioning of reflections on suit's surfaces.
     partialTargetInvalidation: 1 # Fixes corrupted textures.
@@ -47084,8 +47068,6 @@ SLPS-73416:
 SLPS-73417:
   name: "Armored Core 3 [PlayStation 2 The Best]"
   region: "NTSC-J"
-  roundModes:
-    eeRoundMode: 0 # Fixes Z-Fighting.
   gsHWFixes:
     halfPixelOffset: 2 # Corrects positioning of reflections on suit's surfaces.
     roundSprite: 2 # Reduces garbage on the UI whilst upscaling.
@@ -47103,8 +47085,6 @@ SLPS-73419:
 SLPS-73420:
   name: "Armored Core 3 - Silent Line [PlayStation 2 The Best]"
   region: "NTSC-J"
-  roundModes:
-    eeRoundMode: 0 # Fixes Z-Fighting.
   gsHWFixes:
     halfPixelOffset: 2 # Corrects positioning of reflections on suit's surfaces.
     partialTargetInvalidation: 1 # Fixes corrupted textures.
@@ -49054,8 +49034,6 @@ SLUS-20434:
 SLUS-20435:
   name: "Armored Core 3"
   region: "NTSC-U"
-  roundModes:
-    eeRoundMode: 0 # Fixes Z-Fighting.
   gsHWFixes:
     halfPixelOffset: 2 # Corrects positioning of reflections on suit's surfaces.
     roundSprite: 2 # Reduces garbage on the UI whilst upscaling.
@@ -50117,8 +50095,6 @@ SLUS-20644:
   name: "Armored Core 3 - Silent Line"
   region: "NTSC-U"
   compat: 5
-  roundModes:
-    eeRoundMode: 0 # Fixes Z-Fighting.
   gsHWFixes:
     halfPixelOffset: 2 # Corrects positioning of reflections on suit's surfaces.
     partialTargetInvalidation: 1 # Fixes corrupted textures.


### PR DESCRIPTION
### Description of Changes
Removed EE Round Mode from Armored Core 3 and Armored Core Silent Line.

### Rationale behind Changes
Current master forces Nearest rounding to fix Z-fighting, but it causes below problems:
- In Armored Core 3, intro cutscene of "Disable Pulse Generator" mission gets glitched.
- In Armored Core Silent Line, vertical lasers get vanished in "Secure Fortress NK-432" mission.

Chop/Zero rounding doesn't cause them, but it gets Z-fighting come back, so #2398 might be reopened.

### Suggested Testing Steps
Test mentioned mission levels.
