### PR TITLE
Debugger: A bunch of stuff

### DIFF
--- a/pcsx2-qt/Debugger/CpuWidget.cpp
+++ b/pcsx2-qt/Debugger/CpuWidget.cpp
@@ -550,6 +550,7 @@ void CpuWidget::onFuncListContextMenu(QPoint pos)
 
 	connect(demangleAction, &QAction::triggered, [this] {
 		m_demangleFunctions = !m_demangleFunctions;
+		m_ui.disassemblyWidget->setDemangle(m_demangleFunctions);
 		updateFunctionList();
 	});
 

--- a/pcsx2-qt/Debugger/CpuWidget.cpp
+++ b/pcsx2-qt/Debugger/CpuWidget.cpp
@@ -68,7 +68,10 @@ CpuWidget::CpuWidget(QWidget* parent, DebugInterface& cpu)
 	connect(m_ui.threadList, &QTableView::doubleClicked, this, &CpuWidget::onThreadListDoubleClick);
 
 	m_ui.threadList->horizontalHeader()->setSectionResizeMode(QHeaderView::Stretch);
-	m_ui.threadList->setModel(&m_threadModel);
+	m_threadProxyModel.setSourceModel(&m_threadModel);
+	m_ui.threadList->setModel(&m_threadProxyModel);
+	m_ui.threadList->setSortingEnabled(true);
+	m_ui.threadList->sortByColumn(ThreadModel::ThreadColumns::ID, Qt::SortOrder::AscendingOrder);
 
 	connect(m_ui.stackList, &QTableView::customContextMenuRequested, this, &CpuWidget::onStackListContextMenu);
 	connect(m_ui.stackList, &QTableView::doubleClicked, this, &CpuWidget::onStackListDoubleClick);

--- a/pcsx2-qt/Debugger/CpuWidget.cpp
+++ b/pcsx2-qt/Debugger/CpuWidget.cpp
@@ -282,6 +282,18 @@ void CpuWidget::onBPListContextMenu(QPoint pos)
 		contextMenu->addAction(deleteAction);
 	}
 
+	contextMenu->addSeparator();
+	QAction* actionExport = new QAction(tr("Copy all as CSV"), m_ui.breakpointList);
+	connect(actionExport, &QAction::triggered, [this]() {
+		// It's important to use the User Role here to allow pasting to be translation agnostic
+		QGuiApplication::clipboard()->setText(QtUtils::AbstractItemModelToCSV(m_ui.breakpointList->model(), Qt::UserRole));
+	});
+	contextMenu->addAction(actionExport);
+
+	QAction* actionImport = new QAction(tr("Paste from CSV"), m_ui.breakpointList);
+	connect(actionImport, &QAction::triggered, this, &CpuWidget::contextBPListPasteCSV);
+	contextMenu->addAction(actionImport);
+
 	contextMenu->popup(m_ui.breakpointList->mapToGlobal(pos));
 }
 
@@ -333,6 +345,109 @@ void CpuWidget::contextBPListEdit()
 
 	BreakpointDialog* bpDialog = new BreakpointDialog(this, &m_cpu, m_bpModel, bpObject, selectedRow);
 	bpDialog->show();
