### PR TITLE
GS/HW: Multiple fixes

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -32786,6 +32786,8 @@ SLPM-65080:
   name: "Tokimeki Memorial 3"
   region: "NTSC-J"
   compat: 5
+  gsHWFixes:
+    textureInsideRT: 1 # Fixes character portraits.
 SLPM-65081:
   name: "Grandia II"
   region: "NTSC-J"

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -4210,10 +4210,10 @@ __ri void GSRendererHW::EmulateTextureSampler(const GSTextureCache::Target* rt, 
 	m_conf.ps.wms = (wms & 2 || target_region) ? wms : 0;
 	m_conf.ps.wmt = (wmt & 2 || target_region) ? wmt : 0;
 
-	// Depth + bilinear filtering isn't done yet (And I'm not sure we need it anyway but a game will prove me wrong)
-	// So of course, GTA set the linear mode, but sampling is done at texel center so it is equivalent to nearest sampling
+	// Depth + bilinear filtering isn't done yet. But if the game has just set a Z24 swizzle on a colour texture, we can
+	// just pretend it's not a depth format, since in the texture cache, it's not.
 	// Other games worth testing: Area 51, Burnout
-	if (psm.depth && m_vt.IsLinear())
+	if (psm.depth && m_vt.IsLinear() && tex->GetTexture()->IsDepthStencil())
 		GL_INS("WARNING: Depth + bilinear filtering not supported");
 
 	// Performance note:
@@ -4293,18 +4293,10 @@ __ri void GSRendererHW::EmulateTextureSampler(const GSTextureCache::Target* rt, 
 		}
 
 		// Depth format
-		if (tex->m_texture->GetType() == GSTexture::Type::DepthStencil)
+		if (tex->m_texture->IsDepthStencil())
 		{
 			// Require a float conversion if the texure is a depth format
 			m_conf.ps.depth_fmt = (psm.bpp == 16) ? 2 : 1;
-
-			// Don't force interpolation on depth format
-			bilinear &= m_vt.IsLinear();
-		}
-		else if (psm.depth)
-		{
-			// Use Integral scaling
-			m_conf.ps.depth_fmt = 3;
 
 			// Don't force interpolation on depth format
 			bilinear &= m_vt.IsLinear();

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -4384,9 +4384,11 @@ __ri void GSRendererHW::EmulateTextureSampler(const GSTextureCache::Target* rt, 
 	m_conf.cb_ps.HalfTexel = GSVector4(-0.5f, 0.5f).xxyy() / WH.zwzw();
 	if (complex_wms_wmt)
 	{
+		// Add 0.5 to the coordinates because the region clamp is inclusive, size is exclusive. We use 0.5 because we want to clamp
+		// to the last texel in the image, not halfway between it and wrapping around.
 		const GSVector4i clamp(m_cached_ctx.CLAMP.MINU, m_cached_ctx.CLAMP.MINV, m_cached_ctx.CLAMP.MAXU, m_cached_ctx.CLAMP.MAXV);
-		const GSVector4 region_repeat(GSVector4::cast(clamp));
-		const GSVector4 region_clamp(GSVector4(clamp) / WH.xyxy());
+		const GSVector4 region_repeat = GSVector4::cast(clamp);
+		const GSVector4 region_clamp = (GSVector4(clamp) + GSVector4::cxpr(0.0f, 0.0f, 0.5f, 0.5f)) / WH.xyxy();
 		if (wms >= CLAMP_REGION_CLAMP)
 		{
 			m_conf.cb_ps.MinMax.x = (wms == CLAMP_REGION_CLAMP && !m_conf.ps.depth_fmt) ? region_clamp.x : region_repeat.x;


### PR DESCRIPTION
### Description of Changes

Screenshots are before, then after.

**GS/HW: Toss targets when BW changes instead of incorrectly converting**
Fixes #5589.
![image](https://github.com/PCSX2/pcsx2/assets/11288319/153b4a1a-3204-4a8e-805f-144358e69c99)
![image](https://github.com/PCSX2/pcsx2/assets/11288319/06b140b0-a097-4ebb-9c18-a6c40633ff4e)

**GS/HW: Fix off-by-one in region clamp**

Fixes text in ZIPANG, decals in Enthusia Professional Racing, edge of screen in Dynasty Warriors, and others.
![image](https://github.com/PCSX2/pcsx2/assets/11288319/87604163-12dc-4b63-87e7-6f0d78dd3183)
![image](https://github.com/PCSX2/pcsx2/assets/11288319/e4502b21-5725-4500-8192-e11aef8d4468)
![gsdx_20201207100057_frame1](https://github.com/PCSX2/pcsx2/assets/11288319/a7b061e0-2cc8-4e83-a2df-c1e951f07f5b)
![gsdx_20201207100057_frame1-1](https://github.com/PCSX2/pcsx2/assets/11288319/378ce252-c076-4ce0-ad80-9294f1e4cd04)

**GS/HW: Allow bilinear from colour backed Z formats**

Fixes the haze effect in GTA: San Andreas from being extra blurry.
Improves shadows in Everybody's Golf and Tennis.
![image](https://github.com/PCSX2/pcsx2/assets/11288319/6bcbb419-f0dc-4db8-859c-093c209a7066)
![image](https://github.com/PCSX2/pcsx2/assets/11288319/be8ec979-8056-4014-aca2-cf7df31ab5f2)


### Rationale behind Changes

See above.

### Suggested Testing Steps

Runner says it's good, but double check a couple of the games above.
