### PR TITLE
CI: Default to non-portable builds

### DIFF
--- a/bin/portable.ini
+++ b/bin/portable.ini
@@ -1,1 +1,0 @@
-RunWizard=0


### PR DESCRIPTION
## For anyone who can't be bothered to read, **THIS DOES NOT REMOVE PORTABLE MODE.** Keep your pitchforks to yourself.
It just changes the default, you can still re-enable portable mode by creating `portable.ini` in the PCSX2 directory. All existing portable installations will remain in portable mode, unless you remove `portable.ini` and move your data over.

### Description of Changes

For all the time I've been around at least, PCSX2 has defaulted to portable mode for nightly builds. But only for Windows, Mac/Linux are not portable in the first place. I'm not really sure why.

For the stable release, we definitely want to default to non-portable. But in my opinion, we should just make non-portable the default anyway.

#### Arguments for non-portable mode by default:
 - Easier to test different builds, since they all share the same ini/bios/cards/etc.
 - Consistency across platforms.
 - Users can install to Program Files if they really want to (after #10633 is merged).
 - The "expected" behaviour of applications.
 - Separation of user data from the application.
 - Users can sync their data across devices with something like OneDrive (although that in itself can be a can of worms when conflicts happen).

#### Arguments for portable mode by default:
 - Easier to blow away the whole install for troubleshooting (you can just delete inis/gamesettings in Documents instead).
 - ???

### Rationale behind Changes

Stable release prep.

### Suggested Testing Steps

Make sure non-portable mode works.
