### PR TITLE
Debugger: Some more debugger updates

### DIFF
--- a/pcsx2-qt/Debugger/CpuWidget.cpp
+++ b/pcsx2-qt/Debugger/CpuWidget.cpp
@@ -61,23 +61,35 @@ CpuWidget::CpuWidget(QWidget* parent, DebugInterface& cpu)
 	connect(m_ui.breakpointList, &QTableView::customContextMenuRequested, this, &CpuWidget::onBPListContextMenu);
 	connect(m_ui.breakpointList, &QTableView::doubleClicked, this, &CpuWidget::onBPListDoubleClicked);
 
-	m_ui.breakpointList->horizontalHeader()->setSectionResizeMode(QHeaderView::Stretch);
 	m_ui.breakpointList->setModel(&m_bpModel);
+	for (std::size_t i = 0; auto mode : BreakpointModel::HeaderResizeModes)
+	{
+		m_ui.breakpointList->horizontalHeader()->setSectionResizeMode(i, mode);
+		i++;
+	}
 
 	connect(m_ui.threadList, &QTableView::customContextMenuRequested, this, &CpuWidget::onThreadListContextMenu);
 	connect(m_ui.threadList, &QTableView::doubleClicked, this, &CpuWidget::onThreadListDoubleClick);
 
-	m_ui.threadList->horizontalHeader()->setSectionResizeMode(QHeaderView::Stretch);
 	m_threadProxyModel.setSourceModel(&m_threadModel);
 	m_ui.threadList->setModel(&m_threadProxyModel);
 	m_ui.threadList->setSortingEnabled(true);
 	m_ui.threadList->sortByColumn(ThreadModel::ThreadColumns::ID, Qt::SortOrder::AscendingOrder);
+	for (std::size_t i = 0; auto mode : ThreadModel::HeaderResizeModes)
+	{
+		m_ui.threadList->horizontalHeader()->setSectionResizeMode(i, mode);
+		i++;
+	}
 
 	connect(m_ui.stackList, &QTableView::customContextMenuRequested, this, &CpuWidget::onStackListContextMenu);
 	connect(m_ui.stackList, &QTableView::doubleClicked, this, &CpuWidget::onStackListDoubleClick);
 
-	m_ui.stackList->horizontalHeader()->setSectionResizeMode(QHeaderView::Stretch);
 	m_ui.stackList->setModel(&m_stackModel);
+	for (std::size_t i = 0; auto mode : StackModel::HeaderResizeModes)
+	{
+		m_ui.stackList->horizontalHeader()->setSectionResizeMode(i, mode);
+		i++;
+	}
 
 	connect(m_ui.tabWidgetRegFunc, &QTabWidget::currentChanged, [this](int i) {if(i == 1){updateFunctionList(true);} });
 	connect(m_ui.listFunctions, &QListWidget::customContextMenuRequested, this, &CpuWidget::onFuncListContextMenu);

--- a/pcsx2-qt/Debugger/CpuWidget.cpp
+++ b/pcsx2-qt/Debugger/CpuWidget.cpp
@@ -246,7 +246,7 @@ void CpuWidget::onBPListDoubleClicked(const QModelIndex& index)
 	{
 		if (index.column() == BreakpointModel::OFFSET)
 		{
-			m_ui.disassemblyWidget->gotoAddress(m_bpModel.data(index, Qt::UserRole).toUInt());
+			m_ui.disassemblyWidget->gotoAddress(m_bpModel.data(index, BreakpointModel::DataRole).toUInt());
 		}
 	}
 }
@@ -285,8 +285,8 @@ void CpuWidget::onBPListContextMenu(QPoint pos)
 	contextMenu->addSeparator();
 	QAction* actionExport = new QAction(tr("Copy all as CSV"), m_ui.breakpointList);
 	connect(actionExport, &QAction::triggered, [this]() {
-		// It's important to use the User Role here to allow pasting to be translation agnostic
-		QGuiApplication::clipboard()->setText(QtUtils::AbstractItemModelToCSV(m_ui.breakpointList->model(), Qt::UserRole));
+		// It's important to use the Export Role here to allow pasting to be translation agnostic
+		QGuiApplication::clipboard()->setText(QtUtils::AbstractItemModelToCSV(m_ui.breakpointList->model(), BreakpointModel::ExportRole));
 	});
 	contextMenu->addAction(actionExport);
 
