### PR TITLE
GS: Pre-round/truncate STQ values based on hardware tests

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -17027,6 +17027,9 @@ SLES-52022:
 SLES-52023:
   name: "Manhunt"
   region: "PAL-M5"
+  gsHWFixes:
+    halfPixelOffset: 1 # Helps with light occlusion problems when upscaling.
+    autoFlush: 2 # Fixes light occlusion draws which mistakenly get all drawn at once, so wrong texture data is picked.
 SLES-52025:
   name: "NFL Street"
   region: "PAL-E"
@@ -59120,6 +59123,9 @@ SLUS-20827:
   name: "Manhunt"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 1 # Helps with light occlusion problems when upscaling.
+    autoFlush: 2 # Fixes light occlusion draws which mistakenly get all drawn at once, so wrong texture data is picked.
 SLUS-20828:
   name: "ShellShock - Nam '67"
   region: "NTSC-U"

--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -27,6 +27,7 @@
 #include <cfloat>
 #include <fstream>
 #include <iomanip>
+#include <bit>
 
 int GSState::s_n = 0;
 int GSState::s_last_transfer_draw_n = 0;
@@ -503,7 +504,7 @@ void GSState::DumpVertices(const std::string& filename)
 			file << uv_U << DEL << uv_V;
 		}
 		else
-			file << v.ST.S << DEL << v.ST.T << DEL << v.RGBAQ.Q;
+			file << v.ST.S << "(" << std::bit_cast<u32>(v.ST.S) << ")" << DEL << v.ST.T << "(" << std::bit_cast<u32>(v.ST.T) << ")" << DEL << v.RGBAQ.Q << "(" << std::bit_cast<u32>(v.RGBAQ.Q) << ")";
 
 		file << std::endl;
 	}
@@ -1593,6 +1594,13 @@ inline bool GSState::TestDrawChanged()
 	return false;
 }
 
+u32 GSState::CalcMask(int exp, int max_exp)
+{
+	const int amount = 9 + (max_exp - exp);
+
+	return (1 << std::min(amount, 23)) - 1;
+}
+
 void GSState::FlushPrim()
 {
 	if (m_index.tail > 0)
@@ -1667,6 +1675,50 @@ void GSState::FlushPrim()
 #endif
 
 		m_vt.Update(m_vertex.buff, m_index.buff, m_vertex.tail, m_index.tail, GSUtil::GetPrimClass(PRIM->PRIM));
+
+		// Texel coordinate rounding
+		// Helps Manhunt (lights shining through objects).
+		// Can help with some alignment issues when upscaling too, and is for both Software and Hardware renderers.
+		// Sometimes hardware doesn't get affected, likely due to the difference in how GPU's handle textures (Persona minimap).
+		if (m_env.PRIM.TME && (GSUtil::GetPrimClass(PRIM->PRIM) == GS_PRIM_CLASS::GS_SPRITE_CLASS || m_vt.m_eq.z))
+		{
+			if (!m_env.PRIM.FST) // STQ's
+			{
+				const bool is_sprite = GSUtil::GetPrimClass(PRIM->PRIM) == GS_PRIM_CLASS::GS_SPRITE_CLASS;
+				// ST's have the lowest 9 bits (or greater depending on exponent difference) rounding down (from hardware tests).
+				for (int i = m_index.tail - 1; i >= 0; i--)
+				{
+					GSVertex* v = &m_vertex.buff[m_index.buff[i]];
+
+					// Only Q on the second vertex is valid
+					if (!(i & 1) && is_sprite)
+						v->RGBAQ.Q = m_vertex.buff[m_index.buff[i + 1]].RGBAQ.Q;
+
+					int T = std::bit_cast<int>(v->ST.T);
+					int Q = std::bit_cast<int>(v->RGBAQ.Q);
+					int S = std::bit_cast<int>(v->ST.S);
+					const int expS = (S >> 23) & 0xff;
+					const int expT = (T >> 23) & 0xff;
+					const int expQ = (Q >> 23) & 0xff;
+					int max_exp = std::max(expS, expQ);
+
+					u32 mask = CalcMask(expS, max_exp);
+					S &= ~mask;
+					v->ST.S = std::bit_cast<float>(S);
+					max_exp = std::max(expT, expQ);
+					mask = CalcMask(expT, max_exp);
+					T &= ~mask;
+					v->ST.T = std::bit_cast<float>(T);
+					Q &= ~0xff;
+
+					if (!is_sprite || (i & 1))
+						v->RGBAQ.Q = std::bit_cast<float>(Q);
+
+					m_vt.m_min.t.x = std::min(m_vt.m_min.t.x, (v->ST.S / v->RGBAQ.Q) * (1 << m_context->TEX0.TW));
+					m_vt.m_min.t.y = std::min(m_vt.m_min.t.y, (v->ST.T / v->RGBAQ.Q) * (1 << m_context->TEX0.TH));
+				}
+			}
+		}
 
 		// Skip draw if Z test is enabled, but set to fail all pixels.
 		const bool skip_draw = (m_context->TEST.ZTE && m_context->TEST.ZTST == ZTST_NEVER);

--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -383,6 +383,7 @@ public:
 	virtual void UpdateSettings(const Pcsx2Config::GSOptions& old_config);
 
 	void Flush(GSFlushReason reason);
+	u32 CalcMask(int exp, int max_exp);
 	void FlushPrim();
 	bool TestDrawChanged();
 	void FlushWrite();


### PR DESCRIPTION
### Description of Changes
Pre-rounds and truncates STQ float values for textures on sprites.

### Rationale behind Changes
Extracted as safe code to use from #6553 so we can at least get the manhunt fixes in for the lighting.
We did some tests on hardware, and we found the truncating of float values gets pretty crazy depending on the difference between values. What is done in this PR seems to work pretty well for a bunch of games, however hardware mode won't feel all the fixes, I believe due to the difference in how GPU's handle texture coordinates.

### Suggested Testing Steps
Test any games including the ones listed below, make sure nothing looks busted in software and hardware.

All the following results are on Software mode

Ben 10:
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/8efe99f0-0b93-47af-9ba9-5355abb98e55)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/9512a00c-4c68-4303-bd16-f9298c632722)

Armored Core 2:
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/a1c54a3e-0806-4adf-9399-f0628fe6c7db)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/98b95426-df20-4579-98f4-d3f4f7060cc5)

Beyond Good & Evil:
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/09eb1548-0d25-4f80-98d8-3bae78f2f1b4)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/5979cdc5-f0fd-45b8-b226-be6e6c5f187f)

G-Force:  (kind of subjective but certainly not bad, matches some other lines on the scene)
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/102e9d45-0d6f-42ed-ac60-a16206210a38)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/74e099b0-d552-4acc-8077-d92b6053a41a)

Manhunt:
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/f55defec-f9c0-4530-b552-3d7ad3b9353f)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/a9b29bd5-c769-4439-8040-229fc3242ccd)

Shinobido - Way of the Ninja (this isn't right either, tbh, but neither is master, and the PS2 is janky as well)
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/2f89372a-7c6d-4a66-b0e8-877316ea7c81)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/9d8353c9-bc1d-468f-866d-016a17ca3568)
PS2 for reference:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/fd869cb9-567b-4b98-854d-0e9439975c4a)

Persona 3:
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/0ff82021-1f9f-445a-bf51-bd29901a6119)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/b00149f5-9ac6-4a93-a46a-87727de91c30)

Persona 3 again:
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/91be648b-94ac-4dd0-a03d-dada35596a9c)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/d94f0d57-abe4-4ec6-a12c-08ab03e3cf57)
