### PR TITLE
GS/Metal: Don't discard alpha on RGB depth copy

### DIFF
--- a/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
+++ b/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
@@ -1558,7 +1558,8 @@ void GSDeviceMTL::StretchRect(GSTexture* sTex, const GSVector4& sRect, GSTexture
 	id<MTLRenderPipelineState> pipeline = m_convert_pipeline[static_cast<int>(shader)];
 	pxAssertRel(pipeline, fmt::format("No pipeline for {}", shaderName(shader)).c_str());
 
-	DoStretchRect(sTex, sRect, dTex, dRect, pipeline, linear, LoadAction::DontCareIfFull, nullptr, 0);
+	const LoadAction load_action = (ShaderConvertWriteMask(shader) == 0xf) ? LoadAction::DontCareIfFull : LoadAction::Load;
+	DoStretchRect(sTex, sRect, dTex, dRect, pipeline, linear, load_action, nullptr, 0);
 }}
 
 void GSDeviceMTL::StretchRect(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect, bool red, bool green, bool blue, bool alpha)


### PR DESCRIPTION
### Description of Changes

Metal was assuming a full StretchRect() always covered all channels.
Depth -> RGB copies don't, which resulted in a DONT_CARE load action, and the alpha channel becoming undefined. At least on Apple Silicon, anyway.

### Rationale behind Changes

Fixes GT4 fade transition, maybe other things that use overlapping Z and RT.

Before:
![image](https://github.com/PCSX2/pcsx2/assets/11288319/ef69ec02-bbd4-4d52-a7eb-98dcd0c050df)
After:
![image](https://github.com/PCSX2/pcsx2/assets/11288319/51db813c-bc5a-474f-9735-6fa9c29d9726)

### Suggested Testing Steps

Test GT4 on Mac, preferably Apple Silicon. Desktop GPUs might just behave "correctly" anyway.
