### PR TITLE
Qt: Misc stuff

### DIFF
--- a/common/SettingsWrapper.cpp
+++ b/common/SettingsWrapper.cpp
@@ -169,3 +169,60 @@ void SettingsSaveWrapper::_EnumEntry(const char* section, const char* var, int& 
 	const int index = (value < 0 || value >= cnt) ? defvalue : value;
 	m_si.SetStringValue(section, var, enumArray[index]);
 }
+
+SettingsClearWrapper::SettingsClearWrapper(SettingsInterface& si)
+	: SettingsWrapper(si)
+{
+}
+
+bool SettingsClearWrapper::IsLoading() const
+{
+	return false;
+}
+
+bool SettingsClearWrapper::IsSaving() const
+{
+	return true;
+}
+
+void SettingsClearWrapper::Entry(const char* section, const char* var, int& value, const int defvalue /*= 0*/)
+{
+	m_si.DeleteValue(section, var);
+}
+
+void SettingsClearWrapper::Entry(const char* section, const char* var, uint& value, const uint defvalue /*= 0*/)
+{
+	m_si.DeleteValue(section, var);
+}
+
+void SettingsClearWrapper::Entry(const char* section, const char* var, bool& value, const bool defvalue /*= false*/)
+{
+	m_si.DeleteValue(section, var);
+}
+
+void SettingsClearWrapper::Entry(const char* section, const char* var, float& value, const float defvalue /*= 0.0*/)
+{
+	m_si.DeleteValue(section, var);
+}
+
+void SettingsClearWrapper::Entry(const char* section, const char* var, std::string& value, const std::string& default_value /*= std::string()*/)
+{
+	m_si.DeleteValue(section, var);
+}
+
+bool SettingsClearWrapper::EntryBitBool(const char* section, const char* var, bool value, const bool defvalue /*= false*/)
+{
+	m_si.DeleteValue(section, var);
+	return defvalue;
+}
+
+int SettingsClearWrapper::EntryBitfield(const char* section, const char* var, int value, const int defvalue /*= 0*/)
+{
+	m_si.DeleteValue(section, var);
+	return defvalue;
+}
+
+void SettingsClearWrapper::_EnumEntry(const char* section, const char* var, int& value, const char* const* enumArray, int defvalue)
+{
+	m_si.DeleteValue(section, var);
+}

--- a/common/SettingsWrapper.h
+++ b/common/SettingsWrapper.h
@@ -96,6 +96,27 @@ protected:
 	void _EnumEntry(const char* section, const char* var, int& value, const char* const* enumArray, int defvalue) override;
 };
 
+class SettingsClearWrapper final : public SettingsWrapper
+{
+public:
+	SettingsClearWrapper(SettingsInterface& si);
+
+	bool IsLoading() const override;
+	bool IsSaving() const override;
+
+	void Entry(const char* section, const char* var, int& value, const int defvalue = 0) override;
+	void Entry(const char* section, const char* var, uint& value, const uint defvalue = 0) override;
+	void Entry(const char* section, const char* var, bool& value, const bool defvalue = false) override;
+	void Entry(const char* section, const char* var, float& value, const float defvalue = 0.0) override;
+
+	void Entry(const char* section, const char* var, std::string& value, const std::string& default_value = std::string()) override;
+	bool EntryBitBool(const char* section, const char* var, bool value, const bool defvalue = false) override;
+	int EntryBitfield(const char* section, const char* var, int value, const int defvalue = 0) override;
+
+protected:
+	void _EnumEntry(const char* section, const char* var, int& value, const char* const* enumArray, int defvalue) override;
+};
+
 #define SettingsWrapSection(section) const char* CURRENT_SETTINGS_SECTION = section;
 #define SettingsWrapEntry(var) wrap.Entry(CURRENT_SETTINGS_SECTION, #var, var, var)
 #define SettingsWrapEntryEx(var, name) wrap.Entry(CURRENT_SETTINGS_SECTION, name, var, var)

--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -1730,6 +1730,8 @@ void MainWindow::closeEvent(QCloseEvent* event)
 	if (!s_vm_valid)
 	{
 		saveStateToConfig();
+		if (m_display_widget)
+			g_emu_thread->stopFullscreenUI();
 		QMainWindow::closeEvent(event);
 		return;
 	}

--- a/pcsx2-qt/MainWindow.h
+++ b/pcsx2-qt/MainWindow.h
@@ -150,6 +150,8 @@ private Q_SLOTS:
 	void onChangeDiscMenuAboutToHide();
 	void onLoadStateMenuAboutToShow();
 	void onSaveStateMenuAboutToShow();
