### PR TITLE
GamePatchSettingsWidget: Enable word wrap for long patch names/descriptions

### DIFF
--- a/pcsx2-qt/Settings/GamePatchDetailsWidget.ui
+++ b/pcsx2-qt/Settings/GamePatchDetailsWidget.ui
@@ -21,6 +21,12 @@
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
       <widget class="QLabel" name="name">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="font">
         <font>
          <pointsize>12</pointsize>
@@ -29,6 +35,9 @@
        </property>
        <property name="text">
         <string>Patch Title</string>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
        </property>
       </widget>
      </item>
@@ -65,6 +74,9 @@
      </property>
      <property name="alignment">
       <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
      </property>
     </widget>
    </item>

--- a/pcsx2-qt/Settings/GamePatchSettingsWidget.ui
+++ b/pcsx2-qt/Settings/GamePatchSettingsWidget.ui
@@ -42,6 +42,9 @@
    </item>
    <item>
     <widget class="QScrollArea" name="scrollArea">
+     <property name="horizontalScrollBarPolicy">
+      <enum>Qt::ScrollBarAlwaysOff</enum>
+     </property>
      <property name="widgetResizable">
       <bool>true</bool>
      </property>


### PR DESCRIPTION
### Description of Changes
Disables vertical scrolling in favour of word wrap on the patch names and description boxes.

Master:
![image](https://github.com/PCSX2/pcsx2/assets/7947461/bf74cc07-d52d-4ffc-b9a6-0988556f1693)

PR:
![image](https://github.com/PCSX2/pcsx2/assets/7947461/4d056817-79a5-4024-81c5-88bc068781d0)

### Rationale behind Changes
Better readability.

### Suggested Testing Steps
Make sure that the Patches tab looks OK.
