### PR TITLE
MemoryCardFile: Fix NTFS compression always applying

### DIFF
--- a/pcsx2-qt/Settings/MemoryCardCreateDialog.cpp
+++ b/pcsx2-qt/Settings/MemoryCardCreateDialog.cpp
@@ -117,10 +117,10 @@ void MemoryCardCreateDialog::createCard()
 	}
 
 #ifdef  _WIN32
-	if (m_ui.ntfsCompression->isChecked() && m_type == MemoryCardType::File)
+	if (m_type == MemoryCardType::File)
 	{
-		const std::string fullPath(Path::Combine(EmuFolders::MemoryCards, name_str));
-		FileSystem::SetPathCompression(fullPath.c_str(), true);
+		const std::string fullPath = Path::Combine(EmuFolders::MemoryCards, name_str);
+		FileSystem::SetPathCompression(fullPath.c_str(), m_ui.ntfsCompression->isChecked());
 	}
 #endif
 

--- a/pcsx2-qt/Settings/MemoryCardCreateDialog.cpp
+++ b/pcsx2-qt/Settings/MemoryCardCreateDialog.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2002-2023 PCSX2 Dev Team
+// SPDX-FileCopyrightText: 2002-2024 PCSX2 Dev Team
 // SPDX-License-Identifier: LGPL-3.0+
 
 #include "common/FileSystem.h"
@@ -36,7 +36,13 @@ MemoryCardCreateDialog::MemoryCardCreateDialog(QWidget* parent /* = nullptr */)
 	connect(m_ui.buttonBox->button(QDialogButtonBox::RestoreDefaults), &QPushButton::clicked, this, &MemoryCardCreateDialog::restoreDefaults);
 
 #ifndef _WIN32
-	m_ui.ntfsCompression->setEnabled(false);
+	m_ui.ntfsCompressionLayout->removeWidget(m_ui.ntfsCompression);
+	safe_delete(m_ui.ntfsCompression);
+	m_ui.ntfsCompressionLayout->removeWidget(m_ui.ntfsCompressionLabel);
+	safe_delete(m_ui.ntfsCompressionLabel);
+	m_ui.mainLayout->removeItem(m_ui.ntfsCompressionLayout);
+	safe_delete(m_ui.ntfsCompressionLayout);
+	resize(600, 480);
 #endif
 
 	updateState();

--- a/pcsx2-qt/Settings/MemoryCardCreateDialog.ui
+++ b/pcsx2-qt/Settings/MemoryCardCreateDialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>593</width>
-    <height>545</height>
+    <width>600</width>
+    <height>535</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -16,13 +16,13 @@
   <property name="modal">
    <bool>true</bool>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_9">
+  <layout class="QVBoxLayout" name="mainLayout">
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,1">
-     <property name="bottomMargin">
+     <property name="spacing">
       <number>10</number>
      </property>
-	 <property name="spacing">
+     <property name="bottomMargin">
       <number>10</number>
      </property>
      <item>
@@ -39,8 +39,8 @@
          <height>48</height>
         </size>
        </property>
-	   <property name="pixmap">
-        <pixmap resource="resources/resources.qrc">:/icons/black/svg/memcard-line.svg</pixmap>
+       <property name="pixmap">
+        <pixmap resource="../resources/resources.qrc">:/icons/black/svg/memcard-line.svg</pixmap>
        </property>
        <property name="alignment">
         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
@@ -227,7 +227,7 @@
     </layout>
    </item>
    <item>
-    <layout class="QVBoxLayout" name="verticalLayout_8">
+    <layout class="QVBoxLayout" name="ntfsCompressionLayout">
      <item>
       <widget class="QCheckBox" name="ntfsCompression">
        <property name="text">
@@ -239,7 +239,7 @@
       </widget>
      </item>
      <item>
-      <widget class="QLabel" name="label_10">
+      <widget class="QLabel" name="ntfsCompressionLabel">
        <property name="text">
         <string>NTFS compression is built-in, fast, and completely reliable. Typically compresses Memory Cards (highly recommended).</string>
        </property>

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -1146,11 +1146,6 @@ struct Pcsx2Config
 		HostFs : 1,
 
 		WarnAboutUnsafeSettings : 1;
