### PR TITLE
CDVD: Report open errors to host

### DIFF
--- a/common/Pcsx2Defs.h
+++ b/common/Pcsx2Defs.h
@@ -97,8 +97,6 @@ static constexpr unsigned int __pagemask = __pagesize - 1;
 	#define likely(x) (!!(x))
 	#define unlikely(x) (!!(x))
 
-	#define CALLBACK __stdcall
-
 #else
 
 // --------------------------------------------------------------------------------------
@@ -110,9 +108,6 @@ static constexpr unsigned int __pagemask = __pagesize - 1;
 	// SysV ABI passes vector parameters through registers unconditionally.
 	#ifndef _WIN32
 		#define __vectorcall
-		#define CALLBACK
-	#else
-		#define CALLBACK __attribute__((stdcall))
 	#endif
 
 	// Inlining note: GCC needs ((unused)) attributes defined on inlined functions to suppress

--- a/pcsx2/CDVD/BlockdumpFileReader.cpp
+++ b/pcsx2/CDVD/BlockdumpFileReader.cpp
@@ -1,5 +1,5 @@
 /*  PCSX2 - PS2 Emulator for PCs
- *  Copyright (C) 2002-2014  PCSX2 Dev Team
+ *  Copyright (C) 2002-2023 PCSX2 Dev Team
  *
  *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU Lesser General Public License as published by the Free Software Found-
@@ -18,6 +18,7 @@
 #include "IsoFileFormats.h"
 #include "common/Assertions.h"
 #include "common/FileSystem.h"
+#include "common/Error.h"
 
 #include <errno.h>
 
@@ -27,11 +28,11 @@ enum isoFlags
 	ISOFLAGS_BLOCKDUMP_V3 = 0x0020
 };
 
-static const uint BlockDumpHeaderSize = 16;
+static constexpr u32 BlockDumpHeaderSize = 16;
 
 bool BlockdumpFileReader::DetectBlockdump(AsyncFileReader* reader)
 {
-	uint oldbs = reader->GetBlockSize();
+	u32 oldbs = reader->GetBlockSize();
 
 	reader->SetBlockSize(1);
 
@@ -45,7 +46,7 @@ bool BlockdumpFileReader::DetectBlockdump(AsyncFileReader* reader)
 	return isbd;
 }
 
-BlockdumpFileReader::BlockdumpFileReader(void)
+BlockdumpFileReader::BlockdumpFileReader()
 	: m_file(NULL)
 	, m_blocks(0)
 	, m_blockofs(0)
@@ -54,19 +55,22 @@ BlockdumpFileReader::BlockdumpFileReader(void)
 {
 }
 
-BlockdumpFileReader::~BlockdumpFileReader(void)
+BlockdumpFileReader::~BlockdumpFileReader()
 {
 	Close();
 }
 
-bool BlockdumpFileReader::Open(std::string fileName)
+bool BlockdumpFileReader::Open(std::string filename, Error* error)
 {
 	char signature[4];
 
-	m_filename = std::move(fileName);
-	m_file = FileSystem::OpenCFile(m_filename.c_str(), "rb");
-	if (!m_file || std::fread(signature, sizeof(signature), 1, m_file) != 1 || std::memcmp(signature, "BDV2", sizeof(signature)) != 0)
+	m_filename = std::move(filename);
+	if (!(m_file = FileSystem::OpenCFile(m_filename.c_str(), "rb", error)))
+		return false;
+
+	if (std::fread(signature, sizeof(signature), 1, m_file) != 1 || std::memcmp(signature, "BDV2", sizeof(signature)) != 0)
 	{
+		Error::SetString(error, "Block dump signature is invalid.");
 		return false;
 	}
 
@@ -75,6 +79,7 @@ bool BlockdumpFileReader::Open(std::string fileName)
 	 || std::fread(&m_blocks,    sizeof(m_blocks),    1, m_file) != 1
 	 || std::fread(&m_blockofs,  sizeof(m_blockofs),  1, m_file) != 1)
 	{
+		Error::SetString(error, "Failed to read block dump information.");
 		return false;
 	}
 
@@ -87,7 +92,10 @@ bool BlockdumpFileReader::Open(std::string fileName)
 	m_dtable = std::make_unique<u32[]>(m_dtablesize);
 
 	if (FileSystem::FSeek64(m_file, BlockDumpHeaderSize, SEEK_SET) != 0)
+	{
+		Error::SetString(error, "Failed to seek to block dump data.");
 		return false;
+	}
 
 	u32 bs = 1024 * 1024;
 	u32 off = 0;
@@ -112,7 +120,7 @@ bool BlockdumpFileReader::Open(std::string fileName)
 	return true;
 }
 
-int BlockdumpFileReader::ReadSync(void* pBuffer, uint lsn, uint count)
+int BlockdumpFileReader::ReadSync(void* pBuffer, u32 lsn, u32 count)
 {
 	u8* dst = (u8*)pBuffer;
 	//	Console.WriteLn("_isoReadBlockD %u, blocksize=%u, blockofs=%u\n", lsn, iso->blocksize, iso->blockofs);
@@ -159,17 +167,17 @@ int BlockdumpFileReader::ReadSync(void* pBuffer, uint lsn, uint count)
 	return 0;
 }
 
-void BlockdumpFileReader::BeginRead(void* pBuffer, uint sector, uint count)
+void BlockdumpFileReader::BeginRead(void* pBuffer, u32 sector, u32 count)
 {
 	m_lresult = ReadSync(pBuffer, sector, count);
 }
 
-int BlockdumpFileReader::FinishRead(void)
+int BlockdumpFileReader::FinishRead()
 {
 	return m_lresult;
 }
 
-void BlockdumpFileReader::CancelRead(void)
+void BlockdumpFileReader::CancelRead()
 {
 }
 
@@ -178,11 +186,11 @@ void BlockdumpFileReader::Close(void)
 	if (m_file)
 	{
 		std::fclose(m_file);
-		m_file = NULL;
+		m_file = nullptr;
 	}
 }
 
-uint BlockdumpFileReader::GetBlockCount(void) const
+u32 BlockdumpFileReader::GetBlockCount() const
 {
 	return m_blocks;
 }

--- a/pcsx2/CDVD/CDVDcommon.cpp
+++ b/pcsx2/CDVD/CDVDcommon.cpp
@@ -38,7 +38,7 @@
 
 #define ENABLE_TIMESTAMPS
 
-CDVD_API* CDVD = nullptr;
+const CDVD_API* CDVD = nullptr;
 
 // ----------------------------------------------------------------------------
 // diskTypeCached
@@ -327,7 +327,7 @@ void CDVDsys_ClearFiles()
 
 void CDVDsys_ChangeSource(CDVD_SourceType type)
 {
-	if (CDVD != NULL)
+	if (CDVD)
 		DoCDVDclose();
 
 	switch (m_CurrentSourceType = type)
@@ -348,15 +348,14 @@ void CDVDsys_ChangeSource(CDVD_SourceType type)
 	}
 }
 
-bool DoCDVDopen()
+bool DoCDVDopen(Error* error)
 {
 	CheckNullCDVD();
 
 	CDVD->newDiskCB(cdvdNewDiskCB);
 
 	auto CurrentSourceType = enum_cast(m_CurrentSourceType);
-	int ret = CDVD->open(!m_SourceFilename[CurrentSourceType].empty() ? m_SourceFilename[CurrentSourceType].c_str() : nullptr);
-	if (ret == -1)
+	if (!CDVD->open(m_SourceFilename[CurrentSourceType], error))
 		return false; // error! (handled by caller)
 
 	int cdtype = DoCDVDdetectDiskType();
@@ -428,8 +427,7 @@ void DoCDVDclose()
 
 	blockDumpFile.Close();
 
-	if (CDVD->close != NULL)
-		CDVD->close();
+	CDVD->close();
 
 	DoCDVDresetDiskTypeCache();
 }
@@ -530,75 +528,75 @@ void DoCDVDresetDiskTypeCache()
 
 
 
-s32 CALLBACK NODISCopen(const char* pTitle)
+static bool NODISCopen(std::string filename, Error* error)
 {
-	return 0;
+	return true;
 }
 
-void CALLBACK NODISCclose()
+static void NODISCclose()
 {
 }
 
-s32 CALLBACK NODISCreadTrack(u32 lsn, int mode)
-{
-	return -1;
-}
-
-s32 CALLBACK NODISCgetBuffer(u8* buffer)
+static s32 NODISCreadTrack(u32 lsn, int mode)
 {
 	return -1;
 }
 
-s32 CALLBACK NODISCreadSubQ(u32 lsn, cdvdSubQ* subq)
+static s32 NODISCgetBuffer(u8* buffer)
 {
 	return -1;
 }
 
-s32 CALLBACK NODISCgetTN(cdvdTN* Buffer)
+static s32 NODISCreadSubQ(u32 lsn, cdvdSubQ* subq)
 {
 	return -1;
 }
 
-s32 CALLBACK NODISCgetTD(u8 Track, cdvdTD* Buffer)
+static s32 NODISCgetTN(cdvdTN* Buffer)
 {
 	return -1;
 }
 
-s32 CALLBACK NODISCgetTOC(void* toc)
+static s32 NODISCgetTD(u8 Track, cdvdTD* Buffer)
 {
 	return -1;
 }
 
-s32 CALLBACK NODISCgetDiskType()
+static s32 NODISCgetTOC(void* toc)
+{
+	return -1;
+}
+
+static s32 NODISCgetDiskType()
 {
 	return CDVD_TYPE_NODISC;
 }
 
-s32 CALLBACK NODISCgetTrayStatus()
+static s32 NODISCgetTrayStatus()
 {
 	return CDVD_TRAY_CLOSE;
 }
 
-s32 CALLBACK NODISCdummyS32()
+static s32 NODISCdummyS32()
 {
 	return 0;
 }
 
-void CALLBACK NODISCnewDiskCB(void (*/* callback */)())
+static void NODISCnewDiskCB(void (*/* callback */)())
 {
 }
 
