### PR TITLE
GS/HW: Don't convert old depth if being overwritten

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -1920,7 +1920,7 @@ GSTextureCache::Target* GSTextureCache::LookupTarget(GIFRegTEX0 TEX0, const GSVe
 				dst_match = t;
 				break;
 			}
-			else if (t->m_age == 1)
+			else if (t->m_age == 1 && (preserve_rgb || (preserve_alpha && (dst_match->m_valid_alpha_low || dst_match->m_valid_alpha_high))))
 			{
 				dst_match = t;
 			}


### PR DESCRIPTION
### Description of Changes
Don't convert old depth buffers to render targets if they are not being preserved

### Rationale behind Changes
Harry potter was misdetecting old targets from a previous frames during a striped memory clear which only matched by address, not size, causing the new target to have a very wrong buffer width (TBW), which then later went very wrong during a readback as it missed half the data. It was a string of nonsense :P

### Suggested Testing Steps
Smoke test mostly. very minor single pixel differences shown in Spider-Man 2 and Motocross Mania probably due to different target sizing/resizing, nothing else showed up in a dump run.

Fixes Harry Potter and the Prisoner of Azkaban
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/0c31b6bf-94c6-4b55-b59e-bba09696e8d9)

PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/d3c558be-cd0c-4e5c-83fd-a64831a1941f)
