### PR TITLE
Qt: Show currently active savestate slot on status bar

### DIFF
--- a/pcsx2-qt/QtHost.cpp
+++ b/pcsx2-qt/QtHost.cpp
@@ -1016,7 +1016,8 @@ void EmuThread::updatePerformanceMetrics(bool force)
 		QString gs_stat;
 		if (THREAD_VU1)
 		{
-			gs_stat = QStringLiteral("%1 | EE: %2% | VU: %3% | GS: %4%")
+			gs_stat = tr("Slot: %1 | %2 | EE: %3% | VU: %4% | GS: %5%")
+						  .arg(VMManager::GetCurrentActiveSaveStateSlot())
 						  .arg(gs_stat_str.c_str())
 						  .arg(PerformanceMetrics::GetCPUThreadUsage(), 0, 'f', 0)
 						  .arg(PerformanceMetrics::GetVUThreadUsage(), 0, 'f', 0)
@@ -1024,7 +1025,8 @@ void EmuThread::updatePerformanceMetrics(bool force)
 		}
 		else
 		{
-			gs_stat = QStringLiteral("%1 | EE: %2% | GS: %3%")
+			gs_stat = tr("Slot: %1 | %2 | EE: %3% | GS: %4%")
+						  .arg(VMManager::GetCurrentActiveSaveStateSlot())
 						  .arg(gs_stat_str.c_str())
 						  .arg(PerformanceMetrics::GetCPUThreadUsage(), 0, 'f', 0)
 						  .arg(PerformanceMetrics::GetGSThreadUsage(), 0, 'f', 0);

--- a/pcsx2/Hotkeys.cpp
+++ b/pcsx2/Hotkeys.cpp
@@ -31,6 +31,10 @@
 
 static s32 s_current_save_slot = 1;
 static std::optional<LimiterModeType> s_limiter_mode_prior_to_hold_interaction;
+s32 VMManager::GetCurrentActiveSaveStateSlot()
+{
+	return s_current_save_slot;
+}
 
 void VMManager::Internal::ResetVMHotkeyState()
 {

--- a/pcsx2/VMManager.h
+++ b/pcsx2/VMManager.h
@@ -54,6 +54,9 @@ namespace VMManager
 	/// The number of usable save state slots.
 	static constexpr s32 NUM_SAVE_STATE_SLOTS = 10;
 
+	/// Returns the currently active savestate slot.
+	s32 GetCurrentActiveSaveStateSlot();
+
 	/// The stack size to use for threads running recompilers
 	static constexpr std::size_t EMU_THREAD_STACK_SIZE = 2 * 1024 * 1024; // µVU likes recursion
 


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
This PR adds the current active savestate slot indicator just like the one on 1.6.0

1.6.0:
![Screenshot_20231030_223353](https://github.com/PCSX2/pcsx2/assets/14798312/aa56c4e5-2016-4737-8140-8b52424997a3)


Nightly:
![Screenshot_20231030_223430](https://github.com/PCSX2/pcsx2/assets/14798312/d389870a-d205-4477-9e8b-5129be181aee)


### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Nice QoL feature so you don't have to constantly switch savestate slots just to see which one you are on at the moment.
Plus 1.6 used to have it so.... feature parity? ;)

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Make sure stuff doesn't break.