### PR TITLE
GS/HW: Detected striped moves in HW

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -46126,6 +46126,8 @@ SLPM-67003:
   name-en: "Sakura Taisen - Atsuki Chishioni"
   region: "NTSC-J"
   compat: 5
+  gsHWFixes:
+    mergeSprite: 1 # Removes blur from the image.
 SLPM-67004:
   name: メダル オブ オナー ライジングサン
   name-sort: めだる おぶ おなー らいじんぐさん

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.h
@@ -405,6 +405,11 @@ protected:
 	FastList<TargetHeightElem> m_target_heights;
 	u64 m_target_memory_usage = 0;
 
+	int m_expected_src_bp = -1;
+	int m_remembered_src_bp = -1;
+	int m_expected_dst_bp = -1;
+	int m_remembered_dst_bp = -1;
+
 	constexpr static size_t S_SURFACE_OFFSET_CACHE_MAX_SIZE = std::numeric_limits<u16>::max();
 	std::unordered_map<SurfaceOffsetKey, SurfaceOffset, SurfaceOffsetKeyHash, SurfaceOffsetKeyEqual> m_surface_offset_cache;
 
@@ -460,6 +465,7 @@ public:
 	static bool FullRectDirty(Target* target, u32 rgba_mask);
 	static bool FullRectDirty(Target* target);
 	bool CanTranslate(u32 bp, u32 bw, u32 spsm, GSVector4i r, u32 dbp, u32 dpsm, u32 dbw);
+	GSVector4i TranslateAlignedRectByPage(u32 tbp, u32 tebp, u32 tbw, u32 tpsm, u32 sbp, u32 spsm, u32 sbw, GSVector4i src_r, bool is_invalidation = false);
 	GSVector4i TranslateAlignedRectByPage(Target* t, u32 sbp, u32 spsm, u32 sbw, GSVector4i src_r, bool is_invalidation = false);
 	void DirtyRectByPage(u32 sbp, u32 spsm, u32 sbw, Target* t, GSVector4i src_r);
 	void DirtyRectByPageOld(u32 sbp, u32 spsm, u32 sbw, Target* t, GSVector4i src_r);


### PR DESCRIPTION
### Description of Changes
Detect striped moves in hardware moves

### Rationale behind Changes
If a game decides to transfer one line at a time with a single page width/height,, right now it'll do the first line then do the rest in native resolution, this should fix that.

Also added merge sprite to Sakura Teisen to remove the blur from the picture.

### Suggested Testing Steps
Test Sakura Teisen - Atsuki Chishioni, make sure upscaling works okay (GS dump tested only)

Fixes #10056

Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/5d17a1a7-86d5-49a3-9f38-8db06392ec64)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/88ba5ae8-e771-4fac-aea8-886fd27703a7)
