### PR TITLE
GS/HW: ignore lower 3 bits of 16bit color for AEM check

### DIFF
--- a/bin/resources/shaders/dx11/tfx.fx
+++ b/bin/resources/shaders/dx11/tfx.fx
@@ -631,7 +631,7 @@ float4 sample_color(float2 st, float uv_w)
 		}
 		else if(PS_AEM_FMT == FMT_16)
 		{
-			c[i].a = c[i].a >= 0.5 ? TA.y : !PS_AEM || any(c[i].rgb) ? TA.x : 0;
+			c[i].a = c[i].a >= 0.5 ? TA.y : !PS_AEM || any(int3(c[i].rgb * 255.0f) & 0xF8) ? TA.x : 0;
 		}
 	}
 

--- a/bin/resources/shaders/opengl/tfx_fs.glsl
+++ b/bin/resources/shaders/opengl/tfx_fs.glsl
@@ -580,7 +580,7 @@ vec4 sample_color(vec2 st)
 		c[i].a = ( (PS_AEM == 0) || any(bvec3(c[i].rgb))  ) ? TA.x : 0.0f;
 		//c[i].a = ( (PS_AEM == 0) || (sum > 0.0f) ) ? TA.x : 0.0f;
 #elif (PS_AEM_FMT == FMT_16)
-		c[i].a = c[i].a >= 0.5 ? TA.y : ( (PS_AEM == 0) || any(bvec3(c[i].rgb)) ) ? TA.x : 0.0f;
+		c[i].a = c[i].a >= 0.5 ? TA.y : ( (PS_AEM == 0) || any(bvec3(ivec3(c[i].rgb * 255.0f) & ivec3(0xF8))) ) ? TA.x : 0.0f;
 		//c[i].a = c[i].a >= 0.5 ? TA.y : ( (PS_AEM == 0) || (sum > 0.0f) ) ? TA.x : 0.0f;
 #endif
 	}

--- a/bin/resources/shaders/vulkan/tfx.glsl
+++ b/bin/resources/shaders/vulkan/tfx.glsl
@@ -817,7 +817,7 @@ vec4 sample_color(vec2 st)
 		#if (PS_AEM_FMT == FMT_24)
 			c[i].a = (PS_AEM == 0 || any(bvec3(c[i].rgb))) ? TA.x : 0.0f;
 		#elif (PS_AEM_FMT == FMT_16)
-			c[i].a = (c[i].a >= 0.5) ? TA.y : ((PS_AEM == 0 || any(bvec3(c[i].rgb))) ? TA.x : 0.0f);
+			c[i].a = (c[i].a >= 0.5) ? TA.y : ((PS_AEM == 0 || any(bvec3(ivec3(c[i].rgb * 255.0f) & ivec3(0xF8)))) ? TA.x : 0.0f);
 		#endif
 	}
 

--- a/pcsx2/GS/Renderers/Metal/tfx.metal
+++ b/pcsx2/GS/Renderers/Metal/tfx.metal
@@ -702,7 +702,7 @@ struct PSMain
 			if (PS_AEM_FMT == FMT_24)
 				c[i].a = !PS_AEM || any(c[i].rgb != 0) ? cb.ta.x : 0.f;
 			else if (PS_AEM_FMT == FMT_16)
-				c[i].a = c[i].a >= 0.5 ? cb.ta.y : !PS_AEM || any(c[i].rgb != 0) ? cb.ta.x : 0.f;
+				c[i].a = c[i].a >= 0.5 ? cb.ta.y : !PS_AEM || any((int3(c[i].rgb * 255.0f) & 0xF8) != 0) ? cb.ta.x : 0.f;
 		}
 
 		if (PS_LTF)


### PR DESCRIPTION
### Description of Changes
Ignore the lower 3 bits of 16bit colours when doing an AEM (transparent when RGB == 0) check

### Rationale behind Changes
the AEM check is designed for treating colours as transparent if RGB are all zero, the problem was, for 16bit, we often treat these values as 32bit, so they can have a fractional value (1-7), which would cause AEM to fail and draw the colour opaque. This PR masks out the lower 3 bits when checking for zero equality, thus getting the correct result.

### Suggested Testing Steps
Not sure what it affects beyond Final Fantasy X-2 and The Suffering - Ties That Bind

Fixes #3870 The Suffering - Ties That Bind lack of black hands etc in cutscenes.
Fixes Final Fantasy X-2 button backgrounds when in the Garment Grids.


The Suffering:
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/6d62435a-3649-4d58-bd05-7ab88e4d2668)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/825c6995-e402-4407-b5ed-a9ece522f56b)

Final Fantasy X-2:
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/cfc2c252-7c19-43a9-a7bf-ca94ceb21f7f)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/701cf0c3-9c70-4972-939d-ebf19ae1cc04)

