### PR TITLE
SIO2/Pad/Multitap/Memcard: Assorted accuracy improvements for response data

### DIFF
--- a/pcsx2/SIO/Memcard/MemoryCardProtocol.cpp
+++ b/pcsx2/SIO/Memcard/MemoryCardProtocol.cpp
@@ -88,7 +88,18 @@ void MemoryCardProtocol::Probe()
 {
 	MC_LOG.WriteLn("%s", __FUNCTION__);
 	PS1_FAIL();
-	The2bTerminator(4);
+
+	if (!mcd->IsPresent())
+	{
+		g_Sio2FifoOut.push_back(0xff);
+		g_Sio2FifoOut.push_back(0xff);
+		g_Sio2FifoOut.push_back(0xff);
+		g_Sio2FifoOut.push_back(0xff);
+	}
+	else
+	{
+		The2bTerminator(4);
+	}
 }
 
 void MemoryCardProtocol::UnknownWriteDeleteEnd()
@@ -253,6 +264,12 @@ void MemoryCardProtocol::ReadData()
 u8 MemoryCardProtocol::PS1Read(u8 data)
 {
 	MC_LOG.WriteLn("%s", __FUNCTION__);
+
+	if (!mcd->IsPresent())
+	{
+		return 0xff;
+	}
+
 	bool sendAck = true;
 	u8 ret = 0;
 
@@ -489,7 +506,18 @@ void MemoryCardProtocol::AuthF3()
 {
 	MC_LOG.WriteLn("%s", __FUNCTION__);
 	PS1_FAIL();
-	The2bTerminator(5);
+
+	if (!mcd->IsPresent())
+	{
+		g_Sio2FifoOut.push_back(0xff);
+		g_Sio2FifoOut.push_back(0xff);
+		g_Sio2FifoOut.push_back(0xff);
+		g_Sio2FifoOut.push_back(0xff);
+	}
+	else
+	{
+		The2bTerminator(5);
+	}
 }
 
 void MemoryCardProtocol::AuthF7()

--- a/pcsx2/SIO/Multitap/MultitapProtocol.cpp
+++ b/pcsx2/SIO/Multitap/MultitapProtocol.cpp
@@ -15,6 +15,8 @@
 
 #include "PrecompiledHeader.h"
 
+#include "Common.h"
+
 #include "SIO/Multitap/MultitapProtocol.h"
 
 #include "SIO/Sio2.h"
@@ -23,35 +25,78 @@
 #define MT_LOG_ENABLE 0
 #define MT_LOG if (MT_LOG_ENABLE) DevCon
 
-MultitapProtocol g_MultitapProtocol;
+MultitapProtocol g_MultitapPort0;
+MultitapProtocol g_MultitapPort1;
 
 void MultitapProtocol::SupportCheck()
 {
 	MT_LOG.WriteLn("%s", __FUNCTION__);
-	g_Sio2FifoOut.push_back(0x5a);
-	g_Sio2FifoOut.push_back(0x04);
-	g_Sio2FifoOut.push_back(0x00);
-	g_Sio2FifoOut.push_back(0x5a);
+
+	if (EmuConfig.Pad.IsMultitapPortEnabled(g_Sio2.port))
+	{
+		g_Sio2FifoOut.push_back(0xff);
+		g_Sio2FifoOut.push_back(0x80);
+		g_Sio2FifoOut.push_back(0x5a);
+		g_Sio2FifoOut.push_back(0x04);
+		g_Sio2FifoOut.push_back(0x00);
+		g_Sio2FifoOut.push_back(0x5a);
+	}
+	else
+	{
+		g_Sio2FifoOut.push_back(0xff);
+		g_Sio2FifoOut.push_back(0xff);
+		g_Sio2FifoOut.push_back(0xff);
+		g_Sio2FifoOut.push_back(0xff);
+		g_Sio2FifoOut.push_back(0xff);
+		g_Sio2FifoOut.push_back(0xff);
+	}
 }
 
-void MultitapProtocol::Select()
+void MultitapProtocol::Select(MultitapMode mode)
 {
 	MT_LOG.WriteLn("%s", __FUNCTION__);
-	const u8 newSlot = g_Sio2FifoIn.front();
-	g_Sio2FifoIn.pop_front();
-	const bool isInBounds = (newSlot < SIO::SLOTS);
-
-	if (isInBounds)
+	
+	if (EmuConfig.Pad.IsMultitapPortEnabled(g_Sio2.port))
 	{
-		g_Sio2.slot = newSlot;
-		MT_LOG.WriteLn("Slot changed to %d", g_Sio2.slot);
-	}
+		const u8 newSlot = g_Sio2FifoIn.front();
+		g_Sio2FifoIn.pop_front();
+		const bool isInBounds = (newSlot < SIO::SLOTS);
 
-	g_Sio2FifoOut.push_back(0x5a);
-	g_Sio2FifoOut.push_back(0x00);
-	g_Sio2FifoOut.push_back(0x00);
-	g_Sio2FifoOut.push_back(isInBounds ? newSlot : 0xff);
-	g_Sio2FifoOut.push_back(isInBounds ? 0x5a : 0x66);
+		if (isInBounds)
+		{
+			switch (mode)
+			{
+				case MultitapMode::SELECT_PAD:
+					this->currentPadSlot = newSlot;
+					break;
+				case MultitapMode::SELECT_MEMCARD:
+					this->currentMemcardSlot = newSlot;
+					break;
+				default:
+					break;
+			}
+
+			MT_LOG.WriteLn("Slot changed to %d", newSlot);
+		}
+
+		g_Sio2FifoOut.push_back(0xff);
+		g_Sio2FifoOut.push_back(0x80);
+		g_Sio2FifoOut.push_back(0x5a);
+		g_Sio2FifoOut.push_back(0x00);
+		g_Sio2FifoOut.push_back(0x00);
+		g_Sio2FifoOut.push_back(isInBounds ? newSlot : 0xff);
+		g_Sio2FifoOut.push_back(isInBounds ? 0x5a : 0x66);
+	}
+	else
+	{
+		g_Sio2FifoOut.push_back(0xff);
+		g_Sio2FifoOut.push_back(0xff);
+		g_Sio2FifoOut.push_back(0xff);
+		g_Sio2FifoOut.push_back(0xff);
+		g_Sio2FifoOut.push_back(0xff);
+		g_Sio2FifoOut.push_back(0xff);
+		g_Sio2FifoOut.push_back(0xff);
+	}
 }
 
 MultitapProtocol::MultitapProtocol() = default;
