### PR TITLE
GS: Move texture coordinate rounding to vertex trace

### DIFF
--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -383,7 +383,6 @@ public:
 	virtual void UpdateSettings(const Pcsx2Config::GSOptions& old_config);
 
 	void Flush(GSFlushReason reason);
-	u32 CalcMask(int exp, int max_exp);
 	void FlushPrim();
 	bool TestDrawChanged();
 	void FlushWrite();

--- a/pcsx2/GS/Renderers/Common/GSVertexTrace.cpp
+++ b/pcsx2/GS/Renderers/Common/GSVertexTrace.cpp
@@ -24,7 +24,7 @@ GSVertexTrace::GSVertexTrace(const GSState* state, bool provoking_vertex_first)
 	MULTI_ISA_SELECT(GSVertexTracePopulateFunctions)(*this, provoking_vertex_first);
 }
 
-void GSVertexTrace::Update(const void* vertex, const u16* index, int v_count, int i_count, GS_PRIM_CLASS primclass)
+void GSVertexTrace::Update(void* vertex, const u16* index, int v_count, int i_count, GS_PRIM_CLASS primclass)
 {
 	if (i_count == 0)
 		return;

--- a/pcsx2/GS/Renderers/Common/GSVertexTrace.h
+++ b/pcsx2/GS/Renderers/Common/GSVertexTrace.h
@@ -49,7 +49,7 @@ public:
 protected:
 	const GSState* m_state;
 
-	typedef void (*FindMinMaxPtr)(GSVertexTrace& vt, const void* vertex, const u16* index, int count);
+	typedef void (*FindMinMaxPtr)(GSVertexTrace& vt, void* vertex, const u16* index, int count);
 
 	FindMinMaxPtr m_fmm[2][2][2][2][4];
 
@@ -77,7 +77,7 @@ public:
 public:
 	GSVertexTrace(const GSState* state, bool provoking_vertex_first);
 
-	void Update(const void* vertex, const u16* index, int v_count, int i_count, GS_PRIM_CLASS primclass);
+	void Update(void* vertex, const u16* index, int v_count, int i_count, GS_PRIM_CLASS primclass);
 
 	bool IsLinear() const { return m_filter.opt_linear; }
 	bool IsRealLinear() const { return m_filter.linear; }


### PR DESCRIPTION
### Description of Changes

#10281 introduced rounding of texture coordinates, but restricted it to sprites, and flat triangles.

I wasn't keen on the extra loop, so originally I planned to move it onto the GPU, but the need to update the vertex trace shattered my hopes and dreams. We can't even cheaply compute it on the min/max, because min/max STQ isn't tracked, only the un-normalized texture coordinates.

So I moved it into the vertex trace instead. But we can't skip it for flat triangles, because we don't know if they're flat yet. So now we do it for everything. Seems to have very negligible, if any effect on performance.

1396 dumps changed, but nothing really noticeable, some very minor texture movement.

### Rationale behind Changes

Vroom vroom

### Suggested Testing Steps

Test performance, make sure nothing is broken with a few games