+}
+
+void CpuWidget::contextBPListPasteCSV()
+{
+	QString csv = QGuiApplication::clipboard()->text();
+	// Skip header
+	csv = csv.mid(csv.indexOf('\n') + 1);
+
+	for (const QString& line : csv.split('\n'))
+	{
+		const QStringList fields = line.split(',');
+		if (fields.size() != BreakpointModel::BreakpointColumns::COLUMN_COUNT)
+		{
+			Console.WriteLn("Debugger CSV Import: Invalid number of columns, skipping");
+			continue;
+		}
+
+		bool ok;
+		int type = fields[0].toUInt(&ok);
+		if (!ok)
+		{
+			Console.WriteLn("Debugger CSV Import: Failed to parse type '%s', skipping", fields[0].toUtf8().constData());
+			continue;
+		}
+
+		// This is how we differentiate between breakpoints and memchecks
+		if (type == MEMCHECK_INVALID)
+		{
+			BreakPoint bp;
+
+			// Address
+			bp.addr = fields[1].toUInt(&ok, 16);
+			if (!ok)
+			{
+				Console.WriteLn("Debugger CSV Import: Failed to parse address '%s', skipping", fields[1].toUtf8().constData());
+				continue;
+			}
+
+			// Condition
+			if (fields[4] != "No Condition")
+			{
+				PostfixExpression expr;
+				bp.hasCond = true;
+				bp.cond.debug = &m_cpu;
+
+				if (!m_cpu.initExpression(fields[4].toUtf8().constData(), expr))
+				{
+					Console.WriteLn("Debugger CSV Import: Failed to parse cond '%s', skipping", fields[4].toUtf8().constData());
+					continue;
+				}
+				bp.cond.expression = expr;
+				strncpy(&bp.cond.expressionString[0], fields[4].toUtf8().constData(), sizeof(bp.cond.expressionString));
+			}
+
+			// Enabled
+			bp.enabled = fields[6].toUInt(&ok);
+			if (!ok)
+			{
+				Console.WriteLn("Debugger CSV Import: Failed to parse enable flag '%s', skipping", fields[1].toUtf8().constData());
+				continue;
+			}
+
+			m_bpModel.insertBreakpointRows(0, 1, {bp});
+		}
+		else
+		{
+			MemCheck mc;
+			// Mode
+			if (type >= MEMCHECK_INVALID)
+			{
+				Console.WriteLn("Debugger CSV Import: Failed to parse cond type '%s', skipping", fields[0].toUtf8().constData());
+				continue;
+			}
+			mc.cond = static_cast<MemCheckCondition>(type);
+
+			// Address
+			mc.start = fields[1].toUInt(&ok, 16);
+			if (!ok)
+			{
+				Console.WriteLn("Debugger CSV Import: Failed to parse address '%s', skipping", fields[1].toUtf8().constData());
+				continue;
+			}
+
+			// Size
+			mc.end = fields[2].toUInt(&ok, 16) + mc.start;
+			if (!ok)
+			{
+				Console.WriteLn("Debugger CSV Import: Failed to parse length '%s', skipping", fields[1].toUtf8().constData());
+				continue;
+			}
+
+			// Result
+			int result = fields[6].toUInt(&ok);
+			if (!ok)
+			{
+				Console.WriteLn("Debugger CSV Import: Failed to parse result flag '%s', skipping", fields[1].toUtf8().constData());
+				continue;
+			}
+			mc.result = static_cast<MemCheckResult>(result);
+
+			m_bpModel.insertBreakpointRows(0, 1, {mc});
+		}
+	}
 }
 
 void CpuWidget::updateFunctionList(bool whenEmpty)
@@ -395,6 +510,14 @@ void CpuWidget::onThreadListContextMenu(QPoint pos)
 		QGuiApplication::clipboard()->setText(m_ui.threadList->model()->data(selModel->currentIndex()).toString());
 	});
 	contextMenu->addAction(actionCopy);
+
+	contextMenu->addSeparator();
+
+	QAction* actionExport = new QAction(tr("Copy all as CSV"), m_ui.threadList);
+	connect(actionExport, &QAction::triggered, [this]() {
+		QGuiApplication::clipboard()->setText(QtUtils::AbstractItemModelToCSV(m_ui.threadList->model()));
+	});
+	contextMenu->addAction(actionExport);
 
 	contextMenu->popup(m_ui.threadList->mapToGlobal(pos));
 }
@@ -498,6 +621,14 @@ void CpuWidget::onStackListContextMenu(QPoint pos)
 		QGuiApplication::clipboard()->setText(m_ui.stackList->model()->data(selModel->currentIndex()).toString());
 	});
 	contextMenu->addAction(actionCopy);
