### PR TITLE
GameDB: Add speedhack and hwfixes to McDonald's Original Happy Disc.

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -6897,6 +6897,13 @@ SCKA-90016:
 SCPM-85101:
   name: "McDonald's Original Happy Disc"
   region: "NTSC-J"
+  speedHacks:
+    instantVU1: 0 # Fixes noodles.
+    mtvu: 0
+  gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes metal textures.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SCPM-85301:
   name: "Gran Turismo Concept - Copen Special Edition [Demo]"
   region: "NTSC-J"


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Add speedhack and hwfixes to McDonald's Original Happy Disc.

PaRappa the Rapper 2:
Instant Vu 0, MTVU0, fixes noodles.

Pipo Saru 2001:
Recommended blend level high, fixes metal surfaces not being rendered correctly. Full mipmap, plus trilinear ps2, fixes ground textures to match sw renderer.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Fixes https://github.com/PCSX2/pcsx2/issues/9850

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
CI passes.
