### PR TITLE
GS/TC: Remove old targets when changing width and outside a page

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -1722,7 +1722,19 @@ GSTextureCache::Target* GSTextureCache::LookupTarget(GIFRegTEX0 TEX0, const GSVe
 					}
 				}
 
-				if (can_use && !is_shuffle && preserve_alpha && preserve_rgb && TEX0.TBW != t->m_TEX0.TBW && t->m_dirty.size() >= 1)
+				// TODO: What might be a nicer solution than this, is to rearrange the targets to match the new layout, however this comes with some caviets:
+				// 1. They can draw wider than the FBW
+				// 2. The dirty+valid rects will need to also be rearranged
+				// 3. This could mean larger targets hanging around more
+				// 4. Sources which reference a target may become invalid and will need to be removed
+				// 5. Potential performance implications from additional render passes/copying
+				//
+				// But the bonuses are:
+				// 1. Rearranging the page layout will fix quite a few games which do this
+				// 2. Preserved data will be in the correct place (in most cases)
+				// 3. Less deleting sources/targets
+				// 4. We can basically do clears in hardware, if they aren't insane ones
+				if (can_use && !is_shuffle && ((preserve_alpha && preserve_rgb) || (size.y > GSLocalMemory::m_psm[t->m_TEX0.PSM].pgs.y && !possible_clear)) && TEX0.TBW != t->m_TEX0.TBW && t->m_dirty.size() >= 1)
 				{
 					can_use = false;
 				}


### PR DESCRIPTION
### Description of Changes
Removes old targets if the width changes and is drawing outside the height of a page, if it's not a clear and the target is dirty.

### Rationale behind Changes
In this scenario, the likelyhood is the target is changing to something new, which was the case with Medal of Honor, causing the texture to be the wrong shape, which can mess up the rendering. The only other solution would be for us to rearrange targets on width change, but we don't do this currently.

### Suggested Testing Steps
Test some random games and Medal of Honor - European Assault

Medal of Honor - European Assault:
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/828dff77-dee2-4b5b-ba13-da5dc3a316af)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/7e49f3b9-1cbb-40f1-8442-22e237949e7a)

