### PR TITLE
R5900 Recompiler: Export reset flag (To use with eemem)

### DIFF
--- a/pcsx2/x86/ix86-32/iR5900.cpp
+++ b/pcsx2/x86/ix86-32/iR5900.cpp
@@ -54,9 +54,16 @@
 using namespace x86Emitter;
 using namespace R5900;
 
-static bool eeRecNeedsReset = false;
-static bool eeCpuExecuting = false;
+// For debuggers
+extern "C" {
+#ifdef _WIN32
+_declspec(dllexport) bool eeRecNeedsReset = false;
+#else
+__attribute__((visibility("default"), used)) bool eeRecNeedsReset = false;
+#endif
+}
 static bool eeRecExitRequested = false;
+static bool eeCpuExecuting = false;
 static bool g_resetEeScalingStats = false;
 
 #define PC_GETBLOCK(x) PC_GETBLOCK_(x, recLUT)
@@ -372,7 +379,7 @@ static void recEventTest()
 {
 	_cpuEventTest_Shared();
 
-	if (eeRecExitRequested)
+	if (eeRecExitRequested || eeRecNeedsReset)
 	{
 		eeRecExitRequested = false;
 		recExitExecution();


### PR DESCRIPTION
This is just an idea.
Currently EE instruction memory is page protected (I assume PAGE_READONLY?) for the JIT. This prevents you from writing to it using WriteProcessMemory. This is an issue when you depend on the EEMem pointer.
You can bypass this by changing the page protection

```cpp
DWORD dwOldProtect;
// Change the protection to writeable
VirtualProtectEx(hProcess, (PVOID)addressToWrite, sizeToWrite, PAGE_READWRITE, &dwOldProtect);

// Write your data
WriteProcessMemory(hProcess, (PVOID)addressToWrite, &newOp, sizeToWrite, nullptr);

// Restore the protection
VirtualProtectEx(hProcess, (PVOID)addressToWrite, sizeToWrite, dwOldProtect, nullptr);
```
There is an issue with this though, you don't trip the page protection in PCSX2. Your newly written instruction data wont be recompiled :(
(I do wonder if an external process is able to trip the protection, that would be a much better solution)

This is where this PR comes in.
We can export `eeRecNeedsReset` and do the following to clear our old instruction blocks after we've written to the guest memory
```cpp
// Get the address of eeRecNeedsReset
uintptr_t recExitRequested = GetProcAddressEx(hProcess, hPCSX2, "eeRecNeedsReset");
bool resetTrue = true;
// Set eeRecNeedsReset to true
WriteProcessMemory(hProcess, (PVOID)eeRecNeedsReset, &resetTrue, 1, nullptr)
```

There is no easy equivalent for the IOP JIT (It can just be added to an event test I think), but I was wondering if there were any thoughts on this?