### PR TITLE
Debugger: Run the tables keybind handler before the widgets

### DIFF
--- a/pcsx2-qt/Debugger/MemoryViewWidget.h
+++ b/pcsx2-qt/Debugger/MemoryViewWidget.h
@@ -72,7 +72,8 @@ public:
 	void SelectAt(QPoint pos);
 	u128 GetSelectedSegment();
 	void InsertAtCurrentSelection(const QString& text);
-	void KeyPress(int key, QChar keychar);
+	// Returns true if the keypress was handled
+	bool KeyPress(int key, QChar keychar);
 
 	MemoryViewType GetViewType()
 	{


### PR DESCRIPTION
This fixes the issue of 'G' executing the go-to box instead of putting it into the text view

### Description of Changes
Runs the tables keypress handler before the widget

### Rationale behind Changes
If you were to click on the text area and press 'G', you'd end up opening the goto address box instead of inserting a 'G' into that address
CTRL+G is still an override and will work whether you're clicked into the text or hex area.

### Suggested Testing Steps
- Open the debugger
	- Click into the text area
		- Press 'G'
			- A 'G' should be inserted
		- Press 'g'
			- A 'g' should be inserted
		- Press CTRL + 'G'
			- The go to address box should pop up
	- Click into the hex area
		- Press 'g', 'G' or CTRL + 'G'
			- The go to address box should pop up