### PR TITLE
FileSystem: Handle infinite symlink loops in FindFiles()

### DIFF
--- a/pcsx2/GameList.cpp
+++ b/pcsx2/GameList.cpp
@@ -591,7 +591,11 @@ void GameList::ScanDirectory(const char* path, bool recursive, bool only_cache, 
 	Console.WriteLn("Scanning %s%s", path, recursive ? " (recursively)" : "");
 
 	progress->PushState();
-	progress->SetFormattedStatusText(fmt::format(recursive ? TRANSLATE_FS("GameList","Scanning directory {} (recursively)...") : TRANSLATE_FS("GameList","Scanning directory {}..."), path).c_str());
+	progress->SetStatusText(fmt::format(
+		recursive ? TRANSLATE_FS("GameList", "Scanning directory {} (recursively)...") :
+					TRANSLATE_FS("GameList", "Scanning directory {}..."),
+		path)
+								.c_str());
 
 	FileSystem::FindResultsArray files;
 	FileSystem::FindFiles(path, "*",


### PR DESCRIPTION
### Description of Changes

If PCSX2 hits a symbolic link in recursive directory scanning that points to a directory above it in the path, it ends up following this symbolic link, until it eventually hits the arbitrary path limit. This can cause the system to run out of memory, which is not desirable.

So, let's use the `RealPath()` functions I added a while back to resolve each recursive directory to its "real" location, and only scan each of those once.

### Rationale behind Changes

<img width="1413" alt="image" src="https://github.com/PCSX2/pcsx2/assets/11288319/2997931a-7cab-4240-9e53-8e3f446bfddf">

### Suggested Testing Steps

Test game list scanning on Windows and Linux.