-
-	// uses automatic ntfs compression when creating new memory cards (Win32 only)
-#ifdef _WIN32
-	bool McdCompressNTFS;
-#endif
 	BITFIELD_END
 
 	CpuOptions Cpu;

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -1697,11 +1697,6 @@ Pcsx2Config::Pcsx2Config()
 	InhibitScreensaver = true;
 	BackupSavestate = true;
 	SavestateZstdCompression = true;
-
-#ifdef _WIN32
-	McdCompressNTFS = true;
-#endif
-
 	WarnAboutUnsafeSettings = true;
 
 	// To be moved to FileMemoryCard pluign (someday)
@@ -1769,10 +1764,6 @@ void Pcsx2Config::LoadSaveCore(SettingsWrapper& wrap)
 	BaseFilenames.LoadSave(wrap);
 	EmulationSpeed.LoadSave(wrap);
 	LoadSaveMemcards(wrap);
-
-#ifdef _WIN32
-	SettingsWrapEntry(McdCompressNTFS);
-#endif
 
 	if (wrap.IsLoading())
 	{

--- a/pcsx2/SIO/Memcard/MemoryCardFile.cpp
+++ b/pcsx2/SIO/Memcard/MemoryCardFile.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2002-2023 PCSX2 Dev Team
+// SPDX-FileCopyrightText: 2002-2024 PCSX2 Dev Team
 // SPDX-License-Identifier: LGPL-3.0+
 
 #include "SIO/Memcard/MemoryCardFile.h"
@@ -257,6 +257,9 @@ void FileMemoryCard::Open()
 	{
 		m_filenames[slot] = {};
 
+		if (EmuConfig.Mcd[slot].Type != MemoryCardType::File)
+			continue;
+
 		if (FileMcd_IsMultitapSlot(slot))
 		{
 			if (!EmuConfig.Pad.MultitapPort0_Enabled && (FileMcd_GetMtapPort(slot) == 0))
@@ -265,29 +268,13 @@ void FileMemoryCard::Open()
 				continue;
 		}
 
-		std::string fname(EmuConfig.FullpathToMcd(slot));
-		std::string_view str(fname);
-		bool cont = false;
+		const std::string fname = EmuConfig.FullpathToMcd(slot);
 
-		if (fname.empty())
+		if (!EmuConfig.Mcd[slot].Enabled || fname.empty())
 		{
-			str = "[empty filename]";
-			cont = true;
-		}
-
-		if (!EmuConfig.Mcd[slot].Enabled)
-		{
-			str = "[disabled]";
-			cont = true;
-		}
-
-		if (EmuConfig.Mcd[slot].Type == MemoryCardType::File)
-			Console.WriteLn(cont ? Color_Gray : Color_Green, fmt::format("McdSlot {} [File]: {}", slot, str));
-		else
-			cont = true;
-
-		if (cont)
+			Console.WriteLnFmt("McdSlot {} [File]: [disabled/empty filename]", slot);
 			continue;
+		}
 
 		if (FileSystem::GetPathFileSize(fname.c_str()) <= 0)
 		{
@@ -301,9 +288,6 @@ void FileMemoryCard::Open()
 					fname.c_str());
 			}
 		}
-
-		// [TODO] : Add memcard size detection and report it to the console log.
-		//   (8MB, 256Mb, formatted, unformatted, etc ...)
 
 		if (fname.ends_with(".bin"))
 		{
@@ -339,6 +323,10 @@ void FileMemoryCard::Open()
 		}
 		else // Load checksum
 		{
+			Console.WriteLnFmt(Color_Green, "McdSlot {} [File]: {} [{} MB, {}]", slot, Path::GetFileName(fname),
+				(FileSystem::FSize64(m_file[slot]) + (MCD_SIZE + 1)) / MC2_MBSIZE,
+				FileMcd_IsMemoryCardFormatted(m_file[slot]) ? "Formatted" : "UNFORMATTED");
+
 			m_filenames[slot] = std::move(fname);
 			m_ispsx[slot] = FileSystem::FSize64(m_file[slot]) == 0x20000;
 			m_chkaddr = 0x210;
@@ -827,18 +815,27 @@ static bool IsMemoryCardFolder(const std::string& path)
 	return FileSystem::FileExists(superblock_path.c_str());
 }
 
