### PR TITLE
Debugger: Fix IOP stack tracing

### DIFF
--- a/pcsx2/DebugTools/DebugInterface.cpp
+++ b/pcsx2/DebugTools/DebugInterface.cpp
@@ -1003,14 +1003,22 @@ std::string R3000DebugInterface::disasm(u32 address, bool simplify)
 
 bool R3000DebugInterface::isValidAddress(u32 addr)
 {
-	if (addr >= 0x10000000 && addr < 0x10010000)
+	if (addr >= 0x1D000000 && addr < 0x1E000000)
+	{
 		return true;
-	if (addr >= 0x12000000 && addr < 0x12001100)
-		return true;
-	if (addr >= 0x70000000 && addr < 0x70004000)
-		return true;
+	}
 
-	return !(addr & 0x40000000) && vtlb_GetPhyPtr(addr & 0x1FFFFFFF) != NULL;
+	if (addr >= 0x1F400000 && addr < 0x1FA00000)
+	{
+		return true;
+	}
+
+	if (addr < 0x200000)
+	{
+		return true;
+	}
+
+	return false;
 }
 
 u32 R3000DebugInterface::getCycles()

--- a/pcsx2/DebugTools/MipsStackWalk.cpp
+++ b/pcsx2/DebugTools/MipsStackWalk.cpp
@@ -68,6 +68,16 @@ namespace MipsStackWalk
 		return false;
 	}
 
