### PR TITLE
QT: Return ability to pass launch arguments with CLI option -gameargs

### DIFF
--- a/pcsx2-qt/QtHost.cpp
+++ b/pcsx2-qt/QtHost.cpp
@@ -1253,7 +1253,7 @@ bool QtHost::InitializeConfig()
 		}
 
 		VMManager::SetDefaultSettings(*s_base_settings_interface, true, true, true, true, true);
-		
+
 		// Don't save if we're running the setup wizard. We want to run it next time if they don't finish it.
 		if (!s_run_setup_wizard)
 			SaveSettings();
@@ -1542,6 +1542,7 @@ void QtHost::PrintCommandLineHelp(const std::string_view& progname)
 	std::fprintf(stderr, "  -batch: Enables batch mode (exits after shutting down).\n");
 	std::fprintf(stderr, "  -nogui: Hides main window while running (implies batch mode).\n");
 	std::fprintf(stderr, "  -elf <file>: Overrides the boot ELF with the specified filename.\n");
+	std::fprintf(stderr, "  -gameargs <string>: passes the specified quoted space-delimited string of launch arguments.\n");
 	std::fprintf(stderr, "  -disc <path>: Uses the specified host DVD drive as a source.\n");
 	std::fprintf(stderr, "  -logfile <path>: Writes the application log to path instead of emulog.txt.\n");
 	std::fprintf(stderr, "  -bios: Starts the BIOS (System Menu/OSDSYS).\n");
@@ -1634,6 +1635,11 @@ bool QtHost::ParseCommandLineOptions(const QStringList& args, std::shared_ptr<VM
 			else if (CHECK_ARG_PARAM(QStringLiteral("-elf")))
 			{
 				AutoBoot(autoboot)->elf_override = (++it)->toStdString();
+				continue;
+			}
+			else if (CHECK_ARG_PARAM(QStringLiteral("-gameargs")))
+			{
+				EmuConfig.CurrentGameArgs = (++it)->toStdString();
 				continue;
 			}
 			else if (CHECK_ARG_PARAM(QStringLiteral("-disc")))
@@ -1738,7 +1744,7 @@ bool QtHost::ParseCommandLineOptions(const QStringList& args, std::shared_ptr<VM
 	{
 		QMessageBox::critical(nullptr, QStringLiteral("Error"),
 			s_nogui_mode ? QStringLiteral("Cannot use no-gui mode, because no boot filename was specified.") :
-                           QStringLiteral("Cannot use batch mode, because no boot filename was specified."));
+						   QStringLiteral("Cannot use batch mode, because no boot filename was specified."));
 		return false;
 	}
 

--- a/pcsx2/R5900.cpp
+++ b/pcsx2/R5900.cpp
@@ -575,9 +575,8 @@ int ParseArgumentString(u32 arg_block)
 	if (!arg_block)
 		return 0;
 
-	int argc = 1; // one arg is guaranteed at least
-	g_argPtrs[0] = arg_block; // first arg is right here
-	bool wasSpace = false; // status of last char. scanned
+	int argc = 0;
+	bool wasSpace = true; // status of last char. scanned
 	int args_len = strlen((char *)PSM(arg_block));
 	for (int i = 0; i < args_len; i++)
 	{


### PR DESCRIPTION
### Description of Changes
Recreated https://github.com/PCSX2/pcsx2/pull/2576 for QT

### Rationale behind Changes
Useful feature for homebrew, but some retail games will also benefit from it. More details in PR mentioned earlier + below added an example of Splinter Cell command.

### Suggested Testing Steps
This can be tested in [Tom Clancy's Splinter Cell](http://redump.org/disc/3812/) cause this game support arguments (credits to @rickgaiser). If you mount an iso in virtual drive `/dev/rdisk2` then you can choose the following command to directly start the game and skip the main menu (MacOs command, Windows commands can be different):

```sh
./PCSX2.app/Contents/MacOS/PCSX2 -disc /dev/rdisk2 -elf /Volumes/SPLINTER_CELL/LOADER.PS2 -gameargs "cdrom0:\\LOADER.PS2;1 0_0_2 -wantload -ll -diskimage -restart -l=1 -v=13117"
```

It will boot directly into this screen:
![Tom Clancy's Splinter Cell  LOADER _SLES-51466_20231223220933](https://github.com/PCSX2/pcsx2/assets/621640/53a7b92e-2d7e-4807-b678-8921a737361d)

fixes https://github.com/PCSX2/pcsx2/issues/9762