-static bool IsMemoryCardFormatted(const std::string& path)
+bool FileMcd_IsMemoryCardFormatted(const std::string& path)
 {
 	auto fp = FileSystem::OpenManagedSharedCFile(path.c_str(), "rb", FileSystem::FileShareMode::DenyNone);
 	if (!fp)
 		return false;
 
+	return FileMcd_IsMemoryCardFormatted(fp.get());
+}
+
+bool FileMcd_IsMemoryCardFormatted(std::FILE* fp)
+{
 	static const char formatted_psx[] = "MC";
 	static const char formatted_string[] = "Sony PS2 Memory Card Format";
 	static constexpr size_t read_length = sizeof(formatted_string) - 1;
 
+	const s64 pos = FileSystem::FTell64(fp);
+
 	u8 data[read_length];
-	if (std::fread(data, read_length, 1, fp.get()) != 1)
+	const bool okay = (FileSystem::FSeek64(fp, 0, SEEK_SET) == 0 && std::fread(data, read_length, 1, fp) == 1);
+	FileSystem::FSeek64(fp, pos, SEEK_SET);
+	if (!okay)
 		return false;
 
 	return (std::memcmp(data, formatted_string, sizeof(formatted_string) - 1) == 0 ||
@@ -890,7 +887,7 @@ std::vector<AvailableMcdInfo> FileMcd_GetAvailableCards(bool include_in_use_card
 			if (fd.Size < MCD_SIZE)
 				continue;
 
-			const bool formatted = IsMemoryCardFormatted(fd.FileName);
+			const bool formatted = FileMcd_IsMemoryCardFormatted(fd.FileName);
 			mcds.push_back({std::move(basename), std::move(fd.FileName), fd.ModificationTime,
 				MemoryCardType::File, GetMemoryCardFileTypeFromSize(fd.Size),
 				static_cast<u32>(fd.Size), formatted});
@@ -923,7 +920,7 @@ std::optional<AvailableMcdInfo> FileMcd_GetCardInfo(const std::string_view& name
 	{
 		if (sd.Size >= MCD_SIZE)
 		{
-			const bool formatted = IsMemoryCardFormatted(path);
+			const bool formatted = FileMcd_IsMemoryCardFormatted(path);
 			ret = {std::move(basename), std::move(path), sd.ModificationTime,
 				MemoryCardType::File, GetMemoryCardFileTypeFromSize(sd.Size),
 				static_cast<u32>(sd.Size), formatted};

--- a/pcsx2/SIO/Memcard/MemoryCardFile.cpp
+++ b/pcsx2/SIO/Memcard/MemoryCardFile.cpp
@@ -305,10 +305,6 @@ void FileMemoryCard::Open()
 		// [TODO] : Add memcard size detection and report it to the console log.
 		//   (8MB, 256Mb, formatted, unformatted, etc ...)
 
-#ifdef _WIN32
-		FileSystem::SetPathCompression(fname.c_str(), EmuConfig.McdCompressNTFS);
-#endif
-
 		if (fname.ends_with(".bin"))
 		{
 			std::string newname(fname + "x");

--- a/pcsx2/SIO/Memcard/MemoryCardFile.h
+++ b/pcsx2/SIO/Memcard/MemoryCardFile.h
@@ -1,8 +1,11 @@
-// SPDX-FileCopyrightText: 2002-2023 PCSX2 Dev Team
+// SPDX-FileCopyrightText: 2002-2024 PCSX2 Dev Team
 // SPDX-License-Identifier: LGPL-3.0+
 
 #pragma once
+
 #include "Config.h"
+
+#include <cstdio>
 #include <ctime>
 #include <optional>
 #include <string>
@@ -50,6 +53,8 @@ int FileMcd_ReIndex(uint port, uint slot, const std::string& filter);
 
 std::vector<AvailableMcdInfo> FileMcd_GetAvailableCards(bool include_in_use_cards);
 std::optional<AvailableMcdInfo> FileMcd_GetCardInfo(const std::string_view& name);
+bool FileMcd_IsMemoryCardFormatted(const std::string& path);
+bool FileMcd_IsMemoryCardFormatted(std::FILE* fp);
 bool FileMcd_CreateNewCard(const std::string_view& name, MemoryCardType type, MemoryCardFileType file_type);
 bool FileMcd_RenameCard(const std::string_view& name, const std::string_view& new_name);
 bool FileMcd_DeleteCard(const std::string_view& name);


### PR DESCRIPTION
### Description of Changes

Inherited from wx....

### Rationale behind Changes

If you unchecked the NTFS compression checkbox, it wouldn't explicitly set it to false, so if the memcards directory was compressed, the file would automatically be compressed too.

### Suggested Testing Steps

Test memcard creation and selection (boot and make sure saves still load).
