### PR TITLE
GameDB: Set cpuCLUTRender to 2 for Sega Ages 2500 Vol.31 Virtual On (SLPM-62767)

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -32034,6 +32034,8 @@ SLPM-62767:
   region: "NTSC-J"
   clampModes:
     eeClampMode: 2 # Fixes white shadows.
+  gsHWFixes:
+    cpuCLUTRender: 2 # Fixes CLUT colours.
 SLPM-62768:
   name: "Sengoku Musou 2 & Sengoku Musou 2 - Empires Saikyou Data"
   region: "NTSC-J"


### PR DESCRIPTION
Fixes black and white colors in hardware renderers.

No cpuCLUTRender set:
![image](https://github.com/PCSX2/pcsx2/assets/885618/41642851-17f5-4405-b102-de6e42e77a94)

Software:
![image](https://github.com/PCSX2/pcsx2/assets/885618/e26fa4a4-6662-402f-9e02-bf5802053331)


cpuCLUTRender: 2
![image](https://github.com/PCSX2/pcsx2/assets/885618/b3be6c7b-d247-45a5-8cfc-1b4ec450c439)


### Description of Changes
Added cpuCLUTRender: 2 to GameIndex.yaml to fix the grayscale colors while playing the game using hardware renderers. 

### Rationale behind Changes
The game looks fine in software mode, but doesn't in any hardware renderer. This game is part of a series of Model 2 arcade ports Sega did that leave these grayscale textures unless cpuCLUTRender: 2 is used (like Sega Rally 95). 

### Suggested Testing Steps
Launch the game and start a normal match. The mech selection screen will be the first thing you see with issues.
