### PR TITLE
ImGuiOverlays: Display inputs as integer, ignoring deadzone

### DIFF
--- a/pcsx2/ImGui/ImGuiOverlays.cpp
+++ b/pcsx2/ImGui/ImGuiOverlays.cpp
@@ -509,22 +509,14 @@ void ImGuiManager::DrawInputsOverlay()
 			{
 				case InputBindingInfo::Type::Axis:
 				case InputBindingInfo::Type::HalfAxis:
-				{
-					// axes are always shown
-					const float value = static_cast<float>(pad->GetRawInput(bind)) * (1.0f / 255.0f);
-					if (value >= (254.0f / 255.0f))
-						text.append_fmt(" {}", bi.icon_name ? bi.icon_name : bi.name);
-					else if (value > (1.0f / 255.0f))
-						text.append_fmt(" {}: {:.2f}", bi.icon_name ? bi.icon_name : bi.name, value);
-				}
-				break;
-
 				case InputBindingInfo::Type::Button:
 				{
-					// buttons only shown when active
-					const float value = static_cast<float>(pad->GetRawInput(bind)) * (1.0f / 255.0f);
-					if (value >= 0.5f)
+					// axes are only shown if not resting/past deadzone
+					const u8 value = pad->GetEffectiveInput(bind);
+					if (value >= 254)
 						text.append_fmt(" {}", bi.icon_name ? bi.icon_name : bi.name);
+					else if (value >= 1)
+						text.append_fmt(" {}: {}", bi.icon_name ? bi.icon_name : bi.name, value);
 				}
 				break;
 

--- a/pcsx2/SIO/Pad/PadBase.h
+++ b/pcsx2/SIO/Pad/PadBase.h
@@ -47,6 +47,7 @@ public: // Public members
 	virtual void SetButtonDeadzone(float deadzone) = 0;
 	virtual void SetAnalogInvertL(bool x, bool y) = 0;
 	virtual void SetAnalogInvertR(bool x, bool y) = 0;
+	virtual u8 GetEffectiveInput(u32 index) const = 0;
 	virtual u8 GetRawInput(u32 index) const = 0;
 	virtual std::tuple<u8, u8> GetRawLeftAnalog() const = 0;
 	virtual std::tuple<u8, u8> GetRawRightAnalog() const = 0;

--- a/pcsx2/SIO/Pad/PadDualshock2.cpp
+++ b/pcsx2/SIO/Pad/PadDualshock2.cpp
@@ -785,6 +785,42 @@ void PadDualshock2::SetAnalogInvertR(bool x, bool y)
 	this->analogs.ryInvert = y;
 }
 
