### PR TITLE
CI/Linux: Disable Wayland and spring cleaning

### DIFF
--- a/.github/workflows/linux_build_qt.yml
+++ b/.github/workflows/linux_build_qt.yml
@@ -110,8 +110,8 @@ jobs:
         env:
           COMPILER: ${{ inputs.compiler }}
           ADDITIONAL_CMAKE_ARGS: ${{ inputs.cmakeflags }}
-          CLANG_PATH: /usr/bin/clang-16
-          CLANGXX_PATH: /usr/bin/clang++-16
+          CLANG_PATH: /usr/bin/clang-17
+          CLANGXX_PATH: /usr/bin/clang++-17
         run: |
           DEPS_PREFIX="$HOME/deps" .github/workflows/scripts/linux/generate-cmake-qt.sh
 

--- a/.github/workflows/scripts/linux/flatpak/net.pcsx2.PCSX2.json
+++ b/.github/workflows/scripts/linux/flatpak/net.pcsx2.PCSX2.json
@@ -20,10 +20,10 @@
     "--share=network",
     "--share=ipc",
     "--socket=fallback-x11",
-    "--socket=wayland",
     "--socket=pulseaudio",
     "--filesystem=host:ro",
-    "--talk-name=org.freedesktop.ScreenSaver"
+    "--talk-name=org.freedesktop.ScreenSaver",
+    "--env=QT_QPA_PLATFORM=xcb"
   ],
   "modules": [
     "modules/10-libpcap.json",

--- a/.github/workflows/scripts/linux/flatpak/net.pcsx2.PCSX2.json
+++ b/.github/workflows/scripts/linux/flatpak/net.pcsx2.PCSX2.json
@@ -1,10 +1,10 @@
 {
   "app-id": "net.pcsx2.PCSX2",
   "runtime": "org.kde.Platform",
-  "runtime-version": "6.5",
+  "runtime-version": "6.6",
   "sdk": "org.kde.Sdk",
   "sdk-extensions": [
-    "org.freedesktop.Sdk.Extension.llvm16"
+    "org.freedesktop.Sdk.Extension.llvm17"
   ],
   "add-extensions": {
     "org.freedesktop.Platform.ffmpeg-full": {
@@ -39,8 +39,8 @@
         "env": {
           "DEPS_PREFIX": "/app",
           "COMPILER": "clang",
-          "CLANG_PATH": "/usr/lib/sdk/llvm16/bin/clang",
-          "CLANGXX_PATH": "/usr/lib/sdk/llvm16/bin/clang++",
+          "CLANG_PATH": "/usr/lib/sdk/llvm17/bin/clang",
+          "CLANGXX_PATH": "/usr/lib/sdk/llvm17/bin/clang++",
           "ADDITIONAL_CMAKE_ARGS": "-DUSE_LINKED_FFMPEG=ON"
         }
       },

--- a/.github/workflows/scripts/linux/flatpak/net.pcsx2.PCSX2.json
+++ b/.github/workflows/scripts/linux/flatpak/net.pcsx2.PCSX2.json
@@ -21,7 +21,6 @@
     "--share=ipc",
     "--socket=fallback-x11",
     "--socket=pulseaudio",
-    "--filesystem=host:ro",
     "--talk-name=org.freedesktop.ScreenSaver",
     "--env=QT_QPA_PLATFORM=xcb"
   ],
@@ -60,7 +59,8 @@
         "install -Dm644 bin/resources/icons/AppIconLarge.png ${FLATPAK_DEST}/share/icons/hicolor/512x512/apps/net.pcsx2.PCSX2.png",
         "install -Dm644 .github/workflows/scripts/linux/pcsx2-qt.desktop ${FLATPAK_DEST}/share/applications/net.pcsx2.PCSX2.desktop",
         "desktop-file-edit --set-key=Icon --set-value=net.pcsx2.PCSX2 ${FLATPAK_DEST}/share/applications/net.pcsx2.PCSX2.desktop",
-        "install -Dm644 .github/workflows/scripts/linux/flatpak/net.pcsx2.PCSX2.metainfo.xml ${FLATPAK_DEST}/share/metainfo/net.pcsx2.PCSX2.metainfo.xml"
+        "install -Dm644 .github/workflows/scripts/linux/flatpak/net.pcsx2.PCSX2.metainfo.xml ${FLATPAK_DEST}/share/metainfo/net.pcsx2.PCSX2.metainfo.xml",
+        "mkdir -p ${FLATPAK_DEST}/lib/ffmpeg"
       ]
     }
   ]

