### PR TITLE
MemoryCardFolder: Fix incorrect save timestamps

### DIFF
--- a/pcsx2/SIO/Memcard/MemoryCardFolder.cpp
+++ b/pcsx2/SIO/Memcard/MemoryCardFolder.cpp
@@ -41,6 +41,10 @@
 #include <mutex>
 #include <optional>
 
+#ifdef _MSC_VER
+#define timegm _mkgmtime
+#endif
+
 // A helper function to parse the YAML file
 static std::optional<ryml::Tree> loadYamlFile(const char* filePath)
 {

--- a/pcsx2/SIO/Memcard/MemoryCardFolder.cpp
+++ b/pcsx2/SIO/Memcard/MemoryCardFolder.cpp
@@ -88,9 +88,6 @@ static auto last = std::chrono::time_point<std::chrono::system_clock>();
 
 MemoryCardFileEntryDateTime MemoryCardFileEntryDateTime::FromTime(time_t time)
 {
-	// TODO: Is this safe with regard to DST?
-	time += MEMORY_CARD_FILE_ENTRY_DATE_TIME_OFFSET;
-
 	struct tm converted = {};
 #ifdef _MSC_VER
 	gmtime_s(&converted, &time);
@@ -118,7 +115,7 @@ time_t MemoryCardFileEntryDateTime::ToTime() const
 	converted.tm_mday = day;
 	converted.tm_mon = std::max(static_cast<int>(month) - 1, 0);
 	converted.tm_year = std::max(static_cast<int>(year) - 1900, 0);
-	return mktime(&converted);
+	return timegm(&converted);
 }
 
 FolderMemoryCard::FolderMemoryCard()

--- a/pcsx2/SIO/Memcard/MemoryCardFolder.cpp
+++ b/pcsx2/SIO/Memcard/MemoryCardFolder.cpp
@@ -41,10 +41,6 @@
 #include <mutex>
 #include <optional>
 
-#ifdef _MSC_VER
-#define timegm _mkgmtime
-#endif
-
 // A helper function to parse the YAML file
 static std::optional<ryml::Tree> loadYamlFile(const char* filePath)
 {
@@ -119,7 +115,12 @@ time_t MemoryCardFileEntryDateTime::ToTime() const
 	converted.tm_mday = day;
 	converted.tm_mon = std::max(static_cast<int>(month) - 1, 0);
 	converted.tm_year = std::max(static_cast<int>(year) - 1900, 0);
+
+#ifdef _MSC_VER
+	return _mkgmtime(&converted);
+#else
 	return timegm(&converted);
+#endif
 }
 
 FolderMemoryCard::FolderMemoryCard()

--- a/pcsx2/SIO/Memcard/MemoryCardFolder.h
+++ b/pcsx2/SIO/Memcard/MemoryCardFolder.h
@@ -26,10 +26,6 @@
 
 //#define DEBUG_WRITE_FOLDER_CARD_IN_MEMORY_TO_FILE_ON_CHANGE
 
-#ifdef _WIN32
-#define timegm _mkgmtime
-#endif
-
 // --------------------------------------------------------------------------------------
 //  Superblock Header Struct
 // --------------------------------------------------------------------------------------

--- a/pcsx2/SIO/Memcard/MemoryCardFolder.h
+++ b/pcsx2/SIO/Memcard/MemoryCardFolder.h
@@ -26,6 +26,10 @@
 
 //#define DEBUG_WRITE_FOLDER_CARD_IN_MEMORY_TO_FILE_ON_CHANGE
 
+#ifdef _WIN32
+#define timegm _mkgmtime
+#endif
+
 // --------------------------------------------------------------------------------------
 //  Superblock Header Struct
 // --------------------------------------------------------------------------------------


### PR DESCRIPTION
### Description of Changes
1. Use **timegm** / **_mkgmtime** (on Windows) instead of **mktime**, to make sure that timestamps will be treated as if they were in UTC, thus not adding or subtracting any time while saving. 
2. Change **MemoryCardFileEntryDateTime::FromTime** accordingly, since we no longer need to offset times read from **_pcsx2_index** manually.

This way timestamps inside mcFolders will match those in mcFiles and thus will be interpreted correctly by the PS2 Bios.

### Rationale behind Changes
Always used memory card files and decided to try out memory card folders for a change.
I then noticed the timestamps (inside the **_pcsx2_index** files) on all the saves I converted from mcFile -> mcFolder were off by 8 hours. Do note that my timezone is UTC+1 and mcFiles store time in JST/UTC+9, so the offset being 8 hours gave me a hint as to what's going on.

To confirm this I converted the memory card back and forth from folder -> file -> folder -> etc. multiple times and sure enough, the timestamps offset by an additional 8 hours every time it converted **from** file **to** folder. 

Further testing revealed that even just regular saving on mcFolders would produce incorrect timestamps. With each save the timestamps kept offsetting more and more, until they were dated multiple days in the future.

### Suggested Testing Steps
I tested this pretty thoroughly.
1. Converting from file->folder->file->etc. multiple times.
2. Creating regular saves on mcFolders.
4. Changing the timezone inside the PS2 Bios before and after converting or saving.
5. Checking the timestamps in the PS2 Bios and inside _pcsx2_index on every step along the way. 

As far as I can tell, with this change timestamps for saves inside mcFolders will always be correct.