### PR TITLE
CDVD: Better simulate RPM changes going in to CLV + read speed

### DIFF
--- a/pcsx2/CDVD/CDVD.h
+++ b/pcsx2/CDVD/CDVD.h
@@ -167,6 +167,7 @@ struct cdvdStruct
 	u32 SeekToSector; // Holds the destination sector during seek operations.
 	u32 MaxSector;    // Current disc max sector.
 	u32 ReadTime;     // Avg. time to read one block of data (in Iop cycles)
+	u32 RotSpeed;     // Rotational Speed
 	bool Spinning;    // indicates if the Cdvd is spinning or needs a spinup delay
 	cdvdTrayTimer Tray;
 	u8 nextSectorsBuffered;

--- a/pcsx2/CDVD/CDVD_internal.h
+++ b/pcsx2/CDVD/CDVD_internal.h
@@ -151,16 +151,13 @@ static const uint tbl_ContigiousSeekDelta[3] =
 		16, // dual-layer DVD-ROM [currently unused]
 };
 
-// Note: DVD read times are modified to be faster, because games seem to be a lot more
-// concerned with accurate(ish) seek delays and less concerned with actual block read speeds.
-// Translation: it's a minor speedhack :D
-
 static const uint PSX_CD_READSPEED = 153600;   // Bytes per second, rough values from outer CD (CAV).
 static const uint PSX_DVD_READSPEED = 1382400; // Bytes per second, rough values from outer DVD (CAV).
 
 static const uint CD_SECTORS_PERSECOND = 75;
 static const uint DVD_SECTORS_PERSECOND = 675;
 
+// Rotations per minute.
 static const uint CD_MIN_ROTATION_X1 = 214;
 static const uint CD_MAX_ROTATION_X1 = 497;
 

--- a/pcsx2/SaveState.h
+++ b/pcsx2/SaveState.h
@@ -37,7 +37,7 @@ enum class FreezeAction
 // [SAVEVERSION+]
 // This informs the auto updater that the users savestates will be invalidated.
 
-static const u32 g_SaveVersion = (0x9A42 << 16) | 0x0000;
+static const u32 g_SaveVersion = (0x9A43 << 16) | 0x0000;
 
 
 // the freezing data between submodules and core


### PR DESCRIPTION
### Description of Changes
Improve the latency of RPM changes when going for CAV to CLV

### Rationale behind Changes
Going in to CLV the game will expect the speed to stabilise before reading, CAV is more YOLO so doesn't *really* matter so much. Before we just made it simulate a whole spinup in both situations, which caused problems in games like Nickelodeons Avatar, where it swaps constantly between CAV and CLV during cutscenes.

- Corrects CLV read speeds for CD and DVD's.
- Fixed rotational latency which was the wrong way around for CLV, also averaged it (half) for actual rotational latency.

More work can be done to improve seek times (maybe port the seek calculations from Duckstation?), but not really interested in doing so right now :P

### Suggested Testing Steps
Try cutscenes on Nickelodeon Avatar - The Legend of Aang, Digital Devil Saga ~~and maybe transitions in Shadow Hearts Covenant? :/~~