### PR TITLE
Debugger: Add Saved Addresses tab widget for bookmarking memory addresses

### DIFF
--- a/pcsx2-qt/CMakeLists.txt
+++ b/pcsx2-qt/CMakeLists.txt
@@ -167,6 +167,8 @@ target_sources(pcsx2-qt PRIVATE
 	Debugger/Models/ThreadModel.h
 	Debugger/Models/StackModel.cpp
 	Debugger/Models/StackModel.h
+	Debugger/Models/SavedAddressesModel.cpp
+	Debugger/Models/SavedAddressesModel.h
 	Tools/InputRecording/NewInputRecordingDlg.cpp
 	Tools/InputRecording/NewInputRecordingDlg.h
 	Tools/InputRecording/NewInputRecordingDlg.ui

--- a/pcsx2-qt/Debugger/CpuWidget.cpp
+++ b/pcsx2-qt/Debugger/CpuWidget.cpp
@@ -415,6 +415,7 @@ void CpuWidget::contextBPListPasteCSV()
 			QString matchedValue = match.captured(0);
 			fields << matchedValue.mid(1, matchedValue.length() - 2);
 		}
+
 		if (fields.size() != BreakpointModel::BreakpointColumns::COLUMN_COUNT)
 		{
 			Console.WriteLn("Debugger CSV Import: Invalid number of columns, skipping");
@@ -422,7 +423,7 @@ void CpuWidget::contextBPListPasteCSV()
 		}
 
 		bool ok;
-		int type = fields[BreakpointModel::BreakpointColumns::TYPE].toUInt(&ok);
+		const int type = fields[BreakpointModel::BreakpointColumns::TYPE].toUInt(&ok);
 		if (!ok)
 		{
 			Console.WriteLn("Debugger CSV Import: Failed to parse type '%s', skipping", fields[BreakpointModel::BreakpointColumns::TYPE].toUtf8().constData());
@@ -496,7 +497,7 @@ void CpuWidget::contextBPListPasteCSV()
 			}
 
 			// Result
-			int result = fields [BreakpointModel::BreakpointColumns::ENABLED].toUInt(&ok);
+			const int result = fields [BreakpointModel::BreakpointColumns::ENABLED].toUInt(&ok);
 			if (!ok)
 			{
 				Console.WriteLn("Debugger CSV Import: Failed to parse result flag '%s', skipping", fields [BreakpointModel::BreakpointColumns::ENABLED].toUtf8().constData());
@@ -637,7 +638,7 @@ void CpuWidget::contextSearchResultGoToDisassembly()
 	if (!selModel->hasSelection())
 		return;
 
-	m_ui.disassemblyWidget->gotoAddress(m_ui.listSearchResults->selectedItems().first()->data(256).toUInt());
+	m_ui.disassemblyWidget->gotoAddress(m_ui.listSearchResults->selectedItems().first()->data(Qt::UserRole).toUInt());
 }
 
 void CpuWidget::contextRemoveSearchResult()
@@ -647,8 +648,8 @@ void CpuWidget::contextRemoveSearchResult()
 		return;
 
 	const int selectedResultIndex = m_ui.listSearchResults->row(m_ui.listSearchResults->selectedItems().first());
-	auto* rowToRemove = m_ui.listSearchResults->takeItem(selectedResultIndex);
-	if (m_searchResults.size() > static_cast<size_t>(selectedResultIndex) && m_searchResults.at(selectedResultIndex) == rowToRemove->data(256).toUInt())
+	const auto* rowToRemove = m_ui.listSearchResults->takeItem(selectedResultIndex);
+	if (m_searchResults.size() > static_cast<size_t>(selectedResultIndex) && m_searchResults.at(selectedResultIndex) == rowToRemove->data(Qt::UserRole).toUInt())
 	{
 		m_searchResults.erase(m_searchResults.begin() + selectedResultIndex);
 	}
@@ -689,7 +690,7 @@ void CpuWidget::updateFunctionList(bool whenEmpty)
 
 			item->setText(QString("%0 %1").arg(FilledQStringFromValue(symbol.address, 16)).arg(symbolName));
 
-			item->setData(256, symbol.address);
+			item->setData(Qt::UserRole, symbol.address);
 
 			m_ui.listFunctions->addItem(item);
 		}
@@ -717,7 +718,7 @@ void CpuWidget::updateFunctionList(bool whenEmpty)
 						symbolName = demangledName;
 				}
 				QTreeWidgetItem* functionItem = new QTreeWidgetItem(moduleItem, QStringList(QString("%0 %1").arg(FilledQStringFromValue(sym.address, 16)).arg(symbolName)));
-				functionItem->setData(0, 256, sym.address);
+				functionItem->setData(0, Qt::UserRole, sym.address);
 				functions.append(functionItem);
 			}
 			moduleItem->addChildren(functions);
@@ -794,7 +795,7 @@ void CpuWidget::onFuncListContextMenu(QPoint pos)
 	else
 		m_funclistContextMenu->clear();
 
