### PR TITLE
Misc: More warning cleanup

### DIFF
--- a/pcsx2-qt/QtHost.cpp
+++ b/pcsx2-qt/QtHost.cpp
@@ -1398,7 +1398,7 @@ std::optional<bool> QtHost::DownloadFile(QWidget* parent, const QString& title, 
 	QtModalProgressCallback progress(parent);
 	progress.GetDialog().setLabelText(
 		qApp->translate("EmuThread", "Downloading %1...").arg(QtUtils::StringViewToQString(
-			std::string_view(url).substr((url_file_part_pos >= 0) ? (url_file_part_pos + 1) : 0))));
+			std::string_view(url).substr((url_file_part_pos != std::string::npos) ? (url_file_part_pos + 1) : 0))));
 	progress.GetDialog().setWindowTitle(title);
 	progress.GetDialog().setWindowIcon(GetAppIcon());
 	progress.SetCancellable(true);

--- a/pcsx2/Cache.cpp
+++ b/pcsx2/Cache.cpp
@@ -14,15 +14,11 @@ namespace
 	union alignas(64) CacheData
 	{
 		u8 bytes[64];
-
-		constexpr CacheData(): bytes{0} {}
 	};
 
 	struct CacheTag
 	{
-		uptr rawValue = 0;
-
-		CacheTag() = default;
+		uptr rawValue;
 
 		// The lower parts of a cache tags structure is as follows:
 		// 31 - 12: The physical address cache tag.
@@ -112,7 +108,7 @@ namespace
 			pxAssertMsg(!tag.isDirtyAndValid(), "Loaded a value into cache without writing back the old one!");
 
 			tag.setAddr(ppf);
-			data = *reinterpret_cast<CacheData*>(ppf & ~0x3FULL);
+			std::memcpy(&data, reinterpret_cast<void*>(ppf & ~0x3FULL), sizeof(data));
 			tag.setValid();
 			tag.clearDirty();
 		}
@@ -120,7 +116,7 @@ namespace
 		void clear()
 		{
 			tag.clear();
-			data = CacheData();
+			std::memset(&data, 0, sizeof(data));
 		}
 	};
 
@@ -145,8 +141,7 @@ namespace
 		}
 	};
 
-	static Cache cache;
-
+	static Cache cache = {};
 }
 
 void resetCache()

--- a/pcsx2/Dmac.h
+++ b/pcsx2/Dmac.h
@@ -83,7 +83,7 @@ union tDMA_TAG {
 	};
 	u32 _u32;
 
-	tDMA_TAG() {}
+	tDMA_TAG() = default;
 
 	tDMA_TAG(u32 val) { _u32 = val; }
 	u16 upper() const { return (_u32 >> 16); }
@@ -121,6 +121,7 @@ union tDMA_CHCR {
 	};
 	u32 _u32;
 
+	tDMA_CHCR() = default;
 	tDMA_CHCR( u32 val) { _u32 = val; }
 
 	bool test(u32 flags) const { return !!(_u32 & flags); }
@@ -143,6 +144,7 @@ union tDMA_SADR {
 	};
 	u32 _u32;
 
+	tDMA_SADR() = default;
 	tDMA_SADR(u32 val) { _u32 = val; }
 
 	void reset() { _u32 = 0; }
@@ -156,6 +158,7 @@ union tDMA_QWC {
 	};
 	u32 _u32;
 
+	tDMA_QWC() = default;
 	tDMA_QWC(u32 val) { _u32 = val; }
 
 	void reset() { _u32 = 0; }
@@ -264,6 +267,7 @@ union tDMAC_QUEUE
 	};
 	u16 _u16;
 
+	tDMAC_QUEUE() = default;
 	tDMAC_QUEUE(u16 val) { _u16 = val; }
 	void reset() { _u16 = 0; }
 	bool empty() const { return (_u16 == 0); }
@@ -322,6 +326,7 @@ union tDMAC_CTRL {
 	};
 	u32 _u32;
 
