### PR TITLE
DEV9: fix some missing includes and nonportable u_long type use

### DIFF
--- a/pcsx2/DEV9/Sessions/TCP_Session/TCP_Session_In.cpp
+++ b/pcsx2/DEV9/Sessions/TCP_Session/TCP_Session_In.cpp
@@ -80,7 +80,7 @@ namespace Sessions
 			int err = 0;
 			int recived;
 
-			u_long available;
+			unsigned long available;
 #ifdef _WIN32
 			err = ioctlsocket(client, FIONREAD, &available);
 #elif defined(__POSIX__)

--- a/pcsx2/DEV9/Sessions/UDP_Session/UDP_FixedPort.cpp
+++ b/pcsx2/DEV9/Sessions/UDP_Session/UDP_FixedPort.cpp
@@ -8,6 +8,7 @@
 #define SOCKET_ERROR -1
 #include <errno.h>
 #include <sys/ioctl.h>
+#include <sys/select.h>
 #include <netinet/in.h>
 #endif
 
@@ -132,7 +133,7 @@ namespace Sessions
 
 		if (hasData)
 		{
-			u_long available = 0;
+			unsigned long available = 0;
 			PayloadData* recived = nullptr;
 			std::unique_ptr<u8[]> buffer;
 			sockaddr endpoint{0};

--- a/pcsx2/DEV9/Sessions/UDP_Session/UDP_Session.cpp
+++ b/pcsx2/DEV9/Sessions/UDP_Session/UDP_Session.cpp
@@ -8,6 +8,7 @@
 #define SOCKET_ERROR -1
 #include <errno.h>
 #include <sys/ioctl.h>
+#include <sys/select.h>
 #include <netinet/in.h>
 #endif
 
@@ -119,7 +120,7 @@ namespace Sessions
 
 		if (hasData)
 		{
-			u_long available = 0;
+			unsigned long available = 0;
 			PayloadData* recived = nullptr;
 			std::unique_ptr<u8[]> buffer;
 			sockaddr endpoint{0};


### PR DESCRIPTION
probably just new fallout for only me since 47a65ce01ec48ad6f38468c201547bacec98d969 but i didn't bisect

### Description of Changes
replace u_long with unsigned long and include `<sys/select.h>` for `fd_set`/`FD_ISSET` etc in the posix path. 

### Rationale behind Changes
fixes downstream builds against musl libc on linux (which is strict about header namespaces and doesn't have nonstandard typenames like `u_long` aliased to `unsigned long`).  
(nobody cares about this but me, but this should be a completely harmless change anyway)

### Suggested Testing Steps
make sure nothing broke in dev9, but this should yield identical build output to before
