### PR TITLE
SPU: DC filter output

### DIFF
--- a/pcsx2/SPU2/defs.h
+++ b/pcsx2/SPU2/defs.h
@@ -513,6 +513,8 @@ extern u16 OutPos;
 extern u16 InputPos;
 // SPU Mixing Cycles ("Ticks mixed" counter)
 extern u32 Cycles;
+// DC Filter state
+extern StereoOut16 DCFilterIn, DCFilterOut;
 
 extern s16 spu2regs[0x010000 / sizeof(s16)];
 extern s16 _spu2mem[0x200000 / sizeof(s16)];

--- a/pcsx2/SPU2/spu2sys.cpp
+++ b/pcsx2/SPU2/spu2sys.cpp
@@ -37,6 +37,7 @@ V_CoreDebug DebugCores[2];
 V_Core Cores[2];
 V_SPDIF Spdif;
 
+StereoOut16 DCFilterIn, DCFilterOut;
 u16 OutPos;
 u16 InputPos;
 u32 Cycles;
@@ -149,6 +150,8 @@ void V_Core::Init(int index)
 	DMAPtr = nullptr;
 	KeyOn = 0;
 	OutPos = 0;
+	DCFilterIn = {};
+	DCFilterOut = {};
 
 	psxmode = false;
 	psxSoundDataTransferControl = 0;


### PR DESCRIPTION
Some games leave paused voices hanging with volume turned on which results in dc offset. Filter it out.

Fixes #5337 

### Suggested Testing Steps
Test that audio still sounds fine.
