### PR TITLE
Qt: Allow custom patches with default patches

### DIFF
--- a/pcsx2-qt/Settings/GamePatchSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GamePatchSettingsWidget.cpp
@@ -68,6 +68,8 @@ GamePatchSettingsWidget::GamePatchSettingsWidget(SettingsWindow* dialog, QWidget
 	m_ui.scrollArea->setFrameShape(QFrame::WinPanel);
 	m_ui.scrollArea->setFrameShadow(QFrame::Sunken);
 
+	setUnlabeledPatchesWarningVisibility(false);
+
 	connect(m_ui.reload, &QPushButton::clicked, this, &GamePatchSettingsWidget::onReloadClicked);
 
 	reloadList();
@@ -86,10 +88,12 @@ void GamePatchSettingsWidget::onReloadClicked()
 void GamePatchSettingsWidget::reloadList()
 {
 	// Patches shouldn't have any unlabelled patch groups, because they're new.
-	std::vector<Patch::PatchInfo> patches = Patch::GetPatchInfo(m_dialog->getSerial(), m_dialog->getDiscCRC(), false, nullptr);
+	u32 numberOfUnlabeledPatches = 0;
+	std::vector<Patch::PatchInfo> patches = Patch::GetPatchInfo(m_dialog->getSerial(), m_dialog->getDiscCRC(), false, &numberOfUnlabeledPatches);
 	std::vector<std::string> enabled_list =
 		m_dialog->getSettingsInterface()->GetStringList(Patch::PATCHES_CONFIG_SECTION, Patch::PATCH_ENABLE_CONFIG_KEY);
 
+	setUnlabeledPatchesWarningVisibility(numberOfUnlabeledPatches > 0);
 	delete m_ui.scrollArea->takeWidget();
 
 	QWidget* container = new QWidget(m_ui.scrollArea);
@@ -129,4 +133,8 @@ void GamePatchSettingsWidget::reloadList()
 	layout->addStretch(1);
 
 	m_ui.scrollArea->setWidget(container);
+}
+
+void GamePatchSettingsWidget::setUnlabeledPatchesWarningVisibility(bool visible) {
+	m_ui.unlabeledPatchWarning->setVisible(visible);
 }

--- a/pcsx2-qt/Settings/GamePatchSettingsWidget.h
+++ b/pcsx2-qt/Settings/GamePatchSettingsWidget.h
@@ -60,6 +60,7 @@ private Q_SLOTS:
 
 private:
 	void reloadList();
+	void setUnlabeledPatchesWarningVisibility(bool visible);
 
 	Ui::GamePatchSettingsWidget m_ui;
 	SettingsWindow* m_dialog;

--- a/pcsx2-qt/Settings/GamePatchSettingsWidget.ui
+++ b/pcsx2-qt/Settings/GamePatchSettingsWidget.ui
@@ -34,6 +34,13 @@
     </widget>
    </item>
    <item>
+    <widget class="QLabel" name="unlabeledPatchWarning">
+     <property name="text">
+      <string>Any patches bundled with PCSX2 for this game will be disabled since you have unlabeled patches loaded.</string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QScrollArea" name="scrollArea">
      <property name="widgetResizable">
       <bool>true</bool>

--- a/pcsx2/Patch.cpp
+++ b/pcsx2/Patch.cpp
@@ -158,9 +158,13 @@ namespace Patch
 	static std::vector<std::string> FindPatchFilesOnDisk(
 		const std::string_view& serial, u32 crc, bool cheats, bool all_crcs);
 
+	static bool containsPatchName(PatchInfoList& patches, std::string patchName);
+	static bool containsPatchName(PatchList& patches, std::string patchName);
+
 	template <typename F>
 	static void EnumeratePnachFiles(const std::string_view& serial, u32 crc, bool cheats, bool for_ui, const F& f);
 
+	static bool PatchStringHasUnlabelledPatch(std::string pnach_data);
 	static void ExtractPatchInfo(PatchInfoList* dst, const std::string& pnach_data, u32* num_unlabelled_patches);
 	static void ReloadEnabledLists();
 	static u32 EnablePatches(const PatchList& patches, const EnablePatchList& enable_list);
@@ -215,6 +219,13 @@ void Patch::TrimPatchLine(std::string& buffer)
 		buffer.erase(pos);
 }
 
