### PR TITLE
GS/PCRTC: Avoid trying to lookup bad framebuffers

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -162,6 +162,9 @@ GSTexture* GSRendererHW::GetOutput(int i, float& scale, int& y_offset)
 	GSPCRTCRegs::PCRTCDisplay& curFramebuffer = PCRTCDisplays.PCRTCDisplays[index];
 	const GSVector2i framebufferSize(PCRTCDisplays.GetFramebufferSize(i));
 
+	if (curFramebuffer.framebufferRect.rempty() || curFramebuffer.FBW == 0)
+		return nullptr;
+
 	PCRTCDisplays.RemoveFramebufferOffset(i);
 	// TRACE(_T("[%d] GetOutput %d %05x (%d)\n"), (int)m_perfmon.GetFrame(), i, (int)TEX0.TBP0, (int)TEX0.PSM);
 

--- a/pcsx2/GS/Renderers/SW/GSRendererSW.cpp
+++ b/pcsx2/GS/Renderers/SW/GSRendererSW.cpp
@@ -115,8 +115,13 @@ GSTexture* GSRendererSW::GetOutput(int i, float& scale, int& y_offset)
 	GSPCRTCRegs::PCRTCDisplay& curFramebuffer = PCRTCDisplays.PCRTCDisplays[index];
 	GSVector2i framebufferSize = PCRTCDisplays.GetFramebufferSize(i);
 	GSVector4i framebufferRect = PCRTCDisplays.GetFramebufferRect(i);
-	int w = curFramebuffer.FBW * 64;
-	int h = framebufferSize.y;
+
+	// Try to avoid broken/incomplete setups which are probably ingnored on console, but can cause us problems.
+	if (framebufferRect.rempty() || curFramebuffer.FBW == 0)
+		return nullptr;
+
+	const int w = curFramebuffer.FBW * 64;
+	const int h = framebufferSize.y;
 
 	if (g_gs_device->ResizeRenderTarget(&m_texture[index], w, h, false, false))
 	{


### PR DESCRIPTION
### Description of Changes
Avoid looking up framebuffers with a bad setup

### Rationale behind Changes
Some games (V-Rally 3 in this case) can enable the PCRTC circuits before they've set anything up, which basically would only return garbage and it causes PCSX2 to crash, so best to avoid it.

### Suggested Testing Steps
Try V-Rally 3 and a bunch of other games.

Fixes #9942