### PR TITLE
GS/HW: Fix up and restore some old valid channel behaviour

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -2184,8 +2184,8 @@ void GSRendererHW::Draw()
 			tgt = nullptr;
 		}
 		const bool possible_shuffle = ((rt_32bit && GSLocalMemory::m_psm[m_cached_ctx.FRAME.PSM].bpp == 16) || m_cached_ctx.FRAME.Block() == m_cached_ctx.TEX0.TBP0) || IsPossibleChannelShuffle();
-		const bool req_color = m_context->ALPHA.IsUsingCs();
-		const bool req_alpha = m_context->TEX0.TCC && (m_cached_ctx.FRAME.FBMSK & (fm_mask & 0xFF000000)) != (fm_mask & 0xFF000000);
+		const bool req_color = (!PRIM->ABE || (PRIM->ABE && m_context->ALPHA.IsUsingCs())) && (possible_shuffle || (m_cached_ctx.FRAME.FBMSK & (fm_mask & 0x00FFFFFF)) != (fm_mask & 0x00FFFFFF));
+		const bool req_alpha = m_context->TEX0.TCC && ((m_cached_ctx.TEST.ATE && m_cached_ctx.TEST.ATST > ATST_ALWAYS) || (possible_shuffle || (m_cached_ctx.FRAME.FBMSK & (fm_mask & 0xFF000000)) != (fm_mask & 0xFF000000)));
 
 		src = tex_psm.depth ? g_texture_cache->LookupDepthSource(TEX0, env.TEXA, MIP_CLAMP, tmm.coverage, possible_shuffle, m_vt.IsLinear(), m_cached_ctx.FRAME.Block(), req_color, req_alpha) :
 								g_texture_cache->LookupSource(TEX0, env.TEXA, MIP_CLAMP, tmm.coverage, (GSConfig.HWMipmap >= HWMipmapLevel::Basic || GSConfig.TriFilter == TriFiltering::Forced) ? &hash_lod_range : nullptr,

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -5476,13 +5476,8 @@ bool GSTextureCache::Target::HasValidBitsForFormat(u32 psm, bool req_color, bool
 			color_valid = m_valid_rgb;
 			break;
 	}
-	
-	if (req_color && color_valid && !alpha_valid && (m_dirty.GetDirtyChannels() & GSUtil::GetChannelMask(psm)) & 0x7)
-	{
-		alpha_valid = true;
-	}
 
-	return ((alpha_valid && req_alpha) || !req_alpha) && ((color_valid && req_color) || !req_color);
+	return (color_valid && req_color) || (!req_color && ((alpha_valid && req_alpha) || !req_alpha));
 }
 
 void GSTextureCache::Target::ResizeDrawn(const GSVector4i& rect)


### PR DESCRIPTION
### Description of Changes
Fixes `requires rgb/alpha` detection and modifies behaviour to semi resemble the old behaviour.

### Rationale behind Changes
We don't really deal with the alpha channels properly if it's expecting some level of preloaded stuff, we kinda fall over.  The old code used to just check if RGB was valid for normal formats, but that cause problems with games storing fonts in the alpha channel, but now the detection is improved to do similar, unless only the alpha is required, then the alpha is checked.

### Suggested Testing Steps
Test random games and Hitman 2 + Tony Hawk Pro Skater 4

Fixes Tony Hawk Pro Skater 2 black screen
Fixes Hitman 2 black screen
