### PR TITLE
GS/TC: Update source age on HW move

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -5452,6 +5452,8 @@ void GSTextureCache::Target::Update()
 
 void GSTextureCache::Target::UpdateIfDirtyIntersects(const GSVector4i& rc)
 {
+	m_age = 0;
+
 	for (auto& dirty : m_dirty)
 	{
 		const GSVector4i dirty_rc(dirty.GetDirtyRect(m_TEX0));


### PR DESCRIPTION
### Description of Changes
Resets the age of the source RT when doing a hardware move.

### Rationale behind Changes
Age is supposed to be reset when the target is being used, so it was likely just an oversight.

### Suggested Testing Steps
Check Waga Ryuu o Miyo - Pride of the Dragon Peace

Fixes #6950
