### PR TITLE
CI/Flatpak: Validate build before pushing

### DIFF
--- a/.github/workflows/linux_build_flatpak.yml
+++ b/.github/workflows/linux_build_flatpak.yml
@@ -85,6 +85,10 @@ jobs:
           cat .github/workflows/scripts/linux/flatpak/net.pcsx2.PCSX2.metainfo.xml
           flatpak run org.freedesktop.appstream-glib validate .github/workflows/scripts/linux/flatpak/net.pcsx2.PCSX2.metainfo.xml
 
+      - name: Validate manifest
+        run: |
+          flatpak run --command=flatpak-builder-lint org.flatpak.Builder manifest .github/workflows/scripts/linux/flatpak/net.pcsx2.PCSX2.json
+
       - name: Build Flatpak
         uses: flatpak/flatpak-github-actions/flatpak-builder@v6.3
         with:
@@ -102,6 +106,14 @@ jobs:
       - name: Commit screenshots to OSTree
         run: |
           ostree commit --repo=repo --canonical-permissions --branch=screenshots/x86_64 flatpak_app/screenshots
+
+      - name: Validate build directory
+        run: |
+          flatpak run --command=flatpak-builder-lint org.flatpak.Builder builddir flatpak_app
+
+      - name: Validate repo
+        run: |
+          flatpak run --command=flatpak-builder-lint org.flatpak.Builder repo repo
 
       - name: Push to Flathub beta
         if: inputs.publish == true && inputs.branch == 'beta'

--- a/.github/workflows/scripts/linux/flatpak/net.pcsx2.PCSX2.json
+++ b/.github/workflows/scripts/linux/flatpak/net.pcsx2.PCSX2.json
@@ -19,7 +19,7 @@
     "--device=all",
     "--share=network",
     "--share=ipc",
-    "--socket=fallback-x11",
+    "--socket=x11",
     "--socket=pulseaudio",
     "--talk-name=org.freedesktop.ScreenSaver",
     "--env=QT_QPA_PLATFORM=xcb"

--- a/.github/workflows/scripts/linux/install-packages-flatpak.sh
+++ b/.github/workflows/scripts/linux/install-packages-flatpak.sh
@@ -46,6 +46,9 @@ sudo flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub
 echo "Will install the following packages for building - ${FLATPAK_PACKAGES[*]}"
 retry_command sudo flatpak -y install "${FLATPAK_PACKAGES[@]}"
 
+echo "Installing Flatpak Builder"
+retry_command sudo flatpak -y install flathub org.flatpak.builder
+
 echo "Downloading flat-manager-client"
 mkdir -p "$FLAT_MANAGER_CLIENT_DIR"
 pushd "$FLAT_MANAGER_CLIENT_DIR"


### PR DESCRIPTION
### Description of Changes

Flathub is going to enable server-side release validation, therefore we should validate on our end before pushing.

### Rationale behind Changes

Closes #10133.

### Suggested Testing Steps

Make sure Flatpak still works.
