### PR TITLE
GameDB: Include Instant DMA to Ape Escape 3

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -1598,6 +1598,7 @@ SCAJ-20138:
   region: "NTSC-Unk"
   gameFixes:
     - SoftwareRendererFMVHack # Fixes interlacing.
+    - InstantDMAHack # Improves performance on specific stages.
   gsHWFixes:
     preloadFrameData: 1 # Fixes black background in the pause menu.
     mipmap: 2 # Fixes miptrick texture effects.
@@ -1908,6 +1909,7 @@ SCAJ-20195:
   region: "NTSC-C"
   gameFixes:
     - SoftwareRendererFMVHack # Fixes interlacing.
+    - InstantDMAHack # Improves performance on specific stages.
   gsHWFixes:
     preloadFrameData: 1 # Fixes black background in the pause menu.
     mipmap: 2 # Fixes miptrick texture effects.
@@ -5332,6 +5334,7 @@ SCES-53642:
   compat: 5
   gameFixes:
     - SoftwareRendererFMVHack # Fixes interlacing.
+    - InstantDMAHack # Improves performance on specific stages.
   gsHWFixes:
     preloadFrameData: 1 # Fixes black background in the pause menu.
     mipmap: 2 # Fixes miptrick texture effects.
@@ -6621,6 +6624,7 @@ SCKA-20062:
   region: "NTSC-K"
   gameFixes:
     - SoftwareRendererFMVHack # Fixes interlacing.
+    - InstantDMAHack # Improves performance on specific stages.
   gsHWFixes:
     preloadFrameData: 1 # Fixes black background in the pause menu.
     mipmap: 2 # Fixes miptrick texture effects.
@@ -8801,6 +8805,7 @@ SCPS-19327:
   region: "NTSC-J"
   gameFixes:
     - SoftwareRendererFMVHack # Fixes interlacing.
+    - InstantDMAHack # Improves performance on specific stages.
   gsHWFixes:
     preloadFrameData: 1 # Fixes black background in the pause menu.
     mipmap: 2 # Fixes miptrick texture effects.
@@ -10852,6 +10857,7 @@ SCUS-97501:
   compat: 5
   gameFixes:
     - SoftwareRendererFMVHack # Fixes interlacing.
+    - InstantDMAHack # Improves performance on specific stages.
   gsHWFixes:
     preloadFrameData: 1 # Fixes black background in the pause menu.
     mipmap: 2 # Fixes miptrick texture effects.
@@ -11056,6 +11062,7 @@ SCUS-97548:
   region: "NTSC-U"
   gameFixes:
     - SoftwareRendererFMVHack # Fixes interlacing.
+    - InstantDMAHack # Improves performance on specific stages.
   gsHWFixes:
     preloadFrameData: 1 # Fixes black background in the pause menu.
     mipmap: 2 # Fixes miptrick texture effects.


### PR DESCRIPTION
### Description of Changes
Includes the Instant DMA Hack to Ape Escape 3 (all regions).

### Rationale behind Changes
Fixes (if not, improves) performance in specific regions of the game that uses a camera-overlay of a region of the map to reproduce a screen (examples in maps 'The Big City' and 'Specter TV-Studio', 4 and 5 respectfully)

### Suggested Testing Steps
Has been checked with success and a major improvement in those maps inside a freeplay-mode save, but further tests are welcoming as well.