### PR TITLE
Debugger: Add Not Equals Array/String filter searches + minor memory search UI change

### DIFF
--- a/pcsx2-qt/Debugger/CpuWidget.cpp
+++ b/pcsx2-qt/Debugger/CpuWidget.cpp
@@ -988,19 +988,37 @@ std::vector<u32> searchWorker(DebugInterface* cpu, std::vector<u32> searchAddres
 	return hitAddresses;
 }
 
-static bool compareByteArrayAtAddress(DebugInterface* cpu, u32 addr, QByteArray value)
+static bool compareByteArrayAtAddress(DebugInterface* cpu, SearchComparison searchComparison, u32 addr, QByteArray value)
 {
+	const bool isNotOperator = searchComparison == SearchComparison::NotEquals;
 	for (qsizetype i = 0; i < value.length(); i++)
 	{
-		if (static_cast<char>(cpu->read8(addr + i)) != value[i])
+		const char nextByte = cpu->read8(addr + i);
+		switch (searchComparison)
 		{
-			return false;
+			case SearchComparison::Equals:
+			{
+				if (nextByte != value[i])
+					return false;
+				break;
+			}
+			case SearchComparison::NotEquals:
+			{
+				if (nextByte != value[i])
+					return true;
+				break;
+			}
+			default:
+			{
+				Console.Error("Debugger: Unknown search comparison when doing memory search");
+				return false;
+			}
 		}
 	}
-	return true;
+	return !isNotOperator;
 }
 
