### PR TITLE
x86/FPU: Always preserve sign in neg.s (Fix GT4 text)

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -314,7 +314,6 @@ PAPX-90512:
   region: "NTSC-J"
   clampModes:
     vuClampMode: 2 # Text in GT mode works.
-    # eeClampMode = 3  Text in races works.
   gsHWFixes:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
@@ -523,7 +522,6 @@ PBPX-95523:
     trilinearFiltering: 1
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
-  # eeClampMode = 3  Text in races works.
   # vuClampMode = 2  Text in GT mode works.
 PBPX-95524:
   name: "Gran Turismo 4 - Prologue [PlayStation 2 Racing Pack]"
@@ -534,7 +532,6 @@ PBPX-95524:
     trilinearFiltering: 1
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
-  # eeClampMode = 3  Text in races works.
   # vuClampMode = 2  Text in GT mode works.
 PBPX-95525:
   name: "Final Fantasy XII"
@@ -561,7 +558,6 @@ PBPX-95601:
     - "SCPS-19304"
     - "SCPS-15009"
     - "SCPS-55007"
-  # eeClampMode = 3  Text in races works.
 PCPX-96301:
   name: "I.Q Remix+ - Intelligent Qube"
   region: "NTSC-J"
@@ -767,7 +763,6 @@ PCPX-96649:
     trilinearFiltering: 1
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
-  # eeClampMode = 3  Text in races works.
 PCPX-96653:
   name: "Ratchet & Clank 3"
   region: "NTSC-J"
@@ -1176,7 +1171,6 @@ SCAJ-20066:
     - "SCPS-19304"
     - "SCPS-15009"
     - "SCPS-55007"
-  # eeClampMode = 3  Text in races works.
   # vuClampMode = 2  Text in GT mode works.
 SCAJ-20067:
   name: "GunGrave O.D."
@@ -2051,14 +2045,12 @@ SCAJ-30006:
     - "SCPS-19304"
     - "SCPS-15009"
     - "SCPS-55007"
-  # eeClampMode = 3  Text in races works.
 SCAJ-30007:
   name: "Gran Turismo 4"
   region: "NTSC-Unk"
   compat: 5
   clampModes:
     vuClampMode: 2 # Text in GT mode works.
-    # eeClampMode = 3  Text in races works.
   gsHWFixes:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
@@ -2069,7 +2061,6 @@ SCAJ-30008:
   region: "NTSC-Unk"
   clampModes:
     vuClampMode: 2 # Text in GT mode works.
-    # eeClampMode = 3  Text in races works.
   gsHWFixes:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
@@ -3135,7 +3126,6 @@ SCED-52455:
     trilinearFiltering: 1
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
-  # eeClampMode = 3  Text in races works.
   # vuClampMode = 2  Text in GT mode works.
 SCED-52461:
   name: "SingStar [Press Kit]"
@@ -4675,7 +4665,6 @@ SCES-51719:
   compat: 5
   clampModes:
     vuClampMode: 2 # Text in GT mode works.
-    # eeClampMode = 3  Text in races works.
   gsHWFixes:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
@@ -4923,7 +4912,6 @@ SCES-52438:
     - "SCES-51719"
     - "SCES-52438"
     - "SCES-50294"
-  # eeClampMode = 3  Text in races works.
   # vuClampMode = 2  Text in GT mode works.
 SCES-52456:
   name: "Ratchet & Clank 3"
@@ -6333,7 +6321,6 @@ SCKA-20022:
     trilinearFiltering: 1
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
-  # eeClampMode = 3  Text in races works.
   # vuClampMode = 2  Text in GT mode works.
 SCKA-20023:
   name: "Fatal Frame II"
@@ -6961,7 +6948,6 @@ SCKA-30001:
   region: "NTSC-K"
   clampModes:
     vuClampMode: 2 # Text in GT mode works.
-    # eeClampMode = 3  Text in races works.
   gsHWFixes:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
@@ -7645,7 +7631,6 @@ SCPS-15055:
     - "SCPS-19304"
     - "SCPS-15009"
     - "SCPS-55007"
-  # eeClampMode = 3  Text in races works.
   # vuClampMode = 2  Text in GT mode works.
 SCPS-15056:
   name: ラチェット＆クランク2 ガガガ！銀河のコマンドーっす
@@ -8212,7 +8197,6 @@ SCPS-17001:
   compat: 5
   clampModes:
     vuClampMode: 2 # Text in GT mode works.
-    # eeClampMode = 3  Text in races works.
   gsHWFixes:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
