### PR TITLE
GameDB: MGS 3 Fixes

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -26495,6 +26495,7 @@ SLES-82013:
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     halfPixelOffset: 2 # Fixes blurry characters.
     autoFlush: 2 # Fixes lens flare.
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
@@ -26520,6 +26521,7 @@ SLES-82024:
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     halfPixelOffset: 2 # Fixes blurry characters.
     autoFlush: 2 # Fixes lens flare.
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
@@ -26529,6 +26531,7 @@ SLES-82026:
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     halfPixelOffset: 2 # Fixes blurry characters.
     autoFlush: 2 # Fixes lens flare.
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
@@ -26578,6 +26581,7 @@ SLES-82032:
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     halfPixelOffset: 2 # Fixes blurry characters.
     autoFlush: 2 # Fixes lens flare.
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
@@ -26640,6 +26644,7 @@ SLES-82042:
     - BlitInternalFPSHack # Fixes internal FPS detection.
     - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
     halfPixelOffset: 2 # Fixes blurriness.
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
@@ -26650,6 +26655,7 @@ SLES-82043:
     - BlitInternalFPSHack # Fixes internal FPS detection.
     - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
     halfPixelOffset: 2 # Fixes blurriness.
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
@@ -26662,6 +26668,7 @@ SLES-82044:
     - BlitInternalFPSHack # Fixes internal FPS detection.
     - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
     halfPixelOffset: 2 # Fixes blurriness.
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
@@ -26672,6 +26679,7 @@ SLES-82045:
     - BlitInternalFPSHack # Fixes internal FPS detection.
     - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
     halfPixelOffset: 2 # Fixes blurriness.
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
@@ -26684,6 +26692,7 @@ SLES-82046:
     - BlitInternalFPSHack # Fixes internal FPS detection.
     - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
     halfPixelOffset: 2 # Fixes blurriness.
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
@@ -26694,6 +26703,7 @@ SLES-82047:
     - BlitInternalFPSHack # Fixes internal FPS detection.
     - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
     halfPixelOffset: 2 # Fixes blurriness.
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
@@ -26706,6 +26716,7 @@ SLES-82048:
     - BlitInternalFPSHack # Fixes internal FPS detection.
     - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
     halfPixelOffset: 2 # Fixes blurriness.
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
@@ -26716,6 +26727,7 @@ SLES-82049:
     - BlitInternalFPSHack # Fixes internal FPS detection.
     - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
     halfPixelOffset: 2 # Fixes blurriness.
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
@@ -26728,6 +26740,7 @@ SLES-82050:
     - BlitInternalFPSHack # Fixes internal FPS detection.
     - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
     halfPixelOffset: 2 # Fixes blurriness.
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
@@ -26740,6 +26753,7 @@ SLES-82051:
     - BlitInternalFPSHack # Fixes internal FPS detection.
     - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
     halfPixelOffset: 2 # Fixes blurriness.
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
@@ -26752,6 +26766,7 @@ SLES-82052:
     - BlitInternalFPSHack # Fixes internal FPS detection.
     - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
     halfPixelOffset: 2 # Fixes blurriness.
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
@@ -26764,6 +26779,7 @@ SLES-82053:
     - BlitInternalFPSHack # Fixes internal FPS detection.
     - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
     halfPixelOffset: 2 # Fixes blurriness.
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
@@ -27817,6 +27833,7 @@ SLKA-25251:
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     halfPixelOffset: 2 # Fixes blurriness.
     autoFlush: 2 # Fixes lens flare.
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
@@ -28225,6 +28242,7 @@ SLKA-25353:
     - BlitInternalFPSHack # Fixes internal FPS detection.
     - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
     halfPixelOffset: 2 # Fixes blurriness.
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
@@ -28236,6 +28254,7 @@ SLKA-25354:
     - BlitInternalFPSHack # Fixes internal FPS detection.
     - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
     halfPixelOffset: 2 # Fixes blurriness.
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
@@ -28249,6 +28268,7 @@ SLKA-25355:
     - BlitInternalFPSHack # Fixes internal FPS detection.
     - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
     halfPixelOffset: 2 # Fixes blurriness.
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
@@ -38535,6 +38555,7 @@ SLPM-65789:
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     halfPixelOffset: 2 # Fixes blurriness.
     autoFlush: 2 # Fixes lens flare.
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
@@ -38546,6 +38567,7 @@ SLPM-65790:
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     halfPixelOffset: 2 # Fixes blurriness.
     autoFlush: 2 # Fixes lens flare.
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
@@ -40370,6 +40392,7 @@ SLPM-66117:
     - BlitInternalFPSHack # Fixes internal FPS detection.
     - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
     halfPixelOffset: 2 # Fixes blurriness.
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
@@ -40382,6 +40405,7 @@ SLPM-66118:
     - BlitInternalFPSHack # Fixes internal FPS detection.
     - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
     halfPixelOffset: 2 # Fixes blurriness.
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
@@ -40394,6 +40418,7 @@ SLPM-66119:
     - BlitInternalFPSHack # Fixes internal FPS detection.
     - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
     halfPixelOffset: 2 # Fixes blurriness.
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
@@ -40983,6 +41008,7 @@ SLPM-66220:
     - BlitInternalFPSHack # Fixes internal FPS detection.
     - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
     halfPixelOffset: 2 # Fixes blurriness.
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
@@ -40997,6 +41023,7 @@ SLPM-66221:
     - BlitInternalFPSHack # Fixes internal FPS detection.
     - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
     halfPixelOffset: 2 # Fixes blurriness.
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
@@ -41011,6 +41038,7 @@ SLPM-66222:
     - BlitInternalFPSHack # Fixes internal FPS detection.
     - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
     halfPixelOffset: 2 # Fixes blurriness.
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
@@ -41025,6 +41053,7 @@ SLPM-66223:
     - BlitInternalFPSHack # Fixes internal FPS detection.
     - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
     halfPixelOffset: 2 # Fixes blurriness.
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
@@ -41039,6 +41068,7 @@ SLPM-66224:
     - BlitInternalFPSHack # Fixes internal FPS detection.
     - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
     halfPixelOffset: 2 # Fixes blurriness.
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
@@ -44391,6 +44421,7 @@ SLPM-66794:
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     halfPixelOffset: 2 # Fixes blurriness.
     autoFlush: 2 # Fixes lens flare.
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
@@ -45812,6 +45843,7 @@ SLPM-68516:
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     halfPixelOffset: 2 # Fixes blurriness.
     autoFlush: 2 # Fixes lens flare.
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
@@ -59228,6 +59260,7 @@ SLUS-20915:
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     halfPixelOffset: 2 # Fixes blurriness.
     autoFlush: 2 # Fixes lens flare.
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
@@ -61096,6 +61129,7 @@ SLUS-21243:
     - BlitInternalFPSHack # Fixes internal FPS detection.
     - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
     halfPixelOffset: 2 # Fixes blurriness.
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
@@ -61834,6 +61868,7 @@ SLUS-21359:
     - BlitInternalFPSHack # Fixes internal FPS detection.
     - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
     halfPixelOffset: 2 # Fixes blurriness.
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
@@ -61844,6 +61879,7 @@ SLUS-21360:
     - BlitInternalFPSHack # Fixes internal FPS detection.
     - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
     halfPixelOffset: 2 # Fixes blurriness.
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
@@ -66042,6 +66078,7 @@ TLES-82043:
     - BlitInternalFPSHack # Fixes internal FPS detection.
     - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
     halfPixelOffset: 2 # Fixes blurriness.
 VW067-J1:


### PR DESCRIPTION
### Description of Changes
Fixes for skin colour and banding by recommending high blending.

Basic:
![Metal Gear Solid 3 - Subsistence  Disc 1 of 3 _SLUS-21359_20231025162644](https://github.com/PCSX2/pcsx2/assets/80843560/90d8b428-3d1b-42c2-a9d7-7c313a88baab)

High:
![Metal Gear Solid 3 - Subsistence  Disc 1 of 3 _SLUS-21359_20231025162711](https://github.com/PCSX2/pcsx2/assets/80843560/4079757f-5915-470c-8792-cc45d94f4e87)

### Rationale behind Changes
Banding is gross and bad.

### Suggested Testing Steps
Make sure CI Is happy.
