### PR TITLE
GS:MTL: Add Intel HD 4000 to the list of GPUs to use PixelFormatView on

### DIFF
--- a/pcsx2/GS/Renderers/Metal/GSMTLDeviceInfo.mm
+++ b/pcsx2/GS/Renderers/Metal/GSMTLDeviceInfo.mm
@@ -192,7 +192,7 @@ GSMTLDevice::GSMTLDevice(MRCOwned<id<MTLDevice>> dev)
 	if (char* env = getenv("MTL_SLOW_COLOR_COMPRESSION"))
 		features.slow_color_compression = env[0] == '1' || env[0] == 'y' || env[0] == 'Y';
 	else
-		features.slow_color_compression = [[dev name] containsString:@"AMD"];
+		features.slow_color_compression = [[dev name] containsString:@"AMD"] || [[dev name] isEqualToString:@"Intel HD Graphics 4000"];
 
 	features.max_texsize = 8192;
 	if ([dev supportsFeatureSet:MTLFeatureSet_macOS_GPUFamily1_v1])


### PR DESCRIPTION
### Description of Changes
Sets slow_color_compression for Intel HD 4000s, which makes us add `MTLTextureUsagePixelFormatView` to them.  Apparently they're really slow without it, at least in our sample size of one OCLP Big Sur Mac mini.

Not sure why this does anything at all, as [texture compression is only supported on Skylake+](https://gitlab.freedesktop.org/mesa/mesa/-/blame/c572adceaa493ab2f7b6cad6d6bd100c6d93ff4d/src/intel/isl/isl_format.c#L88) (and only on Icelake+ in a way Metal can use due to its allowance of reinterpreting between sRGB and non-sRGB textures even on non-PFV textures), but apparently it does something and that something makes things faster

### Rationale behind Changes
Makes Metal renderer not slower than MoltenVK on Intel HD 4000

### Suggested Testing Steps
@MajmunX can you verify that this makes Metal fast without having to run with `MTL_SLOW_COLOR_COMPRESSION=1`?
