### PR TITLE
GS/HW: Don't use TEXA on 16/24 bit when TCC is set to Vertex alpha

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -4190,7 +4190,7 @@ __ri void GSRendererHW::EmulateTextureSampler(const GSTextureCache::Target* rt, 
 
 		// Force a 32 bits access (normally shuffle is done on 16 bits)
 		// m_ps_sel.tex_fmt = 0; // removed as an optimization
-		m_conf.ps.aem = TEXA.AEM;
+
 		//ASSERT(tex->m_target);
 
 		// Require a float conversion if the texure is a depth otherwise uses Integral scaling
@@ -4200,10 +4200,19 @@ __ri void GSRendererHW::EmulateTextureSampler(const GSTextureCache::Target* rt, 
 		}
 
 		// Shuffle is a 16 bits format, so aem is always required
-		GSVector4 ta(TEXA & GSVector4i::x000000ff());
-		ta /= 255.0f;
-		m_conf.cb_ps.TA_MaxDepth_Af.x = ta.x;
-		m_conf.cb_ps.TA_MaxDepth_Af.y = ta.y;
+		if (m_cached_ctx.TEX0.TCC)
+		{
+			m_conf.ps.aem = TEXA.AEM;
+			GSVector4 ta(TEXA & GSVector4i::x000000ff());
+			ta /= 255.0f;
+			m_conf.cb_ps.TA_MaxDepth_Af.x = ta.x;
+			m_conf.cb_ps.TA_MaxDepth_Af.y = ta.y;
+		}
+		else
+		{
+			m_conf.cb_ps.TA_MaxDepth_Af.x = 0;
+			m_conf.cb_ps.TA_MaxDepth_Af.y = 1.0f;
+		}
 
 		// The purpose of texture shuffle is to move color channel. Extra interpolation is likely a bad idea.
 		bilinear &= m_vt.IsLinear();


### PR DESCRIPTION
### Description of Changes
Makes sure the alpha used is the vertex alpha on shuffles when TCC (Use Texture Alpha) is set to false (aka Vertex Alpha)

### Rationale behind Changes
TEXA is basically ignored if the texture alpha of 16/24 bit is used but the alpha is ignored, this was happening for normal draws, but for shuffles it was always using TEXA.  This forces the values to be direct replacements, so the alpha goes unmodified. 

### Suggested Testing Steps
Annoyingly the only thing affected was the Official US Playstation Demo Disc 57 main menu, nothing else I have dumps for uses it, so, smoke test I guess..

Fixes #4090 Official US Playstation Magazine Demo Disc 057 main menu.

Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/b5bbaaaf-3f60-4170-a772-08803d7ee34e)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/a5276e0d-d66f-45a2-9baf-38bbfff872d5)

