### PR TITLE
iR5900 Recompiler: Skip exception handler for (i)FlushCache syscalls

### DIFF
--- a/pcsx2/x86/ix86-32/iR5900.cpp
+++ b/pcsx2/x86/ix86-32/iR5900.cpp
@@ -740,7 +740,12 @@ static void recExecute()
 void R5900::Dynarec::OpcodeImpl::recSYSCALL()
 {
 	EE::Profiler.EmitOp(eeOpcode::SYSCALL);
-
+	if (GPR_IS_CONST1(3))
+	{
+		// If it's FlushCache or iFlushCache, we can skip it since we don't support cache in the JIT.
+		if (g_cpuConstRegs[3].UC[0] == 0x64 || g_cpuConstRegs[3].UC[0] == 0x68)
+			return;
+	}
 	recCall(R5900::Interpreter::OpcodeImpl::SYSCALL);
 	g_branch = 2; // Indirect branch with event check.
 }

--- a/pcsx2/x86/ix86-32/iR5900.cpp
+++ b/pcsx2/x86/ix86-32/iR5900.cpp
@@ -744,7 +744,12 @@ void R5900::Dynarec::OpcodeImpl::recSYSCALL()
 	{
 		// If it's FlushCache or iFlushCache, we can skip it since we don't support cache in the JIT.
 		if (g_cpuConstRegs[3].UC[0] == 0x64 || g_cpuConstRegs[3].UC[0] == 0x68)
+		{
+			// Emulate the amount of cycles it takes for the exception handlers to run
+			// This number was found by using github.com/F0bes/flushcache-cycles
+			s_nBlockCycles += 5650;
 			return;
+		}
 	}
 	recCall(R5900::Interpreter::OpcodeImpl::SYSCALL);
 	g_branch = 2; // Indirect branch with event check.


### PR DESCRIPTION
### Description of Changes
Skips handling exceptions when FlushCache and iFlushCache syscalls

### Rationale behind Changes
The cache isn't supported in the recompiler anyways. It might increase performance by a little bit

### Suggested Testing Steps
Benchmark EE heavy games