### PR TITLE
Readme: Clarify latest build/contribution info

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ _Note1: Recommended Single Thread Performance is based on moderately complex gam
 
 _Note2: Recommended GPU is based on 3x Internal, ~1080p resolution requirements. Higher resolutions will require stronger cards; 6x Internal, ~4K resolution will require a [PassMark G3D Mark](https://www.videocardbenchmark.net/high_end_gpus.html) rating around 12000 (GeForce RTX 2060 Radeon RX 6600 Intel Arc A750). Just like CPU requirements, this is also highly game dependent. A quick reference for GPU **intensive games**: [Wiki](https://wiki.pcsx2.net/Category:GPU_intensive_games)_   
 
-### Technical Notes
+## Technical Notes
 
 -   You need the [Visual C++ 2019 x64 Redistributables](https://support.microsoft.com/en-us/help/2977003/) to run PCSX2 on Windows.
 -   Windows XP and Direct3D9 support was dropped after stable release 1.4.0.
@@ -51,5 +51,10 @@ _Note2: Recommended GPU is based on 3x Internal, ~1080p resolution requirements.
 -   PCSX2 uses two CPU cores for emulation by default. A third core can be used via the MTVU speed hack, which is compatible with most games. This can be a significant speedup on CPUs with 3+ cores, but it may be a slowdown on GS-limited games (or on CPUs with fewer than 2 cores). Software renderers will then additionally use however many rendering threads it is set to and will need higher core counts to run efficiently.
 -   Requirements benchmarks are based on a statistic from the Passmark CPU bench marking software. When we say "STR", we are referring to Passmark's "Single Thread Rating" statistic. You can look up your CPU on [Passmark's website for CPUs](https://cpubenchmark.net) to see how it compares to PCSX2's requirements.
 -   Vulkan requires an up-to-date GPU driver; old drivers may cause graphical problems.
+
+## Contributing / Building
+Want to contribute to the development of PCSX2?
+
+See the [Contributing Guidelines](https://github.com/PCSX2/pcsx2/blob/master/.github/CONTRIBUTING.md) or visit the [GitHub Wiki](https://github.com/PCSX2/pcsx2/wiki)
 
 Want more? [Check out the PCSX2 website](https://pcsx2.net/).


### PR DESCRIPTION
### Description of Changes
* Add section for Contributing / Building in the README with a link to the Contributing.md / GitHub Wiki
The new category is placed at the bottom, since it is only relevant to developers.
* Adjust the Technical Notes header from ### to ## to match the rest of the README

### Rationale behind Changes
* As a new contributor, I did not think to check the GitHub Wiki for build instructions. Instead I referenced the PCSX2 Wiki (first result when searching), which was completely outdated and did not mention the pcsx2-windows-dependencies repo. 
* Rather than have build instructions in the README, simply linking to the GitHub Wiki will allow for one source of truth, preventing constant updates to the README if/when build procedures change.
* I did not see the contributing.md (since it was in the .github folder rather than top level) until the below github-actions bot posted below. Updated the commit to reference that file.

As an aside, the PCSX2 wiki building pages should probably be replaced/stubbed with a redirect to the GitHub Wiki.