### PR TITLE
Achievements: Different choice of words in achievement popup

### DIFF
--- a/pcsx2/Achievements.cpp
+++ b/pcsx2/Achievements.cpp
@@ -1014,7 +1014,7 @@ void Achievements::DisplayAchievementSummary()
 		std::string summary;
 		if (s_game_summary.num_core_achievements > 0)
 		{
-			summary = fmt::format(TRANSLATE_FS("Achievements", "You have earned {} of {} achievements, and {} of {} points."),
+			summary = fmt::format(TRANSLATE_FS("Achievements", "You have unlocked {} of {} achievements, and earned {} of {} points."),
 				s_game_summary.num_unlocked_achievements, s_game_summary.num_core_achievements, s_game_summary.points_unlocked,
 				s_game_summary.points_core);
 		}


### PR DESCRIPTION
### Description of Changes
Changed one line regarding the number of achievements unlocked and points earned in one popup.

### Rationale behind Changes
Better consistency with the other references to the number of achievements unlocked and points earned in the rest of the achievements UI.

### Suggested Testing Steps
CI passes.
