### PR TITLE
GS: Add optimisations for common GIF transfer sequences

### DIFF
--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -63,12 +63,31 @@ private:
 
 	typedef void (GSState::*GIFPackedRegHandlerC)(const GIFPackedReg* RESTRICT r, u32 size);
 
-	GIFPackedRegHandlerC m_fpGIFPackedRegHandlersC[2] = {};
+	GIFPackedRegHandlerC m_fpGIFPackedRegHandlersC[11] = {};
 	GIFPackedRegHandlerC m_fpGIFPackedRegHandlerSTQRGBAXYZF2[8] = {};
 	GIFPackedRegHandlerC m_fpGIFPackedRegHandlerSTQRGBAXYZ2[8] = {};
+	GIFPackedRegHandlerC m_fpGIFPackedRegHandlerUVRGBAXYZ2[8] = {};
+	GIFPackedRegHandlerC m_fpGIFPackedRegHandlerRGBAXYZ2[8] = {};
+	GIFPackedRegHandlerC m_fpGIFPackedRegHandlerRGBAXYZF2[8] = {};
+	GIFPackedRegHandlerC m_fpGIFPackedRegHandlerSTQXYZ2[8] = {};
+	GIFPackedRegHandlerC m_fpGIFPackedRegHandlerSTQXYZF2[8] = {};
+	GIFPackedRegHandlerC m_fpGIFPackedRegHandlerUVXYZ2[8] = {};
+	GIFPackedRegHandlerC m_fpGIFPackedRegHandlerUVXYZF2[8] = {};
+	GIFPackedRegHandlerC m_fpGIFPackedRegHandlerRGBAUVXYZF2[8] = {};
+	GIFPackedRegHandlerC m_fpGIFPackedRegHandlerUVRGBAXYZF2[8] = {};
 
 	template<u32 prim, bool auto_flush, bool index_swap> void GIFPackedRegHandlerSTQRGBAXYZF2(const GIFPackedReg* RESTRICT r, u32 size);
 	template<u32 prim, bool auto_flush, bool index_swap> void GIFPackedRegHandlerSTQRGBAXYZ2(const GIFPackedReg* RESTRICT r, u32 size);
+	template<u32 prim, bool auto_flush, bool index_swap> void GIFPackedRegHandlerUVRGBAXYZ2(const GIFPackedReg* RESTRICT r, u32 size);
+	template<u32 prim, bool auto_flush, bool index_swap> void GIFPackedRegHandlerRGBAXYZ2(const GIFPackedReg* RESTRICT r, u32 size);
+	template<u32 prim, bool auto_flush, bool index_swap> void GIFPackedRegHandlerRGBAXYZF2(const GIFPackedReg* RESTRICT r, u32 size);
+	template<u32 prim, bool auto_flush, bool index_swap> void GIFPackedRegHandlerSTQXYZ2(const GIFPackedReg* RESTRICT r, u32 size);
+	template<u32 prim, bool auto_flush, bool index_swap> void GIFPackedRegHandlerSTQXYZF2(const GIFPackedReg* RESTRICT r, u32 size);
+	template<u32 prim, bool auto_flush, bool index_swap> void GIFPackedRegHandlerUVXYZ2(const GIFPackedReg* RESTRICT r, u32 size);
+	template<u32 prim, bool auto_flush, bool index_swap> void GIFPackedRegHandlerUVXYZF2(const GIFPackedReg* RESTRICT r, u32 size);
+	template<u32 prim, bool auto_flush, bool index_swap> void GIFPackedRegHandlerRGBAUVXYZF2(const GIFPackedReg* RESTRICT r, u32 size);
+	template<u32 prim, bool auto_flush, bool index_swap> void GIFPackedRegHandlerUVRGBAXYZF2(const GIFPackedReg* RESTRICT r, u32 size);
+
 	void GIFPackedRegHandlerNOP(const GIFPackedReg* RESTRICT r, u32 size);
 
 	template<int i> void ApplyTEX0(GIFRegTEX0& TEX0);


### PR DESCRIPTION
### Description of Changes
Attempt to optimise the flow of incoming data for the GS

### Rationale behind Changes
Doing this in a custom fashion is in theory faster than doing it one by one. Not all paths covered but some common ones.

### Suggested Testing Steps
Benchmark random games, see if there's any performance difference over a few runs.

