### PR TITLE
GS/TC: Ignore horizontal offset in invalidation start position

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -408,9 +408,6 @@ void GSTextureCache::DirtyRectByPage(u32 sbp, u32 spsm, u32 sbw, Target* t, GSVe
 	GSVector4i in_rect = src_r;
 	u32 target_bp = t->m_TEX0.TBP0;
 	int block_offset = static_cast<int>(sbp) - static_cast<int>(target_bp);
-	int page_offset = (block_offset) >> 5;
-	const int start_page = page_offset + (src_r.x / src_info->pgs.x) + ((src_r.y / src_info->pgs.y) * std::max(static_cast<int>(sbw), 1));
-
 	// Different format needs to be page aligned, unless the block layout matches, then we can block align
 	// Might be able to translate the original rect.
 	if (!(src_info->bpp == dst_info->bpp))
@@ -453,6 +450,10 @@ void GSTextureCache::DirtyRectByPage(u32 sbp, u32 spsm, u32 sbw, Target* t, GSVe
 	// FIXME: Is this a problem? Does having buffer widths less than pages in size throw a real spanner in the works?
 	const int src_pg_width = std::max((src_width + (src_info->pgs.x - 1)) / src_info->pgs.x, 1);
 	const int dst_pg_width = std::max((dst_width + (dst_info->pgs.x - 1)) / dst_info->pgs.x, 1);
+
+	int page_offset = (block_offset) >> 5;
+	// remove any hoizontal offset, this is added back on later.
+	const int start_page = (page_offset - (page_offset % src_pg_width)) + (src_r.x / src_info->pgs.x) + ((src_r.y / src_info->pgs.y) * std::max(static_cast<int>(sbw), 1));
 
 	// Pages aligned.
 	const GSVector4i page_mask(GSVector4i((src_info->pgs.x - 1), (src_info->pgs.y - 1)).xyxy());


### PR DESCRIPTION
### Description of Changes
Remove horizontal offset from start invalidation page.

### Rationale behind Changes
This is handled later, so we shouldn't do this too early. It was breaking SOCOM 3 loading screens due to the invalidation being offset correctly on the target, but the width was different, so it was getting in a mess.

### Suggested Testing Steps
Not really much to test, did a dump run, was fine.

SOCOM 3:
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/10078d26-fa5e-4c27-95dd-8c09c8403362)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/1b0b81e5-8135-4124-9d72-2b5e1f1699ae)

