### PR TITLE
Debugger: initialise SavedAddress.address with 0 instead of NULL

### DIFF
--- a/pcsx2-qt/Debugger/Models/SavedAddressesModel.cpp
+++ b/pcsx2-qt/Debugger/Models/SavedAddressesModel.cpp
@@ -119,7 +119,7 @@ Qt::ItemFlags SavedAddressesModel::flags(const QModelIndex& index) const
 
 void SavedAddressesModel::addRow()
 {
-	const SavedAddress defaultNewAddress = {NULL, "Name", "Description"};
+	const SavedAddress defaultNewAddress = {0, "Name", "Description"};
 	addRow(defaultNewAddress);
 }
 


### PR DESCRIPTION
### Description of Changes
Uses an int 0 instead of NULL as the initialiser for the default address

### Rationale behind Changes
In c++11 and higher it's valid for NULL to be `nullptr_t` instead of just a `0` (see https://en.cppreference.com/w/cpp/types/NULL , though the only platform that i know of that actually does this by default via their stddef.h is musl libc). When that's the case:

```
../pcsx2-qt/Debugger/Models/SavedAddressesModel.cpp:122:42: error: cannot initialize a member subobject of type 'u32' (aka 'unsigned int') with an rvalue of type 'std::nullptr_t'
  122 |         const SavedAddress defaultNewAddress = {NULL, "Name", "Description"};
      |                                                 ^~~~
```

since the intent is a default for `u32`, a 0 works all the time.

### Suggested Testing Steps
None needed.
