### PR TITLE
GS/HW: Fix CRC hack for Growlanser V not checking for null

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSHwHack.cpp
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.cpp
@@ -1283,7 +1283,7 @@ static bool GetMoveTargetPair(GSRendererHW& r, GSTextureCache::Target** src, GIF
 		GSLocalMemory::m_psm[src_desc.PSM].depth ? GSTextureCache::DepthStencil : GSTextureCache::RenderTarget;
 	GSTextureCache::Target* tsrc =
 		g_texture_cache->LookupTarget(src_desc, GSVector2i(1, 1), r.GetTextureScaleFactor(), src_type);
-	if (!src)
+	if (!tsrc)
 		return false;
 
 	// The target might not.


### PR DESCRIPTION
### Description of Changes
Fixes missing null check on Growlanser CRC hack.

### Rationale behind Changes
wasn't checking if tsrc was null, then tried to use it.

### Suggested Testing Steps
Start a new game of Growlanser V, make sure it goes ingame.

Fixes #9827
