### PR TITLE
GameDB: Add VU0 clamping Extra + Sign to Sky Odyssey

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -542,6 +542,8 @@ PCPX-96312:
 PCPX-96314:
   name: "The Sky Odyssey"
   region: "NTSC-J"
+  clampModes:
+    vu0ClampMode: 3 # Fixes runway line thickness on minimap.
 PCPX-96315:
   name: "Phase Paradox"
   region: "NTSC-J"
@@ -3856,6 +3858,8 @@ SCES-50034:
 SCES-50105:
   name: "Sky Odyssey"
   region: "PAL-M5"
+  clampModes:
+    vu0ClampMode: 3 # Fixes runway line thickness on minimap.
 SCES-50139:
   name: "World Rally Championship"
   region: "PAL-M7"
@@ -6969,6 +6973,8 @@ SCPS-15002:
 SCPS-15003:
   name: "Sky Odyssey"
   region: "NTSC-J"
+  clampModes:
+    vu0ClampMode: 3 # Fixes runway line thickness on minimap.
 SCPS-15004:
   name: "Dark Cloud"
   region: "NTSC-J"
@@ -47221,6 +47227,8 @@ SLUS-20134:
   name: "Sky Odyssey"
   region: "NTSC-U"
   compat: 5
+  clampModes:
+    vu0ClampMode: 3 # Fixes runway line thickness on minimap.
 SLUS-20136:
   name: "Barbarian"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
Adds VU0 clamping Extra + Sign to Sky Odyssey to fix the line thickness of runways.

### Rationale behind Changes
It was incorrect before.

### Suggested Testing Steps
Watch CI

Fixes #9878

Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/92cfe770-f27f-4ca5-921f-3578985f11b8)

PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/c5a8fdb0-0624-4f8a-bc58-0f1025606ac5)
