### PR TITLE
GIF: Get rid of assertion with side effects

### DIFF
--- a/pcsx2/Gif_Unit.cpp
+++ b/pcsx2/Gif_Unit.cpp
@@ -86,7 +86,7 @@ bool Gif_HandlerAD(u8* pMem)
 	return false;
 }
 
-bool Gif_HandlerAD_MTVU(u8* pMem)
+void Gif_HandlerAD_MTVU(u8* pMem)
 {
 	// Note: Atomic communication is with MTVU.cpp Get_GSChanges
 	const u8 reg = pMem[8] & 0x7f;
@@ -129,7 +129,6 @@ bool Gif_HandlerAD_MTVU(u8* pMem)
 	{
 		DevCon.Warning("GIF Handler Debug - Write to unknown register! [reg=%x]", reg);
 	}
-	return 0;
 }
 
 // Returns true if pcsx2 needed to process the packet...

--- a/pcsx2/Gif_Unit.h
+++ b/pcsx2/Gif_Unit.h
@@ -16,7 +16,7 @@ struct GS_Packet;
 extern void Gif_MTGS_Wait(bool isMTVU);
 extern void Gif_FinishIRQ();
 extern bool Gif_HandlerAD(u8* pMem);
-extern bool Gif_HandlerAD_MTVU(u8* pMem);
+extern void Gif_HandlerAD_MTVU(u8* pMem);
 extern bool Gif_HandlerAD_Debug(u8* pMem);
 extern void Gif_AddBlankGSPacket(u32 size, GIF_PATH path);
 extern void Gif_AddGSPacketMTVU(GS_Packet& gsPack, GIF_PATH path);
@@ -450,7 +450,8 @@ struct Gif_Path
 						break; // Exit Early
 					if (gifTag.curReg() == GIF_REG_A_D)
 					{
-						pxAssert(!Gif_HandlerAD_MTVU(&buffer[curOffset]));
+						pxAssertMsg(Gif_HandlerAD_Debug(&buffer[curOffset]), "Unhandled GIF packet");
+						Gif_HandlerAD_MTVU(&buffer[curOffset]);
 					}
 					incTag(curOffset, gsPack.size, 16); // 1 QWC
 					gifTag.packedStep();


### PR DESCRIPTION
### Description of Changes

#10448 uncovered an assertion in GIF that assumed it would be evaluated - said assertion was actually the processing of the packet. Assertions should never have side effects.

### Rationale behind Changes

Fixes Tony Hawk games locking up on boot. Regression from #10448.

### Suggested Testing Steps

Already tested.

