### PR TITLE
Qt: Make Shift+Wheel scroll settings info panel

### DIFF
--- a/pcsx2-qt/Settings/SettingsWindow.cpp
+++ b/pcsx2-qt/Settings/SettingsWindow.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2002-2023 PCSX2 Dev Team
+// SPDX-FileCopyrightText: 2002-2024 PCSX2 Dev Team
 // SPDX-License-Identifier: LGPL-3.0+
 
 #include "MainWindow.h"
@@ -32,7 +32,9 @@
 #include "common/Path.h"
 #include "common/StringUtil.h"
 
+#include <QtGui/QWheelEvent>
 #include <QtWidgets/QMessageBox>
+#include <QtWidgets/QScrollBar>
 #include <QtWidgets/QTextEdit>
 
 static QList<SettingsWindow*> s_open_game_properties_dialogs;
@@ -110,7 +112,7 @@ void SettingsWindow::setupUi(const GameList::Entry* game)
 	addWidget(m_interface_settings = new InterfaceSettingsWidget(this, m_ui.settingsContainer), tr("Interface"),
 		QStringLiteral("interface-line"),
 		tr("<strong>Interface Settings</strong><hr>These options control how the software looks and behaves.<br><br>Mouse over an option "
-		   "for additional information."));
+		   "for additional information, and Shift+Wheel to scroll this panel."));
 
 	// We don't include game list/bios settings in per-game settings.
 	if (!isPerGameSettings())
@@ -120,14 +122,15 @@ void SettingsWindow::setupUi(const GameList::Entry* game)
 			tr("<strong>Game List Settings</strong><hr>The list above shows the directories which will be searched by PCSX2 to populate "
 			   "the game list. Search directories can be added, removed, and switched to recursive/non-recursive."));
 		addWidget(m_bios_settings = new BIOSSettingsWidget(this, m_ui.settingsContainer), tr("BIOS"), QStringLiteral("chip-line"),
-			tr("<strong>BIOS Settings</strong><hr>Configure your BIOS here.<br><br>Mouse over an option for additional information."));
+			tr("<strong>BIOS Settings</strong><hr>Configure your BIOS here.<br><br>Mouse over an option for additional information, "
+			   "and Shift+Wheel to scroll this panel."));
 	}
 
 	// Common to both per-game and global settings.
 	addWidget(m_emulation_settings = new EmulationSettingsWidget(this, m_ui.settingsContainer), tr("Emulation"),
 		QStringLiteral("emulation-line"),
 		tr("<strong>Emulation Settings</strong><hr>These options determine the configuration of frame pacing and game "
-		   "settings.<br><br>Mouse over an option for additional information."));
+		   "settings.<br><br>Mouse over an option for additional information, and Shift+Wheel to scroll this panel."));
 
 	if (isPerGameSettings())
 	{
@@ -153,19 +156,19 @@ void SettingsWindow::setupUi(const GameList::Entry* game)
 
 	addWidget(m_graphics_settings = new GraphicsSettingsWidget(this, m_ui.settingsContainer), tr("Graphics"), QStringLiteral("image-fill"),
 		tr("<strong>Graphics Settings</strong><hr>These options determine the configuration of the graphical output.<br><br>Mouse over an "
-		   "option for additional information."));
+		   "option for additional information, and Shift+Wheel to scroll this panel."));
 	addWidget(m_audio_settings = new AudioSettingsWidget(this, m_ui.settingsContainer), tr("Audio"), QStringLiteral("volume-up-line"),
 		tr("<strong>Audio Settings</strong><hr>These options control the audio output of the console.<br><br>Mouse over an option for "
-		   "additional information."));
+		   "additional information, and Shift+Wheel to scroll this panel."));
 
 	addWidget(m_memory_card_settings = new MemoryCardSettingsWidget(this, m_ui.settingsContainer), tr("Memory Cards"),
 		QStringLiteral("memcard-line"),
 		tr("<strong>Memory Card Settings</strong><hr>Create and configure Memory Cards here.<br><br>Mouse over an option for "
-		   "additional information."));
+		   "additional information, and Shift+Wheel to scroll this panel."));
 
 	addWidget(m_dev9_settings = new DEV9SettingsWidget(this, m_ui.settingsContainer), tr("Network & HDD"), QStringLiteral("global-line"),
 		tr("<strong>Network & HDD Settings</strong><hr>These options control the network connectivity and internal HDD storage of the "
-		   "console.<br><br>Mouse over an option for additional information."));
+		   "console.<br><br>Mouse over an option for additional information, and Shift+Wheel to scroll this panel."));
 
 	if (!isPerGameSettings())
 	{
@@ -199,7 +202,7 @@ void SettingsWindow::setupUi(const GameList::Entry* game)
 		addWidget(m_advanced_settings = new AdvancedSettingsWidget(this, m_ui.settingsContainer), tr("Advanced"),
 			QStringLiteral("warning-line"),
 			tr("<strong>Advanced Settings</strong><hr>These are advanced options to determine the configuration of the simulated "
-			   "console.<br><br>Mouse over an option for additional information."));
+			   "console.<br><br>Mouse over an option for additional information, and Shift+Wheel to scroll this panel."));
 		addWidget(m_debug_settings = new DebugSettingsWidget(this, m_ui.settingsContainer), tr("Debug"),
 			QStringLiteral("heart-monitor-line"),
 			tr("<strong>Debug Settings</strong><hr>These are options which can be used to log internal information about the application. "
@@ -399,8 +402,36 @@ bool SettingsWindow::eventFilter(QObject* object, QEvent* event)
 			m_ui.helpText->setText(m_category_help_text[m_ui.settingsCategory->currentRow()]);
 		}
 	}
