### PR TITLE
IOP HLE: Fix broken dopen implementation

### DIFF
--- a/pcsx2/IopBios.cpp
+++ b/pcsx2/IopBios.cpp
@@ -403,9 +403,11 @@ namespace R3000A
 			std::string relativePath = full_path.substr(full_path.find(':') + 1);
 			std::string path = host_path(relativePath, true);
 
-			FileSystem::FindResultsArray results;
-			if (!FileSystem::FindFiles(path.c_str(), "*", FILESYSTEM_FIND_FILES | FILESYSTEM_FIND_FOLDERS | FILESYSTEM_FIND_RELATIVE_PATHS | FILESYSTEM_FIND_HIDDEN_FILES, &results))
+			if (!FileSystem::DirectoryExists(path.c_str()))
 				return -IOP_ENOENT; // Should return ENOTDIR if path is a file?
+
+			FileSystem::FindResultsArray results;
+			FileSystem::FindFiles(path.c_str(), "*", FILESYSTEM_FIND_FILES | FILESYSTEM_FIND_FOLDERS | FILESYSTEM_FIND_RELATIVE_PATHS | FILESYSTEM_FIND_HIDDEN_FILES, &results);
 
 			*dir = new HostDir(std::move(results), std::move(path));
 			if (!*dir)


### PR DESCRIPTION
Regression from https://github.com/pcsx2/pcsx2/commit/bbc0bcae1e39bea6f49f89a08a4bb67b5edb4eac (#6551)
FindFiles returns false when the directory is empty or the path is NULL, **not** when there is an error like the old GHC implementation. This made it so you couldn't `dopen` an empty directory.
