### PR TITLE
GS:MTL: Fix handling of tex is depth fb

### DIFF
--- a/pcsx2/GS/Renderers/Metal/tfx.metal
+++ b/pcsx2/GS/Renderers/Metal/tfx.metal
@@ -532,7 +532,12 @@ struct PSMain
 
 	float4 fetch_c(ushort2 uv)
 	{
-		return PS_TEX_IS_DEPTH ? tex_depth.read(uv) : tex.read(uv);
+		if (PS_TEX_IS_FB)
+			return current_color;
+		else if (PS_TEX_IS_DEPTH)
+			return tex_depth.read(uv);
+		else
+			return tex.read(uv);
 	}
 
 	// MARK: Depth sampling


### PR DESCRIPTION
### Description of Changes
Fixes tex is fb + depth texture on the Metal renderer

### Rationale behind Changes
Less broken

### Suggested Testing Steps
Test [OutRun_2006.gs.xz.zip](https://github.com/PCSX2/pcsx2/files/12908672/OutRun_2006.gs.xz.zip)

