### PR TITLE
GS:MTL: Give labels to textures

### DIFF
--- a/pcsx2/GS/Renderers/Metal/GSDeviceMTL.h
+++ b/pcsx2/GS/Renderers/Metal/GSDeviceMTL.h
@@ -331,6 +331,24 @@ public:
 	std::vector<DebugEntry> m_debug_entries;
 	u32 m_debug_group_level = 0;
 
+	enum class TextureLabel
+	{
+		ColorRT,
+		HDRRT,
+		U16RT,
+		U32RT,
+		DepthStencil,
+		PrimIDTexture,
+		RWTexture,
+		Unorm8Texture,
+		Texture,
+		ReplacementTexture,
+		Other,
+		Last = Other,
+	};
+	u32 m_texture_counts[static_cast<u32>(TextureLabel::Last) + 1] = {};
+	u32 m_dl_texture_count = 0;
+
 	GSDeviceMTL();
 	~GSDeviceMTL() override;
 

--- a/pcsx2/GS/Renderers/Metal/GSTextureMTL.mm
+++ b/pcsx2/GS/Renderers/Metal/GSTextureMTL.mm
@@ -164,7 +164,7 @@ GSDownloadTextureMTL::GSDownloadTextureMTL(GSDeviceMTL* dev, MRCOwned<id<MTLBuff
 GSDownloadTextureMTL::~GSDownloadTextureMTL() = default;
 
 std::unique_ptr<GSDownloadTextureMTL> GSDownloadTextureMTL::Create(GSDeviceMTL* dev, u32 width, u32 height, GSTexture::Format format)
-{
+{ @autoreleasepool {
 	const u32 buffer_size = GetBufferSize(width, height, format, PITCH_ALIGNMENT);
 
 	MRCOwned<id<MTLBuffer>> buffer = MRCTransfer([dev->m_dev.dev newBufferWithLength:buffer_size options:MTLResourceStorageModeShared]);
@@ -174,8 +174,9 @@ std::unique_ptr<GSDownloadTextureMTL> GSDownloadTextureMTL::Create(GSDeviceMTL* 
 		return {};
 	}
 
+	[buffer setLabel:[NSString stringWithFormat:@"Download Texture %d", dev->m_dl_texture_count++]];
 	return std::unique_ptr<GSDownloadTextureMTL>(new GSDownloadTextureMTL(dev, buffer, width, height, format));
-}
+}}
 
 void GSDownloadTextureMTL::CopyFromTexture(
 	const GSVector4i& drc, GSTexture* stex, const GSVector4i& src, u32 src_level, bool use_transfer_pitch)


### PR DESCRIPTION
### Description of Changes
Adds labels to textures based on their usage and a counter

### Rationale behind Changes
If a texture doesn't have a label, Xcode's GPU debugger gives it the amazing label of `sprintf(label, "Texture %p", this)`, which is very non-memorable and makes keeping track of which textures are going where much more painful than it needs to be.

### Suggested Testing Steps
- [x] Take a gpu trace and look at it in the Xcode trace debugger
  <details>
  <summary>Before</summary>
  
  <img width="1536" alt="image" src="https://github.com/PCSX2/pcsx2/assets/3315070/eb639f77-2616-4700-b0e8-201eb7cee45d">
  </details>
  <details>
  <summary>After</Summary>

  <img width="1536" alt="image" src="https://github.com/PCSX2/pcsx2/assets/3315070/3db27b0c-fe74-4cb1-8089-acd511d661af">
  </details>