+	else if (event->type() == QEvent::Wheel)
+	{
+		if (handleWheelEvent(static_cast<QWheelEvent*>(event)))
+			return true;
+	}
 
 	return QWidget::eventFilter(object, event);
+}
+
+bool SettingsWindow::handleWheelEvent(QWheelEvent* event)
+{
+	if (!(event->modifiers() & Qt::ShiftModifier))
+		return false;
+
+	const int amount = event->hasPixelDelta() ? event->pixelDelta().y() : (event->angleDelta().y() / 20);
+
+	QScrollBar* sb = m_ui.helpText->verticalScrollBar();
+	if (!sb)
+		return false;
+
+	sb->setSliderPosition(std::max(sb->sliderPosition() - amount, 0));
+	return true;
+}
+
+void SettingsWindow::wheelEvent(QWheelEvent* event)
+{
+	if (handleWheelEvent(event))
+		return;
+
+	QWidget::wheelEvent(event);
 }
 
 void SettingsWindow::setWindowTitle(const QString& title)

--- a/pcsx2-qt/Settings/SettingsWindow.h
+++ b/pcsx2-qt/Settings/SettingsWindow.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2002-2023 PCSX2 Dev Team
+// SPDX-FileCopyrightText: 2002-2024 PCSX2 Dev Team
 // SPDX-License-Identifier: LGPL-3.0+
 
 #pragma once
@@ -9,12 +9,14 @@
 #include <array>
 #include <memory>
 
+class QWheelEvent;
+
 class INISettingsInterface;
 class SettingsInterface;
 
 namespace GameList
 {
-struct Entry;
+	struct Entry;
 }
 
 class InterfaceSettingsWidget;
@@ -103,6 +105,7 @@ private Q_SLOTS:
 
 protected:
 	void closeEvent(QCloseEvent*) override;
+	void wheelEvent(QWheelEvent* event);
 
 private:
 	enum : u32
@@ -113,6 +116,7 @@ private:
 	void setupUi(const GameList::Entry* game);
 
 	void addWidget(QWidget* widget, QString title, QString icon, QString help_text);
+	bool handleWheelEvent(QWheelEvent* event);
 
 	SettingsWindow* reopen();
 

--- a/pcsx2/ImGui/ImGuiManager.cpp
+++ b/pcsx2/ImGui/ImGuiManager.cpp
@@ -1049,7 +1049,7 @@ void ImGuiManager::ClearSoftwareCursor(u32 index)
 
 void ImGuiManager::SetSoftwareCursorPosition(u32 index, float pos_x, float pos_y)
 {
-	pxAssert(index >= InputManager::MAX_POINTER_DEVICES);
+	pxAssert(index < InputManager::MAX_SOFTWARE_CURSORS);
 	SoftwareCursor& sc = s_software_cursors[index];
 	sc.pos.first = pos_x;
 	sc.pos.second = pos_y;

--- a/pcsx2/USB/usb-lightgun/guncon2.cpp
+++ b/pcsx2/USB/usb-lightgun/guncon2.cpp
@@ -427,7 +427,6 @@ namespace usb_lightgun
 
 	void GunCon2State::UpdateSoftwarePointerPosition()
 	{
-		pxAssert(has_relative_binds);
 		if (cursor_path.empty())
 			return;
 


### PR DESCRIPTION
### Description of Changes

Backport of https://github.com/stenzek/duckstation/commit/89709094003301674cd3ff900aa68f00f8ca6f49.

### Rationale behind Changes

Some locales have long setting descriptions, which do not fit in the current sized textbox.

### Suggested Testing Steps

Kinda difficult to test if you don't have any long descriptions, but I've hacked one in and it works as expected.
