### PR TITLE
GS/HW: Disable texture when not required

### DIFF
--- a/pcsx2/GS/GSRegs.h
+++ b/pcsx2/GS/GSRegs.h
@@ -545,6 +545,7 @@ REG_END2
 	// output will be Cd, Cs is discarded
 	__forceinline bool IsCdOutput() const { return (C == 2 && D != 1 && FIX == 0x00); }
 	__forceinline bool IsUsingCs() const { return (A == 0 || B == 0 || D == 0); }
+	__forceinline bool IsUsingAs() const { return (A != B && C == 0); }
 
 	__forceinline bool IsBlack() const { return ((C == 2 && FIX == 0) || (A == 2 && A == B)) && D == 2; }
 REG_END2

--- a/pcsx2/GS/Renderers/Common/GSRenderer.h
+++ b/pcsx2/GS/Renderers/Common/GSRenderer.h
@@ -39,6 +39,7 @@ private:
 protected:
 	GSVector2i m_real_size{0, 0};
 	bool m_texture_shuffle = false;
+	bool m_process_texture = false;
 	bool m_copy_16bit_to_target_shuffle = false;
 	bool m_same_group_texture_shuffle = false;
 


### PR DESCRIPTION
### Description of Changes
Disable using texture when not required

### Rationale behind Changes
Sometimes texture mapping can be enabled when it isn't required, meaning a lookup is done but not required. This avoids it where possible.

### Suggested Testing Steps
Test games, including ones listed. None of these games have been performance tested, only dump run for changes.

Reduction in stats, perf change questionable if it happens:

Ace combat 04: -1 Upload
Fire Pro Wrestling: -1 Upload
Futurama: -1 Upload
Maximo vs. Army of Zin: -1 Upload
Mobile Suit Gundam - Zeonic Front: -1 Upload
Need for Speed - Underground: -1 Render Pass and -1 Copy
Spider-Man 2: -1 Upload (-2 Uploads in another scene)

Also potential performance implications to test for on (no reduction in stats but all disable texturing):

Captain Tsubasa
Conspiracy - Weapons of Mass Distruction
Destroy All Humans
Drakan
Enthusia Professional Racing
Scarface - The World is Yours
Time Crisis 2 (1322 hits in dumps, quite a lot)
UEFA Champions League
Valkyrie Profile 2 (varies from 24 to 912 hits, scene/dump dependent)
Xenosaga Episode III