### PR TITLE
GS/HW: Update dirty depth in matching format

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -5435,10 +5435,25 @@ void GSTextureCache::Target::Update()
 
 	if (ndrects > 0)
 	{
+		ShaderConvert depth_shader = upscaled ? ShaderConvert::RGBA8_TO_FLOAT32_BILN : ShaderConvert::RGBA8_TO_FLOAT32;
+		if (m_type == DepthStencil && GSLocalMemory::m_psm[m_TEX0.PSM].trbpp != 32)
+		{
+			switch (GSLocalMemory::m_psm[m_TEX0.PSM].trbpp)
+			{
+				case 24:
+					depth_shader = upscaled ? ShaderConvert::RGBA8_TO_FLOAT24_BILN : ShaderConvert::RGBA8_TO_FLOAT24;
+					break;
+				case 16:
+					depth_shader = upscaled ? ShaderConvert::RGB5A1_TO_FLOAT16_BILN : ShaderConvert::RGB5A1_TO_FLOAT16;
+					break;
+				default:
+					break;
+			}
+		}
+
 		// No need to sort here, it's all the one texture.
-		const ShaderConvert shader = (m_type == RenderTarget) ? ShaderConvert::COPY :
-																(upscaled ? ShaderConvert::RGBA8_TO_FLOAT32_BILN :
-																			ShaderConvert::RGBA8_TO_FLOAT32);
+		const ShaderConvert shader = (m_type == RenderTarget) ? ShaderConvert::COPY : depth_shader;
+
 		g_gs_device->DrawMultiStretchRects(drects, ndrects, m_texture, shader);
 	}
 


### PR DESCRIPTION
### Description of Changes
Correctly update dirty depth with the correct format, when local memory invalidates buffers.

### Rationale behind Changes
this was always doing 32bit and making the depth buffer incorrect, which broke a bunch of games.

### Suggested Testing Steps
Test random stuff but also test Glass Rose, Kamen Rider, Warship Gunner 2, and Sakura Taisen

Fixes #9981 Karmen Riders missing characters in HW
Fixes #7553 Warship Gunner 2 shadows and geometry (the hull problem had been previously fixed but shadows were missing)
Fixes #1919 Sakura Taisen shadows (the ground was fixed previously)
Fixes Glass Rose missing ghosts in hardware

Glass Rose:
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/942f962a-ddb3-4e77-b99f-e38090ea0043)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/f1da85a3-6b3f-474c-a4e8-4ed1ac651ade)

Kamen Rider:
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/96b72a99-7f76-41eb-9b13-5f440e4cb378)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/2a67b443-ad75-41a9-a249-489fc92e9748)

Warship Gunner 2:
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/cb970fe6-77c0-4051-b426-7b783ba54b1c)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/63242f91-345e-4601-94af-53529116b310)

Sakura Taisen:
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/95e9a6c0-9fea-46bd-abf3-75b86d0887af)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/bf1b1a7a-f912-4bbf-a116-1ab5845a353e)
