### PR TITLE
SPU: VolumeSlide: disregard phase when exp + decr

### DIFF
--- a/pcsx2/SPU2/ADSR.cpp
+++ b/pcsx2/SPU2/ADSR.cpp
@@ -144,11 +144,20 @@ void V_VolumeSlide::Update()
 		}
 	}
 
-	counter_inc = std::max<u32>(1, counter_inc);
+	// Allow counter_inc to be zero only in when all bits
+	// of the rate field are set
+	if (Step != 3 && Shift != 0x1f)
+	{
+		counter_inc = std::max<u32>(1, counter_inc);
+	}
 	Counter += counter_inc;
 
 	// If negative phase "increase" to -0x8000 or "decrease" towards 0
-	level_inc = Phase ? -level_inc : level_inc;
+	// Unless in Exp + Decr modes
+	if (!(Exp && Decr))
+	{
+		level_inc = Phase ? -level_inc : level_inc;
+	}
 
 	if (Counter >= 0x8000)
 	{
@@ -162,6 +171,11 @@ void V_VolumeSlide::Update()
 		{
 			s32 low = Phase ? INT16_MIN : 0;
 			s32 high = Phase ? 0 : INT16_MAX;
+			if (Exp)
+			{
+				low = 0;
+				high = INT16_MAX;
+			}
 			Value = std::clamp<s32>(Value + level_inc, low, high);
 		}
 	}


### PR DESCRIPTION
Fixes #10685 

Nocash docs says volume sweep phase does nothing in exponential decrease mode.