### PR TITLE
GS/HW: Fix 16bit depth conversion in shuffles + fix NFSU CRC

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSHwHack.cpp
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.cpp
@@ -636,9 +636,9 @@ bool GSHwHack::GSC_NFSUndercover(GSRendererHW& r, int& skip)
 		v[0].XYZ.Y = static_cast<u16>(RCONTEXT->XYOFFSET.OFY + (r.m_r.w << 4));
 		v[0].U = r.m_r.z << 4;
 		v[0].V = r.m_r.w << 4;
-		RCONTEXT->scissor.in.z = r.m_r.z;
+		RCONTEXT->scissor.in.z = r.m_r.z * 2;
 		RCONTEXT->scissor.in.w = r.m_r.w;
-		r.m_vt.m_max.p.x = r.m_r.z;
+		r.m_vt.m_max.p.x = r.m_r.z * 2;
 		r.m_vt.m_max.p.y = r.m_r.w;
 		r.m_vt.m_max.t.x = r.m_r.z;
 		r.m_vt.m_max.t.y = r.m_r.w;

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -4298,7 +4298,7 @@ __ri void GSRendererHW::EmulateTextureSampler(const GSTextureCache::Target* rt, 
 		// Require a float conversion if the texure is a depth otherwise uses Integral scaling
 		if (psm.depth)
 		{
-			m_conf.ps.depth_fmt = (tex->m_texture->GetType() != GSTexture::Type::DepthStencil) ? 3 : 1;
+			m_conf.ps.depth_fmt = (tex->m_texture->GetType() != GSTexture::Type::DepthStencil) ? 3 : tex->m_32_bits_fmt ? 1 : 2;
 		}
 
 		// Shuffle is a 16 bits format, so aem is always required


### PR DESCRIPTION
### Description of Changes
Fixes the 16bit depth conversion on shuffles
Also fix the size of the shuffle draw in the CRC hack for NFS Undercover.  Handling the shuffle properly is likely possible, but would need a lot of retooling of the split shuffle handling, and I suspect it will break things.

### Rationale behind Changes
When the texture was actually 16bit depth on a shuffle, it was telling the shader that the format was actually 32bit, so the conversion was incorrect, breaking the shuffle. Used as a DOF effect.
The CRC was getting trolled by the shuffle code which was halving the width of the draw.

### Suggested Testing Steps
Test NFS Undercover, nothing else really affected.

Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/f176b008-7608-4286-8a0e-2d4955e22176)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/287eab44-45d2-4d33-8444-5c2dbbdfda42)