@@ -429,7 +429,7 @@ void CpuWidget::contextBPListPasteCSV()
 			}
 
 			// Size
-			mc.end = fields[2].toUInt(&ok, 16) + mc.start;
+			mc.end = fields[2].toUInt(&ok) + mc.start;
 			if (!ok)
 			{
 				Console.WriteLn("Debugger CSV Import: Failed to parse length '%s', skipping", fields[1].toUtf8().constData());

--- a/pcsx2-qt/Debugger/DebuggerWindow.h
+++ b/pcsx2-qt/Debugger/DebuggerWindow.h
@@ -44,4 +44,6 @@ private:
 
 	CpuWidget* m_cpuWidget_r5900;
 	CpuWidget* m_cpuWidget_r3000;
+
+	void setTabActiveStyle(BreakPointCpu toggledCPU);
 };

--- a/pcsx2-qt/Debugger/DisassemblyWidget.cpp
+++ b/pcsx2-qt/Debugger/DisassemblyWidget.cpp
@@ -380,9 +380,9 @@ void DisassemblyWidget::paintEvent(QPaintEvent* event)
 
 		// Breakpoint marker
 		bool enabled;
-		if(CBreakPoints::IsAddressBreakPoint(m_cpu->getCpuType(), rowAddress, &enabled) && !CBreakPoints::IsTempBreakPoint(m_cpu->getCpuType(), rowAddress))
+		if (CBreakPoints::IsAddressBreakPoint(m_cpu->getCpuType(), rowAddress, &enabled) && !CBreakPoints::IsTempBreakPoint(m_cpu->getCpuType(), rowAddress))
 		{
-			if(enabled)
+			if (enabled)
 			{
 				painter.setPen(Qt::green);
 				painter.drawText(2, i * m_rowHeight, w, m_rowHeight, Qt::AlignLeft, "\u25A0");
@@ -725,7 +725,21 @@ inline QString DisassemblyWidget::DisassemblyStringFromAddress(u32 address, QFon
 	{
 		// We want this text elided
 		QFontMetrics metric(font);
-		lineString = lineString.arg(metric.elidedText(QString::fromStdString((m_demangleFunctions ? demangler->demangleToString(addressSymbol) : addressSymbol)), Qt::ElideRight, (selected ? 32 : 8) * font.pointSize()));
+		QString symbolString;
+		if (m_demangleFunctions)
+		{
+			symbolString = QString::fromStdString(demangler->demangleToString(addressSymbol));
+			if (symbolString.isEmpty())
+			{
+				symbolString = QString::fromStdString(addressSymbol);
+			}
+		}
+		else
+		{
+			symbolString = QString::fromStdString(addressSymbol);
+		}
+
+		lineString = lineString.arg(metric.elidedText(symbolString, Qt::ElideRight, (selected ? 32 : 8) * font.pointSize()));
 	}
 
 	lineString = lineString.leftJustified(4, ' ') // Address / symbol

--- a/pcsx2-qt/Debugger/DisassemblyWidget.cpp
+++ b/pcsx2-qt/Debugger/DisassemblyWidget.cpp
@@ -377,6 +377,21 @@ void DisassemblyWidget::paintEvent(QPaintEvent* event)
 		QString lineString = DisassemblyStringFromAddress(rowAddress, painter.font(), curPC, rowAddress == m_selectedAddressStart);
 
 		painter.drawText(2, i * m_rowHeight, w, m_rowHeight, Qt::AlignLeft, lineString);
+
+		// Breakpoint marker
+		bool enabled;
+		if(CBreakPoints::IsAddressBreakPoint(m_cpu->getCpuType(), rowAddress, &enabled) && !CBreakPoints::IsTempBreakPoint(m_cpu->getCpuType(), rowAddress))
+		{
+			if(enabled)
+			{
+				painter.setPen(Qt::green);
+				painter.drawText(2, i * m_rowHeight, w, m_rowHeight, Qt::AlignLeft, "\u25A0");
+			}
+			else
+			{
+				painter.drawText(2, i * m_rowHeight, w, m_rowHeight, Qt::AlignLeft, "\u2612");
+			}
+		}
 		alternate = !alternate;
 	}
 	// Draw the branch lines
@@ -698,14 +713,12 @@ inline QString DisassemblyWidget::DisassemblyStringFromAddress(u32 address, QFon
 	const bool isConditionalMet = line.info.conditionMet;
 	const bool isCurrentPC = m_cpu->getPC() == address;
 
-	const bool isBreakpoint = CBreakPoints::IsAddressBreakPoint(m_cpu->getCpuType(), address) && !CBreakPoints::IsTempBreakPoint(m_cpu->getCpuType(), address);
 	const std::string addressSymbol = m_cpu->GetSymbolMap().GetLabelString(address);
 
 	const auto demangler = demangler::CDemangler::createGcc();
 
-	QString lineString("%1 %2  %3 %4  %5 %6");
+	QString lineString("  %1  %2 %3  %4 %5");
 
-	lineString = lineString.arg(isBreakpoint ? "\u25A0" : " "); // Bp block ( ■ )
 	if (addressSymbol.empty()) // The address wont have symbol text if it's the start of a function for example
 		lineString = lineString.arg(address, 8, 16, QChar('0')).toUpper();
 	else

--- a/pcsx2-qt/Debugger/DisassemblyWidget.cpp
+++ b/pcsx2-qt/Debugger/DisassemblyWidget.cpp
@@ -609,6 +609,7 @@ void DisassemblyWidget::keyPressEvent(QKeyEvent* event)
 			contextCopyInstructionText();
 			break;
 		case Qt::Key_B:
+		case Qt::Key_Space:
 			contextToggleBreakpoint();
 			break;
 		case Qt::Key_M:

--- a/pcsx2-qt/Debugger/Models/BreakpointModel.cpp
+++ b/pcsx2-qt/Debugger/Models/BreakpointModel.cpp
@@ -98,7 +98,7 @@ QVariant BreakpointModel::data(const QModelIndex& index, int role) const
 			}
 		}
 	}
