### PR TITLE
Qt: Make Patch/Cheat Settings 'Show All CRCs' a toggle-able setting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,7 @@ oprofile_data/
 /bin/bios
 /bin/cache
 /bin/cheats
+/bin/patches
 /bin/covers
 /bin/dumps
 /bin/gamesettings

--- a/pcsx2-qt/Settings/GameCheatSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GameCheatSettingsWidget.cpp
@@ -23,6 +23,7 @@ GameCheatSettingsWidget::GameCheatSettingsWidget(SettingsWindow* dialog, QWidget
 
 	SettingsInterface* sif = m_dialog->getSettingsInterface();
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.enableCheats, "EmuCore", "EnableCheats", false);
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.allCRCsCheckbox, "EmuCore", "ShowCheatsForAllCRCs", false);
 	updateListEnabled();
 
 	connect(m_ui.enableCheats, &QCheckBox::stateChanged, this, &GameCheatSettingsWidget::updateListEnabled);
@@ -31,6 +32,7 @@ GameCheatSettingsWidget::GameCheatSettingsWidget(SettingsWindow* dialog, QWidget
 	connect(m_ui.reloadCheats, &QPushButton::clicked, this, &GameCheatSettingsWidget::onReloadClicked);
 	connect(m_ui.enableAll, &QPushButton::clicked, this, [this]() { setStateForAll(true); });
 	connect(m_ui.disableAll, &QPushButton::clicked, this, [this]() { setStateForAll(false); });
+	connect(m_ui.allCRCsCheckbox, &QCheckBox::stateChanged, this, &GameCheatSettingsWidget::onReloadClicked);
 }
 
 GameCheatSettingsWidget::~GameCheatSettingsWidget() = default;
@@ -78,6 +80,7 @@ void GameCheatSettingsWidget::updateListEnabled()
 	m_ui.enableAll->setEnabled(cheats_enabled);
 	m_ui.disableAll->setEnabled(cheats_enabled);
 	m_ui.reloadCheats->setEnabled(cheats_enabled);
+	m_ui.allCRCsCheckbox->setEnabled(cheats_enabled);
 }
 
 void GameCheatSettingsWidget::setCheatEnabled(std::string name, bool enabled, bool save_and_reload_settings)
