### PR TITLE
CI/AppImage: Work around GH runner issue #8659

### DIFF
--- a/.github/workflows/linux_build_qt.yml
+++ b/.github/workflows/linux_build_qt.yml
@@ -51,6 +51,14 @@ jobs:
       CCACHE_MAXSIZE: 100M
 
     steps:
+      # Work around https://github.com/actions/runner-images/issues/8659
+      - name: Remove GCC 13 from runner image
+        shell: bash
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/ubuntu-toolchain-r-ubuntu-test-jammy.list
+          sudo apt-get update
+          sudo apt-get install -y --allow-downgrades libc6=2.35-0ubuntu3.4 libc6-dev=2.35-0ubuntu3.4 libstdc++6=12.3.0-1ubuntu1~22.04 libgcc-s1=12.3.0-1ubuntu1~22.04
+
       - name: Checkout Repository
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
### Description of Changes

GitHub runners have added the toolchain test repo, which pulled in GCC 13, which means that our AppImages no longer run on Ubuntu 22.04/Debian 12.

Until they fix that, try to remove the traces of GCC 13 from the runner image before building, which means it should link with the older libstdc++, and hopefully still work fine.

This is documented upstream at https://github.com/actions/runner-images/issues/8659

### Rationale behind Changes

Fixing AppImages on older-than-2023 distros.

### Suggested Testing Steps

Check AppImage on Ubuntu 22.04/Debian 12.
