### PR TITLE
Pad: More detailed config logs

### DIFF
--- a/pcsx2/SIO/Pad/PadDualshock2.h
+++ b/pcsx2/SIO/Pad/PadDualshock2.h
@@ -97,6 +97,8 @@ private:
 	// Used to store the last vibration mapping request the PS2 made for the large motor.
 	u8 largeMotorLastConfig = 0xff;
 
+	void ConfigLog();
+
 	u8 Mystery(u8 commandByte);
 	u8 ButtonQuery(u8 commandByte);
 	u8 Poll(u8 commandByte);

--- a/pcsx2/SIO/Pad/PadGuitar.cpp
+++ b/pcsx2/SIO/Pad/PadGuitar.cpp
@@ -51,6 +51,19 @@ static const SettingInfo s_settings[] = {
 const Pad::ControllerInfo PadGuitar::ControllerInfo = {Pad::ControllerType::Guitar, "Guitar",
 	TRANSLATE_NOOP("Pad", "Guitar"), s_bindings, s_settings, Pad::VibrationCapabilities::NoVibration};
 
+void PadGuitar::ConfigLog()
+{
+	const auto [port, slot] = sioConvertPadToPortAndSlot(unifiedSlot);
+
+	// AL: Analog Light (is it turned on right now)
+	// AB: Analog Button (is it useable or is it locked in its current state)
+	Console.WriteLn(fmt::format("[Pad] Guitar Config Finished - P{0}/S{1} - AL: {2} - AB: {3}",
+		port + 1,
+		slot + 1,
+		(this->analogLight ? "On" : "Off"),
+		(this->analogLocked ? "Locked" : "Usable")));
+}
+
 u8 PadGuitar::Mystery(u8 commandByte)
 {
 	switch (this->commandBytesReceived)
@@ -124,12 +137,7 @@ u8 PadGuitar::Config(u8 commandByte)
 			if (this->isInConfig)
 			{
 				this->isInConfig = false;
-				const auto [port, slot] = sioConvertPadToPortAndSlot(unifiedSlot);
-				Console.WriteLn("[Pad] Game finished pad setup for port %d / slot %d - Analogs: %s - Analog Button: %s - Pressure: Not available on guitars",
-					port + 1,
-					slot + 1,
-					(this->analogLight ? "On" : "Off"),
-					(this->analogLocked ? "Locked" : "Usable"));
+				this->ConfigLog();
 			}
 			else
 			{

--- a/pcsx2/SIO/Pad/PadGuitar.h
+++ b/pcsx2/SIO/Pad/PadGuitar.h
@@ -49,6 +49,8 @@ private:
 	float whammyDeadzone = 0.0f;
 	float buttonDeadzone = 0.0f; // Button deadzone is still a good idea, in case a host analog stick is bound to a guitar button
 
+	void ConfigLog();
+
 	u8 Mystery(u8 commandByte);
 	u8 ButtonQuery(u8 commandByte);
 	u8 Poll(u8 commandByte);


### PR DESCRIPTION
### Description of Changes
Adds additional details about vibration motor config and the specific button mapping requested by the game.

### Rationale behind Changes
Might help with more rapid diagnosis of controller problems, specifically with games that do non-standard things with controller config.

### Suggested Testing Steps
Boot games, verify that controller config logs show up and show new info.
