### PR TITLE
GS/HW: Use RcpScaleFactor when applying half texel offset

### DIFF
--- a/bin/resources/shaders/dx11/tfx.fx
+++ b/bin/resources/shaders/dx11/tfx.fx
@@ -600,7 +600,7 @@ float4 sample_color(float2 st, float uv_w)
 
 		if(PS_LTF)
 		{
-			uv = st.xyxy + HalfTexel;
+			uv = st.xyxy + HalfTexel * RcpScaleFactor;
 			dd = frac(uv.xy * WH.zw);
 
 			if(PS_FST == 0)

--- a/bin/resources/shaders/opengl/tfx_fs.glsl
+++ b/bin/resources/shaders/opengl/tfx_fs.glsl
@@ -540,7 +540,7 @@ vec4 sample_color(vec2 st)
 
 	if(PS_LTF != 0)
 	{
-		uv = st.xyxy + HalfTexel;
+		uv = st.xyxy + HalfTexel * RcpScaleFactor;
 		dd = fract(uv.xy * WH.zw);
 #if (PS_FST == 0)
 		// Background in Shin Megami Tensei Lucifers

--- a/bin/resources/shaders/vulkan/tfx.glsl
+++ b/bin/resources/shaders/vulkan/tfx.glsl
@@ -787,7 +787,7 @@ vec4 sample_color(vec2 st)
 
 		#if PS_LTF
 		{
-			uv = st.xyxy + HalfTexel;
+			uv = st.xyxy + HalfTexel * RcpScaleFactor;
 			dd = fract(uv.xy * WH.zw);
 
 			#if PS_FST == 0

--- a/pcsx2/GS/Renderers/Metal/tfx.metal
+++ b/pcsx2/GS/Renderers/Metal/tfx.metal
@@ -674,7 +674,7 @@ struct PSMain
 			float4 uv;
 			if (PS_LTF)
 			{
-				uv = st.xyxy + cb.half_texel;
+				uv = st.xyxy + cb.half_texel * cb.scale_factor.y;
 				dd = fract(uv.xy * cb.wh.zw);
 				if (!FST)
 				{


### PR DESCRIPTION
### Description of Changes
Applies RcpScaleFactor to the HalfTexel offset used within the `tfx` shader

### Rationale behind Changes
This fixes a problem in both "Ratchet and Clank: Up Your Arsenal" and "Ratchet: Deadlocked" where the bloom effect becomes increasingly offset as the user increases the resolution scale

<img src=https://github.com/PCSX2/pcsx2/assets/24617621/1e3536f5-8878-4095-b78f-4d1fb637a754 width=400/>

<img src=https://github.com/PCSX2/pcsx2/assets/24617621/ce218395-bffc-4256-b93b-2bf1cce427cf width=400/>

### Suggested Testing Steps
Other games that make use of the non-zero `PS_LTF` branch within the `tfx` shader need to be tested to ensure this tweak didn't cause problems (I'm not too sure if there's a list of games that would be effected)
