### PR TITLE
GameDB: Set HPO Native to Fast and Furious

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -23834,7 +23834,7 @@ SLES-54483:
   compat: 5
   gsHWFixes:
     mergeSprite: 1 # Fixes bluriness.
-    halfPixelOffset: 1 # Fixes bluriness.
+    halfPixelOffset: 4 # Fixes bluriness.
 SLES-54485:
   name: "Cinderella"
   region: "PAL-M3"
@@ -63250,7 +63250,7 @@ SLUS-21449:
   compat: 5
   gsHWFixes:
     mergeSprite: 1 # Fixes bluriness.
-    halfPixelOffset: 1 # Fixes bluriness.
+    halfPixelOffset: 4 # Fixes bluriness.
 SLUS-21450:
   name: "Super PickUps"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
Changes HPO Vertex to HPO Native in Fast and Furious

### Rationale behind Changes
Looks gooder. Less ghosting/blur.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
