### PR TITLE
GS/TC: Avoid no size targets being made

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -2023,6 +2023,9 @@ GSTextureCache::Target* GSTextureCache::CreateTarget(GIFRegTEX0 TEX0, const GSVe
 		GL_CACHE("TC: Lookup %s(Color) %dx%d FBMSK %08x, miss (0x%x, TBW %d, %s) draw %d", is_frame ? "Frame" : "Target",
 			size.x, size.y, fbmask, TEX0.TBP0, TEX0.TBW, psm_str(TEX0.PSM), g_gs_renderer->s_n);
 	}
+	// Avoid making garbage targets (usually PCRTC).
+	if (GSVector4i::loadh(size).rempty())
+		return nullptr;
 
 	Target* dst = Target::Create(TEX0, size.x, size.y, scale, type, true);
 
@@ -5286,6 +5289,7 @@ GSTextureCache::Target::Target(GIFRegTEX0 TEX0, int type, const GSVector2i& unsc
 	, m_valid(GSVector4i::zero())
 {
 	m_TEX0 = TEX0;
+	m_end_block = m_TEX0.TBP0;
 	m_unscaled_size = unscaled_size;
 	m_scale = scale;
 	m_texture = texture;


### PR DESCRIPTION
### Description of Changes
Avoids targets with no size being made in the texture cache

### Rationale behind Changes
Sometimes the PCRTC circuits get enabled with rubbish sizes, this confuses the texture cache, and it was ending up with targets covering the entire GS memory.

Also sets the end block to match the start block on new targets, rather than the end of memory, just in case it does somehow not update it, it won't span the entire memory.

### Suggested Testing Steps
Test the FMVS on Taiko no Tatsujin - Tatacon de Dodon ga Don

Fixes #9883
