### PR TITLE
Qt: Minor Translation Fixes

### DIFF
--- a/pcsx2-qt/Settings/ControllerBindingWidget_Popn.ui
+++ b/pcsx2-qt/Settings/ControllerBindingWidget_Popn.ui
@@ -101,7 +101,7 @@
      <item row="0" column="0">
       <widget class="QGroupBox" name="groupBox_21">
        <property name="title">
-        <string extracomment="Leave this button name as-is.">Select</string>
+        <string extracomment="Leave this button name as-is or uppercase it entirely.">Select</string>
        </property>
        <layout class="QGridLayout" name="gridLayout_21">
         <property name="leftMargin">
@@ -135,7 +135,7 @@
      <item row="1" column="0">
       <widget class="QGroupBox" name="groupBox_22">
        <property name="title">
-        <string extracomment="Leave this button name as-is.">Yellow (Left)</string>
+        <string>Yellow (Left)</string>
        </property>
        <layout class="QGridLayout" name="gridLayout_22">
         <property name="leftMargin">
@@ -169,7 +169,7 @@
      <item row="1" column="3">
       <widget class="QGroupBox" name="groupBox_24">
        <property name="title">
-        <string extracomment="Leave this button name as-is.">Yellow (Right)</string>
+        <string>Yellow (Right)</string>
        </property>
        <layout class="QGridLayout" name="gridLayout_24">
         <property name="leftMargin">
@@ -203,7 +203,7 @@
      <item row="1" column="2">
       <widget class="QGroupBox" name="groupBox_26">
        <property name="title">
-        <string extracomment="Leave this button name as-is or uppercase it entirely.">Blue (Right)</string>
+        <string>Blue (Right)</string>
        </property>
        <layout class="QGridLayout" name="gridLayout_26">
         <property name="leftMargin">
@@ -237,7 +237,7 @@
      <item row="1" column="1">
       <widget class="QGroupBox" name="groupBox_25">
        <property name="title">
-        <string extracomment="Leave this button name as-is or uppercase it entirely.">Blue (Left)</string>
+        <string>Blue (Left)</string>
        </property>
        <layout class="QGridLayout" name="gridLayout_25">
         <property name="leftMargin">
@@ -271,7 +271,7 @@
      <item row="0" column="1">
       <widget class="QGroupBox" name="groupBox_23">
        <property name="title">
-        <string extracomment="Leave this button name as-is.">Start</string>
+        <string extracomment="Leave this button name as-is or uppercase it entirely.">Start</string>
        </property>
        <layout class="QGridLayout" name="gridLayout_23">
         <property name="leftMargin">
@@ -356,7 +356,7 @@
      <item row="0" column="3">
       <widget class="QGroupBox" name="groupBox_28">
        <property name="title">
-        <string extracomment="Leave this button name as-is.">Green (Right)</string>
+        <string>Green (Right)</string>
        </property>
        <layout class="QGridLayout" name="gridLayout_29">
         <property name="leftMargin">
@@ -396,7 +396,7 @@
      <item row="0" column="0">
       <widget class="QGroupBox" name="groupBox_27">
        <property name="title">
-        <string extracomment="Leave this button name as-is.">White (Left)</string>
+        <string>White (Left)</string>
        </property>
        <layout class="QGridLayout" name="gridLayout_28">
         <property name="leftMargin">
@@ -436,7 +436,7 @@
      <item row="0" column="1">
       <widget class="QGroupBox" name="groupBox_29">
        <property name="title">
-        <string extracomment="Leave this button name as-is.">Green (Left)</string>
+        <string>Green (Left)</string>
        </property>
        <layout class="QGridLayout" name="gridLayout_30">
         <property name="leftMargin">
@@ -476,7 +476,7 @@
      <item row="0" column="4">
       <widget class="QGroupBox" name="groupBox_30">
        <property name="title">
-        <string extracomment="Leave this button name as-is.">White (Right)</string>
+        <string>White (Right)</string>
        </property>
        <layout class="QGridLayout" name="gridLayout_31">
         <property name="leftMargin">

--- a/pcsx2-qt/Translations/pcsx2-qt_en.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_en.ts
@@ -2163,37 +2163,33 @@ Unread messages: {2}</source>
     <message>
         <location filename="../Settings/ControllerBindingWidget_Popn.ui" line="104"/>
         <source>Select</source>
-        <extracomment>Leave this button name as-is.</extracomment>
+        <extracomment>Leave this button name as-is or uppercase it entirely.</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../Settings/ControllerBindingWidget_Popn.ui" line="138"/>
         <source>Yellow (Left)</source>
-        <extracomment>Leave this button name as-is.</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../Settings/ControllerBindingWidget_Popn.ui" line="172"/>
         <source>Yellow (Right)</source>
-        <extracomment>Leave this button name as-is.</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../Settings/ControllerBindingWidget_Popn.ui" line="206"/>
         <source>Blue (Right)</source>
-        <extracomment>Leave this button name as-is or uppercase it entirely.</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../Settings/ControllerBindingWidget_Popn.ui" line="240"/>
         <source>Blue (Left)</source>
-        <extracomment>Leave this button name as-is or uppercase it entirely.</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../Settings/ControllerBindingWidget_Popn.ui" line="274"/>
         <source>Start</source>
-        <extracomment>Leave this button name as-is.</extracomment>
+        <extracomment>Leave this button name as-is or uppercase it entirely.</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2204,25 +2200,21 @@ Unread messages: {2}</source>
     <message>
         <location filename="../Settings/ControllerBindingWidget_Popn.ui" line="359"/>
         <source>Green (Right)</source>
-        <extracomment>Leave this button name as-is.</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../Settings/ControllerBindingWidget_Popn.ui" line="399"/>
         <source>White (Left)</source>
-        <extracomment>Leave this button name as-is.</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../Settings/ControllerBindingWidget_Popn.ui" line="439"/>
         <source>Green (Left)</source>
-        <extracomment>Leave this button name as-is.</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../Settings/ControllerBindingWidget_Popn.ui" line="479"/>
         <source>White (Right)</source>
-        <extracomment>Leave this button name as-is.</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3856,7 +3848,7 @@ Enter function name</source>
     </message>
     <message>
         <location filename="../QtHost.cpp" line="1417"/>
-        <source>Download failed with HTTP status code {}.</source>
+        <source>Download failed with HTTP status code %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
This PR removes the translation hint from Pop'n Music bindings as it is unnecessary and the string SHOULD be localizeable.
![image](https://github.com/PCSX2/pcsx2/assets/14798312/83a2cd7f-0875-4594-bd75-9735de6b46b9)


### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Making Translation Better

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Make sure i don't miss other stuff