### PR TITLE
Achievements: Use big picture to confirm HC mode disable

### DIFF
--- a/pcsx2-qt/QtHost.h
+++ b/pcsx2-qt/QtHost.h
@@ -194,7 +194,6 @@ private:
 	static constexpr u32 FULLSCREEN_UI_CONTROLLER_POLLING_INTERVAL = 8;
 
 	void destroyVM();
-	void executeVM();
 
 	void createBackgroundControllerPollTimer();
 	void destroyBackgroundControllerPollTimer();

--- a/pcsx2/Achievements.h
+++ b/pcsx2/Achievements.h
@@ -19,6 +19,7 @@
 
 #include "Config.h"
 
+#include <functional>
 #include <mutex>
 #include <string>
 #include <utility>
@@ -83,6 +84,7 @@ namespace Achievements
 
 	/// Prompts the user to disable hardcore mode, if they agree, returns true.
 	bool ConfirmHardcoreModeDisable(const char* trigger);
+	void ConfirmHardcoreModeDisableAsync(const char* trigger, std::function<void(bool)> callback);
 
 	/// Returns true if hardcore mode is active, and functionality should be restricted.
 	bool IsHardcoreModeActive();

--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -855,17 +855,12 @@ void FullscreenUI::DoStartPath(const std::string& path, std::optional<s32> state
 	params.fast_boot = fast_boot;
 
 	// switch to nothing, we'll get brought back if init fails
-	const MainWindowType prev_window = s_current_main_window;
-	s_current_main_window = MainWindowType::None;
-
-	Host::RunOnCPUThread([params = std::move(params), prev_window]() {
+	Host::RunOnCPUThread([params = std::move(params)]() {
 		if (VMManager::HasValidVM())
 			return;
 
 		if (VMManager::Initialize(std::move(params)))
 			VMManager::SetState(VMState::Running);
-		else
-			s_current_main_window = prev_window;
 	});
 }
 
@@ -5513,6 +5508,18 @@ void FullscreenUI::DrawGameListWindow()
 			break;
 		default:
 			break;
+	}
+	
+	if (VMManager::GetState() != VMState::Shutdown)
+	{
+		// Dummy window to prevent interacting with the game list while loading.
+		ImGui::PushStyleColor(ImGuiCol_WindowBg, ImVec4(1.0f, 1.0f, 1.0f, 1.0f));
+		ImGui::SetNextWindowSize(ImGui::GetIO().DisplaySize);
+		ImGui::SetNextWindowPos(ImVec2(0, 0));
+		ImGui::SetNextWindowBgAlpha(0.25f);
+		ImGui::Begin("##dummy", nullptr, ImGuiWindowFlags_NoDecoration);
+		ImGui::End();
+		ImGui::PopStyleColor();
 	}
 }
 

--- a/pcsx2/VMManager.h
+++ b/pcsx2/VMManager.h
@@ -47,6 +47,7 @@ struct VMBootParameters
 
 	std::optional<bool> fast_boot;
 	std::optional<bool> fullscreen;
+	bool disable_achievements_hardcore_mode = false;
 };
 
 namespace VMManager


### PR DESCRIPTION
### Description of Changes

Currently, PCSX2 if you're fullscreen and load a state while HC mode is on, because it blocks until the VM is un-fullscreened, but the VM can't un-fullscreen because it's waiting for the UI thread to confirm the mode switch.

Instead, use the big picture UI to manage it all. Works with a gamepad, and doesn't break fullscreen.

Also fixes the pause buffering "exploit" by putting a cooldown on pause hotkeys.

### Rationale behind Changes

Fixes deadlocks.

### Suggested Testing Steps

Try loading states while fullscreen and HC is on.
Make sure PCSX2 "works" as normal, since I changed the main CPU thread loop.