@@ -138,7 +141,8 @@ void GameCheatSettingsWidget::setStateRecursively(QTreeWidgetItem* parent, bool 
 void GameCheatSettingsWidget::reloadList()
 {
 	u32 num_unlabelled_codes = 0;
-	m_patches = Patch::GetPatchInfo(m_dialog->getSerial(), m_dialog->getDiscCRC(), true, &num_unlabelled_codes);
+	bool showAllCRCS = m_ui.allCRCsCheckbox->isChecked();
+	m_patches = Patch::GetPatchInfo(m_dialog->getSerial(), m_dialog->getDiscCRC(), true, showAllCRCS, & num_unlabelled_codes);
 	m_enabled_patches =
 		m_dialog->getSettingsInterface()->GetStringList(Patch::CHEATS_CONFIG_SECTION, Patch::PATCH_ENABLE_CONFIG_KEY);
 

--- a/pcsx2-qt/Settings/GameCheatSettingsWidget.ui
+++ b/pcsx2-qt/Settings/GameCheatSettingsWidget.ui
@@ -85,6 +85,16 @@
       </widget>
      </item>
      <item>
+      <widget class="QCheckBox" name="allCRCsCheckbox">
+       <property name="text">
+        <string>All CRCs</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
       <spacer name="horizontalSpacer">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>

--- a/pcsx2-qt/Settings/GamePatchSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GamePatchSettingsWidget.cpp
@@ -5,6 +5,7 @@
 #include "QtHost.h"
 #include "QtUtils.h"
 #include "Settings/GamePatchSettingsWidget.h"
+#include "SettingWidgetBinder.h"
 #include "Settings/SettingsWindow.h"
 
 #include "pcsx2/GameList.h"
@@ -57,6 +58,9 @@ GamePatchSettingsWidget::GamePatchSettingsWidget(SettingsWindow* dialog, QWidget
 	setUnlabeledPatchesWarningVisibility(false);
 
 	connect(m_ui.reload, &QPushButton::clicked, this, &GamePatchSettingsWidget::onReloadClicked);
+	connect(m_ui.allCRCsCheckbox, &QCheckBox::stateChanged, this, &GamePatchSettingsWidget::onReloadClicked);
+	SettingsInterface* sif = m_dialog->getSettingsInterface();
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.allCRCsCheckbox, "EmuCore", "ShowPatchesForAllCRCs", false);
 
 	reloadList();
 }
@@ -75,7 +79,8 @@ void GamePatchSettingsWidget::reloadList()
 {
 	// Patches shouldn't have any unlabelled patch groups, because they're new.
 	u32 number_of_unlabeled_patches = 0;
-	std::vector<Patch::PatchInfo> patches = Patch::GetPatchInfo(m_dialog->getSerial(), m_dialog->getDiscCRC(), false, &number_of_unlabeled_patches);
+	bool showAllCRCS = m_ui.allCRCsCheckbox->isChecked();
+	std::vector<Patch::PatchInfo> patches = Patch::GetPatchInfo(m_dialog->getSerial(), m_dialog->getDiscCRC(), false, showAllCRCS, &number_of_unlabeled_patches);
 	std::vector<std::string> enabled_list =
 		m_dialog->getSettingsInterface()->GetStringList(Patch::PATCHES_CONFIG_SECTION, Patch::PATCH_ENABLE_CONFIG_KEY);
 

--- a/pcsx2-qt/Settings/GamePatchSettingsWidget.ui
+++ b/pcsx2-qt/Settings/GamePatchSettingsWidget.ui
@@ -53,6 +53,19 @@
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
+      <widget class="QCheckBox" name="allCRCsCheckbox">
+       <property name="enabled">
+        <bool>true</bool>
+       </property>
+       <property name="text">
+        <string>All CRCs</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
       <spacer name="horizontalSpacer">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>

--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -2414,9 +2414,9 @@ void FullscreenUI::PopulatePatchesAndCheatsList(const std::string_view& serial, 
 		std::sort(list.begin(), list.end(), [](const Patch::PatchInfo& lhs, const Patch::PatchInfo& rhs) { return lhs.name < rhs.name; });
 	};
 
-	s_game_patch_list = Patch::GetPatchInfo(serial, crc, false, nullptr);
+	s_game_patch_list = Patch::GetPatchInfo(serial, crc, false, true, nullptr);
 	sort_patches(s_game_patch_list);
-	s_game_cheats_list = Patch::GetPatchInfo(serial, crc, true, &s_game_cheat_unlabelled_count);
+	s_game_cheats_list = Patch::GetPatchInfo(serial, crc, true, true, &s_game_cheat_unlabelled_count);
 	sort_patches(s_game_cheats_list);
 
 	pxAssert(s_game_settings_interface);

--- a/pcsx2/Patch.cpp
+++ b/pcsx2/Patch.cpp
@@ -518,14 +518,14 @@ std::string_view Patch::PatchInfo::GetNameParentPart() const
 	return ret;
 }
 
-Patch::PatchInfoList Patch::GetPatchInfo(const std::string_view& serial, u32 crc, bool cheats, u32* num_unlabelled_patches)
+Patch::PatchInfoList Patch::GetPatchInfo(const std::string_view& serial, u32 crc, bool cheats, bool showAllCRCS, u32* num_unlabelled_patches)
 {
 	PatchInfoList ret;
 
 	if (num_unlabelled_patches)
 		*num_unlabelled_patches = 0;
 
-	EnumeratePnachFiles(serial, crc, cheats, true,
+	EnumeratePnachFiles(serial, crc, cheats, showAllCRCS,
 		[&ret, num_unlabelled_patches](const std::string& filename, const std::string& pnach_data) {
 			ExtractPatchInfo(&ret, pnach_data, num_unlabelled_patches);
 		});

--- a/pcsx2/Patch.h
+++ b/pcsx2/Patch.h
@@ -81,7 +81,7 @@ namespace Patch
 	extern const char* CHEATS_CONFIG_SECTION;
 	extern const char* PATCH_ENABLE_CONFIG_KEY;
 
-	extern PatchInfoList GetPatchInfo(const std::string_view& serial, u32 crc, bool cheats, u32* num_unlabelled_patches);
+	extern PatchInfoList GetPatchInfo(const std::string_view& serial, u32 crc, bool cheats, bool showAllCRCS, u32* num_unlabelled_patches);
 
 	/// Returns the path to a new cheat/patch pnach for the specified serial and CRC.
 	extern std::string GetPnachFilename(const std::string_view& serial, u32 crc, bool cheats);


### PR DESCRIPTION
### Description of Changes
Makes the default functionality to search for Cheats/Patches for all CRCs for a particular game a toggle-able setting.
This functionality was changed in #9246, changing it from only showing the current CRC to showing all available CRCs. This keeps the new functionality as default while allowing the ability to override it.

![PCSX2-AllCRCs](https://github.com/PCSX2/pcsx2/assets/4957200/94e48d24-f7ed-4348-be10-2dd6381f0654)

**Note:** Also adds `/bin/patches` to `.gitignore` so patches in the development folder aren't considered a commit-able change. (Just as the cheats folder is currently handled)
___
### Rationale behind Changes
This helps for decluttering cheat lists and showing only Cheats/Patches meant for a particular CRC.
As one who owns multiple regions in order to write patches for different versions (and thus has many copies of a patch that are incompatible with each other) it is difficult to deal with. Being able to keep the current setting by default but be able to toggle it off is ideal.
___
### Suggested Testing Steps
Pre-test steps:
- If own two copies of a game with different CRCs but the same serial, one can test via having a patch or cheat file for each CRC.
- If you don't, you can still make a second patch for your game serial with a madeup CRC.

Toggling the checkbox will filter out patches/cheats that aren't for the current CRC, and show them again when toggled back on.

This setting is also integrated into per game settings, so verifying the `.ini` would be good. And that is removed when clearing settings.

Testing that the setting stays the same upon closing and reopening the settings window and after restarting PCSX2.