### PR TITLE
GS/TC: Invalidate alpha on overlapping targets with no alpha

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -2847,6 +2847,13 @@ void GSTextureCache::InvalidateVideoMem(const GSOffset& off, const GSVector4i& r
 					}
 				}
 			}
+			// This is a situation where it is uploading in to the alpha channel but that is not part of the mask for the target format.
+			// So we need to make sure the alpha is not marked as valid. (Juiced does a shuffle on the Z24 depth, making the alpha valid data).
+			else if (GSUtil::GetChannelMask(psm) == 0x8 && GSUtil::GetChannelMask(t->m_TEX0.PSM) == 0x7 && t->Overlaps(bp, bw, psm, r))
+			{
+				t->m_valid_alpha_high &= !(psm == PSMT8H || psm == PSMT4HH);
+				t->m_valid_alpha_low &= !(psm == PSMT8H || psm == PSMT4HL);
+			}
 		}
 	}
 }


### PR DESCRIPTION
### Description of Changes
Invalidate alpha on channels with no alpha channel on upload to alpha channel.

### Rationale behind Changes
Invalidation code was only invalidating when the upload shares bits with the target, which is correct, however there are scenarios (mainly texture shuffles) where the alpha channel can be marked as valid, even though it's not part of the target, so if the data being uploaded covers the alpha channel, we need to change the `m_alpha_valid_high/low` to false, despite no valid area changes.

In the case of Juiced, it has a Z24 buffer, which means no alpha channel, so the game stores car textures in the alpha channel, but due to a shuffle effect on the Z24 buffer, it gets marked that the alpha has been rendered, and a later texture lookup (for the car texture) thinks this is now a valid texture to use, but it isn't, as it has uploaded the new texture again to overwrite the earlier shuffle. The problem was, we weren't dealing with this, as outlined above.

### Suggested Testing Steps
Test Juiced, make sure it's still okay, nothing else showed up as affected.

Juiced:

Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/773870b8-81d3-4ec7-a355-c2f63e33510c)

PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/50a1dd77-4ca4-4b72-ae25-3256b7eab022)
