### PR TITLE
Qt: Fix QFileDialog usage in NewInputRecordingDlg

### DIFF
--- a/pcsx2-qt/Tools/InputRecording/NewInputRecordingDlg.cpp
+++ b/pcsx2-qt/Tools/InputRecording/NewInputRecordingDlg.cpp
@@ -79,22 +79,14 @@ void NewInputRecordingDlg::onRecordingTypeSaveStateChecked(bool checked)
 
 void NewInputRecordingDlg::onBrowseForPathClicked()
 {
-	QFileDialog dialog(this);
-	dialog.setFileMode(QFileDialog::AnyFile);
-	dialog.setWindowTitle("Select a File");
-	dialog.setNameFilter(tr("Input Recording Files (*.p2m2)"));
-	dialog.setDefaultSuffix("p2m2");
-	QStringList fileNames;
-	if (dialog.exec())
-	{
-		fileNames = dialog.selectedFiles();
-	}
-	if (fileNames.length() > 0)
-	{
-		m_filePath = fileNames.first();
-		m_ui.m_filePathInput->setText(m_filePath);
-		updateFormStatus();
-	}
+	QString filter = tr("Input Recording Files (*.p2m2)");
+	QString filename = QFileDialog::getSaveFileName(this, tr("Select a File"), QString(), filter, &filter);
+	if (filename.isEmpty())
+		return;
+
+	m_filePath = std::move(filename);
+	m_ui.m_filePathInput->setText(m_filePath);
+	updateFormStatus();
 }
 
 void NewInputRecordingDlg::onAuthorNameChanged(const QString& text)


### PR DESCRIPTION
### Description of Changes

It was effectively creating a file open dialog, instead of a save dialog, and confusing GNOME.

GNOME is broken in so many ways, but this one was on us.

### Rationale behind Changes

See above.

### Suggested Testing Steps

Test saving input rec.
