### PR TITLE
IOP HLE: Generate module list on release builds

### DIFF
--- a/pcsx2/IopBios.cpp
+++ b/pcsx2/IopBios.cpp
@@ -1103,7 +1103,7 @@ namespace R3000A
 			R3000SymbolMap.RemoveModule(modname, version);
 		}
 
-		void RegisterLibraryEntries_DEBUG()
+		int RegisterLibraryEntries_HLE()
 		{
 			LoadFuncs(a0);
 
@@ -1115,11 +1115,13 @@ namespace R3000A
 			}
 
 			CurrentBiosInformation.iopModListAddr = GetModList(a0);
+			return 0;
 		}
 
-		void ReleaseLibraryEntries_DEBUG()
+		int ReleaseLibraryEntries_HLE()
 		{
 			ReleaseFuncs(a0);
+			return 0;
 		}
 	} // namespace loadcore
 
@@ -1240,6 +1242,10 @@ namespace R3000A
 	{
 		// debugging output
 		// clang-format off
+		MODULE(loadcore)
+			EXPORT_H(  6, RegisterLibraryEntries)
+			EXPORT_H(  7, ReleaseLibraryEntries);
+		END_MODULE
 		MODULE(sysmem)
 			EXPORT_H( 14, Kprintf)
 		END_MODULE
@@ -1281,10 +1287,6 @@ namespace R3000A
 	irxDEBUG irxImportDebug(const std::string& libname, u16 index)
 	{
 		// clang-format off
-		MODULE(loadcore)
-			EXPORT_D(  6, RegisterLibraryEntries)
-			EXPORT_D(  7, ReleaseLibraryEntries);
-		END_MODULE
 		MODULE(intrman)
 			EXPORT_D(  4, RegisterIntrHandler)
 		END_MODULE


### PR DESCRIPTION
### Description of Changes
Moved the Register/ReleaseLibraryEntries HLE so it'll be run in release builds

### Rationale behind Changes
A lot of people debug with release builds and having a "broken" function window the debugger on these builds isn't that practical 

### Suggested Testing Steps
See if the function list works on release builds
