### PR TITLE
Qt: Clean up memory card settings section.

### DIFF
--- a/pcsx2-qt/Settings/MemoryCardSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/MemoryCardSettingsWidget.cpp
@@ -54,7 +54,6 @@ MemoryCardSettingsWidget::MemoryCardSettingsWidget(SettingsWindow* dialog, QWidg
 
 	connect(m_ui.refreshCard, &QPushButton::clicked, this, &MemoryCardSettingsWidget::refresh);
 	connect(m_ui.createCard, &QPushButton::clicked, this, &MemoryCardSettingsWidget::createCard);
-	connect(m_ui.duplicateCard, &QPushButton::clicked, this, &MemoryCardSettingsWidget::duplicateCard);
 	connect(m_ui.renameCard, &QPushButton::clicked, this, &MemoryCardSettingsWidget::renameCard);
 	connect(m_ui.convertCard, &QPushButton::clicked, this, &MemoryCardSettingsWidget::convertCard);
 	connect(m_ui.deleteCard, &QPushButton::clicked, this, &MemoryCardSettingsWidget::deleteCard);
@@ -193,18 +192,8 @@ void MemoryCardSettingsWidget::updateCardActions()
 	bool isPS1 = (cardInfo.has_value() ? cardInfo.value().file_type == MemoryCardFileType::PS1 : false);
 
 	m_ui.convertCard->setEnabled(hasSelection && !isPS1);
-	m_ui.duplicateCard->setEnabled(hasSelection);
 	m_ui.renameCard->setEnabled(hasSelection);
 	m_ui.deleteCard->setEnabled(hasSelection);
-}
-
-void MemoryCardSettingsWidget::duplicateCard()
-{
-	const QString selectedCard(getSelectedCard());
-	if (selectedCard.isEmpty())
-		return;
-
-	QMessageBox::critical(this, tr("Error"), tr("Not yet implemented."));
 }
 
 void MemoryCardSettingsWidget::deleteCard()
@@ -294,7 +283,6 @@ void MemoryCardSettingsWidget::listContextMenuRequested(const QPoint& pos)
 		}
 		menu.addSeparator();
 
-		connect(menu.addAction(tr("Duplicate")), &QAction::triggered, this, &MemoryCardSettingsWidget::duplicateCard);
 		connect(menu.addAction(tr("Rename")), &QAction::triggered, this, &MemoryCardSettingsWidget::renameCard);
 		connect(menu.addAction(tr("Convert")), &QAction::triggered, this, &MemoryCardSettingsWidget::convertCard);
 		connect(menu.addAction(tr("Delete")), &QAction::triggered, this, &MemoryCardSettingsWidget::deleteCard);

--- a/pcsx2-qt/Settings/MemoryCardSettingsWidget.h
+++ b/pcsx2-qt/Settings/MemoryCardSettingsWidget.h
@@ -98,7 +98,6 @@ private:
 
 	QString getSelectedCard() const;
 	void updateCardActions();
-	void duplicateCard();
 	void deleteCard();
 	void renameCard();
 	void convertCard();

--- a/pcsx2-qt/Settings/MemoryCardSettingsWidget.ui
+++ b/pcsx2-qt/Settings/MemoryCardSettingsWidget.ui
@@ -147,13 +147,6 @@
          </widget>
         </item>
         <item>
-         <widget class="QPushButton" name="duplicateCard">
-          <property name="text">
-           <string>Duplicate</string>
-          </property>
-         </widget>
-        </item>
-        <item>
          <widget class="QPushButton" name="renameCard">
           <property name="text">
            <string>Rename</string>


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
This PR removes some unneeded and unused options on the memory card settings page.

Removed option:
- Duplicate (It is not implemented and no plan to do so, it is trivial to do by the user anyway)
- ~~NTFS Compression (It's already enforced by default and there's no reason to disable it.)~~

Master:
![Screenshot_20240122_230437](https://github.com/PCSX2/pcsx2/assets/14798312/e1dba89a-03a2-41fc-a2f7-c7d98d4dc65d)

PR:
![Screenshot_20240122_230356](https://github.com/PCSX2/pcsx2/assets/14798312/ade902c2-0175-4596-9306-13fde563915c)

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Squeaky Clean ✨

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Make sure i didn't break anything on Windows.