### PR TITLE
Qt: Fix returning from fullscreen on MacOS

### DIFF
--- a/pcsx2-qt/DisplayWidget.h
+++ b/pcsx2-qt/DisplayWidget.h
@@ -41,6 +41,7 @@ public:
 	void updateCursor(bool hidden);
 
 	void handleCloseEvent(QCloseEvent* event);
+	void destroy();
 
 Q_SIGNALS:
 	void windowResizedEvent(int width, int height, float scale);
@@ -59,6 +60,7 @@ private:
 	bool m_clip_mouse_enabled = false;
 #endif
 	bool m_cursor_hidden = false;
+	bool m_destroying = false;
 
 	std::vector<int> m_keys_pressed_with_modifiers;
 

--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -1991,9 +1991,6 @@ std::optional<WindowInfo> MainWindow::acquireRenderWindow(bool recreate_window, 
 
 	createDisplayWidget(fullscreen, render_to_main);
 
-	// we need the surface visible.. this might be able to be replaced with something else
-	QCoreApplication::processEvents(QEventLoop::ExcludeUserInputEvents);
-
 	std::optional<WindowInfo> wi = m_display_widget->getWindowInfo();
 	if (!wi.has_value())
 	{
@@ -2165,7 +2162,7 @@ void MainWindow::destroyDisplayWidget(bool show_game_list)
 
 	if (m_display_widget)
 	{
-		m_display_widget->deleteLater();
+		m_display_widget->destroy();
 		m_display_widget = nullptr;
 	}
 
@@ -2247,7 +2244,7 @@ SettingsDialog* MainWindow::getSettingsDialog()
 			updateLanguage();
 			// If you doSettings now, on macOS, the window will somehow end up underneath the main window that was created above
 			// Delay it slightly...
-			QtHost::RunOnUIThread([]{
+			QtHost::RunOnUIThread([] {
 				g_main_window->doSettings("Interface");
 			});
 		});


### PR DESCRIPTION
### Description of Changes

Fixes returning from fullscreen putting the main window in fullscreen mode on MacOS.

I limited it to MacOS, because I can't be arsed testing to see if Lameland hates it, which it might.

### Rationale behind Changes

Fix janky fullscreen behavior.

### Suggested Testing Steps

Test entering and returning from fullscreen in MacOS. Make sure it no longer stays fullscreen.

Make sure I didn't break fullscreen on Windows/Linux.
