### PR TITLE
VMManager: Force TimeStretch in Achievements HC Mode

### DIFF
--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -2741,6 +2741,9 @@ void VMManager::EnforceAchievementsChallengeModeSettings()
 	EmuConfig.Speedhacks.EECycleRate =
 		std::max<decltype(EmuConfig.Speedhacks.EECycleRate)>(EmuConfig.Speedhacks.EECycleRate, 0);
 	EmuConfig.Speedhacks.EECycleSkip = 0;
+
+	// Async mix breaks games.
+	EmuConfig.SPU2.SynchMode = Pcsx2Config::SPU2Options::SynchronizationMode::TimeStretch;
 }
 
 void VMManager::LogUnsafeSettingsToConsole(const std::string& messages)


### PR DESCRIPTION
### Description of Changes

Async mix should be purged 😠 .

### Rationale behind Changes

Closes #10609.

### Suggested Testing Steps

Already tested.
