### PR TITLE
Debugger: Don't modify disassembly focus on CPU state change

### DIFF
--- a/pcsx2-qt/Debugger/CpuWidget.cpp
+++ b/pcsx2-qt/Debugger/CpuWidget.cpp
@@ -262,7 +262,7 @@ void CpuWidget::onVMPaused()
 	}
 	else
 	{
-		m_ui.disassemblyWidget->gotoAddress(m_cpu.getPC());
+		m_ui.disassemblyWidget->gotoAddress(m_cpu.getPC(), false);
 	}
 
 	reloadCPUWidgets();
@@ -501,7 +501,7 @@ void CpuWidget::contextRemoveSearchResult()
 
 	const int selectedResultIndex = m_ui.listSearchResults->row(m_ui.listSearchResults->selectedItems().first());
 	auto* rowToRemove = m_ui.listSearchResults->takeItem(selectedResultIndex);
-	if (m_searchResults.size() > selectedResultIndex && m_searchResults.at(selectedResultIndex) == rowToRemove->data(256).toUInt())
+	if (m_searchResults.size() > static_cast<size_t>(selectedResultIndex) && m_searchResults.at(selectedResultIndex) == rowToRemove->data(256).toUInt())
 	{
 		m_searchResults.erase(m_searchResults.begin() + selectedResultIndex);
 	}

--- a/pcsx2-qt/Debugger/DisassemblyWidget.cpp
+++ b/pcsx2-qt/Debugger/DisassemblyWidget.cpp
@@ -837,7 +837,7 @@ QString DisassemblyWidget::FetchSelectionInfo(SelectionInfo selInfo)
 	return infoBlock;
 }
 
-void DisassemblyWidget::gotoAddress(u32 address)
+void DisassemblyWidget::gotoAddress(u32 address, bool should_set_focus)
 {
 	const u32 destAddress = address & ~3;
 	// Center the address
@@ -846,7 +846,8 @@ void DisassemblyWidget::gotoAddress(u32 address)
 	m_selectedAddressEnd = destAddress;
 
 	this->repaint();
-	this->setFocus();
+	if(should_set_focus)
+		this->setFocus();
 }
 
 bool DisassemblyWidget::AddressCanRestore(u32 start, u32 end)

--- a/pcsx2-qt/Debugger/DisassemblyWidget.h
+++ b/pcsx2-qt/Debugger/DisassemblyWidget.h
@@ -69,7 +69,7 @@ public slots:
 	void contextStubFunction();
 	void contextRestoreFunction();
 
-	void gotoAddress(u32 address);
+	void gotoAddress(u32 address, bool should_set_focus = true);
 
 	void setDemangle(bool demangle) { m_demangleFunctions = demangle; };
 signals:

--- a/pcsx2-qt/Debugger/MemoryViewWidget.h
+++ b/pcsx2-qt/Debugger/MemoryViewWidget.h
@@ -115,7 +115,7 @@ public slots:
 	void gotoAddress(u32 address);
 
 signals:
-	void gotoInDisasm(u32 address);
+	void gotoInDisasm(u32 address, bool should_set_focus = true);
 	void VMUpdate();
 
 private:

--- a/pcsx2-qt/Debugger/RegisterWidget.h
+++ b/pcsx2-qt/Debugger/RegisterWidget.h
@@ -57,7 +57,7 @@ public slots:
 	void tabCurrentChanged(int cur);
 
 signals:
-	void gotoInDisasm(u32 address);
+	void gotoInDisasm(u32 address, bool should_set_focus = true);
 	void gotoInMemory(u32 address);
 	void VMUpdate();
 


### PR DESCRIPTION
### Description of Changes
Fixes #10392 

### Rationale behind Changes
The inactive CPU widget was being set to focus every time the VM state changed to pause.

### Suggested Testing Steps
Try to reproduce the issue in #10392 
I also fixed a signed-compare warning. Try removing memory search results and verify that it works.