### PR TITLE
GS/HW: Allow more draws to remain if recent draws done near vsync

### DIFF
--- a/pcsx2/GS/Renderers/Common/GSRenderer.cpp
+++ b/pcsx2/GS/Renderers/Common/GSRenderer.cpp
@@ -944,6 +944,11 @@ bool GSRenderer::IsIdleFrame() const
 	return (m_last_draw_n == s_n && m_last_transfer_n == s_transfer_n);
 }
 
+int GSRenderer::GetLastVSyncDraw() const
+{
+	return m_last_draw_n;
+}
+
 bool GSRenderer::SaveSnapshotToMemory(u32 window_width, u32 window_height, bool apply_aspect, bool crop_borders,
 	u32* width, u32* height, std::vector<u32>* pixels)
 {

--- a/pcsx2/GS/Renderers/Common/GSRenderer.h
+++ b/pcsx2/GS/Renderers/Common/GSRenderer.h
@@ -68,6 +68,7 @@ public:
 	virtual GSTexture* LookupPaletteSource(u32 CBP, u32 CPSM, u32 CBW, GSVector2i& offset, float* scale, const GSVector2i& size);
 
 	bool IsIdleFrame() const;
+	int GetLastVSyncDraw() const;
 
 	bool SaveSnapshotToMemory(u32 window_width, u32 window_height, bool apply_aspect, bool crop_borders,
 		u32* width, u32* height, std::vector<u32>* pixels);

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -113,11 +113,11 @@ void GSRendererHW::VSync(u32 field, bool registers_written, bool idle_frame)
 	{
 		// If it did draws very recently, we should keep the recent stuff in case it hasn't been preloaded/used yet.
 		// Rocky Legend does this with the main menu FMV's.
-		if (s_last_transfer_draw_n == s_n)
+		if (s_last_transfer_draw_n > (s_n - 5) && s_last_transfer_draw_n >= GetLastVSyncDraw())
 		{
 			for (auto iter = m_draw_transfers.rbegin(); iter != m_draw_transfers.rend(); iter++)
 			{
-				if ((s_n - iter->draw) > 5)
+				if ((s_n - iter->draw) > 50)
 				{
 					m_draw_transfers.erase(m_draw_transfers.begin(), std::next(iter).base());
 					break;

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -2411,11 +2411,10 @@ GSTextureCache::Target* GSTextureCache::LookupDisplayTarget(GIFRegTEX0 TEX0, con
 				else
 					++iter;
 
-				if (eerect.rintersect(newrect).eq(newrect))
-				{
-					can_create = true;
-					break;
-				}
+				// In theory it might not be a full rect, but it should be enough to display *something*.
+				// It's also possible we haven't saved enough of the transfers to fill the rect if the game draws the picture in lots of small transfers.
+				can_create = true;
+				break;
 			}
 			else
 				++iter;


### PR DESCRIPTION
### Description of Changes
Allow more draws to remain queued at vsync if there were recent uploads.

### Rationale behind Changes
This was kind of a regression from #10296 as we rely on the transfers now to create new PCRTC frames if there are no matching draws, and this makes matching more difficult with FMV's.

### Suggested Testing Steps
Test Final Fantasy X International, and some random FMV's.

Also fixes Neopets FMV's