+	void onStartFullscreenUITriggered();
+	void onFullscreenUIStateChange(bool running);
 	void onViewToolbarActionToggled(bool checked);
 	void onViewLockToolbarActionToggled(bool checked);
 	void onViewStatusBarActionToggled(bool checked);

--- a/pcsx2-qt/QtHost.h
+++ b/pcsx2-qt/QtHost.h
@@ -126,6 +126,7 @@ Q_SIGNALS:
 	void onResizeRenderWindowRequested(qint32 width, qint32 height);
 	void onReleaseRenderWindowRequested();
 	void onMouseModeRequested(bool relative_mode, bool hide_cursor);
+	void onFullscreenUIStateChange(bool running);
 
 	/// Called when the VM is starting initialization, but has not been completed yet.
 	void onVMStarting();

--- a/pcsx2-qt/Settings/EmulationSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/EmulationSettingsWidget.cpp
@@ -166,7 +166,7 @@ void EmulationSettingsWidget::initializeSpeedCombo(QComboBox* cb, const char* se
 	if (m_dialog->isPerGameSettings())
 	{
 		cb->addItem(tr("Use Global Setting [%1%]").arg(value * 100.0f, 0, 'f', 0));
-		if (!m_dialog->getSettingsInterface()->GetFloatValue(key, section, &value))
+		if (!m_dialog->getSettingsInterface()->GetFloatValue(section, key, &value))
 		{
 			// set to something without data
 			value = -1.0f;

--- a/pcsx2-qt/Settings/SettingsDialog.h
+++ b/pcsx2-qt/Settings/SettingsDialog.h
@@ -51,12 +51,13 @@ class SettingsDialog final : public QDialog
 
 public:
 	explicit SettingsDialog(QWidget* parent);
-	SettingsDialog(QWidget* parent, std::unique_ptr<SettingsInterface> sif, const GameList::Entry* game, std::string serial, u32 disc_crc, QString filename = QString());
+	SettingsDialog(QWidget* parent, std::unique_ptr<INISettingsInterface> sif, const GameList::Entry* game, std::string serial,
+		u32 disc_crc, QString filename = QString());
 	~SettingsDialog();
 
 	static void openGamePropertiesDialog(const GameList::Entry* game, const std::string_view& title, std::string serial, u32 disc_crc);
 
-	__fi SettingsInterface* getSettingsInterface() const { return m_sif.get(); }
+	SettingsInterface* getSettingsInterface() const;
 	__fi bool isPerGameSettings() const { return static_cast<bool>(m_sif); }
 	__fi const std::string& getSerial() const { return m_serial; }
 	__fi u32 getDiscCRC() const { return m_disc_crc; }
@@ -108,6 +109,8 @@ Q_SIGNALS:
 private Q_SLOTS:
 	void onCategoryCurrentRowChanged(int row);
 	void onRestoreDefaultsClicked();
+	void onCopyGlobalSettingsClicked();
+	void onClearSettingsClicked();
 
 protected:
 	void closeEvent(QCloseEvent*) override;
@@ -122,7 +125,9 @@ private:
 
 	void addWidget(QWidget* widget, QString title, QString icon, QString help_text);
 
-	std::unique_ptr<SettingsInterface> m_sif;
+	SettingsDialog* reopen();
+
+	std::unique_ptr<INISettingsInterface> m_sif;
 
 	Ui::SettingsDialog m_ui;
 
@@ -149,6 +154,7 @@ private:
 
 	QString m_filename;
 
+	std::string m_game_list_filename;
 	std::string m_serial;
 	u32 m_disc_crc;
 };

--- a/pcsx2-qt/Settings/SettingsDialog.ui
+++ b/pcsx2-qt/Settings/SettingsDialog.ui
@@ -81,11 +81,25 @@
     </widget>
    </item>
    <item row="2" column="0" colspan="2">
-    <layout class="QHBoxLayout" name="horizontalLayout_2">
+    <layout class="QHBoxLayout" name="footerLayout">
      <item>
       <widget class="QPushButton" name="restoreDefaultsButton">
        <property name="text">
         <string>Restore Defaults</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="copyGlobalSettingsButton">
+       <property name="text">
+        <string>Copy Global Settings</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="clearGameSettingsButton">
+       <property name="text">
+        <string>Clear Settings</string>
        </property>
       </widget>
      </item>

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -1350,6 +1350,7 @@ struct Pcsx2Config
 
 	Pcsx2Config();
 	void LoadSave(SettingsWrapper& wrap);
+	void LoadSaveCore(SettingsWrapper& wrap);
 	void LoadSaveMemcards(SettingsWrapper& wrap);
 
 	/// Reloads options affected by patches.
@@ -1366,6 +1367,12 @@ struct Pcsx2Config
 
 	/// Copies runtime configuration settings (e.g. frame limiter state).
 	void CopyRuntimeConfig(Pcsx2Config& cfg);
+
+	/// Copies configuration from one file to another. Does not copy controller settings.
+	static void CopyConfiguration(SettingsInterface* dest_si, SettingsInterface& src_si);
+
+	/// Clears all core keys from the specified interface.
+	static void ClearConfiguration(SettingsInterface* dest_si);
 };
 
 extern Pcsx2Config EmuConfig;

--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -2490,15 +2490,7 @@ void FullscreenUI::DoCopyGameSettings()
 	if (!s_game_settings_interface)
 		return;
 
-	Pcsx2Config temp;
-	{
-		SettingsLoadWrapper wrapper(*GetEditingSettingsInterface(false));
-		temp.LoadSave(wrapper);
-	}
-	{
-		SettingsSaveWrapper wrapper(*s_game_settings_interface.get());
-		temp.LoadSave(wrapper);
-	}
+	Pcsx2Config::CopyConfiguration(s_game_settings_interface.get(), *GetEditingSettingsInterface(false));
 
 	SetSettingsChanged(s_game_settings_interface.get());
 
@@ -2511,9 +2503,7 @@ void FullscreenUI::DoClearGameSettings()
 	if (!s_game_settings_interface)
 		return;
 
-	s_game_settings_interface->Clear();
-	if (!s_game_settings_interface->GetFileName().empty())
-		FileSystem::DeleteFilePath(s_game_settings_interface->GetFileName().c_str());
+	Pcsx2Config::ClearConfiguration(s_game_settings_interface.get());
 
 	SetSettingsChanged(s_game_settings_interface.get());
 

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -1485,7 +1485,7 @@ Pcsx2Config::Pcsx2Config()
 	PINESlot = 28011;
 }
 
