### PR TITLE
GameDB: RPM Tuning bloom misalignment fix

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -17362,6 +17362,10 @@ SLES-52190:
   name: "RPM Tuning"
   region: "PAL-M6"
   compat: 5
+  gsHWFixes:
+    autoFlush: 1
+    roundSprite: 2 # Aligns bloom effect
+    wildArmsHack: 1 # Aligns bloom effect
 SLES-52202:
   name: "Downhill Domination"
   region: "PAL-M5"


### PR DESCRIPTION
### Description of Changes
Bloom effects aren't aligned correctly when increasing internal resolution, enabling Round Sprite and Wild Arms Hack fixes it.

### Rationale behind Changes
Misaligned effects are bad mmkay

Software (native res)
![RPM Tuning_SLES-52190_20231206215217](https://github.com/PCSX2/pcsx2/assets/19964653/83050e38-0327-48b2-9a22-7e95ec7ffe6b)

Hardware (upscaled)
![RPM Tuning_SLES-52190_20231206215232](https://github.com/PCSX2/pcsx2/assets/19964653/6ba708f9-2202-47c3-aac6-c41770921159)

Hardware (upscaled w/fixes)
![RPM Tuning_SLES-52190_20231206215254](https://github.com/PCSX2/pcsx2/assets/19964653/91c8a83c-17c5-4ea0-9f68-8f7ec1eccb30)

[GS Dump](https://drive.google.com/file/d/1ObomDS9PyC_puUJjmt4NFmts8H4OWpfX/view?usp=sharing)