### PR TITLE
GS/HW: Fix some channel shuffle and target match behaviour

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -3408,7 +3408,7 @@ __ri bool GSRendererHW::EmulateChannelShuffle(GSTextureCache::Target* src, bool 
 		// So far 2 games hit this code path. Urban Chaos and Tales of Abyss
 		// UC: will copy depth to green channel
 		// ToA: will copy depth to alpha channel
-		if ((m_cached_ctx.FRAME.FBMSK & 0xFF0000) == 0xFF0000)
+		if ((m_cached_ctx.FRAME.FBMSK & 0x00FF0000) == 0x00FF0000)
 		{
 			// Green channel is masked
 			GL_INS("Tales Of Abyss Crazyness (MSB 16b depth to Alpha)");
@@ -3443,13 +3443,15 @@ __ri bool GSRendererHW::EmulateChannelShuffle(GSTextureCache::Target* src, bool 
 	}
 	else if (m_cached_ctx.CLAMP.WMS == 3 && ((m_cached_ctx.CLAMP.MAXU & 0x8) == 8))
 	{
-		// Read either blue or Alpha. Let's go for Blue ;)
 		// MGS3/Kill Zone
-		GL_INS("Blue channel");
 		if (test_only)
 			return true;
 
-		m_conf.ps.channel = ChannelFetch_BLUE;
+		ChannelFetch channel_select = (m_cached_ctx.CLAMP.WMT != 3 || (m_cached_ctx.CLAMP.WMT == 3 && ((m_cached_ctx.CLAMP.MAXV & 0x2) == 0))) ? ChannelFetch_BLUE : ChannelFetch_ALPHA;
+
+		GL_INS("%s channel", (channel_select == ChannelFetch_BLUE) ? "blue" : "alpha");
+
+		m_conf.ps.channel = channel_select;
 	}
 	else if (m_cached_ctx.CLAMP.WMS == 3 && ((m_cached_ctx.CLAMP.MINU & 0x8) == 0))
 	{

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -466,18 +466,19 @@ void GSRendererHW::ConvertSpriteTextureShuffle(bool& write_ba, bool& read_ba, GS
 	if (PRIM->FST)
 	{
 		GL_INS("First vertex is  P: %d => %d    T: %d => %d", v[0].XYZ.X, v[1].XYZ.X, v[0].U, v[1].U);
-
+		const int reversed_pos = (v[0].XYZ.X > v[1].XYZ.X) ? 1 : 0;
+		const int reversed_U = (v[0].U > v[1].U) ? 1 : 0;
 		for (u32 i = 0; i < count; i += 2)
 		{
 			if (write_ba)
-				v[i].XYZ.X -= 128u;
+				v[i + reversed_pos].XYZ.X -= 128u;
 			else
-				v[i + 1].XYZ.X += 128u;
+				v[i + 1 - reversed_pos].XYZ.X += 128u;
 
 			if (read_ba)
-				v[i].U -= 128u;
+				v[i + reversed_U].U -= 128u;
 			else
-				v[i + 1].U += 128u;
+				v[i + 1 - reversed_U].U += 128u;
 
 			if (!half_bottom_vert)
 			{
@@ -503,18 +504,20 @@ void GSRendererHW::ConvertSpriteTextureShuffle(bool& write_ba, bool& read_ba, GS
 	{
 		const float offset_8pix = 8.0f / tw;
 		GL_INS("First vertex is  P: %d => %d    T: %f => %f (offset %f)", v[0].XYZ.X, v[1].XYZ.X, v[0].ST.S, v[1].ST.S, offset_8pix);
+		const int reversed_pos = (v[0].XYZ.X > v[1].XYZ.X) ? 1 : 0;
+		const int reversed_S = (v[0].ST.S > v[1].ST.S) ? 1 : 0;
 
 		for (u32 i = 0; i < count; i += 2)
 		{
 			if (write_ba)
-				v[i].XYZ.X -= 128u;
+				v[i + reversed_pos].XYZ.X -= 128u;
 			else
-				v[i + 1].XYZ.X += 128u;
+				v[i + 1 - reversed_pos].XYZ.X += 128u;
 
 			if (read_ba)
-				v[i].ST.S -= offset_8pix;
+				v[i + reversed_S].ST.S -= offset_8pix;
 			else
-				v[i + 1].ST.S += offset_8pix;
+				v[i + 1 - reversed_S].ST.S += offset_8pix;
 
 			if (!half_bottom_vert)
 			{
@@ -2627,8 +2630,8 @@ void GSRendererHW::Draw()
 				m_index.tail = 2;
 			}
 		}
-
-		if (rt && (!is_possible_mem_clear || rt->m_TEX0.PSM != FRAME_TEX0.PSM))
+		const bool blending_cd = PRIM->ABE && !m_context->ALPHA.IsOpaque();
+		if (rt && ((!is_possible_mem_clear || blending_cd) || rt->m_TEX0.PSM != FRAME_TEX0.PSM))
 		{
 			if (rt->m_TEX0.TBW != FRAME_TEX0.TBW && !m_cached_ctx.ZBUF.ZMSK && (m_cached_ctx.FRAME.FBMSK & 0xFF000000))
 			{

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.h
@@ -134,6 +134,7 @@ public:
 		int m_age = 0;
 		u32 m_end_block = MAX_BP; // Hint of the surface area.
 		bool m_32_bits_fmt = false; // Allow to detect the casting of 32 bits as 16 bits texture
+		bool m_was_dst_matched = false;
 		bool m_shared_texture = false;
 
 		__fi GSTexture* GetTexture() const { return m_texture; }


### PR DESCRIPTION
### Description of Changes
Fixes some behaviour for alpha shuffles, also fix handling of dst matches when target is used as a source or the entire content is invalidated.

### Rationale behind Changes
__Channel shuffle change__: Alpha just wasnt' handled, there was a note there saying "let's choose blue" like a flip of a coin.

__DST Matches change__: There were cases where games were using a target as a different format, or adding an alpha channel to a 24bit value, but things were getting out of sync.  Terminator 3 was using this with old data in the RGB (where the depth was), Final Fantasy X-2 used part of the Z buffer as a 16bit target, but this later got completely cleared and we weren't removing the target due to the valid size being different, now we invalidate dst matches based on the area drawn to them.

### Suggested Testing Steps
Check The Terminator 3 and the menus in Final Fantasy X-2.  Maybe a sprinkle of other games.

Final Fantasy X-2:
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/51613af7-6f55-493f-9c65-2fef4739893f)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/680c2068-b28b-41a1-8cbc-f2d97839ba1e)

Terminator 3:
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/4bd82401-9d3d-48fe-9200-04be2ba919e4)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/e6046e6b-5b28-4e91-b22c-a99c533f0757)