@@ -65,14 +110,24 @@ void MultitapProtocol::FullReset()
 {
 	SoftReset();
 
-	g_Sio2.slot = 0;
+	this->currentPadSlot = 0;
+	this->currentMemcardSlot = 0;
+}
+
+u8 MultitapProtocol::GetPadSlot()
+{
+	return this->currentPadSlot;
+}
+
+u8 MultitapProtocol::GetMemcardSlot()
+{
+	return this->currentMemcardSlot;
 }
 
 void MultitapProtocol::SendToMultitap()
 {
 	const u8 commandByte = g_Sio2FifoIn.front();
 	g_Sio2FifoIn.pop_front();
-	g_Sio2FifoOut.push_back(0x80);
 
 	switch (static_cast<MultitapMode>(commandByte))
 	{
@@ -81,8 +136,10 @@ void MultitapProtocol::SendToMultitap()
 			SupportCheck();
 			break;
 		case MultitapMode::SELECT_PAD:
+			Select(MultitapMode::SELECT_PAD);
+			break;
 		case MultitapMode::SELECT_MEMCARD:
-			Select();
+			Select(MultitapMode::SELECT_MEMCARD);
 			break;
 		default:
 			DevCon.Warning("%s() Unhandled MultitapMode (%02X)", __FUNCTION__, commandByte);

--- a/pcsx2/SIO/Multitap/MultitapProtocol.cpp
+++ b/pcsx2/SIO/Multitap/MultitapProtocol.cpp
@@ -16,6 +16,7 @@
 #include "PrecompiledHeader.h"
 
 #include "Common.h"
+#include "StateWrapper.h"
 
 #include "SIO/Multitap/MultitapProtocol.h"
 
@@ -25,8 +26,7 @@
 #define MT_LOG_ENABLE 0
 #define MT_LOG if (MT_LOG_ENABLE) DevCon
 
-MultitapProtocol g_MultitapPort0;
-MultitapProtocol g_MultitapPort1;
+std::array<MultitapProtocol, SIO::PORTS> g_MultitapArr;
 
 void MultitapProtocol::SupportCheck()
 {
@@ -112,6 +112,16 @@ void MultitapProtocol::FullReset()
 
 	this->currentPadSlot = 0;
 	this->currentMemcardSlot = 0;
+}
+
+bool MultitapProtocol::DoState(StateWrapper& sw)
+{
+	if (!sw.DoMarker("Multitap"))
+		return false;
+
+	sw.Do(&currentPadSlot);
+	sw.Do(&currentMemcardSlot);
+	return true;
 }
 
 u8 MultitapProtocol::GetPadSlot()

--- a/pcsx2/SIO/Multitap/MultitapProtocol.h
+++ b/pcsx2/SIO/Multitap/MultitapProtocol.h
@@ -15,6 +15,12 @@
 
 #pragma once
 
+#include "SIO/SioTypes.h"
+
+#include <array>
+
+class StateWrapper;
+
 enum class MultitapMode
 {
 	NOT_SET = 0xff,
@@ -39,6 +45,7 @@ public:
 
 	void SoftReset();
 	void FullReset();
+	bool DoState(StateWrapper& sw);
 
 	u8 GetPadSlot();
 	u8 GetMemcardSlot();
@@ -46,6 +53,5 @@ public:
 	void SendToMultitap();
 };
 
-extern MultitapProtocol g_MultitapPort0;
-extern MultitapProtocol g_MultitapPort1;
+extern std::array<MultitapProtocol, SIO::PORTS> g_MultitapArr;
 

--- a/pcsx2/SIO/Multitap/MultitapProtocol.h
+++ b/pcsx2/SIO/Multitap/MultitapProtocol.h
@@ -27,8 +27,11 @@ enum class MultitapMode
 class MultitapProtocol
 {
 private:
+	u8 currentPadSlot = 0;
+	u8 currentMemcardSlot = 0;
+
 	void SupportCheck();
-	void Select();
+	void Select(MultitapMode mode);
 
 public:
 	MultitapProtocol();
@@ -37,7 +40,12 @@ public:
 	void SoftReset();
 	void FullReset();
 
+	u8 GetPadSlot();
+	u8 GetMemcardSlot();
+
 	void SendToMultitap();
 };
 
-extern MultitapProtocol g_MultitapProtocol;
+extern MultitapProtocol g_MultitapPort0;
+extern MultitapProtocol g_MultitapPort1;
+

--- a/pcsx2/SIO/Pad/Pad.h
+++ b/pcsx2/SIO/Pad/Pad.h
@@ -28,6 +28,8 @@ class StateWrapper;
 
 namespace Pad
 {
+	constexpr size_t DEFAULT_EJECT_TICKS = 50;
+
 	bool Initialize();
 	void Shutdown();
 

--- a/pcsx2/SIO/Pad/PadBase.cpp
+++ b/pcsx2/SIO/Pad/PadBase.cpp
@@ -17,9 +17,10 @@
 
 #include "SIO/Pad/PadBase.h"
 
-PadBase::PadBase(u8 unifiedSlot)
+PadBase::PadBase(u8 unifiedSlot, size_t ejectTicks)
 {
 	this->unifiedSlot = unifiedSlot;
+	this->ejectTicks = ejectTicks;
 }
 
 PadBase::~PadBase() = default;

--- a/pcsx2/SIO/Pad/PadBase.h
+++ b/pcsx2/SIO/Pad/PadBase.h
@@ -23,6 +23,14 @@
 
 class PadBase
 {
+public:
+	// How many commands the pad should pretend to be ejected for.
+	// Since changing pads in the UI or ejecting a multitap is instant,
+	// this simulates the time it would take for a human to plug in the pad.
+	// That gives games a chance to see a pad get inserted rather than the
+	// pad's type magically changing from one frame to the next.
+	size_t ejectTicks = 0;
+
 protected:
 	std::array<u8, 32> rawInputs = {};
 	u8 unifiedSlot;
@@ -32,7 +40,7 @@ protected:
 	size_t commandBytesReceived = 0;
 
 public: // Public members
-	PadBase(u8 unifiedSlot);
+	PadBase(u8 unifiedSlot, size_t ejectTicks = 0);
 	virtual ~PadBase();
 
 	void SoftReset();

--- a/pcsx2/SIO/Pad/PadDualshock2.cpp
+++ b/pcsx2/SIO/Pad/PadDualshock2.cpp
@@ -547,8 +547,8 @@ u8 PadDualshock2::ResponseBytes(u8 commandByte)
 	}
 }
 
-PadDualshock2::PadDualshock2(u8 unifiedSlot)
-	: PadBase(unifiedSlot)
+PadDualshock2::PadDualshock2(u8 unifiedSlot, size_t ejectTicks)
+	: PadBase(unifiedSlot, ejectTicks)
 {
 	currentMode = Pad::Mode::DIGITAL;
 }

--- a/pcsx2/SIO/Pad/PadDualshock2.h
+++ b/pcsx2/SIO/Pad/PadDualshock2.h
@@ -112,7 +112,7 @@ private:
 	u8 ResponseBytes(u8 commandByte);
 
 public:
-	PadDualshock2(u8 unifiedSlot);
+	PadDualshock2(u8 unifiedSlot, size_t ejectTicks);
 	~PadDualshock2() override;
 
 	static inline bool IsAnalogKey(int index)

--- a/pcsx2/SIO/Pad/PadGuitar.cpp
+++ b/pcsx2/SIO/Pad/PadGuitar.cpp
@@ -248,8 +248,8 @@ u8 PadGuitar::VibrationMap(u8 commandByte)
 	return 0xff;
 }
 
-PadGuitar::PadGuitar(u8 unifiedSlot)
-	: PadBase(unifiedSlot)
+PadGuitar::PadGuitar(u8 unifiedSlot, size_t ejectTicks)
+	: PadBase(unifiedSlot, ejectTicks)
 {
 	currentMode = Pad::Mode::DIGITAL;
 }

--- a/pcsx2/SIO/Pad/PadGuitar.h
+++ b/pcsx2/SIO/Pad/PadGuitar.h
@@ -63,7 +63,7 @@ private:
 	u8 VibrationMap(u8 commandByte);
 
 public:
-	PadGuitar(u8 unifiedSlot);
+	PadGuitar(u8 unifiedSlot, size_t ejectTicks);
 	~PadGuitar() override;
 
 	Pad::ControllerType GetType() const override;

--- a/pcsx2/SIO/Pad/PadNotConnected.cpp
+++ b/pcsx2/SIO/Pad/PadNotConnected.cpp
@@ -117,5 +117,5 @@ u8 PadNotConnected::GetPressure(u32 index) const
 
 u8 PadNotConnected::SendCommandByte(u8 commandByte)
 {
-	return 0x00;
+	return 0xff;
 }

--- a/pcsx2/SIO/Pad/PadNotConnected.cpp
+++ b/pcsx2/SIO/Pad/PadNotConnected.cpp
@@ -22,8 +22,8 @@
 const Pad::ControllerInfo PadNotConnected::ControllerInfo = {Pad::ControllerType::NotConnected, "None",
 	TRANSLATE_NOOP("Pad", "Not Connected"), {}, {}, Pad::VibrationCapabilities::NoVibration };
 
-PadNotConnected::PadNotConnected(u8 unifiedSlot)
-	: PadBase(unifiedSlot)
+PadNotConnected::PadNotConnected(u8 unifiedSlot, size_t ejectTicks)
+	: PadBase(unifiedSlot, ejectTicks)
 {
 
 }

--- a/pcsx2/SIO/Pad/PadNotConnected.h
+++ b/pcsx2/SIO/Pad/PadNotConnected.h
@@ -20,7 +20,7 @@
 class PadNotConnected final : public PadBase
 {
 public:
-	PadNotConnected(u8 unifiedSlot);
+	PadNotConnected(u8 unifiedSlot, size_t ejectTicks = 0);
 	~PadNotConnected() override;
 
 	Pad::ControllerType GetType() const override;

--- a/pcsx2/SIO/Sio2.h
+++ b/pcsx2/SIO/Sio2.h
@@ -40,7 +40,6 @@ public:
 	u32 iStat; // 0x1f808280
 
 	u8 port = 0;
-	u8 slot = 0;
 
 	// The current working index of SEND3. The SEND3 register is a 16 position
 	// array of command descriptors. Each descriptor describes the port the command

--- a/pcsx2/SIO/SioTypes.h
+++ b/pcsx2/SIO/SioTypes.h
@@ -130,10 +130,21 @@ namespace Sio2Ctrl
 	static constexpr u32 SIO2MAN_RESET = 0x000003bc;
 } // namespace Sio2Ctrl
 
+// TODO: Remove deprecated options once memcards are no longer using them.
 namespace Recv1
 {
+	// Deprecated
 	static constexpr u32 DISCONNECTED = 0x1d100;
+	// Deprecated
 	static constexpr u32 CONNECTED = 0x1100;
+
+	static constexpr u32 NO_DEVICES_MISSING = 0x1000;
+	static constexpr u32 PORT_1_MISSING = 0x1D000;
+	static constexpr u32 PORT_2_MISSING = 0x2D000;
+	static constexpr u32 BOTH_PORTS_MISSING = 0x3D000;
+	static constexpr u32 ONE_PORT_OPEN = 0x100;
+	static constexpr u32 TWO_PORTS_OPEN = 0x200;
+
 } // namespace Recv1
 
 namespace Recv2

--- a/pcsx2/SaveState.cpp
+++ b/pcsx2/SaveState.cpp
@@ -33,6 +33,7 @@
 #include "R3000A.h"
 #include "SIO/Sio0.h"
 #include "SIO/Sio2.h"
+#include "SIO/Multitap/MultitapProtocol.h"
 #include "SPU2/spu2.h"
 #include "SaveState.h"
 #include "StateWrapper.h"
@@ -259,6 +260,9 @@ bool SaveStateBase::FreezeInternals()
 
 		okay = okay && g_Sio0.DoState(sw);
 		okay = okay && g_Sio2.DoState(sw);
+		okay = okay && g_MultitapArr.at(0).DoState(sw);
+		okay = okay && g_MultitapArr.at(1).DoState(sw);
+
 		if (!okay || !sw.IsGood())
 			return false;
 

--- a/pcsx2/SaveState.h
+++ b/pcsx2/SaveState.h
@@ -37,7 +37,7 @@ enum class FreezeAction
 // [SAVEVERSION+]
 // This informs the auto updater that the users savestates will be invalidated.
 
-static const u32 g_SaveVersion = (0x9A48 << 16) | 0x0000;
+static const u32 g_SaveVersion = (0x9A49 << 16) | 0x0000;
 
 
 // the freezing data between submodules and core


### PR DESCRIPTION
### Description of Changes
An assortment of changes which I've attempted to fragment into separate commits as best I could. Brings PCSX2 much much closer to what PS2 hardware does for the RECV1 register and the data values peripherals send.

Main focus was extending RECV1 - the old method was that we had a known good value for when a device was found, and a known good value for when no device was found. These were assumed to always work, and because of how most games poll devices, they kind of just did. Hardware tests however showed there were some more specific nuances, and implementing these makes games such as Gauntlet: Dark Legacy much happier when dealing with multitaps.

Old code also assumed that when the game changes the target slot for a multitap, it intends to do so for both pads and memcards at the same time. However, these are separate commands in the protocol for a reason. Though most multitap games do just choose to keep the pad and memcard slots in sync for a particular multitap, Gauntlet: Dark Legacy is one where it will attempt to access a different pad and memcard slot on the same multitap, at the same time. Slot management is now handled by the multitap and tracked independently for pads and memcards.

A PS1 hack was removed from SIO2, since the SIO0 code has since been fully separated and the hack no longer has any business being in SIO2. It was inconsequential, but its just 0.01% nicer to look at now.

A few return values which were 0x00 for error conditions are now 0xFF. The default state of the data rail is 0xFF, and peripherals transmit data by pulling the voltage down. As such, if a peripheral is missing or doesn't understand the command it was given, it will make no attempt to send data back, and the rail will remain at 0xFF.

### Rationale behind Changes
Fixes #10190. Makes response data sent to IOP modules more accurate, might help other games with multitap troubles.

### Suggested Testing Steps
Test every multitap game we can find. Try with a multitap in port 1, and with a multitap in port 2, and with two multitaps in. Try disabling multitaps, enabling them again, disabling individual controllers, enabling them again. Be on the lookout for warnings in the system console about the pad entering/exiting config mode when it shouldn't be. There are some cases where this is expected (e.g. removing a multitap but still having a controller present in that port - the game is going to freak out for a moment because in its eyes, you just ejected a multitap and replaced it with a controller in less than 16 milliseconds). Please be observant of what the game supports on hardware - e.g. if a game on a real PS2 only lets you use a multitap in port 1, please don't report that a multitap isn't working in port 2. That's not a bug, that's just developers being weird. No short supply of that it seems.

Test normal memory card function in various games. Nothing should really change here, but since some of the responses for when cards are missing have changed, it would be good to touch. Games with troublesome history with memcards include MGS3 and Shining Force EXA. General tests for others will do, both saving and loading.

Test normal pad function in various games. Nothing should really change here either, but likewise some responses for missing pads are different, plus now RECV1 handling is different. If you had games which were a little odd with pads prior, try them out and see if anything changes for better or worse. True Crime: Streets of LA previously had a SIF bug which was resolved temporarily by a combination of changes, including wrongly setting the Not Connected pad's data returns to 0x00. That should no longer be an issue, please test to verify.