--- a/.github/workflows/scripts/linux/install-packages-flatpak.sh
+++ b/.github/workflows/scripts/linux/install-packages-flatpak.sh
@@ -6,8 +6,8 @@ source "$SCRIPTDIR/functions.sh"
 set -e
 
 ARCH=x86_64
-KDE_BRANCH=6.5
-BRANCH=22.08
+KDE_BRANCH=6.6
+BRANCH=23.08
 FLAT_MANAGER_CLIENT_DIR="$HOME/.local/bin"
 
 # Build packages. Mostly needed for flat-manager-client.
@@ -30,7 +30,7 @@ declare -a FLATPAK_PACKAGES=(
   "org.kde.Platform/${ARCH}/${KDE_BRANCH}"
   "org.kde.Sdk/${ARCH}/${KDE_BRANCH}"
   "org.freedesktop.Platform.ffmpeg-full/${ARCH}/${BRANCH}"
-  "org.freedesktop.Sdk.Extension.llvm16/${ARCH}/${BRANCH}"
+  "org.freedesktop.Sdk.Extension.llvm17/${ARCH}/${BRANCH}"
   "org.freedesktop.appstream-glib/${ARCH}/stable"
 )
 

--- a/.github/workflows/scripts/linux/install-packages-qt.sh
+++ b/.github/workflows/scripts/linux/install-packages-qt.sh
@@ -65,11 +65,11 @@ declare -a PCSX2_PACKAGES=(
 )
 
 if [ "${COMPILER}" = "clang" ]; then
-	BUILD_PACKAGES+=("llvm-16" "lld-16" "clang-16")
+	BUILD_PACKAGES+=("llvm-17" "lld-17" "clang-17")
 
 	# Ubuntu 22.04 doesn't ship with LLVM 16, so we need to pull it from the llvm.org repos.
 	retry_command wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-	sudo apt-add-repository -n 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-16 main'
+	sudo apt-add-repository -n 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-17 main'
 fi
 
 retry_command sudo apt-get -qq update && break

--- a/cmake/SearchForStuff.cmake
+++ b/cmake/SearchForStuff.cmake
@@ -156,7 +156,7 @@ disable_compiler_warnings_for_target(cubeb)
 disable_compiler_warnings_for_target(speex)
 
 # Find the Qt components that we need.
-find_package(Qt6 6.5.3 COMPONENTS CoreTools Core GuiTools Gui WidgetsTools Widgets Network LinguistTools REQUIRED)
+find_package(Qt6 6.6.0 COMPONENTS CoreTools Core GuiTools Gui WidgetsTools Widgets Network LinguistTools REQUIRED)
 
 if(WIN32)
   add_subdirectory(3rdparty/rainterface EXCLUDE_FROM_ALL)


### PR DESCRIPTION
### Description of Changes

Disables Wayland, it's super broken/buggy in basically every scenario. KDE isn't _too_ buggy, GNOME is a complete disaster.

 - Stupid obsession with CSD in Gnome => inconsistency
 - Inability to position windows => window position saving doesn't work
 - NVIDIA just crashes in swap chain creation under Wayland
 - Broken global menus
 - and many others

Until they sort their s**t out, which is unlikely, since there's been very little progress over the last decade, just keep it disabled. For the Flatpaks, users can re-enable it with flatseal if they really want the crappy experience.

Bumps the Flatpak to the KDE/Qt 6.6 runtime, now that it's available.

Bumps the compiler to Clang/LLVM 17, as that's all that's available in 6.6

Removes the host:ro filesystem permission from the PCSX2 flatpak. It's not needed, since we go through portals for adding game directories, and gets rid of the big ass warning about filesystem access on flathub.

NOTE: If you're using third party launchers/frontends with the flatpak, this **will** break them, since they're probably not using portal paths. Go complain to your launcher/frontend about it, **not us**, there are ways they can work around it (but I'm not going to do their job for them, since a good number of them are scummy paid products).

### Rationale behind Changes

See above.

### Suggested Testing Steps

Make sure AppImage and Flatpak still work.
