### PR TITLE
GameDB: Upscaling fixes for King's Field IV

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -13712,7 +13712,8 @@ SLES-50920:
   compat: 5
   gsHWFixes:
     preloadFrameData: 1 # Fixes invisible lava, there is another issue that needs skipdraw 1 for blurry font but it removes much brightness.
-    halfPixelOffset: 2 # Fixes font rendering.
+    cpuSpriteRenderBW: 2 # Fixes sky and lava when upscaling.
+    cpuSpriteRenderLevel: 2 # Needed for above.
   patches:
     401F4726:
       content: |-
@@ -42653,7 +42654,8 @@ SLPS-25057:
   region: "NTSC-J"
   gsHWFixes:
     preloadFrameData: 1 # Fixes invisible lava, there is another issue that needs skipdraw 1 for blurry font but it removes much brightness.
-    halfPixelOffset: 2 # Fixes font rendering.
+    cpuSpriteRenderBW: 2 # Fixes sky and lava when upscaling.
+    cpuSpriteRenderLevel: 2 # Needed for above.
   patches:
     04C3765E:
       content: |-
@@ -48122,7 +48124,8 @@ SLUS-20318:
   compat: 5
   gsHWFixes:
     preloadFrameData: 1 # Fixes invisible lava, there is another issue that needs skipdraw 1 for blurry font but it removes much brightness.
-    halfPixelOffset: 2 # Fixes font rendering.
+    cpuSpriteRenderBW: 2 # Fixes sky and lava when upscaling.
+    cpuSpriteRenderLevel: 2 # Needed for above.
   patches:
     36E02E91:
       content: |-
@@ -48290,7 +48293,8 @@ SLUS-20353:
   region: "NTSC-U"
   gsHWFixes:
     preloadFrameData: 1 # Fixes invisible lava, there is another issue that needs skipdraw 1 for blurry font but it removes much brightness.
-    halfPixelOffset: 2 # Fixes font rendering.
+    cpuSpriteRenderBW: 2 # Fixes sky and lava when upscaling.
+    cpuSpriteRenderLevel: 2 # Needed for above.
 SLUS-20354:
   name: "Red Card Soccer 2003"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
Added Upscaling fixes to King's Field IV
### Rationale behind Changes
Removes white lines on sky and lava when upscaling.
### Suggested Testing Steps
Already tested.

![King's Field IV - The Ancient City_SLUS-20318_20230909214438](https://github.com/PCSX2/pcsx2/assets/61622979/7231b2e5-5ec8-48d5-91ac-6517438b2c51)

[King's Field IV - The Ancient City_SLUS-20318_20230909214438.gs.zip](https://github.com/PCSX2/pcsx2/files/12566595/King.s.Field.IV.-.The.Ancient.City_SLUS-20318_20230909214438.gs.zip)

closes #3811 