### PR TITLE
VIF: Correct DMA stall for VIF1 MFIFO - Improve IPU Core/DMA call flow

### DIFF
--- a/pcsx2/Dmac.h
+++ b/pcsx2/Dmac.h
@@ -336,6 +336,7 @@ union tDMAC_CTRL {
 	tDMAC_CTRL(u32 val) { _u32 = val; }
 
 	bool test(u32 flags) const { return !!(_u32 & flags); }
+	bool is_mfifo(bool is_vif) const { return (is_vif) ? (MFD == MFD_VIF1) : (MFD == MFD_GIF); }
 	void set_flags(u32 flags) { _u32 |= flags; }
 	void clear_flags(u32 flags) { _u32 &= ~flags; }
 	void reset() { _u32 = 0; }

--- a/pcsx2/GS.cpp
+++ b/pcsx2/GS.cpp
@@ -50,6 +50,7 @@ static __fi void gsCSRwrite( const tGS_CSR& csr )
 		//gifUnit.Reset(true); // Don't think gif should be reset...
 		gifUnit.gsSIGNAL.queued = false;
 		gifUnit.gsFINISH.gsFINISHFired = true;
+		gifUnit.gsFINISH.gsFINISHPending = false;
 		// Privilage registers also reset.
 		std::memset(g_RealGSMem, 0, sizeof(g_RealGSMem));
 		GSIMR.reset();
@@ -84,6 +85,7 @@ static __fi void gsCSRwrite( const tGS_CSR& csr )
 	if (csr.FINISH)	{
 		CSRreg.FINISH = false;
 		gifUnit.gsFINISH.gsFINISHFired = false; //Clear the previously fired FINISH (YS, Indiecar 2005, MGS3)
+		gifUnit.gsFINISH.gsFINISHPending = false;
 	}
 	if(csr.HSINT)	CSRreg.HSINT	= false;
 	if(csr.VSINT)	CSRreg.VSINT	= false;

--- a/pcsx2/Gif_Unit.cpp
+++ b/pcsx2/Gif_Unit.cpp
@@ -84,8 +84,8 @@ bool Gif_HandlerAD(u8* pMem)
 	else if (reg == GIF_A_D_REG_FINISH)
 	{ // FINISH
 		GUNIT_WARN("GIF Handler - FINISH");
-		CSRreg.FINISH = true;
 		gifUnit.gsFINISH.gsFINISHFired = false;
+		gifUnit.gsFINISH.gsFINISHPending = true;
 	}
 	else if (reg == GIF_A_D_REG_LABEL)
 	{ // LABEL
@@ -188,6 +188,11 @@ bool Gif_HandlerAD_Debug(u8* pMem)
 
 void Gif_FinishIRQ()
 {
+	if (gifUnit.gsFINISH.gsFINISHPending)
+	{
+		CSRreg.FINISH = true;
+		gifUnit.gsFINISH.gsFINISHPending = false;
+	}
 	if (CSRreg.FINISH && !GSIMR.FINISHMSK && !gifUnit.gsFINISH.gsFINISHFired)
 	{
 		gsIrq();

--- a/pcsx2/Gif_Unit.h
+++ b/pcsx2/Gif_Unit.h
@@ -177,6 +177,7 @@ struct GS_SIGNAL
 struct GS_FINISH
 {
 	bool gsFINISHFired;
+	bool gsFINISHPending;
 
 	void Reset() { std::memset(this, 0, sizeof(*this)); }
 };
@@ -838,7 +839,8 @@ struct Gif_Unit
 			FlushToMTGS();
 		}
 
-		Gif_FinishIRQ();
+		if(!checkPaths(true, true, true, true))
+			Gif_FinishIRQ();
 
 		//Path3 can rewind the DMA, so we send back the amount we go back!
 		if (isPath3)

--- a/pcsx2/IPU/IPU.h
+++ b/pcsx2/IPU/IPU.h
@@ -132,7 +132,7 @@ struct alignas(16) tIPU_BP {
 				// be possible -- so if the fill fails we'll only return 0 if we don't have enough
 				// remaining bits in the FIFO to fill the request.
 				// Used to do ((FP!=0) && (BP + bits) <= 128) if we get here there's defo not enough data now though
-
+				IPUCoreStatus.WaitingOnIPUTo = true;
 				return false;
 			}
 
@@ -293,8 +293,6 @@ extern bool EnableFMV;
 
 alignas(16) extern tIPU_cmd ipu_cmd;
 extern uint eecount_on_last_vdec;
-extern bool CommandExecuteQueued;
-extern u32 ProcessedData;
 
 extern void ipuReset();
 

--- a/pcsx2/IPU/IPU_Fifo.cpp
+++ b/pcsx2/IPU/IPU_Fifo.cpp
@@ -40,7 +40,7 @@ void IPU_Fifo_Input::clear()
 	writepos = 0;
 
 	// Because the FIFO is drained it will request more data immediately
-	IPU1Status.DataRequested = true;
+	IPUCoreStatus.DataRequested = true;
 
 	if (ipu1ch.chcr.STR && cpuRegs.eCycle[4] == 0x9999)
 	{
@@ -91,9 +91,7 @@ int IPU_Fifo_Input::write(const u32* pMem, int size)
 	g_BP.IFC += transfer_size;
 
 	if (g_BP.IFC == 8)
-		IPU1Status.DataRequested = false;
-
-	CPU_INT(IPU_PROCESS, transfer_size * BIAS);
+		IPUCoreStatus.DataRequested = false;
 
 	return transfer_size;
 }
@@ -104,7 +102,7 @@ int IPU_Fifo_Input::read(void *value)
 	if (g_BP.IFC <= 1)
 	{
 		// IPU FIFO is empty and DMA is waiting so lets tell the DMA we are ready to put data in the FIFO
-		IPU1Status.DataRequested = true;
+		IPUCoreStatus.DataRequested = true;
 
 		if(ipu1ch.chcr.STR && cpuRegs.eCycle[4] == 0x9999)
 		{
@@ -142,7 +140,7 @@ int IPU_Fifo_Output::write(const u32 *value, uint size)
 	ipuRegs.ctrl.OFC += transfer_size;
 
 	if(ipu0ch.chcr.STR)
-		IPU_INT_FROM(ipuRegs.ctrl.OFC * BIAS);
+		IPU_INT_FROM(1);
 
 	return transfer_size;
 }
@@ -181,12 +179,13 @@ void WriteFIFO_IPUin(const mem128_t* value)
 	IPU_LOG( "WriteFIFO/IPUin <- 0x%08X.%08X.%08X.%08X", value->_u32[0], value->_u32[1], value->_u32[2], value->_u32[3]);
 
 	//committing every 16 bytes
-	if( ipu_fifo.in.write(value->_u32, 1) == 0 )
+	if( ipu_fifo.in.write(value->_u32, 1) > 0 )
 	{
-		if (ipuRegs.ctrl.BUSY && !CommandExecuteQueued)
+		if (ipuRegs.ctrl.BUSY && IPUCoreStatus.WaitingOnIPUTo)
 		{
-			CommandExecuteQueued = false;
-			CPU_INT(IPU_PROCESS, 8);
+			IPUCoreStatus.WaitingOnIPUFrom = false;
+			IPUCoreStatus.WaitingOnIPUTo = false;
+			CPU_INT(IPU_PROCESS, 2 * BIAS);
 		}
 	}
 }

--- a/pcsx2/IPU/IPUdma.h
+++ b/pcsx2/IPU/IPUdma.h
@@ -17,10 +17,15 @@
 
 #include "IPU.h"
 
-struct IPUStatus {
+struct IPUDMAStatus {
 	bool InProgress;
 	bool DMAFinished;
+};
+
+struct IPUStatus {
 	bool DataRequested;
+	bool WaitingOnIPUFrom;
+	bool WaitingOnIPUTo;
 };
 
 extern void ipuCMDProcess();
@@ -33,4 +38,5 @@ extern void IPU0dma();
 extern void IPU1dma();
 
 extern void ipuDmaReset();
-extern IPUStatus IPU1Status;
+extern IPUDMAStatus IPU1Status;
+extern IPUStatus IPUCoreStatus;

--- a/pcsx2/MTVU.cpp
+++ b/pcsx2/MTVU.cpp
@@ -400,10 +400,10 @@ void VU_Thread::Get_MTVUChanges()
 	{
 		mtvuInterrupts.fetch_and(~InterruptFlagFinish, std::memory_order_relaxed);
 		GUNIT_WARN("Finish firing");
-		CSRreg.FINISH = true;
 		gifUnit.gsFINISH.gsFINISHFired = false;
+		gifUnit.gsFINISH.gsFINISHPending = true;
 
-		if (!gifRegs.stat.APATH)
+		if (!gifUnit.checkPaths(true, true, true, true))
 			Gif_FinishIRQ();
 	}
 	if (interrupts & InterruptFlagLabel)

--- a/pcsx2/SaveState.h
+++ b/pcsx2/SaveState.h
@@ -37,7 +37,7 @@ enum class FreezeAction
 // [SAVEVERSION+]
 // This informs the auto updater that the users savestates will be invalidated.
 
-static const u32 g_SaveVersion = (0x9A40 << 16) | 0x0000;
+static const u32 g_SaveVersion = (0x9A41 << 16) | 0x0000;
 
 
 // the freezing data between submodules and core

--- a/pcsx2/SaveState.h
+++ b/pcsx2/SaveState.h
@@ -37,7 +37,7 @@ enum class FreezeAction
 // [SAVEVERSION+]
 // This informs the auto updater that the users savestates will be invalidated.
 
-static const u32 g_SaveVersion = (0x9A3F << 16) | 0x0000;
+static const u32 g_SaveVersion = (0x9A40 << 16) | 0x0000;
 
 
 // the freezing data between submodules and core

--- a/pcsx2/Vif0_Dma.cpp
+++ b/pcsx2/Vif0_Dma.cpp
@@ -137,8 +137,15 @@ __fi void vif0SetupTransfer()
 __fi void vif0VUFinish()
 {
 	// Sync up VU0 so we don't errantly wait.
-	while (static_cast<int>(cpuRegs.cycle - VU0.cycle) > 0 && (VU0.VI[REG_VPU_STAT].UL & 0x1))
+	while (VU0.VI[REG_VPU_STAT].UL & 0x1)
+	{
+		const int cycle_diff = static_cast<int>(cpuRegs.cycle - VU0.cycle);
+
+		if ((EmuConfig.Gamefixes.VUSyncHack && cycle_diff < VU0.nextBlockCycles) || cycle_diff <= 0)
+			break;
+
 		CpuVU0->ExecuteBlock();
+	}
 
 	if (VU0.VI[REG_VPU_STAT].UL & 0x5)
 	{

--- a/pcsx2/Vif1_Dma.cpp
+++ b/pcsx2/Vif1_Dma.cpp
@@ -232,8 +232,15 @@ __fi void vif1SetupTransfer()
 __fi void vif1VUFinish()
 {
 	// Sync up VU1 so we don't errantly wait.
-	while (!THREAD_VU1 && static_cast<int>(cpuRegs.cycle - VU1.cycle) > 0 && (VU0.VI[REG_VPU_STAT].UL & 0x100))
+	while (!THREAD_VU1 && (VU0.VI[REG_VPU_STAT].UL & 0x100))
+	{
+		const int cycle_diff = static_cast<int>(cpuRegs.cycle - VU1.cycle);
+
+		if ((EmuConfig.Gamefixes.VUSyncHack && cycle_diff < VU1.nextBlockCycles) || cycle_diff <= 0)
+			break;
+
 		CpuVU1->ExecuteBlock();
+	}
 
 	if (VU0.VI[REG_VPU_STAT].UL & 0x500)
 	{

--- a/pcsx2/Vif1_MFIFO.cpp
+++ b/pcsx2/Vif1_MFIFO.cpp
@@ -300,7 +300,7 @@ void vifMFIFOInterrupt()
 		{
 			GUNIT_WARN("vifMFIFOInterrupt() - Waiting for Path 2 to be ready");
 			CPU_INT(DMAC_MFIFO_VIF, 128);
-			CPU_SET_DMASTALL(DMAC_VIF1, true);
+			CPU_SET_DMASTALL(DMAC_MFIFO_VIF, true);
 			return;
 		}
 	}
@@ -308,7 +308,7 @@ void vifMFIFOInterrupt()
 	{
 		//DevCon.Warning("Waiting on VU1 MFIFO");
 		CPU_INT(VIF_VU1_FINISH, std::max(16, cpuGetCycles(VU_MTVU_BUSY)));
-		CPU_SET_DMASTALL(DMAC_VIF1, true);
+		CPU_SET_DMASTALL(DMAC_MFIFO_VIF, true);
 		return;
 	}
 
@@ -341,7 +341,7 @@ void vifMFIFOInterrupt()
 			{
 				vif1Regs.stat.VPS = VPS_DECODING; //If there's more data you need to say it's decoding the next VIF CMD (Onimusha - Blade Warriors)
 				VIF_LOG("VIF1 MFIFO Stalled");
-				CPU_SET_DMASTALL(DMAC_VIF1, true);
+				CPU_SET_DMASTALL(DMAC_MFIFO_VIF, true);
 				return;
 			}
 		}
@@ -361,7 +361,7 @@ void vifMFIFOInterrupt()
 	if (vif1.inprogress & 0x10)
 	{
 		FireMFIFOEmpty();
-		CPU_SET_DMASTALL(DMAC_VIF1, true);
+		CPU_SET_DMASTALL(DMAC_MFIFO_VIF, true);
 		return;
 	}
 
@@ -412,6 +412,6 @@ void vifMFIFOInterrupt()
 	vif1ch.chcr.STR = false;
 	hwDmacIrq(DMAC_VIF1);
 	DMA_LOG("VIF1 MFIFO DMA End");
-	CPU_SET_DMASTALL(DMAC_VIF1, false);
+	CPU_SET_DMASTALL(DMAC_MFIFO_VIF, false);
 	vif1Regs.stat.FQC = 0;
 }

--- a/pcsx2/Vif_Codes.cpp
+++ b/pcsx2/Vif_Codes.cpp
@@ -66,6 +66,11 @@ __ri void vifExecQueue(int idx)
 	}*/
 }
 
+static __fi EE_EventType vif1InternalIrq()
+{
+	return dmacRegs.ctrl.is_mfifo(true) ? DMAC_MFIFO_VIF : DMAC_VIF1;
+}
+
 static __fi void vifFlush(int idx)
 {
 	vifExecQueue(idx);
@@ -85,7 +90,7 @@ static __fi void vuExecMicro(int idx, u32 addr, bool requires_wait)
 	vifFlush(idx);
 	if (GetVifX.waitforvu)
 	{
-		CPU_SET_DMASTALL(idx ? DMAC_VIF1 : DMAC_VIF0, true);
+		CPU_SET_DMASTALL(idx ? vif1InternalIrq() : DMAC_VIF0, true);
 		return;
 	}
 
@@ -225,7 +230,7 @@ vifOp(vifCode_Flush)
 
 		if (vif1.waitforvu || vif1Regs.stat.VGW)
 		{
-			CPU_SET_DMASTALL(DMAC_VIF1, true);
+			CPU_SET_DMASTALL(vif1InternalIrq(), true);
 			return 0;
 		}
 
@@ -258,7 +263,7 @@ vifOp(vifCode_FlushA)
 
 		if (vif1.waitforvu || vif1Regs.stat.VGW)
 		{
-			CPU_SET_DMASTALL(DMAC_VIF1, true);
+			CPU_SET_DMASTALL(vif1InternalIrq(), true);
 			return 0;
 		}
 
@@ -279,7 +284,7 @@ vifOp(vifCode_FlushE)
 
 		if (vifX.waitforvu)
 		{
-			CPU_SET_DMASTALL(idx ? DMAC_VIF1 : DMAC_VIF0, true);
+			CPU_SET_DMASTALL(idx ? vif1InternalIrq() : DMAC_VIF0, true);
 			return 0;
 		}
 
@@ -387,7 +392,7 @@ vifOp(vifCode_MPG)
 
 		if (vifX.waitforvu)
 		{
-			CPU_SET_DMASTALL(idx ? DMAC_VIF1 : DMAC_VIF0, true);
+			CPU_SET_DMASTALL(idx ? vif1InternalIrq() : DMAC_VIF0, true);
 			return 0;
 		}
 		else
@@ -435,7 +440,7 @@ vifOp(vifCode_MSCAL)
 
 		if (vifX.waitforvu)
 		{
-			CPU_SET_DMASTALL(idx ? DMAC_VIF1 : DMAC_VIF0, true);
+			CPU_SET_DMASTALL(idx ? vif1InternalIrq() : DMAC_VIF0, true);
 			return 0;
 		}
 
@@ -474,7 +479,7 @@ vifOp(vifCode_MSCALF)
 
 		if (vifX.waitforvu || vif1Regs.stat.VGW)
 		{
-			CPU_SET_DMASTALL(idx ? DMAC_VIF1 : DMAC_VIF0, true);
+			CPU_SET_DMASTALL(idx ? vif1InternalIrq() : DMAC_VIF0, true);
 			return 0;
 		}
 
@@ -496,7 +501,7 @@ vifOp(vifCode_MSCNT)
 
 		if (vifX.waitforvu)
 		{
-			CPU_SET_DMASTALL(idx ? DMAC_VIF1 : DMAC_VIF0, true);
+			CPU_SET_DMASTALL(idx ? vif1InternalIrq() : DMAC_VIF0, true);
 			return 0;
 		}
 


### PR DESCRIPTION
### Description of Changes
Correct the DMA Stall for VIF MFIFO, correctly delay GIF FINISH interrupts
Improve IPU Core/DMA call flow

### Rationale behind Changes
The DMA Stall was pointing to normal VIF so this would have hung in some situations, especially when using Instant DMA.
GIF FINISH was being set immediately, so any games which were watching for the interrupts could have started processing it too early.
For IPU the timing of the DMA's is just gross and it was getting messy, so I've attempted to clean this up somewhat and make it make more sense to how the rest of the emulator works.

### Suggested Testing Steps
Nothing specific (Except Batman Begins FMVs), just test stuff, if you know what games use MFIFO and FINISH then you're certainly going to be able to target things well :P I can't think of a list of games off-hand though. Also test random FMV's, make sure they work as well as they did.

Savestate bump, sorry
