### PR TITLE
[UI] Adding missing strings, English fixes

### DIFF
--- a/pcsx2-qt/Translations.cpp
+++ b/pcsx2-qt/Translations.cpp
@@ -38,8 +38,8 @@ QT_TRANSLATE_NOOP("MAC_APPLICATION_MENU", "Quit %1")
 QT_TRANSLATE_NOOP("MAC_APPLICATION_MENU", "About %1")
 
 // Strings that will be parsed out by our build system and sent to fun places
-QT_TRANSLATE_NOOP("PermissionsDialogMicrophone", "PCSX2 uses your microphone to emulate a USB microphone plugged into the virtual PS2")
-QT_TRANSLATE_NOOP("PermissionsDialogCamera", "PCSX2 uses your camera to emulate an EyeToy camera plugged into the virtual PS2")
+QT_TRANSLATE_NOOP("PermissionsDialogMicrophone", "PCSX2 uses your microphone to emulate a USB microphone plugged into the virtual PS2.")
+QT_TRANSLATE_NOOP("PermissionsDialogCamera", "PCSX2 uses your camera to emulate an EyeToy camera plugged into the virtual PS2.")
 #endif
 
 namespace QtHost

--- a/pcsx2/GameList.cpp
+++ b/pcsx2/GameList.cpp
@@ -591,7 +591,7 @@ void GameList::ScanDirectory(const char* path, bool recursive, bool only_cache, 
 	Console.WriteLn("Scanning %s%s", path, recursive ? " (recursively)" : "");
 
 	progress->PushState();
-	progress->SetFormattedStatusText("Scanning directory '%s'%s...", path, recursive ? " (recursively)" : "");
+	progress->SetFormattedStatusText(TRANSLATE("GameList", "Scanning directory '%s'%s..."), path, recursive ? TRANSLATE("GameList", " (recursively)") : "");
 
 	FileSystem::FindResultsArray files;
 	FileSystem::FindFiles(path, "*",
@@ -619,7 +619,7 @@ void GameList::ScanDirectory(const char* path, bool recursive, bool only_cache, 
 		}
 
 		const std::string_view filename = Path::GetFileName(ffd.FileName);
-		progress->SetFormattedStatusText("Scanning '%.*s'...", static_cast<int>(filename.size()), filename.data());
+		progress->SetFormattedStatusText(TRANSLATE("GameList", "Scanning '%.*s'..."), static_cast<int>(filename.size()), filename.data());
 		ScanFile(std::move(ffd.FileName), ffd.ModificationTime, lock, played_time_map, custom_attributes_ini);
 		progress->SetProgressValue(files_scanned);
 	}


### PR DESCRIPTION
### Description of Changes
- Adding missing ending periods to the Mac microphone/camera permission explanations.
- Making the Scanning strings at the bottom area of QT translatable.

### Rationale behind Changes
Cleaner English texts, advancing towards a 100% translatable UI.

### Suggested Testing Steps
Check that the new translatable strings are not failing somewhere.
