### PR TITLE
PINE: fix regressions introduced in #10448

### DIFF
--- a/pcsx2/PINE.cpp
+++ b/pcsx2/PINE.cpp
@@ -63,7 +63,7 @@ bool PINEServer::Initialize(int slot)
 	// yes very good windows s/sun/sin/g sure is fine
 	server.sin_family = AF_INET;
 	// localhost only
-	server.sin_addr.s_addr = INADDR_LOOPBACK;
+	server.sin_addr.s_addr = inet_addr("127.0.0.1");
 	server.sin_port = htons(slot);
 
 	if (bind(m_sock, (struct sockaddr*)&server, sizeof(server)) == SOCKET_ERROR)

--- a/pcsx2/PINE.h
+++ b/pcsx2/PINE.h
@@ -189,7 +189,7 @@ protected:
 	 */
 	static inline bool SafetyChecks(u32 command_len, int command_size, u32 reply_len, int reply_size = 0, u32 buf_size = MAX_IPC_SIZE - 1)
 	{
-		return ((command_len + command_size) > buf_size ||
+		return !((command_len + command_size) > buf_size ||
 					(reply_len + reply_size) >= MAX_IPC_RETURN_SIZE);
 	}
 


### PR DESCRIPTION
### Description of Changes
PR #10448 introduced two regressions to PINE:

- Inverted the OOB checks, causing it to return that a packet is unsafe when within bounds
- Used the incorrect type for socket binding, leading to the socket never binding on Windows.

This fixes both regressions

### Rationale behind Changes
PINE was broken

### Suggested Testing Steps
Well a bit late but compile and run the sample client from here: https://projects.govanify.com/govanify/pine


This fixes #10582