### PR TITLE
IopMem: Fix incorrect memory pointer

### DIFF
--- a/pcsx2/IopMem.cpp
+++ b/pcsx2/IopMem.cpp
@@ -39,7 +39,7 @@ void iopMemAlloc()
 
 	psxMemRLUT = psxMemWLUT + 0x2000; //(uptr*)_aligned_malloc(0x10000 * sizeof(uptr),16);
 
-	iopMem = reinterpret_cast<IopVM_MemoryAllocMess*>(SysMemory::GetCodePtr(HostMemoryMap::IOPmemOffset));
+	iopMem = reinterpret_cast<IopVM_MemoryAllocMess*>(SysMemory::GetIOPMem());
 }
 
 void iopMemRelease()

--- a/pcsx2/VUmicroMem.cpp
+++ b/pcsx2/VUmicroMem.cpp
@@ -23,7 +23,7 @@ alignas(16) VURegs vuRegs[2];
 
 void vuMemAllocate()
 {
-	u8* curpos = SysMemory::GetDataPtr(HostMemoryMap::VUmemOffset);
+	u8* curpos = SysMemory::GetVUMem();
 	VU0.Micro	= curpos; curpos += VU0_PROGSIZE;
 	VU0.Mem		= curpos; curpos += VU0_MEMSIZE;
 	VU1.Micro	= curpos; curpos += VU1_PROGSIZE;


### PR DESCRIPTION
### Description of Changes

Was pointing into rec space instead of the data space.

### Rationale behind Changes

Memory corruption is bad.

### Suggested Testing Steps

CI passes.
