### PR TITLE
Debugger: Fix an issue where the debugger is always on top of the main window

### DIFF
--- a/pcsx2-qt/Debugger/DebuggerWindow.cpp
+++ b/pcsx2-qt/Debugger/DebuggerWindow.cpp
@@ -42,11 +42,17 @@ DebuggerWindow::DebuggerWindow(QWidget* parent)
 	connect(m_ui.actionStepInto, &QAction::triggered, this, &DebuggerWindow::onStepInto);
 	connect(m_ui.actionStepOver, &QAction::triggered, this, &DebuggerWindow::onStepOver);
 	connect(m_ui.actionStepOut, &QAction::triggered, this, &DebuggerWindow::onStepOut);
+	connect(m_ui.actionOnTop, &QAction::triggered, [this] { this->setWindowFlags(this->windowFlags() ^ Qt::WindowStaysOnTopHint); this->show(); });
 
 	connect(g_emu_thread, &EmuThread::onVMPaused, this, &DebuggerWindow::onVMStateChanged);
 	connect(g_emu_thread, &EmuThread::onVMResumed, this, &DebuggerWindow::onVMStateChanged);
 
 	onVMStateChanged(); // If we missed a state change while we weren't loaded
+	
+	// We can't do this in the designer, but we want to right align the actionOnTop action in the toolbar
+	QWidget* spacer = new QWidget(this);
+	spacer->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+	m_ui.toolBar->insertWidget(m_ui.actionOnTop, spacer);
 
 	m_cpuWidget_r5900 = new CpuWidget(this, r5900Debug);
 	m_cpuWidget_r3000 = new CpuWidget(this, r3000Debug);

--- a/pcsx2-qt/Debugger/DebuggerWindow.ui
+++ b/pcsx2-qt/Debugger/DebuggerWindow.ui
@@ -13,6 +13,11 @@
   <property name="windowTitle">
    <string>PCSX2 Debugger</string>
   </property>
+  <property name="windowIcon">
+   <iconset>
+    <normalon>:/icons/AppIcon64.png</normalon>
+   </iconset>
+  </property>
   <widget class="QWidget" name="centralwidget">
    <layout class="QGridLayout" name="gridLayout">
     <item row="0" column="0">
@@ -46,6 +51,7 @@
    <addaction name="actionStepInto"/>
    <addaction name="actionStepOver"/>
    <addaction name="actionStepOut"/>
+   <addaction name="actionOnTop"/>
   </widget>
   <action name="actionRun">
    <property name="icon">
@@ -86,6 +92,17 @@
    </property>
    <property name="shortcut">
     <string>Shift+F11</string>
+   </property>
+  </action>
+  <action name="actionOnTop">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Always On Top</string>
+   </property>
+   <property name="toolTip">
+    <string>Show this window on top</string>
    </property>
   </action>
  </widget>

--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -118,6 +118,13 @@ MainWindow::~MainWindow()
 	// make sure the game list isn't refreshing, because it's on a separate thread
 	cancelGameListRefresh();
 
+	if (m_debugger_window)
+	{
+		m_debugger_window->close();
+		m_debugger_window->deleteLater();
+		m_debugger_window = nullptr;
+	}
+
 	// we compare here, since recreate destroys the window later
 	if (g_main_window == this)
 		g_main_window = nullptr;
@@ -2300,7 +2307,8 @@ void MainWindow::doSettings(const char* category /* = nullptr */)
 DebuggerWindow* MainWindow::getDebuggerWindow()
 {
 	if (!m_debugger_window)
-		m_debugger_window = new DebuggerWindow(this);
+		// Don't pass us (this) as the parent, otherwise the window is always on top of the mainwindow (on windows at least)
+		m_debugger_window = new DebuggerWindow(nullptr);
 
 	return m_debugger_window;
 }


### PR DESCRIPTION
### Description of Changes
The title + A toolbar checkbox to toggle always on top off and on

### Rationale behind Changes
Sometimes you don't want the debugger on top of everything all the time

### Suggested Testing Steps
Click on the main window while the debugger is on top of it. The debugger should go behind the main window.
Try the above after clicking the always on top button.
