### PR TITLE
GS/HW: Fix texture shuffles with reversed co-ords

### DIFF
--- a/pcsx2/GS/GSPerfMon.cpp
+++ b/pcsx2/GS/GSPerfMon.cpp
@@ -30,10 +30,12 @@ void GSPerfMon::Reset()
 	std::memset(m_stats, 0, sizeof(m_stats));
 }
 
-void GSPerfMon::EndFrame()
+void GSPerfMon::EndFrame(bool frame_only)
 {
 	m_frame++;
-	m_count++;
+
+	if(!frame_only)
+		m_count++;
 }
 
 void GSPerfMon::Update()

--- a/pcsx2/GS/GSPerfMon.h
+++ b/pcsx2/GS/GSPerfMon.h
@@ -52,7 +52,7 @@ public:
 
 	void SetFrame(u64 frame) { m_frame = frame; }
 	u64 GetFrame() { return m_frame; }
-	void EndFrame();
+	void EndFrame(bool frame_only);
 
 	void Put(counter_t c, double val) { m_counters[c] += val; }
 	double GetCounter(counter_t c) { return m_counters[c]; }

--- a/pcsx2/GS/Renderers/Common/GSRenderer.cpp
+++ b/pcsx2/GS/Renderers/Common/GSRenderer.cpp
@@ -602,7 +602,9 @@ void GSRenderer::VSync(u32 field, bool registers_written, bool idle_frame)
 	if (!idle_frame)
 		g_gs_device->AgePool();
 
-	g_perfmon.EndFrame();
+
+	g_perfmon.EndFrame(idle_frame);
+
 	if ((g_perfmon.GetFrame() & 0x1f) == 0)
 		g_perfmon.Update();
 

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -345,7 +345,9 @@ void GSRendererHW::ConvertSpriteTextureShuffle(bool& write_ba, bool& read_ba, GS
 	const u32 count = m_vertex.next;
 	GSVertex* v = &m_vertex.buff[0];
 	const GIFRegXYOFFSET& o = m_context->XYOFFSET;
-	const GSVertex first_vert = (v[0].XYZ.X <= v[m_vertex.tail - 2].XYZ.X) ? v[0] : v[m_vertex.tail - 2];
+	// Could be drawing upside down or just back to front on the actual verts.
+	const GSVertex* start_verts = (v[0].XYZ.X <= v[m_vertex.tail - 2].XYZ.X) ? &v[0] : &v[m_vertex.tail - 2];
+	const GSVertex first_vert = (start_verts[0].XYZ.X <= start_verts[1].XYZ.X) ? start_verts[0] : start_verts[1];
 	// vertex position is 8 to 16 pixels, therefore it is the 16-31 bits of the colors
 	const int pos = (first_vert.XYZ.X - o.OFX) & 0xFF;
 	write_ba = (pos > 112 && pos < 136);


### PR DESCRIPTION
### Description of Changes
Fixes games which reverse their texture shuffle coordinates, causing bad detections in our code.  Mostly fixes fog effects.

### Rationale behind Changes
This was getting false shuffles, causing the wrong thing to be shuffled out.

Also fixed the performance metrics for games which have idle frames, they were erroneously getting divided by two

### Suggested Testing Steps
Test the games listed below, smoke test others, though dump run says everything else is unchanged.

Fixes #7292 

Colin McRae Rally 2005 (Though still broken, only less):
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/a7213777-bb64-4a57-9547-fd7fbb1f0f2e)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/7357fc7c-8ff8-4914-a07a-aff244436bbb)

Grand Prix Challenge:
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/811ae97f-b5d9-4180-a75b-436e4754889a)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/05c4cd52-6eca-49e2-9122-9c0f4faf22cc)

Test Drive Unlimited:
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/92cc1182-3210-4f22-bd6c-ca18e328858b)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/34d44d32-c074-4891-bf47-09918999d1f0)

Transformers:
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/9aec30dd-5108-49cf-a03c-337f91c06398)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/e40c1f3c-5a5e-4246-b372-d1b59c79153d)
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/0274aed3-17fe-484b-92bc-f517478bb407)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/8bace768-a1c4-4bc9-8738-90cb5e291885)
