### PR TITLE
Qt: Tidy up Tools menu

### DIFF
--- a/common/Console.cpp
+++ b/common/Console.cpp
@@ -271,6 +271,15 @@ cleanup:
 #endif
 }
 
+bool Log::IsDebugOutputAvailable()
+{
+#ifdef _WIN32
+	return IsDebuggerPresent();
+#else
+	return false;
+#endif
+}
+
 bool Log::IsDebugOutputEnabled()
 {
 	return (s_console_level > LOGLEVEL_NONE);

--- a/common/Console.h
+++ b/common/Console.h
@@ -73,6 +73,7 @@ namespace Log
 	void SetConsoleOutputLevel(LOGLEVEL level);
 
 	// adds a debug console output
+	bool IsDebugOutputAvailable();
 	bool IsDebugOutputEnabled();
 	void SetDebugOutputLevel(LOGLEVEL level);
 

--- a/pcsx2-qt/MainWindow.h
+++ b/pcsx2-qt/MainWindow.h
@@ -222,6 +222,7 @@ private:
 	void updateDisplayRelatedActions(bool has_surface, bool render_to_main, bool fullscreen);
 	void updateGameDependentActions();
 	void updateStatusBarWidgetVisibility();
+	void updateAdvancedSettingsVisibility();
 	void updateWindowTitle();
 	void updateWindowState(bool force_visible = false);
 	void setProgressBar(int current, int total);


### PR DESCRIPTION
### Description of Changes

Make System Console and Verbose contingent on Advanced Settings being enabled.
Make Debug Console contingent on actually running under a debugger.

### Rationale behind Changes

Less cramped.

### Suggested Testing Steps

Make sure menu items are hidden without advanced, shown with.
Restart PCSX2 inbetween and make sure it behaves itself.
