### PR TITLE
GameDB: Various fixes

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -8886,6 +8886,10 @@ SCPS-51011:
 SCPS-51012:
   name: "Gigantic Drive"
   region: "NTSC-J"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
+    autoFlush: 2 # Fixes DOF effect.
 SCPS-51013:
   name: "Torneko's Adventure 3"
   region: "NTSC-J"
@@ -12912,6 +12916,10 @@ SLES-50211:
   name: "Gauntlet - Dark Legacy"
   region: "PAL-M3"
   compat: 5
+  gsHWFixes:
+    recommendedBlendingLevel: 5 # Corrects lighting to match software.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-50212:
   name: "Paris-Dakar Rally"
   region: "PAL-E"
@@ -15144,7 +15152,7 @@ SLES-51192:
     - EETimingHack # Fixes flickering textures.
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes missing lighting effects.
-    mipmap: 1 # Fixes blurry textures. Full would be ideal here but causes broken face textures on Harry.
+    mipmap: 2 # Fixes blurry textures.
     trilinearFiltering: 1 # Fixes blurry textures.
     cpuFramebufferConversion: 1 # Fixes right side of the screen from garbage textures.
     texturePreloading: 0 # Performs better on certain areas like mid-game in and around the castle as the hash goes easily to 200 MB.
@@ -15155,7 +15163,7 @@ SLES-51193:
     - EETimingHack # Fixes flickering textures.
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes missing lighting effects.
-    mipmap: 1 # Fixes blurry textures. Full would be ideal here but causes broken face textures on Harry.
+    mipmap: 2 # Fixes blurry textures.
     trilinearFiltering: 1 # Fixes blurry textures.
     cpuFramebufferConversion: 1 # Fixes right side of the screen from garbage textures.
     texturePreloading: 0 # Performs better on certain areas like mid-game in and around the castle as the hash goes easily to 200 MB.
@@ -15166,7 +15174,7 @@ SLES-51194:
     - EETimingHack # Fixes flickering textures.
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes missing lighting effects.
-    mipmap: 1 # Fixes blurry textures. Full would be ideal here but causes broken face textures on Harry.
+    mipmap: 2 # Fixes blurry textures.
     trilinearFiltering: 1 # Fixes blurry textures.
     cpuFramebufferConversion: 1 # Fixes right side of the screen from garbage textures.
     texturePreloading: 0 # Performs better on certain areas like mid-game in and around the castle as the hash goes easily to 200 MB.
@@ -15177,7 +15185,7 @@ SLES-51195:
     - EETimingHack # Fixes flickering textures.
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes missing lighting effects.
-    mipmap: 1 # Fixes blurry textures. Full would be ideal here but causes broken face textures on Harry.
+    mipmap: 2 # Fixes blurry textures.
     trilinearFiltering: 1 # Fixes blurry textures.
     cpuFramebufferConversion: 1 # Fixes right side of the screen from garbage textures.
     texturePreloading: 0 # Performs better on certain areas like mid-game in and around the castle as the hash goes easily to 200 MB.
@@ -15188,7 +15196,7 @@ SLES-51196:
     - EETimingHack # Fixes flickering textures.
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes missing lighting effects.
-    mipmap: 1 # Fixes blurry textures. Full would be ideal here but causes broken face textures on Harry.
+    mipmap: 2 # Fixes blurry textures.
     trilinearFiltering: 1 # Fixes blurry textures.
     cpuFramebufferConversion: 1 # Fixes right side of the screen from garbage textures.
     texturePreloading: 0 # Performs better on certain areas like mid-game in and around the castle as the hash goes easily to 200 MB.
@@ -15244,7 +15252,7 @@ SLES-51214:
     - EETimingHack # Fixes flickering textures.
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes missing lighting effects.
-    mipmap: 1 # Fixes blurry textures. Full would be ideal here but causes broken face textures on Harry.
+    mipmap: 2 # Fixes blurry textures.
     trilinearFiltering: 1 # Fixes blurry textures.
     cpuFramebufferConversion: 1 # Fixes right side of the screen from garbage textures.
     texturePreloading: 0 # Performs better on certain areas like mid-game in and around the castle as the hash goes easily to 200 MB.
@@ -15255,7 +15263,7 @@ SLES-51215:
     - EETimingHack # Fixes flickering textures.
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes missing lighting effects.
-    mipmap: 1 # Fixes blurry textures. Full would be ideal here but causes broken face textures on Harry.
+    mipmap: 2 # Fixes blurry textures.
     trilinearFiltering: 1 # Fixes blurry textures.
     cpuFramebufferConversion: 1 # Fixes right side of the screen from garbage textures.
     texturePreloading: 0 # Performs better on certain areas like mid-game in and around the castle as the hash goes easily to 200 MB.