+
+	contextMenu->addSeparator();
+
+	QAction* actionExport = new QAction(tr("Copy all as CSV"), m_ui.stackList);
+	connect(actionExport, &QAction::triggered, [this]() {
+		QGuiApplication::clipboard()->setText(QtUtils::AbstractItemModelToCSV(m_ui.stackList->model()));
+	});
+	contextMenu->addAction(actionExport);
 
 	contextMenu->popup(m_ui.stackList->mapToGlobal(pos));
 }

--- a/pcsx2-qt/Debugger/CpuWidget.cpp
+++ b/pcsx2-qt/Debugger/CpuWidget.cpp
@@ -294,7 +294,7 @@ void CpuWidget::onBPListContextMenu(QPoint pos)
 	connect(actionImport, &QAction::triggered, this, &CpuWidget::contextBPListPasteCSV);
 	contextMenu->addAction(actionImport);
 
-	contextMenu->popup(m_ui.breakpointList->mapToGlobal(pos));
+	contextMenu->popup(m_ui.breakpointList->viewport()->mapToGlobal(pos));
 }
 
 void CpuWidget::contextBPListCopy()
@@ -519,7 +519,7 @@ void CpuWidget::onThreadListContextMenu(QPoint pos)
 	});
 	contextMenu->addAction(actionExport);
 
-	contextMenu->popup(m_ui.threadList->mapToGlobal(pos));
+	contextMenu->popup(m_ui.threadList->viewport()->mapToGlobal(pos));
 }
 
 void CpuWidget::onThreadListDoubleClick(const QModelIndex& index)
@@ -591,7 +591,7 @@ void CpuWidget::onFuncListContextMenu(QPoint pos)
 	m_funclistContextMenu->addAction(gotoMemory);
 
 
-	m_funclistContextMenu->popup(m_ui.listFunctions->mapToGlobal(pos));
+	m_funclistContextMenu->popup(m_ui.listFunctions->viewport()->mapToGlobal(pos));
 }
 
 void CpuWidget::onFuncListDoubleClick(QListWidgetItem* item)
@@ -630,7 +630,7 @@ void CpuWidget::onStackListContextMenu(QPoint pos)
 	});
 	contextMenu->addAction(actionExport);
 
-	contextMenu->popup(m_ui.stackList->mapToGlobal(pos));
+	contextMenu->popup(m_ui.stackList->viewport()->mapToGlobal(pos));
 }
 
 void CpuWidget::onStackListDoubleClick(const QModelIndex& index)

--- a/pcsx2-qt/Debugger/CpuWidget.h
+++ b/pcsx2-qt/Debugger/CpuWidget.h
@@ -73,6 +73,7 @@ public slots:
 	void updateFunctionList(bool whenEmpty = false);
 	void onFuncListContextMenu(QPoint pos);
 	void onFuncListDoubleClick(QListWidgetItem* item);
+	bool getDemangleFunctions() const { return m_demangleFunctions; }
 
 	void reloadCPUWidgets()
 	{

--- a/pcsx2-qt/Debugger/CpuWidget.h
+++ b/pcsx2-qt/Debugger/CpuWidget.h
@@ -29,6 +29,7 @@
 #include "QtHost.h"
 #include <QtWidgets/QWidget>
 #include <QtWidgets/QTableWidget>
+#include <QtCore/QSortFilterProxyModel>
 
 #include <vector>
 
@@ -103,6 +104,7 @@ private:
 
 	BreakpointModel m_bpModel;
 	ThreadModel m_threadModel;
+	QSortFilterProxyModel m_threadProxyModel;
 	StackModel m_stackModel;
 
 	bool m_demangleFunctions = true;

--- a/pcsx2-qt/Debugger/CpuWidget.h
+++ b/pcsx2-qt/Debugger/CpuWidget.h
@@ -60,6 +60,7 @@ public slots:
 	void contextBPListDelete();
 	void contextBPListNew();
 	void contextBPListEdit();
+	void contextBPListPasteCSV();
 
 	void updateThreads();
 	void onThreadListDoubleClick(const QModelIndex& index);

--- a/pcsx2-qt/Debugger/DisassemblyWidget.cpp
+++ b/pcsx2-qt/Debugger/DisassemblyWidget.cpp
@@ -373,7 +373,7 @@ void DisassemblyWidget::paintEvent(QPaintEvent* event)
 
 		// Row text
 		painter.setPen(GetAddressFunctionColor(rowAddress));
-		QString lineString = DisassemblyStringFromAddress(rowAddress, painter.font(), curPC);
+		QString lineString = DisassemblyStringFromAddress(rowAddress, painter.font(), curPC, rowAddress == m_selectedAddressStart);
 
 		painter.drawText(2, i * m_rowHeight, w, m_rowHeight, Qt::AlignLeft, lineString);
 		alternate = !alternate;
@@ -683,7 +683,7 @@ void DisassemblyWidget::customMenuRequested(QPoint pos)
 	contextMenu->popup(this->mapToGlobal(pos));
 }
 
