### PR TITLE
Use native language GameDB entries

### DIFF
--- a/.github/workflows/lint_gamedb.yml
+++ b/.github/workflows/lint_gamedb.yml
@@ -35,4 +35,9 @@ jobs:
 
       - name: Check Formatting
         run: |
-          prettier --check ./bin/resources/GameIndex.yaml
+          if ! prettier --check bin/resources/GameIndex.yaml; then
+            prettier --write bin/resources/GameIndex.yaml
+            echo "Prettier failed, diff:"
+            git diff bin/resources/GameIndex.yaml
+            exit 1
+          fi

--- a/.github/workflows/lint_gamedb.yml
+++ b/.github/workflows/lint_gamedb.yml
@@ -20,12 +20,19 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
 
+      - name: Install Packages
+        run: |
+          npm install -g ajv-cli prettier
+          sudo apt-get -y install yamllint
+
+      - name: Validate YAML
+        run: |
+          yamllint -sd "{extends: relaxed, rules: {line-length: disable}}" ./bin/resources/GameIndex.yaml
+
       - name: Validate Contents
         run: |
-          npm install -g ajv-cli
           ajv validate -s ./pcsx2/Docs/gamedb-schema.json --spec=draft2020 -d ./bin/resources/GameIndex.yaml
 
       - name: Check Formatting
         run: |
-          npm install -g prettier
           prettier --check ./bin/resources/GameIndex.yaml

--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -7304,8 +7304,8 @@ SCPS-15026:
   name-en: "Boku no Natsuyasumi 2 - Umi no Bouken-hen"
   region: "NTSC-J"
 SCPS-15027:
-  name: ポポロクロイス〜はじまりの冒険〜 通常版(初回生産)
-  name-sort: ぽぽろくろいす〜はじまりのぼうけん〜 つうじょうばん(しょかいせいさん)
+  name: ポポロクロイス〜はじまりの冒険〜 通常版 [初回生産]
+  name-sort: ぽぽろくろいす〜はじまりのぼうけん〜 つうじょうばん [しょかいせいさん]
   name-en: "PoPoLoCrois - Hajimari no Bouken [Limited]"
   region: "NTSC-J"
 SCPS-15028:
@@ -7628,8 +7628,8 @@ SCPS-15069:
   region: "NTSC-J"
   compat: 5
 SCPS-15070:
-  name: "EyeToy:Play(ソフト単品)"
-  name-sort: "EyeToy:Play(そふとたんぴん)"
+  name: "EyeToy:Play [ソフト単品]"
+  name-sort: "EyeToy:Play [そふとたんぴん]"
   name-en: "EyeToy - Play [Game Only]"
   region: "NTSC-J"
 SCPS-15071:
@@ -7739,8 +7739,8 @@ SCPS-15088:
   region: "NTSC-J"
   compat: 5
 SCPS-15089:
-  name: アイトーイ プレイ2(“PlayStation 2”専用 EyeToy USBカメラ同梱版)
-  name-sort: あいとーい ぷれい2(“PlayStation 2”せんよう EyeToy USBかめらどうこんばん)
+  name: アイトーイ プレイ2 [“PlayStation 2”専用 EyeToy USBカメラ同梱版]
+  name-sort: あいとーい ぷれい2 [“PlayStation 2”せんよう EyeToy USBかめらどうこんばん]
   name-en: "EyeToy - Play 2 [With Camera]"
   region: "NTSC-J"
 SCPS-15090:
@@ -8279,8 +8279,8 @@ SCPS-19215:
     cpuSpriteRenderBW: 2 # Fixes lines in geometry.
     cpuSpriteRenderLevel: 2 # Needed for above.
 SCPS-19251:
-  name: "WILD ARMS Alter code:F PlayStation®2 the Best"
-  name-sort: "WILD ARMS Alter code:F PlayStation®2 the Best"
+  name: "WILD ARMS Alter code:F [PlayStation®2 the Best]"
+  name-sort: "WILD ARMS Alter code:F [PlayStation®2 the Best]"
   name-en: "Wild ARMs - Alter Code F [PlayStation 2 The Best]"
   region: "NTSC-J"
   gsHWFixes:
@@ -8310,8 +8310,8 @@ SCPS-19252:
     - "SCPS-15009"
     - "SCPS-55007"
 SCPS-19253:
-  name: "WILD ARMS Alter code:F PlayStation 2 the Best"
-  name-sort: "WILD ARMS Alter code:F PlayStation 2 the Best"
+  name: "WILD ARMS Alter code:F [PlayStation 2 the Best]"
+  name-sort: "WILD ARMS Alter code:F [PlayStation 2 the Best]"
   name-en: "Wild ARMs - Alter Code F [PlayStation 2 The Best - Reprint]"
   region: "NTSC-J"
   gsHWFixes:
@@ -28838,8 +28838,8 @@ SLPM-55113:
   name: "WinBack 2 - Project Poseidon"
   region: "NTSC-J"
 SLPM-55114:
-  name: マナケミア２ 〜おちた学園と錬金術士たち〜【ガストベストプライス】
-  name-sort: まなけみあに 〜おちたがくえんとれんきんじゅつしたち〜【がすとべすとぷらいす】
+  name: マナケミア２ 〜おちた学園と錬金術士たち〜 [ガストベストプライス]
+  name-sort: まなけみあに 〜おちたがくえんとれんきんじゅつしたち〜 [がすとべすとぷらいす]
   name-en: "Mana Khemia 2 - Ochita Gakuen to Renkinjutsushi Tachi"
   region: "NTSC-J"
   gsHWFixes:
@@ -29257,8 +29257,8 @@ SLPM-55250:
   name: "Warship Gunner 2 - Kurogane no Houkou"
   region: "NTSC-J"
 SLPM-55251:
-  name: 太閤立志伝V【コーエー定番シリーズ】
-  name-sort: たいこうりっしでんV【こーえーていばんしりーず】
+  name: 太閤立志伝V [コーエー定番シリーズ]
+  name-sort: たいこうりっしでんV [こーえーていばんしりーず]
   name-en: "WWE SmackDown vs. Raw 2009"
   region: "NTSC-J"
 SLPM-55252:
@@ -31126,8 +31126,8 @@ SLPM-62160:
   name: "Simple 2000 Series Vol. 4 - The Double Mahjong Puzzle"
   region: "NTSC-J"
 SLPM-62161:
-  name: GENERATION OF CHAOS NEXT (限定版)
-  name-sort: GENERATION OF CHAOS NEXT (げんていばん)
+  name: GENERATION OF CHAOS NEXT [限定版]
+  name-sort: GENERATION OF CHAOS NEXT [げんていばん]
   name-en: "Generation of Chaos - Next [Limited Edition]"
   region: "NTSC-J"
   compat: 5
@@ -31339,8 +31339,8 @@ SLPM-62215:
   name: "Virtua Cop Re-Birth"
   region: "NTSC-J"
 SLPM-62216:
-  name: EVER BLUE (カプコレ)
-  name-sort: EVER BLUE (かぷこれ)
+  name: EVER BLUE [カプコレ]
+  name-sort: EVER BLUE [かぷこれ]
   name-en: "Ever Blue [CapKore The Best]"
   region: "NTSC-J"
 SLPM-62217:
@@ -31392,8 +31392,8 @@ SLPM-62227:
   region: "NTSC-J"
   compat: 5
 SLPM-62228:
-  name: シルフィード・ザ・ロストプラネット(カプコレ)
-  name-sort: しるふぃーど・ざ・ろすとぷらねっと(かぷこれ)
+  name: シルフィード・ザ・ロストプラネット [カプコレ]
+  name-sort: しるふぃーど・ざ・ろすとぷらねっと [かぷこれ]
   name-en: "Silpheed - The Lost Planet"
   region: "NTSC-J"
 SLPM-62229:
@@ -31442,8 +31442,8 @@ SLPM-62236:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
 SLPM-62237:
-  name: 学園都市 ヴァラノワール(限定版)
-  name-sort: がくえんとし ゔぁらのわーる(げんていばん)
+  name: 学園都市 ヴァラノワール [限定版]
+  name-sort: がくえんとし ゔぁらのわーる [げんていばん]
   name-en: "Gakuen Toshi Vara Noir [Limited Edition]"
   region: "NTSC-J"
 SLPM-62238:
@@ -31563,8 +31563,8 @@ SLPM-62262:
   name: "GI Jockey 2 [Koei the best]"
   region: "NTSC-J"
 SLPM-62263:
-  name: スノーボードヘヴン(カプコレ)
-  name-sort: すのーぼーどへゔん(かぷこれ)
+  name: スノーボードヘヴン [カプコレ]
+  name-sort: すのーぼーどへゔん [かぷこれ]
   name-en: "Snowboard Heaven"
   region: "NTSC-J"
   gameFixes:
@@ -31831,8 +31831,8 @@ SLPM-62324:
   name-en: "Simple 2000 Series Vol. 8 - Gekitou! Meiro King"
   region: "NTSC-J"
 SLPM-62325:
-  name: ハイヒートメジャーリーグベースボール 2003【THE BEST タカラモノ】
-  name-sort: はいひーとめじゃーりーぐべーすぼーる 2003【THE BEST たからもの】
+  name: ハイヒートメジャーリーグベースボール 2003 [THE BEST タカラモノ]
+  name-sort: はいひーとめじゃーりーぐべーすぼーる 2003 [THE BEST たからもの]
   name-en: "High Heat Major League Baseball 2003 [Konami The Best]"
   region: "NTSC-J"
 SLPM-62326:
@@ -31970,8 +31970,8 @@ SLPM-62354:
   name-en: "Space Invaders 25th Anniversary"
   region: "NTSC-J"
 SLPM-62355:
-  name: チョロQHG2【THE BEST タカラモノ】
-  name-sort: ちょろQHG2【THE BEST たからもの】
+  name: チョロQHG2 [THE BEST タカラモノ]
+  name-sort: ちょろQHG2 [THE BEST たからもの]
   name-en: "Choro Q HG 2"
   region: "NTSC-J"
   gsHWFixes:
@@ -32062,13 +32062,13 @@ SLPM-62375:
   name-en: "Simple 2000 Series Vol. 36 - The Musume Ikusei Simulation"
   region: "NTSC-J"
 SLPM-62376:
-  name: GetBackers奪還屋 奪還だョ!全員集合!(コナミ ザ ベスト)
-  name-sort: GetBackersだっかんや だっかんだょ!ぜんいんしゅうごう!(こなみ ざ べすと)
+  name: GetBackers奪還屋 奪還だョ!全員集合! [コナミ ザ ベスト]
+  name-sort: GetBackersだっかんや だっかんだょ!ぜんいんしゅうごう! [こなみ ざ べすと]
   name-en: "Get Backers - All Members Gather [Konami The Best]"
   region: "NTSC-J"
 SLPM-62377:
-  name: GetBackers奪還屋 奪われた無限城(コナミ ザ ベスト)
-  name-sort: GetBackersだっかんや うばわれたむげんじょう(こなみ ざ べすと)
+  name: GetBackers奪還屋 奪われた無限城 [コナミ ザ ベスト]
+  name-sort: GetBackersだっかんや うばわれたむげんじょう [こなみ ざ べすと]
   name-en: "Get Backers Dakkanoku - Ubawareta Mugenshiro [Konami The Best]"
   region: "NTSC-J"
 SLPM-62378:
@@ -32224,8 +32224,8 @@ SLPM-62409:
   name-en: "Wizardry Empire III - Ancestry of the Emperor"
   region: "NTSC-J"
 SLPM-62410:
-  name: サイレントスコープ3 (コナミ ザ ベスト)
-  name-sort: さいれんとすこーぷ3 (こなみ ざ べすと)
+  name: サイレントスコープ3 [コナミ ザ ベスト]
+  name-sort: さいれんとすこーぷ3 [こなみ ざ べすと]
   name-en: "Silent Scope 3 [Konami The Best]"
   region: "NTSC-J"
 SLPM-62411:
@@ -32360,8 +32360,8 @@ SLPM-62439:
   region: "NTSC-J"
   compat: 4
 SLPM-62440:
-  name: グローランサーIII(Atlus Best Collection)
-  name-sort: ぐろーらんさーIII(Atlus Best Collection)
+  name: グローランサーIII [Atlus Best Collection]
+  name-sort: ぐろーらんさーIII [Atlus Best Collection]
   name-en: "Growlanser III [Atlus The Best]"
   region: "NTSC-J"
   compat: 4
@@ -32531,8 +32531,8 @@ SLPM-62472:
   name-en: "Diet Channel"
   region: "NTSC-J"
 SLPM-62473:
-  name: 信長の野望 嵐世紀【KOEI The Best】
-  name-sort: のぶながのやぼう あらしせいき【KOEI The Best】
+  name: 信長の野望 嵐世紀 [KOEI The Best]
+  name-sort: のぶながのやぼう あらしせいき [KOEI The Best]
   name-en: "Nobunaga no Yabou - Ranseiki [Koei The Best]"
   region: "NTSC-J"
 SLPM-62474:
@@ -32735,8 +32735,8 @@ SLPM-62511:
   name-en: "Victory Wings - Zero Pilot Series"
   region: "NTSC-J"
 SLPM-62512:
-  name: 経営シミュレーション ジュラシック・パーク(コナミ ザ ベスト)
-  name-sort: けいえいしみゅれーしょん じゅらしっく・ぱーく(こなみ ざ べすと)
+  name: 経営シミュレーション ジュラシック・パーク [コナミ ザ ベスト]
+  name-sort: けいえいしみゅれーしょん じゅらしっく・ぱーく [こなみ ざ べすと]
   name-en: "Keiei Simulation - Jurassic Park [Konami The Best]"
   region: "NTSC-J"
   gsHWFixes:
@@ -32746,8 +32746,8 @@ SLPM-62512:
     textureInsideRT: 1 # Fixes rainbow lighting for some areas.
     getSkipCount: "GSC_BlueTongueGames" # Mipmap rendering on CPU.
 SLPM-62513:
-  name: ハリー・ポッターと秘密の部屋【EA BEST HITS】
-  name-sort: はりー・ぽったーとひみつのへや【EA BEST HITS】
+  name: ハリー・ポッターと秘密の部屋 [EA BEST HITS]
+  name-sort: はりー・ぽったーとひみつのへや [EA BEST HITS]
   name-en: "Harry Potter and the Chamber of Secrets [EA Best Hits]"
   region: "NTSC-J"
   gameFixes:
@@ -32758,8 +32758,8 @@ SLPM-62513:
     trilinearFiltering: 1 # Fixes blurry textures.
     cpuFramebufferConversion: 1 # Fixes right side of the screen from garbage textures.
 SLPM-62514:
-  name: シムピープル ～お茶の間劇場～【EA BEST HITS】
-  name-sort: しむぴーぷる ～おちゃのまげきじょう～【EA BEST HITS】
+  name: シムピープル ～お茶の間劇場～ [EA BEST HITS]
+  name-sort: しむぴーぷる ～おちゃのまげきじょう～ [EA BEST HITS]
   name-en: "Sim People [EA Best Hits]"
   region: "NTSC-J"
 SLPM-62515:
@@ -32776,18 +32776,18 @@ SLPM-62516:
   name-en: "EyeToy Sports - Let's Play Sports!"
   region: "NTSC-J"
 SLPM-62517:
-  name: WinningPost 5【KOEI The Best】
-  name-sort: WinningPost 5【KOEI The Best】
+  name: WinningPost 5 [KOEI The Best]
+  name-sort: WinningPost 5 [KOEI The Best]
   name-en: "Winning Post 5 [Koei The Best]"
   region: "NTSC-J"
 SLPM-62518:
-  name: 提督の決断IV【KOEI The Best】
-  name-sort: ていとくのけつだんIV【KOEI The Best】
+  name: 提督の決断IV [KOEI The Best]
+  name-sort: ていとくのけつだんIV [KOEI The Best]
   name-en: "Teitoku no Ketsudan IV [Koei the Best]"
   region: "NTSC-J"
 SLPM-62519:
-  name: 三國志VIII【KOEI The Best】
-  name-sort: さんごくしVIII【KOEI The Best】
+  name: 三國志VIII [KOEI The Best]
+  name-sort: さんごくしVIII [KOEI The Best]
   name-en: "Sangokushi VIII [Koei The Best]"
   region: "NTSC-J"
 SLPM-62520:
@@ -32831,13 +32831,13 @@ SLPM-62529:
   name-en: "Karaoke Revolution - Kazoku Idol Sengen"
   region: "NTSC-J"
 SLPM-62530:
-  name: グラディウスIII＆IV〜復活の神話〜(コナミ殿堂セレクション)
-  name-sort: ぐらでぃうすIII＆IV〜ふっかつのしんわ〜(こなみでんどうせれくしょん)
+  name: グラディウスIII＆IV〜復活の神話〜 [コナミ殿堂セレクション]
+  name-sort: ぐらでぃうすIII＆IV〜ふっかつのしんわ〜 [こなみでんどうせれくしょん]
   name-en: "Gradius III & IV [Konami Dendou Collection]"
   region: "NTSC-J"
 SLPM-62531:
-  name: 麻雀やろうぜ!2 (コナミ殿堂セレクション)
-  name-sort: まーじゃんやろうぜ!2 (こなみでんどうせれくしょん)
+  name: 麻雀やろうぜ!2 [コナミ殿堂セレクション]
+  name-sort: まーじゃんやろうぜ!2 [こなみでんどうせれくしょん]
   name-en: "Mahjong Yarouze! 2 [Konami Palace Selection]"
   region: "NTSC-J"
 SLPM-62532:
@@ -32856,13 +32856,13 @@ SLPM-62534:
   region: "NTSC-J"
   compat: 5
 SLPM-62536:
-  name: ジーワンジョッキー3【KOEI The Best】
-  name-sort: じーわんじょっきー3【KOEI The Best】
+  name: ジーワンジョッキー3 [KOEI The Best]
+  name-sort: じーわんじょっきー3 [KOEI The Best]
   name-en: "G1 Jockey 3 [Koei The Best]"
   region: "NTSC-J"
 SLPM-62537:
-  name: スター・ウォーズ スターファイター【EA BEST HITS】
-  name-sort: すたー・うぉーず すたーふぁいたー【EA BEST HITS】
+  name: スター・ウォーズ スターファイター [EA BEST HITS]
+  name-sort: すたー・うぉーず すたーふぁいたー [EA BEST HITS]
   name-en: "Star Wars - Starfighter [EA Best Hits]"
   region: "NTSC-J"
 SLPM-62538:
@@ -32907,8 +32907,8 @@ SLPM-62545:
   region: "NTSC-J"
   compat: 5
 SLPM-62546:
-  name: 三國志VII【コーエー定番シリーズ】
-  name-sort: さんごくしVII【こーえーていばんしりーず】
+  name: 三國志VII [コーエー定番シリーズ]
+  name-sort: さんごくしVII [こーえーていばんしりーず]
   name-en: "Sangokushi VII [Koei Collection Series]"
   region: "NTSC-J"
 SLPM-62547:
@@ -32930,8 +32930,8 @@ SLPM-62549:
   name-en: "Otona no Gal Jan - Kimi ni Hane Man [Jaleco the Best]"
   region: "NTSC-J"
 SLPM-62550:
-  name: ウィザードリィ エンパイアIII 〜覇王の系譜〜 Good Price(限定版)
-  name-sort: うぃざーどりぃ えんぱいあIII 〜はおうのけいふ〜 Good Price(げんていばん)
+  name: ウィザードリィ エンパイアIII 〜覇王の系譜〜 Good Price [限定版]
+  name-sort: うぃざーどりぃ えんぱいあIII 〜はおうのけいふ〜 Good Price [げんていばん]
   name-en: "Wizardry Empire III - Ancestry of the Emperor [Good Price - Limited Edition]"
   region: "NTSC-J"
 SLPM-62551:
@@ -33012,8 +33012,8 @@ SLPM-62564:
   gameFixes:
     - XGKickHack # Fixes distant car textures.
 SLPM-62565:
-  name: ボボボーボ・ボーボボ 集まれ!!体感ボーボボ(カメラ同梱)
-  name-sort: ぼぼぼーぼ・ぼーぼぼ あつまれ!!たいかんぼーぼぼ(かめらどうこん)
+  name: ボボボーボ・ボーボボ 集まれ!!体感ボーボボ [カメラ同梱]
+  name-sort: ぼぼぼーぼ・ぼーぼぼ あつまれ!!たいかんぼーぼぼ [かめらどうこん]
   name-en: "Boboboubo Boubobo - Atsumare!! Taikan Boubobo [Doukonban]"
   region: "NTSC-J"
 SLPM-62566:
@@ -33022,15 +33022,15 @@ SLPM-62566:
   name-en: "Typing of the Dead - Zombie Panic"
   region: "NTSC-J"
 SLPM-62567:
-  name: WIN BACK【コーエー定番シリーズ】
-  name-sort: WIN BACK【こーえーていばんしりーず】
+  name: WIN BACK [コーエー定番シリーズ]
+  name-sort: WIN BACK [こーえーていばんしりーず]
   name-en: "Winback [Koei Best Series]"
   region: "NTSC-J"
   clampModes:
     vuClampMode: 3 # Fixes missing 3D polygons when going ingame.
 SLPM-62568:
-  name: 真・三國無双【コーエー定番シリーズ】
-  name-sort: しん・さんごくむそう【こーえーていばんしりーず】
+  name: 真・三國無双 [コーエー定番シリーズ]
+  name-sort: しん・さんごくむそう [こーえーていばんしりーず]
   name-en: "Shin Sangoku Musou [Koei The Best]"
   region: "NTSC-J"
 SLPM-62569:
@@ -33248,8 +33248,8 @@ SLPM-62613:
   region: "NTSC-J"
   compat: 5
 SLPM-62614:
-  name: ホースブレーカー【コーエー定番シリーズ】
-  name-sort: ほーすぶれーかー【こーえーていばんしりーず】
+  name: ホースブレーカー [コーエー定番シリーズ]
+  name-sort: ほーすぶれーかー [こーえーていばんしりーず]
   name-en: "Horse Breaker [Koei Teiban Series]"
   region: "NTSC-J"
 SLPM-62615:
@@ -33279,8 +33279,8 @@ SLPM-62620:
   name-en: "Pachi-Slot Winning Post"
   region: "NTSC-J"
 SLPM-62621:
-  name: グラディウスV(コナミ ザ ベスト)
-  name-sort: ぐらでぃうすV(こなみ ざ べすと)
+  name: グラディウスV [コナミ ザ ベスト]
+  name-sort: ぐらでぃうすV [こなみ ざ べすと]
   name-en: "Gradius V [Konami The Best]"
   region: "NTSC-J"
 SLPM-62622:
@@ -33387,23 +33387,23 @@ SLPM-62638:
   gameFixes:
     - XGKickHack # Fixes characters clothing.
 SLPM-62639:
-  name: 麻雀大会III ミレニアムリーグ【コーエー定番シリーズ】
-  name-sort: まーじゃんたいかいIII みれにあむりーぐ【こーえーていばんしりーず】
+  name: 麻雀大会III ミレニアムリーグ [コーエー定番シリーズ]
+  name-sort: まーじゃんたいかいIII みれにあむりーぐ [こーえーていばんしりーず]
   name-en: "Mahjong Taikai III - Millennium League [Koei Selection Series]"
   region: "NTSC-J"
 SLPM-62640:
-  name: 太閤立志伝IV【コーエー定番シリーズ】
-  name-sort: たいこうりっしでんIV【こーえーていばんしりーず】
+  name: 太閤立志伝IV [コーエー定番シリーズ]
+  name-sort: たいこうりっしでんIV [こーえーていばんしりーず]
   name-en: "Taikou Risshiden IV [Koei Selection Series]"
   region: "NTSC-J"
 SLPM-62641:
-  name: 三國志VIII with パワーアップキット【KOEI The BEST】
-  name-sort: さんごくしVIII with ぱわーあっぷきっと【KOEI The BEST】
+  name: 三國志VIII with パワーアップキット [KOEI The BEST]
+  name-sort: さんごくしVIII with ぱわーあっぷきっと [KOEI The BEST]
   name-en: "Sangokushi VIII [with Power-Up Kit] [Koei The Best]"
   region: "NTSC-J"
 SLPM-62642:
-  name: 信長の野望・嵐世記 with パワーアップキット【KOEI The BEST】
-  name-sort: のぶながのやぼう・らんせいき with ぱわーあっぷきっと【KOEI The BEST】
+  name: 信長の野望・嵐世記 with パワーアップキット [KOEI The BEST]
+  name-sort: のぶながのやぼう・らんせいき with ぱわーあっぷきっと [KOEI The BEST]
   name-en: "Nobunaga no Yabou - Ranseiki [with Power-Up Kit] [Koei The Best]"
   region: "NTSC-J"
 SLPM-62643:
@@ -33538,8 +33538,8 @@ SLPM-62677:
   name-en: "Sega Ages 2500 Series Vol.15 - Decathlete Collection"
   region: "NTSC-J"
 SLPM-62678:
-  name: 鋼鉄の咆哮 〜ウォーシップコマンダー〜【コーエー定番シリーズ】
-  name-sort: くろがねのほうこう 〜うぉーしっぷこまんだー〜【こーえーていばんしりーず】
+  name: 鋼鉄の咆哮 〜ウォーシップコマンダー〜 [コーエー定番シリーズ]
+  name-sort: くろがねのほうこう 〜うぉーしっぷこまんだー〜 [こーえーていばんしりーず]
   name-en: "Kurogane no Houkou - Warship Commander [Koei Selection Series]"
   region: "NTSC-J"
 SLPM-62679:
@@ -33553,8 +33553,8 @@ SLPM-62680:
   name-en: "Relakuma - Ojama Shitemasu 2"
   region: "NTSC-J"
 SLPM-62681:
-  name: 信長の野望・嵐世記【コーエー定番シリーズ】
-  name-sort: のぶながのやぼう・らんせいき【こーえーていばんしりーず】
+  name: 信長の野望・嵐世記 [コーエー定番シリーズ]
+  name-sort: のぶながのやぼう・らんせいき [こーえーていばんしりーず]
   name-en: "Nobunaga no Yabou - Ranseiki [Koei Selection Series]"
   region: "NTSC-J"
 SLPM-62682:
@@ -33630,8 +33630,8 @@ SLPM-62696:
   name-en: "Oretachi Geasen Zoku Sono - Yie Ar Kung-fu"
   region: "NTSC-J"
 SLPM-62697:
-  name: ジェネレーション オブ カオス ネクスト 〜失われし絆〜【IFコレクション】
-  name-sort: じぇねれーしょん おぶ かおす ねくすと 〜うしなわれしきずな〜【IFこれくしょん】
+  name: ジェネレーション オブ カオス ネクスト 〜失われし絆〜 [IFコレクション]
+  name-sort: じぇねれーしょん おぶ かおす ねくすと 〜うしなわれしきずな〜 [IFこれくしょん]
   name-en: "Generation of Chaos Next [Idea Factory Collection]"
   region: "NTSC-J"
 SLPM-62698:
@@ -33640,18 +33640,18 @@ SLPM-62698:
   name-en: "Ultimate Pro Pinball"
   region: "NTSC-J"
 SLPM-62699:
-  name: カルディナル アーク 〜混沌の封札〜【IFコレクション】
-  name-sort: かるでぃなる あーく 〜こんとんのふうさつ〜【IFこれくしょん】
+  name: カルディナル アーク 〜混沌の封札〜 [IFコレクション]
+  name-sort: かるでぃなる あーく 〜こんとんのふうさつ〜 [IFこれくしょん]
   name-en: "Neverland Card War Cardinal Arc - Konton no Fuusatsu [Idea Factory Collection]"
   region: "NTSC-J"
 SLPM-62700:
-  name: セレクション プリンセスメーカー【BEST HIT】
-  name-sort: せれくしょん ぷりんせすめーかー【BEST HIT】
+  name: セレクション プリンセスメーカー [BEST HIT]
+  name-sort: せれくしょん ぷりんせすめーかー [BEST HIT]
   name-en: "Princess Maker [Best Hit Selection]"
   region: "NTSC-J"
 SLPM-62701:
-  name: セレクション プリンセスメーカー2【BEST HIT】
-  name-sort: せれくしょん ぷりんせすめーかー2【BEST HIT】
+  name: セレクション プリンセスメーカー2 [BEST HIT]
+  name-sort: せれくしょん ぷりんせすめーかー2 [BEST HIT]
   name-en: "Princess Maker 2 [Best Hit Selection]"
   region: "NTSC-J"
 SLPM-62702:
@@ -33660,8 +33660,8 @@ SLPM-62702:
   name-en: "Momotaro Densetsu 15"
   region: "NTSC-J"
 SLPM-62703:
-  name: SEGA RALLY CHAMPIONSHIP (「セガラリー2007」同梱用)
-  name-sort: SEGA RALLY CHAMPIONSHIP (「せがらりー2007」どうこんよう)
+  name: SEGA RALLY CHAMPIONSHIP [「セガラリー2007」同梱用]
+  name-sort: SEGA RALLY CHAMPIONSHIP [「せがらりー2007」どうこんよう]
   name-en: "Sega Rally Championship '95"
   region: "NTSC-J"
   compat: 5
@@ -33698,8 +33698,8 @@ SLPM-62709:
   name-en: "Sega Ages 2500 Series Vol.23 - Sega Memorial Selection"
   region: "NTSC-J"
 SLPM-62710:
-  name: 三國志VIII【コーエー定番シリーズ】
-  name-sort: さんごくしVIII【こーえーていばんしりーず】
+  name: 三國志VIII [コーエー定番シリーズ]
+  name-sort: さんごくしVIII [こーえーていばんしりーず]
   name-en: "San Goku Shi VIII"
   region: "NTSC-J"
 SLPM-62711:
@@ -33809,8 +33809,8 @@ SLPM-62736:
   name-en: "Slotter Up Mania [Dorart Value Series]"
   region: "NTSC-J"
 SLPM-62737:
-  name: ラリーショックス&フリークスタイル モトクロス【EA BEST HITS】
-  name-sort: らりーしょっくす&ふりーくすたいる もとくろす【EA BEST HITS】
+  name: ラリーショックス&フリークスタイル モトクロス [EA BEST HITS]
+  name-sort: らりーしょっくす&ふりーくすたいる もとくろす [EA BEST HITS]
   name-en: "Rally Shox & Freestyle Motorcross [EA Best Hits]"
   region: "NTSC-J"
 SLPM-62738:
@@ -33851,13 +33851,13 @@ SLPM-62746:
   region: "NTSC-J"
   compat: 5
 SLPM-62747:
-  name: ジーワン ジョッキー3【コーエー定番シリーズ】
-  name-sort: じーわん じょっきー3【こーえーていばんしりーず】
+  name: ジーワン ジョッキー3 [コーエー定番シリーズ]
+  name-sort: じーわん じょっきー3 [こーえーていばんしりーず]
   name-en: "G1 Jockey 3 [Koei Selection Series]"
   region: "NTSC-J"
 SLPM-62748:
-  name: 信長の野望・嵐世記 with パワーアップキット【コーエー定番シリーズ】
-  name-sort: のぶながのやぼう・らんせいき with ぱわーあっぷきっと【こーえーていばんしりーず】
+  name: 信長の野望・嵐世記 with パワーアップキット [コーエー定番シリーズ]
+  name-sort: のぶながのやぼう・らんせいき with ぱわーあっぷきっと [こーえーていばんしりーず]
   name-en: "Nobunaga no Yabou - Renseiki [with Power-Up Kit] [Koei Selection Series]"
   region: "NTSC-J"
 SLPM-62749:
@@ -33909,8 +33909,8 @@ SLPM-62758:
   name-en: "River Ride Adventure featuring Salomon"
   region: "NTSC-J"
 SLPM-62759:
-  name: 信長の野望・蒼天録【コーエー定番シリーズ】
-  name-sort: のぶながのやぼう・そうてんろく【こーえーていばんしりーず】
+  name: 信長の野望・蒼天録 [コーエー定番シリーズ]
+  name-sort: のぶながのやぼう・そうてんろく [こーえーていばんしりーず]
   name-en: "Nobunaga no Yabou - Soutenroku [Koei Selection Series]"
   region: "NTSC-J"
 SLPM-62760:
@@ -33927,8 +33927,8 @@ SLPM-62761:
   gsHWFixes:
     roundSprite: 2 # Fixes sprite ghosting.
 SLPM-62762:
-  name: 三國志VIII withパワーアップキット【コーエー定番シリーズ】
-  name-sort: さんごくしVIII withぱわーあっぷきっと【こーえーていばんしりーず】
+  name: 三國志VIII withパワーアップキット [コーエー定番シリーズ]
+  name-sort: さんごくしVIII withぱわーあっぷきっと [こーえーていばんしりーず]
   name-en: "Sangokushi VIII [with Power-Up Kit] [Koei Selection Series]"
   region: "NTSC-J"
 SLPM-62763:
@@ -33937,8 +33937,8 @@ SLPM-62763:
   name-en: "Bomberman Land 3 [Hudson Best Version]"
   region: "NTSC-J"
 SLPM-62764:
-  name: リラックマ〜おじゃましてます2週間〜(ベスト版)
-  name-sort: りらっくま〜おじゃましてます2しゅうかん〜(べすとばん)
+  name: リラックマ〜おじゃましてます2週間〜 [ベスト版]
+  name-sort: りらっくま〜おじゃましてます2しゅうかん〜 [べすとばん]
   name-en: "Ojama Shitemasu 2 Shuukan [Best Version]"
   region: "NTSC-J"
 SLPM-62766:
@@ -34707,8 +34707,8 @@ SLPM-65098:
     instantVU1: 0 # Fixes hang on FMV's when CDVD timing is accurate.
     mtvu: 0
 SLPM-65100:
-  name: 鬼武者2(初回生産限定版)
-  name-sort: おにむしゃ2(しょかいせいさんげんていばん)
+  name: 鬼武者2 [初回生産限定版]
+  name-sort: おにむしゃ2 [しょかいせいさんげんていばん]
   name-en: "Onimusha 2"
   region: "NTSC-J"
 SLPM-65101:
@@ -35082,13 +35082,13 @@ SLPM-65185:
   gsHWFixes:
     roundSprite: 1 # Fixes text alignment.
 SLPM-65186:
-  name: Thread Colors(スレッドカラーズ)〜さよならの向こう側〜(限定生産初回BOX)
-  name-sort: Thread Colors(すれっどからーず)〜さよならのむこうがわ〜(げんていせいさんしょかいBOX)
+  name: Thread Colors(スレッドカラーズ)〜さよならの向こう側〜 [限定生産初回BOX]
+  name-sort: Thread Colors(すれっどからーず)〜さよならのむこうがわ〜 [げんていせいさんしょかいBOX]
   name-en: "Thread Colors [Limited Edition]"
   region: "NTSC-J"
 SLPM-65187:
-  name: Thread Colors(スレッドカラーズ)〜さよならの向こう側〜(量産型ふつう版)
-  name-sort: Thread Colors(すれっどからーず)〜さよならのむこうがわ〜(りょうさんがたふつうばん)
+  name: Thread Colors(スレッドカラーズ)〜さよならの向こう側〜 [量産型ふつう版]
+  name-sort: Thread Colors(すれっどからーず)〜さよならのむこうがわ〜 [りょうさんがたふつうばん]
   name-en: "Thread Colors"
   region: "NTSC-J"
 SLPM-65190:
@@ -35157,8 +35157,8 @@ SLPM-65202:
   name-en: "K-1 World Grand Prix 2002"
   region: "NTSC-J"
 SLPM-65203:
-  name: ファントム-PHANTOM OF INFERNO- (初回限定版)
-  name-sort: ふぁんとむ-PHANTOM OF INFERNO- (しょかいげんていばん)
+  name: ファントム-PHANTOM OF INFERNO- [初回限定版]
+  name-sort: ふぁんとむ-PHANTOM OF INFERNO- [しょかいげんていばん]
   name-en: "Phantom of Inferno [Limited Edition]"
   region: "NTSC-J"
 SLPM-65204:
@@ -35636,23 +35636,23 @@ SLPM-65279:
   name-en: "Generation of Chaos 3"
   region: "NTSC-J"
 SLPM-65280:
-  name: グリーングリーン ～鐘の音ダイナミック～(デラックスパック)
-  name-sort: ぐりーんぐりーん ～かねのおとだいなみっく～(でらっくすぱっく)
+  name: グリーングリーン ～鐘の音ダイナミック～ [デラックスパック]
+  name-sort: ぐりーんぐりーん ～かねのおとだいなみっく～ [でらっくすぱっく]
   name-en: "Green Green - Sound of the Ring Dynamic [Limited Edition]"
   region: "NTSC-J"
 SLPM-65281:
-  name: グリーングリーン ～鐘の音ダイナミック～(通常版)
-  name-sort: ぐりーんぐりーん ～かねのおとだいなみっく～(つうじょうばん)
+  name: グリーングリーン ～鐘の音ダイナミック～ [通常版]
+  name-sort: ぐりーんぐりーん ～かねのおとだいなみっく～ [つうじょうばん]
   name-en: "Green Green - Sound of the Ring Dynamic"
   region: "NTSC-J"
 SLPM-65282:
-  name: グリーングリーン ～鐘の音ロマンティック～(デラックスパック)
-  name-sort: ぐりーんぐりーん ～かねのおとろまんてぃっく～(でらっくすぱっく)
+  name: グリーングリーン ～鐘の音ロマンティック～ [デラックスパック]
+  name-sort: ぐりーんぐりーん ～かねのおとろまんてぃっく～ [でらっくすぱっく]
   name-en: "Green Green - Sound of the Ring Romantic [Limited Edition]"
   region: "NTSC-J"
 SLPM-65283:
-  name: グリーングリーン 〜鐘の音ロマンティック〜(通常版)
-  name-sort: ぐりーんぐりーん 〜かねのおとろまんてぃっく〜(つうじょうばん)
+  name: グリーングリーン 〜鐘の音ロマンティック〜 [通常版]
+  name-sort: ぐりーんぐりーん 〜かねのおとろまんてぃっく〜 [つうじょうばん]
   name-en: "Green Green - Sound of the Ring Romantic"
   region: "NTSC-J"
 SLPM-65284:
@@ -35714,8 +35714,8 @@ SLPM-65295:
   name-en: "Cafe Little Wish - Mahou no Recipe"
   region: "NTSC-J"
 SLPM-65296:
-  name: F～ファナティック～(初回限定版)
-  name-sort: F～ふぁなてぃっく～(しょかいげんていばん)
+  name: F～ファナティック～ [初回限定版]
+  name-sort: F～ふぁなてぃっく～ [しょかいげんていばん]
   name-en: "F - Fanatic [Limited Edition]"
   region: "NTSC-J"
 SLPM-65297:
@@ -35951,8 +35951,8 @@ SLPM-65338:
   name-en: "Juunikoku-ki - Guren no Shirube Koejin no Michi"
   region: "NTSC-J"
 SLPM-65339:
-  name: 悪代官【グローバル ザ ベスト】
-  name-sort: あくだいかん【ぐろーばる ざ べすと】
+  name: 悪代官 [グローバル ザ ベスト]
+  name-sort: あくだいかん [ぐろーばる ざ べすと]
   name-en: "Akudaikan [Global The Best]"
   region: "NTSC-J"
 SLPM-65340:
@@ -35961,8 +35961,8 @@ SLPM-65340:
   name-en: "Shinseiki Evangelion - Ayanami Ikusai Keikaku with Asuka Hokan Keikaku"
   region: "NTSC-J"
 SLPM-65341:
-  name: サイレントヒル2 最期の詩 (コナミ・ザ・ベスト)
-  name-sort: さいれんとひる2 さいごのし (こなみ・ざ・べすと)
+  name: サイレントヒル2 最期の詩 [コナミ・ザ・ベスト]
+  name-sort: さいれんとひる2 さいごのし [こなみ・ざ・べすと]
   name-en: "Silent Hill 2 - Saigo No Uta [Konami The Best]"
   region: "NTSC-J"
   speedHacks:
@@ -36033,13 +36033,13 @@ SLPM-65355:
   name: "Natsuiro Komachi - Ichijitsu Senka"
   region: "NTSC-J"
 SLPM-65356:
-  name: 夏色小町【一日千夏】(通常版)
-  name-sort: なついろこまち【いちじつせんか】(つうじょうばん)
+  name: 夏色小町【一日千夏】 [通常版]
+  name-sort: なついろこまち【いちじつせんか】 [つうじょうばん]
   name-en: "Natsuiro Komachi"
   region: "NTSC-J"
 SLPM-65357:
-  name: バイオハザード コード:ベロニカ 完全版(カプコレ)
-  name-sort: ばいおはざーど こーど:べろにか かんぜんばん(かぷこれ)
+  name: バイオハザード コード:ベロニカ 完全版 [カプコレ]
+  name-sort: ばいおはざーど こーど:べろにか かんぜんばん [かぷこれ]
   name-en: "BioHazard - Code Veronica - Perfect Version"
   region: "NTSC-J"
 SLPM-65358:
@@ -36049,13 +36049,13 @@ SLPM-65358:
   region: "NTSC-J"
   compat: 5
 SLPM-65359:
-  name: ユーディーのアトリエ 〜グラムナート の錬金術士〜【ガストベストプライス】
-  name-sort: ゆーでぃーのあとりえ 〜ぐらむなーと のれんきんじゅつし〜【がすとべすとぷらいす】
+  name: ユーディーのアトリエ 〜グラムナート の錬金術士〜 [ガストベストプライス]
+  name-sort: ゆーでぃーのあとりえ 〜ぐらむなーと のれんきんじゅつし〜 [がすとべすとぷらいす]
   name-en: "Judie no Atelier - Gramnad no Renkinjutsushi [Gust Best Price]"
   region: "NTSC-J"
 SLPM-65361:
-  name: ANUBIS ZONE OF THE ENDERS SPECIAL EDITION(限定版)
-  name-sort: ANUBIS ZONE OF THE ENDERS SPECIAL EDITION(げんていばん)
+  name: ANUBIS ZONE OF THE ENDERS SPECIAL EDITION [限定版]
+  name-sort: ANUBIS ZONE OF THE ENDERS SPECIAL EDITION [げんていばん]
   name-en: "Anubis - Zone of the Enders Special Edition [Limited Edition]"
   region: "NTSC-J"
   compat: 5
@@ -36068,13 +36068,13 @@ SLPM-65363:
   name: "Shoujo Yoshitsune-den"
   region: "NTSC-J"
 SLPM-65364:
-  name: 少女義経伝(通常版)
-  name-sort: しょうじょよしつねでん(つうじょうばん)
+  name: 少女義経伝 [通常版]
+  name-sort: しょうじょよしつねでん [つうじょうばん]
   name-en: "Shoujo Yoshitsune-den"
   region: "NTSC-J"
 SLPM-65365:
-  name: ときめきメモリアル Girl’s Side (コナミ ザ ベスト)
-  name-sort: ときめきめもりある Girl’s Side (こなみ ざ べすと)
+  name: ときめきメモリアル Girl’s Side [コナミ ザ ベスト]
+  name-sort: ときめきめもりある Girl’s Side [こなみ ざ べすと]
   name-en: "Tokimeki Memorial - Girl's Side [Konami The Best]"
   region: "NTSC-J"
 SLPM-65366:
@@ -36169,8 +36169,8 @@ SLPM-65382:
   name-en: "Grand Theft Auto III"
   region: "NTSC-J"
 SLPM-65383:
-  name: GROWLANSER IV 〜Wayfarer of the time〜(デラックスパック)
-  name-sort: GROWLANSER IV 〜Wayfarer of the time〜(でらっくすぱっく)
+  name: GROWLANSER IV 〜Wayfarer of the time〜 [デラックスパック]
+  name-sort: GROWLANSER IV 〜Wayfarer of the time〜 [でらっくすぱっく]
   name-en: "Growlanser IV - Wayfarer of the Time [Limited Edition]"
   region: "NTSC-J"
 SLPM-65384:
@@ -36193,13 +36193,13 @@ SLPM-65387:
   name-en: "Aero Dancing 4 - New Generation [Sega The Best 2800]"
   region: "NTSC-J"
 SLPM-65388:
-  name: Lost Passage 〜失われた一節〜(初回限定版)
-  name-sort: Lost Passage 〜うしなわれたいっせつ〜(しょかいげんていばん)
+  name: Lost Passage 〜失われた一節〜 [初回限定版]
+  name-sort: Lost Passage 〜うしなわれたいっせつ〜 [しょかいげんていばん]
   name-en: "Lost Passage [Limited Edition]"
   region: "NTSC-J"
 SLPM-65389:
-  name: Lost Passage 〜失われた一節〜(通常版)
-  name-sort: Lost Passage 〜うしなわれたいっせつ〜(つうじょうばん)
+  name: Lost Passage 〜失われた一節〜 [通常版]
+  name-sort: Lost Passage 〜うしなわれたいっせつ〜 [つうじょうばん]
   name-en: "Lost Passage"
   region: "NTSC-J"
 SLPM-65390:
@@ -36395,13 +36395,13 @@ SLPM-65423:
   name-en: "Sangokushi IX"
   region: "NTSC-J"
 SLPM-65424:
-  name: モエかん 〜もえっ娘島へようこそ〜 (初回限定版)
-  name-sort: もえかん 〜もえっこしまへようこそ〜 (しょかいげんていばん)
+  name: モエかん 〜もえっ娘島へようこそ〜 [初回限定版]
+  name-sort: もえかん 〜もえっこしまへようこそ〜 [しょかいげんていばん]
   name-en: "Moekko Company [Limited Edition]"
   region: "NTSC-J"
 SLPM-65425:
-  name: モエかん 〜もえっ娘島へようこそ〜 (通常版)
-  name-sort: もえかん 〜もえっこしまへようこそ〜 (つうじょうばん)
+  name: モエかん 〜もえっ娘島へようこそ〜 [通常版]
+  name-sort: もえかん 〜もえっこしまへようこそ〜 [つうじょうばん]
   name-en: "Moekko Company"
   region: "NTSC-J"
 SLPM-65426:
@@ -36421,8 +36421,8 @@ SLPM-65428:
   region: "NTSC-J"
   compat: 5
 SLPM-65429:
-  name: GALAXY ANGEL Moonlit Lovers 初回限定版(ファーストパッケージ)
-  name-sort: GALAXY ANGEL Moonlit Lovers しょかいげんていばん(ふぁーすとぱっけーじ)
+  name: GALAXY ANGEL Moonlit Lovers 初回限定版 [ファーストパッケージ]
+  name-sort: GALAXY ANGEL Moonlit Lovers しょかいげんていばん [ふぁーすとぱっけーじ]
   name-en: "Galaxy Angel - Moonlit Lovers"
   region: "NTSC-J"
 SLPM-65431:
@@ -36550,8 +36550,8 @@ SLPM-65449:
     halfPixelOffset: 2 # Fixes depth lines.
     recommendedBlendingLevel: 4 # Fixes missing lighting and makes snow not look like snow sludge.
 SLPM-65450:
-  name: 探偵学園Q 〜奇翁館の殺意〜 (初回生産分)
-  name-sort: たんていがくえんQ 〜きおきなかんのさつい〜 (しょかいせいさんぶん)
+  name: 探偵学園Q 〜奇翁館の殺意〜 [初回生産分]
+  name-sort: たんていがくえんQ 〜きおきなかんのさつい〜 [しょかいせいさんぶん]
   name-en: "Tantei Gakuen Q - Kiokan no Satsui [First Limited Edition]"
   region: "NTSC-J"
 SLPM-65451:
@@ -36572,13 +36572,13 @@ SLPM-65455:
   name: "Nobunaga no Yabou - Soutenroku [with Power-Up Kit]"
   region: "NTSC-J"
 SLPM-65456:
-  name: ナースウィッチ小麦ちゃん マジカルて(初回限定版)
-  name-sort: なーすうぃっちこむぎちゃん まじかるて(しょかいげんていばん)
+  name: ナースウィッチ小麦ちゃん マジカルて [初回限定版]
+  name-sort: なーすうぃっちこむぎちゃん まじかるて [しょかいげんていばん]
   name-en: "Magical Nurse Witch Komugi-chan [Limited Edition]"
   region: "NTSC-J"
 SLPM-65457:
-  name: ナースウィッチ小麦ちゃん マジカルて(通常版)
-  name-sort: なーすうぃっちこむぎちゃん まじかるて(つうじょうばん)
+  name: ナースウィッチ小麦ちゃん マジカルて [通常版]
+  name-sort: なーすうぃっちこむぎちゃん まじかるて [つうじょうばん]
   name-en: "Magical Nurse Witch Komugi-chan"
   region: "NTSC-J"
 SLPM-65458:
@@ -36787,8 +36787,8 @@ SLPM-65499:
   name-en: "Bloody Roar 4"
   region: "NTSC-J"
 SLPM-65500:
-  name: ANUBIS ZONE OF THE ENDERS SPECIAL EDITION(通常版)
-  name-sort: ANUBIS ZONE OF THE ENDERS SPECIAL EDITION(つうじょうばん)
+  name: ANUBIS ZONE OF THE ENDERS SPECIAL EDITION [通常版]
+  name-sort: ANUBIS ZONE OF THE ENDERS SPECIAL EDITION [つうじょうばん]
   name-en: "Anubis - Zone of the Enders Special Edition"
   region: "NTSC-J"
 SLPM-65501:
@@ -36856,13 +36856,13 @@ SLPM-65510:
   name-en: "Prince of Tennis - Love of Prince - Bitter"
   region: "NTSC-J"
 SLPM-65512:
-  name: Angel’s Feather(限定版)
-  name-sort: Angel’s Feather(げんていばん)
+  name: Angel’s Feather [限定版]
+  name-sort: Angel’s Feather [げんていばん]
   name-en: "Angel's Feather [Limited Edition]"
   region: "NTSC-J"
 SLPM-65513:
-  name: Angel’s Feather(通常版)
-  name-sort: Angel’s Feather(つうじょうばん)
+  name: Angel’s Feather [通常版]
+  name-sort: Angel’s Feather [つうじょうばん]
   name-en: "Angel's Feather"
   region: "NTSC-J"
 SLPM-65514:
@@ -36894,13 +36894,13 @@ SLPM-65519:
   name-en: "Raimuiro Senkitan Jun"
   region: "NTSC-J"
 SLPM-65520:
-  name: てんたま2wins(限定版)
-  name-sort: てんたま2wins(げんていばん)
+  name: てんたま2wins [限定版]
+  name-sort: てんたま2wins [げんていばん]
   name-en: "Tentama 2 Wins [Limited Edition]"
   region: "NTSC-J"
 SLPM-65521:
-  name: てんたま2wins(通常版)
-  name-sort: てんたま2wins(つうじょうばん)
+  name: てんたま2wins [通常版]
+  name-sort: てんたま2wins [つうじょうばん]
   name-en: "Tentama 2 Wins"
   region: "NTSC-J"
 SLPM-65522:
@@ -36954,8 +36954,8 @@ SLPM-65532:
   name-en: "Puyo Puyo Fever"
   region: "NTSC-J"
 SLPM-65533:
-  name: ピューと吹く!ジャガー 明日のジャンプ (初回限定版)
-  name-sort: ぴゅーとふく!じゃがー あしたのじゃんぷ (しょかいげんていばん)
+  name: ピューと吹く!ジャガー 明日のジャンプ [初回限定版]
+  name-sort: ぴゅーとふく!じゃがー あしたのじゃんぷ [しょかいげんていばん]
   name-en: "Pyu to Fuku! Jaguar Ashita no Japan"
   region: "NTSC-J"
 SLPM-65534:
@@ -36972,13 +36972,13 @@ SLPM-65536:
   name: "Houshin Engi 2"
   region: "NTSC-J"
 SLPM-65537:
-  name: 超・バトル封神【KOEI The Best】
-  name-sort: ちょう・ばとるほうしん【KOEI The Best】
+  name: 超・バトル封神 [KOEI The Best]
+  name-sort: ちょう・ばとるほうしん [KOEI The Best]
   name-en: "Chou Battle Houshin [Koei The Best]"
   region: "NTSC-J"
 SLPM-65538:
-  name: 007 ナイトファイア【EA BEST HITS】
-  name-sort: 007 ないとふぁいあ【EA BEST HITS】
+  name: 007 ナイトファイア [EA BEST HITS]
+  name-sort: 007 ないとふぁいあ [EA BEST HITS]
   name-en: "007 - Nightfire [EA Best Hits]"
   region: "NTSC-J"
   clampModes:
@@ -37001,8 +37001,8 @@ SLPM-65540:
   name-en: "Galaxy Angel - Moonlit Lovers [First Limited Edition]"
   region: "NTSC-J"
 SLPM-65541:
-  name: 愛蔵版 アンジェリーク トロワ【KOEI The Best】
-  name-sort: あいぞうばん あんじぇりーく とろわ【KOEI The Best】
+  name: 愛蔵版 アンジェリーク トロワ [KOEI The Best]
+  name-sort: あいぞうばん あんじぇりーく とろわ [KOEI The Best]
   name-en: "Angelique Trois - Aizouhen [Koei The Best]"
   region: "NTSC-J"
 SLPM-65542:
@@ -37021,8 +37021,8 @@ SLPM-65545:
   name-en: "Juurokuya Renka - Kami Furusato"
   region: "NTSC-J"
 SLPM-65546:
-  name: CROSS+CHANNEL 〜To all people〜(限定版)
-  name-sort: CROSS+CHANNEL 〜To all people〜(げんていばん)
+  name: CROSS+CHANNEL 〜To all people〜 [限定版]
+  name-sort: CROSS+CHANNEL 〜To all people〜 [げんていばん]
   name-en: "Cross Channel - To All People [Limited Edition]"
   region: "NTSC-J"
 SLPM-65547:
@@ -37036,13 +37036,13 @@ SLPM-65548:
   name-en: "Freedom Fighters"
   region: "NTSC-J"
 SLPM-65549:
-  name: Remember 11 〜the age of infinity〜(限定版)
-  name-sort: Remember 11 〜the age of infinity〜(げんていばん)
+  name: Remember 11 〜the age of infinity〜 [限定版]
+  name-sort: Remember 11 〜the age of infinity〜 [げんていばん]
   name-en: "Remember 11 - The Age of Infinity [Limited Edition]"
   region: "NTSC-J"
 SLPM-65550:
-  name: Remember 11 〜the age of infinity〜(通常版)
-  name-sort: Remember 11 〜the age of infinity〜(つうじょうばん)
+  name: Remember 11 〜the age of infinity〜 [通常版]
+  name-sort: Remember 11 〜the age of infinity〜 [つうじょうばん]
   name-en: "Remember 11 - The Age of Infinity"
   region: "NTSC-J"
 SLPM-65551:
@@ -37082,8 +37082,8 @@ SLPM-65556:
   name-en: "Nobunaga no Yabou - Tenka Sousei"
   region: "NTSC-J"
 SLPM-65557:
-  name: ステディ×スタディ(限定版)
-  name-sort: すてでぃ×すたでぃ(げんていばん)
+  name: ステディ×スタディ [限定版]
+  name-sort: すてでぃ×すたでぃ [げんていばん]
   name-en: "Steady X Study [Limited Edition]"
   region: "NTSC-J"
 SLPM-65558:
@@ -37092,8 +37092,8 @@ SLPM-65558:
   name-en: "Steady X Study"
   region: "NTSC-J"
 SLPM-65559:
-  name: てのひらをたいように ～永久の絆～(初回限定版)
-  name-sort: てのひらをたいように ～えいきゅうのきずな～(しょかいげんていばん)
+  name: てのひらをたいように ～永久の絆～ [初回限定版]
+  name-sort: てのひらをたいように ～えいきゅうのきずな～ [しょかいげんていばん]
   name-en: "Tenohira wo Taiyou ni [Limited Edition]"
   region: "NTSC-J"
 SLPM-65560:
@@ -37132,8 +37132,8 @@ SLPM-65569:
   name-en: "Kita He - Diamond Dust + Kiss is Beginning"
   region: "NTSC-J"
 SLPM-65570:
-  name: フロッガー(コナミ殿堂セレクション)
-  name-sort: ふろっがー(こなみでんどうせれくしょん)
+  name: フロッガー [コナミ殿堂セレクション]
+  name-sort: ふろっがー [こなみでんどうせれくしょん]
   name-en: "Frogger [Konami Palace Collection]"
   region: "NTSC-J"
 SLPM-65571:
@@ -37147,8 +37147,8 @@ SLPM-65572:
   name-en: "Generation of Chaos 4"
   region: "NTSC-J"
 SLPM-65573:
-  name: WRC II ～EXTREME～【Spike The Best】
-  name-sort: WRC II ～EXTREME～【Spike The Best】
+  name: WRC II ～EXTREME～ [Spike The Best]
+  name-sort: WRC II ～EXTREME～ [Spike The Best]
   name-en: "WRC II Extreme [Spike The Best]"
   region: "NTSC-J"
   gameFixes:
@@ -37245,8 +37245,8 @@ SLPM-65590:
   name-en: "Densha de Go! Final"
   region: "NTSC-J"
 SLPM-65591:
-  name: ロスト・アヤ・ソフィア(限定版)
-  name-sort: ろすと・あや・そふぃあ(げんていばん)
+  name: ロスト・アヤ・ソフィア [限定版]
+  name-sort: ろすと・あや・そふぃあ [げんていばん]
   name-en: "Lost Aya Sophia [Limited Edition]"
   region: "NTSC-J"
 SLPM-65592:
@@ -37319,8 +37319,8 @@ SLPM-65604:
   region: "NTSC-J"
   compat: 5
 SLPM-65607:
-  name: 3LDK 〜幸せになろうよ〜(初回限定版)
-  name-sort: 3LDK 〜しあわせになろうよ〜(しょかいげんていばん)
+  name: 3LDK 〜幸せになろうよ〜 [初回限定版]
+  name-sort: 3LDK 〜しあわせになろうよ〜 [しょかいげんていばん]
   name-en: "3LDK - Shiawase ni Narou yo [Limited Edition]"
   region: "NTSC-J"
 SLPM-65608:
@@ -37358,8 +37358,8 @@ SLPM-65613:
   name-en: "Yu-Gi-Oh! Capsule Monster Coliseum"
   region: "NTSC-J"
 SLPM-65614:
-  name: ニード・フォー・スピード アンダーグラウンド【EA BEST HITS】
-  name-sort: にーど・ふぉー・すぴーど あんだーぐらうんど【EA BEST HITS】
+  name: ニード・フォー・スピード アンダーグラウンド [EA BEST HITS]
+  name-sort: にーど・ふぉー・すぴーど あんだーぐらうんど [EA BEST HITS]
   name-en: "Need for Speed - Underground J"
   region: "NTSC-J"
   gameFixes:
@@ -37370,13 +37370,13 @@ SLPM-65615:
   name-en: "Dokapon DX"
   region: "NTSC-J"
 SLPM-65616:
-  name: 十二国記-紅蓮の標 黄塵の路-(コナミ・ザ・ベスト)
-  name-sort: じゅうにこくき-ぐれんのしるべ こうじんのみち-(こなみ・ざ・べすと)
+  name: 十二国記-紅蓮の標 黄塵の路- [コナミ・ザ・ベスト]
+  name-sort: じゅうにこくき-ぐれんのしるべ こうじんのみち- [こなみ・ざ・べすと]
   name-en: "Juunikoku-ki - Guren no Shirube Koejin no Michi [Konami The Best]"
   region: "NTSC-J"
 SLPM-65617:
-  name: 冒険時代活劇ゴエモン(コナミ殿堂セレクション)
-  name-sort: ぼうけんじだいかつげきごえもん(こなみでんどうせれくしょん)
+  name: 冒険時代活劇ゴエモン [コナミ殿堂セレクション]
+  name-sort: ぼうけんじだいかつげきごえもん [こなみでんどうせれくしょん]
   name-en: "Bouken Jidai Katsugeki Goemon [Konami Collection]"
   region: "NTSC-J"
 SLPM-65618:
@@ -37388,8 +37388,8 @@ SLPM-65619:
   name-en: "Tom Clancy's Ghost Recon - Jungle Storm"
   region: "NTSC-J"
 SLPM-65620:
-  name: 悪代官2～妄想伝～【グローバル ザ・ベスト】
-  name-sort: あくだいかん2～もうそうでん～【ぐろーばる ざ・べすと】
+  name: 悪代官2～妄想伝～ [グローバル ザ・ベスト]
+  name-sort: あくだいかん2～もうそうでん～ [ぐろーばる ざ・べすと]
   name-en: "Akudaikan 2 - Mousouden [Global The Best]"
   region: "NTSC-J"
 SLPM-65621:
@@ -37399,8 +37399,8 @@ SLPM-65621:
   region: "NTSC-J"
   compat: 5
 SLPM-65622:
-  name: サイレントヒル3 (コナミ・ザ・ベスト)
-  name-sort: さいれんとひる3 (こなみ・ざ・べすと)
+  name: サイレントヒル3 [コナミ・ザ・ベスト]
+  name-sort: さいれんとひる3 [こなみ・ざ・べすと]
   name-en: "Silent Hill 3 [Konami The Best]"
   region: "NTSC-J"
   clampModes:
@@ -37416,23 +37416,23 @@ SLPM-65622:
     - "SLPM-65341"
     - "SLPM-65631"
 SLPM-65623:
-  name: 探偵学園Q奇翁館の殺意(コナミ ザ ベスト)
-  name-sort: たんていがくえんQきおきなかんのさつい(こなみ ざ べすと)
+  name: 探偵学園Q奇翁館の殺意 [コナミ ザ ベスト]
+  name-sort: たんていがくえんQきおきなかんのさつい [こなみ ざ べすと]
   name-en: "Tantei Gakuen Q - Kiokan no Satsui [Konami The Best]"
   region: "NTSC-J"
 SLPM-65624:
-  name: DEAR BOYS Fast Break!(コナミ殿堂セレクション)
-  name-sort: DEAR BOYS Fast Break!(こなみでんどうせれくしょん)
+  name: DEAR BOYS Fast Break! [コナミ殿堂セレクション]
+  name-sort: DEAR BOYS Fast Break! [こなみでんどうせれくしょん]
   name-en: "Dear Boys Fast Break! [Konami Palace Collection]"
   region: "NTSC-J"
 SLPM-65625:
-  name: あしたのジョー～まっ白に燃え尽きろ!～(コナミ ザ ベスト)
-  name-sort: あしたのじょー～まっしろにもえつきろ!～(こなみ ざ べすと)
+  name: あしたのジョー～まっ白に燃え尽きろ!～ [コナミ ザ ベスト]
+  name-sort: あしたのじょー～まっしろにもえつきろ!～ [こなみ ざ べすと]
   name-en: "Ashita no Joe - Masshiro ni Moetsukuru [Konami The Best]"
   region: "NTSC-J"
 SLPM-65626:
-  name: 恐怖新聞【平成版】～怪奇!心霊ファイル～(コナミ ザ ベスト)
-  name-sort: きょうふしんぶん【へいせいばん】～かいき!しんれいふぁいる～(こなみ ざ べすと)
+  name: 恐怖新聞【平成版】～怪奇!心霊ファイル～ [コナミ ザ ベスト]
+  name-sort: きょうふしんぶん【へいせいばん】～かいき!しんれいふぁいる～ [こなみ ざ べすと]
   name-en: "Kyoufu Shinbun (Heisei-Han) Kaiki! Shinrei File [Konami The Best]"
   region: "NTSC-J"
 SLPM-65627:
@@ -37456,8 +37456,8 @@ SLPM-65630:
   name-en: "Jikkyou Powerful Pro Yakyuu 11"
   region: "NTSC-J"
 SLPM-65631:
-  name: サイレントヒル2 最後の詩 (コナミ殿堂セレクション)
-  name-sort: さいれんとひる2 さいごのし (こなみでんどうせれくしょん)
+  name: サイレントヒル2 最後の詩 [コナミ殿堂セレクション]
+  name-sort: さいれんとひる2 さいごのし [こなみでんどうせれくしょん]
   name-en: "Silent Hill 2 [Konami The Best]"
   region: "NTSC-J"
   speedHacks:
@@ -37485,8 +37485,8 @@ SLPM-65635:
   name-en: "Bakuen Kakeshi Neverland Senki Zero"
   region: "NTSC-J"
 SLPM-65636:
-  name: 三國志戦記2【KOEI The Best】
-  name-sort: さんごくしせんき2【KOEI The Best】
+  name: 三國志戦記2 [KOEI The Best]
+  name-sort: さんごくしせんき2 [KOEI The Best]
   name-en: "Sangokushi Senki 2 [Koei The Best]"
   region: "NTSC-J"
 SLPM-65637:
@@ -37537,8 +37537,8 @@ SLPM-65646:
   name: "Komorebi no Namikimichi - Utsurikawaru Kisetsu no Naka de"
   region: "NTSC-J"
 SLPM-65647:
-  name: 遊戯王真デュエルモンスターズ II 継承されし記憶(コナミ殿堂セレクション)
-  name-sort: ゆうぎおうまでゅえるもんすたーず II けいしょうされしきおく(こなみでんどうせれくしょん)
+  name: 遊戯王真デュエルモンスターズ II 継承されし記憶 [コナミ殿堂セレクション]
+  name-sort: ゆうぎおうまでゅえるもんすたーず II けいしょうされしきおく [こなみでんどうせれくしょん]
   name-en: "Yu-Gi-Oh! 2 [Konami Dendou Collection]"
   region: "NTSC-J"
   roundModes:
@@ -37546,23 +37546,23 @@ SLPM-65647:
   clampModes:
     eeClampMode: 2 # Partially fixes battle animation.
 SLPM-65648:
-  name: メダルオブオナー 史上最大の作戦【EA BEST HITS】
-  name-sort: めだるおぶおなー しじょうさいだいのさくせん【EA BEST HITS】
+  name: メダルオブオナー 史上最大の作戦 [EA BEST HITS]
+  name-sort: めだるおぶおなー しじょうさいだいのさくせん [EA BEST HITS]
   name-en: "Medal of Honor - Frontline [EA Best Hits]"
   region: "NTSC-J"
 SLPM-65649:
-  name: NBAストリート2 ダンク天国【EA BEST HITS】
-  name-sort: NBAすとりーと2 だんくてんごく【EA BEST HITS】
+  name: NBAストリート2 ダンク天国 [EA BEST HITS]
+  name-sort: NBAすとりーと2 だんくてんごく [EA BEST HITS]
   name-en: "NBA Street Vol. 2 [EA Best Hits]"
   region: "NTSC-J"
 SLPM-65650:
-  name: ハリー・ポッターと賢者の石【EA BEST HITS】
-  name-sort: はりー・ぽったーとけんじゃのいし【EA BEST HITS】
+  name: ハリー・ポッターと賢者の石 [EA BEST HITS]
+  name-sort: はりー・ぽったーとけんじゃのいし [EA BEST HITS]
   name-en: "Harry Potter and the Sorcerer's Stone [EA Best Hits]"
   region: "NTSC-J"
 SLPM-65651:
-  name: 九龍妖魔學園紀(デラックスパック)
-  name-sort: くうろんようまがくえんき(でらっくすぱっく)
+  name: 九龍妖魔學園紀 [デラックスパック]
+  name-sort: くうろんようまがくえんき [でらっくすぱっく]
   name-en: "Kowloon Youma Gakuenki [Limited Edition]"
   region: "NTSC-J"
 SLPM-65652:
@@ -37625,8 +37625,8 @@ SLPM-65665:
   name-en: "BloodRayne"
   region: "NTSC-J"
 SLPM-65666:
-  name: NBAライブ2004【EA BEST HITS】
-  name-sort: NBAらいぶ2004【EA BEST HITS】
+  name: NBAライブ2004 [EA BEST HITS]
+  name-sort: NBAらいぶ2004 [EA BEST HITS]
   name-en: "NBA Live 2004 [EA Best Hits]"
   region: "NTSC-J"
   clampModes:
@@ -37647,8 +37647,8 @@ SLPM-65670:
   name-en: "Aqua Kids"
   region: "NTSC-J"
 SLPM-65671:
-  name: W 〜ウィッシュ〜(初回限定版)
-  name-sort: W 〜うぃっしゅ〜(しょかいげんていばん)
+  name: W 〜ウィッシュ〜 [初回限定版]
+  name-sort: W 〜うぃっしゅ〜 [しょかいげんていばん]
   name-en: "W - Wish [Limited Edition]"
   region: "NTSC-J"
 SLPM-65672:
@@ -37665,8 +37665,8 @@ SLPM-65674:
   name-en: "Taikou Risshiden V"
   region: "NTSC-J"
 SLPM-65675:
-  name: ふぁいなる・アプローチ (初回限定版)
-  name-sort: ふぁいなる・あぷろーち (しょかいげんていばん)
+  name: ふぁいなる・アプローチ [初回限定版]
+  name-sort: ふぁいなる・あぷろーち [しょかいげんていばん]
   name-en: "Final Approach [Limited Edition]"
   region: "NTSC-J"
 SLPM-65676:
@@ -37675,18 +37675,18 @@ SLPM-65676:
   name-en: "Final Approach"
   region: "NTSC-J"
 SLPM-65677:
-  name: テニスの王子様 Smash Hit!(コナミ ザ ベスト)
-  name-sort: てにすのおうじさま Smash Hit!(こなみ ざ べすと)
+  name: テニスの王子様 Smash Hit! [コナミ ザ ベスト]
+  name-sort: てにすのおうじさま Smash Hit! [こなみ ざ べすと]
   name-en: "Prince of Tennis - Smash Hit! [Konami The Best]"
   region: "NTSC-J"
 SLPM-65678:
-  name: テニスの王子様 Smash Hit!2(コナミ ザ ベスト)
-  name-sort: てにすのおうじさま Smash Hit!2(こなみ ざ べすと)
+  name: テニスの王子様 Smash Hit!2 [コナミ ザ ベスト]
+  name-sort: てにすのおうじさま Smash Hit!2 [こなみ ざ べすと]
   name-en: "Prince of Tennis - Smash Hit! 2 [Konami The Best]"
   region: "NTSC-J"
 SLPM-65679:
-  name: テニスの王子様 SWEAT＆TEARS 2(コナミ ザ ベスト)
-  name-sort: てにすのおうじさま SWEAT＆TEARS 2(こなみ ざ べすと)
+  name: テニスの王子様 SWEAT＆TEARS 2 [コナミ ザ ベスト]
+  name-sort: てにすのおうじさま SWEAT＆TEARS 2 [こなみ ざ べすと]
   name-en: "Prince of Tennis - Sweat 2 [Konami The Best]"
   region: "NTSC-J"
 SLPM-65680:
@@ -37705,8 +37705,8 @@ SLPM-65682:
   name-en: "Monochrome"
   region: "NTSC-J"
 SLPM-65683:
-  name: ヴィオラートのアトリエ～グラムナートの錬金術士2～【ガストベストプライス】
-  name-sort: ゔぃおらーとのあとりえ～ぐらむなーとのれんきんじゅつし2～【がすとべすとぷらいす】
+  name: ヴィオラートのアトリエ～グラムナートの錬金術士2～ [ガストベストプライス]
+  name-sort: ゔぃおらーとのあとりえ～ぐらむなーとのれんきんじゅつし2～ [がすとべすとぷらいす]
   name-en: "Violet no Atelier - Gramnad no Renkinjutsushi [Gust Best Price]"
   region: "NTSC-J"
   gsHWFixes:
@@ -37780,13 +37780,13 @@ SLPM-65692:
     - "SLPM-65428"
     - "SLPM-74201"
 SLPM-65693:
-  name: ときめきメモリアル3～約束のあの場所で～(コナミ殿堂セレクション)
-  name-sort: ときめきめもりある3～やくそくのあのばしょで～(こなみでんどうせれくしょん)
+  name: ときめきメモリアル3～約束のあの場所で～ [コナミ殿堂セレクション]
+  name-sort: ときめきめもりある3～やくそくのあのばしょで～ [こなみでんどうせれくしょん]
   name-en: "Tokimeki Memorial 3 [Konami Palace Selection]"
   region: "NTSC-J"
 SLPM-65694:
-  name: 幻想水滸伝III(コナミ殿堂セレクション)
-  name-sort: げんそうすいこでんIII(こなみでんどうせれくしょん)
+  name: 幻想水滸伝III [コナミ殿堂セレクション]
+  name-sort: げんそうすいこでんIII [こなみでんどうせれくしょん]
   name-en: "Genso Suikoden 3 [Konami Dendou Collection]"
   region: "NTSC-J"
   memcardFilters:
@@ -37889,8 +37889,8 @@ SLPM-65715:
   name-en: "Angelique Etoile"
   region: "NTSC-J"
 SLPM-65716:
-  name: 凱歌の号砲 エアランドフォース【KOEI The Best】
-  name-sort: がいかのごうほう えあらんどふぉーす【KOEI The Best】
+  name: 凱歌の号砲 エアランドフォース [KOEI The Best]
+  name-sort: がいかのごうほう えあらんどふぉーす [KOEI The Best]
   name-en: "Gaika no Gouhou - Air Land Force [Koei The Best]"
   region: "NTSC-J"
 SLPM-65717:
@@ -37921,8 +37921,8 @@ SLPM-65719:
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
 SLPM-65720:
-  name: 真・三國無双2 猛将伝【KOEI The Best】
-  name-sort: しん・さんごくむそう2 もうしょうでん【KOEI The Best】
+  name: 真・三國無双2 猛将伝 [KOEI The Best]
+  name-sort: しん・さんごくむそう2 もうしょうでん [KOEI The Best]
   name-en: "Shin Sangoku Musou 2 Mushoden [Koei the Best]"
   region: "NTSC-J"
 SLPM-65721:
@@ -37931,8 +37931,8 @@ SLPM-65721:
   name-en: "Pro Yakyuu Spirits 2004 Climax"
   region: "NTSC-J"
 SLPM-65722:
-  name: Airforce Delta ～Blue Wing Knights～ (コナミ ザ ベスト)
-  name-sort: Airforce Delta ～Blue Wing Knights～ (こなみ ざ べすと)
+  name: Airforce Delta ～Blue Wing Knights～ [コナミ ザ ベスト]
+  name-sort: Airforce Delta ～Blue Wing Knights～ [こなみ ざ べすと]
   name-en: "Airforce Delta - Blue Wing Knights [Konami the Best]"
   region: "NTSC-J"
 SLPM-65723:
@@ -37946,8 +37946,8 @@ SLPM-65724:
   name-en: "Choro Q Works"
   region: "NTSC-J"
 SLPM-65725:
-  name: 007エブリシング オア ナッシング【EA BEST HITS】
-  name-sort: 007えぶりしんぐ おあ なっしんぐ【EA BEST HITS】
+  name: 007エブリシング オア ナッシング [EA BEST HITS]
+  name-sort: 007えぶりしんぐ おあ なっしんぐ [EA BEST HITS]
   name-en: "007 - Everything or Nothing [EA Best Hits]"
   region: "NTSC-J"
   gsHWFixes:
@@ -37955,8 +37955,8 @@ SLPM-65725:
     mipmap: 2 # Cleans up texture detail.
     trilinearFiltering: 1 # Smoothes out mipmapping.
 SLPM-65726:
-  name: スター・ウォーズ ジャンゴ・フェット【EA BEST HITS】
-  name-sort: すたー・うぉーず じゃんご・ふぇっと【EA BEST HITS】
+  name: スター・ウォーズ ジャンゴ・フェット [EA BEST HITS]
+  name-sort: すたー・うぉーず じゃんご・ふぇっと [EA BEST HITS]
   name-en: "Star Wars - Jango Fett [EA Best Hits]"
   region: "NTSC-J"
   compat: 5
@@ -37966,8 +37966,8 @@ SLPM-65726:
     vuClampMode: 3
     eeClampMode: 2 # Fixes missing/grey texture or geometry ingame.
 SLPM-65727:
-  name: ロード・オブ・ザ・リング/王の帰還【EA BEST HITS】
-  name-sort: ろーど・おぶ・ざ・りんぐ/おうのきかん【EA BEST HITS】
+  name: ロード・オブ・ザ・リング/王の帰還 [EA BEST HITS]
+  name-sort: ろーど・おぶ・ざ・りんぐ/おうのきかん [EA BEST HITS]
   name-en: "Lord of the Rings, The - The Return of the King [EA Best Hits]"
   region: "NTSC-J"
 SLPM-65728:
@@ -38067,8 +38067,8 @@ SLPM-65741:
     cpuSpriteRenderLevel: 2 # Needed for above.
     recommendedBlendingLevel: 2 # Fixes car and bike exhaust smoke rendering.
 SLPM-65742:
-  name: COOL GIRL(コナミ ザ ベスト)
-  name-sort: COOL GIRL(こなみ ざ べすと)
+  name: COOL GIRL [コナミ ザ ベスト]
+  name-sort: COOL GIRL [こなみ ざ べすと]
   name-en: "Cool Girl [Konami the Best]"
   region: "NTSC-J"
   memcardFilters:
@@ -38080,13 +38080,13 @@ SLPM-65743:
   name: "Cool Girl (Disc 2) (Aska Side)"
   region: "NTSC-J"
 SLPM-65744:
-  name: ファイアーファイター F.D.18(コナミ ザ ベスト)
-  name-sort: ふぁいあーふぁいたー F.D.18(こなみ ざ べすと)
+  name: ファイアーファイター F.D.18 [コナミ ザ ベスト]
+  name-sort: ふぁいあーふぁいたー F.D.18 [こなみ ざ べすと]
   name-en: "Firefighter F.D. 18 [Konami The Best]"
   region: "NTSC-J"
 SLPM-65745:
-  name: ときめきメモリアル Girl’s Side (コナミ殿堂セレクション)
-  name-sort: ときめきめもりある Girl’s Side (こなみでんどうせれくしょん)
+  name: ときめきメモリアル Girl’s Side [コナミ殿堂セレクション]
+  name-sort: ときめきめもりある Girl’s Side [こなみでんどうせれくしょん]
   name-en: "Tokimeki Memorial - Girl's Side [Konami Dendou Collection]"
   region: "NTSC-J"
 SLPM-65746:
@@ -38127,8 +38127,8 @@ SLPM-65752:
   clampModes:
     eeClampMode: 2 # Reduces FPU calculation errors.
 SLPM-65753:
-  name: 決戦【コーエー定番シリーズ】
-  name-sort: けっせん【こーえーていばんしりーず】
+  name: 決戦 [コーエー定番シリーズ]
+  name-sort: けっせん [こーえーていばんしりーず]
   name-en: "Kessen [Koei Collection Series]"
   region: "NTSC-J"
 SLPM-65754:
@@ -38153,8 +38153,8 @@ SLPM-65756:
   name-en: "Tennis no Oji-Sama - Rush & Dream"
   region: "NTSC-J"
 SLPM-65757:
-  name: メダル オブ オナー ライジングサン【EA BEST HITS】
-  name-sort: めだる おぶ おなー らいじんぐさん【EA BEST HITS】
+  name: メダル オブ オナー ライジングサン [EA BEST HITS]
+  name-sort: めだる おぶ おなー らいじんぐさん [EA BEST HITS]
   name-en: "Medal of Honor - Rising Sun [EA Best Hits]"
   region: "NTSC-J"
 SLPM-65758:
@@ -38293,8 +38293,8 @@ SLPM-65783:
   name-en: "Nobunaga no Yabou Online - Tappi no Shou"
   region: "NTSC-J"
 SLPM-65785:
-  name: なついろ〜星屑のメモリー〜 (初回限定版)
-  name-sort: なついろ〜ほしくずのめもりー〜 (しょかいげんていばん)
+  name: なついろ〜星屑のメモリー〜 [初回限定版]
+  name-sort: なついろ〜ほしくずのめもりー〜 [しょかいげんていばん]
   name-en: "Natsuiro - Hoshikuzu no Memory [Limited Edition]"
   region: "NTSC-J"
 SLPM-65786:
@@ -38340,8 +38340,8 @@ SLPM-65791:
   name-en: "S.L.A.I. - Steel Lancer Arena International"
   region: "NTSC-J"
 SLPM-65793:
-  name: SSX3【EA BEST HITS】
-  name-sort: SSX3【EA BEST HITS】
+  name: SSX3 [EA BEST HITS]
+  name-sort: SSX3 [EA BEST HITS]
   name-en: "SSX 3 [EA Best Hits]"
   region: "NTSC-J"
   gsHWFixes:
@@ -38415,13 +38415,13 @@ SLPM-65801:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
 SLPM-65802:
-  name: DEF JAM VENDETTA【EA BEST HITS】
-  name-sort: DEF JAM VENDETTA【EA BEST HITS】
+  name: DEF JAM VENDETTA [EA BEST HITS]
+  name-sort: DEF JAM VENDETTA [EA BEST HITS]
   name-en: "Def Jam - Vendetta [EA Best Hits]"
   region: "NTSC-J"
 SLPM-65803:
-  name: フリーダム・ファイターズ【EA BEST HITS】
-  name-sort: ふりーだむ・ふぁいたーず【EA BEST HITS】
+  name: フリーダム・ファイターズ [EA BEST HITS]
+  name-sort: ふりーだむ・ふぁいたーず [EA BEST HITS]
   name-en: "Freedom Fighters [EA Best Hits]"
   region: "NTSC-J"
 SLPM-65804:
@@ -38487,23 +38487,23 @@ SLPM-65816:
   name-en: "Shin Bakusou Dekotora Densetsu"
   region: "NTSC-J"
 SLPM-65817:
-  name: テニスの王子様 Love of Prince Sweet(コナミ殿堂セレクション)
-  name-sort: てにすのおうじさま Love of Prince Sweet(こなみでんどうせれくしょん)
+  name: テニスの王子様 Love of Prince Sweet [コナミ殿堂セレクション]
+  name-sort: てにすのおうじさま Love of Prince Sweet [こなみでんどうせれくしょん]
   name-en: "Tennis no Oji-Sama - Love of Prince Sweet [Konami Palace Selection]"
   region: "NTSC-J"
 SLPM-65818:
-  name: テニスの王子様 Love of Prince Bitter(コナミ殿堂セレクション)
-  name-sort: てにすのおうじさま Love of Prince Bitter(こなみでんどうせれくしょん)
+  name: テニスの王子様 Love of Prince Bitter [コナミ殿堂セレクション]
+  name-sort: てにすのおうじさま Love of Prince Bitter [こなみでんどうせれくしょん]
   name-en: "Tennis no Oji-Sama - Love of Prince Bitter [Konami Palace Selection]"
   region: "NTSC-J"
 SLPM-65819:
-  name: テニスの王子様 Kiss of Prince ICE(コナミ殿堂セレクション)
-  name-sort: てにすのおうじさま Kiss of Prince ICE(こなみでんどうせれくしょん)
+  name: テニスの王子様 Kiss of Prince ICE [コナミ殿堂セレクション]
+  name-sort: てにすのおうじさま Kiss of Prince ICE [こなみでんどうせれくしょん]
   name-en: "Tennis no Oji-Sama - Kiss of Prince - Ice Version [Konami Palace Selection]"
   region: "NTSC-J"
 SLPM-65820:
-  name: テニスの王子様 Kiss of Prince FLAME(コナミ殿堂セレクション)
-  name-sort: てにすのおうじさま Kiss of Prince FLAME(こなみでんどうせれくしょん)
+  name: テニスの王子様 Kiss of Prince FLAME [コナミ殿堂セレクション]
+  name-sort: てにすのおうじさま Kiss of Prince FLAME [こなみでんどうせれくしょん]
   name-en: "Tennis no Oji-Sama - Kiss of Prince - Flame Version [Konami Palace Selection]"
   region: "NTSC-J"
 SLPM-65821:
@@ -38568,8 +38568,8 @@ SLPM-65832:
   name-en: "Izumo Complete"
   region: "NTSC-J"
 SLPM-65833:
-  name: 遙かなる時空の中で 2【KOEI The Best】
-  name-sort: はるかなるときのなかで 2【KOEI The Best】
+  name: 遙かなる時空の中で 2 [KOEI The Best]
+  name-sort: はるかなるときのなかで 2 [KOEI The Best]
   name-en: "Harukanaru Jikuu no Naka De 2 [Koei the Best]"
   region: "NTSC-J"
 SLPM-65834:
@@ -38595,8 +38595,8 @@ SLPM-65837:
   name-en: "Terminator 3 - Redemption"
   region: "NTSC-J"
 SLPM-65838:
-  name: 半熟銀河弁当 半熟英雄4 〜7人の半熟英雄〜(限定版)
-  name-sort: はんじゅくぎんがべんとう はんじゅくえいゆう4 〜7にんのはんじゅくえいゆう〜(げんていばん)
+  name: 半熟銀河弁当 半熟英雄4 〜7人の半熟英雄〜 [限定版]
+  name-sort: はんじゅくぎんがべんとう はんじゅくえいゆう4 〜7にんのはんじゅくえいゆう〜 [げんていばん]
   name-en: "Hanjuku Hero 4 [Limited Edition]"
   region: "NTSC-J"
   gsHWFixes:
@@ -38785,13 +38785,13 @@ SLPM-65874:
   name-en: "Simple 2000 Series Vol. 71 - The Fantasy Renai Adventure - Kanojo no Densetsu"
   region: "NTSC-J"
 SLPM-65875:
-  name: グローランサーIV 〜 Wayfarer of the time 〜 (Atlus Best Collection)
-  name-sort: ぐろーらんさーIV 〜 Wayfarer of the time 〜 (Atlus Best Collection)
+  name: グローランサーIV 〜 Wayfarer of the time 〜 [Atlus Best Collection]
+  name-sort: ぐろーらんさーIV 〜 Wayfarer of the time 〜 [Atlus Best Collection]
   name-en: "Growlanser IV - Wayfarer of the Time [Atlus The Best]"
   region: "NTSC-J"
 SLPM-65876:
-  name: BUSIN 0 Wizardry Alternative NEO(Atlus Best Collection)
-  name-sort: BUSIN 0 Wizardry Alternative NEO(Atlus Best Collection)
+  name: BUSIN 0 Wizardry Alternative NEO [Atlus Best Collection]
+  name-sort: BUSIN 0 Wizardry Alternative NEO [Atlus Best Collection]
   name-en: "Busin 0 - Wizardry Alternative Neo [Atlus Best Collection]"
   region: "NTSC-J"
   gsHWFixes:
@@ -38803,8 +38803,8 @@ SLPM-65878:
   name-en: "Galaxy Angel - Eternal Lovers"
   region: "NTSC-J"
 SLPM-65879:
-  name: ラブひな ご〜じゃす チラッとハプニング (コナミ殿堂セレクション)
-  name-sort: らぶひな ご〜じゃす ちらっとはぷにんぐ (こなみでんどうせれくしょん)
+  name: ラブひな ご〜じゃす チラッとハプニング [コナミ殿堂セレクション]
+  name-sort: らぶひな ご〜じゃす ちらっとはぷにんぐ [こなみでんどうせれくしょん]
   name-en: "Love Hina Gorgeous [Konami Dendou Selection]"
   region: "NTSC-J"
 SLPM-65880:
@@ -38971,8 +38971,8 @@ SLPM-65909:
   roundModes:
     eeRoundMode: 1 # Fixes object balls never stopping in the Monkey Billiards DX minigame.
 SLPM-65910:
-  name: カフェ・リンドバーグ -summer season-(Sweet Box 版)
-  name-sort: かふぇ・りんどばーぐ -summer season-(Sweet Box ばん)
+  name: カフェ・リンドバーグ -summer season- [Sweet Box 版]
+  name-sort: かふぇ・りんどばーぐ -summer season- [Sweet Box ばん]
   name-en: "Cafe Lindbergh - Summer Season [Sweet Box]"
   region: "NTSC-J"
 SLPM-65911:
@@ -39014,8 +39014,8 @@ SLPM-65916:
   name-en: "Harukanaru Jikuu no Kade - Hachiha Katsunori"
   region: "NTSC-J"
 SLPM-65917:
-  name: トランスフォーマー【THE BEST タカラモノ】
-  name-sort: とらんすふぉーまー【THE BEST たからもの】
+  name: トランスフォーマー [THE BEST タカラモノ]
+  name-sort: とらんすふぉーまー [THE BEST たからもの]
   name-en: "Transformers Tatakai [The Best]"
   region: "NTSC-J"
 SLPM-65918:
@@ -39036,23 +39036,23 @@ SLPM-65920:
   region: "NTSC-J"
   compat: 5
 SLPM-65921:
-  name: Piaキャロットへようこそ!!3(ベスト版)
-  name-sort: Piaきゃろっとへようこそ!!3(べすとばん)
+  name: Piaキャロットへようこそ!!3 [ベスト版]
+  name-sort: Piaきゃろっとへようこそ!!3 [べすとばん]
   name-en: "Pia Carrot e Youkoso!! 3 [Best Version]"
   region: "NTSC-J"
 SLPM-65922:
-  name: あいかぎ 〜ぬくもりとひだまりの中で〜 (ベスト版)
-  name-sort: あいかぎ 〜ぬくもりとひだまりのなかで〜 (べすとばん)
+  name: あいかぎ 〜ぬくもりとひだまりの中で〜 [ベスト版]
+  name-sort: あいかぎ 〜ぬくもりとひだまりのなかで〜 [べすとばん]
   name-en: "Aikagi [Best Version]"
   region: "NTSC-J"
 SLPM-65923:
-  name: Canvas 〜セピア色のモチーフ〜 (ベスト版)
-  name-sort: Canvas 〜せぴあいろのもちーふ〜 (べすとばん)
+  name: Canvas 〜セピア色のモチーフ〜 [ベスト版]
+  name-sort: Canvas 〜せぴあいろのもちーふ〜 [べすとばん]
   name-en: "Canvas [Best Version]"
   region: "NTSC-J"
 SLPM-65924:
-  name: この晴れた空の下で (数量限定版)
-  name-sort: このはれたそらのしたで (すうりょうげんていばん)
+  name: この晴れた空の下で [数量限定版]
+  name-sort: このはれたそらのしたで [すうりょうげんていばん]
   name-en: "Kono Haretasora no Shita de [Limited Edition]"
   region: "NTSC-J"
 SLPM-65925:
@@ -39093,8 +39093,8 @@ SLPM-65930:
   name-en: "EVE - Burst Error Plus [GameBridge The Best]"
   region: "NTSC-J"
 SLPM-65931:
-  name: 新紀幻想スペクトラルソウルズ【IFコレクション】
-  name-sort: しんきげんそうすぺくとらるそうるず【IFこれくしょん】
+  name: 新紀幻想スペクトラルソウルズ [IFコレクション]
+  name-sort: しんきげんそうすぺくとらるそうるず [IFこれくしょん]
   name-en: "Shinseiki Genso - Spectral Souls [IF Collection]"
   region: "NTSC-J"
 SLPM-65932:
@@ -39214,13 +39214,13 @@ SLPM-65953:
   name-en: "Final Fantasy XI [Entry Disc 2005]"
   region: "NTSC-J"
 SLPM-65954:
-  name: トム・クランシーシリーズ ゴーストリコン【ユービーアイベスト】
-  name-sort: とむ・くらんしーしりーず ごーすとりこん【ゆーびーあいべすと】
+  name: トム・クランシーシリーズ ゴーストリコン [ユービーアイベスト]
+  name-sort: とむ・くらんしーしりーず ごーすとりこん [ゆーびーあいべすと]
   name-en: "Tom Clancy's Ghost Recon [Ubisoft Best]"
   region: "NTSC-J"
 SLPM-65955:
-  name: トム・クランシーシリーズ スプリンターセル【ユービーアイソフトベスト】
-  name-sort: とむ・くらんしーしりーず すぷりんたーせる【ゆーびーあいそふとべすと】
+  name: トム・クランシーシリーズ スプリンターセル [ユービーアイソフトベスト]
+  name-sort: とむ・くらんしーしりーず すぷりんたーせる [ゆーびーあいそふとべすと]
   name-en: "Tom Clancy's Splinter Cell [Ubisoft Best]"
   region: "NTSC-J"
 SLPM-65957:
@@ -39229,8 +39229,8 @@ SLPM-65957:
   name-en: "Harukanaru Jikuu no Kade Hachiha Katsunori"
   region: "NTSC-J"
 SLPM-65958:
-  name: バーンアウト3:テイクダウン【EA BEST HITS】
-  name-sort: ばーんあうと3:ていくだうん【EA BEST HITS】
+  name: バーンアウト3:テイクダウン [EA BEST HITS]
+  name-sort: ばーんあうと3:ていくだうん [EA BEST HITS]
   name-en: "Burnout 3 - Takedown [EA Best Hits]"
   region: "NTSC-J"
   clampModes:
@@ -39261,8 +39261,8 @@ SLPM-65961:
   name-en: "North Wind Promise Forever"
   region: "NTSC-J"
 SLPM-65962:
-  name: ホームメイド 〜終の館〜(初回限定版)
-  name-sort: ほーむめいど 〜ついのやかた〜(しょかいげんていばん)
+  name: ホームメイド 〜終の館〜 [初回限定版]
+  name-sort: ほーむめいど 〜ついのやかた〜 [しょかいげんていばん]
   name-en: "Home Maid - Owari no Tachi [Limited Edition]"
   region: "NTSC-J"
 SLPM-65963:
@@ -39271,8 +39271,8 @@ SLPM-65963:
   name-en: "Home Maid - Owari no Tachi"
   region: "NTSC-J"
 SLPM-65964:
-  name: まじかる☆ている 〜ちっちゃな魔法使い〜(初回限定版)
-  name-sort: まじかる☆ている 〜ちっちゃなまほうつかい〜(しょかいげんていばん)
+  name: まじかる☆ている 〜ちっちゃな魔法使い〜 [初回限定版]
+  name-sort: まじかる☆ている 〜ちっちゃなまほうつかい〜 [しょかいげんていばん]
   name-en: "Magical Tale - Chitchana Mahoutsukai [Limited Edition]"
   region: "NTSC-J"
 SLPM-65965:
@@ -39301,8 +39301,8 @@ SLPM-65969:
   name-en: "Lovely Doll - Lovely Idol"
   region: "NTSC-J"
 SLPM-65970:
-  name: カッパの飼い方 -How to breed kappas- (コナミ殿堂セレクション)
-  name-sort: かっぱのかいかた -How to breed kappas- (こなみでんどうせれくしょん)
+  name: カッパの飼い方 -How to breed kappas- [コナミ殿堂セレクション]
+  name-sort: かっぱのかいかた -How to breed kappas- [こなみでんどうせれくしょん]
   name-en: "Kappa no Kai-Kata - How to Breed Kappas [Konami Palace Selection]"
   region: "NTSC-J"
 SLPM-65971:
@@ -39323,8 +39323,8 @@ SLPM-65973:
   name-en: "Mirai Shounen Conan"
   region: "NTSC-J"
 SLPM-65974:
-  name: 喧嘩番長(初回生産版)
-  name-sort: けんかばんちょう(しょかいせいさんばん)
+  name: 喧嘩番長 [初回生産版]
+  name-sort: けんかばんちょう [しょかいせいさんばん]
   name-en: "Kenka Banchou"
   region: "NTSC-J"
 SLPM-65975:
@@ -39365,8 +39365,8 @@ SLPM-65977:
   memcardFilters:
     - "SLPM-65976"
 SLPM-65978:
-  name: 鋼鉄の咆哮2 ウォーシップガンナー【KOEI THE BEST】
-  name-sort: くろがねのほうこう2 うぉーしっぷがんなー【KOEI THE BEST】
+  name: 鋼鉄の咆哮2 ウォーシップガンナー [KOEI THE BEST]
+  name-sort: くろがねのほうこう2 うぉーしっぷがんなー [KOEI THE BEST]
   name-en: "Kurogane no Houkou 2 - Warship Gunner [Koei The Best]"
   region: "NTSC-J"
 SLPM-65980:
@@ -39403,8 +39403,8 @@ SLPM-65985:
     roundSprite: 1 # Fixes font artifacts for health and other sprites.
     texturePreloading: 0 # Improves performance and prevents it disabling itself regardless.
 SLPM-65986:
-  name: Quartett!〜THE STAGE OF LOVE〜(初回限定版)
-  name-sort: Quartett!〜THE STAGE OF LOVE〜(しょかいげんていばん)
+  name: Quartett!〜THE STAGE OF LOVE〜 [初回限定版]
+  name-sort: Quartett!〜THE STAGE OF LOVE〜 [しょかいげんていばん]
   name-en: "Quartett! The Stage of Love [Limited Edition]"
   region: "NTSC-J"
 SLPM-65987:
@@ -39413,8 +39413,8 @@ SLPM-65987:
   name-en: "Quartett! The Stage of Love"
   region: "NTSC-J"
 SLPM-65988:
-  name: 少女義経伝・弐 〜刻を超える契り〜 (特別版)
-  name-sort: しょうじょよしつねでん・に 〜こくをこえるちぎり〜 (とくべつばん)
+  name: 少女義経伝・弐 〜刻を超える契り〜 [特別版]
+  name-sort: しょうじょよしつねでん・に 〜こくをこえるちぎり〜 [とくべつばん]
   name-en: "Shoujo Yoshitsune Den 2 [Premium Pack]"
   region: "NTSC-J"
 SLPM-65989:
@@ -39423,8 +39423,8 @@ SLPM-65989:
   name-en: "Shoujo Yoshitsune Den 2"
   region: "NTSC-J"
 SLPM-65990:
-  name: NEO CONTRA(コナミ殿堂セレクション)
-  name-sort: NEO CONTRA(こなみでんどうせれくしょん)
+  name: NEO CONTRA [コナミ殿堂セレクション]
+  name-sort: NEO CONTRA [こなみでんどうせれくしょん]
   name-en: "Neo Contra [Konami Palace Selection]"
   region: "NTSC-J"
   roundModes:
@@ -39432,8 +39432,8 @@ SLPM-65990:
   clampModes:
     eeClampMode: 2 # Reduces FPU calculation errors.
 SLPM-65991:
-  name: ANUBIS ZONE OF THE ENDERS SPECIAL EDITION (コナミ殿堂セレクション)
-  name-sort: ANUBIS ZONE OF THE ENDERS SPECIAL EDITION (こなみでんどうせれくしょん)
+  name: ANUBIS ZONE OF THE ENDERS SPECIAL EDITION [コナミ殿堂セレクション]
+  name-sort: ANUBIS ZONE OF THE ENDERS SPECIAL EDITION [こなみでんどうせれくしょん]
   name-en: "Anubis - Zone of the Enders Special Edition [Konami Dendou Collection]"
   region: "NTSC-J"
 SLPM-65994:
@@ -39508,8 +39508,8 @@ SLPM-66005:
   name: "Harukanaru Toki no Naka de 3"
   region: "NTSC-J"
 SLPM-66006:
-  name: 愛蔵版 アンジェリークトロワ【コーエー定番シリーズ】
-  name-sort: あいぞうばん あんじぇりーくとろわ【こーえーていばんしりーず】
+  name: 愛蔵版 アンジェリークトロワ [コーエー定番シリーズ]
+  name-sort: あいぞうばん あんじぇりーくとろわ [こーえーていばんしりーず]
   name-en: "Angelique Trois - Aizouhen [Koei Selection]"
   region: "NTSC-J"
 SLPM-66007:
@@ -39529,28 +39529,28 @@ SLPM-66009:
   region: "NTSC-J"
   compat: 5
 SLPM-66010:
-  name: テニスの王子様 Smash Hit! (コナミ殿堂セレクション)
-  name-sort: てにすのおうじさま Smash Hit! (こなみでんどうせれくしょん)
+  name: テニスの王子様 Smash Hit! [コナミ殿堂セレクション]
+  name-sort: てにすのおうじさま Smash Hit! [こなみでんどうせれくしょん]
   name-en: "Tennis no Oji-Sama - Smash-Hit! [Konami Palace Selection]"
   region: "NTSC-J"
 SLPM-66011:
-  name: テニスの王子様 Smash Hit!2(コナミ殿堂セレクション)
-  name-sort: てにすのおうじさま Smash Hit!2(こなみでんどうせれくしょん)
+  name: テニスの王子様 Smash Hit!2 [コナミ殿堂セレクション]
+  name-sort: てにすのおうじさま Smash Hit!2 [こなみでんどうせれくしょん]
   name-en: "Tennis no Oji-Sama - Smash-Hit! 2 [Konami Palace Selection]"
   region: "NTSC-J"
 SLPM-66012:
-  name: テニスの王子様SWEAT&TEARS 2(コナミ殿堂セレクション)
-  name-sort: てにすのおうじさまSWEAT&TEARS 2(こなみでんどうせれくしょん)
+  name: テニスの王子様SWEAT&TEARS 2 [コナミ殿堂セレクション]
+  name-sort: てにすのおうじさまSWEAT&TEARS 2 [こなみでんどうせれくしょん]
   name-en: "Tennis no Oji-Sama - Sweat & Tears 2 [Konami Palace Selection]"
   region: "NTSC-J"
 SLPM-66013:
-  name: テニスの王子様最強チームを結成せよ!(コナミ殿堂セレクション)
-  name-sort: てにすのおうじさまさいきょうちーむをけっせいせよ!(こなみでんどうせれくしょん)
+  name: テニスの王子様最強チームを結成せよ! [コナミ殿堂セレクション]
+  name-sort: てにすのおうじさまさいきょうちーむをけっせいせよ! [こなみでんどうせれくしょん]
   name-en: "Tennis no Oji-Sama - Form the Strongest Team [Konami Palace Selection]"
   region: "NTSC-J"
 SLPM-66014:
-  name: テニスの王子様 RUSH&DREAM!(コナミ殿堂セレクション)
-  name-sort: てにすのおうじさま RUSH&DREAM!(こなみでんどうせれくしょん)
+  name: テニスの王子様 RUSH&DREAM! [コナミ殿堂セレクション]
+  name-sort: てにすのおうじさま RUSH&DREAM! [こなみでんどうせれくしょん]
   name-en: "Tennis no Oji-Sama - Rush & Dream [Konami Palace Selection]"
   region: "NTSC-J"
 SLPM-66015:
@@ -39567,8 +39567,8 @@ SLPM-66017:
   name: "Firefighter F.D.18"
   region: "NTSC-J"
 SLPM-66018:
-  name: サイレントヒル3 (コナミ殿堂セレクション)
-  name-sort: さいれんとひる3 (こなみでんどうせれくしょん)
+  name: サイレントヒル3 [コナミ殿堂セレクション]
+  name-sort: さいれんとひる3 [こなみでんどうせれくしょん]
   name-en: "Silent Hill 3 [Konami Dendou Collection]"
   region: "NTSC-J"
   clampModes:
@@ -39621,8 +39621,8 @@ SLPM-66024:
   name-en: "Fushigi Yuugi - ShigiYuugi Kurotake Kaiden Gaiden - Kagami no Fujo"
   region: "NTSC-J"
 SLPM-66025:
-  name: 新天魔界ジェネレーション オブ カオスIV【IFコレクション】
-  name-sort: しんてんまかいじぇねれーしょん おぶ かおすIV【IFこれくしょん】
+  name: 新天魔界ジェネレーション オブ カオスIV [IFコレクション]
+  name-sort: しんてんまかいじぇねれーしょん おぶ かおすIV [IFこれくしょん]
   name-en: "Generation of Chaos IV [Idea Factory Collection]"
   region: "NTSC-J"
 SLPM-66026:
@@ -39660,8 +39660,8 @@ SLPM-66031:
   roundModes:
     eeRoundMode: 0 # Fixes enemies not moving (especially Chapter 7 boss).
 SLPM-66032:
-  name: サイレントヒル4 (コナミ・ザ・ベスト)
-  name-sort: さいれんとひる4 (こなみ・ざ・べすと)
+  name: サイレントヒル4 [コナミ・ザ・ベスト]
+  name-sort: さいれんとひる4 [こなみ・ざ・べすと]
   name-en: "Silent Hill 4 [Konami The Best]"
   region: "NTSC-J"
   speedHacks:
@@ -39751,8 +39751,8 @@ SLPM-66050:
   name-en: "Daisan Teikoku Koubouki II - Aufstieg und Fall des Dritten Reich"
   region: "NTSC-J"
 SLPM-66051:
-  name: ニード・フォー・スピード アンダーグラウンド2 車道【EA BEST HITS】
-  name-sort: にーど・ふぉー・すぴーど あんだーぐらうんど2 しゃどう【EA BEST HITS】
+  name: ニード・フォー・スピード アンダーグラウンド2 車道 [EA BEST HITS]
+  name-sort: にーど・ふぉー・すぴーど あんだーぐらうんど2 しゃどう [EA BEST HITS]
   name-en: "Need for Speed Underground 2 [EA Best Hits] - SHA_DO"
   region: "NTSC-J"
   gsHWFixes:
@@ -39918,8 +39918,8 @@ SLPM-66079:
   name: "Medal of Honor - Europe Kyoushuu"
   region: "NTSC-J"
 SLPM-66080:
-  name: GENERATION OF CHAOSIII 〜時の封印〜【IFコレクション】
-  name-sort: GENERATION OF CHAOSIII 〜ときのふういん〜【IFこれくしょん】
+  name: GENERATION OF CHAOSIII 〜時の封印〜 [IFコレクション]
+  name-sort: GENERATION OF CHAOSIII 〜ときのふういん〜 [IFこれくしょん]
   name-en: "Generation of Chaos 3 [IF Collection]"
   region: "NTSC-J"
 SLPM-66081:
@@ -39947,8 +39947,8 @@ SLPM-66084:
   gsHWFixes:
     beforeDraw: "OI_PointListPalette"
 SLPM-66085:
-  name: Rumble Roses(コナミ・ザ・ベスト)
-  name-sort: Rumble Roses(こなみ・ざ・べすと)
+  name: Rumble Roses [コナミ・ザ・ベスト]
+  name-sort: Rumble Roses [こなみ・ざ・べすと]
   name-en: "Rumble Roses [Konami The Best]"
   region: "NTSC-J"
 SLPM-66086:
@@ -39994,21 +39994,21 @@ SLPM-66092:
   gsHWFixes:
     roundSprite: 1 # Fixes vertical and horizontal lines.
 SLPM-66093:
-  name: 決戦II【コーエー定番シリーズ】
-  name-sort: けっせんII【こーえーていばんしりーず】
+  name: 決戦II [コーエー定番シリーズ]
+  name-sort: けっせんII [こーえーていばんしりーず]
   name-en: "Kessen II [Koei Selection Series]"
   region: "NTSC-J"
 SLPM-66094:
-  name: 真・三國無双2【コーエー定番シリーズ】
-  name-sort: しん・さんごくむそう2【こーえーていばんしりーず】
+  name: 真・三國無双2 [コーエー定番シリーズ]
+  name-sort: しん・さんごくむそう2 [こーえーていばんしりーず]
   name-en: "Shin Sangoku Musou 2 [Koei Selection Series]"
   region: "NTSC-J"
 SLPM-66095:
   name: "Chou Battle Houshin"
   region: "NTSC-J"
 SLPM-66096:
-  name: 真・三國無双2猛将伝【コーエー定番シリーズ】
-  name-sort: しん・さんごくむそう2もうしょうでん【こーえーていばんしりーず】
+  name: 真・三國無双2猛将伝 [コーエー定番シリーズ]
+  name-sort: しん・さんごくむそう2もうしょうでん [こーえーていばんしりーず]
   name-en: "Shin Sangoku Musou 2 - Mushoden [Koei Selection Series]"
   region: "NTSC-J"
 SLPM-66097:
@@ -40017,8 +40017,8 @@ SLPM-66097:
   name-en: "Shinseiki Evangelion - Ayanami Ikusai Keikaku with Asuka Hokan Keikaku [Broccoli Best Quality]"
   region: "NTSC-J"
 SLPM-66098:
-  name: トゥルークライム -STREETS OF L.A.- (カプコレ)
-  name-sort: とぅるーくらいむ -STREETS OF L.A.- (かぷこれ)
+  name: トゥルークライム -STREETS OF L.A.- [カプコレ]
+  name-sort: とぅるーくらいむ -STREETS OF L.A.- [かぷこれ]
   name-en: "True Crime - Streets of L.A. [CapKore]"
   region: "NTSC-J"
   gsHWFixes:
@@ -40047,8 +40047,8 @@ SLPM-66102:
   gsHWFixes:
     roundSprite: 1 # Fixes vertical lines.
 SLPM-66103:
-  name: WRC3【スパイク ザ ベスト】
-  name-sort: WRC3【すぱいく ざ べすと】
+  name: WRC3 [スパイク ザ ベスト]
+  name-sort: WRC3 [すぱいく ざ べすと]
   name-en: "WRC 3 [Spike the Best]"
   region: "NTSC-J"
   compat: 5
@@ -40058,8 +40058,8 @@ SLPM-66103:
     roundSprite: 2 # Correct misaligned font, better aligns car shadow.
     autoFlush: 2 # Fixes sun luminosity.
 SLPM-66104:
-  name: ぷよぷよフィーバー2【チュー!】
-  name-sort: ぷよぷよふぃーばー2【ちゅー!】
+  name: ぷよぷよフィーバー2 [チュー!]
+  name-sort: ぷよぷよふぃーばー2 [ちゅー!]
   name-en: "Puyo Puyo Fever 2"
   region: "NTSC-J"
 SLPM-66105:
@@ -40132,23 +40132,23 @@ SLPM-66113:
   name-en: "Hissatsu Ura-Kagyou"
   region: "NTSC-J"
 SLPM-66114:
-  name: 水の旋律(初回限定版)
-  name-sort: みずのせんりつ(しょかいげんていばん)
+  name: 水の旋律 [初回限定版]
+  name-sort: みずのせんりつ [しょかいげんていばん]
   name-en: "Mizu no Senritsu [Limited Edition]"
   region: "NTSC-J"
 SLPM-66115:
-  name: 水の旋律(通常版)
-  name-sort: みずのせんりつ(つうじょうばん)
+  name: 水の旋律 [通常版]
+  name-sort: みずのせんりつ [つうじょうばん]
   name-en: "Mizu no Senritsu"
   region: "NTSC-J"
 SLPM-66116:
-  name: NBA ライブ 2005【EA BEST HITS】
-  name-sort: NBA らいぶ 2005【EA BEST HITS】
+  name: NBA ライブ 2005 [EA BEST HITS]
+  name-sort: NBA らいぶ 2005 [EA BEST HITS]
   name-en: "NBA Live 2005 [EA Best Hits]"
   region: "NTSC-J"
 SLPM-66117:
-  name: METAL GEAR SOLID 3 SUBSISTENCE (ヘッドセット同梱版) [ディスク1/3]
-  name-sort: METAL GEAR SOLID 3 SUBSISTENCE (へっどせっとどうこんばん) [でぃすく1/3]
+  name: METAL GEAR SOLID 3 SUBSISTENCE [ヘッドセット同梱版] [ディスク1/3]
+  name-sort: METAL GEAR SOLID 3 SUBSISTENCE [へっどせっとどうこんばん] [でぃすく1/3]
   name-en: "Metal Gear Solid 3 - Subsistence [with Headset] [Disc 1 of 3]"
   region: "NTSC-J"
   gameFixes:
@@ -40159,8 +40159,8 @@ SLPM-66117:
     halfPixelOffset: 2 # Fixes blurriness.
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
 SLPM-66118:
-  name: METAL GEAR SOLID 3 SUBSISTENCE (ヘッドセット同梱版) [ディスク2/3]
-  name-sort: METAL GEAR SOLID 3 SUBSISTENCE (へっどせっとどうこんばん) [でぃすく2/3]
+  name: METAL GEAR SOLID 3 SUBSISTENCE [ヘッドセット同梱版] [ディスク2/3]
+  name-sort: METAL GEAR SOLID 3 SUBSISTENCE [へっどせっとどうこんばん] [でぃすく2/3]
   name-en: "Metal Gear Solid 3 - Subsistence [with Headset] [Disc 2 of 3]"
   region: "NTSC-J"
   gameFixes:
@@ -40171,8 +40171,8 @@ SLPM-66118:
     halfPixelOffset: 2 # Fixes blurriness.
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
 SLPM-66119:
-  name: METAL GEAR SOLID 3 SUBSISTENCE (ヘッドセット同梱版) [ディスク2/3]
-  name-sort: METAL GEAR SOLID 3 SUBSISTENCE (へっどせっとどうこんばん) [でぃすく2/3]
+  name: METAL GEAR SOLID 3 SUBSISTENCE [ヘッドセット同梱版] [ディスク2/3]
+  name-sort: METAL GEAR SOLID 3 SUBSISTENCE [へっどせっとどうこんばん] [でぃすく2/3]
   name-en: "Metal Gear Solid 3 - Subsistence [with Headset] [Disc 3 of 3]"
   region: "NTSC-J"
   gameFixes:
@@ -40191,18 +40191,18 @@ SLPM-66121:
     halfPixelOffset: 2 # Fixes shadows.
     gpuPaletteConversion: 0 # Stops potential crashes from too many palette textures.
 SLPM-66122:
-  name: キングダム ハーツ【アルティメット ヒッツ】
-  name-sort: きんぐだむ はーつ【あるてぃめっと ひっつ】
+  name: キングダム ハーツ [アルティメット ヒッツ]
+  name-sort: きんぐだむ はーつ [あるてぃめっと ひっつ]
   name-en: "Kingdom Hearts [Ultimate Hits]"
   region: "NTSC-J"
 SLPM-66123:
-  name: キングダム ハーツ -ファイナル   ミックス-【アルティメット ヒッツ】
-  name-sort: きんぐだむ はーつ -ふぁいなる   みっくす-【あるてぃめっと ひっつ】
+  name: キングダム ハーツ -ファイナル   ミックス- [アルティメット ヒッツ]
+  name-sort: きんぐだむ はーつ -ふぁいなる   みっくす- [あるてぃめっと ひっつ]
   name-en: "Kingdom Hearts - Final Mix [Ultimate Hits]"
   region: "NTSC-J"
 SLPM-66124:
-  name: ファイナルファンタジー X【アルティメット ヒッツ】
-  name-sort: ふぁいなるふぁんたじー X【あるてぃめっと ひっつ】
+  name: ファイナルファンタジー X [アルティメット ヒッツ]
+  name-sort: ふぁいなるふぁんたじー X [あるてぃめっと ひっつ]
   name-en: "Final Fantasy X [Ultimate Hits]"
   region: "NTSC-J"
   roundModes:
@@ -40210,8 +40210,8 @@ SLPM-66124:
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
 SLPM-66125:
-  name: ファイナルファンタジー X-2【アルティメット ヒッツ】
-  name-sort: ふぁいなるふぁんたじー X-2【あるてぃめっと ひっつ】
+  name: ファイナルファンタジー X-2 [アルティメット ヒッツ]
+  name-sort: ふぁいなるふぁんたじー X-2 [あるてぃめっと ひっつ]
   name-en: "Final Fantasy X-2 [Ultimate Hits]"
   region: "NTSC-J"
   gameFixes:
@@ -40323,8 +40323,8 @@ SLPM-66144:
   clampModes:
     eeClampMode: 3 # Fixes black screen.
 SLPM-66145:
-  name: ゴールデンアイ ダークエージェント【EA BEST HITS】
-  name-sort: ごーるでんあい だーくえーじぇんと【EA BEST HITS】
+  name: ゴールデンアイ ダークエージェント [EA BEST HITS]
+  name-sort: ごーるでんあい だーくえーじぇんと [EA BEST HITS]
   name-en: "GoldenEye - Rogue Agent [EA Best Hits]"
   region: "NTSC-J"
 SLPM-66146:
@@ -40338,8 +40338,8 @@ SLPM-66147:
   name-en: "Memories Off #5 - Togireta Film"
   region: "NTSC-J"
 SLPM-66148:
-  name: スターウォーズ バトルフロント【EA BEST HITS】
-  name-sort: すたーうぉーず ばとるふろんと【EA BEST HITS】
+  name: スターウォーズ バトルフロント [EA BEST HITS]
+  name-sort: すたーうぉーず ばとるふろんと [EA BEST HITS]
   name-en: "Star Wars - Battlefront [EA Best Hits]"
   region: "NTSC-J"
   gsHWFixes:
@@ -40376,8 +40376,8 @@ SLPM-66153:
   name-en: "Konneko - Keep a Memory Green"
   region: "NTSC-J"
 SLPM-66155:
-  name: アニメバトル 烈火の炎 FINAL BURNING (コナミ殿堂セレクション)
-  name-sort: あにめばとる れっかのほのお FINAL BURNING (こなみでんどうせれくしょん)
+  name: アニメバトル 烈火の炎 FINAL BURNING [コナミ殿堂セレクション]
+  name-sort: あにめばとる れっかのほのお FINAL BURNING [こなみでんどうせれくしょん]
   name-en: "Flame of Recca - Final Burning [Konami Palace Selection]"
   region: "NTSC-J"
 SLPM-66156:
@@ -40511,8 +40511,8 @@ SLPM-66177:
     halfPixelOffset: 2 # Fix effects upscaling.
     autoFlush: 1 # Fixes broken post processing.
 SLPM-66178:
-  name: ポップンミュージック 7 (コナミザベスト)
-  name-sort: ぽっぷんみゅーじっく 7 (こなみざ・べすと)
+  name: ポップンミュージック 7 [コナミザベスト]
+  name-sort: ぽっぷんみゅーじっく 7 [こなみざ・べすと]
   name-en: "Pop'n music 7 [Konami The Best]"
   region: "NTSC-J"
 SLPM-66179:
@@ -40655,8 +40655,8 @@ SLPM-66202:
   name-en: "Fragments Blue [Special Edition]"
   region: "NTSC-J"
 SLPM-66203:
-  name: フラグメンツ・ブルー (通常版)
-  name-sort: ふらぐめんつ・ぶるー (つうじょうばん)
+  name: フラグメンツ・ブルー [通常版]
+  name-sort: ふらぐめんつ・ぶるー [つうじょうばん]
   name-en: "Fragments Blue"
   region: "NTSC-J"
 SLPM-66204:
@@ -40702,13 +40702,13 @@ SLPM-66208:
   name-en: "Sakura Taisen V - Episode 0 - Samurai Girl of Wild [Sega the Best]"
   region: "NTSC-J"
 SLPM-66209:
-  name: ポップンミュージック 9 (コナミザベスト)
-  name-sort: ぽっぷんみゅーじっく 9 (こなみざ・べすと)
+  name: ポップンミュージック 9 [コナミザベスト]
+  name-sort: ぽっぷんみゅーじっく 9 [こなみざ・べすと]
   name-en: "Pop'n music 9 [Konami The Best]"
   region: "NTSC-J"
 SLPM-66210:
-  name: ポップンミュージック 10 (コナミザベスト)
-  name-sort: ぽっぷんみゅーじっく 10 (こなみざ・べすと)
+  name: ポップンミュージック 10 [コナミザベスト]
+  name-sort: ぽっぷんみゅーじっく 10 [こなみざ・べすと]
   name-en: "Pop'n music 10 [Konami The Best]"
   region: "NTSC-J"
 SLPM-66211:
@@ -40735,8 +40735,8 @@ SLPM-66213:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
 SLPM-66214:
-  name: WHITE CLARITY(ホワイト クラリティー)〜And The tears became you.〜 初回限定版
-  name-sort: WHITE CLARITY(ほわいと くらりてぃー)〜And The tears became you.〜 しょかいげんていばん
+  name: WHITE CLARITY(ホワイト クラリティー)〜And The tears became you.〜 [初回限定版]
+  name-sort: WHITE CLARITY(ほわいと くらりてぃー)〜And The tears became you.〜 [しょかいげんていばん]
   name-en: "White Clarity - And, the Tears Became You [First Print Limited Edition]"
   region: "NTSC-J"
 SLPM-66215:
@@ -40760,8 +40760,8 @@ SLPM-66219:
   name-en: "Tennis no Oji-Sama - Gakuensai no Oji-Sama"
   region: "NTSC-J"
 SLPM-66220:
-  name: METAL GEAR SOLID 3 SUBSISTENCE (初回生産版) [ディスク1/3]
-  name-sort: METAL GEAR SOLID 3 SUBSISTENCE (しょかいせいさんばん) [でぃすく1/3]
+  name: METAL GEAR SOLID 3 SUBSISTENCE [初回生産版] [ディスク1/3]
+  name-sort: METAL GEAR SOLID 3 SUBSISTENCE [しょかいせいさんばん] [でぃすく1/3]
   name-en: "Metal Gear Solid 3 - Subsistence [First Print Limited Edition] [Disc 1 of 3]"
   region: "NTSC-J"
   gameFixes:
@@ -40774,8 +40774,8 @@ SLPM-66220:
   memcardFilters:
     - "SLPM-66117"
 SLPM-66221:
-  name: METAL GEAR SOLID 3 SUBSISTENCE (初回生産版) [ディスク2/3]
-  name-sort: METAL GEAR SOLID 3 SUBSISTENCE (しょかいせいさんばん) [でぃすく2/3]
+  name: METAL GEAR SOLID 3 SUBSISTENCE [初回生産版] [ディスク2/3]
+  name-sort: METAL GEAR SOLID 3 SUBSISTENCE [しょかいせいさんばん] [でぃすく2/3]
   name-en: "Metal Gear Solid 3 - Subsistence [First Print Limited Edition] [Disc 2 of 3]"
   region: "NTSC-J"
   gameFixes:
@@ -40788,8 +40788,8 @@ SLPM-66221:
   memcardFilters:
     - "SLPM-66117"
 SLPM-66222:
-  name: METAL GEAR SOLID 3 SUBSISTENCE (初回生産版) [ディスク3/3]
-  name-sort: METAL GEAR SOLID 3 SUBSISTENCE (しょかいせいさんばん) [でぃすく3/3]
+  name: METAL GEAR SOLID 3 SUBSISTENCE [初回生産版] [ディスク3/3]
+  name-sort: METAL GEAR SOLID 3 SUBSISTENCE [しょかいせいさんばん] [でぃすく3/3]
   name-en: "Metal Gear Solid 3 - Subsistence [First Print Limited Edition] [Disc 3 of 3]"
   region: "NTSC-J"
   gameFixes:
@@ -40845,8 +40845,8 @@ SLPM-66227:
   name-en: "GI Jockey 4 + Winning Post 7 [Twin Pack] [GI Jockey 4 Disc]"
   region: "NTSC-J"
 SLPM-66228:
-  name: ウイニングポスト7(ジーワンジョッキー4&ウイニングポストツインパック用)
-  name-sort: ういにんぐぽすと7(じーわんじょっきー4&ういにんぐぽすとついんぱっくよう)
+  name: ウイニングポスト7 [ジーワンジョッキー4&ウイニングポストツインパック用]
+  name-sort: ういにんぐぽすと7 [じーわんじょっきー4&ういにんぐぽすとついんぱっくよう]
   name-en: "GI Jockey 4 + Winning Post 7 [Twin Pack] [Winning Post 7 Disc]"
   region: "NTSC-J"
 SLPM-66229:
@@ -40981,8 +40981,8 @@ SLPM-66250:
   name-en: "Choro Q HG 4 [Takara Best]"
   region: "NTSC-J"
 SLPM-66251:
-  name: EX人生ゲームII【アトラスベストコレクション】
-  name-sort: EXじんせいげーむII【あとらすべすとこれくしょん】
+  name: EX人生ゲームII [アトラスベストコレクション]
+  name-sort: EXじんせいげーむII [あとらすべすとこれくしょん]
   name-en: "EX Jinsei Game II [Takara Best]"
   region: "NTSC-J"
   gsHWFixes:
@@ -41022,8 +41022,8 @@ SLPM-66257:
   gameFixes:
     - SoftwareRendererFMVHack # Fixes upscale lines in FMVs.
 SLPM-66258:
-  name: 魔法先生ネギま! 1時間目 お子ちゃま先生は魔法使い!(コナミザベスト)
-  name-sort: まほうせんせいねぎま! 1じかんめ おこちゃませんせいはまほうつかい!(こなみざ・べすと)
+  name: 魔法先生ネギま! 1時間目 お子ちゃま先生は魔法使い! [コナミザベスト]
+  name-sort: まほうせんせいねぎま! 1じかんめ おこちゃませんせいはまほうつかい! [こなみざ・べすと]
   name-en: "Magic Teacher Negima - Honor Version [Konami The Best]"
   region: "NTSC-J"
 SLPM-66259:
@@ -41032,21 +41032,21 @@ SLPM-66259:
   name-en: "Mahou Sensei Negima! Silver Medal [Konami The Best]"
   region: "NTSC-J"
 SLPM-66260:
-  name: リモートコントロールダンディSF (コナミザベスト)
-  name-sort: りもーとこんとろーるだんでぃSF (こなみざ・べすと)
+  name: リモートコントロールダンディSF [コナミザベスト]
+  name-sort: りもーとこんとろーるだんでぃSF [こなみざ・べすと]
   name-en: "Remote Control Dandy SF [Konami the Best]"
   region: "NTSC-J"
 SLPM-66261:
-  name: OZ -オズ- (コナミザベスト)
-  name-sort: OZ -おず- (こなみざ・べすと)
+  name: OZ -オズ- [コナミザベスト]
+  name-sort: OZ -おず- [こなみざ・べすと]
   name-en: "Oz [Konami The Best]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misaligned bloom.
     autoFlush: 2 # Fixes misaligned bloom on sun.
 SLPM-66262:
-  name: トム・クランシーシリーズ レインボーシックス3【ユービーアイソフトベスト】
-  name-sort: とむ・くらんしーしりーず れいんぼーしっくす3【ゆーびーあいそふとべすと】
+  name: トム・クランシーシリーズ レインボーシックス3 [ユービーアイソフトベスト]
+  name-sort: とむ・くらんしーしりーず れいんぼーしっくす3 [ゆーびーあいそふとべすと]
   name-en: "Tom Clancy's Rainbow Six 3 [Ubisoft The Best]"
   region: "NTSC-J"
 SLPM-66263:
@@ -41057,23 +41057,23 @@ SLPM-66263:
   speedHacks:
     mvuFlag: 0 # Fixes bad graphics.
 SLPM-66264:
-  name: Canvas2 〜虹色のスケッチ〜(DXパック)
-  name-sort: Canvas2 〜にじいろのすけっち〜(DXぱっく)
+  name: Canvas2 〜虹色のスケッチ〜 [DXパック]
+  name-sort: Canvas2 〜にじいろのすけっち〜 [DXぱっく]
   name-en: "Canvas 2 - Nijiiro no Sketch [DX Pack]"
   region: "NTSC-J"
 SLPM-66265:
-  name: Canvas2 〜虹色のスケッチ〜(通常版)
-  name-sort: Canvas2 〜にじいろのすけっち〜(つうじょうばん)
+  name: Canvas2 〜虹色のスケッチ〜 [通常版]
+  name-sort: Canvas2 〜にじいろのすけっち〜 [つうじょうばん]
   name-en: "Canvas 2 - Nijiiro no Sketch"
   region: "NTSC-J"
 SLPM-66266:
-  name: 鋼鉄の咆哮2 ウォーシップコマンダー【KOEI The Best】
-  name-sort: くろがねのほうこう2 うぉーしっぷこまんだー【KOEI The Best】
+  name: 鋼鉄の咆哮2 ウォーシップコマンダー [KOEI The Best]
+  name-sort: くろがねのほうこう2 うぉーしっぷこまんだー [KOEI The Best]
   name-en: "Kurogane no Houkou 2 - Warship Commander [Koei The Best]"
   region: "NTSC-J"
 SLPM-66267:
-  name: 太閤立志伝V【KOEI The Best】
-  name-sort: たいこうりっしでんV【KOEI The Best】
+  name: 太閤立志伝V [KOEI The Best]
+  name-sort: たいこうりっしでんV [KOEI The Best]
   name-en: "Taikou Risshiden V"
   region: "NTSC-J"
 SLPM-66268:
@@ -41187,8 +41187,8 @@ SLPM-66284:
   name-en: "Dessert Love - Sweet Plus"
   region: "NTSC-J"
 SLPM-66285:
-  name: プリンセスコンチェルト(通常版)
-  name-sort: ぷりんせすこんちぇると(つうじょうばん)
+  name: プリンセスコンチェルト [通常版]
+  name-sort: ぷりんせすこんちぇると [つうじょうばん]
   name-en: "Princess Concerto"
   region: "NTSC-J"
 SLPM-66286:
@@ -41399,8 +41399,8 @@ SLPM-66322:
     textureInsideRT: 1 # Required for complex offset shuffles.
     recommendedBlendingLevel: 4 # Fixes lighting.
 SLPM-66323:
-  name: ふぁいなる・あぷろーち(プリンセスソフトコレクション)
-  name-sort: ふぁいなる・あぷろーち(ぷりんせすそふとこれくしょん)
+  name: ふぁいなる・あぷろーち [プリンセスソフトコレクション]
+  name-sort: ふぁいなる・あぷろーち [ぷりんせすそふとこれくしょん]
   name-en: "Princess Software Collection, The"
   region: "NTSC-J"
 SLPM-66324:
@@ -41413,8 +41413,8 @@ SLPM-66324:
     - "SLPM-66316"
     - "SLPM-66442"
 SLPM-66325:
-  name: キャッスルヴァニア(コナミ殿堂セレクション)
-  name-sort: きゃっするゔぁにあ(こなみでんどうせれくしょん)
+  name: キャッスルヴァニア [コナミ殿堂セレクション]
+  name-sort: きゃっするゔぁにあ [こなみでんどうせれくしょん]
   name-en: "Castlevania [Konami Palace Selection]"
   region: "NTSC-J"
   clampModes:
@@ -41472,8 +41472,8 @@ SLPM-66333:
   region: "NTSC-J"
   compat: 5
 SLPM-66334:
-  name: WRC4【Spike the Best】
-  name-sort: WRC4【Spike the Best】
+  name: WRC4 [Spike the Best]
+  name-sort: WRC4 [Spike the Best]
   name-en: "WRC 4 [Spike the Best]"
   region: "NTSC-J"
   gameFixes:
@@ -41557,8 +41557,8 @@ SLPM-66348:
   name-en: "Harukanaru Jikuu no Kade 3 - Unmei no Meikyuu"
   region: "NTSC-J"
 SLPM-66349:
-  name: スペクトラルフォース クロニクル【IFコレクション】
-  name-sort: すぺくとらるふぉーす くろにくる【IFこれくしょん】
+  name: スペクトラルフォース クロニクル [IFコレクション]
+  name-sort: すぺくとらるふぉーす くろにくる [IFこれくしょん]
   name-en: "Spectral Force Chronicle"
   region: "NTSC-J"
 SLPM-66350:
@@ -41657,15 +41657,15 @@ SLPM-66371:
   name-en: "Train Simulator & Densha de Go! Tokyo Kyuukouhen [Ongakukan Pocket Books]"
   region: "NTSC-J"
 SLPM-66372:
-  name: DIGITAL DEVIL SAGA 〜アバタール・チューナー〜【ATLUS BEST COLLECTION】
-  name-sort: DIGITAL DEVIL SAGA 〜あばたーる・ちゅーなー〜【ATLUS BEST COLLECTION】
+  name: DIGITAL DEVIL SAGA 〜アバタール・チューナー〜 [ATLUS BEST COLLECTION]
+  name-sort: DIGITAL DEVIL SAGA 〜あばたーる・ちゅーなー〜 [ATLUS BEST COLLECTION]
   name-en: "Digital Devil Saga - Avatar Tuner [Atlus Best Collection]"
   region: "NTSC-J"
   gameFixes:
     - EETimingHack
 SLPM-66373:
-  name: DIGITAL DEVIL SAGA 〜アバタール・チューナー2〜【ATLUS BEST COLLECTION】
-  name-sort: DIGITAL DEVIL SAGA 〜あばたーる・ちゅーなー2〜【ATLUS BEST COLLECTION】
+  name: DIGITAL DEVIL SAGA 〜アバタール・チューナー2〜 [ATLUS BEST COLLECTION]
+  name-sort: DIGITAL DEVIL SAGA 〜あばたーる・ちゅーなー2〜 [ATLUS BEST COLLECTION]
   name-en: "Digital Devil Saga - Avatar Tuner 2 [Atlus Best Collection]"
   region: "NTSC-J"
   gameFixes:
@@ -41712,13 +41712,13 @@ SLPM-66379:
   name-en: "Kishin Houkou Demon Bane [Kadokawa The Best]"
   region: "NTSC-J"
 SLPM-66380:
-  name: 蜜×蜜ドロップス LOVE×LOVE HONEY LIFE(限定版)
-  name-sort: みつ×みつどろっぷす LOVE×LOVE HONEY LIFE(げんていばん)
+  name: 蜜×蜜ドロップス LOVE×LOVE HONEY LIFE [限定版]
+  name-sort: みつ×みつどろっぷす LOVE×LOVE HONEY LIFE [げんていばん]
   name-en: "Mitsu x Mitsu Drops - Love x Love Honey Life [Limited Edition]"
   region: "NTSC-J"
 SLPM-66381:
-  name: 蜜×蜜ドロップス LOVE×LOVE HONEY LIFE(通常版)
-  name-sort: みつ×みつどろっぷす LOVE×LOVE HONEY LIFE(つうじょうばん)
+  name: 蜜×蜜ドロップス LOVE×LOVE HONEY LIFE [通常版]
+  name-sort: みつ×みつどろっぷす LOVE×LOVE HONEY LIFE [つうじょうばん]
   name-en: "Mitsu x Mitsu Drops - Love x Love Honey Life"
   region: "NTSC-J"
   patches:
@@ -41754,13 +41754,13 @@ SLPM-66386:
   name-en: "FIFA World Cup - Germany 2006"
   region: "NTSC-J"
 SLPM-66387:
-  name: 真・爆走デコトラ伝説 〜天下統一頂上決戦〜【Spike The Best】
-  name-sort: しん・ばくそうでことらでんせつ 〜てんかとういつちょうじょうけっせん〜【Spike The Best】
+  name: 真・爆走デコトラ伝説 〜天下統一頂上決戦〜 [Spike The Best]
+  name-sort: しん・ばくそうでことらでんせつ 〜てんかとういつちょうじょうけっせん〜 [Spike The Best]
   name-en: "Shin Bakusou Dekotora Densetsu [Spike the Best]"
   region: "NTSC-J"
 SLPM-66388:
-  name: ファイプロ・リターンズ【Spike The Best】
-  name-sort: ふぁいぷろ・りたーんず【Spike The Best】
+  name: ファイプロ・リターンズ [Spike The Best]
+  name-sort: ふぁいぷろ・りたーんず [Spike The Best]
   name-en: "Fire Pro Wrestling Returns [Spike The Best]"
   region: "NTSC-J"
 SLPM-66390:
@@ -41903,8 +41903,8 @@ SLPM-66414:
   name: "Colorful Box - To Love"
   region: "NTSC-J"
 SLPM-66415:
-  name: ミステリート 〜八十神かおるの事件ファイル〜(初回限定版)
-  name-sort: みすてりーと 〜やそがみかおるのじけんふぁいる〜(しょかいげんていばん)
+  name: ミステリート 〜八十神かおるの事件ファイル〜 [初回限定版]
+  name-sort: みすてりーと 〜やそがみかおるのじけんふぁいる〜 [しょかいげんていばん]
   name-en: "Mystereet [First Print - Limited Edition]"
   region: "NTSC-J"
 SLPM-66416:
@@ -41939,23 +41939,23 @@ SLPM-66419:
     textureInsideRT: 1 # Required for swirl battle transition.
     nativePaletteDraw: 1
 SLPM-66420:
-  name: フロントミッション4【アルティメット ヒッツ】
-  name-sort: ふろんとみっしょん4【あるてぃめっと ひっつ】
+  name: フロントミッション4 [アルティメット ヒッツ]
+  name-sort: ふろんとみっしょん4 [あるてぃめっと ひっつ]
   name-en: "Front Mission 4 [Ultimate Hits]"
   region: "NTSC-J"
   gsHWFixes:
     preloadFrameData: 1 # Fixes mech shadows.
     roundSprite: 2 # Fixes font artifacts.
 SLPM-66421:
-  name: フロントミッション5 〜Scars of the War〜【アルティメット ヒッツ】
-  name-sort: ふろんとみっしょん5 〜Scars of the War〜【あるてぃめっと ひっつ】
+  name: フロントミッション5 〜Scars of the War〜 [アルティメット ヒッツ]
+  name-sort: ふろんとみっしょん5 〜Scars of the War〜 [あるてぃめっと ひっつ]
   name-en: "Front Mission 5 - Scars of the War [Ultimate Hits]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 1 # Fixes blurriness but no fix for font or other artifacts possible with round sprite.
 SLPM-66422:
-  name: Romancing SaGa −Minstrel Song−【Ultimate Hits】
-  name-sort: Romancing SaGa -Minstrel Song-【Ultimate Hits】
+  name: Romancing SaGa −Minstrel Song− [Ultimate Hits]
+  name-sort: Romancing SaGa -Minstrel Song- [Ultimate Hits]
   name-en: "Romancing Saga - Minstrel Song [Ultimate Hits]"
   region: "NTSC-J"
 SLPM-66424:
@@ -42043,8 +42043,8 @@ SLPM-66438:
   gameFixes:
     - EETimingHack # Fixes non-working game (BSOD/crash otherwise).
 SLPM-66439:
-  name: 保健室へようこそ (初回限定版)
-  name-sort: ほけんしつへようこそ (しょかいげんていばん)
+  name: 保健室へようこそ [初回限定版]
+  name-sort: ほけんしつへようこそ [しょかいげんていばん]
   name-en: "Hokenshitsu e Youkoso [Limited Edition]"
   region: "NTSC-J"
 SLPM-66440:
@@ -42154,8 +42154,8 @@ SLPM-66454:
   name-en: "Hiiro no Kakera"
   region: "NTSC-J"
 SLPM-66455:
-  name: スペクトラルフォース ラジカルエレメンツ【IFコレクション】
-  name-sort: すぺくとらるふぉーす らじかるえれめんつ【IFこれくしょん】
+  name: スペクトラルフォース ラジカルエレメンツ [IFコレクション]
+  name-sort: すぺくとらるふぉーす らじかるえれめんつ [IFこれくしょん]
   name-en: "Spectral Force - Radical Elements [IF Collection]"
   region: "NTSC-J"
 SLPM-66456:
@@ -42219,18 +42219,18 @@ SLPM-66462:
   name-en: "Disney-Pixar's Cars"
   region: "NTSC-J"
 SLPM-66463:
-  name: デフジャム・ファイト・フォー・NY【EA BEST HITS】
-  name-sort: でふじゃむ・ふぁいと・ふぉー・NY【EA BEST HITS】
+  name: デフジャム・ファイト・フォー・NY [EA BEST HITS]
+  name-sort: でふじゃむ・ふぁいと・ふぉー・NY [EA BEST HITS]
   name-en: "Def Jam - Fight for NY [EA Best Hits]"
   region: "NTSC-J"
 SLPM-66464:
-  name: MVP ベースボール2005【EA BEST HITS】
-  name-sort: MVP べーすぼーる2005【EA BEST HITS】
+  name: MVP ベースボール2005 [EA BEST HITS]
+  name-sort: MVP べーすぼーる2005 [EA BEST HITS]
   name-en: "MVP Baseball 2005 [EA Best Hits]"
   region: "NTSC-J"
 SLPM-66465:
-  name: マーセナリーズ【EA BEST HITS】
-  name-sort: まーせなりーず【EA BEST HITS】
+  name: マーセナリーズ [EA BEST HITS]
+  name-sort: まーせなりーず [EA BEST HITS]
   name-en: "Mercenaries - Playground of Destruction [EA Best Hits]"
   region: "NTSC-J"
   gsHWFixes:
@@ -42307,8 +42307,8 @@ SLPM-66477:
   name-en: "Kamiwaza"
   region: "NTSC-J"
 SLPM-66478:
-  name: スターオーシャン Till the End of Time ディレクターズカット [ディスク1/2]【アルティメット ヒッツ】
-  name-sort: すたーおーしゃん Till the End of Time でぃれくたーずかっと [でぃすく1/2]【あるてぃめっと ひっつ】
+  name: スターオーシャン Till the End of Time ディレクターズカット [ディスク1/2] [アルティメット ヒッツ]
+  name-sort: すたーおーしゃん Till the End of Time でぃれくたーずかっと [でぃすく1/2] [あるてぃめっと ひっつ]
   name-en: "Star Ocean 3 - Till the End of Time [Ultimate Hits] [Disc 1 of 2]"
   region: "NTSC-J"
   compat: 5
@@ -42319,8 +42319,8 @@ SLPM-66478:
     roundSprite: 1 # Fixes door transition vertical lines and mini-map artifacts.
     textureInsideRT: 1 # Fixes missing battle effects.
 SLPM-66479:
-  name: スターオーシャン Till the End of Time ディレクターズカット [ディスク2/2]【アルティメット ヒッツ】
-  name-sort: すたーおーしゃん Till the End of Time でぃれくたーずかっと [でぃすく2/2]【あるてぃめっと ひっつ】
+  name: スターオーシャン Till the End of Time ディレクターズカット [ディスク2/2] [アルティメット ヒッツ]
+  name-sort: すたーおーしゃん Till the End of Time でぃれくたーずかっと [でぃすく2/2] [あるてぃめっと ひっつ]
   name-en: "Star Ocean 3 - Till the End of Time [Ultimate Hits] [Disc 2 of 2]"
   region: "NTSC-J"
   compat: 5
@@ -42333,14 +42333,14 @@ SLPM-66479:
   memcardFilters:
     - "SLPM-66478"
 SLPM-66480:
-  name: ドラゴンクエスト V 天空の花嫁【アルティメット ヒッツ】
-  name-sort: どらごんくえすと V てんくうのはなよめ【あるてぃめっと ひっつ】
+  name: ドラゴンクエスト V 天空の花嫁 [アルティメット ヒッツ]
+  name-sort: どらごんくえすと V てんくうのはなよめ [あるてぃめっと ひっつ]
   name-en: "Dragon Quest V - Bride of the Sky [Ultimate Hits]"
   region: "NTSC-J"
   compat: 5
 SLPM-66481:
-  name: ドラゴンクエスト VIII 空と海と大地と呪われし姫君【アルティメット ヒッツ】
-  name-sort: どらごんくえすと VIII そらとうみとだいちとのろわれしひめぎみ【あるてぃめっと ひっつ】
+  name: ドラゴンクエスト VIII 空と海と大地と呪われし姫君 [アルティメット ヒッツ]
+  name-sort: どらごんくえすと VIII そらとうみとだいちとのろわれしひめぎみ [あるてぃめっと ひっつ]
   name-en: "Dragon Quest VIII [Ultimate Hits]"
   region: "NTSC-J"
   gsHWFixes:
@@ -42388,8 +42388,8 @@ SLPM-66489:
   name-en: "Mabino x Style [2800 Collection]"
   region: "NTSC-J"
 SLPM-66491:
-  name: あやかしびと -幻妖異聞録-(通常版)
-  name-sort: あやかしびと -げんよういぶんろく-(つうじょうばん)
+  name: あやかしびと -幻妖異聞録- [通常版]
+  name-sort: あやかしびと -げんよういぶんろく- [つうじょうばん]
   name-en: "Ayakashi-bito - Gen'you Ibunroku"
   region: "NTSC-J"
   gsHWFixes:
@@ -42402,8 +42402,8 @@ SLPM-66492:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes lighting misalignment.
 SLPM-66493:
-  name: 新天魔界 ジェネレーション オブ カオスV【IFコレクション】
-  name-sort: しんてんまかい じぇねれーしょん おぶ かおすV【IFこれくしょん】
+  name: 新天魔界 ジェネレーション オブ カオスV [IFコレクション]
+  name-sort: しんてんまかい じぇねれーしょん おぶ かおすV [IFこれくしょん]
   name-en: "Shinten Makai - Generation of Chaos V [IF Collection]"
   region: "NTSC-J"
 SLPM-66494:
@@ -42424,8 +42424,8 @@ SLPM-66495:
         // This patch skips over the stack code, allowing the game to boot.
         patch=1,EE,00149F18,word,10000003
 SLPM-66496:
-  name: トム・クランシーシリーズ スプリンターセル カオスセオリー【ユービーアイソフト ベスト】
-  name-sort: とむ・くらんしーしりーず すぷりんたーせる かおすせおりー【ゆーびーあいそふと べすと】
+  name: トム・クランシーシリーズ スプリンターセル カオスセオリー [ユービーアイソフト ベスト]
+  name-sort: とむ・くらんしーしりーず すぷりんたーせる かおすせおりー [ゆーびーあいそふと べすと]
   name-en: "Tom Clancy's Splinter Cell - Chaos Theory"
   region: "NTSC-J"
 SLPM-66497:
@@ -42497,8 +42497,8 @@ SLPM-66506:
   name-en: "Gundam - Federation vs. Zeon DX [Mega Hits]"
   region: "NTSC-J"
 SLPM-66507:
-  name: 乙女の事情 (初回限定版)
-  name-sort: おとめのじじょう (しょかいげんていばん)
+  name: 乙女の事情 [初回限定版]
+  name-sort: おとめのじじょう [しょかいげんていばん]
   name-en: "Otome no Jijou [Limited Edition]"
   region: "NTSC-J"
 SLPM-66508:
@@ -42533,20 +42533,20 @@ SLPM-66513:
   name-en: "Fate-stay Night - Realta Nua"
   region: "NTSC-J"
 SLPM-66514:
-  name: メダル オブ オナー ヨーロッパ強襲【EA BEST HITS】
-  name-sort: めだる おぶ おなー よーろっぱきょうしゅう【EA BEST HITS】
+  name: メダル オブ オナー ヨーロッパ強襲 [EA BEST HITS]
+  name-sort: めだる おぶ おなー よーろっぱきょうしゅう [EA BEST HITS]
   name-en: "Medal of Honor - European Assault [EA Best Hits]"
   region: "NTSC-J"
 SLPM-66515:
-  name: スター・ウォーズ エピソード3 シスの復讐【EA BEST HITS】
-  name-sort: すたー・うぉーず えぴそーど3 しすのふくしゅう【EA BEST HITS】
+  name: スター・ウォーズ エピソード3 シスの復讐 [EA BEST HITS]
+  name-sort: すたー・うぉーず えぴそーど3 しすのふくしゅう [EA BEST HITS]
   name-en: "Star Wars - Episode III - Sith no Fukushuu [EA Best Hits]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 1 # Fixes bloom misalignment.
 SLPM-66516:
-  name: ザ・シムズ&ザ・アーブズ シムズ・イン・ザ・シティ【EA BEST HITS】
-  name-sort: ざ・しむず&ざ・あーぶず しむず・いん・ざ・してぃ【EA BEST HITS】
+  name: ザ・シムズ&ザ・アーブズ シムズ・イン・ザ・シティ [EA BEST HITS]
+  name-sort: ざ・しむず&ざ・あーぶず しむず・いん・ざ・してぃ [EA BEST HITS]
   name-en: "Sims, The & The Urbz - Sims in the City [EA Best Hits]"
   region: "NTSC-J"
   gsHWFixes:
@@ -42576,43 +42576,43 @@ SLPM-66521:
   region: "NTSC-J"
   compat: 5
 SLPM-66522:
-  name: 真・三國無双3【コーエー定番シリーズ】
-  name-sort: しん・さんごくむそう3【こーえーていばんしりーず】
+  name: 真・三國無双3 [コーエー定番シリーズ]
+  name-sort: しん・さんごくむそう3 [こーえーていばんしりーず]
   name-en: "Shin Sangoku Musou 3 [KOEI Selection]"
   region: "NTSC-J"
 SLPM-66523:
-  name: 三國志IX with パワーアップキット【KOEI The Best】
-  name-sort: さんごくしIX with ぱわーあっぷきっと【KOEI The Best】
+  name: 三國志IX with パワーアップキット [KOEI The Best]
+  name-sort: さんごくしIX with ぱわーあっぷきっと [KOEI The Best]
   name-en: "Sangokushi IX [with Power-Up Kit]"
   region: "NTSC-J"
 SLPM-66524:
-  name: アンジェリーク エトワール【KOEI The Best】
-  name-sort: あんじぇりーく えとわーる【KOEI The Best】
+  name: アンジェリーク エトワール [KOEI The Best]
+  name-sort: あんじぇりーく えとわーる [KOEI The Best]
   name-en: "Angelique Etoile [Koei Best]"
   region: "NTSC-J"
 SLPM-66525:
-  name: Zill O’ll 〜infinite〜【KOEI The Best】
-  name-sort: Zill O’ll 〜infinite〜【KOEI The Best】
+  name: Zill O’ll 〜infinite〜 [KOEI The Best]
+  name-sort: Zill O’ll 〜infinite〜 [KOEI The Best]
   name-en: "Zill O'll Infinite [Koei The Best]"
   region: "NTSC-J"
 SLPM-66526:
-  name: 凱歌の号砲 エアランドフォース【コーエー定番シリーズ】
-  name-sort: がいかのごうほう えあらんどふぉーす【こーえーていばんしりーず】
+  name: 凱歌の号砲 エアランドフォース [コーエー定番シリーズ]
+  name-sort: がいかのごうほう えあらんどふぉーす [こーえーていばんしりーず]
   name-en: "Gaika no Gouhou - Air Land Force [KOEI Selection]"
   region: "NTSC-J"
 SLPM-66527:
-  name: 三國志戦記2【コーエー定番シリーズ】
-  name-sort: さんごくしせんき2【こーえーていばんしりーず】
+  name: 三國志戦記2 [コーエー定番シリーズ]
+  name-sort: さんごくしせんき2 [こーえーていばんしりーず]
   name-en: "Sangokushi Senki 2 [KOEI Selection]"
   region: "NTSC-J"
 SLPM-66528:
-  name: 信長の野望・天下創世 with パワーアップキット【KOEI The Best】
-  name-sort: のぶながのやぼう・てんかそうせい with ぱわーあっぷきっと【KOEI The Best】
+  name: 信長の野望・天下創世 with パワーアップキット [KOEI The Best]
+  name-sort: のぶながのやぼう・てんかそうせい with ぱわーあっぷきっと [KOEI The Best]
   name-en: "Nobunaga no Yabou - Tenka Sousei [with Power Up Kit] [KOEI the Best]"
   region: "NTSC-J"
 SLPM-66529:
-  name: 亡国のイージス 2035 〜ウォーシップガンナー〜【KOEI The Best】
-  name-sort: ぼうこくのいーじす 2035 〜うぉーしっぷがんなー〜【KOEI The Best】
+  name: 亡国のイージス 2035 〜ウォーシップガンナー〜 [KOEI The Best]
+  name-sort: ぼうこくのいーじす 2035 〜うぉーしっぷがんなー〜 [KOEI The Best]
   name-en: "Boukoku no Aegis 2035 - Warship Gunner [KOEI the Best]"
   region: "NTSC-J"
 SLPM-66530:
@@ -42651,8 +42651,8 @@ SLPM-66536:
   name-en: "Aria - The Natural - Tooi Yume no Mirage"
   region: "NTSC-J"
 SLPM-66537:
-  name: イリスのアトリエ エターナルマナ2【ガスト ベスト プライス】
-  name-sort: いりすのあとりえ えたーなるまな2【がすと べすと ぷらいす】
+  name: イリスのアトリエ エターナルマナ2 [ガスト ベスト プライス]
+  name-sort: いりすのあとりえ えたーなるまな2 [がすと べすと ぷらいす]
   name-en: "Iris no Atelier - Eternal Mana 2 [Gust Best Price]"
   region: "NTSC-J"
   gameFixes:
@@ -42720,8 +42720,8 @@ SLPM-66553:
   name-en: "Chaos Wars"
   region: "NTSC-J"
 SLPM-66554:
-  name: インタールード(ベスト版)
-  name-sort: いんたーるーど(べすとばん)
+  name: インタールード [ベスト版]
+  name-sort: いんたーるーど [べすとばん]
   name-en: "Interlude [Best Version]"
   region: "NTSC-J"
 SLPM-66555:
@@ -42730,15 +42730,15 @@ SLPM-66555:
   name-en: "SuperLite 2000 Series - Tokyo Bus Guide 2"
   region: "NTSC-J"
 SLPM-66556:
-  name: 忍道 戒【Spike the Best】
-  name-sort: しのびどう いましめ【Spike the Best】
+  name: 忍道 戒 [Spike the Best]
+  name-sort: しのびどう いましめ [Spike the Best]
   name-en: "Shinobido Imashime [Spike The Best]"
   region: "NTSC-J"
   clampModes:
     eeClampMode: 3 # Fixes hang going in to the gardens.
 SLPM-66557:
-  name: FIFAストリート【EA BEST HITS】
-  name-sort: FIFAすとりーと【EA BEST HITS】
+  name: FIFAストリート [EA BEST HITS]
+  name-sort: FIFAすとりーと [EA BEST HITS]
   name-en: "FIFA Street [EA Best Hits]"
   region: "NTSC-J"
 SLPM-66558:
@@ -42751,23 +42751,23 @@ SLPM-66558:
     textureInsideRT: 1 # Needed for post processing effects.
     minimumBlendingLevel: 4 # Fixes multiple lighting effects from lights, computers, cave walls and more.
 SLPM-66559:
-  name: Winning Post6【コーエー定番シリーズ】
-  name-sort: Winning Post6【こーえーていばんしりーず】
+  name: Winning Post6 [コーエー定番シリーズ]
+  name-sort: Winning Post6 [こーえーていばんしりーず]
   name-en: "Winning Post 6 [KOEI Selection]"
   region: "NTSC-J"
 SLPM-66560:
-  name: 三國志X【KOEI The Best】
-  name-sort: さんごくしX【KOEI The Best】
+  name: 三國志X [KOEI The Best]
+  name-sort: さんごくしX [KOEI The Best]
   name-en: "Sangokushi X [KOEI The Best]"
   region: "NTSC-J"
 SLPM-66561:
-  name: NBAライブ 06【EA BEST HITS】
-  name-sort: NBAらいぶ 06【EA BEST HITS】
+  name: NBAライブ 06 [EA BEST HITS]
+  name-sort: NBAらいぶ 06 [EA BEST HITS]
   name-en: "NBA Live '06 [EA Best Hits]"
   region: "NTSC-J"
 SLPM-66562:
-  name: ニード・フォー・スピード モスト・ウォンテッド【EA BEST HITS】
-  name-sort: にーど・ふぉー・すぴーど もすと・うぉんてっど【EA BEST HITS】
+  name: ニード・フォー・スピード モスト・ウォンテッド [EA BEST HITS]
+  name-sort: にーど・ふぉー・すぴーど もすと・うぉんてっど [EA BEST HITS]
   name-en: "Need for Speed - Most Wanted [EA Best Hits]"
   region: "NTSC-J"
   gsHWFixes:
@@ -42822,8 +42822,8 @@ SLPM-66567:
     roundSprite: 1 # Reduces misaligned bloom.
     mergeSprite: 1 # Removes bloom explosion around electrical lights and other light sources such as moon/sun.
 SLPM-66568:
-  name: ブラザー イン アームズ ロード トゥ ヒル サーティ【ユービーアイソフト ベスト】
-  name-sort: ぶらざー いん あーむず ろーど とぅ ひる さーてぃ【ゆーびーあいそふと べすと】
+  name: ブラザー イン アームズ ロード トゥ ヒル サーティ [ユービーアイソフト ベスト]
+  name-sort: ぶらざー いん あーむず ろーど とぅ ひる さーてぃ [ゆーびーあいそふと べすと]
   name-en: "Brothers In Arms - Road to Hill 30 [Ubisoft Best]"
   region: "NTSC-J"
   gsHWFixes:
@@ -42856,8 +42856,8 @@ SLPM-66572:
     - "SLPM-66572"
     - "SLPS-20423"
 SLPM-66573:
-  name: 鋼鉄の咆哮2ウォーシップガンナー【コーエー定番シリーズ】
-  name-sort: くろがねのほうこう2うぉーしっぷがんなー【こーえーていばんしりーず】
+  name: 鋼鉄の咆哮2ウォーシップガンナー [コーエー定番シリーズ]
+  name-sort: くろがねのほうこう2うぉーしっぷがんなー [こーえーていばんしりーず]
   name-en: "Kurogane no Houkou 2 - Warship Gunner [KOEI Selection]"
   region: "NTSC-J"
 SLPM-66574:
@@ -43012,8 +43012,8 @@ SLPM-66600:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
 SLPM-66601:
-  name: SSX on tour【EA BEST HITS】
-  name-sort: SSX on tour【EA BEST HITS】
+  name: SSX on tour [EA BEST HITS]
+  name-sort: SSX on tour [EA BEST HITS]
   name-en: "SSX On Tour [EA Best Hits]"
   region: "NTSC-J"
   gsHWFixes:
@@ -43088,13 +43088,13 @@ SLPM-66612:
   name-en: "School Love [Limited Edition]"
   region: "NTSC-J"
 SLPM-66613:
-  name: メダル オブ オナー 史上最大の作戦&メダル オブ オナー ライジングサン【EA BEST HITS】
-  name-sort: めだる おぶ おなー しじょうさいだいのさくせん&めだる おぶ おなー らいじんぐさん【EA BEST HITS】
+  name: メダル オブ オナー 史上最大の作戦&メダル オブ オナー ライジングサン [EA BEST HITS]
+  name-sort: めだる おぶ おなー しじょうさいだいのさくせん&めだる おぶ おなー らいじんぐさん [EA BEST HITS]
   name-en: "Medal of Honor - Rising Sun & Frontline [EA Best Hits]"
   region: "NTSC-J"
 SLPM-66615:
-  name: 007 ナイト ファイア&007 エブリシング オア ナッシング【EA BEST HITS】
-  name-sort: 007 ないと ふぁいあ&007 えぶりしんぐ おあ なっしんぐ【EA BEST HITS】
+  name: 007 ナイト ファイア&007 エブリシング オア ナッシング [EA BEST HITS]
+  name-sort: 007 ないと ふぁいあ&007 えぶりしんぐ おあ なっしんぐ [EA BEST HITS]
   name-en: "007 - Nightfire [EA Best Hits Dual Pack]"
   region: "NTSC-J"
 SLPM-66616:
@@ -43112,8 +43112,8 @@ SLPM-66617:
     halfPixelOffset: 2 # Fixes blurriness.
     roundSprite: 2 # Fixes blurriness.
 SLPM-66618:
-  name: 夢見師 (初回限定版)
-  name-sort: ゆめみし (しょかいげんていばん)
+  name: 夢見師 [初回限定版]
+  name-sort: ゆめみし [しょかいげんていばん]
   name-en: "Yumemishi [First Print Limited Edition]"
   region: "NTSC-J"
 SLPM-66619:
@@ -43132,8 +43132,8 @@ SLPM-66621:
   name-en: "Beatmania IIDX 12 HAPPY SKY"
   region: "NTSC-J"
 SLPM-66622:
-  name: トム・クランシーシリーズ ゴーストリコン2【ユービーアイソフト ベスト】
-  name-sort: とむ・くらんしーしりーず ごーすとりこん2【ゆーびーあいそふと べすと】
+  name: トム・クランシーシリーズ ゴーストリコン2 [ユービーアイソフト ベスト]
+  name-sort: とむ・くらんしーしりーず ごーすとりこん2 [ゆーびーあいそふと べすと]
   name-en: "Tom Clancy's Ghost Recon 2 [Ubisoft Best]"
   region: "NTSC-J"
 SLPM-66623:
@@ -43142,18 +43142,18 @@ SLPM-66623:
   name-en: "Dokapon the World [Asmik Tokudane Series]"
   region: "NTSC-J"
 SLPM-66624:
-  name: つよきす〜Mighy Heart〜(プリンセスソフトコレクション)
-  name-sort: つよきす〜Mighy Heart〜(ぷりんせすそふとこれくしょん)
+  name: つよきす〜Mighy Heart〜 [プリンセスソフトコレクション]
+  name-sort: つよきす〜Mighy Heart〜 [ぷりんせすそふとこれくしょん]
   name-en: "Tsuyo Kiss - Mighty Heart [Princess Soft Collection]"
   region: "NTSC-J"
 SLPM-66625:
-  name: とらぶるふぉうちゅん COMPANY★はぴCURE (初回限定版)
-  name-sort: とらぶるふぉうちゅん COMPANY★はぴCURE (しょかいげんていばん)
+  name: とらぶるふぉうちゅん COMPANY★はぴCURE [初回限定版]
+  name-sort: とらぶるふぉうちゅん COMPANY★はぴCURE [しょかいげんていばん]
   name-en: "Trouble Fortune Company - HapiCure [Limited Edition]"
   region: "NTSC-J"
 SLPM-66626:
-  name: とらぶるふぉうちゅん COMPANY★はぴCURE (通常版)
-  name-sort: とらぶるふぉうちゅん COMPANY★はぴCURE (つうじょうばん)
+  name: とらぶるふぉうちゅん COMPANY★はぴCURE [通常版]
+  name-sort: とらぶるふぉうちゅん COMPANY★はぴCURE [つうじょうばん]
   name-en: "Trouble Fortune Company - HapiCure"
   region: "NTSC-J"
 SLPM-66627:
@@ -43162,8 +43162,8 @@ SLPM-66627:
   name-en: "WWE SmackDown! vs. RAW 2007"
   region: "NTSC-J"
 SLPM-66628:
-  name: OutRun2 SP(アウトラン2 スペシャルツアーズ)初回限定版
-  name-sort: OutRun2 SP(あうとらん2 すぺしゃるつあーず)しょかいげんていばん
+  name: OutRun2 SP(アウトラン2 スペシャルツアーズ) [初回限定版]
+  name-sort: OutRun2 SP(あうとらん2 すぺしゃるつあーず) [しょかいげんていばん]
   name-en: "OutRun 2 SP [First Print Limited Edition]"
   region: "NTSC-J"
   compat: 5
@@ -43172,8 +43172,8 @@ SLPM-66628:
     halfPixelOffset: 2 # Fixes bloom misalignment still a bit misaligned.
     roundSprite: 1 # Fixes bloom misalignment still a bit misaligned + font artifacts.
 SLPM-66629:
-  name: DIRGE of CERBERUS -FINAL FANTASY VII- INTERNATIONAL【Ultimate Hits】
-  name-sort: DIRGE of CERBERUS -FINAL FANTASY VII- INTERNATIONAL【Ultimate Hits】
+  name: DIRGE of CERBERUS -FINAL FANTASY VII- INTERNATIONAL [Ultimate Hits]
+  name-sort: DIRGE of CERBERUS -FINAL FANTASY VII- INTERNATIONAL [Ultimate Hits]
   name-en: "Dirge of Cerberus - Final Fantasy VII International"
   region: "NTSC-J"
   gsHWFixes:
@@ -43281,8 +43281,8 @@ SLPM-66649:
   gsHWFixes:
     roundSprite: 1 # Fixes vertical and horizontal lines.
 SLPM-66651:
-  name: バトルフィールド2 モダンコンバット【EA BEST HITS】
-  name-sort: ばとるふぃーるど2 もだんこんばっと【EA BEST HITS】
+  name: バトルフィールド2 モダンコンバット [EA BEST HITS]
+  name-sort: ばとるふぃーるど2 もだんこんばっと [EA BEST HITS]
   name-en: "Battlefield 2 - Modern Combat [EA Best Hits]"
   region: "NTSC-J"
   gsHWFixes:
@@ -43293,8 +43293,8 @@ SLPM-66651:
     getSkipCount: "GSC_Battlefield2" # Depth clear.
     beforeDraw: "OI_Battlefield2" # Framebuffer copy, fixes rendering for bottom part of screen.
 SLPM-66652:
-  name: バーンアウト リベンジ【EA BEST HITS】
-  name-sort: ばーんあうと りべんじ【EA BEST HITS】
+  name: バーンアウト リベンジ [EA BEST HITS]
+  name-sort: ばーんあうと りべんじ [EA BEST HITS]
   name-en: "Burnout Revenge [EA Best Hits]"
   region: "NTSC-J"
   clampModes:
@@ -43324,28 +43324,28 @@ SLPM-66653:
   name-en: "Akudaikan 3"
   region: "NTSC-J"
 SLPM-66654:
-  name: 遙かなる時空の中で2【コーエー定番シリーズ】
-  name-sort: はるかなるときのなかで2【こーえーていばんしりーず】
+  name: 遙かなる時空の中で2 [コーエー定番シリーズ]
+  name-sort: はるかなるときのなかで2 [こーえーていばんしりーず]
   name-en: "Harukanaru Toki no Naka de 2 [Koei Selection]"
   region: "NTSC-J"
 SLPM-66655:
-  name: 遙かなる時空の中で 〜八葉抄〜【KOEI The Best】
+  name: 遙かなる時空の中で 〜八葉抄〜 [KOEI The Best]
   name-sort: はるかなるときのなかで 〜はちようしょう〜
   name-en: "Harukanaru Jikuu no Kade - Hachiha Katsunori [Koei the Best]"
   region: "NTSC-J"
 SLPM-66656:
-  name: ウォーシップガンナー2 〜鋼鉄の咆哮〜【KOEI The Best】
-  name-sort: うぉーしっぷがんなー2 〜くろがねのほうこう〜【KOEI The Best】
+  name: ウォーシップガンナー2 〜鋼鉄の咆哮〜 [KOEI The Best]
+  name-sort: うぉーしっぷがんなー2 〜くろがねのほうこう〜 [KOEI The Best]
   name-en: "Warship Gunner 2 - Change of Direction [Koei the Best]"
   region: "NTSC-J"
 SLPM-66657:
-  name: 真・三國無双3 猛将伝【コーエー定番シリーズ】
-  name-sort: しん・さんごくむそう3 もうしょうでん【こーえーていばんしりーず】
+  name: 真・三國無双3 猛将伝 [コーエー定番シリーズ]
+  name-sort: しん・さんごくむそう3 もうしょうでん [こーえーていばんしりーず]
   name-en: "Shin Sangoku Musou 3 Mushoden [Koei Selection]"
   region: "NTSC-J"
 SLPM-66658:
-  name: 真・三國無双3 Empiers【コーエー定番シリーズ】
-  name-sort: しん・さんごくむそう3 Empiers【こーえーていばんしりーず】
+  name: 真・三國無双3 Empiers [コーエー定番シリーズ]
+  name-sort: しん・さんごくむそう3 Empiers [こーえーていばんしりーず]
   name-en: "Shin Sangoku Musou 3 Empires [Koei Selection]"
   region: "NTSC-J"
 SLPM-66659:
@@ -43429,8 +43429,8 @@ SLPM-66672:
   name-en: "Tom Clancy's Splinter Cell - Double Agent"
   region: "NTSC-J"
 SLPM-66673:
-  name: プリンス・オブ・ペルシャ ケンシ ノ ココロ【ユービーアイソフトベスト】
-  name-sort: ぷりんす・おぶ・ぺるしゃ けんし の こころ【ゆーびーあいそふとべすと】
+  name: プリンス・オブ・ペルシャ ケンシ ノ ココロ [ユービーアイソフトベスト]
+  name-sort: ぷりんす・おぶ・ぺるしゃ けんし の こころ [ゆーびーあいそふとべすと]
   name-en: "Prince of Persia - Warrior Within [Ubisoft the Best]"
   region: "NTSC-J"
   gsHWFixes:
@@ -43468,8 +43468,8 @@ SLPM-66676:
     - "SLPM-66675"
     - "SLPM-66676"
 SLPM-66677:
-  name: ファイナルファンタジーX インターナショナル【アルティメット ヒッツ】
-  name-sort: ふぁいなるふぁんたじーX いんたーなしょなる【あるてぃめっと ひっつ】
+  name: ファイナルファンタジーX インターナショナル [アルティメット ヒッツ]
+  name-sort: ふぁいなるふぁんたじーX いんたーなしょなる [あるてぃめっと ひっつ]
   name-en: "Final Fantasy X - International [Ultimate Hits]"
   region: "NTSC-J"
   roundModes:
@@ -43477,8 +43477,8 @@ SLPM-66677:
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
 SLPM-66678:
-  name: ファイナルファンタジーX-2 インターナショナル+ラストミッション【アルティメット ヒッツ】
-  name-sort: ふぁいなるふぁんたじーX-2 いんたーなしょなる+らすとみっしょん【あるてぃめっと ひっつ】
+  name: ファイナルファンタジーX-2 インターナショナル+ラストミッション [アルティメット ヒッツ]
+  name-sort: ふぁいなるふぁんたじーX-2 いんたーなしょなる+らすとみっしょん [あるてぃめっと ひっつ]
   name-en: "Final Fantasy X-2 - International + Last Mission [Ultimate Hits]"
   region: "NTSC-J"
   gameFixes:
@@ -43535,13 +43535,13 @@ SLPM-66687:
         // This patch skips over the stack code, allowing the game to boot.
         patch=1,EE,001D1ED8,word,10000003
 SLPM-66688:
-  name: 遙かなる時空の中で3【KOEI The Best】
+  name: 遙かなる時空の中で3 [KOEI The Best]
   name-sort: はるかなるときのなかで3 KOEI The Best
   name-en: "Harukanaru Jikuu no Kade 3 [Koei the Best]"
   region: "NTSC-J"
 SLPM-66689:
-  name: ペルソナ3フェス 【アペンドディスク版】
-  name-sort: ぺるそな3ふぇす 【あぺんどでぃすくばん】
+  name: ペルソナ3フェス [アペンドディスク版]
+  name-sort: ぺるそな3ふぇす [あぺんどでぃすくばん]
   name-en: "Persona 3 FES [Append Edition]"
   region: "NTSC-J"
   gsHWFixes:
@@ -43567,13 +43567,13 @@ SLPM-66691:
   name-en: "Sengoku Basara 2 [CapKore]"
   region: "NTSC-J"
 SLPM-66692:
-  name: セレクション 星界の戦旗【BEST HIT】
-  name-sort: せれくしょん せいかいのせんき【BEST HIT】
+  name: セレクション 星界の戦旗 [BEST HIT]
+  name-sort: せれくしょん せいかいのせんき [BEST HIT]
   name-en: "Seikai no Senki [Best Hit]"
   region: "NTSC-J"
 SLPM-66693:
-  name: セレクション プリンセスメーカー4【BEST HIT】
-  name-sort: せれくしょん ぷりんせすめーかー4【BEST HIT】
+  name: セレクション プリンセスメーカー4 [BEST HIT]
+  name-sort: せれくしょん ぷりんせすめーかー4 [BEST HIT]
   name-en: "Princess Maker 4 [Best Version]"
   region: "NTSC-J"
 SLPM-66694:
@@ -43645,8 +43645,8 @@ SLPM-66707:
   name: "Yukinko Daisenpuu - Sayuki to Koyuki no Hie Hie Daisoudou"
   region: "NTSC-J"
 SLPM-66708:
-  name: ブラザー イン アームズ 名誉の代償【ユービーアイソフトベスト】
-  name-sort: ぶらざー いん あーむず めいよのだいしょう【ゆーびーあいそふとべすと】
+  name: ブラザー イン アームズ 名誉の代償 [ユービーアイソフトベスト]
+  name-sort: ぶらざー いん あーむず めいよのだいしょう [ゆーびーあいそふとべすと]
   name-en: "Brothers In Arms - Earned In Blood [Ubisoft Best]"
   region: "NTSC-J"
   gsHWFixes:
@@ -43687,8 +43687,8 @@ SLPM-66714:
     alignSprite: 1 # Fixes vertical lines.
     halfPixelOffset: 1 # Fixes misaligned bloom.
 SLPM-66715:
-  name: 新紀幻想 スペクトラル ソウルズ II【IFコレクション】
-  name-sort: しんきげんそう すぺくとらる そうるず II【IFこれくしょん】
+  name: 新紀幻想 スペクトラル ソウルズ II [IFコレクション]
+  name-sort: しんきげんそう すぺくとらる そうるず II [IFこれくしょん]
   name-en: "Shinki Gensou Spectral Souls II [IF Collection]"
   region: "NTSC-J"
 SLPM-66716:
@@ -43700,23 +43700,23 @@ SLPM-66716:
   gsHWFixes:
     moveHandler: "MV_Growlanser" # Fixes precomputed depth buffer.
 SLPM-66717:
-  name: スタンダード大戦略 電撃戦【SEGA THE BEST】
-  name-sort: すたんだーどだいせんりゃく でんげきせん【SEGA THE BEST】
+  name: スタンダード大戦略 電撃戦 [SEGA THE BEST]
+  name-sort: すたんだーどだいせんりゃく でんげきせん [SEGA THE BEST]
   name-en: "Standard Daisenryaku - Dengekisen [Sega the Best]"
   region: "NTSC-J"
 SLPM-66718:
-  name: スタンダード大戦略 失われた勝利【SEGA THE BEST】
-  name-sort: すたんだーどだいせんりゃく うしなわれたしょうり【SEGA THE BEST】
+  name: スタンダード大戦略 失われた勝利 [SEGA THE BEST]
+  name-sort: すたんだーどだいせんりゃく うしなわれたしょうり [SEGA THE BEST]
   name-en: "Sutandādo Daisenryaku - Ushinawareta Shoeri [Sega the Best]"
   region: "NTSC-J"
 SLPM-66719:
-  name: 天下人【SEGA THE BEST】
-  name-sort: てんかじん【SEGA THE BEST】
+  name: 天下人 [SEGA THE BEST]
+  name-sort: てんかじん [SEGA THE BEST]
   name-en: "Tenka-bito [Sega the Best]"
   region: "NTSC-J"
 SLPM-66720:
-  name: GUILTY GEAR XX SLASH(ギルティギア イグゼクス スラッシュ)【SEGA THE BEST】
-  name-sort: GUILTY GEAR XX SLASH(ぎるてぃぎあ いぐぜくす すらっしゅ)【SEGA THE BEST】
+  name: GUILTY GEAR XX SLASH(ギルティギア イグゼクス スラッシュ) [SEGA THE BEST]
+  name-sort: GUILTY GEAR XX SLASH(ぎるてぃぎあ いぐぜくす すらっしゅ) [SEGA THE BEST]
   name-en: "Guilty Gear XX #Slash [Sega the Best]"
   region: "NTSC-J"
 SLPM-66721:
@@ -43745,8 +43745,8 @@ SLPM-66725:
   name-en: "Zoids Struggle [Tomy Best Collection]"
   region: "NTSC-J"
 SLPM-66726:
-  name: お嬢様組曲 -Sweet Concert- (通常版)
-  name-sort: おじょうさまくみきょく -Sweet Concert- (つうじょうばん)
+  name: お嬢様組曲 -Sweet Concert- [通常版]
+  name-sort: おじょうさまくみきょく -Sweet Concert- [つうじょうばん]
   name-en: "Ojousama Kumikyoku - Sweet Concert"
   region: "NTSC-J"
 SLPM-66727:
@@ -43785,23 +43785,23 @@ SLPM-66731:
     getSkipCount: "GSC_BlackAndBurnoutSky"
     beforeDraw: "OI_BurnoutGames"
 SLPM-66732:
-  name: 許嫁(いいなずけ)【初回限定版】
-  name-sort: いいなずけ(いいなずけ)【しょかいげんていばん】
+  name: 許嫁(いいなずけ) [初回限定版]
+  name-sort: いいなずけ(いいなずけ) [しょかいげんていばん]
   name-en: "Iinazuke [Limited Edition]"
   region: "NTSC-J"
 SLPM-66733:
-  name: 許嫁(いいなずけ)【通常版】
-  name-sort: いいなずけ(いいなずけ)【つうじょうばん】
+  name: 許嫁(いいなずけ) [通常版]
+  name-sort: いいなずけ(いいなずけ) [つうじょうばん]
   name-en: "Iinazuke"
   region: "NTSC-J"
 SLPM-66734:
-  name: きると〜貴方と紡ぐ夢と恋のドレス〜(初回限定版)
-  name-sort: きると〜あなたとつむぐゆめとこいのどれす〜(しょかいげんていばん)
+  name: きると〜貴方と紡ぐ夢と恋のドレス〜 [初回限定版]
+  name-sort: きると〜あなたとつむぐゆめとこいのどれす〜 [しょかいげんていばん]
   name-en: "Kiruto - Anata to Tsumugu Yume to Koi no Dress [Limited Edition]"
   region: "NTSC-J"
 SLPM-66735:
-  name: きると〜貴方と紡ぐ夢と恋のドレス〜(通常版)
-  name-sort: きると〜あなたとつむぐゆめとこいのどれす〜(つうじょうばん)
+  name: きると〜貴方と紡ぐ夢と恋のドレス〜 [通常版]
+  name-sort: きると〜あなたとつむぐゆめとこいのどれす〜 [つうじょうばん]
   name-en: "Kiruto - Anata to Tsumugu Yume to Koi no Dress"
   region: "NTSC-J"
 SLPM-66736:
@@ -43851,13 +43851,13 @@ SLPM-66739:
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
 SLPM-66740:
-  name: 戦闘国家・改・レジェンド(DX版)
-  name-sort: せんとうこっか・かい・れじぇんど(DXばん)
+  name: 戦闘国家・改・レジェンド [DX版]
+  name-sort: せんとうこっか・かい・れじぇんど [DXばん]
   name-en: "Sentou Kokka Kai - Legend [DX Pack]"
   region: "NTSC-J"
 SLPM-66741:
-  name: 戦闘国家・改・レジェンド(通常版)
-  name-sort: せんとうこっか・かい・れじぇんど(つうじょうばん)
+  name: 戦闘国家・改・レジェンド [通常版]
+  name-sort: せんとうこっか・かい・れじぇんど [つうじょうばん]
   name-en: "Sentou Kokka Kai - Legend"
   region: "NTSC-J"
 SLPM-66742:
@@ -43916,8 +43916,8 @@ SLPM-66750:
   region: "NTSC-J"
   compat: 5
 SLPM-66751:
-  name: まほろばStories(通常版)
-  name-sort: まほろばStories(つうじょうばん)
+  name: まほろばStories [通常版]
+  name-sort: まほろばStories [つうじょうばん]
   name-en: "Mahoroba Stories"
   region: "NTSC-J"
 SLPM-66752:
@@ -43929,60 +43929,60 @@ SLPM-66752:
     halfPixelOffset: 2 # Fixes lighting misalignment.
     mergeSprite: 1 # Removes occasional vertical lines.
 SLPM-66753:
-  name: 月面兎兵器ミーナ -ふたつのPROJECT M-【限定版】
-  name-sort: げつめんうさぎへいきみーな -ふたつのPROJECT M-【げんていばん】
+  name: 月面兎兵器ミーナ -ふたつのPROJECT M- [限定版]
+  name-sort: げつめんうさぎへいきみーな -ふたつのPROJECT M- [げんていばん]
   name-en: "Getsumento Heiki Mina - Futatsu no Project M [Limited Edition]"
   region: "NTSC-J"
 SLPM-66754:
-  name: 月面兎兵器ミーナ -ふたつのPROJECT M-【通常版】
-  name-sort: げつめんうさぎへいきみーな -ふたつのPROJECT M-【つうじょうばん】
+  name: 月面兎兵器ミーナ -ふたつのPROJECT M- [通常版]
+  name-sort: げつめんうさぎへいきみーな -ふたつのPROJECT M- [つうじょうばん]
   name-en: "Getsumento Heiki Mina - Futatsu no Project M"
   region: "NTSC-J"
 SLPM-66755:
-  name: 魔女っ娘ア・ラ・モードII〜魔女と剣のストラグル〜(通常版)
-  name-sort: まじょっこあ・ら・もーどII〜まじょとけんのすとらぐる〜(つうじょうばん)
+  name: 魔女っ娘ア・ラ・モードII〜魔女と剣のストラグル〜 [通常版]
+  name-sort: まじょっこあ・ら・もーどII〜まじょとけんのすとらぐる〜 [つうじょうばん]
   name-en: "Majo-musume - A La Mode II"
   region: "NTSC-J"
   gsHWFixes:
     cpuCLUTRender: 1 # Fixes bad colour rendering.
 SLPM-66756:
-  name: Que〜エンシェントリーフの妖精〜(初回限定版)
-  name-sort: Que〜えんしぇんとりーふのようせい〜(しょかいげんていばん)
+  name: Que〜エンシェントリーフの妖精〜 [初回限定版]
+  name-sort: Que〜えんしぇんとりーふのようせい〜 [しょかいげんていばん]
   name-en: "Que - Ancient Leaf no Yousei [Limited Edition]"
   region: "NTSC-J"
 SLPM-66757:
-  name: Que〜エンシェントリーフの妖精〜(通常版)
-  name-sort: Que〜えんしぇんとりーふのようせい〜(つうじょうばん)
+  name: Que〜エンシェントリーフの妖精〜 [通常版]
+  name-sort: Que〜えんしぇんとりーふのようせい〜 [つうじょうばん]
   name-en: "Que - Ancient Leaf no Yousei"
   region: "NTSC-J"
 SLPM-66758:
-  name: ネオ アンジェリーク【KOEI The Best】
-  name-sort: ねお あんじぇりーく【KOEI The Best】
+  name: ネオ アンジェリーク [KOEI The Best]
+  name-sort: ねお あんじぇりーく [KOEI The Best]
   name-en: "Neo Angelique [Koei the Best]"
   region: "NTSC-J"
 SLPM-66759:
-  name: 遙かなる時空の中で3 十六夜記【KOEI The Best】
-  name-sort: はるかなるときのなかで3 いざよいき【KOEI The Best】
+  name: 遙かなる時空の中で3 十六夜記 [KOEI The Best]
+  name-sort: はるかなるときのなかで3 いざよいき [KOEI The Best]
   name-en: "Harukanaru Jikuu no Kade 3 - Izayoiki [Koei the Best]"
   region: "NTSC-J"
 SLPM-66760:
-  name: 信長の野望・蒼天録 with パワーアップキット【コーエー定番シリーズ】
-  name-sort: のぶながのやぼう・そうてんろく with ぱわーあっぷきっと【こーえーていばんしりーず】
+  name: 信長の野望・蒼天録 with パワーアップキット [コーエー定番シリーズ]
+  name-sort: のぶながのやぼう・そうてんろく with ぱわーあっぷきっと [こーえーていばんしりーず]
   name-en: "Nobunaga no Yabou - Soutenroku [with Power-Up Kit] [Koei Selection]"
   region: "NTSC-J"
 SLPM-66761:
-  name: Panic Palette(限定版)
-  name-sort: Panic Palette(げんていばん)
+  name: Panic Palette [限定版]
+  name-sort: Panic Palette [げんていばん]
   name-en: "Panic Palette [Limited Edition]"
   region: "NTSC-J"
 SLPM-66762:
-  name: Panic Palette(通常版)
-  name-sort: Panic Palette(つうじょうばん)
+  name: Panic Palette [通常版]
+  name-sort: Panic Palette [つうじょうばん]
   name-en: "Panic Palette"
   region: "NTSC-J"
 SLPM-66763:
-  name: 新世紀エヴァンゲリオン バトルオーケストラ【通常版】
-  name-sort: しんせいきえゔぁんげりおん ばとるおーけすとら【つうじょうばん】
+  name: 新世紀エヴァンゲリオン バトルオーケストラ [通常版]
+  name-sort: しんせいきえゔぁんげりおん ばとるおーけすとら [つうじょうばん]
   name-en: "Neon Genesis Evangelion - Battle Orchestra"
   region: "NTSC-J"
   compat: 5
@@ -43992,13 +43992,13 @@ SLPM-66764:
   name-en: "Izumo Zero"
   region: "NTSC-J"
 SLPM-66765:
-  name: 十次元立方体サイファー ゲーム・オブ・サバイバル(初回限定版)
-  name-sort: じゅうじげんりっぽうたいさいふぁー げーむ・おぶ・さばいばる(しょかいげんていばん)
+  name: 十次元立方体サイファー ゲーム・オブ・サバイバル [初回限定版]
+  name-sort: じゅうじげんりっぽうたいさいふぁー げーむ・おぶ・さばいばる [しょかいげんていばん]
   name-en: "Juujimoto Ripputai Sypher - Game of Survival [Limited Edition]"
   region: "NTSC-J"
 SLPM-66766:
-  name: 十次元立方体サイファー ゲーム・オブ・サバイバル(通常版)
-  name-sort: じゅうじげんりっぽうたいさいふぁー げーむ・おぶ・さばいばる(つうじょうばん)
+  name: 十次元立方体サイファー ゲーム・オブ・サバイバル [通常版]
+  name-sort: じゅうじげんりっぽうたいさいふぁー げーむ・おぶ・さばいばる [つうじょうばん]
   name-en: "Juujimoto Ripputai Sypher - Game of Survival"
   region: "NTSC-J"
 SLPM-66767:
@@ -44025,35 +44025,35 @@ SLPM-66770:
   name-en: "Kuon no Kizuna - Sairinshou [Best Version]"
   region: "NTSC-J"
 SLPM-66771:
-  name: 電車でGO!山陽新幹線編【エターナルヒッツ】
-  name-sort: でんしゃでGO!さんようしんかんせんへん【えたーなるひっつ】
+  name: 電車でGO!山陽新幹線編 [エターナルヒッツ]
+  name-sort: でんしゃでGO!さんようしんかんせんへん [えたーなるひっつ]
   name-en: "Densha de Go! Shinkansen [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPM-66772:
-  name: 電車でGO!FINAL【エターナルヒッツ】
-  name-sort: でんしゃでGO!FINAL【えたーなるひっつ】
+  name: 電車でGO!FINAL [エターナルヒッツ]
+  name-sort: でんしゃでGO!FINAL [えたーなるひっつ]
   name-en: "Densha de Go! Final [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPM-66773:
-  name: ジェットでGO!2【エターナルヒッツ】
-  name-sort: じぇっとでGO!2【えたーなるひっつ】
+  name: ジェットでGO!2 [エターナルヒッツ]
+  name-sort: じぇっとでGO!2 [えたーなるひっつ]
   name-en: "Densha de Go! Professional 2 [Taito Best]"
   region: "NTSC-J"
 SLPM-66774:
-  name: エナジーエアーフォース【エターナルヒッツ】
-  name-sort: えなじーえあーふぉーす【えたーなるひっつ】
+  name: エナジーエアーフォース [エターナルヒッツ]
+  name-sort: えなじーえあーふぉーす [えたーなるひっつ]
   name-en: "Energy Airforce - AimStrike! [Taito Best]"
   region: "NTSC-J"
 SLPM-66775:
-  name: タイトーメモリーズ 上巻【エターナルヒッツ】
-  name-sort: たいとーめもりーず じょうかん【えたーなるひっつ】
+  name: タイトーメモリーズ 上巻 [エターナルヒッツ]
+  name-sort: たいとーめもりーず じょうかん [えたーなるひっつ]
   name-en: "Taito Memories - Joukan [Taito Best]"
   region: "NTSC-J"
   gsHWFixes:
     roundSprite: 1 # Fixes vertical and horizontal lines.
 SLPM-66776:
-  name: タイトーメモリーズ 下巻【エターナルヒッツ】
-  name-sort: たいとーめもりーず げかん【えたーなるひっつ】
+  name: タイトーメモリーズ 下巻 [エターナルヒッツ]
+  name-sort: たいとーめもりーず げかん [えたーなるひっつ]
   name-en: "Taito Memories Gekan [Taito Best]"
   region: "NTSC-J"
   gsHWFixes:
@@ -44085,13 +44085,13 @@ SLPM-66780:
   memcardFilters:
     - "SLPM-66779"
 SLPM-66781:
-  name: ドラゴンクエスト 少年ヤンガスと不思議のダンジョン【アルティメットヒッツ】
-  name-sort: どらごんくえすと しょうねんやんがすとふしぎのだんじょん【あるてぃめっとひっつ】
+  name: ドラゴンクエスト 少年ヤンガスと不思議のダンジョン [アルティメットヒッツ]
+  name-sort: どらごんくえすと しょうねんやんがすとふしぎのだんじょん [あるてぃめっとひっつ]
   name-en: "Dragon Quest - Shounen Yangus to Fushigi no Dungeon [Ultimate Hits]"
   region: "NTSC-J"
 SLPM-66782:
-  name: ヴァルキリープロファイル2シルメリア【アルティメットヒッツ】
-  name-sort: ゔぁるきりーぷろふぁいる2しるめりあ【あるてぃめっとひっつ】
+  name: ヴァルキリープロファイル2シルメリア [アルティメットヒッツ]
+  name-sort: ゔぁるきりーぷろふぁいる2しるめりあ [あるてぃめっとひっつ]
   name-en: "Valkyrie Profile 2 - Silmeria [Ultimate Hits]"
   region: "NTSC-J"
   compat: 5
@@ -44111,8 +44111,8 @@ SLPM-66784:
   name: "Idol Janshi Suchie-Pai III Remix"
   region: "NTSC-J"
 SLPM-66785:
-  name: アイドル雀士 スーチーパイIV (通常版)
-  name-sort: あいどるじゃんし すーちーぱいIV (つうじょうばん)
+  name: アイドル雀士 スーチーパイIV [通常版]
+  name-sort: あいどるじゃんし すーちーぱいIV [つうじょうばん]
   name-en: "Idol Janshi Suchie-Pai 4"
   region: "NTSC-J"
 SLPM-66786:
@@ -44145,8 +44145,8 @@ SLPM-66790:
   name-en: "Grand Theft Auto - Vice City [Best Price]"
   region: "NTSC-J"
 SLPM-66791:
-  name: Memories Off ♯5 アンコール【通常版】
-  name-sort: Memories Off ♯5 あんこーる【つうじょうばん】
+  name: Memories Off ♯5 アンコール [通常版]
+  name-sort: Memories Off ♯5 あんこーる [つうじょうばん]
   name-en: "Memories Off #5 Encore"
   region: "NTSC-J"
 SLPM-66792:
@@ -44213,13 +44213,13 @@ SLPM-66803:
   name-en: "Shikaku Tantei - Sora no Sekai - Thousand Dreams"
   region: "NTSC-J"
 SLPM-66804:
-  name: カラフルアクアリウム〜My Little Mermaid〜(初回限定版)
-  name-sort: からふるあくありうむ〜My Little Mermaid〜(しょかいげんていばん)
+  name: カラフルアクアリウム〜My Little Mermaid〜 [初回限定版]
+  name-sort: からふるあくありうむ〜My Little Mermaid〜 [しょかいげんていばん]
   name-en: "Colorful Aquarium - My Little Mermaid [Limited Edition]"
   region: "NTSC-J"
 SLPM-66805:
-  name: カラフルアクアリウム〜My Little Mermaid〜(通常版)
-  name-sort: からふるあくありうむ〜My Little Mermaid〜(つうじょうばん)
+  name: カラフルアクアリウム〜My Little Mermaid〜 [通常版]
+  name-sort: からふるあくありうむ〜My Little Mermaid〜 [つうじょうばん]
   name-en: "Colorful Aquarium - My Little Mermaid"
   region: "NTSC-J"
 SLPM-66806:
@@ -44240,8 +44240,8 @@ SLPM-66807:
     wildArmsHack: 1 # Reduces blooming misalignment.
     autoFlush: 2 # Fixes glows.
 SLPM-66808:
-  name: ゴーストリコン アドバンスウォーファイター【ユービーアイソフトベスト】
-  name-sort: ごーすとりこん あどばんすうぉーふぁいたー【ゆーびーあいそふとべすと】
+  name: ゴーストリコン アドバンスウォーファイター [ユービーアイソフトベスト]
+  name-sort: ごーすとりこん あどばんすうぉーふぁいたー [ゆーびーあいそふとべすと]
   name-en: "Tom Clancy's Ghost Recon - Advanced Warfighter [Ubisoft the Best]"
   region: "NTSC-J"
   gsHWFixes:
@@ -44259,18 +44259,18 @@ SLPM-66810:
   name-en: "J.League Winning Eleven 2007 Club Championship"
   region: "NTSC-J"
 SLPM-66811:
-  name: Winning Post 7【KOEI The Best】
-  name-sort: Winning Post 7【KOEI The Best】
+  name: Winning Post 7 [KOEI The Best]
+  name-sort: Winning Post 7 [KOEI The Best]
   name-en: "Winning Post 7 [Koei the Best]"
   region: "NTSC-J"
 SLPM-66812:
-  name: ジーワンジョッキー4【KOEI The Best】
-  name-sort: じーわんじょっきー4【KOEI The Best】
+  name: ジーワンジョッキー4 [KOEI The Best]
+  name-sort: じーわんじょっきー4 [KOEI The Best]
   name-en: "GI Jockey 4 [Koei the Best]"
   region: "NTSC-J"
 SLPM-66813:
-  name: 三國志IX【コーエー定番シリーズ】
-  name-sort: さんごくしIX【こーえーていばんしりーず】
+  name: 三國志IX [コーエー定番シリーズ]
+  name-sort: さんごくしIX [こーえーていばんしりーず]
   name-en: "Sangokushi IX [Koei Selection]"
   region: "NTSC-J"
 SLPM-66814:
@@ -44322,8 +44322,8 @@ SLPM-66823:
   name-en: "Taka Reet Ura Mahjong Retsuden - Mukoubushi"
   region: "NTSC-J"
 SLPM-66824:
-  name: 翡翠の雫 〜緋色の欠片2〜(限定版)
-  name-sort: ひすいのしずく 〜ひいろのかけら2〜(げんていばん)
+  name: 翡翠の雫 〜緋色の欠片2〜 [限定版]
+  name-sort: ひすいのしずく 〜ひいろのかけら2〜 [げんていばん]
   name-en: "Hiiro no Kakera 2 [Limited Edition]"
   region: "NTSC-J"
 SLPM-66825:
@@ -44332,13 +44332,13 @@ SLPM-66825:
   name-en: "Hiiro no Kakera 2"
   region: "NTSC-J"
 SLPM-66826:
-  name: 妖鬼姫伝 〜あやかし幻灯話〜(限定版)
-  name-sort: ようきひでん 〜あやかしげんとうばなし〜(げんていばん)
+  name: 妖鬼姫伝 〜あやかし幻灯話〜 [限定版]
+  name-sort: ようきひでん 〜あやかしげんとうばなし〜 [げんていばん]
   name-en: "Youki Hime Den [Limited Edition]"
   region: "NTSC-J"
 SLPM-66827:
-  name: 妖鬼姫伝 〜あやかし幻灯話〜(通常版)
-  name-sort: ようきひでん 〜あやかしげんとうばなし〜(つうじょうばん)
+  name: 妖鬼姫伝 〜あやかし幻灯話〜 [通常版]
+  name-sort: ようきひでん 〜あやかしげんとうばなし〜 [つうじょうばん]
   name-en: "Youki Hime Den"
   region: "NTSC-J"
 SLPM-66828:
@@ -44363,8 +44363,8 @@ SLPM-66834:
   name: "Kin'iro no Corda 2 Encore"
   region: "NTSC-J"
 SLPM-66835:
-  name: 金色のコルダ2 アンコール(通常版)
-  name-sort: きんいろのこるだ2 あんこーる(つうじょうばん)
+  name: 金色のコルダ2 アンコール [通常版]
+  name-sort: きんいろのこるだ2 あんこーる [つうじょうばん]
   name-en: "Kiniro no Corda 2 Anchor"
   region: "NTSC-J"
 SLPM-66836:
@@ -44413,13 +44413,13 @@ SLPM-66843:
   name-en: "Generations of Chaos - Desire"
   region: "NTSC-J"
 SLPM-66844:
-  name: 悠久ノ桜(限定版)
-  name-sort: ゆうきゅうのさくら(げんていばん)
+  name: 悠久ノ桜 [限定版]
+  name-sort: ゆうきゅうのさくら [げんていばん]
   name-en: "Yuukyuu no Sakura [Limited Edition]"
   region: "NTSC-J"
 SLPM-66845:
-  name: 悠久ノ桜(通常版)
-  name-sort: ゆうきゅうのさくら(つうじょうばん)
+  name: 悠久ノ桜 [通常版]
+  name-sort: ゆうきゅうのさくら [つうじょうばん]
   name-en: "Yuukyuu no Sakura"
   region: "NTSC-J"
 SLPM-66846:
@@ -44438,8 +44438,8 @@ SLPM-66848:
   name-en: "Sengoku Basara 2 Heroes"
   region: "NTSC-J"
 SLPM-66849:
-  name: イリスのアトリエ グランファンタズム【ガストベストプライス】
-  name-sort: いりすのあとりえ ぐらんふぁんたずむ【がすとべすとぷらいす】
+  name: イリスのアトリエ グランファンタズム [ガストベストプライス]
+  name-sort: いりすのあとりえ ぐらんふぁんたずむ [がすとべすとぷらいす]
   name-en: "Iris no Atelier - Grand Fantasm [Gust Best Price]"
   region: "NTSC-J"
   gsHWFixes:
@@ -44485,13 +44485,13 @@ SLPM-66856:
   name-en: "Togainu no Chi - True Blood"
   region: "NTSC-J"
 SLPM-66857:
-  name: いつか、届く、あの空に。 〜陽の道と緋の昏と〜(初回限定版)
-  name-sort: いつか、とどく、あのそらに。 〜ようのみちとひのたそがれと〜(しょかいげんていばん)
+  name: いつか、届く、あの空に。 〜陽の道と緋の昏と〜 [初回限定版]
+  name-sort: いつか、とどく、あのそらに。 〜ようのみちとひのたそがれと〜 [しょかいげんていばん]
   name-en: "Itsuka, Todoku, Ano Sora ni [Limited Edition]"
   region: "NTSC-J"
 SLPM-66858:
-  name: いつか、届く、あの空に。 〜陽の道と緋の昏と〜(通常版)
-  name-sort: いつか、とどく、あのそらに。 〜ようのみちとひのたそがれと〜(つうじょうばん)
+  name: いつか、届く、あの空に。 〜陽の道と緋の昏と〜 [通常版]
+  name-sort: いつか、とどく、あのそらに。 〜ようのみちとひのたそがれと〜 [つうじょうばん]
   name-en: "Itsuka, Todoku, Ano Sora ni"
   region: "NTSC-J"
 SLPM-66859:
@@ -44500,18 +44500,18 @@ SLPM-66859:
   name-en: "Sengoku Basara [Best Price]"
   region: "NTSC-J"
 SLPM-66860:
-  name: 熱帯低気圧少女(初回限定版)
-  name-sort: ねったいていきあつしょうじょ(しょかいげんていばん)
+  name: 熱帯低気圧少女 [初回限定版]
+  name-sort: ねったいていきあつしょうじょ [しょかいげんていばん]
   name-en: "Nettai Teikiatsu Otome [Limited Edition]"
   region: "NTSC-J"
 SLPM-66861:
-  name: 熱帯低気圧少女(通常版)
-  name-sort: ねったいていきあつしょうじょ(つうじょうばん)
+  name: 熱帯低気圧少女 [通常版]
+  name-sort: ねったいていきあつしょうじょ [つうじょうばん]
   name-en: "Nettai Teikiatsu Otome"
   region: "NTSC-J"
 SLPM-66862:
-  name: あやかしびとー幻妖異聞録ー【BestSelection】
-  name-sort: あやかしびとーげんよういぶんろくー【BestSelection】
+  name: あやかしびとー幻妖異聞録ー [BestSelection]
+  name-sort: あやかしびとーげんよういぶんろくー [BestSelection]
   name-en: "Ayaka Shibito [Best Selection]"
   region: "NTSC-J"
 SLPM-66863:
@@ -44540,13 +44540,13 @@ SLPM-66867:
   name-en: "MotoGP '07"
   region: "NTSC-J"
 SLPM-66868:
-  name: スプリンターセル 二重スパイ【ユービーアイソフトベスト】
-  name-sort: すぷりんたーせる にじゅうすぱい【ゆーびーあいそふとべすと】
+  name: スプリンターセル 二重スパイ [ユービーアイソフトベスト]
+  name-sort: すぷりんたーせる にじゅうすぱい [ゆーびーあいそふとべすと]
   name-en: "Tom Clancy's Splinter Cell - Double Agent [Ubisoft the Best]"
   region: "NTSC-J"
 SLPM-66869:
-  name: ニード・フォー・スピード カーボン【EA BEST HITS】
-  name-sort: にーど・ふぉー・すぴーど かーぼん【EA BEST HITS】
+  name: ニード・フォー・スピード カーボン [EA BEST HITS]
+  name-sort: にーど・ふぉー・すぴーど かーぼん [EA BEST HITS]
   name-en: "Need for Speed - Carbon [EA Best Hits]"
   region: "NTSC-J"
   clampModes:
@@ -44556,18 +44556,18 @@ SLPM-66869:
     halfPixelOffset: 2 # Fixes blurriness.
     roundSprite: 2 # Fixes blurriness.
 SLPM-66870:
-  name: 星色のおくりもの(初回スペシャル限定版)
-  name-sort: ほしいろのおくりもの(しょかいすぺしゃるげんていばん)
+  name: 星色のおくりもの [初回スペシャル限定版]
+  name-sort: ほしいろのおくりもの [しょかいすぺしゃるげんていばん]
   name-en: "Kuri no Okurimono [First Print Special Edition]"
   region: "NTSC-J"
 SLPM-66871:
-  name: 召喚少女-ElementalGirl Calling-(DXパック)
-  name-sort: しょうかんしょうじょ-ElementalGirl Calling-(DXぱっく)
+  name: 召喚少女-ElementalGirl Calling- [DXパック]
+  name-sort: しょうかんしょうじょ-ElementalGirl Calling- [DXぱっく]
   name-en: "Shoukan Shoujo - Elemental Girl Calling [DX Pack]"
   region: "NTSC-J"
 SLPM-66872:
-  name: 召喚少女-ElementalGirl Calling-(通常版)
-  name-sort: しょうかんしょうじょ-ElementalGirl Calling-(つうじょうばん)
+  name: 召喚少女-ElementalGirl Calling- [通常版]
+  name-sort: しょうかんしょうじょ-ElementalGirl Calling- [つうじょうばん]
   name-en: "Shoukan Shoujo - Elemental Girl Calling"
   region: "NTSC-J"
   compat: 5
@@ -44602,13 +44602,13 @@ SLPM-66878:
   name-en: "Dokapon Kingdom"
   region: "NTSC-J"
 SLPM-66879:
-  name: StarTRain -your past makes your future-(初回限定版)
-  name-sort: StarTRain -your past makes your future-(しょかいげんていばん)
+  name: StarTRain -your past makes your future- [初回限定版]
+  name-sort: StarTRain -your past makes your future- [しょかいげんていばん]
   name-en: "StarTRain - Your Past Makes Your Future [Limited Edition]"
   region: "NTSC-J"
 SLPM-66880:
-  name: StarTRain -your past makes your future-(通常版)
-  name-sort: StarTRain -your past makes your future-(つうじょうばん)
+  name: StarTRain -your past makes your future- [通常版]
+  name-sort: StarTRain -your past makes your future- [つうじょうばん]
   name-en: "StarTRain - Your Past Makes Your Future"
   region: "NTSC-J"
 SLPM-66881:
@@ -44624,8 +44624,8 @@ SLPM-66881:
     skipDrawStart: 1 # Removes large black box around player car till we properly emulate it.
     skipDrawEnd: 1 # Removes large black box around player car till we properly emulate it.
 SLPM-66882:
-  name: はかれなはーと 〜君がために輝きを〜(限定版・サントラボイスCD付)
-  name-sort: はかれなはーと 〜きみがためにかがやきを〜(げんていばん・さんとらぼいすCDづけ)
+  name: はかれなはーと 〜君がために輝きを〜 [限定版・サントラボイスCD付]
+  name-sort: はかれなはーと 〜きみがためにかがやきを〜 [げんていばん・さんとらぼいすCDづけ]
   name-en: "Hakarena Heart [Limited Edition]"
   region: "NTSC-J"
 SLPM-66883:
@@ -44653,8 +44653,8 @@ SLPM-66886:
     halfPixelOffset: 1 # Fixes ghosting.
     alignSprite: 1 # Fixes vertical lines.
 SLPM-66887:
-  name: 遙かなる時空の中で3 運命の迷宮【KOEI The Best】
-  name-sort: はるかなるときのなかで3 うんめいのめいきゅう【KOEI The Best】
+  name: 遙かなる時空の中で3 運命の迷宮 [KOEI The Best]
+  name-sort: はるかなるときのなかで3 うんめいのめいきゅう [KOEI The Best]
   name-en: "Harukanaru Jikuu no Kade 3 - Unmei no Meikyuu [Koei the Best]"
   region: "NTSC-J"
 SLPM-66888:
@@ -44673,8 +44673,8 @@ SLPM-66890:
   name-en: "Puri-Saga! Princess o Sagase!"
   region: "NTSC-J"
 SLPM-66891:
-  name: Myself;Yourself(初回限定版)
-  name-sort: Myself;Yourself(しょかいげんていばん)
+  name: Myself;Yourself [初回限定版]
+  name-sort: Myself;Yourself [しょかいげんていばん]
   name-en: "Myself, Yourself [Limited Edition]"
   region: "NTSC-J"
 SLPM-66892:
@@ -44711,8 +44711,8 @@ SLPM-66897:
     halfPixelOffset: 2 # Fixes ghosting.
     autoFlush: 2 # Fixes post lighting.
 SLPM-66898:
-  name: スペクトラルジーン(限定版)
-  name-sort: すぺくとらるじーん(げんていばん)
+  name: スペクトラルジーン [限定版]
+  name-sort: すぺくとらるじーん [げんていばん]
   name-en: "Spectral Gene [Limited Edition]"
   region: "NTSC-J"
 SLPM-66899:
@@ -44755,8 +44755,8 @@ SLPM-66906:
   name-en: "Tenshou Gakuen Gekkouroku [Tokudane Price]"
   region: "NTSC-J"
 SLPM-66907:
-  name: 許婚【プリンセスソフト・コレクション】
-  name-sort: きょこん【ぷりんせすそふと・これくしょん】
+  name: 許婚 [プリンセスソフト・コレクション]
+  name-sort: きょこん [ぷりんせすそふと・これくしょん]
   name-en: "Iinazuke [Princess Soft Collection]"
   region: "NTSC-J"
 SLPM-66908:
@@ -44779,8 +44779,8 @@ SLPM-66910:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misalignment.
 SLPM-66911:
-  name: ふぁいなりすと【プリンセスソフト・コレクション】
-  name-sort: ふぁいなりすと【ぷりんせすそふと・これくしょん】
+  name: ふぁいなりすと [プリンセスソフト・コレクション]
+  name-sort: ふぁいなりすと [ぷりんせすそふと・これくしょん]
   name-en: "Finalist [Princess Soft Collection]"
   region: "NTSC-J"
 SLPM-66912:
@@ -44908,18 +44908,18 @@ SLPM-66936:
   name-en: "Night Wizard - The Video Game - Denial of the World"
   region: "NTSC-J"
 SLPM-66937:
-  name: 雀・三國無双【KOEI The Best】
-  name-sort: じゃん・さんごくむそう【KOEI The Best】
+  name: 雀・三國無双 [KOEI The Best]
+  name-sort: じゃん・さんごくむそう [KOEI The Best]
   name-en: "Jan Sangoku Musou [Koei the Best]"
   region: "NTSC-J"
 SLPM-66938:
-  name: アンジェリークエトワール【コーエー定番シリーズ】
-  name-sort: あんじぇりーくえとわーる【こーえーていばんしりーず】
+  name: アンジェリークエトワール [コーエー定番シリーズ]
+  name-sort: あんじぇりーくえとわーる [こーえーていばんしりーず]
   name-en: "Angelique Etoile [Koei Selection]"
   region: "NTSC-J"
 SLPM-66939:
-  name: 亡国のイージス2035　〜ウォーシップガンナー〜【コーエー定番シリーズ】
-  name-sort: ぼうこくのいーじす2035　〜うぉーしっぷがんなー〜【こーえーていばんしりーず】
+  name: 亡国のイージス2035　〜ウォーシップガンナー〜 [コーエー定番シリーズ]
+  name-sort: ぼうこくのいーじす2035　〜うぉーしっぷがんなー〜 [こーえーていばんしりーず]
   name-en: "Boukoku no Aegis 2035 - Warship Gunner [Koei Selection]"
   region: "NTSC-J"
 SLPM-66940:
@@ -44953,8 +44953,8 @@ SLPM-66945:
   name-en: "Petit Four"
   region: "NTSC-J"
 SLPM-66946:
-  name: NBAライブ 07【EA BEST HITS】
-  name-sort: NBAらいぶ 07【EA BEST HITS】
+  name: NBAライブ 07 [EA BEST HITS]
+  name-sort: NBAらいぶ 07 [EA BEST HITS]
   name-en: "NBA Live '07 [EA Best Hits]"
   region: "NTSC-J"
 SLPM-66947:
@@ -45099,13 +45099,13 @@ SLPM-66970:
   name-en: "Pro Yakyuu Spirits 5"
   region: "NTSC-J"
 SLPM-66971:
-  name: 三國志IX with パワーアップキット【コーエー定番シリーズ】
-  name-sort: さんごくしIX with ぱわーあっぷきっと【こーえーていばんしりーず】
+  name: 三國志IX with パワーアップキット [コーエー定番シリーズ]
+  name-sort: さんごくしIX with ぱわーあっぷきっと [こーえーていばんしりーず]
   name-en: "Sangokushi IX [with Power-Up Kit] [Koei Selection]"
   region: "NTSC-J"
 SLPM-66972:
-  name: 鋼鉄の咆哮2 ウォーシップコマンダー【コーエー定番シリーズ】
-  name-sort: くろがねのほうこう2 うぉーしっぷこまんだー【こーえーていばんしりーず】
+  name: 鋼鉄の咆哮2 ウォーシップコマンダー [コーエー定番シリーズ]
+  name-sort: くろがねのほうこう2 うぉーしっぷこまんだー [こーえーていばんしりーず]
   name-en: "Kurogane no Houkou 2 - Warship Commander [Koei Selection]"
   region: "NTSC-J"
 SLPM-66973:
@@ -45183,8 +45183,8 @@ SLPM-66993:
   name-en: "Rim Runners [Best Version]"
   region: "NTSC-J"
 SLPM-66994:
-  name: マナケミア 〜学園の錬金術士たち〜【ガストベストプライス】
-  name-sort: まなけみあ 〜がくえんのれんきんじゅつしたち〜【がすとべすとぷらいす】
+  name: マナケミア 〜学園の錬金術士たち〜 [ガストベストプライス]
+  name-sort: まなけみあ 〜がくえんのれんきんじゅつしたち〜 [がすとべすとぷらいす]
   name-en: "Mana-Khemia - Gakuen no Renkinjutsu Shitachi [Best Version]"
   region: "NTSC-J"
   roundModes:
@@ -45216,8 +45216,8 @@ SLPM-66999:
   name-en: "Fushigi Yuugi - Suzaku Ibun"
   region: "NTSC-J"
 SLPM-67000:
-  name: ふしぎ遊戯 玄武開伝 外伝 鏡の巫女【IFコレクション】
-  name-sort: ふしぎゆうぎ げんぶひらきでん がいでん きょうのみこ【IFこれくしょん】
+  name: ふしぎ遊戯 玄武開伝 外伝 鏡の巫女 [IFコレクション]
+  name-sort: ふしぎゆうぎ げんぶひらきでん がいでん きょうのみこ [IFこれくしょん]
   name-en: "Fushigi Yuugi - ShigiYuugi Kurotake Kaiden Gaiden - Kagami no Fujo [IF Collection]"
   region: "NTSC-J"
 SLPM-67001:
@@ -46851,8 +46851,8 @@ SLPS-20123:
   name: "Initial D - Takahashi Ryousuke no Typing Saisoku Riron"
   region: "NTSC-J"
 SLPS-20125:
-  name: 上海フォーエレメント【super value 2800】
-  name-sort: しゃんはいふぉーえれめんと【super value 2800】
+  name: 上海フォーエレメント [super value 2800]
+  name-sort: しゃんはいふぉーえれめんと [super value 2800]
   name-en: "Shanghai - The Four Elements [Super Value 2800]"
   region: "NTSC-J"
 SLPS-20127:
@@ -47194,8 +47194,8 @@ SLPS-20220:
   name: "Pachi-Slot Aruze Oukoku 7 [Disc 1][Ekishou Disc]"
   region: "NTSC-J"
 SLPS-20221:
-  name: 太鼓の達人 タタコンでドドンがドン(※タタコン同梱セット)
-  name-sort: たいこのたつじん たたこんでどどんがどん(※たたこんどうこんせっと)
+  name: 太鼓の達人 タタコンでドドンがドン [※タタコン同梱セット]
+  name-sort: たいこのたつじん たたこんでどどんがどん [※たたこんどうこんせっと]
   name-en: "Taiko no Tatsujin - Tatacon de Dodon ga Don [with Tatacon]"
   region: "NTSC-J"
   compat: 5
@@ -47412,8 +47412,8 @@ SLPS-20281:
   clampModes:
     vuClampMode: 0 # Fixes missing game board.
 SLPS-20282:
-  name: 太鼓の達人 タタコンでドドンがドン(ソフト単品)
-  name-sort: たいこのたつじん たたこんでどどんがどん(そふとたんぴん)
+  name: 太鼓の達人 タタコンでドドンがドン [ソフト単品]
+  name-sort: たいこのたつじん たたこんでどどんがどん [そふとたんぴん]
   name-en: "Taiko no Tatsujin - Tatacon de Dodon ga Don"
   region: "NTSC-J"
 SLPS-20283:
@@ -47664,13 +47664,13 @@ SLPS-20343:
   name-en: "Net de Bomberman"
   region: "NTSC-J"
 SLPS-20344:
-  name: ファントム・ブレイブ(限定版)
-  name-sort: ふぁんとむ・ぶれいぶ(げんていばん)
+  name: ファントム・ブレイブ [限定版]
+  name-sort: ふぁんとむ・ぶれいぶ [げんていばん]
   name-en: "Phantom Brave [Limited Edition]"
   region: "NTSC-J"
 SLPS-20345:
-  name: ファントム・ブレイブ(通常版)
-  name-sort: ふぁんとむ・ぶれいぶ(つうじょうばん)
+  name: ファントム・ブレイブ [通常版]
+  name-sort: ふぁんとむ・ぶれいぶ [つうじょうばん]
   name-en: "Phantom Brave"
   region: "NTSC-J"
 SLPS-20347:
@@ -47702,23 +47702,23 @@ SLPS-20353:
   name: "Suki na Mono wa Suki dakara Shou ga Nai!! First Limit & Target Nights - Sukishou! Episode #01+#02 (Disc 2) (Target Nights - Sukishou! Episode #02)"
   region: "NTSC-J"
 SLPS-20354:
-  name: 山佐Digiワールド3【ベストオブベスト】
-  name-sort: さんさDigiわーるど3【べすとおぶべすと】
+  name: 山佐Digiワールド3 [ベストオブベスト]
+  name-sort: さんさDigiわーるど3 [べすとおぶべすと]
   name-en: "Yamasa Digi World 3 [Best of Best]"
   region: "NTSC-J"
 SLPS-20355:
-  name: 山佐DigiワールドSPネオプラネットXX【ベストオブベスト】
-  name-sort: さんさDigiわーるどSPねおぷらねっとXX【べすとおぶべすと】
+  name: 山佐DigiワールドSPネオプラネットXX [ベストオブベスト]
+  name-sort: さんさDigiわーるどSPねおぷらねっとXX [べすとおぶべすと]
   name-en: "Yamasa Digi World SP - Neo Planett XX [Best of Best]"
   region: "NTSC-J"
 SLPS-20356:
-  name: 山佐Digiワールド4【ベストオブベスト】
-  name-sort: さんさDigiわーるど4【べすとおぶべすと】
+  name: 山佐Digiワールド4 [ベストオブベスト]
+  name-sort: さんさDigiわーるど4 [べすとおぶべすと]
   name-en: "Yamasa Digi World 4 [Best of Best]"
   region: "NTSC-J"
 SLPS-20357:
-  name: 山佐DigiワールドSP 海一番R【ベストオブベスト】
-  name-sort: さんさDigiわーるどSP うみいちばんR【べすとおぶべすと】
+  name: 山佐DigiワールドSP 海一番R [ベストオブベスト]
+  name-sort: さんさDigiわーるどSP うみいちばんR [べすとおぶべすと]
   name-en: "Yamasa Digi World SP - Umi Ichiban R [Best of Best]"
   region: "NTSC-J"
 SLPS-20361:
@@ -47753,8 +47753,8 @@ SLPS-20367:
   region: "NTSC-J"
   compat: 5
 SLPS-20368:
-  name: かいけつゾロリ めざせ!いたずらキング(単品版)
-  name-sort: かいけつぞろり めざせ!いたずらきんぐ(たんぴんばん)
+  name: かいけつゾロリ めざせ!いたずらキング [単品版]
+  name-sort: かいけつぞろり めざせ!いたずらきんぐ [たんぴんばん]
   name-en: "Kaiketsu Zorro Mezase! Itazura King"
   region: "NTSC-J"
 SLPS-20369:
@@ -47898,15 +47898,15 @@ SLPS-20398:
   name-en: "La Pucelle - Hikari no Seijo Densetsu - 2-shuume Hajimemashita"
   region: "NTSC-J"
 SLPS-20399:
-  name: 太鼓の達人 ゴー!ゴー!五代目(タタコン同梱セット)
-  name-sort: たいこのたつじん ごー!ごー!ごだいめ(たたこんどうこんせっと)
+  name: 太鼓の達人 ゴー!ゴー!五代目 [タタコン同梱セット]
+  name-sort: たいこのたつじん ごー!ごー!ごだいめ [たたこんどうこんせっと]
   name-en: "Taiko no Tatsujin - Go! Go! Godaime [with Tatacon]"
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
 SLPS-20400:
-  name: 太鼓の達人 ゴー!ゴー!五代目(ソフト単品)
-  name-sort: たいこのたつじん ごー!ごー!ごだいめ(そふとたんぴん)
+  name: 太鼓の達人 ゴー!ゴー!五代目 [ソフト単品]
+  name-sort: たいこのたつじん ごー!ごー!ごだいめ [そふとたんぴん]
   name-en: "Taiko no Tatsujin - Go! Go! Godaime"
   region: "NTSC-J"
   gsHWFixes:
@@ -47923,8 +47923,8 @@ SLPS-20402:
   region: "NTSC-J"
   compat: 5
 SLPS-20403:
-  name: 上海〜三国牌闘儀〜【super value 2800】
-  name-sort: しゃんはい〜さんこくぱい闘儀〜【super value 2800】
+  name: 上海〜三国牌闘儀〜 [super value 2800]
+  name-sort: しゃんはい〜さんこくぱい闘儀〜 [super value 2800]
   name-en: "Shanghai - Sangoku Pai Tatagi [Super Value 2800]"
   region: "NTSC-J"
 SLPS-20404:
@@ -47936,8 +47936,8 @@ SLPS-20405:
   name-en: "Slotter UP - Core 5"
   region: "NTSC-J"
 SLPS-20406:
-  name: C@M-STATION カム・ステーション 同梱版 (“EyeToy”カメラ＆USBヘッドセット同梱版)
-  name-sort: C@M-STATION かむ・すてーしょん どうこんばん (“EyeToy”かめら＆USBへっどせっとどうこんばん)
+  name: C@M-STATION カム・ステーション 同梱版 [“EyeToy”カメラ＆USBヘッドセット同梱版]
+  name-sort: C@M-STATION かむ・すてーしょん どうこんばん [“EyeToy”かめら＆USBへっどせっとどうこんばん]
   name-en: "Cam-Station [with EyeToy & USB Headset]"
   region: "NTSC-J"
 SLPS-20407:
@@ -47952,8 +47952,8 @@ SLPS-20408:
   region: "NTSC-J"
   compat: 5
 SLPS-20409:
-  name: ファントム・キングダム(初回限定版)
-  name-sort: ふぁんとむ・きんぐだむ(しょかいげんていばん)
+  name: ファントム・キングダム [初回限定版]
+  name-sort: ふぁんとむ・きんぐだむ [しょかいげんていばん]
   name-en: "Phantom Kingdom [Limited Edition]"
   region: "NTSC-J"
 SLPS-20410:
@@ -47972,8 +47972,8 @@ SLPS-20412:
   name-en: "Hissatsu Pachinko Station v10"
   region: "NTSC-J"
 SLPS-20413:
-  name: 太鼓の達人 TAIKO DRUM MASTERS(タタコン同梱)
-  name-sort: たいこのたつじん TAIKO DRUM MASTERS(たたこんどうこん)
+  name: 太鼓の達人 TAIKO DRUM MASTERS [タタコン同梱]
+  name-sort: たいこのたつじん TAIKO DRUM MASTERS [たたこんどうこん]
   name-en: "Taiko no Tatsujin - Taiko Drum Master [with Tatacon]"
   region: "NTSC-J"
   gsHWFixes:
@@ -47987,8 +47987,8 @@ SLPS-20414:
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
 SLPS-20416:
-  name: 陰陽大戦記 白虎演舞 “EyeToy”カメラ同梱版
-  name-sort: いんようだいせんき びゃっこえんぶ “EyeToy”かめらどうこんばん
+  name: 陰陽大戦記 白虎演舞 [“EyeToy”カメラ同梱版]
+  name-sort: いんようだいせんき びゃっこえんぶ [“EyeToy”かめらどうこんばん]
   name-en: "Inyou Taisenki - Byakko Enbu [with EyeToy]"
   region: "NTSC-J"
 SLPS-20417:
@@ -48027,15 +48027,15 @@ SLPS-20423:
   clampModes:
     vuClampMode: 3 # Fixes bad coordinate spam.
 SLPS-20424:
-  name: 太鼓の達人 とびっきり!アニメスペシャル (「タタコン」同梱版)
-  name-sort: たいこのたつじん とびっきり!あにめすぺしゃる (「たたこん」どうこんばん)
+  name: 太鼓の達人 とびっきり!アニメスペシャル [「タタコン」同梱版]
+  name-sort: たいこのたつじん とびっきり!あにめすぺしゃる [「たたこん」どうこんばん]
   name-en: "Taiko no Tatsujin - Tobikkiri! Anime Special [with Tatacon]"
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
 SLPS-20425:
-  name: 太鼓の達人 とびっきり!アニメスペシャル (ソフト単品)
-  name-sort: たいこのたつじん とびっきり!あにめすぺしゃる (そふとたんぴん)
+  name: 太鼓の達人 とびっきり!アニメスペシャル [ソフト単品]
+  name-sort: たいこのたつじん とびっきり!あにめすぺしゃる [そふとたんぴん]
   name-en: "Taiko no Tatsujin - Tobikkiri! Anime Special"
   region: "NTSC-J"
   gsHWFixes:
@@ -48126,8 +48126,8 @@ SLPS-20446:
   name-en: "Simple 2000 Series Vol. 89 - The Party Game 2"
   region: "NTSC-J"
 SLPS-20447:
-  name: 仮面ライダーヒビキ(初回生産版)
-  name-sort: かめんらいだーひびき(しょかいせいさんばん)
+  name: 仮面ライダーヒビキ [初回生産版]
+  name-sort: かめんらいだーひびき [しょかいせいさんばん]
   name-en: "Kamen Rider Hibiki"
   region: "NTSC-J"
   compat: 5
@@ -48331,8 +48331,8 @@ SLPS-20484:
   name-en: "Simple 2000 Series Ultimate Vol. 34 - Sakigake!! Otokojuku"
   region: "NTSC-J"
 SLPS-20485:
-  name: 太鼓の達人 ドカッ!と大盛り七代目(タタコン同梱)
-  name-sort: たいこのたつじん どかっ!とおおもりななだいめ(たたこんどうこん)
+  name: 太鼓の達人 ドカッ!と大盛り七代目 [タタコン同梱]
+  name-sort: たいこのたつじん どかっ!とおおもりななだいめ [たたこんどうこん]
   name-en: "Taiko no Tatsujin - Doka! to Oomori Nanadaime [with Tatacon]"
   region: "NTSC-J"
   gsHWFixes:
@@ -48837,16 +48837,16 @@ SLPS-25059:
   name-en: "G-Breaker - Legend of Cloudia"
   region: "NTSC-J"
 SLPS-25060:
-  name: 機動戦士ガンダム めぐりあい宇宙(限定版)
-  name-sort: きどうせんしがんだむ めぐりあいうちゅう(げんていばん)
+  name: 機動戦士ガンダム めぐりあい宇宙 [限定版]
+  name-sort: きどうせんしがんだむ めぐりあいうちゅう [げんていばん]
   name-en: "Mobile Suit Gundam - Meguriai Sora [Limited Edition]"
   region: "NTSC-J"
 SLPS-25061:
   name: "Kidou Senshi Gundam - Ver. 1.5"
   region: "NTSC-J"
 SLPS-25062:
-  name: 機動戦士ガンダム めぐりあい宇宙(DVD同梱版)
-  name-sort: きどうせんしがんだむ めぐりあいうちゅう(DVDどうこんばん)
+  name: 機動戦士ガンダム めぐりあい宇宙 [DVD同梱版]
+  name-sort: きどうせんしがんだむ めぐりあいうちゅう [DVDどうこんばん]
   name-en: "Kidou Senshi Gundam - Meguriai Sora"
   region: "NTSC-J"
 SLPS-25064:
@@ -48950,8 +48950,8 @@ SLPS-25079:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
 SLPS-25080:
-  name: 宇宙戦艦ヤマト イスカンダルへの追憶 (初回生産限定版)
-  name-sort: うちゅうせんかんやまと いすかんだるへのついおく (しょかいせいさんげんていばん)
+  name: 宇宙戦艦ヤマト イスカンダルへの追憶 [初回生産限定版]
+  name-sort: うちゅうせんかんやまと いすかんだるへのついおく [しょかいせいさんげんていばん]
   name-en: "Uchuu Senkan Yamato - Iscandar he no Tsuioku [Special Edition]"
   region: "NTSC-J"
 SLPS-25081:
@@ -49169,8 +49169,8 @@ SLPS-25121:
     - "SLPS-73232"
     - "SLPS-73233"
 SLPS-25122:
-  name: 機動戦士ガンダム戦記 LIMITED BOX(限定版)
-  name-sort: きどうせんしがんだむせんき LIMITED BOX(げんていばん)
+  name: 機動戦士ガンダム戦記 LIMITED BOX [限定版]
+  name-sort: きどうせんしがんだむせんき LIMITED BOX [げんていばん]
   name-en: "Mobile Suit Gundam - Lost War Chronicles [Limited Edition]"
   region: "NTSC-J"
 SLPS-25123:
@@ -49223,13 +49223,13 @@ SLPS-25136:
   name-en: "Kuon no Kizuna Sairin Mikotonori"
   region: "NTSC-J"
 SLPS-25138:
-  name: Ever17〜the out of infinity〜(限定版)
-  name-sort: Ever17〜the out of infinity〜(げんていばん)
+  name: Ever17〜the out of infinity〜 [限定版]
+  name-sort: Ever17〜the out of infinity〜 [げんていばん]
   name-en: "Ever 17 - The Out of Infinity"
   region: "NTSC-J"
 SLPS-25139:
-  name: Baldur's Gate Dark Alliance (限定版)
-  name-sort: Baldur's Gate Dark Alliance (げんていばん)
+  name: Baldur's Gate Dark Alliance [限定版]
+  name-sort: Baldur's Gate Dark Alliance [げんていばん]
   name-en: "Baldur's Gate - Dark Alliance [Limited Edition]"
   region: "NTSC-J"
   compat: 5
@@ -49283,8 +49283,8 @@ SLPS-25144:
   name-en: "Memorial Song"
   region: "NTSC-J"
 SLPS-25145:
-  name: フーリガン〜君のなかの勇気〜(限定版)
-  name-sort: ふーりがん〜きみのなかのゆうき〜(げんていばん)
+  name: フーリガン〜君のなかの勇気〜 [限定版]
+  name-sort: ふーりがん〜きみのなかのゆうき〜 [げんていばん]
   name-en: "Hooligan [Limited Edition]"
   region: "NTSC-J"
 SLPS-25146:
@@ -49370,8 +49370,8 @@ SLPS-25160:
   name-en: "Final Fantasy XI 2002 [Special Art Box]"
   region: "NTSC-J"
 SLPS-25161:
-  name: 宇宙戦艦ヤマト 暗黒星団帝国の逆襲(初回生産限定)
-  name-sort: うちゅうせんかんやまと あんこくせいだんていこくのぎゃくしゅう(しょかいせいさんげんてい)
+  name: 宇宙戦艦ヤマト 暗黒星団帝国の逆襲 [初回生産限定]
+  name-sort: うちゅうせんかんやまと あんこくせいだんていこくのぎゃくしゅう [しょかいせいさんげんてい]
   name-en: "Uchuu Senkan Yamato - Ankoku Seidan Teikoku no Gyakushuu [Special Edition]"
   region: "NTSC-J"
 SLPS-25162:
@@ -49469,8 +49469,8 @@ SLPS-25181:
   name-en: "Gunvari Collection & Time Crisis"
   region: "NTSC-J"
 SLPS-25182:
-  name: アイドル雀士R 雀ぐる★プロジェクト(限定版)
-  name-sort: あいどるじゃんしR じゃんぐる★ぷろじぇくと(げんていばん)
+  name: アイドル雀士R 雀ぐる★プロジェクト [限定版]
+  name-sort: あいどるじゃんしR じゃんぐる★ぷろじぇくと [げんていばん]
   name-en: "Idol Janshi R - Jan-Guru Project [Limited Edition]"
   region: "NTSC-J"
 SLPS-25183:
@@ -49609,8 +49609,8 @@ SLPS-25204:
     mipmap: 2 # Mipmap + trilinear, improves road and grass textures to match sw renderer.
     trilinearFiltering: 1
 SLPS-25205:
-  name: イース I・II エターナルストーリー(特別限定版)
-  name-sort: いーす I・II えたーなるすとーりー(とくべつげんていばん)
+  name: イース I・II エターナルストーリー [特別限定版]
+  name-sort: いーす I・II えたーなるすとーりー [とくべつげんていばん]
   name-en: "Ys I-II - Eternal Story [Limited Edition]"
   region: "NTSC-J"
 SLPS-25206:
@@ -49700,8 +49700,8 @@ SLPS-25226:
   name-en: "Memories Off - Duet"
   region: "NTSC-J"
 SLPS-25227:
-  name: 第2次スーパーロボット大戦α(限定版)
-  name-sort: だい2じすーぱーろぼっとたいせんあるふぁ(げんていばん)
+  name: 第2次スーパーロボット大戦α [限定版]
+  name-sort: だい2じすーぱーろぼっとたいせんあるふぁ [げんていばん]
   name-en: "Super Robot Wars - Alpha 2nd [Limited Edition]"
   region: "NTSC-J"
 SLPS-25228:
@@ -49863,8 +49863,8 @@ SLPS-25254:
   gameFixes:
     - EETimingHack # Fixes various VIF errors.
 SLPS-25255:
-  name: サイドワインダー V フライトBOX 【特別限定版】
-  name-sort: さいどわいんだー V ふらいとBOX 【とくべつげんていばん】
+  name: サイドワインダー V フライトBOX [特別限定版]
+  name-sort: さいどわいんだー V ふらいとBOX [とくべつげんていばん]
   name-en: "Sidewinder V [Premium Flight Box]"
   region: "NTSC-J"
 SLPS-25256:
@@ -49915,8 +49915,8 @@ SLPS-25264:
   name-en: "RahXephon [Limited Edition]"
   region: "NTSC-J"
 SLPS-25265:
-  name: ラーゼフォン 蒼穹幻想曲(通常版)
-  name-sort: らーぜふぉん そうきゅうげんそうきょく(つうじょうばん)
+  name: ラーゼフォン 蒼穹幻想曲 [通常版]
+  name-sort: らーぜふぉん そうきゅうげんそうきょく [つうじょうばん]
   name-en: "RahXephon"
   region: "NTSC-J"
 SLPS-25266:
@@ -50000,22 +50000,22 @@ SLPS-25288:
   name-en: "D-A - Black [Limited Edition]"
   region: "NTSC-J"
 SLPS-25289:
-  name: タイムクライシス3(ガンコン2同梱)
-  name-sort: たいむくらいしす3(がんこん2どうこん)
+  name: タイムクライシス3 [ガンコン2同梱]
+  name-sort: たいむくらいしす3 [がんこん2どうこん]
   name-en: "Time Crisis 3 [with G-Con 2]"
   region: "NTSC-J"
   gsHWFixes:
     texturePreloading: 0 # Performs much better with no preload.
 SLPS-25290:
-  name: タイムクライシス3(ソフト単品)
-  name-sort: たいむくらいしす3(そふとたんぴん)
+  name: タイムクライシス3 [ソフト単品]
+  name-sort: たいむくらいしす3 [そふとたんぴん]
   name-en: "Time Crisis 3"
   region: "NTSC-J"
   gsHWFixes:
     texturePreloading: 0 # Performs much better with no preload.
 SLPS-25291:
-  name: バルダーズゲート・ダークアライアンス【PCCWジャパン・ザ・ベスト】
-  name-sort: ばるだーずげーと・だーくあらいあんす【PCCWじゃぱん・ざ・べすと】
+  name: バルダーズゲート・ダークアライアンス [PCCWジャパン・ザ・ベスト]
+  name-sort: ばるだーずげーと・だーくあらいあんす [PCCWじゃぱん・ざ・べすと]
   name-en: "Baldur's Gate - Dark Alliance [PCCW The Best]"
   region: "NTSC-J"
   compat: 5
@@ -50195,8 +50195,8 @@ SLPS-25323:
   name-en: "Usagi - Yasei no Topai - Yamashiro Mahjong-Hen"
   region: "NTSC-J"
 SLPS-25324:
-  name: 西風の狂詩曲(ラプソディ)(初回限定版)
-  name-sort: にしかぜのらぷそでぃ(しょかいげんていばん)
+  name: 西風の狂詩曲(ラプソディ) [初回限定版]
+  name-sort: にしかぜのらぷそでぃ [しょかいげんていばん]
   name-en: "Rhapsody of Zephyr"
   region: "NTSC-J"
 SLPS-25326:
@@ -50227,8 +50227,8 @@ SLPS-25330:
   name-en: "Dragon Ball Z - Budokai 2"
   region: "NTSC-J"
 SLPS-25332:
-  name: SNOW(初回限定版)
-  name-sort: SNOW(しょかいげんていばん)
+  name: SNOW [初回限定版]
+  name-sort: SNOW [しょかいげんていばん]
   name-en: "Snow [First Limited Edition]"
   region: "NTSC-J"
   gsHWFixes:
@@ -50239,8 +50239,8 @@ SLPS-25333:
   name-en: "Gallop Racer Lucky 7"
   region: "NTSC-J"
 SLPS-25334:
-  name: シャドウハーツ II(通常版) [ディスク1/2]
-  name-sort: しゃどうはーつ II(つうじょうばん) [でぃすく1/2]
+  name: シャドウハーツ II [通常版] [ディスク1/2]
+  name-sort: しゃどうはーつ II [つうじょうばん] [でぃすく1/2]
   name-en: "Shadow Hearts 2 [Disc 1 of 2]"
   region: "NTSC-J"
   gsHWFixes:
@@ -50249,8 +50249,8 @@ SLPS-25334:
     roundSprite: 2 # Fixes the position of monster sprites and reduces garbage in the UI.
     autoFlush: 2 # Makes the shadow monsters appear.
 SLPS-25335:
-  name: シャドウハーツ II(通常版) [ディスク2/2]
-  name-sort: しゃどうはーつ II(つうじょうばん) [でぃすく2/2]
+  name: シャドウハーツ II [通常版] [ディスク2/2]
+  name-sort: しゃどうはーつ II [つうじょうばん] [でぃすく2/2]
   name-en: "Shadow Hearts 2 [Disc 2 of 2]"
   region: "NTSC-J"
   gsHWFixes:
@@ -50261,13 +50261,13 @@ SLPS-25335:
   memcardFilters:
     - "SLPS-25334"
 SLPS-25336:
-  name: バスランディング3 サミーベスト つりコン2+ 同梱版
-  name-sort: ばすらんでぃんぐ3 さみーべすと つりこん2+ どうこんばん
+  name: バスランディング3 [サミーベスト] [つりコン2+ 同梱版]
+  name-sort: ばすらんでぃんぐ3 [さみーべすと] [つりこん2+ どうこんばん]
   name-en: "Bass Landing 3 [with TsuriCon2+] [Sammy Best]"
   region: "NTSC-J"
 SLPS-25337:
-  name: バスランディング3 サミーベスト
-  name-sort: ばすらんでぃんぐ3 さみーべすと
+  name: バスランディング3 [サミーベスト]
+  name-sort: ばすらんでぃんぐ3 [さみーべすと]
   name-en: "Bass Landing 3 [Sammy Best]"
   region: "NTSC-J"
 SLPS-25338:
@@ -50452,8 +50452,8 @@ SLPS-25365:
   name-en: "Missing Blue [Best Price]"
   region: "NTSC-J"
 SLPS-25366:
-  name: ゼノサーガ エピソードII［善悪の彼岸］ プレミアムボックス [ディスク1/2]
-  name-sort: ぜのさーが えぴそーどII［ぜんあくのひがん］ ぷれみあむぼっくす [でぃすく1/2]
+  name: ゼノサーガ エピソードII [善悪の彼岸] プレミアムボックス [ディスク1/2]
+  name-sort: ぜのさーが えぴそーどII [ぜんあくのひがん] ぷれみあむぼっくす [でぃすく1/2]
   name-en: "Xenosaga Episode II - Jenseits von Gut und Bose [Premium Box] [Disc 1 of 2]"
   region: "NTSC-J"
   gsHWFixes:
@@ -50557,8 +50557,8 @@ SLPS-25377:
   name-en: "Nightmare of Druaga, The - Fushigi no Dungeon"
   region: "NTSC-J"
 SLPS-25378:
-  name: 東京魔人學園外法帖血風録(初回限定版)
-  name-sort: とうきょうまじんがくえんげほうちょうけっぷうろく(しょかいげんていばん)
+  name: 東京魔人學園外法帖血風録 [初回限定版]
+  name-sort: とうきょうまじんがくえんげほうちょうけっぷうろく [しょかいげんていばん]
   name-en: "Tokyo Majin Gakuen - Kaihoujyou Kefurokou [Limited Edition]"
   region: "NTSC-J"
 SLPS-25379:
@@ -50599,8 +50599,8 @@ SLPS-25386:
   name-en: "King of Fighters, The - Maximum Impact Maniax"
   region: "NTSC-J"
 SLPS-25387:
-  name: True Love StorySummer Days,and yet...【エンターブレインコレクション】
-  name-sort: True Love StorySummer Days,and yet...【えんたーぶれいんこれくしょん】
+  name: True Love StorySummer Days,and yet... [エンターブレインコレクション]
+  name-sort: True Love StorySummer Days,and yet... [えんたーぶれいんこれくしょん]
   name-en: "True Love Story - Summer Days, and Yet..."
   region: "NTSC-J"
 SLPS-25388:
@@ -50614,8 +50614,8 @@ SLPS-25389:
   name-en: "Gundam Seed - Never Ending Tomorrow"
   region: "NTSC-J"
 SLPS-25390:
-  name: クローバーハーツ ルッキングフォーハピネス(初回限定版)
-  name-sort: くろーばーはーつ るっきんぐふぉーはぴねす(しょかいげんていばん)
+  name: クローバーハーツ ルッキングフォーハピネス [初回限定版]
+  name-sort: くろーばーはーつ るっきんぐふぉーはぴねす [しょかいげんていばん]
   name-en: "Clover Heart's - Looking for Happiness [Limited Edition]"
   region: "NTSC-J"
   gsHWFixes:
@@ -50653,8 +50653,8 @@ SLPS-25396:
   name-en: "Fantastic Fortune 2 - Triple Star"
   region: "NTSC-J"
 SLPS-25397:
-  name: シンドバットアドベンチャーは榎本加奈子でどうですか (特典版)
-  name-sort: しんどばっとあどべんちゃーはえのもとかなこでどうですか (とくてんばん)
+  name: シンドバットアドベンチャーは榎本加奈子でどうですか [特典版]
+  name-sort: しんどばっとあどべんちゃーはえのもとかなこでどうですか [とくてんばん]
   name-en: "Golden Voyage - Sinbad Adventure"
   region: "NTSC-J"
 SLPS-25398:
@@ -50771,8 +50771,8 @@ SLPS-25415:
   name-en: "Chuuka na Janshi - Tenhoo Painyan [Collector's Edition]"
   region: "NTSC-J"
 SLPS-25416:
-  name: ちゅ〜かな雀士 てんほー牌娘(通常版)
-  name-sort: ちゅ〜かなじゃんし てんほーぱいにゃん(つうじょうばん)
+  name: ちゅ〜かな雀士 てんほー牌娘 [通常版]
+  name-sort: ちゅ〜かなじゃんし てんほーぱいにゃん [つうじょうばん]
   name-en: "Chuuka na Janshi - Tenhoo Painyan"
   region: "NTSC-J"
 SLPS-25417:
@@ -50813,8 +50813,8 @@ SLPS-25420:
   name: "Sinbad Adventure wa Enomoto Kanako de Dou desu ka"
   region: "NTSC-J"
 SLPS-25421:
-  name: 牧場物語 Oh!ワンダフルライフ(初回版)
-  name-sort: ぼくじょうものがたり Oh!わんだふるらいふ(しょかいばん)
+  name: 牧場物語 Oh!ワンダフルライフ [初回版]
+  name-sort: ぼくじょうものがたり Oh!わんだふるらいふ [しょかいばん]
   name-en: "Bokujou Monogatari - Oh! Wonderful Life [First Print Limited Edition]"
   region: "NTSC-J"
   patches:
@@ -50832,8 +50832,8 @@ SLPS-25422:
     alignSprite: 1 # Fixes FMV lines.
     getSkipCount: "GSC_DeathByDegreesTekkenNinaWilliams"
 SLPS-25423:
-  name: 怪盗アプリコット 完全版 (限定版)
-  name-sort: かいとうあぷりこっと かんぜんばん (げんていばん)
+  name: 怪盗アプリコット 完全版 [限定版]
+  name-sort: かいとうあぷりこっと かんぜんばん [げんていばん]
   name-en: "Kaitou Apricot - Complete Edition [Limited Edition]"
   region: "NTSC-J"
 SLPS-25424:
@@ -50860,15 +50860,15 @@ SLPS-25427:
   region: "NTSC-J"
   compat: 5
 SLPS-25428:
-  name: メタルスラッグ3【SNK Best Collection】
-  name-sort: めたるすらっぐ3【SNK Best Collection】
+  name: メタルスラッグ3 [SNK Best Collection]
+  name-sort: めたるすらっぐ3 [SNK Best Collection]
   name-en: "Metal Slug 3 [SNK Best Collection]"
   region: "NTSC-J"
   gsHWFixes:
     gpuPaletteConversion: 2 # Stops excessive VRAM usage with preloading on.
 SLPS-25429:
-  name: THE KING OF FIGHTERS 2000【SNK Best Collection】
-  name-sort: THE KING OF FIGHTERS 2000【SNK Best Collection】
+  name: THE KING OF FIGHTERS 2000 [SNK Best Collection]
+  name-sort: THE KING OF FIGHTERS 2000 [SNK Best Collection]
   name-en: "King of Fighters 2000, The [SNK Best Collection]"
   region: "NTSC-J"
 SLPS-25430:
@@ -50882,13 +50882,13 @@ SLPS-25431:
   name: "Bokujou Monogatari - Oh! Wonderful Life"
   region: "NTSC-J"
 SLPS-25432:
-  name: 魔女っ娘ア・ラ・モード 唱えて、恋の魔法!(初回限定版)
-  name-sort: まじょっこあ・ら・もーど となえて、こいのまほう!(しょかいげんていばん)
+  name: 魔女っ娘ア・ラ・モード 唱えて、恋の魔法! [初回限定版]
+  name-sort: まじょっこあ・ら・もーど となえて、こいのまほう! [しょかいげんていばん]
   name-en: "Majo-musume A La Mode [Magical Box]"
   region: "NTSC-J"
 SLPS-25433:
-  name: 帝国千戦記 (初回限定版)
-  name-sort: ていこくせんせんき (しょかいげんていばん)
+  name: 帝国千戦記 [初回限定版]
+  name-sort: ていこくせんせんき [しょかいげんていばん]
   name-en: "Teikoku Sensenki [Limited Edition]"
   region: "NTSC-J"
 SLPS-25434:
@@ -50952,8 +50952,8 @@ SLPS-25447:
   name-en: "Top wo Nerae! Gunbuster"
   region: "NTSC-J"
 SLPS-25448:
-  name: THE KING OF FIGHTERS 94 RE-BOUT(スペシャル限定版)
-  name-sort: THE KING OF FIGHTERS 94 RE-BOUT(すぺしゃるげんていばん)
+  name: THE KING OF FIGHTERS 94 RE-BOUT [スペシャル限定版]
+  name-sort: THE KING OF FIGHTERS 94 RE-BOUT [すぺしゃるげんていばん]
   name-en: "King of Fighters '94, The - Rebout [Special Pack]"
   region: "NTSC-J"
 SLPS-25449:
@@ -51012,8 +51012,8 @@ SLPS-25457:
     getSkipCount: "GSC_SteambotChronicles" # Causes green (incorrect) water but removes depth and blur issues.
     roundSprite: 1 # Fixes colored 3D anaglyph bleeding effects.
 SLPS-25458:
-  name: THE KING OF FIGHTERS 2001【SNK Best Collection】
-  name-sort: THE KING OF FIGHTERS 2001【SNK Best Collection】
+  name: THE KING OF FIGHTERS 2001 [SNK Best Collection]
+  name-sort: THE KING OF FIGHTERS 2001 [SNK Best Collection]
   name-en: "King of Fighters 2001, The [SNK Best Collection]"
   region: "NTSC-J"
 SLPS-25459:
@@ -51165,8 +51165,8 @@ SLPS-25483:
   name-en: "Sui-Toshi-Zun"
   region: "NTSC-J"
 SLPS-25484:
-  name: SNK VS. CAPCOM SVC CHAOS【SNK BEST Collection】
-  name-sort: SNK VS. CAPCOM SVC CHAOS【SNK BEST Collection】
+  name: SNK VS. CAPCOM SVC CHAOS [SNK BEST Collection]
+  name-sort: SNK VS. CAPCOM SVC CHAOS [SNK BEST Collection]
   name-en: "SNK vs. Capcom Chaos [SNK Best Collection]"
   region: "NTSC-J"
 SLPS-25485:
@@ -51226,8 +51226,8 @@ SLPS-25496:
   name-en: "Berwick Saga - Tear Ring Saga Series [Deluxe Pack]"
   region: "NTSC-J"
 SLPS-25497:
-  name: ティアリングサーガシリーズ ベルウィックサーガ(通常版)
-  name-sort: てぃありんぐさーがしりーず べるうぃっくさーが(つうじょうばん)
+  name: ティアリングサーガシリーズ ベルウィックサーガ [通常版]
+  name-sort: てぃありんぐさーがしりーず べるうぃっくさーが [つうじょうばん]
   name-en: "Berwick Saga - Tear Ring Saga Series"
   region: "NTSC-J"
 SLPS-25498:
@@ -51257,14 +51257,14 @@ SLPS-25502:
   region: "NTSC-J"
   compat: 5
 SLPS-25503:
-  name: 幕末浪漫 月華の剣士 1・2【NEOGEOオンラインコレクション】
-  name-sort: ばくまつろまん げっかのけんし 1・2【NEOGEOおんらいんこれくしょん】
+  name: 幕末浪漫 月華の剣士 1・2 [NEOGEOオンラインコレクション]
+  name-sort: ばくまつろまん げっかのけんし 1・2 [NEOGEOおんらいんこれくしょん]
   name-en: "NeoGeo Online Collection Vol.2 - Bakumatsu Roman - Gekka no Kenshi 1&2"
   region: "NTSC-J"
   compat: 5
 SLPS-25504:
-  name: 餓狼 MARK OF THE WOLVES(限定版)【NEOGEOオンラインコレクション】
-  name-sort: がろう MARK OF THE WOLVES(げんていばん)【NEOGEOおんらいんこれくしょん】
+  name: 餓狼 MARK OF THE WOLVES [限定版] [NEOGEOオンラインコレクション]
+  name-sort: がろう MARK OF THE WOLVES [げんていばん] [NEOGEOおんらいんこれくしょん]
   name-en: "Garou - Mark of the Wolves [Limited Edition]"
   region: "NTSC-J"
 SLPS-25505:
@@ -51289,8 +51289,8 @@ SLPS-25508:
   name-en: "Mai-Hime - The Another"
   region: "NTSC-J"
 SLPS-25509:
-  name: 餓狼 MARK OF THE WOLVES【NEOGEOオンラインコレクション】
-  name-sort: がろう MARK OF THE WOLVES【NEOGEOおんらいんこれくしょん】
+  name: 餓狼 MARK OF THE WOLVES [NEOGEOオンラインコレクション]
+  name-sort: がろう MARK OF THE WOLVES [NEOGEOおんらいんこれくしょん]
   name-en: "Garou - Mark of the Wolves"
   region: "NTSC-J"
 SLPS-25510:
@@ -51310,8 +51310,8 @@ SLPS-25511:
   name-en: "Rasetsu Alternative"
   region: "NTSC-J"
 SLPS-25513:
-  name: 蒼い海のトリスティア 〜ナノカ・フランカ発明工房記〜(初回限定版)
-  name-sort: あおいうみのとりすてぃあ 〜なのか・ふらんかはつめいこうぼうき〜(しょかいげんていばん)
+  name: 蒼い海のトリスティア 〜ナノカ・フランカ発明工房記〜 [初回限定版]
+  name-sort: あおいうみのとりすてぃあ 〜なのか・ふらんかはつめいこうぼうき〜 [しょかいげんていばん]
   name-en: "Aoi Umi no Tristia - Nanoca Flanka Hatsumei Koubouki [Shokai Genteiban]"
   region: "NTSC-J"
 SLPS-25514:
@@ -51409,8 +51409,8 @@ SLPS-25532:
   name-en: "Critical Velocity"
   region: "NTSC-J"
 SLPS-25533:
-  name: テイルズ オブ レジェンディア (Tales of Leg endia)
-  name-sort: ているず おぶ れじぇんでぃあ (Tales of Leg endia)
+  name: テイルズ オブ レジェンディア (Tales of Legendia)
+  name-sort: ているず おぶ れじぇんでぃあ (Tales of Legendia)
   name-en: "Tales of Legendia"
   region: "NTSC-J"
   compat: 5
@@ -51423,8 +51423,8 @@ SLPS-25534:
   region: "NTSC-J"
   compat: 5
 SLPS-25535:
-  name: THE KING OF FIGHTERS -オロチ編- NEOGEO STICK3同梱(限定版)【NEOGEOオンラインコレクション】
-  name-sort: THE KING OF FIGHTERS -おろちへん- NEOGEO STICK3どうこん(げんていばん)【NEOGEOおんらいんこれくしょん】
+  name: THE KING OF FIGHTERS -オロチ編- NEOGEO STICK3同梱 [限定版] [NEOGEOオンラインコレクション]
+  name-sort: THE KING OF FIGHTERS -おろちへん- NEOGEO STICK3どうこん [げんていばん] [NEOGEOおんらいんこれくしょん]
   name-en: "NeoGeo Online Collection Vol.3 - The King of Fighters - Orochi Collection [Special Pack]"
   region: "NTSC-J"
 SLPS-25537:
@@ -51499,8 +51499,8 @@ SLPS-25549:
   name-en: "Gundam Seed Destiny - Generation of C.E."
   region: "NTSC-J"
 SLPS-25550:
-  name: カウボーイビバップ 追憶の夜曲 (初回生産限定版)
-  name-sort: かうぼーいびばっぷ ついおくのせれなーで (しょかいせいさんげんていばん)
+  name: カウボーイビバップ 追憶の夜曲 [初回生産限定版]
+  name-sort: かうぼーいびばっぷ ついおくのせれなーで [しょかいせいさんげんていばん]
   name-en: "Cowboy Bebop - Tsuioku no Serenade [Limited Edition]"
   region: "NTSC-J"
   clampModes:
@@ -51611,18 +51611,18 @@ SLPS-25570:
   name-en: "Kino no Tabi 2 - The Beautiful World"
   region: "NTSC-J"
 SLPS-25571:
-  name: メタルスラッグ4【SNK Best Collection】
-  name-sort: めたるすらっぐ4【SNK Best Collection】
+  name: メタルスラッグ4 [SNK Best Collection]
+  name-sort: めたるすらっぐ4 [SNK Best Collection]
   name-en: "Metal Slug 4 [SNK Best Collection]"
   region: "NTSC-J"
 SLPS-25572:
-  name: サムライスピリッツ零【SNK Best Collection】
-  name-sort: さむらいすぴりっつぜろ【SNK Best Collection】
+  name: サムライスピリッツ零 [SNK Best Collection]
+  name-sort: さむらいすぴりっつぜろ [SNK Best Collection]
   name-en: "Samurai Spirits Zero [SNK Best Collection]"
   region: "NTSC-J"
 SLPS-25573:
-  name: ザ・キング・オブ・ファイターズ 2002【SNK Best Collection】
-  name-sort: ざ・きんぐ・おぶ・ふぁいたーず 2002【SNK Best Collection】
+  name: ザ・キング・オブ・ファイターズ 2002 [SNK Best Collection]
+  name-sort: ざ・きんぐ・おぶ・ふぁいたーず 2002 [SNK Best Collection]
   name-en: "King of Fighters 2002, The [SNK Best Collection]"
   region: "NTSC-J"
 SLPS-25574:
@@ -51804,8 +51804,8 @@ SLPS-25604:
   gsHWFixes:
     roundSprite: 1 # Fixes vertical lines in FMVs, character portraits and other sprites.
 SLPS-25605:
-  name: THE KING OF FIGHTERS -オロチ編-通常版【NEOGEOオンラインコレクション】
-  name-sort: THE KING OF FIGHTERS -おろちへん-つうじょうばん【NEOGEOおんらいんこれくしょん】
+  name: THE KING OF FIGHTERS -オロチ編-通常版 [NEOGEOオンラインコレクション]
+  name-sort: THE KING OF FIGHTERS -おろちへん-つうじょうばん [NEOGEOおんらいんこれくしょん]
   name-en: "NeoGeo Online Collection Vol.3 - The King of Fighters - Orochi Collection"
   region: "NTSC-J"
 SLPS-25606:
@@ -51828,23 +51828,23 @@ SLPS-25608:
   region: "NTSC-J"
   compat: 5
 SLPS-25609:
-  name: KOF MAXIMUM IMPACT 2(初回生産版)
-  name-sort: KOF MAXIMUM IMPACT 2(しょかいせいさんばん)
+  name: KOF MAXIMUM IMPACT 2 [初回生産版]
+  name-sort: KOF MAXIMUM IMPACT 2 [しょかいせいさんばん]
   name-en: "King of Fighters, The - Maximum Impact 2"
   region: "NTSC-J"
 SLPS-25610:
-  name: 龍虎の拳〜天・地・人〜【NEOGEOオンラインコレクション】
-  name-sort: りゅうこのけん〜てん・ち・じん〜【NEOGEOおんらいんこれくしょん】
+  name: 龍虎の拳〜天・地・人〜 [NEOGEOオンラインコレクション]
+  name-sort: りゅうこのけん〜てん・ち・じん〜 [NEOGEOおんらいんこれくしょん]
   name-en: "Ryuuko no Ken - Ten-Chi-Jin [Art of Fighting Collection]"
   region: "NTSC-J"
 SLPS-25611:
-  name: Strawberry Panic!ストロベリー・パニック!(初回限定版)
-  name-sort: Strawberry Panic!すとろべりー・ぱにっく!(しょかいげんていばん)
+  name: Strawberry Panic!ストロベリー・パニック! [初回限定版]
+  name-sort: Strawberry Panic!すとろべりー・ぱにっく! [しょかいげんていばん]
   name-en: "Strawberry Panic [Limited Edition]"
   region: "NTSC-J"
 SLPS-25612:
-  name: Strawberry Panic!ストロベリー・パニック!(通常版)
-  name-sort: Strawberry Panic!すとろべりー・ぱにっく!(つうじょうばん)
+  name: Strawberry Panic!ストロベリー・パニック! [通常版]
+  name-sort: Strawberry Panic!すとろべりー・ぱにっく! [つうじょうばん]
   name-en: "Strawberry Panic"
   region: "NTSC-J"
 SLPS-25613:
@@ -51982,13 +51982,13 @@ SLPS-25633:
   name-en: "Futakoi Alternative - Koi to Shoujo to Machinegun [Best Collection]"
   region: "NTSC-J"
 SLPS-25634:
-  name: メタルスラッグ5【SNK BEST COLLECTION】
-  name-sort: めたるすらっぐ5【SNK BEST COLLECTION】
+  name: メタルスラッグ5 [SNK BEST COLLECTION]
+  name-sort: めたるすらっぐ5 [SNK BEST COLLECTION]
   name-en: "Metal Slug 5 [SNK Best Collection]"
   region: "NTSC-J"
 SLPS-25635:
-  name: THE KING OF FIGHTERS 2003【SNK BEST COLLECTION】
-  name-sort: THE KING OF FIGHTERS 2003【SNK BEST COLLECTION】
+  name: THE KING OF FIGHTERS 2003 [SNK BEST COLLECTION]
+  name-sort: THE KING OF FIGHTERS 2003 [SNK BEST COLLECTION]
   name-en: "King of Fighters 2003, The [SNK Best Collection]"
   region: "NTSC-J"
 SLPS-25636:
@@ -51997,8 +51997,8 @@ SLPS-25636:
   name-en: "King of Fighters, The - Maximum Impact - Maniax"
   region: "NTSC-J"
 SLPS-25638:
-  name: KOF MAXIMUM IMPACT 2(通常版)
-  name-sort: KOF MAXIMUM IMPACT 2(つうじょうばん)
+  name: KOF MAXIMUM IMPACT 2 [通常版]
+  name-sort: KOF MAXIMUM IMPACT 2 [つうじょうばん]
   name-en: "King of Fighters, The - Maximum Impact 2"
   region: "NTSC-J"
 SLPS-25639:
@@ -52176,13 +52176,13 @@ SLPS-25657:
     autoFlush: 2 # Helps ghosting.
     halfPixelOffset: 2 # Helps ghosting when upscaling.
 SLPS-25658:
-  name: びんちょうタン しあわせ暦 (初回限定版)
-  name-sort: びんちょうたん しあわせごよみ (しょかいげんていばん)
+  name: びんちょうタン しあわせ暦 [初回限定版]
+  name-sort: びんちょうたん しあわせごよみ [しょかいげんていばん]
   name-en: "Binchou-Tan - Shiwase Goyomi [Shokai Genteiban]"
   region: "NTSC-J"
 SLPS-25659:
-  name: びんちょうタン しあわせ暦 (通常版)
-  name-sort: びんちょうたん しあわせごよみ (つうじょうばん)
+  name: びんちょうタン しあわせ暦 [通常版]
+  name-sort: びんちょうたん しあわせごよみ [つうじょうばん]
   name-en: "Binchou-Tan - Shiwase Koyomi"
   region: "NTSC-J"
 SLPS-25660:
@@ -52192,23 +52192,23 @@ SLPS-25660:
   region: "NTSC-J"
   compat: 5
 SLPS-25661:
-  name: ザ・キング・オブ・ファイターズ -ネスツ編-【NEOGEOオンラインコレクション】
-  name-sort: ざ・きんぐ・おぶ・ふぁいたーず -ねすつへん-【NEOGEOおんらいんこれくしょん】
+  name: ザ・キング・オブ・ファイターズ -ネスツ編- [NEOGEOオンラインコレクション]
+  name-sort: ざ・きんぐ・おぶ・ふぁいたーず -ねすつへん- [NEOGEOおんらいんこれくしょん]
   name-en: "King of Fighters, The - Nests"
   region: "NTSC-J"
 SLPS-25662:
-  name: 今日からマ王!はじマりの旅(プレミアムBOX)
-  name-sort: きょうからまおう!はじまりのたび(ぷれみあむBOX)
+  name: 今日からマ王!はじマりの旅 [プレミアムBOX]
+  name-sort: きょうからまおう!はじまりのたび [ぷれみあむBOX]
   name-en: "Kyo Kara Maoh! The 1st trip of Maoh! [Premium Box]"
   region: "NTSC-J"
 SLPS-25663:
-  name: 今日からマ王!はじマりの旅(通常版)
-  name-sort: きょうからまおう!はじまりのたび(つうじょうばん)
+  name: 今日からマ王!はじマりの旅 [通常版]
+  name-sort: きょうからまおう!はじまりのたび [つうじょうばん]
   name-en: "Kyo Kara Maoh! The 1st trip of Maoh!"
   region: "NTSC-J"
 SLPS-25664:
-  name: 餓狼伝説バトルアーカイブズ1【NEOGEOオンラインコレクション】
-  name-sort: がろうでんせつばとるあーかいぶず1【NEOGEOおんらいんこれくしょん】
+  name: 餓狼伝説バトルアーカイブズ1 [NEOGEOオンラインコレクション]
+  name-sort: がろうでんせつばとるあーかいぶず1 [NEOGEOおんらいんこれくしょん]
   name-en: "NeoGeo Online Collection - Garou Densetsu Battle Archives Vol.1"
   region: "NTSC-J"
   compat: 5
@@ -52231,8 +52231,8 @@ SLPS-25668:
   name-en: "Torikago no Mukougawa - The Angles with Strange Wings"
   region: "NTSC-J"
 SLPS-25669:
-  name: スクールランブル二学期 恐怖の(?)夏合宿! 洋館に幽霊現る!? お宝を巡って真っ向勝負!!!の巻 【初回限定版】
-  name-sort: すくーるらんぶるにがっき きょうふの(?)なつがっしゅく! ようかんにゆうれいあらわる!? おたからをめぐってまっこうしょうぶ!!!のまき 【しょかいげんていばん】
+  name: スクールランブル二学期 恐怖の(?)夏合宿! 洋館に幽霊現る!? お宝を巡って真っ向勝負!!!の巻 [初回限定版]
+  name-sort: すくーるらんぶるにがっき きょうふの(?)なつがっしゅく! ようかんにゆうれいあらわる!? おたからをめぐってまっこうしょうぶ!!!のまき [しょかいげんていばん]
   name-en: "School Rumble 2nd Term [Limited Edition]"
   region: "NTSC-J"
   compat: 5
@@ -52280,8 +52280,8 @@ SLPS-25677:
   region: "NTSC-J"
   compat: 5
 SLPS-25678:
-  name: うたわれるもの 散りゆく者への子守唄(初回限定版)
-  name-sort: うたわれるもの ちりゆくものへのこもりうた(しょかいげんていばん)
+  name: うたわれるもの 散りゆく者への子守唄 [初回限定版]
+  name-sort: うたわれるもの ちりゆくものへのこもりうた [しょかいげんていばん]
   name-en: "Utawareru Mono [Limited Edition]"
   region: "NTSC-J"
 SLPS-25679:
@@ -52290,8 +52290,8 @@ SLPS-25679:
   name-en: "Utawareru Mono"
   region: "NTSC-J"
 SLPS-25680:
-  name: 舞ー乙HiME 乙女舞闘史!! 【Limited Edition】
-  name-sort: まいおとめ おとめぶとうし!! 【Limited Edition】
+  name: 舞ー乙HiME 乙女舞闘史!! [Limited Edition]
+  name-sort: まいおとめ おとめぶとうし!! [Limited Edition]
   name-en: "Mai-Kinoto Hime [Limited Edition]"
   region: "NTSC-J"
 SLPS-25681:
@@ -52305,16 +52305,16 @@ SLPS-25682:
   name-en: "Sanyo Pachinko Paradise 13"
   region: "NTSC-J"
 SLPS-25683:
-  name: ポンコツ浪漫大活劇バンピートロット【アイレム コレクション】
-  name-sort: ぽんこつろまんだいかつげきばんぴーとろっと【あいれむ これくしょん】
+  name: ポンコツ浪漫大活劇バンピートロット [アイレム コレクション]
+  name-sort: ぽんこつろまんだいかつげきばんぴーとろっと [あいれむ これくしょん]
   name-en: "Ponkotsu Roman Daikatsugeki Bumpy Trot [Irem Collection]"
   region: "NTSC-J"
   gsHWFixes:
     getSkipCount: "GSC_SteambotChronicles" # Causes green (incorrect) water but removes depth and blur issues.
     roundSprite: 1 # Fixes colored 3D anaglyph bleeding effects.
 SLPS-25684:
-  name: マーメイドプリズム(限定版BOX)
-  name-sort: まーめいどぷりずむ(げんていばんBOX)
+  name: マーメイドプリズム [限定版BOX]
+  name-sort: まーめいどぷりずむ [げんていばんBOX]
   name-en: "Mermaid Prism [Limited Edition]"
   region: "NTSC-J"
 SLPS-25685:
@@ -52360,8 +52360,8 @@ SLPS-25691:
     halfPixelOffset: 1 # Fixes extreme ghosting.
     wildArmsHack: 1 # Aligns vertical blurring.
 SLPS-25693:
-  name: プリンセス・プリンセス 姫たちのアブナい放課後 (初回限定版)
-  name-sort: ぷりんせす・ぷりんせす ひめたちのあぶないほうかご (しょかいげんていばん)
+  name: プリンセス・プリンセス 姫たちのアブナい放課後 [初回限定版]
+  name-sort: ぷりんせす・ぷりんせす ひめたちのあぶないほうかご [しょかいげんていばん]
   name-en: "Shinseiki GPX - Road to the Infinity 3"
   region: "NTSC-J"
 SLPS-25694:
@@ -52388,8 +52388,8 @@ SLPS-25697:
   gameFixes:
     - EETimingHack # Fixes FMV hanging.
 SLPS-25698:
-  name: 餓狼伝説バトルアーカイブズ2【NEOGEOオンラインコレクション】
-  name-sort: がろうでんせつばとるあーかいぶず2【NEOGEOおんらいんこれくしょん】
+  name: 餓狼伝説バトルアーカイブズ2 [NEOGEOオンラインコレクション]
+  name-sort: がろうでんせつばとるあーかいぶず2 [NEOGEOおんらいんこれくしょん]
   name-en: "Fatal Fury - Battle Archives 2"
   region: "NTSC-J"
 SLPS-25699:
@@ -52462,13 +52462,13 @@ SLPS-25711:
   name-en: "Kashimashi! Girl Meets Girl [Best Collection]"
   region: "NTSC-J"
 SLPS-25712:
-  name: THE KING OF FIGHTERS NEOWAVE【SNK BEST COLLECTION】
-  name-sort: THE KING OF FIGHTERS NEOWAVE【SNK BEST COLLECTION】
+  name: THE KING OF FIGHTERS NEOWAVE [SNK BEST COLLECTION]
+  name-sort: THE KING OF FIGHTERS NEOWAVE [SNK BEST COLLECTION]
   name-en: "King of Fighters Neowave [SNK the Best]"
   region: "NTSC-J"
 SLPS-25713:
-  name: ティンクルスタースプライツーLa Petite Princesse-【SNK BEST COLLECTION】
-  name-sort: てぃんくるすたーすぷらいつーLa Petite Princesse-【SNK BEST COLLECTION】
+  name: ティンクルスタースプライツーLa Petite Princesse- [SNK BEST COLLECTION]
+  name-sort: てぃんくるすたーすぷらいつーLa Petite Princesse- [SNK BEST COLLECTION]
   name-en: "Twinkle Star Sprites - La Petite Princesse [SNK the Best]"
   region: "NTSC-J"
 SLPS-25714:
@@ -52527,8 +52527,8 @@ SLPS-25721:
   name-en: "HimeHibi - Princess Days"
   region: "NTSC-J"
 SLPS-25722:
-  name: Routes PE (初回限定版)
-  name-sort: Routes PE (しょかいげんていばん)
+  name: Routes PE [初回限定版]
+  name-sort: Routes PE [しょかいげんていばん]
   name-en: "Routes PE [Limited Edition]"
   region: "NTSC-J"
 SLPS-25723:
@@ -52557,13 +52557,13 @@ SLPS-25727:
   name-en: "Routes PE"
   region: "NTSC-J"
 SLPS-25728:
-  name: くじびき アンバランス 会長お願いすま〜っしゅファイト☆ 【初回限定版】
-  name-sort: くじびき あんばらんす かいちょうおねがいすま〜っしゅふぁいと☆ 【しょかいげんていばん】
+  name: くじびき アンバランス 会長お願いすま〜っしゅファイト☆ [初回限定版]
+  name-sort: くじびき あんばらんす かいちょうおねがいすま〜っしゅふぁいと☆ [しょかいげんていばん]
   name-en: "Kujibiki Ambulance [Limited Edition]"
   region: "NTSC-J"
 SLPS-25729:
-  name: くじびき アンバランス 会長お願いすま〜っしゅファイト☆ 【通常版】
-  name-sort: くじびき あんばらんす かいちょうおねがいすま〜っしゅふぁいと☆ 【つうじょうばん】
+  name: くじびき アンバランス 会長お願いすま〜っしゅファイト☆ [通常版]
+  name-sort: くじびき あんばらんす かいちょうおねがいすま〜っしゅふぁいと☆ [つうじょうばん]
   name-en: "Kujibiki Unbalance"
   region: "NTSC-J"
 SLPS-25730:
@@ -52598,18 +52598,18 @@ SLPS-25735:
   name-en: "Dragon Shadow Spell"
   region: "NTSC-J"
 SLPS-25736:
-  name: サムライスピリッツ天下一剣客伝【SNK BEST COLLECTION】
-  name-sort: さむらいすぴりっつてんかいちけんかくでん【SNK BEST COLLECTION】
+  name: サムライスピリッツ天下一剣客伝 [SNK BEST COLLECTION]
+  name-sort: さむらいすぴりっつてんかいちけんかくでん [SNK BEST COLLECTION]
   name-en: "Samurai Spirits - Tenkaichi Kenkakuten [SNK Best]"
   region: "NTSC-J"
 SLPS-25737:
-  name: ネオジオバトルコロシアム【SNK BEST COLLECTION】
-  name-sort: ねおじおばとるころしあむ【SNK BEST COLLECTION】
+  name: ネオジオバトルコロシアム [SNK BEST COLLECTION]
+  name-sort: ねおじおばとるころしあむ [SNK BEST COLLECTION]
   name-en: "Neo Geo Battle Coliseum [SNK Best]"
   region: "NTSC-J"
 SLPS-25738:
-  name: SOUL CRADLE(ソウルクレイドル) 世界を喰らう者 【初回限定版】
-  name-sort: そうるくれいどる せかいをくらうもの 【しょかいげんていばん】
+  name: SOUL CRADLE(ソウルクレイドル) 世界を喰らう者 [初回限定版]
+  name-sort: そうるくれいどる せかいをくらうもの [しょかいげんていばん]
   name-en: "Soul Cradle Sekai o Kurau Mono [Limited Edition]"
   region: "NTSC-J"
   compat: 5
@@ -52624,13 +52624,13 @@ SLPS-25740:
   name-en: "Lupin III - Lupin ni wa Shi o, Zenigata ni wa Koi o"
   region: "NTSC-J"
 SLPS-25742:
-  name: ああっ女神さまっ (初回限定版)
-  name-sort: ああっめがみさまっ (しょかいげんていばん)
+  name: ああっ女神さまっ [初回限定版]
+  name-sort: ああっめがみさまっ [しょかいげんていばん]
   name-en: "Aa Megami-sama [Holy Box]"
   region: "NTSC-J"
 SLPS-25743:
-  name: ああっ女神さまっ (通常版)
-  name-sort: ああっめがみさまっ (つうじょうばん)
+  name: ああっ女神さまっ [通常版]
+  name-sort: ああっめがみさまっ [つうじょうばん]
   name-en: "Aa Megami-sama"
   region: "NTSC-J"
 SLPS-25744:
@@ -52654,13 +52654,13 @@ SLPS-25747:
   name-en: "Garouden Break Blow - Fist or Twist"
   region: "NTSC-J"
 SLPS-25748:
-  name: 蒼い空のネオスフィア〜ナノカ・フランカ発明工房記2〜 (初回限定版)
-  name-sort: あおいそらのねおすふぃあ〜なのか・ふらんかはつめいこうぼうき2〜 (しょかいげんていばん)
+  name: 蒼い空のネオスフィア〜ナノカ・フランカ発明工房記2〜 [初回限定版]
+  name-sort: あおいそらのねおすふぃあ〜なのか・ふらんかはつめいこうぼうき2〜 [しょかいげんていばん]
   name-en: "Aoi Sora no Neosphere - Nanoca Flanka Hatsumei Koubouki 2 [Shokai Genteiban]"
   region: "NTSC-J"
 SLPS-25749:
-  name: 蒼い空のネオスフィア〜ナノカ・フランカ発明工房記2〜 (通常版)
-  name-sort: あおいそらのねおすふぃあ〜なのか・ふらんかはつめいこうぼうき2〜 (つうじょうばん)
+  name: 蒼い空のネオスフィア〜ナノカ・フランカ発明工房記2〜 [通常版]
+  name-sort: あおいそらのねおすふぃあ〜なのか・ふらんかはつめいこうぼうき2〜 [つうじょうばん]
   name-en: "Aoi Sora no Neosphere - Nanoca Flanka Hatsumei Koubouki 2"
   region: "NTSC-J"
 SLPS-25750:
@@ -52669,8 +52669,8 @@ SLPS-25750:
   name-en: "Super Robot Taisen - Scramble Commander The 2nd"
   region: "NTSC-J"
 SLPS-25751:
-  name: がくえんゆーとぴあ まなびストレート! キラキラ☆ Happy Festa! (初回限定版)
-  name-sort: がくえんゆーとぴあ まなびすとれーと! きらきら☆ Happy Festa! (しょかいげんていばん)
+  name: がくえんゆーとぴあ まなびストレート! キラキラ☆ Happy Festa! [初回限定版]
+  name-sort: がくえんゆーとぴあ まなびすとれーと! きらきら☆ Happy Festa! [しょかいげんていばん]
   name-en: "Gakuen Utopia - Manabi Straight! KiraKira Happy Festa! [Limited Edition]"
   region: "NTSC-J"
 SLPS-25752:
@@ -52712,13 +52712,13 @@ SLPS-25756:
     - "SLPS-25656"
     - "SLPS-25756"
 SLPS-25757:
-  name: ななついろ★ドロップスPure!! (初回限定版)
-  name-sort: ななついろ★どろっぷすPure!! (しょかいげんていばん)
+  name: ななついろ★ドロップスPure!! [初回限定版]
+  name-sort: ななついろ★どろっぷすPure!! [しょかいげんていばん]
   name-en: "Nanatsu Iro - Drops Pure!! [First Print Limited Edition]"
   region: "NTSC-J"
 SLPS-25758:
-  name: ななついろ★ドロップス Pure!!(通常版)
-  name-sort: ななついろ★どろっぷす Pure!!(つうじょうばん)
+  name: ななついろ★ドロップス Pure!! [通常版]
+  name-sort: ななついろ★どろっぷす Pure!! [つうじょうばん]
   name-en: "Nanatsu Iro - Drops Pure!!"
   region: "NTSC-J"
 SLPS-25759:
@@ -52759,13 +52759,13 @@ SLPS-25765:
   name-en: "King of Fighters, The - Maximum Impact Regulation A"
   region: "NTSC-J"
 SLPS-25766:
-  name: オレンジハニー 僕はキミに恋してる(初回限定版)
-  name-sort: おれんじはにー ぼくはきみにこいしてる(しょかいげんていばん)
+  name: オレンジハニー 僕はキミに恋してる [初回限定版]
+  name-sort: おれんじはにー ぼくはきみにこいしてる [しょかいげんていばん]
   name-en: "Orange Honey - Boku wa Kimi ni Koishiteru [Limited Edition]"
   region: "NTSC-J"
 SLPS-25767:
-  name: オレンジハニー 僕はキミに恋してる(通常版)
-  name-sort: おれんじはにー ぼくはきみにこいしてる(つうじょうばん)
+  name: オレンジハニー 僕はキミに恋してる [通常版]
+  name-sort: おれんじはにー ぼくはきみにこいしてる [つうじょうばん]
   name-en: "Orange Honey - Boku wa Kimi ni Koishiteru"
   region: "NTSC-J"
 SLPS-25768:
@@ -52792,8 +52792,8 @@ SLPS-25770:
   name-en: "Rakushou! Pachi-Slot Sengen 5"
   region: "NTSC-J"
 SLPS-25771:
-  name: グリムグリモア (初回生産版)
-  name-sort: ぐりむぐりもあ (しょかいせいさんばん)
+  name: グリムグリモア [初回生産版]
+  name-sort: ぐりむぐりもあ [しょかいせいさんばん]
   name-en: "Grim Grimoire"
   region: "NTSC-J"
   compat: 5
@@ -52801,13 +52801,13 @@ SLPS-25772:
   name: "GrimGrimoire"
   region: "NTSC-J-K"
 SLPS-25773:
-  name: テイルズ オブ ファンダムVol.2(ティアバージョン)
-  name-sort: ているず おぶ ふぁんだむVol.2(てぃあばーじょん)
+  name: テイルズ オブ ファンダムVol.2 [ティアバージョン]
+  name-sort: ているず おぶ ふぁんだむVol.2 [てぃあばーじょん]
   name-en: "Tales of Fandom Vol.2 [Tia Version]"
   region: "NTSC-J"
 SLPS-25774:
-  name: テイルズ オブ ファンダムVol.2(ルークバージョン)
-  name-sort: ているず おぶ ふぁんだむVol.2(るーくばーじょん)
+  name: テイルズ オブ ファンダムVol.2 [ルークバージョン]
+  name-sort: ているず おぶ ふぁんだむVol.2 [るーくばーじょん]
   name-en: "Tales of Fandom Vol.2 [Luke Version]"
   region: "NTSC-J"
 SLPS-25775:
@@ -52821,18 +52821,18 @@ SLPS-25776:
   name-en: "Pachitte Chonmage Tatsujin 12"
   region: "NTSC-J"
 SLPS-25777:
-  name: すもももももも 〜地上最強のヨメ〜 継承しましょ!? 恋の花ムコ争奪戦!!(初回限定版)
-  name-sort: すもももももも 〜ちじょうさいきょうのよめ〜 けいしょうしましょ!? こいのはなむこそうだつせん!!(しょかいげんていばん)
+  name: すもももももも 〜地上最強のヨメ〜 継承しましょ!? 恋の花ムコ争奪戦!! [初回限定版]
+  name-sort: すもももももも 〜ちじょうさいきょうのよめ〜 けいしょうしましょ!? こいのはなむこそうだつせん!! [しょかいげんていばん]
   name-en: "Sumomomomomo - Chijou Saikyou no Yome [Limited Edition]"
   region: "NTSC-J"
 SLPS-25778:
-  name: すもももももも 〜地上最強のヨメ〜 継承しましょ!? 恋の花ムコ争奪戦!!(通常版)
-  name-sort: すもももももも 〜ちじょうさいきょうのよめ〜 けいしょうしましょ!? こいのはなむこそうだつせん!!(つうじょうばん)
+  name: すもももももも 〜地上最強のヨメ〜 継承しましょ!? 恋の花ムコ争奪戦!! [通常版]
+  name-sort: すもももももも 〜ちじょうさいきょうのよめ〜 けいしょうしましょ!? こいのはなむこそうだつせん!! [つうじょうばん]
   name-en: "Sumomomo Momomo - Chijou Saikyou no Yome - Keishou Shimasho! Koi no Hanamuko Soudatsu-sen!!"
   region: "NTSC-J"
 SLPS-25779:
-  name: KOF MAXIMUMIMPACT 2【SNK BEST COLLECTION】
-  name-sort: KOF MAXIMUMIMPACT 2【SNK BEST COLLECTION】
+  name: KOF MAXIMUMIMPACT 2 [SNK BEST COLLECTION]
+  name-sort: KOF MAXIMUMIMPACT 2 [SNK BEST COLLECTION]
   name-en: "King of Fighters, The - Maximum Impact 2 [SNK Best Collection]"
   region: "NTSC-J"
 SLPS-25780:
@@ -52841,19 +52841,19 @@ SLPS-25780:
   name-en: "Nodame Cantabile"
   region: "NTSC-J"
 SLPS-25781:
-  name: 風雲 SUPER COMBO【NEOGEOオンラインコレクション】
-  name-sort: ふううん SUPER COMBO【NEOGEOおんらいんこれくしょん】
+  name: 風雲 SUPER COMBO [NEOGEOオンラインコレクション]
+  name-sort: ふううん SUPER COMBO [NEOGEOおんらいんこれくしょん]
   name-en: "Fuuun Super Combo"
   region: "NTSC-J"
   compat: 5
 SLPS-25782:
-  name: ワールドヒーローズ ゴージャス【NEOGEOオンラインコレクション】
-  name-sort: わーるどひーろーず ごーじゃす【NEOGEOおんらいんこれくしょん】
+  name: ワールドヒーローズ ゴージャス [NEOGEOオンラインコレクション]
+  name-sort: わーるどひーろーず ごーじゃす [NEOGEOおんらいんこれくしょん]
   name-en: "World Heroes - Gorgeous"
   region: "NTSC-J"
 SLPS-25783:
-  name: ザ・キング・オブ・ファイターズ98アルティメットマッチ【NEOGEOオンラインコレクション】
-  name-sort: ざ・きんぐ・おぶ・ふぁいたーず98あるてぃめっとまっち【NEOGEOおんらいんこれくしょん】
+  name: ザ・キング・オブ・ファイターズ98アルティメットマッチ [NEOGEOオンラインコレクション]
+  name-sort: ざ・きんぐ・おぶ・ふぁいたーず98あるてぃめっとまっち [NEOGEOおんらいんこれくしょん]
   name-en: "King of Fighters '98, The - Ultimate Match"
   region: "NTSC-J"
 SLPS-25784:
@@ -52877,13 +52877,13 @@ SLPS-25787:
   region: "NTSC-J"
   compat: 5
 SLPS-25788:
-  name: メタルスラッグ【SNK BEST COLLECTION】
-  name-sort: めたるすらっぐ【SNK BEST COLLECTION】
+  name: メタルスラッグ [SNK BEST COLLECTION]
+  name-sort: めたるすらっぐ [SNK BEST COLLECTION]
   name-en: "Metal Slug [SNK Best Collection]"
   region: "NTSC-J"
 SLPS-25789:
-  name: THE KING OF FIGHTERS XI【SNK BEST COLLECTION】
-  name-sort: THE KING OF FIGHTERS XI【SNK BEST COLLECTION】
+  name: THE KING OF FIGHTERS XI [SNK BEST COLLECTION]
+  name-sort: THE KING OF FIGHTERS XI [SNK BEST COLLECTION]
   name-en: "King of Fighters XI, The [SNK Best Collection]"
   region: "NTSC-J"
 SLPS-25790:
@@ -52922,15 +52922,15 @@ SLPS-25796:
   name-en: "Ore no Shite Agake"
   region: "NTSC-J"
 SLPS-25797:
-  name: 一騎当千 Shining Dragon(限定爆裂パック)
-  name-sort: いっきとうせん Shining Dragon(げんていばくれつぱっく)
+  name: 一騎当千 Shining Dragon [限定爆裂パック]
+  name-sort: いっきとうせん Shining Dragon [げんていばくれつぱっく]
   name-en: "Ikki Tousen - Shining Dragon [Limited Edition]"
   region: "NTSC-J"
   gsHWFixes:
     roundSprite: 1 # Aligns bloom effect.
 SLPS-25798:
-  name: 一騎当千 Shining Dragon(通常版)
-  name-sort: いっきとうせん Shining Dragon(つうじょうばん)
+  name: 一騎当千 Shining Dragon [通常版]
+  name-sort: いっきとうせん Shining Dragon [つうじょうばん]
   name-en: "Ikki Tousen - Shining Dragon"
   region: "NTSC-J"
   compat: 5
@@ -52964,8 +52964,8 @@ SLPS-25803:
   name-en: "xxxHolic - Shigatsu Tsuitachi no Izayoi Sowa"
   region: "NTSC-J"
 SLPS-25804:
-  name: DEAR My SUN!! 〜ムスコ★育成★狂騒曲〜(限定版)
-  name-sort: DEAR My SUN!! 〜むすこ★いくせい★きょうそうきょく〜(げんていばん)
+  name: DEAR My SUN!! 〜ムスコ★育成★狂騒曲〜 [限定版]
+  name-sort: DEAR My SUN!! 〜むすこ★いくせい★きょうそうきょく〜 [げんていばん]
   name-en: "Dear My Sun [Limited Edition]"
   region: "NTSC-J"
 SLPS-25806:
@@ -52975,13 +52975,13 @@ SLPS-25806:
   region: "NTSC-J"
   compat: 5
 SLPS-25807:
-  name: セイント・ビースト 〜螺旋の章〜(限定版)
-  name-sort: せいんと・びーすと 〜らせんのしょう〜(げんていばん)
+  name: セイント・ビースト 〜螺旋の章〜 [限定版]
+  name-sort: せいんと・びーすと 〜らせんのしょう〜 [げんていばん]
   name-en: "Saint Beast - Rasen no Shou [Limited Edition]"
   region: "NTSC-J"
 SLPS-25808:
-  name: セイント・ビースト 〜螺旋の章〜(通常版)
-  name-sort: せいんと・びーすと 〜らせんのしょう〜(つうじょうばん)
+  name: セイント・ビースト 〜螺旋の章〜 [通常版]
+  name-sort: せいんと・びーすと 〜らせんのしょう〜 [つうじょうばん]
   name-en: "Saint Beast - Rasen no Shou"
   region: "NTSC-J"
 SLPS-25809:
@@ -52990,8 +52990,8 @@ SLPS-25809:
   name-en: "Gintama - Gin-san to Issho! Boku no Kabuki-chou Nikki"
   region: "NTSC-J"
 SLPS-25810:
-  name: DEAR My SUN!! 〜ムスコ★育成★狂騒曲〜(通常版)
-  name-sort: DEAR My SUN!! 〜むすこ★いくせい★きょうそうきょく〜(つうじょうばん)
+  name: DEAR My SUN!! 〜ムスコ★育成★狂騒曲〜 [通常版]
+  name-sort: DEAR My SUN!! 〜むすこ★いくせい★きょうそうきょく〜 [つうじょうばん]
   name-en: "Dear My Sun"
   region: "NTSC-J"
 SLPS-25811:
@@ -53101,13 +53101,13 @@ SLPS-25829:
   name-en: "Another Century's Episode 2 [Special Vocal Version]"
   region: "NTSC-J"
 SLPS-25830:
-  name: ゼロの使い魔 夢魔が紡ぐ夜風の幻想曲(限定版)
-  name-sort: ぜろのつかいま むまがつむぐよかぜのげんそうきょく(げんていばん)
+  name: ゼロの使い魔 夢魔が紡ぐ夜風の幻想曲 [限定版]
+  name-sort: ぜろのつかいま むまがつむぐよかぜのげんそうきょく [げんていばん]
   name-en: "Zero no Tsukaima - Muma ga Tsumugu Yokaze no Gensoukyoku [Limited Edition]"
   region: "NTSC-J"
 SLPS-25831:
-  name: ゼロの使い魔 夢魔が紡ぐ夜風の幻想曲(通常版)
-  name-sort: ぜろのつかいま むまがつむぐよかぜのげんそうきょく(つうじょうばん)
+  name: ゼロの使い魔 夢魔が紡ぐ夜風の幻想曲 [通常版]
+  name-sort: ぜろのつかいま むまがつむぐよかぜのげんそうきょく [つうじょうばん]
   name-en: "Zero no Tsukaima - Muma ga Tsumugu Yokaze no Gensoukyoku"
   region: "NTSC-J"
 SLPS-25832:
@@ -53129,8 +53129,8 @@ SLPS-25834:
     mipmap: 2 # Cleans up texture detail.
     trilinearFiltering: 1 # Smoothes out texture transitions.
 SLPS-25835:
-  name: スーパーロボット大戦OG外伝(限定版)
-  name-sort: すーぱーろぼっとたいせんOGがいでん(げんていばん)
+  name: スーパーロボット大戦OG外伝 [限定版]
+  name-sort: すーぱーろぼっとたいせんOGがいでん [げんていばん]
   name-en: "Super Robot Taisen OG - Original Generations Gaiden [Limited Edition]"
   region: "NTSC-J"
 SLPS-25836:
@@ -53157,8 +53157,8 @@ SLPS-25838:
   name-en: "Taiheiyou no Arashi - Senkan Yamato, Akatsuki ni Shutsugeki su"
   region: "NTSC-J"
 SLPS-25839:
-  name: サムライスピリッツ 六番勝負【NEOGEOオンラインコレクション】
-  name-sort: さむらいすぴりっつ ろくばんしょうぶ【NEOGEOおんらいんこれくしょん】
+  name: サムライスピリッツ 六番勝負 [NEOGEOオンラインコレクション]
+  name-sort: さむらいすぴりっつ ろくばんしょうぶ [NEOGEOおんらいんこれくしょん]
   name-en: "Samurai Spirits - Rokuban Shoubu [NeoGeo Online Collection Vol. 12]"
   region: "NTSC-J"
 SLPS-25840:
@@ -53219,8 +53219,8 @@ SLPS-25848:
   name-en: "Naraku no Shiro"
   region: "NTSC-J"
 SLPS-25849:
-  name: サンソフトコレクション【NEOGEOオンラインコレクション】
-  name-sort: さんそふとこれくしょん【NEOGEOおんらいんこれくしょん】
+  name: サンソフトコレクション [NEOGEOオンラインコレクション]
+  name-sort: さんそふとこれくしょん [NEOGEOおんらいんこれくしょん]
   name-en: "Sunsoft Collection"
   region: "NTSC-J"
   compat: 5
@@ -53232,15 +53232,15 @@ SLPS-25850:
   gsHWFixes:
     roundSprite: 1 # Fixes textboxes and character portraits.
 SLPS-25851:
-  name: 絶体絶命都市2-凍てついた記憶たち-【アイレムコレクション】
-  name-sort: ぜったいぜつめいとし2-いてついたきおくたち-【あいれむこれくしょん】
+  name: 絶体絶命都市2-凍てついた記憶たち- [アイレムコレクション]
+  name-sort: ぜったいぜつめいとし2-いてついたきおくたち- [あいれむこれくしょん]
   name-en: "Zettai Zetsumei Toshi 2 - Itetsuita Kioku Tachi [Irem Collection]"
   region: "NTSC-J"
   gsHWFixes:
     getSkipCount: "GSC_ZettaiZetsumeiToshi2"
 SLPS-25852:
-  name: パチパラ13 〜スーパー海とパチプロ風雲録〜【アイレムコレクション】
-  name-sort: ぱちぱら13 〜すーぱーうみとぱちぷろふううんろく〜【あいれむこれくしょん】
+  name: パチパラ13 〜スーパー海とパチプロ風雲録〜 [アイレムコレクション]
+  name-sort: ぱちぱら13 〜すーぱーうみとぱちぷろふううんろく〜 [あいれむこれくしょん]
   name-en: "Sanyo Pachinko Paradise 13 [Irem Collection]"
   region: "NTSC-J"
 SLPS-25853:
@@ -53286,33 +53286,33 @@ SLPS-25860:
   name-en: "Code Geass - Hangyaku no Lelouch - Lost Colors"
   region: "NTSC-J"
 SLPS-25861:
-  name: CR新世紀エヴァンゲリオン〜奇跡の価値は〜(スペシャルプライス版)
-  name-sort: CRしんせいきえゔぁんげりおん〜きせきのかちは〜(すぺしゃるぷらいすばん)
+  name: CR新世紀エヴァンゲリオン〜奇跡の価値は〜 [スペシャルプライス版]
+  name-sort: CRしんせいきえゔぁんげりおん〜きせきのかちは〜 [すぺしゃるぷらいすばん]
   name-en: "Hisshou Pachinko - Pachi-Slot Kouryoku Series Vol.10 [Special Price Edition]"
   region: "NTSC-J"
 SLPS-25862:
-  name: CR新世紀エヴァンゲリオン〜セカンドインパクト〜(スペシャルプライス版)
-  name-sort: CRしんせいきえゔぁんげりおん〜せかんどいんぱくと〜(すぺしゃるぷらいすばん)
+  name: CR新世紀エヴァンゲリオン〜セカンドインパクト〜 [スペシャルプライス版]
+  name-sort: CRしんせいきえゔぁんげりおん〜せかんどいんぱくと〜 [すぺしゃるぷらいすばん]
   name-en: "Hisshou Pachinko - Pachi-Slot Kouryoku Series Vol.05 - CR Neon Genesis Evangelion Sekandoinpakuto & Pachislot Neon Genesis Evangelion [Special Price Edition]"
   region: "NTSC-J"
 SLPS-25863:
-  name: THE BEST 餓狼伝説 バトルアーカイブズ1【NEOGEOオンラインコレクション】
-  name-sort: THE BEST がろうでんせつ ばとるあーかいぶず1【NEOGEOおんらいんこれくしょん】
+  name: THE BEST 餓狼伝説 バトルアーカイブズ1 [NEOGEOオンラインコレクション]
+  name-sort: THE BEST がろうでんせつ ばとるあーかいぶず1 [NEOGEOおんらいんこれくしょん]
   name-en: "Fatal Fury - Battle Archives 1 [SNK the Best]"
   region: "NTSC-J"
 SLPS-25864:
-  name: THE BEST 餓狼伝説バトルアーカイブズ2【NEOGEOオンラインコレクション】
-  name-sort: THE BEST がろうでんせつばとるあーかいぶず2【NEOGEOおんらいんこれくしょん】
+  name: THE BEST 餓狼伝説バトルアーカイブズ2 [NEOGEOオンラインコレクション]
+  name-sort: THE BEST がろうでんせつばとるあーかいぶず2 [NEOGEOおんらいんこれくしょん]
   name-en: "Fatal Fury - Battle Archives 2 [SNK the Best]"
   region: "NTSC-J"
 SLPS-25865:
-  name: THE BEST ザ・キング・オブ・ファイターズ〜ネスツ編〜【NEOGEOオンラインコレクション】
-  name-sort: THE BEST ざ・きんぐ・おぶ・ふぁいたーず〜ねすつへん〜【NEOGEOおんらいんこれくしょん】
+  name: THE BEST ザ・キング・オブ・ファイターズ〜ネスツ編〜 [NEOGEOオンラインコレクション]
+  name-sort: THE BEST ざ・きんぐ・おぶ・ふぁいたーず〜ねすつへん〜 [NEOGEOおんらいんこれくしょん]
   name-en: "King of Fighters, The - Nests [SNK the Best]"
   region: "NTSC-J"
 SLPS-25866:
-  name: THE BEST 風雲スーパーコンボ【NEOGEOオンラインコレクション】
-  name-sort: THE BEST ふううんすーぱーこんぼ【NEOGEOおんらいんこれくしょん】
+  name: THE BEST 風雲スーパーコンボ [NEOGEOオンラインコレクション]
+  name-sort: THE BEST ふううんすーぱーこんぼ [NEOGEOおんらいんこれくしょん]
   name-en: "Fuuun Super Combo [SNK the Best]"
   region: "NTSC-J"
 SLPS-25867:
@@ -53561,8 +53561,8 @@ SLPS-25929:
   name: "Little Anchor"
   region: "NTSC-J"
 SLPS-25930:
-  name: MLB 2K9(英語版)
-  name-sort: MLB 2K9(えいごばん)
+  name: MLB 2K9 [英語版]
+  name-sort: MLB 2K9 [えいごばん]
   name-en: "Major League Baseball 2K9"
   region: "NTSC-J"
 SLPS-25931:
@@ -53576,13 +53576,13 @@ SLPS-25932:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
 SLPS-25934:
-  name: THE BEST サムライスピリッツ六番勝負【NEOGEOオンラインコレクション】
-  name-sort: THE BEST さむらいすぴりっつろくばんしょうぶ【NEOGEOおんらいんこれくしょん】
+  name: THE BEST サムライスピリッツ六番勝負 [NEOGEOオンラインコレクション]
+  name-sort: THE BEST さむらいすぴりっつろくばんしょうぶ [NEOGEOおんらいんこれくしょん]
   name-en: "Samurai Spirits - Rokuban Shoubu [NeoGeo Online Collection the Best]"
   region: "NTSC-J"
 SLPS-25935:
-  name: THE BEST ザ・キング・オブ・ファイターズ'98 アルティメットマッチ【NEOGEOオンラインコレクション】
-  name-sort: THE BEST ざ・きんぐ・おぶ・ふぁいたーず'98 あるてぃめっとまっち【NEOGEOおんらいんこれくしょん】
+  name: THE BEST ザ・キング・オブ・ファイターズ'98 アルティメットマッチ [NEOGEOオンラインコレクション]
+  name-sort: THE BEST ざ・きんぐ・おぶ・ふぁいたーず'98 あるてぃめっとまっち [NEOGEOおんらいんこれくしょん]
   name-en: "King of Fighters '98 Ultimate Match, The [NeoGeo Online Collection the Best]"
   region: "NTSC-J"
 SLPS-25936:
@@ -65490,8 +65490,8 @@ TCPS-10075:
   gsHWFixes:
     preloadFrameData: 1 # Fixes missing text.
 TCPS-10084:
-  name: 零式艦上戦闘記(数量限定パッケージ)
-  name-sort: れいしきかんじょうせんとうき(すうりょうげんていぱっけーじ)
+  name: 零式艦上戦闘記 [数量限定パッケージ]
+  name-sort: れいしきかんじょうせんとうき [すうりょうげんていぱっけーじ]
   name-en: "Zero Shinkikan Josentoki"
   region: "NTSC-J"
 TCPS-10085:
@@ -65516,8 +65516,8 @@ TCPS-10107:
   name-en: "Giga Wing Generations"
   region: "NTSC-J"
 TCPS-10109:
-  name: イースIII ～ワンダラーズ フロム イース～ (初回限定版)
-  name-sort: いーすIII ～わんだらーず ふろむ いーす～ (しょかいげんていばん)
+  name: イースIII ～ワンダラーズ フロム イース～ [初回限定版]
+  name-sort: いーすIII ～わんだらーず ふろむ いーす～ [しょかいげんていばん]
   name-en: "Ys III - Wanderers from Ys [Limited Edition]"
   region: "NTSC-J"
 TCPS-10111:
@@ -65608,13 +65608,13 @@ TCPS-10147:
   name-en: "Zero Shikikan Josentoki Ni"
   region: "NTSC-J"
 TCPS-10148:
-  name: 零式艦上戦闘記 弐 【限定版】
-  name-sort: れいしきかんじょうせんとうき 弐 【げんていばん】
+  name: 零式艦上戦闘記 弐 [限定版]
+  name-sort: れいしきかんじょうせんとうき 弐 [げんていばん]
   name-en: "Zero Shikikan Josentoki Ni [Limited Edition]"
   region: "NTSC-J"
 TCPS-10152:
-  name: ローゼンメイデン ドゥエルヴァルツァ(通常版)
-  name-sort: ろーぜんめいでん どぅえるゔぁるつぁ(つうじょうばん)
+  name: ローゼンメイデン ドゥエルヴァルツァ [通常版]
+  name-sort: ろーぜんめいでん どぅえるゔぁるつぁ [つうじょうばん]
   name-en: "Rozen Maiden - Duellwalzer"
   region: "NTSC-J"
 TCPS-10153:

--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -25988,7 +25988,7 @@ SLES-55520:
     9E36E023:
       content: |-
         //Patched by kozarrov
-        //Fix Pause menu, some hud parts, etc. 
+        //Fix Pause menu, some hud parts, etc.
         patch=1,EE,0016ee38,word,3464fff0
         patch=1,EE,0016ee58,word,3464fffc
 SLES-55522:

--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -7537,7 +7537,7 @@ SCPS-15060:
   region: "NTSC-J"
 SCPS-15061:
   name: "EyeToy: Play(アイトーイ プレイ)"
-  name-sort: "EyeToy: Play(あいとーい ぷれい)"
+  name-sort: あいとーい ぷれい
   name-en: "EyeToy - Play [with Camera]"
   region: "NTSC-J"
 SCPS-15062:
@@ -7795,7 +7795,7 @@ SCPS-15092:
     - "SCPS-19253"
 SCPS-15093:
   name: RULE of ROSE (ルール オブ ローズ)
-  name-sort: RULE of ROSE (るーる おぶ ろーず)
+  name-sort: るーる おぶ ろーず
   name-en: "Rule of Rose"
   region: "NTSC-J"
   compat: 5
@@ -31999,7 +31999,7 @@ SLPM-62361:
   region: "NTSC-J"
 SLPM-62362:
   name: SEGA AGES 2500 シリーズ Vol.1 PHANTASY STAR(ファンタシースター) generation1限定
-  name-sort: SEGA AGES 2500 しりーず Vol.1 PHANTASY STAR(ふぁんたしーすたー) generation1げんてい
+  name-sort: SEGA AGES 2500 しりーず Vol.1 ふぁんたしーすたー generation1げんてい
   name-en: "Sega Ages 2500 Series Vol.01 - Phantasy Star Generation 1"
   region: "NTSC-J"
   compat: 5
@@ -35083,12 +35083,12 @@ SLPM-65185:
     roundSprite: 1 # Fixes text alignment.
 SLPM-65186:
   name: Thread Colors(スレッドカラーズ)〜さよならの向こう側〜 [限定生産初回BOX]
-  name-sort: Thread Colors(すれっどからーず)〜さよならのむこうがわ〜 [げんていせいさんしょかいBOX]
+  name-sort: すれっどからーず 〜さよならのむこうがわ〜 [げんていせいさんしょかいBOX]
   name-en: "Thread Colors [Limited Edition]"
   region: "NTSC-J"
 SLPM-65187:
   name: Thread Colors(スレッドカラーズ)〜さよならの向こう側〜 [量産型ふつう版]
-  name-sort: Thread Colors(すれっどからーず)〜さよならのむこうがわ〜 [りょうさんがたふつうばん]
+  name-sort: すれっどからーず 〜さよならのむこうがわ〜 [りょうさんがたふつうばん]
   name-en: "Thread Colors"
   region: "NTSC-J"
 SLPM-65190:
@@ -35490,7 +35490,7 @@ SLPM-65255:
     roundSprite: 2 # Reduces font artifacts.
 SLPM-65256:
   name: ファーストKiss☆物語(ストーリーズ) スペシャルCD同梱版
-  name-sort: ふぁーすとKiss☆ものがたり(すとーりーず) すぺしゃるCDどうこんばん
+  name-sort: ふぁーすとKiss☆すとーりーず すぺしゃるCDどうこんばん
   name-en: "First Kiss Story 1&2 [Limited Edition]"
   region: "NTSC-J"
 SLPM-65257:
@@ -35800,7 +35800,7 @@ SLPM-65309:
   region: "NTSC-J"
 SLPM-65310:
   name: The Mark of KRI(マーク オブ クリィ)
-  name-sort: The Mark of KRI(まーく おぶ くりぃ)
+  name-sort: まーく おぶ くりぃ
   name-en: "Mark of Kri, The"
   region: "NTSC-J"
 SLPM-65311:
@@ -35812,7 +35812,7 @@ SLPM-65311:
     roundSprite: 1 # Aligns text boxes.
 SLPM-65313:
   name: ファーストKiss☆物語(ストーリーズ)
-  name-sort: ふぁーすとKiss☆ものがたり(すとーりーず)
+  name-sort: ふぁーすとKiss☆すとーりーず
   name-en: "First Kiss Story 1&2"
   region: "NTSC-J"
 SLPM-65314:
@@ -36113,7 +36113,7 @@ SLPM-65372:
   region: "NTSC-J"
 SLPM-65373:
   name: 玻璃の薔薇(ガラスノバラ)
-  name-sort: がらすのばら(がらすのばら)
+  name-sort: がらすのばら
   name-en: "Glass Rose"
   region: "NTSC-J"
   compat: 5
@@ -36306,7 +36306,7 @@ SLPM-65409:
   region: "NTSC-J"
 SLPM-65410:
   name: ゲッタウェイ(the Getaway)
-  name-sort: げったうぇい(the Getaway)
+  name-sort: げったうぇい
   name-en: "Getaway, The"
   region: "NTSC-J"
   gsHWFixes:
@@ -36693,7 +36693,7 @@ SLPM-65479:
     halfPixelOffset: 1 # Fixes vertical lines, font and others.
 SLPM-65480:
   name: michigan(ミシガン)
-  name-sort: michigan(みしがん)
+  name-sort: みしがん
   name-en: "Michigan"
   region: "NTSC-J"
 SLPM-65481:
@@ -37276,7 +37276,7 @@ SLPM-65596:
   region: "NTSC-J"
 SLPM-65597:
   name: DIGITAL DEVIL SAGA(デジタル・デビル・サーガ)〜アバタール・チューナー〜
-  name-sort: DIGITAL DEVIL SAGA(でじたる・でびる・さーが)〜あばたーる・ちゅーなー〜
+  name-sort: でじたる・でびる・さーが〜あばたーる・ちゅーなー〜
   name-en: "Digital Devil Saga - Avatar Tuner"
   region: "NTSC-J"
   gameFixes:
@@ -37696,12 +37696,12 @@ SLPM-65680:
   region: "NTSC-J"
 SLPM-65681:
   name: Monochrome(モノクローム) 初回限定版
-  name-sort: Monochrome(ものくろーむ) しょかいげんていばん
+  name-sort: ものくろーむ しょかいげんていばん
   name-en: "Monochrome [Limited Edition]"
   region: "NTSC-J"
 SLPM-65682:
   name: Monochrome(モノクローム)
-  name-sort: Monochrome(ものくろーむ)
+  name-sort: ものくろーむ
   name-en: "Monochrome"
   region: "NTSC-J"
 SLPM-65683:
@@ -37718,7 +37718,7 @@ SLPM-65684:
   region: "NTSC-J"
 SLPM-65685:
   name: Stella Deus(ステラデウス)
-  name-sort: Stella Deus(すてらでうす)
+  name-sort: すてらでうす
   name-en: "Stella Deus"
   region: "NTSC-J"
 SLPM-65686:
@@ -38031,7 +38031,7 @@ SLPM-65737:
   region: "NTSC-J"
 SLPM-65738:
   name: LoveSongs♪ADV(アドベンチャー)『双葉理保 19歳〜冬〜』
-  name-sort: LoveSongs♪ADV(あどべんちゃー)『ふたばりほ 19さい〜ふゆ〜』
+  name-sort: LoveSongs♪あどべんちゃー『ふたばりほ 19さい〜ふゆ〜』
   name-en: "Love Songs Adv - Futaba Riho 19 Sai"
   region: "NTSC-J"
 SLPM-65739:
@@ -38356,7 +38356,7 @@ SLPM-65794:
   compat: 5
 SLPM-65795:
   name: DIGITAL DEVIL SAGA(デジタル・デビル・サーガ) 〜アバタール・チューナー2〜
-  name-sort: DIGITAL DEVIL SAGA(でじたる・でびる・さーが) 〜あばたーる・ちゅーなー2〜
+  name-sort: でじたる・でびる・さーが 〜あばたーる・ちゅーなー2〜
   name-en: "Digital Devil Saga - Avatar Tuner 2"
   region: "NTSC-J"
   gameFixes:
@@ -38436,7 +38436,7 @@ SLPM-65805:
   region: "NTSC-J"
 SLPM-65806:
   name: VM JAPAN(ブイエムジャパン)
-  name-sort: VM JAPAN(ぶいえむじゃぱん)
+  name-sort: ぶいえむじゃぱん
   name-en: "VM Japan"
   region: "NTSC-J"
 SLPM-65807:
@@ -38842,7 +38842,7 @@ SLPM-65884:
   region: "NTSC-J"
 SLPM-65885:
   name: RUMBLE ROSES(ランブルローズ)
-  name-sort: RUMBLE ROSES(らんぶるろーず)
+  name-sort: らんぶるろーず
   name-en: "Rumble Roses"
   region: "NTSC-J"
 SLPM-65886:
@@ -39025,7 +39025,7 @@ SLPM-65918:
   region: "NTSC-J"
 SLPM-65919:
   name: THE RUMBLE FISH(ザ・ランブルフィッシュ)
-  name-sort: THE RUMBLE FISH(ざ・らんぶるふぃっしゅ)
+  name-sort: ざ・らんぶるふぃっしゅ
   name-en: "Rumble Fish, The"
   region: "NTSC-J"
   compat: 5
@@ -39142,7 +39142,7 @@ SLPM-65941:
   region: "NTSC-J"
 SLPM-65942:
   name: MERCENARIES(マーセナリーズ)
-  name-sort: MERCENARIES(まーせなりーず)
+  name-sort: まーせなりーず
   name-en: "Mercenaries - Playground of Destruction"
   region: "NTSC-J"
   gsHWFixes:
@@ -39171,7 +39171,7 @@ SLPM-65946:
   compat: 5
 SLPM-65947:
   name: Killer7(キラー7)
-  name-sort: Killer7(きらー7)
+  name-sort: きらー7
   name-en: "Killer7"
   region: "NTSC-J"
 SLPM-65948:
@@ -39376,7 +39376,7 @@ SLPM-65980:
   region: "NTSC-J"
 SLPM-65981:
   name: FRONT MISSION ONLINE(フロントミッション オンライン)
-  name-sort: FRONT MISSION ONLINE(ふろんとみっしょん おんらいん)
+  name-sort: ふろんとみっしょん おんらいん
   name-en: "Front Mission Online"
   region: "NTSC-J"
 SLPM-65982:
@@ -39654,7 +39654,7 @@ SLPM-66030:
   compat: 5
 SLPM-66031:
   name: ファンタシー スター  ユニバース (Phantasy Star Universe)
-  name-sort: ふぁんたしー すたー  ゆにばーす (Phantasy Star Universe)
+  name-sort: ふぁんたしー すたー  ゆにばーす
   name-en: "Phantasy Star Universe"
   region: "NTSC-J"
   roundModes:
@@ -39772,12 +39772,12 @@ SLPM-66053:
   region: "NTSC-J"
 SLPM-66054:
   name: 新天魔界 ジェネレーション オブ カオス V(ファイブ) 限定版
-  name-sort: しんてんまかい じぇねれーしょん おぶ かおす V(ふぁいぶ) げんていばん
+  name-sort: しんてんまかい じぇねれーしょん おぶ かおす ふぁいぶ げんていばん
   name-en: "Generation of Chaos 5 [Limited Edition]"
   region: "NTSC-J"
 SLPM-66055:
   name: 新天魔界 ジェネレーション オブ カオス V(ファイブ)
-  name-sort: しんてんまかい じぇねれーしょん おぶ かおす V(ふぁいぶ)
+  name-sort: しんてんまかい じぇねれーしょん おぶ かおす ふぁいぶ
   name-en: "Generation of Chaos 5"
   region: "NTSC-J"
 SLPM-66056:
@@ -40537,7 +40537,7 @@ SLPM-66182:
   region: "NTSC-J"
 SLPM-66183:
   name: ゲッタウェイ ブラックマンデー(The Getaway Black Monday)
-  name-sort: げったうぇい ぶらっくまんでー(The Getaway Black Monday)
+  name-sort: げったうぇい ぶらっくまんでー
   name-en: "Getaway, The - Black Monday"
   region: "NTSC-J"
   gsHWFixes:
@@ -40736,7 +40736,7 @@ SLPM-66213:
     halfPixelOffset: 2 # Fixes blurriness.
 SLPM-66214:
   name: WHITE CLARITY(ホワイト クラリティー)〜And The tears became you.〜 [初回限定版]
-  name-sort: WHITE CLARITY(ほわいと くらりてぃー)〜And The tears became you.〜 [しょかいげんていばん]
+  name-sort: ほわいと くらりてぃー 〜And The tears became you.〜 [しょかいげんていばん]
   name-en: "White Clarity - And, the Tears Became You [First Print Limited Edition]"
   region: "NTSC-J"
 SLPM-66215:
@@ -41467,7 +41467,7 @@ SLPM-66332:
   region: "NTSC-J"
 SLPM-66333:
   name: GUILTY GEAR XX SLASH (ギルティギア イグゼクス スラッシュ)
-  name-sort: GUILTY GEAR XX SLASH (ぎるてぃぎあ いぐぜくす すらっしゅ)
+  name-sort: ぎるてぃぎあ いぐぜくす すらっしゅ
   name-en: "Guilty Gear XX Slash"
   region: "NTSC-J"
   compat: 5
@@ -42396,7 +42396,7 @@ SLPM-66491:
     cpuCLUTRender: 1 # Fixes rendering.
 SLPM-66492:
   name: COMMANDOS STRIKE FORCE(コマンドス ストライク・フォース)
-  name-sort: COMMANDOS STRIKE FORCE(こまんどす すとらいく・ふぉーす)
+  name-sort: こまんどす すとらいく・ふぉーす
   name-en: "Commandos Strike Force"
   region: "NTSC-J"
   gsHWFixes:
@@ -42697,7 +42697,7 @@ SLPM-66549:
   region: "NTSC-J"
 SLPM-66550:
   name: GOD HAND(ゴッドハンド)
-  name-sort: GOD HAND(ごっどはんど)
+  name-sort: ごっどはんど
   name-en: "God Hand"
   region: "NTSC-J"
   compat: 5
@@ -42706,7 +42706,7 @@ SLPM-66550:
     halfPixelOffset: 2 # Depth of field effect aligned properly + Shifts buildings correctly.
 SLPM-66551:
   name: APPLESEED EX(アップルシード エクス)
-  name-sort: APPLESEED EX(あっぷるしーど えくす)
+  name-sort: あっぷるしーど えくす
   name-en: "Appleseed EX"
   region: "NTSC-J"
 SLPM-66552:
@@ -42837,7 +42837,7 @@ SLPM-66569:
     roundSprite: 2 # Reduces artifacts like vertical lines in main menu but there are many other artifacts still.
 SLPM-66570:
   name: I”s Pure(アイズピュア)
-  name-sort: I”s Pure(あいずぴゅあ)
+  name-sort: あいずぴゅあ
   name-en: "I's Pure"
   region: "NTSC-J"
 SLPM-66571:
@@ -43163,7 +43163,7 @@ SLPM-66627:
   region: "NTSC-J"
 SLPM-66628:
   name: OutRun2 SP(アウトラン2 スペシャルツアーズ) [初回限定版]
-  name-sort: OutRun2 SP(あうとらん2 すぺしゃるつあーず) [しょかいげんていばん]
+  name-sort: あうとらん2 すぺしゃるつあーず [しょかいげんていばん]
   name-en: "OutRun 2 SP [First Print Limited Edition]"
   region: "NTSC-J"
   compat: 5
@@ -43190,7 +43190,7 @@ SLPM-66631:
   region: "NTSC-J"
 SLPM-66632:
   name: 喧嘩番長2 〜FULLTHROTTLE〜(フルスロットル)
-  name-sort: けんかばんちょう2 〜FULLTHROTTLE〜(ふるすろっとる)
+  name-sort: けんかばんちょう2 〜ふるすろっとる〜
   name-en: "Kenka Banchou 2 - Full Throttle"
   region: "NTSC-J"
 SLPM-66633:
@@ -43716,7 +43716,7 @@ SLPM-66719:
   region: "NTSC-J"
 SLPM-66720:
   name: GUILTY GEAR XX SLASH(ギルティギア イグゼクス スラッシュ) [SEGA THE BEST]
-  name-sort: GUILTY GEAR XX SLASH(ぎるてぃぎあ いぐぜくす すらっしゅ) [SEGA THE BEST]
+  name-sort: ぎるてぃぎあ いぐぜくす すらっしゅ [SEGA THE BEST]
   name-en: "Guilty Gear XX #Slash [Sega the Best]"
   region: "NTSC-J"
 SLPM-66721:
@@ -43786,12 +43786,12 @@ SLPM-66731:
     beforeDraw: "OI_BurnoutGames"
 SLPM-66732:
   name: 許嫁(いいなずけ) [初回限定版]
-  name-sort: いいなずけ(いいなずけ) [しょかいげんていばん]
+  name-sort: いいなずけ [しょかいげんていばん]
   name-en: "Iinazuke [Limited Edition]"
   region: "NTSC-J"
 SLPM-66733:
   name: 許嫁(いいなずけ) [通常版]
-  name-sort: いいなずけ(いいなずけ) [つうじょうばん]
+  name-sort: いいなずけ [つうじょうばん]
   name-en: "Iinazuke"
   region: "NTSC-J"
 SLPM-66734:
@@ -44434,7 +44434,7 @@ SLPM-66847:
   region: "NTSC-J"
 SLPM-66848:
   name: 戦国BASARA2 英雄外伝(HEROES)
-  name-sort: せんごくBASARA2 えいゆうがいでん(HEROES)
+  name-sort: せんごくBASARA2 HEROES
   name-en: "Sengoku Basara 2 Heroes"
   region: "NTSC-J"
 SLPM-66849:
@@ -46941,7 +46941,7 @@ SLPS-20149:
   region: "NTSC-J"
 SLPS-20150:
   name: AKIRA PSYCHO BALL(アキラ サイコボール)
-  name-sort: AKIRA PSYCHO BALL(あきら さいこぼーる)
+  name-sort: あきら さいこぼーる
   name-en: "Akira Psycho Ball"
   region: "NTSC-J"
 SLPS-20151:
@@ -47918,7 +47918,7 @@ SLPS-20401:
   region: "NTSC-J"
 SLPS-20402:
   name: 仮面ライダー剣(ブレイド)
-  name-sort: かめんらいだーけん(ぶれいど)
+  name-sort: かめんらいだーぶれいど
   name-en: "Kamen Rider Blade"
   region: "NTSC-J"
   compat: 5
@@ -48609,7 +48609,7 @@ SLPS-25024:
   region: "NTSC-J"
 SLPS-25025:
   name: 7(セブン)〜モールモースの騎兵隊〜
-  name-sort: 7(せぶん)〜もーるもーすのきへいたい〜
+  name-sort: せぶん〜もーるもーすのきへいたい〜
   name-en: "7 (Seven) - Molmorth no Kiheitai"
   region: "NTSC-J"
   compat: 5
@@ -49043,7 +49043,7 @@ SLPS-25101:
     - FullVU0SyncHack # Fixes SPS.
 SLPS-25102:
   name: PROJECT ARMS(プロジェクトアームズ)
-  name-sort: PROJECT ARMS(ぷろじぇくとあーむず)
+  name-sort: ぷろじぇくとあーむず
   name-en: "Project Arms"
   region: "NTSC-J"
 SLPS-25103:
@@ -49660,7 +49660,7 @@ SLPS-25216:
   compat: 5
 SLPS-25217:
   name: SHADOW TOWER ABYSS(シャドウタワー アビス)
-  name-sort: SHADOW TOWER ABYSS(しゃどうたわー あびす)
+  name-sort: しゃどうたわー あびす
   name-en: "Shadow Tower Abyss"
   region: "NTSC-J"
   compat: 5
@@ -50040,7 +50040,7 @@ SLPS-25294:
   region: "NTSC-J"
 SLPS-25295:
   name: Kaena(ケイナ)
-  name-sort: Kaena(けいな)
+  name-sort: けいな
   name-en: "Kaena"
   region: "NTSC-J"
   compat: 5
@@ -50918,7 +50918,7 @@ SLPS-25438:
   region: "NTSC-J"
 SLPS-25439:
   name: はじめの一歩 ALL☆STARS(オール☆スターズ)
-  name-sort: はじめのいちほ ALL☆STARS(おーる☆すたーず)
+  name-sort: はじめのいちほ おーる☆すたーず
   name-en: "Hajime no Ippo - All-Stars"
   region: "NTSC-J"
 SLPS-25440:
@@ -51269,7 +51269,7 @@ SLPS-25504:
   region: "NTSC-J"
 SLPS-25505:
   name: NAMCO×CAPCOM(ナムコ クロス カプコン)
-  name-sort: NAMCO×CAPCOM(なむこ くろす かぷこん)
+  name-sort: なむこ くろす かぷこん
   name-en: "Namco X Capcom"
   region: "NTSC-J"
   compat: 5
@@ -51295,7 +51295,7 @@ SLPS-25509:
   region: "NTSC-J"
 SLPS-25510:
   name: 鉄拳5 (TEKKEN 5)
-  name-sort: てっけん5 (TEKKEN 5)
+  name-sort: てっけん5
   name-en: "Tekken 5"
   region: "NTSC-J"
   compat: 5
@@ -51410,7 +51410,7 @@ SLPS-25532:
   region: "NTSC-J"
 SLPS-25533:
   name: テイルズ オブ レジェンディア (Tales of Legendia)
-  name-sort: ているず おぶ れじぇんでぃあ (Tales of Legendia)
+  name-sort: ているず おぶ れじぇんでぃあ
   name-en: "Tales of Legendia"
   region: "NTSC-J"
   compat: 5
@@ -52264,7 +52264,7 @@ SLPS-25674:
   compat: 5
 SLPS-25675:
   name: バトルスタジアムD.O.N(ディー・オー・エヌ)
-  name-sort: ばとるすたじあむD.O.N(でぃー・おー・えぬ)
+  name-sort: ばとるすたじあむでぃー・おー・えぬ
   name-en: "Battle Stadium D.O.N"
   region: "NTSC-J"
   compat: 5
@@ -52409,7 +52409,7 @@ SLPS-25701:
   region: "NTSC-J"
 SLPS-25702:
   name: 雨格子の館(あまごうしのやかた)
-  name-sort: あめこうしのやかた(あまごうしのやかた)
+  name-sort: あめごうしのやかた
   name-en: "Amagoushi no Yakata"
   region: "NTSC-J"
 SLPS-25703:
@@ -53347,7 +53347,7 @@ SLPS-25877:
   region: "NTSC-J"
 SLPS-25879:
   name: Bully (ブリー)
-  name-sort: Bully (ぶりー)
+  name-sort: ぶりー
   name-en: "Bully"
   region: "NTSC-J"
   clampModes:
@@ -65638,7 +65638,7 @@ TCPS-10158:
     halfPixelOffset: 2
 TCPS-10159:
   name: TT SUPERBIKES(TTスーパーバイクス)
-  name-sort: TT SUPERBIKES(TTすーぱーばいくす)
+  name-sort: TTすーぱーばいくす
   name-en: "Suzuki TT Super Bikes - Real Road Racing"
   region: "NTSC-J"
 TCPS-10160:

--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -28838,8 +28838,8 @@ SLPM-55113:
   name: "WinBack 2 - Project Poseidon"
   region: "NTSC-J"
 SLPM-55114:
-  name: ガストベストプライス マナケミア２ 〜おちた学園と錬金術士たち〜
-  name-sort: がすとべすとぷらいす まなけみあに 〜おちたがくえんとれんきんじゅつしたち〜
+  name: マナケミア２ 〜おちた学園と錬金術士たち〜【ガストベストプライス】
+  name-sort: まなけみあに 〜おちたがくえんとれんきんじゅつしたち〜【がすとべすとぷらいす】
   name-en: "Mana Khemia 2 - Ochita Gakuen to Renkinjutsushi Tachi"
   region: "NTSC-J"
   gsHWFixes:
@@ -29257,8 +29257,8 @@ SLPM-55250:
   name: "Warship Gunner 2 - Kurogane no Houkou"
   region: "NTSC-J"
 SLPM-55251:
-  name: コーエー定番シリーズ 太閤立志伝V
-  name-sort: こーえーていばんしりーず たいこうりっしでんV
+  name: 太閤立志伝V【コーエー定番シリーズ】
+  name-sort: たいこうりっしでんV【こーえーていばんしりーず】
   name-en: "WWE SmackDown vs. Raw 2009"
   region: "NTSC-J"
 SLPM-55252:
@@ -31831,8 +31831,8 @@ SLPM-62324:
   name-en: "Simple 2000 Series Vol. 8 - Gekitou! Meiro King"
   region: "NTSC-J"
 SLPM-62325:
-  name: THE BEST タカラモノ ハイヒートメジャーリーグベースボール 2003
-  name-sort: THE BEST たからもの はいひーとめじゃーりーぐべーすぼーる 2003
+  name: ハイヒートメジャーリーグベースボール 2003【THE BEST タカラモノ】
+  name-sort: はいひーとめじゃーりーぐべーすぼーる 2003【THE BEST たからもの】
   name-en: "High Heat Major League Baseball 2003 [Konami The Best]"
   region: "NTSC-J"
 SLPM-62326:
@@ -31970,8 +31970,8 @@ SLPM-62354:
   name-en: "Space Invaders 25th Anniversary"
   region: "NTSC-J"
 SLPM-62355:
-  name: THE BEST タカラモノ チョロQHG2
-  name-sort: THE BEST たからもの ちょろQHG2
+  name: チョロQHG2【THE BEST タカラモノ】
+  name-sort: ちょろQHG2【THE BEST たからもの】
   name-en: "Choro Q HG 2"
   region: "NTSC-J"
   gsHWFixes:
@@ -32531,8 +32531,8 @@ SLPM-62472:
   name-en: "Diet Channel"
   region: "NTSC-J"
 SLPM-62473:
-  name: KOEI The Best 信長の野望 嵐世紀
-  name-sort: KOEI The Best のぶながのやぼう あらしせいき
+  name: 信長の野望 嵐世紀【KOEI The Best】
+  name-sort: のぶながのやぼう あらしせいき【KOEI The Best】
   name-en: "Nobunaga no Yabou - Ranseiki [Koei The Best]"
   region: "NTSC-J"
 SLPM-62474:
@@ -32746,8 +32746,8 @@ SLPM-62512:
     textureInsideRT: 1 # Fixes rainbow lighting for some areas.
     getSkipCount: "GSC_BlueTongueGames" # Mipmap rendering on CPU.
 SLPM-62513:
-  name: EA BEST HITS ハリー・ポッターと秘密の部屋
-  name-sort: EA BEST HITS はりー・ぽったーとひみつのへや
+  name: ハリー・ポッターと秘密の部屋【EA BEST HITS】
+  name-sort: はりー・ぽったーとひみつのへや【EA BEST HITS】
   name-en: "Harry Potter and the Chamber of Secrets [EA Best Hits]"
   region: "NTSC-J"
   gameFixes:
@@ -32758,8 +32758,8 @@ SLPM-62513:
     trilinearFiltering: 1 # Fixes blurry textures.
     cpuFramebufferConversion: 1 # Fixes right side of the screen from garbage textures.
 SLPM-62514:
-  name: EA BEST HITS シムピープル ～お茶の間劇場～
-  name-sort: EA BEST HITS しむぴーぷる ～おちゃのまげきじょう～
+  name: シムピープル ～お茶の間劇場～【EA BEST HITS】
+  name-sort: しむぴーぷる ～おちゃのまげきじょう～【EA BEST HITS】
   name-en: "Sim People [EA Best Hits]"
   region: "NTSC-J"
 SLPM-62515:
@@ -32776,18 +32776,18 @@ SLPM-62516:
   name-en: "EyeToy Sports - Let's Play Sports!"
   region: "NTSC-J"
 SLPM-62517:
-  name: KOEI The Best WinningPost 5
-  name-sort: KOEI The Best WinningPost 5
+  name: WinningPost 5【KOEI The Best】
+  name-sort: WinningPost 5【KOEI The Best】
   name-en: "Winning Post 5 [Koei The Best]"
   region: "NTSC-J"
 SLPM-62518:
-  name: KOEI The Best 提督の決断IV
-  name-sort: KOEI The Best ていとくのけつだんIV
+  name: 提督の決断IV【KOEI The Best】
+  name-sort: ていとくのけつだんIV【KOEI The Best】
   name-en: "Teitoku no Ketsudan IV [Koei the Best]"
   region: "NTSC-J"
 SLPM-62519:
-  name: KOEI The Best 三國志VIII
-  name-sort: KOEI The Best さんごくしVIII
+  name: 三國志VIII【KOEI The Best】
+  name-sort: さんごくしVIII【KOEI The Best】
   name-en: "Sangokushi VIII [Koei The Best]"
   region: "NTSC-J"
 SLPM-62520:
@@ -32856,13 +32856,13 @@ SLPM-62534:
   region: "NTSC-J"
   compat: 5
 SLPM-62536:
-  name: KOEI The Best ジーワンジョッキー3
-  name-sort: KOEI The Best じーわんじょっきー3
+  name: ジーワンジョッキー3【KOEI The Best】
+  name-sort: じーわんじょっきー3【KOEI The Best】
   name-en: "G1 Jockey 3 [Koei The Best]"
   region: "NTSC-J"
 SLPM-62537:
-  name: EA BEST HITS スター・ウォーズ スターファイター
-  name-sort: EA BEST HITS すたー・うぉーず すたーふぁいたー
+  name: スター・ウォーズ スターファイター【EA BEST HITS】
+  name-sort: すたー・うぉーず すたーふぁいたー【EA BEST HITS】
   name-en: "Star Wars - Starfighter [EA Best Hits]"
   region: "NTSC-J"
 SLPM-62538:
@@ -32907,8 +32907,8 @@ SLPM-62545:
   region: "NTSC-J"
   compat: 5
 SLPM-62546:
-  name: コーエー定番シリーズ 三國志VII
-  name-sort: こーえーていばんしりーず さんごくしVII
+  name: 三國志VII【コーエー定番シリーズ】
+  name-sort: さんごくしVII【こーえーていばんしりーず】
   name-en: "Sangokushi VII [Koei Collection Series]"
   region: "NTSC-J"
 SLPM-62547:
@@ -33022,15 +33022,15 @@ SLPM-62566:
   name-en: "Typing of the Dead - Zombie Panic"
   region: "NTSC-J"
 SLPM-62567:
-  name: コーエー定番シリーズ WIN BACK
-  name-sort: こーえーていばんしりーず WIN BACK
+  name: WIN BACK【コーエー定番シリーズ】
+  name-sort: WIN BACK【こーえーていばんしりーず】
   name-en: "Winback [Koei Best Series]"
   region: "NTSC-J"
   clampModes:
     vuClampMode: 3 # Fixes missing 3D polygons when going ingame.
 SLPM-62568:
-  name: コーエー定番シリーズ 真・三國無双
-  name-sort: こーえーていばんしりーず しん・さんごくむそう
+  name: 真・三國無双【コーエー定番シリーズ】
+  name-sort: しん・さんごくむそう【こーえーていばんしりーず】
   name-en: "Shin Sangoku Musou [Koei The Best]"
   region: "NTSC-J"
 SLPM-62569:
@@ -33248,8 +33248,8 @@ SLPM-62613:
   region: "NTSC-J"
   compat: 5
 SLPM-62614:
-  name: コーエー定番シリーズ ホースブレーカー
-  name-sort: こーえーていばんしりーず ほーすぶれーかー
+  name: ホースブレーカー【コーエー定番シリーズ】
+  name-sort: ほーすぶれーかー【こーえーていばんしりーず】
   name-en: "Horse Breaker [Koei Teiban Series]"
   region: "NTSC-J"
 SLPM-62615:
@@ -33387,23 +33387,23 @@ SLPM-62638:
   gameFixes:
     - XGKickHack # Fixes characters clothing.
 SLPM-62639:
-  name: コーエー定番シリーズ 麻雀大会III ミレニアムリーグ
-  name-sort: こーえーていばんしりーず まーじゃんたいかいIII みれにあむりーぐ
+  name: 麻雀大会III ミレニアムリーグ【コーエー定番シリーズ】
+  name-sort: まーじゃんたいかいIII みれにあむりーぐ【こーえーていばんしりーず】
   name-en: "Mahjong Taikai III - Millennium League [Koei Selection Series]"
   region: "NTSC-J"
 SLPM-62640:
-  name: コーエー定番シリーズ 太閤立志伝IV
-  name-sort: こーえーていばんしりーず たいこうりっしでんIV
+  name: 太閤立志伝IV【コーエー定番シリーズ】
+  name-sort: たいこうりっしでんIV【こーえーていばんしりーず】
   name-en: "Taikou Risshiden IV [Koei Selection Series]"
   region: "NTSC-J"
 SLPM-62641:
-  name: KOEI The BEST 三國志VIII with パワーアップキット
-  name-sort: KOEI The BEST さんごくしVIII with ぱわーあっぷきっと
+  name: 三國志VIII with パワーアップキット【KOEI The BEST】
+  name-sort: さんごくしVIII with ぱわーあっぷきっと【KOEI The BEST】
   name-en: "Sangokushi VIII [with Power-Up Kit] [Koei The Best]"
   region: "NTSC-J"
 SLPM-62642:
-  name: KOEI The BEST 信長の野望・嵐世記 with パワーアップキット
-  name-sort: KOEI The BEST のぶながのやぼう・らんせいき with ぱわーあっぷきっと
+  name: 信長の野望・嵐世記 with パワーアップキット【KOEI The BEST】
+  name-sort: のぶながのやぼう・らんせいき with ぱわーあっぷきっと【KOEI The BEST】
   name-en: "Nobunaga no Yabou - Ranseiki [with Power-Up Kit] [Koei The Best]"
   region: "NTSC-J"
 SLPM-62643:
@@ -33538,8 +33538,8 @@ SLPM-62677:
   name-en: "Sega Ages 2500 Series Vol.15 - Decathlete Collection"
   region: "NTSC-J"
 SLPM-62678:
-  name: コーエー定番シリーズ 鋼鉄の咆哮 〜ウォーシップコマンダー〜
-  name-sort: こーえーていばんしりーず くろがねのほうこう 〜うぉーしっぷこまんだー〜
+  name: 鋼鉄の咆哮 〜ウォーシップコマンダー〜【コーエー定番シリーズ】
+  name-sort: くろがねのほうこう 〜うぉーしっぷこまんだー〜【こーえーていばんしりーず】
   name-en: "Kurogane no Houkou - Warship Commander [Koei Selection Series]"
   region: "NTSC-J"
 SLPM-62679:
@@ -33553,8 +33553,8 @@ SLPM-62680:
   name-en: "Relakuma - Ojama Shitemasu 2"
   region: "NTSC-J"
 SLPM-62681:
-  name: コーエー定番シリーズ 信長の野望・嵐世記
-  name-sort: こーえーていばんしりーず のぶながのやぼう・らんせいき
+  name: 信長の野望・嵐世記【コーエー定番シリーズ】
+  name-sort: のぶながのやぼう・らんせいき【こーえーていばんしりーず】
   name-en: "Nobunaga no Yabou - Ranseiki [Koei Selection Series]"
   region: "NTSC-J"
 SLPM-62682:
@@ -33630,8 +33630,8 @@ SLPM-62696:
   name-en: "Oretachi Geasen Zoku Sono - Yie Ar Kung-fu"
   region: "NTSC-J"
 SLPM-62697:
-  name: IFコレクション ジェネレーション オブ カオス ネクスト 〜失われし絆〜
-  name-sort: IFこれくしょん じぇねれーしょん おぶ かおす ねくすと 〜うしなわれしきずな〜
+  name: ジェネレーション オブ カオス ネクスト 〜失われし絆〜【IFコレクション】
+  name-sort: じぇねれーしょん おぶ かおす ねくすと 〜うしなわれしきずな〜【IFこれくしょん】
   name-en: "Generation of Chaos Next [Idea Factory Collection]"
   region: "NTSC-J"
 SLPM-62698:
@@ -33640,18 +33640,18 @@ SLPM-62698:
   name-en: "Ultimate Pro Pinball"
   region: "NTSC-J"
 SLPM-62699:
-  name: IFコレクション カルディナル アーク 〜混沌の封札〜
-  name-sort: IFこれくしょん かるでぃなる あーく 〜こんとんのふうさつ〜
+  name: カルディナル アーク 〜混沌の封札〜【IFコレクション】
+  name-sort: かるでぃなる あーく 〜こんとんのふうさつ〜【IFこれくしょん】
   name-en: "Neverland Card War Cardinal Arc - Konton no Fuusatsu [Idea Factory Collection]"
   region: "NTSC-J"
 SLPM-62700:
-  name: BEST HIT セレクション プリンセスメーカー
-  name-sort: BEST HIT せれくしょん ぷりんせすめーかー
+  name: セレクション プリンセスメーカー【BEST HIT】
+  name-sort: せれくしょん ぷりんせすめーかー【BEST HIT】
   name-en: "Princess Maker [Best Hit Selection]"
   region: "NTSC-J"
 SLPM-62701:
-  name: BEST HIT セレクション プリンセスメーカー2
-  name-sort: BEST HIT せれくしょん ぷりんせすめーかー2
+  name: セレクション プリンセスメーカー2【BEST HIT】
+  name-sort: せれくしょん ぷりんせすめーかー2【BEST HIT】
   name-en: "Princess Maker 2 [Best Hit Selection]"
   region: "NTSC-J"
 SLPM-62702:
@@ -33698,8 +33698,8 @@ SLPM-62709:
   name-en: "Sega Ages 2500 Series Vol.23 - Sega Memorial Selection"
   region: "NTSC-J"
 SLPM-62710:
-  name: コーエー定番シリーズ 三國志VIII
-  name-sort: こーえーていばんしりーず さんごくしVIII
+  name: 三國志VIII【コーエー定番シリーズ】
+  name-sort: さんごくしVIII【こーえーていばんしりーず】
   name-en: "San Goku Shi VIII"
   region: "NTSC-J"
 SLPM-62711:
@@ -33809,8 +33809,8 @@ SLPM-62736:
   name-en: "Slotter Up Mania [Dorart Value Series]"
   region: "NTSC-J"
 SLPM-62737:
-  name: EA BEST HITS ラリーショックス&フリークスタイル モトクロス
-  name-sort: EA BEST HITS らりーしょっくす&ふりーくすたいる もとくろす
+  name: ラリーショックス&フリークスタイル モトクロス【EA BEST HITS】
+  name-sort: らりーしょっくす&ふりーくすたいる もとくろす【EA BEST HITS】
   name-en: "Rally Shox & Freestyle Motorcross [EA Best Hits]"
   region: "NTSC-J"
 SLPM-62738:
@@ -33851,13 +33851,13 @@ SLPM-62746:
   region: "NTSC-J"
   compat: 5
 SLPM-62747:
-  name: コーエー定番シリーズ ジーワン ジョッキー3
-  name-sort: こーえーていばんしりーず じーわん じょっきー3
+  name: ジーワン ジョッキー3【コーエー定番シリーズ】
+  name-sort: じーわん じょっきー3【こーえーていばんしりーず】
   name-en: "G1 Jockey 3 [Koei Selection Series]"
   region: "NTSC-J"
 SLPM-62748:
-  name: コーエー定番シリーズ 信長の野望・嵐世記 with パワーアップキット
-  name-sort: こーえーていばんしりーず のぶながのやぼう・らんせいき with ぱわーあっぷきっと
+  name: 信長の野望・嵐世記 with パワーアップキット【コーエー定番シリーズ】
+  name-sort: のぶながのやぼう・らんせいき with ぱわーあっぷきっと【こーえーていばんしりーず】
   name-en: "Nobunaga no Yabou - Renseiki [with Power-Up Kit] [Koei Selection Series]"
   region: "NTSC-J"
 SLPM-62749:
@@ -33909,8 +33909,8 @@ SLPM-62758:
   name-en: "River Ride Adventure featuring Salomon"
   region: "NTSC-J"
 SLPM-62759:
-  name: コーエー定番シリーズ 信長の野望・蒼天録
-  name-sort: こーえーていばんしりーず のぶながのやぼう・そうてんろく
+  name: 信長の野望・蒼天録【コーエー定番シリーズ】
+  name-sort: のぶながのやぼう・そうてんろく【こーえーていばんしりーず】
   name-en: "Nobunaga no Yabou - Soutenroku [Koei Selection Series]"
   region: "NTSC-J"
 SLPM-62760:
@@ -33927,8 +33927,8 @@ SLPM-62761:
   gsHWFixes:
     roundSprite: 2 # Fixes sprite ghosting.
 SLPM-62762:
-  name: コーエー定番シリーズ 三國志VIII withパワーアップキット
-  name-sort: こーえーていばんしりーず さんごくしVIII withぱわーあっぷきっと
+  name: 三國志VIII withパワーアップキット【コーエー定番シリーズ】
+  name-sort: さんごくしVIII withぱわーあっぷきっと【こーえーていばんしりーず】
   name-en: "Sangokushi VIII [with Power-Up Kit] [Koei Selection Series]"
   region: "NTSC-J"
 SLPM-62763:
@@ -35951,8 +35951,8 @@ SLPM-65338:
   name-en: "Juunikoku-ki - Guren no Shirube Koejin no Michi"
   region: "NTSC-J"
 SLPM-65339:
-  name: グローバル ザ ベスト 悪代官
-  name-sort: ぐろーばる ざ べすと あくだいかん
+  name: 悪代官【グローバル ザ ベスト】
+  name-sort: あくだいかん【ぐろーばる ざ べすと】
   name-en: "Akudaikan [Global The Best]"
   region: "NTSC-J"
 SLPM-65340:
@@ -36049,8 +36049,8 @@ SLPM-65358:
   region: "NTSC-J"
   compat: 5
 SLPM-65359:
-  name: ガストベストプライス ユーディーのアトリエ 〜グラムナート の錬金術士〜
-  name-sort: がすとべすとぷらいす ゆーでぃーのあとりえ 〜ぐらむなーと のれんきんじゅつし〜
+  name: ユーディーのアトリエ 〜グラムナート の錬金術士〜【ガストベストプライス】
+  name-sort: ゆーでぃーのあとりえ 〜ぐらむなーと のれんきんじゅつし〜【がすとべすとぷらいす】
   name-en: "Judie no Atelier - Gramnad no Renkinjutsushi [Gust Best Price]"
   region: "NTSC-J"
 SLPM-65361:
@@ -36972,13 +36972,13 @@ SLPM-65536:
   name: "Houshin Engi 2"
   region: "NTSC-J"
 SLPM-65537:
-  name: KOEI The Best 超・バトル封神
-  name-sort: KOEI The Best ちょう・ばとるほうしん
+  name: 超・バトル封神【KOEI The Best】
+  name-sort: ちょう・ばとるほうしん【KOEI The Best】
   name-en: "Chou Battle Houshin [Koei The Best]"
   region: "NTSC-J"
 SLPM-65538:
-  name: EA BEST HITS 007 ナイトファイア
-  name-sort: EA BEST HITS 007 ないとふぁいあ
+  name: 007 ナイトファイア【EA BEST HITS】
+  name-sort: 007 ないとふぁいあ【EA BEST HITS】
   name-en: "007 - Nightfire [EA Best Hits]"
   region: "NTSC-J"
   clampModes:
@@ -37001,8 +37001,8 @@ SLPM-65540:
   name-en: "Galaxy Angel - Moonlit Lovers [First Limited Edition]"
   region: "NTSC-J"
 SLPM-65541:
-  name: KOEI The Best 愛蔵版 アンジェリーク トロワ
-  name-sort: KOEI The Best あいぞうばん あんじぇりーく とろわ
+  name: 愛蔵版 アンジェリーク トロワ【KOEI The Best】
+  name-sort: あいぞうばん あんじぇりーく とろわ【KOEI The Best】
   name-en: "Angelique Trois - Aizouhen [Koei The Best]"
   region: "NTSC-J"
 SLPM-65542:
@@ -37147,8 +37147,8 @@ SLPM-65572:
   name-en: "Generation of Chaos 4"
   region: "NTSC-J"
 SLPM-65573:
-  name: Spike The Best WRC II ～EXTREME～
-  name-sort: Spike The Best WRC II ～EXTREME～
+  name: WRC II ～EXTREME～【Spike The Best】
+  name-sort: WRC II ～EXTREME～【Spike The Best】
   name-en: "WRC II Extreme [Spike The Best]"
   region: "NTSC-J"
   gameFixes:
@@ -37358,8 +37358,8 @@ SLPM-65613:
   name-en: "Yu-Gi-Oh! Capsule Monster Coliseum"
   region: "NTSC-J"
 SLPM-65614:
-  name: EA BEST HITS ニード・フォー・スピード アンダーグラウンド
-  name-sort: EA BEST HITS にーど・ふぉー・すぴーど あんだーぐらうんど
+  name: ニード・フォー・スピード アンダーグラウンド【EA BEST HITS】
+  name-sort: にーど・ふぉー・すぴーど あんだーぐらうんど【EA BEST HITS】
   name-en: "Need for Speed - Underground J"
   region: "NTSC-J"
   gameFixes:
@@ -37388,8 +37388,8 @@ SLPM-65619:
   name-en: "Tom Clancy's Ghost Recon - Jungle Storm"
   region: "NTSC-J"
 SLPM-65620:
-  name: グローバル ザ・ベスト 悪代官2～妄想伝～
-  name-sort: ぐろーばる ざ・べすと あくだいかん2～もうそうでん～
+  name: 悪代官2～妄想伝～【グローバル ザ・ベスト】
+  name-sort: あくだいかん2～もうそうでん～【ぐろーばる ざ・べすと】
   name-en: "Akudaikan 2 - Mousouden [Global The Best]"
   region: "NTSC-J"
 SLPM-65621:
@@ -37485,8 +37485,8 @@ SLPM-65635:
   name-en: "Bakuen Kakeshi Neverland Senki Zero"
   region: "NTSC-J"
 SLPM-65636:
-  name: KOEI The Best 三國志戦記2
-  name-sort: KOEI The Best さんごくしせんき2
+  name: 三國志戦記2【KOEI The Best】
+  name-sort: さんごくしせんき2【KOEI The Best】
   name-en: "Sangokushi Senki 2 [Koei The Best]"
   region: "NTSC-J"
 SLPM-65637:
@@ -37546,18 +37546,18 @@ SLPM-65647:
   clampModes:
     eeClampMode: 2 # Partially fixes battle animation.
 SLPM-65648:
-  name: EA BEST HITS メダルオブオナー 史上最大の作戦
-  name-sort: EA BEST HITS めだるおぶおなー しじょうさいだいのさくせん
+  name: メダルオブオナー 史上最大の作戦【EA BEST HITS】
+  name-sort: めだるおぶおなー しじょうさいだいのさくせん【EA BEST HITS】
   name-en: "Medal of Honor - Frontline [EA Best Hits]"
   region: "NTSC-J"
 SLPM-65649:
-  name: EA BEST HITS NBAストリート2 ダンク天国
-  name-sort: EA BEST HITS NBAすとりーと2 だんくてんごく
+  name: NBAストリート2 ダンク天国【EA BEST HITS】
+  name-sort: NBAすとりーと2 だんくてんごく【EA BEST HITS】
   name-en: "NBA Street Vol. 2 [EA Best Hits]"
   region: "NTSC-J"
 SLPM-65650:
-  name: EA BEST HITS ハリー・ポッターと賢者の石
-  name-sort: EA BEST HITS はりー・ぽったーとけんじゃのいし
+  name: ハリー・ポッターと賢者の石【EA BEST HITS】
+  name-sort: はりー・ぽったーとけんじゃのいし【EA BEST HITS】
   name-en: "Harry Potter and the Sorcerer's Stone [EA Best Hits]"
   region: "NTSC-J"
 SLPM-65651:
@@ -37625,8 +37625,8 @@ SLPM-65665:
   name-en: "BloodRayne"
   region: "NTSC-J"
 SLPM-65666:
-  name: EA BEST HITS NBAライブ2004
-  name-sort: EA BEST HITS NBAらいぶ2004
+  name: NBAライブ2004【EA BEST HITS】
+  name-sort: NBAらいぶ2004【EA BEST HITS】
   name-en: "NBA Live 2004 [EA Best Hits]"
   region: "NTSC-J"
   clampModes:
@@ -37705,8 +37705,8 @@ SLPM-65682:
   name-en: "Monochrome"
   region: "NTSC-J"
 SLPM-65683:
-  name: ガストベストプライス ヴィオラートのアトリエ～グラムナートの錬金術士2～
-  name-sort: がすとべすとぷらいす ゔぃおらーとのあとりえ～ぐらむなーとのれんきんじゅつし2～
+  name: ヴィオラートのアトリエ～グラムナートの錬金術士2～【ガストベストプライス】
+  name-sort: ゔぃおらーとのあとりえ～ぐらむなーとのれんきんじゅつし2～【がすとべすとぷらいす】
   name-en: "Violet no Atelier - Gramnad no Renkinjutsushi [Gust Best Price]"
   region: "NTSC-J"
   gsHWFixes:
@@ -37844,8 +37844,8 @@ SLPM-65701:
   name-en: "Ghost Hunter"
   region: "NTSC-J"
 SLPM-65702:
-  name: コーエー定番シリーズ 三國志戦記
-  name-sort: こーえーていばんしりーず さんごくしせんき
+  name: 三國志戦記 [コーエー定番シリーズ]
+  name-sort: さんごくしせんき [こーえーていばんしりーず]
   name-en: "Sangokushi Senki [Koei Collection Series]"
   region: "NTSC-J"
 SLPM-65703:
@@ -37889,8 +37889,8 @@ SLPM-65715:
   name-en: "Angelique Etoile"
   region: "NTSC-J"
 SLPM-65716:
-  name: KOEI The Best 凱歌の号砲 エアランドフォース
-  name-sort: KOEI The Best がいかのごうほう えあらんどふぉーす
+  name: 凱歌の号砲 エアランドフォース【KOEI The Best】
+  name-sort: がいかのごうほう えあらんどふぉーす【KOEI The Best】
   name-en: "Gaika no Gouhou - Air Land Force [Koei The Best]"
   region: "NTSC-J"
 SLPM-65717:
@@ -37921,8 +37921,8 @@ SLPM-65719:
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
 SLPM-65720:
-  name: KOEI The Best 真・三國無双2 猛将伝
-  name-sort: KOEI The Best しん・さんごくむそう2 もうしょうでん
+  name: 真・三國無双2 猛将伝【KOEI The Best】
+  name-sort: しん・さんごくむそう2 もうしょうでん【KOEI The Best】
   name-en: "Shin Sangoku Musou 2 Mushoden [Koei the Best]"
   region: "NTSC-J"
 SLPM-65721:
@@ -37946,8 +37946,8 @@ SLPM-65724:
   name-en: "Choro Q Works"
   region: "NTSC-J"
 SLPM-65725:
-  name: EA BEST HITS 007エブリシング オア ナッシング
-  name-sort: EA BEST HITS 007えぶりしんぐ おあ なっしんぐ
+  name: 007エブリシング オア ナッシング【EA BEST HITS】
+  name-sort: 007えぶりしんぐ おあ なっしんぐ【EA BEST HITS】
   name-en: "007 - Everything or Nothing [EA Best Hits]"
   region: "NTSC-J"
   gsHWFixes:
@@ -37955,8 +37955,8 @@ SLPM-65725:
     mipmap: 2 # Cleans up texture detail.
     trilinearFiltering: 1 # Smoothes out mipmapping.
 SLPM-65726:
-  name: EA BEST HITS スター・ウォーズ ジャンゴ・フェット
-  name-sort: EA BEST HITS すたー・うぉーず じゃんご・ふぇっと
+  name: スター・ウォーズ ジャンゴ・フェット【EA BEST HITS】
+  name-sort: すたー・うぉーず じゃんご・ふぇっと【EA BEST HITS】
   name-en: "Star Wars - Jango Fett [EA Best Hits]"
   region: "NTSC-J"
   compat: 5
@@ -37966,8 +37966,8 @@ SLPM-65726:
     vuClampMode: 3
     eeClampMode: 2 # Fixes missing/grey texture or geometry ingame.
 SLPM-65727:
-  name: EA BEST HITS ロード・オブ・ザ・リング/王の帰還
-  name-sort: EA BEST HITS ろーど・おぶ・ざ・りんぐ/おうのきかん
+  name: ロード・オブ・ザ・リング/王の帰還【EA BEST HITS】
+  name-sort: ろーど・おぶ・ざ・りんぐ/おうのきかん【EA BEST HITS】
   name-en: "Lord of the Rings, The - The Return of the King [EA Best Hits]"
   region: "NTSC-J"
 SLPM-65728:
@@ -38127,8 +38127,8 @@ SLPM-65752:
   clampModes:
     eeClampMode: 2 # Reduces FPU calculation errors.
 SLPM-65753:
-  name: コーエー定番シリーズ 決戦
-  name-sort: こーえーていばんしりーず けっせん
+  name: 決戦【コーエー定番シリーズ】
+  name-sort: けっせん【こーえーていばんしりーず】
   name-en: "Kessen [Koei Collection Series]"
   region: "NTSC-J"
 SLPM-65754:
@@ -38153,8 +38153,8 @@ SLPM-65756:
   name-en: "Tennis no Oji-Sama - Rush & Dream"
   region: "NTSC-J"
 SLPM-65757:
-  name: EA BEST HITS メダル オブ オナー ライジングサン
-  name-sort: EA BEST HITS めだる おぶ おなー らいじんぐさん
+  name: メダル オブ オナー ライジングサン【EA BEST HITS】
+  name-sort: めだる おぶ おなー らいじんぐさん【EA BEST HITS】
   name-en: "Medal of Honor - Rising Sun [EA Best Hits]"
   region: "NTSC-J"
 SLPM-65758:
@@ -38340,8 +38340,8 @@ SLPM-65791:
   name-en: "S.L.A.I. - Steel Lancer Arena International"
   region: "NTSC-J"
 SLPM-65793:
-  name: EA BEST HITS SSX3
-  name-sort: EA BEST HITS SSX3
+  name: SSX3【EA BEST HITS】
+  name-sort: SSX3【EA BEST HITS】
   name-en: "SSX 3 [EA Best Hits]"
   region: "NTSC-J"
   gsHWFixes:
@@ -38415,13 +38415,13 @@ SLPM-65801:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
 SLPM-65802:
-  name: EA BEST HITS DEF JAM VENDETTA
-  name-sort: EA BEST HITS DEF JAM VENDETTA
+  name: DEF JAM VENDETTA【EA BEST HITS】
+  name-sort: DEF JAM VENDETTA【EA BEST HITS】
   name-en: "Def Jam - Vendetta [EA Best Hits]"
   region: "NTSC-J"
 SLPM-65803:
-  name: EA BEST HITS フリーダム・ファイターズ
-  name-sort: EA BEST HITS ふりーだむ・ふぁいたーず
+  name: フリーダム・ファイターズ【EA BEST HITS】
+  name-sort: ふりーだむ・ふぁいたーず【EA BEST HITS】
   name-en: "Freedom Fighters [EA Best Hits]"
   region: "NTSC-J"
 SLPM-65804:
@@ -38568,8 +38568,8 @@ SLPM-65832:
   name-en: "Izumo Complete"
   region: "NTSC-J"
 SLPM-65833:
-  name: KOEI The Best 遙かなる時空の中で 2
-  name-sort: KOEI The Best はるかなるときのなかで 2
+  name: 遙かなる時空の中で 2【KOEI The Best】
+  name-sort: はるかなるときのなかで 2【KOEI The Best】
   name-en: "Harukanaru Jikuu no Naka De 2 [Koei the Best]"
   region: "NTSC-J"
 SLPM-65834:
@@ -39014,8 +39014,8 @@ SLPM-65916:
   name-en: "Harukanaru Jikuu no Kade - Hachiha Katsunori"
   region: "NTSC-J"
 SLPM-65917:
-  name: THE BEST タカラモノ トランスフォーマー
-  name-sort: THE BEST たからもの とらんすふぉーまー
+  name: トランスフォーマー【THE BEST タカラモノ】
+  name-sort: とらんすふぉーまー【THE BEST たからもの】
   name-en: "Transformers Tatakai [The Best]"
   region: "NTSC-J"
 SLPM-65918:
@@ -39093,8 +39093,8 @@ SLPM-65930:
   name-en: "EVE - Burst Error Plus [GameBridge The Best]"
   region: "NTSC-J"
 SLPM-65931:
-  name: IFコレクション 新紀幻想スペクトラルソウルズ
-  name-sort: IFこれくしょん しんきげんそうすぺくとらるそうるず
+  name: 新紀幻想スペクトラルソウルズ【IFコレクション】
+  name-sort: しんきげんそうすぺくとらるそうるず【IFこれくしょん】
   name-en: "Shinseiki Genso - Spectral Souls [IF Collection]"
   region: "NTSC-J"
 SLPM-65932:
@@ -39214,13 +39214,13 @@ SLPM-65953:
   name-en: "Final Fantasy XI [Entry Disc 2005]"
   region: "NTSC-J"
 SLPM-65954:
-  name: ユービーアイベスト トム・クランシーシリーズ ゴーストリコン
-  name-sort: ゆーびーあいべすと とむ・くらんしーしりーず ごーすとりこん
+  name: トム・クランシーシリーズ ゴーストリコン【ユービーアイベスト】
+  name-sort: とむ・くらんしーしりーず ごーすとりこん【ゆーびーあいべすと】
   name-en: "Tom Clancy's Ghost Recon [Ubisoft Best]"
   region: "NTSC-J"
 SLPM-65955:
-  name: ユービーアイソフトベスト トム・クランシーシリーズ スプリンターセル
-  name-sort: ゆーびーあいそふとべすと とむ・くらんしーしりーず すぷりんたーせる
+  name: トム・クランシーシリーズ スプリンターセル【ユービーアイソフトベスト】
+  name-sort: とむ・くらんしーしりーず すぷりんたーせる【ゆーびーあいそふとべすと】
   name-en: "Tom Clancy's Splinter Cell [Ubisoft Best]"
   region: "NTSC-J"
 SLPM-65957:
@@ -39229,8 +39229,8 @@ SLPM-65957:
   name-en: "Harukanaru Jikuu no Kade Hachiha Katsunori"
   region: "NTSC-J"
 SLPM-65958:
-  name: EA BEST HITS バーンアウト3:テイクダウン
-  name-sort: EA BEST HITS ばーんあうと3:ていくだうん
+  name: バーンアウト3:テイクダウン【EA BEST HITS】
+  name-sort: ばーんあうと3:ていくだうん【EA BEST HITS】
   name-en: "Burnout 3 - Takedown [EA Best Hits]"
   region: "NTSC-J"
   clampModes:
@@ -39351,20 +39351,22 @@ SLPM-65975:
   roundModes:
     eeRoundMode: 2 # Fixes rainbow highlighting on cars.
 SLPM-65976:
-  name: グランディアIII
-  name-sort: ぐらんでぃあIII
+  name: グランディアIII [ディスク1/2]
+  name-sort: ぐらんでぃあIII [でぃすく1/2]
   name-en: "Grandia III [Disc 1 of 2]"
   region: "NTSC-J"
   compat: 5
 SLPM-65977:
-  name: "Grandia III [Disc 2 of 2]"
+  name: グランディアIII [ディスク2/2]
+  name-sort: ぐらんでぃあIII [でぃすく2/2]
+  name-en: "Grandia III [Disc 2 of 2]"
   region: "NTSC-J"
   compat: 5
   memcardFilters:
     - "SLPM-65976"
 SLPM-65978:
-  name: KOEI THE BEST 鋼鉄の咆哮2 ウォーシップガンナー
-  name-sort: KOEI THE BEST くろがねのほうこう2 うぉーしっぷがんなー
+  name: 鋼鉄の咆哮2 ウォーシップガンナー【KOEI THE BEST】
+  name-sort: くろがねのほうこう2 うぉーしっぷがんなー【KOEI THE BEST】
   name-en: "Kurogane no Houkou 2 - Warship Gunner [Koei The Best]"
   region: "NTSC-J"
 SLPM-65980:
@@ -39506,8 +39508,8 @@ SLPM-66005:
   name: "Harukanaru Toki no Naka de 3"
   region: "NTSC-J"
 SLPM-66006:
-  name: コーエー定番シリーズ 愛蔵版 アンジェリークトロワ
-  name-sort: こーえーていばんしりーず あいぞうばん あんじぇりーくとろわ
+  name: 愛蔵版 アンジェリークトロワ【コーエー定番シリーズ】
+  name-sort: あいぞうばん あんじぇりーくとろわ【こーえーていばんしりーず】
   name-en: "Angelique Trois - Aizouhen [Koei Selection]"
   region: "NTSC-J"
 SLPM-66007:
@@ -39619,8 +39621,8 @@ SLPM-66024:
   name-en: "Fushigi Yuugi - ShigiYuugi Kurotake Kaiden Gaiden - Kagami no Fujo"
   region: "NTSC-J"
 SLPM-66025:
-  name: IFコレクション 新天魔界ジェネレーション オブ カオスIV
-  name-sort: IFこれくしょん しんてんまかいじぇねれーしょん おぶ かおすIV
+  name: 新天魔界ジェネレーション オブ カオスIV【IFコレクション】
+  name-sort: しんてんまかいじぇねれーしょん おぶ かおすIV【IFこれくしょん】
   name-en: "Generation of Chaos IV [Idea Factory Collection]"
   region: "NTSC-J"
 SLPM-66026:
@@ -39749,8 +39751,8 @@ SLPM-66050:
   name-en: "Daisan Teikoku Koubouki II - Aufstieg und Fall des Dritten Reich"
   region: "NTSC-J"
 SLPM-66051:
-  name: EA BEST HITS ニード・フォー・スピード アンダーグラウンド2 車道
-  name-sort: EA BEST HITS にーど・ふぉー・すぴーど あんだーぐらうんど2 しゃどう
+  name: ニード・フォー・スピード アンダーグラウンド2 車道【EA BEST HITS】
+  name-sort: にーど・ふぉー・すぴーど あんだーぐらうんど2 しゃどう【EA BEST HITS】
   name-en: "Need for Speed Underground 2 [EA Best Hits] - SHA_DO"
   region: "NTSC-J"
   gsHWFixes:
@@ -39916,8 +39918,8 @@ SLPM-66079:
   name: "Medal of Honor - Europe Kyoushuu"
   region: "NTSC-J"
 SLPM-66080:
-  name: IFコレクション GENERATION OF CHAOSIII 〜時の封印〜
-  name-sort: IFこれくしょん GENERATION OF CHAOSIII 〜ときのふういん〜
+  name: GENERATION OF CHAOSIII 〜時の封印〜【IFコレクション】
+  name-sort: GENERATION OF CHAOSIII 〜ときのふういん〜【IFこれくしょん】
   name-en: "Generation of Chaos 3 [IF Collection]"
   region: "NTSC-J"
 SLPM-66081:
@@ -39992,21 +39994,21 @@ SLPM-66092:
   gsHWFixes:
     roundSprite: 1 # Fixes vertical and horizontal lines.
 SLPM-66093:
-  name: コーエー定番シリーズ 決戦II
-  name-sort: こーえーていばんしりーず けっせんII
+  name: 決戦II【コーエー定番シリーズ】
+  name-sort: けっせんII【こーえーていばんしりーず】
   name-en: "Kessen II [Koei Selection Series]"
   region: "NTSC-J"
 SLPM-66094:
-  name: コーエー定番シリーズ 真・三國無双2
-  name-sort: こーえーていばんしりーず しん・さんごくむそう2
+  name: 真・三國無双2【コーエー定番シリーズ】
+  name-sort: しん・さんごくむそう2【こーえーていばんしりーず】
   name-en: "Shin Sangoku Musou 2 [Koei Selection Series]"
   region: "NTSC-J"
 SLPM-66095:
   name: "Chou Battle Houshin"
   region: "NTSC-J"
 SLPM-66096:
-  name: コーエー定番シリーズ 真・三國無双2猛将伝
-  name-sort: こーえーていばんしりーず しん・さんごくむそう2もうしょうでん
+  name: 真・三國無双2猛将伝【コーエー定番シリーズ】
+  name-sort: しん・さんごくむそう2もうしょうでん【こーえーていばんしりーず】
   name-en: "Shin Sangoku Musou 2 - Mushoden [Koei Selection Series]"
   region: "NTSC-J"
 SLPM-66097:
@@ -40045,8 +40047,8 @@ SLPM-66102:
   gsHWFixes:
     roundSprite: 1 # Fixes vertical lines.
 SLPM-66103:
-  name: スパイク ザ ベスト WRC3
-  name-sort: すぱいく ざ べすと WRC3
+  name: WRC3【スパイク ザ ベスト】
+  name-sort: WRC3【すぱいく ざ べすと】
   name-en: "WRC 3 [Spike the Best]"
   region: "NTSC-J"
   compat: 5
@@ -40140,8 +40142,8 @@ SLPM-66115:
   name-en: "Mizu no Senritsu"
   region: "NTSC-J"
 SLPM-66116:
-  name: EA BEST HITS NBA ライブ 2005
-  name-sort: EA BEST HITS NBA らいぶ 2005
+  name: NBA ライブ 2005【EA BEST HITS】
+  name-sort: NBA らいぶ 2005【EA BEST HITS】
   name-en: "NBA Live 2005 [EA Best Hits]"
   region: "NTSC-J"
 SLPM-66117:
@@ -40189,18 +40191,18 @@ SLPM-66121:
     halfPixelOffset: 2 # Fixes shadows.
     gpuPaletteConversion: 0 # Stops potential crashes from too many palette textures.
 SLPM-66122:
-  name: アルティメット ヒッツ キングダム ハーツ
-  name-sort: あるてぃめっと ひっつ きんぐだむ はーつ
+  name: キングダム ハーツ【アルティメット ヒッツ】
+  name-sort: きんぐだむ はーつ【あるてぃめっと ひっつ】
   name-en: "Kingdom Hearts [Ultimate Hits]"
   region: "NTSC-J"
 SLPM-66123:
-  name: アルティメット ヒッツ キングダム ハーツ -ファイナル   ミックス-
-  name-sort: あるてぃめっと ひっつ きんぐだむ はーつ -ふぁいなる   みっくす-
+  name: キングダム ハーツ -ファイナル   ミックス-【アルティメット ヒッツ】
+  name-sort: きんぐだむ はーつ -ふぁいなる   みっくす-【あるてぃめっと ひっつ】
   name-en: "Kingdom Hearts - Final Mix [Ultimate Hits]"
   region: "NTSC-J"
 SLPM-66124:
-  name: アルティメット ヒッツ ファイナルファンタジー X
-  name-sort: あるてぃめっと ひっつ ふぁいなるふぁんたじー X
+  name: ファイナルファンタジー X【アルティメット ヒッツ】
+  name-sort: ふぁいなるふぁんたじー X【あるてぃめっと ひっつ】
   name-en: "Final Fantasy X [Ultimate Hits]"
   region: "NTSC-J"
   roundModes:
@@ -40208,8 +40210,8 @@ SLPM-66124:
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
 SLPM-66125:
-  name: アルティメット ヒッツ ファイナルファンタジー X-2
-  name-sort: あるてぃめっと ひっつ ふぁいなるふぁんたじー X-2
+  name: ファイナルファンタジー X-2【アルティメット ヒッツ】
+  name-sort: ふぁいなるふぁんたじー X-2【あるてぃめっと ひっつ】
   name-en: "Final Fantasy X-2 [Ultimate Hits]"
   region: "NTSC-J"
   gameFixes:
@@ -40321,8 +40323,8 @@ SLPM-66144:
   clampModes:
     eeClampMode: 3 # Fixes black screen.
 SLPM-66145:
-  name: EA BEST HITS ゴールデンアイ ダークエージェント
-  name-sort: EA BEST HITS ごーるでんあい だーくえーじぇんと
+  name: ゴールデンアイ ダークエージェント【EA BEST HITS】
+  name-sort: ごーるでんあい だーくえーじぇんと【EA BEST HITS】
   name-en: "GoldenEye - Rogue Agent [EA Best Hits]"
   region: "NTSC-J"
 SLPM-66146:
@@ -40336,8 +40338,8 @@ SLPM-66147:
   name-en: "Memories Off #5 - Togireta Film"
   region: "NTSC-J"
 SLPM-66148:
-  name: EA BEST HITS スターウォーズ バトルフロント
-  name-sort: EA BEST HITS すたーうぉーず ばとるふろんと
+  name: スターウォーズ バトルフロント【EA BEST HITS】
+  name-sort: すたーうぉーず ばとるふろんと【EA BEST HITS】
   name-en: "Star Wars - Battlefront [EA Best Hits]"
   region: "NTSC-J"
   gsHWFixes:
@@ -40979,8 +40981,8 @@ SLPM-66250:
   name-en: "Choro Q HG 4 [Takara Best]"
   region: "NTSC-J"
 SLPM-66251:
-  name: アトラスベストコレクション EX人生ゲームII
-  name-sort: あとらすべすとこれくしょん EXじんせいげーむII
+  name: EX人生ゲームII【アトラスベストコレクション】
+  name-sort: EXじんせいげーむII【あとらすべすとこれくしょん】
   name-en: "EX Jinsei Game II [Takara Best]"
   region: "NTSC-J"
   gsHWFixes:
@@ -41043,8 +41045,8 @@ SLPM-66261:
     halfPixelOffset: 2 # Fixes misaligned bloom.
     autoFlush: 2 # Fixes misaligned bloom on sun.
 SLPM-66262:
-  name: ユービーアイソフトベスト トム・クランシーシリーズ レインボーシックス3
-  name-sort: ゆーびーあいそふとべすと とむ・くらんしーしりーず れいんぼーしっくす3
+  name: トム・クランシーシリーズ レインボーシックス3【ユービーアイソフトベスト】
+  name-sort: とむ・くらんしーしりーず れいんぼーしっくす3【ゆーびーあいそふとべすと】
   name-en: "Tom Clancy's Rainbow Six 3 [Ubisoft The Best]"
   region: "NTSC-J"
 SLPM-66263:
@@ -41065,13 +41067,13 @@ SLPM-66265:
   name-en: "Canvas 2 - Nijiiro no Sketch"
   region: "NTSC-J"
 SLPM-66266:
-  name: KOEI The Best 鋼鉄の咆哮2 ウォーシップコマンダー
-  name-sort: KOEI The Best くろがねのほうこう2 うぉーしっぷこまんだー
+  name: 鋼鉄の咆哮2 ウォーシップコマンダー【KOEI The Best】
+  name-sort: くろがねのほうこう2 うぉーしっぷこまんだー【KOEI The Best】
   name-en: "Kurogane no Houkou 2 - Warship Commander [Koei The Best]"
   region: "NTSC-J"
 SLPM-66267:
-  name: KOEI The Best 太閤立志伝V
-  name-sort: KOEI The Best たいこうりっしでんV
+  name: 太閤立志伝V【KOEI The Best】
+  name-sort: たいこうりっしでんV【KOEI The Best】
   name-en: "Taikou Risshiden V"
   region: "NTSC-J"
 SLPM-66268:
@@ -41470,8 +41472,8 @@ SLPM-66333:
   region: "NTSC-J"
   compat: 5
 SLPM-66334:
-  name: Spike the Best WRC4
-  name-sort: Spike the Best WRC4
+  name: WRC4【Spike the Best】
+  name-sort: WRC4【Spike the Best】
   name-en: "WRC 4 [Spike the Best]"
   region: "NTSC-J"
   gameFixes:
@@ -41555,8 +41557,8 @@ SLPM-66348:
   name-en: "Harukanaru Jikuu no Kade 3 - Unmei no Meikyuu"
   region: "NTSC-J"
 SLPM-66349:
-  name: IFコレクション スペクトラルフォース クロニクル
-  name-sort: IFこれくしょん すぺくとらるふぉーす くろにくる
+  name: スペクトラルフォース クロニクル【IFコレクション】
+  name-sort: すぺくとらるふぉーす くろにくる【IFこれくしょん】
   name-en: "Spectral Force Chronicle"
   region: "NTSC-J"
 SLPM-66350:
@@ -41655,15 +41657,15 @@ SLPM-66371:
   name-en: "Train Simulator & Densha de Go! Tokyo Kyuukouhen [Ongakukan Pocket Books]"
   region: "NTSC-J"
 SLPM-66372:
-  name: ATLUS BEST COLLECTION DIGITAL DEVIL SAGA 〜アバタール・チューナー〜
-  name-sort: ATLUS BEST COLLECTION DIGITAL DEVIL SAGA 〜あばたーる・ちゅーなー〜
+  name: DIGITAL DEVIL SAGA 〜アバタール・チューナー〜【ATLUS BEST COLLECTION】
+  name-sort: DIGITAL DEVIL SAGA 〜あばたーる・ちゅーなー〜【ATLUS BEST COLLECTION】
   name-en: "Digital Devil Saga - Avatar Tuner [Atlus Best Collection]"
   region: "NTSC-J"
   gameFixes:
     - EETimingHack
 SLPM-66373:
-  name: ATLUS BEST COLLECTION DIGITAL DEVIL SAGA 〜アバタール・チューナー2〜
-  name-sort: ATLUS BEST COLLECTION DIGITAL DEVIL SAGA 〜あばたーる・ちゅーなー2〜
+  name: DIGITAL DEVIL SAGA 〜アバタール・チューナー2〜【ATLUS BEST COLLECTION】
+  name-sort: DIGITAL DEVIL SAGA 〜あばたーる・ちゅーなー2〜【ATLUS BEST COLLECTION】
   name-en: "Digital Devil Saga - Avatar Tuner 2 [Atlus Best Collection]"
   region: "NTSC-J"
   gameFixes:
@@ -41752,13 +41754,13 @@ SLPM-66386:
   name-en: "FIFA World Cup - Germany 2006"
   region: "NTSC-J"
 SLPM-66387:
-  name: Spike The Best 真・爆走デコトラ伝説 〜天下統一頂上決戦〜
-  name-sort: Spike The Best しん・ばくそうでことらでんせつ 〜てんかとういつちょうじょうけっせん〜
+  name: 真・爆走デコトラ伝説 〜天下統一頂上決戦〜【Spike The Best】
+  name-sort: しん・ばくそうでことらでんせつ 〜てんかとういつちょうじょうけっせん〜【Spike The Best】
   name-en: "Shin Bakusou Dekotora Densetsu [Spike the Best]"
   region: "NTSC-J"
 SLPM-66388:
-  name: Spike The Best ファイプロ・リターンズ
-  name-sort: Spike The Best ふぁいぷろ・りたーんず
+  name: ファイプロ・リターンズ【Spike The Best】
+  name-sort: ふぁいぷろ・りたーんず【Spike The Best】
   name-en: "Fire Pro Wrestling Returns [Spike The Best]"
   region: "NTSC-J"
 SLPM-66390:
@@ -41937,23 +41939,23 @@ SLPM-66419:
     textureInsideRT: 1 # Required for swirl battle transition.
     nativePaletteDraw: 1
 SLPM-66420:
-  name: アルティメット ヒッツ フロントミッション4
-  name-sort: あるてぃめっと ひっつ ふろんとみっしょん4
+  name: フロントミッション4【アルティメット ヒッツ】
+  name-sort: ふろんとみっしょん4【あるてぃめっと ひっつ】
   name-en: "Front Mission 4 [Ultimate Hits]"
   region: "NTSC-J"
   gsHWFixes:
     preloadFrameData: 1 # Fixes mech shadows.
     roundSprite: 2 # Fixes font artifacts.
 SLPM-66421:
-  name: アルティメット ヒッツ フロントミッション5 〜Scars of the War〜
-  name-sort: あるてぃめっと ひっつ ふろんとみっしょん5 〜Scars of the War〜
+  name: フロントミッション5 〜Scars of the War〜【アルティメット ヒッツ】
+  name-sort: ふろんとみっしょん5 〜Scars of the War〜【あるてぃめっと ひっつ】
   name-en: "Front Mission 5 - Scars of the War [Ultimate Hits]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 1 # Fixes blurriness but no fix for font or other artifacts possible with round sprite.
 SLPM-66422:
-  name: Ultimate Hits Romancing SaGa −Minstrel Song−
-  name-sort: Ultimate Hits Romancing SaGa -Minstrel Song-
+  name: Romancing SaGa −Minstrel Song−【Ultimate Hits】
+  name-sort: Romancing SaGa -Minstrel Song-【Ultimate Hits】
   name-en: "Romancing Saga - Minstrel Song [Ultimate Hits]"
   region: "NTSC-J"
 SLPM-66424:
@@ -42152,8 +42154,8 @@ SLPM-66454:
   name-en: "Hiiro no Kakera"
   region: "NTSC-J"
 SLPM-66455:
-  name: IFコレクション スペクトラルフォース ラジカルエレメンツ
-  name-sort: IFこれくしょん すぺくとらるふぉーす らじかるえれめんつ
+  name: スペクトラルフォース ラジカルエレメンツ【IFコレクション】
+  name-sort: すぺくとらるふぉーす らじかるえれめんつ【IFこれくしょん】
   name-en: "Spectral Force - Radical Elements [IF Collection]"
   region: "NTSC-J"
 SLPM-66456:
@@ -42217,18 +42219,18 @@ SLPM-66462:
   name-en: "Disney-Pixar's Cars"
   region: "NTSC-J"
 SLPM-66463:
-  name: EA BEST HITS デフジャム・ファイト・フォー・NY
-  name-sort: EA BEST HITS でふじゃむ・ふぁいと・ふぉー・NY
+  name: デフジャム・ファイト・フォー・NY【EA BEST HITS】
+  name-sort: でふじゃむ・ふぁいと・ふぉー・NY【EA BEST HITS】
   name-en: "Def Jam - Fight for NY [EA Best Hits]"
   region: "NTSC-J"
 SLPM-66464:
-  name: EA BEST HITS MVP ベースボール2005
-  name-sort: EA BEST HITS MVP べーすぼーる2005
+  name: MVP ベースボール2005【EA BEST HITS】
+  name-sort: MVP べーすぼーる2005【EA BEST HITS】
   name-en: "MVP Baseball 2005 [EA Best Hits]"
   region: "NTSC-J"
 SLPM-66465:
-  name: EA BEST HITS マーセナリーズ
-  name-sort: EA BEST HITS まーせなりーず
+  name: マーセナリーズ【EA BEST HITS】
+  name-sort: まーせなりーず【EA BEST HITS】
   name-en: "Mercenaries - Playground of Destruction [EA Best Hits]"
   region: "NTSC-J"
   gsHWFixes:
@@ -42305,8 +42307,8 @@ SLPM-66477:
   name-en: "Kamiwaza"
   region: "NTSC-J"
 SLPM-66478:
-  name: アルティメット ヒッツ スターオーシャン Till the End of Time ディレクターズカット [ディスク1/2]
-  name-sort: あるてぃめっと ひっつ すたーおーしゃん Till the End of Time でぃれくたーずかっと [でぃすく1/2]
+  name: スターオーシャン Till the End of Time ディレクターズカット [ディスク1/2]【アルティメット ヒッツ】
+  name-sort: すたーおーしゃん Till the End of Time でぃれくたーずかっと [でぃすく1/2]【あるてぃめっと ひっつ】
   name-en: "Star Ocean 3 - Till the End of Time [Ultimate Hits] [Disc 1 of 2]"
   region: "NTSC-J"
   compat: 5
@@ -42317,8 +42319,8 @@ SLPM-66478:
     roundSprite: 1 # Fixes door transition vertical lines and mini-map artifacts.
     textureInsideRT: 1 # Fixes missing battle effects.
 SLPM-66479:
-  name: アルティメット ヒッツ スターオーシャン Till the End of Time ディレクターズカット [ディスク2/2]
-  name-sort: あるてぃめっと ひっつ すたーおーしゃん Till the End of Time でぃれくたーずかっと [でぃすく2/2]
+  name: スターオーシャン Till the End of Time ディレクターズカット [ディスク2/2]【アルティメット ヒッツ】
+  name-sort: すたーおーしゃん Till the End of Time でぃれくたーずかっと [でぃすく2/2]【あるてぃめっと ひっつ】
   name-en: "Star Ocean 3 - Till the End of Time [Ultimate Hits] [Disc 2 of 2]"
   region: "NTSC-J"
   compat: 5
@@ -42331,14 +42333,14 @@ SLPM-66479:
   memcardFilters:
     - "SLPM-66478"
 SLPM-66480:
-  name: アルティメット ヒッツ ドラゴンクエスト V 天空の花嫁
-  name-sort: あるてぃめっと ひっつ どらごんくえすと V てんくうのはなよめ
+  name: ドラゴンクエスト V 天空の花嫁【アルティメット ヒッツ】
+  name-sort: どらごんくえすと V てんくうのはなよめ【あるてぃめっと ひっつ】
   name-en: "Dragon Quest V - Bride of the Sky [Ultimate Hits]"
   region: "NTSC-J"
   compat: 5
 SLPM-66481:
-  name: アルティメット ヒッツ ドラゴンクエスト VIII 空と海と大地と呪われし姫君
-  name-sort: あるてぃめっと ひっつ どらごんくえすと VIII そらとうみとだいちとのろわれしひめぎみ
+  name: ドラゴンクエスト VIII 空と海と大地と呪われし姫君【アルティメット ヒッツ】
+  name-sort: どらごんくえすと VIII そらとうみとだいちとのろわれしひめぎみ【あるてぃめっと ひっつ】
   name-en: "Dragon Quest VIII [Ultimate Hits]"
   region: "NTSC-J"
   gsHWFixes:
@@ -42400,8 +42402,8 @@ SLPM-66492:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes lighting misalignment.
 SLPM-66493:
-  name: IFコレクション 新天魔界 ジェネレーション オブ カオスV
-  name-sort: IFこれくしょん しんてんまかい じぇねれーしょん おぶ かおすV
+  name: 新天魔界 ジェネレーション オブ カオスV【IFコレクション】
+  name-sort: しんてんまかい じぇねれーしょん おぶ かおすV【IFこれくしょん】
   name-en: "Shinten Makai - Generation of Chaos V [IF Collection]"
   region: "NTSC-J"
 SLPM-66494:
@@ -42422,8 +42424,8 @@ SLPM-66495:
         // This patch skips over the stack code, allowing the game to boot.
         patch=1,EE,00149F18,word,10000003
 SLPM-66496:
-  name: ユービーアイソフト ベスト トム・クランシーシリーズ スプリンターセル カオスセオリー
-  name-sort: ゆーびーあいそふと べすと とむ・くらんしーしりーず すぷりんたーせる かおすせおりー
+  name: トム・クランシーシリーズ スプリンターセル カオスセオリー【ユービーアイソフト ベスト】
+  name-sort: とむ・くらんしーしりーず すぷりんたーせる かおすせおりー【ゆーびーあいそふと べすと】
   name-en: "Tom Clancy's Splinter Cell - Chaos Theory"
   region: "NTSC-J"
 SLPM-66497:
@@ -42531,20 +42533,20 @@ SLPM-66513:
   name-en: "Fate-stay Night - Realta Nua"
   region: "NTSC-J"
 SLPM-66514:
-  name: EA BEST HITS メダル オブ オナー ヨーロッパ強襲
-  name-sort: EA BEST HITS めだる おぶ おなー よーろっぱきょうしゅう
+  name: メダル オブ オナー ヨーロッパ強襲【EA BEST HITS】
+  name-sort: めだる おぶ おなー よーろっぱきょうしゅう【EA BEST HITS】
   name-en: "Medal of Honor - European Assault [EA Best Hits]"
   region: "NTSC-J"
 SLPM-66515:
-  name: EA BEST HITS スター・ウォーズ エピソード3 シスの復讐
-  name-sort: EA BEST HITS すたー・うぉーず えぴそーど3 しすのふくしゅう
+  name: スター・ウォーズ エピソード3 シスの復讐【EA BEST HITS】
+  name-sort: すたー・うぉーず えぴそーど3 しすのふくしゅう【EA BEST HITS】
   name-en: "Star Wars - Episode III - Sith no Fukushuu [EA Best Hits]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 1 # Fixes bloom misalignment.
 SLPM-66516:
-  name: EA BEST HITS ザ・シムズ&ザ・アーブズ シムズ・イン・ザ・シティ
-  name-sort: EA BEST HITS ざ・しむず&ざ・あーぶず しむず・いん・ざ・してぃ
+  name: ザ・シムズ&ザ・アーブズ シムズ・イン・ザ・シティ【EA BEST HITS】
+  name-sort: ざ・しむず&ざ・あーぶず しむず・いん・ざ・してぃ【EA BEST HITS】
   name-en: "Sims, The & The Urbz - Sims in the City [EA Best Hits]"
   region: "NTSC-J"
   gsHWFixes:
@@ -42574,43 +42576,43 @@ SLPM-66521:
   region: "NTSC-J"
   compat: 5
 SLPM-66522:
-  name: コーエー定番シリーズ 真・三國無双3
-  name-sort: こーえーていばんしりーず しん・さんごくむそう3
+  name: 真・三國無双3【コーエー定番シリーズ】
+  name-sort: しん・さんごくむそう3【こーえーていばんしりーず】
   name-en: "Shin Sangoku Musou 3 [KOEI Selection]"
   region: "NTSC-J"
 SLPM-66523:
-  name: KOEI The Best 三國志IX with パワーアップキット
-  name-sort: KOEI The Best さんごくしIX with ぱわーあっぷきっと
+  name: 三國志IX with パワーアップキット【KOEI The Best】
+  name-sort: さんごくしIX with ぱわーあっぷきっと【KOEI The Best】
   name-en: "Sangokushi IX [with Power-Up Kit]"
   region: "NTSC-J"
 SLPM-66524:
-  name: KOEI The Best アンジェリーク エトワール
-  name-sort: KOEI The Best あんじぇりーく えとわーる
+  name: アンジェリーク エトワール【KOEI The Best】
+  name-sort: あんじぇりーく えとわーる【KOEI The Best】
   name-en: "Angelique Etoile [Koei Best]"
   region: "NTSC-J"
 SLPM-66525:
-  name: KOEI The Best Zill O’ll 〜infinite〜
-  name-sort: KOEI The Best Zill O’ll 〜infinite〜
+  name: Zill O’ll 〜infinite〜【KOEI The Best】
+  name-sort: Zill O’ll 〜infinite〜【KOEI The Best】
   name-en: "Zill O'll Infinite [Koei The Best]"
   region: "NTSC-J"
 SLPM-66526:
-  name: コーエー定番シリーズ 凱歌の号砲 エアランドフォース
-  name-sort: こーえーていばんしりーず がいかのごうほう えあらんどふぉーす
+  name: 凱歌の号砲 エアランドフォース【コーエー定番シリーズ】
+  name-sort: がいかのごうほう えあらんどふぉーす【こーえーていばんしりーず】
   name-en: "Gaika no Gouhou - Air Land Force [KOEI Selection]"
   region: "NTSC-J"
 SLPM-66527:
-  name: コーエー定番シリーズ 三國志戦記2
-  name-sort: こーえーていばんしりーず さんごくしせんき2
+  name: 三國志戦記2【コーエー定番シリーズ】
+  name-sort: さんごくしせんき2【こーえーていばんしりーず】
   name-en: "Sangokushi Senki 2 [KOEI Selection]"
   region: "NTSC-J"
 SLPM-66528:
-  name: KOEI The Best 信長の野望・天下創世 with パワーアップキット
-  name-sort: KOEI The Best のぶながのやぼう・てんかそうせい with ぱわーあっぷきっと
+  name: 信長の野望・天下創世 with パワーアップキット【KOEI The Best】
+  name-sort: のぶながのやぼう・てんかそうせい with ぱわーあっぷきっと【KOEI The Best】
   name-en: "Nobunaga no Yabou - Tenka Sousei [with Power Up Kit] [KOEI the Best]"
   region: "NTSC-J"
 SLPM-66529:
-  name: KOEI The Best 亡国のイージス 2035 〜ウォーシップガンナー〜
-  name-sort: KOEI The Best ぼうこくのいーじす 2035 〜うぉーしっぷがんなー〜
+  name: 亡国のイージス 2035 〜ウォーシップガンナー〜【KOEI The Best】
+  name-sort: ぼうこくのいーじす 2035 〜うぉーしっぷがんなー〜【KOEI The Best】
   name-en: "Boukoku no Aegis 2035 - Warship Gunner [KOEI the Best]"
   region: "NTSC-J"
 SLPM-66530:
@@ -42649,8 +42651,8 @@ SLPM-66536:
   name-en: "Aria - The Natural - Tooi Yume no Mirage"
   region: "NTSC-J"
 SLPM-66537:
-  name: ガスト ベスト プライス イリスのアトリエ エターナルマナ2
-  name-sort: がすと べすと ぷらいす いりすのあとりえ えたーなるまな2
+  name: イリスのアトリエ エターナルマナ2【ガスト ベスト プライス】
+  name-sort: いりすのあとりえ えたーなるまな2【がすと べすと ぷらいす】
   name-en: "Iris no Atelier - Eternal Mana 2 [Gust Best Price]"
   region: "NTSC-J"
   gameFixes:
@@ -42728,15 +42730,15 @@ SLPM-66555:
   name-en: "SuperLite 2000 Series - Tokyo Bus Guide 2"
   region: "NTSC-J"
 SLPM-66556:
-  name: Spike the Best 忍道 戒
-  name-sort: Spike the Best しのびどう いましめ
+  name: 忍道 戒【Spike the Best】
+  name-sort: しのびどう いましめ【Spike the Best】
   name-en: "Shinobido Imashime [Spike The Best]"
   region: "NTSC-J"
   clampModes:
     eeClampMode: 3 # Fixes hang going in to the gardens.
 SLPM-66557:
-  name: EA BEST HITS FIFAストリート
-  name-sort: EA BEST HITS FIFAすとりーと
+  name: FIFAストリート【EA BEST HITS】
+  name-sort: FIFAすとりーと【EA BEST HITS】
   name-en: "FIFA Street [EA Best Hits]"
   region: "NTSC-J"
 SLPM-66558:
@@ -42749,23 +42751,23 @@ SLPM-66558:
     textureInsideRT: 1 # Needed for post processing effects.
     minimumBlendingLevel: 4 # Fixes multiple lighting effects from lights, computers, cave walls and more.
 SLPM-66559:
-  name: コーエー定番シリーズ Winning Post6
-  name-sort: こーえーていばんしりーず Winning Post6
+  name: Winning Post6【コーエー定番シリーズ】
+  name-sort: Winning Post6【こーえーていばんしりーず】
   name-en: "Winning Post 6 [KOEI Selection]"
   region: "NTSC-J"
 SLPM-66560:
-  name: KOEI The Best 三國志X
-  name-sort: KOEI The Best さんごくしX
+  name: 三國志X【KOEI The Best】
+  name-sort: さんごくしX【KOEI The Best】
   name-en: "Sangokushi X [KOEI The Best]"
   region: "NTSC-J"
 SLPM-66561:
-  name: EA BEST HITS NBAライブ 06
-  name-sort: EA BEST HITS NBAらいぶ 06
+  name: NBAライブ 06【EA BEST HITS】
+  name-sort: NBAらいぶ 06【EA BEST HITS】
   name-en: "NBA Live '06 [EA Best Hits]"
   region: "NTSC-J"
 SLPM-66562:
-  name: EA BEST HITS ニード・フォー・スピード モスト・ウォンテッド
-  name-sort: EA BEST HITS にーど・ふぉー・すぴーど もすと・うぉんてっど
+  name: ニード・フォー・スピード モスト・ウォンテッド【EA BEST HITS】
+  name-sort: にーど・ふぉー・すぴーど もすと・うぉんてっど【EA BEST HITS】
   name-en: "Need for Speed - Most Wanted [EA Best Hits]"
   region: "NTSC-J"
   gsHWFixes:
@@ -42820,8 +42822,8 @@ SLPM-66567:
     roundSprite: 1 # Reduces misaligned bloom.
     mergeSprite: 1 # Removes bloom explosion around electrical lights and other light sources such as moon/sun.
 SLPM-66568:
-  name: ユービーアイソフト ベスト ブラザー イン アームズ ロード トゥ ヒル サーティ
-  name-sort: ゆーびーあいそふと べすと ぶらざー いん あーむず ろーど とぅ ひる さーてぃ
+  name: ブラザー イン アームズ ロード トゥ ヒル サーティ【ユービーアイソフト ベスト】
+  name-sort: ぶらざー いん あーむず ろーど とぅ ひる さーてぃ【ゆーびーあいそふと べすと】
   name-en: "Brothers In Arms - Road to Hill 30 [Ubisoft Best]"
   region: "NTSC-J"
   gsHWFixes:
@@ -42854,8 +42856,8 @@ SLPM-66572:
     - "SLPM-66572"
     - "SLPS-20423"
 SLPM-66573:
-  name: コーエー定番シリーズ 鋼鉄の咆哮2ウォーシップガンナー
-  name-sort: こーえーていばんしりーず くろがねのほうこう2うぉーしっぷがんなー
+  name: 鋼鉄の咆哮2ウォーシップガンナー【コーエー定番シリーズ】
+  name-sort: くろがねのほうこう2うぉーしっぷがんなー【こーえーていばんしりーず】
   name-en: "Kurogane no Houkou 2 - Warship Gunner [KOEI Selection]"
   region: "NTSC-J"
 SLPM-66574:
@@ -43010,8 +43012,8 @@ SLPM-66600:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
 SLPM-66601:
-  name: EA BEST HITS SSX on tour
-  name-sort: EA BEST HITS SSX on tour
+  name: SSX on tour【EA BEST HITS】
+  name-sort: SSX on tour【EA BEST HITS】
   name-en: "SSX On Tour [EA Best Hits]"
   region: "NTSC-J"
   gsHWFixes:
@@ -43086,13 +43088,13 @@ SLPM-66612:
   name-en: "School Love [Limited Edition]"
   region: "NTSC-J"
 SLPM-66613:
-  name: EA BEST HITS メダル オブ オナー 史上最大の作戦&メダル オブ オナー ライジングサン
-  name-sort: EA BEST HITS めだる おぶ おなー しじょうさいだいのさくせん&めだる おぶ おなー らいじんぐさん
+  name: メダル オブ オナー 史上最大の作戦&メダル オブ オナー ライジングサン【EA BEST HITS】
+  name-sort: めだる おぶ おなー しじょうさいだいのさくせん&めだる おぶ おなー らいじんぐさん【EA BEST HITS】
   name-en: "Medal of Honor - Rising Sun & Frontline [EA Best Hits]"
   region: "NTSC-J"
 SLPM-66615:
-  name: EA BEST HITS 007 ナイト ファイア&007 エブリシング オア ナッシング
-  name-sort: EA BEST HITS 007 ないと ふぁいあ&007 えぶりしんぐ おあ なっしんぐ
+  name: 007 ナイト ファイア&007 エブリシング オア ナッシング【EA BEST HITS】
+  name-sort: 007 ないと ふぁいあ&007 えぶりしんぐ おあ なっしんぐ【EA BEST HITS】
   name-en: "007 - Nightfire [EA Best Hits Dual Pack]"
   region: "NTSC-J"
 SLPM-66616:
@@ -43130,8 +43132,8 @@ SLPM-66621:
   name-en: "Beatmania IIDX 12 HAPPY SKY"
   region: "NTSC-J"
 SLPM-66622:
-  name: ユービーアイソフト ベスト トム・クランシーシリーズ ゴーストリコン2
-  name-sort: ゆーびーあいそふと べすと とむ・くらんしーしりーず ごーすとりこん2
+  name: トム・クランシーシリーズ ゴーストリコン2【ユービーアイソフト ベスト】
+  name-sort: とむ・くらんしーしりーず ごーすとりこん2【ゆーびーあいそふと べすと】
   name-en: "Tom Clancy's Ghost Recon 2 [Ubisoft Best]"
   region: "NTSC-J"
 SLPM-66623:
@@ -43170,8 +43172,8 @@ SLPM-66628:
     halfPixelOffset: 2 # Fixes bloom misalignment still a bit misaligned.
     roundSprite: 1 # Fixes bloom misalignment still a bit misaligned + font artifacts.
 SLPM-66629:
-  name: Ultimate Hits DIRGE of CERBERUS -FINAL FANTASY VII- INTERNATIONAL
-  name-sort: Ultimate Hits DIRGE of CERBERUS -FINAL FANTASY VII- INTERNATIONAL
+  name: DIRGE of CERBERUS -FINAL FANTASY VII- INTERNATIONAL【Ultimate Hits】
+  name-sort: DIRGE of CERBERUS -FINAL FANTASY VII- INTERNATIONAL【Ultimate Hits】
   name-en: "Dirge of Cerberus - Final Fantasy VII International"
   region: "NTSC-J"
   gsHWFixes:
@@ -43279,8 +43281,8 @@ SLPM-66649:
   gsHWFixes:
     roundSprite: 1 # Fixes vertical and horizontal lines.
 SLPM-66651:
-  name: EA BEST HITS バトルフィールド2 モダンコンバット
-  name-sort: EA BEST HITS ばとるふぃーるど2 もだんこんばっと
+  name: バトルフィールド2 モダンコンバット【EA BEST HITS】
+  name-sort: ばとるふぃーるど2 もだんこんばっと【EA BEST HITS】
   name-en: "Battlefield 2 - Modern Combat [EA Best Hits]"
   region: "NTSC-J"
   gsHWFixes:
@@ -43291,8 +43293,8 @@ SLPM-66651:
     getSkipCount: "GSC_Battlefield2" # Depth clear.
     beforeDraw: "OI_Battlefield2" # Framebuffer copy, fixes rendering for bottom part of screen.
 SLPM-66652:
-  name: EA BEST HITS バーンアウト リベンジ
-  name-sort: EA BEST HITS ばーんあうと りべんじ
+  name: バーンアウト リベンジ【EA BEST HITS】
+  name-sort: ばーんあうと りべんじ【EA BEST HITS】
   name-en: "Burnout Revenge [EA Best Hits]"
   region: "NTSC-J"
   clampModes:
@@ -43322,28 +43324,28 @@ SLPM-66653:
   name-en: "Akudaikan 3"
   region: "NTSC-J"
 SLPM-66654:
-  name: コーエー定番シリーズ 遙かなる時空の中で2
-  name-sort: はるかなるときのなかで2 こーえーていばんしりーず
+  name: 遙かなる時空の中で2【コーエー定番シリーズ】
+  name-sort: はるかなるときのなかで2【こーえーていばんしりーず】
   name-en: "Harukanaru Toki no Naka de 2 [Koei Selection]"
   region: "NTSC-J"
 SLPM-66655:
-  name: KOEI The Best 遙かなる時空の中で 〜八葉抄〜
+  name: 遙かなる時空の中で 〜八葉抄〜【KOEI The Best】
   name-sort: はるかなるときのなかで 〜はちようしょう〜
   name-en: "Harukanaru Jikuu no Kade - Hachiha Katsunori [Koei the Best]"
   region: "NTSC-J"
 SLPM-66656:
-  name: KOEI The Best ウォーシップガンナー2 〜鋼鉄の咆哮〜
-  name-sort: KOEI The Best うぉーしっぷがんなー2 〜くろがねのほうこう〜
+  name: ウォーシップガンナー2 〜鋼鉄の咆哮〜【KOEI The Best】
+  name-sort: うぉーしっぷがんなー2 〜くろがねのほうこう〜【KOEI The Best】
   name-en: "Warship Gunner 2 - Change of Direction [Koei the Best]"
   region: "NTSC-J"
 SLPM-66657:
-  name: コーエー定番シリーズ 真・三國無双3 猛将伝
-  name-sort: こーえーていばんしりーず しん・さんごくむそう3 もうしょうでん
+  name: 真・三國無双3 猛将伝【コーエー定番シリーズ】
+  name-sort: しん・さんごくむそう3 もうしょうでん【こーえーていばんしりーず】
   name-en: "Shin Sangoku Musou 3 Mushoden [Koei Selection]"
   region: "NTSC-J"
 SLPM-66658:
-  name: コーエー定番シリーズ 真・三國無双3 Empiers
-  name-sort: こーえーていばんしりーず しん・さんごくむそう3 Empiers
+  name: 真・三國無双3 Empiers【コーエー定番シリーズ】
+  name-sort: しん・さんごくむそう3 Empiers【こーえーていばんしりーず】
   name-en: "Shin Sangoku Musou 3 Empires [Koei Selection]"
   region: "NTSC-J"
 SLPM-66659:
@@ -43427,8 +43429,8 @@ SLPM-66672:
   name-en: "Tom Clancy's Splinter Cell - Double Agent"
   region: "NTSC-J"
 SLPM-66673:
-  name: ユービーアイソフトベスト プリンス・オブ・ペルシャ ケンシ ノ ココロ
-  name-sort: ゆーびーあいそふとべすと ぷりんす・おぶ・ぺるしゃ けんし の こころ
+  name: プリンス・オブ・ペルシャ ケンシ ノ ココロ【ユービーアイソフトベスト】
+  name-sort: ぷりんす・おぶ・ぺるしゃ けんし の こころ【ゆーびーあいそふとべすと】
   name-en: "Prince of Persia - Warrior Within [Ubisoft the Best]"
   region: "NTSC-J"
   gsHWFixes:
@@ -43466,8 +43468,8 @@ SLPM-66676:
     - "SLPM-66675"
     - "SLPM-66676"
 SLPM-66677:
-  name: アルティメット ヒッツ ファイナルファンタジーX インターナショナル
-  name-sort: あるてぃめっと ひっつ ふぁいなるふぁんたじーX いんたーなしょなる
+  name: ファイナルファンタジーX インターナショナル【アルティメット ヒッツ】
+  name-sort: ふぁいなるふぁんたじーX いんたーなしょなる【あるてぃめっと ひっつ】
   name-en: "Final Fantasy X - International [Ultimate Hits]"
   region: "NTSC-J"
   roundModes:
@@ -43475,8 +43477,8 @@ SLPM-66677:
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
 SLPM-66678:
-  name: アルティメット ヒッツ ファイナルファンタジーX-2 インターナショナル+ラストミッション
-  name-sort: あるてぃめっと ひっつ ふぁいなるふぁんたじーX-2 いんたーなしょなる+らすとみっしょん
+  name: ファイナルファンタジーX-2 インターナショナル+ラストミッション【アルティメット ヒッツ】
+  name-sort: ふぁいなるふぁんたじーX-2 いんたーなしょなる+らすとみっしょん【あるてぃめっと ひっつ】
   name-en: "Final Fantasy X-2 - International + Last Mission [Ultimate Hits]"
   region: "NTSC-J"
   gameFixes:
@@ -43533,7 +43535,7 @@ SLPM-66687:
         // This patch skips over the stack code, allowing the game to boot.
         patch=1,EE,001D1ED8,word,10000003
 SLPM-66688:
-  name: KOEI The Best 遙かなる時空の中で3
+  name: 遙かなる時空の中で3【KOEI The Best】
   name-sort: はるかなるときのなかで3 KOEI The Best
   name-en: "Harukanaru Jikuu no Kade 3 [Koei the Best]"
   region: "NTSC-J"
@@ -43565,13 +43567,13 @@ SLPM-66691:
   name-en: "Sengoku Basara 2 [CapKore]"
   region: "NTSC-J"
 SLPM-66692:
-  name: BEST HIT セレクション 星界の戦旗
-  name-sort: BEST HIT せれくしょん せいかいのせんき
+  name: セレクション 星界の戦旗【BEST HIT】
+  name-sort: せれくしょん せいかいのせんき【BEST HIT】
   name-en: "Seikai no Senki [Best Hit]"
   region: "NTSC-J"
 SLPM-66693:
-  name: BEST HIT セレクション プリンセスメーカー4
-  name-sort: BEST HIT せれくしょん ぷりんせすめーかー4
+  name: セレクション プリンセスメーカー4【BEST HIT】
+  name-sort: せれくしょん ぷりんせすめーかー4【BEST HIT】
   name-en: "Princess Maker 4 [Best Version]"
   region: "NTSC-J"
 SLPM-66694:
@@ -43643,8 +43645,8 @@ SLPM-66707:
   name: "Yukinko Daisenpuu - Sayuki to Koyuki no Hie Hie Daisoudou"
   region: "NTSC-J"
 SLPM-66708:
-  name: ユービーアイソフトベスト ブラザー イン アームズ 名誉の代償
-  name-sort: ゆーびーあいそふとべすと ぶらざー いん あーむず めいよのだいしょう
+  name: ブラザー イン アームズ 名誉の代償【ユービーアイソフトベスト】
+  name-sort: ぶらざー いん あーむず めいよのだいしょう【ゆーびーあいそふとべすと】
   name-en: "Brothers In Arms - Earned In Blood [Ubisoft Best]"
   region: "NTSC-J"
   gsHWFixes:
@@ -43685,8 +43687,8 @@ SLPM-66714:
     alignSprite: 1 # Fixes vertical lines.
     halfPixelOffset: 1 # Fixes misaligned bloom.
 SLPM-66715:
-  name: IFコレクション 新紀幻想 スペクトラル ソウルズ II
-  name-sort: IFこれくしょん しんきげんそう すぺくとらる そうるず II
+  name: 新紀幻想 スペクトラル ソウルズ II【IFコレクション】
+  name-sort: しんきげんそう すぺくとらる そうるず II【IFこれくしょん】
   name-en: "Shinki Gensou Spectral Souls II [IF Collection]"
   region: "NTSC-J"
 SLPM-66716:
@@ -43698,23 +43700,23 @@ SLPM-66716:
   gsHWFixes:
     moveHandler: "MV_Growlanser" # Fixes precomputed depth buffer.
 SLPM-66717:
-  name: SEGA THE BEST スタンダード大戦略 電撃戦
-  name-sort: SEGA THE BEST すたんだーどだいせんりゃく でんげきせん
+  name: スタンダード大戦略 電撃戦【SEGA THE BEST】
+  name-sort: すたんだーどだいせんりゃく でんげきせん【SEGA THE BEST】
   name-en: "Standard Daisenryaku - Dengekisen [Sega the Best]"
   region: "NTSC-J"
 SLPM-66718:
-  name: SEGA THE BEST スタンダード大戦略 失われた勝利
-  name-sort: SEGA THE BEST すたんだーどだいせんりゃく うしなわれたしょうり
+  name: スタンダード大戦略 失われた勝利【SEGA THE BEST】
+  name-sort: すたんだーどだいせんりゃく うしなわれたしょうり【SEGA THE BEST】
   name-en: "Sutandādo Daisenryaku - Ushinawareta Shoeri [Sega the Best]"
   region: "NTSC-J"
 SLPM-66719:
-  name: SEGA THE BEST 天下人
-  name-sort: SEGA THE BEST てんかじん
+  name: 天下人【SEGA THE BEST】
+  name-sort: てんかじん【SEGA THE BEST】
   name-en: "Tenka-bito [Sega the Best]"
   region: "NTSC-J"
 SLPM-66720:
-  name: SEGA THE BEST GUILTY GEAR XX SLASH(ギルティギア イグゼクス スラッシュ)
-  name-sort: SEGA THE BEST GUILTY GEAR XX SLASH(ぎるてぃぎあ いぐぜくす すらっしゅ)
+  name: GUILTY GEAR XX SLASH(ギルティギア イグゼクス スラッシュ)【SEGA THE BEST】
+  name-sort: GUILTY GEAR XX SLASH(ぎるてぃぎあ いぐぜくす すらっしゅ)【SEGA THE BEST】
   name-en: "Guilty Gear XX #Slash [Sega the Best]"
   region: "NTSC-J"
 SLPM-66721:
@@ -43954,18 +43956,18 @@ SLPM-66757:
   name-en: "Que - Ancient Leaf no Yousei"
   region: "NTSC-J"
 SLPM-66758:
-  name: KOEI The Best ネオ アンジェリーク
-  name-sort: KOEI The Best ねお あんじぇりーく
+  name: ネオ アンジェリーク【KOEI The Best】
+  name-sort: ねお あんじぇりーく【KOEI The Best】
   name-en: "Neo Angelique [Koei the Best]"
   region: "NTSC-J"
 SLPM-66759:
-  name: KOEI The Best 遙かなる時空の中で3 十六夜記
-  name-sort: KOEI The Best はるかなるときのなかで3 いざよいき
+  name: 遙かなる時空の中で3 十六夜記【KOEI The Best】
+  name-sort: はるかなるときのなかで3 いざよいき【KOEI The Best】
   name-en: "Harukanaru Jikuu no Kade 3 - Izayoiki [Koei the Best]"
   region: "NTSC-J"
 SLPM-66760:
-  name: コーエー定番シリーズ 信長の野望・蒼天録 with パワーアップキット
-  name-sort: こーえーていばんしりーず のぶながのやぼう・そうてんろく with ぱわーあっぷきっと
+  name: 信長の野望・蒼天録 with パワーアップキット【コーエー定番シリーズ】
+  name-sort: のぶながのやぼう・そうてんろく with ぱわーあっぷきっと【こーえーていばんしりーず】
   name-en: "Nobunaga no Yabou - Soutenroku [with Power-Up Kit] [Koei Selection]"
   region: "NTSC-J"
 SLPM-66761:
@@ -44023,35 +44025,35 @@ SLPM-66770:
   name-en: "Kuon no Kizuna - Sairinshou [Best Version]"
   region: "NTSC-J"
 SLPM-66771:
-  name: エターナルヒッツ 電車でGO!山陽新幹線編
-  name-sort: えたーなるひっつ でんしゃでGO!さんようしんかんせんへん
+  name: 電車でGO!山陽新幹線編【エターナルヒッツ】
+  name-sort: でんしゃでGO!さんようしんかんせんへん【えたーなるひっつ】
   name-en: "Densha de Go! Shinkansen [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPM-66772:
-  name: エターナルヒッツ 電車でGO!FINAL
-  name-sort: えたーなるひっつ でんしゃでGO!FINAL
+  name: 電車でGO!FINAL【エターナルヒッツ】
+  name-sort: でんしゃでGO!FINAL【えたーなるひっつ】
   name-en: "Densha de Go! Final [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPM-66773:
-  name: エターナルヒッツ ジェットでGO!2
-  name-sort: えたーなるひっつ じぇっとでGO!2
+  name: ジェットでGO!2【エターナルヒッツ】
+  name-sort: じぇっとでGO!2【えたーなるひっつ】
   name-en: "Densha de Go! Professional 2 [Taito Best]"
   region: "NTSC-J"
 SLPM-66774:
-  name: エターナルヒッツ エナジーエアーフォース
-  name-sort: えたーなるひっつ えなじーえあーふぉーす
+  name: エナジーエアーフォース【エターナルヒッツ】
+  name-sort: えなじーえあーふぉーす【えたーなるひっつ】
   name-en: "Energy Airforce - AimStrike! [Taito Best]"
   region: "NTSC-J"
 SLPM-66775:
-  name: エターナルヒッツ タイトーメモリーズ 上巻
-  name-sort: えたーなるひっつ たいとーめもりーず じょうかん
+  name: タイトーメモリーズ 上巻【エターナルヒッツ】
+  name-sort: たいとーめもりーず じょうかん【えたーなるひっつ】
   name-en: "Taito Memories - Joukan [Taito Best]"
   region: "NTSC-J"
   gsHWFixes:
     roundSprite: 1 # Fixes vertical and horizontal lines.
 SLPM-66776:
-  name: エターナルヒッツ タイトーメモリーズ 下巻
-  name-sort: えたーなるひっつ たいとーめもりーず げかん
+  name: タイトーメモリーズ 下巻【エターナルヒッツ】
+  name-sort: たいとーめもりーず げかん【えたーなるひっつ】
   name-en: "Taito Memories Gekan [Taito Best]"
   region: "NTSC-J"
   gsHWFixes:
@@ -44083,13 +44085,13 @@ SLPM-66780:
   memcardFilters:
     - "SLPM-66779"
 SLPM-66781:
-  name: アルティメットヒッツ ドラゴンクエスト 少年ヤンガスと不思議のダンジョン
-  name-sort: あるてぃめっとひっつ どらごんくえすと しょうねんやんがすとふしぎのだんじょん
+  name: ドラゴンクエスト 少年ヤンガスと不思議のダンジョン【アルティメットヒッツ】
+  name-sort: どらごんくえすと しょうねんやんがすとふしぎのだんじょん【あるてぃめっとひっつ】
   name-en: "Dragon Quest - Shounen Yangus to Fushigi no Dungeon [Ultimate Hits]"
   region: "NTSC-J"
 SLPM-66782:
-  name: アルティメットヒッツ ヴァルキリープロファイル2シルメリア
-  name-sort: あるてぃめっとひっつ ゔぁるきりーぷろふぁいる2しるめりあ
+  name: ヴァルキリープロファイル2シルメリア【アルティメットヒッツ】
+  name-sort: ゔぁるきりーぷろふぁいる2しるめりあ【あるてぃめっとひっつ】
   name-en: "Valkyrie Profile 2 - Silmeria [Ultimate Hits]"
   region: "NTSC-J"
   compat: 5
@@ -44238,8 +44240,8 @@ SLPM-66807:
     wildArmsHack: 1 # Reduces blooming misalignment.
     autoFlush: 2 # Fixes glows.
 SLPM-66808:
-  name: ユービーアイソフトベスト ゴーストリコン アドバンスウォーファイター
-  name-sort: ゆーびーあいそふとべすと ごーすとりこん あどばんすうぉーふぁいたー
+  name: ゴーストリコン アドバンスウォーファイター【ユービーアイソフトベスト】
+  name-sort: ごーすとりこん あどばんすうぉーふぁいたー【ゆーびーあいそふとべすと】
   name-en: "Tom Clancy's Ghost Recon - Advanced Warfighter [Ubisoft the Best]"
   region: "NTSC-J"
   gsHWFixes:
@@ -44257,18 +44259,18 @@ SLPM-66810:
   name-en: "J.League Winning Eleven 2007 Club Championship"
   region: "NTSC-J"
 SLPM-66811:
-  name: KOEI The Best Winning Post 7
-  name-sort: KOEI The Best Winning Post 7
+  name: Winning Post 7【KOEI The Best】
+  name-sort: Winning Post 7【KOEI The Best】
   name-en: "Winning Post 7 [Koei the Best]"
   region: "NTSC-J"
 SLPM-66812:
-  name: KOEI The Best ジーワンジョッキー4
-  name-sort: KOEI The Best じーわんじょっきー4
+  name: ジーワンジョッキー4【KOEI The Best】
+  name-sort: じーわんじょっきー4【KOEI The Best】
   name-en: "GI Jockey 4 [Koei the Best]"
   region: "NTSC-J"
 SLPM-66813:
-  name: コーエー定番シリーズ 三國志IX
-  name-sort: こーえーていばんしりーず さんごくしIX
+  name: 三國志IX【コーエー定番シリーズ】
+  name-sort: さんごくしIX【こーえーていばんしりーず】
   name-en: "Sangokushi IX [Koei Selection]"
   region: "NTSC-J"
 SLPM-66814:
@@ -44382,7 +44384,7 @@ SLPM-66837:
     trilinearFiltering: 1
 SLPM-66838:
   name: ファンタスティックフォーチュン2☆☆☆(トリプルスター) BEST HIT セレクション
-  name-sort: ふぁんたすてぃっくふぉーちゅん2☆☆☆(とりぷるすたー) BEST HIT せれくしょん
+  name-sort: ふぁんたすてぃっくふぉーちゅん2とりぷるすたー BEST HIT せれくしょん
   name-en: "Fantastic Fortune 2 - Triple Star [Best Hit Selection]"
   region: "NTSC-J"
 SLPM-66839:
@@ -44436,8 +44438,8 @@ SLPM-66848:
   name-en: "Sengoku Basara 2 Heroes"
   region: "NTSC-J"
 SLPM-66849:
-  name: ガストベストプライス イリスのアトリエ グランファンタズム
-  name-sort: がすとべすとぷらいす いりすのあとりえ ぐらんふぁんたずむ
+  name: イリスのアトリエ グランファンタズム【ガストベストプライス】
+  name-sort: いりすのあとりえ ぐらんふぁんたずむ【がすとべすとぷらいす】
   name-en: "Iris no Atelier - Grand Fantasm [Gust Best Price]"
   region: "NTSC-J"
   gsHWFixes:
@@ -44538,13 +44540,13 @@ SLPM-66867:
   name-en: "MotoGP '07"
   region: "NTSC-J"
 SLPM-66868:
-  name: ユービーアイソフトベスト スプリンターセル 二重スパイ
-  name-sort: ゆーびーあいそふとべすと すぷりんたーせる にじゅうすぱい
+  name: スプリンターセル 二重スパイ【ユービーアイソフトベスト】
+  name-sort: すぷりんたーせる にじゅうすぱい【ゆーびーあいそふとべすと】
   name-en: "Tom Clancy's Splinter Cell - Double Agent [Ubisoft the Best]"
   region: "NTSC-J"
 SLPM-66869:
-  name: EA BEST HITS ニード・フォー・スピード カーボン
-  name-sort: EA BEST HITS にーど・ふぉー・すぴーど かーぼん
+  name: ニード・フォー・スピード カーボン【EA BEST HITS】
+  name-sort: にーど・ふぉー・すぴーど かーぼん【EA BEST HITS】
   name-en: "Need for Speed - Carbon [EA Best Hits]"
   region: "NTSC-J"
   clampModes:
@@ -44651,8 +44653,8 @@ SLPM-66886:
     halfPixelOffset: 1 # Fixes ghosting.
     alignSprite: 1 # Fixes vertical lines.
 SLPM-66887:
-  name: KOEI The Best 遙かなる時空の中で3 運命の迷宮
-  name-sort: KOEI The Best はるかなるときのなかで3 うんめいのめいきゅう
+  name: 遙かなる時空の中で3 運命の迷宮【KOEI The Best】
+  name-sort: はるかなるときのなかで3 うんめいのめいきゅう【KOEI The Best】
   name-en: "Harukanaru Jikuu no Kade 3 - Unmei no Meikyuu [Koei the Best]"
   region: "NTSC-J"
 SLPM-66888:
@@ -44906,18 +44908,18 @@ SLPM-66936:
   name-en: "Night Wizard - The Video Game - Denial of the World"
   region: "NTSC-J"
 SLPM-66937:
-  name: KOEI The Best 雀・三國無双
-  name-sort: KOEI The Best じゃん・さんごくむそう
+  name: 雀・三國無双【KOEI The Best】
+  name-sort: じゃん・さんごくむそう【KOEI The Best】
   name-en: "Jan Sangoku Musou [Koei the Best]"
   region: "NTSC-J"
 SLPM-66938:
-  name: コーエー定番シリーズ アンジェリークエトワール
-  name-sort: こーえーていばんしりーず あんじぇりーくえとわーる
+  name: アンジェリークエトワール【コーエー定番シリーズ】
+  name-sort: あんじぇりーくえとわーる【こーえーていばんしりーず】
   name-en: "Angelique Etoile [Koei Selection]"
   region: "NTSC-J"
 SLPM-66939:
-  name: コーエー定番シリーズ 亡国のイージス2035　〜ウォーシップガンナー〜
-  name-sort: こーえーていばんしりーず ぼうこくのいーじす2035　〜うぉーしっぷがんなー〜
+  name: 亡国のイージス2035　〜ウォーシップガンナー〜【コーエー定番シリーズ】
+  name-sort: ぼうこくのいーじす2035　〜うぉーしっぷがんなー〜【こーえーていばんしりーず】
   name-en: "Boukoku no Aegis 2035 - Warship Gunner [Koei Selection]"
   region: "NTSC-J"
 SLPM-66940:
@@ -44951,8 +44953,8 @@ SLPM-66945:
   name-en: "Petit Four"
   region: "NTSC-J"
 SLPM-66946:
-  name: EA BEST HITS NBAライブ 07
-  name-sort: EA BEST HITS NBAらいぶ 07
+  name: NBAライブ 07【EA BEST HITS】
+  name-sort: NBAらいぶ 07【EA BEST HITS】
   name-en: "NBA Live '07 [EA Best Hits]"
   region: "NTSC-J"
 SLPM-66947:
@@ -45097,13 +45099,13 @@ SLPM-66970:
   name-en: "Pro Yakyuu Spirits 5"
   region: "NTSC-J"
 SLPM-66971:
-  name: コーエー定番シリーズ 三國志IX with パワーアップキット
-  name-sort: こーえーていばんしりーず さんごくしIX with ぱわーあっぷきっと
+  name: 三國志IX with パワーアップキット【コーエー定番シリーズ】
+  name-sort: さんごくしIX with ぱわーあっぷきっと【こーえーていばんしりーず】
   name-en: "Sangokushi IX [with Power-Up Kit] [Koei Selection]"
   region: "NTSC-J"
 SLPM-66972:
-  name: コーエー定番シリーズ 鋼鉄の咆哮2 ウォーシップコマンダー
-  name-sort: こーえーていばんしりーず くろがねのほうこう2 うぉーしっぷこまんだー
+  name: 鋼鉄の咆哮2 ウォーシップコマンダー【コーエー定番シリーズ】
+  name-sort: くろがねのほうこう2 うぉーしっぷこまんだー【こーえーていばんしりーず】
   name-en: "Kurogane no Houkou 2 - Warship Commander [Koei Selection]"
   region: "NTSC-J"
 SLPM-66973:
@@ -45181,8 +45183,8 @@ SLPM-66993:
   name-en: "Rim Runners [Best Version]"
   region: "NTSC-J"
 SLPM-66994:
-  name: ガストベストプライス マナケミア 〜学園の錬金術士たち〜
-  name-sort: がすとべすとぷらいす まなけみあ 〜がくえんのれんきんじゅつしたち〜
+  name: マナケミア 〜学園の錬金術士たち〜【ガストベストプライス】
+  name-sort: まなけみあ 〜がくえんのれんきんじゅつしたち〜【がすとべすとぷらいす】
   name-en: "Mana-Khemia - Gakuen no Renkinjutsu Shitachi [Best Version]"
   region: "NTSC-J"
   roundModes:
@@ -45214,8 +45216,8 @@ SLPM-66999:
   name-en: "Fushigi Yuugi - Suzaku Ibun"
   region: "NTSC-J"
 SLPM-67000:
-  name: IFコレクション ふしぎ遊戯 玄武開伝 外伝 鏡の巫女
-  name-sort: IFこれくしょん ふしぎゆうぎ げんぶひらきでん がいでん きょうのみこ
+  name: ふしぎ遊戯 玄武開伝 外伝 鏡の巫女【IFコレクション】
+  name-sort: ふしぎゆうぎ げんぶひらきでん がいでん きょうのみこ【IFこれくしょん】
   name-en: "Fushigi Yuugi - ShigiYuugi Kurotake Kaiden Gaiden - Kagami no Fujo [IF Collection]"
   region: "NTSC-J"
 SLPM-67001:
@@ -46849,8 +46851,8 @@ SLPS-20123:
   name: "Initial D - Takahashi Ryousuke no Typing Saisoku Riron"
   region: "NTSC-J"
 SLPS-20125:
-  name: super value 2800 上海フォーエレメント
-  name-sort: super value 2800 しゃんはいふぉーえれめんと
+  name: 上海フォーエレメント【super value 2800】
+  name-sort: しゃんはいふぉーえれめんと【super value 2800】
   name-en: "Shanghai - The Four Elements [Super Value 2800]"
   region: "NTSC-J"
 SLPS-20127:
@@ -47265,7 +47267,7 @@ SLPS-20242:
   name: "Tomak - Save the Earth - Love Story"
   region: "NTSC-J"
 SLPS-20243:
-  name: NewPrice GoGoGolf
+  name: GoGoGolf [NewPrice]
   name-en: "Go Go Golf [NewPrice]"
   region: "NTSC-J"
   gsHWFixes:
@@ -47700,23 +47702,23 @@ SLPS-20353:
   name: "Suki na Mono wa Suki dakara Shou ga Nai!! First Limit & Target Nights - Sukishou! Episode #01+#02 (Disc 2) (Target Nights - Sukishou! Episode #02)"
   region: "NTSC-J"
 SLPS-20354:
-  name: ベストオブベスト 山佐Digiワールド3
-  name-sort: べすとおぶべすと さんさDigiわーるど3
+  name: 山佐Digiワールド3【ベストオブベスト】
+  name-sort: さんさDigiわーるど3【べすとおぶべすと】
   name-en: "Yamasa Digi World 3 [Best of Best]"
   region: "NTSC-J"
 SLPS-20355:
-  name: ベストオブベスト 山佐DigiワールドSPネオプラネットXX
-  name-sort: べすとおぶべすと さんさDigiわーるどSPねおぷらねっとXX
+  name: 山佐DigiワールドSPネオプラネットXX【ベストオブベスト】
+  name-sort: さんさDigiわーるどSPねおぷらねっとXX【べすとおぶべすと】
   name-en: "Yamasa Digi World SP - Neo Planett XX [Best of Best]"
   region: "NTSC-J"
 SLPS-20356:
-  name: ベストオブベスト 山佐Digiワールド4
-  name-sort: べすとおぶべすと さんさDigiわーるど4
+  name: 山佐Digiワールド4【ベストオブベスト】
+  name-sort: さんさDigiわーるど4【べすとおぶべすと】
   name-en: "Yamasa Digi World 4 [Best of Best]"
   region: "NTSC-J"
 SLPS-20357:
-  name: ベストオブベスト 山佐DigiワールドSP 海一番R
-  name-sort: べすとおぶべすと さんさDigiわーるどSP うみいちばんR
+  name: 山佐DigiワールドSP 海一番R【ベストオブベスト】
+  name-sort: さんさDigiわーるどSP うみいちばんR【べすとおぶべすと】
   name-en: "Yamasa Digi World SP - Umi Ichiban R [Best of Best]"
   region: "NTSC-J"
 SLPS-20361:
@@ -47921,8 +47923,8 @@ SLPS-20402:
   region: "NTSC-J"
   compat: 5
 SLPS-20403:
-  name: super value 2800 上海〜三国牌闘儀〜
-  name-sort: super value 2800 しゃんはい〜さんこくぱい闘儀〜
+  name: 上海〜三国牌闘儀〜【super value 2800】
+  name-sort: しゃんはい〜さんこくぱい闘儀〜【super value 2800】
   name-en: "Shanghai - Sangoku Pai Tatagi [Super Value 2800]"
   region: "NTSC-J"
 SLPS-20404:
@@ -50012,8 +50014,8 @@ SLPS-25290:
   gsHWFixes:
     texturePreloading: 0 # Performs much better with no preload.
 SLPS-25291:
-  name: PCCWジャパン・ザ・ベスト バルダーズゲート・ダークアライアンス
-  name-sort: PCCWじゃぱん・ざ・べすと ばるだーずげーと・だーくあらいあんす
+  name: バルダーズゲート・ダークアライアンス【PCCWジャパン・ザ・ベスト】
+  name-sort: ばるだーずげーと・だーくあらいあんす【PCCWじゃぱん・ざ・べすと】
   name-en: "Baldur's Gate - Dark Alliance [PCCW The Best]"
   region: "NTSC-J"
   compat: 5
@@ -50597,8 +50599,8 @@ SLPS-25386:
   name-en: "King of Fighters, The - Maximum Impact Maniax"
   region: "NTSC-J"
 SLPS-25387:
-  name: エンターブレインコレクション True Love StorySummer Days,and yet...
-  name-sort: えんたーぶれいんこれくしょん True Love StorySummer Days,and yet...
+  name: True Love StorySummer Days,and yet...【エンターブレインコレクション】
+  name-sort: True Love StorySummer Days,and yet...【えんたーぶれいんこれくしょん】
   name-en: "True Love Story - Summer Days, and Yet..."
   region: "NTSC-J"
 SLPS-25388:
@@ -50647,7 +50649,7 @@ SLPS-25395:
   region: "NTSC-J"
 SLPS-25396:
   name: ファンタスティックフォーチュン2 ☆☆☆(トリプルスター)
-  name-sort: ふぁんたすてぃっくふぉーちゅん2 ☆☆☆(とりぷるすたー)
+  name-sort: ふぁんたすてぃっくふぉーちゅん2 とりぷるすたー
   name-en: "Fantastic Fortune 2 - Triple Star"
   region: "NTSC-J"
 SLPS-25397:
@@ -50858,15 +50860,15 @@ SLPS-25427:
   region: "NTSC-J"
   compat: 5
 SLPS-25428:
-  name: SNK Best Collection メタルスラッグ3
-  name-sort: SNK Best Collection めたるすらっぐ3
+  name: メタルスラッグ3【SNK Best Collection】
+  name-sort: めたるすらっぐ3【SNK Best Collection】
   name-en: "Metal Slug 3 [SNK Best Collection]"
   region: "NTSC-J"
   gsHWFixes:
     gpuPaletteConversion: 2 # Stops excessive VRAM usage with preloading on.
 SLPS-25429:
-  name: SNK Best Collection THE KING OF FIGHTERS 2000
-  name-sort: SNK Best Collection THE KING OF FIGHTERS 2000
+  name: THE KING OF FIGHTERS 2000【SNK Best Collection】
+  name-sort: THE KING OF FIGHTERS 2000【SNK Best Collection】
   name-en: "King of Fighters 2000, The [SNK Best Collection]"
   region: "NTSC-J"
 SLPS-25430:
@@ -51010,8 +51012,8 @@ SLPS-25457:
     getSkipCount: "GSC_SteambotChronicles" # Causes green (incorrect) water but removes depth and blur issues.
     roundSprite: 1 # Fixes colored 3D anaglyph bleeding effects.
 SLPS-25458:
-  name: SNK Best Collection THE KING OF FIGHTERS 2001
-  name-sort: SNK Best Collection THE KING OF FIGHTERS 2001
+  name: THE KING OF FIGHTERS 2001【SNK Best Collection】
+  name-sort: THE KING OF FIGHTERS 2001【SNK Best Collection】
   name-en: "King of Fighters 2001, The [SNK Best Collection]"
   region: "NTSC-J"
 SLPS-25459:
@@ -51163,8 +51165,8 @@ SLPS-25483:
   name-en: "Sui-Toshi-Zun"
   region: "NTSC-J"
 SLPS-25484:
-  name: SNK BEST Collection SNK VS. CAPCOM SVC CHAOS
-  name-sort: SNK BEST Collection SNK VS. CAPCOM SVC CHAOS
+  name: SNK VS. CAPCOM SVC CHAOS【SNK BEST Collection】
+  name-sort: SNK VS. CAPCOM SVC CHAOS【SNK BEST Collection】
   name-en: "SNK vs. Capcom Chaos [SNK Best Collection]"
   region: "NTSC-J"
 SLPS-25485:
@@ -51255,14 +51257,14 @@ SLPS-25502:
   region: "NTSC-J"
   compat: 5
 SLPS-25503:
-  name: NEOGEOオンラインコレクション 幕末浪漫 月華の剣士 1・2
-  name-sort: NEOGEOおんらいんこれくしょん ばくまつろまん げっかのけんし 1・2
+  name: 幕末浪漫 月華の剣士 1・2【NEOGEOオンラインコレクション】
+  name-sort: ばくまつろまん げっかのけんし 1・2【NEOGEOおんらいんこれくしょん】
   name-en: "NeoGeo Online Collection Vol.2 - Bakumatsu Roman - Gekka no Kenshi 1&2"
   region: "NTSC-J"
   compat: 5
 SLPS-25504:
-  name: NEOGEOオンラインコレクション 餓狼 MARK OF THE WOLVES(限定版)
-  name-sort: NEOGEOおんらいんこれくしょん 餓狼 MARK OF THE WOLVES(げんていばん)
+  name: 餓狼 MARK OF THE WOLVES(限定版)【NEOGEOオンラインコレクション】
+  name-sort: がろう MARK OF THE WOLVES(げんていばん)【NEOGEOおんらいんこれくしょん】
   name-en: "Garou - Mark of the Wolves [Limited Edition]"
   region: "NTSC-J"
 SLPS-25505:
@@ -51287,8 +51289,8 @@ SLPS-25508:
   name-en: "Mai-Hime - The Another"
   region: "NTSC-J"
 SLPS-25509:
-  name: NEOGEOオンラインコレクション 餓狼 MARK OF THE WOLVES
-  name-sort: NEOGEOおんらいんこれくしょん 餓狼 MARK OF THE WOLVES
+  name: 餓狼 MARK OF THE WOLVES【NEOGEOオンラインコレクション】
+  name-sort: がろう MARK OF THE WOLVES【NEOGEOおんらいんこれくしょん】
   name-en: "Garou - Mark of the Wolves"
   region: "NTSC-J"
 SLPS-25510:
@@ -51421,8 +51423,8 @@ SLPS-25534:
   region: "NTSC-J"
   compat: 5
 SLPS-25535:
-  name: NEOGEOオンラインコレクション THE KING OF FIGHTERS -オロチ編- NEOGEO STICK3同梱(限定版)
-  name-sort: NEOGEOおんらいんこれくしょん THE KING OF FIGHTERS -おろちへん- NEOGEO STICK3どうこん(げんていばん)
+  name: THE KING OF FIGHTERS -オロチ編- NEOGEO STICK3同梱(限定版)【NEOGEOオンラインコレクション】
+  name-sort: THE KING OF FIGHTERS -おろちへん- NEOGEO STICK3どうこん(げんていばん)【NEOGEOおんらいんこれくしょん】
   name-en: "NeoGeo Online Collection Vol.3 - The King of Fighters - Orochi Collection [Special Pack]"
   region: "NTSC-J"
 SLPS-25537:
@@ -51609,18 +51611,18 @@ SLPS-25570:
   name-en: "Kino no Tabi 2 - The Beautiful World"
   region: "NTSC-J"
 SLPS-25571:
-  name: SNK Best Collection メタルスラッグ4
-  name-sort: SNK Best Collection めたるすらっぐ4
+  name: メタルスラッグ4【SNK Best Collection】
+  name-sort: めたるすらっぐ4【SNK Best Collection】
   name-en: "Metal Slug 4 [SNK Best Collection]"
   region: "NTSC-J"
 SLPS-25572:
-  name: SNK Best Collection サムライスピリッツ零
-  name-sort: SNK Best Collection さむらいすぴりっつぜろ
+  name: サムライスピリッツ零【SNK Best Collection】
+  name-sort: さむらいすぴりっつぜろ【SNK Best Collection】
   name-en: "Samurai Spirits Zero [SNK Best Collection]"
   region: "NTSC-J"
 SLPS-25573:
-  name: SNK Best Collection ザ・キング・オブ・ファイターズ 2002
-  name-sort: SNK Best Collection ざ・きんぐ・おぶ・ふぁいたーず 2002
+  name: ザ・キング・オブ・ファイターズ 2002【SNK Best Collection】
+  name-sort: ざ・きんぐ・おぶ・ふぁいたーず 2002【SNK Best Collection】
   name-en: "King of Fighters 2002, The [SNK Best Collection]"
   region: "NTSC-J"
 SLPS-25574:
@@ -51802,8 +51804,8 @@ SLPS-25604:
   gsHWFixes:
     roundSprite: 1 # Fixes vertical lines in FMVs, character portraits and other sprites.
 SLPS-25605:
-  name: NEOGEOオンラインコレクション THE KING OF FIGHTERS -オロチ編-通常版
-  name-sort: NEOGEOおんらいんこれくしょん THE KING OF FIGHTERS -おろちへん-つうじょうばん
+  name: THE KING OF FIGHTERS -オロチ編-通常版【NEOGEOオンラインコレクション】
+  name-sort: THE KING OF FIGHTERS -おろちへん-つうじょうばん【NEOGEOおんらいんこれくしょん】
   name-en: "NeoGeo Online Collection Vol.3 - The King of Fighters - Orochi Collection"
   region: "NTSC-J"
 SLPS-25606:
@@ -51831,8 +51833,8 @@ SLPS-25609:
   name-en: "King of Fighters, The - Maximum Impact 2"
   region: "NTSC-J"
 SLPS-25610:
-  name: NEOGEOオンラインコレクション 龍虎の拳〜天・地・人〜
-  name-sort: NEOGEOおんらいんこれくしょん りゅうこのけん〜てん・ち・じん〜
+  name: 龍虎の拳〜天・地・人〜【NEOGEOオンラインコレクション】
+  name-sort: りゅうこのけん〜てん・ち・じん〜【NEOGEOおんらいんこれくしょん】
   name-en: "Ryuuko no Ken - Ten-Chi-Jin [Art of Fighting Collection]"
   region: "NTSC-J"
 SLPS-25611:
@@ -51980,13 +51982,13 @@ SLPS-25633:
   name-en: "Futakoi Alternative - Koi to Shoujo to Machinegun [Best Collection]"
   region: "NTSC-J"
 SLPS-25634:
-  name: SNK BEST COLLECTION メタルスラッグ5
-  name-sort: SNK BEST COLLECTION めたるすらっぐ5
+  name: メタルスラッグ5【SNK BEST COLLECTION】
+  name-sort: めたるすらっぐ5【SNK BEST COLLECTION】
   name-en: "Metal Slug 5 [SNK Best Collection]"
   region: "NTSC-J"
 SLPS-25635:
-  name: SNK BEST COLLECTION THE KING OF FIGHTERS 2003
-  name-sort: SNK BEST COLLECTION THE KING OF FIGHTERS 2003
+  name: THE KING OF FIGHTERS 2003【SNK BEST COLLECTION】
+  name-sort: THE KING OF FIGHTERS 2003【SNK BEST COLLECTION】
   name-en: "King of Fighters 2003, The [SNK Best Collection]"
   region: "NTSC-J"
 SLPS-25636:
@@ -52190,8 +52192,8 @@ SLPS-25660:
   region: "NTSC-J"
   compat: 5
 SLPS-25661:
-  name: NEOGEOオンラインコレクション ザ・キング・オブ・ファイターズ -ネスツ編-
-  name-sort: NEOGEOおんらいんこれくしょん ざ・きんぐ・おぶ・ふぁいたーず -ねすつへん-
+  name: ザ・キング・オブ・ファイターズ -ネスツ編-【NEOGEOオンラインコレクション】
+  name-sort: ざ・きんぐ・おぶ・ふぁいたーず -ねすつへん-【NEOGEOおんらいんこれくしょん】
   name-en: "King of Fighters, The - Nests"
   region: "NTSC-J"
 SLPS-25662:
@@ -52205,8 +52207,8 @@ SLPS-25663:
   name-en: "Kyo Kara Maoh! The 1st trip of Maoh!"
   region: "NTSC-J"
 SLPS-25664:
-  name: NEOGEOオンラインコレクション 餓狼伝説バトルアーカイブズ1
-  name-sort: NEOGEOおんらいんこれくしょん がろうでんせつばとるあーかいぶず1
+  name: 餓狼伝説バトルアーカイブズ1【NEOGEOオンラインコレクション】
+  name-sort: がろうでんせつばとるあーかいぶず1【NEOGEOおんらいんこれくしょん】
   name-en: "NeoGeo Online Collection - Garou Densetsu Battle Archives Vol.1"
   region: "NTSC-J"
   compat: 5
@@ -52303,8 +52305,8 @@ SLPS-25682:
   name-en: "Sanyo Pachinko Paradise 13"
   region: "NTSC-J"
 SLPS-25683:
-  name: アイレム コレクション ポンコツ浪漫大活劇バンピートロット
-  name-sort: あいれむ これくしょん ぽんこつろまんだいかつげきばんぴーとろっと
+  name: ポンコツ浪漫大活劇バンピートロット【アイレム コレクション】
+  name-sort: ぽんこつろまんだいかつげきばんぴーとろっと【あいれむ これくしょん】
   name-en: "Ponkotsu Roman Daikatsugeki Bumpy Trot [Irem Collection]"
   region: "NTSC-J"
   gsHWFixes:
@@ -52386,8 +52388,8 @@ SLPS-25697:
   gameFixes:
     - EETimingHack # Fixes FMV hanging.
 SLPS-25698:
-  name: NEOGEOオンラインコレクション 餓狼伝説バトルアーカイブズ2
-  name-sort: NEOGEOおんらいんこれくしょん がろうでんせつばとるあーかいぶず2
+  name: 餓狼伝説バトルアーカイブズ2【NEOGEOオンラインコレクション】
+  name-sort: がろうでんせつばとるあーかいぶず2【NEOGEOおんらいんこれくしょん】
   name-en: "Fatal Fury - Battle Archives 2"
   region: "NTSC-J"
 SLPS-25699:
@@ -52460,13 +52462,13 @@ SLPS-25711:
   name-en: "Kashimashi! Girl Meets Girl [Best Collection]"
   region: "NTSC-J"
 SLPS-25712:
-  name: SNK BEST COLLECTION THE KING OF FIGHTERS NEOWAVE
-  name-sort: SNK BEST COLLECTION THE KING OF FIGHTERS NEOWAVE
+  name: THE KING OF FIGHTERS NEOWAVE【SNK BEST COLLECTION】
+  name-sort: THE KING OF FIGHTERS NEOWAVE【SNK BEST COLLECTION】
   name-en: "King of Fighters Neowave [SNK the Best]"
   region: "NTSC-J"
 SLPS-25713:
-  name: SNK BEST COLLECTION ティンクルスタースプライツーLa Petite Princesse-
-  name-sort: SNK BEST COLLECTION てぃんくるすたーすぷらいつーLa Petite Princesse-
+  name: ティンクルスタースプライツーLa Petite Princesse-【SNK BEST COLLECTION】
+  name-sort: てぃんくるすたーすぷらいつーLa Petite Princesse-【SNK BEST COLLECTION】
   name-en: "Twinkle Star Sprites - La Petite Princesse [SNK the Best]"
   region: "NTSC-J"
 SLPS-25714:
@@ -52596,13 +52598,13 @@ SLPS-25735:
   name-en: "Dragon Shadow Spell"
   region: "NTSC-J"
 SLPS-25736:
-  name: SNK BEST COLLECTION サムライスピリッツ天下一剣客伝
-  name-sort: SNK BEST COLLECTION さむらいすぴりっつてんかいちけんかくでん
+  name: サムライスピリッツ天下一剣客伝【SNK BEST COLLECTION】
+  name-sort: さむらいすぴりっつてんかいちけんかくでん【SNK BEST COLLECTION】
   name-en: "Samurai Spirits - Tenkaichi Kenkakuten [SNK Best]"
   region: "NTSC-J"
 SLPS-25737:
-  name: SNK BEST COLLECTION ネオジオバトルコロシアム
-  name-sort: SNK BEST COLLECTION ねおじおばとるころしあむ
+  name: ネオジオバトルコロシアム【SNK BEST COLLECTION】
+  name-sort: ねおじおばとるころしあむ【SNK BEST COLLECTION】
   name-en: "Neo Geo Battle Coliseum [SNK Best]"
   region: "NTSC-J"
 SLPS-25738:
@@ -52829,8 +52831,8 @@ SLPS-25778:
   name-en: "Sumomomo Momomo - Chijou Saikyou no Yome - Keishou Shimasho! Koi no Hanamuko Soudatsu-sen!!"
   region: "NTSC-J"
 SLPS-25779:
-  name: SNK BEST COLLECTION KOF MAXIMUMIMPACT 2
-  name-sort: SNK BEST COLLECTION KOF MAXIMUMIMPACT 2
+  name: KOF MAXIMUMIMPACT 2【SNK BEST COLLECTION】
+  name-sort: KOF MAXIMUMIMPACT 2【SNK BEST COLLECTION】
   name-en: "King of Fighters, The - Maximum Impact 2 [SNK Best Collection]"
   region: "NTSC-J"
 SLPS-25780:
@@ -52839,19 +52841,19 @@ SLPS-25780:
   name-en: "Nodame Cantabile"
   region: "NTSC-J"
 SLPS-25781:
-  name: NEOGEOオンラインコレクション 風雲 SUPER COMBO
-  name-sort: NEOGEOおんらいんこれくしょん ふううん SUPER COMBO
+  name: 風雲 SUPER COMBO【NEOGEOオンラインコレクション】
+  name-sort: ふううん SUPER COMBO【NEOGEOおんらいんこれくしょん】
   name-en: "Fuuun Super Combo"
   region: "NTSC-J"
   compat: 5
 SLPS-25782:
-  name: NEOGEOオンラインコレクション ワールドヒーローズ ゴージャス
-  name-sort: NEOGEOおんらいんこれくしょん わーるどひーろーず ごーじゃす
+  name: ワールドヒーローズ ゴージャス【NEOGEOオンラインコレクション】
+  name-sort: わーるどひーろーず ごーじゃす【NEOGEOおんらいんこれくしょん】
   name-en: "World Heroes - Gorgeous"
   region: "NTSC-J"
 SLPS-25783:
-  name: NEOGEOオンラインコレクション ザ・キング・オブ・ファイターズ98アルティメットマッチ
-  name-sort: NEOGEOおんらいんこれくしょん ざ・きんぐ・おぶ・ふぁいたーず98あるてぃめっとまっち
+  name: ザ・キング・オブ・ファイターズ98アルティメットマッチ【NEOGEOオンラインコレクション】
+  name-sort: ざ・きんぐ・おぶ・ふぁいたーず98あるてぃめっとまっち【NEOGEOおんらいんこれくしょん】
   name-en: "King of Fighters '98, The - Ultimate Match"
   region: "NTSC-J"
 SLPS-25784:
@@ -52875,13 +52877,13 @@ SLPS-25787:
   region: "NTSC-J"
   compat: 5
 SLPS-25788:
-  name: SNK BEST COLLECTION メタルスラッグ
-  name-sort: SNK BEST COLLECTION めたるすらっぐ
+  name: メタルスラッグ【SNK BEST COLLECTION】
+  name-sort: めたるすらっぐ【SNK BEST COLLECTION】
   name-en: "Metal Slug [SNK Best Collection]"
   region: "NTSC-J"
 SLPS-25789:
-  name: SNK BEST COLLECTION THE KING OF FIGHTERS XI
-  name-sort: SNK BEST COLLECTION THE KING OF FIGHTERS XI
+  name: THE KING OF FIGHTERS XI【SNK BEST COLLECTION】
+  name-sort: THE KING OF FIGHTERS XI【SNK BEST COLLECTION】
   name-en: "King of Fighters XI, The [SNK Best Collection]"
   region: "NTSC-J"
 SLPS-25790:
@@ -53155,8 +53157,8 @@ SLPS-25838:
   name-en: "Taiheiyou no Arashi - Senkan Yamato, Akatsuki ni Shutsugeki su"
   region: "NTSC-J"
 SLPS-25839:
-  name: NEOGEOオンラインコレクション サムライスピリッツ 六番勝負
-  name-sort: NEOGEOおんらいんこれくしょん さむらいすぴりっつ ろくばんしょうぶ
+  name: サムライスピリッツ 六番勝負【NEOGEOオンラインコレクション】
+  name-sort: さむらいすぴりっつ ろくばんしょうぶ【NEOGEOおんらいんこれくしょん】
   name-en: "Samurai Spirits - Rokuban Shoubu [NeoGeo Online Collection Vol. 12]"
   region: "NTSC-J"
 SLPS-25840:
@@ -53217,8 +53219,8 @@ SLPS-25848:
   name-en: "Naraku no Shiro"
   region: "NTSC-J"
 SLPS-25849:
-  name: NEOGEOオンラインコレクション サンソフトコレクション
-  name-sort: NEOGEOおんらいんこれくしょん さんそふとこれくしょん
+  name: サンソフトコレクション【NEOGEOオンラインコレクション】
+  name-sort: さんそふとこれくしょん【NEOGEOおんらいんこれくしょん】
   name-en: "Sunsoft Collection"
   region: "NTSC-J"
   compat: 5
@@ -53230,15 +53232,15 @@ SLPS-25850:
   gsHWFixes:
     roundSprite: 1 # Fixes textboxes and character portraits.
 SLPS-25851:
-  name: アイレムコレクション 絶体絶命都市2-凍てついた記憶たち-
-  name-sort: あいれむこれくしょん ぜったいぜつめいとし2-いてついたきおくたち-
+  name: 絶体絶命都市2-凍てついた記憶たち-【アイレムコレクション】
+  name-sort: ぜったいぜつめいとし2-いてついたきおくたち-【あいれむこれくしょん】
   name-en: "Zettai Zetsumei Toshi 2 - Itetsuita Kioku Tachi [Irem Collection]"
   region: "NTSC-J"
   gsHWFixes:
     getSkipCount: "GSC_ZettaiZetsumeiToshi2"
 SLPS-25852:
-  name: アイレムコレクション パチパラ13 〜スーパー海とパチプロ風雲録〜
-  name-sort: あいれむこれくしょん ぱちぱら13 〜すーぱーうみとぱちぷろふううんろく〜
+  name: パチパラ13 〜スーパー海とパチプロ風雲録〜【アイレムコレクション】
+  name-sort: ぱちぱら13 〜すーぱーうみとぱちぷろふううんろく〜【あいれむこれくしょん】
   name-en: "Sanyo Pachinko Paradise 13 [Irem Collection]"
   region: "NTSC-J"
 SLPS-25853:
@@ -53294,23 +53296,23 @@ SLPS-25862:
   name-en: "Hisshou Pachinko - Pachi-Slot Kouryoku Series Vol.05 - CR Neon Genesis Evangelion Sekandoinpakuto & Pachislot Neon Genesis Evangelion [Special Price Edition]"
   region: "NTSC-J"
 SLPS-25863:
-  name: NEOGEOオンラインコレクション THE BEST 餓狼伝説 バトルアーカイブズ1
-  name-sort: NEOGEOおんらいんこれくしょん THE BEST がろうでんせつ ばとるあーかいぶず1
+  name: THE BEST 餓狼伝説 バトルアーカイブズ1【NEOGEOオンラインコレクション】
+  name-sort: THE BEST がろうでんせつ ばとるあーかいぶず1【NEOGEOおんらいんこれくしょん】
   name-en: "Fatal Fury - Battle Archives 1 [SNK the Best]"
   region: "NTSC-J"
 SLPS-25864:
-  name: NEOGEOオンラインコレクション THE BEST 餓狼伝説バトルアーカイブズ2
-  name-sort: NEOGEOおんらいんこれくしょん THE BEST がろうでんせつばとるあーかいぶず2
+  name: THE BEST 餓狼伝説バトルアーカイブズ2【NEOGEOオンラインコレクション】
+  name-sort: THE BEST がろうでんせつばとるあーかいぶず2【NEOGEOおんらいんこれくしょん】
   name-en: "Fatal Fury - Battle Archives 2 [SNK the Best]"
   region: "NTSC-J"
 SLPS-25865:
-  name: NEOGEOオンラインコレクション THE BEST ザ・キング・オブ・ファイターズ〜ネスツ編〜
-  name-sort: NEOGEOおんらいんこれくしょん THE BEST ざ・きんぐ・おぶ・ふぁいたーず〜ねすつへん〜
+  name: THE BEST ザ・キング・オブ・ファイターズ〜ネスツ編〜【NEOGEOオンラインコレクション】
+  name-sort: THE BEST ざ・きんぐ・おぶ・ふぁいたーず〜ねすつへん〜【NEOGEOおんらいんこれくしょん】
   name-en: "King of Fighters, The - Nests [SNK the Best]"
   region: "NTSC-J"
 SLPS-25866:
-  name: NEOGEOオンラインコレクション THE BEST 風雲スーパーコンボ
-  name-sort: NEOGEOおんらいんこれくしょん THE BEST ふううんすーぱーこんぼ
+  name: THE BEST 風雲スーパーコンボ【NEOGEOオンラインコレクション】
+  name-sort: THE BEST ふううんすーぱーこんぼ【NEOGEOおんらいんこれくしょん】
   name-en: "Fuuun Super Combo [SNK the Best]"
   region: "NTSC-J"
 SLPS-25867:
@@ -53574,13 +53576,13 @@ SLPS-25932:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
 SLPS-25934:
-  name: NEOGEOオンラインコレクション THE BEST サムライスピリッツ六番勝負
-  name-sort: NEOGEOおんらいんこれくしょん THE BEST さむらいすぴりっつろくばんしょうぶ
+  name: THE BEST サムライスピリッツ六番勝負【NEOGEOオンラインコレクション】
+  name-sort: THE BEST さむらいすぴりっつろくばんしょうぶ【NEOGEOおんらいんこれくしょん】
   name-en: "Samurai Spirits - Rokuban Shoubu [NeoGeo Online Collection the Best]"
   region: "NTSC-J"
 SLPS-25935:
-  name: NEOGEOオンラインコレクション THE BEST ザ・キング・オブ・ファイターズ'98 アルティメットマッチ
-  name-sort: NEOGEOおんらいんこれくしょん THE BEST ざ・きんぐ・おぶ・ふぁいたーず'98 あるてぃめっとまっち
+  name: THE BEST ザ・キング・オブ・ファイターズ'98 アルティメットマッチ【NEOGEOオンラインコレクション】
+  name-sort: THE BEST ざ・きんぐ・おぶ・ふぁいたーず'98 あるてぃめっとまっち【NEOGEOおんらいんこれくしょん】
   name-en: "King of Fighters '98 Ultimate Match, The [NeoGeo Online Collection the Best]"
   region: "NTSC-J"
 SLPS-25936:

--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -33,55 +33,88 @@
 # ---------------------------------------------
 
 ALCH-00001:
-  name: "Katakamuna - Ushinawareta Ingaritsu [Deluxe Pack]"
+  name: 片神名〜喪われた因果律〜
+  name-sort: かたかむな〜うしなわれたいんがりつ〜
+  name-en: "Katakamuna - Ushinawareta Ingaritsu [Deluxe Pack]"
   region: "NTSC-J"
 ALCH-00003:
-  name: "Chocolat Maid Cafe Curio [Limited Edition]"
+  name: ショコラ　〜maid cafe curio〜 限定版
+  name-sort: しょこら　〜maid cafe curio〜 げんていばん
+  name-en: "Chocolat Maid Cafe Curio [Limited Edition]"
   region: "NTSC-J"
 ALCH-00005:
-  name: "Haru no Ashioto - Step of Spring [Paku Paku Pack]"
+  name: はるのあしおと -Step of Spring- パクパクパック
+  name-en: "Haru no Ashioto - Step of Spring [Paku Paku Pack]"
   region: "NTSC-J"
 ALCH-00007:
-  name: "Parfait - Chocolat Second Style [Limited Edition]"
+  name: パルフェ Chocolat Second Style 限定版
+  name-sort: ぱるふぇ Chocolat Second Style げんていばん
+  name-en: "Parfait - Chocolat Second Style [Limited Edition]"
   region: "NTSC-J"
 ALCH-00008:
-  name: "Aria - The Natural - Tooi Yume no Mirage [Limited Edition]"
+  name: ARIA The NATURAL 〜遠い記憶のミラージュ〜 限定版
+  name-sort: ARIA The NATURAL 〜とおいきおくのみらーじゅ〜
+  name-en: "Aria - The Natural - Tooi Yume no Mirage [Limited Edition]"
   region: "NTSC-J"
 ALCH-00009:
-  name: "Higurashi no Naku Koro ni Matsuri [First Print Limited Edition]"
+  name: ひぐらしのなく頃に祭 初回限定版
+  name-sort: ひぐらしのなくころにまつり　しょかいげんていばん
+  name-en: "Higurashi no Naku Koro ni Matsuri [First Print Limited Edition]"
   region: "NTSC-J"
 ALCH-00010:
-  name: "Kono Aozora ni Yakusoku wo - Melody of the Sun and Sea [Limited Edition]"
+  name: この青空に約束を　〜melody of the sun and sea〜 限定版
+  name-sort: このあおぞらにやくそくを　〜melody of the sun and sea〜 げんていばん
+  name-en: "Kono Aozora ni Yakusoku wo - Melody of the Sun and Sea [Limited Edition]"
   region: "NTSC-J"
 ALCH-00011:
-  name: "Pure x Cure RE-Covery [Koi no Kyuukyuu Set]"
+  name: "Pure×Cure Re:covery 恋と救急セット"
+  name-sort: "Pure×Cure Re:covery こいときゅうきゅうせっと"
+  name-en: "Pure x Cure RE-Covery [Koi no Kyuukyuu Set]"
   region: "NTSC-J"
 ALCH-00014:
-  name: "Aria - The Origination ~Aoi Hoshi no El Cielo~ [Limited Edition]"
+  name: ARIA The ORIGINATION 〜蒼い惑星のエルシエロ〜 限定版
+  name-sort: ARIA The ORIGINATION 〜あおいほしののえるしえろ〜 げんていばん
+  name-en: "Aria - The Origination ~Aoi Hoshi no El Cielo~ [Limited Edition]"
   region: "NTSC-J"
 ALCH-00015:
-  name: "Sugar+Spice! - Anoko no Suteki na Nanimokamo [First Press Limited Edition]"
+  name: Sugar+Spice! ～あの子のステキな何もかも～ 初回限定版
+  name-sort: Sugar+Spice! ～あのこのすてきななにもかも～ しょかいげんていばん
+  name-en: "Sugar+Spice! - Anoko no Suteki na Nanimokamo [First Press Limited Edition]"
   region: "NTSC-J"
 ALCH-00016:
-  name: "Koisuru Otome to Shugo no Tate - The Shield of Aigis [Limited Edition]"
+  name: 恋する乙女と守護の楯 -The shield of AIGIS- 限定版
+  name-sort: こいするおとめとしゅごのたて -The shield of AIGIS- げんていばん
+  name-en: "Koisuru Otome to Shugo no Tate - The Shield of Aigis [Limited Edition]"
   region: "NTSC-J"
 ALCH-00017:
-  name: "Triggerheart Exelica Enhanced [Nendroid Super Set]"
+  name: トリガーハート エグゼリカ エンハンスド ねんどろいど スペシャルセット 初回限定版同梱
+  name-sort: とりがーはーと えぐぜりか えんはんすど ねんどろいど すぺしゃるせっと しょかいげんていばんどうこん
+  name-en: "Triggerheart Exelica Enhanced [Nendroid Super Set]"
   region: "NTSC-J"
 ALCH-00021:
-  name: "Sekirei - Mirai Kara no Okurimono [Special Pack]"
+  name: セキレイ ～未来からのおくりもの～ 幾久しく！スペシャルパック
+  name-sort: せきれい 〜みらいからのおくりもの〜 いくひさしく！すぺしゃるぱっく
+  name-en: "Sekirei - Mirai Kara no Okurimono [Special Pack]"
   region: "NTSC-J"
 ALCH-00027:
-  name: "Suzunone Seven - Rebirth Knot [Limited Edition]"
+  name: スズノネセブン！～Rebirth Knot〜 限定版
+  name-sort: すずのねせぶん！～Rebirth Knot〜 げんていばん
+  name-en: "Suzunone Seven - Rebirth Knot [Limited Edition]"
   region: "NTSC-J"
 ALCH-00028:
-  name: "Hana to Otome ni Shukufuku wo - Harukaze no Okurimono [Saint Box]"
+  name: 花と乙女に祝福を 〜春風の贈り物〜 聖ルピナスBOX
+  name-sort: はなとおとめにしゅくふくを 〜はるかぜのおくりもの〜 せいんとるぴなすBOX
+  name-en: "Hana to Otome ni Shukufuku wo - Harukaze no Okurimono [Saint Box]"
   region: "NTSC-J"
 ALCH-0004:
-  name: "Duel Savior Destiny [Messiah Box]"
+  name: デュエルセイヴァー　ディスティニー メサイアボックス
+  name-sort: でゅえるせいゔぁー　でぃすてぃにー めさいあぼっくす
+  name-en: "Duel Savior Destiny [Messiah Box]"
   region: "NTSC-J"
 CPCS-01005:
-  name: "Gun Survivor 4 - BioHazard - Heroes Never Die [with GunCon2]"
+  name: ガンサバイバー4 バイオハザード ヒーローズ ネバー ダイ WITH ガンコン2
+  name-sort: がんさばいばー4 ばいおはざーど ひーろーず ねばー だい WITH がんこん2
+  name-en: "Gun Survivor 4 - BioHazard - Heroes Never Die [with GunCon2]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 1 # Fixes character offset with flashlight and blurriness.
@@ -89,7 +122,9 @@ CPCS-01005:
     roundSprite: 2 # Fixes font artifacts.
     mergeSprite: 1 # Fixes flame-like bleeding.
 CPCS-01020:
-  name: "Monster Hunter 2 [DX Hunters Box]"
+  name: モンスターハンター2 DXハンターボックス
+  name-sort: もんすたーはんたー2 DXはんたーぼっくす
+  name-en: "Monster Hunter 2 [DX Hunters Box]"
   region: "NTSC-J"
   compat: 5
   clampModes:
@@ -97,7 +132,9 @@ CPCS-01020:
   gsHWFixes:
     maximumBlendingLevel: 0 # Fixes unnecessary load on the GPU.
 GUST-00009:
-  name: "Mana Khemia - Alchemists of Al-Revis [Premium Box]"
+  name: マナケミア 〜学園の錬金術師たち〜 プレミアムボックス
+  name-sort: まなけみあ 〜がくえんのれんきんじゅつしたち〜 ぷれみあむぼっくす
+  name-en: "Mana Khemia - Alchemists of Al-Revis [Premium Box]"
   region: "NTSC-J"
   roundModes:
     eeRoundMode: 0 # Fixes jump issue.
@@ -106,10 +143,14 @@ GUST-00009:
   gsHWFixes:
     roundSprite: 1 # Fixes misalignment of textures in the Pause Menu.
 PAPX-90201:
-  name: "Fantavision [Taikenban]"
+  name: ファンタビジョン 体験版
+  name-sort: ふぁんたびじょん たいけんばん
+  name-en: "Fantavision [Taikenban]"
   region: "NTSC-J"
 PAPX-90202:
-  name: "IQ Remix - Intelligent Qube [Trial]"
+  name: I.Q REMIX＋ 体験版
+  name-sort: I.Q REMIX＋ たいけんばん
+  name-en: "IQ Remix - Intelligent Qube [Trial]"
   region: "NTSC-J"
 PAPX-90203:
   name: "Gran Turismo 2000 [Trial]"
@@ -167,7 +208,9 @@ PAPX-90220:
   name: "Surveillance - Kanshisha"
   region: "NTSC-J"
 PAPX-90222:
-  name: "Jak x Daxter - Kyuu Sekai no Isan [Demo, Taikenban]"
+  name: ジャック×ダクスター 旧世界の遺産 体験版
+  name-sort: じゃっく×だくすたー きゅうせかいのいさん たいけんばん
+  name-en: "Jak x Daxter - Kyuu Sekai no Isan [Demo, Taikenban]"
   region: "NTSC-J"
   gsHWFixes:
     mipmap: 2 # Fixes broken textures.
@@ -175,7 +218,9 @@ PAPX-90222:
     cpuSpriteRenderBW: 4 # Fixes character and water textures.
     cpuSpriteRenderLevel: 2 # Needed for above.
 PAPX-90223:
-  name: "Jak x Daxter - Kyuu Sekai no Isan [Demo, Taikenban]"
+  name: ジャック×ダクスター 旧世界の遺産 体験版
+  name-sort: じゃっく×だくすたー きゅうせかいのいさん たいけんばん
+  name-en: "Jak x Daxter - Kyuu Sekai no Isan [Demo, Taikenban]"
   region: "NTSC-J"
   gsHWFixes:
     mipmap: 2 # Fixes broken textures.
@@ -201,7 +246,9 @@ PAPX-90230:
   name: "Arc the Lad - Seirei no Tasogare - Premiere Disc"
   region: "NTSC-J"
 PAPX-90231:
-  name: "Kaitou Sly Cooper [Demo, Taikenban]"
+  name: 怪盗 スライ・クーパー 体験版
+  name-sort: かいとう すらい・くーぱー たいけんばん
+  name-en: "Kaitou Sly Cooper [Demo, Taikenban]"
   region: "NTSC-J"
 PAPX-90232:
   name: "Chain Dive"
@@ -6879,15 +6926,18 @@ SCPN-60160:
   name: "PlayStation BB Navigator - Version 0.32"
   region: "NTSC-J"
 SCPS-11001:
-  name: "I.Q. Remix+ - Intelligent Qube"
+  name: I.Q REMIX＋
+  name-en: "I.Q. Remix+ - Intelligent Qube"
   region: "NTSC-J"
   compat: 5
 SCPS-11002:
-  name: "Fantavision"
+  name: FANTAVISION
+  name-sort: FANTAVISION
+  name-en: "Fantavision"
   region: "NTSC-J"
   compat: 5
 SCPS-11003:
-  name: "Ico"
+  name: ICO
   region: "NTSC-J"
   compat: 5
   clampModes:
@@ -6898,63 +6948,95 @@ SCPS-11003:
     halfPixelOffset: 1 # Fixes effect misalignment.
     moveHandler: "MV_Ico" # Fixes depth buffer post-processing.
 SCPS-11004:
-  name: "Bikkuri Mouse"
+  name: びっくりマウス
+  name-sort: びっくりまうす
+  name-en: "Bikkuri Mouse"
   region: "NTSC-J"
   compat: 5
 SCPS-11005:
-  name: "Sagashi ni Ikouyo - Go to Find It!"
+  name: 探しに行こうよ
+  name-sort: さがしにいこうよ
+  name-en: "Sagashi ni Ikouyo - Go to Find It!"
   region: "NTSC-J"
 SCPS-11006:
-  name: "Sky Gunner"
+  name: SKY GUNNER
+  name-sort: SKY GUNNER
+  name-en: "Sky Gunner"
   region: "NTSC-J"
   compat: 5
 SCPS-11007:
-  name: "Tsuganai"
+  name: tsugunai 〜つぐない〜
+  name-sort: tsugunai 〜つぐない〜
+  name-en: "Tsuganai"
   region: "NTSC-J"
 SCPS-11008:
-  name: "Boku to Mao"
+  name: ボクと魔王
+  name-sort: ぼくとまおう
+  name-en: "Boku to Mao"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
     autoFlush: 1 # Depth of field blur is incorrect without it.
 SCPS-11009:
-  name: "Ka"
+  name: 蚊
+  name-sort: か
+  name-en: "Ka"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
 SCPS-11010:
-  name: "Yoake no Mariko [with Microphone]"
+  name: 夜明けのマリコ パフォーマンスパック
+  name-sort: よあけのまりこ ぱふぉーまんすぱっく
+  name-en: "Yoake no Mariko [with Microphone]"
   region: "NTSC-J"
 SCPS-11011:
-  name: "Check-i-TV"
+  name: Check-i-TV
+  name-sort: Check-i-TV
+  name-en: "Check-i-TV"
   region: "NTSC-J"
 SCPS-11012:
-  name: "Rimococoron"
+  name: リモココロン
+  name-sort: りもこころん
+  name-en: "Rimococoron"
   region: "NTSC-J"
   compat: 5
 SCPS-11013:
-  name: "Bravo Music"
+  name: ブラボーミュージック
+  name-sort: ぶらぼーみゅーじっく
+  name-en: "Bravo Music"
   region: "NTSC-J"
   compat: 5
 SCPS-11014:
-  name: "Pipo Saru 2001"
+  name: ピポサル2001
+  name-sort: ぴぽさる2001
+  name-en: "Pipo Saru 2001"
   region: "NTSC-J"
   compat: 5
 SCPS-11015:
-  name: "Check-i-TV [Kyou kara Check! Pack]"
+  name: Check-i-TV きょうから「チェキッ」パック
+  name-sort: Check-i-TV きょうから「ちぇきっ」ぱっく
+  name-en: "Check-i-TV [Kyou kara Check! Pack]"
   region: "NTSC-J"
 SCPS-11016:
-  name: "Seigi no Mikata"
+  name: 正義の味方
+  name-sort: せいぎのみかた
+  name-en: "Seigi no Mikata"
   region: "NTSC-J"
 SCPS-11017:
-  name: "Bravo Music - Christmas Edition"
+  name: ブラボーミュージック Christmas Edition
+  name-sort: ぶらぼーみゅーじっく Christmas Edition
+  name-en: "Bravo Music - Christmas Edition"
   region: "NTSC-J"
 SCPS-11018:
-  name: "Yoake no Mariko"
+  name: 夜明けのマリコ
+  name-sort: よあけのまりこ
+  name-en: "Yoake no Mariko"
   region: "NTSC-J"
 SCPS-11019:
-  name: "Bravo Music - Chou-Meikyokuban [Genteiban]"
+  name: ブラボーミュージック 超名曲盤（限定版）
+  name-sort: ぶらぼーみゅーじっく ちょうめいきょくばん（げんていばん）
+  name-en: "Bravo Music - Chou-Meikyokuban [Genteiban]"
   region: "NTSC-J"
   memcardFilters:
     - "SCPS-11023"
@@ -6964,132 +7046,193 @@ SCPS-11020:
   name: "Otostaz [Taikenban]"
   region: "NTSC-J"
 SCPS-11021:
-  name: "Yoake no Mariko 2nd Act"
+  name: 夜明けのマリコ 2ndAct パフォーマンスパック
+  name-sort: よあけのまりこ 2ndAct ぱふぉーまんすぱっく
+  name-en: "Yoake no Mariko 2nd Act"
   region: "NTSC-J"
 SCPS-11022:
-  name: "Yoake no Mariko 2nd Act"
+  name: 夜明けのマリコ 2ndAct
+  name-sort: よあけのまりこ 2ndAct
+  name-en: "Yoake no Mariko 2nd Act"
   region: "NTSC-J"
 SCPS-11023:
-  name: "Bravo Music - Chou-Meikyokuban"
+  name: ブラボーミュージック 超名曲盤
+  name-sort: ぶらぼーみゅーじっく ちょうめいきょくばん
+  name-en: "Bravo Music - Chou-Meikyokuban"
   region: "NTSC-J"
   memcardFilters:
     - "SCPS-11023"
     - "SCPS-11019"
     - "SCPS-11020"
 SCPS-11024:
-  name: "Otostaz"
+  name: オトスタツ
+  name-sort: おとすたつ
+  name-en: "Otostaz"
   region: "NTSC-J"
   compat: 5
 SCPS-11025:
-  name: "Space Fisherman"
+  name: スペースフィッシャーメン
+  name-sort: すぺーすふぃっしゃーめん
+  name-en: "Space Fisherman"
   region: "NTSC-J"
   compat: 5
   clampModes:
     vuClampMode: 3 # Fixes SPS and bad textures.
 SCPS-11026:
-  name: "Gacharoku"
+  name: ガチャろく
+  name-sort: がちゃろく
+  name-en: "Gacharoku"
   region: "NTSC-J"
   gsHWFixes:
     gpuPaletteConversion: 2 # Fixes hash cache exploding.
 SCPS-11027:
-  name: "Mawaza"
+  name: MAWAZA
+  name-en: "Mawaza"
   region: "NTSC-J"
   compat: 5
 SCPS-11028:
-  name: "Let's Bravo Music"
+  name: Let’s ブラボーミュージック
+  name-sort: Let’s ぶらぼーみゅーじっく
+  name-en: "Let's Bravo Music"
   region: "NTSC-J"
 SCPS-11029:
-  name: "Shibai Muchi"
+  name: しばいみち マイク同梱版
+  name-sort: しばいみち まいくどうこんばん
+  name-en: "Shibai Muchi"
   region: "NTSC-J"
 SCPS-11030:
-  name: "Shibai Muchi [with Microphone]"
+  name: しばいみち
+  name-sort: しばいみち
+  name-en: "Shibai Muchi [with Microphone]"
   region: "NTSC-J"
 SCPS-11031:
-  name: "Kumauta"
+  name: くまうた
+  name-sort: くまうた
+  name-en: "Kumauta"
   region: "NTSC-J"
 SCPS-11032:
-  name: "Vib-Ripple"
+  name: ビブリップル
+  name-sort: びぶりっぷる
+  name-en: "Vib-Ripple"
   region: "NTSC-J"
   compat: 5
 SCPS-11033:
-  name: "Mojib-Ribbon"
+  name: モジブリボン
+  name-sort: もじぶりぼん
+  name-en: "Mojib-Ribbon"
   region: "NTSC-J"
   compat: 5
 SCPS-11034:
-  name: "Gacharoku 2"
+  name: ガチャろく2 〜今度は世界一周よ!!〜
+  name-sort: がちゃろく2 〜こんどはせかいいっしゅうよ!!〜
+  name-en: "Gacharoku 2"
   region: "NTSC-J"
 SCPS-15001:
-  name: "Scandal"
+  name: スキャンダル
+  name-sort: すきゃんだる
+  name-en: "Scandal"
   region: "NTSC-J"
   compat: 5
   gameFixes:
     - InstantDMAHack # Fixes graphical corruption.
 SCPS-15002:
-  name: "TV DJ"
+  name: TVDJ〜ティービィーディージェー〜
+  name-sort: TVDJ〜てぃーびぃーでぃーじぇー〜
+  name-en: "TV DJ"
   region: "NTSC-J"
   compat: 5
 SCPS-15003:
-  name: "Sky Odyssey"
+  name: The Sky Odyssey
+  name-sort: The Sky Odyssey
+  name-en: "Sky Odyssey"
   region: "NTSC-J"
   clampModes:
     vu0ClampMode: 3 # Fixes runway line thickness on minimap.
 SCPS-15004:
-  name: "Dark Cloud"
+  name: ダーククラウド
+  name-sort: だーくくらうど
+  name-en: "Dark Cloud"
   region: "NTSC-J"
   gsHWFixes:
     mipmap: 2 # Fixes mipmapping.
     trilinearFiltering: 1 # Smoothes out mipmapping.
     halfPixelOffset: 2 # Distance is less blurry, game has reduced LOD so it will still look blurry.
 SCPS-15005:
-  name: "Phase Paradox"
+  name: PHASE PARADOX
+  name-sort: PHASE PARADOX
+  name-en: "Phase Paradox"
   region: "NTSC-J"
 SCPS-15006:
-  name: "Popolocrois Story 3 [Limited Edition]"
+  name: ポポロクロイス〜はじまりの冒険〜 プレミアムボックス
+  name-sort: ぽぽろくろいす〜はじまりのぼうけん〜 ぷれみあむぼっくす
+  name-en: "Popolocrois Story 3 [Limited Edition]"
   region: "NTSC-J"
 SCPS-15007:
-  name: "Blood - The Last Vampire - Vol.1 Joukan"
+  name: BLOOD THE LAST VAMPIRE （上巻）
+  name-sort: BLOOD THE LAST VAMPIRE （じょうかん）
+  name-en: "Blood - The Last Vampire - Vol.1 Joukan"
   region: "NTSC-J"
   compat: 5
 SCPS-15008:
-  name: "Blood - The Last Vampire - Vol.2 Gekan"
+  name: BLOOD THE LAST VAMPIRE （下巻）
+  name-sort: BLOOD THE LAST VAMPIRE （げかん）
+  name-en: "Blood - The Last Vampire - Vol.2 Gekan"
   region: "NTSC-J"
   compat: 5
 SCPS-15009:
-  name: "Gran Turismo 3 - A-Spec"
+  name: グランツーリスモ3 A-spec
+  name-sort: ぐらんつーりすも3 A-spec
+  name-en: "Gran Turismo 3 - A-Spec"
   region: "NTSC-J"
   gsHWFixes:
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 SCPS-15010:
-  name: "Gran Turismo - Concept 2001 Tokyo"
+  name: グランツーリスモ コンセプト 2001 TOKYO
+  name-sort: ぐらんつーりすも こんせぷと 2001 TOKYO
+  name-en: "Gran Turismo - Concept 2001 Tokyo"
   region: "NTSC-J"
   compat: 5
 SCPS-15011:
-  name: "Extermination"
+  name: EXTERMINATION
+  name-sort: EXTERMINATION
+  name-en: "Extermination"
   region: "NTSC-J"
   gameFixes:
     - SoftwareRendererFMVHack # Black FMV.
 SCPS-15012:
-  name: "Surveillance"
+  name: サーヴィランス 監視者
+  name-sort: さーゔぃらんす かんししゃ
+  name-en: "Surveillance"
   region: "NTSC-J"
 SCPS-15013:
-  name: "Poinie's Poin"
+  name: ポイニーポイン
+  name-sort: ぽいにーぽいん
+  name-en: "Poinie's Poin"
   region: "NTSC-J"
   gameFixes:
     - SoftwareRendererFMVHack # Prevents ingame flicker due to large clears/copies.
   gsHWFixes:
     textureInsideRT: 1 # Fixes text corruption.
 SCPS-15014:
-  name: "Genshi no Kotoba"
+  name: げんしのことば
+  name-sort: げんしのことば
+  name-en: "Genshi no Kotoba"
   region: "NTSC-J"
 SCPS-15015:
-  name: "Toro to Kyuujitsu"
+  name: トロと休日
+  name-sort: とろときゅうじつ
+  name-en: "Toro to Kyuujitsu"
   region: "NTSC-J"
   compat: 5
 SCPS-15016:
-  name: "Minna no Golf 3"
+  name: みんなのGOLF 3
+  name-sort: みんなのGOLF 3
+  name-en: "Minna no Golf 3"
   region: "NTSC-J"
 SCPS-15017:
-  name: "PaRappa the Rapper 2"
+  name: パラッパラッパー2
+  name-sort: ぱらっぱらっぱー2
+  name-en: "PaRappa the Rapper 2"
   region: "NTSC-J"
   speedHacks:
     instantVU1: 0 # Fixes noodles.
@@ -7100,20 +7243,28 @@ SCPS-15017:
     wildArmsHack: 1 # Fixes misaligment depth of field effect.
     roundSprite: 2 # Fixes misaligment depth of field effect even more.
 SCPS-15018:
-  name: "Train Simulator Real, The - Yamanote Sen"
+  name: THE 山手線 〜Train Simulator Real
+  name-sort: THE やまてせん 〜Train Simulator Real
+  name-en: "Train Simulator Real, The - Yamanote Sen"
   region: "NTSC-J"
 SCPS-15019:
-  name: "Formula One 2001"
+  name: Formula One 2001
+  name-sort: Formula One 2001
+  name-en: "Formula One 2001"
   region: "NTSC-J"
   gameFixes:
     - XGKickHack
 SCPS-15020:
-  name: "Legaia 2 - Duel Saga"
+  name: レガイア デュエルサーガ
+  name-sort: れがいあ でゅえるさーが
+  name-en: "Legaia 2 - Duel Saga"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Reduces ghosting.
 SCPS-15021:
-  name: "Jak x Daxter - Kyuusekai no Isan"
+  name: ジャック×ダクスター 旧世界の遺産
+  name-sort: じゃっく×だくすたー きゅうせかいのいさん
+  name-en: "Jak x Daxter - Kyuusekai no Isan"
   region: "NTSC-J"
   gsHWFixes:
     mipmap: 2 # Fixes broken textures.
@@ -7121,52 +7272,76 @@ SCPS-15021:
     cpuSpriteRenderBW: 4 # Fixes character and water textures.
     cpuSpriteRenderLevel: 2 # Needed for above.
 SCPS-15022:
-  name: "Dual Hearts"
+  name: デュアルハーツ
+  name-sort: でゅあるはーつ
+  name-en: "Dual Hearts"
   region: "NTSC-J"
 SCPS-15023:
-  name: "Wild ARMs - Advanced 3rd"
+  name: WILD ARMS Advanced 3rd プレミアムボックス
+  name-sort: WILD ARMS Advanced 3rd ぷれみあむぼっくす
+  name-en: "Wild ARMs - Advanced 3rd"
   region: "NTSC-J"
   gsHWFixes:
     wildArmsHack: 1 # Fixes font artifacts and out-of-bound 2D textures.
     gpuPaletteConversion: 2 # Fixes micro-stuttering and drops in performance while also reducing hash cache explosions and GS usage.
 SCPS-15024:
-  name: "Wild ARMs - Advanced 3rd"
+  name: WILD ARMS Advanced 3rd
+  name-sort: WILD ARMS Advanced 3rd
+  name-en: "Wild ARMs - Advanced 3rd"
   region: "NTSC-J"
   gsHWFixes:
     wildArmsHack: 1 # Fixes font artifacts and out-of-bound 2D textures.
     gpuPaletteConversion: 2 # Fixes micro-stuttering and drops in performance while also reducing hash cache explosions and GS usage.
 SCPS-15025:
-  name: "Saru Get You 2"
+  name: サルゲッチュ2
+  name-sort: さるげっちゅ2
+  name-en: "Saru Get You 2"
   region: "NTSC-J"
   compat: 5
 SCPS-15026:
-  name: "Boku no Natsuyasumi 2 - Umi no Bouken-hen"
+  name: ぼくのなつやすみ2 海の冒険篇
+  name-sort: ぼくのなつやすみ2 うみのぼうけんへん
+  name-en: "Boku no Natsuyasumi 2 - Umi no Bouken-hen"
   region: "NTSC-J"
 SCPS-15027:
-  name: "PoPoLoCrois - Hajimari no Bouken [Limited]"
+  name: ポポロクロイス〜はじまりの冒険〜 通常版(初回生産)
+  name-sort: ぽぽろくろいす〜はじまりのぼうけん〜 つうじょうばん(しょかいせいさん)
+  name-en: "PoPoLoCrois - Hajimari no Bouken [Limited]"
   region: "NTSC-J"
 SCPS-15028:
-  name: "PoPoLoCrois - Hajimari no Bouken"
+  name: ポポロクロイス〜はじまりの冒険〜
+  name-sort: ぽぽろくろいす〜はじまりのぼうけん〜
+  name-en: "PoPoLoCrois - Hajimari no Bouken"
   region: "NTSC-J"
 SCPS-15029:
-  name: "Xi (Sai) Jumbo"
+  name: XIゴ
+  name-sort: XIご
+  name-en: "Xi (Sai) Jumbo"
   region: "NTSC-J"
 SCPS-15030:
-  name: "Fantavision"
+  name: ふたりのFANTAVISION
+  name-sort: ふたりのFANTAVISION
+  name-en: "Fantavision"
   region: "NTSC-J"
   compat: 5
 SCPS-15031:
-  name: "Train Simulator Real, The"
+  name: THE 京浜急行　〜Train Simulator Real〜 （限定版）
+  name-sort: THE けいひんきゅうこう　〜Train Simulator Real〜 （げんていばん）
+  name-en: "Train Simulator Real, The"
   region: "NTSC-J"
   gsHWFixes:
     texturePreloading: 1 # Increases performance due to massive hash cache size.
 SCPS-15032:
-  name: "Formula One 2002"
+  name: Formula One 2002
+  name-sort: Formula One 2002
+  name-en: "Formula One 2002"
   region: "NTSC-J"
   gameFixes:
     - XGKickHack
 SCPS-15033:
-  name: "Dark Chronicle"
+  name: ダーククロニクル
+  name-sort: だーくくろにくる
+  name-en: "Dark Chronicle"
   region: "NTSC-J"
   clampModes:
     eeClampMode: 3 # Fixes textbox.
@@ -7175,74 +7350,109 @@ SCPS-15033:
     cpuSpriteRenderBW: 2 # Fixes lines in geometry.
     cpuSpriteRenderLevel: 2 # Needed for above.
 SCPS-15034:
-  name: "This is Football 2003"
+  name: This Is Football サッカー世界戦記 2003
+  name-sort: This Is Football さっかーせかいせんき 2003
+  name-en: "This is Football 2003"
   region: "NTSC-J"
 SCPS-15035:
-  name: "Train Simulator Real, The - Keihin Keikyu"
+  name: THE 京浜急行 〜Train Simulator Real
+  name-sort: THE けいひんきゅうこう 〜Train Simulator Real
+  name-en: "Train Simulator Real, The - Keihin Keikyu"
   region: "NTSC-J"
   gsHWFixes:
     texturePreloading: 1 # Increases performance due to massive hash cache size.
 SCPS-15036:
-  name: "Kaitou Sly Cooper"
+  name: 怪盗 スライ・クーパー
+  name-sort: かいとう すらい・くーぱー
+  name-en: "Kaitou Sly Cooper"
   region: "NTSC-J"
 SCPS-15037:
-  name: "Ratchet & Clank"
+  name: ラチェット＆クランク
+  name-sort: らちぇっと＆くらんく
+  name-en: "Ratchet & Clank"
   region: "NTSC-J"
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
     mipmap: 1
 SCPS-15038:
-  name: "Operator's Side"
+  name: OPERATOR’S SIDE マイク同梱版
+  name-sort: OPERATOR’S SIDE まいくどうこんばん
+  name-en: "Operator's Side"
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
 SCPS-15039:
-  name: "Operator's Side"
+  name: OPERATOR’S SIDE
+  name-sort: OPERATOR’S SIDE
+  name-en: "Operator's Side"
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
 SCPS-15040:
-  name: "Arc the Lad - Twilight of the Spirits [Limited Edition]"
+  name: アークザラッド 精霊の黄昏 プレミアムBOX
+  name-sort: あーくざらっど せいれいのたそがれ ぷれみあむBOX
+  name-en: "Arc the Lad - Twilight of the Spirits [Limited Edition]"
   region: "NTSC-J"
 SCPS-15041:
-  name: "Arc the Lad - Seirei no Koukon"
+  name: アークザラッド 精霊の黄昏
+  name-sort: あーくざらっど せいれいのたそがれ
+  name-en: "Arc the Lad - Seirei no Koukon"
   region: "NTSC-J"
 SCPS-15042:
-  name: "Deka Voice [with Microphone]"
+  name: デカボイス マイク同梱版
+  name-sort: でかぼいす まいくどうこんばん
+  name-en: "Deka Voice [with Microphone]"
   region: "NTSC-J"
 SCPS-15043:
-  name: "Deka Voice"
+  name: デカボイス
+  name-sort: でかぼいす
+  name-en: "Deka Voice"
   region: "NTSC-J"
   compat: 4
 SCPS-15044:
-  name: "SOCOM - U.S. Navy SEALs"
+  name: "SOCOM: U.S. NAVY SEALs"
+  name-en: "SOCOM - U.S. Navy SEALs"
   region: "NTSC-J"
   clampModes:
     vuClampMode: 2 # Fixes bad shadows.
 SCPS-15045:
-  name: "Ka 2- Let's Go Hawaiian"
+  name: 蚊2 レッツゴーハワイ
+  name-sort: か2 れっつごーはわい
+  name-en: "Ka 2- Let's Go Hawaiian"
   region: "NTSC-J"
   compat: 5
 SCPS-15046:
-  name: "Hungry Ghosts"
+  name: HUNGRY GHOSTS
+  name-sort: HUNGRY GHOSTS
+  name-en: "Hungry Ghosts"
   region: "NTSC-J"
   compat: 5
 SCPS-15047:
-  name: "Dokodemo Issyo - Watashi na Ehon"
+  name: どこでもいっしょ 私なえほん
+  name-sort: どこでもいっしょ わたしなえほん
+  name-en: "Dokodemo Issyo - Watashi na Ehon"
   region: "NTSC-J"
 SCPS-15049:
-  name: "Minna no Golf Online"
+  name: みんなのGOLF オンライン
+  name-sort: みんなのGOLF おんらいん
+  name-en: "Minna no Golf Online"
   region: "NTSC-J"
 SCPS-15050:
-  name: "Flipnic"
+  name: フリップニック
+  name-sort: ふりっぷにっく
+  name-en: "Flipnic"
   region: "NTSC-J"
   compat: 5
 SCPS-15051:
-  name: "MLB 2003"
+  name: MLB2003
+  name-sort: MLB2003
+  name-en: "MLB 2003"
   region: "NTSC-J"
 SCPS-15052:
-  name: "Saints Seinaru Mamono"
+  name: SAINTS（セインツ） 聖なる魔物
+  name-sort: SAINTS（せいんつ） せいなるまもの
+  name-en: "Saints Seinaru Mamono"
   region: "NTSC-J"
   roundModes:
     vu1RoundMode: 1 # Fixes SPS.
@@ -7250,7 +7460,9 @@ SCPS-15052:
   clampModes:
     vu1ClampMode: 0 # Fix other SPS.
 SCPS-15053:
-  name: "Siren"
+  name: SIREN
+  name-sort: SIREN
+  name-en: "Siren"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
@@ -7258,10 +7470,14 @@ SCPS-15053:
     cpuSpriteRenderBW: 4 # Fixes sky rendering.
     cpuSpriteRenderLevel: 2 # Needed for above.
 SCPS-15054:
-  name: "ChainDive"
+  name: CHAINDIVE
+  name-sort: CHAINDIVE
+  name-en: "ChainDive"
   region: "NTSC-J"
 SCPS-15055:
-  name: "Gran Turismo 4 - Prologue"
+  name: グランツーリスモ4 “プロローグ”版
+  name-sort: ぐらんつーりすも4 “ぷろろーぐ”ばん
+  name-en: "Gran Turismo 4 - Prologue"
   region: "NTSC-J"
   gsHWFixes:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
@@ -7282,7 +7498,9 @@ SCPS-15055:
   # eeClampMode = 3  Text in races works.
   # vuClampMode = 2  Text in GT mode works.
 SCPS-15056:
-  name: "Ratchet & Clank 2"
+  name: ラチェット＆クランク2 ガガガ！銀河のコマンドーっす
+  name-sort: らちぇっと＆くらんく2 ががが！ぎんがのこまんどーっす
+  name-en: "Ratchet & Clank 2"
   region: "NTSC-J"
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
@@ -7292,7 +7510,9 @@ SCPS-15056:
     - "SCPS-15056"
     - "SCPS-15037"
 SCPS-15057:
-  name: "Jak and Daxter II"
+  name: ジャック×ダクスター2
+  name-sort: じゃっく×だくすたー2
+  name-en: "Jak and Daxter II"
   region: "NTSC-J"
   gsHWFixes:
     mipmap: 2 # Fixes broken textures.
@@ -7301,25 +7521,39 @@ SCPS-15057:
     cpuSpriteRenderLevel: 2 # Needed for above.
     autoFlush: 2 # Fixes lighting.
 SCPS-15058:
-  name: "Arc the Lad - Generation"
+  name: Arc The Lad GENERATION
+  name-sort: Arc The Lad GENERATION
+  name-en: "Arc the Lad - Generation"
   region: "NTSC-J"
 SCPS-15059:
-  name: "Minna no Golf 4"
+  name: みんなのGOLF 4
+  name-sort: みんなのGOLF 4
+  name-en: "Minna no Golf 4"
   region: "NTSC-J"
 SCPS-15060:
-  name: "Koufuku Sousakan"
+  name: 幸福操作官
+  name-sort: こうふくそうさかん
+  name-en: "Koufuku Sousakan"
   region: "NTSC-J"
 SCPS-15061:
-  name: "EyeToy - Play [with Camera]"
+  name: "EyeToy: Play(アイトーイ プレイ)"
+  name-sort: "EyeToy: Play(あいとーい ぷれい)"
+  name-en: "EyeToy - Play [with Camera]"
   region: "NTSC-J"
 SCPS-15062:
-  name: "Bakuso! Mountain Bikers"
+  name: 爆走マウンテンバイカーズ
+  name-sort: ばくそうまうんてんばいかーず
+  name-en: "Bakuso! Mountain Bikers"
   region: "NTSC-J"
 SCPS-15063:
-  name: "Popolocrois - The Law of the Moon"
+  name: ポポロクロイス 月の掟の冒険
+  name-sort: ぽぽろくろいす つきのおきてのぼうけん
+  name-en: "Popolocrois - The Law of the Moon"
   region: "NTSC-J"
 SCPS-15064:
-  name: "Koukaku Kidoutai - Stand Alone Complex"
+  name: 攻殻機動隊 STAND ALONE COMPLEX
+  name-sort: こうかくきどうたい STAND ALONE COMPLEX
+  name-en: "Koukaku Kidoutai - Stand Alone Complex"
   region: "NTSC-J"
   compat: 5
   patches:
@@ -7363,73 +7597,112 @@ SCPS-15064:
   gsHWFixes:
     getSkipCount: "GSC_GiTS"
 SCPS-15065:
-  name: "SOCOM II - U.S. Navy SEALs"
+  name: "SOCOM II: U.S. NAVY SEALs"
+  name-en: "SOCOM II - U.S. Navy SEALs"
   region: "NTSC-J"
   compat: 5
   gameFixes:
     - EETimingHack # Get rids of DMA8/9 non-fatal errors.
     - VIF1StallHack # Fixes broken HUD.
 SCPS-15066:
-  name: "Prince of Persia - The Sands of Time"
+  name: プリンス・オブ・ペルシャ 〜時間の砂〜
+  name-sort: ぷりんす・おぶ・ぺるしゃ 〜じかんのすな〜
+  name-en: "Prince of Persia - The Sands of Time"
   region: "NTSC-J"
   gsHWFixes:
     autoFlush: 2 # Reduces post-processing misalignment.
 SCPS-15067:
-  name: "Dokodemo Issyo - Toro to Nagare Boshi"
+  name: どこでもいっしょ トロと流れ星
+  name-sort: どこでもいっしょ とろとながれぼし
+  name-en: "Dokodemo Issyo - Toro to Nagare Boshi"
   region: "NTSC-J"
 SCPS-15068:
-  name: "MLB 2004"
+  name: MLB 2004
+  name-sort: MLB 2004
+  name-en: "MLB 2004"
   region: "NTSC-J"
 SCPS-15069:
-  name: "Fish - Legend of Seven Waters and Gods"
+  name: うお 7つの水の伝説のヌシ
+  name-sort: うお 7つのみずのでんせつのぬし
+  name-en: "Fish - Legend of Seven Waters and Gods"
   region: "NTSC-J"
   compat: 5
 SCPS-15070:
-  name: "EyeToy - Play [Game Only]"
+  name: "EyeToy:Play(ソフト単品)"
+  name-sort: "EyeToy:Play(そふとたんぴん)"
+  name-en: "EyeToy - Play [Game Only]"
   region: "NTSC-J"
 SCPS-15071:
-  name: "Minna no Golf Online"
+  name: みんなのGOLF オンライン“PlayStation BB Unit”パック〜オンラインはじめてパック〜
+  name-sort: みんなのGOLF おんらいん“PlayStation BB Unit”ぱっく〜おんらいんはじめてぱっく〜
+  name-en: "Minna no Golf Online"
   region: "NTSC-J"
 SCPS-15072:
-  name: "Gacha Mecha Stadium - Saru Battle"
+  name: ガチャメカスタジアム サルバト～レ
+  name-sort: がちゃめかすたじあむ さるばと～れ
+  name-en: "Gacha Mecha Stadium - Saru Battle"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Corrects fullscreen bloom misalignment.
 SCPS-15073:
-  name: "EyeToy - Groove [with Camera]"
+  name: アイトーイ フリフリダンス天国（EyeToyカメラ同梱版）
+  name-sort: あいとーい ふりふりだんすてんごく（EyeToyかめらどうこんばん）
+  name-en: "EyeToy - Groove [with Camera]"
   region: "NTSC-J"
 SCPS-15074:
-  name: "Olympic Summer Games - Athens 2004"
+  name: ATHENS 2004
+  name-sort: ATHENS 2004
+  name-en: "Olympic Summer Games - Athens 2004"
   region: "NTSC-J"
 SCPS-15075:
-  name: "DJ Box [Premium Kit]"
+  name: DJbox プレミアムキット
+  name-sort: DJbox ぷれみあむきっと
+  name-en: "DJ Box [Premium Kit]"
   region: "NTSC-J"
 SCPS-15076:
-  name: "EyeToy - HuriHuri Dance"
+  name: アイトーイ フリフリダンス天国
+  name-sort: あいとーい ふりふりだんすてんごく
+  name-en: "EyeToy - HuriHuri Dance"
   region: "NTSC-J"
 SCPS-15077:
-  name: "EyeToy - Uki Uki Panic [with Camera]"
+  name: サルアイトーイ 大騒ぎ！ウッキウキゲームてんこもりっ!! EyeToy USBカメラ同梱版
+  name-sort: さるあいとーい おおさわぎ！うっきうきげーむてんこもりっ!! EyeToy USBかめらどうこんばん
+  name-en: "EyeToy - Uki Uki Panic [with Camera]"
   region: "NTSC-J"
 SCPS-15078:
-  name: "EyeToy - Uki Uki Panic [Game Only]"
+  name: サルアイトーイ 大騒ぎ！ウッキウキゲームてんこもりっ!!
+  name-sort: さるあいとーい おおさわぎ！うっきうきげーむてんこもりっ!!
+  name-en: "EyeToy - Uki Uki Panic [Game Only]"
   region: "NTSC-J"
 SCPS-15079:
-  name: "Bakufuu Slash! Kizna Arashi [EyeToy Camera Doukonban]"
+  name: 爆封スラッシュ! キズナ 嵐 EyeToyカメラ同梱版
+  name-sort: 爆封すらっしゅ! きずな あらし EyeToyかめらどうこんばん
+  name-en: "Bakufuu Slash! Kizna Arashi [EyeToy Camera Doukonban]"
   region: "NTSC-J"
 SCPS-15080:
-  name: "Waga Ryuomiyo - Pride of the Dragon Peace"
+  name: 我が竜を見よ
+  name-sort: わがりゅうをみよ
+  name-en: "Waga Ryuomiyo - Pride of the Dragon Peace"
   region: "NTSC-J"
 SCPS-15081:
-  name: "Dokodemo Issyo - Toro to Ippai"
+  name: どこでもいっしょ トロといっぱい
+  name-sort: どこでもいっしょ とろといっぱい
+  name-en: "Dokodemo Issyo - Toro to Ippai"
   region: "NTSC-J"
 SCPS-15082:
-  name: "DJ Box"
+  name: DJbox
+  name-sort: DJbox
+  name-en: "DJ Box"
   region: "NTSC-J"
 SCPS-15083:
-  name: "Formula One 2004"
+  name: Formula One 2004
+  name-sort: Formula One 2004
+  name-en: "Formula One 2004"
   region: "NTSC-J"
 SCPS-15084:
-  name: "Ratchet & Clank 3"
+  name: ラチェット＆クランク3 突撃！ガラクチック★レンジャーズ
+  name-sort: らちぇっと＆くらんく3 とつげき！がらくちっく★れんじゃーず
+  name-en: "Ratchet & Clank 3"
   region: "NTSC-J"
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
@@ -7443,31 +7716,45 @@ SCPS-15084:
     - "SCPS-15056"
     - "SCPS-15037"
 SCPS-15085:
-  name: "Kenran Butousai"
+  name: 絢爛舞踏祭
+  name-sort: けんらんぶとうさい
+  name-en: "Kenran Butousai"
   region: "NTSC-J"
   clampModes:
     eeClampMode: 0 # Fixes missing graphics.
 SCPS-15086:
-  name: "Bakufuu Slash! Kizna Arashi [Game Only]"
+  name: 爆封スラッシュ! キズナ 嵐
+  name-sort: 爆封すらっしゅ! きずな あらし
+  name-en: "Bakufuu Slash! Kizna Arashi [Game Only]"
   region: "NTSC-J"
 SCPS-15087:
-  name: "Bleach - Erabareshi Tamashii"
+  name: BLEACH 〜選ばれし魂〜
+  name-sort: BLEACH 〜えらばれしたましい〜
+  name-en: "Bleach - Erabareshi Tamashii"
   region: "NTSC-J"
 SCPS-15088:
-  name: "Bokura no Kazoku - My Family Growing Up in the 21st Century"
+  name: ぼくらのかぞく
+  name-sort: ぼくらのかぞく
+  name-en: "Bokura no Kazoku - My Family Growing Up in the 21st Century"
   region: "NTSC-J"
   compat: 5
 SCPS-15089:
-  name: "EyeToy - Play 2 [With Camera]"
+  name: アイトーイ プレイ2(“PlayStation 2”専用 EyeToy USBカメラ同梱版)
+  name-sort: あいとーい ぷれい2(“PlayStation 2”せんよう EyeToy USBかめらどうこんばん)
+  name-en: "EyeToy - Play 2 [With Camera]"
   region: "NTSC-J"
 SCPS-15090:
-  name: "Kaitou Sly Cooper 2"
+  name: 怪盗スライ・クーパー2
+  name-sort: かいとうすらい・くーぱー2
+  name-en: "Kaitou Sly Cooper 2"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes chromatic effect.
 SCPS-15091:
-  name: "Wild ARMs - The 4th Detonator"
+  name: WILD ARMS the 4th Detonator 初回生産版
+  name-sort: WILD ARMS the 4th Detonator しょかいせいさんばん
+  name-en: "Wild ARMs - The 4th Detonator"
   region: "NTSC-J"
   gsHWFixes:
     textureInsideRT: 1
@@ -7486,7 +7773,9 @@ SCPS-15091:
     - "SCPS-19251"
     - "SCPS-19253"
 SCPS-15092:
-  name: "Wild ARMs - The 4th Detonator"
+  name: WILD ARMS the 4th Detonator
+  name-sort: WILD ARMS the 4th Detonator
+  name-en: "Wild ARMs - The 4th Detonator"
   region: "NTSC-J"
   gsHWFixes:
     textureInsideRT: 1
@@ -7505,17 +7794,25 @@ SCPS-15092:
     - "SCPS-19251"
     - "SCPS-19253"
 SCPS-15093:
-  name: "Rule of Rose"
+  name: RULE of ROSE (ルール オブ ローズ)
+  name-sort: RULE of ROSE (るーる おぶ ろーず)
+  name-en: "Rule of Rose"
   region: "NTSC-J"
   compat: 5
 SCPS-15094:
-  name: "EyeToy - Play 2 [Game Only]"
+  name: アイトーイ プレイ2
+  name-sort: あいとーい ぷれい2
+  name-en: "EyeToy - Play 2 [Game Only]"
   region: "NTSC-J"
 SCPS-15095:
-  name: "Genji - Dawn of the Samurai"
+  name: GENJI
+  name-sort: GENJI
+  name-en: "Genji - Dawn of the Samurai"
   region: "NTSC-J"
 SCPS-15096:
-  name: "Saru Get You! 3"
+  name: サルゲッチュ3
+  name-sort: さるげっちゅ3
+  name-en: "Saru Get You! 3"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
@@ -7525,7 +7822,9 @@ SCPS-15096:
     halfPixelOffset: 2 # Fixes misaligned blur.
     autoFlush: 2 # Fixes corruption in cutscenes and brightens the image.
 SCPS-15097:
-  name: "Wanda to Kyozou"
+  name: ワンダと巨像
+  name-sort: わんだと巨像
+  name-en: "Wanda to Kyozou"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
@@ -7540,10 +7839,14 @@ SCPS-15097:
     - "SCPS-19151"
     - "SCPS-55001"
 SCPS-15098:
-  name: "Formula One 2005"
+  name: Formula One 2005
+  name-sort: Formula One 2005
+  name-en: "Formula One 2005"
   region: "NTSC-J"
 SCPS-15099:
-  name: "Ratchet & Clank 4th - GiriGiri Ginga no Giga Battle"
+  name: ラチェット＆クランク4th ギリギリ銀河のギガバトル （Special Gift Package）
+  name-sort: らちぇっと＆くらんく4th ぎりぎりぎんがのぎがばとる （Special Gift Package）
+  name-en: "Ratchet & Clank 4th - GiriGiri Ginga no Giga Battle"
   region: "NTSC-J"
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
@@ -7553,7 +7856,9 @@ SCPS-15099:
     halfPixelOffset: 2 # Fixes misaligned bloom.
     autoFlush: 2 # Helps fix misaligned bloom.
 SCPS-15100:
-  name: "Ratchet & Clank 4th - GiriGiri Ginga no Giga Battle"
+  name: ラチェット＆クランク4th ギリギリ銀河のギガバトル
+  name-sort: らちぇっと＆くらんく4th ぎりぎりぎんがのぎがばとる
+  name-en: "Ratchet & Clank 4th - GiriGiri Ginga no Giga Battle"
   region: "NTSC-J"
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
@@ -7563,10 +7868,14 @@ SCPS-15100:
     halfPixelOffset: 2 # Fixes misaligned bloom.
     autoFlush: 2 # Helps fix misaligned bloom.
 SCPS-15101:
-  name: "Bleach - Hanatareshi Yabou"
+  name: BLEACH 〜放たれし野望〜
+  name-sort: BLEACH 〜はなたれしやぼう〜
+  name-en: "Bleach - Hanatareshi Yabou"
   region: "NTSC-J"
 SCPS-15102:
-  name: "Rogue Galaxy"
+  name: ローグギャラクシー
+  name-sort: ろーぐぎゃらくしー
+  name-en: "Rogue Galaxy"
   region: "NTSC-J"
   gsHWFixes:
     autoFlush: 2 # Fix glow effects from lamps.
@@ -7574,26 +7883,34 @@ SCPS-15102:
     preloadFrameData: 1 # Fixes corrupt textures especially on water.
     disablePartialInvalidation: 1 # Prevents UI and subtitles from disappearing.
 SCPS-15103:
-  name: "Gunparade Orchestra - Shiro no Shou - Aomori Penguin Densetsu [Limited Edition]"
+  name: ガンパレード・オーケストラ 白の章 〜青森ペンギン伝説〜（限定版）
+  name-sort: がんぱれーど・おーけすとら しろのしょう 〜あおもりぺんぎんでんせつ〜（げんていばん）
+  name-en: "Gunparade Orchestra - Shiro no Shou - Aomori Penguin Densetsu [Limited Edition]"
   region: "NTSC-J"
   memcardFilters:
     - "SCPS-15103"
     - "SCPS-15104"
 SCPS-15104:
-  name: "Gunparade Orchestra - Shiro no Shou - Aomori Penguin Densetsu"
+  name: ガンパレード・オーケストラ 白の章 〜青森ペンギン伝説〜
+  name-sort: がんぱれーど・おーけすとら しろのしょう 〜あおもりぺんぎんでんせつ〜
+  name-en: "Gunparade Orchestra - Shiro no Shou - Aomori Penguin Densetsu"
   region: "NTSC-J"
   memcardFilters:
     - "SCPS-15103"
     - "SCPS-15104"
 SCPS-15105:
-  name: "Tourist Trophy - The Real Riding Simulator"
+  name: ツーリスト・トロフィー
+  name-sort: つーりすと・とろふぃー
+  name-en: "Tourist Trophy - The Real Riding Simulator"
   region: "NTSC-J"
   clampModes:
     vuClampMode: 2 # Fixes SPS in TT Mode menu caused by the moving tooltips.
   gsHWFixes:
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 SCPS-15106:
-  name: "Siren 2"
+  name: SIREN2
+  name-sort: SIREN2
+  name-en: "Siren 2"
   region: "NTSC-J"
   compat: 5
   gameFixes:
@@ -7608,7 +7925,9 @@ SCPS-15106:
         patch=0,EE,0013AB64,word,48449000
         patch=0,EE,0013AB6C,word,4BC949FF
 SCPS-15107:
-  name: "Gunparade Orchestra - Midori no Shou [Limited Edition]"
+  name: ガンパレード・オーケストラ 緑の章 〜狼と彼の少年〜 限定版
+  name-sort: がんぱれーど・おーけすとら みどりのしょう 〜おおかみとかれのしょうねん〜 げんていばん
+  name-en: "Gunparade Orchestra - Midori no Shou [Limited Edition]"
   region: "NTSC-J"
   memcardFilters:
     - "SCPS-15103"
@@ -7616,7 +7935,9 @@ SCPS-15107:
     - "SCPS-15107"
     - "SCPS-15108"
 SCPS-15108:
-  name: "Gunparade Orchestra - Midori no Shou"
+  name: ガンパレード・オーケストラ 緑の章 〜狼と彼の少年〜
+  name-sort: がんぱれーど・おーけすとら みどりのしょう 〜おおかみとかれのしょうねん〜
+  name-en: "Gunparade Orchestra - Midori no Shou"
   region: "NTSC-J"
   memcardFilters:
     - "SCPS-15103"
@@ -7624,7 +7945,9 @@ SCPS-15108:
     - "SCPS-15107"
     - "SCPS-15108"
 SCPS-15109:
-  name: "Gunparade Orchestra - Ao no Shou [Limited Edition]"
+  name: ガンパレード・オーケストラ 青の章 〜光の海から手紙を送ります〜 限定版
+  name-sort: がんぱれーど・おーけすとら あおのしょう 〜ひかりのうみからてがみをおくります〜 げんていばん
+  name-en: "Gunparade Orchestra - Ao no Shou [Limited Edition]"
   region: "NTSC-J"
   memcardFilters:
     - "SCPS-15103"
@@ -7634,7 +7957,9 @@ SCPS-15109:
     - "SCPS-15109"
     - "SCPS-15110"
 SCPS-15110:
-  name: "Gunparade Orchestra - Ao no Shou"
+  name: ガンパレード・オーケストラ 青の章 〜光の海から手紙を送ります〜
+  name-sort: がんぱれーど・おーけすとら あおのしょう 〜ひかりのうみからてがみをおくります〜
+  name-en: "Gunparade Orchestra - Ao no Shou"
   region: "NTSC-J"
   memcardFilters:
     - "SCPS-15103"
@@ -7644,42 +7969,60 @@ SCPS-15110:
     - "SCPS-15109"
     - "SCPS-15110"
 SCPS-15111:
-  name: "Brave Story - Wataru no Bouken"
+  name: ブレイブ ストーリー ワタルの冒険
+  name-sort: ぶれいぶ すとーりー わたるのぼうけん
+  name-en: "Brave Story - Wataru no Bouken"
   region: "NTSC-J"
 SCPS-15112:
-  name: "Blood+ - Souyoku no Battle Rondo"
+  name: BLOOD+ 〜双翼のバトル輪舞曲(ロンド)〜
+  name-sort: BLOOD+ 〜そうよくのばとるろんど〜
+  name-en: "Blood+ - Souyoku no Battle Rondo"
   region: "NTSC-J"
   compat: 5
 SCPS-15113:
-  name: "Minna no Tennis"
+  name: みんなのテニス
+  name-sort: みんなのてにす
+  name-en: "Minna no Tennis"
   region: "NTSC-J"
   roundModes:
     vu1RoundMode: 1 # Fixes the display of scores and text ingame.
 SCPS-15114:
-  name: "Kikou Souhei Armodyne"
+  name: 機甲装兵アーモダイン
+  name-sort: きこうそうへいあーもだいん
+  name-en: "Kikou Souhei Armodyne"
   region: "NTSC-J"
   speedHacks:
     mvuFlag: 0 # Fixes bad graphics.
 SCPS-15115:
-  name: "Saru Get You - Million Monkeys"
+  name: サルゲッチュ ミリオンモンキーズ
+  name-sort: さるげっちゅ みりおんもんきーず
+  name-en: "Saru Get You - Million Monkeys"
   region: "NTSC-J"
   compat: 5
 SCPS-15116:
-  name: "Bleach - Blade Battlers"
+  name: BLEACH 〜ブレイド・バトラーズ〜
+  name-sort: BLEACH 〜ぶれいど・ばとらーず〜
+  name-en: "Bleach - Blade Battlers"
   region: "NTSC-J"
   compat: 5
 SCPS-15117:
-  name: "Formula One 2006"
+  name: Formula One 2006
+  name-sort: Formula One 2006
+  name-en: "Formula One 2006"
   region: "NTSC-J"
 SCPS-15118:
-  name: "Wild ARMs - The Vth Vanguard"
+  name: WILD ARMS the Vth Vanguard
+  name-sort: WILD ARMS the Vth Vanguard
+  name-en: "Wild ARMs - The Vth Vanguard"
   region: "NTSC-J"
   gsHWFixes:
     roundSprite: 1 # Fixes font sizes.
     cpuFramebufferConversion: 1 # Fixes sepia-tone flashback sequences.
     gpuPaletteConversion: 2 # Fixes micro-stuttering and drops in performance while also reducing hash cache explosions and GS usage.
 SCPS-15119:
-  name: "Bleach - Blade Battlers 2nd"
+  name: BLEACH 〜ブレイド・バトラーズ2nd〜
+  name-sort: BLEACH 〜ぶれいど・ばとらーず2nd〜
+  name-en: "Bleach - Blade Battlers 2nd"
   region: "NTSC-J"
   compat: 5
   gameFixes:
@@ -7687,12 +8030,16 @@ SCPS-15119:
   gsHWFixes:
     preloadFrameData: 1 # Fixes removed bloom.
 SCPS-15120:
-  name: "Ratchet & Clank 5 Gekitotsu! Dodeka Ginga no Mirimiri Gundan"
+  name: ラチェット＆クランク5 激突！ドデカ銀河のミリミリ軍団
+  name-sort: らちぇっと＆くらんく5 げきとつ！どでかぎんがのみりみりぐんだん
+  name-en: "Ratchet & Clank 5 Gekitotsu! Dodeka Ginga no Mirimiri Gundan"
   region: "NTSC-J"
   gsHWFixes:
     mipmap: 1
 SCPS-17001:
-  name: "Gran Turismo 4"
+  name: グランツーリスモ4
+  name-sort: ぐらんつーりすも4
+  name-en: "Gran Turismo 4"
   region: "NTSC-J"
   compat: 5
   clampModes:
@@ -7715,25 +8062,37 @@ SCPS-17001:
     - "SCPS-15009"
     - "SCPS-55007"
 SCPS-17002:
-  name: "Wild ARMs - Alter Code F"
+  name: "WILD ARMS Alter code:F"
+  name-sort: "WILD ARMS Alter code:F"
+  name-en: "Wild ARMs - Alter Code F"
   region: "NTSC-J"
   gsHWFixes:
     wildArmsHack: 1 # Fixes font artifacts and out-of-bound 2D textures.
     gpuPaletteConversion: 2 # Fixes micro-stuttering and drops in performance while also reducing hash cache explosions and GS usage.
 SCPS-17008:
-  name: "Nike - Gran Turismo [Limited Edition - 8 inch]"
+  name: NIKE/ GRAN TURISMO Limited Edition (8inch)
+  name-sort: NIKE/ GRAN TURISMO Limited Edition (8inch)
+  name-en: "Nike - Gran Turismo [Limited Edition - 8 inch]"
   region: "NTSC-J"
 SCPS-17009:
-  name: "Nike - Gran Turismo [Limited Edition - 9 inch]"
+  name: NIKE/ GRAN TURISMO Limited Edition (9inch)
+  name-sort: NIKE/ GRAN TURISMO Limited Edition (9inch)
+  name-en: "Nike - Gran Turismo [Limited Edition - 9 inch]"
   region: "NTSC-J"
 SCPS-17010:
-  name: "Nike - Gran Turismo [Limited Edition - 10 inch]"
+  name: NIKE/ GRAN TURISMO Limited Edition (10inch)
+  name-sort: NIKE/ GRAN TURISMO Limited Edition (10inch)
+  name-en: "Nike - Gran Turismo [Limited Edition - 10 inch]"
   region: "NTSC-J"
 SCPS-17011:
-  name: "Nike - Gran Turismo [Limited Edition - 11 inch]"
+  name: NIKE/ GRAN TURISMO Limited Edition (11inch)
+  name-sort: NIKE/ GRAN TURISMO Limited Edition (11inch)
+  name-en: "Nike - Gran Turismo [Limited Edition - 11 inch]"
   region: "NTSC-J"
 SCPS-17013:
-  name: "Rogue Galaxy [Director's Cut]"
+  name: ローグギャラクシー ディレクターズカット
+  name-sort: ろーぐぎゃらくしー でぃれくたーずかっと
+  name-en: "Rogue Galaxy [Director's Cut]"
   region: "NTSC-J"
   gsHWFixes:
     autoFlush: 2 # Fix glow effects from lamps.
@@ -7753,17 +8112,23 @@ SCPS-17502:
   name: "Linux for PlayStation 2 - Release 1.0 (Disc 2) (Software Packages)"
   region: "NTSC-J"
 SCPS-19101:
-  name: "Mosquito [PlayStation 2 The Best]"
+  name: 蚊 PlayStation 2 the Best
+  name-sort: か PlayStation 2 the Best
+  name-en: "Mosquito [PlayStation 2 The Best]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
 SCPS-19102:
-  name: "Boku to Maou [PlayStation 2 The Best]"
+  name: ボクと魔王 PlayStation®2 the Best
+  name-sort: ぼくとまおう PlayStation®2 the Best
+  name-en: "Boku to Maou [PlayStation 2 The Best]"
   region: "NTSC-J"
   gsHWFixes:
     autoFlush: 1 # Depth of field blur is incorrect without it.
 SCPS-19103:
-  name: "Ico [PlayStation 2 The Best]"
+  name: ICO PlayStation 2 the Best
+  name-sort: ICO PlayStation 2 the Best
+  name-en: "ICO [PlayStation 2 The Best]"
   region: "NTSC-J"
   compat: 5
   clampModes:
@@ -7774,13 +8139,19 @@ SCPS-19103:
     halfPixelOffset: 1 # Fixes effect misalignment.
     moveHandler: "MV_Ico" # Fixes depth buffer post-processing.
 SCPS-19104:
-  name: "Pipo Saru 2001 [PlayStation 2 The Best]"
+  name: ピポサル2001 PlayStation 2 the Best
+  name-sort: ぴぽさる2001 PlayStation 2 the Best
+  name-en: "Pipo Saru 2001 [PlayStation 2 The Best]"
   region: "NTSC-J"
 SCPS-19105:
-  name: "Bravo Music [PlayStation 2 The Best]"
+  name: ブラボーミュージック PlayStation®2 the Best
+  name-sort: ぶらぼーみゅーじっく PlayStation®2 the Best
+  name-en: "Bravo Music [PlayStation 2 The Best]"
   region: "NTSC-J"
 SCPS-19151:
-  name: "Ico [PlayStation 2 The Best]"
+  name: ICO PlayStation 2 the Best
+  name-sort: ICO PlayStation 2 the Best
+  name-en: "ICO [PlayStation 2 The Best]"
   region: "NTSC-J"
   compat: 5
   clampModes:
@@ -7794,10 +8165,14 @@ SCPS-19152:
   name: "Saru Get You! 2 [PlayStation 2 The Best]"
   region: "NTSC-J"
 SCPS-19153:
-  name: "Pipo Saru 2001 [PlayStation 2 The Best]"
+  name: ピポサル2001 PlayStation 2 the Best
+  name-sort: ぴぽさる2001 PlayStation 2 the Best
+  name-en: "Pipo Saru 2001 [PlayStation 2 The Best]"
   region: "NTSC-J"
 SCPS-19201:
-  name: "PaRappa the Rapper 2 [PlayStation 2 The Best]"
+  name: パラッパラッパー2 PlayStation 2 the Best
+  name-sort: ぱらっぱらっぱー2 PlayStation 2 the Best
+  name-en: "PaRappa the Rapper 2 [PlayStation 2 The Best]"
   region: "NTSC-J"
   speedHacks:
     instantVU1: 0 # Fixes noodles.
@@ -7808,43 +8183,61 @@ SCPS-19201:
     wildArmsHack: 1 # Fixes misaligment depth of field effect.
     roundSprite: 2 # Fixes misaligment depth of field effect even more.
 SCPS-19202:
-  name: "Extermination [PlayStation 2 The Best]"
+  name: EXTERMINATION PlayStation 2 the Best
+  name-sort: EXTERMINATION PlayStation 2 the Best
+  name-en: "Extermination [PlayStation 2 The Best]"
   region: "NTSC-J"
   gameFixes:
     - SoftwareRendererFMVHack # Black FMV.
 SCPS-19203:
-  name: "Dark Cloud [PlayStation 2 The Best]"
+  name: ダーククラウド PlayStation 2 the Best
+  name-sort: だーくくらうど PlayStation 2 the Best
+  name-en: "Dark Cloud [PlayStation 2 The Best]"
   region: "NTSC-J"
   gsHWFixes:
     mipmap: 2 # Fixes mipmapping.
     trilinearFiltering: 1 # Smoothes out mipmapping.
     halfPixelOffset: 2 # Distance is less blurry, game has reduced LOD so it will still look blurry.
 SCPS-19204:
-  name: "Legaia - Duel Saga [PlayStation 2 The Best]"
+  name: レガイア デュエルサーガ PlayStation 2 the Best
+  name-sort: れがいあ でゅえるさーが PlayStation 2 the Best
+  name-en: "Legaia - Duel Saga [PlayStation 2 The Best]"
   region: "NTSC-J"
 SCPS-19205:
-  name: "Wild ARMs - Advanced 3rd [PlayStation 2 The Best]"
+  name: WILD ARMS Advanced 3rd PlayStation®2 the Best
+  name-sort: WILD ARMS Advanced 3rd PlayStation®2 the Best
+  name-en: "Wild ARMs - Advanced 3rd [PlayStation 2 The Best]"
   region: "NTSC-J"
   gsHWFixes:
     wildArmsHack: 1 # Fixes font artifacts and out-of-bound 2D textures.
     gpuPaletteConversion: 2 # Fixes micro-stuttering and drops in performance while also reducing hash cache explosions and GS usage.
 SCPS-19206:
-  name: "Ape Escape 2 [PlayStation 2 The Best]"
+  name: サルゲッチュ2 PlayStation 2 the Best
+  name-sort: さるげっちゅ2 PlayStation 2 the Best
+  name-en: "Ape Escape 2 [PlayStation 2 The Best]"
   region: "NTSC-J"
   gsHWFixes:
     mipmap: 2 # Fixes miptrick texture effects.
     trilinearFiltering: 1 # Fixes miptrick blending.
 SCPS-19207:
-  name: "Popolocrois Story - Hajime no Bouken [PlayStation 2 The Best]"
+  name: ポポロクロイス〜はじまりの冒険〜 PlayStation 2 the Best
+  name-sort: ぽぽろくろいす〜はじまりのぼうけん〜 PlayStation 2 the Best
+  name-en: "Popolocrois Story - Hajime no Bouken [PlayStation 2 The Best]"
   region: "NTSC-J"
 SCPS-19208:
-  name: "Gran Turismo - Concept 2001 Tokyo [PlayStation 2 The Best]"
+  name: グランツーリスモ Concept2001 TOKYO PlayStation 2 the Best
+  name-sort: ぐらんつーりすも Concept2001 TOKYO PlayStation 2 the Best
+  name-en: "Gran Turismo - Concept 2001 Tokyo [PlayStation 2 The Best]"
   region: "NTSC-J"
 SCPS-19209:
-  name: "Boku no Summer Vacation [PlayStation 2 The Best]"
+  name: ぼくのなつやすみ2 海の冒険篇 PlayStation® 2 the Best
+  name-sort: ぼくのなつやすみ2 うみのぼうけんへん PlayStation® 2 the Best
+  name-en: "Boku no Summer Vacation [PlayStation 2 The Best]"
   region: "NTSC-J"
 SCPS-19210:
-  name: "Jak x Daxter - Kyuusekai no Isan [PlayStation 2 The Best]"
+  name: ジャック×ダクスター PlayStation®2 the Best
+  name-sort: じゃっく×だくすたー PlayStation®2 the Best
+  name-en: "Jak x Daxter - Kyuusekai no Isan [PlayStation 2 The Best]"
   region: "NTSC-J"
   gsHWFixes:
     mipmap: 2 # Fixes broken textures.
@@ -7852,24 +8245,32 @@ SCPS-19210:
     cpuSpriteRenderBW: 4 # Fixes character and water textures.
     cpuSpriteRenderLevel: 2 # Needed for above.
 SCPS-19211:
-  name: "Ratchet & Clank [PlayStation 2 The Best]"
+  name: ラチェット＆クランク PlayStation®2 the Best
+  name-sort: らちぇっと＆くらんく PlayStation®2 the Best
+  name-en: "Ratchet & Clank [PlayStation 2 The Best]"
   region: "NTSC-J"
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
     mipmap: 1
 SCPS-19213:
-  name: "Operator's Side [PlayStation 2 The Best] [with Microphone]"
+  name: OPERATOR’S SIDE マイク同梱版 PlayStation®2 the Best
+  name-sort: OPERATOR’S SIDE まいくどうこんばん PlayStation®2 the Best
+  name-en: "Operator's Side [PlayStation 2 The Best] [with Microphone]"
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
 SCPS-19214:
-  name: "Operator's Side [PlayStation 2 The Best]"
+  name: OPERATOR’S SIDE PlayStation®2 the Best
+  name-sort: OPERATOR’S SIDE PlayStation®2 the Best
+  name-en: "Operator's Side [PlayStation 2 The Best]"
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
 SCPS-19215:
-  name: "Dark Chronicle [PlayStation 2 The Best]"
+  name: ダーククロニクル PlayStation®2 the Best
+  name-sort: だーくくろにくる PlayStation®2 the Best
+  name-en: "Dark Chronicle [PlayStation 2 The Best]"
   region: "NTSC-J"
   clampModes:
     eeClampMode: 3 # Fixes textbox.
@@ -7878,12 +8279,16 @@ SCPS-19215:
     cpuSpriteRenderBW: 2 # Fixes lines in geometry.
     cpuSpriteRenderLevel: 2 # Needed for above.
 SCPS-19251:
-  name: "Wild ARMs - Alter Code F [PlayStation 2 The Best]"
+  name: "WILD ARMS Alter code:F PlayStation®2 the Best"
+  name-sort: "WILD ARMS Alter code:F PlayStation®2 the Best"
+  name-en: "Wild ARMs - Alter Code F [PlayStation 2 The Best]"
   region: "NTSC-J"
   gsHWFixes:
     wildArmsHack: 1 # Fixes font artifacts and out-of-bound 2D textures.
 SCPS-19252:
-  name: "Gran Turismo 4 [PlayStation 2 The Best]"
+  name: グランツーリスモ4 PlayStation 2 the Best
+  name-sort: ぐらんつーりすも4 PlayStation 2 the Best
+  name-en: "Gran Turismo 4 [PlayStation 2 The Best]"
   region: "NTSC-J"
   clampModes:
     vuClampMode: 2 # Text in GT mode works.
@@ -7905,7 +8310,9 @@ SCPS-19252:
     - "SCPS-15009"
     - "SCPS-55007"
 SCPS-19253:
-  name: "Wild ARMs - Alter Code F [PlayStation 2 The Best - Reprint]"
+  name: "WILD ARMS Alter code:F PlayStation 2 the Best"
+  name-sort: "WILD ARMS Alter code:F PlayStation 2 the Best"
+  name-en: "Wild ARMs - Alter Code F [PlayStation 2 The Best - Reprint]"
   region: "NTSC-J"
   gsHWFixes:
     wildArmsHack: 1 # Fixes font artifacts and out-of-bound 2D textures.
@@ -7918,20 +8325,28 @@ SCPS-19254:
     preloadFrameData: 1 # Fixes corrupt textures especially on water.
     disablePartialInvalidation: 1 # Prevents UI and subtitles from disappearing.
 SCPS-19301:
-  name: "Minna no Golf 4 [PlayStation 2 The Best]"
+  name: みんなのGOLF 4 PlayStation 2 the Best
+  name-sort: みんなのGOLF 4 PlayStation 2 the Best
+  name-en: "Minna no Golf 4 [PlayStation 2 The Best]"
   region: "NTSC-J"
 SCPS-19302:
-  name: "Ratchet & Clank 2 [PlayStation 2 The Best]"
+  name: ラチェット＆クランク2 ガガガ！銀河のコマンドーっす PlayStation®2 the Best
+  name-sort: らちぇっと＆くらんく2 ががが！ぎんがのこまんどーっす PlayStation®2 the Best
+  name-en: "Ratchet & Clank 2 [PlayStation 2 The Best]"
   region: "NTSC-J"
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
     mipmap: 1
 SCPS-19303:
-  name: "Boku no Natsuyasumi 2 [PlayStation 2 The Best]"
+  name: ぼくのなつやすみ2 海の冒険篇 PlayStation 2 the Best
+  name-sort: ぼくのなつやすみ2 うみのぼうけんへん PlayStation 2 the Best
+  name-en: "Boku no Natsuyasumi 2 [PlayStation 2 The Best]"
   region: "NTSC-J"
 SCPS-19304:
-  name: "Gran Turismo 4 - Prologue [PlayStation 2 The Best]"
+  name: グランツーリスモ 4 “プロローグ版” PlayStation®2 the Best
+  name-sort: ぐらんつーりすも 4 “ぷろろーぐばん” PlayStation®2 the Best
+  name-en: "Gran Turismo 4 - Prologue [PlayStation 2 The Best]"
   region: "NTSC-J"
   gsHWFixes:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
@@ -7952,14 +8367,18 @@ SCPS-19304:
   # vuClampMode = 2  Text in GT mode works.
   # eeClampMode = 3  Text in races works.
 SCPS-19305:
-  name: "Siren [PlayStation 2 The Best]"
+  name: SIREN PlayStation 2 the Best
+  name-sort: SIREN PlayStation 2 the Best
+  name-en: "Siren [PlayStation 2 The Best]"
   region: "NTSC-J"
   gsHWFixes:
     roundSprite: 1 # Fixes gaps between menu options.
     cpuSpriteRenderBW: 4 # Fixes sky rendering.
     cpuSpriteRenderLevel: 2 # Needed for above.
 SCPS-19306:
-  name: "Dark Chronicle [PlayStation 2 The Best]"
+  name: ダーククロニクル PlayStation®2 the Best
+  name-sort: だーくくろにくる PlayStation®2 the Best
+  name-en: "Dark Chronicle [PlayStation 2 The Best]"
   region: "NTSC-J"
   clampModes:
     eeClampMode: 3 # Fixes textbox.
@@ -7968,13 +8387,19 @@ SCPS-19306:
     cpuSpriteRenderBW: 2 # Fixes lines in geometry.
     cpuSpriteRenderLevel: 2 # Needed for above.
 SCPS-19307:
-  name: "Popolocrois - The First Adventure [PlayStation 2 The Best]"
+  name: ポポロクロイス〜はじまりの冒険〜 PlayStation®2 the Best
+  name-sort: ぽぽろくろいす〜はじまりのぼうけん〜 PlayStation®2 the Best
+  name-en: "Popolocrois - The First Adventure [PlayStation 2 The Best]"
   region: "NTSC-J"
 SCPS-19308:
-  name: "Saru Get You 2 [PlayStation 2 The Best]"
+  name: サルゲッチュ2 PlayStation 2 the Best
+  name-sort: さるげっちゅ2 PlayStation 2 the Best
+  name-en: "Saru Get You 2 [PlayStation 2 The Best]"
   region: "NTSC-J"
 SCPS-19309:
-  name: "Ratchet & Clank 3 - Up Your Arsenal [PlayStation 2 The Best]"
+  name: ラチェット＆クランク3 突撃！ガラクチック★レンジャーズ PlayStation®2 the Best
+  name-sort: らちぇっと＆くらんく3 とつげき！がらくちっく★れんじゃーず PlayStation®2 the Best
+  name-en: "Ratchet & Clank 3 - Up Your Arsenal [PlayStation 2 The Best]"
   region: "NTSC-J"
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
@@ -7984,14 +8409,18 @@ SCPS-19309:
     halfPixelOffset: 2 # Fixes misaligned bloom.
     autoFlush: 2 # Helps fix misaligned bloom.
 SCPS-19310:
-  name: "Ratchet & Clank [PlayStation 2 The Best]"
+  name: ラチェット＆クランク PlayStation®2 the Best
+  name-sort: らちぇっと＆くらんく PlayStation®2 the Best
+  name-en: "Ratchet & Clank [PlayStation 2 The Best]"
   region: "NTSC-J"
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
     mipmap: 1
 SCPS-19311:
-  name: "Saru Get You 3 [PlayStation 2 The Best]"
+  name: サルゲッチュ3 PlayStation 2 the Best
+  name-sort: さるげっちゅ3 PlayStation 2 the Best
+  name-en: "Saru Get You 3 [PlayStation 2 The Best]"
   region: "NTSC-J"
   gsHWFixes:
     preloadFrameData: 1 # Fixes black background in the pause menu.
@@ -8000,14 +8429,18 @@ SCPS-19311:
     halfPixelOffset: 2 # Fixes misaligned blur.
     autoFlush: 2 # Fixes corruption in cutscenes and brightens the image.
 SCPS-19312:
-  name: "Siren [PlayStation 2 The Best]"
+  name: SIREN PlayStation 2 the Best
+  name-sort: SIREN PlayStation 2 the Best
+  name-en: "Siren [PlayStation 2 The Best]"
   region: "NTSC-J"
   gsHWFixes:
     roundSprite: 1 # Fixes gaps between menu options.
     cpuSpriteRenderBW: 4 # Fixes sky rendering.
     cpuSpriteRenderLevel: 2 # Needed for above.
 SCPS-19313:
-  name: "Wild ARMs - The 4th Detonator [PlayStation 2 The Best]"
+  name: WILD ARMS the 4th Detonator PlayStation®2 the Best
+  name-sort: WILD ARMS the 4th Detonator PlayStation®2 the Best
+  name-en: "Wild ARMs - The 4th Detonator [PlayStation 2 The Best]"
   region: "NTSC-J"
   gsHWFixes:
     textureInsideRT: 1
@@ -8029,14 +8462,18 @@ SCPS-19315:
   name: "EyeToy - Play [PlayStation 2 The Best]"
   region: "NTSC-J"
 SCPS-19316:
-  name: "Ratchet & Clank [PlayStation 2 The Best]"
+  name: ラチェット＆クランク PlayStation®2 the Best
+  name-sort: らちぇっと＆くらんく PlayStation®2 the Best
+  name-en: "Ratchet & Clank [PlayStation 2 The Best]"
   region: "NTSC-J"
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
     mipmap: 1
 SCPS-19317:
-  name: "Ratchet & Clank 2 - Going Commando [PlayStation 2 The Best]"
+  name: ラチェット＆クランク2 ガガガ！銀河のコマンドーっす PlayStation®2 the Best
+  name-sort: らちぇっと＆くらんく2 ががが！ぎんがのこまんどーっす PlayStation®2 the Best
+  name-en: "Ratchet & Clank 2 - Going Commando [PlayStation 2 The Best]"
   region: "NTSC-J"
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
@@ -8050,13 +8487,19 @@ SCPS-19317:
     - "SCPS-19310"
     - "SCPS-19316"
 SCPS-19318:
-  name: "Genji - Dawn of the Samurai [PlayStation 2 The Best]"
+  name: GENJI PlayStation 2 the Best
+  name-sort: GENJI PlayStation 2 the Best
+  name-en: "Genji - Dawn of the Samurai [PlayStation 2 The Best]"
   region: "NTSC-J"
 SCPS-19319:
-  name: "Minna no Golf 4 [PlayStation 2 The Best]"
+  name: みんなのGOLF 4 PlayStation®2 the Best
+  name-sort: みんなのGOLF 4 PlayStation®2 the Best
+  name-en: "Minna no Golf 4 [PlayStation 2 The Best]"
   region: "NTSC-J"
 SCPS-19320:
-  name: "Wanda to Kyozou [PlayStation 2 The Best]"
+  name: ワンダと巨像 PlayStation®2 the Best
+  name-sort: わんだと巨像 PlayStation®2 the Best
+  name-en: "Wanda to Kyozou [PlayStation 2 The Best]"
   region: "NTSC-J"
   gsHWFixes:
     mipmap: 1
@@ -8070,7 +8513,9 @@ SCPS-19320:
     - "SCPS-19151"
     - "SCPS-55001"
 SCPS-19321:
-  name: "Ratchet & Clank 4th - GiriGiri Ginga no Giga Battle [PlayStation 2 The Best]"
+  name: ラチェット＆クランク4th ギリギリ銀河のギガバトル PlayStation 2 the Best
+  name-sort: らちぇっと＆くらんく4th ぎりぎりぎんがのぎがばとる PlayStation 2 the Best
+  name-en: "Ratchet & Clank 4th - GiriGiri Ginga no Giga Battle [PlayStation 2 The Best]"
   region: "NTSC-J"
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
@@ -8080,7 +8525,9 @@ SCPS-19321:
     halfPixelOffset: 2 # Fixes misaligned bloom.
     autoFlush: 2 # Helps fix misaligned bloom.
 SCPS-19322:
-  name: "Wild ARMs - The 4th Detonator [PlayStation 2 The Best - Reprint]"
+  name: WILD ARMS the 4th Detonator PlayStation 2 the Best
+  name-sort: WILD ARMS the 4th Detonator PlayStation 2 the Best
+  name-en: "Wild ARMs - The 4th Detonator [PlayStation 2 The Best - Reprint]"
   region: "NTSC-J"
   gsHWFixes:
     textureInsideRT: 1
@@ -8099,7 +8546,9 @@ SCPS-19322:
     - "SCPS-19251"
     - "SCPS-19253"
 SCPS-19323:
-  name: "Wild ARMs - The 4th Detonator [PlayStation 2 The Best - Reprint]"
+  name: WILD ARMS Advanced 3rd PlayStation®2 the Best
+  name-sort: WILD ARMS Advanced 3rd PlayStation®2 the Best
+  name-en: "Wild ARMs - The 4th Detonator [PlayStation 2 The Best - Reprint]"
   region: "NTSC-J"
   gsHWFixes:
     textureInsideRT: 1
@@ -8118,17 +8567,23 @@ SCPS-19323:
     - "SCPS-19251"
     - "SCPS-19253"
 SCPS-19324:
-  name: "Tourist Trophy - The Real Riding Simulator [PlayStation 2 The Best]"
+  name: ツーリスト・トロフィー PlayStation 2 the Best
+  name-sort: つーりすと・とろふぃー PlayStation 2 the Best
+  name-en: "Tourist Trophy - The Real Riding Simulator [PlayStation 2 The Best]"
   region: "NTSC-J"
   clampModes:
     vuClampMode: 2 # Fixes SPS in TT Mode menu caused by the moving tooltips.
   gsHWFixes:
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 SCPS-19325:
-  name: "Ape Escape - Million Monkeys [PlayStation 2 The Best]"
+  name: サルゲッチュ ミリオンモンキーズ PlayStation 2 the Best
+  name-sort: さるげっちゅ みりおんもんきーず PlayStation 2 the Best
+  name-en: "Ape Escape - Million Monkeys [PlayStation 2 The Best]"
   region: "NTSC-J"
 SCPS-19326:
-  name: "Siren 2 [PlayStation 2 The Best]"
+  name: SIREN2 PlayStation 2 the Best
+  name-sort: SIREN2 PlayStation 2 the Best
+  name-en: "Siren 2 [PlayStation 2 The Best]"
   region: "NTSC-J"
   gameFixes:
     - XGKickHack # Fixes SPS.
@@ -8136,14 +8591,18 @@ SCPS-19326:
     mergeSprite: 1 # Fixes vertical lines in-game.
     preloadFrameData: 1 # Fixes some missing effects.
 SCPS-19327:
-  name: "Ape Escape 3 [PlayStation 2 the Best - Reprint]"
+  name: サルゲッチュ3 PlayStation 2 the Best
+  name-sort: さるげっちゅ3 PlayStation 2 the Best
+  name-en: "Ape Escape 3 [PlayStation 2 the Best - Reprint]"
   region: "NTSC-J"
   gsHWFixes:
     preloadFrameData: 1 # Fixes black background in the pause menu.
     mipmap: 2 # Fixes miptrick texture effects.
     trilinearFiltering: 1 # Fixes miptrick blending.
 SCPS-19328:
-  name: "Ratchet & Clank 4th - GiriGiri Ginga no Giga Battle [PlayStation 2 the Best - Reprint]"
+  name: ラチェット＆クランク4th ギリギリ銀河のギガバトル PlayStation®2 the Best
+  name-sort: らちぇっと＆くらんく4th ぎりぎりぎんがのぎがばとる PlayStation®2 the Best
+  name-en: "Ratchet & Clank 4th - GiriGiri Ginga no Giga Battle [PlayStation 2 the Best - Reprint]"
   region: "NTSC-J"
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
@@ -8153,20 +8612,28 @@ SCPS-19328:
     halfPixelOffset: 2 # Fixes misaligned bloom.
     autoFlush: 2 # Helps fix misaligned bloom.
 SCPS-19329:
-  name: "Bleach - Blade Battlers [PlayStation 2 The Best]"
+  name: BLEACH 〜ブレイド・バトラーズ〜 PlayStation®2 the Best
+  name-sort: BLEACH 〜ぶれいど・ばとらーず〜 PlayStation®2 the Best
+  name-en: "Bleach - Blade Battlers [PlayStation 2 The Best]"
   region: "NTSC-J"
   gameFixes:
     - OPHFlagHack # Special moves "Bankai" hang otherwise.
   gsHWFixes:
     preloadFrameData: 1 # Fixes removed bloom.
 SCPS-19330:
-  name: "Bleach - Hanatareshi Yabou [PlayStation 2 The Best]"
+  name: BLEACH 〜放たれし野望〜 PlayStation®2 the Best
+  name-sort: BLEACH 〜はなたれしやぼう〜 PlayStation®2 the Best
+  name-en: "Bleach - Hanatareshi Yabou [PlayStation 2 The Best]"
   region: "NTSC-J"
 SCPS-19331:
-  name: "Bleach - Selected Soul [PlayStation 2 The Best]"
+  name: BLEACH 〜選ばれし魂〜 PlayStation®2 the Best
+  name-sort: BLEACH 〜えらばれしたましい〜 PlayStation®2 the Best
+  name-en: "Bleach - Selected Soul [PlayStation 2 The Best]"
   region: "NTSC-J"
 SCPS-19332:
-  name: "Minna no Tennis [PlayStation 2 The Best]"
+  name: みんなのテニスPlayStation®2 the Best
+  name-sort: みんなのてにすPlayStation®2 the Best
+  name-en: "Minna no Tennis [PlayStation 2 The Best]"
   region: "NTSC-J"
   roundModes:
     vu1RoundMode: 1 # Fixes the display of scores and text ingame.
@@ -28019,7 +28486,9 @@ SLPM-55004:
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
 SLPM-55005:
-  name: "Mana Khemia 2 - Ochita Gakuen to Renkinjutsushi Tachi"
+  name: マナケミア2 〜おちた学園と錬金術士たち〜
+  name-sort: まなけみあ2 〜おちたがくえんとれんきんじゅつしたち〜
+  name-en: "Mana Khemia 2 - Ochita Gakuen to Renkinjutsushi Tachi"
   region: "NTSC-J"
   gsHWFixes:
     roundSprite: 1 # Fixes lines in sprites but still some lines left.
@@ -28029,7 +28498,9 @@ SLPM-55006:
   name: "Akane-iro ni Somaru Saka - Parallel"
   region: "NTSC-J"
 SLPM-55008:
-  name: "Sengoku Basara X"
+  name: 戦国BASARA X
+  name-sort: せんごくBASARA X
+  name-en: "Sengoku Basara X"
   region: "NTSC-J"
   compat: 5
 SLPM-55009:
@@ -28045,7 +28516,9 @@ SLPM-55013:
   name: "Sorayume"
   region: "NTSC-J"
 SLPM-55014:
-  name: "Aria - The Origination - Aoi Hoshi no El Cielo"
+  name: ARIA The ORIGINATION 〜蒼い惑星のエルシエロ〜
+  name-sort: ARIA The ORIGINATION 〜あおいほしののえるしえろ〜
+  name-en: "Aria - The Origination - Aoi Hoshi no El Cielo"
   region: "NTSC-J"
 SLPM-55015:
   name: "Yotsunoha - A Journey of Sincerity [Limited Edition]"
@@ -28079,7 +28552,9 @@ SLPM-55023:
   name: "Dragon Quest & Final Fantasy in Itadaki Street Special"
   region: "NTSC-J"
 SLPM-55024:
-  name: "Jikkyou Powerful Pro Yakyuu 15"
+  name: 実況パワフルプロ野球１５
+  name-sort: じっきょうぱわふるぷろやきゅう１５
+  name-en: "Jikkyou Powerful Pro Yakyuu 15"
   region: "NTSC-J"
 SLPM-55028:
   name: "Secret Game - Killer Queen"
@@ -28094,7 +28569,9 @@ SLPM-55032:
   name: "Piyo-tan - Oyashiki Sennyuu Daisakusen"
   region: "NTSC-J"
 SLPM-55033:
-  name: "J. League Winning Eleven 2008 - Club Championship"
+  name: Jリーグウイニングイレブン 2008 クラブチャンピオンシップ
+  name-sort: Jりーぐういにんぐいれぶん 2008 くらぶちゃんぴおんしっぷ
+  name-en: "J. League Winning Eleven 2008 - Club Championship"
   region: "NTSC-J"
 SLPM-55034:
   name: "Battlefield 2 - Modern Combat [EASY 1980]"
@@ -28153,7 +28630,9 @@ SLPM-55046:
     skipDrawStart: 1 # Removes large black box around player car till we properly emulate it.
     skipDrawEnd: 1 # Removes large black box around player car till we properly emulate it.
 SLPM-55047:
-  name: "Sugar+Spice! - Anoko no Suteki na Nanimokamo"
+  name: Sugar+Spice! ～あの子のステキな何もかも～
+  name-sort: Sugar+Spice! ～あのこのすてきななにもかも～
+  name-en: "Sugar+Spice! - Anoko no Suteki na Nanimokamo"
   region: "NTSC-J"
 SLPM-55048:
   name: "Shin Sangoku Musou 4 - Empires"
@@ -28202,16 +28681,24 @@ SLPM-55061:
     halfPixelOffset: 2 # Fixes blurriness.
     roundSprite: 2 # Fixes blurriness.
 SLPM-55062:
-  name: "Jikkyou Powerful Major League 3"
+  name: 実況パワフルメジャーリーグ3
+  name-sort: じっきょうぱわふるめじゃーりーぐ3
+  name-en: "Jikkyou Powerful Major League 3"
   region: "NTSC-J"
 SLPM-55063:
-  name: "Hakuouki - Shinsengumi Kitan [Limited Edition]"
+  name: 薄桜鬼 新選組奇譚 限定版
+  name-sort: はくおうき しんせんぐみきたん げんていばん
+  name-en: "Hakuouki - Shinsengumi Kitan [Limited Edition]"
   region: "NTSC-J"
 SLPM-55064:
-  name: "Hakuouki"
+  name: 薄桜鬼 新選組奇譚
+  name-sort: はくおうき しんせんぐみきたん
+  name-en: "Hakuouki"
   region: "NTSC-J"
 SLPM-55065:
-  name: "Kamiyo Gakuen Makorouku Kurunugia"
+  name: 神代學園幻光録 クル・ヌ・ギ・ア
+  name-sort: かみよりがくえんげんこうろく くる・ぬ・ぎ・あ
+  name-en: "Kamiyo Gakuen Makorouku Kurunugia"
   region: "NTSC-J"
   patches:
     938DF440:
@@ -28252,7 +28739,9 @@ SLPM-55080:
     mergeSprite: 1 # Fixes misaligned white lines.
     PCRTCOverscan: 1 # Fixes missing HUD.
 SLPM-55081:
-  name: "Drag-on Dragoon 2 - Fuuin no Aka, Haitoku no Kuro [Ultimate Hits]"
+  name: ドラッグオンドラグーン2 〜封印の紅 背徳の黒〜
+  name-sort: どらっぐおんどらぐーん2 〜ふういんのあか はいとくのくろ〜
+  name-en: "Drag-on Dragoon 2 - Fuuin no Aka, Haitoku no Kuro [Ultimate Hits]"
   region: "NTSC-J"
   clampModes:
     eeClampMode: 2 # Fixes wrong color on some characters and breakable objects.
@@ -28298,7 +28787,9 @@ SLPM-55095:
   name: "Shinkyoku Soukai Polyphonica - The Black - Episode 1 & 2 CS Edition"
   region: "NTSC-J"
 SLPM-55096:
-  name: "ThunderForce VI"
+  name: THUNDERFORCE VI
+  name-sort: THUNDERFORCE VI
+  name-en: "ThunderForce VI"
   region: "NTSC-J"
   compat: 5
 SLPM-55097:
@@ -28325,7 +28816,9 @@ SLPM-55106:
   name: "Arcana Heart"
   region: "NTSC-J"
 SLPM-55108:
-  name: "Fate - Unlimited Codes"
+  name: フェイト/アンリミテッドコード
+  name-sort: ふぇいと/あんりみてっどこーど
+  name-en: "Fate - Unlimited Codes"
   region: "NTSC-J"
   compat: 5
   roundModes:
@@ -28334,7 +28827,9 @@ SLPM-55109:
   name: "Major League Baseball 2K8"
   region: "NTSC-J"
 SLPM-55110:
-  name: "Mercenaries 2 - World in Flames"
+  name: マーセナリーズ2 ワールド イン フレームス
+  name-sort: まーせなりーず2 わーるど いん ふれーむす
+  name-en: "Mercenaries 2 - World in Flames"
   region: "NTSC-J"
 SLPM-55112:
   name: "Sangokushi 11 with Power-Up Kit"
@@ -28343,7 +28838,9 @@ SLPM-55113:
   name: "WinBack 2 - Project Poseidon"
   region: "NTSC-J"
 SLPM-55114:
-  name: "Mana Khemia 2 - Ochita Gakuen to Renkinjutsushi Tachi"
+  name: ガストベストプライス マナケミア２ 〜おちた学園と錬金術士たち〜
+  name-sort: がすとべすとぷらいす まなけみあに 〜おちたがくえんとれんきんじゅつしたち〜
+  name-en: "Mana Khemia 2 - Ochita Gakuen to Renkinjutsushi Tachi"
   region: "NTSC-J"
   gsHWFixes:
     roundSprite: 1 # Fixes lines in sprites but still some lines left.
@@ -28356,29 +28853,41 @@ SLPM-55117:
   name: "Beatmania IIDX 15 - DJ Troopers"
   region: "NTSC-J"
 SLPM-55118:
-  name: "Galaxy Angel II - Eigou Kaiki no Koku [Disc 1 of 2]"
+  name: ギャラクシーエンジェルII 永劫回帰の刻
+  name-sort: ぎゃらくしーえんじぇるII えいごうかいきのこく
+  name-en: "Galaxy Angel II - Eigou Kaiki no Koku [Disc 1 of 2]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 1 # Reduces misaligned lighting and other effects.
 SLPM-55119:
-  name: "Galaxy Angel II - Eigou Kaiki no Koku [Disc 2 of 2]"
+  name: ギャラクシーエンジェルII 永劫回帰の刻
+  name-sort: ぎゃらくしーえんじぇるII えいごうかいきのこく
+  name-en: "Galaxy Angel II - Eigou Kaiki no Koku [Disc 2 of 2]"
   region: "NTSC-J"
   memcardFilters:
     - "SLPM-55118"
 SLPM-55120:
-  name: "Fukakutei Sekai no Tantei Shinshi - Akugyou Souma no Jiken File [Limited Edition]"
+  name: 不確定世界の探偵紳士 〜悪行双麻の事件ファイル〜 初回限定版
+  name-sort: ふかくていせかいのたんていしんし 〜あくぎょうそうあさのじけんふぁいる〜 しょかいげんていばん
+  name-en: "Fukakutei Sekai no Tantei Shinshi - Akugyou Souma no Jiken File [Limited Edition]"
   region: "NTSC-J"
 SLPM-55121:
-  name: "Fukakutei Sekai no Tantei Shinshi - Akugyou Souma no Jiken File"
+  name: 不確定世界の探偵紳士 〜悪行双麻の事件ファイル〜
+  name-sort: ふかくていせかいのたんていしんし 〜あくぎょうそうあさのじけんふぁいる〜
+  name-en: "Fukakutei Sekai no Tantei Shinshi - Akugyou Souma no Jiken File"
   region: "NTSC-J"
 SLPM-55122:
-  name: "Gundam Musou 2"
+  name: ガンダム無双2
+  name-sort: がんだむむそう2
+  name-en: "Gundam Musou 2"
   region: "NTSC-J"
 SLPM-55125:
   name: "Hakarena Heart - Kimi ga Tame ni Kagayaki o"
   region: "NTSC-J"
 SLPM-55127:
-  name: "Need for Speed - Undercover"
+  name: ニード・フォー・スピード アンダーカバー
+  name-sort: にーど・ふぉー・すぴーど あんだーかばー
+  name-en: "Need for Speed - Undercover"
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves car reflections.
@@ -28391,7 +28900,9 @@ SLPM-55130:
   name: "Pro Yakyuu Spirits 5 - Kanzenban"
   region: "NTSC-J"
 SLPM-55131:
-  name: "World Soccer Winning Eleven 2009"
+  name: ワールドサッカーウイニングイレブン2009
+  name-sort: わーるどさっかーういにんぐいれぶん2009
+  name-en: "World Soccer Winning Eleven 2009"
   region: "NTSC-J"
 SLPM-55132:
   name: "Kira Kira - Rock 'N' Roll Show"
@@ -28409,7 +28920,9 @@ SLPM-55137:
   name: "Harukanaru Toki no Naka de - Yume no Ukihashi Special"
   region: "NTSC-J"
 SLPM-55138:
-  name: "Harukanaru Toki no Naka de - Yume no Ukihashi Special"
+  name: 遙かなる時空の中で 夢浮橋 Special
+  name-sort: はるかなるときのなかで ゆめのうきはし Special
+  name-en: "Harukanaru Toki no Naka de - Yume no Ukihashi Special"
   region: "NTSC-J"
 SLPM-55139:
   name: "Drift Nights - Juiced 2"
@@ -28448,7 +28961,9 @@ SLPM-55147:
   name: "Suggoi! Arcana Heart 2"
   region: "NTSC-J"
 SLPM-55148:
-  name: "007 - Nagusame no Houshuu"
+  name: 007 / 慰めの報酬
+  name-sort: 007 / なぐさめのほうしゅう
+  name-en: "007 - Nagusame no Houshuu"
   region: "NTSC-J"
 SLPM-55149:
   name: "Loveroot Zero - Kiss Kiss Labyrinth"
@@ -28469,7 +28984,9 @@ SLPM-55154:
   name: "Tsuyokiss 2 Gakki - Swift Love"
   region: "NTSC-J"
 SLPM-55155:
-  name: "Jikkyou Powerful Major League 2009"
+  name: 実況パワフルメジャーリーグ2009
+  name-sort: じっきょうぱわふるめじゃーりーぐ2009
+  name-en: "Jikkyou Powerful Major League 2009"
   region: "NTSC-J"
 SLPM-55156:
   name: "D.C.I.F. - Da Capo Innocent Finale"
@@ -28514,7 +29031,9 @@ SLPM-55169:
   name: "Arcobaleno!"
   region: "NTSC-J"
 SLPM-55170:
-  name: "Skip Beat!"
+  name: スキップ・ビート
+  name-sort: すきっぷ・びーと
+  name-en: "Skip Beat!"
   region: "NTSC-J"
 SLPM-55173:
   name: "Strike Witches - Anata to Dekiru Koto [Limited Edition]"
@@ -28532,13 +29051,17 @@ SLPM-55177:
   name: "Wand of Fortune"
   region: "NTSC-J"
 SLPM-55182:
-  name: "J. League Winning Eleven 2009 - Club Championship"
+  name: Jリーグ ウイニングイレブン2009 クラブチャンピオンシップ
+  name-sort: Jりーぐ ういにんぐいれぶん2009 くらぶちゃんぴおんしっぷ
+  name-en: "J. League Winning Eleven 2009 - Club Championship"
   region: "NTSC-J"
 SLPM-55183:
   name: "Melty Blood - Actress Again"
   region: "NTSC-J"
 SLPM-55184:
-  name: "Melty Blood - Actress Again"
+  name: メルティブラッド アクトレスアゲイン
+  name-sort: めるてぃぶらっど あくとれすあげいん
+  name-en: "Melty Blood - Actress Again"
   region: "NTSC-J"
   compat: 5
 SLPM-55185:
@@ -28560,7 +29083,9 @@ SLPM-55190:
   name: "L2 - Love x Loop"
   region: "NTSC-J"
 SLPM-55191:
-  name: "L2 - Love x Loop"
+  name: L2 Love×Loop
+  name-sort: L2 Love×Loop
+  name-en: "L2 - Love x Loop"
   region: "NTSC-J"
   patches:
     9F9DCD8A:
@@ -28603,10 +29128,14 @@ SLPM-55206:
   name: "S.Y.K Shinsetsu Saiyuuki"
   region: "NTSC-J"
 SLPM-55207:
-  name: "Hakuouki - Zuisouroku [Limited Edition]"
+  name: 薄桜鬼 随想録 限定版
+  name-sort: はくおうき ずいそうろく げんていばん
+  name-en: "Hakuouki - Zuisouroku [Limited Edition]"
   region: "NTSC-J"
 SLPM-55208:
-  name: "Hakuouki - Zuisouroku"
+  name: 薄桜鬼 随想録
+  name-sort: はくおうき ずいそうろく
+  name-en: "Hakuouki - Zuisouroku"
   region: "NTSC-J"
 SLPM-55209:
   name: "World Soccer Winning Eleven 2010"
@@ -28658,7 +29187,9 @@ SLPM-55223:
   name: "NadePro!! Kisama mo Seiyuu Yatte Miro!"
   region: "NTSC-J"
 SLPM-55226:
-  name: "FIFA 10 - World Class Soccer"
+  name: FIFA10 ワールドクラスサッカー
+  name-sort: FIFA10 わーるどくらすさっかー
+  name-en: "FIFA 10 - World Class Soccer"
   region: "NTSC-J"
 SLPM-55227:
   name: "Sekirei - Mirai kara no Okurimono"
@@ -28697,10 +29228,14 @@ SLPM-55242:
   name: "Gundam Musou 2"
   region: "NTSC-J"
 SLPM-55243:
-  name: "Suzunone Seven - Rebirth Knot"
+  name: スズノネセブン！～Rebirth Knot〜
+  name-sort: すずのねせぶん！～Rebirth Knot〜
+  name-en: "Suzunone Seven - Rebirth Knot"
   region: "NTSC-J"
 SLPM-55244:
-  name: "Need for Speed - Undercover [Ea-SY! 1980]"
+  name: EA:SY!1980ニード・フォー・スピード アンダーカバー
+  name-sort: EA:SY!1980にーど・ふぉー・すぴーど あんだーかばー
+  name-en: "Need for Speed - Undercover [Ea-SY! 1980]"
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves car reflections.
@@ -28722,10 +29257,14 @@ SLPM-55250:
   name: "Warship Gunner 2 - Kurogane no Houkou"
   region: "NTSC-J"
 SLPM-55251:
-  name: "WWE SmackDown vs. Raw 2009"
+  name: コーエー定番シリーズ 太閤立志伝V
+  name-sort: こーえーていばんしりーず たいこうりっしでんV
+  name-en: "WWE SmackDown vs. Raw 2009"
   region: "NTSC-J"
 SLPM-55252:
-  name: "Pro Yakyuu Spirits 2010"
+  name: プロ野球スピリッツ2010
+  name-sort: ぷろやきゅうすぴりっつ2010
+  name-en: "Pro Yakyuu Spirits 2010"
   region: "NTSC-J"
 SLPM-55253:
   name: "Winning Post World 2010"
@@ -28740,16 +29279,22 @@ SLPM-55257:
   name: "Luxury & Beauty - Lucian Bee's - Evil Violet"
   region: "NTSC-J"
 SLPM-55258:
-  name: "World Soccer Winning Eleven 2010 - Aoki Samurai no Chousen"
+  name: ワールドサッカーウイニングイレブン2010蒼き侍の挑戦
+  name-sort: わーるどさっかーういにんぐいれぶん2010あおきさむらいのちょうせん
+  name-en: "World Soccer Winning Eleven 2010 - Aoki Samurai no Chousen"
   region: "NTSC-J"
 SLPM-55259:
   name: "Desert Kingdom"
   region: "NTSC-J"
 SLPM-55262:
-  name: "J.League Winning Eleven 2010 - Club Championship"
+  name: Jリーグウイニングイレブン2010クラブチャンピオンシップ
+  name-sort: Jりーぐういにんぐいれぶん2010くらぶちゃんぴおんしっぷ
+  name-en: "J.League Winning Eleven 2010 - Club Championship"
   region: "NTSC-J"
 SLPM-55263:
-  name: "Hana to Otome ni Shukufuku o - Harukaze no Okurimono [St. Lupinus Box]"
+  name: 花と乙女に祝福を 〜春風の贈り物〜
+  name-sort: はなとおとめにしゅくふくを 〜はるかぜのおくりもの〜
+  name-en: "Hana to Otome ni Shukufuku o - Harukaze no Okurimono [St. Lupinus Box]"
   region: "NTSC-J"
 SLPM-55264:
   name: "Moujuutsukai to Oujisama [Limited Edition - Twin Pack]"
@@ -28772,10 +29317,14 @@ SLPM-55270:
   name: "Shinkyoku Soukai Polyphonica - After School"
   region: "NTSC-J"
 SLPM-55271:
-  name: "FIFA 10 - World Class Soccer [Ea -SY! 1980]"
+  name: EA:SY! 1980 FIFA10 ワールドクラスサッカー
+  name-sort: EA:SY! 1980 FIFA10 わーるどくらすさっかー
+  name-en: "FIFA 10 - World Class Soccer [Ea -SY! 1980]"
   region: "NTSC-J"
 SLPM-55273:
-  name: "Hakuouki - Reimeiroku"
+  name: 薄桜鬼 黎明録
+  name-sort: はくおうき れいめいろく
+  name-en: "Hakuouki - Reimeiroku"
   region: "NTSC-J"
 SLPM-55274:
   name: "Uragiri wa Boku no Namae o Shitteiru - Tasogare ni Ochita Inori"
@@ -28784,13 +29333,17 @@ SLPM-55275:
   name: "Slotter Up Core 12 - Ping Pong"
   region: "NTSC-J"
 SLPM-55276:
-  name: "World Soccer Winning Eleven 2011"
+  name: ワールドサッカー ウイニングイレブン 2011
+  name-sort: わーるどさっかー ういにんぐいれぶん 2011
+  name-en: "World Soccer Winning Eleven 2011"
   region: "NTSC-J"
 SLPM-55277:
   name: "Sengoku-hime 2 - En - Hyakka, Senran Tatsukaze no Gotoku"
   region: "NTSC-J"
 SLPM-55280:
-  name: "King of Fighters '98 Ultimate Match, The"
+  name: Palais de Reine/パレドゥレーヌ ベスト版
+  name-sort: Palais de Reine/ぱれどぅれーぬ べすとばん
+  name-en: "King of Fighters '98 Ultimate Match, The"
   region: "NTSC-J"
 SLPM-55281:
   name: "Clock Zero - Shuuen no Ichibyou"
@@ -28799,10 +29352,14 @@ SLPM-55282:
   name: "Armen Noir"
   region: "NTSC-J"
 SLPM-55283:
-  name: "Hakuouki - Reimeiroku [Limited Edition]"
+  name: 薄桜鬼 黎明録 限定版
+  name-sort: はくおうき れいめいろく げんていばん
+  name-en: "Hakuouki - Reimeiroku [Limited Edition]"
   region: "NTSC-J"
 SLPM-55285:
-  name: "Crimson Empire"
+  name: クリムゾン・エンパイア
+  name-sort: くりむぞん・えんぱいあ
+  name-en: "Crimson Empire"
   region: "NTSC-J"
 SLPM-55287:
   name: "Moujuutsukai to Oujisama - Snow Bride"
@@ -29882,54 +30439,82 @@ SLPM-61164:
   name: "Dengeki PS2 PlayStation D96"
   region: "NTSC-J"
 SLPM-62001:
-  name: "Drum Mania"
+  name: ドラムマニア
+  name-sort: どらむまにあ
+  name-en: "Drum Mania"
   region: "NTSC-J"
 SLPM-62002:
-  name: "Live World Soccer 2000"
+  name: 実況ワールドサッカー2000
+  name-sort: じっきょうわーるどさっかー2000
+  name-en: "Live World Soccer 2000"
   region: "NTSC-J"
   compat: 5
 SLPM-62003:
   name: "Mahjong Taikai III - Millennium League"
   region: "NTSC-J"
 SLPM-62004:
-  name: "Mahjong Yarouze! 2"
+  name: 麻雀やろうぜ！2
+  name-sort: まーじゃんやろうぜ！2
+  name-en: "Mahjong Yarouze! 2"
   region: "NTSC-J"
 SLPM-62005:
-  name: "Shin Sangoku Musou"
+  name: 真・三國無双
+  name-sort: しん・さんごくむそう
+  name-en: "Shin Sangoku Musou"
   region: "NTSC-J"
 SLPM-62006:
-  name: "Eisei Meijin 4"
+  name: 永世名人IV
+  name-sort: えいせいめいじんIV
+  name-en: "Eisei Meijin 4"
   region: "NTSC-J"
 SLPM-62007:
-  name: "Gradius III & IV"
+  name: グラディウスIII&IV 復活の神話
+  name-sort: ぐらでぃうすIII&IV ふっかつのしんわ
+  name-en: "Gradius III & IV"
   region: "NTSC-J"
   compat: 5
 SLPM-62008:
-  name: "Jikkyou Powerful Pro Yakyuu 7"
+  name: 実況パワフルプロ野球7
+  name-sort: じっきょうぱわふるぷろやきゅう7
+  name-en: "Jikkyou Powerful Pro Yakyuu 7"
   region: "NTSC-J"
 SLPM-62009:
-  name: "Ganbare Nippon Olympics 2000"
+  name: がんばれ！ニッポン!オリンピック2000
+  name-sort: がんばれ！にっぽん!おりんぴっく2000
+  name-en: "Ganbare Nippon Olympics 2000"
   region: "NTSC-J"
 SLPM-62010:
-  name: "Romance of the Three Kingdoms VII"
+  name: 三國志VII
+  name-sort: さんごくしVII
+  name-en: "Romance of the Three Kingdoms VII"
   region: "NTSC-J"
 SLPM-62011:
-  name: "Jikkyou G1 Stable"
+  name: 実況G1ステイブル
+  name-sort: じっきょうG1すていぶる
+  name-en: "Jikkyou G1 Stable"
   region: "NTSC-J"
 SLPM-62012:
-  name: "KeyboardMania"
+  name: キーボードマニア
+  name-sort: きーぼーどまにあ
+  name-en: "KeyboardMania"
   region: "NTSC-J"
 SLPM-62013:
-  name: "Ring of Red"
+  name: RING OF RED
+  name-sort: RING OF RED
+  name-en: "Ring of Red"
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
 SLPM-62015:
-  name: "Silpheed - The Lost Planet"
+  name: シルフィード ザ・ロストプラネット
+  name-sort: しるふぃーど ざ・ろすとぷらねっと
+  name-en: "Silpheed - The Lost Planet"
   region: "NTSC-J"
   compat: 5
 SLPM-62016:
-  name: "Super Bust-A-Move"
+  name: スーパーパズルボブル
+  name-sort: すーぱーぱずるぼぶる
+  name-en: "Super Bust-A-Move"
   region: "NTSC-J"
   compat: 5
 SLPM-62019:
@@ -29939,33 +30524,49 @@ SLPM-62020:
   name: "GI Jockey 2"
   region: "NTSC-J"
 SLPM-62021:
-  name: "Angelique Trois [Premium Box]"
+  name: アンジェリーク トロワ プレミアムBOX
+  name-sort: あんじぇりーく とろわ ぷれみあむBOX
+  name-en: "Angelique Trois [Premium Box]"
   region: "NTSC-J"
 SLPM-62022:
-  name: "Angelique Trois"
+  name: アンジェリーク トロワ
+  name-sort: あんじぇりーく とろわ
+  name-en: "Angelique Trois"
   region: "NTSC-J"
 SLPM-62023:
-  name: "Winback"
+  name: WIN BACK
+  name-sort: WIN BACK
+  name-en: "Winback"
   region: "NTSC-J"
   clampModes:
     vuClampMode: 3 # Fixes missing 3D polygons when going ingame.
 SLPM-62025:
-  name: "PrintFan"
+  name: Printfan with POPegg
+  name-sort: Printfan with POPegg
+  name-en: "PrintFan"
   region: "NTSC-J"
 SLPM-62026:
-  name: "Silent Scope"
+  name: サイレントスコープ
+  name-sort: さいれんとすこーぷ
+  name-en: "Silent Scope"
   region: "NTSC-J"
 SLPM-62027:
-  name: "Snowboard Heaven"
+  name: スノーボード ヘヴン
+  name-sort: すのーぼーど へゔん
+  name-en: "Snowboard Heaven"
   region: "NTSC-J"
   gameFixes:
     - SoftwareRendererFMVHack # Fixes FMVs.
   # tex in rt makes videos semi appear in hardware but they are flashy and broken.
 SLPM-62028:
-  name: "Greatest Striker"
+  name: グレイテストストライカー
+  name-sort: ぐれいてすとすとらいかー
+  name-en: "Greatest Striker"
   region: "NTSC-J"
 SLPM-62029:
-  name: "Bust A Move - Dance Summit 2001"
+  name: ダンスサミット2001 バスト・ア・ムーブ
+  name-sort: だんすさみっと2001 ばすと・あ・むーぶ
+  name-en: "Bust A Move - Dance Summit 2001"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
@@ -29974,19 +30575,29 @@ SLPM-62030:
   name: "Mahjong Sengen - Saken de Ron!"
   region: "NTSC-J"
 SLPM-62031:
-  name: "Primal Image for Printer"
+  name: Primal Image FOR PRINTER
+  name-sort: Primal Image FOR PRINTER
+  name-en: "Primal Image for Printer"
   region: "NTSC-J"
 SLPM-62032:
-  name: "ESPN NBA 2Night"
+  name: ESPN NBA 2Night
+  name-sort: ESPN NBA 2Night
+  name-en: "ESPN NBA 2Night"
   region: "NTSC-J"
 SLPM-62034:
-  name: "Jikkyou Powerful Pro Yakyuu 7 Ketteiban"
+  name: 実況パワフルプロ野球7 決定版
+  name-sort: じっきょうぱわふるぷろやきゅう7 けっていばん
+  name-en: "Jikkyou Powerful Pro Yakyuu 7 Ketteiban"
   region: "NTSC-J"
 SLPM-62035:
-  name: "Iku ze! Onsen Takkyuu!!"
+  name: いくぜ！温泉卓球！！
+  name-sort: いくぜ！おんせんたっきゅう！！
+  name-en: "Iku ze! Onsen Takkyuu!!"
   region: "NTSC-J"
 SLPM-62036:
-  name: "Chou Kousoku Reversi"
+  name: 超高速リバーシ
+  name-sort: ちょうこうそくりばーし
+  name-en: "Chou Kousoku Reversi"
   region: "NTSC-J"
 SLPM-62037:
   name: "Chou Kousoku Igo"
@@ -29998,10 +30609,14 @@ SLPM-62039:
   name: "Chou Kousoku Shougi"
   region: "NTSC-J"
 SLPM-62040:
-  name: "Jikkyou World Soccer 2000 - Final Edition"
+  name: 実況ワールドサッカー2000 ファイナルエディション
+  name-sort: じっきょうわーるどさっかー2000 ふぁいなるえでぃしょん
+  name-en: "Jikkyou World Soccer 2000 - Final Edition"
   region: "NTSC-J"
 SLPM-62041:
-  name: "ESPN National Hockey Night"
+  name: ESPN National Hockey Night
+  name-sort: ESPN National Hockey Night
+  name-en: "ESPN National Hockey Night"
   region: "NTSC-J"
 SLPM-62042:
   name: "Kurogane no Houkou - Warship Commander"
@@ -30014,45 +30629,69 @@ SLPM-62043:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
 SLPM-62044:
-  name: "RC Revenge Pro"
+  name: RCリベンジPro
+  name-sort: RCりべんじPro
+  name-en: "RC Revenge Pro"
   region: "NTSC-J"
 SLPM-62045:
-  name: "Jikkou J. League Perfect Striker 3"
+  name: 実況Jリーグパーフェクトストライカー3
+  name-sort: じっきょうJりーぐぱーふぇくとすとらいかー3
+  name-en: "Jikkou J. League Perfect Striker 3"
   region: "NTSC-J"
 SLPM-62046:
-  name: "WTA Tennis Tour USA"
+  name: WTA Tour tennis
+  name-sort: WTA Tour tennis
+  name-en: "WTA Tennis Tour USA"
   region: "NTSC-J"
   compat: 5
 SLPM-62047:
-  name: "Endonesia"
+  name: エンドネシア
+  name-sort: えんどねしあ
+  name-en: "Endonesia"
   region: "NTSC-J"
 SLPM-62048:
-  name: "Battle Gear 2"
+  name: バトルギア2
+  name-sort: ばとるぎあ2
+  name-en: "Battle Gear 2"
   region: "NTSC-J"
 SLPM-62049:
-  name: "Densha de Go! 3 - Tsuukin-hen"
+  name: 電車でGO!3 通勤編
+  name-sort: でんしゃでGO!3 つうきんへん
+  name-en: "Densha de Go! 3 - Tsuukin-hen"
   region: "NTSC-J"
 SLPM-62050:
   name: "Densha de Go! Shinkansen - San'you Shinkansen-hen"
   region: "NTSC-J"
 SLPM-62051:
-  name: "Yanya Caballista - featuring Gawoo"
+  name: ヤンヤ カバジスタ〜featuring Gawoo〜
+  name-sort: やんや かばじすた〜featuring Gawoo〜
+  name-en: "Yanya Caballista - featuring Gawoo"
   region: "NTSC-J"
 SLPM-62052:
-  name: "Beatmania Da Da Da!!"
+  name: beatmania打打打!!
+  name-sort: beatmaniaだだだ!!
+  name-en: "Beatmania Da Da Da!!"
   region: "NTSC-J"
 SLPM-62053:
-  name: "World Soccer Winning Eleven 5"
+  name: ワールドサッカー ウイニングイレブン5
+  name-sort: わーるどさっかー ういにんぐいれぶん5
+  name-en: "World Soccer Winning Eleven 5"
   region: "NTSC-J"
 SLPM-62054:
-  name: "Eternity Master V"
+  name: 永世名人V
+  name-sort: えいせいめいじんV
+  name-en: "Eternity Master V"
   region: "NTSC-J"
 SLPM-62055:
-  name: "Bloody Roar 3"
+  name: BLOODY ROAR 3
+  name-sort: BLOODY ROAR 3
+  name-en: "Bloody Roar 3"
   region: "NTSC-J"
   compat: 5
 SLPM-62056:
-  name: "DNA - Dark Native Apostle"
+  name: Dark Native Apostle D.N.A.
+  name-sort: Dark Native Apostle D.N.A.
+  name-en: "DNA - Dark Native Apostle"
   region: "NTSC-J"
 SLPM-62058:
   name: "Winning Post 4 Maximum 2001"
@@ -30061,7 +30700,9 @@ SLPM-62059:
   name: "GI Jockey 2 2001"
   region: "NTSC-J"
 SLPM-62060:
-  name: "Winning Post 4 Maximum 2001"
+  name: Winning Post 4 MAXIMUM 2001
+  name-sort: Winning Post 4 MAXIMUM 2001
+  name-en: "Winning Post 4 Maximum 2001"
   region: "NTSC-J"
   gsHWFixes:
     mipmap: 1 # Improves ground textures to match sw renderer.
@@ -30069,67 +30710,99 @@ SLPM-62061:
   name: "GI Jockey 2 2001"
   region: "NTSC-J"
 SLPM-62062:
-  name: "Gitaroo Man One"
+  name: ギタルマンワン
+  name-sort: ぎたるまんわん
+  name-en: "Gitaroo Man One"
   region: "NTSC-J"
   roundModes:
     eeRoundMode: 1 # Fixes disappearing characters.
 SLPM-62063:
-  name: "Gradius III & IV [Konami The Best]"
+  name: グラディウスIII&IV～復活の神話～ コナミ ザ・ベスト
+  name-sort: ぐらでぃうすIII&IV～ふっかつのしんわ～ こなみ ざ・べすと
+  name-en: "Gradius III & IV [Konami The Best]"
   region: "NTSC-J"
 SLPM-62065:
   name: "Simple 2000 Series Vol. 1 - The Table Game"
   region: "NTSC-J"
 SLPM-62067:
-  name: "Hunter X Hunter - Ryumyaku no Saidan"
+  name: HUNTER×HUNTER 龍派の祭壇
+  name-sort: HUNTER×HUNTER りゅうはのさいだん
+  name-en: "Hunter X Hunter - Ryumyaku no Saidan"
   region: "NTSC-J"
 SLPM-62068:
-  name: "EGBrowser"
+  name: EGBROWSER
+  name-sort: EGBROWSER
+  name-en: "EGBrowser"
   region: "NTSC-J"
 SLPM-62069:
-  name: "All-Star Baseball 2002"
+  name: ALL-STAR BASEBALL 2002
+  name-sort: ALL-STAR BASEBALL 2002
+  name-en: "All-Star Baseball 2002"
   region: "NTSC-J"
 SLPM-62070:
-  name: "Uchu-Jintte Naani"
+  name: うちゅ〜じんってなぁに？
+  name-sort: うちゅ〜じんってなぁに？
+  name-en: "Uchu-Jintte Naani"
   region: "NTSC-J"
 SLPM-62071:
-  name: "Jikkyou Powerful Pro Yakyuu 8"
+  name: 実況パワフルプロ野球8
+  name-sort: じっきょうぱわふるぷろやきゅう8
+  name-en: "Jikkyou Powerful Pro Yakyuu 8"
   region: "NTSC-J"
 SLPM-62072:
-  name: "Horse Breaker"
+  name: HorseBreaker
+  name-sort: HorseBreaker
+  name-en: "Horse Breaker"
   region: "NTSC-J"
 SLPM-62073:
-  name: "Tam Tam Paradise"
+  name: タムタムパラダイス
+  name-sort: たむたむぱらだいす
+  name-en: "Tam Tam Paradise"
   region: "NTSC-J"
   compat: 5
 SLPM-62074:
   name: "Honkakuteki Pachinko Jikki Kouryaku Series - Milky Bar & Killer Queen - Eikyuu Hozon-ban"
   region: "NTSC-J"
 SLPM-62075:
-  name: "Live World Soccer 2001"
+  name: 実況ワールドサッカー2001
+  name-sort: じっきょうわーるどさっかー2001
+  name-en: "Live World Soccer 2001"
   region: "NTSC-J"
 SLPM-62076:
-  name: "Age of Empires II - The Age of Kings"
+  name: AGE OF EMPIRES II THE AGE OF KINGS
+  name-sort: AGE OF EMPIRES II THE AGE OF KINGS
+  name-en: "Age of Empires II - The Age of Kings"
   region: "NTSC-J"
   gsHWFixes:
     estimateTextureRegion: 1 # Improves performance and reduces hash cache size when moving.
 SLPM-62077:
-  name: "Maestro Music 2, The"
+  name: マエストロムジークII 同梱版
+  name-sort: まえすとろむじーくII どうこんばん
+  name-en: "Maestro Music 2, The"
   region: "NTSC-J"
 SLPM-62078:
-  name: "Maestro Music 2, The"
+  name: マエストロムジークII
+  name-sort: まえすとろむじーくII
+  name-en: "Maestro Music 2, The"
   region: "NTSC-J"
 SLPM-62079:
   name: "Se-Pa 2001"
   region: "NTSC-J"
 SLPM-62081:
-  name: "Ever Blue"
+  name: EVERBLUE
+  name-sort: EVERBLUE
+  name-en: "Ever Blue"
   region: "NTSC-J"
   compat: 5
 SLPM-62082:
-  name: "Professional Baseball Japan 2001"
+  name: プロ野球 JAPAN2001
+  name-sort: ぷろやきゅう JAPAN2001
+  name-en: "Professional Baseball Japan 2001"
   region: "NTSC-J"
 SLPM-62084:
-  name: "ESPN X-Games Skateboarding"
+  name: ESPN XGames skateboarding
+  name-sort: ESPN XGames skateboarding
+  name-en: "ESPN X-Games Skateboarding"
   region: "NTSC-J"
 SLPM-62085:
   name: "Silent Scope 2 - Innocent Sweeper"
@@ -30138,49 +30811,73 @@ SLPM-62086:
   name: "PlayOnline Beta Edition - PlayOnline Viewer Beta Version & Tetra Master Beta Version"
   region: "NTSC-J"
 SLPM-62087:
-  name: "Touge 3"
+  name: 峠3
+  name-sort: とうげ3
+  name-en: "Touge 3"
   region: "NTSC-J"
 SLPM-62088:
-  name: "J-League Winning Eleven 5"
+  name: Jリーグ ウイニングイレブン5
+  name-sort: Jりーぐ ういにんぐいれぶん5
+  name-en: "J-League Winning Eleven 5"
   region: "NTSC-J"
 SLPM-62091:
-  name: "Ring of Red [Konami the Best]"
+  name: RING OF RED コナミ ザ・ベスト
+  name-sort: RING OF RED こなみ ざ・べすと
+  name-en: "Ring of Red [Konami the Best]"
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
 SLPM-62092:
-  name: "XG3 Extreme G Racing"
+  name: エクストリームG3
+  name-sort: えくすとりーむG3
+  name-en: "XG3 Extreme G Racing"
   region: "NTSC-J"
 SLPM-62093:
   name: "Simple 2000 Series Ultimate Vol. 1 - Love - Smash!"
   region: "NTSC-J"
 SLPM-62094:
-  name: "Simple 2000 Series Vol. 2 - The Party Game"
+  name: SIMPLE2000シリーズ Vol.2 THE パーティーゲーム
+  name-sort: SIMPLE2000しりーず Vol.2 THE ぱーてぃーげーむ
+  name-en: "Simple 2000 Series Vol. 2 - The Party Game"
   region: "NTSC-J"
 SLPM-62095:
-  name: "Flying Circus [Limited Edition]"
+  name: FLYING CIRCUS プロポ型コントローラ同梱版
+  name-sort: FLYING CIRCUS ぷろぽがたこんとろーらどうこんばん
+  name-en: "Flying Circus [Limited Edition]"
   region: "NTSC-J"
 SLPM-62096:
-  name: "Flying Circus"
+  name: FLYING CIRCUS
+  name-sort: FLYING CIRCUS
+  name-en: "Flying Circus"
   region: "NTSC-J"
 SLPM-62097:
-  name: "Keisatsukan, The - Shinjuku 24-ji"
+  name: ザ・警察官 新宿24時
+  name-sort: ざ・けいさつかん しんじゅく24じ
+  name-en: "Keisatsukan, The - Shinjuku 24-ji"
   region: "NTSC-J"
 SLPM-62098:
-  name: "Busin - Wizardry Alternative"
+  name: BUSIN 〜Wizardry Alternative〜
+  name-sort: BUSIN 〜Wizardry Alternative〜
+  name-en: "Busin - Wizardry Alternative"
   region: "NTSC-J"
 SLPM-62099:
   name: "Nihon Sumou Kyoukai Kounin - Nihon Oozumou - Kakutou-hen"
   region: "NTSC-J"
 SLPM-62100:
-  name: "Rez [Special Package]"
+  name: Rez SPECIAL PACKAGE
+  name-sort: Rez SPECIAL PACKAGE
+  name-en: "Rez [Special Package]"
   region: "NTSC-J"
 SLPM-62101:
-  name: "Rez"
+  name: Rez
+  name-sort: Rez
+  name-en: "Rez"
   region: "NTSC-J"
   compat: 5
 SLPM-62102:
-  name: "Crazy Taxi"
+  name: CRAZY TAXI
+  name-sort: CRAZY TAXI
+  name-en: "Crazy Taxi"
   region: "NTSC-J"
   gameFixes:
     - EETimingHack # Fixes credits screen.
@@ -30188,7 +30885,9 @@ SLPM-62103:
   name: "EX Okuman Chouja Game - The Money Battle"
   region: "NTSC-J"
 SLPM-62104:
-  name: "Choro Q HG 2"
+  name: チョロQ HG2
+  name-sort: ちょろQ HG2
+  name-en: "Choro Q HG 2"
   region: "NTSC-J"
   gsHWFixes:
     roundSprite: 2 # Fixes sprite ghosting.
@@ -30196,24 +30895,34 @@ SLPM-62105:
   name: "Taikou Risshiden IV"
   region: "NTSC-J"
 SLPM-62107:
-  name: "Growlanser 3 - The Duel Darkness"
+  name: グローランサーIII 萌え萌えラッキーパック
+  name-sort: ぐろーらんさーIII もえもえらっきーぱっく
+  name-en: "Growlanser 3 - The Duel Darkness"
   region: "NTSC-J"
   compat: 4
 SLPM-62108:
-  name: "Growlanser 3 - The Duel Darkness"
+  name: グローランサーIII
+  name-sort: ぐろーらんさーIII
+  name-en: "Growlanser 3 - The Duel Darkness"
   region: "NTSC-J"
   compat: 4
 SLPM-62109:
-  name: "Hippa Linda"
+  name: ひっぱリンダ
+  name-sort: ひっぱりんだ
+  name-en: "Hippa Linda"
   region: "NTSC-J"
 SLPM-62111:
   name: "EGBrowser"
   region: "NTSC-J"
 SLPM-62112:
-  name: "Itadaki Street 3"
+  name: いただきストリート3 億万長者にしてあげる! 〜家庭教師付き!〜
+  name-sort: いただきすとりーと3 おくまんちょうじゃにしてあげる! 〜かていきょうしつき!〜
+  name-en: "Itadaki Street 3"
   region: "NTSC-J"
 SLPM-62113:
-  name: "World Soccer Winning Eleven 5 - Final Evolution"
+  name: ワールドサッカー ウイニングイレブン5 ファイナルエヴォリューション
+  name-sort: わーるどさっかー ういにんぐいれぶん5 ふぁいなるえゔぉりゅーしょん
+  name-en: "World Soccer Winning Eleven 5 - Final Evolution"
   region: "NTSC-J"
 SLPM-62114:
   name: "Crash Bandicoot 4 - Sakuretsu! Majin Power"
@@ -30228,58 +30937,90 @@ SLPM-62116:
   name: "EX Jinsei Game"
   region: "NTSC-J"
 SLPM-62117:
-  name: "Momotaro Train X"
+  name: 桃太郎電鉄X（ばってん）〜九州編もあるばい〜
+  name-sort: ももたろうでんてつX（ばってん）〜きゅうしゅうへんもあるばい〜
+  name-en: "Momotaro Train X"
   region: "NTSC-J"
 SLPM-62118:
-  name: "Bomberman Kart"
+  name: ボンバーマンカート
+  name-sort: ぼんばーまんかーと
+  name-en: "Bomberman Kart"
   region: "NTSC-J"
   compat: 5
 SLPM-62119:
-  name: "Jikkyou Powerful Pro Yakyuu 8 Ketteiban"
+  name: 実況パワフルプロ野球8 決定版
+  name-sort: じっきょうぱわふるぷろやきゅう8 けっていばん
+  name-en: "Jikkyou Powerful Pro Yakyuu 8 Ketteiban"
   region: "NTSC-J"
 SLPM-62120:
-  name: "Jikkyou World Soccer 2001"
+  name: 実況Jリーグパーフェクトストライカー4
+  name-sort: じっきょうJりーぐぱーふぇくとすとらいかー4
+  name-en: "Jikkyou World Soccer 2001"
   region: "NTSC-J"
 SLPM-62121:
-  name: "ESPN NBA 2Night 2002"
+  name: ESPN NBA 2night 2002
+  name-sort: ESPN NBA 2night 2002
+  name-en: "ESPN NBA 2Night 2002"
   region: "NTSC-J"
 SLPM-62122:
-  name: "Hermina to Culus - Lilie no Atelier Mou Hitotsu no Monogatari"
+  name: ヘルミーナとクルス
+  name-sort: へるみーなとくるす
+  name-en: "Hermina to Culus - Lilie no Atelier Mou Hitotsu no Monogatari"
   region: "NTSC-J"
 SLPM-62123:
-  name: "Winning Post 5"
+  name: Winning Post5
+  name-sort: Winning Post5
+  name-en: "Winning Post 5"
   region: "NTSC-J"
 SLPM-62124:
-  name: "Ready 2 Rumble Boxing - Round 2"
+  name: READY 2 RUMBLE BOXING ROUND 2
+  name-sort: READY 2 RUMBLE BOXING ROUND 2
+  name-en: "Ready 2 Rumble Boxing - Round 2"
   region: "NTSC-J"
 SLPM-62125:
-  name: "Gauntlet - Dark Legacy"
+  name: GAUNTLET DARK LEGACY
+  name-sort: GAUNTLET DARK LEGACY
+  name-en: "Gauntlet - Dark Legacy"
   region: "NTSC-J"
 SLPM-62126:
   name: "Hyper Sports 2002 Winter"
   region: "NTSC-J"
 SLPM-62127:
-  name: "Maximo"
+  name: マキシモ
+  name-sort: まきしも
+  name-en: "Maximo"
   region: "NTSC-J"
   compat: 5
 SLPM-62128:
-  name: "Le Mans 24 Hours"
+  name: LE MANS 24 HOURS
+  name-sort: LE MANS 24 HOURS
+  name-en: "Le Mans 24 Hours"
   region: "NTSC-J"
 SLPM-62129:
-  name: "Climax Tennis"
+  name: CLIMAX TENNIS
+  name-sort: CLIMAX TENNIS
+  name-en: "Climax Tennis"
   region: "NTSC-J"
 SLPM-62130:
-  name: "Virtua Fighter 4"
+  name: Virtua Fighter 4
+  name-sort: Virtua Fighter 4
+  name-en: "Virtua Fighter 4"
   region: "NTSC-J"
   compat: 5
 SLPM-62131:
-  name: "Romance of the Three Kingdoms VIII"
+  name: 三國志VIII
+  name-sort: さんごくししVIII
+  name-en: "Romance of the Three Kingdoms VIII"
   region: "NTSC-J"
 SLPM-62132:
-  name: "Internet Othello - Othello World 24"
+  name: インターネットオセロ オセロワールド24
+  name-sort: いんたーねっとおせろ おせろわーるど24
+  name-en: "Internet Othello - Othello World 24"
   region: "NTSC-J"
 SLPM-62133:
-  name: "Bloody Roar 3 [Konami The Best]"
+  name: BLOODY ROAR3 ハドソン・ザ・ベスト
+  name-sort: BLOODY ROAR3 はどそん・ざ・べすと
+  name-en: "Bloody Roar 3 [Konami The Best]"
   region: "NTSC-J"
 SLPM-62134:
   name: "Final Fantasy XI [Beta Edition]"
@@ -30291,13 +31032,19 @@ SLPM-62136:
   name: "NetFront for Delta"
   region: "NTSC-J"
 SLPM-62137:
-  name: "Psyvariar Complete Edition [Special Sound Box]"
+  name: サイヴァリア コンプリートエディション スペシャルサウンドボックス
+  name-sort: さいゔぁりあ こんぷりーとえでぃしょん すぺしゃるさうんどぼっくす
+  name-en: "Psyvariar Complete Edition [Special Sound Box]"
   region: "NTSC-J"
 SLPM-62138:
-  name: "Psyvariar Complete Edition [Special Capture Box]"
+  name: サイヴァリア コンプリートエディション スペシャルキャプチャーボックス
+  name-sort: さいゔぁりあ こんぷりーとえでぃしょん すぺしゃるきゃぷちゃーぼっくす
+  name-en: "Psyvariar Complete Edition [Special Capture Box]"
   region: "NTSC-J"
 SLPM-62139:
-  name: "Psyvariar Complete Edition"
+  name: サイヴァリア コンプリートエディション
+  name-sort: さいゔぁりあ こんぷりーとえでぃしょん
+  name-en: "Psyvariar Complete Edition"
   region: "NTSC-J"
   compat: 5
 SLPM-62140:
@@ -30307,10 +31054,14 @@ SLPM-62141:
   name: "Eisei Meijin VI - Tsuushin Shougi Club"
   region: "NTSC-J"
 SLPM-62142:
-  name: "World Grand Prix"
+  name: 鉄1 〜電車でバトル!〜 WORLD GRAND PRIX
+  name-sort: てつ1 〜でんしゃでばとる!〜 WORLD GRAND PRIX
+  name-en: "World Grand Prix"
   region: "NTSC-J"
 SLPM-62143:
-  name: "Hakoniwa Tetsudou - Blue Train Express"
+  name: 箱庭鉄道〜ブルートレイン・特急編〜
+  name-sort: はこにわてつどう〜ぶるーとれいん・とっきゅうへん〜
+  name-en: "Hakoniwa Tetsudou - Blue Train Express"
   region: "NTSC-J"
 SLPM-62144:
   name: "Super Bust-A-Move"
@@ -30322,7 +31073,9 @@ SLPM-62146:
   name: "Chou Kousoku Mahjong Plus"
   region: "NTSC-J"
 SLPM-62147:
-  name: "Bass Strike"
+  name: BASS STRIKE〜バス ストライク〜
+  name-sort: BASS STRIKE〜ばす すとらいく〜
+  name-en: "Bass Strike"
   region: "NTSC-J"
 SLPM-62148:
   name: "Nobunaga no Yabou - Ranseiki"
@@ -30333,61 +31086,85 @@ SLPM-62150:
   gsHWFixes:
     deinterlace: 7 # Fixes flashing FMVs.
 SLPM-62151:
-  name: "Live GI Stable 2"
+  name: 実況GIステイブル2
+  name-sort: じっきょうGIすていぶる2
+  name-en: "Live GI Stable 2"
   region: "NTSC-J"
 SLPM-62153:
-  name: "Racing Construction - Mareru Tsukeru Hahiiru Ore - Dead Heat"
+  name: まげるつけるはしーる俺☆デットヒート
+  name-sort: まげるつけるはしーるおれ☆でっとひーと
+  name-en: "Racing Construction - Mareru Tsukeru Hahiiru Ore - Dead Heat"
   region: "NTSC-J"
 SLPM-62154:
-  name: "DDRMAX ~DanceDanceRevolution 6thMIX~"
+  name: DDRMAX 〜DanceDanceRevolution 6thMIX〜
+  name-sort: DDRMAX 〜DanceDanceRevolution 6thMIX〜
+  name-en: "DDRMAX ~DanceDanceRevolution 6thMIX~"
   region: "NTSC-J"
   compat: 5
 SLPM-62155:
-  name: "Baseball 2002, The - Battle Ball Park Sengen"
+  name: THE BASEBALL 2002 バトルボールパーク宣言
+  name-sort: THE BASEBALL 2002 ばとるぼーるぱーくせんげん
+  name-en: "Baseball 2002, The - Battle Ball Park Sengen"
   region: "NTSC-J"
 SLPM-62156:
   name: "Saikyou no Igo 2"
   region: "NTSC-J"
 SLPM-62157:
-  name: "Buile Baku"
+  name: ビルバク
+  name-sort: びるばく
+  name-en: "Buile Baku"
   region: "NTSC-J"
 SLPM-62158:
   name: "Virtua Fighter 4"
   region: "NTSC-J"
 SLPM-62159:
-  name: "World Soccer Winning Eleven 6"
+  name: ワールドサッカーウイニングイレブン6
+  name-sort: わーるどさっかーういにんぐいれぶん6
+  name-en: "World Soccer Winning Eleven 6"
   region: "NTSC-J"
 SLPM-62160:
   name: "Simple 2000 Series Vol. 4 - The Double Mahjong Puzzle"
   region: "NTSC-J"
 SLPM-62161:
-  name: "Generation of Chaos - Next [Limited Edition]"
+  name: GENERATION OF CHAOS NEXT (限定版)
+  name-sort: GENERATION OF CHAOS NEXT (げんていばん)
+  name-en: "Generation of Chaos - Next [Limited Edition]"
   region: "NTSC-J"
   compat: 5
 SLPM-62163:
   name: "WinBack"
   region: "NTSC-C-E-J"
 SLPM-62164:
-  name: "Generation of Chaos - Next"
+  name: GENERATION OF CHAOS NEXT 〜失われし絆〜
+  name-sort: GENERATION OF CHAOS NEXT 〜うしなわれしきずな〜
+  name-en: "Generation of Chaos - Next"
   region: "NTSC-J"
 SLPM-62165:
-  name: "Shikigami no Shiro [Limited Edition]"
+  name: 式神の城
+  name-sort: しきがみのしろ
+  name-en: "Shikigami no Shiro [Limited Edition]"
   region: "NTSC-J"
   compat: 5
 SLPM-62168:
-  name: "Disney Golf Classics"
+  name: ディズニーゴルフ クラシック
+  name-sort: でぃずにーごるふ くらしっく
+  name-en: "Disney Golf Classics"
   region: "NTSC-J"
   gsHWFixes:
     mipmap: 2 # Mipmap + trilinear, improves grass rendering to match software.
     trilinearFiltering: 1
 SLPM-62169:
-  name: "Live World Soccer 2002"
+  name: 実況ワールドサッカー2002
+  name-sort: じっきょうわーるどさっかー2002
+  name-en: "Live World Soccer 2002"
   region: "NTSC-J"
 SLPM-62170:
   name: "Internet Mahjong - Toufuusou de Asobou"
   region: "NTSC-J"
 SLPM-62171:
-  name: "Simple 2000 Series Vol. 5 - The Block Kuzushi Hyper"
+  name: SIMPLE2000シリーズVol.5 THEブロックくずしHYPER
+  name-sort: SIMPLE2000しりーずVol.5 THEぶろっくくずしHYPER
+  name-en: "Simple 2000 Series Vol. 5 - The Block Kuzushi Hyper"
   region: "NTSC-J"
 SLPM-62172:
   name: "Internet Shougi - Shougi Doujou 24"
@@ -30396,13 +31173,19 @@ SLPM-62174:
   name: "Simple 2000 Honkaku Shikou Series Vol. 3 - The Chess"
   region: "NTSC-J"
 SLPM-62175:
-  name: "Beatmania Da Da Da!! The Best Da"
+  name: beatmania打打打!!THE BEST打
+  name-sort: beatmaniaだだだ!!THE BESTだ
+  name-en: "Beatmania Da Da Da!! THE BEST Da"
   region: "NTSC-J"
 SLPM-62176:
-  name: "EGBrowser BB"
+  name: EGBROWSER BB
+  name-sort: EGBROWSER BB
+  name-en: "EGBrowser BB"
   region: "NTSC-J"
 SLPM-62177:
-  name: "Kuusen [Kadokawa The Best]"
+  name: 空戦 KADOKAWA THE Best
+  name-sort: くうせん KADOKAWA THE Best
+  name-en: "Kuusen [Kadokawa The Best]"
   region: "NTSC-J"
 SLPM-62178:
   name: "Internet Igo - Heisei Kiin 24"
@@ -30411,14 +31194,18 @@ SLPM-62179:
   name: "Simple 2000 Honkaku Shikou Series Vol. 2 - The Igo"
   region: "NTSC-J"
 SLPM-62180:
-  name: "Simple 2000 Honkaku Shikou Series Vol. 1 - The Shogi"
+  name: SIMPLE2000本格思考シリーズVol.1 THE将棋〜森田和郎の将棋指南〜
+  name-sort: SIMPLE2000ほんかくしこうしりーずVol.1 THEしょうぎ〜もりたかずおのしょうぎしなん〜
+  name-en: "Simple 2000 Honkaku Shikou Series Vol. 1 - The Shogi"
   region: "NTSC-J"
   compat: 5
 SLPM-62181:
   name: "Street Golfer"
   region: "NTSC-J"
 SLPM-62182:
-  name: "Top Gun - Ace of the Sky"
+  name: TOP GUN エース オブ ザ スカイ
+  name-sort: TOP GUN えーす おぶ ざ すかい
+  name-en: "Top Gun - Ace of the Sky"
   region: "NTSC-J"
 SLPM-62183:
   name: "Shin Sangoku Musou"
@@ -30430,19 +31217,27 @@ SLPM-62185:
   name: "San Goku Shi VII"
   region: "NTSC-J"
 SLPM-62186:
-  name: "Get Backers - The Stolen City of Infinite"
+  name: ゲットバッカーズ奪還屋 奪われた無限城
+  name-sort: げっとばっかーずだっかんや うばわれたむげんじょう
+  name-en: "Get Backers - The Stolen City of Infinite"
   region: "NTSC-J"
 SLPM-62188:
   name: "Crazy Bump's - Kattobi Car Battle!"
   region: "NTSC-J"
 SLPM-62190:
-  name: "High Heat - Major League Baseball 2003"
+  name: ハイヒートメジャーリーグベースボール 2003
+  name-sort: はいひーとめじゃーりーぐべーすぼーる 2003
+  name-en: "High Heat - Major League Baseball 2003"
   region: "NTSC-J"
 SLPM-62192:
-  name: "Jikkyou Powerful Pro Yakyuu 9"
+  name: 実況パワフルプロ野球9
+  name-sort: じっきょうぱわふるぷろやきゅう9
+  name-en: "Jikkyou Powerful Pro Yakyuu 9"
   region: "NTSC-J"
 SLPM-62193:
-  name: "J League Perfect Striker 5"
+  name: 実況Jリーグパーフェクトストライカー5
+  name-sort: じっきょうJりーぐぱーふぇくとすとらいかー5
+  name-en: "J League Perfect Striker 5"
   region: "NTSC-J"
 SLPM-62194:
   name: "Nihon Sumou Kyoukai Kounin - Nihon Oozumou - Gekitou Honbasho-hen"
@@ -30454,15 +31249,21 @@ SLPM-62196:
   name: "Simple 2000 Series Vol. 6 - The Snowboard"
   region: "NTSC-J"
 SLPM-62197:
-  name: "Simple 2000 Series Vol. 7 - The Boxing - Real Fist Fighter"
+  name: SIMPLE2000シリーズVol.7 THEボクシング〜REAL FIST FIGHTER〜
+  name-sort: SIMPLE2000しりーずVol.7 THEぼくしんぐ〜REAL FIST FIGHTER〜
+  name-en: "Simple 2000 Series Vol. 7 - The Boxing - Real Fist Fighter"
   region: "NTSC-J"
   gameFixes:
     - XGKickHack # Fixes graphical issues.
 SLPM-62198:
-  name: "Simple 2000 Honkaku Shikou Series Vol. 4 - The Mahjong"
+  name: SIMPLE2000本格思考シリーズVol.4 THE麻雀
+  name-sort: SIMPLE2000ほんかくしこうしりーずVol.4 THEまーじゃん
+  name-en: "Simple 2000 Honkaku Shikou Series Vol. 4 - The Mahjong"
   region: "NTSC-J"
 SLPM-62199:
-  name: "Dragon Quest Characters - Toruneko no Daibouken 3"
+  name: ドラゴンクエスト・キャラクターズ トルネコの大冒険3 〜不思議のダンジョン〜
+  name-sort: どらごんくえすと・きゃらくたーず とるねこのだいぼうけん3 〜ふしぎのだんじょん〜
+  name-en: "Dragon Quest Characters - Toruneko no Daibouken 3"
   region: "NTSC-J"
 SLPM-62200:
   name: "Horse Breaker"
@@ -30483,53 +31284,79 @@ SLPM-62203:
   gameFixes:
     - XGKickHack # Fixes corrupted textures.
 SLPM-62204:
-  name: "LEGO Racers 2"
+  name: LEGO RACERS 2
+  name-sort: LEGO RACERS 2
+  name-en: "LEGO Racers 2"
   region: "NTSC-J"
   gsHWFixes:
     textureInsideRT: 1 # Fixes top left corner rendering.
 SLPM-62205:
-  name: "Virtua Cop Re-Birth"
+  name: VIRTUA COP Re-Birth
+  name-sort: VIRTUA COP Re-Birth
+  name-en: "Virtua Cop Re-Birth"
   region: "NTSC-J"
   compat: 5
 SLPM-62206:
-  name: "Growlanser 2 [Atlus The Best]"
+  name: グローランサーII <アトラスベストコレクション>
+  name-sort: ぐろーらんさーII <あとらすべすとこれくしょん>
+  name-en: "Growlanser 2 [Atlus The Best]"
   region: "NTSC-J"
   compat: 4
 SLPM-62207:
-  name: "Simple 2000 Series Vol. 9 - The Renai Adventure - Bittersweet Fools"
+  name: SIMPLE2000シリーズVol.9 THE恋愛アドベンチャー 〜BITTERSWEET FOOLS〜
+  name-sort: SIMPLE2000しりーずVol.9 THEれんあいあどべんちゃー 〜BITTERSWEET FOOLS〜
+  name-en: "Simple 2000 Series Vol. 9 - The Renai Adventure - Bittersweet Fools"
   region: "NTSC-J"
 SLPM-62208:
   name: "Nobunaga no Yabou Online"
   region: "NTSC-J"
 SLPM-62209:
-  name: "Gigantic Drive"
+  name: ギガンティック ドライブ
+  name-sort: ぎがんてぃっく どらいぶ
+  name-en: "Gigantic Drive"
   region: "NTSC-J"
 SLPM-62211:
-  name: "18 Wheeler - American Pro Trucker"
+  name: 18WHEELER
+  name-sort: 18WHEELER
+  name-en: "18 Wheeler - American Pro Trucker"
   region: "NTSC-J"
 SLPM-62212:
-  name: "Critical Bullet - 7th Target"
+  name: クリティカルバレット 7th TARGET
+  name-sort: くりてぃかるばれっと 7th TARGET
+  name-en: "Critical Bullet - 7th Target"
   region: "NTSC-J"
 SLPM-62213:
-  name: "Ultimate Fighting Championship 2 - Tap-Out"
+  name: UFC2 TAPOUT
+  name-sort: UFC2 TAPOUT
+  name-en: "Ultimate Fighting Championship 2 - Tap-Out"
   region: "NTSC-J"
 SLPM-62214:
-  name: "Ever Blue 2"
+  name: EVER BLUE2
+  name-sort: EVER BLUE2
+  name-en: "Ever Blue 2"
   region: "NTSC-J"
 SLPM-62215:
   name: "Virtua Cop Re-Birth"
   region: "NTSC-J"
 SLPM-62216:
-  name: "Ever Blue [CapKore The Best]"
+  name: EVER BLUE (カプコレ)
+  name-sort: EVER BLUE (かぷこれ)
+  name-en: "Ever Blue [CapKore The Best]"
   region: "NTSC-J"
 SLPM-62217:
-  name: "J League Winning Eleven 6"
+  name: Jリーグウイニングイレブン6
+  name-sort: Jりーぐういにんぐいれぶん6
+  name-en: "J League Winning Eleven 6"
   region: "NTSC-J"
 SLPM-62218:
-  name: "Simple 2000 Series Vol. 10 - The Table Game Sekai-Hen"
+  name: SIMPLE2000シリーズVol.10 THEテーブルゲーム 世界編 〜チェス・バックギャモン・ダイヤモンド・軍人将棋 etc〜
+  name-sort: SIMPLE2000しりーずVol.10 THEてーぶるげーむ せかいへん 〜ちぇす・ばっくぎゃもん・だいやもんど・ぐんじんしょうぎ etc〜
+  name-en: "Simple 2000 Series Vol. 10 - The Table Game Sekai-Hen"
   region: "NTSC-J"
 SLPM-62219:
-  name: "Simple 2000 Series Vol. 8 - The Tennis"
+  name: SIMPLE2000シリーズVol.8 THEテニス
+  name-sort: SIMPLE2000しりーずVol.8 THEてにす
+  name-en: "Simple 2000 Series Vol. 8 - The Tennis"
   region: "NTSC-J"
   gameFixes:
     - XGKickHack # Fixes SPS and console spam.
@@ -30537,50 +31364,76 @@ SLPM-62220:
   name: "Pachi-Slot Kanzen Kouryaku - Gigazone - The Meteor Strike"
   region: "NTSC-J"
 SLPM-62221:
-  name: "Winning Post 5 Maximum 2002"
+  name: Winning Post5 MAXIMUM 2002
+  name-sort: Winning Post5 MAXIMUM 2002
+  name-en: "Winning Post 5 Maximum 2002"
   region: "NTSC-J"
   gsHWFixes:
     mipmap: 1 # Improves ground textures to match sw renderer.
 SLPM-62223:
-  name: "Simple 2000 Series Vol. 11 - The Off-Road Buggy"
+  name: SIMPLE2000シリーズVol.11 THEオフロードバギー
+  name-sort: SIMPLE2000しりーずVol.11 THEおふろーどばぎー
+  name-en: "Simple 2000 Series Vol. 11 - The Off-Road Buggy"
   region: "NTSC-J"
 SLPM-62224:
-  name: "Simple 2000 Series Ultimate Vol. 3 - Saisoku! Zokusha King - Buchigiri Densetsu"
+  name: SIMPLE2000シリーズ アルティメットVol.3 最速!族車キング〜仏恥義理伝説〜
+  name-sort: SIMPLE2000しりーず あるてぃめっとVol.3 さいそく!ぞくしゃきんぐ〜ふつはじぎりでんせつ〜
+  name-en: "Simple 2000 Series Ultimate Vol. 3 - Saisoku! Zokusha King - Buchigiri Densetsu"
   region: "NTSC-J"
 SLPM-62225:
-  name: "Nobunaga no Yabou Arashi Seiki [with Power-Up Kit]"
+  name: 信長の野望 嵐世記withパワーアップキット
+  name-sort: のぶながのやぼう らんせいきwithぱわーあっぷきっと
+  name-en: "Nobunaga no Yabou Arashi Seiki [with Power-Up Kit]"
   region: "NTSC-J"
 SLPM-62227:
-  name: "Marvel vs. Capcom 2"
+  name: MARVEL VS. CAPCOM2 New Age of Heroes
+  name-sort: MARVEL VS. CAPCOM2 New Age of Heroes
+  name-en: "Marvel vs. Capcom 2"
   region: "NTSC-J"
   compat: 5
 SLPM-62228:
-  name: "Silpheed - The Lost Planet"
+  name: シルフィード・ザ・ロストプラネット(カプコレ)
+  name-sort: しるふぃーど・ざ・ろすとぷらねっと(かぷこれ)
+  name-en: "Silpheed - The Lost Planet"
   region: "NTSC-J"
 SLPM-62229:
-  name: "Super Puzzle Bobble 2"
+  name: スーパーパズルボブル 2
+  name-sort: すーぱーぱずるぼぶる 2
+  name-en: "Super Puzzle Bobble 2"
   region: "NTSC-J"
   compat: 5
 SLPM-62230:
-  name: "Silent Scope 3"
+  name: SILENT SCOPE 3
+  name-sort: SILENT SCOPE 3
+  name-en: "Silent Scope 3"
   region: "NTSC-J"
 SLPM-62231:
   name: "Simple 2000 Series Vol. 12 - The Quiz 20000"
   region: "NTSC-J"
 SLPM-62232:
-  name: "Simple 2000 Series Vol. 15 - The Rugby"
+  name: SIMPLE2000シリーズVol.15 THEラグビー
+  name-sort: SIMPLE2000しりーずVol.15 THEらぐびー
+  name-en: "Simple 2000 Series Vol. 15 - The Rugby"
   region: "NTSC-J"
 SLPM-62233:
-  name: "Simple 2000 Series Ultimate Vol. 4 - Urawaza Ikasa Mahjong Machi"
+  name: SIMPLE2000シリーズ アルティメットVol.4 裏技イカサ麻雀街 〜兄ィさん、つかんじまったようだね〜
+  name-sort: SIMPLE2000しりーず あるてぃめっとVol.4 うらわざいかさまーじゃんがい 〜あにぃさん、つかんじまったようだね〜
+  name-en: "Simple 2000 Series Ultimate Vol. 4 - Urawaza Ikasa Mahjong Machi"
   region: "NTSC-J"
 SLPM-62234:
-  name: "Simple 2000 Series Vol. 13 - Onna no Ko no Tame no - The Renai Adventure - Garasu no Mori"
+  name: SIMPLE2000シリーズVol.13 女の子のためのTHE恋愛アドベンチャー〜硝子の森〜
+  name-sort: SIMPLE2000しりーずVol.13 おんなのこのためのTHEれんあいあどべんちゃー〜がらすのもり〜
+  name-en: "Simple 2000 Series Vol. 13 - Onna no Ko no Tame no - The Renai Adventure - Garasu no Mori"
   region: "NTSC-J"
 SLPM-62235:
-  name: "GetBass Battle"
+  name: GetBass Battle
+  name-sort: GetBass Battle
+  name-en: "GetBass Battle"
   region: "NTSC-J"
 SLPM-62236:
-  name: "Power Smash 2"
+  name: PowerSmash 2
+  name-sort: PowerSmash 2
+  name-en: "Power Smash 2"
   region: "NTSC-J"
   compat: 5
   gameFixes:
@@ -30589,13 +31442,19 @@ SLPM-62236:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
 SLPM-62237:
-  name: "Gakuen Toshi Vara Noir [Limited Edition]"
+  name: 学園都市 ヴァラノワール(限定版)
+  name-sort: がくえんとし ゔぁらのわーる(げんていばん)
+  name-en: "Gakuen Toshi Vara Noir [Limited Edition]"
   region: "NTSC-J"
 SLPM-62238:
-  name: "Gakuen Toshi Vara Noir"
+  name: 学園都市ヴァラノワール
+  name-sort: がくえんとしゔぁらのわーる
+  name-en: "Gakuen Toshi Vara Noir"
   region: "NTSC-J"
 SLPM-62239:
-  name: "Supercar Street Challenge"
+  name: Supercar Street Challenge
+  name-sort: Supercar Street Challenge
+  name-en: "Supercar Street Challenge"
   region: "NTSC-J"
 SLPM-62240:
   name: "The Sims"
@@ -30611,42 +31470,66 @@ SLPM-62241:
     trilinearFiltering: 1 # Fixes blurry textures.
     cpuFramebufferConversion: 1 # Fixes right side of the screen from garbage textures.
 SLPM-62244:
-  name: "Choro Q HG 3"
+  name: チョロQHG3
+  name-sort: ちょろQHG3
+  name-en: "Choro Q HG 3"
   region: "NTSC-J"
 SLPM-62245:
-  name: "Yuusei kara no Buttai X - Episode II"
+  name: 遊星からの物体X episode II
+  name-sort: ゆうせいからのぶったいX episode II
+  name-en: "Yuusei kara no Buttai X - Episode II"
   region: "NTSC-J"
 SLPM-62247:
-  name: "Shin Contra"
+  name: 真魂斗羅
+  name-sort: しんこんとら
+  name-en: "Shin Contra"
   region: "NTSC-J"
 SLPM-62248:
-  name: "Simple 2000 Series Ultimate Vol. 5 - Love - Mahjong!"
+  name: SIMPLE2000シリーズ アルティメットVol.5 ラブ★マージャン!
+  name-sort: SIMPLE2000しりーず あるてぃめっとVol.5 らぶ★まーじゃん!
+  name-en: "Simple 2000 Series Ultimate Vol. 5 - Love - Mahjong!"
   region: "NTSC-J"
   gameFixes:
     - XGKickHack # Fixes SPS.
 SLPM-62249:
-  name: "Hello Kitty Star Light - Isogasi Cube"
+  name: SIMPLE2000シリーズ ハローキティVol.1 スターライト★パズル〜いそがしキューブ★どっすんフワワ(ハート) 〜
+  name-sort: SIMPLE2000しりーず はろーきてぃVol.1 すたーらいと★ぱずる〜いそがしきゅーぶ★どっすんふわわ(はーと) 〜
+  name-en: "Hello Kitty Star Light - Isogasi Cube"
   region: "NTSC-J"
 SLPM-62250:
-  name: "Hello Kitty Star Light - Minna de Sugoroku"
+  name: SIMPLE2000シリーズ ハローキティVol.2 みんなですごろく〜不思議な世界の仲良しすごろく〜
+  name-sort: SIMPLE2000しりーず はろーきてぃVol.2 みんなですごろく〜ふしぎなせかいのなかよしすごろく〜
+  name-en: "Hello Kitty Star Light - Minna de Sugoroku"
   region: "NTSC-J"
 SLPM-62251:
-  name: "Simple 2000 Series Vol. 14 - The Billiard"
+  name: SIMPLE2000シリーズVol.14 THEビリヤード
+  name-sort: SIMPLE2000しりーずVol.14 THEびりやーど
+  name-en: "Simple 2000 Series Vol. 14 - The Billiard"
   region: "NTSC-J"
 SLPM-62252:
-  name: "Simple 2000 Series Vol. 17 - The Suiri-Aratanaru 20 no Jikenbo"
+  name: SIMPLE2000シリーズVol.17 THE推理〜新たなる20の事件簿〜
+  name-sort: SIMPLE2000しりーずVol.17 THEすいり〜あらたなる20のじけんぼ〜
+  name-en: "Simple 2000 Series Vol. 17 - The Suiri-Aratanaru 20 no Jikenbo"
   region: "NTSC-J"
 SLPM-62253:
-  name: "Simple 2000 Series Vol. 16 - The Sniper"
+  name: SIMPLE2000シリーズVol.16 THEスナイパー2 〜悪夢の銃弾〜
+  name-sort: SIMPLE2000しりーずVol.16 THEすないぱー2 〜あくむのじゅうだん〜
+  name-en: "Simple 2000 Series Vol. 16 - The Sniper"
   region: "NTSC-J"
 SLPM-62254:
-  name: "Kaerazu no Mori"
+  name: 歸らずの森
+  name-sort: 歸らずのもり
+  name-en: "Kaerazu no Mori"
   region: "NTSC-J"
 SLPM-62255:
-  name: "NBA Starting Five"
+  name: NBA STARTING FIVE
+  name-sort: NBA STARTING FIVE
+  name-en: "NBA Starting Five"
   region: "NTSC-J"
 SLPM-62256:
-  name: "Super Trucks"
+  name: SUPER TRUCKS
+  name-sort: SUPER TRUCKS
+  name-en: "Super Trucks"
   region: "NTSC-J"
   roundModes:
     eeRoundMode: 0 # Fixes starting position.
@@ -30654,25 +31537,35 @@ SLPM-62256:
     halfPixelOffset: 2 # Gets rid of fog line.
     roundSprite: 1 # Fixes lines in FMVs.
 SLPM-62257:
-  name: "Rally Championship"
+  name: RALLY CHAMPIONSHIP
+  name-sort: RALLY CHAMPIONSHIP
+  name-en: "Rally Championship"
   region: "NTSC-J"
 SLPM-62258:
-  name: "GTC Africa"
+  name: GTC AFRICA
+  name-sort: GTC AFRICA
+  name-en: "GTC Africa"
   region: "NTSC-J"
 SLPM-62259:
   name: "Dejikame Album - Kuraemon"
   region: "NTSC-J"
 SLPM-62260:
-  name: "DogStation"
+  name: 犬とあそぼう dog station マイクパック
+  name-sort: いぬとあそぼう dog station まいくぱっく
+  name-en: "DogStation"
   region: "NTSC-J"
 SLPM-62261:
-  name: "DogStation"
+  name: 犬とあそぼう dog station
+  name-sort: いぬとあそぼう dog station
+  name-en: "DogStation"
   region: "NTSC-J"
 SLPM-62262:
   name: "GI Jockey 2 [Koei the best]"
   region: "NTSC-J"
 SLPM-62263:
-  name: "Snowboard Heaven"
+  name: スノーボードヘヴン(カプコレ)
+  name-sort: すのーぼーどへゔん(かぷこれ)
+  name-en: "Snowboard Heaven"
   region: "NTSC-J"
   gameFixes:
     - SoftwareRendererFMVHack # Fixes FMVs.
@@ -30689,46 +31582,72 @@ SLPM-62265:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
 SLPM-62266:
-  name: "Momotaro Densetsu XI"
+  name: 桃太郎電鉄11 ブラックボンビー出現の巻
+  name-sort: ももたろうでんてつ11 ぶらっくぼんびーしゅつげんのまき
+  name-en: "Momotaro Densetsu XI"
   region: "NTSC-J"
 SLPM-62268:
-  name: "Winning Eleven 6 - Final Evolution"
+  name: ワールドサッカーウイニングイレブン6 ファイナルエヴォリューション
+  name-sort: わーるどさっかーういにんぐいれぶん6 ふぁいなるえゔぉりゅーしょん
+  name-en: "Winning Eleven 6 - Final Evolution"
   region: "NTSC-J"
   compat: 5
 SLPM-62269:
-  name: "Akagi - Yami ni Oritatta Tensai"
+  name: アカギ〜闇に降り立った天才〜
+  name-sort: あかぎ〜やみにおりたったてんさい〜
+  name-en: "Akagi - Yami ni Oritatta Tensai"
   region: "NTSC-J"
 SLPM-62270:
-  name: "Simple 2000 Series Vol. 19 - The Love Simulation - The Coffee Shop"
+  name: SIMPLE2000シリーズVol.19 THE恋愛シミュレーション〜私におまカフェ〜
+  name-sort: SIMPLE2000しりーずVol.19 THEれんあいしみゅれーしょん〜わたしにおまかふぇ〜
+  name-en: "Simple 2000 Series Vol. 19 - The Love Simulation - The Coffee Shop"
   region: "NTSC-J"
 SLPM-62271:
-  name: "Simple 2000 Series Vol. 20 - The Dungeon RPG"
+  name: SIMPLE2000シリーズVol.20 THEダンジョンRPG忍〜魔物の棲む城〜
+  name-sort: SIMPLE2000しりーずVol.20 THEだんじょんRPGにん〜まもののすむしろ〜
+  name-en: "Simple 2000 Series Vol. 20 - The Dungeon RPG"
   region: "NTSC-J"
   gameFixes:
     - XGKickHack # Fixes missing blue lines on the characters in dark areas.
 SLPM-62272:
-  name: "Simple 2000 Series Vol. 18 - The Party Sugoroku"
+  name: SIMPLE2000シリーズVol.18 THEパーティーすごろく
+  name-sort: SIMPLE2000しりーずVol.18 THEぱーてぃーすごろく
+  name-en: "Simple 2000 Series Vol. 18 - The Party Sugoroku"
   region: "NTSC-J"
 SLPM-62273:
-  name: "Mai-Shin 3"
+  name: 牌神3
+  name-sort: はいしん3
+  name-en: "Mai-Shin 3"
   region: "NTSC-J"
 SLPM-62274:
-  name: "Jikkyou Powerful Pro Yakyuu 9 Ketteiban"
+  name: 実況パワフルプロ野球9 決定版
+  name-sort: じっきょうぱわふるぷろやきゅう9 けっていばん
+  name-en: "Jikkyou Powerful Pro Yakyuu 9 Ketteiban"
   region: "NTSC-J"
 SLPM-62275:
-  name: "Space Raiders"
+  name: SPACE RAIDERS
+  name-sort: SPACE RAIDERS
+  name-en: "Space Raiders"
   region: "NTSC-J"
 SLPM-62276:
-  name: "Get Backers - All Members Gather"
+  name: GetBackers奪還屋 奪還だヨ！全員集合！！
+  name-sort: GetBackersだっかんや だっかんだよ！ぜんいんしゅうごう！！
+  name-en: "Get Backers - All Members Gather"
   region: "NTSC-J"
 SLPM-62277:
-  name: "GI Jockey 3"
+  name: ジーワンジョッキー3
+  name-sort: じーわんじょっきー3
+  name-en: "GI Jockey 3"
   region: "NTSC-J"
 SLPM-62278:
-  name: "Hunter x Hunter"
+  name: HUNTER×HUNTER 龍派の祭壇 コナミ ザ ベスト
+  name-sort: HUNTER×HUNTER りゅうはのさいだん こなみ ざ べすと
+  name-en: "Hunter x Hunter"
   region: "NTSC-J"
 SLPM-62279:
-  name: "GI Jockey 3 [Premium Pack]"
+  name: ジーワンジョッキー3&ウイニングポスト5 マキシマム2002 プレミアムパック
+  name-sort: じーわんじょっきー3&ういにんぐぽすと5 まきしまむ2002 ぷれみあむぱっく
+  name-en: "GI Jockey 3 [Premium Pack]"
   region: "NTSC-J"
 SLPM-62280:
   name: "Winning Post 5 Maximum 2002 [Premium Pack]"
@@ -30737,56 +31656,80 @@ SLPM-62281:
   name: "US Open 2002 - A USTA Event"
   region: "NTSC-J"
 SLPM-62282:
-  name: "Silent Scope 2 - Innocent Sweeper"
+  name: SILENT SCOPE2 INNOCENT SWEEPER コナミ ザ・ベスト
+  name-sort: SILENT SCOPE2 INNOCENT SWEEPER こなみ ざ・べすと
+  name-en: "Silent Scope 2 - Innocent Sweeper"
   region: "NTSC-J"
 SLPM-62283:
   name: "Nobunaga no Yabou - Soutenroku"
   region: "NTSC-J"
 SLPM-62284:
-  name: "Europe Games Collection"
+  name: ヨーロピアンゲームコレクション
+  name-sort: よーろぴあんげーむこれくしょん
+  name-en: "Europe Games Collection"
   region: "NTSC-J"
 SLPM-62285:
-  name: "Waku Waku Volley 2"
+  name: わくわくバレー2
+  name-sort: わくわくばれー2
+  name-en: "Waku Waku Volley 2"
   region: "NTSC-J"
   compat: 5
 SLPM-62286:
   name: "Monster Bass"
   region: "NTSC-J"
 SLPM-62287:
-  name: "Fire Pro Wrestling Z [Limited Edition]"
+  name: ファイヤープロレスリングZ 闘辞苑 同梱BOX
+  name-sort: ふぁいやーぷろれすりんぐZ とうじえん どうこんBOX
+  name-en: "Fire Pro Wrestling Z [Limited Edition]"
   region: "NTSC-J"
   gameFixes:
     - InstantDMAHack # Fixes bad ring/UI textures.
 SLPM-62288:
-  name: "Pop'n music Best Hits!"
+  name: ポップンミュージック ベストヒッツ！
+  name-sort: ぽっぷんみゅーじっく べすとひっつ！
+  name-en: "Pop'n music Best Hits!"
   region: "NTSC-J"
 SLPM-62290:
   name: "TV Kuraemon"
   region: "NTSC-J"
 SLPM-62291:
-  name: "Bomberman Land 2 - Game Shijou Saidai no Theme Park"
+  name: ボンバーマンランド2 ゲーム史上最大のテーマパーク
+  name-sort: ぼんばーまんらんど2 げーむしじょうさいだいのてーまぱーく
+  name-en: "Bomberman Land 2 - Game Shijou Saidai no Theme Park"
   region: "NTSC-J"
 SLPM-62292:
-  name: "Warrior Blade - Rastan vs. Barbarian"
+  name: Warrior Blade - ラスタン VS バーバリアン編 -
+  name-sort: Warrior Blade - らすたん VS ばーばりあんへん -
+  name-en: "Warrior Blade - Rastan vs. Barbarian"
   region: "NTSC-J"
 SLPM-62293:
   name: "Magical Pachinko Cotton - Pachinko Jikki Simulation"
   region: "NTSC-J"
 SLPM-62294:
-  name: "Simple 2000 Series Vol. 21 - The Moonlight Tale RPG"
+  name: SIMPLE2000シリーズVol.21 THE美少女シミュレーションRPG 〜MoonLightTale〜
+  name-sort: SIMPLE2000しりーずVol.21 THEびしょうじょしみゅれーしょんRPG 〜MoonLightTale〜
+  name-en: "Simple 2000 Series Vol. 21 - The Moonlight Tale RPG"
   region: "NTSC-J"
 SLPM-62295:
-  name: "Simple 2000 Series Vol. 22 - The Tsuukin Densha Untenshi - Densha de Go! 3 Tsuukin Hen"
+  name: SIMPLE2000シリーズVol.22 THE通勤電車運転士 ～電車でGO!3通勤編～
+  name-sort: SIMPLE2000しりーずVol.22 THEつうきんでんしゃうんてんし ～でんしゃでGO!3つうきんへん～
+  name-en: "Simple 2000 Series Vol. 22 - The Tsuukin Densha Untenshi - Densha de Go! 3 Tsuukin Hen"
   region: "NTSC-J"
 SLPM-62296:
-  name: "Simple 2000 Series Ultimate Vol. 6 - Love - Upper!"
+  name: SIMPLE2000シリーズ アルティメット Vol.6 ラブ★アッパー！
+  name-sort: SIMPLE2000しりーず あるてぃめっと Vol.6 らぶ★あっぱー！
+  name-en: "Simple 2000 Series Ultimate Vol. 6 - Love - Upper!"
   region: "NTSC-J"
   compat: 5
 SLPM-62297:
-  name: "Got To Do! Hot Spring Table Tennis"
+  name: 彩京べすと いくぜ！温泉卓球
+  name-sort: さいきょうべすと いくぜ！おんせんたっきゅう
+  name-en: "Got To Do! Hot Spring Table Tennis"
   region: "NTSC-J"
 SLPM-62298:
-  name: "Petit Copter"
+  name: プチコプター
+  name-sort: ぷちこぷたー
+  name-en: "Petit Copter"
   region: "NTSC-J"
 SLPM-62299:
   name: "Winback [Koei The Best]"
@@ -30797,30 +31740,40 @@ SLPM-62300:
   name: "Horse Breaker [Koei The Best]"
   region: "NTSC-J"
 SLPM-62301:
-  name: "Aerobics Revolution"
+  name: エアロビクスレボリューション
+  name-sort: えあろびくすれぼりゅーしょん
+  name-en: "Aerobics Revolution"
   region: "NTSC-J"
 SLPM-62302:
   name: "Eisei Meijin 7 - Tsuushin Shougi Club"
   region: "NTSC-J"
 SLPM-62305:
-  name: "Othello [SuperLite 2000]"
+  name: SuperLite 2000テーブル オセロ
+  name-sort: SuperLite 2000てーぶる おせろ
+  name-en: "Othello [SuperLite 2000]"
   region: "NTSC-J"
 SLPM-62306:
   name: "SuperLite 2000 Vol. 2 - Shougi"
   region: "NTSC-J"
 SLPM-62307:
-  name: "Simple 2000 Series Vol. 26 - The Pinball X 3"
+  name: SIMPLE2000シリーズVol.26 THEピンボール×3
+  name-sort: SIMPLE2000しりーずVol.26 THEぴんぼーる×3
+  name-en: "Simple 2000 Series Vol. 26 - The Pinball X 3"
   region: "NTSC-J"
   gameFixes:
     - XGKickHack # Fixes SPS and console spam.
 SLPM-62308:
-  name: "Simple 2000 Series Vol. 24 - The Bowling"
+  name: SIMPLE2000シリーズVol.24 THEボウリングHYPER
+  name-sort: SIMPLE2000しりーずVol.24 THEぼうりんぐHYPER
+  name-en: "Simple 2000 Series Vol. 24 - The Bowling"
   region: "NTSC-J"
 SLPM-62309:
   name: "Simple 2000 Series Vol. 25 - The Menkyo Shutoku Simulation"
   region: "NTSC-J"
 SLPM-62310:
-  name: "Souten Ryuu - The Arcade"
+  name: 蒼天龍　THE　ARCADE
+  name-sort: そうてんりゅう　THE　ARCADE
+  name-en: "Souten Ryuu - The Arcade"
   region: "NTSC-J"
 SLPM-62312:
   name: "Saikyou no Igo 2"
@@ -30829,49 +31782,73 @@ SLPM-62313:
   name: "Simple 2000 Series Vol. 23 - The Puzzle Collection 2000-mon"
   region: "NTSC-J"
 SLPM-62314:
-  name: "Simple 2000 Series Vol. 7 - Saikyou! Shiro Biking Security Police"
+  name: SIMPLE2000シリーズ アルティメットVol.7 最強!白バイキング～SECURITY POLICE～
+  name-sort: SIMPLE2000しりーず あるてぃめっとVol.7 さいきょう!しろばいきんぐ～SECURITY POLICE～
+  name-en: "Simple 2000 Series Vol. 7 - Saikyou! Shiro Biking Security Police"
   region: "NTSC-J"
 SLPM-62315:
-  name: "Puchi Copter [with Controller]"
+  name: プチコプター ラジコンプロポ型コントローラセット
+  name-sort: ぷちこぷたー らじこんぷろぽがたこんとろーらせっと
+  name-en: "Puchi Copter [with Controller]"
   region: "NTSC-J"
 SLPM-62316:
-  name: "Table Mahjong [Superlite 2000 Series]"
+  name: SuperLite 2000テーブル 麻雀
+  name-sort: SuperLite 2000てーぶる まーじゃん
+  name-en: "Table Mahjong [Superlite 2000 Series]"
   region: "NTSC-J"
 SLPM-62317:
   name: "SuperLite 2000 Vol. 3 - Igo"
   region: "NTSC-J"
 SLPM-62318:
-  name: "XII Stag"
+  name: トゥエルブスタッグ
+  name-sort: とぅえるぶすたっぐ
+  name-en: "XII Stag"
   region: "NTSC-J"
 SLPM-62319:
-  name: "Romance of the Three Kingdoms VIII"
+  name: 三國志VIII with パワーアップキット
+  name-sort: さんごくしVIII with ぱわーあっぷきっと
+  name-en: "Romance of the Three Kingdoms VIII"
   region: "NTSC-J"
 SLPM-62320:
   name: "2003-nen Kaimaku - Ganbare Kyuukai-ou - Iwayuru Pro Yakyuu desu ne"
   region: "NTSC-J"
 SLPM-62321:
-  name: "Robocop"
+  name: ロボコップ～新たなる危機～
+  name-sort: ろぼこっぷ～あらたなるきき～
+  name-en: "Robocop"
   region: "NTSC-J"
 SLPM-62322:
-  name: "Conveni 3, The - Ano Machi o Dokusen seyo"
+  name: ザ・コンビニ3 〜あの町を独占せよ〜
+  name-sort: ざ・こんびに3 〜あのまちをどくせんせよ〜
+  name-en: "Conveni 3, The - Ano Machi o Dokusen seyo"
   region: "NTSC-J"
 SLPM-62323:
   name: "AI Shougi 2003"
   region: "NTSC-J"
 SLPM-62324:
-  name: "Simple 2000 Series Vol. 8 - Gekitou! Meiro King"
+  name: SIMPLE2000シリーズ アルティメットVol.8 激闘!迷路キング
+  name-sort: SIMPLE2000しりーず あるてぃめっとVol.8 げきとう!めいろきんぐ
+  name-en: "Simple 2000 Series Vol. 8 - Gekitou! Meiro King"
   region: "NTSC-J"
 SLPM-62325:
-  name: "High Heat Major League Baseball 2003 [Konami The Best]"
+  name: THE BEST タカラモノ ハイヒートメジャーリーグベースボール 2003
+  name-sort: THE BEST たからもの はいひーとめじゃーりーぐべーすぼーる 2003
+  name-en: "High Heat Major League Baseball 2003 [Konami The Best]"
   region: "NTSC-J"
 SLPM-62326:
-  name: "G-Taste Mahjong [Limited Edition]"
+  name: G-taste麻雀 フィギュア同梱スペシャル版
+  name-sort: G-tasteまーじゃん ふぃぎゅあどうこんすぺしゃるばん
+  name-en: "G-Taste Mahjong [Limited Edition]"
   region: "NTSC-J"
 SLPM-62327:
-  name: "G-Taste Mahjong"
+  name: G-taste麻雀
+  name-sort: G-tasteまーじゃん
+  name-en: "G-Taste Mahjong"
   region: "NTSC-J"
 SLPM-62328:
-  name: "Simple 2000 Series Vol. 27 - The Pro Yakyuu 2003 Pennant Race"
+  name: SIMPLE2000シリーズVol.27 THEプロ野球 ～2003ペナントレース～
+  name-sort: SIMPLE2000しりーずVol.27 THEぷろやきゅう ～2003ぺなんとれーす～
+  name-en: "Simple 2000 Series Vol. 27 - The Pro Yakyuu 2003 Pennant Race"
   region: "NTSC-J"
 SLPM-62329:
   name: "AI Igo 2003"
@@ -30889,47 +31866,71 @@ SLPM-62333:
   name: "PlayOnline Viewer - Tetra Master & Janhourou"
   region: "NTSC-J"
 SLPM-62334:
-  name: "Simple 2000 Series Vol. 29 - The Renai Board Game"
+  name: SIMPLE2000シリーズVol.29 THE恋愛ボードゲーム ～青春18ラヂオ～
+  name-sort: SIMPLE2000しりーずVol.29 THEれんあいぼーどげーむ ～せいしゅん18らぢお～
+  name-en: "Simple 2000 Series Vol. 29 - The Renai Board Game"
   region: "NTSC-J"
 SLPM-62335:
-  name: "Simple 2000 Series Vol. 28 - The Bushido - Tsujigiri Ichi-dai"
+  name: SIMPLE2000シリーズVol.28 THE武士道～辻斬一代～
+  name-sort: SIMPLE2000しりーずVol.28 THEぶしどう～つじぎりいちだい～
+  name-en: "Simple 2000 Series Vol. 28 - The Bushido - Tsujigiri Ichi-dai"
   region: "NTSC-J"
 SLPM-62336:
-  name: "Simple 2000 Series Vol. 44 - The Hajimete no RPG - Densetsu no Keishousha"
+  name: SIMPLE2000シリーズ Vol.44 THE はじめてのRPG〜伝説の継承者〜
+  name-sort: SIMPLE2000しりーず Vol.44 THE はじめてのRPG〜でんせつのけいしょうしゃ〜
+  name-en: "Simple 2000 Series Vol. 44 - The Hajimete no RPG - Densetsu no Keishousha"
   region: "NTSC-J"
   compat: 5
 SLPM-62337:
-  name: "Simple 2000 Series Vol. 30 - The Basketball - 3-on-3"
+  name: SIMPLE2000シリーズVol.30 THEストリートバスケ 3ON3
+  name-sort: SIMPLE2000しりーずVol.30 THEすとりーとばすけ 3ON3
+  name-en: "Simple 2000 Series Vol. 30 - The Basketball - 3-on-3"
   region: "NTSC-J"
 SLPM-62338:
-  name: "Ishikura Noboru no Igo Kouza"
+  name: 石倉昇九段の囲碁講座 入門編
+  name-sort: いしくらのぼるきゅうだんのいごこうざ にゅうもんへん
+  name-en: "Ishikura Noboru no Igo Kouza"
   region: "NTSC-J"
 SLPM-62339:
-  name: "Kikou Heidan J-Phoenix 2 - Joshou-hen"
+  name: 機甲兵団J-PHOENIX2 序章編
+  name-sort: きこうへいだんJ-PHOENIX2 じょしょうへん
+  name-en: "Kikou Heidan J-Phoenix 2 - Joshou-hen"
   region: "NTSC-J"
 SLPM-62340:
-  name: "Apprentice Magician"
+  name: リプルのたまご
+  name-sort: りぷるのたまご
+  name-en: "Apprentice Magician"
   region: "NTSC-J"
 SLPM-62341:
-  name: "Fushigi no Kuni no Alice"
+  name: 不思議の国のアリス
+  name-sort: ふしぎのくにのありす
+  name-en: "Fushigi no Kuni no Alice"
   region: "NTSC-J"
 SLPM-62342:
-  name: "Fire Pro Wrestling Z"
+  name: ファイヤープロレスリングZ
+  name-sort: ふぁいやーぷろれすりんぐZ
+  name-en: "Fire Pro Wrestling Z"
   region: "NTSC-J"
   compat: 5
   gameFixes:
     - InstantDMAHack # Fixes bad ring/UI textures.
 SLPM-62343:
-  name: "Simple 2000 Series Vol. 34 - The Renai Horror Adventure - Hyouryuu Shoujo"
+  name: SIMPLE2000シリーズVol.34 THE恋愛ホラーアドベンチャー～漂流少女～
+  name-sort: SIMPLE2000しりーずVol.34 THEれんあいほらーあどべんちゃー～ひょうりゅうしょうじょ～
+  name-en: "Simple 2000 Series Vol. 34 - The Renai Horror Adventure - Hyouryuu Shoujo"
   region: "NTSC-J"
 SLPM-62344:
-  name: "Simple 2000 Series Vol. 31 - The Chikyuu Boueigun"
+  name: SIMPLE2000シリーズVol.31 THE地球防衛軍
+  name-sort: SIMPLE2000しりーずVol.31 THEちきゅうぼうえいぐん
+  name-en: "Simple 2000 Series Vol. 31 - The Chikyuu Boueigun"
   region: "NTSC-J"
   gsHWFixes:
     mipmap: 2 # Improves distant textures.
     trilinearFiltering: 1 # Smooths high frequency textures on distant ground.
 SLPM-62345:
-  name: "Simple 2000 Series Vol. 32 - The Sensha"
+  name: SIMPLE2000シリーズVol.32 THE戦車
+  name-sort: SIMPLE2000しりーずVol.32 THEせんしゃ
+  name-en: "Simple 2000 Series Vol. 32 - The Sensha"
   region: "NTSC-J"
 SLPM-62346:
   name: "Keiei Simulation - Jurassic Park [Konami the Best]"
@@ -30941,30 +31942,44 @@ SLPM-62346:
     textureInsideRT: 1 # Fixes rainbow lighting for some areas.
     getSkipCount: "GSC_BlueTongueGames" # Mipmap rendering on CPU.
 SLPM-62348:
-  name: "Mechsmith, The - Rum"
+  name: IFコレクション　THE MECHSMITH
+  name-sort: IFこれくしょん　THE MECHSMITH
+  name-en: "Mechsmith, The - Rum"
   region: "NTSC-J"
 SLPM-62349:
-  name: "Welcome to Universal Studios Japan"
+  name: WELCOME TO UNIVERSAL STUDIOS JAPAN(TM)
+  name-sort: WELCOME TO UNIVERSAL STUDIOS JAPAN(TM)
+  name-en: "Welcome to Universal Studios Japan"
   region: "NTSC-J"
 SLPM-62350:
-  name: "Hudson Selection Vol.2 - Star Soldier"
+  name: ハドソンセレクションVOL.2 スターソルジャー
+  name-sort: はどそんせれくしょんVOL.2 すたーそるじゃー
+  name-en: "Hudson Selection Vol.2 - Star Soldier"
   region: "NTSC-J"
 SLPM-62352:
   name: "Simple 2000 Series Vol. 40 - The Touyou Sandai Senjutsu"
   region: "NTSC-J"
 SLPM-62353:
-  name: "Simple 2000 Series Vol. 33 - The Jet Coaster - Yuuenchi Otsukkurou!"
+  name: SIMPLE2000シリーズVol.33 THEジェットコースター
+  name-sort: SIMPLE2000しりーずVol.33 THEじぇっとこーすたー
+  name-en: "Simple 2000 Series Vol. 33 - The Jet Coaster - Yuuenchi Otsukkurou!"
   region: "NTSC-J"
 SLPM-62354:
-  name: "Space Invaders 25th Anniversary"
+  name: SPACE INVADERS ANNIVERSARY
+  name-sort: SPACE INVADERS ANNIVERSARY
+  name-en: "Space Invaders 25th Anniversary"
   region: "NTSC-J"
 SLPM-62355:
-  name: "Choro Q HG 2"
+  name: THE BEST タカラモノ チョロQHG2
+  name-sort: THE BEST たからもの ちょろQHG2
+  name-en: "Choro Q HG 2"
   region: "NTSC-J"
   gsHWFixes:
     roundSprite: 2 # Fixes sprite ghosting.
 SLPM-62356:
-  name: "World Soccer Winning Eleven 7"
+  name: ワールドサッカー ウイニングイレブン7
+  name-sort: わーるどさっかー ういにんぐいれぶん7
+  name-en: "World Soccer Winning Eleven 7"
   region: "NTSC-J"
   compat: 5
 SLPM-62357:
@@ -30983,19 +31998,27 @@ SLPM-62361:
   name: "Shin Contra"
   region: "NTSC-J"
 SLPM-62362:
-  name: "Sega Ages 2500 Series Vol.01 - Phantasy Star Generation 1"
+  name: SEGA AGES 2500 シリーズ Vol.1 PHANTASY STAR(ファンタシースター) generation1限定
+  name-sort: SEGA AGES 2500 しりーず Vol.1 PHANTASY STAR(ふぁんたしーすたー) generation1げんてい
+  name-en: "Sega Ages 2500 Series Vol.01 - Phantasy Star Generation 1"
   region: "NTSC-J"
   compat: 5
 SLPM-62364:
-  name: "Sega Ages 2500 Series Vol.02 - Monaco GP"
+  name: SEGA AGES 2500 シリーズ Vol.2 モナコGP
+  name-sort: SEGA AGES 2500 しりーず Vol.2 もなこGP
+  name-en: "Sega Ages 2500 Series Vol.02 - Monaco GP"
   region: "NTSC-J"
   gameFixes:
     - XGKickHack # Fixes black and white vehicle previews.
 SLPM-62365:
-  name: "Cardinal Arc - Konton no Fuusatsu"
+  name: カルディナル アーク 〜混沌の封札〜
+  name-sort: かるでぃなる あーく 〜こんとんのふうさつ〜
+  name-en: "Cardinal Arc - Konton no Fuusatsu"
   region: "NTSC-J"
 SLPM-62366:
-  name: "Sega Ages 2500 Series Vol.03 - Fantasy Zone"
+  name: SEGA AGES 2500 シリーズ Vol.3 ファンタジーゾーン
+  name-sort: SEGA AGES 2500 しりーず Vol.3 ふぁんたじーぞーん
+  name-en: "Sega Ages 2500 Series Vol.03 - Fantasy Zone"
   region: "NTSC-J"
   compat: 5
 SLPM-62367:
@@ -31005,57 +32028,89 @@ SLPM-62368:
   name: "Koei Sangokushi Special Save Data-shuu"
   region: "NTSC-J"
 SLPM-62369:
-  name: "Karaoke Revolution - J-Pop Vol.1"
+  name: カラオケレボリューション(J-POPベストVol.1)
+  name-sort: からおけれぼりゅーしょん(J-POPべすとVol.1)
+  name-en: "Karaoke Revolution - J-Pop Vol.1"
   region: "NTSC-J"
 SLPM-62370:
-  name: "Psyvariar Medium Unit [Superlite 2000 Series]"
+  name: SuperLite 2000シューティング PSYVARIAR 〜MIDIUM UNIT〜
+  name-sort: SuperLite 2000しゅーてぃんぐ PSYVARIAR 〜MIDIUM UNIT〜
+  name-en: "Psyvariar Medium Unit [Superlite 2000 Series]"
   region: "NTSC-J"
 SLPM-62371:
-  name: "Psyvariar Revision [Superlite 2000 Series]"
+  name: SuperLite 2000シューティング PSYVARIAR 〜RIVISION〜
+  name-sort: SuperLite 2000しゅーてぃんぐ PSYVARIAR 〜RIVISION〜
+  name-en: "Psyvariar Revision [Superlite 2000 Series]"
   region: "NTSC-J"
   compat: 5
 SLPM-62372:
   name: "SuperLite 2000 Vol. 7 - Oekaki Puzzle"
   region: "NTSC-J"
 SLPM-62373:
-  name: "Simple 2000 Series Vol. 35 - The Helicopter"
+  name: SIMPLE2000シリーズVol.35 THEヘリコプター
+  name-sort: SIMPLE2000しりーずVol.35 THEへりこぷたー
+  name-en: "Simple 2000 Series Vol. 35 - The Helicopter"
   region: "NTSC-J"
 SLPM-62374:
-  name: "Simple 2000 Series Ultimate Vol. 12 - Street Golfer"
+  name: SIMPLE2000シリーズ アルティメットVol.12 ストリートゴルファー
+  name-sort: SIMPLE2000しりーず あるてぃめっとVol.12 すとりーとごるふぁー
+  name-en: "Simple 2000 Series Ultimate Vol. 12 - Street Golfer"
   region: "NTSC-J"
 SLPM-62375:
-  name: "Simple 2000 Series Vol. 36 - The Musume Ikusei Simulation"
+  name: SIMPLE2000シリーズVol.36 THE娘育成シミュレーション
+  name-sort: SIMPLE2000しりーずVol.36 THEむすめいくせいしみゅれーしょん
+  name-en: "Simple 2000 Series Vol. 36 - The Musume Ikusei Simulation"
   region: "NTSC-J"
 SLPM-62376:
-  name: "Get Backers - All Members Gather [Konami The Best]"
+  name: GetBackers奪還屋 奪還だョ!全員集合!(コナミ ザ ベスト)
+  name-sort: GetBackersだっかんや だっかんだょ!ぜんいんしゅうごう!(こなみ ざ べすと)
+  name-en: "Get Backers - All Members Gather [Konami The Best]"
   region: "NTSC-J"
 SLPM-62377:
-  name: "Get Backers Dakkanoku - Ubawareta Mugenshiro [Konami The Best]"
+  name: GetBackers奪還屋 奪われた無限城(コナミ ザ ベスト)
+  name-sort: GetBackersだっかんや うばわれたむげんじょう(こなみ ざ べすと)
+  name-en: "Get Backers Dakkanoku - Ubawareta Mugenshiro [Konami The Best]"
   region: "NTSC-J"
 SLPM-62378:
-  name: "Bakusou Convoy Densetsu"
+  name: 爆走コンボイ伝説 〜男花道アメリカ浪漫〜
+  name-sort: ばくそうこんぼいでんせつ 〜おとこはなみちあめりかろまん〜
+  name-en: "Bakusou Convoy Densetsu"
   region: "NTSC-J"
 SLPM-62379:
-  name: "Karaoke Revolution - J-Pop Vol.2"
+  name: カラオケレボリュ-ション(J-POPベストVol.2)
+  name-sort: からおけれぼりゅ-しょん(J-POPべすとVol.2)
+  name-en: "Karaoke Revolution - J-Pop Vol.2"
   region: "NTSC-J"
 SLPM-62380:
-  name: "Karaoke Revolution - J-Pop Vol.3"
+  name: カラオケレボリューション(JーPOPベストVol.3)
+  name-sort: からおけれぼりゅーしょん(JーPOPべすとVol.3)
+  name-en: "Karaoke Revolution - J-Pop Vol.3"
   region: "NTSC-J"
 SLPM-62381:
-  name: "Karaoke Revolution - J-Pop Vol.4"
+  name: カラオケレボリューション(J-POPベストVol.4)
+  name-sort: からおけれぼりゅーしょん(J-POPべすとVol.4)
+  name-en: "Karaoke Revolution - J-Pop Vol.4"
   region: "NTSC-J"
 SLPM-62382:
-  name: "Karaoke Revolution - Love & Ballad"
+  name: カラオケレボリューション ナイトセレクション2003
+  name-sort: からおけれぼりゅーしょん ないとせれくしょん2003
+  name-en: "Karaoke Revolution - Love & Ballad"
   region: "NTSC-J"
   compat: 4
 SLPM-62383:
-  name: "Karaoke Revolution - Night Selection 2003"
+  name: カラオケレボリューション Love&Ballad
+  name-sort: からおけれぼりゅーしょん Love&Ballad
+  name-en: "Karaoke Revolution - Night Selection 2003"
   region: "NTSC-J"
 SLPM-62384:
-  name: "Sega Ages 2500 Series Vol.04 - Space Harrier"
+  name: SEGA AGES 2500 シリーズ Vol.4 スペースハリアー
+  name-sort: SEGA AGES 2500 しりーず Vol.4 すぺーすはりあー
+  name-en: "Sega Ages 2500 Series Vol.04 - Space Harrier"
   region: "NTSC-J"
 SLPM-62385:
-  name: "Sega Ages 2500 Series Vol.05 - Golden Axe"
+  name: SEGA AGES 2500 シリーズ Vol.5 ゴールデンアックス
+  name-sort: SEGA AGES 2500 しりーず Vol.5 ごーるでんあっくす
+  name-en: "Sega Ages 2500 Series Vol.05 - Golden Axe"
   region: "NTSC-J"
   compat: 5
 SLPM-62386:
@@ -31068,22 +32123,32 @@ SLPM-62388:
   name: "SuperLite 2000 Vol. 9 - NumCro"
   region: "NTSC-J"
 SLPM-62389:
-  name: "Big Bass - Bass Tsuri Kanzen Kouryaku [SuperLite 2000 Series]"
+  name: SuperLite 2000釣り　ビッグバス 〜バス釣り完全攻略〜
+  name-sort: SuperLite 2000つり　びっぐばす 〜ばすづりかんぜんこうりゃく〜
+  name-en: "Big Bass - Bass Tsuri Kanzen Kouryaku [SuperLite 2000 Series]"
   region: "NTSC-J"
 SLPM-62390:
-  name: "Ichigeki Sacchuu! HoiHoi-san [Limited Edition]"
+  name: 一撃殺虫!!ホイホイさん 限定版
+  name-sort: いちげきさっちゅう!!ほいほいさん げんていばん
+  name-en: "Ichigeki Sacchuu! HoiHoi-san [Limited Edition]"
   region: "NTSC-J"
 SLPM-62391:
-  name: "Ichigeki Sacchuu! HoiHoi-san"
+  name: 一撃殺虫!!ホイホイさん
+  name-sort: いちげきさっちゅう!!ほいほいさん
+  name-en: "Ichigeki Sacchuu! HoiHoi-san"
   region: "NTSC-J"
 SLPM-62392:
-  name: "G1 Jockey 3 2003"
+  name: ジーワンジョッキー3 2003
+  name-sort: じーわんじょっきー3 2003
+  name-en: "G1 Jockey 3 2003"
   region: "NTSC-J"
 SLPM-62393:
   name: "GI Jockey 3 2003 [Premium Pack]"
   region: "NTSC-J"
 SLPM-62394:
-  name: "Power Smash 2 [Sega The Best - 2800 Series]"
+  name: Power Smash 2 SEGA THE BEST 2800
+  name-sort: Power Smash 2 SEGA THE BEST 2800
+  name-en: "Power Smash 2 [Sega The Best - 2800 Series]"
   region: "NTSC-J"
   gameFixes:
     - XGKickHack # Fixes black models on certain games in World Tour.
@@ -31091,7 +32156,9 @@ SLPM-62394:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
 SLPM-62395:
-  name: "Simple 2000 Series Vol. 37 - The Shooting - Double Shienryu"
+  name: SIMPLE2000シリーズVol.37 THEシューティング 〜ダブル紫炎龍〜
+  name-sort: SIMPLE2000しりーずVol.37 THEしゅーてぃんぐ 〜だぶるしえんりゅう〜
+  name-en: "Simple 2000 Series Vol. 37 - The Shooting - Double Shienryu"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
@@ -31100,7 +32167,9 @@ SLPM-62396:
   name: "Simple 2000 Honkaku Shikou Series Vol. 6 - The Card"
   region: "NTSC-J"
 SLPM-62397:
-  name: "Simple 2000 Honkaku Shikou Series Vol. 5 - Kiryoku Kentei"
+  name: SIMPLE2000本格思考シリーズVol.5 THE棋力検定〜楽しく学べる囲碁入門〜
+  name-sort: SIMPLE2000ほんかくしこうしりーずVol.5 THEきりょくけんてい〜たのしくまなべるいごにゅうもん〜
+  name-en: "Simple 2000 Honkaku Shikou Series Vol. 5 - Kiryoku Kentei"
   region: "NTSC-J"
 SLPM-62398:
   name: "Simple 2000 Series Vol. 39 - The Boku no Machizukuri - Machi-ing Maker++"
@@ -31109,37 +32178,55 @@ SLPM-62399:
   name: "Simple 2000 Series Ultimate Vol. 13 - Kyousou! Tansha King"
   region: "NTSC-J"
 SLPM-62400:
-  name: "Sega Ages 2500 Series Vol.12 - Puyo Puyo Tsu Perfect Set"
+  name: SEGA AGES 2500 シリーズ Vol.12 ぷよぷよ通 パーフェクト・セット
+  name-sort: SEGA AGES 2500 しりーず Vol.12 ぷよぷよつう ぱーふぇくと・せっと
+  name-en: "Sega Ages 2500 Series Vol.12 - Puyo Puyo Tsu Perfect Set"
   region: "NTSC-J"
 SLPM-62401:
-  name: "Death Crimson OX+"
+  name: デスクリムゾンOX+
+  name-sort: ですくりむぞんOX+
+  name-en: "Death Crimson OX+"
   region: "NTSC-J"
 SLPM-62403:
-  name: "Chou Aniki - Seinaru Protein Densetsu"
+  name: 超兄貴 〜聖なるプロテイン伝説〜
+  name-sort: ちょうあにき 〜せいなるぷろていんでんせつ〜
+  name-en: "Chou Aniki - Seinaru Protein Densetsu"
   region: "NTSC-J"
   compat: 5
 SLPM-62404:
-  name: "Hudson Selection Vol.1 - Cubic Lode Runner"
+  name: ハドソンセレクションVOL.1 キュービックロードランナー
+  name-sort: はどそんせれくしょんVOL.1 きゅーびっくろーどらんなー
+  name-en: "Hudson Selection Vol.1 - Cubic Lode Runner"
   region: "NTSC-J"
 SLPM-62405:
   name: "Taikou Risshiden IV"
   region: "NTSC-J"
 SLPM-62406:
-  name: "Kurogane no Houkou - Warship Commander [Koei The Best]"
+  name: 鋼鉄の咆哮 〜ウォーシップコマンダー〜 KOEI The BEST
+  name-sort: くろがねのほうこう 〜うぉーしっぷこまんだー〜 KOEI The BEST
+  name-en: "Kurogane no Houkou - Warship Commander [Koei The Best]"
   region: "NTSC-J"
 SLPM-62407:
-  name: "Takahashi Naoko no Marathon Shiyou yo!"
+  name: 高橋尚子とマラソンしようよ!
+  name-sort: たかはししょうことまらそんしようよ!
+  name-en: "Takahashi Naoko no Marathon Shiyou yo!"
   region: "NTSC-J"
   gsHWFixes:
     preloadFrameData: 1 # Fixes missing text.
 SLPM-62408:
-  name: "Harry Potter - Quidditch World Cup"
+  name: ハリー・ポッター クィディッチ ワールドカップ
+  name-sort: はりー・ぽったー くぃでぃっち わーるどかっぷ
+  name-en: "Harry Potter - Quidditch World Cup"
   region: "NTSC-J"
 SLPM-62409:
-  name: "Wizardry Empire III - Ancestry of the Emperor"
+  name: ウィザードリィ エンパイアIII 〜覇王の系譜〜
+  name-sort: うぃざーどりぃ えんぱいあIII 〜はおうのけいふ〜
+  name-en: "Wizardry Empire III - Ancestry of the Emperor"
   region: "NTSC-J"
 SLPM-62410:
-  name: "Silent Scope 3 [Konami The Best]"
+  name: サイレントスコープ3 (コナミ ザ ベスト)
+  name-sort: さいれんとすこーぷ3 (こなみ ざ べすと)
+  name-en: "Silent Scope 3 [Konami The Best]"
   region: "NTSC-J"
 SLPM-62411:
   name: "Buggy Grand Prix - Kattobi! Daisakusen"
@@ -31147,25 +32234,39 @@ SLPM-62411:
   gameFixes:
     - EETimingHack # Fixes random graphical corruption.
 SLPM-62412:
-  name: "Simple 2000 Series Vol. 41 - The Volleyball"
+  name: SIMPLE2000シリーズVol.41 THEバレーボール
+  name-sort: SIMPLE2000しりーずVol.41 THEばれーぼーる
+  name-en: "Simple 2000 Series Vol. 41 - The Volleyball"
   region: "NTSC-J"
 SLPM-62413:
-  name: "Kuusen 2"
+  name: 空戦 II
+  name-sort: くうせん II
+  name-en: "Kuusen 2"
   region: "NTSC-J"
 SLPM-62414:
-  name: "Karaoke Revolution - Dreams & Memories"
+  name: カラオケレボリューション Dreams & Memories
+  name-sort: からおけれぼりゅーしょん Dreams & Memories
+  name-en: "Karaoke Revolution - Dreams & Memories"
   region: "NTSC-J"
 SLPM-62415:
-  name: "G1 Jockey 2 [Koei Teiban Series]"
+  name: コーエー定番シリーズ　ジーワン ジョッキー２
+  name-sort: こーえーていばんしりーず　じーわん じょっきーに
+  name-en: "G1 Jockey 2 [Koei Teiban Series]"
   region: "NTSC-J"
 SLPM-62416:
-  name: "Momotaro Densetsu XII - West Japan Hen"
+  name: 桃太郎電鉄12 西日本編もありまっせー!
+  name-sort: ももたろうでんてつ12 にしにほんへんもありまっせー!
+  name-en: "Momotaro Densetsu XII - West Japan Hen"
   region: "NTSC-J"
 SLPM-62417:
-  name: "Sakigake!! Cromatier High School - Kore wa Hyottoshite Game Nanoka! Hen"
+  name: 魁!!クロマティ高校 これはひょっとしてゲームなのか?
+  name-sort: さきがけ!!くろまてぃこうこう これはひょっとしてげーむなのか?
+  name-en: "Sakigake!! Cromatier High School - Kore wa Hyottoshite Game Nanoka! Hen"
   region: "NTSC-J"
 SLPM-62418:
-  name: "Hudson Selection Vol.3 - PC Genjin"
+  name: ハドソンセレクションVOL.3 PC原人
+  name-sort: はどそんせれくしょんVOL.3 PCげんじん
+  name-en: "Hudson Selection Vol.3 - PC Genjin"
   region: "NTSC-J"
   compat: 5
 SLPM-62419:
@@ -31178,54 +32279,80 @@ SLPM-62421:
   name: "Ishikura Noboru Kudan no Igo Kouza - Joukyuu-hen Mezase, Jitsuryoku Shodan!"
   region: "NTSC-J"
 SLPM-62422:
-  name: "Hudson Selection Vol.4 - Takahashi Meijin no Bouken Jima"
+  name: ハドソンセレクションVOL.4 高橋名人の冒険島
+  name-sort: はどそんせれくしょんVOL.4 たかはしめいじんのぼうけんじま
+  name-en: "Hudson Selection Vol.4 - Takahashi Meijin no Bouken Jima"
   region: "NTSC-J"
   compat: 5
 SLPM-62423:
-  name: "Tetris Kiwamemichi [SuperLite 2000 Series]"
+  name: SuperLite 2000 パズル テトリス KIWAMEMICHI
+  name-sort: SuperLite 2000 ぱずる てとりす KIWAMEMICHI
+  name-en: "Tetris Kiwamemichi [SuperLite 2000 Series]"
   region: "NTSC-J"
 SLPM-62424:
-  name: "Sukusuku Inufuku"
+  name: すくすく犬福
+  name-sort: すくすくいぬふく
+  name-en: "Sukusuku Inufuku"
   region: "NTSC-J"
 SLPM-62425:
-  name: "Sega Ages 2500 Series Vol.07 - Columns"
+  name: SEGA AGES 2500 シリーズ Vol.7 コラムス
+  name-sort: SEGA AGES 2500 しりーず Vol.7 こらむす
+  name-en: "Sega Ages 2500 Series Vol.07 - Columns"
   region: "NTSC-J"
   compat: 5
 SLPM-62426:
-  name: "Simple 2000 Series Vol. 42 - The Ishu Kakutou Waza"
+  name: SIMPLE2000シリーズ Vol.42 異種格闘技 〜ボクシングVSキックVS空手VSプロレスVS柔術VS・・・〜
+  name-sort: SIMPLE2000しりーず Vol.42 いしゅかくとうぎ 〜ぼくしんぐVSきっくVSからてVSぷろれすVSじゅうじゅつVS・・・〜
+  name-en: "Simple 2000 Series Vol. 42 - The Ishu Kakutou Waza"
   region: "NTSC-J"
 SLPM-62427:
-  name: "Dance Dance Revolution Party Collection"
+  name: Dance Dance Revolution パーティーコレクション
+  name-sort: Dance Dance Revolution ぱーてぃーこれくしょん
+  name-en: "Dance Dance Revolution Party Collection"
   region: "NTSC-J"
   compat: 5
 SLPM-62428:
-  name: "Kiwame Mahjong DXII - The 4th Mondo 21 Cup Competition"
+  name: 極 麻雀 DXII The 4th MONDO21Cup Competition
+  name-sort: きわめ まーじゃん DXII The 4th MONDO21Cup Competition
+  name-en: "Kiwame Mahjong DXII - The 4th Mondo 21 Cup Competition"
   region: "NTSC-J"
 SLPM-62429:
-  name: "Simple 2000 Series Ultimate Vol. 15 - Love - Ping Pong!"
+  name: SIMPLE2000シリーズ アルティメット Vol.15 ラブ★ピンポン
+  name-sort: SIMPLE2000しりーず あるてぃめっと Vol.15 らぶ★ぴんぽん
+  name-en: "Simple 2000 Series Ultimate Vol. 15 - Love - Ping Pong!"
   region: "NTSC-J"
 SLPM-62430:
-  name: "Simple 2000 Series Vol. 43 - The Saiban"
+  name: SIMPLE2000シリーズ Vol.43 THE裁判 〜新米司法官 桃田 司の10の裁判ファイル
+  name-sort: SIMPLE2000しりーず Vol.43 THEさいばん 〜しんまいしほうかん ももた つかさの10のさいばんふぁいる
+  name-en: "Simple 2000 Series Vol. 43 - The Saiban"
   region: "NTSC-J"
 SLPM-62431:
   name: "Simple 2000 Series Ultimate Vol. 14 - Topai! Dramatic Mahjong"
   region: "NTSC-J"
 SLPM-62432:
-  name: "Sega Ages 2500 Series Vol.11 - Hokuto no Ken"
+  name: SEGA AGES 2500 シリーズ Vol.11 北斗の拳
+  name-sort: SEGA AGES 2500 しりーず Vol.11 ほくとのけん
+  name-en: "Sega Ages 2500 Series Vol.11 - Hokuto no Ken"
   region: "NTSC-J"
   compat: 5
 SLPM-62433:
-  name: "Sega Ages 2500 Series Vol.06 - Bonanza Brothers"
+  name: SEGA AGES 2500 シリーズ Vol.6 イチニのタントアールとボナンザブラザーズ。
+  name-sort: SEGA AGES 2500 しりーず Vol.6 いちにのたんとあーるとぼなんざぶらざーず。
+  name-en: "Sega Ages 2500 Series Vol.06 - Bonanza Brothers"
   region: "NTSC-J"
   compat: 5
 SLPM-62435:
   name: "Tennis no Oujisama - Smash Hit! 2 - Original Anime Game"
   region: "NTSC-J"
 SLPM-62437:
-  name: "Sui Sui Sweet - Amai Koi no Mitsuke-kata"
+  name: すいすい Sweet 〜あまい恋のみつけ方〜
+  name-sort: すいすい Sweet 〜あまいこいのみつけかた〜
+  name-en: "Sui Sui Sweet - Amai Koi no Mitsuke-kata"
   region: "NTSC-J"
 SLPM-62438:
-  name: "Growlanser Collection - The Dual Darkness"
+  name: グローランサーコレクション
+  name-sort: ぐろーらんさーこれくしょん
+  name-en: "Growlanser Collection - The Dual Darkness"
   region: "NTSC-J"
   compat: 4
 SLPM-62439:
@@ -31233,101 +32360,157 @@ SLPM-62439:
   region: "NTSC-J"
   compat: 4
 SLPM-62440:
-  name: "Growlanser III [Atlus The Best]"
+  name: グローランサーIII(Atlus Best Collection)
+  name-sort: ぐろーらんさーIII(Atlus Best Collection)
+  name-en: "Growlanser III [Atlus The Best]"
   region: "NTSC-J"
   compat: 4
 SLPM-62442:
-  name: "Youkoso Hitsuji-Mura"
+  name: ようこそ ひつじ村
+  name-sort: ようこそ ひつじむら
+  name-en: "Youkoso Hitsuji-Mura"
   region: "NTSC-J"
 SLPM-62443:
-  name: "Sega Ages 2500 Series Vol.08 - Virtua Racing"
+  name: SEGA AGES 2500 シリーズ Vol.8 V.R. バーチャレーシング
+  name-sort: SEGA AGES 2500 しりーず Vol.8 V.R. ばーちゃれーしんぐ
+  name-en: "Sega Ages 2500 Series Vol.08 - Virtua Racing"
   region: "NTSC-J"
   compat: 5
 SLPM-62444:
-  name: "Sega Ages 2500 Series Vol.15 - Decathlete Collection"
+  name: SEGA AGES 2500 シリーズ Vol.15 デカスリート・コレクション
+  name-sort: SEGA AGES 2500 しりーず Vol.15 でかすりーと・これくしょん
+  name-en: "Sega Ages 2500 Series Vol.15 - Decathlete Collection"
   region: "NTSC-J"
 SLPM-62445:
-  name: "Sega Ages 2500 Series Vol.09 - Gain Ground"
+  name: SEGA AGES 2500 シリーズ Vol.9 ゲイングランド
+  name-sort: SEGA AGES 2500 しりーず Vol.9 げいんぐらんど
+  name-en: "Sega Ages 2500 Series Vol.09 - Gain Ground"
   region: "NTSC-J"
   compat: 5
 SLPM-62446:
-  name: "Sega Ages 2500 Series Vol.10 - Afterburner II"
+  name: SEGA AGES 2500 シリーズ Vol.10 アフターバーナーII
+  name-sort: SEGA AGES 2500 しりーず Vol.10 あふたーばーなーII
+  name-en: "Sega Ages 2500 Series Vol.10 - Afterburner II"
   region: "NTSC-J"
   compat: 5
 SLPM-62447:
-  name: "Sega Ages 2500 Series Vol.13 - Outrun"
+  name: SEGA AGES 2500 シリーズ Vol.13 アウトラン
+  name-sort: SEGA AGES 2500 しりーず Vol.13 あうとらん
+  name-en: "Sega Ages 2500 Series Vol.13 - Outrun"
   region: "NTSC-J"
 SLPM-62448:
-  name: "Crossword [SuperLite 2000 Series]"
+  name: SuperLite 2000パズル クロスワード
+  name-sort: SuperLite 2000ぱずる くろすわーど
+  name-en: "Crossword [SuperLite 2000 Series]"
   region: "NTSC-J"
 SLPM-62449:
-  name: "Tom & Jerry - War of the Whiskers"
+  name: トムとジェリー ヒゲヒゲだいせんそう
+  name-sort: とむとじぇりー ひげひげだいせんそう
+  name-en: "Tom & Jerry - War of the Whiskers"
   region: "NTSC-J"
   gsHWFixes:
     mipmap: 1 # Cleans up texture detail.
     disableDepthSupport: 1 # Fixes shadow flicker.
 SLPM-62450:
-  name: "Karaoke Revolution - Anime Song Selection"
+  name: カラオケレボリューション 〜アニメソングコレクション〜
+  name-sort: からおけれぼりゅーしょん 〜あにめそんぐこれくしょん〜
+  name-en: "Karaoke Revolution - Anime Song Selection"
   region: "NTSC-J"
 SLPM-62451:
-  name: "Karaoke Revolution - J-Pop Vol.5"
+  name: カラオケレボリューション J-POPベストvol.5
+  name-sort: からおけれぼりゅーしょん J-POPべすとvol.5
+  name-en: "Karaoke Revolution - J-Pop Vol.5"
   region: "NTSC-J"
 SLPM-62453:
-  name: "G-Taste Mahjong"
+  name: 彩京べすと G-taste麻雀
+  name-sort: さいきょうべすと G-tasteまーじゃん
+  name-en: "G-Taste Mahjong"
   region: "NTSC-J"
 SLPM-62454:
-  name: "Karaoke Revolution - J-Pop Vol.6"
+  name: カラオケレボリューション J-POPベストvol.6
+  name-sort: からおけれぼりゅーしょん J-POPべすとvol.6
+  name-en: "Karaoke Revolution - J-Pop Vol.6"
   region: "NTSC-J"
 SLPM-62455:
-  name: "Karaoke Revolution - J-Pop Vol.7"
+  name: カラオケレボリューション J-POPベストvol.7
+  name-sort: からおけれぼりゅーしょん J-POPべすとvol.7
+  name-en: "Karaoke Revolution - J-Pop Vol.7"
   region: "NTSC-J"
 SLPM-62456:
-  name: "Karaoke Revolution - J-Pop Vol.8"
+  name: カラオケレボリューション J-POPベストvol.8
+  name-sort: からおけれぼりゅーしょん J-POPべすとvol.8
+  name-en: "Karaoke Revolution - J-Pop Vol.8"
   region: "NTSC-J"
 SLPM-62457:
-  name: "Karaoke Revolution - Snow & Party"
+  name: カラオケレボリューション 〜Snow & Party〜
+  name-sort: からおけれぼりゅーしょん 〜Snow & Party〜
+  name-en: "Karaoke Revolution - Snow & Party"
   region: "NTSC-J"
 SLPM-62458:
-  name: "Daisan Teikoku Koubouki - Aufstieg und Fall des dritten Reiches"
+  name: 第三帝国興亡記
+  name-sort: だいさんていこくこうぼうき
+  name-en: "Daisan Teikoku Koubouki - Aufstieg und Fall des dritten Reiches"
   region: "NTSC-J"
 SLPM-62459:
-  name: "Simple 2000 Series Vol. 16 - Sengoku vs. Gendai"
+  name: SIMPLE2000シリーズ アルティメット Vol.16 戦国VS現代
+  name-sort: SIMPLE2000しりーず あるてぃめっと Vol.16 せんごくVSげんだい
+  name-en: "Simple 2000 Series Vol. 16 - Sengoku vs. Gendai"
   region: "NTSC-J"
   compat: 5
 SLPM-62460:
-  name: "Kakoniwa Tetsudou - Blue Train Tokkyuuhen [SuperLite 2000 Series]"
+  name: SuperLite2000 シミュレーション 箱庭鉄道 ～ブルートレイン・特急編～
+  name-sort: SuperLite2000 しみゅれーしょん はこにわてつどう ～ぶるーとれいん・とっきゅうへん～
+  name-en: "Kakoniwa Tetsudou - Blue Train Tokkyuuhen [SuperLite 2000 Series]"
   region: "NTSC-J"
 SLPM-62461:
-  name: "Shikigami no Shiro II"
+  name: 式神の城II
+  name-sort: しきがみのしろII
+  name-en: "Shikigami no Shiro II"
   region: "NTSC-J"
   compat: 5
 SLPM-62462:
-  name: "Gradius V"
+  name: グラディウスV
+  name-sort: ぐらでぃうすV
+  name-en: "Gradius V"
   region: "NTSC-J"
   compat: 5
 SLPM-62463:
-  name: "Loop Sequencer - Music Generator"
+  name: ループシーケンサー ミュージックジェネレーター
+  name-sort: るーぷしーけんさー みゅーじっくじぇねれーたー
+  name-en: "Loop Sequencer - Music Generator"
   region: "NTSC-J"
 SLPM-62464:
-  name: "pop'n Taisen Pazurudama Online"
+  name: pop’n対戦ぱずるだまONLINE
+  name-sort: pop’nたいせんぱずるだまONLINE
+  name-en: "pop'n Taisen Pazurudama Online"
   region: "NTSC-J"
   compat: 5
 SLPM-62465:
-  name: "LeMans 24 Hours [Sega The Best]"
+  name: LE MANS 24 HOURS SEGA THE BEST 2800
+  name-sort: LE MANS 24 HOURS SEGA THE BEST 2800
+  name-en: "LeMans 24 Hours [Sega The Best]"
   region: "NTSC-J"
 SLPM-62466:
-  name: "Zooo [Superlite 2000 Series]"
+  name: SuperLite 2000パズル ZOOO
+  name-sort: SuperLite 2000ぱずる ZOOO
+  name-en: "Zooo [Superlite 2000 Series]"
   region: "NTSC-J"
   compat: 5
 SLPM-62467:
-  name: "Simple 2000 Series Ultimate Vol. 18 - Love - Aerobics"
+  name: SIMPLE2000シリーズ アルティメットVol.18 ラブ★エアロビ
+  name-sort: SIMPLE2000しりーず あるてぃめっとVol.18 らぶ★えあろび
+  name-en: "Simple 2000 Series Ultimate Vol. 18 - Love - Aerobics"
   region: "NTSC-J"
   compat: 5
 SLPM-62468:
-  name: "Simple 2000 Series Ultimate Vol. 17 - Taisen! Bakudan Poi Poi"
+  name: SIMPLE2000シリーズ アルティメット Vol.17 対戦!爆弾ポイポイ
+  name-sort: SIMPLE2000しりーず あるてぃめっと Vol.17 たいせん!ばくだんぽいぽい
+  name-en: "Simple 2000 Series Ultimate Vol. 17 - Taisen! Bakudan Poi Poi"
   region: "NTSC-J"
 SLPM-62469:
-  name: "Gunbird 1&2"
+  name: GUNBIRD 1＆2
+  name-sort: GUNBIRD 1＆2
+  name-en: "Gunbird 1&2"
   region: "NTSC-J"
   compat: 5
 SLPM-62470:
@@ -31338,44 +32521,70 @@ SLPM-62470:
     - "SLPM-62470"
     - "SLPM-62518"
 SLPM-62471:
-  name: "Uno [SuperLite 2000 Series]"
+  name: SuperLite 2000テーブル UNO
+  name-sort: SuperLite 2000てーぶる UNO
+  name-en: "Uno [SuperLite 2000 Series]"
   region: "NTSC-J"
 SLPM-62472:
-  name: "Diet Channel"
+  name: ダイエット チャンネル
+  name-sort: だいえっと ちゃんねる
+  name-en: "Diet Channel"
   region: "NTSC-J"
 SLPM-62473:
-  name: "Nobunaga no Yabou - Ranseiki [Koei The Best]"
+  name: KOEI The Best 信長の野望 嵐世紀
+  name-sort: KOEI The Best のぶながのやぼう あらしせいき
+  name-en: "Nobunaga no Yabou - Ranseiki [Koei The Best]"
   region: "NTSC-J"
 SLPM-62474:
-  name: "Simple 2000 Series Vol. 46 - The Kanji Quiz - Challenge! Kanji Kentei"
+  name: SIMPLE2000シリーズ Vol.46 THE 漢字クイズ〜チャレンジ!漢字検定〜
+  name-sort: SIMPLE2000しりーず Vol.46 THE かんじくいず〜ちゃれんじ!かんじけんてい〜
+  name-en: "Simple 2000 Series Vol. 46 - The Kanji Quiz - Challenge! Kanji Kentei"
   region: "NTSC-J"
 SLPM-62475:
-  name: "Momotaro Densetsu XI [Hudson The Best]"
+  name: 桃太郎電鉄11 ハドソン・ザ・ベスト
+  name-sort: ももたろうでんてつ11 はどそん・ざ・べすと
+  name-en: "Momotaro Densetsu XI [Hudson The Best]"
   region: "NTSC-J"
 SLPM-62476:
-  name: "Get Backers Dakkanoku - Ura Shinjuku Saikyou Battle"
+  name: GetBackers奪還屋 裏新宿最強バトル
+  name-sort: GetBackersだっかんや うらしんじゅくさいきょうばとる
+  name-en: "Get Backers Dakkanoku - Ura Shinjuku Saikyou Battle"
   region: "NTSC-J"
 SLPM-62477:
-  name: "Simple 2000 Series Vol. 47 - The Gassen Sekigahara"
+  name: SIMPLE2000シリーズ Vol.47 THE 合戦 関が原
+  name-sort: SIMPLE2000しりーず Vol.47 THE かっせん せきがはら
+  name-en: "Simple 2000 Series Vol. 47 - The Gassen Sekigahara"
   region: "NTSC-J"
 SLPM-62478:
-  name: "Bomberman Kart DX"
+  name: ボンバーマンランドシリーズ ボンバーマンカートDX
+  name-sort: ぼんばーまんらんどしりーず ぼんばーまんかーとDX
+  name-en: "Bomberman Kart DX"
   region: "NTSC-J"
 SLPM-62479:
-  name: "Karaoke Revolution - J-Pop Vol.9"
+  name: カラオケレボリューション J-POPベストVol.9
+  name-sort: からおけれぼりゅーしょん J-POPべすとVol.9
+  name-en: "Karaoke Revolution - J-Pop Vol.9"
   region: "NTSC-J"
 SLPM-62480:
-  name: "Hot Gimmick Cosplay Mahjong [Limited Edition]"
+  name: 対戦ホットギミック コスプレ雀 スペシャル版
+  name-sort: たいせんほっとぎみっく こすぷれじゃん すぺしゃるばん
+  name-en: "Hot Gimmick Cosplay Mahjong [Limited Edition]"
   region: "NTSC-J"
   compat: 5
 SLPM-62481:
-  name: "Waku Waku Volleyball 2 [Superlite 2000 Series]"
+  name: SuperLite2000 スポーツ わくわくバレー2
+  name-sort: SuperLite2000 すぽーつ わくわくばれー2
+  name-en: "Waku Waku Volleyball 2 [Superlite 2000 Series]"
   region: "NTSC-J"
 SLPM-62482:
-  name: "Pachinko Slot Tokodensho - Inoki Festival"
+  name: パチスロ闘魂伝承 猪木祭 アントニオ猪木という名のパチスロ機 アントニオ猪木自身がパチスロ機
+  name-sort: ぱちすろとうこんでんしょう いのきまつり あんとにおいのきというなのぱちすろき あんとにおいのきじしんがぱちすろき
+  name-en: "Pachinko Slot Tokodensho - Inoki Festival"
   region: "NTSC-J"
 SLPM-62483:
-  name: "Simple 2000 Series Vol. 48 - The Taxi - Untenshu ha Kimi da"
+  name: SIMPLE2000シリーズ Vol.48 THE タクシー ～運転手は君だ～
+  name-sort: SIMPLE2000しりーず Vol.48 THE たくしー ～うんてんしゅはきみだ～
+  name-en: "Simple 2000 Series Vol. 48 - The Taxi - Untenshu ha Kimi da"
   region: "NTSC-J"
   gsHWFixes:
     mipmap: 2 # Fixes road markings.
@@ -31384,13 +32593,19 @@ SLPM-62483:
     eeRoundMode: 2 # Positive rounding fixes distant white models.
     vu1RoundMode: 2 # Positive rounding fixes close white models.
 SLPM-62484:
-  name: "Simple 2000 Series Vol. 50 - The Daibijin"
+  name: SIMPLE2000シリーズ Vol.50 THE 大美人
+  name-sort: SIMPLE2000しりーず Vol.50 THE だいびじん
+  name-en: "Simple 2000 Series Vol. 50 - The Daibijin"
   region: "NTSC-J"
 SLPM-62485:
-  name: "Simple 2000 Series Vol. 49 - The World Champ Dodge Baller"
+  name: SIMPLE2000シリーズVol.49 THE ドッヂボール ～World Champion Dodge Baller〜～
+  name-sort: SIMPLE2000しりーずVol.49 THE どっぢぼーる ～World Champion Dodge Baller〜～
+  name-en: "Simple 2000 Series Vol. 49 - The World Champ Dodge Baller"
   region: "NTSC-J"
 SLPM-62486:
-  name: "Chou Saisoku! Zokusha King B.U. [Simple Series DX]"
+  name: 超最速!族車キングBU～仏恥義理伝説2～
+  name-sort: ちょうさいそく!ぞくしゃきんぐBU～ふつはじぎりでんせつ2～
+  name-en: "Chou Saisoku! Zokusha King B.U. [Simple Series DX]"
   region: "NTSC-J"
   clampModes:
     eeClampMode: 3 # Fixes white shadows.
@@ -31398,14 +32613,20 @@ SLPM-62487:
   name: "SuperLite 2000 Vol. 19 - Hanafuda"
   region: "NTSC-J"
 SLPM-62488:
-  name: "Hot Gimmick Cosplay Mahjong"
+  name: 対戦ホットギミック コスプレ雀
+  name-sort: たいせんほっとぎみっく こすぷれじゃん
+  name-en: "Hot Gimmick Cosplay Mahjong"
   region: "NTSC-J"
 SLPM-62489:
-  name: "Yoshinoya"
+  name: 吉野家
+  name-sort: よしのや
+  name-en: "Yoshinoya"
   region: "NTSC-J"
   compat: 5
 SLPM-62490:
-  name: "Dragon Quest VIII [Premium Disc]"
+  name: 「ドラゴンクエストVIII」プレミアム映像ディスク
+  name-sort: 「どらごんくえすとVIII」ぷれみあむえいぞうでぃすく
+  name-en: "Dragon Quest VIII [Premium Disc]"
   region: "NTSC-J"
   gsHWFixes:
     autoFlush: 2 # Fixes missing bloom from surfaces like windows.
@@ -31413,70 +32634,110 @@ SLPM-62490:
     halfPixelOffset: 2 # Sharpens world in far distances, aligns some bloom better.
     roundSprite: 1 # Fixes font artifacts.
 SLPM-62491:
-  name: "RockMan Power Battle Fighters"
+  name: ロックマン パワーバトルファイターズ
+  name-sort: ろっくまん ぱわーばとるふぁいたーず
+  name-en: "RockMan Power Battle Fighters"
   region: "NTSC-J"
 SLPM-62492:
-  name: "Karaoke Revolution - Kids Song Selection"
+  name: カラオケレボリューション キッズソングセレクション
+  name-sort: からおけれぼりゅーしょん きっずそんぐせれくしょん
+  name-en: "Karaoke Revolution - Kids Song Selection"
   region: "NTSC-J"
 SLPM-62493:
-  name: "Simple 2000 Series Vol. 54 - The Daikiju"
+  name: SIMPLE2000シリーズ Vol.54 THE 大海獣
+  name-sort: SIMPLE2000しりーず Vol.54 THE だいかいじゅう
+  name-en: "Simple 2000 Series Vol. 54 - The Daikiju"
   region: "NTSC-J"
 SLPM-62494:
-  name: "Simple 2000 Series Vol. 55 - The Cat Fight"
+  name: SIMPLE2000シリーズ Vol.55 THE キャットファイト
+  name-sort: SIMPLE2000しりーず Vol.55 THE きゃっとふぁいと
+  name-en: "Simple 2000 Series Vol. 55 - The Cat Fight"
   region: "NTSC-J"
   compat: 5
 SLPM-62495:
-  name: "Simple 2000 Series Vol. 53 - The Camera Kozo"
+  name: SIMPLE2000シリーズ Vol.53 THE カメラ小僧
+  name-sort: SIMPLE2000しりーず Vol.53 THE かめらこぞう
+  name-en: "Simple 2000 Series Vol. 53 - The Camera Kozo"
   region: "NTSC-J"
 SLPM-62496:
-  name: "Simple 2000 Series Vol. 52 - The Space Raiders"
+  name: SIMPLE2000シリーズ Vol.52 THE 地球侵略群～スペースレイダース～
+  name-sort: SIMPLE2000しりーず Vol.52 THE ちきゅうしんりゃくぐん～すぺーすれいだーす～
+  name-en: "Simple 2000 Series Vol. 52 - The Space Raiders"
   region: "NTSC-J"
 SLPM-62497:
-  name: "Simple 2000 Series Vol. 51 - The Senkan"
+  name: SIMPLE2000シリーズ Vol.51 THE 戦艦
+  name-sort: SIMPLE2000しりーず Vol.51 THE せんかん
+  name-en: "Simple 2000 Series Vol. 51 - The Senkan"
   region: "NTSC-J"
 SLPM-62498:
   name: "Shin Sangoku Musou 3 & Moushouden Saikyou Data"
   region: "NTSC-J"
 SLPM-62499:
-  name: "Gambler Densetsu Tetsuya Digest"
+  name: 勝負師伝説 哲也 DIGEST
+  name-sort: しょうぶしでんせつ てつや DIGEST
+  name-en: "Gambler Densetsu Tetsuya Digest"
   region: "NTSC-J"
 SLPM-62500:
-  name: "Sega Ages 2500 Series Vol.14 - Alien Syndrome"
+  name: SEGA AGES 2500 シリーズ Vol.14 エイリアンシンドローム
+  name-sort: SEGA AGES 2500 しりーず Vol.14 えいりあんしんどろーむ
+  name-en: "Sega Ages 2500 Series Vol.14 - Alien Syndrome"
   region: "NTSC-J"
 SLPM-62501:
-  name: "Juusou Kihei Valken"
+  name: 重装機兵ヴァルケン
+  name-sort: じゅうそうきへいゔぁるけん
+  name-en: "Juusou Kihei Valken"
   region: "NTSC-J"
 SLPM-62502:
-  name: "Nobunaga Senki"
+  name: 信長戦記
+  name-sort: のぶながせんき
+  name-en: "Nobunaga Senki"
   region: "NTSC-J"
 SLPM-62503:
-  name: "Bomberman Battles"
+  name: BOMBERMAN BATTLES
+  name-sort: BOMBERMAN BATTLES
+  name-en: "Bomberman Battles"
   region: "NTSC-J"
 SLPM-62504:
-  name: "Simple 2000 Series Vol. 56 - The Survival Game"
+  name: SIMPLE2000シリーズ Vol.56 THE サバイバルゲーム
+  name-sort: SIMPLE2000しりーず Vol.56 THE さばいばるげーむ
+  name-en: "Simple 2000 Series Vol. 56 - The Survival Game"
   region: "NTSC-J"
 SLPM-62505:
-  name: "Fukuhara Love Ping Pong"
+  name: 福原愛の卓球一直線
+  name-sort: ふくはらあいのたっきゅういっちょくせん
+  name-en: "Fukuhara Love Ping Pong"
   region: "NTSC-J"
 SLPM-62506:
-  name: "Vampire Panic"
+  name: ヴァンパイアパニック 限定版
+  name-sort: ゔぁんぱいあぱにっく げんていばん
+  name-en: "Vampire Panic"
   region: "NTSC-J"
   compat: 5
 SLPM-62508:
-  name: "Simple 2000 Series Vol. 57 - The Pro Yakyuu 2004"
+  name: SIMPLE2000シリーズ Vol.57 THE プロ野球2004
+  name-sort: SIMPLE2000しりーず Vol.57 THE ぷろやきゅう2004
+  name-en: "Simple 2000 Series Vol. 57 - The Pro Yakyuu 2004"
   region: "NTSC-J"
 SLPM-62509:
-  name: "Simple 2000 Series Vol. 58 - The Gekai"
+  name: SIMPLE2000シリーズ Vol.58 THE 外科医
+  name-sort: SIMPLE2000しりーず Vol.58 THE げかい
+  name-en: "Simple 2000 Series Vol. 58 - The Gekai"
   region: "NTSC-J"
 SLPM-62510:
-  name: "Simple 2000 Series Vol. 60 - The Tokusatsu Henshin Hero"
+  name: SIMPLE2000シリーズ Vol.60 THE 特撮変身ヒーロー
+  name-sort: SIMPLE2000しりーず Vol.60 THE とくさつへんしんひーろー
+  name-en: "Simple 2000 Series Vol. 60 - The Tokusatsu Henshin Hero"
   region: "NTSC-J"
   compat: 5
 SLPM-62511:
-  name: "Victory Wings - Zero Pilot Series"
+  name: ヴィクトリー・ウイングス 〜ゼロ・パイロット シリーズ〜
+  name-sort: ゔぃくとりー・ういんぐす 〜ぜろ・ぱいろっと しりーず〜
+  name-en: "Victory Wings - Zero Pilot Series"
   region: "NTSC-J"
 SLPM-62512:
-  name: "Keiei Simulation - Jurassic Park [Konami The Best]"
+  name: 経営シミュレーション ジュラシック・パーク(コナミ ザ ベスト)
+  name-sort: けいえいしみゅれーしょん じゅらしっく・ぱーく(こなみ ざ べすと)
+  name-en: "Keiei Simulation - Jurassic Park [Konami The Best]"
   region: "NTSC-J"
   gsHWFixes:
     autoFlush: 2 # Fixes glows. Also needed for recursive mipmap rendering.
@@ -31485,7 +32746,9 @@ SLPM-62512:
     textureInsideRT: 1 # Fixes rainbow lighting for some areas.
     getSkipCount: "GSC_BlueTongueGames" # Mipmap rendering on CPU.
 SLPM-62513:
-  name: "Harry Potter and the Chamber of Secrets [EA Best Hits]"
+  name: EA BEST HITS ハリー・ポッターと秘密の部屋
+  name-sort: EA BEST HITS はりー・ぽったーとひみつのへや
+  name-en: "Harry Potter and the Chamber of Secrets [EA Best Hits]"
   region: "NTSC-J"
   gameFixes:
     - EETimingHack # Fixes flickering textures.
@@ -31495,125 +32758,191 @@ SLPM-62513:
     trilinearFiltering: 1 # Fixes blurry textures.
     cpuFramebufferConversion: 1 # Fixes right side of the screen from garbage textures.
 SLPM-62514:
-  name: "Sim People [EA Best Hits]"
+  name: EA BEST HITS シムピープル ～お茶の間劇場～
+  name-sort: EA BEST HITS しむぴーぷる ～おちゃのまげきじょう～
+  name-en: "Sim People [EA Best Hits]"
   region: "NTSC-J"
 SLPM-62515:
-  name: "Psikyo Shooting Collection Vol.1 - Strikers 1945 1-2"
+  name: 彩京シューティングコレクション Vol.1 STRIKERS1945 I＆II
+  name-sort: さいきょうしゅーてぃんぐこれくしょん Vol.1 STRIKERS1945 I＆II
+  name-en: "Psikyo Shooting Collection Vol.1 - Strikers 1945 1-2"
   region: "NTSC-J"
   compat: 5
   gameFixes:
     - EETimingHack # Fixes part II intro screen.
 SLPM-62516:
-  name: "EyeToy Sports - Let's Play Sports!"
+  name: レッツプレイスポーツ!
+  name-sort: れっつぷれいすぽーつ!
+  name-en: "EyeToy Sports - Let's Play Sports!"
   region: "NTSC-J"
 SLPM-62517:
-  name: "Winning Post 5 [Koei The Best]"
+  name: KOEI The Best WinningPost 5
+  name-sort: KOEI The Best WinningPost 5
+  name-en: "Winning Post 5 [Koei The Best]"
   region: "NTSC-J"
 SLPM-62518:
-  name: "Teitoku no Ketsudan IV [Koei the Best]"
+  name: KOEI The Best 提督の決断IV
+  name-sort: KOEI The Best ていとくのけつだんIV
+  name-en: "Teitoku no Ketsudan IV [Koei the Best]"
   region: "NTSC-J"
 SLPM-62519:
-  name: "Sangokushi VIII [Koei The Best]"
+  name: KOEI The Best 三國志VIII
+  name-sort: KOEI The Best さんごくしVIII
+  name-en: "Sangokushi VIII [Koei The Best]"
   region: "NTSC-J"
 SLPM-62520:
   name: "Nobunaga no Yabou - Soutenroku"
   region: "NTSC-J"
 SLPM-62521:
-  name: "Kiwame Mahjong DXII - The 4th Mondo 21 Cup Competition [Athena Best Collection]"
+  name: 極麻雀DXII-The 4th MONDO21Cup Competition Athena Best Collection Vol.2
+  name-sort: きわめまーじゃんDXII-The 4th MONDO21Cup Competition Athena Best Collection Vol.2
+  name-en: "Kiwame Mahjong DXII - The 4th Mondo 21 Cup Competition [Athena Best Collection]"
   region: "NTSC-J"
 SLPM-62523:
   name: "Shikigami no Shiro [Taito The Best]"
   region: "NTSC-J"
 SLPM-62524:
-  name: "Simple 2000 Series Vol. 59 - The Uchyujin to Hanashi Sou!"
+  name: SIMPLE2000シリーズ Vol.59 THE 宇宙人と話そう!～うちゅ～じんってなぁに?～
+  name-sort: SIMPLE2000しりーず Vol.59 THE うちゅうじんとはなそう!～うちゅ～じんってなぁに?～
+  name-en: "Simple 2000 Series Vol. 59 - The Uchyujin to Hanashi Sou!"
   region: "NTSC-J"
   compat: 5
 SLPM-62525:
-  name: "Simple 2000 Series Vol. 61 - The OneeChanBara"
+  name: SIMPLE2000シリーズ Vol.61 THE お姉チャンバラ
+  name-sort: SIMPLE2000しりーず Vol.61 THE おあねちゃんばら
+  name-en: "Simple 2000 Series Vol. 61 - The OneeChanBara"
   region: "NTSC-J"
   compat: 5
 SLPM-62526:
-  name: "Giant Robo - The Animation - Chikyuu ga Seishi suru Hi"
+  name: ジャイアントロボ THE ANIMATION 地球が静止する日
+  name-sort: じゃいあんとろぼ THE ANIMATION ちきゅうがせいしするひ
+  name-en: "Giant Robo - The Animation - Chikyuu ga Seishi suru Hi"
   region: "NTSC-J"
   gsHWFixes:
     preloadFrameData: 1 # Fixes blackscreen.
 SLPM-62528:
-  name: "Karaoke Revolution - Kazoku Idol Sengen [with Microphone]"
+  name: カラオケレボリューション ファミリーパック
+  name-sort: からおけれぼりゅーしょん ふぁみりーぱっく
+  name-en: "Karaoke Revolution - Kazoku Idol Sengen [with Microphone]"
   region: "NTSC-J"
 SLPM-62529:
-  name: "Karaoke Revolution - Kazoku Idol Sengen"
+  name: カラオケレボリューション☆家族アイドル化宣言☆
+  name-sort: からおけれぼりゅーしょん☆かぞくあいどるかせんげん☆
+  name-en: "Karaoke Revolution - Kazoku Idol Sengen"
   region: "NTSC-J"
 SLPM-62530:
-  name: "Gradius III & IV [Konami Dendou Collection]"
+  name: グラディウスIII＆IV〜復活の神話〜(コナミ殿堂セレクション)
+  name-sort: ぐらでぃうすIII＆IV〜ふっかつのしんわ〜(こなみでんどうせれくしょん)
+  name-en: "Gradius III & IV [Konami Dendou Collection]"
   region: "NTSC-J"
 SLPM-62531:
-  name: "Mahjong Yarouze! 2 [Konami Palace Selection]"
+  name: 麻雀やろうぜ!2 (コナミ殿堂セレクション)
+  name-sort: まーじゃんやろうぜ!2 (こなみでんどうせれくしょん)
+  name-en: "Mahjong Yarouze! 2 [Konami Palace Selection]"
   region: "NTSC-J"
 SLPM-62532:
-  name: "Ys III - Wanderers from Ys [Limited Edition]"
+  name: イースIII ～ワンダラーズ フロム イース～
+  name-sort: いーすIII ～わんだらーず ふろむ いーす～
+  name-en: "Ys III - Wanderers from Ys [Limited Edition]"
   region: "NTSC-J"
   compat: 5
 SLPM-62533:
   name: "Usagi - Yasei no Touhai - The Arcade - Yamashiro Mahjong-hen"
   region: "NTSC-J"
 SLPM-62534:
-  name: "Simple 2000 Series Vol. 63 - The Suieitaikai"
+  name: SIMPLE2000シリーズ Vol.63 もぎたて水着!女まみれの THE 水泳大会
+  name-sort: SIMPLE2000しりーず Vol.63 もぎたてみずぎ!おんなまみれの THE すいえいたいかい
+  name-en: "Simple 2000 Series Vol. 63 - The Suieitaikai"
   region: "NTSC-J"
   compat: 5
 SLPM-62536:
-  name: "G1 Jockey 3 [Koei The Best]"
+  name: KOEI The Best ジーワンジョッキー3
+  name-sort: KOEI The Best じーわんじょっきー3
+  name-en: "G1 Jockey 3 [Koei The Best]"
   region: "NTSC-J"
 SLPM-62537:
-  name: "Star Wars - Starfighter [EA Best Hits]"
+  name: EA BEST HITS スター・ウォーズ スターファイター
+  name-sort: EA BEST HITS すたー・うぉーず すたーふぁいたー
+  name-en: "Star Wars - Starfighter [EA Best Hits]"
   region: "NTSC-J"
 SLPM-62538:
-  name: "Kyoushuu Kidou Butai - Kougeki Helicopter Senki"
+  name: 強襲機甲部隊〜攻撃ヘリコプター戦記〜
+  name-sort: きょうしゅうきこうぶたい〜こうげきへりこぷたーせんき〜
+  name-en: "Kyoushuu Kidou Butai - Kougeki Helicopter Senki"
   region: "NTSC-J"
 SLPM-62539:
-  name: "Chess Champion [SuperLite 2000 Series]"
+  name: SuperLite 2000 テーブル めざせ! チェスチャンピオン
+  name-sort: SuperLite 2000 てーぶる めざせ! ちぇすちゃんぴおん
+  name-en: "Chess Champion [SuperLite 2000 Series]"
   region: "NTSC-J"
 SLPM-62540:
-  name: "Super Husaru [SuperLite 2000 Series]"
+  name: SuperLite 2000シリーズ めざせ!スーパーハスラー
+  name-sort: SuperLite 2000しりーず めざせ!すーぱーはすらー
+  name-en: "Super Husaru [SuperLite 2000 Series]"
   region: "NTSC-J"
 SLPM-62541:
-  name: "Super Bowling [Superlite 2000 Series Sports]"
+  name: SuperLite 2000 スポーツ めざせ! スーパーボウラー
+  name-sort: SuperLite 2000 すぽーつ めざせ! すーぱーぼうらー
+  name-en: "Super Bowling [Superlite 2000 Series Sports]"
   region: "NTSC-J"
 SLPM-62542:
-  name: "Simple 2000 Series Vol. 20 - The Love Mahjong 2"
+  name: SIMPLE2000シリーズ アルティメット Vol.20 ラブ★マージャン!2
+  name-sort: SIMPLE2000しりーず あるてぃめっと Vol.20 らぶ★まーじゃん!2
+  name-en: "Simple 2000 Series Vol. 20 - The Love Mahjong 2"
   region: "NTSC-J"
 SLPM-62543:
-  name: "Simple 2000 Series Vol. 65 - The Kyonshi Panic"
+  name: SIMPLE2000シリーズ Vol.65 THE キョンシーパニック
+  name-sort: SIMPLE2000しりーず Vol.65 THE きょんしーぱにっく
+  name-en: "Simple 2000 Series Vol. 65 - The Kyonshi Panic"
   region: "NTSC-J"
 SLPM-62544:
-  name: "Simple 2000 Series Vol. 19 - Akagi Yama ni Oritattatensai"
+  name: SIMPLE2000シリーズ アルティメット Vol.19 アカギ〜闇に降り立った天才〜
+  name-sort: SIMPLE2000しりーず あるてぃめっと Vol.19 あかぎ〜やみにおりたったてんさい〜
+  name-en: "Simple 2000 Series Vol. 19 - Akagi Yama ni Oritattatensai"
   region: "NTSC-J"
 SLPM-62545:
-  name: "Simple 2000 Series Vol. 64 - Splatter Action"
+  name: SIMPLE2000シリーズ Vol.64 THE スプラッターアクション
+  name-sort: SIMPLE2000しりーず Vol.64 THE すぷらったーあくしょん
+  name-en: "Simple 2000 Series Vol. 64 - Splatter Action"
   region: "NTSC-J"
   compat: 5
 SLPM-62546:
-  name: "Sangokushi VII [Koei Collection Series]"
+  name: コーエー定番シリーズ 三國志VII
+  name-sort: こーえーていばんしりーず さんごくしVII
+  name-en: "Sangokushi VII [Koei Collection Series]"
   region: "NTSC-J"
 SLPM-62547:
-  name: "Sega Ages 2500 Series Vol.16 - Virtua Fighter 2"
+  name: SEGA AGES 2500 シリーズ Vol.16 バーチャファイター2
+  name-sort: SEGA AGES 2500 しりーず Vol.16 ばーちゃふぁいたー2
+  name-en: "Sega Ages 2500 Series Vol.16 - Virtua Fighter 2"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
     cpuCLUTRender: 2 # Fixes CLUT colours.
 SLPM-62548:
-  name: "Heisei Bakutoden [SuperLite 2000 Series]"
+  name: SuperLite 2000パズル 平成博徒伝
+  name-sort: SuperLite 2000ぱずる へいせいばくとでん
+  name-en: "Heisei Bakutoden [SuperLite 2000 Series]"
   region: "NTSC-J"
 SLPM-62549:
-  name: "Otona no Gal Jan - Kimi ni Hane Man [Jaleco the Best]"
+  name: JALECO the BEST おとなのギャル雀 〜きみにハネ満!〜
+  name-sort: JALECO the BEST おとなのぎゃるじゃん 〜きみにはねまん!〜
+  name-en: "Otona no Gal Jan - Kimi ni Hane Man [Jaleco the Best]"
   region: "NTSC-J"
 SLPM-62550:
-  name: "Wizardry Empire III - Ancestry of the Emperor [Good Price - Limited Edition]"
+  name: ウィザードリィ エンパイアIII 〜覇王の系譜〜 Good Price(限定版)
+  name-sort: うぃざーどりぃ えんぱいあIII 〜はおうのけいふ〜 Good Price(げんていばん)
+  name-en: "Wizardry Empire III - Ancestry of the Emperor [Good Price - Limited Edition]"
   region: "NTSC-J"
 SLPM-62551:
-  name: "Wizardry Empire III - Ancestry of the Emperor [Good Price]"
+  name: ウィザードリィ エンパイアIII 〜覇王の系譜〜 Good Price
+  name-sort: うぃざーどりぃ えんぱいあIII 〜はおうのけいふ〜 Good Price
+  name-en: "Wizardry Empire III - Ancestry of the Emperor [Good Price]"
   region: "NTSC-J"
 SLPM-62552:
-  name: "Super Shanghai 2005"
+  name: スーパー上海2005
+  name-sort: すーぱーしゃんはい2005
+  name-en: "Super Shanghai 2005"
   region: "NTSC-J"
   compat: 5
   patches:
@@ -31623,94 +32952,144 @@ SLPM-62552:
         comment=patch by kr_ps2
         patch=1,IOP,000760B0,word,24040001
 SLPM-62553:
-  name: "Sega Ages 2500 Series Vol.17 - Phantasy Star Generation 2"
+  name: SEGA AGES 2500シリーズ Vol.17 PHANTASY STAR generation:2
+  name-sort: SEGA AGES 2500しりーず Vol.17 PHANTASY STAR generation:2
+  name-en: "Sega Ages 2500 Series Vol.17 - Phantasy Star Generation 2"
   region: "NTSC-J"
   compat: 5
 SLPM-62554:
-  name: "EyeToy - Sega Superstars [with Camera]"
+  name: セガ スーパースターズ“EyeToy”カメラ同梱版
+  name-sort: せが すーぱーすたーず“EyeToy”かめらどうこんばん
+  name-en: "EyeToy - Sega Superstars [with Camera]"
   region: "NTSC-J"
 SLPM-62555:
-  name: "Momotaro Densetsu"
+  name: 桃太郎電鉄USA
+  name-sort: ももたろうでんてつUSA
+  name-en: "Momotaro Densetsu"
   region: "NTSC-J"
 SLPM-62556:
-  name: "Simple 2000 Series Vol. 66 - The Party Unou Quiz"
+  name: SIMPLE2000シリーズ Vol.66 THE パーティー右脳クイズ
+  name-sort: SIMPLE2000しりーず Vol.66 THE ぱーてぃーうのうくいず
+  name-en: "Simple 2000 Series Vol. 66 - The Party Unou Quiz"
   region: "NTSC-J"
 SLPM-62557:
-  name: "Simple 2000 Series Vol. 67 - The Suiri"
+  name: SIMPLE2000シリーズ Vol.67 THE 推理 〜そして誰もいなくなった〜
+  name-sort: SIMPLE2000しりーず Vol.67 THE すいり 〜そしてだれもいなくなった〜
+  name-en: "Simple 2000 Series Vol. 67 - The Suiri"
   region: "NTSC-J"
 SLPM-62558:
-  name: "Simple 2000 Series Vol. 21 - Kenka Joutou! Yankee Banchou"
+  name: SIMPLE2000シリーズ Ultimate Vol.21 喧嘩上等!ヤンキー番長 〜昭和99年の伝説〜
+  name-sort: SIMPLE2000しりーず Ultimate Vol.21 けんかじょうとう!やんきーばんちょう 〜しょうわ99ねんのでんせつ〜
+  name-en: "Simple 2000 Series Vol. 21 - Kenka Joutou! Yankee Banchou"
   region: "NTSC-J"
 SLPM-62559:
-  name: "Sega Superstars"
+  name: セガ スーパースターズ
+  name-sort: せが すーぱーすたーず
+  name-en: "Sega Superstars"
   region: "NTSC-J"
 SLPM-62560:
-  name: "Growlanser IV - Return"
+  name: グローランサーIV Return
+  name-sort: ぐろーらんさーIV Return
+  name-en: "Growlanser IV - Return"
   region: "NTSC-J"
 SLPM-62562:
-  name: "Psyvariar 2 - Ultimate Final"
+  name: サイヴァリア2 アルティメット・ファイナル
+  name-sort: さいゔぁりあ2 あるてぃめっと・ふぁいなる
+  name-en: "Psyvariar 2 - Ultimate Final"
   region: "NTSC-J"
   compat: 5
 SLPM-62563:
-  name: "Psikyo Shooting Collection Vol.2 - Sengoku Ace & Sengoku Blade"
+  name: 彩京シューティングコレクション Vol.2 戦国エース＆戦国ブレード
+  name-sort: さいきょうしゅーてぃんぐこれくしょん Vol.2 せんごくえーす＆せんごくぶれーど
+  name-en: "Psikyo Shooting Collection Vol.2 - Sengoku Ace & Sengoku Blade"
   region: "NTSC-J"
   compat: 5
 SLPM-62564:
-  name: "Simple 2000 Series Vol. 68 - The Tousou Highway - Nagoya - Tokyo"
+  name: SIMPLE2000シリーズ Vol.68 THE 逃走ハイウェイ〜名古屋-東京〜
+  name-sort: SIMPLE2000しりーず Vol.68 THE とうそうはいうぇい〜なごや-とうきょう〜
+  name-en: "Simple 2000 Series Vol. 68 - The Tousou Highway - Nagoya - Tokyo"
   region: "NTSC-J"
   gameFixes:
     - XGKickHack # Fixes distant car textures.
 SLPM-62565:
-  name: "Boboboubo Boubobo - Atsumare!! Taikan Boubobo [Doukonban]"
+  name: ボボボーボ・ボーボボ 集まれ!!体感ボーボボ(カメラ同梱)
+  name-sort: ぼぼぼーぼ・ぼーぼぼ あつまれ!!たいかんぼーぼぼ(かめらどうこん)
+  name-en: "Boboboubo Boubobo - Atsumare!! Taikan Boubobo [Doukonban]"
   region: "NTSC-J"
 SLPM-62566:
-  name: "Typing of the Dead - Zombie Panic"
+  name: THE TYPING OF THE DEAD ZOMBIE PANIC
+  name-sort: THE TYPING OF THE DEAD ZOMBIE PANIC
+  name-en: "Typing of the Dead - Zombie Panic"
   region: "NTSC-J"
 SLPM-62567:
-  name: "Winback [Koei Best Series]"
+  name: コーエー定番シリーズ WIN BACK
+  name-sort: こーえーていばんしりーず WIN BACK
+  name-en: "Winback [Koei Best Series]"
   region: "NTSC-J"
   clampModes:
     vuClampMode: 3 # Fixes missing 3D polygons when going ingame.
 SLPM-62568:
-  name: "Shin Sangoku Musou [Koei The Best]"
+  name: コーエー定番シリーズ 真・三國無双
+  name-sort: こーえーていばんしりーず しん・さんごくむそう
+  name-en: "Shin Sangoku Musou [Koei The Best]"
   region: "NTSC-J"
 SLPM-62569:
-  name: "PC Genjin [Hudson The Best]"
+  name: PC原人　ハドソン・ザ・ベスト
+  name-sort: PCげんじん　はどそん・ざ・べすと
+  name-en: "PC Genjin [Hudson The Best]"
   region: "NTSC-J"
 SLPM-62570:
-  name: "Takahashi Meijin no Adventure Island [Hudson The Best]"
+  name: 高橋名人の冒険島　ハドソン・ザ・ベスト
+  name-sort: たかはしめいじんのぼうけんじま　はどそん・ざ・べすと
+  name-en: "Takahashi Meijin no Adventure Island [Hudson The Best]"
   region: "NTSC-J"
 SLPM-62571:
-  name: "Simple 2000 Series Ultimate Vol. 22 - Stylish Mahjong"
+  name: SIMPLE2000シリーズ アルティメット Vol.22 スタイリッシュ麻雀 〜兎-野生の闘牌- ＆ 兎-野生の闘牌 THE ARCADE- ダブルパック〜
+  name-sort: SIMPLE2000しりーず あるてぃめっと Vol.22 すたいりっしゅまーじゃん 〜うさぎ-やせいの闘牌- ＆ うさぎ-やせいの闘牌 THE ARCADE- だぶるぱっく〜
+  name-en: "Simple 2000 Series Ultimate Vol. 22 - Stylish Mahjong"
   region: "NTSC-J"
   compat: 5
 SLPM-62572:
-  name: "Boboboubo Boubobo - Atsumare!! Taikan Boubobo"
+  name: ボボボーボ・ボーボボ 集まれ!!体感ボーボボ
+  name-sort: ぼぼぼーぼ・ぼーぼぼ あつまれ!!たいかんぼーぼぼ
+  name-en: "Boboboubo Boubobo - Atsumare!! Taikan Boubobo"
   region: "NTSC-J"
 SLPM-62573:
   name: "Kessen III - Enjoy Disc"
   region: "NTSC-J"
 SLPM-62574:
-  name: "Gambler Densetsu Tetsuya Digest [Athena Best Collection Vol.3]"
+  name: 勝負師伝説 哲也 DIGEST Athena Best Collection Vol.3
+  name-sort: しょうぶしでんせつ てつや DIGEST Athena Best Collection Vol.3
+  name-en: "Gambler Densetsu Tetsuya Digest [Athena Best Collection Vol.3]"
   region: "NTSC-J"
 SLPM-62576:
   name: "Jissen Pachi-Slot Hisshouhou! Hokuto no Ken Plus"
   region: "NTSC-J"
 SLPM-62577:
-  name: "Jissen Pachi-Slot Hisshouhou! Hokuto no Ken Plus"
+  name: 実戦パチスロ必勝法! 北斗の拳 Plus
+  name-sort: じっせんぱちすろひっしょうほう! ほくとのけん Plus
+  name-en: "Jissen Pachi-Slot Hisshouhou! Hokuto no Ken Plus"
   region: "NTSC-J"
 SLPM-62578:
-  name: "Buzz Rod Fishing Fantasy"
+  name: バズロッド 〜フィッシングファンタジー
+  name-sort: ばずろっど 〜ふぃっしんぐふぁんたじー
+  name-en: "Buzz Rod Fishing Fantasy"
   region: "NTSC-J"
 SLPM-62579:
-  name: "Simple 2000 Series Vol. 74 - Onna no Ko Senyou - The Oujisama to Romance - Ripuru no Tamago"
+  name: SIMPLE2000シリーズ Vol.74 女の子専用 THE 王子様とロマンス 〜リプルのたまご〜
+  name-sort: SIMPLE2000しりーず Vol.74 おんなのこせんよう THE おうじさまとろまんす 〜りぷるのたまご〜
+  name-en: "Simple 2000 Series Vol. 74 - Onna no Ko Senyou - The Oujisama to Romance - Ripuru no Tamago"
   region: "NTSC-J"
 SLPM-62580:
-  name: "Simple 2000 Series Vol. 69 - The Board Game Collection"
+  name: SIMPLE2000シリーズ Vol.69 THE ボードゲームコレクション
+  name-sort: SIMPLE2000しりーず Vol.69 THE ぼーどげーむこれくしょん
+  name-en: "Simple 2000 Series Vol. 69 - The Board Game Collection"
   region: "NTSC-J"
   compat: 5
 SLPM-62581:
-  name: "K-1 Premium 2004 Dynamite!!"
+  name: K-1 PREMIUM 2004 Dynamite!!
+  name-sort: K-1 PREMIUM 2004 Dynamite!!
+  name-en: "K-1 Premium 2004 Dynamite!!"
   region: "NTSC-J"
   gameFixes:
     - XGKickHack # Fixes black and white fighters.
@@ -31722,71 +33101,113 @@ SLPM-62581:
         patch=1,EE,00301de0,word,0000948c
         patch=1,EE,00301e08,word,0000948c
 SLPM-62582:
-  name: "Slotter-Up Core 6"
+  name: スロッターUPコア6 爆炎打! 巨人の星II
+  name-sort: すろったーUPこあ6 爆炎だ! きょじんのほしII
+  name-en: "Slotter-Up Core 6"
   region: "NTSC-J"
 SLPM-62583:
-  name: "Hudson Selection Vol.1 - Cubic Lode Runner [Hudson The Best]"
+  name: キュービックロードランナー ハドソン・ザ・ベスト
+  name-sort: きゅーびっくろーどらんなー はどそん・ざ・べすと
+  name-en: "Hudson Selection Vol.1 - Cubic Lode Runner [Hudson The Best]"
   region: "NTSC-J"
 SLPM-62584:
-  name: "Hudson Selection Vol.2 - Star Soldier [Hudson The Best]"
+  name: スターソルジャー ハドソン・ザ・ベスト
+  name-sort: すたーそるじゃー はどそん・ざ・べすと
+  name-en: "Hudson Selection Vol.2 - Star Soldier [Hudson The Best]"
   region: "NTSC-J"
 SLPM-62585:
-  name: "Sakigake! Cromartie High School [Hudson The Best]"
+  name: 魁!クロマティ高校 ハドソン・ザ・ベスト
+  name-sort: さきがけ!くろまてぃこうこう はどそん・ざ・べすと
+  name-en: "Sakigake! Cromartie High School [Hudson The Best]"
   region: "NTSC-J"
 SLPM-62586:
-  name: "Simple 2000 Series Vol. 70 - Kanshikikan"
+  name: SIMPLE2000シリーズ Vol.70 THE 鑑識官
+  name-sort: SIMPLE2000しりーず Vol.70 THE かんしきかん
+  name-en: "Simple 2000 Series Vol. 70 - Kanshikikan"
   region: "NTSC-J"
 SLPM-62588:
-  name: "Simple 2000 Series Vol. 73 - The Saiyuki Saruden"
+  name: SIMPLE2000シリーズ Vol.73 THE 西遊闘猿伝
+  name-sort: SIMPLE2000しりーず Vol.73 THE せいゆう闘猿でん
+  name-en: "Simple 2000 Series Vol. 73 - The Saiyuki Saruden"
   region: "NTSC-J"
 SLPM-62589:
-  name: "Simple 2000 Series Vol. 72 - Ninhaza"
+  name: SIMPLE2000シリーズ Vol.72 THE 任侠
+  name-sort: SIMPLE2000しりーず Vol.72 THE にんきょう
+  name-en: "Simple 2000 Series Vol. 72 - Ninhaza"
   region: "NTSC-J"
 SLPM-62591:
-  name: "GI Jockey 3 2005"
+  name: ジーワンジョッキー3 2005年度版
+  name-sort: じーわんじょっきー3 2005ねんどばん
+  name-en: "GI Jockey 3 2005"
   region: "NTSC-J"
 SLPM-62593:
-  name: "Psikyo Shooting Collection Vol.3 - Sol Divide & Dragon Blaze"
+  name: 彩京シューティングコレクション Vol.3 ソルディバイド＆ドラゴンブレイズ
+  name-sort: さいきょうしゅーてぃんぐこれくしょん Vol.3 そるでぃばいど＆どらごんぶれいず
+  name-en: "Psikyo Shooting Collection Vol.3 - Sol Divide & Dragon Blaze"
   region: "NTSC-J"
   compat: 5
 SLPM-62594:
-  name: "Hot Gimmick Cosplay Mahjong - Pure"
+  name: 彩京べすと 対戦ホットギミック コスプレ雀
+  name-sort: さいきょうべすと たいせんほっとぎみっく こすぷれじゃん
+  name-en: "Hot Gimmick Cosplay Mahjong - Pure"
   region: "NTSC-J"
 SLPM-62595:
-  name: "Choro Q HG 3 [Takara The Best]"
+  name: チョロQ HG3 THE BEST タカラモノ
+  name-sort: ちょろQ HG3 THE BEST たからもの
+  name-en: "Choro Q HG 3 [Takara The Best]"
   region: "NTSC-J"
 SLPM-62596:
-  name: "EX Okuman Chouja Game [Takara The Best]"
+  name: EX億万長者ゲーム THE BEST タカラモノ
+  name-sort: EXおくまんちょうじゃげーむ THE BEST たからもの
+  name-en: "EX Okuman Chouja Game [Takara The Best]"
   region: "NTSC-J"
 SLPM-62597:
-  name: "Gakuen Heaven - Okawari!"
+  name: 学園ヘヴン おかわりっ!
+  name-sort: がくえんへゔん おかわりっ!
+  name-en: "Gakuen Heaven - Okawari!"
   region: "NTSC-J"
 SLPM-62598:
   name: "Sakura Taisen V - Saraba Itoshiki Hito yo"
   region: "NTSC-J"
 SLPM-62599:
-  name: "Bomberman Kart DX"
+  name: ボンバーマンカートDX ハドソン・ザ・ベスト
+  name-sort: ぼんばーまんかーとDX はどそん・ざ・べすと
+  name-en: "Bomberman Kart DX"
   region: "NTSC-J"
 SLPM-62600:
-  name: "Simple 2000 Series Vol. 75 - The Tokudane"
+  name: SIMPLE2000シリーズ Vol.75 THE 特ダネ 〜日本全国スクープ列島〜
+  name-sort: SIMPLE2000しりーず Vol.75 THE とくだね 〜にほんぜんこくすくーぷれっとう〜
+  name-en: "Simple 2000 Series Vol. 75 - The Tokudane"
   region: "NTSC-J"
 SLPM-62601:
-  name: "Conveti 3, The [Hamster The Best]"
+  name: ザ・コンビニ3 〜あの町を独占せよ〜 HAMSTER the Best
+  name-sort: ざ・こんびに3 〜あのまちをどくせんせよ〜 HAMSTER the Best
+  name-en: "Conveti 3, The [Hamster The Best]"
   region: "NTSC-J"
 SLPM-62602:
-  name: "Yokushin - GigaWing Generations"
+  name: 翼神 ギガウイングジェネレーションズ
+  name-sort: よくしん ぎがういんぐじぇねれーしょんず
+  name-en: "Yokushin - GigaWing Generations"
   region: "NTSC-J"
 SLPM-62603:
-  name: "Wizardry Summoner"
+  name: ウィザードリィサマナー
+  name-sort: うぃざーどりぃさまなー
+  name-en: "Wizardry Summoner"
   region: "NTSC-J"
 SLPM-62604:
-  name: "Simple 2000 Series Vol. 76 - The Hanasou Eigo no Tabi"
+  name: SIMPLE2000シリーズ Vol.76 THE 話そう英語の旅
+  name-sort: SIMPLE2000しりーず Vol.76 THE はなそうえいごのたび
+  name-en: "Simple 2000 Series Vol. 76 - The Hanasou Eigo no Tabi"
   region: "NTSC-J"
 SLPM-62605:
-  name: "Simple 2000 Series Vol. 77 - The Hanasou Kankokugo no Tabi"
+  name: SIMPLE2000シリーズ Vol.77 THE 話そう韓国語の旅
+  name-sort: SIMPLE2000しりーず Vol.77 THE はなそうかんこくごのたび
+  name-en: "Simple 2000 Series Vol. 77 - The Hanasou Kankokugo no Tabi"
   region: "NTSC-J"
 SLPM-62606:
-  name: "Sega Ages 2500 Series Vol.19 - Fighting Vipers"
+  name: SEGA AGES 2500 シリーズ Vol.19 ファイティングバイパーズ
+  name-sort: SEGA AGES 2500 しりーず Vol.19 ふぁいてぃんぐばいぱーず
+  name-en: "Sega Ages 2500 Series Vol.19 - Fighting Vipers"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
@@ -31795,54 +33216,82 @@ SLPM-62607:
   name: "Shikigami no Shiro III [Taito The Best]"
   region: "NTSC-J"
 SLPM-62608:
-  name: "Yoshinoya [Superlite 2000 Series]"
+  name: SuperLite 2000 アクション 吉野家
+  name-sort: SuperLite 2000 あくしょん よしのや
+  name-en: "Yoshinoya [Superlite 2000 Series]"
   region: "NTSC-J"
 SLPM-62609:
-  name: "Majhong Haoh - Shinken Battle [Mycom The Best]"
+  name: MYCOM BEST 麻雀覇王 段級バトル
+  name-sort: MYCOM BEST まーじゃんはおう だんきゅうばとる
+  name-en: "Majhong Haoh - Shinken Battle [Mycom The Best]"
   region: "NTSC-J"
 SLPM-62610:
-  name: "Saikyou Toudai Shogi Supesharu II"
+  name: 最強 東大将棋 スペシャルII
+  name-sort: さいきょう とうだいしょうぎ すぺしゃるII
+  name-en: "Saikyou Toudai Shogi Supesharu II"
   region: "NTSC-J"
 SLPM-62611:
-  name: "Taisen Hot Gimmick Axes Jong [Limited Edition]"
+  name: 対戦ホットギミック アクセス雀 スペシャル版
+  name-sort: たいせんほっとぎみっく あくせすじゃん すぺしゃるばん
+  name-en: "Taisen Hot Gimmick Axes Jong [Limited Edition]"
   region: "NTSC-J"
   compat: 5
 SLPM-62612:
-  name: "Taisen Hot Gimmick Axes Jong"
+  name: 対戦ホットギミック アクセス雀
+  name-sort: たいせんほっとぎみっく あくせすじゃん
+  name-en: "Taisen Hot Gimmick Axes Jong"
   region: "NTSC-J"
 SLPM-62613:
-  name: "Tough Dark Fight"
+  name: TOUGH DARK FIGHT
+  name-sort: TOUGH DARK FIGHT
+  name-en: "Tough Dark Fight"
   region: "NTSC-J"
   compat: 5
 SLPM-62614:
-  name: "Horse Breaker [Koei Teiban Series]"
+  name: コーエー定番シリーズ ホースブレーカー
+  name-sort: こーえーていばんしりーず ほーすぶれーかー
+  name-en: "Horse Breaker [Koei Teiban Series]"
   region: "NTSC-J"
 SLPM-62615:
-  name: "Slotter Up Mania 6"
+  name: スロッターUPマニア6 沖の熱風! パイオニアスペシャルII
+  name-sort: すろったーUPまにあ6 おきのねっぷう! ぱいおにあすぺしゃるII
+  name-en: "Slotter Up Mania 6"
   region: "NTSC-J"
 SLPM-62616:
-  name: "Simple 2000 Series Ultimate Vol. 25 - Chou-Saisoku! Zokusha King BU no BU"
+  name: SIMPLE2000シリーズ Ultimate Vol.25 超最速!族車キングBUのBU 〜仏恥義理伝説2改〜
+  name-sort: SIMPLE2000しりーず Ultimate Vol.25 ちょうさいそく!ぞくしゃきんぐBUのBU 〜ふつはじぎりでんせつ2かい〜
+  name-en: "Simple 2000 Series Ultimate Vol. 25 - Chou-Saisoku! Zokusha King BU no BU"
   region: "NTSC-J"
 SLPM-62617:
   name: "Simple 2000 Series Vol. 79 - Akko ni Omakase! The Party Quiz"
   region: "NTSC-J"
 SLPM-62618:
-  name: "Simple 2000 Series Vol. 78 - The Uchuu Daisensou"
+  name: SIMPLE2000シリーズ Vol.78 THE 宇宙大戦争
+  name-sort: SIMPLE2000しりーず Vol.78 THE うちゅうだいせんそう
+  name-en: "Simple 2000 Series Vol. 78 - The Uchuu Daisensou"
   region: "NTSC-J"
 SLPM-62619:
   name: "Shoujo Yoshitsune-jong - Benkei no Naki Dokoro"
   region: "NTSC-J"
 SLPM-62620:
-  name: "Pachi-Slot Winning Post"
+  name: パチスロ ウイニングポスト
+  name-sort: ぱちすろ ういにんぐぽすと
+  name-en: "Pachi-Slot Winning Post"
   region: "NTSC-J"
 SLPM-62621:
-  name: "Gradius V [Konami The Best]"
+  name: グラディウスV(コナミ ザ ベスト)
+  name-sort: ぐらでぃうすV(こなみ ざ べすと)
+  name-en: "Gradius V [Konami The Best]"
   region: "NTSC-J"
 SLPM-62622:
-  name: "Slotter Up Core 7"
+  name: スロッターUPコア7 激闘打!ストリートファイターII
+  name-sort: すろったーUPこあ7 げきとうだ!すとりーとふぁいたーII
+  name-en: "Slotter Up Core 7"
   region: "NTSC-J"
 SLPM-62623:
-  name: "Elemental Gerad"
+  name: エレメンタルジェレイド-纏え、翠風の剣-
+  name-sort: えれめんたるじぇれいど-まとえ、すいふうのつるぎ-
+  name-en: "Elemental Gerad"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
@@ -31857,45 +33306,67 @@ SLPM-62623:
         patch=1,EE,0053B740,word,00009400
         patch=1,EE,0053B768,word,00009400
 SLPM-62624:
-  name: "Petit Copter 2"
+  name: プチコプター2
+  name-sort: ぷちこぷたー2
+  name-en: "Petit Copter 2"
   region: "NTSC-J"
 SLPM-62625:
-  name: "Onihama Bakusou Gurentai Gekitou Hen"
+  name: 鬼浜爆走愚連隊 激闘編
+  name-sort: おにはまばくそうぐれんたい げきとうへん
+  name-en: "Onihama Bakusou Gurentai Gekitou Hen"
   region: "NTSC-J"
 SLPM-62626:
-  name: "Oretachi Geasen Zoku Sono Vol.01 - Scramble"
+  name: オレたちゲーセン族 その1 スクランブル
+  name-sort: おれたちげーせんぞく その1 すくらんぶる
+  name-en: "Oretachi Geasen Zoku Sono Vol.01 - Scramble"
   region: "NTSC-J"
 SLPM-62627:
-  name: "Oretachi Geasen Zoku Sono Vol.02 - Crazy Climber"
+  name: オレたちゲーセン族 その2 クレイジー・クライマー
+  name-sort: おれたちげーせんぞく その2 くれいじー・くらいまー
+  name-en: "Oretachi Geasen Zoku Sono Vol.02 - Crazy Climber"
   region: "NTSC-J"
 SLPM-62628:
-  name: "Oretachi Geasen Zoku Sono Vol.03 - Karate Michi"
+  name: オレたちゲーセン族 その3 空手道
+  name-sort: おれたちげーせんぞく その3 からてどう
+  name-en: "Oretachi Geasen Zoku Sono Vol.03 - Karate Michi"
   region: "NTSC-J"
 SLPM-62629:
-  name: "Mahjong Haoh - Battle Royal"
+  name: 麻雀覇王 バトルロイヤル
+  name-sort: まーじゃんはおう ばとるろいやる
+  name-en: "Mahjong Haoh - Battle Royal"
   region: "NTSC-J"
 SLPM-62630:
-  name: "Sukusuku Inufuku [Hamster The Best]"
+  name: すくすく犬福 HAMSTER the Best
+  name-sort: すくすくいぬふく HAMSTER the Best
+  name-en: "Sukusuku Inufuku [Hamster The Best]"
   region: "NTSC-J"
 SLPM-62631:
-  name: "Simple 2000 Series 2-in-1 Vol. 3 - The Puzzle Collection 2000 Toi & The Touyou Sandai Senjitsu Fusui, Seimeidanhan, Ekisen [Disc 1 of 2]"
+  name: SIMPLE2000シリーズ 2in1 Vol.3 THE パズルコレクション2,000問 & THE 東洋三大占術〜風水・姓名判断・易占〜
+  name-sort: SIMPLE2000しりーず 2in1 Vol.3 THE ぱずるこれくしょん2,000もん & THE とうようさんだいうらないじゅつ〜ふうすい・せいめいはんだん・えきうらない〜
+  name-en: "Simple 2000 Series 2-in-1 Vol. 3 - The Puzzle Collection 2000 Toi & The Touyou Sandai Senjitsu Fusui, Seimeidanhan, Ekisen [Disc 1 of 2]"
   region: "NTSC-J"
 SLPM-62632:
   name: "Simple 2000 Series 2-in-1 Vol. 3 - The Puzzle Collection 2000 Toi & The Touyou Sandai Senjitsu Fusui, Seimeidanhan, Ekisen [Disc 2 of 2]"
   region: "NTSC-J"
 SLPM-62633:
-  name: "Simple 2000 Series 2-in-1 Vol. 2 - The Bass Fishing & The Bowling Hyper [Disc 1 of 2]"
+  name: SIMPLE2000シリーズ 2in1 Vol.2 THE バスフィッシング ＆ THE ボウリングHYPER
+  name-sort: SIMPLE2000しりーず 2in1 Vol.2 THE ばすふぃっしんぐ ＆ THE ぼうりんぐHYPER
+  name-en: "Simple 2000 Series 2-in-1 Vol. 2 - The Bass Fishing & The Bowling Hyper [Disc 1 of 2]"
   region: "NTSC-J"
 SLPM-62634:
   name: "Simple 2000 Series 2-in-1 Vol. 2 - The Bass Fishing & The Bowling Hyper [Disc 2 of 2]"
   region: "NTSC-J"
 SLPM-62635:
-  name: "Simple 2000 Series Ultimate Vol. 26 - Love - Smash! 5.1 - Tennis Robo no Gyakushuu"
+  name: SIMPLE2000シリーズ Ultimate Vol.26 ラブ★スマッシュ!5.1 〜テニスロボの反乱〜
+  name-sort: SIMPLE2000しりーず Ultimate Vol.26 らぶ★すまっしゅ!5.1 〜てにすろぼのはんらん〜
+  name-en: "Simple 2000 Series Ultimate Vol. 26 - Love - Smash! 5.1 - Tennis Robo no Gyakushuu"
   region: "NTSC-J"
   gameFixes:
     - XGKickHack # Fixes bad Geometry.
 SLPM-62636:
-  name: "Simple 2000 Series 2-in-1 Vol. 1 - The Tennis & The Snowboard [Disc 1 of 2]"
+  name: SIMPLE2000シリーズ 2in1 Vol.1 THE テニス ＆ THE スノーボード
+  name-sort: SIMPLE2000しりーず 2in1 Vol.1 THE てにす ＆ THE すのーぼーど
+  name-en: "Simple 2000 Series 2-in-1 Vol. 1 - The Tennis & The Snowboard [Disc 1 of 2]"
   region: "NTSC-J"
   gameFixes:
     - XGKickHack # Fixes SPS and console spam (The Tennis).
@@ -31903,48 +33374,76 @@ SLPM-62637:
   name: "Simple 2000 Series 2-in-1 Vol. 1 - The Tennis & The Snowboard [Disc 2 of 2]"
   region: "NTSC-J"
 SLPM-62638:
-  name: "Simple 2000 Series Vol. 80 - The OneeChanPuruu"
+  name: SIMPLE2000シリーズ Vol.80 THE お姉チャンプルゥ 〜THE姉チャン特別編〜
+  name-sort: SIMPLE2000しりーず Vol.80 THE おあねちゃんぷるぅ 〜THEあねちゃんとくべつへん〜
+  name-en: "Simple 2000 Series Vol. 80 - The OneeChanPuruu"
   region: "NTSC-J"
   gameFixes:
     - XGKickHack # Fixes characters clothing.
 SLPM-62639:
-  name: "Mahjong Taikai III - Millennium League [Koei Selection Series]"
+  name: コーエー定番シリーズ 麻雀大会III ミレニアムリーグ
+  name-sort: こーえーていばんしりーず まーじゃんたいかいIII みれにあむりーぐ
+  name-en: "Mahjong Taikai III - Millennium League [Koei Selection Series]"
   region: "NTSC-J"
 SLPM-62640:
-  name: "Taikou Risshiden IV [Koei Selection Series]"
+  name: コーエー定番シリーズ 太閤立志伝IV
+  name-sort: こーえーていばんしりーず たいこうりっしでんIV
+  name-en: "Taikou Risshiden IV [Koei Selection Series]"
   region: "NTSC-J"
 SLPM-62641:
-  name: "Sangokushi VIII [with Power-Up Kit] [Koei The Best]"
+  name: KOEI The BEST 三國志VIII with パワーアップキット
+  name-sort: KOEI The BEST さんごくしVIII with ぱわーあっぷきっと
+  name-en: "Sangokushi VIII [with Power-Up Kit] [Koei The Best]"
   region: "NTSC-J"
 SLPM-62642:
-  name: "Nobunaga no Yabou - Ranseiki [with Power-Up Kit] [Koei The Best]"
+  name: KOEI The BEST 信長の野望・嵐世記 with パワーアップキット
+  name-sort: KOEI The BEST のぶながのやぼう・らんせいき with ぱわーあっぷきっと
+  name-en: "Nobunaga no Yabou - Ranseiki [with Power-Up Kit] [Koei The Best]"
   region: "NTSC-J"
 SLPM-62643:
-  name: "Bomberman Land 3"
+  name: ボンバーマンランド3
+  name-sort: ぼんばーまんらんど3
+  name-en: "Bomberman Land 3"
   region: "NTSC-J"
 SLPM-62644:
-  name: "Oretachi Geasen Zoku Sono Vol.04 - Time Pilot"
+  name: オレたちゲーセン族 その4 タイムパイロット
+  name-sort: おれたちげーせんぞく その4 たいむぱいろっと
+  name-en: "Oretachi Geasen Zoku Sono Vol.04 - Time Pilot"
   region: "NTSC-J"
 SLPM-62645:
-  name: "Oretachi Geasen Zoku Sono Vol.05 - Moon Cresta"
+  name: オレたちゲーセン族 その5 ムーンクレスタ
+  name-sort: おれたちげーせんぞく その5 むーんくれすた
+  name-en: "Oretachi Geasen Zoku Sono Vol.05 - Moon Cresta"
   region: "NTSC-J"
 SLPM-62646:
-  name: "Oretachi Geasen Zoku Sono Vol.06 - Sonic Wings"
+  name: オレたちゲーセン族 その6 ソニックウィングス
+  name-sort: おれたちげーせんぞく その6 そにっくうぃんぐす
+  name-en: "Oretachi Geasen Zoku Sono Vol.06 - Sonic Wings"
   region: "NTSC-J"
 SLPM-62648:
-  name: "K-1 World Max 2005"
+  name: K-1 WORLD MAX 2005 〜世界王者への道〜
+  name-sort: K-1 WORLD MAX 2005 〜せかいおうじゃへのみち〜
+  name-en: "K-1 World Max 2005"
   region: "NTSC-J"
 SLPM-62649:
-  name: "Simple 2000 Series Vol. 88 - The Sekai Meisaku Gekijou Quiz"
+  name: SIMPLE2000シリーズ Vol.85 世界名作劇場クイズ
+  name-sort: SIMPLE2000しりーず Vol.85 せかいめいさくげきじょうくいず
+  name-en: "Simple 2000 Series Vol. 88 - The Sekai Meisaku Gekijou Quiz"
   region: "NTSC-J"
 SLPM-62650:
-  name: "Simple 2000 Series Vol. 82 - The Kung-fu"
+  name: SIMPLE2000シリーズ Vol.82 THE カンフー
+  name-sort: SIMPLE2000しりーず Vol.82 THE かんふー
+  name-en: "Simple 2000 Series Vol. 82 - The Kung-fu"
   region: "NTSC-J"
 SLPM-62651:
-  name: "Simple 2000 Series Vol. 83 - The Konchuu Saishuu"
+  name: SIMPLE2000シリーズ Vol.83 THE 昆虫採集
+  name-sort: SIMPLE2000しりーず Vol.83 THE こんちゅうさいしゅう
+  name-en: "Simple 2000 Series Vol. 83 - The Konchuu Saishuu"
   region: "NTSC-J"
 SLPM-62652:
-  name: "Simple 2000 Series Vol. 81 - The Chikyuu Boueigun 2"
+  name: SIMPLE2000シリーズ Vol.81 THE 地球防衛軍2
+  name-sort: SIMPLE2000しりーず Vol.81 THE ちきゅうぼうえいぐん2
+  name-en: "Simple 2000 Series Vol. 81 - The Chikyuu Boueigun 2"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
@@ -31956,34 +33455,48 @@ SLPM-62653:
   gameFixes:
     - EETimingHack # Fixes part II intro screen.
 SLPM-62655:
-  name: "Sega Ages 2500 Series Vol.11 - Hokuto no Ken"
+  name: SEGA AGES 2500シリーズ Vol.11 北斗の拳
+  name-sort: SEGA AGES 2500しりーず Vol.11 ほくとのけん
+  name-en: "Sega Ages 2500 Series Vol.11 - Hokuto no Ken"
   region: "NTSC-J"
 SLPM-62656:
-  name: "Sega Ages 2500 Series Vol.12 - Puyo Puyo Perfect Set"
+  name: SEGA AGES 2500 シリーズ Vol.12 ぷよぷよ通 パーフェクト・セット
+  name-sort: SEGA AGES 2500 しりーず Vol.12 ぷよぷよつう ぱーふぇくと・せっと
+  name-en: "Sega Ages 2500 Series Vol.12 - Puyo Puyo Perfect Set"
   region: "NTSC-J"
 SLPM-62658:
   name: "Kyoushuu Kidou Butai - Kougeki Helicopter Senki [Taito The Best]"
   region: "NTSC-J"
 SLPM-62660:
-  name: "Oretachi Geasen Zoku Sono Vol.09 - Super Volleyball"
+  name: オレたちゲーセン族 スーパーバレーボール
+  name-sort: おれたちげーせんぞく すーぱーばれーぼーる
+  name-en: "Oretachi Geasen Zoku Sono Vol.09 - Super Volleyball"
   region: "NTSC-J"
 SLPM-62661:
-  name: "Oretachi Geasen Zoku Sono - Terra Cresta"
+  name: オレたちゲーセン族 テラクレスタ
+  name-sort: おれたちげーせんぞく てらくれすた
+  name-en: "Oretachi Geasen Zoku Sono - Terra Cresta"
   region: "NTSC-J"
 SLPM-62662:
-  name: "Simple 2000 Series 2-in-1 Vol. 5 - The Shooting & The Helicopter [Disc 1 of 2]"
+  name: SIMPLE2000シリーズ 2in1 Vol.5 THE シューティング〜ダブル紫炎龍〜 ＆ THE ヘリコプター
+  name-sort: SIMPLE2000しりーず 2in1 Vol.5 THE しゅーてぃんぐ〜だぶるしえんりゅう〜 ＆ THE へりこぷたー
+  name-en: "Simple 2000 Series 2-in-1 Vol. 5 - The Shooting & The Helicopter [Disc 1 of 2]"
   region: "NTSC-J"
 SLPM-62663:
   name: "Simple 2000 Series 2-in-1 Vol. 5 - The Shooting & The Helicopter [Disc 2 of 2]"
   region: "NTSC-J"
 SLPM-62664:
-  name: "Simple 2000 Series 2-in-1 Vol. 4 - The Bushidou & The Sniper 2 [Disc 1 of 2]"
+  name: SIMPLE2000シリーズ 2in1 Vol.4 THE 武士道 〜辻斬り一代〜 ＆ THE スナイパー2 〜悪夢の銃弾〜
+  name-sort: SIMPLE2000しりーず 2in1 Vol.4 THE ぶしどう 〜つじぎりいちだい〜 ＆ THE すないぱー2 〜あくむのじゅうだん〜
+  name-en: "Simple 2000 Series 2-in-1 Vol. 4 - The Bushidou & The Sniper 2 [Disc 1 of 2]"
   region: "NTSC-J"
 SLPM-62665:
   name: "Simple 2000 Series 2-in-1 Vol. 4 - The Bushidou & The Sniper 2 [Disc 2 of 2]"
   region: "NTSC-J"
 SLPM-62666:
-  name: "Sega Ages 2500 Series Vol.01 - Phantasy Star Generation 1"
+  name: SEGA AGES 2500シリーズ Vol.1 PHANTASY STAR generation:1 通常版
+  name-sort: SEGA AGES 2500しりーず Vol.1 PHANTASY STAR generation:1 つうじょうばん
+  name-en: "Sega Ages 2500 Series Vol.01 - Phantasy Star Generation 1"
   region: "NTSC-J"
 SLPM-62668:
   name: "Sega Ages 2500 Series Vol.03 - Fantasy Zone"
@@ -31992,176 +33505,272 @@ SLPM-62669:
   name: "Sega Ages 2500 Series Vol. 4 - Space Harrier"
   region: "NTSC-J"
 SLPM-62670:
-  name: "Sega Ages 2500 Series Vol.05 - Golden Axe"
+  name: SEGA AGES 2500シリーズ Vol.5 ゴールデンアックス
+  name-sort: SEGA AGES 2500しりーず Vol.5 ごーるでんあっくす
+  name-en: "Sega Ages 2500 Series Vol.05 - Golden Axe"
   region: "NTSC-J"
 SLPM-62671:
-  name: "Sega Ages 2500 Series Vol.06 - Bonanza Bros. & Tant-R"
+  name: SEGA AGES 2500シリーズ Vol.6 イチニのタントアールとボナンザブラザーズ。
+  name-sort: SEGA AGES 2500しりーず Vol.6 いちにのたんとあーるとぼなんざぶらざーず。
+  name-en: "Sega Ages 2500 Series Vol.06 - Bonanza Bros. & Tant-R"
   region: "NTSC-J"
 SLPM-62672:
   name: "Sega Ages 2500 Series Vol. 7 - Columns"
   region: "NTSC-J"
 SLPM-62675:
-  name: "Sega Ages 2500 Series Vol.13 - Outrun"
+  name: SEGA AGES 2500シリーズ Vol.13 アウトラン
+  name-sort: SEGA AGES 2500しりーず Vol.13 あうとらん
+  name-en: "Sega Ages 2500 Series Vol.13 - Outrun"
   region: "NTSC-J"
 SLPM-62677:
-  name: "Sega Ages 2500 Series Vol.15 - Decathlete Collection"
+  name: SEGA AGES 2500シリーズ Vol.15 デカスリート・コレクション
+  name-sort: SEGA AGES 2500しりーず Vol.15 でかすりーと・これくしょん
+  name-en: "Sega Ages 2500 Series Vol.15 - Decathlete Collection"
   region: "NTSC-J"
 SLPM-62678:
-  name: "Kurogane no Houkou - Warship Commander [Koei Selection Series]"
+  name: コーエー定番シリーズ 鋼鉄の咆哮 〜ウォーシップコマンダー〜
+  name-sort: こーえーていばんしりーず くろがねのほうこう 〜うぉーしっぷこまんだー〜
+  name-en: "Kurogane no Houkou - Warship Commander [Koei Selection Series]"
   region: "NTSC-J"
 SLPM-62679:
-  name: "Relakuma - Ojama Shitemasu 2 [Limited Edition]"
+  name: リラックマ 〜おじゃましてます2週間〜 初回限定ぬいぐるみパック
+  name-sort: りらっくま 〜おじゃましてます2しゅうかん〜 しょかいげんていぬいぐるみぱっく
+  name-en: "Relakuma - Ojama Shitemasu 2 [Limited Edition]"
   region: "NTSC-J"
 SLPM-62680:
-  name: "Relakuma - Ojama Shitemasu 2"
+  name: リラックマ 〜おじゃましてます2週間〜
+  name-sort: りらっくま 〜おじゃましてます2しゅうかん〜
+  name-en: "Relakuma - Ojama Shitemasu 2"
   region: "NTSC-J"
 SLPM-62681:
-  name: "Nobunaga no Yabou - Ranseiki [Koei Selection Series]"
+  name: コーエー定番シリーズ 信長の野望・嵐世記
+  name-sort: こーえーていばんしりーず のぶながのやぼう・らんせいき
+  name-en: "Nobunaga no Yabou - Ranseiki [Koei Selection Series]"
   region: "NTSC-J"
 SLPM-62682:
-  name: "Slotter Up Core 8 - Giant's Star III"
+  name: スロッターUPコア8 極炎打! 巨人の星 III
+  name-sort: すろったーUPこあ8 きょくえんだ! きょじんのほし III
+  name-en: "Slotter Up Core 8 - Giant's Star III"
   region: "NTSC-J"
 SLPM-62683:
-  name: "Mahjong Taikai Battle [Mycom The Best]"
+  name: MYCOM BEST 麻雀覇王 大会バトル
+  name-sort: MYCOM BEST まーじゃんはおう たいかいばとる
+  name-en: "Mahjong Taikai Battle [Mycom The Best]"
   region: "NTSC-J"
 SLPM-62684:
-  name: "Toudai Shogi - Jouseki Dojo Kanketsuhen [Mycom The Best]"
+  name: MYCOM BEST 東大将棋 定跡道場 完結編
+  name-sort: MYCOM BEST とうだいしょうぎ じょうせきどうじょう かんけつへん
+  name-en: "Toudai Shogi - Jouseki Dojo Kanketsuhen [Mycom The Best]"
   region: "NTSC-J"
 SLPM-62685:
-  name: "Homura"
+  name: HOMURA
+  name-sort: HOMURA
+  name-en: "Homura"
   region: "NTSC-J"
   compat: 5
 SLPM-62686:
   name: "Psikyo Shooting Collection Vol.2 - Sengoku Ace & Sengoku Blade [Taito The Best]"
   region: "NTSC-J"
 SLPM-62687:
-  name: "Sega Ages 2500 Series Vol.24 - Last Bronx"
+  name: SEGA AGES 2500 シリーズ Vol.24 ラストブロンクス-東京番外地-
+  name-sort: SEGA AGES 2500 しりーず Vol.24 らすとぶろんくす-とうきょうばんがいち-
+  name-en: "Sega Ages 2500 Series Vol.24 - Last Bronx"
   region: "NTSC-J"
   gsHWFixes:
     cpuCLUTRender: 2 # Fixes CLUT colours.
 SLPM-62689:
-  name: "Langrisser III"
+  name: ラングリッサーIII
+  name-sort: らんぐりっさーIII
+  name-en: "Langrisser III"
   region: "NTSC-J"
 SLPM-62690:
-  name: "Raiden III"
+  name: 雷電III
+  name-sort: らいでんIII
+  name-en: "Raiden III"
   region: "NTSC-J"
 SLPM-62691:
-  name: "Sega Ages 2500 Series Vol.20 - Space Harrier Collection"
+  name: SEGA AGES 2500シリーズ Vol.20 スペースハリアーII 〜スペースハリアーコンプリートコレクション〜
+  name-sort: SEGA AGES 2500しりーず Vol.20 すぺーすはりあーII 〜すぺーすはりあーこんぷりーとこれくしょん〜
+  name-en: "Sega Ages 2500 Series Vol.20 - Space Harrier Collection"
   region: "NTSC-J"
   compat: 5
 SLPM-62692:
-  name: "Sega Ages 2500 Series Vol.21 - SDI & Quartet"
+  name: SEGA AGES 2500シリーズ Vol.21 SDI ＆ カルテット 〜SEGA SYSTEM 16 COLLECTION〜
+  name-sort: SEGA AGES 2500しりーず Vol.21 SDI ＆ かるてっと 〜SEGA SYSTEM 16 COLLECTION〜
+  name-en: "Sega Ages 2500 Series Vol.21 - SDI & Quartet"
   region: "NTSC-J"
 SLPM-62693:
-  name: "Slotter Up Mania 7 - Saishin Saikyou Pioneer MAX"
+  name: スロッターUPマニア7 最新最強!パイオニアMAX
+  name-sort: すろったーUPまにあ7 さいしんさいきょう!ぱいおにあMAX
+  name-en: "Slotter Up Mania 7 - Saishin Saikyou Pioneer MAX"
   region: "NTSC-J"
 SLPM-62694:
-  name: "Slotter Up Mania 8"
+  name: スロッターUPマニア8 閃光告知!ジャグラースペシャルII
+  name-sort: すろったーUPまにあ8 せんこうこくち!じゃぐらーすぺしゃるII
+  name-en: "Slotter Up Mania 8"
   region: "NTSC-J"
 SLPM-62695:
-  name: "Oretachi Geasen Zoku Sono - Burger Time"
+  name: オレたちゲーセン族 バーガータイム
+  name-sort: おれたちげーせんぞく ばーがーたいむ
+  name-en: "Oretachi Geasen Zoku Sono - Burger Time"
   region: "NTSC-J"
 SLPM-62696:
-  name: "Oretachi Geasen Zoku Sono - Yie Ar Kung-fu"
+  name: オレたちゲーセン族 イー・アル・カンフー
+  name-sort: おれたちげーせんぞく いー・ある・かんふー
+  name-en: "Oretachi Geasen Zoku Sono - Yie Ar Kung-fu"
   region: "NTSC-J"
 SLPM-62697:
-  name: "Generation of Chaos Next [Idea Factory Collection]"
+  name: IFコレクション ジェネレーション オブ カオス ネクスト 〜失われし絆〜
+  name-sort: IFこれくしょん じぇねれーしょん おぶ かおす ねくすと 〜うしなわれしきずな〜
+  name-en: "Generation of Chaos Next [Idea Factory Collection]"
   region: "NTSC-J"
 SLPM-62698:
-  name: "Ultimate Pro Pinball"
+  name: アルティメット プロ ピンボール
+  name-sort: あるてぃめっと ぷろ ぴんぼーる
+  name-en: "Ultimate Pro Pinball"
   region: "NTSC-J"
 SLPM-62699:
-  name: "Neverland Card War Cardinal Arc - Konton no Fuusatsu [Idea Factory Collection]"
+  name: IFコレクション カルディナル アーク 〜混沌の封札〜
+  name-sort: IFこれくしょん かるでぃなる あーく 〜こんとんのふうさつ〜
+  name-en: "Neverland Card War Cardinal Arc - Konton no Fuusatsu [Idea Factory Collection]"
   region: "NTSC-J"
 SLPM-62700:
-  name: "Princess Maker [Best Hit Selection]"
+  name: BEST HIT セレクション プリンセスメーカー
+  name-sort: BEST HIT せれくしょん ぷりんせすめーかー
+  name-en: "Princess Maker [Best Hit Selection]"
   region: "NTSC-J"
 SLPM-62701:
-  name: "Princess Maker 2 [Best Hit Selection]"
+  name: BEST HIT セレクション プリンセスメーカー2
+  name-sort: BEST HIT せれくしょん ぷりんせすめーかー2
+  name-en: "Princess Maker 2 [Best Hit Selection]"
   region: "NTSC-J"
 SLPM-62702:
-  name: "Momotaro Densetsu 15"
+  name: 桃太郎電鉄15 五大ボンビー登場!の巻
+  name-sort: ももたろうでんてつ15 ごだいぼんびーとうじょう!のまき
+  name-en: "Momotaro Densetsu 15"
   region: "NTSC-J"
 SLPM-62703:
-  name: "Sega Rally Championship '95"
+  name: SEGA RALLY CHAMPIONSHIP (「セガラリー2007」同梱用)
+  name-sort: SEGA RALLY CHAMPIONSHIP (「せがらりー2007」どうこんよう)
+  name-en: "Sega Rally Championship '95"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
     cpuCLUTRender: 2 # Fixes CLUT colours.
 SLPM-62704:
-  name: "Oretachi Geasen Zoku Sono Vol.10 - Quarth"
+  name: オレたちゲーセン族 クォース
+  name-sort: おれたちげーせんぞく くぉーす
+  name-en: "Oretachi Geasen Zoku Sono Vol.10 - Quarth"
   region: "NTSC-J"
 SLPM-62705:
-  name: "Oretachi Geasen Zoku Sono - Nekketsu Koukou Dodgeball-bu"
+  name: オレたちゲーセン族 熱血高校ドッジボール部
+  name-sort: おれたちげーせんぞく ねっけつこうこうどっじぼーるぶ
+  name-en: "Oretachi Geasen Zoku Sono - Nekketsu Koukou Dodgeball-bu"
   region: "NTSC-J"
 SLPM-62706:
-  name: "Oretachi Geasen Zoku Sono - Nekketsu Kouha Kunio-kun"
+  name: オレたちゲーセン族 熱血硬派くにおくん
+  name-sort: おれたちげーせんぞく ねっけつこうはくにおくん
+  name-en: "Oretachi Geasen Zoku Sono - Nekketsu Kouha Kunio-kun"
   region: "NTSC-J"
 SLPM-62707:
-  name: "Oretachi Geasen Zoku Sono - Rabio Lepus"
+  name: オレたちゲーセン族 ラビオ レプス
+  name-sort: おれたちげーせんぞく らびお れぷす
+  name-en: "Oretachi Geasen Zoku Sono - Rabio Lepus"
   region: "NTSC-J"
 SLPM-62708:
-  name: "Sega Ages 2500 Series Vol.22 - Advanced Daisenryaku - Doitsu Dengeki Sakusen"
+  name: SEGA AGES 2500 シリーズ Vol.22 アドバンスト大戦略 -ドイツ電撃作戦-
+  name-sort: SEGA AGES 2500 しりーず Vol.22 あどばんすとだいせんりゃく -どいつでんげきさくせん-
+  name-en: "Sega Ages 2500 Series Vol.22 - Advanced Daisenryaku - Doitsu Dengeki Sakusen"
   region: "NTSC-J"
 SLPM-62709:
-  name: "Sega Ages 2500 Series Vol.23 - Sega Memorial Selection"
+  name: SEGA AGES 2500 シリーズ Vol.23 セガ メモリアルセレクション
+  name-sort: SEGA AGES 2500 しりーず Vol.23 せが めもりあるせれくしょん
+  name-en: "Sega Ages 2500 Series Vol.23 - Sega Memorial Selection"
   region: "NTSC-J"
 SLPM-62710:
-  name: "San Goku Shi VIII"
+  name: コーエー定番シリーズ 三國志VIII
+  name-sort: こーえーていばんしりーず さんごくしVIII
+  name-en: "San Goku Shi VIII"
   region: "NTSC-J"
 SLPM-62711:
-  name: "Welcome to Sheep Village [Superlite 2000]"
+  name: SuperLite 2000 ようこそ ひつじ村
+  name-sort: SuperLite 2000 ようこそ ひつじむら
+  name-en: "Welcome to Sheep Village [Superlite 2000]"
   region: "NTSC-J"
 SLPM-62712:
-  name: "Sega Ages 2500 Series Vol.25 - Gunstar Heroes - Treasure Box"
+  name: SEGA AGES 2500 シリーズ Vol.25 ガンスターヒーローズ 〜トレジャーボックス〜
+  name-sort: SEGA AGES 2500 しりーず Vol.25 がんすたーひーろーず 〜とれじゃーぼっくす〜
+  name-en: "Sega Ages 2500 Series Vol.25 - Gunstar Heroes - Treasure Box"
   region: "NTSC-J"
   compat: 5
 SLPM-62713:
   name: "Yokushin - Giga Wing Generations [Taito The Best]"
   region: "NTSC-J"
 SLPM-62714:
-  name: "Shin Sangoku Musou Series Collection Joukan"
+  name: 真・三國無双シリーズコレクション　上巻
+  name-sort: しん・さんごくむそうしりーずこれくしょん　じょうかん
+  name-en: "Shin Sangoku Musou Series Collection Joukan"
   region: "NTSC-J"
 SLPM-62715:
   name: "Shin Sangoku Musou Series Collection Joukan Saikyou Data"
   region: "NTSC-J"
 SLPM-62717:
-  name: "Sega Ages 2500 Series Vol.26 - Dynamite Deka"
+  name: SEGA AGES 2500 シリーズ Vol.26 ダイナマイト刑事
+  name-sort: SEGA AGES 2500 しりーず Vol.26 だいなまいとけいじ
+  name-en: "Sega Ages 2500 Series Vol.26 - Dynamite Deka"
   region: "NTSC-J"
   compat: 5
 SLPM-62718:
-  name: "Sega Ages 2500 Series Vol.27 - Panzer Dragoon"
+  name: SEGA AGES 2500 シリーズ Vol.27 パンツァードラグーン
+  name-sort: SEGA AGES 2500 しりーず Vol.27 ぱんつぁーどらぐーん
+  name-en: "Sega Ages 2500 Series Vol.27 - Panzer Dragoon"
   region: "NTSC-J"
 SLPM-62719:
-  name: "Nobunaga no Yabou - Tenka Souyo"
+  name: パチスロ 信長の野望 天下創世
+  name-sort: ぱちすろ のぶながのやぼう てんかそうせい
+  name-en: "Nobunaga no Yabou - Tenka Souyo"
   region: "NTSC-J"
 SLPM-62720:
   name: "Wizardry Summoner [Taito The Best]"
   region: "NTSC-J"
 SLPM-62721:
-  name: "Ichigeki Sacchuu! HoiHoi-san [Konami The Best]"
+  name: 一撃殺虫!!ホイホイさん コナミ・ザ・ベスト
+  name-sort: いちげきさっちゅう!!ほいほいさん こなみ・ざ・べすと
+  name-en: "Ichigeki Sacchuu! HoiHoi-san [Konami The Best]"
   region: "NTSC-J"
 SLPM-62722:
-  name: "Jissen Pachi-Slot Hisshouhou! Ore no Sora"
+  name: 実戦パチスロ必勝法! 俺の空
+  name-sort: じっせんぱちすろひっしょうほう! おれのそら
+  name-en: "Jissen Pachi-Slot Hisshouhou! Ore no Sora"
   region: "NTSC-J"
 SLPM-62724:
-  name: "Conveni 4, The - Ano Machi o Dokusen seyo"
+  name: ザ・コンビニ4 〜あの町を占拠せよ〜
+  name-sort: ざ・こんびに4 〜あのまちをせんきょせよ〜
+  name-en: "Conveni 4, The - Ano Machi o Dokusen seyo"
   region: "NTSC-J"
 SLPM-62725:
-  name: "Mahjong Hoah - Shinken Battle II"
+  name: 麻雀覇王 段級バトルII
+  name-sort: まーじゃんはおう だんきゅうばとるII
+  name-en: "Mahjong Hoah - Shinken Battle II"
   region: "NTSC-J"
 SLPM-62726:
-  name: "Shooting Love - Trizeal"
+  name: シューティング ラブ。 〜TRIZEAL〜
+  name-sort: しゅーてぃんぐ らぶ。 〜TRIZEAL〜
+  name-en: "Shooting Love - Trizeal"
   region: "NTSC-J"
 SLPM-62727:
-  name: "Spectral vs. Generation"
+  name: スペクトラル VS ジェネレーション
+  name-sort: すぺくとらる VS じぇねれーしょん
+  name-en: "Spectral vs. Generation"
   region: "NTSC-J"
   compat: 5
 SLPM-62728:
   name: "Shin Sangoku Musou 4 & Shin Sangoku Musou 4 - Moushouden Saikyou Data"
   region: "NTSC-J"
 SLPM-62729:
-  name: "Oretachi Geasen Zoku Sono Vol.15 - Akumajou Dracula"
+  name: オレたちゲーセン族 悪魔城ドラキュラ
+  name-sort: おれたちげーせんぞく あくまじょうどらきゅら
+  name-en: "Oretachi Geasen Zoku Sono Vol.15 - Akumajou Dracula"
   region: "NTSC-J"
   compat: 5
   clampModes:
@@ -32170,107 +33779,167 @@ SLPM-62729:
   gsHWFixes:
     roundSprite: 1 # Fixes font sizes to be bigger.
 SLPM-62730:
-  name: "Oretachi Geasen Zoku Sono Vol.16 - Contra"
+  name: オレたちゲーセン族 魂斗羅
+  name-sort: おれたちげーせんぞく こんとら
+  name-en: "Oretachi Geasen Zoku Sono Vol.16 - Contra"
   region: "NTSC-J"
 SLPM-62731:
-  name: "Oretachi Geasen Zoku Sono Vol.17 - Pooyan"
+  name: オレたちゲーセン族 プーヤン
+  name-sort: おれたちげーせんぞく ぷーやん
+  name-en: "Oretachi Geasen Zoku Sono Vol.17 - Pooyan"
   region: "NTSC-J"
 SLPM-62733:
-  name: "Garfield - Saving Arlene"
+  name: ガーフィールド アーリーンを救え!
+  name-sort: がーふぃーるど あーりーんをすくえ!
+  name-en: "Garfield - Saving Arlene"
   region: "NTSC-J"
 SLPM-62736:
-  name: "Slotter Up Mania [Dorart Value Series]"
+  name: DORART VALUE スロッターUPマニア 超沖スロ!パイオニア
+  name-sort: DORART VALUE すろったーUPまにあ ちょうおきすろ!ぱいおにあ
+  name-en: "Slotter Up Mania [Dorart Value Series]"
   region: "NTSC-J"
 SLPM-62737:
-  name: "Rally Shox & Freestyle Motorcross [EA Best Hits]"
+  name: EA BEST HITS ラリーショックス&フリークスタイル モトクロス
+  name-sort: EA BEST HITS らりーしょっくす&ふりーくすたいる もとくろす
+  name-en: "Rally Shox & Freestyle Motorcross [EA Best Hits]"
   region: "NTSC-J"
 SLPM-62738:
   name: "Freekstyle Motocross"
   region: "NTSC-J"
 SLPM-62739:
-  name: "Suro Genjin"
+  name: パチスロ完全攻略 スロ原人・鬼浜爆走愚連隊激闘編
+  name-sort: ぱちすろかんぜんこうりゃく すろげんじん・おにはまばくそうぐれんたいげきとうへん
+  name-en: "Suro Genjin"
   region: "NTSC-J"
 SLPM-62740:
-  name: "Saikyo Shogi Gekisashi Special"
+  name: 最強将棋 激指スペシャル
+  name-sort: さいきょうしょうぎ げきさしすぺしゃる
+  name-en: "Saikyo Shogi Gekisashi Special"
   region: "NTSC-J"
 SLPM-62742:
   name: "Wizardry Gaiden - Sentou no Kangoku - Prisoners of the Battles"
   region: "NTSC-J"
 SLPM-62743:
-  name: "School Heaven Okawari [The Best]"
+  name: 学園ヘヴン おかわりっ! ベスト版
+  name-sort: がくえんへゔん おかわりっ! べすとばん
+  name-en: "School Heaven Okawari [The Best]"
   region: "NTSC-J"
 SLPM-62744:
-  name: "Oretachi Geasen Zoku Sono - Thunder Cross"
+  name: オレたちゲーセン族 サンダークロス
+  name-sort: おれたちげーせんぞく さんだーくろす
+  name-en: "Oretachi Geasen Zoku Sono - Thunder Cross"
   region: "NTSC-J"
 SLPM-62745:
-  name: "Oretachi Geasen Zoku Sono Vol.19 - Trio the Punch"
+  name: オレたちゲーセン族 トリオ・ザ・パンチ
+  name-sort: おれたちげーせんぞく とりお・ざ・ぱんち
+  name-en: "Oretachi Geasen Zoku Sono Vol.19 - Trio the Punch"
   region: "NTSC-J"
 SLPM-62746:
-  name: "Sega Ages 2500 Series Vol.28 - Tetris Collection"
+  name: SEGA AGES 2500 シリーズ Vol.28 テトリスコレクション
+  name-sort: SEGA AGES 2500 しりーず Vol.28 てとりすこれくしょん
+  name-en: "Sega Ages 2500 Series Vol.28 - Tetris Collection"
   region: "NTSC-J"
   compat: 5
 SLPM-62747:
-  name: "G1 Jockey 3 [Koei Selection Series]"
+  name: コーエー定番シリーズ ジーワン ジョッキー3
+  name-sort: こーえーていばんしりーず じーわん じょっきー3
+  name-en: "G1 Jockey 3 [Koei Selection Series]"
   region: "NTSC-J"
 SLPM-62748:
-  name: "Nobunaga no Yabou - Renseiki [with Power-Up Kit] [Koei Selection Series]"
+  name: コーエー定番シリーズ 信長の野望・嵐世記 with パワーアップキット
+  name-sort: こーえーていばんしりーず のぶながのやぼう・らんせいき with ぱわーあっぷきっと
+  name-en: "Nobunaga no Yabou - Renseiki [with Power-Up Kit] [Koei Selection Series]"
   region: "NTSC-J"
 SLPM-62749:
-  name: "Jissen Pachi-Slot Hisshouhou! Mister Magic Neo"
+  name: 実戦パチスロ必勝法! ミスターマジックネオ
+  name-sort: じっせんぱちすろひっしょうほう! みすたーまじっくねお
+  name-en: "Jissen Pachi-Slot Hisshouhou! Mister Magic Neo"
   region: "NTSC-J"
 SLPM-62750:
-  name: "Momotaro Densetsu 16"
+  name: 桃太郎電鉄16 北海道大移動!の巻
+  name-sort: ももたろうでんてつ16 ほっかいどうだいいどう!のまき
+  name-en: "Momotaro Densetsu 16"
   region: "NTSC-J"
 SLPM-62751:
   name: "Shin Sangoku Musou Series Collection Gekan Saikyou Data"
   region: "NTSC-J"
 SLPM-62752:
-  name: "Slotter Up Core 9"
+  name: スロッターUPコア9 ジャグ極めたり!ファイナルジャグラー
+  name-sort: すろったーUPこあ9 じゃぐきわめたり!ふぁいなるじゃぐらー
+  name-en: "Slotter Up Core 9"
   region: "NTSC-J"
 SLPM-62753:
-  name: "Homura [Taito The Best]"
+  name: HOMURA TAITO BEST
+  name-sort: HOMURA TAITO BEST
+  name-en: "Homura [Taito The Best]"
   region: "NTSC-J"
 SLPM-62754:
-  name: "Puyo Puyo! 15th Anniversary"
+  name: ぷよぷよ!
+  name-sort: ぷよぷよ!
+  name-en: "Puyo Puyo! 15th Anniversary"
   region: "NTSC-J"
 SLPM-62755:
-  name: "Mahjong Haoh - Shinken Battle [Mycom The Best]"
+  name: MYCOM BEST 麻雀覇王 真剣バトル
+  name-sort: MYCOM BEST まーじゃんはおう しんけんばとる
+  name-en: "Mahjong Haoh - Shinken Battle [Mycom The Best]"
   region: "NTSC-J"
 SLPM-62756:
-  name: "Saikyou Toudai Shogi 6 [Mycom The Best]"
+  name: MYCOM BEST 最強 東大将棋6
+  name-sort: MYCOM BEST さいきょう とうだいしょうぎ6
+  name-en: "Saikyou Toudai Shogi 6 [Mycom The Best]"
   region: "NTSC-J"
 SLPM-62757:
-  name: "EX Okuman Chouja Game [Atlus Best Collection]"
+  name: EX億万長者ゲーム アトラスベストコレクション
+  name-sort: EXおくまんちょうじゃげーむ あとらすべすとこれくしょん
+  name-en: "EX Okuman Chouja Game [Atlus Best Collection]"
   region: "NTSC-J"
 SLPM-62758:
-  name: "River Ride Adventure featuring Salomon"
+  name: RIVER RIDE ADVENTURE featuring SALOMON (リバーライドアドベンチャー フィーチャリングサロモン)
+  name-sort: RIVER RIDE ADVENTURE featuring SALOMON (りばーらいどあどべんちゃー ふぃーちゃりんぐさろもん)
+  name-en: "River Ride Adventure featuring Salomon"
   region: "NTSC-J"
 SLPM-62759:
-  name: "Nobunaga no Yabou - Soutenroku [Koei Selection Series]"
+  name: コーエー定番シリーズ 信長の野望・蒼天録
+  name-sort: こーえーていばんしりーず のぶながのやぼう・そうてんろく
+  name-en: "Nobunaga no Yabou - Soutenroku [Koei Selection Series]"
   region: "NTSC-J"
 SLPM-62760:
-  name: "Sega Ages 2500 Vol.29 - Monster World Complete Collection"
+  name: SEGA AGES 2500 シリーズ Vol.29 モンスターワールド コンプリートコレクション
+  name-sort: SEGA AGES 2500 しりーず Vol.29 もんすたーわーるど こんぷりーとこれくしょん
+  name-en: "Sega Ages 2500 Vol.29 - Monster World Complete Collection"
   region: "NTSC-J"
   compat: 5
 SLPM-62761:
-  name: "Choro Q HG 2 [Atlus Best Collection]"
+  name: チョロQ HG2 アトラスベストコレクション
+  name-sort: ちょろQ HG2 あとらすべすとこれくしょん
+  name-en: "Choro Q HG 2 [Atlus Best Collection]"
   region: "NTSC-J"
   gsHWFixes:
     roundSprite: 2 # Fixes sprite ghosting.
 SLPM-62762:
-  name: "Sangokushi VIII [with Power-Up Kit] [Koei Selection Series]"
+  name: コーエー定番シリーズ 三國志VIII withパワーアップキット
+  name-sort: こーえーていばんしりーず さんごくしVIII withぱわーあっぷきっと
+  name-en: "Sangokushi VIII [with Power-Up Kit] [Koei Selection Series]"
   region: "NTSC-J"
 SLPM-62763:
-  name: "Bomberman Land 3 [Hudson Best Version]"
+  name: ボンバーマンランド3 ハドソン・ザ・ベスト
+  name-sort: ぼんばーまんらんど3 はどそん・ざ・べすと
+  name-en: "Bomberman Land 3 [Hudson Best Version]"
   region: "NTSC-J"
 SLPM-62764:
-  name: "Ojama Shitemasu 2 Shuukan [Best Version]"
+  name: リラックマ〜おじゃましてます2週間〜(ベスト版)
+  name-sort: りらっくま〜おじゃましてます2しゅうかん〜(べすとばん)
+  name-en: "Ojama Shitemasu 2 Shuukan [Best Version]"
   region: "NTSC-J"
 SLPM-62766:
-  name: "Sega Ages 2500 Vol.30 - Galaxy Force II"
+  name: SEGA AGES 2500 シリーズ Vol.30 ギャラクシーフォースII 〜スペシャルエクステンデッドエディション〜
+  name-sort: SEGA AGES 2500 しりーず Vol.30 ぎゃらくしーふぉーすII 〜すぺしゃるえくすてんでっどえでぃしょん〜
+  name-en: "Sega Ages 2500 Vol.30 - Galaxy Force II"
   region: "NTSC-J"
 SLPM-62767:
-  name: "Sega Ages 2500 Vol.31 - Dennou Senki Virtual On"
+  name: SEGA AGES 2500 シリーズ Vol.31 電脳戦機バーチャロン
+  name-sort: SEGA AGES 2500 しりーず Vol.31 でんのうせんきばーちゃろん
+  name-en: "Sega Ages 2500 Vol.31 - Dennou Senki Virtual On"
   region: "NTSC-J"
   clampModes:
     eeClampMode: 2 # Fixes white shadows.
@@ -32283,35 +33952,53 @@ SLPM-62769:
   name: "Quiz & Variety - Suku Suku Inufuku 2 - Motto Suku Suku"
   region: "NTSC-J"
 SLPM-62770:
-  name: "Volleyball World Cup - Venus Evolution"
+  name: バレーボール ワールドカップ 〜ヴィーナスエボリューション〜
+  name-sort: ばれーぼーる わーるどかっぷ 〜ゔぃーなすえぼりゅーしょん〜
+  name-en: "Volleyball World Cup - Venus Evolution"
   region: "NTSC-J"
   compat: 5
 SLPM-62771:
-  name: "Choro Q HG 3 [Atlus Best Collection]"
+  name: チョロQ HG3 Atlus Best Collection
+  name-sort: ちょろQ HG3 Atlus Best Collection
+  name-en: "Choro Q HG 3 [Atlus Best Collection]"
   region: "NTSC-J"
 SLPM-62772:
-  name: "Mahjong Haoh - Battle Royal [Mycom Best]"
+  name: マイコミBEST 麻雀覇王バトルロイヤル
+  name-sort: まいこみBEST まーじゃんはおうばとるろいやる
+  name-en: "Mahjong Haoh - Battle Royal [Mycom Best]"
   region: "NTSC-J"
 SLPM-62773:
-  name: "Slotter Up Mania 9"
+  name: スロッターUPマニア9　アツ沖だぜ！めんそーれ-30＆めんそーれ2-30
+  name-sort: すろったーUPまにあ9　あつおきだぜ！めんそーれ-30＆めんそーれ2-30
+  name-en: "Slotter Up Mania 9"
   region: "NTSC-J"
 SLPM-62774:
-  name: "Jissen Pachi-Slot Hisshouhou! Selection - Salaryman Kintarou - Slotter Kintarou - Ore no Sora"
+  name: 実戦パチスロ必勝法！ Selection 〜サラリーマン金太郎・スロッター金太郎・俺の空〜
+  name-sort: じっせんぱちすろひっしょうほう！ Selection 〜さらりーまんきんたろう・すろったーきんたろう・おれのそら〜
+  name-en: "Jissen Pachi-Slot Hisshouhou! Selection - Salaryman Kintarou - Slotter Kintarou - Ore no Sora"
   region: "NTSC-J"
 SLPM-62775:
-  name: "Sega Ages 2500 Vol.32 - Phantasy Star Complete Collection"
+  name: SEGA AGES 2500シリーズ Vol.32 ファンタシースター コンプリートコレクション
+  name-sort: SEGA AGES 2500しりーず Vol.32 ふぁんたしーすたー こんぷりーとこれくしょん
+  name-en: "Sega Ages 2500 Vol.32 - Phantasy Star Complete Collection"
   region: "NTSC-J"
 SLPM-62777:
   name: "Harukaze P. S. - Plus Situation"
   region: "NTSC-J"
 SLPM-62778:
-  name: "Slotter Up Mania 10 - Pioneer Special 3"
+  name: スロッターUPマニア10 パイオニアスペシャル3
+  name-sort: すろったーUPまにあ10 ぱいおにあすぺしゃる3
+  name-en: "Slotter Up Mania 10 - Pioneer Special 3"
   region: "NTSC-J"
 SLPM-62779:
-  name: "Puyo Puyo! [Special Price]"
+  name: ぷよぷよ！ スペシャルプライス
+  name-sort: ぷよぷよ！ すぺしゃるぷらいす
+  name-en: "Puyo Puyo! [Special Price]"
   region: "NTSC-J"
 SLPM-62780:
-  name: "Fantasy Zone Complete Collection"
+  name: SEGA AGES 2500シリーズ Vol.33 ファンタジーゾーンコンプリートコレクション
+  name-sort: SEGA AGES 2500しりーず Vol.33 ふぁんたじーぞーんこんぷりーとこれくしょん
+  name-en: "Fantasy Zone Complete Collection"
   region: "NTSC-J"
   compat: 5
 SLPM-62781:
@@ -32441,11 +34128,15 @@ SLPM-64552:
   name: "Silent Scope 3"
   region: "NTSC-K"
 SLPM-65001:
-  name: "Kessen"
+  name: 決戦
+  name-sort: けっせん
+  name-en: "Kessen"
   region: "NTSC-J"
   compat: 5
 SLPM-65002:
-  name: "0 Story [Disc 1 of 2]"
+  name: ラブストーリー
+  name-sort: らぶすとーりー
+  name-en: "0 Story [Disc 1 of 2]"
   region: "NTSC-J"
   compat: 5
   gameFixes:
@@ -32459,25 +34150,37 @@ SLPM-65003:
   memcardFilters:
     - "SLPM-65002"
 SLPM-65004:
-  name: "Reiselied - Ephemeral Fantasia"
+  name: ライゼリート 〜エフェメラルファンタジア〜
+  name-sort: らいぜりーと 〜えふぇめらるふぁんたじあ〜
+  name-en: "Reiselied - Ephemeral Fantasia"
   region: "NTSC-J"
 SLPM-65005:
-  name: "I am the Coach"
+  name: オレが監督だ！ 〜激闘ペナントレース〜
+  name-sort: おれがかんとくだ！ 〜げきとうぺなんとれーす〜
+  name-en: "I am the Coach"
   region: "NTSC-J"
 SLPM-65006:
-  name: "Beatmania IIDX 3rd Style"
+  name: beatmania IIDX 3rd style
+  name-sort: beatmania IIDX 3rd style
+  name-en: "Beatmania IIDX 3rd style"
   region: "NTSC-J"
 SLPM-65007:
   name: "Roadsters Trophy 2000"
   region: "NTSC-J"
 SLPM-65008:
-  name: "7 Blades"
+  name: 7 BLADES
+  name-sort: 7 BLADES
+  name-en: "7 Blades"
   region: "NTSC-J"
 SLPM-65009:
-  name: "ESPN X-Games Snowboarding"
+  name: ESPN XGames Snowboarding
+  name-sort: ESPN XGames Snowboarding
+  name-en: "ESPN X-Games Snowboarding"
   region: "NTSC-J"
 SLPM-65010:
-  name: "Onimusha"
+  name: 鬼武者
+  name-sort: おにむしゃ
+  name-en: "Onimusha"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
@@ -32485,11 +34188,15 @@ SLPM-65010:
   gameFixes:
     - SoftwareRendererFMVHack # Fixes FMVs.
 SLPM-65011:
-  name: "GUITAR FREAKS 3rd MIX & drummania 2nd MIX"
+  name: ギターフリークス3rd MIX&ドラムマニア2nd MIX
+  name-sort: ぎたーふりーくす3rd MIX&どらむまにあ2nd MIX
+  name-en: "GUITAR FREAKS 3rd MIX & drummania 2nd MIX"
   region: "NTSC-J"
   compat: 5
 SLPM-65012:
-  name: "Gitaroo Man"
+  name: ギタルマン
+  name-sort: ぎたるまん
+  name-en: "Gitaroo Man"
   region: "NTSC-J"
   compat: 5
   roundModes:
@@ -32504,17 +34211,23 @@ SLPM-65012:
         // fix stage 4 flashing triangles
         patch=0,EE,00104140,word,00000000
 SLPM-65013:
-  name: "Shadow of Memories"
+  name: シャドウ オブ メモリーズ
+  name-sort: しゃどう おぶ めもりーず
+  name-en: "Shadow of Memories"
   region: "NTSC-J"
   compat: 5
 SLPM-65014:
-  name: "Bouken Jidai Katsugeki - Goemon"
+  name: 冒険時代活劇 ゴエモン
+  name-sort: ぼうけんじだいかつげき ごえもん
+  name-en: "Bouken Jidai Katsugeki - Goemon"
   region: "NTSC-J"
   compat: 5
   gameFixes:
     - GoemonTlbHack
 SLPM-65015:
-  name: "Kessen 2"
+  name: 決戦II
+  name-sort: けっせんII
+  name-en: "Kessen 2"
   region: "NTSC-J"
   patches:
     7C012435:
@@ -32526,30 +34239,44 @@ SLPM-65015:
         patch=0,EE,0016ae98,word,30848000
         patch=0,EE,0016ae9c,word,4BE72B3C
 SLPM-65016:
-  name: "Love Songs [Limited Edition]"
+  name: Love Songs アイドルがクラスメ〜ト 限定版
+  name-sort: Love Songs あいどるがくらすめ〜と げんていばん
+  name-en: "Love Songs [Limited Edition]"
   region: "NTSC-J"
 SLPM-65017:
-  name: "Love Songs - Idol is my Classmate"
+  name: Love Songs アイドルがクラスメ〜ト
+  name-sort: Love Songs あいどるがくらすめ〜と
+  name-en: "Love Songs - Idol is my Classmate"
   region: "NTSC-J"
 SLPM-65018:
-  name: "Z.O.E. - Zone of the Enders [Limited Edition]"
+  name: Z.O.E プレミアムパッケージ
+  name-sort: Z.O.E ぷれみあむぱっけーじ
+  name-en: "Z.O.E. - Zone of the Enders [Limited Edition]"
   region: "NTSC-J"
   gsHWFixes:
     gpuPaletteConversion: 2 # Improves FPS and reduces HC size.
 SLPM-65019:
-  name: "Z.O.E. - Zone of the Enders"
+  name: Z.O.E
+  name-sort: Z.O.E
+  name-en: "Z.O.E. - Zone of the Enders"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
     gpuPaletteConversion: 2 # Improves FPS and reduces HC size.
 SLPM-65020:
-  name: "ParaParaParadise"
+  name: パラパラパラダイス
+  name-sort: ぱらぱらぱらだいす
+  name-en: "ParaParaParadise"
   region: "NTSC-J"
 SLPM-65021:
-  name: "Super Galdelic Hour"
+  name: スーパーギャルデリックアワー
+  name-sort: すーぱーぎゃるでりっくあわー
+  name-en: "Super Galdelic Hour"
   region: "NTSC-J"
 SLPM-65022:
-  name: "BioHazard - Code Veronica - Perfect Version"
+  name: バイオハザード コード:ベロニカ 完全版
+  name-sort: ばいおはざーど こーど:べろにか かんぜんばん
+  name-en: "BioHazard - Code Veronica - Perfect Version"
   region: "NTSC-J"
   compat: 5
 SLPM-65023:
@@ -32558,13 +34285,17 @@ SLPM-65023:
   gsHWFixes:
     disablePartialInvalidation: 1 # Fixes corrupt textures.
 SLPM-65024:
-  name: "BioHazard - 5th Anniversary Package - Nightmare Returns [Disc 1 of 2]"
+  name: バイオハザード コード:ベロニカ 完全版
+  name-sort: ばいおはざーど こーど:べろにか かんぜんばん
+  name-en: "BioHazard - 5th Anniversary Package - Nightmare Returns [Disc 1 of 2]"
   region: "NTSC-J"
 SLPM-65025:
   name: "BioHazard - 5th Anniversary Package - Nightmare Returns [Disc 2 of 2]"
   region: "NTSC-J"
 SLPM-65026:
-  name: "Beatmania IIDX 4th Style - New Songs Collection"
+  name: beatmania IIDX 4th style -new songs collection-
+  name-sort: beatmania IIDX 4th style -new songs collection-
+  name-en: "Beatmania IIDX 4th style -new songs collection-"
   region: "NTSC-J"
 SLPM-65027:
   name: "Anime Eikaiwa - 15 Shounen Hyouryuuki - Hitomi no Naka no Shounen"
@@ -32591,18 +34322,24 @@ SLPM-65031:
         patch=0,EE,0016ae98,word,30848000
         patch=0,EE,0016ae9c,word,4BE72B3C
 SLPM-65032:
-  name: "Tokyo Bus Guide - Annai"
+  name: 東京バス案内 今日から君も運転手
+  name-sort: とうきょうばすあんない きょうからきみもうんてんしゅ
+  name-en: "Tokyo Bus Guide - Annai"
   region: "NTSC-J"
   compat: 5
 SLPM-65033:
-  name: "Kikou Heidan J-Phoenix"
+  name: 機甲兵団 J-PHOENIX
+  name-sort: きこうへいだん J-PHOENIX
+  name-en: "Kikou Heidan J-Phoenix"
   region: "NTSC-J"
   memcardFilters:
     - "SLPS-20075"
     - "SLPM-65033"
     - "SLPM-65117"
 SLPM-65034:
-  name: "Sangokushi North Winds"
+  name: 北方謙三 三国志
+  name-sort: きたがたけんぞう さんごくし
+  name-en: "Sangokushi North Winds"
   region: "NTSC-J"
 SLPM-65035:
   name: "Kitakata Kenzou Sangokushi (Disc 2)"
@@ -32611,16 +34348,22 @@ SLPM-65037:
   name: "Angelique Trois - Aizouban [Shokai Gentei Package]"
   region: "NTSC-J"
 SLPM-65038:
-  name: "Devil May Cry"
+  name: Devil May Cry
+  name-sort: Devil May Cry
+  name-en: "Devil May Cry"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
     disablePartialInvalidation: 1 # Fixes corrupt textures.
 SLPM-65039:
-  name: "Densha de Go! Shinkansen"
+  name: 電車でGO!新幹線 山陽新幹線編
+  name-sort: でんしゃでGO!しんかんせん さんようしんかんせんへん
+  name-en: "Densha de Go! Shinkansen"
   region: "NTSC-J"
 SLPM-65040:
-  name: "Fear, The [Disc 1 of 4]"
+  name: ザ・フィアー
+  name-sort: ざ・ふぃあー
+  name-en: "Fear, The [Disc 1 of 4]"
   region: "NTSC-J"
   memcardFilters:
     - "SLPM-65040"
@@ -32653,74 +34396,108 @@ SLPM-65043:
     - "SLPM-65042"
     - "SLPM-65043"
 SLPM-65044:
-  name: "Aizouban Angelique Trois [Koei The Best]"
+  name: 愛蔵版 アンジェリークトロワ
+  name-sort: あいぞうばん あんじぇりーくとろわ
+  name-en: "Aizouban Angelique Trois [Koei The Best]"
   region: "NTSC-J"
 SLPM-65046:
   name: "Gofungo no Sekai"
   region: "NTSC-J"
 SLPM-65047:
-  name: "Capcom vs. SNK 2"
+  name: CAPCOM VS. SNK 2 MILLIONAIRE FIGHTING 2001
+  name-sort: CAPCOM VS. SNK 2 MILLIONAIRE FIGHTING 2001
+  name-en: "Capcom vs. SNK 2"
   region: "NTSC-J"
   compat: 5
 SLPM-65048:
   name: "Kinniku Banzuke - Muscle Wars 21"
   region: "NTSC-J"
 SLPM-65049:
-  name: "Beatmania IIDX 5th Style - New Songs Collection"
+  name: beatmania IIDX 5th style -new songs collection-
+  name-sort: beatmania IIDX 5th style -new songs collection-
+  name-en: "Beatmania IIDX 5th style -new songs collection-"
   region: "NTSC-J"
 SLPM-65050:
-  name: "Yu-Gi-Oh! Shin Duel Monsters 2"
+  name: 遊戯王 真デュエルモンスターズII 継承されし記憶
+  name-sort: ゆうぎおう までゅえるもんすたーずII けいしょうされしきおく
+  name-en: "Yu-Gi-Oh! Shin Duel Monsters 2"
   region: "NTSC-J"
   roundModes:
     eeRoundMode: 2 # Partially fixes battle animation.
   clampModes:
     eeClampMode: 2 # Partially fixes battle animation.
 SLPM-65051:
-  name: "Silent Hill 2"
+  name: サイレントヒル2
+  name-sort: さいれんとひる2
+  name-en: "Silent Hill 2"
   region: "NTSC-J"
   compat: 5
   speedHacks:
     instantVU1: 0 # Fixes hang on FMV's when CDVD timing is accurate.
     mtvu: 0
 SLPM-65052:
-  name: "GUITAR FREAKS 4thMIX & drummania 3rdMIX"
+  name: ギタドラ!ギターフリークス4thMIX&ドラムマニア3rdMIX
+  name-sort: ぎたどら!ぎたーふりーくす4thMIX&どらむまにあ3rdMIX
+  name-en: "GUITAR FREAKS 4thMIX & drummania 3rdMIX"
   region: "NTSC-J"
   compat: 5
 SLPM-65053:
-  name: "Shin Sangoku Musou 2"
+  name: 真・三國無双2
+  name-sort: しん・さんごくむそう2
+  name-en: "Shin Sangoku Musou 2"
   region: "NTSC-J"
   compat: 5
 SLPM-65054:
-  name: "Abarenbou Princess"
+  name: 暴れん坊プリンセス
+  name-sort: あばれんぼうぷりんせす
+  name-en: "Abarenbou Princess"
   region: "NTSC-J"
   compat: 5
 SLPM-65056:
-  name: "Orega Kantoku da Vol.2 - Getitou Pennant Race"
+  name: オレが監督だ!Volume.2 〜激闘ペナントレース〜
+  name-sort: おれがかんとくだ!Volume.2 〜げきとうぺなんとれーす〜
+  name-en: "Orega Kantoku da Vol.2 - Getitou Pennant Race"
   region: "NTSC-J"
 SLPM-65057:
-  name: "7 Blades"
+  name: 7 BLADES コナミ ザ・ベスト
+  name-sort: 7 BLADES こなみ ざ・べすと
+  name-en: "7 Blades"
   region: "NTSC-J"
 SLPM-65059:
-  name: "BioHazard Gun Survivor 2 - CODE - Veronica [with Guncon]"
+  name: ガンサバイバー2 バイオハザード コード:ベロニカ WITH ガンコン2
+  name-sort: がんさばいばー2 ばいおはざーど こーど:べろにか WITH がんこん2
+  name-en: "BioHazard Gun Survivor 2 - CODE - Veronica [with Guncon]"
   region: "NTSC-J"
   compat: 5
 SLPM-65060:
-  name: "BioHazard Gun Survivor 2 - CODE - Veronica"
+  name: ガンサバイバー2 バイオハザード コード:ベロニカ
+  name-sort: がんさばいばー2 ばいおはざーど こーど:べろにか
+  name-en: "BioHazard Gun Survivor 2 - CODE - Veronica"
   region: "NTSC-J"
 SLPM-65061:
-  name: "Adventure of Tokyo Disney Sea - Ushinawareta Houseki no Himitsu"
+  name: アドベンチャー オブ 東京ディズニーシー 〜失われた宝石の秘密
+  name-sort: あどべんちゃー おぶ とうきょうでぃずにーしー 〜うしなわれたほうせきのひみつ
+  name-en: "Adventure of Tokyo Disney Sea - Ushinawareta Houseki no Himitsu"
   region: "NTSC-J"
 SLPM-65065:
-  name: "Sorcerous Stabber Orphen [Kadokawa The Best]"
+  name: 魔術師オーフェン KADOKAWA THE Best
+  name-sort: まじゅつしおーふぇん KADOKAWA THE Best
+  name-en: "Sorcerous Stabber Orphen [Kadokawa The Best]"
   region: "NTSC-J"
 SLPM-65066:
-  name: "Bouken Jidai Katsugeki Goemon"
+  name: 冒険時代活劇 ゴエモン コナミ ザ・ベスト
+  name-sort: ぼうけんじだいかつげき ごえもん こなみ ざ・べすと
+  name-en: "Bouken Jidai Katsugeki Goemon"
   region: "NTSC-J"
 SLPM-65070:
-  name: "Shadow of Memories"
+  name: シャドウ オブ メモリーズ コナミ ザ・ベスト
+  name-sort: しゃどう おぶ めもりーず こなみ ざ・べすと
+  name-en: "Shadow of Memories"
   region: "NTSC-J"
 SLPM-65071:
-  name: "Zero 4 Champ Series - Drift Champ"
+  name: ゼロヨンチャンプシリーズ ドリフトチャンプ
+  name-sort: ぜろよんちゃんぷしりーず どりふとちゃんぷ
+  name-en: "Zero 4 Champ Series - Drift Champ"
   region: "NTSC-J"
   patches:
     8449FFE1:
@@ -32730,10 +34507,14 @@ SLPM-65071:
         patch=1,EE,002a140c,word,00000000
         patch=1,EE,002a120c,word,00000000
 SLPM-65072:
-  name: "ESPN Winter X-Games Snowboarding 2002"
+  name: ESPN winter Xgames Snowboarding 2002
+  name-sort: ESPN winter Xgames Snowboarding 2002
+  name-en: "ESPN Winter X-Games Snowboarding 2002"
   region: "NTSC-J"
 SLPM-65073:
-  name: "Genso Suikoden III"
+  name: 幻想水滸伝III（初回生産分：特殊仕様）
+  name-sort: げんそうすいこでんIII（しょかいせいさんぶん：とくしゅしよう）
+  name-en: "Genso Suikoden III"
   region: "NTSC-J"
   memcardFilters: # This looks like a mess because it includes all serials for Suikoden 3, Suikoden 2, Suikogaiden 1, and Suikogaiden 2. A lot of these probably aren't actually required but it's not really hurting anything to have them here.
     - "SLPM-65073"
@@ -32750,7 +34531,9 @@ SLPM-65073:
     - "SLPM-86953"
     - "SLPM-87262"
 SLPM-65074:
-  name: "Genso Suikoden III"
+  name: 幻想水滸伝III
+  name-sort: げんそうすいこでんIII
+  name-en: "Genso Suikoden III"
   region: "NTSC-J"
   memcardFilters:
     - "SLPM-65073"
@@ -32767,13 +34550,19 @@ SLPM-65074:
     - "SLPM-86953"
     - "SLPM-87262"
 SLPM-65075:
-  name: "K-1 World Grand Prix 2001"
+  name: K-1 WORLD GP 2001
+  name-sort: K-1 WORLD GP 2001
+  name-en: "K-1 World Grand Prix 2001"
   region: "NTSC-J"
 SLPM-65076:
-  name: "Gundam - Federation vs. Zeon DX"
+  name: 機動戦士ガンダム 連邦vs.ジオン DX
+  name-sort: きどうせんしがんだむ れんぽうvs.じおん DX
+  name-en: "Gundam - Federation vs. Zeon DX"
   region: "NTSC-J"
 SLPM-65077:
-  name: "Metal Gear Solid 2 - Sons of Liberty [Premium Package]"
+  name: METAL GEAR SOLID 2 SONS OF LIBERTY PREMIUM PACKAGE
+  name-sort: METAL GEAR SOLID 2 SONS OF LIBERTY PREMIUM PACKAGE
+  name-en: "Metal Gear Solid 2 - Sons of Liberty [Premium Package]"
   region: "NTSC-J"
   gameFixes:
     - InstantDMAHack # Fixes broken half-bottom artifacts.
@@ -32783,7 +34572,9 @@ SLPM-65077:
     - "SLPM-65078"
     - "SLPM-65077"
 SLPM-65078:
-  name: "Metal Gear Solid 2 - Sons of Liberty"
+  name: METAL GEAR SOLID 2 SONS OF LIBERTY
+  name-sort: METAL GEAR SOLID 2 SONS OF LIBERTY
+  name-en: "Metal Gear Solid 2 - Sons of Liberty"
   region: "NTSC-J"
   gameFixes:
     - InstantDMAHack # Fixes broken half-bottom artifacts.
@@ -32793,7 +34584,9 @@ SLPM-65078:
     - "SLPM-65078"
     - "SLPM-65077"
 SLPM-65080:
-  name: "Tokimeki Memorial 3"
+  name: ときめきメモリアル3 〜約束のあの場所で〜
+  name-sort: ときめきめもりある3 〜やくそくのあのばしょで〜
+  name-en: "Tokimeki Memorial 3"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
@@ -32802,16 +34595,22 @@ SLPM-65081:
   name: "Grandia II"
   region: "NTSC-J"
 SLPM-65082:
-  name: "Grandia Xtreme [Limited Edition]"
+  name: グランディア エクストリーム リミテッドボックス
+  name-sort: ぐらんでぃあ えくすとりーむ りみてっどぼっくす
+  name-en: "Grandia Xtreme [Limited Edition]"
   region: "NTSC-J"
 SLPM-65083:
-  name: "Houshin Engi 2"
+  name: 封神演義2
+  name-sort: ほうしんえんぎ2
+  name-en: "Houshin Engi 2"
   region: "NTSC-J"
 SLPM-65085:
   name: "Alone in the Dark - The New Nightmare"
   region: "NTSC-J"
 SLPM-65086:
-  name: "Visual Mix - Ayumi Hamasaki Dome Tour 2001 [Disc 1 of 2]"
+  name: “A” VISUAL MIX
+  name-sort: “A” VISUAL MIX
+  name-en: "Visual Mix - Ayumi Hamasaki Dome Tour 2001 [Disc 1 of 2]"
   region: "NTSC-J"
   compat: 5
   memcardFilters:
@@ -32829,49 +34628,71 @@ SLPM-65087:
     - "SLPM-65086"
     - "SLPM-65087"
 SLPM-65089:
-  name: "Grandia Xtreme"
+  name: グランディア エクストリーム
+  name-sort: ぐらんでぃあ えくすとりーむ
+  name-en: "Grandia Xtreme"
   region: "NTSC-J"
 SLPM-65090:
-  name: "Spy Hunter"
+  name: SPY HUNTER
+  name-sort: SPY HUNTER
+  name-en: "Spy Hunter"
   region: "NTSC-J"
   gameFixes:
     - VIF1StallHack # Fixes loading hang.
 SLPM-65091:
-  name: "Harukanaru Toki no Naka de 2 [Limited Edition]"
+  name: 遙かなる時空の中で2 プレミアムBOX
+  name-sort: はるかなるときのなかで2 ぷれみあむBOX
+  name-en: "Harukanaru Toki no Naka de 2 [Limited Edition]"
   region: "NTSC-J"
 SLPM-65092:
-  name: "Harukanaru Toki no Naka de 2"
+  name: 遙かなる時空の中で2
+  name-sort: はるかなるときのなかで2
+  name-en: "Harukanaru Toki no Naka de 2"
   region: "NTSC-J"
 SLPM-65093:
-  name: "Sangokushi Senki"
+  name: 三國志戦記
+  name-sort: さんごくしせんき
+  name-en: "Sangokushi Senki"
   region: "NTSC-J"
 SLPM-65094:
   name: "KEYBOARDMANIA II 2ndMIX & 3rdMIX"
   region: "NTSC-J"
 SLPM-65095:
-  name: "Space Channel 5"
+  name: スペースチャンネル5
+  name-sort: すぺーすちゃんねる5
+  name-en: "Space Channel 5"
   region: "NTSC-J"
   compat: 5
 SLPM-65096:
-  name: "Space Channel 5 - Part 2"
+  name: スペースチャンネル5 パート2
+  name-sort: すぺーすちゃんねる5 ぱーと2
+  name-en: "Space Channel 5 - Part 2"
   region: "NTSC-J"
   compat: 5
 SLPM-65097:
-  name: "Galacta Meisaku Gekijou - Rakugaki Oukouku"
+  name: ガラクタ名作劇場 ラクガキ王国
+  name-sort: がらくためいさくげきじょう らくがきおうこく
+  name-en: "Galacta Meisaku Gekijou - Rakugaki Oukouku"
   region: "NTSC-J"
   compat: 5
 SLPM-65098:
-  name: "Silent Hill 2 - Saigo no Uta"
+  name: サイレントヒル2 最期の詩
+  name-sort: さいれんとひる2 さいごのし
+  name-en: "Silent Hill 2 - Saigo no Uta"
   region: "NTSC-J"
   compat: 5
   speedHacks:
     instantVU1: 0 # Fixes hang on FMV's when CDVD timing is accurate.
     mtvu: 0
 SLPM-65100:
-  name: "Onimusha 2"
+  name: 鬼武者2(初回生産限定版)
+  name-sort: おにむしゃ2(しょかいせいさんげんていばん)
+  name-en: "Onimusha 2"
   region: "NTSC-J"
 SLPM-65101:
-  name: "Onimusha 2"
+  name: 鬼武者2
+  name-sort: おにむしゃ2
+  name-en: "Onimusha 2"
   region: "NTSC-J"
   memcardFilters:
     - "SLPM-65100"
@@ -32879,25 +34700,39 @@ SLPM-65104:
   name: "SSX Tricky"
   region: "NTSC-C"
 SLPM-65105:
-  name: "Shin Combat Choro Q"
+  name: 新コンバットチョロQ
+  name-sort: しんこんばっとちょろQ
+  name-en: "Shin Combat Choro Q"
   region: "NTSC-J"
 SLPM-65107:
-  name: "Simple 2000 Series Ultimate Vol. 2 - Edit Racing"
+  name: SIMPLE2000シリーズ アルティメットVol.2 エディット・レーシング
+  name-sort: SIMPLE2000しりーず あるてぃめっとVol.2 えでぃっと・れーしんぐ
+  name-en: "Simple 2000 Series Ultimate Vol. 2 - Edit Racing"
   region: "NTSC-J"
 SLPM-65108:
-  name: "Jet de Go! 2"
+  name: ジェットでGO!2
+  name-sort: じぇっとでGO!2
+  name-en: "Jet de Go! 2"
   region: "NTSC-J"
 SLPM-65109:
-  name: "J-League Sakatsuku 2002"
+  name: サカつく2002 J.LEAGUE プロサッカークラブをつくろう!
+  name-sort: さかつく2002 J.LEAGUE ぷろさっかーくらぶをつくろう!
+  name-en: "J-League Sakatsuku 2002"
   region: "NTSC-J"
 SLPM-65110:
-  name: "Roommania #203"
+  name: ROOMMANIA#203
+  name-sort: ROOMMANIA#203
+  name-en: "Roommania #203"
   region: "NTSC-J"
 SLPM-65111:
-  name: "NFL 2K2"
+  name: NFL2K2
+  name-sort: NFL2K2
+  name-en: "NFL 2K2"
   region: "NTSC-J"
 SLPM-65113:
-  name: "Splashdown"
+  name: Splashdown
+  name-sort: Splashdown
+  name-en: "Splashdown"
   region: "NTSC-J"
 SLPM-65115:
   name: "Final Fantasy X International"
@@ -32907,30 +34742,44 @@ SLPM-65115:
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
 SLPM-65116:
-  name: "Lilie no Atelier Plus - Salburg no Renkinjutsushi 3"
+  name: リリーのアトリエ プラス 〜ザールブルグの錬金術士3〜
+  name-sort: りりーのあとりえ ぷらす 〜ざーるぶるぐのれんきんじゅつし3〜
+  name-en: "Lilie no Atelier Plus - Salburg no Renkinjutsushi 3"
   region: "NTSC-J"
 SLPM-65117:
-  name: "Kikou Heidan J-Phoenix [Takara The Best]"
+  name: ザ・ベスト・タカラモノ 機甲兵団 J-PHOENIX
+  name-sort: ざ・べすと・たからもの きこうへいだん J-PHOENIX
+  name-en: "Kikou Heidan J-Phoenix [Takara The Best]"
   region: "NTSC-J"
   memcardFilters:
     - "SLPS-20075"
     - "SLPM-65033"
     - "SLPM-65117"
 SLPM-65118:
-  name: "Tokimeki Memorial 2 - Video Clips"
+  name: ときめきメモリアル2 ミュージックビデオクリップ サーカスで逢いましょう
+  name-sort: ときめきめもりある2 みゅーじっくびでおくりっぷ さーかすであいましょう
+  name-en: "Tokimeki Memorial 2 - Video Clips"
   region: "NTSC-J"
 SLPM-65119:
-  name: "Shine - Spinning World"
+  name: SHINE 〜言葉を紡いで〜 限定版
+  name-sort: SHINE 〜ことばをつむいで〜 げんていばん
+  name-en: "Shine - Spinning World"
   region: "NTSC-J"
 SLPM-65120:
-  name: "Shine - Spinning World"
+  name: SHINE 〜言葉を紡いで〜
+  name-sort: SHINE 〜ことばをつむいで〜
+  name-en: "Shine - Spinning World"
   region: "NTSC-J"
 SLPM-65121:
-  name: "Switch"
+  name: SWITCH
+  name-sort: SWITCH
+  name-en: "Switch"
   region: "NTSC-J"
   compat: 5
 SLPM-65122:
-  name: "Kikou Heidan J-Phoenix Burst Tactics [Limited Edition]"
+  name: 機甲兵団 J-PHOENIX BURST TACTICS LIMITED EDITION
+  name-sort: きこうへいだん J-PHOENIX BURST TACTICS LIMITED EDITION
+  name-en: "Kikou Heidan J-Phoenix Burst Tactics [Limited Edition]"
   region: "NTSC-J"
   memcardFilters:
     - "SLPS-20075"
@@ -32939,7 +34788,9 @@ SLPM-65122:
     - "SLPM-65122"
     - "SLPM-65123"
 SLPM-65123:
-  name: "Kikou Heidan J-Phoenix Burst Tactics"
+  name: 機甲兵団 J-PHOENIX BURST TACTICS
+  name-sort: きこうへいだん J-PHOENIX BURST TACTICS
+  name-en: "Kikou Heidan J-Phoenix Burst Tactics"
   region: "NTSC-J"
   memcardFilters:
     - "SLPS-20075"
@@ -32948,57 +34799,89 @@ SLPM-65123:
     - "SLPM-65122"
     - "SLPM-65123"
 SLPM-65124:
-  name: "Auto Modellista"
+  name: auto modellista
+  name-sort: auto modellista
+  name-en: "Auto Modellista"
   region: "NTSC-J"
 SLPM-65125:
-  name: "NBA 2K3"
+  name: 夏色の砂時計（初回限定生産版）
+  name-sort: なついろのすなどけい（しょかいげんていせいさんばん）
+  name-en: "NBA 2K3"
   region: "NTSC-J"
 SLPM-65126:
-  name: "Tokimeki Memorial Girl's Side [Limited Edition]"
+  name: ときめきメモリアル Girl’s Side 初回生産版
+  name-sort: ときめきめもりある Girl’s Side しょかいせいさんばん
+  name-en: "Tokimeki Memorial Girl's Side [Limited Edition]"
   region: "NTSC-J"
 SLPM-65130:
-  name: "Dramatic Soccer Game - Becoming a National Team Member"
+  name: ドラマティックサッカーゲーム 日本代表選手になろう!
+  name-sort: どらまてぃっくさっかーげーむ にほんだいひょうせんしゅになろう!
+  name-en: "Dramatic Soccer Game - Becoming a National Team Member"
   region: "NTSC-J"
 SLPM-65131:
-  name: "Judie no Atelier - Gramnad no Renkinjutsushi"
+  name: ユーディーのアトリエ 〜グラムナートの錬金術士〜
+  name-sort: ゆーでぃーのあとりえ 〜ぐらむなーとのれんきんじゅつし〜
+  name-en: "Judie no Atelier - Gramnad no Renkinjutsushi"
   region: "NTSC-J"
 SLPM-65132:
-  name: "Warriors of Might and Magic"
+  name: ウォリアーズ オブ マイト アンド マジック
+  name-sort: うぉりあーず おぶ まいと あんど まじっく
+  name-en: "Warriors of Might and Magic"
   region: "NTSC-J"
 SLPM-65133:
-  name: "Konohana 2"
+  name: 此花2 〜届かないレクイエム〜
+  name-sort: このはな2 〜とどかないれくいえむ〜
+  name-en: "Konohana 2"
   region: "NTSC-J"
 SLPM-65134:
-  name: "Red Card"
+  name: RED CARD レッド・カード
+  name-sort: RED CARD れっど・かーど
+  name-en: "Red Card"
   region: "NTSC-J"
 SLPM-65135:
-  name: "NBA 2K2"
+  name: NBA2K2
+  name-sort: NBA2K2
+  name-en: "NBA 2K2"
   region: "NTSC-J"
 SLPM-65136:
   name: "Natsu-iro no Sunadokei"
   region: "NTSC-J"
 SLPM-65137:
-  name: "All-Star Baseball 2003"
+  name: All-Star Baseball 2003
+  name-sort: All-Star Baseball 2003
+  name-en: "All-Star Baseball 2003"
   region: "NTSC-J"
 SLPM-65139:
-  name: "Gun Survivor 3 - Dino Crisis"
+  name: GUN SURVIVOR3 DINO CRISIS
+  name-sort: GUN SURVIVOR3 DINO CRISIS
+  name-en: "Gun Survivor 3 - Dino Crisis"
   region: "NTSC-J"
   compat: 5
 SLPM-65140:
-  name: "Jojo no Kimyou na Bouken - Ougon no Kaze"
+  name: ジョジョの奇妙な冒険 黄金の旋風
+  name-sort: じょじょのきみょうなぼうけん おうごんのせんぷう
+  name-en: "Jojo no Kimyou na Bouken - Ougon no Kaze"
   region: "NTSC-J"
 SLPM-65141:
-  name: "Tsuzuse Gareijiri"
+  name: 続せがれいじり 変珍たませがれ
+  name-sort: ぞくせがれいじり へんちんたませがれ
+  name-en: "Tsuzuse Gareijiri"
   region: "NTSC-J"
   compat: 5
 SLPM-65142:
-  name: "Anime Super Remix, The - Kyojin no Hoshi"
+  name: ジ・アニメスーパーリミックス 巨人の星
+  name-sort: じ・あにめすーぱーりみっくす きょじんのほし
+  name-en: "Anime Super Remix, The - Kyojin no Hoshi"
   region: "NTSC-J"
 SLPM-65143:
-  name: "Anime Super Remix, The - Ashita no Joe 2"
+  name: ジ・アニメスーパーリミックス あしたのジョー2
+  name-sort: じ・あにめすーぱーりみっくす あしたのじょー2
+  name-en: "Anime Super Remix, The - Ashita no Joe 2"
   region: "NTSC-J"
 SLPM-65144:
-  name: "Maken Shao"
+  name: 魔剣爻 アトラス・ベストコレクション
+  name-sort: まけんしゃお アトラス・ベストコレクション
+  name-en: "Maken Shao"
   region: "NTSC-J"
   speedHacks:
     mvuFlag: 0
@@ -33009,34 +34892,50 @@ SLPM-65146:
   name: "Shin Sangoku Musou 2"
   region: "NTSC-J"
 SLPM-65148:
-  name: "Densha de Go! Ryojou-hen"
+  name: 電車でGO!〜旅情編〜
+  name-sort: でんしゃでGO!〜りょじょうへん〜
+  name-en: "Densha de Go! Ryojou-hen"
   region: "NTSC-J"
 SLPM-65149:
   name: "Choro Q HG"
   region: "NTSC-J"
 SLPM-65150:
-  name: "Aero Dancing 4 - New Generation"
+  name: aero dancing 4 new generation
+  name-sort: aero dancing 4 new generation
+  name-en: "Aero Dancing 4 - New Generation"
   region: "NTSC-J"
 SLPM-65151:
   name: "Akudaikan"
   region: "NTSC-J"
 SLPM-65152:
-  name: "GunGrave [Limited Edition]"
+  name: GUNGRAVE 特別限定版
+  name-sort: GUNGRAVE とくべつげんていばん
+  name-en: "GunGrave [Limited Edition]"
   region: "NTSC-J"
 SLPM-65153:
-  name: "GunGrave"
+  name: GUNGRAVE
+  name-sort: GUNGRAVE
+  name-en: "GunGrave"
   region: "NTSC-J"
 SLPM-65154:
-  name: "Rumbling Hearts"
+  name: 君が望む永遠　～Rumbling hearts～ （初回限定版）
+  name-sort: きみがのぞむえいえん　～Rumbling hearts～ （しょかいげんていばん）
+  name-en: "Rumbling Hearts"
   region: "NTSC-J"
 SLPM-65155:
-  name: "Rumbling Hearts"
+  name: 君が望む永遠　～Rumbling hearts～
+  name-sort: きみがのぞむえいえん　～Rumbling hearts～
+  name-en: "Rumbling Hearts"
   region: "NTSC-J"
 SLPM-65156:
-  name: "Beatmania IIDX 6th Style - New Songs Collection"
+  name: beatmania IIDX 6th style -new songs collection-
+  name-sort: beatmania IIDX 6th style -new songs collection-
+  name-en: "Beatmania IIDX 6th style -new songs collection-"
   region: "NTSC-J"
 SLPM-65158:
-  name: "Riding Spirits"
+  name: RS〜ライディング スピリッツ〜
+  name-sort: RS〜らいでぃんぐ すぴりっつ〜
+  name-en: "Riding Spirits"
   region: "NTSC-J"
 SLPM-65159:
   name: "Angelique Trois - Aizouban"
@@ -33063,26 +34962,36 @@ SLPM-65163:
         patch=0,EE,00276170,word,48438800
         patch=0,EE,0027617c,word,4BE521AC
 SLPM-65164:
-  name: "Project Minerva [Limited Edition]"
+  name: PROJECT MINERVA 限定版
+  name-sort: PROJECT MINERVA げんていばん
+  name-en: "Project Minerva [Limited Edition]"
   region: "NTSC-J"
 SLPM-65165:
-  name: "Project Minerva"
+  name: PROJECT MINERVA
+  name-sort: PROJECT MINERVA
+  name-en: "Project Minerva"
   region: "NTSC-J"
 SLPM-65166:
   name: "Ultimate Fighting Championship 2 - Tap-Out"
   region: "NTSC-J"
 SLPM-65167:
-  name: "Pride"
+  name: PRIDE
+  name-sort: PRIDE
+  name-en: "Pride"
   region: "NTSC-J"
 SLPM-65168:
   name: "Medal of Honor - Frontline"
   region: "NTSC-C"
 SLPM-65169:
-  name: "Combat Queen"
+  name: COMBATQUEEN
+  name-sort: COMBATQUEEN
+  name-en: "Combat Queen"
   region: "NTSC-J"
   compat: 5
 SLPM-65170:
-  name: "Shin Sangoku Musou 2 - Mushoden"
+  name: 真・三國無双2 猛将伝
+  name-sort: しん・さんごくむそう2 もうしょうでん
+  name-en: "Shin Sangoku Musou 2 - Mushoden"
   region: "NTSC-J"
 SLPM-65171:
   name: "Shin Sangoku Musou 2"
@@ -33091,39 +35000,57 @@ SLPM-65172:
   name: "Shin Sangoku Musou 2 - Moushouden"
   region: "NTSC-J"
 SLPM-65173:
-  name: "Innocent Black"
+  name: 探偵 神宮寺三郎 Innocent Black
+  name-sort: たんてい じんぐうじさぶろう Innocent Black
+  name-en: "Innocent Black"
   region: "NTSC-J"
 SLPM-65174:
-  name: "Britney's Dance Beat"
+  name: BRITNEY’S DANCE BEAT
+  name-sort: BRITNEY’S DANCE BEAT
+  name-en: "Britney's Dance Beat"
   region: "NTSC-J"
 SLPM-65176:
-  name: "King of Colosseum - Red"
+  name: キング オブ コロシアム(赤) 新日本×全日本×パンクラスディスク
+  name-sort: きんぐ おぶ ころしあむ(あか) しんにほん×ぜんにほん×ぱんくらすでぃすく
+  name-en: "King of Colosseum - Red"
   region: "NTSC-J"
   gameFixes:
     - InstantDMAHack # Fixes hang on opening.
 SLPM-65177:
-  name: "Energy Airforce"
+  name: エナジーエアフォース
+  name-sort: えなじーえあふぉーす
+  name-en: "Energy Airforce"
   region: "NTSC-J"
   compat: 5
 SLPM-65178:
-  name: "Ferrari F355 Challenge"
+  name: Ferrari F355 challenge
+  name-sort: Ferrari F355 challenge
+  name-en: "Ferrari F355 Challenge"
   region: "NTSC-J"
   gsHWFixes:
     roundSprite: 1 # Fixes text alignment.
 SLPM-65179:
-  name: "Culdcept 2 - Expansion"
+  name: カルドセプト セカンド エキスパンション
+  name-sort: かるどせぷと せかんど えきすぱんしょん
+  name-en: "Culdcept 2 - Expansion"
   region: "NTSC-J"
 SLPM-65180:
-  name: "Baseball 2003, The - Battle Ball Park Sengen - Perfect Play Pro Yakyuu"
+  name: THE BASEBALL2003 バトルボールパーク宣言 パーフェクトプレープロ野球
+  name-sort: THE BASEBALL2003 ばとるぼーるぱーくせんげん ぱーふぇくとぷれーぷろやきゅう
+  name-en: "Baseball 2003, The - Battle Ball Park Sengen - Perfect Play Pro Yakyuu"
   region: "NTSC-J"
 SLPM-65181:
   name: "Need for Speed - Hot Pursuit 2"
   region: "NTSC-C"
 SLPM-65183:
-  name: "Auto Modellista"
+  name: auto modellista モデムパック バージョン
+  name-sort: auto modellista もでむぱっく ばーじょん
+  name-en: "Auto Modellista"
   region: "NTSC-J"
 SLPM-65184:
-  name: "Document of Metal Gear Solid 2, The"
+  name: THE DOCUMENT OF METAL GEAR SOLID 2
+  name-sort: THE DOCUMENT OF METAL GEAR SOLID 2
+  name-en: "Document of Metal Gear Solid 2, The"
   region: "NTSC-J"
   gameFixes:
     - EETimingHack # Fixes corrupted or missing menu fonts.
@@ -33133,16 +35060,22 @@ SLPM-65185:
   gsHWFixes:
     roundSprite: 1 # Fixes text alignment.
 SLPM-65186:
-  name: "Thread Colors [Limited Edition]"
+  name: Thread Colors(スレッドカラーズ)〜さよならの向こう側〜(限定生産初回BOX)
+  name-sort: Thread Colors(すれっどからーず)〜さよならのむこうがわ〜(げんていせいさんしょかいBOX)
+  name-en: "Thread Colors [Limited Edition]"
   region: "NTSC-J"
 SLPM-65187:
-  name: "Thread Colors"
+  name: Thread Colors(スレッドカラーズ)〜さよならの向こう側〜(量産型ふつう版)
+  name-sort: Thread Colors(すれっどからーず)〜さよならのむこうがわ〜(りょうさんがたふつうばん)
+  name-en: "Thread Colors"
   region: "NTSC-J"
 SLPM-65190:
   name: "Tony Hawk's Pro Skater 3"
   region: "NTSC-J"
 SLPM-65191:
-  name: "V-Rally 3"
+  name: V-RALLY3
+  name-sort: V-RALLY3
+  name-en: "V-Rally 3"
   region: "NTSC-J"
   gsHWFixes:
     preloadFrameData: 1 # Fixes fog and make lights on cars work again.
@@ -33162,16 +35095,22 @@ SLPM-65193:
   gsHWFixes:
     mipmap: 1 # Fixes broken player textures.
 SLPM-65196:
-  name: "Breath of Fire V - Dragon Quarter"
+  name: ブレス オブ ファイア V ドラゴンクォーター
+  name-sort: ぶれす おぶ ふぁいあ V どらごんくぉーたー
+  name-en: "Breath of Fire V - Dragon Quarter"
   region: "NTSC-J"
 SLPM-65197:
-  name: "Nobunaga's Ambition Online"
+  name: 信長の野望 Online
+  name-sort: のぶながのやぼう Online
+  name-en: "Nobunaga's Ambition Online"
   region: "NTSC-J"
 SLPM-65198:
   name: "Shaun Palmer's Pro Snowboarder"
   region: "NTSC-J"
 SLPM-65199:
-  name: "Kikou Heidan J-Phoenix Cobalt Shoutai-hen"
+  name: 機甲兵団J-PHOENIX コバルト小隊篇
+  name-sort: きこうへいだんJ-PHOENIX こばるとしょうたいへん
+  name-en: "Kikou Heidan J-Phoenix Cobalt Shoutai-hen"
   region: "NTSC-J"
   memcardFilters:
     - "SLPS-20075"
@@ -33181,7 +35120,9 @@ SLPM-65199:
     - "SLPM-65123"
     - "SLPM-65199"
 SLPM-65200:
-  name: "Shinobi"
+  name: Shinobi
+  name-sort: Shinobi
+  name-en: "Shinobi"
   region: "NTSC-J"
 SLPM-65201:
   name: "Star Wars - Jedi Starfighter"
@@ -33189,30 +35130,46 @@ SLPM-65201:
   clampModes:
     vuClampMode: 3 # Fixes SPS on menu.
 SLPM-65202:
-  name: "K-1 World Grand Prix 2002"
+  name: K-1 WORLD GRAND PRIX 2002
+  name-sort: K-1 WORLD GRAND PRIX 2002
+  name-en: "K-1 World Grand Prix 2002"
   region: "NTSC-J"
 SLPM-65203:
-  name: "Phantom of Inferno [Limited Edition]"
+  name: ファントム-PHANTOM OF INFERNO- (初回限定版)
+  name-sort: ふぁんとむ-PHANTOM OF INFERNO- (しょかいげんていばん)
+  name-en: "Phantom of Inferno [Limited Edition]"
   region: "NTSC-J"
 SLPM-65204:
-  name: "Phantom of Inferno"
+  name: ファントム-PHANTOM OF INFERNO-
+  name-sort: ふぁんとむ-PHANTOM OF INFERNO-
+  name-en: "Phantom of Inferno"
   region: "NTSC-J"
 SLPM-65205:
-  name: "Spider-Man"
+  name: スパイダーマン
+  name-sort: すぱいだーまん
+  name-en: "Spider-Man"
   region: "NTSC-J"
 SLPM-65206:
-  name: "King of Colosseum - Green"
+  name: キング オブ コロシアム(緑) 〜ノア×ZERO-ONE ディスク〜
+  name-sort: きんぐ おぶ ころしあむ(みどり) 〜のあ×ZERO-ONE でぃすく〜
+  name-en: "King of Colosseum - Green"
   region: "NTSC-J"
   gameFixes:
     - InstantDMAHack # Fixes hang on opening.
 SLPM-65207:
-  name: "Chou Battle Houshin"
+  name: 超・バトル封神
+  name-sort: ちょう・ばとるほうしん
+  name-en: "Chou Battle Houshin"
   region: "NTSC-J"
 SLPM-65208:
-  name: "Pop'n music 7"
+  name: ポップンミュージック7
+  name-sort: ぽっぷんみゅーじっく7
+  name-en: "Pop'n music 7"
   region: "NTSC-J"
 SLPM-65209:
-  name: "Star Ocean 3 [Limited Edition]"
+  name: スターオーシャン Till the End of Time
+  name-sort: すたーおーしゃん Till the End of Time
+  name-en: "Star Ocean 3 [Limited Edition]"
   region: "NTSC-J"
   compat: 5
   gameFixes:
@@ -33258,7 +35215,9 @@ SLPM-65209:
         //Force jump to execute iReferEventFlagStatus
         patch=1,IOP,00025198,word,0800946D
 SLPM-65210:
-  name: "Chou Battle Houshin [Premium Pack]"
+  name: 超・バトル封神&封神演義2 プレミアムパック
+  name-sort: ちょう・ばとるほうしん&ほうしんえんぎ2 ぷれみあむぱっく
+  name-en: "Chou Battle Houshin [Premium Pack]"
   region: "NTSC-J"
 SLPM-65211:
   name: "Houshin Engi 2 [Premium Pack]"
@@ -33271,42 +35230,62 @@ SLPM-65212:
   clampModes:
     vuClampMode: 3 # Fixes white shiny weapons.
 SLPM-65213:
-  name: "Evolution Skateboarding"
+  name: Evolution Skateboarding
+  name-sort: Evolution Skateboarding
+  name-en: "Evolution Skateboarding"
   region: "NTSC-J"
 SLPM-65215:
-  name: "Chou Battle Houshin - Bundle #2"
+  name: 超・バトル封神&真・三國無双2 猛将伝 プレミアムパック
+  name-sort: ちょう・ばとるほうしん&しん・さんごくむそう2 もうしょうでん ぷれみあむぱっく
+  name-en: "Chou Battle Houshin - Bundle #2"
   region: "NTSC-J"
 SLPM-65217:
   name: "Seaman - Kindan no Pet - Kanzenban"
   region: "NTSC-J"
 SLPM-65218:
-  name: "Bomberman Jetters"
+  name: ボンバーマンジェッターズ
+  name-sort: ぼんばーまんじぇったーず
+  name-en: "Bomberman Jetters"
   region: "NTSC-J"
 SLPM-65219:
-  name: "Cheerful Party"
+  name: はっぴーぶりーでぃんぐ 〜Cheerful Party〜 初回限定版
+  name-sort: はっぴーぶりーでぃんぐ 〜Cheerful Party〜 しょかいげんていばん
+  name-en: "Cheerful Party"
   region: "NTSC-J"
 SLPM-65220:
-  name: "Cheerful Party"
+  name: はっぴーぶりーでぃんぐ 〜Cheerful Party〜
+  name-sort: はっぴーぶりーでぃんぐ 〜Cheerful Party〜
+  name-en: "Cheerful Party"
   region: "NTSC-J"
 SLPM-65221:
-  name: "Clock Tower 3"
+  name: クロックタワー3
+  name-sort: くろっくたわー3
+  name-en: "Clock Tower 3"
   region: "NTSC-J"
   compat: 5
 SLPM-65222:
-  name: "Yu-Gi-Oh! 2 [Konami The Best]"
+  name: 遊戯王真デュエルマスターズ II 継承されし記憶 コナミ ザ ベスト
+  name-sort: ゆうぎおうまでゅえるますたーず II けいしょうされしきおく こなみ ざ べすと
+  name-en: "Yu-Gi-Oh! 2 [Konami The Best]"
   region: "NTSC-J"
   roundModes:
     eeRoundMode: 2 # Partially fixes battle animation.
   clampModes:
     eeClampMode: 2 # Partially fixes battle animation.
 SLPM-65223:
-  name: "Triangle Again"
+  name: トライアングル・アゲイン
+  name-sort: とらいあんぐる・あげいん
+  name-en: "Triangle Again"
   region: "NTSC-J"
 SLPM-65224:
-  name: "NFL 2K3"
+  name: NFL 2K3
+  name-sort: NFL 2K3
+  name-en: "NFL 2K3"
   region: "NTSC-J"
 SLPM-65226:
-  name: "Savage Skies"
+  name: SAVAGE SKIES
+  name-sort: SAVAGE SKIES
+  name-en: "Savage Skies"
   region: "NTSC-J"
   patches:
     6911C604:
@@ -33321,20 +35300,30 @@ SLPM-65226:
         patch=0,EE,00163130,word,03e00008
         patch=0,EE,00163134,word,27bd0030
 SLPM-65227:
-  name: "J-League Pro Soccer Club - Tsukuku! 3"
+  name: J.LEAGUE プロサッカークラブをつくろう!3
+  name-sort: J.LEAGUE ぷろさっかーくらぶをつくろう!3
+  name-en: "J-League Pro Soccer Club - Tsukuku! 3"
   region: "NTSC-J"
 SLPM-65228:
-  name: "Taisho Mononoke Ibunroku"
+  name: 大正もののけ異聞録
+  name-sort: たいしょうもののけいぶんろく
+  name-en: "Taisho Mononoke Ibunroku"
   region: "NTSC-J"
   compat: 5
 SLPM-65229:
-  name: "Totsugeki! Army Men - Shijou Saishou no Sakusen"
+  name: 突撃!アーミーマン 史上最小の作戦
+  name-sort: とつげき!あーみーまん しじょうさいしょうのさくせん
+  name-en: "Totsugeki! Army Men - Shijou Saishou no Sakusen"
   region: "NTSC-J"
 SLPM-65230:
-  name: "Tokimeki Memorial 3 [Konami The Best]"
+  name: ときめきメモリアル3 約束のあの場所で コナミ ザ・ベスト
+  name-sort: ときめきめもりある3 やくそくのあのばしょで こなみ ざ・べすと
+  name-en: "Tokimeki Memorial 3 [Konami The Best]"
   region: "NTSC-J"
 SLPM-65231:
-  name: "Evolution Snowboarding"
+  name: EVOLUTION SNOWBOARDING
+  name-sort: EVOLUTION SNOWBOARDING
+  name-en: "Evolution Snowboarding"
   region: "NTSC-J"
   compat: 5
   patches:
@@ -33347,7 +35336,9 @@ SLPM-65231:
         patch=1,EE,00122780,word,27BDFD00
         patch=1,EE,00122AE8,word,27BD0300
 SLPM-65232:
-  name: "Devil May Cry 2 [Dante Disc]"
+  name: Devil May Cry 2
+  name-sort: Devil May Cry 2
+  name-en: "Devil May Cry 2 [Dante Disc]"
   region: "NTSC-J"
   compat: 5
 SLPM-65233:
@@ -33357,50 +35348,72 @@ SLPM-65233:
   memcardFilters:
     - "SLPM-65232"
 SLPM-65234:
-  name: "Bakusou Dekotora Densetsu - Otoko Hanamichi Yume Roman"
+  name: 爆走デコトラ伝説 〜男花道夢浪漫〜
+  name-sort: ばくそうでことらでんせつ 〜おとこはなみちゆめろまん〜
+  name-en: "Bakusou Dekotora Densetsu - Otoko Hanamichi Yume Roman"
   region: "NTSC-J"
   gsHWFixes:
     textureInsideRT: 1 # Fixes inside RT shuffling.
     getSkipCount: "GSC_BigMuthaTruckers"
 SLPM-65235:
-  name: "New Roommania - Porori Seishun"
+  name: ニュールーマニア ポロリ青春
+  name-sort: にゅーるーまにあ ぽろりせいしゅん
+  name-en: "New Roommania - Porori Seishun"
   region: "NTSC-J"
   compat: 5
 SLPM-65236:
-  name: "Anubis - Zone of the Enders"
+  name: ANUBIS ZONE OF THE ENDERS
+  name-sort: ANUBIS ZONE OF THE ENDERS
+  name-en: "Anubis - Zone of the Enders"
   region: "NTSC-J"
 SLPM-65237:
-  name: "Z.O.E. - Zone of the Enders [PlayStation 2 The Best]"
+  name: ZONE OF THE ENDERS PlayStation 2 the Best
+  name-sort: ZONE OF THE ENDERS PlayStation 2 the Best
+  name-en: "Z.O.E. - Zone of the Enders [PlayStation 2 The Best]"
   region: "NTSC-J"
   gsHWFixes:
     gpuPaletteConversion: 2 # Improves FPS and reduces HC size.
 SLPM-65238:
-  name: "Angelic Concert [Limited Edition]"
+  name: エンジェリック・コンサート スペシャルボックス
+  name-sort: えんじぇりっく・こんさーと すぺしゃるぼっくす
+  name-en: "Angelic Concert [Limited Edition]"
   region: "NTSC-J"
 SLPM-65239:
-  name: "Angelic Concert"
+  name: エンジェリック・コンサート
+  name-sort: えんじぇりっく・こんさーと
+  name-en: "Angelic Concert"
   region: "NTSC-J"
 SLPM-65240:
   name: "Pro Yakyuu Team o Tsukurou! 2"
   region: "NTSC-J"
 SLPM-65241:
-  name: "Shin Megami Tensei III - Nocturne [Limited Edition]"
+  name: 真・女神転生 III-NOCTURNE デラックスパック
+  name-sort: しん・めがみてんせい III-NOCTURNE でらっくすぱっく
+  name-en: "Shin Megami Tensei III - Nocturne [Limited Edition]"
   region: "NTSC-J"
   roundModes:
     eeRoundMode: 0 # Ladder glitch in "Assembly of Nihilo B11" level.
 SLPM-65242:
-  name: "Shin Megami Tensei III - Nocturne"
+  name: 真・女神転生 III-NOCTURNE
+  name-sort: しん・めがみてんせい III-NOCTURNE
+  name-en: "Shin Megami Tensei III - Nocturne"
   region: "NTSC-J"
   roundModes:
     eeRoundMode: 0 # Ladder glitch in "Assembly of Nihilo B11" level.
 SLPM-65243:
-  name: "Densha de Go! Professional 2"
+  name: 電車でGO!プロフェッショナル2
+  name-sort: でんしゃでGO!ぷろふぇっしょなる2
+  name-en: "Densha de Go! Professional 2"
   region: "NTSC-J"
 SLPM-65244:
-  name: "Tom Clancy's Ghost Recon"
+  name: トム・クランシーシリーズ ゴーストリコン
+  name-sort: とむ・くらんしーしりーず ごーすとりこん
+  name-en: "Tom Clancy's Ghost Recon"
   region: "NTSC-J"
 SLPM-65245:
-  name: "BioHazard Gun Survivor 4 - Heroes Never Die"
+  name: ガンサバイバー4 バイオハザード ヒーローズ ネバーダイ
+  name-sort: がんさばいばー4 ばいおはざーど ひーろーず ねばーだい
+  name-en: "BioHazard Gun Survivor 4 - Heroes Never Die"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
@@ -33409,19 +35422,27 @@ SLPM-65245:
     roundSprite: 2 # Fixes font artifacts.
     mergeSprite: 1 # Fixes flame-like bleeding.
 SLPM-65246:
-  name: "Kaido Battle - Nikko, Haruna, Rokko, Hakone"
+  name: 街道バトル 〜日光・榛名・六甲・箱根〜
+  name-sort: かいどうばとる 〜にっこう・はるな・ろっこう・はこね〜
+  name-en: "Kaido Battle - Nikko, Haruna, Rokko, Hakone"
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
     wildArmsHack: 1 # De-blurs the 3D image.
 SLPM-65247:
-  name: "Sangokushi Senki 2"
+  name: 三國志戦記2
+  name-sort: さんごくしせんき2
+  name-en: "Sangokushi Senki 2"
   region: "NTSC-J"
 SLPM-65248:
-  name: "Shin Sangoku Musou 3"
+  name: 真・三國無双3
+  name-sort: しん・さんごくむそう3
+  name-en: "Shin Sangoku Musou 3"
   region: "NTSC-J"
 SLPM-65249:
-  name: "Chaos Legion"
+  name: CHAOS LEGION
+  name-sort: CHAOS LEGION
+  name-en: "Chaos Legion"
   region: "NTSC-J"
   compat: 5
   clampModes:
@@ -33434,18 +35455,26 @@ SLPM-65250:
   name: "Kattobi! Golf"
   region: "NTSC-J"
 SLPM-65254:
-  name: "Galaxy Angel"
+  name: ギャラクシーエンジェル
+  name-sort: ぎゃらくしーえんじぇる
+  name-en: "Galaxy Angel"
   region: "NTSC-J"
 SLPM-65255:
-  name: "Chobits - Chii dake no Hito"
+  name: ちょびっツ ～ちぃだけのヒト～
+  name-sort: ちょびっつ ～ちぃだけのひと～
+  name-en: "Chobits - Chii dake no Hito"
   region: "NTSC-J"
   gsHWFixes:
     roundSprite: 2 # Reduces font artifacts.
 SLPM-65256:
-  name: "First Kiss Story 1&2 [Limited Edition]"
+  name: ファーストKiss☆物語(ストーリーズ) スペシャルCD同梱版
+  name-sort: ふぁーすとKiss☆ものがたり(すとーりーず) すぺしゃるCDどうこんばん
+  name-en: "First Kiss Story 1&2 [Limited Edition]"
   region: "NTSC-J"
 SLPM-65257:
-  name: "Silent Hill 3"
+  name: サイレントヒル3
+  name-sort: さいれんとひる3
+  name-en: "Silent Hill 3"
   region: "NTSC-J"
   compat: 5
   clampModes:
@@ -33464,22 +35493,30 @@ SLPM-65259:
   name: "Shin Megami Tensei III - Nocturne"
   region: "NTSC-J"
 SLPM-65260:
-  name: "Gaika no Gouhou - Air Land Force"
+  name: 凱歌の号砲
+  name-sort: がいかのごうほう
+  name-en: "Gaika no Gouhou - Air Land Force"
   region: "NTSC-J"
 SLPM-65261:
   name: "TBS All-Star Kansha-sai Vol .1 - Chou Gouka! Quiz Ketteiban"
   region: "NTSC-J"
 SLPM-65262:
-  name: "Boboboubo Boubobo - Hajike Matsuri"
+  name: ボボボーボ・ボーボボ ハジけ祭
+  name-sort: ぼぼぼーぼ・ぼーぼぼ はじけまつり
+  name-en: "Boboboubo Boubobo - Hajike Matsuri"
   region: "NTSC-J"
 SLPM-65263:
-  name: "Shin Sangoku Musou 2 & Shin Sangoku Musou 2 Mushoden [Koei Mega Pack] [Disc 1 of 2]"
+  name: コーエーメガパック 真・三國無双2&真・三國無双2 猛将伝
+  name-sort: こーえーめがぱっく しん・さんごくむそう2&しん・さんごくむそう2 もうしょうでん
+  name-en: "Shin Sangoku Musou 2 & Shin Sangoku Musou 2 Mushoden [Koei Mega Pack] [Disc 1 of 2]"
   region: "NTSC-J"
 SLPM-65264:
   name: "Shin Sangoku Musou 2 & Shin Sangoku Musou 2 Mushoden [Koei Mega Pack] [Disc 2 of 2]"
   region: "NTSC-J"
 SLPM-65266:
-  name: "Drag-on Dragoon"
+  name: ドラッグ オン ドラグーン
+  name-sort: どらっぐ おん どらぐーん
+  name-en: "Drag-on Dragoon"
   region: "NTSC-J"
   clampModes:
     eeClampMode: 3 # Characters are visible in-game.
@@ -33488,10 +35525,14 @@ SLPM-65266:
     mergeSprite: 1 # Fixes misaligned white lines.
     PCRTCOverscan: 1 # Fixes missing HUD.
 SLPM-65267:
-  name: "Kurogane no Houkou 2 - Warship Gunner"
+  name: 鋼鉄の咆哮2 WARSHIP GUNNER
+  name-sort: くろがねのほうこう2 WARSHIP GUNNER
+  name-en: "Kurogane no Houkou 2 - Warship Gunner"
   region: "NTSC-J"
 SLPM-65268:
-  name: "Initial D - Special Stage"
+  name: 頭文字D Special Stage
+  name-sort: かしらもじD Special Stage
+  name-en: "Initial D - Special Stage"
   region: "NTSC-J"
   patches:
     A62EBC2C:
@@ -33515,120 +35556,186 @@ SLPM-65268:
         patch=1,EE,0017D9D8,word,48439000
         patch=1,EE,0017D9DC,word,4BCA51FF
 SLPM-65269:
-  name: "NBA 2K3"
+  name: NBA 2K3
+  name-sort: NBA 2K3
+  name-en: "NBA 2K3"
   region: "NTSC-J"
 SLPM-65270:
-  name: "Virtua Fighter 4 - Evolution"
+  name: バーチャファイター4 エボリューション
+  name-sort: ばーちゃふぁいたー4 えぼりゅーしょん
+  name-en: "Virtua Fighter 4 - Evolution"
   region: "NTSC-J"
 SLPM-65271:
-  name: "Over the Monochrome Rainbow featuring Shogo Hamada"
+  name: OVER THE MONOCHROME RAINBOW featuring SHOGO HAMADA
+  name-sort: OVER THE MONOCHROME RAINBOW featuring SHOGO HAMADA
+  name-en: "Over the Monochrome Rainbow featuring Shogo Hamada"
   region: "NTSC-J"
 SLPM-65272:
   name: "Kyuuketsu-hime Yui - Sen'yashou"
   region: "NTSC-J"
 SLPM-65273:
-  name: "Triangle Again 2"
+  name: トライアングルアゲイン2
+  name-sort: とらいあんぐるあげいん2
+  name-en: "Triangle Again 2"
   region: "NTSC-J"
 SLPM-65274:
-  name: "Saishuu Heiki Kanojo [Limited Edition]"
+  name: 最終兵器彼女 限定版
+  name-sort: さいしゅうへいきかのじょ げんていばん
+  name-en: "Saishuu Heiki Kanojo [Limited Edition]"
   region: "NTSC-J"
 SLPM-65275:
-  name: "Saishuu Heiki Kanojo"
+  name: 最終兵器彼女
+  name-sort: さいしゅうへいきかのじょ
+  name-en: "Saishuu Heiki Kanojo"
   region: "NTSC-J"
 SLPM-65276:
-  name: "Grand Prix Challenge"
+  name: GRAND PRIX CHALLENGE
+  name-sort: GRAND PRIX CHALLENGE
+  name-en: "Grand Prix Challenge"
   region: "NTSC-J"
   gameFixes:
     - VIFFIFOHack
 SLPM-65277:
-  name: "DDRMAX2 Dance Dance Revolution 7th Mix"
+  name: DDRMAX2 Dance Dance Revolution 7th Mix
+  name-sort: DDRMAX2 Dance Dance Revolution 7th Mix
+  name-en: "DDRMAX2 Dance Dance Revolution 7th Mix"
   region: "NTSC-J"
   compat: 5
 SLPM-65278:
-  name: "Generation of Chaos 3 [Limited Edition]"
+  name: GENERATION OF CHAOS 3 ～時の封印～ （限定版）
+  name-sort: GENERATION OF CHAOS 3 ～じのふういん～ （げんていばん）
+  name-en: "Generation of Chaos 3 [Limited Edition]"
   region: "NTSC-J"
 SLPM-65279:
-  name: "Generation of Chaos 3"
+  name: GENERATION OF CHAOS 3 ～時の封印～
+  name-sort: GENERATION OF CHAOS 3 ～じのふういん～
+  name-en: "Generation of Chaos 3"
   region: "NTSC-J"
 SLPM-65280:
-  name: "Green Green - Sound of the Ring Dynamic [Limited Edition]"
+  name: グリーングリーン ～鐘の音ダイナミック～(デラックスパック)
+  name-sort: ぐりーんぐりーん ～かねのおとだいなみっく～(でらっくすぱっく)
+  name-en: "Green Green - Sound of the Ring Dynamic [Limited Edition]"
   region: "NTSC-J"
 SLPM-65281:
-  name: "Green Green - Sound of the Ring Dynamic"
+  name: グリーングリーン ～鐘の音ダイナミック～(通常版)
+  name-sort: ぐりーんぐりーん ～かねのおとだいなみっく～(つうじょうばん)
+  name-en: "Green Green - Sound of the Ring Dynamic"
   region: "NTSC-J"
 SLPM-65282:
-  name: "Green Green - Sound of the Ring Romantic [Limited Edition]"
+  name: グリーングリーン ～鐘の音ロマンティック～(デラックスパック)
+  name-sort: ぐりーんぐりーん ～かねのおとろまんてぃっく～(でらっくすぱっく)
+  name-en: "Green Green - Sound of the Ring Romantic [Limited Edition]"
   region: "NTSC-J"
 SLPM-65283:
-  name: "Green Green - Sound of the Ring Romantic"
+  name: グリーングリーン 〜鐘の音ロマンティック〜(通常版)
+  name-sort: ぐりーんぐりーん 〜かねのおとろまんてぃっく〜(つうじょうばん)
+  name-en: "Green Green - Sound of the Ring Romantic"
   region: "NTSC-J"
 SLPM-65284:
-  name: "WRC II Extreme"
+  name: WRC II〜EXTREME〜
+  name-sort: WRC II〜EXTREME〜
+  name-en: "WRC II Extreme"
   region: "NTSC-J"
   gameFixes:
     - XGKickHack # Fixes SPS.
   gsHWFixes:
     halfPixelOffset: 1 # Fixes texture misalignment.
 SLPM-65285:
-  name: "Love Hina Gorgeous [First Limited Edition]"
+  name: ラブひな ごーじゃす ～チラっとハプニング!!～ 初回限定版
+  name-sort: らぶひな ごーじゃす ～ちらっとはぷにんぐ!!～ しょかいげんていばん
+  name-en: "Love Hina Gorgeous [First Limited Edition]"
   region: "NTSC-J"
   compat: 5
 SLPM-65286:
-  name: "Auto Modellista - US Tuned"
+  name: アウトモデリスタ U.S.-tuned
+  name-sort: あうともでりすた U.S.-tuned
+  name-en: "Auto Modellista - US Tuned"
   region: "NTSC-J"
 SLPM-65287:
-  name: "Final Fantasy XI - Girade no Genei"
+  name: ファイナルファンタジーXI ジラートの幻影 拡張データディスク
+  name-sort: ふぁいなるふぁんたじーXI じらーとのげんえい かくちょうでーたでぃすく
+  name-en: "Final Fantasy XI - Girade no Genei"
   region: "NTSC-J"
 SLPM-65288:
-  name: "Final Fantasy XI - Girade no Genei [All-in-One Pack]"
+  name: プレイオンライン/ファイナルファンタジーXI ジラートの幻影 オールインワンパック2003
+  name-sort: ぷれいおんらいん/ふぁいなるふぁんたじーXI じらーとのげんえい おーるいんわんぱっく2003
+  name-en: "Final Fantasy XI - Girade no Genei [All-in-One Pack]"
   region: "NTSC-J"
 SLPM-65289:
-  name: "Final Fantasy XI [Entry Disc]"
+  name: プレイオンライン/ファイナルファンタジーXI エントリーディスク
+  name-sort: ぷれいおんらいん/ふぁいなるふぁんたじーXI えんとりーでぃすく
+  name-en: "Final Fantasy XI [Entry Disc]"
   region: "NTSC-J"
 SLPM-65290:
-  name: "Merge Marginal [Limited Edition]"
+  name: マージ ～あの時の遠い約束を～ 初回限定版
+  name-sort: まーじ ～あのときのとおいやくそくを～ しょかいげんていばん
+  name-en: "Merge Marginal [Limited Edition]"
   region: "NTSC-J"
 SLPM-65291:
-  name: "Merge Marginal"
+  name: マージ ～あの時の遠い約束を～
+  name-sort: まーじ ～あのときのとおいやくそくを～
+  name-en: "Merge Marginal"
   region: "NTSC-J"
 SLPM-65292:
   name: "Love Hina Gorgeous - Chiratto Happening!!"
   region: "NTSC-J"
 SLPM-65294:
-  name: "Cafe Little Wish - Mahou no Recipe [Limited Edition]"
+  name: カフェ・リトルウィッシュ ～魔法のレシピ～ 初回限定版
+  name-sort: かふぇ・りとるうぃっしゅ ～まほうのれしぴ～ しょかいげんていばん
+  name-en: "Cafe Little Wish - Mahou no Recipe [Limited Edition]"
   region: "NTSC-J"
 SLPM-65295:
-  name: "Cafe Little Wish - Mahou no Recipe"
+  name: カフェ・リトルウィッシュ ～魔法のレシピ～
+  name-sort: かふぇ・りとるうぃっしゅ ～まほうのれしぴ～
+  name-en: "Cafe Little Wish - Mahou no Recipe"
   region: "NTSC-J"
 SLPM-65296:
-  name: "F - Fanatic [Limited Edition]"
+  name: F～ファナティック～(初回限定版)
+  name-sort: F～ふぁなてぃっく～(しょかいげんていばん)
+  name-en: "F - Fanatic [Limited Edition]"
   region: "NTSC-J"
 SLPM-65297:
-  name: "F - Fanatic"
+  name: F～ファナティック～
+  name-sort: F～ふぁなてぃっく～
+  name-en: "F - Fanatic"
   region: "NTSC-J"
 SLPM-65298:
-  name: "Winning Post 5 Maximum 2003"
+  name: Winning Post5 MAXIMAM 2003
+  name-sort: Winning Post5 MAXIMAM 2003
+  name-en: "Winning Post 5 Maximum 2003"
   region: "NTSC-J"
 SLPM-65299:
-  name: "Konohana 3"
+  name: 此花3 ～偽りの影の向こうに～
+  name-sort: このはな3 ～いつわりのかげのむこうに～
+  name-en: "Konohana 3"
   region: "NTSC-J"
 SLPM-65300:
-  name: "All-Star Pro Wrestling III"
+  name: オールスター・プロレスリングIII
+  name-sort: おーるすたー・ぷろれすりんぐIII
+  name-en: "All-Star Pro Wrestling III"
   region: "NTSC-J"
   compat: 5
 SLPM-65301:
-  name: "Torakapuu! Dash [Limited Edition]"
+  name: とらかぷっ!だーっしゅ!!でらっくすぱっく
+  name-sort: とらかぷっ!だーっしゅ!!でらっくすぱっく
+  name-en: "Torakapuu! Dash [Limited Edition]"
   region: "NTSC-J"
 SLPM-65302:
-  name: "Torakapuu! Dash"
+  name: とらかぷっ!だーっしゅ!!
+  name-sort: とらかぷっ!だーっしゅ!!
+  name-en: "Torakapuu! Dash"
   region: "NTSC-J"
 SLPM-65303:
-  name: "Dennou Senki - Virtual-On Marz"
+  name: 電脳戦機バーチャロン マーズ
+  name-sort: でんのうせんきばーちゃろん まーず
+  name-en: "Dennou Senki - Virtual-On Marz"
   region: "NTSC-J"
   gsHWFixes:
     cpuCLUTRender: 2 # Fixes CLUT colours.
 SLPM-65305:
-  name: "Genso Suikoden 3"
+  name: 幻想水滸伝 III KONAMI THE BEST
+  name-sort: げんそうすいこでん III KONAMI THE BEST
+  name-en: "Genso Suikoden 3"
   region: "NTSC-J"
   memcardFilters:
     - "SLPM-65073"
@@ -33645,13 +35752,19 @@ SLPM-65305:
     - "SLPM-86953"
     - "SLPM-87262"
 SLPM-65306:
-  name: "Sakura - Yuki Gekka [First Print Limited Edition]"
+  name: SAKURA～雪月華～ 初回限定版
+  name-sort: SAKURA～せつげっか～ しょかいげんていばん
+  name-en: "Sakura - Yuki Gekka [First Print Limited Edition]"
   region: "NTSC-J"
 SLPM-65307:
-  name: "Sakura - Yuki Gekka"
+  name: SAKURA～雪月華～
+  name-sort: SAKURA～せつげっか～
+  name-en: "Sakura - Yuki Gekka"
   region: "NTSC-J"
 SLPM-65308:
-  name: "Shutokou Battle 01"
+  name: 首都高バトル01
+  name-sort: しゅとこうばとる01
+  name-en: "Shutokou Battle 01"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
@@ -33662,70 +35775,112 @@ SLPM-65309:
   name: "Splashdown [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPM-65310:
-  name: "Mark of Kri, The"
+  name: The Mark of KRI(マーク オブ クリィ)
+  name-sort: The Mark of KRI(まーく おぶ くりぃ)
+  name-en: "Mark of Kri, The"
   region: "NTSC-J"
 SLPM-65311:
-  name: "Violet no Atelier - Gramnad no Renkinjutsushi"
+  name: ヴィオラートのアトリエ 〜グラムナートの錬金術士2〜
+  name-sort: ゔぃおらーとのあとりえ 〜ぐらむなーとのれんきんじゅつし2〜
+  name-en: "Violet no Atelier - Gramnad no Renkinjutsushi"
   region: "NTSC-J"
   gsHWFixes:
     roundSprite: 1 # Aligns text boxes.
 SLPM-65313:
-  name: "First Kiss Story 1&2"
+  name: ファーストKiss☆物語(ストーリーズ)
+  name-sort: ふぁーすとKiss☆ものがたり(すとーりーず)
+  name-en: "First Kiss Story 1&2"
   region: "NTSC-J"
 SLPM-65314:
-  name: "Hanjuku Hero VS 3-D [Limited Edition]"
+  name: 7大ふろくつき!半熟英雄 対 3D 特大号
+  name-sort: 7だいふろくつき!はんじゅくえいゆう たい 3D とくだいごう
+  name-en: "Hanjuku Hero VS 3-D [Limited Edition]"
   region: "NTSC-J"
 SLPM-65315:
-  name: "Hanjuku Hero VS 3-D"
+  name: 半熟英雄 対 3D
+  name-sort: はんじゅくえいゆう たい 3D
+  name-en: "Hanjuku Hero VS 3-D"
   region: "NTSC-J"
   compat: 5
 SLPM-65316:
-  name: "Pop'n music 8"
+  name: ポップンミュージック8
+  name-sort: ぽっぷんみゅーじっく8
+  name-en: "Pop'n music 8"
   region: "NTSC-J"
 SLPM-65317:
-  name: "Jikkyou Powerful Pro Yakyuu 10"
+  name: 実況パワフルプロ野球10
+  name-sort: じっきょうぱわふるぷろやきゅう10
+  name-en: "Jikkyou Powerful Pro Yakyuu 10"
   region: "NTSC-J"
 SLPM-65318:
-  name: "Shoubushi Tetsuya 2"
+  name: 勝負師伝説 哲也2 玄人頂上決戦
+  name-sort: しょうぶしでんせつ てつや2 くろうとちょうじょうけっせん
+  name-en: "Shoubushi Tetsuya 2"
   region: "NTSC-J"
 SLPM-65319:
-  name: "Eve Burst Error Plus [Limited Edition]"
+  name: EVE burst error PLUS 限定版 DVD-BOX
+  name-sort: EVE burst error PLUS げんていばん DVD-BOX
+  name-en: "Eve Burst Error Plus [Limited Edition]"
   region: "NTSC-J"
 SLPM-65320:
-  name: "Eve Burst Error Plus"
+  name: EVE burst error PLUS
+  name-sort: EVE burst error PLUS
+  name-en: "Eve Burst Error Plus"
   region: "NTSC-J"
 SLPM-65321:
-  name: "Prince of Tennis - Smash Hit!"
+  name: テニスの王子様 Smash Hit! 初回SP限定版
+  name-sort: てにすのおうじさま Smash Hit! しょかいSPげんていばん
+  name-en: "Prince of Tennis - Smash Hit!"
   region: "NTSC-J"
 SLPM-65322:
-  name: "Prince of Tennis - Smash Hit! - B-Type"
+  name: テニスの王子様 Smash Hit! (Btype)
+  name-sort: てにすのおうじさま Smash Hit! (Btype)
+  name-en: "Prince of Tennis - Smash Hit! - B-Type"
   region: "NTSC-J"
 SLPM-65323:
-  name: "Prince of Tennis - Smash Hit! - C-Type"
+  name: テニスの王子様 Smash Hit! (Ctype)
+  name-sort: てにすのおうじさま Smash Hit! (Ctype)
+  name-en: "Prince of Tennis - Smash Hit! - C-Type"
   region: "NTSC-J"
 SLPM-65324:
-  name: "Gregory Horror Show - Soul Collector"
+  name: グレゴリーホラーショー ソウルコレクター
+  name-sort: ぐれごりーほらーしょー そうるこれくたー
+  name-en: "Gregory Horror Show - Soul Collector"
   region: "NTSC-J"
 SLPM-65325:
-  name: "Air Ranger 2 - Rescue Helicopter [Best]"
+  name: レスキューヘリ　エアレンジャー2 低価格版
+  name-sort: れすきゅーへり　えあれんじゃー2 ていかかくばん
+  name-en: "Air Ranger 2 - Rescue Helicopter [Best]"
   region: "NTSC-J"
 SLPM-65326:
-  name: "Choro Q HG 4"
+  name: チョロQHG4
+  name-sort: ちょろQHG4
+  name-en: "Choro Q HG 4"
   region: "NTSC-J"
 SLPM-65327:
-  name: "Prince of Tennis - Smash Hit! [Limited Edition]"
+  name: テニスの王子様 Smash Hit!
+  name-sort: てにすのおうじさま Smash Hit!
+  name-en: "Prince of Tennis - Smash Hit! [Limited Edition]"
   region: "NTSC-J"
 SLPM-65328:
-  name: "Shirachuu Tankenbu"
+  name: 白中探検部
+  name-sort: しろちゅうたんけんぶ
+  name-en: "Shirachuu Tankenbu"
   region: "NTSC-J"
 SLPM-65329:
-  name: "Makai Tensei"
+  name: 魔界転生
+  name-sort: まかいてんしょう
+  name-en: "Makai Tensei"
   region: "NTSC-J"
 SLPM-65330:
-  name: "Akudaikan 2 - Mousouden"
+  name: 悪代官2〜妄想伝〜
+  name-sort: あくだいかん2〜もうそうでん〜
+  name-en: "Akudaikan 2 - Mousouden"
   region: "NTSC-J"
 SLPM-65331:
-  name: "Rockman X7"
+  name: ロックマンX7
+  name-sort: ろっくまんX7
+  name-en: "Rockman X7"
   region: "NTSC-J"
   compat: 5
   clampModes:
@@ -33733,77 +35888,119 @@ SLPM-65331:
   gsHWFixes:
     disablePartialInvalidation: 1 # Fixes Fixes black screens.
 SLPM-65332:
-  name: "Mahoromatic Automatic Maiden [Limited Edition]"
+  name: まほろまてぃっく 萌っと≠きらきらメイドさん。 限定版
+  name-sort: まほろまてぃっく もえっと≠きらきらめいどさん。 げんていばん
+  name-en: "Mahoromatic Automatic Maiden [Limited Edition]"
   region: "NTSC-J"
 SLPM-65333:
-  name: "Mahoromatic Automatic Maiden"
+  name: まほろまてぃっく 萌っと≠きらきらメイドさん。
+  name-sort: まほろまてぃっく もえっと≠きらきらめいどさん。
+  name-en: "Mahoromatic Automatic Maiden"
   region: "NTSC-J"
 SLPM-65334:
-  name: "Shinseiki Evangelion - Ayanami Ikusei Keikaku with Asuka Hokan Keikaku"
+  name: 新世紀エヴァンゲリオン 綾波育成計画 with アスカ補完計画
+  name-sort: しんせいきえゔぁんげりおん あやなみいくせいけいかく with あすかほかんけいかく
+  name-en: "Shinseiki Evangelion - Ayanami Ikusei Keikaku with Asuka Hokan Keikaku"
   region: "NTSC-J"
   compat: 5
 SLPM-65335:
-  name: "Gekitou Professional Baseball"
+  name: 激闘プロ野球 水島新司オールスターズ VS プロ野球
+  name-sort: げきとうぷろやきゅう みずしましんじおーるすたーず VS ぷろやきゅう
+  name-en: "Gekitou Professional Baseball"
   region: "NTSC-J"
 SLPM-65336:
-  name: "K-1 World Grand Prix - The Beast Attack!"
+  name: K-1 WORLD GRAND PRIX THE BEAST ATTACK!
+  name-sort: K-1 WORLD GRAND PRIX THE BEAST ATTACK!
+  name-en: "K-1 World Grand Prix - The Beast Attack!"
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes upscaling lines.
 SLPM-65337:
-  name: "Gegege no Kitaro - Ibun Youkaitan"
+  name: ゲゲゲの鬼太郎 異聞妖怪奇
+  name-sort: げげげのきたろう いぶんようかいき
+  name-en: "Gegege no Kitaro - Ibun Youkaitan"
   region: "NTSC-J"
   compat: 5
 SLPM-65338:
-  name: "Juunikoku-ki - Guren no Shirube Koejin no Michi"
+  name: 十二国記 紅蓮の標 黄塵の路
+  name-sort: じゅうにこくき ぐれんのしるべ こうじんのみち
+  name-en: "Juunikoku-ki - Guren no Shirube Koejin no Michi"
   region: "NTSC-J"
 SLPM-65339:
-  name: "Akudaikan [Global The Best]"
+  name: グローバル ザ ベスト 悪代官
+  name-sort: ぐろーばる ざ べすと あくだいかん
+  name-en: "Akudaikan [Global The Best]"
   region: "NTSC-J"
 SLPM-65340:
-  name: "Shinseiki Evangelion - Ayanami Ikusai Keikaku with Asuka Hokan Keikaku"
+  name: 新世紀エヴァンゲリオン 綾波育成計画 Withアスカ補完計画
+  name-sort: しんせいきえゔぁんげりおん あやなみいくせいけいかく Withあすかほかんけいかく
+  name-en: "Shinseiki Evangelion - Ayanami Ikusai Keikaku with Asuka Hokan Keikaku"
   region: "NTSC-J"
 SLPM-65341:
-  name: "Silent Hill 2 - Saigo No Uta [Konami The Best]"
+  name: サイレントヒル2 最期の詩 (コナミ・ザ・ベスト)
+  name-sort: さいれんとひる2 さいごのし (こなみ・ざ・べすと)
+  name-en: "Silent Hill 2 - Saigo No Uta [Konami The Best]"
   region: "NTSC-J"
   speedHacks:
     instantVU1: 0 # Fixes hang on FMV's when CDVD timing is accurate.
     mtvu: 0
 SLPM-65342:
-  name: "Kyoufu Shinbun (Heisei) Kaiki! Shinrei File"
+  name: 恐怖新聞【平成版】〜怪奇!心霊ファイル〜(PS2)
+  name-sort: きょうふしんぶん【へいせいばん】〜かいき!しんれいふぁいる〜(PS2)
+  name-en: "Kyoufu Shinbun (Heisei) Kaiki! Shinrei File"
   region: "NTSC-J"
 SLPM-65343:
-  name: "Kikou Heidan J-Phoenix 2"
+  name: 機甲兵団 J-PHOENIX2
+  name-sort: きこうへいだん J-PHOENIX2
+  name-en: "Kikou Heidan J-Phoenix 2"
   region: "NTSC-J"
   memcardFilters:
     - "SLPM-62339"
     - "SLPM-65343"
 SLPM-65344:
-  name: "Project Minerva - Professional"
+  name: プロジェクト・ミネルヴァ・プロフェッショナル
+  name-sort: ぷろじぇくと・みねるゔぁ・ぷろふぇっしょなる
+  name-en: "Project Minerva - Professional"
   region: "NTSC-J"
 SLPM-65345:
-  name: "Simple 2000 Series Ultimate Vol. 9 - Bakusou! Manhattan - Runabout 3"
+  name: SIMPLE2000シリーズ アルティメットVol.9 爆走マンハッタン
+  name-sort: SIMPLE2000しりーず あるてぃめっとVol.9 ばくそうまんはったん
+  name-en: "Simple 2000 Series Ultimate Vol. 9 - Bakusou! Manhattan - Runabout 3"
   region: "NTSC-J"
 SLPM-65346:
-  name: "Winning Post 6"
+  name: WinningPost 6
+  name-sort: WinningPost 6
+  name-en: "Winning Post 6"
   region: "NTSC-J"
 SLPM-65347:
-  name: "Bistro Cupid 2 [Tokubetsu-ban]"
+  name: ビストロ・きゅーぴっと2 特別版
+  name-sort: びすとろ・きゅーぴっと2 とくべつばん
+  name-en: "Bistro Cupid 2 [Tokubetsu-ban]"
   region: "NTSC-J"
 SLPM-65348:
-  name: "Bistro Cupid 2"
+  name: ビストロ・きゅーぴっと2 通常版
+  name-sort: びすとろ・きゅーぴっと2 つうじょうばん
+  name-en: "Bistro Cupid 2"
   region: "NTSC-J"
 SLPM-65349:
-  name: "Tokyo Bus Guide [Superlite 2000 Series]"
+  name: SuperLite 2000シミュレーション 東京バス案内〜今日から君も運転手〜
+  name-sort: SuperLite 2000しみゅれーしょん とうきょうばすあんない〜きょうからきみもうんてんしゅ〜
+  name-en: "Tokyo Bus Guide [Superlite 2000 Series]"
   region: "NTSC-J"
 SLPM-65350:
-  name: "Simple 2000 Series Ultimate Vol. 11 - Wandaba Style - Totsugeki! Mix Ki Juice"
+  name: SIMPLE2000シリーズ アルティメットVol.11 ワンダバスタイル〜突撃!みっくす生JUICE〜
+  name-sort: SIMPLE2000しりーず あるてぃめっとVol.11 わんだばすたいる〜とつげき!みっくすなまJUICE〜
+  name-en: "Simple 2000 Series Ultimate Vol. 11 - Wandaba Style - Totsugeki! Mix Ki Juice"
   region: "NTSC-J"
 SLPM-65352:
-  name: "Simple 2000 Series Ultimate Vol. 10 - Love - Songs"
+  name: SIMPLE2000シリーズ アルティメットVol.10 ラブ★ソングス♪
+  name-sort: SIMPLE2000しりーず あるてぃめっとVol.10 らぶ★そんぐす♪
+  name-en: "Simple 2000 Series Ultimate Vol. 10 - Love - Songs"
   region: "NTSC-J"
 SLPM-65353:
-  name: "SuperLite 2000 Series Vol. 6 - Konohana 2 - Todokanai Requiem"
+  name: SuperLite 2000アドベンチャー 此花2〜届かないレクイエム〜
+  name-sort: SuperLite 2000あどべんちゃー このはな2〜とどかないれくいえむ〜
+  name-en: "SuperLite 2000 Series Vol. 6 - Konohana 2 - Todokanai Requiem"
   region: "NTSC-J"
 SLPM-65354:
   name: "Sangokushi Senki 2"
@@ -33812,64 +36009,94 @@ SLPM-65355:
   name: "Natsuiro Komachi - Ichijitsu Senka"
   region: "NTSC-J"
 SLPM-65356:
-  name: "Natsuiro Komachi"
+  name: 夏色小町【一日千夏】(通常版)
+  name-sort: なついろこまち【いちじつせんか】(つうじょうばん)
+  name-en: "Natsuiro Komachi"
   region: "NTSC-J"
 SLPM-65357:
-  name: "BioHazard - Code Veronica - Perfect Version"
+  name: バイオハザード コード:ベロニカ 完全版(カプコレ)
+  name-sort: ばいおはざーど こーど:べろにか かんぜんばん(かぷこれ)
+  name-en: "BioHazard - Code Veronica - Perfect Version"
   region: "NTSC-J"
 SLPM-65358:
-  name: "Dance Dance Revolution EXTREME"
+  name: Dance Dance Revolution EXTREME
+  name-sort: Dance Dance Revolution EXTREME
+  name-en: "Dance Dance Revolution EXTREME"
   region: "NTSC-J"
   compat: 5
 SLPM-65359:
-  name: "Judie no Atelier - Gramnad no Renkinjutsushi [Gust Best Price]"
+  name: ガストベストプライス ユーディーのアトリエ 〜グラムナート の錬金術士〜
+  name-sort: がすとべすとぷらいす ゆーでぃーのあとりえ 〜ぐらむなーと のれんきんじゅつし〜
+  name-en: "Judie no Atelier - Gramnad no Renkinjutsushi [Gust Best Price]"
   region: "NTSC-J"
 SLPM-65361:
-  name: "Anubis - Zone of the Enders Special Edition [Limited Edition]"
+  name: ANUBIS ZONE OF THE ENDERS SPECIAL EDITION(限定版)
+  name-sort: ANUBIS ZONE OF THE ENDERS SPECIAL EDITION(げんていばん)
+  name-en: "Anubis - Zone of the Enders Special Edition [Limited Edition]"
   region: "NTSC-J"
   compat: 5
 SLPM-65362:
-  name: "NHK Tensai Bit-Kun - Guramon Battle"
+  name: NHK 天才ビットくん グラモンバトル
+  name-sort: NHK てんさいびっとくん ぐらもんばとる
+  name-en: "NHK Tensai Bit-Kun - Guramon Battle"
   region: "NTSC-J"
 SLPM-65363:
   name: "Shoujo Yoshitsune-den"
   region: "NTSC-J"
 SLPM-65364:
-  name: "Shoujo Yoshitsune-den"
+  name: 少女義経伝(通常版)
+  name-sort: しょうじょよしつねでん(つうじょうばん)
+  name-en: "Shoujo Yoshitsune-den"
   region: "NTSC-J"
 SLPM-65365:
-  name: "Tokimeki Memorial - Girl's Side [Konami The Best]"
+  name: ときめきメモリアル Girl’s Side (コナミ ザ ベスト)
+  name-sort: ときめきめもりある Girl’s Side (こなみ ざ べすと)
+  name-en: "Tokimeki Memorial - Girl's Side [Konami The Best]"
   region: "NTSC-J"
 SLPM-65366:
-  name: "Dear Boys - Fast Break!"
+  name: DEAR BOYS Fast Break!
+  name-sort: DEAR BOYS Fast Break!
+  name-en: "Dear Boys - Fast Break!"
   region: "NTSC-J"
 SLPM-65367:
-  name: "Makai Eiyuuki Maximo - Machine Monster no Yabou"
+  name: 魔界英雄記マキシモ 〜マシンモンスターの野望〜
+  name-sort: まかいえいゆうきまきしも 〜ましんもんすたーのやぼう〜
+  name-en: "Makai Eiyuuki Maximo - Machine Monster no Yabou"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes outlines around environmental objects.
 SLPM-65368:
-  name: "D.N. Angel - TV Animation Series"
+  name: D・N・ANGEL TV Animation Series 〜紅の翼〜
+  name-sort: D・N・ANGEL TV Animation Series 〜くれないのつばさ〜
+  name-en: "D.N. Angel - TV Animation Series"
   region: "NTSC-J"
 SLPM-65369:
   name: "TBS All Star Kanshasai 2003 Aki - Chou Gouka! Quiz Ketteiban"
   region: "NTSC-J"
 SLPM-65370:
-  name: "Prince of Tennis - Sweat & Tears 2"
+  name: テニスの王子様 SWEAT&TEARS 2
+  name-sort: てにすのおうじさま SWEAT&TEARS 2
+  name-en: "Prince of Tennis - Sweat & Tears 2"
   region: "NTSC-J"
 SLPM-65371:
   name: "Tennis no Oujisama - Sweat & Tears 2 - Seishun Gakuen Teikyuusai '03 - Perfect Live"
   region: "NTSC-J"
 SLPM-65372:
-  name: "Soccer Kantoku Saihai Simulation - Formation Final"
+  name: サッカー監督采配シミュレーション FORMATION FINAL
+  name-sort: さっかーかんとくさいはいしみゅれーしょん FORMATION FINAL
+  name-en: "Soccer Kantoku Saihai Simulation - Formation Final"
   region: "NTSC-J"
 SLPM-65373:
-  name: "Glass Rose"
+  name: 玻璃の薔薇(ガラスノバラ)
+  name-sort: がらすのばら(がらすのばら)
+  name-en: "Glass Rose"
   region: "NTSC-J"
   compat: 5
 SLPM-65374:
-  name: "Energy Airforce - Aim Strike!"
+  name: エナジーエアフォース エイムストライク
+  name-sort: えなじーえあふぉーす えいむすとらいく
+  name-en: "Energy Airforce - Aim Strike!"
   region: "NTSC-J"
   speedHacks:
     instantVU1: 0 # Fixes hanging while going ingame.
@@ -33877,91 +36104,139 @@ SLPM-65374:
   gsHWFixes:
     autoFlush: 2 # Corrects post-processing effect on jet exhausts.
 SLPM-65375:
-  name: "Shin Sangoku Musou 3 - Mushoden [Premium Pack]"
+  name: 真・三國無双3 プレミアムパック(真・三國無双3&真・三國無双3 猛将伝)
+  name-sort: しん・さんごくむそう3 ぷれみあむぱっく(しん・さんごくむそう3&しん・さんごくむそう3 もうしょうでん)
+  name-en: "Shin Sangoku Musou 3 - Mushoden [Premium Pack]"
   region: "NTSC-J"
 SLPM-65376:
   name: "Shin Sangoku Musou 3 - Moushouden"
   region: "NTSC-J"
 SLPM-65377:
-  name: "Shin Sangoku Musou 3 - Mushoden"
+  name: 真・三國無双3 猛将伝
+  name-sort: しん・さんごくむそう3 もうしょうでん
+  name-en: "Shin Sangoku Musou 3 - Mushoden"
   region: "NTSC-J"
 SLPM-65378:
-  name: "Busin 0 - Wizardry Alternative Neo"
+  name: BUSIN 0 Wizardry Alternative NEO
+  name-sort: BUSIN 0 Wizardry Alternative NEO
+  name-en: "Busin 0 - Wizardry Alternative Neo"
   region: "NTSC-J"
   gsHWFixes:
     autoFlush: 2 # Corrects blur effects in menus.
     roundSprite: 2 # Aligns some text/graphics when upscaling.
 SLPM-65379:
-  name: "Baseball 2003, The - Battle Ball Park Sengen - Perfect Play Pro Yakyuu - Shuukigou"
+  name: THE BASEBALL2003 バトルボールパーク宣言 パーフェクト プレープロ野球 秋季号
+  name-sort: THE BASEBALL2003 ばとるぼーるぱーくせんげん ぱーふぇくと ぷれーぷろやきゅう しゅうきごう
+  name-en: "Baseball 2003, The - Battle Ball Park Sengen - Perfect Play Pro Yakyuu - Shuukigou"
   region: "NTSC-J"
 SLPM-65380:
-  name: "Samurai Michi 2"
+  name: 侍道2 〜WAY OF THE SAMURAI 2〜
+  name-sort: さむらいどう2 〜WAY OF THE SAMURAI 2〜
+  name-en: "Samurai Michi 2"
   region: "NTSC-J"
 SLPM-65381:
-  name: "Kimagure Strawberry Cafe"
+  name: きまぐれストロベリーカフェ
+  name-sort: きまぐれすとろべりーかふぇ
+  name-en: "Kimagure Strawberry Cafe"
   region: "NTSC-J"
 SLPM-65382:
-  name: "Grand Theft Auto III"
+  name: Grand Theft Auto III
+  name-sort: Grand Theft Auto III
+  name-en: "Grand Theft Auto III"
   region: "NTSC-J"
 SLPM-65383:
-  name: "Growlanser IV - Wayfarer of the Time [Limited Edition]"
+  name: GROWLANSER IV 〜Wayfarer of the time〜(デラックスパック)
+  name-sort: GROWLANSER IV 〜Wayfarer of the time〜(でらっくすぱっく)
+  name-en: "Growlanser IV - Wayfarer of the Time [Limited Edition]"
   region: "NTSC-J"
 SLPM-65384:
-  name: "Dream Mix TV World Fighters"
+  name: ドリームミックスTV ワールドファイターズ
+  name-sort: どりーむみっくすTV わーるどふぁいたーず
+  name-en: "Dream Mix TV World Fighters"
   region: "NTSC-J"
   compat: 5
 SLPM-65385:
   name: "Winning Post 6"
   region: "NTSC-J"
 SLPM-65386:
-  name: "Train Simulator - Midosuji Line"
+  name: Train Simulator 御堂筋線
+  name-sort: Train Simulator みどうすじせん
+  name-en: "Train Simulator - Midosuji Line"
   region: "NTSC-J"
 SLPM-65387:
-  name: "Aero Dancing 4 - New Generation [Sega The Best 2800]"
+  name: aero dancing 4 new generation SEGA THE BEST 2800
+  name-sort: aero dancing 4 new generation SEGA THE BEST 2800
+  name-en: "Aero Dancing 4 - New Generation [Sega The Best 2800]"
   region: "NTSC-J"
 SLPM-65388:
-  name: "Lost Passage [Limited Edition]"
+  name: Lost Passage 〜失われた一節〜(初回限定版)
+  name-sort: Lost Passage 〜うしなわれたいっせつ〜(しょかいげんていばん)
+  name-en: "Lost Passage [Limited Edition]"
   region: "NTSC-J"
 SLPM-65389:
-  name: "Lost Passage"
+  name: Lost Passage 〜失われた一節〜(通常版)
+  name-sort: Lost Passage 〜うしなわれたいっせつ〜(つうじょうばん)
+  name-en: "Lost Passage"
   region: "NTSC-J"
 SLPM-65390:
-  name: "Shinki Gensou - Spectral Souls [Limited Edition]"
+  name: 新紀幻想 スペクトラル ソウルズ 限定版
+  name-sort: しんきげんそう すぺくとらる そうるず げんていばん
+  name-en: "Shinki Gensou - Spectral Souls [Limited Edition]"
   region: "NTSC-J"
 SLPM-65391:
-  name: "Shinki Gensou - Spectral Souls"
+  name: 新紀幻想 スペクトラル ソウルズ
+  name-sort: しんきげんそう すぺくとらる そうるず
+  name-en: "Shinki Gensou - Spectral Souls"
   region: "NTSC-J"
 SLPM-65392:
-  name: "Kanojo no Densetsu - Boku no Sekiban"
+  name: 彼女の伝説、僕の石版〜アリミリオンの剣とともに〜
+  name-sort: かのじょのでんせつ、ぼくのせきばん〜ありみりおんのけんとともに〜
+  name-en: "Kanojo no Densetsu - Boku no Sekiban"
   region: "NTSC-J"
 SLPM-65393:
-  name: "Simple 2000 Series Vol. 38 - The Yuujou Adventure - Hotaru Soul"
+  name: SIMPLE2000シリーズVol.39 漢のためのバイブルTHE友情アドベンチャー 〜炎多留・魂〜
+  name-sort: SIMPLE2000しりーずVol.39 おとこのためのばいぶるTHEゆうじょうあどべんちゃー 〜ほたる・そうる〜
+  name-en: "Simple 2000 Series Vol. 38 - The Yuujou Adventure - Hotaru Soul"
   region: "NTSC-J"
 SLPM-65394:
-  name: "Love Smash! 5"
+  name: ラブ★スマッシュ!5〜テニスロボの反乱〜
+  name-sort: らぶ★すまっしゅ!5〜てにすろぼのはんらん〜
+  name-en: "Love Smash! 5"
   region: "NTSC-J"
   gameFixes:
     - XGKickHack # Fixes bad Geometry.
 SLPM-65395:
-  name: "Digi-Charat Fantasy"
+  name: デ・ジ・キャラット ファンタジー エクセレント プレミアム版
+  name-sort: で・じ・きゃらっと ふぁんたじー えくせれんと ぷれみあむばん
+  name-en: "Digi-Charat Fantasy"
   region: "NTSC-J"
 SLPM-65396:
   name: "Di Gi Charat Fantasy Excellent"
   region: "NTSC-J"
 SLPM-65397:
-  name: "Prince of Tennis - Kiss of Prince - Ice Version"
+  name: テニスの王子様 〜Kiss of Prince〜 Ice version
+  name-sort: てにすのおうじさま 〜Kiss of Prince〜 Ice version
+  name-en: "Prince of Tennis - Kiss of Prince - Ice Version"
   region: "NTSC-J"
 SLPM-65398:
-  name: "Prince of Tennis - Kiss of Prince - Flame Version"
+  name: テニスの王子様 〜Kiss of Prince〜 Flame version
+  name-sort: てにすのおうじさま 〜Kiss of Prince〜 Flame version
+  name-en: "Prince of Tennis - Kiss of Prince - Flame Version"
   region: "NTSC-J"
 SLPM-65399:
-  name: "D.C.P.S. [Limited Edition]"
+  name: D.C.P.S. 〜ダ・カーポ〜 プラスシチュエーション DXパック
+  name-sort: D.C.P.S. 〜だ・かーぽ〜 ぷらすしちゅえーしょん DXぱっく
+  name-en: "D.C.P.S. [Limited Edition]"
   region: "NTSC-J"
 SLPM-65400:
-  name: "D.C.P.S."
+  name: D.C.P.S. 〜ダ・カーポ〜 プラスシチュエーション
+  name-sort: D.C.P.S. 〜だ・かーぽ〜 ぷらすしちゅえーしょん
+  name-en: "D.C.P.S."
   region: "NTSC-J"
 SLPM-65401:
-  name: "Tengai Makyou II - Manji Maru"
+  name: 天外魔境II MANJI MARU
+  name-sort: てんがいまきょうII MANJI MARU
+  name-en: "Tengai Makyou II - Manji Maru"
   region: "NTSC-J"
 SLPM-65402:
   name: "Tengai Makyou II - Manji Maru"
@@ -33970,31 +36245,45 @@ SLPM-65403:
   name: "Sangokushi Senki"
   region: "NTSC-J"
 SLPM-65404:
-  name: "Kita He - Diamond Dust"
+  name: 北へ。〜Diamond Dust〜
+  name-sort: きたへ。〜Diamond Dust〜
+  name-en: "Kita He - Diamond Dust"
   region: "NTSC-J"
 SLPM-65405:
-  name: "Chou Jikuu Yousai Macross"
+  name: 超時空要塞マクロス
+  name-sort: ちょうじくうようさいまくろす
+  name-en: "Chou Jikuu Yousai Macross"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
     texturePreloading: 1 # Performs much better with partial preload.
 SLPM-65406:
-  name: "Castlevania [Limited Edition]"
+  name: キャッスルヴァニア 限定版
+  name-sort: きゃっするゔぁにあ げんていばん
+  name-en: "Castlevania [Limited Edition]"
   region: "NTSC-J"
   clampModes:
     eeClampMode: 3 # Fixes cutscene freezes.
 SLPM-65407:
-  name: "Transformers Tatakai"
+  name: トランスフォーマー
+  name-sort: とらんすふぉーまー
+  name-en: "Transformers Tatakai"
   region: "NTSC-J"
   compat: 5
 SLPM-65408:
-  name: "Growlanser IV - Wayfarer of the Time"
+  name: GROWLANSER IV 〜Wayfarer of thetime〜
+  name-sort: GROWLANSER IV 〜Wayfarer of thetime〜
+  name-en: "Growlanser IV - Wayfarer of the Time"
   region: "NTSC-J"
 SLPM-65409:
-  name: "Air Ranger 2 Plus - Rescue Helicopter"
+  name: レスキューヘリ エアレンジャー2 plus
+  name-sort: れすきゅーへり えあれんじゃー2 plus
+  name-en: "Air Ranger 2 Plus - Rescue Helicopter"
   region: "NTSC-J"
 SLPM-65410:
-  name: "Getaway, The"
+  name: ゲッタウェイ(the Getaway)
+  name-sort: げったうぇい(the Getaway)
+  name-en: "Getaway, The"
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes the fog wall.
@@ -34003,17 +36292,23 @@ SLPM-65410:
     halfPixelOffset: 2 # Fixes outlines around characters.
     getSkipCount: "GSC_GetawayGames"
 SLPM-65411:
-  name: "Onimusha Buraiden"
+  name: 鬼武者 無頼伝
+  name-sort: おにむしゃ ぶらいでん
+  name-en: "Onimusha Buraiden"
   region: "NTSC-J"
   compat: 5
   memcardFilters:
     - "SLPM-65411"
     - "SLPM-65413"
 SLPM-65412:
-  name: "War of the Monsters"
+  name: 怪獣大激戦 War of the Monsters
+  name-sort: かいじゅうだいげきせん War of the Monsters
+  name-en: "War of the Monsters"
   region: "NTSC-J"
 SLPM-65413:
-  name: "Onimusha 3"
+  name: 鬼武者3
+  name-sort: おにむしゃ3
+  name-en: "Onimusha 3"
   region: "NTSC-J"
   clampModes:
     vuClampMode: 3 # Makes sure enemies appear correctly.
@@ -34026,75 +36321,115 @@ SLPM-65413:
     disablePartialInvalidation: 1 # Fixes textureless graphics ingame.
     bilinearUpscale: 2 # Gets rid of center vertical line when upscaling.
 SLPM-65414:
-  name: "Simple 2000 Series Vol. 45 - The Koi to Namida to, Tsuioku to..."
+  name: SIMPLE2000シリーズ Vol.45 THE 恋と涙と、追憶と・・・。〜スレッドカラーズ さよならの向こう側〜
+  name-sort: SIMPLE2000しりーず Vol.45 THE こいとなみだと、ついおくと・・・。〜すれっどからーず さよならのむこうがわ〜
+  name-en: "Simple 2000 Series Vol. 45 - The Koi to Namida to, Tsuioku to..."
   region: "NTSC-J"
 SLPM-65415:
   name: "EX Jinsei Game II"
   region: "NTSC-J"
 SLPM-65416:
-  name: "Pride Grand Prix 2003"
+  name: PRIDE GP 2003
+  name-sort: PRIDE GP 2003
+  name-en: "Pride Grand Prix 2003"
   region: "NTSC-J"
 SLPM-65417:
-  name: "Mat Hoffman's Pro BMX 2003"
+  name: Mat Hoffman’s Pro BMX 2003 マット・ホフマン プロBMX
+  name-sort: Mat Hoffman’s Pro BMX 2003 まっと・ほふまん ぷろBMX
+  name-en: "Mat Hoffman's Pro BMX 2003"
   region: "NTSC-J"
 SLPM-65418:
-  name: "Kelly Slater's Pro Surfer 2003"
+  name: Kelly Slater’s Pro Surfer 2003 ケリー・スレーター プロサーファー
+  name-sort: Kelly Slater’s Pro Surfer 2003 けりー・すれーたー ぷろさーふぁー
+  name-en: "Kelly Slater's Pro Surfer 2003"
   region: "NTSC-J"
 SLPM-65419:
-  name: "Tony Hawk's Pro Skater 2003"
+  name: Tony Hawk’s Pro Skater 2003 トニー・ホーク プロスケーター
+  name-sort: Tony Hawk’s Pro Skater 2003 とにー・ほーく ぷろすけーたー
+  name-en: "Tony Hawk's Pro Skater 2003"
   region: "NTSC-J"
   roundModes:
     vu1RoundMode: 0 # Crashes without.
 SLPM-65420:
-  name: "Dabitsuku 3 - Let's Become a Derby Owner"
+  name: ダビつく3 ダービー馬をつくろう!
+  name-sort: だびつく3 だーびーばをつくろう!
+  name-en: "Dabitsuku 3 - Let's Become a Derby Owner"
   region: "NTSC-J"
 SLPM-65421:
-  name: "Ever 17 - Out of Infinity [Premium Edition]"
+  name: Ever17〜the out of infinity〜 PREMIUM EDITION
+  name-sort: Ever17〜the out of infinity〜 PREMIUM EDITION
+  name-en: "Ever 17 - Out of Infinity [Premium Edition]"
   region: "NTSC-J"
 SLPM-65422:
-  name: "Tom Clancy's Splinter Cell"
+  name: トム・クランシーシリーズ スプリンターセル
+  name-sort: とむ・くらんしーしりーず すぷりんたーせる
+  name-en: "Tom Clancy's Splinter Cell"
   region: "NTSC-J"
 SLPM-65423:
-  name: "Sangokushi IX"
+  name: 三國志IX
+  name-sort: さんごくしIX
+  name-en: "Sangokushi IX"
   region: "NTSC-J"
 SLPM-65424:
-  name: "Moekko Company [Limited Edition]"
+  name: モエかん 〜もえっ娘島へようこそ〜 (初回限定版)
+  name-sort: もえかん 〜もえっこしまへようこそ〜 (しょかいげんていばん)
+  name-en: "Moekko Company [Limited Edition]"
   region: "NTSC-J"
 SLPM-65425:
-  name: "Moekko Company"
+  name: モエかん 〜もえっ娘島へようこそ〜 (通常版)
+  name-sort: もえかん 〜もえっこしまへようこそ〜 (つうじょうばん)
+  name-en: "Moekko Company"
   region: "NTSC-J"
 SLPM-65426:
-  name: "Pro Baseball Team Tsukuro! 2003"
+  name: プロ野球チームをつくろう!2003
+  name-sort: ぷろやきゅうちーむをつくろう!2003
+  name-en: "Pro Baseball Team Tsukuro! 2003"
   region: "NTSC-J"
 SLPM-65427:
-  name: "Riding Spirits 2"
+  name: RSII 〜ライディングスピリッツ2〜
+  name-sort: RSII 〜らいでぃんぐすぴりっつ2〜
+  name-en: "Riding Spirits 2"
   region: "NTSC-J"
 SLPM-65428:
-  name: "BioHazard Outbreak"
+  name: バイオハザード アウトブレイク
+  name-sort: ばいおはざーど あうとぶれいく
+  name-en: "BioHazard Outbreak"
   region: "NTSC-J"
   compat: 5
 SLPM-65429:
-  name: "Galaxy Angel - Moonlit Lovers"
+  name: GALAXY ANGEL Moonlit Lovers 初回限定版(ファーストパッケージ)
+  name-sort: GALAXY ANGEL Moonlit Lovers しょかいげんていばん(ふぁーすとぱっけーじ)
+  name-en: "Galaxy Angel - Moonlit Lovers"
   region: "NTSC-J"
 SLPM-65431:
-  name: "Sonic Heroes"
+  name: ソニック ヒーローズ
+  name-sort: そにっく ひーろーず
+  name-en: "Sonic Heroes"
   region: "NTSC-J"
   compat: 5
 SLPM-65432:
-  name: "J-League Winning Eleven Tactics"
+  name: Jリーグウイニングイレブンタクティクス
+  name-sort: Jりーぐういにんぐいれぶんたくてぃくす
+  name-en: "J-League Winning Eleven Tactics"
   region: "NTSC-J"
 SLPM-65433:
-  name: "K-1 World Grand Prix 2003"
+  name: K-1 WORLD GRAND PRIX 2003
+  name-sort: K-1 WORLD GRAND PRIX 2003
+  name-en: "K-1 World Grand Prix 2003"
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes upscaling lines.
 SLPM-65434:
-  name: "Battle Gear 3"
+  name: バトルギア3
+  name-sort: ばとるぎあ3
+  name-en: "Battle Gear 3"
   region: "NTSC-J"
   clampModes:
     vuClampMode: 3 # Stops car from falling through track.
 SLPM-65435:
-  name: "Diamond Dust"
+  name: 北へ。〜Diamond Dust〜
+  name-sort: きたへ。〜Diamond Dust〜
+  name-en: "Diamond Dust"
   region: "NTSC-J"
 SLPM-65436:
   name: "Shin Sangoku Musou 3 - Moushouden"
@@ -34103,7 +36438,9 @@ SLPM-65437:
   name: "Kessen II"
   region: "NTSC-J"
 SLPM-65438:
-  name: "Star Ocean 3 [Director's Cut] [Disc 1 of 2]"
+  name: スターオーシャン Till the End of Time ディレクターズカット
+  name-sort: すたーおーしゃん Till the End of Time でぃれくたーずかっと
+  name-en: "Star Ocean 3 [Director's Cut] [Disc 1 of 2]"
   region: "NTSC-J"
   compat: 5
   gameFixes:
@@ -34125,134 +36462,196 @@ SLPM-65439:
   memcardFilters:
     - "SLPM-65438"
 SLPM-65441:
-  name: "Ashita no Joe - Masshiro ni Moe Tsukiro!"
+  name: あしたのジョー 〜まっ白に燃え尽きろ!〜
+  name-sort: あしたのじょー 〜まっしろにもえつきろ!〜
+  name-en: "Ashita no Joe - Masshiro ni Moe Tsukiro!"
   region: "NTSC-J"
 SLPM-65442:
-  name: "Terminator 3, The - Rise of the Machines"
+  name: ターミネーター3 -Rise of the machines-
+  name-sort: たーみねーたー3 -Rise of the machines-
+  name-en: "Terminator 3, The - Rise of the Machines"
   region: "NTSC-J"
 SLPM-65443:
-  name: "Front Mission 4"
+  name: フロントミッション フォース
+  name-sort: ふろんとみっしょん ふぉーす
+  name-en: "Front Mission 4"
   region: "NTSC-J"
   gsHWFixes:
     preloadFrameData: 1 # Fixes mech shadows.
     roundSprite: 2 # Fixes font artifacts.
 SLPM-65444:
-  name: "Castlevania"
+  name: キャッスルヴァニア
+  name-sort: きゃっするゔぁにあ
+  name-en: "Castlevania"
   region: "NTSC-J"
   compat: 5
   clampModes:
     eeClampMode: 3 # Fixes cutscene freezes.
 SLPM-65445:
-  name: "Jikkyou Powerful Pro Yakyuu 10 Chou Ketteiban - 2003 Memorial"
+  name: 実況パワフルプロ野球10 超決定版 2003メモリアル
+  name-sort: じっきょうぱわふるぷろやきゅう10 ちょうけっていばん 2003めもりある
+  name-en: "Jikkyou Powerful Pro Yakyuu 10 Chou Ketteiban - 2003 Memorial"
   region: "NTSC-J"
 SLPM-65446:
-  name: "007 - Everything or Nothing"
+  name: 007 エブリシング オア ナッシング
+  name-sort: 007 えぶりしんぐ おあ なっしんぐ
+  name-en: "007 - Everything or Nothing"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes lines in cutscenes.
     mipmap: 2 # Cleans up texture detail.
     trilinearFiltering: 1 # Smoothes out mipmapping.
 SLPM-65447:
-  name: "Kunoichi"
+  name: Kunoichi-忍-
+  name-sort: Kunoichi
+  name-en: "Kunoichi"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
     getSkipCount: "GSC_Kunoichi"
 SLPM-65448:
-  name: "Cambrian QTS - Kaseki ni Natte mo"
+  name: カンブリアンQTS 〜化石になっても〜
+  name-sort: かんぶりあんQTS 〜かせきになっても〜
+  name-en: "Cambrian QTS - Kaseki ni Natte mo"
   region: "NTSC-J"
 SLPM-65449:
-  name: "SSX 3"
+  name: SSX3
+  name-sort: SSX3
+  name-en: "SSX 3"
   region: "NTSC-J"
   gsHWFixes:
     textureInsideRT: 1 # Fixes rainbow effect in the pause menu before a jump.
     halfPixelOffset: 2 # Fixes depth lines.
     recommendedBlendingLevel: 4 # Fixes missing lighting and makes snow not look like snow sludge.
 SLPM-65450:
-  name: "Tantei Gakuen Q - Kiokan no Satsui [First Limited Edition]"
+  name: 探偵学園Q 〜奇翁館の殺意〜 (初回生産分)
+  name-sort: たんていがくえんQ 〜きおきなかんのさつい〜 (しょかいせいさんぶん)
+  name-en: "Tantei Gakuen Q - Kiokan no Satsui [First Limited Edition]"
   region: "NTSC-J"
 SLPM-65451:
-  name: "Prince of Tennis - Smash Hit! 2 [First Limited Edition]"
+  name: テニスの王子様 Smash Hit!2 初回SP限定版
+  name-sort: てにすのおうじさま Smash Hit!2 しょかいSPげんていばん
+  name-en: "Prince of Tennis - Smash Hit! 2 [First Limited Edition]"
   region: "NTSC-J"
 SLPM-65452:
   name: "Tennis no Oujisama - Smash Hit! 2"
   region: "NTSC-J"
 SLPM-65454:
-  name: "Prince of Tennis - Smash Hit! 2"
+  name: テニスの王子様 Smash Hit!2
+  name-sort: てにすのおうじさま Smash Hit!2
+  name-en: "Prince of Tennis - Smash Hit! 2"
   region: "NTSC-J"
   compat: 5
 SLPM-65455:
   name: "Nobunaga no Yabou - Soutenroku [with Power-Up Kit]"
   region: "NTSC-J"
 SLPM-65456:
-  name: "Magical Nurse Witch Komugi-chan [Limited Edition]"
+  name: ナースウィッチ小麦ちゃん マジカルて(初回限定版)
+  name-sort: なーすうぃっちこむぎちゃん まじかるて(しょかいげんていばん)
+  name-en: "Magical Nurse Witch Komugi-chan [Limited Edition]"
   region: "NTSC-J"
 SLPM-65457:
-  name: "Magical Nurse Witch Komugi-chan"
+  name: ナースウィッチ小麦ちゃん マジカルて(通常版)
+  name-sort: なーすうぃっちこむぎちゃん まじかるて(つうじょうばん)
+  name-en: "Magical Nurse Witch Komugi-chan"
   region: "NTSC-J"
 SLPM-65458:
-  name: "Kurogane no Houkou 2 - Warship Commander"
+  name: 鋼鉄の咆哮2 ウォーシップコマンダー
+  name-sort: くろがねのほうこう2 うぉーしっぷこまんだー
+  name-en: "Kurogane no Houkou 2 - Warship Commander"
   region: "NTSC-J"
 SLPM-65459:
-  name: "Bujingai"
+  name: 武刃街 -BUJINGAI-
+  name-sort: ぶじんがい
+  name-en: "Bujingai"
   region: "NTSC-J"
 SLPM-65460:
-  name: "Conflict Delta - Wangan War 1991"
+  name: コンフリクト デルタ 湾岸戦争1991
+  name-sort: こんふりくと でるた わんがんせんそう1991
+  name-en: "Conflict Delta - Wangan War 1991"
   region: "NTSC-J"
 SLPM-65461:
-  name: "Tantei Gakuen Q - Kioukan no Satsui"
+  name: 探偵学園Q〜奇翁館の殺意〜
+  name-sort: たんていがくえんQ〜きおきなかんのさつい〜
+  name-en: "Tantei Gakuen Q - Kioukan no Satsui"
   region: "NTSC-J"
 SLPM-65462:
-  name: "Shin Megami Tensei III - Nocturne Maniax"
+  name: 真・女神転生III-NOCTURNE マニアクス
+  name-sort: しん・めがみてんせいIII-NOCTURNE まにあくす
+  name-en: "Shin Megami Tensei III - Nocturne Maniax"
   region: "NTSC-J"
   compat: 5
   roundModes:
     eeRoundMode: 0 # Ladder glitch in "Assembly of Nihilo B11" level.
 SLPM-65463:
-  name: "Rocky"
+  name: ROCKY
+  name-sort: ROCKY
+  name-en: "Rocky"
   region: "NTSC-J"
   clampModes:
     eeClampMode: 0 # Fixes boxers not appearing/disappearing.
   gameFixes:
     - VIF1StallHack # Fixes freezes.
 SLPM-65464:
-  name: "Wind - A Breath of Heart"
+  name: Wind-a breath of heart-
+  name-sort: Wind-a breath of heart-
+  name-en: "Wind - A Breath of Heart"
   region: "NTSC-J"
 SLPM-65465:
-  name: "Harry Potter to Kenja no Ishi"
+  name: ハリー・ポッターと賢者の石
+  name-sort: はりー・ぽったーとけんじゃのいし
+  name-en: "Harry Potter to Kenja no Ishi"
   region: "NTSC-J"
   gameFixes:
     - EETimingHack
 SLPM-65466:
-  name: "Yomigaeri - Refrain"
+  name: 黄泉がえり ～リフレイン～
+  name-sort: よみがえり ～りふれいん～
+  name-en: "Yomigaeri - Refrain"
   region: "NTSC-J"
 SLPM-65468:
-  name: "Roommate Asami - D-Collection"
+  name: ルームメイト・麻美 D-Collection
+  name-sort: るーむめいと・あさみ D-Collection
+  name-en: "Roommate Asami - D-Collection"
   region: "NTSC-J"
 SLPM-65469:
   name: "Medal of Honor - Rising Sun"
   region: "NTSC-J"
 SLPM-65470:
-  name: "Firefighter F.D. 18"
+  name: FIREFIGHTER F.D.18
+  name-sort: FIREFIGHTER F.D.18
+  name-en: "Firefighter F.D. 18"
   region: "NTSC-J"
 SLPM-65471:
-  name: "Need for Speed - Underground"
+  name: ニード・フォー・スピード アンダーグラウンド
+  name-sort: にーど・ふぉー・すぴーど あんだーぐらうんど
+  name-en: "Need for Speed - Underground"
   region: "NTSC-J"
 SLPM-65472:
-  name: "Train Simulator & Densha de Go! Tokyo Kyuukouhen"
+  name: TrainSimulator+電車でGO! 東京急行編
+  name-sort: TrainSimulator+でんしゃでGO! とうきょうきゅうこうへん
+  name-en: "Train Simulator & Densha de Go! Tokyo Kyuukouhen"
   region: "NTSC-J"
 SLPM-65473:
-  name: "Hagane no Renkinjutsushi - Tobenai Tenshi"
+  name: 鋼の錬金術師 翔べない天使
+  name-sort: はがねのれんきんじゅつし とべないてんし
+  name-en: "Hagane no Renkinjutsushi - Tobenai Tenshi"
   region: "NTSC-J"
   compat: 5
 SLPM-65474:
-  name: "Kurogane no Houkou 2 - Warship Commander [Limited Edition]"
+  name: 鋼鉄の咆哮2 プレミアムパック(ウォーシップコマンダー&WARSHIP GUNNER)
+  name-sort: くろがねのほうこう2 ぷれみあむぱっく(うぉーしっぷこまんだー&WARSHIP GUNNER)
+  name-en: "Kurogane no Houkou 2 - Warship Commander [Limited Edition]"
   region: "NTSC-J"
 SLPM-65477:
-  name: "Crimson Sea 2"
+  name: 紅の海2 ～Crimson Sea～
+  name-sort: くれないのうみ2 ～Crimson Sea～
+  name-en: "Crimson Sea 2"
   region: "NTSC-J"
 SLPM-65478:
-  name: "Final Fantasy X-2 International"
+  name: ファイナルファンタジーX-2 インターナショナル+ラストミッション
+  name-sort: ふぁいなるふぁんたじーX-2 いんたーなしょなる+らすとみっしょん
+  name-en: "Final Fantasy X-2 International"
   region: "NTSC-J"
   compat: 5
   gameFixes:
@@ -34260,84 +36659,132 @@ SLPM-65478:
   gsHWFixes:
     roundSprite: 1 # Fixes font artifacts.
 SLPM-65479:
-  name: "Sims, The - Bustin' Out"
+  name: ザ・シムズ
+  name-sort: ざ・しむず
+  name-en: "Sims, The - Bustin' Out"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 1 # Fixes vertical lines, font and others.
 SLPM-65480:
-  name: "Michigan"
+  name: michigan(ミシガン)
+  name-sort: michigan(みしがん)
+  name-en: "Michigan"
   region: "NTSC-J"
 SLPM-65481:
-  name: "After... Wasureenu Kizuna [Shokai Genteiban]"
+  name: After...〜忘れえぬ絆〜 初回限定版
+  name-sort: After...〜わすれえぬきずな〜 しょかいげんていばん
+  name-en: "After... Wasureenu Kizuna [Shokai Genteiban]"
   region: "NTSC-J"
 SLPM-65482:
-  name: "After..."
+  name: After...〜忘れえぬ絆〜 通常版
+  name-sort: After...〜わすれえぬきずな〜 つうじょうばん
+  name-en: "After..."
   region: "NTSC-J"
 SLPM-65483:
-  name: "Secret Weapons Over Normandy"
+  name: シークレット・ウェポン・オーバー・ノルマンディ
+  name-sort: しーくれっと・うぇぽん・おーばー・のるまんでぃ
+  name-en: "Secret Weapons Over Normandy"
   region: "NTSC-J"
 SLPM-65484:
-  name: "WISP - Word Image Sound Play"
+  name: wordimagesoundplay
+  name-sort: wordimagesoundplay
+  name-en: "WISP - Word Image Sound Play"
   region: "NTSC-J"
   compat: 5
 SLPM-65486:
-  name: "Airforce Delta - Blue Wing Knights"
+  name: AIRFORCE DELTA BLUE WING KNIGHTS
+  name-sort: AIRFORCE DELTA BLUE WING KNIGHTS
+  name-en: "Airforce Delta - Blue Wing Knights"
   region: "NTSC-J"
 SLPM-65488:
-  name: "Grand Theft Auto - Vice City"
+  name: Grand Theft Auto:Vice City
+  name-sort: Grand Theft Auto:Vice City
+  name-en: "Grand Theft Auto - Vice City"
   region: "NTSC-J"
 SLPM-65489:
-  name: "Tantei Jingiji Saburo - Innocent Black [WorkJam Best Collection]"
+  name: ワークジャム ベストコレクション vol.1 探偵 神宮寺三郎 Innocent Black
+  name-sort: わーくじゃむ べすとこれくしょん vol.1 たんてい じんぐうじさぶろう Innocent Black
+  name-en: "Tantei Jingiji Saburo - Innocent Black [WorkJam Best Collection]"
   region: "NTSC-J"
 SLPM-65490:
-  name: "Sanma Nisai Deus Mechanica - Demon Bane [Limited Edition]"
+  name: 機神咆吼デモンベイン DXパック
+  name-sort: ざんまたいせいでもんべいん DXぱっく
+  name-en: "Sanma Nisai Deus Mechanica - Demon Bane [Limited Edition]"
   region: "NTSC-J"
 SLPM-65491:
-  name: "Sanma Nisai Deus Mechanica - Demon Bane"
+  name: 機神咆吼デモンベイン
+  name-sort: ざんまたいせいでもんべいん
+  name-en: "Sanma Nisai Deus Mechanica - Demon Bane"
   region: "NTSC-J"
 SLPM-65492:
-  name: "GunGrave O.D."
+  name: GUNGRAVE O.D.
+  name-sort: GUNGRAVE O.D.
+  name-en: "GunGrave O.D."
   region: "NTSC-J"
 SLPM-65493:
-  name: "Hurrah! Sailor"
+  name: ふらせら Hurrah!Sailor 初回限定版
+  name-sort: ふらせら Hurrah!Sailor しょかいげんていばん
+  name-en: "Hurrah! Sailor"
   region: "NTSC-J"
 SLPM-65494:
-  name: "Fuuun Shinsengumi"
+  name: 風雲 新撰組
+  name-sort: ふううん しんせんぐみ
+  name-en: "Fuuun Shinsengumi"
   region: "NTSC-J"
 SLPM-65495:
-  name: "Monster Hunter"
+  name: モンスターハンター
+  name-sort: もんすたーはんたー
+  name-en: "Monster Hunter"
   region: "NTSC-J"
   clampModes:
     vuClampMode: 3 # Fixes lighting on character models as caves and other locations don't turn mobs into glow-in-the-dark creatures by themselves.
   gsHWFixes:
     maximumBlendingLevel: 0 # Fixes unnecessary load on the GPU.
 SLPM-65496:
-  name: "Hyper Street Fighter"
+  name: ハイパーストリートファイターII アニバーサリー エディション
+  name-sort: はいぱーすとりーとふぁいたーII あにばーさりー えでぃしょん
+  name-en: "Hyper Street Fighter"
   region: "NTSC-J"
 SLPM-65497:
-  name: "World Soccer Winning Eleven 7 - International [Limited Edition]"
+  name: ワールドサッカー ウイニングイレブン7 インターナショナル プレミアムパッケージ supported by アディダス
+  name-sort: わーるどさっかー ういにんぐいれぶん7 いんたーなしょなる ぷれみあむぱっけーじ supported by あでぃだす
+  name-en: "World Soccer Winning Eleven 7 - International [Limited Edition]"
   region: "NTSC-J"
 SLPM-65498:
-  name: "World Soccer Winning Eleven 7 - International"
+  name: ワールドサッカー ウイニングイレブン7 インターナショナル
+  name-sort: わーるどさっかー ういにんぐいれぶん7 いんたーなしょなる
+  name-en: "World Soccer Winning Eleven 7 - International"
   region: "NTSC-J"
 SLPM-65499:
-  name: "Bloody Roar 4"
+  name: BLOODY ROAR4
+  name-sort: BLOODY ROAR4
+  name-en: "Bloody Roar 4"
   region: "NTSC-J"
 SLPM-65500:
-  name: "Anubis - Zone of the Enders Special Edition"
+  name: ANUBIS ZONE OF THE ENDERS SPECIAL EDITION(通常版)
+  name-sort: ANUBIS ZONE OF THE ENDERS SPECIAL EDITION(つうじょうばん)
+  name-en: "Anubis - Zone of the Enders Special Edition"
   region: "NTSC-J"
 SLPM-65501:
-  name: "Frogger Rescue"
+  name: フロッガーレスキュー
+  name-sort: ふろっがーれすきゅー
+  name-en: "Frogger Rescue"
   region: "NTSC-J"
 SLPM-65502:
-  name: "GunGrave [Red Best Collection]"
+  name: GUNGRAVE レッドベストセレクション
+  name-sort: GUNGRAVE れっどべすとせれくしょん
+  name-en: "GunGrave [Red Best Collection]"
   region: "NTSC-J"
 SLPM-65503:
-  name: "Lord of the Rings, The - The Return of the King"
+  name: ロード・オブ・ザ・リング/王の帰還
+  name-sort: ろーど・おぶ・ざ・りんぐ/おうのきかん
+  name-en: "Lord of the Rings, The - The Return of the King"
   region: "NTSC-J"
   compat: 5
 SLPM-65504:
-  name: "Cool Girl [Limited Edition] [Disc 1 of 2]"
+  name: COOL GIRL 初回限定版
+  name-sort: COOL GIRL しょかいげんていばん
+  name-en: "Cool Girl [Limited Edition] [Disc 1 of 2]"
   region: "NTSC-J"
   memcardFilters:
     - "SLPM-65504"
@@ -34353,7 +36800,9 @@ SLPM-65505:
     - "SLPM-65506"
     - "SLPM-65742"
 SLPM-65506:
-  name: "Cool Girl"
+  name: COOL GIRL
+  name-sort: COOL GIRL
+  name-en: "Cool Girl"
   region: "NTSC-J"
   memcardFilters:
     - "SLPM-65504"
@@ -34364,100 +36813,154 @@ SLPM-65507:
   name: "Cool Girl (Disc 2) (Aska Side)"
   region: "NTSC-J"
 SLPM-65508:
-  name: "Pop'n music 9"
+  name: ポップンミュージック9
+  name-sort: ぽっぷんみゅーじっく9
+  name-en: "Pop'n music 9"
   region: "NTSC-J"
 SLPM-65509:
-  name: "Prince of Tennis - Love of Prince - Sweet"
+  name: テニスの王子様 Love of Prince Sweet
+  name-sort: てにすのおうじさま Love of Prince Sweet
+  name-en: "Prince of Tennis - Love of Prince - Sweet"
   region: "NTSC-J"
 SLPM-65510:
-  name: "Prince of Tennis - Love of Prince - Bitter"
+  name: テニスの王子様 Love of Prince Bitter
+  name-sort: てにすのおうじさま Love of Prince Bitter
+  name-en: "Prince of Tennis - Love of Prince - Bitter"
   region: "NTSC-J"
 SLPM-65512:
-  name: "Angel's Feather [Limited Edition]"
+  name: Angel’s Feather(限定版)
+  name-sort: Angel’s Feather(げんていばん)
+  name-en: "Angel's Feather [Limited Edition]"
   region: "NTSC-J"
 SLPM-65513:
-  name: "Angel's Feather"
+  name: Angel’s Feather(通常版)
+  name-sort: Angel’s Feather(つうじょうばん)
+  name-en: "Angel's Feather"
   region: "NTSC-J"
 SLPM-65514:
-  name: "Kaido Battle 2 - Chain Reaction"
+  name: 街道バトル2 CHAIN REACTION
+  name-sort: かいどうばとる2 CHAIN REACTION
+  name-en: "Kaido Battle 2 - Chain Reaction"
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
     wildArmsHack: 1 # De-blurs the 3D image.
 SLPM-65515:
-  name: "Sakura Taisen - Mysterious Paris"
+  name: サクラ大戦物語 〜ミステリアス巴里〜
+  name-sort: さくらたいせんものがたり 〜みすてりあすぱり〜
+  name-en: "Sakura Taisen - Mysterious Paris"
   region: "NTSC-J"
 SLPM-65517:
-  name: "Sengoku Musou"
+  name: 戦国無双
+  name-sort: せんごくむそう
+  name-en: "Sengoku Musou"
   region: "NTSC-J"
 SLPM-65518:
-  name: "Raimuiro Senkitan Jun [Limited Edition]"
+  name: らいむいろ戦奇譚☆純 DXパック
+  name-sort: らいむいろせんきたん☆じゅん DXぱっく
+  name-en: "Raimuiro Senkitan Jun [Limited Edition]"
   region: "NTSC-J"
 SLPM-65519:
-  name: "Raimuiro Senkitan Jun"
+  name: らいむいろ戦奇譚☆純
+  name-sort: らいむいろせんきたん☆じゅん
+  name-en: "Raimuiro Senkitan Jun"
   region: "NTSC-J"
 SLPM-65520:
-  name: "Tentama 2 Wins [Limited Edition]"
+  name: てんたま2wins(限定版)
+  name-sort: てんたま2wins(げんていばん)
+  name-en: "Tentama 2 Wins [Limited Edition]"
   region: "NTSC-J"
 SLPM-65521:
-  name: "Tentama 2 Wins"
+  name: てんたま2wins(通常版)
+  name-sort: てんたま2wins(つうじょうばん)
+  name-en: "Tentama 2 Wins"
   region: "NTSC-J"
 SLPM-65522:
   name: "Bakushou!! Jinsei Kaidou - Nova Usagi ga Miteru zo!!"
   region: "NTSC-J"
 SLPM-65523:
-  name: "Hurrah! Sailor"
+  name: ふらせら Hurrah!Sailor 通常版
+  name-sort: ふらせら Hurrah!Sailor つうじょうばん
+  name-en: "Hurrah! Sailor"
   region: "NTSC-J"
 SLPM-65524:
-  name: "Orange Pocket - Root [Limited Edition]"
+  name: オレンジポケット -リュート- 初回限定版
+  name-sort: おれんじぽけっと -りゅーと- しょかいげんていばん
+  name-en: "Orange Pocket - Root [Limited Edition]"
   region: "NTSC-J"
 SLPM-65525:
-  name: "Orange Pocket - Root"
+  name: オレンジポケット -リュート-
+  name-sort: おれんじぽけっと -りゅーと-
+  name-en: "Orange Pocket - Root"
   region: "NTSC-J"
 SLPM-65526:
-  name: "Dororo"
+  name: どろろ
+  name-sort: どろろ
+  name-en: "Dororo"
   region: "NTSC-J"
   gsHWFixes:
     minimumBlendingLevel: 2 # Fixes dark font to more bright like software mode.
 SLPM-65527:
-  name: "FIFA Total Football"
+  name: FIFAトータルフットボール
+  name-sort: FIFAとーたるふっとぼーる
+  name-en: "FIFA Total Football"
   region: "NTSC-J"
 SLPM-65529:
-  name: "Mission Impossible - Operation Surma"
+  name: ミッション:インポッシブル -オペレーション・サルマ-
+  name-sort: みっしょん:いんぽっしぶる -おぺれーしょん・さるま-
+  name-en: "Mission Impossible - Operation Surma"
   region: "NTSC-J"
 SLPM-65530:
-  name: "J-League Pro Soccer Club - Tsukuku 2004"
+  name: J.LEAGUE プロサッカークラブをつくろう!’04
+  name-sort: J.LEAGUE ぷろさっかーくらぶをつくろう!’04
+  name-en: "J-League Pro Soccer Club - Tsukuku 2004"
   region: "NTSC-J"
 SLPM-65531:
-  name: "Sakura Taisen V - Episode 0"
+  name: サクラ大戦V EPISODE 0 ～荒野のサムライ娘～
+  name-sort: さくらたいせんV EPISODE 0 ～こうやのさむらいむすめ～
+  name-en: "Sakura Taisen V - Episode 0"
   region: "NTSC-J"
 SLPM-65532:
-  name: "Puyo Puyo Fever"
+  name: ぷよぷよフィーバー
+  name-sort: ぷよぷよふぃーばー
+  name-en: "Puyo Puyo Fever"
   region: "NTSC-J"
 SLPM-65533:
-  name: "Pyu to Fuku! Jaguar Ashita no Japan"
+  name: ピューと吹く!ジャガー 明日のジャンプ (初回限定版)
+  name-sort: ぴゅーとふく!じゃがー あしたのじゃんぷ (しょかいげんていばん)
+  name-en: "Pyu to Fuku! Jaguar Ashita no Japan"
   region: "NTSC-J"
 SLPM-65534:
-  name: "Rogue Ops"
+  name: ローグオプス
+  name-sort: ろーぐおぷす
+  name-en: "Rogue Ops"
   region: "NTSC-J"
 SLPM-65535:
-  name: "Oshiete! Popotan"
+  name: おしえて! ぽぽたん
+  name-sort: おしえて! ぽぽたん
+  name-en: "Oshiete! Popotan"
   region: "NTSC-J"
 SLPM-65536:
   name: "Houshin Engi 2"
   region: "NTSC-J"
 SLPM-65537:
-  name: "Chou Battle Houshin [Koei The Best]"
+  name: KOEI The Best 超・バトル封神
+  name-sort: KOEI The Best ちょう・ばとるほうしん
+  name-en: "Chou Battle Houshin [Koei The Best]"
   region: "NTSC-J"
 SLPM-65538:
-  name: "007 - Nightfire [EA Best Hits]"
+  name: EA BEST HITS 007 ナイトファイア
+  name-sort: EA BEST HITS 007 ないとふぁいあ
+  name-en: "007 - Nightfire [EA Best Hits]"
   region: "NTSC-J"
   clampModes:
     vuClampMode: 2 # Fixes polygon clipping in driving missions.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes fog lines in the distance.
 SLPM-65539:
-  name: "V-Rally 3"
+  name: アタリホットシリーズ V-RALLY3
+  name-sort: あたりほっとしりーず V-RALLY3
+  name-en: "V-Rally 3"
   region: "NTSC-J"
   gsHWFixes:
     preloadFrameData: 1 # Fixes fog and make lights on cars work again.
@@ -34465,37 +36968,59 @@ SLPM-65539:
   gameFixes:
     - EETimingHack # Fixes random graphical corruption.
 SLPM-65540:
-  name: "Galaxy Angel - Moonlit Lovers [First Limited Edition]"
+  name: ギャラクシーエンジェル Moonlit Lovers
+  name-sort: ぎゃらくしーえんじぇる Moonlit Lovers
+  name-en: "Galaxy Angel - Moonlit Lovers [First Limited Edition]"
   region: "NTSC-J"
 SLPM-65541:
-  name: "Angelique Trois - Aizouhen [Koei The Best]"
+  name: KOEI The Best 愛蔵版 アンジェリーク トロワ
+  name-sort: KOEI The Best あいぞうばん あんじぇりーく とろわ
+  name-en: "Angelique Trois - Aizouhen [Koei The Best]"
   region: "NTSC-J"
 SLPM-65542:
-  name: "Zero Shikikan Josentoki"
+  name: 零式艦上戦闘記
+  name-sort: れいしきかんじょうせんとうき
+  name-en: "Zero Shikikan Josentoki"
   region: "NTSC-J"
 SLPM-65543:
-  name: "Pro Yakyuu Spirits 2004"
+  name: プロ野球スピリッツ 2004
+  name-sort: ぷろやきゅうすぴりっつ 2004
+  name-en: "Pro Yakyuu Spirits 2004"
   region: "NTSC-J"
 SLPM-65545:
-  name: "Juurokuya Renka - Kami Furusato"
+  name: 十六夜れんか 〜かみふるさと〜
+  name-sort: じゅうろくやれんか 〜かみふるさと〜
+  name-en: "Juurokuya Renka - Kami Furusato"
   region: "NTSC-J"
 SLPM-65546:
-  name: "Cross Channel - To All People [Limited Edition]"
+  name: CROSS+CHANNEL 〜To all people〜(限定版)
+  name-sort: CROSS+CHANNEL 〜To all people〜(げんていばん)
+  name-en: "Cross Channel - To All People [Limited Edition]"
   region: "NTSC-J"
 SLPM-65547:
-  name: "Cross Channel - To All People"
+  name: CROSS+CHANNEL 〜To all people〜
+  name-sort: CROSS+CHANNEL 〜To all people〜
+  name-en: "Cross Channel - To All People"
   region: "NTSC-J"
 SLPM-65548:
-  name: "Freedom Fighters"
+  name: フリーダム・ファイターズ
+  name-sort: ふりーだむ・ふぁいたーず
+  name-en: "Freedom Fighters"
   region: "NTSC-J"
 SLPM-65549:
-  name: "Remember 11 - The Age of Infinity [Limited Edition]"
+  name: Remember 11 〜the age of infinity〜(限定版)
+  name-sort: Remember 11 〜the age of infinity〜(げんていばん)
+  name-en: "Remember 11 - The Age of Infinity [Limited Edition]"
   region: "NTSC-J"
 SLPM-65550:
-  name: "Remember 11 - The Age of Infinity"
+  name: Remember 11 〜the age of infinity〜(通常版)
+  name-sort: Remember 11 〜the age of infinity〜(つうじょうばん)
+  name-en: "Remember 11 - The Age of Infinity"
   region: "NTSC-J"
 SLPM-65551:
-  name: "Astro Boy Atom"
+  name: ASTRO BOY 鉄腕アトム
+  name-sort: ASTRO BOY てつわんあとむ
+  name-en: "Astro Boy Atom"
   region: "NTSC-J"
   roundModes:
     eeRoundMode: 0 # Fixes character behaviour.
@@ -34503,69 +37028,109 @@ SLPM-65551:
     autoFlush: 1 # Fixes flame bloom.
     halfPixelOffset: 2 # Fixes misaligned bloom.
 SLPM-65552:
-  name: "Metal Wolf Rev [Limited Edition]"
+  name: メタルウルフREV 初回限定版
+  name-sort: めたるうるふREV しょかいげんていばん
+  name-en: "Metal Wolf Rev [Limited Edition]"
   region: "NTSC-J"
 SLPM-65553:
-  name: "Metal Wolf Rev"
+  name: メタルウルフREV 通常版
+  name-sort: めたるうるふREV つうじょうばん
+  name-en: "Metal Wolf Rev"
   region: "NTSC-J"
 SLPM-65554:
-  name: "Croket! Ban-King no Kiki o Sukue"
+  name: コロッケ!～バン王の危機を救え～
+  name-sort: ころっけ!～ばんおうのききをすくえ～
+  name-en: "Croket! Ban-King no Kiki o Sukue"
   region: "NTSC-J"
 SLPM-65555:
-  name: "Dragon Quest V - Bride of the Sky"
+  name: ドラゴンクエストV　天空の花嫁
+  name-sort: どらごんくえすとV　てんくうのはなよめ
+  name-en: "Dragon Quest V - Bride of the Sky"
   region: "NTSC-J"
   compat: 5
 SLPM-65556:
-  name: "Nobunaga no Yabou - Tenka Sousei"
+  name: 信長の野望 天下創世
+  name-sort: のぶながのやぼう てんかそうせい
+  name-en: "Nobunaga no Yabou - Tenka Sousei"
   region: "NTSC-J"
 SLPM-65557:
-  name: "Steady X Study [Limited Edition]"
+  name: ステディ×スタディ(限定版)
+  name-sort: すてでぃ×すたでぃ(げんていばん)
+  name-en: "Steady X Study [Limited Edition]"
   region: "NTSC-J"
 SLPM-65558:
-  name: "Steady X Study"
+  name: ステディ×スタディ
+  name-sort: すてでぃ×すたでぃ
+  name-en: "Steady X Study"
   region: "NTSC-J"
 SLPM-65559:
-  name: "Tenohira wo Taiyou ni [Limited Edition]"
+  name: てのひらをたいように ～永久の絆～(初回限定版)
+  name-sort: てのひらをたいように ～えいきゅうのきずな～(しょかいげんていばん)
+  name-en: "Tenohira wo Taiyou ni [Limited Edition]"
   region: "NTSC-J"
 SLPM-65560:
-  name: "Tenohira wo Taiyou ni"
+  name: てのひらをたいように ～永久の絆～
+  name-sort: てのひらをたいように ～えいきゅうのきずな～
+  name-en: "Tenohira wo Taiyou ni"
   region: "NTSC-J"
 SLPM-65561:
-  name: "Shin Sangoku Musou 3 [Super Premium Pack]"
+  name: 真・三國無双3  スーパープレミアムBOX
+  name-sort: しん・さんごくむそう3  すーぱーぷれみあむBOX
+  name-en: "Shin Sangoku Musou 3 [Super Premium Pack]"
   region: "NTSC-J"
 SLPM-65564:
-  name: "Shin Sangoku Musou 3 - Empires"
+  name: 真・三國無双3　Empires＆猛将伝 プレミアムBOX
+  name-sort: しん・さんごくむそう3　Empires＆もうしょうでん ぷれみあむBOX
+  name-en: "Shin Sangoku Musou 3 - Empires"
   region: "NTSC-J"
 SLPM-65565:
-  name: "Shin Sangoku Musou 3 - Empires"
+  name: 真・三國無双3 Empires
+  name-sort: しん・さんごくむそう3 Empires
+  name-en: "Shin Sangoku Musou 3 - Empires"
   region: "NTSC-J"
 SLPM-65566:
-  name: "La Corda d'Oro [Premium Box]"
+  name: 金色のコルダ プレミアムBOX
+  name-sort: きんいろのこるだ ぷれみあむBOX
+  name-en: "La Corda d'Oro [Premium Box]"
   region: "NTSC-J"
 SLPM-65567:
-  name: "Corda D'Oro, La"
+  name: 金色のコルダ
+  name-sort: きんいろのこるだ
+  name-en: "Corda D'Oro, La"
   region: "NTSC-J"
 SLPM-65569:
-  name: "Kita He - Diamond Dust + Kiss is Beginning"
+  name: 北へ。Diamond Dust + Kiss is Beginning
+  name-sort: きたへ。Diamond Dust + Kiss is Beginning
+  name-en: "Kita He - Diamond Dust + Kiss is Beginning"
   region: "NTSC-J"
 SLPM-65570:
-  name: "Frogger [Konami Palace Collection]"
+  name: フロッガー(コナミ殿堂セレクション)
+  name-sort: ふろっがー(こなみでんどうせれくしょん)
+  name-en: "Frogger [Konami Palace Collection]"
   region: "NTSC-J"
 SLPM-65571:
-  name: "Generation of Chaos 4 [Limited Edition]"
+  name: 新天魔界 GENERATION OF CHAOS 4 限定版
+  name-sort: しんてんまかい GENERATION OF CHAOS 4 げんていばん
+  name-en: "Generation of Chaos 4 [Limited Edition]"
   region: "NTSC-J"
 SLPM-65572:
-  name: "Generation of Chaos 4"
+  name: 新天魔界 GENERATION OF CHAOS 4
+  name-sort: しんてんまかい GENERATION OF CHAOS 4
+  name-en: "Generation of Chaos 4"
   region: "NTSC-J"
 SLPM-65573:
-  name: "WRC II Extreme [Spike The Best]"
+  name: Spike The Best WRC II ～EXTREME～
+  name-sort: Spike The Best WRC II ～EXTREME～
+  name-en: "WRC II Extreme [Spike The Best]"
   region: "NTSC-J"
   gameFixes:
     - XGKickHack # Fixes SPS.
   gsHWFixes:
     halfPixelOffset: 1 # Fixes texture misalignment.
 SLPM-65574:
-  name: "Silent Hill 4 - The Room"
+  name: サイレントヒル4 THE ROOM
+  name-sort: さいれんとひる4 THE ROOM
+  name-en: "Silent Hill 4 - The Room"
   region: "NTSC-J"
   compat: 5
   speedHacks:
@@ -34573,7 +37138,9 @@ SLPM-65574:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes dark sides.
 SLPM-65575:
-  name: "Crimson Tears"
+  name: クリムゾン・ティアーズ
+  name-sort: くりむぞん・てぃあーず
+  name-en: "Crimson Tears"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
@@ -34581,22 +37148,34 @@ SLPM-65575:
     roundSprite: 2 # Reduces misalignment bloom effects.
 #    deinterlace: 6 # Game requires blend tff de-interlacing when auto for 'fixing' shimmer on character models and more flickering or half weaved, though the game suffers from the field order.
 SLPM-65576:
-  name: "Tantei Jinguuji Saburou - Kind of Blue"
+  name: 探偵 神宮寺三郎 KIND OF BLUE
+  name-sort: たんてい じんぐうじさぶろう KIND OF BLUE
+  name-en: "Tantei Jinguuji Saburou - Kind of Blue"
   region: "NTSC-J"
 SLPM-65579:
-  name: "Houkago no Love Beat"
+  name: 放課後のLove Beat
+  name-sort: ほうかごのLove Beat
+  name-en: "Houkago no Love Beat"
   region: "NTSC-J"
 SLPM-65580:
-  name: "Crash Bandicoot - Bakuso! Nitro Kart"
+  name: クラッシュ・バンディクー爆走!ニトロカート
+  name-sort: くらっしゅ・ばんでぃくーばくそう!にとろかーと
+  name-en: "Crash Bandicoot - Bakuso! Nitro Kart"
   region: "NTSC-J"
 SLPM-65581:
-  name: "Haunted Mansion"
+  name: ホーンテッドマンション
+  name-sort: ほーんてっどまんしょん
+  name-en: "Haunted Mansion"
   region: "NTSC-J"
 SLPM-65582:
-  name: "Winning Post 6 Maximum 2004"
+  name: Winning Post6 MAXIMUM 2004
+  name-sort: Winning Post6 MAXIMUM 2004
+  name-en: "Winning Post 6 Maximum 2004"
   region: "NTSC-J"
 SLPM-65583:
-  name: "WRC 3"
+  name: WRC3
+  name-sort: WRC3
+  name-en: "WRC 3"
   region: "NTSC-J"
   compat: 5
   gameFixes:
@@ -34608,123 +37187,193 @@ SLPM-65584:
   name: "Shin Sangoku Musou 3 - Moushouden"
   region: "NTSC-J"
 SLPM-65585:
-  name: "Princess Holiday"
+  name: Princess Holiday～転がるりんご亭千夜一夜～
+  name-sort: Princess Holiday～ころがるりんごていせんやいちや～
+  name-en: "Princess Holiday"
   region: "NTSC-J"
 SLPM-65586:
-  name: "Online Pro Wrestling"
+  name: オンラインプロレスリング
+  name-sort: おんらいんぷろれすりんぐ
+  name-en: "Online Pro Wrestling"
   region: "NTSC-J"
 SLPM-65587:
-  name: "Fight Night 2004"
+  name: EA SPORTS ファイトナイト 2004
+  name-sort: EA SPORTS ふぁいとないと 2004
+  name-en: "Fight Night 2004"
   region: "NTSC-J"
 SLPM-65588:
-  name: "Colorful Box - To Love [Limited Edition]"
+  name: カラフルBOX 〜to LOVE〜 （初回限定版）
+  name-sort: からふるBOX 〜to LOVE〜 （しょかいげんていばん）
+  name-en: "Colorful Box - To Love [Limited Edition]"
   region: "NTSC-J"
 SLPM-65589:
-  name: "Colorful Box - To Love"
+  name: カラフルBOX 〜to LOVE〜
+  name-sort: からふるBOX 〜to LOVE〜
+  name-en: "Colorful Box - To Love"
   region: "NTSC-J"
 SLPM-65590:
-  name: "Densha de Go! Final"
+  name: 電車でGO! -FINAL-
+  name-sort: でんしゃでGO! -FINAL-
+  name-en: "Densha de Go! Final"
   region: "NTSC-J"
 SLPM-65591:
-  name: "Lost Aya Sophia [Limited Edition]"
+  name: ロスト・アヤ・ソフィア(限定版)
+  name-sort: ろすと・あや・そふぃあ(げんていばん)
+  name-en: "Lost Aya Sophia [Limited Edition]"
   region: "NTSC-J"
 SLPM-65592:
-  name: "Lost Aya Sophia"
+  name: ロスト・アヤ・ソフィア
+  name-sort: ろすと・あや・そふぃあ
+  name-en: "Lost Aya Sophia"
   region: "NTSC-J"
 SLPM-65593:
-  name: "Beatmania IIDX 7th Style"
+  name: beatmania IIDX 7th style
+  name-sort: beatmania IIDX 7th style
+  name-en: "Beatmania IIDX 7th style"
   region: "NTSC-J"
 SLPM-65594:
-  name: "Iris no Atelier - Eternal Mana"
+  name: イリスのアトリエ エターナルマナ
+  name-sort: いりすのあとりえ えたーなるまな
+  name-en: "Iris no Atelier - Eternal Mana"
   region: "NTSC-J"
 SLPM-65595:
-  name: "Shoubushi Gambler Densetsu - Tetsuya 2 [Athena Best]"
+  name: 勝負師伝説 哲也2 玄人頂上決戦
+  name-sort: しょうぶしでんせつ てつや2 くろうとちょうじょうけっせん
+  name-en: "Shoubushi Gambler Densetsu - Tetsuya 2 [Athena Best]"
   region: "NTSC-J"
 SLPM-65596:
-  name: "Juuni Kuniki - Kakukaku Taru Ou Michi Beni Midori no Uka"
+  name: 十二国記 赫々たる王道紅緑の羽化
+  name-sort: じゅうにこくき かくかくたるおうどうこうりょくのうか
+  name-en: "Juuni Kuniki - Kakukaku Taru Ou Michi Beni Midori no Uka"
   region: "NTSC-J"
 SLPM-65597:
-  name: "Digital Devil Saga - Avatar Tuner"
+  name: DIGITAL DEVIL SAGA(デジタル・デビル・サーガ)〜アバタール・チューナー〜
+  name-sort: DIGITAL DEVIL SAGA(でじたる・でびる・さーが)〜あばたーる・ちゅーなー〜
+  name-en: "Digital Devil Saga - Avatar Tuner"
   region: "NTSC-J"
   gameFixes:
     - EETimingHack
 SLPM-65598:
-  name: "Tenshou Gakuen Kensousoku"
+  name: 転生學園 幻蒼録
+  name-sort: てんしょうがくえん げんそうろく
+  name-en: "Tenshou Gakuen Kensousoku"
   region: "NTSC-J"
 SLPM-65599:
-  name: "Genso Suikoden 4 [Limited Edition]"
+  name: 幻想水滸伝IV 限定版
+  name-sort: げんそうすいこでんIV げんていばん
+  name-en: "Genso Suikoden 4 [Limited Edition]"
   region: "NTSC-J"
 SLPM-65600:
-  name: "Genso Suikoden 4"
+  name: 幻想水滸伝IV
+  name-sort: げんそうすいこでんIV
+  name-en: "Genso Suikoden 4"
   region: "NTSC-J"
 SLPM-65601:
-  name: "Omoide ni Kawaru-Kimi - Memories Off [SuperLite 2000 Series]"
+  name: SuperLite 2000思い出にかわる君～Memories Off～
+  name-sort: SuperLite 2000おもいでにかわるきみ～Memories Off～
+  name-en: "Omoide ni Kawaru-Kimi - Memories Off [SuperLite 2000 Series]"
   region: "NTSC-J"
 SLPM-65602:
-  name: "King of Colosseum 2"
+  name: キングオブコロシアム II
+  name-sort: きんぐおぶころしあむ II
+  name-en: "King of Colosseum 2"
   region: "NTSC-J"
   compat: 5
 SLPM-65603:
-  name: "Run Like Hell"
+  name: ラン・ライク・ヘル
+  name-sort: らん・らいく・へる
+  name-en: "Run Like Hell"
   region: "NTSC-J"
 SLPM-65604:
-  name: "Anime Battle - Rekka no Honoo - Flame of Recca - Final Burning"
+  name: アニメバトル 烈火の炎 FINAL BURNING <初回生産限定仕様>
+  name-sort: あにめばとる れっかのほのお FINAL BURNING <しょかいせいさんげんていしよう>
+  name-en: "Anime Battle - Rekka no Honoo - Flame of Recca - Final Burning"
   region: "NTSC-J"
   compat: 5
 SLPM-65607:
-  name: "3LDK - Shiawase ni Narou yo [Limited Edition]"
+  name: 3LDK 〜幸せになろうよ〜(初回限定版)
+  name-sort: 3LDK 〜しあわせになろうよ〜(しょかいげんていばん)
+  name-en: "3LDK - Shiawase ni Narou yo [Limited Edition]"
   region: "NTSC-J"
 SLPM-65608:
-  name: "3LDK - Shiawase ni Narou yo"
+  name: 3LDK ～幸せになろうよ～
+  name-sort: 3LDK ～しあわせになろうよ～
+  name-en: "3LDK - Shiawase ni Narou yo"
   region: "NTSC-J"
 SLPM-65609:
-  name: "Memories Off... - Sorekara [Limited Edition]"
+  name: メモリーズ・オフ～それから～ 限定版
+  name-sort: めもりーず・おふ～それから～ げんていばん
+  name-en: "Memories Off... - Sorekara [Limited Edition]"
   region: "NTSC-J"
 SLPM-65610:
-  name: "Memories Off... - Sorekara"
+  name: メモリーズ・オフ〜それから〜 通常版
+  name-sort: めもりーず・おふ〜それから〜 つうじょうばん
+  name-en: "Memories Off... - Sorekara"
   region: "NTSC-J"
 SLPM-65611:
-  name: "Pizzicato Polka"
+  name: PIZZICATO POLKA ～縁鎖現夜～
+  name-sort: PIZZICATO POLKA ～えんさげんや～
+  name-en: "Pizzicato Polka"
   region: "NTSC-J"
 SLPM-65612:
-  name: "Harry Potter to Azkaban no Shuujin"
+  name: ハリー・ポッターとアズカバンの囚人
+  name-sort: はりー・ぽったーとあずかばんのしゅうじん
+  name-en: "Harry Potter to Azkaban no Shuujin"
   region: "NTSC-J"
   gsHWFixes:
     mipmap: 1
     cpuFramebufferConversion: 1 # Fixes right side of the screen from garbage textures.
     halfPixelOffset: 2 # Aligns mirror reflections, removes some bloom-related ghosting.
 SLPM-65613:
-  name: "Yu-Gi-Oh! Capsule Monster Coliseum"
+  name: 遊戯王 カプセルモンスターコロシアム
+  name-sort: ゆうぎおう かぷせるもんすたーころしあむ
+  name-en: "Yu-Gi-Oh! Capsule Monster Coliseum"
   region: "NTSC-J"
 SLPM-65614:
-  name: "Need for Speed - Underground J"
+  name: EA BEST HITS ニード・フォー・スピード アンダーグラウンド
+  name-sort: EA BEST HITS にーど・ふぉー・すぴーど あんだーぐらうんど
+  name-en: "Need for Speed - Underground J"
   region: "NTSC-J"
   gameFixes:
     - EETimingHack # Broken textures.
 SLPM-65615:
-  name: "Dokapon DX"
+  name: ドカポンDX -わたる世界はオニだらけ-
+  name-sort: どかぽんDX -わたるせかいはおにだらけ-
+  name-en: "Dokapon DX"
   region: "NTSC-J"
 SLPM-65616:
-  name: "Juunikoku-ki - Guren no Shirube Koejin no Michi [Konami The Best]"
+  name: 十二国記-紅蓮の標 黄塵の路-(コナミ・ザ・ベスト)
+  name-sort: じゅうにこくき-ぐれんのしるべ こうじんのみち-(こなみ・ざ・べすと)
+  name-en: "Juunikoku-ki - Guren no Shirube Koejin no Michi [Konami The Best]"
   region: "NTSC-J"
 SLPM-65617:
-  name: "Bouken Jidai Katsugeki Goemon [Konami Collection]"
+  name: 冒険時代活劇ゴエモン(コナミ殿堂セレクション)
+  name-sort: ぼうけんじだいかつげきごえもん(こなみでんどうせれくしょん)
+  name-en: "Bouken Jidai Katsugeki Goemon [Konami Collection]"
   region: "NTSC-J"
 SLPM-65618:
   name: "Vampire Panic"
   region: "NTSC-J"
 SLPM-65619:
-  name: "Tom Clancy's Ghost Recon - Jungle Storm"
+  name: トム・クランシーシリーズ ゴーストリコン ジャングルストーム
+  name-sort: とむ・くらんしーしりーず ごーすとりこん じゃんぐるすとーむ
+  name-en: "Tom Clancy's Ghost Recon - Jungle Storm"
   region: "NTSC-J"
 SLPM-65620:
-  name: "Akudaikan 2 - Mousouden [Global The Best]"
+  name: グローバル ザ・ベスト 悪代官2～妄想伝～
+  name-sort: ぐろーばる ざ・べすと あくだいかん2～もうそうでん～
+  name-en: "Akudaikan 2 - Mousouden [Global The Best]"
   region: "NTSC-J"
 SLPM-65621:
-  name: "Street Fighter III - 3rd Strike"
+  name: ストリートファイター III 3rd STRIKE
+  name-sort: すとりーとふぁいたー III 3rd STRIKE
+  name-en: "Street Fighter III - 3rd Strike"
   region: "NTSC-J"
   compat: 5
 SLPM-65622:
-  name: "Silent Hill 3 [Konami The Best]"
+  name: サイレントヒル3 (コナミ・ザ・ベスト)
+  name-sort: さいれんとひる3 (こなみ・ざ・べすと)
+  name-en: "Silent Hill 3 [Konami The Best]"
   region: "NTSC-J"
   clampModes:
     vuClampMode: 2 # Fixes some lighting/shadow artefacts (most light sources like the Flashlight are unaffected).
@@ -34739,118 +37388,182 @@ SLPM-65622:
     - "SLPM-65341"
     - "SLPM-65631"
 SLPM-65623:
-  name: "Tantei Gakuen Q - Kiokan no Satsui [Konami The Best]"
+  name: 探偵学園Q奇翁館の殺意(コナミ ザ ベスト)
+  name-sort: たんていがくえんQきおきなかんのさつい(こなみ ざ べすと)
+  name-en: "Tantei Gakuen Q - Kiokan no Satsui [Konami The Best]"
   region: "NTSC-J"
 SLPM-65624:
-  name: "Dear Boys Fast Break! [Konami Palace Collection]"
+  name: DEAR BOYS Fast Break!(コナミ殿堂セレクション)
+  name-sort: DEAR BOYS Fast Break!(こなみでんどうせれくしょん)
+  name-en: "Dear Boys Fast Break! [Konami Palace Collection]"
   region: "NTSC-J"
 SLPM-65625:
-  name: "Ashita no Joe - Masshiro ni Moetsukuru [Konami The Best]"
+  name: あしたのジョー～まっ白に燃え尽きろ!～(コナミ ザ ベスト)
+  name-sort: あしたのじょー～まっしろにもえつきろ!～(こなみ ざ べすと)
+  name-en: "Ashita no Joe - Masshiro ni Moetsukuru [Konami The Best]"
   region: "NTSC-J"
 SLPM-65626:
-  name: "Kyoufu Shinbun (Heisei-Han) Kaiki! Shinrei File [Konami The Best]"
+  name: 恐怖新聞【平成版】～怪奇!心霊ファイル～(コナミ ザ ベスト)
+  name-sort: きょうふしんぶん【へいせいばん】～かいき!しんれいふぁいる～(こなみ ざ べすと)
+  name-en: "Kyoufu Shinbun (Heisei-Han) Kaiki! Shinrei File [Konami The Best]"
   region: "NTSC-J"
 SLPM-65627:
-  name: "Gegege no Kitarou [Konami The Best]"
+  name: ゲゲゲの鬼太郎 異聞妖怪奇譚  コナミ・ザ・ベスト
+  name-sort: げげげのきたろう いぶんようかいきたん  こなみ・ざ・べすと
+  name-en: "Gegege no Kitarou [Konami The Best]"
   region: "NTSC-J"
 SLPM-65628:
-  name: "Konohana Pack Vol.21 - 3-tsu no Jikenbo [SuperLite 2000 Series]"
+  name: SuperLite 2000 アドベンチャー此花パック～3つの事件簿～
+  name-sort: SuperLite 2000 あどべんちゃーこのはなぱっく～3つのじけんぼ～
+  name-en: "Konohana Pack Vol.21 - 3-tsu no Jikenbo [SuperLite 2000 Series]"
   region: "NTSC-J"
 SLPM-65629:
-  name: "Kappa no Kai-Kata - How to Breed Kappas"
+  name: カッパの飼い方 -How to breed kappas-
+  name-sort: かっぱのかいかた -How to breed kappas-
+  name-en: "Kappa no Kai-Kata - How to Breed Kappas"
   region: "NTSC-J"
 SLPM-65630:
-  name: "Jikkyou Powerful Pro Yakyuu 11"
+  name: 実況パワフルプロ野球11
+  name-sort: じっきょうぱわふるぷろやきゅう11
+  name-en: "Jikkyou Powerful Pro Yakyuu 11"
   region: "NTSC-J"
 SLPM-65631:
-  name: "Silent Hill 2 [Konami The Best]"
+  name: サイレントヒル2 最後の詩 (コナミ殿堂セレクション)
+  name-sort: さいれんとひる2 さいごのし (こなみでんどうせれくしょん)
+  name-en: "Silent Hill 2 [Konami The Best]"
   region: "NTSC-J"
   speedHacks:
     instantVU1: 0 # Fixes hang on FMV's when CDVD timing is accurate.
     mtvu: 0
 SLPM-65632:
-  name: "Virtua Fighter Cyber Generation - Ambition of the Judgement Six"
+  name: バーチャファイターサイバージェネレーション ～ジャッジメントシックスの野望～
+  name-sort: ばーちゃふぁいたーさいばーじぇねれーしょん ～じゃっじめんとしっくすのやぼう～
+  name-en: "Virtua Fighter Cyber Generation - Ambition of the Judgement Six"
   region: "NTSC-J"
   compat: 5
 SLPM-65633:
-  name: "I Love Baseball - Pro Yakyuu wo Koyonaku Aisuru Hito Tachi e"
+  name: アイラブベースボール プロ野球をこよなく愛する人達へ
+  name-sort: あいらぶべーすぼーる ぷろやきゅうをこよなくあいするひとたちへ
+  name-en: "I Love Baseball - Pro Yakyuu wo Koyonaku Aisuru Hito Tachi e"
   region: "NTSC-J"
 SLPM-65634:
-  name: "Summer Girl - Promised Summer"
+  name: 夏少女 Promised Summer
+  name-sort: なつしょうじょ Promised Summer
+  name-en: "Summer Girl - Promised Summer"
   region: "NTSC-J"
 SLPM-65635:
-  name: "Bakuen Kakeshi Neverland Senki Zero"
+  name: 爆炎覚醒 ネバーランド戦記ZERO
+  name-sort: 爆炎かくせい ねばーらんどせんきZERO
+  name-en: "Bakuen Kakeshi Neverland Senki Zero"
   region: "NTSC-J"
 SLPM-65636:
-  name: "Sangokushi Senki 2 [Koei The Best]"
+  name: KOEI The Best 三國志戦記2
+  name-sort: KOEI The Best さんごくしせんき2
+  name-en: "Sangokushi Senki 2 [Koei The Best]"
   region: "NTSC-J"
 SLPM-65637:
-  name: "Rakugaki Oukoku 2 - Majo no Tataki"
+  name: ラクガキ王国2 ～魔王城の戦い～
+  name-sort: らくがきおうこく2 ～まおうじょうのたたかい～
+  name-en: "Rakugaki Oukoku 2 - Majo no Tataki"
   region: "NTSC-J"
   compat: 5
 SLPM-65638:
-  name: "Full House Kiss"
+  name: フルハウスキス
+  name-sort: ふるはうすきす
+  name-en: "Full House Kiss"
   region: "NTSC-J"
 SLPM-65639:
-  name: "Party Shana Nanco [Limited Edition]"
+  name: パティシエなにゃんこ ～初恋はいちご味～ 限定版
+  name-sort: ぱてぃしえなにゃんこ ～はつこいはいちごあじ～ げんていばん
+  name-en: "Party Shana Nanco [Limited Edition]"
   region: "NTSC-J"
 SLPM-65640:
-  name: "Party Shana Nanco"
+  name: パティシエなにゃんこ ～初恋はいちご味～
+  name-sort: ぱてぃしえなにゃんこ ～はつこいはいちごあじ～
+  name-en: "Party Shana Nanco"
   region: "NTSC-J"
 SLPM-65641:
-  name: "Utau - Tumbling Dice"
+  name: うたう♪タンブリング・ダイス ～私たち3人、あ・げ・る～
+  name-sort: うたう♪たんぶりんぐ・だいす ～わたしたち3にん、あ・げ・る～
+  name-en: "Utau - Tumbling Dice"
   region: "NTSC-J"
 SLPM-65642:
-  name: "Meiwaku Seijin Panic Maker"
+  name: めいわく星人 パニックメーカー
+  name-sort: めいわくせいじん ぱにっくめーかー
+  name-en: "Meiwaku Seijin Panic Maker"
   region: "NTSC-J"
   compat: 5
 SLPM-65643:
-  name: "RockMan X - Command Mission"
+  name: ロックマンX コマンドミッション
+  name-sort: ろっくまんX こまんどみっしょん
+  name-en: "RockMan X - Command Mission"
   region: "NTSC-J"
   clampModes:
     vu1ClampMode: 3 # Fixes the trophies.
 SLPM-65644:
-  name: "Guilty Gear Isuka"
+  name: ギルティギア イスカ
+  name-sort: ぎるてぃぎあ いすか
+  name-en: "Guilty Gear Isuka"
   region: "NTSC-J"
 SLPM-65646:
   name: "Komorebi no Namikimichi - Utsurikawaru Kisetsu no Naka de"
   region: "NTSC-J"
 SLPM-65647:
-  name: "Yu-Gi-Oh! 2 [Konami Dendou Collection]"
+  name: 遊戯王真デュエルモンスターズ II 継承されし記憶(コナミ殿堂セレクション)
+  name-sort: ゆうぎおうまでゅえるもんすたーず II けいしょうされしきおく(こなみでんどうせれくしょん)
+  name-en: "Yu-Gi-Oh! 2 [Konami Dendou Collection]"
   region: "NTSC-J"
   roundModes:
     eeRoundMode: 2 # Partially fixes battle animation.
   clampModes:
     eeClampMode: 2 # Partially fixes battle animation.
 SLPM-65648:
-  name: "Medal of Honor - Frontline [EA Best Hits]"
+  name: EA BEST HITS メダルオブオナー 史上最大の作戦
+  name-sort: EA BEST HITS めだるおぶおなー しじょうさいだいのさくせん
+  name-en: "Medal of Honor - Frontline [EA Best Hits]"
   region: "NTSC-J"
 SLPM-65649:
-  name: "NBA Street Vol. 2 [EA Best Hits]"
+  name: EA BEST HITS NBAストリート2 ダンク天国
+  name-sort: EA BEST HITS NBAすとりーと2 だんくてんごく
+  name-en: "NBA Street Vol. 2 [EA Best Hits]"
   region: "NTSC-J"
 SLPM-65650:
-  name: "Harry Potter and the Sorcerer's Stone [EA Best Hits]"
+  name: EA BEST HITS ハリー・ポッターと賢者の石
+  name-sort: EA BEST HITS はりー・ぽったーとけんじゃのいし
+  name-en: "Harry Potter and the Sorcerer's Stone [EA Best Hits]"
   region: "NTSC-J"
 SLPM-65651:
-  name: "Kowloon Youma Gakuenki [Limited Edition]"
+  name: 九龍妖魔學園紀(デラックスパック)
+  name-sort: くうろんようまがくえんき(でらっくすぱっく)
+  name-en: "Kowloon Youma Gakuenki [Limited Edition]"
   region: "NTSC-J"
 SLPM-65652:
-  name: "Kowloon Youma Gakuenki"
+  name: 九龍妖魔學園紀
+  name-sort: くうろんようまがくえんき
+  name-en: "Kowloon Youma Gakuenki"
   region: "NTSC-J"
 SLPM-65653:
-  name: "Darling Special Backlash - Koi no Exhaust Heat"
+  name: Darling Special Backlash ～恋のエキゾースト・ヒート～
+  name-sort: Darling Special Backlash ～こいのえきぞーすと・ひーと～
+  name-en: "Darling Special Backlash - Koi no Exhaust Heat"
   region: "NTSC-J"
 SLPM-65654:
-  name: "Kaiketsu! Osabakiina"
+  name: 解決!オサバキーナ
+  name-sort: かいけつ!おさばきーな
+  name-en: "Kaiketsu! Osabakiina"
   region: "NTSC-J"
 SLPM-65655:
-  name: "Finding Nemo [Yuke's The Best]"
+  name: ファインディング・ニモ YUKE’S the BEST
+  name-sort: ふぁいんでぃんぐ・にも YUKE’S the BEST
+  name-en: "Finding Nemo [Yuke's The Best]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
     alignSprite: 1 # Fixes vertical lines.
 SLPM-65657:
-  name: "World Soccer Winning Eleven 8"
+  name: ワールドサッカーウイニングイレブン8
+  name-sort: わーるどさっかーういにんぐいれぶん8
+  name-en: "World Soccer Winning Eleven 8"
   region: "NTSC-J"
 SLPM-65660:
   name: "Shirachuu Tankenbu"
@@ -34867,79 +37580,123 @@ SLPM-65662:
     halfPixelOffset: 2 # Fixes shadows.
     gpuPaletteConversion: 0 # Stops potential crashes from too many palette textures.
 SLPM-65663:
-  name: "Zwei!!"
+  name: ツヴァイ!!
+  name-sort: つゔぁい!!
+  name-en: "Zwei!!"
   region: "NTSC-J"
   gsHWFixes:
     roundSprite: 1 # Fixes vertical lines.
 SLPM-65664:
-  name: "Memories Off... Duet [SuperLite 2000 Series]"
+  name: SuperLite 2000 恋愛アドベンチャー Memories Off Duet
+  name-sort: SuperLite 2000 れんあいあどべんちゃー Memories Off Duet
+  name-en: "Memories Off... Duet [SuperLite 2000 Series]"
   region: "NTSC-J"
 SLPM-65665:
-  name: "BloodRayne"
+  name: ブラッドレイン
+  name-sort: ぶらっどれいん
+  name-en: "BloodRayne"
   region: "NTSC-J"
 SLPM-65666:
-  name: "NBA Live 2004 [EA Best Hits]"
+  name: EA BEST HITS NBAライブ2004
+  name-sort: EA BEST HITS NBAらいぶ2004
+  name-en: "NBA Live 2004 [EA Best Hits]"
   region: "NTSC-J"
   clampModes:
     vuClampMode: 2 # Missing geometry with microVU.
 SLPM-65668:
-  name: "Spectral Force - Radical Elements [Limited Edition]"
+  name: スペクトラルフォース ラジカルエレメンツ 限定版
+  name-sort: すぺくとらるふぉーす らじかるえれめんつ げんていばん
+  name-en: "Spectral Force - Radical Elements [Limited Edition]"
   region: "NTSC-J"
 SLPM-65669:
-  name: "Spectral Force - Radical Elements"
+  name: スペクトラルフォース ラジカルエレメンツ
+  name-sort: すぺくとらるふぉーす らじかるえれめんつ
+  name-en: "Spectral Force - Radical Elements"
   region: "NTSC-J"
 SLPM-65670:
-  name: "Aqua Kids"
+  name: アクアキッズ
+  name-sort: あくあきっず
+  name-en: "Aqua Kids"
   region: "NTSC-J"
 SLPM-65671:
-  name: "W - Wish [Limited Edition]"
+  name: W 〜ウィッシュ〜(初回限定版)
+  name-sort: W 〜うぃっしゅ〜(しょかいげんていばん)
+  name-en: "W - Wish [Limited Edition]"
   region: "NTSC-J"
 SLPM-65672:
-  name: "W - Wish"
+  name: W 〜ウィッシュ〜
+  name-sort: W 〜うぃっしゅ〜
+  name-en: "W - Wish"
   region: "NTSC-J"
 SLPM-65673:
   name: "Sangokushi IX [with Power-Up Kit]"
   region: "NTSC-J"
 SLPM-65674:
-  name: "Taikou Risshiden V"
+  name: 太閤立志伝V
+  name-sort: たいこうりっしでんV
+  name-en: "Taikou Risshiden V"
   region: "NTSC-J"
 SLPM-65675:
-  name: "Final Approach [Limited Edition]"
+  name: ふぁいなる・アプローチ (初回限定版)
+  name-sort: ふぁいなる・あぷろーち (しょかいげんていばん)
+  name-en: "Final Approach [Limited Edition]"
   region: "NTSC-J"
 SLPM-65676:
-  name: "Final Approach"
+  name: ふぁいなる・アプローチ
+  name-sort: ふぁいなる・あぷろーち
+  name-en: "Final Approach"
   region: "NTSC-J"
 SLPM-65677:
-  name: "Prince of Tennis - Smash Hit! [Konami The Best]"
+  name: テニスの王子様 Smash Hit!(コナミ ザ ベスト)
+  name-sort: てにすのおうじさま Smash Hit!(こなみ ざ べすと)
+  name-en: "Prince of Tennis - Smash Hit! [Konami The Best]"
   region: "NTSC-J"
 SLPM-65678:
-  name: "Prince of Tennis - Smash Hit! 2 [Konami The Best]"
+  name: テニスの王子様 Smash Hit!2(コナミ ザ ベスト)
+  name-sort: てにすのおうじさま Smash Hit!2(こなみ ざ べすと)
+  name-en: "Prince of Tennis - Smash Hit! 2 [Konami The Best]"
   region: "NTSC-J"
 SLPM-65679:
-  name: "Prince of Tennis - Sweat 2 [Konami The Best]"
+  name: テニスの王子様 SWEAT＆TEARS 2(コナミ ザ ベスト)
+  name-sort: てにすのおうじさま SWEAT＆TEARS 2(こなみ ざ べすと)
+  name-en: "Prince of Tennis - Sweat 2 [Konami The Best]"
   region: "NTSC-J"
 SLPM-65680:
-  name: "Prince of Tennis - Make the Strongest Team"
+  name: テニスの王子様 最強チームを結成せよ!
+  name-sort: てにすのおうじさま さいきょうちーむをけっせいせよ!
+  name-en: "Prince of Tennis - Make the Strongest Team"
   region: "NTSC-J"
 SLPM-65681:
-  name: "Monochrome [Limited Edition]"
+  name: Monochrome(モノクローム) 初回限定版
+  name-sort: Monochrome(ものくろーむ) しょかいげんていばん
+  name-en: "Monochrome [Limited Edition]"
   region: "NTSC-J"
 SLPM-65682:
-  name: "Monochrome"
+  name: Monochrome(モノクローム)
+  name-sort: Monochrome(ものくろーむ)
+  name-en: "Monochrome"
   region: "NTSC-J"
 SLPM-65683:
-  name: "Violet no Atelier - Gramnad no Renkinjutsushi [Gust Best Price]"
+  name: ガストベストプライス ヴィオラートのアトリエ～グラムナートの錬金術士2～
+  name-sort: がすとべすとぷらいす ゔぃおらーとのあとりえ～ぐらむなーとのれんきんじゅつし2～
+  name-en: "Violet no Atelier - Gramnad no Renkinjutsushi [Gust Best Price]"
   region: "NTSC-J"
   gsHWFixes:
     roundSprite: 1 # Aligns text boxes.
 SLPM-65684:
-  name: "Meine Liebe - Yuubinaru Kioku"
+  name: マイネリーベ 優美なる記憶
+  name-sort: まいねりーべ ゆうびなるきおく
+  name-en: "Meine Liebe - Yuubinaru Kioku"
   region: "NTSC-J"
 SLPM-65685:
-  name: "Stella Deus"
+  name: Stella Deus(ステラデウス)
+  name-sort: Stella Deus(すてらでうす)
+  name-en: "Stella Deus"
   region: "NTSC-J"
 SLPM-65686:
-  name: "Berserk - Millennium Falcon-hen - Seima Senki no Shou [Branded Box]"
+  name: ベルセルク 千年帝国の鷹(ミレニアム・ファルコン)篇 聖魔戦記の章 限定版
+  name-sort: べるせるく みれにあむ・ふぁるこんへん せいませんきのしょう げんていばん
+  name-en: "Berserk - Millennium Falcon-hen - Seima Senki no Shou [Branded Box]"
   region: "NTSC-J"
   gsHWFixes:
     preloadFrameData: 1 # Partially fixes HUD elements.
@@ -34948,14 +37705,18 @@ SLPM-65686:
   gameFixes:
     - SoftwareRendererFMVHack # Fixes subtitles not showing during FMVs.
 SLPM-65687:
-  name: "Star Wars - Battlefront"
+  name: スター・ウォーズ バトルフロント
+  name-sort: すたー・うぉーず ばとるふろんと
+  name-en: "Star Wars - Battlefront"
   region: "NTSC-J"
   gsHWFixes:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
     recommendedBlendingLevel: 3 # Improves reflections on certain characters and objects on certain levels.
 SLPM-65688:
-  name: "Berserk - Millennium Falcon-hen - Seima Senki no Shou"
+  name: ベルセルク 千年帝国の鷹(ミレニアム・ファルコン)篇 聖魔戦記の章 通常版
+  name-sort: べるせるく みれにあむ・ふぁるこんへん せいませんきのしょう つうじょうばん
+  name-en: "Berserk - Millennium Falcon-hen - Seima Senki no Shou"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
@@ -34965,17 +37726,25 @@ SLPM-65688:
   gameFixes:
     - SoftwareRendererFMVHack # Fixes subtitles not showing during FMVs.
 SLPM-65689:
-  name: "Never 7 - The End of Infinity [SuperLite 2000 Series]"
+  name: SuperLite 2000 恋愛アドベンチャー Never7～the end of infinity～
+  name-sort: SuperLite 2000 れんあいあどべんちゃー Never7～the end of infinity～
+  name-en: "Never 7 - The End of Infinity [SuperLite 2000 Series]"
   region: "NTSC-J"
 SLPM-65690:
-  name: "Konohana 4 - Yami wo Harau Inori"
+  name: 此花4～闇を祓う祈り～
+  name-sort: このはな4～やみをはらういのり～
+  name-en: "Konohana 4 - Yami wo Harau Inori"
   region: "NTSC-J"
   compat: 5
 SLPM-65691:
-  name: "Ever 17 - Out of Infinity [SuperLite 2000 Series]"
+  name: SuperLite 2000 恋愛アドベンチャー Ever17 〜the out of infinity〜 Premium Edition
+  name-sort: SuperLite 2000 れんあいあどべんちゃー Ever17 〜the out of infinity〜 Premium Edition
+  name-en: "Ever 17 - Out of Infinity [SuperLite 2000 Series]"
   region: "NTSC-J"
 SLPM-65692:
-  name: "BioHazard Outbreak - File #2"
+  name: バイオハザード アウトブレイク FILE 2
+  name-sort: ばいおはざーど あうとぶれいく FILE 2
+  name-en: "BioHazard Outbreak - File #2"
   region: "NTSC-J"
   compat: 5
   memcardFilters:
@@ -34983,10 +37752,14 @@ SLPM-65692:
     - "SLPM-65428"
     - "SLPM-74201"
 SLPM-65693:
-  name: "Tokimeki Memorial 3 [Konami Palace Selection]"
+  name: ときめきメモリアル3～約束のあの場所で～(コナミ殿堂セレクション)
+  name-sort: ときめきめもりある3～やくそくのあのばしょで～(こなみでんどうせれくしょん)
+  name-en: "Tokimeki Memorial 3 [Konami Palace Selection]"
   region: "NTSC-J"
 SLPM-65694:
-  name: "Genso Suikoden 3 [Konami Dendou Collection]"
+  name: 幻想水滸伝III(コナミ殿堂セレクション)
+  name-sort: げんそうすいこでんIII(こなみでんどうせれくしょん)
+  name-en: "Genso Suikoden 3 [Konami Dendou Collection]"
   region: "NTSC-J"
   memcardFilters:
     - "SLPM-65073"
@@ -35003,69 +37776,109 @@ SLPM-65694:
     - "SLPM-86953"
     - "SLPM-87262"
 SLPM-65695:
-  name: "Hard Luck - Return of the Heroes"
+  name: ハードラック
+  name-sort: はーどらっく
+  name-en: "Hard Luck - Return of the Heroes"
   region: "NTSC-J"
 SLPM-65696:
-  name: "Simple 2000 Series Vol. 62 - The Super Puzzle Bubble DX"
+  name: SIMPLE2000シリーズ Vol.62 THE スーパーパズルボブルDX
+  name-sort: SIMPLE2000しりーず Vol.62 THE すーぱーぱずるぼぶるDX
+  name-en: "Simple 2000 Series Vol. 62 - The Super Puzzle Bubble DX"
   region: "NTSC-J"
 SLPM-65697:
-  name: "Shrek 2"
+  name: シュレック2
+  name-sort: しゅれっく2
+  name-en: "Shrek 2"
   region: "NTSC-J"
   gsHWFixes:
     mipmap: 2 # Partially fixes the sun effects, but the game suffers from depth/blending issues.
     trilinearFiltering: 1
 SLPM-65698:
-  name: "Love Songs - ADV Futaba Riho 14-sai Natsu"
+  name: LoveSongs♪ADV 双葉理保14歳〜夏〜
+  name-sort: LoveSongs♪ADV ふたばりほ14さい〜なつ〜
+  name-en: "Love Songs - ADV Futaba Riho 14-sai Natsu"
   region: "NTSC-J"
 SLPM-65699:
-  name: "Viewtiful Joe - Aratanaru Kibo"
+  name: ビューティフルジョー 新たなる希望
+  name-sort: びゅーてぃふるじょー あらたなるきぼう
+  name-en: "Viewtiful Joe - Aratanaru Kibo"
   region: "NTSC-J"
   compat: 5
 SLPM-65700:
-  name: "Kengo 3"
+  name: 剣豪3
+  name-sort: けんごう3
+  name-en: "Kengo 3"
   region: "NTSC-J"
   compat: 5
 SLPM-65701:
-  name: "Ghost Hunter"
+  name: ゴーストハンター
+  name-sort: ごーすとはんたー
+  name-en: "Ghost Hunter"
   region: "NTSC-J"
 SLPM-65702:
-  name: "Sangokushi Senki [Koei Collection Series]"
+  name: コーエー定番シリーズ 三國志戦記
+  name-sort: こーえーていばんしりーず さんごくしせんき
+  name-en: "Sangokushi Senki [Koei Collection Series]"
   region: "NTSC-J"
 SLPM-65703:
-  name: "Double Reaction Plus"
+  name: Double Reaction! PLUS
+  name-sort: Double Reaction! PLUS
+  name-en: "Double Reaction Plus"
   region: "NTSC-J"
 SLPM-65704:
-  name: "Standard Daisenryaku Dengekisen"
+  name: スタンダード大戦略 電撃戦
+  name-sort: すたんだーどだいせんりゃく でんげきせん
+  name-en: "Standard Daisenryaku Dengekisen"
   region: "NTSC-J"
 SLPM-65705:
-  name: "Final Fantasy XI - Chains of Promathia [Expansion Disc]"
+  name: ファイナルファンタジーXI プロマシアの呪縛 拡張データディスク
+  name-sort: ふぁいなるふぁんたじーXI ぷろましあのじゅばく かくちょうでーたでぃすく
+  name-en: "Final Fantasy XI - Chains of Promathia [Expansion Disc]"
   region: "NTSC-J"
 SLPM-65706:
-  name: "Final Fantasy XI - Chains of Promathia [All-in-One Pack]"
+  name: プレイオンライン/ファイナルファンタジーXI オールインワンパック2004
+  name-sort: ぷれいおんらいん/ふぁいなるふぁんたじーXI おーるいんわんぱっく2004
+  name-en: "Final Fantasy XI - Chains of Promathia [All-in-One Pack]"
   region: "NTSC-J"
 SLPM-65708:
-  name: "Hagane no Renkinjutsushi - Akaki Elixir no Akuma"
+  name: 鋼の錬金術師2 赤きエリクシルの悪魔 初回限定版
+  name-sort: はがねのれんきんじゅつし2 あかきえりくしるのあくま しょかいげんていばん
+  name-en: "Hagane no Renkinjutsushi - Akaki Elixir no Akuma"
   region: "NTSC-J"
 SLPM-65710:
-  name: "Apocripha-0"
+  name: Apocripha/0 通常版
+  name-sort: Apocripha/0 つうじょうばん
+  name-en: "Apocripha-0"
   region: "NTSC-J"
 SLPM-65714:
-  name: "Angelique Etoile [Premium Box]"
+  name: アンジェリークエトワール　プレミアムBOX
+  name-sort: あんじぇりーくえとわーる　ぷれみあむBOX
+  name-en: "Angelique Etoile [Premium Box]"
   region: "NTSC-J"
 SLPM-65715:
-  name: "Angelique Etoile"
+  name: アンジェリーク エトワール
+  name-sort: あんじぇりーく えとわーる
+  name-en: "Angelique Etoile"
   region: "NTSC-J"
 SLPM-65716:
-  name: "Gaika no Gouhou - Air Land Force [Koei The Best]"
+  name: KOEI The Best 凱歌の号砲 エアランドフォース
+  name-sort: KOEI The Best がいかのごうほう えあらんどふぉーす
+  name-en: "Gaika no Gouhou - Air Land Force [Koei The Best]"
   region: "NTSC-J"
 SLPM-65717:
-  name: "Tsuki wa Higashi ni Ha wa Nishi ni - Operation Sanctuary"
+  name: 月は東に日は西に-Operation Sanctuary-
+  name-sort: つきはひがしにひはにしに-Operation Sanctuary-
+  name-en: "Tsuki wa Higashi ni Ha wa Nishi ni - Operation Sanctuary"
   region: "NTSC-J"
 SLPM-65718:
-  name: "Sengoku Musou Mushoden"
+  name: 戦国無双 猛将伝
+  name-sort: せんごくむそう もうしょうでん
+  name-en: "Sengoku Musou Mushoden"
   region: "NTSC-J"
 SLPM-65719:
-  name: "Burnout 3 - Takedown"
+  name: バーンアウト3:テイクダウン
+  name-sort: ばーんあうと3:ていくだうん
+  name-en: "Burnout 3 - Takedown"
   region: "NTSC-J"
   clampModes:
     vuClampMode: 3 # Fixes buggy lighting in the garage.
@@ -35080,29 +37893,43 @@ SLPM-65719:
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
 SLPM-65720:
-  name: "Shin Sangoku Musou 2 Mushoden [Koei the Best]"
+  name: KOEI The Best 真・三國無双2 猛将伝
+  name-sort: KOEI The Best しん・さんごくむそう2 もうしょうでん
+  name-en: "Shin Sangoku Musou 2 Mushoden [Koei the Best]"
   region: "NTSC-J"
 SLPM-65721:
-  name: "Pro Yakyuu Spirits 2004 Climax"
+  name: プロ野球スピリッツ 2004 クライマックス
+  name-sort: ぷろやきゅうすぴりっつ 2004 くらいまっくす
+  name-en: "Pro Yakyuu Spirits 2004 Climax"
   region: "NTSC-J"
 SLPM-65722:
-  name: "Airforce Delta - Blue Wing Knights [Konami the Best]"
+  name: Airforce Delta ～Blue Wing Knights～ (コナミ ザ ベスト)
+  name-sort: Airforce Delta ～Blue Wing Knights～ (こなみ ざ べすと)
+  name-en: "Airforce Delta - Blue Wing Knights [Konami the Best]"
   region: "NTSC-J"
 SLPM-65723:
-  name: "Van Helsing"
+  name: ヴァン・ヘルシング
+  name-sort: ゔぁん・へるしんぐ
+  name-en: "Van Helsing"
   region: "NTSC-J"
 SLPM-65724:
-  name: "Choro Q Works"
+  name: チョロQワークス
+  name-sort: ちょろQわーくす
+  name-en: "Choro Q Works"
   region: "NTSC-J"
 SLPM-65725:
-  name: "007 - Everything or Nothing [EA Best Hits]"
+  name: EA BEST HITS 007エブリシング オア ナッシング
+  name-sort: EA BEST HITS 007えぶりしんぐ おあ なっしんぐ
+  name-en: "007 - Everything or Nothing [EA Best Hits]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes lines in cutscenes.
     mipmap: 2 # Cleans up texture detail.
     trilinearFiltering: 1 # Smoothes out mipmapping.
 SLPM-65726:
-  name: "Star Wars - Jango Fett [EA Best Hits]"
+  name: EA BEST HITS スター・ウォーズ ジャンゴ・フェット
+  name-sort: EA BEST HITS すたー・うぉーず じゃんご・ふぇっと
+  name-en: "Star Wars - Jango Fett [EA Best Hits]"
   region: "NTSC-J"
   compat: 5
   roundModes:
@@ -35111,13 +37938,19 @@ SLPM-65726:
     vuClampMode: 3
     eeClampMode: 2 # Fixes missing/grey texture or geometry ingame.
 SLPM-65727:
-  name: "Lord of the Rings, The - The Return of the King [EA Best Hits]"
+  name: EA BEST HITS ロード・オブ・ザ・リング/王の帰還
+  name-sort: EA BEST HITS ろーど・おぶ・ざ・りんぐ/おうのきかん
+  name-en: "Lord of the Rings, The - The Return of the King [EA Best Hits]"
   region: "NTSC-J"
 SLPM-65728:
-  name: "Hobbit, The"
+  name: ホビットの冒険 ロード オブ ザ リング はじまりの物語
+  name-sort: ほびっとのぼうけん ろーど おぶ ざ りんぐ はじまりのものがたり
+  name-en: "Hobbit, The"
   region: "NTSC-J"
 SLPM-65729:
-  name: "True Crime - Streets of L.A."
+  name: トゥルークライム -STREETS OF L.A.-
+  name-sort: とぅるーくらいむ -STREETS OF L.A.-
+  name-en: "True Crime - Streets of L.A."
   region: "NTSC-J"
   gsHWFixes:
     preloadFrameData: 1 # Fixes licences.
@@ -35125,7 +37958,9 @@ SLPM-65729:
     gpuTargetCLUT: 1 # Fixes sun penetrating buildings.
     autoFlush: 1 # Fixes sun occlusion.
 SLPM-65730:
-  name: "Rockman X8"
+  name: ロックマンX8
+  name-sort: ろっくまんX8
+  name-en: "Rockman X8"
   region: "NTSC-J"
   gsHWFixes:
     autoFlush: 2 # Fixes bloom.
@@ -35136,39 +37971,59 @@ SLPM-65730:
     - "SLPM-65730"
     - "SLPM-65643"
 SLPM-65731:
-  name: "Tom Clancy's Rainbow Six 3"
+  name: トム・クランシーシリーズ レインボーシックス3
+  name-sort: とむ・くらんしーしりーず れいんぼーしっくす3
+  name-en: "Tom Clancy's Rainbow Six 3"
   region: "NTSC-J"
 SLPM-65732:
-  name: "Akai Ito"
+  name: アカイイト
+  name-sort: あかいいと
+  name-en: "Akai Ito"
   region: "NTSC-J"
   compat: 5
 SLPM-65734:
-  name: "Kita He - Diamond Dust [Hudson The Best]"
+  name: 北へ。Diamond Dust ハドソン・ザ・ベスト
+  name-sort: きたへ。Diamond Dust はどそん・ざ・べすと
+  name-en: "Kita He - Diamond Dust [Hudson The Best]"
   region: "NTSC-J"
 SLPM-65735:
-  name: "Ao no Mamade [Treasure Box]"
+  name: 蒼のままで・・・・・・ 限定版
+  name-sort: あおのままで・・・・・・ げんていばん
+  name-en: "Ao no Mamade [Treasure Box]"
   region: "NTSC-J"
 SLPM-65736:
-  name: "Ao no Mamade"
+  name: 蒼のままで・・・・・・
+  name-sort: あおのままで・・・・・・
+  name-en: "Ao no Mamade"
   region: "NTSC-J"
 SLPM-65737:
-  name: "Meshimase Roman Sabou"
+  name: 召しませ浪漫茶房
+  name-sort: めしませろまんさぼう
+  name-en: "Meshimase Roman Sabou"
   region: "NTSC-J"
 SLPM-65738:
-  name: "Love Songs Adv - Futaba Riho 19 Sai"
+  name: LoveSongs♪ADV(アドベンチャー)『双葉理保 19歳〜冬〜』
+  name-sort: LoveSongs♪ADV(あどべんちゃー)『ふたばりほ 19さい〜ふゆ〜』
+  name-en: "Love Songs Adv - Futaba Riho 19 Sai"
   region: "NTSC-J"
 SLPM-65739:
-  name: "Nightmare Before Christmas"
+  name: ティム・バートン ナイトメアー・ビフォア・クリスマス ブギーの逆襲
+  name-sort: てぃむ・ばーとん ないとめあー・びふぉあ・くりすます ぶぎーのぎゃくしゅう
+  name-en: "Nightmare Before Christmas"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
     wildArmsHack: 1 # Fixes blurriness.
     mergeSprite: 1 # Fixes misaligned lights.
 SLPM-65740:
-  name: "J-League Winning Eleven 8 - Asia Championship"
+  name: Jリーグ ウイニングイレブン8 〜Asia Championship〜
+  name-sort: Jりーぐ ういにんぐいれぶん8 〜Asia Championship〜
+  name-en: "J-League Winning Eleven 8 - Asia Championship"
   region: "NTSC-J"
 SLPM-65741:
-  name: "Driv3r"
+  name: DRIV3R
+  name-sort: DRIV3R
+  name-en: "Driv3r"
   region: "NTSC-J"
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
@@ -35184,7 +38039,9 @@ SLPM-65741:
     cpuSpriteRenderLevel: 2 # Needed for above.
     recommendedBlendingLevel: 2 # Fixes car and bike exhaust smoke rendering.
 SLPM-65742:
-  name: "Cool Girl [Konami the Best]"
+  name: COOL GIRL(コナミ ザ ベスト)
+  name-sort: COOL GIRL(こなみ ざ べすと)
+  name-en: "Cool Girl [Konami the Best]"
   region: "NTSC-J"
   memcardFilters:
     - "SLPM-65504"
@@ -35195,66 +38052,96 @@ SLPM-65743:
   name: "Cool Girl (Disc 2) (Aska Side)"
   region: "NTSC-J"
 SLPM-65744:
-  name: "Firefighter F.D. 18 [Konami The Best]"
+  name: ファイアーファイター F.D.18(コナミ ザ ベスト)
+  name-sort: ふぁいあーふぁいたー F.D.18(こなみ ざ べすと)
+  name-en: "Firefighter F.D. 18 [Konami The Best]"
   region: "NTSC-J"
 SLPM-65745:
-  name: "Tokimeki Memorial - Girl's Side [Konami Dendou Collection]"
+  name: ときめきメモリアル Girl’s Side (コナミ殿堂セレクション)
+  name-sort: ときめきめもりある Girl’s Side (こなみでんどうせれくしょん)
+  name-en: "Tokimeki Memorial - Girl's Side [Konami Dendou Collection]"
   region: "NTSC-J"
 SLPM-65746:
-  name: "FIFA Total Football 2"
+  name: FIFAトータルフットボール2
+  name-sort: FIFAとーたるふっとぼーる2
+  name-en: "FIFA Total Football 2"
   region: "NTSC-J"
 SLPM-65747:
   name: "Hagane no Renkinjutsushi 2 - Akaki Elixir no Akuma"
   region: "NTSC-J"
 SLPM-65748:
-  name: "Zoids Struggle"
+  name: ZOIDS STRUGGLE
+  name-sort: ZOIDS STRUGGLE
+  name-en: "Zoids Struggle"
   region: "NTSC-J"
 SLPM-65749:
-  name: "Zoids Infinity"
+  name: ZOIDSインフィニティ フューザーズ
+  name-sort: ZOIDSいんふぃにてぃ ふゅーざーず
+  name-en: "Zoids Infinity"
   region: "NTSC-J"
 SLPM-65750:
-  name: "Dokapon the World"
+  name: ドカポン・ザ・ワールド
+  name-sort: どかぽん・ざ・わーるど
+  name-en: "Dokapon the World"
   region: "NTSC-J"
 SLPM-65751:
-  name: "Suigetsu Mayoi-Gokoro"
+  name: 水月 〜迷心〜
+  name-sort: すいげつ 〜まよいごころ〜
+  name-en: "Suigetsu Mayoi-Gokoro"
   region: "NTSC-J"
 SLPM-65752:
-  name: "Neo Contra"
+  name: NEO CONTORA
+  name-sort: NEO CONTORA
+  name-en: "Neo Contra"
   region: "NTSC-J"
   roundModes:
     eeRoundMode: 0 # Reduces FPU calculation errors.
   clampModes:
     eeClampMode: 2 # Reduces FPU calculation errors.
 SLPM-65753:
-  name: "Kessen [Koei Collection Series]"
+  name: コーエー定番シリーズ 決戦
+  name-sort: こーえーていばんしりーず けっせん
+  name-en: "Kessen [Koei Collection Series]"
   region: "NTSC-J"
 SLPM-65754:
-  name: "Metal Gear Solid 2 [Konami Dendou Collection]"
+  name: METAL GEAR SOLID 2 SONS OF LIBERTY コナミ殿堂セレクション
+  name-sort: METAL GEAR SOLID 2 SONS OF LIBERTY こなみでんどうせれくしょん
+  name-en: "Metal Gear Solid 2 [Konami Dendou Collection]"
   region: "NTSC-J"
   gameFixes:
     - InstantDMAHack # Fixes broken half-bottom artifacts.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
 SLPM-65755:
-  name: "Samurai Western - Katsugeki Samurai-dou"
+  name: サムライウエスタン 活劇侍道
+  name-sort: さむらいうえすたん かつげきさむらいどう
+  name-en: "Samurai Western - Katsugeki Samurai-dou"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes line across the middle of the screen and offset blur.
 SLPM-65756:
-  name: "Tennis no Oji-Sama - Rush & Dream"
+  name: テニスの王子様 RUSH＆DREAM!
+  name-sort: てにすのおうじさま RUSH＆DREAM!
+  name-en: "Tennis no Oji-Sama - Rush & Dream"
   region: "NTSC-J"
 SLPM-65757:
-  name: "Medal of Honor - Rising Sun [EA Best Hits]"
+  name: EA BEST HITS メダル オブ オナー ライジングサン
+  name-sort: EA BEST HITS めだる おぶ おなー らいじんぐさん
+  name-en: "Medal of Honor - Rising Sun [EA Best Hits]"
   region: "NTSC-J"
 SLPM-65758:
-  name: "Sonic Mega Collection Plus"
+  name: ソニック メガコレクション プラス
+  name-sort: そにっく めがこれくしょん ぷらす
+  name-en: "Sonic Mega Collection Plus"
   region: "NTSC-J"
   memcardFilters:
     - "SLPM-65758"
     - "SLAJ-25027"
     - "SLPM-65431"
 SLPM-65759:
-  name: "Mr. Incredible"
+  name: Mr.インクレディブル
+  name-sort: Mr.いんくれでぃぶる
+  name-en: "Mr. Incredible"
   region: "NTSC-J"
   gsHWFixes:
     mipmap: 2 # Mipmap + trilinear, improves the street's textures to match sw renderer.
@@ -35262,27 +38149,41 @@ SLPM-65759:
     halfPixelOffset: 2 # Fixes bloom misalignment when upscaling.
     cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling.
 SLPM-65760:
-  name: "Grand Theft Auto III [Capcom The Best]"
+  name: Grand Theft Auto III カプコレ
+  name-sort: Grand Theft Auto III かぷこれ
+  name-en: "Grand Theft Auto III [Capcom The Best]"
   region: "NTSC-J"
 SLPM-65761:
-  name: "World Super Police"
+  name: 高速機動隊 〜World Super Police〜
+  name-sort: こうそくきどうたい 〜World Super Police〜
+  name-en: "World Super Police"
   region: "NTSC-J"
   gameFixes:
     - EETimingHack # Fixes game hanging at mission 1.
 SLPM-65762:
-  name: "Katakamuna"
+  name: 片神名～喪われた因果律～
+  name-sort: かたかむな～うしなわれたいんがりつ～
+  name-en: "Katakamuna"
   region: "NTSC-J"
 SLPM-65763:
-  name: "007 Goldeneye - Rogue Agent"
+  name: ゴールデンアイ ダーク・エージェント
+  name-sort: ごーるでんあい だーく・えーじぇんと
+  name-en: "007 Goldeneye - Rogue Agent"
   region: "NTSC-J"
 SLPM-65764:
-  name: "Men at Work! 3 [Limited Edition]"
+  name: メンアットワーク!3 愛と青春のハンター学園 初回限定版
+  name-sort: めんあっとわーく!3 あいとせいしゅんのはんたーがくえん しょかいげんていばん
+  name-en: "Men at Work! 3 [Limited Edition]"
   region: "NTSC-J"
 SLPM-65765:
-  name: "Men at Work! 3"
+  name: メンアットワーク!3 愛と青春のハンター学園
+  name-sort: めんあっとわーく!3 あいとせいしゅんのはんたーがくえん
+  name-en: "Men at Work! 3"
   region: "NTSC-J"
 SLPM-65766:
-  name: "Need for Speed - Underground 2"
+  name: ニード・フォー・スピード アンダーグラウンド2
+  name-sort: にーど・ふぉー・すぴーど あんだーぐらうんど2
+  name-en: "Need for Speed - Underground 2"
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves reflection quality and map opacity.
@@ -35290,65 +38191,103 @@ SLPM-65766:
   gameFixes:
     - SoftwareRendererFMVHack # Workaround for strange HPO Normal screen shake.
 SLPM-65767:
-  name: "NBA Starting Five 2005"
+  name: NBA STARTINGFIVE 2005
+  name-sort: NBA STARTINGFIVE 2005
+  name-en: "NBA Starting Five 2005"
   region: "NTSC-J"
 SLPM-65768:
-  name: "Beatmania IIDX 8th Style"
+  name: beatmania IIDX 8th style
+  name-sort: beatmania IIDX 8th style
+  name-en: "Beatmania IIDX 8th style"
   region: "NTSC-J"
 SLPM-65769:
-  name: "Pop'n music 10 [Controller Set]"
+  name: pop’n music コントローラセット
+  name-sort: pop’n music こんとろーらせっと
+  name-en: "Pop'n music 10 [Controller Set]"
   region: "NTSC-J"
 SLPM-65770:
-  name: "Pop'n music 10"
+  name: ポップンミュージック10
+  name-sort: ぽっぷんみゅーじっく10
+  name-en: "Pop'n music 10"
   region: "NTSC-J"
 SLPM-65771:
-  name: "Natural 2 Duo - Sakurairo no Kisetsu [Deluxe Pack]"
+  name: ナチュラル2 -DUO- 桜色の季節 DXパック
+  name-sort: なちゅらる2 -DUO- さくらいろのきせつ DXぱっく
+  name-en: "Natural 2 Duo - Sakurairo no Kisetsu [Deluxe Pack]"
   region: "NTSC-J"
 SLPM-65772:
-  name: "Natural 2 Duo"
+  name: ナチュラル2 −DUO− 桜色の季節
+  name-sort: なちゅらる2 -DUO- さくらいろのきせつ
+  name-en: "Natural 2 Duo"
   region: "NTSC-J"
 SLPM-65773:
-  name: "Shining Tears"
+  name: シャイニング・ティアーズ
+  name-sort: しゃいにんぐ・てぃあーず
+  name-en: "Shining Tears"
   region: "NTSC-J"
 SLPM-65775:
-  name: "DDR Festival Dance Dance Revolution"
+  name: DDR Festival Dance Dance Revolution
+  name-sort: DDR Festival Dance Dance Revolution
+  name-en: "DDR Festival Dance Dance Revolution"
   region: "NTSC-J"
   compat: 5
 SLPM-65776:
-  name: "Tenkuu Danzai - Skelter Heaven [Limited Edition]"
+  name: 天空断罪 スケルターヘブン 限定版
+  name-sort: てんくうだんざい すけるたーへぶん げんていばん
+  name-en: "Tenkuu Danzai - Skelter Heaven [Limited Edition]"
   region: "NTSC-J"
 SLPM-65777:
-  name: "Tenkuu Danzai - Skelter Heaven"
+  name: 天空断罪 スケルターヘブン
+  name-sort: てんくうだんざい すけるたーへぶん
+  name-en: "Tenkuu Danzai - Skelter Heaven"
   region: "NTSC-J"
 SLPM-65778:
-  name: "Sega Ages 2500 Series Vol.18 - Dragon Force"
+  name: SEGA AGES 2500 シリーズ Vol.18 ドラゴンフォース
+  name-sort: SEGA AGES 2500 しりーず Vol.18 どらごんふぉーす
+  name-en: "Sega Ages 2500 Series Vol.18 - Dragon Force"
   region: "NTSC-J"
 SLPM-65779:
-  name: "Exciting Pro Wrestling 5 [Yuke's the Best]"
+  name: エキサイティングプロレス5 YUKE’s the Best
+  name-sort: えきさいてぃんぐぷろれす5 YUKE’s the Best
+  name-en: "Exciting Pro Wrestling 5 [Yuke's the Best]"
   region: "NTSC-J"
 SLPM-65780:
   name: "Kessen III [Treasure Box]"
   region: "NTSC-J"
 SLPM-65781:
-  name: "Kessen III"
+  name: 決戦III
+  name-sort: けっせんIII
+  name-en: "Kessen III"
   region: "NTSC-J"
 SLPM-65783:
-  name: "Nobunaga no Yabou Online - Tappi no Shou"
+  name: 信長の野望 Online 〜飛龍の章〜
+  name-sort: のぶながのやぼう Online 〜ひりゅうのしょう〜
+  name-en: "Nobunaga no Yabou Online - Tappi no Shou"
   region: "NTSC-J"
 SLPM-65785:
-  name: "Natsuiro - Hoshikuzu no Memory [Limited Edition]"
+  name: なついろ〜星屑のメモリー〜 (初回限定版)
+  name-sort: なついろ〜ほしくずのめもりー〜 (しょかいげんていばん)
+  name-en: "Natsuiro - Hoshikuzu no Memory [Limited Edition]"
   region: "NTSC-J"
 SLPM-65786:
-  name: "Natsuiro - Hoshikuzu no Memory"
+  name: なついろ〜星屑のメモリー〜
+  name-sort: なついろ〜ほしくずのめもりー〜
+  name-en: "Natsuiro - Hoshikuzu no Memory"
   region: "NTSC-J"
 SLPM-65787:
-  name: "NBA Live 2005"
+  name: NBAライブ2005
+  name-sort: NBAらいぶ2005
+  name-en: "NBA Live 2005"
   region: "NTSC-J"
 SLPM-65788:
-  name: "Winning Eleven 8 - Liveware Evolution"
+  name: ワールドサッカーウイニングイレブン8 ライヴウエアエヴォリューション
+  name-sort: わーるどさっかーういにんぐいれぶん8 らいゔうえあえゔぉりゅーしょん
+  name-en: "Winning Eleven 8 - Liveware Evolution"
   region: "NTSC-J"
 SLPM-65789:
-  name: "Metal Gear Solid 3 - Snake Eater [Premium Pack]"
+  name: METAL GEAR SOLID 3 SNAKE EATER PREMIUM PACKAGE
+  name-sort: METAL GEAR SOLID 3 SNAKE EATER PREMIUM PACKAGE
+  name-en: "Metal Gear Solid 3 - Snake Eater [Premium Pack]"
   region: "NTSC-J"
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
@@ -35357,7 +38296,9 @@ SLPM-65789:
     autoFlush: 2 # Fixes lens flare.
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
 SLPM-65790:
-  name: "Metal Gear Solid 3 - Snake Eater"
+  name: METAL GEAR SOLID 3 SNAKE EATER
+  name-sort: METAL GEAR SOLID 3 SNAKE EATER
+  name-en: "Metal Gear Solid 3 - Snake Eater"
   region: "NTSC-J"
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
@@ -35366,21 +38307,29 @@ SLPM-65790:
     autoFlush: 2 # Fixes lens flare.
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
 SLPM-65791:
-  name: "S.L.A.I. - Steel Lancer Arena International"
+  name: S.L.A.I -STEEL LANCER ARENA INTERNATIONAL-
+  name-sort: S.L.A.I -STEEL LANCER ARENA INTERNATIONAL-
+  name-en: "S.L.A.I. - Steel Lancer Arena International"
   region: "NTSC-J"
 SLPM-65793:
-  name: "SSX 3 [EA Best Hits]"
+  name: EA BEST HITS SSX3
+  name-sort: EA BEST HITS SSX3
+  name-en: "SSX 3 [EA Best Hits]"
   region: "NTSC-J"
   gsHWFixes:
     textureInsideRT: 1 # Fixes rainbow effect in the pause menu before a jump.
     halfPixelOffset: 2 # Fixes depth lines.
     recommendedBlendingLevel: 4 # Fixes missing lighting and makes snow not look like snow sludge.
 SLPM-65794:
-  name: "Capcom Fighting Jam"
+  name: カプコン ファイティング ジャム
+  name-sort: かぷこん ふぁいてぃんぐ じゃむ
+  name-en: "Capcom Fighting Jam"
   region: "NTSC-J"
   compat: 5
 SLPM-65795:
-  name: "Digital Devil Saga - Avatar Tuner 2"
+  name: DIGITAL DEVIL SAGA(デジタル・デビル・サーガ) 〜アバタール・チューナー2〜
+  name-sort: DIGITAL DEVIL SAGA(でじたる・でびる・さーが) 〜あばたーる・ちゅーなー2〜
+  name-en: "Digital Devil Saga - Avatar Tuner 2"
   region: "NTSC-J"
   gameFixes:
     - EETimingHack
@@ -35392,14 +38341,20 @@ SLPM-65795:
     - "SLPM-65597"
     - "SLPM-66372"
 SLPM-65796:
-  name: "Project Altered Beast"
+  name: 獣王記 -PROJECT ALTERED BEAST-
+  name-sort: じゅうおうき -PROJECT ALTERED BEAST-
+  name-en: "Project Altered Beast"
   region: "NTSC-J"
 SLPM-65797:
-  name: "Dragon Quest & Final Fantasy in Itadaki Street"
+  name: ドラゴンクエスト＆ファイナルファンタジー in いただきストリートSpecial
+  name-sort: どらごんくえすと＆ふぁいなるふぁんたじー in いただきすとりーとSpecial
+  name-en: "Dragon Quest & Final Fantasy in Itadaki Street"
   region: "NTSC-J"
   compat: 5
 SLPM-65798:
-  name: "Madden NFL Superbowl 2005"
+  name: マッデン NFL スーパーボウル 2005
+  name-sort: まっでん NFL すーぱーぼうる 2005
+  name-en: "Madden NFL Superbowl 2005"
   region: "NTSC-J"
   clampModes:
     vuClampMode: 3 # Missing geometry with microVU.
@@ -35407,10 +38362,14 @@ SLPM-65798:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
 SLPM-65799:
-  name: "New Jinsei Game"
+  name: NEW人生ゲーム
+  name-sort: NEWじんせいげーむ
+  name-en: "New Jinsei Game"
   region: "NTSC-J"
 SLPM-65800:
-  name: "Radiata Stories"
+  name: ラジアータ ストーリーズ
+  name-sort: らじあーた すとーりーず
+  name-en: "Radiata Stories"
   region: "NTSC-J"
   gameFixes:
     - VuAddSubHack
@@ -35418,7 +38377,9 @@ SLPM-65800:
     alignSprite: 1 # Fixes vertical bars.
     halfPixelOffset: 2 # Fixes misalignment bloom effects.
 SLPM-65801:
-  name: "Crash Bandicoot 5"
+  name: クラッシュ・バンディクー5 え～っクラッシュとコルテックスの野望?!?
+  name-sort: くらっしゅ・ばんでぃくー5 え～っくらっしゅとこるてっくすのやぼう?!?
+  name-en: "Crash Bandicoot 5"
   region: "NTSC-J"
   compat: 5
   gameFixes:
@@ -35426,30 +38387,46 @@ SLPM-65801:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
 SLPM-65802:
-  name: "Def Jam - Vendetta [EA Best Hits]"
+  name: EA BEST HITS DEF JAM VENDETTA
+  name-sort: EA BEST HITS DEF JAM VENDETTA
+  name-en: "Def Jam - Vendetta [EA Best Hits]"
   region: "NTSC-J"
 SLPM-65803:
-  name: "Freedom Fighters [EA Best Hits]"
+  name: EA BEST HITS フリーダム・ファイターズ
+  name-sort: EA BEST HITS ふりーだむ・ふぁいたーず
+  name-en: "Freedom Fighters [EA Best Hits]"
   region: "NTSC-J"
 SLPM-65804:
-  name: "European Club Soccer - Winning Eleven Tactics"
+  name: EUROPEAN CLUB SOCCER Winning Eleven Tactics ヨーロピアンクラブサッカーウイニングイレブンタクティクス
+  name-sort: EUROPEAN CLUB SOCCER Winning Eleven Tactics よーろぴあんくらぶさっかーういにんぐいれぶんたくてぃくす
+  name-en: "European Club Soccer - Winning Eleven Tactics"
   region: "NTSC-J"
 SLPM-65805:
-  name: "Gojira Monster Fighter"
+  name: ゴジラ怪獣大乱闘 〜地球最終決戦〜
+  name-sort: ごじらかいじゅうだいらんとう 〜ちきゅうさいしゅうけっせん〜
+  name-en: "Gojira Monster Fighter"
   region: "NTSC-J"
 SLPM-65806:
-  name: "VM Japan"
+  name: VM JAPAN(ブイエムジャパン)
+  name-sort: VM JAPAN(ぶいえむじゃぱん)
+  name-en: "VM Japan"
   region: "NTSC-J"
 SLPM-65807:
-  name: "Urbz, The - Sims in the City"
+  name: ザ・アーブズ シムズ・イン・ザ・シティ
+  name-sort: ざ・あーぶず しむず・いん・ざ・してぃ
+  name-en: "Urbz, The - Sims in the City"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes upscaling lines.
 SLPM-65808:
-  name: "Derby Tsuku 4 - Derby Uma o Tsukurou!"
+  name: ダビつく4 ダービー馬をつくろう!
+  name-sort: だびつく4 だーびーばをつくろう!
+  name-en: "Derby Tsuku 4 - Derby Uma o Tsukurou!"
   region: "NTSC-J"
 SLPM-65809:
-  name: "NanoBreaker"
+  name: NANO BREAKER
+  name-sort: NANO BREAKER
+  name-en: "NanoBreaker"
   region: "NTSC-J"
 SLPM-65810:
   name: "Densha de Go! Ryojou-hen"
@@ -35458,136 +38435,206 @@ SLPM-65811:
   name: "Zero Shikikan Josentoki [Taito Best]"
   region: "NTSC-J"
 SLPM-65812:
-  name: "Bakushou! Jinsei Kaimichi [Taito Best]"
+  name: 爆笑!!人生回道 NOVAうさぎが見てるぞ!! TAITO BEST
+  name-sort: ばくしょう!!じんせいかいどう NOVAうさぎがみてるぞ!! TAITO BEST
+  name-en: "Bakushou! Jinsei Kaimichi [Taito Best]"
   region: "NTSC-J"
 SLPM-65813:
-  name: "Fu-un Bakumatsu Den"
+  name: 風雲 幕末伝
+  name-sort: ふううん ばくまつでん
+  name-en: "Fu-un Bakumatsu Den"
   region: "NTSC-J"
   compat: 5
 SLPM-65815:
-  name: "Tom Clancy's Splinter Cell - Pandora Tomorrow"
+  name: トム・クランシーシリーズ スプリンターセル パンドラトゥモロー
+  name-sort: とむ・くらんしーしりーず すぷりんたーせる ぱんどらとぅもろー
+  name-en: "Tom Clancy's Splinter Cell - Pandora Tomorrow"
   region: "NTSC-J"
   gsHWFixes:
     preloadFrameData: 1 # Fixes missing loading screens.
     mergeSprite: 1 # Fixes misaligned bloom on light sources.
 SLPM-65816:
-  name: "Shin Bakusou Dekotora Densetsu"
+  name: 真・爆走デコトラ伝説 〜天下統一頂上決戦〜
+  name-sort: しん・ばくそうでことらでんせつ 〜てんかとういつちょうじょうけっせん〜
+  name-en: "Shin Bakusou Dekotora Densetsu"
   region: "NTSC-J"
 SLPM-65817:
-  name: "Tennis no Oji-Sama - Love of Prince Sweet [Konami Palace Selection]"
+  name: テニスの王子様 Love of Prince Sweet(コナミ殿堂セレクション)
+  name-sort: てにすのおうじさま Love of Prince Sweet(こなみでんどうせれくしょん)
+  name-en: "Tennis no Oji-Sama - Love of Prince Sweet [Konami Palace Selection]"
   region: "NTSC-J"
 SLPM-65818:
-  name: "Tennis no Oji-Sama - Love of Prince Bitter [Konami Palace Selection]"
+  name: テニスの王子様 Love of Prince Bitter(コナミ殿堂セレクション)
+  name-sort: てにすのおうじさま Love of Prince Bitter(こなみでんどうせれくしょん)
+  name-en: "Tennis no Oji-Sama - Love of Prince Bitter [Konami Palace Selection]"
   region: "NTSC-J"
 SLPM-65819:
-  name: "Tennis no Oji-Sama - Kiss of Prince - Ice Version [Konami Palace Selection]"
+  name: テニスの王子様 Kiss of Prince ICE(コナミ殿堂セレクション)
+  name-sort: てにすのおうじさま Kiss of Prince ICE(こなみでんどうせれくしょん)
+  name-en: "Tennis no Oji-Sama - Kiss of Prince - Ice Version [Konami Palace Selection]"
   region: "NTSC-J"
 SLPM-65820:
-  name: "Tennis no Oji-Sama - Kiss of Prince - Flame Version [Konami Palace Selection]"
+  name: テニスの王子様 Kiss of Prince FLAME(コナミ殿堂セレクション)
+  name-sort: てにすのおうじさま Kiss of Prince FLAME(こなみでんどうせれくしょん)
+  name-en: "Tennis no Oji-Sama - Kiss of Prince - Flame Version [Konami Palace Selection]"
   region: "NTSC-J"
 SLPM-65821:
-  name: "Shinseiki Yuusha Taisen"
+  name: 新世紀勇者大戦
+  name-sort: しんせいきゆうしゃたいせん
+  name-en: "Shinseiki Yuusha Taisen"
   region: "NTSC-J"
 SLPM-65822:
-  name: "Ichigo 100% Strawberry Diary"
+  name: いちご100ストロベリーダイアリー
+  name-sort: いちご100すとろべりーだいありー
+  name-en: "Ichigo 100% Strawberry Diary"
   region: "NTSC-J"
 SLPM-65823:
-  name: "Shinsengumi Gunrou-den"
+  name: 新選組群狼伝
+  name-sort: しんせんぐみぐんろうでん
+  name-en: "Shinsengumi Gunrou-den"
   region: "NTSC-J"
 SLPM-65824:
-  name: "Viewtiful Joe 2"
+  name: ビューティフルジョー2 ブラックフィルムの謎
+  name-sort: びゅーてぃふるじょー2 ぶらっくふぃるむのなぞ
+  name-en: "Viewtiful Joe 2"
   region: "NTSC-J"
   compat: 5
 SLPM-65825:
-  name: "Jikkyou Powerful Pro Yakyuu 11 Chou Ketteiban"
+  name: 実況パワフルプロ野球11 超決定版
+  name-sort: じっきょうぱわふるぷろやきゅう11 ちょうけっていばん
+  name-en: "Jikkyou Powerful Pro Yakyuu 11 Chou Ketteiban"
   region: "NTSC-J"
 SLPM-65826:
-  name: "Tsukiyo ni Saraba"
+  name: ツキヨニサラバ
+  name-sort: つきよにさらば
+  name-en: "Tsukiyo ni Saraba"
   region: "NTSC-J"
   compat: 5
 SLPM-65828:
-  name: "Angel Wish - Kimi no Egao ni Chu!"
+  name: AngelWish 君の笑顔にチュッ!
+  name-sort: AngelWish くんのえがおにちゅっ!
+  name-en: "Angel Wish - Kimi no Egao ni Chu!"
   region: "NTSC-J"
 SLPM-65829:
-  name: "Ys - The Ark of Napishtim [Limited Edition]"
+  name: イース -ナピシュテムの匣- 限定版
+  name-sort: いーす -なぴしゅてむのはこ- げんていばん
+  name-en: "Ys - The Ark of Napishtim [Limited Edition]"
   region: "NTSC-J"
   gameFixes:
     - EETimingHack
 SLPM-65830:
-  name: "Ys - The Ark of Napishtim"
+  name: イース -ナピシュテムの匣- 初回生産版
+  name-sort: いーす -なぴしゅてむのはこ- しょかいせいさんばん
+  name-en: "Ys - The Ark of Napishtim"
   region: "NTSC-J"
   gameFixes:
     - EETimingHack
 SLPM-65831:
-  name: "Hello Kitty no PikoPiko Daisakusen"
+  name: ハローキティのピコピコ大作戦!
+  name-sort: はろーきてぃのぴこぴこだいさくせん!
+  name-en: "Hello Kitty no PikoPiko Daisakusen"
   region: "NTSC-J"
 SLPM-65832:
-  name: "Izumo Complete"
+  name: IZUMO コンプリート
+  name-sort: IZUMO こんぷりーと
+  name-en: "Izumo Complete"
   region: "NTSC-J"
 SLPM-65833:
-  name: "Harukanaru Jikuu no Naka De 2 [Koei the Best]"
+  name: KOEI The Best 遙かなる時空の中で 2
+  name-sort: KOEI The Best はるかなるときのなかで 2
+  name-en: "Harukanaru Jikuu no Naka De 2 [Koei the Best]"
   region: "NTSC-J"
 SLPM-65834:
-  name: "Harukanaru Jikuu no Naka De 3"
+  name: 遙かなる時空の中で3
+  name-sort: はるかなるときのなかで3
+  name-en: "Harukanaru Jikuu no Naka De 3"
   region: "NTSC-J"
 SLPM-65835:
-  name: "Bakumatsu Renka - Shinsengumi"
+  name: 幕末恋華・新選組
+  name-sort: ばくまつれんか・しんせんぐみ
+  name-en: "Bakumatsu Renka - Shinsengumi"
   region: "NTSC-J"
 SLPM-65836:
-  name: "Ys - The Ark of Napishtim"
+  name: イース ナピシュテムの匣
+  name-sort: いーす なぴしゅてむのはこ
+  name-en: "Ys - The Ark of Napishtim"
   region: "NTSC-J"
   gameFixes:
     - EETimingHack
 SLPM-65837:
-  name: "Terminator 3 - Redemption"
+  name: Terminator 3:The Redemption
+  name-sort: Terminator 3:The Redemption
+  name-en: "Terminator 3 - Redemption"
   region: "NTSC-J"
 SLPM-65838:
-  name: "Hanjuku Hero 4 [Limited Edition]"
+  name: 半熟銀河弁当 半熟英雄4 〜7人の半熟英雄〜(限定版)
+  name-sort: はんじゅくぎんがべんとう はんじゅくえいゆう4 〜7にんのはんじゅくえいゆう〜(げんていばん)
+  name-en: "Hanjuku Hero 4 [Limited Edition]"
   region: "NTSC-J"
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes clipping sprites.
     cpuSpriteRenderLevel: 2 # Needed for above.
 SLPM-65839:
-  name: "Hanjuku Hero 4"
+  name: 半熟英雄4 〜7人の半熟英雄〜
+  name-sort: はんじゅくえいゆう4 〜7にんのはんじゅくえいゆう〜
+  name-en: "Hanjuku Hero 4"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes clipping sprites.
     cpuSpriteRenderLevel: 2 # Needed for above.
 SLPM-65840:
-  name: "Wizardry X - Zensen no Gakufu"
+  name: ウィザードリィ エクス 〜前線の学府〜
+  name-sort: うぃざーどりぃ えくす 〜ぜんせんのがくふ〜
+  name-en: "Wizardry X - Zensen no Gakufu"
   region: "NTSC-J"
 SLPM-65841:
-  name: "Mizuiro [Best]"
+  name: みずいろ ベスト版
+  name-sort: みずいろ べすとばん
+  name-en: "Mizuiro [Best]"
   region: "NTSC-J"
 SLPM-65842:
-  name: "Kanon [Best]"
+  name: Kanon ベスト版
+  name-sort: Kanon べすとばん
+  name-en: "Kanon [Best]"
   region: "NTSC-J"
 SLPM-65843:
-  name: "120 Yen no Haru - 120 Yen Stories"
+  name: 120円の春
+  name-sort: 120えんのはる
+  name-en: "120 Yen no Haru - 120 Yen Stories"
   region: "NTSC-J"
   gsHWFixes:
     cpuCLUTRender: 1 # Fixes CLUT generation.
 SLPM-65844:
-  name: "Air [Best]"
+  name: AIR ベスト版
+  name-sort: AIR べすとばん
+  name-en: "Air [Best]"
   region: "NTSC-J"
 SLPM-65845:
-  name: "Baldur's Gate - Dark Alliance II"
+  name: Baldur’s Gate DARK ALLIANCE II
+  name-sort: Baldur’s Gate DARK ALLIANCE II
+  name-en: "Baldur's Gate - Dark Alliance II"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
     roundSprite: 1 # Fixes lines in sprites but still some lines left.
     estimateTextureRegion: 1 # Improves performance.
 SLPM-65846:
-  name: "Lord of the Rings, The - Uchitsu Kuni Daisanki"
+  name: ロード・オブ・ザ・リング 中つ国第三紀
+  name-sort: ろーど・おぶ・ざ・りんぐ なかつくにだいさんき
+  name-en: "Lord of the Rings, The - Uchitsu Kuni Daisanki"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
 SLPM-65847:
-  name: "Soriaro no Fuukin Remix [First Print - Limited Edition]"
+  name: 空色の風琴 〜Remix〜 初回限定版
+  name-sort: そらいろのおるがん 〜Remix〜 しょかいげんていばん
+  name-en: "Soriaro no Fuukin Remix [First Print - Limited Edition]"
   region: "NTSC-J"
 SLPM-65848:
-  name: "Soriaro no Fuukin Remix"
+  name: 空色の風琴 〜Remix〜
+  name-sort: そらいろのおるがん 〜Remix〜
+  name-en: "Soriaro no Fuukin Remix"
   region: "NTSC-J"
 SLPM-65850:
   name: "Harukanaru Toki no Naka de 3 [Triple Pack]"
@@ -35596,57 +38643,87 @@ SLPM-65852:
   name: "Exciting Pro Wres 6"
   region: "NTSC-J"
 SLPM-65853:
-  name: "Let's Make a Baseball Team 3"
+  name: プロ野球チームをつくろう!3
+  name-sort: ぷろやきゅうちーむをつくろう!3
+  name-en: "Let's Make a Baseball Team 3"
   region: "NTSC-J"
 SLPM-65854:
-  name: "Red Dead Revolver"
+  name: レッド・デッド・リボルバー
+  name-sort: れっど・でっど・りぼるばー
+  name-en: "Red Dead Revolver"
   region: "NTSC-J"
 SLPM-65855:
-  name: "Girls Bravo - Romance 15's [Deluxe Pack]"
+  name: GIRLSブラボー Romance15’s DXパック
+  name-sort: GIRLSぶらぼー Romance15’s DXぱっく
+  name-en: "Girls Bravo - Romance 15's [Deluxe Pack]"
   region: "NTSC-J"
 SLPM-65856:
-  name: "Girls Bravo - Romance 15's"
+  name: GIRLSブラボー Romance15’s
+  name-sort: GIRLSぶらぼー Romance15’s
+  name-en: "Girls Bravo - Romance 15's"
   region: "NTSC-J"
 SLPM-65857:
-  name: "Memories Off - After Rain Vol.1 [Special Edition]"
+  name: メモリーズオフ アフターレイン vol.1 折鶴 SPECIAL EDITION
+  name-sort: めもりーずおふ あふたーれいん vol.1 おりづる SPECIAL EDITION
+  name-en: "Memories Off - After Rain Vol.1 [Special Edition]"
   region: "NTSC-J"
 SLPM-65858:
-  name: "Memories Off - After Rain Vol.1"
+  name: メモリーズオフ アフターレイン Vol.1 折鶴
+  name-sort: めもりーずおふ あふたーれいん Vol.1 おりづる
+  name-en: "Memories Off - After Rain Vol.1"
   region: "NTSC-J"
 SLPM-65859:
   name: "Junrui Sosa - Kan Pony - Eirian vs. Seirian"
   region: "NTSC-J"
 SLPM-65860:
-  name: "Shinki Gensou Spectral Souls II [Premium Box]"
+  name: 新紀幻想 スペクトラルソウルズ II 限定版
+  name-sort: しんきげんそう すぺくとらるそうるず II げんていばん
+  name-en: "Shinki Gensou Spectral Souls II [Premium Box]"
   region: "NTSC-J"
 SLPM-65861:
-  name: "Shinki Gensou Spectral Souls II"
+  name: 新紀幻想 スペクトラルソウルズ II
+  name-sort: しんきげんそう すぺくとらるそうるず II
+  name-en: "Shinki Gensou Spectral Souls II"
   region: "NTSC-J"
 SLPM-65862:
-  name: "Pyua Pyua Mimi Toshippono Monogatari"
+  name: ぴゅあぴゅあ 耳としっぽのものがたり
+  name-sort: ぴゅあぴゅあ みみとしっぽのものがたり
+  name-en: "Pyua Pyua Mimi Toshippono Monogatari"
   region: "NTSC-J"
 SLPM-65863:
-  name: "D1 Grand Prix Series - Professional Drift"
+  name: D1グランプリ
+  name-sort: D1ぐらんぷり
+  name-en: "D1 Grand Prix Series - Professional Drift"
   region: "NTSC-J"
   clampModes:
     eeClampMode: 3 # Fixes black void.
 SLPM-65864:
-  name: "Nobunaga no Yabou - Tenka Sousei [with Power-Up Kit]"
+  name: 信長の野望・天下創世 with パワーアップキット
+  name-sort: のぶながのやぼう・てんかそうせい with ぱわーあっぷきっと
+  name-en: "Nobunaga no Yabou - Tenka Sousei [with Power-Up Kit]"
   region: "NTSC-J"
 SLPM-65866:
-  name: "Izuku e Iku no, Anohi"
+  name: 何処へ行くの、あの日 〜光る明日へ…〜
+  name-sort: どこへいくの、あのひ 〜ひかるあしたへ…〜
+  name-en: "Izuku e Iku no, Anohi"
   region: "NTSC-J"
 SLPM-65867:
-  name: "Shinseiki Evangelion - Koutetsu no Girlfriend 2nd"
+  name: 新世紀エヴァンゲリオン 鋼鉄のガールフレンド2nd
+  name-sort: しんせいきえゔぁんげりおん こうてつのがーるふれんど2nd
+  name-en: "Shinseiki Evangelion - Koutetsu no Girlfriend 2nd"
   region: "NTSC-J"
   compat: 5
 SLPM-65868:
-  name: "Metal Saga - Chain of Cloud"
+  name: METAL SAGA 〜砂塵の鎖〜
+  name-sort: METAL SAGA 〜さじんのくさり〜
+  name-en: "Metal Saga - Chain of Cloud"
   region: "NTSC-J"
   gameFixes:
     - DMABusyHack # Intro FMV.
 SLPM-65869:
-  name: "Monster Hunter G"
+  name: モンスターハンターG
+  name-sort: もんすたーはんたーG
+  name-en: "Monster Hunter G"
   region: "NTSC-J"
   compat: 5
   clampModes:
@@ -35654,38 +38731,58 @@ SLPM-65869:
   gsHWFixes:
     maximumBlendingLevel: 0 # Fixes unnecessary load on the GPU.
 SLPM-65870:
-  name: "Magic Teacher Negima - Honor Version"
+  name: 魔法先生ネギま! 1時間目 お子ちゃま先生は魔法使い!〜優等生版
+  name-sort: まほうせんせいねぎま! 1じかんめ おこちゃませんせいはまほうつかい!〜ゆうとうせいばん
+  name-en: "Magic Teacher Negima - Honor Version"
   region: "NTSC-J"
 SLPM-65871:
-  name: "Magic Teacher Negima - Scholarship Version"
+  name: 魔法先生ネギま! 1時間目 お子ちゃま先生は魔法使い!〜特待生版
+  name-sort: まほうせんせいねぎま! 1じかんめ おこちゃませんせいはまほうつかい!〜とくたいせいばん
+  name-en: "Magic Teacher Negima - Scholarship Version"
   region: "NTSC-J"
   compat: 5
 SLPM-65872:
-  name: "Simple 2000 Series Ultimate Vol. 24 - Makai Tenshou"
+  name: SIMPLE2000シリーズUltimate Vol.24 魔界転生
+  name-sort: SIMPLE2000しりーずUltimate Vol.24 まかいてんしょう
+  name-en: "Simple 2000 Series Ultimate Vol. 24 - Makai Tenshou"
   region: "NTSC-J"
 SLPM-65873:
-  name: "Simple 2000 Series Ultimate Vol. 23 - Project Minerva Professional"
+  name: SIMPLE2000シリーズUltimate Vol.23 プロジェクト・ミネルヴァ プロフェッショナル
+  name-sort: SIMPLE2000しりーずUltimate Vol.23 ぷろじぇくと・みねるゔぁ ぷろふぇっしょなる
+  name-en: "Simple 2000 Series Ultimate Vol. 23 - Project Minerva Professional"
   region: "NTSC-J"
 SLPM-65874:
-  name: "Simple 2000 Series Vol. 71 - The Fantasy Renai Adventure - Kanojo no Densetsu"
+  name: SIMPLE2000シリーズ Vol.71 THE ファンタジー恋愛アドベンチャー〜彼女の伝説、僕の石版〜
+  name-sort: SIMPLE2000しりーず Vol.71 THE ふぁんたじーれんあいあどべんちゃー〜かのじょのでんせつ、ぼくのせきばん〜
+  name-en: "Simple 2000 Series Vol. 71 - The Fantasy Renai Adventure - Kanojo no Densetsu"
   region: "NTSC-J"
 SLPM-65875:
-  name: "Growlanser IV - Wayfarer of the Time [Atlus The Best]"
+  name: グローランサーIV 〜 Wayfarer of the time 〜 (Atlus Best Collection)
+  name-sort: ぐろーらんさーIV 〜 Wayfarer of the time 〜 (Atlus Best Collection)
+  name-en: "Growlanser IV - Wayfarer of the Time [Atlus The Best]"
   region: "NTSC-J"
 SLPM-65876:
-  name: "Busin 0 - Wizardry Alternative Neo [Atlus Best Collection]"
+  name: BUSIN 0 Wizardry Alternative NEO(Atlus Best Collection)
+  name-sort: BUSIN 0 Wizardry Alternative NEO(Atlus Best Collection)
+  name-en: "Busin 0 - Wizardry Alternative Neo [Atlus Best Collection]"
   region: "NTSC-J"
   gsHWFixes:
     autoFlush: 2 # Corrects blur effects in menus.
     roundSprite: 2 # Aligns some text/graphics when upscaling.
 SLPM-65878:
-  name: "Galaxy Angel - Eternal Lovers"
+  name: ギャラクシーエンジェル Eternal Lovers スタンダードパッケージ
+  name-sort: ぎゃらくしーえんじぇる Eternal Lovers すたんだーどぱっけーじ
+  name-en: "Galaxy Angel - Eternal Lovers"
   region: "NTSC-J"
 SLPM-65879:
-  name: "Love Hina Gorgeous [Konami Dendou Selection]"
+  name: ラブひな ご〜じゃす チラッとハプニング (コナミ殿堂セレクション)
+  name-sort: らぶひな ご〜じゃす ちらっとはぷにんぐ (こなみでんどうせれくしょん)
+  name-en: "Love Hina Gorgeous [Konami Dendou Selection]"
   region: "NTSC-J"
 SLPM-65880:
-  name: "Devil May Cry 3"
+  name: Devil May Cry 3
+  name-sort: Devil May Cry 3
+  name-en: "Devil May Cry 3"
   region: "NTSC-J"
   compat: 5
   roundModes:
@@ -35694,30 +38791,46 @@ SLPM-65880:
     halfPixelOffset: 2 # Reduces ghosting but still an issue compared to native.
     roundSprite: 2 # Clears up much of the blurring that HPO Special does not.
 SLPM-65881:
-  name: "SmackDown vs. Raw - Exciting Professional Wrestling 6"
+  name: エキサイティングプロレス6 SMACKDOWN! Vs RAW
+  name-sort: えきさいてぃんぐぷろれす6 SMACKDOWN! Vs RAW
+  name-en: "SmackDown vs. Raw - Exciting Professional Wrestling 6"
   region: "NTSC-J"
 SLPM-65882:
-  name: "Duel Masters"
+  name: デュエル・マスターズ 〜邪封超龍転生(バース・オブ・スーパードラゴン)〜
+  name-sort: でゅえる・ますたーず 〜ばーす・おぶ・すーぱーどらごん〜
+  name-en: "Duel Masters"
   region: "NTSC-J"
 SLPM-65883:
-  name: "Shadow of Rome"
+  name: シャドウ・オブ・ローマ
+  name-sort: しゃどう・おぶ・ろーま
+  name-en: "Shadow of Rome"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness and misaligned garbage when upscaling.
 SLPM-65884:
-  name: "Remote Control Dandy SF"
+  name: リモートコントロールダンディSF
+  name-sort: りもーとこんとろーるだんでぃSF
+  name-en: "Remote Control Dandy SF"
   region: "NTSC-J"
 SLPM-65885:
-  name: "Rumble Roses"
+  name: RUMBLE ROSES(ランブルローズ)
+  name-sort: RUMBLE ROSES(らんぶるろーず)
+  name-en: "Rumble Roses"
   region: "NTSC-J"
 SLPM-65886:
-  name: "Guisard Revolution"
+  name: ガイザード・レボリューション 〜 僕らは想いを身に纏う 〜
+  name-sort: がいざーど・れぼりゅーしょん 〜 ぼくらはおもいをみにまとう 〜
+  name-en: "Guisard Revolution"
   region: "NTSC-J"
 SLPM-65887:
-  name: "Like Life an Hour"
+  name: Like Life an hour
+  name-sort: Like Life an hour
+  name-en: "Like Life an Hour"
   region: "NTSC-J"
 SLPM-65888:
-  name: "Dragon Quest VIII"
+  name: ドラゴンクエストVIII　空と海と大地と呪われし姫君
+  name-sort: どらごんくえすとVIII　そらとうみとだいちとのろわれしひめぎみ
+  name-en: "Dragon Quest VIII"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
@@ -35727,137 +38840,209 @@ SLPM-65888:
     roundSprite: 1 # Fixes font artifacts.
     PCRTCOverscan: 1 # Fixes offscreen image.
 SLPM-65889:
-  name: "Kazoku Keikaku - Kokoro no Kizuna"
+  name: 家族計画〜心の絆〜
+  name-sort: かぞくけいかく〜こころのきずな〜
+  name-en: "Kazoku Keikaku - Kokoro no Kizuna"
   region: "NTSC-J"
   gsHWFixes:
     cpuCLUTRender: 1 # Fixes broken colors.
 SLPM-65890:
-  name: "Shin Sangoku Musou 4"
+  name: 真・三國無双4
+  name-sort: しん・さんごくむそう4
+  name-en: "Shin Sangoku Musou 4"
   region: "NTSC-J"
 SLPM-65891:
-  name: "Sangokushi X"
+  name: 三國志X
+  name-sort: さんごくしX
+  name-en: "Sangokushi X"
   region: "NTSC-J"
 SLPM-65892:
-  name: "Zill O'll Infinite"
+  name: Zill O’ll 〜infinite〜
+  name-sort: Zill O’ll 〜infinite〜
+  name-en: "Zill O'll Infinite"
   region: "NTSC-J"
 SLPM-65894:
-  name: "Winning Post 6 2005 Version"
+  name: WinningPost6 2005年度版
+  name-sort: WinningPost6 2005ねんどばん
+  name-en: "Winning Post 6 2005 Version"
   region: "NTSC-J"
 SLPM-65895:
   name: "Tsuki wa Kirisaku [Limited Edition]"
   region: "NTSC-J"
 SLPM-65896:
-  name: "Tsuki wa Kirisaku"
+  name: 月は切り裂く〜探偵 相楽恭一郎〜
+  name-sort: つきはきりさく〜たんてい さがらきょういちろう〜
+  name-en: "Tsuki wa Kirisaku"
   region: "NTSC-J"
 SLPM-65897:
-  name: "Racing Battle - C1 Grand Prix"
+  name: レーシングバトル -C1 GRAND PRIX-
+  name-sort: れーしんぐばとる -C1 GRAND PRIX-
+  name-en: "Racing Battle - C1 Grand Prix"
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
     wildArmsHack: 1 # De-blurs the 3D image.
 SLPM-65898:
-  name: "Castle Fantasia [Deluxe Pack]"
+  name: キャッスルファンタジア エレンシア戦記 DXパック
+  name-sort: きゃっするふぁんたじあ えれんしあせんき DXぱっく
+  name-en: "Castle Fantasia [Deluxe Pack]"
   region: "NTSC-J"
 SLPM-65899:
-  name: "Castle Fantasia"
+  name: キャッスルファンタジア エレンシア戦記
+  name-sort: きゃっするふぁんたじあ えれんしあせんき
+  name-en: "Castle Fantasia"
   region: "NTSC-J"
 SLPM-65900:
-  name: "Sakura Taisen 3 - Remake"
+  name: サクラ大戦3 〜巴里は燃えているか〜初回プレス版
+  name-sort: さくらたいせん3 〜ぱりはもえているか〜しょかいぷれすばん
+  name-en: "Sakura Taisen 3 - Remake"
   region: "NTSC-J"
   compat: 2
 SLPM-65901:
-  name: "Shark Tale"
+  name: シャーク・テイル
+  name-sort: しゃーく・ている
+  name-en: "Shark Tale"
   region: "NTSC-J"
   speedHacks:
     mtvu: 0 # Fixes bad graphics due to bad T-Bit handling.
 SLPM-65902:
-  name: "Memories Off - After Rain Vol.2 Souen [Special Edition]"
+  name: メモリーズオフ アフターレイン vol.2 想演 SPECIAL EDITION
+  name-sort: めもりーずおふ あふたーれいん vol.2 そうえん SPECIAL EDITION
+  name-en: "Memories Off - After Rain Vol.2 Souen [Special Edition]"
   region: "NTSC-J"
 SLPM-65903:
-  name: "Memories Off - After Rain Vol.2 Souen"
+  name: メモリーズオフ アフターレイン Vol.2 想演
+  name-sort: めもりーずおふ あふたーれいん Vol.2 そうえん
+  name-en: "Memories Off - After Rain Vol.2 Souen"
   region: "NTSC-J"
 SLPM-65904:
-  name: "Baldr Force EXE"
+  name: バルドフォース エグゼ
+  name-sort: ばるどふぉーす えぐぜ
+  name-en: "Baldr Force EXE"
   region: "NTSC-J"
 SLPM-65906:
-  name: "Sakura Taisen 3 - Remake"
+  name: サクラ大戦3 〜巴里は燃えているか〜
+  name-sort: さくらたいせん3 〜ぱりはもえているか〜
+  name-en: "Sakura Taisen 3 - Remake"
   region: "NTSC-J"
 SLPM-65907:
-  name: "Def Jam Fight for NY"
+  name: DEF JAM FIGHT FOR NY
+  name-sort: DEF JAM FIGHT FOR NY
+  name-en: "Def Jam Fight for NY"
   region: "NTSC-J"
 SLPM-65908:
-  name: "Shining Force Neo"
+  name: シャイニング・フォース ネオ
+  name-sort: しゃいにんぐ・ふぉーす ねお
+  name-en: "Shining Force Neo"
   region: "NTSC-J"
 SLPM-65909:
-  name: "Super Monkey Ball Deluxe"
+  name: スーパーモンキーボール デラックス
+  name-sort: すーぱーもんきーぼーる でらっくす
+  name-en: "Super Monkey Ball Deluxe"
   region: "NTSC-J"
   roundModes:
     eeRoundMode: 1 # Fixes object balls never stopping in the Monkey Billiards DX minigame.
 SLPM-65910:
-  name: "Cafe Lindbergh - Summer Season [Sweet Box]"
+  name: カフェ・リンドバーグ -summer season-(Sweet Box 版)
+  name-sort: かふぇ・りんどばーぐ -summer season-(Sweet Box ばん)
+  name-en: "Cafe Lindbergh - Summer Season [Sweet Box]"
   region: "NTSC-J"
 SLPM-65911:
-  name: "Cafe Lindbergh - Summer Season"
+  name: カフェ・リンドバーグ −summer season−
+  name-sort: かふぇ・りんどばーぐ −summer season−
+  name-en: "Cafe Lindbergh - Summer Season"
   region: "NTSC-J"
 SLPM-65912:
-  name: "Boboboubo Boubobo [Hudson the Best]"
+  name: ボボボーボ・ボーボボ ハジけ祭 ハドソン・ザ・ベスト
+  name-sort: ぼぼぼーぼ・ぼーぼぼ はじけまつり はどそん・ざ・べすと
+  name-en: "Boboboubo Boubobo [Hudson the Best]"
   region: "NTSC-J"
 SLPM-65913:
-  name: "Demento"
+  name: DEMENTO
+  name-sort: DEMENTO
+  name-en: "Demento"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
     halfPixelOffset: 1 # Fixes blurriness.
     beforeDraw: "OI_HauntingGround" # Fix bloom.
 SLPM-65914:
-  name: "Nana"
+  name: NANA
+  name-sort: NANA
+  name-en: "Nana"
   region: "NTSC-J"
   compat: 5
 SLPM-65915:
-  name: "Fallout - Brotherhood of Steel"
+  name: Fallout BROTHERHOOD OF STEEL
+  name-sort: Fallout BROTHERHOOD OF STEEL
+  name-en: "Fallout - Brotherhood of Steel"
   region: "NTSC-J"
   gsHWFixes:
     estimateTextureRegion: 1 # Improves performance and reduces hash cache size when moving.
     roundSprite: 1 # Fixes HUD garbage.
 SLPM-65916:
-  name: "Harukanaru Jikuu no Kade - Hachiha Katsunori"
+  name: 遙かなる時空の中で 〜八葉抄〜
+  name-sort: はるかなるときのなかで 〜はちようしょう〜
+  name-en: "Harukanaru Jikuu no Kade - Hachiha Katsunori"
   region: "NTSC-J"
 SLPM-65917:
-  name: "Transformers Tatakai [The Best]"
+  name: THE BEST タカラモノ トランスフォーマー
+  name-sort: THE BEST たからもの とらんすふぉーまー
+  name-en: "Transformers Tatakai [The Best]"
   region: "NTSC-J"
 SLPM-65918:
-  name: "Dear My Love - Love Like Powdery Snow"
+  name: Dear My Friend 〜Love like powdery snow〜
+  name-sort: Dear My Friend 〜Love like powdery snow〜
+  name-en: "Dear My Love - Love Like Powdery Snow"
   region: "NTSC-J"
 SLPM-65919:
-  name: "Rumble Fish, The"
+  name: THE RUMBLE FISH(ザ・ランブルフィッシュ)
+  name-sort: THE RUMBLE FISH(ざ・らんぶるふぃっしゅ)
+  name-en: "Rumble Fish, The"
   region: "NTSC-J"
   compat: 5
 SLPM-65920:
-  name: "Romancing SaGa - Minstrel Song"
+  name: Romancing SaGa −Minstrel Song−
+  name-sort: Romancing SaGa -Minstrel Song-
+  name-en: "Romancing SaGa - Minstrel Song"
   region: "NTSC-J"
   compat: 5
 SLPM-65921:
-  name: "Pia Carrot e Youkoso!! 3 [Best Version]"
+  name: Piaキャロットへようこそ!!3(ベスト版)
+  name-sort: Piaきゃろっとへようこそ!!3(べすとばん)
+  name-en: "Pia Carrot e Youkoso!! 3 [Best Version]"
   region: "NTSC-J"
 SLPM-65922:
-  name: "Aikagi [Best Version]"
+  name: あいかぎ 〜ぬくもりとひだまりの中で〜 (ベスト版)
+  name-sort: あいかぎ 〜ぬくもりとひだまりのなかで〜 (べすとばん)
+  name-en: "Aikagi [Best Version]"
   region: "NTSC-J"
 SLPM-65923:
-  name: "Canvas [Best Version]"
+  name: Canvas 〜セピア色のモチーフ〜 (ベスト版)
+  name-sort: Canvas 〜せぴあいろのもちーふ〜 (べすとばん)
+  name-en: "Canvas [Best Version]"
   region: "NTSC-J"
 SLPM-65924:
-  name: "Kono Haretasora no Shita de [Limited Edition]"
+  name: この晴れた空の下で (数量限定版)
+  name-sort: このはれたそらのしたで (すうりょうげんていばん)
+  name-en: "Kono Haretasora no Shita de [Limited Edition]"
   region: "NTSC-J"
 SLPM-65925:
-  name: "Kono Haretasora no Shita de"
+  name: この晴れた空の下で
+  name-sort: このはれたそらのしたで
+  name-en: "Kono Haretasora no Shita de"
   region: "NTSC-J"
 SLPM-65926:
-  name: "Ys IV - Mask of the Sun - A New Theory"
+  name: イースIV 〜Mask of the Sun -a new theory〜
+  name-sort: いーすIV 〜Mask of the Sun -a new theory〜
+  name-en: "Ys IV - Mask of the Sun - A New Theory"
   region: "NTSC-J"
   clampModes:
     eeClampMode: 3 # Fixes camera going off screen.
 SLPM-65927:
-  name: "Forgotten Realms - Demon Stone"
+  name: DEMON STONE デーモンストーン
+  name-sort: DEMON STONE でーもんすとーん
+  name-en: "Forgotten Realms - Demon Stone"
   region: "NTSC-J"
   clampModes:
     vuClampMode: 3 # Removes occasional SPS where the head goes into nightmare fuel.
@@ -35865,68 +39050,106 @@ SLPM-65927:
     halfPixelOffset: 1 # Reduces ghosting.
     roundSprite: 1 # Reduces ghosting even more.
 SLPM-65928:
-  name: "SuperLite 2000 Series - Memories Off Mix"
+  name: SuperLite 2000 バラエティ メモオフみっくす
+  name-sort: SuperLite 2000 ばらえてぃ めもおふみっくす
+  name-en: "SuperLite 2000 Series - Memories Off Mix"
   region: "NTSC-J"
 SLPM-65929:
-  name: "Pro Baseball Spirits 2"
+  name: プロ野球スピリッツ 2
+  name-sort: ぷろやきゅうすぴりっつ 2
+  name-en: "Pro Baseball Spirits 2"
   region: "NTSC-J"
 SLPM-65930:
-  name: "EVE - Burst Error Plus [GameBridge The Best]"
+  name: EVE burst error PLUS ゲームビレッジ・ザ・ベスト
+  name-sort: EVE burst error PLUS げーむびれっじ・ざ・べすと
+  name-en: "EVE - Burst Error Plus [GameBridge The Best]"
   region: "NTSC-J"
 SLPM-65931:
-  name: "Shinseiki Genso - Spectral Souls [IF Collection]"
+  name: IFコレクション 新紀幻想スペクトラルソウルズ
+  name-sort: IFこれくしょん しんきげんそうすぺくとらるそうるず
+  name-en: "Shinseiki Genso - Spectral Souls [IF Collection]"
   region: "NTSC-J"
 SLPM-65932:
-  name: "Sento Country Kai - New Operation [with Bonus DVD]"
+  name: 戦闘国家・改 NEW OPERATIONS
+  name-sort: せんとうこっか・かい NEW OPERATIONS
+  name-en: "Sento Country Kai - New Operation [with Bonus DVD]"
   region: "NTSC-J"
 SLPM-65934:
-  name: "Maple Colors"
+  name: メイプルカラーズ 〜決戦は学園祭〜
+  name-sort: めいぷるからーず 〜けっせんはがくえんさい〜
+  name-en: "Maple Colors"
   region: "NTSC-J"
 SLPM-65935:
-  name: "Princess Maker 4 [Limited Edition]"
+  name: プリンセスメーカー4 コレクターズエディション
+  name-sort: ぷりんせすめーかー4 これくたーずえでぃしょん
+  name-en: "Princess Maker 4 [Limited Edition]"
   region: "NTSC-J"
 SLPM-65936:
-  name: "Princess Maker 4"
+  name: プリンセスメーカー4
+  name-sort: ぷりんせすめーかー4
+  name-en: "Princess Maker 4"
   region: "NTSC-J"
 SLPM-65937:
-  name: "Siekai no Senki"
+  name: 星界の戦旗
+  name-sort: せいかいのせんき
+  name-en: "Siekai no Senki"
   region: "NTSC-J"
 SLPM-65938:
-  name: "Memories Off - After Rain Vol.3 [Special Edition]"
+  name: メモリーズオフ アフターレイン vol.3 卒業 SPECIAL EDITION
+  name-sort: めもりーずおふ あふたーれいん vol.3 そつぎょう SPECIAL EDITION
+  name-en: "Memories Off - After Rain Vol.3 [Special Edition]"
   region: "NTSC-J"
 SLPM-65939:
-  name: "Memories Off - After Rain Vol.3"
+  name: メモリーズオフ アフターレイン Vol.3 卒業
+  name-sort: めもりーずおふ あふたーれいん Vol.3 そつぎょう
+  name-en: "Memories Off - After Rain Vol.3"
   region: "NTSC-J"
 SLPM-65940:
   name: "Mabino x Style"
   region: "NTSC-J"
 SLPM-65941:
-  name: "Mabino x Style"
+  name: マビノ×スタイル
+  name-sort: まびの×すたいる
+  name-en: "Mabino x Style"
   region: "NTSC-J"
 SLPM-65942:
-  name: "Mercenaries - Playground of Destruction"
+  name: MERCENARIES(マーセナリーズ)
+  name-sort: MERCENARIES(まーせなりーず)
+  name-en: "Mercenaries - Playground of Destruction"
   region: "NTSC-J"
   gsHWFixes:
     autoFlush: 2 # Fixes missing lighting.
     # halfPixelOffset: 1 # Fixes lighting misalignment. Do not enable this, it breaks a lot of graphics.
 SLPM-65943:
-  name: "Angel's Feather"
+  name: Angel’s Feather −黒の残影−
+  name-sort: Angel’s Feather -くろのざんかげ-
+  name-en: "Angel's Feather"
   region: "NTSC-J"
 SLPM-65944:
-  name: "Detective Saburou Jinguiji 9 - Kind of Blue [Workjam Best Collection - Vol.2]"
+  name: ワークジャム ベストコレクション Vol.2 探偵 神宮寺三郎 KIND OF BLUE
+  name-sort: わーくじゃむ べすとこれくしょん Vol.2 たんてい じんぐうじさぶろう KIND OF BLUE
+  name-en: "Detective Saburou Jinguiji 9 - Kind of Blue [Workjam Best Collection - Vol.2]"
   region: "NTSC-J"
 SLPM-65945:
-  name: "Red Ninja - End of Honor"
+  name: 紅忍 〜血河の舞〜
+  name-sort: れっどにんじゃ 〜ちかわのまい〜
+  name-en: "Red Ninja - End of Honor"
   region: "NTSC-J"
 SLPM-65946:
-  name: "Beatmania IIDX 9th Style"
+  name: beatmania IIDX 9th style
+  name-sort: beatmania IIDX 9th style
+  name-en: "Beatmania IIDX 9th style"
   region: "NTSC-J"
   compat: 5
 SLPM-65947:
-  name: "Killer7"
+  name: Killer7(キラー7)
+  name-sort: Killer7(きらー7)
+  name-en: "Killer7"
   region: "NTSC-J"
 SLPM-65948:
-  name: "Enthusia Professional Racing"
+  name: ENTHUSIA PROFESSIONAL RACING
+  name-sort: ENTHUSIA PROFESSIONAL RACING
+  name-en: "Enthusia Professional Racing"
   region: "NTSC-J"
   clampModes:
     eeClampMode: 3 # Fixes Freezing at the start of the race.
@@ -35937,32 +39160,50 @@ SLPM-65948:
   gameFixes:
     - SoftwareRendererFMVHack # Fixes upscale lines in FMVs.
 SLPM-65949:
-  name: "Get Ride! AM Driver - The Truth of Xiangke"
+  name: Get Ride!アムドライバー 〜相克の真実〜
+  name-sort: Get Ride!あむどらいばー 〜そうこくのしんじつ〜
+  name-en: "Get Ride! AM Driver - The Truth of Xiangke"
   region: "NTSC-J"
 SLPM-65950:
-  name: "Gantz - The Game"
+  name: GANTZ
+  name-sort: GANTZ
+  name-en: "Gantz - The Game"
   region: "NTSC-J"
   compat: 5
 SLPM-65951:
-  name: "Tom Clancy's Ghost Recon 2"
+  name: トム・クランシーシリーズ ゴーストリコン2
+  name-sort: とむ・くらんしーしりーず ごーすとりこん2
+  name-en: "Tom Clancy's Ghost Recon 2"
   region: "NTSC-J"
 SLPM-65952:
-  name: "Tengai Makyou III - Namida"
+  name: 天外魔境III NAMIDA
+  name-sort: てんがいまきょうIII NAMIDA
+  name-en: "Tengai Makyou III - Namida"
   region: "NTSC-J"
 SLPM-65953:
-  name: "Final Fantasy XI [Entry Disc 2005]"
+  name: プレイオンライン / ファイナルファンタジーXI エントリーディスク2005
+  name-sort: ぷれいおんらいん / ふぁいなるふぁんたじーXI えんとりーでぃすく2005
+  name-en: "Final Fantasy XI [Entry Disc 2005]"
   region: "NTSC-J"
 SLPM-65954:
-  name: "Tom Clancy's Ghost Recon [Ubisoft Best]"
+  name: ユービーアイベスト トム・クランシーシリーズ ゴーストリコン
+  name-sort: ゆーびーあいべすと とむ・くらんしーしりーず ごーすとりこん
+  name-en: "Tom Clancy's Ghost Recon [Ubisoft Best]"
   region: "NTSC-J"
 SLPM-65955:
-  name: "Tom Clancy's Splinter Cell [Ubisoft Best]"
+  name: ユービーアイソフトベスト トム・クランシーシリーズ スプリンターセル
+  name-sort: ゆーびーあいそふとべすと とむ・くらんしーしりーず すぷりんたーせる
+  name-en: "Tom Clancy's Splinter Cell [Ubisoft Best]"
   region: "NTSC-J"
 SLPM-65957:
-  name: "Harukanaru Jikuu no Kade Hachiha Katsunori"
+  name: 遙かなる時空の中で　〜八葉抄〜プレミアムBOX
+  name-sort: はるかなるときのなかで　〜はちようしょう〜ぷれみあむBOX
+  name-en: "Harukanaru Jikuu no Kade Hachiha Katsunori"
   region: "NTSC-J"
 SLPM-65958:
-  name: "Burnout 3 - Takedown [EA Best Hits]"
+  name: EA BEST HITS バーンアウト3:テイクダウン
+  name-sort: EA BEST HITS ばーんあうと3:ていくだうん
+  name-en: "Burnout 3 - Takedown [EA Best Hits]"
   region: "NTSC-J"
   clampModes:
     vuClampMode: 3 # Fixes buggy lighting in the garage.
@@ -35977,57 +39218,91 @@ SLPM-65958:
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
 SLPM-65959:
-  name: "Standard Daisenryaku - Ushinawareta Shouri"
+  name: スタンダード大戦略 失われた勝利
+  name-sort: すたんだーどだいせんりゃく うしなわれたしょうり
+  name-en: "Standard Daisenryaku - Ushinawareta Shouri"
   region: "NTSC-J"
 SLPM-65960:
-  name: "North Wind Promise Forever [Limited Edition]"
+  name: North Wind 〜永遠の約束〜 初回限定版
+  name-sort: North Wind 〜えいえんのやくそく〜 しょかいげんていばん
+  name-en: "North Wind Promise Forever [Limited Edition]"
   region: "NTSC-J"
 SLPM-65961:
-  name: "North Wind Promise Forever"
+  name: North Wind 〜永遠の約束〜
+  name-sort: North Wind 〜えいえんのやくそく〜
+  name-en: "North Wind Promise Forever"
   region: "NTSC-J"
 SLPM-65962:
-  name: "Home Maid - Owari no Tachi [Limited Edition]"
+  name: ホームメイド 〜終の館〜(初回限定版)
+  name-sort: ほーむめいど 〜ついのやかた〜(しょかいげんていばん)
+  name-en: "Home Maid - Owari no Tachi [Limited Edition]"
   region: "NTSC-J"
 SLPM-65963:
-  name: "Home Maid - Owari no Tachi"
+  name: ホームメイド 〜終の館〜
+  name-sort: ほーむめいど 〜ついのやかた〜
+  name-en: "Home Maid - Owari no Tachi"
   region: "NTSC-J"
 SLPM-65964:
-  name: "Magical Tale - Chitchana Mahoutsukai [Limited Edition]"
+  name: まじかる☆ている 〜ちっちゃな魔法使い〜(初回限定版)
+  name-sort: まじかる☆ている 〜ちっちゃなまほうつかい〜(しょかいげんていばん)
+  name-en: "Magical Tale - Chitchana Mahoutsukai [Limited Edition]"
   region: "NTSC-J"
 SLPM-65965:
-  name: "Magical Tale - Chitchana Mahoutsukai"
+  name: まじかる☆ている 〜ちっちゃな魔法使い〜
+  name-sort: まじかる☆ている 〜ちっちゃなまほうつかい〜
+  name-en: "Magical Tale - Chitchana Mahoutsukai"
   region: "NTSC-J"
 SLPM-65966:
-  name: "Spectral Force Chronicle [Limited Edition]"
+  name: スペクトラルフォース クロニクル 10周年記念BOX
+  name-sort: すぺくとらるふぉーす くろにくる 10しゅうねんきねんBOX
+  name-en: "Spectral Force Chronicle [Limited Edition]"
   region: "NTSC-J"
 SLPM-65967:
-  name: "Spectral Force Chronicle"
+  name: スペクトラルフォース クロニクル
+  name-sort: すぺくとらるふぉーす くろにくる
+  name-en: "Spectral Force Chronicle"
   region: "NTSC-J"
 SLPM-65968:
-  name: "Lovely Doll - Lovely Idol [Limited Edition]"
+  name: らぶドル 〜Lovely Idol〜 初回限定版
+  name-sort: らぶどる 〜Lovely Idol〜 しょかいげんていばん
+  name-en: "Lovely Doll - Lovely Idol [Limited Edition]"
   region: "NTSC-J"
 SLPM-65969:
-  name: "Lovely Doll - Lovely Idol"
+  name: らぶドル 〜Lovely Idol〜
+  name-sort: らぶどる 〜Lovely Idol〜
+  name-en: "Lovely Doll - Lovely Idol"
   region: "NTSC-J"
 SLPM-65970:
-  name: "Kappa no Kai-Kata - How to Breed Kappas [Konami Palace Selection]"
+  name: カッパの飼い方 -How to breed kappas- (コナミ殿堂セレクション)
+  name-sort: かっぱのかいかた -How to breed kappas- (こなみでんどうせれくしょん)
+  name-en: "Kappa no Kai-Kata - How to Breed Kappas [Konami Palace Selection]"
   region: "NTSC-J"
 SLPM-65971:
-  name: "Soshite Bokura wa... and He Said"
+  name: そして僕らは、・・・and he said
+  name-sort: そしてぼくらは、・・・and he said
+  name-en: "Soshite Bokura wa... and He Said"
   region: "NTSC-J"
 SLPM-65972:
-  name: "Constantine"
+  name: CONSTANTINE
+  name-sort: CONSTANTINE
+  name-en: "Constantine"
   region: "NTSC-J"
   roundModes:
     eeRoundMode: 2 # Resolves dumpster not being able to be climbed from front in level 2.
 SLPM-65973:
-  name: "Mirai Shounen Conan"
+  name: 未来少年コナン
+  name-sort: みらいしょうねんこなん
+  name-en: "Mirai Shounen Conan"
   region: "NTSC-J"
 SLPM-65974:
-  name: "Kenka Banchou"
+  name: 喧嘩番長(初回生産版)
+  name-sort: けんかばんちょう(しょかいせいさんばん)
+  name-en: "Kenka Banchou"
   region: "NTSC-J"
 SLPM-65975:
-  name: "WRC 4"
+  name: WRC4
+  name-sort: WRC4
+  name-en: "WRC 4"
   region: "NTSC-J"
   gameFixes:
     - XGKickHack # Fixes SPS.
@@ -36048,7 +39323,9 @@ SLPM-65975:
   roundModes:
     eeRoundMode: 2 # Fixes rainbow highlighting on cars.
 SLPM-65976:
-  name: "Grandia III [Disc 1 of 2]"
+  name: グランディアIII
+  name-sort: ぐらんでぃあIII
+  name-en: "Grandia III [Disc 1 of 2]"
   region: "NTSC-J"
   compat: 5
 SLPM-65977:
@@ -36058,77 +39335,113 @@ SLPM-65977:
   memcardFilters:
     - "SLPM-65976"
 SLPM-65978:
-  name: "Kurogane no Houkou 2 - Warship Gunner [Koei The Best]"
+  name: KOEI THE BEST 鋼鉄の咆哮2 ウォーシップガンナー
+  name-sort: KOEI THE BEST くろがねのほうこう2 うぉーしっぷがんなー
+  name-en: "Kurogane no Houkou 2 - Warship Gunner [Koei The Best]"
   region: "NTSC-J"
 SLPM-65980:
-  name: "Dream Mix TV World Fighters [Hudson the Best]"
+  name: ドリームミックスTV ワールドファイターズ ハドソン・ザ・ベスト
+  name-sort: どりーむみっくすTV わーるどふぁいたーず はどそん・ざ・べすと
+  name-en: "Dream Mix TV World Fighters [Hudson the Best]"
   region: "NTSC-J"
 SLPM-65981:
-  name: "Front Mission Online"
+  name: FRONT MISSION ONLINE(フロントミッション オンライン)
+  name-sort: FRONT MISSION ONLINE(ふろんとみっしょん おんらいん)
+  name-en: "Front Mission Online"
   region: "NTSC-J"
 SLPM-65982:
-  name: "Tokyo Bus Guide 2"
+  name: 東京バス案内(ガイド)2
+  name-sort: とうきょうばすあんない(がいど)2
+  name-en: "Tokyo Bus Guide 2"
   region: "NTSC-J"
   compat: 5
 SLPM-65984:
-  name: "Grand Theft Auto - San Andreas"
+  name: Grand Theft Auto:San Andreas
+  name-sort: Grand Theft Auto:San Andreas
+  name-en: "Grand Theft Auto - San Andreas"
   region: "NTSC-J"
   clampModes:
     eeClampMode: 2 # Fixes Game freezes during "Reuniting The Families" mission.
   gsHWFixes:
     autoFlush: 1 # Fixes post processing.
 SLPM-65985:
-  name: "Iris no Atelier - Eternal Mana 2"
+  name: イリスのアトリエ エターナルマナ2
+  name-sort: いりすのあとりえ えたーなるまな2
+  name-en: "Iris no Atelier - Eternal Mana 2"
   region: "NTSC-J"
   gsHWFixes:
     roundSprite: 1 # Fixes font artifacts for health and other sprites.
     texturePreloading: 0 # Improves performance and prevents it disabling itself regardless.
 SLPM-65986:
-  name: "Quartett! The Stage of Love [Limited Edition]"
+  name: Quartett!〜THE STAGE OF LOVE〜(初回限定版)
+  name-sort: Quartett!〜THE STAGE OF LOVE〜(しょかいげんていばん)
+  name-en: "Quartett! The Stage of Love [Limited Edition]"
   region: "NTSC-J"
 SLPM-65987:
-  name: "Quartett! The Stage of Love"
+  name: Quartett!〜THE STAGE OF LOVE〜
+  name-sort: Quartett!〜THE STAGE OF LOVE〜
+  name-en: "Quartett! The Stage of Love"
   region: "NTSC-J"
 SLPM-65988:
-  name: "Shoujo Yoshitsune Den 2 [Premium Pack]"
+  name: 少女義経伝・弐 〜刻を超える契り〜 (特別版)
+  name-sort: しょうじょよしつねでん・に 〜こくをこえるちぎり〜 (とくべつばん)
+  name-en: "Shoujo Yoshitsune Den 2 [Premium Pack]"
   region: "NTSC-J"
 SLPM-65989:
-  name: "Shoujo Yoshitsune Den 2"
+  name: 少女義経伝・弐 〜刻を超える契り〜
+  name-sort: しょうじょよしつねでん・に 〜こくをこえるちぎり〜
+  name-en: "Shoujo Yoshitsune Den 2"
   region: "NTSC-J"
 SLPM-65990:
-  name: "Neo Contra [Konami Palace Selection]"
+  name: NEO CONTRA(コナミ殿堂セレクション)
+  name-sort: NEO CONTRA(こなみでんどうせれくしょん)
+  name-en: "Neo Contra [Konami Palace Selection]"
   region: "NTSC-J"
   roundModes:
     eeRoundMode: 0 # Reduces FPU calculation errors.
   clampModes:
     eeClampMode: 2 # Reduces FPU calculation errors.
 SLPM-65991:
-  name: "Anubis - Zone of the Enders Special Edition [Konami Dendou Collection]"
+  name: ANUBIS ZONE OF THE ENDERS SPECIAL EDITION (コナミ殿堂セレクション)
+  name-sort: ANUBIS ZONE OF THE ENDERS SPECIAL EDITION (こなみでんどうせれくしょん)
+  name-en: "Anubis - Zone of the Enders Special Edition [Konami Dendou Collection]"
   region: "NTSC-J"
 SLPM-65994:
-  name: "Remember 11 - The Age of Infinity [Superlite 2000 Series]"
+  name: SuperLite 2000 アドベンチャー Remember11 -the age of infinity-
+  name-sort: SuperLite 2000 あどべんちゃー Remember11 -the age of infinity-
+  name-en: "Remember 11 - The Age of Infinity [Superlite 2000 Series]"
   region: "NTSC-J"
 SLPM-65995:
-  name: "Dog's Life"
+  name: ドッグズライフ
+  name-sort: どっぐずらいふ
+  name-en: "Dog's Life"
   region: "NTSC-J"
   clampModes:
     vuClampMode: 3 # Fixes minor SPS on characters.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes double image.
 SLPM-65996:
-  name: "Hametsu no Mars [Limited Edition]"
+  name: 破滅のマルス 限定版
+  name-sort: はめつのまるす げんていばん
+  name-en: "Hametsu no Mars [Limited Edition]"
   region: "NTSC-J"
 SLPM-65997:
-  name: "Hametsu no Mars"
+  name: 破滅のマルス
+  name-sort: はめつのまるす
+  name-en: "Hametsu no Mars"
   region: "NTSC-J"
 SLPM-65998:
-  name: "Vampire Darkstalkers Collection"
+  name: ヴァンパイア ダークストーカーズ コレクション
+  name-sort: ゔぁんぱいあ だーくすとーかーず これくしょん
+  name-en: "Vampire Darkstalkers Collection"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
     roundSprite: 1 # Fixes squares around sprites when upscaling.
 SLPM-65999:
-  name: "Drag-on Dragoon 2 - Fuuin no Aka, Haitoku no Kuro"
+  name: ドラッグ オン ドラグーン2 -封印の紅、背徳の黒-
+  name-sort: どらっぐ おん どらぐーん2 -ふういんのあか、はいとくのくろ-
+  name-en: "Drag-on Dragoon 2 - Fuuin no Aka, Haitoku no Kuro"
   region: "NTSC-J"
   clampModes:
     eeClampMode: 2 # Fixes wrong color on some characters and breakable objects.
@@ -36137,15 +39450,21 @@ SLPM-65999:
     mergeSprite: 1 # Align sprite fixes FMVs but not garbage in-game, so needs merge sprite instead.
     texturePreloading: 1 # Performs better with partial preload because it is slow on locations outside gameplay foremost.
 SLPM-66000:
-  name: "Conflict Delta II - Gulf War 1991"
+  name: コンフリクトデルタII 〜湾岸戦争1991〜
+  name-sort: こんふりくとでるたII 〜わんがんせんそう1991〜
+  name-en: "Conflict Delta II - Gulf War 1991"
   region: "NTSC-J"
   gameFixes:
     - SoftwareRendererFMVHack # Fixes seizure inducing FMVs.
 SLPM-66001:
-  name: "Chocolat - Maid Cafe Curio"
+  name: ショコラ　〜maid cafe curio〜
+  name-sort: しょこら　〜maid cafe curio〜
+  name-en: "Chocolat - Maid Cafe Curio"
   region: "NTSC-J"
 SLPM-66002:
-  name: "Prince of Persia - Warrior Within"
+  name: プリンス・オブ・ペルシャ ケンシ ノ ココロ
+  name-sort: ぷりんす・おぶ・ぺるしゃ けんし の こころ
+  name-en: "Prince of Persia - Warrior Within"
   region: "NTSC-J"
   gsHWFixes:
     autoFlush: 2 # Reduces post-processing misalignment.
@@ -36159,44 +39478,68 @@ SLPM-66005:
   name: "Harukanaru Toki no Naka de 3"
   region: "NTSC-J"
 SLPM-66006:
-  name: "Angelique Trois - Aizouhen [Koei Selection]"
+  name: コーエー定番シリーズ 愛蔵版 アンジェリークトロワ
+  name-sort: こーえーていばんしりーず あいぞうばん あんじぇりーくとろわ
+  name-en: "Angelique Trois - Aizouhen [Koei Selection]"
   region: "NTSC-J"
 SLPM-66007:
-  name: "Zoids Tactics"
+  name: ZOIDS TACTICS ゾイドタクティクス
+  name-sort: ZOIDS TACTICS ぞいどたくてぃくす
+  name-en: "Zoids Tactics"
   region: "NTSC-J"
 SLPM-66008:
-  name: "Musashiden II - Blademaster"
+  name: 武蔵伝II ブレイドマスター
+  name-sort: むさしでんII ぶれいどますたー
+  name-en: "Musashiden II - Blademaster"
   region: "NTSC-J"
 SLPM-66009:
-  name: "World Soccer Winning Eleven 9 - Bonus Pack"
+  name: ワールドサッカー ウイニングイレブン9
+  name-sort: わーるどさっかー ういにんぐいれぶん9
+  name-en: "World Soccer Winning Eleven 9 - Bonus Pack"
   region: "NTSC-J"
   compat: 5
 SLPM-66010:
-  name: "Tennis no Oji-Sama - Smash-Hit! [Konami Palace Selection]"
+  name: テニスの王子様 Smash Hit! (コナミ殿堂セレクション)
+  name-sort: てにすのおうじさま Smash Hit! (こなみでんどうせれくしょん)
+  name-en: "Tennis no Oji-Sama - Smash-Hit! [Konami Palace Selection]"
   region: "NTSC-J"
 SLPM-66011:
-  name: "Tennis no Oji-Sama - Smash-Hit! 2 [Konami Palace Selection]"
+  name: テニスの王子様 Smash Hit!2(コナミ殿堂セレクション)
+  name-sort: てにすのおうじさま Smash Hit!2(こなみでんどうせれくしょん)
+  name-en: "Tennis no Oji-Sama - Smash-Hit! 2 [Konami Palace Selection]"
   region: "NTSC-J"
 SLPM-66012:
-  name: "Tennis no Oji-Sama - Sweat & Tears 2 [Konami Palace Selection]"
+  name: テニスの王子様SWEAT&TEARS 2(コナミ殿堂セレクション)
+  name-sort: てにすのおうじさまSWEAT&TEARS 2(こなみでんどうせれくしょん)
+  name-en: "Tennis no Oji-Sama - Sweat & Tears 2 [Konami Palace Selection]"
   region: "NTSC-J"
 SLPM-66013:
-  name: "Tennis no Oji-Sama - Form the Strongest Team [Konami Palace Selection]"
+  name: テニスの王子様最強チームを結成せよ!(コナミ殿堂セレクション)
+  name-sort: てにすのおうじさまさいきょうちーむをけっせいせよ!(こなみでんどうせれくしょん)
+  name-en: "Tennis no Oji-Sama - Form the Strongest Team [Konami Palace Selection]"
   region: "NTSC-J"
 SLPM-66014:
-  name: "Tennis no Oji-Sama - Rush & Dream [Konami Palace Selection]"
+  name: テニスの王子様 RUSH&DREAM!(コナミ殿堂セレクション)
+  name-sort: てにすのおうじさま RUSH&DREAM!(こなみでんどうせれくしょん)
+  name-en: "Tennis no Oji-Sama - Rush & Dream [Konami Palace Selection]"
   region: "NTSC-J"
 SLPM-66015:
-  name: "SuperLite 2000 Series - Ever 17 - The Out of Infinity [Premium Edition]"
+  name: SuperLite 2000 アドベンチャー 藍より青し
+  name-sort: SuperLite 2000 あどべんちゃー あいよりあおし
+  name-en: "SuperLite 2000 Series - Ever 17 - The Out of Infinity [Premium Edition]"
   region: "NTSC-J"
 SLPM-66016:
-  name: "Jissen Pachi-Slot Hisshouhou! Onimusha 3"
+  name: 実戦パチスロ必勝法!鬼武者3
+  name-sort: じっせんぱちすろひっしょうほう!おにむしゃ3
+  name-en: "Jissen Pachi-Slot Hisshouhou! Onimusha 3"
   region: "NTSC-J"
 SLPM-66017:
   name: "Firefighter F.D.18"
   region: "NTSC-J"
 SLPM-66018:
-  name: "Silent Hill 3 [Konami Dendou Collection]"
+  name: サイレントヒル3 (コナミ殿堂セレクション)
+  name-sort: さいれんとひる3 (こなみでんどうせれくしょん)
+  name-en: "Silent Hill 3 [Konami Dendou Collection]"
   region: "NTSC-J"
   clampModes:
     vuClampMode: 2 # Fixes some lighting/shadow artefacts (most light sources like the Flashlight are unaffected).
@@ -36211,116 +39554,176 @@ SLPM-66018:
     - "SLPM-65341"
     - "SLPM-65631"
 SLPM-66019:
-  name: "Stuntman"
+  name: STUNTMAN スタントマン
+  name-sort: STUNTMAN すたんとまん
+  name-en: "Stuntman"
   region: "NTSC-J"
   gsHWFixes:
     cpuSpriteRenderBW: 4 # Fixes textures.
 SLPM-66020:
-  name: "Psi-Ops - The Mindgate Conspiracy"
+  name: サイオプス サイキック・オペレーション
+  name-sort: さいおぷす さいきっく・おぺれーしょん
+  name-en: "Psi-Ops - The Mindgate Conspiracy"
   region: "NTSC-J"
   gsHWFixes:
     roundSprite: 2 # Removes blurriness and artifacting at sides, esspecialy helps 3D11.
 SLPM-66021:
-  name: "NBA Street V3"
+  name: NBA ストリート V3
+  name-sort: NBA すとりーと V3
+  name-en: "NBA Street V3"
   region: "NTSC-J"
 SLPM-66022:
-  name: "Kaido Touge no Densetsu"
+  name: KAIDO -峠の伝説-
+  name-sort: KAIDO -とうげのでんせつ-
+  name-en: "Kaido Touge no Densetsu"
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
     wildArmsHack: 1 # De-blurs the 3D image.
 SLPM-66023:
-  name: "Fushigi Yuugi - ShigiYuugi Kurotake Kaiden Gaiden - Kagami no Fujo [Limited Edition]"
+  name: 〜ふしぎ遊戯玄武開伝外伝〜 鏡の巫女 限定版
+  name-sort: 〜ふしぎゆうぎげんぶかいでんがいでん〜 かがみのみこ げんていばん
+  name-en: "Fushigi Yuugi - ShigiYuugi Kurotake Kaiden Gaiden - Kagami no Fujo [Limited Edition]"
   region: "NTSC-J"
 SLPM-66024:
-  name: "Fushigi Yuugi - ShigiYuugi Kurotake Kaiden Gaiden - Kagami no Fujo"
+  name: 〜ふしぎ遊戯玄武開伝外伝〜 鏡の巫女
+  name-sort: 〜ふしぎゆうぎげんぶかいでんがいでん〜 かがみのみこ
+  name-en: "Fushigi Yuugi - ShigiYuugi Kurotake Kaiden Gaiden - Kagami no Fujo"
   region: "NTSC-J"
 SLPM-66025:
-  name: "Generation of Chaos IV [Idea Factory Collection]"
+  name: IFコレクション 新天魔界ジェネレーション オブ カオスIV
+  name-sort: IFこれくしょん しんてんまかいじぇねれーしょん おぶ かおすIV
+  name-en: "Generation of Chaos IV [Idea Factory Collection]"
   region: "NTSC-J"
 SLPM-66026:
-  name: "Hatsukoi - First Kiss [Limited Edition]"
+  name: 初恋-first kiss- 初回限定版
+  name-sort: はつこい-first kiss- しょかいげんていばん
+  name-en: "Hatsukoi - First Kiss [Limited Edition]"
   region: "NTSC-J"
 SLPM-66027:
-  name: "Hatsukoi - First Kiss"
+  name: 初恋−first kiss−
+  name-sort: はつこい-first kiss-
+  name-en: "Hatsukoi - First Kiss"
   region: "NTSC-J"
 SLPM-66028:
-  name: "Ururun Quest"
+  name: うるるんクエスト恋遊記
+  name-sort: うるるんくえすとこいゆうき
+  name-en: "Ururun Quest"
   region: "NTSC-J"
   compat: 5
 SLPM-66029:
-  name: "Realize - Panorama Luminary"
+  name: リアライズ -Panorama Luminary-
+  name-sort: りあらいず -Panorama Luminary-
+  name-en: "Realize - Panorama Luminary"
   region: "NTSC-J"
 SLPM-66030:
-  name: "Heavy Metal Thunder"
+  name: ヘビーメタルサンダー
+  name-sort: へびーめたるさんだー
+  name-en: "Heavy Metal Thunder"
   region: "NTSC-J"
   compat: 5
 SLPM-66031:
-  name: "Phantasy Star Universe"
+  name: ファンタシー スター  ユニバース (Phantasy Star Universe)
+  name-sort: ふぁんたしー すたー  ゆにばーす (Phantasy Star Universe)
+  name-en: "Phantasy Star Universe"
   region: "NTSC-J"
   roundModes:
     eeRoundMode: 0 # Fixes enemies not moving (especially Chapter 7 boss).
 SLPM-66032:
-  name: "Silent Hill 4 [Konami The Best]"
+  name: サイレントヒル4 (コナミ・ザ・ベスト)
+  name-sort: さいれんとひる4 (こなみ・ざ・べすと)
+  name-en: "Silent Hill 4 [Konami The Best]"
   region: "NTSC-J"
   speedHacks:
     mvuFlag: 0 # Fixes invisible wall in front of the door leading to East 3F in the 2nd visit of Apartment world preventing Eileen's Nurse Outfit.
   gsHWFixes:
     halfPixelOffset: 1 # Fixes dark sides.
 SLPM-66033:
-  name: "Oz"
+  name: OZ -オズ-
+  name-sort: OZ -おず-
+  name-en: "Oz"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misaligned bloom.
     autoFlush: 2 # Fixes misaligned bloom on sun.
 SLPM-66034:
-  name: "Grand Theft Auto - Vice City"
+  name: Grand Theft Auto:Vice City カプコレ
+  name-sort: Grand Theft Auto:Vice City かぷこれ
+  name-en: "Grand Theft Auto - Vice City"
   region: "NTSC-J"
 SLPM-66035:
-  name: "Kenka Banchou"
+  name: 喧嘩番長
+  name-sort: けんかばんちょう
+  name-en: "Kenka Banchou"
   region: "NTSC-J"
 SLPM-66038:
-  name: "Georama Sensen Ijou Nashi"
+  name: ジオラマ戦線異状なし 〜スターリングラードへの道〜
+  name-sort: じおらませんせんいじょうなし 〜すたーりんぐらーどへのみち〜
+  name-en: "Georama Sensen Ijou Nashi"
   region: "NTSC-J"
 SLPM-66039:
-  name: "SuperLite 2000 Series - Memories Off... Sorekara"
+  name: SuperLite 2000シリーズ Memories Off 〜それから〜
+  name-sort: SuperLite 2000しりーず Memories Off 〜それから〜
+  name-en: "SuperLite 2000 Series - Memories Off... Sorekara"
   region: "NTSC-J"
 SLPM-66040:
-  name: "Edo Mono"
+  name: 江戸もの
+  name-sort: えどもの
+  name-en: "Edo Mono"
   region: "NTSC-J"
 SLPM-66041:
-  name: "Shoujo Yoshitsune Den [WellMADE The Best]"
+  name: 少女義経伝 WellMADE THE BEST
+  name-sort: しょうじょよしつねでん WellMADE THE BEST
+  name-en: "Shoujo Yoshitsune Den [WellMADE The Best]"
   region: "NTSC-J"
 SLPM-66042:
-  name: "Brothers In Arms - Road to Hill 30"
+  name: ブラザー イン アームズ ロードトゥヒルサーティー
+  name-sort: ぶらざー いん あーむず ろーどとぅひるさーてぃー
+  name-en: "Brothers In Arms - Road to Hill 30"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Reduces blurriness, there are still ghosting issues for like lighting poles.
 SLPM-66043:
-  name: "Racing Game - Chuui!"
+  name: レーシングゲーム「注意!!!」
+  name-sort: れーしんぐげーむ「ちゅうい!!!」
+  name-en: "Racing Game - Chuui!"
   region: "NTSC-J"
 SLPM-66044:
-  name: "MVP Baseball 2005"
+  name: MVPベースボール2005
+  name-sort: MVPべーすぼーる2005
+  name-en: "MVP Baseball 2005"
   region: "NTSC-J"
 SLPM-66045:
-  name: "My Merry May with be"
+  name: My Merry May with be
+  name-sort: My Merry May with be
+  name-en: "My Merry May with be"
   region: "NTSC-J"
 SLPM-66046:
-  name: "Star Wars - Episode III - Revenge of the Sith"
+  name: スター・ウォーズ エピソード3 シスの復讐
+  name-sort: すたー・うぉーず えぴそーど3 しすのふくしゅう
+  name-en: "Star Wars - Episode III - Revenge of the Sith"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 1 # Fixes bloom misalignment.
 SLPM-66047:
-  name: "FIFA Street"
+  name: FIFA ストリート
+  name-sort: FIFA すとりーと
+  name-en: "FIFA Street"
   region: "NTSC-J"
 SLPM-66049:
-  name: "D.C.P.S. - Da Capo Plus Situation [Kadokawa the Best]"
+  name: D.C.P.S. 〜ダ・カーポ〜 プラスシチュエーション KADOKAWA THE Best
+  name-sort: D.C.P.S. 〜だ・かーぽ〜 ぷらすしちゅえーしょん KADOKAWA THE Best
+  name-en: "D.C.P.S. - Da Capo Plus Situation [Kadokawa the Best]"
   region: "NTSC-J"
 SLPM-66050:
-  name: "Daisan Teikoku Koubouki II - Aufstieg und Fall des Dritten Reich"
+  name: 第三帝国興亡記 II
+  name-sort: だいさんていこくこうぼうき II
+  name-en: "Daisan Teikoku Koubouki II - Aufstieg und Fall des Dritten Reich"
   region: "NTSC-J"
 SLPM-66051:
-  name: "Need for Speed Underground 2 - SHA_DO"
+  name: EA BEST HITS ニード・フォー・スピード アンダーグラウンド2 車道
+  name-sort: EA BEST HITS にーど・ふぉー・すぴーど あんだーぐらうんど2 しゃどう
+  name-en: "Need for Speed Underground 2 [EA Best Hits] - SHA_DO"
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves reflection quality and map opacity.
@@ -36328,50 +39731,76 @@ SLPM-66051:
   gameFixes:
     - SoftwareRendererFMVHack # Workaround for strange HPO Normal screen shake.
 SLPM-66052:
-  name: "Miko Mai - Eien no Omoi"
+  name: 巫女舞 〜永遠の想い〜
+  name-sort: みこまい 〜えいえんのおもい〜
+  name-en: "Miko Mai - Eien no Omoi"
   region: "NTSC-J"
 SLPM-66053:
-  name: "Dokapon DX [Asmik Ace Best Series]"
+  name: アスミック得だねシリーズ ドカポンDX -わたる世界はオニだらけ-
+  name-sort: あすみっくとくだねしりーず どかぽんDX -わたるせかいはおにだらけ-
+  name-en: "Dokapon DX [Asmik Ace Best Series]"
   region: "NTSC-J"
 SLPM-66054:
-  name: "Generation of Chaos 5 [Limited Edition]"
+  name: 新天魔界 ジェネレーション オブ カオス V(ファイブ) 限定版
+  name-sort: しんてんまかい じぇねれーしょん おぶ かおす V(ふぁいぶ) げんていばん
+  name-en: "Generation of Chaos 5 [Limited Edition]"
   region: "NTSC-J"
 SLPM-66055:
-  name: "Generation of Chaos 5"
+  name: 新天魔界 ジェネレーション オブ カオス V(ファイブ)
+  name-sort: しんてんまかい じぇねれーしょん おぶ かおす V(ふぁいぶ)
+  name-en: "Generation of Chaos 5"
   region: "NTSC-J"
 SLPM-66056:
-  name: "Mushihimesama"
+  name: 虫姫さま
+  name-sort: むしひめさま
+  name-en: "Mushihimesama"
   region: "NTSC-J"
   compat: 5
 SLPM-66057:
-  name: "Taito Memories - Joukan"
+  name: タイトーメモリーズ 上巻
+  name-sort: たいとーめもりーず じょうかん
+  name-en: "Taito Memories - Joukan"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
     roundSprite: 1 # Fixes vertical and horizontal lines.
 SLPM-66058:
-  name: "Sengoku Basara"
+  name: 戦国BASARA
+  name-sort: せんごくBASARA
+  name-en: "Sengoku Basara"
   region: "NTSC-J"
 SLPM-66059:
-  name: "Robots"
+  name: ロボッツ
+  name-sort: ろぼっつ
+  name-en: "Robots"
   region: "NTSC-J"
 SLPM-66060:
-  name: "Boukoku no Aegis 2035 - Warship Gunner"
+  name: 亡国のイージス2035 〜ウォーシップガンナー〜
+  name-sort: ぼうこくのいーじす2035 〜うぉーしっぷがんなー〜
+  name-en: "Boukoku no Aegis 2035 - Warship Gunner"
   region: "NTSC-J"
 SLPM-66061:
-  name: "Jikkyou Powerful Pro Yakyuu 12"
+  name: 実況パワフルプロ野球12
+  name-sort: じっきょうぱわふるぷろやきゅう12
+  name-en: "Jikkyou Powerful Pro Yakyuu 12"
   region: "NTSC-J"
 SLPM-66062:
-  name: "Mahou Sensei Negima! Gold Medal"
+  name: 魔法先生ネギま! 2時間目 戦う乙女たち! 麻帆良大運動会SP! 金メダル版
+  name-sort: まほうせんせいねぎま! 2じかんめ たたかうおとめたち! まほらだいうんどうかいSP! きんめだるばん
+  name-en: "Mahou Sensei Negima! Gold Medal"
   region: "NTSC-J"
 SLPM-66063:
-  name: "Mahou Sensei Negima! Silver Medal"
+  name: 魔法先生ネギま! 2時間目 戦う乙女たち! 麻帆良大運動会SP! 銀メダル版
+  name-sort: まほうせんせいねぎま! 2じかんめ たたかうおとめたち! まほらだいうんどうかいSP! ぎんめだるばん
+  name-en: "Mahou Sensei Negima! Silver Medal"
   region: "NTSC-J"
 SLPM-66064:
   name: "Tough - Dark Fight"
   region: "NTSC-J"
 SLPM-66065:
-  name: "Pop'n music 11"
+  name: ポップンミュージック11
+  name-sort: ぽっぷんみゅーじっく11
+  name-en: "Pop'n music 11"
   region: "NTSC-J"
 SLPM-66066:
   name: "Yu-Gi-Oh! Capsule Monster Coliseum"
@@ -36380,31 +39809,45 @@ SLPM-66067:
   name: "Crash Bandicoot - Bakusou! Nitro Kart"
   region: "NTSC-J"
 SLPM-66068:
-  name: "Richard Burns Rally"
+  name: リチャード・バーンズ ラリー
+  name-sort: りちゃーど・ばーんず らりー
+  name-en: "Richard Burns Rally"
   region: "NTSC-J"
 SLPM-66069:
-  name: "Shikigami no Shiro - Nanayozuki Gensoukyoku"
+  name: 式神の城 七夜月幻想曲
+  name-sort: しきがみのしろ ななよづきげんそうきょく
+  name-en: "Shikigami no Shiro - Nanayozuki Gensoukyoku"
   region: "NTSC-J"
   compat: 5
 SLPM-66070:
-  name: "Shadow Hearts - From the New World [Limited Edition]"
+  name: シャドウハーツ フロム・ザ・ニュー・ワールド PREMIUM BOX
+  name-sort: しゃどうはーつ ふろむ・ざ・にゅー・わーるど PREMIUM BOX
+  name-en: "Shadow Hearts - From the New World [Limited Edition]"
   region: "NTSC-J"
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts and reduces text box artifacts.
 SLPM-66071:
-  name: "Shadow Hearts - From the New World"
+  name: シャドウハーツ フロム・ザ・ニュー・ワールド
+  name-sort: しゃどうはーつ ふろむ・ざ・にゅー・わーるど
+  name-en: "Shadow Hearts - From the New World"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts and reduces text box artifacts.
 SLPM-66072:
-  name: "Fight Night Round 2"
+  name: ファイトナイト ラウンド2
+  name-sort: ふぁいとないと らうんど2
+  name-en: "Fight Night Round 2"
   region: "NTSC-J"
 SLPM-66073:
-  name: "Hagane no Renkinjutsushi 3 - Kami o Tsugu Shoujo"
+  name: 鋼の錬金術師3 −神を継ぐ少女−
+  name-sort: はがねのれんきんじゅつし3 -かみをつぐしょうじょ-
+  name-en: "Hagane no Renkinjutsushi 3 - Kami o Tsugu Shoujo"
   region: "NTSC-J"
 SLPM-66074:
-  name: "Sonic Gems Collection"
+  name: ソニック ジェムズ コレクション
+  name-sort: そにっく じぇむず これくしょん
+  name-en: "Sonic Gems Collection"
   region: "NTSC-J"
   compat: 5
   roundModes:
@@ -36423,7 +39866,9 @@ SLPM-66076:
   name: "Meine Liebe - Yuubinaru kioku [Konami the Best]"
   region: "NTSC-J"
 SLPM-66077:
-  name: "K-1 World Max 2005"
+  name: K-1 WORLD MAX 2005 〜世界王者への道〜
+  name-sort: K-1 WORLD MAX 2005 〜せかいおうじゃへのみち〜
+  name-en: "K-1 World Max 2005"
   region: "NTSC-J"
   compat: 5
   gameFixes:
@@ -36435,80 +39880,116 @@ SLPM-66077:
         patch=1,EE,003dfe60,word,0000948c
         patch=1,EE,003dfe88,word,0000948c
 SLPM-66078:
-  name: "White Princess the Second"
+  name: White Princess the second 〜やはり一途にイってもそうじゃなくてもOKなご都合主義学園アドベンチャー〜
+  name-sort: White Princess the second 〜やはりいちずにいってもそうじゃなくてもOKなごつごうしゅぎがくえんあどべんちゃー〜
+  name-en: "White Princess the Second"
   region: "NTSC-J"
 SLPM-66079:
   name: "Medal of Honor - Europe Kyoushuu"
   region: "NTSC-J"
 SLPM-66080:
-  name: "Generation of Chaos 3 [IF Collection]"
+  name: IFコレクション GENERATION OF CHAOSIII 〜時の封印〜
+  name-sort: IFこれくしょん GENERATION OF CHAOSIII 〜ときのふういん〜
+  name-en: "Generation of Chaos 3 [IF Collection]"
   region: "NTSC-J"
 SLPM-66081:
-  name: "Iris no Atelier - Eternal Mana [Gust Best Price]"
+  name: イリスのアトリエ エターナルマナ Gust Best Price
+  name-sort: いりすのあとりえ えたーなるまな Gust Best Price
+  name-en: "Iris no Atelier - Eternal Mana [Gust Best Price]"
   region: "NTSC-J"
 SLPM-66082:
-  name: "Fire Pro Wrestling Returns"
+  name: ファイプロ・リターンズ
+  name-sort: ふぁいぷろ・りたーんず
+  name-en: "Fire Pro Wrestling Returns"
   region: "NTSC-J"
 SLPM-66083:
-  name: "Ramune - Garasu-Bin ni Utsuru Umi [Limited Edition]"
+  name: ラムネ〜ガラスびんに映る海〜 初回限定版
+  name-sort: らむね〜がらすびんにうつるうみ〜 しょかいげんていばん
+  name-en: "Ramune - Garasu-Bin ni Utsuru Umi [Limited Edition]"
   region: "NTSC-J"
   gsHWFixes:
     beforeDraw: "OI_PointListPalette"
 SLPM-66084:
-  name: "Ramune - Garasu-Bin ni Utsuru Umi"
+  name: ラムネ～ガラスびんに映る海～
+  name-sort: らむね～がらすびんにうつるうみ～
+  name-en: "Ramune - Garasu-Bin ni Utsuru Umi"
   region: "NTSC-J"
   gsHWFixes:
     beforeDraw: "OI_PointListPalette"
 SLPM-66085:
-  name: "Rumble Roses [Konami The Best]"
+  name: Rumble Roses(コナミ・ザ・ベスト)
+  name-sort: Rumble Roses(こなみ・ざ・べすと)
+  name-en: "Rumble Roses [Konami The Best]"
   region: "NTSC-J"
 SLPM-66086:
-  name: "Gokujou Seitokai"
+  name: 極上生徒会
+  name-sort: ごくじょうせいとかい
+  name-en: "Gokujou Seitokai"
   region: "NTSC-J"
 SLPM-66087:
-  name: "Winning Post 7"
+  name: Winning Post 7
+  name-sort: Winning Post 7
+  name-en: "Winning Post 7"
   region: "NTSC-J"
 SLPM-66088:
   name: "Simple 2000 Series Vol. 84 - The Boku ni Oma-Cafe - Kimagure Strawberry Cafe"
   region: "NTSC-J"
 SLPM-66089:
-  name: "3-nen B-gumi Kinpachi Sensei - Densetsu no Kyoudan ni Tate! Kanzenban"
+  name: 3年B組金八先生 伝説の教壇に立て! 完全版
+  name-sort: 3ねんBぐみきんぱちせんせい でんせつのきょうだんにたて! かんぜんばん
+  name-en: "3-nen B-gumi Kinpachi Sensei - Densetsu no Kyoudan ni Tate! Kanzenban"
   region: "NTSC-J"
 SLPM-66090:
-  name: "Crash Bandicoot - Gacchanko World"
+  name: クラッシュ・バンディクー がっちゃんこワールド
+  name-sort: くらっしゅ・ばんでぃくー がっちゃんこわーるど
+  name-en: "Crash Bandicoot - Gacchanko World"
   region: "NTSC-J"
   gsHWFixes:
     PCRTCOverscan: 1 # Fixes offscreen image.
     nativePaletteDraw: 1 # Fixes the look of screen effects.
     halfPixelOffset: 2 # Corrects the alignment of screen effects.
 SLPM-66091:
-  name: "Shinobido Imashime"
+  name: 忍道 戒
+  name-sort: しのびどう いましめ
+  name-en: "Shinobido Imashime"
   region: "NTSC-J"
   compat: 5
   clampModes:
     eeClampMode: 3 # Fixes hang going in to the gardens.
 SLPM-66092:
-  name: "Taito Memories Gekan"
+  name: タイトーメモリーズ 下巻
+  name-sort: たいとーめもりーず げかん
+  name-en: "Taito Memories Gekan"
   region: "NTSC-J"
   gsHWFixes:
     roundSprite: 1 # Fixes vertical and horizontal lines.
 SLPM-66093:
-  name: "Kessen II [Koei Selection Series]"
+  name: コーエー定番シリーズ 決戦II
+  name-sort: こーえーていばんしりーず けっせんII
+  name-en: "Kessen II [Koei Selection Series]"
   region: "NTSC-J"
 SLPM-66094:
-  name: "Shin Sangoku Musou 2 [Koei Selection Series]"
+  name: コーエー定番シリーズ 真・三國無双2
+  name-sort: こーえーていばんしりーず しん・さんごくむそう2
+  name-en: "Shin Sangoku Musou 2 [Koei Selection Series]"
   region: "NTSC-J"
 SLPM-66095:
   name: "Chou Battle Houshin"
   region: "NTSC-J"
 SLPM-66096:
-  name: "Shin Sangoku Musou 2 - Mushoden [Koei Selection Series]"
+  name: コーエー定番シリーズ 真・三國無双2猛将伝
+  name-sort: こーえーていばんしりーず しん・さんごくむそう2もうしょうでん
+  name-en: "Shin Sangoku Musou 2 - Mushoden [Koei Selection Series]"
   region: "NTSC-J"
 SLPM-66097:
-  name: "Shinseiki Evangelion - Ayanami Ikusai Keikaku with Asuka Hokan Keikaku [Broccoli Best Quality]"
+  name: Broccoli Best Quality 新世紀エヴァンゲリオン 綾波育成計画withアスカ補完計画
+  name-sort: Broccoli Best Quality しんせいきえゔぁんげりおん あやなみいくせいけいかくwithあすかほかんけいかく
+  name-en: "Shinseiki Evangelion - Ayanami Ikusai Keikaku with Asuka Hokan Keikaku [Broccoli Best Quality]"
   region: "NTSC-J"
 SLPM-66098:
-  name: "True Crime - Streets of L.A. [CapKore]"
+  name: トゥルークライム -STREETS OF L.A.- (カプコレ)
+  name-sort: とぅるーくらいむ -STREETS OF L.A.- (かぷこれ)
+  name-en: "True Crime - Streets of L.A. [CapKore]"
   region: "NTSC-J"
   gsHWFixes:
     preloadFrameData: 1 # Fixes licences.
@@ -36519,10 +40000,14 @@ SLPM-66099:
   name: "Harukanaru Toki no Naka de 3 - Izayoiki [Premium Box-Triple Pack]"
   region: "NTSC-J"
 SLPM-66100:
-  name: "Harukanaru Jikuu no Kade 3"
+  name: 遙かなる時空の中で3 十六夜記
+  name-sort: はるかなるときのなかで3 いざよいき
+  name-en: "Harukanaru Jikuu no Kade 3"
   region: "NTSC-J"
 SLPM-66101:
-  name: "Shin Sangoku Musou 4 - Mushoden"
+  name: 真・三國無双4 猛将伝
+  name-sort: しん・さんごくむそう4 もうしょうでん
+  name-en: "Shin Sangoku Musou 4 - Mushoden"
   region: "NTSC-J"
   gsHWFixes:
     autoFlush: 2 # Fixes sun luminosity.
@@ -36532,7 +40017,9 @@ SLPM-66102:
   gsHWFixes:
     roundSprite: 1 # Fixes vertical lines.
 SLPM-66103:
-  name: "WRC 3 [Spike the Best]"
+  name: スパイク ザ ベスト WRC3
+  name-sort: すぱいく ざ べすと WRC3
+  name-en: "WRC 3 [Spike the Best]"
   region: "NTSC-J"
   compat: 5
   gameFixes:
@@ -36541,10 +40028,14 @@ SLPM-66103:
     roundSprite: 2 # Correct misaligned font, better aligns car shadow.
     autoFlush: 2 # Fixes sun luminosity.
 SLPM-66104:
-  name: "Puyo Puyo Fever 2"
+  name: ぷよぷよフィーバー2【チュー!】
+  name-sort: ぷよぷよふぃーばー2【ちゅー!】
+  name-en: "Puyo Puyo Fever 2"
   region: "NTSC-J"
 SLPM-66105:
-  name: "Rhapsodia"
+  name: RHAPSODIA ラプソディア
+  name-sort: RHAPSODIA らぷそでぃあ
+  name-en: "Rhapsodia"
   region: "NTSC-J"
   memcardFilters: # This is the JP Suikoden Tactics.
     - "SLPM-66105"
@@ -36552,13 +40043,19 @@ SLPM-66105:
     - "SLPM-65599"
     - "SLPM-65600"
 SLPM-66106:
-  name: "Hoshi no Furu Koku [Limited Edition]"
+  name: 星の降る刻 限定版
+  name-sort: ほしのふるこく げんていばん
+  name-en: "Hoshi no Furu Koku [Limited Edition]"
   region: "NTSC-J"
 SLPM-66107:
-  name: "Hoshi no Furu Koku"
+  name: 星の降る刻
+  name-sort: ほしのふるこく
+  name-en: "Hoshi no Furu Koku"
   region: "NTSC-J"
 SLPM-66108:
-  name: "Burnout Revenge"
+  name: バーンアウト リベンジ
+  name-sort: ばーんあうと りべんじ
+  name-en: "Burnout Revenge"
   region: "NTSC-J"
   clampModes:
     vuClampMode: 0 # Fixes buggy lighting in the garage.
@@ -36582,31 +40079,47 @@ SLPM-66108:
     - "SLAJ-25053"
     - "SLPM-66204"
 SLPM-66109:
-  name: "Code Age Commanders - Tsugumono Tsugarerumono"
+  name: コード・エイジ コマンダーズ 〜継ぐ者 継がれる者〜
+  name-sort: こーど・えいじ こまんだーず 〜つぐもの つがれるもの〜
+  name-en: "Code Age Commanders - Tsugumono Tsugarerumono"
   region: "NTSC-J"
 SLPM-66110:
-  name: "Fushigi no Umi no Nadia - Inherit the Blue Water [Limited Edition]"
+  name: ふしぎの海のナディア コレクターズエディション
+  name-sort: ふしぎのうみのなでぃあ これくたーずえでぃしょん
+  name-en: "Fushigi no Umi no Nadia - Inherit the Blue Water [Limited Edition]"
   region: "NTSC-J"
 SLPM-66111:
   name: "Fushigi no Umi no Nadia - Dennou Battle - Miss Nautilus Contest"
   region: "NTSC-J"
 SLPM-66112:
-  name: "Fushigi no Umi no Nadia - Inherit the Blue Water"
+  name: ふしぎの海のナディア 通常版
+  name-sort: ふしぎのうみのなでぃあ つうじょうばん
+  name-en: "Fushigi no Umi no Nadia - Inherit the Blue Water"
   region: "NTSC-J"
 SLPM-66113:
-  name: "Hissatsu Ura-Kagyou"
+  name: 必殺裏稼業
+  name-sort: ひっさつうらかぎょう
+  name-en: "Hissatsu Ura-Kagyou"
   region: "NTSC-J"
 SLPM-66114:
-  name: "Mizu no Senritsu [Limited Edition]"
+  name: 水の旋律(初回限定版)
+  name-sort: みずのせんりつ(しょかいげんていばん)
+  name-en: "Mizu no Senritsu [Limited Edition]"
   region: "NTSC-J"
 SLPM-66115:
-  name: "Mizu no Senritsu"
+  name: 水の旋律(通常版)
+  name-sort: みずのせんりつ(つうじょうばん)
+  name-en: "Mizu no Senritsu"
   region: "NTSC-J"
 SLPM-66116:
-  name: "NBA Live 2005 [EA Best Hits]"
+  name: EA BEST HITS NBA ライブ 2005
+  name-sort: EA BEST HITS NBA らいぶ 2005
+  name-en: "NBA Live 2005 [EA Best Hits]"
   region: "NTSC-J"
 SLPM-66117:
-  name: "Metal Gear Solid 3 - Subsistence [with Headset] [Disc 1 of 3]"
+  name: METAL GEAR SOLID 3 SUBSISTENCE (ヘッドセット同梱版)
+  name-sort: METAL GEAR SOLID 3 SUBSISTENCE (へっどせっとどうこんばん)
+  name-en: "Metal Gear Solid 3 - Subsistence [with Headset] [Disc 1 of 3]"
   region: "NTSC-J"
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
@@ -36644,20 +40157,28 @@ SLPM-66121:
     halfPixelOffset: 2 # Fixes shadows.
     gpuPaletteConversion: 0 # Stops potential crashes from too many palette textures.
 SLPM-66122:
-  name: "Kingdom Hearts [Ultimate Hits]"
+  name: アルティメット ヒッツ キングダム ハーツ
+  name-sort: あるてぃめっと ひっつ きんぐだむ はーつ
+  name-en: "Kingdom Hearts [Ultimate Hits]"
   region: "NTSC-J"
 SLPM-66123:
-  name: "Kingdom Hearts - Final Mix [Ultimate Hits]"
+  name: アルティメット ヒッツ キングダム ハーツ -ファイナル   ミックス-
+  name-sort: あるてぃめっと ひっつ きんぐだむ はーつ -ふぁいなる   みっくす-
+  name-en: "Kingdom Hearts - Final Mix [Ultimate Hits]"
   region: "NTSC-J"
 SLPM-66124:
-  name: "Final Fantasy X [Ultimate Hits]"
+  name: アルティメット ヒッツ ファイナルファンタジー X
+  name-sort: あるてぃめっと ひっつ ふぁいなるふぁんたじー X
+  name-en: "Final Fantasy X [Ultimate Hits]"
   region: "NTSC-J"
   roundModes:
     eeRoundMode: 1 # Fixes reverse control and boss in some places.
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
 SLPM-66125:
-  name: "Final Fantasy X-2 [Ultimate Hits]"
+  name: アルティメット ヒッツ ファイナルファンタジー X-2
+  name-sort: あるてぃめっと ひっつ ふぁいなるふぁんたじー X-2
+  name-en: "Final Fantasy X-2 [Ultimate Hits]"
   region: "NTSC-J"
   gameFixes:
     - SoftwareRendererFMVHack # Fixes brightness and overlapping subtitles.
@@ -36673,16 +40194,22 @@ SLPM-66129:
   name: "Guilty Gear XX #Reload"
   region: "NTSC-J"
 SLPM-66130:
-  name: "Tom Clancy's Splinter Cell - Chaos Theory"
+  name: トム・クランシーシリーズ スプリンターセル カオスセオリー
+  name-sort: とむ・くらんしーしりーず すぷりんたーせる かおすせおりー
+  name-en: "Tom Clancy's Splinter Cell - Chaos Theory"
   region: "NTSC-J"
 SLPM-66131:
-  name: "Tim Burton's The Nightmare Before Christmas [Premium Pack]"
+  name: ティム・バートン ナイトメアー・ビフォア・クリスマス ブギーの逆襲 プレミアムパック
+  name-sort: てぃむ・ばーとん ないとめあー・びふぉあ・くりすます ぶぎーのぎゃくしゅう ぷれみあむぱっく
+  name-en: "Tim Burton's The Nightmare Before Christmas [Premium Pack]"
   region: "NTSC-J"
   gsHWFixes:
     wildArmsHack: 1 # Fixes blurriness.
     mergeSprite: 1 # Fixes misaligned lights.
 SLPM-66132:
-  name: "Gladiator - Road to Freedom - Remix"
+  name: GLADIATOR ROAD TO FREEDOM REMIX
+  name-sort: GLADIATOR ROAD TO FREEDOM REMIX
+  name-en: "Gladiator - Road to Freedom - Remix"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 3 # Fixes bloom misalignment still a bit misaligned.
@@ -36692,40 +40219,60 @@ SLPM-66133:
   name: "Shuffle! On the Stage [Deluxe Pack]"
   region: "NTSC-J"
 SLPM-66134:
-  name: "Shuffle! On the Stage"
+  name: シャッフル!オン・ザ・ステージ
+  name-sort: しゃっふる!おん・ざ・すてーじ
+  name-en: "Shuffle! On the Stage"
   region: "NTSC-J"
 SLPM-66135:
-  name: "World Tank Museum For Game - Toubu Sensen Success"
+  name: WORLD TANK MUSEUM for GAME ワールド タンク ミュージアム フォー ゲーム
+  name-sort: WORLD TANK MUSEUM for GAME わーるど たんく みゅーじあむ ふぉー げーむ
+  name-en: "World Tank Museum For Game - Toubu Sensen Success"
   region: "NTSC-J"
 SLPM-66136:
-  name: "SuperLite 2000 Vol. 34 - Akai Ito"
+  name: SuperLite2000 アカイイト
+  name-sort: SuperLite2000 あかいいと
+  name-en: "SuperLite 2000 Vol. 34 - Akai Ito"
   region: "NTSC-J"
 SLPM-66137:
-  name: "Clover Heart's - Looking for Happiness [The Best]"
+  name: CloverHeart’s ベスト版
+  name-sort: CloverHeart’s べすとばん
+  name-en: "Clover Heart's - Looking for Happiness [The Best]"
   region: "NTSC-J"
   gsHWFixes:
     minimumBlendingLevel: 4 # Fixes transparancy.
 SLPM-66138:
-  name: "Desire [Best Version]"
+  name: DESIRE ベスト版
+  name-sort: DESIRE べすとばん
+  name-en: "Desire [Best Version]"
   region: "NTSC-J"
 SLPM-66139:
-  name: "Duel Savior Destiny"
+  name: デュエルセイヴァー　ディスティニー
+  name-sort: でゅえるせいゔぁー　でぃすてぃにー
+  name-en: "Duel Savior Destiny"
   region: "NTSC-J"
   gsHWFixes:
     beforeDraw: "OI_PointListPalette"
 SLPM-66140:
-  name: "Atelier Marie + Elie - Salburg no Renkinjutsushi 1 & 2"
+  name: アトリエ マリー+エリー ザールブルグの錬金術士1・2
+  name-sort: あとりえ まりー+えりー ざーるぶるぐのれんきんじゅつし1・2
+  name-en: "Atelier Marie + Elie - Salburg no Renkinjutsushi 1 & 2"
   region: "NTSC-J"
   gsHWFixes:
     roundSprite: 2 # Fixes the sprites on textbox and characters.
 SLPM-66141:
-  name: "Matantei Loki Ragnarok Mayoukaku"
+  name: 魔探偵ロキRAGNAROK 魔妖画〜失われた微笑〜
+  name-sort: またんていろきRAGNAROK ま妖画〜うしなわれたびしょう〜
+  name-en: "Matantei Loki Ragnarok Mayoukaku"
   region: "NTSC-J"
 SLPM-66142:
-  name: "Rebirth Moon [Limited Edition]"
+  name: リバース ムーン 限定版
+  name-sort: りばーす むーん げんていばん
+  name-en: "Rebirth Moon [Limited Edition]"
   region: "NTSC-J"
 SLPM-66143:
-  name: "Rebirth Moon"
+  name: リバース ムーン
+  name-sort: りばーす むーん
+  name-en: "Rebirth Moon"
   region: "NTSC-J"
   patches:
     1B139735:
@@ -36735,64 +40282,96 @@ SLPM-66143:
         // This patch skips over the stack code, allowing the game to boot.
         patch=1,EE,0023B0C8,word,10000003
 SLPM-66144:
-  name: "D1 Grand Prix 2005"
+  name: D1グランプリ 2005
+  name-sort: D1ぐらんぷり 2005
+  name-en: "D1 Grand Prix 2005"
   region: "NTSC-J"
   clampModes:
     eeClampMode: 3 # Fixes black screen.
 SLPM-66145:
-  name: "GoldenEye - Rogue Agent [EA Best Hits]"
+  name: EA BEST HITS ゴールデンアイ ダークエージェント
+  name-sort: EA BEST HITS ごーるでんあい だーくえーじぇんと
+  name-en: "GoldenEye - Rogue Agent [EA Best Hits]"
   region: "NTSC-J"
 SLPM-66146:
-  name: "Memories Off #5 - Togireta Film [Limited Edition]"
+  name: Memories Off #5th とぎれたフィルム 初回限定版
+  name-sort: Memories Off #5th とぎれたふぃるむ しょかいげんていばん
+  name-en: "Memories Off #5 - Togireta Film [Limited Edition]"
   region: "NTSC-J"
 SLPM-66147:
-  name: "Memories Off #5 - Togireta Film"
+  name: Memories Off #5th とぎれたフィルム
+  name-sort: Memories Off #5th とぎれたふぃるむ
+  name-en: "Memories Off #5 - Togireta Film"
   region: "NTSC-J"
 SLPM-66148:
-  name: "Star Wars - Battlefront [EA Best Hits]"
+  name: EA BEST HITS スターウォーズ バトルフロント
+  name-sort: EA BEST HITS すたーうぉーず ばとるふろんと
+  name-en: "Star Wars - Battlefront [EA Best Hits]"
   region: "NTSC-J"
   gsHWFixes:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
     recommendedBlendingLevel: 3 # Improves reflections on certain characters and objects on certain levels.
 SLPM-66149:
-  name: "Shirogane no Torikago [Limited Edition]"
+  name: しろがねの鳥籠 限定版
+  name-sort: しろがねのとりかご げんていばん
+  name-en: "Shirogane no Torikago [Limited Edition]"
   region: "NTSC-J"
 SLPM-66150:
-  name: "Shirogane no Torikago"
+  name: しろがねの鳥籠 通常版
+  name-sort: しろがねのとりかご つうじょうばん
+  name-en: "Shirogane no Torikago"
   region: "NTSC-J"
 SLPM-66151:
-  name: "Killzone"
+  name: KILLZONE
+  name-sort: KILLZONE
+  name-en: "Killzone"
   region: "NTSC-J"
   clampModes:
     vuClampMode: 0 # Resolves I Reg Clamping / performance impact and yellow graphics in certain areas.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
 SLPM-66152:
-  name: "Konneko - Keep a Memory Green [Limited Edition]"
+  name: こんねこ 〜Keep a memory green〜 初回限定版
+  name-sort: こんねこ 〜Keep a memory green〜 しょかいげんていばん
+  name-en: "Konneko - Keep a Memory Green [Limited Edition]"
   region: "NTSC-J"
 SLPM-66153:
-  name: "Konneko - Keep a Memory Green"
+  name: こんねこ 〜Keep a memory green〜
+  name-sort: こんねこ 〜Keep a memory green〜
+  name-en: "Konneko - Keep a Memory Green"
   region: "NTSC-J"
 SLPM-66155:
-  name: "Flame of Recca - Final Burning [Konami Palace Selection]"
+  name: アニメバトル 烈火の炎 FINAL BURNING (コナミ殿堂セレクション)
+  name-sort: あにめばとる れっかのほのお FINAL BURNING (こなみでんどうせれくしょん)
+  name-en: "Flame of Recca - Final Burning [Konami Palace Selection]"
   region: "NTSC-J"
 SLPM-66156:
-  name: "Marheaven Arm Fight Dream"
+  name: メルヘヴン ARM FIGHT DREAM
+  name-sort: めるへゔん ARM FIGHT DREAM
+  name-en: "Marheaven Arm Fight Dream"
   region: "NTSC-J"
 SLPM-66157:
-  name: "Rune Princess [First Print - Limited Edition]"
+  name: ルーンプリンセス 初回限定版
+  name-sort: るーんぷりんせす しょかいげんていばん
+  name-en: "Rune Princess [First Print - Limited Edition]"
   region: "NTSC-J"
 SLPM-66158:
-  name: "Rune Princess"
+  name: ルーンプリンセス
+  name-sort: るーんぷりんせす
+  name-en: "Rune Princess"
   region: "NTSC-J"
 SLPM-66159:
-  name: "Call of Duty - Final Hour"
+  name: コール オブ デューティー:ファイネスト アワー
+  name-sort: こーる おぶ でゅーてぃー:ふぁいねすと あわー
+  name-en: "Call of Duty - Final Hour"
   region: "NTSC-J"
   gsHWFixes:
     cpuSpriteRenderBW: 1 # Fixes textures.
 SLPM-66160:
-  name: "Devil May Cry 3 [Special Edition]"
+  name: Devil May Cry 3 Special Edition
+  name-sort: Devil May Cry 3 Special Edition
+  name-en: "Devil May Cry 3 [Special Edition]"
   region: "NTSC-J"
   compat: 5
   roundModes:
@@ -36804,7 +40383,9 @@ SLPM-66161:
   name: "Kokoro no Tobira"
   region: "NTSC-J"
 SLPM-66163:
-  name: "Fuuraiki 2"
+  name: 風雨来記2
+  name-sort: ふううらいき2
+  name-en: "Fuuraiki 2"
   region: "NTSC-J"
   patches:
     FDF6D8C2:
@@ -36814,14 +40395,20 @@ SLPM-66163:
         // Fixes hang before going ingame
         patch=1,EE,002324dc,word,00000000
 SLPM-66164:
-  name: "Mahou Tsukai Kurohime"
+  name: 魔砲使い黒姫
+  name-sort: まほうつかいくろひめ
+  name-en: "Mahou Tsukai Kurohime"
   region: "NTSC-J"
   compat: 5
 SLPM-66165:
-  name: "Otome Hao Anesama ni Koi Shiteru"
+  name: 乙女はお姉さまに恋してる
+  name-sort: おとめはおあねさまにこいしてる
+  name-en: "Otome Hao Anesama ni Koi Shiteru"
   region: "NTSC-J"
 SLPM-66166:
-  name: "Shadow the Hedgehog"
+  name: シャドウ・ザ・ヘッジホッグ
+  name-sort: しゃどう・ざ・へっじほっぐ
+  name-en: "Shadow the Hedgehog"
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 4 # Improves smoke rendering.
@@ -36834,22 +40421,32 @@ SLPM-66167:
     roundSprite: 1 # Fixes vertical lines and minor ghosting.
     autoFlush: 1 # Fixes sun going through walls.
 SLPM-66168:
-  name: "Ryu Ga Gotoku"
+  name: 龍が如く
+  name-sort: りゅうがごとく
+  name-en: "Ryu Ga Gotoku"
   region: "NTSC-J"
 SLPM-66169:
-  name: "J-League Winning Eleven 9 - Asia Championship"
+  name: J.LEAGUE Winning Eleven 9 Asia Championship
+  name-sort: J.LEAGUE Winning Eleven 9 Asia Championship
+  name-en: "J-League Winning Eleven 9 - Asia Championship"
   region: "NTSC-J"
 SLPM-66170:
-  name: "Genso Suikoden V [Limited Edition]"
+  name: 幻想水滸伝V 限定版
+  name-sort: げんそうすいこでんV げんていばん
+  name-en: "Genso Suikoden V [Limited Edition]"
   region: "NTSC-J"
 SLPM-66171:
-  name: "NBA Live '06"
+  name: NBAライブ06
+  name-sort: NBAらいぶ06
+  name-en: "NBA Live '06"
   region: "NTSC-J"
 SLPM-66172:
   name: "Sangokushi IX"
   region: "NTSC-J"
 SLPM-66175:
-  name: "Akumajo Dracula - Yami no Juin"
+  name: 悪魔城ドラキュラ 闇の呪印
+  name-sort: あくまじょうどらきゅら やみのじゅいん
+  name-en: "Akumajo Dracula - Yami no Juin"
   region: "NTSC-J"
   compat: 5
   clampModes:
@@ -36864,11 +40461,15 @@ SLPM-66175:
     - "SLPM-65444"
     - "SLPM-66325"
 SLPM-66176:
-  name: "Chaos Field - New Order"
+  name: カオスフィールド ニューオーダー
+  name-sort: かおすふぃーるど にゅーおーだー
+  name-en: "Chaos Field - New Order"
   region: "NTSC-J"
   compat: 5
 SLPM-66177:
-  name: "Matrix, The - Path of Neo"
+  name: THE MATRIX:PATH of NEO マトリックス:パス・オブ・ネオ
+  name-sort: THE MATRIX:PATH of NEO まとりっくす:ぱす・おぶ・ねお
+  name-en: "Matrix, The - Path of Neo"
   region: "NTSC-J"
   gsHWFixes:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
@@ -36876,22 +40477,34 @@ SLPM-66177:
     halfPixelOffset: 2 # Fix effects upscaling.
     autoFlush: 1 # Fixes broken post processing.
 SLPM-66178:
-  name: "Pop'n music 7 [Konami The Best]"
+  name: ポップンミュージック 7 (コナミザベスト)
+  name-sort: ぽっぷんみゅーじっく 7 (こなみざ・べすと)
+  name-en: "Pop'n music 7 [Konami The Best]"
   region: "NTSC-J"
 SLPM-66179:
-  name: "Pop'n music 8 [Konami The Best]"
+  name: ポップンミュージック 8 コナミザベスト
+  name-sort: ぽっぷんみゅーじっく 8 こなみざ・べすと
+  name-en: "Pop'n music 8 [Konami The Best]"
   region: "NTSC-J"
 SLPM-66180:
-  name: "Beatmania IIDX 10th Style"
+  name: beatmania IIDX 10th style
+  name-sort: beatmania IIDX 10th style
+  name-en: "Beatmania IIDX 10th style"
   region: "NTSC-J"
 SLPM-66181:
-  name: "Beat Down - Fists of Vengeance"
+  name: BEAT DOWN
+  name-sort: BEAT DOWN
+  name-en: "Beat Down - Fists of Vengeance"
   region: "NTSC-J"
 SLPM-66182:
-  name: "Kono Haretasora no Shita de [Good Price]"
+  name: この晴れた空の下で Good Price
+  name-sort: このはれたそらのしたで Good Price
+  name-en: "Kono Haretasora no Shita de [Good Price]"
   region: "NTSC-J"
 SLPM-66183:
-  name: "Getaway, The - Black Monday"
+  name: ゲッタウェイ ブラックマンデー(The Getaway Black Monday)
+  name-sort: げったうぇい ぶらっくまんでー(The Getaway Black Monday)
+  name-en: "Getaway, The - Black Monday"
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes the fog wall.
@@ -36899,7 +40512,9 @@ SLPM-66183:
     halfPixelOffset: 2 # Fixes outlines on screen edges.
     getSkipCount: "GSC_GetawayGames"
 SLPM-66184:
-  name: "Ikusa Gami"
+  name: 戦神 -いくさがみ-
+  name-sort: いくさがみ
+  name-en: "Ikusa Gami"
   region: "NTSC-J"
   gameFixes:
     - VIF1StallHack # Fixes black screen on boot.
@@ -36907,7 +40522,9 @@ SLPM-66184:
     autoFlush: 2 # Fixes missing bloom effects.
     halfPixelOffset: 2 # Fixes misaligned lighting and bloom.
 SLPM-66185:
-  name: "Game ni Nattayo! Dokuro-chan [Limited Edition]"
+  name: ゲームになったよ!ドクロちゃん〜健康診断大作戦〜 限定版
+  name-sort: げーむになったよ!どくろちゃん〜けんこうしんだんだいさくせん〜 げんていばん
+  name-en: "Game ni Nattayo! Dokuro-chan [Limited Edition]"
   region: "NTSC-J"
   patches:
     169099FC:
@@ -36917,7 +40534,9 @@ SLPM-66185:
         // This patch skips over the stack code, allowing the game to boot.
         patch=1,EE,00156608,word,10000003
 SLPM-66186:
-  name: "Game ni Nattayo! Dokuro-chan"
+  name: ゲームになったよ!ドクロちゃん〜健康診断大作戦〜
+  name-sort: げーむになったよ!どくろちゃん〜けんこうしんだんだいさくせん〜
+  name-en: "Game ni Nattayo! Dokuro-chan"
   region: "NTSC-J"
   patches:
     169099FC:
@@ -36927,23 +40546,31 @@ SLPM-66186:
         // This patch skips over the stack code, allowing the game to boot.
         patch=1,EE,00156608,word,10000003
 SLPM-66187:
-  name: "Exciting Pro Wrestling 6 - SmackDown vs. RAW [Yuke's the Best]"
+  name: エキサイティングプロレス6 YUKE’s the Best
+  name-sort: えきさいてぃんぐぷろれす6 YUKE’s the Best
+  name-en: "Exciting Pro Wrestling 6 - SmackDown vs. RAW [Yuke's the Best]"
   region: "NTSC-J"
 SLPM-66188:
   name: "Exciting Pro Wres 7"
   region: "NTSC-J"
 SLPM-66189:
-  name: "SSX On Tour"
+  name: SSX On Tour
+  name-sort: SSX On Tour
+  name-en: "SSX On Tour"
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes missing lighting and makes snow not look like snow sludge.
 SLPM-66190:
-  name: "Star Wars - Battlefront II"
+  name: スター・ウォーズ バトルフロントII
+  name-sort: すたー・うぉーず ばとるふろんとII
+  name-en: "Star Wars - Battlefront II"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 1 # Fixes bloom misalignment.
 SLPM-66191:
-  name: "Tiger Woods PGA Tour 06"
+  name: タイガー・ウッズ PGA TOUR 06
+  name-sort: たいがー・うっず PGA TOUR 06
+  name-en: "Tiger Woods PGA Tour 06"
   region: "NTSC-J"
   clampModes:
     vuClampMode: 3 # Fixes black textures on characters.
@@ -36951,37 +40578,57 @@ SLPM-66191:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
 SLPM-66192:
-  name: "Izumo 2"
+  name: IZUMO2 猛き剣の閃記
+  name-sort: IZUMO2 たけきつるぎのせんき
+  name-en: "Izumo 2"
   region: "NTSC-J"
 SLPM-66193:
-  name: "Fahrenheit"
+  name: Fahrenheit ファーレンハイト
+  name-sort: Fahrenheit ふぁーれんはいと
+  name-en: "Fahrenheit"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 1 # Slight lighting misalignment.
 SLPM-66194:
-  name: "Otona no Gal Jan 2"
+  name: おとなのギャル雀2 〜恋して倍満!〜
+  name-sort: おとなのぎゃるじゃん2 〜こいしてばいまん!〜
+  name-en: "Otona no Gal Jan 2"
   region: "NTSC-J"
 SLPM-66195:
-  name: "SuperLite 2000 Series - Love Adventure Monochrome"
+  name: SuperLite 2000シリーズ モノクローム
+  name-sort: SuperLite 2000しりーず ものくろーむ
+  name-en: "SuperLite 2000 Series - Love Adventure Monochrome"
   region: "NTSC-J"
   compat: 5
 SLPM-66196:
-  name: "Sentimental Prelude [Best Version]"
+  name: Sentimental Prelude ベスト版
+  name-sort: Sentimental Prelude べすとばん
+  name-en: "Sentimental Prelude [Best Version]"
   region: "NTSC-J"
 SLPM-66197:
-  name: "Godzilla Kaijuu Dairansen - Chikyuu Saishuu Kessen [Atari Hot Series]"
+  name: ゴジラ怪獣大乱闘 地球最終決戦
+  name-sort: ごじらかいじゅうだいらんとう ちきゅうさいしゅうけっせん
+  name-en: "Godzilla Kaijuu Dairansen - Chikyuu Saishuu Kessen [Atari Hot Series]"
   region: "NTSC-J"
 SLPM-66201:
-  name: "Seishun no Kagayaki [Best Version]"
+  name: フレンズ 〜青春の輝き〜 ベスト版
+  name-sort: ふれんず 〜せいしゅんのかがやき〜 べすとばん
+  name-en: "Seishun no Kagayaki [Best Version]"
   region: "NTSC-J"
 SLPM-66202:
-  name: "Fragments Blue [Special Edition]"
+  name: フラグメンツ・ブルー スペシャルエディション
+  name-sort: ふらぐめんつ・ぶるー すぺしゃるえでぃしょん
+  name-en: "Fragments Blue [Special Edition]"
   region: "NTSC-J"
 SLPM-66203:
-  name: "Fragments Blue"
+  name: フラグメンツ・ブルー (通常版)
+  name-sort: ふらぐめんつ・ぶるー (つうじょうばん)
+  name-en: "Fragments Blue"
   region: "NTSC-J"
 SLPM-66204:
-  name: "Madden NFL '06"
+  name: MADDEN NFL 06
+  name-sort: MADDEN NFL 06
+  name-en: "Madden NFL '06"
   region: "NTSC-J"
   clampModes:
     vuClampMode: 3 # Missing geometry with microVU.
@@ -36989,13 +40636,17 @@ SLPM-66204:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
 SLPM-66205:
-  name: "Front Mission 5 - Scars of the War"
+  name: FRONT MISSION 5 〜Scars of the War〜
+  name-sort: FRONT MISSION 5 〜Scars of the War〜
+  name-en: "Front Mission 5 - Scars of the War"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
     halfPixelOffset: 1 # Fixes blurriness but no fix for font or other artifacts possible with round sprite.
 SLPM-66206:
-  name: "Battlefield 2 - Modern Combat"
+  name: バトルフィールド2 モダンコンバット
+  name-sort: ばとるふぃーるど2 もだんこんばっと
+  name-en: "Battlefield 2 - Modern Combat"
   region: "NTSC-J"
   gsHWFixes:
     minimumBlendingLevel: 4 # Fixes ground texture rendering.
@@ -37005,30 +40656,44 @@ SLPM-66206:
     getSkipCount: "GSC_Battlefield2" # Depth clear.
     beforeDraw: "OI_Battlefield2" # Framebuffer copy, fixes rendering for bottom part of screen.
 SLPM-66207:
-  name: "Dororo [Sega the Best 2800]"
+  name: どろろ SEGA THE BEST
+  name-sort: どろろ SEGA THE BEST
+  name-en: "Dororo [Sega the Best 2800]"
   region: "NTSC-J"
   gsHWFixes:
     minimumBlendingLevel: 2 # Fixes dark font to more bright like software mode.
 SLPM-66208:
-  name: "Sakura Taisen V - Episode 0 - Samurai Girl of Wild [Sega the Best]"
+  name: サクラ大戦V EPISODE 0 〜荒野のサムライ娘〜 SEGA THE BEST
+  name-sort: さくらたいせんV EPISODE 0 〜こうやのさむらいむすめ〜 SEGA THE BEST
+  name-en: "Sakura Taisen V - Episode 0 - Samurai Girl of Wild [Sega the Best]"
   region: "NTSC-J"
 SLPM-66209:
-  name: "Pop'n music 9 [Konami The Best]"
+  name: ポップンミュージック 9 (コナミザベスト)
+  name-sort: ぽっぷんみゅーじっく 9 (こなみざ・べすと)
+  name-en: "Pop'n music 9 [Konami The Best]"
   region: "NTSC-J"
 SLPM-66210:
-  name: "Pop'n music 10 [Konami The Best]"
+  name: ポップンミュージック 10 (コナミザベスト)
+  name-sort: ぽっぷんみゅーじっく 10 (こなみざ・べすと)
+  name-en: "Pop'n music 10 [Konami The Best]"
   region: "NTSC-J"
 SLPM-66211:
-  name: "King Kong, Peter Jackson's - The Official Game of the Movie"
+  name: PETER JACKSON’S キング・コング オフィシャル ゲーム オブ ザ ムービー
+  name-sort: PETER JACKSON’S きんぐ・こんぐ おふぃしゃる げーむ おぶ ざ むーびー
+  name-en: "King Kong, Peter Jackson's - The Official Game of the Movie"
   region: "NTSC-J"
 SLPM-66212:
-  name: "Sega Rally 2006"
+  name: セガラリー2006
+  name-sort: せがらりー2006
+  name-en: "Sega Rally 2006"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
     cpuCLUTRender: 1 # Fixes rainbow textures.
 SLPM-66213:
-  name: "BioHazard 4"
+  name: バイオハザード4
+  name-sort: ばいおはざーど4
+  name-en: "BioHazard 4"
   region: "NTSC-J"
   compat: 5
   gameFixes:
@@ -37036,22 +40701,34 @@ SLPM-66213:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
 SLPM-66214:
-  name: "White Clarity - And, the Tears Became You [First Print Limited Edition]"
+  name: WHITE CLARITY(ホワイト クラリティー)〜And The tears became you.〜 初回限定版
+  name-sort: WHITE CLARITY(ほわいと くらりてぃー)〜And The tears became you.〜 しょかいげんていばん
+  name-en: "White Clarity - And, the Tears Became You [First Print Limited Edition]"
   region: "NTSC-J"
 SLPM-66215:
-  name: "White Clarity - And, the Tears Became You"
+  name: WHITE CLARITY 〜And The tears became you.〜
+  name-sort: WHITE CLARITY 〜And The tears became you.〜
+  name-en: "White Clarity - And, the Tears Became You"
   region: "NTSC-J"
 SLPM-66217:
-  name: "Jikkyou Powerful Pro Yakyuu 12 Ketteiban"
+  name: 実況パワフルプロ野球 12 決定版
+  name-sort: じっきょうぱわふるぷろやきゅう 12 けっていばん
+  name-en: "Jikkyou Powerful Pro Yakyuu 12 Ketteiban"
   region: "NTSC-J"
 SLPM-66218:
-  name: "Eyeshield 21 Amefoot Yarouze! Ya-!Ha-!"
+  name: アイシールド21 〜アメフトやろうぜ!Ya-!Ha-!〜
+  name-sort: あいしーるど21 〜あめふとやろうぜ!Ya-!Ha-!〜
+  name-en: "Eyeshield 21 Amefoot Yarouze! Ya-!Ha-!"
   region: "NTSC-J"
 SLPM-66219:
-  name: "Tennis no Oji-Sama - Gakuensai no Oji-Sama"
+  name: テニスの王子様 〜学園祭の王子様〜
+  name-sort: てにすのおうじさま 〜がくえんさいのおうじさま〜
+  name-en: "Tennis no Oji-Sama - Gakuensai no Oji-Sama"
   region: "NTSC-J"
 SLPM-66220:
-  name: "Metal Gear Solid 3 - Subsistence [First Print Limited Edition] [Disc 1 of 3]"
+  name: METAL GEAR SOLID 3 SUBSISTENCE (初回生産版)
+  name-sort: METAL GEAR SOLID 3 SUBSISTENCE (しょかいせいさんばん)
+  name-en: "Metal Gear Solid 3 - Subsistence [First Print Limited Edition] [Disc 1 of 3]"
   region: "NTSC-J"
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
@@ -37087,7 +40764,9 @@ SLPM-66222:
   memcardFilters:
     - "SLPM-66117"
 SLPM-66223:
-  name: "Metal Gear Solid 3 - Subsistence [Disc 1 of 2]"
+  name: METAL GEAR SOLID 3 SUBSISTENCE
+  name-sort: METAL GEAR SOLID 3 SUBSISTENCE
+  name-en: "Metal Gear Solid 3 - Subsistence [Disc 1 of 2]"
   region: "NTSC-J"
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
@@ -37111,25 +40790,39 @@ SLPM-66224:
   memcardFilters:
     - "SLPM-66117"
 SLPM-66225:
-  name: "Da Capo Four Seasons [Deluxe Pack]"
+  name: D.C.F.S. 〜ダ・カーポ〜 フォーシーズンズ DXパック
+  name-sort: D.C.F.S. 〜だ・かーぽ〜 ふぉーしーずんず DXぱっく
+  name-en: "Da Capo Four Seasons [Deluxe Pack]"
   region: "NTSC-J"
 SLPM-66226:
-  name: "Da Capo Four Seasons"
+  name: D.C.F.S. 〜ダ・カーポ〜 フォーシーズンズ
+  name-sort: D.C.F.S. 〜だ・かーぽ〜 ふぉーしーずんず
+  name-en: "Da Capo Four Seasons"
   region: "NTSC-J"
 SLPM-66227:
-  name: "GI Jockey 4 + Winning Post 7 [Twin Pack] [GI Jockey 4 Disc]"
+  name: ジーワンジョッキー 4 & WinningPost 7 ツインパック
+  name-sort: じーわんじょっきー 4 & WinningPost 7 ついんぱっく
+  name-en: "GI Jockey 4 + Winning Post 7 [Twin Pack] [GI Jockey 4 Disc]"
   region: "NTSC-J"
 SLPM-66228:
-  name: "GI Jockey 4 + Winning Post 7 [Twin Pack] [Winning Post 7 Disc]"
+  name: ウイニングポスト7(ジーワンジョッキー4&ウイニングポストツインパック用)
+  name-sort: ういにんぐぽすと7(じーわんじょっきー4&ういにんぐぽすとついんぱっくよう)
+  name-en: "GI Jockey 4 + Winning Post 7 [Twin Pack] [Winning Post 7 Disc]"
   region: "NTSC-J"
 SLPM-66229:
-  name: "GI Jockey 4"
+  name: ジーワンジョッキー 4
+  name-sort: じーわんじょっきー 4
+  name-en: "GI Jockey 4"
   region: "NTSC-J"
 SLPM-66231:
-  name: "Cartagra - Tamashii no Kunou"
+  name: カルタグラ 〜魂の苦悩〜
+  name-sort: かるたぐら 〜たましいのくのう〜
+  name-en: "Cartagra - Tamashii no Kunou"
   region: "NTSC-J"
 SLPM-66232:
-  name: "Need for Speed - Most Wanted"
+  name: ニード・フォー・スピード モスト・ウォンテッド
+  name-sort: にーど・ふぉー・すぴーど もすと・うぉんてっど
+  name-en: "Need for Speed - Most Wanted"
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves car reflections.
@@ -37144,60 +40837,90 @@ SLPM-66232:
     - "SLPM-66051"
     - "SLPM-66960"
 SLPM-66233:
-  name: "Kingdom Hearts II"
+  name: キングダム ハーツII
+  name-sort: きんぐだむ はーつII
+  name-en: "Kingdom Hearts II"
   region: "NTSC-J"
   gsHWFixes:
     autoFlush: 2 # Fixes effects.
     roundSprite: 2 # Fixes upscaling artifacts.
   compat: 5
 SLPM-66234:
-  name: "Wizardry X - Zensen no Gakufu [Wonder Price]"
+  name: ウィザードリィ エクス 〜前線の学府〜 ワンダープライス
+  name-sort: うぃざーどりぃ えくす 〜ぜんせんのがくふ〜 わんだーぷらいす
+  name-en: "Wizardry X - Zensen no Gakufu [Wonder Price]"
   region: "NTSC-J"
 SLPM-66235:
-  name: "Psychic Force Complete"
+  name: サイキックフォース COMPLETE
+  name-sort: さいきっくふぉーす COMPLETE
+  name-en: "Psychic Force Complete"
   region: "NTSC-J"
   compat: 5
 SLPM-66237:
-  name: "Otometeki Koi Kakumei Rabu Rebo!! [Love Revo Box]"
+  name: 乙女的恋革命★ラブレボ!!ラブレボックス
+  name-sort: おとめてきこいかくめい★らぶれぼ!!らぶれぼっくす
+  name-en: "Otometeki Koi Kakumei Rabu Rebo!! [Love Revo Box]"
   region: "NTSC-J"
 SLPM-66238:
-  name: "Otometeki Koi Kakumei Rabu Rebo!!"
+  name: 乙女的恋革命★ラブレボ!!
+  name-sort: おとめてきこいかくめい★らぶれぼ!!
+  name-en: "Otometeki Koi Kakumei Rabu Rebo!!"
   region: "NTSC-J"
 SLPM-66239:
-  name: "Wrestle Angels Survivor"
+  name: レッスルエンジェルス SURVIVOR
+  name-sort: れっするえんじぇるす SURVIVOR
+  name-en: "Wrestle Angels Survivor"
   region: "NTSC-J"
 SLPM-66240:
-  name: "Jissen Pachi-Slot Hisshouhou! Aladdin 2 Evolution"
+  name: 実戦パチスロ必勝法! アラジン2エボリューション
+  name-sort: じっせんぱちすろひっしょうほう! あらじん2えぼりゅーしょん
+  name-en: "Jissen Pachi-Slot Hisshouhou! Aladdin 2 Evolution"
   region: "NTSC-J"
 SLPM-66241:
-  name: "Jissen Pachinko Hisshouhou! CR Hokuto no Ken"
+  name: 実戦パチンコ必勝法! CR 北斗の拳
+  name-sort: じっせんぱちんこひっしょうほう! CR ほくとのけん
+  name-en: "Jissen Pachinko Hisshouhou! CR Hokuto no Ken"
   region: "NTSC-J"
 SLPM-66242:
-  name: "Dance Dance Revolution Strike"
+  name: Dance Dance Revolution Strike
+  name-sort: Dance Dance Revolution Strike
+  name-en: "Dance Dance Revolution Strike"
   region: "NTSC-J"
   compat: 5
 SLPM-66243:
-  name: "Galaxy Angel II"
+  name: ギャラクシーエンジェルII 〜絶対領域の扉〜 通常版
+  name-sort: ぎゃらくしーえんじぇるII 〜ぜったいりょういきのとびら〜 つうじょうばん
+  name-en: "Galaxy Angel II"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 1 # Reduces misaligned lighting and other effects.
 SLPM-66244:
-  name: "Derby Tsuku 5 - Derby Uma o Tsukurou!"
+  name: ダービー馬をつくろう!5
+  name-sort: だーびーばをつくろう!5
+  name-en: "Derby Tsuku 5 - Derby Uma o Tsukurou!"
   region: "NTSC-J"
 SLPM-66245:
-  name: "Jewels Ocean - Star of Sierra Leone"
+  name: ジュエルスオーシャン Star of Sierra Leone
+  name-sort: じゅえるすおーしゃん Star of Sierra Leone
+  name-en: "Jewels Ocean - Star of Sierra Leone"
   region: "NTSC-J"
 SLPM-66246:
-  name: "Devil Summoner - Kuzunoha Raidou tai Chouriki Heidan"
+  name: デビルサマナー 葛葉ライドウ対超力兵団
+  name-sort: でびるさまなー くずのはらいどうたいちょうりきへいだん
+  name-en: "Devil Summoner - Kuzunoha Raidou tai Chouriki Heidan"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
     minimumBlendingLevel: 3 # Fixes broken effect rendering.
 SLPM-66247:
-  name: "Meine Liebe II - Hokori to Seigi to Ai"
+  name: マイネリーベII 〜誇りと正義と愛〜
+  name-sort: まいねりーべII 〜ほこりとせいぎとあい〜
+  name-en: "Meine Liebe II - Hokori to Seigi to Ai"
   region: "NTSC-J"
 SLPM-66248:
-  name: "Mr. Incredible - Kyouteki Underminer Toujou"
+  name: Mr.インクレディブル 〜強敵アンダーマイナー登場〜
+  name-sort: Mr.いんくれでぃぶる 〜きょうてきあんだーまいなーとうじょう〜
+  name-en: "Mr. Incredible - Kyouteki Underminer Toujou"
   region: "NTSC-J"
   gsHWFixes:
     mipmap: 2 # Mipmap + trilinear, improves the street's textures to match sw renderer.
@@ -37205,16 +40928,22 @@ SLPM-66248:
     halfPixelOffset: 2 # Fixes bloom misalignment when upscaling.
     cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling.
 SLPM-66249:
-  name: "Growlanser V - Generations [Limited Edition]"
+  name: グローランサーV ジェネレーションズ 初回限定生産版
+  name-sort: ぐろーらんさーV じぇねれーしょんず しょかいげんていせいさんばん
+  name-en: "Growlanser V - Generations [Limited Edition]"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
     moveHandler: "MV_Growlanser" # Fixes precomputed depth buffer.
 SLPM-66250:
-  name: "Choro Q HG 4 [Takara Best]"
+  name: アトラスベストコレクション　チョロＱＨＧ4
+  name-sort: あとらすべすとこれくしょん　ちょろＱＨＧ4
+  name-en: "Choro Q HG 4 [Takara Best]"
   region: "NTSC-J"
 SLPM-66251:
-  name: "EX Jinsei Game II [Takara Best]"
+  name: アトラスベストコレクション EX人生ゲームII
+  name-sort: あとらすべすとこれくしょん EXじんせいげーむII
+  name-en: "EX Jinsei Game II [Takara Best]"
   region: "NTSC-J"
   gsHWFixes:
     roundSprite: 1 # Fixes vertical and horizontal lines.
@@ -37222,19 +40951,27 @@ SLPM-66252:
   name: "Star Wars - Episode III - Sith no Fukushuu"
   region: "NTSC-J"
 SLPM-66253:
-  name: "Finalist [Limited First Edition]"
+  name: ふぁいなりすと 初回限定版
+  name-sort: ふぁいなりすと しょかいげんていばん
+  name-en: "Finalist [Limited First Edition]"
   region: "NTSC-J"
 SLPM-66254:
-  name: "Finalist"
+  name: ふぁいなりすと 通常版
+  name-sort: ふぁいなりすと つうじょうばん
+  name-en: "Finalist"
   region: "NTSC-J"
 SLPM-66255:
-  name: "World Soccer Winning Eleven 9 [Bonus Pack]"
+  name: ワールドサッカーウイニングイレブン 9 ボーナスパック
+  name-sort: わーるどさっかーういにんぐいれぶん 9 ぼーなすぱっく
+  name-en: "World Soccer Winning Eleven 9 [Bonus Pack]"
   region: "NTSC-J"
 SLPM-66256:
   name: "Nana"
   region: "NTSC-J"
 SLPM-66257:
-  name: "Enthusia - Professional Racing"
+  name: ENTHUSIA PROFESSIONAL RACING コナミ殿堂セレクション
+  name-sort: ENTHUSIA PROFESSIONAL RACING こなみでんどうせれくしょん
+  name-en: "Enthusia - Professional Racing"
   region: "NTSC-J"
   clampModes:
     eeClampMode: 3 # Corrects crazy car AI and prevents crash.
@@ -37245,66 +40982,102 @@ SLPM-66257:
   gameFixes:
     - SoftwareRendererFMVHack # Fixes upscale lines in FMVs.
 SLPM-66258:
-  name: "Magic Teacher Negima - Honor Version [Konami The Best]"
+  name: 魔法先生ネギま! 1時間目 お子ちゃま先生は魔法使い!(コナミザベスト)
+  name-sort: まほうせんせいねぎま! 1じかんめ おこちゃませんせいはまほうつかい!(こなみざ・べすと)
+  name-en: "Magic Teacher Negima - Honor Version [Konami The Best]"
   region: "NTSC-J"
 SLPM-66259:
-  name: "Mahou Sensei Negima! Silver Medal [Konami The Best]"
+  name: 魔法先生ネギま! 2時間目 戦う乙女たち!麻帆良大運動会SP! コナミ・ザ・ベスト
+  name-sort: まほうせんせいねぎま! 2じかんめ たたかうおとめたち!まほらだいうんどうかいSP! こなみ・ざ・べすと
+  name-en: "Mahou Sensei Negima! Silver Medal [Konami The Best]"
   region: "NTSC-J"
 SLPM-66260:
-  name: "Remote Control Dandy SF [Konami the Best]"
+  name: リモートコントロールダンディSF (コナミザベスト)
+  name-sort: りもーとこんとろーるだんでぃSF (こなみざ・べすと)
+  name-en: "Remote Control Dandy SF [Konami the Best]"
   region: "NTSC-J"
 SLPM-66261:
-  name: "Oz [Konami The Best]"
+  name: OZ -オズ- (コナミザベスト)
+  name-sort: OZ -おず- (こなみざ・べすと)
+  name-en: "Oz [Konami The Best]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misaligned bloom.
     autoFlush: 2 # Fixes misaligned bloom on sun.
 SLPM-66262:
-  name: "Tom Clancy's Rainbow Six 3 [Ubisoft The Best]"
+  name: ユービーアイソフトベスト トム・クランシーシリーズ レインボーシックス3
+  name-sort: ゆーびーあいそふとべすと とむ・くらんしーしりーず れいんぼーしっくす3
+  name-en: "Tom Clancy's Rainbow Six 3 [Ubisoft The Best]"
   region: "NTSC-J"
 SLPM-66263:
-  name: "Full Spectrum Warrior"
+  name: フル スペクトラム ウォリアー
+  name-sort: ふる すぺくとらむ うぉりあー
+  name-en: "Full Spectrum Warrior"
   region: "NTSC-J"
   speedHacks:
     mvuFlag: 0 # Fixes bad graphics.
 SLPM-66264:
-  name: "Canvas 2 - Nijiiro no Sketch [DX Pack]"
+  name: Canvas2 〜虹色のスケッチ〜(DXパック)
+  name-sort: Canvas2 〜にじいろのすけっち〜(DXぱっく)
+  name-en: "Canvas 2 - Nijiiro no Sketch [DX Pack]"
   region: "NTSC-J"
 SLPM-66265:
-  name: "Canvas 2 - Nijiiro no Sketch"
+  name: Canvas2 〜虹色のスケッチ〜(通常版)
+  name-sort: Canvas2 〜にじいろのすけっち〜(つうじょうばん)
+  name-en: "Canvas 2 - Nijiiro no Sketch"
   region: "NTSC-J"
 SLPM-66266:
-  name: "Kurogane no Houkou 2 - Warship Commander [Koei The Best]"
+  name: KOEI The Best 鋼鉄の咆哮2 ウォーシップコマンダー
+  name-sort: KOEI The Best くろがねのほうこう2 うぉーしっぷこまんだー
+  name-en: "Kurogane no Houkou 2 - Warship Commander [Koei The Best]"
   region: "NTSC-J"
 SLPM-66267:
-  name: "Taikou Risshiden V"
+  name: KOEI The Best 太閤立志伝V
+  name-sort: KOEI The Best たいこうりっしでんV
+  name-en: "Taikou Risshiden V"
   region: "NTSC-J"
 SLPM-66268:
-  name: "Smackdown! vs. Raw 2006 - Exciting Pro Wrestling 7"
+  name: エキサイティングプロレス7 SMACKDOWN! VS. RAW 2006
+  name-sort: えきさいてぃんぐぷろれす7 SMACKDOWN! VS. RAW 2006
+  name-en: "Smackdown! vs. Raw 2006 - Exciting Pro Wrestling 7"
   region: "NTSC-J"
 SLPM-66269:
-  name: "Blazing Souls [Limited Edition]"
+  name: ブレイジング ソウルズ 限定版
+  name-sort: ぶれいじんぐ そうるず げんていばん
+  name-en: "Blazing Souls [Limited Edition]"
   region: "NTSC-J"
 SLPM-66270:
-  name: "Blazing Souls"
+  name: ブレイジング ソウルズ 通常版
+  name-sort: ぶれいじんぐ そうるず つうじょうばん
+  name-en: "Blazing Souls"
   region: "NTSC-J"
 SLPM-66271:
-  name: "Dirge of Cerberus - Final Fantasy VII"
+  name: ダージュ オブ ケルベロス -ファイナルファンタジーVII-
+  name-sort: だーじゅ おぶ けるべろす -ふぁいなるふぁんたじーVII-
+  name-en: "Dirge of Cerberus - Final Fantasy VII"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
     autoFlush: 2 # Fixes lighting.
 SLPM-66272:
-  name: "I-O"
+  name: I/O
+  name-sort: I/O
+  name-en: "I-O"
   region: "NTSC-J"
 SLPM-66273:
-  name: "Memories Off After Rain Vol.1 - Ensou [Superlite 2000]"
+  name: SuperLite 2000 Memories Off AfterRain Vol.1 〜折鶴〜
+  name-sort: SuperLite 2000 Memories Off AfterRain Vol.1 〜おりづる〜
+  name-en: "Memories Off After Rain Vol.1 - Ensou [Superlite 2000]"
   region: "NTSC-J"
 SLPM-66274:
-  name: "Ninkyouden Toseinin Ichidaiki"
+  name: 任侠伝 渡世人一代記
+  name-sort: にんきょうでん とせいにんいちだいき
+  name-en: "Ninkyouden Toseinin Ichidaiki"
   region: "NTSC-J"
 SLPM-66275:
-  name: "Shin Onimusha - Dawn of Dreams [Disc 1 of 2]"
+  name: 新 鬼武者 DAWN OF DREAMS
+  name-sort: しん おにむしゃ DAWN OF DREAMS
+  name-en: "Shin Onimusha - Dawn of Dreams [Disc 1 of 2]"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
@@ -37318,7 +41091,9 @@ SLPM-66276:
   memcardFilters:
     - "SLPM-66275"
 SLPM-66277:
-  name: "Juiced"
+  name: Juiced〜チューンドカー伝説〜
+  name-sort: Juiced〜ちゅーんどかーでんせつ〜
+  name-en: "Juiced"
   region: "NTSC-J"
   speedHacks:
     instantVU1: 0 # Significantly improves game speed.
@@ -37330,13 +41105,19 @@ SLPM-66277:
     cpuCLUTRender: 1 # Fixes broken headlights.
     minimumBlendingLevel: 3
 SLPM-66278:
-  name: "Shin Gouketuji Ichizoku - Bonnou Kaihou"
+  name: 新・豪血寺一族 -煩悩解放-
+  name-sort: しん・ごうちてらいちぞく -ぼんのうかいほう-
+  name-en: "Shin Gouketuji Ichizoku - Bonnou Kaihou"
   region: "NTSC-J"
 SLPM-66279:
-  name: "Nobunaga no Yabou - Kakushin"
+  name: 信長の野望・革新
+  name-sort: のぶながのやぼう・かくしん
+  name-en: "Nobunaga no Yabou - Kakushin"
   region: "NTSC-J"
 SLPM-66280:
-  name: "Monster Hunter 2"
+  name: モンスターハンター2（dos）
+  name-sort: もんすたーはんたー2（dos）
+  name-en: "Monster Hunter 2"
   region: "NTSC-J"
   compat: 5
   clampModes:
@@ -37344,51 +41125,81 @@ SLPM-66280:
   gsHWFixes:
     maximumBlendingLevel: 0 # Fixes unnecessary load on the GPU.
 SLPM-66281:
-  name: "Sonic Riders"
+  name: ソニックライダーズ
+  name-sort: そにっくらいだーず
+  name-en: "Sonic Riders"
   region: "NTSC-J"
 SLPM-66282:
-  name: "Memories Off After Rain Vol.2 - Souen [Superlite 2000]"
+  name: SuperLite 2000 Memories Off AfterRain Vol.2 〜想演〜
+  name-sort: SuperLite 2000 Memories Off AfterRain Vol.2 〜そうえん〜
+  name-en: "Memories Off After Rain Vol.2 - Souen [Superlite 2000]"
   region: "NTSC-J"
 SLPM-66283:
-  name: "SuperLite 2000 Series - Memories Off After Rain Vol.3 - Graduation"
+  name: SuperLite 2000 Memories Off AfterRain Vol.3 〜卒業〜
+  name-sort: SuperLite 2000 Memories Off AfterRain Vol.3 〜そつぎょう〜
+  name-en: "SuperLite 2000 Series - Memories Off After Rain Vol.3 - Graduation"
   region: "NTSC-J"
 SLPM-66284:
-  name: "Dessert Love - Sweet Plus"
+  name: Dessert Love -Sweet Plus-
+  name-sort: Dessert Love -Sweet Plus-
+  name-en: "Dessert Love - Sweet Plus"
   region: "NTSC-J"
 SLPM-66285:
-  name: "Princess Concerto"
+  name: プリンセスコンチェルト(通常版)
+  name-sort: ぷりんせすこんちぇると(つうじょうばん)
+  name-en: "Princess Concerto"
   region: "NTSC-J"
 SLPM-66286:
-  name: "Genso Suikoden V"
+  name: 幻想水滸伝V
+  name-sort: げんそうすいこでんV
+  name-en: "Genso Suikoden V"
   region: "NTSC-J"
 SLPM-66287:
-  name: "Sengoku Basara"
+  name: 戦国BASARA カプコレ
+  name-sort: せんごくBASARA かぷこれ
+  name-en: "Sengoku Basara"
   region: "NTSC-J"
 SLPM-66288:
-  name: "Full House Kiss 2"
+  name: フルハウスキス2
+  name-sort: ふるはうすきす2
+  name-en: "Full House Kiss 2"
   region: "NTSC-J"
 SLPM-66289:
-  name: "Black Cat - Kikai-jikake no Tenshi"
+  name: BLACK CAT 〜機械仕掛けの天使〜
+  name-sort: BLACK CAT 〜きかいしかけのてんし〜
+  name-en: "Black Cat - Kikai-jikake no Tenshi"
   region: "NTSC-J"
 SLPM-66290:
-  name: "Galaxy Angel [The Best]"
+  name: Broccoli Best Quality ギャラクシーエンジェル
+  name-sort: Broccoli Best Quality ぎゃらくしーえんじぇる
+  name-en: "Galaxy Angel [The Best]"
   region: "NTSC-J"
 SLPM-66291:
-  name: "Tenka-bito"
+  name: 天下人
+  name-sort: てんかじん
+  name-en: "Tenka-bito"
   region: "NTSC-J"
 SLPM-66292:
-  name: "Jissen Pachi-Slot Hisshouhou! Ultraman Club ST"
+  name: 実戦パチスロ必勝法! ウルトラマン倶楽部ST
+  name-sort: じっせんぱちすろひっしょうほう! うるとらまんくらぶST
+  name-en: "Jissen Pachi-Slot Hisshouhou! Ultraman Club ST"
   region: "NTSC-J"
 SLPM-66293:
-  name: "Gakuen Alice - KiraKira Memory Kiss"
+  name: 学園アリス 〜きらきら★メモリーキッス〜
+  name-sort: がくえんありす 〜きらきら★めもりーきっす〜
+  name-en: "Gakuen Alice - KiraKira Memory Kiss"
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Reduces vertical line issue in textbox.
 SLPM-66294:
-  name: "Sotsugyou 2nd Generation"
+  name: 卒業 2nd Generation
+  name-sort: そつぎょう 2nd Generation
+  name-en: "Sotsugyou 2nd Generation"
   region: "NTSC-J"
 SLPM-66295:
-  name: "Yamiyo ni Sasayaku - Tantei Sagara Kyouichirou [Limited Edition]"
+  name: 闇夜にささやく 〜探偵 相楽恭一郎〜 限定版
+  name-sort: やみよにささやく 〜たんてい さがらきょういちろう〜 げんていばん
+  name-en: "Yamiyo ni Sasayaku - Tantei Sagara Kyouichirou [Limited Edition]"
   region: "NTSC-J"
   patches:
     23A9A026:
@@ -37398,7 +41209,9 @@ SLPM-66295:
         // This patch skips over the stack code, allowing the game to boot.
         patch=1,EE,00156888,word,10000003
 SLPM-66296:
-  name: "Yamiyo ni Sasayaku - Tantei Sagara Kyouichirou"
+  name: 闇夜にささやく 〜探偵 相楽恭一郎〜 通常版
+  name-sort: やみよにささやく 〜たんてい さがらきょういちろう〜 つうじょうばん
+  name-en: "Yamiyo ni Sasayaku - Tantei Sagara Kyouichirou"
   region: "NTSC-J"
   patches:
     23A9A026:
@@ -37408,23 +41221,35 @@ SLPM-66296:
         // This patch skips over the stack code, allowing the game to boot.
         patch=1,EE,00156888,word,10000003
 SLPM-66297:
-  name: "Separate Hearts [Limited Edition]"
+  name: セパレイトハーツ 限定版
+  name-sort: せぱれいとはーつ げんていばん
+  name-en: "Separate Hearts [Limited Edition]"
   region: "NTSC-J"
 SLPM-66298:
-  name: "Separate Hearts"
+  name: セパレイトハーツ 通常版
+  name-sort: せぱれいとはーつ つうじょうばん
+  name-en: "Separate Hearts"
   region: "NTSC-J"
 SLPM-66299:
-  name: "Reishiki Kanjou Sentouki 2"
+  name: 零式艦上戦闘記 弐
+  name-sort: れいしきかんじょうせんとうき 弐
+  name-en: "Reishiki Kanjou Sentouki 2"
   region: "NTSC-J"
 SLPM-66300:
-  name: "Wizardry Xth - Mugen no Gakuto"
+  name: ウィザードリィエクス2 〜無限の学徒〜
+  name-sort: うぃざーどりぃえくす2 〜むげんのがくと〜
+  name-en: "Wizardry Xth - Mugen no Gakuto"
   region: "NTSC-J"
 SLPM-66301:
-  name: "Ibara"
+  name: 鋳薔薇
+  name-sort: いばら
+  name-en: "Ibara"
   region: "NTSC-J"
   compat: 5
 SLPM-66302:
-  name: "Clannad"
+  name: CLANNAD
+  name-sort: CLANNAD
+  name-en: "Clannad"
   region: "NTSC-J"
   gsHWFixes:
     gpuTargetCLUT: 1 # Fixes colours.
@@ -37442,7 +41267,9 @@ SLPM-66306:
   name: "Shin Sangoku Musou 3 - Moushouden"
   region: "NTSC-J"
 SLPM-66307:
-  name: "Sengoku Musou 2"
+  name: 戦国無双2
+  name-sort: せんごくむそう2
+  name-en: "Sengoku Musou 2"
   region: "NTSC-J"
   gsHWFixes:
     roundSprite: 2 # Helps to alleviate misaligned text.
@@ -37460,24 +41287,34 @@ SLPM-66307:
     - "SLPM-74224"
     - "SLPM-74249"
 SLPM-66308:
-  name: "Harukanaru Toki no Naka Premium Boxset"
+  name: 遙かなる時空の中で　プレミアムBOXコンプリート
+  name-sort: はるかなるときのなかで　ぷれみあむBOXこんぷりーと
+  name-en: "Harukanaru Toki no Naka Premium Boxset"
   region: "NTSC-J"
 SLPM-66312:
   name: "Saishuu Heiki Kanojo [Konami the Best]"
   region: "NTSC-J"
 SLPM-66313:
-  name: "GuitarFreaksV & DrumManiaV"
+  name: ギターフリークスV & ドラムマニアV
+  name-sort: ぎたーふりーくすV & どらむまにあV
+  name-en: "GuitarFreaksV & DrumManiaV"
   region: "NTSC-J"
   compat: 5
 SLPM-66314:
-  name: "Pop'n music 12 Iroha"
+  name: ポップンミュージック12 いろは
+  name-sort: ぽっぷんみゅーじっく12 いろは
+  name-en: "Pop'n music 12 Iroha"
   region: "NTSC-J"
   compat: 5
 SLPM-66315:
-  name: "Shinseiki Evangelion - Koutetsu no Girlfriend 2nd [Broccoli Best Quality]"
+  name: Broccoli Best Quality 新世紀エヴァンゲリオン 鋼鉄のガールフレンド2nd
+  name-sort: Broccoli Best Quality しんせいきえゔぁんげりおん こうてつのがーるふれんど2nd
+  name-en: "Shinseiki Evangelion - Koutetsu no Girlfriend 2nd [Broccoli Best Quality]"
   region: "NTSC-J"
 SLPM-66316:
-  name: "Pro Soccer Club o Tsukurou! Europe Championship"
+  name: プロサッカークラブをつくろう!ヨーロッパチャンピオンシップ
+  name-sort: ぷろさっかーくらぶをつくろう!よーろっぱちゃんぴおんしっぷ
+  name-en: "Pro Soccer Club o Tsukurou! Europe Championship"
   region: "NTSC-J"
   clampModes:
     eeClampMode: 3 # Makes the game to correctly register left and right Dpad button input.
@@ -37486,39 +41323,57 @@ SLPM-66316:
     - "SLPM-66324"
     - "SLPM-66442"
 SLPM-66317:
-  name: "Capcom Classics Collection Vol.1"
+  name: カプコン クラシックス コレクション
+  name-sort: かぷこん くらしっくす これくしょん
+  name-en: "Capcom Classics Collection Vol.1"
   region: "NTSC-J"
 SLPM-66318:
-  name: "Haru no Ashioto - Step of Spring"
+  name: はるのあしおと -Step of Spring-
+  name-sort: はるのあしおと -Step of Spring-
+  name-en: "Haru no Ashioto - Step of Spring"
   region: "NTSC-J"
 SLPM-66319:
-  name: "New Choro Q [Atlus Best Collection]"
+  name: 新コンバットチョロQ アトラス・ベストコレクション
+  name-sort: しんこんばっとちょろQ あとらす・べすとこれくしょん
+  name-en: "New Choro Q [Atlus Best Collection]"
   region: "NTSC-J"
 SLPM-66320:
-  name: "Final Fantasy XII"
+  name: ファイナルファンタジーXII
+  name-sort: ふぁいなるふぁんたじーXII
+  name-en: "Final Fantasy XII"
   region: "NTSC-J"
   compat: 5
 SLPM-66321:
-  name: "Kurogane no Houkou - Warship Gunner 2"
+  name: ウォーシップガンナー2 〜鋼鉄の咆哮〜
+  name-sort: うぉーしっぷがんなー2 〜くろがねのほうこう〜
+  name-en: "Kurogane no Houkou - Warship Gunner 2"
   region: "NTSC-J"
 SLPM-66322:
-  name: "007 - Russia yori Ai o Komete"
+  name: 007 ロシアより愛をこめて
+  name-sort: 007 ろしあよりあいをこめて
+  name-en: "007 - Russia yori Ai o Komete"
   region: "NTSC-J"
   gsHWFixes:
     textureInsideRT: 1 # Required for complex offset shuffles.
     recommendedBlendingLevel: 4 # Fixes lighting.
 SLPM-66323:
-  name: "Princess Software Collection, The"
+  name: ふぁいなる・あぷろーち(プリンセスソフトコレクション)
+  name-sort: ふぁいなる・あぷろーち(ぷりんせすそふとこれくしょん)
+  name-en: "Princess Software Collection, The"
   region: "NTSC-J"
 SLPM-66324:
-  name: "World Football Climax"
+  name: ワールドフットボール クライマックス 日本代表パッケージ
+  name-sort: わーるどふっとぼーる くらいまっくす にほんだいひょうぱっけーじ
+  name-en: "World Football Climax"
   region: "NTSC-J"
   memcardFilters: # SLPM-66316 enables import of teams.
     - "SLPM-66324"
     - "SLPM-66316"
     - "SLPM-66442"
 SLPM-66325:
-  name: "Castlevania [Konami Palace Selection]"
+  name: キャッスルヴァニア(コナミ殿堂セレクション)
+  name-sort: きゃっするゔぁにあ(こなみでんどうせれくしょん)
+  name-en: "Castlevania [Konami Palace Selection]"
   region: "NTSC-J"
   clampModes:
     eeClampMode: 3 # Fixes cutscene freezes.
@@ -37526,12 +41381,16 @@ SLPM-66326:
   name: "Ys - The Ark of Napishtim"
   region: "NTSC-J"
 SLPM-66327:
-  name: "Wallace & Gromit - The Curse of the Were-Rabbit"
+  name: ウォレスとグルミット野菜畑で大ピンチ!
+  name-sort: うぉれすとぐるみっとやさいはたけでだいぴんち!
+  name-en: "Wallace & Gromit - The Curse of the Were-Rabbit"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misalignment/bloom when upscaling.
 SLPM-66328:
-  name: "Call of Duty 2 - Big Red One"
+  name: Call of Duty 2 Big Red One
+  name-sort: Call of Duty 2 Big Red One
+  name-en: "Call of Duty 2 - Big Red One"
   region: "NTSC-J"
   gameFixes:
     - SoftwareRendererFMVHack # Right side of the FMV is not rendering correctly.
@@ -37542,26 +41401,38 @@ SLPM-66328:
     mipmap: 2 # Mipmap + trilinear, improves ground and building textures to match sw renderer.
     trilinearFiltering: 1
 SLPM-66329:
-  name: "Mahou Sensei Negima! Kagai Jugyou"
+  name: 魔法先生ネギま! 課外授業 乙女のドキドキ・ビーチサイド
+  name-sort: まほうせんせいねぎま! かがいじゅぎょう おとめのどきどき・びーちさいど
+  name-en: "Mahou Sensei Negima! Kagai Jugyou"
   region: "NTSC-J"
   compat: 5
   gameFixes:
     - XGKickHack # Fixes rendering problems.
 SLPM-66330:
-  name: "Tokimeki Memorial - Girl's Side - 2nd Kiss"
+  name: ときめきメモリアル Girl’s Side 2nd Kiss 初回生産版
+  name-sort: ときめきめもりある Girl’s Side 2nd Kiss しょかいせいさんばん
+  name-en: "Tokimeki Memorial - Girl's Side - 2nd Kiss"
   region: "NTSC-J"
 SLPM-66331:
-  name: "Kouenji Onago Soccer [1st Stage Limited Edition]"
+  name: 高円寺女子サッカー  1st stage限定版
+  name-sort: こうえんじじょしさっかー  1st stageげんていばん
+  name-en: "Kouenji Onago Soccer [1st Stage Limited Edition]"
   region: "NTSC-J"
 SLPM-66332:
-  name: "Kouenji Onago Soccer"
+  name: 高円寺女子サッカー 通常版
+  name-sort: こうえんじじょしさっかー つうじょうばん
+  name-en: "Kouenji Onago Soccer"
   region: "NTSC-J"
 SLPM-66333:
-  name: "Guilty Gear XX Slash"
+  name: GUILTY GEAR XX SLASH (ギルティギア イグゼクス スラッシュ)
+  name-sort: GUILTY GEAR XX SLASH (ぎるてぃぎあ いぐぜくす すらっしゅ)
+  name-en: "Guilty Gear XX Slash"
   region: "NTSC-J"
   compat: 5
 SLPM-66334:
-  name: "WRC 4 [Spike the Best]"
+  name: Spike the Best WRC4
+  name-sort: Spike the Best WRC4
+  name-en: "WRC 4 [Spike the Best]"
   region: "NTSC-J"
   gameFixes:
     - XGKickHack # Fixes SPS.
@@ -37585,28 +41456,44 @@ SLPM-66335:
   name: "Ichigo 100 Percent Strawberry Diary"
   region: "NTSC-J"
 SLPM-66336:
-  name: "Shinseiki Evangelion - Koutetsu no Girlfriend [Special Edition]"
+  name: 新世紀エヴァンゲリオン 鋼鉄のガールフレンド<特別編>
+  name-sort: しんせいきえゔぁんげりおん こうてつのがーるふれんど<とくべつへん>
+  name-en: "Shinseiki Evangelion - Koutetsu no Girlfriend [Special Edition]"
   region: "NTSC-J"
 SLPM-66337:
-  name: "EVE New Generation [Deluxe Pack]"
+  name: イブ〜ニュージェネレーション〜 DXパック
+  name-sort: いぶ〜にゅーじぇねれーしょん〜 DXぱっく
+  name-en: "EVE New Generation [Deluxe Pack]"
   region: "NTSC-J"
 SLPM-66338:
-  name: "EVE New Generation"
+  name: イブ〜ニュージェネレーション〜
+  name-sort: いぶ〜にゅーじぇねれーしょん〜
+  name-en: "EVE New Generation"
   region: "NTSC-J"
 SLPM-66339:
-  name: "Neo Angelique [Premium Box]"
+  name: ネオ アンジェリーク プレミアムBOX
+  name-sort: ねお あんじぇりーく ぷれみあむBOX
+  name-en: "Neo Angelique [Premium Box]"
   region: "NTSC-J"
 SLPM-66340:
-  name: "Neo Angelique"
+  name: ネオ アンジェリーク
+  name-sort: ねお あんじぇりーく
+  name-en: "Neo Angelique"
   region: "NTSC-J"
 SLPM-66341:
-  name: "Jan Sangoku Musou"
+  name: 雀・三國無双
+  name-sort: じゃん・さんごくむそう
+  name-en: "Jan Sangoku Musou"
   region: "NTSC-J"
 SLPM-66342:
-  name: "Winning Post 7 Maximum 2006"
+  name: WinningPost7 MAXIMUM 2006
+  name-sort: WinningPost7 MAXIMUM 2006
+  name-en: "Winning Post 7 Maximum 2006"
   region: "NTSC-J"
 SLPM-66343:
-  name: "Shin Sangoku Musou 4 - Empires"
+  name: 真・三國無双4 Empires
+  name-sort: しん・さんごくむそう4 Empires
+  name-en: "Shin Sangoku Musou 4 - Empires"
   region: "NTSC-J"
 SLPM-66344:
   name: "Harukanaru Toki no Naka de 3 - Unmei no Labyrinth [Triple Pack]"
@@ -37618,28 +41505,42 @@ SLPM-66346:
   name: "Harukanaru Toki no Naka de 3 - Izayoiki"
   region: "NTSC-J"
 SLPM-66347:
-  name: "Harukanaru Jikuu no Kade 3 - Unmei no Meikyuu [Premium Box]"
+  name: 遙かなる時空の中で3 運命の迷宮 プレミアムBOX
+  name-sort: はるかなるときのなかで3 うんめいのめいきゅう ぷれみあむBOX
+  name-en: "Harukanaru Jikuu no Kade 3 - Unmei no Meikyuu [Premium Box]"
   region: "NTSC-J"
 SLPM-66348:
-  name: "Harukanaru Jikuu no Kade 3 - Unmei no Meikyuu"
+  name: 遙かなる時空の中で3 運命の迷宮
+  name-sort: はるかなるときのなかで3 うんめいのめいきゅう
+  name-en: "Harukanaru Jikuu no Kade 3 - Unmei no Meikyuu"
   region: "NTSC-J"
 SLPM-66349:
-  name: "Spectral Force Chronicle"
+  name: IFコレクション スペクトラルフォース クロニクル
+  name-sort: IFこれくしょん すぺくとらるふぉーす くろにくる
+  name-en: "Spectral Force Chronicle"
   region: "NTSC-J"
 SLPM-66350:
   name: "Spectral vs. Generation"
   region: "NTSC-J"
 SLPM-66351:
-  name: "Soshite Kono Uchuu ni Kirameku Kimi no Shi"
+  name: そしてこの宇宙にきらめく君の詩
+  name-sort: そしてこのうちゅうにきらめくきみのし
+  name-en: "Soshite Kono Uchuu ni Kirameku Kimi no Shi"
   region: "NTSC-J"
 SLPM-66352:
-  name: "Memories Off - Sorekara Again [Limited Edition]"
+  name: Memories Off〜それから〜Again 限定版
+  name-sort: Memories Off〜それから〜Again げんていばん
+  name-en: "Memories Off - Sorekara Again [Limited Edition]"
   region: "NTSC-J"
 SLPM-66353:
-  name: "Memories Off - Sorekara Again"
+  name: Memories Off〜それから〜Again 通常版
+  name-sort: Memories Off〜それから〜Again つうじょうばん
+  name-en: "Memories Off - Sorekara Again"
   region: "NTSC-J"
 SLPM-66354:
-  name: "Black"
+  name: BLACK
+  name-sort: BLACK
+  name-en: "Black"
   region: "NTSC-J"
   compat: 5
   clampModes:
@@ -37671,24 +41572,36 @@ SLPM-66357:
   name: "Rozen Maiden - Duellwalzer"
   region: "NTSC-J"
 SLPM-66358:
-  name: "Shinobido Takumi"
+  name: 忍道 匠
+  name-sort: しのびどう たくみ
+  name-en: "Shinobido Takumi"
   region: "NTSC-J"
   clampModes:
     eeClampMode: 3 # Fixes crash after main menu.
 SLPM-66359:
-  name: "Mutsu-boshi Kirari - Hoshifuru Miyako"
+  name: 六ツ星きらり〜ほしふるみやこ〜
+  name-sort: むっつぼしきらり〜ほしふるみやこ〜
+  name-en: "Mutsu-boshi Kirari - Hoshifuru Miyako"
   region: "NTSC-J"
 SLPM-66360:
-  name: "Ys V - Lost Kefin - Kingdom of Sand"
+  name: イースV 〜Lost Kefin,Kingdom of Sand〜
+  name-sort: いーすV 〜Lost Kefin,Kingdom of Sand〜
+  name-en: "Ys V - Lost Kefin - Kingdom of Sand"
   region: "NTSC-J"
 SLPM-66361:
-  name: "Konohana 4 - Yami wo Harau Inori [Superlite 2000]"
+  name: SuperLite 2000 此花4 〜闇を祓う祈り〜
+  name-sort: SuperLite 2000 このはな4 〜やみをはらういのり〜
+  name-en: "Konohana 4 - Yami wo Harau Inori [Superlite 2000]"
   region: "NTSC-J"
 SLPM-66363:
-  name: "Dragon Quest - Shoenen Yangus to Fushigi no Dungeon"
+  name: ドラゴンクエスト 少年ヤンガスと不思議のダンジョン
+  name-sort: どらごんくえすと しょうねんやんがすとふしぎのだんじょん
+  name-en: "Dragon Quest - Shoenen Yangus to Fushigi no Dungeon"
   region: "NTSC-J"
 SLPM-66364:
-  name: "Pro Yakyuu Spirits 3"
+  name: プロ野球スピリッツ3
+  name-sort: ぷろやきゅうすぴりっつ3
+  name-en: "Pro Yakyuu Spirits 3"
   region: "NTSC-J"
 SLPM-66368:
   name: "Shin Sangoku Musou 4 - Empires"
@@ -37697,15 +41610,21 @@ SLPM-66369:
   name: "Shin Sangoku Musou 4 - Moushouden"
   region: "NTSC-J"
 SLPM-66371:
-  name: "Train Simulator & Densha de Go! Tokyo Kyuukouhen [Ongakukan Pocket Books]"
+  name: Train Simulator+電車でGO!東京急行編ベスト
+  name-sort: Train Simulator+でんしゃでGO!とうきょうきゅうこうへんべすと
+  name-en: "Train Simulator & Densha de Go! Tokyo Kyuukouhen [Ongakukan Pocket Books]"
   region: "NTSC-J"
 SLPM-66372:
-  name: "Digital Devil Saga - Avatar Tuner [Atlus Best Collection]"
+  name: ATLUS BEST COLLECTION DIGITAL DEVIL SAGA 〜アバタール・チューナー〜
+  name-sort: ATLUS BEST COLLECTION DIGITAL DEVIL SAGA 〜あばたーる・ちゅーなー〜
+  name-en: "Digital Devil Saga - Avatar Tuner [Atlus Best Collection]"
   region: "NTSC-J"
   gameFixes:
     - EETimingHack
 SLPM-66373:
-  name: "Digital Devil Saga - Avatar Tuner 2 [Atlus Best Collection]"
+  name: ATLUS BEST COLLECTION DIGITAL DEVIL SAGA 〜アバタール・チューナー2〜
+  name-sort: ATLUS BEST COLLECTION DIGITAL DEVIL SAGA 〜あばたーる・ちゅーなー2〜
+  name-en: "Digital Devil Saga - Avatar Tuner 2 [Atlus Best Collection]"
   region: "NTSC-J"
   gameFixes:
     - EETimingHack
@@ -37717,32 +41636,48 @@ SLPM-66373:
     - "SLPM-65597"
     - "SLPM-66372"
 SLPM-66374:
-  name: "World Soccer Winning Eleven 10"
+  name: ワールドサッカーウイニングイレブン10
+  name-sort: わーるどさっかーういにんぐいれぶん10
+  name-en: "World Soccer Winning Eleven 10"
   region: "NTSC-J"
   compat: 5
 SLPM-66375:
-  name: "Ookami"
+  name: 大神
+  name-sort: おおがみ
+  name-en: "Ookami"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
     roundSprite: 2 # Reduces misalignment issues but the game is just bad for upscaling.
 SLPM-66376:
-  name: "KimiStar - Kimi to Study [BGM Collection Package]"
+  name: きみスタ〜きみとスタディ〜BGMコレクションパッケージ
+  name-sort: きみすた〜きみとすたでぃ〜BGMこれくしょんぱっけーじ
+  name-en: "KimiStar - Kimi to Study [BGM Collection Package]"
   region: "NTSC-J"
 SLPM-66377:
-  name: "KimiStar - Kimi to Study"
+  name: きみスタ〜きみとスタディ〜 通常パッケージ
+  name-sort: きみすた〜きみとすたでぃ〜 つうじょうぱっけーじ
+  name-en: "KimiStar - Kimi to Study"
   region: "NTSC-J"
 SLPM-66378:
-  name: "Garfield - Saving Arleene"
+  name: ガーフィールド アーリーンを救え!
+  name-sort: がーふぃーるど あーりーんをすくえ!
+  name-en: "Garfield - Saving Arleene"
   region: "NTSC-J"
 SLPM-66379:
-  name: "Kishin Houkou Demon Bane [Kadokawa The Best]"
+  name: 機神咆哮デモンベイン KADOKAWA The Best
+  name-sort: きしんほうこうでもんべいん KADOKAWA The Best
+  name-en: "Kishin Houkou Demon Bane [Kadokawa The Best]"
   region: "NTSC-J"
 SLPM-66380:
-  name: "Mitsu x Mitsu Drops - Love x Love Honey Life [Limited Edition]"
+  name: 蜜×蜜ドロップス LOVE×LOVE HONEY LIFE(限定版)
+  name-sort: みつ×みつどろっぷす LOVE×LOVE HONEY LIFE(げんていばん)
+  name-en: "Mitsu x Mitsu Drops - Love x Love Honey Life [Limited Edition]"
   region: "NTSC-J"
 SLPM-66381:
-  name: "Mitsu x Mitsu Drops - Love x Love Honey Life"
+  name: 蜜×蜜ドロップス LOVE×LOVE HONEY LIFE(通常版)
+  name-sort: みつ×みつどろっぷす LOVE×LOVE HONEY LIFE(つうじょうばん)
+  name-en: "Mitsu x Mitsu Drops - Love x Love Honey Life"
   region: "NTSC-J"
   patches:
     A37C886C:
@@ -37752,53 +41687,83 @@ SLPM-66381:
         // This patch skips over the stack code, allowing the game to boot.
         patch=1,EE,00157318,word,10000003
 SLPM-66382:
-  name: "Tenshou Gakuen Gensouroku [Tokudane Price]"
+  name: アスミック得だねシリーズ 転生學園幻蒼録
+  name-sort: あすみっくとくだねしりーず てんしょうがくえんげんそうろく
+  name-en: "Tenshou Gakuen Gensouroku [Tokudane Price]"
   region: "NTSC-J"
 SLPM-66383:
-  name: "Natsuyume Yobanashi [2800 Collection]"
+  name: 夏夢夜話<2800コレクション>
+  name-sort: なつゆめやわ<2800これくしょん>
+  name-en: "Natsuyume Yobanashi [2800 Collection]"
   region: "NTSC-J"
 SLPM-66384:
-  name: "Iris [2800 Collection]"
+  name: Iris<2800コレクション>
+  name-sort: Iris<2800これくしょん>
+  name-en: "Iris [2800 Collection]"
   region: "NTSC-J"
 SLPM-66385:
-  name: "Omoi no Kakera - Close to [2800 Collection]"
+  name: 想いのかけら-Close to-<2800コレクション>
+  name-sort: おもいのかけら-Close to-<2800これくしょん>
+  name-en: "Omoi no Kakera - Close to [2800 Collection]"
   region: "NTSC-J"
 SLPM-66386:
-  name: "FIFA World Cup - Germany 2006"
+  name: 2006 FIFA ワールドカップ ドイツ大会
+  name-sort: 2006 FIFA わーるどかっぷ どいつたいかい
+  name-en: "FIFA World Cup - Germany 2006"
   region: "NTSC-J"
 SLPM-66387:
-  name: "Shin Bakusou Dekotora Densetsu [Spike the Best]"
+  name: Spike The Best 真・爆走デコトラ伝説 〜天下統一頂上決戦〜
+  name-sort: Spike The Best しん・ばくそうでことらでんせつ 〜てんかとういつちょうじょうけっせん〜
+  name-en: "Shin Bakusou Dekotora Densetsu [Spike the Best]"
   region: "NTSC-J"
 SLPM-66388:
-  name: "Fire Pro Wrestling Returns [Spike The Best]"
+  name: Spike The Best ファイプロ・リターンズ
+  name-sort: Spike The Best ふぁいぷろ・りたーんず
+  name-en: "Fire Pro Wrestling Returns [Spike The Best]"
   region: "NTSC-J"
 SLPM-66390:
-  name: "Bara no Ki ni Bara no Hanasaku - Das Versprechen"
+  name: 薔薇ノ木ニ薔薇ノ花咲ク -Das Versprechen-
+  name-sort: ばらのきにばらのはなさきく -Das Versprechen-
+  name-en: "Bara no Ki ni Bara no Hanasaku - Das Versprechen"
   region: "NTSC-J"
 SLPM-66391:
-  name: "Prince of Persia - The Two Thrones"
+  name: プリンス・オブ・ペルシャ 二つの魂
+  name-sort: ぷりんす・おぶ・ぺるしゃ ふたつのたましい
+  name-en: "Prince of Persia - The Two Thrones"
   region: "NTSC-J"
   gsHWFixes:
     autoFlush: 2 # Reduces post-processing misalignment.
     halfPixelOffset: 1 # Reduces post-processing misalignment.
 SLPM-66393:
-  name: "Final Fantasy XI - Aht Urhgan no Hihou [All-in-One Pack]"
+  name: プレイオンライン / ファイナルファンタジーXI オールインワンパック2006
+  name-sort: ぷれいおんらいん / ふぁいなるふぁんたじーXI おーるいんわんぱっく2006
+  name-en: "Final Fantasy XI - Aht Urhgan no Hihou [All-in-One Pack]"
   region: "NTSC-J"
 SLPM-66394:
-  name: "Final Fantasy XI - Aht Urhgan no Hihou"
+  name: ファイナルファンタジーXI アトルガンの秘宝 拡張データディスク
+  name-sort: ふぁいなるふぁんたじーXI あとるがんのひほう かくちょうでーたでぃすく
+  name-en: "Final Fantasy XI - Aht Urhgan no Hihou"
   region: "NTSC-J"
 SLPM-66395:
-  name: "Honoo no Takkyubin"
+  name: 炎の宅配便
+  name-sort: ほのおのたくはいびん
+  name-en: "Honoo no Takkyubin"
   region: "NTSC-J"
   compat: 5
 SLPM-66396:
-  name: "Tensei Hakken Fuumoroku"
+  name: 転生八犬士封魔録
+  name-sort: てんせいはっけんしふうまろく
+  name-en: "Tensei Hakken Fuumoroku"
   region: "NTSC-J"
 SLPM-66398:
-  name: "Parufu - Chocolat Second Brew"
+  name: パルフェ Chocolat Second Style
+  name-sort: ぱるふぇ Chocolat Second Style
+  name-en: "Parufu - Chocolat Second Brew"
   region: "NTSC-J"
 SLPM-66399:
-  name: "Samurai 7 [Limited Edition]"
+  name: SAMURAI 7 限定版
+  name-sort: SAMURAI 7 げんていばん
+  name-en: "Samurai 7 [Limited Edition]"
   region: "NTSC-J"
   patches:
     836F4606:
@@ -37808,7 +41773,9 @@ SLPM-66399:
         // This patch skips over the stack code, allowing the game to boot.
         patch=1,EE,00157F78,word,10000003
 SLPM-66400:
-  name: "Samurai 7"
+  name: SAMURAI 7 通常版
+  name-sort: SAMURAI 7 つうじょうばん
+  name-en: "Samurai 7"
   region: "NTSC-J"
   patches:
     836F4606:
@@ -37818,13 +41785,17 @@ SLPM-66400:
         // This patch skips over the stack code, allowing the game to boot.
         patch=1,EE,00157F78,word,10000003
 SLPM-66401:
-  name: "Wrestle Kingdom"
+  name: レッスルキングダム
+  name-sort: れっするきんぐだむ
+  name-en: "Wrestle Kingdom"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
 SLPM-66402:
-  name: "Taito Memories - Joukan [Taito The Best]"
+  name: タイトーメモリーズ 上巻 TAITO BEST
+  name-sort: たいとーめもりーず じょうかん TAITO BEST
+  name-en: "Taito Memories - Joukan [Taito The Best]"
   region: "NTSC-J"
   gsHWFixes:
     roundSprite: 1 # Fixes vertical and horizontal lines.
@@ -37843,53 +41814,79 @@ SLPM-66404:
     autoFlush: 2 # Fixes shadow alignment along with HPO Special (Normal looks better but causes top left glitches).
     halfPixelOffset: 2
 SLPM-66405:
-  name: "Radirgy Precious"
+  name: ラジルギ・プレシャス
+  name-sort: らじるぎ・ぷれしゃす
+  name-en: "Radirgy Precious"
   region: "NTSC-J"
   compat: 5
 SLPM-66406:
-  name: "Sakura Hana"
+  name: 桜華 〜心輝かせる桜〜
+  name-sort: さくらはな 〜こころかがやかせるさくら〜
+  name-en: "Sakura Hana"
   region: "NTSC-J"
 SLPM-66407:
-  name: "Mighty Heart"
+  name: つよきす 〜Mighty Heart〜 完全生産限定版
+  name-sort: つよきす 〜Mighty Heart〜 かんぜんせいさんげんていばん
+  name-en: "Mighty Heart"
   region: "NTSC-J"
 SLPM-66408:
-  name: "Tsuyo Kiss - Mighty Heart"
+  name: つよきす 〜Mighty Heart〜 通常版
+  name-sort: つよきす 〜Mighty Heart〜 つうじょうばん
+  name-en: "Tsuyo Kiss - Mighty Heart"
   region: "NTSC-J"
 SLPM-66409:
-  name: "Street Fighter Zero - Fighters Generation"
+  name: ストリートファイターZERO ファイターズ ジェネレーション
+  name-sort: すとりーとふぁいたーZERO ふぁいたーず じぇねれーしょん
+  name-en: "Street Fighter Zero - Fighters Generation"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
     roundSprite: 1 # Fixes squares around sprites when upscaling.
 SLPM-66410:
-  name: "Brothers In Arms - Meiyo no Daishou"
+  name: ブラザー イン アームズ 名誉の代償
+  name-sort: ぶらざー いん あーむず めいよのだいしょう
+  name-en: "Brothers In Arms - Meiyo no Daishou"
   region: "NTSC-J"
 SLPM-66412:
-  name: "Pizzicato Polka - Suisei Genya [2800 Collection]"
+  name: ピチカートポルカ 〜縁鎖現夜〜 <2800コレクション>
+  name-sort: ぴちかーとぽるか 〜えんさげんや〜 <2800これくしょん>
+  name-en: "Pizzicato Polka - Suisei Genya [2800 Collection]"
   region: "NTSC-J"
 SLPM-66413:
-  name: "Cross+Channel - To All People [2800 Collection]"
+  name: CROSS+CHANNEL 〜To all people〜 <2800コレクション>
+  name-sort: CROSS+CHANNEL 〜To all people〜 <2800これくしょん>
+  name-en: "Cross+Channel - To All People [2800 Collection]"
   region: "NTSC-J"
 SLPM-66414:
   name: "Colorful Box - To Love"
   region: "NTSC-J"
 SLPM-66415:
-  name: "Mystereet [First Print - Limited Edition]"
+  name: ミステリート 〜八十神かおるの事件ファイル〜(初回限定版)
+  name-sort: みすてりーと 〜やそがみかおるのじけんふぁいる〜(しょかいげんていばん)
+  name-en: "Mystereet [First Print - Limited Edition]"
   region: "NTSC-J"
 SLPM-66416:
-  name: "Mystereet"
+  name: ミステリート 〜八十神かおるの事件ファイル〜
+  name-sort: みすてりーと 〜やそがみかおるのじけんふぁいる〜
+  name-en: "Mystereet"
   region: "NTSC-J"
 SLPM-66417:
-  name: "Jikkyou Powerful Major League"
+  name: 実況パワフルメジャーリーグ
+  name-sort: じっきょうぱわふるめじゃーりーぐ
+  name-en: "Jikkyou Powerful Major League"
   region: "NTSC-J"
 SLPM-66418:
-  name: "Growlanser V - Generations"
+  name: グローランサーV ジェネレーションズ 通常版
+  name-sort: ぐろーらんさーV じぇねれーしょんず つうじょうばん
+  name-en: "Growlanser V - Generations"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
     moveHandler: "MV_Growlanser" # Fixes precomputed depth buffer.
 SLPM-66419:
-  name: "Valkyrie Profile 2 - Silmeria"
+  name: ヴァルキリープロファイル2 -シルメリア-
+  name-sort: ゔぁるきりーぷろふぁいる2 -しるめりあ-
+  name-en: "Valkyrie Profile 2 - Silmeria"
   region: "NTSC-J"
   compat: 5
   gameFixes:
@@ -37900,18 +41897,24 @@ SLPM-66419:
     textureInsideRT: 1 # Required for swirl battle transition.
     nativePaletteDraw: 1
 SLPM-66420:
-  name: "Front Mission 4 [Ultimate Hits]"
+  name: アルティメット ヒッツ フロントミッション4
+  name-sort: あるてぃめっと ひっつ ふろんとみっしょん4
+  name-en: "Front Mission 4 [Ultimate Hits]"
   region: "NTSC-J"
   gsHWFixes:
     preloadFrameData: 1 # Fixes mech shadows.
     roundSprite: 2 # Fixes font artifacts.
 SLPM-66421:
-  name: "Front Mission 5 - Scars of the War [Ultimate Hits]"
+  name: アルティメット ヒッツ フロントミッション5 〜Scars of the War〜
+  name-sort: あるてぃめっと ひっつ ふろんとみっしょん5 〜Scars of the War〜
+  name-en: "Front Mission 5 - Scars of the War [Ultimate Hits]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 1 # Fixes blurriness but no fix for font or other artifacts possible with round sprite.
 SLPM-66422:
-  name: "Romancing Saga - Minstrel Song [Ultimate Hits]"
+  name: Ultimate Hits Romancing SaGa −Minstrel Song−
+  name-sort: Ultimate Hits Romancing SaGa -Minstrel Song-
+  name-en: "Romancing Saga - Minstrel Song [Ultimate Hits]"
   region: "NTSC-J"
 SLPM-66424:
   name: "La Corda D'oro [Koei the Best]"
@@ -37920,20 +41923,28 @@ SLPM-66425:
   name: "Nobunaga no Yabou - Soutenroku with Power-Up Kit"
   region: "NTSC-J"
 SLPM-66426:
-  name: "Beatmania IIDX 11 - IIDX Red"
+  name: beatmania IIDX 11 IIDX RED
+  name-sort: beatmania IIDX 11 IIDX RED
+  name-en: "Beatmania IIDX 11 IIDX RED"
   region: "NTSC-J"
 SLPM-66427:
-  name: "Full Spectrum Warrior - Ten Hammers"
+  name: フル スペクトラム ウォリアー2 テンハンマーズ
+  name-sort: ふる すぺくとらむ うぉりあー2 てんはんまーず
+  name-en: "Full Spectrum Warrior - Ten Hammers"
   region: "NTSC-J"
   speedHacks:
     mvuFlag: 0 # Fixes bad graphics.
 SLPM-66429:
-  name: "Special Forces - Fire for Effect"
+  name: CTSF テロ対策特殊部隊 ネメシスの襲来
+  name-sort: CTSF てろたいさくとくしゅぶたい ねめしすのしゅうらい
+  name-en: "Special Forces - Fire for Effect"
   region: "NTSC-J"
   clampModes:
     vu1ClampMode: 3 # Fixes smoke particles.
 SLPM-66430:
-  name: "Destroy All Humans!"
+  name: デストロイ オール ヒューマンズ!
+  name-sort: ですとろい おーる ひゅーまんず!
+  name-en: "Destroy All Humans!"
   region: "NTSC-J"
   gsHWFixes:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
@@ -37944,60 +41955,88 @@ SLPM-66430:
     halfPixelOffset: 2 # Fixes misaligned bloom.
     autoFlush: 2 # Fixes sun occlusion and brightness.
 SLPM-66431:
-  name: "WinBack 2 - Project Poseidon"
+  name: WINBACK 2 Project Poseidon
+  name-sort: WINBACK 2 Project Poseidon
+  name-en: "WinBack 2 - Project Poseidon"
   region: "NTSC-J"
 SLPM-66432:
-  name: "Tamashii Kyou [Limited Edition]"
+  name: 魂響(たまゆら)〜御霊送りの詩〜 初回限定版
+  name-sort: たまゆら〜ごたまおくりのし〜 しょかいげんていばん
+  name-en: "Tamashii Kyou [Limited Edition]"
   region: "NTSC-J"
 SLPM-66433:
-  name: "Tamashii Kyou"
+  name: 魂響(たまゆら)〜御霊送りの詩〜
+  name-sort: たまゆら〜ごたまおくりのし〜
+  name-en: "Tamashii Kyou"
   region: "NTSC-J"
 SLPM-66434:
-  name: "Festa!! Hyper Girls Party [Limited Edition]"
+  name: Festa!!HYPER GIRLS PARTY 限定版
+  name-sort: Festa!!HYPER GIRLS PARTY げんていばん
+  name-en: "Festa!! Hyper Girls Party [Limited Edition]"
   region: "NTSC-J"
 SLPM-66435:
-  name: "Festa!! Hyper Girls Party"
+  name: Festa!!HYPER GIRLS PARTY 通常版
+  name-sort: Festa!!HYPER GIRLS PARTY つうじょうばん
+  name-en: "Festa!! Hyper Girls Party"
   region: "NTSC-J"
 SLPM-66436:
-  name: "Iris no Atelier - Grand Fantasm"
+  name: イリスのアトリエ グランファンタズム
+  name-sort: いりすのあとりえ ぐらんふぁんたずむ
+  name-en: "Iris no Atelier - Grand Fantasm"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
     roundSprite: 1 # Fixes vertical lines in FMVs, character portraits and other sprites.
 SLPM-66437:
-  name: "Soul Link Extension"
+  name: Soul Link EXTENSION
+  name-sort: Soul Link EXTENSION
+  name-en: "Soul Link Extension"
   region: "NTSC-J"
 SLPM-66438:
-  name: "Melty Blood - Act Cadenza"
+  name: メルティブラッド アクトカデンツァ
+  name-sort: めるてぃぶらっど あくとかでんつぁ
+  name-en: "Melty Blood - Act Cadenza"
   region: "NTSC-J"
   compat: 5
   gameFixes:
     - EETimingHack # Fixes non-working game (BSOD/crash otherwise).
 SLPM-66439:
-  name: "Hokenshitsu e Youkoso [Limited Edition]"
+  name: 保健室へようこそ (初回限定版)
+  name-sort: ほけんしつへようこそ (しょかいげんていばん)
+  name-en: "Hokenshitsu e Youkoso [Limited Edition]"
   region: "NTSC-J"
 SLPM-66440:
-  name: "Hokenshitsu e Youkoso"
+  name: 保健室へようこそ
+  name-sort: ほけんしつへようこそ
+  name-en: "Hokenshitsu e Youkoso"
   region: "NTSC-J"
 SLPM-66441:
-  name: "Oookuki"
+  name: 大奥記
+  name-sort: おおおくき
+  name-en: "Oookuki"
   region: "NTSC-J"
 SLPM-66442:
-  name: "World Football Climax"
+  name: ワールド フットボール クライマックス
+  name-sort: わーるど ふっとぼーる くらいまっくす
+  name-en: "World Football Climax"
   region: "NTSC-J"
   memcardFilters: # SLPM-66316 enables import of teams.
     - "SLPM-66442"
     - "SLPM-66316"
     - "SLPM-66324"
 SLPM-66443:
-  name: "FIFA Street 2"
+  name: FIFAストリート2
+  name-sort: FIFAすとりーと2
+  name-en: "FIFA Street 2"
   region: "NTSC-J"
   gameFixes:
     - GIFFIFOHack # Fixes flag corruptions.
   speedHacks:
     eeCycleRate: 3 # Fixes corrupted graphics.
 SLPM-66444:
-  name: "Spartan - Kodai Greece Eiyuuden"
+  name: スパルタン 〜古代ギリシャ英雄伝〜
+  name-sort: すぱるたん 〜こだいぎりしゃえいゆうでん〜
+  name-en: "Spartan - Kodai Greece Eiyuuden"
   region: "NTSC-J"
   gameFixes:
     - EETimingHack # Fixes garbage textures flashing on the character model.
@@ -38005,30 +42044,44 @@ SLPM-66444:
     autoFlush: 1 # Fixes missing post processing.
     halfPixelOffset: 1 # Aligns post processing.
 SLPM-66445:
-  name: "Persona 3"
+  name: ペルソナ3
+  name-sort: ぺるそな3
+  name-en: "Persona 3"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
     mipmap: 1
 SLPM-66446:
-  name: "Beat Down - Fists of Vengeance [CapKore]"
+  name: ビートダウン カプコレ
+  name-sort: びーとだうん かぷこれ
+  name-en: "Beat Down - Fists of Vengeance [CapKore]"
   region: "NTSC-J"
 SLPM-66447:
-  name: "Sengoku Basara 2"
+  name: 戦国BASARA2
+  name-sort: せんごくBASARA2
+  name-en: "Sengoku Basara 2"
   region: "NTSC-J"
   compat: 5
 SLPM-66448:
-  name: "We Are [Limited Edition]"
+  name: We Are* 限定版
+  name-sort: We Are* げんていばん
+  name-en: "We Are [Limited Edition]"
   region: "NTSC-J"
 SLPM-66449:
-  name: "We Are"
+  name: We Are* 通常版
+  name-sort: We Are* つうじょうばん
+  name-en: "We Are"
   region: "NTSC-J"
 SLPM-66450:
-  name: "Jikkyou Powerful Pro Yakyuu 13"
+  name: 実況パワフルプロ野球13
+  name-sort: じっきょうぱわふるぷろやきゅう13
+  name-en: "Jikkyou Powerful Pro Yakyuu 13"
   region: "NTSC-J"
   compat: 5
 SLPM-66451:
-  name: "Major League Baseball 2K6"
+  name: メジャーリーグベースボール 2K6
+  name-sort: めじゃーりーぐべーすぼーる 2K6
+  name-en: "Major League Baseball 2K6"
   region: "NTSC-J"
   patches:
     F0393708:
@@ -38037,10 +42090,14 @@ SLPM-66451:
         comment=fixes hang at start
         patch=1,EE,0035d8b8,word,00000000
 SLPM-66452:
-  name: "Kamaitachi no Yoru 3"
+  name: かまいたちの夜×3 三日月島事件の真相
+  name-sort: かまいたちのよる×3 みかづきじまじけんのしんそう
+  name-en: "Kamaitachi no Yoru 3"
   region: "NTSC-J"
 SLPM-66453:
-  name: "Hiiro no Kakera [Limited Edition]"
+  name: 緋色の欠片 限定版
+  name-sort: ひいろのかけら げんていばん
+  name-en: "Hiiro no Kakera [Limited Edition]"
   region: "NTSC-J"
   patches:
     1E65AEEF:
@@ -38050,13 +42107,19 @@ SLPM-66453:
         // This patch skips over the stack code, allowing the game to boot.
         patch=1,EE,00160478,word,10000003
 SLPM-66454:
-  name: "Hiiro no Kakera"
+  name: 緋色の欠片
+  name-sort: ひいろのかけら
+  name-en: "Hiiro no Kakera"
   region: "NTSC-J"
 SLPM-66455:
-  name: "Spectral Force - Radical Elements [IF Collection]"
+  name: IFコレクション スペクトラルフォース ラジカルエレメンツ
+  name-sort: IFこれくしょん すぺくとらるふぉーす らじかるえれめんつ
+  name-en: "Spectral Force - Radical Elements [IF Collection]"
   region: "NTSC-J"
 SLPM-66456:
-  name: "Asobi ni Iku yo! Chikyuu Pinch no Kon'yaku Sengen [Genteiban]"
+  name: あそびにいくヨ! 〜ちきゅうぴんちのこんやくせんげん〜 限定版
+  name-sort: あそびにいくよ! 〜ちきゅうぴんちのこんやくせんげん〜 げんていばん
+  name-en: "Asobi ni Iku yo! Chikyuu Pinch no Kon'yaku Sengen [Genteiban]"
   region: "NTSC-J"
   patches:
     87FFC318:
@@ -38066,7 +42129,9 @@ SLPM-66456:
         // This patch skips over the stack code, allowing the game to boot.
         patch=1,EE,001579D8,word,10000003
 SLPM-66457:
-  name: "Asobi ni Iku yo! Chikyuu Pinch no Kon'yaku Sengen"
+  name: あそびにいくヨ! 〜ちきゅうぴんちのこんやくせんげん〜
+  name-sort: あそびにいくよ! 〜ちきゅうぴんちのこんやくせんげん〜
+  name-en: "Asobi ni Iku yo! Chikyuu Pinch no Kon'yaku Sengen"
   region: "NTSC-J"
   patches:
     87FFC318:
@@ -38076,7 +42141,9 @@ SLPM-66457:
         // This patch skips over the stack code, allowing the game to boot.
         patch=1,EE,001579D8,word,10000003
 SLPM-66458:
-  name: "Fuuraiki"
+  name: 風雨来記
+  name-sort: ふううらいき
+  name-en: "Fuuraiki"
   region: "NTSC-J"
   patches:
     37CA944E:
@@ -38086,56 +42153,84 @@ SLPM-66458:
         // Fixes hang before going ingame
         patch=1,EE,0023122c,word,00000000
 SLPM-66459:
-  name: "Zero Pilot - Zero"
+  name: ゼロパイロット・零
+  name-sort: ぜろぱいろっと・れい
+  name-en: "Zero Pilot - Zero"
   region: "NTSC-J"
 SLPM-66460:
-  name: "_summer ##"
+  name: _summer##
+  name-sort: _summer##
+  name-en: "_summer ##"
   region: "NTSC-J"
 SLPM-66461:
-  name: "Tom Clancy's Ghost Recon - Advanced Warfighter"
+  name: ゴーストリコン アドバンス ウォーファイター
+  name-sort: ごーすとりこん あどばんす うぉーふぁいたー
+  name-en: "Tom Clancy's Ghost Recon - Advanced Warfighter"
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes  building and ground colours.
     mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
     trilinearFiltering: 1
 SLPM-66462:
-  name: "Disney-Pixar's Cars"
+  name: カーズ
+  name-sort: かーず
+  name-en: "Disney-Pixar's Cars"
   region: "NTSC-J"
 SLPM-66463:
-  name: "Def Jam - Fight for NY [EA Best Hits]"
+  name: EA BEST HITS デフジャム・ファイト・フォー・NY
+  name-sort: EA BEST HITS でふじゃむ・ふぁいと・ふぉー・NY
+  name-en: "Def Jam - Fight for NY [EA Best Hits]"
   region: "NTSC-J"
 SLPM-66464:
-  name: "MVP Baseball 2005 [EA Best Hits]"
+  name: EA BEST HITS MVP ベースボール2005
+  name-sort: EA BEST HITS MVP べーすぼーる2005
+  name-en: "MVP Baseball 2005 [EA Best Hits]"
   region: "NTSC-J"
 SLPM-66465:
-  name: "Mercenaries - Playground of Destruction [EA Best Hits]"
+  name: EA BEST HITS マーセナリーズ
+  name-sort: EA BEST HITS まーせなりーず
+  name-en: "Mercenaries - Playground of Destruction [EA Best Hits]"
   region: "NTSC-J"
   gsHWFixes:
     autoFlush: 2 # Fixes missing lighting.
     # halfPixelOffset: 1 # Fixes lighting misalignment. Do not enable this, it breaks a lot of graphics.
 SLPM-66467:
-  name: "Midway Arcade Treasures - The Game Center of USA"
+  name: ゲーセンUSA ミッドウェイアーケードトレジャーズ
+  name-sort: げーせんUSA みっどうぇいあーけーどとれじゃーず
+  name-en: "Midway Arcade Treasures - The Game Center of USA"
   region: "NTSC-J"
 SLPM-66468:
-  name: "Area 51"
+  name: AREA-51
+  name-sort: AREA-51
+  name-en: "Area 51"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misaligned lighting and other effects, needs Special otherwise lights flicker.
 SLPM-66469:
-  name: "Love-Com - Punch de Court [Limited Edition]"
+  name: 「ラブ★コン ～パンチDEコント～」限定版
+  name-sort: 「らぶ★こん ～ぱんちDEこんと～」げんていばん
+  name-en: "Love-Com - Punch de Court [Limited Edition]"
   region: "NTSC-J"
 SLPM-66470:
-  name: "Love-Com - Punch de Court"
+  name: 「ラブ★コン ～パンチDEコント～」通常版
+  name-sort: 「らぶ★こん ～ぱんちDEこんと～」つうじょうばん
+  name-en: "Love-Com - Punch de Court"
   region: "NTSC-J"
   compat: 5
 SLPM-66471:
-  name: "Hanaki"
+  name: 花帰葬
+  name-sort: はなきそう
+  name-en: "Hanaki"
   region: "NTSC-J"
 SLPM-66472:
-  name: "Planetarian - The Reverie of a Little Planet"
+  name: planetarian 〜ちいさなほしのゆめ〜
+  name-sort: planetarian 〜ちいさなほしのゆめ〜
+  name-en: "Planetarian - The Reverie of a Little Planet"
   region: "NTSC-J"
 SLPM-66473:
-  name: "True Crime - New York City"
+  name: トゥルー・クライム 〜ニューヨークシティ〜
+  name-sort: とぅるー・くらいむ 〜にゅーよーくしてぃ〜
+  name-en: "True Crime - New York City"
   region: "NTSC-J"
   clampModes:
     eeClampMode: 2 # Fixes SPS on highway.
@@ -38149,20 +42244,30 @@ SLPM-66473:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
 SLPM-66474:
-  name: "Odin Sphere"
+  name: オーディンスフィア
+  name-sort: おーでぃんすふぃあ
+  name-en: "Odin Sphere"
   region: "NTSC-J"
   compat: 5
 SLPM-66475:
-  name: "Jissen Pachi-Slot Hisshouhou! Hokuto no Ken Special Edition"
+  name: 実戦パチスロ必勝法! 北斗の拳SE
+  name-sort: じっせんぱちすろひっしょうほう! ほくとのけんSE
+  name-en: "Jissen Pachi-Slot Hisshouhou! Hokuto no Ken Special Edition"
   region: "NTSC-J"
 SLPM-66476:
-  name: "Jissen Pachinko Hisshouhou! CR Salaryman Kintarou"
+  name: 実戦パチンコ必勝法! CR サラリーマン金太郎
+  name-sort: じっせんぱちんこひっしょうほう! CR さらりーまんきんたろう
+  name-en: "Jissen Pachinko Hisshouhou! CR Salaryman Kintarou"
   region: "NTSC-J"
 SLPM-66477:
-  name: "Kamiwaza"
+  name: 神業
+  name-sort: かみわざ
+  name-en: "Kamiwaza"
   region: "NTSC-J"
 SLPM-66478:
-  name: "Star Ocean 3 - Till the End of Time [Ultimate Hits] [Disc 1 of 2]"
+  name: アルティメット ヒッツ スターオーシャン Till the End of Time ディレクターズカット
+  name-sort: あるてぃめっと ひっつ すたーおーしゃん Till the End of Time でぃれくたーずかっと
+  name-en: "Star Ocean 3 - Till the End of Time [Ultimate Hits] [Disc 1 of 2]"
   region: "NTSC-J"
   compat: 5
   gameFixes:
@@ -38184,11 +42289,15 @@ SLPM-66479:
   memcardFilters:
     - "SLPM-66478"
 SLPM-66480:
-  name: "Dragon Quest V - Bride of the Sky [Ultimate Hits]"
+  name: アルティメット ヒッツ ドラゴンクエスト V 天空の花嫁
+  name-sort: あるてぃめっと ひっつ どらごんくえすと V てんくうのはなよめ
+  name-en: "Dragon Quest V - Bride of the Sky [Ultimate Hits]"
   region: "NTSC-J"
   compat: 5
 SLPM-66481:
-  name: "Dragon Quest VIII [Ultimate Hits]"
+  name: アルティメット ヒッツ ドラゴンクエスト VIII 空と海と大地と呪われし姫君
+  name-sort: あるてぃめっと ひっつ どらごんくえすと VIII そらとうみとだいちとのろわれしひめぎみ
+  name-en: "Dragon Quest VIII [Ultimate Hits]"
   region: "NTSC-J"
   gsHWFixes:
     autoFlush: 2 # Fixes missing bloom from surfaces like windows.
@@ -38196,48 +42305,72 @@ SLPM-66481:
     halfPixelOffset: 2 # Sharpens world in far distances, aligns some bloom better.
     roundSprite: 1 # Fixes font artifacts.
 SLPM-66482:
-  name: "Tokimeki Memorial - Girl's Side 2nd Kiss"
+  name: ときめきメモリアル Girl’s Side 2nd Kiss リピート生産版
+  name-sort: ときめきめもりある Girl’s Side 2nd Kiss りぴーとせいさんばん
+  name-en: "Tokimeki Memorial - Girl's Side 2nd Kiss"
   region: "NTSC-J"
 SLPM-66483:
   name: "Mushihimesama [Taito Best]"
   region: "NTSC-J"
 SLPM-66484:
-  name: "GuitarFreaks & DrumMania MASTERPIECE SILVER"
+  name: GuitarFreaks & DrumMania MASTERPIECE SILVER
+  name-sort: GuitarFreaks & DrumMania MASTERPIECE SILVER
+  name-en: "GuitarFreaks & DrumMania MASTERPIECE SILVER"
   region: "NTSC-J"
   compat: 5
 SLPM-66485:
-  name: "State of Emergency - Revenge"
+  name: ステート・オブ・エマージェンシー リベンジ
+  name-sort: すてーと・おぶ・えまーじぇんしー りべんじ
+  name-en: "State of Emergency - Revenge"
   region: "NTSC-J"
 SLPM-66486:
-  name: "Tentama - 1st Sunny Side [2800 Collection]"
+  name: てんたま-1st Sunny Sideー <2800コレクション>
+  name-sort: てんたま-1st Sunny Sideー <2800これくしょん>
+  name-en: "Tentama - 1st Sunny Side [2800 Collection]"
   region: "NTSC-J"
 SLPM-66487:
-  name: "Tentama 2 - Wins [2800 Collection]"
+  name: てんたま2wins <2800コレクション>
+  name-sort: てんたま2wins <2800これくしょん>
+  name-en: "Tentama 2 - Wins [2800 Collection]"
   region: "NTSC-J"
 SLPM-66488:
-  name: "My Merry May With Be [2800 Collection]"
+  name: My Merry May with be <2800コレクション>
+  name-sort: My Merry May with be <2800これくしょん>
+  name-en: "My Merry May With Be [2800 Collection]"
   region: "NTSC-J"
 SLPM-66489:
-  name: "Mabino x Style [2800 Collection]"
+  name: マビノ×スタイル <2800コレクション>
+  name-sort: まびの×すたいる <2800これくしょん>
+  name-en: "Mabino x Style [2800 Collection]"
   region: "NTSC-J"
 SLPM-66491:
-  name: "Ayakashi-bito - Gen'you Ibunroku"
+  name: あやかしびと -幻妖異聞録-(通常版)
+  name-sort: あやかしびと -げんよういぶんろく-(つうじょうばん)
+  name-en: "Ayakashi-bito - Gen'you Ibunroku"
   region: "NTSC-J"
   gsHWFixes:
     cpuCLUTRender: 1 # Fixes rendering.
 SLPM-66492:
-  name: "Commandos Strike Force"
+  name: COMMANDOS STRIKE FORCE(コマンドス ストライク・フォース)
+  name-sort: COMMANDOS STRIKE FORCE(こまんどす すとらいく・ふぉーす)
+  name-en: "Commandos Strike Force"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes lighting misalignment.
 SLPM-66493:
-  name: "Shinten Makai - Generation of Chaos V [IF Collection]"
+  name: IFコレクション 新天魔界 ジェネレーション オブ カオスV
+  name-sort: IFこれくしょん しんてんまかい じぇねれーしょん おぶ かおすV
+  name-en: "Shinten Makai - Generation of Chaos V [IF Collection]"
   region: "NTSC-J"
 SLPM-66494:
-  name: "Joshikousei Game's High! [Limited Edition]"
+  name: 女子高生 GAME’S-HIGH! 限定版
+  name-sort: じょしこうせい GAME’S-HIGH! げんていばん
+  name-en: "Joshikousei Game's High! [Limited Edition]"
   region: "NTSC-J"
 SLPM-66495:
-  name: "Joshikousei Game's High!"
+  name: 女子高生 GAME’S-HIGH!
+  name-sort: じょしこうせい GAME’S-HIGH!
+  name-en: "Joshikousei Game's High!"
   region: "NTSC-J"
   patches:
     9FEA4A95:
@@ -38247,10 +42380,14 @@ SLPM-66495:
         // This patch skips over the stack code, allowing the game to boot.
         patch=1,EE,00149F18,word,10000003
 SLPM-66496:
-  name: "Tom Clancy's Splinter Cell - Chaos Theory"
+  name: ユービーアイソフト ベスト トム・クランシーシリーズ スプリンターセル カオスセオリー
+  name-sort: ゆーびーあいそふと べすと とむ・くらんしーしりーず すぷりんたーせる かおすせおりー
+  name-en: "Tom Clancy's Splinter Cell - Chaos Theory"
   region: "NTSC-J"
 SLPM-66497:
-  name: "Ice Age 2"
+  name: アイスエイジ2
+  name-sort: あいすえいじ2
+  name-en: "Ice Age 2"
   region: "NTSC-J"
   patches:
     33DB9037:
@@ -38259,76 +42396,114 @@ SLPM-66497:
         patch=1,EE,002e91e8,word,27bdfee0 //27bdff70
         patch=1,EE,002e9224,word,27bd0120 //27bd0090
 SLPM-66498:
-  name: "TOCA Race Driver 2 - Ultimate Racing Simulator"
+  name: TOCA RACE DRIVER 2 ULTIMATE RACING SIMULATOR
+  name-sort: TOCA RACE DRIVER 2 ULTIMATE RACING SIMULATOR
+  name-en: "TOCA Race Driver 2 - Ultimate Racing Simulator"
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes lighting and vertical lines, also works with normal vertex.
 SLPM-66499:
-  name: "Kamisama Kazoku - Ouen Ganbou"
+  name: 神様家族 応援願望
+  name-sort: かみさまかぞく おうえんがんぼう
+  name-en: "Kamisama Kazoku - Ouen Ganbou"
   region: "NTSC-J"
 SLPM-66500:
-  name: "Like Life an Hour [Best Version]"
+  name: Like Life an hour ベスト版
+  name-sort: Like Life an hour べすとばん
+  name-en: "Like Life an Hour [Best Version]"
   region: "NTSC-J"
 SLPM-66501:
-  name: "Onimusha [Mega Hits]"
+  name: 鬼武者 MEGA HITS!
+  name-sort: おにむしゃ MEGA HITS!
+  name-en: "Onimusha [Mega Hits]"
   region: "NTSC-J"
   gsHWFixes:
     texturePreloading: 1 # Performs much better with partial preload.
   gameFixes:
     - SoftwareRendererFMVHack # Fixes FMVs.
 SLPM-66502:
-  name: "Devil May Cry [Mega Hits]"
+  name: Devil May Cry MEGA HITS!
+  name-sort: Devil May Cry MEGA HITS!
+  name-en: "Devil May Cry [Mega Hits]"
   region: "NTSC-J"
   gsHWFixes:
     disablePartialInvalidation: 1 # Fixes corrupt textures.
 SLPM-66503:
-  name: "Metal Gear Solid 2 [Mega Hits]"
+  name: METAL GEAR SOLID 2 SONS OF LIBERTY MEGA HITS!
+  name-sort: METAL GEAR SOLID 2 SONS OF LIBERTY MEGA HITS!
+  name-en: "Metal Gear Solid 2 [Mega Hits]"
   region: "NTSC-J"
   gameFixes:
     - DMABusyHack # Fixes broken half-bottom artifacts.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
 SLPM-66504:
-  name: "Onimusha 2 [Mega Hits]"
+  name: 鬼武者2 MEGA HITS!
+  name-sort: おにむしゃ2 MEGA HITS!
+  name-en: "Onimusha 2 [Mega Hits]"
   region: "NTSC-J"
 SLPM-66505:
-  name: "Shin Sangoku Musou 2 [Mega Hits]"
+  name: 真・三國無双2 MEGA HITS!
+  name-sort: しん・さんごくむそう2 MEGA HITS!
+  name-en: "Shin Sangoku Musou 2 [Mega Hits]"
   region: "NTSC-J"
 SLPM-66506:
-  name: "Gundam - Federation vs. Zeon DX [Mega Hits]"
+  name: 機動戦士ガンダム 連邦VS.ジオンDX MEGA HITS!
+  name-sort: きどうせんしがんだむ れんぽうVS.じおんDX MEGA HITS!
+  name-en: "Gundam - Federation vs. Zeon DX [Mega Hits]"
   region: "NTSC-J"
 SLPM-66507:
-  name: "Otome no Jijou [Limited Edition]"
+  name: 乙女の事情 (初回限定版)
+  name-sort: おとめのじじょう (しょかいげんていばん)
+  name-en: "Otome no Jijou [Limited Edition]"
   region: "NTSC-J"
 SLPM-66508:
-  name: "Otome no Jijou"
+  name: 乙女の事情
+  name-sort: おとめのじじょう
+  name-en: "Otome no Jijou"
   region: "NTSC-J"
 SLPM-66509:
-  name: "Rugby '06"
+  name: ラグビー06
+  name-sort: らぐびー06
+  name-en: "Rugby '06"
   region: "NTSC-J"
 SLPM-66510:
-  name: "NHL '06"
+  name: NHL 06
+  name-sort: NHL 06
+  name-en: "NHL '06"
   region: "NTSC-J"
 SLPM-66511:
-  name: "Kyuuryuu Youma Gakuenki Re-charge"
+  name: 九龍妖魔學園紀 再装填 (re:charge)
+  name-sort: くうろんようまがくえんき さいそうてん (re:charge)
+  name-en: "Kyuuryuu Youma Gakuenki Re-charge"
   region: "NTSC-J"
   compat: 5
 SLPM-66512:
-  name: "Fate-stay Night - Realta Nua [Extra Edition]"
+  name: Fate/stay night[Realta Nua] extra edition
+  name-sort: Fate/stay night[Realta Nua] extra edition
+  name-en: "Fate-stay Night - Realta Nua [Extra Edition]"
   region: "NTSC-J"
 SLPM-66513:
-  name: "Fate-stay Night - Realta Nua"
+  name: Fate/stay night[Realta Nua]
+  name-sort: Fate/stay night[Realta Nua]
+  name-en: "Fate-stay Night - Realta Nua"
   region: "NTSC-J"
 SLPM-66514:
-  name: "Medal of Honor - European Assault [EA Best Hits]"
+  name: EA BEST HITS メダル オブ オナー ヨーロッパ強襲
+  name-sort: EA BEST HITS めだる おぶ おなー よーろっぱきょうしゅう
+  name-en: "Medal of Honor - European Assault [EA Best Hits]"
   region: "NTSC-J"
 SLPM-66515:
-  name: "Star Wars - Episode III - Sith no Fukushuu [EA Best Hits]"
+  name: EA BEST HITS スター・ウォーズ エピソード3 シスの復讐
+  name-sort: EA BEST HITS すたー・うぉーず えぴそーど3 しすのふくしゅう
+  name-en: "Star Wars - Episode III - Sith no Fukushuu [EA Best Hits]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 1 # Fixes bloom misalignment.
 SLPM-66516:
-  name: "Sims, The & The Urbz - Sims in the City [EA Best Hits]"
+  name: EA BEST HITS ザ・シムズ&ザ・アーブズ シムズ・イン・ザ・シティ
+  name-sort: EA BEST HITS ざ・しむず&ざ・あーぶず しむず・いん・ざ・してぃ
+  name-en: "Sims, The & The Urbz - Sims in the City [EA Best Hits]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes upscaling lines.
@@ -38336,65 +42511,105 @@ SLPM-66517:
   name: "The Urbz - Sims in the City"
   region: "NTSC-J"
 SLPM-66518:
-  name: "Teikoku Sensenki [Best Version]"
+  name: 帝国千戦記 ベスト版
+  name-sort: ていこくせんせんき べすとばん
+  name-en: "Teikoku Sensenki [Best Version]"
   region: "NTSC-J"
 SLPM-66519:
-  name: "Gakuen Heaven - Boy's Love Scramble! [Best Version]"
+  name: 学園ヘヴン BOY’S LOVE SCRAMBLE! ベスト版
+  name-sort: がくえんへゔん BOY’S LOVE SCRAMBLE! べすとばん
+  name-en: "Gakuen Heaven - Boy's Love Scramble! [Best Version]"
   region: "NTSC-J"
 SLPM-66520:
-  name: "BioHazard - Code Veronica [Premium Box]"
+  name: バイオハザード コード:ベロニカ 完全版 プレミアムパック
+  name-sort: ばいおはざーど こーど:べろにか かんぜんばん ぷれみあむぱっく
+  name-en: "BioHazard - Code Veronica [Premium Box]"
   region: "NTSC-J"
 SLPM-66521:
-  name: "Taito Memories Vol.2 [Taito The Best]"
+  name: タイトーメモリーズ 下巻 TAITO BEST
+  name-sort: たいとーめもりーず げかん TAITO BEST
+  name-en: "Taito Memories Vol.2 [Taito The Best]"
   region: "NTSC-J"
   compat: 5
 SLPM-66522:
-  name: "Shin Sangoku Musou 3 [KOEI Selection]"
+  name: コーエー定番シリーズ 真・三國無双3
+  name-sort: こーえーていばんしりーず しん・さんごくむそう3
+  name-en: "Shin Sangoku Musou 3 [KOEI Selection]"
   region: "NTSC-J"
 SLPM-66523:
-  name: "Sangokushi IX [with Power-Up Kit]"
+  name: KOEI The Best 三國志IX with パワーアップキット
+  name-sort: KOEI The Best さんごくしIX with ぱわーあっぷきっと
+  name-en: "Sangokushi IX [with Power-Up Kit]"
   region: "NTSC-J"
 SLPM-66524:
-  name: "Angelique Etoile [Koei Best]"
+  name: KOEI The Best アンジェリーク エトワール
+  name-sort: KOEI The Best あんじぇりーく えとわーる
+  name-en: "Angelique Etoile [Koei Best]"
   region: "NTSC-J"
 SLPM-66525:
-  name: "Zill O'll Infinite [Koei The Best]"
+  name: KOEI The Best Zill O’ll 〜infinite〜
+  name-sort: KOEI The Best Zill O’ll 〜infinite〜
+  name-en: "Zill O'll Infinite [Koei The Best]"
   region: "NTSC-J"
 SLPM-66526:
-  name: "Gaika no Gouhou - Air Land Force [KOEI Selection]"
+  name: コーエー定番シリーズ 凱歌の号砲 エアランドフォース
+  name-sort: こーえーていばんしりーず がいかのごうほう えあらんどふぉーす
+  name-en: "Gaika no Gouhou - Air Land Force [KOEI Selection]"
   region: "NTSC-J"
 SLPM-66527:
-  name: "Sangokushi Senki 2 [KOEI Selection]"
+  name: コーエー定番シリーズ 三國志戦記2
+  name-sort: こーえーていばんしりーず さんごくしせんき2
+  name-en: "Sangokushi Senki 2 [KOEI Selection]"
   region: "NTSC-J"
 SLPM-66528:
-  name: "Nobunaga no Yabou - Tenka Sousei [with Power Up Kit] [KOEI the Best]"
+  name: KOEI The Best 信長の野望・天下創世 with パワーアップキット
+  name-sort: KOEI The Best のぶながのやぼう・てんかそうせい with ぱわーあっぷきっと
+  name-en: "Nobunaga no Yabou - Tenka Sousei [with Power Up Kit] [KOEI the Best]"
   region: "NTSC-J"
 SLPM-66529:
-  name: "Boukoku no Aegis 2035 - Warship Gunner [KOEI the Best]"
+  name: KOEI The Best 亡国のイージス 2035 〜ウォーシップガンナー〜
+  name-sort: KOEI The Best ぼうこくのいーじす 2035 〜うぉーしっぷがんなー〜
+  name-en: "Boukoku no Aegis 2035 - Warship Gunner [KOEI the Best]"
   region: "NTSC-J"
 SLPM-66530:
-  name: "Gift Prism"
+  name: Gift -prism- 通常版
+  name-sort: Gift -prism- つうじょうばん
+  name-en: "Gift Prism"
   region: "NTSC-J"
 SLPM-66531:
-  name: "Mizu no Senritsu 2 [Limited Edition]"
+  name: 水の旋律2〜緋の記憶〜 限定版
+  name-sort: みずのせんりつ2〜ひのきおく〜 げんていばん
+  name-en: "Mizu no Senritsu 2 [Limited Edition]"
   region: "NTSC-J"
 SLPM-66532:
-  name: "Mizu no Senritsu 2"
+  name: 水の旋律2〜緋の記憶〜
+  name-sort: みずのせんりつ2〜ひのきおく〜
+  name-en: "Mizu no Senritsu 2"
   region: "NTSC-J"
 SLPM-66533:
-  name: "Pop'n music 13 Carnival"
+  name: ポップンミュージック13 カーニバル
+  name-sort: ぽっぷんみゅーじっく13 かーにばる
+  name-en: "Pop'n music 13 Carnival"
   region: "NTSC-J"
 SLPM-66534:
-  name: "Ryu Koku [Limited Edition]"
+  name: 龍刻 Ryu-Koku 限定版
+  name-sort: りゅうこく Ryu-Koku げんていばん
+  name-en: "Ryu Koku [Limited Edition]"
   region: "NTSC-J"
 SLPM-66535:
-  name: "Ryu Koku"
+  name: 龍刻 Ryu-Koku 通常版
+  name-sort: りゅうこく Ryu-Koku つうじょうばん
+  name-en: "Ryu Koku"
   region: "NTSC-J"
 SLPM-66536:
-  name: "Aria - The Natural - Tooi Yume no Mirage"
+  name: ARIA The NATURAL 〜遠い記憶のミラージュ〜
+  name-sort: ARIA The NATURAL 〜とおいきおくのみらーじゅ〜
+  name-en: "Aria - The Natural - Tooi Yume no Mirage"
   region: "NTSC-J"
 SLPM-66537:
-  name: "Iris no Atelier - Eternal Mana 2 [Gust Best Price]"
+  name: ガスト ベスト プライス イリスのアトリエ エターナルマナ2
+  name-sort: がすと べすと ぷらいす いりすのあとりえ えたーなるまな2
+  name-en: "Iris no Atelier - Eternal Mana 2 [Gust Best Price]"
   region: "NTSC-J"
   gameFixes:
     - SoftwareRendererFMVHack # Horizontal lines in FMV.
@@ -38402,74 +42617,114 @@ SLPM-66537:
     roundSprite: 1 # Fixes font artifacts for health and other sprites.
     texturePreloading: 0 # Improves performance and prevents it disabling itself regardless.
 SLPM-66538:
-  name: "GI Jockey 4 2006"
+  name: ジーワン ジョッキー4 2006
+  name-sort: じーわん じょっきー4 2006
+  name-en: "GI Jockey 4 2006"
   region: "NTSC-J"
 SLPM-66539:
-  name: "Nobunaga no Yabou Online - Haten no Shou"
+  name: 信長の野望Online 破天の章
+  name-sort: のぶながのやぼうOnline やぶてんのしょう
+  name-en: "Nobunaga no Yabou Online - Haten no Shou"
   region: "NTSC-J"
 SLPM-66542:
-  name: "Sengoku Musou 2 Empires"
+  name: 戦国無双2 Empires
+  name-sort: せんごくむそう2 Empires
+  name-en: "Sengoku Musou 2 Empires"
   region: "NTSC-J"
 SLPM-66543:
-  name: "Youjinbou - Unmei no Freud"
+  name: Yo-Jin-Bo 〜運命のフロイデ〜
+  name-sort: Yo-Jin-Bo 〜うんめいのふろいで〜
+  name-en: "Youjinbou - Unmei no Freud"
   region: "NTSC-J"
 SLPM-66544:
-  name: "Sekai no Zente - Two of Us"
+  name: 世界ノ全テ 〜two of us〜
+  name-sort: せかいのぜんて 〜two of us〜
+  name-en: "Sekai no Zente - Two of Us"
   region: "NTSC-J"
 SLPM-66548:
-  name: "Harukanaru Jikuu no Uchi de Mai Ichi Yoru"
+  name: 遙かなる時空の中で 舞一夜 通常版
+  name-sort: はるかなるときのなかで まいひとよ つうじょうばん
+  name-en: "Harukanaru Jikuu no Uchi de Mai Ichi Yoru"
   region: "NTSC-J"
 SLPM-66549:
-  name: "Sangokushi XI"
+  name: 三國志11
+  name-sort: さんごくし11
+  name-en: "Sangokushi XI"
   region: "NTSC-J"
 SLPM-66550:
-  name: "God Hand"
+  name: GOD HAND(ゴッドハンド)
+  name-sort: GOD HAND(ごっどはんど)
+  name-en: "God Hand"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
     mergeSprite: 1 # Reduces bloom but fixes blurriness around models + Recommended to use Shadeboost brightness 80.
     halfPixelOffset: 2 # Depth of field effect aligned properly + Shifts buildings correctly.
 SLPM-66551:
-  name: "Appleseed EX"
+  name: APPLESEED EX(アップルシード エクス)
+  name-sort: APPLESEED EX(あっぷるしーど えくす)
+  name-en: "Appleseed EX"
   region: "NTSC-J"
 SLPM-66552:
-  name: "Neverland Reportage"
+  name: ネバーランド研究史
+  name-sort: ねばーらんどけんきゅうし
+  name-en: "Neverland Reportage"
   region: "NTSC-J"
 SLPM-66553:
-  name: "Chaos Wars"
+  name: カオス ウォーズ
+  name-sort: かおす うぉーず
+  name-en: "Chaos Wars"
   region: "NTSC-J"
 SLPM-66554:
-  name: "Interlude [Best Version]"
+  name: インタールード(ベスト版)
+  name-sort: いんたーるーど(べすとばん)
+  name-en: "Interlude [Best Version]"
   region: "NTSC-J"
 SLPM-66555:
-  name: "SuperLite 2000 Series - Tokyo Bus Guide 2"
+  name: SuperLite2000シリーズ 東京バス案内 (ガイド) 2
+  name-sort: SuperLite2000しりーず とうきょうばすあんない (がいど) 2
+  name-en: "SuperLite 2000 Series - Tokyo Bus Guide 2"
   region: "NTSC-J"
 SLPM-66556:
-  name: "Shinobido Imashime [Spike The Best]"
+  name: Spike the Best 忍道 戒
+  name-sort: Spike the Best しのびどう いましめ
+  name-en: "Shinobido Imashime [Spike The Best]"
   region: "NTSC-J"
   clampModes:
     eeClampMode: 3 # Fixes hang going in to the gardens.
 SLPM-66557:
-  name: "FIFA Street [EA Best Hits]"
+  name: EA BEST HITS FIFAストリート
+  name-sort: EA BEST HITS FIFAすとりーと
+  name-en: "FIFA Street [EA Best Hits]"
   region: "NTSC-J"
 SLPM-66558:
-  name: "Tomb Raider - Legend"
+  name: "トゥームレイダー: レジェンド"
+  name-sort: "とぅーむれいだー: れじぇんど"
+  name-en: "Tomb Raider - Legend"
   region: "NTSC-J"
   gsHWFixes:
     mipmap: 1 # Fixes distant characters and models but there are still some flickering textures.
     textureInsideRT: 1 # Needed for post processing effects.
     minimumBlendingLevel: 4 # Fixes multiple lighting effects from lights, computers, cave walls and more.
 SLPM-66559:
-  name: "Winning Post 6 [KOEI Selection]"
+  name: コーエー定番シリーズ Winning Post6
+  name-sort: こーえーていばんしりーず Winning Post6
+  name-en: "Winning Post 6 [KOEI Selection]"
   region: "NTSC-J"
 SLPM-66560:
-  name: "Sangokushi X [KOEI The Best]"
+  name: KOEI The Best 三國志X
+  name-sort: KOEI The Best さんごくしX
+  name-en: "Sangokushi X [KOEI The Best]"
   region: "NTSC-J"
 SLPM-66561:
-  name: "NBA Live '06 [EA Best Hits]"
+  name: EA BEST HITS NBAライブ 06
+  name-sort: EA BEST HITS NBAらいぶ 06
+  name-en: "NBA Live '06 [EA Best Hits]"
   region: "NTSC-J"
 SLPM-66562:
-  name: "Need for Speed - Most Wanted [EA Best Hits]"
+  name: EA BEST HITS ニード・フォー・スピード モスト・ウォンテッド
+  name-sort: EA BEST HITS にーど・ふぉー・すぴーど もすと・うぉんてっど
+  name-en: "Need for Speed - Most Wanted [EA Best Hits]"
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves car reflections.
@@ -38484,13 +42739,19 @@ SLPM-66562:
     - "SLPM-66051"
     - "SLPM-66960"
 SLPM-66563:
-  name: "Mizu no Senritsu [2800 Collection]"
+  name: 水の旋律<2800コレクション>
+  name-sort: みずのせんりつ<2800これくしょん>
+  name-en: "Mizu no Senritsu [2800 Collection]"
   region: "NTSC-J"
 SLPM-66564:
-  name: "REC - DokiDoki Seiyuu Paradise [Limited Edition]"
+  name: REC☆ドキドキ声優パラダイス☆ 限定版
+  name-sort: REC☆どきどきせいゆうぱらだいす☆ げんていばん
+  name-en: "REC - DokiDoki Seiyuu Paradise [Limited Edition]"
   region: "NTSC-J"
 SLPM-66565:
-  name: "REC - DokiDoki Seiyuu Paradise"
+  name: REC☆ドキドキ声優パラダイス☆ 通常版
+  name-sort: REC☆どきどきせいゆうぱらだいす☆ つうじょうばん
+  name-en: "REC - DokiDoki Seiyuu Paradise"
   region: "NTSC-J"
   patches:
     17E04DE7:
@@ -38500,10 +42761,14 @@ SLPM-66565:
         // This patch skips over the stack code, allowing the game to boot.
         patch=1,EE,001BAA28,word,10000003
 SLPM-66566:
-  name: "Tenshou Gakuen Gekkou Hasumi"
+  name: 転生學園月光録
+  name-sort: てんしょうがくえんげっこうろく
+  name-en: "Tenshou Gakuen Gekkou Hasumi"
   region: "NTSC-J"
 SLPM-66567:
-  name: "Driver - Parallel Lines"
+  name: ドライバー パラレルラインズ
+  name-sort: どらいばー ぱられるらいんず
+  name-en: "Driver - Parallel Lines"
   region: "NTSC-J"
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
@@ -38513,23 +42778,33 @@ SLPM-66567:
     roundSprite: 1 # Reduces misaligned bloom.
     mergeSprite: 1 # Removes bloom explosion around electrical lights and other light sources such as moon/sun.
 SLPM-66568:
-  name: "Brothers In Arms - Road to Hill 30 [Ubisoft Best]"
+  name: ユービーアイソフト ベスト ブラザー イン アームズ ロード トゥ ヒル サーティ
+  name-sort: ゆーびーあいそふと べすと ぶらざー いん あーむず ろーど とぅ ひる さーてぃ
+  name-en: "Brothers In Arms - Road to Hill 30 [Ubisoft Best]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Reduces blurriness, there are still ghosting issues for like lighting poles.
 SLPM-66569:
-  name: "Secret of Evangelion"
+  name: シークレット・オブ・エヴァンゲリオン 通常版
+  name-sort: しーくれっと・おぶ・えゔぁんげりおん つうじょうばん
+  name-en: "Secret of Evangelion"
   region: "NTSC-J"
   gsHWFixes:
     roundSprite: 2 # Reduces artifacts like vertical lines in main menu but there are many other artifacts still.
 SLPM-66570:
-  name: "I's Pure"
+  name: I”s Pure(アイズピュア)
+  name-sort: I”s Pure(あいずぴゅあ)
+  name-en: "I's Pure"
   region: "NTSC-J"
 SLPM-66571:
-  name: "Memories Off #5 - Togireta [Superlite 2000 Series]"
+  name: SuperLite2000 恋愛アドベンチャー Memories Off #5 とぎれたフィルム
+  name-sort: SuperLite2000 れんあいあどべんちゃー Memories Off #5 とぎれたふぃるむ
+  name-en: "Memories Off #5 - Togireta [Superlite 2000 Series]"
   region: "NTSC-J"
 SLPM-66572:
-  name: "LEGO Star Wars II - The Original Trilogy"
+  name: レゴ スター・ウォーズII
+  name-sort: れご すたー・うぉーずII
+  name-en: "LEGO Star Wars II - The Original Trilogy"
   region: "NTSC-J"
   gsHWFixes:
     cpuCLUTRender: 1 # Fixes ghosting on objects and people.
@@ -38537,20 +42812,30 @@ SLPM-66572:
     - "SLPM-66572"
     - "SLPS-20423"
 SLPM-66573:
-  name: "Kurogane no Houkou 2 - Warship Gunner [KOEI Selection]"
+  name: コーエー定番シリーズ 鋼鉄の咆哮2ウォーシップガンナー
+  name-sort: こーえーていばんしりーず くろがねのほうこう2うぉーしっぷがんなー
+  name-en: "Kurogane no Houkou 2 - Warship Gunner [KOEI Selection]"
   region: "NTSC-J"
 SLPM-66574:
-  name: "Meitantei Evangelion"
+  name: 名探偵エヴァンゲリオン
+  name-sort: めいたんていえゔぁんげりおん
+  name-en: "Meitantei Evangelion"
   region: "NTSC-J"
 SLPM-66575:
-  name: "GuitarFreaks V2 & DrumMania V2"
+  name: GuitarFreaks V2 & DrumMania V2
+  name-sort: GuitarFreaks V2 & DrumMania V2
+  name-en: "GuitarFreaks V2 & DrumMania V2"
   region: "NTSC-J"
 SLPM-66576:
-  name: "Seiken Densetsu 4"
+  name: 聖剣伝説4
+  name-sort: きよしけんでんせつ4
+  name-en: "Seiken Densetsu 4"
   region: "NTSC-J"
   compat: 5
 SLPM-66577:
-  name: "Gladiator - Road to Freedom [Special Remix] [Ertain the Best]"
+  name: GLADIATOR ROAD TO FREEDOM REMIX アーティン ベスト
+  name-sort: GLADIATOR ROAD TO FREEDOM REMIX あーてぃん べすと
+  name-en: "Gladiator - Road to Freedom [Special Remix] [Ertain the Best]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 3 # Fixes bloom misalignment still a bit misaligned.
@@ -38569,7 +42854,9 @@ SLPM-66581:
   name: "Shin Sangoku Musou 4 - Empires"
   region: "NTSC-J"
 SLPM-66582:
-  name: "Kohitsuji Hokaku Keikaku! Sweet Boys Life [Limited Edition]"
+  name: 仔羊捕獲ケーカク! スイートボーイズライフ 初回限定版
+  name-sort: 仔羊ほかくけーかく! すいーとぼーいずらいふ しょかいげんていばん
+  name-en: "Kohitsuji Hokaku Keikaku! Sweet Boys Life [Limited Edition]"
   region: "NTSC-J"
   patches:
     9466CBA1:
@@ -38579,49 +42866,73 @@ SLPM-66582:
         // This patch skips over the stack code, allowing the game to boot.
         patch=1,EE,0014A148,word,10000003
 SLPM-66583:
-  name: "Kohitsuji Hokaku Keikaku! Sweet Boys Life"
+  name: 仔羊捕獲ケーカク! スイートボーイズライフ 通常版
+  name-sort: 仔羊ほかくけーかく! すいーとぼーいずらいふ つうじょうばん
+  name-en: "Kohitsuji Hokaku Keikaku! Sweet Boys Life"
   region: "NTSC-J"
 SLPM-66584:
-  name: "Yoake Yori Ruriiro na - Brighter than Dawning Blue"
+  name: 夜明け前より瑠璃色な 〜Brighter than dawning blue〜
+  name-sort: よあけまえよりるりいろな 〜Brighter than dawning blue〜
+  name-en: "Yoake Yori Ruriiro na - Brighter than Dawning Blue"
   region: "NTSC-J"
 SLPM-66585:
-  name: "Elvandia Story"
+  name: エルヴァンディアストーリー
+  name-sort: えるゔぁんでぃあすとーりー
+  name-en: "Elvandia Story"
   region: "NTSC-J"
   compat: 5
   clampModes:
     eeClampMode: 3 # Fixes black overlay ingame during dialog.
     vuClampMode: 3 # Fixes black overlay ingame during dialog.
 SLPM-66586:
-  name: "Karutagura - Tamashii no Kunou [2800 Collection]"
+  name: カルタグラ 〜魂の苦悩〜<2800コレクション>
+  name-sort: かるたぐら 〜たましいのくのう〜<2800これくしょん>
+  name-en: "Karutagura - Tamashii no Kunou [2800 Collection]"
   region: "NTSC-J"
 SLPM-66587:
-  name: "Karutagura - Tamashii no Kunou [Best Version]"
+  name: 水月 〜迷心〜<2800コレクション>
+  name-sort: すいげつ 〜まよいごころ〜<2800これくしょん>
+  name-en: "Karutagura - Tamashii no Kunou [Best Version]"
   region: "NTSC-J"
 SLPM-66588:
-  name: "White Princess the Second [2800 Collection]"
+  name: White Princess the second<2800コレクション>
+  name-sort: White Princess the second<2800これくしょん>
+  name-en: "White Princess the Second [2800 Collection]"
   region: "NTSC-J"
 SLPM-66589:
-  name: "NBA Live '07"
+  name: NBAライブ 07
+  name-sort: NBAらいぶ 07
+  name-en: "NBA Live '07"
   region: "NTSC-J"
 SLPM-66590:
-  name: "Jikkyou Powerful Pro Yakyuu 13 Ketteiban"
+  name: 実況パワフルプロ野球13 決定版
+  name-sort: じっきょうぱわふるぷろやきゅう13 けっていばん
+  name-en: "Jikkyou Powerful Pro Yakyuu 13 Ketteiban"
   region: "NTSC-J"
 SLPM-66591:
-  name: "FlatOut 2 GTR"
+  name: FLATOUT 2 GTR(がんばれ!とびだせ!レーシング!!)
+  name-sort: FLATOUT 2 GTR(がんばれ!とびだせ!れーしんぐ!!)
+  name-en: "FlatOut 2 GTR"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
     mipmap: 1
     halfPixelOffset: 2 # Corrects most vertical lines.
 SLPM-66592:
-  name: "Negima! 3-Jikanme [Theater Version]"
+  name: ネギま!?3時間目〜恋と魔法と世界樹伝説!〜 演劇版
+  name-sort: ねぎま!?3じかんめ〜こいとまほうとせかいじゅでんせつ!〜 えんげきばん
+  name-en: "Negima! 3-Jikanme [Theater Version]"
   region: "NTSC-J"
 SLPM-66593:
-  name: "Negima! 3-Jikanme [Live Version]"
+  name: ネギま!?3時間目〜恋と魔法と世界樹伝説!〜 ライブ版
+  name-sort: ねぎま!?3じかんめ〜こいとまほうとせかいじゅでんせつ!〜 らいぶばん
+  name-en: "Negima! 3-Jikanme [Live Version]"
   region: "NTSC-J"
   compat: 5
 SLPM-66594:
-  name: "Rhapsodia [Konami the Best]"
+  name: RHAPSODIA ラプソディア コナミ ザ ベスト
+  name-sort: RHAPSODIA らぷそでぃあ こなみ ざ べすと
+  name-en: "Rhapsodia [Konami the Best]"
   region: "NTSC-J"
   memcardFilters:
     - "SLPM-66105"
@@ -38629,19 +42940,27 @@ SLPM-66594:
     - "SLPM-65599"
     - "SLPM-65600"
 SLPM-66595:
-  name: "J-League Winning Eleven 10 - Europa League '06-'07"
+  name: Jリーグ ウイニングイレブン 10+欧州リーグ ’06   -’07
+  name-sort: Jりーぐ ういにんぐいれぶん 10+おうしゅうりーぐ ’06   -’07
+  name-en: "J-League Winning Eleven 10 - Europa League '06-'07"
   region: "NTSC-J"
 SLPM-66596:
-  name: "Prince of Tennis - Gakuensai no Oji-sama [Konami the Best]"
+  name: テニスの王子様 学園祭の王子様 コナミザベスト
+  name-sort: てにすのおうじさま がくえんさいのおうじさま こなみざ・べすと
+  name-en: "Prince of Tennis - Gakuensai no Oji-sama [Konami the Best]"
   region: "NTSC-J"
 SLPM-66597:
   name: "Ya to Hime Zankiko - Tsurugi no Maki [Limited Edition]"
   region: "NTSC-J"
 SLPM-66598:
-  name: "Yatohime Zankikou"
+  name: 夜刀姫斬鬼行 -剣の巻-
+  name-sort: やとひめざんきこう -けんのまき-
+  name-en: "Yatohime Zankikou"
   region: "NTSC-J"
 SLPM-66600:
-  name: "Madden NFL '07"
+  name: MADDEN NFL 07
+  name-sort: MADDEN NFL 07
+  name-en: "Madden NFL '07"
   region: "NTSC-J"
   clampModes:
     vuClampMode: 3 # Missing geometry with microVU.
@@ -38649,12 +42968,16 @@ SLPM-66600:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
 SLPM-66601:
-  name: "SSX On Tour [EA Best Hits]"
+  name: EA BEST HITS SSX on tour
+  name-sort: EA BEST HITS SSX on tour
+  name-en: "SSX On Tour [EA Best Hits]"
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes missing lighting and makes snow not look like snow sludge.
 SLPM-66602:
-  name: "Ryu ga Gotoku 2 [Disc 1 of 2]"
+  name: 龍が如く 2
+  name-sort: りゅうがごとく 2
+  name-en: "Ryu ga Gotoku 2 [Disc 1 of 2]"
   region: "NTSC-J"
   memcardFilters:
     - "SLPM-66602"
@@ -38672,45 +42995,69 @@ SLPM-66603:
     - "SLPM-74234"
     - "SLPM-74253"
 SLPM-66604:
-  name: "Galaxy Angel - Moonlit Lovers [Banpresido the Best]"
+  name: Broccoli Best Quality ギャラクシーエンジェル Moonlit Lovers
+  name-sort: Broccoli Best Quality ぎゃらくしーえんじぇる Moonlit Lovers
+  name-en: "Galaxy Angel - Moonlit Lovers [Banpresido the Best]"
   region: "NTSC-J"
 SLPM-66605:
-  name: "Castle Fantasia - Arihato Senki"
+  name: キャッスルファンタジア アリハト戦記
+  name-sort: きゃっするふぁんたじあ ありはとせんき
+  name-en: "Castle Fantasia - Arihato Senki"
   region: "NTSC-J"
 SLPM-66606:
-  name: "White Breath - Kizuna [First Print - Limited Edition]"
+  name: ホワイトブレス〜絆〜 限定版
+  name-sort: ほわいとぶれす〜きずな〜 げんていばん
+  name-en: "White Breath - Kizuna [First Print - Limited Edition]"
   region: "NTSC-J"
 SLPM-66607:
-  name: "White Breath - Kizuna"
+  name: ホワイトブレス〜絆〜 通常版
+  name-sort: ほわいとぶれす〜きずな〜 つうじょうばん
+  name-en: "White Breath - Kizuna"
   region: "NTSC-J"
 SLPM-66608:
-  name: "Prince of Tennis - DokiDoki Survival - Sanroku no Mystic"
+  name: テニスの王子様 ドキドキサバイバル 山麓のMystic
+  name-sort: てにすのおうじさま どきどきさばいばる さんろくのMystic
+  name-en: "Prince of Tennis - DokiDoki Survival - Sanroku no Mystic"
   region: "NTSC-J"
 SLPM-66609:
-  name: "Dance Dance Revolution SuperNOVA"
+  name: Dance Dance Revolution SuperNOVA
+  name-sort: Dance Dance Revolution SuperNOVA
+  name-en: "Dance Dance Revolution SuperNOVA"
   region: "NTSC-J"
 SLPM-66610:
-  name: "Prince of Tennis - DokiDoki Survival - Umibe no Secret"
+  name: テニスの王子様 ドキドキサバイバル 海辺のSecret
+  name-sort: てにすのおうじさま どきどきさばいばる うみべのSecret
+  name-en: "Prince of Tennis - DokiDoki Survival - Umibe no Secret"
   region: "NTSC-J"
 SLPM-66611:
-  name: "Tomoyo After - It's Wonderful Life [CS Edition]"
+  name: 智代アフター ～It’s a Wonderful Life～ CS Edition
+  name-sort: ともよあふたー ～It’s a Wonderful Life～ CS Edition
+  name-en: "Tomoyo After - It's Wonderful Life [CS Edition]"
   region: "NTSC-J"
   gsHWFixes:
     cpuCLUTRender: 1 # Fixes Colours.
 SLPM-66612:
-  name: "School Love [Limited Edition]"
+  name: すくぅ〜る らぶっ!〜恋と希望のメトロノーム〜 初回限定版
+  name-sort: すくぅ〜る らぶっ!〜こいときぼうのめとろのーむ〜 しょかいげんていばん
+  name-en: "School Love [Limited Edition]"
   region: "NTSC-J"
 SLPM-66613:
-  name: "Medal of Honor - Rising Sun & Frontline [EA Best Hits]"
+  name: EA BEST HITS メダル オブ オナー 史上最大の作戦&メダル オブ オナー ライジングサン
+  name-sort: EA BEST HITS めだる おぶ おなー しじょうさいだいのさくせん&めだる おぶ おなー らいじんぐさん
+  name-en: "Medal of Honor - Rising Sun & Frontline [EA Best Hits]"
   region: "NTSC-J"
 SLPM-66615:
-  name: "007 - Nightfire [EA Best Hits Dual Pack]"
+  name: EA BEST HITS 007 ナイト ファイア&007 エブリシング オア ナッシング
+  name-sort: EA BEST HITS 007 ないと ふぁいあ&007 えぶりしんぐ おあ なっしんぐ
+  name-en: "007 - Nightfire [EA Best Hits Dual Pack]"
   region: "NTSC-J"
 SLPM-66616:
   name: "007 - Everything or Nothing [EA Best Hits Dual Pack]"
   region: "NTSC-J"
 SLPM-66617:
-  name: "Need for Speed - Carbon"
+  name: ニード・フォー・スピード カーボン
+  name-sort: にーど・ふぉー・すぴーど かーぼん
+  name-en: "Need for Speed - Carbon"
   region: "NTSC-J"
   clampModes:
     eeClampMode: 3 # Fixes game hang after opening intro.
@@ -38719,37 +43066,59 @@ SLPM-66617:
     halfPixelOffset: 2 # Fixes blurriness.
     roundSprite: 2 # Fixes blurriness.
 SLPM-66618:
-  name: "Yumemishi [First Print Limited Edition]"
+  name: 夢見師 (初回限定版)
+  name-sort: ゆめみし (しょかいげんていばん)
+  name-en: "Yumemishi [First Print Limited Edition]"
   region: "NTSC-J"
 SLPM-66619:
-  name: "Yumemishi"
+  name: 夢見師
+  name-sort: ゆめみし
+  name-en: "Yumemishi"
   region: "NTSC-J"
 SLPM-66620:
-  name: "Higurashi no Naku Koro ni Matsuri"
+  name: ひぐらしのなく頃に祭
+  name-sort: ひぐらしのなくころにまつり
+  name-en: "Higurashi no Naku Koro ni Matsuri"
   region: "NTSC-J"
 SLPM-66621:
-  name: "Beatmania IIDX 12 - Happy Sky"
+  name: beatmania IIDX 12 HAPPY SKY
+  name-sort: beatmania IIDX 12 HAPPY SKY
+  name-en: "Beatmania IIDX 12 HAPPY SKY"
   region: "NTSC-J"
 SLPM-66622:
-  name: "Tom Clancy's Ghost Recon 2 [Ubisoft Best]"
+  name: ユービーアイソフト ベスト トム・クランシーシリーズ ゴーストリコン2
+  name-sort: ゆーびーあいそふと べすと とむ・くらんしーしりーず ごーすとりこん2
+  name-en: "Tom Clancy's Ghost Recon 2 [Ubisoft Best]"
   region: "NTSC-J"
 SLPM-66623:
-  name: "Dokapon the World [Asmik Tokudane Series]"
+  name: アスミック得だねシリーズ ドカポン・ザ・ワールド
+  name-sort: あすみっくとくだねしりーず どかぽん・ざ・わーるど
+  name-en: "Dokapon the World [Asmik Tokudane Series]"
   region: "NTSC-J"
 SLPM-66624:
-  name: "Tsuyo Kiss - Mighty Heart [Princess Soft Collection]"
+  name: つよきす〜Mighy Heart〜(プリンセスソフトコレクション)
+  name-sort: つよきす〜Mighy Heart〜(ぷりんせすそふとこれくしょん)
+  name-en: "Tsuyo Kiss - Mighty Heart [Princess Soft Collection]"
   region: "NTSC-J"
 SLPM-66625:
-  name: "Trouble Fortune Company - HapiCure [Limited Edition]"
+  name: とらぶるふぉうちゅん COMPANY★はぴCURE (初回限定版)
+  name-sort: とらぶるふぉうちゅん COMPANY★はぴCURE (しょかいげんていばん)
+  name-en: "Trouble Fortune Company - HapiCure [Limited Edition]"
   region: "NTSC-J"
 SLPM-66626:
-  name: "Trouble Fortune Company - HapiCure"
+  name: とらぶるふぉうちゅん COMPANY★はぴCURE (通常版)
+  name-sort: とらぶるふぉうちゅん COMPANY★はぴCURE (つうじょうばん)
+  name-en: "Trouble Fortune Company - HapiCure"
   region: "NTSC-J"
 SLPM-66627:
-  name: "WWE SmackDown! vs. RAW 2007"
+  name: WWE 2007 SmackDown(R) vs Raw(R)
+  name-sort: WWE 2007 SmackDown(R) vs Raw(R)
+  name-en: "WWE SmackDown! vs. RAW 2007"
   region: "NTSC-J"
 SLPM-66628:
-  name: "OutRun 2 SP [First Print Limited Edition]"
+  name: OutRun2 SP(アウトラン2 スペシャルツアーズ)初回限定版
+  name-sort: OutRun2 SP(あうとらん2 すぺしゃるつあーず)しょかいげんていばん
+  name-en: "OutRun 2 SP [First Print Limited Edition]"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
@@ -38757,55 +43126,83 @@ SLPM-66628:
     halfPixelOffset: 2 # Fixes bloom misalignment still a bit misaligned.
     roundSprite: 1 # Fixes bloom misalignment still a bit misaligned + font artifacts.
 SLPM-66629:
-  name: "Dirge of Cerberus - Final Fantasy VII International"
+  name: Ultimate Hits DIRGE of CERBERUS -FINAL FANTASY VII- INTERNATIONAL
+  name-sort: Ultimate Hits DIRGE of CERBERUS -FINAL FANTASY VII- INTERNATIONAL
+  name-en: "Dirge of Cerberus - Final Fantasy VII International"
   region: "NTSC-J"
   gsHWFixes:
     autoFlush: 2 # Fixes lighting.
 SLPM-66630:
-  name: "Melheaven - Arm Fight Dream [Konami the Best]"
+  name: メルヘヴン ARM FIGHT DREAM コナミ・ザ・ベスト
+  name-sort: めるへゔん ARM FIGHT DREAM こなみ・ざ・べすと
+  name-en: "Melheaven - Arm Fight Dream [Konami the Best]"
   region: "NTSC-J"
 SLPM-66631:
-  name: "Gokujou Seitokai [Konami the Best]"
+  name: 極上生徒会 コナミ・ザ・ベスト
+  name-sort: ごくじょうせいとかい こなみ・ざ・べすと
+  name-en: "Gokujou Seitokai [Konami the Best]"
   region: "NTSC-J"
 SLPM-66632:
-  name: "Kenka Banchou 2 - Full Throttle"
+  name: 喧嘩番長2 〜FULLTHROTTLE〜(フルスロットル)
+  name-sort: けんかばんちょう2 〜FULLTHROTTLE〜(ふるすろっとる)
+  name-en: "Kenka Banchou 2 - Full Throttle"
   region: "NTSC-J"
 SLPM-66633:
-  name: "Shoujo Mahou Gaku Little Witch Romanesque"
+  name: 少女魔法学リトルウィッチロマネスク 〜アリアとカヤと黒の塔〜
+  name-sort: しょうじょまほうがくりとるうぃっちろまねすく 〜ありあとかやとくろのとう〜
+  name-en: "Shoujo Mahou Gaku Little Witch Romanesque"
   region: "NTSC-J"
 SLPM-66634:
-  name: "Devil Summoner - Kuzunoha Raidou tai Chouriki Heidan [Atlus Best Collection]"
+  name: デビルサマナー 葛葉ライドウ対超力兵団 アトラスベストコレクション
+  name-sort: でびるさまなー くずのはらいどうたいちょうりきへいだん あとらすべすとこれくしょん
+  name-en: "Devil Summoner - Kuzunoha Raidou tai Chouriki Heidan [Atlus Best Collection]"
   region: "NTSC-J"
   gsHWFixes:
     minimumBlendingLevel: 3 # Fixes broken effect rendering.
 SLPM-66635:
-  name: "Wind - A Breath of Heart [Alchemist Best Collection]"
+  name: Wind -a breath of heart- アルケベスト版
+  name-sort: Wind -a breath of heart- あるけべすとばん
+  name-en: "Wind - A Breath of Heart [Alchemist Best Collection]"
   region: "NTSC-J"
 SLPM-66636:
-  name: "Hyper Street Fighter II - The Anniversary Edition [CapKore]"
+  name: ハイパーストリートファイターII アニバーサリーエディション カプコレ
+  name-sort: はいぱーすとりーとふぁいたーII あにばーさりーえでぃしょん かぷこれ
+  name-en: "Hyper Street Fighter II - The Anniversary Edition [CapKore]"
   region: "NTSC-J"
 SLPM-66637:
-  name: "Vampire Darkstalkers Collection [Capcom the Best]"
+  name: ヴァンパイア ダークストーカーズ コレクション カプコレ
+  name-sort: ゔぁんぱいあ だーくすとーかーず これくしょん かぷこれ
+  name-en: "Vampire Darkstalkers Collection [Capcom the Best]"
   region: "NTSC-J"
   gsHWFixes:
     roundSprite: 1 # Fixes squares around sprites when upscaling.
 SLPM-66638:
-  name: "Demento [CapKore]"
+  name: デメント カプコレ
+  name-sort: でめんと かぷこれ
+  name-en: "Demento [CapKore]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 1 # Fixes blurriness.
     beforeDraw: "OI_HauntingGround" # Fix bloom.
 SLPM-66639:
-  name: "Street Fighter III - 3rd Strike [Capcom the Best]"
+  name: ストリートファイターIII 3rd STRIKE Fight for the future カプコレ
+  name-sort: すとりーとふぁいたーIII 3rd STRIKE Fight for the future かぷこれ
+  name-en: "Street Fighter III - 3rd Strike [Capcom the Best]"
   region: "NTSC-J"
 SLPM-66640:
-  name: "Full House Kiss [CapKore]"
+  name: フルハウスキス カプコレ
+  name-sort: ふるはうすきす かぷこれ
+  name-en: "Full House Kiss [CapKore]"
   region: "NTSC-J"
 SLPM-66641:
-  name: "School Love"
+  name: すくぅ〜る らぶっ!〜恋と希望のメトロノーム〜
+  name-sort: すくぅ〜る らぶっ!〜こいときぼうのめとろのーむ〜
+  name-en: "School Love"
   region: "NTSC-J"
 SLPM-66642:
-  name: "Prince of Tennis, The - Card Hunter [First Print Limited Edition]"
+  name: テニスの王子様 CARD HUNTER 初回限定版
+  name-sort: てにすのおうじさま CARD HUNTER しょかいげんていばん
+  name-en: "Prince of Tennis, The - Card Hunter [First Print Limited Edition]"
   region: "NTSC-J"
 SLPM-66643:
   name: "OutRun 2 SP"
@@ -38815,15 +43212,21 @@ SLPM-66643:
     halfPixelOffset: 2 # Fixes bloom misalignment still a bit misaligned.
     roundSprite: 1 # Fixes bloom misalignment still a bit misaligned + font artifacts.
 SLPM-66644:
-  name: "J-League Pro Soccer Club o Tsukurou 5"
+  name: J.LEAGUE プロサッカークラブをつくろう!5
+  name-sort: J.LEAGUE ぷろさっかーくらぶをつくろう!5
+  name-en: "J-League Pro Soccer Club o Tsukurou 5"
   region: "NTSC-J"
 SLPM-66645:
-  name: "Bionicle Heroes"
+  name: バイオニクル ヒーローズ
+  name-sort: ばいおにくる ひーろーず
+  name-en: "Bionicle Heroes"
   region: "NTSC-J"
   gsHWFixes:
     cpuCLUTRender: 1 # Fixes ghosting on objects and people.
 SLPM-66646:
-  name: "Shining Force EXA"
+  name: シャイニング・フォース イクサ
+  name-sort: しゃいにんぐ・ふぉーす いくさ
+  name-en: "Shining Force EXA"
   region: "NTSC-J"
 SLPM-66649:
   name: "Taito Memories II - Joukan"
@@ -38832,7 +43235,9 @@ SLPM-66649:
   gsHWFixes:
     roundSprite: 1 # Fixes vertical and horizontal lines.
 SLPM-66651:
-  name: "Battlefield 2 - Modern Combat [EA Best Hits]"
+  name: EA BEST HITS バトルフィールド2 モダンコンバット
+  name-sort: EA BEST HITS ばとるふぃーるど2 もだんこんばっと
+  name-en: "Battlefield 2 - Modern Combat [EA Best Hits]"
   region: "NTSC-J"
   gsHWFixes:
     minimumBlendingLevel: 4 # Fixes ground texture rendering.
@@ -38842,7 +43247,9 @@ SLPM-66651:
     getSkipCount: "GSC_Battlefield2" # Depth clear.
     beforeDraw: "OI_Battlefield2" # Framebuffer copy, fixes rendering for bottom part of screen.
 SLPM-66652:
-  name: "Burnout Revenge [EA Best Hits]"
+  name: EA BEST HITS バーンアウト リベンジ
+  name-sort: EA BEST HITS ばーんあうと りべんじ
+  name-en: "Burnout Revenge [EA Best Hits]"
   region: "NTSC-J"
   clampModes:
     vuClampMode: 0 # Fixes buggy lighting in the garage.
@@ -38866,53 +43273,81 @@ SLPM-66652:
     - "SLAJ-25053"
     - "SLPM-66204"
 SLPM-66653:
-  name: "Akudaikan 3"
+  name: 悪代官3
+  name-sort: あくだいかん3
+  name-en: "Akudaikan 3"
   region: "NTSC-J"
 SLPM-66654:
-  name: "Harukanaru Toki no Naka de 2 [Koei Selection]"
+  name: コーエー定番シリーズ 遙かなる時空の中で2
+  name-sort: はるかなるときのなかで2 こーえーていばんしりーず
+  name-en: "Harukanaru Toki no Naka de 2 [Koei Selection]"
   region: "NTSC-J"
 SLPM-66655:
-  name: "Harukanaru Jikuu no Kade - Hachiha Katsunori [Koei the Best]"
+  name: KOEI The Best 遙かなる時空の中で 〜八葉抄〜
+  name-sort: はるかなるときのなかで 〜はちようしょう〜
+  name-en: "Harukanaru Jikuu no Kade - Hachiha Katsunori [Koei the Best]"
   region: "NTSC-J"
 SLPM-66656:
-  name: "Warship Gunner 2 - Change of Direction [Koei the Best]"
+  name: KOEI The Best ウォーシップガンナー2 〜鋼鉄の咆哮〜
+  name-sort: KOEI The Best うぉーしっぷがんなー2 〜くろがねのほうこう〜
+  name-en: "Warship Gunner 2 - Change of Direction [Koei the Best]"
   region: "NTSC-J"
 SLPM-66657:
-  name: "Shin Sangoku Musou 3 Mushoden [Koei Selection]"
+  name: コーエー定番シリーズ 真・三國無双3 猛将伝
+  name-sort: こーえーていばんしりーず しん・さんごくむそう3 もうしょうでん
+  name-en: "Shin Sangoku Musou 3 Mushoden [Koei Selection]"
   region: "NTSC-J"
 SLPM-66658:
-  name: "Shin Sangoku Musou 3 Empires [Koei Selection]"
+  name: コーエー定番シリーズ 真・三國無双3 Empiers
+  name-sort: こーえーていばんしりーず しん・さんごくむそう3 Empiers
+  name-en: "Shin Sangoku Musou 3 Empires [Koei Selection]"
   region: "NTSC-J"
 SLPM-66659:
-  name: "Soshite Kono Uchuu ni Kirameku Kimi no Shi XXX"
+  name: そしてこの宇宙にきらめく君の詩 XXX
+  name-sort: そしてこのうちゅうにきらめくきみのし XXX
+  name-en: "Soshite Kono Uchuu ni Kirameku Kimi no Shi XXX"
   region: "NTSC-J"
 SLPM-66660:
-  name: "Hokuto no Ken"
+  name: 北斗の拳 〜審判の双蒼星 拳豪列伝〜
+  name-sort: ほくとのけん 〜しんぱんのそうそうせい けんごうれつでん〜
+  name-en: "Hokuto no Ken"
   region: "NTSC-J"
   compat: 5
 SLPM-66661:
-  name: "Dessert Love - Sweet Plus [Best Collection]"
+  name: Dessert Love -Sweet Plus- Best Collection
+  name-sort: Dessert Love -Sweet Plus- Best Collection
+  name-en: "Dessert Love - Sweet Plus [Best Collection]"
   region: "NTSC-J"
 SLPM-66662:
-  name: "Dog Island, The - Hitotsu no Hana no Monogatari"
+  name: THE DOG ISLAND ひとつの花の物語
+  name-sort: THE DOG ISLAND ひとつのはなのものがたり
+  name-en: "Dog Island, The - Hitotsu no Hana no Monogatari"
   region: "NTSC-J"
   gsHWFixes:
     autoFlush: 2 # Fixes certains font colors.
     halfPixelOffset: 2 # Fixes lighting misalignment.
     alignSprite: 1 # Fixes almost all vertical lines.
 SLPM-66663:
-  name: "Phantasy Star Universe - Ambition of the Illuminus"
+  name: PHANTASY STAR UNIVERSE イルミナスの野望
+  name-sort: PHANTASY STAR UNIVERSE いるみなすのやぼう
+  name-en: "Phantasy Star Universe - Ambition of the Illuminus"
   region: "NTSC-J"
   roundModes:
     eeRoundMode: 0 # Fixes enemies not moving.
 SLPM-66664:
-  name: "Full House Kiss 2 [CapKore]"
+  name: フルハウスキス2 カプコレ
+  name-sort: ふるはうすきす2 かぷこれ
+  name-en: "Full House Kiss 2 [CapKore]"
   region: "NTSC-J"
 SLPM-66667:
-  name: "Meine Liebe II [Konami Palace Selection]"
+  name: マイネリーベII 〜誇りと正義と愛〜 コナミ殿堂セレクション
+  name-sort: まいねりーべII 〜ほこりとせいぎとあい〜 こなみでんどうせれくしょん
+  name-en: "Meine Liebe II [Konami Palace Selection]"
   region: "NTSC-J"
 SLPM-66668:
-  name: "Akumajo Dracula - Yami no Juin [Konami the Best]"
+  name: 悪魔城ドラキュラ 闇の呪印 コナミ・ザ・ベスト
+  name-sort: あくまじょうどらきゅら やみのじゅいん こなみ・ざ・べすと
+  name-en: "Akumajo Dracula - Yami no Juin [Konami the Best]"
   region: "NTSC-J"
   clampModes:
     vuClampMode: 0 # Fixes SPS with microVU.
@@ -38926,26 +43361,38 @@ SLPM-66668:
     - "SLPM-65444"
     - "SLPM-66325"
 SLPM-66669:
-  name: "Prince of Tennis, The - Card Hunter [First Print Limited Edition]"
+  name: テニスの王子様 CARD HUNTER
+  name-sort: てにすのおうじさま CARD HUNTER
+  name-en: "Prince of Tennis, The - Card Hunter [First Print Limited Edition]"
   region: "NTSC-J"
 SLPM-66670:
-  name: "Stella Deus [Best Version]"
+  name: STELLA DEUS アトラスベストコレクション
+  name-sort: STELLA DEUS あとらすべすとこれくしょん
+  name-en: "Stella Deus [Best Version]"
   region: "NTSC-J"
 SLPM-66671:
-  name: "Shining Wind"
+  name: シャイニング・ウィンド
+  name-sort: しゃいにんぐ・うぃんど
+  name-en: "Shining Wind"
   region: "NTSC-J"
   gameFixes:
     - DMABusyHack
 SLPM-66672:
-  name: "Tom Clancy's Splinter Cell - Double Agent"
+  name: スプリンターセル 二重スパイ
+  name-sort: すぷりんたーせる にじゅうすぱい
+  name-en: "Tom Clancy's Splinter Cell - Double Agent"
   region: "NTSC-J"
 SLPM-66673:
-  name: "Prince of Persia - Warrior Within [Ubisoft the Best]"
+  name: ユービーアイソフトベスト プリンス・オブ・ペルシャ ケンシ ノ ココロ
+  name-sort: ゆーびーあいそふとべすと ぷりんす・おぶ・ぺるしゃ けんし の こころ
+  name-en: "Prince of Persia - Warrior Within [Ubisoft the Best]"
   region: "NTSC-J"
   gsHWFixes:
     autoFlush: 2 # Reduces post-processing misalignment.
 SLPM-66674:
-  name: "Tiger Woods PGA Tour 07"
+  name: タイガー・ウッズ PGA TOUR(R)07
+  name-sort: たいがー・うっず PGA TOUR(R)07
+  name-en: "Tiger Woods PGA Tour 07"
   region: "NTSC-J"
   clampModes:
     vuClampMode: 2 # Fixes black textures on characters.
@@ -38953,7 +43400,9 @@ SLPM-66674:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
 SLPM-66675:
-  name: "Kingdom Hearts II - Final Mix +"
+  name: KINGDOM HEARTS II FINAL MIX+ 通常版
+  name-sort: KINGDOM HEARTS II FINAL MIX+ つうじょうばん
+  name-en: "Kingdom Hearts II - Final Mix +"
   region: "NTSC-J"
   gsHWFixes:
     autoFlush: 2 # Fixes effects.
@@ -38973,21 +43422,27 @@ SLPM-66676:
     - "SLPM-66675"
     - "SLPM-66676"
 SLPM-66677:
-  name: "Final Fantasy X - International [Ultimate Hits]"
+  name: アルティメット ヒッツ ファイナルファンタジーX インターナショナル
+  name-sort: あるてぃめっと ひっつ ふぁいなるふぁんたじーX いんたーなしょなる
+  name-en: "Final Fantasy X - International [Ultimate Hits]"
   region: "NTSC-J"
   roundModes:
     eeRoundMode: 1 # Fixes reverse control and boss in some places.
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
 SLPM-66678:
-  name: "Final Fantasy X-2 - International + Last Mission [Ultimate Hits]"
+  name: アルティメット ヒッツ ファイナルファンタジーX-2 インターナショナル+ラストミッション
+  name-sort: あるてぃめっと ひっつ ふぁいなるふぁんたじーX-2 いんたーなしょなる+らすとみっしょん
+  name-en: "Final Fantasy X-2 - International + Last Mission [Ultimate Hits]"
   region: "NTSC-J"
   gameFixes:
     - SoftwareRendererFMVHack # Fixes brightness and overlapping subtitles.
   gsHWFixes:
     roundSprite: 1 # Fixes font artifacts.
 SLPM-66679:
-  name: "Devil Summoner - Kuzunoha Raidou tai Abaddon Ou [Plus]"
+  name: デビルサマナー 葛葉ライドウ 対 アバドン王 Plus
+  name-sort: でびるさまなー くずのはらいどう たい あばどんおう Plus
+  name-en: "Devil Summoner - Kuzunoha Raidou tai Abaddon Ou [Plus]"
   region: "NTSC-J"
   memcardFilters:
     - "SLPM-66679"
@@ -39001,7 +43456,9 @@ SLPM-66681:
   roundModes:
     eeRoundMode: 0 # Ladder glitch in "Assembly of Nihilo B11" level.
 SLPM-66683:
-  name: "Devil Summoner - Kuzunoha Raidou tai Abaddon Ou"
+  name: デビルサマナー 葛葉ライドウ 対 アバドン王 初回生産版
+  name-sort: でびるさまなー くずのはらいどう たい あばどんおう しょかいせいさんばん
+  name-en: "Devil Summoner - Kuzunoha Raidou tai Abaddon Ou"
   region: "NTSC-J"
   memcardFilters:
     - "SLPM-66679"
@@ -39009,14 +43466,20 @@ SLPM-66683:
     - "SLPM-66246"
     - "SLPM-66634"
 SLPM-66685:
-  name: "Seaman 2 - Peking Genjin Ikusei Kit"
+  name: シーマン2 〜北京原人育成キット〜
+  name-sort: しーまん2 〜ぺきんげんじんいくせいきっと〜
+  name-en: "Seaman 2 - Peking Genjin Ikusei Kit"
   region: "NTSC-J"
   compat: 2
 SLPM-66686:
-  name: "GuitarFreaks & DrumMania MASTERPIECE GOLD"
+  name: GuitarFreaks & DrumMania MASTERPIECE GOLD
+  name-sort: GuitarFreaks & DrumMania MASTERPIECE GOLD
+  name-en: "GuitarFreaks & DrumMania MASTERPIECE GOLD"
   region: "NTSC-J"
 SLPM-66687:
-  name: "Hiiro no Kakera - Ano Sora no Shita de"
+  name: 緋色の欠片 〜あの空の下で〜
+  name-sort: ひいろのかけら 〜あのそらのしたで〜
+  name-en: "Hiiro no Kakera - Ano Sora no Shita de"
   region: "NTSC-J"
   patches:
     "8365E603":
@@ -39026,10 +43489,14 @@ SLPM-66687:
         // This patch skips over the stack code, allowing the game to boot.
         patch=1,EE,001D1ED8,word,10000003
 SLPM-66688:
-  name: "Harukanaru Jikuu no Kade 3 [Koei the Best]"
+  name: KOEI The Best 遙かなる時空の中で3
+  name-sort: はるかなるときのなかで3 KOEI The Best
+  name-en: "Harukanaru Jikuu no Kade 3 [Koei the Best]"
   region: "NTSC-J"
 SLPM-66689:
-  name: "Persona 3 FES [Append Edition]"
+  name: ペルソナ3フェス 【アペンドディスク版】
+  name-sort: ぺるそな3ふぇす 【あぺんどでぃすくばん】
+  name-en: "Persona 3 FES [Append Edition]"
   region: "NTSC-J"
   gsHWFixes:
     mipmap: 2 # Fixes flashing windows.
@@ -39038,7 +43505,9 @@ SLPM-66689:
     - "SLPM-66689"
     - "SLPM-66690"
 SLPM-66690:
-  name: "Persona 3 FES [Independent Starting Version]"
+  name: ペルソナ3フェス
+  name-sort: ぺるそな3ふぇす
+  name-en: "Persona 3 FES [Independent Starting Version]"
   region: "NTSC-J"
   gsHWFixes:
     mipmap: 2 # Fixes flashing windows.
@@ -39047,70 +43516,104 @@ SLPM-66690:
     - "SLPM-66689"
     - "SLPM-66690"
 SLPM-66691:
-  name: "Sengoku Basara 2 [CapKore]"
+  name: 戦国BASARA2 カプコレ
+  name-sort: せんごくBASARA2 かぷこれ
+  name-en: "Sengoku Basara 2 [CapKore]"
   region: "NTSC-J"
 SLPM-66692:
-  name: "Seikai no Senki [Best Hit]"
+  name: BEST HIT セレクション 星界の戦旗
+  name-sort: BEST HIT せれくしょん せいかいのせんき
+  name-en: "Seikai no Senki [Best Hit]"
   region: "NTSC-J"
 SLPM-66693:
-  name: "Princess Maker 4 [Best Version]"
+  name: BEST HIT セレクション プリンセスメーカー4
+  name-sort: BEST HIT せれくしょん ぷりんせすめーかー4
+  name-en: "Princess Maker 4 [Best Version]"
   region: "NTSC-J"
 SLPM-66694:
-  name: "Nickelodeon SpongeBob SquarePants"
+  name: スポンジ・ボブ
+  name-sort: すぽんじ・ぼぶ
+  name-en: "Nickelodeon SpongeBob SquarePants"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
 SLPM-66695:
-  name: "Kono Aozora ni Yakusoku o - Melody of the Sun and Sea"
+  name: この青空に約束を　〜melody of the sun and sea〜
+  name-sort: このあおぞらにやくそくを　〜melody of the sun and sea〜
+  name-en: "Kono Aozora ni Yakusoku o - Melody of the Sun and Sea"
   region: "NTSC-J"
 SLPM-66696:
-  name: "SuperLite 2000 Series - Memories Off - Sorekara Again"
+  name: Memories Off 〜それからagain〜
+  name-sort: Memories Off 〜それからagain〜
+  name-en: "SuperLite 2000 Series - Memories Off - Sorekara Again"
   region: "NTSC-J"
 SLPM-66697:
-  name: "Nightmare Before Christmas, The [CapKore]"
+  name: ティム・バートン ナイトメアー・ビフォア・クリスマス ブギーの逆襲 カプコレ
+  name-sort: てぃむ・ばーとん ないとめあー・びふぉあ・くりすます ぶぎーのぎゃくしゅう かぷこれ
+  name-en: "Nightmare Before Christmas, The [CapKore]"
   region: "NTSC-J"
   gsHWFixes:
     wildArmsHack: 1 # Fixes blurriness.
     mergeSprite: 1 # Fixes misaligned lights.
 SLPM-66698:
-  name: "Shijou Saikyou no Teishi - Kenichi"
+  name: 史上最強の弟子ケンイチ 激闘!ラグナレク八拳豪
+  name-sort: しじょうさいきょうのでしけんいち げきとう!らぐなれくはちけんごう
+  name-en: "Shijou Saikyou no Teishi - Kenichi"
   region: "NTSC-J"
 SLPM-66699:
   name: "Kin'iro no Corda 2"
   region: "NTSC-J"
 SLPM-66700:
-  name: "Konjiki no Corda 2"
+  name: 金色のコルダ2
+  name-sort: きんいろのこるだ2
+  name-en: "Konjiki no Corda 2"
   region: "NTSC-J"
 SLPM-66701:
-  name: "Sangokushi XI [with Power-Up Kit]"
+  name: 三國志11 withパワーアップキット
+  name-sort: さんごくし11 withぱわーあっぷきっと
+  name-en: "Sangokushi XI [with Power-Up Kit]"
   region: "NTSC-J"
 SLPM-66702:
-  name: "Winning Post 7 Maximum 2007"
+  name: Winning Post 7 MAXIMUM2007
+  name-sort: Winning Post 7 MAXIMUM2007
+  name-en: "Winning Post 7 Maximum 2007"
   region: "NTSC-J"
 SLPM-66703:
-  name: "Racing Game - Chuui!!!! [Konami the Best]"
+  name: レーシングゲーム「注意!!!!」 コナミ・ザ・ベスト
+  name-sort: れーしんぐげーむ「ちゅうい!!!!」 こなみ・ざ・べすと
+  name-en: "Racing Game - Chuui!!!! [Konami the Best]"
   region: "NTSC-J"
 SLPM-66704:
-  name: "Negima! Dream Tactic Yumemiru Otome Princess [Maihime Edition]"
+  name: ネギま!? どりーむたくてぃっく 夢見る乙女はプリンセス 舞姫版
+  name-sort: ねぎま!? どりーむたくてぃっく ゆめみるおとめはぷりんせす まいひめばん
+  name-en: "Negima! Dream Tactic Yumemiru Otome Princess [Maihime Edition]"
   region: "NTSC-J"
   compat: 5
 SLPM-66705:
-  name: "Negima! Dream Tactic Yumemiru Otome Princess [Utahime Edition]"
+  name: ネギま!? どりーむたくてぃっく 夢見る乙女はプリンセス 歌姫版
+  name-sort: ねぎま!? どりーむたくてぃっく ゆめみるおとめはぷりんせす うたひめばん
+  name-en: "Negima! Dream Tactic Yumemiru Otome Princess [Utahime Edition]"
   region: "NTSC-J"
   compat: 5
 SLPM-66707:
   name: "Yukinko Daisenpuu - Sayuki to Koyuki no Hie Hie Daisoudou"
   region: "NTSC-J"
 SLPM-66708:
-  name: "Brothers In Arms - Earned In Blood [Ubisoft Best]"
+  name: ユービーアイソフトベスト ブラザー イン アームズ 名誉の代償
+  name-sort: ゆーびーあいそふとべすと ぶらざー いん あーむず めいよのだいしょう
+  name-en: "Brothers In Arms - Earned In Blood [Ubisoft Best]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
 SLPM-66709:
-  name: "Angel Profile"
+  name: エンジェル・プロファイル
+  name-sort: えんじぇる・ぷろふぁいる
+  name-en: "Angel Profile"
   region: "NTSC-J"
 SLPM-66710:
-  name: "Godfather, The"
+  name: ゴッドファーザー
+  name-sort: ごっどふぁーざー
+  name-en: "Godfather, The"
   region: "NTSC-J"
   gsHWFixes:
     mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
@@ -39130,64 +43633,100 @@ SLPM-66713:
   gsHWFixes:
     roundSprite: 1 # Fixes vertical and horizontal lines.
 SLPM-66714:
-  name: "Wrestle Kingdom 2 - Pro Wrestling Sekai Taisen"
+  name: レッスルキングダム2 プロレスリング世界大戦
+  name-sort: れっするきんぐだむ2 ぷろれすりんぐせかいたいせん
+  name-en: "Wrestle Kingdom 2 - Pro Wrestling Sekai Taisen"
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
     halfPixelOffset: 1 # Fixes misaligned bloom.
 SLPM-66715:
-  name: "Shinki Gensou Spectral Souls II [IF Collection]"
+  name: IFコレクション 新紀幻想 スペクトラル ソウルズ II
+  name-sort: IFこれくしょん しんきげんそう すぺくとらる そうるず II
+  name-en: "Shinki Gensou Spectral Souls II [IF Collection]"
   region: "NTSC-J"
 SLPM-66716:
-  name: "Growlanser VI"
+  name: グローランサーVI
+  name-sort: ぐろーらんさーVI
+  name-en: "Growlanser VI"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
     moveHandler: "MV_Growlanser" # Fixes precomputed depth buffer.
 SLPM-66717:
-  name: "Standard Daisenryaku - Dengekisen [Sega the Best]"
+  name: SEGA THE BEST スタンダード大戦略 電撃戦
+  name-sort: SEGA THE BEST すたんだーどだいせんりゃく でんげきせん
+  name-en: "Standard Daisenryaku - Dengekisen [Sega the Best]"
   region: "NTSC-J"
 SLPM-66718:
-  name: "Sutandādo Daisenryaku - Ushinawareta Shoeri [Sega the Best]"
+  name: SEGA THE BEST スタンダード大戦略 失われた勝利
+  name-sort: SEGA THE BEST すたんだーどだいせんりゃく うしなわれたしょうり
+  name-en: "Sutandādo Daisenryaku - Ushinawareta Shoeri [Sega the Best]"
   region: "NTSC-J"
 SLPM-66719:
-  name: "Tenka-bito [Sega the Best]"
+  name: SEGA THE BEST 天下人
+  name-sort: SEGA THE BEST てんかじん
+  name-en: "Tenka-bito [Sega the Best]"
   region: "NTSC-J"
 SLPM-66720:
-  name: "Guilty Gear XX #Slash [Sega the Best]"
+  name: SEGA THE BEST GUILTY GEAR XX SLASH(ギルティギア イグゼクス スラッシュ)
+  name-sort: SEGA THE BEST GUILTY GEAR XX SLASH(ぎるてぃぎあ いぐぜくす すらっしゅ)
+  name-en: "Guilty Gear XX #Slash [Sega the Best]"
   region: "NTSC-J"
 SLPM-66721:
-  name: "Musou Orochi"
+  name: 無双OROCHI
+  name-sort: むそうOROCHI
+  name-en: "Musou Orochi"
   region: "NTSC-J"
 SLPM-66722:
-  name: "Jissen Pachinko Hisshouhou! CR Aladdin Destiny EX"
+  name: 実戦パチンコ必勝法!CRアラジンデスティニーEX
+  name-sort: じっせんぱちんこひっしょうほう!CRあらじんですてぃにーEX
+  name-en: "Jissen Pachinko Hisshouhou! CR Aladdin Destiny EX"
   region: "NTSC-J"
 SLPM-66723:
-  name: "Zoids Infinity Fuzors [Tomy Best Collection]"
+  name: ゾイドインフィニティフューザーズ トミコレベスト
+  name-sort: ぞいどいんふぃにてぃふゅーざーず とみこれべすと
+  name-en: "Zoids Infinity Fuzors [Tomy Best Collection]"
   region: "NTSC-J"
 SLPM-66724:
-  name: "Zoids Tactics [Tomy Best Collection]"
+  name: ゾイドタクティクス トミコレベスト
+  name-sort: ぞいどたくてぃくす とみこれべすと
+  name-en: "Zoids Tactics [Tomy Best Collection]"
   region: "NTSC-J"
 SLPM-66725:
-  name: "Zoids Struggle [Tomy Best Collection]"
+  name: ゾイドストラグル トミコレベスト
+  name-sort: ぞいどすとらぐる とみこれべすと
+  name-en: "Zoids Struggle [Tomy Best Collection]"
   region: "NTSC-J"
 SLPM-66726:
-  name: "Ojousama Kumikyoku - Sweet Concert"
+  name: お嬢様組曲 -Sweet Concert- (通常版)
+  name-sort: おじょうさまくみきょく -Sweet Concert- (つうじょうばん)
+  name-en: "Ojousama Kumikyoku - Sweet Concert"
   region: "NTSC-J"
 SLPM-66727:
-  name: "Love Drops"
+  name: らぶ☆どろ〜LoveDrops〜
+  name-sort: らぶ☆どろ〜LoveDrops〜
+  name-en: "Love Drops"
   region: "NTSC-J"
 SLPM-66728:
-  name: "Pro Yakyuu Spirits 4"
+  name: プロ野球スピリッツ4
+  name-sort: ぷろやきゅうすぴりっつ4
+  name-en: "Pro Yakyuu Spirits 4"
   region: "NTSC-J"
 SLPM-66729:
-  name: "Shounen Onyouji - Tsubasa Yoima, Ten e Kare [Deluxe Box]"
+  name: 少年陰陽師 翼よいま、天へ還れ DXパック
+  name-sort: しょうねんおんみょうじ つばさよいま、てんへかえれ DXぱっく
+  name-en: "Shounen Onyouji - Tsubasa Yoima, Ten e Kare [Deluxe Box]"
   region: "NTSC-J"
 SLPM-66730:
-  name: "Shounen Onyouji - Tsubasa Yoima, Ten e Kare"
+  name: 少年陰陽師 翼よいま、天へ還れ 通常版
+  name-sort: しょうねんおんみょうじ つばさよいま、てんへかえれ つうじょうばん
+  name-en: "Shounen Onyouji - Tsubasa Yoima, Ten e Kare"
   region: "NTSC-J"
 SLPM-66731:
-  name: "Black [EA Best Hits]"
+  name: BLACK THE BEST
+  name-sort: BLACK THE BEST
+  name-en: "Black [EA Best Hits]"
   region: "NTSC-J"
   clampModes:
     vuClampMode: 3 # Fixes SPS.
@@ -39200,22 +43739,34 @@ SLPM-66731:
     getSkipCount: "GSC_BlackAndBurnoutSky"
     beforeDraw: "OI_BurnoutGames"
 SLPM-66732:
-  name: "Iinazuke [Limited Edition]"
+  name: 許嫁(いいなずけ)【初回限定版】
+  name-sort: いいなずけ(いいなずけ)【しょかいげんていばん】
+  name-en: "Iinazuke [Limited Edition]"
   region: "NTSC-J"
 SLPM-66733:
-  name: "Iinazuke"
+  name: 許嫁(いいなずけ)【通常版】
+  name-sort: いいなずけ(いいなずけ)【つうじょうばん】
+  name-en: "Iinazuke"
   region: "NTSC-J"
 SLPM-66734:
-  name: "Kiruto - Anata to Tsumugu Yume to Koi no Dress [Limited Edition]"
+  name: きると〜貴方と紡ぐ夢と恋のドレス〜(初回限定版)
+  name-sort: きると〜あなたとつむぐゆめとこいのどれす〜(しょかいげんていばん)
+  name-en: "Kiruto - Anata to Tsumugu Yume to Koi no Dress [Limited Edition]"
   region: "NTSC-J"
 SLPM-66735:
-  name: "Kiruto - Anata to Tsumugu Yume to Koi no Dress"
+  name: きると〜貴方と紡ぐ夢と恋のドレス〜(通常版)
+  name-sort: きると〜あなたとつむぐゆめとこいのどれす〜(つうじょうばん)
+  name-en: "Kiruto - Anata to Tsumugu Yume to Koi no Dress"
   region: "NTSC-J"
 SLPM-66736:
-  name: "Rogue Hearts Dungeon"
+  name: ローグ ハーツ ダンジョン
+  name-sort: ろーぐ はーつ だんじょん
+  name-en: "Rogue Hearts Dungeon"
   region: "NTSC-J"
 SLPM-66737:
-  name: "Ouran Koukou Host Club [Limited Edition]"
+  name: 桜蘭高校ホスト部 限定版
+  name-sort: おうらんこうこうほすとぶ げんていばん
+  name-en: "Ouran Koukou Host Club [Limited Edition]"
   region: "NTSC-J"
   patches:
     3BE2C709:
@@ -39225,7 +43776,9 @@ SLPM-66737:
         // This patch skips over the stack code, allowing the game to boot.
         patch=1,EE,00189e88,word,10000003
 SLPM-66738:
-  name: "Ouran Koukou Host Club"
+  name: 桜蘭高校ホスト部
+  name-sort: おうらんこうこうほすとぶ
+  name-en: "Ouran Koukou Host Club"
   region: "NTSC-J"
   patches:
     3BE2C709:
@@ -39235,7 +43788,9 @@ SLPM-66738:
         // This patch skips over the stack code, allowing the game to boot.
         patch=1,EE,00189e88,word,10000003
 SLPM-66739:
-  name: "Burnout Dominator"
+  name: バーンアウト ドミネーター
+  name-sort: ばーんあうと どみねーたー
+  name-en: "Burnout Dominator"
   region: "NTSC-J"
   clampModes:
     vuClampMode: 3 # Fixes buggy lighting in the garage.
@@ -39250,37 +43805,54 @@ SLPM-66739:
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
 SLPM-66740:
-  name: "Sentou Kokka Kai - Legend [DX Pack]"
+  name: 戦闘国家・改・レジェンド(DX版)
+  name-sort: せんとうこっか・かい・れじぇんど(DXばん)
+  name-en: "Sentou Kokka Kai - Legend [DX Pack]"
   region: "NTSC-J"
 SLPM-66741:
-  name: "Sentou Kokka Kai - Legend"
+  name: 戦闘国家・改・レジェンド(通常版)
+  name-sort: せんとうこっか・かい・れじぇんど(つうじょうばん)
+  name-en: "Sentou Kokka Kai - Legend"
   region: "NTSC-J"
 SLPM-66742:
-  name: "Pop'n music 14 FEVER!"
+  name: ポップンミュージック14 FEVER!
+  name-sort: ぽっぷんみゅーじっく14 FEVER!
+  name-en: "Pop'n music 14 FEVER!"
   region: "NTSC-J"
   compat: 5
 SLPM-66743:
-  name: "Shinkyoku Soukai Polyphonica"
+  name: 神曲奏界ポリフォニカ
+  name-sort: しんきょくそうかいぽりふぉにか
+  name-en: "Shinkyoku Soukai Polyphonica"
   region: "NTSC-J"
 SLPM-66744:
-  name: "Killer7 [CapKore]"
+  name: Killer7 カプコレ
+  name-sort: Killer7 かぷこれ
+  name-en: "Killer7 [CapKore]"
   region: "NTSC-J"
 SLPM-66745:
-  name: "Shadow of Rome [CapKore]"
+  name: シャドウ・オブ・ローマ カプコレ
+  name-sort: しゃどう・おぶ・ろーま かぷこれ
+  name-en: "Shadow of Rome [CapKore]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness and misaligned garbage when upscaling.
 SLPM-66746:
-  name: "Guilty Gear XX - Accent Core"
+  name: GUILTY GEAR XX ΛCORE(ギルティギア イグゼクス アクセントコア)
+  name-en: "Guilty Gear XX - Accent Core"
   region: "NTSC-J"
   compat: 5
 SLPM-66747:
-  name: "Baroque"
+  name: バロック
+  name-sort: ばろっく
+  name-en: "Baroque"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 1 # Fixes ghosting of characters.
 SLPM-66748:
-  name: "Mana-Khemia - Gakuen no Renkinjutsu Shitachi"
+  name: マナケミア 〜学園の錬金術師たち〜
+  name-sort: まなけみあ 〜がくえんのれんきんじゅつしたち〜
+  name-en: "Mana-Khemia - Gakuen no Renkinjutsu Shitachi"
   region: "NTSC-J"
   roundModes:
     eeRoundMode: 0 # Fixes jump issue.
@@ -39288,111 +43860,172 @@ SLPM-66748:
     - DMABusyHack
     - SoftwareRendererFMVHack # Vertical lines in FMV.
 SLPM-66749:
-  name: "Wizardry X 2 - Mugen no Gakuto [Wonder Price]"
+  name: ウィザードリィエクス2 〜無限の学徒〜 ワンダープライス
+  name-sort: うぃざーどりぃえくす2 〜むげんのがくと〜 わんだーぷらいす
+  name-en: "Wizardry X 2 - Mugen no Gakuto [Wonder Price]"
   region: "NTSC-J"
 SLPM-66750:
-  name: "Final Fantasy XII International - Zodiac Job System [with Bonus DVD]"
+  name: FINAL FANTASY XII INTERNATIONAL Zodiac Job System
+  name-en: "Final Fantasy XII International - Zodiac Job System [with Bonus DVD]"
   region: "NTSC-J"
   compat: 5
 SLPM-66751:
-  name: "Mahoroba Stories"
+  name: まほろばStories(通常版)
+  name-sort: まほろばStories(つうじょうばん)
+  name-en: "Mahoroba Stories"
   region: "NTSC-J"
 SLPM-66752:
-  name: "Medal of Honor - Vanguard"
+  name: メダル オブ オナー ヴァンガード
+  name-sort: めだる おぶ おなー ゔぁんがーど
+  name-en: "Medal of Honor - Vanguard"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes lighting misalignment.
     mergeSprite: 1 # Removes occasional vertical lines.
 SLPM-66753:
-  name: "Getsumento Heiki Mina - Futatsu no Project M [Limited Edition]"
+  name: 月面兎兵器ミーナ -ふたつのPROJECT M-【限定版】
+  name-sort: げつめんうさぎへいきみーな -ふたつのPROJECT M-【げんていばん】
+  name-en: "Getsumento Heiki Mina - Futatsu no Project M [Limited Edition]"
   region: "NTSC-J"
 SLPM-66754:
-  name: "Getsumento Heiki Mina - Futatsu no Project M"
+  name: 月面兎兵器ミーナ -ふたつのPROJECT M-【通常版】
+  name-sort: げつめんうさぎへいきみーな -ふたつのPROJECT M-【つうじょうばん】
+  name-en: "Getsumento Heiki Mina - Futatsu no Project M"
   region: "NTSC-J"
 SLPM-66755:
-  name: "Majo-musume - A La Mode II"
+  name: 魔女っ娘ア・ラ・モードII〜魔女と剣のストラグル〜(通常版)
+  name-sort: まじょっこあ・ら・もーどII〜まじょとけんのすとらぐる〜(つうじょうばん)
+  name-en: "Majo-musume - A La Mode II"
   region: "NTSC-J"
   gsHWFixes:
     cpuCLUTRender: 1 # Fixes bad colour rendering.
 SLPM-66756:
-  name: "Que - Ancient Leaf no Yousei [Limited Edition]"
+  name: Que〜エンシェントリーフの妖精〜(初回限定版)
+  name-sort: Que〜えんしぇんとりーふのようせい〜(しょかいげんていばん)
+  name-en: "Que - Ancient Leaf no Yousei [Limited Edition]"
   region: "NTSC-J"
 SLPM-66757:
-  name: "Que - Ancient Leaf no Yousei"
+  name: Que〜エンシェントリーフの妖精〜(通常版)
+  name-sort: Que〜えんしぇんとりーふのようせい〜(つうじょうばん)
+  name-en: "Que - Ancient Leaf no Yousei"
   region: "NTSC-J"
 SLPM-66758:
-  name: "Neo Angelique [Koei the Best]"
+  name: KOEI The Best ネオ アンジェリーク
+  name-sort: KOEI The Best ねお あんじぇりーく
+  name-en: "Neo Angelique [Koei the Best]"
   region: "NTSC-J"
 SLPM-66759:
-  name: "Harukanaru Jikuu no Kade 3 - Izayoiki [Koei the Best]"
+  name: KOEI The Best 遙かなる時空の中で3 十六夜記
+  name-sort: KOEI The Best はるかなるときのなかで3 いざよいき
+  name-en: "Harukanaru Jikuu no Kade 3 - Izayoiki [Koei the Best]"
   region: "NTSC-J"
 SLPM-66760:
-  name: "Nobunaga no Yabou - Soutenroku [with Power-Up Kit] [Koei Selection]"
+  name: コーエー定番シリーズ 信長の野望・蒼天録 with パワーアップキット
+  name-sort: こーえーていばんしりーず のぶながのやぼう・そうてんろく with ぱわーあっぷきっと
+  name-en: "Nobunaga no Yabou - Soutenroku [with Power-Up Kit] [Koei Selection]"
   region: "NTSC-J"
 SLPM-66761:
-  name: "Panic Palette [Limited Edition]"
+  name: Panic Palette(限定版)
+  name-sort: Panic Palette(げんていばん)
+  name-en: "Panic Palette [Limited Edition]"
   region: "NTSC-J"
 SLPM-66762:
-  name: "Panic Palette"
+  name: Panic Palette(通常版)
+  name-sort: Panic Palette(つうじょうばん)
+  name-en: "Panic Palette"
   region: "NTSC-J"
 SLPM-66763:
-  name: "Neon Genesis Evangelion - Battle Orchestra"
+  name: 新世紀エヴァンゲリオン バトルオーケストラ【通常版】
+  name-sort: しんせいきえゔぁんげりおん ばとるおーけすとら【つうじょうばん】
+  name-en: "Neon Genesis Evangelion - Battle Orchestra"
   region: "NTSC-J"
   compat: 5
 SLPM-66764:
-  name: "Izumo Zero"
+  name: IZUMO零 〜横濱あやかし絵巻〜
+  name-sort: IZUMOぜろ 〜よこはまあやかしえまき〜
+  name-en: "Izumo Zero"
   region: "NTSC-J"
 SLPM-66765:
-  name: "Juujimoto Ripputai Sypher - Game of Survival [Limited Edition]"
+  name: 十次元立方体サイファー ゲーム・オブ・サバイバル(初回限定版)
+  name-sort: じゅうじげんりっぽうたいさいふぁー げーむ・おぶ・さばいばる(しょかいげんていばん)
+  name-en: "Juujimoto Ripputai Sypher - Game of Survival [Limited Edition]"
   region: "NTSC-J"
 SLPM-66766:
-  name: "Juujimoto Ripputai Sypher - Game of Survival"
+  name: 十次元立方体サイファー ゲーム・オブ・サバイバル(通常版)
+  name-sort: じゅうじげんりっぽうたいさいふぁー げーむ・おぶ・さばいばる(つうじょうばん)
+  name-en: "Juujimoto Ripputai Sypher - Game of Survival"
   region: "NTSC-J"
 SLPM-66767:
-  name: "Urban Chaos - Riot Response"
+  name: アーバンカオス
+  name-sort: あーばんかおす
+  name-en: "Urban Chaos - Riot Response"
   region: "NTSC-J"
   gsHWFixes:
     roundSprite: 1 # Fixes edge garbage and thin lines.
     autoFlush: 1 # Fixes misaligned lights at native resolution.
 SLPM-66768:
-  name: "Missing Parts - The Tantei Stories - Side A [Best Version]"
+  name: MISSINGPARTS sideA nice price!
+  name-sort: MISSINGPARTS sideA nice price!
+  name-en: "Missing Parts - The Tantei Stories - Side A [Best Version]"
   region: "NTSC-J"
 SLPM-66769:
-  name: "Missing Parts - The Tantei Stories - Side B [Best Version]"
+  name: MISSINGPARTS sideB nice price!
+  name-sort: MISSINGPARTS sideB nice price!
+  name-en: "Missing Parts - The Tantei Stories - Side B [Best Version]"
   region: "NTSC-J"
 SLPM-66770:
-  name: "Kuon no Kizuna - Sairinshou [Best Version]"
+  name: 久遠の絆 再臨詔 nice price!
+  name-sort: くおんのきずな さいりんしょう nice price!
+  name-en: "Kuon no Kizuna - Sairinshou [Best Version]"
   region: "NTSC-J"
 SLPM-66771:
-  name: "Densha de Go! Shinkansen [PlayStation 2 The Best]"
+  name: エターナルヒッツ 電車でGO!山陽新幹線編
+  name-sort: えたーなるひっつ でんしゃでGO!さんようしんかんせんへん
+  name-en: "Densha de Go! Shinkansen [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPM-66772:
-  name: "Densha de Go! Final [PlayStation 2 The Best]"
+  name: エターナルヒッツ 電車でGO!FINAL
+  name-sort: えたーなるひっつ でんしゃでGO!FINAL
+  name-en: "Densha de Go! Final [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPM-66773:
-  name: "Densha de Go! Professional 2 [Taito Best]"
+  name: エターナルヒッツ ジェットでGO!2
+  name-sort: えたーなるひっつ じぇっとでGO!2
+  name-en: "Densha de Go! Professional 2 [Taito Best]"
   region: "NTSC-J"
 SLPM-66774:
-  name: "Energy Airforce - AimStrike! [Taito Best]"
+  name: エターナルヒッツ エナジーエアーフォース
+  name-sort: えたーなるひっつ えなじーえあーふぉーす
+  name-en: "Energy Airforce - AimStrike! [Taito Best]"
   region: "NTSC-J"
 SLPM-66775:
-  name: "Taito Memories - Joukan [Taito Best]"
+  name: エターナルヒッツ タイトーメモリーズ 上巻
+  name-sort: えたーなるひっつ たいとーめもりーず じょうかん
+  name-en: "Taito Memories - Joukan [Taito Best]"
   region: "NTSC-J"
   gsHWFixes:
     roundSprite: 1 # Fixes vertical and horizontal lines.
 SLPM-66776:
-  name: "Taito Memories Gekan [Taito Best]"
+  name: エターナルヒッツ タイトーメモリーズ 下巻
+  name-sort: えたーなるひっつ たいとーめもりーず げかん
+  name-en: "Taito Memories Gekan [Taito Best]"
   region: "NTSC-J"
   gsHWFixes:
     roundSprite: 1 # Fixes vertical and horizontal lines.
 SLPM-66777:
-  name: "Jikkyou Powerful Pro Yakyuu 14"
+  name: 実況パワフルプロ野球14
+  name-sort: じっきょうぱわふるぷろやきゅう14
+  name-en: "Jikkyou Powerful Pro Yakyuu 14"
   region: "NTSC-J"
 SLPM-66778:
-  name: "Galaxy Angel - Eternal Lovers [Broccoli The Best Quality]"
+  name: ギャラクシーエンジェル Eternal Lovers Broccoli Best Quality
+  name-sort: ぎゃらくしーえんじぇる Eternal Lovers Broccoli Best Quality
+  name-en: "Galaxy Angel - Eternal Lovers [Broccoli The Best Quality]"
   region: "NTSC-J"
 SLPM-66779:
-  name: "Galaxy Angel II - Mugen Kairou no Kagi [Disc 1 of 2]"
+  name: ギャラクシーエンジェルII 無限回廊の鍵【通常版】
+  name-sort: ぎゃらくしーえんじぇるII むげんかいろうのかぎ【つうじょうばん】
+  name-en: "Galaxy Angel II - Mugen Kairou no Kagi [Disc 1 of 2]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 1 # Reduces misaligned lighting and other effects.
@@ -39404,10 +44037,14 @@ SLPM-66780:
   memcardFilters:
     - "SLPM-66779"
 SLPM-66781:
-  name: "Dragon Quest - Shounen Yangus to Fushigi no Dungeon [Ultimate Hits]"
+  name: アルティメットヒッツ ドラゴンクエスト 少年ヤンガスと不思議のダンジョン
+  name-sort: あるてぃめっとひっつ どらごんくえすと しょうねんやんがすとふしぎのだんじょん
+  name-en: "Dragon Quest - Shounen Yangus to Fushigi no Dungeon [Ultimate Hits]"
   region: "NTSC-J"
 SLPM-66782:
-  name: "Valkyrie Profile 2 - Silmeria [Ultimate Hits]"
+  name: アルティメットヒッツ ヴァルキリープロファイル2シルメリア
+  name-sort: あるてぃめっとひっつ ゔぁるきりーぷろふぁいる2しるめりあ
+  name-en: "Valkyrie Profile 2 - Silmeria [Ultimate Hits]"
   region: "NTSC-J"
   compat: 5
   gameFixes:
@@ -39418,38 +44055,56 @@ SLPM-66782:
     textureInsideRT: 1 # Required for swirl battle transition.
     nativePaletteDraw: 1
 SLPM-66783:
-  name: "Idol Janshi Suchie-Pai 4 [Limited Edition]"
+  name: アイドル雀士 スーチーパイIV 「完全限定版・コレクターズエディション」
+  name-sort: あいどるじゃんし すーちーぱいIV 「かんぜんげんていばん・これくたーずえでぃしょん」
+  name-en: "Idol Janshi Suchie-Pai 4 [Limited Edition]"
   region: "NTSC-J"
 SLPM-66784:
   name: "Idol Janshi Suchie-Pai III Remix"
   region: "NTSC-J"
 SLPM-66785:
-  name: "Idol Janshi Suchie-Pai 4"
+  name: アイドル雀士 スーチーパイIV (通常版)
+  name-sort: あいどるじゃんし すーちーぱいIV (つうじょうばん)
+  name-en: "Idol Janshi Suchie-Pai 4"
   region: "NTSC-J"
 SLPM-66786:
-  name: "Gift - Prism [Broccoli Best Quality]"
+  name: Broccoli Best Quality gift -prism- Sweets So Sweet
+  name-sort: Broccoli Best Quality gift -prism- Sweets So Sweet
+  name-en: "Gift - Prism [Broccoli Best Quality]"
   region: "NTSC-J"
 SLPM-66787:
-  name: "Suika A.S+ Eternal Name"
+  name: 水夏A.S+ Eternal Name 通常版
+  name-sort: すいかA.S+ Eternal Name つうじょうばん
+  name-en: "Suika A.S+ Eternal Name"
   region: "NTSC-J"
 SLPM-66788:
-  name: "Grand Theft Auto - San Andreas [Best Price]"
+  name: Grand Theft Auto:San Andreas ベストプライス
+  name-sort: Grand Theft Auto:San Andreas べすとぷらいす
+  name-en: "Grand Theft Auto - San Andreas [Best Price]"
   region: "NTSC-J"
   clampModes:
     eeClampMode: 2 # Fixes Game freezes during "Reuniting The Families" mission.
   gsHWFixes:
     autoFlush: 1 # Fixes post processing.
 SLPM-66789:
-  name: "Grand Theft Auto III [Best Price]"
+  name: Grand Theft Auto III ベストプライス
+  name-sort: Grand Theft Auto III べすとぷらいす
+  name-en: "Grand Theft Auto III [Best Price]"
   region: "NTSC-J"
 SLPM-66790:
-  name: "Grand Theft Auto - Vice City [Best Price]"
+  name: Grand Theft Auto:Vice City ベストプライス
+  name-sort: Grand Theft Auto:Vice City べすとぷらいす
+  name-en: "Grand Theft Auto - Vice City [Best Price]"
   region: "NTSC-J"
 SLPM-66791:
-  name: "Memories Off #5 Encore"
+  name: Memories Off ♯5 アンコール【通常版】
+  name-sort: Memories Off ♯5 あんこーる【つうじょうばん】
+  name-en: "Memories Off #5 Encore"
   region: "NTSC-J"
 SLPM-66792:
-  name: "Metal Gear Solid 2 - Sons of Liberty [20th Anniversary Edition] [Disc 1 of 2]"
+  name: METAL GEAR 20th ANNIVERSARY METAL GEAR SOLID 2 SONS OF LIBERTY
+  name-sort: METAL GEAR 20th ANNIVERSARY METAL GEAR SOLID 2 SONS OF LIBERTY
+  name-en: "Metal Gear Solid 2 - Sons of Liberty [20th Anniversary Edition] [Disc 1 of 2]"
   region: "NTSC-J"
   gameFixes:
     - InstantDMAHack # Fixes broken half-bottom artifacts.
@@ -39463,7 +44118,9 @@ SLPM-66793:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
 SLPM-66794:
-  name: "Metal Gear Solid 3 - Snake Eater [20th Anniversary Edition]"
+  name: MERAL GEAR 20th ANNIVERSARY METAL GEAR SOLID 3 SNAKE EATER
+  name-sort: MERAL GEAR 20th ANNIVERSARY METAL GEAR SOLID 3 SNAKE EATER
+  name-en: "Metal Gear Solid 3 - Snake Eater [20th Anniversary Edition]"
   region: "NTSC-J"
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
@@ -39475,7 +44132,9 @@ SLPM-66795:
   name: "Metal Gear & Metal Gear 2 - Solid Snake"
   region: "NTSC-J"
 SLPM-66796:
-  name: "Metal Gear Solid - 20th Anniversary Collection"
+  name: METAL GEAR 20th ANNIVERSARY METAL GEAR SOLID COLLECTION
+  name-sort: METAL GEAR 20th ANNIVERSARY METAL GEAR SOLID COLLECTION
+  name-en: "Metal Gear Solid - 20th Anniversary Collection"
   region: "NTSC-J"
 SLPM-66797:
   name: "The Document of Metal Gear Solid 2"
@@ -39484,28 +44143,44 @@ SLPM-66798:
   name: "Metal Gear Solid 3 - Subsistence (Disc 1) (Subsistence)"
   region: "NTSC-J"
 SLPM-66800:
-  name: "Pirates of the Caribbean - At World's End"
+  name: パイレーツ・オブ・カリビアン/ワールド・エンド
+  name-sort: ぱいれーつ・おぶ・かりびあん/わーるど・えんど
+  name-en: "Pirates of the Caribbean - At World's End"
   region: "NTSC-J"
 SLPM-66801:
-  name: "Izumo Complete [GN Software Best]"
+  name: IZUMO コンプリート ベスト版
+  name-sort: IZUMO こんぷりーと べすとばん
+  name-en: "Izumo Complete [GN Software Best]"
   region: "NTSC-J"
 SLPM-66802:
-  name: "Kimore Hi no Namiki Michi [GN Software Best]"
+  name: 木漏れ日の並木道 〜移り変わる季節の中で〜 ベスト版
+  name-sort: こもれびのなみきみち 〜うつりかわるきせつのなかで〜 べすとばん
+  name-en: "Kimore Hi no Namiki Michi [GN Software Best]"
   region: "NTSC-J"
 SLPM-66803:
-  name: "Shikaku Tantei - Sora no Sekai - Thousand Dreams"
+  name: 死角探偵 空の世界〜Thousand Dreams〜
+  name-sort: しかくたんてい そらのせかい〜Thousand Dreams〜
+  name-en: "Shikaku Tantei - Sora no Sekai - Thousand Dreams"
   region: "NTSC-J"
 SLPM-66804:
-  name: "Colorful Aquarium - My Little Mermaid [Limited Edition]"
+  name: カラフルアクアリウム〜My Little Mermaid〜(初回限定版)
+  name-sort: からふるあくありうむ〜My Little Mermaid〜(しょかいげんていばん)
+  name-en: "Colorful Aquarium - My Little Mermaid [Limited Edition]"
   region: "NTSC-J"
 SLPM-66805:
-  name: "Colorful Aquarium - My Little Mermaid"
+  name: カラフルアクアリウム〜My Little Mermaid〜(通常版)
+  name-sort: からふるあくありうむ〜My Little Mermaid〜(つうじょうばん)
+  name-en: "Colorful Aquarium - My Little Mermaid"
   region: "NTSC-J"
 SLPM-66806:
-  name: "Shuffle! On the Stage [Kadokawa the Best]"
+  name: シャッフル!オン・ザ・ステージ KADOKAWA The BEST
+  name-sort: しゃっふる!おん・ざ・すてーじ KADOKAWA The BEST
+  name-en: "Shuffle! On the Stage [Kadokawa the Best]"
   region: "NTSC-J"
 SLPM-66807:
-  name: "Disney-Pixar's Remy no Oishii Restaurant"
+  name: レミーのおいしいレストラン
+  name-sort: れみーのおいしいれすとらん
+  name-en: "Disney-Pixar's Remy no Oishii Restaurant"
   region: "NTSC-J"
   compat: 5
   roundModes:
@@ -39515,77 +44190,121 @@ SLPM-66807:
     wildArmsHack: 1 # Reduces blooming misalignment.
     autoFlush: 2 # Fixes glows.
 SLPM-66808:
-  name: "Tom Clancy's Ghost Recon - Advanced Warfighter [Ubisoft the Best]"
+  name: ユービーアイソフトベスト ゴーストリコン アドバンスウォーファイター
+  name-sort: ゆーびーあいそふとべすと ごーすとりこん あどばんすうぉーふぁいたー
+  name-en: "Tom Clancy's Ghost Recon - Advanced Warfighter [Ubisoft the Best]"
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes  building and ground colours.
     mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
     trilinearFiltering: 1
 SLPM-66809:
-  name: "Saishu Shiken Kujira - Alive"
+  name: 最終試験くじら−Alive−
+  name-sort: さいしゅうしけんくじら-Alive-
+  name-en: "Saishu Shiken Kujira - Alive"
   region: "NTSC-J"
 SLPM-66810:
-  name: "J.League Winning Eleven 2007 Club Championship"
+  name: J.League Winning Eleven 2007 CLUB CHAMPIONSHIP
+  name-sort: J.League Winning Eleven 2007 CLUB CHAMPIONSHIP
+  name-en: "J.League Winning Eleven 2007 Club Championship"
   region: "NTSC-J"
 SLPM-66811:
-  name: "Winning Post 7 [Koei the Best]"
+  name: KOEI The Best Winning Post 7
+  name-sort: KOEI The Best Winning Post 7
+  name-en: "Winning Post 7 [Koei the Best]"
   region: "NTSC-J"
 SLPM-66812:
-  name: "GI Jockey 4 [Koei the Best]"
+  name: KOEI The Best ジーワンジョッキー4
+  name-sort: KOEI The Best じーわんじょっきー4
+  name-en: "GI Jockey 4 [Koei the Best]"
   region: "NTSC-J"
 SLPM-66813:
-  name: "Sangokushi IX [Koei Selection]"
+  name: コーエー定番シリーズ 三國志IX
+  name-sort: こーえーていばんしりーず さんごくしIX
+  name-en: "Sangokushi IX [Koei Selection]"
   region: "NTSC-J"
 SLPM-66814:
-  name: "Pure x Cure Re-covery"
+  name: Pure×Cure Re:covery
+  name-sort: Pure×Cure Re:covery
+  name-en: "Pure x Cure Re-covery"
   region: "NTSC-J"
 SLPM-66815:
-  name: "Baldr Bullet - Equilibrium"
+  name: バルドバレット イクリブリアム
+  name-sort: ばるどばれっと いくりぶりあむ
+  name-en: "Baldr Bullet - Equilibrium"
   region: "NTSC-J"
 SLPM-66816:
-  name: "Chanter# - Kimi no Uta ga Todoitara"
+  name: Chanter〜キミの歌がとどいたら#〜
+  name-sort: Chanter〜きみのうたがとどいたら#〜
+  name-en: "Chanter# - Kimi no Uta ga Todoitara"
   region: "NTSC-J"
 SLPM-66817:
-  name: "Palais de Reine"
+  name: Palais de Reine
+  name-sort: Palais de Reine
+  name-en: "Palais de Reine"
   region: "NTSC-J"
 SLPM-66818:
-  name: "Quiz & Variety SukuSuku Inufuku 2 - Motto SukuSuku"
+  name: クイズ&バラエティ すくすく犬福2 〜もっとすくすく〜
+  name-sort: くいず&ばらえてぃ すくすくいぬふく2 〜もっとすくすく〜
+  name-en: "Quiz & Variety SukuSuku Inufuku 2 - Motto SukuSuku"
   region: "NTSC-J"
 SLPM-66819:
-  name: "Beat Down - Fists of Vengeance [Best Price]"
+  name: ビートダウン Best Price
+  name-sort: びーとだうん Best Price
+  name-en: "Beat Down - Fists of Vengeance [Best Price]"
   region: "NTSC-J"
 SLPM-66820:
-  name: "Jissen Pachinko Hisshouhou! CR Sakura Taisen"
+  name: 実戦パチンコ必勝法! CRサクラ大戦
+  name-sort: じっせんぱちんこひっしょうほう! CRさくらたいせん
+  name-en: "Jissen Pachinko Hisshouhou! CR Sakura Taisen"
   region: "NTSC-J"
 SLPM-66821:
   name: "Sengoku Musou 2 Mushoden"
   region: "NTSC-J"
 SLPM-66822:
-  name: "GuitarFreaks & DrumMania V3"
+  name: GuitarFreaks & DrumMania V3
+  name-sort: GuitarFreaks & DrumMania V3
+  name-en: "GuitarFreaks & DrumMania V3"
   region: "NTSC-J"
 SLPM-66823:
-  name: "Taka Reet Ura Mahjong Retsuden - Mukoubushi"
+  name: 高レート裏麻雀列伝 むこうぶち 〜御無礼、終了ですね〜
+  name-sort: こうれーとうらまーじゃんれつでん むこうぶち 〜ごぶれい、しゅうりょうですね〜
+  name-en: "Taka Reet Ura Mahjong Retsuden - Mukoubushi"
   region: "NTSC-J"
 SLPM-66824:
-  name: "Hiiro no Kakera 2 [Limited Edition]"
+  name: 翡翠の雫 〜緋色の欠片2〜(限定版)
+  name-sort: ひすいのしずく 〜ひいろのかけら2〜(げんていばん)
+  name-en: "Hiiro no Kakera 2 [Limited Edition]"
   region: "NTSC-J"
 SLPM-66825:
-  name: "Hiiro no Kakera 2"
+  name: 翡翠の雫 〜緋色の欠片2〜
+  name-sort: ひすいのしずく 〜ひいろのかけら2〜
+  name-en: "Hiiro no Kakera 2"
   region: "NTSC-J"
 SLPM-66826:
-  name: "Youki Hime Den [Limited Edition]"
+  name: 妖鬼姫伝 〜あやかし幻灯話〜(限定版)
+  name-sort: ようきひでん 〜あやかしげんとうばなし〜(げんていばん)
+  name-en: "Youki Hime Den [Limited Edition]"
   region: "NTSC-J"
 SLPM-66827:
-  name: "Youki Hime Den"
+  name: 妖鬼姫伝 〜あやかし幻灯話〜(通常版)
+  name-sort: ようきひでん 〜あやかしげんとうばなし〜(つうじょうばん)
+  name-en: "Youki Hime Den"
   region: "NTSC-J"
 SLPM-66828:
-  name: "Beatmania IIDX 13 - DistorteD"
+  name: beatmania IIDX 13 DistorteD
+  name-sort: beatmania IIDX 13 DistorteD
+  name-en: "Beatmania IIDX 13 DistorteD"
   region: "NTSC-J"
 SLPM-66829:
-  name: "Major League Baseball 2K7"
+  name: メジャーリーグベースボール 2K7
+  name-sort: めじゃーりーぐべーすぼーる 2K7
+  name-en: "Major League Baseball 2K7"
   region: "NTSC-J"
 SLPM-66830:
-  name: "Disney's Lewis to Mirai Dorobou"
+  name: ルイスと未来泥棒
+  name-sort: るいすとみらいどろぼう
+  name-en: "Disney's Lewis to Mirai Dorobou"
   region: "NTSC-J"
 SLPM-66832:
   name: "Tennis no Oujisama - Doki Doki Survival - Umibe no Secret"
@@ -39594,13 +44313,19 @@ SLPM-66834:
   name: "Kin'iro no Corda 2 Encore"
   region: "NTSC-J"
 SLPM-66835:
-  name: "Kiniro no Corda 2 Anchor"
+  name: 金色のコルダ2 アンコール(通常版)
+  name-sort: きんいろのこるだ2 あんこーる(つうじょうばん)
+  name-en: "Kiniro no Corda 2 Anchor"
   region: "NTSC-J"
 SLPM-66836:
-  name: "EA Sports Rugby '08"
+  name: EA SPORTS ラグビー08
+  name-sort: EA SPORTS らぐびー08
+  name-en: "EA Sports Rugby '08"
   region: "NTSC-J"
 SLPM-66837:
-  name: "Madden NFL '08"
+  name: マッデン NFL 08
+  name-sort: まっでん NFL 08
+  name-en: "Madden NFL '08"
   region: "NTSC-J"
   clampModes:
     vuClampMode: 3 # Missing geometry with microVU.
@@ -39608,92 +44333,146 @@ SLPM-66837:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
 SLPM-66838:
-  name: "Fantastic Fortune 2 - Triple Star [Best Hit Selection]"
+  name: ファンタスティックフォーチュン2☆☆☆(トリプルスター) BEST HIT セレクション
+  name-sort: ふぁんたすてぃっくふぉーちゅん2☆☆☆(とりぷるすたー) BEST HIT せれくしょん
+  name-en: "Fantastic Fortune 2 - Triple Star [Best Hit Selection]"
   region: "NTSC-J"
 SLPM-66839:
-  name: "We Are [Best Hit Selection]"
+  name: We Are* BEST HIT セレクション
+  name-sort: We Are* BEST HIT せれくしょん
+  name-en: "We Are [Best Hit Selection]"
   region: "NTSC-J"
 SLPM-66840:
-  name: "Mizu no Senritsu 2 [Best Hit Selection]"
+  name: 水の旋律2〜緋の記憶〜 BEST HIT セレクション
+  name-sort: みずのせんりつ2〜ひのきおく〜 BEST HIT せれくしょん
+  name-en: "Mizu no Senritsu 2 [Best Hit Selection]"
   region: "NTSC-J"
 SLPM-66841:
-  name: "Will O' Wisp [Limited Edition]"
+  name: ウィル・オ・ウィスプ 限定版
+  name-sort: うぃる・お・うぃすぷ げんていばん
+  name-en: "Will O' Wisp [Limited Edition]"
   region: "NTSC-J"
 SLPM-66842:
-  name: "Will O' Wisp"
+  name: ウィル・オ・ウィスプ
+  name-sort: うぃる・お・うぃすぷ
+  name-en: "Will O' Wisp"
   region: "NTSC-J"
 SLPM-66843:
-  name: "Generations of Chaos - Desire"
+  name: ジェネレーション オブ カオス ディザイア
+  name-sort: じぇねれーしょん おぶ かおす でぃざいあ
+  name-en: "Generations of Chaos - Desire"
   region: "NTSC-J"
 SLPM-66844:
-  name: "Yuukyuu no Sakura [Limited Edition]"
+  name: 悠久ノ桜(限定版)
+  name-sort: ゆうきゅうのさくら(げんていばん)
+  name-en: "Yuukyuu no Sakura [Limited Edition]"
   region: "NTSC-J"
 SLPM-66845:
-  name: "Yuukyuu no Sakura"
+  name: 悠久ノ桜(通常版)
+  name-sort: ゆうきゅうのさくら(つうじょうばん)
+  name-en: "Yuukyuu no Sakura"
   region: "NTSC-J"
 SLPM-66846:
-  name: "Prism Ark - Awake"
+  name: プリズム・アーク -AWAKE-
+  name-sort: ぷりずむ・あーく -AWAKE-
+  name-en: "Prism Ark - Awake"
   region: "NTSC-J"
 SLPM-66847:
-  name: "Arabians Lost - The Engagement on Desert"
+  name: アラビアンズ・ロスト〜The engagement on desert〜
+  name-sort: あらびあんず・ろすと〜The engagement on desert〜
+  name-en: "Arabians Lost - The Engagement on Desert"
   region: "NTSC-J"
 SLPM-66848:
-  name: "Sengoku Basara 2 Heroes"
+  name: 戦国BASARA2 英雄外伝(HEROES)
+  name-sort: せんごくBASARA2 えいゆうがいでん(HEROES)
+  name-en: "Sengoku Basara 2 Heroes"
   region: "NTSC-J"
 SLPM-66849:
-  name: "Iris no Atelier - Grand Fantasm [Gust Best Price]"
+  name: ガストベストプライス イリスのアトリエ グランファンタズム
+  name-sort: がすとべすとぷらいす いりすのあとりえ ぐらんふぁんたずむ
+  name-en: "Iris no Atelier - Grand Fantasm [Gust Best Price]"
   region: "NTSC-J"
   gsHWFixes:
     roundSprite: 1 # Fixes vertical lines in FMVs, character portraits and other sprites.
 SLPM-66850:
-  name: "Arcana Heart"
+  name: アルカナハート
+  name-sort: あるかなはーと
+  name-en: "Arcana Heart"
   region: "NTSC-J"
   compat: 5
 SLPM-66851:
-  name: "Grand Theft Auto - Liberty City Stories"
+  name: Grand Theft Auto:Liberty City Stories
+  name-sort: Grand Theft Auto:Liberty City Stories
+  name-en: "Grand Theft Auto - Liberty City Stories"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 1 # Removes blur due to misaligned fullscreen effect.
 SLPM-66852:
-  name: "Capcom Classics Collection [Best Price]"
+  name: カプコン クラシックス コレクション Best Price
+  name-sort: かぷこん くらしっくす これくしょん Best Price
+  name-en: "Capcom Classics Collection [Best Price]"
   region: "NTSC-J"
 SLPM-66853:
-  name: "Jojo no Kimyouna Bouken - Ougon no Kaze [Best Price]"
+  name: ジョジョの奇妙な冒険 黄金の旋風 Best Price
+  name-sort: じょじょのきみょうなぼうけん おうごんのせんぷう Best Price
+  name-en: "Jojo no Kimyouna Bouken - Ougon no Kaze [Best Price]"
   region: "NTSC-J"
 SLPM-66854:
-  name: "Street Fighter Zero - Fighters Generation [Best Price]"
+  name: ストリートファイターゼロ ファイターズ ジェネレーション Best Price
+  name-sort: すとりーとふぁいたーぜろ ふぁいたーず じぇねれーしょん Best Price
+  name-en: "Street Fighter Zero - Fighters Generation [Best Price]"
   region: "NTSC-J"
   gsHWFixes:
     roundSprite: 1 # Fixes squares around sprites when upscaling.
 SLPM-66855:
-  name: "Togainu no Chi - True Blood [Limited Edition]"
+  name: 咎狗の血 True Blood Limited Edition
+  name-sort: とがいぬのち True Blood Limited Edition
+  name-en: "Togainu no Chi - True Blood [Limited Edition]"
   region: "NTSC-J"
 SLPM-66856:
-  name: "Togainu no Chi - True Blood"
+  name: 咎狗の血 True Blood
+  name-sort: とがいぬのち True Blood
+  name-en: "Togainu no Chi - True Blood"
   region: "NTSC-J"
 SLPM-66857:
-  name: "Itsuka, Todoku, Ano Sora ni [Limited Edition]"
+  name: いつか、届く、あの空に。 〜陽の道と緋の昏と〜(初回限定版)
+  name-sort: いつか、とどく、あのそらに。 〜ようのみちとひのたそがれと〜(しょかいげんていばん)
+  name-en: "Itsuka, Todoku, Ano Sora ni [Limited Edition]"
   region: "NTSC-J"
 SLPM-66858:
-  name: "Itsuka, Todoku, Ano Sora ni"
+  name: いつか、届く、あの空に。 〜陽の道と緋の昏と〜(通常版)
+  name-sort: いつか、とどく、あのそらに。 〜ようのみちとひのたそがれと〜(つうじょうばん)
+  name-en: "Itsuka, Todoku, Ano Sora ni"
   region: "NTSC-J"
 SLPM-66859:
-  name: "Sengoku Basara [Best Price]"
+  name: 戦国BASARA Best Prise
+  name-sort: せんごくBASARA Best Prise
+  name-en: "Sengoku Basara [Best Price]"
   region: "NTSC-J"
 SLPM-66860:
-  name: "Nettai Teikiatsu Otome [Limited Edition]"
+  name: 熱帯低気圧少女(初回限定版)
+  name-sort: ねったいていきあつしょうじょ(しょかいげんていばん)
+  name-en: "Nettai Teikiatsu Otome [Limited Edition]"
   region: "NTSC-J"
 SLPM-66861:
-  name: "Nettai Teikiatsu Otome"
+  name: 熱帯低気圧少女(通常版)
+  name-sort: ねったいていきあつしょうじょ(つうじょうばん)
+  name-en: "Nettai Teikiatsu Otome"
   region: "NTSC-J"
 SLPM-66862:
-  name: "Ayaka Shibito [Best Selection]"
+  name: あやかしびとー幻妖異聞録ー【BestSelection】
+  name-sort: あやかしびとーげんよういぶんろくー【BestSelection】
+  name-en: "Ayaka Shibito [Best Selection]"
   region: "NTSC-J"
 SLPM-66863:
-  name: "WWE SmackDown vs. RAW 2008"
+  name: WWE2008 SmackDown vs Raw
+  name-sort: WWE2008 SmackDown vs Raw
+  name-en: "WWE SmackDown vs. RAW 2008"
   region: "NTSC-J"
 SLPM-66864:
-  name: "Umisho"
+  name: ウミショー
+  name-sort: うみしょー
+  name-en: "Umisho"
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Reduces misaligned line distortian when in QTE.
@@ -39701,16 +44480,24 @@ SLPM-66865:
   name: "Sengoku Basara 2"
   region: "NTSC-J"
 SLPM-66866:
-  name: "Jissen Pachi-Slot Hisshouhou! Hokuto no Ken 2"
+  name: 実戦パチスロ必勝法! 北斗の拳2 乱世覇王伝 天覇の章
+  name-sort: じっせんぱちすろひっしょうほう! ほくとのけん2 らんせいはおうでん てんはのしょう
+  name-en: "Jissen Pachi-Slot Hisshouhou! Hokuto no Ken 2"
   region: "NTSC-J"
 SLPM-66867:
-  name: "MotoGP '07"
+  name: MotoGP 07
+  name-sort: MotoGP 07
+  name-en: "MotoGP '07"
   region: "NTSC-J"
 SLPM-66868:
-  name: "Tom Clancy's Splinter Cell - Double Agent [Ubisoft the Best]"
+  name: ユービーアイソフトベスト スプリンターセル 二重スパイ
+  name-sort: ゆーびーあいそふとべすと すぷりんたーせる にじゅうすぱい
+  name-en: "Tom Clancy's Splinter Cell - Double Agent [Ubisoft the Best]"
   region: "NTSC-J"
 SLPM-66869:
-  name: "Need for Speed - Carbon [EA Best Hits]"
+  name: EA BEST HITS ニード・フォー・スピード カーボン
+  name-sort: EA BEST HITS にーど・ふぉー・すぴーど かーぼん
+  name-en: "Need for Speed - Carbon [EA Best Hits]"
   region: "NTSC-J"
   clampModes:
     eeClampMode: 3 # Fixes game hang after opening intro.
@@ -39719,41 +44506,65 @@ SLPM-66869:
     halfPixelOffset: 2 # Fixes blurriness.
     roundSprite: 2 # Fixes blurriness.
 SLPM-66870:
-  name: "Kuri no Okurimono [First Print Special Edition]"
+  name: 星色のおくりもの(初回スペシャル限定版)
+  name-sort: ほしいろのおくりもの(しょかいすぺしゃるげんていばん)
+  name-en: "Kuri no Okurimono [First Print Special Edition]"
   region: "NTSC-J"
 SLPM-66871:
-  name: "Shoukan Shoujo - Elemental Girl Calling [DX Pack]"
+  name: 召喚少女-ElementalGirl Calling-(DXパック)
+  name-sort: しょうかんしょうじょ-ElementalGirl Calling-(DXぱっく)
+  name-en: "Shoukan Shoujo - Elemental Girl Calling [DX Pack]"
   region: "NTSC-J"
 SLPM-66872:
-  name: "Shoukan Shoujo - Elemental Girl Calling"
+  name: 召喚少女-ElementalGirl Calling-(通常版)
+  name-sort: しょうかんしょうじょ-ElementalGirl Calling-(つうじょうばん)
+  name-en: "Shoukan Shoujo - Elemental Girl Calling"
   region: "NTSC-J"
   compat: 5
 SLPM-66873:
-  name: "Lucky Star [DX Pack]"
+  name: らき☆すた 〜陵桜学園 桜藤祭〜 DXパック
+  name-sort: らき☆すた 〜りょうおうがくえん おうとうさい〜 DXぱっく
+  name-en: "Lucky Star [DX Pack]"
   region: "NTSC-J"
 SLPM-66874:
-  name: "Lucky Star"
+  name: らき☆すた 〜陵桜学園 桜藤祭〜
+  name-sort: らき☆すた 〜りょうおうがくえん おうとうさい〜
+  name-en: "Lucky Star"
   region: "NTSC-J"
 SLPM-66875:
-  name: "Jikkyou Powerful Major League 2"
+  name: 実況パワフルメジャーリーグ2
+  name-sort: じっきょうぱわふるめじゃーりーぐ2
+  name-en: "Jikkyou Powerful Major League 2"
   region: "NTSC-J"
 SLPM-66876:
-  name: "Izumo 2 [GN Software Best]"
+  name: IZUMO2 -猛き剣の戦記- ベスト版
+  name-sort: IZUMO2 -もうきけんのせんき- べすとばん
+  name-en: "Izumo 2 [GN Software Best]"
   region: "NTSC-J"
 SLPM-66877:
-  name: "_summer ## [GNsoftware Best]"
+  name: _summer## アンダーバーサマーダブルシャープ ベスト版
+  name-sort: _summer## あんだーばーさまーだぶるしゃーぷ べすとばん
+  name-en: "_summer ## [GNsoftware Best]"
   region: "NTSC-J"
 SLPM-66878:
-  name: "Dokapon Kingdom"
+  name: ドカポンキングダム
+  name-sort: どかぽんきんぐだむ
+  name-en: "Dokapon Kingdom"
   region: "NTSC-J"
 SLPM-66879:
-  name: "StarTRain - Your Past Makes Your Future [Limited Edition]"
+  name: StarTRain -your past makes your future-(初回限定版)
+  name-sort: StarTRain -your past makes your future-(しょかいげんていばん)
+  name-en: "StarTRain - Your Past Makes Your Future [Limited Edition]"
   region: "NTSC-J"
 SLPM-66880:
-  name: "StarTRain - Your Past Makes Your Future"
+  name: StarTRain -your past makes your future-(通常版)
+  name-sort: StarTRain -your past makes your future-(つうじょうばん)
+  name-en: "StarTRain - Your Past Makes Your Future"
   region: "NTSC-J"
 SLPM-66881:
-  name: "TOCA Race Driver 3 - The Ultimate Racing Simulator"
+  name: TOCA RACE DRIVER™ 3 THE ULTIMATE RACING SIMULATOR
+  name-sort: TOCA RACE DRIVER™ 3 THE ULTIMATE RACING SIMULATOR
+  name-en: "TOCA Race Driver 3 - The Ultimate Racing Simulator"
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes lighting and vertical lines, also works with normal vertex.
@@ -39763,255 +44574,396 @@ SLPM-66881:
     skipDrawStart: 1 # Removes large black box around player car till we properly emulate it.
     skipDrawEnd: 1 # Removes large black box around player car till we properly emulate it.
 SLPM-66882:
-  name: "Hakarena Heart [Limited Edition]"
+  name: はかれなはーと 〜君がために輝きを〜(限定版・サントラボイスCD付)
+  name-sort: はかれなはーと 〜きみがためにかがやきを〜(げんていばん・さんとらぼいすCDづけ)
+  name-en: "Hakarena Heart [Limited Edition]"
   region: "NTSC-J"
 SLPM-66883:
-  name: "Hakarena Heart"
+  name: はかれなはーと 〜君がために輝きを〜
+  name-sort: はかれなはーと 〜きみがためにかがやきを〜
+  name-en: "Hakarena Heart"
   region: "NTSC-J"
 SLPM-66884:
-  name: "NBA Live '08"
+  name: NBA LIVE 08
+  name-sort: NBA LIVE 08
+  name-en: "NBA Live '08"
   region: "NTSC-J"
 SLPM-66885:
-  name: "Winning Eleven 2008"
+  name: ワールドサッカーウイニングイレブン2008
+  name-sort: わーるどさっかーういにんぐいれぶん2008
+  name-en: "Winning Eleven 2008"
   region: "NTSC-J"
 SLPM-66886:
-  name: "Harry Potter and the Order of the Phoenix"
+  name: ハリー・ポッターと不死鳥の騎士団
+  name-sort: はりー・ぽったーとふしちょうのきしだん
+  name-en: "Harry Potter and the Order of the Phoenix"
   region: "NTSC-J"
   gsHWFixes:
     mipmap: 1
     halfPixelOffset: 1 # Fixes ghosting.
     alignSprite: 1 # Fixes vertical lines.
 SLPM-66887:
-  name: "Harukanaru Jikuu no Kade 3 - Unmei no Meikyuu [Koei the Best]"
+  name: KOEI The Best 遙かなる時空の中で3 運命の迷宮
+  name-sort: KOEI The Best はるかなるときのなかで3 うんめいのめいきゅう
+  name-en: "Harukanaru Jikuu no Kade 3 - Unmei no Meikyuu [Koei the Best]"
   region: "NTSC-J"
 SLPM-66888:
-  name: "GI Jockey 4 - 2007"
+  name: ジーワン ジョッキー4 2007
+  name-sort: じーわん じょっきー4 2007
+  name-en: "GI Jockey 4 - 2007"
   region: "NTSC-J"
 SLPM-66889:
-  name: "Puri-Saga! Princess o Sagase! [Limited Edition]"
+  name: ぷりサガ〜プリンセスをさがせ〜 初回限定版
+  name-sort: ぷりさが〜ぷりんせすをさがせ〜 しょかいげんていばん
+  name-en: "Puri-Saga! Princess o Sagase! [Limited Edition]"
   region: "NTSC-J"
 SLPM-66890:
-  name: "Puri-Saga! Princess o Sagase!"
+  name: ぷりサガ〜プリンセスをさがせ〜
+  name-sort: ぷりさが〜ぷりんせすをさがせ〜
+  name-en: "Puri-Saga! Princess o Sagase!"
   region: "NTSC-J"
 SLPM-66891:
-  name: "Myself, Yourself [Limited Edition]"
+  name: Myself;Yourself(初回限定版)
+  name-sort: Myself;Yourself(しょかいげんていばん)
+  name-en: "Myself, Yourself [Limited Edition]"
   region: "NTSC-J"
 SLPM-66892:
-  name: "Myself, Yourself"
+  name: Myself;Yourself
+  name-sort: Myself;Yourself
+  name-en: "Myself, Yourself"
   region: "NTSC-J"
 SLPM-66893:
-  name: "Final Fantasy XI - Vana'diel Collection"
+  name: PlayOnline/FINAL FANTASY XI ヴァナ・ディール コレクション
+  name-sort: PlayOnline/FINAL FANTASY XI ゔぁな・でぃーる これくしょん
+  name-en: "Final Fantasy XI - Vana'diel Collection"
   region: "NTSC-J"
 SLPM-66894:
-  name: "Final Fantasy XI - Wings of the Goddess"
+  name: FINAL FANTASY XI アルタナの神兵 拡張データディスク
+  name-sort: FINAL FANTASY XI あるたなのかみへい かくちょうでーたでぃすく
+  name-en: "Final Fantasy XI - Wings of the Goddess"
   region: "NTSC-J"
 SLPM-66895:
-  name: "Manea Sugoroku - Kabukuro"
+  name: マネーすごろく カブコロ
+  name-sort: まねーすごろく かぶころ
+  name-en: "Manea Sugoroku - Kabukuro"
   region: "NTSC-J"
 SLPM-66896:
-  name: "Pia Carrot e Youkoso!! G.O. Summer Fair"
+  name: Piaキャロットへようこそ！！G.O. 〜サマーフェア〜
+  name-sort: Piaきゃろっとへようこそ！！G.O. 〜さまーふぇあ〜
+  name-en: "Pia Carrot e Youkoso!! G.O. Summer Fair"
   region: "NTSC-J"
 SLPM-66897:
-  name: "Tales of the Abyss"
+  name: XYANIDE：ザイナイド
+  name-sort: XYANIDE：ざいないど
+  name-en: "Tales of the Abyss"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
     autoFlush: 2 # Fixes post lighting.
 SLPM-66898:
-  name: "Spectral Gene [Limited Edition]"
+  name: スペクトラルジーン(限定版)
+  name-sort: すぺくとらるじーん(げんていばん)
+  name-en: "Spectral Gene [Limited Edition]"
   region: "NTSC-J"
 SLPM-66899:
-  name: "Spectral Gene"
+  name: スペクトラルジーン
+  name-sort: すぺくとらるじーん
+  name-en: "Spectral Gene"
   region: "NTSC-J"
 SLPM-66900:
-  name: "Kuri no Okurimono"
+  name: 星色のおくりもの
+  name-sort: ほししょくのおくりもの
+  name-en: "Kuri no Okurimono"
   region: "NTSC-J"
 SLPM-66901:
-  name: "12Riven - The Psi-Climinal of Integral"
+  name: 12RIVEN - the Ψcliminal of integral -
+  name-en: "12Riven - The Psi-Climinal of Integral"
   region: "NTSC-J"
 SLPM-66902:
-  name: "Disney Princess - Enchanted Journey"
+  name: ディズニープリンセス 魔法の世界へ
+  name-sort: でぃずにーぷりんせす まほうのせかいへ
+  name-en: "Disney Princess - Enchanted Journey"
   region: "NTSC-J"
 SLPM-66903:
-  name: "GI Jockey 4 - 2007 [with Winning Post 7 Maximum 2007 - Premium Pack]"
+  name: ジーワン ジョッキー4 2007 & Winning Post7 2007 プレミアムパック
+  name-sort: じーわん じょっきー4 2007 & Winning Post7 2007 ぷれみあむぱっく
+  name-en: "GI Jockey 4 - 2007 [with Winning Post 7 Maximum 2007 - Premium Pack]"
   region: "NTSC-J"
 SLPM-66904:
   name: "Winning Post 7 Maximum 2007 [with GI Jockey 4 - 2007 - Premium Pack]"
   region: "NTSC-J"
 SLPM-66905:
-  name: "D.C. Da Capo The Origin"
+  name: D.C. 〜ダ・カーポ〜 the Origin
+  name-sort: D.C. 〜だ・かーぽ〜 the Origin
+  name-en: "D.C. Da Capo The Origin"
   region: "NTSC-J"
   gsHWFixes:
     roundSprite: 2 # Reduces sprite artifacts like in the menu.
 SLPM-66906:
-  name: "Tenshou Gakuen Gekkouroku [Tokudane Price]"
+  name: アスミック得だねシリーズ　転生學園月光録
+  name-sort: あすみっくとくだねしりーず　てんしょうがくえんげっこうろく
+  name-en: "Tenshou Gakuen Gekkouroku [Tokudane Price]"
   region: "NTSC-J"
 SLPM-66907:
-  name: "Iinazuke [Princess Soft Collection]"
+  name: 許婚【プリンセスソフト・コレクション】
+  name-sort: きょこん【ぷりんせすそふと・これくしょん】
+  name-en: "Iinazuke [Princess Soft Collection]"
   region: "NTSC-J"
 SLPM-66908:
-  name: "Izumo 2 - Gakuen Kyousoukyoku - Double Tact"
+  name: IZUMO2 学園狂想曲 ダブルタクト
+  name-sort: IZUMO2 がくえんきょうそうきょく だぶるたくと
+  name-en: "Izumo 2 - Gakuen Kyousoukyoku - Double Tact"
   region: "NTSC-J"
 SLPM-66909:
-  name: "Shinkyoku Soukai Polyphonica 3&4 Hanashi Kanketsuhen"
+  name: 神曲奏界ポリフォニカ　３＆４話完結編
+  name-sort: しんきょくそうかいぽりふぉにか　３＆４わかんけつへん
+  name-en: "Shinkyoku Soukai Polyphonica 3&4 Hanashi Kanketsuhen"
   region: "NTSC-J"
 SLPM-66910:
-  name: "Stuntman - Ignition"
+  name: スタントマン:イグニッション
+  name-sort: すたんとまん:いぐにっしょん
+  name-en: "Stuntman - Ignition"
   region: "NTSC-J"
   gameFixes:
     - VIFFIFOHack
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misalignment.
 SLPM-66911:
-  name: "Finalist [Princess Soft Collection]"
+  name: ふぁいなりすと【プリンセスソフト・コレクション】
+  name-sort: ふぁいなりすと【ぷりんせすそふと・これくしょん】
+  name-en: "Finalist [Princess Soft Collection]"
   region: "NTSC-J"
 SLPM-66912:
-  name: "Higurashi no Naku Koro ni Matsuri - Kakera Asobi [Append Version]"
+  name: ひぐらしのなく頃に祭　カケラ遊び　アペンド版
+  name-sort: ひぐらしのなくころにまつり　かけらあそび　あぺんどばん
+  name-en: "Higurashi no Naku Koro ni Matsuri - Kakera Asobi [Append Version]"
   region: "NTSC-J"
 SLPM-66913:
-  name: "Higurashi no Naku Koro ni Matsuri - Kakera Asobi"
+  name: ひぐらしのなく頃に祭　カケラ遊び
+  name-sort: ひぐらしのなくころにまつり　かけらあそび
+  name-en: "Higurashi no Naku Koro ni Matsuri - Kakera Asobi"
   region: "NTSC-J"
 SLPM-66914:
-  name: "Houkago wa Hakugin no Shirabe"
+  name: 放課後は白銀の調べ
+  name-sort: ほうかごははくぎんのしらべ
+  name-en: "Houkago wa Hakugin no Shirabe"
   region: "NTSC-J"
 SLPM-66915:
-  name: "Yu-Gi-Oh Duel Monsters GX - Tag Force Evolution"
+  name: 遊戯王GX タッグフォース エヴォリューション
+  name-sort: ゆうぎおうGX たっぐふぉーす えゔぉりゅーしょん
+  name-en: "Yu-Gi-Oh Duel Monsters GX - Tag Force Evolution"
   region: "NTSC-J"
 SLPM-66916:
-  name: "Jikkyou Powerful Pro Yakyuu 14 Ketteiban"
+  name: 実況パワフルプロ野球14決定版
+  name-sort: じっきょうぱわふるぷろやきゅう14けっていばん
+  name-en: "Jikkyou Powerful Pro Yakyuu 14 Ketteiban"
   region: "NTSC-J"
 SLPM-66917:
-  name: "Grand Theft Auto - Vice City Stories"
+  name: Grand Theft Auto:Vice City Stories
+  name-sort: Grand Theft Auto:Vice City Stories
+  name-en: "Grand Theft Auto - Vice City Stories"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned effect when in-game Trails option is turned on.
 SLPM-66918:
-  name: "Princess Maker 5"
+  name: プリンセスメーカー5
+  name-sort: ぷりんせすめーかー5
+  name-en: "Princess Maker 5"
   region: "NTSC-J"
 SLPM-66919:
-  name: "Kyuuketsu Kitan Moonties"
+  name: 吸血奇譚 ムーンタイズ
+  name-sort: きゅうけつきたん むーんたいず
+  name-en: "Kyuuketsu Kitan Moonties"
   region: "NTSC-J"
   gsHWFixes:
     beforeDraw: "OI_PointListPalette"
 SLPM-66920:
-  name: "Hoshi Furu"
+  name: ほしフル〜星の降る街〜
+  name-sort: ほしふる〜ほしのふるまち〜
+  name-en: "Hoshi Furu"
   region: "NTSC-J"
 SLPM-66921:
-  name: "H2O"
+  name: H2Oプラス
+  name-sort: H2Oぷらす
+  name-en: "H2O"
   region: "NTSC-J"
 SLPM-66922:
-  name: "D.C.II P.S. - Da Capo II - Plus Situation [DX Pack]"
+  name: D.C.II P.S. 〜ダ・カーポII〜 プラスシチュエーション DXパック
+  name-sort: D.C.II P.S. 〜だ・かーぽII〜 ぷらすしちゅえーしょん DXぱっく
+  name-en: "D.C.II P.S. - Da Capo II - Plus Situation [DX Pack]"
   region: "NTSC-J"
 SLPM-66923:
   name: "D.C.II P.S. - Da Capo II - Plus Situation [Disc 2] [DX Pack]"
   region: "NTSC-J"
 SLPM-66924:
-  name: "D.C.II P.S. - Da Capo II - Plus Situation"
+  name: D.C.II P.S. 〜ダ・カーポII〜 プラスシチュエーション
+  name-sort: D.C.II P.S. 〜だ・かーぽII〜 ぷらすしちゅえーしょん
+  name-en: "D.C.II P.S. - Da Capo II - Plus Situation"
   region: "NTSC-J"
 SLPM-66925:
   name: "D.C.II P.S. - Da Capo II - Plus Situation (Disc 2)"
   region: "NTSC-J"
 SLPM-66926:
-  name: "NiGHTS into Dreams..."
+  name: NiGHTS into Dreams...
+  name-sort: NiGHTS into Dreams...
+  name-en: "NiGHTS into Dreams..."
   region: "NTSC-J"
   compat: 5
 SLPM-66927:
-  name: "Wrestle Angels Survivor [Good Price]"
+  name: レッスルエンジェルス SURVIVOR Good Price
+  name-sort: れっするえんじぇるす SURVIVOR Good Price
+  name-en: "Wrestle Angels Survivor [Good Price]"
   region: "NTSC-J"
 SLPM-66928:
   name: "Your Memories Off Girls Style"
   region: "NTSC-J"
 SLPM-66929:
-  name: "Elminage - Yami no Fujo to Kamigami no Yubiwa"
+  name: エルミナージュ 〜闇の巫女と神々の指輪〜
+  name-sort: えるみなーじゅ 〜やみのみことかみ々のゆびわ〜
+  name-en: "Elminage - Yami no Fujo to Kamigami no Yubiwa"
   region: "NTSC-J"
 SLPM-66930:
   name: "Dance Dance Revolution SuperNOVA 2"
   region: "NTSC-J"
 SLPM-66931:
-  name: "Juiced 2 - Hot Import Nights"
+  name: ドリフトナイツ:Juiced2
+  name-sort: どりふとないつ:Juiced2
+  name-en: "Juiced 2 - Hot Import Nights"
   region: "NTSC-J"
 SLPM-66932:
-  name: "Need for Speed - ProStreet"
+  name: ニード・フォー・スピード　プロストリート
+  name-sort: にーど・ふぉー・すぴーど　ぷろすとりーと
+  name-en: "Need for Speed - ProStreet"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth line.
 SLPM-66933:
-  name: "Kimi ga Aruji de Shitsuji ga Ore de - Oshie Nikki [Limited Edition]"
+  name: 君が主で執事が俺で〜お仕え日記〜 初回限定版
+  name-sort: きみがおもでしつじがおれで〜おつかえにっき〜 しょかいげんていばん
+  name-en: "Kimi ga Aruji de Shitsuji ga Ore de - Oshie Nikki [Limited Edition]"
   region: "NTSC-J"
 SLPM-66934:
-  name: "Kimi ga Aruji de Shitsuji ga Ore de - Oshie Nikki"
+  name: 君が主で執事が俺で〜お仕え日記〜
+  name-sort: きみがおもでしつじがおれで〜おつかえにっき〜
+  name-en: "Kimi ga Aruji de Shitsuji ga Ore de - Oshie Nikki"
   region: "NTSC-J"
 SLPM-66935:
-  name: "True Tears"
+  name: true tears〜トゥルーティアーズ〜
+  name-sort: true tears〜とぅるーてぃあーず〜
+  name-en: "True Tears"
   region: "NTSC-J"
 SLPM-66936:
-  name: "Night Wizard - The Video Game - Denial of the World"
+  name: ナイトウィザード The VIDEO GAME 〜Denial of the World〜
+  name-sort: ないとうぃざーど The VIDEO GAME 〜Denial of the World〜
+  name-en: "Night Wizard - The Video Game - Denial of the World"
   region: "NTSC-J"
 SLPM-66937:
-  name: "Jan Sangoku Musou [Koei the Best]"
+  name: KOEI The Best 雀・三國無双
+  name-sort: KOEI The Best じゃん・さんごくむそう
+  name-en: "Jan Sangoku Musou [Koei the Best]"
   region: "NTSC-J"
 SLPM-66938:
-  name: "Angelique Etoile [Koei Selection]"
+  name: コーエー定番シリーズ アンジェリークエトワール
+  name-sort: こーえーていばんしりーず あんじぇりーくえとわーる
+  name-en: "Angelique Etoile [Koei Selection]"
   region: "NTSC-J"
 SLPM-66939:
-  name: "Boukoku no Aegis 2035 - Warship Gunner [Koei Selection]"
+  name: コーエー定番シリーズ 亡国のイージス2035　〜ウォーシップガンナー〜
+  name-sort: こーえーていばんしりーず ぼうこくのいーじす2035　〜うぉーしっぷがんなー〜
+  name-en: "Boukoku no Aegis 2035 - Warship Gunner [Koei Selection]"
   region: "NTSC-J"
 SLPM-66940:
-  name: "Gundam Musou Special"
+  name: ガンダム無双Special
+  name-sort: がんだむむそうSpecial
+  name-en: "Gundam Musou Special"
   region: "NTSC-J"
 SLPM-66941:
-  name: "Hokuto no Ken [Sega the Best]"
+  name: 北斗の拳 審判の双蒼星 拳豪列伝 SEGA THE BEST
+  name-sort: ほくとのけん しんぱんのそうそうせい けんごうれつでん SEGA THE BEST
+  name-en: "Hokuto no Ken [Sega the Best]"
   region: "NTSC-J"
 SLPM-66942:
-  name: "Final Approach 2 - 1st Priority [First Print Limited Edition]"
+  name: Φ(ふぁい)なる・あぷろーち 2 〜1st priority〜 ＜初回限定版＞
+  name-sort: ふぁいなる・あぷろーち 2 〜1st priority〜 ＜しょかいげんていばん＞
+  name-en: "Final Approach 2 - 1st Priority [First Print Limited Edition]"
   region: "NTSC-J"
 SLPM-66943:
-  name: "Final Approach 2 - 1st Priority"
+  name: Φ(ふぁい)なる・あぷろーち 2 〜1st priority〜
+  name-sort: ふぁいなる・あぷろーち 2 〜1st priority〜
+  name-en: "Final Approach 2 - 1st Priority"
   region: "NTSC-J"
 SLPM-66944:
-  name: "Petit Four [Limited Edition]"
+  name: プティフール 限定版
+  name-sort: ぷてぃふーる げんていばん
+  name-en: "Petit Four [Limited Edition]"
   region: "NTSC-J"
 SLPM-66945:
-  name: "Petit Four"
+  name: プティフール
+  name-sort: ぷてぃふーる
+  name-en: "Petit Four"
   region: "NTSC-J"
 SLPM-66946:
-  name: "NBA Live '07 [EA Best Hits]"
+  name: EA BEST HITS NBAライブ 07
+  name-sort: EA BEST HITS NBAらいぶ 07
+  name-en: "NBA Live '07 [EA Best Hits]"
   region: "NTSC-J"
 SLPM-66947:
-  name: "Nobunaga no Yabou - Kakushin [with Power-Up Kit]"
+  name: 信長の野望・革新 with パワーアップキット
+  name-sort: のぶながのやぼう・かくしん with ぱわーあっぷきっと
+  name-en: "Nobunaga no Yabou - Kakushin [with Power-Up Kit]"
   region: "NTSC-J"
 SLPM-66948:
-  name: "Nobunaga no Yabou - Kakushin [with Power-Up Kit and Sangokushi XI]"
+  name: 信長の野望・革新 with パワーアップキット ＆ 三國志11 with パワーアップキット ツインパック
+  name-sort: のぶながのやぼう・かくしん with ぱわーあっぷきっと ＆ さんごくし11 with ぱわーあっぷきっと ついんぱっく
+  name-en: "Nobunaga no Yabou - Kakushin [with Power-Up Kit and Sangokushi XI]"
   region: "NTSC-J"
 SLPM-66950:
-  name: "Winning Post 7 Maximum 2008"
+  name: ウイニングポスト７ マキシマム2008
+  name-sort: ういにんぐぽすとなな まきしまむ2008
+  name-en: "Winning Post 7 Maximum 2008"
   region: "NTSC-J"
 SLPM-66951:
   name: "Harukanaru Toki no Naka de 4"
   region: "NTSC-J"
 SLPM-66952:
-  name: "Harukanaru Jikuu no Kade 4"
+  name: 遙かなる時空の中で4
+  name-sort: はるかなるときのなかで4
+  name-en: "Harukanaru Jikuu no Kade 4"
   region: "NTSC-J"
 SLPM-66953:
-  name: "Musou Orochi - Maou Sairin"
+  name: 無双OROCHI 魔王再臨
+  name-sort: むそうOROCHI まおうさいりん
+  name-en: "Musou Orochi - Maou Sairin"
   region: "NTSC-J"
 SLPM-66954:
-  name: "Nobunaga no Yabou - Online - Souha no Shou"
+  name: 信長の野望 Online 争覇の章
+  name-sort: のぶながのやぼう Online そうはのしょう
+  name-en: "Nobunaga no Yabou - Online - Souha no Shou"
   region: "NTSC-J"
 SLPM-66956:
-  name: "Neo Angelique - Full Voice"
+  name: ネオ アンジェリーク フルボイス
+  name-sort: ねお あんじぇりーく ふるぼいす
+  name-en: "Neo Angelique - Full Voice"
   region: "NTSC-J"
 SLPM-66957:
-  name: "Neon Genesis Evangelion - Battle Orchestra [Broccoli Best Quality]"
+  name: Broccoli Best Quality 新世紀エヴァンゲリオン バトルオーケストラ
+  name-sort: Broccoli Best Quality しんせいきえゔぁんげりおん ばとるおーけすとら
+  name-en: "Neon Genesis Evangelion - Battle Orchestra [Broccoli Best Quality]"
   region: "NTSC-J"
 SLPM-66958:
-  name: "Aoi Shiro [Genteiban]"
+  name: アオイシロ 初回限定版
+  name-sort: あおいしろ しょかいげんていばん
+  name-en: "Aoi Shiro [Genteiban]"
   region: "NTSC-J"
 SLPM-66959:
-  name: "Aoishiro"
+  name: アオイシロ
+  name-sort: あおいしろ
+  name-en: "Aoishiro"
   region: "NTSC-J"
 SLPM-66960:
-  name: "Need for Speed - Underground 2 [EA-SY! 1980]"
+  name: EA:SY!1980 ニード・フォー・スピード アンダーグラウンド 2 車道
+  name-sort: EA:SY!1980 にーど・ふぉー・すぴーど あんだーぐらうんど 2 しゃどう
+  name-en: "Need for Speed - Underground 2 [EA-SY! 1980]"
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves reflection quality and map opacity.
@@ -40019,7 +44971,9 @@ SLPM-66960:
   gameFixes:
     - SoftwareRendererFMVHack # Workaround for strange HPO Normal screen shake.
 SLPM-66961:
-  name: "Black [EA-SY! 1980]"
+  name: EA:SY!1980 BLACK
+  name-sort: EA:SY!1980 BLACK
+  name-en: "Black [EA-SY! 1980]"
   region: "NTSC-J"
   clampModes:
     vuClampMode: 3 # Fixes SPS.
@@ -40032,7 +44986,9 @@ SLPM-66961:
     getSkipCount: "GSC_BlackAndBurnoutSky"
     beforeDraw: "OI_BurnoutGames"
 SLPM-66962:
-  name: "Burnout 3 - Takedown [EA-SY! 1980]"
+  name: EA:SY!1980 バーンアウト 3 テイクダウン
+  name-sort: EA:SY!1980 ばーんあうと 3 ていくだうん
+  name-en: "Burnout 3 - Takedown [EA-SY! 1980]"
   region: "NTSC-J"
   clampModes:
     vuClampMode: 3 # Fixes buggy lighting in the garage.
@@ -40047,17 +45003,25 @@ SLPM-66962:
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
 SLPM-66963:
-  name: "Medal of Honor - Frontline [EA-SY! 1980]"
+  name: EA:SY!1980 MEDAL OF HONOR 史上最大の作戦
+  name-sort: EA:SY!1980 MEDAL OF HONOR しじょうさいだいのさくせん
+  name-en: "Medal of Honor - Frontline [EA-SY! 1980]"
   region: "NTSC-J"
 SLPM-66964:
-  name: "Guilty Gear XX - Accent Core Plus [Append Edition]"
+  name: GUILTY GEAR XX Λ CORE PLUS アペンド版
+  name-sort: GUILTY GEAR XX Λ CORE PLUS あぺんどばん
+  name-en: "Guilty Gear XX - Accent Core Plus [Append Edition]"
   region: "NTSC-J"
 SLPM-66965:
-  name: "Guilty Gear XX - Accent Core Plus"
+  name: GUILTY GEAR XX Λ CORE PLUS
+  name-sort: GUILTY GEAR XX Λ CORE PLUS
+  name-en: "Guilty Gear XX - Accent Core Plus"
   region: "NTSC-J"
   compat: 5
 SLPM-66966:
-  name: "Godfather, The [EA-SY! 1980]"
+  name: EA:SY!1980 ゴッドファーザー
+  name-sort: EA:SY!1980 ごっどふぁーざー
+  name-en: "Godfather, The [EA-SY! 1980]"
   region: "NTSC-J"
   gsHWFixes:
     mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
@@ -40065,28 +45029,44 @@ SLPM-66966:
     textureInsideRT: 1 # Required for complex offset shuffles.
     halfPixelOffset: 2 # Fixes center line in post processing.
 SLPM-66967:
-  name: "Aria - The Natural - Tooi Yume no Mirage [Alchemist Best Collection]"
+  name: ARIA the NATURAL 〜遠い記憶のミラージュ〜 アルケベスト
+  name-sort: ARIA the NATURAL 〜とおいきおくのみらーじゅ〜 あるけべすと
+  name-en: "Aria - The Natural - Tooi Yume no Mirage [Alchemist Best Collection]"
   region: "NTSC-J"
 SLPM-66968:
-  name: "Kamiwaza [Acquire the Best]"
+  name: ACQUIRE THE BEST 神業
+  name-sort: ACQUIRE THE BEST かみわざ
+  name-en: "Kamiwaza [Acquire the Best]"
   region: "NTSC-J"
 SLPM-66969:
-  name: "Hoshigari Empusa"
+  name: ほしがりエンプーサ
+  name-sort: ほしがりえんぷーさ
+  name-en: "Hoshigari Empusa"
   region: "NTSC-J"
 SLPM-66970:
-  name: "Pro Yakyuu Spirits 5"
+  name: プロ野球スピリッツ５
+  name-sort: ぷろやきゅうすぴりっつご
+  name-en: "Pro Yakyuu Spirits 5"
   region: "NTSC-J"
 SLPM-66971:
-  name: "Sangokushi IX [with Power-Up Kit] [Koei Selection]"
+  name: コーエー定番シリーズ 三國志IX with パワーアップキット
+  name-sort: こーえーていばんしりーず さんごくしIX with ぱわーあっぷきっと
+  name-en: "Sangokushi IX [with Power-Up Kit] [Koei Selection]"
   region: "NTSC-J"
 SLPM-66972:
-  name: "Kurogane no Houkou 2 - Warship Commander [Koei Selection]"
+  name: コーエー定番シリーズ 鋼鉄の咆哮2 ウォーシップコマンダー
+  name-sort: こーえーていばんしりーず くろがねのほうこう2 うぉーしっぷこまんだー
+  name-en: "Kurogane no Houkou 2 - Warship Commander [Koei Selection]"
   region: "NTSC-J"
 SLPM-66973:
-  name: "Princess Nightmare"
+  name: プリンセスナイトメア
+  name-sort: ぷりんせすないとめあ
+  name-en: "Princess Nightmare"
   region: "NTSC-J"
 SLPM-66974:
-  name: "Slotter Up Core 10 - Mach GoGoGo"
+  name: スロッターUPコア10 マッハGoGoGo 2
+  name-sort: すろったーUPこあ10 まっはGoGoGo 2
+  name-en: "Slotter Up Core 10 - Mach GoGoGo"
   region: "NTSC-J"
 SLPM-66975:
   name: "Edel Blume [Genteiban]"
@@ -40095,10 +45075,14 @@ SLPM-66976:
   name: "Edel Blume"
   region: "NTSC-J"
 SLPM-66977:
-  name: "Shinkyoku Soukai Polyphonica 0-4 Hanashi Full Pack"
+  name: 神曲奏界ポリフォニカ 0〜4話フルパック
+  name-sort: しんきょくそうかいぽりふぉにか 0〜4わふるぱっく
+  name-en: "Shinkyoku Soukai Polyphonica 0-4 Hanashi Full Pack"
   region: "NTSC-J"
 SLPM-66978:
-  name: "Persona 4 [Konami-style Special Edition]"
+  name: ペルソナ4
+  name-sort: ぺるそな4
+  name-en: "Persona 4 [Konami-style Special Edition]"
   region: "NTSC-J"
   compat: 5
 SLPM-66980:
@@ -40114,30 +45098,44 @@ SLPM-66984:
   name: "Gakuen Heaven - Boy's Love Scramble!"
   region: "NTSC-J"
 SLPM-66987:
-  name: "Kowloon Youma Gakuen Ki [Best Version]"
+  name: 九龍妖魔学園紀 再装填(re:charge) アトラスベストコレクション
+  name-sort: くうろんようまがくえんき さいそうてん(re:charge) あとらすべすとこれくしょん
+  name-en: "Kowloon Youma Gakuen Ki [Best Version]"
   region: "NTSC-J"
 SLPM-66988:
   name: "Memories Off 6 - T-Wave"
   region: "NTSC-J"
 SLPM-66989:
-  name: "Castle Fantasia - Arihato Senki [Best Version]"
+  name: キャッスルファンタジア アリハト戦記 ベスト版
+  name-sort: きゃっするふぁんたじあ ありはとせんき べすとばん
+  name-en: "Castle Fantasia - Arihato Senki [Best Version]"
   region: "NTSC-J"
 SLPM-66990:
-  name: "Majo-musume A La Mode II [Best Version]"
+  name: 魔女っ娘ア・ラ・モードII 〜魔法と剣のストラグル〜 ベスト版
+  name-sort: まじょっこあ・ら・もーどII 〜まほうとけんのすとらぐる〜 べすとばん
+  name-en: "Majo-musume A La Mode II [Best Version]"
   region: "NTSC-J"
   gsHWFixes:
     beforeDraw: "OI_PointListPalette"
 SLPM-66991:
-  name: "Fuuuraiki [Best Version]"
+  name: 風雨来記 nice price！
+  name-sort: ふううらいき nice price！
+  name-en: "Fuuuraiki [Best Version]"
   region: "NTSC-J"
 SLPM-66992:
-  name: "Fuuuraiki 2 [Best Version]"
+  name: 風雨来記２ nice price！
+  name-sort: ふううらいきに nice price！
+  name-en: "Fuuuraiki 2 [Best Version]"
   region: "NTSC-J"
 SLPM-66993:
-  name: "Rim Runners [Best Version]"
+  name: リムランナーズ nice price！
+  name-sort: りむらんなーず nice price！
+  name-en: "Rim Runners [Best Version]"
   region: "NTSC-J"
 SLPM-66994:
-  name: "Mana-Khemia - Gakuen no Renkinjutsu Shitachi [Best Version]"
+  name: ガストベストプライス マナケミア 〜学園の錬金術士たち〜
+  name-sort: がすとべすとぷらいす まなけみあ 〜がくえんのれんきんじゅつしたち〜
+  name-en: "Mana-Khemia - Gakuen no Renkinjutsu Shitachi [Best Version]"
   region: "NTSC-J"
   roundModes:
     eeRoundMode: 0 # Fixes jump issue.
@@ -40148,25 +45146,37 @@ SLPM-66995:
   name: "Beatmania IIDX 14 - Gold"
   region: "NTSC-J"
 SLPM-66996:
-  name: "Shuumatsu Otome Gensou Alicematic Apocalypse [Limited Edition]"
+  name: 終末少女幻想アリスマチック 〜Apocalypse〜 初回限定版
+  name-sort: しゅうまつしょうじょげんそうありすまちっく 〜Apocalypse〜 しょかいげんていばん
+  name-en: "Shuumatsu Otome Gensou Alicematic Apocalypse [Limited Edition]"
   region: "NTSC-J"
 SLPM-66997:
-  name: "Shuumatsu Otome Gensou Alicematic Apocalypse"
+  name: 終末少女幻想アリスマチック 〜Apocalypse〜
+  name-sort: しゅうまつしょうじょげんそうありすまちっく 〜Apocalypse〜
+  name-en: "Shuumatsu Otome Gensou Alicematic Apocalypse"
   region: "NTSC-J"
 SLPM-66998:
-  name: "Fushigi Yuugi - Suzaku Ibun [Limited Edition]"
+  name: ふしぎ遊戯 朱雀異聞 限定版
+  name-sort: ふしぎゆうぎ すざくいぶん げんていばん
+  name-en: "Fushigi Yuugi - Suzaku Ibun [Limited Edition]"
   region: "NTSC-J"
 SLPM-66999:
-  name: "Fushigi Yuugi - Suzaku Ibun"
+  name: ふしぎ遊戯 朱雀異聞
+  name-sort: ふしぎゆうぎ すざくいぶん
+  name-en: "Fushigi Yuugi - Suzaku Ibun"
   region: "NTSC-J"
 SLPM-67000:
-  name: "Fushigi Yuugi - ShigiYuugi Kurotake Kaiden Gaiden - Kagami no Fujo [IF Collection]"
+  name: IFコレクション ふしぎ遊戯 玄武開伝 外伝 鏡の巫女
+  name-sort: IFこれくしょん ふしぎゆうぎ げんぶひらきでん がいでん きょうのみこ
+  name-en: "Fushigi Yuugi - ShigiYuugi Kurotake Kaiden Gaiden - Kagami no Fujo [IF Collection]"
   region: "NTSC-J"
 SLPM-67001:
   name: "Wonder Zone"
   region: "NTSC-J"
 SLPM-67002:
-  name: "Metal Gear Solid 2 - Substance"
+  name: METAL GEAR SOLID 2 SUBSTANCE
+  name-sort: METAL GEAR SOLID 2 SUBSTANCE
+  name-en: "Metal Gear Solid 2 - Substance"
   region: "NTSC-J"
   gameFixes:
     - InstantDMAHack # Fixes broken half-bottom artifacts.
@@ -40174,27 +45184,39 @@ SLPM-67002:
     roundSprite: 2 # Fixes font artifacts.
     recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
 SLPM-67003:
-  name: "Sakura Taisen - Atsuki Chishioni"
+  name: サクラ大戦 〜熱き血潮に〜
+  name-sort: さくらたいせん 〜あつきちしおに〜
+  name-en: "Sakura Taisen - Atsuki Chishioni"
   region: "NTSC-J"
   compat: 5
 SLPM-67004:
-  name: "Medal of Honor - Rising Sun"
+  name: メダル オブ オナー ライジングサン
+  name-sort: めだる おぶ おなー らいじんぐさん
+  name-en: "Medal of Honor - Rising Sun"
   region: "NTSC-J"
 SLPM-67005:
-  name: "Lord of the Rings, The - The Two Towers [EA Best Hits]"
+  name: ロード・オブ・ザ・リング / 王の帰還
+  name-sort: ろーど・おぶ・ざ・りんぐ / おうのきかん
+  name-en: "Lord of the Rings, The - The Two Towers [EA Best Hits]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misaligned lighting and other effects.
   clampModes:
     vuClampMode: 3 # Fix white shiny weapons.
 SLPM-67006:
-  name: "Train Simulator - Kyushu Shinkansen"
+  name: Train Simulator 九州新幹線
+  name-sort: Train Simulator きゅうしゅうしんかんせん
+  name-en: "Train Simulator - Kyushu Shinkansen"
   region: "NTSC-J"
 SLPM-67007:
-  name: "Train Simulator - Keisei Toei Keikyu"
+  name: Train Simulator 京成・都営浅草・京急線
+  name-sort: Train Simulator けいせい・とえいあさくさ・きょうきゅうせん
+  name-en: "Train Simulator - Keisei Toei Keikyu"
   region: "NTSC-J"
 SLPM-67008:
-  name: "Metal Gear Solid 2 - Substance [Konami Dendou Collection]"
+  name: METAL GEAR SOLID 2 SUBSTANCE コナミ殿堂セレクション
+  name-sort: METAL GEAR SOLID 2 SUBSTANCE こなみでんどうせれくしょん
+  name-en: "Metal Gear Solid 2 - Substance [Konami Dendou Collection]"
   region: "NTSC-J"
   gameFixes:
     - InstantDMAHack # Fixes broken half-bottom artifacts.
@@ -40202,31 +45224,41 @@ SLPM-67008:
     roundSprite: 2 # Fixes font artifacts.
     recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
 SLPM-67009:
-  name: "Sakura Taisen V - Saraba Itoshiki Hito Yo"
+  name: サクラ大戦V 〜さらば愛しき人よ〜
+  name-sort: さくらたいせんV 〜さらばいとしきひとよ〜
+  name-en: "Sakura Taisen V - Saraba Itoshiki Hito Yo"
   region: "NTSC-J"
 SLPM-67010:
-  name: "God of War"
+  name: ゴッド・オブ・ウォー
+  name-sort: ごっど・おぶ・うぉー
+  name-en: "God of War"
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes water vertical lines.
     roundSprite: 1 # Fixes vertical lines and minor ghosting.
     autoFlush: 1 # Fixes sun going through walls.
 SLPM-67011:
-  name: "God of War [CapKore]"
+  name: ゴッド・オブ・ウォー カプコレ
+  name-sort: ごっど・おぶ・うぉー かぷこれ
+  name-en: "God of War [CapKore]"
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes water vertical lines.
     roundSprite: 1 # Fixes vertical lines and minor ghosting.
     autoFlush: 1 # Fixes sun going through walls.
 SLPM-67012:
-  name: "God of War [Best Price]"
+  name: ゴッド・オブ・ウォー Best Price!
+  name-sort: ごっど・おぶ・うぉー Best Price!
+  name-en: "God of War [Best Price]"
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes water vertical lines.
     roundSprite: 1 # Fixes vertical lines and minor ghosting.
     autoFlush: 1 # Fixes sun going through walls.
 SLPM-67013:
-  name: "God of War II - The End Begins"
+  name: ゴッド・オブ・ウォー II 終焉への序曲
+  name-sort: ごっど・おぶ・うぉー II しゅうえんへのじょきょく
+  name-en: "God of War II - The End Begins"
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes water vertical lines.
@@ -40237,7 +45269,9 @@ SLPM-67014:
   name: "Sengoku Musou 2 - Moushouden"
   region: "NTSC-J"
 SLPM-67015:
-  name: "School Days LxH"
+  name: School Days L×H
+  name-sort: School Days L×H
+  name-en: "School Days LxH"
   region: "NTSC-J"
 SLPM-67502:
   name: "Devil May Cry"
@@ -40557,55 +45591,81 @@ SLPM-69006:
   name: "PictureParadise Club Vol. 2"
   region: "NTSC-J"
 SLPM-74001:
-  name: "Gungriffon Blaze [PlayStation 2 The Best]"
+  name: ガングリフォンブレイズ PlayStation 2 the Best
+  name-sort: がんぐりふぉんぶれいず PlayStation 2 the Best
+  name-en: "Gungriffon Blaze [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPM-74002:
-  name: "Shin Sangoku Musou [PlayStation 2 The Best]"
+  name: 真・三國無双 PlayStation 2 the Best
+  name-sort: しん・さんごくむそう PlayStation 2 the Best
+  name-en: "Shin Sangoku Musou [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPM-74003:
-  name: "Crash Bandicoot 4 - Sakuretsu! Majin Power! [PlayStation 2 The Best]"
+  name: クラッシュ・バンディクー4 さくれつ!魔神パワー PlayStation 2 the Best
+  name-sort: くらっしゅ・ばんでぃくー4 さくれつ!まじんぱわー PlayStation 2 the Best
+  name-en: "Crash Bandicoot 4 - Sakuretsu! Majin Power! [PlayStation 2 The Best]"
   region: "NTSC-J"
   gsHWFixes:
     nativePaletteDraw: 1
     autoFlush: 2 # Fixes refraction effect.
 SLPM-74004:
-  name: "Maximo - Ghosts to Glory [PlayStation 2 The Best]"
+  name: マキシモ PlayStation 2 the Best
+  name-sort: まきしも PlayStation 2 the Best
+  name-en: "Maximo - Ghosts to Glory [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPM-74005:
   name: "Romance of the Three Kingdoms VII [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPM-74006:
-  name: "Rez [PlayStation 2 The Best]"
+  name: Rez PlayStation®2 the Best
+  name-sort: Rez PlayStation®2 the Best
+  name-en: "Rez [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPM-74007:
-  name: "Busin - Wizardry Alternative [PlayStation 2 The Best]"
+  name: BUSIN〜Wizardry Alternative〜 PlayStation®2 the Best
+  name-sort: BUSIN〜Wizardry Alternative〜 PlayStation®2 the Best
+  name-en: "Busin - Wizardry Alternative [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPM-74044:
   name: "Space Channel 5 - Part 2 [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPM-74101:
-  name: "Bomberman Land 2 [PlayStation 2 The Best]"
+  name: ボンバーマンランド2 PlayStation®2 the Best
+  name-sort: ぼんばーまんらんど2 PlayStation®2 the Best
+  name-en: "Bomberman Land 2 [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPM-74102:
-  name: "Momotaro Densetsu 12 [PlayStation 2 The Best]"
+  name: 桃太郎電鉄12 西日本編もありまっせー! PlayStation®2 the Best
+  name-sort: ももたろうでんてつ12 にしにほんへんもありまっせー! PlayStation®2 the Best
+  name-en: "Momotaro Densetsu 12 [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPM-74103:
-  name: "Momotaro Dentetsu USA [PlayStation 2 The Best]"
+  name: 桃太郎電鉄USA PlayStation 2 the Best
+  name-sort: ももたろうでんてつUSA PlayStation 2 the Best
+  name-en: "Momotaro Dentetsu USA [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPM-74104:
-  name: "Momotarou Densetsu 15 [PlayStation 2 The Best]"
+  name: 桃太郎電鉄15 PlayStation®2 the Best
+  name-sort: ももたろうでんてつ15 PlayStation®2 the Best
+  name-en: "Momotarou Densetsu 15 [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPM-74105:
   name: "Momotarou Dentetsu 16 - Hokkaido Daiidou no Maki!"
   region: "NTSC-J"
 SLPM-74201:
-  name: "BioHazard Outbreak [PlayStation 2 The Best]"
+  name: バイオハザード アウトブレイク PlayStation®2 the Best
+  name-sort: ばいおはざーど あうとぶれいく PlayStation®2 the Best
+  name-en: "BioHazard Outbreak [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPM-74202:
-  name: "Fuuun Shinsengumi [PlayStation 2 The Best]"
+  name: 風雲 新撰組 PlayStation®2 the Best
+  name-sort: ふううん しんせんぐみ PlayStation®2 the Best
+  name-en: "Fuuun Shinsengumi [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPM-74204:
-  name: "Shutokou Battle 01 [PlayStation 2 The Best]"
+  name: 首都高バトル 01 PlayStation®2 the Best
+  name-sort: しゅとこうばとる 01 PlayStation®2 the Best
+  name-en: "Shutokou Battle 01 [PlayStation 2 The Best]"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
@@ -40613,28 +45673,40 @@ SLPM-74204:
     wildArmsHack: 1 # Improves visual clarity whilst upscaling.
     roundSprite: 1 # Reduces graphics garbage on UI whilst upscaling.
 SLPM-74205:
-  name: "Shin Megami Tensei III - Nocturne [PlayStation 2 The Best]"
+  name: 真・女神転生 III - NOCTURNE PlayStation®2 the Best
+  name-sort: しん・めがみてんせい III - NOCTURNE PlayStation®2 the Best
+  name-en: "Shin Megami Tensei III - Nocturne [PlayStation 2 The Best]"
   region: "NTSC-J"
   roundModes:
     eeRoundMode: 0 # Ladder glitch in "Assembly of Nihilo B11" level.
 SLPM-74206:
-  name: "Onimusha [PlayStation 2 The Best]"
+  name: 鬼武者 PlayStation®2 the Best
+  name-sort: おにむしゃ PlayStation®2 the Best
+  name-en: "Onimusha [PlayStation 2 The Best]"
   region: "NTSC-J"
   gsHWFixes:
     texturePreloading: 1 # Performs much better with partial preload.
   gameFixes:
     - SoftwareRendererFMVHack # Fixes FMVs.
 SLPM-74208:
-  name: "Tengai Makyou 2 - Manjimaru [PlayStation 2 The Best]"
+  name: 天外魔境II MANJI MARU PlayStation®2 the Best
+  name-sort: てんがいまきょうII MANJI MARU PlayStation®2 the Best
+  name-en: "Tengai Makyou 2 - Manjimaru [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPM-74209:
-  name: "Samurai Michi 2 [PlayStation 2 The Best]"
+  name: 侍道2 決闘版 PlayStation®2 the Best
+  name-sort: さむらいどう2 けっとうばん PlayStation®2 the Best
+  name-en: "Samurai Michi 2 [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPM-74210:
-  name: "Puyo Puyo Fever [PlayStation 2 The Best]"
+  name: ぷよぷよフィーバー お買い得版 PlayStation®2 the Best
+  name-sort: ぷよぷよふぃーばー おかいどくばん PlayStation®2 the Best
+  name-en: "Puyo Puyo Fever [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPM-74211:
-  name: "Shutokou Battle 0 [PlayStation 2 The Best]"
+  name: 首都高バトル 0 PlayStation®2 The Best
+  name-sort: しゅとこうばとる 0 PlayStation®2 The Best
+  name-en: "Shutokou Battle 0 [PlayStation 2 The Best]"
   region: "NTSC-J"
   compat: 5
 SLPM-74212:
@@ -40647,25 +45719,37 @@ SLPM-74214:
   name: "Densha de Go! Final"
   region: "NTSC-J"
 SLPM-74215:
-  name: "Shin Sangoku Musou 3 [PlayStation 2 The Best]"
+  name: 真・三國無双3 Playstation 2 the Best
+  name-sort: しん・さんごくむそう3 Playstation 2 the Best
+  name-en: "Shin Sangoku Musou 3 [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPM-74217:
   name: "Shin Sangoku Musou 3"
   region: "NTSC-J"
 SLPM-74218:
-  name: "Shining Tears [PlayStation 2 The Best]"
+  name: シャイニング・ティアーズ PlayStation®2 the Best
+  name-sort: しゃいにんぐ・てぃあーず PlayStation®2 the Best
+  name-en: "Shining Tears [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPM-74219:
-  name: "Shin Sangoku Musou 3 - Empires [PlayStation 2 The Best]"
+  name: 真・三國無双3Empires PlayStation®2 the best
+  name-sort: しん・さんごくむそう3Empires PlayStation®2 the best
+  name-en: "Shin Sangoku Musou 3 - Empires [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPM-74220:
-  name: "Kengo 3 [PlayStation 2 The Best]"
+  name: 剣豪3 PlayStation®2 the Best
+  name-sort: けんごう3 PlayStation®2 the Best
+  name-en: "Kengo 3 [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPM-74221:
-  name: "Kenka Banchou [PlayStation 2 The Best]"
+  name: 喧嘩番長 PlayStation®2 the Best
+  name-sort: けんかばんちょう PlayStation®2 the Best
+  name-en: "Kenka Banchou [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPM-74222:
-  name: "Samurai Kanzenban [PlayStation 2 The Best]"
+  name: 侍〜完全版〜 PlayStation®2 the Best
+  name-sort: さむらい〜かんぜんばん〜 PlayStation®2 the Best
+  name-en: "Samurai Kanzenban [PlayStation 2 The Best]"
   region: "NTSC-J"
   gameFixes:
     - EETimingHack # Stops crash after intro movie.
@@ -40676,15 +45760,21 @@ SLPM-74224:
   name: "Sengoku Musou Mushoden [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPM-74225:
-  name: "Nobunaga no Yabou - Tenka Sousei [PlayStation 2 The Best]"
+  name: 信長の野望・天下創世 PlayStation®2 the Best
+  name-sort: のぶながのやぼう・てんかそうせい PlayStation®2 the Best
+  name-en: "Nobunaga no Yabou - Tenka Sousei [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPM-74226:
-  name: "Metal Saga - Sajin no Kusari [PlayStation 2 The Best]"
+  name: METAL SAGA 〜砂塵の鎖〜 PlayStation®2 the Best
+  name-sort: METAL SAGA 〜さじんのくさり〜 PlayStation®2 the Best
+  name-en: "Metal Saga - Sajin no Kusari [PlayStation 2 The Best]"
   region: "NTSC-J"
   gameFixes:
     - DMABusyHack # Intro FMV.
 SLPM-74227:
-  name: "Ikusa Gami [PlayStation 2 The Best]"
+  name: 戦神-いくさがみ- PlayStation 2 the Best
+  name-sort: いくさがみ PlayStation 2 the Best
+  name-en: "Ikusa Gami [PlayStation 2 The Best]"
   region: "NTSC-J"
   gameFixes:
     - VIF1StallHack # Fixes black screen on boot.
@@ -40692,7 +45782,9 @@ SLPM-74227:
     autoFlush: 2 # Fixes missing bloom effects.
     halfPixelOffset: 2 # Fixes misaligned lighting and bloom.
 SLPM-74228:
-  name: "Fuuun Bakumatsu-den [PlayStation 2 The Best]"
+  name: 風雲幕末伝 PlayStation 2 the Best
+  name-sort: ふううんばくまつでん PlayStation 2 the Best
+  name-en: "Fuuun Bakumatsu-den [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPM-74229:
   name: "BioHazard 4 [PlayStation 2 The Best]"
@@ -40702,15 +45794,21 @@ SLPM-74229:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
 SLPM-74230:
-  name: "Devil May Cry [PlayStation 2 The Best]"
+  name: Devil May Cry PlayStation 2 the Best
+  name-sort: Devil May Cry PlayStation 2 the Best
+  name-en: "Devil May Cry [PlayStation 2 The Best]"
   region: "NTSC-J"
   gsHWFixes:
     disablePartialInvalidation: 1 # Fixes corrupt textures.
 SLPM-74231:
-  name: "Kessen III [PlayStation 2 The Best]"
+  name: 決戦III PlayStation 2 the Best
+  name-sort: けっせんIII PlayStation 2 the Best
+  name-en: "Kessen III [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPM-74232:
-  name: "Shin Onimusha - Dawn of Dreams [PlayStation 2 The Best]"
+  name: 新鬼武者 DAWN OF DREAMS PlayStation 2 the Best
+  name-sort: しんおにむしゃ DAWN OF DREAMS PlayStation 2 the Best
+  name-en: "Shin Onimusha - Dawn of Dreams [PlayStation 2 The Best]"
   region: "NTSC-J"
   gameFixes:
     - SoftwareRendererFMVHack # Wrong white textures in FMV.
@@ -40726,36 +45824,54 @@ SLPM-74233:
   memcardFilters:
     - "SLPM-74232"
 SLPM-74234:
-  name: "Ryu Ga Gotoku [PlayStation 2 The Best]"
+  name: 龍が如く PlayStation 2 the Best
+  name-sort: りゅうがごとく PlayStation 2 the Best
+  name-en: "Ryu Ga Gotoku [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPM-74235:
-  name: "Sengoku Musou [PlayStation 2 The Best]"
+  name: 戦国無双 PlayStation 2 the Best
+  name-sort: せんごくむそう PlayStation 2 the Best
+  name-en: "Sengoku Musou [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPM-74236:
-  name: "Shin Sangoku Musou 4 [PlayStation 2 The Best]"
+  name: 真・三國無双4 PlayStation 2 the Best
+  name-sort: しん・さんごくむそう4 PlayStation 2 the Best
+  name-en: "Shin Sangoku Musou 4 [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPM-74237:
-  name: "New Jinsei Game [PlayStation 2 The Best]"
+  name: NEW人生ゲーム PlayStation®2 the Best
+  name-sort: NEWじんせいげーむ PlayStation®2 the Best
+  name-en: "New Jinsei Game [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPM-74238:
-  name: "Genso Suikoden V [PlayStation 2 The Best]"
+  name: 幻想水滸伝V PlayStation 2 the Best
+  name-sort: げんそうすいこでんV PlayStation 2 the Best
+  name-en: "Genso Suikoden V [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPM-74239:
-  name: "Okami [PlayStation 2 The Best]"
+  name: 大神 PlayStation 2 the Best
+  name-sort: おおがみ PlayStation 2 the Best
+  name-en: "Okami [PlayStation 2 The Best]"
   region: "NTSC-J"
   gsHWFixes:
     roundSprite: 2 # Reduces misalignment issues but the game is just bad for upscaling.
 SLPM-74240:
-  name: "Tengai Makyou III - Namida [Best Version]"
+  name: 天外魔境III NAMIDA PlayStation®2 the Best
+  name-sort: てんがいまきょうIII NAMIDA PlayStation®2 the Best
+  name-en: "Tengai Makyou III - Namida [Best Version]"
   region: "NTSC-J"
 SLPM-74241:
-  name: "God Hand [PlayStation 2 The Best]"
+  name: GOD HAND PlayStation®2 the Best
+  name-sort: GOD HAND PlayStation®2 the Best
+  name-en: "God Hand [PlayStation 2 The Best]"
   region: "NTSC-J"
   gsHWFixes:
     mergeSprite: 1 # Reduces bloom but fixes blurriness around models + Recommended to use Shadeboost brightness 80.
     halfPixelOffset: 2 # Depth of field effect aligned properly + Shifts buildings correctly.
 SLPM-74242:
-  name: "Devil May Cry 3 [Special Edition] [PlayStation 2 The Best]"
+  name: Devil May Cry 3 Special Edition PlayStation®2 the Best
+  name-sort: Devil May Cry 3 Special Edition PlayStation®2 the Best
+  name-en: "Devil May Cry 3 [Special Edition] [PlayStation 2 The Best]"
   region: "NTSC-J"
   roundModes:
     eeRoundMode: 0 # Fixes inability to enter door in Mission 18.
@@ -40763,7 +45879,9 @@ SLPM-74242:
     halfPixelOffset: 2 # Reduces ghosting but still an issue compared to native.
     roundSprite: 2 # Clears up much of the blurring that HPO Special does not.
 SLPM-74243:
-  name: "True Crime - New York City [PlayStation 2 The Best]"
+  name: トゥルー・クライム〜ニューヨークシティ〜 PlayStation 2 the Best
+  name-sort: とぅるー・くらいむ〜にゅーよーくしてぃ〜 PlayStation 2 the Best
+  name-en: "True Crime - New York City [PlayStation 2 The Best]"
   region: "NTSC-J"
   clampModes:
     eeClampMode: 2 # Fixes SPS on highway.
@@ -40777,22 +45895,30 @@ SLPM-74243:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
 SLPM-74244:
-  name: "Phantasy Star Universe [PlayStation 2 The Best]"
+  name: ファンタシー スター ユニバース PlayStation 2 the Best
+  name-sort: ふぁんたしー すたー ゆにばーす PlayStation 2 the Best
+  name-en: "Phantasy Star Universe [PlayStation 2 The Best]"
   region: "NTSC-J"
   roundModes:
     eeRoundMode: 0 # Fixes enemies not moving (especially Chapter 7 boss).
 SLPM-74245:
-  name: "Monster Hunter 2 [PlayStation 2 The Best]"
+  name: モンスターハンター2（dos） PlayStation®2 the Best
+  name-sort: もんすたーはんたー2（dos） PlayStation®2 the Best
+  name-en: "Monster Hunter 2 [PlayStation 2 The Best]"
   region: "NTSC-J"
   clampModes:
     vuClampMode: 3 # Fixes lighting on character models as caves and other locations don't turn mobs into glow-in-the-dark creatures by themselves.
   gsHWFixes:
     maximumBlendingLevel: 0 # Fixes unnecessary load on the GPU.
 SLPM-74246:
-  name: "Capcom vs. SNK 2 - Millionaire Fighting 2001 [PlayStation 2 the Best - Reprint]"
+  name: CAPCOM VS.SNK 2 MILLIONAIRE FIGHTING 2001 PlayStation 2 the Best
+  name-sort: CAPCOM VS.SNK 2 MILLIONAIRE FIGHTING 2001 PlayStation 2 the Best
+  name-en: "Capcom vs. SNK 2 - Millionaire Fighting 2001 [PlayStation 2 the Best - Reprint]"
   region: "NTSC-J"
 SLPM-74247:
-  name: "Sengoku Musou 2 [PlayStation 2 The Best]"
+  name: 戦国無双2 PlayStation 2 the Best
+  name-sort: せんごくむそう2 PlayStation 2 the Best
+  name-en: "Sengoku Musou 2 [PlayStation 2 The Best]"
   region: "NTSC-J"
   gsHWFixes:
     roundSprite: 2 # Helps to alleviate misaligned text.
@@ -40809,22 +45935,30 @@ SLPM-74247:
     - "SLPM-74224"
     - "SLPM-74249"
 SLPM-74248:
-  name: "Monster Hunter G [PlayStation 2 The Best]"
+  name: モンスターハンターG PlayStation®2 the Best
+  name-sort: もんすたーはんたーG PlayStation®2 the Best
+  name-en: "Monster Hunter G [PlayStation 2 The Best]"
   region: "NTSC-J"
   clampModes:
     vuClampMode: 3 # Fixes lighting on character models as caves and other locations don't turn mobs into glow-in-the-dark creatures by themselves.
   gsHWFixes:
     maximumBlendingLevel: 0 # Fixes unnecessary load on the GPU.
 SLPM-74249:
-  name: "Sengoku Musou Mushoden [PlayStation 2 The Best]"
+  name: 戦国無双 猛将伝 PlayStation®2 the Best
+  name-sort: せんごくむそう もうしょうでん PlayStation®2 the Best
+  name-en: "Sengoku Musou Mushoden [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPM-74250:
-  name: "Shin Sangoku Musou 4 Mushoden [PlayStation 2 The Best]"
+  name: 真・三國無双4 猛将伝 PlayStation®2 the Best
+  name-sort: しん・さんごくむそう4 もうしょうでん PlayStation®2 the Best
+  name-en: "Shin Sangoku Musou 4 Mushoden [PlayStation 2 The Best]"
   region: "NTSC-J"
   gsHWFixes:
     autoFlush: 2 # Fixes sun luminosity.
 SLPM-74251:
-  name: "Shin Onimusha - Dawn of Dreams [PlayStation 2 the Best - Reprint Disc 1]"
+  name: 新鬼武者 PlayStation®2 the Best
+  name-sort: しんおにむしゃ PlayStation®2 the Best
+  name-en: "Shin Onimusha - Dawn of Dreams [PlayStation 2 the Best - Reprint Disc 1]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misalignment and upscaling lines.
@@ -40838,10 +45972,14 @@ SLPM-74252:
   memcardFilters:
     - "SLPM-74251"
 SLPM-74253:
-  name: "Ryu ga Gotoku [PlayStation 2 the Best - Reprint]"
+  name: 龍が如く PlayStation 2 the Best
+  name-sort: りゅうがごとく PlayStation 2 the Best
+  name-en: "Ryu ga Gotoku [PlayStation 2 the Best - Reprint]"
   region: "NTSC-J"
 SLPM-74254:
-  name: "EX Jinsei Game II [PlayStation 2 the Best - Reprint]"
+  name: EX人生ゲームII PlayStation®2 the Best
+  name-sort: EXじんせいげーむII PlayStation®2 the Best
+  name-en: "EX Jinsei Game II [PlayStation 2 the Best - Reprint]"
   region: "NTSC-J"
 SLPM-74255:
   name: "Metal Gear Solid 2 - Sons of Liberty [PlayStation 2 The Best] [Disc 1 of 2]"
@@ -40864,7 +46002,9 @@ SLPM-74258:
   name: "Metal Gear & Metal Gear 2 - Solid Snake"
   region: "NTSC-J"
 SLPM-74259:
-  name: "Odin Sphere [PlayStation 2 The Best]"
+  name: オーディンスフィア PlayStation®2 the Best
+  name-sort: おーでぃんすふぃあ PlayStation®2 the Best
+  name-en: "Odin Sphere [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPM-74260:
   name: "Shining Force EXA"
@@ -40884,7 +46024,9 @@ SLPM-74264:
   name: "Sengoku Basara 2 - Heroes"
   region: "NTSC-J"
 SLPM-74265:
-  name: "Nobunaga no Yabou - Kakushin [PlayStation 2 The Best]"
+  name: 信長の野望・革新 PlayStation®2 the Best
+  name-sort: のぶながのやぼう・かくしん PlayStation®2 the Best
+  name-en: "Nobunaga no Yabou - Kakushin [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPM-74266:
   name: "Sengoku Musou 2 - Empires"
@@ -40911,16 +46053,22 @@ SLPM-74275:
   name: "Sengoku Basara 2 - Heroes"
   region: "NTSC-J"
 SLPM-74276:
-  name: "Sangoku Musou 2 [PlayStation 2 The Best]"
+  name: ガンダム無双2 PlayStation®2 the Best
+  name-sort: がんだむむそう2 PlayStation®2 the Best
+  name-en: "Sangoku Musou 2 [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPM-74277:
-  name: "Persona 3 FES [PlayStation 2 The Best]"
+  name: ペルソナ3フェス PlayStation®2 the Best
+  name-sort: ぺるそな3ふぇす PlayStation®2 the Best
+  name-en: "Persona 3 FES [PlayStation 2 The Best]"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
     mipmap: 2 # Fixes flashing windows.
 SLPM-74278:
-  name: "Persona 4 [PlayStation 2 The Best]"
+  name: ペルソナ4 PlayStation®2 the Best
+  name-sort: ぺるそな4 PlayStation®2 the Best
+  name-en: "Persona 4 [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPM-74279:
   name: "Shin Sangoku Musou 4 - Moushouden"
@@ -40938,7 +46086,9 @@ SLPM-74284:
   name: "Sengoku Musou 2 - Empires"
   region: "NTSC-J"
 SLPM-74286:
-  name: "Shin Sangoku Musou 5 Special [PlayStation 2 The Best]"
+  name: 真・三國無双5 Special PlayStation®2 the Best
+  name-sort: しん・さんごくむそう5 Special PlayStation®2 the Best
+  name-en: "Shin Sangoku Musou 5 Special [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPM-74287:
   name: "Shin Sangoku Musou 5 Special (Disc 2)"
@@ -40951,7 +46101,9 @@ SLPM-74288:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
 SLPM-74301:
-  name: "Ryu ga Gotoku 2 [PlayStation 2 The Best]"
+  name: 龍が如く2 PlayStation 2 the Best
+  name-sort: りゅうがごとく2 PlayStation 2 the Best
+  name-en: "Ryu ga Gotoku 2 [PlayStation 2 The Best]"
   region: "NTSC-J"
   memcardFilters:
     - "SLPM-66602"
@@ -40963,21 +46115,29 @@ SLPM-74401:
   name: "Kessen"
   region: "NTSC-J"
 SLPM-74402:
-  name: "Capcom vs. SNK 2 [PlayStation 2 The Best]"
+  name: CAPCOM VS. SNK2 MILLIONAIRE FIGHTING 2001 PlayStation®2 the Best
+  name-sort: CAPCOM VS. SNK2 MILLIONAIRE FIGHTING 2001 PlayStation®2 the Best
+  name-en: "Capcom vs. SNK 2 [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPM-74403:
   name: "Densha de Go! Shinkansen [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPM-74404:
-  name: "Space Channel 5 - Part 2 [PlayStation 2 The Best]"
+  name: スペースチャンネル5 Part2 PlayStation 2 the Best
+  name-sort: すぺーすちゃんねる5 Part2 PlayStation 2 the Best
+  name-en: "Space Channel 5 - Part 2 [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPM-74405:
-  name: "Samurai Complete Edition [PlayStation 2 The Best]"
+  name: 侍〜完全版〜 PlayStation 2 the Best
+  name-sort: さむらい〜かんぜんばん〜 PlayStation 2 the Best
+  name-en: "Samurai Complete Edition [PlayStation 2 The Best]"
   region: "NTSC-J"
   gameFixes:
     - EETimingHack # Stops crash after intro movie.
 SLPM-74406:
-  name: "World Rally Championship [PlayStation 2 The Best]"
+  name: WRC〜ワールド・ラリー・チャンピオンシップ〜 PlayStation 2 the Best
+  name-sort: WRC〜わーるど・らりー・ちゃんぴおんしっぷ〜 PlayStation 2 the Best
+  name-en: "World Rally Championship [PlayStation 2 The Best]"
   region: "NTSC-J"
   roundModes:
     eeRoundMode: 0 # Fixes crash when using the Subaru.
@@ -40990,31 +46150,45 @@ SLPM-74408:
   name: "Rakugaki Kingdom [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPM-74409:
-  name: "Gun Survivor 2 - BioHazard Code - Veronica [PlayStation 2 The Best]"
+  name: ガンサバイバー2 バイオハザード コード:ベロニカ PlayStation 2 the Best
+  name-sort: がんさばいばー2 ばいおはざーど こーど:べろにか PlayStation 2 the Best
+  name-en: "Gun Survivor 2 - BioHazard Code - Veronica [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPM-74410:
-  name: "Breath of Fire V - Dragon Quarter [PlayStation 2 The Best]"
+  name: ブレス オブ ファイアV ドラゴン クォーター PlayStation®2 the Best
+  name-sort: ぶれす おぶ ふぁいあV どらごん くぉーたー PlayStation®2 the Best
+  name-en: "Breath of Fire V - Dragon Quarter [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPM-74411:
-  name: "Culdcept II - Expansion [PlayStation 2 The Best]"
+  name: カルドセプト セカンド エキスパンション PlayStation®2 the Best
+  name-sort: かるどせぷと せかんど えきすぱんしょん PlayStation®2 the Best
+  name-en: "Culdcept II - Expansion [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPM-74412:
-  name: "Kengo 2 [PlayStation 2 The Best]"
+  name: 剣豪2 PlayStation®2 the Best
+  name-sort: けんごう2 PlayStation®2 the Best
+  name-en: "Kengo 2 [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPM-74414:
   name: "Energy Airforce"
   region: "NTSC-J"
 SLPM-74415:
-  name: "Shinobi [PlayStation 2 The Best]"
+  name: Shinobi PlayStation 2 the Best
+  name-sort: Shinobi PlayStation 2 the Best
+  name-en: "Shinobi [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPM-74416:
   name: "Clock Tower 3"
   region: "NTSC-J"
 SLPM-74420:
-  name: "Initial D - Special Stage [PlayStation 2 The Best]"
+  name: 頭文字D Special Stage PlayStation2 the Best
+  name-sort: かしらもじD Special Stage PlayStation2 the Best
+  name-en: "Initial D - Special Stage [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPM-74421:
-  name: "Dennou Senki - Virtual-On Marz [PlayStation 2 The Best]"
+  name: 電脳戦機バーチャロン マーズ PlayStation®2 the Best
+  name-sort: でんのうせんきばーちゃろん まーず PlayStation®2 the Best
+  name-en: "Dennou Senki - Virtual-On Marz [PlayStation 2 The Best]"
   region: "NTSC-J"
   gsHWFixes:
     cpuCLUTRender: 2 # Fixes CLUT colours.
@@ -41036,7 +46210,9 @@ SLPS-20000:
   name: "AH-64D Apache"
   region: "NTSC-J"
 SLPS-20001:
-  name: "Ridge Racer V"
+  name: リッジレーサーV
+  name-sort: りっじれーさーV
+  name-en: "Ridge Racer V"
   region: "NTSC-J"
   compat: 5
   clampModes:
@@ -41049,11 +46225,15 @@ SLPS-20001:
     gpuPaletteConversion: 2 # Lots of CLUTs in large textures.
     cpuCLUTRender: 1 # Fixes car textures.
 SLPS-20002:
-  name: "Doukyu Billiards"
+  name: 撞球 ビリヤードマスター2
+  name-sort: どうきゅう びりやーどますたー2
+  name-en: "Doukyu Billiards"
   region: "NTSC-J"
   compat: 5
 SLPS-20003:
-  name: "Street Fighter EX3"
+  name: ストリートファイターEX3
+  name-sort: すとりーとふぁいたーEX3
+  name-en: "Street Fighter EX3"
   region: "NTSC-J"
   gsHWFixes:
     getSkipCount: "GSC_SFEX3"
@@ -41061,13 +46241,19 @@ SLPS-20004:
   name: "Kakinoki Shougi IV"
   region: "NTSC-J"
 SLPS-20005:
-  name: "EX Billiards"
+  name: EXビリヤード
+  name-sort: EXびりやーど
+  name-en: "EX Billiards"
   region: "NTSC-J"
 SLPS-20006:
-  name: "A-Train 6"
+  name: A列車で行こう6
+  name-sort: Aれっしゃでいこう6
+  name-en: "A-Train 6"
   region: "NTSC-J"
 SLPS-20007:
-  name: "Driving Emotion Type-S"
+  name: DRIVING EMOTION TYPE-S
+  name-sort: DRIVING EMOTION TYPE-S
+  name-en: "Driving Emotion Type-S"
   region: "NTSC-J"
   compat: 5
   clampModes:
@@ -41082,35 +46268,53 @@ SLPS-20008:
   name: "Morita Shougi"
   region: "NTSC-J"
 SLPS-20009:
-  name: "Golf Paradise"
+  name: ゴルフパラダイス
+  name-sort: ごるふぱらだいす
+  name-en: "Golf Paradise"
   region: "NTSC-J"
 SLPS-20010:
-  name: "Pro Baseball Gekikuukan"
+  name: 劇空間プロ野球 AT THE END OF THE CENTURY 1999
+  name-sort: げきくうかんぷろやきゅう AT THE END OF THE CENTURY 1999
+  name-en: "Pro Baseball Gekikuukan"
   region: "NTSC-J"
 SLPS-20011:
-  name: "American Arcade"
+  name: アメリカン・アーケード
+  name-sort: あめりかん・あーけーど
+  name-en: "American Arcade"
   region: "NTSC-J"
   compat: 5
 SLPS-20012:
-  name: "Sky Surfer"
+  name: スカイサーファー
+  name-sort: すかいさーふぁー
+  name-en: "Sky Surfer"
   region: "NTSC-J"
 SLPS-20013:
-  name: "Primal Image Vol.01"
+  name: Primal Image vol.1
+  name-sort: Primal Image vol.1
+  name-en: "Primal Image Vol.01"
   region: "NTSC-J"
 SLPS-20015:
-  name: "Tekken Tag Tournament"
+  name: 鉄拳タッグトーナメント
+  name-sort: てっけんたっぐとーなめんと
+  name-en: "Tekken Tag Tournament"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
 SLPS-20016:
-  name: "Dream Audition"
+  name: ドリームオーディション
+  name-sort: どりーむおーでぃしょん
+  name-en: "Dream Audition"
   region: "NTSC-J"
 SLPS-20017:
-  name: "Street Mahjong Trance 2"
+  name: ストリート麻雀トランス 麻神2
+  name-sort: すとりーとまーじゃんとらんす あさしん2
+  name-en: "Street Mahjong Trance 2"
   region: "NTSC-J"
 SLPS-20018:
-  name: "Stepping Selection [Disc 1 of 2]"
+  name: ステッピングセレクション
+  name-sort: すてっぴんぐせれくしょん
+  name-en: "Stepping Selection [Disc 1 of 2]"
   region: "NTSC-J"
   memcardFilters:
     - "SLPS-20018"
@@ -41122,69 +46326,101 @@ SLPS-20019:
     - "SLPS-20018"
     - "SLPS-20019"
 SLPS-20020:
-  name: "FIFA 2000 World Championship"
+  name: FIFA SOCCER WORLD CHAMPIONSHIP
+  name-sort: FIFA SOCCER WORLD CHAMPIONSHIP
+  name-en: "FIFA 2000 World Championship"
   region: "NTSC-J"
 SLPS-20021:
-  name: "Wild Wild Racing"
+  name: ワイルドワイルドレーシング
+  name-sort: わいるどわいるどれーしんぐ
+  name-en: "Wild Wild Racing"
   region: "NTSC-J"
 SLPS-20022:
-  name: "All-Star Pro Wrestling"
+  name: オールスター・プロレスリング
+  name-sort: おーるすたー・ぷろれすりんぐ
+  name-en: "All-Star Pro Wrestling"
   region: "NTSC-J"
 SLPS-20023:
-  name: "Cross Fire"
+  name: クロスファイア
+  name-sort: くろすふぁいあ
+  name-en: "Cross Fire"
   region: "NTSC-J"
   gsHWFixes:
     mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
     trilinearFiltering: 1
 SLPS-20024:
-  name: "Hresvelgr"
+  name: フレースヴェルグ
+  name-sort: ふれーすゔぇるぐ
+  name-en: "Hresvelgr"
   region: "NTSC-J"
 SLPS-20025:
-  name: "SSX - Snowboard Supercross"
+  name: エクストリーム・レーシング SSX
+  name-sort: えくすとりーむ・れーしんぐ SSX
+  name-en: "SSX - Snowboard Supercross"
   region: "NTSC-J"
   roundModes:
     eeRoundMode: 0 # Fixes riders vanishing into the floor.
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes missing lighting.
 SLPS-20027:
-  name: "Aquaqua"
+  name: AQUAQUA
+  name-sort: AQUAQUA
+  name-en: "Aquaqua"
   region: "NTSC-J"
   compat: 5
 SLPS-20028:
-  name: "Game Select 5"
+  name: GAME SELECT5 和
+  name-sort: GAME SELECT5 わ
+  name-en: "Game Select 5"
   region: "NTSC-J"
 SLPS-20029:
-  name: "Surfroid"
+  name: サーフロイド〜伝説のサーファー〜
+  name-sort: さーふろいど〜でんせつのさーふぁー〜
+  name-en: "Surfroid"
   region: "NTSC-J"
 SLPS-20030:
   name: "Shanghai - The Four Elements"
   region: "NTSC-J"
 SLPS-20031:
-  name: "Mechsmith, The - Run-Dim"
+  name: メックスミス・ランディム
+  name-sort: めっくすみす・らんでぃむ
+  name-en: "Mechsmith, The - Run-Dim"
   region: "NTSC-J"
 SLPS-20033:
-  name: "Gungriffon Blaze"
+  name: GUNGRIFFON BLAZE
+  name-sort: GUNGRIFFON BLAZE
+  name-en: "Gungriffon Blaze"
   region: "NTSC-J"
 SLPS-20034:
-  name: "Velvet File"
+  name: Velvet File
+  name-sort: Velvet File
+  name-en: "Velvet File"
   region: "NTSC-J"
   gsHWFixes:
     gpuPaletteConversion: 2 # Reduces HC size.
 SLPS-20035:
-  name: "Pro Mahjong Kiwame Next"
+  name: プロ麻雀 極 NEXT
+  name-sort: ぷろまーじゃん きわめ NEXT
+  name-en: "Pro Mahjong Kiwame Next"
   region: "NTSC-J"
   gameFixes:
     - SkipMPEGHack # Fixes black screen.
 SLPS-20036:
-  name: "Magical Sports - 2000 Koushien"
+  name: マジカルスポーツ 2000甲子園
+  name-sort: まじかるすぽーつ 2000こうしえん
+  name-en: "Magical Sports - 2000 Koushien"
   region: "NTSC-J"
 SLPS-20037:
-  name: "Magical Sports - Go Go Golf"
+  name: マジカルスポーツ GoGoGolf
+  name-sort: まじかるすぽーつ GoGoGolf
+  name-en: "Magical Sports - Go Go Golf"
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves brightness on terrain textures.
 SLPS-20038:
-  name: "Grappler Baki - Baki Saidai no Tournament"
+  name: グラップラー刃牙
+  name-sort: ぐらっぷらーはきば
+  name-en: "Grappler Baki - Baki Saidai no Tournament"
   region: "NTSC-J"
   gameFixes:
     - EETimingHack # Fixes hang at menu.
@@ -41192,19 +46428,29 @@ SLPS-20039:
   name: "Ide Yousuke no Mahjong Kazoku 2"
   region: "NTSC-J"
 SLPS-20040:
-  name: "MotoGP"
+  name: MotoGP
+  name-sort: MotoGP
+  name-en: "MotoGP"
   region: "NTSC-J"
 SLPS-20041:
-  name: "Mahjong Goku Taisei"
+  name: 麻雀悟空 大聖
+  name-sort: まーじゃんごくう たいせい
+  name-en: "Mahjong Goku Taisei"
   region: "NTSC-J"
 SLPS-20042:
-  name: "F1 Racing Championship"
+  name: F1 Racing Championship
+  name-sort: F1 Racing Championship
+  name-en: "F1 Racing Championship"
   region: "NTSC-J"
 SLPS-20043:
-  name: "Lake Masters Fishing EX"
+  name: レイクマスターズEX
+  name-sort: れいくますたーずEX
+  name-en: "Lake Masters Fishing EX"
   region: "NTSC-J"
 SLPS-20044:
-  name: "F1 Championship Season 2000"
+  name: F1チャンピオンシップ シーズン2000
+  name-sort: F1ちゃんぴおんしっぷ しーずん2000
+  name-en: "F1 Championship Season 2000"
   region: "NTSC-J"
   gameFixes:
     - XGKickHack # Fixes graphical issues.
@@ -41215,62 +46461,92 @@ SLPS-20046:
   name: "Kuusen"
   region: "NTSC-J"
 SLPS-20047:
-  name: "Toudai Shogi"
+  name: 東大将棋 四間飛車道場
+  name-sort: とうだいしょうぎ しけんびしゃどうじょう
+  name-en: "Toudai Shogi"
   region: "NTSC-J"
 SLPS-20048:
-  name: "Sim Theme Park"
+  name: テーマパーク2001
+  name-sort: てーまぱーく2001
+  name-en: "Sim Theme Park"
   region: "NTSC-J"
 SLPS-20050:
-  name: "Happy! Happy!! Boarders in Hokkaidou Rusutsu Resort"
+  name: Happy! Happy!! Boarders
+  name-sort: Happy! Happy!! Boarders
+  name-en: "Happy! Happy!! Boarders in Hokkaidou Rusutsu Resort"
   region: "NTSC-J"
   speedHacks:
     mvuFlag: 0 # Fixes graphical issues.
 SLPS-20051:
-  name: "Hissatsu Pachinko Station V"
+  name: 必殺パチンコステーションV 炎の爆笑軍団
+  name-sort: ひっさつぱちんこすてーしょんV えんのばくしょうぐんだん
+  name-en: "Hissatsu Pachinko Station V"
   region: "NTSC-J"
 SLPS-20052:
-  name: "Global Folktale"
+  name: Global Folktale
+  name-sort: Global Folktale
+  name-en: "Global Folktale"
   region: "NTSC-J"
 SLPS-20053:
-  name: "Tenshi no Present - Māru Oukoku Monogatari"
+  name: 天使のプレゼント マール王国物語 限定版
+  name-sort: てんしのぷれぜんと まーるおうこくものがたり げんていばん
+  name-en: "Tenshi no Present - Māru Oukoku Monogatari"
   region: "NTSC-J"
 SLPS-20054:
-  name: "FIFA World Championship 2001"
+  name: FIFA2001 ワールドチャンピオンシップ
+  name-sort: FIFA2001 わーるどちゃんぴおんしっぷ
+  name-en: "FIFA World Championship 2001"
   region: "NTSC-J"
   gsHWFixes:
     mipmap: 1 # Fixes broken player textures.
 SLPS-20055:
-  name: "Technictix"
+  name: テクニクティクス
+  name-sort: てくにくてぃくす
+  name-en: "Technictix"
   region: "NTSC-J"
   compat: 5
 SLPS-20056:
   name: "Colorio - Hagaki Print"
   region: "NTSC-J"
 SLPS-20057:
-  name: "Dog of Bay"
+  name: DOG OF BAY
+  name-sort: DOG OF BAY
+  name-en: "Dog of Bay"
   region: "NTSC-J"
   gameFixes:
     - XGKickHack # Fixes corrupted textures.
 SLPS-20058:
-  name: "Kengo"
+  name: 剣豪
+  name-sort: けんごう
+  name-en: "Kengo"
   region: "NTSC-J"
 SLPS-20059:
-  name: "Hresvelgr [International Edition]"
+  name: フレースヴェルグ インターナショナルエディション
+  name-sort: ふれーすゔぇるぐ いんたーなしょなるえでぃしょん
+  name-en: "Hresvelgr [International Edition]"
   region: "NTSC-J"
 SLPS-20060:
-  name: "Dream Audition 2"
+  name: ドリームオーディション2
+  name-sort: どりーむおーでぃしょん2
+  name-en: "Dream Audition 2"
   region: "NTSC-J"
 SLPS-20061:
   name: "Mamimune - Mogacho no Print Hour"
   region: "NTSC-J"
 SLPS-20062:
-  name: "Truck Kyousoukyoku"
+  name: トラック狂走曲 〜愛と哀しみのロデオ〜
+  name-sort: とらっくきょうそうきょく 〜あいとかなしみのろでお〜
+  name-en: "Truck Kyousoukyoku"
   region: "NTSC-J"
 SLPS-20064:
-  name: "Top Gear Daredevil"
+  name: トップギア・デアデビル
+  name-sort: とっぷぎあ・であでびる
+  name-en: "Top Gear Daredevil"
   region: "NTSC-J"
 SLPS-20065:
-  name: "Madden NFL 2001"
+  name: MADDEN NFL スーパーボウル 2001
+  name-sort: MADDEN NFL すーぱーぼうる 2001
+  name-en: "Madden NFL 2001"
   region: "NTSC-J"
   clampModes:
     vuClampMode: 3 # Missing geometry with microVU.
@@ -41278,13 +46554,19 @@ SLPS-20065:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
 SLPS-20066:
-  name: "Rhapsody 3 - Tenshi no Present - The Marl Kingdom Stories"
+  name: 天使のプレゼント マール王国物語
+  name-sort: てんしのぷれぜんと まーるおうこくものがたり
+  name-en: "Rhapsody 3 - Tenshi no Present - The Marl Kingdom Stories"
   region: "NTSC-J"
 SLPS-20067:
-  name: "Crazy Bumps"
+  name: CRAZY BUMP’S かっとびカーバトル!
+  name-sort: CRAZY BUMP’S かっとびかーばとる!
+  name-en: "Crazy Bumps"
   region: "NTSC-J"
 SLPS-20068:
-  name: "Midnight Club - Street Racing"
+  name: MIDNIGHT CLUB〜STREET RACING〜
+  name-sort: MIDNIGHT CLUB〜STREET RACING〜
+  name-en: "Midnight Club - Street Racing"
   region: "NTSC-J"
   memcardFilters:
     - "SLPS-20068"
@@ -41293,13 +46575,19 @@ SLPS-20070:
   name: "Disney's Donald Duck - Rescue Daisakusen!!"
   region: "NTSC-J"
 SLPS-20071:
-  name: "Game Select 5"
+  name: GAME SELECT 5 洋
+  name-sort: GAME SELECT 5 よう
+  name-en: "Game Select 5"
   region: "NTSC-J"
 SLPS-20072:
-  name: "Real Robots Regiment"
+  name: リアルロボットレジメント
+  name-sort: りあるろぼっとれじめんと
+  name-en: "Real Robots Regiment"
   region: "NTSC-J"
 SLPS-20073:
-  name: "NBA Live 2001"
+  name: NBAライブ2001
+  name-sort: NBAらいぶ2001
+  name-en: "NBA Live 2001"
   region: "NTSC-J"
 SLPS-20074:
   name: "Kousoku Tanigawa Shougi"
@@ -41311,7 +46599,9 @@ SLPS-20077:
   name: "Pilot ni Narou! 2"
   region: "NTSC-J"
 SLPS-20078:
-  name: "Generation of Chaos"
+  name: シムピープル お茶の間劇場
+  name-sort: しむぴーぷる おちゃのまげきじょう
+  name-en: "Generation of Chaos"
   region: "NTSC-J"
 SLPS-20080:
   name: "Typing Namidabashi - Ashita no Joe Touda"
@@ -41320,10 +46610,14 @@ SLPS-20081:
   name: "Typing Namidabashi - Ashita no Joe Touda"
   region: "NTSC-J"
 SLPS-20082:
-  name: "Saikyou Toudai Shogi 3 [Mycom Best]"
+  name: 最強 東大将棋3
+  name-sort: さいきょう とうだいしょうぎ3
+  name-en: "Saikyou Toudai Shogi 3 [Mycom Best]"
   region: "NTSC-J"
 SLPS-20083:
-  name: "Air Ranger Rescue Helicopter"
+  name: レスキューヘリ エアレンジャー
+  name-sort: れすきゅーへり えあれんじゃー
+  name-en: "Air Ranger Rescue Helicopter"
   region: "NTSC-J"
   gameFixes:
     - VUSyncHack # Fixes graphics.
@@ -41331,7 +46625,9 @@ SLPS-20083:
     mipmap: 2 # Fixes ground graphics.
     trilinearFiltering: 1 # Fixes ground graphics.
 SLPS-20084:
-  name: "Basic Studio [Disc 1]"
+  name: BASIC STUDIO パワフルゲーム工房
+  name-sort: BASIC STUDIO ぱわふるげーむこうぼう
+  name-en: "Basic Studio [Disc 1]"
   region: "NTSC-J"
   memcardFilters:
     - "SLPS-20084"
@@ -41343,20 +46639,28 @@ SLPS-20085:
     - "SLPS-20084"
     - "SLPS-20085"
 SLPS-20086:
-  name: "Generation of Chaos [Limited Edition]"
+  name: GENERATION OF CHAOS 限定版
+  name-sort: GENERATION OF CHAOS げんていばん
+  name-en: "Generation of Chaos [Limited Edition]"
   region: "NTSC-J"
 SLPS-20087:
-  name: "Generation of Chaos"
+  name: GENERATION OF CHAOS
+  name-sort: GENERATION OF CHAOS
+  name-en: "Generation of Chaos"
   region: "NTSC-J"
 SLPS-20089:
   name: "Gun-Heats"
   region: "NTSC-J"
 SLPS-20091:
-  name: "Gekisha Boy 2"
+  name: 激写ボーイ2 〜特ダネ王国ニッポン〜
+  name-sort: げきしゃぼーい2 〜とくだねおうこくにっぽん〜
+  name-en: "Gekisha Boy 2"
   region: "NTSC-J"
   compat: 5
 SLPS-20092:
-  name: "Tiger Woods PGA Tour 2001"
+  name: タイガー・ウッズ PGA TOUR 2001
+  name-sort: たいがー・うっず PGA TOUR 2001
+  name-en: "Tiger Woods PGA Tour 2001"
   region: "NTSC-J"
   gsHWFixes:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
@@ -41365,10 +46669,14 @@ SLPS-20093:
   name: "Super Mic-chan"
   region: "NTSC-J"
 SLPS-20094:
-  name: "Shinseiki Evangelion - Typing Project-E [TVware Information Revolution Series]"
+  name: TVware情報革命シリーズ 新世紀エヴァンゲリオン タイピング-E計画
+  name-sort: TVwareじょうほうかくめいしりーず しんせいきえゔぁんげりおん たいぴんぐ-Eけいかく
+  name-en: "Shinseiki Evangelion - Typing Project-E [TVware Information Revolution Series]"
   region: "NTSC-J"
 SLPS-20095:
-  name: "Knockout Kings 2001"
+  name: ノックアウトキング2001
+  name-sort: のっくあうときんぐ2001
+  name-en: "Knockout Kings 2001"
   region: "NTSC-J"
   gsHWFixes:
     disablePartialInvalidation: 1 # Fixes missing arena, fighters and other missing graphics.
@@ -41376,10 +46684,14 @@ SLPS-20096:
   name: "Gambler Densetsu Tetsuya"
   region: "NTSC-J"
 SLPS-20097:
-  name: "Magical Sports - Koshien"
+  name: マジカルスポーツ 甲子園
+  name-sort: まじかるすぽーつ こうしえん
+  name-en: "Magical Sports - Koshien"
   region: "NTSC-J"
 SLPS-20098:
-  name: "Magical Sports - Hard Hitter"
+  name: マジカルスポーツ Hard Hitter
+  name-sort: まじかるすぽーつ Hard Hitter
+  name-en: "Magical Sports - Hard Hitter"
   region: "NTSC-J"
   gsHWFixes:
     mipmap: 2 # Improves ground texture rendering.
@@ -41388,33 +46700,49 @@ SLPS-20099:
   name: "Dream Audition 3"
   region: "NTSC-J"
 SLPS-20100:
-  name: "Tetsu-One Train Battle"
+  name: 鉄1 〜電車でバトル〜
+  name-sort: てつ1 〜でんしゃでばとる〜
+  name-en: "Tetsu-One Train Battle"
   region: "NTSC-J"
 SLPS-20101:
-  name: "City Crisis"
+  name: CITY CRISIS
+  name-sort: CITY CRISIS
+  name-en: "City Crisis"
   region: "NTSC-J"
 SLPS-20102:
-  name: "Pachinko Paradise 6"
+  name: 三洋パチンコパラダイス6 〜ギンパニ大水族館〜
+  name-sort: さんようぱちんこぱらだいす6 〜ぎんぱにだいすいぞくかん〜
+  name-en: "Pachinko Paradise 6"
   region: "NTSC-J"
 SLPS-20103:
-  name: "Lake Masters EX Super"
+  name: レイクマスターズEX Super
+  name-sort: れいくますたーずEX Super
+  name-en: "Lake Masters EX Super"
   region: "NTSC-J"
 SLPS-20104:
-  name: "Bokujou Monogatari 3"
+  name: 牧場物語3 ハートに火をつけて
+  name-sort: ぼくじょうものがたり3 はーとにひをつけて
+  name-en: "Bokujou Monogatari 3"
   region: "NTSC-J"
 SLPS-20105:
-  name: "Growlanser II - The Sense of Justice [Deluxe Pack]"
+  name: グローランサーII デラックスパック
+  name-sort: ぐろーらんさーII でらっくすぱっく
+  name-en: "Growlanser II - The Sense of Justice [Deluxe Pack]"
   region: "NTSC-J"
   compat: 4
 SLPS-20106:
-  name: "Growlanser II - The Sense of Justice"
+  name: グローランサーII
+  name-sort: ぐろーらんさーII
+  name-en: "Growlanser II - The Sense of Justice"
   region: "NTSC-J"
   compat: 4
 SLPS-20107:
   name: "NBA Street"
   region: "NTSC-J"
 SLPS-20108:
-  name: "Quake III - Revolution"
+  name: QUAKE III REVOLUTION
+  name-sort: QUAKE III REVOLUTION
+  name-en: "Quake III - Revolution"
   region: "NTSC-J"
   gsHWFixes:
     mipmap: 1
@@ -41422,13 +46750,19 @@ SLPS-20110:
   name: "Mezase! Meimon Yakyuubu 2"
   region: "NTSC-J"
 SLPS-20111:
-  name: "Magical Sports - Pro Baseball 2001"
+  name: マジカルスポーツ 2001プロ野球
+  name-sort: まじかるすぽーつ 2001ぷろやきゅう
+  name-en: "Magical Sports - Pro Baseball 2001"
   region: "NTSC-J"
 SLPS-20112:
-  name: "Hissatsu Pachinko Station v2.0"
+  name: 必殺パチンコステーションV2 天才バカボン
+  name-sort: ひっさつぱちんこすてーしょんV2 てんさいばかぼん
+  name-en: "Hissatsu Pachinko Station v2.0"
   region: "NTSC-J"
 SLPS-20113:
-  name: "Time Crisis II [with Guncon 2]"
+  name: タイムクライシス2＋ガンコン2
+  name-sort: たいむくらいしす2＋がんこん2
+  name-en: "Time Crisis II [with Guncon 2]"
   region: "NTSC-J"
 SLPS-20114:
   name: "TVware Jouhou Kakumei Series - Katei no Igaku"
@@ -41443,40 +46777,56 @@ SLPS-20117:
   name: "Taikyoku Mahjong - Net de Ron!"
   region: "NTSC-J"
 SLPS-20120:
-  name: "F1 2001"
+  name: F1 2001
+  name-sort: F1 2001
+  name-en: "F1 2001"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 1 # Fixes black void when upscaling.
 SLPS-20121:
-  name: "Kanon"
+  name: Kanon
+  name-sort: Kanon
+  name-en: "Kanon"
   region: "NTSC-J"
 SLPS-20122:
-  name: "Time Crisis II"
+  name: タイムクライシス2
+  name-sort: たいむくらいしす2
+  name-en: "Time Crisis II"
   region: "NTSC-J"
 SLPS-20123:
   name: "Initial D - Takahashi Ryousuke no Typing Saisoku Riron"
   region: "NTSC-J"
 SLPS-20125:
-  name: "Shanghai - The Four Elements [Super Value 2800]"
+  name: super value 2800 上海フォーエレメント
+  name-sort: super value 2800 しゃんはいふぉーえれめんと
+  name-en: "Shanghai - The Four Elements [Super Value 2800]"
   region: "NTSC-J"
 SLPS-20127:
   name: "Chou! Rakushii Internet Tomodachi Nowa [Type-OS]"
   region: "NTSC-J"
 SLPS-20128:
-  name: "Toshiyuki Morikawa Private Collection - Puppet Princess of Marl's Kingdom"
+  name: マールDEジグソー 限定版
+  name-sort: まーるDEじぐそー げんていばん
+  name-en: "Toshiyuki Morikawa Private Collection - Puppet Princess of Marl's Kingdom"
   region: "NTSC-J"
 SLPS-20129:
-  name: "Marl de Jigsaw"
+  name: マールDEジグソー
+  name-sort: まーるDEじぐそー
+  name-en: "Marl de Jigsaw"
   region: "NTSC-J"
   compat: 5
 SLPS-20130:
-  name: "New Best Play Professional Baseball"
+  name: 新ベストプレープロ野球
+  name-sort: しんべすとぷれーぷろやきゅう
+  name-en: "New Best Play Professional Baseball"
   region: "NTSC-J"
 SLPS-20131:
   name: "Jissen Pachi-Slot Hisshouhou! Juuou"
   region: "NTSC-J"
 SLPS-20132:
-  name: "Chenuen no San Goku Shi"
+  name: 鄭問之三國誌
+  name-sort: ちぇんうぇんのさんごくし
+  name-en: "Chenuen no San Goku Shi"
   region: "NTSC-J"
 SLPS-20133:
   name: "Pro Mahjong Kiwame Next"
@@ -41488,18 +46838,24 @@ SLPS-20135:
   name: "Pai Chenjan"
   region: "NTSC-J"
 SLPS-20136:
-  name: "Guilty Gear X Plus [DX Pack]"
+  name: ギルティギア ゼクス プラス DXパック
+  name-sort: ぎるてぃぎあ ぜくす ぷらす DXぱっく
+  name-en: "Guilty Gear X Plus [DX Pack]"
   region: "NTSC-J"
   compat: 5
 SLPS-20137:
-  name: "Guilty Gear X Plus"
+  name: ギルティギア ゼクス プラス
+  name-sort: ぎるてぃぎあ ぜくす ぷらす
+  name-en: "Guilty Gear X Plus"
   region: "NTSC-J"
   compat: 5
 SLPS-20138:
   name: "Digital Holmes"
   region: "NTSC-J"
 SLPS-20139:
-  name: "All Star Pro-Wrestling II"
+  name: オールスター・プロレスリングII
+  name-sort: おーるすたー・ぷろれすりんぐII
+  name-en: "All Star Pro-Wrestling II"
   region: "NTSC-J"
 SLPS-20140:
   name: "Dream Audition SuperHit Disc 1"
@@ -41508,10 +46864,14 @@ SLPS-20141:
   name: "Dream Audition SuperHit Disc 2"
   region: "NTSC-J"
 SLPS-20143:
-  name: "RPG Tsukuru 5"
+  name: RPGツクール5
+  name-sort: RPGつくーる5
+  name-en: "RPG Tsukuru 5"
   region: "NTSC-J"
 SLPS-20144:
-  name: "Seed, The"
+  name: シード
+  name-sort: しーど
+  name-en: "Seed, The"
   region: "NTSC-J"
 SLPS-20145:
   name: "TVware Jouhou Kakumei Series - Pro Atlas for TV - Shutoken"
@@ -41526,7 +46886,9 @@ SLPS-20149:
   name: "Chou! Rakushii Internet Tomodachi Nowa [Broadband]"
   region: "NTSC-J"
 SLPS-20150:
-  name: "Akira Psycho Ball"
+  name: AKIRA PSYCHO BALL(アキラ サイコボール)
+  name-sort: AKIRA PSYCHO BALL(あきら さいこぼーる)
+  name-en: "Akira Psycho Ball"
   region: "NTSC-J"
 SLPS-20151:
   name: "Pachi-Slot Aruze Oukoku 6"
@@ -41552,23 +46914,33 @@ SLPS-20160:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes blurriness and misaligned shadows.
 SLPS-20161:
-  name: "Saikyou Toudai Shogi Special"
+  name: 最強 東大将棋スペシャル
+  name-sort: さいきょう とうだいしょうぎすぺしゃる
+  name-en: "Saikyou Toudai Shogi Special"
   region: "NTSC-J"
   compat: 5
 SLPS-20162:
-  name: "Typing Kengo 634 [with Keyboard]"
+  name: タイピング剣豪 六三四の剣（キーボード同梱版）
+  name-sort: たいぴんぐけんごう ろくさんよんのけん（きーぼーどどうこんばん）
+  name-en: "Typing Kengo 634 [with Keyboard]"
   region: "NTSC-J"
 SLPS-20163:
-  name: "Typing Kengo 634"
+  name: タイピング剣豪 六三四の剣
+  name-sort: たいぴんぐけんごう ろくさんよんのけん
+  name-en: "Typing Kengo 634"
   region: "NTSC-J"
 SLPS-20164:
   name: "Plarail - Yume ga Ippai! Plarail de Ikou!"
   region: "NTSC-J"
 SLPS-20165:
-  name: "La Pucelle - Hikari no Seijo Densetsu [Limited Edition]"
+  name: ラ・ピュセル 光の聖女伝説 限定版
+  name-sort: ら・ぴゅせる ひかりのせいじょでんせつ げんていばん
+  name-en: "La Pucelle - Hikari no Seijo Densetsu [Limited Edition]"
   region: "NTSC-J"
 SLPS-20167:
-  name: "La Pucelle - Hikari no Seijo Densetsu"
+  name: ラ・ピュセル 光の聖女伝説
+  name-sort: ら・ぴゅせる ひかりのせいじょでんせつ
+  name-en: "La Pucelle - Hikari no Seijo Densetsu"
   region: "NTSC-J"
 SLPS-20168:
   name: "NHL 2002"
@@ -41580,7 +46952,9 @@ SLPS-20170:
   name: "Wave Rally"
   region: "NTSC-J"
 SLPS-20171:
-  name: "Smash Court Tennis Pro"
+  name: スマッシュコート プロトーナメント
+  name-sort: すまっしゅこーと ぷろとーなめんと
+  name-en: "Smash Court Tennis Pro"
   region: "NTSC-J"
 SLPS-20172:
   name: "Koushien - Konpeki no Sora"
@@ -41595,13 +46969,19 @@ SLPS-20174:
   name: "Typing Renai Hakusho - Boys Be... [with Keyboard]"
   region: "NTSC-J"
 SLPS-20175:
-  name: "Typing Renai Hakusho - Boys Be..."
+  name: タイピング恋愛白書 BOYS BE・・・
+  name-sort: たいぴんぐれんあいはくしょ BOYS BE・・・
+  name-en: "Typing Renai Hakusho - Boys Be..."
   region: "NTSC-J"
 SLPS-20177:
-  name: "Make Your Dream Home"
+  name: マイホームをつくろう!
+  name-sort: まいほーむをつくろう!
+  name-en: "Make Your Dream Home"
   region: "NTSC-J"
 SLPS-20178:
-  name: "Samurai"
+  name: 侍〜SAMURAI〜
+  name-sort: さむらい〜SAMURAI〜
+  name-en: "Samurai"
   region: "NTSC-J"
   gameFixes:
     - EETimingHack # Stops crash after intro movie.
@@ -41618,14 +46998,18 @@ SLPS-20184:
   name: "Eikan wa Kimi ni 2002 - Koushien no Kodou"
   region: "NTSC-J"
 SLPS-20185:
-  name: "Wangan Midnight"
+  name: 湾岸ミッドナイト
+  name-sort: わんがんみっどないと
+  name-en: "Wangan Midnight"
   region: "NTSC-J"
   compat: 5
 SLPS-20186:
   name: "Pachinko de Asobou! Fever Dodeka Saurus"
   region: "NTSC-J"
 SLPS-20187:
-  name: "Black-Matrix II"
+  name: BLACK/MATRIX2
+  name-sort: BLACK/MATRIX2
+  name-en: "Black-Matrix II"
   region: "NTSC-J"
   compat: 5
 SLPS-20190:
@@ -41647,7 +47031,9 @@ SLPS-20193:
   name: "Jissen Pachi-Slot Hisshouhou! Sammy's Collection"
   region: "NTSC-J"
 SLPS-20194:
-  name: "Underwater Unit"
+  name: ーUー underwater unit
+  name-sort: ーUー underwater unit
+  name-en: "Underwater Unit"
   region: "NTSC-J"
 SLPS-20195:
   name: "World Fantasista"
@@ -41655,19 +47041,25 @@ SLPS-20195:
   gameFixes:
     - FullVU0SyncHack # Fixes SPS.
 SLPS-20196:
-  name: "Akagawa Jirou - Tsuki no Hikari - Shizumeru Kane no Satsujin"
+  name: 月の光 ～沈める鐘の殺人～
+  name-sort: つきのひかり ～しずめるかねのさつじん～
+  name-en: "Akagawa Jirou - Tsuki no Hikari - Shizumeru Kane no Satsujin"
   region: "NTSC-J"
 SLPS-20197:
   name: "Surfing Air Show with RatBoy"
   region: "NTSC-J"
 SLPS-20198:
-  name: "Raging Bless"
+  name: RAGINGBLESS 〜降魔黙示録〜
+  name-sort: RAGINGBLESS 〜ごうまもくしろく〜
+  name-en: "Raging Bless"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
     deinterlace: 7 # Fixes blurriness.
 SLPS-20199:
-  name: "F1 2002"
+  name: F1 2002
+  name-sort: F1 2002
+  name-en: "F1 2002"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 1 # Fixes black void when upscaling.
@@ -41675,7 +47067,9 @@ SLPS-20200:
   name: "Final Fantasy XI [Disc 2 of 2]"
   region: "NTSC-J"
 SLPS-20202:
-  name: "Coloball 2002"
+  name: コロボール2002
+  name-sort: ころぼーる2002
+  name-en: "Coloball 2002"
   region: "NTSC-J"
 SLPS-20203:
   name: "Sanyo Pachinko Paradise 7 - Edokko Gen-san"
@@ -41687,7 +47081,9 @@ SLPS-20207:
   name: "Usagi - Yasei no Topai"
   region: "NTSC-J"
 SLPS-20208:
-  name: "Boku wa Chiisai"
+  name: ボクは小さい
+  name-sort: ぼくはちいさい
+  name-en: "Boku wa Chiisai"
   region: "NTSC-J"
   compat: 5
 SLPS-20209:
@@ -41703,7 +47099,9 @@ SLPS-20213:
   name: "Hissatsu Pachinko Station V4 - Drumtic Mahjong"
   region: "NTSC-J"
 SLPS-20214:
-  name: "3D Kakutou Tkool 2"
+  name: 3D格闘ツクール2
+  name-sort: 3Dかくとうつくーる2
+  name-en: "3D Kakutou Tkool 2"
   region: "NTSC-J"
 SLPS-20215:
   name: "Jissen Pachi-Slot Hisshouhou! Aladdin A"
@@ -41720,12 +47118,16 @@ SLPS-20217:
   name: "Hokka Hoka Sentou"
   region: "NTSC-J"
 SLPS-20218:
-  name: "Ninja Assault"
+  name: ニンジャアサルト
+  name-sort: にんじゃあさると
+  name-en: "Ninja Assault"
   region: "NTSC-J"
   gsHWFixes:
     preloadFrameData: 1 # Fixes intro captions not displaying.
 SLPS-20219:
-  name: "Tsukande! Mawashite! Dossun Pazuru Egg Mania"
+  name: エッグマニア つかんで!まわして!どっすんぱず〜る!!
+  name-sort: えっぐまにあ つかんで!まわして!どっすんぱず〜る!!
+  name-en: "Tsukande! Mawashite! Dossun Pazuru Egg Mania"
   region: "NTSC-J"
   patches:
     2A925A22:
@@ -41738,11 +47140,15 @@ SLPS-20220:
   name: "Pachi-Slot Aruze Oukoku 7 [Disc 1][Ekishou Disc]"
   region: "NTSC-J"
 SLPS-20221:
-  name: "Taiko no Tatsujin - Tatacon de Dodon ga Don [with Tatacon]"
+  name: 太鼓の達人 タタコンでドドンがドン(※タタコン同梱セット)
+  name-sort: たいこのたつじん たたこんでどどんがどん(※たたこんどうこんせっと)
+  name-en: "Taiko no Tatsujin - Tatacon de Dodon ga Don [with Tatacon]"
   region: "NTSC-J"
   compat: 5
 SLPS-20222:
-  name: "Inaka Kurasi - Nan no Shima no Monogatari"
+  name: いなか暮らし 南の島の物語
+  name-sort: いなかくらし みなみのしまのものがたり
+  name-en: "Inaka Kurasi - Nan no Shima no Monogatari"
   region: "NTSC-J"
 SLPS-20223:
   name: "Exciting Pro Wres 4"
@@ -41754,7 +47160,9 @@ SLPS-20225:
   name: "Toudai Shougi - Shiken Bisha Doujou"
   region: "NTSC-J"
 SLPS-20226:
-  name: "Yamasa Digi World SP DX - Neo Planett XX"
+  name: 山佐DigiワールドSP DX
+  name-sort: やまさDigiわーるどSP DX
+  name-en: "Yamasa Digi World SP DX - Neo Planett XX"
   region: "NTSC-J"
 SLPS-20227:
   name: "Yamasa Digi World SP - Neo Planett XX"
@@ -41766,7 +47174,9 @@ SLPS-20229:
   name: "Hissatsu Pachinko Station V5 - PinkLady"
   region: "NTSC-J"
 SLPS-20230:
-  name: "Chulip"
+  name: チュウリップ
+  name-sort: ちゅうりっぷ
+  name-en: "Chulip"
   region: "NTSC-J"
   compat: 5
 SLPS-20231:
@@ -41776,7 +47186,9 @@ SLPS-20233:
   name: "Hissatsu Pachinko Station V6 - Yume no Chou Tokkyuu"
   region: "NTSC-J"
 SLPS-20234:
-  name: "Harry Potter to Himitsu no Heya"
+  name: ハリー・ポッターと秘密の部屋
+  name-sort: はりー・ぽったーとひみつのへや
+  name-en: "Harry Potter to Himitsu no Heya"
   region: "NTSC-J"
   gameFixes:
     - EETimingHack # Fixes flickering textures.
@@ -41801,7 +47213,8 @@ SLPS-20242:
   name: "Tomak - Save the Earth - Love Story"
   region: "NTSC-J"
 SLPS-20243:
-  name: "Magical Sports Go Go Golf [NewPrice]"
+  name: NewPrice GoGoGolf
+  name-en: "Go Go Golf [NewPrice]"
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves brightness on terrain textures.
@@ -41809,7 +47222,9 @@ SLPS-20244:
   name: "Magical Sports - 2000 Koushien [NewPrice]"
   region: "NTSC-J"
 SLPS-20245:
-  name: "Low Rider"
+  name: LOWRIDER 〜Round The World〜
+  name-sort: LOWRIDER 〜Round The World〜
+  name-en: "Low Rider"
   region: "NTSC-J"
 SLPS-20246:
   name: "Rally Shox"
@@ -41824,10 +47239,14 @@ SLPS-20248:
   name: "Downforce"
   region: "NTSC-J"
 SLPS-20250:
-  name: "Makai Senki Disgaea [Limited Edition]"
+  name: 魔界戦記 ディスガイア 限定版
+  name-sort: まかいせんき でぃすがいあ げんていばん
+  name-en: "Makai Senki Disgaea [Limited Edition]"
   region: "NTSC-J"
 SLPS-20251:
-  name: "Makai Senki Disgaea"
+  name: 魔界戦記 ディスガイア
+  name-sort: まかいせんき でぃすがいあ
+  name-en: "Makai Senki Disgaea"
   region: "NTSC-J"
 SLPS-20253:
   name: "Pachitte Chonmage Tatsujin 2 - CR Jurassic Park"
@@ -41836,35 +47255,49 @@ SLPS-20255:
   name: "Million God"
   region: "NTSC-J"
 SLPS-20256:
-  name: "Cool Shot - Yukawa Keiko"
+  name: COOL SHOT 夕川景子のプロフェッショナルビリヤード
+  name-sort: COOL SHOT ゆうがわけいこのぷろふぇっしょなるびりやーど
+  name-en: "Cool Shot - Yukawa Keiko"
   region: "NTSC-J"
   compat: 5
 SLPS-20257:
   name: "Yamasa Digi World 4 DX - Penguin Paradise, Crazy Shaman R, Zakzak Senryoubako R, Destroyer XX, King Pulsar"
   region: "NTSC-J"
 SLPS-20258:
-  name: "Yamasa Digi World 4 - Penguin Paradise, Crazy Shaman R, Zakzak Senryoubako R, Destroyer XX, King Pulsar"
+  name: 山佐Digiワールド4
+  name-sort: やまさDigiわーるど4
+  name-en: "Yamasa Digi World 4 - Penguin Paradise, Crazy Shaman R, Zakzak Senryoubako R, Destroyer XX, King Pulsar"
   region: "NTSC-J"
 SLPS-20259:
-  name: "Kotoba no Puzzle - Mojipittan"
+  name: ことばのパズル もじぴったん
+  name-sort: ことばのぱずる もじぴったん
+  name-en: "Kotoba no Puzzle - Mojipittan"
   region: "NTSC-J"
 SLPS-20260:
-  name: "Sakigake!! Kuromati Koukou"
+  name: 魁!! クロマティ高校
+  name-sort: さきがけ!! くろまてぃこうこう
+  name-en: "Sakigake!! Kuromati Koukou"
   region: "NTSC-J"
 SLPS-20261:
   name: "Sanyo Pachinko Paradise 8 - Shin Umi Monogatari"
   region: "NTSC-J"
 SLPS-20262:
-  name: "Slot! Pro DX - Fujiko 2"
+  name: SLOT!PRO DX 不二子2
+  name-sort: SLOT!PRO DX ふじこ2
+  name-en: "Slot! Pro DX - Fujiko 2"
   region: "NTSC-J"
 SLPS-20263:
-  name: "J.League Tactics Manager - Realtime Soccer Simulation"
+  name: J.LEAGUE TACTICS MANAGER
+  name-sort: J.LEAGUE TACTICS MANAGER
+  name-en: "J.League Tactics Manager - Realtime Soccer Simulation"
   region: "NTSC-J"
 SLPS-20264:
   name: "Usagi - Yasei no Touhai - The Arcade"
   region: "NTSC-J"
 SLPS-20265:
-  name: "Fever 7"
+  name: FEVER7 SANKYO公式パチンコシミュレーション
+  name-sort: FEVER7 SANKYOこうしきぱちんこしみゅれーしょん
+  name-en: "Fever 7"
   region: "NTSC-J"
 SLPS-20266:
   name: "Baskelian"
@@ -41876,11 +47309,15 @@ SLPS-20268:
   name: "Jissen Pachi-Slot Hisshouhou! Salaryman Kintarou"
   region: "NTSC-J"
 SLPS-20272:
-  name: "Taiko no Tatsujin - Doki! Shinkyoku Darake no Haru Matsuri"
+  name: 太鼓の達人 ドキッ!新曲だらけの春祭り
+  name-sort: たいこのたつじん どきっ!しんきょくだらけのはるまつり
+  name-en: "Taiko no Tatsujin - Doki! Shinkyoku Darake no Haru Matsuri"
   region: "NTSC-J"
   compat: 5
 SLPS-20273:
-  name: "Netsu Chu! Pro Yakyuu 2003"
+  name: 熱チュー!プロ野球2003
+  name-sort: ねつちゅー!ぷろやきゅう2003
+  name-en: "Netsu Chu! Pro Yakyuu 2003"
   region: "NTSC-J"
   patches:
     34FB1FB7:
@@ -41904,52 +47341,76 @@ SLPS-20278:
   name: "Slotter Up Mania - Chou Oki-Slot! Pioneer Special"
   region: "NTSC-J"
 SLPS-20279:
-  name: "Hissatsu Pachinko Station v7 - Tensai Bakabon 2"
+  name: 必殺パチンコステーションV7 天才バカボン2
+  name-sort: ひっさつぱちんこすてーしょんV7 てんさいばかぼん2
+  name-en: "Hissatsu Pachinko Station v7 - Tensai Bakabon 2"
   region: "NTSC-J"
 SLPS-20280:
-  name: "Mahou no Pumpkin"
+  name: 魔法のパンプキン 〜アンとグレッグの大冒険〜
+  name-sort: まほうのぱんぷきん 〜あんとぐれっぐのだいぼうけん〜
+  name-en: "Mahou no Pumpkin"
   region: "NTSC-J"
 SLPS-20281:
-  name: "Monopoly - Mezase!! Daifugou Jinsei!!"
+  name: モノポリー ～めざせっ!!大富豪人生!!～
+  name-sort: ものぽりー ～めざせっ!!だいふごうじんせい!!～
+  name-en: "Monopoly - Mezase!! Daifugou Jinsei!!"
   region: "NTSC-J"
   clampModes:
     vuClampMode: 0 # Fixes missing game board.
 SLPS-20282:
-  name: "Taiko no Tatsujin - Tatacon de Dodon ga Don"
+  name: 太鼓の達人 タタコンでドドンがドン(ソフト単品)
+  name-sort: たいこのたつじん たたこんでどどんがどん(そふとたんぴん)
+  name-en: "Taiko no Tatsujin - Tatacon de Dodon ga Don"
   region: "NTSC-J"
 SLPS-20283:
   name: "Chulip"
   region: "NTSC-J"
 SLPS-20284:
-  name: "Marl de Jigsaw"
+  name: マールDEジグソー ～日本一ソフトウェア the Best～
+  name-sort: まーるDEじぐそー ～にっぽんいちそふとうぇあ the Best～
+  name-en: "Marl de Jigsaw"
   region: "NTSC-J"
 SLPS-20285:
-  name: "Slotter Up Core"
+  name: スロッターUPコア 炎打!巨人の星
+  name-sort: すろったーUPこあ えんだ!きょじんのほし
+  name-en: "Slotter Up Core"
   region: "NTSC-J"
 SLPS-20286:
   name: "Slotter Up Core 2 Gouda Minami no Teiou"
   region: "NTSC-J"
 SLPS-20287:
-  name: "Yakiniku Bugyou Bonfire!"
+  name: 焼肉奉行 ボンファイア!
+  name-sort: やきにくぶぎょう ぼんふぁいあ!
+  name-en: "Yakiniku Bugyou Bonfire!"
   region: "NTSC-J"
 SLPS-20288:
-  name: "Saikyoe Toedai Shoegi 2003"
+  name: 最強 東大将棋2003
+  name-sort: さいきょう とうだいしょうぎ2003
+  name-en: "Saikyoe Toedai Shoegi 2003"
   region: "NTSC-J"
 SLPS-20289:
-  name: "Yamasa Digi World SP - Umi Ichiban R"
+  name: 山佐DigiワールドSP海一番R
+  name-sort: やまさDigiわーるどSPうみいちばんR
+  name-en: "Yamasa Digi World SP - Umi Ichiban R"
   region: "NTSC-J"
 SLPS-20291:
-  name: "Fish Eyes 3"
+  name: FISH EYES 3〜記憶の破片たち〜
+  name-sort: FISH EYES 3〜きおくのはへんたち〜
+  name-en: "Fish Eyes 3"
   region: "NTSC-J"
 SLPS-20292:
   name: "Jissen Pachi-Slot Hisshouhou! Savanna Park DX"
   region: "NTSC-J"
 SLPS-20293:
-  name: "Jissen Pachi-Slot Hisshouhou! Savanna Park"
+  name: 実戦パチスロ必勝法!サバンナパーク
+  name-sort: じっせんぱちすろひっしょうほう!さばんなぱーく
+  name-en: "Jissen Pachi-Slot Hisshouhou! Savanna Park"
   region: "NTSC-J"
   compat: 5
 SLPS-20294:
-  name: "Hanabi Shokunin Ninarou 2"
+  name: 花火職人になろう2
+  name-sort: はなびしょくにんになろう2
+  name-en: "Hanabi Shokunin Ninarou 2"
   region: "NTSC-J"
 SLPS-20295:
   name: "F1 Career Challenge"
@@ -41957,31 +47418,43 @@ SLPS-20295:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes black void when upscaling.
 SLPS-20296:
-  name: "Dugout '03 - The Turning Point"
+  name: プロ野球シミュレーション ダグアウト’03-the TURNING POINT-
+  name-sort: ぷろやきゅうしみゅれーしょん だぐあうと’03-the TURNING POINT-
+  name-en: "Dugout '03 - The Turning Point"
   region: "NTSC-J"
 SLPS-20298:
   name: "Fever 8 - Sankyo Koushiki Pachinko Simulation"
   region: "NTSC-J"
 SLPS-20299:
-  name: "Black Matrix 2"
+  name: BLACK/MATRIX II ベスト版
+  name-sort: BLACK/MATRIX II べすとばん
+  name-en: "Black Matrix 2"
   region: "NTSC-J"
 SLPS-20300:
-  name: "Mobile Suit - Gundam Seed"
+  name: 機動戦士ガンダムSEED
+  name-sort: きどうせんしがんだむSEED
+  name-en: "Mobile Suit - Gundam Seed"
   region: "NTSC-J"
 SLPS-20301:
-  name: "Gachinko Professional Baseball"
+  name: ガチンコプロ野球
+  name-sort: がちんこぷろやきゅう
+  name-en: "Gachinko Professional Baseball"
   region: "NTSC-J"
 SLPS-20302:
   name: "Gokuraku-jong Premium"
   region: "NTSC-J"
 SLPS-20303:
-  name: "Inaka Kurasi [Best Collection]"
+  name: いなか暮らし～南の島の物語 ベストコレクション
+  name-sort: いなかくらし～みなみのしまのものがたり べすとこれくしょん
+  name-en: "Inaka Kurasi [Best Collection]"
   region: "NTSC-J"
 SLPS-20304:
   name: "Boku wa Chiisai"
   region: "NTSC-J"
 SLPS-20305:
-  name: "Real Sports Professional Baseball"
+  name: REAL SPORTS プロ野球
+  name-sort: REAL SPORTS ぷろやきゅう
+  name-en: "Real Sports Professional Baseball"
   region: "NTSC-J"
 SLPS-20306:
   name: "Slotter Up Mania 2 - Kokuchi no Kyoku! Juggler Special"
@@ -41999,10 +47472,14 @@ SLPS-20310:
   name: "Mahjong Hiryuu Densetsu - Tenpai"
   region: "NTSC-J"
 SLPS-20311:
-  name: "Primopuel - My Special Partner [Limited Edition]"
+  name: プリモプエル おしゃべりは〜とな〜 コプエルマイク同梱版
+  name-sort: ぷりもぷえる おしゃべりは〜とな〜 こぷえるまいくどうこんばん
+  name-en: "Primopuel - My Special Partner [Limited Edition]"
   region: "NTSC-J"
 SLPS-20312:
-  name: "Primopuel - My Special Partner"
+  name: プリモプエル おしゃべりは〜とな〜
+  name-sort: ぷりもぷえる おしゃべりは〜とな〜
+  name-en: "Primopuel - My Special Partner"
   region: "NTSC-J"
 SLPS-20313:
   name: "Mahjong Haou - Taikai Battle"
@@ -42014,24 +47491,34 @@ SLPS-20315:
   name: "Yamasa Digi World SP - Neo Magic Pulsar XX"
   region: "NTSC-J"
 SLPS-20316:
-  name: "Hissatsu Pachinko Station v8"
+  name: 必殺パチンコステーションV8 忍者ハットリくん
+  name-sort: ひっさつぱちんこすてーしょんV8 にんじゃはっとりくん
+  name-en: "Hissatsu Pachinko Station v8"
   region: "NTSC-J"
 SLPS-20317:
-  name: "Jissen Pachi-Slot Hisshouhou! King Camel"
+  name: 実戦パチスロ必勝法!キングキャメル
+  name-sort: じっせんぱちすろひっしょうほう!きんぐきゃめる
+  name-en: "Jissen Pachi-Slot Hisshouhou! King Camel"
   region: "NTSC-J"
   compat: 5
 SLPS-20318:
   name: "3D Kakutou Tkool 2 [ebKore]"
   region: "NTSC-J"
 SLPS-20320:
-  name: "Taiko no Tatsujin - Appare Sandaime [with Tatacon]"
+  name: 太鼓の達人 あっぱれ三代目 太鼓型専用コントローラ『タタコン』同梱版
+  name-sort: たいこのたつじん あっぱれさんだいめ たいこがたせんようこんとろーら『たたこん』どうこんばん
+  name-en: "Taiko no Tatsujin - Appare Sandaime [with Tatacon]"
   region: "NTSC-J"
 SLPS-20321:
-  name: "Taiko no Tatsujin - Appare Sandaime"
+  name: 太鼓の達人 あっぱれ三代目
+  name-sort: たいこのたつじん あっぱれさんだいめ
+  name-en: "Taiko no Tatsujin - Appare Sandaime"
   region: "NTSC-J"
   compat: 5
 SLPS-20322:
-  name: "Netsu Chu! Pro Yakyuu 2003 - Aki no Night Matsuri"
+  name: 熱チュー!プロ野球2003 秋のナイター祭り
+  name-sort: ねつちゅー!ぷろやきゅう2003 あきのないたーまつり
+  name-en: "Netsu Chu! Pro Yakyuu 2003 - Aki no Night Matsuri"
   region: "NTSC-J"
   patches:
     D3DAF7F4:
@@ -42040,7 +47527,9 @@ SLPS-20322:
         comment=fixes hang before ingame
         patch=1,EE,00102398,word,00000000
 SLPS-20323:
-  name: "Pochi to Nyaa"
+  name: ポチッとにゃー
+  name-sort: ぽちっとにゃー
+  name-en: "Pochi to Nyaa"
   region: "NTSC-J"
   compat: 5
 SLPS-20324:
@@ -42053,287 +47542,447 @@ SLPS-20327:
   name: "Mahjong Haou - Jansou Battle"
   region: "NTSC-J"
 SLPS-20328:
-  name: "Otona no Gal Jan - Kimi ni Hane Man"
+  name: おとなのギャル雀 きみにハネ満!〜
+  name-sort: おとなのぎゃるじゃん きみにはねまん!〜
+  name-en: "Otona no Gal Jan - Kimi ni Hane Man"
   region: "NTSC-J"
 SLPS-20329:
-  name: "Kamen Rider 555"
+  name: 仮面ライダー555
+  name-sort: かめんらいだー555
+  name-en: "Kamen Rider 555"
   region: "NTSC-J"
   compat: 5
 SLPS-20330:
-  name: "Taiko no Tatsujin - Waku Waku Anime Matsuri"
+  name: 太鼓の達人 わくわくアニメ祭り
+  name-sort: たいこのたつじん わくわくあにめまつり
+  name-en: "Taiko no Tatsujin - Waku Waku Anime Matsuri"
   region: "NTSC-J"
   compat: 5
 SLPS-20331:
-  name: "Fever 9 - Sankyo"
+  name: FEVER9 SANKYO公式パチンコシミュレーション
+  name-sort: FEVER9 SANKYOこうしきぱちんこしみゅれーしょん
+  name-en: "Fever 9 - Sankyo"
   region: "NTSC-J"
 SLPS-20332:
   name: "Saikyou Toudai Shougi 4"
   region: "NTSC-J"
 SLPS-20333:
-  name: "Taisen 1 - Shogi"
+  name: TAISEN (1) 将棋
+  name-sort: TAISEN (1) しょうぎ
+  name-en: "Taisen 1 - Shogi"
   region: "NTSC-J"
 SLPS-20334:
-  name: "Taisen 2 - Go"
+  name: TAISEN (2) 囲碁
+  name-sort: TAISEN (2) いご
+  name-en: "Taisen 2 - Go"
   region: "NTSC-J"
 SLPS-20335:
-  name: "Taisen 3 - Mahjong"
+  name: TAISEN (3) 麻雀
+  name-sort: TAISEN (3) まーじゃん
+  name-en: "Taisen 3 - Mahjong"
   region: "NTSC-J"
 SLPS-20336:
-  name: "Taisen 4 - Soldier"
+  name: TAISEN (4) ソルジャー 〜企業戦士将棋〜
+  name-sort: TAISEN (4) そるじゃー 〜きぎょうせんししょうぎ〜
+  name-en: "Taisen 4 - Soldier"
   region: "NTSC-J"
 SLPS-20337:
-  name: "Slotter UP - Core Alpha"
+  name: スロッターUPコアα 祝虎!優勝パネル!新化!巨人の星
+  name-sort: すろったーUPこああるふぁ しゅくとら!ゆうしょうぱねる!しんか!きょじんのほし
+  name-en: "Slotter UP - Core Alpha"
   region: "NTSC-J"
 SLPS-20338:
   name: "Slotter Up Mania 3 - Densetsu Fukkatsu! New Pegasus Special"
   region: "NTSC-J"
 SLPS-20339:
-  name: "Jissen Pachi-Slot Hisshouhou! Sammy's Collection 2 DX"
+  name: 実戦パチスロ必勝法! Sammy Collection2 DX
+  name-sort: じっせんぱちすろひっしょうほう! Sammy Collection2 DX
+  name-en: "Jissen Pachi-Slot Hisshouhou! Sammy's Collection 2 DX"
   region: "NTSC-J"
 SLPS-20340:
-  name: "Jissen Pachi-Slot Hisshouhou! Sammy's Collection 2"
+  name: 実戦パチスロ必勝法! Sammy Collection2
+  name-sort: じっせんぱちすろひっしょうほう! Sammy Collection2
+  name-en: "Jissen Pachi-Slot Hisshouhou! Sammy's Collection 2"
   region: "NTSC-J"
 SLPS-20343:
-  name: "Net de Bomberman"
+  name: ネットでボンバーマン
+  name-sort: ねっとでぼんばーまん
+  name-en: "Net de Bomberman"
   region: "NTSC-J"
 SLPS-20344:
-  name: "Phantom Brave [Limited Edition]"
+  name: ファントム・ブレイブ(限定版)
+  name-sort: ふぁんとむ・ぶれいぶ(げんていばん)
+  name-en: "Phantom Brave [Limited Edition]"
   region: "NTSC-J"
 SLPS-20345:
-  name: "Phantom Brave"
+  name: ファントム・ブレイブ(通常版)
+  name-sort: ふぁんとむ・ぶれいぶ(つうじょうばん)
+  name-en: "Phantom Brave"
   region: "NTSC-J"
 SLPS-20347:
-  name: "Saikyou Toudai Shogi 2004"
+  name: 最強 東大将棋2004
+  name-sort: さいきょう とうだいしょうぎ2004
+  name-en: "Saikyou Toudai Shogi 2004"
   region: "NTSC-J"
 SLPS-20349:
-  name: "Mahjong Party - Duel with The Idol"
+  name: まーじゃんパーティー アイドルと麻雀勝負
+  name-sort: まーじゃんぱーてぃー あいどるとまーじゃんしょうぶ
+  name-en: "Mahjong Party - Duel with The Idol"
   region: "NTSC-J"
 SLPS-20350:
-  name: "Soccer Life! We are Challengers to Europe"
+  name: サッカーライフ!
+  name-sort: さっかーらいふ!
+  name-en: "Soccer Life! We are Challengers to Europe"
   region: "NTSC-J"
 SLPS-20351:
-  name: "Slotter UP - Mania 4"
+  name: スロッターUPマニア4 南国の香!スーパーハナハナ&シオマール&オアーゼ
+  name-sort: すろったーUPまにあ4 なんごくのかおり!すーぱーはなはな&しおまーる&おあーぜ
+  name-en: "Slotter UP - Mania 4"
   region: "NTSC-J"
 SLPS-20352:
-  name: "Sukisyo - First Limit & Target Nights"
+  name: 好きなものは好きだからしょうがない!! -FIRST LIMIT&TARGET†NIGHTS- Sukisyo! Episode #01+#02
+  name-sort: すきなものはすきだからしょうがない!! -FIRST LIMIT&TARGET†NIGHTS- Sukisyo! Episode #01+#02
+  name-en: "Sukisyo - First Limit & Target Nights"
   region: "NTSC-J"
 SLPS-20353:
   name: "Suki na Mono wa Suki dakara Shou ga Nai!! First Limit & Target Nights - Sukishou! Episode #01+#02 (Disc 2) (Target Nights - Sukishou! Episode #02)"
   region: "NTSC-J"
 SLPS-20354:
-  name: "Yamasa Digi World 3 [Best of Best]"
+  name: ベストオブベスト 山佐Digiワールド3
+  name-sort: べすとおぶべすと さんさDigiわーるど3
+  name-en: "Yamasa Digi World 3 [Best of Best]"
   region: "NTSC-J"
 SLPS-20355:
-  name: "Yamasa Digi World SP - Neo Planett XX [Best of Best]"
+  name: ベストオブベスト 山佐DigiワールドSPネオプラネットXX
+  name-sort: べすとおぶべすと さんさDigiわーるどSPねおぷらねっとXX
+  name-en: "Yamasa Digi World SP - Neo Planett XX [Best of Best]"
   region: "NTSC-J"
 SLPS-20356:
-  name: "Yamasa Digi World 4 [Best of Best]"
+  name: ベストオブベスト 山佐Digiワールド4
+  name-sort: べすとおぶべすと さんさDigiわーるど4
+  name-en: "Yamasa Digi World 4 [Best of Best]"
   region: "NTSC-J"
 SLPS-20357:
-  name: "Yamasa Digi World SP - Umi Ichiban R [Best of Best]"
+  name: ベストオブベスト 山佐DigiワールドSP 海一番R
+  name-sort: べすとおぶべすと さんさDigiわーるどSP うみいちばんR
+  name-en: "Yamasa Digi World SP - Umi Ichiban R [Best of Best]"
   region: "NTSC-J"
 SLPS-20361:
-  name: "Princess Maker - Refine"
+  name: プリンセスメーカー
+  name-sort: ぷりんせすめーかー
+  name-en: "Princess Maker - Refine"
   region: "NTSC-J"
 SLPS-20362:
-  name: "Kaiketsu Zorro Mezase! Itazura King [Limited Edition]"
+  name: かいけつゾロリ めざせ！いたずらキング EyeToy USBカメラ同梱版
+  name-sort: かいけつぞろり めざせ！いたずらきんぐ EyeToy USBかめらどうこんばん
+  name-en: "Kaiketsu Zorro Mezase! Itazura King [Limited Edition]"
   region: "NTSC-J"
 SLPS-20364:
-  name: "Sekai Saikyou Ginsei Igo 5"
+  name: 世界最強銀星囲碁5
+  name-sort: せかいさいきょうぎんせいいご5
+  name-en: "Sekai Saikyou Ginsei Igo 5"
   region: "NTSC-J"
 SLPS-20365:
-  name: "RockMan Collection [Special Box]"
+  name: 最強銀星将棋4
+  name-sort: さいきょうぎんせいしょうぎ4
+  name-en: "RockMan Collection [Special Box]"
   region: "NTSC-J"
 SLPS-20366:
-  name: "CR Kamen Rider Pachi-Slot Expert 5"
+  name: CR仮面ライダー パチってちょんまげ達人5
+  name-sort: CRかめんらいだー ぱちってちょんまげたつじん5
+  name-en: "CR Kamen Rider Pachi-Slot Expert 5"
   region: "NTSC-J"
 SLPS-20367:
-  name: "Curry House CoCo Ichiban'ya - Kyou mo Genki da! Curry ga Umai!!"
+  name: カレーハウスCoCo壱番屋 今日も元気だ!カレーがうまい!!
+  name-sort: かれーはうすCoCoいちばんや きょうもげんきだ!かれーがうまい!!
+  name-en: "Curry House CoCo Ichiban'ya - Kyou mo Genki da! Curry ga Umai!!"
   region: "NTSC-J"
   compat: 5
 SLPS-20368:
-  name: "Kaiketsu Zorro Mezase! Itazura King"
+  name: かいけつゾロリ めざせ!いたずらキング(単品版)
+  name-sort: かいけつぞろり めざせ!いたずらきんぐ(たんぴんばん)
+  name-en: "Kaiketsu Zorro Mezase! Itazura King"
   region: "NTSC-J"
 SLPS-20369:
-  name: "Kinnikuman Generations"
+  name: キン肉マン ジェネレーションズ
+  name-sort: きんにくまん じぇねれーしょんず
+  name-en: "Kinnikuman Generations"
   region: "NTSC-J"
 SLPS-20370:
-  name: "Slotter Up Core 3 - Doronjo ni Omakase!"
+  name: スロッターUPコア3 愉打! ドロンジョにおまかせ
+  name-sort: すろったーUPこあ3 愉打! どろんじょにおまかせ
+  name-en: "Slotter Up Core 3 - Doronjo ni Omakase!"
   region: "NTSC-J"
 SLPS-20371:
-  name: "Mahjong Haou Shinken Battle"
+  name: 麻雀覇王 真剣バトル
+  name-sort: まーじゃんはおう しんけんばとる
+  name-en: "Mahjong Haou Shinken Battle"
   region: "NTSC-J"
 SLPS-20372:
-  name: "Jissen Pachi-Slot Hisshouhou! Hokuto no Ken [Limited Edition]"
+  name: 実戦パチスロ必勝法! 北斗の拳 DXパック
+  name-sort: じっせんぱちすろひっしょうほう! ほくとのけん DXぱっく
+  name-en: "Jissen Pachi-Slot Hisshouhou! Hokuto no Ken [Limited Edition]"
   region: "NTSC-J"
 SLPS-20373:
-  name: "Jissen Pachi-Slot Hisshouhou! Hokuto no Ken"
+  name: 実戦パチスロ必勝法! 北斗の拳
+  name-sort: じっせんぱちすろひっしょうほう! ほくとのけん
+  name-en: "Jissen Pachi-Slot Hisshouhou! Hokuto no Ken"
   region: "NTSC-J"
 SLPS-20374:
-  name: "Football Kingdom - Trial Edition"
+  name: フットボールキングダム トライアルエディション
+  name-sort: ふっとぼーるきんぐだむ とらいあるえでぃしょん
+  name-en: "Football Kingdom - Trial Edition"
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
 SLPS-20375:
-  name: "Sanyo Pachinko Paradise 10 - Gen-san Okaeri"
+  name: 三洋パチンコパラダイス10 ～源さん おかえりっ!～
+  name-sort: さんようぱちんこぱらだいす10 ～げんさん おかえりっ!～
+  name-en: "Sanyo Pachinko Paradise 10 - Gen-san Okaeri"
   region: "NTSC-J"
 SLPS-20376:
-  name: "Daito Giken Koushiki Pachi-Slot Simulator Yoshimune"
+  name: 大都技研公式パチスロシミュレーター 吉宗
+  name-sort: だいとぎけんこうしきぱちすろしみゅれーたー よしむね
+  name-en: "Daito Giken Koushiki Pachi-Slot Simulator Yoshimune"
   region: "NTSC-J"
 SLPS-20377:
-  name: "Fish Eyes 3 [Best Collection]"
+  name: FISH EYES 3 ～記憶の破片たち～ Best Collection
+  name-sort: FISH EYES 3 ～きおくのはへんたち～ Best Collection
+  name-en: "Fish Eyes 3 [Best Collection]"
   region: "NTSC-J"
 SLPS-20378:
-  name: "Slotter UP - Core 4"
+  name: スロッターUPコア4 ガチスロ! トンちゃんの実戦 パチスロオレ主義!!
+  name-sort: すろったーUPこあ4 がちすろ! とんちゃんのじっせん ぱちすろおれしゅぎ!!
+  name-en: "Slotter UP - Core 4"
   region: "NTSC-J"
   compat: 5
 SLPS-20379:
-  name: "Eikan wa Kimi ni 2004 - Koushien no Kodou [Artdink Best Choice]"
+  name: ARTDINK BEST CHOICE 栄冠は君に2004～甲子園の鼓動～
+  name-sort: ARTDINK BEST CHOICE えいかんはきみに2004～こうしえんのこどう～
+  name-en: "Eikan wa Kimi ni 2004 - Koushien no Kodou [Artdink Best Choice]"
   region: "NTSC-J"
 SLPS-20380:
-  name: "Shinkon Gattai Godannar!!"
+  name: 神魂合体ゴーダンナー!!
+  name-sort: しんこんがったいごーだんなー!!
+  name-en: "Shinkon Gattai Godannar!!"
   region: "NTSC-J"
 SLPS-20381:
-  name: "Monkey Turn V"
+  name: モンキーターンV
+  name-sort: もんきーたーんV
+  name-en: "Monkey Turn V"
   region: "NTSC-J"
 SLPS-20382:
-  name: "Taiko no Tatsujin - Atsumare! Matsuri da!! Yondaime [with Tatacon]"
+  name: 太鼓の達人 あつまれ！祭りだ！！四代目 タタコン同梱セット
+  name-sort: たいこのたつじん あつまれ！まつりだ！！よんだいめ たたこんどうこんせっと
+  name-en: "Taiko no Tatsujin - Atsumare! Matsuri da!! Yondaime [with Tatacon]"
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
 SLPS-20383:
-  name: "Taiko no Tatsujin - Atsumare! Matsuri da!! Yondaime"
+  name: 太鼓の達人 あつまれ！祭りだ！！四代目
+  name-sort: たいこのたつじん あつまれ！まつりだ！！よんだいめ
+  name-en: "Taiko no Tatsujin - Atsumare! Matsuri da!! Yondaime"
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
 SLPS-20384:
-  name: "Hayarigami - Keishichou Kaii Jiken File"
+  name: 流行り神 警視庁怪異事件ファイル （初回限定版）
+  name-sort: はやりがみ けいしちょうかいいじけんふぁいる （しょかいげんていばん）
+  name-en: "Hayarigami - Keishichou Kaii Jiken File"
   region: "NTSC-J"
 SLPS-20386:
-  name: "Value 2000 Series - Igo 4"
+  name: バリュー2000シリーズ 囲碁4
+  name-sort: ばりゅー2000しりーず いご4
+  name-en: "Value 2000 Series - Igo 4"
   region: "NTSC-J"
 SLPS-20387:
-  name: "Value 2000 Series - Shogi 4"
+  name: バリュー2000シリーズ 将棋4
+  name-sort: ばりゅー2000しりーず しょうぎ4
+  name-en: "Value 2000 Series - Shogi 4"
   region: "NTSC-J"
 SLPS-20388:
-  name: "CR Pachinko Yellow Cab - Pachitte Chonmage Tatsujin 6"
+  name: CRぱちんこイエローキャブ パチってちょんまげ達人6
+  name-sort: CRぱちんこいえろーきゃぶ ぱちってちょんまげたつじん6
+  name-en: "CR Pachinko Yellow Cab - Pachitte Chonmage Tatsujin 6"
   region: "NTSC-J"
 SLPS-20389:
-  name: "Saikyou Toudai Shogi 5 [Mycom Best]"
+  name: MYCOM BEST 最強東大将棋5
+  name-sort: MYCOM BEST さいきょうとうだいしょうぎ5
+  name-en: "Saikyou Toudai Shogi 5 [Mycom Best]"
   region: "NTSC-J"
 SLPS-20391:
-  name: "Saiyuki Gunlock"
+  name: 最遊記RELOAD GUNLOCK
+  name-sort: さいゆうきRELOAD GUNLOCK
+  name-en: "Saiyuki Gunlock"
   region: "NTSC-J"
 SLPS-20392:
-  name: "Toudai Shogi - Jouseki Dojo Kanketsuhen"
+  name: 東大将棋 定跡道場 完結編
+  name-sort: とうだいしょうぎ じょうせきどうじょう かんけつへん
+  name-en: "Toudai Shogi - Jouseki Dojo Kanketsuhen"
   region: "NTSC-J"
 SLPS-20393:
-  name: "Princess Maker 2"
+  name: プリンセスメーカー2
+  name-sort: ぷりんせすめーかー2
+  name-en: "Princess Maker 2"
   region: "NTSC-J"
 SLPS-20394:
-  name: "Suki na Mono wa Sukida Rashouganai + White Flower + Sukisyo!"
+  name: 好きなものは好きだからしょうがない!! -RAIN- Sukisyo! Episode #03
+  name-sort: すきなものはすきだからしょうがない!! -RAIN- Sukisyo! Episode #03
+  name-en: "Suki na Mono wa Sukida Rashouganai + White Flower + Sukisyo!"
   region: "NTSC-J"
 SLPS-20396:
-  name: "Slotter UP - Mania 5"
+  name: スロッターUPマニア5 爽快激打!マッハGoGoGo＆だるま猫
+  name-sort: すろったーUPまにあ5 そうかいげきだ!まっはGoGoGo＆だるまねこ
+  name-en: "Slotter UP - Mania 5"
   region: "NTSC-J"
 SLPS-20397:
   name: "Pachitte Chonmage Tatsujin 7 - CR Pachinko Dokaben"
   region: "NTSC-J"
 SLPS-20398:
-  name: "La Pucelle - Hikari no Seijo Densetsu - 2-shuume Hajimemashita"
+  name: ラ・ピュセル 光の聖女伝説 2周目はじめました。
+  name-sort: ら・ぴゅせる ひかりのせいじょでんせつ 2しゅうめはじめました。
+  name-en: "La Pucelle - Hikari no Seijo Densetsu - 2-shuume Hajimemashita"
   region: "NTSC-J"
 SLPS-20399:
-  name: "Taiko no Tatsujin - Go! Go! Godaime [with Tatacon]"
+  name: 太鼓の達人 ゴー!ゴー!五代目(タタコン同梱セット)
+  name-sort: たいこのたつじん ごー!ごー!ごだいめ(たたこんどうこんせっと)
+  name-en: "Taiko no Tatsujin - Go! Go! Godaime [with Tatacon]"
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
 SLPS-20400:
-  name: "Taiko no Tatsujin - Go! Go! Godaime"
+  name: 太鼓の達人 ゴー!ゴー!五代目(ソフト単品)
+  name-sort: たいこのたつじん ごー!ごー!ごだいめ(そふとたんぴん)
+  name-en: "Taiko no Tatsujin - Go! Go! Godaime"
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
 SLPS-20401:
-  name: "Tecmo Hit Parade"
+  name: テクモ ヒットパレード
+  name-sort: てくも ひっとぱれーど
+  name-en: "Tecmo Hit Parade"
   region: "NTSC-J"
 SLPS-20402:
-  name: "Kamen Rider Blade"
+  name: 仮面ライダー剣(ブレイド)
+  name-sort: かめんらいだーけん(ぶれいど)
+  name-en: "Kamen Rider Blade"
   region: "NTSC-J"
   compat: 5
 SLPS-20403:
-  name: "Shanghai - Sangoku Pai Tatagi [Super Value 2800]"
+  name: super value 2800 上海〜三国牌闘儀〜
+  name-sort: super value 2800 しゃんはい〜さんこくぱい闘儀〜
+  name-en: "Shanghai - Sangoku Pai Tatagi [Super Value 2800]"
   region: "NTSC-J"
 SLPS-20404:
   name: "Rakushou! Pachi-Slot Sengen 2 - Juujika, Deka Dan"
   region: "NTSC-J"
 SLPS-20405:
-  name: "Slotter UP - Core 5"
+  name: スロッターUPコア5 ルパン大好き!主役は銭形
+  name-sort: すろったーUPこあ5 るぱんだいすき!しゅやくはぜにがた
+  name-en: "Slotter UP - Core 5"
   region: "NTSC-J"
 SLPS-20406:
-  name: "Cam-Station [with EyeToy & USB Headset]"
+  name: C@M-STATION カム・ステーション 同梱版 (“EyeToy”カメラ＆USBヘッドセット同梱版)
+  name-sort: C@M-STATION かむ・すてーしょん どうこんばん (“EyeToy”かめら＆USBへっどせっとどうこんばん)
+  name-en: "Cam-Station [with EyeToy & USB Headset]"
   region: "NTSC-J"
 SLPS-20407:
-  name: "Mahjong Sangokushi"
+  name: 麻雀三国志
+  name-sort: まーじゃんさんごくし
+  name-en: "Mahjong Sangokushi"
   region: "NTSC-J"
 SLPS-20408:
-  name: "Card Captor Sakura - Sakura-Chan to Asobo!"
+  name: カードキャプターさくら 「さくらちゃんとあそぼ!」
+  name-sort: かーどきゃぷたーさくら 「さくらちゃんとあそぼ!」
+  name-en: "Card Captor Sakura - Sakura-Chan to Asobo!"
   region: "NTSC-J"
   compat: 5
 SLPS-20409:
-  name: "Phantom Kingdom [Limited Edition]"
+  name: ファントム・キングダム(初回限定版)
+  name-sort: ふぁんとむ・きんぐだむ(しょかいげんていばん)
+  name-en: "Phantom Kingdom [Limited Edition]"
   region: "NTSC-J"
 SLPS-20410:
-  name: "Phantom Kingdom [Limited Edition]"
+  name: ファントム・キングダム
+  name-sort: ふぁんとむ・きんぐだむ
+  name-en: "Phantom Kingdom [Limited Edition]"
   region: "NTSC-J"
 SLPS-20411:
-  name: "Hissatsu Pachinko Station v9"
+  name: 必殺パチンコステーションV9 おそ松くん
+  name-sort: ひっさつぱちんこすてーしょんV9 おそまつくん
+  name-en: "Hissatsu Pachinko Station v9"
   region: "NTSC-J"
 SLPS-20412:
-  name: "Hissatsu Pachinko Station v10"
+  name: 必殺パチンコステーションV10 レレレにおまかせ
+  name-sort: ひっさつぱちんこすてーしょんV10 れれれにおまかせ
+  name-en: "Hissatsu Pachinko Station v10"
   region: "NTSC-J"
 SLPS-20413:
-  name: "Taiko no Tatsujin - Taiko Drum Master [with Tatacon]"
+  name: 太鼓の達人 TAIKO DRUM MASTERS(タタコン同梱)
+  name-sort: たいこのたつじん TAIKO DRUM MASTERS(たたこんどうこん)
+  name-en: "Taiko no Tatsujin - Taiko Drum Master [with Tatacon]"
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
 SLPS-20414:
-  name: "Taiko no Tatsujin - Taiko Drum Master"
+  name: 太鼓の達人 TAIKO DRUM MASTER
+  name-sort: たいこのたつじん TAIKO DRUM MASTER
+  name-en: "Taiko no Tatsujin - Taiko Drum Master"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
 SLPS-20416:
-  name: "Inyou Taisenki - Byakko Enbu [with EyeToy]"
+  name: 陰陽大戦記 白虎演舞 “EyeToy”カメラ同梱版
+  name-sort: いんようだいせんき びゃっこえんぶ “EyeToy”かめらどうこんばん
+  name-en: "Inyou Taisenki - Byakko Enbu [with EyeToy]"
   region: "NTSC-J"
 SLPS-20417:
-  name: "Inyou Taisenki - Byakko Enbu"
+  name: 陰陽大戦記 白虎演舞
+  name-sort: いんようだいせんき びゃっこえんぶ
+  name-en: "Inyou Taisenki - Byakko Enbu"
   region: "NTSC-J"
 SLPS-20418:
-  name: "Cam-Station"
+  name: C@M-STATION カム・ステーション
+  name-sort: C@M-STATION かむ・すてーしょん
+  name-en: "Cam-Station"
   region: "NTSC-J"
 SLPS-20419:
   name: "Rakushou! Pachi-Slot Sengen 3 - Rio de Carnival, Juujika 600-shiki"
   region: "NTSC-J"
 SLPS-20420:
-  name: "Ultraman Nexus"
+  name: ウルトラマンネクサス
+  name-sort: うるとらまんねくさす
+  name-en: "Ultraman Nexus"
   region: "NTSC-J"
 SLPS-20421:
-  name: "Sekai Saikyou Ginsei Igo 6"
+  name: 世界最強銀星囲碁6
+  name-sort: せかいさいきょうぎんせいいご6
+  name-en: "Sekai Saikyou Ginsei Igo 6"
   region: "NTSC-J"
 SLPS-20422:
-  name: "Hayarigami Revenge"
+  name: 流行り神 Revenge 警視庁怪異事件ファイル
+  name-sort: はやりがみ Revenge けいしちょうかいいじけんふぁいる
+  name-en: "Hayarigami Revenge"
   region: "NTSC-J"
 SLPS-20423:
-  name: "LEGO Star Wars - The Video Game"
+  name: レゴ スター・ウォーズ
+  name-sort: れご すたー・うぉーず
+  name-en: "LEGO Star Wars - The Video Game"
   region: "NTSC-J"
   clampModes:
     vuClampMode: 3 # Fixes bad coordinate spam.
 SLPS-20424:
-  name: "Taiko no Tatsujin - Tobikkiri! Anime Special [with Tatacon]"
+  name: 太鼓の達人 とびっきり!アニメスペシャル (「タタコン」同梱版)
+  name-sort: たいこのたつじん とびっきり!あにめすぺしゃる (「たたこん」どうこんばん)
+  name-en: "Taiko no Tatsujin - Tobikkiri! Anime Special [with Tatacon]"
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
 SLPS-20425:
-  name: "Taiko no Tatsujin - Tobikkiri! Anime Special"
+  name: 太鼓の達人 とびっきり!アニメスペシャル (ソフト単品)
+  name-sort: たいこのたつじん とびっきり!あにめすぺしゃる (そふとたんぴん)
+  name-en: "Taiko no Tatsujin - Tobikkiri! Anime Special"
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
@@ -42349,40 +47998,62 @@ SLPS-20427:
   name: "Pachi-Slot Club Collection - Pachi-Slot da yo Koumon-chama"
   region: "NTSC-J"
 SLPS-20428:
-  name: "Monkey Turn V [Bandai the Best]"
+  name: モンキーターンV BANDAI THE BEST
+  name-sort: もんきーたーんV BANDAI THE BEST
+  name-en: "Monkey Turn V [Bandai the Best]"
   region: "NTSC-J"
 SLPS-20429:
-  name: "Hissatsu Pachislot Ninja Hattori Kun V"
+  name: 必殺パチスロエヴォリューション 忍者ハットリくんV
+  name-sort: ひっさつぱちすろえゔぉりゅーしょん にんじゃはっとりくんV
+  name-en: "Hissatsu Pachislot Ninja Hattori Kun V"
   region: "NTSC-J"
 SLPS-20430:
-  name: "Simple 2000 Series Vol. 91 - The All-Star Kakutou"
+  name: SIMPLE2000シリーズ Vol.91 THE ALL★STAR格闘祭
+  name-sort: SIMPLE2000しりーず Vol.91 THE ALL★STARかくとうさい
+  name-en: "Simple 2000 Series Vol. 91 - The All-Star Kakutou"
   region: "NTSC-J"
   compat: 5
   gameFixes:
     - XGKickHack # Fixes cell shade like effect.
 SLPS-20431:
-  name: "Simple 2000 Series Vol. 86 - The Menkyo Shutoku Simulation"
+  name: SIMPLE2000シリーズ Vol.86 THE 免許取得シミュレーション 〜改正道路交通法対応版〜
+  name-sort: SIMPLE2000しりーず Vol.86 THE めんきょしゅとくしみゅれーしょん 〜かいせいどうろこうつうほうたいおうばん〜
+  name-en: "Simple 2000 Series Vol. 86 - The Menkyo Shutoku Simulation"
   region: "NTSC-J"
 SLPS-20436:
-  name: "Sakigake!! Otokojuku"
+  name: 魁!!男塾
+  name-sort: さきがけ!!おとこじゅく
+  name-en: "Sakigake!! Otokojuku"
   region: "NTSC-J"
 SLPS-20439:
-  name: "Simple 2000 Series Vol. 79 - The Party Quiz - Akko ni Omakase"
+  name: SIMPLE2000シリーズ Vol.79 アッコにおまかせ! THE パーティークイズ
+  name-sort: SIMPLE2000しりーず Vol.79 あっこにおまかせ! THE ぱーてぃーくいず
+  name-en: "Simple 2000 Series Vol. 79 - The Party Quiz - Akko ni Omakase"
   region: "NTSC-J"
 SLPS-20440:
-  name: "Simple 2000 Series Vol. 88 - The Mini Bijo Keikan"
+  name: SIMPLE 2000シリーズ Vol.88 THE ミニ美女警官
+  name-sort: SIMPLE 2000しりーず Vol.88 THE みにびじょけいかん
+  name-en: "Simple 2000 Series Vol. 88 - The Mini Bijo Keikan"
   region: "NTSC-J"
 SLPS-20441:
-  name: "Simple 2000 Series Vol. 87 - The Nadesiko"
+  name: SIMPLE 2000シリーズ Vol.87 THE 戦娘
+  name-sort: SIMPLE 2000しりーず Vol.87 THE なでしこ
+  name-en: "Simple 2000 Series Vol. 87 - The Nadesiko"
   region: "NTSC-J"
 SLPS-20442:
-  name: "Daito Giken Koushiki Pachi-Slot Simulator Banchou"
+  name: 大都技研公式パチスロシミュレーター 押忍!番長
+  name-sort: だいとぎけんこうしきぱちすろしみゅれーたー おす!ばんちょう
+  name-en: "Daito Giken Koushiki Pachi-Slot Simulator Banchou"
   region: "NTSC-J"
 SLPS-20443:
-  name: "Blokus Club with Bumpy Trot"
+  name: ブロックス倶楽部 withバンピートロット
+  name-sort: ぶろっくすくらぶ withばんぴーとろっと
+  name-en: "Blokus Club with Bumpy Trot"
   region: "NTSC-J"
 SLPS-20444:
-  name: "Simple 2000 Series Vol. 90 - The OneeChanBara 2"
+  name: SIMPLE2000シリーズ Vol.90 THE お姉チャンバラ2
+  name-sort: SIMPLE2000しりーず Vol.90 THE おあねちゃんばら2
+  name-en: "Simple 2000 Series Vol. 90 - The OneeChanBara 2"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
@@ -42391,33 +48062,47 @@ SLPS-20444:
   gameFixes:
     - XGKickHack # Fixes blank textures.
 SLPS-20445:
-  name: "Simple 2000 Series Ultimate Vol. 28 - Tousou! Kenka Grand Prix - Drive to Survive"
+  name: SIMPLE2000シリーズ Ultimate Vol.28 闘走!喧嘩グランプリ 〜Drive to Survive〜
+  name-sort: SIMPLE2000しりーず Ultimate Vol.28 とうそう!けんかぐらんぷり 〜Drive to Survive〜
+  name-en: "Simple 2000 Series Ultimate Vol. 28 - Tousou! Kenka Grand Prix - Drive to Survive"
   region: "NTSC-J"
 SLPS-20446:
-  name: "Simple 2000 Series Vol. 89 - The Party Game 2"
+  name: SIMPLE 2000シリーズ Vol.89 THE パーティーゲーム2
+  name-sort: SIMPLE 2000しりーず Vol.89 THE ぱーてぃーげーむ2
+  name-en: "Simple 2000 Series Vol. 89 - The Party Game 2"
   region: "NTSC-J"
 SLPS-20447:
-  name: "Kamen Rider Hibiki"
+  name: 仮面ライダーヒビキ(初回生産版)
+  name-sort: かめんらいだーひびき(しょかいせいさんばん)
+  name-en: "Kamen Rider Hibiki"
   region: "NTSC-J"
   compat: 5
 SLPS-20448:
   name: "Kamen Rider Hibiki - Taiko no Tatsujin Special Version [Trial]"
   region: "NTSC-J"
 SLPS-20450:
-  name: "Taiko no Tatsujin - Wai Wai Happy! Rokudaime [with Tatacon]"
+  name: 太鼓の達人 わいわいハッピー!六代目 タタコン同梱版
+  name-sort: たいこのたつじん わいわいはっぴー!ろくだいめ たたこんどうこんばん
+  name-en: "Taiko no Tatsujin - Wai Wai Happy! Rokudaime [with Tatacon]"
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
 SLPS-20451:
-  name: "Taiko no Tatsujin - Wai Wai Happy! Rokudaime"
+  name: 太鼓の達人 わいわいハッピー!六代目
+  name-sort: たいこのたつじん わいわいはっぴー!ろくだいめ
+  name-en: "Taiko no Tatsujin - Wai Wai Happy! Rokudaime"
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
 SLPS-20452:
-  name: "Simple 2000 Series Ultimate Vol. 30 - Kourin! Zokusha Goddo!"
+  name: SIMPLE 2000シリーズ Ultimate Vol.30 降臨!族車ゴッド〜仏恥義理★愛羅武勇〜
+  name-sort: SIMPLE 2000しりーず Ultimate Vol.30 こうりん!ぞくしゃごっど〜ふっちぎり★あいらぶゆう〜
+  name-en: "Simple 2000 Series Ultimate Vol. 30 - Kourin! Zokusha Goddo!"
   region: "NTSC-J"
 SLPS-20453:
-  name: "Simple 2000 Series Ultimate Vol. 29 - K-1 Premium 2005 Dynamite!!"
+  name: SIMPLE 2000シリーズ Ultimate Vol.29 K-1 PREMIUM 2005 Dynamite!!
+  name-sort: SIMPLE 2000しりーず Ultimate Vol.29 K-1 PREMIUM 2005 Dynamite!!
+  name-en: "Simple 2000 Series Ultimate Vol. 29 - K-1 Premium 2005 Dynamite!!"
   region: "NTSC-J"
   compat: 5
   gameFixes:
@@ -42430,44 +48115,70 @@ SLPS-20453:
         patch=1,EE,00336a20,word,0000948c
         patch=1,EE,00336a48,word,0000948c
 SLPS-20454:
-  name: "Simple 2000 Series Vol. 93 - The Unou Drill"
+  name: SIMPLE2000 Vol.93 THE 右脳ドリル
+  name-sort: SIMPLE2000 Vol.93 THE うのうどりる
+  name-en: "Simple 2000 Series Vol. 93 - The Unou Drill"
   region: "NTSC-J"
 SLPS-20455:
-  name: "Simple 2000 Series Vol. 94 - The Aka-Champion - Come on Baby"
+  name: SIMPLE 2000シリーズ Vol.94 THE 赤ちゃんぴおん〜COME ON BABY〜
+  name-sort: SIMPLE 2000しりーず Vol.94 THE あかちゃんぴおん〜COME ON BABY〜
+  name-en: "Simple 2000 Series Vol. 94 - The Aka-Champion - Come on Baby"
   region: "NTSC-J"
 SLPS-20456:
-  name: "Simple 2000 Series Vol. 95 - The Zombie vs. Kyuukyuusha"
+  name: SIMPLE 2000シリーズ Vol.95 THE ゾンビV.S.救急車
+  name-sort: SIMPLE 2000しりーず Vol.95 THE ぞんびV.S.きゅうきゅうしゃ
+  name-en: "Simple 2000 Series Vol. 95 - The Zombie vs. Kyuukyuusha"
   region: "NTSC-J"
 SLPS-20457:
-  name: "Hissatsu Pachislo Evolution 2 - Osomatsu-Kun"
+  name: 必殺パチスロエヴォリューション2 おそ松くん
+  name-sort: ひっさつぱちすろえゔぉりゅーしょん2 おそまつくん
+  name-en: "Hissatsu Pachislo Evolution 2 - Osomatsu-Kun"
   region: "NTSC-J"
 SLPS-20458:
-  name: "Simple 2000 Series Vol. 96 - The Kaizoku - Gaikotsu Ippaire~tsu!"
+  name: SIMPLE 2000シリーズ Vol.96 THE 海賊 〜ガイコツいっぱいれーつ!〜
+  name-sort: SIMPLE 2000しりーず Vol.96 THE かいぞく 〜がいこついっぱいれーつ!〜
+  name-en: "Simple 2000 Series Vol. 96 - The Kaizoku - Gaikotsu Ippaire~tsu!"
   region: "NTSC-J"
 SLPS-20459:
-  name: "Yamasa Digi World SP - Isao Lady"
+  name: 山佐DigiワールドSP 燃えよ!功夫淑女
+  name-sort: やまさDigiわーるどSP もえよ!かんふーれでぃ
+  name-en: "Yamasa Digi World SP - Isao Lady"
   region: "NTSC-J"
 SLPS-20460:
-  name: "Rakushou! Pachi-Slot Sengen 4"
+  name: 楽勝!パチスロ宣言4 真モグモグ風林火山・リオデカーニバル
+  name-sort: らくしょう!ぱちすろせんげん4 しんもぐもぐふうりんかざん・りおでかーにばる
+  name-en: "Rakushou! Pachi-Slot Sengen 4"
   region: "NTSC-J"
 SLPS-20461:
-  name: "Simple 2000 Series Vol. 99 - The Genshijin"
+  name: SIMPLE 2000シリーズ Vol.99 THE 原始人
+  name-sort: SIMPLE 2000しりーず Vol.99 THE げんしじん
+  name-en: "Simple 2000 Series Vol. 99 - The Genshijin"
   region: "NTSC-J"
   compat: 5
 SLPS-20462:
-  name: "Ougon Kishi Garo [Limited Edition]"
+  name: 黄金騎士 牙狼<GARO>[限定版]
+  name-sort: おうごんきし がろ[げんていばん]
+  name-en: "Ougon Kishi Garo [Limited Edition]"
   region: "NTSC-J"
 SLPS-20463:
-  name: "Ougon Kishi Garo"
+  name: 黄金騎士 牙狼<GARO>[通常版]
+  name-sort: おうごんきし がろ[つうじょうばん]
+  name-en: "Ougon Kishi Garo"
   region: "NTSC-J"
 SLPS-20464:
-  name: "Simple 2000 Series Vol. 105 - The Maid-Fuku to Kikanjuu"
+  name: SIMPLE2000シリーズ Vol.105 THE メイド服と機関銃
+  name-sort: SIMPLE2000しりーず Vol.105 THE めいどふくときかんじゅう
+  name-en: "Simple 2000 Series Vol. 105 - The Maid-Fuku to Kikanjuu"
   region: "NTSC-J"
 SLPS-20465:
-  name: "Simple 2000 Series Vol. 100 - The Otoko Tachi no Kijuu Houza"
+  name: SIMPLE2000シリーズ Vol.100 THE 男たちの機銃砲座
+  name-sort: SIMPLE2000しりーず Vol.100 THE おとこたちのきじゅうほうざ
+  name-en: "Simple 2000 Series Vol. 100 - The Otoko Tachi no Kijuu Houza"
   region: "NTSC-J"
 SLPS-20466:
-  name: "Simple 2000 Series Vol. 101 - The OneeChanpon - OneeChan 2 Special Edition"
+  name: SIMPLE2000シリーズ Vol.101 THE お姉チャンポン 〜THE 姉チャン2 特別編〜
+  name-sort: SIMPLE2000しりーず Vol.101 THE おあねちゃんぽん 〜THE あねちゃん2 とくべつへん〜
+  name-en: "Simple 2000 Series Vol. 101 - The OneeChanpon - OneeChan 2 Special Edition"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 1 # Needed to remove part of red box.
@@ -42475,123 +48186,191 @@ SLPS-20466:
   gameFixes:
     - XGKickHack # Fixes blank textures.
 SLPS-20467:
-  name: "Simple 2000 Series Vol. 102 - The Hohei - Senjou no Inutachi"
+  name: SIMPLE2000シリーズ Vol.102 THE歩兵〜戦場の犬たち〜
+  name-sort: SIMPLE2000しりーず Vol.102 THEほへい〜せんじょうのいぬたち〜
+  name-en: "Simple 2000 Series Vol. 102 - The Hohei - Senjou no Inutachi"
   region: "NTSC-J"
 SLPS-20468:
-  name: "Simple 2000 Series Vol. 106 - The Block Kuzushi Quest - Dragon Kingdom"
+  name: SIMPLE2000シリーズ Vol.106 THEブロックくずしクエスト 〜DragonKingdom〜
+  name-sort: SIMPLE2000しりーず Vol.106 THEぶろっくくずしくえすと 〜DragonKingdom〜
+  name-en: "Simple 2000 Series Vol. 106 - The Block Kuzushi Quest - Dragon Kingdom"
   region: "NTSC-J"
   compat: 5
 SLPS-20469:
-  name: "Matching Maker 2"
+  name: 街ingメーカー2 〜続・ぼくの街づくり〜
+  name-sort: まちingめーかー2 〜ぞく・ぼくのまちづくり〜
+  name-en: "Matching Maker 2"
   region: "NTSC-J"
   compat: 5
 SLPS-20470:
-  name: "Simple 2000 Series Vol. 103 - The Chikyuu Boueigun Tactics"
+  name: SIMPLE2000シリーズ Vol.103 THE地球防衛軍タクティクス
+  name-sort: SIMPLE2000しりーず Vol.103 THEちきゅうぼうえいぐんたくてぃくす
+  name-en: "Simple 2000 Series Vol. 103 - The Chikyuu Boueigun Tactics"
   region: "NTSC-J"
 SLPS-20471:
   name: "Chulip [Super Best Collection]"
   region: "NTSC-J"
 SLPS-20472:
-  name: "Daito Giken Koushiki Pachi-Slot Simulator - Hihouden"
+  name: 大都技研公式パチスロシミュレーター 秘宝伝
+  name-sort: だいとぎけんこうしきぱちすろしみゅれーたー ひほうでん
+  name-en: "Daito Giken Koushiki Pachi-Slot Simulator - Hihouden"
   region: "NTSC-J"
 SLPS-20473:
-  name: "Simple 2000 Series Vol. 104 - The Robot Tsuku Rouze! - Gekitou! Robot Fight"
+  name: SIMPLE2000シリーズ Vol.104 THE ロボットつくろうぜっ! 〜激闘!ロボットファイト〜
+  name-sort: SIMPLE2000しりーず Vol.104 THE ろぼっとつくろうぜっ! 〜げきとう!ろぼっとふぁいと〜
+  name-en: "Simple 2000 Series Vol. 104 - The Robot Tsuku Rouze! - Gekitou! Robot Fight"
   region: "NTSC-J"
 SLPS-20474:
-  name: "Simple 2000 Series Vol. 107 - The Honoo no Kakutou Banchou"
+  name: SIMPLE2000シリーズ Vol.107 THE 炎の格闘番長
+  name-sort: SIMPLE2000しりーず Vol.107 THE えんのかくとうばんちょう
+  name-en: "Simple 2000 Series Vol. 107 - The Honoo no Kakutou Banchou"
   region: "NTSC-J"
 SLPS-20475:
-  name: "Yamasa Digi World SP - Giant Pulsar"
+  name: 山佐DigiワールドSP ジャイアントパルサー
+  name-sort: やまさDigiわーるどSP じゃいあんとぱるさー
+  name-en: "Yamasa Digi World SP - Giant Pulsar"
   region: "NTSC-J"
   compat: 5
 SLPS-20476:
-  name: "Simple 2000 Series Vol. 108 - The Nippon Tokushubutai"
+  name: SIMPLE2000シリーズ Vol.108 THE 日本特殊部隊
+  name-sort: SIMPLE2000しりーず Vol.108 THE にっぽんとくしゅぶたい
+  name-en: "Simple 2000 Series Vol. 108 - The Nippon Tokushubutai"
   region: "NTSC-J"
 SLPS-20477:
-  name: "Fish Eyes 3 [Super Best Collection]"
+  name: FISH EYES 3 〜記憶の破片たち〜 Super Best Collection
+  name-sort: FISH EYES 3 〜きおくのはへんたち〜 Super Best Collection
+  name-en: "Fish Eyes 3 [Super Best Collection]"
   region: "NTSC-J"
 SLPS-20478:
-  name: "Simple 2000 Series Vol. 109 - The Taxi 2 - Untenshu ha Yappari Kimi da!"
+  name: SIMPLE2000シリーズ Vol.109 THEタクシー2 〜運転手はやっぱり君だ!〜
+  name-sort: SIMPLE2000しりーず Vol.109 THEたくしー2 〜うんてんしゅはやっぱりきみだ!〜
+  name-en: "Simple 2000 Series Vol. 109 - The Taxi 2 - Untenshu ha Yappari Kimi da!"
   region: "NTSC-J"
 SLPS-20479:
-  name: "Sokudoku Master"
+  name: 速読マスター
+  name-sort: そくどくますたー
+  name-en: "Sokudoku Master"
   region: "NTSC-J"
 SLPS-20480:
-  name: "Simple 2000 Series Vol. 110 - The Toubou Prisoner"
+  name: SIMPLE2000シリーズ Vol.110 THE逃亡プリズナー 〜ロスシティ 真実への10時間〜
+  name-sort: SIMPLE2000しりーず Vol.110 THEとうぼうぷりずなー 〜ろすしてぃ しんじつへの10じかん〜
+  name-en: "Simple 2000 Series Vol. 110 - The Toubou Prisoner"
   region: "NTSC-J"
 SLPS-20481:
-  name: "Simple 2000 Series Vol. 112 - The Tousou Highway 2 - Road Warrior 2050"
+  name: SIMPLE2000シリーズ Vol.112 THE逃走ハイウェイ2 〜ROAD WARRIOR 2050〜
+  name-sort: SIMPLE2000しりーず Vol.112 THEとうそうはいうぇい2 〜ROAD WARRIOR 2050〜
+  name-en: "Simple 2000 Series Vol. 112 - The Tousou Highway 2 - Road Warrior 2050"
   region: "NTSC-J"
 SLPS-20482:
-  name: "3D Mahjong + Janpai Tori"
+  name: 3D麻雀+雀牌取り
+  name-sort: 3Dまーじゃん+じゃんぱいとり
+  name-en: "3D Mahjong + Janpai Tori"
   region: "NTSC-J"
 SLPS-20483:
-  name: "Kamen Rider Kabuto"
+  name: 仮面ライダーカブト
+  name-sort: かめんらいだーかぶと
+  name-en: "Kamen Rider Kabuto"
   region: "NTSC-J"
 SLPS-20484:
-  name: "Simple 2000 Series Ultimate Vol. 34 - Sakigake!! Otokojuku"
+  name: SIMPLE2000シリーズ UltimateVol.34 魁!!男塾
+  name-sort: SIMPLE2000しりーず UltimateVol.34 さきがけ!!おとこじゅく
+  name-en: "Simple 2000 Series Ultimate Vol. 34 - Sakigake!! Otokojuku"
   region: "NTSC-J"
 SLPS-20485:
-  name: "Taiko no Tatsujin - Doka! to Oomori Nanadaime [with Tatacon]"
+  name: 太鼓の達人 ドカッ!と大盛り七代目(タタコン同梱)
+  name-sort: たいこのたつじん どかっ!とおおもりななだいめ(たたこんどうこん)
+  name-en: "Taiko no Tatsujin - Doka! to Oomori Nanadaime [with Tatacon]"
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
 SLPS-20486:
-  name: "Taiko no Tatsujin - Doka! to Oomori Nanadaime"
+  name: 太鼓の達人 ドカッ!と大盛り七代目
+  name-sort: たいこのたつじん どかっ!とおおもりななだいめ
+  name-en: "Taiko no Tatsujin - Doka! to Oomori Nanadaime"
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
 SLPS-20487:
-  name: "Pachi-Slot King! Kagaku Ninja-Tai Gatchaman"
+  name: パチスロキング! 科学忍者隊ガッチャマン
+  name-sort: ぱちすろきんぐ! かがくにんじゃたいがっちゃまん
+  name-en: "Pachi-Slot King! Kagaku Ninja-Tai Gatchaman"
   region: "NTSC-J"
 SLPS-20488:
-  name: "Simple 2000 Series Vol. 113 - The Tairyou Jigoku"
+  name: SIMPLE2000シリーズ Vol.113 THE大量地獄
+  name-sort: SIMPLE2000しりーず Vol.113 THEたいりょうじごく
+  name-en: "Simple 2000 Series Vol. 113 - The Tairyou Jigoku"
   region: "NTSC-J"
 SLPS-20489:
-  name: "Simple 2000 Series Vol. 114 - The Onna Okappichi Torimonochou - Oharu-chan GoGoGo!"
+  name: SIMPLE2000シリーズ Vol.114 THE女岡っピチ捕物帳 〜お春ちゃんGOGOGO!〜
+  name-sort: SIMPLE2000しりーず Vol.114 THEおんなおかっぴちとりものちょう 〜おはるちゃんGOGOGO!〜
+  name-en: "Simple 2000 Series Vol. 114 - The Onna Okappichi Torimonochou - Oharu-chan GoGoGo!"
   region: "NTSC-J"
   gsHWFixes:
     disableDepthSupport: 1 # Fixes black screen in-game.
     getSkipCount: "GSC_Simple2000Vol114"
 SLPS-20490:
-  name: "Pachi-Slot Club Collection - IM Juggler EX - Juggler Selection"
+  name: パチスロ倶楽部コレクション アイムジャグラーEX〜ジャグラーセレクション〜
+  name-sort: ぱちすろくらぶこれくしょん あいむじゃぐらーEX〜じゃぐらーせれくしょん〜
+  name-en: "Pachi-Slot Club Collection - IM Juggler EX - Juggler Selection"
   region: "NTSC-J"
 SLPS-20491:
-  name: "Simple 2000 Series Vol. 118 - The Ochimusha - Doemu Samurai Toujou"
+  name: SIMPLE2000シリーズVol.118 THE落武者 〜怒獲武サムライ登場〜
+  name-sort: SIMPLE2000しりーずVol.118 THEおちむしゃ 〜どえむさむらいとうじょう〜
+  name-en: "Simple 2000 Series Vol. 118 - The Ochimusha - Doemu Samurai Toujou"
   region: "NTSC-J"
 SLPS-20492:
-  name: "Simple 2000 Series Vol. 115 - The Roomshare to Iu Seikatsu"
+  name: SIMPLE2000シリーズ Vol.115 THEルームシェアという生活。
+  name-sort: SIMPLE2000しりーず Vol.115 THEるーむしぇあというせいかつ。
+  name-en: "Simple 2000 Series Vol. 115 - The Roomshare to Iu Seikatsu"
   region: "NTSC-J"
 SLPS-20493:
-  name: "Simple 2000 Series Vol. 116 - The Neko-Mura no Ninnin - Pagu Daikan no Akugyou Sanmai"
+  name: SIMPLE2000シリーズVol.116 THE ネコ村の人々 〜パグ代官の悪行三昧〜
+  name-sort: SIMPLE2000しりーずVol.116 THE ねこむらのひとびと 〜ぱぐだいかんのあくぎょうさんまい〜
+  name-en: "Simple 2000 Series Vol. 116 - The Neko-Mura no Ninnin - Pagu Daikan no Akugyou Sanmai"
   region: "NTSC-J"
   compat: 5
 SLPS-20494:
-  name: "Simple 2000 Series Vol. 117 - The Zerosen"
+  name: SIMPLE2000シリーズVol.117 THE 零戦
+  name-sort: SIMPLE2000しりーずVol.117 THE ぜろせん
+  name-en: "Simple 2000 Series Vol. 117 - The Zerosen"
   region: "NTSC-J"
 SLPS-20496:
-  name: "Daito Giken Koushiki Pachi-Slot Simulator - Shake II"
+  name: 大都技研公式パチスロシミュレーター シェイクII
+  name-sort: だいとぎけんこうしきぱちすろしみゅれーたー しぇいくII
+  name-en: "Daito Giken Koushiki Pachi-Slot Simulator - Shake II"
   region: "NTSC-J"
 SLPS-20497:
-  name: "Simple 2000 Series Vol. 119 - The Survival Game 2"
+  name: SIMPLE2000シリーズ Vol.119 THE サバイバルゲーム2
+  name-sort: SIMPLE2000しりーず Vol.119 THE さばいばるげーむ2
+  name-en: "Simple 2000 Series Vol. 119 - The Survival Game 2"
   region: "NTSC-J"
 SLPS-20499:
-  name: "Inaka Kurashi - Nan no Shima no Monogatari [Super Best Collection]"
+  name: いなか暮らし 南の島の物語 Super Best Collection
+  name-sort: いなかくらし みなみのしまのものがたり Super Best Collection
+  name-en: "Inaka Kurashi - Nan no Shima no Monogatari [Super Best Collection]"
   region: "NTSC-J"
 SLPS-20500:
-  name: "Simple 2000 Series Vol. 120 - The Saigo no Nippon Tsuwamono"
+  name: SIMPLE2000シリーズ Vol.120 THE 最後の日本兵〜美しき国土奪還作戦〜
+  name-sort: SIMPLE2000しりーず Vol.120 THE さいごのにほんへい〜うつくしきこくどだっかんさくせん〜
+  name-en: "Simple 2000 Series Vol. 120 - The Saigo no Nippon Tsuwamono"
   region: "NTSC-J"
 SLPS-20501:
-  name: "Hayarigami 2"
+  name: 流行り神2 警視庁怪異事件ファイル
+  name-sort: はやりがみ2 けいしちょうかいいじけんふぁいる
+  name-en: "Hayarigami 2"
   region: "NTSC-J"
 SLPS-20502:
   name: "Zero no Tsukaima - Fantasy Force"
   region: "NTSC-J"
 SLPS-20503:
-  name: "Simple 2000 Series Vol. 121 - The Boku no Machi-zukuri 2 - Machi-ing Maker 2.1"
+  name: SIMPLE2000シリーズ Vol.121 THE ぼくの街づくり2 〜街ingメーカー2.1〜
+  name-sort: SIMPLE2000しりーず Vol.121 THE ぼくのまちづくり2 〜まちingめーかー2.1〜
+  name-en: "Simple 2000 Series Vol. 121 - The Boku no Machi-zukuri 2 - Machi-ing Maker 2.1"
   region: "NTSC-J"
 SLPS-20504:
-  name: "Daito Giken Koushiki Pachi-Slot Simulator - Shin Yoshimune"
+  name: 大都技研公式パチスロシュミレーター 新・吉宗
+  name-sort: だいとぎけんこうしきぱちすろしゅみれーたー しん・よしたかし
+  name-en: "Daito Giken Koushiki Pachi-Slot Simulator - Shin Yoshimune"
   region: "NTSC-J"
 SLPS-20505:
   name: "FIVB Volleyball World Cup - Venus Evolution"
@@ -42609,7 +48388,9 @@ SLPS-20510:
   name: "Sekai Saikyou Ginsei Igo Kouza"
   region: "NTSC-J"
 SLPS-25001:
-  name: "Eternal Ring"
+  name: ETERNAL RING
+  name-sort: ETERNAL RING
+  name-en: "Eternal Ring"
   region: "NTSC-J"
   compat: 5
   roundModes:
@@ -42617,7 +48398,9 @@ SLPS-25001:
   gsHWFixes:
     disablePartialInvalidation: 1 # Fixes raphics issues.
 SLPS-25002:
-  name: "Dead or Alive 2"
+  name: DEAD OR ALIVE 2
+  name-sort: DEAD OR ALIVE 2
+  name-en: "Dead or Alive 2"
   region: "NTSC-J"
   compat: 5
   patches:
@@ -42641,51 +48424,75 @@ SLPS-25002:
         //patch=0,EE,0028FEA4,word,3C140058
         //patch=0,EE,0028FEA8,word,00000000
 SLPS-25003:
-  name: "Evergrace"
+  name: EVERGRACE
+  name-sort: EVERGRACE
+  name-en: "Evergrace"
   region: "NTSC-J"
   clampModes:
     eeClampMode: 3 # Fixes hanging before going in-game.
 SLPS-25004:
-  name: "Kensetsu Juuki Kenka Battle - Buchigire Kongou!!"
+  name: 建設重機喧嘩バトル ぶちギレ金剛!!
+  name-sort: けんせつじゅうきけんかばとる ぶちぎれこんごう!!
+  name-en: "Kensetsu Juuki Kenka Battle - Buchigire Kongou!!"
   region: "NTSC-J"
   compat: 5
 SLPS-25005:
-  name: "Rock'n Mega Stage"
+  name: ロックンメガステージ
+  name-sort: ろっくんめがすてーじ
+  name-en: "Rock'n Mega Stage"
   region: "NTSC-J"
   compat: 5
 SLPS-25006:
-  name: "Koushien Baseball"
+  name: 栄冠は君に 甲子園への道
+  name-sort: えいかんはきみに こうしえんへのみち
+  name-en: "Koushien Baseball"
   region: "NTSC-J"
 SLPS-25007:
-  name: "Armored Core 2"
+  name: ARMORED CORE 2
+  name-sort: ARMORED CORE 2
+  name-en: "Armored Core 2"
   region: "NTSC-J"
   clampModes:
     eeClampMode: 2 # Fixes Abnormal AI behavior.
   gsHWFixes:
     textureInsideRT: 1 # Fixes texture corruption.
 SLPS-25008:
-  name: "Sorcerous Stabber Orphen"
+  name: 魔術士オーフェン
+  name-sort: まじゅつしおーふぇん
+  name-en: "Sorcerous Stabber Orphen"
   region: "NTSC-J"
 SLPS-25009:
-  name: "G-Saviour"
+  name: G-SAVIOUR
+  name-sort: G-SAVIOUR
+  name-en: "G-Saviour"
   region: "NTSC-J"
 SLPS-25010:
-  name: "Unison"
+  name: UNiSON
+  name-sort: UNiSON
+  name-en: "Unison"
   region: "NTSC-J"
   compat: 5
 SLPS-25011:
-  name: "Sunrise Eiyuutan R"
+  name: サンライズ英雄譚R
+  name-sort: さんらいずえいゆうたんR
+  name-en: "Sunrise Eiyuutan R"
   region: "NTSC-J"
 SLPS-25012:
-  name: "Victorious Boxers"
+  name: はじめの一歩 VICTORIOUS BOXERS
+  name-sort: はじめのいちほ VICTORIOUS BOXERS
+  name-en: "Victorious Boxers"
   region: "NTSC-J"
 SLPS-25013:
-  name: "Kurikuri Mix"
+  name: くりクリミックス
+  name-sort: くりくりみっくす
+  name-en: "Kurikuri Mix"
   region: "NTSC-J"
   speedHacks:
     mtvu: 0 # Prevents broken textures and graphics.
 SLPS-25014:
-  name: "Choro Q HG [Jenny Hi-Grade Box]"
+  name: チョロQ HG チョロQジェニーハイグレードBOX
+  name-sort: ちょろQ HG ちょろQじぇにーはいぐれーどBOX
+  name-en: "Choro Q HG [Jenny Hi-Grade Box]"
   region: "NTSC-J"
   patches:
     6F9C4D7C:
@@ -42697,7 +48504,9 @@ SLPS-25014:
         // Before removing this patch, check initial loading with unformatted memory card.
         patch=1,EE,0017B2A8,word,00000000
 SLPS-25015:
-  name: "Choro Q HG"
+  name: チョロQ HG
+  name-sort: ちょろQ HG
+  name-en: "Choro Q HG"
   region: "NTSC-J"
   patches:
     6F9C4D7C:
@@ -42709,37 +48518,53 @@ SLPS-25015:
         // Before removing this patch, check initial loading with unformatted memory card.
         patch=1,EE,0017B2A8,word,00000000
 SLPS-25016:
-  name: "Neo Atlas 3"
+  name: Neo ATLAS 3
+  name-sort: Neo ATLAS 3
+  name-en: "Neo Atlas 3"
   region: "NTSC-J"
 SLPS-25017:
-  name: "A Ressha de Ikou 2001"
+  name: A列車で行こう2001
+  name-sort: Aれっしゃでいこう2001
+  name-en: "A Ressha de Ikou 2001"
   region: "NTSC-J"
 SLPS-25018:
-  name: "Sidewinder Max"
+  name: サイドワインダーMAX
+  name-sort: さいどわいんだーMAX
+  name-en: "Sidewinder Max"
   region: "NTSC-J"
 SLPS-25020:
-  name: "Mobile Suit Gundam"
+  name: 機動戦士ガンダム
+  name-sort: きどうせんしがんだむ
+  name-en: "Mobile Suit Gundam"
   region: "NTSC-J"
 SLPS-25021:
   name: "Jitsumei Jikkyou Keiba - Dream Classic 2001 Spring"
   region: "NTSC-J"
 SLPS-25022:
-  name: "Cool Boarders - Code Alien"
+  name: COOL BOARDERS CODE ALIEN
+  name-sort: COOL BOARDERS CODE ALIEN
+  name-en: "Cool Boarders - Code Alien"
   region: "NTSC-J"
 SLPS-25023:
-  name: "Bouncer, The"
+  name: バウンサー
+  name-sort: ばうんさー
+  name-en: "Bouncer, The"
   region: "NTSC-J"
 SLPS-25024:
   name: "Disney's Dinosaur"
   region: "NTSC-J"
 SLPS-25025:
-  name: "7 (Seven) - Molmorth no Kiheitai"
+  name: 7(セブン)〜モールモースの騎兵隊〜
+  name-sort: 7(せぶん)〜もーるもーすのきへいたい〜
+  name-en: "7 (Seven) - Molmorth no Kiheitai"
   region: "NTSC-J"
   compat: 5
   gameFixes:
     - EETimingHack # Correct graphics after changing scene.
 SLPS-25026:
-  name: "DOA 2 - Hardcore"
+  name: DOA2 HARD・CORE
+  name-sort: DOA2 HARD・CORE
+  name-en: "DOA 2 - Hardcore"
   region: "NTSC-J"
   compat: 5
   patches:
@@ -42752,25 +48577,35 @@ SLPS-25027:
   name: "Golf Paradise DX"
   region: "NTSC-J"
 SLPS-25028:
-  name: "Shutokou Battle 0"
+  name: 首都高バトル0
+  name-sort: しゅとこうばとる0
+  name-en: "Shutokou Battle 0"
   region: "NTSC-J"
   compat: 5
 SLPS-25029:
-  name: "Rayman 2 Revolution"
+  name: レイマン レボリューション！
+  name-sort: れいまん れぼりゅーしょん！
+  name-en: "Rayman 2 Revolution"
   region: "NTSC-J"
   roundModes:
     eeRoundMode: 0 # Fixes game hanging in the "Clark running away" ingame cutscene.
 SLPS-25030:
-  name: "Lunatic Dawn - Tempest"
+  name: ルナティックドーン テンペスト
+  name-sort: るなてぃっくどーん てんぺすと
+  name-en: "Lunatic Dawn - Tempest"
   region: "NTSC-J"
 SLPS-25031:
   name: "Might and Magic - Day of the Destroyer"
   region: "NTSC-J"
 SLPS-25032:
-  name: "Golful Golf"
+  name: ゴルフルGOLF
+  name-sort: ごるふるGOLF
+  name-en: "Golful Golf"
   region: "NTSC-J"
 SLPS-25033:
-  name: "Kaze no Klonoa 2 - Sekai ga Nozonda Wasuremono"
+  name: 風のクロノア2〜世界が望んだ忘れもの〜
+  name-sort: かぜのくろのあ2〜せかいがのぞんだわすれもの〜
+  name-en: "Kaze no Klonoa 2 - Sekai ga Nozonda Wasuremono"
   region: "NTSC-J"
   compat: 5
   clampModes:
@@ -42781,27 +48616,41 @@ SLPS-25033:
   gsHWFixes:
     cpuCLUTRender: 1 # Fixes shadows, object and enemy colours, platform transitions.
 SLPS-25034:
-  name: "Flower, Sun and Rain"
+  name: 花と太陽と雨と
+  name-sort: はなとたいようとあめと
+  name-en: "Flower, Sun and Rain"
   region: "NTSC-J"
 SLPS-25035:
-  name: "Monster Farm 3"
+  name: モンスターファーム
+  name-sort: もんすたーふぁーむ
+  name-en: "Monster Farm 3"
   region: "NTSC-J"
   clampModes:
     vuClampMode: 3 # Fixes SPS in game.
 SLPS-25036:
-  name: "Gallop Racer 5"
+  name: ギャロップレーサー5
+  name-sort: ぎゃろっぷれーさー5
+  name-en: "Gallop Racer 5"
   region: "NTSC-J"
 SLPS-25037:
-  name: "Velvet File Plus"
+  name: Velvet File Plus
+  name-sort: Velvet File Plus
+  name-en: "Velvet File Plus"
   region: "NTSC-J"
 SLPS-25038:
-  name: "True Love Story 3"
+  name: トゥルーラブストーリー3
+  name-sort: とぅるーらぶすとーりー3
+  name-en: "True Love Story 3"
   region: "NTSC-J"
 SLPS-25039:
-  name: "Missing Blue [First Limited Edition]"
+  name: MissingBlue 初回限定版
+  name-sort: MissingBlue しょかいげんていばん
+  name-en: "Missing Blue [First Limited Edition]"
   region: "NTSC-J"
 SLPS-25040:
-  name: "Armored Core 2 - Another Age"
+  name: ARMORED CORE2 ANOTHER AGE
+  name-sort: ARMORED CORE2 ANOTHER AGE
+  name-en: "Armored Core 2 - Another Age"
   region: "NTSC-J"
   compat: 5
   clampModes:
@@ -42813,22 +48662,30 @@ SLPS-25040:
     - "SLPS-73403"
     - "SLPS-73411"
 SLPS-25041:
-  name: "Shadow Hearts"
+  name: シャドウハーツ
+  name-sort: しゃどうはーつ
+  name-en: "Shadow Hearts"
   region: "NTSC-J"
   clampModes:
     eeClampMode: 3 # Fixes invisible characters in various scenes.
 SLPS-25042:
-  name: "Maken Shao [Limited Edition]"
+  name: 魔剣爻 -MAKEN SHAO-（初回限定版）
+  name-sort: まけんしゃお -MAKEN SHAO-（しょかいげんていばん）
+  name-en: "Maken Shao [Limited Edition]"
   region: "NTSC-J"
   speedHacks:
     mvuFlag: 0
 SLPS-25043:
-  name: "Maken Shao"
+  name: 魔剣爻 -MAKEN SHAO-
+  name-sort: まけんしゃお -MAKEN SHAO-
+  name-en: "Maken Shao"
   region: "NTSC-J"
   speedHacks:
     mvuFlag: 0
 SLPS-25044:
-  name: "Evergrace 2"
+  name: エヴァーグレイスII
+  name-sort: えゔぁーぐれいすII
+  name-en: "Evergrace 2"
   region: "NTSC-J"
   gsHWFixes:
     preloadFrameData: 1 # Fixes textures and flickering such as the wall and sky.
@@ -42837,19 +48694,29 @@ SLPS-25044:
     mipmap: 2 # Fixes shimmering noisy textures
     trilinearFiltering: 1 # Fixes shimmering noisy textures
 SLPS-25045:
-  name: "Lilie no Atelier - Salburg no Renkinjutsushi 3"
+  name: リリーのアトリエ 〜ザールブルグの錬金術士3〜
+  name-sort: りりーのあとりえ 〜ざーるぶるぐのれんきんじゅつし3〜
+  name-en: "Lilie no Atelier - Salburg no Renkinjutsushi 3"
   region: "NTSC-J"
 SLPS-25046:
-  name: "Golf Navigator Vol.1"
+  name: ゴルフナビゲーター Vol.1
+  name-sort: ごるふなびげーたー Vol.1
+  name-en: "Golf Navigator Vol.1"
   region: "NTSC-J"
 SLPS-25047:
-  name: "Golf Navigator Vol.2"
+  name: ゴルフナビゲーター Vol.2
+  name-sort: ごるふなびげーたー Vol.2
+  name-en: "Golf Navigator Vol.2"
   region: "NTSC-J"
 SLPS-25048:
-  name: "Zeonic Front - Kidou Senshi Gundam 0079"
+  name: ZEONIC FRONT 機動戦士ガンダム0079
+  name-sort: ZEONIC FRONT きどうせんしがんだむ0079
+  name-en: "Zeonic Front - Kidou Senshi Gundam 0079"
   region: "NTSC-J"
 SLPS-25050:
-  name: "Final Fantasy X"
+  name: ファイナルファンタジーX
+  name-sort: ふぁいなるふぁんたじーX
+  name-en: "Final Fantasy X"
   region: "NTSC-J"
   compat: 5
   roundModes:
@@ -42857,10 +48724,14 @@ SLPS-25050:
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
 SLPS-25051:
-  name: "Missing Blue"
+  name: MissingBlue
+  name-sort: MissingBlue
+  name-en: "Missing Blue"
   region: "NTSC-J"
 SLPS-25052:
-  name: "Ace Combat 04 - Shattered Skies"
+  name: エースコンバット04 シャッタードスカイ
+  name-sort: えーすこんばっと04 しゃったーどすかい
+  name-en: "Ace Combat 04 - Shattered Skies"
   region: "NTSC-J"
   compat: 5
   gameFixes:
@@ -42873,19 +48744,27 @@ SLPS-25052:
     mergeSprite: 1 # Fixes vertical lines.
     gpuTargetCLUT: 1 # Fixes broken sun.
 SLPS-25053:
-  name: "Eikan wa Kimi ni - Koushien no Hasha"
+  name: 栄冠は君に 甲子園の覇者
+  name-sort: えいかんはきみに こうしえんのはしゃ
+  name-en: "Eikan wa Kimi ni - Koushien no Hasha"
   region: "NTSC-J"
 SLPS-25054:
-  name: "Tamamayu Story 2"
+  name: 玉繭物語2〜滅びの蟲〜
+  name-sort: たままゆものがたり2〜ほろびの蟲〜
+  name-en: "Tamamayu Story 2"
   region: "NTSC-J"
 SLPS-25055:
-  name: "Golf Navigator Vol.3"
+  name: ゴルフナビゲーター Vol.3
+  name-sort: ごるふなびげーたー Vol.3
+  name-en: "Golf Navigator Vol.3"
   region: "NTSC-J"
 SLPS-25056:
   name: "I Golf Navigator Vol. 4 - Taiheiyou Club - Gotenba Courseshioka Golf Club"
   region: "NTSC-J"
 SLPS-25057:
-  name: "King's Field IV"
+  name: キングスフィールドIV
+  name-sort: きんぐすふぃーるどIV
+  name-en: "King's Field IV"
   region: "NTSC-J"
   gsHWFixes:
     preloadFrameData: 1 # Fixes invisible lava, there is another issue that needs skipdraw 1 for blurry font but it removes much brightness.
@@ -42899,19 +48778,27 @@ SLPS-25057:
         // Issue: Some doors leading to some areas appeared as black voids that you can walk into.
         patch=1,EE,001BE37C,word,46150036
 SLPS-25059:
-  name: "G-Breaker - Legend of Cloudia"
+  name: 機甲武装Gブレーカー レジェンド オブ クラウディア
+  name-sort: きこうぶそうGぶれーかー れじぇんど おぶ くらうでぃあ
+  name-en: "G-Breaker - Legend of Cloudia"
   region: "NTSC-J"
 SLPS-25060:
-  name: "Mobile Suit Gundam - Meguriai Sora [Limited Edition]"
+  name: 機動戦士ガンダム めぐりあい宇宙(限定版)
+  name-sort: きどうせんしがんだむ めぐりあいうちゅう(げんていばん)
+  name-en: "Mobile Suit Gundam - Meguriai Sora [Limited Edition]"
   region: "NTSC-J"
 SLPS-25061:
   name: "Kidou Senshi Gundam - Ver. 1.5"
   region: "NTSC-J"
 SLPS-25062:
-  name: "Kidou Senshi Gundam - Meguriai Sora"
+  name: 機動戦士ガンダム めぐりあい宇宙(DVD同梱版)
+  name-sort: きどうせんしがんだむ めぐりあいうちゅう(DVDどうこんばん)
+  name-en: "Kidou Senshi Gundam - Meguriai Sora"
   region: "NTSC-J"
 SLPS-25064:
-  name: "Sea-Man"
+  name: シーマン 〜禁断のペット〜 ガゼー博士の実験島（シーマイクコントローラ同梱版）
+  name-sort: しーまん 〜きんだんのぺっと〜 がぜーはかせのじっけんとう（しーまいくこんとろーらどうこんばん）
+  name-en: "Sea-Man"
   region: "NTSC-J"
 SLPS-25065:
   name: "Kindan no Pet - Seaman - GassÃ© Hakase no Jikken-tou"
@@ -42923,15 +48810,21 @@ SLPS-25068:
   name: "Jitsumei Jikkyou Keiba - Dream Classic - 2001 Autumn"
   region: "NTSC-J"
 SLPS-25069:
-  name: "FIFA 2002 - Road to World Cup"
+  name: FIFA 2002 ロード・トゥ・FIFAワールドカップ
+  name-sort: FIFA 2002 ろーど・とぅ・FIFAわーるどかっぷ
+  name-en: "FIFA 2002 - Road to World Cup"
   region: "NTSC-J"
   gsHWFixes:
     mipmap: 1 # Fixes broken player textures.
 SLPS-25070:
-  name: "Tales of the Sunrise Heroes 2"
+  name: サンライズ英雄譚2
+  name-sort: さんらいずえいゆうたん2
+  name-en: "Tales of the Sunrise Heroes 2"
   region: "NTSC-J"
 SLPS-25071:
-  name: "Visual Mix - Ayumi Hamasaki Dome Tour 2001 [Disc 1 of 2]"
+  name: “A” VISUAL MIX
+  name-sort: “A” VISUAL MIX
+  name-en: "Visual Mix - Ayumi Hamasaki Dome Tour 2001 [Disc 1 of 2]"
   region: "NTSC-J"
   memcardFilters:
     - "SLPS-25071"
@@ -42950,7 +48843,9 @@ SLPS-25073:
   name: "Cinema Surfing - Youga Taizen"
   region: "NTSC-J"
 SLPS-25074:
-  name: "Project Zero"
+  name: 零 〜zero〜
+  name-sort: ぜろ 〜zero〜
+  name-en: "Project Zero"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
@@ -42964,24 +48859,34 @@ SLPS-25074:
         patch=1,EE,0011de3c,word,46156032
         patch=1,EE,0011de40,word,45010002
 SLPS-25075:
-  name: "Sidewinder F"
+  name: サイドワインダーF+FLIGHT FORCE 同梱パック
+  name-sort: さいどわいんだーF+FLIGHT FORCE どうこんぱっく
+  name-en: "Sidewinder F"
   region: "NTSC-J"
 SLPS-25076:
-  name: "Sidewinder F"
+  name: サイドワインダーF
+  name-sort: さいどわいんだーF
+  name-en: "Sidewinder F"
   region: "NTSC-J"
 SLPS-25077:
-  name: "Vampire Night"
+  name: ヴァンパイアナイト
+  name-sort: ゔぁんぱいあないと
+  name-en: "Vampire Night"
   region: "NTSC-J"
   compat: 5
 SLPS-25078:
-  name: "SSX Tricky"
+  name: SSX TRICKY
+  name-sort: SSX TRICKY
+  name-en: "SSX Tricky"
   region: "NTSC-J"
   roundModes:
     eeRoundMode: 0 # Fixes riders vanish into the floor.
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes missing lighting and makes snow not look like snow sludge.
 SLPS-25079:
-  name: "Madden NFL 2002"
+  name: MADDEN NFL スーパーボウル 2002
+  name-sort: MADDEN NFL すーぱーぼうる 2002
+  name-en: "Madden NFL 2002"
   region: "NTSC-J"
   clampModes:
     vuClampMode: 3 # Missing geometry with microVU.
@@ -42989,19 +48894,27 @@ SLPS-25079:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
 SLPS-25080:
-  name: "Uchuu Senkan Yamato - Iscandar he no Tsuioku [Special Edition]"
+  name: 宇宙戦艦ヤマト イスカンダルへの追憶 (初回生産限定版)
+  name-sort: うちゅうせんかんやまと いすかんだるへのついおく (しょかいせいさんげんていばん)
+  name-en: "Uchuu Senkan Yamato - Iscandar he no Tsuioku [Special Edition]"
   region: "NTSC-J"
 SLPS-25081:
-  name: "Saishuu Densha"
+  name: 最終電車
+  name-sort: さいしゅうでんしゃ
+  name-en: "Saishuu Densha"
   region: "NTSC-J"
 SLPS-25083:
   name: "Exciting Pro Wres 3 [Genteiban]"
   region: "NTSC-J"
 SLPS-25084:
-  name: "Thunder Strike - Operation Phoenix"
+  name: サンダーストライク:オペレーション フェニックス
+  name-sort: さんだーすとらいく:おぺれーしょん ふぇにっくす
+  name-en: "Thunder Strike - Operation Phoenix"
   region: "NTSC-J"
 SLPS-25085:
-  name: "Soul Reaver 2 - Legacy of Kain"
+  name: ソウルリーバー2
+  name-sort: そうるりーばー2
+  name-en: "Soul Reaver 2 - Legacy of Kain"
   region: "NTSC-J"
   gsHWFixes:
     mipmap: 1
@@ -43009,7 +48922,9 @@ SLPS-25087:
   name: "Exciting Pro Wres 3"
   region: "NTSC-J"
 SLPS-25088:
-  name: "Final Fantasy X International"
+  name: ファイナルファンタジーX インターナショナル
+  name-sort: ふぁいなるふぁんたじーX いんたーなしょなる
+  name-en: "Final Fantasy X International"
   region: "NTSC-J"
   compat: 5
   roundModes:
@@ -43022,31 +48937,45 @@ SLPS-25089:
   gameFixes:
     - VUSyncHack # Fixes flickering and missing textures.
 SLPS-25094:
-  name: "Reveal Fantasia"
+  name: リーヴェルファンタジア 〜マリエルと妖精物語〜
+  name-sort: りーゔぇるふぁんたじあ 〜まりえるとようせいものがたり〜
+  name-en: "Reveal Fantasia"
   region: "NTSC-J"
   gameFixes:
     - InstantDMAHack # Fixes NULL GIFChain hang.
 SLPS-25095:
-  name: "Uchuu Senkan Yamato - Iscandar he no Tsuioku"
+  name: 宇宙戦艦ヤマト イスカンダルへの追憶
+  name-sort: うちゅうせんかんやまと いすかんだるへのついおく
+  name-en: "Uchuu Senkan Yamato - Iscandar he no Tsuioku"
   region: "NTSC-J"
 SLPS-25096:
-  name: "Galerians 2 [Limited Edition]"
+  name: ガレリアンズ:アッシュ×リオン コンプリートパック
+  name-sort: がれりあんず:あっしゅ×りおん こんぷりーとぱっく
+  name-en: "Galerians 2 [Limited Edition]"
   region: "NTSC-J"
 SLPS-25097:
-  name: "Velvet File Plus"
+  name: ヴェルベットファイルPlus
+  name-sort: ゔぇるべっとふぁいるPlus
+  name-en: "Velvet File Plus"
   region: "NTSC-J"
 SLPS-25098:
-  name: "Air Ranger 2 - Rescue Helicopter"
+  name: レスキューヘリ エアレンジャー2
+  name-sort: れすきゅーへり えあれんじゃー2
+  name-en: "Air Ranger 2 - Rescue Helicopter"
   region: "NTSC-J"
 SLPS-25099:
-  name: "World Rally Championship"
+  name: WRC〜ワールドラリーチャンピオンシップ〜
+  name-sort: WRC〜わーるどらりーちゃんぴおんしっぷ〜
+  name-en: "World Rally Championship"
   region: "NTSC-J"
   roundModes:
     eeRoundMode: 0 # Fixes crash when using the Subaru.
   gameFixes:
     - XGKickHack # Fixes SPS while ingame.
 SLPS-25100:
-  name: "Tekken 4"
+  name: 鉄拳4
+  name-sort: てっけん4
+  name-en: "Tekken 4"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
@@ -43057,67 +48986,95 @@ SLPS-25101:
   gameFixes:
     - FullVU0SyncHack # Fixes SPS.
 SLPS-25102:
-  name: "Project Arms"
+  name: PROJECT ARMS(プロジェクトアームズ)
+  name-sort: PROJECT ARMS(ぷろじぇくとあーむず)
+  name-en: "Project Arms"
   region: "NTSC-J"
 SLPS-25103:
-  name: "Super Robot Taisen Impact [Limited Edition]"
+  name: スーパーロボット大戦IMPACT 限定版
+  name-sort: すーぱーろぼっとたいせんIMPACT げんていばん
+  name-en: "Super Robot Taisen Impact [Limited Edition]"
   region: "NTSC-J"
   gsHWFixes:
     estimateTextureRegion: 1 # Reduces hash cache size.
 SLPS-25104:
-  name: "Super Robot Taisen Impact"
+  name: スーパーロボット大戦IMPACT
+  name-sort: すーぱーろぼっとたいせんIMPACT
+  name-en: "Super Robot Taisen Impact"
   region: "NTSC-J"
   gsHWFixes:
     estimateTextureRegion: 1 # Reduces hash cache size.
 SLPS-25105:
-  name: "Kingdom Hearts"
+  name: キングダム ハーツ
+  name-sort: きんぐだむ はーつ
+  name-en: "Kingdom Hearts"
   region: "NTSC-J"
 SLPS-25106:
   name: "America Oudan Ultra Quiz"
   region: "NTSC-J"
 SLPS-25107:
-  name: "Kengo 2"
+  name: 剣豪2
+  name-sort: けんごう2
+  name-en: "Kengo 2"
   region: "NTSC-J"
   compat: 5
 SLPS-25108:
-  name: "Runabout 3 - Neo Age"
+  name: RUNABOUT3 neoAGE
+  name-sort: RUNABOUT3 neoAGE
+  name-en: "Runabout 3 - Neo Age"
   region: "NTSC-J"
 SLPS-25110:
   name: "Project FIFA World Cup - Sorenara Kimi ga Daihyou Kantoku"
   region: "NTSC-J"
 SLPS-25111:
-  name: "Higanbana"
+  name: 彼岸花
+  name-sort: ひがんばな
+  name-en: "Higanbana"
   region: "NTSC-J"
 SLPS-25112:
-  name: "Armored Core 3"
+  name: ARMORED CORE 3
+  name-sort: ARMORED CORE 3
+  name-en: "Armored Core 3"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Corrects positioning of reflections on suit's surfaces.
     roundSprite: 2 # Reduces garbage on the UI whilst upscaling.
 SLPS-25113:
-  name: "Zettai Zetsumei Toshi"
+  name: 絶体絶命都市
+  name-sort: ぜったいぜつめいとし
+  name-en: "Zettai Zetsumei Toshi"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
     autoFlush: 2 # Fixes incorrect blur effect.
 SLPS-25114:
-  name: "G-Breaker - Daisanshi Cloudia Taisen"
+  name: 機甲武装Gブレイカー 第三次クラウディア大戦
+  name-sort: きこうぶそうGぶれいかー だいさんじくらうでぃあたいせん
+  name-en: "G-Breaker - Daisanshi Cloudia Taisen"
   region: "NTSC-J"
 SLPS-25115:
-  name: "EOE - Eve of Extinction - Houkai no Zen'ya"
+  name: E.O.E 〜崩壊の前夜〜
+  name-sort: E.O.E 〜ほうかいのぜんや〜
+  name-en: "EOE - Eve of Extinction - Houkai no Zen'ya"
   region: "NTSC-J"
 SLPS-25117:
-  name: "Sankyo Fever 6"
+  name: FEVER6 SANKYO公式パチンコシミュレーション
+  name-sort: FEVER6 SANKYOこうしきぱちんこしみゅれーしょん
+  name-en: "Sankyo Fever 6"
   region: "NTSC-J"
 SLPS-25118:
-  name: "2002 FIFA World Cup"
+  name: 2002FIFAワールドカップ
+  name-sort: 2002FIFAわーるどかっぷ
+  name-en: "2002 FIFA World Cup"
   region: "NTSC-J"
   gsHWFixes:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
 SLPS-25119:
-  name: "Galerians 2"
+  name: ガレリアンズ:アッシュ
+  name-sort: がれりあんず:あっしゅ
+  name-en: "Galerians 2"
   region: "NTSC-J"
   patches:
     E8E54032:
@@ -43131,10 +49088,14 @@ SLPS-25119:
         patch=1,EE,001da878,word,44813800
         patch=1,EE,001da888,word,44810000
 SLPS-25120:
-  name: "Gundam Gihren's Ambition"
+  name: 機動戦士ガンダム ギレンの野望 ジオン独立戦争記
+  name-sort: きどうせんしがんだむ ぎれんのやぼう じおんどくりつせんそうき
+  name-en: "Gundam Gihren's Ambition"
   region: "NTSC-J"
 SLPS-25121:
-  name: "dot hack - Infection Part 1"
+  name: .hack//感染拡大 Vol.1
+  name-sort: .hack//かんせんかくだい Vol.1
+  name-en: "dot hack - Infection Part 1"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 1 # Sharpens world in far distances.
@@ -43152,19 +49113,29 @@ SLPS-25121:
     - "SLPS-73232"
     - "SLPS-73233"
 SLPS-25122:
-  name: "Mobile Suit Gundam - Lost War Chronicles [Limited Edition]"
+  name: 機動戦士ガンダム戦記 LIMITED BOX(限定版)
+  name-sort: きどうせんしがんだむせんき LIMITED BOX(げんていばん)
+  name-en: "Mobile Suit Gundam - Lost War Chronicles [Limited Edition]"
   region: "NTSC-J"
 SLPS-25123:
-  name: "Mobile Suit Gundam - Lost War Chronicles"
+  name: 機動戦士ガンダム戦記
+  name-sort: きどうせんしがんだむせんき
+  name-en: "Mobile Suit Gundam - Lost War Chronicles"
   region: "NTSC-J"
 SLPS-25124:
-  name: "G-Breaker 2 - Doumei no Hangeki"
+  name: 機甲武装Gブレイカー2 同盟の反撃
+  name-sort: きこうぶそうGぶれいかー2 どうめいのはんげき
+  name-en: "G-Breaker 2 - Doumei no Hangeki"
   region: "NTSC-J"
 SLPS-25125:
-  name: "Jitsumei Jikkyou Keiba - Dream Classic 2002"
+  name: 実名実況競馬ドリームクラシック2002
+  name-sort: じつめいじっきょうけいばどりーむくらしっく2002
+  name-en: "Jitsumei Jikkyou Keiba - Dream Classic 2002"
   region: "NTSC-J"
 SLPS-25127:
-  name: "Air"
+  name: AIR
+  name-sort: AIR
+  name-en: "Air"
   region: "NTSC-J"
 SLPS-25128:
   name: "Victorious Boxer - Championship Version"
@@ -43173,25 +49144,37 @@ SLPS-25129:
   name: "Victorious Boxer - Championship Version"
   region: "NTSC-J"
 SLPS-25130:
-  name: "Roommate Asami - Okusama wa Joshikousei"
+  name: ルームメイト・麻美-おくさまは女子高生-
+  name-sort: るーむめいと・あさみ-おくさまはじょしこうせい-
+  name-en: "Roommate Asami - Okusama wa Joshikousei"
   region: "NTSC-J"
 SLPS-25131:
-  name: "Ghost Vibration"
+  name: ゴーストヴァイブレーション
+  name-sort: ごーすとゔぁいぶれーしょん
+  name-en: "Ghost Vibration"
   region: "NTSC-J"
 SLPS-25132:
   name: "Kamaitachi no Yoru 2 - Kangoku-jima no Warabe-uta"
   region: "NTSC-J"
 SLPS-25135:
-  name: "Kamaitachi no Yoru 2"
+  name: かまいたちの夜2〜監獄島のわらべ唄〜
+  name-sort: かまいたちのよる2〜かんごくじまのわらべうた〜
+  name-en: "Kamaitachi no Yoru 2"
   region: "NTSC-J"
 SLPS-25136:
-  name: "Kuon no Kizuna Sairin Mikotonori"
+  name: 久遠の絆 再臨詔
+  name-sort: くおんのきずな さいりんしょう
+  name-en: "Kuon no Kizuna Sairin Mikotonori"
   region: "NTSC-J"
 SLPS-25138:
-  name: "Ever 17 - The Out of Infinity"
+  name: Ever17〜the out of infinity〜(限定版)
+  name-sort: Ever17〜the out of infinity〜(げんていばん)
+  name-en: "Ever 17 - The Out of Infinity"
   region: "NTSC-J"
 SLPS-25139:
-  name: "Baldur's Gate - Dark Alliance [Limited Edition]"
+  name: Baldur's Gate Dark Alliance (限定版)
+  name-sort: Baldur's Gate Dark Alliance (げんていばん)
+  name-en: "Baldur's Gate - Dark Alliance [Limited Edition]"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
@@ -43204,12 +49187,16 @@ SLPS-25140:
     estimateTextureRegion: 1 # Improves performance.
     roundSprite: 1 # Fixes lines in menus.
 SLPS-25141:
-  name: "Pac-Man World 2"
+  name: パックマンワールド2
+  name-sort: ぱっくまんわーるど2
+  name-en: "Pac-Man World 2"
   region: "NTSC-J"
   gameFixes:
     - EETimingHack # Fixes hanging in Butane Pain, Ghost Bayou, Pinky's Revenge and Clyde in the Caldera levels.
 SLPS-25142:
-  name: "Tiger Woods PGA Tour 2002"
+  name: タイガー・ウッズ PGA TOUR 2002
+  name-sort: たいがー・うっず PGA TOUR 2002
+  name-en: "Tiger Woods PGA Tour 2002"
   region: "NTSC-J"
   gameFixes:
     - VUSyncHack # Fixes the inverted legs.
@@ -43217,7 +49204,9 @@ SLPS-25142:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
 SLPS-25143:
-  name: "dot hack - Mutation Part 2"
+  name: .hack//悪性変異 Vol.2
+  name-sort: .hack//あくせいへんい Vol.2
+  name-en: "dot hack - Mutation Part 2"
   region: "NTSC-J"
   memcardFilters:
     - "SCPS-55029"
@@ -43233,13 +49222,19 @@ SLPS-25143:
     - "SLPS-73232"
     - "SLPS-73233"
 SLPS-25144:
-  name: "Memorial Song"
+  name: メモリアルソング
+  name-sort: めもりあるそんぐ
+  name-en: "Memorial Song"
   region: "NTSC-J"
 SLPS-25145:
-  name: "Hooligan [Limited Edition]"
+  name: フーリガン〜君のなかの勇気〜(限定版)
+  name-sort: ふーりがん〜きみのなかのゆうき〜(げんていばん)
+  name-en: "Hooligan [Limited Edition]"
   region: "NTSC-J"
 SLPS-25146:
-  name: "Hooligan"
+  name: フーリガン〜君のなかの勇気〜
+  name-sort: ふーりがん〜きみのなかのゆうき〜
+  name-en: "Hooligan"
   region: "NTSC-J"
 SLPS-25147:
   name: "Star Wars - Jedi Starfighter"
@@ -43250,25 +49245,37 @@ SLPS-25148:
   name: "Panel Quiz Attack 25"
   region: "NTSC-J"
 SLPS-25149:
-  name: "Ever 17 - The Out of Infinity"
+  name: Ever17〜the out of infinity〜
+  name-sort: Ever17〜the out of infinity〜
+  name-en: "Ever 17 - The Out of Infinity"
   region: "NTSC-J"
 SLPS-25150:
-  name: "Only You"
+  name: Only you リベルクルス ドラマCD付き
+  name-sort: Only you りべるくるす どらまCDつき
+  name-en: "Only You"
   region: "NTSC-J"
 SLPS-25151:
-  name: "Medal of Honor - Shijou Saidai no Sakusen"
+  name: メダル・オブ・オナー 史上最大の作戦
+  name-sort: めだる・おぶ・おなー しじょうさいだいのさくせん
+  name-en: "Medal of Honor - Shijou Saidai no Sakusen"
   region: "NTSC-J"
 SLPS-25153:
   name: "Disney's Lilo and Stitch - Stitch no Daibouken"
   region: "NTSC-J"
 SLPS-25154:
-  name: "Flower, Sun and Rain [Victor The Best]"
+  name: 花と太陽と雨と Victor the Best
+  name-sort: はなとたいようとあめと Victor the Best
+  name-en: "Flower, Sun and Rain [Victor The Best]"
   region: "NTSC-J"
 SLPS-25155:
-  name: "Ultraman Fighting Evolution 2"
+  name: ウルトラマン Fighting Evolution 2
+  name-sort: うるとらまん Fighting Evolution 2
+  name-en: "Ultraman Fighting Evolution 2"
   region: "NTSC-J"
 SLPS-25156:
-  name: "King of Fighters 2000, The"
+  name: ザ・キング・オブ・ファイターズ2000
+  name-sort: ざ・きんぐ・おぶ・ふぁいたーず2000
+  name-en: "King of Fighters 2000, The"
   region: "NTSC-J"
 SLPS-25157:
   name: "Madden NFL Super Bowl 2003"
@@ -43279,7 +49286,9 @@ SLPS-25157:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
 SLPS-25158:
-  name: "dot hack - Outbreak Part 3"
+  name: .hack//侵食汚染 vol.3
+  name-sort: .hack//しんしょくおせん vol.3
+  name-en: "dot hack - Outbreak Part 3"
   region: "NTSC-J"
   memcardFilters:
     - "SCPS-55029"
@@ -43295,25 +49304,39 @@ SLPS-25158:
     - "SLPS-73232"
     - "SLPS-73233"
 SLPS-25159:
-  name: "Technic Beat"
+  name: テクニクビート
+  name-sort: てくにくびーと
+  name-en: "Technic Beat"
   region: "NTSC-J"
 SLPS-25160:
-  name: "Final Fantasy XI 2002 [Special Art Box]"
+  name: FINAL FANTASY XI 2002 SPECIAL ART BOX
+  name-sort: FINAL FANTASY XI 2002 SPECIAL ART BOX
+  name-en: "Final Fantasy XI 2002 [Special Art Box]"
   region: "NTSC-J"
 SLPS-25161:
-  name: "Uchuu Senkan Yamato - Ankoku Seidan Teikoku no Gyakushuu [Special Edition]"
+  name: 宇宙戦艦ヤマト 暗黒星団帝国の逆襲(初回生産限定)
+  name-sort: うちゅうせんかんやまと あんこくせいだんていこくのぎゃくしゅう(しょかいせいさんげんてい)
+  name-en: "Uchuu Senkan Yamato - Ankoku Seidan Teikoku no Gyakushuu [Special Edition]"
   region: "NTSC-J"
 SLPS-25162:
-  name: "Uchuu Senkan Yamato - Ankoku Seidan Teikoku no Gyakushuu"
+  name: 宇宙戦艦ヤマト 暗黒星団帝国の逆襲
+  name-sort: うちゅうせんかんやまと あんこくせいだんていこくのぎゃくしゅう
+  name-en: "Uchuu Senkan Yamato - Ankoku Seidan Teikoku no Gyakushuu"
   region: "NTSC-J"
 SLPS-25164:
-  name: "Uchuu Senkan Yamato - Nijuu Ginga no Houkai"
+  name: 宇宙戦艦ヤマト 二重銀河の崩壊
+  name-sort: うちゅうせんかんやまと にじゅうぎんがのほうかい
+  name-en: "Uchuu Senkan Yamato - Nijuu Ginga no Houkai"
   region: "NTSC-J"
 SLPS-25165:
-  name: "Gunvari Collection + Time Crisis"
+  name: ガンバリコレクション プラス タイムクライシス with ガンコン2
+  name-sort: がんばりこれくしょん ぷらす たいむくらいしす with がんこん2
+  name-en: "Gunvari Collection + Time Crisis"
   region: "NTSC-J"
 SLPS-25166:
-  name: "Ingot 79"
+  name: 金鉱脈探査シミュレーション インゴット79
+  name-sort: きんこうみゃくたんさしみゅれーしょん いんごっと79
+  name-en: "Ingot 79"
   region: "NTSC-J"
 SLPS-25167:
   name: "Triple Play 2002"
@@ -43322,7 +49345,9 @@ SLPS-25168:
   name: "NBA Live 2003"
   region: "NTSC-J"
 SLPS-25169:
-  name: "Armored Core 3 - Silent Line"
+  name: ARMORED CORE 3 SILENT LINE
+  name-sort: ARMORED CORE 3 SILENT LINE
+  name-en: "Armored Core 3 - Silent Line"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Corrects positioning of reflections on suit's surfaces.
@@ -43334,19 +49359,27 @@ SLPS-25169:
     - "SLPS-73417"
     - "SLPS-73420"
 SLPS-25170:
-  name: "SD Gundam G Generation Neo"
+  name: SDガンダム GGENERATION-NEO
+  name-sort: SDがんだむ GGENERATION-NEO
+  name-en: "SD Gundam G Generation Neo"
   region: "NTSC-J"
 SLPS-25171:
-  name: "Lupin III - Majutsu no Isan"
+  name: ルパン三世 魔術王の遺産
+  name-sort: るぱんさんせい まじゅつおうのいさん
+  name-en: "Lupin III - Majutsu no Isan"
   region: "NTSC-J"
 SLPS-25172:
-  name: "Tales of Destiny 2"
+  name: テイルズ オブ デスティニー2
+  name-sort: ているず おぶ ですてぃにー2
+  name-en: "Tales of Destiny 2"
   region: "NTSC-J"
 SLPS-25173:
   name: "Omoide ni Kawaru Kimi - Memories Off"
   region: "NTSC-J"
 SLPS-25174:
-  name: "Dragon Ball Z - Budokai"
+  name: ドラゴンボールZ
+  name-sort: どらごんぼーるZ
+  name-en: "Dragon Ball Z - Budokai"
   region: "NTSC-J"
 SLPS-25175:
   name: "A Ressha de Ikou 2001"
@@ -43355,37 +49388,55 @@ SLPS-25176:
   name: "Neo Atlas III"
   region: "NTSC-J"
 SLPS-25177:
-  name: "Gallop Racer 6 - Revolution"
+  name: Gallop Racer 6 -Revolution-
+  name-sort: Gallop Racer 6 -Revolution-
+  name-en: "Gallop Racer 6 - Revolution"
   region: "NTSC-J"
 SLPS-25178:
-  name: "Argus no Senshi"
+  name: アルゴスの戦士
+  name-sort: あるごすのせんし
+  name-en: "Argus no Senshi"
   region: "NTSC-J"
   compat: 5
 SLPS-25179:
-  name: "FIFA 2003"
+  name: FIFA2003ヨーロッパサッカー
+  name-sort: FIFA2003よーろっぱさっかー
+  name-en: "FIFA 2003"
   region: "NTSC-J"
   clampModes:
     vuClampMode: 2 # Missing geometry with microVU.
   gsHWFixes:
     mipmap: 1 # Improves field textures.
 SLPS-25181:
-  name: "Gunvari Collection & Time Crisis"
+  name: ガンバリコレクション プラス タイムクライシス
+  name-sort: がんばりこれくしょん ぷらす たいむくらいしす
+  name-en: "Gunvari Collection & Time Crisis"
   region: "NTSC-J"
 SLPS-25182:
-  name: "Idol Janshi R - Jan-Guru Project [Limited Edition]"
+  name: アイドル雀士R 雀ぐる★プロジェクト(限定版)
+  name-sort: あいどるじゃんしR じゃんぐる★ぷろじぇくと(げんていばん)
+  name-en: "Idol Janshi R - Jan-Guru Project [Limited Edition]"
   region: "NTSC-J"
 SLPS-25183:
-  name: "Idol Janshi R - Jan-Guru Project"
+  name: アイドル雀士R 雀ぐる★プロジェクト
+  name-sort: あいどるじゃんしR じゃんぐる★ぷろじぇくと
+  name-en: "Idol Janshi R - Jan-Guru Project"
   region: "NTSC-J"
 SLPS-25184:
-  name: "Guilty Gear XX - The Midnight Carnival"
+  name: ギルティギア イグゼクス
+  name-sort: ぎるてぃぎあ いぐぜくす
+  name-en: "Guilty Gear XX - The Midnight Carnival"
   region: "NTSC-J"
   compat: 5
 SLPS-25185:
-  name: "Unlimited SaGa [Limited Edition]"
+  name: アンリミテッド：サガ リミテッドエディション
+  name-sort: あんりみてっど：さが りみてっどえでぃしょん
+  name-en: "Unlimited SaGa [Limited Edition]"
   region: "NTSC-J"
 SLPS-25186:
-  name: "Kidou Shinsengumi - Moe yo Ken"
+  name: 機動新撰組 萌えよ剣
+  name-sort: きどうしんせんぐみ もえよけん
+  name-en: "Kidou Shinsengumi - Moe yo Ken"
   region: "NTSC-J"
 SLPS-25187:
   name: "Panel Quiz Attack 25"
@@ -43397,58 +49448,82 @@ SLPS-25189:
   name: "Toukon Inoki-michi - Puzzle de Daaa!"
   region: "NTSC-J"
 SLPS-25190:
-  name: "Sweet Legacy"
+  name: スイートレガシー 〜ボクと彼女の名もないお菓子〜
+  name-sort: すいーとれがしー 〜ぼくとかのじょのなもないおかし〜
+  name-en: "Sweet Legacy"
   region: "NTSC-J"
 SLPS-25191:
-  name: "Mizuiro Light Blue"
+  name: みずいろ
+  name-sort: みずいろ
+  name-en: "Mizuiro Light Blue"
   region: "NTSC-J"
 SLPS-25192:
-  name: "My Merry May"
+  name: My Merry May 初回限定版
+  name-sort: My Merry May しょかいげんていばん
+  name-en: "My Merry May"
   region: "NTSC-J"
 SLPS-25193:
-  name: "My Merry May"
+  name: My Merry May
+  name-sort: My Merry May
+  name-en: "My Merry May"
   region: "NTSC-J"
 SLPS-25194:
   name: "Herdy Gerdy"
   region: "NTSC-J"
 SLPS-25195:
-  name: "Venus & Braves [Premium Pack]"
+  name: ヴィーナス&ブレイブス 〜魔女と女神と滅びの予言〜 プレミアムボックス
+  name-sort: ゔぃーなす&ぶれいぶす 〜まじょとめがみとほろびのよげん〜 ぷれみあむぼっくす
+  name-en: "Venus & Braves [Premium Pack]"
   region: "NTSC-J"
   compat: 5
   gameFixes:
     - EETimingHack
 SLPS-25196:
-  name: "Venus & Braves"
+  name: ヴィーナス&ブレイブス 〜魔女と女神と滅びの予言〜
+  name-sort: ゔぃーなす&ぶれいぶす 〜まじょとめがみとほろびのよげん〜
+  name-en: "Venus & Braves"
   region: "NTSC-J"
   compat: 5
   gameFixes:
     - EETimingHack
 SLPS-25197:
-  name: "Kingdom Hearts - Final Mix [Limited Edition]"
+  name: キングダム ハーツ -ファイナルミックス- プラチナ リミテッド
+  name-sort: きんぐだむ はーつ -ふぁいなるみっくす- ぷらちな りみてっど
+  name-en: "Kingdom Hearts - Final Mix [Limited Edition]"
   region: "NTSC-J"
   gsHWFixes:
     roundSprite: 1 # Fixes picture artifacts.
 SLPS-25198:
-  name: "Kingdom Hearts - Final Mix"
+  name: キングダム ハーツ -ファイナル ミックス-
+  name-sort: きんぐだむ はーつ -ふぁいなる みっくす-
+  name-en: "Kingdom Hearts - Final Mix"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
     roundSprite: 1 # Fixes picture artifacts.
 SLPS-25199:
-  name: "Unlimited Saga"
+  name: アンリミテッド：サガ
+  name-sort: あんりみてっど：さが
+  name-en: "Unlimited Saga"
   region: "NTSC-J"
   compat: 5
 SLPS-25200:
-  name: "Final Fantasy XI"
+  name: ファイナルファンタジーXI
+  name-sort: ふぁいなるふぁんたじーXI
+  name-en: "Final Fantasy XI"
   region: "NTSC-J"
   compat: 3
 SLPS-25201:
-  name: "Reveal Fantasia"
+  name: リーヴェルファンタジア マリエルと妖精物語
+  name-sort: りーゔぇるふぁんたじあ まりえるとようせいものがたり
+  name-en: "Reveal Fantasia"
   region: "NTSC-J"
   gameFixes:
     - InstantDMAHack # Fixes NULL GIFChain hang.
 SLPS-25202:
-  name: "dot hack - Quarantine Part 4"
+  name: .hack//絶対包囲 vol.4
+  name-sort: .hack//ぜったいほうい vol.4
+  name-en: "dot hack - Quarantine Part 4"
   region: "NTSC-J"
   memcardFilters:
     - "SCPS-55029"
@@ -43469,23 +49544,31 @@ SLPS-25203:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes fog lines in the distance.
 SLPS-25204:
-  name: "MotoGP3"
+  name: MotoGP3
+  name-sort: MotoGP3
+  name-en: "MotoGP3"
   region: "NTSC-J"
   gsHWFixes:
     roundSprite: 2 # Fixes lines at the edges of the HUD.
     mipmap: 2 # Mipmap + trilinear, improves road and grass textures to match sw renderer.
     trilinearFiltering: 1
 SLPS-25205:
-  name: "Ys I-II - Eternal Story [Limited Edition]"
+  name: イース I・II エターナルストーリー(特別限定版)
+  name-sort: いーす I・II えたーなるすとーりー(とくべつげんていばん)
+  name-en: "Ys I-II - Eternal Story [Limited Edition]"
   region: "NTSC-J"
 SLPS-25206:
-  name: "Ys I-II - Eternal Story"
+  name: イース I・II エターナルストーリー
+  name-sort: いーす I・II えたーなるすとーりー
+  name-en: "Ys I-II - Eternal Story"
   region: "NTSC-J"
 SLPS-25207:
   name: "TimeSplitter - Jikuu no Shinryakusha"
   region: "NTSC-J"
 SLPS-25209:
-  name: "Metal Slug 3"
+  name: メタルスラッグ3
+  name-sort: めたるすらっぐ3
+  name-en: "Metal Slug 3"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
@@ -43494,54 +49577,86 @@ SLPS-25210:
   name: "Exciting Pro Wres 4"
   region: "NTSC-J"
 SLPS-25212:
-  name: "Giren no Yabou - Zeon Dokuritsu Sensouden"
+  name: 機動戦士ガンダム ギレンの野望 ジオン独立戦争記 攻略指令書
+  name-sort: きどうせんしがんだむ ぎれんのやぼう じおんどくりつせんそうき こうりゃくしれいしょ
+  name-en: "Giren no Yabou - Zeon Dokuritsu Sensouden"
   region: "NTSC-J"
 SLPS-25213:
-  name: "Bass Landing 3"
+  name: バスランディング3
+  name-sort: ばすらんでぃんぐ3
+  name-en: "Bass Landing 3"
   region: "NTSC-J"
 SLPS-25214:
-  name: "Guardian Angel"
+  name: ガーディアン エンジェル
+  name-sort: がーでぃあん えんじぇる
+  name-en: "Guardian Angel"
   region: "NTSC-J"
 SLPS-25215:
-  name: "Iris [Limited Edition]"
+  name: Iris 初回限定版
+  name-sort: Iris しょかいげんていばん
+  name-en: "Iris [Limited Edition]"
   region: "NTSC-J"
 SLPS-25216:
-  name: "Iris"
+  name: Iris
+  name-sort: Iris
+  name-en: "Iris"
   region: "NTSC-J"
   compat: 5
 SLPS-25217:
-  name: "Shadow Tower Abyss"
+  name: SHADOW TOWER ABYSS(シャドウタワー アビス)
+  name-sort: SHADOW TOWER ABYSS(しゃどうたわー あびす)
+  name-en: "Shadow Tower Abyss"
   region: "NTSC-J"
   compat: 5
 SLPS-25219:
-  name: "Canary"
+  name: カナリア～この想いを歌に乗せて～
+  name-sort: かなりあ～このおもいをうたにのせて～
+  name-en: "Canary"
   region: "NTSC-J"
 SLPS-25220:
-  name: "Elysion"
+  name: エリュシオン〜永遠のサンクチュアリ〜
+  name-sort: えりゅしおん〜えいえんのさんくちゅあり〜
+  name-en: "Elysion"
   region: "NTSC-J"
 SLPS-25221:
-  name: "Pia - Welcome to Carrot 3"
+  name: Piaキャロットへようこそ!!3〜round summer〜（初回限定版）
+  name-sort: Piaきゃろっとへようこそ!!3〜round summer〜（しょかいげんていばん）
+  name-en: "Pia - Welcome to Carrot 3"
   region: "NTSC-J"
 SLPS-25223:
-  name: "Canvas - Sepia-iro no Motif"
+  name: Canvas〜セピア色のモチーフ〜
+  name-sort: Canvas〜せぴあいろのもちーふ〜
+  name-en: "Canvas - Sepia-iro no Motif"
   region: "NTSC-J"
 SLPS-25224:
-  name: "Ai yori Aoshi [Shokai Genteiban]"
+  name: 藍より青し 初回限定版
+  name-sort: あいよりあおし しょかいげんていばん
+  name-en: "Ai yori Aoshi [Shokai Genteiban]"
   region: "NTSC-J"
 SLPS-25225:
-  name: "Ai Yori Aoshi"
+  name: 藍より青し
+  name-sort: あいよりあおし
+  name-en: "Ai Yori Aoshi"
   region: "NTSC-J"
 SLPS-25226:
-  name: "Memories Off - Duet"
+  name: メモリーズオフ デュエット～1st ＆ 2ndストーリーズ～
+  name-sort: めもりーずおふ でゅえっと～1st ＆ 2ndすとーりーず～
+  name-en: "Memories Off - Duet"
   region: "NTSC-J"
 SLPS-25227:
-  name: "Super Robot Wars - Alpha 2nd [Limited Edition]"
+  name: 第2次スーパーロボット大戦α(限定版)
+  name-sort: だい2じすーぱーろぼっとたいせんあるふぁ(げんていばん)
+  name-en: "Super Robot Wars - Alpha 2nd [Limited Edition]"
   region: "NTSC-J"
 SLPS-25228:
-  name: "Super Robot Wars - Alpha 2nd"
+  name: 第2次スーパーロボット大戦α
+  name-sort: だい2じすーぱーろぼっとたいせんあるふぁ
+  name-en: "Super Robot Wars - Alpha 2nd"
   region: "NTSC-J"
 SLPS-25230:
-  name: "Soul Calibur II"
+  name: ソウルキャリバー II
+  name-sort: そうるきゃりばー II
+  name-en: "Soul Calibur II"
   region: "NTSC-J"
   compat: 5
   clampModes:
@@ -43550,7 +49665,9 @@ SLPS-25230:
     alignSprite: 1 # Fixes vertical lines.
     recommendedBlendingLevel: 3 # Fixes menu transparency.
 SLPS-25231:
-  name: "Myst III - Exile"
+  name: ミストIII:エグザイル
+  name-sort: みすとIII:えぐざいる
+  name-en: "Myst III - Exile"
   region: "NTSC-J"
   patches:
     D7CCA373:
@@ -43562,80 +49679,116 @@ SLPS-25231:
         patch=0,EE,001F0498,word,8c430000
         patch=0,EE,001F04A8,word,0460FFFA
 SLPS-25233:
-  name: "Do DonPachi Daioujou"
+  name: 怒首領蜂 大往生
+  name-sort: いかしゅりょうはち だいおうじょう
+  name-en: "Do DonPachi Daioujou"
   region: "NTSC-J"
   compat: 5
 SLPS-25234:
-  name: "Tenchu 3"
+  name: 天誅 参
+  name-sort: てんちゅう さん
+  name-en: "Tenchu 3"
   region: "NTSC-J"
 SLPS-25235:
-  name: "Yumeria"
+  name: ゆめりあ
+  name-sort: ゆめりあ
+  name-en: "Yumeria"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
     autoFlush: 2 # Fixes double image.
 SLPS-25236:
-  name: "Fantastic Fortune 2"
+  name: ファンタスティックフォーチュン2
+  name-sort: ふぁんたすてぃっくふぉーちゅん2
+  name-en: "Fantastic Fortune 2"
   region: "NTSC-J"
 SLPS-25237:
-  name: "Only You"
+  name: Only you リベルクルス
+  name-sort: Only you りべるくるす
+  name-en: "Only You"
   region: "NTSC-J"
 SLPS-25238:
-  name: "My Merry Maybe"
+  name: My Merry May be
+  name-sort: My Merry May be
+  name-en: "My Merry Maybe"
   region: "NTSC-J"
 SLPS-25240:
-  name: "Motion Gravure Series - Megumi"
+  name: MEGUMI / モーショングラビアシリーズ(仮)
+  name-sort: MEGUMI / もーしょんぐらびあしりーず(かり)
+  name-en: "Motion Gravure Series - Megumi"
   region: "NTSC-J"
   compat: 5
 SLPS-25241:
-  name: "Motion Gravure Series - Hiroko Mori"
+  name: 森ひろこ / モーショングラビアシリーズ(仮)
+  name-sort: もりひろこ / もーしょんぐらびあしりーず(かり)
+  name-en: "Motion Gravure Series - Hiroko Mori"
   region: "NTSC-J"
   compat: 5
 SLPS-25242:
-  name: "Motion Gravure Series - Tomomi Kitagawa"
+  name: 北川友美 / モーショングラビアシリーズ(仮)
+  name-sort: きたがわともみ / もーしょんぐらびあしりーず(かり)
+  name-en: "Motion Gravure Series - Tomomi Kitagawa"
   region: "NTSC-J"
   compat: 5
 SLPS-25243:
-  name: "Motion Gravure Series - Harumi Nemoto"
+  name: 根本はるみ / モーショングラビアシリーズ(仮)
+  name-sort: ねもとはるみ / もーしょんぐらびあしりーず(かり)
+  name-en: "Motion Gravure Series - Harumi Nemoto"
   region: "NTSC-J"
   compat: 5
 SLPS-25244:
-  name: "Max Payne"
+  name: MAX PAYNE
+  name-sort: MAX PAYNE
+  name-en: "Max Payne"
   region: "NTSC-J"
   clampModes:
     eeClampMode: 3 # Fixes crashes.
 SLPS-25245:
-  name: "True Love Story - Summer Days and Yet"
+  name: True Love Story Summer Days,and yet... トゥルーラブストーリー サマーデイズ アンド イエット...
+  name-sort: True Love Story Summer Days,and yet... とぅるーらぶすとーりー さまーでいず あんど いえっと...
+  name-en: "True Love Story - Summer Days and Yet"
   region: "NTSC-J"
 SLPS-25246:
-  name: "Tomb Raider - The Angel of Darkness"
+  name: トゥームレイダー 美しき逃亡者
+  name-sort: とぅーむれいだー うつくしきとうぼうしゃ
+  name-en: "Tomb Raider - The Angel of Darkness"
   region: "NTSC-J"
   gsHWFixes:
     autoFlush: 2 # Fixes lava effect.
 SLPS-25247:
-  name: "R-Type Final"
+  name: R-TYPE FINAL
+  name-sort: R-TYPE FINAL
+  name-en: "R-Type Final"
   region: "NTSC-J"
   compat: 5
 SLPS-25248:
-  name: "Kino no Tabi - The Beautiful World"
+  name: キノの旅 -the Beautiful World-
+  name-sort: きののたび -the Beautiful World-
+  name-en: "Kino no Tabi - The Beautiful World"
   region: "NTSC-J"
 SLPS-25249:
   name: "Sanyo Pachinko Paradise 9 - Shin Umi Okawari!"
   region: "NTSC-J"
 SLPS-25250:
-  name: "Final Fantasy X-2"
+  name: FINAL FANTASY X-2
+  name-sort: FINAL FANTASY X-2
+  name-en: "Final Fantasy X-2"
   region: "NTSC-J"
   gameFixes:
     - SoftwareRendererFMVHack # Fixes brightness and overlapping subtitles.
   gsHWFixes:
     roundSprite: 1 # Fixes font artifacts.
 SLPS-25251:
-  name: "MVP Baseball 2003"
+  name: MVPベースボール 2003
+  name-sort: MVPべーすぼーる 2003
+  name-en: "MVP Baseball 2003"
   region: "NTSC-J"
   clampModes:
     vuClampMode: 3 # Fixes missing environment.
 SLPS-25252:
-  name: "Star wars - Jango Fett"
+  name: スターウォーズ ジャンゴフェット
+  name-sort: すたーうぉーず じゃんごふぇっと
+  name-en: "Star wars - Jango Fett"
   region: "NTSC-J"
   compat: 5
   roundModes:
@@ -43647,33 +49800,51 @@ SLPS-25253:
   name: "Mezamashi TV - 10th Anniversary - Kyou no Wanko"
   region: "NTSC-J"
 SLPS-25254:
-  name: "Enter the Matrix"
+  name: ENTER THE MATRIX
+  name-sort: ENTER THE MATRIX
+  name-en: "Enter the Matrix"
   region: "NTSC-J"
   gameFixes:
     - EETimingHack # Fixes various VIF errors.
 SLPS-25255:
-  name: "Sidewinder V [Premium Flight Box]"
+  name: サイドワインダー V フライトBOX 【特別限定版】
+  name-sort: さいどわいんだー V ふらいとBOX 【とくべつげんていばん】
+  name-en: "Sidewinder V [Premium Flight Box]"
   region: "NTSC-J"
 SLPS-25256:
-  name: "Never 7 - The End of Infinity"
+  name: Never7 〜the end of infinity〜
+  name-sort: Never7 〜the end of infinity〜
+  name-en: "Never 7 - The End of Infinity"
   region: "NTSC-J"
 SLPS-25257:
-  name: "Close To"
+  name: 想いのかけら ～Close to ～
+  name-sort: おもいのかけら ～Close to ～
+  name-en: "Close To"
   region: "NTSC-J"
 SLPS-25258:
-  name: "Virtual View - R.C.T. Eyes Play"
+  name: ヴァーチャルビュー R.C.T エイゾープレイ
+  name-sort: ゔぁーちゃるびゅー R.C.T えいぞーぷれい
+  name-en: "Virtual View - R.C.T. Eyes Play"
   region: "NTSC-J"
 SLPS-25259:
-  name: "Virtual View - Nemoto Harumi"
+  name: ヴァーチャル・ビュー 根本はるみ エイゾープレイ
+  name-sort: ゔぁーちゃる・びゅー ねもとはるみ えいぞーぷれい
+  name-en: "Virtual View - Nemoto Harumi"
   region: "NTSC-J"
 SLPS-25260:
-  name: "Virtual View - Megumi"
+  name: ヴァーチャル・ビュー MEGUMI エイゾープレイ
+  name-sort: ゔぁーちゃる・びゅー MEGUMI えいぞーぷれい
+  name-en: "Virtual View - Megumi"
   region: "NTSC-J"
 SLPS-25261:
-  name: "Guilty Gear XX #Reload"
+  name: GUILTY GEAR XX #RELOAD ～THE MIDNIGHT CARNIVAL～
+  name-sort: GUILTY GEAR XX #RELOAD ～THE MIDNIGHT CARNIVAL～
+  name-en: "Guilty Gear XX #Reload"
   region: "NTSC-J"
 SLPS-25262:
-  name: "Private Nurse Maria"
+  name: プライベートナース -まりあ-
+  name-sort: ぷらいべーとなーす -まりあ-
+  name-en: "Private Nurse Maria"
   region: "NTSC-J"
   compat: 5
 SLPS-25263:
@@ -43683,16 +49854,24 @@ SLPS-25263:
   gsHWFixes:
     halfPixelOffset: 1 # Corrects shadow misalignment.
 SLPS-25264:
-  name: "RahXephon [Limited Edition]"
+  name: ラーゼフォン 蒼穹幻想曲 PLUSCULUS
+  name-sort: らーぜふぉん そうきゅうげんそうきょく PLUSCULUS
+  name-en: "RahXephon [Limited Edition]"
   region: "NTSC-J"
 SLPS-25265:
-  name: "RahXephon"
+  name: ラーゼフォン 蒼穹幻想曲(通常版)
+  name-sort: らーぜふぉん そうきゅうげんそうきょく(つうじょうばん)
+  name-en: "RahXephon"
   region: "NTSC-J"
 SLPS-25266:
-  name: "King of Fighters 2001, The"
+  name: ザ・キング・オブ・ファイターズ 2001
+  name-sort: ざ・きんぐ・おぶ・ふぁいたーず 2001
+  name-en: "King of Fighters 2001, The"
   region: "NTSC-J"
 SLPS-25267:
-  name: "Summon Night 3"
+  name: サモンナイト3
+  name-sort: さもんないと3
+  name-en: "Summon Night 3"
   region: "NTSC-J"
 SLPS-25268:
   name: "Dead to Rights"
@@ -43701,148 +49880,226 @@ SLPS-25269:
   name: "Hitman - Silent Assassin"
   region: "NTSC-J"
 SLPS-25270:
-  name: "Sunrise World War"
+  name: サンライズ ワールド ウォー from サンライズ英雄譚
+  name-sort: さんらいず わーるど うぉー from さんらいずえいゆうたん
+  name-en: "Sunrise World War"
   region: "NTSC-J"
 SLPS-25271:
-  name: "Sidewinder V"
+  name: サイドワインダー V
+  name-sort: さいどわいんだー V
+  name-en: "Sidewinder V"
   region: "NTSC-J"
   compat: 5
 SLPS-25272:
-  name: "Hulk, The"
+  name: HULK
+  name-sort: HULK
+  name-en: "Hulk, The"
   region: "NTSC-J"
 SLPS-25274:
-  name: "Aikagi"
+  name: あいかぎ 〜ぬくもりとひだまりの中で〜
+  name-sort: あいかぎ 〜ぬくもりとひだまりのなかで〜
+  name-en: "Aikagi"
   region: "NTSC-J"
 SLPS-25275:
-  name: "Def Jam - Vendetta"
+  name: Def Jam Vendetta
+  name-sort: Def Jam Vendetta
+  name-en: "Def Jam - Vendetta"
   region: "NTSC-J"
 SLPS-25276:
-  name: "Natsu Yume Ya Wa"
+  name: 夏夢夜話
+  name-sort: なつゆめやわ
+  name-en: "Natsu Yume Ya Wa"
   region: "NTSC-J"
 SLPS-25278:
-  name: "Memories Off - Mix"
+  name: メモオフみっくす
+  name-sort: めもおふみっくす
+  name-en: "Memories Off - Mix"
   region: "NTSC-J"
 SLPS-25279:
-  name: "Bouken Shounen Club Gahou"
+  name: 冒険少年クラブ画報
+  name-sort: ぼうけんしょうねんくらぶがほう
+  name-en: "Bouken Shounen Club Gahou"
   region: "NTSC-J"
 SLPS-25281:
   name: "True Love Story 3 [Enterbrain collection]"
   region: "NTSC-J"
 SLPS-25282:
-  name: "School Heaven - Boy's Love Scramble!"
+  name: 学園ヘヴン BOY’S LOVE SCRAMBLE!
+  name-sort: がくえんへゔん BOY’S LOVE SCRAMBLE!
+  name-en: "School Heaven - Boy's Love Scramble!"
   region: "NTSC-J"
 SLPS-25283:
-  name: "Interlude"
+  name: INTERLUDE
+  name-sort: INTERLUDE
+  name-en: "Interlude"
   region: "NTSC-J"
 SLPS-25287:
-  name: "Victorious Boxers 2 - Ippo's Road to Glory"
+  name: はじめの一歩2 VICTORIOUS ROAD
+  name-sort: はじめのいちほ2 VICTORIOUS ROAD
+  name-en: "Victorious Boxers 2 - Ippo's Road to Glory"
   region: "NTSC-J"
 SLPS-25288:
-  name: "D-A - Black [Limited Edition]"
+  name: D→A:BLACK 初回限定版
+  name-sort: D→A:BLACK しょかいげんていばん
+  name-en: "D-A - Black [Limited Edition]"
   region: "NTSC-J"
 SLPS-25289:
-  name: "Time Crisis 3 [with G-Con 2]"
+  name: タイムクライシス3(ガンコン2同梱)
+  name-sort: たいむくらいしす3(がんこん2どうこん)
+  name-en: "Time Crisis 3 [with G-Con 2]"
   region: "NTSC-J"
   gsHWFixes:
     texturePreloading: 0 # Performs much better with no preload.
 SLPS-25290:
-  name: "Time Crisis 3"
+  name: タイムクライシス3(ソフト単品)
+  name-sort: たいむくらいしす3(そふとたんぴん)
+  name-en: "Time Crisis 3"
   region: "NTSC-J"
   gsHWFixes:
     texturePreloading: 0 # Performs much better with no preload.
 SLPS-25291:
-  name: "Baldur's Gate - Dark Alliance [PCCW The Best]"
+  name: PCCWジャパン・ザ・ベスト バルダーズゲート・ダークアライアンス
+  name-sort: PCCWじゃぱん・ざ・べすと ばるだーずげーと・だーくあらいあんす
+  name-en: "Baldur's Gate - Dark Alliance [PCCW The Best]"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
     texturePreloading: 1 # Performs much better with partial preload.
     estimateTextureRegion: 1 # Improves performance.
 SLPS-25292:
-  name: "D-A - Black"
+  name: D→A:BLACK
+  name-sort: D→A:BLACK
+  name-en: "D-A - Black"
   region: "NTSC-J"
 SLPS-25293:
-  name: "Naruto - Narutimett Hero"
+  name: NARUTO -ナルト- ナルティメットヒーロー
+  name-sort: NARUTO -なると- なるてぃめっとひーろー
+  name-en: "Naruto - Narutimett Hero"
   region: "NTSC-J"
   compat: 5
 SLPS-25294:
-  name: "Uchuu no Stellvia"
+  name: 宇宙のステルヴィア
+  name-sort: うちゅうのすてるゔぃあ
+  name-en: "Uchuu no Stellvia"
   region: "NTSC-J"
 SLPS-25295:
-  name: "Kaena"
+  name: Kaena(ケイナ)
+  name-sort: Kaena(けいな)
+  name-en: "Kaena"
   region: "NTSC-J"
   compat: 5
   gameFixes:
     - EETimingHack # For black textures on characters.
 SLPS-25296:
-  name: "Super Robot Wars - Scramble Commander"
+  name: スーパーロボット大戦 Scramble Commander
+  name-sort: すーぱーろぼっとたいせん Scramble Commander
+  name-en: "Super Robot Wars - Scramble Commander"
   region: "NTSC-J"
 SLPS-25298:
-  name: "Tentama 1st - Sunny Side"
+  name: てんたま -1st Sunny Side-
+  name-sort: てんたま -1st Sunny Side-
+  name-en: "Tentama 1st - Sunny Side"
   region: "NTSC-J"
 SLPS-25299:
-  name: "Shinseiki Evangelions 2"
+  name: 新世紀エヴァンゲリオン2
+  name-sort: しんせいきえゔぁんげりおん2
+  name-en: "Shinseiki Evangelions 2"
   region: "NTSC-J"
 SLPS-25300:
-  name: "R - Racing Evolution"
+  name: R:RACING EVOLUTION
+  name-sort: R:RACING EVOLUTION
+  name-en: "R - Racing Evolution"
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
 SLPS-25301:
-  name: "Missing Parts - The Tantei Stories - Side A"
+  name: ミッシングパーツ sideA the TANTEI stories
+  name-sort: みっしんぐぱーつ sideA the TANTEI stories
+  name-en: "Missing Parts - The Tantei Stories - Side A"
   region: "NTSC-J"
 SLPS-25302:
-  name: "Kamen Rider - Seigi no Keifu"
+  name: 仮面ライダー 正義の系譜
+  name-sort: かめんらいだー せいぎのけいふ
+  name-en: "Kamen Rider - Seigi no Keifu"
   region: "NTSC-J"
 SLPS-25303:
-  name: "Zero - Crimson Butterfly"
+  name: 零〜紅い蝶〜
+  name-sort: ぜろ〜あかいちょう〜
+  name-en: "Zero - Crimson Butterfly"
   region: "NTSC-J"
   compat: 5
 SLPS-25304:
-  name: "Beast Sapp"
+  name: ビーストサップ
+  name-sort: びーすとさっぷ
+  name-en: "Beast Sapp"
   region: "NTSC-J"
 SLPS-25305:
-  name: "Mobile Suit Z Gundam - AEUG vs. Titans"
+  name: 機動戦士Zガンダム エゥーゴVS.ティターンズ
+  name-sort: きどうせんしZがんだむ えぅーごVS.てぃたーんず
+  name-en: "Mobile Suit Z Gundam - AEUG vs. Titans"
   region: "NTSC-J"
 SLPS-25307:
-  name: "New Century GPX Cyber Formula - Road to the Infinity"
+  name: 新世紀GPXサイバーフォーミュラ The Road To THE INFINITY
+  name-sort: しんせいきGPXさいばーふぉーみゅら The Road To THE INFINITY
+  name-en: "New Century GPX Cyber Formula - Road to the Infinity"
   region: "NTSC-J"
 SLPS-25308:
-  name: "Crouching Tiger, Hidden Dragon"
+  name: クラウチングタイガー・ヒドゥンドラゴン
+  name-sort: くらうちんぐたいがー・ひどぅんどらごん
+  name-en: "Crouching Tiger, Hidden Dragon"
   region: "NTSC-J"
   gameFixes:
     - InstantDMAHack # Fixes FMVs to be visible.
 SLPS-25309:
-  name: "Exciting Pro Wrestling 4 [Yuke's The Best]"
+  name: エキサイティングプロレス4 YUKE’S the Best
+  name-sort: えきさいてぃんぐぷろれす4 YUKE’S the Best
+  name-en: "Exciting Pro Wrestling 4 [Yuke's The Best]"
   region: "NTSC-J"
 SLPS-25310:
-  name: "Disney-Pixar's Finding Nemo"
+  name: ファインディング・ニモ
+  name-sort: ふぁいんでぃんぐ・にも
+  name-en: "Disney-Pixar's Finding Nemo"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
     alignSprite: 1 # Fixes vertical lines.
 SLPS-25311:
-  name: "Spy Fiction"
+  name: SPY FICTION
+  name-sort: SPY FICTION
+  name-en: "Spy Fiction"
   region: "NTSC-J"
 SLPS-25312:
-  name: "Zero Pilot - The Miracle in Lonely Air"
+  name: ZERO PIROT 〜孤空の奇蹟〜
+  name-sort: ZERO PIROT 〜こくうのきせき〜
+  name-en: "Zero Pilot - The Miracle in Lonely Air"
   region: "NTSC-J"
 SLPS-25313:
-  name: "Seven Samurai 20XX"
+  name: SEVEN SAMURAI 20XX
+  name-sort: SEVEN SAMURAI 20XX
+  name-en: "Seven Samurai 20XX"
   region: "NTSC-J"
 SLPS-25314:
-  name: "Nebula - Echo Night"
+  name: NEBULA -ECHO NIGHT-
+  name-sort: NEBULA -ECHO NIGHT-
+  name-en: "Nebula - Echo Night"
   region: "NTSC-J"
   compat: 5
 SLPS-25315:
-  name: "One Piece - Grand Battle 3"
+  name: ワンピース グランドバトル!3
+  name-sort: わんぴーす ぐらんどばとる!3
+  name-en: "One Piece - Grand Battle 3"
   region: "NTSC-J"
   compat: 5
 SLPS-25316:
-  name: "SNK vs. Capcom Chaos"
+  name: SNK VS. CAPCOM SVC CHAOS
+  name-sort: SNK VS. CAPCOM SVC CHAOS
+  name-en: "SNK vs. Capcom Chaos"
   region: "NTSC-J"
   compat: 5
 SLPS-25317:
-  name: "Shadow Hearts 2 [Deluxe Pack] [Disc 1 of 2]"
+  name: シャドウハーツ II DXパック
+  name-sort: しゃどうはーつ II DXぱっく
+  name-en: "Shadow Hearts 2 [Deluxe Pack] [Disc 1 of 2]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurrines, preload frame for FMV breaks visuals with this setting.
@@ -43860,28 +50117,42 @@ SLPS-25318:
   memcardFilters:
     - "SLPS-25317"
 SLPS-25319:
-  name: "Kero Kero King DX Plus"
+  name: ケロケロキング スーパーDX
+  name-sort: けろけろきんぐ すーぱーDX
+  name-en: "Kero Kero King DX Plus"
   region: "NTSC-J"
 SLPS-25320:
-  name: "InuYasha - Juso no Kamen"
+  name: 犬夜叉 呪詛の仮面
+  name-sort: いぬやしゃ じゅそのかめん
+  name-en: "InuYasha - Juso no Kamen"
   region: "NTSC-J"
 SLPS-25321:
-  name: "Derby Stallion 2004"
+  name: ダービースタリオン 04
+  name-sort: だーびーすたりおん 04
+  name-en: "Derby Stallion 2004"
   region: "NTSC-J"
 SLPS-25323:
-  name: "Usagi - Yasei no Topai - Yamashiro Mahjong-Hen"
+  name: 兎 -野性の闘牌-山城麻雀篇
+  name-sort: うさぎ -やせいのとうはい-やましろまーじゃんへん
+  name-en: "Usagi - Yasei no Topai - Yamashiro Mahjong-Hen"
   region: "NTSC-J"
 SLPS-25324:
-  name: "Rhapsody of Zephyr"
+  name: 西風の狂詩曲(ラプソディ)(初回限定版)
+  name-sort: にしかぜのらぷそでぃ(しょかいげんていばん)
+  name-en: "Rhapsody of Zephyr"
   region: "NTSC-J"
 SLPS-25326:
-  name: "WWE Smackdown! Here Comes the Pain - Exciting Pro Wrestling 5 [Limited Edition]"
+  name: エキサイティングプロレス5
+  name-sort: えきさいてぃんぐぷろれす5
+  name-en: "WWE Smackdown! Here Comes the Pain - Exciting Pro Wrestling 5 [Limited Edition]"
   region: "NTSC-J"
 SLPS-25327:
   name: "Exciting Pro Wres 5"
   region: "NTSC-J"
 SLPS-25329:
-  name: "Kuon"
+  name: 九怨 -kuon-
+  name-sort: くおん
+  name-en: "Kuon"
   region: "NTSC-J"
   compat: 5
   roundModes:
@@ -43893,18 +50164,26 @@ SLPS-25329:
     halfPixelOffset: 2 # Reduces ghosting.
     preloadFrameData: 1 # Fixes red cracklines on walls.
 SLPS-25330:
-  name: "Dragon Ball Z - Budokai 2"
+  name: ドラゴンボールZ2
+  name-sort: どらごんぼーるZ2
+  name-en: "Dragon Ball Z - Budokai 2"
   region: "NTSC-J"
 SLPS-25332:
-  name: "Snow [First Limited Edition]"
+  name: SNOW(初回限定版)
+  name-sort: SNOW(しょかいげんていばん)
+  name-en: "Snow [First Limited Edition]"
   region: "NTSC-J"
   gsHWFixes:
     minimumBlendingLevel: 4 # Fixes transparancy.
 SLPS-25333:
-  name: "Gallop Racer Lucky 7"
+  name: ギャロップレーサー ラッキー7
+  name-sort: ぎゃろっぷれーさー らっきー7
+  name-en: "Gallop Racer Lucky 7"
   region: "NTSC-J"
 SLPS-25334:
-  name: "Shadow Hearts 2 [Disc 1 of 2]"
+  name: シャドウハーツ II(通常版)
+  name-sort: しゃどうはーつ II(つうじょうばん)
+  name-en: "Shadow Hearts 2 [Disc 1 of 2]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurrines, preload frame for FMV breaks visuals with this setting.
@@ -43922,13 +50201,19 @@ SLPS-25335:
   memcardFilters:
     - "SLPS-25334"
 SLPS-25336:
-  name: "Bass Landing 3 [with TsuriCon2+] [Sammy Best]"
+  name: バスランディング3 サミーベスト つりコン2+ 同梱版
+  name-sort: ばすらんでぃんぐ3 さみーべすと つりこん2+ どうこんばん
+  name-en: "Bass Landing 3 [with TsuriCon2+] [Sammy Best]"
   region: "NTSC-J"
 SLPS-25337:
-  name: "Bass Landing 3 [Sammy Best]"
+  name: バスランディング3 サミーベスト
+  name-sort: ばすらんでぃんぐ3 さみーべすと
+  name-en: "Bass Landing 3 [Sammy Best]"
   region: "NTSC-J"
 SLPS-25338:
-  name: "Armored Core - Nexus [Disc 1]"
+  name: ARMORED CORE NEXUS
+  name-sort: ARMORED CORE NEXUS
+  name-en: "Armored Core - Nexus [Disc 1]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
@@ -43954,44 +50239,68 @@ SLPS-25339:
     - "SLPS-73202"
     - "SLPS-73203"
 SLPS-25340:
-  name: "Missing Parts - Side B"
+  name: ミッシングパーツ sideB the TANTEI stories
+  name-sort: みっしんぐぱーつ sideB the TANTEI stories
+  name-en: "Missing Parts - Side B"
   region: "NTSC-J"
 SLPS-25341:
-  name: "Backyard Wrestling - Don't Try This at Home"
+  name: バックヤードレスリング
+  name-sort: ばっくやーどれすりんぐ
+  name-en: "Backyard Wrestling - Don't Try This at Home"
   region: "NTSC-J"
 SLPS-25342:
-  name: "Snow"
+  name: SNOW
+  name-sort: SNOW
+  name-en: "Snow"
   region: "NTSC-J"
   gsHWFixes:
     minimumBlendingLevel: 4 # Fixes transparancy.
 SLPS-25343:
-  name: "Gunslinger Girl Vol.1"
+  name: ガンスリンガー・ガール Volume.I
+  name-sort: がんすりんがー・がーる Volume.I
+  name-en: "Gunslinger Girl Vol.1"
   region: "NTSC-J"
   compat: 5
 SLPS-25344:
-  name: "Saiyuki Reload"
+  name: 最遊記RELOAD
+  name-sort: さいゆうきRELOAD
+  name-en: "Saiyuki Reload"
   region: "NTSC-J"
 SLPS-25345:
-  name: "Super Robot Wars MX"
+  name: スーパーロボット大戦MX
+  name-sort: すーぱーろぼっとたいせんMX
+  name-en: "Super Robot Wars MX"
   region: "NTSC-J"
   compat: 5
 SLPS-25346:
-  name: "Samurai Spirits Zero"
+  name: サムライスピリッツ零
+  name-sort: さむらいすぴりっつぜろ
+  name-en: "Samurai Spirits Zero"
   region: "NTSC-J"
 SLPS-25347:
-  name: "King of Fighters 2002, The"
+  name: THE KING OF FIGHTERS 2002
+  name-sort: THE KING OF FIGHTERS 2002
+  name-en: "King of Fighters 2002, The"
   region: "NTSC-J"
 SLPS-25348:
-  name: "Kokoro no Tobira [Limited Edition]"
+  name: こころの扉 初回限定版 コレクターズエディション
+  name-sort: こころのとびら しょかいげんていばん これくたーずえでぃしょん
+  name-en: "Kokoro no Tobira [Limited Edition]"
   region: "NTSC-J"
 SLPS-25349:
-  name: "Kokoro no Tobira"
+  name: こころの扉
+  name-sort: こころのとびら
+  name-en: "Kokoro no Tobira"
   region: "NTSC-J"
 SLPS-25350:
-  name: "Netsu Chu! Pro Baseball 2004"
+  name: 熱チュー!プロ野球2004
+  name-sort: ねつちゅー!ぷろやきゅう2004
+  name-en: "Netsu Chu! Pro Baseball 2004"
   region: "NTSC-J"
 SLPS-25351:
-  name: "Burnout 2 - Point of Impact"
+  name: BURNOUT2:POINT OF IMPACT
+  name-sort: BURNOUT2:POINT OF IMPACT
+  name-en: "Burnout 2 - Point of Impact"
   region: "NTSC-J"
   gsHWFixes:
     gpuTargetCLUT: 1 # Fixes bloom and sun rendering in front of everything.
@@ -44001,34 +50310,52 @@ SLPS-25351:
   roundModes:
     vu1RoundMode: 1 # Bright lights in cars.
 SLPS-25352:
-  name: "Espgaluda"
+  name: エスプガルーダ
+  name-sort: えすぷがるーだ
+  name-en: "Espgaluda"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
     texturePreloading: 1 # Performs much better with partial preload.
 SLPS-25353:
-  name: "Xenosaga Freaks"
+  name: ゼノサーガ フリークス
+  name-sort: ぜのさーが ふりーくす
+  name-en: "Xenosaga Freaks"
   region: "NTSC-J"
 SLPS-25354:
-  name: "Panzer Frony - Ausf. B"
+  name: PANZER FRONT Ausf.B
+  name-sort: PANZER FRONT Ausf.B
+  name-en: "Panzer Frony - Ausf. B"
   region: "NTSC-J"
 SLPS-25355:
-  name: "UFC 2004 - Ultimate Fighting Championship"
+  name: UFC2004
+  name-sort: UFC2004
+  name-en: "UFC 2004 - Ultimate Fighting Championship"
   region: "NTSC-J"
 SLPS-25356:
-  name: "Broken Sword - Nenereru Ryuu no Densetsu"
+  name: ブロークン・ソード〜眠れる竜の伝説〜
+  name-sort: ぶろーくん・そーど〜ねむれるりゅうのでんせつ〜
+  name-en: "Broken Sword - Nenereru Ryuu no Densetsu"
   region: "NTSC-J"
 SLPS-25357:
-  name: "3-nen B-gumi Kinpachi Sensei - Densetsu no Kyoudan ni Tate!"
+  name: 3年B組金八先生 伝説の教壇に立て!
+  name-sort: 3ねんBぐみきんぱちせんせい でんせつのきょうだんにたて!
+  name-en: "3-nen B-gumi Kinpachi Sensei - Densetsu no Kyoudan ni Tate!"
   region: "NTSC-J"
 SLPS-25358:
-  name: "Gold Gasho Bell! - Friendship Tag Battle"
+  name: 金色のガッシュベル!! 友情タッグバトル
+  name-sort: きんいろのがっしゅべる!! ゆうじょうたっぐばとる
+  name-en: "Gold Gasho Bell! - Friendship Tag Battle"
   region: "NTSC-J"
 SLPS-25359:
-  name: "Shaman King Funbari Spirits"
+  name: シャーマンキング ふんばりスピリッツ
+  name-sort: しゃーまんきんぐ ふんばりすぴりっつ
+  name-en: "Shaman King Funbari Spirits"
   region: "NTSC-J"
 SLPS-25360:
-  name: "Katamari Damacy"
+  name: 塊魂
+  name-sort: かたまりたましい
+  name-en: "Katamari Damacy"
   region: "NTSC-J"
   compat: 5
   roundModes:
@@ -44038,22 +50365,34 @@ SLPS-25360:
   speedHacks:
     mvuFlag: 0 # Fixes performance and falling through floor and other gameplay.
 SLPS-25361:
-  name: "Smash Court Professional Tournament 2"
+  name: スマッシュコートプロトーナメント2
+  name-sort: すまっしゅこーとぷろとーなめんと2
+  name-en: "Smash Court Professional Tournament 2"
   region: "NTSC-J"
 SLPS-25362:
-  name: "Tetsujin 28 Go"
+  name: 鉄人28号
+  name-sort: てつじん28ごう
+  name-en: "Tetsujin 28 Go"
   region: "NTSC-J"
 SLPS-25363:
-  name: "Sakurazaka Shouboutai"
+  name: 桜坂消防隊
+  name-sort: さくらざかしょうぼうたい
+  name-en: "Sakurazaka Shouboutai"
   region: "NTSC-J"
 SLPS-25364:
-  name: "Ultraman"
+  name: ウルトラマン
+  name-sort: うるとらまん
+  name-en: "Ultraman"
   region: "NTSC-J"
 SLPS-25365:
-  name: "Missing Blue [Best Price]"
+  name: ベストプライス MissingBlue
+  name-sort: べすとぷらいす MissingBlue
+  name-en: "Missing Blue [Best Price]"
   region: "NTSC-J"
 SLPS-25366:
-  name: "Xenosaga Episode II - Jenseits von Gut und Bose [Premium Box] [Disc 1 of 2]"
+  name: ゼノサーガ エピソードII［善悪の彼岸］ プレミアムボックス
+  name-sort: ぜのさーが えぴそーどII［ぜんあくのひがん］ ぷれみあむぼっくす
+  name-en: "Xenosaga Episode II - Jenseits von Gut und Bose [Premium Box] [Disc 1 of 2]"
   region: "NTSC-J"
   gsHWFixes:
     autoFlush: 2 # Fixes shadows in cutscenes.
@@ -44081,7 +50420,9 @@ SLPS-25367:
     - "SLPS-25353"
     - "SLPS-73224"
 SLPS-25368:
-  name: "Xenosaga Episode II - Jenseits von Gut und Bose [Disc 1 of 2]"
+  name: ゼノサーガ エピソードII［善悪の彼岸］
+  name-sort: ぜのさーが えぴそーどII［ぜんあくのひがん］
+  name-en: "Xenosaga Episode II - Jenseits von Gut und Bose [Disc 1 of 2]"
   region: "NTSC-J"
   gsHWFixes:
     autoFlush: 2 # Fixes shadows in cutscenes.
@@ -44109,139 +50450,215 @@ SLPS-25369:
     - "SLPS-25353"
     - "SLPS-73224"
 SLPS-25370:
-  name: "Spawn - Armageddon"
+  name: SPAWN 運命の鎖
+  name-sort: SPAWN うんめいのくさり
+  name-en: "Spawn - Armageddon"
   region: "NTSC-J"
 SLPS-25371:
-  name: "DearS [Limited Edition]"
+  name: DearS 初回限定版
+  name-sort: DearS しょかいげんていばん
+  name-en: "DearS [Limited Edition]"
   region: "NTSC-J"
 SLPS-25372:
-  name: "DearS"
+  name: DearS
+  name-sort: DearS
+  name-en: "DearS"
   region: "NTSC-J"
 SLPS-25373:
-  name: "Gunslinger Girl Vol.2"
+  name: ガンスリンガー・ガール Volume.II
+  name-sort: がんすりんがー・がーる Volume.II
+  name-en: "Gunslinger Girl Vol.2"
   region: "NTSC-J"
 SLPS-25374:
-  name: "Great Escape, The"
+  name: 大脱走 THE GREAT ESCAPE
+  name-sort: だいだっそう THE GREAT ESCAPE
+  name-en: "Great Escape, The"
   region: "NTSC-J"
 SLPS-25375:
-  name: "XIII"
+  name: XIII[サーティーン]大統領を殺した男
+  name-sort: XIII[さーてぃーん]だいとうりょうをころしたおとこ
+  name-en: "XIII"
   region: "NTSC-J"
 SLPS-25376:
-  name: "Metal Slug 4"
+  name: メタルスラッグ4
+  name-sort: めたるすらっぐ4
+  name-en: "Metal Slug 4"
   region: "NTSC-J"
   compat: 5
 SLPS-25377:
-  name: "Nightmare of Druaga, The - Fushigi no Dungeon"
+  name: ザ・ナイトメア・オブ・ドルアーガ 不思議のダンジョン
+  name-sort: ざ・ないとめあ・おぶ・どるあーが ふしぎのだんじょん
+  name-en: "Nightmare of Druaga, The - Fushigi no Dungeon"
   region: "NTSC-J"
 SLPS-25378:
-  name: "Tokyo Majin Gakuen - Kaihoujyou Kefurokou [Limited Edition]"
+  name: 東京魔人學園外法帖血風録(初回限定版)
+  name-sort: とうきょうまじんがくえんげほうちょうけっぷうろく(しょかいげんていばん)
+  name-en: "Tokyo Majin Gakuen - Kaihoujyou Kefurokou [Limited Edition]"
   region: "NTSC-J"
 SLPS-25379:
-  name: "Tokyo Majin Gakuen - Kaihoujyou Kefurokou"
+  name: 東京魔人學園外法帖血風録
+  name-sort: とうきょうまじんがくえんげほうちょうけっぷうろく
+  name-en: "Tokyo Majin Gakuen - Kaihoujyou Kefurokou"
   region: "NTSC-J"
 SLPS-25381:
-  name: "Gakuen Heaven - Boy's Love Scramble! Type B"
+  name: 学園ヘヴン BOY’S LOVE SCRAMBLE!
+  name-sort: がくえんへゔん BOY’S LOVE SCRAMBLE!
+  name-en: "Gakuen Heaven - Boy's Love Scramble! Type B"
   region: "NTSC-J"
 SLPS-25382:
-  name: "One Piece - Land Land"
+  name: ONE PIECE ランドランド!
+  name-sort: ONE PIECE らんどらんど!
+  name-en: "One Piece - Land Land"
   region: "NTSC-J"
 SLPS-25383:
-  name: "Digimon Battle Chronicle"
+  name: デジモンバトルクロニクル
+  name-sort: でじもんばとるくろにくる
+  name-en: "Digimon Battle Chronicle"
   region: "NTSC-J"
   clampModes:
     eeClampMode: 3 # Fixes impossible  menu selection issue.
 SLPS-25384:
-  name: "Tenchu Kurenai"
+  name: 天誅 紅
+  name-sort: てんちゅう くれない
+  name-en: "Tenchu Kurenai"
   region: "NTSC-J"
 SLPS-25385:
-  name: "Friends Seishun no Kagayaki"
+  name: フレンズ 〜青春の輝き〜
+  name-sort: ふれんず 〜せいしゅんのかがやき〜
+  name-en: "Friends Seishun no Kagayaki"
   region: "NTSC-J"
 SLPS-25386:
-  name: "King of Fighters, The - Maximum Impact Maniax"
+  name: KOFマキシマムインパクト
+  name-sort: KOFまきしまむいんぱくと
+  name-en: "King of Fighters, The - Maximum Impact Maniax"
   region: "NTSC-J"
 SLPS-25387:
-  name: "True Love Story - Summer Days, and Yet..."
+  name: エンターブレインコレクション True Love StorySummer Days,and yet...
+  name-sort: えんたーぶれいんこれくしょん True Love StorySummer Days,and yet...
+  name-en: "True Love Story - Summer Days, and Yet..."
   region: "NTSC-J"
 SLPS-25388:
-  name: "Gunslinger Girl Vol.3"
+  name: ガンスリンガー・ガール Volume.III
+  name-sort: がんすりんがー・がーる Volume.III
+  name-en: "Gunslinger Girl Vol.3"
   region: "NTSC-J"
 SLPS-25389:
-  name: "Gundam Seed - Never Ending Tomorrow"
+  name: 機動戦士ガンダムSEED 終わらない明日へ
+  name-sort: きどうせんしがんだむSEED おわらないあしたへ
+  name-en: "Gundam Seed - Never Ending Tomorrow"
   region: "NTSC-J"
 SLPS-25390:
-  name: "Clover Heart's - Looking for Happiness [Limited Edition]"
+  name: クローバーハーツ ルッキングフォーハピネス(初回限定版)
+  name-sort: くろーばーはーつ るっきんぐふぉーはぴねす(しょかいげんていばん)
+  name-en: "Clover Heart's - Looking for Happiness [Limited Edition]"
   region: "NTSC-J"
   gsHWFixes:
     minimumBlendingLevel: 4 # Fixes transparancy.
 SLPS-25391:
-  name: "Clover Heart's - Looking for Happiness"
+  name: クローバーハーツ ルッキングフォーハピネス
+  name-sort: くろーばーはーつ るっきんぐふぉーはぴねす
+  name-en: "Clover Heart's - Looking for Happiness"
   region: "NTSC-J"
   gsHWFixes:
     minimumBlendingLevel: 4 # Fixes transparancy.
 SLPS-25392:
-  name: "Desire"
+  name: DESIRE
+  name-sort: DESIRE
+  name-en: "Desire"
   region: "NTSC-J"
 SLPS-25393:
-  name: "Rim Runners"
+  name: Rim Runners
+  name-sort: Rim Runners
+  name-en: "Rim Runners"
   region: "NTSC-J"
 SLPS-25394:
-  name: "Another Century's Episode"
+  name: Another Century’s Episode
+  name-sort: Another Century’s Episode
+  name-en: "Another Century's Episode"
   region: "NTSC-J"
 SLPS-25395:
-  name: "Sentimental Prelude"
+  name: センチメンタルプレリュード
+  name-sort: せんちめんたるぷれりゅーど
+  name-en: "Sentimental Prelude"
   region: "NTSC-J"
 SLPS-25396:
-  name: "Fantastic Fortune 2 - Triple Star"
+  name: ファンタスティックフォーチュン2 ☆☆☆(トリプルスター)
+  name-sort: ふぁんたすてぃっくふぉーちゅん2 ☆☆☆(とりぷるすたー)
+  name-en: "Fantastic Fortune 2 - Triple Star"
   region: "NTSC-J"
 SLPS-25397:
-  name: "Golden Voyage - Sinbad Adventure"
+  name: シンドバットアドベンチャーは榎本加奈子でどうですか (特典版)
+  name-sort: しんどばっとあどべんちゃーはえのもとかなこでどうですか (とくてんばん)
+  name-en: "Golden Voyage - Sinbad Adventure"
   region: "NTSC-J"
 SLPS-25398:
-  name: "Naruto - Narutimett Hero 2"
+  name: NARUTO-ナルト-ナルティメットヒーロー2
+  name-sort: NARUTO-なると-なるてぃめっとひーろー2
+  name-en: "Naruto - Narutimett Hero 2"
   region: "NTSC-J"
   clampModes:
     vu0ClampMode: 0 # Fixes glow effects.
     vu1ClampMode: 3 # Fixes rare SPS.
 SLPS-25399:
-  name: "Keroro Gunsou - Mero Mero Battle Royale"
+  name: ケロロ軍曹 メロメロバトルロイヤル
+  name-sort: けろろぐんそう めろめろばとるろいやる
+  name-en: "Keroro Gunsou - Mero Mero Battle Royale"
   region: "NTSC-J"
   gsHWFixes:
     preloadFrameData: 1 # Fixes invisible text.
 SLPS-25400:
-  name: "Tales of Symphonia"
+  name: テイルズ オブ シンフォニア
+  name-sort: ているず おぶ しんふぉにあ
+  name-en: "Tales of Symphonia"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
     getSkipCount: "GSC_TalesofSymphonia"
 SLPS-25401:
-  name: "Magna Carta"
+  name: マグナカルタ
+  name-sort: まぐなかるた
+  name-en: "Magna Carta"
   region: "NTSC-J"
 SLPS-25402:
-  name: "Hagane no Renkinjutsushi - Dream Carnival"
+  name: 鋼の錬金術師 ドリームカーニバル
+  name-sort: はがねのれんきんじゅつし どりーむかーにばる
+  name-en: "Hagane no Renkinjutsushi - Dream Carnival"
   region: "NTSC-J"
   compat: 5
 SLPS-25403:
-  name: "Hitman - Silent Assassin [Eidos The Best]"
+  name: ヒットマン:サイレントアサシン アイドスベスト
+  name-sort: ひっとまん:さいれんとあさしん あいどすべすと
+  name-en: "Hitman - Silent Assassin [Eidos The Best]"
   region: "NTSC-J"
 SLPS-25404:
-  name: "RPG Maker 3"
+  name: RPGツクール
+  name-sort: RPGつくーる
+  name-en: "RPG Maker 3"
   region: "NTSC-J"
 SLPS-25405:
-  name: "Tokyo Majin Gakuen - Kaihoujyou Kefurokou [Best Collection]"
+  name: 東京魔人學園外法帖血風録 Best Collection
+  name-sort: とうきょうまじんがくえんげほうちょうけっぷうろく Best Collection
+  name-en: "Tokyo Majin Gakuen - Kaihoujyou Kefurokou [Best Collection]"
   region: "NTSC-J"
 SLPS-25406:
-  name: "Hitman - Contracts"
+  name: ヒットマン:コントラクト
+  name-sort: ひっとまん:こんとらくと
+  name-en: "Hitman - Contracts"
   region: "NTSC-J"
   gsHWFixes:
     texturePreloading: 1 # Performs much better with partial preload.
   roundModes:
     vu1RoundMode: 0 # Fixes missing light cones curtains and certain effects.
 SLPS-25407:
-  name: "King of Fighters 2003, The"
+  name: THE KING OF FIGHTERS 2003
+  name-sort: THE KING OF FIGHTERS 2003
+  name-en: "King of Fighters 2003, The"
   region: "NTSC-J"
 SLPS-25408:
-  name: "Armored Core - Nine Breaker"
+  name: ARMORED CORE NINE BREAKER
+  name-sort: ARMORED CORE NINE BREAKER
+  name-en: "Armored Core - Nine Breaker"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
@@ -44255,34 +50672,52 @@ SLPS-25408:
     - "SLPS-73202"
     - "SLPS-73203"
 SLPS-25409:
-  name: "Futakoi [Limited Edition]"
+  name: 双恋—フタコイ— 初回限定版
+  name-sort: そうこい—ふたこい— しょかいげんていばん
+  name-en: "Futakoi [Limited Edition]"
   region: "NTSC-J"
 SLPS-25410:
-  name: "Futakoi"
+  name: 双恋—フタコイ—
+  name-sort: そうこい—ふたこい—
+  name-en: "Futakoi"
   region: "NTSC-J"
 SLPS-25411:
-  name: "To Heart 2 [Deluxe Edition]"
+  name: ToHeart & ToHeart2 限定デラックスパック
+  name-sort: ToHeart & ToHeart2 げんていでらっくすぱっく
+  name-en: "To Heart 2 [Deluxe Edition]"
   region: "NTSC-J"
 SLPS-25412:
   name: "ToHeart"
   region: "NTSC-J"
 SLPS-25413:
-  name: "To Heart 2 [Limited Edition]"
+  name: ToHeart2 初回限定版
+  name-sort: ToHeart2 しょかいげんていばん
+  name-en: "To Heart 2 [Limited Edition]"
   region: "NTSC-J"
 SLPS-25414:
-  name: "To Heart 2"
+  name: ToHeart2
+  name-sort: ToHeart2
+  name-en: "To Heart 2"
   region: "NTSC-J"
 SLPS-25415:
-  name: "Chuuka na Janshi - Tenhoo Painyan [Collector's Edition]"
+  name: ちゅ〜かな雀士 てんほー牌娘 コレクターズエディション
+  name-sort: ちゅ〜かなじゃんし てんほーぱいにゃん これくたーずえでぃしょん
+  name-en: "Chuuka na Janshi - Tenhoo Painyan [Collector's Edition]"
   region: "NTSC-J"
 SLPS-25416:
-  name: "Chuuka na Janshi - Tenhoo Painyan"
+  name: ちゅ〜かな雀士 てんほー牌娘(通常版)
+  name-sort: ちゅ〜かなじゃんし てんほーぱいにゃん(つうじょうばん)
+  name-en: "Chuuka na Janshi - Tenhoo Painyan"
   region: "NTSC-J"
 SLPS-25417:
-  name: "Panzer Front Ausf.B [Enterbrain Collection]"
+  name: eb!コレ PANZER FRONT Ausf.B
+  name-sort: eb!これ PANZER FRONT Ausf.B
+  name-en: "Panzer Front Ausf.B [Enterbrain Collection]"
   region: "NTSC-J"
 SLPS-25418:
-  name: "Ace Combat 5 - The Unsung War"
+  name: エースコンバット5 ジ・アンサング・ウォー
+  name-sort: えーすこんばっと5 じ・あんさんぐ・うぉー
+  name-en: "Ace Combat 5 - The Unsung War"
   region: "NTSC-J"
   compat: 5
   gameFixes:
@@ -44304,13 +50739,17 @@ SLPS-25418:
         patch=0,EE,001A3B7C,word,484A8800
         patch=0,EE,001A3B80,word,4B0C682C
 SLPS-25419:
-  name: "Mobile Suit Gundam - Gundam vs. Z-Gundam"
+  name: 機動戦士ガンダム ガンダムvs.Zガンダム
+  name-sort: きどうせんしがんだむ がんだむvs.Zがんだむ
+  name-en: "Mobile Suit Gundam - Gundam vs. Z-Gundam"
   region: "NTSC-J"
 SLPS-25420:
   name: "Sinbad Adventure wa Enomoto Kanako de Dou desu ka"
   region: "NTSC-J"
 SLPS-25421:
-  name: "Bokujou Monogatari - Oh! Wonderful Life [First Print Limited Edition]"
+  name: 牧場物語 Oh!ワンダフルライフ(初回版)
+  name-sort: ぼくじょうものがたり Oh!わんだふるらいふ(しょかいばん)
+  name-en: "Bokujou Monogatari - Oh! Wonderful Life [First Print Limited Edition]"
   region: "NTSC-J"
   patches:
     D2F0DC73:
@@ -44319,39 +50758,57 @@ SLPS-25421:
         // Fix hang at shipping shed.
         patch=1,EE,002bd36c,word,00000000
 SLPS-25422:
-  name: "Death by Degrees - Tekken - Nina Williams"
+  name: デス バイ ディグリーズ 鉄拳:ニーナ ウィリアムズ
+  name-sort: です ばい でぃぐりーず てっけん:にーな うぃりあむず
+  name-en: "Death by Degrees - Tekken - Nina Williams"
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes FMV lines.
     getSkipCount: "GSC_DeathByDegreesTekkenNinaWilliams"
 SLPS-25423:
-  name: "Kaitou Apricot - Complete Edition [Limited Edition]"
+  name: 怪盗アプリコット 完全版 (限定版)
+  name-sort: かいとうあぷりこっと かんぜんばん (げんていばん)
+  name-en: "Kaitou Apricot - Complete Edition [Limited Edition]"
   region: "NTSC-J"
 SLPS-25424:
-  name: "Kaitou Apricot - Complete Edition"
+  name: 怪盗アプリコット 完全版
+  name-sort: かいとうあぷりこっと かんぜんばん
+  name-en: "Kaitou Apricot - Complete Edition"
   region: "NTSC-J"
 SLPS-25425:
-  name: "SD Gundam Force Daikessen!"
+  name: SDガンダムフォース 大決戦!次元海賊デ・スカール
+  name-sort: SDがんだむふぉーす だいけっせん!じげんかいぞくで・すかーる
+  name-en: "SD Gundam Force Daikessen!"
   region: "NTSC-J"
   clampModes:
     eeClampMode: 2 # Needed for SPS on some characters.
 SLPS-25426:
-  name: "Detective Conan - Inheritance of Britain"
+  name: 名探偵コナン 大英帝国の遺産
+  name-sort: めいたんていこなん だいえいていこくのいさん
+  name-en: "Detective Conan - Inheritance of Britain"
   region: "NTSC-J"
 SLPS-25427:
-  name: "Legions Gekitou! Saga Battle"
+  name: レジェンズ 激闘!サーガバトル
+  name-sort: れじぇんず げきとう!さーがばとる
+  name-en: "Legions Gekitou! Saga Battle"
   region: "NTSC-J"
   compat: 5
 SLPS-25428:
-  name: "Metal Slug 3 [SNK Best Collection]"
+  name: SNK Best Collection メタルスラッグ3
+  name-sort: SNK Best Collection めたるすらっぐ3
+  name-en: "Metal Slug 3 [SNK Best Collection]"
   region: "NTSC-J"
   gsHWFixes:
     gpuPaletteConversion: 2 # Stops excessive VRAM usage with preloading on.
 SLPS-25429:
-  name: "King of Fighters 2000, The [SNK Best Collection]"
+  name: SNK Best Collection THE KING OF FIGHTERS 2000
+  name-sort: SNK Best Collection THE KING OF FIGHTERS 2000
+  name-en: "King of Fighters 2000, The [SNK Best Collection]"
   region: "NTSC-J"
 SLPS-25430:
-  name: "Lupin III - Columbus no Isan wa Akenisomaru"
+  name: ルパン三世 コロンブスの遺産は朱に染まる
+  name-sort: るぱんさんせい ころんぶすのいさんはしゅにそまる
+  name-en: "Lupin III - Columbus no Isan wa Akenisomaru"
   region: "NTSC-J"
   gameFixes:
     - FpuNegDivHack # Fixes game softlock after prison level.
@@ -44359,105 +50816,163 @@ SLPS-25431:
   name: "Bokujou Monogatari - Oh! Wonderful Life"
   region: "NTSC-J"
 SLPS-25432:
-  name: "Majo-musume A La Mode [Magical Box]"
+  name: 魔女っ娘ア・ラ・モード 唱えて、恋の魔法!(初回限定版)
+  name-sort: まじょっこあ・ら・もーど となえて、こいのまほう!(しょかいげんていばん)
+  name-en: "Majo-musume A La Mode [Magical Box]"
   region: "NTSC-J"
 SLPS-25433:
-  name: "Teikoku Sensenki [Limited Edition]"
+  name: 帝国千戦記 (初回限定版)
+  name-sort: ていこくせんせんき (しょかいげんていばん)
+  name-en: "Teikoku Sensenki [Limited Edition]"
   region: "NTSC-J"
 SLPS-25434:
-  name: "Rhapsody of Zephyr, The [Best Collection]"
+  name: 西風の狂詩曲〜The Rhapsody of Zephyr〜 Best Collection
+  name-sort: にしかぜのらぷそでぃ〜The Rhapsody of Zephyr〜 Best Collection
+  name-en: "Rhapsody of Zephyr, The [Best Collection]"
   region: "NTSC-J"
 SLPS-25435:
-  name: "Majo-musume A La Mode"
+  name: 魔女っ娘ア・ラ・モード 唱えて、恋の魔法!
+  name-sort: まじょっこあ・ら・もーど となえて、こいのまほう!
+  name-en: "Majo-musume A La Mode"
   region: "NTSC-J"
 SLPS-25436:
-  name: "Teikoku Sensenki"
+  name: 帝国千戦記
+  name-sort: ていこくせんせんき
+  name-en: "Teikoku Sensenki"
   region: "NTSC-J"
 SLPS-25437:
-  name: "D A - White"
+  name: D→A:WHITE 初回限定版
+  name-sort: D→A:WHITE しょかいげんていばん
+  name-en: "D A - White"
   region: "NTSC-J"
 SLPS-25438:
-  name: "D A - White [Limited Edition]"
+  name: D→A:WHITE
+  name-sort: D→A:WHITE
+  name-en: "D A - White [Limited Edition]"
   region: "NTSC-J"
 SLPS-25439:
-  name: "Hajime no Ippo - All-Stars"
+  name: はじめの一歩 ALL☆STARS(オール☆スターズ)
+  name-sort: はじめのいちほ ALL☆STARS(おーる☆すたーず)
+  name-en: "Hajime no Ippo - All-Stars"
   region: "NTSC-J"
 SLPS-25440:
-  name: "Gold Gashbell!! Gekitou! Saikyou no Mamonotachi"
+  name: 金色のガッシュベル!! 激闘!最強の魔物達
+  name-sort: きんいろのがっしゅべる!! げきとう!さいきょうのまものたち
+  name-en: "Gold Gashbell!! Gekitou! Saikyou no Mamonotachi"
   region: "NTSC-J"
 SLPS-25441:
-  name: "Ultraman Fighting Evolution 3"
+  name: ウルトラマン Fighting Evolution3
+  name-sort: うるとらまん Fighting Evolution3
+  name-en: "Ultraman Fighting Evolution 3"
   region: "NTSC-J"
 SLPS-25443:
-  name: "Kawa no Nushi Tsuri - Wonderful Journey"
+  name: 川のぬし釣り ワンダフルジャーニー
+  name-sort: かわのぬしつり わんだふるじゃーにー
+  name-en: "Kawa no Nushi Tsuri - Wonderful Journey"
   region: "NTSC-J"
 SLPS-25444:
-  name: "Cherry Blossom"
+  name: Cherry blossom 〜チェリーブロッサム〜
+  name-sort: Cherry blossom 〜ちぇりーぶろっさむ〜
+  name-en: "Cherry Blossom"
   region: "NTSC-J"
 SLPS-25445:
-  name: "Kagero II - Dark Illusion"
+  name: 影牢II -Dark illusion-
+  name-sort: かげろうII -Dark illusion-
+  name-en: "Kagero II - Dark Illusion"
   region: "NTSC-J"
 SLPS-25447:
-  name: "Top wo Nerae! Gunbuster"
+  name: トップをねらえ!
+  name-sort: とっぷをねらえ!
+  name-en: "Top wo Nerae! Gunbuster"
   region: "NTSC-J"
 SLPS-25448:
-  name: "King of Fighters '94, The - Rebout [Special Pack]"
+  name: THE KING OF FIGHTERS 94 RE-BOUT(スペシャル限定版)
+  name-sort: THE KING OF FIGHTERS 94 RE-BOUT(すぺしゃるげんていばん)
+  name-en: "King of Fighters '94, The - Rebout [Special Pack]"
   region: "NTSC-J"
 SLPS-25449:
-  name: "King of Fighters '94, The - Rebout"
+  name: THE KING OF FIGHTERS 94 RE-BOUT
+  name-sort: THE KING OF FIGHTERS 94 RE-BOUT
+  name-en: "King of Fighters '94, The - Rebout"
   region: "NTSC-J"
 SLPS-25450:
-  name: "Tales of Rebirth"
+  name: テイルズ オブ リバース
+  name-sort: ているず おぶ りばーす
+  name-en: "Tales of Rebirth"
   region: "NTSC-J"
   compat: 5
   speedHacks:
     mvuFlag: 0 # Fixes graphical corruptions.
 SLPS-25451:
-  name: "Hana to Taiyou to Ame to [Super Best Collection]"
+  name: 花と太陽と雨と Super Best Collection
+  name-sort: はなとたいようとあめと Super Best Collection
+  name-en: "Hana to Taiyou to Ame to [Super Best Collection]"
   region: "NTSC-J"
 SLPS-25452:
-  name: "Kino no Tabi - The Beautiful World [MediaWorks Best]"
+  name: キノの旅 -the Beautiful World- 電撃SP
+  name-sort: きののたび -the Beautiful World- でんげきSP
+  name-en: "Kino no Tabi - The Beautiful World [MediaWorks Best]"
   region: "NTSC-J"
 SLPS-25453:
-  name: "Digimon World X"
+  name: デジモンワールドX
+  name-sort: でじもんわーるどX
+  name-en: "Digimon World X"
   region: "NTSC-J"
 SLPS-25454:
-  name: "Daisenryaku VII Exceed"
+  name: 義経英雄伝
+  name-sort: よしつねえいゆうでん
+  name-en: "Daisenryaku VII Exceed"
   region: "NTSC-J"
 SLPS-25455:
-  name: "Sanyo Pachinko Paradise 11"
+  name: 三洋パチンコパラダイス11〜新海とさらば銀玉の狼〜
+  name-sort: さんようぱちんこぱらだいす11〜しんかいとさらばぎんだまのおおかみ〜
+  name-en: "Sanyo Pachinko Paradise 11"
   region: "NTSC-J"
 SLPS-25456:
-  name: "Gladiator - Road to Freedom"
+  name: GLADIATOR ROAD TO FREEDOM
+  name-sort: GLADIATOR ROAD TO FREEDOM
+  name-en: "Gladiator - Road to Freedom"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 3 # Fixes bloom misalignment still a bit misaligned.
     roundSprite: 1 # Fixes bloom misalignment still a bit misaligned.
     cpuCLUTRender: 1 # Fixes sun background on the windows when selecting your 'race'.
 SLPS-25457:
-  name: "Ponkotsu Roeman Daikatsugeki Bumpy Trot"
+  name: ポンコツ浪漫大活劇バンピートロット
+  name-sort: ぽんこつろまんだいかつげきばんぴーとろっと
+  name-en: "Ponkotsu Roeman Daikatsugeki Bumpy Trot"
   region: "NTSC-J"
   gsHWFixes:
     getSkipCount: "GSC_SteambotChronicles" # Causes green (incorrect) water but removes depth and blur issues.
     roundSprite: 1 # Fixes colored 3D anaglyph bleeding effects.
 SLPS-25458:
-  name: "King of Fighters 2001, The [SNK Best Collection]"
+  name: SNK Best Collection THE KING OF FIGHTERS 2001
+  name-sort: SNK Best Collection THE KING OF FIGHTERS 2001
+  name-en: "King of Fighters 2001, The [SNK Best Collection]"
   region: "NTSC-J"
 SLPS-25459:
-  name: "Sword of Destiny"
+  name: 天星 ソード オブ デスティニー
+  name-sort: てんせい そーど おぶ ですてぃにー
+  name-en: "Sword of Destiny"
   region: "NTSC-J"
 SLPS-25460:
-  name: "Dragon Ball Z 3"
+  name: ドラゴンボールZ3
+  name-sort: どらごんぼーるZ3
+  name-en: "Dragon Ball Z 3"
   region: "NTSC-J"
 SLPS-25461:
-  name: "Armored Core - Formula Front"
+  name: アーマード・コア フォーミュラフロント
+  name-sort: あーまーど・こあ ふぉーみゅらふろんと
+  name-en: "Armored Core - Formula Front"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
     cpuSpriteRenderBW: 1 # Fixes broken shadow caused by HPO 1.
     cpuSpriteRenderLevel: 2 # Needed for above.
 SLPS-25462:
-  name: "Armored Core - Last Raven"
+  name: アーマード・コア ラストレイヴン
+  name-sort: あーまーど・こあ らすとれいゔん
+  name-en: "Armored Core - Last Raven"
   region: "NTSC-J"
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes glow effects, but breaks shadows of certain objects.
@@ -44473,19 +50988,29 @@ SLPS-25462:
     - "SLPS-25462"
     - "SLPS-73247"
 SLPS-25463:
-  name: "My Home o Tsukurou 2! Takumi"
+  name: マイホームをつくろう2!匠
+  name-sort: まいほーむをつくろう2!たくみ
+  name-en: "My Home o Tsukurou 2! Takumi"
   region: "NTSC-J"
 SLPS-25464:
-  name: "Daisenryaku VII Exceed"
+  name: 大戦略VII エクシード
+  name-sort: だいせんりゃくVII えくしーど
+  name-en: "Daisenryaku VII Exceed"
   region: "NTSC-J"
 SLPS-25465:
-  name: "Azumi"
+  name: あずみ
+  name-sort: あずみ
+  name-en: "Azumi"
   region: "NTSC-J"
 SLPS-25466:
-  name: "Eternal Aselia - The Spirit of Eternity Sword [Limited Edition]"
+  name: 永遠のアセリア -この大地の果てでー 初回限定版
+  name-sort: えいえんのあせりあ -このだいちのはてでー しょかいげんていばん
+  name-en: "Eternal Aselia - The Spirit of Eternity Sword [Limited Edition]"
   region: "NTSC-J"
 SLPS-25467:
-  name: "Minna Daisuki Katamari Damacy"
+  name: みんな大好き塊魂
+  name-sort: みんなだいすきかたまりたましい
+  name-en: "Minna Daisuki Katamari Damacy"
   region: "NTSC-J"
   compat: 5
   roundModes:
@@ -44503,129 +51028,209 @@ SLPS-25467:
     - "SLPS-73210"
     - "SLPS-73240"
 SLPS-25468:
-  name: "Eternal Aselia - The Spirit of Eternity Sword"
+  name: 永遠のアセリア −この大地の果てで−
+  name-sort: えいえんのあせりあ -このだいちのはてで-
+  name-en: "Eternal Aselia - The Spirit of Eternity Sword"
   region: "NTSC-J"
 SLPS-25469:
-  name: "Baseball Live 2005"
+  name: ベースボールライブ2005
+  name-sort: べーすぼーるらいぶ2005
+  name-en: "Baseball Live 2005"
   region: "NTSC-J"
 SLPS-25470:
-  name: "Bouken-ou Beet - Darkness Century"
+  name: 冒険王ビィト ダークネスセンチュリー
+  name-sort: ぼうけんおうびぃと だーくねすせんちゅりー
+  name-en: "Bouken-ou Beet - Darkness Century"
   region: "NTSC-J"
 SLPS-25471:
-  name: "Gakkou o Tsukurou - Happy Days!!"
+  name: 学校をつくろう Happy Days!!
+  name-sort: がっこうをつくろう Happy Days!!
+  name-en: "Gakkou o Tsukurou - Happy Days!!"
   region: "NTSC-J"
 SLPS-25472:
-  name: "XIII [Best Collection]"
+  name: XIII[サーティーン] 大統領を殺した男 Best Collection
+  name-sort: XIII[さーてぃーん] だいとうりょうをころしたおとこ Best Collection
+  name-en: "XIII [Best Collection]"
   region: "NTSC-J"
 SLPS-25473:
-  name: "One Piece - Grand Battle! Combat Rush"
+  name: ONE PIECE グラバト!RUSH
+  name-sort: ONE PIECE ぐらばと!RUSH
+  name-en: "One Piece - Grand Battle! Combat Rush"
   region: "NTSC-J"
 SLPS-25474:
-  name: "Beck - The Game"
+  name: BECK THE GAME
+  name-sort: BECK THE GAME
+  name-en: "Beck - The Game"
   region: "NTSC-J"
 SLPS-25476:
-  name: "Saint Seiya Seiiki Juunikyuu Hen"
+  name: 聖闘士星矢 -聖域十二宮編-
+  name-sort: せいんとせいや -せいいきじゅうにきゅうへん-
+  name-en: "Saint Seiya Seiiki Juunikyuu Hen"
   region: "NTSC-J"
   compat: 5
 SLPS-25478:
-  name: "Mobile Suit Gundam - One Year War"
+  name: 機動戦士ガンダム 一年戦争
+  name-sort: きどうせんしがんだむ いちねんせんそう
+  name-en: "Mobile Suit Gundam - One Year War"
   region: "NTSC-J"
 SLPS-25479:
-  name: "Gold Gashbell - Friendship Tag Battle 2"
+  name: 金色のガッシュベル!!友情タッグバトル2
+  name-sort: きんいろのがっしゅべる!!ゆうじょうたっぐばとる2
+  name-en: "Gold Gashbell - Friendship Tag Battle 2"
   region: "NTSC-J"
 SLPS-25480:
-  name: "ZIPANG"
+  name: ジパング
+  name-sort: じぱんぐ
+  name-en: "ZIPANG"
   region: "NTSC-J"
 SLPS-25481:
-  name: "Gattsu!! Mori no Ishimatsu"
+  name: ガッツだ!!森の石松
+  name-sort: がっつだ!!もりのいしまつ
+  name-en: "Gattsu!! Mori no Ishimatsu"
   region: "NTSC-J"
 SLPS-25482:
-  name: "Yuki Katari [Renewal Version]"
+  name: 雪語り リニューアル版
+  name-sort: ゆきかたり りにゅーあるばん
+  name-en: "Yuki Katari [Renewal Version]"
   region: "NTSC-J"
 SLPS-25483:
-  name: "Sui-Toshi-Zun"
+  name: すい～とし～ずん
+  name-sort: すい～とし～ずん
+  name-en: "Sui-Toshi-Zun"
   region: "NTSC-J"
 SLPS-25484:
-  name: "SNK vs. Capcom Chaos [SNK Best Collection]"
+  name: SNK BEST Collection SNK VS. CAPCOM SVC CHAOS
+  name-sort: SNK BEST Collection SNK VS. CAPCOM SVC CHAOS
+  name-en: "SNK vs. Capcom Chaos [SNK Best Collection]"
   region: "NTSC-J"
 SLPS-25485:
-  name: "Mobile Suit Gundam Ver.1.5 [Gundam the Best]"
+  name: 機動戦士ガンダムVer.1.5 GUNDAM THE BEST
+  name-sort: きどうせんしがんだむVer.1.5 GUNDAM THE BEST
+  name-en: "Mobile Suit Gundam Ver.1.5 [Gundam the Best]"
   region: "NTSC-J"
 SLPS-25486:
-  name: "Mobile Suit Gundam - Lost War Chronicles [Gundam the Best]"
+  name: 機動戦士ガンダム戦記 GUNDAM THE BEST
+  name-sort: きどうせんしがんだむせんき GUNDAM THE BEST
+  name-en: "Mobile Suit Gundam - Lost War Chronicles [Gundam the Best]"
   region: "NTSC-J"
 SLPS-25487:
-  name: "Mobile Suit Gundam - Meguriai Sora [Gundam the Best]"
+  name: 機動戦士ガンダム めぐりあい宇宙 GUNDAM THE BEST
+  name-sort: きどうせんしがんだむ めぐりあいうちゅう GUNDAM THE BEST
+  name-en: "Mobile Suit Gundam - Meguriai Sora [Gundam the Best]"
   region: "NTSC-J"
 SLPS-25488:
-  name: "Zeonic Front - Mobile Suit Gundam 0079 [Gundam the Best]"
+  name: ジオニックフロント 機動戦士ガンダム0079 GUNDAM THE BEST
+  name-sort: じおにっくふろんと きどうせんしがんだむ0079 GUNDAM THE BEST
+  name-en: "Zeonic Front - Mobile Suit Gundam 0079 [Gundam the Best]"
   region: "NTSC-J"
 SLPS-25489:
-  name: "Ambition of Giren - Zeon Independence War + Direction Book of Capture [Gundam the Best]"
+  name: 機動戦士ガンダム ギレンの野望 ジオン独立戦争記+攻略指令書 GUNDAM THE BEST
+  name-sort: きどうせんしがんだむ ぎれんのやぼう じおんどくりつせんそうき+こうりゃくしれいしょ GUNDAM THE BEST
+  name-en: "Ambition of Giren - Zeon Independence War + Direction Book of Capture [Gundam the Best]"
   region: "NTSC-J"
 SLPS-25491:
-  name: "SD Gundam G Generation Neo [Gundam The Best]"
+  name: SDガンダム G GENERATION—NEO GUNDAM THE BEST
+  name-sort: SDがんだむ G GENERATION—NEO GUNDAM THE BEST
+  name-en: "SD Gundam G Generation Neo [Gundam The Best]"
   region: "NTSC-J"
 SLPS-25492:
-  name: "SD Gundam G Generation - Gundam Seed [Gundam The Best]"
+  name: SDガンダム G GENERATION SEED GUNDAM THE BEST
+  name-sort: SDがんだむ G GENERATION SEED GUNDAM THE BEST
+  name-en: "SD Gundam G Generation - Gundam Seed [Gundam The Best]"
   region: "NTSC-J"
 SLPS-25493:
-  name: "Backyard Wrestling 2 - There Goes the Neighborhood"
+  name: バックヤードレスリング2
+  name-sort: ばっくやーどれすりんぐ2
+  name-en: "Backyard Wrestling 2 - There Goes the Neighborhood"
   region: "NTSC-J"
 SLPS-25494:
-  name: "Fragrance Tale"
+  name: Fragrance Tale 〜フレグランス テイル〜
+  name-sort: Fragrance Tale 〜ふれぐらんす ている〜
+  name-en: "Fragrance Tale"
   region: "NTSC-J"
 SLPS-25495:
-  name: "Metal Slug 5"
+  name: メタルスラッグ5
+  name-sort: めたるすらっぐ5
+  name-en: "Metal Slug 5"
   region: "NTSC-J"
   compat: 5
 SLPS-25496:
-  name: "Berwick Saga - Tear Ring Saga Series [Deluxe Pack]"
+  name: ティアリングサーガシリーズ ベルウィックサーガ DXパック
+  name-sort: てぃありんぐさーがしりーず べるうぃっくさーが DXぱっく
+  name-en: "Berwick Saga - Tear Ring Saga Series [Deluxe Pack]"
   region: "NTSC-J"
 SLPS-25497:
-  name: "Berwick Saga - Tear Ring Saga Series"
+  name: ティアリングサーガシリーズ ベルウィックサーガ(通常版)
+  name-sort: てぃありんぐさーがしりーず べるうぃっくさーが(つうじょうばん)
+  name-en: "Berwick Saga - Tear Ring Saga Series"
   region: "NTSC-J"
 SLPS-25498:
-  name: "Jikuu Bouken Zentrix"
+  name: 時空冒険記 ゼントリックス
+  name-sort: じくうぼうけんき ぜんとりっくす
+  name-en: "Jikuu Bouken Zentrix"
   region: "NTSC-J"
 SLPS-25499:
-  name: "Yu Yu Hakusho Forever"
+  name: 幽★遊★白書 FOREVER
+  name-sort: ゆう★ゆう★はくしょ FOREVER
+  name-en: "Yu Yu Hakusho Forever"
   region: "NTSC-J"
 SLPS-25500:
-  name: "namCollection - Namco 50th Anniversary"
+  name: namco 50th ANNIVERSARY ナムコレクション
+  name-sort: namco 50th ANNIVERSARY なむこれくしょん
+  name-en: "namCollection - Namco 50th Anniversary"
   region: "NTSC-J"
 SLPS-25501:
-  name: "Onmyou Taisenki - Hasha no In"
+  name: 陰陽大戦記 覇者の印
+  name-sort: いんようだいせんき はしゃのしるし
+  name-en: "Onmyou Taisenki - Hasha no In"
   region: "NTSC-J"
 SLPS-25502:
-  name: "Steamboy"
+  name: スチームボーイ
+  name-sort: すちーむぼーい
+  name-en: "Steamboy"
   region: "NTSC-J"
   compat: 5
 SLPS-25503:
-  name: "NeoGeo Online Collection Vol.2 - Bakumatsu Roman - Gekka no Kenshi 1&2"
+  name: NEOGEOオンラインコレクション 幕末浪漫 月華の剣士 1・2
+  name-sort: NEOGEOおんらいんこれくしょん ばくまつろまん げっかのけんし 1・2
+  name-en: "NeoGeo Online Collection Vol.2 - Bakumatsu Roman - Gekka no Kenshi 1&2"
   region: "NTSC-J"
   compat: 5
 SLPS-25504:
-  name: "Garou - Mark of the Wolves [Limited Edition]"
+  name: NEOGEOオンラインコレクション 餓狼 MARK OF THE WOLVES(限定版)
+  name-sort: NEOGEOおんらいんこれくしょん 餓狼 MARK OF THE WOLVES(げんていばん)
+  name-en: "Garou - Mark of the Wolves [Limited Edition]"
   region: "NTSC-J"
 SLPS-25505:
-  name: "Namco X Capcom"
+  name: NAMCO×CAPCOM(ナムコ クロス カプコン)
+  name-sort: NAMCO×CAPCOM(なむこ くろす かぷこん)
+  name-en: "Namco X Capcom"
   region: "NTSC-J"
   compat: 5
 SLPS-25506:
-  name: "For Symphony - With All One's Heart"
+  name: for Symphony 〜with all one’s heart〜
+  name-sort: for Symphony 〜with all one’s heart〜
+  name-en: "For Symphony - With All One's Heart"
   region: "NTSC-J"
 SLPS-25507:
-  name: "Mai-Hime [Limited Edition]"
+  name: 舞-HiME 運命の系統樹 DXパック
+  name-sort: まい-HiME うんめいのけいとうじゅ DXぱっく
+  name-en: "Mai-Hime [Limited Edition]"
   region: "NTSC-J"
 SLPS-25508:
-  name: "Mai-Hime - The Another"
+  name: 舞-HiME 運命の系統樹
+  name-sort: まい-HiME うんめいのけいとうじゅ
+  name-en: "Mai-Hime - The Another"
   region: "NTSC-J"
 SLPS-25509:
-  name: "Garou - Mark of the Wolves"
+  name: NEOGEOオンラインコレクション 餓狼 MARK OF THE WOLVES
+  name-sort: NEOGEOおんらいんこれくしょん 餓狼 MARK OF THE WOLVES
+  name-en: "Garou - Mark of the Wolves"
   region: "NTSC-J"
 SLPS-25510:
-  name: "Tekken 5"
+  name: 鉄拳5 (TEKKEN 5)
+  name-sort: てっけん5 (TEKKEN 5)
+  name-en: "Tekken 5"
   region: "NTSC-J"
   compat: 5
   clampModes:
@@ -44634,152 +51239,238 @@ SLPS-25510:
     alignSprite: 1 # Fixes vertical lines.
     getSkipCount: "GSC_Tekken5"
 SLPS-25511:
-  name: "Rasetsu Alternative"
+  name: 羅刹 -Alternative-
+  name-sort: らせつ -Alternative-
+  name-en: "Rasetsu Alternative"
   region: "NTSC-J"
 SLPS-25513:
-  name: "Aoi Umi no Tristia - Nanoca Flanka Hatsumei Koubouki [Shokai Genteiban]"
+  name: 蒼い海のトリスティア 〜ナノカ・フランカ発明工房記〜(初回限定版)
+  name-sort: あおいうみのとりすてぃあ 〜なのか・ふらんかはつめいこうぼうき〜(しょかいげんていばん)
+  name-en: "Aoi Umi no Tristia - Nanoca Flanka Hatsumei Koubouki [Shokai Genteiban]"
   region: "NTSC-J"
 SLPS-25514:
-  name: "Aoi Umi no Tristia - Nanoca Flanka Hatsumei Koubouki"
+  name: 蒼い海のトリスティア 〜ナノカ・フランカ発明工房記〜
+  name-sort: あおいうみのとりすてぃあ 〜なのか・ふらんかはつめいこうぼうき〜
+  name-en: "Aoi Umi no Tristia - Nanoca Flanka Hatsumei Koubouki"
   region: "NTSC-J"
 SLPS-25515:
-  name: "Futakoi Alternative [Limited Edition]"
+  name: フタコイ オルタナティブ 恋と少女とマシンガン 限定版
+  name-sort: ふたこい おるたなてぃぶ こいとしょうじょとましんがん げんていばん
+  name-en: "Futakoi Alternative [Limited Edition]"
   region: "NTSC-J"
 SLPS-25516:
-  name: "Futakoi Alternative"
+  name: フタコイ オルタナティブ 恋と少女とマシンガン
+  name-sort: ふたこい おるたなてぃぶ こいとしょうじょとましんがん
+  name-en: "Futakoi Alternative"
   region: "NTSC-J"
 SLPS-25517:
-  name: "Enjoy Golf!"
+  name: エンジョイゴルフ!
+  name-sort: えんじょいごるふ!
+  name-en: "Enjoy Golf!"
   region: "NTSC-J"
 SLPS-25518:
-  name: "InuYasha - Ougi Ranbu"
+  name: 犬夜叉 奥義乱舞
+  name-sort: いぬやしゃ おうぎらんぶ
+  name-en: "InuYasha - Ougi Ranbu"
   region: "NTSC-J"
 SLPS-25519:
-  name: "Sousei no Aquarion"
+  name: 創聖のアクエリオン
+  name-sort: そうせいのあくえりおん
+  name-en: "Sousei no Aquarion"
   region: "NTSC-J"
 SLPS-25520:
-  name: "Gundam True Odyssey"
+  name: ガンダム トゥルーオデッセイ 〜失われしGの伝説〜
+  name-sort: がんだむ とぅるーおでっせい 〜うしなわれしGのでんせつ〜
+  name-en: "Gundam True Odyssey"
   region: "NTSC-J"
 SLPS-25521:
-  name: "Soccer Life 2"
+  name: サッカーライフ2
+  name-sort: さっかーらいふ2
+  name-en: "Soccer Life 2"
   region: "NTSC-J"
 SLPS-25522:
-  name: "Yoshitsuneki [Gouka Kenran Box]"
+  name: 義経紀 限定版 豪華絢爛BOX
+  name-sort: よしつねき げんていばん ごうかけんらんBOX
+  name-en: "Yoshitsuneki [Gouka Kenran Box]"
   region: "NTSC-J"
 SLPS-25523:
-  name: "Yoshitsuneki"
+  name: 義経紀
+  name-sort: よしつねき
+  name-en: "Yoshitsuneki"
   region: "NTSC-J"
 SLPS-25525:
-  name: "King of Fighters, The - NeoWave"
+  name: THE KING OF FIGHTERS NEOWAVE
+  name-sort: THE KING OF FIGHTERS NEOWAVE
+  name-en: "King of Fighters, The - NeoWave"
   region: "NTSC-J"
   compat: 5
 SLPS-25526:
-  name: "Medical 91"
+  name: MEDICAL 91
+  name-sort: MEDICAL 91
+  name-en: "Medical 91"
   region: "NTSC-J"
 SLPS-25527:
-  name: "dot hack - Fragment"
+  name: .hack // fragment オンライン / オフライン
+  name-sort: .hack // fragment おんらいん / おふらいん
+  name-en: "dot hack - Fragment"
   region: "NTSC-J"
   compat: 5
 SLPS-25528:
-  name: "Summon Night EX Thesis - Yoake no Tsubasa"
+  name: サモンナイトエクステーゼ 〜夜明けの翼〜
+  name-sort: さもんないとえくすてーぜ 〜よあけのつばさ〜
+  name-en: "Summon Night EX Thesis - Yoake no Tsubasa"
   region: "NTSC-J"
 SLPS-25529:
-  name: "Ultraman Fighting Evolution - Rebirth"
+  name: ウルトラマン Fighting Evolution Rebirth
+  name-sort: うるとらまん Fighting Evolution Rebirth
+  name-en: "Ultraman Fighting Evolution - Rebirth"
   region: "NTSC-J"
   gsHWFixes:
     getSkipCount: "GSC_UltramanFightingEvolution"
 SLPS-25530:
-  name: "Garouden Break Blow"
+  name: 餓狼伝 Breakblow
+  name-sort: がろうでん Breakblow
+  name-en: "Garouden Break Blow"
   region: "NTSC-J"
 SLPS-25531:
-  name: "SD Gundam G Generation - Gundam Seed Edition"
+  name: SDガンダム GGENERATION SEED
+  name-sort: SDがんだむ GGENERATION SEED
+  name-en: "SD Gundam G Generation - Gundam Seed Edition"
   region: "NTSC-J"
 SLPS-25532:
-  name: "Critical Velocity"
+  name: クリティカル ベロシティ
+  name-sort: くりてぃかる べろしてぃ
+  name-en: "Critical Velocity"
   region: "NTSC-J"
 SLPS-25533:
-  name: "Tales of Legendia"
+  name: テイルズ オブ レジェンディア (Tales of Leg endia)
+  name-sort: ているず おぶ れじぇんでぃあ (Tales of Leg endia)
+  name-en: "Tales of Legendia"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
     getSkipCount: "GSC_TalesOfLegendia"
 SLPS-25534:
-  name: "Twinkle Star Sprites - La Petite Princesse"
+  name: ティンクルスタースプライツ 〜La Petite Princesse〜
+  name-sort: てぃんくるすたーすぷらいつ 〜La Petite Princesse〜
+  name-en: "Twinkle Star Sprites - La Petite Princesse"
   region: "NTSC-J"
   compat: 5
 SLPS-25535:
-  name: "NeoGeo Online Collection Vol.3 - The King of Fighters - Orochi Collection [Special Pack]"
+  name: NEOGEOオンラインコレクション THE KING OF FIGHTERS -オロチ編- NEOGEO STICK3同梱(限定版)
+  name-sort: NEOGEOおんらいんこれくしょん THE KING OF FIGHTERS -おろちへん- NEOGEO STICK3どうこん(げんていばん)
+  name-en: "NeoGeo Online Collection Vol.3 - The King of Fighters - Orochi Collection [Special Pack]"
   region: "NTSC-J"
 SLPS-25537:
-  name: "Super Robot Wars - Alpha 3"
+  name: 第3次スーパーロボット大戦α 〜終焉の銀河へ〜
+  name-sort: だい3じすーぱーろぼっとたいせんあるふぁ 〜しゅうえんのぎんがへ〜
+  name-en: "Super Robot Wars - Alpha 3"
   region: "NTSC-J"
   compat: 5
 SLPS-25538:
-  name: "Super Robot Wars - Alpha [Premium Pack]"
+  name: スーパーロボット大戦α PREMIUM EDITION
+  name-sort: すーぱーろぼっとたいせんあるふぁ PREMIUM EDITION
+  name-en: "Super Robot Wars - Alpha [Premium Pack]"
   region: "NTSC-J"
 SLPS-25539:
-  name: "School Rumble [Limited Edition]"
+  name: スクールランブル ねる娘は育つ。 DXパック
+  name-sort: すくーるらんぶる ねるむすめはそだつ。 DXぱっく
+  name-en: "School Rumble [Limited Edition]"
   region: "NTSC-J"
 SLPS-25540:
-  name: "School Rumble"
+  name: スクールランブル ねる娘は育つ。
+  name-sort: すくーるらんぶる ねるむすめはそだつ。
+  name-en: "School Rumble"
   region: "NTSC-J"
 SLPS-25541:
-  name: "New Century GPX Cyber Formula - Road to the Infinity 2"
+  name: 新世紀GPXサイバーフォーミュラ ROAD TO THE INFINITY 2
+  name-sort: しんせいきGPXさいばーふぉーみゅら ROAD TO THE INFINITY 2
+  name-en: "New Century GPX Cyber Formula - Road to the Infinity 2"
   region: "NTSC-J"
 SLPS-25542:
-  name: "Naruto Uzumaki Ninden"
+  name: NARUTO-ナルト- うずまき忍伝
+  name-sort: NARUTO-なると- うずまきにんでん
+  name-en: "Naruto Uzumaki Ninden"
   region: "NTSC-J"
   compat: 5
   gameFixes:
     - OPHFlagHack
 SLPS-25543:
-  name: "Futakoi - Koi to Mizugi no Survival"
+  name: 双恋島 恋と水着のサバイバル!
+  name-sort: ふたこいじま こいとみずぎのさばいばる!
+  name-en: "Futakoi - Koi to Mizugi no Survival"
   region: "NTSC-J"
 SLPS-25544:
-  name: "Fatal Frame - Zero"
+  name: 零 〜刺青の聲〜
+  name-sort: ぜろ 〜しせいのこえ〜
+  name-en: "Fatal Frame - Zero"
   region: "NTSC-J"
   compat: 5
 SLPS-25545:
-  name: "Fighting for One Piece"
+  name: Fighting For ONE PIECE ファイティング フォー ワンピース
+  name-sort: Fighting For ONE PIECE ふぁいてぃんぐ ふぉー わんぴーす
+  name-en: "Fighting for One Piece"
   region: "NTSC-J"
   compat: 5
 SLPS-25546:
-  name: "Ichigo Mashimaro [Limited Edition]"
+  name: 苺ましまろ 初回限定版
+  name-sort: いちごましまろ しょかいげんていばん
+  name-en: "Ichigo Mashimaro [Limited Edition]"
   region: "NTSC-J"
 SLPS-25547:
-  name: "Ichigo Mashimaro"
+  name: 苺ましまろ
+  name-sort: いちごましまろ
+  name-en: "Ichigo Mashimaro"
   region: "NTSC-J"
 SLPS-25548:
-  name: "Pachitte Ultra Seven Chonmage Tatsujin 8"
+  name: ぱちんこウルトラセブン パチってちょんまげ達人8
+  name-sort: ぱちんこうるとらせぶん ぱちってちょんまげたつじん8
+  name-en: "Pachitte Ultra Seven Chonmage Tatsujin 8"
   region: "NTSC-J"
 SLPS-25549:
-  name: "Gundam Seed Destiny - Generation of C.E."
+  name: 機動戦士ガンダムSEED DESTINY 〜GENERATION of C.E.〜
+  name-sort: きどうせんしがんだむSEED DESTINY 〜GENERATION of C.E.〜
+  name-en: "Gundam Seed Destiny - Generation of C.E."
   region: "NTSC-J"
 SLPS-25550:
-  name: "Cowboy Bebop - Tsuioku no Serenade [Limited Edition]"
+  name: カウボーイビバップ 追憶の夜曲 (初回生産限定版)
+  name-sort: かうぼーいびばっぷ ついおくのせれなーで (しょかいせいさんげんていばん)
+  name-en: "Cowboy Bebop - Tsuioku no Serenade [Limited Edition]"
   region: "NTSC-J"
   clampModes:
     eeClampMode: 0 # Fixes HUD going black.
 SLPS-25551:
-  name: "Cowboy Bebop - Tsuioku no Serenade"
+  name: カウボーイビバップ 追憶の夜曲
+  name-sort: かうぼーいびばっぷ ついおくのせれなーで
+  name-en: "Cowboy Bebop - Tsuioku no Serenade"
   region: "NTSC-J"
   clampModes:
     eeClampMode: 0 # Fixes HUD going black.
   compat: 5
 SLPS-25552:
-  name: "Inuyasha - Juuso no Kamen [Bandai the Best]"
+  name: 犬夜叉〜呪詛の仮面〜 BANDAI THE BEST
+  name-sort: いぬやしゃ〜じゅそのかめん〜 BANDAI THE BEST
+  name-en: "Inuyasha - Juuso no Kamen [Bandai the Best]"
   region: "NTSC-J"
 SLPS-25553:
-  name: "Yoshitsune Eiyuuden Shura -The Story of Hero Yoshitsune Shura"
+  name: 義経英雄伝 修羅
+  name-sort: よしつねえいゆうでん しゅら
+  name-en: "Yoshitsune Eiyuuden Shura -The Story of Hero Yoshitsune Shura"
   region: "NTSC-J"
 SLPS-25554:
-  name: "Eureka Seven TR1 - New Wave"
+  name: エウレカセブン TR1:NEW WAVE
+  name-sort: えうれかせぶん TR1:NEW WAVE
+  name-en: "Eureka Seven TR1 - New Wave"
   region: "NTSC-J"
 SLPS-25556:
-  name: "Hissatsu Pachinko Station V11"
+  name: 必殺パチンコステーションV11 CRギャートルズ
+  name-sort: ひっさつぱちんこすてーしょんV11 CRぎゃーとるず
+  name-en: "Hissatsu Pachinko Station V11"
   region: "NTSC-J"
 SLPS-25557:
-  name: "Urban Reign"
+  name: アーバンレイン
+  name-sort: あーばんれいん
+  name-en: "Urban Reign"
   region: "NTSC-J"
   gameFixes:
     - EETimingHack # Mitigates bounciness of vertical shaking but better fix with EE cyclerate +1.
@@ -44788,72 +51479,108 @@ SLPS-25557:
     textureInsideRT: 1 # Fixes corruption.
     getSkipCount: "GSC_UrbanReign"
 SLPS-25558:
-  name: "NeoGeo Battle Coliseum"
+  name: ネオジオ バトルコロシアム
+  name-sort: ねおじお ばとるころしあむ
+  name-en: "NeoGeo Battle Coliseum"
   region: "NTSC-J"
   compat: 5
 SLPS-25559:
-  name: "Samurai Spirits - Tenkaichi Kenkakuden"
+  name: サムライスピリッツ 天下一剣客伝
+  name-sort: さむらいすぴりっつ てんかいちけんかくでん
+  name-en: "Samurai Spirits - Tenkaichi Kenkakuden"
   region: "NTSC-J"
   compat: 5
 SLPS-25560:
-  name: "Dragon Ball Z - Sparking!"
+  name: ドラゴンボールZ Sparking!
+  name-sort: どらごんぼーるZ Sparking!
+  name-en: "Dragon Ball Z - Sparking!"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes lines when powering up.
     roundSprite: 2 # Fixes misaligned bloom.
 SLPS-25561:
-  name: "MotoGP 4"
+  name: MotoGP4
+  name-sort: MotoGP4
+  name-en: "MotoGP 4"
   region: "NTSC-J"
 SLPS-25564:
-  name: "Gallop Racer 8 - Live Horse Racing"
+  name: ギャロップレーサー8 ライヴホースレーシング
+  name-sort: ぎゃろっぷれーさー8 らいゔほーすれーしんぐ
+  name-en: "Gallop Racer 8 - Live Horse Racing"
   region: "NTSC-J"
 SLPS-25565:
-  name: "Hisshou Pachinko Kouryoku Series Vol.1 - CR Shinseiki Evangelion"
+  name: 必勝パチンコ攻略シリーズ Vol.1 CR新世紀エヴァンゲリオン
+  name-sort: ひっしょうぱちんここうりゃくしりーず Vol.1 CRしんせいきえゔぁんげりおん
+  name-en: "Hisshou Pachinko Kouryoku Series Vol.1 - CR Shinseiki Evangelion"
   region: "NTSC-J"
 SLPS-25566:
-  name: "Simple 2000 Series Ultimate Vol. 27 - Houkago no Love Beat"
+  name: SIMPLE 2000シリーズ Ultimate Vol.27 放課後のラブ★ビート♪
+  name-sort: SIMPLE 2000しりーず Ultimate Vol.27 ほうかごのらぶ★びーと♪
+  name-en: "Simple 2000 Series Ultimate Vol. 27 - Houkago no Love Beat"
   region: "NTSC-J"
 SLPS-25567:
-  name: "Pachitte Chonmage Tatsujin 9"
+  name: ぱちんこ水戸黄門 パチってちょんまげ達人9
+  name-sort: ぱちんこみとこうもん ぱちってちょんまげたつじん9
+  name-en: "Pachitte Chonmage Tatsujin 9"
   region: "NTSC-J"
 SLPS-25568:
-  name: "Keroro Gunsou - Mero Mero Battle Royale [Bandai The Best]"
+  name: ケロロ軍曹 メロメロバトルロイヤル BANDAI THE BEST
+  name-sort: けろろぐんそう めろめろばとるろいやる BANDAI THE BEST
+  name-en: "Keroro Gunsou - Mero Mero Battle Royale [Bandai The Best]"
   region: "NTSC-J"
   gsHWFixes:
     preloadFrameData: 1 # Fixes invisible text.
 SLPS-25569:
-  name: "Kidou Senshi Gundam SEED - Rengou vs. Z.A.F.T."
+  name: 機動戦士ガンダムSEED 連合vs.Z.A.F.T
+  name-sort: きどうせんしがんだむSEED れんごうvs.Z.A.F.T
+  name-en: "Kidou Senshi Gundam SEED - Rengou vs. Z.A.F.T."
   region: "NTSC-J"
   roundModes:
     eeRoundMode: 1 # Fixes camera issue.
   gameFixes:
     - FpuNegDivHack # Fixes target loss issue.
 SLPS-25570:
-  name: "Kino no Tabi 2 - The Beautiful World"
+  name: キノの旅II
+  name-sort: きののたびII
+  name-en: "Kino no Tabi 2 - The Beautiful World"
   region: "NTSC-J"
 SLPS-25571:
-  name: "Metal Slug 4 [SNK Best Collection]"
+  name: SNK Best Collection メタルスラッグ4
+  name-sort: SNK Best Collection めたるすらっぐ4
+  name-en: "Metal Slug 4 [SNK Best Collection]"
   region: "NTSC-J"
 SLPS-25572:
-  name: "Samurai Spirits Zero [SNK Best Collection]"
+  name: SNK Best Collection サムライスピリッツ零
+  name-sort: SNK Best Collection さむらいすぴりっつぜろ
+  name-en: "Samurai Spirits Zero [SNK Best Collection]"
   region: "NTSC-J"
 SLPS-25573:
-  name: "King of Fighters 2002, The [SNK Best Collection]"
+  name: SNK Best Collection ザ・キング・オブ・ファイターズ 2002
+  name-sort: SNK Best Collection ざ・きんぐ・おぶ・ふぁいたーず 2002
+  name-en: "King of Fighters 2002, The [SNK Best Collection]"
   region: "NTSC-J"
 SLPS-25574:
-  name: "Sanyo Pachinko Paradise 12"
+  name: パチパラ12 〜大海と夏の思い出〜
+  name-sort: ぱちぱら12 〜たいかいとなつのおもいで〜
+  name-en: "Sanyo Pachinko Paradise 12"
   region: "NTSC-J"
 SLPS-25575:
-  name: "Keroro Gunsou - Mero Mero Battle Royale Z"
+  name: ケロロ軍曹 メロメロバトルロイヤルZ
+  name-sort: けろろぐんそう めろめろばとるろいやるZ
+  name-en: "Keroro Gunsou - Mero Mero Battle Royale Z"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
     preloadFrameData: 1 # Fixes invisible text.
 SLPS-25576:
-  name: "One Piece - Pirates Carnival"
+  name: ワンピース パイレーツカーニバル
+  name-sort: わんぴーす ぱいれーつかーにばる
+  name-en: "One Piece - Pirates Carnival"
   region: "NTSC-J"
 SLPS-25577:
-  name: "Soul Calibur III"
+  name: ソウルキャリバーIII
+  name-sort: そうるきゃりばーIII
+  name-en: "Soul Calibur III"
   region: "NTSC-J"
   compat: 5
   gameFixes:
@@ -44865,7 +51592,9 @@ SLPS-25577:
     halfPixelOffset: 3 # Fixes blurriness (normal vertex causes vertical lines).
     recommendedBlendingLevel: 3 # Fixes menu transparency.
 SLPS-25578:
-  name: "K-1 World Grand Prix 2005"
+  name: K-1 WORLD GP 2005
+  name-sort: K-1 WORLD GP 2005
+  name-en: "K-1 World Grand Prix 2005"
   region: "NTSC-J"
   gameFixes:
     - XGKickHack # Fixes black and white fighters.
@@ -44877,54 +51606,80 @@ SLPS-25578:
         patch=1,EE,004269f0,word,0000948c
         patch=1,EE,00426a18,word,0000948c
 SLPS-25579:
-  name: "Little Aid"
+  name: Little Aid
+  name-sort: Little Aid
+  name-en: "Little Aid"
   region: "NTSC-J"
 SLPS-25580:
-  name: "Chicken Little"
+  name: チキン・リトル
+  name-sort: ちきん・りとる
+  name-en: "Chicken Little"
   region: "NTSC-J"
 SLPS-25581:
-  name: "Simple 2000 Series Vol. 92 - The Game of a Curse"
+  name: SIMPLE 2000シリーズ Vol.92 THE 呪いのゲーム
+  name-sort: SIMPLE 2000しりーず Vol.92 THE のろいのげーむ
+  name-en: "Simple 2000 Series Vol. 92 - The Game of a Curse"
   region: "NTSC-J"
 SLPS-25582:
-  name: "Asutoro Kyudan Kessen"
+  name: アストロ球団 決戦!!ビクトリー球団編
+  name-sort: あすとろきゅうだん けっせん!!びくとりーきゅうだんへん
+  name-en: "Asutoro Kyudan Kessen"
   region: "NTSC-J"
 SLPS-25583:
   name: "One Piece - Pirates Carnival"
   region: "NTSC-J"
 SLPS-25584:
-  name: "From TV Animation - One Piece - Pirates Carnival [with Multitap for new models]"
+  name: ワンピース パイレーツカーニバル “PlayStation 2”(SCPH-70000シリーズ)専用マルチタップ同梱版
+  name-sort: わんぴーす ぱいれーつかーにばる “PlayStation 2”(SCPH-70000しりーず)せんようまるちたっぷどうこんばん
+  name-en: "From TV Animation - One Piece - Pirates Carnival [with Multitap for new models]"
   region: "NTSC-J"
 SLPS-25585:
-  name: "Monster Farm 5 - Circus Caravan"
+  name: モンスターファーム5 サーカスキャラバン
+  name-sort: もんすたーふぁーむ5 さーかすきゃらばん
+  name-en: "Monster Farm 5 - Circus Caravan"
   region: "NTSC-J"
 SLPS-25586:
-  name: "Tales of the Abyss"
+  name: テイルズ オブ ジ アビス
+  name-sort: ているず おぶ じ あびす
+  name-en: "Tales of the Abyss"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
     autoFlush: 2 # Fixes post lighting.
 SLPS-25587:
-  name: "Sugar Sugar Rune - Koi mo Oshare mo Pick-Up"
+  name: シュガシュガルーン 恋もおしゃれもピックアップ!
+  name-sort: しゅがしゅがるーん こいもおしゃれもぴっくあっぷ!
+  name-en: "Sugar Sugar Rune - Koi mo Oshare mo Pick-Up"
   region: "NTSC-J"
 SLPS-25588:
-  name: "Meitantei Conan - Daiei Teikoku no Isan [Bandai The Best]"
+  name: 名探偵コナン 大英帝国の遺産 BANDAI THE BEST
+  name-sort: めいたんていこなん だいえいていこくのいさん BANDAI THE BEST
+  name-en: "Meitantei Conan - Daiei Teikoku no Isan [Bandai The Best]"
   region: "NTSC-J"
 SLPS-25589:
-  name: "Naruto Narutimett Hero 3"
+  name: NARUTO-ナルト-ナルティメットヒーロー3
+  name-sort: NARUTO-なると-なるてぃめっとひーろー3
+  name-en: "Naruto Narutimett Hero 3"
   region: "NTSC-J"
   clampModes:
     vuClampMode: 2 # Fixes invisible QTE button prompts and overbright in some scenes.
   gameFixes:
     - SoftwareRendererFMVHack # Fixes vertical lines in FMVs.
 SLPS-25590:
-  name: "Namco Museum Arcade Hits"
+  name: ナムコミュージアム アーケードHITS!
+  name-sort: なむこみゅーじあむ あーけーどHITS!
+  name-en: "Namco Museum Arcade Hits"
   region: "NTSC-J"
 SLPS-25591:
-  name: "Last Escort - Shinya no Kokuchou Monogatari"
+  name: ラスト・エスコート〜深夜の黒蝶物語〜
+  name-sort: らすと・えすこーと〜しんやのくろちょうものがたり〜
+  name-en: "Last Escort - Shinya no Kokuchou Monogatari"
   region: "NTSC-J"
 SLPS-25592:
-  name: "Sunrise Eiyuutan 3"
+  name: サンライズ英雄譚3
+  name-sort: さんらいずえいゆうたん3
+  name-en: "Sunrise Eiyuutan 3"
   region: "NTSC-J"
 SLPS-25593:
   name: "Hoshigari Empusa"
@@ -44936,115 +51691,181 @@ SLPS-25595:
   name: "Konjiki no Gashbell!! Go! Go! Mamono Fight!!"
   region: "NTSC-J"
 SLPS-25596:
-  name: "Konjiki no Gashbell! - Go!Go! Mamono Fight"
+  name: 金色のガッシュベル!!ゴー!ゴー!魔物ファイト!! ソフト単品
+  name-sort: きんいろのがっしゅべる!!ごー!ごー!まものふぁいと!! そふとたんぴん
+  name-en: "Konjiki no Gashbell! - Go!Go! Mamono Fight"
   region: "NTSC-J"
 SLPS-25597:
-  name: "Kawa no Nushi Tsuri - Wonderful Journey [Best Collection]"
+  name: 川のぬし釣り ワンダフルジャーニー Best Collection
+  name-sort: かわのぬしつり わんだふるじゃーにー Best Collection
+  name-en: "Kawa no Nushi Tsuri - Wonderful Journey [Best Collection]"
   region: "NTSC-J"
 SLPS-25598:
-  name: "Gakkou o Tsukurou - Happy Days!! [Best Collection]"
+  name: 学校をつくろう!!Happy Days Best Collection
+  name-sort: がっこうをつくろう!!Happy Days Best Collection
+  name-en: "Gakkou o Tsukurou - Happy Days!! [Best Collection]"
   region: "NTSC-J"
 SLPS-25599:
-  name: "Shakugan no Shana"
+  name: 灼眼のシャナ
+  name-sort: 灼眼のしゃな
+  name-en: "Shakugan no Shana"
   region: "NTSC-J"
 SLPS-25600:
-  name: "Samurai Champloo - Sidetracked"
+  name: サムライチャンプルー
+  name-sort: さむらいちゃんぷるー
+  name-en: "Samurai Champloo - Sidetracked"
   region: "NTSC-J"
 SLPS-25601:
-  name: "Ueki no Housoku - Taosu Ze Roberuto Juudan!!"
+  name: うえきの法則 倒すぜロベルト十団!!
+  name-sort: うえきのほうそく たおすぜろべるとじゅうだん!!
+  name-en: "Ueki no Housoku - Taosu Ze Roberuto Juudan!!"
   region: "NTSC-J"
 SLPS-25602:
-  name: "Hisshou Pachinko-Pachislot Kouryaku Series Vol.2 - Bomber Powerful & Yume Yume World DX"
+  name: 必勝パチンコ★パチスロ攻略シリーズ Vol.2 ボンバーパワフル&夢夢ワールドDX
+  name-sort: ひっしょうぱちんこ★ぱちすろこうりゃくしりーず Vol.2 ぼんばーぱわふる&ゆめゆめわーるどDX
+  name-en: "Hisshou Pachinko-Pachislot Kouryaku Series Vol.2 - Bomber Powerful & Yume Yume World DX"
   region: "NTSC-J"
 SLPS-25603:
-  name: "Tensei - Swords of Destiny [Best Collection]"
+  name: 天星 SWORDS OF DESTINY Best Collection
+  name-sort: てんせい SWORDS OF DESTINY Best Collection
+  name-en: "Tensei - Swords of Destiny [Best Collection]"
   region: "NTSC-J"
 SLPS-25604:
-  name: "Ar tonelico - Sekai no Owari de Utai Tsuzukeru Shoujo"
+  name: アルトネリコ 世界の終わりで詩い続ける少女
+  name-sort: あるとねりこ せかいのおわりでしいつづけるしょうじょ
+  name-en: "Ar tonelico - Sekai no Owari de Utai Tsuzukeru Shoujo"
   region: "NTSC-J"
   gsHWFixes:
     roundSprite: 1 # Fixes vertical lines in FMVs, character portraits and other sprites.
 SLPS-25605:
-  name: "NeoGeo Online Collection Vol.3 - The King of Fighters - Orochi Collection"
+  name: NEOGEOオンラインコレクション THE KING OF FIGHTERS -オロチ編-通常版
+  name-sort: NEOGEOおんらいんこれくしょん THE KING OF FIGHTERS -おろちへん-つうじょうばん
+  name-en: "NeoGeo Online Collection Vol.3 - The King of Fighters - Orochi Collection"
   region: "NTSC-J"
 SLPS-25606:
-  name: "Zettai Zetsumei Toshi 2 - Itetsuita Kioutachi"
+  name: 絶体絶命都市2 -凍てついた記憶たち-
+  name-sort: ぜったいぜつめいとし2 -いてついたきおくたち-
+  name-en: "Zettai Zetsumei Toshi 2 - Itetsuita Kioutachi"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
     getSkipCount: "GSC_ZettaiZetsumeiToshi2"
 SLPS-25607:
-  name: "Makai Senki Disgaea 2 [Limited Edition]"
+  name: 魔界戦記ディスガイア2 初回限定版
+  name-sort: まかいせんきでぃすがいあ2 しょかいげんていばん
+  name-en: "Makai Senki Disgaea 2 [Limited Edition]"
   region: "NTSC-J"
 SLPS-25608:
-  name: "Makai Senki Disgaea 2"
+  name: 魔界戦記ディスガイア2
+  name-sort: まかいせんきでぃすがいあ2
+  name-en: "Makai Senki Disgaea 2"
   region: "NTSC-J"
   compat: 5
 SLPS-25609:
-  name: "King of Fighters, The - Maximum Impact 2"
+  name: KOF MAXIMUM IMPACT 2(初回生産版)
+  name-sort: KOF MAXIMUM IMPACT 2(しょかいせいさんばん)
+  name-en: "King of Fighters, The - Maximum Impact 2"
   region: "NTSC-J"
 SLPS-25610:
-  name: "Ryuuko no Ken - Ten-Chi-Jin [Art of Fighting Collection]"
+  name: NEOGEOオンラインコレクション 龍虎の拳〜天・地・人〜
+  name-sort: NEOGEOおんらいんこれくしょん りゅうこのけん〜てん・ち・じん〜
+  name-en: "Ryuuko no Ken - Ten-Chi-Jin [Art of Fighting Collection]"
   region: "NTSC-J"
 SLPS-25611:
-  name: "Strawberry Panic [Limited Edition]"
+  name: Strawberry Panic!ストロベリー・パニック!(初回限定版)
+  name-sort: Strawberry Panic!すとろべりー・ぱにっく!(しょかいげんていばん)
+  name-en: "Strawberry Panic [Limited Edition]"
   region: "NTSC-J"
 SLPS-25612:
-  name: "Strawberry Panic"
+  name: Strawberry Panic!ストロベリー・パニック!(通常版)
+  name-sort: Strawberry Panic!すとろべりー・ぱにっく!(つうじょうばん)
+  name-en: "Strawberry Panic"
   region: "NTSC-J"
 SLPS-25613:
-  name: "My Home o Tsukurou 2! Takumi [Best Collection]"
+  name: マイホームをつくろう2! 匠 Best Collection
+  name-sort: まいほーむをつくろう2! たくみ Best Collection
+  name-en: "My Home o Tsukurou 2! Takumi [Best Collection]"
   region: "NTSC-J"
 SLPS-25614:
-  name: "Mai-Hime - Unmei no Keitouju [Best Collection]"
+  name: 舞-HiME 運命の系統樹 Best Collection
+  name-sort: まい-HiME うんめいのけいとうじゅ Best Collection
+  name-en: "Mai-Hime - Unmei no Keitouju [Best Collection]"
   region: "NTSC-J"
 SLPS-25615:
-  name: "My Home wo Tsukurou 2! Kantan Sekkei!!"
+  name: マイホームをつくろう2 充実!簡単設計!!
+  name-sort: まいほーむをつくろう2 じゅうじつ!かんたんせっけい!!
+  name-en: "My Home wo Tsukurou 2! Kantan Sekkei!!"
   region: "NTSC-J"
 SLPS-25616:
-  name: "Ski Jumping Pairs Reloaded"
+  name: スキージャンプ・ペア Reloaded
+  name-sort: すきーじゃんぷ・ぺあ Reloaded
+  name-en: "Ski Jumping Pairs Reloaded"
   region: "NTSC-J"
 SLPS-25617:
-  name: "Etude Prologue - Yureugoku Kokoro no Katachi"
+  name: e’tude prologue 〜揺れ動く心のかたち〜
+  name-sort: e’tude prologue 〜ゆれうごくこころのかたち〜
+  name-en: "Etude Prologue - Yureugoku Kokoro no Katachi"
   region: "NTSC-J"
 SLPS-25618:
-  name: "D-A - Black [Best Price]"
+  name: ベストプライス D→A:BLACK
+  name-sort: べすとぷらいす D→A:BLACK
+  name-en: "D-A - Black [Best Price]"
   region: "NTSC-J"
 SLPS-25619:
-  name: "D-A - White [Best Price]"
+  name: ベストプライス D→A:WHITE
+  name-sort: べすとぷらいす D→A:WHITE
+  name-en: "D-A - White [Best Price]"
   region: "NTSC-J"
 SLPS-25620:
-  name: "Hisshou Pachinko-Pachislot Kouryaku Series Vol.3 - CR Marilyn Monroe"
+  name: 必勝パチンコ★パチスロ攻略シリーズ Vol.3 CRマリリン・モンロー
+  name-sort: ひっしょうぱちんこ★ぱちすろこうりゃくしりーず Vol.3 CRまりりん・もんろー
+  name-en: "Hisshou Pachinko-Pachislot Kouryaku Series Vol.3 - CR Marilyn Monroe"
   region: "NTSC-J"
 SLPS-25621:
-  name: "Kashimashi! Girl Meets Girl [Limited Edition]"
+  name: かしまし 〜ガールミーツガール〜「初めての夏物語。」限定版
+  name-sort: かしまし 〜がーるみーつがーる〜「はじめてのなつものご。」げんていばん
+  name-en: "Kashimashi! Girl Meets Girl [Limited Edition]"
   region: "NTSC-J"
 SLPS-25622:
-  name: "Kashimashi! Girl Meets Girl"
+  name: かしまし 〜ガールミーツガール〜「初めての夏物語。」通常版
+  name-sort: かしまし 〜がーるみーつがーる〜「はじめてのなつものご。」つうじょうばん
+  name-en: "Kashimashi! Girl Meets Girl"
   region: "NTSC-J"
 SLPS-25623:
-  name: "Another Century's Episode 2"
+  name: Another Century’s Episode 2
+  name-sort: Another Century’s Episode 2
+  name-en: "Another Century's Episode 2"
   region: "NTSC-J"
   compat: 5
 SLPS-25624:
-  name: "Futakoi-Futakoi Island Collection"
+  name: 電撃SP 双恋 / 双恋島 双恋COLLECTION
+  name-sort: でんげきSP ふたこい / ふたこいじま ふたこいCOLLECTION
+  name-en: "Futakoi-Futakoi Island Collection"
   region: "NTSC-J"
 SLPS-25625:
   name: "Futakoi-jima - Koi to Mizugi no Survival"
   region: "NTSC-J"
 SLPS-25626:
-  name: "Chronicles of Narnia, The - The Lion, The Witch and The Wardrobe"
+  name: ナルニア国物語 〜第1章 ライオンと魔女〜
+  name-sort: なるにあこくものがたり 〜だい1しょう らいおんとまじょ〜
+  name-en: "Chronicles of Narnia, The - The Lion, The Witch and The Wardrobe"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes lighting misalignment.
 SLPS-25627:
-  name: "Mobile Suit Gundam Climax U.C."
+  name: 機動戦士ガンダム クライマックスU.C.
+  name-sort: きどうせんしがんだむ くらいまっくすU.C.
+  name-en: "Mobile Suit Gundam Climax U.C."
   region: "NTSC-J"
 SLPS-25628:
-  name: "IGPX"
+  name: IGPX
+  name-sort: IGPX
+  name-en: "IGPX"
   region: "NTSC-J"
 SLPS-25629:
-  name: "Ace Combat Zero - The Belkan War"
+  name: エースコンバット・ゼロ ザ・ベルカン・ウォー
+  name-sort: えーすこんばっと・ぜろ ざ・べるかん・うぉー
+  name-en: "Ace Combat Zero - The Belkan War"
   region: "NTSC-J"
   gameFixes:
     - SoftwareRendererFMVHack # Fixes FMVs disabling hash cache.
@@ -45075,34 +51896,54 @@ SLPS-25629:
         patch=0,EE,00131e94,word,484A8800
         patch=0,EE,00131e98,word,4B0C682C
 SLPS-25630:
-  name: "Pro Yakyuu Netsu Star 2006"
+  name: プロ野球 熱スタ2006
+  name-sort: ぷろやきゅう ねつすた2006
+  name-en: "Pro Yakyuu Netsu Star 2006"
   region: "NTSC-J"
 SLPS-25631:
-  name: "Simple 2000 Series Vol. 98 - Roman Sabou"
+  name: SIMPLE 2000シリーズ Vol.98 THE 浪漫茶房
+  name-sort: SIMPLE 2000しりーず Vol.98 THE ろまんさぼう
+  name-en: "Simple 2000 Series Vol. 98 - Roman Sabou"
   region: "NTSC-J"
 SLPS-25632:
-  name: "Simple 2000 Series Vol. 97 - The Koi no Engine"
+  name: SIMPLE 2000シリーズ Vol.97 THE 恋のエンジン
+  name-sort: SIMPLE 2000しりーず Vol.97 THE こいのえんじん
+  name-en: "Simple 2000 Series Vol. 97 - The Koi no Engine"
   region: "NTSC-J"
 SLPS-25633:
-  name: "Futakoi Alternative - Koi to Shoujo to Machinegun [Best Collection]"
+  name: フタコイオルタナティブ 恋と少女とマシンガン Best Collection
+  name-sort: ふたこいおるたなてぃぶ こいとしょうじょとましんがん Best Collection
+  name-en: "Futakoi Alternative - Koi to Shoujo to Machinegun [Best Collection]"
   region: "NTSC-J"
 SLPS-25634:
-  name: "Metal Slug 5 [SNK Best Collection]"
+  name: SNK BEST COLLECTION メタルスラッグ5
+  name-sort: SNK BEST COLLECTION めたるすらっぐ5
+  name-en: "Metal Slug 5 [SNK Best Collection]"
   region: "NTSC-J"
 SLPS-25635:
-  name: "King of Fighters 2003, The [SNK Best Collection]"
+  name: SNK BEST COLLECTION THE KING OF FIGHTERS 2003
+  name-sort: SNK BEST COLLECTION THE KING OF FIGHTERS 2003
+  name-en: "King of Fighters 2003, The [SNK Best Collection]"
   region: "NTSC-J"
 SLPS-25636:
-  name: "King of Fighters, The - Maximum Impact - Maniax"
+  name: KOF マキシマムインパクト マニアックス
+  name-sort: KOF まきしまむいんぱくと まにあっくす
+  name-en: "King of Fighters, The - Maximum Impact - Maniax"
   region: "NTSC-J"
 SLPS-25638:
-  name: "King of Fighters, The - Maximum Impact 2"
+  name: KOF MAXIMUM IMPACT 2(通常版)
+  name-sort: KOF MAXIMUM IMPACT 2(つうじょうばん)
+  name-en: "King of Fighters, The - Maximum Impact 2"
   region: "NTSC-J"
 SLPS-25639:
-  name: "Plus Plum 2 Again"
+  name: ぷらすぷらむ2
+  name-sort: ぷらすぷらむ2
+  name-en: "Plus Plum 2 Again"
   region: "NTSC-J"
 SLPS-25640:
-  name: "Xenosaga Episode III - Also Sprach Zarathustra [Disc 1 of 2]"
+  name: ゼノサーガ エピソードIII [ツァラトゥストラはかく語りき]
+  name-sort: ぜのさーが えぴそーどIII [つぁらとぅすとらはかくかたりき]
+  name-en: "Xenosaga Episode III - Also Sprach Zarathustra [Disc 1 of 2]"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
@@ -45126,42 +51967,62 @@ SLPS-25641:
     - "SLPS-25640"
     - "SLPS-25368"
 SLPS-25642:
-  name: "Super Dragon Ball Z"
+  name: 超ドラゴンボールZ
+  name-sort: ちょうどらごんぼーるZ
+  name-en: "Super Dragon Ball Z"
   region: "NTSC-J"
   compat: 5
 SLPS-25643:
-  name: "Kimikisu"
+  name: キミキス
+  name-sort: きみきす
+  name-en: "Kimikisu"
   region: "NTSC-J"
   gsHWFixes:
     roundSprite: 1 # Fixes textboxes and character portraits.
 SLPS-25644:
-  name: "Simple 2000 Series Ultimate Vol. 31 - K-1 World Max 2005"
+  name: SIMPLE 2000シリーズ Ultimate Vol.31 K-1 WORLD MAX 2005 〜世界王者への道〜
+  name-sort: SIMPLE 2000しりーず Ultimate Vol.31 K-1 WORLD MAX 2005 〜せかいおうじゃへのみち〜
+  name-en: "Simple 2000 Series Ultimate Vol. 31 - K-1 World Max 2005"
   region: "NTSC-J"
 SLPS-25645:
-  name: "Hisshou Pachinko-Pachislot Kouryaku Series Vol.4 - CR Ashita Gaarusa Yoshimoto World"
+  name: 必勝パチンコ★パチスロ攻略シリーズ Vol.4 CR明日があるさ よしもとワールド
+  name-sort: ひっしょうぱちんこ★ぱちすろこうりゃくしりーず Vol.4 CRあしたがあるさ よしもとわーるど
+  name-en: "Hisshou Pachinko-Pachislot Kouryaku Series Vol.4 - CR Ashita Gaarusa Yoshimoto World"
   region: "NTSC-J"
   gameFixes:
     - EETimingHack # Fixes FMV hanging.
 SLPS-25646:
-  name: "Eureka Seven - New Vision"
+  name: エウレカセブン NEW VISION
+  name-sort: えうれかせぶん NEW VISION
+  name-en: "Eureka Seven - New Vision"
   region: "NTSC-J"
 SLPS-25647:
-  name: "Simple 2000 Series Ultimate Vol. 32 - Azumi"
+  name: SIMPLE 2000シリーズ Ultimate Vol.32 あずみ
+  name-sort: SIMPLE 2000しりーず Ultimate Vol.32 あずみ
+  name-en: "Simple 2000 Series Ultimate Vol. 32 - Azumi"
   region: "NTSC-J"
 SLPS-25648:
-  name: "Hisshou Pachinko-Pachislot Kouryaku Series Vol.5 - CR Shinseiki Evangelion Second Impact & Pachisuro Shinseiki Evangelion"
+  name: 必勝パチンコ★パチスロ攻略シリーズ Vol.5 CR新世紀エヴァンゲリオン セカンドインパクト&パチスロ新世紀エヴァンゲリオン
+  name-sort: ひっしょうぱちんこ★ぱちすろこうりゃくしりーず Vol.5 CRしんせいきえゔぁんげりおん せかんどいんぱくと&ぱちすろしんせいきえゔぁんげりおん
+  name-en: "Hisshou Pachinko-Pachislot Kouryaku Series Vol.5 - CR Shinseiki Evangelion Second Impact & Pachisuro Shinseiki Evangelion"
   region: "NTSC-J"
 SLPS-25649:
-  name: "Space Sheriff Spirits"
+  name: 宇宙刑事魂
+  name-sort: うちゅうけいじたましい
+  name-en: "Space Sheriff Spirits"
   region: "NTSC-J"
   gsHWFixes:
     autoFlush: 2 # Fixes black stages.
 SLPS-25650:
-  name: "Metal Slug 3D"
+  name: メタルスラッグ
+  name-sort: めたるすらっぐ
+  name-en: "Metal Slug 3D"
   region: "NTSC-J"
   compat: 5
 SLPS-25651:
-  name: "dot hack G.U. Vol.1 - Saitan"
+  name: .hack//G.U. Vol.1 再誕
+  name-sort: .hack//G.U. Vol.1 さい誕
+  name-en: "dot hack G.U. Vol.1 - Saitan"
   region: "NTSC-J"
   memcardFilters:
     - "SCPS-55029"
@@ -45184,13 +52045,19 @@ SLPS-25652:
   name: "dot hack G.U. Vol. 1 - Saitan [Terminal Disc - The End of the World]"
   region: "NTSC-J"
 SLPS-25653:
-  name: "Cluster Edge [Limited Edition]"
+  name: クラスターエッジ 君を待つ未来への証 初回限定版
+  name-sort: くらすたーえっじ くんをまつみらいへのあかし しょかいげんていばん
+  name-en: "Cluster Edge [Limited Edition]"
   region: "NTSC-J"
 SLPS-25654:
-  name: "Cluster Edge - Kimi o Matsu Mirai e no Akashi"
+  name: クラスターエッジ 君を待つ未来への証
+  name-sort: くらすたーえっじ くんをまつみらいへのあかし
+  name-en: "Cluster Edge - Kimi o Matsu Mirai e no Akashi"
   region: "NTSC-J"
 SLPS-25655:
-  name: "dot hack G.U. Vol.2 - Kimi Omou Koe"
+  name: .hack//G.U. Vol.2 君想フ声
+  name-sort: .hack//G.U. Vol.2 きみおもふごえ
+  name-en: "dot hack G.U. Vol.2 - Kimi Omou Koe"
   region: "NTSC-J"
   memcardFilters:
     - "SCPS-55029"
@@ -45210,7 +52077,9 @@ SLPS-25655:
     - "SLPS-25656"
     - "SLPS-25756"
 SLPS-25656:
-  name: "dot hack - G.U. Vol.3 - Aruku Youna Hayasa de"
+  name: .hack//G.U. Vol.3 歩くような速さで
+  name-sort: .hack//G.U. Vol.3 あるくようなはやさで
+  name-en: "dot hack - G.U. Vol.3 - Aruku Youna Hayasa de"
   region: "NTSC-J"
   memcardFilters:
     - "SCPS-55029"
@@ -45230,168 +52099,260 @@ SLPS-25656:
     - "SLPS-25656"
     - "SLPS-25756"
 SLPS-25657:
-  name: "Fighting Beauty Wulong"
+  name: 格闘美神 武龍
+  name-sort: ふぁいちんぐびゅーてぃー うーろん
+  name-en: "Fighting Beauty Wulong"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
     autoFlush: 2 # Helps ghosting.
     halfPixelOffset: 2 # Helps ghosting when upscaling.
 SLPS-25658:
-  name: "Binchou-Tan - Shiwase Goyomi [Shokai Genteiban]"
+  name: びんちょうタン しあわせ暦 (初回限定版)
+  name-sort: びんちょうたん しあわせごよみ (しょかいげんていばん)
+  name-en: "Binchou-Tan - Shiwase Goyomi [Shokai Genteiban]"
   region: "NTSC-J"
 SLPS-25659:
-  name: "Binchou-Tan - Shiwase Koyomi"
+  name: びんちょうタン しあわせ暦 (通常版)
+  name-sort: びんちょうたん しあわせごよみ (つうじょうばん)
+  name-en: "Binchou-Tan - Shiwase Koyomi"
   region: "NTSC-J"
 SLPS-25660:
-  name: "King of Fighters XI, The"
+  name: ザ・キング・オブ・ファイターズXI
+  name-sort: ざ・きんぐ・おぶ・ふぁいたーずXI
+  name-en: "King of Fighters XI, The"
   region: "NTSC-J"
   compat: 5
 SLPS-25661:
-  name: "King of Fighters, The - Nests"
+  name: NEOGEOオンラインコレクション ザ・キング・オブ・ファイターズ -ネスツ編-
+  name-sort: NEOGEOおんらいんこれくしょん ざ・きんぐ・おぶ・ふぁいたーず -ねすつへん-
+  name-en: "King of Fighters, The - Nests"
   region: "NTSC-J"
 SLPS-25662:
-  name: "Kyo Kara Maoh! The 1st trip of Maoh! [Premium Box]"
+  name: 今日からマ王!はじマりの旅(プレミアムBOX)
+  name-sort: きょうからまおう!はじまりのたび(ぷれみあむBOX)
+  name-en: "Kyo Kara Maoh! The 1st trip of Maoh! [Premium Box]"
   region: "NTSC-J"
 SLPS-25663:
-  name: "Kyo Kara Maoh! The 1st trip of Maoh!"
+  name: 今日からマ王!はじマりの旅(通常版)
+  name-sort: きょうからまおう!はじまりのたび(つうじょうばん)
+  name-en: "Kyo Kara Maoh! The 1st trip of Maoh!"
   region: "NTSC-J"
 SLPS-25664:
-  name: "NeoGeo Online Collection - Garou Densetsu Battle Archives Vol.1"
+  name: NEOGEOオンラインコレクション 餓狼伝説バトルアーカイブズ1
+  name-sort: NEOGEOおんらいんこれくしょん がろうでんせつばとるあーかいぶず1
+  name-en: "NeoGeo Online Collection - Garou Densetsu Battle Archives Vol.1"
   region: "NTSC-J"
   compat: 5
 SLPS-25665:
-  name: "Pachitte Chonmage Tatsujin 10"
+  name: ぱちんこ冬のソナタ パチってちょんまげ達人10
+  name-sort: ぱちんこふゆのそなた ぱちってちょんまげたつじん10
+  name-en: "Pachitte Chonmage Tatsujin 10"
   region: "NTSC-J"
 SLPS-25666:
   name: "Sakura Zakashobotai [Irem Best]"
   region: "NTSC-J"
 SLPS-25667:
-  name: "Daito Giken Premium Pachi-Slot Collection - Yoshimune"
+  name: 大都技研プレミアムパチスロコレクション 吉宗
+  name-sort: だいとぎけんぷれみあむぱちすろこれくしょん よしむね
+  name-en: "Daito Giken Premium Pachi-Slot Collection - Yoshimune"
   region: "NTSC-J"
 SLPS-25668:
-  name: "Torikago no Mukougawa - The Angles with Strange Wings"
+  name: 鳥篭の向こうがわ
+  name-sort: とりかごのむこうがわ
+  name-en: "Torikago no Mukougawa - The Angles with Strange Wings"
   region: "NTSC-J"
 SLPS-25669:
-  name: "School Rumble 2nd Term [Limited Edition]"
+  name: スクールランブル二学期 恐怖の(?)夏合宿! 洋館に幽霊現る!? お宝を巡って真っ向勝負!!!の巻 【初回限定版】
+  name-sort: すくーるらんぶるにがっき きょうふの(?)なつがっしゅく! ようかんにゆうれいあらわる!? おたからをめぐってまっこうしょうぶ!!!のまき 【しょかいげんていばん】
+  name-en: "School Rumble 2nd Term [Limited Edition]"
   region: "NTSC-J"
   compat: 5
 SLPS-25670:
-  name: "School Rumble 2nd Term"
+  name: スクールランブル二学期 恐怖の(?)夏合宿! 洋館に幽霊現る!? お宝を巡って真っ向勝負!!!の巻
+  name-sort: すくーるらんぶるにがっき きょうふの(?)なつがっしゅく! ようかんにゆうれいあらわる!? おたからをめぐってまっこうしょうぶ!!!のまき
+  name-en: "School Rumble 2nd Term"
   region: "NTSC-J"
 SLPS-25671:
-  name: "School Rumble [Best Collection]"
+  name: SchoolRumble スクールランブル ねる娘は育つ。Best Collection
+  name-sort: SchoolRumble すくーるらんぶる ねるむすめはそだつ。Best Collection
+  name-en: "School Rumble [Best Collection]"
   region: "NTSC-J"
 SLPS-25672:
-  name: "7Cafe - Katashiki Mei Bonba Pawafuru 2"
+  name: 必勝パチンコ★パチスロ攻略シリーズ Vol.6 7Cafe〜型式名ボンバーパワフル2〜
+  name-sort: ひっしょうぱちんこ★ぱちすろこうりゃくしりーず Vol.6 7Cafe〜けいしきめいぼんばーぱわふる2〜
+  name-en: "7Cafe - Katashiki Mei Bonba Pawafuru 2"
   region: "NTSC-J"
 SLPS-25673:
-  name: "Last Escort - The Black Butterfly Special Night"
+  name: ラスト・エスコート〜黒蝶スペシャルナイト〜
+  name-sort: らすと・えすこーと〜くろちょうすぺしゃるないと〜
+  name-en: "Last Escort - The Black Butterfly Special Night"
   region: "NTSC-J"
 SLPS-25674:
-  name: "Metal Slug 6"
+  name: メタルスラッグ6
+  name-sort: めたるすらっぐ6
+  name-en: "Metal Slug 6"
   region: "NTSC-J"
   compat: 5
 SLPS-25675:
-  name: "Battle Stadium D.O.N"
+  name: バトルスタジアムD.O.N(ディー・オー・エヌ)
+  name-sort: ばとるすたじあむD.O.N(でぃー・おー・えぬ)
+  name-en: "Battle Stadium D.O.N"
   region: "NTSC-J"
   compat: 5
 SLPS-25676:
-  name: "Kinnikuman Muscle Grand Prix Max"
+  name: キン肉マン マッスルグランプリ MAX
+  name-sort: きんにくまん まっするぐらんぷり MAX
+  name-en: "Kinnikuman Muscle Grand Prix Max"
   region: "NTSC-J"
 SLPS-25677:
-  name: "Blood+ - One Night Kiss"
+  name: BLOOD+ One Night Kiss
+  name-sort: BLOOD+ One Night Kiss
+  name-en: "Blood+ - One Night Kiss"
   region: "NTSC-J"
   compat: 5
 SLPS-25678:
-  name: "Utawareru Mono [Limited Edition]"
+  name: うたわれるもの 散りゆく者への子守唄(初回限定版)
+  name-sort: うたわれるもの ちりゆくものへのこもりうた(しょかいげんていばん)
+  name-en: "Utawareru Mono [Limited Edition]"
   region: "NTSC-J"
 SLPS-25679:
-  name: "Utawareru Mono"
+  name: うたわれるもの 散りゆく者への子守唄
+  name-sort: うたわれるもの ちりゆくものへのこもりうた
+  name-en: "Utawareru Mono"
   region: "NTSC-J"
 SLPS-25680:
-  name: "Mai-Kinoto Hime [Limited Edition]"
+  name: 舞ー乙HiME 乙女舞闘史!! 【Limited Edition】
+  name-sort: まいおとめ おとめぶとうし!! 【Limited Edition】
+  name-en: "Mai-Kinoto Hime [Limited Edition]"
   region: "NTSC-J"
 SLPS-25681:
-  name: "Mai-Kinoto Hime"
+  name: 舞ー乙HiME 乙女舞闘史!!
+  name-sort: まいおとめ おとめぶとうし!!
+  name-en: "Mai-Kinoto Hime"
   region: "NTSC-J"
 SLPS-25682:
-  name: "Sanyo Pachinko Paradise 13"
+  name: パチパラ13〜スーパー海とパチプロ風雲録〜
+  name-sort: ぱちぱら13〜すーぱーうみとぱちぷろふううんろく〜
+  name-en: "Sanyo Pachinko Paradise 13"
   region: "NTSC-J"
 SLPS-25683:
-  name: "Ponkotsu Roman Daikatsugeki Bumpy Trot [Irem Collection]"
+  name: アイレム コレクション ポンコツ浪漫大活劇バンピートロット
+  name-sort: あいれむ これくしょん ぽんこつろまんだいかつげきばんぴーとろっと
+  name-en: "Ponkotsu Roman Daikatsugeki Bumpy Trot [Irem Collection]"
   region: "NTSC-J"
   gsHWFixes:
     getSkipCount: "GSC_SteambotChronicles" # Causes green (incorrect) water but removes depth and blur issues.
     roundSprite: 1 # Fixes colored 3D anaglyph bleeding effects.
 SLPS-25684:
-  name: "Mermaid Prism [Limited Edition]"
+  name: マーメイドプリズム(限定版BOX)
+  name-sort: まーめいどぷりずむ(げんていばんBOX)
+  name-en: "Mermaid Prism [Limited Edition]"
   region: "NTSC-J"
 SLPS-25685:
-  name: "Rurouni Kenshin - Enjou! Kyoto Rinne"
+  name: るろうに剣心-明治剣客浪漫譚- 炎上!京都輪廻
+  name-sort: るろうにけんしん-めいじけんかくろまんたん- えんじょう!きょうとりんね
+  name-en: "Rurouni Kenshin - Enjou! Kyoto Rinne"
   region: "NTSC-J"
 SLPS-25686:
-  name: "Jojo no Kimyou na Bouken - Phantom Blood"
+  name: ジョジョの奇妙な冒険 ファントムブラッド
+  name-sort: じょじょのきみょうなぼうけん ふぁんとむぶらっど
+  name-en: "Jojo no Kimyou na Bouken - Phantom Blood"
   region: "NTSC-J"
 SLPS-25687:
-  name: "Korobotto Adventure"
+  name: コロボットアドベンチャー
+  name-sort: ころぼっとあどべんちゃー
+  name-en: "Korobotto Adventure"
   region: "NTSC-J"
   compat: 5
 SLPS-25688:
-  name: "Simoun - Shoubi Sensou - Fuuin no Remersion [First Print - Limited Edition]"
+  name: シムーン 異薔薇戦争 封印のリ・マージョン 初回限定版
+  name-sort: しむーん いばらせんそう ふういんのり・まーじょん しょかいげんていばん
+  name-en: "Simoun - Shoubi Sensou - Fuuin no Remersion [First Print - Limited Edition]"
   region: "NTSC-J"
 SLPS-25689:
-  name: "Simoun - Shoubi Sensou - Fuuin no Remersion"
+  name: シムーン 異薔薇戦争 封印のリ・マージョン 通常版
+  name-sort: しむーん いばらせんそう ふういんのり・まーじょん つうじょうばん
+  name-en: "Simoun - Shoubi Sensou - Fuuin no Remersion"
   region: "NTSC-J"
 SLPS-25690:
-  name: "Dragon Ball Z - Sparking Neo"
+  name: ドラゴンボールZ Sparking! NEO
+  name-sort: どらごんぼーるZ Sparking! NEO
+  name-en: "Dragon Ball Z - Sparking Neo"
   region: "NTSC-J"
   gsHWFixes:
     beforeDraw: "OI_DBZBTGames"
 SLPS-25691:
-  name: "Captain Tsubasa"
+  name: キャプテン翼
+  name-sort: きゃぷてんつばさ
+  name-en: "Captain Tsubasa"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
     halfPixelOffset: 1 # Fixes extreme ghosting.
     wildArmsHack: 1 # Aligns vertical blurring.
 SLPS-25693:
-  name: "Shinseiki GPX - Road to the Infinity 3"
+  name: プリンセス・プリンセス 姫たちのアブナい放課後 (初回限定版)
+  name-sort: ぷりんせす・ぷりんせす ひめたちのあぶないほうかご (しょかいげんていばん)
+  name-en: "Shinseiki GPX - Road to the Infinity 3"
   region: "NTSC-J"
 SLPS-25694:
-  name: "Princess Princess"
+  name: プリンセス・プリンセス 姫たちのアブナい放課後
+  name-sort: ぷりんせす・ぷりんせす ひめたちのあぶないほうかご
+  name-en: "Princess Princess"
   region: "NTSC-J"
 SLPS-25695:
-  name: "New Century GPX Cyber Formula - Road to the Infinity 3"
+  name: 新世紀GPXサイバーフォーミュラ ROAD TO THE INFINITY 3
+  name-sort: しんせいきGPXさいばーふぉーみゅら ROAD TO THE INFINITY 3
+  name-en: "New Century GPX Cyber Formula - Road to the Infinity 3"
   region: "NTSC-J"
 SLPS-25696:
-  name: "Simple 2000 Series Vol. 122 - The Ningyo Hime Monogatari - Mermaid Prism"
+  name: マーメイドプリズム
+  name-sort: まーめいどぷりずむ
+  name-en: "Simple 2000 Series Vol. 122 - The Ningyo Hime Monogatari - Mermaid Prism"
   region: "NTSC-J"
 SLPS-25697:
-  name: "Hisshou Pachinko-PachiSlot Kouryaku Series Vol.7 - CR Fever Powerful Zero"
+  name: 必勝パチンコ★パチスロ攻略シリーズ Vol.7 CRフィーバー パワフルZERO
+  name-sort: ひっしょうぱちんこ★ぱちすろこうりゃくしりーず Vol.7 CRふぃーばー ぱわふるZERO
+  name-en: "Hisshou Pachinko-PachiSlot Kouryaku Series Vol.7 - CR Fever Powerful Zero"
   region: "NTSC-J"
   compat: 5
   gameFixes:
     - EETimingHack # Fixes FMV hanging.
 SLPS-25698:
-  name: "Fatal Fury - Battle Archives 2"
+  name: NEOGEOオンラインコレクション 餓狼伝説バトルアーカイブズ2
+  name-sort: NEOGEOおんらいんこれくしょん がろうでんせつばとるあーかいぶず2
+  name-en: "Fatal Fury - Battle Archives 2"
   region: "NTSC-J"
 SLPS-25699:
-  name: "Hisshou Pachinko-Pachislot Kouryaku Series Vol.8"
+  name: 必勝パチンコ★パチスロ攻略シリーズ Vol.8 CR松浦亜弥
+  name-sort: ひっしょうぱちんこ★ぱちすろこうりゃくしりーず Vol.8 CRまつうらあや
+  name-en: "Hisshou Pachinko-Pachislot Kouryaku Series Vol.8"
   region: "NTSC-J"
 SLPS-25700:
-  name: "Aoi no Tristia [The Best Price]"
+  name: 蒼い海のトリスティア 〜ナノカ・フランカ発明工房記〜 The Best Price
+  name-sort: あおいうみのとりすてぃあ 〜なのか・ふらんかはつめいこうぼうき〜 The Best Price
+  name-en: "Aoi no Tristia [The Best Price]"
   region: "NTSC-J"
 SLPS-25701:
-  name: "Gallop Racer Inbreed"
+  name: ギャロップレーサー インブリード
+  name-sort: ぎゃろっぷれーさー いんぶりーど
+  name-en: "Gallop Racer Inbreed"
   region: "NTSC-J"
 SLPS-25702:
-  name: "Amagoushi no Yakata"
+  name: 雨格子の館(あまごうしのやかた)
+  name-sort: あめこうしのやかた(あまごうしのやかた)
+  name-en: "Amagoushi no Yakata"
   region: "NTSC-J"
 SLPS-25703:
-  name: "Simple 2000 Series Vol. 111 - The Itadaki Raider"
+  name: SIMPLE2000シリーズ Vol.111 THE いただきライダー 〜お前のバイクは俺のモノ / Jacked〜
+  name-sort: SIMPLE2000しりーず Vol.111 THE いただきらいだー 〜おまえのばいくはおれのもの / Jacked〜
+  name-en: "Simple 2000 Series Vol. 111 - The Itadaki Raider"
   region: "NTSC-J"
 SLPS-25704:
-  name: "Summon Night 4"
+  name: サモンナイト4
+  name-sort: さもんないと4
+  name-en: "Summon Night 4"
   region: "NTSC-J"
 SLPS-25706:
   name: "Eureka Seven - New Vision"
@@ -45400,13 +52361,19 @@ SLPS-25707:
   name: "Eureka Seven TR1 - New Wave Graduation"
   region: "NTSC-J"
 SLPS-25708:
-  name: "Zero no Tsukaima [Limited Edition]"
+  name: ゼロの使い魔 小悪魔と春風の協奏曲 初回限定版
+  name-sort: ぜろのつかいま こあくまとはるかぜのこんちぇると しょかいげんていばん
+  name-en: "Zero no Tsukaima [Limited Edition]"
   region: "NTSC-J"
 SLPS-25709:
-  name: "Zero no Tsukaima"
+  name: ゼロの使い魔 小悪魔と春風の協奏曲
+  name-sort: ぜろのつかいま こあくまとはるかぜのこんちぇると
+  name-en: "Zero no Tsukaima"
   region: "NTSC-J"
 SLPS-25710:
-  name: "K-1 World Grand Prix 2006"
+  name: K-1 WORLD GP 2006
+  name-sort: K-1 WORLD GP 2006
+  name-en: "K-1 World Grand Prix 2006"
   region: "NTSC-J"
   compat: 4
   gsHWFixes:
@@ -45422,32 +52389,48 @@ SLPS-25710:
         patch=1,EE,004574B0,word,0000948c
         patch=1,EE,004574D8,word,0000948c
 SLPS-25711:
-  name: "Kashimashi! Girl Meets Girl [Best Collection]"
+  name: かしまし 〜ガールミーツガール「初めての夏物語。」Best Collection
+  name-sort: かしまし 〜がーるみーつがーる「はじめてのなつものご。」Best Collection
+  name-en: "Kashimashi! Girl Meets Girl [Best Collection]"
   region: "NTSC-J"
 SLPS-25712:
-  name: "King of Fighters Neowave [SNK the Best]"
+  name: SNK BEST COLLECTION THE KING OF FIGHTERS NEOWAVE
+  name-sort: SNK BEST COLLECTION THE KING OF FIGHTERS NEOWAVE
+  name-en: "King of Fighters Neowave [SNK the Best]"
   region: "NTSC-J"
 SLPS-25713:
-  name: "Twinkle Star Sprites - La Petite Princesse [SNK the Best]"
+  name: SNK BEST COLLECTION ティンクルスタースプライツーLa Petite Princesse-
+  name-sort: SNK BEST COLLECTION てぃんくるすたーすぷらいつーLa Petite Princesse-
+  name-en: "Twinkle Star Sprites - La Petite Princesse [SNK the Best]"
   region: "NTSC-J"
 SLPS-25714:
-  name: "Naruto - Konoha Spirits"
+  name: NARUTO-ナルト- 木ノ葉スピリッツ!!
+  name-sort: NARUTO-なると- きのはすぴりっつ!!
+  name-en: "Naruto - Konoha Spirits"
   region: "NTSC-J"
   gameFixes:
     - OPHFlagHack
 SLPS-25715:
-  name: "Tales of Destiny"
+  name: テイルズ オブ デスティニー
+  name-sort: ているず おぶ ですてぃにー
+  name-en: "Tales of Destiny"
   region: "NTSC-J"
   gameFixes:
     - FpuMulHack
 SLPS-25716:
-  name: "Digimon Savers - Another Mission"
+  name: デジモンセイバーズ アナザーミッション
+  name-sort: でじもんせいばーず あなざーみっしょん
+  name-en: "Digimon Savers - Another Mission"
   region: "NTSC-J"
 SLPS-25717:
-  name: "Simple 2000 Series Ultimate Vol. 33 - Ururun Quest Koiyuuki"
+  name: SIMPLE2000シリーズ UltimateVol.33 うるるんクエスト恋遊記
+  name-sort: SIMPLE2000しりーず UltimateVol.33 うるるんくえすとこいゆうき
+  name-en: "Simple 2000 Series Ultimate Vol. 33 - Ururun Quest Koiyuuki"
   region: "NTSC-J"
 SLPS-25718:
-  name: "Mobile Suit Gundam Seed Destiny - Rengou vs. Z.A.F.T. II Plus"
+  name: 機動戦士ガンダムSEED DESTINY 連合vs.Z.A.F.T.II PLUS
+  name-sort: きどうせんしがんだむSEED DESTINY れんごうvs.Z.A.F.T.II PLUS
+  name-en: "Mobile Suit Gundam Seed Destiny - Rengou vs. Z.A.F.T. II Plus"
   region: "NTSC-J"
   compat: 5
   roundModes:
@@ -45461,40 +52444,64 @@ SLPS-25718:
         patch=0,EE,00252824,word,48488000
         patch=0,EE,00252828,word,4B040183
 SLPS-25719:
-  name: "Happiness! Deluxe [First Print Limited Edition]"
+  name: はぴねす!でらっくす 初回限定版
+  name-sort: はぴねす!でらっくす しょかいげんていばん
+  name-en: "Happiness! Deluxe [First Print Limited Edition]"
   region: "NTSC-J"
 SLPS-25720:
-  name: "Happiness! Deluxe"
+  name: はぴねす!でらっくす 通常版
+  name-sort: はぴねす!でらっくす つうじょうばん
+  name-en: "Happiness! Deluxe"
   region: "NTSC-J"
 SLPS-25721:
-  name: "HimeHibi - Princess Days"
+  name: ひめひび -Princess Days-
+  name-sort: ひめひび -Princess Days-
+  name-en: "HimeHibi - Princess Days"
   region: "NTSC-J"
 SLPS-25722:
-  name: "Routes PE [Limited Edition]"
+  name: Routes PE (初回限定版)
+  name-sort: Routes PE (しょかいげんていばん)
+  name-en: "Routes PE [Limited Edition]"
   region: "NTSC-J"
 SLPS-25723:
-  name: "Simple 2000 Series Vol. 123 - The Office Love Jikenbou - Reijou Tantei"
+  name: 令嬢探偵〜オフィスラブ事件慕〜
+  name-sort: れいじょうたんてい〜おふぃすらぶじけん慕〜
+  name-en: "Simple 2000 Series Vol. 123 - The Office Love Jikenbou - Reijou Tantei"
   region: "NTSC-J"
 SLPS-25724:
-  name: "Pachinko Kaou - Misora Hibari"
+  name: ぱちんこ華王 美空ひばり
+  name-sort: ぱちんこかおう みそらひばり
+  name-en: "Pachinko Kaou - Misora Hibari"
   region: "NTSC-J"
 SLPS-25725:
-  name: "King's Field - Dark Side Box"
+  name: FROM SOFTWARE 20th ANNIVERSARY『KING’S FIELD -DARK SIDE BOX-』
+  name-sort: FROM SOFTWARE 20th ANNIVERSARY『KING’S FIELD -DARK SIDE BOX-』
+  name-en: "King's Field - Dark Side Box"
   region: "NTSC-J"
 SLPS-25726:
-  name: "SNK Slot Panic Vol.1"
+  name: SNKスロットパニック 球児
+  name-sort: SNKすろっとぱにっく きゅうじ
+  name-en: "SNK Slot Panic Vol.1"
   region: "NTSC-J"
 SLPS-25727:
-  name: "Routes PE"
+  name: Routes PE
+  name-sort: Routes PE
+  name-en: "Routes PE"
   region: "NTSC-J"
 SLPS-25728:
-  name: "Kujibiki Ambulance [Limited Edition]"
+  name: くじびき アンバランス 会長お願いすま〜っしゅファイト☆ 【初回限定版】
+  name-sort: くじびき あんばらんす かいちょうおねがいすま〜っしゅふぁいと☆ 【しょかいげんていばん】
+  name-en: "Kujibiki Ambulance [Limited Edition]"
   region: "NTSC-J"
 SLPS-25729:
-  name: "Kujibiki Unbalance"
+  name: くじびき アンバランス 会長お願いすま〜っしゅファイト☆ 【通常版】
+  name-sort: くじびき あんばらんす かいちょうおねがいすま〜っしゅふぁいと☆ 【つうじょうばん】
+  name-en: "Kujibiki Unbalance"
   region: "NTSC-J"
 SLPS-25730:
-  name: "Armored Core - Last Raven [Machine Side Box]"
+  name: ARMORED CORE -MACHINE SIDE BOX-
+  name-sort: ARMORED CORE -MACHINE SIDE BOX-
+  name-en: "Armored Core - Last Raven [Machine Side Box]"
   region: "NTSC-J"
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes glow effects, but breaks shadows of certain objects.
@@ -45508,68 +52515,110 @@ SLPS-25732:
   name: "Armored Core 3 [Machine Side Box]"
   region: "NTSC-J"
 SLPS-25733:
-  name: "Super Robot Taisen OG - Original Generations"
+  name: スーパーロボット大戦OG ORIGINAL GENERATIONS
+  name-sort: すーぱーろぼっとたいせんOG ORIGINAL GENERATIONS
+  name-en: "Super Robot Taisen OG - Original Generations"
   region: "NTSC-J"
 SLPS-25734:
-  name: "Battle of Yuu Yuu Hakusho, The - Shitou! Ankoku Bujutsukai - 120% Full Power"
+  name: THE BATTLE OF 幽★遊★白書〜死闘!暗黒武術会〜120%
+  name-sort: THE BATTLE OF ゆう★ゆう★はくしょ〜しとう!あんこくぶじゅつかい〜120%
+  name-en: "Battle of Yuu Yuu Hakusho, The - Shitou! Ankoku Bujutsukai - 120% Full Power"
   region: "NTSC-J"
 SLPS-25735:
-  name: "Dragon Shadow Spell"
+  name: ドラゴンシャドウスペル
+  name-sort: どらごんしゃどうすぺる
+  name-en: "Dragon Shadow Spell"
   region: "NTSC-J"
 SLPS-25736:
-  name: "Samurai Spirits - Tenkaichi Kenkakuten [SNK Best]"
+  name: SNK BEST COLLECTION サムライスピリッツ天下一剣客伝
+  name-sort: SNK BEST COLLECTION さむらいすぴりっつてんかいちけんかくでん
+  name-en: "Samurai Spirits - Tenkaichi Kenkakuten [SNK Best]"
   region: "NTSC-J"
 SLPS-25737:
-  name: "Neo Geo Battle Coliseum [SNK Best]"
+  name: SNK BEST COLLECTION ネオジオバトルコロシアム
+  name-sort: SNK BEST COLLECTION ねおじおばとるころしあむ
+  name-en: "Neo Geo Battle Coliseum [SNK Best]"
   region: "NTSC-J"
 SLPS-25738:
-  name: "Soul Cradle Sekai o Kurau Mono [Limited Edition]"
+  name: SOUL CRADLE(ソウルクレイドル) 世界を喰らう者 【初回限定版】
+  name-sort: そうるくれいどる せかいをくらうもの 【しょかいげんていばん】
+  name-en: "Soul Cradle Sekai o Kurau Mono [Limited Edition]"
   region: "NTSC-J"
   compat: 5
 SLPS-25739:
-  name: "Soul Cradle Sekai o Kurau Mono"
+  name: SOUL CRADLE(ソウルクレイドル) 世界を喰らう者
+  name-sort: そうるくれいどる せかいをくらうもの
+  name-en: "Soul Cradle Sekai o Kurau Mono"
   region: "NTSC-J"
 SLPS-25740:
-  name: "Lupin III - Lupin ni wa Shi o, Zenigata ni wa Koi o"
+  name: ルパン三世 ルパンには死を、銭形には恋を
+  name-sort: るぱんさんせい るぱんにはしを、ぜにがたにはこいを
+  name-en: "Lupin III - Lupin ni wa Shi o, Zenigata ni wa Koi o"
   region: "NTSC-J"
 SLPS-25742:
-  name: "Aa Megami-sama [Holy Box]"
+  name: ああっ女神さまっ (初回限定版)
+  name-sort: ああっめがみさまっ (しょかいげんていばん)
+  name-en: "Aa Megami-sama [Holy Box]"
   region: "NTSC-J"
 SLPS-25743:
-  name: "Aa Megami-sama"
+  name: ああっ女神さまっ (通常版)
+  name-sort: ああっめがみさまっ (つうじょうばん)
+  name-en: "Aa Megami-sama"
   region: "NTSC-J"
 SLPS-25744:
-  name: "Saint Seiya Meiou Hades Juunikyuu Hen"
+  name: 聖闘士星矢 冥王ハーデス十二宮編
+  name-sort: せいんとせいや めいおうはーですじゅうにきゅうへん
+  name-en: "Saint Seiya Meiou Hades Juunikyuu Hen"
   region: "NTSC-J"
 SLPS-25745:
-  name: "Hisshou Pachinko-Pachislot Kouryaku Series Vol.1 - CR Shinseiki Evangelion"
+  name: 必勝パチンコ★パチスロ攻略シリーズ vol.1 CR新世紀エヴァンゲリオン
+  name-sort: ひっしょうぱちんこ★ぱちすろこうりゃくしりーず vol.1 CRしんせいきえゔぁんげりおん
+  name-en: "Hisshou Pachinko-Pachislot Kouryaku Series Vol.1 - CR Shinseiki Evangelion"
   region: "NTSC-J"
 SLPS-25746:
-  name: "CR Fever Captain Harlock"
+  name: 必勝パチンコ★パチスロ攻略シリーズ Vol.9 CRフィーバー キャプテンハーロック
+  name-sort: ひっしょうぱちんこ★ぱちすろこうりゃくしりーず Vol.9 CRふぃーばー きゃぷてんはーろっく
+  name-en: "CR Fever Captain Harlock"
   region: "NTSC-J"
 SLPS-25747:
-  name: "Garouden Break Blow - Fist or Twist"
+  name: 餓狼伝Breakblow Fist or Twist
+  name-sort: がろうでんBreakblow Fist or Twist
+  name-en: "Garouden Break Blow - Fist or Twist"
   region: "NTSC-J"
 SLPS-25748:
-  name: "Aoi Sora no Neosphere - Nanoca Flanka Hatsumei Koubouki 2 [Shokai Genteiban]"
+  name: 蒼い空のネオスフィア〜ナノカ・フランカ発明工房記2〜 (初回限定版)
+  name-sort: あおいそらのねおすふぃあ〜なのか・ふらんかはつめいこうぼうき2〜 (しょかいげんていばん)
+  name-en: "Aoi Sora no Neosphere - Nanoca Flanka Hatsumei Koubouki 2 [Shokai Genteiban]"
   region: "NTSC-J"
 SLPS-25749:
-  name: "Aoi Sora no Neosphere - Nanoca Flanka Hatsumei Koubouki 2"
+  name: 蒼い空のネオスフィア〜ナノカ・フランカ発明工房記2〜 (通常版)
+  name-sort: あおいそらのねおすふぃあ〜なのか・ふらんかはつめいこうぼうき2〜 (つうじょうばん)
+  name-en: "Aoi Sora no Neosphere - Nanoca Flanka Hatsumei Koubouki 2"
   region: "NTSC-J"
 SLPS-25750:
-  name: "Super Robot Taisen - Scramble Commander The 2nd"
+  name: スーパーロボット大戦 Scramble Commander the 2nd
+  name-sort: すーぱーろぼっとたいせん Scramble Commander the 2nd
+  name-en: "Super Robot Taisen - Scramble Commander The 2nd"
   region: "NTSC-J"
 SLPS-25751:
-  name: "Gakuen Utopia - Manabi Straight! KiraKira Happy Festa! [Limited Edition]"
+  name: がくえんゆーとぴあ まなびストレート! キラキラ☆ Happy Festa! (初回限定版)
+  name-sort: がくえんゆーとぴあ まなびすとれーと! きらきら☆ Happy Festa! (しょかいげんていばん)
+  name-en: "Gakuen Utopia - Manabi Straight! KiraKira Happy Festa! [Limited Edition]"
   region: "NTSC-J"
 SLPS-25752:
-  name: "Gakuen Utopia - Manabi Straight! KiraKira Happy Festa!"
+  name: がくえんゆーとぴあ まなびストレート! キラキラ☆ Happy Festa!
+  name-sort: がくえんゆーとぴあ まなびすとれーと! きらきら☆ Happy Festa!
+  name-en: "Gakuen Utopia - Manabi Straight! KiraKira Happy Festa!"
   region: "NTSC-J"
 SLPS-25753:
-  name: "Ichigo Mashimaro [Shock SP]"
+  name: 電撃SP 苺ましまろ
+  name-sort: でんげきSP いちごましまろ
+  name-en: "Ichigo Mashimaro [Shock SP]"
   region: "NTSC-J"
 SLPS-25754:
-  name: "Kino no Tabi 2 - The Beautiful World [Electric Shock SP]"
+  name: 電撃SP キノの旅II
+  name-sort: でんげきSP きののたびII
+  name-en: "Kino no Tabi 2 - The Beautiful World [Electric Shock SP]"
   region: "NTSC-J"
 SLPS-25755:
   name: "Dot Hack G.U. Vol. 1 - Saitan"
@@ -45595,42 +52644,66 @@ SLPS-25756:
     - "SLPS-25656"
     - "SLPS-25756"
 SLPS-25757:
-  name: "Nanatsu Iro - Drops Pure!! [First Print Limited Edition]"
+  name: ななついろ★ドロップスPure!! (初回限定版)
+  name-sort: ななついろ★どろっぷすPure!! (しょかいげんていばん)
+  name-en: "Nanatsu Iro - Drops Pure!! [First Print Limited Edition]"
   region: "NTSC-J"
 SLPS-25758:
-  name: "Nanatsu Iro - Drops Pure!!"
+  name: ななついろ★ドロップス Pure!!(通常版)
+  name-sort: ななついろ★どろっぷす Pure!!(つうじょうばん)
+  name-en: "Nanatsu Iro - Drops Pure!!"
   region: "NTSC-J"
 SLPS-25759:
-  name: "Shiju Hachi"
+  name: 四八(仮)
+  name-sort: しじゅうはち かっこかり
+  name-en: "Shiju Hachi"
   region: "NTSC-J"
   compat: 5
 SLPS-25760:
-  name: "VitaminX [Limited Edition]"
+  name: VitaminX LIMITED EDITION
+  name-sort: VitaminX LIMITED EDITION
+  name-en: "VitaminX [Limited Edition]"
   region: "NTSC-J"
 SLPS-25761:
-  name: "VitaminX"
+  name: VitaminX
+  name-sort: VitaminX
+  name-en: "VitaminX"
   region: "NTSC-J"
 SLPS-25762:
-  name: "Metal Slug Complete"
+  name: メタルスラッグ コンプリート
+  name-sort: めたるすらっぐ こんぷりーと
+  name-en: "Metal Slug Complete"
   region: "NTSC-J"
 SLPS-25763:
-  name: "Shin Bokujou Monogatari - Pure Innocent Life"
+  name: 新牧場物語:ピュア イノセントライフ
+  name-sort: しんぼくじょうものがたり:ぴゅあ いのせんとらいふ
+  name-en: "Shin Bokujou Monogatari - Pure Innocent Life"
   region: "NTSC-J"
   compat: 5
 SLPS-25764:
-  name: "Busou Renkin - Youkoso Papillon Park e"
+  name: 武装錬金 〜ようこそ パピヨンパークへ〜
+  name-sort: ぶそうれんきん 〜ようこそ ぱぴよんぱーくへ〜
+  name-en: "Busou Renkin - Youkoso Papillon Park e"
   region: "NTSC-J"
 SLPS-25765:
-  name: "King of Fighters, The - Maximum Impact Regulation A"
+  name: KOF MAXIMUM IMPACT REGULATION“A”
+  name-sort: KOF MAXIMUM IMPACT REGULATION“A”
+  name-en: "King of Fighters, The - Maximum Impact Regulation A"
   region: "NTSC-J"
 SLPS-25766:
-  name: "Orange Honey - Boku wa Kimi ni Koishiteru [Limited Edition]"
+  name: オレンジハニー 僕はキミに恋してる(初回限定版)
+  name-sort: おれんじはにー ぼくはきみにこいしてる(しょかいげんていばん)
+  name-en: "Orange Honey - Boku wa Kimi ni Koishiteru [Limited Edition]"
   region: "NTSC-J"
 SLPS-25767:
-  name: "Orange Honey - Boku wa Kimi ni Koishiteru"
+  name: オレンジハニー 僕はキミに恋してる(通常版)
+  name-sort: おれんじはにー ぼくはきみにこいしてる(つうじょうばん)
+  name-en: "Orange Honey - Boku wa Kimi ni Koishiteru"
   region: "NTSC-J"
 SLPS-25768:
-  name: "Naruto Shippuuden Narutimate Accel"
+  name: NARUTO-ナルト- 疾風伝 ナルティメットアクセル
+  name-sort: NARUTO-なると- しっぷうでん なるてぃめっとあくせる
+  name-en: "Naruto Shippuuden Narutimate Accel"
   region: "NTSC-J"
   gameFixes:
     - SoftwareRendererFMVHack # Fixes vertical lines in FMVs.
@@ -45641,170 +52714,266 @@ SLPS-25768:
     vu0ClampMode: 3 # Fixes bad dialog backgrounds.
     vu1ClampMode: 3 # Fixes SPS on characters.
 SLPS-25769:
-  name: "Netsu Chu! Pro Baseball 2007"
+  name: プロ野球 熱スタ2007
+  name-sort: ぷろやきゅう ねつすた2007
+  name-en: "Netsu Chu! Pro Baseball 2007"
   region: "NTSC-J"
 SLPS-25770:
-  name: "Rakushou! Pachi-Slot Sengen 5"
+  name: 楽勝!パチスロ宣言5リオパラダイス
+  name-sort: らくしょう!ぱちすろせんげん5りおぱらだいす
+  name-en: "Rakushou! Pachi-Slot Sengen 5"
   region: "NTSC-J"
 SLPS-25771:
-  name: "Grim Grimoire"
+  name: グリムグリモア (初回生産版)
+  name-sort: ぐりむぐりもあ (しょかいせいさんばん)
+  name-en: "Grim Grimoire"
   region: "NTSC-J"
   compat: 5
 SLPS-25772:
   name: "GrimGrimoire"
   region: "NTSC-J-K"
 SLPS-25773:
-  name: "Tales of Fandom Vol.2 [Tia Version]"
+  name: テイルズ オブ ファンダムVol.2(ティアバージョン)
+  name-sort: ているず おぶ ふぁんだむVol.2(てぃあばーじょん)
+  name-en: "Tales of Fandom Vol.2 [Tia Version]"
   region: "NTSC-J"
 SLPS-25774:
-  name: "Tales of Fandom Vol.2 [Luke Version]"
+  name: テイルズ オブ ファンダムVol.2(ルークバージョン)
+  name-sort: ているず おぶ ふぁんだむVol.2(るーくばーじょん)
+  name-en: "Tales of Fandom Vol.2 [Luke Version]"
   region: "NTSC-J"
 SLPS-25775:
-  name: "Magician's Academy, The"
+  name: まじしゃんず・あかでみい
+  name-sort: まじしゃんず・あかでみい
+  name-en: "Magician's Academy, The"
   region: "NTSC-J"
 SLPS-25776:
-  name: "Pachitte Chonmage Tatsujin 12"
+  name: ぱちんこウルトラマン ぱちってちょんまげ達人12
+  name-sort: ぱちんこうるとらまん ぱちってちょんまげたつじん12
+  name-en: "Pachitte Chonmage Tatsujin 12"
   region: "NTSC-J"
 SLPS-25777:
-  name: "Sumomomomomo - Chijou Saikyou no Yome [Limited Edition]"
+  name: すもももももも 〜地上最強のヨメ〜 継承しましょ!? 恋の花ムコ争奪戦!!(初回限定版)
+  name-sort: すもももももも 〜ちじょうさいきょうのよめ〜 けいしょうしましょ!? こいのはなむこそうだつせん!!(しょかいげんていばん)
+  name-en: "Sumomomomomo - Chijou Saikyou no Yome [Limited Edition]"
   region: "NTSC-J"
 SLPS-25778:
-  name: "Sumomomo Momomo - Chijou Saikyou no Yome - Keishou Shimasho! Koi no Hanamuko Soudatsu-sen!!"
+  name: すもももももも 〜地上最強のヨメ〜 継承しましょ!? 恋の花ムコ争奪戦!!(通常版)
+  name-sort: すもももももも 〜ちじょうさいきょうのよめ〜 けいしょうしましょ!? こいのはなむこそうだつせん!!(つうじょうばん)
+  name-en: "Sumomomo Momomo - Chijou Saikyou no Yome - Keishou Shimasho! Koi no Hanamuko Soudatsu-sen!!"
   region: "NTSC-J"
 SLPS-25779:
-  name: "King of Fighters, The - Maximum Impact 2 [SNK Best Collection]"
+  name: SNK BEST COLLECTION KOF MAXIMUMIMPACT 2
+  name-sort: SNK BEST COLLECTION KOF MAXIMUMIMPACT 2
+  name-en: "King of Fighters, The - Maximum Impact 2 [SNK Best Collection]"
   region: "NTSC-J"
 SLPS-25780:
-  name: "Nodame Cantabile"
+  name: のだめカンタービレ
+  name-sort: のだめかんたーびれ
+  name-en: "Nodame Cantabile"
   region: "NTSC-J"
 SLPS-25781:
-  name: "Fuuun Super Combo"
+  name: NEOGEOオンラインコレクション 風雲 SUPER COMBO
+  name-sort: NEOGEOおんらいんこれくしょん ふううん SUPER COMBO
+  name-en: "Fuuun Super Combo"
   region: "NTSC-J"
   compat: 5
 SLPS-25782:
-  name: "World Heroes - Gorgeous"
+  name: NEOGEOオンラインコレクション ワールドヒーローズ ゴージャス
+  name-sort: NEOGEOおんらいんこれくしょん わーるどひーろーず ごーじゃす
+  name-en: "World Heroes - Gorgeous"
   region: "NTSC-J"
 SLPS-25783:
-  name: "King of Fighters '98, The - Ultimate Match"
+  name: NEOGEOオンラインコレクション ザ・キング・オブ・ファイターズ98アルティメットマッチ
+  name-sort: NEOGEOおんらいんこれくしょん ざ・きんぐ・おぶ・ふぁいたーず98あるてぃめっとまっち
+  name-en: "King of Fighters '98, The - Ultimate Match"
   region: "NTSC-J"
 SLPS-25784:
-  name: "Another Century's Episode 3 - The Final"
+  name: Another Century’s Episode 3 THE FINAL
+  name-sort: Another Century’s Episode 3 THE FINAL
+  name-en: "Another Century's Episode 3 - The Final"
   region: "NTSC-J"
   clampModes:
     vuClampMode: 3 # Was used to fix game crash, but not sure it's required anymore.
 SLPS-25786:
-  name: "Hisshou Pachinko-Pachislot Kouryaku Series Vol.10 - CR Shinseiki Evangelion - Kiseki no kachi Ha"
+  name: 必勝パチンコ★パチスロ攻略シリーズ Vol.10 CR新世紀エヴァンゲリオン〜奇跡の価値は〜
+  name-sort: ひっしょうぱちんこ★ぱちすろこうりゃくしりーず Vol.10 CRしんせいきえゔぁんげりおん〜きせきのかちは〜
+  name-en: "Hisshou Pachinko-Pachislot Kouryaku Series Vol.10 - CR Shinseiki Evangelion - Kiseki no kachi Ha"
   region: "NTSC-J"
   gameFixes:
     - EETimingHack # Fixes FMV hanging.
 SLPS-25787:
-  name: "Sanyo Pachinko Paradise 14"
+  name: パチパラ14 〜風と雲とスーパー海IN沖縄〜
+  name-sort: ぱちぱら14 〜かぜとくもとすーぱーうみINおきなわ〜
+  name-en: "Sanyo Pachinko Paradise 14"
   region: "NTSC-J"
   compat: 5
 SLPS-25788:
-  name: "Metal Slug [SNK Best Collection]"
+  name: SNK BEST COLLECTION メタルスラッグ
+  name-sort: SNK BEST COLLECTION めたるすらっぐ
+  name-en: "Metal Slug [SNK Best Collection]"
   region: "NTSC-J"
 SLPS-25789:
-  name: "King of Fighters XI, The [SNK Best Collection]"
+  name: SNK BEST COLLECTION THE KING OF FIGHTERS XI
+  name-sort: SNK BEST COLLECTION THE KING OF FIGHTERS XI
+  name-en: "King of Fighters XI, The [SNK Best Collection]"
   region: "NTSC-J"
 SLPS-25790:
-  name: "Art of Fighting Collection [NeoGeo Online Collection the Best]"
+  name: NEOGEO ONLINE COLLECTION THE BEST 龍虎の拳 〜天・地・人〜
+  name-sort: NEOGEO ONLINE COLLECTION THE BEST りゅうこのけん 〜てん・ち・じん〜
+  name-en: "Art of Fighting Collection [NeoGeo Online Collection the Best]"
   region: "NTSC-J"
 SLPS-25791:
-  name: "King of Fighters, The - Orochi Collection [NeoGeo Online Collection the Best]"
+  name: NEOGEO ONLINE COLLECTION THE BEST THE KING OF FIGHTERS 〜オロチ編〜
+  name-sort: NEOGEO ONLINE COLLECTION THE BEST THE KING OF FIGHTERS 〜おろちへん〜
+  name-en: "King of Fighters, The - Orochi Collection [NeoGeo Online Collection the Best]"
   region: "NTSC-J"
 SLPS-25792:
-  name: "Bakumatsu Roman - Last Blade 2-in-1 [NeoGeo Online Collection the Best]"
+  name: NEOGEO ONLINE COLLECTION THE BEST 幕末浪漫 月華の剣士 1・2
+  name-sort: NEOGEO ONLINE COLLECTION THE BEST ばくまつろまん げっかのけんし 1・2
+  name-en: "Bakumatsu Roman - Last Blade 2-in-1 [NeoGeo Online Collection the Best]"
   region: "NTSC-J"
 SLPS-25793:
-  name: "Garou - Mark of the Wolves [NeoGeo Online Collection the Best]"
+  name: NEOGEO ONLINE COLLECTION THE BEST 餓狼 MARK OF THE WOLVES
+  name-sort: NEOGEO ONLINE COLLECTION THE BEST がろう MARK OF THE WOLVES
+  name-en: "Garou - Mark of the Wolves [NeoGeo Online Collection the Best]"
   region: "NTSC-J"
 SLPS-25794:
-  name: "Cluster Edge [Best Collection]"
+  name: クラスターエッジ〜君を待つ未来への証〜 Best Collection
+  name-sort: くらすたーえっじ〜きみをまつみらいへのあかし〜 Best Collection
+  name-en: "Cluster Edge [Best Collection]"
   region: "NTSC-J"
 SLPS-25795:
-  name: "School Rumble - 2nd Term [Best Collection]"
+  name: スクールランブル二学期 恐怖の(?)夏合宿! 洋館に幽霊現る!?お宝を巡って真っ向勝負!!!の巻 Best Collection
+  name-sort: すくーるらんぶるにがっき きょうふの(?)なつがっしゅく! ようかんにゆうれいあらわる!?おたからをめぐってまっこうしょうぶ!!!のまき Best Collection
+  name-en: "School Rumble - 2nd Term [Best Collection]"
   region: "NTSC-J"
 SLPS-25796:
-  name: "Ore no Shite Agake"
+  name: 俺の下でAGAKE
+  name-sort: おれのしたでAGAKE
+  name-en: "Ore no Shite Agake"
   region: "NTSC-J"
 SLPS-25797:
-  name: "Ikki Tousen - Shining Dragon [Limited Edition]"
+  name: 一騎当千 Shining Dragon(限定爆裂パック)
+  name-sort: いっきとうせん Shining Dragon(げんていばくれつぱっく)
+  name-en: "Ikki Tousen - Shining Dragon [Limited Edition]"
   region: "NTSC-J"
   gsHWFixes:
     roundSprite: 1 # Aligns bloom effect.
 SLPS-25798:
-  name: "Ikki Tousen - Shining Dragon"
+  name: 一騎当千 Shining Dragon(通常版)
+  name-sort: いっきとうせん Shining Dragon(つうじょうばん)
+  name-en: "Ikki Tousen - Shining Dragon"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
     roundSprite: 1 # Aligns bloom effect.
 SLPS-25799:
-  name: "Ultraman Fighting Evolution 3 [Banpresto Best]"
+  name: ウルトラマン Fighting Evolution 3 バンプレストベスト
+  name-sort: うるとらまん Fighting Evolution 3 ばんぷれすとべすと
+  name-en: "Ultraman Fighting Evolution 3 [Banpresto Best]"
   region: "NTSC-J"
 SLPS-25800:
-  name: "Ultraman Fighting Evolution - Rebirth [Banpresto Best]"
+  name: ウルトラマン Fighting Evolution Rebirth バンプレストベスト
+  name-sort: うるとらまん Fighting Evolution Rebirth ばんぷれすとべすと
+  name-en: "Ultraman Fighting Evolution - Rebirth [Banpresto Best]"
   region: "NTSC-J"
   gsHWFixes:
     getSkipCount: "GSC_UltramanFightingEvolution"
 SLPS-25801:
-  name: "Kyou Kara Maou! Shin Ma-Kuni no Kyuujitsu [Limited Edition]"
+  name: 今日からマ王！ 眞マ国の休日
+  name-sort: きょうからまおう！ まことまこくのきゅうじつ
+  name-en: "Kyou Kara Maou! Shin Ma-Kuni no Kyuujitsu [Limited Edition]"
   region: "NTSC-J"
 SLPS-25802:
-  name: "Kyou Kara Maou! Shin Ma-Kuni no Kyuujitsu"
+  name: 今日からマ王！ 眞マ国の休日
+  name-sort: きょうからまおう！ まことまこくのきゅうじつ
+  name-en: "Kyou Kara Maou! Shin Ma-Kuni no Kyuujitsu"
   region: "NTSC-J"
 SLPS-25803:
-  name: "xxxHolic - Shigatsu Tsuitachi no Izayoi Sowa"
+  name: xxx HOLiC〜四月一日の十六夜草話〜
+  name-sort: xxx HOLiC〜わたぬきのいざよいそうわ〜
+  name-en: "xxxHolic - Shigatsu Tsuitachi no Izayoi Sowa"
   region: "NTSC-J"
 SLPS-25804:
-  name: "Dear My Sun [Limited Edition]"
+  name: DEAR My SUN!! 〜ムスコ★育成★狂騒曲〜(限定版)
+  name-sort: DEAR My SUN!! 〜むすこ★いくせい★きょうそうきょく〜(げんていばん)
+  name-en: "Dear My Sun [Limited Edition]"
   region: "NTSC-J"
 SLPS-25806:
-  name: "Kateikyoushi Hitman Reborn! Dream Hyper Battle"
+  name: 家庭教師ヒットマン REBORN!ドリームハイパーバトル!死ぬ気の炎と黒き記憶
+  name-sort: かていきょうしひっとまん REBORN!どりーむはいぱーばとる!しぬきのほのおとくろききおく
+  name-en: "Kateikyoushi Hitman Reborn! Dream Hyper Battle"
   region: "NTSC-J"
   compat: 5
 SLPS-25807:
-  name: "Saint Beast - Rasen no Shou [Limited Edition]"
+  name: セイント・ビースト 〜螺旋の章〜(限定版)
+  name-sort: せいんと・びーすと 〜らせんのしょう〜(げんていばん)
+  name-en: "Saint Beast - Rasen no Shou [Limited Edition]"
   region: "NTSC-J"
 SLPS-25808:
-  name: "Saint Beast - Rasen no Shou"
+  name: セイント・ビースト 〜螺旋の章〜(通常版)
+  name-sort: せいんと・びーすと 〜らせんのしょう〜(つうじょうばん)
+  name-en: "Saint Beast - Rasen no Shou"
   region: "NTSC-J"
 SLPS-25809:
-  name: "Gintama - Gin-san to Issho! Boku no Kabuki-chou Nikki"
+  name: 銀魂 銀さんと一緒!ボクのかぶき町日記
+  name-sort: ぎんたま ぎんさんといっしょ!ぼくのかぶきちょうちにっき
+  name-en: "Gintama - Gin-san to Issho! Boku no Kabuki-chou Nikki"
   region: "NTSC-J"
 SLPS-25810:
-  name: "Dear My Sun"
+  name: DEAR My SUN!! 〜ムスコ★育成★狂騒曲〜(通常版)
+  name-sort: DEAR My SUN!! 〜むすこ★いくせい★きょうそうきょく〜(つうじょうばん)
+  name-en: "Dear My Sun"
   region: "NTSC-J"
 SLPS-25811:
-  name: "Happiness! Deluxe [Best Collection]"
+  name: はぴねす! でらっくす Best Collection
+  name-sort: はぴねす! でらっくす Best Collection
+  name-en: "Happiness! Deluxe [Best Collection]"
   region: "NTSC-J"
 SLPS-25812:
-  name: "Tori no Hoshi - Aerial Planet"
+  name: トリノホシ 〜Aerial Planet〜
+  name-sort: とりのほし 〜Aerial Planet〜
+  name-en: "Tori no Hoshi - Aerial Planet"
   region: "NTSC-J"
 SLPS-25813:
-  name: "Hisshou Pachinko - Pachi-Slot Kouryoku Series Vol.11 - Shinseiki Evangelion - Magokoro o, Kimi ni"
+  name: 必勝パチンコ★パチスロ攻略シリーズ Vol.11 新世紀エヴァンゲリオン〜まごころを、君に〜
+  name-sort: ひっしょうぱちんこ★ぱちすろこうりゃくしりーず Vol.11 しんせいきえゔぁんげりおん〜まごころを、きみに〜
+  name-en: "Hisshou Pachinko - Pachi-Slot Kouryoku Series Vol.11 - Shinseiki Evangelion - Magokoro o, Kimi ni"
   region: "NTSC-J"
 SLPS-25814:
-  name: "Shinseiki GPX Cyber Formula - Road to the Infinity 4"
+  name: 新世紀GPX サイバーフォーミュラ Road To The INFINITY 4
+  name-sort: しんせいきGPX さいばーふぉーみゅら Road To The INFINITY 4
+  name-en: "Shinseiki GPX Cyber Formula - Road to the Infinity 4"
   region: "NTSC-J"
 SLPS-25815:
-  name: "Dragon Ball Z Sparking! Meteor"
+  name: ドラゴンボールZ スパーキング!メテオ
+  name-sort: どらごんぼーるZ すぱーきんぐ!めてお
+  name-en: "Dragon Ball Z Sparking! Meteor"
   region: "NTSC-J"
   gsHWFixes:
     beforeDraw: "OI_DBZBTGames"
 SLPS-25816:
-  name: "Yamasa Digi World Collaboration SP - Pachi-Slot Ridge Racer"
+  name: 山佐DigiワールドコラボレーションSP パチスロ リッジレーサー
+  name-sort: やまさDigiわーるどこらぼれーしょんSP ぱちすろ りっじれーさー
+  name-en: "Yamasa Digi World Collaboration SP - Pachi-Slot Ridge Racer"
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
 SLPS-25817:
-  name: "Bakumatsu Renka - Karyuu Kenshiden [Genteiban]"
+  name: 幕末恋華・花柳剣士伝 雅の玉手箱
+  name-sort: ばくまつれんか・かりゅうけんしでん みやびのたまてばこ
+  name-en: "Bakumatsu Renka - Karyuu Kenshiden [Genteiban]"
   region: "NTSC-J"
 SLPS-25818:
-  name: "Bakumatsu Renka - Karyuu Kenshiden"
+  name: 幕末恋華・花柳剣士伝
+  name-sort: ばくまつれんか・かりゅうけんしでん
+  name-en: "Bakumatsu Renka - Karyuu Kenshiden"
   region: "NTSC-J"
 SLPS-25819:
-  name: "Ar tonelico II - Sekai ni Hibiku Shoujo-Tachi no Souzoushi"
+  name: アルトネリコ2 世界に響く少女たちの創造詩
+  name-sort: あるとねりこ2 せかいにひびくしょうじょたちのそうぞうし
+  name-en: "Ar tonelico II - Sekai ni Hibiku Shoujo-Tachi no Souzoushi"
   region: "NTSC-J"
   compat: 5
   roundModes:
@@ -45813,64 +52982,98 @@ SLPS-25819:
     roundSprite: 1 # Fixes textboxes and character portraits.
     beforeDraw: "OI_ArTonelico2"
 SLPS-25820:
-  name: "Kateikyoushi Hitman Reborn!! Let's Ansatsu! Nerawareta 10 Daime!"
+  name: 家庭教師ヒットマンREBORN! Let’s暗殺!? 狙われた10代目!
+  name-sort: かていきょうしひっとまんREBORN! Let’sあんさつ!? ねらわれた10だいめ!
+  name-en: "Kateikyoushi Hitman Reborn!! Let's Ansatsu! Nerawareta 10 Daime!"
   region: "NTSC-J"
   gsHWFixes:
     roundSprite: 2 # Reduces font artifacts but characters still have major artifacts.
 SLPS-25821:
-  name: "Suzumiya Haruhi no Tomadoi [Limited Edition]"
+  name: 涼宮ハルヒの戸惑 超限定版
+  name-sort: すずみやはるひのとまどい ちょうげんていばん
+  name-en: "Suzumiya Haruhi no Tomadoi [Limited Edition]"
   region: "NTSC-J"
 SLPS-25822:
-  name: "Suzumiya Haruhi no Tomadoi"
+  name: 涼宮ハルヒの戸惑
+  name-sort: すずみやはるひのとまどい
+  name-en: "Suzumiya Haruhi no Tomadoi"
   region: "NTSC-J"
 SLPS-25823:
-  name: "Spider-Man 3"
+  name: スパイダーマン3
+  name-sort: すぱいだーまん3
+  name-en: "Spider-Man 3"
   region: "NTSC-J"
   roundModes:
     eeRoundMode: 0 # Fixes idle camera behaviour.
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes textures.
 SLPS-25825:
-  name: "Zero no Tsukaima [Best Collection]"
+  name: ゼロの使い魔 小悪魔と春風の協奏曲 Best Collection
+  name-sort: ぜろのつかいま しょうあくまとはるかぜのきょうそうきょく Best Collection
+  name-en: "Zero no Tsukaima [Best Collection]"
   region: "NTSC-J"
 SLPS-25826:
-  name: "My Home o Tsukurou 2! Easy Design [Best Collection]"
+  name: マイホームをつくろう2 充実!簡単設計!! Best Collection
+  name-sort: まいほーむをつくろう2 じゅうじつ!かんたんせっけい!! Best Collection
+  name-en: "My Home o Tsukurou 2! Easy Design [Best Collection]"
   region: "NTSC-J"
 SLPS-25827:
-  name: "Soukou Kihei Votoms"
+  name: 装甲騎兵ボトムズ
+  name-sort: そうこうきへいぼとむず
+  name-en: "Soukou Kihei Votoms"
   region: "NTSC-J"
 SLPS-25828:
-  name: "Pachitte Chonmage Tatsujin 13 - Pachinko Hissatsu Shigotonin III"
+  name: ぱちんこ必殺仕事人III パチってちょんまげ達人13
+  name-sort: ぱちんこひっさつしごとじんIII ぱちってちょんまげたつじん13
+  name-en: "Pachitte Chonmage Tatsujin 13 - Pachinko Hissatsu Shigotonin III"
   region: "NTSC-J"
 SLPS-25829:
-  name: "Another Century's Episode 2 [Special Vocal Version]"
+  name: Another Century’s Episode 2 Special Vocal Version
+  name-sort: Another Century’s Episode 2 Special Vocal Version
+  name-en: "Another Century's Episode 2 [Special Vocal Version]"
   region: "NTSC-J"
 SLPS-25830:
-  name: "Zero no Tsukaima - Muma ga Tsumugu Yokaze no Gensoukyoku [Limited Edition]"
+  name: ゼロの使い魔 夢魔が紡ぐ夜風の幻想曲(限定版)
+  name-sort: ぜろのつかいま むまがつむぐよかぜのげんそうきょく(げんていばん)
+  name-en: "Zero no Tsukaima - Muma ga Tsumugu Yokaze no Gensoukyoku [Limited Edition]"
   region: "NTSC-J"
 SLPS-25831:
-  name: "Zero no Tsukaima - Muma ga Tsumugu Yokaze no Gensoukyoku"
+  name: ゼロの使い魔 夢魔が紡ぐ夜風の幻想曲(通常版)
+  name-sort: ぜろのつかいま むまがつむぐよかぜのげんそうきょく(つうじょうばん)
+  name-en: "Zero no Tsukaima - Muma ga Tsumugu Yokaze no Gensoukyoku"
   region: "NTSC-J"
 SLPS-25832:
-  name: "SD Gundam G Generation Spirits"
+  name: SDガンダム G GENERATION SPIRITS
+  name-sort: SDがんだむ G GENERATION SPIRITS
+  name-en: "SD Gundam G Generation Spirits"
   region: "NTSC-J"
 SLPS-25833:
-  name: "Simple 2000 Series Vol. 122 - The Ningyo Hime Monogatari - Mermaid Prism"
+  name: SIMPLE2000シリーズ Vol.122 THE 人魚姫物語〜マーメイドプリズム〜
+  name-sort: SIMPLE2000しりーず Vol.122 THE にんぎょひめものがたり〜まーめいどぷりずむ〜
+  name-en: "Simple 2000 Series Vol. 122 - The Ningyo Hime Monogatari - Mermaid Prism"
   region: "NTSC-J"
 SLPS-25834:
-  name: "Transformers - The Game"
+  name: トランスフォーマー THE GAME
+  name-sort: とらんすふぉーまー THE GAME
+  name-en: "Transformers - The Game"
   region: "NTSC-J"
   gsHWFixes:
     mipmap: 2 # Cleans up texture detail.
     trilinearFiltering: 1 # Smoothes out texture transitions.
 SLPS-25835:
-  name: "Super Robot Taisen OG - Original Generations Gaiden [Limited Edition]"
+  name: スーパーロボット大戦OG外伝(限定版)
+  name-sort: すーぱーろぼっとたいせんOGがいでん(げんていばん)
+  name-en: "Super Robot Taisen OG - Original Generations Gaiden [Limited Edition]"
   region: "NTSC-J"
 SLPS-25836:
-  name: "Super Robot Taisen OG - Original Generations Gaiden"
+  name: スーパーロボット大戦OG外伝
+  name-sort: すーぱーろぼっとたいせんOGがいでん
+  name-en: "Super Robot Taisen OG - Original Generations Gaiden"
   region: "NTSC-J"
 SLPS-25837:
-  name: "Naruto Shippuuden - Narutimate Accel 2"
+  name: NARUTO-ナルト- 疾風伝 ナルティメットアクセル2
+  name-sort: NARUTO-なると- しっぷうでん なるてぃめっとあくせる2
+  name-en: "Naruto Shippuuden - Narutimate Accel 2"
   region: "NTSC-J"
   gameFixes:
     - SoftwareRendererFMVHack # Fixes vertical lines in FMVs.
@@ -45881,20 +53084,28 @@ SLPS-25837:
     vu0ClampMode: 3 # Fixes bad dialog backgrounds.
     vu1ClampMode: 3 # Fixes SPS on characters.
 SLPS-25838:
-  name: "Taiheiyou no Arashi - Senkan Yamato, Akatsuki ni Shutsugeki su"
+  name: 太平洋の嵐　〜戦艦大和、暁に出撃す〜
+  name-sort: たいへいようのあらし　〜せんかんやまと、あかつきにしゅつげきす〜
+  name-en: "Taiheiyou no Arashi - Senkan Yamato, Akatsuki ni Shutsugeki su"
   region: "NTSC-J"
 SLPS-25839:
-  name: "Samurai Spirits - Rokuban Shoubu [NeoGeo Online Collection Vol. 12]"
+  name: NEOGEOオンラインコレクション サムライスピリッツ 六番勝負
+  name-sort: NEOGEOおんらいんこれくしょん さむらいすぴりっつ ろくばんしょうぶ
+  name-en: "Samurai Spirits - Rokuban Shoubu [NeoGeo Online Collection Vol. 12]"
   region: "NTSC-J"
 SLPS-25840:
-  name: "Guitar Hero III - Legends of Rock [with Guitar]"
+  name: ギターヒーロー３ レジェンド オブ ロック （ギターヒーロー３専用ワイヤレス クレイマー®ストライカー コントローラ同梱セット）
+  name-sort: ぎたーひーろーさん れじぇんど おぶ ろっく （ぎたーひーろーさんせんようわいやれす くれいまー®すとらいかー こんとろーらどうこんせっと）
+  name-en: "Guitar Hero III - Legends of Rock [with Guitar]"
   region: "NTSC-J"
   roundModes:
     vu1RoundMode: 0 # Crashes without.
   gsHWFixes:
     textureInsideRT: 1 # Crowd textures.
 SLPS-25841:
-  name: "Tales of Destiny [Director's Cut] [Premium Box]"
+  name: テイルズ オブ デスティニー ディレクターズカット プレミアムBOX
+  name-sort: ているず おぶ ですてぃにー でぃれくたーずかっと ぷれみあむBOX
+  name-en: "Tales of Destiny [Director's Cut] [Premium Box]"
   region: "NTSC-J"
   gameFixes:
     - FpuMulHack
@@ -45903,7 +53114,9 @@ SLPS-25841:
     - "SLPS-25842"
     - "SLPS-25715"
 SLPS-25842:
-  name: "Tales of Destiny [Director's Cut]"
+  name: テイルズ オブ デスティニー ディレクターズカット
+  name-sort: ているず おぶ ですてぃにー でぃれくたーずかっと
+  name-en: "Tales of Destiny [Director's Cut]"
   region: "NTSC-J"
   compat: 5
   gameFixes:
@@ -45913,91 +53126,141 @@ SLPS-25842:
     - "SLPS-25842"
     - "SLPS-25715"
 SLPS-25843:
-  name: "Tir-Na-Nog"
+  name: ティル・ナ・ノーグ 〜悠久の仁〜
+  name-sort: てぃる・な・のーぐ 〜ゆうきゅうのひとし〜
+  name-en: "Tir-Na-Nog"
   region: "NTSC-J"
 SLPS-25844:
-  name: "Last Escort 2 - Shiya no Amai Ira [Gorgeous Version]"
+  name: ラスト・エスコート 2 〜深夜の甘い棘〜 Gorgeous版
+  name-sort: らすと・えすこーと 2 〜しんやのあまいとげ〜 Gorgeousばん
+  name-en: "Last Escort 2 - Shiya no Amai Ira [Gorgeous Version]"
   region: "NTSC-J"
 SLPS-25845:
-  name: "Last Escort 2 - Shiya no Amai Ira"
+  name: ラスト・エスコート 2 〜深夜の甘い棘〜
+  name-sort: らすと・えすこーと 2 〜しんやのあまいとげ〜
+  name-en: "Last Escort 2 - Shiya no Amai Ira"
   region: "NTSC-J"
 SLPS-25847:
-  name: "Amekoushi no Kan [The Best Price]"
+  name: 雨格子の館 一柳和、最初の受難 The Best Price
+  name-sort: あめこうしのやかた いちやなぎなごむ、さいしょのじゅなん The Best Price
+  name-en: "Amekoushi no Kan [The Best Price]"
   region: "NTSC-J"
 SLPS-25848:
-  name: "Naraku no Shiro"
+  name: 奈落の城 一柳和、2度目の受難
+  name-sort: ならくのしろ いちやなぎなごむ、2どめのじゅなん
+  name-en: "Naraku no Shiro"
   region: "NTSC-J"
 SLPS-25849:
-  name: "Sunsoft Collection"
+  name: NEOGEOオンラインコレクション サンソフトコレクション
+  name-sort: NEOGEOおんらいんこれくしょん さんそふとこれくしょん
+  name-en: "Sunsoft Collection"
   region: "NTSC-J"
   compat: 5
 SLPS-25850:
-  name: "KimiKiss [ebKore+]"
+  name: エビコレ＋ キミキス eb！コレ
+  name-sort: えびこれ＋ きみきす eb！これ
+  name-en: "KimiKiss [ebKore+]"
   region: "NTSC-J"
   gsHWFixes:
     roundSprite: 1 # Fixes textboxes and character portraits.
 SLPS-25851:
-  name: "Zettai Zetsumei Toshi 2 - Itetsuita Kioku Tachi [Irem Collection]"
+  name: アイレムコレクション 絶体絶命都市2-凍てついた記憶たち-
+  name-sort: あいれむこれくしょん ぜったいぜつめいとし2-いてついたきおくたち-
+  name-en: "Zettai Zetsumei Toshi 2 - Itetsuita Kioku Tachi [Irem Collection]"
   region: "NTSC-J"
   gsHWFixes:
     getSkipCount: "GSC_ZettaiZetsumeiToshi2"
 SLPS-25852:
-  name: "Sanyo Pachinko Paradise 13 [Irem Collection]"
+  name: アイレムコレクション パチパラ13 〜スーパー海とパチプロ風雲録〜
+  name-sort: あいれむこれくしょん ぱちぱら13 〜すーぱーうみとぱちぷろふううんろく〜
+  name-en: "Sanyo Pachinko Paradise 13 [Irem Collection]"
   region: "NTSC-J"
 SLPS-25853:
-  name: "Pachinko Kamen Rider - Shocker Zenmetsu Daisakusen"
+  name: パチってちょんまげ達人 14 ぱちんこ仮面ライダー ショッカー全滅大作戦
+  name-sort: ぱちってちょんまげたつじん 14 ぱちんこかめんらいだー しょっかーぜんめつだいさくせん
+  name-en: "Pachinko Kamen Rider - Shocker Zenmetsu Daisakusen"
   region: "NTSC-J"
 SLPS-25854:
-  name: "Poison Pink"
+  name: POISON PINK
+  name-sort: POISON PINK
+  name-en: "Poison Pink"
   region: "NTSC-J"
   clampModes:
     eeClampMode: 0 # In-game background visible.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness when upscaling.
 SLPS-25855:
-  name: "Battle of Sunrise"
+  name: バトル オブ サンライズ
+  name-sort: ばとる おぶ さんらいず
+  name-en: "Battle of Sunrise"
   region: "NTSC-J"
 SLPS-25856:
-  name: "Tomb Raider - Anniversary"
+  name: "トゥームレイダー: アニバーサリー"
+  name-sort: "とぅーむれいだー: あにばーさりー"
+  name-en: "Tomb Raider - Anniversary"
   region: "NTSC-J"
   gsHWFixes:
     mipmap: 1
     textureInsideRT: 1 # Needed for post processing effects.
 SLPS-25858:
-  name: "Dengeki SP - Shakugan no Shana"
+  name: 電撃SP 灼眼のシャナ
+  name-sort: でんげきSP 灼眼のしゃな
+  name-en: "Dengeki SP - Shakugan no Shana"
   region: "NTSC-J"
 SLPS-25859:
-  name: "Orange Honey - Boku wa Kimi ni Koishiteru [Best Version]"
+  name: オレンジハニー 僕はキミに恋してる Best Collection
+  name-sort: おれんじはにー ぼくはきみにこいしてる Best Collection
+  name-en: "Orange Honey - Boku wa Kimi ni Koishiteru [Best Version]"
   region: "NTSC-J"
 SLPS-25860:
-  name: "Code Geass - Hangyaku no Lelouch - Lost Colors"
+  name: コードギアス 反逆のルルーシュ LOST COLORS
+  name-sort: こーどぎあす はんぎゃくのるるーしゅ LOST COLORS
+  name-en: "Code Geass - Hangyaku no Lelouch - Lost Colors"
   region: "NTSC-J"
 SLPS-25861:
-  name: "Hisshou Pachinko - Pachi-Slot Kouryoku Series Vol.10 [Special Price Edition]"
+  name: CR新世紀エヴァンゲリオン〜奇跡の価値は〜(スペシャルプライス版)
+  name-sort: CRしんせいきえゔぁんげりおん〜きせきのかちは〜(すぺしゃるぷらいすばん)
+  name-en: "Hisshou Pachinko - Pachi-Slot Kouryoku Series Vol.10 [Special Price Edition]"
   region: "NTSC-J"
 SLPS-25862:
-  name: "Hisshou Pachinko - Pachi-Slot Kouryoku Series Vol.05 - CR Neon Genesis Evangelion Sekandoinpakuto & Pachislot Neon Genesis Evangelion [Special Price Edition]"
+  name: CR新世紀エヴァンゲリオン〜セカンドインパクト〜(スペシャルプライス版)
+  name-sort: CRしんせいきえゔぁんげりおん〜せかんどいんぱくと〜(すぺしゃるぷらいすばん)
+  name-en: "Hisshou Pachinko - Pachi-Slot Kouryoku Series Vol.05 - CR Neon Genesis Evangelion Sekandoinpakuto & Pachislot Neon Genesis Evangelion [Special Price Edition]"
   region: "NTSC-J"
 SLPS-25863:
-  name: "Fatal Fury - Battle Archives 1 [SNK the Best]"
+  name: NEOGEOオンラインコレクション THE BEST 餓狼伝説 バトルアーカイブズ1
+  name-sort: NEOGEOおんらいんこれくしょん THE BEST がろうでんせつ ばとるあーかいぶず1
+  name-en: "Fatal Fury - Battle Archives 1 [SNK the Best]"
   region: "NTSC-J"
 SLPS-25864:
-  name: "Fatal Fury - Battle Archives 2 [SNK the Best]"
+  name: NEOGEOオンラインコレクション THE BEST 餓狼伝説バトルアーカイブズ2
+  name-sort: NEOGEOおんらいんこれくしょん THE BEST がろうでんせつばとるあーかいぶず2
+  name-en: "Fatal Fury - Battle Archives 2 [SNK the Best]"
   region: "NTSC-J"
 SLPS-25865:
-  name: "King of Fighters, The - Nests [SNK the Best]"
+  name: NEOGEOオンラインコレクション THE BEST ザ・キング・オブ・ファイターズ〜ネスツ編〜
+  name-sort: NEOGEOおんらいんこれくしょん THE BEST ざ・きんぐ・おぶ・ふぁいたーず〜ねすつへん〜
+  name-en: "King of Fighters, The - Nests [SNK the Best]"
   region: "NTSC-J"
 SLPS-25866:
-  name: "Fuuun Super Combo [SNK the Best]"
+  name: NEOGEOオンラインコレクション THE BEST 風雲スーパーコンボ
+  name-sort: NEOGEOおんらいんこれくしょん THE BEST ふううんすーぱーこんぼ
+  name-en: "Fuuun Super Combo [SNK the Best]"
   region: "NTSC-J"
 SLPS-25867:
-  name: "Hanayoi Romanesque - Ai to Kanashimi [Limited Edition]"
+  name: 花宵ロマネスク 愛と哀しみ−それは君のためのアリア 限定版
+  name-sort: はなよいろまねすく あいとかなしみ-それはきみのためのありあ げんていばん
+  name-en: "Hanayoi Romanesque - Ai to Kanashimi [Limited Edition]"
   region: "NTSC-J"
 SLPS-25868:
-  name: "Hanayoi Romanesque - Ai to Kanashimi"
+  name: 花宵ロマネスク 愛と哀しみ−それは君のためのアリア
+  name-sort: はなよいろまねすく あいとかなしみ-それはきみのためのありあ
+  name-en: "Hanayoi Romanesque - Ai to Kanashimi"
   region: "NTSC-J"
 SLPS-25869:
-  name: "CR Shinseiki Evangelion - Shito, Futatabi"
+  name: 必勝パチンコ★パチスロ攻略シリーズ Vol.12 CR新世紀エヴァンゲリオン〜使徒、再び〜
+  name-sort: ひっしょうぱちんこ★ぱちすろこうりゃくしりーず Vol.12 CRしんせいきえゔぁんげりおん〜しと、ふたたび〜
+  name-en: "CR Shinseiki Evangelion - Shito, Futatabi"
   region: "NTSC-J"
 SLPS-25871:
   name: "Drastic Killer"
@@ -46015,7 +53278,9 @@ SLPS-25877:
   name: "Busou Renkin - Youkoso Papillon Park e"
   region: "NTSC-J"
 SLPS-25879:
-  name: "Bully"
+  name: Bully (ブリー)
+  name-sort: Bully (ぶりー)
+  name-en: "Bully"
   region: "NTSC-J"
   clampModes:
     eeClampMode: 3 # Fixes the inability to take the bottle in the trophy case in Chapter 2: Hattrick vs Galloway.
@@ -46026,7 +53291,9 @@ SLPS-25880:
   name: "True Fortune"
   region: "NTSC-J"
 SLPS-25881:
-  name: "Kinnikuman Muscle Grand Prix 2"
+  name: キン肉マン マッスルグランプリ2 特盛
+  name-sort: きんにくまん まっするぐらんぷり2 とくもり
+  name-en: "Kinnikuman Muscle Grand Prix 2"
   region: "NTSC-J"
   compat: 5
 SLPS-25882:
@@ -46053,10 +53320,14 @@ SLPS-25886:
   roundModes:
     vu1RoundMode: 0 # Fixes VU size spam and potential graphical issues with GH3 engine.
 SLPS-25887:
-  name: "Super Robot Taisen Z"
+  name: スーパーロボット大戦Ｚ
+  name-sort: すーぱーろぼっとたいせんZ
+  name-en: "Super Robot Taisen Z"
   region: "NTSC-J"
 SLPS-25888:
-  name: "Star Wars - The Force Unleashed"
+  name: スター・ウォーズ・フォース・アンリーシュド
+  name-sort: すたー・うぉーず・ふぉーす・あんりーしゅど
+  name-en: "Star Wars - The Force Unleashed"
   region: "NTSC-J"
   compat: 5
   patches:
@@ -46068,12 +53339,16 @@ SLPS-25888:
         patch=1,EE,0017d454,word,3464fff0
         patch=1,EE,0017d460,word,3463fffc
 SLPS-25889:
-  name: "Guitar Hero - Aerosmith"
+  name: ギターヒーロー エアロスミス
+  name-sort: ぎたーひーろー えあろすみす
+  name-en: "Guitar Hero - Aerosmith"
   region: "NTSC-J"
   roundModes:
     vu1RoundMode: 0 # Fixes VU size spam and potential graphical issues with GH3 engine.
 SLPS-25890:
-  name: "Guitar Hero III - Legends of Rock"
+  name: ギターヒーロー3 レジェンドオブロック
+  name-sort: ぎたーひーろー3 れじぇんどおぶろっく
+  name-en: "Guitar Hero III - Legends of Rock"
   region: "NTSC-J"
   roundModes:
     vu1RoundMode: 0 # Crashes without.
@@ -46083,19 +53358,27 @@ SLPS-25891:
   name: "Nogizaka Haruka no Himitsu - Cosplay, Hajimemashita"
   region: "NTSC-J"
 SLPS-25892:
-  name: "Nogizaka Haruka no Himitsu - Cosplay Hajimemashita"
+  name: 乃木坂春香の秘密 こすぷれ、はじめました♥
+  name-sort: のぎざかはるかのひみつ こすぷれ、はじめました♥
+  name-en: "Nogizaka Haruka no Himitsu - Cosplay Hajimemashita"
   region: "NTSC-J"
 SLPS-25893:
   name: "Zero no Tsukaima - Muma ga Tsumugu Yokaze no Fantasy [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPS-25894:
-  name: "Aa Megami-sama [PlayStation 2 The Best]"
+  name: ああっ女神さまっ Best Collection
+  name-sort: ああっめがみさまっ Best Collection
+  name-en: "Aa Megami-sama [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPS-25897:
-  name: "Zero no Tsukaima - Maigo no Period to Ikusen no Symphony [Limited Edition]"
+  name: ゼロの使い魔 迷子の終止符と幾千の交響曲 限定版
+  name-sort: ぜろのつかいま まいごのしゅうしふといくせんのこうきょうきょく げんていばん
+  name-en: "Zero no Tsukaima - Maigo no Period to Ikusen no Symphony [Limited Edition]"
   region: "NTSC-J"
 SLPS-25898:
-  name: "Zero no Tsukaima - Maigo no Period to Ikusen no Symphony"
+  name: ゼロの使い魔 迷子の終止符と幾千の交響曲
+  name-sort: ぜろのつかいま まいごのしゅうしふといくせんのこうきょうきょく
+  name-en: "Zero no Tsukaima - Maigo no Period to Ikusen no Symphony"
   region: "NTSC-J"
 SLPS-25899:
   name: "Kateikyoushi Hitman Reborn!! Let's Ansatsu! Nerawareta 10 Daime! [Best Collection]"
@@ -46115,10 +53398,14 @@ SLPS-25904:
   name: "Katekyoo Hitman Reborn! Kindan no Yami no Delta"
   region: "NTSC-J"
 SLPS-25905:
-  name: "Dragon Ball Z - Infinite World"
+  name: ドラゴンボールZ インフィニットワールド
+  name-sort: どらごんぼーるZ いんふぃにっとわーるど
+  name-en: "Dragon Ball Z - Infinite World"
   region: "NTSC-J"
 SLPS-25906:
-  name: "ADK Tamashii"
+  name: ADK魂
+  name-sort: ADKたましい
+  name-en: "ADK Tamashii"
   region: "NTSC-J"
   compat: 5
 SLPS-25907:
@@ -46143,18 +53430,24 @@ SLPS-25912:
   name: "Soul Eater - Battle Resonance"
   region: "NTSC-J"
 SLPS-25914:
-  name: "Kidou Senshi Gundam - Giren no Yabou - Axis no Kyoui V"
+  name: 機動戦士ガンダム ギレンの野望 アクシズの脅威V
+  name-sort: きどうせんしがんだむ ぎれんのやぼう あくしずのきょういV
+  name-en: "Kidou Senshi Gundam - Giren no Yabou - Axis no Kyoui V"
   region: "NTSC-J"
   gameFixes:
     - FpuNegDivHack
 SLPS-25915:
-  name: "King of Fighters 2002, The - Unlimited Match"
+  name: ザ・キング・オブ・ファイターズ 2002 アンリミテッドマッチ
+  name-sort: ざ・きんぐ・おぶ・ふぁいたーず 2002 あんりみてっどまっち
+  name-en: "King of Fighters 2002, The - Unlimited Match"
   region: "NTSC-J"
 SLPS-25916:
   name: "Shinjuku no Ookami"
   region: "NTSC-J"
 SLPS-25917:
-  name: "Sacred Blaze"
+  name: セイクリッドブレイズ
+  name-sort: せいくりっどぶれいず
+  name-en: "Sacred Blaze"
   region: "NTSC-J"
   gsHWFixes:
     cpuSpriteRenderBW: 1 # Fixes half screen effects.
@@ -46187,7 +53480,9 @@ SLPS-25925:
   name: "NHL 2K9"
   region: "NTSC-J"
 SLPS-25927:
-  name: "Tomb Raider - Underworld"
+  name: "TOMB RAIDER: UNDERWORLD"
+  name-sort: "TOMB RAIDER: UNDERWORLD"
+  name-en: "Tomb Raider - Underworld"
   region: "NTSC-J"
   gsHWFixes:
     textureInsideRT: 1 # Needed for post processing effects.
@@ -46198,7 +53493,9 @@ SLPS-25929:
   name: "Little Anchor"
   region: "NTSC-J"
 SLPS-25930:
-  name: "Major League Baseball 2K9"
+  name: MLB 2K9(英語版)
+  name-sort: MLB 2K9(えいごばん)
+  name-en: "Major League Baseball 2K9"
   region: "NTSC-J"
 SLPS-25931:
   name: "Katekyoo Hitman Reborn! Nerae! Ring x Vongola Trainers [Best Collection]"
@@ -46211,10 +53508,14 @@ SLPS-25932:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
 SLPS-25934:
-  name: "Samurai Spirits - Rokuban Shoubu [NeoGeo Online Collection the Best]"
+  name: NEOGEOオンラインコレクション THE BEST サムライスピリッツ六番勝負
+  name-sort: NEOGEOおんらいんこれくしょん THE BEST さむらいすぴりっつろくばんしょうぶ
+  name-en: "Samurai Spirits - Rokuban Shoubu [NeoGeo Online Collection the Best]"
   region: "NTSC-J"
 SLPS-25935:
-  name: "King of Fighters '98 Ultimate Match, The [NeoGeo Online Collection the Best]"
+  name: NEOGEOオンラインコレクション THE BEST ザ・キング・オブ・ファイターズ'98 アルティメットマッチ
+  name-sort: NEOGEOおんらいんこれくしょん THE BEST ざ・きんぐ・おぶ・ふぁいたーず'98 あるてぃめっとまっち
+  name-en: "King of Fighters '98 Ultimate Match, The [NeoGeo Online Collection the Best]"
   region: "NTSC-J"
 SLPS-25936:
   name: "NeoGeo Online Collection Vol. 11 - Sunsoft Collection"
@@ -46241,7 +53542,9 @@ SLPS-25943:
   name: "Hisshou Pachinko Pachi-Slot Kouryaku Series Vol. 14 - CR Shin Seiki Evangelion - Saigo no Shisha [Gentei Special Box]"
   region: "NTSC-J"
 SLPS-25944:
-  name: "Kamen Rider Climax Heroes"
+  name: 仮面ライダー クライマックスヒーローズ
+  name-sort: かめんらいだー くらいまっくすひーろーず
+  name-en: "Kamen Rider Climax Heroes"
   region: "NTSC-J"
   compat: 5
 SLPS-25945:
@@ -46252,10 +53555,14 @@ SLPS-25945:
     textureInsideRT: 1 # Needed for post processing effects.
     minimumBlendingLevel: 4 # Fixes multiple lighting effects from lights, computers, cave walls and more.
 SLPS-25947:
-  name: "Summon Night Gran-These - Horobi no Ken to Yakusoku no Kishi"
+  name: サモンナイトグランテーゼ 滅びの剣と約束の騎士
+  name-sort: さもんないとぐらんてーぜ ほろびのけんとやくそくのきし
+  name-en: "Summon Night Gran-These - Horobi no Ken to Yakusoku no Kishi"
   region: "NTSC-J"
 SLPS-25948:
-  name: "Zero no Tsukaima - Maigo no Period to Ikusen no Symphony [Best Collection]"
+  name: ゼロの使い魔 迷子の終止符と幾千の交響曲 Best Collection
+  name-sort: ぜろのつかいま まいごのしゅうしふといくせんのこうきょうきょく Best Collection
+  name-en: "Zero no Tsukaima - Maigo no Period to Ikusen no Symphony [Best Collection]"
   region: "NTSC-J"
 SLPS-25950:
   name: "Bully [Best of Bethesda]"
@@ -46275,18 +53582,24 @@ SLPS-25955:
   name: "Moe Moe 2-Ji Taisen (Ryaku) 2"
   region: "NTSC-J"
 SLPS-25956:
-  name: "Moe Moe 2-ji Taisen Ryoku 2"
+  name: 萌え萌え2次大戦(略)2[chu〜♪]
+  name-sort: もえもえ2じたいせん(りゃく)2[chu〜♪]
+  name-en: "Moe Moe 2-ji Taisen Ryoku 2"
   region: "NTSC-J"
 SLPS-25958:
   name: "Last Escort - Club Katze"
   region: "NTSC-J"
 SLPS-25959:
-  name: "Kidou Senshi Gundam - Giren no Yabou - Axis no Kyoui V"
+  name: 機動戦士ガンダム ギレンの野望 アクシズの脅威V GUNDAM 30th ANNIVERSARY COLLECTION
+  name-sort: きどうせんしがんだむ ぎれんのやぼう あくしずのきょういV GUNDAM 30th ANNIVERSARY COLLECTION
+  name-en: "Kidou Senshi Gundam - Giren no Yabou - Axis no Kyoui V"
   region: "NTSC-J"
   gameFixes:
     - FpuNegDivHack
 SLPS-25961:
-  name: "Kidou Senshi Gundam SEED - Rengou vs. Z.A.F.T."
+  name: 機動戦士ガンダムSEED DESTINY 連合 vs. Z.A.F.T. II plus GUNDAM 30th ANNIVERSARY COLLECTION
+  name-sort: きどうせんしがんだむSEED DESTINY れんごう vs. Z.A.F.T. II plus GUNDAM 30th ANNIVERSARY COLLECTION
+  name-en: "Kidou Senshi Gundam SEED - Rengou vs. Z.A.F.T."
   region: "NTSC-K"
   roundModes:
     eeRoundMode: 1 # Fixes camera issue.
@@ -46329,7 +53642,9 @@ SLPS-25982:
   name: "Tir Na Nog - Yuukyuu no Jin"
   region: "NTSC-J"
 SLPS-25983:
-  name: "King of Fighters 2002, The - Unlimited Match"
+  name: THE KING OF FIGHTERS 2002 UNLIMITED MATCH 闘劇ver.
+  name-sort: THE KING OF FIGHTERS 2002 UNLIMITED MATCH とうげきver.
+  name-en: "King of Fighters 2002, The - Unlimited Match"
   region: "NTSC-J"
 SLPS-25987:
   name: "Amagami [EBKore+]"
@@ -46345,7 +53660,9 @@ SLPS-25989:
   gsHWFixes:
     roundSprite: 1 # Fixes character sprites.
 SLPS-29001:
-  name: "Xenosaga Episode 1 - Der Wille zur Macht [Premium Box]"
+  name: ゼノサーガ エピソードI 力への意志 プレミアムボックス
+  name-sort: ぜのさーが えぴそーどI ちからへのいし ぷれみあむぼっくす
+  name-en: "Xenosaga Episode 1 - Der Wille zur Macht [Premium Box]"
   region: "NTSC-J"
   gsHWFixes:
     autoFlush: 2 # Fixes shadows in cutscenes.
@@ -46369,7 +53686,9 @@ SLPS-29001:
         patch=1,EE,00285f60,word,2673ffff
         patch=1,EE,00285f64,word,00000000
 SLPS-29002:
-  name: "Xenosaga Episode 1 - Der Wille zur Macht"
+  name: ゼノサーガ エピソードI 力への意志
+  name-sort: ぜのさーが えぴそーどI ちからへのいし
+  name-en: "Xenosaga Episode 1 - Der Wille zur Macht"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
@@ -46394,14 +53713,18 @@ SLPS-29002:
         patch=1,EE,00285f60,word,2673ffff
         patch=1,EE,00285f64,word,00000000
 SLPS-29003:
-  name: "Lord of the Rings - The Two Towers [Collector's Box]"
+  name: ロード・オブ・ザ・リング 二つの塔 限定版
+  name-sort: ろーど・おぶ・ざ・りんぐ ふたつのとう げんていばん
+  name-en: "Lord of the Rings - The Two Towers [Collector's Box]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misaligned lighting and other effects.
   clampModes:
     vuClampMode: 3 # Fix white shiny weapons.
 SLPS-29004:
-  name: "Lord of the Rings, The - The Two Towers"
+  name: ロード・オブ・ザ・リング 二つの塔
+  name-sort: ろーど・おぶ・ざ・りんぐ ふたつのとう
+  name-en: "Lord of the Rings, The - The Two Towers"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
@@ -46409,7 +53732,9 @@ SLPS-29004:
   clampModes:
     vuClampMode: 3 # Fix white shiny weapons.
 SLPS-29005:
-  name: "Xenosaga Episode 1 - Der Wille zur Macht [Reloaded]"
+  name: ゼノサーガ エピソード I リローディッド [力への意志]
+  name-sort: ぜのさーが えぴそーど I りろーでぃっど [ちからへのいし]
+  name-en: "Xenosaga Episode 1 - Der Wille zur Macht [Reloaded]"
   region: "NTSC-J"
   gsHWFixes:
     autoFlush: 2 # Fixes shadows in cutscenes.
@@ -46424,77 +53749,113 @@ SLPS-71502:
   name: "Ridge Racer V"
   region: "NTSC-J"
 SLPS-72501:
-  name: "Final Fantasy X [Mega Hits]"
+  name: ファイナルファンタジーX MEGA HITS!
+  name-sort: ふぁいなるふぁんたじーX MEGA HITS!
+  name-en: "Final Fantasy X [Mega Hits]"
   region: "NTSC-J"
   roundModes:
     eeRoundMode: 1 # Fixes reverse control and boss in some places.
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
 SLPS-72502:
-  name: "Tales of Destiny 2 [Mega Hits]"
+  name: テイルズ・オブ・ディスティニー2 MEGA HITS!
+  name-sort: ているず・おぶ・でぃすてぃにー2 MEGA HITS!
+  name-en: "Tales of Destiny 2 [Mega Hits]"
   region: "NTSC-J"
 SLPS-73001:
   name: "Pilot ni Narou! 2"
   region: "NTSC-J"
 SLPS-73003:
-  name: "Farms Story 3 [PlayStation 2 The Best]"
+  name: 牧場物語3 ハートに火をつけて PlayStation 2 the Best
+  name-sort: ぼくじょうものがたり3 はーとにひをつけて PlayStation 2 the Best
+  name-en: "Farms Story 3 [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPS-73004:
   name: "Gambler Densetsu Tetsuya"
   region: "NTSC-J"
 SLPS-73005:
-  name: "Guilty Gear X - Plus [PlayStation 2 The Best]"
+  name: ギルティギアゼクスプラス PlayStation 2 the Best
+  name-sort: ぎるてぃぎあぜくすぷらす PlayStation 2 the Best
+  name-en: "Guilty Gear X - Plus [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPS-73006:
-  name: "Time Crisis II [PlayStation 2 The Best]"
+  name: タイムクライシス2 PlayStation 2 the Best
+  name-sort: たいむくらいしす2 PlayStation 2 the Best
+  name-en: "Time Crisis II [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPS-73007:
   name: "Kamaitachi no Yoru 2 - Kangoku-jima no Warabe-uta - Special Eizou"
   region: "NTSC-J"
 SLPS-73101:
-  name: "Kotoba no Puzzle - Mojipittan [PlayStation 2 The Best]"
+  name: ことばのパズル もじぴったん PlayStation 2 the Best
+  name-sort: ことばのぱずる もじぴったん PlayStation 2 the Best
+  name-en: "Kotoba no Puzzle - Mojipittan [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPS-73102:
-  name: "Bokujou Monogatari 3 - Heart ni Hi o Tsukete [PlayStation 2 The Best]"
+  name: 牧場物語3 ～ハートに火をつけて PlayStation®2 the Best
+  name-sort: ぼくじょうものがたり3 ～はーとにひをつけて PlayStation®2 the Best
+  name-en: "Bokujou Monogatari 3 - Heart ni Hi o Tsukete [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPS-73103:
-  name: "Makai Senki Disgaea [PlayStation 2 The Best]"
+  name: 魔界戦記ディスガイア PlayStation®2 the Best
+  name-sort: まかいせんきでぃすがいあ PlayStation®2 the Best
+  name-en: "Makai Senki Disgaea [PlayStation 2 The Best]"
   region: "NTSC-J"
   compat: 5
 SLPS-73104:
-  name: "Tekken Tag Tournament [PlayStation 2 The Best]"
+  name: 鉄拳タッグトーナメント PlayStation®2 the Best
+  name-sort: てっけんたっぐとーなめんと PlayStation®2 the Best
+  name-en: "Tekken Tag Tournament [PlayStation 2 The Best]"
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
 SLPS-73105:
-  name: "Kinnikuman Generations [PlayStation 2 The Best]"
+  name: キン肉マン ジェネレーションズ PlayStation®2 the Best
+  name-sort: きんにくまん じぇねれーしょんず PlayStation®2 the Best
+  name-en: "Kinnikuman Generations [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPS-73106:
-  name: "Pilot Nina Rou! 2 [PlayStation 2 The Best]"
+  name: パイロットになろう!2 PlayStation®2 the Best
+  name-sort: ぱいろっとになろう!2 PlayStation®2 the Best
+  name-en: "Pilot Nina Rou! 2 [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPS-73107:
-  name: "Taiko no Tatsujin - Go! Go! Godaime [PlayStation 2 The Best]"
+  name: 太鼓の達人 ゴー!ゴー!五代目 PlayStation 2 the Best
+  name-sort: たいこのたつじん ごー!ごー!ごだいめ PlayStation 2 the Best
+  name-en: "Taiko no Tatsujin - Go! Go! Godaime [PlayStation 2 The Best]"
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
 SLPS-73108:
-  name: "Phantom Brave [PlayStation 2 The Best]"
+  name: ファントム・ブレイブ 2周目はじめました。 PlayStation 2 the Best
+  name-sort: ふぁんとむ・ぶれいぶ 2しゅうめはじめました。 PlayStation 2 the Best
+  name-en: "Phantom Brave [PlayStation 2 The Best]"
   region: "NTSC-J"
   compat: 5
 SLPS-73109:
-  name: "Bokujou Monogatari 3 - Heart ni Hi o Tsukete [PlayStation 2 The Best]"
+  name: 牧場物語3〜 ハートに火をつけて PlayStation®2 the Best
+  name-sort: ぼくじょうものがたり3〜 はーとにひをつけて PlayStation®2 the Best
+  name-en: "Bokujou Monogatari 3 - Heart ni Hi o Tsukete [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPS-73110:
-  name: "Taiko no Tatsujin - Appare Sandaime [PlayStation 2 The Best]"
+  name: 太鼓の達人 あっぱれ三代目 PlayStation®2 the Best
+  name-sort: たいこのたつじん あっぱれさんだいめ PlayStation®2 the Best
+  name-en: "Taiko no Tatsujin - Appare Sandaime [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPS-73111:
-  name: "Taiko no Tatsujin - Waku Waku Anime Matsuri [PlayStation 2 The Best]"
+  name: 太鼓の達人 わくわくアニメ祭り PlayStation®2 the Best
+  name-sort: たいこのたつじん わくわくあにめまつり PlayStation®2 the Best
+  name-en: "Taiko no Tatsujin - Waku Waku Anime Matsuri [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPS-73201:
-  name: "Fatal Frame II - Crimson Butterfly [PlayStation 2 The Best]"
+  name: 零～紅い蝶～ PlayStation®2 the Best
+  name-sort: れい～あかいちょう～ PlayStation®2 the Best
+  name-en: "Fatal Frame II - Crimson Butterfly [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPS-73202:
-  name: "Armored Core - Nexus [Disc 1] [PlayStation 2 The Best]"
+  name: ARMORED CORE NEXUS PlayStation®2 the Best
+  name-sort: ARMORED CORE NEXUS PlayStation®2 the Best
+  name-en: "Armored Core - Nexus [Disc 1] [PlayStation 2 The Best]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
@@ -46520,12 +53881,16 @@ SLPS-73203:
     - "SLPS-73202"
     - "SLPS-73203"
 SLPS-73204:
-  name: "Zettai Zetsumei Toshi [PlayStation 2 The Best]"
+  name: 絶体絶命都市 PlayStation®2 the Best
+  name-sort: ぜったいぜつめいとし PlayStation®2 the Best
+  name-en: "Zettai Zetsumei Toshi [PlayStation 2 The Best]"
   region: "NTSC-J"
   gsHWFixes:
     autoFlush: 2 # Fixes incorrect blur effect.
 SLPS-73205:
-  name: "Ace Combat 04 - Shattered Skies [PlayStation 2 The Best]"
+  name: エースコンバット04 シャッタードスカイ PlayStation®2 the Best
+  name-sort: えーすこんばっと04 しゃったーどすかい PlayStation®2 the Best
+  name-en: "Ace Combat 04 - Shattered Skies [PlayStation 2 The Best]"
   region: "NTSC-J"
   gameFixes:
     - SoftwareRendererFMVHack # Fixes FMVs disabling hash cache.
@@ -46537,23 +53902,33 @@ SLPS-73205:
     mergeSprite: 1 # Fixes vertical lines.
     gpuTargetCLUT: 1 # Fixes broken sun.
 SLPS-73206:
-  name: "Super Robot Taisen Alpha 2nd [PlayStation 2 The Best]"
+  name: 第2次スーパーロボット大戦α PlayStation®2 the Best
+  name-sort: だい2じすーぱーろぼっとたいせんあるふぁ PlayStation®2 the Best
+  name-en: "Super Robot Taisen Alpha 2nd [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPS-73207:
-  name: "Dragon Ball Z [PlayStation 2 The Best]"
+  name: ドラゴンボールZ PlayStation®2 the Best
+  name-sort: どらごんぼーるZ PlayStation®2 the Best
+  name-en: "Dragon Ball Z [PlayStation 2 The Best]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes lines when powering up.
 SLPS-73208:
-  name: "Dragon Ball Z 2 [PlayStation 2 The Best]"
+  name: ドラゴンボールZ2 PlayStation®2 the Best
+  name-sort: どらごんぼーるZ2 PlayStation®2 the Best
+  name-en: "Dragon Ball Z 2 [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPS-73209:
-  name: "Tekken 4 [PlayStation 2 The Best]"
+  name: 鉄拳4 PlayStation®2 the Best
+  name-sort: てっけん4 PlayStation®2 the Best
+  name-en: "Tekken 4 [PlayStation 2 The Best]"
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
 SLPS-73210:
-  name: "Katamari Damacy [PlayStation 2 The Best]"
+  name: 塊魂 PlayStation®2 the Best
+  name-sort: かたまりたましい PlayStation®2 the Best
+  name-en: "Katamari Damacy [PlayStation 2 The Best]"
   region: "NTSC-J"
   roundModes:
     vu1RoundMode: 0 # Fixes SPS.
@@ -46562,13 +53937,19 @@ SLPS-73210:
   speedHacks:
     mvuFlag: 0 # Fixes performance and falling through floor and other gameplay.
 SLPS-73211:
-  name: "Summon Night 3 [PlayStation 2 The Best]"
+  name: サモンナイト3 PlayStation®2 the Best
+  name-sort: さもんないと3 PlayStation®2 the Best
+  name-en: "Summon Night 3 [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPS-73212:
-  name: "Naruto Narutimett Hero [PlayStation 2 The Best]"
+  name: NARUTO -ナルト-ナルティメットヒーロー PlayStation®2 the Best
+  name-sort: NARUTO -なると-なるてぃめっとひーろー PlayStation®2 the Best
+  name-en: "Naruto Narutimett Hero [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPS-73214:
-  name: "Shadow Hearts 2 [Director's Cut] [PlayStation 2 The Best] [Disc 1 of 2]"
+  name: シャドウ ハーツ II ディレクターズカット PlayStation®2 the Best
+  name-sort: しゃどう はーつ II でぃれくたーずかっと PlayStation®2 the Best
+  name-en: "Shadow Hearts 2 [Director's Cut] [PlayStation 2 The Best] [Disc 1 of 2]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurrines, preload frame for FMV breaks visuals with this setting.
@@ -46586,16 +53967,22 @@ SLPS-73215:
   memcardFilters:
     - "SLPS-73214"
 SLPS-73216:
-  name: "Magna Carta [PlayStation 2 The Best]"
+  name: マグナカルタ PlayStation®2 the Best
+  name-sort: まぐなかるた PlayStation®2 the Best
+  name-en: "Magna Carta [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPS-73217:
-  name: "Tales of Symphonia [PlayStation 2 The Best]"
+  name: テイルズ オブ シンフォニア PlayStation®2 the Best
+  name-sort: ているず おぶ しんふぉにあ PlayStation®2 the Best
+  name-en: "Tales of Symphonia [PlayStation 2 The Best]"
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
     getSkipCount: "GSC_TalesofSymphonia"
 SLPS-73218:
-  name: "Ace Combat 5 - The Unsung War [PlayStation 2 The Best]"
+  name: エースコンバット5 ジ・アンサング・ウォー PlayStation®2 the Best
+  name-sort: えーすこんばっと5 じ・あんさんぐ・うぉー PlayStation®2 the Best
+  name-en: "Ace Combat 5 - The Unsung War [PlayStation 2 The Best]"
   region: "NTSC-J"
   gameFixes:
     - SoftwareRendererFMVHack # Fixes FMVs disabling hash cache.
@@ -46608,22 +53995,32 @@ SLPS-73218:
     mergeSprite: 1 # Fixes vertical lines.
     cpuCLUTRender: 1 # Fixes sun occlusion.
 SLPS-73219:
-  name: "Tales of Destiny 2 [PlayStation 2 The Best]"
+  name: テイルズ・オブ・ディスティニー2 PlayStation®2 the Best
+  name-sort: ているず・おぶ・でぃすてぃにー2 PlayStation®2 the Best
+  name-en: "Tales of Destiny 2 [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPS-73220:
-  name: "Ultraman [PlayStation 2 The Best]"
+  name: ウルトラマン PlayStation®2 the Best
+  name-sort: うるとらまん PlayStation®2 the Best
+  name-en: "Ultraman [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPS-73221:
-  name: "Naruto Narutimett Hero 2 [PlayStation 2 The Best]"
+  name: NARUTO -ナルト-ナルティメットヒーロー2 PlayStation®2 the Best
+  name-sort: NARUTO -なると-なるてぃめっとひーろー2 PlayStation®2 the Best
+  name-en: "Naruto Narutimett Hero 2 [PlayStation 2 The Best]"
   region: "NTSC-J"
   clampModes:
     vu0ClampMode: 0 # Fixes glow effects.
     vu1ClampMode: 3 # Fixes rare SPS.
 SLPS-73222:
-  name: "Harvest Moon - A Wonderful Life [PlayStation 2 The Best]"
+  name: 牧場物語 Oh!ワンダフルライフ PlayStation®2 the Best
+  name-sort: ぼくじょうものがたり Oh!わんだふるらいふ PlayStation®2 the Best
+  name-en: "Harvest Moon - A Wonderful Life [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPS-73223:
-  name: "Tekken 5 [PlayStation 2 The Best]"
+  name: 鉄拳5 PlayStation®2 the Best
+  name-sort: てっけん5 PlayStation®2 the Best
+  name-en: "Tekken 5 [PlayStation 2 The Best]"
   region: "NTSC-J"
   clampModes:
     eeClampMode: 2 # Fixes camera and stops constant coin noises on Pirates Cove.
@@ -46631,7 +54028,9 @@ SLPS-73223:
     alignSprite: 1 # Fixes vertical lines.
     getSkipCount: "GSC_Tekken5"
 SLPS-73224:
-  name: "Xenosaga Episode II - Jenseits von Gut und Bose [PlayStation 2 The Best] [Disc 1 of 2]"
+  name: ゼノサーガ エピソードII［善悪の彼岸］ PlayStation®2 the Best
+  name-sort: ぜのさーが えぴそーどII［ぜんあくのひがん］ PlayStation®2 the Best
+  name-en: "Xenosaga Episode II - Jenseits von Gut und Bose [PlayStation 2 The Best] [Disc 1 of 2]"
   region: "NTSC-J"
   gsHWFixes:
     autoFlush: 2 # Fixes shadows in cutscenes.
@@ -46659,19 +54058,27 @@ SLPS-73225:
     - "SLPS-25353"
     - "SLPS-73224"
 SLPS-73226:
-  name: "Tenchu Kurenai [PlayStation 2 The Best]"
+  name: 天誅 紅 PlayStation®2 the Best
+  name-sort: てんちゅう くれない PlayStation®2 the Best
+  name-en: "Tenchu Kurenai [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPS-73227:
-  name: "Another Century's Episode [PlayStation 2 The Best]"
+  name: Another Century’s Episode PlayStation®2 the Best
+  name-sort: Another Century’s Episode PlayStation®2 the Best
+  name-en: "Another Century's Episode [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPS-73228:
   name: "Fuuun Bakumatsuden [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPS-73229:
-  name: "TearRing Saga Series - Berwick Saga [PlayStation 2 The Best]"
+  name: ベルウィックサーガ PlayStation®2 the Best
+  name-sort: べるうぃっくさーが PlayStation®2 the Best
+  name-en: "TearRing Saga Series - Berwick Saga [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPS-73230:
-  name: "dot hack - Vol.1 & Vol.2 [PlayStation 2 The Best] [Vol.1 Disc]"
+  name: .hack// Vol.1×Vol.2 PlayStation 2 the Best
+  name-sort: .hack// Vol.1×Vol.2 PlayStation 2 the Best
+  name-en: "dot hack - Vol.1 & Vol.2 [PlayStation 2 The Best] [Vol.1 Disc]"
   region: "NTSC-J"
   memcardFilters:
     - "SCPS-55029"
@@ -46703,7 +54110,9 @@ SLPS-73231:
     - "SLPS-73232"
     - "SLPS-73233"
 SLPS-73232:
-  name: "dot hack - Vol.3 & Vol.4 [PlayStation 2 The Best] [Vol.3 Disc]"
+  name: .hack// Vol.3×Vol.4 PlayStation 2 the Best
+  name-sort: .hack// Vol.3×Vol.4 PlayStation 2 the Best
+  name-en: "dot hack - Vol.3 & Vol.4 [PlayStation 2 The Best] [Vol.3 Disc]"
   region: "NTSC-J"
   memcardFilters:
     - "SCPS-55029"
@@ -46735,25 +54144,39 @@ SLPS-73233:
     - "SLPS-73232"
     - "SLPS-73233"
 SLPS-73234:
-  name: "Kidou Senshi Z-Gundam - AEUG vs. Titans [PlayStation 2 The Best]"
+  name: 機動戦士Zガンダム エゥーゴVS.ティターンズ PlayStation®2 the Best
+  name-sort: きどうせんしZがんだむ えぅーごVS.てぃたーんず PlayStation®2 the Best
+  name-en: "Kidou Senshi Z-Gundam - AEUG vs. Titans [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPS-73235:
-  name: "Dragon Ball Z 3 [PlayStation 2 The Best]"
+  name: ドラゴンボールZ3 PlayStation®2 the Best
+  name-sort: どらごんぼーるZ3 PlayStation®2 the Best
+  name-en: "Dragon Ball Z 3 [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPS-73236:
-  name: "Venus & Braves [PlayStation 2 The Best]"
+  name: ヴィーナスアンドブレイブス〜魔女と女神と滅びの予言〜 PlayStation®2 the Best
+  name-sort: ゔぃーなすあんどぶれいぶす〜まじょとめがみとほろびのよげん〜 PlayStation®2 the Best
+  name-en: "Venus & Braves [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPS-73237:
-  name: "Tenchu San [PlayStation 2 The Best]"
+  name: 天誅 参 PlayStation®2 the Best
+  name-sort: てんちゅう さん PlayStation®2 the Best
+  name-en: "Tenchu San [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPS-73238:
-  name: "Super Robot Wars - Alpha 3 [PlayStation 2 The Best]"
+  name: 第3次スーパーロボット大戦α -終焉の銀河へー PlayStation 2 the Best
+  name-sort: だい3じすーぱーろぼっとたいせんあるふぁ -しゅうえんのぎんがへー PlayStation 2 the Best
+  name-en: "Super Robot Wars - Alpha 3 [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPS-73239:
-  name: "Yu Yu Hakusho Forever [PlayStation 2 The Best]"
+  name: 幽★遊★白書 FOREVER PlayStation 2 the Best
+  name-sort: ゆう★ゆう★はくしょ FOREVER PlayStation 2 the Best
+  name-en: "Yu Yu Hakusho Forever [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPS-73240:
-  name: "Katamari Damacy [PlayStation 2 The Best]"
+  name: 塊魂 PlayStation 2 the Best
+  name-sort: かたまりたましい PlayStation 2 the Best
+  name-en: "Katamari Damacy [PlayStation 2 The Best]"
   region: "NTSC-J"
   roundModes:
     vu1RoundMode: 0 # Fixes SPS.
@@ -46762,7 +54185,9 @@ SLPS-73240:
   speedHacks:
     mvuFlag: 0 # Fixes performance and falling through floor and other gameplay.
 SLPS-73241:
-  name: "Minna Daisuki Katamari Damacy [PlayStation 2 The Best]"
+  name: みんな大好き塊魂 PlayStation 2 the Best
+  name-sort: みんなだいすきかたまりたましい PlayStation 2 the Best
+  name-en: "Minna Daisuki Katamari Damacy [PlayStation 2 The Best]"
   region: "NTSC-J"
   roundModes:
     vu1RoundMode: 0 # Fixes SPS.
@@ -46779,25 +54204,37 @@ SLPS-73241:
     - "SLPS-73210"
     - "SLPS-73240"
 SLPS-73242:
-  name: "Tales of Legendia [PlayStation 2 The Best]"
+  name: テイルズ オブ レジェンディア PlayStation 2 the Best
+  name-sort: ているず おぶ れじぇんでぃあ PlayStation 2 the Best
+  name-en: "Tales of Legendia [PlayStation 2 The Best]"
   region: "NTSC-J"
   gsHWFixes:
     getSkipCount: "GSC_TalesOfLegendia"
 SLPS-73243:
-  name: "Namco X Capcom [PlayStation 2 The Best]"
+  name: ナムコ クロス カプコン PlayStation 2 the Best
+  name-sort: なむこ くろす かぷこん PlayStation 2 the Best
+  name-en: "Namco X Capcom [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPS-73244:
-  name: "R-Type Final [PlayStation 2 The Best]"
+  name: R・TYPE FINAL PlayStation®2 the Best
+  name-sort: R・TYPE FINAL PlayStation®2 the Best
+  name-en: "R-Type Final [PlayStation 2 The Best]"
   region: "NTSC-J"
   compat: 5
 SLPS-73245:
-  name: "Fatal Frame - Zero [PlayStation 2 The Best]"
+  name: 零 〜刺青の聲〜 PlayStation 2 the Best
+  name-sort: ぜろ 〜しせいのこえ〜 PlayStation 2 the Best
+  name-en: "Fatal Frame - Zero [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPS-73246:
-  name: "Gundam True Odyssey [PlayStation 2 The Best]"
+  name: ガンダム トゥルーオデッセイ 〜失われしGの伝説〜 PlayStation 2 the Best
+  name-sort: がんだむ とぅるーおでっせい 〜うしなわれしGのでんせつ〜 PlayStation 2 the Best
+  name-en: "Gundam True Odyssey [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPS-73247:
-  name: "Armored Core - Last Raven [PlayStation 2 The Best]"
+  name: ARMORED CORE -LAST RAVEN- PlayStation 2 the Best
+  name-sort: ARMORED CORE -LAST RAVEN- PlayStation 2 the Best
+  name-en: "Armored Core - Last Raven [PlayStation 2 The Best]"
   region: "NTSC-J"
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes glow effects, but breaks shadows of certain objects.
@@ -46813,15 +54250,21 @@ SLPS-73247:
     - "SLPS-25462"
     - "SLPS-73247"
 SLPS-73248:
-  name: "Kagero 2 - Dark Illusion [PlayStation 2 The Best]"
+  name: 影牢II -Dark illusion- PlayStation®2 the Best
+  name-sort: かげろうII -Dark illusion- PlayStation®2 the Best
+  name-en: "Kagero 2 - Dark Illusion [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPS-73249:
-  name: "Ar tonelico - Sekai no Owari de Utai Tsuzukeru Shoujo [PlayStation 2 The Best]"
+  name: アルトネリコ 世界の終わりで詩い続ける少女 PlayStation 2 the Best
+  name-sort: あるとねりこ せかいのおわりでしいつづけるしょうじょ PlayStation 2 the Best
+  name-en: "Ar tonelico - Sekai no Owari de Utai Tsuzukeru Shoujo [PlayStation 2 The Best]"
   region: "NTSC-J"
   gsHWFixes:
     roundSprite: 1 # Fixes vertical lines in FMVs, character portraits and other sprites.
 SLPS-73250:
-  name: "Ace Combat Zero - The Belkan War [PlayStation 2 The Best]"
+  name: エースコンバット・ゼロ・ザ・ベルカン・ウォー PlayStation 2 the Best
+  name-sort: えーすこんばっと・ぜろ・ざ・べるかん・うぉー PlayStation 2 the Best
+  name-en: "Ace Combat Zero - The Belkan War [PlayStation 2 The Best]"
   region: "NTSC-J"
   gameFixes:
     - SoftwareRendererFMVHack # Fixes FMVs disabling hash cache.
@@ -46844,48 +54287,66 @@ SLPS-73250:
     - "SLPS-25418"
     - "SLPS-73218"
 SLPS-73251:
-  name: "Naruto - Narutimett Hero 3 [PlayStation 2 The Best]"
+  name: NARUTO-ナルト-ナルティメットヒーロー3 PlayStation®2 the Best
+  name-sort: NARUTO-なると-なるてぃめっとひーろー3 PlayStation®2 the Best
+  name-en: "Naruto - Narutimett Hero 3 [PlayStation 2 The Best]"
   region: "NTSC-J"
   clampModes:
     vuClampMode: 2 # Fixes invisible QTE button prompts and overbright in some scenes.
   gameFixes:
     - SoftwareRendererFMVHack # Fixes vertical lines in FMVs.
 SLPS-73252:
-  name: "Tales of the Abyss [PlayStation 2 The Best]"
+  name: テイルズ オブ ジ アビス PlayStation 2 the Best
+  name-sort: ているず おぶ じ あびす PlayStation 2 the Best
+  name-en: "Tales of the Abyss [PlayStation 2 The Best]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
     autoFlush: 2 # Fixes post lighting.
 SLPS-73253:
-  name: "Rurouni Kenshin - Enjou! Kyoto Rinne [PlayStation 2 The Best]"
+  name: るろうに剣心-明治剣客浪漫譚- 炎上!京都輪廻 PlayStation2 the Best
+  name-sort: るろうにけんしん-めいじけんかくろまんたん- えんじょう!きょうとりんね PlayStation2 the Best
+  name-en: "Rurouni Kenshin - Enjou! Kyoto Rinne [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPS-73254:
-  name: "Makai Senki Disgaea [PlayStation 2 The Best]"
+  name: 魔界戦記ディスガイア2 PlayStation 2 the Best
+  name-sort: まかいせんきでぃすがいあ2 PlayStation 2 the Best
+  name-en: "Makai Senki Disgaea [PlayStation 2 The Best]"
   region: "NTSC-J"
   gameFixes:
     - SoftwareRendererFMVHack # Fixes flickering FMV's.
 SLPS-73255:
-  name: "Fatal Frame [PlayStation 2 the Best - Reprint]"
+  name: 零〜zero〜 PlayStation 2 the Best
+  name-sort: ぜろ〜zero〜 PlayStation 2 the Best
+  name-en: "Fatal Frame [PlayStation 2 the Best - Reprint]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Reduces blurriness.
     alignSprite: 1 # Fixes vertical lines on hidden ghosts.
 SLPS-73256:
-  name: "Fatal Frame II - Crimson Butterfly [PlayStation 2 the Best - Reprint]"
+  name: 零〜紅い蝶〜 PlayStation 2 the Best
+  name-sort: ぜろ〜あかいちょう〜 PlayStation 2 the Best
+  name-en: "Fatal Frame II - Crimson Butterfly [PlayStation 2 the Best - Reprint]"
   region: "NTSC-J"
 SLPS-73257:
-  name: "Fatal Frame III - The Tormented [PlayStation 2 the Best - Reprint]"
+  name: 零〜刺青の聲〜 PlayStation 2 the Best
+  name-sort: ぜろ〜しせいのこえ〜 PlayStation 2 the Best
+  name-en: "Fatal Frame III - The Tormented [PlayStation 2 the Best - Reprint]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 1 # Reduces blurriness.
 SLPS-73258:
-  name: "Kenka Banchou 2 - Full Throttle [PlayStation 2 The Best]"
+  name: 喧嘩番長2 〜フルスロットル〜 PlayStation®2 the Best
+  name-sort: けんかばんちょう2 〜ふるすろっとる〜 PlayStation®2 the Best
+  name-en: "Kenka Banchou 2 - Full Throttle [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPS-73259:
   name: "Dot Hack G.U. Vol. 1 - Saitan"
   region: "NTSC-J"
 SLPS-73263:
-  name: "Ar tonelico II - Sekai ni Hibiku Shoujo-Tachi no Metafalica [PlayStation 2 The Best]"
+  name: アルトネリコ2 世界に響く少女たちの創造詩 PlayStation 2 the Best
+  name-sort: あるとねりこ2 せかいにひびくしょうじょたちのそうぞうし PlayStation 2 the Best
+  name-en: "Ar tonelico II - Sekai ni Hibiku Shoujo-Tachi no Metafalica [PlayStation 2 The Best]"
   region: "NTSC-J"
   roundModes:
     eeRoundMode: 0 # Fixes "Fall through floor" bug when approaching chests.
@@ -46905,7 +54366,9 @@ SLPS-73267:
   name: "Dot Hack G.U. Vol. 3 - Aruku You na Hayasa de"
   region: "NTSC-J"
 SLPS-73269:
-  name: "Kidou Senshi Gundam SEED - Rengou vs. Z.A.F.T."
+  name: 機動戦士ガンダムSEED DESTINY 連合VS. Z.A.F.T. II PLUS PlayStation®2 the Best
+  name-sort: きどうせんしがんだむSEED DESTINY れんごうVS. Z.A.F.T. II PLUS PlayStation®2 the Best
+  name-en: "Kidou Senshi Gundam SEED - Rengou vs. Z.A.F.T."
   region: "NTSC-K"
   roundModes:
     eeRoundMode: 1 # Fixes camera issue.
@@ -46915,21 +54378,29 @@ SLPS-73270:
   name: "Super Robot Taisen Z [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPS-73401:
-  name: "Victorious Boxers - Championship Edition [PlayStation 2 The Best]"
+  name: はじめの一歩 VICTORIOUS BOXERS 〜CHAMPIONSHIP VERSION〜 PlayStation 2 the Best
+  name-sort: はじめのいちほ VICTORIOUS BOXERS 〜CHAMPIONSHIP VERSION〜 PlayStation 2 the Best
+  name-en: "Victorious Boxers - Championship Edition [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPS-73402:
-  name: "Shutokou Battle 0 [PlayStation 2 The Best]"
+  name: 首都高バトル0 PlayStation 2 the Best
+  name-sort: しゅとこうばとる0 PlayStation 2 the Best
+  name-en: "Shutokou Battle 0 [PlayStation 2 The Best]"
   region: "NTSC-J"
   compat: 5
 SLPS-73403:
-  name: "Armored Core 2 [PlayStation 2 The Best]"
+  name: ARMORED CORE2 PlayStation 2 the Best
+  name-sort: ARMORED CORE2 PlayStation 2 the Best
+  name-en: "Armored Core 2 [PlayStation 2 The Best]"
   region: "NTSC-J"
   clampModes:
     eeClampMode: 2 # Fixes Abnormal AI behavior.
   gsHWFixes:
     textureInsideRT: 1 # Fixes texture corruption.
 SLPS-73404:
-  name: "Klonoa 2 [PlayStation 2 The Best]"
+  name: 風のクロノア2〜世界が望んだ忘れもの〜PlayStation 2 the Best
+  name-sort: かぜのくろのあ2〜せかいがのぞんだわすれもの〜PlayStation 2 the Best
+  name-en: "Klonoa 2 [PlayStation 2 The Best]"
   region: "NTSC-J"
   clampModes:
     eeClampMode: 3 # Objects appear in wrong places without it.
@@ -46939,17 +54410,23 @@ SLPS-73404:
   gsHWFixes:
     cpuCLUTRender: 1 # Fixes shadows, object and enemy colours, platform transitions.
 SLPS-73405:
-  name: "Zero [PlayStation 2 The Best]"
+  name: 零〜zero〜 PlayStation 2 the Best
+  name-sort: ぜろ〜zero〜 PlayStation 2 the Best
+  name-en: "Zero [PlayStation 2 The Best]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Reduces blurriness.
     alignSprite: 1 # Fixes vertical lines on hidden ghosts.
 SLPS-73406:
-  name: "DOA 2 - Hardcore [PlayStation 2 The Best]"
+  name: DOA2 HARD・CORE PlayStation 2 the Best
+  name-sort: DOA2 HARD・CORE PlayStation 2 the Best
+  name-en: "DOA 2 - Hardcore [PlayStation 2 The Best]"
   region: "NTSC-J"
   compat: 5
 SLPS-73407:
-  name: "Sidewinder MAX [PlayStation 2 The Best]"
+  name: サイドワインダーMAX PlayStation 2 the Best
+  name-sort: さいどわいんだーMAX PlayStation 2 the Best
+  name-en: "Sidewinder MAX [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPS-73408:
   name: "7 (Seven) - Molmorth no Kiheitai [PlayStation 2 the Best]"
@@ -46958,7 +54435,9 @@ SLPS-73409:
   name: "Exciting Pro Wres 3"
   region: "NTSC-J"
 SLPS-73410:
-  name: "Ace Combat 04 - Shattered Skies [PlayStation 2 The Best]"
+  name: エースコンバット04 シャッタードスカイ PlayStation 2 the Best
+  name-sort: えーすこんばっと04 しゃったーどすかい PlayStation 2 the Best
+  name-en: "Ace Combat 04 - Shattered Skies [PlayStation 2 The Best]"
   region: "NTSC-J"
   gameFixes:
     - SoftwareRendererFMVHack # Fixes FMVs disabling hash cache.
@@ -46981,35 +54460,49 @@ SLPS-73411:
     - "SLPS-73403"
     - "SLPS-73411"
 SLPS-73412:
-  name: "Vampire Night [PlayStation 2 The Best]"
+  name: ヴァンパイアナイト PlayStation 2 the Best
+  name-sort: ゔぁんぱいあないと PlayStation 2 the Best
+  name-en: "Vampire Night [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPS-73413:
   name: "Kamaitachi no Yoru 2 - Kangoku-jima no Warabe-uta"
   region: "NTSC-J"
 SLPS-73415:
-  name: "Gallop Racer 6 - Revolution [PlayStation 2 The Best]"
+  name: Gallop Racer 6 -Revolution- PlayStation®2 the Best
+  name-sort: Gallop Racer 6 -Revolution- PlayStation®2 the Best
+  name-en: "Gallop Racer 6 - Revolution [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPS-73416:
-  name: "Super Robot Wars - Impact [PlayStation 2 The Best]"
+  name: スーパーロボット大戦IMPACT PlayStation®2 the Best
+  name-sort: すーぱーろぼっとたいせんIMPACT PlayStation®2 the Best
+  name-en: "Super Robot Wars - Impact [PlayStation 2 The Best]"
   region: "NTSC-J"
   gsHWFixes:
     estimateTextureRegion: 1 # Reduces hash cache size.
 SLPS-73417:
-  name: "Armored Core 3 [PlayStation 2 The Best]"
+  name: ARMORED CORE 3 PlayStation 2 the Best
+  name-sort: ARMORED CORE 3 PlayStation 2 the Best
+  name-en: "Armored Core 3 [PlayStation 2 The Best]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Corrects positioning of reflections on suit's surfaces.
     roundSprite: 2 # Reduces garbage on the UI whilst upscaling.
 SLPS-73418:
-  name: "Shadow Hearts [PlayStation 2 The Best]"
+  name: シャドウハーツ PlayStation® 2 the Best
+  name-sort: しゃどうはーつ PlayStation® 2 the Best
+  name-en: "Shadow Hearts [PlayStation 2 The Best]"
   region: "NTSC-J"
   clampModes:
     eeClampMode: 3 # Fixes invisible characters in various scenes.
 SLPS-73419:
-  name: "Lupin III - Majutsu-Ou no Isan [PlayStation 2 The Best]"
+  name: ルパン三世 魔術王の遺産 PlayStation 2 the Best
+  name-sort: るぱんさんせい まじゅつおうのいさん PlayStation 2 the Best
+  name-en: "Lupin III - Majutsu-Ou no Isan [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPS-73420:
-  name: "Armored Core 3 - Silent Line [PlayStation 2 The Best]"
+  name: ARMORED CORE 3 SILENT LINE PlayStation 2 the Best
+  name-sort: ARMORED CORE 3 SILENT LINE PlayStation 2 the Best
+  name-en: "Armored Core 3 - Silent Line [PlayStation 2 The Best]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Corrects positioning of reflections on suit's surfaces.
@@ -47021,22 +54514,32 @@ SLPS-73420:
     - "SLPS-73417"
     - "SLPS-73420"
 SLPS-73421:
-  name: "Tenchu 3 [PlayStation 2 The Best]"
+  name: 天誅 参 PlayStation 2 the Best
+  name-sort: てんちゅう さん PlayStation 2 the Best
+  name-en: "Tenchu 3 [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPS-73422:
-  name: "Ultraman Fighting Evolution 2 [PlayStation 2 The Best]"
+  name: ウルトラマン ファイティングエボリューション2 PlayStation 2 the Best
+  name-sort: うるとらまん ふぁいてぃんぐえぼりゅーしょん2 PlayStation 2 the Best
+  name-en: "Ultraman Fighting Evolution 2 [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPS-73423:
-  name: "Monster Farm 4 [PlayStation 2 The Best]"
+  name: モンスターファーム4 PlayStation 2 the Best
+  name-sort: もんすたーふぁーむ4 PlayStation 2 the Best
+  name-en: "Monster Farm 4 [PlayStation 2 The Best]"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
     halfPixelOffset: 1 # Corrects shadow misalignment.
 SLPS-73424:
-  name: "Guilty Gear XX [PlayStation 2 The Best]"
+  name: GUILTY GEAR XX PlayStation 2 the Best
+  name-sort: GUILTY GEAR XX PlayStation 2 the Best
+  name-en: "Guilty Gear XX [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPS-73901:
-  name: "Xenosaga Episode 1 - Der Wille zur Macht [PlayStation 2 The Best]"
+  name: ゼノサーガ エピソードI 力への意志 PlayStation 2 the Best
+  name-sort: ぜのさーが えぴそーどI ちからへのいし PlayStation 2 the Best
+  name-en: "Xenosaga Episode 1 - Der Wille zur Macht [PlayStation 2 The Best]"
   region: "NTSC-J"
   gsHWFixes:
     autoFlush: 2 # Fixes shadows in cutscenes.
@@ -57893,13 +65396,19 @@ TCES-53286:
     cpuSpriteRenderLevel: 2 # Needed for above.
     textureInsideRT: 1 # Fixes broken character models.
 TCPS-10058:
-  name: "Densha de Go! Shinkansen [with Controller]"
+  name: 電車でGO!新幹線 山陽新幹線編 運転士セット PlayStation 2 the Best
+  name-sort: でんしゃでGO!しんかんせん さんようしんかんせんへん うんてんしせっと PlayStation 2 the Best
+  name-en: "Densha de Go! Shinkansen [with Controller]"
   region: "NTSC-J"
 TCPS-10068:
-  name: "Densha de Go! Ryojou-hen [with Controller]"
+  name: 電車でGO! 旅情編コントローラ同梱セット
+  name-sort: でんしゃでGO! りょじょうへんこんとろーらどうこんせっと
+  name-en: "Densha de Go! Ryojou-hen [with Controller]"
   region: "NTSC-J"
 TCPS-10074:
-  name: "Space Invaders 25th Anniversary Bundle"
+  name: スペースインベーダー筐体型コントローラ同梱セット
+  name-sort: すぺーすいんべーだーきょうたいけいこんとろーらどうこんせっと
+  name-en: "Space Invaders 25th Anniversary Bundle"
   region: "NTSC-J"
 TCPS-10075:
   name: "Takahashi Naoko no Marathon Shiyou yo!"
@@ -57907,34 +65416,52 @@ TCPS-10075:
   gsHWFixes:
     preloadFrameData: 1 # Fixes missing text.
 TCPS-10084:
-  name: "Zero Shinkikan Josentoki"
+  name: 零式艦上戦闘記(数量限定パッケージ)
+  name-sort: れいしきかんじょうせんとうき(すうりょうげんていぱっけーじ)
+  name-en: "Zero Shinkikan Josentoki"
   region: "NTSC-J"
 TCPS-10085:
-  name: "Densha de Go! Final [Limited Edition]"
+  name: 電車でGO!FINAL
+  name-sort: でんしゃでGO!FINAL
+  name-en: "Densha de Go! Final [Limited Edition]"
   region: "NTSC-J"
   compat: 5
 TCPS-10094:
-  name: "Ys III - Wanderers from Ys"
+  name: イースIII 〜ワンダラーズフロムイース〜
+  name-sort: いーすIII 〜わんだらーずふろむいーす〜
+  name-en: "Ys III - Wanderers from Ys"
   region: "NTSC-J"
 TCPS-10106:
-  name: "Ys IV - Mask of the Sun - A New Theory"
+  name: イース IV Mask of the Sun -a new theory-
+  name-sort: いーす IV Mask of the Sun -a new theory-
+  name-en: "Ys IV - Mask of the Sun - A New Theory"
   region: "NTSC-J"
 TCPS-10107:
-  name: "Giga Wing Generations"
+  name: 翼神 ギガウィング ジェネレーションズ
+  name-sort: よくしん ぎがうぃんぐ じぇねれーしょんず
+  name-en: "Giga Wing Generations"
   region: "NTSC-J"
 TCPS-10109:
-  name: "Ys III - Wanderers from Ys [Limited Edition]"
+  name: イースIII ～ワンダラーズ フロム イース～ (初回限定版)
+  name-sort: いーすIII ～わんだらーず ふろむ いーす～ (しょかいげんていばん)
+  name-en: "Ys III - Wanderers from Ys [Limited Edition]"
   region: "NTSC-J"
 TCPS-10111:
-  name: "Erementar Gerad"
+  name: エレメンタル ジェレイド -纏え、翠風の剣-
+  name-sort: えれめんたる じぇれいど -まとえ、すいふうのつるぎ-
+  name-en: "Erementar Gerad"
   region: "NTSC-J"
   gameFixes:
     - XGKickHack # Fixes chocolate coloured characters.
 TCPS-10113:
-  name: "Mushihime-sama"
+  name: 虫姫さま
+  name-sort: むしひめさま
+  name-en: "Mushihime-sama"
   region: "NTSC-J"
 TCPS-10114:
-  name: "Matantei Loki Ragnarok Mayoukaku"
+  name: 魔探偵ロキRAGNAROK 魔妖画 〜失われた微笑〜
+  name-sort: またんていろきRAGNAROK ま妖画 〜うしなわれたびしょう〜
+  name-en: "Matantei Loki Ragnarok Mayoukaku"
   region: "NTSC-J"
 TCPS-10115:
   name: "Taito Memories - Joukan"
@@ -57942,10 +65469,14 @@ TCPS-10115:
   gsHWFixes:
     roundSprite: 1 # Fixes vertical and horizontal lines.
 TCPS-10117:
-  name: "Mushihime-sama [Limited Edition]"
+  name: 虫姫さま 初回限定版
+  name-sort: むしひめさま しょかいげんていばん
+  name-en: "Mushihime-sama [Limited Edition]"
   region: "NTSC-J"
 TCPS-10123:
-  name: "Langrisser III"
+  name: ラングリッサーIII
+  name-sort: らんぐりっさーIII
+  name-en: "Langrisser III"
   region: "NTSC-J"
 TCPS-10124:
   name: "Taito Memories Gekan"
@@ -57953,46 +65484,72 @@ TCPS-10124:
   gsHWFixes:
     roundSprite: 1 # Fixes vertical and horizontal lines.
 TCPS-10125:
-  name: "Raiden III"
+  name: 雷電III
+  name-sort: らいでんIII
+  name-en: "Raiden III"
   region: "NTSC-J"
 TCPS-10128:
-  name: "Ultimate Pro Pinball"
+  name: アルティメット プロ ピンボール
+  name-sort: あるてぃめっと ぷろ ぴんぼーる
+  name-en: "Ultimate Pro Pinball"
   region: "NTSC-J"
 TCPS-10130:
-  name: "Homura"
+  name: HOMURA
+  name-sort: HOMURA
+  name-en: "Homura"
   region: "NTSC-J"
 TCPS-10131:
-  name: "Ibara"
+  name: 鋳薔薇
+  name-sort: いばら
+  name-en: "Ibara"
   region: "NTSC-J"
 TCPS-10132:
-  name: "Psychic Force Complete"
+  name: サイキックフォース COMPLETE
+  name-sort: さいきっくふぉーす COMPLETE
+  name-en: "Psychic Force Complete"
   region: "NTSC-J"
 TCPS-10133:
-  name: "Psychic Force Complete [with Wong Figure]"
+  name: サイキックフォース COMPLETE ウォン フィギュア同梱版
+  name-sort: さいきっくふぉーす COMPLETE うぉん ふぃぎゅあどうこんばん
+  name-en: "Psychic Force Complete [with Wong Figure]"
   region: "NTSC-J"
 TCPS-10134:
-  name: "Psychic Force Complete [with Emilio Figure]"
+  name: サイキックフォース COMPLETE エミリオ フィギュア同梱版
+  name-sort: さいきっくふぉーす COMPLETE えみりお ふぃぎゅあどうこんばん
+  name-en: "Psychic Force Complete [with Emilio Figure]"
   region: "NTSC-J"
 TCPS-10135:
-  name: "Psychic Force Complete [with Wendy Figure]"
+  name: サイキックフォース COMPLETE ウェンディー フィギュア同梱版
+  name-sort: さいきっくふぉーす COMPLETE うぇんでぃー ふぃぎゅあどうこんばん
+  name-en: "Psychic Force Complete [with Wendy Figure]"
   region: "NTSC-J"
 TCPS-10136:
-  name: "Psychic Force Complete [with 3 Figures]"
+  name: サイキックフォース COMPLETE フィギュア三体同梱版
+  name-sort: さいきっくふぉーす COMPLETE ふぃぎゅあさんたいどうこんばん
+  name-en: "Psychic Force Complete [with 3 Figures]"
   region: "NTSC-J"
 TCPS-10147:
-  name: "Zero Shikikan Josentoki Ni"
+  name: 零式艦上戦闘記 弐
+  name-sort: れいしきかんじょうせんとうき 弐
+  name-en: "Zero Shikikan Josentoki Ni"
   region: "NTSC-J"
 TCPS-10148:
-  name: "Zero Shikikan Josentoki Ni [Limited Edition]"
+  name: 零式艦上戦闘記 弐 【限定版】
+  name-sort: れいしきかんじょうせんとうき 弐 【げんていばん】
+  name-en: "Zero Shikikan Josentoki Ni [Limited Edition]"
   region: "NTSC-J"
 TCPS-10152:
-  name: "Rozen Maiden - Duellwalzer"
+  name: ローゼンメイデン ドゥエルヴァルツァ(通常版)
+  name-sort: ろーぜんめいでん どぅえるゔぁるつぁ(つうじょうばん)
+  name-en: "Rozen Maiden - Duellwalzer"
   region: "NTSC-J"
 TCPS-10153:
   name: "Rozen Maiden - Duellwalzer [Limited Edition]"
   region: "NTSC-J"
 TCPS-10154:
-  name: "Ys V - Lost Kefin - Kingdom of Sand"
+  name: イースV LOST KEFIN,KINGDOM OF SAND
+  name-sort: いーすV LOST KEFIN,KINGDOM OF SAND
+  name-en: "Ys V - Lost Kefin - Kingdom of Sand"
   region: "NTSC-J"
 TCPS-10158:
   name: "Ultimate Spider-Man"
@@ -58006,7 +65563,9 @@ TCPS-10158:
     autoFlush: 2 # Fixes shadow alignment along with HPO Special (Normal looks better but causes top left glitches).
     halfPixelOffset: 2
 TCPS-10159:
-  name: "Suzuki TT Super Bikes - Real Road Racing"
+  name: TT SUPERBIKES(TTスーパーバイクス)
+  name-sort: TT SUPERBIKES(TTすーぱーばいくす)
+  name-en: "Suzuki TT Super Bikes - Real Road Racing"
   region: "NTSC-J"
 TCPS-10160:
   name: "Taito Memories - Joukan [Taito The Best]"
@@ -58019,13 +65578,19 @@ TCPS-10164:
   gsHWFixes:
     roundSprite: 1 # Fixes vertical and horizontal lines.
 TCPS-10166:
-  name: "Wizardry Gaiden - Sentou no Kangoku - Prisoners of the Battles"
+  name: ウィザードリィ・外伝 〜戦闘の監獄〜
+  name-sort: うぃざーどりぃ・がいでん 〜せんとうのかんごく〜
+  name-en: "Wizardry Gaiden - Sentou no Kangoku - Prisoners of the Battles"
   region: "NTSC-J"
 TCPS-10168:
-  name: "Mushihime-sama [Taito The Best]"
+  name: 虫姫さま TAITO BEST
+  name-sort: むしひめさま TAITO BEST
+  name-en: "Mushihime-sama [Taito The Best]"
   region: "NTSC-J"
 TCPS-10172:
-  name: "Homura [Taito the Best]"
+  name: HOMURA TAITO BEST
+  name-sort: HOMURA TAITO BEST
+  name-en: "Homura [Taito the Best]"
   region: "NTSC-J"
 TCPS-10178:
   name: "Taito Memories II - Joukan [Taito The Best]"
@@ -58087,12 +65652,6 @@ TLES-82043:
     halfPixelOffset: 2 # Fixes blurriness.
 VW067-J1:
   name: "Crash Bandicoot 4 - Sakuretsu! Majin Power!"
-  region: "NTSC-J"
-  gsHWFixes:
-    nativePaletteDraw: 1
-    autoFlush: 2 # Fixes refraction effect.
-VW067-J2:
-  name: "Crash Bandicoot 4 - Sakuretsu! Majin Power! [PlayStation 2 The Best]"
   region: "NTSC-J"
   gsHWFixes:
     nativePaletteDraw: 1

--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -28853,15 +28853,15 @@ SLPM-55117:
   name: "Beatmania IIDX 15 - DJ Troopers"
   region: "NTSC-J"
 SLPM-55118:
-  name: ギャラクシーエンジェルII 永劫回帰の刻
-  name-sort: ぎゃらくしーえんじぇるII えいごうかいきのこく
+  name: ギャラクシーエンジェルII 永劫回帰の刻 [ディスク1/2]
+  name-sort: ぎゃらくしーえんじぇるII えいごうかいきのこく [でぃすく1/2]
   name-en: "Galaxy Angel II - Eigou Kaiki no Koku [Disc 1 of 2]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 1 # Reduces misaligned lighting and other effects.
 SLPM-55119:
-  name: ギャラクシーエンジェルII 永劫回帰の刻
-  name-sort: ぎゃらくしーえんじぇるII えいごうかいきのこく
+  name: ギャラクシーエンジェルII 永劫回帰の刻 [ディスク2/2]
+  name-sort: ぎゃらくしーえんじぇるII えいごうかいきのこく [でぃすく2/2]
   name-en: "Galaxy Angel II - Eigou Kaiki no Koku [Disc 2 of 2]"
   region: "NTSC-J"
   memcardFilters:
@@ -33341,20 +33341,24 @@ SLPM-62630:
   name-en: "Sukusuku Inufuku [Hamster The Best]"
   region: "NTSC-J"
 SLPM-62631:
-  name: SIMPLE2000シリーズ 2in1 Vol.3 THE パズルコレクション2,000問 & THE 東洋三大占術〜風水・姓名判断・易占〜
-  name-sort: SIMPLE2000しりーず 2in1 Vol.3 THE ぱずるこれくしょん2,000もん & THE とうようさんだいうらないじゅつ〜ふうすい・せいめいはんだん・えきうらない〜
+  name: SIMPLE2000シリーズ 2in1 Vol.3 THE パズルコレクション2,000問 & THE 東洋三大占術〜風水・姓名判断・易占〜 [ディスク1/2]
+  name-sort: SIMPLE2000しりーず 2in1 Vol.3 THE ぱずるこれくしょん2,000もん & THE とうようさんだいうらないじゅつ〜ふうすい・せいめいはんだん・えきうらない〜 [でぃすく1/2]
   name-en: "Simple 2000 Series 2-in-1 Vol. 3 - The Puzzle Collection 2000 Toi & The Touyou Sandai Senjitsu Fusui, Seimeidanhan, Ekisen [Disc 1 of 2]"
   region: "NTSC-J"
 SLPM-62632:
-  name: "Simple 2000 Series 2-in-1 Vol. 3 - The Puzzle Collection 2000 Toi & The Touyou Sandai Senjitsu Fusui, Seimeidanhan, Ekisen [Disc 2 of 2]"
+  name: SIMPLE2000シリーズ 2in1 Vol.3 THE パズルコレクション2,000問 & THE 東洋三大占術〜風水・姓名判断・易占〜 [ディスク2/2]
+  name-sort: SIMPLE2000しりーず 2in1 Vol.3 THE ぱずるこれくしょん2,000もん & THE とうようさんだいうらないじゅつ〜ふうすい・せいめいはんだん・えきうらない〜 [でぃすく2/2]
+  name-en: "Simple 2000 Series 2-in-1 Vol. 3 - The Puzzle Collection 2000 Toi & The Touyou Sandai Senjitsu Fusui, Seimeidanhan, Ekisen [Disc 2 of 2]"
   region: "NTSC-J"
 SLPM-62633:
-  name: SIMPLE2000シリーズ 2in1 Vol.2 THE バスフィッシング ＆ THE ボウリングHYPER
-  name-sort: SIMPLE2000しりーず 2in1 Vol.2 THE ばすふぃっしんぐ ＆ THE ぼうりんぐHYPER
+  name: SIMPLE2000シリーズ 2in1 Vol.2 THE バスフィッシング ＆ THE ボウリングHYPER [ディスク1/2]
+  name-sort: SIMPLE2000しりーず 2in1 Vol.2 THE ばすふぃっしんぐ ＆ THE ぼうりんぐHYPER [でぃすく1/2]
   name-en: "Simple 2000 Series 2-in-1 Vol. 2 - The Bass Fishing & The Bowling Hyper [Disc 1 of 2]"
   region: "NTSC-J"
 SLPM-62634:
-  name: "Simple 2000 Series 2-in-1 Vol. 2 - The Bass Fishing & The Bowling Hyper [Disc 2 of 2]"
+  name: SIMPLE2000シリーズ 2in1 Vol.2 THE バスフィッシング ＆ THE ボウリングHYPER [ディスク2/2]
+  name-sort: SIMPLE2000しりーず 2in1 Vol.2 THE ばすふぃっしんぐ ＆ THE ぼうりんぐHYPER [でぃすく2/2]
+  name-en: "Simple 2000 Series 2-in-1 Vol. 2 - The Bass Fishing & The Bowling Hyper [Disc 2 of 2]"
   region: "NTSC-J"
 SLPM-62635:
   name: SIMPLE2000シリーズ Ultimate Vol.26 ラブ★スマッシュ!5.1 〜テニスロボの反乱〜
@@ -33364,14 +33368,16 @@ SLPM-62635:
   gameFixes:
     - XGKickHack # Fixes bad Geometry.
 SLPM-62636:
-  name: SIMPLE2000シリーズ 2in1 Vol.1 THE テニス ＆ THE スノーボード
-  name-sort: SIMPLE2000しりーず 2in1 Vol.1 THE てにす ＆ THE すのーぼーど
+  name: SIMPLE2000シリーズ 2in1 Vol.1 THE テニス ＆ THE スノーボード [ディスク1/2]
+  name-sort: SIMPLE2000しりーず 2in1 Vol.1 THE てにす ＆ THE すのーぼーど [でぃすく1/2]
   name-en: "Simple 2000 Series 2-in-1 Vol. 1 - The Tennis & The Snowboard [Disc 1 of 2]"
   region: "NTSC-J"
   gameFixes:
     - XGKickHack # Fixes SPS and console spam (The Tennis).
 SLPM-62637:
-  name: "Simple 2000 Series 2-in-1 Vol. 1 - The Tennis & The Snowboard [Disc 2 of 2]"
+  name: SIMPLE2000シリーズ 2in1 Vol.1 THE テニス ＆ THE スノーボード [ディスク2/2]
+  name-sort: SIMPLE2000しりーず 2in1 Vol.1 THE てにす ＆ THE すのーぼーど [でぃすく2/2]
+  name-en: "Simple 2000 Series 2-in-1 Vol. 1 - The Tennis & The Snowboard [Disc 2 of 2]"
   region: "NTSC-J"
 SLPM-62638:
   name: SIMPLE2000シリーズ Vol.80 THE お姉チャンプルゥ 〜THE姉チャン特別編〜
@@ -33478,20 +33484,24 @@ SLPM-62661:
   name-en: "Oretachi Geasen Zoku Sono - Terra Cresta"
   region: "NTSC-J"
 SLPM-62662:
-  name: SIMPLE2000シリーズ 2in1 Vol.5 THE シューティング〜ダブル紫炎龍〜 ＆ THE ヘリコプター
-  name-sort: SIMPLE2000しりーず 2in1 Vol.5 THE しゅーてぃんぐ〜だぶるしえんりゅう〜 ＆ THE へりこぷたー
+  name: SIMPLE2000シリーズ 2in1 Vol.5 THE シューティング〜ダブル紫炎龍〜 ＆ THE ヘリコプター [ディスク1/2]
+  name-sort: SIMPLE2000しりーず 2in1 Vol.5 THE しゅーてぃんぐ〜だぶるしえんりゅう〜 ＆ THE へりこぷたー [でぃすく1/2]
   name-en: "Simple 2000 Series 2-in-1 Vol. 5 - The Shooting & The Helicopter [Disc 1 of 2]"
   region: "NTSC-J"
 SLPM-62663:
-  name: "Simple 2000 Series 2-in-1 Vol. 5 - The Shooting & The Helicopter [Disc 2 of 2]"
+  name: SIMPLE2000シリーズ 2in1 Vol.5 THE シューティング〜ダブル紫炎龍〜 ＆ THE ヘリコプター [ディスク2/2]
+  name-sort: SIMPLE2000しりーず 2in1 Vol.5 THE しゅーてぃんぐ〜だぶるしえんりゅう〜 ＆ THE へりこぷたー [でぃすく2/2]
+  name-en: "Simple 2000 Series 2-in-1 Vol. 5 - The Shooting & The Helicopter [Disc 2 of 2]"
   region: "NTSC-J"
 SLPM-62664:
-  name: SIMPLE2000シリーズ 2in1 Vol.4 THE 武士道 〜辻斬り一代〜 ＆ THE スナイパー2 〜悪夢の銃弾〜
-  name-sort: SIMPLE2000しりーず 2in1 Vol.4 THE ぶしどう 〜つじぎりいちだい〜 ＆ THE すないぱー2 〜あくむのじゅうだん〜
+  name: SIMPLE2000シリーズ 2in1 Vol.4 THE 武士道 〜辻斬り一代〜 ＆ THE スナイパー2 〜悪夢の銃弾〜 [ディスク1/2]
+  name-sort: SIMPLE2000しりーず 2in1 Vol.4 THE ぶしどう 〜つじぎりいちだい〜 ＆ THE すないぱー2 〜あくむのじゅうだん〜 [でぃすく1/2]
   name-en: "Simple 2000 Series 2-in-1 Vol. 4 - The Bushidou & The Sniper 2 [Disc 1 of 2]"
   region: "NTSC-J"
 SLPM-62665:
-  name: "Simple 2000 Series 2-in-1 Vol. 4 - The Bushidou & The Sniper 2 [Disc 2 of 2]"
+  name: SIMPLE2000シリーズ 2in1 Vol.4 THE 武士道 〜辻斬り一代〜 ＆ THE スナイパー2 〜悪夢の銃弾〜 [ディスク2/2]
+  name-sort: SIMPLE2000しりーず 2in1 Vol.4 THE ぶしどう 〜つじぎりいちだい〜 ＆ THE すないぱー2 〜あくむのじゅうだん〜 [でぃすく2/2]
+  name-en: "Simple 2000 Series 2-in-1 Vol. 4 - The Bushidou & The Sniper 2 [Disc 2 of 2]"
   region: "NTSC-J"
 SLPM-62666:
   name: SEGA AGES 2500シリーズ Vol.1 PHANTASY STAR generation:1 通常版
@@ -34134,15 +34144,17 @@ SLPM-65001:
   region: "NTSC-J"
   compat: 5
 SLPM-65002:
-  name: ラブストーリー
-  name-sort: らぶすとーりー
+  name: ラブストーリー [ディスク1/2]
+  name-sort: らぶすとーりー [でぃすく1/2]
   name-en: "0 Story [Disc 1 of 2]"
   region: "NTSC-J"
   compat: 5
   gameFixes:
     - SoftwareRendererFMVHack # Fixes removed bloom in FMV.
 SLPM-65003:
-  name: "0 Story [Disc 2 of 2]"
+  name: ラブストーリー [ディスク2/2]
+  name-sort: らぶすとーりー [でぃすく2/2]
+  name-en: "0 Story [Disc 2 of 2]"
   region: "NTSC-J"
   compat: 5
   gameFixes:
@@ -34285,12 +34297,14 @@ SLPM-65023:
   gsHWFixes:
     disablePartialInvalidation: 1 # Fixes corrupt textures.
 SLPM-65024:
-  name: バイオハザード コード:ベロニカ 完全版
-  name-sort: ばいおはざーど こーど:べろにか かんぜんばん
+  name: バイオハザード コード:ベロニカ 完全版 [ディスク1/2]
+  name-sort: ばいおはざーど こーど:べろにか かんぜんばん [でぃすく1/2]
   name-en: "BioHazard - 5th Anniversary Package - Nightmare Returns [Disc 1 of 2]"
   region: "NTSC-J"
 SLPM-65025:
-  name: "BioHazard - 5th Anniversary Package - Nightmare Returns [Disc 2 of 2]"
+  name: バイオハザード コード:ベロニカ 完全版 [ディスク2/2]
+  name-sort: ばいおはざーど こーど:べろにか かんぜんばん [でぃすく2/2]
+  name-en: "BioHazard - 5th Anniversary Package - Nightmare Returns [Disc 2 of 2]"
   region: "NTSC-J"
 SLPM-65026:
   name: beatmania IIDX 4th style -new songs collection-
@@ -34361,8 +34375,8 @@ SLPM-65039:
   name-en: "Densha de Go! Shinkansen"
   region: "NTSC-J"
 SLPM-65040:
-  name: ザ・フィアー
-  name-sort: ざ・ふぃあー
+  name: ザ・フィアー [ディスク1/4]
+  name-sort: ざ・ふぃあー [でぃすく1/4]
   name-en: "Fear, The [Disc 1 of 4]"
   region: "NTSC-J"
   memcardFilters:
@@ -34371,7 +34385,9 @@ SLPM-65040:
     - "SLPM-65042"
     - "SLPM-65043"
 SLPM-65041:
-  name: "Fear, The [Disc 2 of 4]"
+  name: ザ・フィアー [ディスク2/4]
+  name-sort: ざ・ふぃあー [でぃすく2/4]
+  name-en: "Fear, The [Disc 2 of 4]"
   region: "NTSC-J"
   memcardFilters:
     - "SLPM-65040"
@@ -34379,7 +34395,9 @@ SLPM-65041:
     - "SLPM-65042"
     - "SLPM-65043"
 SLPM-65042:
-  name: "Fear, The [Disc 3of 4]"
+  name: ザ・フィアー [ディスク3/4]
+  name-sort: ざ・ふぃあー [でぃすく3/4]
+  name-en: "Fear, The [Disc 3of 4]"
   region: "NTSC-J"
   compat: 5
   memcardFilters:
@@ -34388,7 +34406,9 @@ SLPM-65042:
     - "SLPM-65042"
     - "SLPM-65043"
 SLPM-65043:
-  name: "Fear, The [Disc 4 of 4]"
+  name: ザ・フィアー [ディスク4/4]
+  name-sort: ざ・ふぃあー [でぃすく4/4]
+  name-en: "Fear, The [Disc 4 of 4]"
   region: "NTSC-J"
   memcardFilters:
     - "SLPM-65040"
@@ -34608,8 +34628,8 @@ SLPM-65085:
   name: "Alone in the Dark - The New Nightmare"
   region: "NTSC-J"
 SLPM-65086:
-  name: “A” VISUAL MIX
-  name-sort: “A” VISUAL MIX
+  name: “A” VISUAL MIX [ディスク1/2]
+  name-sort: “A” VISUAL MIX [ディスク1/2]
   name-en: "Visual Mix - Ayumi Hamasaki Dome Tour 2001 [Disc 1 of 2]"
   region: "NTSC-J"
   compat: 5
@@ -34619,7 +34639,9 @@ SLPM-65086:
     - "SLPM-65086"
     - "SLPM-65087"
 SLPM-65087:
-  name: "Visual Mix - Ayumi Hamasaki Dome Tour 2001 [Disc 2 of 2]"
+  name: “A” VISUAL MIX [ディスク2/2]
+  name-sort: “A” VISUAL MIX [ディスク2/2]
+  name-en: "Visual Mix - Ayumi Hamasaki Dome Tour 2001 [Disc 2 of 2]"
   region: "NTSC-J"
   compat: 5
   memcardFilters:
@@ -35506,12 +35528,14 @@ SLPM-65262:
   name-en: "Boboboubo Boubobo - Hajike Matsuri"
   region: "NTSC-J"
 SLPM-65263:
-  name: コーエーメガパック 真・三國無双2&真・三國無双2 猛将伝
-  name-sort: こーえーめがぱっく しん・さんごくむそう2&しん・さんごくむそう2 もうしょうでん
+  name: コーエーメガパック 真・三國無双2&真・三國無双2 猛将伝 [ディスク1/2]
+  name-sort: こーえーめがぱっく しん・さんごくむそう2&しん・さんごくむそう2 もうしょうでん [でぃすく1/2]
   name-en: "Shin Sangoku Musou 2 & Shin Sangoku Musou 2 Mushoden [Koei Mega Pack] [Disc 1 of 2]"
   region: "NTSC-J"
 SLPM-65264:
-  name: "Shin Sangoku Musou 2 & Shin Sangoku Musou 2 Mushoden [Koei Mega Pack] [Disc 2 of 2]"
+  name: コーエーメガパック 真・三國無双2&真・三國無双2 猛将伝 [ディスク2/2]
+  name-sort: こーえーめがぱっく しん・さんごくむそう2&しん・さんごくむそう2 もうしょうでん [でぃすく2/2]
+  name-en: "Shin Sangoku Musou 2 & Shin Sangoku Musou 2 Mushoden [Koei Mega Pack] [Disc 2 of 2]"
   region: "NTSC-J"
 SLPM-65266:
   name: ドラッグ オン ドラグーン
@@ -36438,8 +36462,8 @@ SLPM-65437:
   name: "Kessen II"
   region: "NTSC-J"
 SLPM-65438:
-  name: スターオーシャン Till the End of Time ディレクターズカット
-  name-sort: すたーおーしゃん Till the End of Time でぃれくたーずかっと
+  name: スターオーシャン Till the End of Time ディレクターズカット [ディスク1/2]
+  name-sort: すたーおーしゃん Till the End of Time でぃれくたーずかっと [でぃすく1/2]
   name-en: "Star Ocean 3 [Director's Cut] [Disc 1 of 2]"
   region: "NTSC-J"
   compat: 5
@@ -36450,7 +36474,9 @@ SLPM-65438:
     roundSprite: 1 # Fixes door transition vertical lines and mini-map artifacts.
     textureInsideRT: 1 # Fixes missing battle effects.
 SLPM-65439:
-  name: "Star Ocean 3 [Director's Cut] [Disc 2 of 2]"
+  name: スターオーシャン Till the End of Time ディレクターズカット [ディスク2/2]
+  name-sort: すたーおーしゃん Till the End of Time でぃれくたーずかっと [でぃすく2/2]
+  name-en: "Star Ocean 3 [Director's Cut] [Disc 2 of 2]"
   region: "NTSC-J"
   compat: 5
   gameFixes:
@@ -36782,8 +36808,8 @@ SLPM-65503:
   region: "NTSC-J"
   compat: 5
 SLPM-65504:
-  name: COOL GIRL 初回限定版
-  name-sort: COOL GIRL しょかいげんていばん
+  name: COOL GIRL 初回限定版 [ディスク1/2]
+  name-sort: COOL GIRL しょかいげんていばん [でぃすく1/2]
   name-en: "Cool Girl [Limited Edition] [Disc 1 of 2]"
   region: "NTSC-J"
   memcardFilters:
@@ -36792,7 +36818,9 @@ SLPM-65504:
     - "SLPM-65506"
     - "SLPM-65742"
 SLPM-65505:
-  name: "Cool Girl [Limited Edition] [Disc 2 of 2]"
+  name: COOL GIRL 初回限定版 [ディスク2/2]
+  name-sort: COOL GIRL しょかいげんていばん [でぃすく2/2]
+  name-en: "Cool Girl [Limited Edition] [Disc 2 of 2]"
   region: "NTSC-J"
   memcardFilters:
     - "SLPM-65504"
@@ -40117,8 +40145,8 @@ SLPM-66116:
   name-en: "NBA Live 2005 [EA Best Hits]"
   region: "NTSC-J"
 SLPM-66117:
-  name: METAL GEAR SOLID 3 SUBSISTENCE (ヘッドセット同梱版)
-  name-sort: METAL GEAR SOLID 3 SUBSISTENCE (へっどせっとどうこんばん)
+  name: METAL GEAR SOLID 3 SUBSISTENCE (ヘッドセット同梱版) [ディスク1/3]
+  name-sort: METAL GEAR SOLID 3 SUBSISTENCE (へっどせっとどうこんばん) [でぃすく1/3]
   name-en: "Metal Gear Solid 3 - Subsistence [with Headset] [Disc 1 of 3]"
   region: "NTSC-J"
   gameFixes:
@@ -40129,7 +40157,9 @@ SLPM-66117:
     halfPixelOffset: 2 # Fixes blurriness.
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
 SLPM-66118:
-  name: "Metal Gear Solid 3 - Subsistence [with Headset] [Disc 2 of 3]"
+  name: METAL GEAR SOLID 3 SUBSISTENCE (ヘッドセット同梱版) [ディスク2/3]
+  name-sort: METAL GEAR SOLID 3 SUBSISTENCE (へっどせっとどうこんばん) [でぃすく2/3]
+  name-en: "Metal Gear Solid 3 - Subsistence [with Headset] [Disc 2 of 3]"
   region: "NTSC-J"
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
@@ -40139,7 +40169,9 @@ SLPM-66118:
     halfPixelOffset: 2 # Fixes blurriness.
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
 SLPM-66119:
-  name: "Metal Gear Solid 3 - Subsistence [with Headset] [Disc 3 of 3]"
+  name: METAL GEAR SOLID 3 SUBSISTENCE (ヘッドセット同梱版) [ディスク2/3]
+  name-sort: METAL GEAR SOLID 3 SUBSISTENCE (へっどせっとどうこんばん) [でぃすく2/3]
+  name-en: "Metal Gear Solid 3 - Subsistence [with Headset] [Disc 3 of 3]"
   region: "NTSC-J"
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
@@ -40726,8 +40758,8 @@ SLPM-66219:
   name-en: "Tennis no Oji-Sama - Gakuensai no Oji-Sama"
   region: "NTSC-J"
 SLPM-66220:
-  name: METAL GEAR SOLID 3 SUBSISTENCE (初回生産版)
-  name-sort: METAL GEAR SOLID 3 SUBSISTENCE (しょかいせいさんばん)
+  name: METAL GEAR SOLID 3 SUBSISTENCE (初回生産版) [ディスク1/3]
+  name-sort: METAL GEAR SOLID 3 SUBSISTENCE (しょかいせいさんばん) [でぃすく1/3]
   name-en: "Metal Gear Solid 3 - Subsistence [First Print Limited Edition] [Disc 1 of 3]"
   region: "NTSC-J"
   gameFixes:
@@ -40740,7 +40772,9 @@ SLPM-66220:
   memcardFilters:
     - "SLPM-66117"
 SLPM-66221:
-  name: "Metal Gear Solid 3 - Subsistence [First Print Limited Edition] [Disc 2 of 3]"
+  name: METAL GEAR SOLID 3 SUBSISTENCE (初回生産版) [ディスク2/3]
+  name-sort: METAL GEAR SOLID 3 SUBSISTENCE (しょかいせいさんばん) [でぃすく2/3]
+  name-en: "Metal Gear Solid 3 - Subsistence [First Print Limited Edition] [Disc 2 of 3]"
   region: "NTSC-J"
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
@@ -40752,7 +40786,9 @@ SLPM-66221:
   memcardFilters:
     - "SLPM-66117"
 SLPM-66222:
-  name: "Metal Gear Solid 3 - Subsistence [First Print Limited Edition] [Disc 3 of 3]"
+  name: METAL GEAR SOLID 3 SUBSISTENCE (初回生産版) [ディスク3/3]
+  name-sort: METAL GEAR SOLID 3 SUBSISTENCE (しょかいせいさんばん) [でぃすく3/3]
+  name-en: "Metal Gear Solid 3 - Subsistence [First Print Limited Edition] [Disc 3 of 3]"
   region: "NTSC-J"
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
@@ -40764,8 +40800,8 @@ SLPM-66222:
   memcardFilters:
     - "SLPM-66117"
 SLPM-66223:
-  name: METAL GEAR SOLID 3 SUBSISTENCE
-  name-sort: METAL GEAR SOLID 3 SUBSISTENCE
+  name: METAL GEAR SOLID 3 SUBSISTENCE [ディスク1/2]
+  name-sort: METAL GEAR SOLID 3 SUBSISTENCE [でぃすく1/2]
   name-en: "Metal Gear Solid 3 - Subsistence [Disc 1 of 2]"
   region: "NTSC-J"
   gameFixes:
@@ -40778,7 +40814,9 @@ SLPM-66223:
   memcardFilters:
     - "SLPM-66117"
 SLPM-66224:
-  name: "Metal Gear Solid 3 - Subsistence [Disc 2 of 2]"
+  name: METAL GEAR SOLID 3 SUBSISTENCE [ディスク2/2]
+  name-sort: METAL GEAR SOLID 3 SUBSISTENCE [でぃすく2/2]
+  name-en: "Metal Gear Solid 3 - Subsistence [Disc 2 of 2]"
   region: "NTSC-J"
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
@@ -41075,15 +41113,17 @@ SLPM-66274:
   name-en: "Ninkyouden Toseinin Ichidaiki"
   region: "NTSC-J"
 SLPM-66275:
-  name: 新 鬼武者 DAWN OF DREAMS
-  name-sort: しん おにむしゃ DAWN OF DREAMS
+  name: 新 鬼武者 DAWN OF DREAMS [ディスク1/2]
+  name-sort: しん おにむしゃ DAWN OF DREAMS [でぃすく1/2]
   name-en: "Shin Onimusha - Dawn of Dreams [Disc 1 of 2]"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misalignment and upscaling lines.
 SLPM-66276:
-  name: "Shin Onimusha - Dawn of Dreams [Disc 2 of 2]"
+  name: 新 鬼武者 DAWN OF DREAMS [ディスク2/2]
+  name-sort: しん おにむしゃ DAWN OF DREAMS [でぃすく2/2]
+  name-en: "Shin Onimusha - Dawn of Dreams [Disc 2 of 2]"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
@@ -42265,8 +42305,8 @@ SLPM-66477:
   name-en: "Kamiwaza"
   region: "NTSC-J"
 SLPM-66478:
-  name: アルティメット ヒッツ スターオーシャン Till the End of Time ディレクターズカット
-  name-sort: あるてぃめっと ひっつ すたーおーしゃん Till the End of Time でぃれくたーずかっと
+  name: アルティメット ヒッツ スターオーシャン Till the End of Time ディレクターズカット [ディスク1/2]
+  name-sort: あるてぃめっと ひっつ すたーおーしゃん Till the End of Time でぃれくたーずかっと [でぃすく1/2]
   name-en: "Star Ocean 3 - Till the End of Time [Ultimate Hits] [Disc 1 of 2]"
   region: "NTSC-J"
   compat: 5
@@ -42277,7 +42317,9 @@ SLPM-66478:
     roundSprite: 1 # Fixes door transition vertical lines and mini-map artifacts.
     textureInsideRT: 1 # Fixes missing battle effects.
 SLPM-66479:
-  name: "Star Ocean 3 - Till the End of Time [Ultimate Hits] [Disc 2 of 2]"
+  name: アルティメット ヒッツ スターオーシャン Till the End of Time ディレクターズカット [ディスク2/2]
+  name-sort: あるてぃめっと ひっつ すたーおーしゃん Till the End of Time でぃれくたーずかっと [でぃすく2/2]
+  name-en: "Star Ocean 3 - Till the End of Time [Ultimate Hits] [Disc 2 of 2]"
   region: "NTSC-J"
   compat: 5
   gameFixes:
@@ -42975,8 +43017,8 @@ SLPM-66601:
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes missing lighting and makes snow not look like snow sludge.
 SLPM-66602:
-  name: 龍が如く 2
-  name-sort: りゅうがごとく 2
+  name: 龍が如く 2 [ディスク1/2]
+  name-sort: りゅうがごとく 2 [でぃすく1/2]
   name-en: "Ryu ga Gotoku 2 [Disc 1 of 2]"
   region: "NTSC-J"
   memcardFilters:
@@ -42986,7 +43028,9 @@ SLPM-66602:
     - "SLPM-74234"
     - "SLPM-74253"
 SLPM-66603:
-  name: "Ryu ga Gotoku 2 [Disc 2 of 2]"
+  name: 龍が如く 2 [ディスク2/2]
+  name-sort: りゅうがごとく 2 [でぃすく2/2]
+  name-en: "Ryu ga Gotoku 2 [Disc 2 of 2]"
   region: "NTSC-J"
   memcardFilters:
     - "SLPM-66602"
@@ -44023,14 +44067,16 @@ SLPM-66778:
   name-en: "Galaxy Angel - Eternal Lovers [Broccoli The Best Quality]"
   region: "NTSC-J"
 SLPM-66779:
-  name: ギャラクシーエンジェルII 無限回廊の鍵【通常版】
-  name-sort: ぎゃらくしーえんじぇるII むげんかいろうのかぎ【つうじょうばん】
+  name: ギャラクシーエンジェルII 無限回廊の鍵【通常版】 [ディスク1/2]
+  name-sort: ぎゃらくしーえんじぇるII むげんかいろうのかぎ【つうじょうばん】 [でぃすく1/2]
   name-en: "Galaxy Angel II - Mugen Kairou no Kagi [Disc 1 of 2]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 1 # Reduces misaligned lighting and other effects.
 SLPM-66780:
-  name: "Galaxy Angel II - Mugen Kairou no Kagi [Disc 2 of 2]"
+  name: ギャラクシーエンジェルII 無限回廊の鍵【通常版】 [ディスク2/2]
+  name-sort: ぎゃらくしーえんじぇるII むげんかいろうのかぎ【つうじょうばん】 [でぃすく2/2]
+  name-en: "Galaxy Angel II - Mugen Kairou no Kagi [Disc 2 of 2]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 1 # Reduces misaligned lighting and other effects.
@@ -44102,8 +44148,8 @@ SLPM-66791:
   name-en: "Memories Off #5 Encore"
   region: "NTSC-J"
 SLPM-66792:
-  name: METAL GEAR 20th ANNIVERSARY METAL GEAR SOLID 2 SONS OF LIBERTY
-  name-sort: METAL GEAR 20th ANNIVERSARY METAL GEAR SOLID 2 SONS OF LIBERTY
+  name: METAL GEAR 20th ANNIVERSARY METAL GEAR SOLID 2 SONS OF LIBERTY [ディスク1/2]
+  name-sort: METAL GEAR 20th ANNIVERSARY METAL GEAR SOLID 2 SONS OF LIBERTY [でぃすく1/2]
   name-en: "Metal Gear Solid 2 - Sons of Liberty [20th Anniversary Edition] [Disc 1 of 2]"
   region: "NTSC-J"
   gameFixes:
@@ -44111,7 +44157,9 @@ SLPM-66792:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
 SLPM-66793:
-  name: "Metal Gear Solid 2 - Sons of Liberty [20th Anniversary Edition] [Disc 2 of 2]"
+  name: METAL GEAR 20th ANNIVERSARY METAL GEAR SOLID 2 SONS OF LIBERTY [ディスク2/2]
+  name-sort: METAL GEAR 20th ANNIVERSARY METAL GEAR SOLID 2 SONS OF LIBERTY [でぃすく2/2]
+  name-en: "Metal Gear Solid 2 - Sons of Liberty [20th Anniversary Edition] [Disc 2 of 2]"
   region: "NTSC-J"
   gameFixes:
     - InstantDMAHack # Fixes broken half-bottom artifacts.
@@ -46312,15 +46360,17 @@ SLPS-20017:
   name-en: "Street Mahjong Trance 2"
   region: "NTSC-J"
 SLPS-20018:
-  name: ステッピングセレクション
-  name-sort: すてっぴんぐせれくしょん
+  name: ステッピングセレクション [ディスク1/2]
+  name-sort: すてっぴんぐせれくしょん [でぃすく1/2]
   name-en: "Stepping Selection [Disc 1 of 2]"
   region: "NTSC-J"
   memcardFilters:
     - "SLPS-20018"
     - "SLPS-20019"
 SLPS-20019:
-  name: "Stepping Selection [Disc 2 of 2]"
+  name: ステッピングセレクション [ディスク2/2]
+  name-sort: すてっぴんぐせれくしょん [でぃすく2/2]
+  name-en: "Stepping Selection [Disc 2 of 2]"
   region: "NTSC-J"
   memcardFilters:
     - "SLPS-20018"
@@ -46625,15 +46675,17 @@ SLPS-20083:
     mipmap: 2 # Fixes ground graphics.
     trilinearFiltering: 1 # Fixes ground graphics.
 SLPS-20084:
-  name: BASIC STUDIO パワフルゲーム工房
-  name-sort: BASIC STUDIO ぱわふるげーむこうぼう
+  name: BASIC STUDIO パワフルゲーム工房 [ディスク1/2]
+  name-sort: BASIC STUDIO ぱわふるげーむこうぼう [でぃすく1/2]
   name-en: "Basic Studio [Disc 1]"
   region: "NTSC-J"
   memcardFilters:
     - "SLPS-20084"
     - "SLPS-20085"
 SLPS-20085:
-  name: "Basic Studio [Disc 2]"
+  name: BASIC STUDIO パワフルゲーム工房 [ディスク2/2]
+  name-sort: BASIC STUDIO ぱわふるげーむこうぼう [でぃすく2/2]
+  name-en: "Basic Studio [Disc 2]"
   region: "NTSC-J"
   memcardFilters:
     - "SLPS-20084"
@@ -48822,8 +48874,8 @@ SLPS-25070:
   name-en: "Tales of the Sunrise Heroes 2"
   region: "NTSC-J"
 SLPS-25071:
-  name: “A” VISUAL MIX
-  name-sort: “A” VISUAL MIX
+  name: “A” VISUAL MIX [ディスク1/2]
+  name-sort: “A” VISUAL MIX [でぃすく1/2]
   name-en: "Visual Mix - Ayumi Hamasaki Dome Tour 2001 [Disc 1 of 2]"
   region: "NTSC-J"
   memcardFilters:
@@ -48832,7 +48884,9 @@ SLPS-25071:
     - "SLPM-65086"
     - "SLPM-65087"
 SLPS-25072:
-  name: "Visual Mix - Ayumi Hamasaki Dome Tour 2001 [Disc 2 of 2]"
+  name: “A” VISUAL MIX [ディスク2/2]
+  name-sort: “A” VISUAL MIX [でぃすく2/2]
+  name-en: "Visual Mix - Ayumi Hamasaki Dome Tour 2001 [Disc 2 of 2]"
   region: "NTSC-J"
   memcardFilters:
     - "SLPS-25071"
@@ -50097,8 +50151,8 @@ SLPS-25316:
   region: "NTSC-J"
   compat: 5
 SLPS-25317:
-  name: シャドウハーツ II DXパック
-  name-sort: しゃどうはーつ II DXぱっく
+  name: シャドウハーツ II DXパック [ディスク1/2]
+  name-sort: しゃどうはーつ II DXぱっく [でぃすく1/2]
   name-en: "Shadow Hearts 2 [Deluxe Pack] [Disc 1 of 2]"
   region: "NTSC-J"
   gsHWFixes:
@@ -50107,7 +50161,9 @@ SLPS-25317:
     roundSprite: 2 # Fixes the position of monster sprites and reduces garbage in the UI.
     autoFlush: 2 # Makes the shadow monsters appear.
 SLPS-25318:
-  name: "Shadow Hearts 2 [Deluxe Pack] [Disc 2 of 2]"
+  name: シャドウハーツ II DXパック [ディスク2/2]
+  name-sort: しゃどうはーつ II DXぱっく [でぃすく2/2]
+  name-en: "Shadow Hearts 2 [Deluxe Pack] [Disc 2 of 2]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurrines, preload frame for FMV breaks visuals with this setting.
@@ -50181,8 +50237,8 @@ SLPS-25333:
   name-en: "Gallop Racer Lucky 7"
   region: "NTSC-J"
 SLPS-25334:
-  name: シャドウハーツ II(通常版)
-  name-sort: しゃどうはーつ II(つうじょうばん)
+  name: シャドウハーツ II(通常版) [ディスク1/2]
+  name-sort: しゃどうはーつ II(つうじょうばん) [でぃすく1/2]
   name-en: "Shadow Hearts 2 [Disc 1 of 2]"
   region: "NTSC-J"
   gsHWFixes:
@@ -50191,7 +50247,9 @@ SLPS-25334:
     roundSprite: 2 # Fixes the position of monster sprites and reduces garbage in the UI.
     autoFlush: 2 # Makes the shadow monsters appear.
 SLPS-25335:
-  name: "Shadow Hearts 2 [Disc 2 of 2]"
+  name: シャドウハーツ II(通常版) [ディスク2/2]
+  name-sort: しゃどうはーつ II(つうじょうばん) [でぃすく2/2]
+  name-en: "Shadow Hearts 2 [Disc 2 of 2]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurrines, preload frame for FMV breaks visuals with this setting.
@@ -50211,8 +50269,8 @@ SLPS-25337:
   name-en: "Bass Landing 3 [Sammy Best]"
   region: "NTSC-J"
 SLPS-25338:
-  name: ARMORED CORE NEXUS
-  name-sort: ARMORED CORE NEXUS
+  name: ARMORED CORE NEXUS [ディスク1/2]
+  name-sort: ARMORED CORE NEXUS [でぃすく1/2]
   name-en: "Armored Core - Nexus [Disc 1]"
   region: "NTSC-J"
   gsHWFixes:
@@ -50226,7 +50284,9 @@ SLPS-25338:
     - "SLPS-73202"
     - "SLPS-73203"
 SLPS-25339:
-  name: "Armored Core - Nexus [Disc 2]"
+  name: ARMORED CORE NEXUS [ディスク2/2]
+  name-sort: ARMORED CORE NEXUS [でぃすく2/2]
+  name-en: "Armored Core - Nexus [Disc 2]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
@@ -50390,8 +50450,8 @@ SLPS-25365:
   name-en: "Missing Blue [Best Price]"
   region: "NTSC-J"
 SLPS-25366:
-  name: ゼノサーガ エピソードII［善悪の彼岸］ プレミアムボックス
-  name-sort: ぜのさーが えぴそーどII［ぜんあくのひがん］ ぷれみあむぼっくす
+  name: ゼノサーガ エピソードII［善悪の彼岸］ プレミアムボックス [ディスク1/2]
+  name-sort: ぜのさーが えぴそーどII［ぜんあくのひがん］ ぷれみあむぼっくす [でぃすく1/2]
   name-en: "Xenosaga Episode II - Jenseits von Gut und Bose [Premium Box] [Disc 1 of 2]"
   region: "NTSC-J"
   gsHWFixes:
@@ -50406,7 +50466,9 @@ SLPS-25366:
     - "SLPS-25353"
     - "SLPS-73224"
 SLPS-25367:
-  name: "Xenosaga Episode II - Jenseits von Gut und Bose [Premium Box] [Disc 2 of 2]"
+  name: ゼノサーガ エピソードII［善悪の彼岸］ プレミアムボックス [ディスク2/2]
+  name-sort: ぜのさーが えぴそーどII［ぜんあくのひがん］ ぷれみあむぼっくす [でぃすく2/2]
+  name-en: "Xenosaga Episode II - Jenseits von Gut und Bose [Premium Box] [Disc 2 of 2]"
   region: "NTSC-J"
   gsHWFixes:
     autoFlush: 2 # Fixes shadows in cutscenes.
@@ -50420,8 +50482,8 @@ SLPS-25367:
     - "SLPS-25353"
     - "SLPS-73224"
 SLPS-25368:
-  name: ゼノサーガ エピソードII［善悪の彼岸］
-  name-sort: ぜのさーが えぴそーどII［ぜんあくのひがん］
+  name: ゼノサーガ エピソードII［善悪の彼岸］ [ディスク1/2]
+  name-sort: ぜのさーが えぴそーどII［ぜんあくのひがん］ [でぃすく1/2]
   name-en: "Xenosaga Episode II - Jenseits von Gut und Bose [Disc 1 of 2]"
   region: "NTSC-J"
   gsHWFixes:
@@ -50436,7 +50498,9 @@ SLPS-25368:
     - "SLPS-25353"
     - "SLPS-73224"
 SLPS-25369:
-  name: "Xenosaga Episode II - Jenseits von Gut und Bose [Disc 2 of 2]"
+  name: ゼノサーガ エピソードII［善悪の彼岸］ [ディスク2/2]
+  name-sort: ぜのさーが えぴそーどII［ぜんあくのひがん］ [でぃすく2/2]
+  name-en: "Xenosaga Episode II - Jenseits von Gut und Bose [Disc 2 of 2]"
   region: "NTSC-J"
   gsHWFixes:
     autoFlush: 2 # Fixes shadows in cutscenes.
@@ -51941,8 +52005,8 @@ SLPS-25639:
   name-en: "Plus Plum 2 Again"
   region: "NTSC-J"
 SLPS-25640:
-  name: ゼノサーガ エピソードIII [ツァラトゥストラはかく語りき]
-  name-sort: ぜのさーが えぴそーどIII [つぁらとぅすとらはかくかたりき]
+  name: ゼノサーガ エピソードIII [ツァラトゥストラはかく語りき] [ディスク1/2]
+  name-sort: ぜのさーが えぴそーどIII [つぁらとぅすとらはかくかたりき] [でぃすく1/2]
   name-en: "Xenosaga Episode III - Also Sprach Zarathustra [Disc 1 of 2]"
   region: "NTSC-J"
   compat: 5
@@ -51955,7 +52019,9 @@ SLPS-25640:
     - "SLPS-25640"
     - "SLPS-25368"
 SLPS-25641:
-  name: "Xenosaga Episode III - Also Sprach Zarathustra [Disc 2 of 2]"
+  name: ゼノサーガ エピソードIII [ツァラトゥストラはかく語りき] [ディスク2/2]
+  name-sort: ぜのさーが えぴそーどIII [つぁらとぅすとらはかくかたりき] [でぃすく2/2]
+  name-en: "Xenosaga Episode III - Also Sprach Zarathustra [Disc 2 of 2]"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
@@ -53853,8 +53919,8 @@ SLPS-73201:
   name-en: "Fatal Frame II - Crimson Butterfly [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPS-73202:
-  name: ARMORED CORE NEXUS PlayStation®2 the Best
-  name-sort: ARMORED CORE NEXUS PlayStation®2 the Best
+  name: ARMORED CORE NEXUS PlayStation®2 the Best [ディスク1/2]
+  name-sort: ARMORED CORE NEXUS PlayStation®2 the Best [でぃすく1/2]
   name-en: "Armored Core - Nexus [Disc 1] [PlayStation 2 The Best]"
   region: "NTSC-J"
   gsHWFixes:
@@ -53868,7 +53934,9 @@ SLPS-73202:
     - "SLPS-73202"
     - "SLPS-73203"
 SLPS-73203:
-  name: "Armored Core - Nexus [Disc 2] [PlayStation 2 The Best]"
+  name: ARMORED CORE NEXUS PlayStation®2 the Best [ディスク2/2]
+  name-sort: ARMORED CORE NEXUS PlayStation®2 the Best [でぃすく2/2]
+  name-en: "Armored Core - Nexus [Disc 2] [PlayStation 2 The Best]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
@@ -53947,8 +54015,8 @@ SLPS-73212:
   name-en: "Naruto Narutimett Hero [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPS-73214:
-  name: シャドウ ハーツ II ディレクターズカット PlayStation®2 the Best
-  name-sort: しゃどう はーつ II でぃれくたーずかっと PlayStation®2 the Best
+  name: シャドウ ハーツ II ディレクターズカット PlayStation®2 the Best [ディスク1/2]
+  name-sort: しゃどう はーつ II でぃれくたーずかっと PlayStation®2 the Best [でぃすく1/2]
   name-en: "Shadow Hearts 2 [Director's Cut] [PlayStation 2 The Best] [Disc 1 of 2]"
   region: "NTSC-J"
   gsHWFixes:
@@ -53957,7 +54025,9 @@ SLPS-73214:
     roundSprite: 2 # Fixes the position of monster sprites and reduces garbage in the UI.
     autoFlush: 2 # Makes the shadow monsters appear.
 SLPS-73215:
-  name: "Shadow Hearts 2 [Director's Cut] [PlayStation 2 The Best] [Disc 2 of 2]"
+  name: シャドウ ハーツ II ディレクターズカット PlayStation®2 the Best [ディスク2/2]
+  name-sort: しゃどう はーつ II でぃれくたーずかっと PlayStation®2 the Best [でぃすく2/2]
+  name-en: "Shadow Hearts 2 [Director's Cut] [PlayStation 2 The Best] [Disc 2 of 2]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurrines, preload frame for FMV breaks visuals with this setting.
@@ -54028,8 +54098,8 @@ SLPS-73223:
     alignSprite: 1 # Fixes vertical lines.
     getSkipCount: "GSC_Tekken5"
 SLPS-73224:
-  name: ゼノサーガ エピソードII［善悪の彼岸］ PlayStation®2 the Best
-  name-sort: ぜのさーが えぴそーどII［ぜんあくのひがん］ PlayStation®2 the Best
+  name: ゼノサーガ エピソードII［善悪の彼岸］ PlayStation®2 the Best [ディスク1/2]
+  name-sort: ぜのさーが えぴそーどII［ぜんあくのひがん］ PlayStation®2 the Best [でぃすく1/2]
   name-en: "Xenosaga Episode II - Jenseits von Gut und Bose [PlayStation 2 The Best] [Disc 1 of 2]"
   region: "NTSC-J"
   gsHWFixes:
@@ -54044,7 +54114,9 @@ SLPS-73224:
     - "SLPS-25353"
     - "SLPS-73224"
 SLPS-73225:
-  name: "Xenosaga Episode II - Jenseits von Gut und Bose [PlayStation 2 The Best] [Disc 2 of 2]"
+  name: ゼノサーガ エピソードII［善悪の彼岸］ PlayStation®2 the Best [ディスク2/2]
+  name-sort: ぜのさーが えぴそーどII［ぜんあくのひがん］ PlayStation®2 the Best [でぃすく2/2]
+  name-en: "Xenosaga Episode II - Jenseits von Gut und Bose [PlayStation 2 The Best] [Disc 2 of 2]"
   region: "NTSC-J"
   gsHWFixes:
     autoFlush: 2 # Fixes shadows in cutscenes.

--- a/pcsx2-qt/GameList/GameListModel.cpp
+++ b/pcsx2-qt/GameList/GameListModel.cpp
@@ -341,7 +341,7 @@ QVariant GameListModel::data(const QModelIndex& index, int role) const
 
 				case Column_Title:
 				case Column_Cover:
-					return QString::fromStdString(ge->title);
+					return QString::fromStdString(ge->GetTitleSort());
 
 				case Column_FileTitle:
 					return QtUtils::StringViewToQString(Path::GetFileTitle(ge->path));
@@ -438,7 +438,7 @@ bool GameListModel::titlesLessThan(int left_row, int right_row) const
 
 	const GameList::Entry* left = GameList::GetEntryByIndex(left_row);
 	const GameList::Entry* right = GameList::GetEntryByIndex(right_row);
-	return (StringUtil::Strcasecmp(left->title.c_str(), right->title.c_str()) < 0);
+	return (StringUtil::Strcasecmp(left->GetTitleSort().c_str(), right->GetTitleSort().c_str()) < 0);
 }
 
 bool GameListModel::lessThan(const QModelIndex& left_index, const QModelIndex& right_index, int column) const

--- a/pcsx2-qt/GameList/GameListModel.cpp
+++ b/pcsx2-qt/GameList/GameListModel.cpp
@@ -438,7 +438,7 @@ bool GameListModel::titlesLessThan(int left_row, int right_row) const
 
 	const GameList::Entry* left = GameList::GetEntryByIndex(left_row);
 	const GameList::Entry* right = GameList::GetEntryByIndex(right_row);
-	return (StringUtil::Strcasecmp(left->GetTitleSort().c_str(), right->GetTitleSort().c_str()) < 0);
+	return QtHost::LocaleSensitiveCompare(QString::fromStdString(left->GetTitleSort()), QString::fromStdString(right->GetTitleSort())) < 0;
 }
 
 bool GameListModel::lessThan(const QModelIndex& left_index, const QModelIndex& right_index, int column) const

--- a/pcsx2-qt/GameList/GameListModel.h
+++ b/pcsx2-qt/GameList/GameListModel.h
@@ -96,6 +96,7 @@ private:
 	float m_cover_scale = 0.0f;
 	std::atomic<u32> m_cover_scale_counter{0};
 	bool m_show_titles_for_covers = false;
+	bool m_prefer_english_titles = false;
 
 	std::array<QString, Column_Count> m_column_display_names;
 	std::array<QPixmap, static_cast<u32>(GameList::EntryType::Count)> m_type_pixmaps;

--- a/pcsx2-qt/GameList/GameListWidget.cpp
+++ b/pcsx2-qt/GameList/GameListWidget.cpp
@@ -87,7 +87,8 @@ public:
 			if (!m_filter_name.isEmpty() &&
 				!QString::fromStdString(entry->path).contains(m_filter_name, Qt::CaseInsensitive) &&
 				!QString::fromStdString(entry->serial).contains(m_filter_name, Qt::CaseInsensitive) &&
-				!QString::fromStdString(entry->title).contains(m_filter_name, Qt::CaseInsensitive))
+				!QString::fromStdString(entry->title).contains(m_filter_name, Qt::CaseInsensitive) &&
+				!QString::fromStdString(entry->title_en).contains(m_filter_name, Qt::CaseInsensitive))
 				return false;
 		}
 

--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -479,14 +479,14 @@ void MainWindow::recreate()
 void MainWindow::recreateSettings()
 {
 	QString current_category;
-	if (m_setings_window)
+	if (m_settings_window)
 	{
-		const bool was_visible = m_setings_window->isVisible();
+		const bool was_visible = m_settings_window->isVisible();
 
-		current_category = m_setings_window->getCategory();
-		m_setings_window->hide();
-		m_setings_window->deleteLater();
-		m_setings_window = nullptr;
+		current_category = m_settings_window->getCategory();
+		m_settings_window->hide();
+		m_settings_window->deleteLater();
+		m_settings_window = nullptr;
 
 		if (!was_visible)
 			return;
@@ -528,11 +528,11 @@ void MainWindow::destroySubWindows()
 		m_controller_settings_window = nullptr;
 	}
 
-	if (m_setings_window)
+	if (m_settings_window)
 	{
-		m_setings_window->close();
-		m_setings_window->deleteLater();
-		m_setings_window = nullptr;
+		m_settings_window->close();
+		m_settings_window->deleteLater();
+		m_settings_window = nullptr;
 	}
 }
 
@@ -610,7 +610,7 @@ void MainWindow::onShowAdvancedSettingsToggled(bool checked)
 	m_ui.menuDebug->menuAction()->setVisible(checked);
 
 	// just recreate the entire settings window, it's easier.
-	if (m_setings_window)
+	if (m_settings_window)
 		recreateSettings();
 }
 
@@ -2286,11 +2286,11 @@ void MainWindow::restoreDisplayWindowGeometryFromConfig()
 
 SettingsWindow* MainWindow::getSettingsWindow()
 {
-	if (!m_setings_window)
+	if (!m_settings_window)
 	{
-		m_setings_window = new SettingsWindow();
-		connect(m_setings_window->getInterfaceSettingsWidget(), &InterfaceSettingsWidget::themeChanged, this, &MainWindow::updateTheme);
-		connect(m_setings_window->getInterfaceSettingsWidget(), &InterfaceSettingsWidget::languageChanged, this, [this]() {
+		m_settings_window = new SettingsWindow();
+		connect(m_settings_window->getInterfaceSettingsWidget(), &InterfaceSettingsWidget::themeChanged, this, &MainWindow::updateTheme);
+		connect(m_settings_window->getInterfaceSettingsWidget(), &InterfaceSettingsWidget::languageChanged, this, [this]() {
 			// reopen settings dialog after it applies
 			updateLanguage();
 			// If you doSettings now, on macOS, the window will somehow end up underneath the main window that was created above
@@ -2299,12 +2299,12 @@ SettingsWindow* MainWindow::getSettingsWindow()
 				g_main_window->doSettings("Interface");
 			});
 		});
-		connect(m_setings_window->getGameListSettingsWidget(), &GameListSettingsWidget::preferEnglishGameListChanged, this, []{
+		connect(m_settings_window->getGameListSettingsWidget(), &GameListSettingsWidget::preferEnglishGameListChanged, this, []{
 			g_main_window->m_game_list_widget->refreshGridCovers();
 		});
 	}
 
-	return m_setings_window;
+	return m_settings_window;
 }
 
 void MainWindow::doSettings(const char* category /* = nullptr */)

--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -2299,6 +2299,9 @@ SettingsWindow* MainWindow::getSettingsWindow()
 				g_main_window->doSettings("Interface");
 			});
 		});
+		connect(m_setings_window->getGameListSettingsWidget(), &GameListSettingsWidget::preferEnglishGameListChanged, this, []{
+			g_main_window->m_game_list_widget->refreshGridCovers();
+		});
 	}
 
 	return m_setings_window;

--- a/pcsx2-qt/MainWindow.h
+++ b/pcsx2-qt/MainWindow.h
@@ -282,7 +282,7 @@ private:
 	DisplayWidget* m_display_widget = nullptr;
 	DisplayContainer* m_display_container = nullptr;
 
-	SettingsWindow* m_setings_window = nullptr;
+	SettingsWindow* m_settings_window = nullptr;
 	ControllerSettingsWindow* m_controller_settings_window = nullptr;
 	InputRecordingViewer* m_input_recording_viewer = nullptr;
 	AutoUpdaterDialog* m_auto_updater_dialog = nullptr;

--- a/pcsx2-qt/QtHost.cpp
+++ b/pcsx2-qt/QtHost.cpp
@@ -1296,6 +1296,7 @@ void Host::SetDefaultUISettings(SettingsInterface& si)
 	si.SetBoolValue("UI", "RenderToSeparateWindow", false);
 	si.SetBoolValue("UI", "HideMainWindowWhenRunning", false);
 	si.SetBoolValue("UI", "DisableWindowResize", false);
+	si.SetBoolValue("UI", "PreferEnglishGameList", false);
 	si.SetStringValue("UI", "Theme", QtHost::GetDefaultThemeName());
 }
 

--- a/pcsx2-qt/QtHost.h
+++ b/pcsx2-qt/QtHost.h
@@ -283,4 +283,7 @@ namespace QtHost
 	/// VM state, safe to access on UI thread.
 	bool IsVMValid();
 	bool IsVMPaused();
+
+	/// Compare strings in the locale of the current UI language
+	int LocaleSensitiveCompare(QStringView lhs, QStringView rhs);
 } // namespace QtHost

--- a/pcsx2-qt/Settings/GameListSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GameListSettingsWidget.cpp
@@ -93,11 +93,19 @@ void GameListSettingsWidget::refreshExclusionList()
 		m_ui.excludedPaths->addItem(QString::fromStdString(path));
 }
 
-void GameListSettingsWidget::resizeEvent(QResizeEvent* event)
+bool GameListSettingsWidget::event(QEvent* event)
 {
-	QWidget::resizeEvent(event);
+	bool res = QWidget::event(event);
 
-	QtUtils::ResizeColumnsForTableView(m_ui.searchDirectoryList, {-1, 100});
+	switch (event->type())
+	{
+		case QEvent::LayoutRequest:
+		case QEvent::Resize:
+			QtUtils::ResizeColumnsForTableView(m_ui.searchDirectoryList, {-1, 100});
+			break;
+	}
+
+	return res;
 }
 
 void GameListSettingsWidget::addPathToTable(const std::string& path, bool recursive)

--- a/pcsx2-qt/Settings/GameListSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GameListSettingsWidget.cpp
@@ -30,11 +30,20 @@
 #include "MainWindow.h"
 #include "QtHost.h"
 #include "QtUtils.h"
+#include "SettingWidgetBinder.h"
 
 GameListSettingsWidget::GameListSettingsWidget(SettingsWindow* dialog, QWidget* parent)
 	: QWidget(parent)
 {
+	SettingsInterface* sif = dialog->getSettingsInterface();
+
 	m_ui.setupUi(this);
+
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.preferEnglishGameList, "UI", "PreferEnglishGameList", false);
+	connect(m_ui.preferEnglishGameList, &QCheckBox::stateChanged, [this]{ emit preferEnglishGameListChanged(); });
+
+	dialog->registerWidgetHelp(m_ui.preferEnglishGameList, tr("Prefer English Titles"), tr("Unchecked"),
+		tr("For games with both a title in the game's native language and one in English, prefer the English title."));
 
 	m_ui.searchDirectoryList->setSelectionMode(QAbstractItemView::SingleSelection);
 	m_ui.searchDirectoryList->setSelectionBehavior(QAbstractItemView::SelectRows);

--- a/pcsx2-qt/Settings/GameListSettingsWidget.h
+++ b/pcsx2-qt/Settings/GameListSettingsWidget.h
@@ -32,6 +32,9 @@ public:
 	bool addExcludedPath(const std::string& path);
 	void refreshExclusionList();
 
+Q_SIGNALS:
+	void preferEnglishGameListChanged();
+
 public Q_SLOTS:
 	void addSearchDirectory(QWidget* parent_widget);
 

--- a/pcsx2-qt/Settings/GameListSettingsWidget.h
+++ b/pcsx2-qt/Settings/GameListSettingsWidget.h
@@ -49,7 +49,7 @@ private Q_SLOTS:
 	void onRescanAllGamesClicked();
 
 protected:
-	void resizeEvent(QResizeEvent* event);
+	bool event(QEvent* event);
 
 private:
 	void addPathToTable(const std::string& path, bool recursive);

--- a/pcsx2-qt/Settings/GameListSettingsWidget.ui
+++ b/pcsx2-qt/Settings/GameListSettingsWidget.ui
@@ -24,6 +24,22 @@
     <number>0</number>
    </property>
    <item>
+    <widget class="QGroupBox" name="gameListGroup">
+     <property name="title">
+      <string>Display</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_gameList">
+      <item row="0" column="0">
+       <widget class="QCheckBox" name="preferEnglishGameList">
+        <property name="text">
+         <string>Prefer English Titles</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <layout class="QHBoxLayout" name="horizontalLayout_2">
      <item>
       <widget class="QLabel" name="label">

--- a/pcsx2-qt/Settings/GameListSettingsWidget.ui
+++ b/pcsx2-qt/Settings/GameListSettingsWidget.ui
@@ -24,22 +24,6 @@
     <number>0</number>
    </property>
    <item>
-    <widget class="QGroupBox" name="gameListGroup">
-     <property name="title">
-      <string>Display</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_gameList">
-      <item row="0" column="0">
-       <widget class="QCheckBox" name="preferEnglishGameList">
-        <property name="text">
-         <string>Prefer English Titles</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
     <widget class="QGroupBox" name="gameScanningGroup">
      <property name="title">
       <string>Game Scanning</string>
@@ -260,6 +244,22 @@
          </widget>
         </item>
        </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="gameListGroup">
+     <property name="title">
+      <string>Display</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_gameList">
+      <item row="0" column="0">
+       <widget class="QCheckBox" name="preferEnglishGameList">
+        <property name="text">
+         <string>Prefer English Titles</string>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>

--- a/pcsx2-qt/Settings/GameListSettingsWidget.ui
+++ b/pcsx2-qt/Settings/GameListSettingsWidget.ui
@@ -40,220 +40,229 @@
     </widget>
    </item>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_2">
-     <item>
-      <widget class="QLabel" name="label">
-       <property name="text">
-        <string>Search Directories (will be scanned for games)</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer_2">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QToolButton" name="addSearchDirectoryButton">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string>Add...</string>
-       </property>
-       <property name="icon">
-        <iconset theme="folder-add-line">
-         <normaloff>.</normaloff>.</iconset>
-       </property>
-       <property name="toolButtonStyle">
-        <enum>Qt::ToolButtonTextBesideIcon</enum>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QToolButton" name="removeSearchDirectoryButton">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string>Remove</string>
-       </property>
-       <property name="icon">
-        <iconset theme="folder-reduce-line">
-         <normaloff>.</normaloff>.</iconset>
-       </property>
-       <property name="toolButtonStyle">
-        <enum>Qt::ToolButtonTextBesideIcon</enum>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item>
-    <widget class="QTableWidget" name="searchDirectoryList">
-     <column>
-      <property name="text">
-       <string>Search Directory</string>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>Scan Recursively</string>
-      </property>
-     </column>
+    <widget class="QGroupBox" name="gameScanningGroup">
+     <property name="title">
+      <string>Game Scanning</string>
+     </property>
+     <layout class="QVBoxLayout" name="gameScanningVBox">
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
+        <item>
+         <widget class="QLabel" name="label">
+          <property name="text">
+           <string>Search Directories (will be scanned for games)</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_2">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QToolButton" name="addSearchDirectoryButton">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>Add...</string>
+          </property>
+          <property name="icon">
+           <iconset theme="folder-add-line">
+            <normaloff>.</normaloff>.</iconset>
+          </property>
+          <property name="toolButtonStyle">
+           <enum>Qt::ToolButtonTextBesideIcon</enum>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QToolButton" name="removeSearchDirectoryButton">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>Remove</string>
+          </property>
+          <property name="icon">
+           <iconset theme="folder-reduce-line">
+            <normaloff>.</normaloff>.</iconset>
+          </property>
+          <property name="toolButtonStyle">
+           <enum>Qt::ToolButtonTextBesideIcon</enum>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <widget class="QTableWidget" name="searchDirectoryList">
+        <column>
+         <property name="text">
+          <string>Search Directory</string>
+         </property>
+        </column>
+        <column>
+         <property name="text">
+          <string>Scan Recursively</string>
+         </property>
+        </column>
+       </widget>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_3">
+        <item>
+         <widget class="QLabel" name="label_2">
+          <property name="text">
+           <string>Excluded Paths (will not be scanned)</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_3">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QToolButton" name="addExcludedPath">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>Directory...</string>
+          </property>
+          <property name="icon">
+           <iconset theme="folder-add-line">
+            <normaloff>.</normaloff>.</iconset>
+          </property>
+          <property name="toolButtonStyle">
+           <enum>Qt::ToolButtonTextBesideIcon</enum>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QToolButton" name="addExcludedFile">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>File...</string>
+          </property>
+          <property name="icon">
+           <iconset theme="file-add-line">
+            <normaloff>.</normaloff>.</iconset>
+          </property>
+          <property name="toolButtonStyle">
+           <enum>Qt::ToolButtonTextBesideIcon</enum>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QToolButton" name="removeExcludedPath">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>Remove</string>
+          </property>
+          <property name="icon">
+           <iconset theme="file-reduce-line">
+            <normaloff>.</normaloff>.</iconset>
+          </property>
+          <property name="toolButtonStyle">
+           <enum>Qt::ToolButtonTextBesideIcon</enum>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <widget class="QListWidget" name="excludedPaths"/>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <item>
+         <spacer name="horizontalSpacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QPushButton" name="scanForNewGames">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>Scan For New Games</string>
+          </property>
+          <property name="icon">
+           <iconset theme="file-search-line">
+            <normaloff>.</normaloff>.</iconset>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="rescanAllGames">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>Rescan All Games</string>
+          </property>
+          <property name="icon">
+           <iconset theme="refresh-line">
+            <normaloff>.</normaloff>.</iconset>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
     </widget>
-   </item>
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_3">
-     <item>
-      <widget class="QLabel" name="label_2">
-       <property name="text">
-        <string>Excluded Paths (will not be scanned)</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer_3">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QToolButton" name="addExcludedPath">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string>Directory...</string>
-       </property>
-       <property name="icon">
-        <iconset theme="folder-add-line">
-         <normaloff>.</normaloff>.</iconset>
-       </property>
-       <property name="toolButtonStyle">
-        <enum>Qt::ToolButtonTextBesideIcon</enum>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QToolButton" name="addExcludedFile">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string>File...</string>
-       </property>
-       <property name="icon">
-        <iconset theme="file-add-line">
-         <normaloff>.</normaloff>.</iconset>
-       </property>
-       <property name="toolButtonStyle">
-        <enum>Qt::ToolButtonTextBesideIcon</enum>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QToolButton" name="removeExcludedPath">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string>Remove</string>
-       </property>
-       <property name="icon">
-        <iconset theme="file-reduce-line">
-         <normaloff>.</normaloff>.</iconset>
-       </property>
-       <property name="toolButtonStyle">
-        <enum>Qt::ToolButtonTextBesideIcon</enum>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item>
-    <widget class="QListWidget" name="excludedPaths"/>
-   </item>
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <spacer name="horizontalSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QPushButton" name="scanForNewGames">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string>Scan For New Games</string>
-       </property>
-       <property name="icon">
-        <iconset theme="file-search-line">
-         <normaloff>.</normaloff>.</iconset>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="rescanAllGames">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string>Rescan All Games</string>
-       </property>
-       <property name="icon">
-        <iconset theme="refresh-line">
-         <normaloff>.</normaloff>.</iconset>
-       </property>
-      </widget>
-     </item>
-    </layout>
    </item>
   </layout>
  </widget>

--- a/pcsx2-qt/Settings/GameSummaryWidget.cpp
+++ b/pcsx2-qt/Settings/GameSummaryWidget.cpp
@@ -81,12 +81,20 @@ void GameSummaryWidget::populateInputProfiles()
 void GameSummaryWidget::populateDetails(const GameList::Entry* entry)
 {
 	m_ui.title->setText(QString::fromStdString(entry->title));
+	m_ui.titleSort->setText(QString::fromStdString(entry->title_sort));
+	m_ui.titleEN->setText(QString::fromStdString(entry->title_en));
 	m_ui.path->setText(QString::fromStdString(entry->path));
 	m_ui.serial->setText(QString::fromStdString(entry->serial));
 	m_ui.crc->setText(QString::fromStdString(fmt::format("{:08X}", entry->crc)));
 	m_ui.type->setCurrentIndex(static_cast<int>(entry->type));
 	m_ui.region->setCurrentIndex(static_cast<int>(entry->region));
 	m_ui.compatibility->setCurrentIndex(static_cast<int>(entry->compatibility_rating));
+
+	int row = 0;
+	m_ui.detailsFormLayout->getWidgetPosition(m_ui.titleSort, &row, nullptr);
+	m_ui.detailsFormLayout->setRowVisible(row, !entry->title_sort.empty());
+	m_ui.detailsFormLayout->getWidgetPosition(m_ui.titleEN, &row, nullptr);
+	m_ui.detailsFormLayout->setRowVisible(row, !entry->title_en.empty());
 
 	std::optional<std::string> profile(m_dialog->getStringValue("EmuCore", "InputProfileName", std::nullopt));
 	if (profile.has_value())
@@ -128,7 +136,9 @@ void GameSummaryWidget::populateDiscPath(const GameList::Entry* entry)
 	else
 	{
 		// Makes no sense to have disc override for a disc.
-		m_ui.detailsFormLayout->removeRow(8);
+		int row = 0;
+		m_ui.detailsFormLayout->getWidgetPosition(m_ui.label_discPath, &row, nullptr);
+		m_ui.detailsFormLayout->removeRow(row);
 		m_ui.discPath = nullptr;
 		m_ui.discPathBrowse = nullptr;
 		m_ui.discPathClear = nullptr;

--- a/pcsx2-qt/Settings/GameSummaryWidget.ui
+++ b/pcsx2-qt/Settings/GameSummaryWidget.ui
@@ -55,55 +55,83 @@
     </layout>
    </item>
    <item row="1" column="0">
-    <widget class="QLabel" name="label_2">
+    <widget class="QLabel" name="label_titleSort">
      <property name="text">
-      <string>Path:</string>
+      <string extracomment='Name for use in sorting (e.g. "XXX, The" for a game called "The XXX")'>Sorting Title:</string>
      </property>
     </widget>
    </item>
    <item row="1" column="1">
-    <widget class="QLineEdit" name="path">
+    <widget class="QLineEdit" name="titleSort">
      <property name="readOnly">
       <bool>true</bool>
      </property>
     </widget>
    </item>
    <item row="2" column="0">
-    <widget class="QLabel" name="label">
+    <widget class="QLabel" name="label_titleEN">
      <property name="text">
-      <string>Serial:</string>
+      <string>English Title:</string>
      </property>
     </widget>
    </item>
    <item row="2" column="1">
-    <widget class="QLineEdit" name="serial">
+    <widget class="QLineEdit" name="titleEN">
      <property name="readOnly">
       <bool>true</bool>
      </property>
     </widget>
    </item>
    <item row="3" column="0">
-    <widget class="QLabel" name="label_36">
+    <widget class="QLabel" name="label_2">
      <property name="text">
-      <string>CRC:</string>
+      <string>Path:</string>
      </property>
     </widget>
    </item>
    <item row="3" column="1">
-    <widget class="QLineEdit" name="crc">
+    <widget class="QLineEdit" name="path">
      <property name="readOnly">
       <bool>true</bool>
      </property>
     </widget>
    </item>
    <item row="4" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Serial:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1">
+    <widget class="QLineEdit" name="serial">
+     <property name="readOnly">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="0">
+    <widget class="QLabel" name="label_36">
+     <property name="text">
+      <string>CRC:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="1">
+    <widget class="QLineEdit" name="crc">
+     <property name="readOnly">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="0">
     <widget class="QLabel" name="label_5">
      <property name="text">
       <string>Type:</string>
      </property>
     </widget>
    </item>
-   <item row="4" column="1">
+   <item row="6" column="1">
     <widget class="QComboBox" name="type">
      <property name="enabled">
       <bool>false</bool>
@@ -146,14 +174,14 @@
      </item>
     </widget>
    </item>
-   <item row="5" column="0">
+   <item row="7" column="0">
     <widget class="QLabel" name="label_3">
      <property name="text">
       <string>Region:</string>
      </property>
     </widget>
    </item>
-   <item row="5" column="1">
+   <item row="7" column="1">
     <layout class="QHBoxLayout" name="horizontalLayout_6">
       <item>
         <widget class="QComboBox" name="region">
@@ -327,14 +355,14 @@
      </item>
     </layout>
    </item>
-   <item row="6" column="0">
+   <item row="8" column="0">
     <widget class="QLabel" name="label_7">
      <property name="text">
       <string>Compatibility:</string>
      </property>
     </widget>
    </item>
-   <item row="6" column="1">
+   <item row="8" column="1">
     <widget class="QComboBox" name="compatibility">
      <property name="enabled">
       <bool>false</bool>
@@ -385,14 +413,14 @@
      </item>
     </widget>
    </item>
-   <item row="7" column="0">
+   <item row="9" column="0">
     <widget class="QLabel" name="label_6">
      <property name="text">
       <string>Input Profile:</string>
      </property>
     </widget>
    </item>
-   <item row="7" column="1">
+   <item row="9" column="1">
     <widget class="QComboBox" name="inputProfile">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -407,14 +435,14 @@
      </item>
     </widget>
    </item>
-   <item row="8" column="0">
-    <widget class="QLabel" name="label_8">
+   <item row="10" column="0">
+    <widget class="QLabel" name="label_discPath">
      <property name="text">
       <string>Disc Path:</string>
      </property>
     </widget>
    </item>
-   <item row="8" column="1">
+   <item row="10" column="1">
     <layout class="QHBoxLayout" name="horizontalLayout_2">
      <item>
       <widget class="QLineEdit" name="discPath"/>
@@ -435,7 +463,7 @@
      </item>
     </layout>
    </item>
-   <item row="10" column="0" colspan="2">
+   <item row="11" column="0" colspan="2">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -448,7 +476,7 @@
      </property>
     </spacer>
    </item>
-   <item row="9" column="0" colspan="2">
+   <item row="12" column="0" colspan="2">
     <layout class="QVBoxLayout" name="verifyLayout">
      <item>
       <widget class="QTableWidget" name="tracks">

--- a/pcsx2-qt/Translations.cpp
+++ b/pcsx2-qt/Translations.cpp
@@ -66,6 +66,9 @@ namespace QtHost
 	static const GlyphInfo* GetGlyphInfo(const std::string_view& language);
 
 	static std::vector<ImWchar> s_glyph_ranges;
+
+	static QLocale s_current_locale;
+	static QCollator s_current_collator;
 } // namespace QtHost
 
 static std::vector<QTranslator*> s_translators;
@@ -111,6 +114,11 @@ void QtHost::InstallTranslator()
 		QString::fromStdString(Host::GetBaseStringSettingValue("UI", "Language", GetDefaultLanguage()));
 	if (language == QStringLiteral("system"))
 		language = getSystemLanguage();
+
+	QString qlanguage = language;
+	qlanguage.replace('-', '_');
+	s_current_locale = QLocale(qlanguage);
+	s_current_collator = QCollator(s_current_locale);
 
 	// Install the base qt translation first.
 #ifdef __APPLE__
@@ -374,4 +382,9 @@ const QtHost::GlyphInfo* QtHost::GetGlyphInfo(const std::string_view& language)
 	}
 
 	return nullptr;
+}
+
+int QtHost::LocaleSensitiveCompare(QStringView lhs, QStringView rhs)
+{
+	return s_current_collator.compare(lhs, rhs);
 }

--- a/pcsx2/Docs/gamedb-schema.json
+++ b/pcsx2/Docs/gamedb-schema.json
@@ -12,6 +12,14 @@
           "type": "string",
           "description": "The name of the game, an arbitrary string"
         },
+        "name-sort": {
+          "type": "string",
+          "description": "The name of the game for use in sorting, an arbitrary string"
+        },
+        "name-en": {
+          "type": "string",
+          "description": "The name of the game in ASCII, an arbitrary string"
+        },
         "region": {
           "type": "string",
           "description": "The region code for the game, for example NTSC-U",

--- a/pcsx2/GameDatabase.cpp
+++ b/pcsx2/GameDatabase.cpp
@@ -103,6 +103,14 @@ void GameDatabase::parseAndInsert(const std::string_view& serial, const c4::yml:
 	{
 		node["name"] >> gameEntry.name;
 	}
+	if (node.has_child("name-sort"))
+	{
+		node["name-sort"] >> gameEntry.name_sort;
+	}
+	if (node.has_child("name-en"))
+	{
+		node["name-en"] >> gameEntry.name_en;
+	}
 	if (node.has_child("region"))
 	{
 		node["region"] >> gameEntry.region;

--- a/pcsx2/GameDatabase.h
+++ b/pcsx2/GameDatabase.h
@@ -104,6 +104,8 @@ namespace GameDatabaseSchema
 	struct GameEntry
 	{
 		std::string name;
+		std::string name_sort;
+		std::string name_en;
 		std::string region;
 		Compatibility compat = Compatibility::Unknown;
 		RoundMode eeRoundMode = RoundMode::Undefined;

--- a/pcsx2/GameList.cpp
+++ b/pcsx2/GameList.cpp
@@ -50,7 +50,7 @@ namespace GameList
 	enum : u32
 	{
 		GAME_LIST_CACHE_SIGNATURE = 0x45434C47,
-		GAME_LIST_CACHE_VERSION = 33,
+		GAME_LIST_CACHE_VERSION = 34,
 
 
 		PLAYED_TIME_SERIAL_LENGTH = 32,
@@ -340,6 +340,8 @@ bool GameList::GetIsoListEntry(const std::string& path, GameList::Entry* entry)
 	if (const GameDatabaseSchema::GameEntry* db_entry = GameDatabase::findGame(entry->serial))
 	{
 		entry->title = std::move(db_entry->name);
+		entry->title_sort = std::move(db_entry->name_sort);
+		entry->title_en = std::move(db_entry->name_en);
 		entry->compatibility_rating = db_entry->compat;
 		entry->region = ParseDatabaseRegion(db_entry->region);
 	}
@@ -443,10 +445,11 @@ bool GameList::LoadEntriesFromCache(std::FILE* stream)
 		u8 compatibility_rating;
 		u64 last_modified_time;
 
-		if (!ReadString(stream, &path) || !ReadString(stream, &ge.serial) || !ReadString(stream, &ge.title) || !ReadU8(stream, &type) ||
-			!ReadU8(stream, &region) || !ReadU64(stream, &ge.total_size) || !ReadU64(stream, &last_modified_time) ||
-			!ReadU32(stream, &ge.crc) || !ReadU8(stream, &compatibility_rating) || region >= static_cast<u8>(Region::Count) ||
-			type >= static_cast<u8>(EntryType::Count) || compatibility_rating > static_cast<u8>(CompatibilityRating::Perfect))
+		if (!ReadString(stream, &path) || !ReadString(stream, &ge.serial) || !ReadString(stream, &ge.title) || !ReadString(stream, &ge.title_sort) ||
+			!ReadString(stream, &ge.title_en) || !ReadU8(stream, &type) || !ReadU8(stream, &region) || !ReadU64(stream, &ge.total_size) ||
+			!ReadU64(stream, &last_modified_time) || !ReadU32(stream, &ge.crc) || !ReadU8(stream, &compatibility_rating) ||
+			region >= static_cast<u8>(Region::Count) || type >= static_cast<u8>(EntryType::Count) ||
+			compatibility_rating > static_cast<u8>(CompatibilityRating::Perfect))
 		{
 			Console.Warning("Game list cache entry is corrupted");
 			return false;
@@ -538,6 +541,8 @@ bool GameList::WriteEntryToCache(const Entry* entry)
 	result &= WriteString(s_cache_write_stream, entry->path);
 	result &= WriteString(s_cache_write_stream, entry->serial);
 	result &= WriteString(s_cache_write_stream, entry->title);
+	result &= WriteString(s_cache_write_stream, entry->title_sort);
+	result &= WriteString(s_cache_write_stream, entry->title_en);
 	result &= WriteU8(s_cache_write_stream, static_cast<u8>(entry->type));
 	result &= WriteU8(s_cache_write_stream, static_cast<u8>(entry->region));
 	result &= WriteU64(s_cache_write_stream, entry->total_size);

--- a/pcsx2/GameList.h
+++ b/pcsx2/GameList.h
@@ -90,10 +90,15 @@ namespace GameList
 		std::string path;
 		std::string serial;
 		std::string title;
+		std::string title_sort;
+		std::string title_en;
 		u64 total_size = 0;
 		std::time_t last_modified_time = 0;
 		std::time_t last_played_time = 0;
 		std::time_t total_played_time = 0;
+
+		const std::string& GetTitleEN() const { return title_en.empty() ? title : title_en; }
+		const std::string& GetTitleSort() const { return title_sort.empty() ? title : title_sort; }
 
 		u32 crc = 0;
 

--- a/pcsx2/GameList.h
+++ b/pcsx2/GameList.h
@@ -97,8 +97,17 @@ namespace GameList
 		std::time_t last_played_time = 0;
 		std::time_t total_played_time = 0;
 
-		const std::string& GetTitleEN() const { return title_en.empty() ? title : title_en; }
-		const std::string& GetTitleSort() const { return title_sort.empty() ? title : title_sort; }
+		const std::string& GetTitle(bool force_en = false) const
+		{
+			return title_en.empty() || !force_en ? title : title_en;
+		}
+		const std::string& GetTitleSort(bool force_en = false) const
+		{
+			// If there's a separate EN title, then title_sort is in the wrong language and we can't use it
+			if (force_en && !title_en.empty())
+				return title_en;
+			return title_sort.empty() ? title : title_sort;
+		}
 
 		u32 crc = 0;
 

--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -2460,7 +2460,7 @@ void FullscreenUI::DrawSettingsWindow()
 		if (s_game_settings_entry)
 		{
 			NavTitle(SmallString::from_fmt(
-				"{} ({})", Host::TranslateToCString(TR_CONTEXT, titles[static_cast<u32>(pages[index])]), s_game_settings_entry->title));
+				"{} ({})", Host::TranslateToCString(TR_CONTEXT, titles[static_cast<u32>(pages[index])]), s_game_settings_entry->GetTitleEN()));
 		}
 		else
 		{
@@ -2575,8 +2575,8 @@ void FullscreenUI::DrawSummarySettingsPage()
 
 	if (s_game_settings_entry)
 	{
-		if (MenuButton(FSUI_ICONSTR(ICON_FA_WINDOW_MAXIMIZE, "Title"), s_game_settings_entry->title.c_str(), true))
-			CopyTextToClipboard(FSUI_STR("Game title copied to clipboard."), s_game_settings_entry->title);
+		if (MenuButton(FSUI_ICONSTR(ICON_FA_WINDOW_MAXIMIZE, "Title"), s_game_settings_entry->GetTitleEN().c_str(), true))
+			CopyTextToClipboard(FSUI_STR("Game title copied to clipboard."), s_game_settings_entry->GetTitleEN());
 		if (MenuButton(FSUI_ICONSTR(ICON_FA_PAGER, "Serial"), s_game_settings_entry->serial.c_str(), true))
 			CopyTextToClipboard(FSUI_STR("Game serial copied to clipboard."), s_game_settings_entry->serial);
 		if (MenuButton(FSUI_ICONSTR(ICON_FA_CODE, "CRC"), fmt::format("{:08X}", s_game_settings_entry->crc).c_str(), true))
@@ -5438,7 +5438,7 @@ void FullscreenUI::PopulateGameListEntryList()
 			}
 
 			// fallback to title when all else is equal
-			const int res = StringUtil::Strcasecmp(lhs->title.c_str(), rhs->title.c_str());
+			const int res = StringUtil::Strcasecmp(lhs->GetTitleEN().c_str(), rhs->GetTitleEN().c_str());
 			return reverse ? (res > 0) : (res < 0);
 		});
 }
@@ -5574,7 +5574,8 @@ void FullscreenUI::DrawGameList(const ImVec2& heading_size)
 			const ImRect summary_bb(ImVec2(text_start_x, midpoint), bb.Max);
 
 			ImGui::PushFont(g_large_font);
-			ImGui::RenderTextClipped(title_bb.Min, title_bb.Max, entry->title.c_str(), entry->title.c_str() + entry->title.size(), nullptr,
+			// TODO: Fix font fallback issues and enable native-language titles
+			ImGui::RenderTextClipped(title_bb.Min, title_bb.Max, entry->GetTitleEN().c_str(), entry->GetTitleEN().c_str() + entry->GetTitleEN().size(), nullptr,
 				ImVec2(0.0f, 0.0f), &title_bb);
 			ImGui::PopFont();
 
@@ -5634,12 +5635,11 @@ void FullscreenUI::DrawGameList(const ImVec2& heading_size)
 		{
 			// title
 			ImGui::PushFont(g_large_font);
-			const std::string_view title(
-				std::string_view(selected_entry->title).substr(0, (selected_entry->title.length() > 37) ? 37 : std::string_view::npos));
+			const std::string_view title(std::string_view(selected_entry->GetTitleEN()).substr(0, 37));
 			text_width = ImGui::CalcTextSize(title.data(), title.data() + title.length(), false, work_width).x;
 			ImGui::SetCursorPosX((work_width - text_width) / 2.0f);
 			ImGui::TextWrapped(
-				"%.*s%s", static_cast<int>(title.size()), title.data(), (title.length() == selected_entry->title.length()) ? "" : "...");
+				"%.*s%s", static_cast<int>(title.size()), title.data(), (title.length() == selected_entry->GetTitleEN().length()) ? "" : "...");
 			ImGui::PopFont();
 
 			ImGui::PushFont(g_medium_font);
@@ -5785,10 +5785,9 @@ void FullscreenUI::DrawGameGrid(const ImVec2& heading_size)
 				ImVec2(1.0f, 1.0f), IM_COL32(255, 255, 255, 255));
 
 			const ImRect title_bb(ImVec2(bb.Min.x, bb.Min.y + image_height + title_spacing), bb.Max);
-			const std::string_view title(
-				std::string_view(entry->title).substr(0, (entry->title.length() > 31) ? 31 : std::string_view::npos));
+			const std::string_view title(std::string_view(entry->GetTitleEN()).substr(0, 31));
 			draw_title.clear();
-			fmt::format_to(std::back_inserter(draw_title), "{}{}", title, (title.length() == entry->title.length()) ? "" : "...");
+			fmt::format_to(std::back_inserter(draw_title), "{}{}", title, (title.length() == entry->GetTitleEN().length()) ? "" : "...");
 			ImGui::PushFont(g_medium_font);
 			ImGui::RenderTextClipped(title_bb.Min, title_bb.Max, draw_title.c_str(), draw_title.c_str() + draw_title.length(), nullptr,
 				ImVec2(0.5f, 0.0f), &title_bb);
@@ -5842,7 +5841,7 @@ void FullscreenUI::HandleGameListOptions(const GameList::Entry* entry)
 	};
 
 	const bool has_resume_state = VMManager::HasSaveStateInSlot(entry->serial.c_str(), entry->crc, -1);
-	OpenChoiceDialog(entry->title.c_str(), false, std::move(options),
+	OpenChoiceDialog(entry->GetTitleEN().c_str(), false, std::move(options),
 		[has_resume_state, entry_path = entry->path, entry_serial = entry->serial](s32 index, const std::string& title, bool checked) {
 			switch (index)
 			{

--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -2460,7 +2460,7 @@ void FullscreenUI::DrawSettingsWindow()
 		if (s_game_settings_entry)
 		{
 			NavTitle(SmallString::from_fmt(
-				"{} ({})", Host::TranslateToCString(TR_CONTEXT, titles[static_cast<u32>(pages[index])]), s_game_settings_entry->GetTitleEN()));
+				"{} ({})", Host::TranslateToCString(TR_CONTEXT, titles[static_cast<u32>(pages[index])]), s_game_settings_entry->GetTitle(true)));
 		}
 		else
 		{
@@ -2575,8 +2575,8 @@ void FullscreenUI::DrawSummarySettingsPage()
 
 	if (s_game_settings_entry)
 	{
-		if (MenuButton(FSUI_ICONSTR(ICON_FA_WINDOW_MAXIMIZE, "Title"), s_game_settings_entry->GetTitleEN().c_str(), true))
-			CopyTextToClipboard(FSUI_STR("Game title copied to clipboard."), s_game_settings_entry->GetTitleEN());
+		if (MenuButton(FSUI_ICONSTR(ICON_FA_WINDOW_MAXIMIZE, "Title"), s_game_settings_entry->GetTitle(true).c_str(), true))
+			CopyTextToClipboard(FSUI_STR("Game title copied to clipboard."), s_game_settings_entry->GetTitle(true));
 		if (MenuButton(FSUI_ICONSTR(ICON_FA_PAGER, "Serial"), s_game_settings_entry->serial.c_str(), true))
 			CopyTextToClipboard(FSUI_STR("Game serial copied to clipboard."), s_game_settings_entry->serial);
 		if (MenuButton(FSUI_ICONSTR(ICON_FA_CODE, "CRC"), fmt::format("{:08X}", s_game_settings_entry->crc).c_str(), true))
@@ -5438,7 +5438,7 @@ void FullscreenUI::PopulateGameListEntryList()
 			}
 
 			// fallback to title when all else is equal
-			const int res = StringUtil::Strcasecmp(lhs->GetTitleEN().c_str(), rhs->GetTitleEN().c_str());
+			const int res = StringUtil::Strcasecmp(lhs->GetTitleSort(true).c_str(), rhs->GetTitleSort(true).c_str());
 			return reverse ? (res > 0) : (res < 0);
 		});
 }
@@ -5575,7 +5575,7 @@ void FullscreenUI::DrawGameList(const ImVec2& heading_size)
 
 			ImGui::PushFont(g_large_font);
 			// TODO: Fix font fallback issues and enable native-language titles
-			ImGui::RenderTextClipped(title_bb.Min, title_bb.Max, entry->GetTitleEN().c_str(), entry->GetTitleEN().c_str() + entry->GetTitleEN().size(), nullptr,
+			ImGui::RenderTextClipped(title_bb.Min, title_bb.Max, entry->GetTitle(true).c_str(), entry->GetTitle(true).c_str() + entry->GetTitle(true).size(), nullptr,
 				ImVec2(0.0f, 0.0f), &title_bb);
 			ImGui::PopFont();
 
@@ -5635,11 +5635,11 @@ void FullscreenUI::DrawGameList(const ImVec2& heading_size)
 		{
 			// title
 			ImGui::PushFont(g_large_font);
-			const std::string_view title(std::string_view(selected_entry->GetTitleEN()).substr(0, 37));
+			const std::string_view title(std::string_view(selected_entry->GetTitle(true)).substr(0, 37));
 			text_width = ImGui::CalcTextSize(title.data(), title.data() + title.length(), false, work_width).x;
 			ImGui::SetCursorPosX((work_width - text_width) / 2.0f);
 			ImGui::TextWrapped(
-				"%.*s%s", static_cast<int>(title.size()), title.data(), (title.length() == selected_entry->GetTitleEN().length()) ? "" : "...");
+				"%.*s%s", static_cast<int>(title.size()), title.data(), (title.length() == selected_entry->GetTitle(true).length()) ? "" : "...");
 			ImGui::PopFont();
 
 			ImGui::PushFont(g_medium_font);
@@ -5785,9 +5785,9 @@ void FullscreenUI::DrawGameGrid(const ImVec2& heading_size)
 				ImVec2(1.0f, 1.0f), IM_COL32(255, 255, 255, 255));
 
 			const ImRect title_bb(ImVec2(bb.Min.x, bb.Min.y + image_height + title_spacing), bb.Max);
-			const std::string_view title(std::string_view(entry->GetTitleEN()).substr(0, 31));
+			const std::string_view title(std::string_view(entry->GetTitle(true)).substr(0, 31));
 			draw_title.clear();
-			fmt::format_to(std::back_inserter(draw_title), "{}{}", title, (title.length() == entry->GetTitleEN().length()) ? "" : "...");
+			fmt::format_to(std::back_inserter(draw_title), "{}{}", title, (title.length() == entry->GetTitle(true).length()) ? "" : "...");
 			ImGui::PushFont(g_medium_font);
 			ImGui::RenderTextClipped(title_bb.Min, title_bb.Max, draw_title.c_str(), draw_title.c_str() + draw_title.length(), nullptr,
 				ImVec2(0.5f, 0.0f), &title_bb);
@@ -5841,7 +5841,7 @@ void FullscreenUI::HandleGameListOptions(const GameList::Entry* entry)
 	};
 
 	const bool has_resume_state = VMManager::HasSaveStateInSlot(entry->serial.c_str(), entry->crc, -1);
-	OpenChoiceDialog(entry->GetTitleEN().c_str(), false, std::move(options),
+	OpenChoiceDialog(entry->GetTitle(true).c_str(), false, std::move(options),
 		[has_resume_state, entry_path = entry->path, entry_serial = entry->serial](s32 index, const std::string& title, bool checked) {
 			switch (index)
 			{


### PR DESCRIPTION
### Description of Changes
Switches the main display of GameDB entries to the game's native language in Qt (bigpicture coming later)
(Note: I only added native language entries to Japanese games, we still need someone to do it for the Korean games.)
...plus a few modifications to the gamedb validation scripts so you actually see line numbers when validation fails

### Questions:
Should I include an option to force English titles?  If so, where should I put it?

### Rationale behind Changes
It would be pretty goofy to have the entire UI translated into Japanese, but still use English titles

### Suggested Testing Steps
- Make sure your Japanese games show in Japanese in the game list
- Make sure the Japanese games sort properly (should be gojuuon order by pronunciation of the kanji)
