### PR TITLE
Game List: Ignore exclusion paths if they are empty string

### DIFF
--- a/pcsx2/GameList.cpp
+++ b/pcsx2/GameList.cpp
@@ -582,7 +582,7 @@ void GameList::RewriteCacheFile()
 
 static bool IsPathExcluded(const std::vector<std::string>& excluded_paths, const std::string& path)
 {
-	return std::find_if(excluded_paths.begin(), excluded_paths.end(), [&path](const std::string& entry) { return path.starts_with(entry); }) != excluded_paths.end();
+	return std::find_if(excluded_paths.begin(), excluded_paths.end(), [&path](const std::string& entry) { return !entry.empty() && path.starts_with(entry); }) != excluded_paths.end();
 }
 
 void GameList::ScanDirectory(const char* path, bool recursive, bool only_cache, const std::vector<std::string>& excluded_paths,


### PR DESCRIPTION
### Description of Changes
Checks if exclusion paths are not empty string before excluding games from the list. Yep, that's it.

### Rationale behind Changes
Works around a bug of unknown origin which causes empty string to be added to the exclusions list, which would in turn clear the games list completely.

### Suggested Testing Steps
Close PCSX2 if it is open. Manually add the following to your PCSX2.ini file in the GameList section towards the bottom:
`ExcludedPaths = `

Verify your games list still populates when you open PCSX2.
