### PR TITLE
Qt: Use HTTPDownloader instead of QtNetwork for updates

### DIFF
--- a/cmake/SearchForStuff.cmake
+++ b/cmake/SearchForStuff.cmake
@@ -156,7 +156,7 @@ disable_compiler_warnings_for_target(cubeb)
 disable_compiler_warnings_for_target(speex)
 
 # Find the Qt components that we need.
-find_package(Qt6 6.6.0 COMPONENTS CoreTools Core GuiTools Gui WidgetsTools Widgets Network LinguistTools REQUIRED)
+find_package(Qt6 6.6.0 COMPONENTS CoreTools Core GuiTools Gui WidgetsTools Widgets LinguistTools REQUIRED)
 
 if(WIN32)
   add_subdirectory(3rdparty/rainterface EXCLUDE_FROM_ALL)

--- a/common/HTTPDownloader.h
+++ b/common/HTTPDownloader.h
@@ -1,5 +1,5 @@
 /*  PCSX2 - PS2 Emulator for PCs
- *  Copyright (C) 2002-2022  PCSX2 Dev Team
+ *  Copyright (C) 2002-2023 PCSX2 Dev Team
  *
  *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU Lesser General Public License as published by the Free Software Found-
@@ -14,14 +14,19 @@
  */
 
 #pragma once
+
 #include "common/Pcsx2Defs.h"
+
 #include <atomic>
 #include <functional>
 #include <memory>
 #include <mutex>
 #include <string>
 #include <string_view>
+#include <variant>
 #include <vector>
+
+class ProgressCallback;
 
 class HTTPDownloader
 {
@@ -56,6 +61,7 @@ public:
 
 		HTTPDownloader* parent;
 		Callback callback;
+		ProgressCallback* progress;
 		std::string url;
 		std::string post_data;
 		std::string content_type;
@@ -63,6 +69,7 @@ public:
 		u64 start_time;
 		s32 status_code = 0;
 		u32 content_length = 0;
+		u32 last_progress_update = 0;
 		Type type = Type::Get;
 		std::atomic<State> state{State::Pending};
 	};
@@ -70,7 +77,7 @@ public:
 	HTTPDownloader();
 	virtual ~HTTPDownloader();
 
-	static std::unique_ptr<HTTPDownloader> Create(const char* user_agent = DEFAULT_USER_AGENT);
+	static std::unique_ptr<HTTPDownloader> Create(std::string user_agent = DEFAULT_USER_AGENT);
 	static std::string URLEncode(const std::string_view& str);
 	static std::string URLDecode(const std::string_view& str);
 	static std::string GetExtensionForContentType(const std::string& content_type);
@@ -78,8 +85,8 @@ public:
 	void SetTimeout(float timeout);
 	void SetMaxActiveRequests(u32 max_active_requests);
 
-	void CreateRequest(std::string url, Request::Callback callback);
-	void CreatePostRequest(std::string url, std::string post_data, Request::Callback callback);
+	void CreateRequest(std::string url, Request::Callback callback, ProgressCallback* progress = nullptr);
+	void CreatePostRequest(std::string url, std::string post_data, Request::Callback callback, ProgressCallback* progress = nullptr);
 	void PollRequests();
 	void WaitForAllRequests();
 	bool HasAnyRequests();

--- a/common/HTTPDownloaderCurl.h
+++ b/common/HTTPDownloaderCurl.h
@@ -28,7 +28,7 @@ public:
 	HTTPDownloaderCurl();
 	~HTTPDownloaderCurl() override;
 
-	bool Initialize(const char* user_agent);
+	bool Initialize(std::string user_agent);
 
 protected:
 	Request* InternalCreateRequest() override;

--- a/common/HTTPDownloaderWinHTTP.cpp
+++ b/common/HTTPDownloaderWinHTTP.cpp
@@ -20,6 +20,7 @@
 #include "common/Console.h"
 #include "common/StringUtil.h"
 #include "common/Timer.h"
+
 #include <VersionHelpers.h>
 #include <algorithm>
 
@@ -39,16 +40,16 @@ HTTPDownloaderWinHttp::~HTTPDownloaderWinHttp()
 	}
 }
 
-std::unique_ptr<HTTPDownloader> HTTPDownloader::Create(const char* user_agent)
+std::unique_ptr<HTTPDownloader> HTTPDownloader::Create(std::string user_agent)
 {
 	std::unique_ptr<HTTPDownloaderWinHttp> instance(std::make_unique<HTTPDownloaderWinHttp>());
-	if (!instance->Initialize(user_agent))
+	if (!instance->Initialize(std::move(user_agent)))
 		return {};
 
 	return instance;
 }
 
-bool HTTPDownloaderWinHttp::Initialize(const char* user_agent)
+bool HTTPDownloaderWinHttp::Initialize(std::string user_agent)
 {
 	const DWORD dwAccessType = WINHTTP_ACCESS_TYPE_AUTOMATIC_PROXY;
 

--- a/common/HTTPDownloaderWinHTTP.h
+++ b/common/HTTPDownloaderWinHTTP.h
@@ -26,7 +26,7 @@ public:
 	HTTPDownloaderWinHttp();
 	~HTTPDownloaderWinHttp() override;
 
-	bool Initialize(const char* user_agent);
+	bool Initialize(std::string user_agent);
 
 protected:
 	Request* InternalCreateRequest() override;
@@ -45,6 +45,8 @@ private:
 
 	static void CALLBACK HTTPStatusCallback(HINTERNET hInternet, DWORD_PTR dwContext, DWORD dwInternetStatus,
 		LPVOID lpvStatusInformation, DWORD dwStatusInformationLength);
+
+	static bool CheckCancelled(Request* request);
 
 	HINTERNET m_hSession = NULL;
 };