+	tDMAC_CTRL() = default;
 	tDMAC_CTRL(u32 val) { _u32 = val; }
 
 	bool test(u32 flags) const { return !!(_u32 & flags); }
@@ -348,6 +353,7 @@ union tDMAC_STAT {
 	u32 _u32;
 	u16 _u16[2];
 
+	tDMAC_STAT() = default;
 	tDMAC_STAT(u32 val) { _u32 = val; }
 
 	bool test(u32 flags) const { return !!(_u32 & flags); }
@@ -372,6 +378,7 @@ union tDMAC_PCR {
 	};
 	u32 _u32;
 
+	tDMAC_PCR() = default;
 	tDMAC_PCR(u32 val) { _u32 = val; }
 
 	bool test(u32 flags) const { return !!(_u32 & flags); }
@@ -390,6 +397,7 @@ union tDMAC_SQWC {
 	};
 	u32 _u32;
 
+	tDMAC_SQWC() = default;
 	tDMAC_SQWC(u32 val) { _u32 = val; }
 
 	bool test(u32 flags) const { return !!(_u32 & flags); }
@@ -406,6 +414,7 @@ union tDMAC_RBSR {
 	};
 	u32 _u32;
 
+	tDMAC_RBSR() = default;
 	tDMAC_RBSR(u32 val) { _u32 = val; }
 
 	void reset() { _u32 = 0; }
@@ -419,6 +428,7 @@ union tDMAC_RBOR {
 	};
 	u32 _u32;
 
+	tDMAC_RBOR() = default;
 	tDMAC_RBOR(u32 val) { _u32 = val; }
 
 	void reset() { _u32 = 0; }
@@ -440,7 +450,7 @@ union tDMAC_ADDR
 	};
 	u32 _u32;
 
-	tDMAC_ADDR() {}
+	tDMAC_ADDR() = default;
 	tDMAC_ADDR(u32 val) { _u32 = val; }
 
 	void clear() { _u32 = 0; }
@@ -490,6 +500,7 @@ union tINTC_STAT {
 	};
 	u32 _u32;
 
+	tINTC_STAT() = default;
 	tINTC_STAT(u32 val) { _u32 = val; }
 
 	bool test(u32 flags) const { return !!(_u32 & flags); }
@@ -506,6 +517,7 @@ union tINTC_MASK {
 	};
 	u32 _u32;
 
+	tINTC_MASK() = default;
 	tINTC_MASK(u32 val) { _u32 = val; }
 
 	bool test(u32 flags) const { return !!(_u32 & flags); }

--- a/pcsx2/GS/GSCapture.cpp
+++ b/pcsx2/GS/GSCapture.cpp
@@ -25,11 +25,13 @@
 #include <mutex>
 #include <string>
 
+// We're using deprecated fields because we're targeting multiple ffmpeg versions.
 #if defined(_MSC_VER)
 #pragma warning(disable:4996) // warning C4996: 'AVCodecContext::channels': was declared deprecated
 #elif defined (__clang__)
