### PR TITLE
GameDB: Add HPO Native to S.L.A.I.

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -19503,6 +19503,8 @@ SLES-52939:
 SLES-52940:
   name: "S.L.A.I. Steel Lancer Arena International"
   region: "PAL-M3"
+  gsHWFixes:
+    halfPixelOffset: 4 # Fixes double image and aligns glow effects.
 SLES-52941:
   name: "Gungrave - Overdose"
   region: "PAL-M3"
@@ -39413,6 +39415,8 @@ SLPM-65791:
   name-sort: S.L.A.I -STEEL LANCER ARENA INTERNATIONAL-
   name-en: "S.L.A.I. - Steel Lancer Arena International"
   region: "NTSC-J"
+  gsHWFixes:
+    halfPixelOffset: 4 # Fixes double image and aligns glow effects.
 SLPM-65793:
   name: SSX3 [EA BEST HITS]
   name-sort: SSX3 [EA BEST HITS]
@@ -60681,6 +60685,8 @@ SLUS-20969:
   name: "S.L.A.I. - Steel Lancer Arena International - Phantom Crash"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 4 # Fixes double image and aligns glow effects.
 SLUS-20970:
   name: "Rumble Roses"
   region: "NTSC-U"
@@ -66607,6 +66613,8 @@ SLUS-29131:
 SLUS-29132:
   name: "S.L.A.I. - Steel Lancer Arena International - Phantom Crash [Public Beta Vol.1.0]"
   region: "NTSC-U"
+  gsHWFixes:
+    halfPixelOffset: 4 # Fixes double image and aligns glow effects.
 SLUS-29133:
   name: "Namco Transmission v2"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
Adds HPO Native to S.L.A.I. Steel Lancer Arena International

### Rationale behind Changes
Fixes double image in-game, and properly aligns object glows in menus.
![S L A I  - Steel Lancer Arena International - Phantom Crash_SLUS-20969_20240116014730 - Copy](https://github.com/PCSX2/pcsx2/assets/53349573/3c6aecac-bd40-47a8-91ba-ea3b21b99241)
![S L A I  - Steel Lancer Arena International - Phantom Crash_SLUS-20969_20240116014753 - Copy](https://github.com/PCSX2/pcsx2/assets/53349573/0330565e-45d8-4707-9695-332146372025)
![S L A I  - Steel Lancer Arena International - Phantom Crash_SLUS-20969_20240116014846 - Copy](https://github.com/PCSX2/pcsx2/assets/53349573/0f9d2acd-01de-4935-b723-020e59986e34)

### Additional Info
Adds ~1px-2px of garbage on left side. Most visible during loading transitions and while paused. Easily fixed with cropping.

GSDumps: https://litter.catbox.moe/kjf86m.7z
