### PR TITLE
DEV9: fix incorrect max hdd size

### DIFF
--- a/pcsx2/DEV9/ATA/ATA_Info.cpp
+++ b/pcsx2/DEV9/ATA/ATA_Info.cpp
@@ -47,8 +47,8 @@ void ATA::WritePaddedString(u8* data, int* index, const std::string& value, u32 
 void ATA::CreateHDDinfo(u64 sizeSectors)
 {
 	//PS2 is limited to 32bit size HDD (2TB), however,
-	//we don't yet support 48bit, so limit to 24bit size
-	constexpr u32 maxSize = 1 << 24;
+	//we don't yet support 48bit, so limit to 28bit size
+	constexpr u32 maxSize = (1 << 28) - 1; // 128Gb
 	sizeSectors = std::min<u32>(sizeSectors, maxSize);
 
 	constexpr u16 sectorSize = 512;


### PR DESCRIPTION
PS2 support 28-bit addressing not the the 24-bit addressing. 24-bit addressing is limited by 8Gb storage, while 28-bit is limited by 128Gb

### Description of Changes
Change hdd max size from 8Gb to 128Gb

### Rationale behind Changes
Currently, games with official HDD support very fast reach the limit of 8Gb and cannot be installed pass that mark.

### Suggested Testing Steps
Run any app that shows hdd size or free space (launchelf for example). Now it will shows correct size/free space.
