### PR TITLE
Qt: Fix incorrect translation context preventing settings switch

### DIFF
--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -985,11 +985,10 @@ bool MainWindow::shouldAbortForMemcardBusy(const VMLock& lock)
 	if (MemcardBusy::IsBusy() && !GSDumpReplayer::IsReplayingDump())
 	{
 		const QMessageBox::StandardButton res = QMessageBox::question(
-			lock.getDialogParent(), 
-			tr("WARNING: Memory Card Busy"), 
-			tr("WARNING: Your memory card is still writing data. Shutting down now will IRREVERSIBLY DESTROY YOUR MEMORY CARD. It is strongly recommended to resume your game and let it finish writing to your memory card.\n\nDo you wish to shutdown anyways and IRREVERSIBLY DESTROY YOUR MEMORY CARD?")
-		);
-		
+			lock.getDialogParent(),
+			tr("WARNING: Memory Card Busy"),
+			tr("WARNING: Your memory card is still writing data. Shutting down now will IRREVERSIBLY DESTROY YOUR MEMORY CARD. It is strongly recommended to resume your game and let it finish writing to your memory card.\n\nDo you wish to shutdown anyways and IRREVERSIBLY DESTROY YOUR MEMORY CARD?"));
+
 		if (res != QMessageBox::Yes)
 		{
 			return true;
@@ -1097,7 +1096,7 @@ bool MainWindow::requestShutdown(bool allow_confirm, bool allow_save_to_state, b
 	{
 		return false;
 	}
-	
+
 	// Only confirm on UI thread because we need to display a msgbox.
 	if (!m_is_closing && allow_confirm && !GSDumpReplayer::IsReplayingDump() && Host::GetBoolSettingValue("UI", "ConfirmShutdown", true))
 	{
@@ -2383,10 +2382,16 @@ SettingsWindow* MainWindow::getSettingsWindow()
 void MainWindow::doSettings(const char* category /* = nullptr */)
 {
 	SettingsWindow* dlg = getSettingsWindow();
-	if (dlg->isVisible())
-		dlg->raise();
-	else
+	if (!dlg->isVisible())
+	{
 		dlg->show();
+	}
+	else
+	{
+		dlg->raise();
+		dlg->activateWindow();
+		dlg->setFocus();
+	}
 
 	if (category)
 		dlg->setCategory(category);
@@ -2409,18 +2414,20 @@ void MainWindow::openDebugger()
 
 void MainWindow::doControllerSettings(ControllerSettingsWindow::Category category)
 {
-	if (m_controller_settings_window)
+	if (!m_controller_settings_window)
+		m_controller_settings_window = new ControllerSettingsWindow();
+
+	if (!m_controller_settings_window->isVisible())
 	{
-		if (m_controller_settings_window->isVisible())
-			m_controller_settings_window->raise();
-		else
-			m_controller_settings_window->show();
+		m_controller_settings_window->show();
 	}
 	else
 	{
-		m_controller_settings_window = new ControllerSettingsWindow();
-		m_controller_settings_window->show();
+		m_controller_settings_window->raise();
+		m_controller_settings_window->activateWindow();
+		m_controller_settings_window->setFocus();
 	}
+
 
 	if (category != ControllerSettingsWindow::Category::Count)
 		m_controller_settings_window->setCategory(category);

--- a/pcsx2-qt/Settings/SettingsWindow.cpp
+++ b/pcsx2-qt/Settings/SettingsWindow.cpp
@@ -256,7 +256,7 @@ QString SettingsWindow::getCategory() const
 void SettingsWindow::setCategory(const char* category)
 {
 	// the titles in the category list will be translated.
-	const QString translated_category(qApp->translate("SettingsDialog", category));
+	const QString translated_category(tr(category));
 
 	for (int i = 0; i < m_ui.settingsCategory->count(); i++)
 	{


### PR DESCRIPTION
### Description of Changes

What the title says.

### Rationale behind Changes

Fixes #10422.

### Suggested Testing Steps

Test linked issue.
