### PR TITLE
GameDB: Add VU Clamping to Twisted Metal - Head-On

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -10417,6 +10417,8 @@ SCUS-97621:
   name: "Twisted Metal - Head-On [Extra Twisted Edition]"
   region: "NTSC-U"
   compat: 5
+  clampModes:
+    vu1ClampMode: 3 # Fixes missing textures.
   gameFixes:
     - VUSyncHack # Fixes black doors on vehicles.
   patches:

--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -10427,6 +10427,8 @@ SCUS-97621:
         author=refraction
         // COP2 rearrangement. RSQRT directly followed by DIV and a few ops using Q causes issues
         // Fixes fire effects
+        patch=1,EE,00237eb0,word,4b000060
+        patch=1,EE,00237ec0,word,4a0203bd
         patch=1,EE,002461d8,word,4bf4b33c
         patch=1,EE,002461dc,word,4b806d9c
         patch=1,EE,002461e0,word,4bc069fc


### PR DESCRIPTION
Fixes missing textures in the game. For example, in the cutscene before the final boss.