### PR TITLE
GameDB: Replace EE timing with cycle rate on Robin Hood 2 - The Siege

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -21617,7 +21617,8 @@ SLES-54122:
   region: "PAL-E"
   gameFixes:
     - GIFFIFOHack # Partially fixes PATH3 Masking timing, not enough on its own.
-    - EETimingHack # Massages the timing slightly further to make it work okay.
+  speedHacks:
+    eeCycleRate: 3 # Corrects timing of PATH3 further.
 SLES-54123:
   name: "Marvel - Ultimate Alliance"
   region: "PAL-E-I"


### PR DESCRIPTION
### Description of Changes
Replace the EE timing fix with EE cycle rate 300% which seems to work better for this game.

### Rationale behind Changes
Does better than the existing hacks, for the one weirdo who actually gets pleasure out of playing this shovelware.

### Suggested Testing Steps
Watch CI
