### PR TITLE
GS/D3D: Fix X3206 CAS shader warning.

### DIFF
--- a/bin/resources/shaders/dx11/cas.hlsl
+++ b/bin/resources/shaders/dx11/cas.hlsl
@@ -56,7 +56,7 @@ void main(uint3 LocalThreadId : SV_GroupThreadID, uint3 WorkGroupId : SV_GroupID
 #endif
 
   // Filter.
-  AF3 c = (float4)0.0f;
+  AF3 c = (float3)0.0f;
 
   CasFilter(c.r, c.g, c.b, gxy, const0, const1, sharpenOnly);
   OutputTexture[ASU2(gxy)] = AF4(c, 1);

--- a/pcsx2/ShaderCacheVersion.h
+++ b/pcsx2/ShaderCacheVersion.h
@@ -15,4 +15,4 @@
 
 /// Version number for GS and other shaders. Increment whenever any of the contents of the
 /// shaders change, to invalidate the cache.
-static constexpr u32 SHADER_CACHE_VERSION = 36;
+static constexpr u32 SHADER_CACHE_VERSION = 37;


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS/D3D: Fix X3206 CAS shader warning.

Warning X3206: implicit truncation of vector type warning fix.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Less shader warnings.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test CAS on DX11/12.
Edit: Tested and CAS works.