### PR TITLE
GameDB: Ace Combat 4 fixes

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -4091,6 +4091,7 @@ SCES-50410:
     gpuTargetCLUT: 1 # Fixes broken sun.
     cpuSpriteRenderBW: 2 # Fixes broken terrain rendering (See #10271 for details).
     cpuSpriteRenderLevel: 2 # Needed for above.
+    estimateTextureRegion: 1 # Improves performance and reduces HC size.
 SCES-50411:
   name: "Vampire Night"
   region: "PAL-M5"
@@ -30033,6 +30034,7 @@ SLPM-60149:
     gpuTargetCLUT: 1 # Fixes broken sun.
     cpuSpriteRenderBW: 2 # Fixes broken terrain rendering (See #10271 for details).
     cpuSpriteRenderLevel: 2 # Needed for above.
+    estimateTextureRegion: 1 # Improves performance and reduces HC size.
 SLPM-60150:
   name: "Tamamayu Monogatari 2 - Horobi no Mushi"
   region: "NTSC-J"
@@ -49386,6 +49388,7 @@ SLPS-25052:
     gpuTargetCLUT: 1 # Fixes broken sun.
     cpuSpriteRenderBW: 2 # Fixes broken terrain rendering (See #10271 for details).
     cpuSpriteRenderLevel: 2 # Needed for above.
+    estimateTextureRegion: 1 # Improves performance and reduces HC size.
 SLPS-25053:
   name: 栄冠は君に 甲子園の覇者
   name-sort: えいかんはきみに こうしえんのはしゃ
@@ -54595,6 +54598,7 @@ SLPS-73205:
     gpuTargetCLUT: 1 # Fixes broken sun.
     cpuSpriteRenderBW: 2 # Fixes broken terrain rendering (See #10271 for details).
     cpuSpriteRenderLevel: 2 # Needed for above.
+    estimateTextureRegion: 1 # Improves performance and reduces HC size.
 SLPS-73206:
   name: 第2次スーパーロボット大戦α PS2 the Best
   name-sort: だい2じすーぱーろぼっとたいせんあるふぁ PS2 the Best
@@ -55150,6 +55154,7 @@ SLPS-73410:
     gpuTargetCLUT: 1 # Fixes broken sun.
     cpuSpriteRenderBW: 2 # Fixes broken terrain rendering (See #10271 for details).
     cpuSpriteRenderLevel: 2 # Needed for above.
+    estimateTextureRegion: 1 # Improves performance and reduces HC size.
 SLPS-73411:
   name: "Armored Core 2 - Another Age [PS2 The Best]"
   region: "NTSC-J"
@@ -55850,6 +55855,7 @@ SLUS-20152:
     gpuTargetCLUT: 1 # Fixes broken sun.
     cpuSpriteRenderBW: 2 # Fixes broken terrain rendering (See #10271 for details).
     cpuSpriteRenderLevel: 2 # Needed for above.
+    estimateTextureRegion: 1 # Improves performance and reduces HC size.
   patches:
     A32F7CD0:
       content: |-


### PR DESCRIPTION
### Description of Changes
Fixes large HC size causing high GS%.

### Rationale behind Changes
More fps more vroom.

### Suggested Testing Steps
Make sure CI is happy.