@@ -15266,7 +15274,7 @@ SLES-51216:
     - EETimingHack # Fixes flickering textures.
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes missing lighting effects.
-    mipmap: 1 # Fixes blurry textures. Full would be ideal here but causes broken face textures on Harry.
+    mipmap: 2 # Fixes blurry textures.
     trilinearFiltering: 1 # Fixes blurry textures.
     cpuFramebufferConversion: 1 # Fixes right side of the screen from garbage textures.
     texturePreloading: 0 # Performs better on certain areas like mid-game in and around the castle as the hash goes easily to 200 MB.
@@ -15277,7 +15285,7 @@ SLES-51217:
     - EETimingHack # Fixes flickering textures.
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes missing lighting effects.
-    mipmap: 1 # Fixes blurry textures. Full would be ideal here but causes broken face textures on Harry.
+    mipmap: 2 # Fixes blurry textures.
     trilinearFiltering: 1 # Fixes blurry textures.
     cpuFramebufferConversion: 1 # Fixes right side of the screen from garbage textures.
     texturePreloading: 0 # Performs better on certain areas like mid-game in and around the castle as the hash goes easily to 200 MB.
@@ -15288,7 +15296,7 @@ SLES-51218:
     - EETimingHack # Fixes flickering textures.
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes missing lighting effects.
-    mipmap: 1 # Fixes blurry textures. Full would be ideal here but causes broken face textures on Harry.
+    mipmap: 2 # Fixes blurry textures.
     trilinearFiltering: 1 # Fixes blurry textures.
     cpuFramebufferConversion: 1 # Fixes right side of the screen from garbage textures.
     texturePreloading: 0 # Performs better on certain areas like mid-game in and around the castle as the hash goes easily to 200 MB.
@@ -15299,7 +15307,7 @@ SLES-51219:
     - EETimingHack # Fixes flickering textures.
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes missing lighting effects.
-    mipmap: 1 # Fixes blurry textures. Full would be ideal here but causes broken face textures on Harry.
+    mipmap: 2 # Fixes blurry textures.
     trilinearFiltering: 1 # Fixes blurry textures.
     cpuFramebufferConversion: 1 # Fixes right side of the screen from garbage textures.
     texturePreloading: 0 # Performs better on certain areas like mid-game in and around the castle as the hash goes easily to 200 MB.
@@ -18332,7 +18340,6 @@ SLES-52567:
     recommendedBlendingLevel: 4 # Fixes bloom.
     autoFlush: 1 # Fixes ghosting.
     textureInsideRT: 1 # Required for offset RTs/textures for post-processing.
-    roundSprite: 2 # Fixes misaligned post-processing.
 SLES-52568:
   name: "Crash Twinsanity"
   region: "PAL-M5"
@@ -31725,6 +31732,10 @@ SLPM-62125:
   name-sort: GAUNTLET DARK LEGACY
   name-en: "Gauntlet - Dark Legacy"
   region: "NTSC-J"
+  gsHWFixes:
+    recommendedBlendingLevel: 5 # Corrects lighting to match software.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-62126:
   name: "Hyper Sports 2002 Winter"
   region: "NTSC-J"
@@ -32062,6 +32073,10 @@ SLPM-62209:
   name-sort: ぎがんてぃっく どらいぶ
   name-en: "Gigantic Drive"
   region: "NTSC-J"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
+    autoFlush: 2 # Fixes DOF effect.
 SLPM-62211:
   name: 18WHEELER
   name-sort: 18WHEELER
@@ -32213,7 +32228,7 @@ SLPM-62241:
     - EETimingHack # Fixes flickering textures.
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes missing lighting effects.
-    mipmap: 1 # Fixes blurry textures. Full would be ideal here but causes broken face textures on Harry.
+    mipmap: 2 # Fixes blurry textures.
     trilinearFiltering: 1 # Fixes blurry textures.
     cpuFramebufferConversion: 1 # Fixes right side of the screen from garbage textures.
 SLPM-62244:
@@ -33504,7 +33519,7 @@ SLPM-62513:
     - EETimingHack # Fixes flickering textures.
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes missing lighting effects.
-    mipmap: 1 # Fixes blurry textures. Full would be ideal here but causes broken face textures on Harry.
+    mipmap: 2 # Fixes blurry textures.
     trilinearFiltering: 1 # Fixes blurry textures.
     cpuFramebufferConversion: 1 # Fixes right side of the screen from garbage textures.
 SLPM-62514:
@@ -34861,7 +34876,7 @@ SLPM-64528:
     - EETimingHack # Fixes flickering textures.
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes missing lighting effects.
-    mipmap: 1 # Fixes blurry textures. Full would be ideal here but causes broken face textures on Harry.
+    mipmap: 2 # Fixes blurry textures.
     trilinearFiltering: 1 # Fixes blurry textures.
     cpuFramebufferConversion: 1 # Fixes right side of the screen from garbage textures.
 SLPM-64532:
@@ -35839,6 +35854,10 @@ SLPM-65180:
 SLPM-65181:
   name: "Need for Speed - Hot Pursuit 2"
   region: "NTSC-C"
