### PR TITLE
GS/HW: Upgrade target to C32 if alpha requested on src is rt

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -15311,9 +15311,6 @@ SLES-51220:
   name: "TY the Tasmanian Tiger"
   region: "PAL-M5"
   compat: 5
-  gsHWFixes:
-    cpuSpriteRenderBW: 1 # Fixes rendering of the moon.
-    cpuSpriteRenderLevel: 2 # Needed for above.
 SLES-51222:
   name: "Rayman 3 - Hoodlum Havoc"
   region: "PAL-M5"
@@ -58244,9 +58241,6 @@ SLUS-20571:
   name: "TY the Tasmanian Tiger"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    cpuSpriteRenderBW: 1 # Fixes rendering of the moon.
-    cpuSpriteRenderLevel: 2 # Needed for above.
 SLUS-20572:
   name: "Tiger Woods PGA Tour 2003"
   region: "NTSC-U"

--- a/pcsx2-gsrunner/Main.cpp
+++ b/pcsx2-gsrunner/Main.cpp
@@ -95,6 +95,8 @@ bool GSRunner::InitializeConfig()
 	if (!VMManager::PerformEarlyHardwareChecks(&error))
 		return false;
 
+	ImGuiManager::SetFontPathAndRange(Path::Combine(EmuFolders::Resources, "fonts" FS_OSPATH_SEPARATOR_STR "Roboto-Regular.ttf"), {});
+
 	// don't provide an ini path, or bother loading. we'll store everything in memory.
 	MemorySettingsInterface& si = s_settings_interface;
 	Host::Internal::SetBaseSettingsLayer(&si);


### PR DESCRIPTION
### Description of Changes
Upgrades a target to 32bit from 24bit if the src is rt requests it and needs the alpha

### Rationale behind Changes
Armored Core - Last Raven was rendering a texture for the VFX in 24bit but uploading the alpha channel, so when it used it as a source and was doing the draw based on an alpha test, it was failing to draw them completely. This upgrades the texture to C32 and adds in the alpha channel.

Edit: As usual I blew the scope up a little, and fixed some bugs with updating dst_matched targets as it was skipping every other dirty rect if there was still dirty alpha, this fixes Kenran Butousai but also some underlying issues with Driv3r, but also re-sorted how valid channels are selected, etc.

### Suggested Testing Steps
Test random games, but also Armored Core - Last Raven, Ty the Tasmanian Tiger, Kenran Butousai, and the Ratchet games showed up weirds in the dump runner but were fine running manually, best check though. Driv3r was also affected by the dst_match changes.

Fixes #9838

Armored Core -  Last Raven
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/c02355a3-a59a-4f46-b763-726cf7d12a48)

PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/6f7f9085-eb24-40a2-820b-c1d731f61318)

Kenran Butousai
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/f13bffd6-25fb-4f30-ab09-699d79b984c5)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/d2b03146-f90d-41f8-a2c0-48487270196d)
