### PR TITLE
SmallString: Add missing copy construct/assign operators

### DIFF
--- a/common/SmallString.h
+++ b/common/SmallString.h
@@ -253,10 +253,58 @@ public:
 		assign(move);
 	}
 
+	__fi SmallStackString(const SmallStackString& copy)
+	{
+		init();
+		assign(copy);
+	}
+
+	__fi SmallStackString(SmallStackString&& move)
+	{
+		init();
+		assign(move);
+	}
+
 	__fi SmallStackString(const std::string_view& sv)
 	{
 		init();
 		assign(sv);
+	}
+
+	__fi SmallStackString& operator=(const SmallStringBase& copy)
+	{
+		assign(copy);
+		return *this;
+	}
+
+	__fi SmallStackString& operator=(SmallStringBase&& move)
+	{
+		assign(move);
+		return *this;
+	}
+
+	__fi SmallStackString& operator=(const SmallStackString& copy)
+	{
+		assign(copy);
+		return *this;
+	}
+
+	__fi SmallStackString& operator=(SmallStackString&& move)
+	{
+		assign(move);
+		return *this;
+	}
+
+	__fi SmallStackString& operator=(const std::string_view& sv)
+	{
+		assign(sv);
+		return *this;
+	}
+
+	__fi SmallStackString& operator=(const char* str)
+	{
+		assign(str);
+		return *this;
 	}
 
 	// Override the fromstring method


### PR DESCRIPTION
### Description of Changes

Port of https://github.com/stenzek/duckstation/commit/a9ee2a34d849135e207da8f1eedd42a646f20bc5

### Rationale behind Changes

Copying SmallString objects could result in crashes.

### Suggested Testing Steps

CI passes.