### PR TITLE
IOP HLE: Add support for host fs when booting an iso

### DIFF
--- a/pcsx2/IopBios.cpp
+++ b/pcsx2/IopBios.cpp
@@ -102,6 +102,12 @@ void Hle_SetElfPath(const char* elfFileName)
 	Console.WriteLn("HLE Host: Set 'host:' root path to: %s\n", hostRoot.c_str());
 }
 
+void Hle_SetIsoPath(const char* isoFilename)
+{
+	hostRoot = Path::ToNativePath(Path::GetDirectory(isoFilename));
+	Console.WriteLn("HLE Host: Set 'host:' root path to: %s\n", hostRoot.c_str());
+}
+
 void Hle_ClearElfPath()
 {
 	hostRoot = {};

--- a/pcsx2/IopBios.cpp
+++ b/pcsx2/IopBios.cpp
@@ -95,20 +95,13 @@ typedef struct
 
 static std::string hostRoot;
 
-void Hle_SetElfPath(const char* elfFileName)
+void Hle_SetHostRoot(const char* bootFilename)
 {
-	DevCon.WriteLn("HLE Host: Will load ELF: %s\n", elfFileName);
-	hostRoot = Path::ToNativePath(Path::GetDirectory(elfFileName));
+	hostRoot = Path::ToNativePath(Path::GetDirectory(bootFilename));
 	Console.WriteLn("HLE Host: Set 'host:' root path to: %s\n", hostRoot.c_str());
 }
 
-void Hle_SetIsoPath(const char* isoFilename)
-{
-	hostRoot = Path::ToNativePath(Path::GetDirectory(isoFilename));
-	Console.WriteLn("HLE Host: Set 'host:' root path to: %s\n", hostRoot.c_str());
-}
-
-void Hle_ClearElfPath()
+void Hle_ClearHostRoot()
 {
 	hostRoot = {};
 }

--- a/pcsx2/IopBios.h
+++ b/pcsx2/IopBios.h
@@ -87,5 +87,6 @@ namespace R3000A
 } // namespace R3000A
 
 extern void Hle_SetElfPath(const char* elfFileName);
+extern void Hle_SetIsoPath(const char* isoFilename);
 extern void Hle_ClearElfPath();
 

--- a/pcsx2/IopBios.h
+++ b/pcsx2/IopBios.h
@@ -86,7 +86,6 @@ namespace R3000A
 	}
 } // namespace R3000A
 
-extern void Hle_SetElfPath(const char* elfFileName);
-extern void Hle_SetIsoPath(const char* isoFilename);
-extern void Hle_ClearElfPath();
+extern void Hle_SetHostRoot(const char* bootFilename);
+extern void Hle_ClearHostRoot();
 

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -1188,15 +1188,15 @@ bool VMManager::Initialize(VMBootParameters boot_params)
 			return false;
 		}
 
-		Hle_SetElfPath(s_elf_override.c_str());
+		Hle_SetHostRoot(s_elf_override.c_str());
 	}
 	else if (CDVDsys_GetSourceType() == CDVD_SourceType::Iso)
 	{
-		Hle_SetIsoPath(CDVDsys_GetFile(CDVDsys_GetSourceType()).c_str());
+		Hle_SetHostRoot(CDVDsys_GetFile(CDVDsys_GetSourceType()).c_str());
 	}
 	else
 	{
-		Hle_ClearElfPath();
+		Hle_ClearHostRoot();
 	}
 
 	// Check for resuming with hardcore mode.
@@ -1984,9 +1984,9 @@ bool VMManager::SetELFOverride(std::string path)
 
 	s_fast_boot_requested = !s_elf_override.empty() || EmuConfig.EnableFastBoot;
 	if (s_elf_override.empty())
-		Hle_ClearElfPath();
+		Hle_ClearHostRoot();
 	else
-		Hle_SetElfPath(s_elf_override.c_str());
+		Hle_SetHostRoot(s_elf_override.c_str());
 
 	Reset();
 	return true;

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -1190,6 +1190,10 @@ bool VMManager::Initialize(VMBootParameters boot_params)
 
 		Hle_SetElfPath(s_elf_override.c_str());
 	}
+	else if (CDVDsys_GetSourceType() == CDVD_SourceType::Iso)
+	{
+		Hle_SetIsoPath(CDVDsys_GetFile(CDVDsys_GetSourceType()).c_str());
+	}
 	else
 	{
 		Hle_ClearElfPath();


### PR DESCRIPTION
### Description of Changes
Sets the ``hostRoot`` path to the directory of the boot iso.

### Rationale behind Changes
Gives access to the host filesystem when running an iso. This isn't useful for anything but niche cases (homebrew, modding) but it is a small addition that won't negatively impact existing features.

### Suggested Testing Steps
Run the elf and the iso with ``Host Filesystem`` enabled and they should both print out the contents of the ``content.txt`` file inside.
[hostfs-tester.zip](https://github.com/PCSX2/pcsx2/files/13315226/hostfs-tester.zip)



Implements #10259