### PR TITLE
Debugger: Disassemble MULT/U as RS, RT

### DIFF
--- a/pcsx2/DebugTools/DisR5900asm.cpp
+++ b/pcsx2/DebugTools/DisR5900asm.cpp
@@ -990,8 +990,8 @@ void MTLO( std::string& output )    { _sap("mtlo\t%s")          GPR_REG[DECODE_R
 void DSLLV( std::string& output )   { _sap("dsllv\t%s, %s")     disDestSource(DECODE_RD, DECODE_RT), GPR_REG[DECODE_RS]); }
 void DSRLV( std::string& output )   { _sap("dsrlv\t%s, %s")     disDestSource(DECODE_RD, DECODE_RT), GPR_REG[DECODE_RS]); }
 void DSRAV( std::string& output )   { _sap("dsrav\t%s, %s")     disDestSource(DECODE_RD, DECODE_RT), GPR_REG[DECODE_RS]); }
-void MULT( std::string& output )    { _sap("mult\t%s, %s, %s")  GPR_REG[DECODE_RD], GPR_REG[DECODE_RS], GPR_REG[DECODE_RT]);}
-void MULTU( std::string& output )   { _sap("multu\t%s, %s, %s") GPR_REG[DECODE_RD], GPR_REG[DECODE_RS], GPR_REG[DECODE_RT]);}
+void MULT( std::string& output )    { _sap("mult\t%s, %s")      GPR_REG[DECODE_RS], GPR_REG[DECODE_RT]); }
+void MULTU( std::string& output )   { _sap("multu\t%s, %s")     GPR_REG[DECODE_RS], GPR_REG[DECODE_RT]);}
 void DIV( std::string& output )     { _sap("div\t%s, %s")       GPR_REG[DECODE_RS], GPR_REG[DECODE_RT]); }
 void DIVU( std::string& output )    { _sap("divu\t%s, %s")      GPR_REG[DECODE_RS], GPR_REG[DECODE_RT]); }
 


### PR DESCRIPTION
### Description of Changes
Updates mult/mult u to not display an RD operand in disassembly view since no such RD exists for these instructions.

### Rationale behind Changes
Since these instructions have no RD operand it makes more sense to show as MULT rs, rt rather than MULT zero, rs, rt. The zero register confuses more than helps clarify that the result goes into HI and LO.

Before:
![image](https://github.com/PCSX2/pcsx2/assets/4957200/275545ea-98c8-48c9-9768-e8d3888fb5e0)

After:
![image](https://github.com/PCSX2/pcsx2/assets/4957200/de87c395-38fc-4d65-8bb7-7e66b1040f41)


### Suggested Testing Steps
Validating only expected instructions are impacted and no additional changes are needed for consistency.