### PR TITLE
GS: Reduce unnecessary flushes

### DIFF
--- a/pcsx2/GS/GSClut.cpp
+++ b/pcsx2/GS/GSClut.cpp
@@ -120,13 +120,9 @@ u8 GSClut::IsInvalid()
 	return m_write.dirty;
 }
 
-void GSClut::ClearDrawInvalidity(bool clear_all)
+void GSClut::ClearDrawInvalidity()
 {
-	if (clear_all)
-	{
-		m_write.dirty = 0;
-	}
-	else if (m_write.dirty & 2)
+	if (m_write.dirty & 2)
 	{
 		m_write.dirty = 1;
 	}

--- a/pcsx2/GS/GSClut.h
+++ b/pcsx2/GS/GSClut.h
@@ -110,7 +110,7 @@ public:
 
 	bool InvalidateRange(u32 start_block, u32 end_block, bool is_draw = false);
 	u8 IsInvalid();
-	void ClearDrawInvalidity(bool clear_all);
+	void ClearDrawInvalidity();
 	u32 GetCLUTCBP();
 	u32 GetCLUTCPSM();
 	void SetNextCLUTTEX0(u64 CBP);

--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -164,7 +164,7 @@ protected:
 	bool IsAutoFlushDraw(u32 prim);
 	template<u32 prim, bool index_swap>
 	void HandleAutoFlush();
-	void CLUTAutoFlush(u32 prim);
+	void CheckCLUTValidity(u32 prim);
 
 	template <u32 prim, bool auto_flush, bool index_swap>
 	void VertexKick(u32 skip);

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -1917,7 +1917,7 @@ void GSRendererHW::Draw()
 	if (GSConfig.UserHacks_CPUCLUTRender > 0 || GSConfig.UserHacks_GPUTargetCLUTMode != GSGPUTargetCLUTMode::Disabled)
 	{
 		const CLUTDrawTestResult result = (GSConfig.UserHacks_CPUCLUTRender == 2) ? PossibleCLUTDrawAggressive() : PossibleCLUTDraw();
-		m_mem.m_clut.ClearDrawInvalidity(false);
+		m_mem.m_clut.ClearDrawInvalidity();
 		if (result == CLUTDrawTestResult::CLUTDrawOnCPU && GSConfig.UserHacks_CPUCLUTRender > 0)
 		{
 			if (SwPrimRender(*this, true, true))


### PR DESCRIPTION
### Description of Changes
Attempt to reduce needless flushes of the GS context
Also fixing up some test draw changes code which was looking at the wrong context, not that it mattered apparently.

### Rationale behind Changes
If the current vertex being written was only being queued but nothing was being drawn, there was no need to flush the context as it could revert back to the previous state by the next vert write.
Also no need to flush on CLUT change if the current texture being drawn is not indexed.

### Suggested Testing Steps
Test random games, biggest difference seen is in FF7 Dirge of Cerberus. Also check Tomb Raider Legends as it had some render size changes (actually looks clearer in places now).

Dirge of Cerberus stat changes:
1665->963 draw calls
287->335 fps

A bunch of other games had small reductions in draw calls but nothing significant, unfortunately.