### PR TITLE
COP0: Correctly update performance counter cycles

### DIFF
--- a/pcsx2/x86/iCOP0.cpp
+++ b/pcsx2/x86/iCOP0.cpp
@@ -150,7 +150,9 @@ void recMFC0()
 	if (_Rd_ == 9)
 	{
 		// This case needs to be handled even if the write-back is ignored (_Rt_ == 0 )
-		xMOV(ecx, ptr[&cpuRegs.cycle]);
+		xMOV(ecx, ptr32[&cpuRegs.cycle]);
+		xADD(ecx, scaleblockcycles_clear());
+		xMOV(ptr32[&cpuRegs.cycle], ecx); // update cycles
 		xMOV(eax, ecx);
 		xSUB(eax, ptr[&cpuRegs.lastCOP0Cycle]);
 		u8* skipInc = JNZ8(0);
@@ -180,6 +182,9 @@ void recMFC0()
 		else if (0 == (_Imm_ & 2)) // MFPC 0, only LSB of register matters
 		{
 			iFlushCall(FLUSH_INTERPRETER);
+			xMOV(eax, ptr32[&cpuRegs.cycle]);
+			xADD(eax, scaleblockcycles_clear());
+			xMOV(ptr32[&cpuRegs.cycle], eax); // update cycles
 			xFastCall((void*)COP0_UpdatePCCR);
 
 			const int regt = _allocX86reg(X86TYPE_GPR, _Rt_, MODE_WRITE);
@@ -188,6 +193,9 @@ void recMFC0()
 		else // MFPC 1
 		{
 			iFlushCall(FLUSH_INTERPRETER);
+			xMOV(eax, ptr32[&cpuRegs.cycle]);
+			xADD(eax, scaleblockcycles_clear());
+			xMOV(ptr32[&cpuRegs.cycle], eax); // update cycles
 			xFastCall((void*)COP0_UpdatePCCR);
 
 			const int regt = _allocX86reg(X86TYPE_GPR, _Rt_, MODE_WRITE);
@@ -214,6 +222,9 @@ void recMTC0()
 		{
 			case 12:
 				iFlushCall(FLUSH_INTERPRETER);
+				xMOV(eax, ptr32[&cpuRegs.cycle]);
+				xADD(eax, scaleblockcycles_clear());
+				xMOV(ptr32[&cpuRegs.cycle], eax); // update cycles
 				xFastCall((void*)WriteCP0Status, g_cpuConstRegs[_Rt_].UL[0]);
 				break;
 
@@ -223,7 +234,9 @@ void recMTC0()
 				break;
 
 			case 9:
-				xMOV(ecx, ptr[&cpuRegs.cycle]);
+				xMOV(ecx, ptr32[&cpuRegs.cycle]);
+				xADD(ecx, scaleblockcycles_clear());
+				xMOV(ptr32[&cpuRegs.cycle], ecx); // update cycles
 				xMOV(ptr[&cpuRegs.lastCOP0Cycle], ecx);
 				xMOV(ptr32[&cpuRegs.CP0.r[9]], g_cpuConstRegs[_Rt_].UL[0]);
 				break;
@@ -235,19 +248,26 @@ void recMTC0()
 						break;
 					// Updates PCRs and sets the PCCR.
 					iFlushCall(FLUSH_INTERPRETER);
+					xMOV(eax, ptr32[&cpuRegs.cycle]);
+					xADD(eax, scaleblockcycles_clear());
+					xMOV(ptr32[&cpuRegs.cycle], eax); // update cycles
 					xFastCall((void*)COP0_UpdatePCCR);
 					xMOV(ptr32[&cpuRegs.PERF.n.pccr], g_cpuConstRegs[_Rt_].UL[0]);
 					xFastCall((void*)COP0_DiagnosticPCCR);
 				}
 				else if (0 == (_Imm_ & 2)) // MTPC 0, only LSB of register matters
 				{
-					xMOV(eax, ptr[&cpuRegs.cycle]);
+					xMOV(eax, ptr32[&cpuRegs.cycle]);
+					xADD(eax, scaleblockcycles_clear());
+					xMOV(ptr32[&cpuRegs.cycle], eax); // update cycles
 					xMOV(ptr32[&cpuRegs.PERF.n.pcr0], g_cpuConstRegs[_Rt_].UL[0]);
 					xMOV(ptr[&cpuRegs.lastPERFCycle[0]], eax);
 				}
 				else // MTPC 1
 				{
-					xMOV(eax, ptr[&cpuRegs.cycle]);
+					xMOV(eax, ptr32[&cpuRegs.cycle]);
+					xADD(eax, scaleblockcycles_clear());
+					xMOV(ptr32[&cpuRegs.cycle], eax); // update cycles
 					xMOV(ptr32[&cpuRegs.PERF.n.pcr1], g_cpuConstRegs[_Rt_].UL[0]);
 					xMOV(ptr[&cpuRegs.lastPERFCycle[1]], eax);
 				}
@@ -269,6 +289,9 @@ void recMTC0()
 			case 12:
 				_eeMoveGPRtoR(arg1reg, _Rt_);
 				iFlushCall(FLUSH_INTERPRETER);
+				xMOV(eax, ptr32[&cpuRegs.cycle]);
+				xADD(eax, scaleblockcycles_clear());
+				xMOV(ptr32[&cpuRegs.cycle], eax); // update cycles
 				xFastCall((void*)WriteCP0Status);
 				break;
 
@@ -279,7 +302,9 @@ void recMTC0()
 				break;
 
 			case 9:
-				xMOV(ecx, ptr[&cpuRegs.cycle]);
+				xMOV(ecx, ptr32[&cpuRegs.cycle]);
+				xADD(ecx, scaleblockcycles_clear());
+				xMOV(ptr32[&cpuRegs.cycle], ecx); // update cycles
 				_eeMoveGPRtoM((uptr)&cpuRegs.CP0.r[9], _Rt_);
 				xMOV(ptr[&cpuRegs.lastCOP0Cycle], ecx);
 				break;
@@ -290,19 +315,26 @@ void recMTC0()
 					if (0 != (_Imm_ & 0x3E)) // only effective when the register is 0
 						break;
 					iFlushCall(FLUSH_INTERPRETER);
+					xMOV(eax, ptr32[&cpuRegs.cycle]);
+					xADD(eax, scaleblockcycles_clear());
+					xMOV(ptr32[&cpuRegs.cycle], eax); // update cycles
 					xFastCall((void*)COP0_UpdatePCCR);
 					_eeMoveGPRtoM((uptr)&cpuRegs.PERF.n.pccr, _Rt_);
 					xFastCall((void*)COP0_DiagnosticPCCR);
 				}
 				else if (0 == (_Imm_ & 2)) // MTPC 0, only LSB of register matters
 				{
-					xMOV(ecx, ptr[&cpuRegs.cycle]);
+					xMOV(ecx, ptr32[&cpuRegs.cycle]);
+					xADD(ecx, scaleblockcycles_clear());
+					xMOV(ptr32[&cpuRegs.cycle], ecx); // update cycles
 					_eeMoveGPRtoM((uptr)&cpuRegs.PERF.n.pcr0, _Rt_);
 					xMOV(ptr[&cpuRegs.lastPERFCycle[0]], ecx);
 				}
 				else // MTPC 1
 				{
-					xMOV(ecx, ptr[&cpuRegs.cycle]);
+					xMOV(ecx, ptr32[&cpuRegs.cycle]);
+					xADD(ecx, scaleblockcycles_clear());
+					xMOV(ptr32[&cpuRegs.cycle], ecx); // update cycles
 					_eeMoveGPRtoM((uptr)&cpuRegs.PERF.n.pcr1, _Rt_);
 					xMOV(ptr[&cpuRegs.lastPERFCycle[1]], ecx);
 				}


### PR DESCRIPTION
### Description of Changes
Update CPU cycles and then the performance counters to correctly increment them

### Rationale behind Changes
cpu cycles weren't being updated, neither was the counter being updated before the KSU mode (Kernel/Supervisor/User) was modified. Also the last check cycle wasn't being updated if the event wasn't counted, meaning it would count bad amounts of cycles.

### Suggested Testing Steps
Test random stuff. GTA 3, Next Generation Tennis 2003 and Spongebob Battle for Bikini Bottom all use performance counters, I did give them a quick go and they seemed fine. Not sure what else is affected by them.

No known fixes.
