### PR TITLE
GameDB: Force minimum blend for Gun

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -20093,7 +20093,7 @@ SLES-53523:
   roundModes:
     vu1RoundMode: 0 # Fixes textures and crashes.
   gsHWFixes:
-    recommendedBlendingLevel: 3 # Fixes broken light and shadow rendering.
+    minimumBlendingLevel: 3 # Fixes broken light and shadow rendering.
     mipmap: 2 # Mipmap + trilinear, improves ground textures and water textures and reflections.
     trilinearFiltering: 1
     textureInsideRT: 1 # Fixes rainbow artifacting around edges of screen.
@@ -20601,7 +20601,7 @@ SLES-53647:
   roundModes:
     vu1RoundMode: 0 # Fixes textures and crashes.
   gsHWFixes:
-    recommendedBlendingLevel: 3 # Fixes broken light and shadow rendering.
+    minimumBlendingLevel: 3 # Fixes broken light and shadow rendering.
     mipmap: 2 # Mipmap + trilinear, improves ground textures and water textures and reflections.
     trilinearFiltering: 1
     textureInsideRT: 1 # Fixes rainbow artifacting around edges of screen.
@@ -52628,7 +52628,7 @@ SLUS-21139:
   roundModes:
     vu1RoundMode: 0 # Fixes textures and crashes.
   gsHWFixes:
-    recommendedBlendingLevel: 3 # Fixes broken light and shadow rendering.
+    minimumBlendingLevel: 3 # Fixes broken light and shadow rendering.
     mipmap: 2 # Mipmap + trilinear, improves ground textures and water textures and reflections.
     trilinearFiltering: 1
     textureInsideRT: 1 # Fixes rainbow artifacting around edges of screen.


### PR DESCRIPTION
### Description of Changes
Forces high blending for Gun as it's required for the game to render correctly anyway.

Before:
![Gun_SLUS-21139_20231015011043](https://github.com/PCSX2/pcsx2/assets/80843560/b890ffe4-0368-4bc0-a75e-a1ef79281e13)

After:
![Gun_SLUS-21139_20231015011045](https://github.com/PCSX2/pcsx2/assets/80843560/e5644121-25a1-48a9-8b65-e0bd62eb35f8)

### Rationale behind Changes
The game needs it so force it.

### Suggested Testing Steps
Make sure CI is happy.