-	else if (role == Qt::UserRole)
+	else if (role == BreakpointModel::DataRole)
 	{
 		auto bp_mc = m_breakpoints.at(index.row());
 
@@ -131,6 +131,52 @@ QVariant BreakpointModel::data(const QModelIndex& index, int role) const
 					return mc->cond;
 				case BreakpointColumns::OFFSET:
 					return mc->start;
+				case BreakpointColumns::SIZE_LABEL:
+					return mc->end - mc->start;
+				case BreakpointColumns::OPCODE:
+					return "";
+				case BreakpointColumns::CONDITION:
+					return "";
+				case BreakpointColumns::HITS:
+					return mc->numHits;
+				case BreakpointColumns::ENABLED:
+					return (mc->result & MEMCHECK_BREAK);
+			}
+		}
+	}
+	else if (role == BreakpointModel::ExportRole)
+	{
+		auto bp_mc = m_breakpoints.at(index.row());
+
+		if (const auto* bp = std::get_if<BreakPoint>(&bp_mc))
+		{
+			switch (index.column())
+			{
+				case BreakpointColumns::TYPE:
+					return MEMCHECK_INVALID;
+				case BreakpointColumns::OFFSET:
+					return QtUtils::FilledQStringFromValue(bp->addr, 16);
+				case BreakpointColumns::SIZE_LABEL:
+					return m_cpu.GetSymbolMap().GetLabelString(bp->addr).c_str();
+				case BreakpointColumns::OPCODE:
+					// Note: Fix up the disassemblymanager so we can use it here, instead of calling a function through the disassemblyview (yuck)
+					return m_cpu.disasm(bp->addr, true).c_str();
+				case BreakpointColumns::CONDITION:
+					return bp->hasCond ? QString::fromLocal8Bit(bp->cond.expressionString) : tr("");
+				case BreakpointColumns::HITS:
+					return 0;
+				case BreakpointColumns::ENABLED:
+					return static_cast<int>(bp->enabled);
+			}
+		}
+		else if (const auto* mc = std::get_if<MemCheck>(&bp_mc))
+		{
+			switch (index.column())
+			{
+				case BreakpointColumns::TYPE:
+					return mc->cond;
+				case BreakpointColumns::OFFSET:
+					return QtUtils::FilledQStringFromValue(mc->start, 16);
 				case BreakpointColumns::SIZE_LABEL:
 					return mc->end - mc->start;
 				case BreakpointColumns::OPCODE:

--- a/pcsx2-qt/Debugger/Models/BreakpointModel.h
+++ b/pcsx2-qt/Debugger/Models/BreakpointModel.h
@@ -16,6 +16,8 @@
 #pragma once
 
 #include <QtCore/QAbstractTableModel>
+#include <QtWidgets/QHeaderView>
+
 #include "DebugTools/DebugInterface.h"
 #include "DebugTools/Breakpoints.h"
 
@@ -42,6 +44,17 @@ public:
 	{
 		DataRole = Qt::UserRole,
 		ExportRole = Qt::UserRole + 1,
+	};
+
+	static constexpr QHeaderView::ResizeMode HeaderResizeModes[BreakpointColumns::COLUMN_COUNT] =
+	{
+		QHeaderView::ResizeMode::ResizeToContents,
+		QHeaderView::ResizeMode::ResizeToContents,
+		QHeaderView::ResizeMode::ResizeToContents,
+		QHeaderView::ResizeMode::Stretch,
+		QHeaderView::ResizeMode::Stretch,
+		QHeaderView::ResizeMode::ResizeToContents,
+		QHeaderView::ResizeMode::ResizeToContents,
 	};
 
 	explicit BreakpointModel(DebugInterface& cpu, QObject* parent = nullptr);

--- a/pcsx2-qt/Debugger/Models/BreakpointModel.h
+++ b/pcsx2-qt/Debugger/Models/BreakpointModel.h
@@ -38,6 +38,12 @@ public:
 		COLUMN_COUNT
 	};
 
+	enum BreakpointRoles : int
+	{
+		DataRole = Qt::UserRole,
+		ExportRole = Qt::UserRole + 1,
+	};
+
 	explicit BreakpointModel(DebugInterface& cpu, QObject* parent = nullptr);
 
 	int rowCount(const QModelIndex& parent = QModelIndex()) const override;

--- a/pcsx2-qt/Debugger/Models/StackModel.h
+++ b/pcsx2-qt/Debugger/Models/StackModel.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <QtCore/QAbstractTableModel>
+#include <QtWidgets/QHeaderView>
 
 #include "DebugTools/DebugInterface.h"
 #include "DebugTools/MipsStackWalk.h"
@@ -34,6 +35,16 @@ public:
 		SP,
 		SIZE,
 		COLUMN_COUNT
+	};
+
+	static constexpr QHeaderView::ResizeMode HeaderResizeModes[StackColumns::COLUMN_COUNT] =
+	{
+		QHeaderView::ResizeMode::ResizeToContents,
+		QHeaderView::ResizeMode::ResizeToContents,
+		QHeaderView::ResizeMode::ResizeToContents,
+		QHeaderView::ResizeMode::Stretch,
+		QHeaderView::ResizeMode::ResizeToContents,
+		QHeaderView::ResizeMode::ResizeToContents,
 	};
 
 	explicit StackModel(DebugInterface& cpu, QObject* parent = nullptr);

--- a/pcsx2-qt/Debugger/Models/ThreadModel.h
+++ b/pcsx2-qt/Debugger/Models/ThreadModel.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <QtCore/QAbstractTableModel>
+#include <QtWidgets/QHeaderView>
 
 #include "DebugTools/DebugInterface.h"
 #include "DebugTools/BiosDebugData.h"
@@ -36,6 +37,16 @@ public:
 		STATE,
 		WAIT_TYPE,
 		COLUMN_COUNT
+	};
+
+	static constexpr QHeaderView::ResizeMode HeaderResizeModes[ThreadColumns::COLUMN_COUNT] =
+	{
+		QHeaderView::ResizeMode::ResizeToContents,
+		QHeaderView::ResizeMode::ResizeToContents,
+		QHeaderView::ResizeMode::ResizeToContents,
+		QHeaderView::ResizeMode::ResizeToContents,
+		QHeaderView::ResizeMode::Stretch,
+		QHeaderView::ResizeMode::Stretch,
 	};
 
 	explicit ThreadModel(DebugInterface& cpu, QObject* parent = nullptr);

