### PR TITLE
SPU2: Fix applying master volume

### DIFF
--- a/pcsx2/SPU2/Mixer.cpp
+++ b/pcsx2/SPU2/Mixer.cpp
@@ -633,7 +633,7 @@ __forceinline
 		Ext = StereoOut32::Empty;
 	else
 	{
-		Ext = clamp_mix(ApplyVolume(Ext, Cores[0].MasterVol));
+		Ext = ApplyVolume(clamp_mix(Ext), Cores[0].MasterVol);
 	}
 
 	// Commit Core 0 output to ram before mixing Core 1:
@@ -657,8 +657,7 @@ __forceinline
 	}
 	else
 	{
-		Out.Left = ApplyVolume(Out.Left, Cores[1].MasterVol.Left.Value);
-		Out.Right = ApplyVolume(Out.Right, Cores[1].MasterVol.Right.Value);
+		Out = ApplyVolume(clamp_mix(Out), Cores[1].MasterVol);
 	}
 
 	// For a long time PCSX2 has had its output volume halved by

--- a/pcsx2/SPU2/defs.h
+++ b/pcsx2/SPU2/defs.h
@@ -350,28 +350,20 @@ struct V_CoreRegs
 
 struct V_VoiceGates
 {
-	s16 DryL; // 'AND Gate' for Direct Output to Left Channel
-	s16 DryR; // 'AND Gate' for Direct Output for Right Channel
-	s16 WetL; // 'AND Gate' for Effect Output for Left Channel
-	s16 WetR; // 'AND Gate' for Effect Output for Right Channel
+	s32 DryL; // 'AND Gate' for Direct Output to Left Channel
+	s32 DryR; // 'AND Gate' for Direct Output for Right Channel
+	s32 WetL; // 'AND Gate' for Effect Output for Left Channel
+	s32 WetR; // 'AND Gate' for Effect Output for Right Channel
 };
 
 struct V_CoreGates
 {
-	union
-	{
-		u128 v128;
-
-		struct
-		{
-			s16 InpL; // Sound Data Input to Direct Output (Left)
-			s16 InpR; // Sound Data Input to Direct Output (Right)
-			s16 SndL; // Voice Data to Direct Output (Left)
-			s16 SndR; // Voice Data to Direct Output (Right)
-			s16 ExtL; // External Input to Direct Output (Left)
-			s16 ExtR; // External Input to Direct Output (Right)
-		};
-	};
+	s32 InpL; // Sound Data Input to Direct Output (Left)
+	s32 InpR; // Sound Data Input to Direct Output (Right)
+	s32 SndL; // Voice Data to Direct Output (Left)
+	s32 SndR; // Voice Data to Direct Output (Right)
+	s32 ExtL; // External Input to Direct Output (Left)
+	s32 ExtR; // External Input to Direct Output (Right)
 };
 
 struct VoiceMixSet

--- a/pcsx2/SaveState.h
+++ b/pcsx2/SaveState.h
@@ -37,7 +37,7 @@ enum class FreezeAction
 // [SAVEVERSION+]
 // This informs the auto updater that the users savestates will be invalidated.
 
-static const u32 g_SaveVersion = (0x9A46 << 16) | 0x0000;
+static const u32 g_SaveVersion = (0x9A47 << 16) | 0x0000;
 
 
 // the freezing data between submodules and core


### PR DESCRIPTION
### Description of Changes
Fix applying master volume.

### Rationale behind Changes
Burnout 3 had samples overflowing 16bits.

### Suggested Testing Steps
Burnout 3 shouldn't be crackling anymore.
