### PR TITLE
GS/HW: Resize rect from half point on double half clear

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -5823,12 +5823,16 @@ bool GSRendererHW::DetectDoubleHalfClear(bool& no_rt, bool& no_ds)
 	// Double the clear rect.
 	if (horizontal)
 	{
+		const int width = m_r.width();
 		m_cached_ctx.FRAME.FBW *= 2;
-		m_r.z += m_r.x + m_r.width();
+		m_r.z = (w_pages * frame_psm.pgs.x);
+		m_r.z += m_r.x + width;
 	}
 	else
 	{
-		m_r.w += m_r.y + m_r.height();
+		const int height = m_r.height();
+		m_r.w = ((half - base) / m_cached_ctx.FRAME.FBW) * frame_psm.pgs.y;
+		m_r.w += m_r.y + height;
 	}
 	ReplaceVerticesWithSprite(m_r, GSVector2i(1, 1));
 


### PR DESCRIPTION
### Description of Changes
Resizes the rect based on the half way point as a base rather than going from the end of the previous rect.

### Rationale behind Changes
some games stopped at the previous pixel, in the case of Spider-Man 2 it did 127x63, so adding on as we did before went to 127x126 instead of 127x127, meaning there was a line left over which didn't get cleared, and this was evident in the shadow

### Suggested Testing Steps
Test Spider-Man 2, nothing else in the dump run seemed to be affected.

Fixes Spider-Man 2 (look at the pavement below Spider-Man)
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/c3a9f4d5-e075-48bd-bf92-71453f1e6165)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/55d04da9-8657-44d8-a019-6108f46f7fd3)

