### PR TITLE
CI: Allow user to override deps build path

### DIFF
--- a/.github/workflows/linux_build_qt.yml
+++ b/.github/workflows/linux_build_qt.yml
@@ -120,7 +120,7 @@ jobs:
 
       - name: Build Dependencies
         if: steps.cache-deps.outputs.cache-hit != 'true'
-        run: .github/workflows/scripts/linux/build-dependencies-qt.sh
+        run: .github/workflows/scripts/linux/build-dependencies-qt.sh "$HOME/deps"
 
       - name: Download patches
         run: |

--- a/.github/workflows/scripts/linux/build-dependencies-qt.sh
+++ b/.github/workflows/scripts/linux/build-dependencies-qt.sh
@@ -2,7 +2,12 @@
 
 set -e
 
-INSTALLDIR="$HOME/deps"
+if [ "$#" -ne 1 ]; then
+    echo "Syntax: $0 <output directory>"
+    exit 1
+fi
+
+INSTALLDIR="$1"
 NPROCS="$(getconf _NPROCESSORS_ONLN)"
 SDL=SDL2-2.28.5
 QT=6.6.1


### PR DESCRIPTION
### Description of Changes

Implemented for Mac in #10506, adding to Linux.

### Rationale behind Changes

Letting users specify where dependencies end up.

### Suggested Testing Steps

AppImage still runs.
