### PR TITLE
Debugger: Clear breakpoint skips when resetting

### DIFF
--- a/pcsx2/DebugTools/Breakpoints.cpp
+++ b/pcsx2/DebugTools/Breakpoints.cpp
@@ -377,6 +377,14 @@ u32 CBreakPoints::CheckSkipFirst(BreakPointCpu cpu, u32 cmpPc)
 	return 0;
 }
 
+void CBreakPoints::ClearSkipFirst()
+{
+	breakSkipFirstAtEE_ = 0;
+	breakSkipFirstTicksEE_ = 0;
+	breakSkipFirstAtIop_ = 0;
+	breakSkipFirstTicksIop_ = 0;
+}
+
 const std::vector<MemCheck> CBreakPoints::GetMemCheckRanges()
 {
 	std::vector<MemCheck> ranges = memChecks_;

--- a/pcsx2/DebugTools/Breakpoints.h
+++ b/pcsx2/DebugTools/Breakpoints.h
@@ -138,6 +138,7 @@ public:
 
 	static void SetSkipFirst(BreakPointCpu cpu, u32 pc);
 	static u32 CheckSkipFirst(BreakPointCpu cpu, u32 pc);
+	static void ClearSkipFirst();
 
 	// Includes uncached addresses.
 	static const std::vector<MemCheck> GetMemCheckRanges();

--- a/pcsx2/R5900.cpp
+++ b/pcsx2/R5900.cpp
@@ -96,6 +96,8 @@ void cpuReset()
 	g_eeloadMain = 0;
 	g_eeloadExec = 0;
 	g_osdsys_str = 0;
+
+	CBreakPoints::ClearSkipFirst();
 }
 
 __ri void cpuException(u32 code, u32 bd)


### PR DESCRIPTION
### Description of Changes
The debugger sets a pc and a tick count to be checked whenever you resume after a breakpoint is hit. If these match during a breakpoint check, the current pc and tick count then the breakpoint is skipped.
This is so you can resume after a breakpoint is executed. Without this you'd continuously break on the same instruction when resuming.

The issue is that resets are queued and wont happen immediately. If you were to break on a breakpoint, queue a reset, then resume, in some instances the breakpoint wouldn't be hit (it'll be skipped) next time it's executed.

I've just removed the skip and tick flags upon cpu reset.

### Rationale behind Changes
Breakpoints were not functioning as expected

### Suggested Testing Steps
Go to the entry point of a game/homebrew. Set a breakpoint there and reset. When you hit that breakpoint, reset, then resume. The same breakpoint should've been hit once again.
