### PR TITLE
GS: Fix autoflush init after renderer switch

### DIFF
--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -24,12 +24,12 @@ int GSState::s_transfer_n = 0;
 
 static __fi bool IsAutoFlushEnabled()
 {
-	return (GSConfig.Renderer == GSRendererType::SW) ? GSConfig.AutoFlushSW : (GSConfig.UserHacks_AutoFlush != GSHWAutoFlushLevel::Disabled);
+	return GSIsHardwareRenderer() ? (GSConfig.UserHacks_AutoFlush != GSHWAutoFlushLevel::Disabled) : GSConfig.AutoFlushSW;
 }
 
 static __fi bool IsFirstProvokingVertex()
 {
-	return (GSConfig.Renderer != GSRendererType::SW && !g_gs_device->Features().provoking_vertex_last);
+	return (GSIsHardwareRenderer() && !g_gs_device->Features().provoking_vertex_last);
 }
 
 constexpr int GSState::GetSaveStateSize()

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -3467,7 +3467,8 @@ bool GSTextureCache::Move(u32 SBP, u32 SBW, u32 SPSM, int sx, int sy, u32 DBP, u
 
 	// DX11/12 is a bit lame and can't partial copy depth targets. We could do this with a blit instead,
 	// but so far haven't seen anything which needs it.
-	if (GSConfig.Renderer == GSRendererType::DX11 || GSConfig.Renderer == GSRendererType::DX12)
+	const GSRendererType renderer = GSGetCurrentRenderer();
+	if (renderer == GSRendererType::DX11 || renderer == GSRendererType::DX12)
 	{
 		if (spsm_s.depth || dpsm_s.depth)
 			return false;

--- a/pcsx2/MTGS.cpp
+++ b/pcsx2/MTGS.cpp
@@ -984,7 +984,7 @@ void MTGS::SetSoftwareRendering(bool software, GSInterlaceMode interlace, bool d
 	if (display_message)
 	{
 		Host::AddIconOSDMessage("SwitchRenderer", ICON_FA_MAGIC, software ?
-			TRANSLATE_STR("GS", "Switching to software renderer...") : TRANSLATE_STR("GS", "Switching to hardware renderer..."),
+			TRANSLATE_STR("GS", "Switching to Software Renderer...") : TRANSLATE_STR("GS", "Switching to Hardware Renderer..."),
 			Host::OSD_QUICK_DURATION);
 	}
 


### PR DESCRIPTION
### Description of Changes

Regression from #10523, and a preexisting issue (switching from sw -> hw).

### Rationale behind Changes

me make a boo boo

### Suggested Testing Steps

Set renderer to software, make sure F9 actually switches to hardware. Check inverse of this.
Make sure catwoman dump is the same in SW, and HW switched to SW.