--- a/pcsx2-qt/QtUtils.cpp
+++ b/pcsx2-qt/QtUtils.cpp
@@ -287,17 +287,8 @@ namespace QtUtils
 		{
 			for (int col = 0; col < model->columnCount(); col++)
 			{
-				switch(model->data(model->index(row, col), role).metaType().id())
-				{
-					case QMetaType::Int:
-					case QMetaType::UInt:
-						csv += QString::number(model->data(model->index(row, col), role).toUInt(nullptr), 16);
-					break;
-					default:
-						csv += model->data(model->index(row, col), role).toString();
-					break;
-				}
-				
+				csv += model->data(model->index(row, col), role).toString();
+
 				if (col < model->columnCount() - 1)
 					csv += ",";
 			}

--- a/pcsx2/DebugTools/Breakpoints.cpp
+++ b/pcsx2/DebugTools/Breakpoints.cpp
@@ -30,6 +30,7 @@ u64 CBreakPoints::breakSkipFirstTicksIop_ = 0;
 std::vector<MemCheck> CBreakPoints::memChecks_;
 std::vector<MemCheck*> CBreakPoints::cleanupMemChecks_;
 bool CBreakPoints::breakpointTriggered_ = false;
+BreakPointCpu CBreakPoints::breakpointTriggeredCpu_;
 bool CBreakPoints::corePaused = false;
 std::function<void()> CBreakPoints::cb_bpUpdated_;
 

--- a/pcsx2/DebugTools/Breakpoints.h
+++ b/pcsx2/DebugTools/Breakpoints.h
@@ -153,8 +153,9 @@ public:
 
 	static void Update(BreakPointCpu cpu = BREAKPOINT_IOP_AND_EE, u32 addr = 0);
 
-	static void SetBreakpointTriggered(bool b) { breakpointTriggered_ = b; };
+	static void SetBreakpointTriggered(bool triggered, BreakPointCpu cpu = BreakPointCpu::BREAKPOINT_IOP_AND_EE) { breakpointTriggered_ = triggered; breakpointTriggeredCpu_ = cpu; };
 	static bool GetBreakpointTriggered() { return breakpointTriggered_; };
+	static BreakPointCpu GetBreakpointTriggeredCpu() { return breakpointTriggeredCpu_; };
 
 	static bool GetCorePaused() { return corePaused; };
 	static void SetCorePaused(bool b) { corePaused = b; };
@@ -175,6 +176,7 @@ private:
 	static u64 breakSkipFirstTicksIop_;
 
 	static bool breakpointTriggered_;
+	static BreakPointCpu breakpointTriggeredCpu_;
 	static bool corePaused;
 
 	static std::function<void()> cb_bpUpdated_;

--- a/pcsx2/DebugTools/DisassemblyManager.cpp
+++ b/pcsx2/DebugTools/DisassemblyManager.cpp
@@ -408,13 +408,13 @@ u32 DisassemblyFunction::getLineAddress(int line)
 	return lineAddresses[line];
 }
 
