### PR TITLE
GameDB: Add minimum blending level for Twisted Metal: Head On

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -10419,6 +10419,8 @@ SCUS-97621:
   compat: 5
   clampModes:
     vu1ClampMode: 3 # Fixes missing textures.
+  gsHWFixes:
+    minimumBlendingLevel: 2 # Fixes smoke effects.
   gameFixes:
     - VUSyncHack # Fixes black doors on vehicles.
   patches:


### PR DESCRIPTION
### Rationale behind Changes
Fixes smoke effects for Vulkan/OpenGL.

Master:
![s1](https://github.com/PCSX2/pcsx2/assets/32846474/9dce216f-1717-4092-bf27-dd09a4d6fab0)

PR:
![s2](https://github.com/PCSX2/pcsx2/assets/32846474/5e865e19-725d-4c3f-8f0c-248ba9fced7e)

Direct3D 11/12 requires minimum value of 5 to fix smoke. Should I set minimumBlendingLevel to 5?

GS dump:
[GSD.zip](https://github.com/PCSX2/pcsx2/files/12590294/GSD.zip)
