### PR TITLE
Core: Set syscon log colour to the EE's log colour

### DIFF
--- a/pcsx2/DebugTools/Debug.h
+++ b/pcsx2/DebugTools/Debug.h
@@ -304,7 +304,6 @@ struct SysConsoleLogPack
 {
 	ConsoleLogSource		ELF;
 	ConsoleLogSource		eeRecPerf;
-	ConsoleLogSource		sysoutConsole;
 	ConsoleLogSource		pgifLog;
 
 	ConsoleLogFromVM<Color_Cyan>		eeConsole;
@@ -374,7 +373,6 @@ extern void __Log( const char* fmt, ... );
 #define eeConLog		SysConsole.eeConsole.IsActive()		&& SysConsole.eeConsole.Write
 #define eeDeci2Log		SysConsole.deci2.IsActive()			&& SysConsole.deci2.Write
 #define iopConLog		SysConsole.iopConsole.IsActive()	&& SysConsole.iopConsole.Write
-#define sysConLog		SysConsole.sysoutConsole.IsActive()	&& SysConsole.sysoutConsole.Write
 #define pgifConLog		SysConsole.pgifLog.IsActive()		&& SysConsole.pgifLog.Write
 #define recordingConLog	SysConsole.recordingConsole.IsActive()	&& SysConsole.recordingConsole.Write
 #define controlLog		SysConsole.controlInfo.IsActive()		&& SysConsole.controlInfo.Write

--- a/pcsx2/LogSink.cpp
+++ b/pcsx2/LogSink.cpp
@@ -400,7 +400,6 @@ void LogSink::UpdateLogging(SettingsInterface& si)
 
 	const bool ee_console_enabled = any_logging_sinks && si.GetBoolValue("Logging", "EnableEEConsole", false);
 	SysConsole.eeConsole.Enabled = ee_console_enabled;
-	SysConsole.sysoutConsole.Enabled = ee_console_enabled;
 
 	SysConsole.iopConsole.Enabled = any_logging_sinks && si.GetBoolValue("Logging", "EnableIOPConsole", false);
 	SysTrace.IOP.R3000A.Enabled = true;

--- a/pcsx2/R5900OpcodeImpl.cpp
+++ b/pcsx2/R5900OpcodeImpl.cpp
@@ -1110,8 +1110,8 @@ void SYSCALL()
 						}
 					}
 				}
-
-				sysConLog(fmt,
+				char buf[2048];
+				snprintf(buf, sizeof(buf), fmt,
 					regs[0],
 					regs[1],
 					regs[2],
@@ -1120,6 +1120,8 @@ void SYSCALL()
 					regs[5],
 					regs[6]
 				);
+
+				eeConLog(buf);
 			}
 			break;
 		}

--- a/pcsx2/SourceLog.cpp
+++ b/pcsx2/SourceLog.cpp
@@ -101,7 +101,6 @@ static const TraceLogDescriptor
 SysConsoleLogPack::SysConsoleLogPack()
 	: ELF(&TLD_ELF, Color_Gray)
 	, eeRecPerf(&TLD_eeRecPerf, Color_Gray)
-	, sysoutConsole(&TLD_sysoutConsole, Color_Gray)
 	, pgifLog(&TLD_Pgif)
 	, eeConsole(&TLD_eeConsole)
 	, iopConsole(&TLD_iopConsole)


### PR DESCRIPTION
### Description of Changes
Remove the syscon logging and merge the syscall logging with the generic EE debug logging

### Rationale behind Changes
It's effectively the same thing. The EE logs cover DECI2 and SIO writes. The syscon logs cover the printf syscall on the EE.

### Suggested Testing Steps
I've tested and it works.