### PR TITLE
DiscordRPC: Show session time in Discord Rich Presence

### DIFF
--- a/pcsx2/Achievements.cpp
+++ b/pcsx2/Achievements.cpp
@@ -814,7 +814,7 @@ void Achievements::UpdateRichPresence(std::unique_lock<std::recursive_mutex>& lo
 	Host::OnAchievementsRefreshed();
 
 	lock.unlock();
-	VMManager::UpdateDiscordPresence();
+	VMManager::UpdateDiscordPresence(false);
 	lock.lock();
 }
 

--- a/pcsx2/VMManager.h
+++ b/pcsx2/VMManager.h
@@ -222,7 +222,7 @@ namespace VMManager
 	u64 GetSessionPlayedTime();
 
 	/// Called when the rich presence string, provided by RetroAchievements, changes.
-	void UpdateDiscordPresence();
+	void UpdateDiscordPresence(bool update_session_time);
 
 	/// Internal callbacks, implemented in the emu core.
 	namespace Internal


### PR DESCRIPTION
### Description of Changes
This PR changes the way Discord Rich Presence shows time elapsed. Now instead of updating on every single RPC change, the time only gets reset on:
* Starting the emulator
* Starting/stopping the game

### Rationale behind Changes
It is more meaningful to show how long the user has been in a specific game than to show how long the current Rich Presence string has been active for.

### Suggested Testing Steps
1. Run any game with RetroAchievements Rich Presence, with Discord Rich Presence enabled.
2. Perform any actions in-game that change the presence string.
3. Confirm that the "Time elapsed" display on Discord does **not** reset when the presence string changes.

Closes #10390