### PR TITLE
GameDB: Add VU1 clamping to Dino Stalker/Gun Survivor 3 - Dino Crisis

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -14564,6 +14564,8 @@ SLES-50927:
 SLES-50930:
   name: "Dino Stalker"
   region: "PAL-E"
+  clampModes:
+    vu1ClampMode: 3 # Fixes flashing in some scenes.
 SLES-50932:
   name: "Smash Court Tennis - Pro Tournament"
   region: "PAL-M5"
@@ -14906,9 +14908,13 @@ SLES-51094:
 SLES-51095:
   name: "Dino Stalker"
   region: "PAL-F"
+  clampModes:
+    vu1ClampMode: 3 # Fixes flashing in some scenes.
 SLES-51096:
   name: "Dino Stalker"
   region: "PAL-G"
+  clampModes:
+    vu1ClampMode: 3 # Fixes flashing in some scenes.
 SLES-51100:
   name: "Club Football - Liverpool FC"
   region: "PAL-M6"
@@ -30643,6 +30649,8 @@ SLPM-61025:
 SLPM-61026:
   name: "Gun Survivor 3 - Dino Crisis"
   region: "NTSC-J"
+  clampModes:
+    vu1ClampMode: 3 # Fixes flashing in some scenes.
 SLPM-61027:
   name: "Prismix - PlayStation 2 Sen'you Music Visual Soft - Demo Disc Vol. 1"
   region: "NTSC-J"
@@ -35554,6 +35562,8 @@ SLPM-65139:
   name-en: "Gun Survivor 3 - Dino Crisis"
   region: "NTSC-J"
   compat: 5
+  clampModes:
+    vu1ClampMode: 3 # Fixes flashing in some scenes.
 SLPM-65140:
   name: ジョジョの奇妙な冒険 黄金の旋風
   name-sort: じょじょのきみょうなぼうけん おうごんのせんぷう
@@ -46218,6 +46228,8 @@ SLPM-67528:
 SLPM-67529:
   name: "Gun Survivor 3 Dino Crisis"
   region: "NTSC-K"
+  clampModes:
+    vu1ClampMode: 3 # Fixes flashing in some scenes.
 SLPM-67530:
   name: "NHL 2003"
   region: "NTSC-K"
@@ -57668,6 +57680,8 @@ SLUS-20485:
   name: "Dino Stalker"
   region: "NTSC-U"
   compat: 5
+  clampModes:
+    vu1ClampMode: 3 # Fixes flashing in some scenes.
 SLUS-20486:
   name: "Marvel vs. Capcom 2"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
adds vu1 clamping to Gun Survivor 3 - Dino Crisis/Dino Stalker

### Rationale behind Changes
fixes flashing when shooting, solution was captured from the wiki

### Suggested Testing Steps
Watch CI, game already tested.
