### PR TITLE
DEV9: LBA48 Support

### DIFF
--- a/pcsx2-qt/Settings/DEV9SettingsWidget.cpp
+++ b/pcsx2-qt/Settings/DEV9SettingsWidget.cpp
@@ -253,6 +253,8 @@ DEV9SettingsWidget::DEV9SettingsWidget(SettingsWindow* dialog, QWidget* parent)
 	else
 		m_ui.hddFile->setText(QString::fromUtf8(m_dialog->getStringValue("DEV9/Hdd", "HddFile", "DEV9hdd.raw").value().c_str()));
 
+	connect(m_ui.hddLBA48, QOverload<int>::of(&QCheckBox::stateChanged), this, &DEV9SettingsWidget::onHddLBA48Changed);
+
 	UpdateHddSizeUIValues();
 
 	connect(m_ui.hddFile, &QLineEdit::textChanged, this, &DEV9SettingsWidget::onHddFileTextChange);
@@ -720,6 +722,21 @@ void DEV9SettingsWidget::onHddSizeAccessorSpin()
 	m_ui.hddSizeSlider->setValue(m_ui.hddSizeSpinBox->value());
 }
 
+void DEV9SettingsWidget::onHddLBA48Changed(int state)
+{
+	const bool enabled = state;
+
+	m_ui.hddSizeSlider->setMaximum(state ? 2000 : 120);
+	m_ui.hddSizeSpinBox->setMaximum(state ? 2000 : 120);
+	m_ui.hddSizeMaxLabel->setText(state ? tr("2000") : tr("120"));
+	// Bump up min size to have ticks align with 100GiB sizes
+	m_ui.hddSizeSlider->setMinimum(state ? 100 : 40);
+	m_ui.hddSizeSpinBox->setMinimum(state ? 100 : 40);
+	m_ui.hddSizeMinLabel->setText(state ? tr("100") : tr("40"));
+
+	m_ui.hddSizeSlider->setTickInterval(state ? 100 : 5);
+}
+
 void DEV9SettingsWidget::onHddCreateClicked()
 {
 	//Do the thing
@@ -799,6 +816,11 @@ void DEV9SettingsWidget::UpdateHddSizeUIValues()
 	const s64 size = FileSystem::GetPathFileSize(hddPath.c_str());
 	if (size < 0)
 		return;
+
+	if (size > static_cast<s64>(120) * 1024 * 1024 * 1024)
+		m_ui.hddLBA48->setChecked(true);
+	else
+		m_ui.hddLBA48->setChecked(false);
 
 	const int sizeGB = size / 1024 / 1024 / 1024;
 	QSignalBlocker sb1(m_ui.hddSizeSpinBox);

--- a/pcsx2-qt/Settings/DEV9SettingsWidget.h
+++ b/pcsx2-qt/Settings/DEV9SettingsWidget.h
@@ -39,6 +39,7 @@ private Q_SLOTS:
 	void onHddFileEdit();
 	void onHddSizeSlide(int i);
 	void onHddSizeAccessorSpin();
+	void onHddLBA48Changed(int state);
 	void onHddCreateClicked();
 
 public:

--- a/pcsx2-qt/Settings/DEV9SettingsWidget.ui
+++ b/pcsx2-qt/Settings/DEV9SettingsWidget.ui
@@ -365,6 +365,20 @@
         </property>
        </widget>
       </item>
+      <item row="4" column="0">
+       <widget class="QLabel" name="hddLBA48Label">
+        <property name="text">
+         <string>48-bit LBA:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <widget class="QCheckBox" name="hddLBA48">
+        <property name="text">
+         <string>Enabled</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>

--- a/pcsx2/DEV9/ATA/ATA.h
+++ b/pcsx2/DEV9/ATA/ATA.h
@@ -22,7 +22,7 @@ public:
 	int nsector = 0;     //sector count
 	int nsectorLeft = 0; //sectors left to transfer
 private:
-	const bool lba48Supported = false;
+	bool lba48Supported = false;
 
 	std::FILE* hddImage = nullptr;
 	u64 hddImageSize;

--- a/pcsx2/DEV9/ATA/ATA_State.cpp
+++ b/pcsx2/DEV9/ATA/ATA_State.cpp
@@ -94,6 +94,8 @@ int ATA::Open(const std::string& hddPath)
 
 	//Store HddImage size for later use
 	hddImageSize = static_cast<u64>(size);
+	lba48Supported = (hddImageSize > ((static_cast<s64>(1) << 28) - 1) * 512);
+
 	CreateHDDinfo(hddImageSize / 512);
 
 	InitSparseSupport(hddPath);

--- a/pcsx2/DEV9/ATA/Commands/ATA_CmdDMA.cpp
+++ b/pcsx2/DEV9/ATA/Commands/ATA_CmdDMA.cpp
@@ -133,7 +133,7 @@ void ATA::HDD_ReadDMA(bool isLBA48)
 {
 	if (!PreCmd())
 		return;
-	DevCon.WriteLn("DEV9: HDD_ReadDMA");
+	DevCon.WriteLn(isLBA48 ? "DEV9: HDD_ReadDMA48" : "DEV9: HDD_ReadDMA");
 
 	IDE_CmdLBA48Transform(isLBA48);
 
@@ -155,7 +155,7 @@ void ATA::HDD_WriteDMA(bool isLBA48)
 {
 	if (!PreCmd())
 		return;
-	DevCon.WriteLn("DEV9: HDD_WriteDMA");
+	DevCon.WriteLn(isLBA48 ? "DEV9: HDD_WriteDMA48" : "DEV9: HDD_WriteDMA");
 
 	IDE_CmdLBA48Transform(isLBA48);
 

--- a/pcsx2/DEV9/ATA/Commands/ATA_Command.cpp
+++ b/pcsx2/DEV9/ATA/Commands/ATA_Command.cpp
@@ -14,11 +14,27 @@ void ATA::IDE_ExecCmd(u16 value)
 		case 0x20:
 			HDD_ReadSectors(false);
 			break;
-			//0x21
+		case 0x24:
+			if (lba48Supported)
+				HDD_ReadSectors(true);
+			else
+				HDD_Unk();
+			break;
+		case 0x29:
+			if (lba48Supported)
+				HDD_ReadMultiple(true);
+			else
+				HDD_Unk();
+			break;
 		case 0x40:
 			HDD_ReadVerifySectors(false);
 			break;
-			//0x41
+		case 0x42:
+			if (lba48Supported)
+				HDD_ReadVerifySectors(true);
+			else
+				HDD_Unk();
+			break;
 		case 0x70:
 			HDD_SeekCmd();
 			break;
@@ -37,13 +53,21 @@ void ATA::IDE_ExecCmd(u16 value)
 		case 0xC8:
 			HDD_ReadDMA(false);
 			break;
-			//0xC9
 		case 0xCA:
 			HDD_WriteDMA(false);
 			break;
-			//0xCB
-			//0x25 = HDDreadDMA48;
-			//0x35 = HDDwriteDMA48;*/
+		case 0x25:
+			if (lba48Supported)
+				HDD_ReadDMA(true);
+			else
+				HDD_Unk();
+			break;
+		case 0x35:
+			if (lba48Supported)
+				HDD_WriteDMA(true);
+			else
+				HDD_Unk();
+			break;
 		case 0xE1:
 			HDD_IdleImmediate();
 			break;
@@ -53,7 +77,12 @@ void ATA::IDE_ExecCmd(u16 value)
 		case 0xE7:
 			HDD_FlushCache();
 			break;
-			//0xEA = HDDflushCache48
+		case 0xEA:
+			if (lba48Supported)
+				HDD_FlushCache();
+			else
+				HDD_Unk();
+			break;
 		case 0xEC:
 			HDD_IdentifyDevice();
 			break;


### PR DESCRIPTION
### Description of Changes
Adds LBA48 support for HDD larger than 128GB
A checkbox is added to allow choosing larger sizes (upto 2tb)
Larger sizes are supported, but need to be created manually
Managed to get this working, thanks to the fixes added in https://github.com/PCSX2/pcsx2/pull/10514

### Rationale behind Changes
Support HDD sizes >128GB with supporting homebrew software.

### Suggested Testing Steps
Test HDD images larger than 128GB with homebrew apps that support LBA48
Note that the UI checkbox doesn't actually toggle LBA48 support, that is instead enabled based on the HDD file size
