### PR TITLE
GS/HW: Don't rely on transfer rect size if target width changes

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -1634,26 +1634,9 @@ GSTextureCache::Target* GSTextureCache::LookupTarget(GIFRegTEX0 TEX0, const GSVe
 					}
 				}
 
-				if (can_use && !is_shuffle && preserve_alpha && preserve_rgb && !(GSLocalMemory::m_psm[TEX0.PSM].bpp == 16 && GSLocalMemory::m_psm[t->m_TEX0.PSM].bpp == 32) && TEX0.TBW != t->m_TEX0.TBW && t->m_dirty.size() >= 1 && !t->m_dirty.GetTotalRect(t->m_TEX0, t->m_unscaled_size).eq(t->m_valid))
+				if (can_use && !is_shuffle && preserve_alpha && preserve_rgb && TEX0.TBW != t->m_TEX0.TBW && t->m_dirty.size() >= 1)
 				{
-					std::vector<GSState::GSUploadQueue>::reverse_iterator iter;
-
-					const int start_draw = GSRendererHW::GetInstance()->m_draw_transfers.back().draw;
-
-					for (iter = GSRendererHW::GetInstance()->m_draw_transfers.rbegin(); iter != GSRendererHW::GetInstance()->m_draw_transfers.rend(); )
-					{
-						if (TEX0.TBP0 == iter->blit.DBP && GSUtil::HasCompatibleBits(iter->blit.DPSM, TEX0.PSM) && draw_rect.rintersect(iter->rect).eq(draw_rect))
-						{
-							can_use = false;
-							break;
-						}
-
-						// Give up after checking recent draw
-						if (start_draw - iter->draw > 0)
-							break;
-
-						++iter;
-					}
+					can_use = false;
 				}
 
 				if (can_use)


### PR DESCRIPTION
### Description of Changes
Ignores the rect size of uploads when checking if a target needs to be tossed when changing the width.

### Rationale behind Changes
This seemed a bit unreliable as it can use the wrong width/rect to upload to, the likelyhood is, if the width has changed and it's not a shuffle, we probably want to toss it, as long as information has been uploaded.

Similar problem with Call of Duty World at War, it was resizing a target after dirtying it, and the rect was being translated, putting the dirty area in the wrong place, since our hw renderer doesn't really understand rescaling on width change.

### Suggested Testing Steps
Try Battle Assault 3 featuring Gundam Seed and a smattering of games to make sure it doesn't break anything. Dump runner only showed this and Baldur's Gate DA 2 as diffs but BG DA2 was an invisible change type one (this game generally shows up randomly).


Fixes garbage on Battle Assault 3 featuring Gundam Seed
Fixes garbage on Call of Duty World at War

Battle Assault 3:
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/21fc68ff-b49e-4502-a3a5-aa6e2aa60ffe)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/36cd7e47-bc60-4fbf-94b0-d5083ec1cf31)

Call of Duty:
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/da1cb539-a496-497f-8da1-519079a738d0)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/9878fdd2-c9d7-45ae-9dd3-d5998d532c51)

