### PR TITLE
Build: Fix up various warnings, increase variable readability

### DIFF
--- a/common/General.h
+++ b/common/General.h
@@ -40,6 +40,17 @@
 		}; \
 	};
 
+template<typename T> static T GetBufferT(u8* buffer, u32 offset) {
+	T value;
+	std::memcpy(&value, buffer + offset, sizeof(value));
+	return value;
+}
+
+static u8 GetBufferU8(u8* buffer, u32 offset) { return GetBufferT<u8>(buffer, offset); }
+static u16 GetBufferU16(u8* buffer, u32 offset) { return GetBufferT<u16>(buffer, offset); }
+static u32 GetBufferU32(u8* buffer, u32 offset) { return GetBufferT<u32>(buffer, offset); }
+static u64 GetBufferU64(u8* buffer, u32 offset) { return GetBufferT<u64>(buffer, offset); }
+
 // --------------------------------------------------------------------------------------
 //  PageProtectionMode
 // --------------------------------------------------------------------------------------

--- a/pcsx2/CDVD/CDVD.cpp
+++ b/pcsx2/CDVD/CDVD.cpp
@@ -50,12 +50,12 @@ u8 monthmap[13] = { 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 };
 
 u8 cdvdParamLength[16] = { 0, 0, 0, 0, 0, 4, 11, 11, 11, 1, 255, 255, 7, 2, 11, 1 };
 
-static __fi void SetSCMDResultSize(u8 size)
+static __fi void SetSCMDResultSize(u8 size) noexcept
 {
-	cdvd.SCMDResultC = size;
-	cdvd.SCMDResultP = 0;
+	cdvd.SCMDResultCnt = size;
+	cdvd.SCMDResultPos = 0;
 	cdvd.sDataIn &= ~0x40;
-	memset(cdvd.SCMDResult, 0, size);
+	memset(&cdvd.SCMDResultBuff[0], 0, size);
 }
 
 static void CDVDSECTORREADY_INT(u32 eCycle)
@@ -106,12 +106,12 @@ static void cdvdSetIrq(uint id = (1 << Irq_CommandComplete))
 static int mg_BIToffset(u8* buffer)
 {
 	int i, ofs = 0x20;
-	for (i = 0; i < *(u16*)&buffer[0x1A]; i++)
+	for (i = 0; i < GetBufferU16(&buffer[0], 0x1A); i++)
 		ofs += 0x10;
 
-	if (*(u16*)&buffer[0x18] & 1)
+	if (GetBufferU16(&buffer[0], 0x18) & 1)
 		ofs += buffer[ofs];
-	if ((*(u16*)&buffer[0x18] & 0xF000) == 0)
+	if ((GetBufferU16(&buffer[0], 0x18) & 0xF000) == 0)
 		ofs += 8;
 
 	return ofs + 0x20;
@@ -133,17 +133,17 @@ static void cdvdGetMechaVer(u8* ver)
 			return;
 		}
 
-		u8 version[4] = {0x3, 0x6, 0x2, 0x0};
-		std::fwrite(version, sizeof(version), 1, fp.get());
+		constexpr u8 version[4] = {0x3, 0x6, 0x2, 0x0};
+		std::fwrite(&version[0], sizeof(version), 1, fp.get());
 		FileSystem::FSeek64(fp.get(), 0, SEEK_SET);
 	}
 
-	auto ret = std::fread(ver, 1, 4, fp.get());
+	const auto ret = std::fread(ver, 1, 4, fp.get());
 	if (ret != 4)
 		Console.Error("Failed to read from %s. Did only %zu/4 bytes", mecfile.c_str(), ret);
 }
 
-NVMLayout* getNvmLayout()
+NVMLayout* getNvmLayout() noexcept
 {
 	NVMLayout* nvmLayout = NULL;
 
@@ -158,7 +158,7 @@ NVMLayout* getNvmLayout()
 static void cdvdCreateNewNVM(std::FILE* fp)
 {
 	u8 zero[1024] = {};
-	std::fwrite(zero, sizeof(zero), 1, fp);
+	std::fwrite(&zero[0], sizeof(zero), 1, fp);
 
 	// Write NVM ILink area with dummy data (Age of Empires 2)
 	// Also write language data defaulting to English (Guitar Hero 2)
@@ -168,28 +168,28 @@ static void cdvdCreateNewNVM(std::FILE* fp)
 
 	if (((BiosVersion >> 8) == 2) && ((BiosVersion & 0xff) != 10)) // bios >= 200, except of 0x210 for PSX2 DESR
 	{
-		u8 RegParams[12];
-		memcpy(RegParams, &PStwoRegionDefaults[BiosRegion][0], 12);
-		std::fseek(fp, *(s32*)(((u8*)nvmLayout) + offsetof(NVMLayout, regparams)), SEEK_SET);
-		std::fwrite(RegParams, sizeof(RegParams), 1, fp);
+		u8 RegParams[12] = { 0 };
+		memcpy(&RegParams[0], &PStwoRegionDefaults[BiosRegion][0], 12);
+		std::fseek(fp, nvmLayout->regparams, SEEK_SET);
+		std::fwrite(&RegParams[0], sizeof(RegParams), 1, fp);
 	}
 
-	u8 ILinkID_Data[8] = {0x00, 0xAC, 0xFF, 0xFF, 0xFF, 0xFF, 0xB9, 0x86};
-	std::fseek(fp, *(s32*)(((u8*)nvmLayout) + offsetof(NVMLayout, ilinkId)), SEEK_SET);
-	std::fwrite(ILinkID_Data, sizeof(ILinkID_Data), 1, fp);
+	constexpr u8 ILinkID_Data[8] = {0x00, 0xAC, 0xFF, 0xFF, 0xFF, 0xFF, 0xB9, 0x86};
+	std::fseek(fp, nvmLayout->ilinkId, SEEK_SET);
+	std::fwrite(&ILinkID_Data[0], sizeof(ILinkID_Data), 1, fp);
 	if (nvmlayouts[1].biosVer <= BiosVersion)
 	{
-		u8 ILinkID_checksum[2] = {0x00, 0x18};
-		std::fseek(fp, *(s32*)(((u8*)nvmLayout) + offsetof(NVMLayout, ilinkId)) + 0x08, SEEK_SET);
-		std::fwrite(ILinkID_checksum, sizeof(ILinkID_checksum), 1, fp);
+		constexpr u8 ILinkID_checksum[2] = {0x00, 0x18};
+		std::fseek(fp, nvmLayout->ilinkId + 0x08, SEEK_SET);
+		std::fwrite(&ILinkID_checksum[0], sizeof(ILinkID_checksum), 1, fp);
 	}
 
-	u8 biosLanguage[16];
-	memcpy(biosLanguage, &biosLangDefaults[BiosRegion][0], 16);
+	u8 biosLanguage[16] = { 0 };
+	memcpy(&biosLanguage[0], &biosLangDefaults[BiosRegion][0], 16);
 	// Config sections first 16 bytes are generally blank expect the last byte which is PS1 mode stuff
 	// So let's ignore that and just write the PS2 mode stuff
-	std::fseek(fp, *(s32*)(((u8*)nvmLayout) + offsetof(NVMLayout, config1)) + 0x10, SEEK_SET);
-	std::fwrite(biosLanguage, sizeof(biosLanguage), 1, fp);
+	std::fseek(fp, nvmLayout->config1 + 0x10, SEEK_SET);
+	std::fwrite(&biosLanguage[0], sizeof(biosLanguage), 1, fp);
 }
 
 static void cdvdNVM(u8* buffer, int offset, size_t bytes, bool read)
@@ -212,18 +212,18 @@ static void cdvdNVM(u8* buffer, int offset, size_t bytes, bool read)
 	}
 	else
 	{
-		u8 LanguageParams[16];
-		u8 RegParams[12];
-		u8 zero[16] = {0};
+		constexpr u8 zero[16] = { 0 };
+		u8 LanguageParams[16] = { 0 };
+		u8 RegParams[12] = { 0 };
 		NVMLayout* nvmLayout = getNvmLayout();
 
-		if (std::fseek(fp.get(), *(s32*)(((u8*)nvmLayout) + offsetof(NVMLayout, config1)) + 0x10, SEEK_SET) != 0 ||
-			std::fread(LanguageParams, 16, 1, fp.get()) != 1 ||
-			std::memcmp(LanguageParams, zero, sizeof(LanguageParams)) == 0 ||
+		if (std::fseek(fp.get(), nvmLayout->config1 + 0x10, SEEK_SET) != 0 ||
+			std::fread(&LanguageParams[0], 16, 1, fp.get()) != 1 ||
+			std::memcmp(&LanguageParams[0], zero, sizeof(LanguageParams)) == 0 ||
 			(((BiosVersion >> 8) == 2) && ((BiosVersion & 0xff) != 10) &&
-				(std::fseek(fp.get(), *(s32*)(((u8*)nvmLayout) + offsetof(NVMLayout, regparams)), SEEK_SET) != 0 ||
-					std::fread(RegParams, 12, 1, fp.get()) != 1 ||
-					std::memcmp(RegParams, zero, sizeof(RegParams)) == 0)))
+				(std::fseek(fp.get(), nvmLayout->regparams, SEEK_SET) != 0 ||
+					std::fread(&RegParams[0], 12, 1, fp.get()) != 1 ||
+					std::memcmp(&RegParams[0], zero, sizeof(RegParams)) == 0)))
 		{
 			Console.Warning("Language or Region Parameters missing, filling in defaults");
 
@@ -261,7 +261,7 @@ void getNvmData(u8* buffer, s32 offset, s32 size, s32 fmtOffset)
 	NVMLayout* nvmLayout = getNvmLayout();
 
 	// get data from eeprom
-	cdvdReadNVM(buffer, *(s32*)(((u8*)nvmLayout) + fmtOffset) + offset, size);
+	cdvdReadNVM(buffer, *reinterpret_cast<s32*>((reinterpret_cast<u8*>(nvmLayout)) + fmtOffset) + offset, size);
 }
 
 void setNvmData(const u8* buffer, s32 offset, s32 size, s32 fmtOffset)
@@ -270,7 +270,7 @@ void setNvmData(const u8* buffer, s32 offset, s32 size, s32 fmtOffset)
 	NVMLayout* nvmLayout = getNvmLayout();
 
 	// set data in eeprom
-	cdvdWriteNVM(buffer, *(s32*)(((u8*)nvmLayout) + fmtOffset) + offset, size);
+	cdvdWriteNVM(buffer, GetBufferU32(&reinterpret_cast<u8*>(nvmLayout)[0], fmtOffset) + offset, size);
 }
 
 static void cdvdReadConsoleID(u8* id)
@@ -629,10 +629,10 @@ void cdvdReadKey(u8, u16, u32 arg2, u8* key)
 
 		// combine the lower 7 bits of each char
 		// to make the 4 letters fit into a single u32
-		letters = (s32)((DiscSerial[3] & 0x7F) << 0) |
-				  (s32)((DiscSerial[2] & 0x7F) << 7) |
-				  (s32)((DiscSerial[1] & 0x7F) << 14) |
-				  (s32)((DiscSerial[0] & 0x7F) << 21);
+		letters = static_cast<s32>((DiscSerial[3] & 0x7F) << 0)  |
+				  static_cast<s32>((DiscSerial[2] & 0x7F) << 7)  |
+				  static_cast<s32>((DiscSerial[1] & 0x7F) << 14) |
+				  static_cast<s32>((DiscSerial[0] & 0x7F) << 21);
 	}
 
 	// calculate magic numbers
@@ -677,7 +677,7 @@ void cdvdReadKey(u8, u16, u32 arg2, u8* key)
 		cdvd.Key[0], cdvd.Key[1], cdvd.Key[2], cdvd.Key[3], cdvd.Key[4], cdvd.Key[14], cdvd.Key[15]);
 }
 
-s32 cdvdGetToc(void* toc)
+s32 cdvdGetToc(void* toc) noexcept
 {
 	s32 ret = CDVD->getTOC(toc);
 	if (ret == -1)
@@ -685,7 +685,7 @@ s32 cdvdGetToc(void* toc)
 	return ret;
 }
 
-s32 cdvdReadSubQ(s32 lsn, cdvdSubQ* subq)
+s32 cdvdReadSubQ(s32 lsn, cdvdSubQ* subq) noexcept
 {
 	s32 ret = CDVD->readSubQ(lsn, subq);
 	if (ret == -1)
@@ -695,9 +695,9 @@ s32 cdvdReadSubQ(s32 lsn, cdvdSubQ* subq)
 
 static void cdvdDetectDisk()
 {
-	cdvd.Type = DoCDVDdetectDiskType();
+	cdvd.DiscType = DoCDVDdetectDiskType();
 
-	if (cdvd.Type != 0)
+	if (cdvd.DiscType != 0)
 	{
 		cdvdTD td;
 		CDVD->getTD(0, &td);
@@ -705,13 +705,13 @@ static void cdvdDetectDisk()
 	}
 }
 
-static void cdvdUpdateStatus(cdvdStatus NewStatus)
+static void cdvdUpdateStatus(cdvdStatus NewStatus) noexcept
 {
 	cdvd.Status = NewStatus;
 	cdvd.StatusSticky |= NewStatus;
 }
 
-static void cdvdUpdateReady(u8 NewReadyStatus)
+static void cdvdUpdateReady(u8 NewReadyStatus) noexcept
 {
 	// We don't really use the MECHA bit but Cold Fear will kick back to the BIOS if it's not set
 	cdvd.Ready = NewReadyStatus | (CDVD_DRIVE_MECHA_INIT | CDVD_DRIVE_DEV9CON);
@@ -778,7 +778,7 @@ s32 cdvdCtrlTrayClose()
 //          gets value for start lsn of layer1
 // returns: 1 if on dual layer disc
 //          0 if not on dual layer disc
-static s32 cdvdReadDvdDualInfo(s32* dualType, u32* layer1Start)
+static s32 cdvdReadDvdDualInfo(s32* dualType, u32* layer1Start) noexcept
 {
 	*dualType = 0;
 	*layer1Start = 0;
@@ -786,9 +786,9 @@ static s32 cdvdReadDvdDualInfo(s32* dualType, u32* layer1Start)
 	return CDVD->getDualInfo(dualType, layer1Start);
 }
 
-static bool cdvdIsDVD()
+static bool cdvdIsDVD() noexcept
 {
-	if (cdvd.Type == CDVD_TYPE_DETCTDVDS || cdvd.Type == CDVD_TYPE_DETCTDVDD || cdvd.Type == CDVD_TYPE_PS2DVD || cdvd.Type == CDVD_TYPE_DVDV)
+	if (cdvd.DiscType == CDVD_TYPE_DETCTDVDS || cdvd.DiscType == CDVD_TYPE_DETCTDVDD || cdvd.DiscType == CDVD_TYPE_PS2DVD || cdvd.DiscType == CDVD_TYPE_DVDV)
 		return true;
 	else
 		return false;
@@ -812,7 +812,7 @@ static int cdvdTrayStateDetecting()
 			return CDVD_TYPE_DETCTDVDS;
 	}
 
-	if (cdvd.Type != CDVD_TYPE_NODISC)
+	if (cdvd.DiscType != CDVD_TYPE_NODISC)
 		return CDVD_TYPE_DETCTCD;
 	else
 		return CDVD_TYPE_DETCT; //Detecting any kind of disc existing
@@ -827,7 +827,7 @@ static u32 cdvdRotationTime(CDVD_MODE_TYPE mode)
 		// Calculate MS per rotation by dividing 1 second of milliseconds by the number of rotations.
 		const float msPerRotation = 1000.0f / rotationPerSecond;
 		// Calculate how many cycles 1 millisecond takes in IOP clocks, multiply by the time for 1 rotation.
-		return ((PSXCLK / 1000) * msPerRotation);
+		return static_cast<u32>((static_cast<float>(PSXCLK) / 1000.0f) * msPerRotation);
 	}
 	else
 	{
@@ -836,7 +836,7 @@ static u32 cdvdRotationTime(CDVD_MODE_TYPE mode)
 
 		//CLV adjusts its speed based on where it is on the disc, so we can take the max RPM and use the sector to work it out
 		// Sector counts are taken from google for Single layer, Dual layer DVD's and for 700MB CD's
-		switch (cdvd.Type)
+		switch (cdvd.DiscType)
 		{
 			case CDVD_TYPE_DETCTDVDS:
 			case CDVD_TYPE_PS2DVD:
@@ -855,16 +855,16 @@ static u32 cdvdRotationTime(CDVD_MODE_TYPE mode)
 				break;
 		}
 		// CLV speeds are reversed, so the centre is the fastest position.
-		const float sectorSpeed = (1.0f - (((float)(cdvd.SeekToSector - offset) / numSectors) * 0.60f)) + 0.40f;
+		const float sectorSpeed = (1.0f - ((static_cast<float>(cdvd.SeekToSector - offset) / numSectors) * 0.60f)) + 0.40f;
 
 		const float rotationPerSecond = static_cast<float>(((mode == MODE_CDROM) ? CD_MAX_ROTATION_X1 : DVD_MAX_ROTATION_X1) * std::min(static_cast<float>(cdvd.Speed), (mode == MODE_CDROM) ? 10.3f : 1.6f) * sectorSpeed) / 60.0f;
 		const float msPerRotation = 1000.0f / rotationPerSecond;
 		//DevCon.Warning("Rotations per second %f, msPerRotation cycles per ms %f total cycles per ms %d cycles per rotation %d", rotationPerSecond, msPerRotation, (u32)(PSXCLK / 1000), (u32)((PSXCLK / 1000) * msPerRotation));
-		return ((PSXCLK / 1000) * msPerRotation);
+		return static_cast<u32>((static_cast<float>(PSXCLK) / 1000.0f) * msPerRotation);
 	}
 }
 
