### PR TITLE
GS/HW: Don't preload target from overlapping targets after hw clear

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -2504,7 +2504,7 @@ bool GSTextureCache::PreloadTarget(GIFRegTEX0 TEX0, const GSVector2i& size, cons
 								continue;
 							}
 
-							if (preserve_target || preload)
+							if (!hw_clear && (preserve_target || preload))
 							{
 								const int copy_width = (t->m_texture->GetWidth()) > (dst->m_texture->GetWidth()) ? (dst->m_texture->GetWidth()) : t->m_texture->GetWidth();
 								const int copy_height = overlapping_pages_height * t->m_scale;


### PR DESCRIPTION
### Description of Changes
Stops targets copying from overlapping targets after a hw clear.

### Rationale behind Changes
ICO was preloading its target from an old target after a mem clear, ending up with bad data. We should probably invalidation partial matched targets on clears too, but this seems to cause a bunch of extra uploads, and doesn't fix anything, so not bothering for now.

### Suggested Testing Steps
Check ICO (Dump already checked)

ICO:
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/eb2c0f02-faab-415b-ae29-6890aa134fdd)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/890845db-e484-4a56-b513-b5cede03aca4)

