### PR TITLE
GS/HW: Fix depth getting discarded with DATE on

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.h
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.h
@@ -63,9 +63,10 @@ private:
 	u32 GetConstantDirectWriteMemClearColor() const;
 	u32 GetConstantDirectWriteMemClearDepth() const;
 	bool IsReallyDithered() const;
+	bool AreAnyPixelsDiscarded() const;
 	bool IsDiscardingDstColor();
 	bool IsDiscardingDstRGB();
-	bool IsDiscardingDstAlpha();
+	bool IsDiscardingDstAlpha() const;
 	bool PrimitiveCoversWithoutGaps();
 
 	enum class CLUTDrawTestResult


### PR DESCRIPTION
### Description of Changes

I probably broke this when I removed `preserve_rt_color` check from `preserve_depth` in refraction's invalidation PR.

### Rationale behind Changes

Throwing away data is bad.

### Suggested Testing Steps

Dump run says it's okay, smoke test.
