### PR TITLE
Qt: Change settings windows from QDialog to QWidget

### DIFF
--- a/pcsx2-qt/CMakeLists.txt
+++ b/pcsx2-qt/CMakeLists.txt
@@ -73,9 +73,9 @@ target_sources(pcsx2-qt PRIVATE
 	Settings/ControllerMacroEditWidget.ui
 	Settings/ControllerMacroWidget.ui
 	Settings/ControllerMouseSettingsDialog.ui
-	Settings/ControllerSettingsDialog.cpp
-	Settings/ControllerSettingsDialog.h
-	Settings/ControllerSettingsDialog.ui
+	Settings/ControllerSettingsWindow.cpp
+	Settings/ControllerSettingsWindow.h
+	Settings/ControllerSettingsWindow.ui
 	Settings/ControllerSettingWidgetBinder.h
 	Settings/DebugSettingsWidget.cpp
 	Settings/DebugSettingsWidget.h
@@ -137,9 +137,9 @@ target_sources(pcsx2-qt PRIVATE
 	Settings/HddCreateQt.cpp
 	Settings/HddCreateQt.h
 	Settings/PatchDetailsWidget.ui
-	Settings/SettingsDialog.cpp
-	Settings/SettingsDialog.h
-	Settings/SettingsDialog.ui
+	Settings/SettingsWindow.cpp
+	Settings/SettingsWindow.h
+	Settings/SettingsWindow.ui
 	Settings/USBBindingWidget_DrivingForce.ui
 	Settings/USBBindingWidget_GTForce.ui
 	Settings/USBBindingWidget_GunCon2.ui

--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -26,7 +26,7 @@
 #include "QtUtils.h"
 #include "SettingWidgetBinder.h"
 #include "Settings/AchievementLoginDialog.h"
-#include "Settings/ControllerSettingsDialog.h"
+#include "Settings/ControllerSettingsWindow.h"
 #include "Settings/GameListSettingsWidget.h"
 #include "Settings/InterfaceSettingsWidget.h"
 #include "Tools/InputRecording/InputRecordingViewer.h"
@@ -117,13 +117,7 @@ MainWindow::~MainWindow()
 {
 	// make sure the game list isn't refreshing, because it's on a separate thread
 	cancelGameListRefresh();
-
-	if (m_debugger_window)
-	{
-		m_debugger_window->close();
-		m_debugger_window->deleteLater();
-		m_debugger_window = nullptr;
-	}
+	destroySubWindows();
 
 	// we compare here, since recreate destroys the window later
 	if (g_main_window == this)
@@ -320,7 +314,7 @@ void MainWindow::connectSignals()
 	connect(m_ui.actionToolbarSaveState, &QAction::triggered, this, [this]() { m_ui.menuSaveState->exec(QCursor::pos()); });
 	connect(m_ui.actionToolbarSettings, &QAction::triggered, this, &MainWindow::onSettingsTriggeredFromToolbar);
 	connect(m_ui.actionToolbarControllerSettings, &QAction::triggered,
-		[this]() { doControllerSettings(ControllerSettingsDialog::Category::GlobalSettings); });
+		[this]() { doControllerSettings(ControllerSettingsWindow::Category::GlobalSettings); });
 	connect(m_ui.actionToolbarScreenshot, &QAction::triggered, this, &MainWindow::onScreenshotActionTriggered);
 	connect(m_ui.actionExit, &QAction::triggered, this, &MainWindow::close);
 	connect(m_ui.actionScreenshot, &QAction::triggered, this, &MainWindow::onScreenshotActionTriggered);
@@ -338,11 +332,11 @@ void MainWindow::connectSignals()
 	connect(m_ui.actionFolderSettings, &QAction::triggered, [this]() { doSettings("Folders"); });
 	connect(m_ui.actionAchievementSettings, &QAction::triggered, [this]() { doSettings("Achievements"); });
 	connect(m_ui.actionControllerSettings, &QAction::triggered,
-		[this]() { doControllerSettings(ControllerSettingsDialog::Category::GlobalSettings); });
+		[this]() { doControllerSettings(ControllerSettingsWindow::Category::GlobalSettings); });
 	connect(m_ui.actionHotkeySettings, &QAction::triggered,
-		[this]() { doControllerSettings(ControllerSettingsDialog::Category::HotkeySettings); });
+		[this]() { doControllerSettings(ControllerSettingsWindow::Category::HotkeySettings); });
 	connect(m_ui.actionAddGameDirectory, &QAction::triggered,
-		[this]() { getSettingsDialog()->getGameListSettingsWidget()->addSearchDirectory(this); });
+		[this]() { getSettingsWindow()->getGameListSettingsWidget()->addSearchDirectory(this); });
 	connect(m_ui.actionScanForNewGames, &QAction::triggered, [this]() { refreshGameList(false); });
 	connect(m_ui.actionRescanAllGames, &QAction::triggered, [this]() { refreshGameList(true); });
 	connect(m_ui.actionViewToolbar, &QAction::toggled, this, &MainWindow::onViewToolbarActionToggled);
@@ -415,7 +409,7 @@ void MainWindow::connectSignals()
 	connect(m_game_list_widget, &GameListWidget::entryContextMenuRequested, this, &MainWindow::onGameListEntryContextMenuRequested,
 		Qt::QueuedConnection);
 	connect(m_game_list_widget, &GameListWidget::addGameDirectoryRequested, this,
-		[this]() { getSettingsDialog()->getGameListSettingsWidget()->addSearchDirectory(this); });
+		[this]() { getSettingsWindow()->getGameListSettingsWidget()->addSearchDirectory(this); });
 }
 
 void MainWindow::connectVMThreadSignals(EmuThread* thread)
@@ -485,14 +479,14 @@ void MainWindow::recreate()
 void MainWindow::recreateSettings()
 {
 	QString current_category;
-	if (m_settings_dialog)
+	if (m_setings_window)
 	{
-		const bool was_visible = m_settings_dialog->isVisible();
+		const bool was_visible = m_setings_window->isVisible();
 
-		current_category = m_settings_dialog->getCategory();
-		m_settings_dialog->hide();
-		m_settings_dialog->deleteLater();
-		m_settings_dialog = nullptr;
+		current_category = m_setings_window->getCategory();
+		m_setings_window->hide();
+		m_setings_window->deleteLater();
+		m_setings_window = nullptr;
 
 		if (!was_visible)
 			return;
@@ -518,7 +512,29 @@ void MainWindow::resetSettings(bool ui)
 	g_main_window->recreateSettings();
 }
 
+void MainWindow::destroySubWindows()
+{
+	if (m_debugger_window)
+	{
+		m_debugger_window->close();
+		m_debugger_window->deleteLater();
+		m_debugger_window = nullptr;
+	}
 
+	if (m_controller_settings_window)
+	{
+		m_controller_settings_window->close();
+		m_controller_settings_window->deleteLater();
+		m_controller_settings_window = nullptr;
+	}
+
+	if (m_setings_window)
+	{
+		m_setings_window->close();
+		m_setings_window->deleteLater();
+		m_setings_window = nullptr;
+	}
+}
 
 void MainWindow::onScreenshotActionTriggered()
 {
@@ -594,7 +610,7 @@ void MainWindow::onShowAdvancedSettingsToggled(bool checked)
 	m_ui.menuDebug->menuAction()->setVisible(checked);
 
 	// just recreate the entire settings window, it's easier.
-	if (m_settings_dialog)
+	if (m_setings_window)
 		recreateSettings();
 }
 
@@ -1174,7 +1190,7 @@ void MainWindow::onGameListEntryContextMenuRequested(const QPoint& point)
 		if (action->isEnabled())
 		{
 			connect(action, &QAction::triggered, [entry]() {
-				SettingsDialog::openGamePropertiesDialog(entry, entry->title,
+				SettingsWindow::openGamePropertiesDialog(entry, entry->title,
 					(entry->type != GameList::EntryType::ELF) ? entry->serial : std::string(),
 					entry->crc);
 			});
@@ -1191,7 +1207,7 @@ void MainWindow::onGameListEntryContextMenuRequested(const QPoint& point)
 		connect(action, &QAction::triggered, [this, entry]() { setGameListEntryCoverImage(entry); });
 
 		connect(menu.addAction(tr("Exclude From List")), &QAction::triggered,
-			[this, entry]() { getSettingsDialog()->getGameListSettingsWidget()->addExcludedPath(entry->path); });
+			[this, entry]() { getSettingsWindow()->getGameListSettingsWidget()->addExcludedPath(entry->path); });
 
 		connect(menu.addAction(tr("Reset Play Time")), &QAction::triggered, [this, entry]() { clearGameListEntryPlayTime(entry); });
 
@@ -1239,7 +1255,7 @@ void MainWindow::onGameListEntryContextMenuRequested(const QPoint& point)
 	}
 
 	connect(menu.addAction(tr("Add Search Directory...")), &QAction::triggered,
-		[this]() { getSettingsDialog()->getGameListSettingsWidget()->addSearchDirectory(this); });
+		[this]() { getSettingsWindow()->getGameListSettingsWidget()->addSearchDirectory(this); });
 
 	menu.exec(point);
 }
@@ -1387,7 +1403,7 @@ void MainWindow::onViewGamePropertiesActionTriggered()
 		const GameList::Entry* entry = GameList::GetEntryForPath(path.toUtf8().constData());
 		if (entry)
 		{
-			SettingsDialog::openGamePropertiesDialog(
+			SettingsWindow::openGamePropertiesDialog(
 				entry, entry->title, m_current_elf_override.isEmpty() ? entry->serial : std::string(), entry->crc);
 			return;
 		}
@@ -1403,12 +1419,12 @@ void MainWindow::onViewGamePropertiesActionTriggered()
 	// can't use serial for ELFs, because they might have a disc set
 	if (m_current_elf_override.isEmpty())
 	{
-		SettingsDialog::openGamePropertiesDialog(
+		SettingsWindow::openGamePropertiesDialog(
 			nullptr, m_current_title.toStdString(), m_current_disc_serial.toStdString(), m_current_disc_crc);
 	}
 	else
 	{
-		SettingsDialog::openGamePropertiesDialog(
+		SettingsWindow::openGamePropertiesDialog(
 			nullptr, m_current_title.toStdString(), std::string(), m_current_disc_crc);
 	}
 }
@@ -1812,6 +1828,7 @@ void MainWindow::closeEvent(QCloseEvent* event)
 		saveStateToConfig();
 		if (m_display_widget)
 			g_emu_thread->stopFullscreenUI();
+		destroySubWindows();
 		QMainWindow::closeEvent(event);
 		return;
 	}
@@ -2267,13 +2284,13 @@ void MainWindow::restoreDisplayWindowGeometryFromConfig()
 	}
 }
 
