### PR TITLE
GS/HW: Fix up Tekken 5 CRC hack to not remove post + break other scenes

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -1521,6 +1521,7 @@ SCAJ-20125:
     eeClampMode: 2 # Fixes camera and stops constant coin noises on Pirates Cove.
   gsHWFixes:
     alignSprite: 1
+    halfPixelOffset: 4 # Align post.
     getSkipCount: "GSC_Tekken5"
 SCAJ-20126:
   name: "Tekken 5"
@@ -1529,6 +1530,7 @@ SCAJ-20126:
     eeClampMode: 2 # Fixes camera and stops constant coin noises on Pirates Cove.
   gsHWFixes:
     alignSprite: 1
+    halfPixelOffset: 4 # Align post.
     getSkipCount: "GSC_Tekken5"
 SCAJ-20127:
   name: "EyeToy - Play 2 [with Camera]"
@@ -1955,6 +1957,7 @@ SCAJ-20199:
     eeClampMode: 2 # Fixes camera and stops constant coin noises on Pirates Cove.
   gsHWFixes:
     alignSprite: 1
+    halfPixelOffset: 4 # Align post.
     getSkipCount: "GSC_Tekken5"
 SCAJ-25002:
   name: "Shinobi"
@@ -3605,6 +3608,7 @@ SCED-53538:
     eeClampMode: 2 # Fixes camera and stops constant coin noises on Pirates Cove.
   gsHWFixes:
     alignSprite: 1
+    halfPixelOffset: 4 # Align post.
     getSkipCount: "GSC_Tekken5"
 SCED-53611:
   name: "Official PlayStation 2 Magazine - German Kids Special"
@@ -5167,6 +5171,7 @@ SCES-53202:
     eeClampMode: 2 # Fixes camera and stops constant coin noises on Pirates Cove.
   gsHWFixes:
     alignSprite: 1
+    halfPixelOffset: 4 # Align post.
     getSkipCount: "GSC_Tekken5"
 SCES-53247:
   name: "WRC Rally Evolved"
@@ -6546,6 +6551,7 @@ SCKA-20049:
     eeClampMode: 2 # Fixes camera and stops constant coin noises on Pirates Cove.
   gsHWFixes:
     alignSprite: 1
+    halfPixelOffset: 4 # Align post.
     getSkipCount: "GSC_Tekken5"
 SCKA-20050:
   name: "Tales of Legendia"
@@ -6754,6 +6760,7 @@ SCKA-20081:
     eeClampMode: 2 # Fixes camera and stops constant coin noises on Pirates Cove.
   gsHWFixes:
     alignSprite: 1
+    halfPixelOffset: 4 # Align post.
     getSkipCount: "GSC_Tekken5"
 SCKA-20082:
   name: "Ace Combat 5 - The Unsung War [PlayStation 2 Big Hit Series]"
@@ -52627,6 +52634,7 @@ SLPS-25510:
     eeClampMode: 2 # Fixes camera and stops constant coin noises on Pirates Cove.
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
+    halfPixelOffset: 4 # Align post.
     getSkipCount: "GSC_Tekken5"
 SLPS-25511:
   name: 羅刹 -Alternative-
@@ -55460,6 +55468,7 @@ SLPS-73223:
     eeClampMode: 2 # Fixes camera and stops constant coin noises on Pirates Cove.
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
+    halfPixelOffset: 4 # Align post.
     getSkipCount: "GSC_Tekken5"
 SLPS-73224:
   name: ゼノサーガ エピソードII［善悪の彼岸］ PS2 the Best [ディスク1/2]
@@ -61311,6 +61320,7 @@ SLUS-21059:
     eeClampMode: 2 # Fixes camera and stops constant coin noises on Pirates Cove.
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
+    halfPixelOffset: 4 # Align post.
     getSkipCount: "GSC_Tekken5"
 SLUS-21060:
   name: "WWE SmackDown! vs. RAW"
@@ -61823,6 +61833,7 @@ SLUS-21160:
     eeClampMode: 2 # Fixes camera and stops constant coin noises on Pirates Cove.
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
+    halfPixelOffset: 4 # Align post.
     getSkipCount: "GSC_Tekken5"
 SLUS-21161:
   name: "Fight Night - Round 2"


### PR DESCRIPTION
### Description of Changes
Fix up Tekken 5 CRC behaviour to not break everything.

### Rationale behind Changes
It was breaking everything. I added HPO Native as well to align the post effect and replaced the skips which avoided the post/blur with a single draw so the picture doesn't get messed up, however this does misalign shadows in other scenes, but it's a lesser evil.

### Suggested Testing Steps
Make sure not everything is broken in Tekken 5.

Fixes #10131

![image](https://github.com/PCSX2/pcsx2/assets/6278726/efca96a7-14e3-4f0b-8264-178864b68731)

