### PR TITLE
GS/HW: Properly scale RT in Sonic Unleashed CRC

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSHwHack.cpp
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.cpp
@@ -1065,8 +1065,8 @@ bool GSHwHack::OI_SonicUnleashed(GSRendererHW& r, GSTexture* rt, GSTexture* ds, 
 									std::max(rt_again->m_unscaled_size.y, src->m_unscaled_size.y));
 			rt_again->ResizeTexture(new_size.x, new_size.y);
 			rt = rt_again->m_texture;
-			rt_size = new_size;
-			rt_again->UpdateDrawn(GSVector4i::loadh(rt_size));
+			rt_size = new_size * GSVector2i(src->GetScale());
+			rt_again->UpdateDrawn(GSVector4i::loadh(new_size));
 		}
 	}
 


### PR DESCRIPTION
### Description of Changes
Properly size RT in Sonic Unleashed CRC

### Rationale behind Changes
It wasn't scaling so it broke when upscaling.

### Suggested Testing Steps
Watch CI, already tested.

Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/80eb335c-f3ea-4e6d-ae98-347b5e20f78b)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/06fc82b7-db1c-47d7-bc82-abf314d06424)

