### PR TITLE
GameDB: Patch to fix Valkyrie Profile 2 PAL FMV timing

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -23834,6 +23834,11 @@ SLES-54644:
     roundSprite: 1 # Fixes area transition vertical lines and lessens red forest vertical lines.
     textureInsideRT: 1 # Required for swirl battle transition.
     nativePaletteDraw: 1
+  patches:
+    04CCB600:
+      content: |-
+        // Modifies the wait loop on FMV's to make sure 304 hsyncs pass instead of 288.
+        patch=1,EE,002B9A44,word,24110130
 SLES-54645:
   name: "Valkyrie Profile 2 - Silmeria"
   region: "PAL-F"


### PR DESCRIPTION
### Description of Changes
Patch to sync audio and video in Valkyrie Profile 2 FMV's

### Rationale behind Changes
I'm not sure on the source of this but, I suspect the game thinks somewhere that it's in NTSC mode instead of PAL (I think a few games do this), but I'm unsure where this would be.  This patch will suffice for the moment, until somebody completely dissects this game.

### Suggested Testing Steps
Test Valkyrie Profile 2 PAL FMV's