### PR TITLE
Qt: Improve fullscreen behaviour

### DIFF
--- a/pcsx2-qt/DisplayWidget.h
+++ b/pcsx2-qt/DisplayWidget.h
@@ -51,6 +51,7 @@ protected:
 	bool event(QEvent* event) override;
 
 private:
+	bool isActuallyFullscreen() const;
 	void updateCenterPos();
 
 	QPoint m_relative_mouse_start_pos{};

--- a/pcsx2-qt/MainWindow.h
+++ b/pcsx2-qt/MainWindow.h
@@ -311,6 +311,7 @@ private:
 	bool m_was_paused_on_surface_loss = false;
 	bool m_was_disc_change_request = false;
 	bool m_is_closing = false;
+	bool m_is_temporarily_windowed = false;
 
 	QString m_last_fps_status;
 

--- a/pcsx2/SIO/Memcard/MemoryCardFolder.cpp
+++ b/pcsx2/SIO/Memcard/MemoryCardFolder.cpp
@@ -83,7 +83,6 @@ static void SaveYAMLToFile(const char* filename, const ryml::NodeRef& node)
 	std::fclose(file);
 }
 
-static constexpr time_t MEMORY_CARD_FILE_ENTRY_DATE_TIME_OFFSET = 60 * 60 * 9; // 9 hours from UTC
 static auto last = std::chrono::time_point<std::chrono::system_clock>();
 
 MemoryCardFileEntryDateTime MemoryCardFileEntryDateTime::FromTime(time_t time)


### PR DESCRIPTION
### Description of Changes

Apparently something changed in Qt 6.6, and the windowed transition when invoking the confirm popup didn't complete in time, and/or something to do with parenting changed, which causes a squished popup dialog.

This was racey anyway, `g_emu_thread->isFullscreen()` gets set before on the CPU thread before it calls back to the UI thread, so the wait loop wasn't actually doing much. Poll it from both locations instead - can't use just the UI thread, because the setFullscreen() call itself is asynchronous.

Changes the close behaviour of the display window, if you press ALT+F4 while full screen, PCSX2 will now exit instead of returning to the game list.

Also fixes the main window getting displayed, but not being interactable while the popup is open.

Includes a small dose of Wayland-frustrated comments too. But I'm going to start blaming Qt instead of Wayland itself, because **some** of the problems are Qt issues. Window position still isn't though :P

### Rationale behind Changes

Closes #10294.

### Suggested Testing Steps

Test fullscreen+confirm dialog, ALT+F4 while fullscreen.