@@ -8466,7 +8450,6 @@ SCPS-19252:
   region: "NTSC-J"
   clampModes:
     vuClampMode: 2 # Text in GT mode works.
-    # eeClampMode = 3  Text in races works.
   gsHWFixes:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
@@ -8541,7 +8524,6 @@ SCPS-19304:
     - "SCPS-15009"
     - "SCPS-55007"
   # vuClampMode = 2  Text in GT mode works.
-  # eeClampMode = 3  Text in races works.
 SCPS-19305:
   name: SIREN PS2 the Best
   name-sort: SIREN PS2 the Best
@@ -9299,7 +9281,6 @@ SCUS-90682:
   region: "NTSC-U"
   clampModes:
     vuClampMode: 2 # Text in GT mode works.
-    # eeClampMode = 3  Text in races works.
   gsHWFixes:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
@@ -10109,7 +10090,6 @@ SCUS-97328:
   compat: 5
   clampModes:
     vuClampMode: 2 # Text in GT mode works.
-    # eeClampMode = 3  Text in races works.
   gsHWFixes:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
@@ -10503,7 +10483,6 @@ SCUS-97436:
   region: "NTSC-U"
   clampModes:
     vuClampMode: 2 # Text in GT mode works.
-    # eeClampMode = 3  Text in races works.
   gsHWFixes:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
@@ -10721,7 +10700,6 @@ SCUS-97483:
   region: "NTSC-U"
   clampModes:
     vuClampMode: 2 # Text in GT mode works.
-    # eeClampMode = 3  Text in races works.
   gsHWFixes:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1

--- a/pcsx2/x86/iFPU.cpp
+++ b/pcsx2/x86/iFPU.cpp
@@ -1669,7 +1669,10 @@ void recNEG_S_xmm(int info)
 
 	//xAND(ptr32[&fpuRegs.fprc[31]], ~(FPUflagO|FPUflagU)); // Clear O and U flags
 	xXOR.PS(xRegisterSSE(EEREC_D), ptr[&s_neg[0]]);
-	ClampValues(EEREC_D);
+
+	// Always preserve sign. Using float clamping here would result in
+	// +inf to become +fMax instead of -fMax, which is definitely wrong.
+	fpuFloat3(EEREC_D);
 }
 
 FPURECOMPILE_CONSTCODE(NEG_S, XMMINFO_WRITED | XMMINFO_READS);


### PR DESCRIPTION
### Description of Changes

Finally had the chance to look into this. The "Full Throttle" text getting stuck on screen seems to be due to the following block of instructions (NTSC-U, Version 1.01):

```
003A9820 sw   zero, 0x  14(a0)
003A9824 neg.s        f03, f00
003A9828 mul.s        f03, f03, f12
003A982C lwc1 f01, 0x   0(a0)
003A9830 mtc1 zero, f00
003A9834 lui  at, 0x3F80
003A9838 mtc1 at, f02
003A983C add.s        f01, f01, f03
003A9840 max.s        f00, f01, f00
003A9844 min.s        f00, f00, f02
003A9848 jr   ->ra
003A984C swc1      f00, 0x   0(a0)
```

Forcing full EE FPU clamping for this block fixes the text. But that's a janky solution, because it would mean finding the offsets for every release/revision. Instead, I noticed that we're using floating-point min/max, which means that negative NaNs get punted to positive FLT_MAX.

Notice the block starts with `neg.s`. With float clamping, `+nan` becomes `+FLT_MAX`, instead of actually changing the sign. So the result of the next multiplication would also have its sign inverted. This is what appears to cause the "Full Throttle" text to get stuck on the screen.

So, instead of using a higher clamp mode, we can just use integer clamping for `neg.s`. I can't think of why you'd actually want the sign of an input to not change, this behaviour seems very wrong, but it is a global change affecting the default clamping level, so there is some risk. But I'm hoping it should be fine.

### Rationale behind Changes

Fixes "Full Throttle" text in Gran Turismo 4 without making license tests crash, which happens with full/double FPU.

Fixes split time display.

Also fixes the text in Gran Bikeismo (Tourist Trophy), which isn't surprising, since it's the same engine.

### Suggested Testing Steps

Test games known to be sensitive to floating point accuracy.
Make sure GT4 text is fixed, and license tests aren't broken.

To check for save data getting broken:

1. Boot your existing Gran Turismo 4 save and go to the GT mode.
2. Enter Home -> Garage and attempt to select every car you own, one by one. If anything goes wrong, the game will throw an error message and refuse to pick that car.
