### PR TITLE
GameDB: Add EE timing fix to Gunfighter II

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -14764,6 +14764,7 @@ SLES-51289:
   compat: 5
   gameFixes:
     - GIFFIFOHack # Fixes flickering textures.
+    - EETimingHack # Further required to stop flickering.
 SLES-51290:
   name: "Sword of the Samurai"
   region: "PAL-E"


### PR DESCRIPTION
### Description of Changes
Adds EE Timing fix to Gunfighter II to help fix texture flickering.

### Rationale behind Changes
GIF FIFO is no longer enough.

### Suggested Testing Steps
Wait for CI To say it's okay, and wait for Sten to fix builds so libzip doesn't explode anymore.
