### PR TITLE
CI: fix flatpak cron and add a way to manually kick off a release

### DIFF
--- a/.github/workflows/cron_publish_flatpak.yml
+++ b/.github/workflows/cron_publish_flatpak.yml
@@ -33,6 +33,7 @@ jobs:
     uses: ./.github/workflows/linux_build_flatpak.yml
     with:
       jobName: "Qt"
+      artifactPrefixName: "PCSX2-linux-Qt-x64-flatpak"
       compiler: clang
       cmakeflags: ""
       publish: true

--- a/.github/workflows/linux_build_flatpak.yml
+++ b/.github/workflows/linux_build_flatpak.yml
@@ -39,6 +39,10 @@ on:
         required: false
         type: boolean
         default: false
+      stableBuild:
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   build_linux:
@@ -58,6 +62,13 @@ jobs:
       - name: Fetch tags
         if: ${{ inputs.fetchTags }}
         run: git fetch --tags --no-recurse-submodules
+
+      - name: Add stable release identifier file
+        if: ${{ inputs.stableBuild == true || inputs.stableBuild == 'true' }}
+        shell: bash
+        run: |
+          echo "#define DEFAULT_UPDATER_CHANNEL \"stable\"" > ./pcsx2-qt/DefaultUpdaterChannel.h
+          cat ./pcsx2-qt/DefaultUpdaterChannel.h
 
       - name: Prepare Artifact Metadata
         id: artifact-metadata

--- a/.github/workflows/linux_build_qt.yml
+++ b/.github/workflows/linux_build_qt.yml
@@ -39,6 +39,10 @@ on:
         required: false
         type: boolean
         default: false
+      stableBuild:
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   build_linux:
@@ -71,6 +75,13 @@ jobs:
       - name: Fetch Tags
         if: ${{ inputs.fetchTags }}
         run: git fetch --tags --no-recurse-submodules
+
+      - name: Add stable release identifier file
+        if: ${{ inputs.stableBuild == true || inputs.stableBuild == 'true' }}
+        shell: bash
+        run: |
+          echo "#define DEFAULT_UPDATER_CHANNEL \"stable\"" > ./pcsx2-qt/DefaultUpdaterChannel.h
+          cat ./pcsx2-qt/DefaultUpdaterChannel.h
 
       - name: Prepare Artifact Metadata
         id: artifact-metadata

--- a/.github/workflows/macos_build.yml
+++ b/.github/workflows/macos_build.yml
@@ -21,6 +21,10 @@ on:
         required: false
         type: boolean
         default: false
+      stableBuild:
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   build_macos:
@@ -46,6 +50,13 @@ jobs:
       - name: Fetch Tags
         if: ${{ inputs.fetchTags }}
         run: git fetch --tags --no-recurse-submodules
+
+      - name: Add stable release identifier file
+        if: ${{ inputs.stableBuild == true || inputs.stableBuild == 'true' }}
+        shell: bash
+        run: |
+          echo "#define DEFAULT_UPDATER_CHANNEL \"stable\"" > ./pcsx2-qt/DefaultUpdaterChannel.h
+          cat ./pcsx2-qt/DefaultUpdaterChannel.h
 
       - name: Use Xcode 14.3.1
         run: sudo xcode-select -s /Applications/Xcode_14.3.1.app

--- a/.github/workflows/release_cut_new.yml
+++ b/.github/workflows/release_cut_new.yml
@@ -14,9 +14,12 @@ on:
     inputs:
       is_prelease:
         description: 'Should be a pre-release?'
-        type: boolean
         required: true
-        default: true
+        default: 'true'
+        type: choice
+        options:
+          - 'true'
+          - 'false'
       tag_value:
         description: 'Create a new release from latest master with the given tag, if this is left blank it will bump the patch version. You dont need to include the "v" prefix'
         required: false
@@ -70,7 +73,7 @@ jobs:
         with:
           body_path: ./release-notes.md
           draft: true
-          prerelease: ${{ inputs.is_prelease == true || inputs.is_prelease == 'true' }}
+          prerelease: ${{ github.event_name != 'workflow_dispatch' || inputs.is_prelease == 'true' }}
           tag_name: ${{ steps.tag_version.outputs.new_tag }}
 
       - name: Create a GitHub Release (Push)
