### PR TITLE
MCD: Correctly wait 60 frames for eject timeout

### DIFF
--- a/pcsx2/SIO/Sio.cpp
+++ b/pcsx2/SIO/Sio.cpp
@@ -100,7 +100,7 @@ void AutoEject::Set(size_t port, size_t slot)
 {
 	if (mcds[port][slot].autoEjectTicks == 0)
 	{
-		mcds[port][slot].autoEjectTicks = 1; // 1 second is enough.
+		mcds[port][slot].autoEjectTicks = 60; // 60 frames is enough.
 		mcds[port][slot].term = 0x55; // Reset terminator to default (0x55), forces the PS2 to recheck the memcard.
 	}
 }


### PR DESCRIPTION
### Description of Changes
Wait 60 (maybe 59?) vsyncs between eject events for memcards.

### Rationale behind Changes
It was waiting 1 frame before, however that same frame was the one it got the UI event, so it was basically immediate, so the PS2 never saw the card change, frying your card.

### Suggested Testing Steps
Already tested
