### PR TITLE
Pad: Don't save button/analog state

### DIFF
--- a/pcsx2/SIO/Pad/PadBase.cpp
+++ b/pcsx2/SIO/Pad/PadBase.cpp
@@ -41,7 +41,6 @@ bool PadBase::Freeze(StateWrapper& sw)
 		return false;
 
 	// Protected PadBase members
-	sw.Do(&rawInputs);
 	sw.Do(&unifiedSlot);
 	sw.Do(&isInConfig);
 	sw.Do(&currentMode);

--- a/pcsx2/SIO/Pad/PadDualshock2.cpp
+++ b/pcsx2/SIO/Pad/PadDualshock2.cpp
@@ -815,7 +815,6 @@ bool PadDualshock2::Freeze(StateWrapper& sw)
 
 	// Private PadDualshock2 members
 	sw.Do(&buttons);
-	sw.DoBytes(&analogs, sizeof(Analogs));
 	sw.Do(&analogLight);
 	sw.Do(&analogLocked);
 	sw.Do(&analogPressed);

--- a/pcsx2/SIO/Pad/PadGuitar.cpp
+++ b/pcsx2/SIO/Pad/PadGuitar.cpp
@@ -402,7 +402,6 @@ bool PadGuitar::Freeze(StateWrapper& sw)
 		return false;
 
 	// Private PadGuitar members
-	sw.Do(&buttons);
 	sw.Do(&whammy);
 	sw.Do(&analogLight);
 	sw.Do(&analogLocked);

--- a/pcsx2/SaveState.h
+++ b/pcsx2/SaveState.h
@@ -37,7 +37,7 @@ enum class FreezeAction
 // [SAVEVERSION+]
 // This informs the auto updater that the users savestates will be invalidated.
 
-static const u32 g_SaveVersion = (0x9A3D << 16) | 0x0000;
+static const u32 g_SaveVersion = (0x9A3E << 16) | 0x0000;
 
 
 // the freezing data between submodules and core

--- a/pcsx2/StateWrapper.h
+++ b/pcsx2/StateWrapper.h
@@ -154,7 +154,7 @@ public:
 	}
 
 	/// Overload for POD types, such as structs.
-	template <typename T, std::enable_if_t<std::is_pod_v<T>, int> = 0>
+	template <typename T, std::enable_if_t<std::is_standard_layout_v<T> && std::is_trivial_v<T>, int> = 0>
 	void DoPOD(T* value_ptr)
 	{
 		if (m_mode == Mode::Read)


### PR DESCRIPTION
### Description of Changes

[SAVEVERSION+] unfortunately, because I haven't moved everything over to StateWrapper yet.

### Rationale behind Changes

Closes #9857.
Closes #9716.

### Suggested Testing Steps

Save state with button held, release, make sure it's released when you load.
