### PR TITLE
Misc: Enable some disabled warnings

### DIFF
--- a/cmake/BuildParameters.cmake
+++ b/cmake/BuildParameters.cmake
@@ -195,22 +195,12 @@ endif()
 
 # -Wno-attributes: "always_inline function might not be inlinable" <= real spam (thousand of warnings!!!)
 # -Wno-missing-field-initializers: standard allow to init only the begin of struct/array in static init. Just a silly warning.
-# Note: future GCC (aka GCC 5.1.1) has less false positive so warning could maybe put back
 # -Wno-unused-function: warn for function not used in release build
-# -Wno-unused-value: lots of warning for this kind of statements "0 && ...". There are used to disable some parts of code in release/dev build.
-# -Wno-format*: Yeah, these need to be taken care of, but...
-# -Wno-stringop-truncation: Who comes up with these compiler warnings, anyways?
-# -Wno-stringop-overflow: Probably the same people as this one...
-# -Wno-maybe-uninitialized: Lots of gcc warnings like "‘test.GSVector8i::<anonymous>.GSVector8i::<unnamed union>::m’ may be used uninitialized" if this is removed.
 
 if (MSVC)
 	set(DEFAULT_WARNINGS)
 else()
-	set(DEFAULT_WARNINGS -Wall -Wextra -Wno-attributes -Wno-unused-function -Wno-unused-parameter -Wno-missing-field-initializers -Wno-format -Wno-format-security -Wno-unused-value)
-endif()
-
-if (USE_GCC)
-	list(APPEND DEFAULT_WARNINGS -Wno-stringop-truncation -Wno-stringop-overflow -Wno-maybe-uninitialized )
+	set(DEFAULT_WARNINGS -Wall -Wextra -Wno-unused-function -Wno-unused-parameter -Wno-missing-field-initializers)
 endif()
 
 if (USE_PGO_GENERATE OR USE_PGO_OPTIMIZE)

--- a/pcsx2-qt/Settings/MemoryCardConvertDialog.cpp
+++ b/pcsx2-qt/Settings/MemoryCardConvertDialog.cpp
@@ -259,7 +259,7 @@ void MemoryCardConvertDialog::ConvertCard()
 		while (m_srcCardInfo.type == MemoryCardType::File ? FileSystem::DirectoryExists(Path::Combine(EmuFolders::MemoryCards, destName.toStdString()).c_str()) : FileSystem::FileExists(Path::Combine(EmuFolders::MemoryCards, destName.toStdString()).c_str()))
 		{
 			destName = baseName;
-			destName.append(StringUtil::StdStringFromFormat("_%02d.ps2", ++num).c_str());
+			destName.append(StringUtil::StdStringFromFormat("_%02zd.ps2", ++num).c_str());
 		}
 		
 		m_destCardName = destName;

--- a/pcsx2/DEV9/Sessions/ICMP_Session/ICMP_Session.cpp
+++ b/pcsx2/DEV9/Sessions/ICMP_Session/ICMP_Session.cpp
@@ -550,7 +550,7 @@ namespace Sessions
 					{
 						Console.Error("DEV9: ICMP: Failed to bind socket. Error: %d", errno);
 						::close(icmpSocket);
-						icmpSocket == -1;
+						icmpSocket = -1;
 						return false;
 					}
 				}
@@ -561,7 +561,7 @@ namespace Sessions
 				{
 					Console.Error("DEV9: ICMP: Failed to setsockopt IP_RECVERR. Error: %d", errno);
 					::close(icmpSocket);
-					icmpSocket == -1;
+					icmpSocket = -1;
 					return false;
 				}
 #endif
@@ -571,7 +571,7 @@ namespace Sessions
 				{
 					Console.Error("DEV9: ICMP: Failed to set TTL. Error: %d", errno);
 					::close(icmpSocket);
-					icmpSocket == -1;
+					icmpSocket = -1;
 					return false;
 				}
 
@@ -585,7 +585,7 @@ namespace Sessions
 					{
 						Console.Error("DEV9: ICMP: Failed to get id. Error: %d", errno);
 						::close(icmpSocket);
-						icmpSocket == -1;
+						icmpSocket = -1;
 						return false;
 					}
 
@@ -621,7 +621,7 @@ namespace Sessions
 				{
 					Console.Error("DEV9: ICMP: Send Error %d", errno);
 					::close(icmpSocket);
-					icmpSocket == -1;
+					icmpSocket = -1;
 					return false;
 				}
 

--- a/pcsx2/Dmac.cpp
+++ b/pcsx2/Dmac.cpp
@@ -58,12 +58,12 @@ tDMA_TAG DMACh::dma_tag()
 
 std::string DMACh::cmq_to_str() const
 {
-	return StringUtil::StdStringFromFormat("chcr = %lx, madr = %lx, qwc  = %lx", chcr._u32, madr, qwc);
+	return StringUtil::StdStringFromFormat("chcr = %x, madr = %x, qwc  = %x", chcr._u32, madr, qwc);
 }
 
 std::string DMACh::cmqt_to_str() const
 {
-	return StringUtil::StdStringFromFormat("chcr = %lx, madr = %lx, qwc  = %lx, tadr = %1x", chcr._u32, madr, qwc, tadr);
+	return StringUtil::StdStringFromFormat("chcr = %x, madr = %x, qwc  = %x, tadr = %1x", chcr._u32, madr, qwc, tadr);
 }
 
 __fi void throwBusError(const char *s)