-SettingsDialog* MainWindow::getSettingsDialog()
+SettingsWindow* MainWindow::getSettingsWindow()
 {
-	if (!m_settings_dialog)
+	if (!m_setings_window)
 	{
-		m_settings_dialog = new SettingsDialog(this);
-		connect(m_settings_dialog->getInterfaceSettingsWidget(), &InterfaceSettingsWidget::themeChanged, this, &MainWindow::updateTheme);
-		connect(m_settings_dialog->getInterfaceSettingsWidget(), &InterfaceSettingsWidget::languageChanged, this, [this]() {
+		m_setings_window = new SettingsWindow();
+		connect(m_setings_window->getInterfaceSettingsWidget(), &InterfaceSettingsWidget::themeChanged, this, &MainWindow::updateTheme);
+		connect(m_setings_window->getInterfaceSettingsWidget(), &InterfaceSettingsWidget::languageChanged, this, [this]() {
 			// reopen settings dialog after it applies
 			updateLanguage();
 			// If you doSettings now, on macOS, the window will somehow end up underneath the main window that was created above
@@ -2284,21 +2301,16 @@ SettingsDialog* MainWindow::getSettingsDialog()
 		});
 	}
 
-	return m_settings_dialog;
+	return m_setings_window;
 }
 
 void MainWindow::doSettings(const char* category /* = nullptr */)
 {
-	SettingsDialog* dlg = getSettingsDialog();
+	SettingsWindow* dlg = getSettingsWindow();
 	if (dlg->isVisible())
-	{
 		dlg->raise();
-	}
 	else
-	{
-		dlg->setModal(false);
 		dlg->show();
-	}
 
 	if (category)
 		dlg->setCategory(category);
@@ -2319,25 +2331,20 @@ void MainWindow::openDebugger()
 	dwnd->isVisible() ? dwnd->hide() : dwnd->show();
 }
 
-ControllerSettingsDialog* MainWindow::getControllerSettingsDialog()
+void MainWindow::doControllerSettings(ControllerSettingsWindow::Category category)
 {
-	if (!m_controller_settings_dialog)
-		m_controller_settings_dialog = new ControllerSettingsDialog(this);
-
-	return m_controller_settings_dialog;
-}
-
-void MainWindow::doControllerSettings(ControllerSettingsDialog::Category category)
-{
-	ControllerSettingsDialog* dlg = getControllerSettingsDialog();
-	if (!dlg->isVisible())
+	if (m_controller_settings_window)
 	{
-		dlg->setModal(false);
-		dlg->show();
+		m_controller_settings_window->raise();
+	}
+	else
+	{
+		m_controller_settings_window = new ControllerSettingsWindow();
+		m_controller_settings_window->show();
 	}
 
-	if (category != ControllerSettingsDialog::Category::Count)
-		dlg->setCategory(category);
+	if (category != ControllerSettingsWindow::Category::Count)
+		m_controller_settings_window->setCategory(category);
 }
 
 QString MainWindow::getDiscDevicePath(const QString& title)

--- a/pcsx2-qt/MainWindow.h
+++ b/pcsx2-qt/MainWindow.h
@@ -24,8 +24,8 @@
 #include <optional>
 
 #include "Tools/InputRecording/InputRecordingViewer.h"
-#include "Settings/ControllerSettingsDialog.h"
-#include "Settings/SettingsDialog.h"
+#include "Settings/ControllerSettingsWindow.h"
+#include "Settings/SettingsWindow.h"
 #include "Debugger/DebuggerWindow.h"
 #include "ui_MainWindow.h"
 
@@ -35,7 +35,7 @@ class AutoUpdaterDialog;
 class DisplayWidget;
 class DisplayContainer;
 class GameListWidget;
-class ControllerSettingsDialog;
+class ControllerSettingsWindow;
 
 class EmuThread;
 
@@ -218,6 +218,7 @@ private:
 	void connectSignals();
 	void recreate();
 	void recreateSettings();
+	void destroySubWindows();
 
 	void registerForDeviceNotifications();
 	void unregisterForDeviceNotifications();
@@ -250,7 +251,7 @@ private:
 	void destroyDisplayWidget(bool show_game_list);
 	void updateDisplayWidgetCursor();
 
-	SettingsDialog* getSettingsDialog();
+	SettingsWindow* getSettingsWindow();
 	void doSettings(const char* category = nullptr);
 
 	InputRecordingViewer* getInputRecordingViewer();
@@ -258,8 +259,7 @@ private:
 
 	DebuggerWindow* getDebuggerWindow();
 
-	ControllerSettingsDialog* getControllerSettingsDialog();
-	void doControllerSettings(ControllerSettingsDialog::Category category = ControllerSettingsDialog::Category::Count);
+	void doControllerSettings(ControllerSettingsWindow::Category category = ControllerSettingsWindow::Category::Count);
 
 	QString getDiscDevicePath(const QString& title);
 
@@ -282,9 +282,9 @@ private:
 	DisplayWidget* m_display_widget = nullptr;
 	DisplayContainer* m_display_container = nullptr;
 
-	SettingsDialog* m_settings_dialog = nullptr;
+	SettingsWindow* m_setings_window = nullptr;
+	ControllerSettingsWindow* m_controller_settings_window = nullptr;
 	InputRecordingViewer* m_input_recording_viewer = nullptr;
-	ControllerSettingsDialog* m_controller_settings_dialog = nullptr;
 	AutoUpdaterDialog* m_auto_updater_dialog = nullptr;
 
 	DebuggerWindow* m_debugger_window = nullptr;

--- a/pcsx2-qt/SettingWidgetBinder.h
+++ b/pcsx2-qt/SettingWidgetBinder.h
@@ -41,7 +41,7 @@
 
 #include "QtHost.h"
 #include "QtUtils.h"
-#include "Settings/SettingsDialog.h"
+#include "Settings/SettingsWindow.h"
 
 namespace SettingWidgetBinder
 {

--- a/pcsx2-qt/Settings/AchievementSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/AchievementSettingsWidget.cpp
@@ -18,7 +18,7 @@
 #include "AchievementSettingsWidget.h"
 #include "AchievementLoginDialog.h"
 #include "MainWindow.h"
-#include "SettingsDialog.h"
+#include "SettingsWindow.h"
 #include "SettingWidgetBinder.h"
 #include "QtUtils.h"
 
@@ -30,7 +30,7 @@
 #include <QtCore/QDateTime>
 #include <QtWidgets/QMessageBox>
 
-AchievementSettingsWidget::AchievementSettingsWidget(SettingsDialog* dialog, QWidget* parent)
+AchievementSettingsWidget::AchievementSettingsWidget(SettingsWindow* dialog, QWidget* parent)
 	: QWidget(parent)
 	, m_dialog(dialog)
 {

--- a/pcsx2-qt/Settings/AchievementSettingsWidget.h
+++ b/pcsx2-qt/Settings/AchievementSettingsWidget.h
@@ -17,14 +17,14 @@
 #include <QtWidgets/QWidget>
 #include "ui_AchievementSettingsWidget.h"
 
-class SettingsDialog;
+class SettingsWindow;
 
 class AchievementSettingsWidget : public QWidget
 {
 	Q_OBJECT
 
 public:
-	explicit AchievementSettingsWidget(SettingsDialog* dialog, QWidget* parent);
+	explicit AchievementSettingsWidget(SettingsWindow* dialog, QWidget* parent);
 	~AchievementSettingsWidget();
 
 private Q_SLOTS:
@@ -41,5 +41,5 @@ private:
 
 	Ui::AchievementSettingsWidget m_ui;
 
-	SettingsDialog* m_dialog;
+	SettingsWindow* m_dialog;
 };

--- a/pcsx2-qt/Settings/AdvancedSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/AdvancedSettingsWidget.cpp
@@ -22,9 +22,9 @@
 #include "QtHost.h"
 #include "QtUtils.h"
 #include "SettingWidgetBinder.h"
-#include "SettingsDialog.h"
+#include "SettingsWindow.h"
 
-AdvancedSettingsWidget::AdvancedSettingsWidget(SettingsDialog* dialog, QWidget* parent)
+AdvancedSettingsWidget::AdvancedSettingsWidget(SettingsWindow* dialog, QWidget* parent)
 	: QWidget(parent)
 	, m_dialog(dialog)
 {

--- a/pcsx2-qt/Settings/AdvancedSettingsWidget.h
+++ b/pcsx2-qt/Settings/AdvancedSettingsWidget.h
@@ -19,14 +19,14 @@
 
 #include "ui_AdvancedSettingsWidget.h"
 
-class SettingsDialog;
+class SettingsWindow;
 
 class AdvancedSettingsWidget : public QWidget
 {
 	Q_OBJECT
 
 public:
-	AdvancedSettingsWidget(SettingsDialog* dialog, QWidget* parent);
+	AdvancedSettingsWidget(SettingsWindow* dialog, QWidget* parent);
 	~AdvancedSettingsWidget();
 
 private:
@@ -34,7 +34,7 @@ private:
 	int getClampingModeIndex(int vunum) const;
 	void setClampingMode(int vunum, int index);
 
-	SettingsDialog* m_dialog;
+	SettingsWindow* m_dialog;
 
 	Ui::AdvancedSystemSettingsWidget m_ui;
 };

--- a/pcsx2-qt/Settings/AudioSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/AudioSettingsWidget.cpp
@@ -26,7 +26,7 @@
 #include "QtHost.h"
 #include "QtUtils.h"
 #include "SettingWidgetBinder.h"
-#include "SettingsDialog.h"
+#include "SettingsWindow.h"
 
 static constexpr s32 DEFAULT_SYNCHRONIZATION_MODE = 0;
 static constexpr s32 DEFAULT_EXPANSION_MODE = 0;
@@ -39,7 +39,7 @@ static constexpr s32 DEFAULT_SOUNDTOUCH_SEQUENCE_LENGTH = 30;
 static constexpr s32 DEFAULT_SOUNDTOUCH_SEEK_WINDOW = 20;
 static constexpr s32 DEFAULT_SOUNDTOUCH_OVERLAP = 10;
 
-AudioSettingsWidget::AudioSettingsWidget(SettingsDialog* dialog, QWidget* parent)
+AudioSettingsWidget::AudioSettingsWidget(SettingsWindow* dialog, QWidget* parent)
 	: QWidget(parent)
 	, m_dialog(dialog)
 {

--- a/pcsx2-qt/Settings/AudioSettingsWidget.h
+++ b/pcsx2-qt/Settings/AudioSettingsWidget.h
@@ -19,14 +19,14 @@
 
 #include "ui_AudioSettingsWidget.h"
 
-class SettingsDialog;
+class SettingsWindow;
 
 class AudioSettingsWidget : public QWidget
 {
 	Q_OBJECT
 
 public:
-	AudioSettingsWidget(SettingsDialog* dialog, QWidget* parent);
+	AudioSettingsWidget(SettingsWindow* dialog, QWidget* parent);
 	~AudioSettingsWidget();
 
 private Q_SLOTS:
@@ -45,7 +45,7 @@ private:
 	void populateOutputModules();
 	void updateVolumeLabel();
 
-	SettingsDialog* m_dialog;
+	SettingsWindow* m_dialog;
 	Ui::AudioSettingsWidget m_ui;
 	u32 m_output_device_latency = 0;
 };

--- a/pcsx2-qt/Settings/BIOSSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/BIOSSettingsWidget.cpp
@@ -26,9 +26,9 @@
 #include "QtHost.h"
 #include "QtUtils.h"
 #include "SettingWidgetBinder.h"
-#include "SettingsDialog.h"
+#include "SettingsWindow.h"
 
-BIOSSettingsWidget::BIOSSettingsWidget(SettingsDialog* dialog, QWidget* parent)
+BIOSSettingsWidget::BIOSSettingsWidget(SettingsWindow* dialog, QWidget* parent)
 	: QWidget(parent)
 	, m_dialog(dialog)
 {

--- a/pcsx2-qt/Settings/BIOSSettingsWidget.h
+++ b/pcsx2-qt/Settings/BIOSSettingsWidget.h
@@ -24,7 +24,7 @@
 
 #include "ui_BIOSSettingsWidget.h"
 
-class SettingsDialog;
+class SettingsWindow;
 class QThread;
 
 // TODO: Move to core.
@@ -43,7 +43,7 @@ class BIOSSettingsWidget : public QWidget
 	Q_OBJECT
 
 public:
-	BIOSSettingsWidget(SettingsDialog* dialog, QWidget* parent);
+	BIOSSettingsWidget(SettingsWindow* dialog, QWidget* parent);
 	~BIOSSettingsWidget();
 
 	class RefreshThread final : public QThread
@@ -71,7 +71,7 @@ private Q_SLOTS:
 
 private:
 	Ui::BIOSSettingsWidget m_ui;
-	SettingsDialog* m_dialog;
+	SettingsWindow* m_dialog;
 
 	RefreshThread* m_refresh_thread = nullptr;
 };

--- a/pcsx2-qt/Settings/ControllerBindingWidgets.cpp
+++ b/pcsx2-qt/Settings/ControllerBindingWidgets.cpp
@@ -29,9 +29,9 @@
 #include "pcsx2/SIO/Pad/Pad.h"
 
 #include "Settings/ControllerBindingWidgets.h"
-#include "Settings/ControllerSettingsDialog.h"
+#include "Settings/ControllerSettingsWindow.h"
 #include "Settings/ControllerSettingWidgetBinder.h"
-#include "Settings/SettingsDialog.h"
+#include "Settings/SettingsWindow.h"
 #include "QtHost.h"
 #include "QtUtils.h"
 #include "SettingWidgetBinder.h"
@@ -40,7 +40,7 @@
 #include "ui_USBBindingWidget_GTForce.h"
 #include "ui_USBBindingWidget_GunCon2.h"
 
-ControllerBindingWidget::ControllerBindingWidget(QWidget* parent, ControllerSettingsDialog* dialog, u32 port)
+ControllerBindingWidget::ControllerBindingWidget(QWidget* parent, ControllerSettingsWindow* dialog, u32 port)
 	: QWidget(parent)
 	, m_dialog(dialog)
 	, m_config_section(fmt::format("Pad{}", port + 1))
@@ -325,7 +325,7 @@ ControllerMacroEditWidget::ControllerMacroEditWidget(ControllerMacroWidget* pare
 {
 	m_ui.setupUi(this);
 
-	ControllerSettingsDialog* dialog = m_bwidget->getDialog();
+	ControllerSettingsWindow* dialog = m_bwidget->getDialog();
 	const std::string& section = m_bwidget->getConfigSection();
 	const Pad::ControllerInfo* cinfo = Pad::GetControllerInfo(m_bwidget->getControllerType());
 	if (!cinfo)
@@ -445,7 +445,7 @@ void ControllerMacroEditWidget::updateFrequencyText()
 
 void ControllerMacroEditWidget::updateBinds()
 {
-	ControllerSettingsDialog* dialog = m_bwidget->getDialog();
+	ControllerSettingsWindow* dialog = m_bwidget->getDialog();
 	const Pad::ControllerInfo* cinfo = Pad::GetControllerInfo(m_bwidget->getControllerType());
 	if (!cinfo)
 		return;
@@ -495,7 +495,7 @@ void ControllerMacroEditWidget::updateBinds()
 //////////////////////////////////////////////////////////////////////////
 
 ControllerCustomSettingsWidget::ControllerCustomSettingsWidget(std::span<const SettingInfo> settings, std::string config_section,
-	std::string config_prefix, const char* translation_ctx, ControllerSettingsDialog* dialog, QWidget* parent_widget)
+	std::string config_prefix, const char* translation_ctx, ControllerSettingsWindow* dialog, QWidget* parent_widget)
 	: QWidget(parent_widget)
 	, m_settings(settings)
 	, m_config_section(std::move(config_section))
@@ -912,7 +912,7 @@ ControllerBindingWidget_Base* ControllerBindingWidget_Guitar::createInstance(Con
 
 //////////////////////////////////////////////////////////////////////////
 
-USBDeviceWidget::USBDeviceWidget(QWidget* parent, ControllerSettingsDialog* dialog, u32 port)
+USBDeviceWidget::USBDeviceWidget(QWidget* parent, ControllerSettingsWindow* dialog, u32 port)
 	: QWidget(parent)
 	, m_dialog(dialog)
 	, m_config_section(fmt::format("USB{}", port + 1))

--- a/pcsx2-qt/Settings/ControllerBindingWidgets.h
+++ b/pcsx2-qt/Settings/ControllerBindingWidgets.h
@@ -29,7 +29,7 @@
 #include "ui_USBDeviceWidget.h"
 
 class InputBindingWidget;
-class ControllerSettingsDialog;
+class ControllerSettingsWindow;
 class ControllerCustomSettingsWidget;
 class ControllerMacroWidget;
 class ControllerMacroEditWidget;
@@ -42,12 +42,12 @@ class ControllerBindingWidget final : public QWidget
 	Q_OBJECT
 
 public:
-	ControllerBindingWidget(QWidget* parent, ControllerSettingsDialog* dialog, u32 port);
+	ControllerBindingWidget(QWidget* parent, ControllerSettingsWindow* dialog, u32 port);
 	~ControllerBindingWidget();
 
 	QIcon getIcon() const;
 
-	__fi ControllerSettingsDialog* getDialog() const { return m_dialog; }
+	__fi ControllerSettingsWindow* getDialog() const { return m_dialog; }
 	__fi const std::string& getConfigSection() const { return m_config_section; }
 	__fi Pad::ControllerType getControllerType() const { return m_controller_type; }
 	__fi u32 getPortNumber() const { return m_port_number; }
@@ -67,7 +67,7 @@ private:
 
 	Ui::ControllerBindingWidget m_ui;
 
-	ControllerSettingsDialog* m_dialog;
+	ControllerSettingsWindow* m_dialog;
 
 	std::string m_config_section;
 	Pad::ControllerType m_controller_type;
@@ -97,7 +97,7 @@ private:
 	void createWidgets(ControllerBindingWidget* parent);
 
 	Ui::ControllerMacroWidget m_ui;
-	ControllerSettingsDialog* m_dialog;
+	ControllerSettingsWindow* m_dialog;
 	std::array<ControllerMacroEditWidget*, NUM_MACROS> m_macros;
 };
 
@@ -142,7 +142,7 @@ class ControllerCustomSettingsWidget : public QWidget
 
 public:
 	ControllerCustomSettingsWidget(std::span<const SettingInfo> settings, std::string config_section, std::string config_prefix,
-		const char* translation_ctx, ControllerSettingsDialog* dialog, QWidget* parent_widget);
+		const char* translation_ctx, ControllerSettingsWindow* dialog, QWidget* parent_widget);
 	~ControllerCustomSettingsWidget();
 
 private Q_SLOTS:
@@ -154,7 +154,7 @@ private:
 	std::span<const SettingInfo> m_settings;
 	std::string m_config_section;
 	std::string m_config_prefix;
-	ControllerSettingsDialog* m_dialog;
+	ControllerSettingsWindow* m_dialog;
 };
 
 //////////////////////////////////////////////////////////////////////////
@@ -168,7 +168,7 @@ public:
 	ControllerBindingWidget_Base(ControllerBindingWidget* parent);
 	virtual ~ControllerBindingWidget_Base();
 
-	__fi ControllerSettingsDialog* getDialog() const { return static_cast<ControllerBindingWidget*>(parent())->getDialog(); }
+	__fi ControllerSettingsWindow* getDialog() const { return static_cast<ControllerBindingWidget*>(parent())->getDialog(); }
 	__fi const std::string& getConfigSection() const { return static_cast<ControllerBindingWidget*>(parent())->getConfigSection(); }
 	__fi Pad::ControllerType getControllerType() const { return static_cast<ControllerBindingWidget*>(parent())->getControllerType(); }
 	__fi u32 getPortNumber() const { return static_cast<ControllerBindingWidget*>(parent())->getPortNumber(); }
@@ -218,12 +218,12 @@ class USBDeviceWidget final : public QWidget
 	Q_OBJECT
 
 public:
-	USBDeviceWidget(QWidget* parent, ControllerSettingsDialog* dialog, u32 port);
+	USBDeviceWidget(QWidget* parent, ControllerSettingsWindow* dialog, u32 port);
 	~USBDeviceWidget();
 
 	QIcon getIcon() const;
 
-	__fi ControllerSettingsDialog* getDialog() const { return m_dialog; }
+	__fi ControllerSettingsWindow* getDialog() const { return m_dialog; }
 	__fi const std::string& getConfigSection() const { return m_config_section; }
 	__fi const std::string& getDeviceType() const { return m_device_type; }
 	__fi u32 getPortNumber() const { return m_port_number; }
@@ -244,7 +244,7 @@ private:
 
 	Ui::USBDeviceWidget m_ui;
 
-	ControllerSettingsDialog* m_dialog;
+	ControllerSettingsWindow* m_dialog;
 
 	std::string m_config_section;
 	std::string m_device_type;
@@ -263,7 +263,7 @@ public:
 	USBBindingWidget(USBDeviceWidget* parent);
 	~USBBindingWidget() override;
 
-	__fi ControllerSettingsDialog* getDialog() const { return static_cast<USBDeviceWidget*>(parent())->getDialog(); }
+	__fi ControllerSettingsWindow* getDialog() const { return static_cast<USBDeviceWidget*>(parent())->getDialog(); }
 	__fi const std::string& getConfigSection() const { return static_cast<USBDeviceWidget*>(parent())->getConfigSection(); }
 	__fi const std::string& getDeviceType() const { return static_cast<USBDeviceWidget*>(parent())->getDeviceType(); }
 	__fi u32 getPortNumber() const { return static_cast<USBDeviceWidget*>(parent())->getPortNumber(); }

--- a/pcsx2-qt/Settings/ControllerGlobalSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/ControllerGlobalSettingsWidget.cpp
@@ -16,7 +16,7 @@
 #include "PrecompiledHeader.h"
 
 #include "Settings/ControllerGlobalSettingsWidget.h"
-#include "Settings/ControllerSettingsDialog.h"
+#include "Settings/ControllerSettingsWindow.h"
 #include "Settings/ControllerSettingWidgetBinder.h"
 #include "QtUtils.h"
 #include "SettingWidgetBinder.h"
@@ -24,7 +24,7 @@
 #include "pcsx2/Input/InputManager.h"
 #include "pcsx2/Input/SDLInputSource.h"
 
-ControllerGlobalSettingsWidget::ControllerGlobalSettingsWidget(QWidget* parent, ControllerSettingsDialog* dialog)
+ControllerGlobalSettingsWidget::ControllerGlobalSettingsWidget(QWidget* parent, ControllerSettingsWindow* dialog)
 	: QWidget(parent)
 	, m_dialog(dialog)
 {
@@ -132,7 +132,7 @@ void ControllerGlobalSettingsWidget::mouseSettingsClicked()
 	dialog.exec();
 }
 
-ControllerLEDSettingsDialog::ControllerLEDSettingsDialog(QWidget* parent, ControllerSettingsDialog* dialog)
+ControllerLEDSettingsDialog::ControllerLEDSettingsDialog(QWidget* parent, ControllerSettingsWindow* dialog)
 	: QDialog(parent)
 	, m_dialog(dialog)
 {
@@ -159,7 +159,7 @@ void ControllerLEDSettingsDialog::linkButton(ColorPickerButton* button, u32 play
 	});
 }
 
-ControllerMouseSettingsDialog::ControllerMouseSettingsDialog(QWidget* parent, ControllerSettingsDialog* dialog)
+ControllerMouseSettingsDialog::ControllerMouseSettingsDialog(QWidget* parent, ControllerSettingsWindow* dialog)
 	: QDialog(parent)
 {
 	m_ui.setupUi(this);

--- a/pcsx2-qt/Settings/ControllerGlobalSettingsWidget.h
+++ b/pcsx2-qt/Settings/ControllerGlobalSettingsWidget.h
@@ -26,14 +26,14 @@
 #include "ui_ControllerLEDSettingsDialog.h"
 #include "ui_ControllerMouseSettingsDialog.h"
 
-class ControllerSettingsDialog;
+class ControllerSettingsWindow;
 
 class ControllerGlobalSettingsWidget : public QWidget
 {
 	Q_OBJECT
 
 public:
-	ControllerGlobalSettingsWidget(QWidget* parent, ControllerSettingsDialog* dialog);
+	ControllerGlobalSettingsWidget(QWidget* parent, ControllerSettingsWindow* dialog);
 	~ControllerGlobalSettingsWidget();
 
 	void addDeviceToList(const QString& identifier, const QString& name);
@@ -49,7 +49,7 @@ private Q_SLOTS:
 
 private:
 	Ui::ControllerGlobalSettingsWidget m_ui;
-	ControllerSettingsDialog* m_dialog;
+	ControllerSettingsWindow* m_dialog;
 };
 
 class ControllerLEDSettingsDialog : public QDialog
@@ -57,14 +57,14 @@ class ControllerLEDSettingsDialog : public QDialog
 	Q_OBJECT
 
 public:
-	ControllerLEDSettingsDialog(QWidget* parent, ControllerSettingsDialog* dialog);
+	ControllerLEDSettingsDialog(QWidget* parent, ControllerSettingsWindow* dialog);
 	~ControllerLEDSettingsDialog();
 
 private:
 	void linkButton(ColorPickerButton* button, u32 player_id);
 
 	Ui::ControllerLEDSettingsDialog m_ui;
-	ControllerSettingsDialog* m_dialog;
+	ControllerSettingsWindow* m_dialog;
 };
 
 class ControllerMouseSettingsDialog : public QDialog
@@ -72,7 +72,7 @@ class ControllerMouseSettingsDialog : public QDialog
 	Q_OBJECT
 
 public:
-	ControllerMouseSettingsDialog(QWidget* parent, ControllerSettingsDialog* dialog);
+	ControllerMouseSettingsDialog(QWidget* parent, ControllerSettingsWindow* dialog);
 	~ControllerMouseSettingsDialog();
 
 private:

--- a/pcsx2-qt/Settings/ControllerSettingsWindow.cpp
+++ b/pcsx2-qt/Settings/ControllerSettingsWindow.cpp
@@ -1,5 +1,5 @@
 /*  PCSX2 - PS2 Emulator for PCs
- *  Copyright (C) 2002-2022  PCSX2 Dev Team
+ *  Copyright (C) 2002-2023 PCSX2 Dev Team
  *
  *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU Lesser General Public License as published by the Free Software Found-
@@ -16,7 +16,7 @@
 #include "PrecompiledHeader.h"
 
 #include "QtHost.h"
-#include "Settings/ControllerSettingsDialog.h"
+#include "Settings/ControllerSettingsWindow.h"
 #include "Settings/ControllerGlobalSettingsWidget.h"
 #include "Settings/ControllerBindingWidgets.h"
 #include "Settings/HotkeySettingsWidget.h"
@@ -36,8 +36,8 @@
 
 static constexpr const std::array<char, 4> s_mtap_slot_names = {{'A', 'B', 'C', 'D'}};
 
-ControllerSettingsDialog::ControllerSettingsDialog(QWidget* parent /* = nullptr */)
-	: QDialog(parent)
+ControllerSettingsWindow::ControllerSettingsWindow()
+	: QWidget(nullptr)
 {
 	m_ui.setupUi(this);
 
@@ -47,27 +47,27 @@ ControllerSettingsDialog::ControllerSettingsDialog(QWidget* parent /* = nullptr 
 	createWidgets();
 
 	m_ui.settingsCategory->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Minimum);
-	connect(m_ui.settingsCategory, &QListWidget::currentRowChanged, this, &ControllerSettingsDialog::onCategoryCurrentRowChanged);
-	connect(m_ui.currentProfile, &QComboBox::currentIndexChanged, this, &ControllerSettingsDialog::onCurrentProfileChanged);
-	connect(m_ui.buttonBox, &QDialogButtonBox::rejected, this, &ControllerSettingsDialog::close);
-	connect(m_ui.newProfile, &QPushButton::clicked, this, &ControllerSettingsDialog::onNewProfileClicked);
-	connect(m_ui.loadProfile, &QPushButton::clicked, this, &ControllerSettingsDialog::onLoadProfileClicked);
-	connect(m_ui.deleteProfile, &QPushButton::clicked, this, &ControllerSettingsDialog::onDeleteProfileClicked);
-	connect(m_ui.restoreDefaults, &QPushButton::clicked, this, &ControllerSettingsDialog::onRestoreDefaultsClicked);
+	connect(m_ui.settingsCategory, &QListWidget::currentRowChanged, this, &ControllerSettingsWindow::onCategoryCurrentRowChanged);
+	connect(m_ui.currentProfile, &QComboBox::currentIndexChanged, this, &ControllerSettingsWindow::onCurrentProfileChanged);
+	connect(m_ui.buttonBox, &QDialogButtonBox::rejected, this, &ControllerSettingsWindow::close);
+	connect(m_ui.newProfile, &QPushButton::clicked, this, &ControllerSettingsWindow::onNewProfileClicked);
+	connect(m_ui.loadProfile, &QPushButton::clicked, this, &ControllerSettingsWindow::onLoadProfileClicked);
+	connect(m_ui.deleteProfile, &QPushButton::clicked, this, &ControllerSettingsWindow::onDeleteProfileClicked);
+	connect(m_ui.restoreDefaults, &QPushButton::clicked, this, &ControllerSettingsWindow::onRestoreDefaultsClicked);
 
-	connect(g_emu_thread, &EmuThread::onInputDevicesEnumerated, this, &ControllerSettingsDialog::onInputDevicesEnumerated);
-	connect(g_emu_thread, &EmuThread::onInputDeviceConnected, this, &ControllerSettingsDialog::onInputDeviceConnected);
-	connect(g_emu_thread, &EmuThread::onInputDeviceDisconnected, this, &ControllerSettingsDialog::onInputDeviceDisconnected);
-	connect(g_emu_thread, &EmuThread::onVibrationMotorsEnumerated, this, &ControllerSettingsDialog::onVibrationMotorsEnumerated);
+	connect(g_emu_thread, &EmuThread::onInputDevicesEnumerated, this, &ControllerSettingsWindow::onInputDevicesEnumerated);
+	connect(g_emu_thread, &EmuThread::onInputDeviceConnected, this, &ControllerSettingsWindow::onInputDeviceConnected);
+	connect(g_emu_thread, &EmuThread::onInputDeviceDisconnected, this, &ControllerSettingsWindow::onInputDeviceDisconnected);
+	connect(g_emu_thread, &EmuThread::onVibrationMotorsEnumerated, this, &ControllerSettingsWindow::onVibrationMotorsEnumerated);
 
 	// trigger a device enumeration to populate the device list
 	g_emu_thread->enumerateInputDevices();
 	g_emu_thread->enumerateVibrationMotors();
 }
 
-ControllerSettingsDialog::~ControllerSettingsDialog() = default;
+ControllerSettingsWindow::~ControllerSettingsWindow() = default;
 
-void ControllerSettingsDialog::setCategory(Category category)
+void ControllerSettingsWindow::setCategory(Category category)
 {
 	switch (category)
 	{
@@ -89,17 +89,17 @@ void ControllerSettingsDialog::setCategory(Category category)
 	}
 }
 
-void ControllerSettingsDialog::onCategoryCurrentRowChanged(int row)
+void ControllerSettingsWindow::onCategoryCurrentRowChanged(int row)
 {
 	m_ui.settingsContainer->setCurrentIndex(row);
 }
 
-void ControllerSettingsDialog::onCurrentProfileChanged(int index)
+void ControllerSettingsWindow::onCurrentProfileChanged(int index)
 {
 	switchProfile((index == 0) ? 0 : m_ui.currentProfile->itemText(index));
 }
 
-void ControllerSettingsDialog::onNewProfileClicked()
+void ControllerSettingsWindow::onNewProfileClicked()
 {
 	const QString profile_name(QInputDialog::getText(this, tr("Create Input Profile"), 
 	tr("Custom input profiles are used to override the Shared input profile for specific games.\n"
@@ -154,7 +154,7 @@ void ControllerSettingsDialog::onNewProfileClicked()
 	switchProfile(profile_name);
 }
 
-void ControllerSettingsDialog::onLoadProfileClicked()
+void ControllerSettingsWindow::onLoadProfileClicked()
 {
 	if (QMessageBox::question(this, tr("Load Input Profile"),
 			tr("Are you sure you want to load the input profile named '%1'?\n\n"
@@ -178,7 +178,7 @@ void ControllerSettingsDialog::onLoadProfileClicked()
 	switchProfile({});
 }
 
-void ControllerSettingsDialog::onDeleteProfileClicked()
+void ControllerSettingsWindow::onDeleteProfileClicked()
 {
 	if (QMessageBox::question(this, tr("Delete Input Profile"),
 			tr("Are you sure you want to delete the input profile named '%1'?\n\n"
@@ -200,7 +200,7 @@ void ControllerSettingsDialog::onDeleteProfileClicked()
 	switchProfile({});
 }
 
-void ControllerSettingsDialog::onRestoreDefaultsClicked()
+void ControllerSettingsWindow::onRestoreDefaultsClicked()
 {
 	if (QMessageBox::question(this, tr("Restore Defaults"),
 			tr("Are you sure you want to restore the default controller configuration?\n\n"
@@ -223,21 +223,21 @@ void ControllerSettingsDialog::onRestoreDefaultsClicked()
 	switchProfile({});
 }
 
-void ControllerSettingsDialog::onInputDevicesEnumerated(const QList<QPair<QString, QString>>& devices)
+void ControllerSettingsWindow::onInputDevicesEnumerated(const QList<QPair<QString, QString>>& devices)
 {
 	m_device_list = devices;
 	for (const QPair<QString, QString>& device : devices)
 		m_global_settings->addDeviceToList(device.first, device.second);
 }
 
-void ControllerSettingsDialog::onInputDeviceConnected(const QString& identifier, const QString& device_name)
+void ControllerSettingsWindow::onInputDeviceConnected(const QString& identifier, const QString& device_name)
 {
 	m_device_list.emplace_back(identifier, device_name);
 	m_global_settings->addDeviceToList(identifier, device_name);
 	g_emu_thread->enumerateVibrationMotors();
 }
 
-void ControllerSettingsDialog::onInputDeviceDisconnected(const QString& identifier)
+void ControllerSettingsWindow::onInputDeviceDisconnected(const QString& identifier)
 {
 	for (auto iter = m_device_list.begin(); iter != m_device_list.end(); ++iter)
 	{
@@ -252,7 +252,7 @@ void ControllerSettingsDialog::onInputDeviceDisconnected(const QString& identifi
 	g_emu_thread->enumerateVibrationMotors();
 }
 
-void ControllerSettingsDialog::onVibrationMotorsEnumerated(const QList<InputBindingKey>& motors)
+void ControllerSettingsWindow::onVibrationMotorsEnumerated(const QList<InputBindingKey>& motors)
 {
 	m_vibration_motors.clear();
 	m_vibration_motors.reserve(motors.size());
@@ -265,7 +265,7 @@ void ControllerSettingsDialog::onVibrationMotorsEnumerated(const QList<InputBind
 	}
 }
 
-bool ControllerSettingsDialog::getBoolValue(const char* section, const char* key, bool default_value) const
+bool ControllerSettingsWindow::getBoolValue(const char* section, const char* key, bool default_value) const
 {
 	if (m_profile_interface)
 		return m_profile_interface->GetBoolValue(section, key, default_value);
@@ -273,7 +273,7 @@ bool ControllerSettingsDialog::getBoolValue(const char* section, const char* key
 		return Host::GetBaseBoolSettingValue(section, key, default_value);
 }
 
-s32 ControllerSettingsDialog::getIntValue(const char* section, const char* key, s32 default_value) const
+s32 ControllerSettingsWindow::getIntValue(const char* section, const char* key, s32 default_value) const
 {
 	if (m_profile_interface)
 		return m_profile_interface->GetIntValue(section, key, default_value);
@@ -281,7 +281,7 @@ s32 ControllerSettingsDialog::getIntValue(const char* section, const char* key, 
 		return Host::GetBaseIntSettingValue(section, key, default_value);
 }
 
-std::string ControllerSettingsDialog::getStringValue(const char* section, const char* key, const char* default_value) const
+std::string ControllerSettingsWindow::getStringValue(const char* section, const char* key, const char* default_value) const
 {
 	std::string value;
 	if (m_profile_interface)
@@ -291,7 +291,7 @@ std::string ControllerSettingsDialog::getStringValue(const char* section, const 
 	return value;
 }
 
-void ControllerSettingsDialog::setBoolValue(const char* section, const char* key, bool value)
+void ControllerSettingsWindow::setBoolValue(const char* section, const char* key, bool value)
 {
 	if (m_profile_interface)
 	{
@@ -307,7 +307,7 @@ void ControllerSettingsDialog::setBoolValue(const char* section, const char* key
 	}
 }
 
-void ControllerSettingsDialog::setIntValue(const char* section, const char* key, s32 value)
+void ControllerSettingsWindow::setIntValue(const char* section, const char* key, s32 value)
 {
 	if (m_profile_interface)
 	{
@@ -323,7 +323,7 @@ void ControllerSettingsDialog::setIntValue(const char* section, const char* key,
 	}
 }
 
-void ControllerSettingsDialog::setStringValue(const char* section, const char* key, const char* value)
+void ControllerSettingsWindow::setStringValue(const char* section, const char* key, const char* value)
 {
 	if (m_profile_interface)
 	{
@@ -339,7 +339,7 @@ void ControllerSettingsDialog::setStringValue(const char* section, const char* k
 	}
 }
 
-void ControllerSettingsDialog::clearSettingValue(const char* section, const char* key)
+void ControllerSettingsWindow::clearSettingValue(const char* section, const char* key)
 {
 	if (m_profile_interface)
 	{
@@ -355,7 +355,7 @@ void ControllerSettingsDialog::clearSettingValue(const char* section, const char
 	}
 }
 
-void ControllerSettingsDialog::createWidgets()
+void ControllerSettingsWindow::createWidgets()
 {
 	QSignalBlocker sb(m_ui.settingsContainer);
 	QSignalBlocker sb2(m_ui.settingsCategory);
@@ -381,7 +381,7 @@ void ControllerSettingsDialog::createWidgets()
 		m_ui.settingsCategory->setCurrentRow(0);
 		m_global_settings = new ControllerGlobalSettingsWidget(m_ui.settingsContainer, this);
 		m_ui.settingsContainer->addWidget(m_global_settings);
-		connect(m_global_settings, &ControllerGlobalSettingsWidget::bindingSetupChanged, this, &ControllerSettingsDialog::createWidgets);
+		connect(m_global_settings, &ControllerGlobalSettingsWidget::bindingSetupChanged, this, &ControllerSettingsWindow::createWidgets);
 		for (const QPair<QString, QString>& dev : m_device_list)
 			m_global_settings->addDeviceToList(dev.first, dev.second);
 	}
@@ -448,7 +448,7 @@ void ControllerSettingsDialog::createWidgets()
 	m_ui.restoreDefaults->setEnabled(isEditingGlobalSettings());
 }
 
-void ControllerSettingsDialog::updateListDescription(u32 global_slot, ControllerBindingWidget* widget)
+void ControllerSettingsWindow::updateListDescription(u32 global_slot, ControllerBindingWidget* widget)
 {
 	for (int i = 0; i < m_ui.settingsCategory->count(); i++)
 	{
@@ -472,7 +472,7 @@ void ControllerSettingsDialog::updateListDescription(u32 global_slot, Controller
 	}
 }
 
-void ControllerSettingsDialog::updateListDescription(u32 port, USBDeviceWidget* widget)
+void ControllerSettingsWindow::updateListDescription(u32 port, USBDeviceWidget* widget)
 {
 	for (int i = 0; i < m_ui.settingsCategory->count(); i++)
 	{
@@ -490,7 +490,7 @@ void ControllerSettingsDialog::updateListDescription(u32 port, USBDeviceWidget* 
 	}
 }
 
-void ControllerSettingsDialog::refreshProfileList()
+void ControllerSettingsWindow::refreshProfileList()
 {
 	const std::vector<std::string> names = Pad::GetInputProfileNames();
 
@@ -510,7 +510,7 @@ void ControllerSettingsDialog::refreshProfileList()
 	}
 }
 
-void ControllerSettingsDialog::switchProfile(const QString& name)
+void ControllerSettingsWindow::switchProfile(const QString& name)
 {
 	QSignalBlocker sb(m_ui.currentProfile);
 

--- a/pcsx2-qt/Settings/ControllerSettingsWindow.h
+++ b/pcsx2-qt/Settings/ControllerSettingsWindow.h
@@ -1,5 +1,5 @@
 /*  PCSX2 - PS2 Emulator for PCs
- *  Copyright (C) 2002-2023  PCSX2 Dev Team
+ *  Copyright (C) 2002-2023 PCSX2 Dev Team
  *
  *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU Lesser General Public License as published by the Free Software Found-
@@ -14,7 +14,7 @@
  */
 
 #pragma once
-#include "ui_ControllerSettingsDialog.h"
+#include "ui_ControllerSettingsWindow.h"
 
 #include "pcsx2/Input/InputManager.h"
 #include "pcsx2/USB/USB.h"
@@ -23,7 +23,7 @@
 #include <QtCore/QPair>
 #include <QtCore/QString>
 #include <QtCore/QStringList>
-#include <QtWidgets/QDialog>
+#include <QtWidgets/QWidget>
 #include <array>
 #include <string>
 
@@ -34,7 +34,7 @@ class USBDeviceWidget;
 
 class SettingsInterface;
 
-class ControllerSettingsDialog final : public QDialog
+class ControllerSettingsWindow final : public QWidget
 {
 	Q_OBJECT
 
@@ -52,8 +52,8 @@ public:
 		MAX_PORTS = 8
 	};
 
-	ControllerSettingsDialog(QWidget* parent = nullptr);
-	~ControllerSettingsDialog();
+	ControllerSettingsWindow();
+	~ControllerSettingsWindow();
 
 	__fi HotkeySettingsWidget* getHotkeySettingsWidget() const { return m_hotkey_settings; }
 
@@ -101,7 +101,7 @@ private:
 	void refreshProfileList();
 	void switchProfile(const QString& name);
 
-	Ui::ControllerSettingsDialog m_ui;
+	Ui::ControllerSettingsWindow m_ui;
 
 	ControllerGlobalSettingsWidget* m_global_settings = nullptr;
 	std::array<ControllerBindingWidget*, MAX_PORTS> m_port_bindings{};

--- a/pcsx2-qt/Settings/ControllerSettingsWindow.ui
+++ b/pcsx2-qt/Settings/ControllerSettingsWindow.ui
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>ControllerSettingsDialog</class>
- <widget class="QDialog" name="ControllerSettingsDialog">
-  <property name="windowModality">
-   <enum>Qt::WindowModal</enum>
+ <class>ControllerSettingsWindow</class>
+ <widget class="QWidget" name="ControllerSettingsWindow">
+  <property name="windowIcon">
+   <iconset>
+    <normalon>:/icons/AppIcon64.png</normalon>
+   </iconset>
   </property>
   <property name="geometry">
    <rect>

--- a/pcsx2-qt/Settings/DEV9DnsHostDialog.cpp
+++ b/pcsx2-qt/Settings/DEV9DnsHostDialog.cpp
@@ -25,7 +25,7 @@
 #include "QtHost.h"
 #include "QtUtils.h"
 #include "SettingWidgetBinder.h"
-#include "SettingsDialog.h"
+#include "SettingsWindow.h"
 
 //Figure out lists
 //On export, we take list from settings (or are given it from the DEV9 panel)

--- a/pcsx2-qt/Settings/DEV9DnsHostDialog.h
+++ b/pcsx2-qt/Settings/DEV9DnsHostDialog.h
@@ -23,7 +23,7 @@
 
 #include "DEV9UiCommon.h"
 
-class SettingsDialog;
+class SettingsWindow;
 
 class DEV9DnsHostDialog : public QDialog
 {

--- a/pcsx2-qt/Settings/DEV9SettingsWidget.cpp
+++ b/pcsx2-qt/Settings/DEV9SettingsWidget.cpp
@@ -30,7 +30,7 @@
 #include "QtHost.h"
 #include "QtUtils.h"
 #include "SettingWidgetBinder.h"
-#include "SettingsDialog.h"
+#include "SettingsWindow.h"
 
 #include "HddCreateQt.h"
 
@@ -58,7 +58,7 @@ static const char* s_dns_name[] = {
 
 using PacketReader::IP::IP_Address;
 
-DEV9SettingsWidget::DEV9SettingsWidget(SettingsDialog* dialog, QWidget* parent)
+DEV9SettingsWidget::DEV9SettingsWidget(SettingsWindow* dialog, QWidget* parent)
 	: QWidget(parent)
 	, m_dialog{dialog}
 {

--- a/pcsx2-qt/Settings/DEV9SettingsWidget.h
+++ b/pcsx2-qt/Settings/DEV9SettingsWidget.h
@@ -24,7 +24,7 @@
 #include "DEV9DnsHostDialog.h"
 #include "DEV9/net.h"
 
-class SettingsDialog;
+class SettingsWindow;
 
 class DEV9SettingsWidget : public QWidget
 {
@@ -54,7 +54,7 @@ private Q_SLOTS:
 	void onHddCreateClicked();
 
 public:
-	DEV9SettingsWidget(SettingsDialog* dialog, QWidget* parent);
+	DEV9SettingsWidget(SettingsWindow* dialog, QWidget* parent);
 	~DEV9SettingsWidget();
 
 protected:
@@ -73,7 +73,7 @@ private:
 	void UpdateHddSizeUIEnabled();
 	void UpdateHddSizeUIValues();
 
-	SettingsDialog* m_dialog;
+	SettingsWindow* m_dialog;
 
 	Ui::DEV9SettingsWidget m_ui;
 

--- a/pcsx2-qt/Settings/DebugSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/DebugSettingsWidget.cpp
@@ -18,13 +18,13 @@
 #include "DebugSettingsWidget.h"
 #include "QtUtils.h"
 #include "SettingWidgetBinder.h"
-#include "SettingsDialog.h"
+#include "SettingsWindow.h"
 
 #include "pcsx2/Host.h"
 
 #include <QtWidgets/QMessageBox>
 
-DebugSettingsWidget::DebugSettingsWidget(SettingsDialog* dialog, QWidget* parent)
+DebugSettingsWidget::DebugSettingsWidget(SettingsWindow* dialog, QWidget* parent)
 	: QWidget(parent)
 	, m_dialog(dialog)
 {

--- a/pcsx2-qt/Settings/DebugSettingsWidget.h
+++ b/pcsx2-qt/Settings/DebugSettingsWidget.h
@@ -21,21 +21,21 @@
 
 enum class GSRendererType : s8;
 
-class SettingsDialog;
+class SettingsWindow;
 
 class DebugSettingsWidget : public QWidget
 {
 	Q_OBJECT
 
 public:
-	DebugSettingsWidget(SettingsDialog* dialog, QWidget* parent);
+	DebugSettingsWidget(SettingsWindow* dialog, QWidget* parent);
 	~DebugSettingsWidget();
 
 private Q_SLOTS:
 	void onDrawDumpingChanged();
 
 private:
-	SettingsDialog* m_dialog;
+	SettingsWindow* m_dialog;
 
 	Ui::DebugSettingsWidget m_ui;
 };

--- a/pcsx2-qt/Settings/EmulationSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/EmulationSettingsWidget.cpp
@@ -24,7 +24,7 @@
 #include "EmulationSettingsWidget.h"
 #include "QtUtils.h"
 #include "SettingWidgetBinder.h"
-#include "SettingsDialog.h"
+#include "SettingsWindow.h"
 
 static constexpr int MINIMUM_EE_CYCLE_RATE = -3;
 static constexpr int MAXIMUM_EE_CYCLE_RATE = 3;
@@ -32,7 +32,7 @@ static constexpr int DEFAULT_EE_CYCLE_RATE = 0;
 static constexpr int DEFAULT_EE_CYCLE_SKIP = 0;
 static constexpr u32 DEFAULT_FRAME_LATENCY = 2;
 
-EmulationSettingsWidget::EmulationSettingsWidget(SettingsDialog* dialog, QWidget* parent)
+EmulationSettingsWidget::EmulationSettingsWidget(SettingsWindow* dialog, QWidget* parent)
 	: QWidget(parent)
 	, m_dialog(dialog)
 {

--- a/pcsx2-qt/Settings/EmulationSettingsWidget.h
+++ b/pcsx2-qt/Settings/EmulationSettingsWidget.h
@@ -19,14 +19,14 @@
 
 #include "ui_EmulationSettingsWidget.h"
 
-class SettingsDialog;
+class SettingsWindow;
 
 class EmulationSettingsWidget : public QWidget
 {
 	Q_OBJECT
 
 public:
-	EmulationSettingsWidget(SettingsDialog* dialog, QWidget* parent);
+	EmulationSettingsWidget(SettingsWindow* dialog, QWidget* parent);
 	~EmulationSettingsWidget();
 
 private Q_SLOTS:
@@ -37,7 +37,7 @@ private:
 	void handleSpeedComboChange(QComboBox* cb, const char* section, const char* key);
 	void updateOptimalFramePacing();
 
-	SettingsDialog* m_dialog;
+	SettingsWindow* m_dialog;
 
 	Ui::EmulationSettingsWidget m_ui;
 };

--- a/pcsx2-qt/Settings/FolderSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/FolderSettingsWidget.cpp
@@ -20,9 +20,9 @@
 
 #include "FolderSettingsWidget.h"
 #include "SettingWidgetBinder.h"
-#include "SettingsDialog.h"
+#include "SettingsWindow.h"
 
-FolderSettingsWidget::FolderSettingsWidget(SettingsDialog* dialog, QWidget* parent)
+FolderSettingsWidget::FolderSettingsWidget(SettingsWindow* dialog, QWidget* parent)
 	: QWidget(parent)
 {
 	SettingsInterface* sif = dialog->getSettingsInterface();

--- a/pcsx2-qt/Settings/FolderSettingsWidget.h
+++ b/pcsx2-qt/Settings/FolderSettingsWidget.h
@@ -19,14 +19,14 @@
 
 #include "ui_FolderSettingsWidget.h"
 
-class SettingsDialog;
+class SettingsWindow;
 
 class FolderSettingsWidget : public QWidget
 {
 	Q_OBJECT
 
 public:
-	FolderSettingsWidget(SettingsDialog* dialog, QWidget* parent);
+	FolderSettingsWidget(SettingsWindow* dialog, QWidget* parent);
 	~FolderSettingsWidget();
 
 private:

--- a/pcsx2-qt/Settings/GameCheatSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GameCheatSettingsWidget.cpp
@@ -20,14 +20,14 @@
 #include "QtUtils.h"
 #include "SettingWidgetBinder.h"
 #include "Settings/GameCheatSettingsWidget.h"
-#include "Settings/SettingsDialog.h"
+#include "Settings/SettingsWindow.h"
 
 #include "pcsx2/GameList.h"
 #include "pcsx2/Patch.h"
 
 #include "common/HeterogeneousContainers.h"
 
-GameCheatSettingsWidget::GameCheatSettingsWidget(SettingsDialog* dialog, QWidget* parent)
+GameCheatSettingsWidget::GameCheatSettingsWidget(SettingsWindow* dialog, QWidget* parent)
 	: m_dialog(dialog)
 {
 	m_ui.setupUi(this);

--- a/pcsx2-qt/Settings/GameCheatSettingsWidget.h
+++ b/pcsx2-qt/Settings/GameCheatSettingsWidget.h
@@ -32,14 +32,14 @@ namespace GameList
 	struct Entry;
 }
 
-class SettingsDialog;
+class SettingsWindow;
 
 class GameCheatSettingsWidget : public QWidget
 {
 	Q_OBJECT
 
 public:
-	GameCheatSettingsWidget(SettingsDialog* dialog, QWidget* parent);
+	GameCheatSettingsWidget(SettingsWindow* dialog, QWidget* parent);
 	~GameCheatSettingsWidget();
 
 private Q_SLOTS:
@@ -57,7 +57,7 @@ private:
 	void reloadList();
 
 	Ui::GameCheatSettingsWidget m_ui;
-	SettingsDialog* m_dialog;
+	SettingsWindow* m_dialog;
 
 	UnorderedStringMap<QTreeWidgetItem*> m_parent_map;
 	std::vector<Patch::PatchInfo> m_patches;

--- a/pcsx2-qt/Settings/GameFixSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GameFixSettingsWidget.cpp
@@ -22,9 +22,9 @@
 #include "QtHost.h"
 #include "QtUtils.h"
 #include "SettingWidgetBinder.h"
-#include "SettingsDialog.h"
+#include "SettingsWindow.h"
 
-GameFixSettingsWidget::GameFixSettingsWidget(SettingsDialog* dialog, QWidget* parent)
+GameFixSettingsWidget::GameFixSettingsWidget(SettingsWindow* dialog, QWidget* parent)
 	: QWidget(parent)
 {
 	SettingsInterface* sif = dialog->getSettingsInterface();

--- a/pcsx2-qt/Settings/GameFixSettingsWidget.h
+++ b/pcsx2-qt/Settings/GameFixSettingsWidget.h
@@ -19,14 +19,14 @@
 
 #include "ui_GameFixSettingsWidget.h"
 
-class SettingsDialog;
+class SettingsWindow;
 
 class GameFixSettingsWidget : public QWidget
 {
 	Q_OBJECT
 
 public:
-	GameFixSettingsWidget(SettingsDialog* dialog, QWidget* parent);
+	GameFixSettingsWidget(SettingsWindow* dialog, QWidget* parent);
 	~GameFixSettingsWidget();
 
 private:

--- a/pcsx2-qt/Settings/GameListSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GameListSettingsWidget.cpp
@@ -31,7 +31,7 @@
 #include "QtHost.h"
 #include "QtUtils.h"
 
-GameListSettingsWidget::GameListSettingsWidget(SettingsDialog* dialog, QWidget* parent)
+GameListSettingsWidget::GameListSettingsWidget(SettingsWindow* dialog, QWidget* parent)
 	: QWidget(parent)
 {
 	m_ui.setupUi(this);

--- a/pcsx2-qt/Settings/GameListSettingsWidget.h
+++ b/pcsx2-qt/Settings/GameListSettingsWidget.h
@@ -19,14 +19,14 @@
 
 #include "ui_GameListSettingsWidget.h"
 
-class SettingsDialog;
+class SettingsWindow;
 
 class GameListSettingsWidget : public QWidget
 {
 	Q_OBJECT
 
 public:
-	GameListSettingsWidget(SettingsDialog* dialog, QWidget* parent);
+	GameListSettingsWidget(SettingsWindow* dialog, QWidget* parent);
 	~GameListSettingsWidget();
 
 	bool addExcludedPath(const std::string& path);

--- a/pcsx2-qt/Settings/GamePatchSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GamePatchSettingsWidget.cpp
@@ -19,7 +19,7 @@
 #include "QtHost.h"
 #include "QtUtils.h"
 #include "Settings/GamePatchSettingsWidget.h"
-#include "Settings/SettingsDialog.h"
+#include "Settings/SettingsWindow.h"
 
 #include "pcsx2/GameList.h"
 #include "pcsx2/Patch.h"
@@ -29,7 +29,7 @@
 #include <algorithm>
 
 GamePatchDetailsWidget::GamePatchDetailsWidget(std::string name, const std::string& author,
-	const std::string& description, bool enabled, SettingsDialog* dialog, QWidget* parent)
+	const std::string& description, bool enabled, SettingsWindow* dialog, QWidget* parent)
 	: QWidget(parent)
 	, m_dialog(dialog)
 	, m_name(name)
@@ -61,7 +61,7 @@ void GamePatchDetailsWidget::onEnabledStateChanged(int state)
 	g_emu_thread->reloadGameSettings();
 }
 
-GamePatchSettingsWidget::GamePatchSettingsWidget(SettingsDialog* dialog, QWidget* parent)
+GamePatchSettingsWidget::GamePatchSettingsWidget(SettingsWindow* dialog, QWidget* parent)
 	: m_dialog(dialog)
 {
 	m_ui.setupUi(this);

--- a/pcsx2-qt/Settings/GamePatchSettingsWidget.h
+++ b/pcsx2-qt/Settings/GamePatchSettingsWidget.h
@@ -27,7 +27,7 @@ namespace GameList
 	struct Entry;
 }
 
-class SettingsDialog;
+class SettingsWindow;
 
 class GamePatchDetailsWidget : public QWidget
 {
@@ -35,7 +35,7 @@ class GamePatchDetailsWidget : public QWidget
 
 public:
 	GamePatchDetailsWidget(std::string name, const std::string& author, const std::string& description, bool enabled,
-		SettingsDialog* dialog, QWidget* parent);
+		SettingsWindow* dialog, QWidget* parent);
 	~GamePatchDetailsWidget();
 
 private Q_SLOTS:
@@ -43,7 +43,7 @@ private Q_SLOTS:
 
 private:
 	Ui::GamePatchDetailsWidget m_ui;
-	SettingsDialog* m_dialog;
+	SettingsWindow* m_dialog;
 	std::string m_name;
 };
 
@@ -52,7 +52,7 @@ class GamePatchSettingsWidget : public QWidget
 	Q_OBJECT
 
 public:
-	GamePatchSettingsWidget(SettingsDialog* dialog, QWidget* parent);
+	GamePatchSettingsWidget(SettingsWindow* dialog, QWidget* parent);
 	~GamePatchSettingsWidget();
 
 private Q_SLOTS:
@@ -62,5 +62,5 @@ private:
 	void reloadList();
 
 	Ui::GamePatchSettingsWidget m_ui;
-	SettingsDialog* m_dialog;
+	SettingsWindow* m_dialog;
 };

--- a/pcsx2-qt/Settings/GameSummaryWidget.cpp
+++ b/pcsx2-qt/Settings/GameSummaryWidget.cpp
@@ -17,7 +17,7 @@
 
 #include "pcsx2/SIO/Pad/Pad.h"
 #include "GameSummaryWidget.h"
-#include "SettingsDialog.h"
+#include "SettingsWindow.h"
 #include "MainWindow.h"
 #include "QtHost.h"
 #include "QtProgressCallback.h"
@@ -38,7 +38,7 @@
 #include <QtWidgets/QFileDialog>
 #include <QtWidgets/QMessageBox>
 
-GameSummaryWidget::GameSummaryWidget(const GameList::Entry* entry, SettingsDialog* dialog, QWidget* parent)
+GameSummaryWidget::GameSummaryWidget(const GameList::Entry* entry, SettingsWindow* dialog, QWidget* parent)
 	: m_dialog(dialog)
 {
 	m_ui.setupUi(this);

--- a/pcsx2-qt/Settings/GameSummaryWidget.h
+++ b/pcsx2-qt/Settings/GameSummaryWidget.h
@@ -24,14 +24,14 @@ namespace GameList
 	struct Entry;
 }
 
-class SettingsDialog;
+class SettingsWindow;
 
 class GameSummaryWidget : public QWidget
 {
 	Q_OBJECT
 
 public:
-	GameSummaryWidget(const GameList::Entry* entry, SettingsDialog* dialog, QWidget* parent);
+	GameSummaryWidget(const GameList::Entry* entry, SettingsWindow* dialog, QWidget* parent);
 	~GameSummaryWidget();
 
 private Q_SLOTS:
@@ -53,7 +53,7 @@ private:
 	void setCustomRegion(int region);
 
 	Ui::GameSummaryWidget m_ui;
-	SettingsDialog* m_dialog;
+	SettingsWindow* m_dialog;
 	std::string m_entry_path;
 	std::string m_redump_search_keyword;
 };

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -18,7 +18,7 @@
 #include "GraphicsSettingsWidget.h"
 #include "QtUtils.h"
 #include "SettingWidgetBinder.h"
-#include "SettingsDialog.h"
+#include "SettingsWindow.h"
 #include <QtWidgets/QMessageBox>
 
 #include "pcsx2/Host.h"
@@ -67,7 +67,7 @@ static constexpr int DEFAULT_INTERLACE_MODE = 0;
 static constexpr int DEFAULT_TV_SHADER_MODE = 0;
 static constexpr int DEFAULT_CAS_SHARPNESS = 50;
 
-GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsDialog* dialog, QWidget* parent)
+GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* dialog, QWidget* parent)
 	: QWidget(parent)
 	, m_dialog(dialog)
 {

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.h
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.h
@@ -21,14 +21,14 @@
 
 enum class GSRendererType : s8;
 
-class SettingsDialog;
+class SettingsWindow;
 
 class GraphicsSettingsWidget : public QWidget
 {
 	Q_OBJECT
 
 public:
-	GraphicsSettingsWidget(SettingsDialog* dialog, QWidget* parent);
+	GraphicsSettingsWidget(SettingsWindow* dialog, QWidget* parent);
 	~GraphicsSettingsWidget();
 
 Q_SIGNALS:
@@ -56,7 +56,7 @@ private:
 	void updateRendererDependentOptions();
 	void resetManualHardwareFixes();
 
-	SettingsDialog* m_dialog;
+	SettingsWindow* m_dialog;
 
 	Ui::GraphicsSettingsWidget m_ui;
 

--- a/pcsx2-qt/Settings/HotkeySettingsWidget.cpp
+++ b/pcsx2-qt/Settings/HotkeySettingsWidget.cpp
@@ -16,7 +16,7 @@
 #include "PrecompiledHeader.h"
 
 #include "Settings/HotkeySettingsWidget.h"
-#include "Settings/ControllerSettingsDialog.h"
+#include "Settings/ControllerSettingsWindow.h"
 #include "InputBindingWidget.h"
 #include "QtUtils.h"
 #include "SettingWidgetBinder.h"
@@ -29,7 +29,7 @@
 #include <QtWidgets/QScrollArea>
 #include <QtWidgets/QVBoxLayout>
 
-HotkeySettingsWidget::HotkeySettingsWidget(QWidget* parent, ControllerSettingsDialog* dialog)
+HotkeySettingsWidget::HotkeySettingsWidget(QWidget* parent, ControllerSettingsWindow* dialog)
 	: QWidget(parent)
 	, m_dialog(dialog)
 {

--- a/pcsx2-qt/Settings/HotkeySettingsWidget.h
+++ b/pcsx2-qt/Settings/HotkeySettingsWidget.h
@@ -24,21 +24,21 @@ class QScrollArea;
 class QGridLayout;
 class QVBoxLayout;
 
-class ControllerSettingsDialog;
+class ControllerSettingsWindow;
 
 class HotkeySettingsWidget : public QWidget
 {
 	Q_OBJECT
 
 public:
-	HotkeySettingsWidget(QWidget* parent, ControllerSettingsDialog* dialog);
+	HotkeySettingsWidget(QWidget* parent, ControllerSettingsWindow* dialog);
 	~HotkeySettingsWidget();
 
 private:
 	void createUi();
 	void createButtons();
 
-	ControllerSettingsDialog* m_dialog;
+	ControllerSettingsWindow* m_dialog;
 	QScrollArea* m_scroll_area = nullptr;
 	QWidget* m_container = nullptr;
 	QVBoxLayout* m_layout = nullptr;

--- a/pcsx2-qt/Settings/InputBindingWidget.cpp
+++ b/pcsx2-qt/Settings/InputBindingWidget.cpp
@@ -29,7 +29,7 @@
 
 #include "QtHost.h"
 #include "QtUtils.h"
-#include "Settings/ControllerSettingsDialog.h"
+#include "Settings/ControllerSettingsWindow.h"
 #include "Settings/InputBindingDialog.h"
 #include "Settings/InputBindingWidget.h"
 
@@ -416,7 +416,7 @@ InputVibrationBindingWidget::InputVibrationBindingWidget(QWidget* parent)
 }
 
 InputVibrationBindingWidget::InputVibrationBindingWidget(
-	QWidget* parent, ControllerSettingsDialog* dialog, std::string section_name, std::string key_name)
+	QWidget* parent, ControllerSettingsWindow* dialog, std::string section_name, std::string key_name)
 {
 	setMinimumWidth(225);
 	setMaximumWidth(225);
@@ -430,7 +430,7 @@ InputVibrationBindingWidget::~InputVibrationBindingWidget()
 {
 }
 
-void InputVibrationBindingWidget::setKey(ControllerSettingsDialog* dialog, std::string section_name, std::string key_name)
+void InputVibrationBindingWidget::setKey(ControllerSettingsWindow* dialog, std::string section_name, std::string key_name)
 {
 	m_dialog = dialog;
 	m_section_name = std::move(section_name);

--- a/pcsx2-qt/Settings/InputBindingWidget.h
+++ b/pcsx2-qt/Settings/InputBindingWidget.h
@@ -25,7 +25,7 @@
 
 class QTimer;
 
-class ControllerSettingsDialog;
+class ControllerSettingsWindow;
 class SettingsInterface;
 
 class InputBindingWidget : public QPushButton
@@ -92,10 +92,10 @@ class InputVibrationBindingWidget : public QPushButton
 
 public:
 	InputVibrationBindingWidget(QWidget* parent);
-	InputVibrationBindingWidget(QWidget* parent, ControllerSettingsDialog* dialog, std::string section_name, std::string key_name);
+	InputVibrationBindingWidget(QWidget* parent, ControllerSettingsWindow* dialog, std::string section_name, std::string key_name);
 	~InputVibrationBindingWidget();
 
-	void setKey(ControllerSettingsDialog* dialog, std::string section_name, std::string key_name);
+	void setKey(ControllerSettingsWindow* dialog, std::string section_name, std::string key_name);
 
 public Q_SLOTS:
 	void clearBinding();
@@ -111,5 +111,5 @@ private:
 	std::string m_key_name;
 	std::string m_binding;
 
-	ControllerSettingsDialog* m_dialog;
+	ControllerSettingsWindow* m_dialog;
 };

--- a/pcsx2-qt/Settings/InterfaceSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/InterfaceSettingsWidget.cpp
@@ -19,7 +19,7 @@
 #include "AutoUpdaterDialog.h"
 #include "MainWindow.h"
 #include "SettingWidgetBinder.h"
-#include "SettingsDialog.h"
+#include "SettingsWindow.h"
 #include "QtHost.h"
 
 const char* InterfaceSettingsWidget::THEME_NAMES[] = {
@@ -69,7 +69,7 @@ const char* InterfaceSettingsWidget::THEME_VALUES[] = {
 	"Custom",
 	nullptr};
 
-InterfaceSettingsWidget::InterfaceSettingsWidget(SettingsDialog* dialog, QWidget* parent)
+InterfaceSettingsWidget::InterfaceSettingsWidget(SettingsWindow* dialog, QWidget* parent)
 	: QWidget(parent)
 {
 	SettingsInterface* sif = dialog->getSettingsInterface();

--- a/pcsx2-qt/Settings/InterfaceSettingsWidget.h
+++ b/pcsx2-qt/Settings/InterfaceSettingsWidget.h
@@ -19,14 +19,14 @@
 
 #include "ui_InterfaceSettingsWidget.h"
 
-class SettingsDialog;
+class SettingsWindow;
 
 class InterfaceSettingsWidget : public QWidget
 {
 	Q_OBJECT
 
 public:
-	InterfaceSettingsWidget(SettingsDialog* dialog, QWidget* parent);
+	InterfaceSettingsWidget(SettingsWindow* dialog, QWidget* parent);
 	~InterfaceSettingsWidget();
 
 Q_SIGNALS:

--- a/pcsx2-qt/Settings/MemoryCardSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/MemoryCardSettingsWidget.cpp
@@ -30,7 +30,7 @@
 #include "QtHost.h"
 #include "QtUtils.h"
 #include "SettingWidgetBinder.h"
-#include "SettingsDialog.h"
+#include "SettingsWindow.h"
 
 #include "pcsx2/SIO/Memcard/MemoryCardFile.h"
 
@@ -41,7 +41,7 @@ static std::string getSlotFilenameKey(u32 slot)
 	return StringUtil::StdStringFromFormat("Slot%u_Filename", slot + 1);
 }
 
-MemoryCardSettingsWidget::MemoryCardSettingsWidget(SettingsDialog* dialog, QWidget* parent)
+MemoryCardSettingsWidget::MemoryCardSettingsWidget(SettingsWindow* dialog, QWidget* parent)
 	: QWidget(parent)
 	, m_dialog(dialog)
 {
@@ -442,7 +442,7 @@ void MemoryCardListWidget::mouseMoveEvent(QMouseEvent* event)
 	drag->exec(Qt::CopyAction);
 }
 
-void MemoryCardListWidget::refresh(SettingsDialog* dialog)
+void MemoryCardListWidget::refresh(SettingsWindow* dialog)
 {
 	clear();
 

--- a/pcsx2-qt/Settings/MemoryCardSettingsWidget.h
+++ b/pcsx2-qt/Settings/MemoryCardSettingsWidget.h
@@ -25,7 +25,7 @@
 #include <QtWidgets/QToolButton>
 #include <QtWidgets/QListWidget>
 
-class SettingsDialog;
+class SettingsWindow;
 
 struct AvailableMcdInfo;
 
@@ -36,7 +36,7 @@ public:
 	explicit MemoryCardListWidget(QWidget* parent);
 	~MemoryCardListWidget() override;
 
-	void refresh(SettingsDialog* dialog);
+	void refresh(SettingsWindow* dialog);
 
 protected:
 	void mousePressEvent(QMouseEvent* event) override;
@@ -78,7 +78,7 @@ public:
 		MAX_SLOTS = 2
 	};
 
-	MemoryCardSettingsWidget(SettingsDialog* dialog, QWidget* parent);
+	MemoryCardSettingsWidget(SettingsWindow* dialog, QWidget* parent);
 	~MemoryCardSettingsWidget();
 
 protected:
@@ -115,7 +115,7 @@ private:
 	void renameCard();
 	void convertCard();
 
-	SettingsDialog* m_dialog;
+	SettingsWindow* m_dialog;
 	Ui::MemoryCardSettingsWidget m_ui;
 
 	std::array<SlotGroup, MAX_SLOTS> m_slots;

--- a/pcsx2-qt/Settings/SettingsWindow.h
+++ b/pcsx2-qt/Settings/SettingsWindow.h
@@ -1,5 +1,5 @@
 /*  PCSX2 - PS2 Emulator for PCs
- *  Copyright (C) 2002-2022  PCSX2 Dev Team
+ *  Copyright (C) 2002-2023 PCSX2 Dev Team
  *
  *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU Lesser General Public License as published by the Free Software Found-
@@ -14,10 +14,10 @@
  */
 
 #pragma once
-#include "ui_SettingsDialog.h"
+#include "ui_SettingsWindow.h"
 #include <QtCore/QMap>
 #include <QtCore/QString>
-#include <QtWidgets/QDialog>
+#include <QtWidgets/QWidget>
 #include <array>
 #include <memory>
 
@@ -45,15 +45,15 @@ class AchievementSettingsWidget;
 class AdvancedSettingsWidget;
 class DebugSettingsWidget;
 
-class SettingsDialog final : public QDialog
+class SettingsWindow final : public QWidget
 {
 	Q_OBJECT
 
 public:
-	explicit SettingsDialog(QWidget* parent);
-	SettingsDialog(QWidget* parent, std::unique_ptr<INISettingsInterface> sif, const GameList::Entry* game, std::string serial,
+	explicit SettingsWindow();
+	SettingsWindow(std::unique_ptr<INISettingsInterface> sif, const GameList::Entry* game, std::string serial,
 		u32 disc_crc, QString filename = QString());
-	~SettingsDialog();
+	~SettingsWindow();
 
 	static void openGamePropertiesDialog(const GameList::Entry* game, const std::string_view& title, std::string serial, u32 disc_crc);
 
@@ -125,11 +125,11 @@ private:
 
 	void addWidget(QWidget* widget, QString title, QString icon, QString help_text);
 
-	SettingsDialog* reopen();
+	SettingsWindow* reopen();
 
 	std::unique_ptr<INISettingsInterface> m_sif;
 
-	Ui::SettingsDialog m_ui;
+	Ui::SettingsWindow m_ui;
 
 	InterfaceSettingsWidget* m_interface_settings = nullptr;
 	GameListSettingsWidget* m_game_list_settings = nullptr;

--- a/pcsx2-qt/Settings/SettingsWindow.ui
+++ b/pcsx2-qt/Settings/SettingsWindow.ui
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>SettingsDialog</class>
- <widget class="QDialog" name="SettingsDialog">
-  <property name="windowModality">
-   <enum>Qt::WindowModal</enum>
+ <class>SettingsWindow</class>
+ <widget class="QWidget" name="SettingsWindow">
+  <property name="windowIcon">
+   <iconset>
+    <normalon>:/icons/AppIcon64.png</normalon>
+   </iconset>
   </property>
   <property name="geometry">
    <rect>

--- a/pcsx2-qt/pcsx2-qt.vcxproj
+++ b/pcsx2-qt/pcsx2-qt.vcxproj
@@ -52,7 +52,7 @@
       <PreprocessorDefinitions>LZMA_API_STATIC;ENABLE_RAINTEGRATION;ENABLE_OPENGL;ENABLE_VULKAN;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions>QT_NO_EXCEPTIONS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <!-- Current Qt debug builds assert on RTTI. Remove this once we next build Qt. -->
-      <RuntimeTypeInfo Condition="$(Configuration.Contains(Clang)) And $(Configuration.Contains(Debug))">true</RuntimeTypeInfo>
+      <RuntimeTypeInfo Condition="$(Configuration.Contains(Debug))">true</RuntimeTypeInfo>
     </ClCompile>
     <Link>
       <AdditionalDependencies>$(QtEntryPointLib);%(AdditionalDependencies)</AdditionalDependencies>

--- a/pcsx2-qt/pcsx2-qt.vcxproj
+++ b/pcsx2-qt/pcsx2-qt.vcxproj
@@ -111,13 +111,13 @@
     <ClCompile Include="Settings\GameListSettingsWidget.cpp" />
     <ClCompile Include="Settings\GraphicsSettingsWidget.cpp" />
     <ClCompile Include="Settings\InterfaceSettingsWidget.cpp" />
-    <ClCompile Include="Settings\SettingsDialog.cpp" />
+    <ClCompile Include="Settings\SettingsWindow.cpp" />
     <ClCompile Include="Settings\AdvancedSettingsWidget.cpp" />
     <ClCompile Include="Settings\GameFixSettingsWidget.cpp" />
     <ClCompile Include="Settings\HotkeySettingsWidget.cpp" />
     <ClCompile Include="Settings\InputBindingDialog.cpp" />
     <ClCompile Include="Settings\InputBindingWidget.cpp" />
-    <ClCompile Include="Settings\ControllerSettingsDialog.cpp" />
+    <ClCompile Include="Settings\ControllerSettingsWindow.cpp" />
     <ClCompile Include="Settings\AudioSettingsWidget.cpp" />
     <ClCompile Include="Settings\MemoryCardConvertDialog.cpp" />
     <ClCompile Include="Settings\MemoryCardSettingsWidget.cpp" />
@@ -151,13 +151,13 @@
     <QtMoc Include="Settings\BIOSSettingsWidget.h" />
     <QtMoc Include="Settings\EmulationSettingsWidget.h" />
     <QtMoc Include="Settings\GraphicsSettingsWidget.h" />
-    <QtMoc Include="Settings\SettingsDialog.h" />
+    <QtMoc Include="Settings\SettingsWindow.h" />
     <QtMoc Include="Settings\AdvancedSettingsWidget.h" />
     <QtMoc Include="Settings\GameFixSettingsWidget.h" />
     <QtMoc Include="Settings\HotkeySettingsWidget.h" />
     <QtMoc Include="Settings\InputBindingDialog.h" />
     <QtMoc Include="Settings\InputBindingWidget.h" />
-    <QtMoc Include="Settings\ControllerSettingsDialog.h" />
+    <QtMoc Include="Settings\ControllerSettingsWindow.h" />
     <QtMoc Include="Settings\AudioSettingsWidget.h" />
     <QtMoc Include="Settings\MemoryCardConvertDialog.h" />
     <QtMoc Include="Settings\MemoryCardSettingsWidget.h" />
@@ -212,13 +212,13 @@
     <ClCompile Include="$(IntDir)Settings\moc_BIOSSettingsWidget.cpp" />
     <ClCompile Include="$(IntDir)Settings\moc_ControllerBindingWidgets.cpp" />
     <ClCompile Include="$(IntDir)Settings\moc_ControllerGlobalSettingsWidget.cpp" />
-    <ClCompile Include="$(IntDir)Settings\moc_ControllerSettingsDialog.cpp" />
+    <ClCompile Include="$(IntDir)Settings\moc_ControllerSettingsWindow.cpp" />
     <ClCompile Include="$(IntDir)Settings\moc_MemoryCardCreateDialog.cpp" />
     <ClCompile Include="$(IntDir)Settings\moc_EmulationSettingsWidget.cpp" />
     <ClCompile Include="$(IntDir)Settings\moc_GameListSettingsWidget.cpp" />
     <ClCompile Include="$(IntDir)Settings\moc_GraphicsSettingsWidget.cpp" />
     <ClCompile Include="$(IntDir)Settings\moc_InterfaceSettingsWidget.cpp" />
-    <ClCompile Include="$(IntDir)Settings\moc_SettingsDialog.cpp" />
+    <ClCompile Include="$(IntDir)Settings\moc_SettingsWindow.cpp" />
     <ClCompile Include="$(IntDir)Settings\moc_AdvancedSettingsWidget.cpp" />
     <ClCompile Include="$(IntDir)Settings\moc_GameCheatSettingsWidget.cpp" />
     <ClCompile Include="$(IntDir)Settings\moc_GameFixSettingsWidget.cpp" />
@@ -274,7 +274,7 @@
     <QtUi Include="GameList\GameListWidget.ui">
       <FileType>Document</FileType>
     </QtUi>
-    <QtUi Include="Settings\SettingsDialog.ui">
+    <QtUi Include="Settings\SettingsWindow.ui">
       <FileType>Document</FileType>
     </QtUi>
     <QtUi Include="Settings\GameListSettingsWidget.ui">
@@ -301,7 +301,7 @@
     <QtUi Include="Settings\InputBindingDialog.ui">
       <FileType>Document</FileType>
     </QtUi>
-    <QtUi Include="Settings\ControllerSettingsDialog.ui">
+    <QtUi Include="Settings\ControllerSettingsWindow.ui">
       <FileType>Document</FileType>
     </QtUi>
     <QtUi Include="Settings\ControllerBindingWidget_DualShock2.ui">

--- a/pcsx2-qt/pcsx2-qt.vcxproj.filters
+++ b/pcsx2-qt/pcsx2-qt.vcxproj.filters
@@ -66,7 +66,7 @@
     <ClCompile Include="Settings\InterfaceSettingsWidget.cpp">
       <Filter>Settings</Filter>
     </ClCompile>
-    <ClCompile Include="Settings\SettingsDialog.cpp">
+    <ClCompile Include="Settings\SettingsWindow.cpp">
       <Filter>Settings</Filter>
     </ClCompile>
     <ClCompile Include="$(IntDir)Settings\moc_BIOSSettingsWidget.cpp">
@@ -84,7 +84,7 @@
     <ClCompile Include="$(IntDir)Settings\moc_InterfaceSettingsWidget.cpp">
       <Filter>moc</Filter>
     </ClCompile>
-    <ClCompile Include="$(IntDir)Settings\moc_SettingsDialog.cpp">
+    <ClCompile Include="$(IntDir)Settings\moc_SettingsWindow.cpp">
       <Filter>moc</Filter>
     </ClCompile>
     <ClCompile Include="$(IntDir)Settings\moc_AdvancedSettingsWidget.cpp">
@@ -130,7 +130,7 @@
     <ClCompile Include="$(IntDir)moc_AboutDialog.cpp">
       <Filter>moc</Filter>
     </ClCompile>
-    <ClCompile Include="$(IntDir)Settings\moc_ControllerSettingsDialog.cpp">
+    <ClCompile Include="$(IntDir)Settings\moc_ControllerSettingsWindow.cpp">
       <Filter>moc</Filter>
     </ClCompile>
     <ClCompile Include="$(IntDir)GameList\moc_GameListModel.cpp">
@@ -142,7 +142,7 @@
     <ClCompile Include="$(IntDir)GameList\moc_GameListWidget.cpp">
       <Filter>moc</Filter>
     </ClCompile>
-    <ClCompile Include="Settings\ControllerSettingsDialog.cpp">
+    <ClCompile Include="Settings\ControllerSettingsWindow.cpp">
       <Filter>Settings</Filter>
     </ClCompile>
     <ClCompile Include="Settings\ControllerBindingWidgets.cpp">
@@ -374,7 +374,7 @@
     <QtMoc Include="Settings\InterfaceSettingsWidget.h">
       <Filter>Settings</Filter>
     </QtMoc>
-    <QtMoc Include="Settings\SettingsDialog.h">
+    <QtMoc Include="Settings\SettingsWindow.h">
       <Filter>Settings</Filter>
     </QtMoc>
     <QtMoc Include="Settings\AdvancedSettingsWidget.h">
@@ -402,7 +402,7 @@
     <QtMoc Include="GameList\GameListRefreshThread.h">
       <Filter>GameList</Filter>
     </QtMoc>
-    <QtMoc Include="Settings\ControllerSettingsDialog.h">
+    <QtMoc Include="Settings\ControllerSettingsWindow.h">
       <Filter>Settings</Filter>
     </QtMoc>
     <QtMoc Include="Settings\ControllerBindingWidgets.h">
@@ -513,7 +513,7 @@
     <QtUi Include="Settings\InterfaceSettingsWidget.ui">
       <Filter>Settings</Filter>
     </QtUi>
-    <QtUi Include="Settings\SettingsDialog.ui">
+    <QtUi Include="Settings\SettingsWindow.ui">
       <Filter>Settings</Filter>
     </QtUi>
     <QtUi Include="Settings\AdvancedSettingsWidget.ui">
@@ -525,7 +525,7 @@
     <QtUi Include="Settings\InputBindingDialog.ui">
       <Filter>Settings</Filter>
     </QtUi>
-    <QtUi Include="Settings\ControllerSettingsDialog.ui">
+    <QtUi Include="Settings\ControllerSettingsWindow.ui">
       <Filter>Settings</Filter>
     </QtUi>
     <QtUi Include="Settings\ControllerBindingWidget_DualShock2.ui">


### PR DESCRIPTION
### Description of Changes

Stops the settings dialog getting shrunk and dragged around with the main window on Windows.

### Rationale behind Changes

Fixes the behavioural regression from Qt 6.6.

### Suggested Testing Steps

Test settings and controller settings dialogs.
