### PR TITLE
Memcard: Add tracking for when memory cards are busy writing

### DIFF
--- a/pcsx2-qt/MainWindow.h
+++ b/pcsx2-qt/MainWindow.h
@@ -119,6 +119,7 @@ public Q_SLOTS:
 	void reportError(const QString& title, const QString& message);
 	bool confirmMessage(const QString& title, const QString& message);
 	void runOnUIThread(const std::function<void()>& func);
+	void requestReset();
 	bool requestShutdown(bool allow_confirm = true, bool allow_save_to_state = true, bool default_save_to_state = true);
 	void requestExit(bool allow_confirm = true);
 	void checkForSettingChanges();
@@ -242,6 +243,8 @@ private:
 	bool shouldHideMainWindow() const;
 	void switchToGameListView();
 	void switchToEmulationView();
+
+	bool shouldAbortForMemcardBusy(const VMLock& lock);
 
 	QWidget* getContentParent();
 	QWidget* getDisplayContainer() const;

--- a/pcsx2/CDVD/CDVD.cpp
+++ b/pcsx2/CDVD/CDVD.cpp
@@ -30,7 +30,6 @@
 #include "IopHw.h"
 #include "IopDma.h"
 #include "VMManager.h"
-#include "SIO/Sio.h"
 
 #include "common/Error.h"
 #include "common/FileSystem.h"
@@ -1570,7 +1569,6 @@ void cdvdVsync()
 	cdvd.RTCcount = 0;
 
 	cdvdUpdateTrayState();
-	AutoEject::CountDownTicks();
 
 	cdvd.RTC.second++;
 	if (cdvd.RTC.second < 60)

--- a/pcsx2/Counters.cpp
+++ b/pcsx2/Counters.cpp
@@ -517,6 +517,9 @@ static __fi void VSyncStart(u32 sCycle)
 
 	// Memcard auto ejection - Uses a tick system timed off of real time, decrementing one tick per frame.
 	AutoEject::CountDownTicks();
+	// Memcard IO detection - Uses a tick system to determine when memcards are no longer being written.
+	MemcardBusy::Decrement();
+
 	if (gates)
 		rcntStartGate(true, sCycle); // Counters Start Gate code
 

--- a/pcsx2/Counters.cpp
+++ b/pcsx2/Counters.cpp
@@ -515,6 +515,8 @@ static __fi void VSyncStart(u32 sCycle)
 	hwIntcIrq(INTC_VBLANK_S);
 	psxVBlankStart();
 
+	// Memcard auto ejection - Uses a tick system timed off of real time, decrementing one tick per frame.
+	AutoEject::CountDownTicks();
 	if (gates)
 		rcntStartGate(true, sCycle); // Counters Start Gate code
 

--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -274,12 +274,18 @@ namespace FullscreenUI
 	static void DoStartDisc();
 	static void DoToggleFrameLimit();
 	static void DoToggleSoftwareRenderer();
+	static void RequestShutdown(bool save_state);
 	static void DoShutdown(bool save_state);
+	static void RequestReset();
 	static void DoReset();
+	static void RequestChangeDiscFromFile();
 	static void DoChangeDiscFromFile();
+	static void RequestChangeDisc();
 	static void DoChangeDisc();
 	static void DoRequestExit();
 	static void DoToggleFullscreen();
+
+	static void ConfirmShutdownIfMemcardBusy(std::function<void(bool)> callback);
 
 	//////////////////////////////////////////////////////////////////////////
 	// Settings
@@ -959,9 +965,29 @@ void FullscreenUI::DoToggleSoftwareRenderer()
 	});
 }
 
+void FullscreenUI::RequestShutdown(bool save_state)
+{
+	ConfirmShutdownIfMemcardBusy([save_state](bool result) {
+		if (result)
+			DoShutdown(save_state);
+
+		ClosePauseMenu();
+	});
+}
+
 void FullscreenUI::DoShutdown(bool save_state)
 {
 	Host::RunOnCPUThread([save_state]() { Host::RequestVMShutdown(false, save_state, save_state); });
+}
+
+void FullscreenUI::RequestReset()
+{
+	ConfirmShutdownIfMemcardBusy([](bool result) {
+		if (result)
+			DoReset();
+
+		ClosePauseMenu();
+	});
 }
 
 void FullscreenUI::DoReset()
@@ -971,6 +997,16 @@ void FullscreenUI::DoReset()
 			return;
 
 		VMManager::Reset();
+	});
+}
+
+void FullscreenUI::RequestChangeDiscFromFile()
+{
+	ConfirmShutdownIfMemcardBusy([](bool result) {
+		if (result)
+			DoChangeDiscFromFile();
+		else
+			ClosePauseMenu();
 	});
 }
 
