### PR TITLE
GS:MTL: Properly handle hdr rendering to cleared textures

### DIFF
--- a/pcsx2/GS/Renderers/Metal/GSDeviceMTL.h
+++ b/pcsx2/GS/Renderers/Metal/GSDeviceMTL.h
@@ -262,11 +262,11 @@ public:
 	MRCOwned<id<MTLRenderPipelineState>> m_stencil_clear_pipeline;
 	MRCOwned<id<MTLRenderPipelineState>> m_primid_init_pipeline[2][2];
 	MRCOwned<id<MTLRenderPipelineState>> m_hdr_init_pipeline;
+	MRCOwned<id<MTLRenderPipelineState>> m_hdr_clear_pipeline;
 	MRCOwned<id<MTLRenderPipelineState>> m_hdr_resolve_pipeline;
 	MRCOwned<id<MTLRenderPipelineState>> m_fxaa_pipeline;
 	MRCOwned<id<MTLRenderPipelineState>> m_shadeboost_pipeline;
 	MRCOwned<id<MTLRenderPipelineState>> m_imgui_pipeline;
-	MRCOwned<id<MTLRenderPipelineState>> m_imgui_pipeline_a8;
 
 	MRCOwned<id<MTLFunction>> m_hw_vs[1 << 5];
 	std::unordered_map<PSSelector, MRCOwned<id<MTLFunction>>> m_hw_ps;

--- a/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
+++ b/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
@@ -1054,6 +1054,7 @@ bool GSDeviceMTL::Create()
 	m_clut_pipeline[1] = MakePipeline(pdesc, fs_triangle, LoadShader(@"ps_convert_clut_8"), @"8-bit CLUT Update");
 	pdesc.colorAttachments[0].pixelFormat = ConvertPixelFormat(GSTexture::Format::HDRColor);
 	m_hdr_init_pipeline = MakePipeline(pdesc, fs_triangle, LoadShader(@"ps_hdr_init"), @"HDR Init");
+	m_hdr_clear_pipeline = MakePipeline(pdesc, fs_triangle, LoadShader(@"ps_clear"), @"HDR Clear");
 	pdesc.colorAttachments[0].pixelFormat = MTLPixelFormatInvalid;
 	pdesc.stencilAttachmentPixelFormat = MTLPixelFormatDepth32Float_Stencil8;
 	m_datm_pipeline[0] = MakePipeline(pdesc, fs_triangle, LoadShader(@"ps_datm0"), @"datm0");
@@ -2150,11 +2151,27 @@ void GSDeviceMTL::RenderHW(GSHWDrawConfig& config)
 	if (config.ps.hdr)
 	{
 		GSVector2i size = config.rt->GetSize();
-		hdr_rt = CreateRenderTarget(size.x, size.y, GSTexture::Format::HDRColor);
-		BeginRenderPass(@"HDR Init", hdr_rt, MTLLoadActionDontCare, nullptr, MTLLoadActionDontCare);
-		RenderCopy(config.rt, m_hdr_init_pipeline, config.drawarea);
-		rt = hdr_rt;
-		g_perfmon.Put(GSPerfMon::TextureCopies, 1);
+		rt = hdr_rt = CreateRenderTarget(size.x, size.y, GSTexture::Format::HDRColor, false);
+		switch (config.rt->GetState())
+		{
+			case GSTexture::State::Dirty:
+				BeginRenderPass(@"HDR Init", hdr_rt, MTLLoadActionDontCare, nullptr, MTLLoadActionDontCare);
+				RenderCopy(config.rt, m_hdr_init_pipeline, config.drawarea);
+				g_perfmon.Put(GSPerfMon::TextureCopies, 1);
+				break;
+
+			case GSTexture::State::Cleared:
+			{
+				BeginRenderPass(@"HDR Clear", hdr_rt, MTLLoadActionDontCare, nullptr, MTLLoadActionDontCare);
+				GSVector4 color = GSVector4::rgba32(config.rt->GetClearColor()) / GSVector4::cxpr(65535, 65535, 65535, 255);
+				[m_current_render.encoder setFragmentBytes:&color length:sizeof(color) atIndex:GSMTLBufferIndexUniforms];
+				RenderCopy(nullptr, m_hdr_clear_pipeline, config.drawarea);
+				break;
+			}
+
+			case GSTexture::State::Invalidated:
+				break;
+		}
 	}
 
 	// Try to reduce render pass restarts

--- a/pcsx2/GS/Renderers/Metal/convert.metal
+++ b/pcsx2/GS/Renderers/Metal/convert.metal
@@ -89,6 +89,11 @@ fragment float4 ps_copy_fs(float4 p [[position]], DirectReadTextureIn<float> tex
 	return tex.read(p);
 }
 
+fragment float4 ps_clear(float4 p [[position]], constant float4& color [[buffer(GSMTLBufferIndexUniforms)]])
+{
+	return color;
+}
+
 fragment void ps_datm1(float4 p [[position]], DirectReadTextureIn<float> tex)
 {
 	if (tex.read(p).a < (127.5f / 255.f))


### PR DESCRIPTION
### Description of Changes
Properly handles hdr rendering to cleared textures

### Rationale behind Changes
HDR rendering starts by rendering to an hdr texture, then copying that to the original texture, which means that any clears don't get noticed by the BeginRenderPass code.  We could just `FlushClears` the main rt before hdr, but we might as well save a texture copy by just clearing the HDR target instead.

### Suggested Testing Steps
Test [this Ico gsdump](https://github.com/PCSX2/pcsx2/files/13747729/Ico-ShadowTrails.gs.xz.zip)