### PR TITLE
MTGS: Explicitly set FP control register on startup

### DIFF
--- a/pcsx2/MTGS.cpp
+++ b/pcsx2/MTGS.cpp
@@ -9,6 +9,7 @@
 #include "IconsFontAwesome5.h"
 #include "VMManager.h"
 
+#include "common/FPControl.h"
 #include "common/ScopedGuard.h"
 #include "common/StringUtil.h"
 #include "common/WrappedMemCopy.h"
@@ -143,6 +144,10 @@ void MTGS::ShutdownThread()
 void MTGS::ThreadEntryPoint()
 {
 	Threading::SetNameOfCurrentThread("GS");
+
+	// Explicitly set rounding mode to default (nearest, FTZ off).
+	// Otherwise it appears to get inherited from the EE thread on Linux.
+	FPControlRegister::SetCurrent(FPControlRegister::GetDefault());
 
 	for (;;)
 	{


### PR DESCRIPTION
### Description of Changes

Linux appears? to inherit the value of MXCSR from the creating thread, and that breaks parts of the software renderer.

This broke when switching from clang-16 to clang-17, it's smelling like something to do with denormals (since the EE thread sets FTZ/DAZ), but I can't be bothered to check for code differences to say for certain.

### Rationale behind Changes

Fixes some games being broken in Software on Linux.

### Suggested Testing Steps

Check SH3 and whatever the other broken game was on AppImage.
