### PR TITLE
Qt: Fix unclickable links in Setup Wizard

### DIFF
--- a/pcsx2-qt/SetupWizardDialog.ui
+++ b/pcsx2-qt/SetupWizardDialog.ui
@@ -151,7 +151,7 @@
           <bool>true</bool>
          </property>
          <property name="textInteractionFlags">
-          <enum>Qt::TextBrowserInteraction</enum>
+          <set>Qt::TextBrowserInteraction</set>
          </property>
         </widget>
        </item>
@@ -232,6 +232,12 @@
          </property>
          <property name="wordWrap">
           <bool>true</bool>
+         </property>
+         <property name="openExternalLinks">
+          <bool>true</bool>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::TextBrowserInteraction</set>
          </property>
         </widget>
        </item>
@@ -343,6 +349,12 @@
          </property>
          <property name="wordWrap">
           <bool>true</bool>
+         </property>
+         <property name="openExternalLinks">
+          <bool>true</bool>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::TextBrowserInteraction</set>
          </property>
         </widget>
        </item>


### PR DESCRIPTION
### Description of Changes

Missing the flag to enable links to be clicked

### Rationale behind Changes

Forgot it

### Suggested Testing Steps

CI passes