### PR TITLE
SPU: Change order of dc filter and final clamp

### DIFF
--- a/pcsx2/SPU2/Mixer.cpp
+++ b/pcsx2/SPU2/Mixer.cpp
@@ -691,8 +691,8 @@ __forceinline
 	// Edit: I'm sorry Jake, but I know of no good audio system that arbitrary distorts and clips
 	// output by design.
 	// Good thing though that this code gets the volume exactly right, as per tests :)
-	Out = clamp_mix(Out);
 	Out = DCFilter(Out);
+	Out = clamp_mix(Out);
 	SndBuffer::Write(StereoOut16(Out));
 
 	// Update AutoDMA output positioning

--- a/pcsx2/SPU2/defs.h
+++ b/pcsx2/SPU2/defs.h
@@ -514,7 +514,7 @@ extern u16 InputPos;
 // SPU Mixing Cycles ("Ticks mixed" counter)
 extern u32 Cycles;
 // DC Filter state
-extern StereoOut16 DCFilterIn, DCFilterOut;
+extern StereoOut32 DCFilterIn, DCFilterOut;
 
 extern s16 spu2regs[0x010000 / sizeof(s16)];
 extern s16 _spu2mem[0x200000 / sizeof(s16)];

--- a/pcsx2/SPU2/spu2sys.cpp
+++ b/pcsx2/SPU2/spu2sys.cpp
@@ -37,7 +37,7 @@ V_CoreDebug DebugCores[2];
 V_Core Cores[2];
 V_SPDIF Spdif;
 
-StereoOut16 DCFilterIn, DCFilterOut;
+StereoOut32 DCFilterIn, DCFilterOut;
 u16 OutPos;
 u16 InputPos;
 u32 Cycles;


### PR DESCRIPTION
The filter seems to introduce some small amount of gain

Should stop the samples overflowing.

That naruto game should be fine again.