### PR TITLE
GS/HW: Always mark fetched/created depth targets as used

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -2373,7 +2373,7 @@ void GSRendererHW::Draw()
 		if (!ds)
 		{
 			ds = g_texture_cache->CreateTarget(ZBUF_TEX0, t_size, GetValidSize(src), target_scale, GSTextureCache::DepthStencil,
-				m_cached_ctx.DepthWrite(), 0, false, force_preload, preserve_depth, m_r, src);
+				true, 0, false, force_preload, preserve_depth, m_r, src);
 			if (unlikely(!ds))
 			{
 				GL_INS("ERROR: Failed to create ZBUF target, skipping.");
@@ -5808,12 +5808,8 @@ bool GSRendererHW::DetectDoubleHalfClear(bool& no_rt, bool& no_ds)
 		return false;
 
 	GSTextureCache::Target* half_point = g_texture_cache->GetExactTarget(half << 5, m_cached_ctx.FRAME.FBW, clear_depth ? GSTextureCache::RenderTarget : GSTextureCache::DepthStencil, half << 5);
-
 	if (half_point)
-	{
-		half_point = nullptr;
 		return false;
-	}
 
 	// Don't allow double half clear to go through when the number of bits written through FRAME and Z are different.
 	// GTA: LCS does this setup, along with a few other games. Thankfully if it's a zero clear, we'll clear both


### PR DESCRIPTION
### Description of Changes

Mercenaries - Playground of Destruction double half clears from 0x2000 -> 0x2DFF, with the ZBUF at 0x2700. Apparently there's some prior target at this BP, because the half_point check was failing.

~~So, restrict said check to only targets created in the current frame. Doesn't seem to be any casualties on the current GS dump collection.~~

Turns out this was actually a channel shuffle from the previous frame that was getting missed, because it never wrote to Z on this target with the draw... so that is the proper fix.

Also fixes a Vulkan spec violation, but it was probably harmless.

### Rationale behind Changes

Fixes half-screen garbage in Mercenaries - Playground of Destruction after certain triggers.

### Suggested Testing Steps

Test Mercenaries.
