### PR TITLE
GS/HW: Allow reverse primitive gap checking

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -21295,7 +21295,6 @@ SLES-53974:
   compat: 5
   gsHWFixes:
     autoFlush: 2 # Fixes missing bloom from surfaces like windows.
-    textureInsideRT: 1 # Fixes corruption.
     # halfPixelOffset: 1 # Aligns shadows properly, but causes grid lines to appear in sea travel.
     halfPixelOffset: 2 # Sharpens world in far distances, aligns some bloom better.
     roundSprite: 1 # Fixes font artifacts.
@@ -31157,7 +31156,6 @@ SLPM-62490:
   region: "NTSC-J"
   gsHWFixes:
     autoFlush: 2 # Fixes missing bloom from surfaces like windows.
-    textureInsideRT: 1 # Fixes corruption.
     # halfPixelOffset: 1 # Aligns shadows properly, but causes grid lines to appear in sea travel.
     halfPixelOffset: 2 # Sharpens world in far distances, aligns some bloom better.
     roundSprite: 1 # Fixes font artifacts.
@@ -35433,7 +35431,6 @@ SLPM-65888:
   compat: 5
   gsHWFixes:
     autoFlush: 2 # Fixes missing bloom from surfaces like windows.
-    textureInsideRT: 1 # Fixes corruption.
     # halfPixelOffset: 1 # Aligns shadows properly, but causes grid lines to appear in sea travel.
     halfPixelOffset: 2 # Sharpens world in far distances, aligns some bloom better.
     roundSprite: 1 # Fixes font artifacts.
@@ -37891,7 +37888,6 @@ SLPM-66481:
   region: "NTSC-J"
   gsHWFixes:
     autoFlush: 2 # Fixes missing bloom from surfaces like windows.
-    textureInsideRT: 1 # Fixes corruption.
     # halfPixelOffset: 1 # Aligns shadows properly, but causes grid lines to appear in sea travel.
     halfPixelOffset: 2 # Sharpens world in far distances, aligns some bloom better.
     roundSprite: 1 # Fixes font artifacts.
@@ -52648,7 +52644,6 @@ SLUS-21207:
   compat: 5
   gsHWFixes:
     autoFlush: 2 # Fixes missing bloom from surfaces like windows.
-    textureInsideRT: 1 # Fixes corruption.
     # halfPixelOffset: 1 # Aligns shadows properly, but causes grid lines to appear in sea travel.
     halfPixelOffset: 2 # Sharpens world in far distances, aligns some bloom better.
     roundSprite: 1 # Fixes font artifacts.
@@ -57242,7 +57237,6 @@ SLUS-29157:
   region: "NTSC-U"
   gsHWFixes:
     autoFlush: 2 # Fixes missing bloom from surfaces like windows.
-    textureInsideRT: 1 # Fixes corruption.
     # halfPixelOffset: 1 # Aligns shadows properly, but causes grid lines to appear in sea travel.
     halfPixelOffset: 2 # Sharpens world in far distances, aligns some bloom better.
     roundSprite: 1 # Fixes font artifacts.

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -6158,11 +6158,24 @@ bool GSRendererHW::PrimitiveCoversWithoutGaps()
 		u32 last_pX = v[1].XYZ.X;
 		for (u32 i = 2; i < m_vertex.next; i += 2)
 		{
-			const u32 dpX = v[i + 1].XYZ.X - v[i].XYZ.X;
-			if (dpX != first_dpX || v[i].XYZ.X != last_pX)
+			if (v[i].XYZ.X < v[i-2].XYZ.X)
 			{
-				m_primitive_covers_without_gaps = false;
-				return false;
+				const u32 dpX = v[i + 1].XYZ.X - v[i].XYZ.X;
+				const u32 prev_X = v[i - 2].XYZ.X - m_context->XYOFFSET.OFX;
+				if (dpX != prev_X || v[i].XYZ.X != m_context->XYOFFSET.OFX)
+				{
+					m_primitive_covers_without_gaps = false;
+					return false;
+				}
+			}
+			else
+			{
+				const u32 dpX = v[i + 1].XYZ.X - v[i].XYZ.X;
+				if (dpX != first_dpX || v[i].XYZ.X != last_pX)
+				{
+					m_primitive_covers_without_gaps = false;
+					return false;
+				}
 			}
 
 			last_pX = v[i + 1].XYZ.X;


### PR DESCRIPTION
### Description of Changes
Allows checking for primitive gaps to allow reverse draws starting from the bottom.
Also remove Tex in RT for Dragon Quest VIII

### Rationale behind Changes
Without gaps didn't allow vertical mode to look in reverse (I didn't do the horizontal equivalent, maybe we should..), which is something DQ8 does, this was causing it to fail to notice it being a new render target and kept the old one, which made a further texture lookup kill the target as it overlapped errantly.

Tex in RT is also being removed from DQ8 as it seems to do more harm than good these days and the game seems fine without it.

### Suggested Testing Steps
Test Dragon Quest VIII (a few areas with and without water/fire, transitions/fmvs etc) and some random other games, make sure everything is fine.

Primitive check change:
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/b45c6828-6e9c-485c-af45-61944b60b198)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/71e538c0-51c5-43ce-a6e3-2828ea299af9)

Tex in RT change:
Master (simulated):
![image](https://github.com/PCSX2/pcsx2/assets/6278726/7fa5c6b9-b4a5-4c36-8aae-baee3bf3041b)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/6f6f9b94-af51-4503-ac30-ff94f6c1d77f)
