### PR TITLE
PCRTC/Counters: Fix H-Blanks per frame

### DIFF
--- a/pcsx2/Counters.cpp
+++ b/pcsx2/Counters.cpp
@@ -216,11 +216,12 @@ static void vSyncInfoCalc(vSyncTimingInfo* info, double framesPerSecond, u32 sca
 	// Dynasty Warriors 3 Xtreme Legends - fake save corruption when loading save
 	// Jak II - random speedups
 	// Shadow of Rome - FMV audio issues
-	const bool ntsc_hblank = gsVideoMode != GS_VideoMode::PAL && gsVideoMode == GS_VideoMode::DVD_PAL;
+	const bool ntsc_hblank = gsVideoMode != GS_VideoMode::PAL && gsVideoMode != GS_VideoMode::DVD_PAL;
 	const u64 HalfFrame = Frame / 2;
-	const u64 Blank = Scanline * ((ntsc_hblank ? 22 : 25) + static_cast<int>(!IsProgressiveVideoMode()));
+	const float extra_scanlines = static_cast<float>(IsProgressiveVideoMode()) * (ntsc_hblank ? 0.5f : 1.5f);
+	const u64 Blank = Scanline * ((ntsc_hblank ? 22.5f : 24.5f) + extra_scanlines);
 	const u64 Render = HalfFrame - Blank;
-	const u64 GSBlank = Scanline * (ntsc_hblank ? 3.5 : 3); // GS VBlank/CSR Swap happens roughly 3.5(NTSC) and 3(PAL) Scanlines after VBlank Start
+	const u64 GSBlank = Scanline * ((ntsc_hblank ? 3.5 : 3) + extra_scanlines); // GS VBlank/CSR Swap happens roughly 3.5(NTSC) and 3(PAL) Scanlines after VBlank Start
 
 	// Important!  The hRender/hBlank timers should be 50/50 for best results.
 	//  (this appears to be what the real EE's timing crystal does anyway)


### PR DESCRIPTION
### Description of Changes
Fixes the H-Blanks per frame according to testing.
Also fix a bug in checking if it's NTSC

### Rationale behind Changes
The numbers were slightly out, I retested them and they match pretty closely now.

### Suggested Testing Steps
Smoke test some games, maybe try some games with incorrect field orders, might be better now..

cycles values are bus cycles/256

----------------------------------------------------------------
Progressive NTSC

PCSX2
bus cycles during vblank 842 vrender 8785 vblank 842
blanks during vblank 23 vrender 240 vblank 23

PS2
bus cycles during vblank 842 vrender 8785 vblank 841
blanks during vblank 23 vrender 240 vblank 23

----------------------------------------------------------------
Progressive PAL

PCSX2
bus cycles during vblank 959 vrender 10617 vblank 958
blanks during vblank 26 vrender 288 vblank 26

PS2
bus cycles during vblank 958 vrender 10616 vblank 958
blanks during vblank 26 vrender 288 vblank 26

----------------------------------------------------------------
Interlaced NTSC

PCSX2
bus cycles during vblank 824 vrender 8786 vblank 823
blanks during vblank 23 vrender 240 vblank 22

PS2
bus cycles during vblank 823 vrender 8785 vblank 823
blanks during vblank 23 vrender 240 vblank 22

----------------------------------------------------------------
Interlaced PAL

PCSX2
bus cycles during vblank 903 vrender 10617 vblank 903
blanks during vblank 25 vrender 288 vblank 24

PS2
bus cycles during vblank 903 vrender 10616 vblank 903
blanks during vblank 25 vrender 288 vblank 24