### PR TITLE
GS/HW: Don't align dirty rectangles to block sizes when updating

### DIFF
--- a/pcsx2-gsrunner/test_check_dumps.py
+++ b/pcsx2-gsrunner/test_check_dumps.py
@@ -60,7 +60,7 @@ def compare_frames(path1, path2):
 def extract_stats(file):
     stats = {}
     try:
-        with open(file, "r") as f:
+        with open(file, "r", errors="ignore") as f:
             for line in f.readlines():
                 m = re.match(".*@HWSTAT@ ([^:]+): (.*) \(avg ([^)]+)\)$", line)
                 if m is None:

--- a/pcsx2/GS/Renderers/Common/GSDirtyRect.cpp
+++ b/pcsx2/GS/Renderers/Common/GSDirtyRect.cpp
@@ -35,7 +35,7 @@ GSDirtyRect::GSDirtyRect(GSVector4i& r, u32 psm, u32 bw, RGBAMask rgba, bool req
 {
 }
 
-GSVector4i GSDirtyRect::GetDirtyRect(GIFRegTEX0 TEX0) const
+GSVector4i GSDirtyRect::GetDirtyRect(GIFRegTEX0 TEX0, bool align) const
 {
 	GSVector4i _r;
 
@@ -48,14 +48,13 @@ GSVector4i GSDirtyRect::GetDirtyRect(GIFRegTEX0 TEX0) const
 		_r.top = (r.top * dst.y) / src.y;
 		_r.right = (r.right * dst.x) / src.x;
 		_r.bottom = (r.bottom * dst.y) / src.y;
-		_r = _r.ralign<Align_Outside>(src);
 	}
 	else
 	{
-		_r = r.ralign<Align_Outside>(src);
+		_r = r;
 	}
 
-	return _r;
+	return align ? _r.ralign<Align_Outside>(src) : _r;
 }
 
 GSVector4i GSDirtyRectList::GetTotalRect(GIFRegTEX0 TEX0, const GSVector2i& size) const
@@ -66,7 +65,7 @@ GSVector4i GSDirtyRectList::GetTotalRect(GIFRegTEX0 TEX0, const GSVector2i& size
 
 		for (auto& dirty_rect : *this)
 		{
-			r = r.runion(dirty_rect.GetDirtyRect(TEX0));
+			r = r.runion(dirty_rect.GetDirtyRect(TEX0, true));
 		}
 
 		const GSVector2i& bs = GSLocalMemory::m_psm[TEX0.PSM].bs;
@@ -92,12 +91,13 @@ u32 GSDirtyRectList::GetDirtyChannels()
 	return channels;
 }
 
-GSVector4i GSDirtyRectList::GetDirtyRect(size_t index, GIFRegTEX0 TEX0, const GSVector4i& clamp) const
+GSVector4i GSDirtyRectList::GetDirtyRect(size_t index, GIFRegTEX0 TEX0, const GSVector4i& clamp, bool align) const
 {
-	const GSVector4i r = (*this)[index].GetDirtyRect(TEX0);
+	GSVector4i r = (*this)[index].GetDirtyRect(TEX0, align);
+	const GSVector2i& bs = GSLocalMemory::m_psm[TEX0.PSM].bs;
+	if (align)
+		r = r.ralign<Align_Outside>(bs);
 
-	GSVector2i bs = GSLocalMemory::m_psm[TEX0.PSM].bs;
-
-	return r.ralign<Align_Outside>(bs).rintersect(clamp);
+	return r.rintersect(clamp);
 }
 

--- a/pcsx2/GS/Renderers/Common/GSDirtyRect.h
+++ b/pcsx2/GS/Renderers/Common/GSDirtyRect.h
@@ -40,7 +40,7 @@ public:
 
 	GSDirtyRect();
 	GSDirtyRect(GSVector4i& r, u32 psm, u32 bw, RGBAMask rgba, bool req_linear);
-	GSVector4i GetDirtyRect(GIFRegTEX0 TEX0) const;
+	GSVector4i GetDirtyRect(GIFRegTEX0 TEX0, bool align) const;
 };
 
 class GSDirtyRectList : public std::vector<GSDirtyRect>
@@ -49,5 +49,5 @@ public:
 	GSDirtyRectList() {}
 	GSVector4i GetTotalRect(GIFRegTEX0 TEX0, const GSVector2i& size) const;
 	u32 GetDirtyChannels();
-	GSVector4i GetDirtyRect(size_t index, GIFRegTEX0 TEX0, const GSVector4i& clamp) const;
+	GSVector4i GetDirtyRect(size_t index, GIFRegTEX0 TEX0, const GSVector4i& clamp, bool align) const;
 };

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -5497,7 +5497,7 @@ GSRendererHW::CLUTDrawTestResult GSRendererHW::PossibleCLUTDraw()
 				bool is_dirty = false;
 				for (const GSDirtyRect& rc : tgt->m_dirty)
 				{
-					if (!rc.GetDirtyRect(m_cached_ctx.TEX0).rintersect(r).rempty())
+					if (!rc.GetDirtyRect(m_cached_ctx.TEX0, false).rintersect(r).rempty())
 					{
 						is_dirty = true;
 						break;
@@ -5597,7 +5597,7 @@ bool GSRendererHW::CanUseSwPrimRender(bool no_rt, bool no_ds, bool draw_sprite_t
 				const GSVector4i tr(GetTextureMinMax(m_cached_ctx.TEX0, m_cached_ctx.CLAMP, m_vt.IsLinear(), false).coverage);
 				for (GSDirtyRect& rc : src_target->m_dirty)
 				{
-					if (!rc.GetDirtyRect(m_cached_ctx.TEX0).rintersect(tr).rempty())
+					if (!rc.GetDirtyRect(m_cached_ctx.TEX0, false).rintersect(tr).rempty())
 						return true;
 				}
 			}


### PR DESCRIPTION
### Description of Changes

Don't align the area we write to the target to the block size. If the format matches, the writes don't need to be block aligned. We still read the whole thing in, because that's the granularity that ReadTexture operates at, but discard those pixels when updating the framebuffer. Onimusha 2 does this dance where it uploads the left 4 pixels to the middle of the image, then moves it to the left, and because we process the move in hardware, local memory never gets updated, and thus is stale.

### Rationale behind Changes

Closes #7563.
Closes #8509.

![image](https://github.com/PCSX2/pcsx2/assets/11288319/b58f6fc9-9219-4328-b4d0-45d4706ee9a6)
![image](https://github.com/PCSX2/pcsx2/assets/11288319/ce6d5b36-52e0-40db-98e7-0795465bef4a)
![image](https://github.com/PCSX2/pcsx2/assets/11288319/80624e1c-cf2e-4980-92cc-b7c094ba30e1)
![image](https://github.com/PCSX2/pcsx2/assets/11288319/7ef4c266-0d38-4214-8173-046503aca432)

### Suggested Testing Steps

Test affected games.
Runner shows no other regressions.