### PR TITLE
UI: Changes for translators

### DIFF
--- a/pcsx2/Achievements.cpp
+++ b/pcsx2/Achievements.cpp
@@ -1014,7 +1014,7 @@ void Achievements::DisplayAchievementSummary()
 		std::string summary;
 		if (s_game_summary.num_core_achievements > 0)
 		{
-			summary = fmt::format(TRANSLATE_FS("Achievements", "You have unlocked {} of {} achievements, and earned {} of {} points."),
+			summary = fmt::format(TRANSLATE_FS("Achievements", "You have unlocked {0} of {1} achievements, and earned {2} of {3} points."),
 				s_game_summary.num_unlocked_achievements, s_game_summary.num_core_achievements, s_game_summary.points_unlocked,
 				s_game_summary.points_core);
 		}
@@ -1097,7 +1097,7 @@ void Achievements::HandleGameCompleteEvent(const rc_client_event_t* event)
 	if (EmuConfig.Achievements.Notifications)
 	{
 		std::string title = fmt::format(TRANSLATE_FS("Achievements", "Mastered {}"), s_game_title);
-		std::string message = fmt::format(TRANSLATE_FS("Achievements", "{} achievements, {} points"),
+		std::string message = fmt::format(TRANSLATE_FS("Achievements", "{0} achievements, {1} points"),
 			s_game_summary.num_unlocked_achievements, s_game_summary.points_unlocked);
 
 		MTGS::RunOnGSThread([title = std::move(title), message = std::move(message), icon = s_game_icon]() {
@@ -1188,13 +1188,13 @@ void Achievements::HandleLeaderboardScoreboardEvent(const rc_client_event_t* eve
 	if (EmuConfig.Achievements.LeaderboardNotifications)
 	{
 		static const char* value_strings[NUM_RC_CLIENT_LEADERBOARD_FORMATS] = {
-			TRANSLATE_NOOP("Achievements", "Your Time: {} (Best: {})"),
-			TRANSLATE_NOOP("Achievements", "Your Score: {} (Best: {})"),
-			TRANSLATE_NOOP("Achievements", "Your Value: {} (Best: {})"),
+			TRANSLATE_NOOP("Achievements", "Your Time: {0} (Best: {1})"),
+			TRANSLATE_NOOP("Achievements", "Your Score: {0} (Best: {1})"),
+			TRANSLATE_NOOP("Achievements", "Your Value: {0} (Best: {1})"),
 		};
 
 		std::string title = event->leaderboard->title;
-		std::string message = fmt::format(TRANSLATE_FS("Achievements", "{}\nLeaderboard Position: {} of {}"),
+		std::string message = fmt::format(TRANSLATE_FS("Achievements", "{0}\nLeaderboard Position: {1} of {2}"),
 			fmt::format(fmt::runtime(Host::TranslateToStringView("Achievements",
 							value_strings[std::min<u8>(event->leaderboard->format, NUM_RC_CLIENT_LEADERBOARD_FORMATS - 1)])),
 				event->leaderboard_scoreboard->submitted_score, event->leaderboard_scoreboard->best_score),
@@ -1326,7 +1326,7 @@ void Achievements::HandleAchievementProgressIndicatorUpdateEvent(const rc_client
 
 void Achievements::HandleServerErrorEvent(const rc_client_event_t* event)
 {
-	std::string message = fmt::format(TRANSLATE_FS("Achievements", "Server error in {}:\n{}"),
+	std::string message = fmt::format(TRANSLATE_FS("Achievements", "Server error in {0}:\n{1}"),
 		event->server_error->api ? event->server_error->api : "UNKNOWN",
 		event->server_error->error_message ? event->server_error->error_message : "UNKNOWN");
 	Console.Error("(Achievements) %s", message.c_str());
@@ -1755,7 +1755,7 @@ void Achievements::ShowLoginSuccess(const rc_client_t* client)
 
 		//: Summary for login notification.
 		std::string title = user->display_name;
-		std::string summary = fmt::format(TRANSLATE_FS("Achievements", "Score: {} ({} softcore)\nUnread messages: {}"), user->score,
+		std::string summary = fmt::format(TRANSLATE_FS("Achievements", "Score: {0} ({1} softcore)\nUnread messages: {2}"), user->score,
 			user->score_softcore, user->num_unread_messages);
 
 		MTGS::RunOnGSThread([title = std::move(title), summary = std::move(summary), badge_path = std::move(badge_path)]() {
@@ -2148,7 +2148,7 @@ void Achievements::DrawAchievementsWindow()
 			}
 			else
 			{
-				text.fmt(TRANSLATE_FS("Achievements", "You have unlocked {} of {} achievements, earning {} of {} possible points."),
+				text.fmt(TRANSLATE_FS("Achievements", "You have unlocked {0} of {1} achievements, earning {2} of {3} possible points."),
 					s_game_summary.num_unlocked_achievements, s_game_summary.num_core_achievements, s_game_summary.points_unlocked,
 					s_game_summary.points_core);
 			}

--- a/pcsx2/GameDatabase.cpp
+++ b/pcsx2/GameDatabase.cpp
@@ -1163,7 +1163,7 @@ const GameDatabase::HashDatabaseEntry* GameDatabase::lookupHash(
 		if (audio_iter != s_track_hash_to_entry_map.end())
 		{
 			fmt::format_to(std::back_inserter(*match_error),
-				TRANSLATE_FS("GameDatabase", "Track {} with hash {} is not found in database.\n"), track + 1,
+				TRANSLATE_FS("GameDatabase", "Track {0} with hash {1} is not found in database.\n"), track + 1,
 				tracks[track].toString());
 			tracks_matched[track] = false;
 			all_okay = false;
@@ -1174,7 +1174,7 @@ const GameDatabase::HashDatabaseEntry* GameDatabase::lookupHash(
 		if (audio_iter->second != data_iter->second)
 		{
 			fmt::format_to(std::back_inserter(*match_error),
-				TRANSLATE_FS("GameDatabase", "Track {} with hash {} is for a different game ({}).\n"), track + 1,
+				TRANSLATE_FS("GameDatabase", "Track {0} with hash {1} is for a different game ({2}).\n"), track + 1,
 				tracks[track].toString(), s_hash_database[audio_iter->second].name);
 			tracks_matched[track] = false;
 			all_okay = false;
@@ -1185,7 +1185,7 @@ const GameDatabase::HashDatabaseEntry* GameDatabase::lookupHash(
 		if (getTrackIndex(candidate->tracks.data(), candidate->tracks.size(), tracks[track]) != track)
 		{
 			fmt::format_to(std::back_inserter(*match_error),
-				TRANSLATE_FS("GameDatabase", "Track {} with hash {} does not match database track.\n"), track + 1,
+				TRANSLATE_FS("GameDatabase", "Track {0} with hash {1} does not match database track.\n"), track + 1,
 				tracks[track].toString());
 			tracks_matched[track] = false;
 			all_okay = false;

--- a/pcsx2/Hotkeys.cpp
+++ b/pcsx2/Hotkeys.cpp
@@ -106,7 +106,7 @@ static void HotkeyCycleSaveSlot(s32 delta)
 
 		Host::AddIconOSDMessage("CycleSaveSlot", ICON_FA_SEARCH,
 			fmt::format(
-				TRANSLATE_FS("Hotkeys", "Save slot {} selected (last save: {})."), s_current_save_slot, date_buf),
+				TRANSLATE_FS("Hotkeys", "Save slot {0} selected (last save: {1})."), s_current_save_slot, date_buf),
 			Host::OSD_QUICK_DURATION);
 	}
 	else

--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -1532,7 +1532,7 @@ void FullscreenUI::DrawIntRangeSetting(SettingsInterface* bsi, const char* title
 	const std::optional<int> value =
 		bsi->GetOptionalIntValue(section, key, game_settings ? std::nullopt : std::optional<int>(default_value));
 	const std::string value_text(
-		value.has_value() ? StringUtil::StdStringFromFormat(format, value.value()) : std::string("Use Global Setting"));
+		value.has_value() ? StringUtil::StdStringFromFormat(format, value.value()) : std::string(FSUI_STR("Use Global Setting")));
 
 	if (MenuButtonWithValue(title, summary, value_text.c_str(), enabled, height, font, summary_font))
 		ImGui::OpenPopup(title);
@@ -1587,7 +1587,7 @@ void FullscreenUI::DrawIntSpinBoxSetting(SettingsInterface* bsi, const char* tit
 	const std::optional<int> value =
 		bsi->GetOptionalIntValue(section, key, game_settings ? std::nullopt : std::optional<int>(default_value));
 	const std::string value_text(
-		value.has_value() ? StringUtil::StdStringFromFormat(format, value.value()) : std::string("Use Global Setting"));
+		value.has_value() ? StringUtil::StdStringFromFormat(format, value.value()) : std::string(FSUI_STR("Use Global Setting")));
 
 	static bool manual_input = false;
 
@@ -1708,7 +1708,7 @@ void FullscreenUI::DrawFloatRangeSetting(SettingsInterface* bsi, const char* tit
 	const std::optional<float> value =
 		bsi->GetOptionalFloatValue(section, key, game_settings ? std::nullopt : std::optional<float>(default_value));
 	const std::string value_text(
-		value.has_value() ? StringUtil::StdStringFromFormat(format, value.value() * multiplier) : std::string("Use Global Setting"));
+		value.has_value() ? StringUtil::StdStringFromFormat(format, value.value() * multiplier) : std::string(FSUI_STR("Use Global Setting")));
 
 	if (MenuButtonWithValue(title, summary, value_text.c_str(), enabled, height, font, summary_font))
 		ImGui::OpenPopup(title);
@@ -1766,7 +1766,7 @@ void FullscreenUI::DrawFloatSpinBoxSetting(SettingsInterface* bsi, const char* t
 	const std::optional<float> value =
 		bsi->GetOptionalFloatValue(section, key, game_settings ? std::nullopt : std::optional<int>(default_value));
 	const std::string value_text(
-		value.has_value() ? StringUtil::StdStringFromFormat(format, value.value() * multiplier) : std::string("Use Global Setting"));
+		value.has_value() ? StringUtil::StdStringFromFormat(format, value.value() * multiplier) : std::string(FSUI_STR("Use Global Setting")));
 
 	static bool manual_input = false;
 
@@ -1898,11 +1898,11 @@ void FullscreenUI::DrawIntRectSetting(SettingsInterface* bsi, const char* title,
 		bsi->GetOptionalIntValue(section, right_key, game_settings ? std::nullopt : std::optional<int>(default_right));
 	const std::optional<int> bottom_value =
 		bsi->GetOptionalIntValue(section, bottom_key, game_settings ? std::nullopt : std::optional<int>(default_bottom));
-	const std::string value_text(fmt::format("{}/{}/{}/{}",
-		left_value.has_value() ? StringUtil::StdStringFromFormat(format, left_value.value()) : std::string("Default"),
-		top_value.has_value() ? StringUtil::StdStringFromFormat(format, top_value.value()) : std::string("Default"),
-		right_value.has_value() ? StringUtil::StdStringFromFormat(format, right_value.value()) : std::string("Default"),
-		bottom_value.has_value() ? StringUtil::StdStringFromFormat(format, bottom_value.value()) : std::string("Default")));
+	const std::string value_text(fmt::format(FSUI_NSTR("{0}/{1}/{2}/{3}"),
+		left_value.has_value() ? StringUtil::StdStringFromFormat(format, left_value.value()) : std::string(FSUI_STR("Default")),
+		top_value.has_value() ? StringUtil::StdStringFromFormat(format, top_value.value()) : std::string(FSUI_STR("Default")),
+		right_value.has_value() ? StringUtil::StdStringFromFormat(format, right_value.value()) : std::string(FSUI_STR("Default")),
+		bottom_value.has_value() ? StringUtil::StdStringFromFormat(format, bottom_value.value()) : std::string(FSUI_STR("Default"))));
 
 	static bool manual_input = false;
 
@@ -1925,7 +1925,7 @@ void FullscreenUI::DrawIntRectSetting(SettingsInterface* bsi, const char* title,
 	bool is_open = true;
 	if (ImGui::BeginPopupModal(title, &is_open, ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove))
 	{
-		static constexpr const char* labels[4] = {"Left: ", "Top: ", "Right: ", "Bottom: "};
+		static constexpr const char* labels[4] = {FSUI_NSTR("Left: "), FSUI_NSTR("Top: "), FSUI_NSTR("Right: "), FSUI_NSTR("Bottom: ")};
 		const char* keys[4] = {left_key, top_key, right_key, bottom_key};
 		int defaults[4] = {default_left, default_top, default_right, default_bottom};
 		s32 values[4] = {static_cast<s32>(left_value.value_or(default_left)), static_cast<s32>(top_value.value_or(default_top)),
@@ -2788,7 +2788,7 @@ void FullscreenUI::DrawInterfaceSettingsPage()
 
 	MenuHeading(FSUI_CSTR("On-Screen Display"));
 	DrawIntSpinBoxSetting(bsi, FSUI_ICONSTR(ICON_FA_SEARCH, "OSD Scale"),
-		FSUI_CSTR("Determines how large the on-screen messages and monitor are."), "EmuCore/GS", "OsdScale", 100, 25, 500, 1, "%d%%");
+		FSUI_CSTR("Determines how large the on-screen messages and monitor are."), "EmuCore/GS", "OsdScale", 100, 25, 500, 1, FSUI_CSTR("%d%%"));
 	DrawToggleSetting(bsi, FSUI_ICONSTR(ICON_FA_LIST, "Show Messages"),
 		FSUI_CSTR(
 			"Shows on-screen-display messages when events occur such as save states being created/loaded, screenshots being taken, etc."),
@@ -3301,11 +3301,11 @@ void FullscreenUI::DrawGraphicsSettingsPage()
 		"EmuCore/GS", "ScreenshotFormat", static_cast<int>(GSScreenshotFormat::PNG), s_screenshot_formats, std::size(s_screenshot_formats),
 		true);
 	DrawIntRangeSetting(bsi, FSUI_CSTR("Screenshot Quality"), FSUI_CSTR("Selects the quality at which screenshots will be compressed."),
-		"EmuCore/GS", "ScreenshotQuality", 50, 1, 100, "%d%%");
+		"EmuCore/GS", "ScreenshotQuality", 50, 1, 100, FSUI_CSTR("%d%%"));
 	DrawIntRangeSetting(bsi, FSUI_CSTR("Vertical Stretch"), FSUI_CSTR("Increases or decreases the virtual picture size vertically."),
-		"EmuCore/GS", "StretchY", 100, 10, 300, "%d%%");
+		"EmuCore/GS", "StretchY", 100, 10, 300, FSUI_CSTR("%d%%"));
 	DrawIntRectSetting(bsi, FSUI_CSTR("Crop"), FSUI_CSTR("Crops the image, while respecting aspect ratio."), "EmuCore/GS", "CropLeft", 0,
-		"CropTop", 0, "CropRight", 0, "CropBottom", 0, 0, 720, 1, "%dpx");
+		"CropTop", 0, "CropRight", 0, "CropBottom", 0, 0, 720, 1, FSUI_CSTR("%dpx"));
 	DrawToggleSetting(bsi, FSUI_CSTR("Enable Widescreen Patches"), FSUI_CSTR("Enables loading widescreen patches from pnach files."),
 		"EmuCore", "EnableWideScreenPatches", false);
 	DrawToggleSetting(bsi, FSUI_CSTR("Enable No-Interlacing Patches"),
@@ -3540,7 +3540,7 @@ void FullscreenUI::DrawGraphicsSettingsPage()
 			"EmuCore/GS", "CASMode", static_cast<int>(GSCASMode::Disabled), s_cas_options, std::size(s_cas_options), true);
 		DrawIntSpinBoxSetting(bsi, FSUI_CSTR("CAS Sharpness"),
 			FSUI_CSTR("Determines the intensity the sharpening effect in CAS post-processing."), "EmuCore/GS", "CASSharpness", 50, 0, 100,
-			1, "%d%%", cas_active);
+			1, FSUI_CSTR("%d%%"), cas_active);
 	}
 
 	MenuHeading(FSUI_CSTR("Filters"));
@@ -3636,7 +3636,7 @@ void FullscreenUI::DrawAudioSettingsPage()
 	MenuHeading(FSUI_CSTR("Runtime Settings"));
 	DrawIntRangeSetting(bsi, FSUI_ICONSTR(ICON_FA_VOLUME_UP, "Output Volume"),
 		FSUI_CSTR("Applies a global volume modifier to all sound produced by the game."), "SPU2/Mixing", "FinalVolume", 100, 0, 200,
-		"%d%%");
+		FSUI_CSTR("%d%%"));
 
 	MenuHeading(FSUI_CSTR("Mixing Settings"));
 	DrawIntListSetting(bsi, FSUI_ICONSTR(ICON_FA_RULER, "Synchronization Mode"),
@@ -3652,17 +3652,17 @@ void FullscreenUI::DrawAudioSettingsPage()
 		FSUI_CSTR("Determines which API is used to play back audio samples on the host."), "SPU2/Output", "OutputModule",
 		default_output_module, output_entries, output_values, std::size(output_entries), true);
 	DrawIntRangeSetting(bsi, FSUI_ICONSTR(ICON_FA_CLOCK, "Latency"),
-		FSUI_CSTR("Sets the average output latency when using the cubeb backend."), "SPU2/Output", "Latency", 100, 15, 200, "%d ms (avg)");
+		FSUI_CSTR("Sets the average output latency when using the cubeb backend."), "SPU2/Output", "Latency", 100, 15, 200, FSUI_CSTR("%d ms (avg)"));
 
 	MenuHeading(FSUI_CSTR("Timestretch Settings"));
 	DrawIntRangeSetting(bsi, FSUI_ICONSTR(ICON_FA_RULER_HORIZONTAL, "Sequence Length"),
 		FSUI_CSTR("Affects how the timestretcher operates when not running at 100% speed."), "Soundtouch", "SequenceLengthMS", 30, 20, 100,
-		"%d ms");
+		FSUI_CSTR("%d ms"));
 	DrawIntRangeSetting(bsi, FSUI_ICONSTR(ICON_FA_WINDOW_MAXIMIZE, "Seekwindow Size"),
 		FSUI_CSTR("Affects how the timestretcher operates when not running at 100% speed."), "Soundtouch", "SeekWindowMS", 20, 10, 30,
-		"%d ms");
+		FSUI_CSTR("%d ms"));
 	DrawIntRangeSetting(bsi, FSUI_ICONSTR(ICON_FA_RECEIPT, "Overlap"),
-		FSUI_CSTR("Affects how the timestretcher operates when not running at 100% speed."), "Soundtouch", "OverlapMS", 20, 5, 15, "%d ms");
+		FSUI_CSTR("Affects how the timestretcher operates when not running at 100% speed."), "Soundtouch", "OverlapMS", 20, 5, 15, FSUI_CSTR("%d ms"));
 
 	EndMenuButtons();
 }
@@ -4206,7 +4206,7 @@ void FullscreenUI::DrawControllerSettingsPage()
 					});
 			}
 
-			const TinyString freq_key = TinyString::from_fmt("Macro{}Frequency", macro_index + 1);
+			const TinyString freq_key = TinyString::from_fmt(FSUI_FSTR("Macro {} Frequency"), macro_index + 1);
 			s32 frequency = bsi->GetIntValue(section, freq_key.c_str(), 0);
 			const SmallString freq_summary =
 				((frequency == 0) ? TinyString(FSUI_VSTR("Macro will not auto-toggle.")) :
@@ -4419,7 +4419,7 @@ void FullscreenUI::DrawFoldersSettingsPage()
 
 void FullscreenUI::DrawAdvancedSettingsPage()
 {
-	static constexpr const char* ee_rounding_mode_settings[] = {"Nearest", "Negative", "Positive", "Chop/Zero (Default)"};
+	static constexpr const char* ee_rounding_mode_settings[] = {FSUI_NSTR("Nearest"), FSUI_NSTR("Negative"), FSUI_NSTR("Positive"), FSUI_NSTR("Chop/Zero (Default)")};
 
 	SettingsInterface* bsi = GetEditingSettingsInterface();
 
@@ -6626,7 +6626,7 @@ void FullscreenUI::DrawAchievementsSettingsPage(std::unique_lock<std::mutex>& se
 			const auto lock = Achievements::GetLock();
 
 			ImGui::PushStyleColor(ImGuiCol_TextDisabled, ImGui::GetStyle().Colors[ImGuiCol_Text]);
-			ActiveButton(SmallString::from_fmt(fmt::runtime(FSUI_ICONSTR(ICON_FA_BOOKMARK, "Game: {} ({})")), Achievements::GetGameID(),
+			ActiveButton(SmallString::from_fmt(fmt::runtime(FSUI_ICONSTR(ICON_FA_BOOKMARK, "Game: {0} ({1})")), Achievements::GetGameID(),
 							 Achievements::GetGameTitle()),
 				false, false, LAYOUT_MENU_BUTTON_HEIGHT_NO_SUMMARY);
 
@@ -6665,6 +6665,8 @@ void FullscreenUI::DrawAchievementsSettingsPage(std::unique_lock<std::mutex>& se
 // TRANSLATION-STRING-AREA-BEGIN
 TRANSLATE_NOOP("FullscreenUI", "Could not find any CD/DVD-ROM devices. Please ensure you have a drive connected and sufficient permissions to access it.");
 TRANSLATE_NOOP("FullscreenUI", "Use Global Setting");
+TRANSLATE_NOOP("FullscreenUI", "{0}/{1}/{2}/{3}");
+TRANSLATE_NOOP("FullscreenUI", "Default");
 TRANSLATE_NOOP("FullscreenUI", "Automatic binding failed, no devices are available.");
 TRANSLATE_NOOP("FullscreenUI", "Game title copied to clipboard.");
 TRANSLATE_NOOP("FullscreenUI", "Game serial copied to clipboard.");
@@ -6681,7 +6683,6 @@ TRANSLATE_NOOP("FullscreenUI", "Create New...");
 TRANSLATE_NOOP("FullscreenUI", "Enter the name of the input profile you wish to create.");
 TRANSLATE_NOOP("FullscreenUI", "Are you sure you want to restore the default settings? Any preferences will be lost.");
 TRANSLATE_NOOP("FullscreenUI", "Settings reset to defaults.");
-TRANSLATE_NOOP("FullscreenUI", "Quick Save Slot");
 TRANSLATE_NOOP("FullscreenUI", "No save present in this slot.");
 TRANSLATE_NOOP("FullscreenUI", "No save states found.");
 TRANSLATE_NOOP("FullscreenUI", "Failed to delete save state.");
@@ -6723,6 +6724,7 @@ TRANSLATE_NOOP("FullscreenUI", "Switches between full screen and windowed when t
 TRANSLATE_NOOP("FullscreenUI", "Hides the mouse pointer/cursor when the emulator is in fullscreen mode.");
 TRANSLATE_NOOP("FullscreenUI", "On-Screen Display");
 TRANSLATE_NOOP("FullscreenUI", "Determines how large the on-screen messages and monitor are.");
+TRANSLATE_NOOP("FullscreenUI", "%d%%");
 TRANSLATE_NOOP("FullscreenUI", "Shows on-screen-display messages when events occur such as save states being created/loaded, screenshots being taken, etc.");
 TRANSLATE_NOOP("FullscreenUI", "Shows the current emulation speed of the system in the top-right corner of the display as a percentage.");
 TRANSLATE_NOOP("FullscreenUI", "Shows the number of video frames (or v-syncs) displayed per second by the system in the top-right corner of the display.");
@@ -6796,6 +6798,7 @@ TRANSLATE_NOOP("FullscreenUI", "Vertical Stretch");
 TRANSLATE_NOOP("FullscreenUI", "Increases or decreases the virtual picture size vertically.");
 TRANSLATE_NOOP("FullscreenUI", "Crop");
 TRANSLATE_NOOP("FullscreenUI", "Crops the image, while respecting aspect ratio.");
+TRANSLATE_NOOP("FullscreenUI", "%dpx");
 TRANSLATE_NOOP("FullscreenUI", "Enable Widescreen Patches");
 TRANSLATE_NOOP("FullscreenUI", "Enables loading widescreen patches from pnach files.");
 TRANSLATE_NOOP("FullscreenUI", "Enable No-Interlacing Patches");
@@ -6948,8 +6951,10 @@ TRANSLATE_NOOP("FullscreenUI", "Determines how the stereo output is transformed 
 TRANSLATE_NOOP("FullscreenUI", "Output Settings");
 TRANSLATE_NOOP("FullscreenUI", "Determines which API is used to play back audio samples on the host.");
 TRANSLATE_NOOP("FullscreenUI", "Sets the average output latency when using the cubeb backend.");
+TRANSLATE_NOOP("FullscreenUI", "%d ms (avg)");
 TRANSLATE_NOOP("FullscreenUI", "Timestretch Settings");
 TRANSLATE_NOOP("FullscreenUI", "Affects how the timestretcher operates when not running at 100% speed.");
+TRANSLATE_NOOP("FullscreenUI", "%d ms");
 TRANSLATE_NOOP("FullscreenUI", "Settings and Operations");
 TRANSLATE_NOOP("FullscreenUI", "Creates a new memory card file or folder.");
 TRANSLATE_NOOP("FullscreenUI", "Simulates a larger memory card by filtering saves only to the current game.");
@@ -7134,7 +7139,9 @@ TRANSLATE_NOOP("FullscreenUI", "Input profile '{}' loaded.");
 TRANSLATE_NOOP("FullscreenUI", "Input profile '{}' saved.");
 TRANSLATE_NOOP("FullscreenUI", "Failed to save input profile '{}'.");
 TRANSLATE_NOOP("FullscreenUI", "Port {} Controller Type");
+TRANSLATE_NOOP("FullscreenUI", "Trigger");
 TRANSLATE_NOOP("FullscreenUI", "Select Macro {} Binds");
+TRANSLATE_NOOP("FullscreenUI", "Macro {} Frequency");
 TRANSLATE_NOOP("FullscreenUI", "Macro will toggle every {} frames.");
 TRANSLATE_NOOP("FullscreenUI", "Port {} Device");
 TRANSLATE_NOOP("FullscreenUI", "Port {} Subtype");
@@ -7152,6 +7159,10 @@ TRANSLATE_NOOP("FullscreenUI", "CRC: {:08X}");
 TRANSLATE_NOOP("FullscreenUI", "Time Played: {}");
 TRANSLATE_NOOP("FullscreenUI", "Last Played: {}");
 TRANSLATE_NOOP("FullscreenUI", "Size: {:.2f} MB");
+TRANSLATE_NOOP("FullscreenUI", "Left: ");
+TRANSLATE_NOOP("FullscreenUI", "Top: ");
+TRANSLATE_NOOP("FullscreenUI", "Right: ");
+TRANSLATE_NOOP("FullscreenUI", "Bottom: ");
 TRANSLATE_NOOP("FullscreenUI", "Summary");
 TRANSLATE_NOOP("FullscreenUI", "Interface Settings");
 TRANSLATE_NOOP("FullscreenUI", "BIOS Settings");
@@ -7339,6 +7350,9 @@ TRANSLATE_NOOP("FullscreenUI", "32 MB");
 TRANSLATE_NOOP("FullscreenUI", "64 MB");
 TRANSLATE_NOOP("FullscreenUI", "Folder [Recommended]");
 TRANSLATE_NOOP("FullscreenUI", "128 KB [PS1]");
+TRANSLATE_NOOP("FullscreenUI", "Negative");
+TRANSLATE_NOOP("FullscreenUI", "Positive");
+TRANSLATE_NOOP("FullscreenUI", "Chop/Zero (Default)");
 TRANSLATE_NOOP("FullscreenUI", "Game Grid");
 TRANSLATE_NOOP("FullscreenUI", "Game List");
 TRANSLATE_NOOP("FullscreenUI", "Game List Settings");
@@ -7494,7 +7508,7 @@ TRANSLATE_NOOP("FullscreenUI", "Login token generated on {}");
 TRANSLATE_NOOP("FullscreenUI", "Logout");
 TRANSLATE_NOOP("FullscreenUI", "Not Logged In");
 TRANSLATE_NOOP("FullscreenUI", "Login");
-TRANSLATE_NOOP("FullscreenUI", "Game: {} ({})");
+TRANSLATE_NOOP("FullscreenUI", "Game: {0} ({1})");
 TRANSLATE_NOOP("FullscreenUI", "Rich presence inactive or unsupported.");
 TRANSLATE_NOOP("FullscreenUI", "Game not loaded or no RetroAchievements available.");
 TRANSLATE_NOOP("FullscreenUI", "Card Enabled");

--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -1532,7 +1532,7 @@ void FullscreenUI::DrawIntRangeSetting(SettingsInterface* bsi, const char* title
 	const std::optional<int> value =
 		bsi->GetOptionalIntValue(section, key, game_settings ? std::nullopt : std::optional<int>(default_value));
 	const std::string value_text(
-		value.has_value() ? StringUtil::StdStringFromFormat(format, value.value()) : std::string(FSUI_STR("Use Global Setting")));
+		value.has_value() ? StringUtil::StdStringFromFormat(format, value.value()) : FSUI_STR("Use Global Setting"));
 
 	if (MenuButtonWithValue(title, summary, value_text.c_str(), enabled, height, font, summary_font))
 		ImGui::OpenPopup(title);
@@ -1587,7 +1587,7 @@ void FullscreenUI::DrawIntSpinBoxSetting(SettingsInterface* bsi, const char* tit
 	const std::optional<int> value =
 		bsi->GetOptionalIntValue(section, key, game_settings ? std::nullopt : std::optional<int>(default_value));
 	const std::string value_text(
-		value.has_value() ? StringUtil::StdStringFromFormat(format, value.value()) : std::string(FSUI_STR("Use Global Setting")));
+		value.has_value() ? StringUtil::StdStringFromFormat(format, value.value()) : FSUI_STR("Use Global Setting"));
 
 	static bool manual_input = false;
 
@@ -1708,7 +1708,7 @@ void FullscreenUI::DrawFloatRangeSetting(SettingsInterface* bsi, const char* tit
 	const std::optional<float> value =
 		bsi->GetOptionalFloatValue(section, key, game_settings ? std::nullopt : std::optional<float>(default_value));
 	const std::string value_text(
-		value.has_value() ? StringUtil::StdStringFromFormat(format, value.value() * multiplier) : std::string(FSUI_STR("Use Global Setting")));
+		value.has_value() ? StringUtil::StdStringFromFormat(format, value.value() * multiplier) : FSUI_STR("Use Global Setting"));
 
 	if (MenuButtonWithValue(title, summary, value_text.c_str(), enabled, height, font, summary_font))
 		ImGui::OpenPopup(title);
@@ -1766,7 +1766,7 @@ void FullscreenUI::DrawFloatSpinBoxSetting(SettingsInterface* bsi, const char* t
 	const std::optional<float> value =
 		bsi->GetOptionalFloatValue(section, key, game_settings ? std::nullopt : std::optional<int>(default_value));
 	const std::string value_text(
-		value.has_value() ? StringUtil::StdStringFromFormat(format, value.value() * multiplier) : std::string(FSUI_STR("Use Global Setting")));
+		value.has_value() ? StringUtil::StdStringFromFormat(format, value.value() * multiplier) : FSUI_STR("Use Global Setting"));
 
 	static bool manual_input = false;
 
@@ -1898,11 +1898,11 @@ void FullscreenUI::DrawIntRectSetting(SettingsInterface* bsi, const char* title,
 		bsi->GetOptionalIntValue(section, right_key, game_settings ? std::nullopt : std::optional<int>(default_right));
 	const std::optional<int> bottom_value =
 		bsi->GetOptionalIntValue(section, bottom_key, game_settings ? std::nullopt : std::optional<int>(default_bottom));
-	const std::string value_text(fmt::format(FSUI_NSTR("{0}/{1}/{2}/{3}"),
-		left_value.has_value() ? StringUtil::StdStringFromFormat(format, left_value.value()) : std::string(FSUI_STR("Default")),
-		top_value.has_value() ? StringUtil::StdStringFromFormat(format, top_value.value()) : std::string(FSUI_STR("Default")),
-		right_value.has_value() ? StringUtil::StdStringFromFormat(format, right_value.value()) : std::string(FSUI_STR("Default")),
-		bottom_value.has_value() ? StringUtil::StdStringFromFormat(format, bottom_value.value()) : std::string(FSUI_STR("Default"))));
+	const std::string value_text(fmt::format(FSUI_FSTR("{0}/{1}/{2}/{3}"),
+		left_value.has_value() ? StringUtil::StdStringFromFormat(format, left_value.value()) : FSUI_STR("Default"),
+		top_value.has_value() ? StringUtil::StdStringFromFormat(format, top_value.value()) : FSUI_STR("Default"),
+		right_value.has_value() ? StringUtil::StdStringFromFormat(format, right_value.value()) : FSUI_STR("Default"),
+		bottom_value.has_value() ? StringUtil::StdStringFromFormat(format, bottom_value.value()) : FSUI_STR("Default")));
 
 	static bool manual_input = false;
 
@@ -1952,7 +1952,7 @@ void FullscreenUI::DrawIntRectSetting(SettingsInterface* bsi, const char* title,
 			// Align value text in middle.
 			ImGui::SetCursorPosY(ImGui::GetCursorPosY() +
 								 ((LayoutScale(LAYOUT_MENU_BUTTON_HEIGHT_NO_SUMMARY) + padding.y * 2.0f) - g_large_font->FontSize) * 0.5f);
-			ImGui::TextUnformatted(labels[i]);
+			ImGui::TextUnformatted(Host::TranslateToCString(TR_CONTEXT, labels[i]));
 			ImGui::SameLine(midpoint);
 			ImGui::SetNextItemWidth(end);
 			button_pos.x = ImGui::GetCursorPosX();

--- a/pcsx2/SIO/Pad/Pad.cpp
+++ b/pcsx2/SIO/Pad/Pad.cpp
@@ -539,8 +539,8 @@ bool Pad::Freeze(StateWrapper& sw)
 				const auto& [port, slot] = sioConvertPadToPortAndSlot(unifiedSlot);
 				Host::AddIconOSDMessage(fmt::format("UnfreezePad{}Changed", unifiedSlot), ICON_FA_GAMEPAD,
 					fmt::format(TRANSLATE_FS("Pad",
-									"Controller port {}, slot {} has a {} connected, but the save state has a "
-									"{}.\nLeaving the original controller type connected, but this may cause issues."),
+									"Controller port {0}, slot {1} has a {2} connected, but the save state has a "
+									"{3}.\nLeaving the original controller type connected, but this may cause issues."),
 						port, slot,
 						GetControllerTypeName(pad ? pad->GetType() : Pad::ControllerType::NotConnected),
 						GetControllerTypeName(type)));

--- a/pcsx2/SIO/Pad/PadDualshock2.cpp
+++ b/pcsx2/SIO/Pad/PadDualshock2.cpp
@@ -667,8 +667,8 @@ void PadDualshock2::Set(u32 index, float value)
 				const auto [port, slot] = sioConvertPadToPortAndSlot(unifiedSlot);
 				
 				Host::AddKeyedOSDMessage(fmt::format("PadAnalogButtonChange{}{}", port, slot),
-					this->analogLight ? fmt::format(TRANSLATE_FS("Pad", "Analog light is now on for port {} / slot {}"), port + 1, slot + 1) :
-										fmt::format(TRANSLATE_FS("Pad", "Analog light is now off for port {} / slot {}"), port + 1, slot + 1),
+					this->analogLight ? fmt::format(TRANSLATE_FS("Pad", "Analog light is now on for port {0} / slot {1}"), port + 1, slot + 1) :
+										fmt::format(TRANSLATE_FS("Pad", "Analog light is now off for port {0} / slot {1}"), port + 1, slot + 1),
 					Host::OSD_INFO_DURATION);
 			}
 		}


### PR DESCRIPTION
### Description of Changes
 - Added numbers to all strings with more than one {} so translators who might not know that they can move those variables can, in fact, move them around the string.
 - Tagged a number of untranslatable strings in Big Picture. Keep in mind that these are the strings that actually exist within the FullscreenUI.cpp file, as there's a number of those strings that do not seem to be taken from there (I do not know from where, though, so I'm leaving those out of scope). The FSUI_XSTR names have been added by guesswork, so more expert eyes are required.
- Ran the generate_fullscreen_ui_translations script, which removes that "Quick Save Slot" string that was inherited from DuckStation for Android.

### Rationale behind Changes
Improving strings for translators with no knowledge of the intricacies of programming, adding missing strings to the translatable database.

### Suggested Testing Steps
Make sure I did not mess things up.