### PR TITLE
GS/HW: Further improve no_rt heuristics

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.h
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.h
@@ -111,6 +111,10 @@ private:
 	bool ContinueSplitClear();
 	void FinishSplitClear();
 
+	bool IsRTWritten();
+	bool IsUsingCsInBlend();
+	bool IsUsingAsInBlend();
+
 	GSVector4i m_r = {};
 	
 	// We modify some of the context registers to optimize away unnecessary operations.
@@ -215,7 +219,7 @@ public:
 	bool TestChannelShuffle(GSTextureCache::Target* src);
 
 	/// Returns true if the specified texture address matches the frame or Z buffer.
-	bool IsTBPFrameOrZ(u32 tbp) const;
+	bool IsTBPFrameOrZ(u32 tbp);
 
 	/// Offsets the current draw, used for RT-in-RT. Offsets are relative to the *current* FBP, not the new FBP.
 	void OffsetDraw(s32 fbp_offset, s32 zbp_offset, s32 xoffset, s32 yoffset);


### PR DESCRIPTION
### Description of Changes

Silly Crash and Burn points the texture to the framebuffer, but either has RGB masked, or blend set to As, with the vertices being all-zero. So the draw does nothing, except write Z.

Some of them also have ATEST enabled, and will always fail, so skip those draws.

Guessing they just left registers as zero...

Reduces almost 500 copies per frame to zero.

~~Breaks Guitar Hero and a couple of other dumps, need to fix those.~~

### Rationale behind Changes

```
crashnburn ['Draw Calls: -395 [2264=>1869]', 'Render Passes: -1119 [1139=>20]', 'Barriers: +365 [0=>365]', 'Copies: -374 [383=>9]']
Crash_N_Burn_SLUS-21013_20240114180751 ['Draw Calls: -495 [2635=>2140]', 'Render Passes: -1404 [1424=>20]', 'Barriers: +456 [0=>456]', 'Copies: -468 [477=>9]']
```

Affects a bunch of others too. Some notable mentions:
```
Okami_SLUS-21115_20230117231844 ['Draw Calls: -15 [516=>501]']
Okami_SLUS-21115_20230117232028 ['Draw Calls: -14 [452=>438]']
starwars  rr - swmodedump ['Draw Calls: -853 [2649=>1796]']
starwars rr - hwmodedump ['Draw Calls: -101 [1101=>1000]']
Transformers_Armada_-_Prelude_to_Energon_Special_Edition_SLES-52388_20230530154039 ['Draw Calls: -411 [12368=>11957]']
Ultimate Spider-Man_SLUS-20870_20230330154505 ['Draw Calls: -61 [847=>786]', 'Render Passes: -1 [23=>22]', 'Uploads: -1 [101=>100]']
Ultimate_Spider-Man_SLES-53391_20230408195516 ['Draw Calls: -33 [709=>676]', 'Uploads: -1 [74=>73]']
Ultraman_Fighting_Evolution_-_Rebirth_SLPS-25529_20230303124827 ['Draw Calls: -1 [382=>381]', 'Render Passes: -1 [182=>181]']
Valkyrie Profile 2 - Silmeria _NTSC-U__SLUS-21452-1 ['Draw Calls: -84 [2595=>2511]']
```

But those might not hold up once I fix the GH regression.

### Suggested Testing Steps

Test crash and burn I guess.