### PR TITLE
GameDB: Fix water in Just Cause

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -22808,9 +22808,9 @@ SLES-54137:
   name: "Just Cause"
   region: "PAL-M3"
   gsHWFixes:
-  	mipmap: 2 # Helps clean up water
+    mipmap: 2 # Helps clean up water
     trilinearFiltering: 1 # Helps clean up water
-	recommendedBlendingLevel: 3 # High blending accuracy fixes notoriously broken water.
+    recommendedBlendingLevel: 3 # High blending accuracy fixes notoriously broken water.
     halfPixelOffset: 1 # Fixes ghosting.
 SLES-54138:
   name: "Steambot Chronicles"
@@ -23051,7 +23051,7 @@ SLES-54200:
   gsHWFixes:
     mipmap: 2 # Helps clean up water
     trilinearFiltering: 1 # Helps clean up water
-	recommendedBlendingLevel: 3 # High blending accuracy fixes notoriously broken water.
+    recommendedBlendingLevel: 3 # High blending accuracy fixes notoriously broken water.
     halfPixelOffset: 1 # Fixes ghosting.
 SLES-54203:
   name: "Pro Evolution Soccer 6"
@@ -63182,7 +63182,7 @@ SLUS-21436:
   gsHWFixes:
     mipmap: 2 # Helps clean up water
     trilinearFiltering: 1 # Helps clean up water
-	recommendedBlendingLevel: 3 # High blending accuracy fixes notoriously broken water.
+    recommendedBlendingLevel: 3 # High blending accuracy fixes notoriously broken water.
     halfPixelOffset: 1 # Fixes ghosting.
 SLUS-21437:
   name: "Disney's Kim Possible - What's the Switch"

--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -22808,6 +22808,9 @@ SLES-54137:
   name: "Just Cause"
   region: "PAL-M3"
   gsHWFixes:
+  	mipmap: 2 # Helps clean up water
+    trilinearFiltering: 1 # Helps clean up water
+	recommendedBlendingLevel: 3 # High blending accuracy fixes notoriously broken water.
     halfPixelOffset: 1 # Fixes ghosting.
 SLES-54138:
   name: "Steambot Chronicles"
@@ -23046,6 +23049,9 @@ SLES-54200:
   name: "Just Cause"
   region: "PAL-F-G"
   gsHWFixes:
+    mipmap: 2 # Helps clean up water
+    trilinearFiltering: 1 # Helps clean up water
+	recommendedBlendingLevel: 3 # High blending accuracy fixes notoriously broken water.
     halfPixelOffset: 1 # Fixes ghosting.
 SLES-54203:
   name: "Pro Evolution Soccer 6"
@@ -63174,6 +63180,9 @@ SLUS-21436:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
+    mipmap: 2 # Helps clean up water
+    trilinearFiltering: 1 # Helps clean up water
+	recommendedBlendingLevel: 3 # High blending accuracy fixes notoriously broken water.
     halfPixelOffset: 1 # Fixes ghosting.
 SLUS-21437:
   name: "Disney's Kim Possible - What's the Switch"


### PR DESCRIPTION
### Description of Changes
Fixes the notoriously inaccurate water in Just Cause. Setting blending to 'High' fixes the translucency part, and then PS2 trilinear + PS2 mipmap fixes the texture on top of the water.

### Rationale behind Changes
This dramatically improves the graphical fidelity of Just Cause, as the water is easily seen from many parts of the map and comprises a large portion of the game world.

### Suggested Testing Steps
Play Just Cause for a bit and see if anything is weird. It shouldn't be, as this simply increases accuracy.