### PR TITLE
GameDB: Fix broken shadows in Armored Core Last Raven

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -1592,8 +1592,6 @@ SCAJ-20143:
   name: "Armored Core - Last Raven"
   region: "NTSC-Unk"
   gsHWFixes:
-    cpuSpriteRenderBW: 2 # Fixes glow effects, but breaks shadows of certain objects.
-    cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects shadow alignment and reduces blurriness.
     recommendedBlendingLevel: 3 # Fixes level and map menu brightness.
 SCAJ-20144:
@@ -21704,8 +21702,6 @@ SLES-53820:
   name: "Armored Core - Last Raven"
   region: "PAL-E"
   gsHWFixes:
-    cpuSpriteRenderBW: 2 # Fixes glow effects, but breaks shadows of certain objects.
-    cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects shadow alignment and reduces blurriness.
     recommendedBlendingLevel: 3 # Fixes level and map menu brightness.
 SLES-53821:
@@ -30481,16 +30477,12 @@ SLPM-61118:
   name: "Armored Core - Last Raven [Famitsu Special Trial Version]"
   region: "NTSC-J"
   gsHWFixes:
-    cpuSpriteRenderBW: 2 # Fixes glow effects, but breaks shadows of certain objects.
-    cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects shadow alignment and reduces blurriness.
     recommendedBlendingLevel: 3 # Fixes level and map menu brightness.
 SLPM-61119:
   name: "Armored Core - Last Raven [Trial]"
   region: "NTSC-J"
   gsHWFixes:
-    cpuSpriteRenderBW: 2 # Fixes glow effects, but breaks shadows of certain objects.
-    cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects shadow alignment and reduces blurriness.
     recommendedBlendingLevel: 3 # Fixes level and map menu brightness.
 SLPM-61120:
@@ -45862,8 +45854,6 @@ SLPM-68520:
   name: "Armored Core - Last Raven [Monthly Champion magazine Special Edition]"
   region: "NTSC-J"
   gsHWFixes:
-    cpuSpriteRenderBW: 2 # Fixes glow effects, but breaks shadows of certain objects.
-    cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects shadow alignment and reduces blurriness.
     recommendedBlendingLevel: 3 # Fixes level and map menu brightness.
 SLPM-68521:
@@ -51295,8 +51285,6 @@ SLPS-25462:
   name-en: "Armored Core - Last Raven"
   region: "NTSC-J"
   gsHWFixes:
-    cpuSpriteRenderBW: 2 # Fixes glow effects, but breaks shadows of certain objects.
-    cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects shadow alignment and reduces blurriness.
     recommendedBlendingLevel: 3 # Fixes level and map menu brightness.
   memcardFilters:
@@ -52826,18 +52814,16 @@ SLPS-25730:
   name-en: "Armored Core - Last Raven [Machine Side Box]"
   region: "NTSC-J"
   gsHWFixes:
-    cpuSpriteRenderBW: 2 # Fixes glow effects, but breaks shadows of certain objects.
-    cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects shadow alignment and reduces blurriness.
     recommendedBlendingLevel: 3 # Fixes level and map menu brightness.
 SLPS-25731:
   name: アーマード・コア 2 -MACHINE SIDE BOX-
-  name-sort: アーマード・コア 2 -MACHINE SIDE BOX-
+  name-sort: あーまーど・こあ 2 -MACHINE SIDE BOX-
   name-en: "Armored Core 2 [Machine Side Box]"
   region: "NTSC-J"
 SLPS-25732:
   name: アーマード・コア 3 -MACHINE SIDE BOX-
-  name-sort: アーマード・コア 3 -MACHINE SIDE BOX-
+  name-sort: あーまーど・こあ 3 -MACHINE SIDE BOX-
   name-en: "Armored Core 3 [Machine Side Box]"
   region: "NTSC-J"
 SLPS-25733:
@@ -54570,8 +54556,6 @@ SLPS-73247:
   name-en: "Armored Core - Last Raven [PS2 The Best]"
   region: "NTSC-J"
   gsHWFixes:
-    cpuSpriteRenderBW: 2 # Fixes glow effects, but breaks shadows of certain objects.
-    cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects shadow alignment and reduces blurriness.
     recommendedBlendingLevel: 3 # Fixes level and map menu brightness.
   memcardFilters:
@@ -61729,8 +61713,6 @@ SLUS-21338:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    cpuSpriteRenderBW: 2 # Fixes glow effects, but breaks shadows of certain objects.
-    cpuSpriteRenderLevel: 2 # Needed for above.
     halfPixelOffset: 2 # Corrects shadow alignment and reduces blurriness.
     recommendedBlendingLevel: 3 # Fixes level and map menu brightness.
 SLUS-21339:


### PR DESCRIPTION
### Description of Changes
- Removed CPU Sprite Renderer from Armored Core Last Raven. It fixes broken shadows.
- Minor change: Replace katakana with hiragana for `name-sort` of three Armored Core [Machine Side Box] games.

### Rationale behind Changes
Broken shadow is now big problem for players. But this change makes glow effects on the wall of red internecine levels vanished again.

### Suggested Testing Steps
Already tested by Jordan.