### PR TITLE
Qt: Resolve any symbolic links in AppRoot/DataRoot

### DIFF
--- a/common/Path.h
+++ b/common/Path.h
@@ -47,6 +47,9 @@ namespace Path
 	/// Returns true if the specified path is an absolute path (C:\Path on Windows or /path on Unix).
 	bool IsAbsolute(const std::string_view& path);
 
+	/// Resolves any symbolic links in the specified path.
+	std::string RealPath(const std::string_view& path);
+
 	/// Makes the specified path relative to another (e.g. /a/b/c, /a/b -> ../c).
 	/// Both paths must be relative, otherwise this function will just return the input path.
 	std::string MakeRelative(const std::string_view& path, const std::string_view& relative_to);

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -1687,7 +1687,7 @@ bool EmuFolders::InitializeCriticalFolders()
 
 void EmuFolders::SetAppRoot()
 {
-	std::string program_path(FileSystem::GetProgramPath());
+	const std::string program_path = FileSystem::GetProgramPath();
 	Console.WriteLn("Program Path: %s", program_path.c_str());
 
 	AppRoot = Path::Canonicalize(Path::GetDirectory(program_path));
@@ -1732,12 +1732,11 @@ void EmuFolders::SetDataDirectory()
 	const char* xdg_config_home = getenv("XDG_CONFIG_HOME");
 	if (xdg_config_home && Path::IsAbsolute(xdg_config_home))
 	{
-		DataRoot = Path::Combine(xdg_config_home, "PCSX2");
+		DataRoot = Path::RealPath(Path::Combine(xdg_config_home, "PCSX2"));
 	}
 	else
 	{
 		// Use ~/PCSX2 for non-XDG, and ~/.config/PCSX2 for XDG.
-		// Maybe we should drop the former when Qt goes live.
 		const char* home_dir = getenv("HOME");
 		if (home_dir)
 		{
@@ -1746,14 +1745,14 @@ void EmuFolders::SetDataDirectory()
 			if (!FileSystem::DirectoryExists(config_dir.c_str()))
 				FileSystem::CreateDirectoryPath(config_dir.c_str(), false);
 
-			DataRoot = Path::Combine(config_dir, "PCSX2");
+			DataRoot = Path::RealPath(Path::Combine(config_dir, "PCSX2"));
 		}
 	}
 #elif defined(__APPLE__)
 	static constexpr char MAC_DATA_DIR[] = "Library/Application Support/PCSX2";
 	const char* home_dir = getenv("HOME");
 	if (home_dir)
-		DataRoot = Path::Combine(home_dir, MAC_DATA_DIR);
+		DataRoot = Path::RealPath(Path::Combine(home_dir, MAC_DATA_DIR));
 #endif
 
 	// make sure it exists

--- a/tests/ctest/common/path_tests.cpp
+++ b/tests/ctest/common/path_tests.cpp
@@ -17,7 +17,7 @@
 #include "common/Path.h"
 #include <gtest/gtest.h>
 
-TEST(FileSystem, ToNativePath)
+TEST(Path, ToNativePath)
 {
 	ASSERT_EQ(Path::ToNativePath(""), "");
 
@@ -41,7 +41,7 @@ TEST(FileSystem, ToNativePath)
 #endif
 }
 
-TEST(FileSystem, IsValidFileName)
+TEST(Path, IsValidFileName)
 {
 #if defined(_WIN32) || defined(__APPLE__)
 	ASSERT_FALSE(Path::IsValidFileName("foo:bar", false));
@@ -64,7 +64,7 @@ TEST(FileSystem, IsValidFileName)
 	ASSERT_FALSE(Path::IsValidFileName("baz/foo", false));
 }
 
-TEST(FileSystem, IsAbsolute)
+TEST(Path, IsAbsolute)
 {
 	ASSERT_FALSE(Path::IsAbsolute(""));
 	ASSERT_FALSE(Path::IsAbsolute("foo"));
@@ -80,7 +80,7 @@ TEST(FileSystem, IsAbsolute)
 #endif
 }
 
-TEST(FileSystem, Canonicalize)
+TEST(Path, Canonicalize)
 {
 	ASSERT_EQ(Path::Canonicalize(""), Path::ToNativePath(""));
 	ASSERT_EQ(Path::Canonicalize("foo/bar/../baz"), Path::ToNativePath("foo/baz"));
@@ -103,7 +103,7 @@ TEST(FileSystem, Canonicalize)
 #endif
 }
 
-TEST(FileSystem, Combine)
+TEST(Path, Combine)
 {
 	ASSERT_EQ(Path::Combine("", ""), Path::ToNativePath(""));
 	ASSERT_EQ(Path::Combine("foo", "bar"), Path::ToNativePath("foo/bar"));
@@ -124,7 +124,7 @@ TEST(FileSystem, Combine)
 #endif
 }
 
-TEST(FileSystem, AppendDirectory)
+TEST(Path, AppendDirectory)
 {
 	ASSERT_EQ(Path::AppendDirectory("foo/bar", "baz"), Path::ToNativePath("foo/baz/bar"));
 	ASSERT_EQ(Path::AppendDirectory("", "baz"), Path::ToNativePath("baz"));
@@ -138,7 +138,7 @@ TEST(FileSystem, AppendDirectory)
 #endif
 }
 
-TEST(FileSystem, MakeRelative)
+TEST(Path, MakeRelative)
 {
 	ASSERT_EQ(Path::MakeRelative("", ""), Path::ToNativePath(""));
 	ASSERT_EQ(Path::MakeRelative("foo", ""), Path::ToNativePath("foo"));
@@ -167,7 +167,7 @@ TEST(FileSystem, MakeRelative)
 #endif
 }
 
-TEST(FileSystem, GetExtension)
+TEST(Path, GetExtension)
 {
 	ASSERT_EQ(Path::GetExtension("foo"), "");
 	ASSERT_EQ(Path::GetExtension("foo.txt"), "txt");
@@ -177,7 +177,7 @@ TEST(FileSystem, GetExtension)
 	ASSERT_EQ(Path::GetExtension("a/b/foo"), "");
 }
 
-TEST(FileSystem, GetFileName)
+TEST(Path, GetFileName)
 {
 	ASSERT_EQ(Path::GetFileName(""), "");
 	ASSERT_EQ(Path::GetFileName("foo"), "foo");
@@ -192,7 +192,7 @@ TEST(FileSystem, GetFileName)
 #endif
 }
 
-TEST(FileSystem, GetFileTitle)
+TEST(Path, GetFileTitle)
 {
 	ASSERT_EQ(Path::GetFileTitle(""), "");
 	ASSERT_EQ(Path::GetFileTitle("foo"), "foo");
@@ -206,7 +206,7 @@ TEST(FileSystem, GetFileTitle)
 #endif
 }
 
-TEST(FileSystem, GetDirectory)
+TEST(Path, GetDirectory)
 {
 	ASSERT_EQ(Path::GetDirectory(""), "");
 	ASSERT_EQ(Path::GetDirectory("foo"), "");
@@ -220,7 +220,7 @@ TEST(FileSystem, GetDirectory)
 #endif
 }
 
-TEST(FileSystem, ChangeFileName)
+TEST(Path, ChangeFileName)
 {
 	ASSERT_EQ(Path::ChangeFileName("", ""), Path::ToNativePath(""));
 	ASSERT_EQ(Path::ChangeFileName("", "bar"), Path::ToNativePath("bar"));
@@ -239,3 +239,17 @@ TEST(FileSystem, ChangeFileName)
 	ASSERT_EQ(Path::ChangeFileName("/foo/bar", "baz"), "/foo/baz");
 #endif
 }
+
+#if 0
+
+// Relies on presence of files.
+TEST(Path, RealPath)
+{
+#ifdef _WIN32
+	ASSERT_EQ(Path::RealPath("C:\\Users\\Me\\Desktop\\foo\\baz"), "C:\\Users\\Me\\Desktop\\foo\\bar\\baz");
+#else
+	ASSERT_EQ(Path::RealPath("/lib/foo/bar"), "/usr/lib/foo/bar");
+#endif
+}
+
+#endif


### PR DESCRIPTION
### Description of Changes

Port of https://github.com/stenzek/duckstation/commit/524625269fe5f365a10dbfc2e18c325b6c4fab61 and https://github.com/stenzek/duckstation/commit/407049cd91b65c8a917533b87c7264dba3e2adc5.

### Rationale behind Changes

Fixes PCSX2 generating incorrect relative paths when the data directory is involved in a symlink'ed path. e.g. from FreeBSD, `/home` is symlinked to `/usr/home`, therefore `..` in `/home/foo` actually resolves to `/usr`, not `/`. Silly Unix...

### Suggested Testing Steps

Ensure Linux/Mac builds still find your user data.

Note to self: Test flatpak as well before merging.