-static uint cdvdBlockReadTime(CDVD_MODE_TYPE mode)
+static uint cdvdBlockReadTime(CDVD_MODE_TYPE mode) noexcept
 {
 	// CAV Read speed is roughly 41% in the centre full speed on outer edge. I imagine it's more logarithmic than this
 	if (cdvd.SpindlCtrl & CDVD_SPINDLE_CAV)
@@ -873,7 +873,7 @@ static uint cdvdBlockReadTime(CDVD_MODE_TYPE mode)
 		int offset = 0;
 
 		// Sector counts are taken from google for Single layer, Dual layer DVD's and for 700MB CD's
-		switch (cdvd.Type)
+		switch (cdvd.DiscType)
 		{
 			case CDVD_TYPE_DETCTDVDS:
 			case CDVD_TYPE_PS2DVD:
@@ -894,13 +894,13 @@ static uint cdvdBlockReadTime(CDVD_MODE_TYPE mode)
 
 		// 0.40f is the "base" inner track speed.
 		const float sectorSpeed = ((static_cast<float>(cdvd.SeekToSector - offset) / static_cast<float>(numSectors)) * 0.60f) + 0.40f;
-		float cycles = static_cast<float>(PSXCLK) / (static_cast<float>(((mode == MODE_CDROM) ? CD_SECTORS_PERSECOND : DVD_SECTORS_PERSECOND) * cdvd.Speed) * sectorSpeed);
+		const float cycles = static_cast<float>(PSXCLK) / (static_cast<float>(((mode == MODE_CDROM) ? CD_SECTORS_PERSECOND : DVD_SECTORS_PERSECOND) * cdvd.Speed) * sectorSpeed);
 
 		return static_cast<int>(cycles);
 	}
 
 	// CLV Read Speed is constant
-	float cycles = static_cast<float>(PSXCLK) / static_cast<float>(((mode == MODE_CDROM) ? CD_SECTORS_PERSECOND : DVD_SECTORS_PERSECOND) * std::min(static_cast<float>(cdvd.Speed), (mode == MODE_CDROM) ? 10.3f : 1.6f));
+	const float cycles = static_cast<float>(PSXCLK) / static_cast<float>(((mode == MODE_CDROM) ? CD_SECTORS_PERSECOND : DVD_SECTORS_PERSECOND) * std::min(static_cast<float>(cdvd.Speed), (mode == MODE_CDROM) ? 10.3f : 1.6f));
 
 	return static_cast<int>(cycles);
 }
@@ -909,7 +909,7 @@ void cdvdReset()
 {
 	std::memset(&cdvd, 0, sizeof(cdvd));
 
-	cdvd.Type = CDVD_TYPE_NODISC;
+	cdvd.DiscType = CDVD_TYPE_NODISC;
 	cdvd.Spinning = false;
 
 	cdvd.sDataIn = 0x40;
@@ -940,19 +940,19 @@ void cdvdReset()
 		// CDVD internally uses GMT+9.  If you think the time's wrong, you're wrong.
 		// Set up your time zone and winter/summer in the BIOS.  No PS2 BIOS I know of features automatic DST.
 		const std::time_t utc_time = std::time(nullptr);
-		const std::time_t gmt9_time = (utc_time + (60 * 60 * 9));
+		const std::time_t gmt9_time = (utc_time + 32400); //60 * 60 * 9
 		struct tm curtime = {};
 #ifdef _MSC_VER
 		gmtime_s(&curtime, &gmt9_time);
 #else
 		gmtime_r(&gmt9_time, &curtime);
 #endif
-		cdvd.RTC.second = (u8)curtime.tm_sec;
-		cdvd.RTC.minute = (u8)curtime.tm_min;
-		cdvd.RTC.hour = (u8)curtime.tm_hour;
-		cdvd.RTC.day = (u8)curtime.tm_mday;
-		cdvd.RTC.month = (u8)curtime.tm_mon + 1; // WX returns Jan as "0"
-		cdvd.RTC.year = (u8)(curtime.tm_year - 100); // offset from 2000
+		cdvd.RTC.second = static_cast<u8>(curtime.tm_sec);
+		cdvd.RTC.minute = static_cast<u8>(curtime.tm_min);
+		cdvd.RTC.hour = static_cast<u8>(curtime.tm_hour);
+		cdvd.RTC.day = static_cast<u8>(curtime.tm_mday);
+		cdvd.RTC.month = static_cast<u8>(curtime.tm_mon + 1); // WX returns Jan as "0"
+		cdvd.RTC.year = static_cast<u8>(curtime.tm_year - 100); // offset from 2000
 	}
 
 	cdvdCtrlTrayClose();
@@ -974,7 +974,7 @@ bool SaveStateBase::cdvdFreeze()
 		// seek is in progress!)
 
 		if (cdvd.Reading)
-			cdvd.RErr = DoCDVDreadTrack(cdvd.Readed ? cdvd.Sector : cdvd.SeekToSector, cdvd.ReadMode);
+			cdvd.ReadErr = DoCDVDreadTrack(cdvd.SeekCompleted ? cdvd.CurrentSector : cdvd.SeekToSector, cdvd.ReadMode);
 	}
 
 	return true;
@@ -995,10 +995,10 @@ void cdvdNewDiskCB()
 		cdvd.Spinning = false;
 		cdvdSetIrq(1 << Irq_Eject);
 		// If it really got ejected, the DVD Reader will report Type 0, so no need to simulate ejection
-		if (cdvd.Type > 0)
+		if (cdvd.DiscType > 0)
 			cdvd.Tray.cdvdActionSeconds = 3;
 	}
-	else if (cdvd.Type > 0)
+	else if (cdvd.DiscType > 0)
 	{
 		DevCon.WriteLn(Color_Green, "Seeking new media");
 		cdvdUpdateReady(CDVD_DRIVE_BUSY);
@@ -1012,8 +1012,8 @@ void cdvdNewDiskCB()
 static void mechaDecryptBytes(u32 madr, int size)
 {
 	int shiftAmount = (cdvd.decSet >> 4) & 7;
-	int doXor = (cdvd.decSet) & 1;
-	int doShift = (cdvd.decSet) & 2;
+	const int doXor = (cdvd.decSet) & 1;
+	const int doShift = (cdvd.decSet) & 2;
 
 	u8* curval = iopPhysMem(madr);
 	for (int i = 0; i < size; ++i, ++curval)
@@ -1029,7 +1029,7 @@ int cdvdReadSector()
 {
 	s32 bcr;
 
-	CDVD_LOG("SECTOR %d (BCR %x;%x)", cdvd.Sector, HW_DMA3_BCR_H16, HW_DMA3_BCR_L16);
+	CDVD_LOG("SECTOR %d (BCR %x;%x)", cdvd.CurrentSector, HW_DMA3_BCR_H16, HW_DMA3_BCR_L16);
 
 	bcr = (HW_DMA3_BCR_H16 * HW_DMA3_BCR_L16) * 4;
 	if (bcr < cdvd.BlockSize || !(HW_DMA3_CHCR & 0x01000000))
@@ -1058,7 +1058,7 @@ int cdvdReadSector()
 		u32 layer1Start;
 		s32 dualType;
 		s32 layerNum;
-		u32 lsn = cdvd.Sector;
+		u32 lsn = cdvd.CurrentSector;
 
 		cdvdReadDvdDualInfo(&dualType, &layer1Start);
 
@@ -1083,9 +1083,9 @@ int cdvdReadSector()
 		}
 
 		mdest[0] = 0x20 | layerNum;
-		mdest[1] = (u8)(lsn >> 16);
-		mdest[2] = (u8)(lsn >> 8);
-		mdest[3] = (u8)(lsn);
+		mdest[1] = static_cast<u8>(lsn >> 16);
+		mdest[2] = static_cast<u8>(lsn >> 8);
+		mdest[3] = static_cast<u8>(lsn);
 
 		// sector IED (not calculated at present)
 		mdest[4] = 0;
@@ -1100,7 +1100,7 @@ int cdvdReadSector()
 		mdest[11] = 0;
 
 		// normal 2048 bytes of sector data
-		memcpy(&mdest[12], cdr.Transfer, 2048);
+		memcpy(&mdest[12], &cdr.Transfer[0], 2048);
 
 		// 4 bytes of edc (not calculated at present)
 		mdest[2060] = 0;
@@ -1110,7 +1110,7 @@ int cdvdReadSector()
 	}
 	else
 	{
-		memcpy(mdest, cdr.Transfer, cdvd.BlockSize);
+		memcpy(mdest, &cdr.Transfer[0], cdvd.BlockSize);
 	}
 
 	// decrypt sector's bytes
@@ -1146,7 +1146,7 @@ __fi void cdvdActionInterrupt()
 		case cdvdAction_Seek:
 			cdvd.Spinning = true;
 			cdvdUpdateReady(CDVD_DRIVE_READY);
-			cdvd.Sector = cdvd.SeekToSector;
+			cdvd.CurrentSector = cdvd.SeekToSector;
 			cdvdUpdateStatus(CDVD_STATUS_PAUSE);
 			cdvd.nextSectorsBuffered = 0;
 			CDVDSECTORREADY_INT(cdvd.ReadTime);
@@ -1156,7 +1156,7 @@ __fi void cdvdActionInterrupt()
 			DevCon.Warning("CDVD Standby Call");
 			cdvd.Spinning = true; //check (rama)
 			cdvdUpdateReady(CDVD_DRIVE_READY);
-			cdvd.Sector = cdvd.SeekToSector;
+			cdvd.CurrentSector = cdvd.SeekToSector;
 			cdvdUpdateStatus(CDVD_STATUS_PAUSE);
 			cdvd.nextSectorsBuffered = 0;
 			CDVDSECTORREADY_INT(cdvd.ReadTime);
@@ -1165,11 +1165,11 @@ __fi void cdvdActionInterrupt()
 		case cdvdAction_Stop:
 			cdvd.Spinning = false;
 			cdvdUpdateReady(CDVD_DRIVE_READY);
-			cdvd.Sector = 0;
+			cdvd.CurrentSector = 0;
 			cdvdUpdateStatus(CDVD_STATUS_STOP);
 			break;
 
-		case cdvdAction_Error:
+		default: // cdvdAction_Error
 			cdvdUpdateReady(CDVD_DRIVE_READY | CDVD_DRIVE_ERROR);
 			cdvdUpdateStatus(CDVD_STATUS_PAUSE);
 			break;
@@ -1203,7 +1203,7 @@ __fi void cdvdReadInterrupt()
 	cdvdUpdateStatus(CDVD_STATUS_READ);
 	cdvd.WaitingDMA = false;
 
-	if (!cdvd.Readed)
+	if (!cdvd.SeekCompleted)
 	{
 		// Seeking finished.  Process the track we requested before, and
 		// then schedule another CDVD read int for when the block read finishes.
@@ -1212,10 +1212,10 @@ __fi void cdvdReadInterrupt()
 		// to call CDVDReadTrack here.
 
 		cdvd.Spinning = true;
-		cdvd.RetryCntP = 0;
+		cdvd.CurrentRetryCnt = 0;
 		cdvd.Reading = 1;
-		cdvd.Readed = 1;
-		cdvd.Sector = cdvd.SeekToSector;
+		cdvd.SeekCompleted = 1;
+		cdvd.CurrentSector = cdvd.SeekToSector;
 		CDVD_LOG("Cdvd Seek Complete at iopcycle=%8.8x.", psxRegs.cycle);
 	}
 
@@ -1235,9 +1235,9 @@ __fi void cdvdReadInterrupt()
 		}
 	}
 
