### PR TITLE
VU: scale VU0 cycle rate with EE + Fix EE Interpreter sync + Implement EE overclocking on Interpreter

### DIFF
--- a/pcsx2/Interpreter.cpp
+++ b/pcsx2/Interpreter.cpp
@@ -39,6 +39,16 @@ static fastjmp_buf intJmpBuf;
 
 static void intEventTest();
 
+u32 intGetCycles()
+{
+	return cpuBlockCycles;
+}
+
+void intSetCycles(u32 cycles)
+{
+	cpuBlockCycles = cycles;
+}
+
 // These macros are used to assemble the repassembler functions
 
 void intBreakpoint(bool memcheck)
@@ -178,7 +188,7 @@ static void execI()
 #endif
 
 
-	cpuBlockCycles += opcode.cycles;
+	cpuBlockCycles += opcode.cycles * (2 - ((cpuRegs.CP0.n.Config >> 18) & 0x1));
 
 	opcode.interpret();
 }

--- a/pcsx2/R5900.h
+++ b/pcsx2/R5900.h
@@ -220,6 +220,8 @@ alignas(16) extern tlbs tlb[48];
 
 extern bool eeEventTestIsActive;
 
+u32 intGetCycles();
+void intSetCycles(u32 cycles);
 void intSetBranch();
 
 // This is a special form of the interpreter's doBranch that is run from various

--- a/pcsx2/R5900.h
+++ b/pcsx2/R5900.h
@@ -220,8 +220,7 @@ alignas(16) extern tlbs tlb[48];
 
 extern bool eeEventTestIsActive;
 
-u32 intGetCycles();
-void intSetCycles(u32 cycles);
+void intUpdateCPUCycles();
 void intSetBranch();
 
 // This is a special form of the interpreter's doBranch that is run from various

--- a/pcsx2/VU0.cpp
+++ b/pcsx2/VU0.cpp
@@ -55,7 +55,7 @@ void COP2_Unknown()
 
 //****************************************************************************
 
-__fi void _vu0run(bool breakOnMbit, bool addCycles) {
+__fi void _vu0run(bool breakOnMbit, bool addCycles, bool sync_only) {
 
 	if (!(VU0.VI[REG_VPU_STAT].UL & 1)) return;
 
@@ -67,12 +67,22 @@ __fi void _vu0run(bool breakOnMbit, bool addCycles) {
 	}
 
 	u32 startcycle = cpuRegs.cycle;
-	u32 runCycles  = 0x7fffffff;
+	s32 runCycles  = 0x7fffffff;
+
+	if (sync_only)
+	{
+		cpuRegs.cycle += intGetCycles() >> 3;
+		intSetCycles(intGetCycles() & (1 << 3) - 1);
+		runCycles  = (s32)(cpuRegs.cycle - VU0.cycle);
+
+		if (runCycles < 0)
+			return;
+	}
 
 	do { // Run VU until it finishes or M-Bit
 		CpuVU0->Execute(runCycles);
 	} while ((VU0.VI[REG_VPU_STAT].UL & 1)						// E-bit Termination
-	  &&	(!breakOnMbit || !(VU0.flags & VUFLAG_MFLAGSET) || (s32)(cpuRegs.cycle - VU0.cycle) > 0));	// M-bit Break
+	  &&	!sync_only && (!breakOnMbit || (!(VU0.flags & VUFLAG_MFLAGSET) && (s32)(cpuRegs.cycle - VU0.cycle) > 0)));	// M-bit Break
 
 	// Add cycles if called from EE's COP2
 	if (addCycles)
@@ -85,15 +95,17 @@ __fi void _vu0run(bool breakOnMbit, bool addCycles) {
 	}
 }
 