-static std::vector<u32> searchWorkerByteArray(DebugInterface* cpu, std::vector<u32> searchAddresses, u32 start, u32 end, QByteArray value)
+static std::vector<u32> searchWorkerByteArray(DebugInterface* cpu, SearchComparison searchComparison, std::vector<u32> searchAddresses, u32 start, u32 end, QByteArray value)
 {
 	std::vector<u32> hitAddresses;
 	const bool isSearchingRange = searchAddresses.size() <= 0;
@@ -1008,7 +1026,7 @@ static std::vector<u32> searchWorkerByteArray(DebugInterface* cpu, std::vector<u
 	{
 		for (u32 addr = start; addr < end; addr += 1)
 		{
-			if (compareByteArrayAtAddress(cpu, addr, value))
+			if (compareByteArrayAtAddress(cpu, searchComparison, addr, value))
 			{
 				hitAddresses.emplace_back(addr);
 				addr += value.length() - 1;
@@ -1019,7 +1037,7 @@ static std::vector<u32> searchWorkerByteArray(DebugInterface* cpu, std::vector<u
 	{
 		for (u32 addr : searchAddresses)
 		{
-			if (compareByteArrayAtAddress(cpu, addr, value))
+			if (compareByteArrayAtAddress(cpu, searchComparison, addr, value))
 			{
 				hitAddresses.emplace_back(addr);
 			}
@@ -1046,9 +1064,9 @@ std::vector<u32> startWorker(DebugInterface* cpu, const SearchType type, const S
 		case SearchType::DoubleType:
 			return searchWorker<double>(cpu, searchAddresses, searchComparison, start, end, value.toDouble());
 		case SearchType::StringType:
-			return searchWorkerByteArray(cpu, searchAddresses, start, end, value.toUtf8());
+			return searchWorkerByteArray(cpu, searchComparison, searchAddresses, start, end, value.toUtf8());
 		case SearchType::ArrayType:
-			return searchWorkerByteArray(cpu, searchAddresses, start, end, QByteArray::fromHex(value.toUtf8()));
+			return searchWorkerByteArray(cpu, searchComparison, searchAddresses, start, end, QByteArray::fromHex(value.toUtf8()));
 		default:
 			Console.Error("Debugger: Unknown type when doing memory search!");
 			break;
@@ -1093,7 +1111,13 @@ void CpuWidget::onSearchButtonClicked()
 	unsigned long long value;
 
 	const bool isVariableSize = searchType == SearchType::ArrayType || searchType == SearchType::StringType;
-	if (isVariableSize && searchComparison != SearchComparison::Equals)
+	if (isVariableSize && !isFilterSearch && searchComparison == SearchComparison::NotEquals)
+	{
+		QMessageBox::critical(this, tr("Debugger"), tr("Search types Array and String can use the Not Equals search comparison type with new searches."));
+		return;
+	}
+
+	if (isVariableSize && searchComparison != SearchComparison::Equals && searchComparison != SearchComparison::NotEquals)
 	{
 		QMessageBox::critical(this, tr("Debugger"), tr("Search types Array and String can only be used with Equals search comparisons."));
 		return;

--- a/pcsx2-qt/Debugger/CpuWidget.ui
+++ b/pcsx2-qt/Debugger/CpuWidget.ui
@@ -183,20 +183,6 @@
           <layout class="QVBoxLayout" name="verticalLayout_3">
            <item>
             <layout class="QGridLayout" name="gridLayout_2">
-             <item row="6" column="0">
-              <widget class="QLabel" name="label_5">
-               <property name="text">
-                <string>End</string>
-               </property>
-              </widget>
-             </item>
-             <item row="5" column="1" colspan="3">
-              <widget class="QLineEdit" name="txtSearchStart">
-               <property name="text">
-                <string notr="true">0x00</string>
-               </property>
-              </widget>
-             </item>
              <item row="0" column="0">
               <widget class="QLabel" name="label">
                <property name="text">
@@ -206,20 +192,6 @@
              </item>
              <item row="0" column="1">
               <widget class="QLineEdit" name="txtSearchValue"/>
-             </item>
-             <item row="5" column="0">
-              <widget class="QLabel" name="label_4">
-               <property name="text">
-                <string>Start</string>
-               </property>
-              </widget>
-             </item>
-             <item row="6" column="1" colspan="3">
-              <widget class="QLineEdit" name="txtSearchEnd">
-               <property name="text">
-                <string notr="true">0x2000000</string>
-               </property>
-              </widget>
              </item>
              <item row="2" column="0">
               <widget class="QLabel" name="label_2">
@@ -338,6 +310,45 @@
                  <string>Less Than Or Equal</string>
                 </property>
                </item>
+              </widget>
+             </item>
+             <item row="1" column="0">
+              <widget class="QLabel" name="comparisonLabel">
+               <property name="text">
+                <string>Comparison</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+           <item>
+            <layout class="QGridLayout" name="gridLayout_3">
+             <item row="0" column="0" alignment="Qt::AlignLeft">
+              <widget class="QLabel" name="label_4">
+               <property name="text">
+                <string>Start</string>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="1" alignment="Qt::AlignLeft">
+              <widget class="QLineEdit" name="txtSearchStart">
+               <property name="text">
+                <string notr="true">0x00</string>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="2">
+              <widget class="QLabel" name="label_5">
+               <property name="text">
+                <string>End</string>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="3">
+              <widget class="QLineEdit" name="txtSearchEnd">
+               <property name="text">
+                <string notr="true">0x2000000</string>
+               </property>
               </widget>
              </item>
             </layout>


### PR DESCRIPTION
### Description of Changes
Adds support for doing `Not Equals` filter searches for Arrays/String searches.
Previously only `Equals` was supported for array/string searches.

Also condenses the memory search `Start`/`End` inputs into one line to make space for future UI elements, and adds a `Comparison` label to label the search comparison type dropdown.

**Note**: Does not support `Not Equals` initial searches, as this would create huge amounts of unnecessary and useless reads/results.
___
### UI changes:
![image](https://github.com/PCSX2/pcsx2/assets/4957200/bbb0288d-b3e5-4b5e-8fa1-c9e5708e20ec)
___
### Not Equals String/Array filter searches:
![PCSX2-ArrayStringNotEquals](https://github.com/PCSX2/pcsx2/assets/4957200/374c9d14-dc9a-478b-8945-005f8f7ce17a)

___

### Rationale behind Changes
Not Equals array and filter searches allow for easy filtering of results/narrowing down strings/data you don't want after seeing the values/results.

The UI changes were made at request, with the `Comparison` label being added so that the dropdown is labeled just as `Type` is.
The `Start` and `End` were changed to one line as it makes more potential space to be used for other features and due to the short length of addresses vs. the amount of space given, full lines aren't needed for each.
___
### Suggested Testing Steps
- Running `Equals` and `Not Equals` searches for both `Array` and `String` types.
- Verifying that `Not Equals` for array/string is supported for Filter searches, but for new searches a message appears giving context that it is not supported.