### PR TITLE
Achievements: Fix the percentage counter when only unofficial achievements exist

### DIFF
--- a/pcsx2/Achievements.cpp
+++ b/pcsx2/Achievements.cpp
@@ -2185,16 +2185,23 @@ void Achievements::DrawAchievementsWindow()
 			ImGui::PopFont();
 
 			const ImRect summary_bb(ImVec2(left, top), ImVec2(right, top + g_medium_font->FontSize));
-			if (s_game_summary.num_unlocked_achievements == s_game_summary.num_core_achievements)
+			if (s_game_summary.num_core_achievements > 0)
 			{
-				text.fmt(TRANSLATE_FS("Achievements", "You have unlocked all achievements and earned {} points!"),
-					s_game_summary.points_unlocked);
+				if (s_game_summary.num_unlocked_achievements == s_game_summary.num_core_achievements)
+				{
+					text.fmt(TRANSLATE_FS("Achievements", "You have unlocked all achievements and earned {} points!"),
+						s_game_summary.points_unlocked);
+				}
+				else
+				{
+					text.fmt(TRANSLATE_FS("Achievements", "You have unlocked {0} of {1} achievements, earning {2} of {3} possible points."),
+						s_game_summary.num_unlocked_achievements, s_game_summary.num_core_achievements, s_game_summary.points_unlocked,
+						s_game_summary.points_core);
+				}
 			}
 			else
 			{
-				text.fmt(TRANSLATE_FS("Achievements", "You have unlocked {0} of {1} achievements, earning {2} of {3} possible points."),
-					s_game_summary.num_unlocked_achievements, s_game_summary.num_core_achievements, s_game_summary.points_unlocked,
-					s_game_summary.points_core);
+				text.assign(TRANSLATE_SV("Achievements", "This game has no achievements."));
 			}
 
 			top += g_medium_font->FontSize + spacing;
@@ -2204,21 +2211,24 @@ void Achievements::DrawAchievementsWindow()
 				summary_bb.Min, summary_bb.Max, text.c_str(), text.end_ptr(), nullptr, ImVec2(0.0f, 0.0f), &summary_bb);
 			ImGui::PopFont();
 
-			const float progress_height = ImGuiFullscreen::LayoutScale(20.0f);
-			const ImRect progress_bb(ImVec2(left, top), ImVec2(right, top + progress_height));
-			const float fraction =
-				static_cast<float>(s_game_summary.num_unlocked_achievements) / static_cast<float>(s_game_summary.num_core_achievements);
-			dl->AddRectFilled(progress_bb.Min, progress_bb.Max, ImGui::GetColorU32(ImGuiFullscreen::UIPrimaryDarkColor));
-			dl->AddRectFilled(progress_bb.Min, ImVec2(progress_bb.Min.x + fraction * progress_bb.GetWidth(), progress_bb.Max.y),
-				ImGui::GetColorU32(ImGuiFullscreen::UISecondaryColor));
+			if (s_game_summary.num_core_achievements > 0)
+			{
+				const float progress_height = ImGuiFullscreen::LayoutScale(20.0f);
+				const ImRect progress_bb(ImVec2(left, top), ImVec2(right, top + progress_height));
+				const float fraction =
+					static_cast<float>(s_game_summary.num_unlocked_achievements) / static_cast<float>(s_game_summary.num_core_achievements);
+				dl->AddRectFilled(progress_bb.Min, progress_bb.Max, ImGui::GetColorU32(ImGuiFullscreen::UIPrimaryDarkColor));
+				dl->AddRectFilled(progress_bb.Min, ImVec2(progress_bb.Min.x + fraction * progress_bb.GetWidth(), progress_bb.Max.y),
+					ImGui::GetColorU32(ImGuiFullscreen::UISecondaryColor));
 
-			text.fmt("{}%", static_cast<int>(std::round(fraction * 100.0f)));
-			text_size = ImGui::CalcTextSize(text.c_str(), text.end_ptr());
-			const ImVec2 text_pos(progress_bb.Min.x + ((progress_bb.Max.x - progress_bb.Min.x) / 2.0f) - (text_size.x / 2.0f),
-				progress_bb.Min.y + ((progress_bb.Max.y - progress_bb.Min.y) / 2.0f) - (text_size.y / 2.0f));
-			dl->AddText(g_medium_font, g_medium_font->FontSize, text_pos, ImGui::GetColorU32(ImGuiFullscreen::UIPrimaryTextColor),
-				text.c_str(), text.end_ptr());
-			top += progress_height + spacing;
+				text.fmt("{}%", static_cast<int>(std::round(fraction * 100.0f)));
+				text_size = ImGui::CalcTextSize(text.c_str(), text.end_ptr());
+				const ImVec2 text_pos(progress_bb.Min.x + ((progress_bb.Max.x - progress_bb.Min.x) / 2.0f) - (text_size.x / 2.0f),
+					progress_bb.Min.y + ((progress_bb.Max.y - progress_bb.Min.y) / 2.0f) - (text_size.y / 2.0f));
+				dl->AddText(g_medium_font, g_medium_font->FontSize, text_pos, ImGui::GetColorU32(ImGuiFullscreen::UIPrimaryTextColor),
+					text.c_str(), text.end_ptr());
+				top += progress_height + spacing;
+			}
 		}
 	}
 	ImGuiFullscreen::EndFullscreenWindow();


### PR DESCRIPTION
### Description of Changes
Fixes broken percentage display if unofficial achievements are enabled.

### Rationale behind Changes
Sets with only unofficial achievements displayed wrong if unofficial test mode was enabled.

Before:
![image](https://github.com/PCSX2/pcsx2/assets/7947461/16a5b901-03da-44bd-8cbd-6418cf5056b6)

After:
![image](https://github.com/PCSX2/pcsx2/assets/7947461/46dbfb44-eb81-4282-9800-1d2a3523ba2a)


### Suggested Testing Steps
1. Launch any game with an unofficial set.
2. Enable "Unofficial Test Mode".
3. Inspect the percentage unlock and text in the Achievements screen.
