### PR TITLE
GS/HW: Don't bother trying to draw empty draws

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -1912,6 +1912,13 @@ void GSRendererHW::Draw()
 	m_r = m_r.blend8(m_r + GSVector4i::cxpr(0, 0, 1, 1), (m_r.xyxy() == m_r.zwzw()));
 	m_r = m_r.rintersect(context->scissor.in);
 
+	// Draw is too small, just skip it.
+	if (m_r.rempty())
+	{
+		GL_INS("Draw %d skipped due to having an empty rect");
+		return;
+	}
+
 	// We want to fix up the context if we're doing a double half clear, regardless of whether we do the CPU fill.
 	const bool is_possible_mem_clear = IsConstantDirectWriteMemClear();
 	if (!GSConfig.UserHacks_DisableSafeFeatures && is_possible_mem_clear)


### PR DESCRIPTION
### Description of Changes
Skips drawing empty rect draws.

### Rationale behind Changes
This doesn't actually draw anything, but just makes weird targets with bad information (the Dark Cloud example had a start BP of 0x1A40 and end of 0x1A3F because of how it's calculated).

### Suggested Testing Steps
Test random games, a bunch of stuff showed up in a GS dump (probably due to lack of resizing), try Dark Cloud.

Dark Cloud
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/525b348d-d8b9-445d-b79c-da7e8b3ea36e)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/5f36a74a-8b20-4cb8-96fa-f13199463b57)

