### PR TITLE
GS/TC: Only look up alternate depth sources if inside the target

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -1493,13 +1493,19 @@ GSTextureCache::Source* GSTextureCache::LookupSource(const GIFRegTEX0& TEX0, con
 
 		if (!found_t && !dst && !GSConfig.UserHacks_DisableDepthSupport)
 		{
+			GSVector4i new_rect = r;
+
+			// Just in case the TextureMinMax trolls us as it does, when checking if inside the target.
+			new_rect.z -= 2;
+			new_rect.w -= 2;
+
 			// Let's try a trick to avoid to use wrongly a depth buffer
 			// Unfortunately, I don't have any Arc the Lad testcase
 			//
 			// 1/ Check only current frame, I guess it is only used as a postprocessing effect
 			for (auto t : m_dst[DepthStencil])
 			{
-				if (t->m_age <= 1 && t->m_used && t->m_dirty.empty() && GSUtil::HasSharedBits(bp, psm, t->m_TEX0.TBP0, t->m_TEX0.PSM))
+				if (t->m_age <= 1 && t->m_used && t->m_dirty.empty() && GSUtil::HasSharedBits(bp, psm, t->m_TEX0.TBP0, t->m_TEX0.PSM) && t->Inside(bp, bw, psm, new_rect))
 				{
 					GL_INS("TC: Warning depth format read as color format. Pixels will be scrambled");
 					// Let's fetch a depth format texture. Rational, it will avoid the texture allocation and the


### PR DESCRIPTION
### Description of Changes
Only allows a depth source to be selected if the rect it wants fits inside the target.

### Rationale behind Changes
Conflict - Vietnam draws a single dot with 0x2300 as the depth location, then uploads its FMV frames to 0x2300, but doesn't get stopped by the dirty because it draws another single dot between frames, so it ends up picking this single dot as the source/frame over the actual frame.

### Suggested Testing Steps
Test Conflict - Vietnam

Fixes #9884
