### PR TITLE
CI/AppImage: Add I_WANT_A_BROKEN_WAYLAND_UI environment variable

### DIFF
--- a/.github/workflows/scripts/linux/appimage-qt.sh
+++ b/.github/workflows/scripts/linux/appimage-qt.sh
@@ -42,6 +42,16 @@ BINARY=pcsx2-qt
 APPDIRNAME=PCSX2.AppDir
 STRIP=strip
 
+declare -a MANUAL_QT_LIBS=(
+	"libQt6WaylandEglClientHwIntegration.so.6"
+)
+
+declare -a MANUAL_QT_PLUGINS=(
+	"wayland-decoration-client"
+	"wayland-graphics-integration-client"
+	"wayland-shell-integration"
+)
+
 set -e
 
 LINUXDEPLOY=./linuxdeploy-x86_64.AppImage
@@ -65,7 +75,6 @@ if [ ! -f "$APPIMAGETOOL" ]; then
 fi
 
 OUTDIR=$(realpath "./$APPDIRNAME")
-SCRIPTDIR=$(dirname "${BASH_SOURCE[0]}")
 rm -fr "$OUTDIR"
 
 # Why the nastyness? linuxdeploy strips our main binary, and there's no option to turn it off.
@@ -89,7 +98,8 @@ cp "$PCSX2DIR/.github/workflows/scripts/linux/pcsx2-qt.desktop" "net.pcsx2.PCSX2
 cp "$PCSX2DIR/bin/resources/icons/AppIconLarge.png" "PCSX2.png"
 
 echo "Running linuxdeploy to create AppDir..."
-EXTRA_QT_PLUGINS="core;gui;network;svg;widgets;xcbqpa" \
+EXTRA_QT_PLUGINS="core;gui;network;svg;waylandclient;widgets;xcbqpa" \
+EXTRA_PLATFORM_PLUGINS="libqwayland-egl.so;libqwayland-generic.so" \
 QMAKE="$DEPSDIR/bin/qmake" \
 NO_STRIP="1" \
 $LINUXDEPLOY --plugin qt --appdir="$OUTDIR" --executable="$BUILDDIR/bin/pcsx2-qt" \
@@ -97,6 +107,34 @@ $LINUXDEPLOY --plugin qt --appdir="$OUTDIR" --executable="$BUILDDIR/bin/pcsx2-qt
 
 echo "Copying resources into AppDir..."
 cp -a "$BUILDDIR/bin/resources" "$OUTDIR/usr/bin"
+
+# LinuxDeploy's Qt plugin doesn't include Wayland support. So manually copy in the additional Wayland libraries.
+echo "Copying Qt Wayland libraries..."
+for lib in "${MANUAL_QT_LIBS[@]}"; do
+	srcpath="$DEPSDIR/lib/$lib"
+	dstpath="$OUTDIR/usr/lib/$lib"
+	echo "  $srcpath -> $dstpath"
+	cp "$srcpath" "$dstpath"
+	$PATCHELF --set-rpath '$ORIGIN' "$dstpath"
+done
+
+# .. and plugins.
+echo "Copying Qt Wayland plugins..."
+for GROUP in "${MANUAL_QT_PLUGINS[@]}"; do
+	srcpath="$DEPSDIR/plugins/$GROUP"
+	dstpath="$OUTDIR/usr/plugins/$GROUP"
+	echo "  $srcpath -> $dstpath"
+	mkdir -p "$dstpath"
+
+	for srcsopath in $(find "$DEPSDIR/plugins/$GROUP" -iname '*.so'); do
+		# This is ../../ because it's usually plugins/group/name.so
+		soname=$(basename "$srcsopath")
+		dstsopath="$dstpath/$soname"
+		echo "    $srcsopath -> $dstsopath"
+		cp "$srcsopath" "$dstsopath"
+		$PATCHELF --set-rpath '$ORIGIN/../../lib:$ORIGIN' "$dstsopath"
+	done
+done
 
 # Restore unstripped deps (for cache).
 rm -fr "$DEPSDIR"
@@ -110,6 +148,17 @@ cp -a "$BUILDDIR/bin/translations" "$OUTDIR/usr/bin"
 echo "Generating AppStream metainfo..."
 mkdir -p "$OUTDIR/usr/share/metainfo"
 "$SCRIPTDIR/generate-metainfo.sh" "$OUTDIR/usr/share/metainfo/net.pcsx2.PCSX2.appdata.xml"
+
+# Copy in AppRun hooks.
+# Unfortunately linuxdeploy is a bit lame and doesn't let us provide our own AppRun hooks, instead
+# they have to come from plugins.. and screw writing one of those just to disable Wayland.
+echo "Copying AppRun hooks..."
+mkdir -p "$OUTDIR/apprun-hooks"
+for hookpath in "$SCRIPTDIR/apprun-hooks"/*; do
+	hookname=$(basename "$hookpath")
+	cp -v "$hookpath" "$OUTDIR/apprun-hooks/$hookname"
+	sed -i -e 's/exec /source "$this_dir"\/apprun-hooks\/"'"$hookname"'"\nexec /' "$OUTDIR/AppRun"
+done
 
 echo "Generating AppImage..."
 rm -f "$NAME.AppImage"

--- a/.github/workflows/scripts/linux/apprun-hooks/default-to-x11.sh
+++ b/.github/workflows/scripts/linux/apprun-hooks/default-to-x11.sh
@@ -1,0 +1,9 @@
+if [[ -z "$I_WANT_A_BROKEN_WAYLAND_UI" ]]; then
+	echo "Forcing X11 instead of Wayland, due to various protocol limitations"
+	echo "and Qt issues. If you want to use Wayland, launch PCSX2 with"
+	echo "I_WANT_A_BROKEN_WAYLAND_UI=YES set."
+	export QT_QPA_PLATFORM=xcb
+else
+	echo "Wayland is not being disabled. Do not complain when things break."
+fi
+


### PR DESCRIPTION
### Description of Changes

Slightly better version of #10179 which enables users to set an environment variable to force the use of Wayland if they want a rubbish, broken experience.

The way I had to do this was utterly disgusting, but LinuxDeploy doesn't let you add your own apprun-hooks, so we have to inject them in after the fact. Hopefully it won't break with some future LinuxDeploy update........

This'll probably have to stay around for years at least, because of the fundamental design flaws in the WL protocol, and if anything gets fixed, GNOME doesn't adopt it, so it's pointless. Guess we could check `XDG_SESSION_TYPE`, but as it stands, WL on KWin is broken too.

tldr, set `I_WANT_A_BROKEN_WAYLAND_UI=YES ./PCSX2.AppImage` (or any other value) if you want pain and suffering, and don't complain.

### Rationale behind Changes

Giving users the choice.

<img width="412" alt="image" src="https://github.com/PCSX2/pcsx2/assets/11288319/ba214de8-3a03-4e30-a9ed-7bda9b1ccde2">
<img width="550" alt="image" src="https://github.com/PCSX2/pcsx2/assets/11288319/44a77c6c-fd81-47e0-869d-208b8c97c353">

### Suggested Testing Steps

Test new option, make sure X11 gets used with it off.
