### PR TITLE
GameDB: Go Go Golf Fixes.

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -14066,7 +14066,6 @@ SLES-51055:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves brightness on terrain textures.
     texturePreloading: 0 # fixes wrong shade.
-
 SLES-51056:
   name: "Fighting Fury"
   region: "PAL-E"

--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -14065,6 +14065,8 @@ SLES-51055:
   region: "PAL-E"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves brightness on terrain textures.
+    texturePreloading: 0 # fixes wrong shade.
+
 SLES-51056:
   name: "Fighting Fury"
   region: "PAL-E"
@@ -28876,6 +28878,7 @@ SLPM-60116:
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves brightness on terrain textures.
+    texturePreloading: 0 # fixes wrong shade.
 SLPM-60117:
   name: "Shin Sangoku Musou"
   region: "NTSC-J"
@@ -41153,6 +41156,7 @@ SLPS-20037:
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves brightness on terrain textures.
+    texturePreloading: 0 # fixes wrong shade.
 SLPS-20038:
   name: "Grappler Baki - Baki Saidai no Tournament"
   region: "NTSC-J"
@@ -41775,6 +41779,7 @@ SLPS-20243:
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves brightness on terrain textures.
+    texturePreloading: 0 # fixes wrong shade.
 SLPS-20244:
   name: "Magical Sports - 2000 Koushien [NewPrice]"
   region: "NTSC-J"


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Add "texturePreloading" to fix broken shade.
[MS_GGG.gs.zst.zip](https://github.com/PCSX2/pcsx2/files/12873863/MS_GGG.gs.zst.zip)

Before:
![Magical Sports - Go Go Golf_SLPS-20037_20231012042522](https://github.com/PCSX2/pcsx2/assets/121824800/3b8af9fc-8e9a-43de-9a1d-c547d8e3a641)
After:
![Magical Sports - Go Go Golf_SLPS-20037_20231012042527](https://github.com/PCSX2/pcsx2/assets/121824800/64bd28d1-6a03-4a3e-8086-0820126df524)
SW:
![Magical Sports - Go Go Golf_SLPS-20037_20231012042531](https://github.com/PCSX2/pcsx2/assets/121824800/f1c56a2d-b9e6-4db3-8522-90597cd75b16)
I checked SLPS-20037 only because I don't have other version (SLPS-20243,SLPM-60116,SLES-51055).
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->

Broken shade is bad.
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Boot up the game and start any cources.


