### PR TITLE
GS/HW: Restore scissor after draw

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -4724,6 +4724,9 @@ void GSRendererHW::CleanupDraw(bool invalidate_temp_src)
 	if (invalidate_temp_src)
 		g_texture_cache->InvalidateTemporarySource();
 
+	// Restore Scissor.
+	m_context->UpdateScissor();
+
 	// Restore offsets.
 	if ((m_context->FRAME.U32[0] ^ m_cached_ctx.FRAME.U32[0]) & 0x3f3f01ff)
 		m_context->offset.fb = m_mem.GetOffset(m_context->FRAME.Block(), m_context->FRAME.FBW, m_context->FRAME.PSM);

--- a/pcsx2/VUops.cpp
+++ b/pcsx2/VUops.cpp
@@ -2693,10 +2693,10 @@ void _vuXGKICKTransfer(s32 cycles, bool flush)
 		{
 			VUM_LOG("XGKICK transfer finished");
 			VU1.xgkickenable = false;
+			VU0.VI[REG_VPU_STAT].UL &= ~(1 << 12);
 			// Check if VIF is waiting for the GIF to not be busy
 			if (vif1Regs.stat.VGW)
 			{
-				VU0.VI[REG_VPU_STAT].UL &= ~(1 << 12);
 				vif1Regs.stat.VGW = false;
 				CPU_INT(DMAC_VIF1, 8);
 			}


### PR DESCRIPTION
### Description of Changes
Restores the scissor after a hardware draw is finished.

### Rationale behind Changes
We can mess with the scissor during a draw, and if this doesn't get updated by writing to SCISSOR or XYOFFSET then it will retain the fiddled scissor, even if it's not correct for the next draw, this corrects that.  It was very prevalent in the Crash Tag Team Racing menu where it would stop updating the lower 2/3 of the image after a period of time.

### Suggested Testing Steps
Test Crash Tag Team Racing (idling in the menu and seeing if it screws up is probably good enough), and smoke test some other games

