### PR TITLE
Misc: Clean up snprintf() usage

### DIFF
--- a/3rdparty/simpleini/include/SimpleIni.h
+++ b/3rdparty/simpleini/include/SimpleIni.h
@@ -2073,11 +2073,7 @@ CSimpleIniTempl<SI_CHAR,SI_STRLESS,SI_CONVERTER>::SetLongValue(
 
     // convert to an ASCII string
     char szInput[64];
-#if __STDC_WANT_SECURE_LIB__ && !_WIN32_WCE
-    sprintf_s(szInput, a_bUseHex ? "0x%lx" : "%ld", a_nValue);
-#else // !__STDC_WANT_SECURE_LIB__
-    sprintf(szInput, a_bUseHex ? "0x%lx" : "%ld", a_nValue);
-#endif // __STDC_WANT_SECURE_LIB__
+    snprintf(szInput, sizeof(szInput), a_bUseHex ? "0x%lx" : "%ld", a_nValue);
 
     // convert to output text
     SI_CHAR szOutput[64];
@@ -2135,11 +2131,7 @@ CSimpleIniTempl<SI_CHAR,SI_STRLESS,SI_CONVERTER>::SetDoubleValue(
 
 	// convert to an ASCII string
 	char szInput[64];
-#if __STDC_WANT_SECURE_LIB__ && !_WIN32_WCE
-	sprintf_s(szInput, "%f", a_nValue);
-#else // !__STDC_WANT_SECURE_LIB__
-	sprintf(szInput, "%f", a_nValue);
-#endif // __STDC_WANT_SECURE_LIB__
+	snprintf(szInput, sizeof(szInput), "%f", a_nValue);
 
 	// convert to output text
 	SI_CHAR szOutput[64];

--- a/pcsx2/DEV9/pcap_io.cpp
+++ b/pcsx2/DEV9/pcap_io.cpp
@@ -321,11 +321,10 @@ bool PCAPAdapter::InitPCAP(const std::string& adapter, bool promiscuous)
 bool PCAPAdapter::SetMACSwitchedFilter(MAC_Address mac)
 {
 	bpf_program fp;
-	char filter[1024] = "ether broadcast or ether dst ";
 
-	char virtual_mac_str[18];
-	sprintf(virtual_mac_str, "%.2x:%.2x:%.2x:%.2x:%.2x:%.2x", mac.bytes[0], mac.bytes[1], mac.bytes[2], mac.bytes[3], mac.bytes[4], mac.bytes[5]);
-	strcat(filter, virtual_mac_str);
+	char filter[128];
+	std::snprintf(filter, std::size(filter), "ether broadcast or ether dst %.2x:%.2x:%.2x:%.2x:%.2x:%.2x",
+		mac.bytes[0], mac.bytes[1], mac.bytes[2], mac.bytes[3], mac.bytes[4], mac.bytes[5]);
 
 	if (pcap_compile(hpcap, &fp, filter, 1, PCAP_NETMASK_UNKNOWN) == -1)
 	{

--- a/pcsx2/DebugTools/DebugInterface.cpp
+++ b/pcsx2/DebugTools/DebugInterface.cpp
@@ -31,6 +31,11 @@
 
 #include "common/StringUtil.h"
 
+#ifdef __clang__
+// TODO: The sprintf() usage here needs to be rewritten...
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
 R5900DebugInterface r5900Debug;
 R3000DebugInterface r3000Debug;
 
@@ -67,7 +72,7 @@ public:
 		for (int i = 0; i < 32; i++)
 		{
 			char reg[8];
-			sprintf(reg, "r%d", i);
+			std::snprintf(reg, std::size(reg), "r%d", i);
 
 			if (strcasecmp(str, reg) == 0 || strcasecmp(str, cpu->getRegisterName(0, i)) == 0)
 			{

--- a/pcsx2/DebugTools/DisR3000A.cpp
+++ b/pcsx2/DebugTools/DisR3000A.cpp
@@ -45,7 +45,7 @@ typedef char* (*TdisR3000AF)(u32 code, u32 pc);
 #define MakeDisFg(fn, b) char* fn(u32 code, u32 pc) { b; return ostr; }
 #define MakeDisF(fn, b) \
 	static char* fn(u32 code, u32 pc) { \
-		sprintf (ostr, "%8.8x %8.8x:", pc, code); \
+		std::snprintf(ostr, sizeof(ostr), "%8.8x %8.8x:", pc, code); \
 		b; /*ostr[(strlen(ostr) - 1)] = 0;*/ return ostr; \
 	}
 
@@ -69,17 +69,17 @@ typedef char* (*TdisR3000AF)(u32 code, u32 pc);
 #define _Branch_  (pc + 4 + ((short)_Im_ * 4))
 #define _OfB_     _Im_, _nRs_
 
-#define dName(i)	sprintf(ostr + strlen(ostr), " %-7s,", i)
-#define dGPR(i)		sprintf(ostr + strlen(ostr), " %8.8x (%s),", psxRegs.GPR.r[i], disRNameGPR[i])
-#define dCP0(i)		sprintf(ostr + strlen(ostr), " %8.8x (%s),", psxRegs.CP0.r[i], disRNameCP0[i])
-#define dHI()		sprintf(ostr + strlen(ostr), " %8.8x (%s),", psxRegs.GPR.n.hi, "hi")
-#define dLO()		sprintf(ostr + strlen(ostr), " %8.8x (%s),", psxRegs.GPR.n.lo, "lo")
-#define dImm()		sprintf(ostr + strlen(ostr), " %4.4x (%d),", _Im_, _Im_)
-#define dTarget()	sprintf(ostr + strlen(ostr), " %8.8x,", _InstrucTarget_)
-#define dSa()		sprintf(ostr + strlen(ostr), " %2.2x (%d),", _Sa_, _Sa_)
-#define dOfB()		sprintf(ostr + strlen(ostr), " %4.4x (%8.8x (%s)),", _Im_, psxRegs.GPR.r[_Rs_], disRNameGPR[_Rs_])
-#define dOffset()	sprintf(ostr + strlen(ostr), " %8.8x,", _Branch_)
-#define dCode()		sprintf(ostr + strlen(ostr), " %8.8x,", (code >> 6) & 0xffffff)
+#define dName(i)	std::snprintf(ostr + std::strlen(ostr), std::size(ostr) - std::strlen(ostr), " %-7s,", i)
+#define dGPR(i)		std::snprintf(ostr + std::strlen(ostr), std::size(ostr) - std::strlen(ostr), " %8.8x (%s),", psxRegs.GPR.r[i], disRNameGPR[i])
+#define dCP0(i)		std::snprintf(ostr + std::strlen(ostr), std::size(ostr) - std::strlen(ostr), " %8.8x (%s),", psxRegs.CP0.r[i], disRNameCP0[i])
+#define dHI()		std::snprintf(ostr + std::strlen(ostr), std::size(ostr) - std::strlen(ostr), " %8.8x (%s),", psxRegs.GPR.n.hi, "hi")
+#define dLO()		std::snprintf(ostr + std::strlen(ostr), std::size(ostr) - std::strlen(ostr), " %8.8x (%s),", psxRegs.GPR.n.lo, "lo")
+#define dImm()		std::snprintf(ostr + std::strlen(ostr), std::size(ostr) - std::strlen(ostr), " %4.4x (%d),", _Im_, _Im_)
+#define dTarget()	std::snprintf(ostr + std::strlen(ostr), std::size(ostr) - std::strlen(ostr), " %8.8x,", _InstrucTarget_)
+#define dSa()		std::snprintf(ostr + std::strlen(ostr), std::size(ostr) - std::strlen(ostr), " %2.2x (%d),", _Sa_, _Sa_)
+#define dOfB()		std::snprintf(ostr + std::strlen(ostr), std::size(ostr) - std::strlen(ostr), " %4.4x (%8.8x (%s)),", _Im_, psxRegs.GPR.r[_Rs_], disRNameGPR[_Rs_])
+#define dOffset()	std::snprintf(ostr + std::strlen(ostr), std::size(ostr) - std::strlen(ostr), " %8.8x,", _Branch_)
+#define dCode()		std::snprintf(ostr + std::strlen(ostr), std::size(ostr) - std::strlen(ostr), " %8.8x,", (code >> 6) & 0xffffff)
 
 /*********************************************************
 * Arithmetic with immediate operand                      *

--- a/pcsx2/DebugTools/DisR5900asm.cpp
+++ b/pcsx2/DebugTools/DisR5900asm.cpp
@@ -697,7 +697,7 @@ void P_COP2_Unknown( std::string& output )
 void label_decode( std::string& output, u32 addr )
 {
 	char buffer[32];
-	sprintf(buffer, "->$0x%08X", addr);
+	std::snprintf(buffer, std::size(buffer), "->$0x%08X", addr);
 	output += std::string(buffer);
 }
 
@@ -751,9 +751,9 @@ const char* signedImmediate(s32 imm, int len = 0)
 	static char buffer[32];
 
 	if (imm >= 0)
-		sprintf(buffer,"0x%*X",len,imm);
+		std::snprintf(buffer,std::size(buffer),"0x%*X",len,imm);
 	else
-		sprintf(buffer,"-0x%*X",len,-imm);
+		std::snprintf(buffer,std::size(buffer),"-0x%*X",len,-imm);
 
 	return buffer;
 }
@@ -762,12 +762,12 @@ const char* disDestSource(int dest, int source)
 {
 	static char buffer[64];
 #ifdef PRINT_REG_CONTENT
-	sprintf(buffer,"%s,%s(0x%8.8x)",GPR_REG[dest],GPR_REG[source], cpuRegs.GPR.r[source].UL[0]);
+	std::snprintf(buffer,std::size(buffer),"%s,%s(0x%8.8x)",GPR_REG[dest],GPR_REG[source], cpuRegs.GPR.r[source].UL[0]);
 #else
 	if (disSimplify && dest == source)
-		sprintf(buffer,"%s",GPR_REG[dest]);
+		std::snprintf(buffer,std::size(buffer),"%s",GPR_REG[dest]);
 	else
-		sprintf(buffer,"%s,%s",GPR_REG[dest],GPR_REG[source]);
+		std::snprintf(buffer,std::size(buffer),"%s,%s",GPR_REG[dest],GPR_REG[source]);
 
 #endif
 

--- a/pcsx2/DebugTools/DisVU0Micro.cpp
+++ b/pcsx2/DebugTools/DisVU0Micro.cpp
@@ -19,7 +19,8 @@
 #include "Debug.h"
 
 static char ostr[1024];
-#define ostrA (ostr + strlen(ostr))
+#define ostrA (ostr + std::strlen(ostr))
+#define ostrAL (std::size(ostr) - std::strlen(ostr))
 
 // Type deffinition of our functions
 #define DisFInterface  (u32 code, u32 pc)
@@ -31,7 +32,7 @@ typedef char* (*TdisR5900F)DisFInterface;
 // These macros are used to assemble the disassembler functions
 #define MakeDisF(fn, b) \
 	char* fn DisFInterface { \
-		sprintf (ostr, "%8.8x %8.8x:", pc, code); \
+		std::snprintf (ostr, std::size(ostr), "%8.8x %8.8x:", pc, code); \
 		b; \
 		return ostr; \
 	}
@@ -44,22 +45,22 @@ typedef char* (*TdisR5900F)DisFInterface;
 #define _Is_ (_Fs_ & 15)
 #define _Id_ (_Fd_ & 15)
 
-#define dName(i)	sprintf(ostrA, " %-7s,", i)
-#define dNameU(i)	{ char op[256]; sprintf(op, "%s.%s%s%s%s", i, _X ? "x" : "", _Y ? "y" : "", _Z ? "z" : "", _W ? "w" : ""); sprintf(ostrA, " %-7s,", op); }
+#define dName(i)	std::snprintf(ostrA, ostrAL, " %-7s,", i)
+#define dNameU(i)	{ char op[256]; std::snprintf(op, std::size(op), "%s.%s%s%s%s", i, _X ? "x" : "", _Y ? "y" : "", _Z ? "z" : "", _W ? "w" : ""); std::snprintf(ostrA, ostrAL, " %-7s,", op); }
 
 
-#define dCP2128f(i)		sprintf(ostrA, " w=%f z=%f y=%f x=%f (%s),", VU0.VF[i].f.w, VU0.VF[i].f.z, VU0.VF[i].f.y, VU0.VF[i].f.x, R5900::COP2_REG_FP[i])
-#define dCP232x(i)		sprintf(ostrA, " x=%f (%s),", VU0.VF[i].f.x, R5900::COP2_REG_FP[i])
-#define dCP232y(i)		sprintf(ostrA, " y=%f (%s),", VU0.VF[i].f.y, R5900::COP2_REG_FP[i])
-#define dCP232z(i)		sprintf(ostrA, " z=%f (%s),", VU0.VF[i].f.z, R5900::COP2_REG_FP[i])
-#define dCP232w(i)		sprintf(ostrA, " w=%f (%s),", VU0.VF[i].f.w, R5900::COP2_REG_FP[i])
-#define dCP2ACCf()		sprintf(ostrA, " w=%f z=%f y=%f x=%f (ACC),", VU0.ACC.f.w, VU0.ACC.f.z, VU0.ACC.f.y, VU0.ACC.f.x)
-#define dCP232i(i)		sprintf(ostrA, " %8.8x (%s),", VU0.VI[i].UL, R5900::COP2_REG_CTL[i])
-#define dCP232iF(i)		sprintf(ostrA, " %f (%s),", VU0.VI[i].F, R5900::COP2_REG_CTL[i])
-#define dCP232f(i, j)	sprintf(ostrA, " Q %s=%f (%s),", R5900::COP2_VFnames[j], VU0.VF[i].F[j], R5900::COP2_REG_FP[i])
-#define dImm5()			sprintf(ostrA, " %d,", (code >> 6) & 0x1f)
-#define dImm11()		sprintf(ostrA, " %d,", code & 0x7ff)
-#define dImm15()		sprintf(ostrA, " %d,", ( ( code >> 10 ) & 0x7800 ) | ( code & 0x7ff ))
+#define dCP2128f(i)		std::snprintf(ostrA, ostrAL, " w=%f z=%f y=%f x=%f (%s),", VU0.VF[i].f.w, VU0.VF[i].f.z, VU0.VF[i].f.y, VU0.VF[i].f.x, R5900::COP2_REG_FP[i])
+#define dCP232x(i)		std::snprintf(ostrA, ostrAL, " x=%f (%s),", VU0.VF[i].f.x, R5900::COP2_REG_FP[i])
+#define dCP232y(i)		std::snprintf(ostrA, ostrAL, " y=%f (%s),", VU0.VF[i].f.y, R5900::COP2_REG_FP[i])
+#define dCP232z(i)		std::snprintf(ostrA, ostrAL, " z=%f (%s),", VU0.VF[i].f.z, R5900::COP2_REG_FP[i])
+#define dCP232w(i)		std::snprintf(ostrA, ostrAL, " w=%f (%s),", VU0.VF[i].f.w, R5900::COP2_REG_FP[i])
+#define dCP2ACCf()		std::snprintf(ostrA, ostrAL, " w=%f z=%f y=%f x=%f (ACC),", VU0.ACC.f.w, VU0.ACC.f.z, VU0.ACC.f.y, VU0.ACC.f.x)
+#define dCP232i(i)		std::snprintf(ostrA, ostrAL, " %8.8x (%s),", VU0.VI[i].UL, R5900::COP2_REG_CTL[i])
+#define dCP232iF(i)		std::snprintf(ostrA, ostrAL, " %f (%s),", VU0.VI[i].F, R5900::COP2_REG_CTL[i])
+#define dCP232f(i, j)	std::snprintf(ostrA, ostrAL, " Q %s=%f (%s),", R5900::COP2_VFnames[j], VU0.VF[i].F[j], R5900::COP2_REG_FP[i])
+#define dImm5()			std::snprintf(ostrA, ostrAL, " %d,", (code >> 6) & 0x1f)
+#define dImm11()		std::snprintf(ostrA, ostrAL, " %d,", code & 0x7ff)
+#define dImm15()		std::snprintf(ostrA, ostrAL, " %d,", ( ( code >> 10 ) & 0x7800 ) | ( code & 0x7ff ))
 
 #define _X ((code>>24) & 0x1)
 #define _Y ((code>>23) & 0x1)

--- a/pcsx2/DebugTools/DisVU1Micro.cpp
+++ b/pcsx2/DebugTools/DisVU1Micro.cpp
@@ -20,7 +20,8 @@
 #include "VUmicro.h"
 
 static char ostr[1024];
-#define ostrA (ostr + strlen(ostr))
+#define ostrA (ostr + std::strlen(ostr))
+#define ostrAL (std::size(ostr) - std::strlen(ostr))
 
 // Type deffinition of our functions
 #define DisFInterface  (u32 code, u32 pc)
@@ -32,7 +33,7 @@ typedef char* (*TdisR5900F)DisFInterface;
 // These macros are used to assemble the disassembler functions
 #define MakeDisF(fn, b) \
 	char* fn DisFInterface { \
-		if( !!CpuVU1->IsInterpreter ) sprintf (ostr, "%8.8x %8.8x:", pc, code); \
+		if( !!CpuVU1->IsInterpreter ) std::snprintf(ostr, std::size(ostr), "%8.8x %8.8x:", pc, code); \
 		else ostr[0] = 0; \
 		b; \
 		return ostr; \
@@ -46,61 +47,61 @@ typedef char* (*TdisR5900F)DisFInterface;
 #define _Is_ (_Fs_ & 15)
 #define _Id_ (_Fd_ & 15)
 
-#define dName(i) sprintf(ostrA, " %-12s", i); \
+#define dName(i) std::snprintf(ostrA, ostrAL, " %-12s", i); \
 
 #define dNameU(i) { \
-	char op[256]; sprintf(op, "%s.%s%s%s%s", i, _X ? "x" : "", _Y ? "y" : "", _Z ? "z" : "", _W ? "w" : ""); \
-	sprintf(ostrA, " %-12s", op); \
+	char op[256]; std::snprintf(op, std::size(op), "%s.%s%s%s%s", i, _X ? "x" : "", _Y ? "y" : "", _Z ? "z" : "", _W ? "w" : ""); \
+	std::snprintf(ostrA, ostrAL, " %-12s", op); \
 }
 
 #define dCP2128f(i) { \
-	if( !CpuVU1->IsInterpreter ) sprintf(ostrA, " %s,", R5900::COP2_REG_FP[i]); \
-	else sprintf(ostrA, " w=%f (%8.8x) z=%f (%8.8x) y=%f (%8.8x) x=%f (%8.8x) (%s),", VU1.VF[i].f.w, VU1.VF[i].UL[3], VU1.VF[i].f.z, VU1.VF[i].UL[2], VU1.VF[i].f.y, VU1.VF[i].UL[1], VU1.VF[i].f.x, VU1.VF[i].UL[0], R5900::COP2_REG_FP[i]); \
+	if( !CpuVU1->IsInterpreter ) std::snprintf(ostrA, ostrAL, " %s,", R5900::COP2_REG_FP[i]); \
+	else std::snprintf(ostrA, ostrAL, " w=%f (%8.8x) z=%f (%8.8x) y=%f (%8.8x) x=%f (%8.8x) (%s),", VU1.VF[i].f.w, VU1.VF[i].UL[3], VU1.VF[i].f.z, VU1.VF[i].UL[2], VU1.VF[i].f.y, VU1.VF[i].UL[1], VU1.VF[i].f.x, VU1.VF[i].UL[0], R5900::COP2_REG_FP[i]); \
 } \
 
 #define dCP232x(i) { \
-	if( !CpuVU1->IsInterpreter ) sprintf(ostrA, " %s,", R5900::COP2_REG_FP[i]); \
-	else sprintf(ostrA, " x=%f (%s),", VU1.VF[i].f.x, R5900::COP2_REG_FP[i]); \
+	if( !CpuVU1->IsInterpreter ) std::snprintf(ostrA, ostrAL, " %s,", R5900::COP2_REG_FP[i]); \
+	else std::snprintf(ostrA, ostrAL, " x=%f (%s),", VU1.VF[i].f.x, R5900::COP2_REG_FP[i]); \
 } \
 
 #define dCP232y(i) { \
-	if( !CpuVU1->IsInterpreter ) sprintf(ostrA, " %s,", R5900::COP2_REG_FP[i]); \
-	else sprintf(ostrA, " y=%f (%s),", VU1.VF[i].f.y, R5900::COP2_REG_FP[i]); \
+	if( !CpuVU1->IsInterpreter ) std::snprintf(ostrA, ostrAL, " %s,", R5900::COP2_REG_FP[i]); \
+	else std::snprintf(ostrA, ostrAL, " y=%f (%s),", VU1.VF[i].f.y, R5900::COP2_REG_FP[i]); \
 } \
 
 #define dCP232z(i) { \
-	if( !CpuVU1->IsInterpreter ) sprintf(ostrA, " %s,", R5900::COP2_REG_FP[i]); \
-	else sprintf(ostrA, " z=%f (%s),", VU1.VF[i].f.z, R5900::COP2_REG_FP[i]); \
+	if( !CpuVU1->IsInterpreter ) std::snprintf(ostrA, ostrAL, " %s,", R5900::COP2_REG_FP[i]); \
+	else std::snprintf(ostrA, ostrAL, " z=%f (%s),", VU1.VF[i].f.z, R5900::COP2_REG_FP[i]); \
 }
 
 #define dCP232w(i) { \
-	if( !CpuVU1->IsInterpreter ) sprintf(ostrA, " %s,", R5900::COP2_REG_FP[i]); \
-	else sprintf(ostrA, " w=%f (%s),", VU1.VF[i].f.w, R5900::COP2_REG_FP[i]); \
+	if( !CpuVU1->IsInterpreter ) std::snprintf(ostrA, ostrAL, " %s,", R5900::COP2_REG_FP[i]); \
+	else std::snprintf(ostrA, ostrAL, " w=%f (%s),", VU1.VF[i].f.w, R5900::COP2_REG_FP[i]); \
 }
 
 #define dCP2ACCf() { \
-	if( !CpuVU1->IsInterpreter ) sprintf(ostrA, " ACC,"); \
-	else sprintf(ostrA, " w=%f z=%f y=%f x=%f (ACC),", VU1.ACC.f.w, VU1.ACC.f.z, VU1.ACC.f.y, VU1.ACC.f.x); \
+	if( !CpuVU1->IsInterpreter ) std::snprintf(ostrA, ostrAL, " ACC,"); \
+	else std::snprintf(ostrA, ostrAL, " w=%f z=%f y=%f x=%f (ACC),", VU1.ACC.f.w, VU1.ACC.f.z, VU1.ACC.f.y, VU1.ACC.f.x); \
 } \
 
 #define dCP232i(i) { \
-	if( !CpuVU1->IsInterpreter ) sprintf(ostrA, " %s,", R5900::COP2_REG_CTL[i]); \
-	else sprintf(ostrA, " %8.8x (%s),", VU1.VI[i].UL, R5900::COP2_REG_CTL[i]); \
+	if( !CpuVU1->IsInterpreter ) std::snprintf(ostrA, ostrAL, " %s,", R5900::COP2_REG_CTL[i]); \
+	else std::snprintf(ostrA, ostrAL, " %8.8x (%s),", VU1.VI[i].UL, R5900::COP2_REG_CTL[i]); \
 }
 
 #define dCP232iF(i) { \
-	if( !CpuVU1->IsInterpreter ) sprintf(ostrA, " %s,", R5900::COP2_REG_CTL[i]); \
-	else sprintf(ostrA, " %f (%s),", VU1.VI[i].F, R5900::COP2_REG_CTL[i]); \
+	if( !CpuVU1->IsInterpreter ) std::snprintf(ostrA, ostrAL, " %s,", R5900::COP2_REG_CTL[i]); \
+	else std::snprintf(ostrA, ostrAL, " %f (%s),", VU1.VI[i].F, R5900::COP2_REG_CTL[i]); \
 }
 
 #define dCP232f(i, j) { \
-	if( !CpuVU1->IsInterpreter ) sprintf(ostrA, " %s%s,", R5900::COP2_REG_FP[i], R5900::COP2_VFnames[j]); \
-	else sprintf(ostrA, " %s=%f (%s),", R5900::COP2_VFnames[j], VU1.VF[i].F[j], R5900::COP2_REG_FP[i]); \
+	if( !CpuVU1->IsInterpreter ) std::snprintf(ostrA, ostrAL, " %s%s,", R5900::COP2_REG_FP[i], R5900::COP2_VFnames[j]); \
+	else std::snprintf(ostrA, ostrAL, " %s=%f (%s),", R5900::COP2_VFnames[j], VU1.VF[i].F[j], R5900::COP2_REG_FP[i]); \
 }
 
-#define dImm5()			sprintf(ostrA, " %d,", (s16)((code >> 6) & 0x10 ? 0xfff0 | ((code >> 6) & 0xf) : (code >> 6) & 0xf))
-#define dImm11()		sprintf(ostrA, " %d,", (s16)(code & 0x400 ? 0xfc00 | (code & 0x3ff) : code & 0x3ff))
-#define dImm15()		sprintf(ostrA, " %d,", ( ( code >> 10 ) & 0x7800 ) | ( code & 0x7ff ))
+#define dImm5()			std::snprintf(ostrA, ostrAL, " %d,", (s16)((code >> 6) & 0x10 ? 0xfff0 | ((code >> 6) & 0xf) : (code >> 6) & 0xf))
+#define dImm11()		std::snprintf(ostrA, ostrAL, " %d,", (s16)(code & 0x400 ? 0xfc00 | (code & 0x3ff) : code & 0x3ff))
+#define dImm15()		std::snprintf(ostrA, ostrAL, " %d,", ( ( code >> 10 ) & 0x7800 ) | ( code & 0x7ff ))
 
 #define _X ((code>>24) & 0x1)
 #define _Y ((code>>23) & 0x1)

--- a/pcsx2/DebugTools/DisVUops.h
+++ b/pcsx2/DebugTools/DisVUops.h
@@ -50,17 +50,17 @@ MakeDisF(dis##VU##MI_RGET, 		dNameU("RGET");    dCP232i(REG_R); dCP2128f(_Ft_);)
 MakeDisF(dis##VU##MI_RNEXT, 	dNameU("RNEXT");   dCP232i(REG_R); dCP2128f(_Ft_);) \
 MakeDisF(dis##VU##MI_RXOR, 		dNameU("RXOR");    dCP232i(REG_R); dCP232f(_Fs_, _Fsf_);) \
 MakeDisF(dis##VU##MI_WAITQ, 	dName("WAITQ");  ) \
-MakeDisF(dis##VU##MI_FSAND, 	dName("FSAND");   dCP232i(_It_); dCP232i(REG_STATUS_FLAG); sprintf(ostrA, " %.3x,", code&0xfff); ) \
-MakeDisF(dis##VU##MI_FSEQ, 		dName("FSEQ");    dCP232i(_It_); dCP232i(REG_STATUS_FLAG); sprintf(ostrA, " %.3x,", code&0xfff);) \
-MakeDisF(dis##VU##MI_FSOR, 		dName("FSOR");    dCP232i(_It_); dCP232i(REG_STATUS_FLAG); sprintf(ostrA, " %.3x,", code&0xfff);) \
+MakeDisF(dis##VU##MI_FSAND, 	dName("FSAND");   dCP232i(_It_); dCP232i(REG_STATUS_FLAG); std::snprintf(ostrA, ostrAL, " %.3x,", code&0xfff); ) \
+MakeDisF(dis##VU##MI_FSEQ, 		dName("FSEQ");    dCP232i(_It_); dCP232i(REG_STATUS_FLAG); std::snprintf(ostrA, ostrAL, " %.3x,", code&0xfff);) \
+MakeDisF(dis##VU##MI_FSOR, 		dName("FSOR");    dCP232i(_It_); dCP232i(REG_STATUS_FLAG); std::snprintf(ostrA, ostrAL, " %.3x,", code&0xfff);) \
 MakeDisF(dis##VU##MI_FSSET, 	dName("FSSET");   dCP232i(REG_STATUS_FLAG);) \
 MakeDisF(dis##VU##MI_FMAND, 	dName("FMAND");   dCP232i(_It_); dCP232i(REG_MAC_FLAG); dCP232i(_Is_);) \
 MakeDisF(dis##VU##MI_FMEQ, 		dName("FMEQ");    dCP232i(_It_); dCP232i(REG_MAC_FLAG); dCP232i(_Is_);) \
 MakeDisF(dis##VU##MI_FMOR, 		dName("FMOR");    dCP232i(_It_); dCP232i(REG_MAC_FLAG); dCP232i(_Is_);) \
-MakeDisF(dis##VU##MI_FCAND, 	dName("FCAND");   dCP232i(1);    sprintf(ostrA, " %8.8x,", code&0xffffff); ) \
+MakeDisF(dis##VU##MI_FCAND, 	dName("FCAND");   dCP232i(1);    std::snprintf(ostrA, ostrAL, " %8.8x,", code&0xffffff); ) \
 MakeDisF(dis##VU##MI_FCEQ, 		dName("FCEQ");    dCP232i(1);    dCP232i(REG_CLIP_FLAG);) \
 MakeDisF(dis##VU##MI_FCOR, 		dName("FCOR");    dCP232i(1);    dCP232i(REG_CLIP_FLAG);) \
-MakeDisF(dis##VU##MI_FCSET, 	dName("FCSET");   dCP232i(REG_CLIP_FLAG); sprintf(ostrA, " %.6x,", code&0xffffff); ) \
+MakeDisF(dis##VU##MI_FCSET, 	dName("FCSET");   dCP232i(REG_CLIP_FLAG); std::snprintf(ostrA, ostrAL, " %.6x,", code&0xffffff); ) \
 MakeDisF(dis##VU##MI_FCGET, 	dName("FCGET");   dCP232i(_It_); dCP232i(REG_CLIP_FLAG);) \
 MakeDisF(dis##VU##MI_IBEQ, 		dName("IBEQ");    dImm11(); dCP232i(_It_); dCP232i(_Is_);) \
 MakeDisF(dis##VU##MI_IBGEZ, 	dName("IBEZ");    dImm11(); dCP232i(_It_); dCP232i(_Is_);) \

--- a/pcsx2/DebugTools/DisassemblyManager.cpp
+++ b/pcsx2/DebugTools/DisassemblyManager.cpp
@@ -44,7 +44,7 @@ static u32 computeHash(u32 address, u32 size)
 }
 
 
-void parseDisasm(SymbolMap& map, const char* disasm, char* opcode, char* arguments, bool insertSymbols)
+static void parseDisasm(SymbolMap& map, const char* disasm, char* opcode, char* arguments, size_t arguments_size, bool insertSymbols)
 {
 	if (*disasm == '(')
 	{
@@ -80,9 +80,9 @@ void parseDisasm(SymbolMap& map, const char* disasm, char* opcode, char* argumen
 			const std::string addressSymbol = map.GetLabelString(branchTarget);
 			if (!addressSymbol.empty() && insertSymbols)
 			{
-				arguments += sprintf(arguments,"%s",addressSymbol.c_str());
+				arguments += std::snprintf(arguments, arguments_size, "%s",addressSymbol.c_str());
 			} else {
-				arguments += sprintf(arguments,"0x%08X",branchTarget);
+				arguments += std::snprintf(arguments, arguments_size, "0x%08X",branchTarget);
 			}
 
 			disasm += 3+2+8;
@@ -700,7 +700,7 @@ bool DisassemblyOpcode::disassemble(u32 address, DisassemblyLineInfo& dest, bool
 	char opcode[64],arguments[256];
 
 	std::string dis = cpu->disasm(address,insertSymbols);
-	parseDisasm(cpu->GetSymbolMap(),dis.c_str(),opcode,arguments,insertSymbols);
+	parseDisasm(cpu->GetSymbolMap(),dis.c_str(),opcode,arguments,std::size(arguments),insertSymbols);
 	dest.type = DISTYPE_OPCODE;
 	dest.name = opcode;
 	dest.params = arguments;
@@ -780,9 +780,9 @@ bool DisassemblyMacro::disassemble(u32 address, DisassemblyLineInfo& dest, bool 
 		addressSymbol = cpu->GetSymbolMap().GetLabelString(immediate);
 		if (!addressSymbol.empty() && insertSymbols)
 		{
-			sprintf(buffer,"%s,%s",cpu->getRegisterName(0,rt),addressSymbol.c_str());
+			std::snprintf(buffer,std::size(buffer),"%s,%s",cpu->getRegisterName(0,rt),addressSymbol.c_str());
 		} else {
-			sprintf(buffer,"%s,0x%08X",cpu->getRegisterName(0,rt),immediate);
+			std::snprintf(buffer,std::size(buffer),"%s,0x%08X",cpu->getRegisterName(0,rt),immediate);
 		}
 
 		dest.params = buffer;
@@ -796,9 +796,9 @@ bool DisassemblyMacro::disassemble(u32 address, DisassemblyLineInfo& dest, bool 
 		addressSymbol = cpu->GetSymbolMap().GetLabelString(immediate);
 		if (!addressSymbol.empty() && insertSymbols)
 		{
-			sprintf(buffer,"%s,%s",cpu->getRegisterName(0,rt),addressSymbol.c_str());
+			std::snprintf(buffer,std::size(buffer),"%s,%s",cpu->getRegisterName(0,rt),addressSymbol.c_str());
 		} else {
-			sprintf(buffer,"%s,0x%08X",cpu->getRegisterName(0,rt),immediate);
+			std::snprintf(buffer,std::size(buffer),"%s,0x%08X",cpu->getRegisterName(0,rt),immediate);
 		}
 
 		dest.params = buffer;
@@ -923,9 +923,9 @@ void DisassemblyData::createLines()
 			} else {
 				char buffer[64];
 				if (pos == end && b == 0)
-					strcpy(buffer,"0");
+					StringUtil::Strlcpy(buffer, "0", std::size(buffer));
 				else
-					sprintf(buffer,"0x%02X",b);
+					std::snprintf(buffer, std::size(buffer), "0x%02X", b);
 
 				if (currentLine.size()+strlen(buffer) >= maxChars)
 				{
@@ -977,12 +977,12 @@ void DisassemblyData::createLines()
 			{
 			case DATATYPE_BYTE:
 				value = memRead8(pos);
-				sprintf(buffer,"0x%02X",value);
+				std::snprintf(buffer,std::size(buffer),"0x%02X",value);
 				pos++;
 				break;
 			case DATATYPE_HALFWORD:
 				value = memRead16(pos);
-				sprintf(buffer,"0x%04X",value);
+				std::snprintf(buffer,std::size(buffer),"0x%04X",value);
 				pos += 2;
 				break;
 			case DATATYPE_WORD:
@@ -990,9 +990,9 @@ void DisassemblyData::createLines()
 					value = memRead32(pos);
 					const std::string label = cpu->GetSymbolMap().GetLabelString(value);
 					if (!label.empty())
-						sprintf(buffer,"%s",label.c_str());
+						std::snprintf(buffer,std::size(buffer),"%s",label.c_str());
 					else
-						sprintf(buffer,"0x%08X",value);
+						std::snprintf(buffer,std::size(buffer),"0x%08X",value);
 					pos += 4;
 				}
 				break;

--- a/pcsx2/DebugTools/ExpressionParser.cpp
+++ b/pcsx2/DebugTools/ExpressionParser.cpp
@@ -15,9 +15,9 @@
 
 #include "PrecompiledHeader.h"
 #include "ExpressionParser.h"
-#include <ctype.h>
-#include <string.h>
-#include <stdio.h>
+#include <cctype>
+#include <cstring>
+#include <cstdio>
 
 typedef enum {
 	EXOP_BRACKETL, EXOP_BRACKETR, EXOP_MEML, EXOP_MEMR, EXOP_MEMSIZE, EXOP_SIGNPLUS, EXOP_SIGNMINUS,
@@ -255,7 +255,7 @@ bool initPostfixExpression(const char* infix, IExpressionFunctions* funcs, Postf
 				isFloat = true;
 			else if (!parseNumber(subStr,16,subPos,value))
 			{
-				sprintf(expressionError,"Invalid number \"%s\"",subStr);
+				std::snprintf(expressionError, std::size(expressionError),"Invalid number \"%s\"",subStr);
 				return false;
 			}
 
@@ -284,14 +284,14 @@ bool initPostfixExpression(const char* infix, IExpressionFunctions* funcs, Postf
 				continue;
 			}
 
-			sprintf(expressionError,"Invalid symbol \"%s\"",subStr);
+			std::snprintf(expressionError, std::size(expressionError),"Invalid symbol \"%s\"",subStr);
 			return false;
 		} else {
 			int len;
 			ExpressionOpcodeType type = getExpressionOpcode(&infix[infixPos],len,lastOpcode);
 			if (type == EXOP_NONE)
 			{
-				sprintf(expressionError,"Invalid operator at \"%s\"",&infix[infixPos]);
+				std::snprintf(expressionError, std::size(expressionError),"Invalid operator at \"%s\"",&infix[infixPos]);
 				return false;
 			}
 
@@ -306,7 +306,7 @@ bool initPostfixExpression(const char* infix, IExpressionFunctions* funcs, Postf
 				{
 					if (opcodeStack.empty())
 					{
-						sprintf(expressionError,"Closing parenthesis without opening one");
+						std::snprintf(expressionError, std::size(expressionError),"Closing parenthesis without opening one");
 						return false;
 					}
 					ExpressionOpcodeType t = opcodeStack[opcodeStack.size()-1];
@@ -320,7 +320,7 @@ bool initPostfixExpression(const char* infix, IExpressionFunctions* funcs, Postf
 				{
 					if (opcodeStack.empty())
 					{
-						sprintf(expressionError,"Closing bracket without opening one");
+						std::snprintf(expressionError, std::size(expressionError),"Closing bracket without opening one");
 						return false;
 					}
 					ExpressionOpcodeType t = opcodeStack[opcodeStack.size()-1];
@@ -373,7 +373,7 @@ bool initPostfixExpression(const char* infix, IExpressionFunctions* funcs, Postf
 
 		if (t == EXOP_BRACKETL)	// opening bracket without closing one
 		{
-			sprintf(expressionError,"Parenthesis not closed");
+			std::snprintf(expressionError, std::size(expressionError),"Parenthesis not closed");
 			return false;
 		}
 		dest.push_back(ExpressionPair(EXCOMM_OP,t));
@@ -388,13 +388,13 @@ bool initPostfixExpression(const char* infix, IExpressionFunctions* funcs, Postf
 		{
 		case EXCOMM_CONST:
 		case EXCOMM_CONST_FLOAT:
-			testPos += sprintf(&test[testPos],"0x%04X ",dest[i].second);
+			testPos += std::snprintf(&test[testPos],std::size(test),"0x%04X ",dest[i].second);
 			break;
 		case EXCOMM_REF:
-			testPos += sprintf(&test[testPos],"r%d ",dest[i].second);
+			testPos += std::snprintf(&test[testPos],std::size(test),"r%d ",dest[i].second);
 			break;
 		case EXCOMM_OP:
-			testPos += sprintf(&test[testPos],"%s ",ExpressionOpcodes[dest[i].second].Name);
+			testPos += std::snprintf(&test[testPos],std::size(test),"%s ",ExpressionOpcodes[dest[i].second].Name);
 			break;
 		};
 	}
@@ -432,7 +432,7 @@ bool parsePostfixExpression(PostfixExpression& exp, IExpressionFunctions* funcs,
 			opcode = exp[num++].second;
 			if (valueStack.size() < ExpressionOpcodes[opcode].args)
 			{
-				sprintf(expressionError,"Not enough arguments");
+				std::snprintf(expressionError, std::size(expressionError),"Not enough arguments");
 				return false;
 			}
 			for (int l = 0; l < ExpressionOpcodes[opcode].args; l++)
@@ -447,7 +447,7 @@ bool parsePostfixExpression(PostfixExpression& exp, IExpressionFunctions* funcs,
 			case EXOP_MEMSIZE:	// must be followed by EXOP_MEM
 				if (exp[num++].second != EXOP_MEM)
 				{
-					sprintf(expressionError,"Invalid memsize operator");
+					std::snprintf(expressionError, std::size(expressionError),"Invalid memsize operator");
 					return false;
 				}
 
@@ -491,7 +491,7 @@ bool parsePostfixExpression(PostfixExpression& exp, IExpressionFunctions* funcs,
 			case EXOP_DIV:			// a/b
 				if (arg[0] == 0)
 				{
-					sprintf(expressionError,"Division by zero");
+					std::snprintf(expressionError, std::size(expressionError),"Division by zero");
 					return false;
 				}
 				if (useFloat)
@@ -502,7 +502,7 @@ bool parsePostfixExpression(PostfixExpression& exp, IExpressionFunctions* funcs,
 			case EXOP_MOD:			// a%b
 				if (arg[0] == 0)
 				{
-					sprintf(expressionError,"Modulo by zero");
+					std::snprintf(expressionError, std::size(expressionError),"Modulo by zero");
 					return false;
 				}
 				valueStack.push_back(arg[1]%arg[0]);
@@ -575,7 +575,7 @@ bool parsePostfixExpression(PostfixExpression& exp, IExpressionFunctions* funcs,
 			case EXOP_TERTELSE:			// exp ? exp : exp, else muss zuerst kommen!
 				if (exp[num++].second != EXOP_TERTIF)
 				{
-					sprintf(expressionError,"Invalid tertiary operator");
+					std::snprintf(expressionError, std::size(expressionError),"Invalid tertiary operator");
 					return false;
 				}
 				valueStack.push_back(arg[2]?arg[1]:arg[0]);

--- a/pcsx2/DebugTools/MIPSAnalyst.cpp
+++ b/pcsx2/DebugTools/MIPSAnalyst.cpp
@@ -131,7 +131,7 @@ namespace MIPSAnalyst
 	}
 
 	static const char *DefaultFunctionName(char buffer[256], u32 startAddr) {
-		sprintf(buffer, "z_un_%08x", startAddr);
+		std::snprintf(buffer, 256, "z_un_%08x", startAddr);
 		return buffer;
 	}
 

--- a/pcsx2/DebugTools/SymbolMap.cpp
+++ b/pcsx2/DebugTools/SymbolMap.cpp
@@ -191,7 +191,7 @@ std::string SymbolMap::GetDescription(unsigned int address) const {
 		return labelName;
 
 	char descriptionTemp[256];
-	sprintf(descriptionTemp, "(%08x)", address);
+	std::snprintf(descriptionTemp, std::size(descriptionTemp), "(%08x)", address);
 	return descriptionTemp;
 }
 

--- a/pcsx2/GS/GSCapture.cpp
+++ b/pcsx2/GS/GSCapture.cpp
@@ -36,6 +36,11 @@
 #include <mutex>
 #include <string>
 
+#ifdef __clang__
+// We're using deprecated fields because we're targeting multiple ffmpeg versions.
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
 extern "C" {
 #include "libavcodec/avcodec.h"
 #include "libavcodec/version.h"
@@ -49,8 +54,6 @@ extern "C" {
 #include "libswresample/swresample.h"
 #include "libswresample/version.h"
 }
-
-#include <mutex>
 
 // Compatibility with both ffmpeg 4.x and 5.x.
 #if (LIBAVFORMAT_VERSION_MAJOR < 59)

--- a/pcsx2/GS/Renderers/SW/GSScanlineEnvironment.h
+++ b/pcsx2/GS/Renderers/SW/GSScanlineEnvironment.h
@@ -104,7 +104,7 @@ union GSScanlineSelector
 	std::string to_string() const
 	{
 		char str[1024];
-		sprintf(str,
+		std::snprintf(str, std::size(str),
 			"fpsm:%d zpsm:%d ztst:%d ztest:%d atst:%d afail:%d iip:%d rfb:%d fb:%d zb:%d zw:%d "
 			"tfx:%d tcc:%d fst:%d ltf:%d tlu:%d wms:%d wmt:%d mmin:%d lcm:%d tw:%d "
 			"fba:%d cclamp:%d date:%d datm:%d "

--- a/pcsx2/IopBios.cpp
+++ b/pcsx2/IopBios.cpp
@@ -892,6 +892,13 @@ namespace R3000A
 	{
 		int Kprintf_HLE()
 		{
+			// Using sprintf here is a bit nasty, but it has a large buffer..
+			// Don't feel like rewriting it.
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
 			// Emulate the expected Kprintf functionality:
 			iopMemWrite32(sp, a0);
 			iopMemWrite32(sp + 4, a1);
@@ -1000,6 +1007,10 @@ namespace R3000A
 			iopConLog(ShiftJIS_ConvertString(tmp, 1023));
 
 			return 1;
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 		}
 	} // namespace sysmem
 

--- a/pcsx2/R5900OpcodeImpl.cpp
+++ b/pcsx2/R5900OpcodeImpl.cpp
@@ -206,7 +206,7 @@ static int __Deci2Call(int call, u32 *addr)
 		{
 			char reqaddr[128];
 			if( addr != NULL )
-				sprintf( reqaddr, "%x %x %x %x", addr[3], addr[2], addr[1], addr[0] );
+				std::snprintf(reqaddr, std::size(reqaddr), "%x %x %x %x", addr[3], addr[2], addr[1], addr[0]);
 
 			if (!deci2addr) return 1;
 


### PR DESCRIPTION
### Description of Changes

This causes hundreds of warnings spewed when building on MacOS.

### Rationale behind Changes

It's really annoying.

### Suggested Testing Steps

Make sure debugger still works and displays values. Most of them were in there.
