### PR TITLE
GS/Vulkan: Ignore GPUs that don't meet the required extensions

### DIFF
--- a/pcsx2/GS/Renderers/DX11/D3D.h
+++ b/pcsx2/GS/Renderers/DX11/D3D.h
@@ -44,6 +44,7 @@ namespace D3D
 	// returns the driver version from the registry as a string
 	std::string GetDriverVersionFromLUID(const LUID& luid);
 
+#ifdef _M_X86
 	// this is sort of a legacy thing that doesn't have much to do with d3d (just the easiest way)
 	// checks to see if the adapter at 0 is NV and thus we should prefer OpenGL
 	enum class VendorID
@@ -56,6 +57,7 @@ namespace D3D
 
 	VendorID GetVendorID(IDXGIAdapter1* adapter);
 	GSRendererType GetPreferredRenderer();
+#endif
 
 	// D3DCompiler wrapper.
 	enum class ShaderType


### PR DESCRIPTION
### Description of Changes

There's no point showing GPUs in the list that don't support the required Vulkan version, or extensions, since they won't be usable.

More critically, it throws off the automatic renderer check, and tries to create a Vulkan device that fails, instead of falling back to D3D. Thanks AMD for not supporting a 2016/2017 extension on your GPUs released in 2019, then dropping support for them entirely.

### Rationale behind Changes

Less user complaints that they can't start PCSX2, because they're using 3 year old drivers.

### Suggested Testing Steps

Make sure Vulkan still works on NV/AMD.
