### PR TITLE
R3000: Fix COP0 Status value on reset

### DIFF
--- a/pcsx2/R3000A.cpp
+++ b/pcsx2/R3000A.cpp
@@ -53,7 +53,7 @@ void psxReset()
 	std::memset(&psxRegs, 0, sizeof(psxRegs));
 
 	psxRegs.pc = 0xbfc00000; // Start in bootstrap
-	psxRegs.CP0.n.Status = 0x10900000; // COP0 enabled | BEV = 1 | TS = 1
+	psxRegs.CP0.n.Status = 0x00400000; // BEV = 1
 	psxRegs.CP0.n.PRid   = 0x0000001f; // PRevID = Revision ID, same as the IOP R3000A
 
 	psxRegs.iopBreak = 0;


### PR DESCRIPTION
### Description of Changes
Fix r3000 COP0 Status value on reset.

## Rationale behind Changes
Previously used value was wrong. BEV bit wasn't correct one, and CU0 and TS bits are not enabled by default.

### Suggested Testing Steps
None, Status register is overwritten almost right after boot. I tested PS2 game/PS1 game/Bios with standard and deckard model bios file just in case.