-inline QString DisassemblyWidget::DisassemblyStringFromAddress(u32 address, QFont font, u32 pc)
+inline QString DisassemblyWidget::DisassemblyStringFromAddress(u32 address, QFont font, u32 pc, bool selected)
 {
 	DisassemblyLineInfo line;
 
@@ -708,7 +708,7 @@ inline QString DisassemblyWidget::DisassemblyStringFromAddress(u32 address, QFon
 	{
 		// We want this text elided
 		QFontMetrics metric(font);
-		lineString = lineString.arg(metric.elidedText(QString::fromStdString(addressSymbol), Qt::ElideRight, 8 * font.pointSize()));
+		lineString = lineString.arg(metric.elidedText(QString::fromStdString(addressSymbol), Qt::ElideRight, (selected ? 32 : 8) * font.pointSize()));
 	}
 
 	lineString = lineString.leftJustified(4, ' ') // Address / symbol

--- a/pcsx2-qt/Debugger/DisassemblyWidget.cpp
+++ b/pcsx2-qt/Debugger/DisassemblyWidget.cpp
@@ -21,6 +21,7 @@
 #include "DebugTools/DisassemblyManager.h"
 #include "DebugTools/Breakpoints.h"
 #include "DebugTools/MipsAssembler.h"
+#include "demangler/demangler.h"
 
 #include "QtUtils.h"
 #include "QtHost.h"
@@ -699,6 +700,8 @@ inline QString DisassemblyWidget::DisassemblyStringFromAddress(u32 address, QFon
 	const bool isBreakpoint = CBreakPoints::IsAddressBreakPoint(m_cpu->getCpuType(), address) && !CBreakPoints::IsTempBreakPoint(m_cpu->getCpuType(), address);
 	const std::string addressSymbol = m_cpu->GetSymbolMap().GetLabelString(address);
 
+	const auto demangler = demangler::CDemangler::createGcc();
+
 	QString lineString("%1 %2  %3 %4  %5 %6");
 
 	lineString = lineString.arg(isBreakpoint ? "\u25A0" : " "); // Bp block ( ■ )
@@ -708,7 +711,7 @@ inline QString DisassemblyWidget::DisassemblyStringFromAddress(u32 address, QFon
 	{
 		// We want this text elided
 		QFontMetrics metric(font);
-		lineString = lineString.arg(metric.elidedText(QString::fromStdString(addressSymbol), Qt::ElideRight, (selected ? 32 : 8) * font.pointSize()));
+		lineString = lineString.arg(metric.elidedText(QString::fromStdString((m_demangleFunctions ? demangler->demangleToString(addressSymbol) : addressSymbol)), Qt::ElideRight, (selected ? 32 : 8) * font.pointSize()));
 	}
 
 	lineString = lineString.leftJustified(4, ' ') // Address / symbol

--- a/pcsx2-qt/Debugger/DisassemblyWidget.h
+++ b/pcsx2-qt/Debugger/DisassemblyWidget.h
@@ -90,7 +90,7 @@ private:
 
 	DisassemblyManager m_disassemblyManager;
 
-	inline QString DisassemblyStringFromAddress(u32 address, QFont font, u32 pc);
+	inline QString DisassemblyStringFromAddress(u32 address, QFont font, u32 pc, bool selected);
 	QColor GetAddressFunctionColor(u32 address);
 	enum class SelectionInfo
 	{

--- a/pcsx2-qt/Debugger/DisassemblyWidget.h
+++ b/pcsx2-qt/Debugger/DisassemblyWidget.h
@@ -64,6 +64,8 @@ public slots:
 	void contextAddFunction();
 	void contextRenameFunction();
 	void contextRemoveFunction();
+	void contextStubFunction();
+
 	void gotoAddress(u32 address);
 
 signals:
@@ -74,7 +76,7 @@ signals:
 private:
 	Ui::DisassemblyWidget ui;
 
-	QMenu* m_contextMenu = 0x0;
+	QMenu* m_contextMenu = nullptr;
 	void CreateCustomContextMenu();
 
 	DebugInterface* m_cpu;

--- a/pcsx2-qt/Debugger/DisassemblyWidget.h
+++ b/pcsx2-qt/Debugger/DisassemblyWidget.h
@@ -56,6 +56,7 @@ public slots:
 	void contextCopyInstructionText();
 	void contextAssembleInstruction();
 	void contextNoopInstruction();
+	void contextRestoreInstruction();
 	void contextRunToCursor();
 	void contextJumpToCursor();
 	void contextToggleBreakpoint();
@@ -65,6 +66,7 @@ public slots:
 	void contextRenameFunction();
 	void contextRemoveFunction();
 	void contextStubFunction();
+	void contextRestoreFunction();
 
 	void gotoAddress(u32 address);
 
@@ -76,15 +78,15 @@ signals:
 private:
 	Ui::DisassemblyWidget ui;
 
-	QMenu* m_contextMenu = nullptr;
-	void CreateCustomContextMenu();
-
 	DebugInterface* m_cpu;
 	u32 m_visibleStart = 0x00336318; // The address of the first opcode shown(row 0)
 	u32 m_visibleRows;
 	u32 m_selectedAddressStart = 0;
 	u32 m_selectedAddressEnd = 0;
 	u32 m_rowHeight = 0;
+
+	std::map<u32, u32> m_nopedInstructions;
+	std::map<u32, std::tuple<u32, u32>> m_stubbedFunctions;
 
 	DisassemblyManager m_disassemblyManager;
 
@@ -97,4 +99,7 @@ private:
 		INSTRUCTIONTEXT,
 	};
 	QString FetchSelectionInfo(SelectionInfo selInfo);
+
+	bool AddressCanRestore(u32 start, u32 end);
+	bool FunctionCanRestore(u32 address);
 };

--- a/pcsx2-qt/Debugger/DisassemblyWidget.h
+++ b/pcsx2-qt/Debugger/DisassemblyWidget.h
@@ -70,6 +70,7 @@ public slots:
 
 	void gotoAddress(u32 address);
 
+	void setDemangle(bool demangle) { m_demangleFunctions = demangle; };
 signals:
 	void gotoInMemory(u32 address);
 	void breakpointsChanged();
@@ -87,6 +88,8 @@ private:
 
 	std::map<u32, u32> m_nopedInstructions;
 	std::map<u32, std::tuple<u32, u32>> m_stubbedFunctions;
+
+	bool m_demangleFunctions = true;
 
 	DisassemblyManager m_disassemblyManager;
 

--- a/pcsx2-qt/Debugger/Models/BreakpointModel.cpp
+++ b/pcsx2-qt/Debugger/Models/BreakpointModel.cpp
@@ -107,7 +107,7 @@ QVariant BreakpointModel::data(const QModelIndex& index, int role) const
 			switch (index.column())
 			{
 				case BreakpointColumns::TYPE:
-					return 0;
+					return MEMCHECK_INVALID;
 				case BreakpointColumns::OFFSET:
 					return bp->addr;
 				case BreakpointColumns::SIZE_LABEL:
@@ -120,7 +120,7 @@ QVariant BreakpointModel::data(const QModelIndex& index, int role) const
 				case BreakpointColumns::HITS:
 					return 0;
 				case BreakpointColumns::ENABLED:
-					return bp->enabled;
+					return static_cast<int>(bp->enabled);
 			}
 		}
 		else if (const auto* mc = std::get_if<MemCheck>(&bp_mc))
@@ -330,7 +330,7 @@ bool BreakpointModel::insertBreakpointRows(int row, int count, std::vector<Break
 		if (const auto* bp = std::get_if<BreakPoint>(&bp_mc))
 		{
 			Host::RunOnCPUThread([cpu = m_cpu.getCpuType(), bp = *bp] {
-				CBreakPoints::AddBreakPoint(cpu, bp.addr);
+				CBreakPoints::AddBreakPoint(cpu, bp.addr, false, bp.enabled);
 
 				if (bp.hasCond)
 				{

--- a/pcsx2-qt/QtUtils.cpp
+++ b/pcsx2-qt/QtUtils.cpp
@@ -95,8 +95,8 @@ namespace QtUtils
 		const int min_column_width = header->minimumSectionSize();
 		const int scrollbar_width = ((view->verticalScrollBar() && view->verticalScrollBar()->isVisible()) ||
 										view->verticalScrollBarPolicy() == Qt::ScrollBarAlwaysOn) ?
-                                        view->verticalScrollBar()->width() :
-                                        0;
+										view->verticalScrollBar()->width() :
+										0;
 		int num_flex_items = 0;
 		int total_width = 0;
 		int column_index = 0;
@@ -115,8 +115,8 @@ namespace QtUtils
 
 		const int flex_width =
 			(num_flex_items > 0) ?
-                std::max((view->contentsRect().width() - total_width - scrollbar_width) / num_flex_items, 1) :
-                0;
+				std::max((view->contentsRect().width() - total_width - scrollbar_width) / num_flex_items, 1) :
+				0;
 
 		column_index = 0;
 		for (const int spec_width : widths)
@@ -269,4 +269,40 @@ namespace QtUtils
 		return wi;
 	}
 
+	QString AbstractItemModelToCSV(QAbstractItemModel* model, int role)
+	{
+		QString csv;
+		// Header
+		for (int col = 0; col < model->columnCount(); col++)
+		{
+			csv += model->headerData(col, Qt::Horizontal, Qt::DisplayRole).toString();
+			if (col < model->columnCount() - 1)
+				csv += ",";
+		}
+
+		csv += "\n";
+
+		// Data
+		for (int row = 0; row < model->rowCount(); row++)
+		{
+			for (int col = 0; col < model->columnCount(); col++)
+			{
+				switch(model->data(model->index(row, col), role).metaType().id())
+				{
+					case QMetaType::Int:
+					case QMetaType::UInt:
+						csv += QString::number(model->data(model->index(row, col), role).toUInt(nullptr), 16);
+					break;
+					default:
+						csv += model->data(model->index(row, col), role).toString();
+					break;
+				}
+				
+				if (col < model->columnCount() - 1)
+					csv += ",";
+			}
+			csv += "\n";
+		}
+		return csv;
+	}
 } // namespace QtUtils

--- a/pcsx2-qt/QtUtils.h
+++ b/pcsx2-qt/QtUtils.h
@@ -20,6 +20,7 @@
 #include <QtCore/QByteArray>
 #include <QtCore/QMetaType>
 #include <QtCore/QString>
+#include <QtCore/QAbstractItemModel>
 #include <functional>
 #include <initializer_list>
 #include <string_view>
@@ -93,4 +94,7 @@ namespace QtUtils
 	{
 		return QString("%1").arg(QString::number(val, base), sizeof(val) * 2, '0').toUpper();
 	};
+
+	/// Converts an abstract item model to a CSV string.
+	QString AbstractItemModelToCSV(QAbstractItemModel* model, int role = Qt::DisplayRole);
 } // namespace QtUtils

--- a/pcsx2/DebugTools/Breakpoints.cpp
+++ b/pcsx2/DebugTools/Breakpoints.cpp
@@ -185,13 +185,13 @@ bool CBreakPoints::IsTempBreakPoint(BreakPointCpu cpu, u32 addr)
 	return bp != INVALID_BREAKPOINT;
 }
 
-void CBreakPoints::AddBreakPoint(BreakPointCpu cpu, u32 addr, bool temp)
+void CBreakPoints::AddBreakPoint(BreakPointCpu cpu, u32 addr, bool temp, bool enabled)
 {
 	size_t bp = FindBreakpoint(cpu, addr, true, temp);
 	if (bp == INVALID_BREAKPOINT)
 	{
 		BreakPoint pt;
-		pt.enabled = true;
+		pt.enabled = enabled;
 		pt.temporary = temp;
 		pt.addr = addr;
 		pt.cpu = cpu;

--- a/pcsx2/DebugTools/Breakpoints.h
+++ b/pcsx2/DebugTools/Breakpoints.h
@@ -69,6 +69,7 @@ enum MemCheckCondition
 	MEMCHECK_WRITE_ONCHANGE = 0x04,
 
 	MEMCHECK_READWRITE = 0x03,
+	MEMCHECK_INVALID = 0x08, // Invalid condition, used by the CSV parser to know if the line is for a memcheck
 };
 
 enum MemCheckResult
@@ -119,7 +120,7 @@ public:
 	static bool IsAddressBreakPoint(BreakPointCpu cpu, u32 addr);
 	static bool IsAddressBreakPoint(BreakPointCpu cpu, u32 addr, bool* enabled);
 	static bool IsTempBreakPoint(BreakPointCpu cpu, u32 addr);
-	static void AddBreakPoint(BreakPointCpu cpu, u32 addr, bool temp = false);
+	static void AddBreakPoint(BreakPointCpu cpu, u32 addr, bool temp = false, bool enabled = true);
 	static void RemoveBreakPoint(BreakPointCpu cpu, u32 addr);
 	static void ChangeBreakPoint(BreakPointCpu cpu, u32 addr, bool enable);
 	static void ClearAllBreakPoints();


### PR DESCRIPTION
### Description of Changes
Implement sorting for the thread list
Implement export CSVs for breakpoints, thread lists, and call stacks
Implement importing CSVs for breakpoints
Fixes an issue with the context menu pop up location
Implements stubbing (noping) functions
Implements restoring instructions that have been noped or re-assembled
Implements restoring functions that have been stubbed
Implements the ability to view long function names in the disassembly view by clicking on function entry points
Demangle function names in the disassembly view

### Rationale behind Changes
Most of these were by request or were just minor issues.
Importing breakpoints via CSVs was added so you can restore / share your breakpoint setups. For example:
```
TYPE,OFFSET,SIZE / LABEL,INSTRUCTION,CONDITION,HITS,ENABLED
8,33634c,,nop,v0 != 1,0,1
8,336354,,nop,a2 == 0xff,0,0
3,336350,1,,,0,2
7,336320,5,,,0,0
1,336300,ff,,,0,0
2,3362c0,1,,,0,0
```
Copy that and use the "Paste from CSV" context option to load my breakpoints

### Suggested Testing Steps
Try exporting and import breakpoints
Try assembling then restoring instructions
Try noping then restoring instructions
Try stubbing then restoring functions
See if the right click context menu for breakpoints,threads, and stack frames pop up at a sensible position
Try sorting the thread list
Try exporting the stack list and thread list using the new context menu
Click on a function name that is elided, it should un-elide and you'll be able to read it :rocket: 
Toggle demangling in the disassembly view by clicking the check box in the function list context menu