### PR TITLE
Qt: Clear Settings button disables Cheats/Patches

### DIFF
--- a/pcsx2-qt/Settings/GameCheatSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GameCheatSettingsWidget.cpp
@@ -80,6 +80,13 @@ void GameCheatSettingsWidget::updateListEnabled()
 	m_ui.reloadCheats->setEnabled(cheats_enabled);
 }
 
+void GameCheatSettingsWidget::disableAllCheats()
+{
+	SettingsInterface* si = m_dialog->getSettingsInterface();
+	si->ClearSection(Patch::CHEATS_CONFIG_SECTION);
+	si->Save();
+}
+
 void GameCheatSettingsWidget::setCheatEnabled(std::string name, bool enabled, bool save_and_reload_settings)
 {
 	SettingsInterface* si = m_dialog->getSettingsInterface();

--- a/pcsx2-qt/Settings/GameCheatSettingsWidget.h
+++ b/pcsx2-qt/Settings/GameCheatSettingsWidget.h
@@ -28,6 +28,7 @@ class GameCheatSettingsWidget : public QWidget
 
 public:
 	GameCheatSettingsWidget(SettingsWindow* dialog, QWidget* parent);
+	void disableAllCheats();
 	~GameCheatSettingsWidget();
 
 private Q_SLOTS:

--- a/pcsx2-qt/Settings/GamePatchSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GamePatchSettingsWidget.cpp
@@ -71,6 +71,13 @@ void GamePatchSettingsWidget::onReloadClicked()
 	g_emu_thread->reloadPatches();
 }
 
+void GamePatchSettingsWidget::disableAllPatches()
+{
+	SettingsInterface* si = m_dialog->getSettingsInterface();
+	si->ClearSection(Patch::PATCHES_CONFIG_SECTION);
+	si->Save();
+}
+
 void GamePatchSettingsWidget::reloadList()
 {
 	// Patches shouldn't have any unlabelled patch groups, because they're new.

--- a/pcsx2-qt/Settings/GamePatchSettingsWidget.h
+++ b/pcsx2-qt/Settings/GamePatchSettingsWidget.h
@@ -41,6 +41,7 @@ class GamePatchSettingsWidget : public QWidget
 
 public:
 	GamePatchSettingsWidget(SettingsWindow* dialog, QWidget* parent);
+	void disableAllPatches();
 	~GamePatchSettingsWidget();
 
 private Q_SLOTS:

--- a/pcsx2-qt/Settings/SettingsWindow.cpp
+++ b/pcsx2-qt/Settings/SettingsWindow.cpp
@@ -314,6 +314,9 @@ void SettingsWindow::onClearSettingsClicked()
 		return;
 	}
 
+	m_game_cheat_settings_widget->disableAllCheats();
+	m_game_patch_settings_widget->disableAllPatches();
+
 	Pcsx2Config::ClearConfiguration(m_sif.get());
 	m_sif->Save();
 	g_emu_thread->reloadGameSettings();


### PR DESCRIPTION
### Description of Changes
The `Clear Settings` button will now disable all cheats and patches from the configuration. This will allow quickly resetting to having no game altering pnach patches/cheats.

Implements #10255

### Rationale behind Changes
One may expect all their configuration for a game including patch/cheat selections to disable when pressing the `Clear Settings` button. This allows them to reset to a full default as cheats/patches can make a significant impact on the game.

### Suggested Testing Steps
Verify all patches/cheats are removed from the gamesettings config.