### PR TITLE
Memcard: Fix terminator not properly flagging ejections

### DIFF
--- a/pcsx2/SIO/Sio.cpp
+++ b/pcsx2/SIO/Sio.cpp
@@ -101,7 +101,7 @@ void AutoEject::Set(size_t port, size_t slot)
 	if (mcds[port][slot].autoEjectTicks == 0)
 	{
 		mcds[port][slot].autoEjectTicks = 60; // 60 frames is enough.
-		mcds[port][slot].term = 0x55; // Reset terminator to default (0x55), forces the PS2 to recheck the memcard.
+		mcds[port][slot].term = Terminator::NOT_READY; // Reset terminator to NOT_READY (0x66), forces the PS2 to recheck the memcard.
 	}
 }
 

--- a/pcsx2/SIO/Sio2.cpp
+++ b/pcsx2/SIO/Sio2.cpp
@@ -265,12 +265,12 @@ void Sio2::Memcard()
 	if (mcd->autoEjectTicks)
 	{
 		SetRecv1(Recv1::DISCONNECTED);
-		g_Sio2FifoOut.push_back(0x00); // Because Sio2::Write pops the first g_Sio2FifoIn member
+		g_Sio2FifoOut.push_back(0xff); // Because Sio2::Write pops the first g_Sio2FifoIn member
 
 		while (!g_Sio2FifoIn.empty())
 		{
 			g_Sio2FifoIn.pop_front();
-			g_Sio2FifoOut.push_back(0x00);
+			g_Sio2FifoOut.push_back(0xff);
 		}
 
 		return;

--- a/pcsx2/SIO/SioTypes.h
+++ b/pcsx2/SIO/SioTypes.h
@@ -170,5 +170,6 @@ namespace Recv3
 
 namespace Terminator
 {
-	static constexpr u32 DEFAULT = 0x55;
+	static constexpr u32 NOT_READY = 0x66;
+	static constexpr u32 READY = 0x55;
 } // namespace Terminator


### PR DESCRIPTION
### Description of Changes
Adjustments from disassembly and some manual tests to make games properly detect the terminator has reset and flagged a card as ejected.

### Rationale behind Changes
Fixes issues where terminator was still not being picked up as an indicator that a card was ejected; in such cases the time ejected was not enough on its own to warn the game, and cards were still vulnerable.

### Suggested Testing Steps
Test basic load/save functionality. Eject and insert cards, then try again. Load a savestate, then try again.
