### PR TITLE
QT: add the ability to load  .backup save states in UI

### DIFF
--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -2577,7 +2577,7 @@ void MainWindow::populateLoadStateMenu(QMenu* menu, const QString& filename, con
 
 	QAction* action = menu->addAction(is_right_click_menu ? tr("Load State File...") : tr("Load From File..."));
 	connect(action, &QAction::triggered, [this, filename]() {
-		const QString path(QFileDialog::getOpenFileName(this, tr("Select Save State File"), QString(), tr("Save States (*.p2s)")));
+		const QString path(QFileDialog::getOpenFileName(this, tr("Select Save State File"), QString(), tr("Save States (*.p2s *.p2s.backup)")));
 		if (path.isEmpty())
 			return;
 


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
 add the ability to load  .backup save states in UI
![image](https://github.com/PCSX2/pcsx2/assets/17685135/e22bbfd6-56f9-439b-863f-c26b8aa1d869)
 
 
 
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->


load some .backup files  make sure they work