### PR TITLE
Patch: Fix last duplicate patch group not being ignored

### DIFF
--- a/pcsx2/Patch.cpp
+++ b/pcsx2/Patch.cpp
@@ -245,6 +245,19 @@ u32 Patch::LoadPatchesFromString(PatchList* patch_list, const std::string& patch
 	const size_t before = patch_list->size();
 
 	PatchGroup current_patch_group;
+	const auto add_current_patch = [patch_list, &current_patch_group]() {
+		// Don't show patches with duplicate names, prefer the first loaded.
+		if (!ContainsPatchName(*patch_list, current_patch_group.name))
+		{
+			patch_list->push_back(std::move(current_patch_group));
+		}
+		else
+		{
+			Console.WriteLn(Color_Gray, fmt::format(
+				"Patch: Skipped loading patch '{}' since a patch with a duplicate name was already loaded.",
+				current_patch_group.name));
+		}
+	};
 
 	std::istringstream ss(patch_file);
 	std::string line;
@@ -264,15 +277,7 @@ u32 Patch::LoadPatchesFromString(PatchList* patch_list, const std::string& patch
 
 			if (!current_patch_group.name.empty() || !current_patch_group.patches.empty())
 			{
-				// Don't show patches with duplicate names, prefer the first loaded.
-				if (!ContainsPatchName(*patch_list, current_patch_group.name))
-				{
-					patch_list->push_back(std::move(current_patch_group));
-				}
-				else
-				{
-					Console.WriteLn(Color_Gray, fmt::format("Patch: Skipped loading patch '{}' since a patch with a duplicate name was already loaded.", current_patch_group.name));
-				}
+				add_current_patch();
 				current_patch_group = {};
 			}
 
@@ -284,7 +289,7 @@ u32 Patch::LoadPatchesFromString(PatchList* patch_list, const std::string& patch
 	}
 
 	if (!current_patch_group.name.empty() || !current_patch_group.patches.empty())
-		patch_list->push_back(std::move(current_patch_group));
+		add_current_patch();
 
 	return static_cast<u32>(patch_list->size() - before);
 }


### PR DESCRIPTION
### Description of Changes

Currently, commands in the **last** patch group defined in a file will still get loaded from the zip, even if it duplicates a local file. Obviously this behaviour wasn't intentional, because anything except the final patch was ignored.

So, make it consistent regardless of the positioning in the file.

### Rationale behind Changes

Fixes the inability to override single-patch-group widescreen cheats.

### Suggested Testing Steps

Already tested.

