### PR TITLE
GS/HW: Fix source partial preload alpha tracking behaviour

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -5432,8 +5432,9 @@ void GSTextureCache::Source::PreloadLevel(int level)
 		std::pair<u8, u8> mip_alpha_minmax;
 		PreloadTexture(m_TEX0, m_TEXA, m_region.AdjustForMipmap(level), g_gs_renderer->m_mem, m_palette != nullptr,
 			m_texture, level, &mip_alpha_minmax);
+		// The entire alpha is always recalculated
 		m_alpha_minmax.first = std::min(m_alpha_minmax.first, mip_alpha_minmax.first);
-		m_alpha_minmax.second = std::min(m_alpha_minmax.second, mip_alpha_minmax.second);
+		m_alpha_minmax.second = std::max(m_alpha_minmax.second, mip_alpha_minmax.second);
 	}
 }
 
@@ -6539,6 +6540,11 @@ void GSTextureCache::PreloadTexture(const GIFRegTEX0& TEX0, const GIFRegTEXA& TE
 	{
 		rtx(mem, off, block_rect, map.bits, map.pitch, TEXA);
 		tex->Unmap();
+		// Temporary, can't read the texture here so we need to come up with a smarter solution, but this will get around it being broken.
+		if (alpha_minmax)
+		{
+			*alpha_minmax = std::make_pair<u8, u8>(0, 255);
+		}
 	}
 	else
 	{


### PR DESCRIPTION
### Description of Changes
Fixes up source alpha tracking behaviour when using partial preloading

### Rationale behind Changes
It was doing the wrong comparison, so the alpha never got set.

### Suggested Testing Steps
Test The Getaway, make sure the intro video shows

The Getaway
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/9f97d030-0308-4127-bfd3-c7279bd6e2a9)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/d846a48b-5dbe-485c-8f3b-96ccbb8bea72)
