### PR TITLE
GS/HW: Allow moves between swizzled formats

### DIFF
--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -1463,8 +1463,16 @@ void GSState::GIFRegHandlerTRXDIR(const GIFReg* RESTRICT r)
 			m_tr.Init(m_env.TRXPOS.SSAX, m_env.TRXPOS.SSAY, m_env.BITBLTBUF, false);
 			break;
 		case 2: // local -> local
-			CheckWriteOverlap(true, true);
-			Move();
+			{
+				CheckWriteOverlap(true, true);
+
+				GL_PUSH("Move (TRXDIR) 0x%x W:%d F:%s => 0x%x W:%d F:%s (DIR %d%d), sPos(%d %d) dPos(%d %d) size(%d %d)",
+					m_env.BITBLTBUF.SBP, m_env.BITBLTBUF.SBW, psm_str(m_env.BITBLTBUF.SPSM),
+					m_env.BITBLTBUF.DBP, m_env.BITBLTBUF.DBW, psm_str(m_env.BITBLTBUF.DPSM),
+					m_env.TRXPOS.DIRX, m_env.TRXPOS.DIRY,
+					m_env.TRXPOS.SSAX, m_env.TRXPOS.SSAY, m_env.TRXPOS.DSAX, m_env.TRXPOS.DSAY, m_env.TRXREG.RRW, m_env.TRXREG.RRH);
+				Move();
+			}
 			break;
 		default: // 3 deactivated as stated by manual. Tested on hardware and no transfers happen.
 			break;
@@ -2028,12 +2036,6 @@ void GSState::Move()
 	const int w = m_env.TRXREG.RRW;
 	const int h = m_env.TRXREG.RRH;
 
-	GL_CACHE("Move! 0x%x W:%d F:%s => 0x%x W:%d F:%s (DIR %d%d), sPos(%d %d) dPos(%d %d) size(%d %d)",
-			 m_env.BITBLTBUF.SBP, m_env.BITBLTBUF.SBW, psm_str(m_env.BITBLTBUF.SPSM),
-			 m_env.BITBLTBUF.DBP, m_env.BITBLTBUF.DBW, psm_str(m_env.BITBLTBUF.DPSM),
-			 m_env.TRXPOS.DIRX, m_env.TRXPOS.DIRY,
-			 sx, sy, dx, dy, w, h);
-
 	InvalidateLocalMem(m_env.BITBLTBUF, GSVector4i(sx, sy, sx + w, sy + h));
 	InvalidateVideoMem(m_env.BITBLTBUF, GSVector4i(dx, dy, dx + w, dy + h));
 
@@ -2444,7 +2446,14 @@ void GSState::Transfer(const u8* mem, u32 size)
 						Write(mem, len * 16);
 						break;
 					case 2:
-						Move();
+						{
+							GL_PUSH("Move (GIF_FLG_IMAGE)! 0x%x W:%d F:%s => 0x%x W:%d F:%s (DIR %d%d), sPos(%d %d) dPos(%d %d) size(%d %d)",
+								m_env.BITBLTBUF.SBP, m_env.BITBLTBUF.SBW, psm_str(m_env.BITBLTBUF.SPSM),
+								m_env.BITBLTBUF.DBP, m_env.BITBLTBUF.DBW, psm_str(m_env.BITBLTBUF.DPSM),
+								m_env.TRXPOS.DIRX, m_env.TRXPOS.DIRY,
+								m_env.TRXPOS.SSAX, m_env.TRXPOS.SSAY, m_env.TRXPOS.DSAX, m_env.TRXPOS.DSAY, m_env.TRXREG.RRW, m_env.TRXREG.RRH);
+							Move();
+						}
 						break;
 					default: // 1 and 3
 						// 1 is invalid because downloads can only be done


### PR DESCRIPTION
### Description of Changes

Kenran Butousai copies C32->Z24 after some P8H copies, which currently readbacks, then later reuploads incorrectly swizzled.

Since we don't emulate swizzling in HW, we can keep all of this on the GPU.

Marked as a draft, because it makes readbacks blow out in Time Crisis 3, and breaks Kunochi. Also K-1 World Grand Prix, which uses a Z24->Z24 move to copy the framebuffer... and I don't have the energy to deal with that nonsense today.

### Rationale behind Changes

Closes #9838.
![image](https://github.com/PCSX2/pcsx2/assets/11288319/70bd3eeb-4b18-47d0-bd53-f9b805836731)
(note: still partially broken, but matches SW)

Closes #7553.
![image](https://github.com/PCSX2/pcsx2/assets/11288319/46615b56-1f3c-4ae1-ad8f-2eb99cd41d23)

### Suggested Testing Steps

None yet until I fix the aforementioned issues.