@@ -992,10 +1028,21 @@ void FullscreenUI::DoChangeDiscFromFile()
 		QueueResetFocus();
 		CloseFileSelector();
 		ReturnToPreviousWindow();
+		ClosePauseMenu();
 	};
 
 	OpenFileSelector(FSUI_ICONSTR(ICON_FA_COMPACT_DISC, "Select Disc Image"), false, std::move(callback), GetDiscImageFilters(),
 		std::string(Path::GetDirectory(s_current_disc_path)));
+}
+
+void FullscreenUI::RequestChangeDisc()
+{
+	ConfirmShutdownIfMemcardBusy([](bool result) {
+		if (result)
+			DoChangeDisc();
+		else
+			ClosePauseMenu();
+	});
 }
 
 void FullscreenUI::DoChangeDisc()
@@ -1011,6 +1058,20 @@ void FullscreenUI::DoRequestExit()
 void FullscreenUI::DoToggleFullscreen()
 {
 	Host::RunOnCPUThread([]() { Host::SetFullscreen(!Host::IsFullscreen()); });
+}
+
+void FullscreenUI::ConfirmShutdownIfMemcardBusy(std::function<void(bool)> callback)
+{
+	if (!MemcardBusy::IsBusy())
+	{
+		callback(true);
+		return;
+	}
+
+	OpenConfirmMessageDialog(FSUI_ICONSTR(ICON_FA_SD_CARD, "WARNING: Memory Card Busy"),
+		FSUI_STR("WARNING: Your memory card is still writing data. Shutting down now will IRREVERSIBLY DESTROY YOUR MEMORY CARD. It is strongly recommended to resume your game and let it finish writing to your memory card.\n\nDo you wish to shutdown anyways and IRREVERSIBLY DESTROY YOUR MEMORY CARD?"),
+		std::move(callback)
+	);
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -4756,7 +4817,7 @@ void FullscreenUI::DrawPauseMenu(MainWindowType type)
 				if (ActiveButton(FSUI_ICONSTR(ICON_FA_COMPACT_DISC, "Change Disc"), false))
 				{
 					s_current_main_window = MainWindowType::None;
-					DoChangeDisc();
+					RequestChangeDisc();
 				}
 
 				if (ActiveButton(FSUI_ICONSTR(ICON_FA_SLIDERS_H, "Settings"), false))
@@ -4766,7 +4827,7 @@ void FullscreenUI::DrawPauseMenu(MainWindowType type)
 				{
 					// skip submenu when we can't save anyway
 					if (!can_load_or_save_state)
-						DoShutdown(false);
+						RequestShutdown(false);
 					else
 						OpenPauseSubMenu(PauseSubMenu::Exit);
 				}
@@ -4785,15 +4846,14 @@ void FullscreenUI::DrawPauseMenu(MainWindowType type)
 
 				if (ActiveButton(FSUI_ICONSTR(ICON_FA_SYNC, "Reset System"), false))
 				{
-					ClosePauseMenu();
-					DoReset();
+					RequestReset();
 				}
 
 				if (ActiveButton(FSUI_ICONSTR(ICON_FA_SAVE, "Exit And Save State"), false))
-					DoShutdown(true);
+					RequestShutdown(true);
 
 				if (ActiveButton(FSUI_ICONSTR(ICON_FA_POWER_OFF, "Exit Without Saving"), false))
-					DoShutdown(false);
+					RequestShutdown(false);
 			}
 			break;
 
@@ -6318,7 +6378,7 @@ void FullscreenUI::DrawAchievementsSettingsPage(std::unique_lock<std::mutex>& se
 						return;
 
 					if (reset)
-						DoReset();
+						RequestReset();
 				});
 		}
 	}

--- a/pcsx2/SIO/Memcard/MemoryCardProtocol.cpp
+++ b/pcsx2/SIO/Memcard/MemoryCardProtocol.cpp
@@ -234,6 +234,8 @@ void MemoryCardProtocol::WriteData()
 	g_Sio2FifoOut.push_back(mcd->term);
 
 	ReadWriteIncrement(writeLength);
+
+	MemcardBusy::SetBusy();
 }
 
 void MemoryCardProtocol::ReadData()
@@ -396,8 +398,9 @@ u8 MemoryCardProtocol::PS1Write(u8 data)
 	}
 
 	g_Sio0.SetAcknowledge(sendAck);
-
 	ps1McState.currentByte++;
+
+	MemcardBusy::SetBusy();
 	return ret;
 }
 
@@ -421,6 +424,8 @@ void MemoryCardProtocol::EraseBlock()
 	PS1_FAIL();
 	mcd->EraseBlock();
 	The2bTerminator(4);
+
+	MemcardBusy::SetBusy();
 }
 
 void MemoryCardProtocol::UnknownBoot()

