### PR TITLE
Qt: Always use non-English title for cover paths

### DIFF
--- a/pcsx2-qt/GameList/GameListModel.cpp
+++ b/pcsx2-qt/GameList/GameListModel.cpp
@@ -179,11 +179,11 @@ void GameListModel::loadOrGenerateCover(const GameList::Entry* ge)
 	// while there's outstanding jobs, the old jobs won't proceed (at the wrong size), or get added into the grid.
 	const u32 counter = m_cover_scale_counter.load(std::memory_order_acquire);
 
-	QFuture<QPixmap> future = QtConcurrent::run([this, path = ge->path, title = ge->GetTitle(m_prefer_english_titles), serial = ge->serial, counter]() -> QPixmap {
+	QFuture<QPixmap> future = QtConcurrent::run([this, entry = *ge, counter]() -> QPixmap {
 		QPixmap image;
 		if (m_cover_scale_counter.load(std::memory_order_acquire) == counter)
 		{
-			const std::string cover_path(GameList::GetCoverImagePath(path, serial, title));
+			const std::string cover_path(GameList::GetCoverImagePathForEntry(&entry));
 			if (!cover_path.empty())
 			{
 				const float dpr = qApp->devicePixelRatio();
@@ -195,6 +195,8 @@ void GameListModel::loadOrGenerateCover(const GameList::Entry* ge)
 				}
 			}
 		}
+
+		const std::string& title = entry.GetTitle(m_prefer_english_titles);
 
 		if (image.isNull())
 			image = createPlaceholderImage(m_placeholder_pixmap, getCoverArtWidth(), getCoverArtHeight(), m_cover_scale, title);

--- a/pcsx2/GameList.cpp
+++ b/pcsx2/GameList.cpp
@@ -1158,11 +1158,6 @@ std::string GameList::FormatTimespan(std::time_t timespan, bool long_format)
 
 std::string GameList::GetCoverImagePathForEntry(const Entry* entry)
 {
-	return GetCoverImagePath(entry->path, entry->serial, entry->title);
-}
-
-std::string GameList::GetCoverImagePath(const std::string& path, const std::string& serial, const std::string& title)
-{
 	static const char* extensions[] = {".jpg", ".jpeg", ".png", ".webp"};
 
 	// TODO(Stenzek): Port to filesystem...
@@ -1172,17 +1167,17 @@ std::string GameList::GetCoverImagePath(const std::string& path, const std::stri
 	{
 
 		// Prioritize lookup by serial (Most specific)
-		if (!serial.empty())
+		if (!entry->serial.empty())
 		{
-			const std::string cover_filename(serial + extension);
+			const std::string cover_filename(entry->serial + extension);
 			cover_path = Path::Combine(EmuFolders::Covers, cover_filename);
 			if (FileSystem::FileExists(cover_path.c_str()))
 				return cover_path;
 		}
 
 		// Try file title (for modded games or specific like above)
-		const std::string_view file_title(Path::GetFileTitle(path));
-		if (!file_title.empty() && title != file_title)
+		const std::string_view file_title(Path::GetFileTitle(entry->path));
+		if (!file_title.empty() && entry->title != file_title)
 		{
 			std::string cover_filename(file_title);
 			cover_filename += extension;
@@ -1193,9 +1188,18 @@ std::string GameList::GetCoverImagePath(const std::string& path, const std::stri
 		}
 
 		// Last resort, check the game title
-		if (!title.empty())
+		if (!entry->title.empty())
 		{
-			std::string cover_filename(title + extension);
+			std::string cover_filename(entry->title + extension);
+			Path::SanitizeFileName(&cover_filename);
+			cover_path = Path::Combine(EmuFolders::Covers, cover_filename);
+			if (FileSystem::FileExists(cover_path.c_str()))
+				return cover_path;
+		}
+		// EN title too
+		if (!entry->title_en.empty())
+		{
+			std::string cover_filename(entry->title_en + extension);
 			Path::SanitizeFileName(&cover_filename);
 			cover_path = Path::Combine(EmuFolders::Covers, cover_filename);
 			if (FileSystem::FileExists(cover_path.c_str()))

--- a/pcsx2/GameList.h
+++ b/pcsx2/GameList.h
@@ -161,7 +161,6 @@ namespace GameList
 	std::string FormatTimespan(std::time_t timespan, bool long_format = false);
 
 	std::string GetCoverImagePathForEntry(const Entry* entry);
-	std::string GetCoverImagePath(const std::string& path, const std::string& code, const std::string& title);
 	std::string GetNewCoverImagePathForEntry(const Entry* entry, const char* new_filename, bool use_serial = false);
 
 	/// Downloads covers using the specified URL templates. By default, covers are saved by title, but this can be changed with


### PR DESCRIPTION
### Description of Changes
Ignore game list display settings, they're for display

### Rationale behind Changes
Prevents cover paths from changing based on the status of the use English titles setting

### Suggested Testing Steps
Set a custom cover for some Japanese games, enable English titles, and make sure the covers are visible
