### PR TITLE
CI/AppImage: Enable DBus for dependencies

### DIFF
--- a/.github/workflows/scripts/linux/build-dependencies-qt.sh
+++ b/.github/workflows/scripts/linux/build-dependencies-qt.sh
@@ -37,7 +37,7 @@ shasum -a 256 --check SHASUMS
 echo "Building SDL..."
 tar xf "$SDL.tar.gz"
 cd "$SDL"
-./configure --prefix "$INSTALLDIR" --disable-dbus --without-x --disable-video-opengl --disable-video-opengles --disable-video-vulkan --disable-wayland-shared --disable-ime --disable-oss --disable-alsa --disable-jack --disable-esd --disable-pipewire --disable-pulseaudio --disable-arts --disable-nas --disable-sndio --disable-fusionsound --disable-diskaudio
+./configure --prefix "$INSTALLDIR" --enable-dbus --without-x --disable-video-opengl --disable-video-opengles --disable-video-vulkan --disable-wayland-shared --disable-ime --disable-oss --disable-alsa --disable-jack --disable-esd --disable-pipewire --disable-pulseaudio --disable-arts --disable-nas --disable-sndio --disable-fusionsound --disable-diskaudio
 make "-j$NPROCS"
 make install
 cd ..
@@ -60,7 +60,7 @@ tar xf "qtbase-everywhere-src-$QT.tar.xz"
 cd "qtbase-everywhere-src-$QT"
 mkdir build
 cd build
-../configure -prefix "$INSTALLDIR" -release -no-dbus -gui -widgets -fontconfig -qt-doubleconversion -ssl -openssl-runtime -opengl desktop -qpa xcb,wayland -xkbcommon -- -DFEATURE_dbus=OFF -DFEATURE_icu=OFF -DFEATURE_printsupport=OFF -DFEATURE_sql=OFF
+../configure -prefix "$INSTALLDIR" -release -dbus-linked -gui -widgets -fontconfig -qt-doubleconversion -ssl -openssl-runtime -opengl desktop -qpa xcb,wayland -xkbcommon -- -DFEATURE_dbus=ON -DFEATURE_icu=OFF -DFEATURE_printsupport=OFF -DFEATURE_sql=OFF
 cmake --build . --parallel
 cmake --install .
 cd ../../

--- a/.github/workflows/scripts/linux/install-packages-qt.sh
+++ b/.github/workflows/scripts/linux/install-packages-qt.sh
@@ -41,6 +41,7 @@ declare -a PCSX2_PACKAGES=(
 	"libasound2-dev"
 	"libbz2-dev"
 	"libcurl4-openssl-dev"
+	"libdbus-1-dev"
 	"libegl1-mesa-dev"
 	"libgl1-mesa-dev"
 	"libgtk-3-dev"


### PR DESCRIPTION
### Description of Changes

Qt needs DBus support for global menu. We're already including DBus in the AppImage for screen saver inhibiting, so may as well build Qt with it too.

Note: Doesn't work in Wayland, because Wayland is broken by design rubbish. 

### Rationale behind Changes

Closes #10173.

### Suggested Testing Steps

Check if global menu works in AppImage.