--- a/pcsx2/SIO/Sio.h
+++ b/pcsx2/SIO/Sio.h
@@ -129,3 +129,11 @@ namespace AutoEject
 	extern void SetAll();
 	extern void ClearAll();
 } // namespace AutoEject
+
+namespace MemcardBusy
+{
+	extern void Decrement();
+	extern void SetBusy();
+	extern bool IsBusy();
+	extern void ClearBusy();
+}

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -1421,6 +1421,7 @@ void VMManager::Shutdown(bool save_resume_state)
 	Pad::Shutdown();
 	g_Sio2.Shutdown();
 	g_Sio0.Shutdown();
+	MemcardBusy::ClearBusy();
 	DEV9close();
 	DoCDVDclose();
 	FWclose();
@@ -1744,6 +1745,14 @@ bool VMManager::LoadState(const char* filename)
 		return false;
 	}
 
+	if (MemcardBusy::IsBusy())
+	{
+		Host::AddIconOSDMessage("LoadStateFromSlot", ICON_FA_EXCLAMATION_TRIANGLE,
+			fmt::format(TRANSLATE_FS("VMManager", "Failed to load state (Memory card is busy)")),
+			Host::OSD_QUICK_DURATION);
+		return false;
+	}
+
 	// TODO: Save the current state so we don't need to reset.
 	if (DoLoadState(filename))
 		return true;
@@ -1773,6 +1782,14 @@ bool VMManager::LoadStateFromSlot(s32 slot)
 		return false;
 	}
 
+	if (MemcardBusy::IsBusy())
+	{
+		Host::AddIconOSDMessage("LoadStateFromSlot", ICON_FA_EXCLAMATION_TRIANGLE,
+			fmt::format(TRANSLATE_FS("VMManager", "Failed to load state from slot {} (Memory card is busy)"), slot),
+			Host::OSD_QUICK_DURATION);
+		return false;
+	}
+
 	Host::AddIconOSDMessage("LoadStateFromSlot", ICON_FA_FOLDER_OPEN,
 		fmt::format(TRANSLATE_FS("VMManager", "Loading state from slot {}..."), slot), Host::OSD_QUICK_DURATION);
 	return DoLoadState(filename.c_str());
@@ -1780,6 +1797,14 @@ bool VMManager::LoadStateFromSlot(s32 slot)
 
 bool VMManager::SaveState(const char* filename, bool zip_on_thread, bool backup_old_state)
 {
+	if (MemcardBusy::IsBusy())
+	{
+		Host::AddIconOSDMessage("LoadStateFromSlot", ICON_FA_EXCLAMATION_TRIANGLE,
+			fmt::format(TRANSLATE_FS("VMManager", "Failed to save state (Memory card is busy)")),
+			Host::OSD_QUICK_DURATION);
+		return false;
+	}
+
 	return DoSaveState(filename, -1, zip_on_thread, backup_old_state);
 }
 
@@ -1788,6 +1813,14 @@ bool VMManager::SaveStateToSlot(s32 slot, bool zip_on_thread)
 	const std::string filename(GetCurrentSaveStateFileName(slot));
 	if (filename.empty())
 		return false;
+
+	if (MemcardBusy::IsBusy())
+	{
+		Host::AddIconOSDMessage("LoadStateFromSlot", ICON_FA_EXCLAMATION_TRIANGLE,
+			fmt::format(TRANSLATE_FS("VMManager", "Failed to save state to slot {} (Memory card is busy)"), slot),
+			Host::OSD_QUICK_DURATION);
+		return false;
+	}
 
 	// if it takes more than a minute.. well.. wtf.
 	Host::AddIconOSDMessage(fmt::format("SaveStateSlot{}", slot), ICON_FA_SAVE,


### PR DESCRIPTION
### Description of Changes
Adds a counter, set to 300 frames when a write operation is sent to a memory card. Every frame, the counter is decremented. On shutdown, the counter is cleared.

Also moved memory card auto eject countdown function out to Counters.cpp. It will run at the same frequency, it's just now it's not stuck in CDVD anymore, it's in Counters.cpp which makes more sense.

### Rationale behind Changes
New MemcardBusy::IsBusy() function can be used by the frontend and/or emu thread to detect if memcard activity has happened within the last 300 frames. That can then be used to determine whether to continue with or abort shutdowns, restarts, disc swaps, savestates, etc.

~~I attempted to make the frontend changes but quickly realized I did not understand how anything worked. I am going to either need assistance or pass that off to someone who does.~~

### Suggested Testing Steps
MAKE NEW MEMCARDS. DO NOT PUT MEMCARDS YOU CARE ABOUT ANYWHERE NEAR THIS.

Boot a game, get it to a point where it will write something to the memcard. Purposely try to shut it down, reset it, load a savestate, while it is writing to the memcard. You should be blocked from completing your "desired" action.
