### PR TITLE
Qt: Make "100%" string available for translation

### DIFF
--- a/pcsx2-qt/Settings/EmulationSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/EmulationSettingsWidget.cpp
@@ -106,7 +106,7 @@ EmulationSettingsWidget::EmulationSettingsWidget(SettingsDialog* dialog, QWidget
 
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.hostFilesystem, "EmuCore", "HostFs", false);
 
-	dialog->registerWidgetHelp(m_ui.normalSpeed, tr("Normal Speed"), "100%",
+	dialog->registerWidgetHelp(m_ui.normalSpeed, tr("Normal Speed"), tr("100%"),
 		tr("Sets the target emulation speed. It is not guaranteed that this speed will be reached, "
 		   "and if not, the emulator will run as fast as it can manage."));
 	//: The "User Preference" string will appear after the text "Recommended Value:"


### PR DESCRIPTION
### Description of Changes
Make a string available for translation.

### Rationale behind Changes
Percentages take a non-breaking space between the value and "%" in French.

### Suggested Testing Steps
Settings->Emulation->Normal speed description
