### PR TITLE
CMake: Set LINUX in current and parent scope

### DIFF
--- a/cmake/Pcsx2Utils.cmake
+++ b/cmake/Pcsx2Utils.cmake
@@ -1,7 +1,12 @@
 function(detect_operating_system)
+	message(STATUS "CMake Version: ${CMAKE_VERSION}")
+	message(STATUS "CMake System Name: ${CMAKE_SYSTEM_NAME}")
+
 	# LINUX wasn't added until CMake 3.25.
 	if (CMAKE_VERSION VERSION_LESS 3.25.0 AND CMAKE_SYSTEM_NAME MATCHES "Linux")
+		# Have to make it visible in this scope as well for below.
 		set(LINUX TRUE PARENT_SCOPE)
+		set(LINUX TRUE)
 	endif()
 
 	if(WIN32)


### PR DESCRIPTION
### Description of Changes

Apparently setting a variable with `PARENT_SCOPE` doesn't apply it in the current scope. Thanks CMake.

This didn't show up on the Linux CI, because apparently they have a later version of CMake installed somewhere else in PATH.

### Rationale behind Changes

Closes #10608.

### Suggested Testing Steps

CI passes.