-bool DisassemblyFunction::disassemble(u32 address, DisassemblyLineInfo& dest, bool insertSymbols)
+bool DisassemblyFunction::disassemble(u32 address, DisassemblyLineInfo& dest, bool insertSymbols, bool simplify)
 {
 	auto it = findDisassemblyEntry(entries,address,false);
 	if (it == entries.end())
 		return false;
 
-	return it->second->disassemble(address,dest,insertSymbols);
+	return it->second->disassemble(address,dest,simplify, simplify);
 }
 
 void DisassemblyFunction::getBranchLines(u32 start, u32 size, std::vector<BranchLine>& dest)
@@ -695,11 +695,11 @@ void DisassemblyFunction::clear()
 	hash = 0;
 }
 
-bool DisassemblyOpcode::disassemble(u32 address, DisassemblyLineInfo& dest, bool insertSymbols)
+bool DisassemblyOpcode::disassemble(u32 address, DisassemblyLineInfo& dest, bool insertSymbols, bool simplify)
 {
 	char opcode[64],arguments[256];
 
-	std::string dis = cpu->disasm(address,insertSymbols);
+	std::string dis = cpu->disasm(address,simplify);
 	parseDisasm(cpu->GetSymbolMap(),dis.c_str(),opcode,arguments,std::size(arguments),insertSymbols);
 	dest.type = DISTYPE_OPCODE;
 	dest.name = opcode;
@@ -765,7 +765,7 @@ void DisassemblyMacro::setMacroMemory(const std::string& _name, u32 _immediate, 
 	numOpcodes = 2;
 }
 
-bool DisassemblyMacro::disassemble(u32 address, DisassemblyLineInfo& dest, bool insertSymbols)
+bool DisassemblyMacro::disassemble(u32 address, DisassemblyLineInfo& dest, bool insertSymbols, bool simplify)
 {
 	char buffer[64];
 	dest.type = DISTYPE_MACRO;
@@ -836,7 +836,7 @@ void DisassemblyData::recheck()
 	}
 }
 
