### PR TITLE
Achievements: Disable Hardcore Mode if the game has a RetroAchievements entry, but no achievements or leaderboards

### DIFF
--- a/pcsx2-qt/Settings/AchievementSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/AchievementSettingsWidget.cpp
@@ -127,7 +127,7 @@ void AchievementSettingsWidget::onHardcoreModeStateChanged()
 
 	// don't bother prompting if the game doesn't have achievements
 	auto lock = Achievements::GetLock();
-	if (!Achievements::HasActiveGame())
+	if (!Achievements::HasActiveGame() || !Achievements::HasAchievementsOrLeaderboards())
 		return;
 
 	if (QMessageBox::question(

--- a/pcsx2/Achievements.cpp
+++ b/pcsx2/Achievements.cpp
@@ -932,13 +932,23 @@ void Achievements::ClientLoadGameCallback(int result, const char* error_message,
 		return;
 	}
 
+	const bool has_achievements = rc_client_has_achievements(client);
+	const bool has_leaderboards = rc_client_has_leaderboards(client);
+
+	// If the game has a RetroAchievements entry but no achievements or leaderboards,
+	// enforcing hardcore mode is pointless.
+	if (!has_achievements && !has_leaderboards)
+	{
+		DisableHardcoreMode();
+	}
+
 	// We should have matched hardcore mode state.
 	pxAssertRel(s_hardcore_mode == (rc_client_get_hardcore_enabled(client) != 0), "Hardcore status mismatch");
 
 	s_game_id = info->id;
 	s_game_title = info->title;
-	s_has_achievements = rc_client_has_achievements(client);
-	s_has_leaderboards = rc_client_has_leaderboards(client);
+	s_has_achievements = has_achievements;
+	s_has_leaderboards = has_leaderboards;
 	s_has_rich_presence = rc_client_has_rich_presence(client);
 	s_game_icon = {};
 

--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -6299,14 +6299,19 @@ void FullscreenUI::DrawAchievementsSettingsPage(std::unique_lock<std::mutex>& se
 	// Check for challenge mode just being enabled.
 	if (check_challenge_state && enabled && bsi->GetBoolValue("Achievements", "ChallengeMode", false) && VMManager::HasValidVM())
 	{
-		ImGuiFullscreen::OpenConfirmMessageDialog(FSUI_STR("Reset System"),
-			FSUI_STR("Hardcore mode will not be enabled until the system is reset. Do you want to reset the system now?"), [](bool reset) {
-				if (!VMManager::HasValidVM())
-					return;
+		// don't bother prompting if the game doesn't have achievements
+		auto lock = Achievements::GetLock();
+		if (Achievements::HasActiveGame() && Achievements::HasAchievementsOrLeaderboards())
+		{
+			ImGuiFullscreen::OpenConfirmMessageDialog(FSUI_STR("Reset System"),
+				FSUI_STR("Hardcore mode will not be enabled until the system is reset. Do you want to reset the system now?"), [](bool reset) {
+					if (!VMManager::HasValidVM())
+						return;
 
-				if (reset)
-					DoReset();
-			});
+					if (reset)
+						DoReset();
+				});
+		}
 	}
 
 	if (!IsEditingGameSettings(bsi))


### PR DESCRIPTION
### Description of Changes
As in the (lengthy) PR title. PCSX2 already disables Hardcore Mode if the game has no RetroAchievements entry, but it kept it enabled if the entry was there but was empty.

### Rationale behind Changes
Consistency. Hardcore Mode is not needed if there is nothing to earn in the game.

### Suggested Testing Steps
1. Ensure that Hardcore Mode still works in games with achievements.
2. Ensure that Hardcore Mode turns off if the game has a RetroAchievements entry, but no achievements or leaderboards.
3. Try to check if no stupid exploits are created by this.
