### PR TITLE
Patch: Fix ungrouped patches from >1 file not merging

### DIFF
--- a/pcsx2-qt/Settings/GameCheatSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GameCheatSettingsWidget.cpp
@@ -17,7 +17,6 @@ GameCheatSettingsWidget::GameCheatSettingsWidget(SettingsWindow* dialog, QWidget
 	: m_dialog(dialog)
 {
 	m_ui.setupUi(this);
-	QtUtils::ResizeColumnsForTreeView(m_ui.cheatList, {300, 100, -1});
 
 	reloadList();
 
@@ -88,6 +87,12 @@ void GameCheatSettingsWidget::disableAllCheats()
 	SettingsInterface* si = m_dialog->getSettingsInterface();
 	si->ClearSection(Patch::CHEATS_CONFIG_SECTION);
 	si->Save();
+}
+
+void GameCheatSettingsWidget::resizeEvent(QResizeEvent* event)
+{
+	QWidget::resizeEvent(event);
+	QtUtils::ResizeColumnsForTreeView(m_ui.cheatList, {320, 100, -1});
 }
 
 void GameCheatSettingsWidget::setCheatEnabled(std::string name, bool enabled, bool save_and_reload_settings)

--- a/pcsx2-qt/Settings/GameCheatSettingsWidget.h
+++ b/pcsx2-qt/Settings/GameCheatSettingsWidget.h
@@ -28,8 +28,12 @@ class GameCheatSettingsWidget : public QWidget
 
 public:
 	GameCheatSettingsWidget(SettingsWindow* dialog, QWidget* parent);
-	void disableAllCheats();
 	~GameCheatSettingsWidget();
+
+	void disableAllCheats();
+
+protected:
+	void resizeEvent(QResizeEvent* event) override;
 
 private Q_SLOTS:
 	void onCheatListItemDoubleClicked(QTreeWidgetItem* item, int column);


### PR DESCRIPTION
### Description of Changes

What a mess...

Also fixes the discrepancy between the number of patches shown in the UI, and the OSD.
But you really should move over to labelled patches. Editing/uncommenting pnaches by hand is terrible.

### Rationale behind Changes

Fixes #10561.

### Suggested Testing Steps

Test linked issue, and make sure that local patches still override zip patches.
