### PR TITLE
Build: Remove unused option `DISABLE_BUILD_DATE`

### DIFF
--- a/cmake/BuildParameters.cmake
+++ b/cmake/BuildParameters.cmake
@@ -4,7 +4,6 @@ set(PCSX2_DEFS "")
 #-------------------------------------------------------------------------------
 # Misc option
 #-------------------------------------------------------------------------------
-option(DISABLE_BUILD_DATE "Disable including the binary compile date")
 option(ENABLE_TESTS "Enables building the unit tests" ON)
 option(LTO_PCSX2_CORE "Enable LTO/IPO/LTCG on the subset of pcsx2 that benefits most from it but not anything else")
 option(USE_VTUNE "Plug VTUNE to profile GS JIT.")


### PR DESCRIPTION
### Description of Changes
#10574 changed things so that `DISABLE_BUILD_DATE` does nothing, but it didn't remove the option declaration at the beginning of the file.

### Rationale behind Changes
Don't declare variables that do nothing.

