### PR TITLE
GS/HW: Don't mark 24bit alpha as valid on upgrade

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -6023,8 +6023,6 @@ bool GSTextureCache::Target::HasValidBitsForFormat(u32 psm, bool req_color, bool
 					AddDirtyRectTarget(this, m_valid, m_TEX0.PSM, m_TEX0.TBW, mask, false);
 
 				alpha_valid = true; // This is going to get resolved going forward.
-				m_valid_alpha_low = true;
-				m_valid_alpha_high = true;
 			}
 			break;
 	}


### PR DESCRIPTION
### Description of Changes
Don't mark the alpha as valid when upgrading 24bit alpha to 32bit

### Rationale behind Changes
turns out this was a bad idea, Ratchet 3 wasn't very happy.

### Suggested Testing Steps
Test Ratchet & Clank 3

Fixes #10626

Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/22c9b33c-5508-446e-b66d-c36b0bc9e687)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/186bbbc2-3eba-4ed2-b9a3-69b454d1a74f)