+u8 PadDualshock2::GetEffectiveInput(u32 index) const
+{
+	if (!IsAnalogKey(index))
+		return GetRawInput(index);
+
+	switch (index)
+	{
+	case Inputs::PAD_L_LEFT:
+		return (analogs.lx > 0 && analogs.lx < 127) ? analogs.lx : 0;
+
+	case Inputs::PAD_L_RIGHT:
+		return (analogs.lx >= 128) ? analogs.lx : 0;
+
+	case Inputs::PAD_L_UP:
+		return (analogs.ly > 0 && analogs.ly < 127) ? analogs.ly : 0;
+
+	case Inputs::PAD_L_DOWN:
+		return (analogs.ly >= 128) ? analogs.ly : 0;
+
+	case Inputs::PAD_R_LEFT:
+		return (analogs.rx > 0 && analogs.rx < 127) ? analogs.rx : 0;
+
+	case Inputs::PAD_R_RIGHT:
+		return (analogs.rx >= 128) ? analogs.rx : 0;
+
+	case Inputs::PAD_R_UP:
+		return (analogs.ry > 0 && analogs.ry < 127) ? analogs.ry : 0;
+
+	case Inputs::PAD_R_DOWN:
+		return (analogs.ry >= 128) ? analogs.ry : 0;
+
+	default:
+		return 0;
+	}
+}
+
 u8 PadDualshock2::GetRawInput(u32 index) const
 {
 	return rawInputs[index];

--- a/pcsx2/SIO/Pad/PadDualshock2.h
+++ b/pcsx2/SIO/Pad/PadDualshock2.h
@@ -125,6 +125,7 @@ public:
 	void SetButtonDeadzone(float deadzone) override;
 	void SetAnalogInvertL(bool x, bool y) override;
 	void SetAnalogInvertR(bool x, bool y) override;
+	u8 GetEffectiveInput(u32 index) const override;
 	u8 GetRawInput(u32 index) const override;
 	std::tuple<u8, u8> GetRawLeftAnalog() const override;
 	std::tuple<u8, u8> GetRawRightAnalog() const override;

--- a/pcsx2/SIO/Pad/PadGuitar.cpp
+++ b/pcsx2/SIO/Pad/PadGuitar.cpp
@@ -355,6 +355,11 @@ void PadGuitar::SetAnalogInvertR(bool x, bool y)
 {
 }
 
+u8 PadGuitar::GetEffectiveInput(u32 index) const
+{
+	return GetRawInput(index);
+}
+
 u8 PadGuitar::GetRawInput(u32 index) const
 {
 	return rawInputs[index];

--- a/pcsx2/SIO/Pad/PadGuitar.h
+++ b/pcsx2/SIO/Pad/PadGuitar.h
@@ -66,6 +66,7 @@ public:
 	void SetButtonDeadzone(float deadzone) override;
 	void SetAnalogInvertL(bool x, bool y) override;
 	void SetAnalogInvertR(bool x, bool y) override;
+	u8 GetEffectiveInput(u32 index) const override;
 	u8 GetRawInput(u32 index) const override;
 	std::tuple<u8, u8> GetRawLeftAnalog() const override;
 	std::tuple<u8, u8> GetRawRightAnalog() const override;

--- a/pcsx2/SIO/Pad/PadNotConnected.cpp
+++ b/pcsx2/SIO/Pad/PadNotConnected.cpp
@@ -76,6 +76,11 @@ void PadNotConnected::SetAnalogInvertR(bool x, bool y)
 
 }
 
+u8 PadNotConnected::GetEffectiveInput(u32 index) const
+{
+	return 0;
+}
+
 u8 PadNotConnected::GetRawInput(u32 index) const
 {
 	return 0;

--- a/pcsx2/SIO/Pad/PadNotConnected.h
+++ b/pcsx2/SIO/Pad/PadNotConnected.h
@@ -23,6 +23,7 @@ public:
 	void SetButtonDeadzone(float deadzone) override;
 	void SetAnalogInvertL(bool x, bool y) override;
 	void SetAnalogInvertR(bool x, bool y) override;
+	u8 GetEffectiveInput(u32 index) const override;
 	u8 GetRawInput(u32 index) const override;
 	std::tuple<u8, u8> GetRawLeftAnalog() const override;
 	std::tuple<u8, u8> GetRawRightAnalog() const override;

--- a/pcsx2/SIO/Pad/PadPopn.cpp
+++ b/pcsx2/SIO/Pad/PadPopn.cpp
@@ -441,6 +441,11 @@ void PadPopn::SetAnalogInvertR(bool x, bool y)
 {
 }
 
+u8 PadPopn::GetEffectiveInput(u32 index) const
+{
+	return GetRawInput(index);
+}
+
 u8 PadPopn::GetRawInput(u32 index) const
 {
 	return rawInputs[index];

--- a/pcsx2/SIO/Pad/PadPopn.h
+++ b/pcsx2/SIO/Pad/PadPopn.h
@@ -89,6 +89,7 @@ public:
 	void SetButtonDeadzone(float deadzone) override;
 	void SetAnalogInvertL(bool x, bool y) override;
 	void SetAnalogInvertR(bool x, bool y) override;
+	u8 GetEffectiveInput(u32 index) const override;
 	u8 GetRawInput(u32 index) const override;
 	std::tuple<u8, u8> GetRawLeftAnalog() const override;
 	std::tuple<u8, u8> GetRawRightAnalog() const override;


### PR DESCRIPTION
### Description of Changes

Currently, the input OSD shows the raw values of the analog sticks, which can be near-zero, since they don't rest at exactly the center. This is a bit annoying.

Instead, use the effective value, which considers any deadzone set by the user. Also switches over to integer values, since this is arguably more readable than fractional. Also matches padtest.

![image](https://github.com/PCSX2/pcsx2/assets/11288319/f4472e9b-3aa1-40c5-a52e-d14661ea4d15)


### Rationale behind Changes

User request

### Suggested Testing Steps

Test input OSD with pad and keyboard.