### PR TITLE
DEV9: Fix MDMA

### DIFF
--- a/pcsx2/DEV9/ATA/ATA.h
+++ b/pcsx2/DEV9/ATA/ATA.h
@@ -40,7 +40,6 @@ private:
 #endif
 
 	int pioMode;
-	int sdmaMode;
 	int mdmaMode;
 	int udmaMode;
 

--- a/pcsx2/DEV9/ATA/ATA_Info.cpp
+++ b/pcsx2/DEV9/ATA/ATA_Info.cpp
@@ -154,16 +154,9 @@ void ATA::CreateHDDinfo(u64 sizeSectors)
 	WriteUInt16(identifyData, &index, static_cast<u16>(curMultipleSectorsSetting | (1 << 8))); //word 59
 	//Total number of user addressable logical sectors
 	WriteUInt32(identifyData, &index, nbSectors); //word 60-61
-	//DMA modes
-	/*
-	 * bits 0-7: Singleword modes supported (0,1,2)
-	 * bits 8-15: Transfer mode active
-	 */
-	if (sdmaMode > 0)
-		WriteUInt16(identifyData, &index, static_cast<u16>(0x07 | (1 << (sdmaMode + 8)))); //word 62
-	else
-		WriteUInt16(identifyData, &index, 0x07); //word 62
-	//DMA Modes
+	//SDMA modes (Unsupported by original HDD)
+	index += 1 * 2; //word 62
+	//MDMA Modes
 	/*
 	 * bits 0-7: Multiword modes supported (0,1,2)
 	 * bits 8-15: Transfer mode active

--- a/pcsx2/DEV9/ATA/ATA_State.cpp
+++ b/pcsx2/DEV9/ATA/ATA_State.cpp
@@ -304,7 +304,6 @@ void ATA::ResetEnd(bool hard)
 	if (hard)
 	{
 		pioMode = 4;
-		sdmaMode = -1;
 		mdmaMode = 2;
 		udmaMode = -1;
 	}
@@ -312,10 +311,7 @@ void ATA::ResetEnd(bool hard)
 	{
 		pioMode = 4;
 		if (udmaMode == -1)
-		{
-			sdmaMode = -1;
 			mdmaMode = 2;
-		}
 	}
 
 	regControlEnableIRQ = false;

--- a/pcsx2/DEV9/ATA/Commands/ATA_CmdDMA.cpp
+++ b/pcsx2/DEV9/ATA/Commands/ATA_CmdDMA.cpp
@@ -77,7 +77,7 @@ void ATA::PostCmdDMADataFromHost()
 
 void ATA::ATAreadDMA8Mem(u8* pMem, int size)
 {
-	if ((udmaMode >= 0) &&
+	if ((udmaMode >= 0 || mdmaMode >= 0) &&
 		(dev9.if_ctrl & SPD_IF_ATA_DMAEN) != 0)
 	{
 		if (size == 0 || nsector == -1)
@@ -103,7 +103,7 @@ void ATA::ATAreadDMA8Mem(u8* pMem, int size)
 
 void ATA::ATAwriteDMA8Mem(u8* pMem, int size)
 {
-	if ((udmaMode >= 0) &&
+	if ((udmaMode >= 0 || mdmaMode >= 0) &&
 		(dev9.if_ctrl & SPD_IF_ATA_DMAEN) != 0)
 	{
 		if (nsector == -1)

--- a/pcsx2/DEV9/ATA/Commands/ATA_CmdNoData.cpp
+++ b/pcsx2/DEV9/ATA/Commands/ATA_CmdNoData.cpp
@@ -101,35 +101,24 @@ void ATA::HDD_SetFeatures()
 					//if mode = 1, disable IORDY
 					DevCon.WriteLn("DEV9: PIO Default");
 					pioMode = 4;
-					sdmaMode = -1;
 					mdmaMode = -1;
 					udmaMode = -1;
 					break;
 				case 0x01: //pio mode (3,4)
 					DevCon.WriteLn("DEV9: PIO Mode %i", mode);
 					pioMode = mode;
-					sdmaMode = -1;
-					mdmaMode = -1;
-					udmaMode = -1;
-					break;
-				case 0x02: //Single word dma mode (0,1,2)
-					DevCon.WriteLn("DEV9: SDMA Mode %i", mode);
-					//pioMode = -1;
-					sdmaMode = mode;
 					mdmaMode = -1;
 					udmaMode = -1;
 					break;
 				case 0x04: //Multi word dma mode (0,1,2)
 					DevCon.WriteLn("DEV9: MDMA Mode %i", mode);
 					//pioMode = -1;
-					sdmaMode = -1;
 					mdmaMode = mode;
 					udmaMode = -1;
 					break;
 				case 0x08: //Ulta dma mode (0,1,2,3,4,5,6)
 					DevCon.WriteLn("DEV9: UDMA Mode %i", mode);
 					//pioMode = -1;
-					sdmaMode = -1;
 					mdmaMode = -1;
 					udmaMode = mode;
 					break;


### PR DESCRIPTION
### Description of Changes
Fixes MDMA mode
Removes SDMA

### Rationale behind Changes
MDMA transfer mode was found to be not working using https://github.com/ps2homebrew/PS2HDDTester/releases
SDMA is not supported by the original PS2 HDD, (determined by inspecting [HDD_IDentify.bin.zip](https://github.com/PCSX2/pcsx2/files/13799140/HDD_IDentify.bin.zip) posted in https://github.com/PCSX2/pcsx2/pull/10514

### Suggested Testing Steps
Run the MDMA tests found in https://github.com/ps2homebrew/PS2HDDTester/releases
