### PR TITLE
Core: Improve determinism on reset + default interlaced

### DIFF
--- a/pcsx2/Hw.cpp
+++ b/pcsx2/Hw.cpp
@@ -40,19 +40,19 @@ void hwReset()
 	psHu32(DMAC_ENABLEW) = 0x1201;
 	psHu32(DMAC_ENABLER) = 0x1201;
 
+	rcntInit();
+
 	// Sets SPU2 sample rate to PS2 standard (48KHz) whenever emulator is reset.
 	// For PSX mode sample rate setting, see HwWrite.cpp
 	SPU2::Reset(false);
 
 	sifReset();
-
 	gsReset();
 	gifUnit.Reset();
 	ipuReset();
 	vif0Reset();
 	vif1Reset();
 	gif_fifo.init();
-	rcntInit();
 	USBreset();
 }
 

--- a/pcsx2/IopMem.cpp
+++ b/pcsx2/IopMem.cpp
@@ -23,10 +23,10 @@
 #include "DEV9/DEV9.h"
 #include "IopHw.h"
 
-uptr *psxMemWLUT = NULL;
-const uptr *psxMemRLUT = NULL;
+uptr *psxMemWLUT = nullptr;
+const uptr *psxMemRLUT = nullptr;
 
-IopVM_MemoryAllocMess* iopMem = NULL;
+IopVM_MemoryAllocMess* iopMem = nullptr;
 
 alignas(__pagesize) u8 iopHw[Ps2MemSize::IopHardware];
 
@@ -104,6 +104,8 @@ void iopMemReset()
 	// this one looks like an old hack for some special write-only memory area,
 	// but leaving it in for reference (air)
 	//for (i=0; i<0x0008; i++) psxMemWLUT[i + 0xbfc0] = (uptr)&psR[i << 16];
+
+	std::memset(iopMem, 0, sizeof(*iopMem));
 }
 
 u8 iopMemRead8(u32 mem)

--- a/pcsx2/Memory.h
+++ b/pcsx2/Memory.h
@@ -126,5 +126,5 @@ static __fi void memRead128(u32 mem, mem128_t& out) { memRead128(mem, &out); }
 static __fi void memWrite128(u32 mem, const mem128_t* val)	{ vtlb_memWrite128(mem, r128_load(val)); }
 static __fi void memWrite128(u32 mem, const mem128_t& val)	{ vtlb_memWrite128(mem, r128_load(&val)); }
 
-
+extern void ba0W16(u32 mem, u16 value);
 extern u16 ba0R16(u32 mem);

--- a/pcsx2/SaveState.cpp
+++ b/pcsx2/SaveState.cpp
@@ -218,6 +218,7 @@ bool SaveStateBase::FreezeInternals()
 		return false;
 
 	bool okay = rcntFreeze();
+	okay = okay && memFreeze();
 	okay = okay && gsFreeze();
 	okay = okay && vuMicroFreeze();
 	okay = okay && vuJITFreeze();

--- a/pcsx2/SaveState.h
+++ b/pcsx2/SaveState.h
@@ -37,7 +37,7 @@ enum class FreezeAction
 // [SAVEVERSION+]
 // This informs the auto updater that the users savestates will be invalidated.
 
-static const u32 g_SaveVersion = (0x9A4A << 16) | 0x0000;
+static const u32 g_SaveVersion = (0x9A4B << 16) | 0x0000;
 
 
 // the freezing data between submodules and core

--- a/pcsx2/SaveState.h
+++ b/pcsx2/SaveState.h
@@ -37,7 +37,7 @@ enum class FreezeAction
 // [SAVEVERSION+]
 // This informs the auto updater that the users savestates will be invalidated.
 
-static const u32 g_SaveVersion = (0x9A49 << 16) | 0x0000;
+static const u32 g_SaveVersion = (0x9A4A << 16) | 0x0000;
 
 
 // the freezing data between submodules and core
@@ -204,6 +204,7 @@ protected:
 	bool vmFreeze();
 	bool mtvuFreeze();
 	bool rcntFreeze();
+	bool memFreeze();
 	bool vuMicroFreeze();
 	bool vuJITFreeze();
 	bool vif0Freeze();

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -1240,6 +1240,14 @@ bool VMManager::Initialize(VMBootParameters boot_params)
 	s_target_speed = GetTargetSpeedForLimiterMode(s_limiter_mode);
 	s_use_vsync_for_timing = false;
 
+	s_cpu_implementation_changed = false;
+	s_cpu_provider_pack->ApplyConfig();
+	SetCPUState(EmuConfig.Cpu.sseMXCSR, EmuConfig.Cpu.sseVU0MXCSR, EmuConfig.Cpu.sseVU1MXCSR);
+	SysClearExecutionCache();
+	memBindConditionalHandlers();
+	SysMemory::Reset();
+	cpuReset();
+
 	Console.WriteLn("Opening GS...");
 	s_gs_open_on_initialize = MTGS::IsOpen();
 	if (!s_gs_open_on_initialize && !MTGS::WaitForOpen())
@@ -1338,13 +1346,6 @@ bool VMManager::Initialize(VMBootParameters boot_params)
 	s_mxcsr_saved = static_cast<u32>(a64_getfpcr());
 #endif
 
-	s_cpu_implementation_changed = false;
-	s_cpu_provider_pack->ApplyConfig();
-	SetCPUState(EmuConfig.Cpu.sseMXCSR, EmuConfig.Cpu.sseVU0MXCSR, EmuConfig.Cpu.sseVU1MXCSR);
-	SysClearExecutionCache();
-	memBindConditionalHandlers();
-	SysMemory::Reset();
-	cpuReset();
 	hwReset();
 
 	Console.WriteLn("VM subsystems initialized in %.2f ms", init_timer.GetTimeMilliseconds());


### PR DESCRIPTION
### Description of Changes
Fix up some reset behaviour to make it more determinate.
Default to interlaced video signal.

### Rationale behind Changes
Indeterminate behaviour is bad.

### Suggested Testing Steps
Test booting games. Fifa 2004 is a good one as it will fail to boot if the interlace mode is wrong, possibly Petit Copter 2 too