-bool DisassemblyData::disassemble(u32 address, DisassemblyLineInfo& dest, bool insertSymbols)
+bool DisassemblyData::disassemble(u32 address, DisassemblyLineInfo& dest, bool insertSymbols, bool simplify)
 {
 	dest.type = DISTYPE_DATA;
 
@@ -1034,7 +1034,7 @@ DisassemblyComment::DisassemblyComment(DebugInterface* _cpu, u32 _address, u32 _
 
 }
 
-bool DisassemblyComment::disassemble(u32 address, DisassemblyLineInfo& dest, bool insertSymbols)
+bool DisassemblyComment::disassemble(u32 address, DisassemblyLineInfo& dest, bool insertSymbols, bool simplify)
 {
 	dest.type = DISTYPE_OTHER;
 	dest.name = name;

--- a/pcsx2/DebugTools/DisassemblyManager.h
+++ b/pcsx2/DebugTools/DisassemblyManager.h
@@ -58,7 +58,7 @@ public:
 	virtual int getLineNum(u32 address, bool findStart) = 0;
 	virtual u32 getLineAddress(int line) = 0;
 	virtual u32 getTotalSize() = 0;
-	virtual bool disassemble(u32 address, DisassemblyLineInfo& dest, bool insertSymbols) = 0;
+	virtual bool disassemble(u32 address, DisassemblyLineInfo& dest, bool insertSymbols, bool simplify = false) = 0;
 	virtual void getBranchLines(u32 start, u32 size, std::vector<BranchLine>& dest) { };
 };
 
@@ -71,7 +71,7 @@ public:
 	virtual int getLineNum(u32 address, bool findStart);
 	virtual u32 getLineAddress(int line);
 	virtual u32 getTotalSize() { return size; };
-	virtual bool disassemble(u32 address, DisassemblyLineInfo& dest, bool insertSymbols);
+	virtual bool disassemble(u32 address, DisassemblyLineInfo& dest, bool insertSymbols, bool simplify = false);
 	virtual void getBranchLines(u32 start, u32 size, std::vector<BranchLine>& dest);
 private:
 	void generateBranchLines();
@@ -98,7 +98,7 @@ public:
 	virtual int getLineNum(u32 address, bool findStart) { return (address-this->address)/4; };
 	virtual u32 getLineAddress(int line) { return address+line*4; };
 	virtual u32 getTotalSize() { return num*4; };
-	virtual bool disassemble(u32 address, DisassemblyLineInfo& dest, bool insertSymbols);
+	virtual bool disassemble(u32 address, DisassemblyLineInfo& dest, bool insertSymbols, bool simplify = false);
 	virtual void getBranchLines(u32 start, u32 size, std::vector<BranchLine>& dest);
 private:
 	DebugInterface* cpu;
@@ -122,7 +122,7 @@ public:
 	virtual int getLineNum(u32 address, bool findStart) { return 0; };
 	virtual u32 getLineAddress(int line) { return address; };
 	virtual u32 getTotalSize() { return numOpcodes*4; };
-	virtual bool disassemble(u32 address, DisassemblyLineInfo& dest, bool insertSymbols) ;
+	virtual bool disassemble(u32 address, DisassemblyLineInfo& dest, bool insertSymbols, bool simplify = false);
 private:
 	enum MacroType { MACRO_LI, MACRO_MEMORYIMM };
 
@@ -148,7 +148,7 @@ public:
 	virtual int getLineNum(u32 address, bool findStart);
 	virtual u32 getLineAddress(int line) { return lineAddresses[line]; };
 	virtual u32 getTotalSize() { return size; };
-	virtual bool disassemble(u32 address, DisassemblyLineInfo& dest, bool insertSymbols);
+	virtual bool disassemble(u32 address, DisassemblyLineInfo& dest, bool insertSymbols, bool simplify = false);
 private:
 	void createLines();
 
@@ -179,7 +179,7 @@ public:
 	virtual int getLineNum(u32 address, bool findStart) { return 0; };
 	virtual u32 getLineAddress(int line) { return address; };
 	virtual u32 getTotalSize() { return size; };
-	virtual bool disassemble(u32 address, DisassemblyLineInfo& dest, bool insertSymbols);
+	virtual bool disassemble(u32 address, DisassemblyLineInfo& dest, bool insertSymbols, bool simplify = false);
 private:
 	[[maybe_unused]]DebugInterface* cpu;
 	u32 address;

--- a/pcsx2/Interpreter.cpp
+++ b/pcsx2/Interpreter.cpp
@@ -54,7 +54,7 @@ void intBreakpoint(bool memcheck)
 			return;
 	}
 