--- a/common/ProgressCallback.h
+++ b/common/ProgressCallback.h
@@ -82,8 +82,8 @@ public:
 	virtual void PushState() override;
 	virtual void PopState() override;
 
-	bool IsCancelled() const;
-	bool IsCancellable() const;
+	virtual bool IsCancelled() const override;
+	virtual bool IsCancellable() const override;
 
 	virtual void SetCancellable(bool cancellable) override;
 	virtual void SetStatusText(const char* text) override;

--- a/common/ProgressCallback.h
+++ b/common/ProgressCallback.h
@@ -82,8 +82,8 @@ public:
 	virtual void PushState() override;
 	virtual void PopState() override;
 
-	virtual bool IsCancelled() const override;
-	virtual bool IsCancellable() const override;
+	bool IsCancelled() const;
+	bool IsCancellable() const;
 
 	virtual void SetCancellable(bool cancellable) override;
 	virtual void SetStatusText(const char* text) override;

--- a/common/vsprops/QtCompile.props
+++ b/common/vsprops/QtCompile.props
@@ -32,7 +32,7 @@
     </ClCompile>
     <Link>
       <AdditionalLibraryDirectories>$(QtLibDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>Qt6Core$(QtLibSuffix).lib;Qt6Gui$(QtLibSuffix).lib;Qt6Widgets$(QtLibSuffix).lib;Qt6Network$(QtLibSuffix).lib;Qt6Concurrent$(QtLibSuffix).lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Qt6Core$(QtLibSuffix).lib;Qt6Gui$(QtLibSuffix).lib;Qt6Widgets$(QtLibSuffix).lib;Qt6Concurrent$(QtLibSuffix).lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
 
@@ -118,24 +118,21 @@
 
   <!--Copy the needed dlls-->
   <ItemGroup>
-    <QtLibNames Include="Qt6Core$(QtLibSuffix);Qt6Gui$(QtLibSuffix);Qt6Widgets$(QtLibSuffix);Qt6Network$(QtLibSuffix);Qt6Svg$(QtLibSuffix);Qt6Concurrent$(QtLibSuffix)" />
+    <QtLibNames Include="Qt6Core$(QtLibSuffix);Qt6Gui$(QtLibSuffix);Qt6Widgets$(QtLibSuffix);Qt6Svg$(QtLibSuffix);Qt6Concurrent$(QtLibSuffix)" />
     <QtDlls Include="@(QtLibNames -> '$(QtBinDir)%(Identity).dll')" />
     <!--Filter plugins to copy based on the observation that all debug versions end in "d"-->
     <QtAllPlugins Include="$(QtPluginsDir)**\*$(QtLibSuffix).dll" />
     <QtPlugins Condition="$(Configuration.Contains(Debug))" Include="@(QtAllPlugins)" />
     <QtPlugins Condition="!$(Configuration.Contains(Debug))" Exclude="$(QtPluginsDir)**\*$(QtDebugSuffix).dll" Include="@(QtAllPlugins)" />
     <QtPluginsDest Include="@(QtPlugins -> '$(QtBinaryOutputDir)$(QtPluginFolder)\%(RecursiveDir)%(Filename)%(Extension)')" />
-    <!--Our normal *d filter fails for the TLS DLLs, because backend ends in d. -->
-    <QtTLSDlls Include="$(QtPluginsDir)tls\qcertonlybackend$(QtLibSuffix).dll;$(QtPluginsDir)tls\qschannelbackend$(QtLibSuffix).dll" />
-    <QtTLSDllsDest Include="@(QtTLSDlls -> '$(QtBinaryOutputDir)$(QtPluginFolder)\tls\%(Filename)%(Extension)')" />
   </ItemGroup>
   <PropertyGroup>
     <QtConfFile>$(QtBinaryOutputDir)qt.conf</QtConfFile>
   </PropertyGroup>
   <Target Name="QtCopyBinaries"
     AfterTargets="Build"
-    Inputs="@(QtDlls);@(QtPlugins);@(QtTLSDlls)"
-    Outputs="@(QtDlls -> '$(QtBinaryOutputDir)%(RecursiveDir)%(Filename)%(Extension)');@(QtPluginsDest);@(QtTLSDllsDest)">
+    Inputs="@(QtDlls);@(QtPlugins)"
+    Outputs="@(QtDlls -> '$(QtBinaryOutputDir)%(RecursiveDir)%(Filename)%(Extension)');@(QtPluginsDest)">
     <Message Text="Copying Qt .dlls" Importance="High" />
     <Copy
       SourceFiles="@(QtDlls)"
@@ -145,11 +142,6 @@
     <Copy
       SourceFiles="@(QtPlugins)"
       DestinationFiles="@(QtPluginsDest)"
-      SkipUnchangedFiles="true"
-    />
-    <Copy
-      SourceFiles="@(QtTLSDlls)"
-      DestinationFiles="@(QtTLSDllsDest)"
       SkipUnchangedFiles="true"
     />
   </Target>

--- a/pcsx2-qt/AutoUpdaterDialog.cpp
+++ b/pcsx2-qt/AutoUpdaterDialog.cpp
@@ -1,5 +1,5 @@
 /*  PCSX2 - PS2 Emulator for PCs
- *  Copyright (C) 2002-2023  PCSX2 Dev Team
+ *  Copyright (C) 2002-2023 PCSX2 Dev Team
  *
  *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU Lesser General Public License as published by the Free Software Found-
@@ -18,6 +18,7 @@
 #include "AutoUpdaterDialog.h"
 #include "MainWindow.h"
 #include "QtHost.h"
+#include "QtProgressCallback.h"
 #include "QtUtils.h"
 
 #include "pcsx2/Host.h"
@@ -26,11 +27,14 @@
 
 #include "updater/UpdaterExtractor.h"
 
+#include "common/Assertions.h"
 #include "common/CocoaTools.h"
 #include "common/Console.h"
 #include "common/FileSystem.h"
+#include "common/HTTPDownloader.h"
 #include "common/StringUtil.h"
 
+#include <functional>
 #include <QtCore/QCoreApplication>
 #include <QtCore/QFile>
 #include <QtCore/QJsonArray>
@@ -39,34 +43,34 @@
 #include <QtCore/QJsonValue>
 #include <QtCore/QProcess>
 #include <QtCore/QString>
-#include <QtNetwork/QNetworkAccessManager>
-#include <QtNetwork/QNetworkReply>
-#include <QtNetwork/QNetworkRequest>
 #include <QtWidgets/QDialog>
 #include <QtWidgets/QMessageBox>
 #include <QtWidgets/QProgressDialog>
+
+// Interval at which HTTP requests are polled.
+static constexpr u32 HTTP_POLL_INTERVAL = 10;
 
 // Logic to detect whether we can use the auto updater.
 // We use tagged commit, because this gets set on nightly builds.
 #if (defined(_WIN32) || defined(__linux__) || defined(__APPLE__)) && defined(GIT_TAG_LO)
 
-	#define AUTO_UPDATER_SUPPORTED 1
+#define AUTO_UPDATER_SUPPORTED 1
 
-	#if defined(_WIN32)
-		#define UPDATE_PLATFORM_STR "Windows"
-	#elif defined(__linux__)
-		#define UPDATE_PLATFORM_STR "Linux"
-	#elif defined(__APPLE__)
-		#define UPDATE_PLATFORM_STR "MacOS"
-	#endif
+#if defined(_WIN32)
+#define UPDATE_PLATFORM_STR "Windows"
+#elif defined(__linux__)
+#define UPDATE_PLATFORM_STR "Linux"
+#elif defined(__APPLE__)
+#define UPDATE_PLATFORM_STR "MacOS"
+#endif
 
-	#ifdef MULTI_ISA_SHARED_COMPILATION
-		// #undef UPDATE_ADDITIONAL_TAGS
-	#elif _M_SSE >= 0x501
-		#define UPDATE_ADDITIONAL_TAGS "AVX2"
-	#else
-		#define UPDATE_ADDITIONAL_TAGS "SSE4"
-	#endif
+#ifdef MULTI_ISA_SHARED_COMPILATION
+// #undef UPDATE_ADDITIONAL_TAGS
+#elif _M_SSE >= 0x501
+#define UPDATE_ADDITIONAL_TAGS "AVX2"
+#else
+#define UPDATE_ADDITIONAL_TAGS "SSE4"
+#endif
 
 #endif
 
@@ -86,8 +90,6 @@ static const char* UPDATE_TAGS[] = {"stable", "nightly"};
 AutoUpdaterDialog::AutoUpdaterDialog(QWidget* parent /* = nullptr */)
 	: QDialog(parent)
 {
-	m_network_access_mgr = new QNetworkAccessManager(this);
-
 	m_ui.setupUi(this);
 
 	setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
@@ -95,6 +97,10 @@ AutoUpdaterDialog::AutoUpdaterDialog(QWidget* parent /* = nullptr */)
 	connect(m_ui.downloadAndInstall, &QPushButton::clicked, this, &AutoUpdaterDialog::downloadUpdateClicked);
 	connect(m_ui.skipThisUpdate, &QPushButton::clicked, this, &AutoUpdaterDialog::skipThisUpdateClicked);
 	connect(m_ui.remindMeLater, &QPushButton::clicked, this, &AutoUpdaterDialog::remindMeLaterClicked);
+
+	m_http = HTTPDownloader::Create(Host::GetHTTPUserAgent());
+	if (!m_http)
+		Console.Error("Failed to create HTTP downloader, auto updater will not be available.");
 }
 
 AutoUpdaterDialog::~AutoUpdaterDialog() = default;
