### PR TITLE
Pad: Don't serialize buttons or config

### DIFF
--- a/pcsx2/SIO/Pad/Pad.cpp
+++ b/pcsx2/SIO/Pad/Pad.cpp
@@ -52,7 +52,7 @@ namespace Pad
 	static std::unique_ptr<PadBase> CreatePad(u8 unifiedSlot, Pad::ControllerType controllerType);
 	static PadBase* ChangePadType(u8 unifiedSlot, Pad::ControllerType controllerType);
 
-	void LoadMacroButtonConfig(
+	static void LoadMacroButtonConfig(
 		const SettingsInterface& si, u32 pad, const ControllerInfo* ci, const std::string& section);
 	static void ApplyMacroButton(u32 controller, const MacroButton& mb);
 

--- a/pcsx2/SIO/Pad/PadBase.h
+++ b/pcsx2/SIO/Pad/PadBase.h
@@ -24,7 +24,7 @@
 class PadBase
 {
 protected:
-	std::array<u8, 32> rawInputs;
+	std::array<u8, 32> rawInputs = {};
 	u8 unifiedSlot;
 	bool isInConfig = false;
 	Pad::Mode currentMode = Pad::Mode::NOT_SET;
@@ -38,7 +38,6 @@ public: // Public members
 	void SoftReset();
 	void FullReset();
 
-	virtual void Init() = 0;
 	virtual Pad::ControllerType GetType() const = 0;
 	virtual const Pad::ControllerInfo& GetInfo() const = 0;
 

--- a/pcsx2/SIO/Pad/PadDualshock2.cpp
+++ b/pcsx2/SIO/Pad/PadDualshock2.cpp
@@ -483,47 +483,10 @@ u8 PadDualshock2::ResponseBytes(u8 commandByte)
 PadDualshock2::PadDualshock2(u8 unifiedSlot)
 	: PadBase(unifiedSlot)
 {
-	this->currentMode = Pad::Mode::DIGITAL;
-	Init();
+	currentMode = Pad::Mode::DIGITAL;
 }
 
 PadDualshock2::~PadDualshock2() = default;
-
-void PadDualshock2::Init()
-{
-	this->buttons = 0xffffffff;
-	this->analogs.lx = Pad::ANALOG_NEUTRAL_POSITION;
-	this->analogs.ly = Pad::ANALOG_NEUTRAL_POSITION;
-	this->analogs.rx = Pad::ANALOG_NEUTRAL_POSITION;
-	this->analogs.ry = Pad::ANALOG_NEUTRAL_POSITION;
-	this->analogs.lxInvert = 0;
-	this->analogs.lyInvert = 0;
-	this->analogs.rxInvert = 0;
-	this->analogs.ryInvert = 0;
-	this->analogLight = false;
-	this->analogLocked = false;
-	this->analogPressed = false;
-	this->responseBytes = 0;
-
-	for (u8 i = 0; i < this->rawInputs.size(); i++)
-	{
-		this->rawInputs[i] = 0;
-	}
-
-	for (u8 i = 0; i < this->pressures.size(); i++)
-	{
-		this->pressures[i] = 0;
-	}
-
-	this->axisScale = 1.0f;
-	this->axisDeadzone = 0.0f;
-	
-	this->vibrationScale[0] = 0.0f;
-	this->vibrationScale[1] = 1.0f;
-
-	this->pressureModifier = 0.5f;
-	this->buttonDeadzone = 0.0f;
-}
 
 Pad::ControllerType PadDualshock2::GetType() const
 {
@@ -814,19 +777,12 @@ bool PadDualshock2::Freeze(StateWrapper& sw)
 		return false;
 
 	// Private PadDualshock2 members
-	sw.Do(&buttons);
 	sw.Do(&analogLight);
 	sw.Do(&analogLocked);
 	sw.Do(&analogPressed);
 	sw.Do(&commandStage);
 	sw.Do(&responseBytes);
-	sw.Do(&pressures);
 	sw.Do(&vibrationMotors);
-	sw.Do(&axisScale);
-	sw.Do(&axisDeadzone);
-	sw.Do(&vibrationScale);
-	sw.Do(&pressureModifier);
-	sw.Do(&buttonDeadzone);
 	sw.Do(&smallMotorLastConfig);
 	sw.Do(&largeMotorLastConfig);
 	return !sw.HasError();

--- a/pcsx2/SIO/Pad/PadDualshock2.h
+++ b/pcsx2/SIO/Pad/PadDualshock2.h
@@ -58,23 +58,22 @@ public:
 		LENGTH,
 	};
 
-	static constexpr u32 PRESSURE_BUTTONS = 12;
 	static constexpr u8 VIBRATION_MOTORS = 2;
 
 private:
 	struct Analogs
 	{
-		u8 lx = 0x7f;
-		u8 ly = 0x7f;
-		u8 rx = 0x7f;
-		u8 ry = 0x7f;
-		u8 lxInvert = 0x7f;
-		u8 lyInvert = 0x7f;
-		u8 rxInvert = 0x7f;
-		u8 ryInvert = 0x7f;
+		u8 lx = Pad::ANALOG_NEUTRAL_POSITION;
+		u8 ly = Pad::ANALOG_NEUTRAL_POSITION;
+		u8 rx = Pad::ANALOG_NEUTRAL_POSITION;
+		u8 ry = Pad::ANALOG_NEUTRAL_POSITION;
+		bool lxInvert = false;
+		bool lyInvert = false;
+		bool rxInvert = false;
+		bool ryInvert = false;
 	};
 
-	u32 buttons;
+	u32 buttons = 0xffffffffu;
 	Analogs analogs;
 	bool analogLight = false;
 	bool analogLocked = false;
@@ -83,17 +82,16 @@ private:
 	// and out of analog mode every frame.
 	bool analogPressed = false;
 	bool commandStage = false;
-	u32 responseBytes;
-	std::array<u8, PRESSURE_BUTTONS> pressures;
-	std::array<u8, VIBRATION_MOTORS> vibrationMotors;
-	float axisScale;
-	float axisDeadzone;
-	std::array<float, 2> vibrationScale;
+	u32 responseBytes = 0;
+	std::array<u8, VIBRATION_MOTORS> vibrationMotors = {};
+	float axisScale = 1.0f;
+	float axisDeadzone = 0.0f;
+	std::array<float, 2> vibrationScale = {1.0f, 1.0f};
 	// When the pressure modifier binding is activated, this is multiplied against
 	// all values in pressures, to artificially reduce pressures and give players
 	// a way to simulate pressure sensitive controls.
-	float pressureModifier;
-	float buttonDeadzone;
+	float pressureModifier = 0.5f;
+	float buttonDeadzone = 0.0f;
 	// Used to store the last vibration mapping request the PS2 made for the small motor.
 	u8 smallMotorLastConfig = 0xff;
 	// Used to store the last vibration mapping request the PS2 made for the large motor.
@@ -125,7 +123,6 @@ public:
 		return (index == Inputs::PAD_L2 || index == Inputs::PAD_R2);
 	}
 
-	void Init() override;
 	Pad::ControllerType GetType() const override;
 	const Pad::ControllerInfo& GetInfo() const override;
 	void Set(u32 index, float value) override;

--- a/pcsx2/SIO/Pad/PadGuitar.cpp
+++ b/pcsx2/SIO/Pad/PadGuitar.cpp
@@ -243,21 +243,10 @@ u8 PadGuitar::VibrationMap(u8 commandByte)
 PadGuitar::PadGuitar(u8 unifiedSlot)
 	: PadBase(unifiedSlot)
 {
-	this->currentMode = Pad::Mode::DIGITAL;
-	Init();
+	currentMode = Pad::Mode::DIGITAL;
 }
 
 PadGuitar::~PadGuitar() = default;
-
-void PadGuitar::Init()
-{
-	this->buttons = 0xffffffff;
-	this->whammy = Pad::ANALOG_NEUTRAL_POSITION;
-	this->analogLight = false;
-	this->analogLocked = false;
-	this->whammyAxisScale = 1.0f;
-	this->whammyDeadzone = 0.0f;
-}
 
 Pad::ControllerType PadGuitar::GetType() const
 {

--- a/pcsx2/SIO/Pad/PadGuitar.h
+++ b/pcsx2/SIO/Pad/PadGuitar.h
@@ -37,17 +37,17 @@ public:
 	};
 
 private:
-	u32 buttons;
-	u8 whammy;
+	u32 buttons = 0xffffffffu;
+	u8 whammy = Pad::ANALOG_NEUTRAL_POSITION;
 	// Technically guitars do not have an analog light, but they still use the same ModeSwitch command
 	// as a DS2, and are told to "turn on their light".
 	bool analogLight = false;
 	// Guitars are also instructed to "lock" their "analog light", despite not having one.
 	bool analogLocked = false;
 	bool commandStage = false;
-	float whammyAxisScale; // Guitars only have 1 axis on the whammy bar.
-	float whammyDeadzone;
-	float buttonDeadzone; // Button deadzone is still a good idea, in case a host analog stick is bound to a guitar button
+	float whammyAxisScale = 1.0f; // Guitars only have 1 axis on the whammy bar.
+	float whammyDeadzone = 0.0f;
+	float buttonDeadzone = 0.0f; // Button deadzone is still a good idea, in case a host analog stick is bound to a guitar button
 
 	u8 Mystery(u8 commandByte);
 	u8 ButtonQuery(u8 commandByte);
@@ -64,7 +64,6 @@ public:
 	PadGuitar(u8 unifiedSlot);
 	~PadGuitar() override;
 
-	void Init() override;
 	Pad::ControllerType GetType() const override;
 	const Pad::ControllerInfo& GetInfo() const override;
 	void Set(u32 index, float value) override;

--- a/pcsx2/SIO/Pad/PadNotConnected.cpp
+++ b/pcsx2/SIO/Pad/PadNotConnected.cpp
@@ -30,11 +30,6 @@ PadNotConnected::PadNotConnected(u8 unifiedSlot)
 
 PadNotConnected::~PadNotConnected() = default;
 
-void PadNotConnected::Init()
-{
-
-}
-
 Pad::ControllerType PadNotConnected::GetType() const
 {
 	return Pad::ControllerType::NotConnected;

--- a/pcsx2/SIO/Pad/PadNotConnected.h
+++ b/pcsx2/SIO/Pad/PadNotConnected.h
@@ -23,7 +23,6 @@ public:
 	PadNotConnected(u8 unifiedSlot);
 	~PadNotConnected() override;
 
-	void Init() override;
 	Pad::ControllerType GetType() const override;
 	const Pad::ControllerInfo& GetInfo() const override;
 	void Set(u32 index, float value) override;

--- a/pcsx2/SaveState.h
+++ b/pcsx2/SaveState.h
@@ -37,7 +37,7 @@ enum class FreezeAction
 // [SAVEVERSION+]
 // This informs the auto updater that the users savestates will be invalidated.
 
-static const u32 g_SaveVersion = (0x9A3E << 16) | 0x0000;
+static const u32 g_SaveVersion = (0x9A3F << 16) | 0x0000;
 
 
 // the freezing data between submodules and core


### PR DESCRIPTION
### Description of Changes

Buttons were stored twice, binary values were still getting saved.

### Rationale behind Changes

Also stops scale/deadzone/etc getting saved to state.

### Suggested Testing Steps

Already tested, CI builds.