-void _vu0WaitMicro()   { _vu0run(1, 1); } // Runs VU0 Micro Until E-bit or M-Bit End
-void _vu0FinishMicro() { _vu0run(0, 1); } // Runs VU0 Micro Until E-Bit End
-void vu0Finish()	   { _vu0run(0, 0); } // Runs VU0 Micro Until E-Bit End (doesn't stall EE)
+void _vu0WaitMicro()   { _vu0run(1, 1, 0); } // Runs VU0 Micro Until E-bit or M-Bit End
+void _vu0FinishMicro() { _vu0run(0, 1, 0); } // Runs VU0 Micro Until E-Bit End
+void vu0Finish()	   { _vu0run(0, 0, 0); } // Runs VU0 Micro Until E-Bit End (doesn't stall EE)
+void vu0Sync()		   { _vu0run(0, 0, 1); } // Runs VU0 until it catches up
 
 namespace R5900 {
 namespace Interpreter{
 namespace OpcodeImpl
 {
 	void LQC2() {
+		vu0Sync();
 		u32 addr = cpuRegs.GPR.r[_Rs_].UL[0] + (s16)cpuRegs.code;
 		if (_Ft_) {
 			memRead128(addr, VU0.VF[_Ft_].UQ);
@@ -107,6 +119,7 @@ namespace OpcodeImpl
 	//TODO: check this
 	// HUH why ? doesn't make any sense ...
 	void SQC2() {
+		vu0Sync();
 		u32 addr = _Imm_ + cpuRegs.GPR.r[_Rs_].UL[0];
 		memWrite128(addr, VU0.VF[_Ft_].UQ);
 	}
@@ -117,6 +130,8 @@ void QMFC2() {
 	if (cpuRegs.code & 1) {
 		_vu0FinishMicro();
 	}
+	else
+		vu0Sync();
 	if (_Rt_ == 0) return;
 	cpuRegs.GPR.r[_Rt_].UD[0] = VU0.VF[_Fs_].UD[0];
 	cpuRegs.GPR.r[_Rt_].UD[1] = VU0.VF[_Fs_].UD[1];
@@ -126,6 +141,8 @@ void QMTC2() {
 	if (cpuRegs.code & 1) {
 		_vu0WaitMicro();
 	}
+	else
+		vu0Sync();
 	if (_Fs_ == 0) return;
 	VU0.VF[_Fs_].UD[0] = cpuRegs.GPR.r[_Rt_].UD[0];
 	VU0.VF[_Fs_].UD[1] = cpuRegs.GPR.r[_Rt_].UD[1];
@@ -135,6 +152,8 @@ void CFC2() {
 	if (cpuRegs.code & 1) {
 		_vu0FinishMicro();
 	}
+	else
+		vu0Sync();
 	if (_Rt_ == 0) return;
 
 	if (_Fs_ == REG_R)
@@ -155,6 +174,8 @@ void CTC2() {
 	if (cpuRegs.code & 1) {
 		_vu0WaitMicro();
 	}
+	else
+		vu0Sync();
 	if (_Fs_ == 0) return;
 
 	switch(_Fs_) {

--- a/pcsx2/VU0.cpp
+++ b/pcsx2/VU0.cpp
@@ -66,13 +66,14 @@ __fi void _vu0run(bool breakOnMbit, bool addCycles, bool sync_only) {
 		return;
 	}
 
+	if(!EmuConfig.Cpu.Recompiler.EnableEE)
+		intUpdateCPUCycles();
+
 	u32 startcycle = cpuRegs.cycle;
 	s32 runCycles  = 0x7fffffff;
 
 	if (sync_only)
 	{
-		cpuRegs.cycle += intGetCycles() >> 3;
-		intSetCycles(intGetCycles() & (1 << 3) - 1);
 		runCycles  = (s32)(cpuRegs.cycle - VU0.cycle);
 
 		if (runCycles < 0)
@@ -127,33 +128,36 @@ namespace OpcodeImpl
 
 
 void QMFC2() {
+	vu0Sync();
+
 	if (cpuRegs.code & 1) {
 		_vu0FinishMicro();
 	}
-	else
-		vu0Sync();
+
 	if (_Rt_ == 0) return;
 	cpuRegs.GPR.r[_Rt_].UD[0] = VU0.VF[_Fs_].UD[0];
 	cpuRegs.GPR.r[_Rt_].UD[1] = VU0.VF[_Fs_].UD[1];
 }
 
 void QMTC2() {
+	vu0Sync();
+
 	if (cpuRegs.code & 1) {
 		_vu0WaitMicro();
 	}
-	else
-		vu0Sync();
+
 	if (_Fs_ == 0) return;
 	VU0.VF[_Fs_].UD[0] = cpuRegs.GPR.r[_Rt_].UD[0];
 	VU0.VF[_Fs_].UD[1] = cpuRegs.GPR.r[_Rt_].UD[1];
 }
 
 void CFC2() {
+	vu0Sync();
+
 	if (cpuRegs.code & 1) {
 		_vu0FinishMicro();
 	}
-	else
-		vu0Sync();
+
 	if (_Rt_ == 0) return;
 
 	if (_Fs_ == REG_R)
@@ -171,11 +175,12 @@ void CFC2() {
 }
 
 void CTC2() {
+	vu0Sync();
+
 	if (cpuRegs.code & 1) {
 		_vu0WaitMicro();
 	}
-	else
-		vu0Sync();
+
 	if (_Fs_ == 0) return;
 
 	switch(_Fs_) {

--- a/pcsx2/VU0.cpp
+++ b/pcsx2/VU0.cpp
@@ -42,7 +42,7 @@
 using namespace R5900;
 
 void COP2_BC2() { Int_COP2BC2PrintTable[_Rt_]();}
-void COP2_SPECIAL() { Int_COP2SPECIAL1PrintTable[_Funct_]();}
+void COP2_SPECIAL() { _vu0FinishMicro(); Int_COP2SPECIAL1PrintTable[_Funct_]();}
 
 void COP2_SPECIAL2() {
 	Int_COP2SPECIAL2PrintTable[(cpuRegs.code & 0x3) | ((cpuRegs.code >> 4) & 0x7c)]();

--- a/pcsx2/VU0microInterp.cpp
+++ b/pcsx2/VU0microInterp.cpp
@@ -286,6 +286,37 @@ void InterpVU0::Execute(u32 cycles)
 		vu0Exec(&VU0);
 	}
 	VU0.VI[REG_TPC].UL >>= 3;
-	VU0.nextBlockCycles = (VU0.cycle - cpuRegs.cycle) + 1;
+
+	if (EmuConfig.Speedhacks.EECycleRate != 0 && (!EmuConfig.Gamefixes.VUSyncHack || EmuConfig.Speedhacks.EECycleRate < 0))
+	{
+		u32 cycle_change = VU0.cycle - startcycles;
+		VU0.cycle -= cycle_change;
+		switch (std::min(static_cast<int>(EmuConfig.Speedhacks.EECycleRate), static_cast<int>(cycle_change)))
+		{
+			case -3: // 50%
+				cycle_change *= 2.0f;
+				break;
+			case -2: // 60%
+				cycle_change *= 1.6666667f;
+				break;
+			case -1: // 75%
+				cycle_change *= 1.3333333f;
+				break;
+			case 1: // 130%
+				cycle_change /= 1.3f;
+				break;
+			case 2: // 180%
+				cycle_change /= 1.8f;
+				break;
+			case 3: // 300%
+				cycle_change /= 3.0f;
+				break;
+			default:
+				break;
+		}
+		VU0.cycle += cycle_change;
+	}
 	fesetround(originalRounding);
+
+	VU0.nextBlockCycles = (VU0.cycle - cpuRegs.cycle) + 1;
 }

--- a/pcsx2/x86/microVU.h
+++ b/pcsx2/x86/microVU.h
@@ -135,7 +135,7 @@ struct microVU
 	u32 p;            // Holds current P instance index
 	u32 q;            // Holds current Q instance index
 	u32 totalCycles;  // Total Cycles that mVU is expected to run for
-	u32 cycles;       // Cycles Counter
+	s32 cycles;       // Cycles Counter
 
 	VURegs& regs() const { return ::vuRegs[index]; }
 

--- a/pcsx2/x86/microVU_Compile.inl
+++ b/pcsx2/x86/microVU_Compile.inl
@@ -464,7 +464,8 @@ void mVUtestCycles(microVU& mVU, microFlagCycles& mFC)
 {
 	iPC = mVUstartPC;
 
-	if (isVU0 && EmuConfig.Speedhacks.EECycleRate != 0)
+	// If the VUSyncHack is on, we want the VU to run behind, to avoid conditions where the VU is sped up.
+	if (isVU0 && EmuConfig.Speedhacks.EECycleRate != 0 && (!EmuConfig.Gamefixes.VUSyncHack || EmuConfig.Speedhacks.EECycleRate < 0))
 	{
 		switch (std::min(static_cast<int>(EmuConfig.Speedhacks.EECycleRate), static_cast<int>(mVUcycles)))
 		{

--- a/pcsx2/x86/microVU_Compile.inl
+++ b/pcsx2/x86/microVU_Compile.inl
@@ -464,6 +464,32 @@ void mVUtestCycles(microVU& mVU, microFlagCycles& mFC)
 {
 	iPC = mVUstartPC;
 
+	if (isVU0 && EmuConfig.Speedhacks.EECycleRate != 0)
+	{
+		switch (std::min(static_cast<int>(EmuConfig.Speedhacks.EECycleRate), static_cast<int>(mVUcycles)))
+		{
+			case -3: // 50%
+				mVUcycles *= 2.0f;
+				break;
+			case -2: // 60%
+				mVUcycles *= 1.6666667f;
+				break;
+			case -1: // 75%
+				mVUcycles *= 1.3333333f;
+				break;
+			case 1: // 130%
+				mVUcycles /= 1.3f;
+				break;
+			case 2: // 180%
+				mVUcycles /= 1.8f;
+				break;
+			case 3: // 300%
+				mVUcycles /= 3.0f;
+				break;
+			default:
+				break;
+		}
+	}
 	xMOV(eax, ptr32[&mVU.cycles]);
 	if (EmuConfig.Gamefixes.VUSyncHack)
 		xSUB(eax, mVUcycles); // Running behind, make sure we have time to run the block

--- a/pcsx2/x86/microVU_Execute.inl
+++ b/pcsx2/x86/microVU_Execute.inl
@@ -355,12 +355,12 @@ _mVUt void mVUcleanUp()
 		mVUreset(mVU, false);
 	}
 
-	mVU.cycles = mVU.totalCycles - mVU.cycles;
+	mVU.cycles = mVU.totalCycles - std::max(0, mVU.cycles);
 	mVU.regs().cycle += mVU.cycles;
 
 	if (!vuIndex || !THREAD_VU1)
 	{
-		u32 cycles_passed = std::min(mVU.cycles, 3000u) * EmuConfig.Speedhacks.EECycleSkip;
+		u32 cycles_passed = std::min(mVU.cycles, 3000) * EmuConfig.Speedhacks.EECycleSkip;
 		if (cycles_passed > 0)
 		{
 			s32 vu0_offset = VU0.cycle - cpuRegs.cycle;


### PR DESCRIPTION
### Description of Changes
Scale VU0 cycles with EE cycle rate
Also fix cycle underflow issue
Fix VU0 sync with EE interpreter
Implement EE overclocking on interpreter

### Rationale behind Changes
When the EE is over/underclocked, VU0 goes out of sync, which can cause problems, most prominently in Ratchet & Clank games, this tries to alleviate that somewhat by trying to keep the two more in sync, this does NOT mean it will be perfectly reliable, but may mean R&C will handle up to 180% without exploding. 300% will boot but the graphics will be broken (unless either VU0 or the EE is set to interpreter).

EE Interpreter changes were to stop Ratchet & Clank crashing but also allow you to over/underclock.

### Suggested Testing Steps
Test Ratchet & Clank games (maybe Jak as well?, other games if you care) with the EE overclocked, see if it works better.

I'm not really concerned if a game is still broken when it was before with overclocking, that is not the aim of this, I only want to know if this shows improvement.

Fixes #2090
