### PR TITLE
Linux: Stop OpenGL overriding Vulkan if both VK and OpenGL are enabled

### DIFF
--- a/pcsx2/GS/GSUtil.cpp
+++ b/pcsx2/GS/GSUtil.cpp
@@ -213,6 +213,7 @@ GSRendererType GSUtil::GetPreferredRenderer()
 #endif
 
 			// Otherwise, whatever is available.
+	if (preferred_renderer == GSRendererType::Auto) // If it's still auto, VK wasn't selected.
 #if defined(ENABLE_OPENGL)
 		preferred_renderer = GSRendererType::OGL;
 #elif defined(ENABLE_VULKAN)


### PR DESCRIPTION
### Description of Changes
Corrects the auto renderer selection on linux if OpenGL and Vulkan are both enabled.

### Rationale behind Changes
If OpenGL was enabled, it was always overriding the renderer with OpenGL, even if Vulkan was fine.

### Suggested Testing Steps
Boot a game on linux (or steamdeck) with the renderer set to auto, make sure it boots using Vulkan if actually supported. You can check this in the emulog for `Allowing Vulkan as default renderer.`
