### PR TITLE
3rdparty: Use upstream xz submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "3rdparty/xz/xz"]
-	path = 3rdparty/xz/xz
-	url = https://github.com/PCSX2/xz.git
 [submodule "3rdparty/gtest"]
 	path = 3rdparty/gtest
 	url = https://github.com/google/googletest.git
@@ -30,3 +27,6 @@
 [submodule "3rdparty/libwebp/libwebp"]
 	path = 3rdparty/libwebp/libwebp
 	url = https://github.com/webmproject/libwebp
+[submodule "3rdparty/xz/xz"]
+	path = 3rdparty/xz/xz
+	url = https://github.com/tukaani-project/xz.git


### PR DESCRIPTION
### Description of Changes
For some reason we used a branch xz from around 6 years ago? Honestly not sure why.

### Rationale behind Changes
6 Year old submodule's are a bit out of date.

### Suggested Testing Steps
Make sure CI passes and that loading xz gs dumps save states and anything else that uses xz still works.