-	if (m_ui.listFunctions->selectedItems().count() && m_ui.listFunctions->selectedItems().first()->data(256).isValid())
+	if (m_ui.listFunctions->selectedItems().count() && m_ui.listFunctions->selectedItems().first()->data(Qt::UserRole).isValid())
 	{
 		QAction* copyName = new QAction(tr("Copy Function Name"), m_ui.listFunctions);
 		connect(copyName, &QAction::triggered, [this] {
@@ -802,14 +803,14 @@ void CpuWidget::onFuncListContextMenu(QPoint pos)
 			// Resolve the function name by fetching the symbolmap and filtering the address
 
 			const QListWidgetItem* selectedItem = m_ui.listFunctions->selectedItems().first();
-			const QString functionName = QString(m_cpu.GetSymbolMap().GetLabelName(selectedItem->data(256).toUInt()).c_str());
+			const QString functionName = QString(m_cpu.GetSymbolMap().GetLabelName(selectedItem->data(Qt::UserRole).toUInt()).c_str());
 			QApplication::clipboard()->setText(functionName);
 		});
 		m_funclistContextMenu->addAction(copyName);
 
 		QAction* copyAddress = new QAction(tr("Copy Function Address"), m_ui.listFunctions);
 		connect(copyAddress, &QAction::triggered, [this] {
-			const QString addressString = FilledQStringFromValue(m_ui.listFunctions->selectedItems().first()->data(256).toUInt(), 16);
+			const QString addressString = FilledQStringFromValue(m_ui.listFunctions->selectedItems().first()->data(Qt::UserRole).toUInt(), 16);
 			QApplication::clipboard()->setText(addressString);
 		});
 
@@ -819,14 +820,14 @@ void CpuWidget::onFuncListContextMenu(QPoint pos)
 
 		QAction* gotoDisasm = new QAction(tr("Go to in Disassembly"), m_ui.listFunctions);
 		connect(gotoDisasm, &QAction::triggered, [this] {
-			m_ui.disassemblyWidget->gotoAddress(m_ui.listFunctions->selectedItems().first()->data(256).toUInt());
+			m_ui.disassemblyWidget->gotoAddress(m_ui.listFunctions->selectedItems().first()->data(Qt::UserRole).toUInt());
 		});
 
 		m_funclistContextMenu->addAction(gotoDisasm);
 
 		QAction* gotoMemory = new QAction(tr("Go to in Memory View"), m_ui.listFunctions);
 		connect(gotoMemory, &QAction::triggered, [this] {
-			m_ui.memoryviewWidget->gotoAddress(m_ui.listFunctions->selectedItems().first()->data(256).toUInt());
+			m_ui.memoryviewWidget->gotoAddress(m_ui.listFunctions->selectedItems().first()->data(Qt::UserRole).toUInt());
 		});
 
 		m_funclistContextMenu->addAction(gotoMemory);
@@ -866,7 +867,7 @@ void CpuWidget::onFuncListContextMenu(QPoint pos)
 
 void CpuWidget::onFuncListDoubleClick(QListWidgetItem* item)
 {
-	m_ui.disassemblyWidget->gotoAddress(item->data(256).toUInt());
+	m_ui.disassemblyWidget->gotoAddress(item->data(Qt::UserRole).toUInt());
 }
 
 void CpuWidget::onModuleTreeContextMenu(QPoint pos)
@@ -876,17 +877,17 @@ void CpuWidget::onModuleTreeContextMenu(QPoint pos)
 	else
 		m_moduleTreeContextMenu->clear();
 
-	if (m_ui.treeModules->selectedItems().count() && m_ui.treeModules->selectedItems().first()->data(0, 256).isValid())
+	if (m_ui.treeModules->selectedItems().count() && m_ui.treeModules->selectedItems().first()->data(0, Qt::UserRole).isValid())
 	{
 		QAction* copyName = new QAction(tr("Copy Function Name"), m_ui.treeModules);
 		connect(copyName, &QAction::triggered, [this] {
-			QApplication::clipboard()->setText(m_cpu.GetSymbolMap().GetLabelName(m_ui.treeModules->selectedItems().first()->data(0, 256).toUInt()).c_str());
+			QApplication::clipboard()->setText(m_cpu.GetSymbolMap().GetLabelName(m_ui.treeModules->selectedItems().first()->data(0, Qt::UserRole).toUInt()).c_str());
 		});
 		m_moduleTreeContextMenu->addAction(copyName);
 
 		QAction* copyAddress = new QAction(tr("Copy Function Address"), m_ui.treeModules);
 		connect(copyAddress, &QAction::triggered, [this] {
-			const QString addressString = FilledQStringFromValue(m_ui.treeModules->selectedItems().first()->data(0, 256).toUInt(), 16);
+			const QString addressString = FilledQStringFromValue(m_ui.treeModules->selectedItems().first()->data(0, Qt::UserRole).toUInt(), 16);
 			QApplication::clipboard()->setText(addressString);
 		});
 		m_moduleTreeContextMenu->addAction(copyAddress);
@@ -895,13 +896,13 @@ void CpuWidget::onModuleTreeContextMenu(QPoint pos)
 
 		QAction* gotoDisasm = new QAction(tr("Go to in Disassembly"), m_ui.treeModules);
 		connect(gotoDisasm, &QAction::triggered, [this] {
-			m_ui.disassemblyWidget->gotoAddress(m_ui.treeModules->selectedItems().first()->data(0, 256).toUInt());
+			m_ui.disassemblyWidget->gotoAddress(m_ui.treeModules->selectedItems().first()->data(0, Qt::UserRole).toUInt());
 		});
 		m_moduleTreeContextMenu->addAction(gotoDisasm);
 
 		QAction* gotoMemory = new QAction(tr("Go to in Memory View"), m_ui.treeModules);
 		connect(gotoMemory, &QAction::triggered, [this] {
-			m_ui.memoryviewWidget->gotoAddress(m_ui.treeModules->selectedItems().first()->data(0, 256).toUInt());
+			m_ui.memoryviewWidget->gotoAddress(m_ui.treeModules->selectedItems().first()->data(0, Qt::UserRole).toUInt());
 		});
 		m_moduleTreeContextMenu->addAction(gotoMemory);
 	}
@@ -939,9 +940,9 @@ void CpuWidget::onModuleTreeContextMenu(QPoint pos)
 
 void CpuWidget::onModuleTreeDoubleClick(QTreeWidgetItem* item)
 {
-	if (item->data(0, 256).isValid())
+	if (item->data(0, Qt::UserRole).isValid())
 	{
-		m_ui.disassemblyWidget->gotoAddress(item->data(0, 256).toUInt());
+		m_ui.disassemblyWidget->gotoAddress(item->data(0, Qt::UserRole).toUInt());
 	}
 }
 void CpuWidget::updateStackFrames()
@@ -1362,7 +1363,7 @@ void CpuWidget::loadSearchResults()
 	{
 		u32 address = m_searchResults.at(numLoaded + i);
 		QListWidgetItem* item = new QListWidgetItem(QtUtils::FilledQStringFromValue(address, 16));
-		item->setData(256, address);
+		item->setData(Qt::UserRole, address);
 		m_ui.listSearchResults->addItem(item);
 	}
 }

