### PR TITLE
GameDB: Darkwatch Upscaling Fix

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -21193,6 +21193,8 @@ SLES-53563:
 SLES-53564:
   name: "Darkwatch"
   region: "PAL-M5"
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes blood vision bloom
 SLES-53566:
   name: "London Taxi - Rush Hour"
   region: "PAL-E"
@@ -60561,6 +60563,8 @@ SLUS-21042:
   name: "Darkwatch"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes blood vision bloom
 SLUS-21043:
   name: "Backyard Wrestling 2 - There Goes the Neighborhood"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
This PR sets HPO to Special setting to fix bloom misalignment seen on player's blood vision. Comparison below:

**Native**
![Darkwatch_SLUS-21042_20231210215824](https://github.com/PCSX2/pcsx2/assets/19964653/c34bed6d-a45d-475a-ba6a-29b57760bb52)

**Upscaled (master)**
![Darkwatch_SLUS-21042_20231210215838](https://github.com/PCSX2/pcsx2/assets/19964653/12908eaa-9c72-454f-8a5f-5c43eaf0d6ee)

**Upscaled (w/fix)**
![Darkwatch_SLUS-21042_20231210215937](https://github.com/PCSX2/pcsx2/assets/19964653/b06ec88e-d83f-462e-9265-2e9aaaa99191)

### Rationale behind Changes
less tinkering ofc

[GS Dump](https://drive.google.com/file/d/12KPfoViX4THhG6-A2-KLb4NFT_geHxiK/view?usp=sharing)