### PR TITLE
Qt/Updater: Move download size indicator for better placement

### DIFF
--- a/pcsx2-qt/AutoUpdaterDialog.cpp
+++ b/pcsx2-qt/AutoUpdaterDialog.cpp
@@ -391,9 +391,6 @@ void AutoUpdaterDialog::getChangesComplete(QNetworkReply* reply)
 					tr("<h2>Settings Warning</h2><p>Installing this update will reset your program configuration. Please note "
 					   "that you will have to reconfigure your settings after this update.</p>"));
 			}
-			changes_html += tr("<h4>Installing this update will download %1 MB through your internet connection.</h4>")
-                    .arg(static_cast<double>(m_download_size) / 1048576.0, 0, 'f', 2);
-				
 			m_ui.updateNotes->setText(changes_html);
 		}
 		else
@@ -522,6 +519,7 @@ void AutoUpdaterDialog::checkIfUpdateNeeded()
 
 	m_ui.currentVersion->setText(tr("Current Version: %1 (%2)").arg(getCurrentVersion()).arg(getCurrentVersionDate()));
 	m_ui.newVersion->setText(tr("New Version: %1 (%2)").arg(m_latest_version).arg(m_latest_version_timestamp.toString()));
+	m_ui.downloadSize->setText(tr("Download Size: %1 MB").arg(static_cast<double>(m_download_size) / 1048576.0, 0, 'f', 2));
 	m_ui.updateNotes->setText(tr("Loading..."));
 	queueGetChanges();
 	exec();

--- a/pcsx2-qt/AutoUpdaterDialog.ui
+++ b/pcsx2-qt/AutoUpdaterDialog.ui
@@ -77,6 +77,13 @@
     </widget>
    </item>
    <item>
+    <widget class="QLabel" name="downloadSize">
+     <property name="text">
+      <string>Download Size: </string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QTextBrowser" name="updateNotes"/>
    </item>
    <item>


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Move the download size text from the changelogs list into the top bar like so:
![image](https://github.com/PCSX2/pcsx2/assets/14798312/e5f38081-48c2-49f5-b41e-4c6b258d2936)

NOTE: The actual functionality is still WIP and will come later.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Better visibility and aesthetic.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Make sure i didn't break other stuff.
