### PR TITLE
Settings: Adds on hover description to 'All CRCs' on hover for cheat/patch settings

### DIFF
--- a/pcsx2-qt/Settings/GameCheatSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GameCheatSettingsWidget.cpp
@@ -32,6 +32,9 @@ GameCheatSettingsWidget::GameCheatSettingsWidget(SettingsWindow* dialog, QWidget
 	connect(m_ui.enableAll, &QPushButton::clicked, this, [this]() { setStateForAll(true); });
 	connect(m_ui.disableAll, &QPushButton::clicked, this, [this]() { setStateForAll(false); });
 	connect(m_ui.allCRCsCheckbox, &QCheckBox::stateChanged, this, &GameCheatSettingsWidget::onReloadClicked);
+
+	dialog->registerWidgetHelp(m_ui.allCRCsCheckbox, tr("Show Cheats For All CRCs"), tr("Checked"),
+		tr("Toggles scanning patch files for all CRCs of the game. With this enabled available patches for the game serial with different CRCs will also be loaded."));
 }
 
 GameCheatSettingsWidget::~GameCheatSettingsWidget() = default;

--- a/pcsx2-qt/Settings/GamePatchSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GamePatchSettingsWidget.cpp
@@ -63,6 +63,9 @@ GamePatchSettingsWidget::GamePatchSettingsWidget(SettingsWindow* dialog, QWidget
 	connect(m_ui.reload, &QPushButton::clicked, this, &GamePatchSettingsWidget::onReloadClicked);
 	connect(m_ui.allCRCsCheckbox, &QCheckBox::stateChanged, this, &GamePatchSettingsWidget::reloadList);
 
+	dialog->registerWidgetHelp(m_ui.allCRCsCheckbox, tr("Show Patches For All CRCs"), tr("Checked"),
+		tr("Toggles scanning patch files for all CRCs of the game. With this enabled available patches for the game serial with different CRCs will also be loaded."));
+
 	reloadList();
 }
 

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -714,7 +714,7 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* dialog, QWidget* 
 		
 		"<b>If unsure, leave it on default.<b>"));
 
-		dialog->registerWidgetHelp(m_ui.audioCaptureBitrate, tr("Audio Bitrate"), tr("160 Kbps"), tr("Sets the audio bitrate to be used."));
+		dialog->registerWidgetHelp(m_ui.audioCaptureBitrate, tr("Audio Bitrate"), tr("160 kbps"), tr("Sets the audio bitrate to be used."));
 
 		dialog->registerWidgetHelp(m_ui.enableAudioCaptureArguments, tr("Enable Extra Audio Arguments"), tr("Unchecked"), tr("Allows you to pass arguments to the selected audio codec."));
 


### PR DESCRIPTION
### Description of Changes
Add an on hover description to explain the purpose of the 'All CRCs' button in the Cheat and Patch Settings window.

Also adds a minor text change to adjust 'Kbps' to 'kbps' by request in graphics settings.

### Rationale behind Changes
Reduces potential confusion about the exact purpose/effect it has.
### Suggested Testing Steps
- Just validating that the text appears on hover.
- Validating `Settings->Graphics->Recording` shows the lowercase "kbps" text for Audio Bitrate.
No other impact area.

___
**Cheat & Patch Settings windows:**
![PCSX2 - All CRCs Description](https://github.com/PCSX2/pcsx2/assets/4957200/88f9cad0-e0ff-40dc-b957-826f89b8f04c)


**Audio Bitrate text change:**
![image](https://github.com/PCSX2/pcsx2/assets/4957200/a50e0175-673a-4ad5-acd3-629c09c3f40b)




