### PR TITLE
SDL: Add option to ignore inversion flag

### DIFF
--- a/pcsx2-qt/Settings/ControllerGlobalSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/ControllerGlobalSettingsWidget.cpp
@@ -23,6 +23,8 @@ ControllerGlobalSettingsWidget::ControllerGlobalSettingsWidget(QWidget* parent, 
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.ignoreSDLInversion, "InputSources", "IgnoreSDLInversion", false);
 	connect(m_ui.enableSDLSource, &QCheckBox::stateChanged, this, &ControllerGlobalSettingsWidget::updateSDLOptionsEnabled);
 	connect(m_ui.ledSettings, &QToolButton::clicked, this, &ControllerGlobalSettingsWidget::ledSettingsClicked);
+	connect(m_ui.ignoreSDLInversion, &QCheckBox::stateChanged, this, &ControllerGlobalSettingsWidget::ignoreInversionClicked);
+	connect(m_ui.ignoreDInputInversion, &QCheckBox::stateChanged, this, &ControllerGlobalSettingsWidget::ignoreInversionClicked);
 
 #ifdef _WIN32
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.enableSDLRawInput, "InputSources", "SDLRawInput", false);
@@ -111,6 +113,11 @@ void ControllerGlobalSettingsWidget::ledSettingsClicked()
 {
 	ControllerLEDSettingsDialog dialog(this, m_dialog);
 	dialog.exec();
+}
+
+void ControllerGlobalSettingsWidget::ignoreInversionClicked()
+{
+	QMessageBox::information(this, tr("Ignore Inversion Changed"), tr("This setting will not automatically modify inversion flags (~) for any existing mappings. You will need to redo any affected mappings for the changes to take effect."));
 }
 
 void ControllerGlobalSettingsWidget::mouseSettingsClicked()

--- a/pcsx2-qt/Settings/ControllerGlobalSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/ControllerGlobalSettingsWidget.cpp
@@ -20,6 +20,7 @@ ControllerGlobalSettingsWidget::ControllerGlobalSettingsWidget(QWidget* parent, 
 
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.enableSDLSource, "InputSources", "SDL", true);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.enableSDLEnhancedMode, "InputSources", "SDLControllerEnhancedMode", false);
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.ignoreSDLInversion, "InputSources", "IgnoreSDLInversion", false);
 	connect(m_ui.enableSDLSource, &QCheckBox::stateChanged, this, &ControllerGlobalSettingsWidget::updateSDLOptionsEnabled);
 	connect(m_ui.ledSettings, &QToolButton::clicked, this, &ControllerGlobalSettingsWidget::ledSettingsClicked);
 

--- a/pcsx2-qt/Settings/ControllerGlobalSettingsWidget.h
+++ b/pcsx2-qt/Settings/ControllerGlobalSettingsWidget.h
@@ -33,6 +33,7 @@ Q_SIGNALS:
 private Q_SLOTS:
 	void updateSDLOptionsEnabled();
 	void ledSettingsClicked();
+	void ignoreInversionClicked();
 	void mouseSettingsClicked();
 
 private:

--- a/pcsx2-qt/Settings/ControllerGlobalSettingsWidget.ui
+++ b/pcsx2-qt/Settings/ControllerGlobalSettingsWidget.ui
@@ -183,6 +183,16 @@
         </property>
        </widget>
       </item>
+      <item row="2" column="1">
+       <widget class="QCheckBox" name="ignoreSDLInversion">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Some third party controllers incorrectly flag their analog sticks as inverted on the positive component, but not negative.&lt;/p&gt;&lt;p&gt;As a result, the analog stick will be &amp;quot;stuck on&amp;quot; even while resting at neutral position. &lt;/p&gt;&lt;p&gt;Enabling this setting will tell PCSX2 to ignore inversion flags when creating mappings, allowing such controllers to function normally.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="text">
+         <string>Ignore Inversion</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>

--- a/pcsx2/Input/SDLInputSource.cpp
+++ b/pcsx2/Input/SDLInputSource.cpp
@@ -189,6 +189,7 @@ void SDLInputSource::LoadSettings(SettingsInterface& si)
 	m_controller_enhanced_mode = si.GetBoolValue("InputSources", "SDLControllerEnhancedMode", false);
 	m_controller_raw_mode = si.GetBoolValue("InputSources", "SDLRawInput", false);
 	m_sdl_hints = si.GetKeyValueList("SDLHints");
+	m_ignore_inversion = si.GetBoolValue("InputSources", "IgnoreSDLInversion", false);
 
 	for (u32 i = 0; i < MAX_LED_COLORS; i++)
 	{
@@ -452,7 +453,7 @@ TinyString SDLInputSource::ConvertKeyToString(InputBindingKey key)
 			if (key.data < std::size(s_sdl_axis_names))
 				ret.fmt("SDL-{}/{}{}", static_cast<u32>(key.source_index), modifier, s_sdl_axis_names[key.data]);
 			else
-				ret.fmt("SDL-{}/{}Axis{}{}", static_cast<u32>(key.source_index), modifier, key.data, key.invert ? "~" : "");
+				ret.fmt("SDL-{}/{}Axis{}{}", static_cast<u32>(key.source_index), modifier, key.data, (key.invert && !m_ignore_inversion) ? "~" : "");
 		}
 		else if (key.source_subtype == InputSubclass::ControllerButton)
 		{

--- a/pcsx2/Input/SDLInputSource.h
+++ b/pcsx2/Input/SDLInputSource.h
@@ -89,4 +89,5 @@ private:
 	bool m_controller_raw_mode = false;
 	std::array<u32, MAX_LED_COLORS> m_led_colors{};
 	std::vector<std::pair<std::string, std::string>> m_sdl_hints;
+	bool m_ignore_inversion = false;
 };


### PR DESCRIPTION
### Description of Changes
Adds another checkbox allowing users to ignore the inversion flag on a control, as reported by the controller. Any binds created while this box is ticked will have the inversion flag forced off.

This is basically copied from #10089 which added this for Dinput. Now it's SDL's turn.

inb4 "xinput when tho"

Xinput does not have this problem. SDL only has this problem when it is acting as a wrapper for, you guessed it, Dinput.

### Rationale behind Changes
Third party controllers and adapters, most notably all the PS2 to USB adapters, seem to love flagging the positive component, but not the negative component of their analog stick axes as inverted. As a result the stick always appears to be pressed, even though it is resting at neutral position. 

We've also seen some wheel devices do this now with pedals now where they use an inversion flag wrongly, and the pedal works backwards.

### Suggested Testing Steps
Testing will require a DInput capable controller which has the above issue. However, you must test with it over SDL. Do NOT enable Dinput for tests.

Try to manually map both analog sticks. If your controller is one with the issue, you will observe a ~ at the end of the positive components of the analog sticks.

Then enable Ignore Inversion, and remap the sticks. You should no longer see a ~ after remapping.