### PR TITLE
GameDB: Fix FMVs on Rule of Rose + PAL Region

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -1761,6 +1761,8 @@ SCAJ-20167:
 SCAJ-20168:
   name: "Rule of Rose"
   region: "NTSC-Unk"
+  gsHWFixes:
+    preloadFrameData: 1 # Fixes Black FMV's.
 SCAJ-20169:
   name: "Dirge of Cerberus - Final Fantasy VII"
   region: "NTSC-Unk"
@@ -7917,6 +7919,8 @@ SCPS-15093:
   name-en: "Rule of Rose"
   region: "NTSC-J"
   compat: 5
+  gsHWFixes:
+    preloadFrameData: 1 # Fixes Black FMV's.
 SCPS-15094:
   name: アイトーイ プレイ2
   name-sort: あいとーい ぷれい2
@@ -22920,7 +22924,9 @@ SLES-54217:
   region: "PAL-E"
 SLES-54218:
   name: "Rule of Rose"
-  region: "PAL-F"
+  region: "PAL-M5"
+  gsHWFixes:
+    preloadFrameData: 1 # Fixes Black FMV's.
 SLES-54221:
   name: "LEGO Star Wars II - The Original Trilogy"
   region: "PAL-M6"
@@ -62799,6 +62805,8 @@ SLUS-21448:
   name: "Rule of Rose"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    preloadFrameData: 1 # Fixes Black FMV's.
 SLUS-21449:
   name: "The Fast and the Furious"
   name-sort: "Fast and the Furious, The"
@@ -65340,6 +65348,8 @@ SLUS-28062:
 SLUS-28063:
   name: "Rule of Rose [Trade Demo]"
   region: "NTSC-U"
+  gsHWFixes:
+    preloadFrameData: 1 # Fixes Black FMV's.
 SLUS-28064:
   name: "Shin Megami Tensei - Devil Summoner [Trade Demo]"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
Add preload frame fix for Rule of Rose to fix FMVs

### Rationale behind Changes
The game draws the FMV frames in a really weird way, by doing a strip of the black border at the top, then drawing the rest of the frame.  This works around it for now, since fixing it properly (preloading on expand) is a can of worms, which I'm not willing to get in to any time soon.

### Suggested Testing Steps
Test Rule of Rose FMVs (already done)

Fixes #9925