### PR TITLE
GS/HW: Always calculate valid area + end block on new targets (WWE Smackdown HCTP Crash)

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -2218,10 +2218,8 @@ bool GSTextureCache::PreloadTarget(GIFRegTEX0 TEX0, const GSVector2i& size, cons
 			AddDirtyRectTarget(dst, newrect, TEX0.PSM, TEX0.TBW, rgba, GSLocalMemory::m_psm[TEX0.PSM].trbpp >= 16);
 		}
 	}
-	else
-	{
-		dst->UpdateValidity(GSVector4i::loadh(valid_size));
-	}
+
+	dst->UpdateValidity(GSVector4i::loadh(valid_size));
 	
 	for (int type = 0; type < 2; type++)
 	{
@@ -2261,6 +2259,8 @@ bool GSTextureCache::PreloadTarget(GIFRegTEX0 TEX0, const GSVector2i& size, cons
 							const int copy_height = y_reduction * t->m_scale;
 							const int old_height = (dst->m_valid.w - y_reduction) * dst->m_scale;
 							GL_INS("RT double buffer copy from FBP 0x%x, %dx%d => %d,%d", t->m_TEX0.TBP0, copy_width, copy_height, 0, old_height);
+
+							pxAssert(old_height > 0);
 
 							// Clear the dirty first
 							dst->Update();


### PR DESCRIPTION
### Description of Changes
Always calculate valid area and end block on new targets

### Rationale behind Changes
Regression from #9745, was using the valid area to calculate target overlap and copying, but if the valid was empty due to it preloading from transfers, it was exploding, notably in WWE Smackdown Here Comes the Pain

### Suggested Testing Steps
Smoke test + WWE Smackdown Here Comes the Pain (already checked). Dump run said nothing else changed.