### PR TITLE
Debugger: Allow copying function names

### DIFF
--- a/pcsx2-qt/Debugger/DisassemblyWidget.cpp
+++ b/pcsx2-qt/Debugger/DisassemblyWidget.cpp
@@ -234,6 +234,11 @@ void DisassemblyWidget::contextAddFunction()
 	}
 }
 
+void DisassemblyWidget::contextCopyFunctionName()
+{
+	QGuiApplication::clipboard()->setText(QString::fromStdString(m_cpu->GetSymbolMap().GetLabelName(m_selectedAddressStart)));
+}
+
 void DisassemblyWidget::contextRemoveFunction()
 {
 	u32 curFuncAddr = m_cpu->GetSymbolMap().GetFunctionStart(m_selectedAddressStart);
@@ -665,6 +670,11 @@ void DisassemblyWidget::customMenuRequested(QPoint pos)
 	connect(action, &QAction::triggered, this, &DisassemblyWidget::contextCopyInstructionHex);
 	contextMenu->addAction(action = new QAction(tr("Copy Instruction Text"), this));
 	connect(action, &QAction::triggered, this, &DisassemblyWidget::contextCopyInstructionText);
+	if (m_selectedAddressStart == m_cpu->GetSymbolMap().GetFunctionStart(m_selectedAddressStart)) 
+	{
+		contextMenu->addAction(action = new QAction(tr("Copy Function Name"), this));
+		connect(action, &QAction::triggered, this, &DisassemblyWidget::contextCopyFunctionName);
+	}
 	contextMenu->addSeparator();
 	if (AddressCanRestore(m_selectedAddressStart, m_selectedAddressEnd))
 	{

--- a/pcsx2-qt/Debugger/DisassemblyWidget.h
+++ b/pcsx2-qt/Debugger/DisassemblyWidget.h
@@ -54,6 +54,7 @@ public slots:
 	void contextCopyAddress();
 	void contextCopyInstructionHex();
 	void contextCopyInstructionText();
+	void contextCopyFunctionName();
 	void contextAssembleInstruction();
 	void contextNoopInstruction();
 	void contextRestoreInstruction();


### PR DESCRIPTION
### Description of Changes
Add the ability to copy a function name when you right click the first instruction of a function (the line where the function name displays).

(Only adds this right click option to the starting instruction of the function that has the text name, not to all instructions of the function.)

**Demonstration:**

![PCSX2-CopyFunctionName](https://github.com/PCSX2/pcsx2/assets/4957200/831240a0-ea2c-4c47-b42d-6b9366878570)

### Rationale behind Changes
Names can be quite long and complicated, thus it can be quite helpful to be able to just copy the name. 
Just a convenience feature.

### Suggested Testing Steps
- Load any ISO or ELF
- Open the debugger
- Open the Functions tab
- Double click a function to jump to it's position
- Right click the first instruction to verify the context menu for "Copy Function Name" exists.
- Verify the copied name is valid and validate that the context menu option is not available for other instructions of the function.