### PR TITLE
GS: Flush draw when address matches FRAME/Z

### DIFF
--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -1853,16 +1853,16 @@ void GSState::CheckWriteOverlap(bool req_write, bool req_read)
 		const bool frame_required = (!(prev_ctx.TEST.ATE && prev_ctx.TEST.ATST == 0 && (prev_ctx.TEST.AFAIL == 2 || prev_ctx.TEST.AFAIL == 0)) && ((prev_ctx.FRAME.FBMSK & frame_mask) != frame_mask)) || prev_ctx.TEST.DATE;
 		if (frame_required)
 		{
-			if ((req_write && GSLocalMemory::HasOverlap(blit.DBP, blit.DBW, blit.DPSM, write_rect, prev_ctx.FRAME.Block(), prev_ctx.FRAME.FBW, prev_ctx.FRAME.PSM, temp_draw_rect)) || 
-				(req_read && GSLocalMemory::HasOverlap(blit.SBP, blit.SBW, blit.SPSM, read_rect, prev_ctx.FRAME.Block(), prev_ctx.FRAME.FBW, prev_ctx.FRAME.PSM, temp_draw_rect)))
+			if ((req_write && (blit.DBP == prev_ctx.FRAME.Block() || GSLocalMemory::HasOverlap(blit.DBP, blit.DBW, blit.DPSM, write_rect, prev_ctx.FRAME.Block(), prev_ctx.FRAME.FBW, prev_ctx.FRAME.PSM, temp_draw_rect))) ||
+				(req_read && (blit.DBP == prev_ctx.FRAME.Block() || GSLocalMemory::HasOverlap(blit.SBP, blit.SBW, blit.SPSM, read_rect, prev_ctx.FRAME.Block(), prev_ctx.FRAME.FBW, prev_ctx.FRAME.PSM, temp_draw_rect))))
 				Flush(GSFlushReason::UPLOADDIRTYFRAME);
 		}
 
 		const bool zbuf_required = (!(prev_ctx.TEST.ATE && prev_ctx.TEST.ATST == 0 && prev_ctx.TEST.AFAIL != 2) && !prev_ctx.ZBUF.ZMSK) || (prev_ctx.TEST.ZTE && prev_ctx.TEST.ZTST > ZTST_ALWAYS);
 		if (zbuf_required)
 		{
-			if ((req_write && GSLocalMemory::HasOverlap(blit.DBP, blit.DBW, blit.DPSM, write_rect, prev_ctx.ZBUF.Block(), prev_ctx.FRAME.FBW, prev_ctx.ZBUF.PSM, temp_draw_rect)) ||
-				(req_read && GSLocalMemory::HasOverlap(blit.SBP, blit.SBW, blit.SPSM, read_rect, prev_ctx.ZBUF.Block(), prev_ctx.FRAME.FBW, prev_ctx.ZBUF.PSM, temp_draw_rect)))
+			if ((req_write && (blit.DBP == prev_ctx.ZBUF.Block() || GSLocalMemory::HasOverlap(blit.DBP, blit.DBW, blit.DPSM, write_rect, prev_ctx.ZBUF.Block(), prev_ctx.FRAME.FBW, prev_ctx.ZBUF.PSM, temp_draw_rect))) ||
+				(req_read && (blit.DBP == prev_ctx.ZBUF.Block() || GSLocalMemory::HasOverlap(blit.SBP, blit.SBW, blit.SPSM, read_rect, prev_ctx.ZBUF.Block(), prev_ctx.FRAME.FBW, prev_ctx.ZBUF.PSM, temp_draw_rect))))
 				Flush(GSFlushReason::UPLOADDIRTYZBUF);
 		}
 	}


### PR DESCRIPTION
### Description of Changes
Checks the address of GS transfers when checking if a flush is required.

### Rationale behind Changes
Armored Core was trying to copy the Colour framebuffer at 0x0 to 0x1180, the home of the Z buffer, with a draw pending which used that Z buffer, however it didn't trigger this because it wasn't overwriting the pending draw, the problem being when a Z target is picked, it'll kill any colour targets to avoid duplication, so the copy was being made, then it was being killed, so data was instead pulled from GS memory, not a good time.

Also fixes the text on the screen in Dr. Seuss' The Cat in the Hat, didn't look in to the reason why, probably a similar reason since software was okay.

### Suggested Testing Steps
Test Cat in the Hat and Armored Core 2 and 3 (pause screens included)

Armored Core 2 pause screen:
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/e83b99ba-529f-413d-9634-42e0de274a2d)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/b1aa8da8-dd97-45ed-8e6a-111122af450c)

Dr. Seuss' The Cat in the Hat:
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/9afb709a-27c7-4c3c-8cb8-98ca6d4ca064)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/a3c2a87b-9a5b-46d3-81d3-a9844ccf0c80)

