### PR TITLE
GS: Disable interlace skipping on FMVs on SW FMV switch

### DIFF
--- a/pcsx2-qt/QtHost.cpp
+++ b/pcsx2-qt/QtHost.cpp
@@ -652,7 +652,7 @@ void EmuThread::switchRenderer(GSRendererType renderer)
 	if (!VMManager::HasValidVM())
 		return;
 
-	MTGS::SwitchRenderer(renderer);
+	MTGS::SwitchRenderer(renderer, EmuConfig.GS.InterlaceMode);
 }
 
 void EmuThread::changeDisc(CDVD_SourceType source, const QString& path)

--- a/pcsx2/Counters.cpp
+++ b/pcsx2/Counters.cpp
@@ -477,9 +477,9 @@ static __fi void DoFMVSwitch()
 	if (EmuConfig.Gamefixes.SoftwareRendererFMVHack && (GSConfig.UseHardwareRenderer() || (RendererSwitched && GSConfig.Renderer == GSRendererType::SW)))
 	{
 		RendererSwitched = GSConfig.UseHardwareRenderer();
-
+		DevCon.Warning("FMV Switch");
 		// we don't use the sw toggle here, because it'll change back to auto if set to sw
-		MTGS::SwitchRenderer(new_fmv_state ? GSRendererType::SW : EmuConfig.GS.Renderer, false);
+		MTGS::SwitchRenderer(new_fmv_state ? GSRendererType::SW : EmuConfig.GS.Renderer, new_fmv_state ? GSInterlaceMode::AdaptiveTFF : EmuConfig.GS.InterlaceMode, false);
 	}
 	else
 		RendererSwitched = false;

--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -780,7 +780,7 @@ void GSUpdateConfig(const Pcsx2Config::GSOptions& new_config)
 	}
 }
 
-void GSSwitchRenderer(GSRendererType new_renderer)
+void GSSwitchRenderer(GSRendererType new_renderer, GSInterlaceMode new_interlace)
 {
 	if (new_renderer == GSRendererType::Auto)
 		new_renderer = GSUtil::GetPreferredRenderer();
@@ -791,6 +791,8 @@ void GSSwitchRenderer(GSRendererType new_renderer)
 	const bool is_software_switch = (new_renderer == GSRendererType::SW || GSConfig.Renderer == GSRendererType::SW);
 	const Pcsx2Config::GSOptions old_config(GSConfig);
 	GSConfig.Renderer = new_renderer;
+	GSConfig.InterlaceMode = new_interlace;
+
 	if (!GSreopen(!is_software_switch, true, old_config))
 		pxFailRel("Failed to reopen GS for renderer switch.");
 }

--- a/pcsx2/GS/GS.h
+++ b/pcsx2/GS/GS.h
@@ -115,7 +115,7 @@ void GSgetTitleStats(std::string& info);
 void GSTranslateWindowToDisplayCoordinates(float window_x, float window_y, float* display_x, float* display_y);
 
 void GSUpdateConfig(const Pcsx2Config::GSOptions& new_config);
-void GSSwitchRenderer(GSRendererType new_renderer);
+void GSSwitchRenderer(GSRendererType new_renderer, GSInterlaceMode new_interlace);
 bool GSSaveSnapshotToMemory(u32 window_width, u32 window_height, bool apply_aspect, bool crop_borders,
 	u32* width, u32* height, std::vector<u32>* pixels);
 void GSJoinSnapshotThreads();

--- a/pcsx2/GS/Renderers/Common/GSRenderer.h
+++ b/pcsx2/GS/Renderers/Common/GSRenderer.h
@@ -75,7 +75,6 @@ public:
 	void QueueSnapshot(const std::string& path, u32 gsdump_frames);
 	void StopGSDump();
 	void PresentCurrentFrame();
-
 	bool BeginCapture(std::string filename, const GSVector2i& size = GSVector2i(0, 0));
 	void EndCapture();
 };

--- a/pcsx2/MTGS.cpp
+++ b/pcsx2/MTGS.cpp
@@ -990,7 +990,7 @@ void MTGS::UpdateVSyncMode()
 	SetVSyncMode(Host::GetEffectiveVSyncMode());
 }
 
-void MTGS::SwitchRenderer(GSRendererType renderer, bool display_message /* = true */)
+void MTGS::SwitchRenderer(GSRendererType renderer, GSInterlaceMode interlace, bool display_message /* = true */)
 {
 	pxAssertRel(IsOpen(), "MTGS is running");
 
@@ -1000,8 +1000,8 @@ void MTGS::SwitchRenderer(GSRendererType renderer, bool display_message /* = tru
 			Pcsx2Config::GSOptions::GetRendererName(renderer)), Host::OSD_INFO_DURATION);
 	}
 
-	RunOnGSThread([renderer]() {
-		GSSwitchRenderer(renderer);
+	RunOnGSThread([renderer, interlace]() {
+		GSSwitchRenderer(renderer, interlace);
 	});
 
 	// See note in ApplySettings() for reasoning here.
@@ -1018,7 +1018,7 @@ void MTGS::SetSoftwareRendering(bool software, bool display_message /* = true */
 	else
 		new_renderer = GSRendererType::SW;
 
-	SwitchRenderer(new_renderer, display_message);
+	SwitchRenderer(new_renderer, EmuConfig.GS.InterlaceMode, display_message);
 }
 
 void MTGS::ToggleSoftwareRendering()

--- a/pcsx2/MTGS.h
+++ b/pcsx2/MTGS.h
@@ -84,7 +84,7 @@ namespace MTGS
 	void UpdateDisplayWindow();
 	void SetVSyncMode(VsyncMode mode);
 	void UpdateVSyncMode();
-	void SwitchRenderer(GSRendererType renderer, bool display_message = true);
+	void SwitchRenderer(GSRendererType renderer, GSInterlaceMode interlace, bool display_message = true);
 	void SetSoftwareRendering(bool software, bool display_message = true);
 	void ToggleSoftwareRendering();
 	bool SaveMemorySnapshot(u32 window_width, u32 window_height, bool apply_aspect, bool crop_borders,


### PR DESCRIPTION
### Description of Changes
Disables the skipping of interlacing when Deinterlacing is on Auto if the SW FMV fix is enabled.

### Rationale behind Changes
A bunch of games have their interlacing built in to the FMV's, and they are expecting the native number of lines, so when you upscale the deinterlacing doesn't work because we're trying to deinterlace more lines.  Further to this we try to cheat when the interlacing is done in FIELD mode, which means the full frame is there and it reads every other line, we output a progressive signal, again this will break with said FMV's above, so this forces the normal MAD Adaptive deinterlacing (if a manual deinterlacing mode isn't set) to take place on these FMV's when the SW switch is engaged, this should drastically reduce combing in FMV's.

No-Interlacing patches will stop this working, just an FYI as it forces the deinterlacing mode to none. You can't have everything ;)

### Suggested Testing Steps
Test FFX FMV's with the SW FMV fix enabled, this is the game which inspired it. May also be good to do the same with Persona 3 as some people had complained about that, maybe others.