+  clampModes:
+    vuClampMode: 2 # White textures.
+  gsHWFixes:
+    halfPixelOffset: 1 # Fixes blurriness.
 SLPM-65183:
   name: auto modellista モデムパック バージョン
   name-sort: auto modellista もでむぱっく ばーじょん
@@ -46407,7 +46426,7 @@ SLPM-68005:
     - EETimingHack # Fixes flickering textures.
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes missing lighting effects.
-    mipmap: 1 # Fixes blurry textures. Full would be ideal here but causes broken face textures on Harry.
+    mipmap: 2 # Fixes blurry textures.
     trilinearFiltering: 1 # Fixes blurry textures.
     cpuFramebufferConversion: 1 # Fixes right side of the screen from garbage textures.
 SLPM-68007:
@@ -48153,7 +48172,7 @@ SLPS-20234:
     - EETimingHack # Fixes flickering textures.
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes missing lighting effects.
-    mipmap: 1 # Fixes blurry textures. Full would be ideal here but causes broken face textures on Harry.
+    mipmap: 2 # Fixes blurry textures.
     trilinearFiltering: 1 # Fixes blurry textures.
     cpuFramebufferConversion: 1 # Fixes right side of the screen from garbage textures.
 SLPS-20237:
@@ -50851,13 +50870,17 @@ SLPS-25263:
 SLPS-25264:
   name: ラーゼフォン 蒼穹幻想曲 PLUSCULUS
   name-sort: らーぜふぉん そうきゅうげんそうきょく PLUSCULUS
-  name-en: "RahXephon [Limited Edition]"
+  name-en: "RAhXEPhON - Soukyuu Gensoukyoku [Plusculus]"
   region: "NTSC-J"
+  gsHWFixes:
+    autoFlush: 2 # Fixes DOF effect.
 SLPS-25265:
   name: ラーゼフォン 蒼穹幻想曲 [通常版]
   name-sort: らーぜふぉん そうきゅうげんそうきょく [つうじょうばん]
-  name-en: "RahXephon"
+  name-en: "RAhXEPhON - Soukyuu Gensoukyoku"
   region: "NTSC-J"
+  gsHWFixes:
+    autoFlush: 2 # Fixes DOF effect.
 SLPS-25266:
   name: ザ・キング・オブ・ファイターズ 2001
   name-sort: ざ・きんぐ・おぶ・ふぁいたーず 2001
@@ -55801,6 +55824,10 @@ SLUS-20047:
   name: "Gauntlet - Dark Legacy"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    recommendedBlendingLevel: 5 # Corrects lighting to match software.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-20048:
   name: "Legion - The Legend of Excalibur"
   region: "NTSC-U"
@@ -57593,6 +57620,10 @@ SLUS-20445:
   name: "Robot Alchemic Drive - RAD"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
+    autoFlush: 2 # Fixes DOF effect.
 SLUS-20446:
   name: "Agassi Tennis Generation"
   region: "NTSC-U"
@@ -58261,7 +58292,7 @@ SLUS-20576:
     - EETimingHack # Fixes flickering textures.
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes missing lighting effects.
-    mipmap: 1 # Fixes blurry textures. Full would be ideal here but causes broken face textures on Harry.
+    mipmap: 2 # Fixes blurry textures.
     trilinearFiltering: 1 # Fixes blurry textures.
     cpuFramebufferConversion: 1 # Fixes right side of the screen from garbage textures.
 SLUS-20577:
@@ -60468,7 +60499,6 @@ SLUS-20992:
     recommendedBlendingLevel: 4 # Fixes bloom.
     autoFlush: 1 # Fixes ghosting.
     textureInsideRT: 1 # Required for offset RTs/textures for post-processing.
-    roundSprite: 2 # Fixes misaligned post-processing.
 SLUS-20993:
   name: "Ghosthunter"
   region: "NTSC-U"
@@ -65890,6 +65920,10 @@ SLUS-29022:
 SLUS-29025:
   name: "R.A.D. - Robot Alchemic Drive [Demo]"
   region: "NTSC-U"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
+    autoFlush: 2 # Fixes DOF effect.
 SLUS-29026:
   name: "MX SuperFly [Demo]"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
Fixes for Catwoman Gauntlet Dark Legacy and Robot Alchemic Drive DOF effect.

Before:
![Mobile Suit Gundam Seed Destiny - Rengou vs  Z A F T  II Plus_SLPS-25718_20240105055202](https://github.com/PCSX2/pcsx2/assets/80843560/01aaca70-5860-4523-ad5a-29367819edf5)

After:
![Mobile Suit Gundam Seed Destiny - Rengou vs  Z A F T  II Plus_SLPS-25718_20240105055212](https://github.com/PCSX2/pcsx2/assets/80843560/213ded94-98a2-42cb-8c63-00216974d488)

### Rationale behind Changes
Game broke bad.

### Suggested Testing Steps
Make sure CI is happy.