-	CBreakPoints::SetBreakpointTriggered(true);
+	CBreakPoints::SetBreakpointTriggered(true, BREAKPOINT_EE);
 	VMManager::SetPaused(true);
 	Cpu->ExitExecution();
 }

--- a/pcsx2/R3000AInterpreter.cpp
+++ b/pcsx2/R3000AInterpreter.cpp
@@ -143,7 +143,7 @@ void psxBreakpoint(bool memcheck)
 			return;
 	}
 
-	CBreakPoints::SetBreakpointTriggered(true);
+	CBreakPoints::SetBreakpointTriggered(true, BREAKPOINT_IOP);
 	VMManager::SetPaused(true);
 	Cpu->ExitExecution();
 }

--- a/pcsx2/x86/iR3000A.cpp
+++ b/pcsx2/x86/iR3000A.cpp
@@ -1289,7 +1289,7 @@ static bool psxDynarecCheckBreakpoint()
 	if (!hit)
 		return false;
 
-	CBreakPoints::SetBreakpointTriggered(true);
+	CBreakPoints::SetBreakpointTriggered(true, BREAKPOINT_IOP);
 	VMManager::SetPaused(true);
 
 	// Exit the EE too.
@@ -1303,7 +1303,7 @@ static bool psxDynarecMemcheck()
 	if (CBreakPoints::CheckSkipFirst(BREAKPOINT_IOP, pc) == pc)
 		return false;
 
-	CBreakPoints::SetBreakpointTriggered(true);
+	CBreakPoints::SetBreakpointTriggered(true, BREAKPOINT_IOP);
 	VMManager::SetPaused(true);
 
 	// Exit the EE too.

--- a/pcsx2/x86/ix86-32/iR5900.cpp
+++ b/pcsx2/x86/ix86-32/iR5900.cpp
@@ -1537,7 +1537,7 @@ void dynarecCheckBreakpoint()
 	if (!hit)
 		return;
 
-	CBreakPoints::SetBreakpointTriggered(true);
+	CBreakPoints::SetBreakpointTriggered(true, BREAKPOINT_EE);
 	VMManager::SetPaused(true);
 	recExitExecution();
 }
@@ -1548,7 +1548,7 @@ void dynarecMemcheck()
 	if (CBreakPoints::CheckSkipFirst(BREAKPOINT_EE, pc) != 0)
 		return;
 
-	CBreakPoints::SetBreakpointTriggered(true);
+	CBreakPoints::SetBreakpointTriggered(true, BREAKPOINT_EE);
 	VMManager::SetPaused(true);
 	recExitExecution();
 }


### PR DESCRIPTION
### Description of Changes

- Fix up the CSV exporting system to support decimal (oops)

- Add spacebar as a breakpoint hotkey
- Change the colour of a breakpoint when it's set and enabled vs set and not enabled
- I tried to fix up the breakpoint, stack and thread list columns. It looks a little goofy when empty but it's pretty okay when it's filled with data. (I either do this or re-implement columns myself **ʷʰᶦᶜʰ ᴵ ʷᶦˡˡ ʰᵃᵛᵉ ᵗᵒ ᵈᵒ ᶠᵒʳ ᵗʰᵉ ʳᵉᵍᶦˢᵗᵉʳ ʷᶦᵈᵍᵉᵗ**)
- Whenever a breakpoint is hit it'll take you to the breaking CPU tab and change the colour of the tab text
- Fall back to an unmangled symbol when a symbol cannot be demangled in the disassembly view (oops x2)
- Until the disassembly widget is updated, I've turned off pseudo instructions. It sometimes doesn't make any sense and can be confusing

### Rationale behind Changes
Who doesn't like improvements?

### Suggested Testing Steps
Test if what I said above works