@@ -172,35 +178,66 @@ void AutoUpdaterDialog::reportError(const char* msg, ...)
 		QMessageBox::critical(this, tr("Updater Error"), QString::fromStdString(full_msg));
 }
 
+bool AutoUpdaterDialog::ensureHttpReady()
+{
+	if (!m_http)
+		return false;
+
+	if (!m_http_poll_timer)
+	{
+		m_http_poll_timer = new QTimer(this);
+		m_http_poll_timer->connect(m_http_poll_timer, &QTimer::timeout, this, &AutoUpdaterDialog::httpPollTimerPoll);
+	}
+
+	if (!m_http_poll_timer->isActive())
+	{
+		m_http_poll_timer->setSingleShot(false);
+		m_http_poll_timer->setInterval(HTTP_POLL_INTERVAL);
+		m_http_poll_timer->start();
+	}
+
+	return true;
+}
+
+void AutoUpdaterDialog::httpPollTimerPoll()
+{
+	pxAssert(m_http);
+	m_http->PollRequests();
+
+	if (!m_http->HasAnyRequests())
+	{
+		Console.WriteLn("(AutoUpdaterDialog) All HTTP requests done.");
+		m_http_poll_timer->stop();
+	}
+}
+
 void AutoUpdaterDialog::queueUpdateCheck(bool display_message)
 {
 	m_display_messages = display_message;
 
 #ifdef AUTO_UPDATER_SUPPORTED
-	connect(m_network_access_mgr, &QNetworkAccessManager::finished, this, &AutoUpdaterDialog::getLatestReleaseComplete);
+	if (!ensureHttpReady())
+	{
+		emit updateCheckCompleted();
+		return;
+	}
 
-	QUrl url(QStringLiteral(LATEST_RELEASE_URL).arg(getCurrentUpdateTag()));
-	QNetworkRequest request(url);
-	m_network_access_mgr->get(request);
+	m_http->CreateRequest(QStringLiteral(LATEST_RELEASE_URL).arg(getCurrentUpdateTag()).toStdString(),
+		std::bind(&AutoUpdaterDialog::getLatestReleaseComplete, this, std::placeholders::_1, std::placeholders::_3));
 #else
 	emit updateCheckCompleted();
 #endif
 }
 