-	if (cdvd.Sector >= cdvd.MaxSector)
+	if (cdvd.CurrentSector >= cdvd.MaxSector)
 	{
-		DevCon.Warning("Read past end of disc Sector %d Max Sector %d", cdvd.Sector, cdvd.MaxSector);
+		DevCon.Warning("Read past end of disc Sector %d Max Sector %d", cdvd.CurrentSector, cdvd.MaxSector);
 		cdvd.Error = 0x32; // Outermost track reached during playback
 		cdvdUpdateReady(CDVD_DRIVE_READY | CDVD_DRIVE_ERROR);
 		cdvdUpdateStatus(CDVD_STATUS_PAUSE);
@@ -1248,9 +1248,9 @@ __fi void cdvdReadInterrupt()
 
 	if (cdvd.Reading)
 	{
-		if (cdvd.RErr == 0)
+		if (cdvd.ReadErr == 0)
 		{
-			while ((cdvd.RErr = DoCDVDgetBuffer(cdr.Transfer)), cdvd.RErr == -2)
+			while ((cdvd.ReadErr = DoCDVDgetBuffer(&cdr.Transfer[0])), cdvd.ReadErr == -2)
 			{
 				// not finished yet ... block on the read until it finishes.
 				Threading::Sleep(0);
@@ -1258,18 +1258,18 @@ __fi void cdvdReadInterrupt()
 			}
 		}
 
-		if (cdvd.RErr == -1)
+		if (cdvd.ReadErr == -1)
 		{
-			cdvd.RetryCntP++;
+			cdvd.CurrentRetryCnt++;
 
-			if (cdvd.RetryCntP <= cdvd.RetryCnt)
+			if (cdvd.CurrentRetryCnt <= cdvd.RetryCntMax)
 			{
-				CDVD_LOG("CDVD read err, retrying... (attempt %d of %d)", cdvd.RetryCntP, cdvd.RetryCnt);
-				cdvd.RErr = DoCDVDreadTrack(cdvd.Sector, cdvd.ReadMode);
+				CDVD_LOG("CDVD read err, retrying... (attempt %d of %d)", cdvd.CurrentRetryCnt, cdvd.RetryCntMax);
+				cdvd.ReadErr = DoCDVDreadTrack(cdvd.CurrentSector, cdvd.ReadMode);
 				CDVDREAD_INT(cdvd.ReadTime);
 			}
 			else
-				Console.Error("CDVD READ ERROR, sector = 0x%08x", cdvd.Sector);
+				Console.Error("CDVD READ ERROR, sector = 0x%08x", cdvd.CurrentSector);
 
 			return;
 		}
@@ -1277,10 +1277,10 @@ __fi void cdvdReadInterrupt()
 		cdvd.Reading = false;
 
 		// Any other value besides 0 should be considered invalid here
-		pxAssert(cdvd.RErr == 0);
+		pxAssert(cdvd.ReadErr == 0);
 	}
 
-	if (cdvd.nSectors > 0 && cdvd.nextSectorsBuffered)
+	if (cdvd.SectorCnt > 0 && cdvd.nextSectorsBuffered)
 	{
 		if (cdvdReadSector() == -1)
 		{
@@ -1305,10 +1305,10 @@ __fi void cdvdReadInterrupt()
 		cdvd.nextSectorsBuffered--;
 		CDVDSECTORREADY_INT(cdvd.ReadTime);
 
-		cdvd.Sector++;
+		cdvd.CurrentSector++;
 		cdvd.SeekToSector++;
 
-		if (--cdvd.nSectors <= 0)
+		if (--cdvd.SectorCnt <= 0)
 		{
 			// Setting the data ready flag fixes a black screen loading issue in
 			// Street Fighter Ex3 (NTSC-J version).
@@ -1330,7 +1330,7 @@ __fi void cdvdReadInterrupt()
 	}
 	else
 	{
-		if (cdvd.nSectors <= 0)
+		if (cdvd.SectorCnt <= 0)
 		{
 			cdvdSetIrq();
 			//psxHu32(0x1070) |= 0x4;
@@ -1344,9 +1344,9 @@ __fi void cdvdReadInterrupt()
 		return;
 	}
 
-	cdvd.RetryCntP = 0;
+	cdvd.CurrentRetryCnt = 0;
 	cdvd.Reading = 1;
-	cdvd.RErr = DoCDVDreadTrack(cdvd.Sector, cdvd.ReadMode);
+	cdvd.ReadErr = DoCDVDreadTrack(cdvd.CurrentSector, cdvd.ReadMode);
 	if (cdvd.nextSectorsBuffered)
 		CDVDREAD_INT((cdvd.BlockSize / 4) * 12);
 	else
@@ -1358,13 +1358,13 @@ static uint cdvdStartSeek(uint newsector, CDVD_MODE_TYPE mode, bool transition_t
 {
 	cdvd.SeekToSector = newsector;
 
-	uint delta = abs((s32)(cdvd.SeekToSector - cdvd.Sector));
+	uint delta = abs(static_cast<s32>(cdvd.SeekToSector - cdvd.CurrentSector));
 	uint seektime = 0;
 	bool isSeeking = cdvd.nCommand == N_CD_SEEK;
 
 	cdvdUpdateReady(CDVD_DRIVE_BUSY);
 	cdvd.Reading = 1;
-	cdvd.Readed = 0;
+	cdvd.SeekCompleted = 0;
 	// Okay so let's explain this, since people keep messing with it in the past and just poking it.
 	// So when the drive is spinning, bit 0x2 is set on the Status, and bit 0x8 is set when the drive is not reading.
 	// So In the case where it's seeking to data it will be Spinning (0x2) not reading (0x8) and Seeking (0x10, but because seeking is also spinning 0x2 is also set))
@@ -1378,10 +1378,11 @@ static uint cdvdStartSeek(uint newsector, CDVD_MODE_TYPE mode, bool transition_t
 
 	if (cdvd.Spinning && transition_to_CLV)
 	{
-		const float old_rpm = (static_cast<float>(PSXCLK) / static_cast<float>(old_rotspeed)) * 60.0f;
-		const float new_rpm = (static_cast<float>(PSXCLK) / static_cast<float>(cdvd.RotSpeed)) * 60.0f;
+		const float psx_clk_cycles = static_cast<float>(PSXCLK);
+		const float old_rpm = (psx_clk_cycles / static_cast<float>(old_rotspeed)) * 60.0f;
+		const float new_rpm = (psx_clk_cycles / static_cast<float>(cdvd.RotSpeed)) * 60.0f;
 		// A rough cycles per RPM change based on 333ms for a full spin up.
-		drive_speed_change_cycles = (PSXCLK / 1000) * (0.054950495049505f * std::abs(new_rpm - old_rpm));
+		drive_speed_change_cycles = (psx_clk_cycles / 1000.0f) * (0.054950495049505f * std::abs(new_rpm - old_rpm));
 		psxRegs.interrupt &= ~(1 << IopEvt_CdvdSectorReady);
 	}
 	cdvdUpdateStatus(CDVD_STATUS_SEEK);
@@ -1402,12 +1403,12 @@ static uint cdvdStartSeek(uint newsector, CDVD_MODE_TYPE mode, bool transition_t
 		if (delta >= tbl_FastSeekDelta[mode])
 		{
 			// Full Seek
-			CDVD_LOG("CdSeek Begin > to sector %d, from %d - delta=%d [FULL]", cdvd.SeekToSector, cdvd.Sector, delta);
+			CDVD_LOG("CdSeek Begin > to sector %d, from %d - delta=%d [FULL]", cdvd.SeekToSector, cdvd.CurrentSector, delta);
 			seektime = Cdvd_FullSeek_Cycles;
 		}
 		else
 		{
-			CDVD_LOG("CdSeek Begin > to sector %d, from %d - delta=%d [FAST]", cdvd.SeekToSector, cdvd.Sector, delta);
+			CDVD_LOG("CdSeek Begin > to sector %d, from %d - delta=%d [FAST]", cdvd.SeekToSector, cdvd.CurrentSector, delta);
 			seektime = Cdvd_FastSeek_Cycles;
 		}
 		isSeeking = true;
@@ -1424,9 +1425,9 @@ static uint cdvdStartSeek(uint newsector, CDVD_MODE_TYPE mode, bool transition_t
 		{
 			//cdvd.Status = CDVD_STATUS_PAUSE;
 			cdvdUpdateStatus(CDVD_STATUS_READ);
-			cdvd.Readed = 1; // Note: 1, not 0, as implied by the next comment. Need to look into this. --arcum42
+			cdvd.SeekCompleted = 1; // Note: 1, not 0, as implied by the next comment. Need to look into this. --arcum42
 			cdvd.Reading = 1; // We don't need to wait for it to read a sector as it's already queued up, or we adjust for it here.
-			cdvd.RetryCntP = 0;
+			cdvd.CurrentRetryCnt = 0;
 
 			// setting Readed to 0 skips the seek logic, which means the next call to
 			// cdvdReadInterrupt will load a block.  So make sure it's properly scheduled
@@ -1466,7 +1467,7 @@ static uint cdvdStartSeek(uint newsector, CDVD_MODE_TYPE mode, bool transition_t
 	// Only do this on reads, the seek kind of accounts for this and then it reads the sectors after
 	if ((delta || cdvd.Action == cdvdAction_Seek) && !isSeeking && !cdvd.nextSectorsBuffered)
 	{
-		const u32 rotationalLatency = cdvdRotationTime((CDVD_MODE_TYPE)cdvdIsDVD()) / 2; // Half it to average the rotational latency.
+		const u32 rotationalLatency = cdvdRotationTime(static_cast<CDVD_MODE_TYPE>(cdvdIsDVD())) / 2; // Half it to average the rotational latency.
 		//DevCon.Warning("%s rotational latency at sector %d is %d cycles", (cdvd.SpindlCtrl & CDVD_SPINDLE_CAV) ? "CAV" : "CLV", cdvd.SeekToSector, rotationalLatency);
 		seektime += rotationalLatency + cdvd.ReadTime;
 		CDVDSECTORREADY_INT(seektime);
@@ -1502,7 +1503,7 @@ void cdvdUpdateTrayState()
 			{
 				case CDVD_DISC_OPEN:
 					cdvdCtrlTrayOpen();
-					if (cdvd.Type > 0 || CDVDsys_GetSourceType() == CDVD_SourceType::NoDisc)
+					if (cdvd.DiscType > 0 || CDVDsys_GetSourceType() == CDVD_SourceType::NoDisc)
 					{
 						cdvd.Tray.cdvdActionSeconds = 3;
 						cdvd.Tray.trayState = CDVD_DISC_EJECT;
@@ -1521,6 +1522,7 @@ void cdvdUpdateTrayState()
 					break;
 				case CDVD_DISC_SEEKING:
 					cdvd.Spinning = true;
+					[[fallthrough]];
 				case CDVD_DISC_ENGAGED:
 					cdvd.Tray.trayState = CDVD_DISC_ENGAGED;
 					cdvdUpdateReady(CDVD_DRIVE_READY);
@@ -1580,14 +1582,14 @@ static __fi u8 cdvdRead18(void) // SDATAOUT
 {
 	u8 ret = 0;
 
-	if (((cdvd.sDataIn & 0x40) == 0) && (cdvd.SCMDResultP < cdvd.SCMDResultC))
+	if (((cdvd.sDataIn & 0x40) == 0) && (cdvd.SCMDResultPos < cdvd.SCMDResultCnt))
 	{
-		cdvd.SCMDResultP++;
-		if (cdvd.SCMDResultP >= cdvd.SCMDResultC)
+		cdvd.SCMDResultPos++;
+		if (cdvd.SCMDResultPos >= cdvd.SCMDResultCnt)
 			cdvd.sDataIn |= 0x40;
-		ret = cdvd.SCMDResult[cdvd.SCMDResultP - 1];
+		ret = cdvd.SCMDResultBuff[cdvd.SCMDResultPos - 1];
 	}
-	CDVD_LOG("cdvdRead18(SDataOut) %x (ResultC=%d, ResultP=%d)", ret, cdvd.SCMDResultC, cdvd.SCMDResultP);
+	CDVD_LOG("cdvdRead18(SDataOut) %x (ResultC=%d, ResultP=%d)", ret, cdvd.SCMDResultCnt, cdvd.SCMDResultPos);
 
 	return ret;
 }
@@ -1607,7 +1609,7 @@ u8 cdvdRead(u8 key)
 		case 0x06: // ERROR
 		{
 			CDVD_LOG("cdvdRead06(Error) %x", cdvd.Error);
-			u8 ret = cdvd.Error;
+			const u8 ret = cdvd.Error;
 			cdvd.Error = 0;
 			return ret;
 		}
@@ -1629,22 +1631,22 @@ u8 cdvdRead(u8 key)
 			return cdvd.StatusSticky;
 		}
 		case 0x0C: // CRT MINUTE
-			CDVD_LOG("cdvdRead0C(Min) %x", itob((u8)(cdvd.Sector / (60 * 75))));
-			return itob((u8)(cdvd.Sector / (60 * 75)));
+			CDVD_LOG("cdvdRead0C(Min) %x", itob((u8)(cdvd.CurrentSector / (60 * 75))));
+			return itob((u8)(cdvd.CurrentSector / (60 * 75)));
 
 		case 0x0D: // CRT SECOND
-			CDVD_LOG("cdvdRead0D(Sec) %x", itob((u8)((cdvd.Sector / 75) % 60) + 2));
-			return itob((u8)((cdvd.Sector / 75) % 60) + 2);
+			CDVD_LOG("cdvdRead0D(Sec) %x", itob((u8)((cdvd.CurrentSector / 75) % 60) + 2));
+			return itob((u8)((cdvd.CurrentSector / 75) % 60) + 2);
 
 		case 0x0E: // CRT FRAME
-			CDVD_LOG("cdvdRead0E(Frame) %x", itob((u8)(cdvd.Sector % 75)));
-			return itob((u8)(cdvd.Sector % 75));
+			CDVD_LOG("cdvdRead0E(Frame) %x", itob((u8)(cdvd.CurrentSector % 75)));
+			return itob((u8)(cdvd.CurrentSector % 75));
 
 		case 0x0F: // TYPE
 			if (cdvd.Tray.trayState == CDVD_DISC_ENGAGED)
 			{
-				CDVD_LOG("cdvdRead0F(Disc Type) Engaged %x", cdvd.Type);
-				return cdvd.Type;
+				CDVD_LOG("cdvdRead0F(Disc Type) Engaged %x", cdvd.DiscType);
+				return cdvd.DiscType;
 			}
 			else
 			{
@@ -1693,7 +1695,7 @@ u8 cdvdRead(u8 key)
 		case 0x23:
 		case 0x24:
 		{
-			int temp = key - 0x20;
+			const int temp = key - 0x20;
 
 			CDVD_LOG("cdvdRead%d(Key%d) %x", key, temp, cdvd.Key[temp]);
 			return cdvd.Key[temp];
@@ -1704,7 +1706,7 @@ u8 cdvdRead(u8 key)
 		case 0x2B:
 		case 0x2C:
 		{
-			int temp = key - 0x23;
+			const int temp = key - 0x23;
 
 			CDVD_LOG("cdvdRead%d(Key%d) %x", key, temp, cdvd.Key[temp]);
 			return cdvd.Key[temp];
@@ -1716,7 +1718,7 @@ u8 cdvdRead(u8 key)
 		case 0x33:
 		case 0x34:
 		{
-			int temp = key - 0x26;
+			const int temp = key - 0x26;
 
 			CDVD_LOG("cdvdRead%d(Key%d) %x", key, temp, cdvd.Key[temp]);
 			return cdvd.Key[temp];
@@ -1748,7 +1750,7 @@ u8 cdvdRead(u8 key)
 
 static bool cdvdReadErrorHandler()
 {
-	if (cdvd.nSectors <= 0)
+	if (cdvd.SectorCnt <= 0)
 	{
 		DevCon.Warning("Bad Sector Count Error");
 		cdvd.Error = 0x21; // Number of read sectors abnormal
@@ -1772,18 +1774,18 @@ static bool cdvdCommandErrorHandler()
 {
 	if (cdvd.nCommand > N_CD_NOP) // Command needs a disc, so check the tray is closed
 	{
-		if ((cdvd.Status & CDVD_STATUS_TRAY_OPEN) || (cdvd.Type == CDVD_TYPE_NODISC))
+		if ((cdvd.Status & CDVD_STATUS_TRAY_OPEN) || (cdvd.DiscType == CDVD_TYPE_NODISC))
 		{
-			cdvd.Error = (cdvd.Type == CDVD_TYPE_NODISC) ? 0x12 : 0x11; // No Disc Tray is open
+			cdvd.Error = (cdvd.DiscType == CDVD_TYPE_NODISC) ? 0x12 : 0x11; // No Disc Tray is open
 			cdvd.Ready |= CDVD_DRIVE_ERROR;
 			cdvdSetIrq();
 			return false;
 		}
 	}
 
-	if (cdvd.NCMDParamC != cdvdParamLength[cdvd.nCommand] && cdvdParamLength[cdvd.nCommand] != 255)
+	if (cdvd.NCMDParamCnt != cdvdParamLength[cdvd.nCommand] && cdvdParamLength[cdvd.nCommand] != 255)
 	{
-		DevCon.Warning("CDVD: Error in command parameter length, expecting %d got %d", cdvdParamLength[cdvd.nCommand], cdvd.NCMDParamC);
+		DevCon.Warning("CDVD: Error in command parameter length, expecting %d got %d", cdvdParamLength[cdvd.nCommand], cdvd.NCMDParamCnt);
 		cdvd.Error = 0x22; // Invalid parameter for command
 		cdvd.Ready |= CDVD_DRIVE_ERROR;
 		cdvdSetIrq();
@@ -1804,7 +1806,7 @@ static bool cdvdCommandErrorHandler()
 
 static void cdvdWrite04(u8 rt)
 { // NCOMMAND
-	CDVD_LOG("cdvdWrite04: NCMD %s (%x) (ParamP = %x)", nCmdName[rt], rt, cdvd.NCMDParamP);
+	CDVD_LOG("cdvdWrite04: NCMD %s (%x) (ParamP = %x)", nCmdName[rt], rt, cdvd.NCMDParamPos);
 
 	if (!(cdvd.Ready & CDVD_DRIVE_READY))
 	{
@@ -1812,8 +1814,8 @@ static void cdvdWrite04(u8 rt)
 		cdvd.Error = 0x13; // Not Ready
 		cdvd.Ready |= CDVD_DRIVE_ERROR;
 		cdvdSetIrq();
-		cdvd.NCMDParamP = 0;
-		cdvd.NCMDParamC = 0;
+		cdvd.NCMDParamPos = 0;
+		cdvd.NCMDParamCnt = 0;
 		return;
 	}
 
@@ -1822,8 +1824,8 @@ static void cdvdWrite04(u8 rt)
 
 	if (!cdvdCommandErrorHandler())
 	{
-		cdvd.NCMDParamP = 0;
-		cdvd.NCMDParamC = 0;
+		cdvd.NCMDParamPos = 0;
+		cdvd.NCMDParamCnt = 0;
 		return;
 	}
 
@@ -1836,11 +1838,11 @@ static void cdvdWrite04(u8 rt)
 		case N_CD_RESET: // CdSync
 			Console.WriteLn("CDVD: Reset NCommand");
 			cdvdUpdateReady(CDVD_DRIVE_READY);
-			cdvd.SCMDParamP = 0;
-			cdvd.SCMDParamC = 0;
+			cdvd.SCMDParamPos = 0;
+			cdvd.SCMDParamCnt = 0;
 			cdvdUpdateStatus(CDVD_STATUS_STOP);
 			cdvd.Spinning = false;
-			std::memset(cdvd.SCMDResult, 0, sizeof(cdvd.SCMDResult));
+			std::memset(&cdvd.SCMDResultBuff[0], 0, sizeof(cdvd.SCMDResultBuff));
 			cdvdSetIrq();
 			break;
 
@@ -1881,7 +1883,7 @@ static void cdvdWrite04(u8 rt)
 
 		case N_CD_SEEK: // CdSeek
 			cdvdUpdateReady(CDVD_DRIVE_BUSY);
-			CDVD_INT(cdvdStartSeek(*reinterpret_cast<uint*>(cdvd.NCMDParam + 0), static_cast<CDVD_MODE_TYPE>(cdvdIsDVD()), false));
+			CDVD_INT(cdvdStartSeek(GetBufferU32(&cdvd.NCMDParamBuff[0], 0), static_cast<CDVD_MODE_TYPE>(cdvdIsDVD()), false));
 			cdvdUpdateStatus(CDVD_STATUS_SEEK);
 			cdvd.Action = cdvdAction_Seek;
 			break;
@@ -1889,17 +1891,17 @@ static void cdvdWrite04(u8 rt)
 		case N_CD_READ: // CdRead
 		{
 			// Assign the seek to sector based on cdvd.Param[0]-[3], and the number of  sectors based on cdvd.Param[4]-[7].
-			cdvd.SeekToSector = *(u32*)(cdvd.NCMDParam + 0);
-			cdvd.nSectors = *(u32*)(cdvd.NCMDParam + 4);
-			cdvd.RetryCnt = (cdvd.NCMDParam[8] == 0) ? 0x100 : cdvd.NCMDParam[8];
-			u32 oldSpindleCtrl = cdvd.SpindlCtrl;
+			cdvd.SeekToSector = GetBufferU32(&cdvd.NCMDParamBuff[0], 0);
+			cdvd.SectorCnt = GetBufferU32(&cdvd.NCMDParamBuff[0], 4);
+			cdvd.RetryCntMax = (cdvd.NCMDParamBuff[8] == 0) ? 0x100 : cdvd.NCMDParamBuff[8];
+			const u32 oldSpindleCtrl = cdvd.SpindlCtrl;
 
-			if (cdvd.NCMDParam[9] & 0x3F)
-				cdvd.SpindlCtrl = cdvd.NCMDParam[9];
+			if (cdvd.NCMDParamBuff[9] & 0x3F)
+				cdvd.SpindlCtrl = cdvd.NCMDParamBuff[9];
 			else
-				cdvd.SpindlCtrl = (cdvd.NCMDParam[9] & 0x80) | (cdvdIsDVD() ? 3 : 5); // Max speed for DVD/CD
+				cdvd.SpindlCtrl = (cdvd.NCMDParamBuff[9] & 0x80) | (cdvdIsDVD() ? 3 : 5); // Max speed for DVD/CD
 
-			if (cdvd.NCMDParam[9] & CDVD_SPINDLE_NOMINAL)
+			if (cdvd.NCMDParamBuff[9] & CDVD_SPINDLE_NOMINAL)
 				DevCon.Warning("CDVD: CD Read using Nominal switch from CAV to CLV, unhandled");
 
 			bool ParamError = false;
@@ -1940,13 +1942,13 @@ static void cdvdWrite04(u8 rt)
 					break;
 			}
 
-			if (cdvdIsDVD() && cdvd.NCMDParam[10] != 0)
+			if (cdvdIsDVD() && cdvd.NCMDParamBuff[10] != 0)
 			{
 				ParamError = true;
 			}
 			else
 			{
-				switch (cdvd.NCMDParam[10])
+				switch (cdvd.NCMDParamBuff[10])
 				{
 					case 2:
 						cdvd.ReadMode = CDVD_MODE_2340;
@@ -1983,23 +1985,23 @@ static void cdvdWrite04(u8 rt)
 				cdvd.Action = cdvdAction_Error;
 				cdvdUpdateStatus(CDVD_STATUS_SEEK);
 				cdvdUpdateReady(CDVD_DRIVE_BUSY);
-				CDVD_INT(cdvdRotationTime((CDVD_MODE_TYPE)cdvdIsDVD()));
+				CDVD_INT(cdvdRotationTime(static_cast<CDVD_MODE_TYPE>(cdvdIsDVD())));
 				break;
 			}
 
 			CDVD_LOG("CDRead > startSector=%d, seekTo=%d nSectors=%d, RetryCnt=%x, Speed=%dx(%s), ReadMode=%x(%x) SpindleCtrl=%x",
-				cdvd.Sector, cdvd.SeekToSector, cdvd.nSectors, cdvd.RetryCnt, cdvd.Speed, (cdvd.SpindlCtrl & CDVD_SPINDLE_CAV) ? "CAV" : "CLV", cdvd.ReadMode, cdvd.NCMDParam[10], cdvd.SpindlCtrl);
+				cdvd.CurrentSector, cdvd.SeekToSector, cdvd.SectorCnt, cdvd.RetryCntMax, cdvd.Speed, (cdvd.SpindlCtrl & CDVD_SPINDLE_CAV) ? "CAV" : "CLV", cdvd.ReadMode, cdvd.NCMDParamBuff[10], cdvd.SpindlCtrl);
 
 			if (EmuConfig.CdvdVerboseReads)
 				Console.WriteLn(Color_Gray, "CDRead: Reading Sector %07d (%03d Blocks of Size %d) at Speed=%dx(%s) Spindle=%x",
-					cdvd.SeekToSector, cdvd.nSectors, cdvd.BlockSize, cdvd.Speed, (cdvd.SpindlCtrl & CDVD_SPINDLE_CAV) ? "CAV" : "CLV", cdvd.SpindlCtrl);
+					cdvd.SeekToSector, cdvd.SectorCnt, cdvd.BlockSize, cdvd.Speed, (cdvd.SpindlCtrl & CDVD_SPINDLE_CAV) ? "CAV" : "CLV", cdvd.SpindlCtrl);
 
 			CDVDREAD_INT(cdvdStartSeek(cdvd.SeekToSector, static_cast<CDVD_MODE_TYPE>(cdvdIsDVD()), !(cdvd.SpindlCtrl & CDVD_SPINDLE_CAV) && (oldSpindleCtrl & CDVD_SPINDLE_CAV)));
 			cdvdUpdateReady(CDVD_DRIVE_BUSY);
 			// Read-ahead by telling CDVD about the track now.
 			// This helps improve performance on actual from-cd emulation
 			// (ie, not using the hard drive)
-			cdvd.RErr = DoCDVDreadTrack(cdvd.SeekToSector, cdvd.ReadMode);
+			cdvd.ReadErr = DoCDVDreadTrack(cdvd.SeekToSector, cdvd.ReadMode);
 
 			// Set the reading block flag.  If a seek is pending then Readed will
 			// take priority in the handler anyway.  If the read is contiguous then
@@ -2019,18 +2021,18 @@ static void cdvdWrite04(u8 rt)
 				return;
 			}
 			// Assign the seek to sector based on cdvd.Param[0]-[3], and the number of  sectors based on cdvd.Param[4]-[7].
-			cdvd.SeekToSector = *(u32*)(cdvd.NCMDParam + 0);
-			cdvd.nSectors = *(u32*)(cdvd.NCMDParam + 4);
-			cdvd.RetryCnt = (cdvd.NCMDParam[8] == 0) ? 0x100 : cdvd.NCMDParam[8];
+			cdvd.SeekToSector = GetBufferU32(&cdvd.NCMDParamBuff[0], 0);
+			cdvd.SectorCnt = GetBufferU32(&cdvd.NCMDParamBuff[0], 4);
+			cdvd.RetryCntMax = (cdvd.NCMDParamBuff[8] == 0) ? 0x100 : cdvd.NCMDParamBuff[8];
 
-			u32 oldSpindleCtrl = cdvd.SpindlCtrl;
+			const u32 oldSpindleCtrl = cdvd.SpindlCtrl;
 
-			if (cdvd.NCMDParam[9] & 0x3F)
-				cdvd.SpindlCtrl = cdvd.NCMDParam[9];
+			if (cdvd.NCMDParamBuff[9] & 0x3F)
+				cdvd.SpindlCtrl = cdvd.NCMDParamBuff[9];
 			else
-				cdvd.SpindlCtrl = (cdvd.NCMDParam[9] & 0x80) | 5; // Max speed for CD
+				cdvd.SpindlCtrl = (cdvd.NCMDParamBuff[9] & 0x80) | 5; // Max speed for CD
 
-			if (cdvd.NCMDParam[9] & CDVD_SPINDLE_NOMINAL)
+			if (cdvd.NCMDParamBuff[9] & CDVD_SPINDLE_NOMINAL)
 				DevCon.Warning("CDVD: CDDA Read using Nominal switch from CAV to CLV, unhandled");
 
 			bool ParamError = false;
@@ -2059,7 +2061,7 @@ static void cdvdWrite04(u8 rt)
 					break;
 			}
 
-			switch (cdvd.NCMDParam[10])
+			switch (cdvd.NCMDParamBuff[10])
 			{
 				case 1:
 					cdvd.ReadMode = CDVD_MODE_2368;
@@ -2087,18 +2089,18 @@ static void cdvdWrite04(u8 rt)
 			}
 
 			CDVD_LOG("CDRead > startSector=%d, seekTo=%d, nSectors=%d, RetryCnt=%x, Speed=%dx(%s), ReadMode=%x(%x) SpindleCtrl=%x",
-				cdvd.Sector, cdvd.SeekToSector, cdvd.nSectors, cdvd.RetryCnt, cdvd.Speed, (cdvd.SpindlCtrl & CDVD_SPINDLE_CAV) ? "CAV" : "CLV", cdvd.ReadMode, cdvd.NCMDParam[10], cdvd.SpindlCtrl);
+				cdvd.CurrentSector, cdvd.SeekToSector, cdvd.SectorCnt, cdvd.RetryCntMax, cdvd.Speed, (cdvd.SpindlCtrl & CDVD_SPINDLE_CAV) ? "CAV" : "CLV", cdvd.ReadMode, cdvd.NCMDParamBuff[10], cdvd.SpindlCtrl);
 
 			if (EmuConfig.CdvdVerboseReads)
 				Console.WriteLn(Color_Gray, "CdAudioRead: Reading Sector %07d (%03d Blocks of Size %d) at Speed=%dx(%s) Spindle=%x",
-					cdvd.Sector, cdvd.nSectors, cdvd.BlockSize, cdvd.Speed, (cdvd.SpindlCtrl & CDVD_SPINDLE_CAV) ? "CAV" : "CLV", cdvd.SpindlCtrl);
+					cdvd.CurrentSector, cdvd.SectorCnt, cdvd.BlockSize, cdvd.Speed, (cdvd.SpindlCtrl & CDVD_SPINDLE_CAV) ? "CAV" : "CLV", cdvd.SpindlCtrl);
 
 			CDVDREAD_INT(cdvdStartSeek(cdvd.SeekToSector, MODE_CDROM, !(cdvd.SpindlCtrl& CDVD_SPINDLE_CAV) && (oldSpindleCtrl& CDVD_SPINDLE_CAV)));
 			cdvdUpdateReady(CDVD_DRIVE_BUSY);
 			// Read-ahead by telling CDVD about the track now.
 			// This helps improve performance on actual from-cd emulation
 			// (ie, not using the hard drive)
-			cdvd.RErr = DoCDVDreadTrack(cdvd.SeekToSector, cdvd.ReadMode);
+			cdvd.ReadErr = DoCDVDreadTrack(cdvd.SeekToSector, cdvd.ReadMode);
 
 			// Set the reading block flag.  If a seek is pending then Readed will
 			// take priority in the handler anyway.  If the read is contiguous then
@@ -2117,22 +2119,22 @@ static void cdvdWrite04(u8 rt)
 				return;
 			}
 			// Assign the seek to sector based on cdvd.Param[0]-[3], and the number of  sectors based on cdvd.Param[4]-[7].
-			cdvd.SeekToSector = *(u32*)(cdvd.NCMDParam + 0);
-			cdvd.nSectors = *(u32*)(cdvd.NCMDParam + 4);
+			cdvd.SeekToSector = GetBufferU32(&cdvd.NCMDParamBuff[0], 0);
+			cdvd.SectorCnt = GetBufferU32(&cdvd.NCMDParamBuff[0], 4);
 
-			u32 oldSpindleCtrl = cdvd.SpindlCtrl;
+			const u32 oldSpindleCtrl = cdvd.SpindlCtrl;
 
-			if (cdvd.NCMDParam[8] == 0)
-				cdvd.RetryCnt = 0x100;
+			if (cdvd.NCMDParamBuff[8] == 0)
+				cdvd.RetryCntMax = 0x100;
 			else
-				cdvd.RetryCnt = cdvd.NCMDParam[8];
+				cdvd.RetryCntMax = cdvd.NCMDParamBuff[8];
 
-			if (cdvd.NCMDParam[9] & 0x3F)
-				cdvd.SpindlCtrl = cdvd.NCMDParam[9];
+			if (cdvd.NCMDParamBuff[9] & 0x3F)
+				cdvd.SpindlCtrl = cdvd.NCMDParamBuff[9];
 			else
-				cdvd.SpindlCtrl = (cdvd.NCMDParam[9] & 0x80) | 3; // Max speed for DVD
+				cdvd.SpindlCtrl = (cdvd.NCMDParamBuff[9] & 0x80) | 3; // Max speed for DVD
 
-			if (cdvd.NCMDParam[9] & CDVD_SPINDLE_NOMINAL)
+			if (cdvd.NCMDParamBuff[9] & CDVD_SPINDLE_NOMINAL)
 				DevCon.Warning("CDVD: DVD Read using Nominal switch from CAV to CLV, unhandled");
 
 			bool ParamError = false;
@@ -2155,7 +2157,7 @@ static void cdvdWrite04(u8 rt)
 					break;
 			}
 
-			if (cdvd.NCMDParam[10] != 0)
+			if (cdvd.NCMDParamBuff[10] != 0)
 				ParamError = true;
 
 			cdvd.ReadMode = CDVD_MODE_2048;
@@ -2178,23 +2180,23 @@ static void cdvdWrite04(u8 rt)
 				cdvd.Action = cdvdAction_Error;
 				cdvdUpdateStatus(CDVD_STATUS_SEEK);
 				cdvdUpdateReady(CDVD_DRIVE_BUSY);
-				CDVD_INT(cdvdRotationTime((CDVD_MODE_TYPE)cdvdIsDVD()));
+				CDVD_INT(cdvdRotationTime(static_cast<CDVD_MODE_TYPE>(cdvdIsDVD())));
 				break;
 			}
 
 			CDVD_LOG("DvdRead > startSector=%d, seekTo=%d nSectors=%d, RetryCnt=%x, Speed=%dx(%s), ReadMode=%x(%x) SpindleCtrl=%x",
-				cdvd.Sector, cdvd.SeekToSector, cdvd.nSectors, cdvd.RetryCnt, cdvd.Speed, (cdvd.SpindlCtrl & CDVD_SPINDLE_CAV) ? "CAV" : "CLV", cdvd.ReadMode, cdvd.NCMDParam[10], cdvd.SpindlCtrl);
+				cdvd.CurrentSector, cdvd.SeekToSector, cdvd.SectorCnt, cdvd.RetryCntMax, cdvd.Speed, (cdvd.SpindlCtrl & CDVD_SPINDLE_CAV) ? "CAV" : "CLV", cdvd.ReadMode, cdvd.NCMDParamBuff[10], cdvd.SpindlCtrl);
 
 			if (EmuConfig.CdvdVerboseReads)
 				Console.WriteLn(Color_Gray, "DvdRead: Reading Sector %07d (%03d Blocks of Size %d) at Speed=%dx(%s) SpindleCtrl=%x",
-					cdvd.SeekToSector, cdvd.nSectors, cdvd.BlockSize, cdvd.Speed, (cdvd.SpindlCtrl & CDVD_SPINDLE_CAV) ? "CAV" : "CLV", cdvd.SpindlCtrl);
+					cdvd.SeekToSector, cdvd.SectorCnt, cdvd.BlockSize, cdvd.Speed, (cdvd.SpindlCtrl & CDVD_SPINDLE_CAV) ? "CAV" : "CLV", cdvd.SpindlCtrl);
 
 			CDVDREAD_INT(cdvdStartSeek(cdvd.SeekToSector, MODE_DVDROM, !(cdvd.SpindlCtrl & CDVD_SPINDLE_CAV) && (oldSpindleCtrl& CDVD_SPINDLE_CAV)));
 			cdvdUpdateReady(CDVD_DRIVE_BUSY);
 			// Read-ahead by telling CDVD about the track now.
 			// This helps improve performance on actual from-cd emulation
 			// (ie, not using the hard drive)
-			cdvd.RErr = DoCDVDreadTrack(cdvd.SeekToSector, cdvd.ReadMode);
+			cdvd.ReadErr = DoCDVDreadTrack(cdvd.SeekToSector, cdvd.ReadMode);
 
 			// Set the reading block flag.  If a seek is pending then Readed will
 			// take priority in the handler anyway.  If the read is contiguous then
@@ -2207,7 +2209,7 @@ static void cdvdWrite04(u8 rt)
 			//the code below handles only CdGetToc!
 			//if(cdvd.Param[0]==0x01)
 			//{
-			DevCon.WriteLn("CDGetToc Param[0]=%d, Param[1]=%d", cdvd.NCMDParam[0], cdvd.NCMDParam[1]);
+			DevCon.WriteLn("CDGetToc Param[0]=%d, Param[1]=%d", cdvd.NCMDParamBuff[0], cdvd.NCMDParamBuff[1]);
 			//}
 			cdvdGetToc(iopPhysMem(HW_DMA3_MADR));
 			cdvdSetIrq();
@@ -2222,11 +2224,11 @@ static void cdvdWrite04(u8 rt)
 
 		case N_CD_READ_KEY: // CdReadKey
 		{
-			u8 arg0 = cdvd.NCMDParam[0];
-			u16 arg1 = cdvd.NCMDParam[1] | (cdvd.NCMDParam[2] << 8);
-			u32 arg2 = cdvd.NCMDParam[3] | (cdvd.NCMDParam[4] << 8) | (cdvd.NCMDParam[5] << 16) | (cdvd.NCMDParam[6] << 24);
+			const u8 arg0 = cdvd.NCMDParamBuff[0];
+			const u16 arg1 = cdvd.NCMDParamBuff[1] | (cdvd.NCMDParamBuff[2] << 8);
+			const u32 arg2 = cdvd.NCMDParamBuff[3] | (cdvd.NCMDParamBuff[4] << 8) | (cdvd.NCMDParamBuff[5] << 16) | (cdvd.NCMDParamBuff[6] << 24);
 			DevCon.WriteLn("cdvdReadKey(%d, %d, %d)", arg0, arg1, arg2);
-			cdvdReadKey(arg0, arg1, arg2, cdvd.Key);
+			cdvdReadKey(arg0, arg1, arg2, &cdvd.Key[0]);
 			cdvd.KeyXor = 0x00;
 			cdvdSetIrq();
 			//After reading the key it needs to go back to buffer the next sector
@@ -2238,7 +2240,7 @@ static void cdvdWrite04(u8 rt)
 		break;
 
 		case N_CD_CHG_SPDL_CTRL: // CdChgSpdlCtrl
-			Console.WriteLn("sceCdChgSpdlCtrl(%d)", cdvd.NCMDParam[0]);
+			Console.WriteLn("sceCdChgSpdlCtrl(%d)", cdvd.NCMDParamBuff[0]);
 			cdvdSetIrq();
 			break;
 
@@ -2247,23 +2249,23 @@ static void cdvdWrite04(u8 rt)
 			cdvdSetIrq();
 			break;
 	}
-	cdvd.NCMDParamP = 0;
-	cdvd.NCMDParamC = 0;
+	cdvd.NCMDParamPos = 0;
+	cdvd.NCMDParamCnt = 0;
 }
 
 static __fi void cdvdWrite05(u8 rt)
 { // NDATAIN
 	CDVD_LOG("cdvdWrite05(NDataIn) %x", rt);
 
-	if (cdvd.NCMDParamP >= 16)
+	if (cdvd.NCMDParamPos >= 16)
 	{
 		DevCon.Warning("CDVD: NCMD Overflow");
-		cdvd.NCMDParamP = 0;
-		cdvd.NCMDParamC = 0;
+		cdvd.NCMDParamPos = 0;
+		cdvd.NCMDParamCnt = 0;
 	}
 
-	cdvd.NCMDParam[cdvd.NCMDParamP++] = rt;
-	cdvd.NCMDParamC++;
+	cdvd.NCMDParamBuff[cdvd.NCMDParamPos++] = rt;
+	cdvd.NCMDParamCnt++;
 }
 
 static __fi void cdvdWrite06(u8 rt)
@@ -2315,7 +2317,7 @@ static __fi void cdvdWrite14(u8 rt)
 static __fi void fail_pol_cal()
 {
 	Console.Error("[MG] ERROR - Make sure the file is already decrypted!!!");
-	cdvd.SCMDResult[0] = 0x80;
+	cdvd.SCMDResultBuff[0] = 0x80;
 }
 
 static void cdvdWrite16(u8 rt) // SCOMMAND
@@ -2327,10 +2329,10 @@ static void cdvdWrite16(u8 rt) // SCOMMAND
 		int address;
 		u8 tmp;
 
-		CDVD_LOG("cdvdWrite16: SCMD %s (%x) (ParamP = %x)", sCmdName[rt], rt, cdvd.SCMDParamP);
+		CDVD_LOG("cdvdWrite16: SCMD %s (%x) (ParamP = %x)", sCmdName[rt], rt, cdvd.SCMDParamPos);
 
 		cdvd.sCommand = rt;
-		std::memset(cdvd.SCMDResult, 0, sizeof(cdvd.SCMDResult));
+		std::memset(&cdvd.SCMDResultBuff[0], 0, sizeof(cdvd.SCMDResultBuff));
 
 		switch (rt)
 		{
@@ -2341,54 +2343,54 @@ static void cdvdWrite16(u8 rt) // SCOMMAND
 
 			case 0x02: // CdReadSubQ  (0:11)
 				SetSCMDResultSize(11);
-				cdvd.SCMDResult[0] = cdvdReadSubQ(cdvd.Sector, (cdvdSubQ*)&cdvd.SCMDResult[1]);
+				cdvd.SCMDResultBuff[0] = cdvdReadSubQ(cdvd.CurrentSector, (cdvdSubQ*)&cdvd.SCMDResultBuff[1]);
 				break;
 
 			case 0x03: // Mecacon-command
-				switch (cdvd.SCMDParam[0])
+				switch (cdvd.SCMDParamBuff[0])
 				{
 					case 0x00: // get mecha version (1:4)
 						SetSCMDResultSize(4);
-						cdvdGetMechaVer(&cdvd.SCMDResult[0]);
+						cdvdGetMechaVer(&cdvd.SCMDResultBuff[0]);
 						break;
 					case 0x30:
 						SetSCMDResultSize(2);
-						cdvd.SCMDResult[0] = cdvd.Status;
-						cdvd.SCMDResult[1] = (cdvd.Status & 0x1) ? 8 : 0;
+						cdvd.SCMDResultBuff[0] = cdvd.Status;
+						cdvd.SCMDResultBuff[1] = (cdvd.Status & 0x1) ? 8 : 0;
 						//Console.Warning("Tray check param[1]=%02X", cdvd.Param[1]);
 						break;
 					case 0x44: // write console ID (9:1)
 						SetSCMDResultSize(1);
-						cdvdWriteConsoleID(&cdvd.SCMDParam[1]);
+						cdvdWriteConsoleID(&cdvd.SCMDParamBuff[1]);
 						break;
 
 					case 0x45: // read console ID (1:9)
 						SetSCMDResultSize(9);
-						cdvdReadConsoleID(&cdvd.SCMDResult[1]);
+						cdvdReadConsoleID(&cdvd.SCMDResultBuff[1]);
 						break;
 
 					case 0xFD: // _sceCdReadRenewalDate (1:6) BCD
 						SetSCMDResultSize(6);
-						cdvd.SCMDResult[0] = 0;
-						cdvd.SCMDResult[1] = 0x04; //year
-						cdvd.SCMDResult[2] = 0x12; //month
-						cdvd.SCMDResult[3] = 0x10; //day
-						cdvd.SCMDResult[4] = 0x01; //hour
-						cdvd.SCMDResult[5] = 0x30; //min
+						cdvd.SCMDResultBuff[0] = 0;
+						cdvd.SCMDResultBuff[1] = 0x04; //year
+						cdvd.SCMDResultBuff[2] = 0x12; //month
+						cdvd.SCMDResultBuff[3] = 0x10; //day
+						cdvd.SCMDResultBuff[4] = 0x01; //hour
+						cdvd.SCMDResultBuff[5] = 0x30; //min
 						break;
 
 					case 0xEF: // read console temperature (1:3)
 						// This returns a fixed value of 30.5 C
 						SetSCMDResultSize(3);
-						cdvd.SCMDResult[0] = 0; // returns 0 on success
-						cdvd.SCMDResult[1] = 0x0F; // last 8 bits for integer
-						cdvd.SCMDResult[2] = 0x05; // leftmost bit for integer, other 7 bits for decimal place
+						cdvd.SCMDResultBuff[0] = 0; // returns 0 on success
+						cdvd.SCMDResultBuff[1] = 0x0F; // last 8 bits for integer
+						cdvd.SCMDResultBuff[2] = 0x05; // leftmost bit for integer, other 7 bits for decimal place
 						break;
 
 					default:
 						SetSCMDResultSize(1);
-						cdvd.SCMDResult[0] = 0x81;
-						Console.Warning("*Unknown Mecacon Command param Test2 subparams - param[0]=%02X", cdvd.SCMDParam[0]);
+						cdvd.SCMDResultBuff[0] = 0x81;
+						Console.Warning("*Unknown Mecacon Command param Test2 subparams - param[0]=%02X", cdvd.SCMDParamBuff[0]);
 						break;
 				}
 				break;
@@ -2399,28 +2401,28 @@ static void cdvdWrite16(u8 rt) // SCOMMAND
 				cdvd.StatusSticky = cdvd.Status & CDVD_STATUS_TRAY_OPEN;
 
 				SetSCMDResultSize(1);
-				cdvd.SCMDResult[0] = 0; // Could be a bit to say it's busy, but actual function is unknown, it expects 0 to continue.
+				cdvd.SCMDResultBuff[0] = 0; // Could be a bit to say it's busy, but actual function is unknown, it expects 0 to continue.
 				break;
 
 			case 0x06: // CdTrayCtrl  (1:1)
 				SetSCMDResultSize(1);
 				//Console.Warning( "CdTrayCtrl, param = %d", cdvd.SCMDParam[0]);
-				if (cdvd.SCMDParam[0] == 0)
-					cdvd.SCMDResult[0] = cdvdCtrlTrayOpen();
+				if (cdvd.SCMDParamBuff[0] == 0)
+					cdvd.SCMDResultBuff[0] = cdvdCtrlTrayOpen();
 				else
-					cdvd.SCMDResult[0] = cdvdCtrlTrayClose();
+					cdvd.SCMDResultBuff[0] = cdvdCtrlTrayClose();
 				break;
 
 			case 0x08: // CdReadRTC (0:8)
 				SetSCMDResultSize(8);
-				cdvd.SCMDResult[0] = 0;
-				cdvd.SCMDResult[1] = itob(cdvd.RTC.second); //Seconds
-				cdvd.SCMDResult[2] = itob(cdvd.RTC.minute); //Minutes
-				cdvd.SCMDResult[3] = itob(cdvd.RTC.hour);   //Hours
-				cdvd.SCMDResult[4] = 0;                     //Nothing
-				cdvd.SCMDResult[5] = itob(cdvd.RTC.day);    //Day
-				cdvd.SCMDResult[6] = itob(cdvd.RTC.month);  //Month
-				cdvd.SCMDResult[7] = itob(cdvd.RTC.year);   //Year
+				cdvd.SCMDResultBuff[0] = 0;
+				cdvd.SCMDResultBuff[1] = itob(cdvd.RTC.second); //Seconds
+				cdvd.SCMDResultBuff[2] = itob(cdvd.RTC.minute); //Minutes
+				cdvd.SCMDResultBuff[3] = itob(cdvd.RTC.hour);   //Hours
+				cdvd.SCMDResultBuff[4] = 0;                     //Nothing
+				cdvd.SCMDResultBuff[5] = itob(cdvd.RTC.day);    //Day
+				cdvd.SCMDResultBuff[6] = itob(cdvd.RTC.month);  //Month
+				cdvd.SCMDResultBuff[7] = itob(cdvd.RTC.year);   //Year
 				/*Console.WriteLn("RTC Read Sec %x Min %x Hr %x Day %x Month %x Year %x", cdvd.Result[1], cdvd.Result[2],
 				  cdvd.Result[3], cdvd.Result[5], cdvd.Result[6], cdvd.Result[7]);
 				  Console.WriteLn("RTC Read Real Sec %d Min %d Hr %d Day %d Month %d Year %d", cdvd.RTC.second, cdvd.RTC.minute,
@@ -2429,15 +2431,15 @@ static void cdvdWrite16(u8 rt) // SCOMMAND
 
 			case 0x09: // sceCdWriteRTC (7:1)
 				SetSCMDResultSize(1);
-				cdvd.SCMDResult[0] = 0;
+				cdvd.SCMDResultBuff[0] = 0;
 				cdvd.RTC.pad = 0;
 
-				cdvd.RTC.second = btoi(cdvd.SCMDParam[cdvd.SCMDParamP - 7]);
-				cdvd.RTC.minute = btoi(cdvd.SCMDParam[cdvd.SCMDParamP - 6]) % 60;
-				cdvd.RTC.hour = btoi(cdvd.SCMDParam[cdvd.SCMDParamP - 5]) % 24;
-				cdvd.RTC.day = btoi(cdvd.SCMDParam[cdvd.SCMDParamP - 3]);
-				cdvd.RTC.month = btoi(cdvd.SCMDParam[cdvd.SCMDParamP - 2] & 0x7f);
-				cdvd.RTC.year = btoi(cdvd.SCMDParam[cdvd.SCMDParamP - 1]);
+				cdvd.RTC.second = btoi(cdvd.SCMDParamBuff[cdvd.SCMDParamPos - 7]);
+				cdvd.RTC.minute = btoi(cdvd.SCMDParamBuff[cdvd.SCMDParamPos - 6]) % 60;
+				cdvd.RTC.hour = btoi(cdvd.SCMDParamBuff[cdvd.SCMDParamPos - 5]) % 24;
+				cdvd.RTC.day = btoi(cdvd.SCMDParamBuff[cdvd.SCMDParamPos - 3]);
+				cdvd.RTC.month = btoi(cdvd.SCMDParamBuff[cdvd.SCMDParamPos - 2] & 0x7f);
+				cdvd.RTC.year = btoi(cdvd.SCMDParamBuff[cdvd.SCMDParamPos - 1]);
 				/*Console.WriteLn("RTC write incomming Sec %x Min %x Hr %x Day %x Month %x Year %x", cdvd.Param[cdvd.ParamP-7], cdvd.Param[cdvd.ParamP-6],
 				  cdvd.Param[cdvd.ParamP-5], cdvd.Param[cdvd.ParamP-3], cdvd.Param[cdvd.ParamP-2], cdvd.Param[cdvd.ParamP-1]);
 				  Console.WriteLn("RTC Write Sec %d Min %d Hr %d Day %d Month %d Year %d", cdvd.RTC.second, cdvd.RTC.minute,
@@ -2446,39 +2448,39 @@ static void cdvdWrite16(u8 rt) // SCOMMAND
 				break;
 
 			case 0x0A: // sceCdReadNVM (2:3)
-				address = (cdvd.SCMDParam[0] << 8) | cdvd.SCMDParam[1];
+				address = (cdvd.SCMDParamBuff[0] << 8) | cdvd.SCMDParamBuff[1];
 
 				if (address < 512)
 				{
 					SetSCMDResultSize(3);
-					cdvdReadNVM(&cdvd.SCMDResult[1], address * 2, 2);
+					cdvdReadNVM(&cdvd.SCMDResultBuff[1], address * 2, 2);
 					// swap bytes around
-					tmp = cdvd.SCMDResult[1];
-					cdvd.SCMDResult[1] = cdvd.SCMDResult[2];
-					cdvd.SCMDResult[2] = tmp;
+					tmp = cdvd.SCMDResultBuff[1];
+					cdvd.SCMDResultBuff[1] = cdvd.SCMDResultBuff[2];
+					cdvd.SCMDResultBuff[2] = tmp;
 				}
 				else
 				{
 					SetSCMDResultSize(1);
-					cdvd.SCMDResult[0] = 0xff;
+					cdvd.SCMDResultBuff[0] = 0xff;
 				}
 				break;
 
 			case 0x0B: // sceCdWriteNVM (4:1)
 				SetSCMDResultSize(1);
-				address = (cdvd.SCMDParam[0] << 8) | cdvd.SCMDParam[1];
+				address = (cdvd.SCMDParamBuff[0] << 8) | cdvd.SCMDParamBuff[1];
 
 				if (address < 512)
 				{
 					// swap bytes around
-					tmp = cdvd.SCMDParam[2];
-					cdvd.SCMDParam[2] = cdvd.SCMDParam[3];
-					cdvd.SCMDParam[3] = tmp;
-					cdvdWriteNVM(&cdvd.SCMDParam[2], address * 2, 2);
+					tmp = cdvd.SCMDParamBuff[2];
+					cdvd.SCMDParamBuff[2] = cdvd.SCMDParamBuff[3];
+					cdvd.SCMDParamBuff[3] = tmp;
+					cdvdWriteNVM(&cdvd.SCMDParamBuff[2], address * 2, 2);
 				}
 				else
 				{
-					cdvd.SCMDResult[0] = 0xff;
+					cdvd.SCMDResultBuff[0] = 0xff;
 				}
 				break;
 
@@ -2493,51 +2495,51 @@ static void cdvdWrite16(u8 rt) // SCOMMAND
 
 			case 0x12: // sceCdReadILinkId (0:9)
 				SetSCMDResultSize(9);
-				cdvdReadILinkID(&cdvd.SCMDResult[1]);
-				if ((!cdvd.SCMDResult[3]) && (!cdvd.SCMDResult[4])) // nvm file is missing correct iLinkId, return hardcoded one
+				cdvdReadILinkID(&cdvd.SCMDResultBuff[1]);
+				if ((!cdvd.SCMDResultBuff[3]) && (!cdvd.SCMDResultBuff[4])) // nvm file is missing correct iLinkId, return hardcoded one
 				{
-					cdvd.SCMDResult[0] = 0x00;
-					cdvd.SCMDResult[1] = 0x00;
-					cdvd.SCMDResult[2] = 0xAC;
-					cdvd.SCMDResult[3] = 0xFF;
-					cdvd.SCMDResult[4] = 0xFF;
-					cdvd.SCMDResult[5] = 0xFF;
-					cdvd.SCMDResult[6] = 0xFF;
-					cdvd.SCMDResult[7] = 0xB9;
-					cdvd.SCMDResult[8] = 0x86;
+					cdvd.SCMDResultBuff[0] = 0x00;
+					cdvd.SCMDResultBuff[1] = 0x00;
+					cdvd.SCMDResultBuff[2] = 0xAC;
+					cdvd.SCMDResultBuff[3] = 0xFF;
+					cdvd.SCMDResultBuff[4] = 0xFF;
+					cdvd.SCMDResultBuff[5] = 0xFF;
+					cdvd.SCMDResultBuff[6] = 0xFF;
+					cdvd.SCMDResultBuff[7] = 0xB9;
+					cdvd.SCMDResultBuff[8] = 0x86;
 				}
 				break;
 
 			case 0x13: // sceCdWriteILinkID (8:1)
 				SetSCMDResultSize(1);
-				cdvdWriteILinkID(&cdvd.SCMDParam[1]);
+				cdvdWriteILinkID(&cdvd.SCMDParamBuff[1]);
 				break;
 
 			case 0x14: // CdCtrlAudioDigitalOut (1:1)
 				//parameter can be 2, 0, ...
 				SetSCMDResultSize(1);
-				cdvd.SCMDResult[0] = 0; //8 is a flag; not used
+				cdvd.SCMDResultBuff[0] = 0; //8 is a flag; not used
 				break;
 
 			case 0x15: // sceCdForbidDVDP (0:1)
 				//Console.WriteLn("sceCdForbidDVDP");
 				SetSCMDResultSize(1);
-				cdvd.SCMDResult[0] = 5;
+				cdvd.SCMDResultBuff[0] = 5;
 				break;
 
 			case 0x16: // AutoAdjustCtrl - from cdvdman (1:1)
 				SetSCMDResultSize(1);
-				cdvd.SCMDResult[0] = 0;
+				cdvd.SCMDResultBuff[0] = 0;
 				break;
 
 			case 0x17: // CdReadModelNumber (1:9) - from xcdvdman
 				SetSCMDResultSize(9);
-				cdvdReadModelNumber(&cdvd.SCMDResult[1], cdvd.SCMDParam[0]);
+				cdvdReadModelNumber(&cdvd.SCMDResultBuff[1], cdvd.SCMDParamBuff[0]);
 				break;
 
 			case 0x18: // CdWriteModelNumber (9:1) - from xcdvdman
 				SetSCMDResultSize(1);
-				cdvdWriteModelNumber(&cdvd.SCMDParam[1], cdvd.SCMDParam[0]);
+				cdvdWriteModelNumber(&cdvd.SCMDParamBuff[1], cdvd.SCMDParamBuff[0]);
 				break;
 
 				//		case 0x19: // sceCdForbidRead (0:1) - from xcdvdman
@@ -2545,17 +2547,17 @@ static void cdvdWrite16(u8 rt) // SCOMMAND
 
 			case 0x1A: // sceCdBootCertify (4:1)//(4:16 in psx?)
 				SetSCMDResultSize(1); //on input there are 4 bytes: 1;?10;J;C for 18000; 1;60;E;C for 39002 from ROMVER
-				cdvd.SCMDResult[0] = 1; //i guess that means okay
+				cdvd.SCMDResultBuff[0] = 1; //i guess that means okay
 				break;
 
 			case 0x1B: // sceCdCancelPOffRdy (0:1) - Call73 from Xcdvdman (1:1)
 				SetSCMDResultSize(1);
-				cdvd.SCMDResult[0] = 0;
+				cdvd.SCMDResultBuff[0] = 0;
 				break;
 
 			case 0x1C: // sceCdBlueLEDCtl (1:1) - Call72 from Xcdvdman
 				SetSCMDResultSize(1);
-				cdvd.SCMDResult[0] = 0;
+				cdvd.SCMDResultBuff[0] = 0;
 				break;
 
 				//		case 0x1D: // cdvdman_call116 (0:5) - In V10 Bios
@@ -2563,11 +2565,11 @@ static void cdvdWrite16(u8 rt) // SCOMMAND
 
 			case 0x1E: // sceRemote2Read (0:5) - // 00 14 AA BB CC -> remote key code
 				SetSCMDResultSize(5);
-				cdvd.SCMDResult[0] = 0x00;
-				cdvd.SCMDResult[1] = 0x14;
-				cdvd.SCMDResult[2] = 0x00;
-				cdvd.SCMDResult[3] = 0x00;
-				cdvd.SCMDResult[4] = 0x00;
+				cdvd.SCMDResultBuff[0] = 0x00;
+				cdvd.SCMDResultBuff[1] = 0x14;
+				cdvd.SCMDResultBuff[2] = 0x00;
+				cdvd.SCMDResultBuff[3] = 0x00;
+				cdvd.SCMDResultBuff[4] = 0x00;
 				break;
 
 				//		case 0x1F: // sceRemote2_7 (2:1) - cdvdman_call117
@@ -2575,9 +2577,9 @@ static void cdvdWrite16(u8 rt) // SCOMMAND
 
 			case 0x20: // sceRemote2_6 (0:3)	// 00 01 00
 				SetSCMDResultSize(3);
-				cdvd.SCMDResult[0] = 0x00;
-				cdvd.SCMDResult[1] = 0x01;
-				cdvd.SCMDResult[2] = 0x00;
+				cdvd.SCMDResultBuff[0] = 0x00;
+				cdvd.SCMDResultBuff[1] = 0x01;
+				cdvd.SCMDResultBuff[2] = 0x00;
 				break;
 
 				//		case 0x21: // sceCdWriteWakeUpTime (8:1)
@@ -2585,22 +2587,22 @@ static void cdvdWrite16(u8 rt) // SCOMMAND
 
 			case 0x22: // sceCdReadWakeUpTime (0:10)
 				SetSCMDResultSize(10);
-				cdvd.SCMDResult[0] = 0;
-				cdvd.SCMDResult[1] = 0;
-				cdvd.SCMDResult[2] = 0;
-				cdvd.SCMDResult[3] = 0;
-				cdvd.SCMDResult[4] = 0;
-				cdvd.SCMDResult[5] = 0;
-				cdvd.SCMDResult[6] = 0;
-				cdvd.SCMDResult[7] = 0;
-				cdvd.SCMDResult[8] = 0;
-				cdvd.SCMDResult[9] = 0;
+				cdvd.SCMDResultBuff[0] = 0;
+				cdvd.SCMDResultBuff[1] = 0;
+				cdvd.SCMDResultBuff[2] = 0;
+				cdvd.SCMDResultBuff[3] = 0;
+				cdvd.SCMDResultBuff[4] = 0;
+				cdvd.SCMDResultBuff[5] = 0;
+				cdvd.SCMDResultBuff[6] = 0;
+				cdvd.SCMDResultBuff[7] = 0;
+				cdvd.SCMDResultBuff[8] = 0;
+				cdvd.SCMDResultBuff[9] = 0;
 				break;
 
 			case 0x24: // sceCdRCBypassCtrl (1:1) - In V10 Bios
 				// FIXME: because PRId<0x23, the bit 0 of sio2 don't get updated 0xBF808284
 				SetSCMDResultSize(1);
-				cdvd.SCMDResult[0] = 0;
+				cdvd.SCMDResultBuff[0] = 0;
 				break;
 
 				//		case 0x25: // cdvdman_call120 (1:1) - In V10 Bios
@@ -2615,19 +2617,19 @@ static void cdvdWrite16(u8 rt) // SCOMMAND
 					SetSCMDResultSize(13);
 
 					const std::string DiscSerial = VMManager::GetDiscSerial();
-					cdvd.SCMDResult[0] = 0;
-					cdvd.SCMDResult[1] = DiscSerial[0];
-					cdvd.SCMDResult[2] = DiscSerial[1];
-					cdvd.SCMDResult[3] = DiscSerial[2];
-					cdvd.SCMDResult[4] = DiscSerial[3];
-					cdvd.SCMDResult[5] = DiscSerial[4];
-					cdvd.SCMDResult[6] = DiscSerial[5];
-					cdvd.SCMDResult[7] = DiscSerial[6];
-					cdvd.SCMDResult[8] = DiscSerial[7];
-					cdvd.SCMDResult[9] = DiscSerial[9]; // Skipping dot here is required.
-					cdvd.SCMDResult[10] = DiscSerial[10];
-					cdvd.SCMDResult[11] = DiscSerial[11];
-					cdvd.SCMDResult[12] = DiscSerial[12];
+					cdvd.SCMDResultBuff[0] = 0;
+					cdvd.SCMDResultBuff[1] = DiscSerial[0];
+					cdvd.SCMDResultBuff[2] = DiscSerial[1];
+					cdvd.SCMDResultBuff[3] = DiscSerial[2];
+					cdvd.SCMDResultBuff[4] = DiscSerial[3];
+					cdvd.SCMDResultBuff[5] = DiscSerial[4];
+					cdvd.SCMDResultBuff[6] = DiscSerial[5];
+					cdvd.SCMDResultBuff[7] = DiscSerial[6];
+					cdvd.SCMDResultBuff[8] = DiscSerial[7];
+					cdvd.SCMDResultBuff[9] = DiscSerial[9]; // Skipping dot here is required.
+					cdvd.SCMDResultBuff[10] = DiscSerial[10];
+					cdvd.SCMDResultBuff[11] = DiscSerial[11];
+					cdvd.SCMDResultBuff[12] = DiscSerial[12];
 				}
 				break;
 
@@ -2636,7 +2638,7 @@ static void cdvdWrite16(u8 rt) // SCOMMAND
 
 			case 0x29: //sceCdNoticeGameStart (1:1)
 				SetSCMDResultSize(1);
-				cdvd.SCMDResult[0] = 0;
+				cdvd.SCMDResultBuff[0] = 0;
 				break;
 
 				//		case 0x2C: //sceCdXBSPowerCtl (2:2)
@@ -2656,12 +2658,12 @@ static void cdvdWrite16(u8 rt) // SCOMMAND
 
 			case 0x31: //sceCdSetMediumRemoval (1:1)
 				SetSCMDResultSize(1);
-				cdvd.SCMDResult[0] = 0;
+				cdvd.SCMDResultBuff[0] = 0;
 				break;
 
 			case 0x32: //sceCdGetMediumRemoval (0:2)
 				SetSCMDResultSize(2);
-				cdvd.SCMDResult[0] = 0;
+				cdvd.SCMDResultBuff[0] = 0;
 				//cdvd.Result[0] = 0; // fixme: I'm pretty sure that the same variable shouldn't be set twice here. Perhaps cdvd.Result[1]?
 				break;
 
@@ -2671,12 +2673,12 @@ static void cdvdWrite16(u8 rt) // SCOMMAND
 			case 0x36: //cdvdman_call189 [__sceCdReadRegionParams - made up name] (0:15) i think it is 16, not 15
 				SetSCMDResultSize(15);
 
-				cdvdGetMechaVer(&cdvd.SCMDResult[1]);
-				cdvdReadRegionParams(&cdvd.SCMDResult[3]); //size==8
-				DevCon.WriteLn("REGION PARAMS = %s %s", mg_zones[cdvd.SCMDResult[1] & 7], &cdvd.SCMDResult[3]);
-				cdvd.SCMDResult[1] = 1 << cdvd.SCMDResult[1]; //encryption zone; see offset 0x1C in encrypted headers
+				cdvdGetMechaVer(&cdvd.SCMDResultBuff[1]);
+				cdvdReadRegionParams(&cdvd.SCMDResultBuff[3]); //size==8
+				DevCon.WriteLn("REGION PARAMS = %s %s", mg_zones[cdvd.SCMDResultBuff[1] & 7], &cdvd.SCMDResultBuff[3]);
+				cdvd.SCMDResultBuff[1] = 1 << cdvd.SCMDResultBuff[1]; //encryption zone; see offset 0x1C in encrypted headers
 				//////////////////////////////////////////
-				cdvd.SCMDResult[2] = 0; //??
+				cdvd.SCMDResultBuff[2] = 0; //??
 				//			cdvd.Result[3] == ROMVER[4] == *0xBFC7FF04
 				//			cdvd.Result[4] == OSDVER[4] == CAP			Jjpn, Aeng, Eeng, Heng, Reng, Csch, Kkor?
 				//			cdvd.Result[5] == OSDVER[5] == small
@@ -2685,45 +2687,45 @@ static void cdvdWrite16(u8 rt) // SCOMMAND
 				//			cdvd.Result[8] == VERSTR[0x22] == *0xBFC7FF52
 				//			cdvd.Result[9] == DVDID						J U O E A R C M
 				//			cdvd.Result[10]== 0;					//??
-				cdvd.SCMDResult[11] = 0; //??
-				cdvd.SCMDResult[12] = 0; //??
+				cdvd.SCMDResultBuff[11] = 0; //??
+				cdvd.SCMDResultBuff[12] = 0; //??
 				//////////////////////////////////////////
-				cdvd.SCMDResult[13] = 0; //0xFF - 77001
-				cdvd.SCMDResult[14] = 0; //??
+				cdvd.SCMDResultBuff[13] = 0; //0xFF - 77001
+				cdvd.SCMDResultBuff[14] = 0; //??
 				break;
 
 			case 0x37: //called from EECONF [sceCdReadMAC - made up name] (0:9)
 				SetSCMDResultSize(9);
-				cdvdReadMAC(&cdvd.SCMDResult[1]);
+				cdvdReadMAC(&cdvd.SCMDResultBuff[1]);
 				break;
 
 			case 0x38: //used to fix the MAC back after accidentally trashed it :D [sceCdWriteMAC - made up name] (8:1)
 				SetSCMDResultSize(1);
-				cdvdWriteMAC(&cdvd.SCMDParam[0]);
+				cdvdWriteMAC(&cdvd.SCMDParamBuff[0]);
 				break;
 
 			case 0x3E: //[__sceCdWriteRegionParams - made up name] (15:1) [Florin: hum, i was expecting 14:1]
 				SetSCMDResultSize(1);
-				cdvdWriteRegionParams(&cdvd.SCMDParam[2]);
+				cdvdWriteRegionParams(&cdvd.SCMDParamBuff[2]);
 				break;
 
 			case 0x40: // CdOpenConfig (3:1)
 				SetSCMDResultSize(1);
-				cdvd.CReadWrite = cdvd.SCMDParam[0];
-				cdvd.COffset = cdvd.SCMDParam[1];
-				cdvd.CNumBlocks = cdvd.SCMDParam[2];
+				cdvd.CReadWrite = cdvd.SCMDParamBuff[0];
+				cdvd.COffset = cdvd.SCMDParamBuff[1];
+				cdvd.CNumBlocks = cdvd.SCMDParamBuff[2];
 				cdvd.CBlockIndex = 0;
-				cdvd.SCMDResult[0] = 0;
+				cdvd.SCMDResultBuff[0] = 0;
 				break;
 
 			case 0x41: // CdReadConfig (0:16)
 				SetSCMDResultSize(16);
-				cdvdReadConfig(&cdvd.SCMDResult[0]);
+				cdvdReadConfig(&cdvd.SCMDResultBuff[0]);
 				break;
 
 			case 0x42: // CdWriteConfig (16:1)
 				SetSCMDResultSize(1);
-				cdvdWriteConfig(&cdvd.SCMDParam[0]);
+				cdvdWriteConfig(&cdvd.SCMDParamBuff[0]);
 				break;
 
 			case 0x43: // CdCloseConfig (0:1)
@@ -2732,98 +2734,98 @@ static void cdvdWrite16(u8 rt) // SCOMMAND
 				cdvd.COffset = 0;
 				cdvd.CNumBlocks = 0;
 				cdvd.CBlockIndex = 0;
-				cdvd.SCMDResult[0] = 0;
+				cdvd.SCMDResultBuff[0] = 0;
 				break;
 
 			case 0x80: // secrman: __mechacon_auth_0x80
 				SetSCMDResultSize(1); //in:1
 				cdvd.mg_datatype = 0; //data
-				cdvd.SCMDResult[0] = 0;
+				cdvd.SCMDResultBuff[0] = 0;
 				break;
 
 			case 0x81: // secrman: __mechacon_auth_0x81
 				SetSCMDResultSize(1); //in:1
 				cdvd.mg_datatype = 0; //data
-				cdvd.SCMDResult[0] = 0;
+				cdvd.SCMDResultBuff[0] = 0;
 				break;
 
 			case 0x82: // secrman: __mechacon_auth_0x82
 				SetSCMDResultSize(1); //in:16
-				cdvd.SCMDResult[0] = 0;
+				cdvd.SCMDResultBuff[0] = 0;
 				break;
 
 			case 0x83: // secrman: __mechacon_auth_0x83
 				SetSCMDResultSize(1); //in:8
-				cdvd.SCMDResult[0] = 0;
+				cdvd.SCMDResultBuff[0] = 0;
 				break;
 
 			case 0x84: // secrman: __mechacon_auth_0x84
 				SetSCMDResultSize(1 + 8 + 4); //in:0
-				cdvd.SCMDResult[0] = 0;
+				cdvd.SCMDResultBuff[0] = 0;
 
-				cdvd.SCMDResult[1] = 0x21;
-				cdvd.SCMDResult[2] = 0xdc;
-				cdvd.SCMDResult[3] = 0x31;
-				cdvd.SCMDResult[4] = 0x96;
-				cdvd.SCMDResult[5] = 0xce;
-				cdvd.SCMDResult[6] = 0x72;
-				cdvd.SCMDResult[7] = 0xe0;
-				cdvd.SCMDResult[8] = 0xc8;
+				cdvd.SCMDResultBuff[1] = 0x21;
+				cdvd.SCMDResultBuff[2] = 0xdc;
+				cdvd.SCMDResultBuff[3] = 0x31;
+				cdvd.SCMDResultBuff[4] = 0x96;
+				cdvd.SCMDResultBuff[5] = 0xce;
+				cdvd.SCMDResultBuff[6] = 0x72;
+				cdvd.SCMDResultBuff[7] = 0xe0;
+				cdvd.SCMDResultBuff[8] = 0xc8;
 
-				cdvd.SCMDResult[9] = 0x69;
-				cdvd.SCMDResult[10] = 0xda;
-				cdvd.SCMDResult[11] = 0x34;
-				cdvd.SCMDResult[12] = 0x9b;
+				cdvd.SCMDResultBuff[9] = 0x69;
+				cdvd.SCMDResultBuff[10] = 0xda;
+				cdvd.SCMDResultBuff[11] = 0x34;
+				cdvd.SCMDResultBuff[12] = 0x9b;
 				break;
 
 			case 0x85: // secrman: __mechacon_auth_0x85
 				SetSCMDResultSize(1 + 4 + 8); //in:0
-				cdvd.SCMDResult[0] = 0;
+				cdvd.SCMDResultBuff[0] = 0;
 
-				cdvd.SCMDResult[1] = 0xeb;
-				cdvd.SCMDResult[2] = 0x01;
-				cdvd.SCMDResult[3] = 0xc7;
-				cdvd.SCMDResult[4] = 0xa9;
+				cdvd.SCMDResultBuff[1] = 0xeb;
+				cdvd.SCMDResultBuff[2] = 0x01;
+				cdvd.SCMDResultBuff[3] = 0xc7;
+				cdvd.SCMDResultBuff[4] = 0xa9;
 
-				cdvd.SCMDResult[5] = 0x3f;
-				cdvd.SCMDResult[6] = 0x9c;
-				cdvd.SCMDResult[7] = 0x5b;
-				cdvd.SCMDResult[8] = 0x19;
-				cdvd.SCMDResult[9] = 0x31;
-				cdvd.SCMDResult[10] = 0xa0;
-				cdvd.SCMDResult[11] = 0xb3;
-				cdvd.SCMDResult[12] = 0xa3;
+				cdvd.SCMDResultBuff[5] = 0x3f;
+				cdvd.SCMDResultBuff[6] = 0x9c;
+				cdvd.SCMDResultBuff[7] = 0x5b;
+				cdvd.SCMDResultBuff[8] = 0x19;
+				cdvd.SCMDResultBuff[9] = 0x31;
+				cdvd.SCMDResultBuff[10] = 0xa0;
+				cdvd.SCMDResultBuff[11] = 0xb3;
+				cdvd.SCMDResultBuff[12] = 0xa3;
 				break;
 
 			case 0x86: // secrman: __mechacon_auth_0x86
 				SetSCMDResultSize(1); //in:16
-				cdvd.SCMDResult[0] = 0;
+				cdvd.SCMDResultBuff[0] = 0;
 				break;
 
 			case 0x87: // secrman: __mechacon_auth_0x87
 				SetSCMDResultSize(1); //in:8
-				cdvd.SCMDResult[0] = 0;
+				cdvd.SCMDResultBuff[0] = 0;
 				break;
 
 			case 0x8D: // sceMgWriteData
 				SetSCMDResultSize(1); //in:length<=16
-				if (cdvd.mg_size + cdvd.SCMDParamC > cdvd.mg_maxsize)
+				if (cdvd.mg_size + cdvd.SCMDParamCnt > cdvd.mg_maxsize)
 				{
-					cdvd.SCMDResult[0] = 0x80;
+					cdvd.SCMDResultBuff[0] = 0x80;
 				}
 				else
 				{
-					memcpy(cdvd.mg_buffer + cdvd.mg_size, cdvd.SCMDParam, cdvd.SCMDParamC);
-					cdvd.mg_size += cdvd.SCMDParamC;
-					cdvd.SCMDResult[0] = 0; // 0 complete ; 1 busy ; 0x80 error
+					memcpy(&cdvd.mg_buffer[cdvd.mg_size], cdvd.SCMDParamBuff, cdvd.SCMDParamCnt);
+					cdvd.mg_size += cdvd.SCMDParamCnt;
+					cdvd.SCMDResultBuff[0] = 0; // 0 complete ; 1 busy ; 0x80 error
 				}
 				break;
 
 			case 0x8E: // sceMgReadData
 				SetSCMDResultSize(std::min(16, cdvd.mg_size));
-				memcpy(cdvd.SCMDResult, cdvd.mg_buffer, cdvd.SCMDResultC);
-				cdvd.mg_size -= cdvd.SCMDResultC;
-				memcpy(cdvd.mg_buffer, cdvd.mg_buffer + cdvd.SCMDResultC, cdvd.mg_size);
+				memcpy(&cdvd.SCMDResultBuff[0], &cdvd.mg_buffer[0], cdvd.SCMDResultCnt);
+				cdvd.mg_size -= cdvd.SCMDResultCnt;
+				memcpy(&cdvd.mg_buffer[0], &cdvd.mg_buffer[cdvd.SCMDResultCnt], cdvd.mg_size);
 				break;
 
 			case 0x88: // secrman: __mechacon_auth_0x88	//for now it is the same; so, fall;)
@@ -2831,17 +2833,16 @@ static void cdvdWrite16(u8 rt) // SCOMMAND
 				SetSCMDResultSize(1); //in:0
 				if (cdvd.mg_datatype == 1) // header data
 				{
-					u64 *psrc, *pdst;
-					int bit_ofs, i;
+					int bit_ofs = 0;
 
-					if ((cdvd.mg_maxsize != cdvd.mg_size) || (cdvd.mg_size < 0x20) || (cdvd.mg_size != *(u16*)&cdvd.mg_buffer[0x14]))
+					if ((cdvd.mg_maxsize != cdvd.mg_size) || (cdvd.mg_size < 0x20) || (cdvd.mg_size != GetBufferU16(&cdvd.mg_buffer[0], 0x14)))
 					{
 						fail_pol_cal();
 						break;
 					}
 
 					std::string zoneStr;
-					for (i = 0; i < 8; i++)
+					for (int i = 0; i < 8; i++)
 					{
 						if (cdvd.mg_buffer[0x1C] & (1 << i))
 							zoneStr += mg_zones[i];
@@ -2852,28 +2853,19 @@ static void cdvdWrite16(u8 rt) // SCOMMAND
 						*(u16*)&cdvd.mg_buffer[0x18], *(u16*)&cdvd.mg_buffer[0x1A],
 						zoneStr.c_str());
 
-					bit_ofs = mg_BIToffset(cdvd.mg_buffer);
+					bit_ofs = mg_BIToffset(&cdvd.mg_buffer[0]);
 
-					psrc = (u64*)&cdvd.mg_buffer[bit_ofs - 0x20];
-
-					pdst = (u64*)cdvd.mg_kbit;
-					pdst[0] = psrc[0];
-					pdst[1] = psrc[1];
-					//memcpy(cdvd.mg_kbit, &cdvd.mg_buffer[bit_ofs-0x20], 0x10);
-
-					pdst = (u64*)cdvd.mg_kcon;
-					pdst[0] = psrc[2];
-					pdst[1] = psrc[3];
-					//memcpy(cdvd.mg_kcon, &cdvd.mg_buffer[bit_ofs-0x10], 0x10);
+					memcpy(&cdvd.mg_kbit[0], &cdvd.mg_buffer[bit_ofs - 0x20], 0x10);
+					memcpy(&cdvd.mg_kcon[0], &cdvd.mg_buffer[bit_ofs - 0x10], 0x10);
 
 					if ((cdvd.mg_buffer[bit_ofs + 5] || cdvd.mg_buffer[bit_ofs + 6] || cdvd.mg_buffer[bit_ofs + 7]) ||
-						(cdvd.mg_buffer[bit_ofs + 4] * 16 + bit_ofs + 8 + 16 != *(u16*)&cdvd.mg_buffer[0x14]))
+						(GetBufferU16(&cdvd.mg_buffer[0],bit_ofs + 4) * 16 + bit_ofs + 8 + 16 != GetBufferU16(&cdvd.mg_buffer[0], 0x14)))
 					{
 						fail_pol_cal();
 						break;
 					}
 				}
-				cdvd.SCMDResult[0] = 0; // 0 complete ; 1 busy ; 0x80 error
+				cdvd.SCMDResultBuff[0] = 0; // 0 complete ; 1 busy ; 0x80 error
 				break;
 
 			case 0x90: // sceMgWriteHeaderStart
@@ -2881,90 +2873,81 @@ static void cdvdWrite16(u8 rt) // SCOMMAND
 				cdvd.mg_size = 0;
 				cdvd.mg_datatype = 1; //header data
 				Console.WriteLn("[MG] hcode=%d cnum=%d a2=%d length=0x%X",
-					cdvd.SCMDParam[0], cdvd.SCMDParam[3], cdvd.SCMDParam[4], cdvd.mg_maxsize = cdvd.SCMDParam[1] | (((int)cdvd.SCMDParam[2]) << 8));
+					cdvd.SCMDParamBuff[0], cdvd.SCMDParamBuff[3], cdvd.SCMDParamBuff[4], cdvd.mg_maxsize = cdvd.SCMDParamBuff[1] | (static_cast<int>(cdvd.SCMDParamBuff[2]) << 8));
 
-				cdvd.SCMDResult[0] = 0; // 0 complete ; 1 busy ; 0x80 error
+				cdvd.SCMDResultBuff[0] = 0; // 0 complete ; 1 busy ; 0x80 error
 				break;
 
 			case 0x91: // sceMgReadBITLength
 			{
 				SetSCMDResultSize(3); //in:0
-				int bit_ofs = mg_BIToffset(cdvd.mg_buffer);
-				memcpy(cdvd.mg_buffer, &cdvd.mg_buffer[bit_ofs], 8 + 16 * cdvd.mg_buffer[bit_ofs + 4]);
+				const int bit_ofs = mg_BIToffset(&cdvd.mg_buffer[0]);
+				memcpy(&cdvd.mg_buffer[0], &cdvd.mg_buffer[bit_ofs], static_cast<size_t>(8 + 16 * static_cast<int>(cdvd.mg_buffer[bit_ofs + 4])));
 
 				cdvd.mg_maxsize = 0; // don't allow any write
 				cdvd.mg_size = 8 + 16 * cdvd.mg_buffer[4]; //new offset, i just moved the data
 				Console.WriteLn("[MG] BIT count=%d", cdvd.mg_buffer[4]);
 
-				cdvd.SCMDResult[0] = (cdvd.mg_datatype == 1) ? 0 : 0x80; // 0 complete ; 1 busy ; 0x80 error
-				cdvd.SCMDResult[1] = (cdvd.mg_size >> 0) & 0xFF;
-				cdvd.SCMDResult[2] = (cdvd.mg_size >> 8) & 0xFF;
+				cdvd.SCMDResultBuff[0] = (cdvd.mg_datatype == 1) ? 0 : 0x80; // 0 complete ; 1 busy ; 0x80 error
+				cdvd.SCMDResultBuff[1] = (cdvd.mg_size >> 0) & 0xFF;
+				cdvd.SCMDResultBuff[2] = (cdvd.mg_size >> 8) & 0xFF;
 				break;
 			}
 			case 0x92: // sceMgWriteDatainLength
 				SetSCMDResultSize(1); //in:2
 				cdvd.mg_size = 0;
 				cdvd.mg_datatype = 0; //data (encrypted)
-				cdvd.mg_maxsize = cdvd.SCMDParam[0] | (((int)cdvd.SCMDParam[1]) << 8);
-				cdvd.SCMDResult[0] = 0; // 0 complete ; 1 busy ; 0x80 error
+				cdvd.mg_maxsize = cdvd.SCMDParamBuff[0] | (((int)cdvd.SCMDParamBuff[1]) << 8);
+				cdvd.SCMDResultBuff[0] = 0; // 0 complete ; 1 busy ; 0x80 error
 				break;
 
 			case 0x93: // sceMgWriteDataoutLength
 				SetSCMDResultSize(1); //in:2
-				if (((cdvd.SCMDParam[0] | (((int)cdvd.SCMDParam[1]) << 8)) == cdvd.mg_size) && (cdvd.mg_datatype == 0))
+				if (((cdvd.SCMDParamBuff[0] | (static_cast<int>(cdvd.SCMDParamBuff[1]) << 8)) == cdvd.mg_size) && (cdvd.mg_datatype == 0))
 				{
 					cdvd.mg_maxsize = 0; // don't allow any write
-					cdvd.SCMDResult[0] = 0; // 0 complete ; 1 busy ; 0x80 error
+					cdvd.SCMDResultBuff[0] = 0; // 0 complete ; 1 busy ; 0x80 error
 				}
 				else
 				{
-					cdvd.SCMDResult[0] = 0x80;
+					cdvd.SCMDResultBuff[0] = 0x80;
 				}
 				break;
 
 			case 0x94: // sceMgReadKbit - read first half of BIT key
 				SetSCMDResultSize(1 + 8); //in:0
-				cdvd.SCMDResult[0] = 0;
-
-				((int*)(cdvd.SCMDResult + 1))[0] = ((int*)cdvd.mg_kbit)[0];
-				((int*)(cdvd.SCMDResult + 1))[1] = ((int*)cdvd.mg_kbit)[1];
-				//memcpy(cdvd.Result+1, cdvd.mg_kbit, 8);
+				cdvd.SCMDResultBuff[0] = 0;
+				memcpy(&cdvd.SCMDResultBuff[1], cdvd.mg_kbit, 8);
 				break;
 
 			case 0x95: // sceMgReadKbit2 - read second half of BIT key
 				SetSCMDResultSize(1 + 8); //in:0
-				cdvd.SCMDResult[0] = 0;
-				((int*)(cdvd.SCMDResult + 1))[0] = ((int*)(cdvd.mg_kbit + 8))[0];
-				((int*)(cdvd.SCMDResult + 1))[1] = ((int*)(cdvd.mg_kbit + 8))[1];
-				//memcpy(cdvd.Result+1, cdvd.mg_kbit+8, 8);
+				cdvd.SCMDResultBuff[0] = 0;
+				memcpy(&cdvd.SCMDResultBuff[1], cdvd.mg_kbit+8, 8);
 				break;
 
 			case 0x96: // sceMgReadKcon - read first half of content key
 				SetSCMDResultSize(1 + 8); //in:0
-				cdvd.SCMDResult[0] = 0;
-				((int*)(cdvd.SCMDResult + 1))[0] = ((int*)cdvd.mg_kcon)[0];
-				((int*)(cdvd.SCMDResult + 1))[1] = ((int*)cdvd.mg_kcon)[1];
-				//memcpy(cdvd.Result+1, cdvd.mg_kcon, 8);
+				cdvd.SCMDResultBuff[0] = 0;
+				memcpy(&cdvd.SCMDResultBuff[1], cdvd.mg_kcon, 8);
 				break;
 
 			case 0x97: // sceMgReadKcon2 - read second half of content key
 				SetSCMDResultSize(1 + 8); //in:0
-				cdvd.SCMDResult[0] = 0;
-				((int*)(cdvd.SCMDResult + 1))[0] = ((int*)(cdvd.mg_kcon + 8))[0];
-				((int*)(cdvd.SCMDResult + 1))[1] = ((int*)(cdvd.mg_kcon + 8))[1];
-				//memcpy(cdvd.Result+1, cdvd.mg_kcon+8, 8);
+				cdvd.SCMDResultBuff[0] = 0;
+				memcpy(&cdvd.SCMDResultBuff[1], cdvd.mg_kcon + 8, 8);
 				break;
 
 			default:
 				SetSCMDResultSize(1); //in:0
-				cdvd.SCMDResult[0] = 0x80; // 0 complete ; 1 busy ; 0x80 error
+				cdvd.SCMDResultBuff[0] = 0x80; // 0 complete ; 1 busy ; 0x80 error
 				Console.WriteLn("SCMD Unknown %x", rt);
 				break;
 		} // end switch
 
 		//Console.WriteLn("SCMD - 0x%x\n", rt);
-		cdvd.SCMDParamP = 0;
-		cdvd.SCMDParamC = 0;
+		cdvd.SCMDParamPos = 0;
+		cdvd.SCMDParamCnt = 0;
 	}
 }
 
@@ -2972,15 +2955,15 @@ static __fi void cdvdWrite17(u8 rt)
 { // SDATAIN
 	CDVD_LOG("cdvdWrite17(SDataIn) %x", rt);
 
-	if (cdvd.SCMDParamP >= 16)
+	if (cdvd.SCMDParamPos >= 16)
 	{
 		DevCon.Warning("CDVD: SCMD Overflow");
-		cdvd.SCMDParamP = 0;
-		cdvd.SCMDParamC = 0;
+		cdvd.SCMDParamPos = 0;
+		cdvd.SCMDParamCnt = 0;
 	}
 
-	cdvd.SCMDParam[cdvd.SCMDParamP++] = rt;
-	cdvd.SCMDParamC++;
+	cdvd.SCMDParamBuff[cdvd.SCMDParamPos++] = rt;
+	cdvd.SCMDParamCnt++;
 }
 
 static __fi void cdvdWrite18(u8 rt)

--- a/pcsx2/CDVD/CDVD.h
+++ b/pcsx2/CDVD/CDVD.h
@@ -28,7 +28,7 @@ class IsoReader;
 #define btoi(b) ((b) / 16 * 10 + (b) % 16) /* BCD to u_char */
 #define itob(i) ((i) / 10 * 16 + (i) % 10) /* u_char to BCD */
 
-static __fi s32 msf_to_lsn(u8* Time)
+static __fi s32 msf_to_lsn(const u8* Time) noexcept
 {
 	u32 lsn;
 
@@ -38,7 +38,7 @@ static __fi s32 msf_to_lsn(u8* Time)
 	return lsn;
 }
 
-static __fi s32 msf_to_lba(u8 m, u8 s, u8 f)
+static __fi s32 msf_to_lba(const u8 m, const u8 s, const u8 f) noexcept
 {
 	u32 lsn;
 	lsn = f;
@@ -47,7 +47,7 @@ static __fi s32 msf_to_lba(u8 m, u8 s, u8 f)
 	return lsn;
 }
 
-static __fi void lsn_to_msf(u8* Time, s32 lsn)
+static __fi void lsn_to_msf(u8* Time, s32 lsn) noexcept
 {
 	u8 m, s, f;
 
@@ -61,7 +61,7 @@ static __fi void lsn_to_msf(u8* Time, s32 lsn)
 	Time[2] = itob(f);
 }
 
-static __fi void lba_to_msf(s32 lba, u8* m, u8* s, u8* f)
+static __fi void lba_to_msf(s32 lba, u8* m, u8* s, u8* f) noexcept
 {
 	lba += 150;
 	*m = lba / (60 * 75);
@@ -111,22 +111,22 @@ struct cdvdStruct
 	u8 IntrStat;
 	u8 Status;
 	u8 StatusSticky;
-	u8 Type;
+	u8 DiscType;
 	u8 sCommand;
 	u8 sDataIn;
 	u8 sDataOut;
 	u8 HowTo;
 
-	u8 NCMDParam[16];
-	u8 SCMDParam[16];
-	u8 SCMDResult[16];
+	u8 NCMDParamBuff[16];
+	u8 SCMDParamBuff[16];
+	u8 SCMDResultBuff[16];
 
-	u8 NCMDParamC;
-	u8 NCMDParamP;
-	u8 SCMDParamC;
-	u8 SCMDParamP;
-	u8 SCMDResultC;
-	u8 SCMDResultP;
+	u8 NCMDParamCnt;
+	u8 NCMDParamPos;
+	u8 SCMDParamCnt;
+	u8 SCMDParamPos;
+	u8 SCMDResultCnt;
+	u8 SCMDResultPos;
 
 	u8 CBlockIndex;
 	u8 COffset;
@@ -138,17 +138,17 @@ struct cdvdStruct
 	int RTCcount;
 	cdvdRTC RTC;
 
-	u32 Sector;
-	int nSectors;
-	int Readed;  // change to bool. --arcum42
+	u32 CurrentSector;
+	int SectorCnt;
+	int SeekCompleted;  // change to bool. --arcum42
 	int Reading; // same here.
 	int WaitingDMA;
 	int ReadMode;
 	int BlockSize; // Total bytes transfered at 1x speed
 	int Speed;
-	int RetryCnt;
-	int RetryCntP;
-	int RErr;
+	int RetryCntMax;
+	int CurrentRetryCnt;
+	int ReadErr;
 	int SpindlCtrl;
 
 	u8 Key[16];

--- a/pcsx2/CDVD/CDVD_internal.h
+++ b/pcsx2/CDVD/CDVD_internal.h
@@ -135,8 +135,8 @@ enum CDVD_MODE_TYPE
 	MODE_DVDROM,
 };
 
-static const uint tbl_FastSeekDelta[3] =
-	{
+static constexpr uint tbl_FastSeekDelta[3] =
+{
 		4371,  // CD-ROM
 		14764, // Single-layer DVD-ROM
 		13360  // dual-layer DVD-ROM [currently unused]
@@ -144,31 +144,31 @@ static const uint tbl_FastSeekDelta[3] =
 
 // if a seek is within this many blocks, read instead of seek.
 // These values are arbitrary assumptions.  Not sure what the real PS2 uses.
-static const uint tbl_ContigiousSeekDelta[3] =
-	{
+static constexpr uint tbl_ContigiousSeekDelta[3] =
+{
 		8,  // CD-ROM
 		16, // single-layer DVD-ROM
 		16, // dual-layer DVD-ROM [currently unused]
 };
 
-static const uint PSX_CD_READSPEED = 153600;   // Bytes per second, rough values from outer CD (CAV).
-static const uint PSX_DVD_READSPEED = 1382400; // Bytes per second, rough values from outer DVD (CAV).
+static constexpr uint PSX_CD_READSPEED = 153600;   // Bytes per second, rough values from outer CD (CAV).
+static constexpr uint PSX_DVD_READSPEED = 1382400; // Bytes per second, rough values from outer DVD (CAV).
 
-static const uint CD_SECTORS_PERSECOND = 75;
-static const uint DVD_SECTORS_PERSECOND = 675;
+static constexpr uint CD_SECTORS_PERSECOND = 75;
+static constexpr uint DVD_SECTORS_PERSECOND = 675;
 
 // Rotations per minute.
-static const uint CD_MIN_ROTATION_X1 = 214;
-static const uint CD_MAX_ROTATION_X1 = 497;
+static constexpr uint CD_MIN_ROTATION_X1 = 214;
+static constexpr uint CD_MAX_ROTATION_X1 = 497;
 
-static const uint DVD_MIN_ROTATION_X1 = 570;
-static const uint DVD_MAX_ROTATION_X1 = 1515;
+static constexpr uint DVD_MIN_ROTATION_X1 = 570;
+static constexpr uint DVD_MAX_ROTATION_X1 = 1515;
 
 // Legacy Note: FullSeek timing causes many games to load very slow, but it likely not the real problem.
 // Games breaking with it set to PSXCLK*40 : "wrath unleashed" and "Shijou Saikyou no Deshi Kenichi".
 
-static const uint Cdvd_FullSeek_Cycles = (PSXCLK * 100) / 1000; // average number of cycles per fullseek (100ms)
-static const uint Cdvd_FastSeek_Cycles = (PSXCLK * 30) / 1000;  // average number of cycles per fastseek (37ms)
+static constexpr uint Cdvd_FullSeek_Cycles = (36864000UL * 100UL) / 1000UL; // average number of cycles per fullseek (100ms)
+static constexpr uint Cdvd_FastSeek_Cycles = (36864000UL * 30UL) / 1000UL;  // average number of cycles per fastseek (37ms)
 bool trayState = 0; // Used to check if the CD tray status has changed since the last time
 
 static const char* mg_zones[8] = {"Japan", "USA", "Europe", "Oceania", "Asia", "Russia", "China", "Mexico"};

--- a/pcsx2/CDVD/IsoFileFormats.h
+++ b/pcsx2/CDVD/IsoFileFormats.h
@@ -32,7 +32,7 @@ enum isoType
 	ISOTYPE_DVDDL
 };
 
-static const int CD_FRAMESIZE_RAW = 2448;
+static constexpr int CD_FRAMESIZE_RAW = 2448;
 
 // --------------------------------------------------------------------------------------
 //  isoFile
@@ -73,9 +73,9 @@ public:
 
 	bool IsOpened() const;
 
-	isoType GetType() const { return m_type; }
-	uint GetBlockCount() const { return m_blocks; }
-	int GetBlockOffset() const { return m_blockofs; }
+	isoType GetType() const noexcept { return m_type; }
+	uint GetBlockCount() const noexcept { return m_blocks; }
+	int GetBlockOffset() const  noexcept { return m_blockofs; }
 
 	const std::string& GetFilename() const
 	{
@@ -127,7 +127,7 @@ public:
 	bool IsOpened() const;
 	u32 GetBlockSize() const;
 
-	const std::string& GetFilename() const
+	const std::string& GetFilename() const noexcept
 	{
 		return m_filename;
 	}

--- a/pcsx2/CDVD/Ps1CD.cpp
+++ b/pcsx2/CDVD/Ps1CD.cpp
@@ -875,7 +875,7 @@ void cdrWrite1(u8 rt)
 			if (cdr.Mode & MODE_CDDA)
 			{
 				StopCdda();
-				cdvd.Type = CDVD_TYPE_PSCDDA;
+				cdvd.DiscType = CDVD_TYPE_PSCDDA;
 			}
 
 			setPs1CDVDSpeed(cdvd.Speed);

--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -881,7 +881,7 @@ void GSState::ApplyTEX0(GIFRegTEX0& TEX0)
 
 	if (wt)
 	{
-		GIFRegBITBLTBUF BITBLTBUF;
+		GIFRegBITBLTBUF BITBLTBUF = {};
 		GSVector4i r;
 
 		if (TEX0.CSM == 0)
@@ -4689,10 +4689,10 @@ void GSState::GSPCRTCRegs::CalculateDisplayOffset(bool scanmask)
 		// Offset is not screen based, but relative to each other.
 		if (both_enabled)
 		{
-			GSVector2i offset;
-
-			offset.x = (PCRTCDisplays[1 - zeroDisplay.x].displayOffset.x - PCRTCDisplays[zeroDisplay.x].displayOffset.x) / (VideoModeDividers[videomode].x + 1);
-			offset.y = (PCRTCDisplays[1 - zeroDisplay.y].displayOffset.y - PCRTCDisplays[zeroDisplay.y].displayOffset.y) / (VideoModeDividers[videomode].y + 1);
+			GSVector2i offset = {
+				(PCRTCDisplays[1 - zeroDisplay.x].displayOffset.x - PCRTCDisplays[zeroDisplay.x].displayOffset.x) / (VideoModeDividers[videomode].x + 1),
+				(PCRTCDisplays[1 - zeroDisplay.y].displayOffset.y - PCRTCDisplays[zeroDisplay.y].displayOffset.y) / (VideoModeDividers[videomode].y + 1)
+			};
 
 			if (offset.x >= 4 || !GSConfig.PCRTCAntiBlur || scanmask)
 			{
@@ -4724,7 +4724,6 @@ void GSState::GSPCRTCRegs::CalculateDisplayOffset(bool scanmask)
 	else // We're using screen offsets, so just calculate the entire offset.
 	{
 		const GSVector4i offsets = !GSConfig.PCRTCOverscan ? VideoModeOffsets[videomode] : VideoModeOffsetsOverscan[videomode];
-		GSVector2i offset = { 0, 0 };
 		GSVector2i zeroDisplay = NearestToZeroOffset();
 
 		if (both_enabled)
@@ -4742,8 +4741,10 @@ void GSState::GSPCRTCRegs::CalculateDisplayOffset(bool scanmask)
 		for (int i = 0; i < 2; i++)
 		{
 			// Should this be MAGV/H in the DISPLAY register rather than the "default" magnification?
-			offset.x = (static_cast<int>(PCRTCDisplays[i].displayOffset.x) - offsets.z) / (VideoModeDividers[videomode].x + 1);
-			offset.y = (static_cast<int>(PCRTCDisplays[i].displayOffset.y) - (offsets.w * (interlaced + 1))) / (VideoModeDividers[videomode].y + 1);
+			const GSVector2i offset = {
+				(static_cast<int>(PCRTCDisplays[i].displayOffset.x) - offsets.z) / (VideoModeDividers[videomode].x + 1),
+				(static_cast<int>(PCRTCDisplays[i].displayOffset.y) - (offsets.w * (interlaced + 1))) / (VideoModeDividers[videomode].y + 1)
+			};
 
 			PCRTCDisplays[i].displayRect.x += offset.x;
 			PCRTCDisplays[i].displayRect.z += offset.x;
@@ -4753,10 +4754,10 @@ void GSState::GSPCRTCRegs::CalculateDisplayOffset(bool scanmask)
 
 		if (both_enabled)
 		{
-			GSVector2i offset;
-
-			offset.x = (PCRTCDisplays[1 - zeroDisplay.x].displayRect.x - PCRTCDisplays[zeroDisplay.x].displayRect.x);
-			offset.y = (PCRTCDisplays[1 - zeroDisplay.y].displayRect.y - PCRTCDisplays[zeroDisplay.y].displayRect.y);
+			const GSVector2i offset = {
+				(PCRTCDisplays[1 - zeroDisplay.x].displayRect.x - PCRTCDisplays[zeroDisplay.x].displayRect.x),
+				(PCRTCDisplays[1 - zeroDisplay.y].displayRect.y - PCRTCDisplays[zeroDisplay.y].displayRect.y)
+			};
 
 			if (offset.x > 0 && offset.x < 4 && GSConfig.PCRTCAntiBlur)
 			{


### PR DESCRIPTION
### Description of Changes
Improve naming of CDVD variables
Clean up C style casting where possible and remove some technical undefined behaviour.
Get rid of some dumb things

### Rationale behind Changes
Cleanup is good

### Suggested Testing Steps
Test some random games, make sure everything works as before, including loading BIOS region info when fast booting.
