### PR TITLE
Qt: (Debugger) Add ability to remove result from Memory Search results

### DIFF
--- a/pcsx2-qt/Debugger/CpuWidget.cpp
+++ b/pcsx2-qt/Debugger/CpuWidget.cpp
@@ -493,6 +493,21 @@ void CpuWidget::contextSearchResultGoToDisassembly()
 	m_ui.disassemblyWidget->gotoAddress(m_ui.listSearchResults->selectedItems().first()->data(256).toUInt());
 }
 
+void CpuWidget::contextRemoveSearchResult()
+{
+	const QItemSelectionModel* selModel = m_ui.listSearchResults->selectionModel();
+	if (!selModel->hasSelection())
+		return;
+
+	const int selectedResultIndex = m_ui.listSearchResults->row(m_ui.listSearchResults->selectedItems().first());
+	auto* rowToRemove = m_ui.listSearchResults->takeItem(selectedResultIndex);
+	if (m_searchResults.size() > selectedResultIndex && m_searchResults.at(selectedResultIndex) == rowToRemove->data(256).toUInt())
+	{
+		m_searchResults.erase(m_searchResults.begin() + selectedResultIndex);
+	}
+	delete rowToRemove;
+}
+
 void CpuWidget::updateFunctionList(bool whenEmpty)
 {
 	if (!m_cpu.isAlive())
@@ -797,6 +812,10 @@ void CpuWidget::onListSearchResultsContextMenu(QPoint pos)
 		QAction* goToDisassemblyAction = new QAction(tr("Go to in Disassembly"), m_ui.listSearchResults);
 		connect(goToDisassemblyAction, &QAction::triggered, this, &CpuWidget::contextSearchResultGoToDisassembly);
 		contextMenu->addAction(goToDisassemblyAction);
+
+		QAction* removeResultAction = new QAction(tr("Remove Result"), m_ui.listSearchResults);
+		connect(removeResultAction, &QAction::triggered, this, &CpuWidget::contextRemoveSearchResult);
+		contextMenu->addAction(removeResultAction);
 	}
 
 	contextMenu->popup(m_ui.listSearchResults->viewport()->mapToGlobal(pos));

--- a/pcsx2-qt/Debugger/CpuWidget.h
+++ b/pcsx2-qt/Debugger/CpuWidget.h
@@ -98,6 +98,7 @@ public slots:
 	void onSearchResultsListScroll(u32 value);
 	void loadSearchResults();
 	void contextSearchResultGoToDisassembly();
+	void contextRemoveSearchResult();
 	void onListSearchResultsContextMenu(QPoint pos);
 
 private:


### PR DESCRIPTION
### Description of Changes
Adds the ability to remove individual search results from the Memory Search results list. Right clicking a result will give the "Remove Result" option in the context menu.

![PCSX2-RemoveResult2](https://github.com/PCSX2/pcsx2/assets/4957200/58e5f2d7-03e6-410a-8937-2acaf1721166)

### Rationale behind Changes
Especially with large lists of results, it's helpful to be able to filter out addresses that we know we're not interested in. Primarily a convenience feature.

### Suggested Testing Steps
- Open a game and the debugger.
- Perform a memory search.
- Right click any result, click 'Remove Result'.
- Verify it's no longer in the list, and does not reappear upon a filter search (ensures it's not just gone from the UI, but our internal results set).

Safe guards are in place to make sure the value being replaced is the one you selected.