--- a/pcsx2-qt/Debugger/CpuWidget.cpp
+++ b/pcsx2-qt/Debugger/CpuWidget.cpp
@@ -7,6 +7,7 @@
 #include "BreakpointDialog.h"
 #include "Models/BreakpointModel.h"
 #include "Models/ThreadModel.h"
+#include "Models/SavedAddressesModel.h"
 
 #include "DebugTools/DebugInterface.h"
 #include "DebugTools/Breakpoints.h"
@@ -39,6 +40,7 @@ CpuWidget::CpuWidget(QWidget* parent, DebugInterface& cpu)
 	, m_bpModel(cpu)
 	, m_threadModel(cpu)
 	, m_stackModel(cpu)
+	, m_savedAddressesModel(cpu)
 {
 	m_ui.setupUi(this);
 
@@ -46,6 +48,7 @@ CpuWidget::CpuWidget(QWidget* parent, DebugInterface& cpu)
 
 	connect(m_ui.registerWidget, &RegisterWidget::gotoInDisasm, m_ui.disassemblyWidget, &DisassemblyWidget::gotoAddress);
 	connect(m_ui.memoryviewWidget, &MemoryViewWidget::gotoInDisasm, m_ui.disassemblyWidget, &DisassemblyWidget::gotoAddress);
+	connect(m_ui.memoryviewWidget, &MemoryViewWidget::addToSavedAddresses, this, &CpuWidget::addAddressToSavedAddressesList);
 
 	connect(m_ui.registerWidget, &RegisterWidget::gotoInMemory, m_ui.memoryviewWidget, &MemoryViewWidget::gotoAddress);
 	connect(m_ui.disassemblyWidget, &DisassemblyWidget::gotoInMemory, m_ui.memoryviewWidget, &MemoryViewWidget::gotoAddress);
@@ -127,6 +130,18 @@ CpuWidget::CpuWidget(QWidget* parent, DebugInterface& cpu)
 	m_resultsLoadTimer.setInterval(100);
 	m_resultsLoadTimer.setSingleShot(true);
 	connect(&m_resultsLoadTimer, &QTimer::timeout, this, &CpuWidget::loadSearchResults);
+
+	m_ui.savedAddressesList->setModel(&m_savedAddressesModel);
+	m_ui.savedAddressesList->setContextMenuPolicy(Qt::CustomContextMenu);
+	connect(m_ui.savedAddressesList, &QTableView::customContextMenuRequested, this, &CpuWidget::onSavedAddressesListContextMenu);
+	for (std::size_t i = 0; auto mode : SavedAddressesModel::HeaderResizeModes)
+	{
+		m_ui.savedAddressesList->horizontalHeader()->setSectionResizeMode(i++, mode);
+	}
+	QTableView* savedAddressesTableView = m_ui.savedAddressesList;
+	connect(m_ui.savedAddressesList->model(), &QAbstractItemModel::dataChanged,	[savedAddressesTableView](const QModelIndex& topLeft) {
+		savedAddressesTableView->resizeColumnToContents(topLeft.column());
+	});
 }
 
 CpuWidget::~CpuWidget() = default;
@@ -490,6 +505,128 @@ void CpuWidget::contextBPListPasteCSV()
 	}
 }
 
