### PR TITLE
GS/HW: Redo some double half clear checks + Reduce CLUT flushes

### DIFF
--- a/pcsx2/GS/GSClut.cpp
+++ b/pcsx2/GS/GSClut.cpp
@@ -120,9 +120,13 @@ u8 GSClut::IsInvalid()
 	return m_write.dirty;
 }
 
-void GSClut::ClearDrawInvalidity()
+void GSClut::ClearDrawInvalidity(bool clear_all)
 {
-	if (m_write.dirty & 2)
+	if (clear_all)
+	{
+		m_write.dirty = 0;
+	}
+	else if (m_write.dirty & 2)
 	{
 		m_write.dirty = 1;
 	}

--- a/pcsx2/GS/GSClut.h
+++ b/pcsx2/GS/GSClut.h
@@ -110,7 +110,7 @@ public:
 
 	bool InvalidateRange(u32 start_block, u32 end_block, bool is_draw = false);
 	u8 IsInvalid();
-	void ClearDrawInvalidity();
+	void ClearDrawInvalidity(bool clear_all);
 	u32 GetCLUTCBP();
 	u32 GetCLUTCPSM();
 	void SetNextCLUTTEX0(u64 CBP);

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -5742,6 +5742,10 @@ bool GSRendererHW::DetectDoubleHalfClear(bool& no_rt, bool& no_ds)
 		return false;
 	}
 
+	// Shortcut, if it's clearing Z then the clut overlap is not reading Z.
+	if (m_state_flush_reason == CLUTCHANGE && clear_depth)
+		return false;
+
 	const int next_ctx = (m_state_flush_reason == CONTEXTCHANGE) ? m_env.PRIM.CTXT : (1 - m_env.PRIM.CTXT);
 
 	// This is likely a full screen, can only really tell if this frame is used in the next draw, and we need to check if the height fills the next scissor.

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -2209,8 +2209,7 @@ bool GSTextureCache::PreloadTarget(GIFRegTEX0 TEX0, const GSVector2i& size, cons
 
 						if (iter->blit.DBP == TEX0.TBP0 && transfer_end == rect_end)
 						{
-							std::advance(iter, 1);
-							GSRendererHW::GetInstance()->m_draw_transfers.erase(iter.base());
+							iter = std::vector<GSState::GSUploadQueue>::reverse_iterator(GSRendererHW::GetInstance()->m_draw_transfers.erase(iter.base() - 1));
 						}
 						else
 							++iter;


### PR DESCRIPTION
### Description of Changes
Redo some of the double half clear checks to try to catch the cases better.

### Rationale behind Changes
There was a lot of problems with misdetections, especially if no targets existed, making some bad targets being created. Naturally I ended up going down a spiral of regressions, so it went a bit further than I was hoping.
Also makes sure we don't flush on CLUT reload if the current draw isn't using a texture, unless the current draw is the new CLUT.

MGS thermal vision has many less draws now, but now has an upload due to a Double Half Clear misdetect, since the code is hit early due to a CLUT upload before the new context is set up.  The solution to this is going to be to delay CLUT reloads until it tries to draw more, but that's out of scope of this PR. Currently mitigated with `GS/HW: Assume not a DHC if clut overlap on depth clear` commit.

### Suggested Testing Steps
Test plenty of stuff, make sure nothing that does double half clears especially breaks.

Fixes shadow problems on Spiderman 2

Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/0bd20422-4aa9-4634-999c-7a84a7f4dafc)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/b3ae8e36-663a-4f5c-8bd0-595706417ca3)

Also reduces the number of drawcalls in some games:
DragonBall Z games seemed to lose around 100 drawcalls on average
Metal Gear Solid 2 Thermal Vision loses 259 drawcalls 
Xenosaga Episode 3 loses around 10 draw calls
Final Fantasy XII GS Dump I have had the following improvements

```Final Fantasy XII preload frame data texture issues
Draw Calls: -14 [577=>563]
Render Passes: -14 [26=>12]
Barriers: -15 [554=>539]
Copies: -1 [1=>0]
FPS 575 -> 595