--- a/pcsx2/GS/Renderers/Common/GSFunctionMap.h
+++ b/pcsx2/GS/Renderers/Common/GSFunctionMap.h
@@ -8,6 +8,8 @@
 
 #include "common/HostSys.h"
 
+#include <cinttypes>
+
 template <class KEY, class VALUE>
 class GSFunctionMap
 {
@@ -115,7 +117,7 @@ public:
 			{
 				u64 tpf = p->ticks / p->frames;
 
-				printf("%016llx | %6llu | %5llu | %5.2f%% %5.1f %6.1f | %8llu %6llu %5.2f%%\n",
+				printf("%016" PRIx64 " | %6" PRIu64 " | %5" PRIu64 " | %5.2f%% %5.1f %6.1f | %8" PRIu64 " %6" PRIu64 " %5.2f%%\n",
 					(u64)key,
 					p->frames,
 					p->prims / p->frames,

--- a/pcsx2/GS/Renderers/SW/GSDrawScanlineCodeGenerator.cpp
+++ b/pcsx2/GS/Renderers/SW/GSDrawScanlineCodeGenerator.cpp
@@ -33,7 +33,7 @@ static bool shouldUseCDrawScanline(u64 key)
 			{
 				u64 key;
 				char yn;
-				if (sscanf(str.c_str(), "%llx %c", &key, &yn) == 2)
+				if (sscanf(str.c_str(), "%" PRIx64 " %c", &key, &yn) == 2)
 				{
 					if (yn != 'Y' && yn != 'N' && yn != 'y' && yn != 'n')
 						Console.Warning("Failed to parse %s: Not y/n", str.c_str());
@@ -57,7 +57,7 @@ static bool shouldUseCDrawScanline(u64 key)
 		{
 			for (const auto& pair : s_use_c_draw_scanline)
 			{
-				fprintf(file, "%016llX %c %s\n", pair.first, pair.second ? 'Y' : 'N', GSScanlineSelector(pair.first).to_string().c_str());
+				fprintf(file, "%016" PRIX64 " %c %s\n", pair.first, pair.second ? 'Y' : 'N', GSScanlineSelector(pair.first).to_string().c_str());
 			}
 			fclose(file);
 		}

--- a/pcsx2/GS/Renderers/SW/GSRendererSW.cpp
+++ b/pcsx2/GS/Renderers/SW/GSRendererSW.cpp
@@ -603,7 +603,7 @@ void GSRendererSW::Sync(int reason)
 
 	if constexpr (LOG)
 	{
-		fprintf(s_fp, "sync n=%d r=%d t=%llu p=%d %c\n", s_n, reason, t, pixels, t > 10000000 ? '*' : ' ');
+		fprintf(s_fp, "sync n=%d r=%d t=%" PRIu64 " p=%d %c\n", s_n, reason, t, pixels, t > 10000000 ? '*' : ' ');
 		fflush(s_fp);
 	}
 
@@ -1445,7 +1445,7 @@ GSRendererSW::SharedData::~SharedData()
 
 	if constexpr (LOG)
 	{
-		fprintf(s_fp, "[%d] done t=%lld p=%d | %d %d %d | %08x_%08x\n",
+		fprintf(s_fp, "[%d] done t=%" PRId64 " p=%d | %d %d %d | %08x_%08x\n",
 			counter,
 			GetCPUTicks() - start, pixels,
 			primclass, vertex_count, index_count,

--- a/pcsx2/IPU/IPU_Fifo.cpp
+++ b/pcsx2/IPU/IPU_Fifo.cpp
@@ -51,12 +51,12 @@ void IPU_Fifo::clear()
 
 std::string IPU_Fifo_Input::desc() const
 {
-	return StringUtil::StdStringFromFormat("IPU Fifo Input: readpos = 0x%x, writepos = 0x%x, data = 0x%x", readpos, writepos, data);
+	return StringUtil::StdStringFromFormat("IPU Fifo Input: readpos = 0x%x, writepos = 0x%x, data = %p", readpos, writepos, data);
 }
 
 std::string IPU_Fifo_Output::desc() const
 {
-	return StringUtil::StdStringFromFormat("IPU Fifo Output: readpos = 0x%x, writepos = 0x%x, data = 0x%x", readpos, writepos, data);
+	return StringUtil::StdStringFromFormat("IPU Fifo Output: readpos = 0x%x, writepos = 0x%x, data = %p", readpos, writepos, data);
 }
 
 int IPU_Fifo_Input::write(const u32* pMem, int size)

--- a/pcsx2/ps2/BiosTools.cpp
+++ b/pcsx2/ps2/BiosTools.cpp
@@ -157,7 +157,7 @@ static bool LoadBiosVersion(std::FILE* fp, u32& version, std::string& descriptio
 
 	if (fileSize < (int)fileOffset)
 	{
-		description += StringUtil::StdStringFromFormat(" %d%%", ((fileSize * 100) / (int)fileOffset));
+		description += StringUtil::StdStringFromFormat(" %d%%", (((int)fileSize * 100) / (int)fileOffset));
 		// we force users to have correct bioses,
 		// not that lame scph10000 of 513KB ;-)
 	}


### PR DESCRIPTION
### Description of Changes
Enabled some previously disabled warnings. Fixed the existing code that caused those warnings to fire.
Only applicable to clang/gcc builds.

### Rationale behind Changes
Forces people to write warning-free code :smiling_imp: :nail_care: 

### Suggested Testing Steps
Check CI and see if the format stuff is proper.