### PR TITLE
DEV9: Don't Report Size setting for Hdd size, Instead use file size

### DIFF
--- a/pcsx2-qt/Settings/DEV9SettingsWidget.h
+++ b/pcsx2-qt/Settings/DEV9SettingsWidget.h
@@ -47,12 +47,9 @@ private Q_SLOTS:
 
 	void onHddEnabledChanged(int state);
 	void onHddBrowseFileClicked();
+	void onHddFileTextChange();
 	void onHddFileEdit();
 	void onHddSizeSlide(int i);
-	// Per game only.
-	void onHddSizeSliderContext(const QPoint& pt);
-	void onHddSizeSliderReset(bool checked = false);
-	//
 	void onHddSizeAccessorSpin();
 	void onHddCreateClicked();
 
@@ -72,6 +69,9 @@ private:
 	std::vector<HostEntryUi> ListBaseHostsConfig();
 	void AddNewHostConfig(const HostEntryUi& host);
 	void DeleteHostConfig(int index);
+
+	void UpdateHddSizeUIEnabled();
+	void UpdateHddSizeUIValues();
 
 	SettingsDialog* m_dialog;
 

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -980,12 +980,6 @@ struct Pcsx2Config
 		bool HddEnable{false};
 		std::string HddFile;
 
-		/* The PS2's HDD max size is 2TB
-		 * which is 2^32 * 512 byte sectors
-		 * Note that we don't yet support
-		 * 48bit LBA, so our limit is lower */
-		uint HddSizeSectors{40 * (1024 * 1024 * 1024 / 512)};
-
 		DEV9Options();
 
 		void LoadSave(SettingsWrapper& wrap);
@@ -1011,8 +1005,7 @@ struct Pcsx2Config
 				   OpEqu(EthHosts) &&
 
 				   OpEqu(HddEnable) &&
-				   OpEqu(HddFile) &&
-				   OpEqu(HddSizeSectors);
+				   OpEqu(HddFile);
 		}
 
 		bool operator!=(const DEV9Options& right) const

--- a/pcsx2/DEV9/ATA/ATA_Info.cpp
+++ b/pcsx2/DEV9/ATA/ATA_Info.cpp
@@ -46,6 +46,11 @@ void ATA::WritePaddedString(u8* data, int* index, const std::string& value, u32 
 
 void ATA::CreateHDDinfo(u64 sizeSectors)
 {
+	//PS2 is limited to 32bit size HDD (2TB), however,
+	//we don't yet support 48bit, so limit to 24bit size
+	constexpr u32 maxSize = 1 << 24;
+	sizeSectors = std::min<u32>(sizeSectors, maxSize);
+
 	constexpr u16 sectorSize = 512;
 	DevCon.WriteLn("DEV9: HddSize : %i", sizeSectors * sectorSize / (1024 * 1024));
 	const u64 nbSectors = sizeSectors;

--- a/pcsx2/DEV9/ATA/ATA_State.cpp
+++ b/pcsx2/DEV9/ATA/ATA_State.cpp
@@ -54,8 +54,6 @@ int ATA::Open(const std::string& hddPath)
 	readBufferLen = 256 * 512;
 	readBuffer = new u8[readBufferLen];
 
-	CreateHDDinfo(EmuConfig.DEV9.HddSizeSectors);
-
 	//Open File
 	if (!FileSystem::FileExists(hddPath.c_str()))
 		return -1;
@@ -68,8 +66,9 @@ int ATA::Open(const std::string& hddPath)
 		return -1;
 	}
 
-	//Store HddImage size for later check
+	//Store HddImage size for later use
 	hddImageSize = static_cast<u64>(size);
+	CreateHDDinfo(hddImageSize / 512);
 
 	InitSparseSupport(hddPath);
 
@@ -560,7 +559,7 @@ bool ATA::HDD_CanSeek()
 
 bool ATA::HDD_CanAccess(int* sectors)
 {
-	s64 maxLBA = std::min<s64>(EmuConfig.DEV9.HddSizeSectors, hddImageSize / 512) - 1;
+	s64 maxLBA = hddImageSize / 512 - 1;
 	if ((regSelect & 0x40) == 0) //CHS mode
 		maxLBA = std::min<s64>(maxLBA, curCylinders * curHeads * curSectors);
 

--- a/pcsx2/DEV9/ATA/ATA_Transfer.cpp
+++ b/pcsx2/DEV9/ATA/ATA_Transfer.cpp
@@ -512,5 +512,6 @@ void ATA::HDD_SetErrorAtTransferEnd()
 		//Write errored sector to LBA
 		currSect++;
 		HDD_SetLBA(currSect);
+		Console.Error("DEV9: ATA: Transfer from invalid LBA %lu", currSect);
 	}
 }

--- a/pcsx2/DEV9/ATA/Commands/ATA_CmdPIOData.cpp
+++ b/pcsx2/DEV9/ATA/Commands/ATA_CmdPIOData.cpp
@@ -73,7 +73,7 @@ void ATA::HDD_IdentifyDevice()
 	DevCon.WriteLn("DEV9: HddidentifyDevice");
 
 	//IDE transfer start
-	CreateHDDinfo(EmuConfig.DEV9.HddSizeSectors);
+	CreateHDDinfo(hddImageSize / 512);
 
 	pioDRQEndTransferFunc = nullptr;
 	DRQCmdPIODataToHost(identifyData, 256 * 2, 0, 256 * 2, true);

--- a/pcsx2/DEV9/DEV9.cpp
+++ b/pcsx2/DEV9/DEV9.cpp
@@ -1054,8 +1054,7 @@ void DEV9CheckChanges(const Pcsx2Config& old_config)
 		{
 			//ATA::Open/Close dosn't set any regs
 			//So we can close/open to apply settings
-			if (EmuConfig.DEV9.HddFile != old_config.DEV9.HddFile ||
-				EmuConfig.DEV9.HddSizeSectors != old_config.DEV9.HddSizeSectors)
+			if (EmuConfig.DEV9.HddFile != old_config.DEV9.HddFile)
 			{
 				dev9.ata->Close();
 				if (dev9.ata->Open(hddPath) != 0)

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -1089,7 +1089,6 @@ void Pcsx2Config::DEV9Options::LoadSave(SettingsWrapper& wrap)
 		SettingsWrapSection("DEV9/Hdd");
 		SettingsWrapEntry(HddEnable);
 		SettingsWrapEntry(HddFile);
-		SettingsWrapEntry(HddSizeSectors);
 	}
 }
 


### PR DESCRIPTION
### Description of Changes
Remove HddSizeSectors setting and instead use the file size to calculate the number of sectors
Additionally, a crash fix to handle invalid LBA accesses.

### Rationale behind Changes
Previously it was possible to set size of the Hdd to a different value to the actual size.
Under such conditions we would report the set size, but report an error when trying to access beyond the end of the file.
This behaviour is unexpected and is pretty dumb.
Additionally, Some games (HDD Utility) would still attempt the read/write regardless of the reported failure, resulting in a emulator crash.

This change also makes it easier for a user to use their own dump, as we should no longer need to contend with GiB vs GB issues.

Unlike in Wx, the Qt build is only able to create a Hdd image in the settings UI, so we can remove the config field as well.

### Suggested Testing Steps
Test that Hdd images report the correct size.
Test that the UI works as expected.