### PR TITLE
Qt: Fix game properties dialogs keeping app open

### DIFF
--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -552,6 +552,8 @@ void MainWindow::destroySubWindows()
 		m_settings_window->deleteLater();
 		m_settings_window = nullptr;
 	}
+
+	SettingsWindow::closeGamePropertiesDialogs();
 }
 
 void MainWindow::onScreenshotActionTriggered()

--- a/pcsx2-qt/Settings/SettingsWindow.cpp
+++ b/pcsx2-qt/Settings/SettingsWindow.cpp
@@ -645,3 +645,11 @@ void SettingsWindow::openGamePropertiesDialog(const GameList::Entry* game, const
 	dialog->show();
 }
 
+void SettingsWindow::closeGamePropertiesDialogs()
+{
+	for (SettingsWindow* dialog : s_open_game_properties_dialogs)
+	{
+		dialog->close();
+		dialog->deleteLater();
+	}
+}

--- a/pcsx2-qt/Settings/SettingsWindow.h
+++ b/pcsx2-qt/Settings/SettingsWindow.h
@@ -56,6 +56,7 @@ public:
 	~SettingsWindow();
 
 	static void openGamePropertiesDialog(const GameList::Entry* game, const std::string_view& title, std::string serial, u32 disc_crc);
+	static void closeGamePropertiesDialogs();
 
 	SettingsInterface* getSettingsInterface() const;
 	__fi bool isPerGameSettings() const { return static_cast<bool>(m_sif); }


### PR DESCRIPTION
### Description of Changes

Since per-game settings windows aren't parented, they don't close with the main window. Explicitly close them.

### Rationale behind Changes

Closing the main window should close PCSX2 completely.

### Suggested Testing Steps

Close main window with a per-game settings/game properties window open. Game properties windows should auto-close.
