### PR TITLE
Qt/Updater: Add download size estimation to the Updater

### DIFF
--- a/pcsx2-qt/AutoUpdaterDialog.cpp
+++ b/pcsx2-qt/AutoUpdaterDialog.cpp
@@ -346,6 +346,8 @@ void AutoUpdaterDialog::getChangesComplete(QNetworkReply* reply)
 			QString changes_html = tr("<h2>Changes:</h2>");
 			changes_html += QStringLiteral("<ul>");
 
+			m_download_size = doc_object["size"].toInt();
+
 			const QJsonArray commits(doc_object["commits"].toArray());
 			bool update_will_break_save_states = false;
 			bool update_increases_settings_version = false;
@@ -390,7 +392,9 @@ void AutoUpdaterDialog::getChangesComplete(QNetworkReply* reply)
 					tr("<h2>Settings Warning</h2><p>Installing this update will reset your program configuration. Please note "
 					   "that you will have to reconfigure your settings after this update.</p>"));
 			}
-
+			changes_html += tr("<h4>Installing this update will download %1 MB through your internet connection.</h4>")
+                    .arg(static_cast<double>(m_download_size) / 1000000.0, 0, 'f', 2);
+				
 			m_ui.updateNotes->setText(changes_html);
 		}
 		else

--- a/pcsx2-qt/Themes.cpp
+++ b/pcsx2-qt/Themes.cpp
@@ -330,6 +330,7 @@ void QtHost::SetStyleFromSettings()
 		const QColor gray(150, 150, 150);
 		const QColor royalBlue(29, 41, 81);
 		const QColor darkishBlue(17, 30, 108);
+		const QColor lighterBlue(25, 32, 130);
 		const QColor highlight(36, 93, 218);
 		const QColor link(0, 202, 255);
 
@@ -341,13 +342,13 @@ void QtHost::SetStyleFromSettings()
 		darkPalette.setColor(QPalette::ToolTipBase, darkishBlue);
 		darkPalette.setColor(QPalette::ToolTipText, Qt::white);
 		darkPalette.setColor(QPalette::Text, Qt::white);
-		darkPalette.setColor(QPalette::Button, darkishBlue);
+		darkPalette.setColor(QPalette::Button, lighterBlue);
 		darkPalette.setColor(QPalette::ButtonText, Qt::white);
 		darkPalette.setColor(QPalette::Link, link);
 		darkPalette.setColor(QPalette::Highlight, highlight);
 		darkPalette.setColor(QPalette::HighlightedText, Qt::white);
 
-		darkPalette.setColor(QPalette::Active, QPalette::Button, darkishBlue);
+		darkPalette.setColor(QPalette::Active, QPalette::Button, lighterBlue);
 		darkPalette.setColor(QPalette::Disabled, QPalette::ButtonText, gray);
 		darkPalette.setColor(QPalette::Disabled, QPalette::WindowText, gray);
 		darkPalette.setColor(QPalette::Disabled, QPalette::Text, gray);
@@ -355,7 +356,7 @@ void QtHost::SetStyleFromSettings()
 
 		qApp->setPalette(darkPalette);
 
-		qApp->setStyleSheet("QToolTip { color: #ffffff; background-color: #2a82da; border: 1px solid white; }");
+		qApp->setStyleSheet("QToolTip { color: #ffffff; background-color: #000080; border: 1px solid white; }");
 	}
 	else if (theme == "VioletAngelPurple")
 	{

--- a/pcsx2-qt/Translations/pcsx2-qt_en.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_en.ts
@@ -1370,8 +1370,8 @@ Unread messages: {2}</source>
     <name>AutoUpdaterDialog</name>
     <message>
         <location filename="../AutoUpdaterDialog.ui" line="17"/>
-        <location filename="../AutoUpdaterDialog.cpp" line="438"/>
-        <location filename="../AutoUpdaterDialog.cpp" line="501"/>
+        <location filename="../AutoUpdaterDialog.cpp" line="442"/>
+        <location filename="../AutoUpdaterDialog.cpp" line="505"/>
         <source>Automatic Updater</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1416,52 +1416,57 @@ Unread messages: {2}</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../AutoUpdaterDialog.cpp" line="380"/>
+        <location filename="../AutoUpdaterDialog.cpp" line="382"/>
         <source>&lt;h2&gt;Save State Warning&lt;/h2&gt;&lt;p&gt;Installing this update will make your save states &lt;b&gt;incompatible&lt;/b&gt;. Please ensure you have saved your games to a Memory Card before installing this update or you will lose progress.&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../AutoUpdaterDialog.cpp" line="390"/>
+        <location filename="../AutoUpdaterDialog.cpp" line="392"/>
         <source>&lt;h2&gt;Settings Warning&lt;/h2&gt;&lt;p&gt;Installing this update will reset your program configuration. Please note that you will have to reconfigure your settings after this update.&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../AutoUpdaterDialog.cpp" line="416"/>
+        <location filename="../AutoUpdaterDialog.cpp" line="395"/>
+        <source>&lt;h4&gt;Installing this update will download %1 MB through your internet connection.&lt;/h4&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../AutoUpdaterDialog.cpp" line="420"/>
         <source>Savestate Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../AutoUpdaterDialog.cpp" line="417"/>
+        <location filename="../AutoUpdaterDialog.cpp" line="421"/>
         <source>&lt;h1&gt;WARNING&lt;/h1&gt;&lt;p style=&apos;font-size:12pt;&apos;&gt;Installing this update will make your &lt;b&gt;save states incompatible&lt;/b&gt;, &lt;i&gt;be sure to save any progress to your memory cards before proceeding&lt;/i&gt;.&lt;/p&gt;&lt;p&gt;Do you wish to continue?&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../AutoUpdaterDialog.cpp" line="437"/>
+        <location filename="../AutoUpdaterDialog.cpp" line="441"/>
         <source>Downloading %1...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../AutoUpdaterDialog.cpp" line="437"/>
+        <location filename="../AutoUpdaterDialog.cpp" line="441"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../AutoUpdaterDialog.cpp" line="502"/>
+        <location filename="../AutoUpdaterDialog.cpp" line="506"/>
         <source>No updates are currently available. Please try again later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../AutoUpdaterDialog.cpp" line="520"/>
+        <location filename="../AutoUpdaterDialog.cpp" line="524"/>
         <source>Current Version: %1 (%2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../AutoUpdaterDialog.cpp" line="521"/>
+        <location filename="../AutoUpdaterDialog.cpp" line="525"/>
         <source>New Version: %1 (%2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../AutoUpdaterDialog.cpp" line="522"/>
+        <location filename="../AutoUpdaterDialog.cpp" line="526"/>
         <source>Loading...</source>
         <translation type="unfinished"></translation>
     </message>

--- a/updater/Windows/WindowsUpdater.cpp
+++ b/updater/Windows/WindowsUpdater.cpp
@@ -522,8 +522,6 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPWSTR lpCmdLi
 		return 1;
 	}
 
-	progress.ModalInformation("Update complete.");
-
 	progress.DisplayFormattedInformation("Launching '%s'...",
 		StringUtil::WideStringToUTF8String(program_to_launch).c_str());
 	ShellExecuteW(nullptr, L"open", program_to_launch.c_str(), nullptr, nullptr, SW_SHOWNORMAL);


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
This PR adds Download Size indicator to the auto updater just like the one on Duckstation.
![image](https://github.com/PCSX2/pcsx2/assets/14798312/dcbecbed-bacc-4801-b5b8-646a2c2cdd5b)

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Good for someone who has limited data caps.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Make sure its shown properly and nothing else broke