### PR TITLE
CDVD: Fix seek times, improve read flow

### DIFF
--- a/pcsx2/IopHw.h
+++ b/pcsx2/IopHw.h
@@ -326,6 +326,7 @@ enum IopEventId
 };
 
 extern void PSX_INT( IopEventId n, s32 ecycle);
+extern int psxRemainingCycles(IopEventId n);
 
 extern void psxSetNextBranch( u32 startCycle, s32 delta );
 extern void psxSetNextBranchDelta( s32 delta );

--- a/pcsx2/R3000A.cpp
+++ b/pcsx2/R3000A.cpp
@@ -129,6 +129,14 @@ __fi int psxTestCycle( u32 startCycle, s32 delta )
 	return (int)(psxRegs.cycle - startCycle) >= delta;
 }
 
+__fi int psxRemainingCycles(IopEventId n)
+{
+	if (psxRegs.interrupt & (1 << n))
+		return ((psxRegs.cycle - psxRegs.sCycle[n]) + psxRegs.eCycle[n]);
+	else
+		return 0;
+}
+
 __fi void PSX_INT( IopEventId n, s32 ecycle )
 {
 	// 19 is CDVD read int, it's supposed to be high.
@@ -189,8 +197,8 @@ static __fi void _psxTestInterrupts()
 	IopTestEvent(IopEvt_SIF1,		sif1Interrupt);	// SIF1
 	IopTestEvent(IopEvt_SIF2,		sif2Interrupt);	// SIF2
 	Sio0TestEvent(IopEvt_SIO);
-	IopTestEvent(IopEvt_CdvdRead,	cdvdReadInterrupt);
 	IopTestEvent(IopEvt_CdvdSectorReady, cdvdSectorReady);
+	IopTestEvent(IopEvt_CdvdRead,	cdvdReadInterrupt);
 
 	// Profile-guided Optimization (sorta)
 	// The following ints are rarely called.  Encasing them in a conditional


### PR DESCRIPTION
### Description of Changes
Fixes CD/DVD seek times when seeking to a close sector
Add an IOP function for looking up remaining time on an interrupt
Fix up the flow of reads vs buffering sectors

### Rationale behind Changes
Seeks were happening way too soon if they were to local positions, there should have been rotational latency in finding the sector, but we were treating it as if it was a contiguous read, meaning the delay was extremely low, much lower than games were expecting.
The flow of reads vs buffered sectors was a little broken, meaning that it was having the DMA reads out of step with the CDVD reads, making it try too early, then wait, meaning it could overstep the read point, plus it was spamming the function way too much.

### Suggested Testing Steps
Test random games, but most importantly, Shadow Hearts Covenant.

Fixes #7139

Edit: It fixes it, success!