### PR TITLE
GS/HW: Properly fix GT4 fade transitions (again)

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSHwHack.cpp
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.cpp
@@ -739,13 +739,21 @@ bool GSHwHack::GSC_PolyphonyDigitalGames(GSRendererHW& r, int& skip)
 					continue;
 			}
 
+			// Need the alpha channel.
 			dst->m_TEX0.PSM = PSMCT32;
+
+			// Alpha is unknown, since it comes from RGB.
+			dst->m_alpha_min = 0;
+			dst->m_alpha_max = 255;
+
 			dst->UpdateValidChannels(PSMCT32, fbmsk);
 			dst->UpdateValidity(GSVector4i::loadh(size));
 
 			GSHWDrawConfig& config = r.BeginHLEHardwareDraw(
 				dst->GetTexture(), nullptr, dst->GetScale(), src->GetTexture(), src->GetScale(), src->GetUnscaledRect());
 			config.pal = palette->GetPaletteGSTexture();
+			config.ps.tfx = TFX_DECAL;
+			config.ps.tcc = true;
 			config.ps.channel = ChannelFetch_RED + channel;
 			config.colormask.wrgba = 8;
 			r.EndHLEHardwareDraw(false);


### PR DESCRIPTION
### Description of Changes

Round 3 with this damn game. Hopefully got it this time. In the split-channel/alpha render fix, I wasn't actually writing alpha with the colour information, so the transition was black instead of from the previous frame.

Also fixes incorrect target texture invalidation, because GT4 writes to the target as C24, it was tossing the alpha channel, which could cause graphical corruption (DONT_CARE load action). Unfortunately it adds an upload/draw in Dirge, Arse Combat and a couple of others, but at least we don't have indeterminate alpha channels hanging around that are flagged as valid...

### Rationale behind Changes

![image](https://github.com/PCSX2/pcsx2/assets/11288319/f6fa06cd-51fe-43a3-a3dc-ea89f513449a)
![image](https://github.com/PCSX2/pcsx2/assets/11288319/49229f7a-5683-4429-865a-6c67e688d4b9)

### Suggested Testing Steps

Test GT4 transitions.
