### PR TITLE
FSUI: Allow toggling fullscreen when VM is paused

### DIFF
--- a/pcsx2-qt/DisplayWidget.cpp
+++ b/pcsx2-qt/DisplayWidget.cpp
@@ -6,6 +6,7 @@
 #include "QtHost.h"
 #include "QtUtils.h"
 
+#include "pcsx2/ImGui/FullscreenUI.h"
 #include "pcsx2/ImGui/ImGuiManager.h"
 
 #include "common/Assertions.h"
@@ -323,8 +324,9 @@ bool DisplayWidget::event(QEvent* event)
 			// don't toggle fullscreen when we're bound.. that wouldn't end well.
 			if (event->type() == QEvent::MouseButtonDblClick &&
 				static_cast<const QMouseEvent*>(event)->button() == Qt::LeftButton &&
-				QtHost::IsVMValid() && !QtHost::IsVMPaused() &&
-				!InputManager::HasAnyBindingsForKey(InputManager::MakePointerButtonKey(0, 0)) &&
+				QtHost::IsVMValid() && !FullscreenUI::HasActiveWindow() &&
+				((!QtHost::IsVMPaused() && !InputManager::HasAnyBindingsForKey(InputManager::MakePointerButtonKey(0, 0))) ||
+					(QtHost::IsVMPaused() && !ImGuiManager::WantsMouseInput())) &&
 				Host::GetBoolSettingValue("UI", "DoubleClickTogglesFullscreen", true))
 			{
 				g_emu_thread->toggleFullscreen();

--- a/pcsx2-qt/QtHost.cpp
+++ b/pcsx2-qt/QtHost.cpp
@@ -497,7 +497,7 @@ void EmuThread::setFullscreen(bool fullscreen, bool allow_render_to_main)
 	MTGS::WaitGS();
 
 	// If we're using exclusive fullscreen, the refresh rate may have changed.
-	UpdateVSyncRate(true);
+	VMManager::UpdateTargetSpeed();
 }
 
 void EmuThread::setSurfaceless(bool surfaceless)

--- a/pcsx2/ImGui/ImGuiManager.cpp
+++ b/pcsx2/ImGui/ImGuiManager.cpp
@@ -836,6 +836,11 @@ bool ImGuiManager::WantsTextInput()
 	return s_imgui_wants_text.load(std::memory_order_acquire);
 }
 
+bool ImGuiManager::WantsMouseInput()
+{
+	return s_imgui_wants_mouse.load(std::memory_order_acquire);
+}
+
 void ImGuiManager::AddTextInput(std::string str)
 {
 	if (!s_imgui_wants_text.load(std::memory_order_acquire))

--- a/pcsx2/ImGui/ImGuiManager.h
+++ b/pcsx2/ImGui/ImGuiManager.h
@@ -72,6 +72,9 @@ namespace ImGuiManager
 	/// Returns true if imgui wants to intercept text input.
 	bool WantsTextInput();
 
+	/// Returns true if imgui wants to intercept mouse input.
+	bool WantsMouseInput();
+
 	/// Called on the UI or CPU thread in response to a key press. String is UTF-8.
 	void AddTextInput(std::string str);
 

--- a/pcsx2/MTGS.cpp
+++ b/pcsx2/MTGS.cpp
@@ -963,7 +963,12 @@ void MTGS::UpdateDisplayWindow()
 
 		// If we're paused, re-present the current frame at the new window size.
 		if (VMManager::GetState() == VMState::Paused)
+		{
+			// Hackity hack, on some systems, presenting a single frame isn't enough to actually get it
+			// displayed. Two seems to be good enough. Maybe something to do with direct scanout.
 			GSPresentCurrentFrame();
+			GSPresentCurrentFrame();
+		}
 	});
 }
 


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Currently, you can't toggle fullscreen by double clicking the left mouse button when PCSX2 is paused via the hotkey, this PR fixes that.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Quality of Life improvements

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Try toggling fullscreen while paused, make sure it works properly.