### PR TITLE
l10n: Remove mentions of "Console Port"

### DIFF
--- a/pcsx2-qt/Settings/ControllerGlobalSettingsWidget.ui
+++ b/pcsx2-qt/Settings/ControllerGlobalSettingsWidget.ui
@@ -45,14 +45,14 @@
       <item row="1" column="0">
        <widget class="QCheckBox" name="multitapPort1">
         <property name="text">
-         <string>Multitap on Console Port 1</string>
+         <string>Multitap on Port 1</string>
         </property>
        </widget>
       </item>
       <item row="1" column="1">
        <widget class="QCheckBox" name="multitapPort2">
         <property name="text">
-         <string>Multitap on Console Port 2</string>
+         <string>Multitap on Port 2</string>
         </property>
        </widget>
       </item>

--- a/pcsx2-qt/Settings/MemoryCardSettingsWidget.ui
+++ b/pcsx2-qt/Settings/MemoryCardSettingsWidget.ui
@@ -44,7 +44,7 @@
       </size>
      </property>
      <property name="title">
-      <string>Console Ports</string>
+      <string>Slots</string>
      </property>
      <layout class="QGridLayout" name="gridLayout"/>
     </widget>

--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -3651,7 +3651,7 @@ void FullscreenUI::DrawMemoryCardSettingsPage()
 	for (u32 port = 0; port < NUM_MEMORY_CARD_PORTS; port++)
 	{
 		SmallString str;
-		str.fmt(FSUI_FSTR("Console Port {}"), port + 1);
+		str.fmt(FSUI_FSTR("Slot {}"), port + 1);
 		MenuHeading(str.c_str());
 
 		std::string enable_key(fmt::format("Slot{}_Enable", port + 1));
@@ -3926,9 +3926,9 @@ void FullscreenUI::DrawControllerSettingsPage()
 #endif
 
 	MenuHeading(FSUI_CSTR("Multitap"));
-	DrawToggleSetting(bsi, FSUI_ICONSTR(ICON_FA_PLUS_SQUARE, "Enable Console Port 1 Multitap"),
+	DrawToggleSetting(bsi, FSUI_ICONSTR(ICON_FA_PLUS_SQUARE, "Enable Port 1 Multitap"),
 		FSUI_CSTR("Enables an additional three controller slots. Not supported in all games."), "Pad", "MultitapPort1", false, true, false);
-	DrawToggleSetting(bsi, FSUI_ICONSTR(ICON_FA_PLUS_SQUARE, "Enable Console Port 2 Multitap"),
+	DrawToggleSetting(bsi, FSUI_ICONSTR(ICON_FA_PLUS_SQUARE, "Enable Port 2 Multitap"),
 		FSUI_CSTR("Enables an additional three controller slots. Not supported in all games."), "Pad", "MultitapPort2", false, true, false);
 
 	const std::array<bool, 2> mtap_enabled = {


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Mentions of "Console Port" were replaced by either "Slot" or "Port", as appropriate.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Console Port is not official terminology. Instead, I believe we should use "Slot" for Memory Card slots and simply "Port" for Multitap-related strings.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Check controller global settings, Memory Card settings, and Big Picture controller and Memory Card settings.

P.S. I did this PR all from GitHub. If you need me to squash commits, please let me know.