### PR TITLE
CI: Disable MFI joystick for SDL on MacOS

### DIFF
--- a/pcsx2/Input/SDLInputSource.cpp
+++ b/pcsx2/Input/SDLInputSource.cpp
@@ -592,6 +592,20 @@ bool SDLInputSource::OpenDevice(int index, bool is_gamecontroller)
 
 	const int joystick_id = SDL_JoystickInstanceID(joystick);
 	int player_id = gcontroller ? SDL_GameControllerGetPlayerIndex(gcontroller) : SDL_JoystickGetPlayerIndex(joystick);
+	for (auto it = m_controllers.begin(); it != m_controllers.end(); ++it)
+	{
+		if (it->joystick_id == joystick_id)
+		{
+			Console.Error("(SDLInputSource) Controller %d, instance %d, player %d already connected, ignoring.", index, joystick_id, player_id);
+			if (gcontroller)
+				SDL_GameControllerClose(gcontroller);
+			else
+				SDL_JoystickClose(joystick);
+
+			return false;
+		}
+	}
+
 	if (player_id < 0 || GetControllerDataForPlayerId(player_id) != m_controllers.end())
 	{
 		const int free_player_id = GetFreePlayerId();


### PR DESCRIPTION
### Description of Changes

Previously discussed on Discord the other week. When MFI is enabled in SDL, plugging a controller in seems to pick a fight between MFI and SDL's HIDAPI, and you get multiple connection events for the same joystick instance.

Based on Tellow's suggestion, I tried disabling MFI, and it stops the duplication. Presumably this will mean that some controllers that are not supported by HIDAPI will no longer work? There's also still an IOKit backend, however...

I also worked around it on our side, so it won't duplicate, but that's not a great solution, because you end up with the player ID (`SDL-#`) changing, which breaks your binds. Disabling MFI ensures it always reconnects as #0.

### Rationale behind Changes

Fixes duplicate controllers showing up on MacOS.

### Suggested Testing Steps

Test replugging controllers on MacOS.
