### PR TITLE
CMake: Fix build on Xcode 15

### DIFF
--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -1227,6 +1227,10 @@ if (APPLE)
 	# We have a bunch of page-sized arrays in bss that we use for jit
 	# Obviously not being able to make those arrays executable would be a problem
 	target_link_options(PCSX2_FLAGS INTERFACE -Wl,-segprot,__DATA,rwx,rw)
+	if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 15)
+		# FB13200673: Xcode 15's new linker's segprot handling is broken, request old linker
+		target_link_options(PCSX2_FLAGS INTERFACE -ld_classic)
+	endif()
 endif()
 
 set_property(GLOBAL PROPERTY PCSX2_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
### Description of Changes
New linker doesn't like our segprot, yay
If they don't fix it before they fully remove the old linker, I guess we'll have to stop sticking rec stuff in bss.  I do like how it shows up in the debugger / profilers this way though...

### Rationale behind Changes
Less broken

### Suggested Testing Steps
Make sure PCSX2s built with Xcode 15 are able to start games