### PR TITLE
Build: remove references to Vista and Windows 7 & Windows 8/8.1

### DIFF
--- a/pcsx2/windows/PCSX2.manifest
+++ b/pcsx2/windows/PCSX2.manifest
@@ -9,14 +9,6 @@
         <application>
             <!-- Windows 10 -->
             <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
-            <!-- Windows 8.1 -->
-            <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
-            <!-- Windows Vista -->
-            <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
-            <!-- Windows 7 -->
-            <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
-            <!-- Windows 8 -->
-            <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
         </application>
     </compatibility>
 </assembly>


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
removes references to Vista and Windows 7
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
PCSX2 no longer supports Vista and Windows 7 & Windows 8/8.1

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
make sure PCSX2 still works on Windows 