### PR TITLE
SDLInputSource: Optionally load game_controller_db.txt from data dir

### DIFF
--- a/pcsx2/Input/SDLInputSource.h
+++ b/pcsx2/Input/SDLInputSource.h
@@ -68,7 +68,6 @@ private:
 	void ShutdownSubsystem();
 	void LoadSettings(SettingsInterface& si);
 	void SetHints();
-	bool LoadControllerDB();
 
 	ControllerDataVector::iterator GetControllerDataForJoystickId(int id);
 	ControllerDataVector::iterator GetControllerDataForPlayerId(int id);


### PR DESCRIPTION
### Description of Changes

For users with controllers that don't have a corresponding GameControllerDB entry, you had to create one, then replace the supplied `game_controller_db.txt` in resources.

This didn't work on Linux, because the AppImage/Flatpak is immutable. On MacOS, it requires re-signing the bundle.

So, load it from the data directory if the file exists there.

### Rationale behind Changes

Easier for users to support their broken-ass off-brand controllers.

### Suggested Testing Steps

Make sure controllers still work.
