### PR TITLE
GS/HW: In double half clears, take larger bit depth

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -5859,7 +5859,7 @@ bool GSRendererHW::DetectDoubleHalfClear(bool& no_rt, bool& no_ds)
 	ReplaceVerticesWithSprite(m_r, GSVector2i(1, 1));
 
 	// Prevent wasting time looking up and creating the target which is getting blown away.
-	if (!clear_depth)
+	if (frame_psm.trbpp >= zbuf_psm.trbpp)
 	{
 		SetNewFRAME(base * BLOCKS_PER_PAGE, m_cached_ctx.FRAME.FBW, m_cached_ctx.FRAME.PSM);
 		m_cached_ctx.ZBUF.ZMSK = true;

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -175,7 +175,7 @@ GSTexture* GSRendererHW::GetOutput(int i, float& scale, int& y_offset)
 	TEX0.TBW = curFramebuffer.FBW;
 	TEX0.PSM = curFramebuffer.PSM;
 
-	if (GSTextureCache::Target* rt = g_texture_cache->LookupDisplayTarget(TEX0, framebufferSize, GetTextureScaleFactor()))
+	if (GSTextureCache::Target* rt = g_texture_cache->LookupDisplayTarget(TEX0, framebufferSize, GetTextureScaleFactor(), false))
 	{
 		rt->Update();
 		t = rt->m_texture;
@@ -214,7 +214,7 @@ GSTexture* GSRendererHW::GetFeedbackOutput(float& scale)
 	TEX0.TBW = m_regs->EXTBUF.EXBW;
 	TEX0.PSM = PCRTCDisplays.PCRTCDisplays[index].PSM;
 
-	GSTextureCache::Target* rt = g_texture_cache->LookupDisplayTarget(TEX0, fb_size, GetTextureScaleFactor());
+	GSTextureCache::Target* rt = g_texture_cache->LookupDisplayTarget(TEX0, fb_size, GetTextureScaleFactor(), true);
 	if (!rt)
 		return nullptr;
 

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.h
@@ -483,7 +483,7 @@ public:
 	Target* CreateTarget(GIFRegTEX0 TEX0, const GSVector2i& size, const GSVector2i& valid_size,float scale, int type, bool used = true, u32 fbmask = 0,
 		bool is_frame = false, bool preload = GSConfig.PreloadFrameWithGSData, bool preserve_target = true,
 		const GSVector4i draw_rc = GSVector4i::zero(), GSTextureCache::Source* src = nullptr);
-	Target* LookupDisplayTarget(GIFRegTEX0 TEX0, const GSVector2i& size, float scale);
+	Target* LookupDisplayTarget(GIFRegTEX0 TEX0, const GSVector2i& size, float scale, bool is_feedback);
 
 	/// Looks up a target in the cache, and only returns it if the BP/BW match exactly.
 	Target* GetExactTarget(u32 BP, u32 BW, int type, u32 end_bp);


### PR DESCRIPTION
### Description of Changes
Can't believe I'm fixing a religious game.

Anyway, Takes the larger bit depth of the two when doing a double half clear, to avoid the alpha not being overwritten when it should be.

Also restricted when the hw renderer can create a new target to cut down FMV errors.

### Rationale behind Changes
Veggie Tales - LarryBoy and the Bad Apple was doing a double half clear to wipe two textures, with the upper half being a C32 texture, but because the Z Buffer was the base, it was using that, which was set to Z24 format, meaning the alpha was left untouched. The next draw relied on this being cleared, but ended up drawing garbage to the screen from a messy alpha channel.

Bad targets were also being created on idle frames between FMV's in games like Clock Tower 3

### Suggested Testing Steps
Smoke test some random games you know do double half clears I suppose and the game mentioned above.

Fixes #9924

Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/3503a1ff-d432-4bf1-88fb-c16b0c1c9bf1)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/8c649798-f4f0-434e-a84d-1b7de1cddd59)

Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/678547f5-0e65-4774-b78b-b8c957ace59c)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/9aec7dab-d6b8-4642-9ecb-1e480c60a4f2)

Some other FMV's (like Dino Crisis 3) also act better.
