### PR TITLE
 Qt: Fix links in first page of Setup Wizard

### DIFF
--- a/pcsx2-qt/SetupWizardDialog.ui
+++ b/pcsx2-qt/SetupWizardDialog.ui
@@ -147,6 +147,12 @@
          <property name="wordWrap">
           <bool>true</bool>
          </property>
+         <property name="openExternalLinks">
+          <bool>true</bool>
+         </property>
+         <property name="textInteractionFlags">
+          <enum>Qt::TextBrowserInteraction</enum>
+         </property>
         </widget>
        </item>
        <item>


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
 fixes links in first page of Setup Wizard 
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
make sure links  work on in first page of Setup Wizard 