### PR TITLE
GameDB: Add Hitman Blood Money HW fix to the US versions

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -52177,6 +52177,7 @@ SLUS-21108:
     vuClampMode: 0 # Fixes bump mapping issues
   gsHWFixes:
     textureInsideRT: 1 # Fixes post processing.
+    getSkipCount: "GSC_HitmanBloodMoney"
 SLUS-21109:
   name: "Drive to Survive"
   region: "NTSC-U"
@@ -57409,6 +57410,7 @@ SLUS-29191:
     vuClampMode: 0 # Fixes bump mapping issues
   gsHWFixes:
     textureInsideRT: 1 # Fixes post processing.
+    getSkipCount: "GSC_HitmanBloodMoney"
 SLUS-29192:
   name: "Test Drive Unlimited [Public Beta Vol.1.0]"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
Adds the HW fix for Blood Money to the US version.

### Rationale behind Changes
I didn't think the US version was affected, so I didn't add it, apparently it is.

### Suggested Testing Steps
Watch CI
