### PR TITLE
GS/TC: Don't expand block offsets to page size when small

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -516,7 +516,9 @@ void GSTextureCache::DirtyRectByPage(u32 sbp, u32 spsm, u32 sbw, Target* t, GSVe
 		{
 			const int xblocks = in_rect.width() / src_info->bs.x;
 			const int yblocks = in_rect.height() / src_info->bs.y;
-			if ((!(block_offset & 0x7) && xblocks <= 4 && yblocks <= 2) || req_depth_offset)
+			// if !(block_offset & 0x7) is false, this is technically incorrect, but FFX hates it and starts making a mess, so it's better this way without adding complexity.
+			// TODO maybe: Add per block invalidation? ugh, would have to keep that to small blocks. 2 blocks in the case of FFX.
+			if ((xblocks <= 4 && yblocks <= 2) || req_depth_offset)
 			{
 				GSVector4i b2a_offset = GSVector4i::zero();
 				const GSVector4i target_rect = GSVector4i(0, 0, src_width, 2048);


### PR DESCRIPTION
### Description of Changes
Avoids expanding dirty rects to the entire page when the block size is relatively small.

### Rationale behind Changes
In FFX it draws 512x416, and it does some invalidation in the pixels between 416 and 448, we were expanding this to the whole page which covers 384->448, causing big black areas in the texture. This change isn't necessarily correct, but it's a lot closer, the only better solution is when the writes are this small, do per block offsetting, but that could get slow and gross.

### Suggested Testing Steps
Test scene transitions in the FFX intro, make sure the bottom corner doesn't have a big black box (already tested).  Smoke test.

Fixes FFX transitions.
