### PR TITLE
GS/HW: Improve clear detection with multiple Tris

### DIFF
--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -2755,16 +2755,24 @@ bool GSState::TrianglesAreQuads() const
 	{
 		const u16* const i = m_index.buff + idx;
 
+		// Make sure the next set of triangles matches an edge of the previous triangle.
+		if (idx > 0)
+		{
+			const u16* const prev_tri= m_index.buff + (idx - 3);
+			const GSVertex& vert = v[i[0]];
+			if (vert.XYZ != m_vertex.buff[prev_tri[0]].XYZ && vert.XYZ != m_vertex.buff[prev_tri[1]].XYZ && vert.XYZ != m_vertex.buff[prev_tri[2]].XYZ)
+				return false;
+		}
 		// Degenerate triangles should've been culled already, so we can check indices.
 		u32 extra_verts = 0;
 		for (u32 j = 3; j < 6; j++)
 		{
-			const u16 idx = i[j];
-			if (idx != i[0] && idx != i[1] && idx != i[2])
+			const u16 tri2_idx = i[j];
+			if (tri2_idx != i[0] && tri2_idx != i[1] && tri2_idx != i[2])
 				extra_verts++;
 		}
 		if (extra_verts == 1)
-			return true;
+			continue;
 
 		// As a fallback, they might've used different vertices with a tri list, not strip.
 		// Note that this won't work unless the quad is axis-aligned.

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -6222,7 +6222,7 @@ bool GSRendererHW::PrimitiveCoversWithoutGaps()
 
 bool GSRendererHW::IsConstantDirectWriteMemClear()
 {
-	const bool direct_draw = (m_vt.m_primclass == GS_SPRITE_CLASS) || (m_index.tail == 6 && m_vt.m_primclass == GS_TRIANGLE_CLASS);
+	const bool direct_draw = (m_vt.m_primclass == GS_SPRITE_CLASS) || (((m_index.tail % 6) == 0 && TrianglesAreQuads()) && m_vt.m_primclass == GS_TRIANGLE_CLASS);
 	// Constant Direct Write without texture/test/blending (aka a GS mem clear)
 	if (direct_draw && !PRIM->TME // Direct write
 		&& !(m_draw_env->SCANMSK.MSK & 2)
@@ -6329,6 +6329,7 @@ void GSRendererHW::ReplaceVerticesWithSprite(const GSVector4i& unscaled_rect, co
 
 	m_r = unscaled_rect;
 	m_context->scissor.in = scissor;
+	m_vt.m_primclass = GS_SPRITE_CLASS;
 }
 
 void GSRendererHW::ReplaceVerticesWithSprite(const GSVector4i& unscaled_rect, const GSVector2i& unscaled_size)

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -5952,6 +5952,7 @@ void GSRendererHW::ClearGSLocalMemory(const GSOffset& off, const GSVector4i& r, 
 			pxAssert((off.bp() & (BLOCKS_PER_PAGE - 1)) == 0);
 			for (u32 current_page = off.bp() >> 5; top < page_aligned_bottom; top += pgs.y, current_page += fbw)
 			{
+				current_page &= 0x7ff;
 				GSVector4i* ptr = reinterpret_cast<GSVector4i*>(m_mem.vm8() + current_page * PAGE_SIZE);
 				GSVector4i* const ptr_end = ptr + iterations_per_page;
 				while (ptr != ptr_end)
@@ -5966,6 +5967,7 @@ void GSRendererHW::ClearGSLocalMemory(const GSOffset& off, const GSVector4i& r, 
 			pxAssert((off.bp() & (BLOCKS_PER_PAGE - 1)) == 0);
 			for (u32 current_page = off.bp() >> 5; top < page_aligned_bottom; top += pgs.y, current_page += fbw)
 			{
+				current_page &= 0x7ff;
 				GSVector4i* ptr = reinterpret_cast<GSVector4i*>(m_mem.vm8() + current_page * PAGE_SIZE);
 				GSVector4i* const ptr_end = ptr + iterations_per_page;
 				while (ptr != ptr_end)
@@ -5984,6 +5986,7 @@ void GSRendererHW::ClearGSLocalMemory(const GSOffset& off, const GSVector4i& r, 
 			pxAssert((off.bp() & (BLOCKS_PER_PAGE - 1)) == 0);
 			for (u32 current_page = off.bp() >> 5; top < page_aligned_bottom; top += pgs.y, current_page += fbw)
 			{
+				current_page &= 0x7ff;
 				GSVector4i* ptr = reinterpret_cast<GSVector4i*>(m_mem.vm8() + current_page * PAGE_SIZE);
 				GSVector4i* const ptr_end = ptr + iterations_per_page;
 				while (ptr != ptr_end)


### PR DESCRIPTION
### Description of Changes
Improves clear detection when using multiple quads

### Rationale behind Changes
before it only checked one triangle, but also it didn't properly set the mode to sprites, even though it was replacing triangles with sprites.

### Suggested Testing Steps
Test Dropship and Grand Prix Challenge, and test random games (bonus if you know they double half clear)

Dropship:
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/65e3faff-9f3c-4b33-9740-8244300f6fef)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/bce86856-98ab-48a4-8aaa-782fc34833b2)

Grand Prix Challenge (still wrong, but not ever other line wrong, solid as it should be)
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/22ba67e5-b3fa-4a84-8c5b-eb9802219949)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/f8ab12b7-c957-4c41-9519-25ff3362fb40)
