### PR TITLE
GameDB: SkyGunner Fixes

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -204,6 +204,8 @@ PAPX-90216:
 PAPX-90218:
   name: "SkyGunner"
   region: "NTSC-J"
+  gsHWFixes:
+    halfPixelOffset: 1 # Fixes misaligned blur in menus.
 PAPX-90220:
   name: "Surveillance - Kanshisha"
   region: "NTSC-J"
@@ -621,6 +623,8 @@ PCPX-96320:
 PCPX-96321:
   name: "SkyGunner [Trial]"
   region: "NTSC-J"
+  gsHWFixes:
+    halfPixelOffset: 1 # Fixes misaligned blur in menus.
 PCPX-96322:
   name: "Ico [Trial]"
   region: "NTSC-J"
@@ -57015,6 +57019,8 @@ SLUS-20384:
   name: "SkyGunner"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 1 # Fixes misaligned blur in menus.
 SLUS-20385:
   name: "WWE Crush Hour"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
Fixes misaligned blur in SkyGunner's menus (Pause Screen, Tutorial Screen, etc.)

### Rationale behind Changes


### Suggested Testing Steps


### Notes
HPO Native has the same effect but shifts menu items. Went with Vertex.
https://cdn.discordapp.com/attachments/827950154862559272/1182109182221099159/SkyGunner_SLUS-20384_20231206172456.gs.zst
