### PR TITLE
Misc: Drop stat compatibility calls

### DIFF
--- a/common/Linux/LnxHostSys.cpp
+++ b/common/Linux/LnxHostSys.cpp
@@ -250,13 +250,9 @@ void* HostSys::CreateSharedMemory(const char* name, size_t size)
 	shm_unlink(name);
 
 	// ensure it's the correct size
-#if !defined(__APPLE__) && !defined(__FreeBSD__)
-	if (ftruncate64(fd, static_cast<off64_t>(size)) < 0)
-#else
 	if (ftruncate(fd, static_cast<off_t>(size)) < 0)
-#endif
 	{
-		std::fprintf(stderr, "ftruncate64(%zu) failed: %d\n", size, errno);
+		std::fprintf(stderr, "ftruncate(%zu) failed: %d\n", size, errno);
 		return nullptr;
 	}
 

--- a/pcsx2/Linux/LnxFlatFileReader.cpp
+++ b/pcsx2/Linux/LnxFlatFileReader.cpp
@@ -88,7 +88,6 @@ void FlatFileReader::CancelRead(void)
 
 void FlatFileReader::Close(void)
 {
-
 	if (m_fd != -1)
 		close(m_fd);
 
@@ -100,15 +99,9 @@ void FlatFileReader::Close(void)
 
 uint FlatFileReader::GetBlockCount(void) const
 {
-#if defined(__HAIKU__) || defined(__APPLE__) || defined(__FreeBSD__)
 	struct stat sysStatData;
 	if (fstat(m_fd, &sysStatData) < 0)
 		return 0;
-#else
-	struct stat64 sysStatData;
-	if (fstat64(m_fd, &sysStatData) < 0)
-		return 0;
-#endif
 
-	return (int)(sysStatData.st_size / m_blocksize);
+	return static_cast<uint>(sysStatData.st_size / m_blocksize);
 }


### PR DESCRIPTION
### Description of Changes

We don't have 32-bit builds anymore, so no need to explicitly use 64-bit file function variants.

### Rationale behind Changes

Closes #8398.

### Suggested Testing Steps

Make sure dual layer DVD dumps still load on Linux.
