### PR TITLE
Qt: Prompt user to enable HC mode on achievement login

### DIFF
--- a/pcsx2-qt/Settings/AchievementSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/AchievementSettingsWidget.cpp
@@ -194,6 +194,19 @@ void AchievementSettingsWidget::onLoginLogoutPressed()
 		return;
 
 	updateLoginState();
+
+	// Login can enable achievements/hardcore.
+	if (!m_ui.enable->isChecked() && Host::GetBaseBoolSettingValue("Achievements", "Enabled", false))
+	{
+		QSignalBlocker sb(m_ui.enable);
+		m_ui.enable->setChecked(true);
+		updateEnableState();
+	}
+	if (!m_ui.hardcoreMode->isChecked() && Host::GetBaseBoolSettingValue("Achievements", "ChallengeMode", false))
+	{
+		QSignalBlocker sb(m_ui.hardcoreMode);
+		m_ui.hardcoreMode->setChecked(true);
+	}
 }
 
 void AchievementSettingsWidget::onViewProfilePressed()

--- a/pcsx2/Achievements.cpp
+++ b/pcsx2/Achievements.cpp
@@ -105,7 +105,6 @@ namespace Achievements
 			u32 tracker_id;
 			std::string text;
 			Common::Timer show_hide_time;
-			u32 display_length;
 			bool active;
 		};
 
@@ -1226,7 +1225,6 @@ void Achievements::HandleLeaderboardTrackerShowEvent(const rc_client_event_t* ev
 	LeaderboardTrackerIndicator indicator;
 	indicator.tracker_id = event->leaderboard_tracker->id;
 	indicator.text = event->leaderboard_tracker->display;
-	indicator.display_length = static_cast<u32>(std::strlen(event->leaderboard_tracker->display));
 	indicator.active = true;
 	s_active_leaderboard_trackers.push_back(std::move(indicator));
 }
@@ -1983,7 +1981,7 @@ void Achievements::DrawGameOverlays()
 
 			TinyString width_string;
 			width_string.append(ICON_FA_STOPWATCH);
-			for (u32 i = 0; i < indicator.display_length; i++)
+			for (u32 i = 0; i < indicator.text.length(); i++)
 				width_string.append('0');
 			const ImVec2 size = ImGuiFullscreen::g_medium_font->CalcTextSizeA(
 				ImGuiFullscreen::g_medium_font->FontSize, FLT_MAX, 0.0f, width_string.c_str(), width_string.end_ptr());


### PR DESCRIPTION
### Description of Changes

Ports of https://github.com/stenzek/duckstation/commit/07fac1fb19553a43d6b25ea0104097cad5b43046 and https://github.com/stenzek/duckstation/commit/dc6bb357d427178ce5b2f1e4c4aaeec26616ced0.

### Rationale behind Changes

Prevents users assuming that hardcore mode is on by default.

Potentially fixes #10355.

### Suggested Testing Steps

Test logging in with achievements+hardcore disabled, look for prompts.
