### PR TITLE
GS/HW: Require 24/16bit RGB color if using AEM

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -2214,7 +2214,8 @@ void GSRendererHW::Draw()
 			tgt = nullptr;
 		}
 		const bool possible_shuffle = ((rt_32bit && GSLocalMemory::m_psm[m_cached_ctx.FRAME.PSM].bpp == 16) || m_cached_ctx.FRAME.Block() == m_cached_ctx.TEX0.TBP0) || IsPossibleChannelShuffle();
-		const bool req_color = (!PRIM->ABE || (PRIM->ABE && m_context->ALPHA.IsUsingCs())) && (possible_shuffle || (m_cached_ctx.FRAME.FBMSK & (fm_mask & 0x00FFFFFF)) != (fm_mask & 0x00FFFFFF));
+		const bool need_aem_color = GSLocalMemory::m_psm[m_cached_ctx.TEX0.PSM].trbpp <= 24 && GSLocalMemory::m_psm[m_cached_ctx.TEX0.PSM].pal == 0 && m_context->ALPHA.C == 0 && m_env.TEXA.AEM;
+		const bool req_color = (!PRIM->ABE || (PRIM->ABE && (m_context->ALPHA.IsUsingCs() || need_aem_color))) && (possible_shuffle || (m_cached_ctx.FRAME.FBMSK & (fm_mask & 0x00FFFFFF)) != (fm_mask & 0x00FFFFFF));
 		const bool req_alpha = (GSUtil::GetChannelMask(m_context->TEX0.PSM) & 0x8) && m_context->TEX0.TCC && ((m_cached_ctx.TEST.ATE && m_cached_ctx.TEST.ATST > ATST_ALWAYS) || (possible_shuffle || (m_cached_ctx.FRAME.FBMSK & (fm_mask & 0xFF000000)) != (fm_mask & 0xFF000000)));
 
 		src = tex_psm.depth ? g_texture_cache->LookupDepthSource(TEX0, env.TEXA, MIP_CLAMP, tmm.coverage, possible_shuffle, m_vt.IsLinear(), m_cached_ctx.FRAME.Block(), req_color, req_alpha) :


### PR DESCRIPTION
### Description of Changes
Make sure RGB is required on source lookup if using a 24/16bit source texture and using As for alpha blending with AEM enabled.

### Rationale behind Changes
Before there was a scenario where it could only use the source for alpha blending, but that source had been cleared to black, and it used AEM to override the alpha values in TEXA, but because we weren't checking this, it was saying it didn't require RGB or Alpha and just getting any old junk, which broken the rendering in Dark Cloud (only thing I've found affected so far)

### Suggested Testing Steps
Test Dark Cloud, nothing else affected by a dump run.

Dark Cloud
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/4b86a2fd-d604-4f5e-88a5-d43d7ad7dd75)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/9b5d679a-6f1f-482c-8998-c4cc0a0b89a9)