+bool Patch::containsPatchName(PatchList& patchList, std::string patchName)
+{
+	return std::find_if(patchList.begin(), patchList.end(), [patchName](const PatchGroup& patch) {
+		return patch.name == patchName;
+	}) != patchList.end();
+}
+
 int Patch::PatchTableExecute(PatchGroup* group, const std::string_view& lhs, const std::string_view& rhs,
 	const std::span<const PatchTextTable>& Table)
 {
@@ -267,7 +278,15 @@ u32 Patch::LoadPatchesFromString(PatchList* patch_list, const std::string& patch
 
 			if (!current_patch_group.name.empty() || !current_patch_group.patches.empty())
 			{
-				patch_list->push_back(std::move(current_patch_group));
+				// Don't show patches with duplicate names, prefer the first loaded.
+				if (!containsPatchName(*patch_list, current_patch_group.name))
+				{
+					patch_list->push_back(std::move(current_patch_group));
+				}
+				else
+				{
+					Console.WriteLn(Color_Gray, fmt::format("Patch: Skipped loading patch '{}' due patch with duplicate name being loaded.", current_patch_group.name));
+				}
 				current_patch_group = {};
 			}
 
@@ -350,6 +369,13 @@ std::vector<std::string> Patch::FindPatchFilesOnDisk(const std::string_view& ser
 	return ret;
 }
 
+bool Patch::containsPatchName(PatchInfoList& patches, std::string patchName)
+{
+	return std::find_if(patches.begin(), patches.end(), [patchName](const PatchInfo& patch) {
+		return patch.name == patchName;
+	}) != patches.end();
+}
+
 template <typename F>
 void Patch::EnumeratePnachFiles(const std::string_view& serial, u32 crc, bool cheats, bool for_ui, const F& f)
 {
@@ -358,20 +384,28 @@ void Patch::EnumeratePnachFiles(const std::string_view& serial, u32 crc, bool ch
 	if (for_ui || !Achievements::IsHardcoreModeActive())
 		disk_patch_files = FindPatchFilesOnDisk(serial, crc, cheats, for_ui);
 
+	bool unlabeled_patch_found = false;
 	if (!disk_patch_files.empty())
 	{
 		for (const std::string& file : disk_patch_files)
 		{
 			std::optional<std::string> contents = FileSystem::ReadFileToString(file.c_str());
 			if (contents.has_value())
-				f(std::move(file), std::move(contents.value()));
-		}
+			{
+				// Catch if unlabeled patches are being loaded so we can disable ZIP patches to prevent conflicts.
+				if (PatchStringHasUnlabelledPatch(contents.value()))
+				{
+					unlabeled_patch_found = true;
+					Console.WriteLn(fmt::format("Patch: Disabling any bundled '{}' patches due to unlabeled patch being loaded. (To avoid conflicts)"), PATCHES_ZIP_NAME);
+				}
 
-		return;
+				f(std::move(file), std::move(contents.value()));
+			}
+		}
 	}
 
 	// Otherwise fall back to the zip.
-	if (cheats || !OpenPatchesZip())
+	if (cheats || unlabeled_patch_found || !OpenPatchesZip())
 		return;
 
 	// Prefer filename with serial.
@@ -384,6 +418,39 @@ void Patch::EnumeratePnachFiles(const std::string_view& serial, u32 crc, bool ch
 	}
 	if (pnach_data.has_value())
 		f(std::move(zip_filename), std::move(pnach_data.value()));
+}
+
+bool Patch::PatchStringHasUnlabelledPatch(std::string pnach_data)
+{
+	std::istringstream ss(pnach_data);
+	std::string line;
+	bool foundPatch = false, foundLabel = false;
+
+	while (std::getline(ss, line))
+	{
+		TrimPatchLine(line);
+		if (line.empty())
+			continue;
+
+		if (line.length() > 2 && line.front() == '[' && line.back() == ']')
+		{
+			if (!foundPatch)
+				return false;
+			foundLabel = true;
+			continue;
+		}
+
+		std::string_view key, value;
+		StringUtil::ParseAssignmentString(line, &key, &value);
+		if (key == "patch")
+		{
+			if (!foundLabel)
+				return true;
+
+			foundPatch = true;
+		}
+		return false;
+	}
 }
 
 void Patch::ExtractPatchInfo(PatchInfoList* dst, const std::string& pnach_data, u32* num_unlabelled_patches)
@@ -406,7 +473,15 @@ void Patch::ExtractPatchInfo(PatchInfoList* dst, const std::string& pnach_data, 
 				if (std::none_of(dst->begin(), dst->end(),
 						[&current_patch](const PatchInfo& pi) { return (pi.name == current_patch.name); }))
 				{
-					dst->push_back(std::move(current_patch));
+					// Don't show patches with duplicate names, prefer the first loaded.
+					if (!containsPatchName(*dst, current_patch.name))
+					{
+						dst->push_back(std::move(current_patch));
+					}
+					else
+					{
+						Console.WriteLn(Color_Gray, fmt::format("Patch: Skipped reading patch '{}' due patch with duplicate name being loaded.", current_patch.name));
+					}
 				}
 				current_patch = {};
 			}


### PR DESCRIPTION
### Description of Changes
Implements #10242

Allow loading patch files from `/patches` folder and the bundled `patches.zip` file simultaneously.
- If a patch in the `/patches` folder and the `patches.zip` have the same name, it loads the `/patches` folder version instead.
- If there are no collisions, all patches from each are loaded.
- If an unlabeled patch from the `/patches` folder is loaded, no bundled patches will be loaded. (Since we can't guarantee they won't collide with a bundled patch)

Also, updates the patches UI to display a warning when unlabeled patches are loaded and causing the bundled patches to not display in the Patches Settings window.

### Rationale behind Changes
To allow users to use the bundled no-interlacing & widescreen patches with their custom patches. As long as there's no collisions, there's no need to stop them from using both.

### Suggested Testing Steps
- Find a game that has bundled patches.
- Create a patch file with an unlabelled patch and a labeled patch for that game.
- Since there's an unlabeled patch, verify only the labeled `/patches` patch is shown in Patch Settings window.
- Comment out the unlabeled patch and save the patches file.
- Reload Patches to verify that the custom labeled patch and the bundled patches are showing.
- Rename the custom labeled patch to the name of one of the bundled patches and save.
- Reload Patches and verify that the folder patch is loaded instead of the bundled patch of the same name. (Easiest way to do this is by adding a `description=Should override bundled patch` field to the patch).

<details> <summary>In my case, I tested this in GTA 3 with this pnach file:</summary>
<pre><code>// Unlabeled patch - this should prevent bundled patches from loading unless commented out
patch=2,EE,2027CEA4,extended,28420001
<br>
// Rename this to a name that does not collide with a bundled patch to test, then name it the same as a bundled patch to test overriding it
[Widescreen 16:9]
description=FromFile, should get preference
// set cutscene camera pos
patch=2,EE,20251628,extended,44800000</code></pre>
</details>