-s32 CALLBACK NODISCreadSector(u8* tempbuffer, u32 lsn, int mode)
-{
-	return -1;
-}
-
-s32 CALLBACK NODISCgetDualInfo(s32* dualType, u32* _layer1start)
+static s32 NODISCreadSector(u8* tempbuffer, u32 lsn, int mode)
 {
 	return -1;
 }
 
-CDVD_API CDVDapi_NoDisc =
+static s32 NODISCgetDualInfo(s32* dualType, u32* _layer1start)
+{
+	return -1;
+}
+
+const CDVD_API CDVDapi_NoDisc =
 	{
 		NODISCclose,
 		NODISCopen,

--- a/pcsx2/CDVD/CDVDcommon.h
+++ b/pcsx2/CDVD/CDVDcommon.h
@@ -1,5 +1,5 @@
 /*  PCSX2 - PS2 Emulator for PCs
- *  Copyright (C) 2002-2010  PCSX2 Dev Team
+ *  Copyright (C) 2002-2023 PCSX2 Dev Team
  *
  *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU Lesser General Public License as published by the Free Software Found-
@@ -16,19 +16,21 @@
 #pragma once
 #include <string>
 
+class Error;
+
 typedef struct _cdvdSubQ
 {
-	u8 ctrl : 4;   // control and mode bits
-	u8 mode : 4;   // control and mode bits
-	u8 trackNum;   // current track number (1 to 99)
+	u8 ctrl : 4; // control and mode bits
+	u8 mode : 4; // control and mode bits
+	u8 trackNum; // current track number (1 to 99)
 	u8 trackIndex; // current index within track (0 to 99)
-	u8 trackM;     // current minute location on the disc (BCD encoded)
-	u8 trackS;     // current sector location on the disc (BCD encoded)
-	u8 trackF;     // current frame location on the disc (BCD encoded)
-	u8 pad;        // unused
-	u8 discM;      // current minute offset from first track (BCD encoded)
-	u8 discS;      // current sector offset from first track (BCD encoded)
-	u8 discF;      // current frame offset from first track (BCD encoded)
+	u8 trackM; // current minute location on the disc (BCD encoded)
+	u8 trackS; // current sector location on the disc (BCD encoded)
+	u8 trackF; // current frame location on the disc (BCD encoded)
+	u8 pad; // unused
+	u8 discM; // current minute offset from first track (BCD encoded)
+	u8 discS; // current sector offset from first track (BCD encoded)
+	u8 discF; // current frame offset from first track (BCD encoded)
 } cdvdSubQ;
 
 typedef struct _cdvdTD
@@ -44,9 +46,9 @@ typedef struct _cdvdTN
 } cdvdTN;
 
 // SpindleCtrl Masks
-#define CDVD_SPINDLE_SPEED 0x7  // Speed ranges from 0-3 (1, 2, 3, 4x for DVD) and 0-5 (1, 2, 4, 12, 24x for CD)
+#define CDVD_SPINDLE_SPEED 0x7 // Speed ranges from 0-3 (1, 2, 3, 4x for DVD) and 0-5 (1, 2, 4, 12, 24x for CD)
 #define CDVD_SPINDLE_NOMINAL 0x40 // Changes the speed to be constant (CLV) based on current speed
-#define CDVD_SPINDLE_CAV 0x80  // CAV/CLV selector
+#define CDVD_SPINDLE_CAV 0x80 // CAV/CLV selector
 
 // CDVDreadTrack mode values:
 #define CDVD_MODE_2352 0 // full 2352 bytes
@@ -56,20 +58,20 @@ typedef struct _cdvdTN
 #define CDVD_MODE_2368 4 // full 2352 bytes + 16 subq
 
 // CDVDgetDiskType returns:
-#define CDVD_TYPE_ILLEGAL 0xff   // Illegal Disc
-#define CDVD_TYPE_DVDV 0xfe      // DVD Video
-#define CDVD_TYPE_CDDA 0xfd      // Audio CD
-#define CDVD_TYPE_PS2DVD 0x14    // PS2 DVD
-#define CDVD_TYPE_PS2CDDA 0x13   // PS2 CD (with audio)
-#define CDVD_TYPE_PS2CD 0x12     // PS2 CD
-#define CDVD_TYPE_PSCDDA 0x11    // PS CD (with audio)
-#define CDVD_TYPE_PSCD 0x10      // PS CD
-#define CDVD_TYPE_UNKNOWN 0x05   // Unknown
+#define CDVD_TYPE_ILLEGAL 0xff // Illegal Disc
+#define CDVD_TYPE_DVDV 0xfe // DVD Video
+#define CDVD_TYPE_CDDA 0xfd // Audio CD
+#define CDVD_TYPE_PS2DVD 0x14 // PS2 DVD
+#define CDVD_TYPE_PS2CDDA 0x13 // PS2 CD (with audio)
+#define CDVD_TYPE_PS2CD 0x12 // PS2 CD
+#define CDVD_TYPE_PSCDDA 0x11 // PS CD (with audio)
+#define CDVD_TYPE_PSCD 0x10 // PS CD
+#define CDVD_TYPE_UNKNOWN 0x05 // Unknown
 #define CDVD_TYPE_DETCTDVDD 0x04 // Detecting Dvd Dual Sided
 #define CDVD_TYPE_DETCTDVDS 0x03 // Detecting Dvd Single Sided
-#define CDVD_TYPE_DETCTCD 0x02   // Detecting Cd
-#define CDVD_TYPE_DETCT 0x01     // Detecting
-#define CDVD_TYPE_NODISC 0x00    // No Disc
+#define CDVD_TYPE_DETCTCD 0x02 // Detecting Cd
+#define CDVD_TYPE_DETCT 0x01 // Detecting
+#define CDVD_TYPE_NODISC 0x00 // No Disc
 
 // CDVDgetTrayStatus returns:
 #define CDVD_TRAY_CLOSE 0x00
@@ -85,44 +87,42 @@ typedef struct _cdvdTN
 //	CDROM_DATA_TRACK	0x04	//do not enable this! (from linux kernel)
 
 // CDVD
-// NOTE: The read/write functions CANNOT use XMM/MMX regs
-// If you want to use them, need to save and restore current ones
-typedef s32(CALLBACK* _CDVDopen)(const char* pTitleFilename);
+typedef bool (*_CDVDopen)(std::string filename, Error* error);
 
 // Initiates an asynchronous track read operation.
 // Returns -1 on error (invalid track)
 // Returns 0 on success.
-typedef s32(CALLBACK* _CDVDreadTrack)(u32 lsn, int mode);
+typedef s32 (*_CDVDreadTrack)(u32 lsn, int mode);
 
 // Copies loaded data to the target buffer.
 // Returns -2 if the asynchronous read is still pending.
 // Returns -1 if the asyncronous read failed.
 // Returns 0 on success.
-typedef s32(CALLBACK* _CDVDgetBuffer)(u8* buffer);
+typedef s32 (*_CDVDgetBuffer)(u8* buffer);
 
-typedef s32(CALLBACK* _CDVDreadSubQ)(u32 lsn, cdvdSubQ* subq);
-typedef s32(CALLBACK* _CDVDgetTN)(cdvdTN* Buffer);
-typedef s32(CALLBACK* _CDVDgetTD)(u8 Track, cdvdTD* Buffer);
-typedef s32(CALLBACK* _CDVDgetTOC)(void* toc);
-typedef s32(CALLBACK* _CDVDgetDiskType)();
-typedef s32(CALLBACK* _CDVDgetTrayStatus)();
-typedef s32(CALLBACK* _CDVDctrlTrayOpen)();
-typedef s32(CALLBACK* _CDVDctrlTrayClose)();
-typedef s32(CALLBACK* _CDVDreadSector)(u8* buffer, u32 lsn, int mode);
-typedef s32(CALLBACK* _CDVDgetDualInfo)(s32* dualType, u32* _layer1start);
+typedef s32 (*_CDVDreadSubQ)(u32 lsn, cdvdSubQ* subq);
+typedef s32 (*_CDVDgetTN)(cdvdTN* Buffer);
+typedef s32 (*_CDVDgetTD)(u8 Track, cdvdTD* Buffer);
+typedef s32 (*_CDVDgetTOC)(void* toc);
+typedef s32 (*_CDVDgetDiskType)();
+typedef s32 (*_CDVDgetTrayStatus)();
+typedef s32 (*_CDVDctrlTrayOpen)();
+typedef s32 (*_CDVDctrlTrayClose)();
+typedef s32 (*_CDVDreadSector)(u8* buffer, u32 lsn, int mode);
+typedef s32 (*_CDVDgetDualInfo)(s32* dualType, u32* _layer1start);
 
-typedef void(CALLBACK* _CDVDnewDiskCB)(void (*callback)());
+typedef void (*_CDVDnewDiskCB)(void (*callback)());
 
 enum class CDVD_SourceType : uint8_t
 {
-	Iso,    // use built in ISO api
-	Disc,   // use built in Disc api
+	Iso, // use built in ISO api
+	Disc, // use built in Disc api
 	NoDisc, // use built in CDVDnull
 };
 
 struct CDVD_API
 {
-	void(CALLBACK* close)();
+	void (*close)();
 
 	// Don't need init or shutdown.  iso/nodisc have no init/shutdown.
 
@@ -148,11 +148,11 @@ struct CDVD_API
 //   Multiple interface system for CDVD.
 // ----------------------------------------------------------------------------
 
-extern CDVD_API* CDVD; // currently active CDVD access mode api (either Iso, NoDisc, or Disc)
+extern const CDVD_API* CDVD; // currently active CDVD access mode api (either Iso, NoDisc, or Disc)
 
-extern CDVD_API CDVDapi_Iso;
-extern CDVD_API CDVDapi_Disc;
-extern CDVD_API CDVDapi_NoDisc;
+extern const CDVD_API CDVDapi_Iso;
+extern const CDVD_API CDVDapi_Disc;
+extern const CDVD_API CDVDapi_NoDisc;
 
 extern void CDVDsys_ChangeSource(CDVD_SourceType type);
 extern void CDVDsys_SetFile(CDVD_SourceType srctype, std::string newfile);
@@ -160,7 +160,7 @@ extern const std::string& CDVDsys_GetFile(CDVD_SourceType srctype);
 extern CDVD_SourceType CDVDsys_GetSourceType();
 extern void CDVDsys_ClearFiles();
 
-extern bool DoCDVDopen();
+extern bool DoCDVDopen(Error* error);
 extern void DoCDVDclose();
 extern s32 DoCDVDreadSector(u8* buffer, u32 lsn, int mode);
 extern s32 DoCDVDreadTrack(u32 lsn, int mode);

--- a/pcsx2/CDVD/CDVDdiscReader.h
+++ b/pcsx2/CDVD/CDVDdiscReader.h
@@ -1,5 +1,5 @@
 /*  PCSX2 - PS2 Emulator for PCs
- *  Copyright (C) 2002-2020  PCSX2 Dev Team
+ *  Copyright (C) 2002-2023 PCSX2 Dev Team
  *
  *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU Lesser General Public License as published by the Free Software Found-
@@ -21,6 +21,8 @@
 
 #include <mutex>
 #include <array>
+
+class Error;
 
 struct track
 {
@@ -69,7 +71,7 @@ public:
 	IOCtlSrc(std::string filename);
 	~IOCtlSrc();
 
-	bool Reopen();
+	bool Reopen(Error* error);
 
 	u32 GetSectorCount() const;
 	const std::vector<toc_entry>& ReadTOC() const;
@@ -96,6 +98,5 @@ void cdvdStopThread();
 void cdvdRequestSector(u32 sector, s32 mode);
 u8* cdvdGetSector(u32 sector, s32 mode);
 s32 cdvdDirectReadSector(u32 sector, s32 mode, u8* buffer);
-s32 cdvdGetMediaType();
-s32 cdvdRefreshData();
+void cdvdRefreshData();
 void cdvdParseTOC();

--- a/pcsx2/CDVD/CDVDdiscThread.cpp
+++ b/pcsx2/CDVD/CDVDdiscThread.cpp
@@ -1,5 +1,5 @@
 /*  PCSX2 - PS2 Emulator for PCs
- *  Copyright (C) 2002-2020  PCSX2 Dev Team
+ *  Copyright (C) 2002-2023 PCSX2 Dev Team
  *
  *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU Lesser General Public License as published by the Free Software Found-
@@ -50,10 +50,10 @@ static std::atomic<bool> cdvd_is_open;
 //bits: 12 would use 1<<12 entries, or 4096*16 sectors ~ 128MB
 #define CACHE_SIZE 12
 
-const u32 CacheSize = 1U << CACHE_SIZE;
-SectorInfo Cache[CacheSize];
+static constexpr u32 CacheSize = 1U << CACHE_SIZE;
+static SectorInfo Cache[CacheSize];
 
-u32 cdvdSectorHash(u32 lsn)
+static u32 cdvdSectorHash(u32 lsn)
 {
 	u32 t = 0;
 
@@ -70,7 +70,7 @@ u32 cdvdSectorHash(u32 lsn)
 	return t & m;
 }
 
-void cdvdCacheUpdate(u32 lsn, u8* data)
+static void cdvdCacheUpdate(u32 lsn, u8* data)
 {
 	std::lock_guard<std::mutex> guard(s_cache_lock);
 	u32 entry = cdvdSectorHash(lsn);
@@ -79,7 +79,7 @@ void cdvdCacheUpdate(u32 lsn, u8* data)
 	Cache[entry].lsn = lsn;
 }
 
-bool cdvdCacheCheck(u32 lsn)
+static bool cdvdCacheCheck(u32 lsn)
 {
 	std::lock_guard<std::mutex> guard(s_cache_lock);
 	u32 entry = cdvdSectorHash(lsn);
@@ -87,7 +87,7 @@ bool cdvdCacheCheck(u32 lsn)
 	return Cache[entry].lsn == lsn;
 }
 
-bool cdvdCacheFetch(u32 lsn, u8* data)
+static bool cdvdCacheFetch(u32 lsn, u8* data)
 {
 	std::lock_guard<std::mutex> guard(s_cache_lock);
 	u32 entry = cdvdSectorHash(lsn);
@@ -101,7 +101,7 @@ bool cdvdCacheFetch(u32 lsn, u8* data)
 	return false;
 }
 
-void cdvdCacheReset()
+static void cdvdCacheReset()
 {
 	std::lock_guard<std::mutex> guard(s_cache_lock);
 	for (u32 i = 0; i < CacheSize; i++)
@@ -110,7 +110,7 @@ void cdvdCacheReset()
 	}
 }
 
-bool cdvdReadBlockOfSectors(u32 sector, u8* data)
+static bool cdvdReadBlockOfSectors(u32 sector, u8* data)
 {
 	u32 count = std::min(sectors_per_read, src->GetSectorCount() - sector);
 	const s32 media = src->GetMediaType();
@@ -133,14 +133,14 @@ bool cdvdReadBlockOfSectors(u32 sector, u8* data)
 	return false;
 }
 
-void cdvdCallNewDiscCB()
+static void cdvdCallNewDiscCB()
 {
 	weAreInNewDiskCB = true;
 	newDiscCB();
 	weAreInNewDiskCB = false;
 }
 
-bool cdvdUpdateDiscStatus()
+static bool cdvdUpdateDiscStatus()
 {
 	bool ready = src->DiscReady();
 
@@ -175,7 +175,7 @@ bool cdvdUpdateDiscStatus()
 	return !ready;
 }
 
-void cdvdThread()
+static void cdvdThread()
 {
 	u8 buffer[2352 * sectors_per_read];
 	u32 prefetches_left = 0;
@@ -379,12 +379,12 @@ s32 cdvdDirectReadSector(u32 sector, s32 mode, u8* buffer)
 	}
 }
 
-s32 cdvdGetMediaType()
+static s32 cdvdGetMediaType()
 {
 	return src->GetMediaType();
 }
 
-s32 cdvdRefreshData()
+void cdvdRefreshData()
 {
 	const char* diskTypeName = "Unknown";
 
@@ -428,6 +428,4 @@ s32 cdvdRefreshData()
 	printf(" * CDVD: Disk Type: %s\n", diskTypeName);
 
 	cdvdCacheReset();
-
-	return 0;
 }

--- a/pcsx2/CDVD/CDVDisoReader.cpp
+++ b/pcsx2/CDVD/CDVDisoReader.cpp
@@ -1,5 +1,5 @@
 /*  PCSX2 - PS2 Emulator for PCs
- *  Copyright (C) 2002-2010  PCSX2 Dev Team
+ *  Copyright (C) 2002-2023 PCSX2 Dev Team
  *
  *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU Lesser General Public License as published by the Free Software Found-
@@ -13,19 +13,13 @@
  *  If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-/*
- *  Original code from libcdvd by Hiryu & Sjeep (C) 2002
- *  Modified by Florin for PCSX2 emu
- *  Fixed CdRead by linuzappz
- */
-
 #include "PrecompiledHeader.h"
 #include "IsoFileFormats.h"
 #include "AsyncFileReader.h"
 #include "CDVD/CDVD.h"
 
 #include "common/Assertions.h"
+#include "common/Error.h"
 
 #include <cstring>
 #include <array>
@@ -37,23 +31,23 @@ static int pmode, cdtype;
 static s32 layer1start = -1;
 static bool layer1searched = false;
 
-void CALLBACK ISOclose()
+static void ISOclose()
 {
 	iso.Close();
 }
 
-s32 CALLBACK ISOopen(const char* pTitle)
+static bool ISOopen(std::string filename, Error* error)
 {
 	ISOclose(); // just in case
 
-	if ((pTitle == NULL) || (pTitle[0] == 0))
+	if (filename.empty())
 	{
-		Console.Error("CDVDiso Error: No filename specified.");
-		return -1;
+		Error::SetString(error, "No filename specified.");
+		return false;
 	}
 
-	if (!iso.Open(pTitle))
-		return -1;
+	if (!iso.Open(std::move(filename), error, false))
+		return false;
 
 	switch (iso.GetType())
 	{
@@ -71,10 +65,10 @@ s32 CALLBACK ISOopen(const char* pTitle)
 	layer1start = -1;
 	layer1searched = false;
 
-	return 0;
+	return true;
 }
 
-s32 CALLBACK ISOreadSubQ(u32 lsn, cdvdSubQ* subq)
+static s32 ISOreadSubQ(u32 lsn, cdvdSubQ* subq)
 {
 	// fake it
 	u8 min, sec, frm;
@@ -98,7 +92,7 @@ s32 CALLBACK ISOreadSubQ(u32 lsn, cdvdSubQ* subq)
 	return 0;
 }
 
-s32 CALLBACK ISOgetTN(cdvdTN* Buffer)
+static s32 ISOgetTN(cdvdTN* Buffer)
 {
 	Buffer->strack = 1;
 	Buffer->etrack = 1;
@@ -106,7 +100,7 @@ s32 CALLBACK ISOgetTN(cdvdTN* Buffer)
 	return 0;
 }
 
-s32 CALLBACK ISOgetTD(u8 Track, cdvdTD* Buffer)
+static s32 ISOgetTD(u8 Track, cdvdTD* Buffer)
 {
 	if (Track == 0)
 	{
@@ -170,7 +164,7 @@ static void FindLayer1Start()
 }
 
 // Should return 0 if no error occurred, or -1 if layer detection FAILED.
-s32 CALLBACK ISOgetDualInfo(s32* dualType, u32* _layer1start)
+static s32 ISOgetDualInfo(s32* dualType, u32* _layer1start)
 {
 	FindLayer1Start();
 
@@ -187,12 +181,12 @@ s32 CALLBACK ISOgetDualInfo(s32* dualType, u32* _layer1start)
 	return 0;
 }
 
-s32 CALLBACK ISOgetDiskType()
+static s32 ISOgetDiskType()
 {
 	return cdtype;
 }
 
-s32 CALLBACK ISOgetTOC(void* toc)
+static s32 ISOgetTOC(void* toc)
 {
 	u8 type = ISOgetDiskType();
 	u8* tocBuff = (u8*)toc;
@@ -326,7 +320,7 @@ s32 CALLBACK ISOgetTOC(void* toc)
 	return 0;
 }
 
-s32 CALLBACK ISOreadSector(u8* tempbuffer, u32 lsn, int mode)
+static s32 ISOreadSector(u8* tempbuffer, u32 lsn, int mode)
 {
 	static u8 cdbuffer[CD_FRAMESIZE_RAW] = {0};
 
@@ -377,7 +371,7 @@ s32 CALLBACK ISOreadSector(u8* tempbuffer, u32 lsn, int mode)
 	return 0;
 }
 
-s32 CALLBACK ISOreadTrack(u32 lsn, int mode)
+static s32 ISOreadTrack(u32 lsn, int mode)
 {
 	int _lsn = lsn;
 
@@ -391,41 +385,41 @@ s32 CALLBACK ISOreadTrack(u32 lsn, int mode)
 	return 0;
 }
 
-s32 CALLBACK ISOgetBuffer(u8* buffer)
+static s32 ISOgetBuffer(u8* buffer)
 {
 	return iso.FinishRead3(buffer, pmode);
 }
 
-//u8* CALLBACK ISOgetBuffer()
+//static u8* ISOgetBuffer()
 //{
 //	iso.FinishRead();
 //	return pbuffer;
 //}
 
-s32 CALLBACK ISOgetTrayStatus()
+static s32 ISOgetTrayStatus()
 {
 	return CDVD_TRAY_CLOSE;
 }
 
-s32 CALLBACK ISOctrlTrayOpen()
+static s32 ISOctrlTrayOpen()
 {
 	return 0;
 }
-s32 CALLBACK ISOctrlTrayClose()
-{
-	return 0;
-}
-
-s32 CALLBACK ISOdummyS32()
+static s32 ISOctrlTrayClose()
 {
 	return 0;
 }
 
-void CALLBACK ISOnewDiskCB(void (*/* callback */)())
+static s32 ISOdummyS32()
+{
+	return 0;
+}
+
+static void ISOnewDiskCB(void (* /* callback */)())
 {
 }
 
-CDVD_API CDVDapi_Iso =
+const CDVD_API CDVDapi_Iso =
 	{
 		ISOclose,
 
@@ -440,7 +434,6 @@ CDVD_API CDVDapi_Iso =
 		ISOdummyS32, // trayStatus
 		ISOdummyS32, // trayOpen
 		ISOdummyS32, // trayClose
-
 		ISOnewDiskCB,
 
 		ISOreadSector,

--- a/pcsx2/CDVD/ChdFileReader.cpp
+++ b/pcsx2/CDVD/ChdFileReader.cpp
@@ -176,27 +176,19 @@ static chd_file* OpenCHD(const std::string& filename, FileSystem::ManagedCFilePt
 	return chd;
 }
 
-bool ChdFileReader::Open2(std::string fileName)
+bool ChdFileReader::Open2(std::string filename, Error* error)
 {
 	Close2();
 
-	m_filename = std::move(fileName);
+	m_filename = std::move(filename);
 
-	auto fp = FileSystem::OpenManagedSharedCFile(m_filename.c_str(), "rb", FileSystem::FileShareMode::DenyWrite);
+	auto fp = FileSystem::OpenManagedSharedCFile(m_filename.c_str(), "rb", FileSystem::FileShareMode::DenyWrite, error);
 	if (!fp)
-	{
-		Console.Error(fmt::format("Failed to open CHD '{}': errno {}", m_filename, errno));
 		return false;
-	}
 
-	// TODO: Propagate error back to caller.
-	Error error;
-	ChdFile = OpenCHD(m_filename, std::move(fp), &error, 0);
+	ChdFile = OpenCHD(m_filename, std::move(fp), error, 0);
 	if (!ChdFile)
-	{
-		Console.Error(fmt::format("Failed to open CHD '{}': {}", m_filename, error.GetDescription()));
 		return false;
-	}
 
 	const chd_header* chd_header = chd_get_header(ChdFile);
 	hunk_size = chd_header->hunkbytes;

--- a/pcsx2/CDVD/ChdFileReader.h
+++ b/pcsx2/CDVD/ChdFileReader.h
@@ -19,17 +19,17 @@
 
 typedef struct _chd_file chd_file;
 
-class ChdFileReader : public ThreadedFileReader
+class ChdFileReader final : public ThreadedFileReader
 {
 	DeclareNoncopyableObject(ChdFileReader);
 
 public:
 	ChdFileReader();
-	virtual ~ChdFileReader() override;
+	~ChdFileReader() override;
 
 	static bool CanHandle(const std::string& fileName, const std::string& displayName);
 
-	bool Open2(std::string fileName) override;
+	bool Open2(std::string filename, Error* error) override;
 
 	Chunk ChunkForOffset(u64 offset) override;
 	int ReadChunk(void* dst, s64 blockID) override;

--- a/pcsx2/CDVD/CsoFileReader.cpp
+++ b/pcsx2/CDVD/CsoFileReader.cpp
@@ -1,28 +1,30 @@
 /*  PCSX2 - PS2 Emulator for PCs
-*  Copyright (C) 2002-2023  PCSX2 Dev Team
-*
-*  PCSX2 is free software: you can redistribute it and/or modify it under the terms
-*  of the GNU Lesser General Public License as published by the Free Software Found-
-*  ation, either version 3 of the License, or (at your option) any later version.
-*
-*  PCSX2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-*  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-*  PURPOSE.  See the GNU General Public License for more details.
-*
-*  You should have received a copy of the GNU General Public License along with PCSX2.
-*  If not, see <http://www.gnu.org/licenses/>.
-*/
+ *  Copyright (C) 2002-2023 PCSX2 Dev Team
+ *
+ *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU Lesser General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  PCSX2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with PCSX2.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
 
 #include "PrecompiledHeader.h"
 
 #include "AsyncFileReader.h"
 #include "CsoFileReader.h"
 
-#include "common/Pcsx2Types.h"
 #include "common/FileSystem.h"
+#include "common/Error.h"
 #include "common/StringUtil.h"
 
 #include <zlib.h>
+
+static constexpr u32 CSO_CHUNKCACHE_SIZE_MB = 200;
 
 // Implementation of CSO compressed ISO reading, based on:
 // https://github.com/unknownbrackets/maxcso/blob/master/README_CSO.md
@@ -39,6 +41,16 @@ struct CsoHeader
 
 static const u32 CSO_READ_BUFFER_SIZE = 256 * 1024;
 
+CsoFileReader::CsoFileReader()
+{
+	m_blocksize = 2048;
+}
+
+CsoFileReader::~CsoFileReader()
+{
+	Close();
+}
+
 bool CsoFileReader::CanHandle(const std::string& fileName, const std::string& displayName)
 {
 	bool supported = false;
@@ -50,7 +62,7 @@ bool CsoFileReader::CanHandle(const std::string& fileName, const std::string& di
 		{
 			if (fread(&hdr, 1, sizeof(hdr), fp) == sizeof(hdr))
 			{
-				supported = ValidateHeader(hdr);
+				supported = ValidateHeader(hdr, nullptr);
 			}
 			fclose(fp);
 		}
@@ -58,26 +70,27 @@ bool CsoFileReader::CanHandle(const std::string& fileName, const std::string& di
 	return supported;
 }
 
-bool CsoFileReader::ValidateHeader(const CsoHeader& hdr)
+bool CsoFileReader::ValidateHeader(const CsoHeader& hdr, Error* error)
 {
 	if (hdr.magic[0] != 'C' || hdr.magic[1] != 'I' || hdr.magic[2] != 'S' || hdr.magic[3] != 'O')
 	{
 		// Invalid magic, definitely a bad file.
+		Error::SetString(error, "File is not a CHD.");
 		return false;
 	}
 	if (hdr.ver > 1)
 	{
-		Console.Error("Only CSOv1 files are supported.");
+		Error::SetString(error, "Only CSOv1 files are supported.");
 		return false;
 	}
 	if ((hdr.frame_size & (hdr.frame_size - 1)) != 0)
 	{
-		Console.Error("CSO frame size must be a power of two.");
+		Error::SetString(error, "CSO frame size must be a power of two.");
 		return false;
 	}
 	if (hdr.frame_size < 2048)
 	{
-		Console.Error("CSO frame size must be at least one sector.");
+		Error::SetString(error, "CSO frame size must be at least one sector.");
 		return false;
 	}
 
@@ -85,14 +98,14 @@ bool CsoFileReader::ValidateHeader(const CsoHeader& hdr)
 	return true;
 }
 
-bool CsoFileReader::Open2(std::string fileName)
+bool CsoFileReader::Open2(std::string filename, Error* error)
 {
 	Close2();
-	m_filename = std::move(fileName);
-	m_src = FileSystem::OpenCFile(m_filename.c_str(), "rb");
+	m_filename = std::move(filename);
+	m_src = FileSystem::OpenCFile(m_filename.c_str(), "rb", error);
 
 	bool success = false;
-	if (m_src && ReadFileHeader() && InitializeBuffers())
+	if (m_src && ReadFileHeader(error) && InitializeBuffers(error))
 	{
 		success = true;
 	}
@@ -105,21 +118,18 @@ bool CsoFileReader::Open2(std::string fileName)
 	return true;
 }
 
-bool CsoFileReader::ReadFileHeader()
+bool CsoFileReader::ReadFileHeader(Error* error)
 {
-	CsoHeader hdr = {};
+	CsoHeader hdr;
 
 	if (FileSystem::FSeek64(m_src, m_dataoffset, SEEK_SET) != 0 || std::fread(&hdr, 1, sizeof(hdr), m_src) != sizeof(hdr))
 	{
-		Console.Error("Failed to read CSO file header.");
+		Error::SetString(error, "Failed to read CSO file header.");
 		return false;
 	}
 
-	if (!ValidateHeader(hdr))
-	{
-		Console.Error("CSO has invalid header.");
+	if (!ValidateHeader(hdr, error))
 		return false;
-	}
 
 	m_frameSize = hdr.frame_size;
 	// Determine the translation from bytes to frame.
@@ -136,7 +146,7 @@ bool CsoFileReader::ReadFileHeader()
 	return true;
 }
 
-bool CsoFileReader::InitializeBuffers()
+bool CsoFileReader::InitializeBuffers(Error* error)
 {
 	// Round up, since part of a frame requires a full frame.
 	u32 numFrames = (u32)((m_totalSize + m_frameSize - 1) / m_frameSize);
@@ -144,28 +154,28 @@ bool CsoFileReader::InitializeBuffers()
 	// We might read a bit of alignment too, so be prepared.
 	if (m_frameSize + (1 << m_indexShift) < CSO_READ_BUFFER_SIZE)
 	{
-		m_readBuffer = new u8[CSO_READ_BUFFER_SIZE];
+		m_readBuffer = std::make_unique<u8[]>(CSO_READ_BUFFER_SIZE);
 	}
 	else
 	{
-		m_readBuffer = new u8[m_frameSize + (1 << m_indexShift)];
+		m_readBuffer = std::make_unique<u8[]>(m_frameSize + (1 << m_indexShift));
 	}
 
 	const u32 indexSize = numFrames + 1;
-	m_index = new u32[indexSize];
-	if (fread(m_index, sizeof(u32), indexSize, m_src) != indexSize)
+	m_index = std::make_unique<u32[]>(indexSize);
+	if (fread(m_index.get(), sizeof(u32), indexSize, m_src) != indexSize)
 	{
-		Console.Error("Unable to read index data from CSO.");
+		Error::SetString(error, "Unable to read index data from CSO.");
 		return false;
 	}
 
-	m_z_stream = new z_stream;
+	m_z_stream = std::make_unique<z_stream>();
 	m_z_stream->zalloc = Z_NULL;
 	m_z_stream->zfree = Z_NULL;
 	m_z_stream->opaque = Z_NULL;
-	if (inflateInit2(m_z_stream, -15) != Z_OK)
+	if (inflateInit2(m_z_stream.get(), -15) != Z_OK)
 	{
-		Console.Error("Unable to initialize zlib for CSO decompression.");
+		Error::SetString(error, "Unable to initialize zlib for CSO decompression.");
 		return false;
 	}
 
@@ -179,24 +189,21 @@ void CsoFileReader::Close2()
 	if (m_src)
 	{
 		fclose(m_src);
-		m_src = NULL;
+		m_src = nullptr;
 	}
 	if (m_z_stream)
 	{
-		inflateEnd(m_z_stream);
-		m_z_stream = NULL;
+		inflateEnd(m_z_stream.get());
+		m_z_stream.reset();
 	}
 
-	if (m_readBuffer)
-	{
-		delete[] m_readBuffer;
-		m_readBuffer = NULL;
-	}
-	if (m_index)
-	{
-		delete[] m_index;
-		m_index = NULL;
-	}
+	m_readBuffer.reset();
+	m_index.reset();
+}
+
+u32 CsoFileReader::GetBlockCount() const
+{
+	return static_cast<u32>((m_totalSize - m_dataoffset) / m_blocksize);
 }
 
 ThreadedFileReader::Chunk CsoFileReader::ChunkForOffset(u64 offset)
@@ -215,7 +222,7 @@ ThreadedFileReader::Chunk CsoFileReader::ChunkForOffset(u64 offset)
 	return chunk;
 }
 
-int CsoFileReader::ReadChunk(void *dst, s64 chunkID)
+int CsoFileReader::ReadChunk(void* dst, s64 chunkID)
 {
 	if (chunkID < 0)
 		return -1;
@@ -250,19 +257,19 @@ int CsoFileReader::ReadChunk(void *dst, s64 chunkID)
 		}
 		// This might be less bytes than frameRawSize in case of padding on the last frame.
 		// This is because the index positions must be aligned.
-		const u32 readRawBytes = fread(m_readBuffer, 1, frameRawSize, m_src);
+		const u32 readRawBytes = fread(m_readBuffer.get(), 1, frameRawSize, m_src);
 
-		m_z_stream->next_in = m_readBuffer;
+		m_z_stream->next_in = m_readBuffer.get();
 		m_z_stream->avail_in = readRawBytes;
 		m_z_stream->next_out = static_cast<Bytef*>(dst);
 		m_z_stream->avail_out = m_frameSize;
 
-		int status = inflate(m_z_stream, Z_FINISH);
+		int status = inflate(m_z_stream.get(), Z_FINISH);
 		bool success = status == Z_STREAM_END && m_z_stream->total_out == m_frameSize;
 
 		if (!success)
 			Console.Error("Unable to decompress CSO frame using zlib.");
-		inflateReset(m_z_stream);
+		inflateReset(m_z_stream.get());
 
 		return success ? m_frameSize : 0;
 	}

--- a/pcsx2/CDVD/CsoFileReader.h
+++ b/pcsx2/CDVD/CsoFileReader.h
@@ -1,17 +1,17 @@
 /*  PCSX2 - PS2 Emulator for PCs
-*  Copyright (C) 2002-2014  PCSX2 Dev Team
-*
-*  PCSX2 is free software: you can redistribute it and/or modify it under the terms
-*  of the GNU Lesser General Public License as published by the Free Software Found-
-*  ation, either version 3 of the License, or (at your option) any later version.
-*
-*  PCSX2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-*  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-*  PURPOSE.  See the GNU General Public License for more details.
-*
-*  You should have received a copy of the GNU General Public License along with PCSX2.
-*  If not, see <http://www.gnu.org/licenses/>.
-*/
+ *  Copyright (C) 2002-2023  PCSX2 Dev Team
+ *
+ *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU Lesser General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  PCSX2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with PCSX2.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
 
 #pragma once
 
@@ -31,56 +31,40 @@
 struct CsoHeader;
 typedef struct z_stream_s z_stream;
 
-static const uint CSO_CHUNKCACHE_SIZE_MB = 200;
-
-class CsoFileReader : public ThreadedFileReader
+class CsoFileReader final : public ThreadedFileReader
 {
 	DeclareNoncopyableObject(CsoFileReader);
 
 public:
-	CsoFileReader(void)
-		: m_frameSize(0)
-		, m_frameShift(0)
-		, m_indexShift(0)
-		, m_readBuffer(0)
-		, m_index(0)
-		, m_totalSize(0)
-		, m_src(0)
-		, m_z_stream(0)
-	{
-		m_blocksize = 2048;
-	};
-
-	~CsoFileReader(void) { Close(); };
+	CsoFileReader();
+	~CsoFileReader() override;
 
 	static bool CanHandle(const std::string& fileName, const std::string& displayName);
-	bool Open2(std::string fileName) override;
+	bool Open2(std::string filename, Error* error) override;
 
 	Chunk ChunkForOffset(u64 offset) override;
-	int ReadChunk(void *dst, s64 chunkID) override;
+	int ReadChunk(void* dst, s64 chunkID) override;
 
-	void Close2(void) override;
+	void Close2() override;
 
-	uint GetBlockCount(void) const override
-	{
-		return (m_totalSize - m_dataoffset) / m_blocksize;
-	};
+	u32 GetBlockCount() const override;
 
 private:
-	static bool ValidateHeader(const CsoHeader& hdr);
-	bool ReadFileHeader();
-	bool InitializeBuffers();
+	static bool ValidateHeader(const CsoHeader& hdr, Error* error);
+	bool ReadFileHeader(Error* error);
+	bool InitializeBuffers(Error* error);
 	int ReadFromFrame(u8* dest, u64 pos, int maxBytes);
 	bool DecompressFrame(Bytef* dst, u32 frame, u32 readBufferSize);
 	bool DecompressFrame(u32 frame, u32 readBufferSize);
 
-	u32 m_frameSize;
-	u8 m_frameShift;
-	u8 m_indexShift;
-	u8* m_readBuffer;;
-	u32* m_index;
-	u64 m_totalSize;
+	u32 m_frameSize = 0;
+	u8 m_frameShift = 0;
+	u8 m_indexShift = 0;
+	std::unique_ptr<u8[]> m_readBuffer;
+
+	std::unique_ptr<u32[]> m_index;
+	u64 m_totalSize = 0;
 	// The actual source cso file handle.
-	FILE* m_src;
-	z_stream* m_z_stream;
+	std::FILE* m_src = nullptr;
+	std::unique_ptr<z_stream> m_z_stream;
 };

--- a/pcsx2/CDVD/Darwin/IOCtlSrc.cpp
+++ b/pcsx2/CDVD/Darwin/IOCtlSrc.cpp
@@ -1,5 +1,5 @@
 /*  PCSX2 - PS2 Emulator for PCs
- *  Copyright (C) 2002-2022  PCSX2 Dev Team
+ *  Copyright (C) 2002-2023 PCSX2 Dev Team
  *
  *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU Lesser General Public License as published by the Free Software Found-
@@ -16,6 +16,8 @@
 #include "PrecompiledHeader.h"
 #include "CDVD/CDVDdiscReader.h"
 #include "CDVD/CDVD.h"
+
+#include "common/Error.h"
 
 #ifdef __APPLE__
 #include <IOKit/storage/IOCDMediaBSDClient.h>
@@ -43,7 +45,7 @@ IOCtlSrc::~IOCtlSrc()
 	}
 }
 
-bool IOCtlSrc::Reopen()
+bool IOCtlSrc::Reopen(Error* error)
 {
 	if (m_device != -1)
 		close(m_device);
@@ -52,7 +54,10 @@ bool IOCtlSrc::Reopen()
 	// drive is empty. Probably does other things too.
 	m_device = open(m_filename.c_str(), O_RDONLY | O_NONBLOCK);
 	if (m_device == -1)
+	{
+		Error::SetErrno(error, errno);
 		return false;
+	}
 
 	// DVD detection MUST be first on Linux - The TOC ioctls work for both
 	// CDs and DVDs.
@@ -256,7 +261,7 @@ bool IOCtlSrc::DiscReady()
 
 	if (!m_sectors)
 	{
-		Reopen();
+		Reopen(nullptr);
 	}
 
 	return !!m_sectors;

--- a/pcsx2/CDVD/GzippedFileReader.h
+++ b/pcsx2/CDVD/GzippedFileReader.h
@@ -1,59 +1,53 @@
 /*  PCSX2 - PS2 Emulator for PCs
-*  Copyright (C) 2002-2014  PCSX2 Dev Team
-*
-*  PCSX2 is free software: you can redistribute it and/or modify it under the terms
-*  of the GNU Lesser General Public License as published by the Free Software Found-
-*  ation, either version 3 of the License, or (at your option) any later version.
-*
-*  PCSX2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-*  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-*  PURPOSE.  See the GNU General Public License for more details.
-*
-*  You should have received a copy of the GNU General Public License along with PCSX2.
-*  If not, see <http://www.gnu.org/licenses/>.
-*/
+ *  Copyright (C) 2002-2023 PCSX2 Dev Team
+ *
+ *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU Lesser General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  PCSX2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with PCSX2.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
 
 #pragma once
-
-typedef struct zstate Zstate;
 
 #include "AsyncFileReader.h"
 #include "ChunksCache.h"
 #include "zlib_indexed.h"
 
-#define GZFILE_SPAN_DEFAULT (1048576L * 4)  /* distance between direct access points when creating a new index */
-#define GZFILE_READ_CHUNK_SIZE (256 * 1024) /* zlib extraction chunks size (at 0-based boundaries) */
-#define GZFILE_CACHE_SIZE_MB 200            /* cache size for extracted data. must be at least GZFILE_READ_CHUNK_SIZE (in MB)*/
+static constexpr int GZFILE_SPAN_DEFAULT = (1048576 * 4); /* distance between direct access points when creating a new index */
+static constexpr int GZFILE_READ_CHUNK_SIZE = (256 * 1024); /* zlib extraction chunks size (at 0-based boundaries) */
+static constexpr int GZFILE_CACHE_SIZE_MB = 200; /* cache size for extracted data. must be at least GZFILE_READ_CHUNK_SIZE (in MB)*/
 
-class GzippedFileReader : public AsyncFileReader
+typedef struct zstate Zstate;
+
+class GzippedFileReader final : public AsyncFileReader
 {
 	DeclareNoncopyableObject(GzippedFileReader);
 
 public:
-	GzippedFileReader(void);
-
-	virtual ~GzippedFileReader(void) { Close(); };
+	GzippedFileReader();
+	~GzippedFileReader();;
 
 	static bool CanHandle(const std::string& fileName, const std::string& displayName);
-	virtual bool Open(std::string fileName);
+	bool Open(std::string filename, Error* error) override;
 
-	virtual int ReadSync(void* pBuffer, uint sector, uint count);
+	int ReadSync(void* pBuffer, u32 sector, u32 count) override;
 
-	virtual void BeginRead(void* pBuffer, uint sector, uint count);
-	virtual int FinishRead(void);
-	virtual void CancelRead(void){};
+	void BeginRead(void* pBuffer, u32 sector, u32 count);
+	int FinishRead();
+	void CancelRead();
 
-	virtual void Close(void);
+	void Close() override;
 
-	virtual uint GetBlockCount(void) const
-	{
-		// type and formula copied from FlatFileReader
-		// FIXME? : Shouldn't it be uint and (size - m_dataoffset) / m_blocksize ?
-		return (int)((m_pIndex ? m_pIndex->uncompressed_size : 0) / m_blocksize);
-	};
+	u32 GetBlockCount() const;
 
-	virtual void SetBlockSize(uint bytes) { m_blocksize = bytes; }
-	virtual void SetDataOffset(int bytes) { m_dataoffset = bytes; }
+	void SetBlockSize(u32 bytes) override;
+	void SetDataOffset(u32 bytes) override;
 
 private:
 	class Czstate
@@ -70,23 +64,23 @@ private:
 		Zstate state;
 	};
 
-	bool OkIndex(); // Verifies that we have an index, or try to create one
+	bool OkIndex(Error* error); // Verifies that we have an index, or try to create one
 	s64 GetOptimalExtractionStart(s64 offset);
 	int _ReadSync(void* pBuffer, s64 offset, uint bytesToRead);
 	void InitZstates();
 
-	int mBytesRead;   // Temp sync read result when simulating async read
-	Access* m_pIndex; // Quick access index
-	Czstate* m_zstates;
-	FILE* m_src;
+	int mBytesRead = 0; // Temp sync read result when simulating async read
+	Access* m_pIndex = nullptr; // Quick access index
+	Czstate* m_zstates = nullptr;
+	FILE* m_src = nullptr;
 
 	ChunksCache m_cache;
 
 #ifdef _WIN32
 	// Used by async prefetch
-	HANDLE hOverlappedFile;
-	OVERLAPPED asyncOperationContext;
-	bool asyncInProgress;
+	HANDLE hOverlappedFile = INVALID_HANDLE_VALUE;
+	OVERLAPPED asyncOperationContext = {};
+	bool asyncInProgress = false;
 	char mDummyAsyncPrefetchTarget[GZFILE_READ_CHUNK_SIZE];
 #endif
 

--- a/pcsx2/CDVD/IsoFileFormats.h
+++ b/pcsx2/CDVD/IsoFileFormats.h
@@ -21,6 +21,8 @@
 #include <memory>
 #include <string>
 
+class Error;
+
 enum isoType
 {
 	ISOTYPE_ILLEGAL = 0,
@@ -35,7 +37,7 @@ static const int CD_FRAMESIZE_RAW = 2448;
 // --------------------------------------------------------------------------------------
 //  isoFile
 // --------------------------------------------------------------------------------------
-class InputIsoFile
+class InputIsoFile final
 {
 	DeclareNoncopyableObject(InputIsoFile);
 
@@ -67,7 +69,7 @@ protected:
 
 public:
 	InputIsoFile();
-	virtual ~InputIsoFile();
+	~InputIsoFile();
 
 	bool IsOpened() const;
 
@@ -81,7 +83,7 @@ public:
 	}
 
 	bool Test(std::string srcfile);
-	bool Open(std::string srcfile, bool testOnly = false);
+	bool Open(std::string srcfile, Error* error, bool testOnly);
 	void Close();
 	bool Detect(bool readType = true);
 
@@ -97,7 +99,7 @@ protected:
 	void FindParts();
 };
 
-class OutputIsoFile
+class OutputIsoFile final
 {
 	DeclareNoncopyableObject(OutputIsoFile);
 
@@ -120,7 +122,7 @@ protected:
 
 public:
 	OutputIsoFile();
-	virtual ~OutputIsoFile();
+	~OutputIsoFile();
 
 	bool IsOpened() const;
 	u32 GetBlockSize() const;

--- a/pcsx2/CDVD/IsoHasher.cpp
+++ b/pcsx2/CDVD/IsoHasher.cpp
@@ -56,12 +56,9 @@ bool IsoHasher::Open(std::string iso_path, Error* error)
 	CDVDsys_SetFile(CDVD_SourceType::Iso, std::move(iso_path));
 	CDVDsys_ChangeSource(CDVD_SourceType::Iso);
 
-	m_is_open = DoCDVDopen();
+	m_is_open = DoCDVDopen(error);
 	if (!m_is_open)
-	{
-		Error::SetString(error, "Failed to open CDVD.");
 		return false;
-	}
 
 	const s32 type = DoCDVDdetectDiskType();
 	switch (type)

--- a/pcsx2/CDVD/Linux/IOCtlSrc.cpp
+++ b/pcsx2/CDVD/Linux/IOCtlSrc.cpp
@@ -1,5 +1,5 @@
 /*  PCSX2 - PS2 Emulator for PCs
- *  Copyright (C) 2002-2020  PCSX2 Dev Team
+ *  Copyright (C) 2002-2023 PCSX2 Dev Team
  *
  *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU Lesser General Public License as published by the Free Software Found-
@@ -16,6 +16,8 @@
 #include "PrecompiledHeader.h"
 #include "CDVD/CDVDdiscReader.h"
 #include "CDVD/CDVD.h"
+
+#include "common/Error.h"
 
 #include <linux/cdrom.h>
 #include <fcntl.h>
@@ -40,7 +42,7 @@ IOCtlSrc::~IOCtlSrc()
 	}
 }
 
-bool IOCtlSrc::Reopen()
+bool IOCtlSrc::Reopen(Error* error)
 {
 	if (m_device != -1)
 		close(m_device);
@@ -49,7 +51,10 @@ bool IOCtlSrc::Reopen()
 	// drive is empty. Probably does other things too.
 	m_device = open(m_filename.c_str(), O_RDONLY | O_NONBLOCK);
 	if (m_device == -1)
+	{
+		Error::SetErrno(error, errno);
 		return false;
+	}
 
 	// DVD detection MUST be first on Linux - The TOC ioctls work for both
 	// CDs and DVDs.
@@ -211,7 +216,7 @@ bool IOCtlSrc::DiscReady()
 	if (ioctl(m_device, CDROM_DRIVE_STATUS, CDSL_CURRENT) == CDS_DISC_OK)
 	{
 		if (!m_sectors)
-			Reopen();
+			Reopen(nullptr);
 	}
 	else
 	{

--- a/pcsx2/CDVD/ThreadedFileReader.cpp
+++ b/pcsx2/CDVD/ThreadedFileReader.cpp
@@ -1,5 +1,5 @@
 /*  PCSX2 - PS2 Emulator for PCs
- *  Copyright (C) 2002-2021 PCSX2 Dev Team
+ *  Copyright (C) 2002-2023 PCSX2 Dev Team
  *
  *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU Lesser General Public License as published by the Free Software Found-
@@ -256,13 +256,13 @@ bool ThreadedFileReader::TryCachedRead(void*& buffer, u64& offset, u32& size, co
 	return allDone;
 }
 
-bool ThreadedFileReader::Open(std::string fileName)
+bool ThreadedFileReader::Open(std::string filename, Error* error)
 {
 	CancelAndWaitUntilStopped();
-	return Open2(std::move(fileName));
+	return Open2(std::move(filename), error);
 }
 
-int ThreadedFileReader::ReadSync(void* pBuffer, uint sector, uint count)
+int ThreadedFileReader::ReadSync(void* pBuffer, u32 sector, u32 count)
 {
 	u32 blocksize = InternalBlockSize();
 	u64 offset = (u64)sector * (u64)blocksize + m_dataoffset;
@@ -316,7 +316,7 @@ void ThreadedFileReader::CancelAndWaitUntilStopped(void)
 		m_condition.wait(lock);
 }
 
-void ThreadedFileReader::BeginRead(void* pBuffer, uint sector, uint count)
+void ThreadedFileReader::BeginRead(void* pBuffer, u32 sector, u32 count)
 {
 	s32 blocksize = InternalBlockSize();
 	u64 offset = (u64)sector * (u64)blocksize + m_dataoffset;
@@ -371,12 +371,12 @@ void ThreadedFileReader::Close(void)
 	Close2();
 }
 
-void ThreadedFileReader::SetBlockSize(uint bytes)
+void ThreadedFileReader::SetBlockSize(u32 bytes)
 {
 	m_blocksize = bytes;
 }
 
-void ThreadedFileReader::SetDataOffset(int bytes)
+void ThreadedFileReader::SetDataOffset(u32 bytes)
 {
 	m_dataoffset = bytes;
 }

--- a/pcsx2/CDVD/ThreadedFileReader.h
+++ b/pcsx2/CDVD/ThreadedFileReader.h
@@ -1,5 +1,5 @@
 /*  PCSX2 - PS2 Emulator for PCs
- *  Copyright (C) 2002-2021 PCSX2 Dev Team
+ *  Copyright (C) 2002-2023 PCSX2 Dev Team
  *
  *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU Lesser General Public License as published by the Free Software Found-
@@ -46,9 +46,9 @@ protected:
 	/// Synchronously read the given block into `dst`
 	virtual int ReadChunk(void* dst, s64 chunkID) = 0;
 	/// AsyncFileReader open but ThreadedFileReader needs prep work first
-	virtual bool Open2(std::string fileName) = 0;
+	virtual bool Open2(std::string filename, Error* error) = 0;
 	/// AsyncFileReader close but ThreadedFileReader needs prep work first
-	virtual void Close2(void) = 0;
+	virtual void Close2() = 0;
 
 	ThreadedFileReader();
 	~ThreadedFileReader();
@@ -108,12 +108,12 @@ private:
 	bool TryCachedRead(void*& buffer, u64& offset, u32& size, const std::lock_guard<std::mutex>&);
 
 public:
-	bool Open(std::string fileName) final override;
-	int ReadSync(void* pBuffer, uint sector, uint count) final override;
-	void BeginRead(void* pBuffer, uint sector, uint count) final override;
-	int FinishRead(void) final override;
-	void CancelRead(void) final override;
-	void Close(void) final override;
-	void SetBlockSize(uint bytes) final override;
-	void SetDataOffset(int bytes) final override;
+	bool Open(std::string filename, Error* error) final override;
+	int ReadSync(void* pBuffer, u32 sector, u32 count) final override;
+	void BeginRead(void* pBuffer, u32 sector, u32 count) final override;
+	int FinishRead() final override;
+	void CancelRead() final override;
+	void Close() final override;
+	void SetBlockSize(u32 bytes) final override;
+	void SetDataOffset(u32 bytes) final override;
 };

--- a/pcsx2/CDVD/Windows/IOCtlSrc.cpp
+++ b/pcsx2/CDVD/Windows/IOCtlSrc.cpp
@@ -1,5 +1,5 @@
 /*  PCSX2 - PS2 Emulator for PCs
- *  Copyright (C) 2002-2020  PCSX2 Dev Team
+ *  Copyright (C) 2002-2023 PCSX2 Dev Team
  *
  *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU Lesser General Public License as published by the Free Software Found-
@@ -16,7 +16,9 @@
 #include "PrecompiledHeader.h"
 #include "CDVD/CDVDdiscReader.h"
 #include "CDVD/CDVD.h"
+
 #include "common/Console.h"
+#include "common/Error.h"
 
 #include <winioctl.h>
 #include <ntddcdvd.h>
@@ -49,7 +51,7 @@ IOCtlSrc::~IOCtlSrc()
 
 // If a new disc is inserted, ReadFile will fail unless the device is closed
 // and reopened.
-bool IOCtlSrc::Reopen()
+bool IOCtlSrc::Reopen(Error* error)
 {
 	if (m_device != INVALID_HANDLE_VALUE)
 		CloseHandle(m_device);
@@ -59,7 +61,10 @@ bool IOCtlSrc::Reopen()
 						  FILE_SHARE_READ, nullptr, OPEN_EXISTING,
 						  FILE_FLAG_SEQUENTIAL_SCAN, nullptr);
 	if (m_device == INVALID_HANDLE_VALUE)
+	{
+		Error::SetWin32(error, GetLastError());
 		return false;
+	}
 
 	DWORD unused;
 	// Required to read from layer 1 of Dual layer DVDs
@@ -321,7 +326,7 @@ bool IOCtlSrc::DiscReady()
 						nullptr, 0, &unused, nullptr))
 	{
 		if (!m_sectors)
-			Reopen();
+			Reopen(nullptr);
 	}
 	else
 	{

--- a/pcsx2/GameList.cpp
+++ b/pcsx2/GameList.cpp
@@ -1,5 +1,5 @@
 /*  PCSX2 - PS2 Emulator for PCs
- *  Copyright (C) 2002-2023  PCSX2 Dev Team
+ *  Copyright (C) 2002-2023 PCSX2 Dev Team
  *
  *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU Lesser General Public License as published by the Free Software Found-
@@ -25,6 +25,7 @@
 #include "common/Assertions.h"
 #include "common/Console.h"
 #include "common/FileSystem.h"
+#include "common/Error.h"
 #include "common/HTTPDownloader.h"
 #include "common/HeterogeneousContainers.h"
 #include "common/Path.h"
@@ -171,10 +172,15 @@ void GameList::FillBootParametersForEntry(VMBootParameters* params, const Entry*
 
 bool GameList::GetIsoSerialAndCRC(const std::string& path, s32* disc_type, std::string* serial, u32* crc)
 {
+	Error error;
+
 	// This isn't great, we really want to make it all thread-local...
 	CDVD = &CDVDapi_Iso;
-	if (CDVD->open(path.c_str()) != 0)
+	if (!CDVD->open(path, &error))
+	{
+		Console.Error(fmt::format("(GameList::GetIsoSerialAndCRC) CDVD open of '{}' failed: {}", path, error.GetDescription()));
 		return false;
+	}
 
 	// TODO: we could include the version in the game list?
 	*disc_type = DoCDVDdetectDiskType();

--- a/pcsx2/Linux/LnxFlatFileReader.cpp
+++ b/pcsx2/Linux/LnxFlatFileReader.cpp
@@ -1,5 +1,5 @@
 /*  PCSX2 - PS2 Emulator for PCs
- *  Copyright (C) 2002-2014  PCSX2 Dev Team
+ *  Copyright (C) 2002-2023 PCSX2 Dev Team
  *
  *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU Lesser General Public License as published by the Free Software Found-
@@ -15,6 +15,7 @@
 
 #include "PrecompiledHeader.h"
 #include "AsyncFileReader.h"
+
 #include "common/FileSystem.h"
 
 #include <unistd.h>
@@ -29,31 +30,31 @@ FlatFileReader::FlatFileReader(bool shareWrite)
 	m_aio_context = 0;
 }
 
-FlatFileReader::~FlatFileReader(void)
+FlatFileReader::~FlatFileReader()
 {
 	Close();
 }
 
-bool FlatFileReader::Open(std::string fileName)
+bool FlatFileReader::Open(std::string filename, Error* error)
 {
-	m_filename = std::move(fileName);
+	m_filename = std::move(filename);
 
 	int err = io_setup(64, &m_aio_context);
 	if (err)
 		return false;
 
-	m_fd = FileSystem::OpenFDFile(m_filename.c_str(), O_RDONLY, 0);
+	m_fd = FileSystem::OpenFDFile(m_filename.c_str(), O_RDONLY, 0, error);
 
 	return (m_fd != -1);
 }
 
-int FlatFileReader::ReadSync(void* pBuffer, uint sector, uint count)
+int FlatFileReader::ReadSync(void* pBuffer, u32 sector, u32 count)
 {
 	BeginRead(pBuffer, sector, count);
 	return FinishRead();
 }
 
-void FlatFileReader::BeginRead(void* pBuffer, uint sector, uint count)
+void FlatFileReader::BeginRead(void* pBuffer, u32 sector, u32 count)
 {
 	u64 offset;
 	offset = sector * (s64)m_blocksize + m_dataoffset;
@@ -67,7 +68,7 @@ void FlatFileReader::BeginRead(void* pBuffer, uint sector, uint count)
 	io_submit(m_aio_context, 1, &iocbs);
 }
 
-int FlatFileReader::FinishRead(void)
+int FlatFileReader::FinishRead()
 {
 	struct io_event event;
 
@@ -78,7 +79,7 @@ int FlatFileReader::FinishRead(void)
 	return event.res;
 }
 
-void FlatFileReader::CancelRead(void)
+void FlatFileReader::CancelRead()
 {
 	// Will be done when m_aio_context context is destroyed
 	// Note: io_cancel exists but need the iocb structure as parameter
@@ -86,7 +87,7 @@ void FlatFileReader::CancelRead(void)
 	//                struct io_event *result);
 }
 
-void FlatFileReader::Close(void)
+void FlatFileReader::Close()
 {
 	if (m_fd != -1)
 		close(m_fd);
@@ -97,11 +98,11 @@ void FlatFileReader::Close(void)
 	m_aio_context = 0;
 }
 
-uint FlatFileReader::GetBlockCount(void) const
+u32 FlatFileReader::GetBlockCount() const
 {
 	struct stat sysStatData;
 	if (fstat(m_fd, &sysStatData) < 0)
 		return 0;
 
-	return static_cast<uint>(sysStatData.st_size / m_blocksize);
+	return static_cast<u32>(sysStatData.st_size / m_blocksize);
 }

--- a/pcsx2/MultipartFileReader.cpp
+++ b/pcsx2/MultipartFileReader.cpp
@@ -1,5 +1,5 @@
 /*  PCSX2 - PS2 Emulator for PCs
- *  Copyright (C) 2002-2014  PCSX2 Dev Team
+ *  Copyright (C) 2002-2023 PCSX2 Dev Team
  *
  *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU Lesser General Public License as published by the Free Software Found-
@@ -15,8 +15,10 @@
 
 #include "PrecompiledHeader.h"
 #include "AsyncFileReader.h"
+
 #include "common/Assertions.h"
 #include "common/FileSystem.h"
+#include "common/Error.h"
 #include "common/Path.h"
 #include "common/StringUtil.h"
 
@@ -120,7 +122,7 @@ void MultipartFileReader::FindParts()
 		Part* thispart = m_parts + m_numparts;
 		AsyncFileReader* thisreader = new FlatFileReader();
 
-		if (!thisreader->Open(nameparts))
+		if (!thisreader->Open(nameparts, nullptr))
 		{
 			delete thisreader;
 			break;
@@ -147,8 +149,9 @@ void MultipartFileReader::FindParts()
 	//Console.WriteLn( Color_Blue, "isoFile: multi-part ISO loaded (%u parts found)", m_numparts );
 }
 
-bool MultipartFileReader::Open(std::string fileName)
+bool MultipartFileReader::Open(std::string filename, Error* error)
 {
+	Error::SetString(error, "Cannot open a MultipartFileReader directly.");
 	// Cannot open a MultipartFileReader directly,
 	// use DetectMultipart to convert a FlatFileReader
 	return false;


### PR DESCRIPTION
### Description of Changes

Currently, we give a pretty crappy error if a user tries to open an invalid/corrupted file. Just "failed to open CDVD". This PR propagates errors from the file backends up to the host, so the user can get _some_ clue about what's going on.

### Rationale behind Changes

![image](https://github.com/PCSX2/pcsx2/assets/11288319/ee9801f5-1477-4016-bc24-7bebba8040a0)

Also cleans up a bunch of crusty old code in CDVD (still pretty yuck), `void funcname(void)`, get rid of `CALLBACK`, etc.

### Suggested Testing Steps

Check compressed and non-compressed ISOs on Windows and Linux.
Check starting direct from DVD on Windows and Linux (if possible).