@@ -97,6 +100,7 @@ jobs:
       cmakeflags: ""
       buildAppImage: true
       fetchTags: true
+      stableBuild: ${{ github.event_name == 'workflow_dispatch' && inputs.is_prelease == 'false' }}
     secrets: inherit
 
   build_linux_flatpak:
@@ -113,6 +117,7 @@ jobs:
       branch: "stable"
       publish: false
       fetchTags: true
+      stableBuild: ${{ github.event_name == 'workflow_dispatch' && inputs.is_prelease == 'false' }}
     secrets: inherit
 
   # Windows
@@ -129,6 +134,7 @@ jobs:
       buildSystem: cmake
       cmakeFlags: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl
       fetchTags: true
+      stableBuild: ${{ github.event_name == 'workflow_dispatch' && inputs.is_prelease == 'false' }}
     secrets: inherit
 
   # MacOS
@@ -142,6 +148,7 @@ jobs:
       jobName: "MacOS Build"
       artifactPrefixName: "PCSX2-macos-Qt"
       fetchTags: true
+      stableBuild: ${{ github.event_name == 'workflow_dispatch' && inputs.is_prelease == 'false' }}
     secrets: inherit
 
   # Upload the Artifacts

--- a/.github/workflows/release_cut_new.yml
+++ b/.github/workflows/release_cut_new.yml
@@ -10,16 +10,16 @@ on:
   push:
     branches:
       - master
-  # TODO - future work
-  # workflow_dispatch:
-  #   inputs:
-  #     isStable:
-  #       description: 'Should it be a stable release?'
-  #       required: true
-  #       default: 'false'
-  #     versionTag:
-  #       description: 'The version to tag with'
-  #       required: true
+  workflow_dispatch:
+    inputs:
+      is_prelease:
+        description: 'Should be a pre-release?'
+        type: boolean
+        required: true
+        default: true
+      tag_value:
+        description: 'Create a new release from latest master with the given tag, if this is left blank it will bump the patch version. You dont need to include the "v" prefix'
+        required: false
 
 permissions:
   contents: write
@@ -42,6 +42,8 @@ jobs:
           github_token: ${{ github.token }}
           tag_prefix: v
           default_bump: patch
+          # if set, it will overwrite the bump settings
+          custom_tag: ${{ github.event.inputs.tag_value == '' && null || github.event.inputs.tag_value }}
 
       # TODO - we could do this and remove the node.js script, but auto-generated notes only work
       # with PRs -- not commits (determine how much we care).
@@ -62,9 +64,18 @@ jobs:
           node index.js
           mv ./release-notes.md ${GITHUB_WORKSPACE}/release-notes.md
 
-      - name: Create a GitHub Release
+      - name: Create a GitHub Release (Manual)
         uses: softprops/action-gh-release@v1
-        if: steps.tag_version.outputs.new_tag
+        if: steps.tag_version.outputs.new_tag && github.event_name == 'workflow_dispatch'
+        with:
+          body_path: ./release-notes.md
+          draft: true
+          prerelease: ${{ inputs.is_prelease == true || inputs.is_prelease == 'true' }}
+          tag_name: ${{ steps.tag_version.outputs.new_tag }}
+
+      - name: Create a GitHub Release (Push)
+        uses: softprops/action-gh-release@v1
+        if: steps.tag_version.outputs.new_tag && github.event_name != 'workflow_dispatch'
         with:
           body_path: ./release-notes.md
           draft: true
