### PR TITLE
IPU: Pause IPU_TO on tag edge. Stop repeat Interrupts

### DIFF
--- a/pcsx2/IPU/IPU.cpp
+++ b/pcsx2/IPU/IPU.cpp
@@ -539,7 +539,7 @@ __fi void IPUCMD_WRITE(u32 val)
 	{
 		IPUCoreStatus.WaitingOnIPUFrom = false;
 		IPUCoreStatus.WaitingOnIPUTo = false;
-		CPU_INT(IPU_PROCESS, 64);
+		IPU_INT_PROCESS(64);
 	}
 	else
 		IPUWorker();

--- a/pcsx2/IPU/IPU.h
+++ b/pcsx2/IPU/IPU.h
@@ -24,7 +24,7 @@
 
 #define IPU_INT_TO( cycles )  if(!(cpuRegs.interrupt & (1<<4))) CPU_INT( DMAC_TO_IPU, cycles )
 #define IPU_INT_FROM( cycles )  CPU_INT( DMAC_FROM_IPU, cycles )
-
+#define IPU_INT_PROCESS( cycles ) if(!(cpuRegs.interrupt & (1 << IPU_PROCESS))) CPU_INT( IPU_PROCESS, cycles )
 //
 // Bitfield Structures
 //

--- a/pcsx2/IPU/IPU_Fifo.cpp
+++ b/pcsx2/IPU/IPU_Fifo.cpp
@@ -181,11 +181,11 @@ void WriteFIFO_IPUin(const mem128_t* value)
 	//committing every 16 bytes
 	if( ipu_fifo.in.write(value->_u32, 1) > 0 )
 	{
-		if (ipuRegs.ctrl.BUSY && IPUCoreStatus.WaitingOnIPUTo)
+		if (ipuRegs.ctrl.BUSY /*&& IPUCoreStatus.WaitingOnIPUTo*/)
 		{
 			IPUCoreStatus.WaitingOnIPUFrom = false;
 			IPUCoreStatus.WaitingOnIPUTo = false;
-			CPU_INT(IPU_PROCESS, 2 * BIAS);
+			IPU_INT_PROCESS(2 * BIAS);
 		}
 	}
 }

--- a/pcsx2/IPU/IPU_MultiISA.cpp
+++ b/pcsx2/IPU/IPU_MultiISA.cpp
@@ -1126,7 +1126,7 @@ __ri static bool mpeg2sliceIDEC()
 					ready_to_decode = false;
 					IPUCoreStatus.WaitingOnIPUFrom = false;
 					IPUCoreStatus.WaitingOnIPUTo = false;
-					CPU_INT(IPU_PROCESS, 64); // Should probably be much higher, but myst 3 doesn't like it right now.
+					IPU_INT_PROCESS( 64); // Should probably be much higher, but myst 3 doesn't like it right now.
 					ipu_cmd.pos[1] = 2;
 					return false;
 				}
@@ -1522,7 +1522,7 @@ __fi static bool mpeg2_slice()
 			ready_to_decode = false;
 			IPUCoreStatus.WaitingOnIPUFrom = false;
 			IPUCoreStatus.WaitingOnIPUTo = false;
-			CPU_INT(IPU_PROCESS, 64); // Should probably be much higher, but myst 3 doesn't like it right now.
+			IPU_INT_PROCESS( 64); // Should probably be much higher, but myst 3 doesn't like it right now.
 			return false;
 		}
 

--- a/pcsx2/IPU/IPUdma.cpp
+++ b/pcsx2/IPU/IPUdma.cpp
@@ -88,7 +88,7 @@ void IPU1dma()
 		if (IPUCoreStatus.WaitingOnIPUTo)
 		{
 			IPUCoreStatus.WaitingOnIPUTo = false;
-			CPU_INT(IPU_PROCESS, 4 * BIAS);
+			IPU_INT_PROCESS(4 * BIAS);
 		}
 		return;
 	}
@@ -130,7 +130,7 @@ void IPU1dma()
 		totalqwc += IPU1chain();
 
 	// Nothing has been processed except maybe a tag, or the DMA is ending
-	if(totalqwc == 0 || (IPU1Status.DMAFinished && !IPU1Status.InProgress) || IPUCoreStatus.DataRequested)
+	if(totalqwc == 0 || (IPU1Status.DMAFinished && !IPU1Status.InProgress))
 	{
 		totalqwc = std::max(4, totalqwc) + tagcycles;
 		IPU_INT_TO(totalqwc * BIAS);
@@ -144,7 +144,7 @@ void IPU1dma()
 	if (IPUCoreStatus.WaitingOnIPUTo && g_BP.IFC >= 1)
 	{
 		IPUCoreStatus.WaitingOnIPUTo = false;
-		CPU_INT(IPU_PROCESS, totalqwc * BIAS);
+		IPU_INT_PROCESS(totalqwc * BIAS);
 	}
 
 	IPU_LOG("Completed Call IPU1 DMA QWC Remaining %x Finished %d In Progress %d tadr %x", ipu1ch.qwc, IPU1Status.DMAFinished, IPU1Status.InProgress, ipu1ch.tadr);
@@ -174,7 +174,7 @@ void IPU0dma()
 		if (IPUCoreStatus.WaitingOnIPUFrom)
 		{
 			IPUCoreStatus.WaitingOnIPUFrom = false;
-			CPU_INT(IPU_PROCESS, ipuRegs.ctrl.OFC * BIAS);
+			IPU_INT_PROCESS(ipuRegs.ctrl.OFC * BIAS);
 		}
 		return;
 	}
@@ -208,7 +208,7 @@ void IPU0dma()
 	if (ipuRegs.ctrl.BUSY && IPUCoreStatus.WaitingOnIPUFrom)
 	{
 		IPUCoreStatus.WaitingOnIPUFrom = false;
-		CPU_INT(IPU_PROCESS, readsize * BIAS);
+		IPU_INT_PROCESS(readsize * BIAS);
 	}
 }
 


### PR DESCRIPTION
### Description of Changes
Stops transferring data on tag edges, also centralise IPU_PROCESS interrupts

### Rationale behind Changes
Transfers will stop on tag edges if there's no data request, until another request for data is made, I believe this was causing data to outstrip the reads, causing bad data to get uploaded.

### Suggested Testing Steps
test videos, especially sensitive games

Fixes #10232 WWE Smackdown Shut Your Mouth