### PR TITLE
Counters: Don't skip vblanks on video mode change

### DIFF
--- a/pcsx2/Counters.cpp
+++ b/pcsx2/Counters.cpp
@@ -465,11 +465,10 @@ void UpdateVSyncRate(bool force)
 		if (custom && video_mode_initialized)
 			Console.Indent().WriteLn(Color_StrongGreen, "... with user configured refresh rate: %.02f Hz", vertical_frequency);
 
-		hsyncCounter.CycleT = vSyncInfo.hRender; // Amount of cycles before the counter will be updated
-		vsyncCounter.CycleT = vSyncInfo.Render;  // Amount of cycles before the counter will be updated
-		hsyncCounter.sCycle = cpuRegs.cycle;
-		vsyncCounter.sCycle = cpuRegs.cycle;
-		vsyncCounter.Mode = MODE_VRENDER;
+		hsyncCounter.CycleT = (hsyncCounter.Mode == MODE_HBLANK) ? vSyncInfo.hBlank : vSyncInfo.hRender;
+		vsyncCounter.CycleT = (vsyncCounter.Mode == MODE_GSBLANK) ?
+								  vSyncInfo.GSBlank :
+								  ((vsyncCounter.Mode == MODE_VSYNC) ? vSyncInfo.Blank : vSyncInfo.Render);
 		cpuRcntSet();
 
 		PerformanceMetrics::SetVerticalFrequency(vertical_frequency);
@@ -683,7 +682,7 @@ __fi void rcntUpdate_hScanline()
 	if( !cpuTestCycle( hsyncCounter.sCycle, hsyncCounter.CycleT ) ) return;
 
 	//iopEventAction = 1;
-	if (hsyncCounter.Mode & MODE_HBLANK) { //HBLANK Start
+	if (hsyncCounter.Mode == MODE_HBLANK) { //HBLANK Start
 		rcntStartGate(false, hsyncCounter.sCycle);
 		psxCheckStartGate16(0);
 


### PR DESCRIPTION
### Description of Changes

Resetting the vsync counter state to render every time `UpdateVSyncRate()` is called can end up missing GS IRQs and the CSR flip.

This was ultimately the cause of #9929, but #9933 also fixes it because it avoids calling `UpdateVSyncRate()` in the config change scenario.

Ultimately we need both to be correct, but I split them into two separate PRs, because of the (slim) chance of regressions.

### Rationale behind Changes

Not skipping IRQs.

### Suggested Testing Steps

Smoke test a few games, preferably both PAL and NTSC. Need to boot them from the start, not load state.
