### PR TITLE
GS/HW: Convert depth16->rgba16 shader to integer

### DIFF
--- a/bin/resources/shaders/dx11/convert.fx
+++ b/bin/resources/shaders/dx11/convert.fx
@@ -164,8 +164,7 @@ PS_OUTPUT ps_convert_float16_rgb5a1(PS_INPUT input)
 
 	// Convert a FLOAT32 (only 16 lsb) depth into a RGB5A1 color texture
 	uint d = uint(sample_c(input.t).r * exp2(32.0f));
-	output.c = float4(uint4((d & 0x1Fu), ((d >> 5) & 0x1Fu), ((d >> 10) & 0x1Fu), (d >> 15) & 0x01u)) / float4(32.0f, 32.0f, 32.0f, 1.0f);
-
+	output.c = float4(uint4(d << 3, d >> 2, d >> 7, d >> 8) & uint4(0xf8, 0xf8, 0xf8, 0x80)) / 255.0f;
 	return output;
 }
 

--- a/bin/resources/shaders/opengl/convert.glsl
+++ b/bin/resources/shaders/opengl/convert.glsl
@@ -122,7 +122,7 @@ void ps_convert_float16_rgb5a1()
 #else
 	uint d = uint(sample_c().r * exp2(24.0f));
 #endif
-	SV_Target0 = vec4(uvec4((d & 0x1Fu), ((d >> 5) & 0x1Fu), ((d >> 10) & 0x1Fu), (d >> 15) & 0x01u)) / vec4(32.0f, 32.0f, 32.0f, 1.0f);
+	SV_Target0 = vec4(uvec4(d << 3, d >> 2, d >> 7, d >> 8) & uvec4(0xf8, 0xf8, 0xf8, 0x80)) / 255.0f;
 }
 #endif
 

--- a/bin/resources/shaders/vulkan/convert.glsl
+++ b/bin/resources/shaders/vulkan/convert.glsl
@@ -142,7 +142,7 @@ void ps_convert_float16_rgb5a1()
 {
 	// Convert a vec32 (only 16 lsb) depth into a RGB5A1 color texture
 	uint d = uint(sample_c(v_tex).r * exp2(32.0f));
-	o_col0 = vec4(uvec4((d & 0x1Fu), ((d >> 5) & 0x1Fu), ((d >> 10) & 0x1Fu), (d >> 15) & 0x01u)) / vec4(32.0f, 32.0f, 32.0f, 1.0f);
+	o_col0 = vec4(uvec4(d << 3, d >> 2, d >> 7, d >> 8) & uvec4(0xf8, 0xf8, 0xf8, 0x80)) / 255.0f;
 }
 #endif
 

--- a/pcsx2/ShaderCacheVersion.h
+++ b/pcsx2/ShaderCacheVersion.h
@@ -15,4 +15,4 @@
 
 /// Version number for GS and other shaders. Increment whenever any of the contents of the
 /// shaders change, to invalidate the cache.
-static constexpr u32 SHADER_CACHE_VERSION = 33;
+static constexpr u32 SHADER_CACHE_VERSION = 34;


### PR DESCRIPTION
### Description of Changes
Converts the non-metal shaders (metal already does this) for depth 16 -> rgb5a1 to use integer full range conversion

Most of the work done by Stenzek (I mostly just helped with the debugging and poked the code in lol)

### Rationale behind Changes
The old way had off by 1 problems and was not really possible to get correct without coming across rounding issues.

### Suggested Testing Steps
Test Shadow Tower Abyss make sure the shadows render correctly and the screen isn't too dark.

Fixes #3281

Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/c6bd39f1-5497-44da-8031-8b97346c7cdf)
![image](https://github.com/PCSX2/pcsx2/assets/6278726/14a89478-3fec-4252-928d-ea58c2a7d6ff)

PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/147905e8-e4ab-4423-b812-32a7617fd481)
![image](https://github.com/PCSX2/pcsx2/assets/6278726/139cc602-c176-46de-9ee7-0a22111df13e)

