### PR TITLE
Updater:Mac: Show tar stderr if it fails

### DIFF
--- a/pcsx2-qt/AutoUpdaterDialog.cpp
+++ b/pcsx2-qt/AutoUpdaterDialog.cpp
@@ -789,7 +789,9 @@ bool AutoUpdaterDialog::processUpdate(const QByteArray& update_data, QProgressDi
 		progress.setValue(progress.maximum());
 		if (untar.exitCode() != EXIT_SUCCESS)
 		{
-			reportError("Failed to unpack update (tar exited with %u)", untar.exitCode());
+			QByteArray msg = untar.readAllStandardError();
+			const char* join = msg.isEmpty() ? "" : ": ";
+			reportError("Failed to unpack update (tar exited with %u%s%s)", untar.exitCode(), join, msg.toStdString().c_str());
 			return false;
 		}
 


### PR DESCRIPTION
### Description of Changes
Prints stderr from tar command if it fails

### Rationale behind Changes
User came to us with the updater failing due to being unable to unpack the update, maybe seeing the stderr from tar will help

### Suggested Testing Steps
Untested, but it hopefully won't be worse than the current error message
(If anyone can think of a way to make tar fail while creating the staging directory succeeds, please test that)