### PR TITLE
CMake: Don't compile PrecompiledHeader.cpp

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -131,6 +131,8 @@ target_sources(common PRIVATE
 	Darwin/DarwinMisc.h
 )
 
+set_source_files_properties(PrecompiledHeader.cpp PROPERTIES HEADER_FILE_ONLY TRUE)
+
 if(USE_VTUNE)
 	target_link_libraries(common PUBLIC Vtune::Vtune)
 endif()

--- a/common/vsprops/QtCompile.props
+++ b/common/vsprops/QtCompile.props
@@ -89,7 +89,7 @@
     <Message Text="moc %(QtMoc.Filename) $(QtToolOutDir)%(QtMoc.RelativeDir)moc_%(QtMoc.Filename).cpp" Importance="High" />
     <Error Condition="!$(QtDirValid)" Text="Qt directory non-existent (download/extract the zip)" />
     <MakeDir Directories="$(QtToolOutDir)%(QtMoc.RelativeDir)" />
-    <Exec Command="&quot;$(QtHostBinDir)moc.exe&quot; &quot;%(QtMoc.FullPath)&quot; -b &quot;PrecompiledHeader.h&quot; -o &quot;$(QtToolOutDir)%(QtMoc.RelativeDir)moc_%(QtMoc.Filename).cpp&quot; -f%(QtMoc.Filename)%(QtMoc.Extension) $(MocDefines) $(MocIncludes)" />
+    <Exec Command="&quot;$(QtHostBinDir)moc.exe&quot; &quot;%(QtMoc.FullPath)&quot; -o &quot;$(QtToolOutDir)%(QtMoc.RelativeDir)moc_%(QtMoc.Filename).cpp&quot; -f%(QtMoc.Filename)%(QtMoc.Extension) $(MocDefines) $(MocIncludes)" />
   </Target>
 
   <ItemGroup>

--- a/pcsx2-qt/CMakeLists.txt
+++ b/pcsx2-qt/CMakeLists.txt
@@ -179,6 +179,7 @@ target_sources(pcsx2-qt PRIVATE
 file(GLOB TS_FILES ${CMAKE_CURRENT_SOURCE_DIR}/Translations/*.ts)
 
 target_precompile_headers(pcsx2-qt PRIVATE PrecompiledHeader.h)
+set_source_files_properties(PrecompiledHeader.cpp PROPERTIES HEADER_FILE_ONLY TRUE)
 
 target_include_directories(pcsx2-qt PRIVATE
 	${Qt6Gui_PRIVATE_INCLUDE_DIRS}

--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -1188,6 +1188,7 @@ target_compile_definitions(PCSX2_FLAGS INTERFACE
 	XBYAK_NO_EXCEPTION
 )
 
+set_source_files_properties(PrecompiledHeader.cpp PROPERTIES HEADER_FILE_ONLY TRUE)
 if(COMMAND target_precompile_headers)
 	message("Using precompiled headers.")
 	target_precompile_headers(PCSX2_FLAGS INTERFACE PrecompiledHeader.h)


### PR DESCRIPTION
### Description of Changes

`PrecompiledHeader.cpp` only exists for generating the PCH with MSBuild, not needed for CMake.

### Rationale behind Changes

Ever-so-slight reduction in build times.

### Suggested Testing Steps

CI passes.
