### PR TITLE
Achievements: Switch to rc_client

### DIFF
--- a/3rdparty/rcheevos/CMakeLists.txt
+++ b/3rdparty/rcheevos/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library(rcheevos
 	rcheevos/include/rc_api_request.h
 	rcheevos/include/rc_api_runtime.h
 	rcheevos/include/rc_api_user.h
+	rcheevos/include/rc_client.h
 	rcheevos/include/rc_consoles.h
 	rcheevos/include/rc_error.h
 	rcheevos/include/rc_hash.h
@@ -26,6 +27,8 @@ add_library(rcheevos
 	rcheevos/src/rcheevos/lboard.c
 	rcheevos/src/rcheevos/memref.c
 	rcheevos/src/rcheevos/operand.c
+	rcheevos/src/rcheevos/rc_client.c
+	rcheevos/src/rcheevos/rc_client_internal.h
 	rcheevos/src/rcheevos/rc_compat.h
 	rcheevos/src/rcheevos/rc_internal.h
 	rcheevos/src/rcheevos/rc_validate.c

--- a/3rdparty/rcheevos/rcheevos.vcxproj
+++ b/3rdparty/rcheevos/rcheevos.vcxproj
@@ -44,6 +44,7 @@
     <ClCompile Include="rcheevos\src\rcheevos\lboard.c" />
     <ClCompile Include="rcheevos\src\rcheevos\memref.c" />
     <ClCompile Include="rcheevos\src\rcheevos\operand.c" />
+    <ClCompile Include="rcheevos\src\rcheevos\rc_client.c" />
     <ClCompile Include="rcheevos\src\rcheevos\rc_validate.c" />
     <ClCompile Include="rcheevos\src\rcheevos\richpresence.c" />
     <ClCompile Include="rcheevos\src\rcheevos\runtime.c" />
@@ -61,6 +62,7 @@
     <ClInclude Include="rcheevos\include\rc_api_request.h" />
     <ClInclude Include="rcheevos\include\rc_api_runtime.h" />
     <ClInclude Include="rcheevos\include\rc_api_user.h" />
+    <ClInclude Include="rcheevos\include\rc_client.h" />
     <ClInclude Include="rcheevos\include\rc_consoles.h" />
     <ClInclude Include="rcheevos\include\rc_error.h" />
     <ClInclude Include="rcheevos\include\rc_hash.h" />
@@ -68,6 +70,7 @@
     <ClInclude Include="rcheevos\include\rc_runtime_types.h" />
     <ClInclude Include="rcheevos\include\rc_url.h" />
     <ClInclude Include="rcheevos\src\rapi\rc_api_common.h" />
+    <ClInclude Include="rcheevos\src\rcheevos\rc_client_internal.h" />
     <ClInclude Include="rcheevos\src\rcheevos\rc_compat.h" />
     <ClInclude Include="rcheevos\src\rcheevos\rc_internal.h" />
     <ClInclude Include="rcheevos\src\rcheevos\rc_validate.h" />

--- a/3rdparty/rcheevos/rcheevos.vcxproj.filters
+++ b/3rdparty/rcheevos/rcheevos.vcxproj.filters
@@ -87,6 +87,9 @@
     <ClCompile Include="rcheevos\src\rurl\url.c">
       <Filter>rurl</Filter>
     </ClCompile>
+    <ClCompile Include="rcheevos\src\rcheevos\rc_client.c">
+      <Filter>rcheevos</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="rcheevos\src\rapi\rc_api_common.h">
@@ -139,6 +142,12 @@
     </ClInclude>
     <ClInclude Include="rcheevos\include\rc_api_request.h">
       <Filter>include</Filter>
+    </ClInclude>
+    <ClInclude Include="rcheevos\include\rc_client.h">
+      <Filter>include</Filter>
+    </ClInclude>
+    <ClInclude Include="rcheevos\src\rcheevos\rc_client_internal.h">
+      <Filter>rcheevos</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/common/FileSystem.cpp
+++ b/common/FileSystem.cpp
@@ -1841,7 +1841,7 @@ bool FileSystem::DeleteDirectory(const char* path)
 	if (stat(path, &sysStatData) != 0 || !S_ISDIR(sysStatData.st_mode))
 		return false;
 
-	return (unlink(path) == 0);
+	return (rmdir(path) == 0);
 }
 
 std::string FileSystem::GetProgramPath()

--- a/common/LRUCache.h
+++ b/common/LRUCache.h
@@ -1,5 +1,5 @@
 /*  PCSX2 - PS2 Emulator for PCs
- *  Copyright (C) 2002-2022  PCSX2 Dev Team
+ *  Copyright (C) 2002-2023 PCSX2 Dev Team
  *
  *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU Lesser General Public License as published by the Free Software Found-
@@ -14,6 +14,7 @@
  */
 
 #pragma once
+#include "HeterogeneousContainers.h"
 #include <cstdint>
 #include <map>
 
@@ -28,7 +29,7 @@ class LRUCache
 		CounterType last_access;
 	};
 
-	using MapType = std::map<K, Item>;
+	using MapType = std::conditional_t<std::is_same_v<K, std::string>, StringMap<Item>, std::map<K, Item>>;
 
 public:
 	LRUCache(std::size_t max_capacity = 16, bool manual_evict = false)
@@ -50,7 +51,7 @@ public:
 			Evict(m_items.size() - m_max_capacity);
 	}
 
-	template<typename KeyT>
+	template <typename KeyT>
 	V* Lookup(const KeyT& key)
 	{
 		auto iter = m_items.find(key);
@@ -97,24 +98,21 @@ public:
 		}
 	}
 
-	template<typename KeyT>
+	template <typename KeyT>
 	bool Remove(const KeyT& key)
 	{
 		auto iter = m_items.find(key);
 		if (iter == m_items.end())
 			return false;
-
 		m_items.erase(iter);
 		return true;
 	}
-
 	void SetManualEvict(bool block)
 	{
 		m_manual_evict = block;
 		if (!m_manual_evict)
 			ManualEvict();
 	}
-
 	void ManualEvict()
 	{
 		// evict if we went over

--- a/common/SmallString.h
+++ b/common/SmallString.h
@@ -171,6 +171,9 @@ public:
 	// gets a writable char array, do not write more than reserve characters to it.
 	__fi char* data() { return m_buffer; }
 
+	// returns the end of the string (pointer is past the last character)
+	__fi const char* end_ptr() const { return m_buffer + m_length; }
+
 	// STL adapters
 	__fi void push_back(value_type&& val) { append(val); }
 

--- a/common/StringUtil.cpp
+++ b/common/StringUtil.cpp
@@ -1,5 +1,5 @@
 /*  PCSX2 - PS2 Emulator for PCs
- *  Copyright (C) 2002-2021  PCSX2 Dev Team
+ *  Copyright (C) 2002-2023  PCSX2 Dev Team
  *
  *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU Lesser General Public License as published by the Free Software Found-
@@ -14,7 +14,10 @@
  */
 
 #include "PrecompiledHeader.h"
+
+#include "Assertions.h"
 #include "StringUtil.h"
+
 #include <cctype>
 #include <codecvt>
 #include <cstdio>
@@ -450,6 +453,47 @@ namespace StringUtil
 	size_t DecodeUTF8(const std::string& str, size_t offset, char32_t* ch)
 	{
 		return DecodeUTF8(str.data() + offset, str.length() - offset, ch);
+	}
+
+	std::string Ellipsise(const std::string_view& str, u32 max_length, const char* ellipsis /*= "..."*/)
+	{
+		std::string ret;
+		ret.reserve(max_length);
+
+		const u32 str_length = static_cast<u32>(str.length());
+		const u32 ellipsis_len = static_cast<u32>(std::strlen(ellipsis));
+		pxAssert(ellipsis_len > 0 && ellipsis_len <= max_length);
+
+		if (str_length > max_length)
+		{
+			const u32 copy_size = std::min(str_length, max_length - ellipsis_len);
+			if (copy_size > 0)
+				ret.append(str.data(), copy_size);
+			if (copy_size != str_length)
+				ret.append(ellipsis);
+		}
+		else
+		{
+			ret.append(str);
+		}
+
+		return ret;
+	}
+
+	void EllipsiseInPlace(std::string& str, u32 max_length, const char* ellipsis /*= "..."*/)
+	{
+		const u32 str_length = static_cast<u32>(str.length());
+		const u32 ellipsis_len = static_cast<u32>(std::strlen(ellipsis));
+		pxAssert(ellipsis_len > 0 && ellipsis_len <= max_length);
+
+		if (str_length > max_length)
+		{
+			const u32 keep_size = std::min(static_cast<u32>(str.length()), max_length - ellipsis_len);
+			if (keep_size != str_length)
+				str.erase(keep_size);
+
+			str.append(ellipsis);
+		}
 	}
 
 #ifdef _WIN32

--- a/common/StringUtil.h
+++ b/common/StringUtil.h
@@ -283,6 +283,10 @@ namespace StringUtil
 	size_t DecodeUTF8(const std::string_view& str, size_t offset, char32_t* ch);
 	size_t DecodeUTF8(const std::string& str, size_t offset, char32_t* ch);
 
+	// Replaces the end of a string with ellipsis if it exceeds the specified length.
+	std::string Ellipsise(const std::string_view& str, u32 max_length, const char* ellipsis = "...");
+	void EllipsiseInPlace(std::string& str, u32 max_length, const char* ellipsis = "...");
+
 	/// Strided memcpy/memcmp.
 	static inline void StrideMemCpy(void* dst, std::size_t dst_stride, const void* src, std::size_t src_stride,
 		std::size_t copy_size, std::size_t count)

--- a/common/Timer.cpp
+++ b/common/Timer.cpp
@@ -1,5 +1,5 @@
 /*  PCSX2 - PS2 Emulator for PCs
- *  Copyright (C) 2002-2021  PCSX2 Dev Team
+ *  Copyright (C) 2002-2023 PCSX2 Dev Team
  *
  *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU Lesser General Public License as published by the Free Software Found-
@@ -162,5 +162,39 @@ namespace Common
 		const double ret = ConvertValueToNanoseconds(value - m_tvStartValue);
 		m_tvStartValue = value;
 		return ret;
+	}
+
+
+	bool Timer::ResetIfSecondsPassed(double s)
+	{
+		const Value value = GetCurrentValue();
+		const double ret = ConvertValueToSeconds(value - m_tvStartValue);
+		if (ret < s)
+			return false;
+
+		m_tvStartValue = value;
+		return true;
+	}
+
+	bool Timer::ResetIfMillisecondsPassed(double s)
+	{
+		const Value value = GetCurrentValue();
+		const double ret = ConvertValueToMilliseconds(value - m_tvStartValue);
+		if (ret < s)
+			return false;
+
+		m_tvStartValue = value;
+		return true;
+	}
+
+	bool Timer::ResetIfNanosecondsPassed(double s)
+	{
+		const Value value = GetCurrentValue();
+		const double ret = ConvertValueToNanoseconds(value - m_tvStartValue);
+		if (ret < s)
+			return false;
+
+		m_tvStartValue = value;
+		return true;
 	}
 } // namespace Common

--- a/common/Timer.h
+++ b/common/Timer.h
@@ -1,5 +1,5 @@
 /*  PCSX2 - PS2 Emulator for PCs
- *  Copyright (C) 2002-2021  PCSX2 Dev Team
+ *  Copyright (C) 2002-2023 PCSX2 Dev Team
  *
  *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU Lesser General Public License as published by the Free Software Found-
@@ -45,6 +45,10 @@ namespace Common
 		double GetTimeSecondsAndReset();
 		double GetTimeMillisecondsAndReset();
 		double GetTimeNanosecondsAndReset();
+
+		bool ResetIfSecondsPassed(double s);
+		bool ResetIfMillisecondsPassed(double s);
+		bool ResetIfNanosecondsPassed(double s);
 
 	private:
 		Value m_tvStartValue;

--- a/pcsx2-qt/MainWindow.h
+++ b/pcsx2-qt/MainWindow.h
@@ -196,6 +196,8 @@ private Q_SLOTS:
 	void onCaptureStopped();
 
 	void onAchievementsLoginRequested(Achievements::LoginRequestReason reason);
+	void onAchievementsLoginSucceeded(const QString& display_name, quint32 points, quint32 sc_points, quint32 unread_messages);
+	void onAchievementsHardcoreModeChanged(bool enabled);
 
 protected:
 	void showEvent(QShowEvent* event) override;

--- a/pcsx2-qt/QtHost.h
+++ b/pcsx2-qt/QtHost.h
@@ -167,8 +167,14 @@ Q_SIGNALS:
 	/// Called when achievements login is requested.
 	void onAchievementsLoginRequested(Achievements::LoginRequestReason reason);
 
+	/// Called when achievements login succeeds. Also happens on startup.
+	void onAchievementsLoginSucceeded(const QString& display_name, quint32 points, quint32 sc_points, quint32 unread_messages);
+
 	/// Called when achievements are reloaded/refreshed (e.g. game change, login, option change).
-	void onAchievementsRefreshed(quint32 id, const QString& game_info_string, quint32 total, quint32 points);
+	void onAchievementsRefreshed(quint32 id, const QString& game_info_string);
+
+	/// Called when hardcore mode is enabled or disabled.
+	void onAchievementsHardcoreModeChanged(bool enabled);
 
 	/// Called when video capture starts/stops.
 	void onCaptureStarted(const QString& filename);

--- a/pcsx2-qt/Settings/AchievementLoginDialog.h
+++ b/pcsx2-qt/Settings/AchievementLoginDialog.h
@@ -1,5 +1,5 @@
 /*  PCSX2 - PS2 Emulator for PCs
- *  Copyright (C) 2002-2022  PCSX2 Dev Team
+ *  Copyright (C) 2002-2023 PCSX2 Dev Team
  *
  *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU Lesser General Public License as published by the Free Software Found-
@@ -34,7 +34,7 @@ public:
 private Q_SLOTS:
 	void loginClicked();
 	void cancelClicked();
-	void processLoginResult(bool result);
+	void processLoginResult(bool result, const QString& message);
 
 private:
 	void connectUi();

--- a/pcsx2-qt/Settings/AchievementSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/AchievementSettingsWidget.cpp
@@ -1,5 +1,5 @@
 /*  PCSX2 - PS2 Emulator for PCs
- *  Copyright (C) 2002-2023  PCSX2 Dev Team
+ *  Copyright (C) 2002-2023 PCSX2 Dev Team
  *
  *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU Lesser General Public License as published by the Free Software Found-
@@ -30,63 +30,43 @@
 #include <QtCore/QDateTime>
 #include <QtWidgets/QMessageBox>
 
-static constexpr s32 DEFAULT_NOTIFICATIONS_DURATION = 5;
-
 AchievementSettingsWidget::AchievementSettingsWidget(SettingsDialog* dialog, QWidget* parent)
 	: QWidget(parent)
 	, m_dialog(dialog)
 {
-	m_ui.setupUi(this);
-
 	SettingsInterface* sif = dialog->getSettingsInterface();
 
+	m_ui.setupUi(this);
+
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.enable, "Achievements", "Enabled", false);
-	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.richPresence, "Achievements", "RichPresence", true);
-	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.challengeMode, "Achievements", "ChallengeMode", false);
-	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.leaderboards, "Achievements", "Leaderboards", true);
-	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.testMode, "Achievements", "TestMode", false);
-	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.unofficialTestMode, "Achievements", "UnofficialTestMode", false);
-	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.notifications, "Achievements", "Notifications", true);
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.hardcoreMode, "Achievements", "ChallengeMode", false);
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.achievementNotifications, "Achievements", "Notifications", true);
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.leaderboardNotifications, "Achievements", "LeaderboardNotifications", true);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.soundEffects, "Achievements", "SoundEffects", true);
-	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.primedIndicators, "Achievements", "PrimedIndicators", true);
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.overlays, "Achievements", "Overlays", true);
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.encoreMode, "Achievements", "EncoreMode", false);
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.spectatorMode, "Achievements", "SpectatorMode", false);
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.unofficialAchievements, "Achievements", "UnofficialTestMode",false);
+	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.achievementNotificationsDuration, "Achievements", "NotificationsDuration", Pcsx2Config::AchievementsOptions::DEFAULT_NOTIFICATION_DURATION);
+	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.leaderboardNotificationsDuration, "Achievements", "LeaderboardsDuration", Pcsx2Config::AchievementsOptions::DEFAULT_LEADERBOARD_DURATION);
 
-	SettingWidgetBinder::BindSliderToIntSetting(sif, m_ui.notifications_duration, m_ui.notifications_duration_seconds,
-		tr(" seconds"), "Achievements", "NotificationsDuration", DEFAULT_NOTIFICATIONS_DURATION);
-	
-	dialog->registerWidgetHelp(m_ui.enable, tr("Enable Achievements"), tr("Unchecked"),
-		tr("When enabled and logged in, PCSX2 will scan for achievements on game load."));
-	dialog->registerWidgetHelp(m_ui.testMode, tr("Enable Test Mode"), tr("Unchecked"),
-		tr("When enabled, PCSX2 will assume all achievements are locked and not send any "
-		   "unlock notifications to the server."));
-	dialog->registerWidgetHelp(m_ui.unofficialTestMode, tr("Test Unofficial Achievements"), tr("Unchecked"),
-		tr("When enabled, PCSX2 will list achievements from unofficial sets. Please note that these achievements are "
-		   "not tracked by RetroAchievements, so they unlock every time."));
-	dialog->registerWidgetHelp(m_ui.richPresence, tr("Enable RA's Rich Presence"), tr("Unchecked"),
-		tr("When enabled, rich presence information will be collected and sent to the RetroAchievements servers where supported."));
-	dialog->registerWidgetHelp(m_ui.challengeMode, tr("Enable Hardcore Mode"), tr("Unchecked"),
-		tr("\"Challenge\" mode for achievements, including leaderboard tracking. Disables save state, cheats, and slowdown functions."));
-	dialog->registerWidgetHelp(m_ui.leaderboards, tr("Enable Leaderboards"), tr("Checked"),
-		tr("Enables tracking and submission of leaderboards in supported games. If leaderboards are disabled, you will still "
-		   "be able to view the leaderboard and scores, but no scores will be uploaded."));
-	dialog->registerWidgetHelp(m_ui.notifications, tr("Show Notifications"), tr("Checked"),
-		tr("Displays popup messages on events such as achievement unlocks and leaderboard submissions."));
-	dialog->registerWidgetHelp(m_ui.soundEffects, tr("Enable Sound Effects"), tr("Checked"),
-		tr("Plays sound effects for events such as achievement unlocks and leaderboard submissions."));
-	dialog->registerWidgetHelp(m_ui.primedIndicators, tr("Show Challenge Indicators"), tr("Checked"),
-		tr("Shows icons in the lower-right corner of the screen when a challenge/primed achievement is active."));
-
-	dialog->registerWidgetHelp(m_ui.notifications_duration, tr("Notification Duration"), 
-		tr("5 seconds"), tr("The duration, in seconds, an achievement popup notification will remain on screen."));
-	dialog->registerWidgetHelp(m_ui.notifications_duration_label, tr("Notification Duration"), 
-		tr("5 seconds"), tr("The duration, in seconds, an achievement popup notification will remain on screen."));
-	dialog->registerWidgetHelp(m_ui.notifications_duration_seconds, tr("Notification Duration"), 
-		tr("5 seconds"), tr("The duration, in seconds, an achievement popup notification will remain on screen."));
+	dialog->registerWidgetHelp(m_ui.enable, tr("Enable Achievements"), tr("Unchecked"), tr("When enabled and logged in, PCSX2 will scan for achievements on startup."));
+	dialog->registerWidgetHelp(m_ui.hardcoreMode, tr("Enable Hardcore Mode"), tr("Unchecked"), tr("\"Challenge\" mode for achievements, including leaderboard tracking. Disables save state, cheats, and slowdown functions."));
+	dialog->registerWidgetHelp(m_ui.achievementNotifications, tr("Show Achievement Notifications"), tr("Checked"), tr("Displays popup messages on events such as achievement unlocks and game completion."));
+	dialog->registerWidgetHelp(m_ui.leaderboardNotifications, tr("Show Leaderboard Notifications"), tr("Checked"), tr("Displays popup messages when starting, submitting, or failing a leaderboard challenge."));
+	dialog->registerWidgetHelp(m_ui.soundEffects, tr("Enable Sound Effects"), tr("Checked"), tr("Plays sound effects for events such as achievement unlocks and leaderboard submissions."));
+	dialog->registerWidgetHelp(m_ui.overlays, tr("Enable In-Game Overlays"), tr("Checked"), tr("Shows icons in the lower-right corner of the screen when a challenge/primed achievement is active."));
+	dialog->registerWidgetHelp(m_ui.encoreMode, tr("Enable Encore Mode"), tr("Unchecked"),tr("When enabled, each session will behave as if no achievements have been unlocked."));
+	dialog->registerWidgetHelp(m_ui.spectatorMode, tr("Enable Spectator Mode"), tr("Unchecked"), tr("When enabled, PCSX2 will assume all achievements are locked and not send any unlock notifications to the server."));
+	dialog->registerWidgetHelp(m_ui.unofficialAchievements, tr("Test Unofficial Achievements"), tr("Unchecked"), tr("When enabled, PCSX2 will list achievements from unofficial sets. Please note that these achievements are not tracked by RetroAchievements, so they unlock every time."));
 
 	connect(m_ui.enable, &QCheckBox::stateChanged, this, &AchievementSettingsWidget::updateEnableState);
-	connect(m_ui.notifications, &QCheckBox::stateChanged, this, &AchievementSettingsWidget::updateEnableState);
-	connect(m_ui.challengeMode, &QCheckBox::stateChanged, this, &AchievementSettingsWidget::updateEnableState);
-	connect(m_ui.challengeMode, &QCheckBox::stateChanged, this, &AchievementSettingsWidget::onChallengeModeStateChanged);
-	connect(m_ui.notifications_duration, &QSlider::valueChanged, this, &AchievementSettingsWidget::onNotificationsDurationChanged);
+	connect(m_ui.hardcoreMode, &QCheckBox::stateChanged, this, &AchievementSettingsWidget::updateEnableState);
+	connect(m_ui.hardcoreMode, &QCheckBox::stateChanged, this, &AchievementSettingsWidget::onHardcoreModeStateChanged);
+	connect(m_ui.achievementNotifications, &QCheckBox::stateChanged, this, &AchievementSettingsWidget::updateEnableState);
+	connect(m_ui.leaderboardNotifications, &QCheckBox::stateChanged, this, &AchievementSettingsWidget::updateEnableState);
+	connect(m_ui.achievementNotificationsDuration, &QSlider::valueChanged, this, &AchievementSettingsWidget::onAchievementsNotificationDurationSliderChanged);
+	connect(m_ui.leaderboardNotificationsDuration, &QSlider::valueChanged, this, &AchievementSettingsWidget::onLeaderboardsNotificationDurationSliderChanged);
 
 	if (!m_dialog->isPerGameSettings())
 	{
@@ -110,6 +90,8 @@ AchievementSettingsWidget::AchievementSettingsWidget(SettingsDialog* dialog, QWi
 	}
 
 	updateEnableState();
+	onAchievementsNotificationDurationSliderChanged();
+	onLeaderboardsNotificationDurationSliderChanged();
 }
 
 AchievementSettingsWidget::~AchievementSettingsWidget() = default;
@@ -117,24 +99,23 @@ AchievementSettingsWidget::~AchievementSettingsWidget() = default;
 void AchievementSettingsWidget::updateEnableState()
 {
 	const bool enabled = m_dialog->getEffectiveBoolValue("Achievements", "Enabled", false);
-	const bool challenge = m_dialog->getEffectiveBoolValue("Achievements", "ChallengeMode", false);
-	const bool notifications = m_dialog->getEffectiveBoolValue("Achievements", "Notifications", true);
-
-	m_ui.testMode->setEnabled(enabled);
-	m_ui.unofficialTestMode->setEnabled(enabled);
-	m_ui.richPresence->setEnabled(enabled);
-	m_ui.challengeMode->setEnabled(enabled);
-	m_ui.leaderboards->setEnabled(enabled && challenge);
-	m_ui.notifications->setEnabled(enabled);
+	const bool notifications = enabled && m_dialog->getEffectiveBoolValue("Achievements", "Notifications", true);
+	const bool lb_notifications = enabled && m_dialog->getEffectiveBoolValue("Achievements", "LeaderboardNotifications", true);
+	m_ui.hardcoreMode->setEnabled(enabled);
+	m_ui.achievementNotifications->setEnabled(enabled);
+	m_ui.leaderboardNotifications->setEnabled(enabled);
+	m_ui.achievementNotificationsDuration->setEnabled(notifications);
+	m_ui.achievementNotificationsDurationLabel->setEnabled(notifications);
+	m_ui.leaderboardNotificationsDuration->setEnabled(lb_notifications);
+	m_ui.leaderboardNotificationsDurationLabel->setEnabled(lb_notifications);
 	m_ui.soundEffects->setEnabled(enabled);
-	m_ui.primedIndicators->setEnabled(enabled);
-
-	m_ui.notifications_duration->setEnabled(enabled && notifications);
-	m_ui.notifications_duration_label->setEnabled(enabled && notifications);
-	m_ui.notifications_duration_seconds->setEnabled(enabled && notifications);
+	m_ui.overlays->setEnabled(enabled);
+	m_ui.encoreMode->setEnabled(enabled);
+	m_ui.spectatorMode->setEnabled(enabled);
+	m_ui.unofficialAchievements->setEnabled(enabled);
 }
 
-void AchievementSettingsWidget::onChallengeModeStateChanged()
+void AchievementSettingsWidget::onHardcoreModeStateChanged()
 {
 	if (!QtHost::IsVMValid())
 		return;
@@ -149,13 +130,29 @@ void AchievementSettingsWidget::onChallengeModeStateChanged()
 	if (!Achievements::HasActiveGame())
 		return;
 
-	if (QMessageBox::question(QtUtils::GetRootWidget(this), tr("Reset System"),
-			tr("Hardcore mode will not be enabled until the system is reset. Do you want to reset the system now?")) != QMessageBox::Yes)
+	if (QMessageBox::question(
+			QtUtils::GetRootWidget(this), tr("Reset System"),
+			tr("Hardcore mode will not be enabled until the system is reset. Do you want to reset the system now?")) !=
+		QMessageBox::Yes)
 	{
 		return;
 	}
 
 	g_emu_thread->resetVM();
+}
+
+void AchievementSettingsWidget::onAchievementsNotificationDurationSliderChanged()
+{
+	const float duration = m_dialog->getEffectiveFloatValue("Achievements", "NotificationsDuration",
+		Pcsx2Config::AchievementsOptions::DEFAULT_NOTIFICATION_DURATION);
+	m_ui.achievementNotificationsDurationLabel->setText(tr("%n seconds", nullptr, static_cast<int>(duration)));
+}
+
+void AchievementSettingsWidget::onLeaderboardsNotificationDurationSliderChanged()
+{
+	const float duration = m_dialog->getEffectiveFloatValue("Achievements", "LeaderboardsDuration",
+		Pcsx2Config::AchievementsOptions::DEFAULT_LEADERBOARD_DURATION);
+	m_ui.leaderboardNotificationsDurationLabel->setText(tr("%n seconds", nullptr, static_cast<int>(duration)));
 }
 
 void AchievementSettingsWidget::updateLoginState()
@@ -168,7 +165,6 @@ void AchievementSettingsWidget::updateLoginState()
 		const u64 login_unix_timestamp =
 			StringUtil::FromChars<u64>(Host::GetBaseStringSettingValue("Achievements", "LoginTimestamp", "0")).value_or(0);
 		const QDateTime login_timestamp(QDateTime::fromSecsSinceEpoch(static_cast<qint64>(login_unix_timestamp)));
-		//: Variable %1 is an username, variable %2 is a timestamp.
 		m_ui.loginStatus->setText(tr("Username: %1\nLogin token generated on %2.")
 									  .arg(QString::fromStdString(username))
 									  .arg(login_timestamp.toString(Qt::TextDate)));
@@ -187,7 +183,7 @@ void AchievementSettingsWidget::onLoginLogoutPressed()
 {
 	if (!Host::GetBaseStringSettingValue("Achievements", "Username").empty())
 	{
-		Host::RunOnCPUThread(Achievements::Logout, true);
+		Host::RunOnCPUThread([]() { Achievements::Logout(); }, true);
 		updateLoginState();
 		return;
 	}
@@ -207,17 +203,12 @@ void AchievementSettingsWidget::onViewProfilePressed()
 		return;
 
 	const QByteArray encoded_username(QUrl::toPercentEncoding(QString::fromStdString(username)));
-	QtUtils::OpenURL(QtUtils::GetRootWidget(this),
+	QtUtils::OpenURL(
+		QtUtils::GetRootWidget(this),
 		QUrl(QStringLiteral("https://retroachievements.org/user/%1").arg(QString::fromUtf8(encoded_username))));
 }
 
-void AchievementSettingsWidget::onAchievementsRefreshed(quint32 id, const QString& game_info_string, quint32 total, quint32 points)
+void AchievementSettingsWidget::onAchievementsRefreshed(quint32 id, const QString& game_info_string)
 {
 	m_ui.gameInfo->setText(game_info_string);
-}
-
-void AchievementSettingsWidget::onNotificationsDurationChanged()
-{
-	m_ui.notifications_duration_seconds->setText(tr("%1 seconds")
-		.arg(m_ui.notifications_duration->value()));
 }

--- a/pcsx2-qt/Settings/AchievementSettingsWidget.h
+++ b/pcsx2-qt/Settings/AchievementSettingsWidget.h
@@ -1,5 +1,5 @@
 /*  PCSX2 - PS2 Emulator for PCs
- *  Copyright (C) 2002-2022  PCSX2 Dev Team
+ *  Copyright (C) 2002-2023 PCSX2 Dev Team
  *
  *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU Lesser General Public License as published by the Free Software Found-
@@ -21,23 +21,25 @@ class SettingsDialog;
 
 class AchievementSettingsWidget : public QWidget
 {
-  Q_OBJECT
+	Q_OBJECT
 
 public:
-  explicit AchievementSettingsWidget(SettingsDialog* dialog, QWidget* parent);
-  ~AchievementSettingsWidget();
+	explicit AchievementSettingsWidget(SettingsDialog* dialog, QWidget* parent);
+	~AchievementSettingsWidget();
 
 private Q_SLOTS:
-  void updateEnableState();
-  void onChallengeModeStateChanged();
-  void onLoginLogoutPressed();
-  void onViewProfilePressed();
-  void onAchievementsRefreshed(quint32 id, const QString& game_info_string, quint32 total, quint32 points);
-  void onNotificationsDurationChanged();
+	void updateEnableState();
+	void onHardcoreModeStateChanged();
+	void onAchievementsNotificationDurationSliderChanged();
+	void onLeaderboardsNotificationDurationSliderChanged();
+	void onLoginLogoutPressed();
+	void onViewProfilePressed();
+	void onAchievementsRefreshed(quint32 id, const QString& game_info_string);
 
 private:
-  void updateLoginState();
+	void updateLoginState();
 
-  Ui::AchievementSettingsWidget m_ui;
-  SettingsDialog* m_dialog;
+	Ui::AchievementSettingsWidget m_ui;
+
+	SettingsDialog* m_dialog;
 };

--- a/pcsx2-qt/Settings/AchievementSettingsWidget.ui
+++ b/pcsx2-qt/Settings/AchievementSettingsWidget.ui
@@ -6,12 +6,12 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>829</width>
-    <height>641</height>
+    <width>674</width>
+    <height>481</height>
    </rect>
   </property>
   <property name="windowTitle">
-   <string notr="true">Form</string>
+   <string>Form</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <property name="leftMargin">
@@ -29,9 +29,16 @@
    <item>
     <widget class="QGroupBox" name="groupBox">
      <property name="title">
-      <string>Global Settings</string>
+      <string>Settings</string>
      </property>
      <layout class="QGridLayout" name="gridLayout">
+      <item row="1" column="1">
+       <widget class="QCheckBox" name="spectatorMode">
+        <property name="text">
+         <string>Enable Spectator Mode</string>
+        </property>
+       </widget>
+      </item>
       <item row="0" column="0">
        <widget class="QCheckBox" name="enable">
         <property name="text">
@@ -39,52 +46,24 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="1">
-       <widget class="QCheckBox" name="richPresence">
-        <property name="text">
-         <string extracomment="This &quot;Rich Presence&quot; is not Discord's, but rather RetroAchivements own system.">Enable RA's Rich Presence</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QCheckBox" name="challengeMode">
-        <property name="text">
-         <string>Enable Hardcore Mode</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QCheckBox" name="leaderboards">
-        <property name="text">
-         <string>Enable Leaderboards</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="1">
-       <widget class="QCheckBox" name="unofficialTestMode">
+      <item row="2" column="0">
+       <widget class="QCheckBox" name="unofficialAchievements">
         <property name="text">
          <string>Test Unofficial Achievements</string>
         </property>
        </widget>
       </item>
-      <item row="2" column="1">
-       <widget class="QCheckBox" name="soundEffects">
+      <item row="1" column="0">
+       <widget class="QCheckBox" name="encoreMode">
         <property name="text">
-         <string>Enable Sound Effects</string>
+         <string>Enable Encore Mode</string>
         </property>
        </widget>
       </item>
-      <item row="2" column="0">
-       <widget class="QCheckBox" name="primedIndicators">
+      <item row="0" column="1">
+       <widget class="QCheckBox" name="hardcoreMode">
         <property name="text">
-         <string>Show Challenge Indicators</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0">
-       <widget class="QCheckBox" name="testMode">
-        <property name="text">
-         <string>Enable Test Mode</string>
+         <string>Enable Hardcore Mode</string>
         </property>
        </widget>
       </item>
@@ -96,42 +75,16 @@
      <property name="title">
       <string>Notifications</string>
      </property>
-     <layout class="QVBoxLayout" name="notifications_box_layout" stretch="0,0">
-      <item>
-       <widget class="QCheckBox" name="notifications">
-        <property name="text">
-         <string>Show Notifications</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <layout class="QHBoxLayout" name="notifications_duration_layout" stretch="0,0,0">
-        <property name="leftMargin">
-         <number>0</number>
-        </property>
-        <property name="topMargin">
-         <number>0</number>
-        </property>
-        <property name="rightMargin">
-         <number>0</number>
-        </property>
-        <property name="bottomMargin">
-         <number>0</number>
-        </property>
+     <layout class="QGridLayout" name="gridLayout_2" columnstretch="1,1">
+      <item row="0" column="1">
+       <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="1,0">
         <item>
-         <widget class="QLabel" name="notifications_duration_label">
-          <property name="text">
-           <string>Duration</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QSlider" name="notifications_duration">
+         <widget class="QSlider" name="achievementNotificationsDuration">
           <property name="minimum">
            <number>3</number>
           </property>
           <property name="maximum">
-           <number>10</number>
+           <number>30</number>
           </property>
           <property name="pageStep">
            <number>1</number>
@@ -154,13 +107,80 @@
          </widget>
         </item>
         <item>
-         <widget class="QLabel" name="notifications_duration_seconds">
+         <widget class="QLabel" name="achievementNotificationsDurationLabel">
           <property name="text">
            <string>5 seconds</string>
           </property>
          </widget>
         </item>
        </layout>
+      </item>
+      <item row="0" column="0">
+       <widget class="QCheckBox" name="achievementNotifications">
+        <property name="text">
+         <string>Show Achievement Notifications</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="1,0">
+        <item>
+         <widget class="QSlider" name="leaderboardNotificationsDuration">
+          <property name="minimum">
+           <number>3</number>
+          </property>
+          <property name="maximum">
+           <number>30</number>
+          </property>
+          <property name="pageStep">
+           <number>1</number>
+          </property>
+          <property name="value">
+           <number>5</number>
+          </property>
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="invertedAppearance">
+           <bool>false</bool>
+          </property>
+          <property name="tickPosition">
+           <enum>QSlider::TicksBelow</enum>
+          </property>
+          <property name="tickInterval">
+           <number>1</number>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="leaderboardNotificationsDurationLabel">
+          <property name="text">
+           <string>5 seconds</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="1" column="0">
+       <widget class="QCheckBox" name="leaderboardNotifications">
+        <property name="text">
+         <string>Show Leaderboard Notifications</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QCheckBox" name="soundEffects">
+        <property name="text">
+         <string>Enable Sound Effects</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QCheckBox" name="overlays">
+        <property name="text">
+         <string>Enable In-Game Overlays</string>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>
@@ -173,24 +193,28 @@
      <layout class="QHBoxLayout" name="horizontalLayout" stretch="1,0">
       <item>
        <widget class="QLabel" name="loginStatus">
+        <property name="text">
+         <string>Username:
+Login token generated at:</string>
+        </property>
         <property name="alignment">
          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
         </property>
        </widget>
       </item>
       <item>
-       <layout class="QVBoxLayout" name="verticalLayout_2">
-        <item>
-         <widget class="QPushButton" name="loginButton">
-          <property name="text">
-           <string>Login...</string>
-          </property>
-         </widget>
-        </item>
+       <layout class="QHBoxLayout" name="horizontalLayout_4">
         <item>
          <widget class="QPushButton" name="viewProfile">
           <property name="text">
            <string>View Profile...</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="loginButton">
+          <property name="text">
+           <string>Login...</string>
           </property>
          </widget>
         </item>
@@ -204,7 +228,7 @@
      <property name="minimumSize">
       <size>
        <width>0</width>
-       <height>80</height>
+       <height>75</height>
       </size>
      </property>
      <property name="title">

--- a/pcsx2/Achievements.cpp
+++ b/pcsx2/Achievements.cpp
@@ -1,5 +1,5 @@
 /*  PCSX2 - PS2 Emulator for PCs
- *  Copyright (C) 2002-2023  PCSX2 Dev Team
+ *  Copyright (C) 2002-2023 PCSX2 Dev Team
  *
  *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU Lesser General Public License as published by the Free Software Found-
@@ -15,6 +15,8 @@
 
 #include "PrecompiledHeader.h"
 
+#define IMGUI_DEFINE_MATH_OPERATORS
+
 #include "Achievements.h"
 #include "CDVD/CDVD.h"
 #include "Elfheader.h"
@@ -23,31 +25,28 @@
 #include "ImGui/ImGuiFullscreen.h"
 #include "ImGui/ImGuiManager.h"
 #include "IopMem.h"
-#include "Memory.h"
 #include "MTGS.h"
+#include "Memory.h"
+#include "SysForwardDefs.h"
 #include "VMManager.h"
 #include "svnrev.h"
-#include "SysForwardDefs.h"
 #include "vtlb.h"
 
 #include "common/Assertions.h"
 #include "common/Console.h"
-#include "common/FileSystem.h"
 #include "common/Error.h"
+#include "common/FileSystem.h"
 #include "common/General.h"
 #include "common/HTTPDownloader.h"
 #include "common/MD5Digest.h"
 #include "common/Path.h"
 #include "common/ScopedGuard.h"
+#include "common/SmallString.h"
 #include "common/StringUtil.h"
 #include "common/Timer.h"
 
-#include "fmt/core.h"
-#include "rc_api_info.h"
-#include "rc_api_request.h"
-#include "rc_api_runtime.h"
-#include "rc_api_user.h"
-#include "rcheevos.h"
+#include "fmt/format.h"
+#include "rc_client.h"
 
 #include <algorithm>
 #include <array>
@@ -67,348 +66,179 @@
 
 namespace Achievements
 {
-	enum : s32
-	{
-		HTTP_OK = Common::HTTPDownloader::HTTP_OK,
+	// Size of the EE physical memory exposed to RetroAchievements.
+	static constexpr u32 EXPOSED_EE_MEMORY_SIZE = Ps2MemSize::MainRam + Ps2MemSize::Scratch;
 
-		// Number of seconds between rich presence pings. RAIntegration uses 2 minutes.
-		RICH_PRESENCE_PING_FREQUENCY = 2 * 60,
-		NO_RICH_PRESENCE_PING_FREQUENCY = RICH_PRESENCE_PING_FREQUENCY * 2,
+	static constexpr u32 LEADERBOARD_NEARBY_ENTRIES_TO_FETCH = 10;
+	static constexpr u32 LEADERBOARD_ALL_FETCH_SIZE = 20;
 
-		// Size of the EE physical memory exposed to RetroAchievements.
-		EXPOSED_EE_MEMORY_SIZE = Ps2MemSize::MainRam + Ps2MemSize::Scratch,
-	};
+	static constexpr float LOGIN_NOTIFICATION_TIME = 5.0f;
+	static constexpr float ACHIEVEMENT_SUMMARY_NOTIFICATION_TIME = 5.0f;
+	static constexpr float GAME_COMPLETE_NOTIFICATION_TIME = 20.0f;
+	static constexpr float LEADERBOARD_STARTED_NOTIFICATION_TIME = 3.0f;
+	static constexpr float LEADERBOARD_FAILED_NOTIFICATION_TIME = 3.0f;
+
+	static constexpr float INDICATOR_FADE_IN_TIME = 0.1f;
+	static constexpr float INDICATOR_FADE_OUT_TIME = 0.5f;
 
 	static constexpr const char* INFO_SOUND_NAME = "sounds/achievements/message.wav";
 	static constexpr const char* UNLOCK_SOUND_NAME = "sounds/achievements/unlock.wav";
 	static constexpr const char* LBSUBMIT_SOUND_NAME = "sounds/achievements/lbsubmit.wav";
 
-	static void FormattedError(const char* format, ...);
-	static void LogFailedResponseJSON(const Common::HTTPDownloader::Request::Data& data);
+	namespace
+	{
+		struct LoginWithPasswordParameters
+		{
+			const char* username;
+			Error* error;
+			rc_client_async_handle_t* request;
+			bool result;
+		};
+		struct LeaderboardTrackerIndicator
+		{
+			u32 tracker_id;
+			ImVec2 size;
+			std::string text;
+			Common::Timer show_hide_time;
+			bool active;
+		};
+
+		struct AchievementChallengeIndicator
+		{
+			const rc_client_achievement_t* achievement;
+			std::string badge_path;
+			Common::Timer show_hide_time;
+			bool active;
+		};
+
+		struct AchievementProgressIndicator
+		{
+			const rc_client_achievement_t* achievement;
+			std::string badge_path;
+			Common::Timer show_hide_time;
+			bool active;
+		};
+	} // namespace
+
+	static void ReportError(const std::string_view& sv);
+	template <typename... T>
+	static void ReportFmtError(fmt::format_string<T...> fmt, T&&... args);
+	template <typename... T>
+	static void ReportRCError(int err, fmt::format_string<T...> fmt, T&&... args);
 	static void EnsureCacheDirectoriesExist();
-	static void CheevosEventHandler(const rc_runtime_event_t* runtime_event);
-	static unsigned PeekMemory(unsigned address, unsigned num_bytes, void* ud);
-	static unsigned PeekMemoryBlock(unsigned address, unsigned char* buffer, unsigned num_bytes);
-	static void PokeMemory(unsigned address, unsigned num_bytes, void* ud, unsigned value);
-	static bool IsMastered();
-	static void ActivateAchievementsAndLeaderboards();
-	static void DeactivateAchievement(Achievement* achievement);
-	static void SendPing();
-	static void SendPlaying();
-	static void UpdateRichPresence();
-	static Achievement* GetMutableAchievementByID(u32 id);
-	static void ClearGameInfo(bool clear_achievements = true, bool clear_leaderboards = true);
+	static void ClearGameInfo();
 	static void ClearGameHash();
 	static std::string GetUserAgent();
 	static void BeginLoadingScreen(const char* text, bool* was_running_idle);
 	static void EndLoadingScreen(bool was_running_idle);
-	static void LoginCallback(s32 status_code, const std::string& content_type, Common::HTTPDownloader::Request::Data data);
-	static void LoginASyncCallback(s32 status_code, const std::string& content_type, Common::HTTPDownloader::Request::Data data);
-	static void LoginWithTokenCallback(s32 status_code, const std::string& content_type, Common::HTTPDownloader::Request::Data data);
-	static void SendLogin(const char* username, const char* password, const char* api_token, Common::HTTPDownloader* http_downloader,
-		Common::HTTPDownloader::Request::Callback callback);
-	static void DownloadImage(std::string url, std::string cache_filename);
-	static void DisplayAchievementSummary();
-	static void DisplayMasteredNotification();
-	static void UnlockAchievement(u32 achievement_id, bool add_notification = true);
-	static void AchievementPrimed(u32 achievement_id);
-	static void AchievementUnprimed(u32 achievement_id);
-	static void SubmitLeaderboard(u32 leaderboard_id, int value);
-	static void GetUserUnlocksCallback(s32 status_code, const std::string& content_type, Common::HTTPDownloader::Request::Data data);
-	static void GetUserUnlocks();
-	static void GetPatchesCallback(s32 status_code, const std::string& content_type, Common::HTTPDownloader::Request::Data data);
-	static void GetLbInfoCallback(s32 status_code, const std::string& content_type, Common::HTTPDownloader::Request::Data data);
-	static void GetPatches(u32 game_id);
 	static std::string_view GetELFNameForHash(const std::string& elf_path);
 	static std::string GetGameHash();
-	static void SetChallengeMode(bool enabled);
-	static void SendGetGameId();
-	static void GetGameIdCallback(s32 status_code, const std::string& content_type, Common::HTTPDownloader::Request::Data data);
-	static void SendPlayingCallback(s32 status_code, const std::string& content_type, Common::HTTPDownloader::Request::Data data);
-	static void UpdateRichPresence();
-	static void SendPingCallback(s32 status_code, const std::string& content_type, Common::HTTPDownloader::Request::Data data);
-	static void UnlockAchievementCallback(s32 status_code, const std::string& content_type, Common::HTTPDownloader::Request::Data data);
-	static void SubmitLeaderboardCallback(s32 status_code, const std::string& content_type, Common::HTTPDownloader::Request::Data data, u32 lboard_id);
+	static void SetHardcoreMode(bool enabled, bool force_display_message);
+	static bool IsLoggedInOrLoggingIn();
+	static bool IsUnknownGame();
+	static void ShowLoginSuccess(const rc_client_t* client);
+	static void IdentifyGame(u32 disc_crc);
+	static void BeginLoadGame();
+	static void UpdateGameSummary();
+	static void DownloadImage(std::string url, std::string cache_filename);
 
-	static s32 GetNotificationsDuration();
+	static bool CreateClient(rc_client_t** client, std::unique_ptr<Common::HTTPDownloader>* http);
+	static void DestroyClient(rc_client_t** client, std::unique_ptr<Common::HTTPDownloader>* http);
+	static void ClientMessageCallback(const char* message, const rc_client_t* client);
+	static uint32_t ClientReadMemory(uint32_t address, uint8_t* buffer, uint32_t num_bytes, rc_client_t* client);
+	static void ClientServerCall(
+		const rc_api_request_t* request, rc_client_server_callback_t callback, void* callback_data, rc_client_t* client);
 
-	static bool s_active = false;
-	static bool s_logged_in = false;
-	static bool s_challenge_mode = false;
-	static u32 s_game_id = 0;
+	static void ClientEventHandler(const rc_client_event_t* event, rc_client_t* client);
+	static void HandleResetEvent(const rc_client_event_t* event);
+	static void HandleUnlockEvent(const rc_client_event_t* event);
+	static void HandleGameCompleteEvent(const rc_client_event_t* event);
+	static void HandleLeaderboardStartedEvent(const rc_client_event_t* event);
+	static void HandleLeaderboardFailedEvent(const rc_client_event_t* event);
+	static void HandleLeaderboardSubmittedEvent(const rc_client_event_t* event);
+	static void HandleLeaderboardScoreboardEvent(const rc_client_event_t* event);
+	static void HandleLeaderboardTrackerShowEvent(const rc_client_event_t* event);
+	static void HandleLeaderboardTrackerHideEvent(const rc_client_event_t* event);
+	static void HandleLeaderboardTrackerUpdateEvent(const rc_client_event_t* event);
+	static void HandleAchievementChallengeIndicatorShowEvent(const rc_client_event_t* event);
+	static void HandleAchievementChallengeIndicatorHideEvent(const rc_client_event_t* event);
+	static void HandleAchievementProgressIndicatorShowEvent(const rc_client_event_t* event);
+	static void HandleAchievementProgressIndicatorHideEvent(const rc_client_event_t* event);
+	static void HandleAchievementProgressIndicatorUpdateEvent(const rc_client_event_t* event);
+	static void HandleServerErrorEvent(const rc_client_event_t* event);
+	static void HandleServerDisconnectedEvent(const rc_client_event_t* event);
+	static void HandleServerReconnectedEvent(const rc_client_event_t* event);
+
+	static void ClientLoginWithTokenCallback(int result, const char* error_message, rc_client_t* client, void* userdata);
+	static void ClientLoginWithPasswordCallback(int result, const char* error_message, rc_client_t* client, void* userdata);
+	static void ClientLoadGameCallback(int result, const char* error_message, rc_client_t* client, void* userdata);
+
+	static void DisplayHardcoreDeferredMessage();
+	static void DisplayAchievementSummary();
+	static void UpdateRichPresence(std::unique_lock<std::recursive_mutex>& lock);
+
+	static std::string GetAchievementBadgePath(const rc_client_achievement_t* achievement, int state);
+	static std::string GetUserBadgePath(const std::string_view& username);
+	static std::string GetLeaderboardUserBadgePath(const rc_client_leaderboard_entry_t* entry);
+
+	static void DrawAchievement(const rc_client_achievement_t* cheevo);
+	static void DrawLeaderboardListEntry(const rc_client_leaderboard_t* lboard);
+	static void DrawLeaderboardEntry(const rc_client_leaderboard_entry_t& entry, bool is_self, float rank_column_width,
+		float name_column_width, float time_column_width, float column_spacing);
+	static void OpenLeaderboard(const rc_client_leaderboard_t* lboard);
+	static void LeaderboardFetchNearbyCallback(
+		int result, const char* error_message, rc_client_leaderboard_entry_list_t* list, rc_client_t* client, void* callback_userdata);
+	static void LeaderboardFetchAllCallback(
+		int result, const char* error_message, rc_client_leaderboard_entry_list_t* list, rc_client_t* client, void* callback_userdata);
+	static void FetchNextLeaderboardEntries();
+	static void CloseLeaderboard();
+
+	static bool s_hardcore_mode = false;
 
 #ifdef ENABLE_RAINTEGRATION
 	static bool s_using_raintegration = false;
 #endif
 
 	static std::recursive_mutex s_achievements_mutex;
-	static rc_runtime_t s_rcheevos_runtime;
-	static std::string s_game_icon_cache_directory;
-	static std::string s_achievement_icon_cache_directory;
+	static rc_client_t* s_client;
+	static std::string s_image_directory;
 	static std::unique_ptr<Common::HTTPDownloader> s_http_downloader;
 
-	static std::string s_username;
-	static std::string s_api_token;
-
-	static u32 s_last_disc_crc;
-	static u32 s_current_crc;
-	static std::string s_game_path;
+	static u32 s_game_disc_crc;
 	static std::string s_game_hash;
 	static std::string s_game_title;
 	static std::string s_game_icon;
-	static std::vector<Achievements::Achievement> s_achievements;
-	static std::vector<Achievements::Leaderboard> s_leaderboards;
-	static std::atomic<u32> s_primed_achievement_count{0};
+	static rc_client_user_game_summary_t s_game_summary;
+	static u32 s_game_id = 0;
 
+	static bool s_has_achievements = false;
+	static bool s_has_leaderboards = false;
 	static bool s_has_rich_presence = false;
 	static std::string s_rich_presence_string;
-	static Common::Timer s_last_ping_time;
+	static Common::Timer s_rich_presence_poll_time;
 
-	static u32 s_last_queried_lboard = 0;
-	static std::optional<std::vector<Achievements::LeaderboardEntry>> s_lboard_entries;
+	static rc_client_async_handle_t* s_login_request;
+	static rc_client_async_handle_t* s_load_game_request;
 
-	template <typename T>
-	static const char* RAPIStructName();
+	static rc_client_achievement_list_t* s_achievement_list;
+	static rc_client_leaderboard_list_t* s_leaderboard_list;
+	static std::vector<std::pair<const void*, std::string>> s_achievement_badge_paths;
+	static const rc_client_leaderboard_t* s_open_leaderboard = nullptr;
+	static rc_client_async_handle_t* s_leaderboard_fetch_handle = nullptr;
+	static std::vector<rc_client_leaderboard_entry_list_t*> s_leaderboard_entry_lists;
+	static rc_client_leaderboard_entry_list_t* s_leaderboard_nearby_entries;
+	static std::vector<std::pair<const rc_client_leaderboard_entry_t*, std::string>> s_leaderboard_user_icon_paths;
+	static bool s_is_showing_all_leaderboard_entries = false;
 
-#define RAPI_STRUCT_NAME(x) \
-	template <> \
-	const char* RAPIStructName<x>() \
-	{ \
-		return #x; \
-	}
-
-	RAPI_STRUCT_NAME(rc_api_login_request_t);
-	RAPI_STRUCT_NAME(rc_api_fetch_image_request_t);
-	RAPI_STRUCT_NAME(rc_api_resolve_hash_request_t);
-	RAPI_STRUCT_NAME(rc_api_fetch_game_data_request_t);
-	RAPI_STRUCT_NAME(rc_api_fetch_user_unlocks_request_t);
-	RAPI_STRUCT_NAME(rc_api_start_session_request_t);
-	RAPI_STRUCT_NAME(rc_api_ping_request_t);
-	RAPI_STRUCT_NAME(rc_api_award_achievement_request_t);
-	RAPI_STRUCT_NAME(rc_api_submit_lboard_entry_request_t);
-	RAPI_STRUCT_NAME(rc_api_fetch_leaderboard_info_request_t);
-
-	RAPI_STRUCT_NAME(rc_api_login_response_t);
-	RAPI_STRUCT_NAME(rc_api_resolve_hash_response_t);
-	RAPI_STRUCT_NAME(rc_api_fetch_game_data_response_t);
-	RAPI_STRUCT_NAME(rc_api_ping_response_t);
-	RAPI_STRUCT_NAME(rc_api_award_achievement_response_t);
-	RAPI_STRUCT_NAME(rc_api_submit_lboard_entry_response_t);
-	RAPI_STRUCT_NAME(rc_api_start_session_response_t);
-	RAPI_STRUCT_NAME(rc_api_fetch_user_unlocks_response_t);
-	RAPI_STRUCT_NAME(rc_api_fetch_leaderboard_info_response_t);
-
-	// Unused for now.
-	// RAPI_STRUCT_NAME(rc_api_response_t);
-	// RAPI_STRUCT_NAME(rc_api_fetch_achievement_info_response_t);
-	// RAPI_STRUCT_NAME(rc_api_fetch_games_list_response_t);
-
-#undef RAPI_STRUCT_NAME
-
-	template <typename T, int (*InitFunc)(rc_api_request_t*, const T*)>
-	struct RAPIRequest : public T
-	{
-	private:
-		rc_api_request_t api_request;
-
-	public:
-		RAPIRequest() { std::memset(this, 0, sizeof(*this)); }
-
-		~RAPIRequest() { rc_api_destroy_request(&api_request); }
-
-		void Send(Common::HTTPDownloader::Request::Callback callback) { Send(s_http_downloader.get(), std::move(callback)); }
-
-		void Send(Common::HTTPDownloader* http_downloader, Common::HTTPDownloader::Request::Callback callback)
-		{
-			const int error = InitFunc(&api_request, this);
-			if (error != RC_OK)
-			{
-				FormattedError("%s failed: error %d (%s)", RAPIStructName<T>(), error, rc_error_str(error));
-				callback(-1, std::string(), Common::HTTPDownloader::Request::Data());
-				return;
-			}
-
-			if (api_request.post_data)
-			{
-				// needs to be a post
-				http_downloader->CreatePostRequest(api_request.url, api_request.post_data, std::move(callback));
-			}
-			else
-			{
-				// get is fine
-				http_downloader->CreateRequest(api_request.url, std::move(callback));
-			}
-		}
-
-		bool DownloadImage(std::string cache_filename)
-		{
-			const int error = InitFunc(&api_request, this);
-			if (error != RC_OK)
-			{
-				FormattedError("%s failed: error %d (%s)", RAPIStructName<T>(), error, rc_error_str(error));
-				return false;
-			}
-
-			pxAssertMsg(!api_request.post_data, "Download request does not have POST data");
-			Achievements::DownloadImage(api_request.url, std::move(cache_filename));
-			return true;
-		}
-
-		std::string GetURL()
-		{
-			const int error = InitFunc(&api_request, this);
-			if (error != RC_OK)
-			{
-				FormattedError("%s failed: error %d (%s)", RAPIStructName<T>(), error, rc_error_str(error));
-				return std::string();
-			}
-
-			return api_request.url;
-		}
-	};
-
-	template <typename T, int (*ParseFunc)(T*, const char*), void (*DestroyFunc)(T*)>
-	struct RAPIResponse : public T
-	{
-	private:
-		bool initialized = false;
-
-	public:
-		RAPIResponse(s32 status_code, Common::HTTPDownloader::Request::Data& data)
-		{
-			if (status_code != Common::HTTPDownloader::HTTP_OK || data.empty())
-			{
-				FormattedError("%s failed: empty response and/or status code %d", RAPIStructName<T>(), status_code);
-				LogFailedResponseJSON(data);
-				return;
-			}
-
-			// ensure null termination, rapi needs it
-			data.push_back(0);
-
-			const int error = ParseFunc(this, reinterpret_cast<const char*>(data.data()));
-			initialized = (error == RC_OK);
-
-			const rc_api_response_t& response = static_cast<T*>(this)->response;
-			if (error != RC_OK)
-			{
-				FormattedError("%s failed: parse function returned %d (%s)", RAPIStructName<T>(), error, rc_error_str(error));
-				LogFailedResponseJSON(data);
-			}
-			else if (!response.succeeded)
-			{
-				FormattedError("%s failed: %s", RAPIStructName<T>(), response.error_message ? response.error_message : "<no error>");
-				LogFailedResponseJSON(data);
-			}
-		}
-
-		~RAPIResponse()
-		{
-			if (initialized)
-				DestroyFunc(this);
-		}
-
-		operator bool() const { return initialized && static_cast<const T*>(this)->response.succeeded; }
-	};
-
+	static std::vector<LeaderboardTrackerIndicator> s_active_leaderboard_trackers;
+	static std::vector<AchievementChallengeIndicator> s_active_challenge_indicators;
+	static std::optional<AchievementProgressIndicator> s_active_progress_indicator;
 } // namespace Achievements
 
-#ifdef ENABLE_RAINTEGRATION
-bool Achievements::IsUsingRAIntegration()
+
+std::unique_lock<std::recursive_mutex> Achievements::GetLock()
 {
-	return s_using_raintegration;
-}
-#endif
-
-void Achievements::FormattedError(const char* format, ...)
-{
-	std::va_list ap;
-	va_start(ap, format);
-	std::string error(fmt::format("Achievements error: {}", StringUtil::StdStringFromFormatV(format, ap)));
-	va_end(ap);
-
-	Console.Error(error);
-	Host::AddOSDMessage(std::move(error), 10.0f);
-}
-
-void Achievements::LogFailedResponseJSON(const Common::HTTPDownloader::Request::Data& data)
-{
-	const std::string str_data(reinterpret_cast<const char*>(data.data()), data.size());
-	Console.Error("API call failed. Response JSON was:\n%s", str_data.c_str());
-}
-
-const Achievements::Achievement* Achievements::GetAchievementByID(u32 id)
-{
-	for (const Achievement& ach : s_achievements)
-	{
-		if (ach.id == id)
-			return &ach;
-	}
-
-	return nullptr;
-}
-
-Achievements::Achievement* Achievements::GetMutableAchievementByID(u32 id)
-{
-	for (Achievement& ach : s_achievements)
-	{
-		if (ach.id == id)
-			return &ach;
-	}
-
-	return nullptr;
-}
-
-void Achievements::ClearGameInfo(bool clear_achievements, bool clear_leaderboards)
-{
-	std::unique_lock lock(s_achievements_mutex);
-	const bool had_game = (s_game_id != 0);
-
-	if (clear_achievements)
-	{
-		while (!s_achievements.empty())
-		{
-			Achievement& ach = s_achievements.back();
-			DeactivateAchievement(&ach);
-			s_achievements.pop_back();
-		}
-		s_primed_achievement_count.store(0, std::memory_order_release);
-	}
-	if (clear_leaderboards)
-	{
-		while (!s_leaderboards.empty())
-		{
-			Leaderboard& lb = s_leaderboards.back();
-			if (lb.active)
-				rc_runtime_deactivate_lboard(&s_rcheevos_runtime, lb.id);
-			s_leaderboards.pop_back();
-		}
-
-		s_last_queried_lboard = 0;
-		s_lboard_entries.reset();
-	}
-
-	if (s_achievements.empty() && s_leaderboards.empty())
-	{
-		// Ready to tear down cheevos completely
-		s_game_title = {};
-		s_game_icon = {};
-		s_rich_presence_string = {};
-		s_has_rich_presence = false;
-		s_game_id = 0;
-
-		if (EmuConfig.EnableDiscordPresence)
-			VMManager::UpdateDiscordPresence(s_rich_presence_string);
-	}
-
-	if (had_game)
-		Host::OnAchievementsRefreshed();
-}
-
-void Achievements::ClearGameHash()
-{
-	s_last_disc_crc = 0;
-	std::string().swap(s_game_hash);
+	return std::unique_lock(s_achievements_mutex);
 }
 
 std::string Achievements::GetUserAgent()
@@ -435,951 +265,28 @@ void Achievements::EndLoadingScreen(bool was_running_idle)
 	ImGuiFullscreen::CloseBackgroundProgressDialog("achievements_loading");
 }
 
-bool Achievements::IsActive()
+void Achievements::ReportError(const std::string_view& sv)
 {
-	return s_active;
+	std::string error = fmt::format("Achievements error: {}", sv);
+	Console.Error(error);
+	Host::AddOSDMessage(std::move(error), Host::OSD_CRITICAL_ERROR_DURATION);
 }
 
-bool Achievements::IsLoggedIn()
+template <typename... T>
+void Achievements::ReportFmtError(fmt::format_string<T...> fmt, T&&... args)
 {
-	return s_logged_in;
+	SmallString str;
+	fmt::vformat_to(std::back_inserter(str), fmt, fmt::make_format_args(args...));
+	ReportError(str);
 }
 
-bool Achievements::HasSavedCredentials()
+template <typename... T>
+void Achievements::ReportRCError(int err, fmt::format_string<T...> fmt, T&&... args)
 {
-	return !s_username.empty() && !s_api_token.empty();
-}
-
-bool Achievements::ChallengeModeActive()
-{
-#ifdef ENABLE_RAINTEGRATION
-	if (IsUsingRAIntegration())
-		return RA_HardcoreModeIsActive() != 0;
-#endif
-
-	return s_challenge_mode;
-}
-
-bool Achievements::LeaderboardsActive()
-{
-	return ChallengeModeActive() && EmuConfig.Achievements.Leaderboards;
-}
-
-bool Achievements::IsTestModeActive()
-{
-	return EmuConfig.Achievements.TestMode;
-}
-
-bool Achievements::IsUnofficialTestModeActive()
-{
-	return EmuConfig.Achievements.UnofficialTestMode;
-}
-
-bool Achievements::IsRichPresenceEnabled()
-{
-	return EmuConfig.Achievements.RichPresence;
-}
-
-bool Achievements::HasActiveGame()
-{
-	return s_game_id != 0;
-}
-
-u32 Achievements::GetGameID()
-{
-	return s_game_id;
-}
-
-std::unique_lock<std::recursive_mutex> Achievements::GetLock()
-{
-	return std::unique_lock(s_achievements_mutex);
-}
-
-void Achievements::Initialize()
-{
-	if (IsUsingRAIntegration())
-		return;
-
-	std::unique_lock lock(s_achievements_mutex);
-	pxAssertRel(EmuConfig.Achievements.Enabled, "Achievements are enabled");
-
-	s_http_downloader = Common::HTTPDownloader::Create(GetUserAgent().c_str());
-	if (!s_http_downloader)
-	{
-		Host::ReportErrorAsync("Achievements Error", "Failed to create HTTPDownloader, cannot use achievements");
-		return;
-	}
-
-	s_active = true;
-	s_challenge_mode = false;
-	rc_runtime_init(&s_rcheevos_runtime);
-	EnsureCacheDirectoriesExist();
-
-	s_last_ping_time.Reset();
-	s_username = Host::GetBaseStringSettingValue("Achievements", "Username");
-	s_api_token = Host::GetBaseStringSettingValue("Achievements", "Token");
-	s_logged_in = false; // We are not logged in until we confirm those credentials
-
-	if (VMManager::HasValidVM())
-		GameChanged(VMManager::GetDiscCRC(), VMManager::GetCurrentCRC());
-}
-
-void Achievements::UpdateSettings(const Pcsx2Config::AchievementsOptions& old_config)
-{
-	if (IsUsingRAIntegration())
-		return;
-
-	if (!EmuConfig.Achievements.Enabled)
-	{
-		// we're done here
-		Shutdown();
-		return;
-	}
-
-	if (!s_active)
-	{
-		// we just got enabled
-		Initialize();
-		return;
-	}
-
-	if (EmuConfig.Achievements.ChallengeMode != old_config.ChallengeMode)
-	{
-		// Hardcore mode can only be enabled through system boot/reset.
-		if (s_challenge_mode && !EmuConfig.Achievements.ChallengeMode)
-		{
-			ResetChallengeMode();
-		}
-		else if (!s_challenge_mode && EmuConfig.Achievements.ChallengeMode)
-		{
-			if (HasActiveGame())
-			{
-				ImGuiFullscreen::ShowToast(std::string(),
-					TRANSLATE_STR("Achievements", "Hardcore mode will be enabled on system reset."), 10.0f);
-			}
-		}
-	}
-
-	// We *could* handle these separately, but easier to just flush everything.
-	if (EmuConfig.Achievements.TestMode != old_config.TestMode ||
-		EmuConfig.Achievements.UnofficialTestMode != old_config.UnofficialTestMode ||
-		EmuConfig.Achievements.RichPresence != old_config.RichPresence)
-	{
-		Shutdown();
-		Initialize();
-		ResetChallengeMode();
-		return;
-	}
-	else if (EmuConfig.Achievements.Leaderboards != old_config.Leaderboards)
-	{
-		// If leaderboards were toggled, redisplay the summary (but only when HC mode is active,
-		// because otherwise leaderboards are irrelevant anyway).
-		if (HasActiveGame() && ChallengeModeActive())
-			DisplayAchievementSummary();
-	}
-
-	// in case cache directory changed
-	EnsureCacheDirectoriesExist();
-}
-
-bool Achievements::ConfirmChallengeModeDisable(const char* trigger)
-{
-#ifdef ENABLE_RAINTEGRATION
-	if (IsUsingRAIntegration())
-		return (RA_WarnDisableHardcore(trigger) != 0);
-#endif
-
-	const bool confirmed = Host::ConfirmMessage("Confirm Hardcore Mode",
-		fmt::format(TRANSLATE_FS("Achievements", "{0} cannot be performed while hardcore mode is active. Do you want "
-												 "to disable hardcore mode? {0} will be cancelled if you select No."),
-			trigger));
-	if (!confirmed)
-		return false;
-
-	DisableChallengeMode();
-	return true;
-}
-
-void Achievements::DisableChallengeMode()
-{
-	if (!s_active)
-		return;
-
-#ifdef ENABLE_RAINTEGRATION
-	if (IsUsingRAIntegration())
-	{
-		if (RA_HardcoreModeIsActive())
-			RA_DisableHardcore();
-
-		return;
-	}
-#endif
-
-	if (s_challenge_mode)
-		SetChallengeMode(false);
-}
-
-bool Achievements::ResetChallengeMode()
-{
-	if (!s_active)
-		return false;
-
-	Host::RemoveKeyedOSDMessage("challenge_mode_reset");
-
-	if (s_challenge_mode == EmuConfig.Achievements.ChallengeMode)
-		return false;
-
-	SetChallengeMode(EmuConfig.Achievements.ChallengeMode);
-	return true;
-}
-
-void Achievements::SetChallengeMode(bool enabled)
-{
-	if (enabled == s_challenge_mode)
-		return;
-
-	// new mode
-	s_challenge_mode = enabled;
-
-	if (HasActiveGame())
-	{
-		ImGuiFullscreen::ShowToast(std::string(),
-			enabled ? TRANSLATE("Achievements", "Hardcore mode is now enabled.") :
-					  TRANSLATE("Achievements", "Hardcore mode is now disabled."),
-			10.0f);
-	}
-
-	if (HasActiveGame() && !IsTestModeActive())
-	{
-		// deactivate, but don't clear all achievements (getting unlocks will reactivate them)
-		std::unique_lock lock(s_achievements_mutex);
-		for (Achievement& achievement : s_achievements)
-		{
-			DeactivateAchievement(&achievement);
-			achievement.locked = true;
-		}
-		for (Leaderboard& leaderboard : s_leaderboards)
-		{
-			if (leaderboard.active)
-			{
-				rc_runtime_deactivate_lboard(&s_rcheevos_runtime, leaderboard.id);
-				leaderboard.active = false;
-			}
-		}
-	}
-
-	// re-grab unlocks, this will reactivate what's locked in non-hardcore mode later on
-	if (!s_achievements.empty())
-		GetUserUnlocks();
-}
-
-bool Achievements::Shutdown()
-{
-#ifdef ENABLE_RAINTEGRATION
-	if (IsUsingRAIntegration())
-	{
-		if (!RA_ConfirmLoadNewRom(true))
-			return false;
-
-		RA_SetPaused(false);
-		RA_ActivateGame(0);
-		return true;
-	}
-#endif
-
-	if (!s_active)
-		return true;
-
-	std::unique_lock lock(s_achievements_mutex);
-	s_http_downloader->WaitForAllRequests();
-
-	ClearGameInfo();
-	ClearGameHash();
-	std::string().swap(s_username);
-	std::string().swap(s_api_token);
-	s_logged_in = false;
-	Host::OnAchievementsRefreshed();
-
-	s_challenge_mode = false;
-	s_active = false;
-	rc_runtime_destroy(&s_rcheevos_runtime);
-
-	s_http_downloader.reset();
-	return true;
-}
-
-bool Achievements::OnReset()
-{
-#ifdef ENABLE_RAINTEGRATION
-	if (IsUsingRAIntegration())
-	{
-		if (!RA_ConfirmLoadNewRom(false))
-			return false;
-
-		RA_OnReset();
-		return true;
-	}
-#endif
-
-	if (!s_active)
-		return true;
-
-	std::unique_lock lock(s_achievements_mutex);
-
-	// Clear the game out, we'll re-query it once the ELF is loaded.
-	ClearGameInfo(true, true);
-	ClearGameHash();
-
-	// Reset runtime, there shouldn't be anything left in it though.
-	DevCon.WriteLn("Resetting rcheevos state...");
-	rc_runtime_reset(&s_rcheevos_runtime);
-	return true;
-}
-
-void Achievements::OnPaused(bool paused)
-{
-#ifdef ENABLE_RAINTEGRATION
-	if (IsUsingRAIntegration())
-		RA_SetPaused(paused);
-#endif
-}
-
-void Achievements::VSyncUpdate()
-{
-#ifdef ENABLE_RAINTEGRATION
-	if (IsUsingRAIntegration())
-	{
-		RA_DoAchievementsFrame();
-		return;
-	}
-#endif
-
-	s_http_downloader->PollRequests();
-
-	if (HasActiveGame())
-	{
-		std::unique_lock lock(s_achievements_mutex);
-		rc_runtime_do_frame(&s_rcheevos_runtime, &CheevosEventHandler, &PeekMemory, nullptr, nullptr);
-		UpdateRichPresence();
-
-		if (!IsTestModeActive())
-		{
-			const s32 ping_frequency = EmuConfig.Achievements.RichPresence ? RICH_PRESENCE_PING_FREQUENCY : NO_RICH_PRESENCE_PING_FREQUENCY;
-			if (static_cast<s32>(s_last_ping_time.GetTimeSeconds()) >= ping_frequency)
-				SendPing();
-		}
-	}
-}
-
-void Achievements::ProcessPendingHTTPRequestsFromGSThread()
-{
-	// no need to do this if we're running, because VSyncUpdate() will take care of it
-	if (VMManager::GetState() == VMState::Running)
-		return;
-
-	if (s_http_downloader->HasAnyRequests())
-		Host::RunOnCPUThread([]() { s_http_downloader->PollRequests(); });
-}
-
-void Achievements::LoadState(const u8* state_data, u32 state_data_size)
-{
-	if (!s_active)
-		return;
-
-	// this assumes that the CRC and ELF name has been loaded prior to the cheevos state (it should be).
-	if (VMManager::GetDiscCRC() != s_last_disc_crc)
-		GameChanged(VMManager::GetDiscCRC(), VMManager::GetCurrentCRC());
-
-#ifdef ENABLE_RAINTEGRATION
-	if (IsUsingRAIntegration())
-	{
-		if (state_data_size == 0)
-		{
-			Console.Warning("State is missing cheevos data, resetting RAIntegration");
-			RA_OnReset();
-		}
-		else
-		{
-			RA_RestoreState(reinterpret_cast<const char*>(state_data));
-		}
-
-		return;
-	}
-#endif
-
-	// if we're active, make sure we've downloaded and activated all the achievements
-	// before deserializing, otherwise that state's going to get lost.
-	if (s_http_downloader->HasAnyRequests())
-	{
-		bool was_running_idle;
-		BeginLoadingScreen("Downloading achievements data...", &was_running_idle);
-		s_http_downloader->WaitForAllRequests();
-		EndLoadingScreen(was_running_idle);
-	}
-
-	std::unique_lock lock(s_achievements_mutex);
-	if (state_data_size == 0)
-	{
-		// reset runtime, no data (state might've been created without cheevos)
-		Console.Warning("State is missing cheevos data, resetting runtime");
-		rc_runtime_reset(&s_rcheevos_runtime);
-		return;
-	}
-
-	// These routines scare me a bit.. the data isn't bounds checked.
-	// Really hope that nobody puts any thing malicious in a save state...
-	const int result = rc_runtime_deserialize_progress(&s_rcheevos_runtime, state_data, nullptr);
-	if (result != RC_OK)
-	{
-		Console.Warning("Failed to deserialize cheevos state (%d), resetting", result);
-		rc_runtime_reset(&s_rcheevos_runtime);
-	}
-}
-
-std::vector<u8> Achievements::SaveState()
-{
-	std::vector<u8> ret;
-
-#ifdef ENABLE_RAINTEGRATION
-	if (IsUsingRAIntegration())
-	{
-		const int size = RA_CaptureState(nullptr, 0);
-
-		const u32 data_size = (size >= 0) ? static_cast<u32>(size) : 0;
-		ret.resize(data_size);
-
-		const int result = RA_CaptureState(reinterpret_cast<char*>(ret.data()), static_cast<int>(data_size));
-		if (result != static_cast<int>(data_size))
-		{
-			Console.Warning("Failed to serialize cheevos state from RAIntegration.");
-			ret.clear();
-		}
-
-		return ret;
-	}
-#endif
-
-	if (s_active)
-	{
-		std::unique_lock lock(s_achievements_mutex);
-
-		// internally this happens twice.. not great.
-		const int size = rc_runtime_progress_size(&s_rcheevos_runtime, nullptr);
-
-		const u32 data_size = (size >= 0) ? static_cast<u32>(size) : 0;
-		ret.resize(data_size);
-
-		const int result = rc_runtime_serialize_progress(ret.data(), &s_rcheevos_runtime, nullptr);
-		if (result != RC_OK)
-		{
-			// set data to zero, effectively serializing nothing
-			Console.Warning("Failed to serialize cheevos state (%d)", result);
-			ret.clear();
-		}
-	}
-
-	return ret;
-}
-
-bool Achievements::SafeHasAchievementsOrLeaderboards()
-{
-	std::unique_lock lock(s_achievements_mutex);
-	return !s_achievements.empty() || s_leaderboards.empty();
-}
-
-const std::string& Achievements::GetUsername()
-{
-	return s_username;
-}
-
-const std::string& Achievements::GetRichPresenceString()
-{
-	return s_rich_presence_string;
-}
-
-std::string Achievements::SafeGetRichPresenceString()
-{
-	std::string rich_presence_string;
-	if (IsActive() && EmuConfig.Achievements.RichPresence)
-	{
-		std::unique_lock lock(s_achievements_mutex);
-		rich_presence_string = s_rich_presence_string;
-	}
-	return rich_presence_string;
-}
-
-void Achievements::EnsureCacheDirectoriesExist()
-{
-	s_game_icon_cache_directory = Path::Combine(EmuFolders::Cache, "achievement_gameicon");
-	s_achievement_icon_cache_directory = Path::Combine(EmuFolders::Cache, "achievement_badge");
-
-	if (!FileSystem::DirectoryExists(s_game_icon_cache_directory.c_str()) &&
-		!FileSystem::CreateDirectoryPath(s_game_icon_cache_directory.c_str(), false))
-	{
-		FormattedError("Failed to create cache directory '%s'", s_game_icon_cache_directory.c_str());
-	}
-
-	if (!FileSystem::DirectoryExists(s_achievement_icon_cache_directory.c_str()) &&
-		!FileSystem::CreateDirectoryPath(s_achievement_icon_cache_directory.c_str(), false))
-	{
-		FormattedError("Failed to create cache directory '%s'", s_achievement_icon_cache_directory.c_str());
-	}
-}
-
-void Achievements::LoginCallback(s32 status_code, const std::string& content_type, Common::HTTPDownloader::Request::Data data)
-{
-	std::unique_lock lock(s_achievements_mutex);
-
-	// NOTE: The strings here can be null if the server returns literal "null" (see rc_json_get_string()), hence the double-check.
-	RAPIResponse<rc_api_login_response_t, rc_api_process_login_response, rc_api_destroy_login_response> response(status_code, data);
-	if (!response || !response.username || !response.api_token)
-	{
-		FormattedError("Login failed. Please check your user name and password, and try again.");
-		return;
-	}
-
-	std::string username(response.username);
-	std::string api_token(response.api_token);
-
-	// save to config
-	Host::SetBaseStringSettingValue("Achievements", "Username", username.c_str());
-	Host::SetBaseStringSettingValue("Achievements", "Token", api_token.c_str());
-	Host::SetBaseStringSettingValue("Achievements", "LoginTimestamp", fmt::format("{}", std::time(nullptr)).c_str());
-	Host::CommitBaseSettingChanges();
-
-	if (s_active)
-	{
-		s_username = std::move(username);
-		s_api_token = std::move(api_token);
-		s_logged_in = true;
-
-		// If we have a game running, set it up.
-		if (!s_game_hash.empty())
-			SendGetGameId();
-	}
-}
-
-void Achievements::LoginASyncCallback(s32 status_code, const std::string& content_type, Common::HTTPDownloader::Request::Data data)
-{
-	ImGuiFullscreen::CloseBackgroundProgressDialog("cheevos_async_login");
-
-	LoginCallback(status_code, std::move(content_type), std::move(data));
-}
-
-void Achievements::LoginWithTokenCallback(s32 status_code, const std::string& content_type, Common::HTTPDownloader::Request::Data data)
-{
-	std::unique_lock lock(s_achievements_mutex);
-
-	RAPIResponse<rc_api_login_response_t, rc_api_process_login_response, rc_api_destroy_login_response> response(status_code, data);
-	if (!response)
-	{
-		lock.unlock();
-		Logout();
-		Host::OnAchievementsLoginRequested(LoginRequestReason::TokenInvalid);
-		return;
-	}
-
-	if (s_active)
-	{
-		s_logged_in = true;
-
-		// If we have a game running, set it up.
-		if (!s_game_hash.empty())
-			SendGetGameId();
-	}
-}
-
-void Achievements::SendLogin(
-	const char* username, const char* password, const char* api_token, Common::HTTPDownloader* http_downloader, Common::HTTPDownloader::Request::Callback callback)
-{
-	RAPIRequest<rc_api_login_request_t, rc_api_init_login_request> request;
-	request.username = username;
-	request.password = password;
-	request.api_token = api_token;
-	request.Send(http_downloader, std::move(callback));
-}
-
-bool Achievements::LoginAsync(const char* username, const char* password)
-{
-	s_http_downloader->WaitForAllRequests();
-
-	if (s_logged_in || std::strlen(username) == 0 || std::strlen(password) == 0 || IsUsingRAIntegration())
-		return false;
-
-	if (FullscreenUI::IsInitialized())
-	{
-		ImGuiFullscreen::OpenBackgroundProgressDialog("cheevos_async_login", "Logging in to RetroAchievements...", 0, 0, 0);
-	}
-
-	SendLogin(username, password, nullptr, s_http_downloader.get(), LoginASyncCallback);
-	return true;
-}
-
-bool Achievements::Login(const char* username, const char* password)
-{
-	if (s_active)
-		s_http_downloader->WaitForAllRequests();
-
-	if (s_logged_in || std::strlen(username) == 0 || std::strlen(password) == 0 || IsUsingRAIntegration())
-		return false;
-
-	if (s_active)
-	{
-		SendLogin(username, password, nullptr, s_http_downloader.get(), LoginCallback);
-		s_http_downloader->WaitForAllRequests();
-		return IsLoggedIn();
-	}
-
-	// create a temporary downloader if we're not initialized
-	pxAssertRel(!s_active, "RetroAchievements is not active on login");
-	std::unique_ptr<Common::HTTPDownloader> http_downloader = Common::HTTPDownloader::Create(GetUserAgent().c_str());
-	if (!http_downloader)
-		return false;
-
-	SendLogin(username, password, nullptr, http_downloader.get(), LoginCallback);
-	http_downloader->WaitForAllRequests();
-
-	return !Host::GetBaseStringSettingValue("Achievements", "Token").empty();
-}
-
-bool Achievements::LoginWithTokenAsync(const char* username, const char* api_token)
-{
-	if (s_logged_in || std::strlen(username) == 0 || std::strlen(api_token) == 0 || IsUsingRAIntegration())
-		return false;
-
-	SendLogin(username, nullptr, api_token, s_http_downloader.get(), LoginWithTokenCallback);
-	return true;
-}
-
-void Achievements::Logout()
-{
-	if (s_active)
-	{
-		std::unique_lock lock(s_achievements_mutex);
-		s_http_downloader->WaitForAllRequests();
-		if (s_logged_in)
-		{
-			ClearGameInfo();
-			s_logged_in = false;
-			Host::OnAchievementsRefreshed();
-		}
-		std::string().swap(s_username);
-		std::string().swap(s_api_token);
-	}
-
-	// remove from config
-	Host::RemoveBaseSettingValue("Achievements", "Username");
-	Host::RemoveBaseSettingValue("Achievements", "Token");
-	Host::RemoveBaseSettingValue("Achievements", "LoginTimestamp");
-	Host::CommitBaseSettingChanges();
-}
-
-void Achievements::DownloadImage(std::string url, std::string cache_filename)
-{
-	auto callback = [cache_filename](s32 status_code, const std::string& content_type, Common::HTTPDownloader::Request::Data data) {
-		if (status_code != HTTP_OK)
-			return;
-
-		if (!FileSystem::WriteBinaryFile(cache_filename.c_str(), data.data(), data.size()))
-		{
-			Console.Error("Failed to write badge image to '%s'", cache_filename.c_str());
-			return;
-		}
-
-		MTGS::RunOnGSThread([cache_filename]() { ImGuiFullscreen::InvalidateCachedTexture(cache_filename); });
-	};
-
-	s_http_downloader->CreateRequest(std::move(url), std::move(callback));
-}
-
-void Achievements::DisplayAchievementSummary()
-{
-	if (EmuConfig.Achievements.Notifications)
-	{
-		std::string title = s_game_title;
-		if (ChallengeModeActive())
-			title += TRANSLATE_SV("Achievements", " (Hardcore Mode)");
-
-		std::string summary;
-		if (GetAchievementCount() > 0)
-		{
-			summary = fmt::format(TRANSLATE_FS("Achievements", "You have earned {0} of {1} achievements, and {2} of {3} points."),
-				GetUnlockedAchiementCount(), GetAchievementCount(), GetCurrentPointsForGame(), GetMaximumPointsForGame());
-		}
-		else
-		{
-			summary = TRANSLATE_SV("Achievements", "This game has no achievements.");
-		}
-		if (GetLeaderboardCount() > 0)
-		{
-			summary.push_back('\n');
-			if (LeaderboardsActive())
-				summary.append(TRANSLATE_SV("Achievements", "Leaderboard submission is enabled."));
-		}
-
-		MTGS::RunOnGSThread([duration = GetNotificationsDuration(), title = std::move(title), summary = std::move(summary), icon = s_game_icon]() {
-			if (FullscreenUI::IsInitialized())
-				ImGuiFullscreen::AddNotification(duration, std::move(title), std::move(summary), std::move(icon));
-		});
-	}
-
-	// Technically not going through the resource API, but since we're passing this to something else, we can't.
-	if (EmuConfig.Achievements.SoundEffects)
-		Common::PlaySoundAsync(Path::Combine(EmuFolders::Resources, INFO_SOUND_NAME).c_str());
-}
-
-void Achievements::DisplayMasteredNotification()
-{
-	if (!EmuConfig.Achievements.Notifications)
-		return;
-
-	std::string title(fmt::format("Mastered {}", s_game_title));
-	std::string message(fmt::format(
-		"{} achievements, {} points{}", GetAchievementCount(), GetCurrentPointsForGame(), s_challenge_mode ? " (Hardcore Mode)" : ""));
-
-	MTGS::RunOnGSThread([duration = GetNotificationsDuration(), title = std::move(title), message = std::move(message), icon = s_game_icon]() {
-		if (FullscreenUI::IsInitialized())
-			ImGuiFullscreen::AddNotification(duration, std::move(title), std::move(message), std::move(icon));
-	});
-}
-
-void Achievements::GetUserUnlocksCallback(s32 status_code, const std::string& content_type, Common::HTTPDownloader::Request::Data data)
-{
-	RAPIResponse<rc_api_fetch_user_unlocks_response_t, rc_api_process_fetch_user_unlocks_response,
-		rc_api_destroy_fetch_user_unlocks_response>
-		response(status_code, data);
-
-	std::unique_lock lock(s_achievements_mutex);
-	if (!response)
-	{
-		ClearGameInfo(true, false);
-		return;
-	}
-
-	// flag achievements as unlocked
-	for (u32 i = 0; i < response.num_achievement_ids; i++)
-	{
-		Achievement* cheevo = GetMutableAchievementByID(response.achievement_ids[i]);
-		if (!cheevo)
-		{
-			Console.Error("Server returned unknown achievement %u", response.achievement_ids[i]);
-			continue;
-		}
-
-		cheevo->locked = false;
-	}
-
-	// start scanning for locked achievements
-	ActivateAchievementsAndLeaderboards();
-	DisplayAchievementSummary();
-	SendPlaying();
-	UpdateRichPresence();
-	SendPing();
-	Host::OnAchievementsRefreshed();
-}
-
-void Achievements::GetUserUnlocks()
-{
-	RAPIRequest<rc_api_fetch_user_unlocks_request_t, rc_api_init_fetch_user_unlocks_request> request;
-	request.username = s_username.c_str();
-	request.api_token = s_api_token.c_str();
-	request.game_id = s_game_id;
-	request.hardcore = static_cast<int>(ChallengeModeActive());
-	request.Send(GetUserUnlocksCallback);
-}
-
-void Achievements::GetPatchesCallback(s32 status_code, const std::string& content_type, Common::HTTPDownloader::Request::Data data)
-{
-	if (!VMManager::HasValidVM())
-		return;
-
-	RAPIResponse<rc_api_fetch_game_data_response_t, rc_api_process_fetch_game_data_response, rc_api_destroy_fetch_game_data_response>
-		response(status_code, data);
-
-	std::unique_lock lock(s_achievements_mutex);
-	ClearGameInfo();
-	if (!response || !response.title)
-		return;
-
-	// ensure fullscreen UI is ready
-	MTGS::RunOnGSThread(&ImGuiManager::InitializeFullscreenUI);
-
-	s_game_id = response.id;
-	s_game_title = response.title;
-
-	// try for a icon
-	if (response.image_name && std::strlen(response.image_name) > 0)
-	{
-		s_game_icon = Path::Combine(s_game_icon_cache_directory, fmt::format("{}.png", s_game_id));
-		if (!FileSystem::FileExists(s_game_icon.c_str()))
-		{
-			RAPIRequest<rc_api_fetch_image_request_t, rc_api_init_fetch_image_request> request;
-			request.image_name = response.image_name;
-			request.image_type = RC_IMAGE_TYPE_GAME;
-			request.DownloadImage(s_game_icon);
-		}
-	}
-
-	// parse achievements
-	for (u32 i = 0; i < response.num_achievements; i++)
-	{
-		const rc_api_achievement_definition_t& defn = response.achievements[i];
-
-		// Skip local and unofficial achievements for now, unless "Test Unofficial Achievements" is enabled
-		if (defn.category == RC_ACHIEVEMENT_CATEGORY_UNOFFICIAL)
-		{
-			if (!IsUnofficialTestModeActive())
-			{
-				Console.Warning("Skipping unofficial achievement %u (%s)", defn.id, defn.title);
-				continue;
-			}
-		}
-		// local achievements shouldn't be in this list, but just in case?
-		else if (defn.category != RC_ACHIEVEMENT_CATEGORY_CORE)
-		{
-			continue;
-		}
-
-		if (GetMutableAchievementByID(defn.id))
-		{
-			Console.Error("Achievement %u already exists", defn.id);
-			continue;
-		}
-
-		if (!defn.definition || !defn.title || !defn.description || !defn.badge_name)
-		{
-			Console.Error("Incomplete achievement %u", defn.id);
-			continue;
-		}
-
-		Achievement cheevo;
-		cheevo.id = defn.id;
-		cheevo.memaddr = defn.definition;
-		cheevo.title = defn.title;
-		cheevo.description = defn.description;
-		cheevo.badge_name = defn.badge_name;
-		cheevo.locked = true;
-		cheevo.active = false;
-		cheevo.primed = false;
-		cheevo.points = defn.points;
-		cheevo.category = static_cast<AchievementCategory>(defn.category);
-		s_achievements.push_back(std::move(cheevo));
-	}
-
-	for (u32 i = 0; i < response.num_leaderboards; i++)
-	{
-		const rc_api_leaderboard_definition_t& defn = response.leaderboards[i];
-		if (!defn.title || !defn.description || !defn.definition)
-		{
-			Console.Error("Incomplete leaderboard %u", defn.id);
-			continue;
-		}
-
-		Leaderboard lboard;
-		lboard.id = defn.id;
-		lboard.title = defn.title;
-		lboard.description = defn.description;
-		lboard.memaddr = defn.definition;
-		lboard.format = defn.format;
-		lboard.active = false;
-		s_leaderboards.push_back(std::move(lboard));
-	}
-
-	// Parse rich presence.
-	if (response.rich_presence_script && std::strlen(response.rich_presence_script) > 0)
-	{
-		const int res = rc_runtime_activate_richpresence(&s_rcheevos_runtime, response.rich_presence_script, nullptr, 0);
-		if (res == RC_OK)
-			s_has_rich_presence = true;
-		else
-			Console.Warning("Failed to activate rich presence: %s", rc_error_str(res));
-	}
-
-	Console.WriteLn("Game Title: %s", s_game_title.c_str());
-	Console.WriteLn("Achievements: %zu", s_achievements.size());
-	Console.WriteLn("Leaderboards: %zu", s_leaderboards.size());
-
-	// We don't want to block saving/loading states when there's no achievements.
-	if (s_achievements.empty() && s_leaderboards.empty())
-		DisableChallengeMode();
-
-	if (!s_achievements.empty() || s_has_rich_presence)
-	{
-		if (!IsTestModeActive())
-		{
-			GetUserUnlocks();
-		}
-		else
-		{
-			ActivateAchievementsAndLeaderboards();
-			DisplayAchievementSummary();
-			Host::OnAchievementsRefreshed();
-		}
-	}
-	else
-	{
-		DisplayAchievementSummary();
-	}
-
-	if (s_achievements.empty() && s_leaderboards.empty() && !s_has_rich_presence)
-	{
-		ClearGameInfo();
-	}
-}
-
-void Achievements::GetLbInfoCallback(s32 status_code, const std::string& content_type, Common::HTTPDownloader::Request::Data data)
-{
-	if (!VMManager::HasValidVM())
-		return;
-
-	RAPIResponse<rc_api_fetch_leaderboard_info_response_t, rc_api_process_fetch_leaderboard_info_response,
-		rc_api_destroy_fetch_leaderboard_info_response>
-		response(status_code, data);
-	if (!response)
-		return;
-
-	std::unique_lock lock(s_achievements_mutex);
-	if (response.id != s_last_queried_lboard)
-	{
-		// User has already requested another leaderboard, drop this data
-		return;
-	}
-
-	const Leaderboard* leaderboard = GetLeaderboardByID(response.id);
-	if (!leaderboard)
-	{
-		Console.Error("Attempting to list unknown leaderboard %u", response.id);
-		return;
-	}
-
-	s_lboard_entries = std::vector<Achievements::LeaderboardEntry>();
-	for (u32 i = 0; i < response.num_entries; i++)
-	{
-		const rc_api_lboard_info_entry_t& entry = response.entries[i];
-		if (!entry.username)
-			continue;
-
-		char score[128];
-		rc_runtime_format_lboard_value(score, sizeof(score), entry.score, leaderboard->format);
-
-		LeaderboardEntry lbe;
-		lbe.user = entry.username;
-		lbe.rank = entry.rank;
-		lbe.formatted_score = score;
-		lbe.submitted = entry.submitted;
-		lbe.is_self = lbe.user == s_username;
-
-		s_lboard_entries->push_back(std::move(lbe));
-	}
-}
-
-void Achievements::GetPatches(u32 game_id)
-{
-	RAPIRequest<rc_api_fetch_game_data_request_t, rc_api_init_fetch_game_data_request> request;
-	request.username = s_username.c_str();
-	request.api_token = s_api_token.c_str();
-	request.game_id = game_id;
-	request.Send(GetPatchesCallback);
+	SmallString str;
+	fmt::vformat_to(std::back_inserter(str), fmt, fmt::make_format_args(args...));
+	str.append_fmt("{} ({})", rc_error_str(err), err);
+	ReportError(str);
 }
 
 std::string_view Achievements::GetELFNameForHash(const std::string& elf_path)
@@ -1441,60 +348,505 @@ std::string Achievements::GetGameHash()
 	return hash_str;
 }
 
-void Achievements::GetGameIdCallback(s32 status_code, const std::string& content_type, Common::HTTPDownloader::Request::Data data)
+
+void Achievements::DownloadImage(std::string url, std::string cache_filename)
 {
-	if (!VMManager::HasValidVM())
-		return;
+	auto callback = [cache_filename](s32 status_code, std::string content_type, Common::HTTPDownloader::Request::Data data) {
+		if (status_code != Common::HTTPDownloader::HTTP_OK)
+			return;
 
-	RAPIResponse<rc_api_resolve_hash_response_t, rc_api_process_resolve_hash_response, rc_api_destroy_resolve_hash_response> response(
-		status_code, data);
-	if (!response)
-		return;
+		if (!FileSystem::WriteBinaryFile(cache_filename.c_str(), data.data(), data.size()))
+		{
+			Console.Error("Failed to write badge image to '%s'", cache_filename.c_str());
+			return;
+		}
 
-	const u32 game_id = response.game_id;
-	Console.WriteLn("Server returned GameID %u", game_id);
-	if (game_id == 0)
+		ImGuiFullscreen::InvalidateCachedTexture(cache_filename);
+	};
+
+	s_http_downloader->CreateRequest(std::move(url), std::move(callback));
+}
+
+bool Achievements::IsActive()
+{
+#ifdef ENABLE_RAINTEGRATION
+	return (s_client != nullptr) || s_using_raintegration;
+#else
+	return (s_client != nullptr);
+#endif
+}
+
+bool Achievements::IsHardcoreModeActive()
+{
+#ifdef ENABLE_RAINTEGRATION
+	if (IsUsingRAIntegration())
+		return RA_HardcoreModeIsActive() != 0;
+#endif
+
+	return s_hardcore_mode;
+}
+
+bool Achievements::HasActiveGame()
+{
+	return s_game_id != 0;
+}
+
+u32 Achievements::GetGameID()
+{
+	return s_game_id;
+}
+
+bool Achievements::HasAchievementsOrLeaderboards()
+{
+	return s_has_achievements || s_has_leaderboards;
+}
+
+bool Achievements::HasAchievements()
+{
+	return s_has_achievements;
+}
+
+bool Achievements::HasLeaderboards()
+{
+	return s_has_leaderboards;
+}
+
+bool Achievements::HasRichPresence()
+{
+	return s_has_rich_presence;
+}
+
+const std::string& Achievements::GetGameTitle()
+{
+	return s_game_title;
+}
+
+const std::string& Achievements::GetRichPresenceString()
+{
+	return s_rich_presence_string;
+}
+
+
+bool Achievements::Initialize()
+{
+	if (IsUsingRAIntegration())
+		return true;
+
+	EnsureCacheDirectoriesExist();
+
+	auto lock = GetLock();
+	pxAssertRel(EmuConfig.Achievements.Enabled, "Achievements are enabled");
+	pxAssertRel(!s_client && !s_http_downloader, "No client and downloader");
+
+	if (!CreateClient(&s_client, &s_http_downloader))
+		return false;
+
+	// Hardcore starts off. We enable it on first boot.
+	s_hardcore_mode = false;
+
+	rc_client_set_event_handler(s_client, ClientEventHandler);
+
+	rc_client_set_hardcore_enabled(s_client, s_hardcore_mode);
+	rc_client_set_encore_mode_enabled(s_client, EmuConfig.Achievements.EncoreMode);
+	rc_client_set_unofficial_enabled(s_client, EmuConfig.Achievements.UnofficialTestMode);
+	rc_client_set_spectator_mode_enabled(s_client, EmuConfig.Achievements.SpectatorMode);
+
+	// Begin disc identification early, before the login finishes.
+	if (VMManager::HasValidVM())
+		IdentifyGame(VMManager::GetDiscCRC());
+
+	const std::string username = Host::GetBaseStringSettingValue("Achievements", "Username");
+	const std::string api_token = Host::GetBaseStringSettingValue("Achievements", "Token");
+	if (!username.empty() && !api_token.empty())
 	{
-		// We don't want to block saving/loading states when there's no achievements.
-		DisableChallengeMode();
+		Console.WriteLn("(Achievements) Attempting login with user '%s'...", username.c_str());
+		s_login_request =
+			rc_client_begin_login_with_token(s_client, username.c_str(), api_token.c_str(), ClientLoginWithTokenCallback, nullptr);
+	}
+
+	// Hardcore mode isn't enabled when achievements first starts, if a game is already running.
+	if (VMManager::HasValidVM() && IsLoggedInOrLoggingIn() && EmuConfig.Achievements.HardcoreMode)
+		DisplayHardcoreDeferredMessage();
+
+	return true;
+}
+
+bool Achievements::CreateClient(rc_client_t** client, std::unique_ptr<Common::HTTPDownloader>* http)
+{
+	*http = Common::HTTPDownloader::Create(GetUserAgent().c_str());
+	if (!*http)
+	{
+		Host::ReportErrorAsync("Achievements Error", "Failed to create HTTPDownloader, cannot use achievements");
+		return false;
+	}
+
+	rc_client_t* new_client = rc_client_create(ClientReadMemory, ClientServerCall);
+	if (!new_client)
+	{
+		Host::ReportErrorAsync("Achievements Error", "rc_client_create() failed, cannot use achievements");
+		http->reset();
+		return false;
+	}
+
+#ifdef PCSX2_DEVBUILD
+	rc_client_enable_logging(new_client, RC_CLIENT_LOG_LEVEL_VERBOSE, ClientMessageCallback);
+#else
+	rc_client_enable_logging(new_client, RC_CLIENT_LOG_LEVEL_INFO, ClientMessageCallback);
+#endif
+
+	rc_client_set_userdata(new_client, http->get());
+
+	*client = new_client;
+	return true;
+}
+
+void Achievements::DestroyClient(rc_client_t** client, std::unique_ptr<Common::HTTPDownloader>* http)
+{
+	(*http)->WaitForAllRequests();
+
+	rc_client_destroy(*client);
+	*client = nullptr;
+
+	http->reset();
+}
+
+void Achievements::UpdateSettings(const Pcsx2Config::AchievementsOptions& old_config)
+{
+	if (IsUsingRAIntegration())
+		return;
+
+	if (!EmuConfig.Achievements.Enabled)
+	{
+		// we're done here
+		Shutdown(false);
 		return;
 	}
 
-	GetPatches(game_id);
+	if (!IsActive())
+	{
+		// we just got enabled
+		Initialize();
+		return;
+	}
+
+	if (EmuConfig.Achievements.HardcoreMode != old_config.HardcoreMode)
+	{
+		// Hardcore mode can only be enabled through reset (ResetChallengeMode()).
+		if (s_hardcore_mode && !EmuConfig.Achievements.HardcoreMode)
+		{
+			ResetHardcoreMode();
+		}
+		else if (!s_hardcore_mode && EmuConfig.Achievements.HardcoreMode)
+		{
+			if (HasActiveGame())
+				DisplayHardcoreDeferredMessage();
+		}
+	}
+
+	// These cannot be modified while a game is loaded, so just toss state and reload.
+	if (HasActiveGame())
+	{
+		if (EmuConfig.Achievements.EncoreMode != old_config.EncoreMode ||
+			EmuConfig.Achievements.SpectatorMode != old_config.SpectatorMode ||
+			EmuConfig.Achievements.UnofficialTestMode != old_config.UnofficialTestMode)
+		{
+			Shutdown(false);
+			Initialize();
+			return;
+		}
+	}
+	else
+	{
+		if (EmuConfig.Achievements.EncoreMode != old_config.EncoreMode)
+			rc_client_set_encore_mode_enabled(s_client, EmuConfig.Achievements.EncoreMode);
+		if (EmuConfig.Achievements.SpectatorMode != old_config.SpectatorMode)
+			rc_client_set_spectator_mode_enabled(s_client, EmuConfig.Achievements.SpectatorMode);
+		if (EmuConfig.Achievements.UnofficialTestMode != old_config.UnofficialTestMode)
+			rc_client_set_unofficial_enabled(s_client, EmuConfig.Achievements.UnofficialTestMode);
+	}
+
+	// in case cache directory changed
+	EnsureCacheDirectoriesExist();
+}
+
+
+bool Achievements::Shutdown(bool allow_cancel)
+{
+#ifdef ENABLE_RAINTEGRATION
+	if (IsUsingRAIntegration())
+	{
+		if (VMManager::HasValidVM() && allow_cancel && !RA_ConfirmLoadNewRom(true))
+			return false;
+
+		RA_SetPaused(false);
+		RA_ActivateGame(0);
+		return true;
+	}
+#endif
+
+	if (!IsActive())
+		return true;
+
+	auto lock = GetLock();
+	pxAssertRel(s_client && s_http_downloader, "Has client and downloader");
+
+	DisableHardcoreMode();
+	ClearGameInfo();
+	ClearGameHash();
+
+	if (s_login_request)
+	{
+		rc_client_abort_async(s_client, s_login_request);
+		s_login_request = nullptr;
+	}
+
+	s_hardcore_mode = false;
+	DestroyClient(&s_client, &s_http_downloader);
+	return true;
+}
+
+
+void Achievements::EnsureCacheDirectoriesExist()
+{
+	s_image_directory = Path::Combine(EmuFolders::Cache, "achievement_images");
+
+	if (!FileSystem::DirectoryExists(s_image_directory.c_str()) && !FileSystem::CreateDirectoryPath(s_image_directory.c_str(), false))
+	{
+		ReportFmtError("Failed to create cache directory '{}'", s_image_directory);
+	}
+}
+
+void Achievements::ClientMessageCallback(const char* message, const rc_client_t* client)
+{
+	Console.WriteLn("(Achievements) %s", message);
+}
+
+uint32_t Achievements::ClientReadMemory(uint32_t address, uint8_t* buffer, uint32_t num_bytes, rc_client_t* client)
+{
+	if ((static_cast<u64>(address) + num_bytes) >= EXPOSED_EE_MEMORY_SIZE)
+	{
+		DevCon.Warning("[Achievements] Ignoring out of bounds memory peek of %u bytes at %08X.", num_bytes, address);
+		return 0u;
+	}
+
+	// Fast paths for known data sizes.
+	const u8* ptr = reinterpret_cast<u8*>(eeMem) + address;
+	switch (num_bytes)
+	{
+		// clang-format off
+		case 1: std::memcpy(buffer, ptr, 1); break;
+		case 2: std::memcpy(buffer, ptr, 2); break;
+		case 4: std::memcpy(buffer, ptr, 4); break;
+		case 8: std::memcpy(buffer, ptr, 8); break;
+		default: std::memcpy(buffer, ptr, num_bytes); break;
+			// clang-format on
+	}
+
+	return num_bytes;
+}
+
+void Achievements::ClientServerCall(
+	const rc_api_request_t* request, rc_client_server_callback_t callback, void* callback_data, rc_client_t* client)
+{
+	Common::HTTPDownloader::Request::Callback hd_callback = [callback, callback_data](s32 status_code, std::string content_type,
+																Common::HTTPDownloader::Request::Data data) {
+		rc_api_server_response_t rr;
+		rr.http_status_code = status_code;
+		rr.body_length = data.size();
+		rr.body = reinterpret_cast<const char*>(data.data());
+
+		callback(&rr, callback_data);
+	};
+
+	Common::HTTPDownloader* http = static_cast<Common::HTTPDownloader*>(rc_client_get_userdata(client));
+
+	// TODO: Content-type for post
+	if (request->post_data)
+	{
+		// const auto pd = std::string_view(request->post_data);
+		// Console.WriteLn(fmt::format("Server POST: {}", pd.substr(0, std::min<size_t>(pd.length(), 10))).c_str());
+		http->CreatePostRequest(request->url, request->post_data, std::move(hd_callback));
+	}
+	else
+	{
+		http->CreateRequest(request->url, std::move(hd_callback));
+	}
+}
+
+
+void Achievements::IdleUpdate()
+{
+	if (!IsActive())
+		return;
+
+#ifdef ENABLE_RAINTEGRATION
+	if (IsUsingRAIntegration())
+		return;
+#endif
+
+	const auto lock = GetLock();
+
+	s_http_downloader->PollRequests();
+	rc_client_idle(s_client);
+}
+
+void Achievements::FrameUpdate()
+{
+	if (!IsActive())
+		return;
+
+#ifdef ENABLE_RAINTEGRATION
+	if (IsUsingRAIntegration())
+	{
+		RA_DoAchievementsFrame();
+		return;
+	}
+#endif
+
+	auto lock = GetLock();
+
+	s_http_downloader->PollRequests();
+
+	// Don't update the actual achievements until an ELF has loaded.
+	if (VMManager::Internal::HasBootedELF())
+		rc_client_do_frame(s_client);
+	else
+		rc_client_idle(s_client);
+
+	UpdateRichPresence(lock);
+}
+
+void Achievements::ClientEventHandler(const rc_client_event_t* event, rc_client_t* client)
+{
+	switch (event->type)
+	{
+		case RC_CLIENT_EVENT_RESET:
+			HandleResetEvent(event);
+			break;
+
+		case RC_CLIENT_EVENT_ACHIEVEMENT_TRIGGERED:
+			HandleUnlockEvent(event);
+			break;
+
+		case RC_CLIENT_EVENT_GAME_COMPLETED:
+			HandleGameCompleteEvent(event);
+			break;
+
+		case RC_CLIENT_EVENT_LEADERBOARD_STARTED:
+			HandleLeaderboardStartedEvent(event);
+			break;
+
+		case RC_CLIENT_EVENT_LEADERBOARD_FAILED:
+			HandleLeaderboardFailedEvent(event);
+			break;
+
+		case RC_CLIENT_EVENT_LEADERBOARD_SUBMITTED:
+			HandleLeaderboardSubmittedEvent(event);
+			break;
+
+		case RC_CLIENT_EVENT_LEADERBOARD_SCOREBOARD:
+			HandleLeaderboardScoreboardEvent(event);
+			break;
+
+		case RC_CLIENT_EVENT_LEADERBOARD_TRACKER_SHOW:
+			HandleLeaderboardTrackerShowEvent(event);
+			break;
+
+		case RC_CLIENT_EVENT_LEADERBOARD_TRACKER_HIDE:
+			HandleLeaderboardTrackerHideEvent(event);
+			break;
+
+		case RC_CLIENT_EVENT_LEADERBOARD_TRACKER_UPDATE:
+			HandleLeaderboardTrackerUpdateEvent(event);
+			break;
+
+		case RC_CLIENT_EVENT_ACHIEVEMENT_CHALLENGE_INDICATOR_SHOW:
+			HandleAchievementChallengeIndicatorShowEvent(event);
+			break;
+
+		case RC_CLIENT_EVENT_ACHIEVEMENT_CHALLENGE_INDICATOR_HIDE:
+			HandleAchievementChallengeIndicatorHideEvent(event);
+			break;
+
+		case RC_CLIENT_EVENT_ACHIEVEMENT_PROGRESS_INDICATOR_SHOW:
+			HandleAchievementProgressIndicatorShowEvent(event);
+			break;
+
+		case RC_CLIENT_EVENT_ACHIEVEMENT_PROGRESS_INDICATOR_HIDE:
+			HandleAchievementProgressIndicatorHideEvent(event);
+			break;
+
+		case RC_CLIENT_EVENT_ACHIEVEMENT_PROGRESS_INDICATOR_UPDATE:
+			HandleAchievementProgressIndicatorUpdateEvent(event);
+			break;
+
+		case RC_CLIENT_EVENT_SERVER_ERROR:
+			HandleServerErrorEvent(event);
+			break;
+
+		case RC_CLIENT_EVENT_DISCONNECTED:
+			HandleServerDisconnectedEvent(event);
+			break;
+
+		case RC_CLIENT_EVENT_RECONNECTED:
+			HandleServerReconnectedEvent(event);
+			break;
+
+		default:
+			Console.Error("Unhandled event: %u", event->type);
+			break;
+	}
+}
+
+void Achievements::UpdateGameSummary()
+{
+	rc_client_get_user_game_summary(s_client, &s_game_summary);
+}
+
+void Achievements::UpdateRichPresence(std::unique_lock<std::recursive_mutex>& lock)
+{
+	// Limit rich presence updates to once per second, since it could change per frame.
+	if (!s_has_rich_presence || !s_rich_presence_poll_time.ResetIfSecondsPassed(1.0))
+		return;
+
+	char buffer[512];
+	const size_t res = rc_client_get_rich_presence_message(s_client, buffer, std::size(buffer));
+	const std::string_view sv(buffer, res);
+	if (s_rich_presence_string == sv)
+		return;
+
+	s_rich_presence_string.assign(sv);
+
+	Console.WriteLn(Color_StrongGreen, fmt::format("Rich presence updated: {}", s_rich_presence_string));
+	Host::OnAchievementsRefreshed();
+
+	lock.unlock();
+	VMManager::UpdateDiscordPresence();
+	lock.lock();
 }
 
 void Achievements::GameChanged(u32 disc_crc, u32 crc)
 {
 	std::unique_lock lock(s_achievements_mutex);
-	if (!s_active)
+
+	if (!IsActive())
 		return;
 
+	IdentifyGame(disc_crc);
+}
+
+void Achievements::IdentifyGame(u32 disc_crc)
+{
 	// avoid reading+hashing the executable if the crc hasn't changed
-	if (s_last_disc_crc == disc_crc)
-	{
-		// but we might've just finished booting the game, in which case we need to activate.
-		if (crc != 0)
-			ActivateAchievementsAndLeaderboards();
-
+	if (s_game_disc_crc == disc_crc)
 		return;
-	}
 
-	std::string game_hash(GetGameHash());
+	std::string game_hash = GetGameHash();
 	if (s_game_hash == game_hash)
 		return;
 
-	if (!IsUsingRAIntegration() && s_http_downloader->HasAnyRequests())
-	{
-		bool was_running_idle;
-		BeginLoadingScreen("Downloading achievements data...", &was_running_idle);
-		s_http_downloader->WaitForAllRequests();
-		EndLoadingScreen(was_running_idle);
-	}
-
-	ClearGameInfo();
 	ClearGameHash();
-	s_last_disc_crc = disc_crc;
-	s_current_crc = crc;
+	s_game_disc_crc = disc_crc;
 	s_game_hash = std::move(game_hash);
 
 #ifdef ENABLE_RAINTEGRATION
@@ -1505,658 +857,2007 @@ void Achievements::GameChanged(u32 disc_crc, u32 crc)
 	}
 #endif
 
+	// shouldn't have a load game request when we're not logged in.
+	pxAssertRel(IsLoggedInOrLoggingIn() || !s_load_game_request, "Logged in with load game request");
+
+	// bail out if we're not logged in, just save the hash
+	if (!IsLoggedInOrLoggingIn())
+	{
+		Console.WriteLn(Color_StrongYellow, "(Achievements) Skipping load game because we're not logged in.");
+		DisableHardcoreMode();
+		return;
+	}
+
+	BeginLoadGame();
+}
+
+void Achievements::BeginLoadGame()
+{
+	// cancel previous requests
+	if (s_load_game_request)
+	{
+		rc_client_abort_async(s_client, s_load_game_request);
+		s_load_game_request = nullptr;
+	}
+
+	ClearGameInfo();
+
 	if (s_game_hash.empty())
 	{
 		// when we're booting the bios, or shutting down, this will fail
-		if (disc_crc != 0)
+		if (s_game_disc_crc != 0)
 		{
 			Host::AddKeyedOSDMessage("retroachievements_disc_read_failed",
 				TRANSLATE_STR("Achievements", "Failed to read executable from disc. Achievements disabled."),
 				Host::OSD_CRITICAL_ERROR_DURATION);
 		}
 
-		s_last_disc_crc = 0;
-		s_current_crc = crc;
+		DisableHardcoreMode();
 		return;
 	}
 
-	if (IsLoggedIn())
-		SendGetGameId();
-	else if (HasSavedCredentials())
-		LoginWithTokenAsync(s_username.c_str(), s_api_token.c_str());
+	s_load_game_request = rc_client_begin_load_game(s_client, s_game_hash.c_str(), ClientLoadGameCallback, nullptr);
 }
 
-void Achievements::SendGetGameId()
+void Achievements::ClientLoadGameCallback(int result, const char* error_message, rc_client_t* client, void* userdata)
 {
-	RAPIRequest<rc_api_resolve_hash_request_t, rc_api_init_resolve_hash_request> request;
-	request.username = s_username.c_str();
-	request.api_token = s_api_token.c_str();
-	request.game_hash = s_game_hash.c_str();
-	request.Send(GetGameIdCallback);
-}
+	s_load_game_request = nullptr;
 
-void Achievements::SendPlayingCallback(s32 status_code, const std::string& content_type, Common::HTTPDownloader::Request::Data data)
-{
-	if (!VMManager::HasValidVM())
-		return;
-
-	RAPIResponse<rc_api_start_session_response_t, rc_api_process_start_session_response, rc_api_destroy_start_session_response> response(
-		status_code, data);
-	if (!response)
-		return;
-
-	Console.WriteLn("Playing game updated to %u (%s)", s_game_id, s_game_title.c_str());
-}
-
-void Achievements::SendPlaying()
-{
-	if (!HasActiveGame())
-		return;
-
-	RAPIRequest<rc_api_start_session_request_t, rc_api_init_start_session_request> request;
-	request.username = s_username.c_str();
-	request.api_token = s_api_token.c_str();
-	request.game_id = s_game_id;
-	request.Send(SendPlayingCallback);
-}
-
-void Achievements::UpdateRichPresence()
-{
-	if (!s_has_rich_presence)
-		return;
-
-	char buffer[512];
-	const int res = rc_runtime_get_richpresence(&s_rcheevos_runtime, buffer, sizeof(buffer), PeekMemory, nullptr, nullptr);
-
-	std::unique_lock lock(s_achievements_mutex);
-	const bool had_rich_presence = !s_rich_presence_string.empty();
-	if (res <= 0)
+	if (result == RC_NO_GAME_LOADED)
 	{
-		if (!had_rich_presence)
-			return;
-
-		s_rich_presence_string.clear();
+		// Unknown game.
+		Console.WriteLn(Color_StrongYellow, "(Achievements) Unknown game '%s', disabling achievements.", s_game_hash.c_str());
+		DisableHardcoreMode();
+		return;
 	}
-	else
+	else if (result == RC_LOGIN_REQUIRED)
 	{
-		if (s_rich_presence_string == buffer)
-			return;
-
-		s_rich_presence_string.assign(buffer);
+		// We would've asked to re-authenticate, so leave HC on for now.
+		// Once we've done so, we'll reload the game.
+		return;
 	}
+	else if (result != RC_OK)
+	{
+		ReportFmtError("Loading game failed: {}", error_message);
+		DisableHardcoreMode();
+		return;
+	}
+
+	const rc_client_game_t* info = rc_client_get_game_info(s_client);
+	if (!info)
+	{
+		ReportError("rc_client_get_game_info() returned NULL");
+		DisableHardcoreMode();
+		return;
+	}
+
+	// We should have matched hardcore mode state.
+	pxAssertRel(s_hardcore_mode == (rc_client_get_hardcore_enabled(client) != 0), "Hardcore status mismatch");
+
+	s_game_id = info->id;
+	s_game_title = info->title;
+	s_has_achievements = rc_client_has_achievements(client);
+	s_has_leaderboards = rc_client_has_leaderboards(client);
+	s_has_rich_presence = rc_client_has_rich_presence(client);
+	s_game_icon = {};
+
+	// ensure fullscreen UI is ready for notifications
+	MTGS::RunOnGSThread(&ImGuiManager::InitializeFullscreenUI);
+
+	if (const std::string_view badge_name = info->badge_name; !badge_name.empty())
+	{
+		s_game_icon = Path::Combine(s_image_directory, fmt::format("game_{}.png", info->id));
+		if (!FileSystem::FileExists(s_game_icon.c_str()))
+		{
+			char buf[512];
+			if (int err = rc_client_game_get_image_url(info, buf, std::size(buf)); err == RC_OK)
+			{
+				DownloadImage(buf, s_game_icon);
+			}
+			else
+			{
+				ReportRCError(err, "rc_client_game_get_image_url() failed: ");
+			}
+		}
+	}
+
+	UpdateGameSummary();
+	DisplayAchievementSummary();
 
 	Host::OnAchievementsRefreshed();
-
-	if (EmuConfig.EnableDiscordPresence)
-		VMManager::UpdateDiscordPresence(s_rich_presence_string);
 }
 
-void Achievements::SendPingCallback(s32 status_code, const std::string& content_type, Common::HTTPDownloader::Request::Data data)
+void Achievements::ClearGameInfo()
 {
-	if (!VMManager::HasValidVM())
-		return;
+	if (MTGS::IsOpen())
+		MTGS::RunOnGSThread(&Achievements::ClearUIState);
 
-	RAPIResponse<rc_api_ping_response_t, rc_api_process_ping_response, rc_api_destroy_ping_response> response(status_code, data);
-}
-
-void Achievements::SendPing()
-{
-	if (!HasActiveGame())
-		return;
-
-	s_last_ping_time.Reset();
-
-	RAPIRequest<rc_api_ping_request_t, rc_api_init_ping_request> request;
-	request.api_token = s_api_token.c_str();
-	request.username = s_username.c_str();
-	request.game_id = s_game_id;
-	request.rich_presence = s_rich_presence_string.c_str();
-	request.Send(SendPingCallback);
-}
-
-const std::string& Achievements::GetGameTitle()
-{
-	return s_game_title;
-}
-
-const std::string& Achievements::GetGameIcon()
-{
-	return s_game_icon;
-}
-
-bool Achievements::EnumerateAchievements(std::function<bool(const Achievement&)> callback)
-{
-	for (const Achievement& cheevo : s_achievements)
+	if (s_load_game_request)
 	{
-		if (!callback(cheevo))
-			return false;
+		rc_client_abort_async(s_client, s_load_game_request);
+		s_load_game_request = nullptr;
 	}
+	rc_client_unload_game(s_client);
 
-	return true;
+	s_active_leaderboard_trackers = {};
+	s_active_challenge_indicators = {};
+	s_active_progress_indicator.reset();
+	s_game_id = 0;
+	s_game_title = {};
+	s_game_icon = {};
+	s_has_achievements = false;
+	s_has_leaderboards = false;
+	s_has_rich_presence = false;
+	s_rich_presence_string = {};
+	s_game_summary = {};
+
+	Host::OnAchievementsRefreshed();
 }
 
-u32 Achievements::GetUnlockedAchiementCount()
+void Achievements::ClearGameHash()
 {
-	u32 count = 0;
-	for (const Achievement& cheevo : s_achievements)
+	s_game_disc_crc = 0;
+	std::string().swap(s_game_hash);
+}
+
+void Achievements::DisplayAchievementSummary()
+{
+	if (EmuConfig.Achievements.Notifications)
 	{
-		if (!cheevo.locked)
-			count++;
-	}
+		std::string title;
+		if (IsHardcoreModeActive())
+			title = fmt::format(TRANSLATE_FS("Achievements", "{} (Hardcore Mode)"), s_game_title);
+		else
+			title = s_game_title;
 
-	return count;
-}
-
-u32 Achievements::GetAchievementCount()
-{
-	return static_cast<u32>(s_achievements.size());
-}
-
-u32 Achievements::GetMaximumPointsForGame()
-{
-	u32 points = 0;
-	for (const Achievement& cheevo : s_achievements)
-		points += cheevo.points;
-
-	return points;
-}
-
-u32 Achievements::GetCurrentPointsForGame()
-{
-	u32 points = 0;
-	for (const Achievement& cheevo : s_achievements)
-	{
-		if (!cheevo.locked)
-			points += cheevo.points;
-	}
-
-	return points;
-}
-
-bool Achievements::EnumerateLeaderboards(std::function<bool(const Leaderboard&)> callback)
-{
-	for (const Leaderboard& lboard : s_leaderboards)
-	{
-		if (!callback(lboard))
-			return false;
-	}
-
-	return true;
-}
-
-std::optional<bool> Achievements::TryEnumerateLeaderboardEntries(u32 id, std::function<bool(const LeaderboardEntry&)> callback)
-{
-	if (id == s_last_queried_lboard)
-	{
-		if (s_lboard_entries)
+		std::string summary;
+		if (s_game_summary.num_core_achievements > 0)
 		{
-			for (const LeaderboardEntry& entry : *s_lboard_entries)
+			summary = fmt::format(TRANSLATE_FS("Achievements", "You have earned {} of {} achievements, and {} of {} points."),
+				s_game_summary.num_unlocked_achievements, s_game_summary.num_core_achievements, s_game_summary.points_unlocked,
+				s_game_summary.points_core);
+		}
+		else
+		{
+			summary = TRANSLATE_STR("Achievements", "This game has no achievements.");
+		}
+
+		MTGS::RunOnGSThread([title = std::move(title), summary = std::move(summary), icon = s_game_icon]() {
+			if (ImGuiManager::InitializeFullscreenUI())
 			{
-				if (!callback(entry))
-					return false;
+				ImGuiFullscreen::AddNotification(
+					"achievement_summary", ACHIEVEMENT_SUMMARY_NOTIFICATION_TIME, std::move(title), std::move(summary), std::move(icon));
 			}
-			return true;
-		}
-	}
-	else
-	{
-		s_last_queried_lboard = id;
-		s_lboard_entries.reset();
-
-		// TODO: Add paging? For now, stick to defaults
-		RAPIRequest<rc_api_fetch_leaderboard_info_request_t, rc_api_init_fetch_leaderboard_info_request> request;
-		request.username = s_username.c_str();
-		request.leaderboard_id = id;
-		request.first_entry = 0;
-
-		// Just over what a single page can store, should be a reasonable amount for now
-		request.count = 15;
-
-		request.Send(GetLbInfoCallback);
+		});
 	}
 
-	return std::nullopt;
+	// Technically not going through the resource API, but since we're passing this to something else, we can't.
+	if (EmuConfig.Achievements.SoundEffects)
+		Common::PlaySoundAsync(Path::Combine(EmuFolders::Resources, INFO_SOUND_NAME).c_str());
 }
 
-const Achievements::Leaderboard* Achievements::GetLeaderboardByID(u32 id)
+void Achievements::DisplayHardcoreDeferredMessage()
 {
-	for (const Leaderboard& lb : s_leaderboards)
-	{
-		if (lb.id == id)
-			return &lb;
-	}
-
-	return nullptr;
-}
-
-u32 Achievements::GetLeaderboardCount()
-{
-	return static_cast<u32>(s_leaderboards.size());
-}
-
-bool Achievements::IsLeaderboardTimeType(const Leaderboard& leaderboard)
-{
-	return leaderboard.format != RC_FORMAT_SCORE && leaderboard.format != RC_FORMAT_VALUE;
-}
-
-bool Achievements::IsMastered()
-{
-	for (const Achievement& cheevo : s_achievements)
-	{
-		if (cheevo.locked)
-			return false;
-	}
-
-	return true;
-}
-
-void Achievements::ActivateAchievementsAndLeaderboards()
-{
-	if (!VMManager::Internal::HasBootedELF())
-	{
-		Console.Warning("Deferring achievement activate until ELF has booted.");
-		return;
-	}
-
-	for (Achievement& cheevo : s_achievements)
-	{
-		if (cheevo.active || !cheevo.locked)
-			continue;
-
-		const int err =
-			rc_runtime_activate_achievement(&s_rcheevos_runtime, cheevo.id, cheevo.memaddr.c_str(), nullptr, 0);
-		if (err != RC_OK)
+	MTGS::RunOnGSThread([]() {
+		if (VMManager::HasValidVM() && EmuConfig.Achievements.HardcoreMode && !s_hardcore_mode &&
+			ImGuiManager::InitializeFullscreenUI())
 		{
-			Console.Error("Achievement %u memaddr parse error: %s", cheevo.id, rc_error_str(err));
-			continue;
+			ImGuiFullscreen::ShowToast(
+				std::string(), TRANSLATE_STR("Achievements", "Hardcore mode will be enabled on system reset."),
+				Host::OSD_WARNING_DURATION);
 		}
-
-		DevCon.WriteLn("Activated achievement %s (%u)", cheevo.title.c_str(), cheevo.id);
-		cheevo.active = true;
-	}
-
-	for (Leaderboard& lb : s_leaderboards)
-	{
-		// Always track the leaderboard, if we don't have leaderboards enabled we just won't submit it.
-		// That way if someone activates them later on, current progress will count.
-		if (lb.active)
-			continue;
-
-		const int err = rc_runtime_activate_lboard(&s_rcheevos_runtime, lb.id, lb.memaddr.c_str(), nullptr, 0);
-		if (err != RC_OK)
-		{
-			Console.Error("Leaderboard %u memaddr parse error: %s", lb.id, rc_error_str(err));
-			continue;
-		}
-
-		DevCon.WriteLn("Activated leaderboard %s (%u)", lb.title.c_str(), lb.id);
-		lb.active = true;
-	}
-}
-
-void Achievements::DeactivateAchievement(Achievement* achievement)
-{
-	if (!achievement->active)
-		return;
-
-	rc_runtime_deactivate_achievement(&s_rcheevos_runtime, achievement->id);
-	achievement->active = false;
-
-	if (achievement->primed)
-	{
-		achievement->primed = false;
-		s_primed_achievement_count.fetch_sub(1, std::memory_order_acq_rel);
-	}
-
-	DevCon.WriteLn("Deactivated achievement %s (%u)", achievement->title.c_str(), achievement->id);
-}
-
-void Achievements::UnlockAchievementCallback(s32 status_code, const std::string& content_type, Common::HTTPDownloader::Request::Data data)
-{
-	if (!VMManager::HasValidVM())
-		return;
-
-	RAPIResponse<rc_api_award_achievement_response_t, rc_api_process_award_achievement_response, rc_api_destroy_award_achievement_response>
-		response(status_code, data);
-	if (!response)
-		return;
-
-	Console.WriteLn("Successfully unlocked achievement %u, new score %u", response.awarded_achievement_id, response.new_player_score);
-}
-
-void Achievements::SubmitLeaderboardCallback(s32 status_code, const std::string& content_type, Common::HTTPDownloader::Request::Data data, u32 lboard_id)
-{
-	if (!VMManager::HasValidVM())
-		return;
-
-	RAPIResponse<rc_api_submit_lboard_entry_response_t, rc_api_process_submit_lboard_entry_response,
-		rc_api_destroy_submit_lboard_entry_response>
-		response(status_code, data);
-	if (!response)
-		return;
-
-	// Force the next leaderboard query to repopulate everything, just in case the user wants to see their new score
-	s_last_queried_lboard = 0;
-
-	const Leaderboard* lb = GetLeaderboardByID(lboard_id);
-	if (!lb || !FullscreenUI::IsInitialized() || !EmuConfig.Achievements.Notifications)
-		return;
-
-	char submitted_score[128];
-	char best_score[128];
-	rc_runtime_format_lboard_value(submitted_score, sizeof(submitted_score), response.submitted_score, lb->format);
-	rc_runtime_format_lboard_value(best_score, sizeof(best_score), response.best_score, lb->format);
-
-	std::string summary = fmt::format(
-		"Your Score: {} (Best: {})\nLeaderboard Position: {} of {}", submitted_score, best_score, response.new_rank, response.num_entries);
-
-	MTGS::RunOnGSThread([duration = GetNotificationsDuration(), title = lb->title, summary = std::move(summary), icon = s_game_icon]() {
-		if (FullscreenUI::IsInitialized())
-			ImGuiFullscreen::AddNotification(duration, std::move(title), std::move(summary), std::move(icon));
 	});
 }
 
-void Achievements::UnlockAchievement(u32 achievement_id, bool add_notification /* = true*/)
+void Achievements::HandleResetEvent(const rc_client_event_t* event)
 {
-	std::unique_lock lock(s_achievements_mutex);
-	Achievement* achievement = GetMutableAchievementByID(achievement_id);
-	if (!achievement)
-	{
-		Console.Error("Attempting to unlock unknown achievement %u", achievement_id);
-		return;
-	}
-	else if (!achievement->locked)
-	{
-		Console.Warning("Achievement %u for game %u is already unlocked", achievement_id, s_game_id);
-		return;
-	}
+	// We handle system resets ourselves, but still need to reset the client's state.
+	Console.WriteLn("Resetting runtime due to reset event");
+	rc_client_reset(s_client);
 
-	achievement->locked = false;
-	DeactivateAchievement(achievement);
+	if (HasActiveGame())
+		UpdateGameSummary();
+}
 
-	Console.WriteLn("Achievement %s (%u) for game %u unlocked", achievement->title.c_str(), achievement_id, s_game_id);
+void Achievements::HandleUnlockEvent(const rc_client_event_t* event)
+{
+	const rc_client_achievement_t* cheevo = event->achievement;
+	pxAssert(cheevo);
+
+	Console.WriteLn("(Achievements) Achievement %s (%u) for game %u unlocked", cheevo->title, cheevo->id, s_game_id);
+	UpdateGameSummary();
 
 	if (EmuConfig.Achievements.Notifications)
 	{
 		std::string title;
-		switch (achievement->category)
-		{
-			case AchievementCategory::Local:
-				title = fmt::format("{} (Local)", achievement->title);
-				break;
-			case AchievementCategory::Unofficial:
-				title = fmt::format("{} (Unofficial)", achievement->title);
-				break;
-			case AchievementCategory::Core:
-			default:
-				title = achievement->title;
-				break;
-		}
+		if (cheevo->category == RC_CLIENT_ACHIEVEMENT_CATEGORY_UNOFFICIAL)
+			title = fmt::format(TRANSLATE_FS("Achievements", "{} (Unofficial)"), cheevo->title);
+		else
+			title = cheevo->title;
+
+		std::string badge_path = GetAchievementBadgePath(cheevo, cheevo->state);
 
 		MTGS::RunOnGSThread(
-			[duration = GetNotificationsDuration(), title = std::move(title), description = achievement->description, icon = GetAchievementBadgePath(*achievement)]() {
-				ImGuiFullscreen::AddNotification(duration, std::move(title), std::move(description), std::move(icon));
+			[title = std::move(title), summary = std::string(cheevo->description), badge_path = std::move(badge_path), id = cheevo->id]() {
+				ImGuiFullscreen::AddNotification(fmt::format("achievement_unlock_{}", id), EmuConfig.Achievements.NotificationsDuration,
+					std::move(title), std::move(summary), std::move(badge_path));
 			});
 	}
 
 	if (EmuConfig.Achievements.SoundEffects)
 		Common::PlaySoundAsync(Path::Combine(EmuFolders::Resources, UNLOCK_SOUND_NAME).c_str());
-
-	if (IsMastered())
-		DisplayMasteredNotification();
-
-	if (IsTestModeActive())
-	{
-		Console.Warning("Skipping sending achievement %u unlock to server because of test mode.", achievement_id);
-		return;
-	}
-
-	if (achievement->category != AchievementCategory::Core)
-	{
-		Console.Warning("Skipping sending achievement %u unlock to server because it's not from the core set.", achievement_id);
-		return;
-	}
-
-	RAPIRequest<rc_api_award_achievement_request_t, rc_api_init_award_achievement_request> request;
-	request.username = s_username.c_str();
-	request.api_token = s_api_token.c_str();
-	request.game_hash = s_game_hash.c_str();
-	request.achievement_id = achievement_id;
-	request.hardcore = static_cast<int>(ChallengeModeActive());
-	request.Send(UnlockAchievementCallback);
 }
 
-void Achievements::AchievementPrimed(u32 achievement_id)
+void Achievements::HandleGameCompleteEvent(const rc_client_event_t* event)
 {
-	std::unique_lock lock(s_achievements_mutex);
-	Achievement* achievement = GetMutableAchievementByID(achievement_id);
-	if (!achievement || achievement->primed)
-		return;
+	Console.WriteLn("(Achievements) Game %u complete", s_game_id);
+	UpdateGameSummary();
 
-	achievement->primed = true;
-	s_primed_achievement_count.fetch_add(1, std::memory_order_acq_rel);
+	if (EmuConfig.Achievements.Notifications)
+	{
+		std::string title = fmt::format(TRANSLATE_FS("Achievements", "Mastered {}"), s_game_title);
+		std::string message = fmt::format(TRANSLATE_FS("Achievements", "{} achievements, {} points"),
+			s_game_summary.num_unlocked_achievements, s_game_summary.points_unlocked);
+
+		MTGS::RunOnGSThread([title = std::move(title), message = std::move(message), icon = s_game_icon]() {
+			if (ImGuiManager::InitializeFullscreenUI())
+			{
+				ImGuiFullscreen::AddNotification(
+					"achievement_mastery", GAME_COMPLETE_NOTIFICATION_TIME, std::move(title), std::move(message), std::move(icon));
+			}
+		});
+	}
 }
 
-void Achievements::AchievementUnprimed(u32 achievement_id)
+void Achievements::HandleLeaderboardStartedEvent(const rc_client_event_t* event)
 {
-	std::unique_lock lock(s_achievements_mutex);
-	Achievement* achievement = GetMutableAchievementByID(achievement_id);
-	if (!achievement || !achievement->primed)
-		return;
+	DevCon.WriteLn("(Achievements) Leaderboard %u (%s) started", event->leaderboard->id, event->leaderboard->title);
 
-	achievement->primed = false;
-	s_primed_achievement_count.fetch_sub(1, std::memory_order_acq_rel);
+	if (EmuConfig.Achievements.LeaderboardNotifications)
+	{
+		std::string title = event->leaderboard->title;
+		std::string message = TRANSLATE_STR("Achievements", "Leaderboard attempt started.");
+
+		MTGS::RunOnGSThread([title = std::move(title), message = std::move(message), icon = s_game_icon, id = event->leaderboard->id]() {
+			if (ImGuiManager::InitializeFullscreenUI())
+			{
+				ImGuiFullscreen::AddNotification(fmt::format("leaderboard_{}", id), LEADERBOARD_STARTED_NOTIFICATION_TIME, std::move(title),
+					std::move(message), std::move(icon));
+			}
+		});
+	}
 }
 
-void Achievements::SubmitLeaderboard(u32 leaderboard_id, int value)
+void Achievements::HandleLeaderboardFailedEvent(const rc_client_event_t* event)
 {
-	if (IsTestModeActive())
+	DevCon.WriteLn("(Achievements) Leaderboard %u (%s) failed", event->leaderboard->id, event->leaderboard->title);
+
+	if (EmuConfig.Achievements.LeaderboardNotifications)
 	{
-		Console.Warning("Skipping sending leaderboard %u result to server because of test mode.", leaderboard_id);
-		return;
+		std::string title = event->leaderboard->title;
+		std::string message = TRANSLATE_STR("Achievements", "Leaderboard attempt failed.");
+
+		MTGS::RunOnGSThread([title = std::move(title), message = std::move(message), icon = s_game_icon, id = event->leaderboard->id]() {
+			if (ImGuiManager::InitializeFullscreenUI())
+			{
+				ImGuiFullscreen::AddNotification(fmt::format("leaderboard_{}", id), LEADERBOARD_FAILED_NOTIFICATION_TIME, std::move(title),
+					std::move(message), std::move(icon));
+			}
+		});
+	}
+}
+
+void Achievements::HandleLeaderboardSubmittedEvent(const rc_client_event_t* event)
+{
+	Console.WriteLn("(Achievements) Leaderboard %u (%s) submitted", event->leaderboard->id, event->leaderboard->title);
+
+	if (EmuConfig.Achievements.LeaderboardNotifications)
+	{
+		static const char* value_strings[NUM_RC_CLIENT_LEADERBOARD_FORMATS] = {
+			TRANSLATE_NOOP("Achievements", "Your Time: {}{}"),
+			TRANSLATE_NOOP("Achievements", "Your Score: {}{}"),
+			TRANSLATE_NOOP("Achievements", "Your Value: {}{}"),
+		};
+
+		std::string title = event->leaderboard->title;
+		std::string message =
+			fmt::format(fmt::runtime(Host::TranslateToStringView("Achievements",
+							value_strings[std::min<u8>(event->leaderboard->format, NUM_RC_CLIENT_LEADERBOARD_FORMATS - 1)])),
+				event->leaderboard->tracker_value ? event->leaderboard->tracker_value : "Unknown",
+				EmuConfig.Achievements.SpectatorMode ? std::string_view() : TRANSLATE_SV("Achievements", " (Submitting)"));
+
+		MTGS::RunOnGSThread([title = std::move(title), message = std::move(message), icon = s_game_icon, id = event->leaderboard->id]() {
+			if (ImGuiManager::InitializeFullscreenUI())
+			{
+				ImGuiFullscreen::AddNotification(fmt::format("leaderboard_{}", id), EmuConfig.Achievements.LeaderboardsDuration,
+					std::move(title), std::move(message), std::move(icon));
+			}
+		});
 	}
 
-	if (!ChallengeModeActive())
-	{
-		Console.Warning("Skipping sending leaderboard %u result to server because Challenge mode is off.", leaderboard_id);
-		return;
-	}
-
-	if (!LeaderboardsActive())
-	{
-		Console.Warning("Skipping sending leaderboard %u result to server because leaderboards are disabled.", leaderboard_id);
-		return;
-	}
-
-	RAPIRequest<rc_api_submit_lboard_entry_request_t, rc_api_init_submit_lboard_entry_request> request;
-	request.username = s_username.c_str();
-	request.api_token = s_api_token.c_str();
-	request.game_hash = s_game_hash.c_str();
-	request.leaderboard_id = leaderboard_id;
-	request.score = value;
-	request.Send([leaderboard_id](s32 status_code, const std::string& content_type, Common::HTTPDownloader::Request::Data data) {
-		SubmitLeaderboardCallback(status_code, content_type, std::move(data), leaderboard_id);
-	});
-
-	// Technically not going through the resource API, but since we're passing this to something else, we can't.
 	if (EmuConfig.Achievements.SoundEffects)
 		Common::PlaySoundAsync(Path::Combine(EmuFolders::Resources, LBSUBMIT_SOUND_NAME).c_str());
 }
 
-std::pair<u32, u32> Achievements::GetAchievementProgress(const Achievement& achievement)
+void Achievements::HandleLeaderboardScoreboardEvent(const rc_client_event_t* event)
 {
-	std::pair<u32, u32> result;
-	rc_runtime_get_achievement_measured(&s_rcheevos_runtime, achievement.id, &result.first, &result.second);
-	return result;
-}
+	Console.WriteLn("(Achievements) Leaderboard %u scoreboard rank %u of %u", event->leaderboard_scoreboard->leaderboard_id,
+		event->leaderboard_scoreboard->new_rank, event->leaderboard_scoreboard->num_entries);
 
-std::string Achievements::GetAchievementProgressText(const Achievement& achievement)
-{
-	char buf[256];
-	rc_runtime_format_achievement_measured(&s_rcheevos_runtime, achievement.id, buf, std::size(buf));
-	return buf;
-}
-
-const std::string& Achievements::GetAchievementBadgePath(const Achievement& achievement, bool download_if_missing, bool force_unlocked_icon)
-{
-	const bool use_locked = (achievement.locked && !force_unlocked_icon);
-	std::string& badge_path = use_locked ? achievement.locked_badge_path : achievement.unlocked_badge_path;
-	if (!badge_path.empty() || achievement.badge_name.empty())
-		return badge_path;
-
-	// well, this comes from the internet.... :)
-	std::string clean_name(Path::SanitizeFileName(achievement.badge_name));
-	badge_path = Path::Combine(s_achievement_icon_cache_directory, fmt::format("{}{}.png", clean_name, use_locked ? "_lock" : ""));
-	if (FileSystem::FileExists(badge_path.c_str()))
-		return badge_path;
-
-	// need to download it
-	if (download_if_missing)
+	if (EmuConfig.Achievements.LeaderboardNotifications)
 	{
-		RAPIRequest<rc_api_fetch_image_request_t, rc_api_init_fetch_image_request> request;
-		request.image_name = achievement.badge_name.c_str();
-		request.image_type = use_locked ? RC_IMAGE_TYPE_ACHIEVEMENT_LOCKED : RC_IMAGE_TYPE_ACHIEVEMENT;
-		request.DownloadImage(badge_path);
-	}
+		static const char* value_strings[NUM_RC_CLIENT_LEADERBOARD_FORMATS] = {
+			TRANSLATE_NOOP("Achievements", "Your Time: {} (Best: {})"),
+			TRANSLATE_NOOP("Achievements", "Your Score: {} (Best: {})"),
+			TRANSLATE_NOOP("Achievements", "Your Value: {} (Best: {})"),
+		};
 
-	return badge_path;
-}
+		std::string title = event->leaderboard->title;
+		std::string message = fmt::format(TRANSLATE_FS("Achievements", "{}\nLeaderboard Position: {} of {}"),
+			fmt::format(fmt::runtime(Host::TranslateToStringView("Achievements",
+							value_strings[std::min<u8>(event->leaderboard->format, NUM_RC_CLIENT_LEADERBOARD_FORMATS - 1)])),
+				event->leaderboard_scoreboard->submitted_score, event->leaderboard_scoreboard->best_score),
+			event->leaderboard_scoreboard->new_rank, event->leaderboard_scoreboard->num_entries);
 
-std::string Achievements::GetAchievementBadgeURL(const Achievement& achievement)
-{
-	RAPIRequest<rc_api_fetch_image_request_t, rc_api_init_fetch_image_request> request;
-	request.image_name = achievement.badge_name.c_str();
-	request.image_type = achievement.locked ? RC_IMAGE_TYPE_ACHIEVEMENT_LOCKED : RC_IMAGE_TYPE_ACHIEVEMENT;
-	return request.GetURL();
-}
-
-u32 Achievements::GetPrimedAchievementCount()
-{
-	// Relaxed is fine here, worst that happens is we draw the triggers one frame late.
-	return s_primed_achievement_count.load(std::memory_order_relaxed);
-}
-
-void Achievements::CheevosEventHandler(const rc_runtime_event_t* runtime_event)
-{
-	static const char* events[] = {"RC_RUNTIME_EVENT_ACHIEVEMENT_ACTIVATED", "RC_RUNTIME_EVENT_ACHIEVEMENT_PAUSED",
-		"RC_RUNTIME_EVENT_ACHIEVEMENT_RESET", "RC_RUNTIME_EVENT_ACHIEVEMENT_TRIGGERED", "RC_RUNTIME_EVENT_ACHIEVEMENT_PRIMED",
-		"RC_RUNTIME_EVENT_LBOARD_STARTED", "RC_RUNTIME_EVENT_LBOARD_CANCELED", "RC_RUNTIME_EVENT_LBOARD_UPDATED",
-		"RC_RUNTIME_EVENT_LBOARD_TRIGGERED", "RC_RUNTIME_EVENT_ACHIEVEMENT_DISABLED", "RC_RUNTIME_EVENT_LBOARD_DISABLED"};
-	const char* event_text = ((unsigned)runtime_event->type >= std::size(events)) ? "unknown" : events[(unsigned)runtime_event->type];
-	DevCon.WriteLn("Cheevos Event %s for %u", event_text, runtime_event->id);
-
-	switch (runtime_event->type)
-	{
-		case RC_RUNTIME_EVENT_ACHIEVEMENT_TRIGGERED:
-			UnlockAchievement(runtime_event->id);
-			break;
-
-		case RC_RUNTIME_EVENT_ACHIEVEMENT_PRIMED:
-			AchievementPrimed(runtime_event->id);
-			break;
-
-		case RC_RUNTIME_EVENT_ACHIEVEMENT_UNPRIMED:
-			AchievementUnprimed(runtime_event->id);
-			break;
-
-		case RC_RUNTIME_EVENT_LBOARD_TRIGGERED:
-			SubmitLeaderboard(runtime_event->id, runtime_event->value);
-			break;
-
-		default:
-			break;
+		MTGS::RunOnGSThread([title = std::move(title), message = std::move(message), icon = s_game_icon, id = event->leaderboard->id]() {
+			if (ImGuiManager::InitializeFullscreenUI())
+			{
+				ImGuiFullscreen::AddNotification(fmt::format("leaderboard_{}", id), EmuConfig.Achievements.LeaderboardsDuration,
+					std::move(title), std::move(message), std::move(icon));
+			}
+		});
 	}
 }
 
-unsigned Achievements::PeekMemory(unsigned address, unsigned num_bytes, void* ud)
+void Achievements::HandleLeaderboardTrackerShowEvent(const rc_client_event_t* event)
 {
-	if ((static_cast<u64>(address) + num_bytes) >= EXPOSED_EE_MEMORY_SIZE)
-	{
-		DevCon.Warning("[Achievements] Ignoring out of bounds memory peek of %u bytes at %08X.", num_bytes, address);
-		return 0u;
-	}
+	DevCon.WriteLn(
+		"(Achievements) Showing leaderboard tracker: %u: %s", event->leaderboard_tracker->id, event->leaderboard_tracker->display);
 
-	switch (num_bytes)
-	{
-		case 1:
-		{
-			u8 value;
-			std::memcpy(&value, reinterpret_cast<u8*>(eeMem) + address, sizeof(value));
-			return static_cast<unsigned>(value);
-		}
+	TinyString width_string;
+	width_string.append(ICON_FA_STOPWATCH);
+	const u32 display_len = static_cast<u32>(std::strlen(event->leaderboard_tracker->display));
+	for (u32 i = 0; i < display_len; i++)
+		width_string.append('0');
 
-		case 2:
-		{
-			u16 value;
-			std::memcpy(&value, reinterpret_cast<u8*>(eeMem) + address, sizeof(value));
-			return static_cast<unsigned>(value);
-		}
-
-		case 4:
-		{
-			u32 value;
-			std::memcpy(&value, reinterpret_cast<u8*>(eeMem) + address, sizeof(value));
-			return static_cast<unsigned>(value);
-		}
-
-		default:
-			return 0u;
-	}
+	LeaderboardTrackerIndicator indicator;
+	indicator.tracker_id = event->leaderboard_tracker->id;
+	indicator.size = ImGuiFullscreen::g_medium_font->CalcTextSizeA(
+		ImGuiFullscreen::g_medium_font->FontSize, FLT_MAX, 0.0f, width_string.c_str(), width_string.end_ptr());
+	indicator.text = fmt::format(ICON_FA_STOPWATCH " {}", event->leaderboard_tracker->display);
+	indicator.active = true;
+	s_active_leaderboard_trackers.push_back(std::move(indicator));
 }
 
-unsigned Achievements::PeekMemoryBlock(unsigned address, unsigned char* buffer, unsigned num_bytes)
+void Achievements::HandleLeaderboardTrackerHideEvent(const rc_client_event_t* event)
 {
-	if ((address >= EXPOSED_EE_MEMORY_SIZE))
-	{
-		DevCon.Warning("[Achievements] Ignoring out of bounds block memory read for %u bytes at %08X.", num_bytes, address);
-		return 0u;
-	}
+	const u32 id = event->leaderboard_tracker->id;
+	auto it = std::find_if(
+		s_active_leaderboard_trackers.begin(), s_active_leaderboard_trackers.end(), [id](const auto& it) { return it.tracker_id == id; });
+	if (it == s_active_leaderboard_trackers.end())
+		return;
 
-	const unsigned read_byte_count = std::min<unsigned>(EXPOSED_EE_MEMORY_SIZE - address, num_bytes);
-	std::memcpy(buffer, reinterpret_cast<u8*>(eeMem) + address, read_byte_count);
-	return read_byte_count;
+	DevCon.WriteLn("(Achievements) Hiding leaderboard tracker: %u", id);
+	it->active = false;
+	it->show_hide_time.Reset();
 }
 
-void Achievements::PokeMemory(unsigned address, unsigned num_bytes, void* ud, unsigned value)
+void Achievements::HandleLeaderboardTrackerUpdateEvent(const rc_client_event_t* event)
 {
-	if ((static_cast<u64>(address) + num_bytes) >= EXPOSED_EE_MEMORY_SIZE)
+	const u32 id = event->leaderboard_tracker->id;
+	auto it = std::find_if(
+		s_active_leaderboard_trackers.begin(), s_active_leaderboard_trackers.end(), [id](const auto& it) { return it.tracker_id == id; });
+	if (it == s_active_leaderboard_trackers.end())
+		return;
+
+	DevCon.WriteLn(
+		"(Achievements) Updating leaderboard tracker: %u: %s", event->leaderboard_tracker->id, event->leaderboard_tracker->display);
+
+	it->text.clear();
+	fmt::format_to(std::back_inserter(it->text), ICON_FA_STOPWATCH " {}", event->leaderboard_tracker->display);
+	it->active = true;
+}
+
+void Achievements::HandleAchievementChallengeIndicatorShowEvent(const rc_client_event_t* event)
+{
+	if (auto it = std::find_if(s_active_challenge_indicators.begin(), s_active_challenge_indicators.end(),
+			[event](const AchievementChallengeIndicator& it) { return it.achievement == event->achievement; });
+		it != s_active_challenge_indicators.end())
 	{
-		DevCon.Warning("[Achievements] Ignoring out of bounds memory poke of %u bytes at %08X (value %08X).", num_bytes, address, value);
+		it->show_hide_time.Reset();
+		it->active = true;
 		return;
 	}
 
-	switch (num_bytes)
-	{
-		case 1:
-		{
-			const u8 value8 = static_cast<u8>(value);
-			std::memcpy(reinterpret_cast<u8*>(eeMem) + address, &value8, sizeof(value8));
-		}
-		break;
+	AchievementChallengeIndicator indicator;
+	indicator.achievement = event->achievement;
+	indicator.badge_path = GetAchievementBadgePath(event->achievement, RC_CLIENT_ACHIEVEMENT_STATE_UNLOCKED);
+	indicator.active = true;
+	s_active_challenge_indicators.push_back(std::move(indicator));
 
-		case 2:
-		{
-			const u16 value16 = static_cast<u16>(value);
-			std::memcpy(reinterpret_cast<u8*>(eeMem) + address, &value16, sizeof(value16));
-		}
-		break;
+	DevCon.WriteLn("(Achievements) Show challenge indicator for %u (%s)", event->achievement->id, event->achievement->title);
+}
 
-		case 4:
-		{
-			const u32 value32 = static_cast<u32>(value);
-			std::memcpy(reinterpret_cast<u8*>(eeMem) + address, &value32, sizeof(value32));
-		}
-		break;
+void Achievements::HandleAchievementChallengeIndicatorHideEvent(const rc_client_event_t* event)
+{
+	auto it = std::find_if(s_active_challenge_indicators.begin(), s_active_challenge_indicators.end(),
+		[event](const AchievementChallengeIndicator& it) { return it.achievement == event->achievement; });
+	if (it == s_active_challenge_indicators.end())
+		return;
 
-		default:
-			break;
-	}
+	DevCon.WriteLn("(Achievements) Hide challenge indicator for %u (%s)", event->achievement->id, event->achievement->title);
+	it->show_hide_time.Reset();
+	it->active = false;
+}
+
+void Achievements::HandleAchievementProgressIndicatorShowEvent(const rc_client_event_t* event)
+{
+	DevCon.WriteLn("(Achievements) Showing progress indicator: %u (%s): %s", event->achievement->id, event->achievement->title,
+		event->achievement->measured_progress);
+
+	if (!s_active_progress_indicator.has_value())
+		s_active_progress_indicator.emplace();
+	else
+		s_active_progress_indicator->show_hide_time.Reset();
+
+	s_active_progress_indicator->achievement = event->achievement;
+	s_active_progress_indicator->badge_path = GetAchievementBadgePath(event->achievement, RC_CLIENT_ACHIEVEMENT_STATE_UNLOCKED);
+	s_active_progress_indicator->active = true;
+}
+
+void Achievements::HandleAchievementProgressIndicatorHideEvent(const rc_client_event_t* event)
+{
+	if (!s_active_progress_indicator.has_value())
+		return;
+
+	DevCon.WriteLn("(Achievements) Hiding progress indicator");
+	s_active_progress_indicator->show_hide_time.Reset();
+	s_active_progress_indicator->active = false;
+}
+
+void Achievements::HandleAchievementProgressIndicatorUpdateEvent(const rc_client_event_t* event)
+{
+	DevCon.WriteLn("(Achievements) Updating progress indicator: %u (%s): %s", event->achievement->id, event->achievement->title,
+		event->achievement->measured_progress);
+	s_active_progress_indicator->achievement = event->achievement;
+	s_active_progress_indicator->active = true;
+}
+
+void Achievements::HandleServerErrorEvent(const rc_client_event_t* event)
+{
+	std::string message = fmt::format(TRANSLATE_FS("Achievements", "Server error in {}:\n{}"),
+		event->server_error->api ? event->server_error->api : "UNKNOWN",
+		event->server_error->error_message ? event->server_error->error_message : "UNKNOWN");
+	Console.Error("(Achievements) %s", message.c_str());
+	Host::AddOSDMessage(std::move(message), Host::OSD_ERROR_DURATION);
+}
+
+void Achievements::HandleServerDisconnectedEvent(const rc_client_event_t* event)
+{
+	Console.Warning("(Achievements) Server disconnected.");
+
+	MTGS::RunOnGSThread([]() {
+		if (ImGuiManager::InitializeFullscreenUI())
+		{
+			ImGuiFullscreen::ShowToast(TRANSLATE_STR("Achievements", "Achievements Disconnected"),
+				TRANSLATE_STR("Achievements", "An unlock request could not be completed. We will keep retrying to submit this request."),
+				Host::OSD_ERROR_DURATION);
+		}
+	});
+}
+
+void Achievements::HandleServerReconnectedEvent(const rc_client_event_t* event)
+{
+	Console.Warning("(Achievements) Server reconnected.");
+
+	MTGS::RunOnGSThread([]() {
+		if (ImGuiManager::InitializeFullscreenUI())
+		{
+			ImGuiFullscreen::ShowToast(TRANSLATE_STR("Achievements", "Achievements Reconnected"),
+				TRANSLATE_STR("Achievements", "All pending unlock requests have completed."), Host::OSD_INFO_DURATION);
+		}
+	});
 }
 
 
-s32 Achievements::GetNotificationsDuration()
+void Achievements::ResetClient()
 {
-	return EmuConfig.Achievements.NotificationsDuration;
+#ifdef ENABLE_RAINTEGRATION
+	if (IsUsingRAIntegration())
+	{
+		RA_OnReset();
+		return;
+	}
+#endif
+
+	if (!IsActive())
+		return;
+
+	Console.WriteLn("(Achievements) Reset client");
+	rc_client_reset(s_client);
+}
+
+void Achievements::OnVMPaused(bool paused)
+{
+#ifdef ENABLE_RAINTEGRATION
+	if (IsUsingRAIntegration())
+		RA_SetPaused(paused);
+#endif
+}
+
+void Achievements::DisableHardcoreMode()
+{
+	if (!IsActive())
+		return;
+
+#ifdef ENABLE_RAINTEGRATION
+	if (IsUsingRAIntegration())
+	{
+		if (RA_HardcoreModeIsActive())
+			RA_DisableHardcore();
+
+		return;
+	}
+#endif
+
+	if (s_hardcore_mode)
+		SetHardcoreMode(false, true);
+}
+
+bool Achievements::ResetHardcoreMode()
+{
+	if (!IsActive())
+		return false;
+
+	const auto lock = GetLock();
+
+	// If we're not logged in, don't apply hardcore mode restrictions.
+	// If we later log in, we'll start with it off anyway.
+	// If we're running an unknown game, don't enable HC mode. We have to do this here,
+	// because the gameid can be cached, and identify immediately on GameChanged(),
+	// which gets called before ResetHardcoreMode().
+	const bool wanted_hardcore_mode = (IsLoggedInOrLoggingIn() || s_load_game_request) &&
+									  EmuConfig.Achievements.HardcoreMode;
+	if (s_hardcore_mode == wanted_hardcore_mode || (wanted_hardcore_mode && IsUnknownGame()))
+		return false;
+
+	SetHardcoreMode(wanted_hardcore_mode, false);
+	return true;
+}
+
+void Achievements::SetHardcoreMode(bool enabled, bool force_display_message)
+{
+	if (enabled == s_hardcore_mode)
+		return;
+
+	// new mode
+	s_hardcore_mode = enabled;
+
+	if (VMManager::HasValidVM() && (HasActiveGame() || force_display_message))
+	{
+		MTGS::RunOnGSThread([enabled]() {
+			if (ImGuiManager::InitializeFullscreenUI())
+			{
+				ImGuiFullscreen::ShowToast(std::string(),
+					enabled ? TRANSLATE_STR("Achievements", "Hardcore mode is now enabled.") :
+							  TRANSLATE_STR("Achievements", "Hardcore mode is now disabled."),
+					Host::OSD_INFO_DURATION);
+			}
+		});
+	}
+
+	rc_client_set_hardcore_enabled(s_client, enabled);
+	pxAssert((rc_client_get_hardcore_enabled(s_client) != 0) == enabled);
+	if (HasActiveGame())
+	{
+		UpdateGameSummary();
+		DisplayAchievementSummary();
+	}
+
+	// Toss away UI state, because it's invalid now
+	if (MTGS::IsOpen())
+		MTGS::RunOnGSThread(&Achievements::ClearUIState);
+
+	Host::OnAchievementsHardcoreModeChanged(enabled);
+}
+
+void Achievements::LoadState(const u8* state_data, u32 state_data_size)
+{
+	const auto lock = GetLock();
+
+	if (!IsActive())
+		return;
+
+	// this assumes that the CRC and ELF name has been loaded prior to the cheevos state (it should be).
+	if (VMManager::GetDiscCRC() != s_game_disc_crc)
+		GameChanged(VMManager::GetDiscCRC(), VMManager::GetCurrentCRC());
+
+#ifdef ENABLE_RAINTEGRATION
+	if (IsUsingRAIntegration())
+	{
+		if (state_data_size == 0)
+		{
+			Console.Warning("State is missing cheevos data, resetting RAIntegration");
+			RA_OnReset();
+		}
+		else
+		{
+			RA_RestoreState(reinterpret_cast<const char*>(state_data));
+		}
+
+		return;
+	}
+#endif
+
+	// if we're active, make sure we've downloaded and activated all the achievements
+	// before deserializing, otherwise that state's going to get lost.
+	if (s_http_downloader->HasAnyRequests())
+	{
+		bool was_running_idle;
+		BeginLoadingScreen("Downloading achievements data...", &was_running_idle);
+		s_http_downloader->WaitForAllRequests();
+		EndLoadingScreen(was_running_idle);
+	}
+
+	if (state_data_size == 0)
+	{
+		// reset runtime, no data (state might've been created without cheevos)
+		Console.Warning("State is missing cheevos data, resetting runtime");
+		rc_client_reset(s_client);
+		return;
+	}
+
+	// These routines scare me a bit.. the data isn't bounds checked.
+	// Really hope that nobody puts any thing malicious in a save state...
+	const int result = rc_client_deserialize_progress(s_client, state_data);
+	if (result != RC_OK)
+	{
+		Console.Warning("Failed to deserialize cheevos state (%d), resetting", result);
+		rc_client_reset(s_client);
+	}
+}
+
+std::vector<u8> Achievements::SaveState()
+{
+	std::vector<u8> ret;
+
+	const auto lock = GetLock();
+
+#ifdef ENABLE_RAINTEGRATION
+	if (IsUsingRAIntegration())
+	{
+		const int size = RA_CaptureState(nullptr, 0);
+
+		const u32 data_size = (size >= 0) ? static_cast<u32>(size) : 0;
+		ret.resize(data_size);
+
+		const int result = RA_CaptureState(reinterpret_cast<char*>(ret.data()), static_cast<int>(data_size));
+		if (result != static_cast<int>(data_size))
+		{
+			Console.Warning("Failed to serialize cheevos state from RAIntegration.");
+			ret.clear();
+		}
+
+		return ret;
+	}
+#endif
+
+	if (IsActive())
+	{
+		// internally this happens twice.. not great.
+		const size_t data_size = rc_client_progress_size(s_client);
+		ret.resize(data_size);
+
+		const int result = rc_client_serialize_progress(s_client, ret.data());
+		if (result != RC_OK)
+		{
+			// set data to zero, effectively serializing nothing
+			Console.Warning("Failed to serialize cheevos state (%d)", result);
+			ret.clear();
+		}
+	}
+
+	return ret;
+}
+
+
+std::string Achievements::GetAchievementBadgePath(const rc_client_achievement_t* achievement, int state)
+{
+	static constexpr std::array<const char*, NUM_RC_CLIENT_ACHIEVEMENT_STATES> s_achievement_state_strings = {
+		{"inactive", "active", "unlocked", "disabled"}};
+
+	std::string path;
+
+	if (achievement->badge_name[0] == 0)
+		return path;
+
+	path = Path::Combine(s_image_directory,
+		TinyString::from_fmt("achievement_{}_{}_{}.png", s_game_id, achievement->id, s_achievement_state_strings[state]));
+
+	if (!FileSystem::FileExists(path.c_str()))
+	{
+		char buf[512];
+		const int res = rc_client_achievement_get_image_url(achievement, state, buf, std::size(buf));
+		if (res == RC_OK)
+			DownloadImage(buf, path);
+		else
+			ReportRCError(res, "rc_client_achievement_get_image_url() for {} failed", achievement->title);
+	}
+
+	return path;
+}
+
+std::string Achievements::GetUserBadgePath(const std::string_view& username)
+{
+	// definitely want to sanitize usernames... :)
+	std::string path;
+	const std::string clean_username = Path::SanitizeFileName(username);
+	if (!clean_username.empty())
+		path = Path::Combine(s_image_directory, TinyString::from_fmt("user_{}.png", clean_username));
+	return path;
+}
+
+std::string Achievements::GetLeaderboardUserBadgePath(const rc_client_leaderboard_entry_t* entry)
+{
+	// TODO: maybe we should just cache these in memory...
+	std::string path = GetUserBadgePath(entry->user);
+
+	if (!FileSystem::FileExists(path.c_str()))
+	{
+		char buf[512];
+		const int res = rc_client_leaderboard_entry_get_user_image_url(entry, buf, std::size(buf));
+		if (res == RC_OK)
+			DownloadImage(buf, path);
+		else
+			ReportRCError(res, "rc_client_leaderboard_entry_get_user_image_url() for {} failed", entry->user);
+	}
+
+	return path;
+}
+
+bool Achievements::IsLoggedInOrLoggingIn()
+{
+	return (rc_client_get_user_info(s_client) != nullptr || s_login_request);
+}
+
+bool Achievements::IsUnknownGame()
+{
+	return (s_game_id == 0 && !s_load_game_request);
+}
+
+bool Achievements::Login(const char* username, const char* password, Error* error)
+{
+	auto lock = GetLock();
+
+	// We need to use a temporary client if achievements aren't currently active.
+	rc_client_t* client = s_client;
+	Common::HTTPDownloader* http = s_http_downloader.get();
+	const bool is_temporary_client = (client == nullptr);
+	std::unique_ptr<Common::HTTPDownloader> temporary_downloader;
+	ScopedGuard temporary_client_guard = [&client, is_temporary_client, &temporary_downloader]() {
+		if (is_temporary_client)
+			DestroyClient(&client, &temporary_downloader);
+	};
+	if (is_temporary_client)
+	{
+		if (!CreateClient(&client, &temporary_downloader))
+		{
+			Error::SetString(error, "Failed to create client.");
+			return false;
+		}
+		http = temporary_downloader.get();
+	}
+
+	LoginWithPasswordParameters params = {username, error, nullptr, false};
+
+	params.request = rc_client_begin_login_with_password(client, username, password, ClientLoginWithPasswordCallback, &params);
+	if (!params.request)
+	{
+		Error::SetString(error, "Failed to create login request.");
+		return false;
+	}
+
+	// Wait until the login request completes.
+	http->WaitForAllRequests();
+	pxAssert(!params.request);
+
+	// Success? Assume the callback set the error message.
+	if (!params.result)
+		return false;
+
+	// If we were't a temporary client, get the game loaded.
+	if (VMManager::HasValidVM() && !is_temporary_client)
+		BeginLoadGame();
+
+	return true;
+}
+
+
+void Achievements::ClientLoginWithPasswordCallback(int result, const char* error_message, rc_client_t* client, void* userdata)
+{
+	pxAssert(userdata);
+
+	LoginWithPasswordParameters* params = static_cast<LoginWithPasswordParameters*>(userdata);
+	params->request = nullptr;
+
+	if (result != RC_OK)
+	{
+		Console.Error("Login failed: %s: %s", rc_error_str(result), error_message ? error_message : "Unknown");
+		Error::SetString(params->error, fmt::format("{}: {}", rc_error_str(result), error_message ? error_message : "Unknown"));
+		params->result = false;
+		return;
+	}
+
+	// Grab the token from the client, and save it to the config.
+	const rc_client_user_t* user = rc_client_get_user_info(client);
+	if (!user || !user->token)
+	{
+		Console.Error("rc_client_get_user_info() returned NULL");
+		Error::SetString(params->error, "rc_client_get_user_info() returned NULL");
+		params->result = false;
+		return;
+	}
+
+	params->result = true;
+
+	// Store configuration.
+	Host::SetBaseStringSettingValue("Achievements", "Username", params->username);
+	Host::SetBaseStringSettingValue("Achievements", "Token", user->token);
+	Host::SetBaseStringSettingValue("Achievements", "LoginTimestamp", fmt::format("{}", std::time(nullptr)).c_str());
+	Host::CommitBaseSettingChanges();
+
+	ShowLoginSuccess(client);
+}
+
+void Achievements::ClientLoginWithTokenCallback(int result, const char* error_message, rc_client_t* client, void* userdata)
+{
+	s_login_request = nullptr;
+
+	if (result != RC_OK)
+	{
+		ReportFmtError("Login failed: {}", error_message);
+		Host::OnAchievementsLoginRequested(LoginRequestReason::TokenInvalid);
+		return;
+	}
+
+	ShowLoginSuccess(client);
+
+	if (VMManager::HasValidVM())
+		BeginLoadGame();
+}
+
+void Achievements::ShowLoginSuccess(const rc_client_t* client)
+{
+	const rc_client_user_t* user = rc_client_get_user_info(client);
+	if (!user)
+		return;
+
+	Host::OnAchievementsLoginSuccess(user->username, user->score, user->score_softcore, user->num_unread_messages);
+
+	// Were we logging in with a temporary client?
+	const auto lock = GetLock();
+	if (s_client != client)
+		return;
+
+	if (EmuConfig.Achievements.Notifications && MTGS::IsOpen())
+	{
+		std::string badge_path = GetUserBadgePath(user->username);
+		if (!FileSystem::FileExists(badge_path.c_str()))
+		{
+			char url[512];
+			const int res = rc_client_user_get_image_url(user, url, std::size(url));
+			if (res == RC_OK)
+				DownloadImage(url, badge_path);
+			else
+				ReportRCError(res, "rc_client_user_get_image_url() failed: ");
+		}
+
+		//: Summary for login notification.
+		std::string title = user->display_name;
+		std::string summary = fmt::format(TRANSLATE_FS("Achievements", "Score: {} ({} softcore)\nUnread messages: {}"), user->score,
+			user->score_softcore, user->num_unread_messages);
+
+		MTGS::RunOnGSThread([title = std::move(title), summary = std::move(summary), badge_path = std::move(badge_path)]() {
+			if (ImGuiManager::InitializeFullscreenUI())
+			{
+				ImGuiFullscreen::AddNotification(
+					"achievements_login", LOGIN_NOTIFICATION_TIME, std::move(title), std::move(summary), std::move(badge_path));
+			}
+		});
+	}
+}
+
+void Achievements::Logout()
+{
+	if (IsActive())
+	{
+		const auto lock = GetLock();
+
+		if (HasActiveGame())
+			ClearGameInfo();
+
+		Console.WriteLn("(Achievements) Logging out...");
+		rc_client_logout(s_client);
+	}
+
+	Console.WriteLn("(Achievements) Clearing credentials...");
+	Host::RemoveBaseSettingValue("Achievements", "Username");
+	Host::RemoveBaseSettingValue("Achievements", "Token");
+	Host::RemoveBaseSettingValue("Achievements", "LoginTimestamp");
+	Host::CommitBaseSettingChanges();
+}
+
+
+bool Achievements::ConfirmSystemReset()
+{
+#ifdef ENABLE_RAINTEGRATION
+	if (IsUsingRAIntegration())
+		return RA_ConfirmLoadNewRom(false);
+#endif
+
+	return true;
+}
+
+bool Achievements::ConfirmHardcoreModeDisable(const char* trigger)
+{
+#ifdef ENABLE_RAINTEGRATION
+	if (IsUsingRAIntegration())
+		return (RA_WarnDisableHardcore(trigger) != 0);
+#endif
+
+	// I really hope this doesn't deadlock :/
+	const bool confirmed = Host::ConfirmMessage(TRANSLATE("Achievements", "Confirm Hardcore Mode"),
+		fmt::format(TRANSLATE_FS("Achievements", "{0} cannot be performed while hardcore mode is active. Do you "
+												 "want to disable hardcore mode? {0} will be cancelled if you select No."),
+			trigger));
+	if (!confirmed)
+		return false;
+
+	DisableHardcoreMode();
+	return true;
+}
+
+void Achievements::ClearUIState()
+{
+	if (FullscreenUI::IsAchievementsWindowOpen() || FullscreenUI::IsLeaderboardsWindowOpen())
+		FullscreenUI::ReturnToMainWindow();
+
+	s_achievement_badge_paths = {};
+
+	CloseLeaderboard();
+	s_leaderboard_user_icon_paths = {};
+	s_leaderboard_entry_lists = {};
+	if (s_leaderboard_list)
+	{
+		rc_client_destroy_leaderboard_list(s_leaderboard_list);
+		s_leaderboard_list = nullptr;
+	}
+
+	if (s_achievement_list)
+	{
+		rc_client_destroy_achievement_list(s_achievement_list);
+		s_achievement_list = nullptr;
+	}
+}
+
+template <typename T>
+static float IndicatorOpacity(const T& i)
+{
+	const float elapsed = static_cast<float>(i.show_hide_time.GetTimeSeconds());
+	const float time = i.active ? Achievements::INDICATOR_FADE_IN_TIME : Achievements::INDICATOR_FADE_OUT_TIME;
+	const float opacity = (elapsed >= time) ? 1.0f : (elapsed / time);
+	return (i.active) ? opacity : (1.0f - opacity);
+}
+
+
+void Achievements::DrawGameOverlays()
+{
+	using ImGuiFullscreen::g_medium_font;
+	using ImGuiFullscreen::LayoutScale;
+
+	if (!HasActiveGame() || !EmuConfig.Achievements.Overlays)
+		return;
+
+	const auto lock = GetLock();
+
+	const float spacing = LayoutScale(10.0f);
+	const float padding = LayoutScale(10.0f);
+	const ImVec2 image_size = LayoutScale(ImGuiFullscreen::LAYOUT_MENU_BUTTON_HEIGHT, ImGuiFullscreen::LAYOUT_MENU_BUTTON_HEIGHT);
+	const ImGuiIO& io = ImGui::GetIO();
+	ImVec2 position = ImVec2(io.DisplaySize.x - padding, io.DisplaySize.y - padding);
+	ImDrawList* dl = ImGui::GetBackgroundDrawList();
+
+	if (!s_active_challenge_indicators.empty())
+	{
+		const float x_advance = image_size.x + spacing;
+		ImVec2 current_position = ImVec2(position.x - image_size.x, position.y - image_size.y);
+
+		for (auto it = s_active_challenge_indicators.begin(); it != s_active_challenge_indicators.end();)
+		{
+			const AchievementChallengeIndicator& indicator = *it;
+			const float opacity = IndicatorOpacity(indicator);
+			const u32 col = ImGui::GetColorU32(ImVec4(1.0f, 1.0f, 1.0f, opacity));
+
+			GSTexture* badge = ImGuiFullscreen::GetCachedTextureAsync(indicator.badge_path.c_str());
+			if (badge)
+			{
+				dl->AddImage(badge, current_position, current_position + image_size, ImVec2(0.0f, 0.0f), ImVec2(1.0f, 1.0f), col);
+				current_position.x -= x_advance;
+			}
+
+			if (!indicator.active && opacity <= 0.01f)
+			{
+				DevCon.WriteLn("(Achievements) Remove challenge indicator");
+				it = s_active_challenge_indicators.erase(it);
+			}
+			else
+			{
+				++it;
+			}
+		}
+
+		position.y -= image_size.y + padding;
+	}
+
+	if (s_active_progress_indicator.has_value())
+	{
+		const AchievementProgressIndicator& indicator = s_active_progress_indicator.value();
+		const float opacity = IndicatorOpacity(indicator);
+		const u32 col = ImGui::GetColorU32(ImVec4(1.0f, 1.0f, 1.0f, opacity));
+
+		const char* text_start = s_active_progress_indicator->achievement->measured_progress;
+		const char* text_end = text_start + std::strlen(text_start);
+		const ImVec2 text_size = g_medium_font->CalcTextSizeA(g_medium_font->FontSize, FLT_MAX, 0.0f, text_start, text_end);
+
+		const ImVec2 box_min =
+			ImVec2(position.x - image_size.x - text_size.x - spacing - padding * 2.0f, position.y - image_size.y - padding * 2.0f);
+		const ImVec2 box_max = position;
+		const float box_rounding = LayoutScale(1.0f);
+
+		dl->AddRectFilled(box_min, box_max, ImGui::GetColorU32(ImVec4(0.13f, 0.13f, 0.13f, opacity * 0.5f)), box_rounding);
+		dl->AddRect(box_min, box_max, ImGui::GetColorU32(ImVec4(0.8f, 0.8f, 0.8f, opacity)), box_rounding);
+
+		GSTexture* badge = ImGuiFullscreen::GetCachedTextureAsync(indicator.badge_path.c_str());
+		if (badge)
+		{
+			const ImVec2 badge_pos = box_min + ImVec2(padding, padding);
+			dl->AddImage(badge, badge_pos, badge_pos + image_size, ImVec2(0.0f, 0.0f), ImVec2(1.0f, 1.0f), col);
+		}
+
+		const ImVec2 text_pos = box_min + ImVec2(padding + image_size.x + spacing, (box_max.y - box_min.y - text_size.y) * 0.5f);
+		const ImVec4 text_clip_rect(text_pos.x, text_pos.y, box_max.x, box_max.y);
+		dl->AddText(g_medium_font, g_medium_font->FontSize, text_pos, col, text_start, text_end, 0.0f, &text_clip_rect);
+
+		if (!indicator.active && opacity <= 0.01f)
+		{
+			DevCon.WriteLn("(Achievements) Remove progress indicator");
+			s_active_progress_indicator.reset();
+		}
+	}
+
+	if (!s_active_leaderboard_trackers.empty())
+	{
+		for (auto it = s_active_leaderboard_trackers.begin(); it != s_active_leaderboard_trackers.end();)
+		{
+			const LeaderboardTrackerIndicator& indicator = *it;
+			const float opacity = IndicatorOpacity(indicator);
+
+			const ImVec2 box_min = ImVec2(position.x - indicator.size.x - padding * 2.0f, position.y - indicator.size.y - padding * 2.0f);
+			const ImVec2 box_max = position;
+			const float box_rounding = LayoutScale(1.0f);
+			dl->AddRectFilled(box_min, box_max, ImGui::GetColorU32(ImVec4(0.13f, 0.13f, 0.13f, opacity * 0.5f)), box_rounding);
+			dl->AddRect(box_min, box_max, ImGui::GetColorU32(ImVec4(0.8f, 0.8f, 0.8f, opacity)), box_rounding);
+
+			const u32 text_col = ImGui::GetColorU32(ImVec4(1.0f, 1.0f, 1.0f, opacity));
+			const ImVec2 text_pos = box_min + ImVec2(padding, padding);
+			const ImVec4 text_clip_rect(text_pos.x, text_pos.y, box_max.x, box_max.y);
+			dl->AddText(g_medium_font, g_medium_font->FontSize, text_pos, text_col, indicator.text.c_str(),
+				indicator.text.c_str() + indicator.text.length(), 0.0f, &text_clip_rect);
+
+			if (!indicator.active && opacity <= 0.01f)
+			{
+				DevCon.WriteLn("(Achievements) Remove tracker indicator");
+				it = s_active_leaderboard_trackers.erase(it);
+			}
+			else
+			{
+				++it;
+			}
+		}
+
+		position.y -= image_size.y + padding;
+	}
+}
+
+void Achievements::DrawPauseMenuOverlays()
+{
+	using ImGuiFullscreen::g_large_font;
+	using ImGuiFullscreen::g_medium_font;
+	using ImGuiFullscreen::LayoutScale;
+
+	if (!HasActiveGame())
+		return;
+
+	const auto lock = GetLock();
+
+	if (s_active_challenge_indicators.empty() && !s_active_progress_indicator.has_value())
+		return;
+
+	const ImGuiIO& io = ImGui::GetIO();
+	ImFont* font = g_medium_font;
+
+	const ImVec2 image_size(
+		LayoutScale(ImGuiFullscreen::LAYOUT_MENU_BUTTON_HEIGHT_NO_SUMMARY, ImGuiFullscreen::LAYOUT_MENU_BUTTON_HEIGHT_NO_SUMMARY));
+	const float start_y = LayoutScale(10.0f + 4.0f + 4.0f) + g_large_font->FontSize + (g_medium_font->FontSize * 2.0f);
+	const float margin = LayoutScale(10.0f);
+	const float spacing = LayoutScale(10.0f);
+	const float padding = LayoutScale(10.0f);
+
+	const float max_text_width = ImGuiFullscreen::LayoutScale(300.0f);
+	const float row_width = max_text_width + padding + padding + image_size.x + spacing;
+	const float title_height = padding + font->FontSize + padding;
+
+	if (!s_active_challenge_indicators.empty())
+	{
+		const ImVec2 box_min(io.DisplaySize.x - row_width - margin, start_y + margin);
+		const ImVec2 box_max(box_min.x + row_width,
+			box_min.y + title_height + (static_cast<float>(s_active_challenge_indicators.size()) * (image_size.y + padding)));
+
+		ImDrawList* dl = ImGui::GetBackgroundDrawList();
+		dl->AddRectFilled(box_min, box_max, IM_COL32(0x21, 0x21, 0x21, 200), LayoutScale(10.0f));
+		dl->AddText(font, font->FontSize, ImVec2(box_min.x + padding, box_min.y + padding), IM_COL32(255, 255, 255, 255),
+			TRANSLATE("Achievements", "Active Challenge Achievements"));
+
+		const float y_advance = image_size.y + spacing;
+		const float acheivement_name_offset = (image_size.y - font->FontSize) / 2.0f;
+		const float max_non_ellipised_text_width = max_text_width - LayoutScale(10.0f);
+		ImVec2 position(box_min.x + padding, box_min.y + title_height);
+
+		for (const AchievementChallengeIndicator& indicator : s_active_challenge_indicators)
+		{
+			GSTexture* badge = ImGuiFullscreen::GetCachedTextureAsync(indicator.badge_path.c_str());
+			if (!badge)
+				continue;
+
+			dl->AddImage(badge, position, position + image_size);
+
+			const char* achievement_title = indicator.achievement->title;
+			const char* achievement_title_end = achievement_title + std::strlen(indicator.achievement->title);
+			const char* remaining_text = nullptr;
+			const ImVec2 text_width(font->CalcTextSizeA(
+				font->FontSize, max_non_ellipised_text_width, 0.0f, achievement_title, achievement_title_end, &remaining_text));
+			const ImVec2 text_position(position.x + image_size.x + spacing, position.y + acheivement_name_offset);
+			const ImVec4 text_bbox(text_position.x, text_position.y, text_position.x + max_text_width, text_position.y + image_size.y);
+			const u32 text_color = IM_COL32(255, 255, 255, 255);
+
+			if (remaining_text < achievement_title_end)
+			{
+				dl->AddText(font, font->FontSize, text_position, text_color, achievement_title, remaining_text, 0.0f, &text_bbox);
+				dl->AddText(font, font->FontSize, ImVec2(text_position.x + text_width.x, text_position.y), text_color, "...", nullptr, 0.0f,
+					&text_bbox);
+			}
+			else
+			{
+				dl->AddText(font, font->FontSize, text_position, text_color, achievement_title, achievement_title_end, 0.0f, &text_bbox);
+			}
+
+			position.y += y_advance;
+		}
+	}
+}
+
+bool Achievements::PrepareAchievementsWindow()
+{
+	auto lock = Achievements::GetLock();
+
+	s_achievement_badge_paths = {};
+
+	if (s_achievement_list)
+		rc_client_destroy_achievement_list(s_achievement_list);
+	s_achievement_list = rc_client_create_achievement_list(s_client, RC_CLIENT_ACHIEVEMENT_CATEGORY_CORE_AND_UNOFFICIAL,
+		RC_CLIENT_ACHIEVEMENT_LIST_GROUPING_PROGRESS /*RC_CLIENT_ACHIEVEMENT_LIST_GROUPING_LOCK_STATE*/);
+	if (!s_achievement_list)
+	{
+		Console.Error("(Achievements) rc_client_create_achievement_list() returned null");
+		return false;
+	}
+
+	return true;
+}
+
+void Achievements::DrawAchievementsWindow()
+{
+	using ImGuiFullscreen::g_large_font;
+	using ImGuiFullscreen::g_medium_font;
+	using ImGuiFullscreen::LayoutScale;
+
+	if (!s_achievement_list)
+		return;
+
+	auto lock = Achievements::GetLock();
+
+	// ensure image downloads still happen while we're paused
+	Achievements::IdleUpdate();
+
+	static constexpr float alpha = 0.8f;
+	static constexpr float heading_alpha = 0.95f;
+	static constexpr float heading_height_unscaled = 110.0f;
+
+	const ImVec4 background(0.13f, 0.13f, 0.13f, alpha);
+	const ImVec4 heading_background(0.13f, 0.13f, 0.13f, heading_alpha);
+	const ImVec2 display_size(ImGui::GetIO().DisplaySize);
+	const float heading_height = ImGuiFullscreen::LayoutScale(heading_height_unscaled);
+
+	if (ImGuiFullscreen::BeginFullscreenWindow(ImVec2(0.0f, 0.0f), ImVec2(display_size.x, heading_height), "achievements_heading",
+			heading_background, 0.0f, 0.0f, ImGuiWindowFlags_NoNav | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoScrollWithMouse))
+	{
+		ImRect bb;
+		bool visible, hovered;
+		ImGuiFullscreen::MenuButtonFrame(
+			"achievements_heading", false, heading_height_unscaled, &visible, &hovered, &bb.Min, &bb.Max, 0, heading_alpha);
+		if (visible)
+		{
+			const float padding = ImGuiFullscreen::LayoutScale(10.0f);
+			const float spacing = ImGuiFullscreen::LayoutScale(10.0f);
+			const float image_height = ImGuiFullscreen::LayoutScale(85.0f);
+
+			const ImVec2 icon_min(bb.Min + ImVec2(padding, padding));
+			const ImVec2 icon_max(icon_min + ImVec2(image_height, image_height));
+
+			if (!s_game_icon.empty())
+			{
+				GSTexture* badge = ImGuiFullscreen::GetCachedTextureAsync(s_game_icon.c_str());
+				if (badge)
+				{
+					ImGui::GetWindowDrawList()->AddImage(
+						badge, icon_min, icon_max, ImVec2(0.0f, 0.0f), ImVec2(1.0f, 1.0f), IM_COL32(255, 255, 255, 255));
+				}
+			}
+
+			float left = bb.Min.x + padding + image_height + spacing;
+			float right = bb.Max.x - padding;
+			float top = bb.Min.y + padding;
+			ImDrawList* dl = ImGui::GetWindowDrawList();
+			SmallString text;
+			ImVec2 text_size;
+
+			if (ImGuiFullscreen::FloatingButton(ICON_FA_WINDOW_CLOSE, 10.0f, 10.0f, -1.0f, -1.0f, 1.0f, 0.0f, true, g_large_font) ||
+				ImGuiFullscreen::WantsToCloseMenu())
+			{
+				FullscreenUI::ReturnToPreviousWindow();
+			}
+
+			const ImRect title_bb(ImVec2(left, top), ImVec2(right, top + g_large_font->FontSize));
+			text.assign(s_game_title);
+
+			if (s_hardcore_mode)
+				text.append(TRANSLATE_SV("Achievements", " (Hardcore Mode)"));
+
+			top += g_large_font->FontSize + spacing;
+
+			ImGui::PushFont(g_large_font);
+			ImGui::RenderTextClipped(title_bb.Min, title_bb.Max, text.c_str(), text.end_ptr(), nullptr, ImVec2(0.0f, 0.0f), &title_bb);
+			ImGui::PopFont();
+
+			const ImRect summary_bb(ImVec2(left, top), ImVec2(right, top + g_medium_font->FontSize));
+			if (s_game_summary.num_unlocked_achievements == s_game_summary.num_core_achievements)
+			{
+				text.fmt(TRANSLATE_FS("Achievements", "You have unlocked all achievements and earned {} points!"),
+					s_game_summary.points_unlocked);
+			}
+			else
+			{
+				text.fmt(TRANSLATE_FS("Achievements", "You have unlocked {} of {} achievements, earning {} of {} possible points."),
+					s_game_summary.num_unlocked_achievements, s_game_summary.num_core_achievements, s_game_summary.points_unlocked,
+					s_game_summary.points_core);
+			}
+
+			top += g_medium_font->FontSize + spacing;
+
+			ImGui::PushFont(g_medium_font);
+			ImGui::RenderTextClipped(
+				summary_bb.Min, summary_bb.Max, text.c_str(), text.end_ptr(), nullptr, ImVec2(0.0f, 0.0f), &summary_bb);
+			ImGui::PopFont();
+
+			const float progress_height = ImGuiFullscreen::LayoutScale(20.0f);
+			const ImRect progress_bb(ImVec2(left, top), ImVec2(right, top + progress_height));
+			const float fraction =
+				static_cast<float>(s_game_summary.num_unlocked_achievements) / static_cast<float>(s_game_summary.num_core_achievements);
+			dl->AddRectFilled(progress_bb.Min, progress_bb.Max, ImGui::GetColorU32(ImGuiFullscreen::UIPrimaryDarkColor));
+			dl->AddRectFilled(progress_bb.Min, ImVec2(progress_bb.Min.x + fraction * progress_bb.GetWidth(), progress_bb.Max.y),
+				ImGui::GetColorU32(ImGuiFullscreen::UISecondaryColor));
+
+			text.fmt("{}%", static_cast<int>(std::round(fraction * 100.0f)));
+			text_size = ImGui::CalcTextSize(text.c_str(), text.end_ptr());
+			const ImVec2 text_pos(progress_bb.Min.x + ((progress_bb.Max.x - progress_bb.Min.x) / 2.0f) - (text_size.x / 2.0f),
+				progress_bb.Min.y + ((progress_bb.Max.y - progress_bb.Min.y) / 2.0f) - (text_size.y / 2.0f));
+			dl->AddText(g_medium_font, g_medium_font->FontSize, text_pos, ImGui::GetColorU32(ImGuiFullscreen::UIPrimaryTextColor),
+				text.c_str(), text.end_ptr());
+			top += progress_height + spacing;
+		}
+	}
+	ImGuiFullscreen::EndFullscreenWindow();
+
+	ImGui::SetNextWindowBgAlpha(alpha);
+
+	if (ImGuiFullscreen::BeginFullscreenWindow(ImVec2(0.0f, heading_height), ImVec2(display_size.x, display_size.y - heading_height),
+			"achievements", background, 0.0f, 0.0f, 0))
+	{
+		static bool buckets_collapsed[NUM_RC_CLIENT_ACHIEVEMENT_BUCKETS] = {};
+		static const char* bucket_names[NUM_RC_CLIENT_ACHIEVEMENT_BUCKETS] = {
+			TRANSLATE_NOOP("Achievements", "Unknown"),
+			TRANSLATE_NOOP("Achievements", "Locked"),
+			TRANSLATE_NOOP("Achievements", "Unlocked"),
+			TRANSLATE_NOOP("Achievements", "Unsupported"),
+			TRANSLATE_NOOP("Achievements", "Unofficial"),
+			TRANSLATE_NOOP("Achievements", "Recently Unlocked"),
+			TRANSLATE_NOOP("Achievements", "Active Challenges"),
+			TRANSLATE_NOOP("Achievements", "Almost There"),
+		};
+
+		ImGuiFullscreen::BeginMenuButtons();
+
+		for (u32 bucket_type : {RC_CLIENT_ACHIEVEMENT_BUCKET_ACTIVE_CHALLENGE, RC_CLIENT_ACHIEVEMENT_BUCKET_RECENTLY_UNLOCKED,
+				 RC_CLIENT_ACHIEVEMENT_BUCKET_UNLOCKED, RC_CLIENT_ACHIEVEMENT_BUCKET_ALMOST_THERE, RC_CLIENT_ACHIEVEMENT_BUCKET_LOCKED,
+				 RC_CLIENT_ACHIEVEMENT_BUCKET_UNOFFICIAL, RC_CLIENT_ACHIEVEMENT_BUCKET_UNSUPPORTED})
+		{
+			for (u32 bucket_idx = 0; bucket_idx < s_achievement_list->num_buckets; bucket_idx++)
+			{
+				const rc_client_achievement_bucket_t& bucket = s_achievement_list->buckets[bucket_idx];
+				if (bucket.bucket_type != bucket_type)
+					continue;
+
+				pxAssert(bucket.bucket_type < NUM_RC_CLIENT_ACHIEVEMENT_BUCKETS);
+
+				// TODO: Once subsets are supported, this will need to change.
+				bool& bucket_collapsed = buckets_collapsed[bucket.bucket_type];
+				bucket_collapsed ^=
+					ImGuiFullscreen::MenuHeadingButton(Host::TranslateToCString("Achievements", bucket_names[bucket.bucket_type]),
+						bucket_collapsed ? ICON_FA_CHEVRON_DOWN : ICON_FA_CHEVRON_UP);
+				if (!bucket_collapsed)
+				{
+					for (u32 i = 0; i < bucket.num_achievements; i++)
+						DrawAchievement(bucket.achievements[i]);
+				}
+			}
+		}
+
+		ImGuiFullscreen::EndMenuButtons();
+	}
+	ImGuiFullscreen::EndFullscreenWindow();
+}
+
+void Achievements::DrawAchievement(const rc_client_achievement_t* cheevo)
+{
+	using ImGuiFullscreen::g_large_font;
+	using ImGuiFullscreen::g_medium_font;
+	using ImGuiFullscreen::LayoutScale;
+
+	static constexpr float alpha = 0.8f;
+	static constexpr float progress_height_unscaled = 20.0f;
+	static constexpr float progress_spacing_unscaled = 5.0f;
+
+	const float spacing = ImGuiFullscreen::LayoutScale(4.0f);
+
+	const bool is_unlocked = (cheevo->state == RC_CLIENT_ACHIEVEMENT_STATE_UNLOCKED);
+	const std::string_view measured_progress(cheevo->measured_progress);
+	const bool is_measured = !is_unlocked && !measured_progress.empty();
+	const float unlock_size = is_unlocked ? (spacing + ImGuiFullscreen::LAYOUT_MEDIUM_FONT_SIZE) : 0.0f;
+
+	ImRect bb;
+	bool visible, hovered;
+	ImGuiFullscreen::MenuButtonFrame(TinyString::from_fmt("chv_{}", cheevo->id), true,
+		!is_measured ? ImGuiFullscreen::LAYOUT_MENU_BUTTON_HEIGHT + unlock_size :
+					   ImGuiFullscreen::LAYOUT_MENU_BUTTON_HEIGHT + progress_height_unscaled + progress_spacing_unscaled,
+		&visible, &hovered, &bb.Min, &bb.Max, 0, alpha);
+	if (!visible)
+		return;
+
+	std::string* badge_path;
+	if (const auto badge_it = std::find_if(
+			s_achievement_badge_paths.begin(), s_achievement_badge_paths.end(), [cheevo](const auto& it) { return (it.first == cheevo); });
+		badge_it != s_achievement_badge_paths.end())
+	{
+		badge_path = &badge_it->second;
+	}
+	else
+	{
+		std::string new_badge_path = Achievements::GetAchievementBadgePath(cheevo, cheevo->state);
+		badge_path = &s_achievement_badge_paths.emplace_back(cheevo, std::move(new_badge_path)).second;
+	}
+
+	const ImVec2 image_size(LayoutScale(ImGuiFullscreen::LAYOUT_MENU_BUTTON_HEIGHT, ImGuiFullscreen::LAYOUT_MENU_BUTTON_HEIGHT));
+	if (!badge_path->empty())
+	{
+		GSTexture* badge = ImGuiFullscreen::GetCachedTextureAsync(badge_path->c_str());
+		if (badge)
+		{
+			ImGui::GetWindowDrawList()->AddImage(
+				badge, bb.Min, bb.Min + image_size, ImVec2(0.0f, 0.0f), ImVec2(1.0f, 1.0f), IM_COL32(255, 255, 255, 255));
+		}
+	}
+
+	SmallString text;
+
+	const float midpoint = bb.Min.y + g_large_font->FontSize + spacing;
+	text.fmt((cheevo->points != 1) ? TRANSLATE_FS("Achievements", "{} points") : TRANSLATE_FS("Achievements", "{} point"), cheevo->points);
+	const ImVec2 points_template_size(
+		g_medium_font->CalcTextSizeA(g_medium_font->FontSize, FLT_MAX, 0.0f, TRANSLATE("Achievements", "XXX points")));
+	const ImVec2 points_size(g_medium_font->CalcTextSizeA(g_medium_font->FontSize, FLT_MAX, 0.0f, text.c_str(), text.end_ptr()));
+	const float points_template_start = bb.Max.x - points_template_size.x;
+	const float points_start = points_template_start + ((points_template_size.x - points_size.x) * 0.5f);
+	const char* lock_text = is_unlocked ? ICON_FA_LOCK_OPEN : ICON_FA_LOCK;
+	const ImVec2 lock_size(g_large_font->CalcTextSizeA(g_large_font->FontSize, FLT_MAX, 0.0f, lock_text));
+
+	const float text_start_x = bb.Min.x + image_size.x + LayoutScale(15.0f);
+	const ImRect title_bb(ImVec2(text_start_x, bb.Min.y), ImVec2(points_start, midpoint));
+	const ImRect summary_bb(ImVec2(text_start_x, midpoint), ImVec2(points_start, midpoint + g_medium_font->FontSize));
+	const ImRect points_bb(ImVec2(points_start, midpoint), bb.Max);
+	const ImRect lock_bb(
+		ImVec2(points_template_start + ((points_template_size.x - lock_size.x) * 0.5f), bb.Min.y), ImVec2(bb.Max.x, midpoint));
+
+	ImGui::PushFont(g_large_font);
+	ImGui::RenderTextClipped(title_bb.Min, title_bb.Max, cheevo->title, nullptr, nullptr, ImVec2(0.0f, 0.0f), &title_bb);
+	ImGui::RenderTextClipped(lock_bb.Min, lock_bb.Max, lock_text, nullptr, &lock_size, ImVec2(0.0f, 0.0f), &lock_bb);
+	ImGui::PopFont();
+
+	ImGui::PushFont(g_medium_font);
+	if (cheevo->description && std::strlen(cheevo->description) > 0)
+	{
+		ImGui::RenderTextClipped(summary_bb.Min, summary_bb.Max, cheevo->description, nullptr, nullptr, ImVec2(0.0f, 0.0f), &summary_bb);
+	}
+	ImGui::RenderTextClipped(points_bb.Min, points_bb.Max, text.c_str(), text.end_ptr(), &points_size, ImVec2(0.0f, 0.0f), &points_bb);
+
+	if (is_unlocked)
+	{
+		text.fmt(TRANSLATE_FS("Achievements", "Unlocked: {}"), FullscreenUI::TimeToPrintableString(cheevo->unlock_time));
+
+		const ImRect unlock_bb(summary_bb.Min.x, summary_bb.Max.y + spacing, summary_bb.Max.x, bb.Max.y);
+		ImGui::RenderTextClipped(unlock_bb.Min, unlock_bb.Max, text.c_str(), text.end_ptr(), nullptr, ImVec2(0.0f, 0.0f), &unlock_bb);
+	}
+	else if (is_measured)
+	{
+		ImDrawList* dl = ImGui::GetWindowDrawList();
+		const float progress_height = LayoutScale(progress_height_unscaled);
+		const float progress_spacing = LayoutScale(progress_spacing_unscaled);
+		const float top = midpoint + g_medium_font->FontSize + progress_spacing;
+		const ImRect progress_bb(ImVec2(text_start_x, top), ImVec2(bb.Max.x, top + progress_height));
+		const float fraction = cheevo->measured_percent * 0.01f;
+		dl->AddRectFilled(progress_bb.Min, progress_bb.Max, ImGui::GetColorU32(ImGuiFullscreen::UIPrimaryDarkColor));
+		dl->AddRectFilled(progress_bb.Min, ImVec2(progress_bb.Min.x + fraction * progress_bb.GetWidth(), progress_bb.Max.y),
+			ImGui::GetColorU32(ImGuiFullscreen::UISecondaryColor));
+
+		const ImVec2 text_size = ImGui::CalcTextSize(measured_progress.data(), measured_progress.data() + measured_progress.size());
+		const ImVec2 text_pos(progress_bb.Min.x + ((progress_bb.Max.x - progress_bb.Min.x) / 2.0f) - (text_size.x / 2.0f),
+			progress_bb.Min.y + ((progress_bb.Max.y - progress_bb.Min.y) / 2.0f) - (text_size.y / 2.0f));
+		dl->AddText(g_medium_font, g_medium_font->FontSize, text_pos, ImGui::GetColorU32(ImGuiFullscreen::UIPrimaryTextColor),
+			measured_progress.data(), measured_progress.data() + measured_progress.size());
+	}
+
+	ImGui::PopFont();
+}
+
+bool Achievements::PrepareLeaderboardsWindow()
+{
+	auto lock = Achievements::GetLock();
+	rc_client_t* const client = s_client;
+
+	s_achievement_badge_paths = {};
+	CloseLeaderboard();
+	if (s_leaderboard_list)
+		rc_client_destroy_leaderboard_list(s_leaderboard_list);
+	s_leaderboard_list = rc_client_create_leaderboard_list(client, RC_CLIENT_LEADERBOARD_LIST_GROUPING_NONE);
+	if (!s_leaderboard_list)
+	{
+		Console.Error("(Achievements) rc_client_create_leaderboard_list() returned null");
+		return false;
+	}
+
+	return true;
+}
+
+void Achievements::DrawLeaderboardsWindow()
+{
+	using ImGuiFullscreen::g_large_font;
+	using ImGuiFullscreen::g_medium_font;
+	using ImGuiFullscreen::LayoutScale;
+
+	static constexpr float alpha = 0.8f;
+	static constexpr float heading_alpha = 0.95f;
+	static constexpr float heading_height_unscaled = 110.0f;
+	static constexpr float tab_height_unscaled = 50.0f;
+
+	auto lock = Achievements::GetLock();
+
+	// ensure image downloads still happen while we're paused
+	Achievements::IdleUpdate();
+
+	const bool is_leaderboard_open = (s_open_leaderboard != nullptr);
+	bool close_leaderboard_on_exit = false;
+
+	ImRect bb;
+
+	const ImVec4 background(0.13f, 0.13f, 0.13f, alpha);
+	const ImVec4 heading_background(0.13f, 0.13f, 0.13f, heading_alpha);
+	const ImVec2 display_size(ImGui::GetIO().DisplaySize);
+	const float padding = LayoutScale(10.0f);
+	const float spacing = LayoutScale(10.0f);
+	const float spacing_small = spacing / 2.0f;
+	float heading_height = LayoutScale(heading_height_unscaled);
+	if (is_leaderboard_open)
+	{
+		// tabs
+		heading_height += spacing_small + LayoutScale(tab_height_unscaled) + spacing;
+
+		// Add space for a legend - spacing + 1 line of text + spacing + line
+		heading_height += LayoutScale(ImGuiFullscreen::LAYOUT_MENU_BUTTON_HEIGHT_NO_SUMMARY) + spacing;
+	}
+
+	const float rank_column_width =
+		g_large_font->CalcTextSizeA(g_large_font->FontSize, std::numeric_limits<float>::max(), -1.0f, "99999").x;
+	const float name_column_width =
+		g_large_font->CalcTextSizeA(g_large_font->FontSize, std::numeric_limits<float>::max(), -1.0f, "WWWWWWWWWWWWWWWWWWWWWW").x;
+	const float time_column_width =
+		g_large_font->CalcTextSizeA(g_large_font->FontSize, std::numeric_limits<float>::max(), -1.0f, "WWWWWWWWWWW").x;
+	const float column_spacing = spacing * 2.0f;
+
+	if (ImGuiFullscreen::BeginFullscreenWindow(ImVec2(0.0f, 0.0f), ImVec2(display_size.x, heading_height), "leaderboards_heading",
+			heading_background, 0.0f, 0.0f, ImGuiWindowFlags_NoNav | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoScrollWithMouse))
+	{
+		bool visible, hovered;
+		ImGuiFullscreen::MenuButtonFrame(
+			"leaderboards_heading", false, heading_height_unscaled, &visible, &hovered, &bb.Min, &bb.Max, 0, alpha);
+
+		if (visible)
+		{
+			const float image_height = LayoutScale(85.0f);
+
+			const ImVec2 icon_min(bb.Min + ImVec2(padding, padding));
+			const ImVec2 icon_max(icon_min + ImVec2(image_height, image_height));
+
+			if (!s_game_icon.empty())
+			{
+				GSTexture* badge = ImGuiFullscreen::GetCachedTextureAsync(s_game_icon.c_str());
+				if (badge)
+				{
+					ImGui::GetWindowDrawList()->AddImage(
+						badge, icon_min, icon_max, ImVec2(0.0f, 0.0f), ImVec2(1.0f, 1.0f), IM_COL32(255, 255, 255, 255));
+				}
+			}
+
+			float left = bb.Min.x + padding + image_height + spacing;
+			float right = bb.Max.x - padding;
+			float top = bb.Min.y + padding;
+			SmallString text;
+
+			if (!is_leaderboard_open)
+			{
+				if (ImGuiFullscreen::FloatingButton(ICON_FA_WINDOW_CLOSE, 10.0f, 10.0f, -1.0f, -1.0f, 1.0f, 0.0f, true, g_large_font) ||
+					ImGuiFullscreen::WantsToCloseMenu())
+				{
+					FullscreenUI::ReturnToPreviousWindow();
+				}
+			}
+			else
+			{
+				if (ImGuiFullscreen::FloatingButton(
+						ICON_FA_CARET_SQUARE_LEFT, 10.0f, 10.0f, -1.0f, -1.0f, 1.0f, 0.0f, true, g_large_font) ||
+					ImGuiFullscreen::WantsToCloseMenu())
+				{
+					close_leaderboard_on_exit = true;
+				}
+			}
+
+			const ImRect title_bb(ImVec2(left, top), ImVec2(right, top + g_large_font->FontSize));
+			text.assign(Achievements::GetGameTitle());
+
+			top += g_large_font->FontSize + spacing;
+
+			ImGui::PushFont(g_large_font);
+			ImGui::RenderTextClipped(title_bb.Min, title_bb.Max, text.c_str(), text.end_ptr(), nullptr, ImVec2(0.0f, 0.0f), &title_bb);
+			ImGui::PopFont();
+
+			if (is_leaderboard_open)
+			{
+				const ImRect subtitle_bb(ImVec2(left, top), ImVec2(right, top + g_large_font->FontSize));
+				text.assign(s_open_leaderboard->title);
+
+				top += g_large_font->FontSize + spacing_small;
+
+				ImGui::PushFont(g_large_font);
+				ImGui::RenderTextClipped(
+					subtitle_bb.Min, subtitle_bb.Max, text.c_str(), text.end_ptr(), nullptr, ImVec2(0.0f, 0.0f), &subtitle_bb);
+				ImGui::PopFont();
+
+				text.assign(s_open_leaderboard->description);
+			}
+			else
+			{
+				u32 count = 0;
+				for (u32 i = 0; i < s_leaderboard_list->num_buckets; i++)
+					count += s_leaderboard_list->buckets[i].num_leaderboards;
+				text.fmt(TRANSLATE_FS("Achievements", "This game has {} leaderboards."), count);
+			}
+
+			const ImRect summary_bb(ImVec2(left, top), ImVec2(right, top + g_medium_font->FontSize));
+			top += g_medium_font->FontSize + spacing_small;
+
+			ImGui::PushFont(g_medium_font);
+			ImGui::RenderTextClipped(
+				summary_bb.Min, summary_bb.Max, text.c_str(), text.end_ptr(), nullptr, ImVec2(0.0f, 0.0f), &summary_bb);
+
+			if (!is_leaderboard_open && !Achievements::IsHardcoreModeActive())
+			{
+				const ImRect hardcore_warning_bb(ImVec2(left, top), ImVec2(right, top + g_medium_font->FontSize));
+				top += g_medium_font->FontSize + spacing_small;
+
+				ImGui::RenderTextClipped(hardcore_warning_bb.Min, hardcore_warning_bb.Max,
+					TRANSLATE("Achievements", "Submitting scores is disabled because hardcore mode is off. Leaderboards are read-only."),
+					nullptr, nullptr, ImVec2(0.0f, 0.0f), &hardcore_warning_bb);
+			}
+
+			ImGui::PopFont();
+
+			if (is_leaderboard_open)
+			{
+				const float tab_width = (ImGui::GetWindowWidth() / ImGuiFullscreen::g_layout_scale) * 0.5f;
+				ImGui::SetCursorPos(ImVec2(0.0f, top + spacing_small));
+
+				if (ImGui::IsNavInputTest(ImGuiNavInput_FocusPrev, ImGuiNavReadMode_Pressed) ||
+					ImGui::IsNavInputTest(ImGuiNavInput_FocusNext, ImGuiNavReadMode_Pressed))
+				{
+					s_is_showing_all_leaderboard_entries = !s_is_showing_all_leaderboard_entries;
+				}
+
+				for (const bool show_all : {false, true})
+				{
+					const char* title = show_all ? TRANSLATE("Achievements", "Show Best") : TRANSLATE("Achievements", "Show Nearby");
+					if (ImGuiFullscreen::NavTab(title, s_is_showing_all_leaderboard_entries == show_all, true, tab_width,
+							tab_height_unscaled, heading_background))
+					{
+						s_is_showing_all_leaderboard_entries = show_all;
+					}
+				}
+
+				const ImVec2 bg_pos = ImVec2(0.0f, ImGui::GetCurrentWindow()->DC.CursorPos.y + LayoutScale(tab_height_unscaled));
+				const ImVec2 bg_size =
+					ImVec2(ImGui::GetWindowWidth(), spacing + LayoutScale(ImGuiFullscreen::LAYOUT_MENU_BUTTON_HEIGHT_NO_SUMMARY) + spacing);
+				ImGui::GetWindowDrawList()->AddRectFilled(bg_pos, bg_pos + bg_size, ImGui::GetColorU32(heading_background));
+
+				ImGui::SetCursorPos(ImVec2(0.0f, ImGui::GetCursorPosY() + LayoutScale(tab_height_unscaled) + spacing));
+
+				ImGuiFullscreen::MenuButtonFrame(
+					"legend", false, ImGuiFullscreen::LAYOUT_MENU_BUTTON_HEIGHT_NO_SUMMARY, &visible, &hovered, &bb.Min, &bb.Max, 0, alpha);
+
+				const float midpoint = bb.Min.y + g_large_font->FontSize + LayoutScale(4.0f);
+				float text_start_x = bb.Min.x + LayoutScale(15.0f) + padding;
+
+				ImGui::PushFont(g_large_font);
+
+				const ImRect rank_bb(ImVec2(text_start_x, bb.Min.y), ImVec2(bb.Max.x, midpoint));
+				ImGui::RenderTextClipped(
+					rank_bb.Min, rank_bb.Max, TRANSLATE("Achievements", "Rank"), nullptr, nullptr, ImVec2(0.0f, 0.0f), &rank_bb);
+				text_start_x += rank_column_width + column_spacing;
+
+				const ImRect user_bb(ImVec2(text_start_x, bb.Min.y), ImVec2(bb.Max.x, midpoint));
+				ImGui::RenderTextClipped(
+					user_bb.Min, user_bb.Max, TRANSLATE("Achievements", "Name"), nullptr, nullptr, ImVec2(0.0f, 0.0f), &user_bb);
+				text_start_x += name_column_width + column_spacing;
+
+				static const char* value_headings[NUM_RC_CLIENT_LEADERBOARD_FORMATS] = {
+					TRANSLATE_NOOP("Achievements", "Time"),
+					TRANSLATE_NOOP("Achievements", "Score"),
+					TRANSLATE_NOOP("Achievements", "Value"),
+				};
+
+				const ImRect score_bb(ImVec2(text_start_x, bb.Min.y), ImVec2(bb.Max.x, midpoint));
+				ImGui::RenderTextClipped(score_bb.Min, score_bb.Max,
+					Host::TranslateToCString(
+						"Achievements", value_headings[std::min<u8>(s_open_leaderboard->format, NUM_RC_CLIENT_LEADERBOARD_FORMATS - 1)]),
+					nullptr, nullptr, ImVec2(0.0f, 0.0f), &score_bb);
+				text_start_x += time_column_width + column_spacing;
+
+				const ImRect date_bb(ImVec2(text_start_x, bb.Min.y), ImVec2(bb.Max.x, midpoint));
+				ImGui::RenderTextClipped(
+					date_bb.Min, date_bb.Max, TRANSLATE("Achievements", "Date Submitted"), nullptr, nullptr, ImVec2(0.0f, 0.0f), &date_bb);
+
+				ImGui::PopFont();
+
+				const float line_thickness = LayoutScale(1.0f);
+				const float line_padding = LayoutScale(5.0f);
+				const ImVec2 line_start(bb.Min.x, bb.Min.y + g_large_font->FontSize + line_padding);
+				const ImVec2 line_end(bb.Max.x, line_start.y);
+				ImGui::GetWindowDrawList()->AddLine(line_start, line_end, ImGui::GetColorU32(ImGuiCol_TextDisabled), line_thickness);
+			}
+		}
+	}
+	ImGuiFullscreen::EndFullscreenWindow();
+
+	if (!is_leaderboard_open)
+	{
+		if (ImGuiFullscreen::BeginFullscreenWindow(ImVec2(0.0f, heading_height), ImVec2(display_size.x, display_size.y - heading_height),
+				"leaderboards", background, 0.0f, 0.0f, 0))
+		{
+			ImGuiFullscreen::BeginMenuButtons();
+
+			for (u32 bucket_index = 0; bucket_index < s_leaderboard_list->num_buckets; bucket_index++)
+			{
+				const rc_client_leaderboard_bucket_t& bucket = s_leaderboard_list->buckets[bucket_index];
+				for (u32 i = 0; i < bucket.num_leaderboards; i++)
+					DrawLeaderboardListEntry(bucket.leaderboards[i]);
+			}
+
+			ImGuiFullscreen::EndMenuButtons();
+		}
+		ImGuiFullscreen::EndFullscreenWindow();
+	}
+	else
+	{
+		if (ImGuiFullscreen::BeginFullscreenWindow(ImVec2(0.0f, heading_height), ImVec2(display_size.x, display_size.y - heading_height),
+				"leaderboard", background, 0.0f, 0.0f, 0))
+		{
+			ImGuiFullscreen::BeginMenuButtons();
+
+			if (!s_is_showing_all_leaderboard_entries)
+			{
+				if (s_leaderboard_nearby_entries)
+				{
+					for (u32 i = 0; i < s_leaderboard_nearby_entries->num_entries; i++)
+					{
+						DrawLeaderboardEntry(s_leaderboard_nearby_entries->entries[i],
+							static_cast<s32>(i) == s_leaderboard_nearby_entries->user_index, rank_column_width, name_column_width,
+							time_column_width, column_spacing);
+					}
+				}
+				else
+				{
+					ImGui::PushFont(g_large_font);
+
+					const ImVec2 pos_min(0.0f, heading_height);
+					const ImVec2 pos_max(display_size.x, display_size.y);
+					ImGui::RenderTextClipped(pos_min, pos_max, TRANSLATE("Achievements", "Downloading leaderboard data, please wait..."),
+						nullptr, nullptr, ImVec2(0.5f, 0.5f));
+
+					ImGui::PopFont();
+				}
+			}
+			else
+			{
+				for (const rc_client_leaderboard_entry_list_t* list : s_leaderboard_entry_lists)
+				{
+					for (u32 i = 0; i < list->num_entries; i++)
+					{
+						DrawLeaderboardEntry(list->entries[i], static_cast<s32>(i) == list->user_index, rank_column_width,
+							name_column_width, time_column_width, column_spacing);
+					}
+				}
+
+				// Fetch next chunk if the loading indicator becomes visible (i.e. we scrolled enough).
+				bool visible, hovered;
+				ImGuiFullscreen::MenuButtonFrame(TRANSLATE("Achievements", "Loading..."), false,
+					ImGuiFullscreen::LAYOUT_MENU_BUTTON_HEIGHT_NO_SUMMARY, &visible, &hovered, &bb.Min, &bb.Max);
+				if (visible)
+				{
+					const float midpoint = bb.Min.y + g_large_font->FontSize + LayoutScale(4.0f);
+					const ImRect title_bb(bb.Min, ImVec2(bb.Max.x, midpoint));
+
+					ImGui::PushFont(g_large_font);
+					ImGui::RenderTextClipped(
+						title_bb.Min, title_bb.Max, TRANSLATE("Achievements", "Loading..."), nullptr, nullptr, ImVec2(0, 0), &title_bb);
+					ImGui::PopFont();
+
+					if (!s_leaderboard_fetch_handle)
+						FetchNextLeaderboardEntries();
+				}
+			}
+
+			ImGuiFullscreen::EndMenuButtons();
+		}
+		ImGuiFullscreen::EndFullscreenWindow();
+	}
+
+	if (close_leaderboard_on_exit)
+		CloseLeaderboard();
+}
+
+void Achievements::DrawLeaderboardEntry(const rc_client_leaderboard_entry_t& entry, bool is_self, float rank_column_width,
+	float name_column_width, float time_column_width, float column_spacing)
+{
+	using ImGuiFullscreen::g_large_font;
+	using ImGuiFullscreen::LayoutScale;
+
+	static constexpr float alpha = 0.8f;
+
+	ImRect bb;
+	bool visible, hovered;
+	bool pressed = ImGuiFullscreen::MenuButtonFrame(
+		entry.user, true, ImGuiFullscreen::LAYOUT_MENU_BUTTON_HEIGHT_NO_SUMMARY, &visible, &hovered, &bb.Min, &bb.Max, 0, alpha);
+	if (!visible)
+		return;
+
+	const float midpoint = bb.Min.y + g_large_font->FontSize + LayoutScale(4.0f);
+	float text_start_x = bb.Min.x + LayoutScale(15.0f);
+	SmallString text;
+
+	text.fmt("{}", entry.rank);
+
+	ImGui::PushFont(g_large_font);
+
+	if (is_self)
+		ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(255, 242, 0, 255));
+
+	const ImRect rank_bb(ImVec2(text_start_x, bb.Min.y), ImVec2(bb.Max.x, midpoint));
+	ImGui::RenderTextClipped(rank_bb.Min, rank_bb.Max, text.c_str(), text.end_ptr(), nullptr, ImVec2(0.0f, 0.0f), &rank_bb);
+	text_start_x += rank_column_width + column_spacing;
+
+	const float icon_size = bb.Max.y - bb.Min.y;
+	const ImRect icon_bb(ImVec2(text_start_x, bb.Min.y), ImVec2(bb.Max.x, midpoint));
+	GSTexture* icon_tex = nullptr;
+	if (auto it = std::find_if(s_leaderboard_user_icon_paths.begin(), s_leaderboard_user_icon_paths.end(),
+			[&entry](const auto& it) { return it.first == &entry; });
+		it != s_leaderboard_user_icon_paths.end())
+	{
+		if (!it->second.empty())
+			icon_tex = ImGuiFullscreen::GetCachedTextureAsync(it->second.c_str());
+	}
+	else
+	{
+		std::string path = Achievements::GetLeaderboardUserBadgePath(&entry);
+		if (!path.empty())
+		{
+			icon_tex = ImGuiFullscreen::GetCachedTextureAsync(path.c_str());
+			s_leaderboard_user_icon_paths.emplace_back(&entry, std::move(path));
+		}
+	}
+	if (icon_tex)
+	{
+		ImGui::GetWindowDrawList()->AddImage(
+			reinterpret_cast<ImTextureID>(icon_tex), icon_bb.Min, icon_bb.Min + ImVec2(icon_size, icon_size));
+	}
+
+	const ImRect user_bb(ImVec2(text_start_x + column_spacing + icon_size, bb.Min.y), ImVec2(bb.Max.x, midpoint));
+	ImGui::RenderTextClipped(user_bb.Min, user_bb.Max, entry.user, nullptr, nullptr, ImVec2(0.0f, 0.0f), &user_bb);
+	text_start_x += name_column_width + column_spacing;
+
+	const ImRect score_bb(ImVec2(text_start_x, bb.Min.y), ImVec2(bb.Max.x, midpoint));
+	ImGui::RenderTextClipped(score_bb.Min, score_bb.Max, entry.display, nullptr, nullptr, ImVec2(0.0f, 0.0f), &score_bb);
+	text_start_x += time_column_width + column_spacing;
+
+	const ImRect time_bb(ImVec2(text_start_x, bb.Min.y), ImVec2(bb.Max.x, midpoint));
+	const auto submit_time = FullscreenUI::TimeToPrintableString(entry.submitted);
+	ImGui::RenderTextClipped(time_bb.Min, time_bb.Max, submit_time.c_str(), submit_time.end_ptr(), nullptr, ImVec2(0.0f, 0.0f), &time_bb);
+
+	if (is_self)
+		ImGui::PopStyleColor();
+
+	ImGui::PopFont();
+
+	if (pressed)
+	{
+		// Anything?
+	}
+}
+void Achievements::DrawLeaderboardListEntry(const rc_client_leaderboard_t* lboard)
+{
+	using ImGuiFullscreen::g_large_font;
+	using ImGuiFullscreen::g_medium_font;
+	using ImGuiFullscreen::LayoutScale;
+
+	static constexpr float alpha = 0.8f;
+
+	TinyString id_str;
+	id_str.fmt("{}", lboard->id);
+
+	ImRect bb;
+	bool visible, hovered;
+	bool pressed = ImGuiFullscreen::MenuButtonFrame(
+		id_str, true, ImGuiFullscreen::LAYOUT_MENU_BUTTON_HEIGHT, &visible, &hovered, &bb.Min, &bb.Max, 0, alpha);
+	if (!visible)
+		return;
+
+	const float midpoint = bb.Min.y + g_large_font->FontSize + LayoutScale(4.0f);
+	const float text_start_x = bb.Min.x + LayoutScale(15.0f);
+	const ImRect title_bb(ImVec2(text_start_x, bb.Min.y), ImVec2(bb.Max.x, midpoint));
+	const ImRect summary_bb(ImVec2(text_start_x, midpoint), bb.Max);
+
+	ImGui::PushFont(g_large_font);
+	ImGui::RenderTextClipped(title_bb.Min, title_bb.Max, lboard->title, nullptr, nullptr, ImVec2(0.0f, 0.0f), &title_bb);
+	ImGui::PopFont();
+
+	if (lboard->description && lboard->description[0] != '\0')
+	{
+		ImGui::PushFont(g_medium_font);
+		ImGui::RenderTextClipped(summary_bb.Min, summary_bb.Max, lboard->description, nullptr, nullptr, ImVec2(0.0f, 0.0f), &summary_bb);
+		ImGui::PopFont();
+	}
+
+	if (pressed)
+		OpenLeaderboard(lboard);
+}
+
+void Achievements::OpenLeaderboard(const rc_client_leaderboard_t* lboard)
+{
+	Console.WriteLn("(Achievements) Opening leaderboard '%s' (%u)", lboard->title, lboard->id);
+
+	CloseLeaderboard();
+
+	s_open_leaderboard = lboard;
+	s_is_showing_all_leaderboard_entries = false;
+	s_leaderboard_fetch_handle = rc_client_begin_fetch_leaderboard_entries_around_user(
+		s_client, lboard->id, LEADERBOARD_NEARBY_ENTRIES_TO_FETCH, LeaderboardFetchNearbyCallback, nullptr);
+}
+
+void Achievements::LeaderboardFetchNearbyCallback(
+	int result, const char* error_message, rc_client_leaderboard_entry_list_t* list, rc_client_t* client, void* callback_userdata)
+{
+	const auto lock = GetLock();
+
+	s_leaderboard_fetch_handle = nullptr;
+
+	if (result != RC_OK)
+	{
+		ImGuiFullscreen::ShowToast(TRANSLATE("Achievements", "Leaderboard download failed"), error_message);
+		CloseLeaderboard();
+		return;
+	}
+
+	if (s_leaderboard_nearby_entries)
+		rc_client_destroy_leaderboard_entry_list(s_leaderboard_nearby_entries);
+	s_leaderboard_nearby_entries = list;
+}
+
+void Achievements::LeaderboardFetchAllCallback(
+	int result, const char* error_message, rc_client_leaderboard_entry_list_t* list, rc_client_t* client, void* callback_userdata)
+{
+	const auto lock = GetLock();
+
+	s_leaderboard_fetch_handle = nullptr;
+
+	if (result != RC_OK)
+	{
+		ImGuiFullscreen::ShowToast(TRANSLATE("Achievements", "Leaderboard download failed"), error_message);
+		CloseLeaderboard();
+		return;
+	}
+
+	s_leaderboard_entry_lists.push_back(list);
+}
+
+void Achievements::FetchNextLeaderboardEntries()
+{
+	u32 start = 1;
+	for (rc_client_leaderboard_entry_list_t* list : s_leaderboard_entry_lists)
+		start += list->num_entries;
+
+	Console.WriteLn("(Achievements) Fetching entries %u to %u", start, start + LEADERBOARD_ALL_FETCH_SIZE);
+
+	if (s_leaderboard_fetch_handle)
+		rc_client_abort_async(s_client, s_leaderboard_fetch_handle);
+	s_leaderboard_fetch_handle = rc_client_begin_fetch_leaderboard_entries(
+		s_client, s_open_leaderboard->id, start, LEADERBOARD_ALL_FETCH_SIZE, LeaderboardFetchAllCallback, nullptr);
+}
+
+void Achievements::CloseLeaderboard()
+{
+	s_leaderboard_user_icon_paths.clear();
+
+	for (auto iter = s_leaderboard_entry_lists.rbegin(); iter != s_leaderboard_entry_lists.rend(); ++iter)
+		rc_client_destroy_leaderboard_entry_list(*iter);
+	s_leaderboard_entry_lists.clear();
+
+	if (s_leaderboard_nearby_entries)
+	{
+		rc_client_destroy_leaderboard_entry_list(s_leaderboard_nearby_entries);
+		s_leaderboard_nearby_entries = nullptr;
+	}
+
+	if (s_leaderboard_fetch_handle)
+	{
+		rc_client_abort_async(s_client, s_leaderboard_fetch_handle);
+		s_leaderboard_fetch_handle = nullptr;
+	}
+
+	s_open_leaderboard = nullptr;
 }
 
 #ifdef ENABLE_RAINTEGRATION
@@ -2181,13 +2882,14 @@ namespace Achievements::RAIntegration
 	static bool s_raintegration_initialized = false;
 } // namespace Achievements::RAIntegration
 
+bool Achievements::IsUsingRAIntegration()
+{
+	return s_using_raintegration;
+}
+
 void Achievements::SwitchToRAIntegration()
 {
 	s_using_raintegration = true;
-	s_active = true;
-
-	// Not strictly the case, but just in case we gate anything by IsLoggedIn().
-	s_logged_in = true;
 }
 
 void Achievements::RAIntegration::InitializeRAIntegration(void* main_window_handle)
@@ -2262,19 +2964,24 @@ void Achievements::RAIntegration::ActivateMenuItem(int item)
 
 int Achievements::RAIntegration::RACallbackIsActive()
 {
-	return static_cast<int>(HasActiveGame());
+	return static_cast<int>(VMManager::HasValidVM());
 }
 
 void Achievements::RAIntegration::RACallbackCauseUnpause()
 {
-	if (VMManager::HasValidVM())
-		VMManager::SetState(VMState::Running);
+	Host::RunOnCPUThread([]() {
+		if (VMManager::HasValidVM())
+			if (VMManager::HasValidVM())
+				VMManager::SetState(VMState::Running);
+	});
 }
 
 void Achievements::RAIntegration::RACallbackCausePause()
 {
-	if (VMManager::HasValidVM())
-		VMManager::SetState(VMState::Paused);
+	Host::RunOnCPUThread([]() {
+		if (VMManager::HasValidVM())
+			VMManager::SetState(VMState::Paused);
+	});
 }
 
 void Achievements::RAIntegration::RACallbackRebuildMenu()
@@ -2302,18 +3009,46 @@ void Achievements::RAIntegration::RACallbackLoadROM(const char* unused)
 
 unsigned char Achievements::RAIntegration::RACallbackReadMemory(unsigned int address)
 {
-	return static_cast<unsigned char>(PeekMemory(address, sizeof(unsigned char), nullptr));
+	if ((static_cast<u64>(address) + sizeof(unsigned char)) >= EXPOSED_EE_MEMORY_SIZE)
+	{
+		DevCon.Warning("[Achievements] Ignoring out of bounds memory peek at %08X.", address);
+		return 0u;
+	}
+
+	unsigned char value;
+	std::memcpy(&value, reinterpret_cast<u8*>(eeMem) + address, sizeof(value));
+	return value;
 }
 
 unsigned int Achievements::RAIntegration::RACallbackReadBlock(unsigned int address, unsigned char* buffer, unsigned int bytes)
 {
-	return PeekMemoryBlock(address, buffer, bytes);
+	if ((address >= EXPOSED_EE_MEMORY_SIZE))
+	{
+		DevCon.Warning("[Achievements] Ignoring out of bounds block memory read for %u bytes at %08X.", bytes, address);
+		return 0u;
+	}
+
+	const unsigned int read_byte_count = std::min<unsigned int>(EXPOSED_EE_MEMORY_SIZE - address, bytes);
+	std::memcpy(buffer, reinterpret_cast<u8*>(eeMem) + address, read_byte_count);
+	return read_byte_count;
 }
 
 void Achievements::RAIntegration::RACallbackWriteMemory(unsigned int address, unsigned char value)
 {
-	PokeMemory(address, sizeof(value), nullptr, static_cast<unsigned>(value));
+	if ((static_cast<u64>(address) + sizeof(value)) >= EXPOSED_EE_MEMORY_SIZE)
+	{
+		DevCon.Warning("[Achievements] Ignoring out of bounds memory poke at %08X (value %08X).", address, value);
+		return;
+	}
+
+	std::memcpy(reinterpret_cast<u8*>(eeMem) + address, &value, sizeof(value));
+}
+
+#else
+
+bool Achievements::IsUsingRAIntegration()
+{
+	return false;
 }
 
 #endif // ENABLE_RAINTEGRATION
-

--- a/pcsx2/Achievements.h
+++ b/pcsx2/Achievements.h
@@ -1,5 +1,5 @@
 /*  PCSX2 - PS2 Emulator for PCs
- *  Copyright (C) 2002-2023  PCSX2 Dev Team
+ *  Copyright (C) 2002-2023 PCSX2 Dev Team
  *
  *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU Lesser General Public License as published by the Free Software Found-
@@ -19,13 +19,12 @@
 
 #include "Config.h"
 
-#include <functional>
 #include <mutex>
-#include <optional>
 #include <string>
-#include <tuple>
 #include <utility>
 #include <vector>
+
+class Error;
 
 namespace Achievements
 {
@@ -35,136 +34,115 @@ namespace Achievements
 		TokenInvalid,
 	};
 
-	enum class AchievementCategory : u8
-	{
-		Local = 0,
-		Core = 3,
-		Unofficial = 5
-	};
-
-	struct Achievement
-	{
-		u32 id;
-		std::string title;
-		std::string description;
-		std::string memaddr;
-		std::string badge_name;
-
-		// badge paths are mutable because they're resolved when they're needed.
-		mutable std::string locked_badge_path;
-		mutable std::string unlocked_badge_path;
-
-		u32 points;
-		AchievementCategory category;
-		bool locked;
-		bool active;
-		bool primed;
-	};
-
-	struct Leaderboard
-	{
-		u32 id;
-		std::string title;
-		std::string description;
-		std::string memaddr;
-		int format;
-		bool active;
-	};
-
-	struct LeaderboardEntry
-	{
-		std::string user;
-		std::string formatted_score;
-		time_t submitted;
-		u32 rank;
-		bool is_self;
-	};
-
-// RAIntegration only exists for Windows, so no point checking it on other platforms.
-#ifdef ENABLE_RAINTEGRATION
-	bool IsUsingRAIntegration();
-#else
-	__fi static bool IsUsingRAIntegration()
-	{
-		return false;
-	}
-#endif
-
-	bool IsActive();
-	bool IsLoggedIn();
-	bool HasSavedCredentials();
-	bool ChallengeModeActive();
-	bool LeaderboardsActive();
-	bool IsTestModeActive();
-	bool IsUnofficialTestModeActive();
-	bool IsRichPresenceEnabled();
-	bool HasActiveGame();
-
-	u32 GetGameID();
-
 	/// Acquires the achievements lock. Must be held when accessing any achievement state from another thread.
 	std::unique_lock<std::recursive_mutex> GetLock();
 
-	void Initialize();
+	/// Initializes the RetroAchievments client.
+	bool Initialize();
+
+	/// Updates achievements settings.
 	void UpdateSettings(const Pcsx2Config::AchievementsOptions& old_config);
 
+	/// Resets the internal state of all achievement tracking. Call on system reset.
+	void ResetClient();
+
 	/// Called when the system is being reset. If it returns false, the reset should be aborted.
-	bool OnReset();
+	bool ConfirmSystemReset();
 
 	/// Called when the system is being shut down. If Shutdown() returns false, the shutdown should be aborted.
-	bool Shutdown();
+	bool Shutdown(bool allow_cancel);
 
 	/// Called when the system is being paused and resumed.
-	void OnPaused(bool paused);
+	void OnVMPaused(bool paused);
 
 	/// Called once a frame at vsync time on the CPU thread.
-	void VSyncUpdate();
+	void FrameUpdate();
 
-	/// Called to process pending HTTP requests when the VM is paused, because otherwise the vsync event won't fire.
-	void ProcessPendingHTTPRequestsFromGSThread();
+	/// Called when the system is paused, because FrameUpdate() won't be getting called.
+	void IdleUpdate();
 
+	/// Saves/loads state.
 	void LoadState(const u8* state_data, u32 state_data_size);
 	std::vector<u8> SaveState();
 
-	/// Returns true if the current game has any achievements or leaderboards.
-	/// Does not need to have the lock held.
-	bool SafeHasAchievementsOrLeaderboards();
+	/// Attempts to log in to RetroAchievements using the specified credentials.
+	/// If the login is successful, the token returned by the server will be saved.
+	bool Login(const char* username, const char* password, Error* error);
 
-	const std::string& GetUsername();
-	const std::string& GetRichPresenceString();
-	std::string SafeGetRichPresenceString();
-
-	bool LoginAsync(const char* username, const char* password);
-	bool Login(const char* username, const char* password);
-	bool LoginWithTokenAsync(const char* username, const char* api_token);
+	/// Logs out of RetroAchievements, clearing any credentials.
 	void Logout();
 
+	/// Called when the system changes game, or is booting.
 	void GameChanged(u32 disc_crc, u32 crc);
 
+	/// Re-enables hardcode mode if it is enabled in the settings.
+	bool ResetHardcoreMode();
+
+	/// Forces hardcore mode off until next reset.
+	void DisableHardcoreMode();
+
+	/// Prompts the user to disable hardcore mode, if they agree, returns true.
+	bool ConfirmHardcoreModeDisable(const char* trigger);
+
+	/// Returns true if hardcore mode is active, and functionality should be restricted.
+	bool IsHardcoreModeActive();
+
+	/// RAIntegration only exists for Windows, so no point checking it on other platforms.
+	bool IsUsingRAIntegration();
+
+	/// Returns true if the achievement system is active. Achievements can be active without a valid client.
+	bool IsActive();
+
+	/// Returns true if RetroAchievements game data has been loaded.
+	bool HasActiveGame();
+
+	/// Returns the RetroAchievements ID for the current game.
+	u32 GetGameID();
+
+	/// Returns true if the current game has any achievements or leaderboards.
+	bool HasAchievementsOrLeaderboards();
+
+	/// Returns true if the current game has any achievements.
+	bool HasAchievements();
+
+	/// Returns true if the current game has any leaderboards.
+	bool HasLeaderboards();
+
+	/// Returns true if the game supports rich presence.
+	bool HasRichPresence();
+
+	/// Returns the current rich presence string.
+	/// Should be called with the lock held.
+	const std::string& GetRichPresenceString();
+
+	/// Returns the RetroAchievements title for the current game.
+	/// Should be called with the lock held.
 	const std::string& GetGameTitle();
-	const std::string& GetGameIcon();
 
-	bool EnumerateAchievements(std::function<bool(const Achievement&)> callback);
-	u32 GetUnlockedAchiementCount();
-	u32 GetAchievementCount();
-	u32 GetMaximumPointsForGame();
-	u32 GetCurrentPointsForGame();
+	/// Clears all cached state used to render the UI.
+	void ClearUIState();
 
-	bool EnumerateLeaderboards(std::function<bool(const Leaderboard&)> callback);
-	std::optional<bool> TryEnumerateLeaderboardEntries(u32 id, std::function<bool(const LeaderboardEntry&)> callback);
-	const Leaderboard* GetLeaderboardByID(u32 id);
-	u32 GetLeaderboardCount();
-	bool IsLeaderboardTimeType(const Leaderboard& leaderboard);
+	/// Draws ImGui overlays when not paused.
+	void DrawGameOverlays();
 
-	const Achievement* GetAchievementByID(u32 id);
-	std::pair<u32, u32> GetAchievementProgress(const Achievement& achievement);
-	std::string GetAchievementProgressText(const Achievement& achievement);
-	const std::string& GetAchievementBadgePath(
-		const Achievement& achievement, bool download_if_missing = true, bool force_unlocked_icon = false);
-	std::string GetAchievementBadgeURL(const Achievement& achievement);
-	u32 GetPrimedAchievementCount();
+	/// Draws ImGui overlays when paused.
+	void DrawPauseMenuOverlays();
+
+	/// Queries the achievement list, and if no achievements are available, returns false.
+	bool PrepareAchievementsWindow();
+
+	/// Renders the achievement list.
+	void DrawAchievementsWindow();
+
+	/// Queries the leaderboard list, and if no leaderboards are available, returns false.
+	bool PrepareLeaderboardsWindow();
+
+	/// Renders the leaderboard list.
+	void DrawLeaderboardsWindow();
 
 #ifdef ENABLE_RAINTEGRATION
+	/// Prevents the internal implementation from being used. Instead, RAIntegration will be
+	/// called into when achievement-related events occur.
 	void SwitchToRAIntegration();
 
 	namespace RAIntegration
@@ -175,23 +153,21 @@ namespace Achievements
 		void ActivateMenuItem(int item);
 	} // namespace RAIntegration
 #endif
-
-	/// Re-enables hardcode mode if it is enabled in the settings.
-	bool ResetChallengeMode();
-
-	/// Forces hardcore mode off until next reset.
-	void DisableChallengeMode();
-
-	/// Prompts the user to disable hardcore mode, if they agree, returns true.
-	bool ConfirmChallengeModeDisable(const char* trigger);
-
-	/// Returns true if features such as save states should be disabled.
-	bool ChallengeModeActive();
 } // namespace Achievements
 
 /// Functions implemented in the frontend.
 namespace Host
 {
+	/// Called if the big picture UI requests achievements login, or token login fails.
 	void OnAchievementsLoginRequested(Achievements::LoginRequestReason reason);
+
+	/// Called when achievements login completes.
+	void OnAchievementsLoginSuccess(const char* display_name, u32 points, u32 sc_points, u32 unread_messages);
+
+	/// Called whenever game details or rich presence information is updated.
+	/// Implementers can assume the lock is held when this is called.
 	void OnAchievementsRefreshed();
+
+	/// Called whenever hardcore mode is toggled.
+	void OnAchievementsHardcoreModeChanged(bool enabled);
 } // namespace Host

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -1243,33 +1243,32 @@ struct Pcsx2Config
 
 	struct AchievementsOptions
 	{
+		static constexpr u32 MINIMUM_NOTIFICATION_DURATION = 3;
+		static constexpr u32 MAXIMUM_NOTIFICATION_DURATION = 30;
+		static constexpr u32 DEFAULT_NOTIFICATION_DURATION = 5;
+		static constexpr u32 DEFAULT_LEADERBOARD_DURATION = 10;
+
 		BITFIELD32()
 		bool
 			Enabled : 1,
-			TestMode : 1,
+			HardcoreMode : 1,
+			EncoreMode : 1,
+			SpectatorMode : 1,
 			UnofficialTestMode : 1,
-			RichPresence : 1,
-			ChallengeMode : 1,
-			Leaderboards : 1,
 			Notifications : 1,
+			LeaderboardNotifications : 1,
 			SoundEffects : 1,
-			PrimedIndicators : 1;
+			Overlays : 1;
 		BITFIELD_END
 
-		s32 NotificationsDuration = 5;
+		u32 NotificationsDuration = DEFAULT_NOTIFICATION_DURATION;
+		u32 LeaderboardsDuration = DEFAULT_LEADERBOARD_DURATION;
 
 		AchievementsOptions();
 		void LoadSave(SettingsWrapper& wrap);
 
-		bool operator==(const AchievementsOptions& right) const
-		{
-			return OpEqu(bitset) && OpEqu(NotificationsDuration);
-		}
-
-		bool operator!=(const AchievementsOptions& right) const
-		{
-			return !this->operator==(right);
-		}
+		bool operator==(const AchievementsOptions& right) const;
+		bool operator!=(const AchievementsOptions& right) const;
 	};
 
 	// ------------------------------------------------------------------------

--- a/pcsx2/Hotkeys.cpp
+++ b/pcsx2/Hotkeys.cpp
@@ -40,7 +40,7 @@ void VMManager::Internal::ResetVMHotkeyState()
 
 static void HotkeyAdjustTargetSpeed(double delta)
 {
-	const double min_speed = Achievements::ChallengeModeActive() ? 1.0 : 0.1;
+	const double min_speed = Achievements::IsHardcoreModeActive() ? 1.0 : 0.1;
 	EmuConfig.EmulationSpeed.NominalScalar = std::max(min_speed, EmuConfig.EmulationSpeed.NominalScalar + delta);
 	if (VMManager::GetLimiterMode() != LimiterModeType::Nominal)
 		VMManager::SetLimiterMode(LimiterModeType::Nominal);

--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -221,7 +221,6 @@ namespace FullscreenUI
 	// Utility
 	//////////////////////////////////////////////////////////////////////////
 	static void ReleaseTexture(std::unique_ptr<GSTexture>& tex);
-	static TinyString TimeToPrintableString(time_t t);
 	static void StartAsyncOp(std::function<void(::ProgressCallback*)> callback, std::string name);
 	static void AsyncOpThreadEntryPoint(std::function<void(::ProgressCallback*)> callback, FullscreenUI::ProgressCallback* progress);
 	static void CancelAsyncOpWithName(const std::string_view& name);
@@ -232,11 +231,9 @@ namespace FullscreenUI
 	//////////////////////////////////////////////////////////////////////////
 	static void UpdateGameDetails(std::string path, std::string serial, std::string title, u32 disc_crc, u32 crc);
 	static void ToggleTheme();
-	static void PauseForMenuOpen();
+	static void PauseForMenuOpen(bool set_pause_menu_open);
 	static void ClosePauseMenu();
 	static void OpenPauseSubMenu(PauseSubMenu submenu);
-	static void ReturnToPreviousWindow();
-	static void ReturnToMainWindow();
 	static void DrawLandingWindow();
 	static void DrawPauseMenu(MainWindowType type);
 	static void ExitFullscreenAndOpenURL(const std::string_view& url);
@@ -324,7 +321,6 @@ namespace FullscreenUI
 	static void DrawHotkeySettingsPage();
 	static void DrawAchievementsSettingsPage(std::unique_lock<std::mutex>& settings_lock);
 	static void DrawFoldersSettingsPage();
-	static void DrawAchievementsLoginWindow();
 	static void DrawAdvancedSettingsPage();
 	static void DrawPatchesOrCheatsSettingsPage(bool cheats);
 	static void DrawGameFixesSettingsPage();
@@ -483,17 +479,7 @@ namespace FullscreenUI
 	// Achievements
 	//////////////////////////////////////////////////////////////////////////
 	static void SwitchToAchievementsWindow();
-	static void DrawAchievementsWindow();
-	static void DrawAchievement(const Achievements::Achievement& cheevo);
-	static void DrawPrimedAchievementsIcons();
-	static void DrawPrimedAchievementsList();
 	static void SwitchToLeaderboardsWindow();
-	static void DrawLeaderboardsWindow();
-	static void DrawLeaderboardListEntry(const Achievements::Leaderboard& lboard);
-	static void DrawLeaderboardEntry(
-		const Achievements::LeaderboardEntry& lbEntry, float rank_column_width, float name_column_width, float column_spacing);
-
-	static std::optional<u32> s_open_leaderboard_id;
 } // namespace FullscreenUI
 
 //////////////////////////////////////////////////////////////////////////
@@ -727,13 +713,13 @@ void FullscreenUI::ToggleTheme()
 	ImGuiFullscreen::SetTheme(new_light);
 }
 
-void FullscreenUI::PauseForMenuOpen()
+void FullscreenUI::PauseForMenuOpen(bool set_pause_menu_open)
 {
 	s_was_paused_on_quick_menu_open = (VMManager::GetState() == VMState::Paused);
 	if (Host::GetBoolSettingValue("UI", "PauseOnMenu", true) && !s_was_paused_on_quick_menu_open)
 		Host::RunOnCPUThread([]() { VMManager::SetPaused(true); });
 
-	s_pause_menu_was_open = true;
+	s_pause_menu_was_open |= set_pause_menu_open;
 }
 
 void FullscreenUI::OpenPauseMenu()
@@ -745,7 +731,7 @@ void FullscreenUI::OpenPauseMenu()
 		if (!ImGuiManager::InitializeFullscreenUI() || s_current_main_window != MainWindowType::None)
 			return;
 
-		PauseForMenuOpen();
+		PauseForMenuOpen(true);
 		s_current_main_window = MainWindowType::PauseMenu;
 		s_current_pause_submenu = PauseSubMenu::None;
 		QueueResetFocus();
@@ -821,11 +807,8 @@ void FullscreenUI::Render()
 	ImGuiFullscreen::BeginLayout();
 
 	// Primed achievements must come first, because we don't want the pause screen to be behind them.
-	if (EmuConfig.Achievements.PrimedIndicators && s_current_main_window == MainWindowType::None &&
-		Achievements::GetPrimedAchievementCount() > 0)
-	{
-		DrawPrimedAchievementsIcons();
-	}
+	if (s_current_main_window == MainWindowType::None && EmuConfig.Achievements.Overlays)
+		Achievements::DrawGameOverlays();
 
 	switch (s_current_main_window)
 	{
@@ -842,10 +825,10 @@ void FullscreenUI::Render()
 			DrawPauseMenu(s_current_main_window);
 			break;
 		case MainWindowType::Achievements:
-			DrawAchievementsWindow();
+			Achievements::DrawAchievementsWindow();
 			break;
 		case MainWindowType::Leaderboards:
-			DrawLeaderboardsWindow();
+			Achievements::DrawLeaderboardsWindow();
 			break;
 		default:
 			break;
@@ -897,27 +880,20 @@ void FullscreenUI::InvalidateCoverCache()
 
 void FullscreenUI::ReturnToPreviousWindow()
 {
-	if (!VMManager::HasValidVM())
-	{
-		SwitchToLanding();
-		return;
-	}
-	else if (s_pause_menu_was_open)
+	if (VMManager::HasValidVM() && s_pause_menu_was_open)
 	{
 		s_current_main_window = MainWindowType::PauseMenu;
 		QueueResetFocus();
 	}
 	else
 	{
-		s_current_main_window = MainWindowType::None;
+		ReturnToMainWindow();
 	}
 }
 
 void FullscreenUI::ReturnToMainWindow()
 {
-	if (s_pause_menu_was_open)
-		ClosePauseMenu();
-
+	ClosePauseMenu();
 	s_current_main_window = VMManager::HasValidVM() ? MainWindowType::None : MainWindowType::Landing;
 }
 
@@ -4849,14 +4825,11 @@ void FullscreenUI::DrawPauseMenu(MainWindowType type)
 					SwitchToGameSettings();
 				}
 
-				if (ActiveButton(FSUI_ICONSTR(ICON_FA_TROPHY, "Achievements"), false,
-						Achievements::HasActiveGame() && Achievements::SafeHasAchievementsOrLeaderboards()))
+				if (ActiveButton(FSUI_ICONSTR(ICON_FA_TROPHY, "Achievements"), false, Achievements::HasAchievementsOrLeaderboards()))
 				{
-					const auto lock = Achievements::GetLock();
-
 					// skip second menu and go straight to cheevos if there's no lbs
-					if (Achievements::GetLeaderboardCount() == 0)
-						SwitchToAchievementsWindow();
+					if (!Achievements::HasLeaderboards())
+						OpenAchievementsWindow();
 					else
 						OpenPauseSubMenu(PauseSubMenu::Achievements);
 				}
@@ -4927,11 +4900,11 @@ void FullscreenUI::DrawPauseMenu(MainWindowType type)
 				if (ActiveButton(FSUI_ICONSTR(ICON_FA_BACKWARD, "Back To Pause Menu"), false) || WantsToCloseMenu())
 					OpenPauseSubMenu(PauseSubMenu::None);
 
-				if (ActiveButton(FSUI_ICONSTR(ICON_FA_TROPHY, "Achievements"), false))
-					SwitchToAchievementsWindow();
+        if (ActiveButton(FSUI_ICONSTR(ICON_FA_TROPHY, "Achievements"), false))
+          OpenAchievementsWindow();
 
-				if (ActiveButton(FSUI_ICONSTR(ICON_FA_STOPWATCH, "Leaderboards"), false))
-					SwitchToLeaderboardsWindow();
+        if (ActiveButton(FSUI_ICONSTR(ICON_FA_STOPWATCH, "Leaderboards"), false))
+          OpenLeaderboardsWindow();
 			}
 			break;
 		}
@@ -4942,8 +4915,8 @@ void FullscreenUI::DrawPauseMenu(MainWindowType type)
 	}
 
 	// Primed achievements must come first, because we don't want the pause screen to be behind them.
-	if (Achievements::GetPrimedAchievementCount() > 0)
-		DrawPrimedAchievementsList();
+	if (Achievements::HasAchievementsOrLeaderboards())
+		Achievements::DrawPauseMenuOverlays();
 }
 
 void FullscreenUI::InitializePlaceholderSaveStateListEntry(SaveStateListEntry* li, s32 slot)
@@ -6476,10 +6449,10 @@ void FullscreenUI::ProgressCallback::SetCancelled()
 		m_cancelled = true;
 }
 
-void FullscreenUI::OpenAchievementsWindow()
+bool FullscreenUI::OpenAchievementsWindow()
 {
 	if (!VMManager::HasValidVM() || !Achievements::IsActive())
-		return;
+		return false;
 
 	MTGS::RunOnGSThread([]() {
 		if (!ImGuiManager::InitializeFullscreenUI())
@@ -6487,6 +6460,13 @@ void FullscreenUI::OpenAchievementsWindow()
 
 		SwitchToAchievementsWindow();
 	});
+
+	return true;
+}
+
+bool FullscreenUI::IsAchievementsWindowOpen()
+{
+	return (s_current_main_window == MainWindowType::Achievements);
 }
 
 void FullscreenUI::SwitchToAchievementsWindow()
@@ -6494,388 +6474,26 @@ void FullscreenUI::SwitchToAchievementsWindow()
 	if (!VMManager::HasValidVM())
 		return;
 
-	if (!Achievements::HasActiveGame() || Achievements::GetAchievementCount() == 0)
+	if (!Achievements::HasAchievements())
 	{
 		ShowToast(std::string(), FSUI_STR("This game has no achievements."));
 		return;
 	}
 
+	if (!Achievements::PrepareAchievementsWindow())
+		return;
+
 	if (s_current_main_window != MainWindowType::PauseMenu)
-		PauseForMenuOpen();
+		PauseForMenuOpen(false);
 
 	s_current_main_window = MainWindowType::Achievements;
 	QueueResetFocus();
 }
 
-void FullscreenUI::DrawAchievement(const Achievements::Achievement& cheevo)
-{
-	static constexpr float alpha = 0.8f;
-	static constexpr float progress_height_unscaled = 20.0f;
-	static constexpr float progress_spacing_unscaled = 5.0f;
-
-	std::string id_str(fmt::format("chv_{}", cheevo.id));
-
-	const auto progress = Achievements::GetAchievementProgress(cheevo);
-	const bool is_measured = progress.second != 0;
-
-	ImRect bb;
-	bool visible, hovered;
-	bool pressed = MenuButtonFrame(id_str.c_str(), true,
-		!is_measured ? LAYOUT_MENU_BUTTON_HEIGHT : LAYOUT_MENU_BUTTON_HEIGHT + progress_height_unscaled + progress_spacing_unscaled,
-		&visible, &hovered, &bb.Min, &bb.Max, 0, alpha);
-	if (!visible)
-		return;
-
-	const ImVec2 image_size(LayoutScale(LAYOUT_MENU_BUTTON_HEIGHT, LAYOUT_MENU_BUTTON_HEIGHT));
-	const std::string& badge_path = Achievements::GetAchievementBadgePath(cheevo);
-	if (!badge_path.empty())
-	{
-		GSTexture* badge = GetCachedTextureAsync(badge_path.c_str());
-		if (badge)
-		{
-			ImGui::GetWindowDrawList()->AddImage(badge->GetNativeHandle(), bb.Min, bb.Min + image_size, ImVec2(0.0f, 0.0f),
-				ImVec2(1.0f, 1.0f), IM_COL32(255, 255, 255, 255));
-		}
-	}
-
-	const float midpoint = bb.Min.y + g_large_font->FontSize + LayoutScale(4.0f);
-	// TODO: needs plural
-	TinyString points_text;
-	if (cheevo.points == 1)
-		points_text = FSUI_VSTR("1 point");
-	else
-		points_text.fmt(FSUI_FSTR("{} points"), cheevo.points);
-	const ImVec2 points_template_size(g_medium_font->CalcTextSizeA(g_medium_font->FontSize, FLT_MAX, 0.0f, FSUI_CSTR("XXX points")));
-	const ImVec2 points_size(g_medium_font->CalcTextSizeA(
-		g_medium_font->FontSize, FLT_MAX, 0.0f, points_text.c_str(), points_text.c_str() + points_text.length()));
-	const float points_template_start = bb.Max.x - points_template_size.x;
-	const float points_start = points_template_start + ((points_template_size.x - points_size.x) * 0.5f);
-	const char* lock_text = cheevo.locked ? ICON_FA_LOCK : ICON_FA_LOCK_OPEN;
-	const ImVec2 lock_size(g_large_font->CalcTextSizeA(g_large_font->FontSize, FLT_MAX, 0.0f, lock_text));
-
-	const float text_start_x = bb.Min.x + image_size.x + LayoutScale(15.0f);
-	const ImRect title_bb(ImVec2(text_start_x, bb.Min.y), ImVec2(points_start, midpoint));
-	const ImRect summary_bb(ImVec2(text_start_x, midpoint), ImVec2(points_start, bb.Max.y));
-	const ImRect points_bb(ImVec2(points_start, midpoint), bb.Max);
-	const ImRect lock_bb(
-		ImVec2(points_template_start + ((points_template_size.x - lock_size.x) * 0.5f), bb.Min.y), ImVec2(bb.Max.x, midpoint));
-
-	ImGui::PushFont(g_large_font);
-	ImGui::RenderTextClipped(title_bb.Min, title_bb.Max, cheevo.title.c_str(), cheevo.title.c_str() + cheevo.title.size(), nullptr,
-		ImVec2(0.0f, 0.0f), &title_bb);
-	ImGui::RenderTextClipped(lock_bb.Min, lock_bb.Max, lock_text, nullptr, &lock_size, ImVec2(0.0f, 0.0f), &lock_bb);
-	ImGui::PopFont();
-
-	ImGui::PushFont(g_medium_font);
-	if (!cheevo.description.empty())
-	{
-		ImGui::RenderTextClipped(summary_bb.Min, summary_bb.Max, cheevo.description.c_str(),
-			cheevo.description.c_str() + cheevo.description.size(), nullptr, ImVec2(0.0f, 0.0f), &summary_bb);
-	}
-	ImGui::RenderTextClipped(points_bb.Min, points_bb.Max, points_text.c_str(), points_text.c_str() + points_text.length(), &points_size,
-		ImVec2(0.0f, 0.0f), &points_bb);
-	ImGui::PopFont();
-
-	if (is_measured)
-	{
-		ImDrawList* dl = ImGui::GetWindowDrawList();
-		const float progress_height = LayoutScale(progress_height_unscaled);
-		const float progress_spacing = LayoutScale(progress_spacing_unscaled);
-		const float top = midpoint + g_medium_font->FontSize + progress_spacing;
-		const ImRect progress_bb(ImVec2(text_start_x, top), ImVec2(bb.Max.x, top + progress_height));
-		const float fraction = static_cast<float>(progress.first) / static_cast<float>(progress.second);
-		dl->AddRectFilled(progress_bb.Min, progress_bb.Max, ImGui::GetColorU32(ImGuiFullscreen::UIPrimaryDarkColor));
-		dl->AddRectFilled(progress_bb.Min, ImVec2(progress_bb.Min.x + fraction * progress_bb.GetWidth(), progress_bb.Max.y),
-			ImGui::GetColorU32(ImGuiFullscreen::UISecondaryColor));
-
-		const std::string text(Achievements::GetAchievementProgressText(cheevo));
-		const ImVec2 text_size = ImGui::CalcTextSize(text.c_str());
-		const ImVec2 text_pos(progress_bb.Min.x + ((progress_bb.Max.x - progress_bb.Min.x) / 2.0f) - (text_size.x / 2.0f),
-			progress_bb.Min.y + ((progress_bb.Max.y - progress_bb.Min.y) / 2.0f) - (text_size.y / 2.0f));
-		dl->AddText(g_medium_font, g_medium_font->FontSize, text_pos, ImGui::GetColorU32(ImGuiFullscreen::UIPrimaryTextColor), text.c_str(),
-			text.c_str() + text.size());
-	}
-
-#if 0
-	// The API doesn't seem to send us this :(
-	if (!cheevo.locked)
-	{
-		ImGui::PushFont(g_medium_font);
-
-		const ImRect time_bb(ImVec2(text_start_x, bb.Min.y),
-			ImVec2(bb.Max.x, bb.Min.y + g_medium_font->FontSize + LayoutScale(4.0f)));
-		text.Format("Unlocked 21 Feb, 2019 @ 3:14am");
-		ImGui::RenderTextClipped(time_bb.Min, time_bb.Max, text.GetCharArray(), text.GetCharArray() + text.GetLength(),
-			nullptr, ImVec2(1.0f, 0.0f), &time_bb);
-		ImGui::PopFont();
-	}
-#endif
-
-	if (pressed)
-	{
-		// TODO: What should we do here?
-		// Display information or something..
-	}
-}
-
-void FullscreenUI::DrawAchievementsWindow()
-{
-	// ensure image downloads still happen while we're paused
-	Achievements::ProcessPendingHTTPRequestsFromGSThread();
-
-	static constexpr float alpha = 0.8f;
-	static constexpr float heading_height_unscaled = 110.0f;
-
-	ImGui::SetNextWindowBgAlpha(alpha);
-
-	const ImVec4 background(0.13f, 0.13f, 0.13f, alpha);
-	const ImVec2 display_size(ImGui::GetIO().DisplaySize);
-	const float heading_height = LayoutScale(heading_height_unscaled);
-
-	if (BeginFullscreenWindow(ImVec2(0.0f, 0.0f), ImVec2(display_size.x, heading_height), "achievements_heading", background, 0.0f, 0.0f,
-			ImGuiWindowFlags_NoNav | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoScrollWithMouse))
-	{
-		auto lock = Achievements::GetLock();
-
-		ImRect bb;
-		bool visible, hovered;
-		/*bool pressed = */ MenuButtonFrame(
-			"achievements_heading", false, heading_height_unscaled, &visible, &hovered, &bb.Min, &bb.Max, 0, alpha);
-
-		if (visible)
-		{
-			const float padding = LayoutScale(10.0f);
-			const float spacing = LayoutScale(10.0f);
-			const float image_height = LayoutScale(85.0f);
-
-			const ImVec2 icon_min(bb.Min + ImVec2(padding, padding));
-			const ImVec2 icon_max(icon_min + ImVec2(image_height, image_height));
-
-			const std::string& icon_path = Achievements::GetGameIcon();
-			if (!icon_path.empty())
-			{
-				GSTexture* badge = GetCachedTexture(icon_path.c_str());
-				if (badge)
-				{
-					ImGui::GetWindowDrawList()->AddImage(
-						badge->GetNativeHandle(), icon_min, icon_max, ImVec2(0.0f, 0.0f), ImVec2(1.0f, 1.0f), IM_COL32(255, 255, 255, 255));
-				}
-			}
-
-			float left = bb.Min.x + padding + image_height + spacing;
-			float right = bb.Max.x - padding;
-			float top = bb.Min.y + padding;
-			ImDrawList* dl = ImGui::GetWindowDrawList();
-			SmallString text;
-			ImVec2 text_size;
-
-			const u32 unlocked_count = Achievements::GetUnlockedAchiementCount();
-			const u32 achievement_count = Achievements::GetAchievementCount();
-			const u32 current_points = Achievements::GetCurrentPointsForGame();
-			const u32 total_points = Achievements::GetMaximumPointsForGame();
-
-			if (FloatingButton(ICON_FA_WINDOW_CLOSE, 10.0f, 10.0f, -1.0f, -1.0f, 1.0f, 0.0f, true, g_large_font))
-				ReturnToMainWindow();
-			if (WantsToCloseMenu())
-				ReturnToPreviousWindow();
-
-			const ImRect title_bb(ImVec2(left, top), ImVec2(right, top + g_large_font->FontSize));
-
-			if (Achievements::ChallengeModeActive())
-				text.fmt(FSUI_FSTR("{} (Hardcore Mode)"), Achievements::GetGameTitle());
-			else
-				text.assign(Achievements::GetGameTitle());
-
-			top += g_large_font->FontSize + spacing;
-
-			ImGui::PushFont(g_large_font);
-			ImGui::RenderTextClipped(
-				title_bb.Min, title_bb.Max, text.c_str(), text.c_str() + text.length(), nullptr, ImVec2(0.0f, 0.0f), &title_bb);
-			ImGui::PopFont();
-
-			const ImRect summary_bb(ImVec2(left, top), ImVec2(right, top + g_medium_font->FontSize));
-			if (unlocked_count == achievement_count)
-			{
-				text.fmt(FSUI_FSTR("You have unlocked all achievements and earned {} points!"), total_points);
-			}
-			else
-			{
-				text.fmt(FSUI_FSTR("You have unlocked {} of {} achievements, earning {} of {} possible points."), unlocked_count,
-					achievement_count, current_points, total_points);
-			}
-
-			top += g_medium_font->FontSize + spacing;
-
-			ImGui::PushFont(g_medium_font);
-			ImGui::RenderTextClipped(
-				summary_bb.Min, summary_bb.Max, text.c_str(), text.c_str() + text.length(), nullptr, ImVec2(0.0f, 0.0f), &summary_bb);
-			ImGui::PopFont();
-
-			const float progress_height = LayoutScale(20.0f);
-			const ImRect progress_bb(ImVec2(left, top), ImVec2(right, top + progress_height));
-			const float fraction = static_cast<float>(unlocked_count) / static_cast<float>(achievement_count);
-			dl->AddRectFilled(progress_bb.Min, progress_bb.Max, ImGui::GetColorU32(ImGuiFullscreen::UIPrimaryDarkColor));
-			dl->AddRectFilled(progress_bb.Min, ImVec2(progress_bb.Min.x + fraction * progress_bb.GetWidth(), progress_bb.Max.y),
-				ImGui::GetColorU32(ImGuiFullscreen::UISecondaryColor));
-
-			text.fmt("{}%", static_cast<int>(std::round(fraction * 100.0f)));
-			text_size = ImGui::CalcTextSize(text.c_str());
-			const ImVec2 text_pos(progress_bb.Min.x + ((progress_bb.Max.x - progress_bb.Min.x) / 2.0f) - (text_size.x / 2.0f),
-				progress_bb.Min.y + ((progress_bb.Max.y - progress_bb.Min.y) / 2.0f) - (text_size.y / 2.0f));
-			dl->AddText(g_medium_font, g_medium_font->FontSize, text_pos, ImGui::GetColorU32(ImGuiFullscreen::UIPrimaryTextColor),
-				text.c_str(), text.c_str() + text.length());
-			top += progress_height + spacing;
-		}
-	}
-	EndFullscreenWindow();
-
-	ImGui::SetNextWindowBgAlpha(alpha);
-
-	if (BeginFullscreenWindow(ImVec2(0.0f, heading_height), ImVec2(display_size.x, display_size.y - heading_height), "achievements",
-			background, 0.0f, 0.0f, 0))
-	{
-		BeginMenuButtons();
-
-		static bool unlocked_achievements_collapsed = false;
-
-		unlocked_achievements_collapsed ^= MenuHeadingButton(
-			FSUI_CSTR("Unlocked Achievements"), unlocked_achievements_collapsed ? ICON_FA_CHEVRON_DOWN : ICON_FA_CHEVRON_UP);
-		if (!unlocked_achievements_collapsed)
-		{
-			Achievements::EnumerateAchievements([](const Achievements::Achievement& cheevo) -> bool {
-				if (!cheevo.locked)
-					DrawAchievement(cheevo);
-
-				return true;
-			});
-		}
-
-		if (Achievements::GetUnlockedAchiementCount() != Achievements::GetAchievementCount())
-		{
-			static bool locked_achievements_collapsed = false;
-			locked_achievements_collapsed ^= MenuHeadingButton(
-				FSUI_CSTR("Locked Achievements"), locked_achievements_collapsed ? ICON_FA_CHEVRON_DOWN : ICON_FA_CHEVRON_UP);
-			if (!locked_achievements_collapsed)
-			{
-				Achievements::EnumerateAchievements([](const Achievements::Achievement& cheevo) -> bool {
-					if (cheevo.locked)
-						DrawAchievement(cheevo);
-
-					return true;
-				});
-			}
-		}
-
-		EndMenuButtons();
-	}
-	EndFullscreenWindow();
-}
-
-void FullscreenUI::DrawPrimedAchievementsIcons()
-{
-	const ImVec2 image_size(LayoutScale(LAYOUT_MENU_BUTTON_HEIGHT, LAYOUT_MENU_BUTTON_HEIGHT));
-	const float spacing = LayoutScale(10.0f);
-	const float padding = LayoutScale(10.0f);
-
-	const ImGuiIO& io = ImGui::GetIO();
-	const float x_advance = image_size.x + spacing;
-	ImVec2 position(io.DisplaySize.x - padding - image_size.x, io.DisplaySize.y - padding - image_size.y);
-
-	auto lock = Achievements::GetLock();
-	Achievements::EnumerateAchievements([&image_size, &x_advance, &position](const Achievements::Achievement& achievement) {
-		if (!achievement.primed)
-			return true;
-
-		const std::string& badge_path = Achievements::GetAchievementBadgePath(achievement, true, true);
-		if (badge_path.empty())
-			return true;
-
-		GSTexture* badge = GetCachedTextureAsync(badge_path.c_str());
-		if (!badge)
-			return true;
-
-		ImDrawList* dl = ImGui::GetBackgroundDrawList();
-		dl->AddImage(badge->GetNativeHandle(), position, position + image_size);
-		position.x -= x_advance;
-		return true;
-	});
-}
-
-void FullscreenUI::DrawPrimedAchievementsList()
-{
-	auto lock = Achievements::GetLock();
-	const u32 primed_count = Achievements::GetPrimedAchievementCount();
-
-	const ImGuiIO& io = ImGui::GetIO();
-	ImFont* font = g_medium_font;
-
-	const ImVec2 image_size(LayoutScale(LAYOUT_MENU_BUTTON_HEIGHT_NO_SUMMARY, LAYOUT_MENU_BUTTON_HEIGHT_NO_SUMMARY));
-	const float margin = LayoutScale(10.0f);
-	const float spacing = LayoutScale(10.0f);
-	const float padding = LayoutScale(10.0f);
-
-	const float max_text_width = LayoutScale(300.0f);
-	const float row_width = max_text_width + padding + padding + image_size.x + spacing;
-	const float title_height = padding + font->FontSize + padding;
-	const ImVec2 box_min(io.DisplaySize.x - row_width - margin, margin);
-	const ImVec2 box_max(box_min.x + row_width, box_min.y + title_height + (static_cast<float>(primed_count) * (image_size.y + padding)));
-
-	ImDrawList* dl = ImGui::GetBackgroundDrawList();
-	dl->AddRectFilled(box_min, box_max, IM_COL32(0x21, 0x21, 0x21, 200), LayoutScale(10.0f));
-	dl->AddText(font, font->FontSize, ImVec2(box_min.x + padding, box_min.y + padding), IM_COL32(255, 255, 255, 255),
-		FSUI_CSTR("Active Challenge Achievements"));
-
-	const float y_advance = image_size.y + spacing;
-	const float acheivement_name_offset = (image_size.y - font->FontSize) / 2.0f;
-	const float max_non_ellipised_text_width = max_text_width - LayoutScale(10.0f);
-	ImVec2 position(box_min.x + padding, box_min.y + title_height);
-
-	Achievements::EnumerateAchievements([font, &image_size, max_text_width, spacing, y_advance, acheivement_name_offset,
-											max_non_ellipised_text_width, &position](const Achievements::Achievement& achievement) {
-		if (!achievement.primed)
-			return true;
-
-		const std::string& badge_path = Achievements::GetAchievementBadgePath(achievement, true, true);
-		if (badge_path.empty())
-			return true;
-
-		GSTexture* badge = GetCachedTextureAsync(badge_path.c_str());
-		if (!badge)
-			return true;
-
-		ImDrawList* dl = ImGui::GetBackgroundDrawList();
-		dl->AddImage(badge->GetNativeHandle(), position, position + image_size);
-
-		const char* achievement_title = achievement.title.c_str();
-		const char* achievement_tile_end = achievement_title + achievement.title.length();
-		const char* remaining_text = nullptr;
-		const ImVec2 text_width(font->CalcTextSizeA(
-			font->FontSize, max_non_ellipised_text_width, 0.0f, achievement_title, achievement_tile_end, &remaining_text));
-		const ImVec2 text_position(position.x + image_size.x + spacing, position.y + acheivement_name_offset);
-		const ImVec4 text_bbox(text_position.x, text_position.y, text_position.x + max_text_width, text_position.y + image_size.y);
-		const u32 text_color = IM_COL32(255, 255, 255, 255);
-
-		if (remaining_text < achievement_tile_end)
-		{
-			dl->AddText(font, font->FontSize, text_position, text_color, achievement_title, remaining_text, 0.0f, &text_bbox);
-			dl->AddText(font, font->FontSize, ImVec2(text_position.x + text_width.x, text_position.y), text_color, "...", nullptr, 0.0f,
-				&text_bbox);
-		}
-		else
-		{
-			dl->AddText(font, font->FontSize, text_position, text_color, achievement_title, achievement_title + achievement.title.length(),
-				0.0f, &text_bbox);
-		}
-
-		position.y += y_advance;
-		return true;
-	});
-}
-
-void FullscreenUI::OpenLeaderboardsWindow()
+bool FullscreenUI::OpenLeaderboardsWindow()
 {
 	if (!VMManager::HasValidVM() || !Achievements::IsActive())
-		return;
+		return false;
 
 	MTGS::RunOnGSThread([]() {
 		if (!ImGuiManager::InitializeFullscreenUI())
@@ -6883,6 +6501,13 @@ void FullscreenUI::OpenLeaderboardsWindow()
 
 		SwitchToLeaderboardsWindow();
 	});
+
+	return true;
+}
+
+bool FullscreenUI::IsLeaderboardsWindowOpen()
+{
+	return (s_current_main_window == MainWindowType::Leaderboards);
 }
 
 void FullscreenUI::SwitchToLeaderboardsWindow()
@@ -6890,341 +6515,20 @@ void FullscreenUI::SwitchToLeaderboardsWindow()
 	if (!VMManager::HasValidVM())
 		return;
 
-	if (!Achievements::HasActiveGame() || Achievements::GetLeaderboardCount() == 0)
+	if (!Achievements::HasLeaderboards())
 	{
 		ShowToast(std::string(), FSUI_STR("This game has no leaderboards."));
 		return;
 	}
 
+	if (!Achievements::PrepareLeaderboardsWindow())
+		return;
+
 	if (s_current_main_window != MainWindowType::PauseMenu)
-		PauseForMenuOpen();
+		PauseForMenuOpen(false);
 
 	s_current_main_window = MainWindowType::Leaderboards;
-	s_open_leaderboard_id.reset();
 	QueueResetFocus();
-}
-
-void FullscreenUI::DrawLeaderboardListEntry(const Achievements::Leaderboard& lboard)
-{
-	static constexpr float alpha = 0.8f;
-
-	std::string id_str(fmt::format("lb_{}", lboard.id));
-
-	ImRect bb;
-	bool visible, hovered;
-	bool pressed = MenuButtonFrame(id_str.c_str(), true, LAYOUT_MENU_BUTTON_HEIGHT, &visible, &hovered, &bb.Min, &bb.Max, 0, alpha);
-	if (!visible)
-		return;
-
-	const float midpoint = bb.Min.y + g_large_font->FontSize + LayoutScale(4.0f);
-	const float text_start_x = bb.Min.x + LayoutScale(15.0f);
-	const ImRect title_bb(ImVec2(text_start_x, bb.Min.y), ImVec2(bb.Max.x, midpoint));
-	const ImRect summary_bb(ImVec2(text_start_x, midpoint), bb.Max);
-
-	ImGui::PushFont(g_large_font);
-	ImGui::RenderTextClipped(title_bb.Min, title_bb.Max, lboard.title.c_str(), lboard.title.c_str() + lboard.title.size(), nullptr,
-		ImVec2(0.0f, 0.0f), &title_bb);
-	ImGui::PopFont();
-
-	if (!lboard.description.empty())
-	{
-		ImGui::PushFont(g_medium_font);
-		ImGui::RenderTextClipped(summary_bb.Min, summary_bb.Max, lboard.description.c_str(),
-			lboard.description.c_str() + lboard.description.size(), nullptr, ImVec2(0.0f, 0.0f), &summary_bb);
-		ImGui::PopFont();
-	}
-
-	if (pressed)
-	{
-		s_open_leaderboard_id = lboard.id;
-	}
-}
-
-void FullscreenUI::DrawLeaderboardEntry(
-	const Achievements::LeaderboardEntry& lbEntry, float rank_column_width, float name_column_width, float column_spacing)
-{
-	static constexpr float alpha = 0.8f;
-
-	ImRect bb;
-	bool visible, hovered;
-	bool pressed =
-		MenuButtonFrame(lbEntry.user.c_str(), true, LAYOUT_MENU_BUTTON_HEIGHT_NO_SUMMARY, &visible, &hovered, &bb.Min, &bb.Max, 0, alpha);
-	if (!visible)
-		return;
-
-	const float midpoint = bb.Min.y + g_large_font->FontSize + LayoutScale(4.0f);
-	float text_start_x = bb.Min.x + LayoutScale(15.0f);
-	std::string rank_str(fmt::format("{}", lbEntry.rank));
-
-	ImGui::PushFont(g_large_font);
-	if (lbEntry.is_self)
-	{
-		ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(255, 242, 0, 255));
-	}
-
-	const ImRect rank_bb(ImVec2(text_start_x, bb.Min.y), ImVec2(bb.Max.x, midpoint));
-	ImGui::RenderTextClipped(rank_bb.Min, rank_bb.Max, rank_str.c_str(), nullptr, nullptr, ImVec2(0.0f, 0.0f), &rank_bb);
-	text_start_x += rank_column_width + column_spacing;
-
-	const ImRect user_bb(ImVec2(text_start_x, bb.Min.y), ImVec2(bb.Max.x, midpoint));
-	ImGui::RenderTextClipped(
-		user_bb.Min, user_bb.Max, lbEntry.user.c_str(), lbEntry.user.c_str() + lbEntry.user.size(), nullptr, ImVec2(0.0f, 0.0f), &user_bb);
-	text_start_x += name_column_width + column_spacing;
-
-	const ImRect score_bb(ImVec2(text_start_x, bb.Min.y), ImVec2(bb.Max.x, midpoint));
-	ImGui::RenderTextClipped(score_bb.Min, score_bb.Max, lbEntry.formatted_score.c_str(),
-		lbEntry.formatted_score.c_str() + lbEntry.formatted_score.size(), nullptr, ImVec2(0.0f, 0.0f), &score_bb);
-
-	if (lbEntry.is_self)
-	{
-		ImGui::PopStyleColor();
-	}
-
-	ImGui::PopFont();
-
-	// This API DOES list the submission date/time, but is it relevant?
-#if 0
-	if (!cheevo.locked)
-	{
-		ImGui::PushFont(g_medium_font);
-
-		const ImRect time_bb(ImVec2(text_start_x, bb.Min.y),
-			ImVec2(bb.Max.x, bb.Min.y + g_medium_font->FontSize + LayoutScale(4.0f)));
-		text.Format("Unlocked 21 Feb, 2019 @ 3:14am");
-		ImGui::RenderTextClipped(time_bb.Min, time_bb.Max, text.GetCharArray(), text.GetCharArray() + text.GetLength(),
-			nullptr, ImVec2(1.0f, 0.0f), &time_bb);
-		ImGui::PopFont();
-	}
-#endif
-
-	if (pressed)
-	{
-		// Anything?
-	}
-}
-
-void FullscreenUI::DrawLeaderboardsWindow()
-{
-	static constexpr float alpha = 0.8f;
-	static constexpr float heading_height_unscaled = 110.0f;
-
-	// ensure image downloads still happen while we're paused
-	Achievements::ProcessPendingHTTPRequestsFromGSThread();
-
-	ImGui::SetNextWindowBgAlpha(alpha);
-
-	const bool is_leaderboard_open = s_open_leaderboard_id.has_value();
-	bool close_leaderboard_on_exit = false;
-
-	const ImVec4 background(0.13f, 0.13f, 0.13f, alpha);
-	const ImVec2 display_size(ImGui::GetIO().DisplaySize);
-	const float padding = LayoutScale(10.0f);
-	const float spacing = LayoutScale(10.0f);
-	const float spacing_small = spacing / 2.0f;
-	float heading_height = LayoutScale(heading_height_unscaled);
-	if (is_leaderboard_open)
-	{
-		// Add space for a legend - spacing + 1 line of text + spacing + line
-		heading_height += spacing + LayoutScale(LAYOUT_MENU_BUTTON_HEIGHT_NO_SUMMARY) + spacing;
-	}
-
-	const float rank_column_width =
-		g_large_font->CalcTextSizeA(g_large_font->FontSize, std::numeric_limits<float>::max(), -1.0f, "99999").x;
-	const float name_column_width =
-		g_large_font->CalcTextSizeA(g_large_font->FontSize, std::numeric_limits<float>::max(), -1.0f, "WWWWWWWWWWWWWWWWWWWW").x;
-	const float column_spacing = spacing * 2.0f;
-
-	if (BeginFullscreenWindow(ImVec2(0.0f, 0.0f), ImVec2(display_size.x, heading_height), "leaderboards_heading", background, 0.0f, 0.0f,
-			ImGuiWindowFlags_NoNav | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoScrollWithMouse))
-	{
-		ImRect bb;
-		bool visible, hovered;
-		/*bool pressed = */
-		MenuButtonFrame("leaderboards_heading", false, heading_height_unscaled, &visible, &hovered, &bb.Min, &bb.Max, 0, alpha);
-
-		if (visible)
-		{
-			const float image_height = LayoutScale(85.0f);
-
-			const ImVec2 icon_min(bb.Min + ImVec2(padding, padding));
-			const ImVec2 icon_max(icon_min + ImVec2(image_height, image_height));
-
-			const std::string& icon_path = Achievements::GetGameIcon();
-			if (!icon_path.empty())
-			{
-				GSTexture* badge = GetCachedTexture(icon_path.c_str());
-				if (badge)
-				{
-					ImGui::GetWindowDrawList()->AddImage(
-						badge->GetNativeHandle(), icon_min, icon_max, ImVec2(0.0f, 0.0f), ImVec2(1.0f, 1.0f), IM_COL32(255, 255, 255, 255));
-				}
-			}
-
-			float left = bb.Min.x + padding + image_height + spacing;
-			float right = bb.Max.x - padding;
-			float top = bb.Min.y + padding;
-
-			const u32 leaderboard_count = Achievements::GetLeaderboardCount();
-
-			if (!is_leaderboard_open)
-			{
-				if (FloatingButton(ICON_FA_WINDOW_CLOSE, 10.0f, 10.0f, -1.0f, -1.0f, 1.0f, 0.0f, true, g_large_font))
-					ReturnToMainWindow();
-				if (WantsToCloseMenu())
-					ReturnToPreviousWindow();
-			}
-			else
-			{
-				if (FloatingButton(ICON_FA_CARET_SQUARE_LEFT, 10.0f, 10.0f, -1.0f, -1.0f, 1.0f, 0.0f, true, g_large_font) ||
-					WantsToCloseMenu())
-				{
-					close_leaderboard_on_exit = true;
-				}
-			}
-
-			const ImRect title_bb(ImVec2(left, top), ImVec2(right, top + g_large_font->FontSize));
-			const std::string& title = Achievements::GetGameTitle();
-
-			top += g_large_font->FontSize + spacing;
-
-			ImGui::PushFont(g_large_font);
-			ImGui::RenderTextClipped(title_bb.Min, title_bb.Max, title.c_str(), nullptr, nullptr, ImVec2(0.0f, 0.0f), &title_bb);
-			ImGui::PopFont();
-
-			SmallString lb_description;
-			if (s_open_leaderboard_id.has_value())
-			{
-				const Achievements::Leaderboard* lboard = Achievements::GetLeaderboardByID(s_open_leaderboard_id.value());
-				if (lboard != nullptr)
-				{
-					const ImRect subtitle_bb(ImVec2(left, top), ImVec2(right, top + g_large_font->FontSize));
-					const std::string& subtitle = lboard->title;
-
-					top += g_large_font->FontSize + spacing_small;
-
-					ImGui::PushFont(g_large_font);
-					ImGui::RenderTextClipped(
-						subtitle_bb.Min, subtitle_bb.Max, subtitle.c_str(), nullptr, nullptr, ImVec2(0.0f, 0.0f), &subtitle_bb);
-					ImGui::PopFont();
-
-					lb_description.assign(lboard->description);
-				}
-			}
-			else
-			{
-				lb_description.fmt(FSUI_FSTR("This game has {} leaderboards."), leaderboard_count);
-			}
-
-			const ImRect summary_bb(ImVec2(left, top), ImVec2(right, top + g_medium_font->FontSize));
-			top += g_medium_font->FontSize + spacing_small;
-
-			ImGui::PushFont(g_medium_font);
-			ImGui::RenderTextClipped(
-				summary_bb.Min, summary_bb.Max, lb_description.c_str(), nullptr, nullptr, ImVec2(0.0f, 0.0f), &summary_bb);
-
-			if (!Achievements::ChallengeModeActive())
-			{
-				const ImRect hardcore_warning_bb(ImVec2(left, top), ImVec2(right, top + g_medium_font->FontSize));
-				top += g_medium_font->FontSize + spacing_small;
-
-				ImGui::RenderTextClipped(hardcore_warning_bb.Min, hardcore_warning_bb.Max,
-					FSUI_CSTR("Submitting scores is disabled because hardcore mode is off. Leaderboards are read-only."), nullptr, nullptr,
-					ImVec2(0.0f, 0.0f), &hardcore_warning_bb);
-			}
-
-			ImGui::PopFont();
-		}
-
-		if (is_leaderboard_open)
-		{
-			/*bool pressed = */
-			MenuButtonFrame("legend", false, LAYOUT_MENU_BUTTON_HEIGHT_NO_SUMMARY, &visible, &hovered, &bb.Min, &bb.Max, 0, alpha);
-
-			if (visible)
-			{
-				const Achievements::Leaderboard* lboard = Achievements::GetLeaderboardByID(s_open_leaderboard_id.value());
-
-				const float midpoint = bb.Min.y + g_large_font->FontSize + LayoutScale(4.0f);
-				float text_start_x = bb.Min.x + LayoutScale(15.0f) + padding;
-
-				ImGui::PushFont(g_large_font);
-
-				const ImRect rank_bb(ImVec2(text_start_x, bb.Min.y), ImVec2(bb.Max.x, midpoint));
-				ImGui::RenderTextClipped(rank_bb.Min, rank_bb.Max, FSUI_CSTR("Rank"), nullptr, nullptr, ImVec2(0.0f, 0.0f), &rank_bb);
-				text_start_x += rank_column_width + column_spacing;
-
-				const ImRect user_bb(ImVec2(text_start_x, bb.Min.y), ImVec2(bb.Max.x, midpoint));
-				ImGui::RenderTextClipped(user_bb.Min, user_bb.Max, FSUI_CSTR("Name"), nullptr, nullptr, ImVec2(0.0f, 0.0f), &user_bb);
-				text_start_x += name_column_width + column_spacing;
-
-				const ImRect score_bb(ImVec2(text_start_x, bb.Min.y), ImVec2(bb.Max.x, midpoint));
-				ImGui::RenderTextClipped(score_bb.Min, score_bb.Max,
-					lboard != nullptr && Achievements::IsLeaderboardTimeType(*lboard) ? FSUI_CSTR("Time") : FSUI_CSTR("Score"), nullptr,
-					nullptr, ImVec2(0.0f, 0.0f), &score_bb);
-
-				ImGui::PopFont();
-
-				const float line_thickness = LayoutScale(1.0f);
-				const float line_padding = LayoutScale(5.0f);
-				const ImVec2 line_start(bb.Min.x, bb.Min.y + g_large_font->FontSize + line_padding);
-				const ImVec2 line_end(bb.Max.x, line_start.y);
-				ImGui::GetWindowDrawList()->AddLine(line_start, line_end, ImGui::GetColorU32(ImGuiCol_TextDisabled), line_thickness);
-			}
-		}
-	}
-	EndFullscreenWindow();
-
-	ImGui::SetNextWindowBgAlpha(alpha);
-
-	if (!is_leaderboard_open)
-	{
-		if (BeginFullscreenWindow(ImVec2(0.0f, heading_height), ImVec2(display_size.x, display_size.y - heading_height), "leaderboards",
-				background, 0.0f, 0.0f, 0))
-		{
-			BeginMenuButtons();
-
-			Achievements::EnumerateLeaderboards([](const Achievements::Leaderboard& lboard) -> bool {
-				DrawLeaderboardListEntry(lboard);
-
-				return true;
-			});
-
-			EndMenuButtons();
-		}
-		EndFullscreenWindow();
-	}
-	else
-	{
-		if (BeginFullscreenWindow(ImVec2(0.0f, heading_height), ImVec2(display_size.x, display_size.y - heading_height), "leaderboard",
-				background, 0.0f, 0.0f, 0))
-		{
-			BeginMenuButtons();
-
-			const auto result = Achievements::TryEnumerateLeaderboardEntries(s_open_leaderboard_id.value(),
-				[rank_column_width, name_column_width, column_spacing](const Achievements::LeaderboardEntry& lbEntry) -> bool {
-					DrawLeaderboardEntry(lbEntry, rank_column_width, name_column_width, column_spacing);
-					return true;
-				});
-
-			if (!result.has_value())
-			{
-				ImGui::PushFont(g_large_font);
-
-				const ImVec2 pos_min(0.0f, heading_height);
-				const ImVec2 pos_max(display_size.x, display_size.y);
-				ImGui::RenderTextClipped(
-					pos_min, pos_max, FSUI_CSTR("Downloading leaderboard data, please wait..."), nullptr, nullptr, ImVec2(0.5f, 0.5f));
-
-				ImGui::PopFont();
-			}
-
-			EndMenuButtons();
-		}
-		EndFullscreenWindow();
-	}
-
-	if (close_leaderboard_on_exit)
-		s_open_leaderboard_id.reset();
 }
 
 void FullscreenUI::DrawAchievementsSettingsPage(std::unique_lock<std::mutex>& settings_lock)
@@ -7250,34 +6554,33 @@ void FullscreenUI::DrawAchievementsSettingsPage(std::unique_lock<std::mutex>& se
 		FSUI_CSTR("When enabled and logged in, PCSX2 will scan for achievements on startup."), "Achievements", "Enabled", false);
 
 	const bool enabled = bsi->GetBoolValue("Achievements", "Enabled", false);
-	const bool challenge = bsi->GetBoolValue("Achievements", "ChallengeMode", false);
 
-	DrawToggleSetting(bsi, FSUI_ICONSTR(ICON_FA_USER_FRIENDS, "Rich Presence"),
-		FSUI_CSTR("When enabled, rich presence information will be collected and sent to the server where supported."), "Achievements",
-		"RichPresence", true, enabled);
 	check_challenge_state |= DrawToggleSetting(bsi, FSUI_ICONSTR(ICON_FA_HARD_HAT, "Hardcore Mode"),
 		FSUI_CSTR(
 			"\"Challenge\" mode for achievements, including leaderboard tracking. Disables save state, cheats, and slowdown functions."),
 		"Achievements", "ChallengeMode", false, enabled);
-	DrawToggleSetting(bsi, FSUI_ICONSTR(ICON_FA_LIST_OL, "Leaderboards"),
-		FSUI_CSTR("Enables tracking and submission of leaderboards in supported games."), "Achievements", "Leaderboards", true,
-		enabled && challenge);
-	DrawToggleSetting(bsi, FSUI_ICONSTR(ICON_FA_INBOX, "Show Notifications"),
+	DrawToggleSetting(bsi, FSUI_ICONSTR(ICON_FA_INBOX, "Achievement Notifications"),
 		FSUI_CSTR("Displays popup messages on events such as achievement unlocks and leaderboard submissions."), "Achievements",
 		"Notifications", true, enabled);
+	DrawToggleSetting(bsi, FSUI_ICONSTR(ICON_FA_LIST_OL, "Leaderboard Notifications"),
+		FSUI_CSTR("Displays popup messages when starting, submitting, or failing a leaderboard challenge."), "Achievements",
+		"LeaderboardNotifications", true, enabled);
 	DrawToggleSetting(bsi, FSUI_ICONSTR(ICON_FA_HEADPHONES, "Sound Effects"),
 		FSUI_CSTR("Plays sound effects for events such as achievement unlocks and leaderboard submissions."), "Achievements",
 		"SoundEffects", true, enabled);
-	DrawToggleSetting(bsi, FSUI_ICONSTR(ICON_FA_MAGIC, "Show Challenge Indicators"),
+	DrawToggleSetting(bsi, FSUI_ICONSTR(ICON_FA_MAGIC, "Enable In-Game Overlays"),
 		FSUI_CSTR("Shows icons in the lower-right corner of the screen when a challenge/primed achievement is active."), "Achievements",
-		"PrimedIndicators", true, enabled);
+		"Overlays", true, enabled);
+	DrawToggleSetting(bsi, FSUI_ICONSTR(ICON_FA_USER_FRIENDS, "Encore Mode"),
+		FSUI_CSTR("When enabled, each session will behave as if no achievements have been unlocked."), "Achievements", "EncoreMode", false,
+		enabled);
+	DrawToggleSetting(bsi, FSUI_ICONSTR(ICON_FA_STETHOSCOPE, "Spectator Mode"),
+		FSUI_CSTR("When enabled, PCSX2 will assume all achievements are locked and not send any unlock notifications to the server."),
+		"Achievements", "SpectatorMode", false, enabled);
 	DrawToggleSetting(bsi, FSUI_ICONSTR(ICON_FA_MEDAL, "Test Unofficial Achievements"),
 		FSUI_CSTR(
 			"When enabled, PCSX2 will list achievements from unofficial sets. These achievements are not tracked by RetroAchievements."),
 		"Achievements", "UnofficialTestMode", false, enabled);
-	DrawToggleSetting(bsi, FSUI_ICONSTR(ICON_FA_STETHOSCOPE, "Test Mode"),
-		FSUI_CSTR("When enabled, PCSX2 will assume all achievements are locked and not send any unlock notifications to the server."),
-		"Achievements", "TestMode", false, enabled);
 
 	// Check for challenge mode just being enabled.
 	if (check_challenge_state && enabled && bsi->GetBoolValue("Achievements", "ChallengeMode", false) && VMManager::HasValidVM())
@@ -7292,26 +6595,19 @@ void FullscreenUI::DrawAchievementsSettingsPage(std::unique_lock<std::mutex>& se
 			});
 	}
 
-	// Potential deadlock here: when we enable achievements, CPU thread reads settings, releases lock, then there's a brief
-	// time when we can progress here and get the setting lock, by the time it goes to read the username out of settings,
-	// we've got it here, but can't get the achievements lock. So only hold one at once.
-	const u64 ts = StringUtil::FromChars<u64>(bsi->GetStringValue("Achievements", "LoginTimestamp", "0")).value_or(0);
-	settings_lock.unlock();
+	if (!IsEditingGameSettings(bsi))
 	{
-		const auto achievements_lock = Achievements::GetLock();
-		if (Achievements::IsActive())
-			Achievements::ProcessPendingHTTPRequestsFromGSThread();
-
 		MenuHeading(FSUI_CSTR("Account"));
-		if (Achievements::HasSavedCredentials())
+		if (bsi->ContainsValue("Achievements", "Token"))
 		{
 			ImGui::PushStyleColor(ImGuiCol_TextDisabled, ImGui::GetStyle().Colors[ImGuiCol_Text]);
-			ActiveButton(TinyString::from_fmt(fmt::runtime(FSUI_ICONSTR(ICON_FA_USER, "Username: {}")), Achievements::GetUsername()), false,
-				false, LAYOUT_MENU_BUTTON_HEIGHT_NO_SUMMARY);
-
-			ActiveButton(TinyString::from_fmt(fmt::runtime(FSUI_ICONSTR(ICON_FA_CLOCK, "Login token generated on {}")),
-							 TimeToPrintableString(static_cast<time_t>(ts))),
-				false, false, LAYOUT_MENU_BUTTON_HEIGHT_NO_SUMMARY);
+			ActiveButton(SmallString::from_fmt(
+							 fmt::runtime(FSUI_ICONSTR(ICON_FA_USER, "Username: {}")), bsi->GetStringValue("Achievements", "Username")),
+				false, false, ImGuiFullscreen::LAYOUT_MENU_BUTTON_HEIGHT_NO_SUMMARY);
+			ActiveButton(SmallString::from_fmt(fmt::runtime(FSUI_ICONSTR(ICON_FA_CLOCK, "Login token generated on {}")),
+							 TimeToPrintableString(static_cast<time_t>(
+								 StringUtil::FromChars<u64>(bsi->GetStringValue("Achievements", "LoginTimestamp", "0")).value_or(0)))),
+				false, false, ImGuiFullscreen::LAYOUT_MENU_BUTTON_HEIGHT_NO_SUMMARY);
 			ImGui::PopStyleColor();
 
 			if (MenuButton(FSUI_ICONSTR(ICON_FA_KEY, "Logout"), FSUI_CSTR("Logs out of RetroAchievements.")))
@@ -7319,117 +6615,46 @@ void FullscreenUI::DrawAchievementsSettingsPage(std::unique_lock<std::mutex>& se
 				Host::RunOnCPUThread([]() { Achievements::Logout(); });
 			}
 		}
-		else if (Achievements::IsActive())
+		else
 		{
 			ActiveButton(FSUI_ICONSTR(ICON_FA_USER, "Not Logged In"), false, false, ImGuiFullscreen::LAYOUT_MENU_BUTTON_HEIGHT_NO_SUMMARY);
 
 			if (MenuButton(FSUI_ICONSTR(ICON_FA_KEY, "Login"), FSUI_CSTR("Logs in to RetroAchievements.")))
-				ImGui::OpenPopup("Achievements Login");
+				Host::OnAchievementsLoginRequested(Achievements::LoginRequestReason::UserInitiated);
+		}
 
-			DrawAchievementsLoginWindow();
+		MenuHeading(FSUI_CSTR("Current Game"));
+		if (Achievements::HasActiveGame())
+		{
+			const auto lock = Achievements::GetLock();
+
+			ImGui::PushStyleColor(ImGuiCol_TextDisabled, ImGui::GetStyle().Colors[ImGuiCol_Text]);
+			ActiveButton(SmallString::from_fmt(fmt::runtime(FSUI_ICONSTR(ICON_FA_BOOKMARK, "Game: {} ({})")), Achievements::GetGameID(),
+							 Achievements::GetGameTitle()),
+				false, false, LAYOUT_MENU_BUTTON_HEIGHT_NO_SUMMARY);
+
+			const std::string& rich_presence_string = Achievements::GetRichPresenceString();
+			if (!rich_presence_string.empty())
+			{
+				ActiveButton(
+					SmallString::from_fmt(ICON_FA_MAP "{}", rich_presence_string), false, false, LAYOUT_MENU_BUTTON_HEIGHT_NO_SUMMARY);
+			}
+			else
+			{
+				ActiveButton(FSUI_ICONSTR(ICON_FA_MAP, "Rich presence inactive or unsupported."), false, false,
+					LAYOUT_MENU_BUTTON_HEIGHT_NO_SUMMARY);
+			}
+
+			ImGui::PopStyleColor();
 		}
 		else
 		{
-			ActiveButton(FSUI_ICONSTR(ICON_FA_USER, "Achievements are disabled."), false, false,
-				ImGuiFullscreen::LAYOUT_MENU_BUTTON_HEIGHT_NO_SUMMARY);
+			ActiveButton(FSUI_ICONSTR(ICON_FA_BAN, "Game not loaded or no RetroAchievements available."), false, false,
+				LAYOUT_MENU_BUTTON_HEIGHT_NO_SUMMARY);
 		}
-	}
-
-	MenuHeading(FSUI_CSTR("Current Game"));
-	if (Achievements::HasActiveGame())
-	{
-		ImGui::PushStyleColor(ImGuiCol_TextDisabled, ImGui::GetStyle().Colors[ImGuiCol_Text]);
-		ActiveButton(TinyString::from_fmt(fmt::runtime(FSUI_ICONSTR(ICON_FA_BOOKMARK, "Game ID: {}")), Achievements::GetGameID()), false,
-			false, LAYOUT_MENU_BUTTON_HEIGHT_NO_SUMMARY);
-		ActiveButton(TinyString::from_fmt(fmt::runtime(FSUI_ICONSTR(ICON_FA_BOOK, "Game Title: {}")), Achievements::GetGameTitle()), false,
-			false, LAYOUT_MENU_BUTTON_HEIGHT_NO_SUMMARY);
-		ActiveButton(TinyString::from_fmt(fmt::runtime(FSUI_ICONSTR(ICON_FA_TROPHY, "Achievements: {} ({} points)")),
-						 Achievements::GetAchievementCount(), Achievements::GetMaximumPointsForGame()),
-			false, false, LAYOUT_MENU_BUTTON_HEIGHT_NO_SUMMARY);
-
-		const std::string& rich_presence_string = Achievements::GetRichPresenceString();
-		if (!rich_presence_string.empty())
-		{
-			ActiveButton(
-				SmallString::from_fmt(ICON_FA_MAP " {}", rich_presence_string), false, false, LAYOUT_MENU_BUTTON_HEIGHT_NO_SUMMARY);
-		}
-		else
-		{
-			ActiveButton(
-				FSUI_ICONSTR(ICON_FA_MAP, "Rich presence inactive or unsupported."), false, false, LAYOUT_MENU_BUTTON_HEIGHT_NO_SUMMARY);
-		}
-
-		ImGui::PopStyleColor();
-	}
-	else
-	{
-		ActiveButton(FSUI_ICONSTR(ICON_FA_BAN, "Game not loaded or no RetroAchievements available."), false, false,
-			LAYOUT_MENU_BUTTON_HEIGHT_NO_SUMMARY);
 	}
 
 	EndMenuButtons();
-
-	settings_lock.lock();
-}
-
-void FullscreenUI::DrawAchievementsLoginWindow()
-{
-	ImGui::SetNextWindowSize(LayoutScale(700.0f, 0.0f));
-	ImGui::SetNextWindowPos(ImGui::GetIO().DisplaySize * 0.5f, ImGuiCond_Always, ImVec2(0.5f, 0.5f));
-
-	ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, LayoutScale(10.0f));
-	ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, LayoutScale(20.0f, 20.0f));
-	ImGui::PushFont(g_large_font);
-
-	bool is_open = true;
-	if (ImGui::BeginPopupModal(FSUI_CSTR("Achievements Login"), &is_open, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize))
-	{
-
-		ImGui::TextWrapped(FSUI_CSTR("Please enter your user name and password for retroachievements.org."));
-		ImGui::NewLine();
-		ImGui::TextWrapped(FSUI_CSTR("Your password will not be saved in PCSX2, an access token will be generated and used instead."));
-
-		ImGui::NewLine();
-
-		static char username[256] = {};
-		static char password[256] = {};
-
-		ImGui::Text(FSUI_CSTR("User Name: "));
-		ImGui::SameLine(LayoutScale(200.0f));
-		ImGui::InputText("##username", username, sizeof(username));
-
-		ImGui::Text(FSUI_CSTR("Password: "));
-		ImGui::SameLine(LayoutScale(200.0f));
-		ImGui::InputText("##password", password, sizeof(password), ImGuiInputTextFlags_Password);
-
-		ImGui::NewLine();
-
-		BeginMenuButtons();
-
-		const bool login_enabled = (std::strlen(username) > 0 && std::strlen(password) > 0);
-
-		if (ActiveButton(FSUI_ICONSTR(ICON_FA_KEY, "Login"), false, login_enabled))
-		{
-			Achievements::LoginAsync(username, password);
-			std::memset(username, 0, sizeof(username));
-			std::memset(password, 0, sizeof(password));
-			ImGui::CloseCurrentPopup();
-		}
-
-		if (ActiveButton(FSUI_ICONSTR(ICON_FA_TIMES, "Cancel"), false))
-		{
-			std::memset(username, 0, sizeof(username));
-			std::memset(password, 0, sizeof(password));
-			ImGui::CloseCurrentPopup();
-		}
-
-		EndMenuButtons();
-
-		ImGui::EndPopup();
-	}
-
-	ImGui::PopFont();
-	ImGui::PopStyleVar(2);
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/pcsx2/ImGui/FullscreenUI.h
+++ b/pcsx2/ImGui/FullscreenUI.h
@@ -1,5 +1,5 @@
 /*  PCSX2 - PS2 Emulator for PCs
- *  Copyright (C) 2002-2022  PCSX2 Dev Team
+ *  Copyright (C) 2002-2023 PCSX2 Dev Team
  *
  *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU Lesser General Public License as published by the Free Software Found-
@@ -14,8 +14,12 @@
  */
 
 #pragma once
+
 #include "common/Pcsx2Defs.h"
 #include "common/ProgressCallback.h"
+#include "common/SmallString.h"
+
+#include <ctime>
 #include <string>
 #include <memory>
 
@@ -31,12 +35,19 @@ namespace FullscreenUI
 	void OnVMDestroyed();
 	void GameChanged(std::string title, std::string path, std::string serial, u32 disc_crc, u32 crc);
 	void OpenPauseMenu();
-	void OpenAchievementsWindow();
-	void OpenLeaderboardsWindow();
+	bool OpenAchievementsWindow();
+	bool OpenLeaderboardsWindow();
+
+	// NOTE: Only call from GS thread.
+	bool IsAchievementsWindowOpen();
+	bool IsLeaderboardsWindowOpen();
+	void ReturnToPreviousWindow();
+	void ReturnToMainWindow();
 
 	void Shutdown(bool clear_state);
 	void Render();
 	void InvalidateCoverCache();
+	TinyString TimeToPrintableString(time_t t);
 
 	class ProgressCallback final : public BaseProgressCallback
 	{

--- a/pcsx2/ImGui/ImGuiFullscreen.cpp
+++ b/pcsx2/ImGui/ImGuiFullscreen.cpp
@@ -90,6 +90,7 @@ namespace ImGuiFullscreen
 	static u32 s_menu_button_index = 0;
 	static u32 s_close_button_state = 0;
 	static bool s_focus_reset_queued = false;
+	static bool s_light_theme = false;
 
 	static LRUCache<std::string, std::shared_ptr<GSTexture>> s_texture_cache(128, true);
 	static std::shared_ptr<GSTexture> s_placeholder_texture;
@@ -152,13 +153,20 @@ namespace ImGuiFullscreen
 	static std::vector<std::string> s_file_selector_filters;
 	static std::vector<FileSelectorItem> s_file_selector_items;
 
+	static constexpr float NOTIFICATION_FADE_IN_TIME = 0.2f;
+	static constexpr float NOTIFICATION_FADE_OUT_TIME = 0.8f;
+
 	struct Notification
 	{
+		std::string key;
 		std::string title;
 		std::string text;
 		std::string badge_path;
 		Common::Timer::Value start_time;
+		Common::Timer::Value move_time;
 		float duration;
+		float target_y;
+		float last_y;
 	};
 
 	static std::vector<Notification> s_notifications;
@@ -1574,6 +1582,88 @@ bool ImGuiFullscreen::NavButton(const char* title, bool is_active, bool enabled 
 	return pressed;
 }
 
+
+bool ImGuiFullscreen::NavTab(const char* title, bool is_active, bool enabled /* = true */, float width, float height,
+	const ImVec4& background, ImFont* font /* = g_large_font */)
+{
+	ImGuiWindow* window = ImGui::GetCurrentWindow();
+	if (window->SkipItems)
+		return false;
+
+	s_menu_button_index++;
+
+	const ImVec2 text_size(font->CalcTextSizeA(font->FontSize, std::numeric_limits<float>::max(), 0.0f, title));
+	const ImVec2 pos(window->DC.CursorPos);
+	const ImVec2 size = ImVec2(((width < 0.0f) ? text_size.x : LayoutScale(width)), LayoutScale(height));
+
+	ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(0.0f, 0.0f));
+	ImGui::ItemSize(ImVec2(size.x, size.y));
+	ImGui::SameLine();
+	ImGui::PopStyleVar();
+
+	ImRect bb(pos, pos + size);
+	const ImGuiID id = window->GetID(title);
+	if (enabled)
+	{
+		// bit contradictory - we don't want this button to be used for *gamepad* navigation, since they're usually
+		// activated with the bumpers and/or the back button.
+		if (!ImGui::ItemAdd(bb, id, nullptr, ImGuiItemFlags_NoNav | ImGuiItemFlags_NoNavDefaultFocus))
+			return false;
+	}
+	else
+	{
+		if (ImGui::IsClippedEx(bb, id))
+			return false;
+	}
+
+	bool held;
+	bool pressed;
+	bool hovered;
+	if (enabled)
+	{
+		pressed = ImGui::ButtonBehavior(bb, id, &hovered, &held, ImGuiButtonFlags_NoNavFocus);
+	}
+	else
+	{
+		pressed = false;
+		held = false;
+		hovered = false;
+	}
+
+	const ImU32 col =
+		hovered ? ImGui::GetColorU32(held ? ImGuiCol_ButtonActive : ImGuiCol_ButtonHovered, 1.0f) :
+				  ImGui::GetColorU32(is_active ? background : ImVec4(background.x, background.y, background.z, 0.5f));
+
+	ImGui::RenderFrame(bb.Min, bb.Max, col, true, 0.0f);
+
+#if 0
+	// This looks a bit rubbish... but left it here if someone thinks they can improve it.
+	if (is_active)
+	{
+		const float line_thickness = LayoutScale(2.0f);
+		ImGui::GetWindowDrawList()->AddLine(ImVec2(bb.Min.x, bb.Max.y - line_thickness),
+			ImVec2(bb.Max.x, bb.Max.y - line_thickness),
+			ImGui::GetColorU32(ImGuiCol_TextDisabled), line_thickness);
+	}
+#endif
+
+	const ImVec2 pad(std::max((size.x - text_size.x) * 0.5f, 0.0f), std::max((size.y - text_size.y) * 0.5f, 0.0f));
+	bb.Min += pad;
+	bb.Max -= pad;
+
+	ImGui::PushStyleColor(
+		ImGuiCol_Text,
+		ImGui::GetColorU32(enabled ? (is_active ? ImGuiCol_Text : ImGuiCol_TextDisabled) : ImGuiCol_ButtonHovered));
+
+	ImGui::PushFont(font);
+	ImGui::RenderTextClipped(bb.Min, bb.Max, title, nullptr, nullptr, ImVec2(0.0f, 0.0f), &bb);
+	ImGui::PopFont();
+
+	ImGui::PopStyleColor();
+
+	return pressed;
+}
+
 void ImGuiFullscreen::PopulateFileSelectorItems()
 {
 	s_file_selector_items.clear();
@@ -2276,14 +2366,42 @@ void ImGuiFullscreen::DrawBackgroundProgressDialogs(ImVec2& position, float spac
 // Notifications
 //////////////////////////////////////////////////////////////////////////
 
-void ImGuiFullscreen::AddNotification(float duration, std::string title, std::string text, std::string image_path)
+void ImGuiFullscreen::AddNotification(std::string key, float duration, std::string title, std::string text,
+	std::string image_path)
 {
+	const Common::Timer::Value current_time = Common::Timer::GetCurrentValue();
+
+	if (!key.empty())
+	{
+		for (auto it = s_notifications.begin(); it != s_notifications.end(); ++it)
+		{
+			if (it->key == key)
+			{
+				it->duration = duration;
+				it->title = std::move(title);
+				it->text = std::move(text);
+				it->badge_path = std::move(image_path);
+
+				// Don't fade it in again
+				const float time_passed =
+					static_cast<float>(Common::Timer::ConvertValueToSeconds(current_time - it->start_time));
+				it->start_time =
+					current_time - Common::Timer::ConvertSecondsToValue(std::min(time_passed, NOTIFICATION_FADE_IN_TIME));
+				return;
+			}
+		}
+	}
+
 	Notification notif;
+	notif.key = std::move(key);
 	notif.duration = duration;
 	notif.title = std::move(title);
 	notif.text = std::move(text);
 	notif.badge_path = std::move(image_path);
-	notif.start_time = Common::Timer::GetCurrentValue();
+	notif.start_time = current_time;
+	notif.move_time = current_time;
+	notif.target_y = -1.0f;
+	notif.last_y = -1.0f;
 	s_notifications.push_back(std::move(notif));
 }
 
@@ -2297,8 +2415,7 @@ void ImGuiFullscreen::DrawNotifications(ImVec2& position, float spacing)
 	if (s_notifications.empty())
 		return;
 
-	static constexpr float EASE_IN_TIME = 0.6f;
-	static constexpr float EASE_OUT_TIME = 0.6f;
+	static constexpr float MOVE_DURATION = 0.5f;
 	const Common::Timer::Value current_time = Common::Timer::GetCurrentValue();
 
 	const float horizontal_padding = ImGuiFullscreen::LayoutScale(20.0f);
@@ -2316,21 +2433,14 @@ void ImGuiFullscreen::DrawNotifications(ImVec2& position, float spacing)
 	ImFont* const title_font = ImGuiFullscreen::g_large_font;
 	ImFont* const text_font = ImGuiFullscreen::g_medium_font;
 
-#if 0
-  static constexpr u32 toast_background_color = IM_COL32(241, 241, 241, 255);
-  static constexpr u32 toast_border_color = IM_COL32(0x88, 0x88, 0x88, 255);
-  static constexpr u32 toast_title_color = IM_COL32(1, 1, 1, 255);
-  static constexpr u32 toast_text_color = IM_COL32(0, 0, 0, 255);
-#else
-	static constexpr u32 toast_background_color = IM_COL32(0x21, 0x21, 0x21, 255);
-	static constexpr u32 toast_border_color = IM_COL32(0x48, 0x48, 0x48, 255);
-	static constexpr u32 toast_title_color = IM_COL32(0xff, 0xff, 0xff, 255);
-	static constexpr u32 toast_text_color = IM_COL32(0xff, 0xff, 0xff, 255);
-#endif
+	const u32 toast_background_color = s_light_theme ? IM_COL32(241, 241, 241, 255) : IM_COL32(0x21, 0x21, 0x21, 255);
+	const u32 toast_border_color = s_light_theme ? IM_COL32(0x88, 0x88, 0x88, 255) : IM_COL32(0x48, 0x48, 0x48, 255);
+	const u32 toast_title_color = s_light_theme ? IM_COL32(1, 1, 1, 255) : IM_COL32(0xff, 0xff, 0xff, 255);
+	const u32 toast_text_color = s_light_theme ? IM_COL32(0, 0, 0, 255) : IM_COL32(0xff, 0xff, 0xff, 255);
 
 	for (u32 index = 0; index < static_cast<u32>(s_notifications.size());)
 	{
-		const Notification& notif = s_notifications[index];
+		Notification& notif = s_notifications[index];
 		const float time_passed = static_cast<float>(Common::Timer::ConvertValueToSeconds(current_time - notif.start_time));
 		if (time_passed >= notif.duration)
 		{
@@ -2338,36 +2448,62 @@ void ImGuiFullscreen::DrawNotifications(ImVec2& position, float spacing)
 			continue;
 		}
 
-		const ImVec2 title_size(text_font->CalcTextSizeA(
-			title_font->FontSize, max_text_width, max_text_width, notif.title.c_str(), notif.title.c_str() + notif.title.size()));
+		const ImVec2 title_size(text_font->CalcTextSizeA(title_font->FontSize, max_text_width, max_text_width,
+			notif.title.c_str(), notif.title.c_str() + notif.title.size()));
 
-		const ImVec2 text_size(text_font->CalcTextSizeA(
-			text_font->FontSize, max_text_width, max_text_width, notif.text.c_str(), notif.text.c_str() + notif.text.size()));
+		const ImVec2 text_size(text_font->CalcTextSizeA(text_font->FontSize, max_text_width, max_text_width,
+			notif.text.c_str(), notif.text.c_str() + notif.text.size()));
 
-		const float box_width =
-			std::max((horizontal_padding * 2.0f) + badge_size + horizontal_spacing + std::max(title_size.x, text_size.x), min_width);
-		const float box_height = std::max((vertical_padding * 2.0f) + title_size.y + vertical_spacing + text_size.y, min_height);
+		const float box_width = std::max(
+			(horizontal_padding * 2.0f) + badge_size + horizontal_spacing + std::max(title_size.x, text_size.x), min_width);
+		const float box_height =
+			std::max((vertical_padding * 2.0f) + title_size.y + vertical_spacing + text_size.y, min_height);
 
-		float x_offset = 0.0f;
-		if (time_passed < EASE_IN_TIME)
+		u8 opacity;
+		if (time_passed < NOTIFICATION_FADE_IN_TIME)
+			opacity = static_cast<u8>((time_passed / NOTIFICATION_FADE_IN_TIME) * 255.0f);
+		else if (time_passed > (notif.duration - NOTIFICATION_FADE_OUT_TIME))
+			opacity = static_cast<u8>(std::min((notif.duration - time_passed) / NOTIFICATION_FADE_OUT_TIME, 1.0f) * 255.0f);
+		else
+			opacity = 255;
+
+		const float expected_y = position.y - ((s_notification_vertical_direction < 0.0f) ? box_height : 0.0f);
+		float actual_y = notif.last_y;
+		if (notif.target_y != expected_y)
 		{
-			const float disp = (box_width + position.x);
-			x_offset = -(disp - (disp * Easing::InBack(time_passed / EASE_IN_TIME)));
+			notif.move_time = current_time;
+			notif.target_y = expected_y;
+			notif.last_y = (notif.last_y < 0.0f) ? expected_y : notif.last_y;
+			actual_y = notif.last_y;
 		}
-		else if (time_passed > (notif.duration - EASE_OUT_TIME))
+		else if (actual_y != expected_y)
 		{
-			const float disp = (box_width + position.x);
-			x_offset = -(disp - (disp * Easing::OutBack((notif.duration - time_passed) / EASE_OUT_TIME)));
+			const float time_since_move =
+				static_cast<float>(Common::Timer::ConvertValueToSeconds(current_time - notif.move_time));
+			if (time_since_move >= MOVE_DURATION)
+			{
+				notif.move_time = current_time;
+				notif.last_y = notif.target_y;
+				actual_y = notif.last_y;
+			}
+			else
+			{
+				const float frac = Easing::OutExpo(time_since_move / MOVE_DURATION);
+				actual_y = notif.last_y - ((notif.last_y - notif.target_y) * frac);
+			}
 		}
 
-		const ImVec2 box_min(position.x + x_offset, position.y - ((s_notification_vertical_direction < 0.0f) ? box_height : 0.0f));
+		const ImVec2 box_min(position.x, actual_y);
 		const ImVec2 box_max(box_min.x + box_width, box_min.y + box_height);
+		const u32 background_color = (toast_background_color & ~IM_COL32_A_MASK) | (opacity << IM_COL32_A_SHIFT);
+		const u32 border_color = (toast_border_color & ~IM_COL32_A_MASK) | (opacity << IM_COL32_A_SHIFT);
 
 		ImDrawList* dl = ImGui::GetForegroundDrawList();
 		dl->AddRectFilled(ImVec2(box_min.x + shadow_size, box_min.y + shadow_size),
-			ImVec2(box_max.x + shadow_size, box_max.y + shadow_size), IM_COL32(20, 20, 20, 180), rounding, ImDrawCornerFlags_All);
-		dl->AddRectFilled(box_min, box_max, toast_background_color, rounding, ImDrawCornerFlags_All);
-		dl->AddRect(box_min, box_max, toast_border_color, rounding, ImDrawCornerFlags_All, ImGuiFullscreen::LayoutScale(1.0f));
+			ImVec2(box_max.x + shadow_size, box_max.y + shadow_size),
+			IM_COL32(20, 20, 20, (180 * opacity) / 255u), rounding, ImDrawCornerFlags_All);
+		dl->AddRectFilled(box_min, box_max, background_color, rounding, ImDrawCornerFlags_All);
+		dl->AddRect(box_min, box_max, border_color, rounding, ImDrawCornerFlags_All, ImGuiFullscreen::LayoutScale(1.0f));
 
 		const ImVec2 badge_min(box_min.x + horizontal_padding, box_min.y + vertical_padding);
 		const ImVec2 badge_max(badge_min.x + badge_size, badge_min.y + badge_size);
@@ -2375,18 +2511,23 @@ void ImGuiFullscreen::DrawNotifications(ImVec2& position, float spacing)
 		{
 			GSTexture* tex = GetCachedTexture(notif.badge_path.c_str());
 			if (tex)
-				dl->AddImage(tex->GetNativeHandle(), badge_min, badge_max);
+			{
+				dl->AddImage(tex, badge_min, badge_max, ImVec2(0.0f, 0.0f), ImVec2(1.0f, 1.0f),
+					IM_COL32(255, 255, 255, opacity));
+			}
 		}
 
 		const ImVec2 title_min(badge_max.x + horizontal_spacing, box_min.y + vertical_padding);
 		const ImVec2 title_max(title_min.x + title_size.x, title_min.y + title_size.y);
-		dl->AddText(title_font, title_font->FontSize, title_min, toast_title_color, notif.title.c_str(),
+		const u32 title_col = (toast_title_color & ~IM_COL32_A_MASK) | (opacity << IM_COL32_A_SHIFT);
+		dl->AddText(title_font, title_font->FontSize, title_min, title_col, notif.title.c_str(),
 			notif.title.c_str() + notif.title.size(), max_text_width);
 
 		const ImVec2 text_min(badge_max.x + horizontal_spacing, title_max.y + vertical_spacing);
 		const ImVec2 text_max(text_min.x + text_size.x, text_min.y + text_size.y);
-		dl->AddText(text_font, text_font->FontSize, text_min, toast_text_color, notif.text.c_str(), notif.text.c_str() + notif.text.size(),
-			max_text_width);
+		const u32 text_col = (toast_text_color & ~IM_COL32_A_MASK) | (opacity << IM_COL32_A_SHIFT);
+		dl->AddText(text_font, text_font->FontSize, text_min, text_col, notif.text.c_str(),
+			notif.text.c_str() + notif.text.size(), max_text_width);
 
 		position.y += s_notification_vertical_direction * (box_height + shadow_size + spacing);
 		index++;
@@ -2434,10 +2575,10 @@ void ImGuiFullscreen::DrawToast()
 	const float spacing = s_toast_title.empty() ? 0.0f : LayoutScale(10.0f);
 	const ImVec2 display_size(ImGui::GetIO().DisplaySize);
 	const ImVec2 title_size(s_toast_title.empty() ? ImVec2(0.0f, 0.0f) :
-                                                    title_font->CalcTextSizeA(title_font->FontSize, FLT_MAX, max_width,
+													title_font->CalcTextSizeA(title_font->FontSize, FLT_MAX, max_width,
 														s_toast_title.c_str(), s_toast_title.c_str() + s_toast_title.length()));
 	const ImVec2 message_size(s_toast_message.empty() ? ImVec2(0.0f, 0.0f) :
-                                                        message_font->CalcTextSizeA(message_font->FontSize, FLT_MAX, max_width,
+														message_font->CalcTextSizeA(message_font->FontSize, FLT_MAX, max_width,
 															s_toast_message.c_str(), s_toast_message.c_str() + s_toast_message.length()));
 	const ImVec2 comb_size(std::max(title_size.x, message_size.x), title_size.y + spacing + message_size.y);
 
@@ -2464,6 +2605,8 @@ void ImGuiFullscreen::DrawToast()
 
 void ImGuiFullscreen::SetTheme(bool light)
 {
+	s_light_theme = light;
+
 	if (!light)
 	{
 		// dark

--- a/pcsx2/ImGui/ImGuiFullscreen.h
+++ b/pcsx2/ImGui/ImGuiFullscreen.h
@@ -213,6 +213,8 @@ namespace ImGuiFullscreen
 		float item_height = LAYOUT_MENU_BUTTON_HEIGHT_NO_SUMMARY);
 	bool NavButton(const char* title, bool is_active, bool enabled = true, float width = -1.0f,
 		float height = LAYOUT_MENU_BUTTON_HEIGHT_NO_SUMMARY, ImFont* font = g_large_font);
+	bool NavTab(const char* title, bool is_active, bool enabled, float width, float height, const ImVec4& background,
+		ImFont* font = g_large_font);
 
 	using FileSelectorCallback = std::function<void(const std::string& path)>;
 	using FileSelectorFilters = std::vector<std::string>;
@@ -253,7 +255,7 @@ namespace ImGuiFullscreen
 	void UpdateBackgroundProgressDialog(const char* str_id, std::string message, s32 min, s32 max, s32 value);
 	void CloseBackgroundProgressDialog(const char* str_id);
 
-	void AddNotification(float duration, std::string title, std::string text, std::string image_path);
+	void AddNotification(std::string key, float duration, std::string title, std::string text, std::string image_path);
 	void ClearNotifications();
 
 	void ShowToast(std::string title, std::string message, float duration = 10.0f);

--- a/pcsx2/Patch.cpp
+++ b/pcsx2/Patch.cpp
@@ -354,7 +354,7 @@ void Patch::EnumeratePnachFiles(const std::string_view& serial, u32 crc, bool ch
 {
 	// Prefer files on disk over the zip.
 	std::vector<std::string> disk_patch_files;
-	if (for_ui || !Achievements::ChallengeModeActive())
+	if (for_ui || !Achievements::IsHardcoreModeActive())
 		disk_patch_files = FindPatchFilesOnDisk(serial, crc, cheats, for_ui);
 
 	if (!disk_patch_files.empty())
@@ -478,7 +478,7 @@ std::string Patch::GetPnachFilename(const std::string_view& serial, u32 crc, boo
 
 void Patch::ReloadEnabledLists()
 {
-	if (EmuConfig.EnableCheats && !Achievements::ChallengeModeActive())
+	if (EmuConfig.EnableCheats && !Achievements::IsHardcoreModeActive())
 		s_enabled_cheats = Host::GetStringListSetting(CHEATS_CONFIG_SECTION, PATCH_ENABLE_CONFIG_KEY);
 	else
 		s_enabled_cheats = {};

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -1431,15 +1431,14 @@ bool Pcsx2Config::PadOptions::Port::operator!=(const PadOptions::Port& right) co
 Pcsx2Config::AchievementsOptions::AchievementsOptions()
 {
 	Enabled = false;
-	TestMode = false;
+	HardcoreMode = false;
+	EncoreMode = false;
+	SpectatorMode = false;
 	UnofficialTestMode = false;
-	RichPresence = true;
-	ChallengeMode = false;
-	Leaderboards = true;
 	Notifications = true;
+	LeaderboardNotifications = true;
 	SoundEffects = true;
-	PrimedIndicators = true;
-	NotificationsDuration = 5;
+	Overlays = true;
 }
 
 void Pcsx2Config::AchievementsOptions::LoadSave(SettingsWrapper& wrap)
@@ -1447,21 +1446,33 @@ void Pcsx2Config::AchievementsOptions::LoadSave(SettingsWrapper& wrap)
 	SettingsWrapSection("Achievements");
 
 	SettingsWrapBitBool(Enabled);
-	SettingsWrapBitBool(TestMode);
+	SettingsWrapBitBoolEx(HardcoreMode, "ChallengeMode");
+	SettingsWrapBitBool(EncoreMode);
+	SettingsWrapBitBool(SpectatorMode);
 	SettingsWrapBitBool(UnofficialTestMode);
-	SettingsWrapBitBool(RichPresence);
-	SettingsWrapBitBool(ChallengeMode);
-	SettingsWrapBitBool(Leaderboards);
 	SettingsWrapBitBool(Notifications);
+	SettingsWrapBitBool(LeaderboardNotifications);
 	SettingsWrapBitBool(SoundEffects);
-	SettingsWrapBitBool(PrimedIndicators);
-	SettingsWrapBitfield(NotificationsDuration);
+	SettingsWrapBitBool(Overlays);
+	SettingsWrapEntry(NotificationsDuration);
+	SettingsWrapEntry(LeaderboardsDuration);
 
 	if (wrap.IsLoading())
 	{
 		//Clamp in case setting was updated manually using the INI
-		NotificationsDuration = std::clamp(NotificationsDuration, 3, 10);
+		NotificationsDuration = std::clamp(NotificationsDuration, MINIMUM_NOTIFICATION_DURATION, MAXIMUM_NOTIFICATION_DURATION);
+		LeaderboardsDuration = std::clamp(LeaderboardsDuration, MINIMUM_NOTIFICATION_DURATION, MAXIMUM_NOTIFICATION_DURATION);
 	}
+}
+
+bool Pcsx2Config::AchievementsOptions::operator==(const AchievementsOptions& right) const
+{
+	return OpEqu(bitset) && OpEqu(NotificationsDuration) && OpEqu(LeaderboardsDuration);
+}
+
+bool Pcsx2Config::AchievementsOptions::operator!=(const AchievementsOptions& right) const
+{
+	return !this->operator==(right);
 }
 
 Pcsx2Config::Pcsx2Config()

--- a/pcsx2/VMManager.h
+++ b/pcsx2/VMManager.h
@@ -102,6 +102,9 @@ namespace VMManager
 	/// Runs the VM until the CPU execution is canceled.
 	void Execute();
 
+	/// Polls input, updates subsystems which are present while paused/inactive.
+	void IdlePollUpdate();
+
 	/// Changes the pause state of the VM, resetting anything needed when unpausing.
 	void SetPaused(bool paused);
 
@@ -215,7 +218,7 @@ namespace VMManager
 	u64 GetSessionPlayedTime();
 
 	/// Called when the rich presence string, provided by RetroAchievements, changes.
-	void UpdateDiscordPresence(const std::string& rich_presence);
+	void UpdateDiscordPresence();
 
 	/// Internal callbacks, implemented in the emu core.
 	namespace Internal

--- a/tests/ctest/common/string_util_tests.cpp
+++ b/tests/ctest/common/string_util_tests.cpp
@@ -113,3 +113,32 @@ TEST(StringUtil, FromCharsIsLocaleIndependent)
 }
 
 #endif
+
+TEST(StringUtil, Ellipsise)
+{
+	ASSERT_EQ(StringUtil::Ellipsise("HelloWorld", 6, "..."), "Hel...");
+	ASSERT_EQ(StringUtil::Ellipsise("HelloWorld", 7, ".."), "Hello..");
+	ASSERT_EQ(StringUtil::Ellipsise("HelloWorld", 20, ".."), "HelloWorld");
+	ASSERT_EQ(StringUtil::Ellipsise("", 20, "..."), "");
+	ASSERT_EQ(StringUtil::Ellipsise("Hello", 10, "..."), "Hello");
+}
+
+TEST(StringUtil, EllipsiseInPlace)
+{
+	std::string s;
+	s = "HelloWorld";
+	StringUtil::EllipsiseInPlace(s, 6, "...");
+	ASSERT_EQ(s, "Hel...");
+	s = "HelloWorld";
+	StringUtil::EllipsiseInPlace(s, 7, "..");
+	ASSERT_EQ(s, "Hello..");
+	s = "HelloWorld";
+	StringUtil::EllipsiseInPlace(s, 20, "..");
+	ASSERT_EQ(s, "HelloWorld");
+	s = "";
+	StringUtil::EllipsiseInPlace(s, 20, "...");
+	ASSERT_EQ(s, "");
+	s = "Hello";
+	StringUtil::EllipsiseInPlace(s, 10, "...");
+	ASSERT_EQ(s, "Hello");
+}

--- a/tests/ctest/core/StubHost.cpp
+++ b/tests/ctest/core/StubHost.cpp
@@ -214,7 +214,15 @@ void Host::OnAchievementsLoginRequested(Achievements::LoginRequestReason reason)
 {
 }
 
+void Host::OnAchievementsLoginSuccess(const char* username, u32 points, u32 sc_points, u32 unread_messages)
+{
+}
+
 void Host::OnAchievementsRefreshed()
+{
+}
+
+void Host::OnAchievementsHardcoreModeChanged(bool enabled)
 {
 }
 


### PR DESCRIPTION
### Description of Changes

Adds new features:

 - Automatic retry of failed requests
 - Leaderboard start/fail notifications
 - On-screen leaderboard trackers
 - Lazy-loaded scrollable leaderboards, viewing both nearest and all
![image](https://github.com/PCSX2/pcsx2/assets/11288319/f65403d0-38e4-4697-8a6d-9aa2fc8f037e)
 - Buckets for achievements (e.g. recently unlocked, almost complete), unlock times
![image](https://github.com/PCSX2/pcsx2/assets/11288319/274b3d6e-440d-4963-9f60-13df7b2edb62)
 - Encore/spectator mode
![image](https://github.com/PCSX2/pcsx2/assets/11288319/3e7e8eff-91a4-4b7b-99da-7313257e660b)
 - Achievement progress indicators
![image](https://github.com/PCSX2/pcsx2/assets/11288319/56473893-3cf3-474c-b05a-e0dacf96a073)

### Rationale behind Changes

New features, less code for us to maintain since the state tracking happens through rcheevos, and consistency across emus.

### Suggested Testing Steps

Hammer achievements.
Make sure RAIntegration still works (I haven't checked that yet).