-// We're using deprecated fields because we're targeting multiple ffmpeg versions.
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#elif defined (__GNUC__)
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
 
 extern "C" {
@@ -1359,7 +1361,7 @@ std::string GSCapture::GetNextCaptureFileName()
 	// Should end with a number.
 	int partnum = 2;
 	std::string_view::size_type pos = name.rfind("_part");
-	if (pos >= 0)
+	if (pos != std::string_view::npos)
 	{
 		std::string_view::size_type cpos = pos + 5;
 		for (; cpos < name.length(); cpos++)

--- a/pcsx2/GS/GSDrawingContext.cpp
+++ b/pcsx2/GS/GSDrawingContext.cpp
@@ -66,13 +66,6 @@ static int extend(int uv, int size)
 	return size;
 }
 
-GSDrawingContext::GSDrawingContext()
-{
-	std::memset(&offset, 0, sizeof(offset));
-
-	Reset();
-}
-
 void GSDrawingContext::Reset()
 {
 	std::memset(&XYOFFSET, 0, sizeof(XYOFFSET));

--- a/pcsx2/GS/GSDrawingContext.h
+++ b/pcsx2/GS/GSDrawingContext.h
@@ -40,8 +40,6 @@ public:
 		GSPixelOffset4* fzb4;
 	} offset;
 
-	GSDrawingContext();
-
 	void Reset();
 
 	void UpdateScissor();

--- a/pcsx2/GS/GSDrawingEnvironment.h
+++ b/pcsx2/GS/GSDrawingEnvironment.h
@@ -23,10 +23,6 @@ public:
 	GIFRegTRXREG     TRXREG;
 	GSDrawingContext CTXT[2];
 
-	GSDrawingEnvironment()
-	{
-	}
-
 	void Reset()
 	{
 		memset(&PRIM, 0, sizeof(PRIM));

--- a/pcsx2/GS/GSRegs.h
+++ b/pcsx2/GS/GSRegs.h
@@ -781,7 +781,7 @@ REG_END2
 	__forceinline bool DoFirstPass() const { return !ATE || ATST != ATST_NEVER; } // not all pixels fail automatically
 	__forceinline bool DoSecondPass() const { return ATE && ATST != ATST_ALWAYS && AFAIL != AFAIL_KEEP; } // pixels may fail, write fb/z
 	__forceinline bool NoSecondPass() const { return ATE && ATST != ATST_ALWAYS && AFAIL == AFAIL_KEEP; } // pixels may fail, no output
-	__forceinline u32 GetAFAIL(u32 fpsm) const { return (AFAIL == AFAIL_RGB_ONLY && (fpsm & 0xF) != 0) ? AFAIL_FB_ONLY : AFAIL; } // FB Only when not 32bit Framebuffer
+	__forceinline u32 GetAFAIL(u32 fpsm) const { return (AFAIL == AFAIL_RGB_ONLY && (fpsm & 0xF) != 0) ? static_cast<u32>(AFAIL_FB_ONLY) : AFAIL; } // FB Only when not 32bit Framebuffer
 REG_END2
 
 REG64_(GIFReg, TEX0)

--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -3337,6 +3337,12 @@ __forceinline void GSState::VertexKick(u32 skip)
 
 	pxAssert(m_vertex.tail < m_vertex.maxcount + 3);
 
+	if constexpr (prim == GS_INVALID)
+	{
+		m_vertex.tail = m_vertex.head;
+		return;
+	}
+
 	if (auto_flush && skip == 0 && m_index.tail > 0 && ((m_vertex.tail + 1) - m_vertex.head) >= n)
 	{
 		HandleAutoFlush<prim, index_swap>();
@@ -3454,7 +3460,6 @@ __forceinline void GSState::VertexKick(u32 skip)
 			case GS_LINELIST:
 			case GS_TRIANGLELIST:
 			case GS_SPRITE:
-			case GS_INVALID:
 				m_vertex.tail = head; // no need to check or grow the buffer length
 				break;
 			case GS_LINESTRIP:
@@ -3561,9 +3566,6 @@ __forceinline void GSState::VertexKick(u32 skip)
 			m_vertex.next = head + 2;
 			m_index.tail += 2;
 			break;
-		case GS_INVALID:
-			m_vertex.tail = head;
-			return;
 		default:
 			ASSUME(0);
 	}

--- a/pcsx2/GS/GSVector4.h
+++ b/pcsx2/GS/GSVector4.h
@@ -55,8 +55,6 @@ public:
 
 	GSVector4() = default;
 
-	constexpr GSVector4(const GSVector4&) = default;
-
 	constexpr static GSVector4 cxpr(float x, float y, float z, float w)
 	{
 		return GSVector4(cxpr_init, x, y, z, w);
@@ -175,11 +173,6 @@ public:
 	__forceinline static GSVector4 f64(double x, double y)
 	{
 		return GSVector4(_mm_castpd_ps(_mm_set_pd(y, x)));
-	}
-
-	__forceinline void operator=(const GSVector4& v)
-	{
-		m = v.m;
 	}
 
 	__forceinline void operator=(float f)

--- a/pcsx2/GS/GSVector4i.h
+++ b/pcsx2/GS/GSVector4i.h
@@ -43,10 +43,7 @@ public:
 		__m128i m;
 	};
 
-	__forceinline constexpr GSVector4i()
-		: x(0), y(0), z(0), w(0)
-	{
-	}
+	GSVector4i() = default;
 
 	constexpr static GSVector4i cxpr(int x, int y, int z, int w)
 	{
@@ -88,11 +85,6 @@ public:
 	{
 	}
 
-	__forceinline GSVector4i(const GSVector4i& v)
-	{
-		m = v.m;
-	}
-
 	__forceinline explicit GSVector4i(const GSVector2i& v)
 	{
 		m = _mm_loadl_epi64((__m128i*)&v);
@@ -124,11 +116,6 @@ public:
 	__forceinline static GSVector4i cast(const GSVector8i& v);
 
 #endif
-
-	__forceinline void operator=(const GSVector4i& v)
-	{
-		m = v.m;
-	}
 
 	__forceinline void operator=(int i)
 	{

--- a/pcsx2/GS/GSVector8.h
+++ b/pcsx2/GS/GSVector8.h
@@ -115,8 +115,6 @@ public:
 #endif
 	}
 
-	constexpr GSVector8(const GSVector8& v) = default;
-
 	__forceinline explicit GSVector8(float f)
 	{
 		*this = f;
@@ -162,11 +160,6 @@ public:
 
 	__forceinline static GSVector8 cast(const GSVector4& v);
 	__forceinline static GSVector8 cast(const GSVector4i& v);
-
-	__forceinline void operator=(const GSVector8& v)
-	{
-		m = v.m;
-	}
 
 	__forceinline void operator=(float f)
 	{

--- a/pcsx2/GS/GSVector8i.h
+++ b/pcsx2/GS/GSVector8i.h
@@ -90,8 +90,6 @@ public:
 #endif
 	}
 
-	GSVector8i(const GSVector8i& v) = default;
-
 	__forceinline explicit GSVector8i(int i)
 	{
 		*this = i;
@@ -105,11 +103,6 @@ public:
 	__forceinline constexpr explicit GSVector8i(__m256i m)
 		: m(m)
 	{
-	}
-
-	__forceinline void operator=(const GSVector8i& v)
-	{
-		m = v.m;
 	}
 
 	__forceinline void operator=(int i)

--- a/pcsx2/GS/Renderers/Common/GSVertex.h
+++ b/pcsx2/GS/Renderers/Common/GSVertex.h
@@ -8,8 +8,6 @@
 #include "GS/Renderers/HW/GSVertexHW.h"
 #include "GS/Renderers/SW/GSVertexSW.h"
 
-#pragma pack(push, 1)
-
 struct alignas(32) GSVertex
 {
 	union
@@ -51,10 +49,7 @@ struct alignas(32) GSVertex
 #endif
 };
 
-struct GSVertexP
-{
-	GSVector4 p;
-};
+static_assert(sizeof(GSVertex) == 32);
 
 struct alignas(32) GSVertexPT1
 {
@@ -64,10 +59,5 @@ struct alignas(32) GSVertexPT1
 	union { u32 c; struct { u8 r, g, b, a; }; };
 };
 
-struct GSVertexPT2
-{
-	GSVector4 p;
-	GSVector2 t[2];
-};
+static_assert(sizeof(GSVertexPT1) == sizeof(GSVertex));
 
-#pragma pack(pop)

--- a/pcsx2/GS/Renderers/Common/GSVertex.h
+++ b/pcsx2/GS/Renderers/Common/GSVertex.h
@@ -26,27 +26,6 @@ struct alignas(32) GSVertex
 #endif
 		__m128i m[2];
 	};
-
-	GSVertex() = default; // Warning object is potentially used in hot path
-
-#if _M_SSE >= 0x500
-	GSVertex(const GSVertex& v)
-	{
-		mx = v.mx;
-	}
-	void operator=(const GSVertex& v) { mx = v.mx; }
-#else
-	GSVertex(const GSVertex& v)
-	{
-		m[0] = v.m[0];
-		m[1] = v.m[1];
-	}
-	void operator=(const GSVertex& v)
-	{
-		m[0] = v.m[0];
-		m[1] = v.m[1];
-	}
-#endif
 };
 
 static_assert(sizeof(GSVertex) == 32);

--- a/pcsx2/GS/Renderers/DX11/GSTexture11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSTexture11.cpp
@@ -15,7 +15,6 @@ GSTexture11::GSTexture11(wil::com_ptr_nothrow<ID3D11Texture2D> texture, const D3
 	GSTexture::Type type, GSTexture::Format format)
 	: m_texture(std::move(texture))
 	, m_desc(desc)
-	, m_mapped_subresource(0)
 {
 	m_size.x = static_cast<int>(desc.Width);
 	m_size.y = static_cast<int>(desc.Height);

--- a/pcsx2/GS/Renderers/DX11/GSTexture11.h
+++ b/pcsx2/GS/Renderers/DX11/GSTexture11.h
@@ -18,7 +18,6 @@ class GSTexture11 final : public GSTexture
 	wil::com_ptr_nothrow<ID3D11DepthStencilView> m_dsv;
 	wil::com_ptr_nothrow<ID3D11UnorderedAccessView> m_uav;
 	D3D11_TEXTURE2D_DESC m_desc;
-	int m_mapped_subresource;
 
 public:
 	explicit GSTexture11(wil::com_ptr_nothrow<ID3D11Texture2D> texture, const D3D11_TEXTURE2D_DESC& desc,

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
@@ -5716,7 +5716,7 @@ void GSDeviceVK::RenderHW(GSHWDrawConfig& config)
 
 		// If this is the first draw to the target as a feedback loop, make sure we re-generate the texture descriptor.
 		// Otherwise, we might have a previous descriptor left over, that has the RT in a different state.
-		m_dirty_flags |= (skip_first_barrier ? DIRTY_FLAG_TFX_TEXTURE_RT : 0);
+		m_dirty_flags |= (skip_first_barrier ? static_cast<u32>(DIRTY_FLAG_TFX_TEXTURE_RT) : 0);
 	}
 
 	// Begin render pass if new target or out of the area.

--- a/pcsx2/IPU/IPU.h
+++ b/pcsx2/IPU/IPU.h
@@ -52,6 +52,7 @@ union tIPU_CTRL {
 	};
 	u32 _u32;
 
+	tIPU_CTRL() = default;
 	tIPU_CTRL( u32 val ) { _u32 = val; }
 
     // CTRL = the first 16 bits of ctrl [0x8000ffff], + value for the next 16 bits,
@@ -153,6 +154,7 @@ union tIPU_CMD_IDEC
 
 	u32 _u32;
 
+	tIPU_CMD_IDEC() = default;
 	tIPU_CMD_IDEC( u32 val ) { _u32 = val; }
 
 	bool test(u32 flags) const { return !!(_u32 & flags); }
@@ -177,6 +179,7 @@ union tIPU_CMD_BDEC
 	};
 	u32 _u32;
 
+	tIPU_CMD_BDEC() = default;
 	tIPU_CMD_BDEC( u32 val ) { _u32 = val; }
 
 	bool test(u32 flags) const { return !!(_u32 & flags); }
@@ -198,6 +201,7 @@ union tIPU_CMD_CSC
 	};
 	u32 _u32;
 
+	tIPU_CMD_CSC() = default;
 	tIPU_CMD_CSC( u32 val ){ _u32 = val; }
 
 	bool test(u32 flags) const { return !!(_u32 & flags); }

--- a/pcsx2/IPU/IPU_MultiISA.cpp
+++ b/pcsx2/IPU/IPU_MultiISA.cpp
@@ -346,11 +346,11 @@ __ri static void IDCT_Copy(s16* block, u8* dest, const int stride)
 
 
 // stride = increment for dest in 16-bit units (typically either 8 [128 bits] or 16 [256 bits]).
-__ri static void IDCT_Add(const int last, s16* block, s16* dest, const int stride)
+__ri static void IDCT_Add(s16* block, s16* dest, const int stride)
 {
 	// on the IPU, stride is always assured to be multiples of QWC (bottom 3 bits are 0).
 
-	if (last != 129 || (block[0] & 7) == 4)
+	if ((block[0] & 7) == 4)
 	{
 		IDCT_Block(block);
 
@@ -954,7 +954,7 @@ __ri static bool slice_non_intra_DCT(s16 * const dest, const int stride, const b
 		return false;
 	}
 
-	IDCT_Add(last, decoder.DCTblock, dest, stride);
+	IDCT_Add(decoder.DCTblock, dest, stride);
 
 	return true;
 }

--- a/pcsx2/SPU2/SndOut.h
+++ b/pcsx2/SPU2/SndOut.h
@@ -57,11 +57,7 @@ struct StereoOut32
 	s32 Left;
 	s32 Right;
 
-	StereoOut32()
-		: Left(0)
-		, Right(0)
-	{
-	}
+	StereoOut32() = default;
 
 	StereoOut32(s32 left, s32 right)
 		: Left(left)
@@ -101,11 +97,7 @@ struct StereoOut16
 	s16 Left;
 	s16 Right;
 
-	__fi StereoOut16()
-		: Left(0)
-		, Right(0)
-	{
-	}
+	StereoOut16() = default;
 
 	__fi StereoOut16(const StereoOut32& src)
 		: Left((s16)src.Left)

--- a/pcsx2/Vif.h
+++ b/pcsx2/Vif.h
@@ -102,7 +102,7 @@ union tVIF_STAT {
 	};
 	u32 _u32;
 
-	tVIF_STAT() {}
+	tVIF_STAT() = default;
 	tVIF_STAT(u32 val)			{ _u32 = val; }
 	bool test(u32 flags) const	{ return !!(_u32 & flags); }
 	void set_flags	(u32 flags)	{ _u32 |=  flags; }
@@ -123,6 +123,7 @@ union tVIF_FBRST {
 	};
 	u32 _u32;
 
+	tVIF_FBRST() = default;
 	tVIF_FBRST(u32 val)					{ _u32 = val; }
 	bool test		(u32 flags) const	{ return !!(_u32 & flags); }
 	void set_flags	(u32 flags)			{ _u32 |=  flags; }
@@ -142,7 +143,7 @@ union tVIF_ERR {
 	};
 	u32 _u32;
 
-	tVIF_ERR() {}
+	tVIF_ERR() = default;
 	tVIF_ERR  (u32 val)					{ _u32 = val; }
 	void write(u32 val)					{ _u32 = val; }
 	bool test		(u32 flags) const	{ return !!(_u32 & flags); }

--- a/pcsx2/x86/ix86-32/iR5900.cpp
+++ b/pcsx2/x86/ix86-32/iR5900.cpp
@@ -2353,7 +2353,7 @@ static void recRecompile(const u32 startpc)
 			else if ((cpuRegs.code >> 26) == 5)
 			{
 				// bne
-				if (timeout_reg != _Rs_ || _Rt_ != 0 || memRead32(i + 4) != 0)
+				if (timeout_reg != static_cast<s32>(_Rs_) || _Rt_ != 0 || memRead32(i + 4) != 0)
 					is_timeout_loop = false;
 			}
 			else if (cpuRegs.code != 0)


### PR DESCRIPTION
### Description of Changes

Most involve making types POD.

For the vector classes, in debug builds, we get an inlined 8-byte-at-a-time move, instead of a call. In release, it gets inlined to a vector move as you would expect.

Some of these were legitimate errors, like in GSCapture and reading uninitialized variables in the IPU.

### Rationale behind Changes

Tidy tidy

### Suggested Testing Steps

Make sure HW and SW renderer performance is unchanged.
Usual smoke tests.
Dump runner says it's okay.