@@ -163,9 +174,6 @@ jobs:
         working-directory: ./ci-artifacts/
         run: for d in *windows*/; do 7z a "${d}asset.7z" ./$d/*; done
 
-      # Artifact Naming:
-      # MacOS: PCSX2-<tag>-macOS-[additional hyphen seperated tags]
-      # Windows|Linux: PCSX2-<tag>-<windows|linux>-<32bit|64bit>--[additional hyphen seperated tags]
       - name: Name and Upload the Release Assets
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/windows_build_qt.yml
+++ b/.github/workflows/windows_build_qt.yml
@@ -40,6 +40,10 @@ on:
         required: false
         type: boolean
         default: false
+      stableBuild:
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   build_windows_qt:
@@ -60,6 +64,13 @@ jobs:
       - name: Fetch Tags
         if: ${{ inputs.fetchTags }}
         run: git fetch --tags --no-recurse-submodules
+
+      - name: Add stable release identifier file
+        if: ${{ inputs.stableBuild == true || inputs.stableBuild == 'true' }}
+        shell: bash
+        run: |
+          echo "#define DEFAULT_UPDATER_CHANNEL \"stable\"" > ./pcsx2-qt/DefaultUpdaterChannel.h
+          cat ./pcsx2-qt/DefaultUpdaterChannel.h
 
       - name: Prepare Artifact Metadata
         id: artifact-metadata

--- a/cmake/Pcsx2Utils.cmake
+++ b/cmake/Pcsx2Utils.cmake
@@ -56,10 +56,23 @@ function(get_git_version_info)
 			OUTPUT_STRIP_TRAILING_WHITESPACE
 			ERROR_QUIET)
 
-		EXECUTE_PROCESS(WORKING_DIRECTORY ${PROJECT_SOURCE_DIR} COMMAND ${GIT_EXECUTABLE} tag --points-at HEAD
-			OUTPUT_VARIABLE PCSX2_GIT_TAG
+		EXECUTE_PROCESS(WORKING_DIRECTORY ${PROJECT_SOURCE_DIR} COMMAND ${GIT_EXECUTABLE} tag --points-at HEAD --sort=version:refname
+			OUTPUT_VARIABLE PCSX2_GIT_TAG_LIST
+			RESULT_VARIABLE TAG_RESULT
 			OUTPUT_STRIP_TRAILING_WHITESPACE
 			ERROR_QUIET)
+
+		# CAUTION: There is a race here, this solves the problem of a commit being tagged multiple times (take the last tag)
+		# however, if simultaneous builds are pushing tags to the same commit you might get inconsistent results (it's a race)
+		#
+		# The easy solution is, don't do that, but just something to be aware of.
+		if(PCSX2_GIT_TAG_LIST AND TAG_RESULT EQUAL 0)
+			string(REPLACE "\n" ";" PCSX2_GIT_TAG_LIST "${PCSX2_GIT_TAG_LIST}")
+			if (PCSX2_GIT_TAG_LIST)
+				list(GET PCSX2_GIT_TAG_LIST -1 PCSX2_GIT_TAG)
+				message("Using tag: ${PCSX2_GIT_TAG}")
+			endif()
+		endif()
 
 		EXECUTE_PROCESS(WORKING_DIRECTORY ${PROJECT_SOURCE_DIR} COMMAND ${GIT_EXECUTABLE} rev-parse HEAD
 			OUTPUT_VARIABLE PCSX2_GIT_HASH
@@ -111,7 +124,7 @@ function(write_svnrev_h)
 			)
 		endif()
 	else()
-		file(WRITE ${CMAKE_BINARY_DIR}/common/include/svnrev.h 
+		file(WRITE ${CMAKE_BINARY_DIR}/common/include/svnrev.h
 			"#define SVN_REV ${PCSX2_WC_TIME}ll\n"
 			"#define GIT_TAG \"${PCSX2_GIT_TAG}\"\n"
 			"#define GIT_TAGGED_COMMIT 0\n"


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->

- I missed updating the flatpak cron workflow so this has a quick fix for that
- Found a problem in the cmake tagging code (likely also exists in the msbuild code but that isn't used for releases).  If a commit had multiple tags it would not handle it well.  Now it grabs the latest tag, but it's worth being aware of this as there is a race condition here (don't kick off a bunch of releases for the same commit at the same time).
- Added a way to manually kick off a release with a custom tag, this will be needed for doing non-regular, non-prelease builds.

![Screenshot 2024-01-06 205858](https://github.com/PCSX2/pcsx2/assets/13153231/d67f4ccc-6cc6-41a3-a984-d528d726b841)

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->

I tested it over on my fork:
- one from the automatic push to master https://github.com/xTVaser/pcsx2-rr/releases/tag/v2.0.2
- one from manually kicking off a prerelease https://github.com/xTVaser/pcsx2-rr/releases/tag/v2.0.3
- one from manually kicking off a non-prerelease with a custom tag https://github.com/xTVaser/pcsx2-rr/releases/tag/v2.1.0