### PR TITLE
GIF: Don't check current path for FINISH

### DIFF
--- a/pcsx2/Gif_Unit.h
+++ b/pcsx2/Gif_Unit.h
@@ -839,7 +839,7 @@ struct Gif_Unit
 			FlushToMTGS();
 		}
 
-		if(!checkPaths(true, true, true, true))
+		if(!checkPaths(stat.APATH != 1, stat.APATH != 2, stat.APATH != 3, true))
 			Gif_FinishIRQ();
 
 		//Path3 can rewind the DMA, so we send back the amount we go back!

--- a/pcsx2/MTVU.cpp
+++ b/pcsx2/MTVU.cpp
@@ -403,7 +403,7 @@ void VU_Thread::Get_MTVUChanges()
 		gifUnit.gsFINISH.gsFINISHFired = false;
 		gifUnit.gsFINISH.gsFINISHPending = true;
 
-		if (!gifUnit.checkPaths(true, true, true, true))
+		if (!gifUnit.checkPaths(false, true, true, true))
 			Gif_FinishIRQ();
 	}
 	if (interrupts & InterruptFlagLabel)


### PR DESCRIPTION
### Description of Changes
Don't check current patch when checking busy paths.

### Rationale behind Changes
It's possible the current path may show as busy to be cleared later, but Finish won't recheck, so let's just ignore the current path.

### Suggested Testing Steps
Check SMT Nocturne

Fixes SMT Nocturne loading