### PR TITLE
CDVD: Get rid of negative data offsets

### DIFF
--- a/pcsx2/CDVD/GzippedFileReader.cpp
+++ b/pcsx2/CDVD/GzippedFileReader.cpp
@@ -387,6 +387,9 @@ int GzippedFileReader::_ReadSync(void* pBuffer, s64 offset, uint bytesToRead)
 	if (!OkIndex(nullptr))
 		return -1;
 
+	if ((offset + bytesToRead) > m_pIndex->uncompressed_size)
+		return -1;
+
 	// Without all the caching, chunking and states, this would be enough:
 	// return extract(m_src, m_pIndex, offset, (unsigned char*)pBuffer, bytesToRead);
 

--- a/pcsx2/CDVD/InputIsoFile.cpp
+++ b/pcsx2/CDVD/InputIsoFile.cpp
@@ -299,16 +299,16 @@ bool InputIsoFile::IsOpened() const
 	return m_reader != NULL;
 }
 
-bool InputIsoFile::tryIsoType(u32 _size, s32 _offset, s32 _blockofs)
+bool InputIsoFile::tryIsoType(u32 size, u32 offset, u32 blockofs)
 {
-	static u8 buf[2456];
+	u8 buf[2456];
 
-	m_blocksize = _size;
-	m_offset = _offset;
-	m_blockofs = _blockofs;
+	m_blocksize = size;
+	m_offset = offset;
+	m_blockofs = blockofs;
 
-	m_reader->SetDataOffset(_offset);
-	m_reader->SetBlockSize(_size);
+	m_reader->SetDataOffset(offset);
+	m_reader->SetBlockSize(size);
 
 	if (ReadSync(buf, 16) < 0)
 		return false;
@@ -358,13 +358,6 @@ bool InputIsoFile::Detect(bool readType)
 		return true; // NERO RAW 2352
 	if (tryIsoType(2448, 150 * 2048, 0))
 		return true; // NERO RAWQ 2448
-
-	if (tryIsoType(2048, -8, 24))
-		return true; // ISO 2048
-	if (tryIsoType(2352, -8, 0))
-		return true; // RAW 2352
-	if (tryIsoType(2448, -8, 0))
-		return true; // RAWQ 2448
 
 	m_offset = 0;
 	m_blocksize = CD_FRAMESIZE_RAW;

--- a/pcsx2/CDVD/IsoFileFormats.h
+++ b/pcsx2/CDVD/IsoFileFormats.h
@@ -95,7 +95,7 @@ public:
 protected:
 	void _init();
 
-	bool tryIsoType(u32 _size, s32 _offset, s32 _blockofs);
+	bool tryIsoType(u32 size, u32 offset, u32 blockofs);
 	void FindParts();
 };
 


### PR DESCRIPTION
### Description of Changes

I hate this janky code
I hate this ugly code
I hate this garbage code
I hate this messy code
I hate this unreliable code

### Rationale behind Changes

Stop PCSX2 crashing when silly users scan files that aren't games.

The whole thing needs to get tossed out. I started fixing the types in GZippedFileReader/ChunkCache, but it's just a can of worms that I don't have the energy to deal with.

If nobody uses gzip support, maybe we can just drop it completely...

### Suggested Testing Steps

Already tested.
