### PR TITLE
GameDB: Fixes for WALL-E

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -25588,40 +25588,50 @@ SLES-55184:
   roundModes:
     vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
   gsHWFixes:
-    halfPixelOffset: 2 # Reduces the ghosting effect.
-    wildArmsHack: 1 # Reduces the ghosting effect.
+    cpuSpriteRenderBW: 2 # Fixes bloom on HW renderer.
+    cpuSpriteRenderLevel: 2 # Needed for above.
+    halfPixelOffset: 4 # Reduces the ghosting effect.
+    roundSprite: 2 # Reduces the ghosting effect.
 SLES-55185:
   name: "Disney-Pixar WALL-E"
   region: "PAL-UK"
   roundModes:
     vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
   gsHWFixes:
-    halfPixelOffset: 2 # Reduces the ghosting effect.
-    wildArmsHack: 1 # Reduces the ghosting effect.
+    cpuSpriteRenderBW: 2 # Fixes bloom on HW renderer.
+    cpuSpriteRenderLevel: 2 # Needed for above.
+    halfPixelOffset: 4 # Reduces the ghosting effect.
+    roundSprite: 2 # Reduces the ghosting effect.
 SLES-55186:
   name: "Disney-Pixar WALL-E"
   region: "PAL-S-P"
   roundModes:
     vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
   gsHWFixes:
-    halfPixelOffset: 2 # Reduces the ghosting effect.
-    wildArmsHack: 1 # Reduces the ghosting effect.
+    cpuSpriteRenderBW: 2 # Fixes bloom on HW renderer.
+    cpuSpriteRenderLevel: 2 # Needed for above.
+    halfPixelOffset: 4 # Reduces the ghosting effect.
+    roundSprite: 2 # Reduces the ghosting effect.
 SLES-55187:
   name: "Disney-Pixar WALL-E"
   region: "PAL-F-G"
   roundModes:
     vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
   gsHWFixes:
-    halfPixelOffset: 2 # Reduces the ghosting effect.
-    wildArmsHack: 1 # Reduces the ghosting effect.
+    cpuSpriteRenderBW: 2 # Fixes bloom on HW renderer.
+    cpuSpriteRenderLevel: 2 # Needed for above.
+    halfPixelOffset: 4 # Reduces the ghosting effect.
+    roundSprite: 2 # Reduces the ghosting effect.
 SLES-55188:
   name: "Disney-Pixar WALL-E"
   region: "PAL-G"
   roundModes:
     vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
   gsHWFixes:
-    halfPixelOffset: 2 # Reduces the ghosting effect.
-    wildArmsHack: 1 # Reduces the ghosting effect.
+    cpuSpriteRenderBW: 2 # Fixes bloom on HW renderer.
+    cpuSpriteRenderLevel: 2 # Needed for above.
+    halfPixelOffset: 4 # Reduces the ghosting effect.
+    roundSprite: 2 # Reduces the ghosting effect.
 SLES-55189:
   name: "Nick Jr. Go Diego Go! Safari Rescue"
   region: "PAL-E-F"
@@ -25644,32 +25654,40 @@ SLES-55193:
   roundModes:
     vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
   gsHWFixes:
-    halfPixelOffset: 2 # Reduces the ghosting effect.
-    wildArmsHack: 1 # Reduces the ghosting effect.
+    cpuSpriteRenderBW: 2 # Fixes bloom on HW renderer.
+    cpuSpriteRenderLevel: 2 # Needed for above.
+    halfPixelOffset: 4 # Reduces the ghosting effect.
+    roundSprite: 2 # Reduces the ghosting effect.
 SLES-55194:
   name: "Disney-Pixar WALL-E"
   region: "PAL-SC"
   roundModes:
     vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
   gsHWFixes:
-    halfPixelOffset: 2 # Reduces the ghosting effect.
-    wildArmsHack: 1 # Reduces the ghosting effect.
+    cpuSpriteRenderBW: 2 # Fixes bloom on HW renderer.
+    cpuSpriteRenderLevel: 2 # Needed for above.
+    halfPixelOffset: 4 # Reduces the ghosting effect.
+    roundSprite: 2 # Reduces the ghosting effect.
 SLES-55195:
   name: "Disney-Pixar WALL-E"
   region: "PAL-GR-I"
   roundModes:
     vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
   gsHWFixes:
-    halfPixelOffset: 2 # Reduces the ghosting effect.
-    wildArmsHack: 1 # Reduces the ghosting effect.
+    cpuSpriteRenderBW: 2 # Fixes bloom on HW renderer.
+    cpuSpriteRenderLevel: 2 # Needed for above.
+    halfPixelOffset: 4 # Reduces the ghosting effect.
+    roundSprite: 2 # Reduces the ghosting effect.
 SLES-55196:
   name: "Disney-Pixar WALL-E"
   region: "PAL-PL-CR"
   roundModes:
     vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
   gsHWFixes:
-    halfPixelOffset: 2 # Reduces the ghosting effect.
-    wildArmsHack: 1 # Reduces the ghosting effect.
+    cpuSpriteRenderBW: 2 # Fixes bloom on HW renderer.
+    cpuSpriteRenderLevel: 2 # Needed for above.
+    halfPixelOffset: 4 # Reduces the ghosting effect.
+    roundSprite: 2 # Reduces the ghosting effect.
 SLES-55197:
   name: "Dancing Stage SuperNOVA 2"
   region: "PAL-M5"
@@ -64316,8 +64334,10 @@ SLUS-21736:
   roundModes:
     vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
   gsHWFixes:
-    halfPixelOffset: 2 # Reduces the ghosting effect.
-    wildArmsHack: 1 # Reduces the ghosting effect.
+    cpuSpriteRenderBW: 2 # Fixes bloom on HW renderer.
+    cpuSpriteRenderLevel: 2 # Needed for above.
+    halfPixelOffset: 4 # Reduces the ghosting effect.
+    roundSprite: 2 # Reduces the ghosting effect.
 SLUS-21737:
   name: "Riding Star"
   region: "NTSC-U"

--- a/pcsx2/Docs/gamedb-schema.json
+++ b/pcsx2/Docs/gamedb-schema.json
@@ -233,7 +233,7 @@
             "halfPixelOffset": {
               "type": "integer",
               "minimum": 0,
-              "maximum": 3
+              "maximum": 4
             },
             "roundSprite": {
               "type": "integer",


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
This PR fixes ghosting and bloom issues on WALL-E

SW:
![Disney-Pixar WALL-E_SLUS-21736_20231211123204](https://github.com/PCSX2/pcsx2/assets/14798312/d7309582-023a-43bb-ab48-72611bc44b8d)

HW: 
![Disney-Pixar WALL-E_SLUS-21736_20231211123129](https://github.com/PCSX2/pcsx2/assets/14798312/5bdc86b3-c7f3-4fe0-ad04-c8c07b2d0fc3)

HW + HPO Native and Round Sprite Full:
![Disney-Pixar WALL-E_SLUS-21736_20231211123147](https://github.com/PCSX2/pcsx2/assets/14798312/744fedd9-0622-46b4-ac81-efadcc9ad874)


### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
less ghost better-er.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Make sure i didn't break anything else.