### PR TITLE
DEV9: ATA Identify Fixes

### DIFF
--- a/pcsx2/DEV9/ATA/ATA_Info.cpp
+++ b/pcsx2/DEV9/ATA/ATA_Info.cpp
@@ -90,7 +90,7 @@ void ATA::CreateHDDinfo(u64 sizeSectors)
 	//Default Num of heads (Retired)
 	WriteUInt16(identifyData, &index, defHeads); //word 3
 	//Number of unformatted bytes per track (Retired)
-	WriteUInt16(identifyData, &index, static_cast<u16>(sectorSize * defSectors)); //word 4
+	WriteUInt16(identifyData, &index, sectorSize * defSectors); //word 4
 	//Number of unformatted bytes per sector (Retired)
 	WriteUInt16(identifyData, &index, sectorSize); //word 5
 	//Default Number of sectors per track (Retired)
@@ -129,7 +129,7 @@ void ATA::CreateHDDinfo(u64 sizeSectors)
 	//Capabilities (0-Shall be set to one to indicate a device specific Standby timer value minimum)
 	WriteUInt16(identifyData, &index, 1 << 14); //word 50
 	//PIO data transfer cycle timing mode (Obsolete)
-	WriteUInt16(identifyData, &index, static_cast<u16>((pioMode > 2 ? pioMode : 2) << 8)); //word 51
+	WriteUInt16(identifyData, &index, (pioMode > 2 ? pioMode : 2) << 8); //word 51
 	//DMA data transfer cycle timing mode (Obsolete)
 	WriteUInt16(identifyData, &index, 0); //word 52
 	//
@@ -146,14 +146,14 @@ void ATA::CreateHDDinfo(u64 sizeSectors)
 	//Number of current sectors per track
 	WriteUInt16(identifyData, &index, curSectors); //word 56
 	//Current capacity in sectors
-	WriteUInt32(identifyData, &index, static_cast<u32>(curOldsize)); //word 57-58
+	WriteUInt32(identifyData, &index, curOldsize); //word 57-58
 	//PIO READ/WRITE Multiple setting
 	/*
 	 * bit 7-0: Current setting for number of logical sectors that shall be transferred per DRQ
 	 *			data block on READ/WRITE Multiple commands
 	 * bit 8: Multiple sector setting is valid
 	 */
-	WriteUInt16(identifyData, &index, static_cast<u16>(curMultipleSectorsSetting | (1 << 8))); //word 59
+	WriteUInt16(identifyData, &index, curMultipleSectorsSetting | (1 << 8)); //word 59
 	//Total number of user addressable logical sectors
 	WriteUInt32(identifyData, &index, nbSectors); //word 60-61
 	//SDMA modes (Unsupported by original HDD)
@@ -164,7 +164,7 @@ void ATA::CreateHDDinfo(u64 sizeSectors)
 	 * bits 8-15: Transfer mode active
 	 */
 	if (mdmaMode >= 0)
-		WriteUInt16(identifyData, &index, static_cast<u16>(0x07 | (1 << (mdmaMode + 8)))); //word 63
+		WriteUInt16(identifyData, &index, 0x07 | (1 << (mdmaMode + 8))); //word 63
 	else
 		WriteUInt16(identifyData, &index, 0x07); //word 63
 	//Bits 0-1 PIO modes supported (3,4)
@@ -284,7 +284,7 @@ void ATA::CreateHDDinfo(u64 sizeSectors)
 	 * bits 8-15: Transfer mode active
 	 */
 	if (udmaMode >= 0)
-		WriteUInt16(identifyData, &index, static_cast<u16>(0x7f | (1 << (udmaMode + 8)))); //word 88
+		WriteUInt16(identifyData, &index, 0x7f | (1 << (udmaMode + 8))); //word 88
 	else
 		WriteUInt16(identifyData, &index, 0x7f); //word 88
 	//Time required for security erase unit completion

--- a/pcsx2/DEV9/ATA/ATA_Info.cpp
+++ b/pcsx2/DEV9/ATA/ATA_Info.cpp
@@ -84,7 +84,9 @@ void ATA::CreateHDDinfo(u64 sizeSectors)
 	//Default Num of cylinders
 	WriteUInt16(identifyData, &index, defCylinders); //word 1
 	//Specific configuration
-	index += 1 * 2; //word 2
+	//We report "Device does not require SET FEATURES subcommand to spin-up after power - up and IDENTIFY DEVICE data is complete"
+	//Matching original PS2 HDD
+	WriteUInt16(identifyData, &index, 0xC837); //word 2
 	//Default Num of heads (Retired)
 	WriteUInt16(identifyData, &index, defHeads); //word 3
 	//Number of unformatted bytes per track (Retired)
@@ -110,9 +112,9 @@ void ATA::CreateHDDinfo(u64 sizeSectors)
 	//Model number (40 ASCII characters)
 	WritePaddedString(identifyData, &index, "PCSX2-DEV9-ATA-HDD", 40); //word 27-46
 	//READ/WRITE MULI max sectors
-	WriteUInt16(identifyData, &index, 128 & (0x80 << 8)); //word 47
-	//Dword IO supported
-	WriteUInt16(identifyData, &index, 1); //word 48
+	WriteUInt16(identifyData, &index, 128 | (0x80 << 8)); //word 47
+	//Reserved
+	index += 1 * 2; //word 48
 	//Capabilities
 	/*
 	 * bits 7-0: Retired
@@ -125,9 +127,9 @@ void ATA::CreateHDDinfo(u64 sizeSectors)
 	 */
 	WriteUInt16(identifyData, &index, ((1 << 11) | (1 << 9) | (1 << 8))); //word 49
 	//Capabilities (0-Shall be set to one to indicate a device specific Standby timer value minimum)
-	index += 1 * 2; //word 50
+	WriteUInt16(identifyData, &index, 1 << 14); //word 50
 	//PIO data transfer cycle timing mode (Obsolete)
-	WriteUInt16(identifyData, &index, static_cast<u8>((pioMode > 2 ? pioMode : 2) << 8)); //word 51
+	WriteUInt16(identifyData, &index, static_cast<u16>((pioMode > 2 ? pioMode : 2) << 8)); //word 51
 	//DMA data transfer cycle timing mode (Obsolete)
 	WriteUInt16(identifyData, &index, 0); //word 52
 	//


### PR DESCRIPTION
### Description of Changes
A few changes that bring our Identify report closer to what original PS2 Hardware reports (as per the dump in https://github.com/PCSX2/pcsx2/pull/10514)
Also remove casts, I had thought these where needed to avoid a narrowing conversion warning, but looking at the build logs we don't get those warnings.

### Rationale behind Changes
Better match PS2 hardware

### Suggested Testing Steps
Test PS2 HDD games and apps
