### PR TITLE
UI: Rename the "Open in Explorer" button to "Open BIOS Folder"

### DIFF
--- a/pcsx2-qt/Settings/BIOSSettingsWidget.ui
+++ b/pcsx2-qt/Settings/BIOSSettingsWidget.ui
@@ -87,7 +87,7 @@
         <item>
          <widget class="QPushButton" name="openSearchDirectory">
           <property name="text">
-           <string>Open in Explorer...</string>
+           <string>Open BIOS Folder...</string>
           </property>
          </widget>
         </item>

--- a/pcsx2-qt/SetupWizardDialog.ui
+++ b/pcsx2-qt/SetupWizardDialog.ui
@@ -298,7 +298,7 @@
          <item>
           <widget class="QPushButton" name="openBiosSearchDirectory">
            <property name="text">
-            <string>Open in Explorer...</string>
+            <string>Open BIOS Folder...</string>
            </property>
           </widget>
          </item>


### PR DESCRIPTION
### Description of Changes
Fixes #10037