-void Pcsx2Config::LoadSave(SettingsWrapper& wrap)
+void Pcsx2Config::LoadSaveCore(SettingsWrapper& wrap)
 {
 	// Switch the rounding mode back to the system default for loading settings.
 	// That way, we'll get exactly the same values as what we loaded when we first started.
@@ -1531,8 +1531,6 @@ void Pcsx2Config::LoadSave(SettingsWrapper& wrap)
 
 	Debugger.LoadSave(wrap);
 	Trace.LoadSave(wrap);
-	USB.LoadSave(wrap);
-	Pad.LoadSave(wrap);
 
 #ifdef ENABLE_ACHIEVEMENTS
 	Achievements.LoadSave(wrap);
@@ -1558,6 +1556,13 @@ void Pcsx2Config::LoadSave(SettingsWrapper& wrap)
 	}
 
 	SSE_MXCSR::SetCurrent(prev_mxcsr);
+}
+
+void Pcsx2Config::LoadSave(SettingsWrapper& wrap)
+{
+	LoadSaveCore(wrap);
+	USB.LoadSave(wrap);
+	Pad.LoadSave(wrap);
 }
 
 void Pcsx2Config::LoadSaveMemcards(SettingsWrapper& wrap)
@@ -1633,6 +1638,26 @@ void Pcsx2Config::CopyRuntimeConfig(Pcsx2Config& cfg)
 	{
 		Mcd[i].Type = cfg.Mcd[i].Type;
 	}
+}
+
+void Pcsx2Config::CopyConfiguration(SettingsInterface* dest_si, SettingsInterface& src_si)
+{
+	Pcsx2Config temp;
+	{
+		SettingsLoadWrapper wrapper(src_si);
+		temp.LoadSaveCore(wrapper);
+	}
+	{
+		SettingsSaveWrapper wrapper(*dest_si);
+		temp.LoadSaveCore(wrapper);
+	}
+}
+
+void Pcsx2Config::ClearConfiguration(SettingsInterface* dest_si)
+{
+	Pcsx2Config temp;
+	SettingsClearWrapper wrapper(*dest_si);
+	temp.LoadSaveCore(wrapper);
 }
 
 bool EmuFolders::InitializeCriticalFolders()


### PR DESCRIPTION
### Description of Changes

Adds copy global settings and reset per-game settings buttons.
Fixes crash when changing language with big picture open.
Adds an option to stop big picture when it's running (and no game is).

### Rationale behind Changes

Closes #9881.
Closes #9110.

### Suggested Testing Steps

Test listed stuff above.