### PR TITLE
GameDB: Fixes for Boku no Natsuyasumi 2

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -7449,6 +7449,8 @@ SCPS-15026:
   name-sort: ぼくのなつやすみ2 うみのぼうけんへん
   name-en: "Boku no Natsuyasumi 2 - Umi no Bouken-hen"
   region: "NTSC-J"
+  gsHWFixes:
+    roundSprite: 1 # Fixes menu text.
 SCPS-15027:
   name: ポポロクロイス〜はじまりの冒険〜 通常版 [初回生産]
   name-sort: ぽぽろくろいす〜はじまりのぼうけん〜 つうじょうばん [しょかいせいさん]
@@ -8501,6 +8503,8 @@ SCPS-19303:
   name-sort: ぼくのなつやすみ2 うみのぼうけんへん PS2 the Best
   name-en: "Boku no Natsuyasumi 2 [PS2 The Best]"
   region: "NTSC-J"
+  gsHWFixes:
+    roundSprite: 1 # Fixes menu text.
 SCPS-19304:
   name: グランツーリスモ 4 “プロローグ版” PS2 the Best
   name-sort: ぐらんつーりすも 4 “ぷろろーぐばん” PS2 the Best


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
This PR fixes the menu text artifacts by enabling Round Sprite Half.

Master:
![Screenshot_20231217_203219](https://github.com/PCSX2/pcsx2/assets/14798312/95ef0dc3-dfa0-43b1-aeac-b765b66cee74)

PR:
![Screenshot_20231217_203238](https://github.com/PCSX2/pcsx2/assets/14798312/821b3d8d-a1a4-482b-85f6-61775aecf702)

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Artifacting bad

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Make sure i didn't miss other things.
