### PR TITLE
Memcard: Remove option to disable auto eject

### DIFF
--- a/pcsx2-qt/Settings/MemoryCardSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/MemoryCardSettingsWidget.cpp
@@ -55,7 +55,6 @@ MemoryCardSettingsWidget::MemoryCardSettingsWidget(SettingsWindow* dialog, QWidg
 
 	SettingWidgetBinder::BindWidgetToFolderSetting(sif, m_ui.directory, m_ui.browse, m_ui.open, m_ui.reset, "Folders",
 		"MemoryCards", Path::Combine(EmuFolders::DataRoot, "memcards"));
-	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.autoEject, "EmuCore", "McdEnableEjection", true);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.automaticManagement, "EmuCore", "McdFolderAutoManage", true);
 
 	setupAdditionalUi();
@@ -75,9 +74,6 @@ MemoryCardSettingsWidget::MemoryCardSettingsWidget(SettingsWindow* dialog, QWidg
 	connect(m_ui.deleteCard, &QPushButton::clicked, this, &MemoryCardSettingsWidget::deleteCard);
 
 	refresh();
-
-	dialog->registerWidgetHelp(m_ui.autoEject, tr("Auto-eject Memory Cards when loading save states"), tr("Checked"),
-		tr("Avoids broken Memory Card saves. May not work with some games such as Guitar Hero."));
 
 	dialog->registerWidgetHelp(m_ui.automaticManagement, tr("Automatically manage saves based on running game"),
 		tr("Checked"),

--- a/pcsx2-qt/Settings/MemoryCardSettingsWidget.ui
+++ b/pcsx2-qt/Settings/MemoryCardSettingsWidget.ui
@@ -185,17 +185,10 @@
       <string>Settings</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_3">
-      <item row="1" column="0">
+      <item row="0" column="0">
        <widget class="QCheckBox" name="automaticManagement">
         <property name="text">
          <string>Automatically manage saves based on running game</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0">
-       <widget class="QCheckBox" name="autoEject">
-        <property name="text">
-         <string>Auto-eject Memory Cards when loading save states</string>
         </property>
        </widget>
       </item>

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -1298,8 +1298,6 @@ struct Pcsx2Config
 		InhibitScreensaver : 1,
 		BackupSavestate : 1,
 		SavestateZstdCompression : 1,
-		// enables simulated ejection of memory cards when loading savestates
-		McdEnableEjection : 1,
 		McdFolderAutoManage : 1,
 
 		HostFs : 1,

--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -3680,8 +3680,6 @@ void FullscreenUI::DrawMemoryCardSettingsPage()
 	DrawFolderSetting(bsi, FSUI_ICONSTR(ICON_FA_FOLDER_OPEN, "Memory Card Directory"), "Folders", "MemoryCards", EmuFolders::MemoryCards);
 	DrawToggleSetting(bsi, FSUI_ICONSTR(ICON_FA_SEARCH, "Folder Memory Card Filter"),
 		FSUI_CSTR("Simulates a larger memory card by filtering saves only to the current game."), "EmuCore", "McdFolderAutoManage", true);
-	DrawToggleSetting(bsi, FSUI_ICONSTR(ICON_FA_MAGIC, "Auto Eject When Loading"),
-		FSUI_CSTR("Automatically ejects Memory Cards when they differ after loading a state."), "EmuCore", "McdEnableEjection", true);
 
 	for (u32 port = 0; port < NUM_MEMORY_CARD_PORTS; port++)
 	{

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -1478,7 +1478,6 @@ Pcsx2Config::Pcsx2Config()
 {
 	bitset = 0;
 	// Set defaults for fresh installs / reset settings
-	McdEnableEjection = true;
 	McdFolderAutoManage = true;
 	EnablePatches = true;
 	EnableFastBoot = true;
@@ -1537,7 +1536,6 @@ void Pcsx2Config::LoadSaveCore(SettingsWrapper& wrap)
 
 	SettingsWrapBitBool(BackupSavestate);
 	SettingsWrapBitBool(SavestateZstdCompression);
-	SettingsWrapBitBool(McdEnableEjection);
 	SettingsWrapBitBool(McdFolderAutoManage);
 
 	SettingsWrapBitBool(WarnAboutUnsafeSettings);

--- a/pcsx2/SIO/Sio.cpp
+++ b/pcsx2/SIO/Sio.cpp
@@ -98,7 +98,7 @@ void AutoEject::CountDownTicks()
 
 void AutoEject::Set(size_t port, size_t slot)
 {
-	if (EmuConfig.McdEnableEjection && mcds[port][slot].autoEjectTicks == 0)
+	if (mcds[port][slot].autoEjectTicks == 0)
 	{
 		mcds[port][slot].autoEjectTicks = 1; // 1 second is enough.
 		mcds[port][slot].term = 0x55; // Reset terminator to default (0x55), forces the PS2 to recheck the memcard.

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -2402,7 +2402,6 @@ void VMManager::CheckForMemoryCardConfigChanges(const Pcsx2Config& old_config)
 		}
 	}
 
-	changed |= (EmuConfig.McdEnableEjection != old_config.McdEnableEjection);
 	changed |= (EmuConfig.McdFolderAutoManage != old_config.McdFolderAutoManage);
 
 	if (!changed)


### PR DESCRIPTION
### Description of Changes
Removes memory card auto eject as an option entirely. No more UI checkbox. No more ini setting. Gone.

### Rationale behind Changes
Another way to try and stop people from killing their memory cards with savestates. If you load a savestate, your memory cards WILL be ejected. It is the ONLY safe option.

### Suggested Testing Steps
Boot games, make sure auto eject still behaves like it should when loading savestates. Specifically, the memcard contents from when the state was captured need to be different to activate auto eject.

Test Guitar Hero 2 in particular. There were some older code comments calling out this game as hanging when auto eject was enabled; I suspect this might have been silently fixed with time.

Would be a good idea to test other Guitar Hero games for safety - I tested Guitar Hero 3 (NTSC-U) and it was fine both in the main menu and in a song.