+	bool IsJRInstr(const R5900::OPCODE& op)
+	{
+		if ((op.flags & IS_BRANCH) && (op.flags & BRANCHTYPE_REGISTER))
+		{
+			return true;
+		}
+
+		return false;
+	}
+
 	bool IsAddImmInstr(const R5900::OPCODE& op)
 	{
 		if (op.flags & IS_ALU)
@@ -114,21 +124,12 @@ namespace MipsStackWalk
 		int ra_offset = -1;
 		const u32 start = frame.pc;
 		u32 stop = entry;
+
 		if (entry == INVALIDTARGET)
 		{
-			/*			if (start >= PSP_GetUserMemoryBase()) {
-				stop = PSP_GetUserMemoryBase();
-			} else if (start >= PSP_GetKernelMemoryBase()) {
-				stop = PSP_GetKernelMemoryBase();
-			} else if (start >= PSP_GetScratchpadMemoryBase()) {
-				stop = PSP_GetScratchpadMemoryBase();
-			}*/
-			stop = 0x80000;
+			stop = std::max<s64>(0, (s64)start - LONGEST_FUNCTION);
 		}
-		if (stop < start - LONGEST_FUNCTION)
-		{
-			stop = start - LONGEST_FUNCTION;
-		}
+
 		for (u32 pc = start; cpu->isValidAddress(pc) && pc >= stop; pc -= 4)
 		{
 			u32 rawOp = cpu->read32(pc);

--- a/pcsx2/DebugTools/MipsStackWalk.cpp
+++ b/pcsx2/DebugTools/MipsStackWalk.cpp
@@ -35,68 +35,78 @@
 
 #define INVALIDTARGET 0xFFFFFFFF
 
-namespace MipsStackWalk {
+namespace MipsStackWalk
+{
 	// In the worst case, we scan this far above the pc for an entry.
 	const int MAX_FUNC_SIZE = 32768 * 4;
 	// After this we assume we're stuck.
 	const size_t MAX_DEPTH = 1024;
 
-	static u32 GuessEntry(DebugInterface* cpu, u32 pc) {
+	static u32 GuessEntry(DebugInterface* cpu, u32 pc)
+	{
 		SymbolInfo info;
-		if (cpu->GetSymbolMap().GetSymbolInfo(&info, pc)) {
+		if (cpu->GetSymbolMap().GetSymbolInfo(&info, pc))
+		{
 			return info.address;
 		}
 		return INVALIDTARGET;
 	}
 
-	bool IsSWInstr(const R5900::OPCODE& op) {
+	bool IsSWInstr(const R5900::OPCODE& op)
+	{
 		if ((op.flags & IS_MEMORY) && (op.flags & IS_STORE))
 		{
 			switch (op.flags & MEMTYPE_MASK)
 			{
-			case MEMTYPE_WORD:
-			case MEMTYPE_DWORD:
-			case MEMTYPE_QWORD:
-				return true;
+				case MEMTYPE_WORD:
+				case MEMTYPE_DWORD:
+				case MEMTYPE_QWORD:
+					return true;
 			}
 		}
 
 		return false;
 	}
 
-	bool IsAddImmInstr(const R5900::OPCODE& op) {
+	bool IsAddImmInstr(const R5900::OPCODE& op)
+	{
 		if (op.flags & IS_ALU)
 			return (op.flags & ALUTYPE_MASK) == ALUTYPE_ADDI;
 
 		return false;
 	}
 
-	bool IsMovRegsInstr(const R5900::OPCODE& op, u32 rawOp) {
+	bool IsMovRegsInstr(const R5900::OPCODE& op, u32 rawOp)
+	{
 		if (op.flags & IS_ALU)
 			return (op.flags & ALUTYPE_MASK) == ALUTYPE_ADDI && (_RS == 0 || _RT == 0);
 
 		return false;
 	}
 
-	bool ScanForAllocaSignature(DebugInterface* cpu, u32 pc) {
+	bool ScanForAllocaSignature(DebugInterface* cpu, u32 pc)
+	{
 		// In God Eater Burst, for example, after 0880E750, there's what looks like an alloca().
 		// It's surrounded by "mov fp, sp" and "mov sp, fp", which is unlikely to be used for other reasons.
 
 		// It ought to be pretty close.
 		u32 stop = pc - 32 * 4;
-		for (; cpu->isValidAddress(pc) && pc >= stop; pc -= 4) {
+		for (; cpu->isValidAddress(pc) && pc >= stop; pc -= 4)
+		{
 			u32 rawOp = cpu->read32(pc);
 			const R5900::OPCODE& op = R5900::GetInstruction(rawOp);
 
 			// We're looking for a "mov fp, sp" close by a "addiu sp, sp, -N".
-			if (IsMovRegsInstr(op,rawOp) && _RD == MIPS_REG_FP && (_RS == MIPS_REG_SP || _RT == MIPS_REG_SP)) {
+			if (IsMovRegsInstr(op, rawOp) && _RD == MIPS_REG_FP && (_RS == MIPS_REG_SP || _RT == MIPS_REG_SP))
+			{
 				return true;
 			}
 		}
 		return false;
 	}
 
-	bool ScanForEntry(DebugInterface* cpu, StackFrame &frame, u32 entry, u32 &ra) {
+	bool ScanForEntry(DebugInterface* cpu, StackFrame& frame, u32 entry, u32& ra)
+	{
 		// Let's hope there are no > 1MB functions on the PSP, for the sake of humanity...
 		const u32 LONGEST_FUNCTION = 1024 * 1024;
 		// TODO: Check if found entry is in the same symbol?  Might be wrong sometimes...
@@ -104,8 +114,9 @@ namespace MipsStackWalk {
 		int ra_offset = -1;
 		const u32 start = frame.pc;
 		u32 stop = entry;
-		if (entry == INVALIDTARGET) {
-/*			if (start >= PSP_GetUserMemoryBase()) {
+		if (entry == INVALIDTARGET)
+		{
+			/*			if (start >= PSP_GetUserMemoryBase()) {
 				stop = PSP_GetUserMemoryBase();
 			} else if (start >= PSP_GetKernelMemoryBase()) {
 				stop = PSP_GetKernelMemoryBase();
@@ -114,31 +125,38 @@ namespace MipsStackWalk {
 			}*/
 			stop = 0x80000;
 		}
-		if (stop < start - LONGEST_FUNCTION) {
+		if (stop < start - LONGEST_FUNCTION)
+		{
 			stop = start - LONGEST_FUNCTION;
 		}
-		for (u32 pc = start; cpu->isValidAddress(pc) && pc >= stop; pc -= 4) {
+		for (u32 pc = start; cpu->isValidAddress(pc) && pc >= stop; pc -= 4)
+		{
 			u32 rawOp = cpu->read32(pc);
 			const R5900::OPCODE& op = R5900::GetInstruction(rawOp);
 
 			// Here's where they store the ra address.
-			if (IsSWInstr(op) && _RT == MIPS_REG_RA && _RS == MIPS_REG_SP) {
+			if (IsSWInstr(op) && _RT == MIPS_REG_RA && _RS == MIPS_REG_SP)
+			{
 				ra_offset = _IMM16;
 			}
 
-			if (IsAddImmInstr(op) && _RT == MIPS_REG_SP && _RS == MIPS_REG_SP) {
+			if (IsAddImmInstr(op) && _RT == MIPS_REG_SP && _RS == MIPS_REG_SP)
+			{
 				// A positive imm either means alloca() or we went too far.
-				if (_IMM16 > 0) {
+				if (_IMM16 > 0)
+				{
 					// TODO: Maybe check for any alloca() signature and bail?
 					continue;
 				}
-				if (ScanForAllocaSignature(cpu,pc)) {
+				if (ScanForAllocaSignature(cpu, pc))
+				{
 					continue;
 				}
 
 				frame.entry = pc;
 				frame.stackSize = -_IMM16;
-				if (ra_offset != -1 && cpu->isValidAddress(frame.sp + ra_offset)) {
+				if (ra_offset != -1 && cpu->isValidAddress(frame.sp + ra_offset))
+				{
 					ra = cpu->read32(frame.sp + ra_offset);
 				}
 				return true;
@@ -147,11 +165,15 @@ namespace MipsStackWalk {
 		return false;
 	}
 
-	bool DetermineFrameInfo(DebugInterface* cpu, StackFrame &frame, u32 possibleEntry, u32 threadEntry, u32 &ra) {
-		if (ScanForEntry(cpu, frame, possibleEntry, ra)) {
+	bool DetermineFrameInfo(DebugInterface* cpu, StackFrame& frame, u32 possibleEntry, u32 threadEntry, u32& ra)
+	{
+		if (ScanForEntry(cpu, frame, possibleEntry, ra))
+		{
 			// Awesome, found one that looks right.
 			return true;
-		} else if (ra != INVALIDTARGET && possibleEntry != INVALIDTARGET) {
+		}
+		else if (ra != INVALIDTARGET && possibleEntry != INVALIDTARGET)
+		{
 			// Let's just assume it's a leaf.
 			frame.entry = possibleEntry;
 			frame.stackSize = 0;
@@ -164,7 +186,8 @@ namespace MipsStackWalk {
 		return ScanForEntry(cpu, frame, newPossibleEntry, ra);
 	}
 
-	std::vector<StackFrame> Walk(DebugInterface* cpu, u32 pc, u32 ra, u32 sp, u32 threadEntry, u32 threadStackTop) {
+	std::vector<StackFrame> Walk(DebugInterface* cpu, u32 pc, u32 ra, u32 sp, u32 threadEntry, u32 threadStackTop)
+	{
 		std::vector<StackFrame> frames;
 		StackFrame current;
 		current.pc = pc;
@@ -173,14 +196,18 @@ namespace MipsStackWalk {
 		current.stackSize = -1;
 
 		u32 prevEntry = INVALIDTARGET;
-		while (pc != threadEntry) {
+		while (pc != threadEntry)
+		{
 			u32 possibleEntry = GuessEntry(cpu, current.pc);
-			if (DetermineFrameInfo(cpu, current, possibleEntry, threadEntry, ra)) {
+			if (DetermineFrameInfo(cpu, current, possibleEntry, threadEntry, ra))
+			{
 				frames.push_back(current);
-				if (current.entry == threadEntry || GuessEntry(cpu, current.entry) == threadEntry) {
+				if (current.entry == threadEntry || GuessEntry(cpu, current.entry) == threadEntry)
+				{
 					break;
 				}
-				if (current.entry == prevEntry || frames.size() >= MAX_DEPTH) {
+				if (current.entry == prevEntry || frames.size() >= MAX_DEPTH)
+				{
 					// Recursion, means we're screwed.  Let's just give up.
 					break;
 				}
@@ -191,7 +218,9 @@ namespace MipsStackWalk {
 				ra = INVALIDTARGET;
 				current.entry = INVALIDTARGET;
 				current.stackSize = -1;
-			} else {
+			}
+			else
+			{
 				// Well, we got as far as we could.
 				current.entry = possibleEntry;
 				current.stackSize = 0;
@@ -202,4 +231,4 @@ namespace MipsStackWalk {
 
 		return frames;
 	}
-};
+}; // namespace MipsStackWalk


### PR DESCRIPTION
### Description of Changes
Fixes up EE assumptions in the stack walker as well as a wrong test for valid iop addresses.

### Rationale behind Changes
They've never worked previously.

### Suggested Testing Steps
Check that backtraces make sense on both ee and iop.
