### PR TITLE
Input-rec: Set git tagged emu version instead of static version.

### DIFF
--- a/pcsx2/Recording/InputRecordingFile.cpp
+++ b/pcsx2/Recording/InputRecordingFile.cpp
@@ -22,6 +22,7 @@
 #include "common/FileSystem.h"
 #include "DebugTools/Debug.h"
 #include "MemoryTypes.h"
+#include "svnrev.h"
 #include "SysForwardDefs.h"
 
 #include <fmt/format.h>
@@ -36,8 +37,13 @@ void InputRecordingFile::InputRecordingFileHeader::init() noexcept
 
 void InputRecordingFile::setEmulatorVersion()
 {
-	static const std::string emuVersion = fmt::format("PCSX2-{}.{}.{}", PCSX2_VersionHi, PCSX2_VersionMid, PCSX2_VersionLo);
-	strncpy(m_header.m_emulatorVersion, emuVersion.c_str(), sizeof(m_header.m_emulatorVersion) - 1);
+	std::string emuVersion;
+	if (!PCSX2_isReleaseVersion && GIT_TAGGED_COMMIT)
+		emuVersion = fmt::format("PCSX2-Nightly-{}", GIT_TAG);
+	else
+		emuVersion = fmt::format("PCSX2-{}.{}.{}", PCSX2_VersionHi, PCSX2_VersionMid, PCSX2_VersionLo);
+
+	StringUtil::Strlcpy(m_header.m_emulatorVersion, emuVersion.c_str(), sizeof(m_header.m_emulatorVersion));
 }
 
 void InputRecordingFile::setAuthor(const std::string& _author)

--- a/pcsx2/Recording/InputRecordingFile.h
+++ b/pcsx2/Recording/InputRecordingFile.h
@@ -33,7 +33,7 @@ class InputRecordingFile
 
 	public:
 		void init() noexcept;
-	} m_header;
+	} m_header = {};
 
 
 public:


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Input-rec: Set git tagged emu version instead of static version.
The static version was set as 1.7.0, not knowing which nightly version the recordings were made on.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Consistency, fixes https://github.com/PCSX2/pcsx2/issues/10366

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test input recording, make sure pcsx2 version info in recordings is properly set, see https://github.com/PCSX2/pcsx2/issues/10366