+void CpuWidget::onSavedAddressesListContextMenu(QPoint pos)
+{
+	QMenu* contextMenu = new QMenu("Saved Addresses List Context Menu", m_ui.savedAddressesList);
+
+	QAction* newAction = new QAction(tr("New"), m_ui.savedAddressesList);
+	connect(newAction, &QAction::triggered, this, &CpuWidget::contextSavedAddressesListNew);
+	contextMenu->addAction(newAction);
+
+	const QModelIndex indexAtPos = m_ui.savedAddressesList->indexAt(pos);
+	const bool isIndexValid = indexAtPos.isValid();
+
+	if (isIndexValid)
+	{
+		if (m_cpu.isAlive())
+		{
+			QAction* goToAddressMemViewAction = new QAction(tr("Go to in Memory View"), m_ui.savedAddressesList);
+			connect(goToAddressMemViewAction, &QAction::triggered, this, [this, indexAtPos]() {
+				const QModelIndex rowAddressIndex = m_ui.savedAddressesList->model()->index(indexAtPos.row(), 0, QModelIndex());
+				m_ui.memoryviewWidget->gotoAddress(m_ui.savedAddressesList->model()->data(rowAddressIndex, Qt::UserRole).toUInt());
+				m_ui.tabWidget->setCurrentWidget(m_ui.tab_memory);
+			});
+			contextMenu->addAction(goToAddressMemViewAction);
+
+			QAction* goToAddressDisassemblyAction = new QAction(tr("Go to in Disassembly"), m_ui.savedAddressesList);
+			connect(goToAddressDisassemblyAction, &QAction::triggered, this, [this, indexAtPos]() {
+				const QModelIndex rowAddressIndex = m_ui.savedAddressesList->model()->index(indexAtPos.row(), 0, QModelIndex());
+				m_ui.disassemblyWidget->gotoAddress(m_ui.savedAddressesList->model()->data(rowAddressIndex, Qt::UserRole).toUInt());
+			});
+			contextMenu->addAction(goToAddressDisassemblyAction);
+		}
+
+		QAction* copyAction = new QAction(indexAtPos.column() == 0 ? tr("Copy Address") : tr("Copy Text"), m_ui.savedAddressesList);
+		connect(copyAction, &QAction::triggered, [this, indexAtPos]() {
+			QGuiApplication::clipboard()->setText(m_ui.savedAddressesList->model()->data(indexAtPos, Qt::DisplayRole).toString());
+		});
+		contextMenu->addAction(copyAction);
+	}
+
+	if (m_ui.savedAddressesList->model()->rowCount() > 0)
+	{
+		QAction* actionExportCSV = new QAction(tr("Copy all as CSV"), m_ui.savedAddressesList);
+		connect(actionExportCSV, &QAction::triggered, [this]() {
+			QGuiApplication::clipboard()->setText(QtUtils::AbstractItemModelToCSV(m_ui.savedAddressesList->model(), Qt::DisplayRole, true));
+		});
+		contextMenu->addAction(actionExportCSV);
+	}
+
+	QAction* actionImportCSV = new QAction(tr("Paste from CSV"), m_ui.savedAddressesList);
+	connect(actionImportCSV, &QAction::triggered, this, &CpuWidget::contextSavedAddressesListPasteCSV);
+	contextMenu->addAction(actionImportCSV);
+
+	contextMenu->popup(m_ui.savedAddressesList->viewport()->mapToGlobal(pos));
+
+	if (isIndexValid)
+	{
+		QAction* deleteAction = new QAction(tr("Delete"), m_ui.savedAddressesList);
+		connect(deleteAction, &QAction::triggered, this, [this, indexAtPos]() {
+			m_ui.savedAddressesList->model()->removeRows(indexAtPos.row(), 1);
+		});
+		contextMenu->addAction(deleteAction);
+	}
+}
+
+void CpuWidget::contextSavedAddressesListPasteCSV()
+{
+	QString csv = QGuiApplication::clipboard()->text();
+	// Skip header
+	csv = csv.mid(csv.indexOf('\n') + 1);
+
+	for (const QString& line : csv.split('\n'))
+	{
+		QStringList fields;
+		// In order to handle text with commas in them we must wrap values in quotes to mark
+		// where a value starts and end so that text commas aren't identified as delimiters.
+		// So matches each quote pair, parse it out, and removes the quotes to get the value.
+		QRegularExpression eachQuotePair(R"("([^"]|\\.)*")");
+		QRegularExpressionMatchIterator it = eachQuotePair.globalMatch(line);
+		while (it.hasNext())
+		{
+			QRegularExpressionMatch match = it.next();
+			QString matchedValue = match.captured(0);
+			fields << matchedValue.mid(1, matchedValue.length() - 2);
+		}
+
+		if (fields.size() != SavedAddressesModel::HeaderColumns::COLUMN_COUNT)
+		{
+			Console.WriteLn("Debugger CSV Import: Invalid number of columns, skipping");
+			continue;
+		}
+
+		bool ok;
+		const u32 address = fields[SavedAddressesModel::HeaderColumns::ADDRESS].toUInt(&ok, 16);
+		if (!ok)
+		{
+			Console.WriteLn("Debugger CSV Import: Failed to parse address '%s', skipping", fields[SavedAddressesModel::HeaderColumns::ADDRESS].toUtf8().constData());
+			continue;
+		}
+
+		const QString label = fields[SavedAddressesModel::HeaderColumns::LABEL];
+		const QString description = fields[SavedAddressesModel::HeaderColumns::DESCRIPTION];
+		const SavedAddressesModel::SavedAddress importedAddress = {address, label, description};
+		m_savedAddressesModel.addRow(importedAddress);
+	}
+}
+
+void CpuWidget::contextSavedAddressesListNew()
+{
+	qobject_cast<SavedAddressesModel*>(m_ui.savedAddressesList->model())->addRow();
+	const u32 rowCount = m_ui.savedAddressesList->model()->rowCount();
+	m_ui.savedAddressesList->edit(m_ui.savedAddressesList->model()->index(rowCount - 1, 0));
+}
+
+void CpuWidget::addAddressToSavedAddressesList(u32 address)
+{
+	qobject_cast<SavedAddressesModel*>(m_ui.savedAddressesList->model())->addRow();
+	const u32 rowCount = m_ui.savedAddressesList->model()->rowCount();
+	const QModelIndex addressIndex = m_ui.savedAddressesList->model()->index(rowCount - 1, 0);
+	m_ui.tabWidget->setCurrentWidget(m_ui.tab_savedaddresses);
+	m_ui.savedAddressesList->model()->setData(addressIndex, address, Qt::UserRole);
+	m_ui.savedAddressesList->edit(m_ui.savedAddressesList->model()->index(rowCount - 1, 1));
+}
+
 void CpuWidget::contextSearchResultGoToDisassembly()
 {
 	const QItemSelectionModel* selModel = m_ui.listSearchResults->selectionModel();
@@ -812,12 +949,19 @@ void CpuWidget::onListSearchResultsContextMenu(QPoint pos)
 {
 	QMenu* contextMenu = new QMenu(tr("Search Results List Context Menu"), m_ui.listSearchResults);
 	const QItemSelectionModel* selModel = m_ui.listSearchResults->selectionModel();
+	const auto listSearchResults = m_ui.listSearchResults;
 
 	if (selModel->hasSelection())
 	{
 		QAction* goToDisassemblyAction = new QAction(tr("Go to in Disassembly"), m_ui.listSearchResults);
 		connect(goToDisassemblyAction, &QAction::triggered, this, &CpuWidget::contextSearchResultGoToDisassembly);
 		contextMenu->addAction(goToDisassemblyAction);
+
+		QAction* addToSavedAddressesAction = new QAction(tr("Add to Saved Memory Addresses"), m_ui.listSearchResults);
+		connect(addToSavedAddressesAction, &QAction::triggered, this, [this, listSearchResults]() {
+			addAddressToSavedAddressesList(listSearchResults->selectedItems().first()->data(Qt::UserRole).toUInt());
+		});
+		contextMenu->addAction(addToSavedAddressesAction);
 
 		QAction* removeResultAction = new QAction(tr("Remove Result"), m_ui.listSearchResults);
 		connect(removeResultAction, &QAction::triggered, this, &CpuWidget::contextRemoveSearchResult);

--- a/pcsx2-qt/Debugger/CpuWidget.cpp
+++ b/pcsx2-qt/Debugger/CpuWidget.cpp
@@ -102,7 +102,11 @@ CpuWidget::CpuWidget(QWidget* parent, DebugInterface& cpu)
 	m_ui.listSearchResults->setContextMenuPolicy(Qt::CustomContextMenu);
 	connect(m_ui.btnSearch, &QPushButton::clicked, this, &CpuWidget::onSearchButtonClicked);
 	connect(m_ui.btnFilterSearch, &QPushButton::clicked, this, &CpuWidget::onSearchButtonClicked);
-	connect(m_ui.listSearchResults, &QListWidget::itemDoubleClicked, [this](QListWidgetItem* item) { m_ui.memoryviewWidget->gotoAddress(item->text().toUInt(nullptr, 16)); });
+	connect(m_ui.listSearchResults, &QListWidget::itemDoubleClicked, [this](QListWidgetItem* item)
+	{
+		m_ui.tabWidget->setCurrentWidget(m_ui.tab_memory);
+		m_ui.memoryviewWidget->gotoAddress(item->text().toUInt(nullptr, 16));
+	});
 	connect(m_ui.listSearchResults->verticalScrollBar(), &QScrollBar::valueChanged, this, &CpuWidget::onSearchResultsListScroll);
 	connect(m_ui.listSearchResults, &QListView::customContextMenuRequested, this, &CpuWidget::onListSearchResultsContextMenu);
 	connect(m_ui.cmbSearchType, &QComboBox::currentIndexChanged, [this](int i) {

--- a/pcsx2-qt/Debugger/CpuWidget.h
+++ b/pcsx2-qt/Debugger/CpuWidget.h
@@ -13,6 +13,7 @@
 #include "Models/BreakpointModel.h"
 #include "Models/ThreadModel.h"
 #include "Models/StackModel.h"
+#include "Models/SavedAddressesModel.h"
 
 #include "QtHost.h"
 #include <QtWidgets/QWidget>
@@ -74,6 +75,11 @@ public slots:
 	void contextBPListEdit();
 	void contextBPListPasteCSV();
 
+	void onSavedAddressesListContextMenu(QPoint pos);
+	void contextSavedAddressesListPasteCSV();
+	void contextSavedAddressesListNew();
+	void addAddressToSavedAddressesList(u32 address);
+
 	void updateThreads();
 	void onThreadListDoubleClick(const QModelIndex& index);
 	void onThreadListContextMenu(QPoint pos);
@@ -128,6 +134,7 @@ private:
 	ThreadModel m_threadModel;
 	QSortFilterProxyModel m_threadProxyModel;
 	StackModel m_stackModel;
+	SavedAddressesModel m_savedAddressesModel;
 	QTimer m_resultsLoadTimer;
 
 	bool m_demangleFunctions = true;

--- a/pcsx2-qt/Debugger/CpuWidget.ui
+++ b/pcsx2-qt/Debugger/CpuWidget.ui
@@ -582,6 +582,38 @@
          </item>
         </layout>
        </widget>
+       <widget class="QWidget" name="tab_savedaddresses">
+        <attribute name="title">
+         <string>Saved Addresses</string>
+        </attribute>
+        <layout class="QHBoxLayout" name="horizontalLayout_9">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QTableView" name="savedAddressesList">
+           <property name="contextMenuPolicy">
+            <enum>Qt::CustomContextMenu</enum>
+           </property>
+           <property name="horizontalScrollBarPolicy">
+            <enum>Qt::ScrollBarAlwaysOff</enum>
+           </property>
+           <property name="gridStyle">
+            <enum>Qt::NoPen</enum>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
       </widget>
      </item>
     </layout>

--- a/pcsx2-qt/Debugger/MemoryViewWidget.cpp
+++ b/pcsx2-qt/Debugger/MemoryViewWidget.cpp
@@ -424,6 +424,10 @@ void MemoryViewWidget::customMenuRequested(QPoint pos)
 
 		m_contextMenu->addSeparator();
 
+		action = new QAction((tr("Add to Saved Memory Addresses")));
+		m_contextMenu->addAction(action);
+		connect(action, &QAction::triggered, this, [this]() { emit addToSavedAddresses(m_table.selectedAddress); });
+
 		action = new QAction(tr("Copy Byte"));
 		m_contextMenu->addAction(action);
 		connect(action, &QAction::triggered, this, [this]() { contextCopyByte(); });

--- a/pcsx2-qt/Debugger/MemoryViewWidget.h
+++ b/pcsx2-qt/Debugger/MemoryViewWidget.h
@@ -104,6 +104,7 @@ public slots:
 
 signals:
 	void gotoInDisasm(u32 address, bool should_set_focus = true);
+	void addToSavedAddresses(u32 address);
 	void VMUpdate();
 
 private:

--- a/pcsx2-qt/Debugger/Models/SavedAddressesModel.cpp
+++ b/pcsx2-qt/Debugger/Models/SavedAddressesModel.cpp
@@ -1,0 +1,152 @@
+// SPDX-FileCopyrightText: 2002-2024 PCSX2 Dev Team
+// SPDX-License-Identifier: LGPL-3.0+
+
+#include "PrecompiledHeader.h"
+#include "SavedAddressesModel.h"
+
+SavedAddressesModel::SavedAddressesModel(DebugInterface& cpu, QObject* parent)
+	: QAbstractTableModel(parent)
+	, m_cpu(cpu)
+{
+}
+
+QVariant SavedAddressesModel::data(const QModelIndex& index, int role) const
+{
+	if (role == Qt::CheckStateRole)
+	{
+		return QVariant();
+	}
+
+	if (role == Qt::DisplayRole || role == Qt::EditRole)
+	{
+		SavedAddress savedAddress = m_savedAddresses.at(index.row());
+		switch (index.column())
+		{
+			case HeaderColumns::ADDRESS:
+				return QString::number(savedAddress.address, 16).toUpper();
+			case HeaderColumns::LABEL:
+				return savedAddress.label;
+			case HeaderColumns::DESCRIPTION:
+				return savedAddress.description;
+		}
+	}
+	if (role == Qt::UserRole)
+	{
+		SavedAddress savedAddress = m_savedAddresses.at(index.row());
+		switch (index.column())
+		{
+			case HeaderColumns::ADDRESS:
+				return savedAddress.address;
+			case HeaderColumns::LABEL:
+				return savedAddress.label;
+			case HeaderColumns::DESCRIPTION:
+				return savedAddress.description;
+		}
+	}
+	return QVariant();
+}
+
+bool SavedAddressesModel::setData(const QModelIndex& index, const QVariant& value, int role)
+{
+	if (role == Qt::CheckStateRole)
+	{
+		return false;
+	}
+
+	if (role == Qt::EditRole)
+	{
+		SavedAddress addressToEdit = m_savedAddresses.at(index.row());
+		if (index.column() == HeaderColumns::ADDRESS)
+		{
+			bool ok = false;
+			const u32 address = value.toString().toUInt(&ok, 16);
+			if (ok)
+				addressToEdit.address = address;
+			else
+				return false;
+		}
+		if (index.column() == HeaderColumns::DESCRIPTION)
+			addressToEdit.description = value.toString();
+		if (index.column() == HeaderColumns::LABEL)
+			addressToEdit.label = value.toString();
+		m_savedAddresses.at(index.row()) = addressToEdit;
+
+		emit dataChanged(index, index, QList<int>(role));
+		return true;
+	}
+	else if (role == Qt::UserRole)
+	{
+		SavedAddress addressToEdit = m_savedAddresses.at(index.row());
+		if (index.column() == HeaderColumns::ADDRESS)
+		{
+			const u32 address = value.toUInt();
+			addressToEdit.address = address;
+		}
+		if (index.column() == HeaderColumns::DESCRIPTION)
+			addressToEdit.description = value.toString();
+		if (index.column() == HeaderColumns::LABEL)
+			addressToEdit.label = value.toString();
+		m_savedAddresses.at(index.row()) = addressToEdit;
+
+		emit dataChanged(index, index, QList<int>(role));
+		return true;
+	}
+	return false;
+}
+
+QVariant SavedAddressesModel::headerData(int section, Qt::Orientation orientation, int role) const
+{
+	if ((role != Qt::DisplayRole && role != Qt::EditRole) || orientation != Qt::Horizontal)
+		return QVariant();
+
+	switch (section)
+	{
+		case SavedAddressesModel::ADDRESS:
+			return tr("MEMORY ADDRESS");
+		case SavedAddressesModel::LABEL:
+			return tr("LABEL");
+		case SavedAddressesModel::DESCRIPTION:
+			return tr("DESCRIPTION");
+		default:
+			return QVariant();
+	}
+}
+
+Qt::ItemFlags SavedAddressesModel::flags(const QModelIndex& index) const
+{
+	return Qt::ItemIsEnabled | Qt::ItemIsSelectable | Qt::ItemIsEditable;
+}
+
+void SavedAddressesModel::addRow()
+{
+	const SavedAddress defaultNewAddress = {NULL, "Name", "Description"};
+	addRow(defaultNewAddress);
+}
+
+void SavedAddressesModel::addRow(SavedAddress addresstoSave)
+{
+	const int newRowIndex = m_savedAddresses.size();
+	beginInsertRows(QModelIndex(), newRowIndex, newRowIndex);
+	m_savedAddresses.push_back(addresstoSave);
+	endInsertRows();
+}
+
+bool SavedAddressesModel::removeRows(int row, int count, const QModelIndex& parent)
+{
+	if (row + count > m_savedAddresses.size() || row < 0 || count < 1)
+		return false;
+	beginRemoveRows(parent, row, row + count - 1);
+	m_savedAddresses.erase(m_savedAddresses.begin() + row, m_savedAddresses.begin() + row + count);
+	endRemoveRows();
+	return true;
+}
+
+int SavedAddressesModel::rowCount(const QModelIndex&) const
+{
+	return m_savedAddresses.size();
+}
+
+int SavedAddressesModel::columnCount(const QModelIndex&) const
+{
+	return HeaderColumns::COLUMN_COUNT;
+}

--- a/pcsx2-qt/Debugger/Models/SavedAddressesModel.h
+++ b/pcsx2-qt/Debugger/Models/SavedAddressesModel.h
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: 2002-2024 PCSX2 Dev Team
+// SPDX-License-Identifier: LGPL-3.0+
+
+#pragma once
+
+#include <QtCore/QAbstractTableModel>
+#include <QtWidgets/QHeaderView>
+
+#include "DebugTools/DebugInterface.h"
+
+class SavedAddressesModel : public QAbstractTableModel
+{
+	Q_OBJECT
+
+public:
+	struct SavedAddress
+	{
+		u32 address;
+		QString label;
+		QString description;
+	};
+
+	enum HeaderColumns : int
+	{
+		ADDRESS = 0,
+		LABEL,
+		DESCRIPTION,
+		COLUMN_COUNT
+	};
+
+	static constexpr QHeaderView::ResizeMode HeaderResizeModes[HeaderColumns::COLUMN_COUNT] =
+	{
+		QHeaderView::ResizeMode::ResizeToContents,
+		QHeaderView::ResizeMode::ResizeToContents,
+		QHeaderView::ResizeMode::Stretch,
+	};
+
+	explicit SavedAddressesModel(DebugInterface& cpu, QObject* parent = nullptr);
+	QVariant data(const QModelIndex& index, int role) const override;
+	QVariant headerData(int section, Qt::Orientation orientation, int role) const override;
+	int rowCount(const QModelIndex& parent = QModelIndex()) const override;
+	int columnCount(const QModelIndex& parent = QModelIndex()) const override;
+	Qt::ItemFlags flags(const QModelIndex& index) const override;
+	void addRow();
+	void addRow(SavedAddress addresstoSave);
+	bool removeRows(int row, int count, const QModelIndex& parent = QModelIndex()) override;
+	bool setData(const QModelIndex& index, const QVariant& value, int role) override;
+
+private:
+	DebugInterface& m_cpu;
+	std::vector<SavedAddress> m_savedAddresses;
+};

--- a/pcsx2-qt/pcsx2-qt.vcxproj
+++ b/pcsx2-qt/pcsx2-qt.vcxproj
@@ -108,6 +108,7 @@
     <ClCompile Include="Debugger\Models\BreakpointModel.cpp" />
     <ClCompile Include="Debugger\Models\ThreadModel.cpp" />
     <ClCompile Include="Debugger\Models\StackModel.cpp" />
+    <ClCompile Include="Debugger\Models\SavedAddressesModel.cpp" />
     <ClCompile Include="Settings\BIOSSettingsWidget.cpp" />
     <ClCompile Include="Settings\ControllerBindingWidgets.cpp" />
     <ClCompile Include="Settings\ControllerGlobalSettingsWidget.cpp" />
@@ -196,6 +197,7 @@
     <QtMoc Include="Debugger\Models\BreakpointModel.h" />
     <QtMoc Include="Debugger\Models\ThreadModel.h" />
     <QtMoc Include="Debugger\Models\StackModel.h" />
+    <QtMoc Include="Debugger\Models\SavedAddressesModel.h" />
     <QtMoc Include="Settings\ControllerBindingWidgets.h" />
     <QtMoc Include="Settings\ControllerGlobalSettingsWidget.h" />
     <ClInclude Include="Settings\MemoryCardConvertWorker.h" />
@@ -251,6 +253,7 @@
     <ClCompile Include="$(IntDir)Debugger\Models\moc_BreakpointModel.cpp" />
     <ClCompile Include="$(IntDir)Debugger\Models\moc_ThreadModel.cpp" />
     <ClCompile Include="$(IntDir)Debugger\Models\moc_StackModel.cpp" />
+    <ClCompile Include="$(IntDir)Debugger\Models\moc_SavedAddressesModel.cpp" />
     <ClCompile Include="$(IntDir)GameList\moc_GameListModel.cpp" />
     <ClCompile Include="$(IntDir)GameList\moc_GameListRefreshThread.cpp" />
     <ClCompile Include="$(IntDir)GameList\moc_GameListWidget.cpp" />

--- a/pcsx2-qt/pcsx2-qt.vcxproj.filters
+++ b/pcsx2-qt/pcsx2-qt.vcxproj.filters
@@ -287,6 +287,9 @@
     <ClCompile Include="Debugger\Models\StackModel.cpp">
       <Filter>Debugger\Models</Filter>
     </ClCompile>
+    <ClCompile Include="Debugger\Models\SavedAddressesModel.cpp">
+      <Filter>Debugger\Models</Filter>
+    </ClCompile>
     <ClCompile Include="$(IntDir)Debugger\moc_CpuWidget.cpp">
       <Filter>moc</Filter>
     </ClCompile>
@@ -312,6 +315,9 @@
       <Filter>moc</Filter>
     </ClCompile>
     <ClCompile Include="$(IntDir)Debugger\Models\moc_StackModel.cpp">
+      <Filter>moc</Filter>
+    </ClCompile>
+    <ClCompile Include="$(IntDir)Debugger\Models\moc_SavedAddressesModel.cpp">
       <Filter>moc</Filter>
     </ClCompile>
     <ClCompile Include="ColorPickerButton.cpp" />
@@ -480,6 +486,9 @@
       <Filter>Debugger\Models</Filter>
     </QtMoc>
     <QtMoc Include="Debugger\Models\StackModel.h">
+      <Filter>Debugger\Models</Filter>
+    </QtMoc>
+    <QtMoc Include="Debugger\Models\SavedAddressesModel.h">
       <Filter>Debugger\Models</Filter>
     </QtMoc>
     <QtMoc Include="ColorPickerButton.h" />


### PR DESCRIPTION
### Description of Changes
Adds the ability to save memory addresses to a newly added `Saved Addresses` tab widget in the debugger.
Works as a way to bookmark memory addresses and allow jumping back to saved addresses.
![PCSX2-SavedAddresses](https://github.com/PCSX2/pcsx2/assets/4957200/9aba3966-02ce-4610-8abc-38924128f21d)

Adds the ability to add memory addresses as a Saved Addresses from the Memory Search results list context menu and `Memory View` context menu. Also allows exporting and importing the Saved Addresses in CSV format so that users can save/restore their addresses.

### Additional changes
- Updates double clicking Memory Search results to change the current tab to the `Memory View`. Previously it would change the address but stay on the same widget (thus not showing the address to the user).
- Replaces uses of the number `256` as a literal in place of `Qt::UserRole` to make it more clear what it's purpose is/where the number stems from.
- Const changes to address warnings in otherwise unrelated code in `CpuWidget.cpp`.


### Rationale behind Changes
Helps making keeping track of memory addresses/search results easier by allowing the user to give labels/descriptions and immediately jump back to that address in the `Memory View` or `Disassembly View`.

This makes it easier to juggle between different memory addresses and remembering details about each, and being able to quickly compare different areas of memory.

### Suggested Testing Steps
- Verify adding a new Saved Address from: The `Saved Addresses` context menu; memory search result context menu; and `Memory View` context menu.
- Exporting/Importing CSV of saved addresses adds the expected addresses.
- Going to disassembly and memory views is working as expected.
- Double clicking a memory search result while on a non-`Memory View` tab takes you to the `Memory View` tab.