### PR TITLE
GameDB: PJ King Kong fixes

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -12146,6 +12146,7 @@ SLED-53723:
   gsHWFixes:
     recommendedBlendingLevel: 2 # Increases image brightness.
     autoFlush: 1 # Corrects vignette to match software.
+    estimateTextureRegion: 1 # Improves performance and reduces hash cache size.
 SLED-53731:
   name: "Battlefield 2 - Modern Combat [Demo]"
   region: "PAL-E"
@@ -21560,18 +21561,21 @@ SLES-53703:
   gsHWFixes:
     recommendedBlendingLevel: 2 # Increases image brightness.
     autoFlush: 1 # Corrects vignette to match software.
+    estimateTextureRegion: 1 # Improves performance and reduces hash cache size.
 SLES-53704:
   name: "King Kong, Peter Jackson's - The Official Game of the Movie"
   region: "PAL-R"
   gsHWFixes:
     recommendedBlendingLevel: 2 # Increases image brightness.
     autoFlush: 1 # Corrects vignette to match software.
+    estimateTextureRegion: 1 # Improves performance and reduces hash cache size.
 SLES-53705:
   name: "King Kong, Peter Jackson's - The Official Game of the Movie"
   region: "PAL-PL-E"
   gsHWFixes:
     recommendedBlendingLevel: 2 # Increases image brightness.
     autoFlush: 1 # Corrects vignette to match software.
+    estimateTextureRegion: 1 # Improves performance and reduces hash cache size.
 SLES-53706:
   name: "The Chronicles of Narnia - The Lion Witch and The Wardrobe"
   name-sort: "Chronicles of Narnia, The - The Lion, The Witch and The Wardrobe"
@@ -28481,6 +28485,7 @@ SLKA-25337:
   gsHWFixes:
     recommendedBlendingLevel: 2 # Increases image brightness.
     autoFlush: 1 # Corrects vignette to match software.
+    estimateTextureRegion: 1 # Improves performance and reduces hash cache size.
 SLKA-25338:
   name: "The Godfather"
   name-sort: "Godfather, The"
@@ -41329,6 +41334,7 @@ SLPM-66211:
   gsHWFixes:
     recommendedBlendingLevel: 2 # Increases image brightness.
     autoFlush: 1 # Corrects vignette to match software.
+    estimateTextureRegion: 1 # Improves performance and reduces hash cache size.
 SLPM-66212:
   name: セガラリー2006
   name-sort: せがらりー2006
@@ -62062,6 +62068,7 @@ SLUS-21311:
   gsHWFixes:
     recommendedBlendingLevel: 2 # Increases image brightness.
     autoFlush: 1 # Corrects vignette to match software.
+    estimateTextureRegion: 1 # Improves performance and reduces hash cache size.
 SLUS-21312:
   name: "Wallace & Gromit - The Curse of the Were-Rabbit"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
Fixes for the hash cache being silly and spiking to stupid levels killing performance.

### Rationale behind Changes
Game is stupid and absolutely destroys the GS thread with silly spikes in the HC during lightning strikes.

### Suggested Testing Steps
Make sure CI is happy boy.