-void AutoUpdaterDialog::getLatestReleaseComplete(QNetworkReply* reply)
+void AutoUpdaterDialog::getLatestReleaseComplete(s32 status_code, std::vector<u8> data)
 {
 #ifdef AUTO_UPDATER_SUPPORTED
-	// this might fail due to a lack of internet connection - in which case, don't spam the user with messages every time.
-	m_network_access_mgr->disconnect(this);
-	reply->deleteLater();
-
 	bool found_update_info = false;
 
-	if (reply->error() == QNetworkReply::NoError)
+	if (status_code == HTTPDownloader::HTTP_STATUS_OK)
 	{
-		const QByteArray reply_json(reply->readAll());
 		QJsonParseError parse_error;
-		QJsonDocument doc(QJsonDocument::fromJson(reply_json, &parse_error));
+		QJsonDocument doc(QJsonDocument::fromJson(QByteArray(reinterpret_cast<const char*>(data.data()), data.size()), &parse_error));
 		if (doc.isObject())
 		{
 			const QJsonObject doc_object(doc.object());
@@ -304,7 +341,7 @@ void AutoUpdaterDialog::getLatestReleaseComplete(QNetworkReply* reply)
 	}
 	else
 	{
-		reportError("Failed to download latest release info: %d", static_cast<int>(reply->error()));
+		reportError("Failed to download latest release info: %d", status_code);
 	}
 
 	if (found_update_info)
@@ -317,29 +354,21 @@ void AutoUpdaterDialog::getLatestReleaseComplete(QNetworkReply* reply)
 void AutoUpdaterDialog::queueGetChanges()
 {
 #ifdef AUTO_UPDATER_SUPPORTED
-	connect(m_network_access_mgr, &QNetworkAccessManager::finished, this, &AutoUpdaterDialog::getChangesComplete);
+	if (!ensureHttpReady())
+		return;
 
-	const QString url_string(QStringLiteral(CHANGES_URL).arg(GIT_HASH).arg(m_latest_version));
-	QUrl url(url_string);
-	QNetworkRequest request(url);
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-	request.setAttribute(QNetworkRequest::FollowRedirectsAttribute, true);
-#endif
-	m_network_access_mgr->get(request);
+	m_http->CreateRequest(QStringLiteral(CHANGES_URL).arg(GIT_HASH).arg(m_latest_version).toStdString(),
+		std::bind(&AutoUpdaterDialog::getChangesComplete, this, std::placeholders::_1, std::placeholders::_3));
 #endif
 }
 
-void AutoUpdaterDialog::getChangesComplete(QNetworkReply* reply)
+void AutoUpdaterDialog::getChangesComplete(s32 status_code, std::vector<u8> data)
 {
 #ifdef AUTO_UPDATER_SUPPORTED
-	m_network_access_mgr->disconnect(this);
-	reply->deleteLater();
-
-	if (reply->error() == QNetworkReply::NoError)
+	if (status_code == HTTPDownloader::HTTP_STATUS_OK)
 	{
-		const QByteArray reply_json(reply->readAll());
 		QJsonParseError parse_error;
-		QJsonDocument doc(QJsonDocument::fromJson(reply_json, &parse_error));
+		QJsonDocument doc(QJsonDocument::fromJson(QByteArray(reinterpret_cast<const char*>(data.data()), data.size()), &parse_error));
 		if (doc.isObject())
 		{
 			const QJsonObject doc_object(doc.object());
@@ -400,7 +429,7 @@ void AutoUpdaterDialog::getChangesComplete(QNetworkReply* reply)
 	}
 	else
 	{
-		reportError("Failed to download change list: %d", static_cast<int>(reply->error()));
+		reportError("Failed to download change list: %d", status_code);
 	}
 #endif
 
@@ -427,61 +456,53 @@ void AutoUpdaterDialog::downloadUpdateClicked()
 	}
 
 	m_display_messages = true;
-	QUrl url(m_download_url);
-	QNetworkRequest request(url);
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-	request.setAttribute(QNetworkRequest::FollowRedirectsAttribute, true);
-#endif
-	QNetworkReply* reply = m_network_access_mgr->get(request);
 
-	QProgressDialog progress(tr("Downloading %1...").arg(m_download_url), tr("Cancel"), 0, 1);
-	progress.setWindowTitle(tr("Automatic Updater"));
-	progress.setWindowIcon(windowIcon());
-	progress.setAutoClose(false);
+	std::optional<bool> download_result;
+	QtModalProgressCallback progress(this);
+	progress.SetTitle(tr("Automatic Updater").toUtf8().constData());
+	progress.SetStatusText(tr("Downloading %1...").arg(m_latest_version).toUtf8().constData());
+	progress.GetDialog().setWindowIcon(windowIcon());
+	progress.SetCancellable(true);
 
-	connect(reply, &QNetworkReply::downloadProgress, [&progress](quint64 received, quint64 total) {
-		progress.setRange(0, static_cast<int>(total));
-		progress.setValue(static_cast<int>(received));
-	});
+	m_http->CreateRequest(
+		m_download_url.toStdString(),
+		[this, &download_result, &progress](s32 status_code, const std::string&, std::vector<u8> data) {
+			if (status_code == HTTPDownloader::HTTP_STATUS_CANCELLED)
+				return;
 
-	connect(m_network_access_mgr, &QNetworkAccessManager::finished, [this, &progress](QNetworkReply* reply) {
-		m_network_access_mgr->disconnect();
+			if (status_code != HTTPDownloader::HTTP_STATUS_OK)
+			{
+				reportError("Download failed: %d", status_code);
+				download_result = false;
+				return;
+			}
 
-		if (reply->error() != QNetworkReply::NoError)
-		{
-			reportError("Download failed: %s", reply->errorString().toUtf8().constData());
-			progress.done(-1);
-			return;
-		}
+			if (data.empty())
+			{
+				reportError("Download failed: Update is empty");
+				download_result = false;
+				return;
+			}
 
-		const QByteArray data = reply->readAll();
-		if (data.isEmpty())
-		{
-			reportError("Download failed: Update is empty");
-			progress.done(-1);
-			return;
-		}
+			download_result = processUpdate(data, progress.GetDialog());
+		},
+		&progress);
 
-		if (processUpdate(data, progress))
-			progress.done(1);
-		else
-			progress.done(-1);
-	});
-
-	const int result = progress.exec();
-	if (result == 0)
+	// Block until completion.
+	while (m_http->HasAnyRequests())
 	{
-		// cancelled
-		reply->abort();
+		QApplication::processEvents(QEventLoop::AllEvents, HTTP_POLL_INTERVAL);
+		m_http->PollRequests();
 	}
-	else if (result == 1)
+
+	if (download_result.value_or(false))
 	{
 		// updater started. since we're a modal on the main window, we have to queue this.
 		QMetaObject::invokeMethod(g_main_window, "requestExit", Qt::QueuedConnection, Q_ARG(bool, true));
 		done(0);
 	}
 
-	reply->deleteLater();
+	// download error or cancelled
 }
 
 void AutoUpdaterDialog::checkIfUpdateNeeded()
@@ -490,8 +511,8 @@ void AutoUpdaterDialog::checkIfUpdateNeeded()
 		QString::fromStdString(Host::GetBaseStringSettingValue("AutoUpdater", "LastVersion")));
 
 	Console.WriteLn(Color_StrongGreen, "Current version: %s", GIT_TAG);
-	Console.WriteLn(Color_StrongYellow, "Latest SHA: %s", m_latest_version.toUtf8().constData());
-	Console.WriteLn(Color_StrongOrange, "Last Checked SHA: %s", last_checked_version.toUtf8().constData());
+	Console.WriteLn(Color_StrongYellow, "Latest version: %s", m_latest_version.toUtf8().constData());
+	Console.WriteLn(Color_StrongOrange, "Last checked version: %s", last_checked_version.toUtf8().constData());
 	if (m_latest_version == GIT_TAG || m_latest_version == last_checked_version)
 	{
 		Console.WriteLn(Color_StrongGreen, "No update needed.");
@@ -522,7 +543,9 @@ void AutoUpdaterDialog::checkIfUpdateNeeded()
 	m_ui.downloadSize->setText(tr("Download Size: %1 MB").arg(static_cast<double>(m_download_size) / 1048576.0, 0, 'f', 2));
 	m_ui.updateNotes->setText(tr("Loading..."));
 	queueGetChanges();
-	exec();
+
+	// We have to defer this, because it comes back through the timer/HTTP callback...
+	QMetaObject::invokeMethod(this, "exec", Qt::QueuedConnection);
 }
 
 void AutoUpdaterDialog::skipThisUpdateClicked()
@@ -539,7 +562,7 @@ void AutoUpdaterDialog::remindMeLaterClicked()
 
 #if defined(_WIN32)
 
-bool AutoUpdaterDialog::processUpdate(const QByteArray& update_data, QProgressDialog&)
+bool AutoUpdaterDialog::processUpdate(const std::vector<u8>& data, QProgressDialog&)
 {
 	const QString update_directory = QCoreApplication::applicationDirPath();
 	const QString update_zip_path = QStringLiteral("%1" FS_OSPATH_SEPARATOR_STR "%2").arg(update_directory).arg(UPDATER_ARCHIVE_NAME);
@@ -555,7 +578,8 @@ bool AutoUpdaterDialog::processUpdate(const QByteArray& update_data, QProgressDi
 
 	{
 		QFile update_zip_file(update_zip_path);
-		if (!update_zip_file.open(QIODevice::WriteOnly) || update_zip_file.write(update_data) != update_data.size())
+		if (!update_zip_file.open(QIODevice::WriteOnly) ||
+			update_zip_file.write(reinterpret_cast<const char*>(data.data()), static_cast<qint64>(data.size())) != static_cast<qint64>(data.size()))
 		{
 			reportError("Writing update zip to '%s' failed", update_zip_path.toUtf8().constData());
 			return false;
@@ -615,7 +639,7 @@ void AutoUpdaterDialog::cleanupAfterUpdate()
 
 #elif defined(__linux__)
 
-bool AutoUpdaterDialog::processUpdate(const QByteArray& update_data, QProgressDialog&)
+bool AutoUpdaterDialog::processUpdate(const std::vector<u8>& data, QProgressDialog&)
 {
 	const char* appimage_path = std::getenv("APPIMAGE");
 	if (!appimage_path || !FileSystem::FileExists(appimage_path))
@@ -655,7 +679,9 @@ bool AutoUpdaterDialog::processUpdate(const QByteArray& update_data, QProgressDi
 		QFile old_file(qappimage_path);
 		const QFileDevice::Permissions old_permissions = old_file.permissions();
 		QFile new_file(new_appimage_path);
-		if (!new_file.open(QIODevice::WriteOnly) || new_file.write(update_data) != update_data.size() || !new_file.setPermissions(old_permissions))
+		if (!new_file.open(QIODevice::WriteOnly) ||
+			new_file.write(reinterpret_cast<const char*>(data.data()), static_cast<qint64>(data.size())) != static_cast<qint64>(data.size()) ||
+			!new_file.setPermissions(old_permissions))
 		{
 			QFile::remove(new_appimage_path);
 			reportError("Failed to write new destination AppImage: %s", new_appimage_path.toUtf8().constData());
@@ -725,7 +751,7 @@ static QString UpdateVersionNumberInName(QString name, QStringView new_version)
 	return name;
 }
 
-bool AutoUpdaterDialog::processUpdate(const QByteArray& update_data, QProgressDialog& progress)
+bool AutoUpdaterDialog::processUpdate(const std::vector<u8>& data, QProgressDialog& progress)
 {
 	std::optional<std::string> path = CocoaTools::GetNonTranslocatedBundlePath();
 	if (!path.has_value())
@@ -754,20 +780,21 @@ bool AutoUpdaterDialog::processUpdate(const QByteArray& update_data, QProgressDi
 			return false;
 		}
 
-		constexpr qsizetype chunk_size = 65536;
+		constexpr size_t chunk_size = 65536;
 		progress.setLabelText(QStringLiteral("Unpacking update..."));
 		progress.reset();
-		progress.setRange(0, static_cast<int>((update_data.size() + chunk_size - 1) / chunk_size));
+		progress.setRange(0, static_cast<int>((data.size() + chunk_size - 1) / chunk_size));
 
 		QProcess untar;
 		untar.setProgram(QStringLiteral("/usr/bin/tar"));
 		untar.setArguments({QStringLiteral("xC"), temp_dir.path()});
 		untar.start();
-		for (qsizetype i = 0; i < update_data.size(); i += chunk_size)
+		for (size_t i = 0; i < data.size(); i += chunk_size)
 		{
 			progress.setValue(static_cast<int>(i / chunk_size));
-			const qsizetype amt = std::min(update_data.size() - i, chunk_size);
-			if (progress.wasCanceled() || untar.write(update_data.data() + i, amt) != amt)
+			const size_t amt = std::min(data.size() - i, chunk_size);
+			if (progress.wasCanceled() ||
+				untar.write(reinterpret_cast<const char*>(data.data() + i), static_cast<qsizetype>(amt)) != static_cast<qsizetype>(amt))
 			{
 				if (!progress.wasCanceled())
 					reportError("Failed to unpack update (write stopped short)");
@@ -796,7 +823,7 @@ bool AutoUpdaterDialog::processUpdate(const QByteArray& update_data, QProgressDi
 		}
 
 		QFileInfoList temp_dir_contents = QDir(temp_dir.path()).entryInfoList(QDir::Filter::Dirs | QDir::Filter::NoDotAndDotDot);
-		auto new_app = std::find_if(temp_dir_contents.begin(), temp_dir_contents.end(), [](const QFileInfo& file){ return file.suffix() == QStringLiteral("app"); });
+		auto new_app = std::find_if(temp_dir_contents.begin(), temp_dir_contents.end(), [](const QFileInfo& file) { return file.suffix() == QStringLiteral("app"); });
 		if (new_app == temp_dir_contents.end())
 		{
 			reportError("Couldn't find application in update package");
@@ -814,7 +841,7 @@ bool AutoUpdaterDialog::processUpdate(const QByteArray& update_data, QProgressDi
 		{
 			QFile::rename(QString::fromStdString(*trashed_path), info.filePath());
 			reportError("Failed to move new application into place (couldn't rename '%s' to '%s')",
-			            new_app->absoluteFilePath().toUtf8().constData(), open_path.toUtf8().constData());
+				new_app->absoluteFilePath().toUtf8().constData(), open_path.toUtf8().constData());
 			return false;
 		}
 		QDir(QString::fromStdString(*trashed_path)).removeRecursively();

--- a/pcsx2-qt/CMakeLists.txt
+++ b/pcsx2-qt/CMakeLists.txt
@@ -193,7 +193,6 @@ target_link_libraries(pcsx2-qt PRIVATE
 	Qt6::Core
 	Qt6::Gui
 	Qt6::Widgets
-	Qt6::Network
 )
 
 # Our Qt builds may have exceptions on, so force them off.

--- a/pcsx2-qt/QtProgressCallback.cpp
+++ b/pcsx2-qt/QtProgressCallback.cpp
@@ -34,15 +34,11 @@ QtModalProgressCallback::QtModalProgressCallback(QWidget* parent_widget, float s
 	m_dialog.setModal(parent_widget != nullptr);
 	m_dialog.setAutoClose(false);
 	m_dialog.setAutoReset(false);
+	connect(&m_dialog, &QProgressDialog::canceled, this, &QtModalProgressCallback::dialogCancelled);
 	checkForDelayedShow();
 }
 
 QtModalProgressCallback::~QtModalProgressCallback() = default;
-
-bool QtModalProgressCallback::IsCancelled() const
-{
-	return m_dialog.wasCanceled();
-}
 
 void QtModalProgressCallback::SetCancellable(bool cancellable)
 {
@@ -121,6 +117,11 @@ bool QtModalProgressCallback::ModalConfirmation(const char* message)
 void QtModalProgressCallback::ModalInformation(const char* message)
 {
 	QMessageBox::information(&m_dialog, tr("Information"), QString::fromUtf8(message));
+}
+
+void QtModalProgressCallback::dialogCancelled()
+{
+	m_cancelled = true;
 }
 
 void QtModalProgressCallback::checkForDelayedShow()

--- a/pcsx2-qt/QtProgressCallback.h
+++ b/pcsx2-qt/QtProgressCallback.h
@@ -29,7 +29,7 @@ public:
 	QtModalProgressCallback(QWidget* parent_widget, float show_delay = 0.0f);
 	~QtModalProgressCallback();
 
-	bool IsCancelled() const override;
+	QProgressDialog& GetDialog() { return m_dialog; }
 
 	void SetCancellable(bool cancellable) override;
 	void SetTitle(const char* title) override;
@@ -45,6 +45,9 @@ public:
 	void ModalError(const char* message) override;
 	bool ModalConfirmation(const char* message) override;
 	void ModalInformation(const char* message) override;
+
+private Q_SLOTS:
+	void dialogCancelled();
 
 private:
 	void checkForDelayedShow();

--- a/pcsx2/Achievements.cpp
+++ b/pcsx2/Achievements.cpp
@@ -28,7 +28,6 @@
 #include "IopMem.h"
 #include "MTGS.h"
 #include "Memory.h"
-#include "SysForwardDefs.h"
 #include "VMManager.h"
 #include "svnrev.h"
 #include "vtlb.h"
@@ -135,7 +134,6 @@ namespace Achievements
 	static void EnsureCacheDirectoriesExist();
 	static void ClearGameInfo();
 	static void ClearGameHash();
-	static std::string GetUserAgent();
 	static void BeginLoadingScreen(const char* text, bool* was_running_idle);
 	static void EndLoadingScreen(bool was_running_idle);
 	static std::string_view GetELFNameForHash(const std::string& elf_path);
@@ -246,19 +244,6 @@ namespace Achievements
 std::unique_lock<std::recursive_mutex> Achievements::GetLock()
 {
 	return std::unique_lock(s_achievements_mutex);
-}
-
-std::string Achievements::GetUserAgent()
-{
-	std::string ret;
-	if (!PCSX2_isReleaseVersion && GIT_TAGGED_COMMIT)
-		ret = fmt::format("PCSX2 Nightly - {} ({})", GIT_TAG, GetOSVersionString());
-	else if (!PCSX2_isReleaseVersion)
-		ret = fmt::format("PCSX2 {} ({})", GIT_REV, GetOSVersionString());
-	else
-		ret = fmt::format("PCSX2 {}.{}.{}-{} ({})", PCSX2_VersionHi, PCSX2_VersionMid, PCSX2_VersionLo, SVN_REV, GetOSVersionString());
-
-	return ret;
 }
 
 void Achievements::BeginLoadingScreen(const char* text, bool* was_running_idle)
@@ -476,7 +461,7 @@ bool Achievements::Initialize()
 
 bool Achievements::CreateClient(rc_client_t** client, std::unique_ptr<HTTPDownloader>* http)
 {
-	*http = HTTPDownloader::Create(GetUserAgent().c_str());
+	*http = HTTPDownloader::Create(Host::GetHTTPUserAgent());
 	if (!*http)
 	{
 		Host::ReportErrorAsync("Achievements Error", "Failed to create HTTPDownloader, cannot use achievements");
@@ -2918,7 +2903,7 @@ void Achievements::SwitchToRAIntegration()
 void Achievements::RAIntegration::InitializeRAIntegration(void* main_window_handle)
 {
 	RA_InitClient((HWND)main_window_handle, "PCSX2", GIT_TAG);
-	RA_SetUserAgentDetail(Achievements::GetUserAgent().c_str());
+	RA_SetUserAgentDetail(Host::GetHTTPUserAgent().c_str());
 
 	RA_InstallSharedFunctions(RACallbackIsActive, RACallbackCauseUnpause, RACallbackCausePause, RACallbackRebuildMenu,
 		RACallbackEstimateTitle, RACallbackResetEmulator, RACallbackLoadROM);

--- a/pcsx2/GameList.cpp
+++ b/pcsx2/GameList.cpp
@@ -1286,7 +1286,7 @@ bool GameList::DownloadCovers(const std::vector<std::string>& url_templates, boo
 		return false;
 	}
 
-	std::unique_ptr<HTTPDownloader> downloader(HTTPDownloader::Create());
+	std::unique_ptr<HTTPDownloader> downloader(HTTPDownloader::Create(Host::GetHTTPUserAgent()));
 	if (!downloader)
 	{
 		progress->DisplayError("Failed to create HTTP downloader.");

--- a/pcsx2/Host.cpp
+++ b/pcsx2/Host.cpp
@@ -19,7 +19,9 @@
 #include "GS/Renderers/HW/GSTextureReplacements.h"
 #include "Host.h"
 #include "LayeredSettingsInterface.h"
+#include "SysForwardDefs.h"
 #include "VMManager.h"
+#include "svnrev.h"
 
 #include "common/Assertions.h"
 #include "common/CrashHandler.h"
@@ -27,6 +29,8 @@
 #include "common/HeterogeneousContainers.h"
 #include "common/Path.h"
 #include "common/StringUtil.h"
+
+#include "fmt/format.h"
 
 #include <cstdarg>
 #include <shared_mutex>
@@ -166,6 +170,19 @@ bool Host::ConfirmFormattedMessage(const std::string_view& title, const char* fo
 	va_end(ap);
 
 	return ConfirmMessage(title, message);
+}
+
+std::string Host::GetHTTPUserAgent()
+{
+	std::string ret;
+	if (!PCSX2_isReleaseVersion && GIT_TAGGED_COMMIT)
+		ret = fmt::format("PCSX2 Nightly - {} ({})", GIT_TAG, GetOSVersionString());
+	else if (!PCSX2_isReleaseVersion)
+		ret = fmt::format("PCSX2 {} ({})", GIT_REV, GetOSVersionString());
+	else
+		ret = fmt::format("PCSX2 {}.{}.{}-{} ({})", PCSX2_VersionHi, PCSX2_VersionMid, PCSX2_VersionLo, SVN_REV, GetOSVersionString());
+
+	return ret;
 }
 
 std::unique_lock<std::mutex> Host::GetSettingsLock()

--- a/pcsx2/Host.h
+++ b/pcsx2/Host.h
@@ -99,6 +99,9 @@ namespace Host
 	/// Requests shut down of the current virtual machine.
 	void RequestVMShutdown(bool allow_confirm, bool allow_save_state, bool default_save_state);
 
+	/// Returns the user agent to use for HTTP requests.
+	std::string GetHTTPUserAgent();
+
 	/// Base setting retrieval, bypasses layers.
 	std::string GetBaseStringSettingValue(const char* section, const char* key, const char* default_value = "");
 	bool GetBaseBoolSettingValue(const char* section, const char* key, bool default_value = false);


### PR DESCRIPTION
### Description of Changes

Qt 6.6 changed some QtNetwork behaviour, which makes it block the UI thread for a second or so doing something with TLS certificates (I forget the exact function name).

I've been wanting to ditch QtNetwork for some time, just procrastinated it, but now I have a reason to actually do it. Since it's blocking DuckStation updating to Qt 6.6 too.

Use our internal HTTPDownloader (WinHttp/Curl) instead.

### Rationale behind Changes

Getting rid of the delay on startup that's been there since Qt 6.6.
Fewer dependencies, yay?

### Suggested Testing Steps

Can't really test it, since the updater doesn't exist on PR builds.
I've tested it on Windows as best I can, will do Linux/Mac as well soon.
