### PR TITLE
GUI: Memory Card "slot" instead of "port"

### DIFF
--- a/pcsx2-qt/Settings/MemoryCardSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/MemoryCardSettingsWidget.cpp
@@ -88,22 +88,22 @@ void MemoryCardSettingsWidget::setupAdditionalUi()
 		createSlotWidgets(&m_slots[i], i);
 
 	// button to swap Memory Cards
-	QToolButton* swap_button = new QToolButton(m_ui.portGroupBox);
+	QToolButton* swap_button = new QToolButton(m_ui.slotGroupBox);
 	swap_button->setIcon(QIcon::fromTheme("arrow-left-right-line"));
 	swap_button->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Expanding);
 	swap_button->setToolTip(tr("Swap Memory Cards"));
 	connect(swap_button, &QToolButton::clicked, this, &MemoryCardSettingsWidget::swapCards);
-	static_cast<QGridLayout*>(m_ui.portGroupBox->layout())->addWidget(swap_button, 0, 1);
+	static_cast<QGridLayout*>(m_ui.slotGroupBox->layout())->addWidget(swap_button, 0, 1);
 }
 
 void MemoryCardSettingsWidget::createSlotWidgets(SlotGroup* port, u32 slot)
 {
 	const bool perGame = m_dialog->isPerGameSettings();
 
-	port->root = new QWidget(m_ui.portGroupBox);
+	port->root = new QWidget(m_ui.slotGroupBox);
 
 	SettingsInterface* sif = m_dialog->getSettingsInterface();
-	port->enable = new QCheckBox(tr("Port %1").arg(slot + 1), port->root);
+	port->enable = new QCheckBox(tr("Slot %1").arg(slot + 1), port->root);
 	SettingWidgetBinder::BindWidgetToBoolSetting(
 		sif, port->enable, CONFIG_SECTION, StringUtil::StdStringFromFormat("Slot%u_Enable", slot + 1), true);
 	connect(port->enable, &QCheckBox::stateChanged, this, &MemoryCardSettingsWidget::refresh);
@@ -128,7 +128,7 @@ void MemoryCardSettingsWidget::createSlotWidgets(SlotGroup* port, u32 slot)
 	vert_layout->addWidget(port->enable, 0);
 	vert_layout->addLayout(bottom_layout, 1);
 
-	static_cast<QGridLayout*>(m_ui.portGroupBox->layout())->addWidget(port->root, 0, (slot != 0) ? 2 : 0);
+	static_cast<QGridLayout*>(m_ui.slotGroupBox->layout())->addWidget(port->root, 0, (slot != 0) ? 2 : 0);
 }
 
 void MemoryCardSettingsWidget::autoSizeUI()
@@ -278,7 +278,7 @@ void MemoryCardSettingsWidget::listContextMenuRequested(const QPoint& pos)
 	{
 		for (u32 slot = 0; slot < MAX_SLOTS; slot++)
 		{
-			connect(menu.addAction(tr("Use for Port %1").arg(slot + 1)), &QAction::triggered, this,
+			connect(menu.addAction(tr("Use for Slot %1").arg(slot + 1)), &QAction::triggered, this,
 				[this, &selectedCard, slot]() { tryInsertCard(slot, selectedCard); });
 		}
 		menu.addSeparator();
@@ -324,7 +324,7 @@ void MemoryCardSettingsWidget::swapCards()
 	if (!card1Name.has_value() || card1Name->empty() || !card2Name.has_value() || card2Name->empty())
 	{
 		QMessageBox::critical(
-			QtUtils::GetRootWidget(this), tr("Error"), tr("Both ports must have a card selected to swap."));
+			QtUtils::GetRootWidget(this), tr("Error"), tr("Both slots must have a card selected to swap."));
 		return;
 	}
 

--- a/pcsx2-qt/Settings/MemoryCardSettingsWidget.ui
+++ b/pcsx2-qt/Settings/MemoryCardSettingsWidget.ui
@@ -24,7 +24,7 @@
     <number>0</number>
    </property>
    <item>
-    <widget class="QGroupBox" name="portGroupBox">
+    <widget class="QGroupBox" name="slotGroupBox">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
        <horstretch>0</horstretch>
@@ -44,7 +44,7 @@
       </size>
      </property>
      <property name="title">
-      <string>Console Ports</string>
+      <string>Memory Card Slots</string>
      </property>
      <layout class="QGridLayout" name="gridLayout"/>
     </widget>

--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -3651,7 +3651,7 @@ void FullscreenUI::DrawMemoryCardSettingsPage()
 	for (u32 port = 0; port < NUM_MEMORY_CARD_PORTS; port++)
 	{
 		SmallString str;
-		str.fmt(FSUI_FSTR("Console Port {}"), port + 1);
+		str.fmt(FSUI_FSTR("Slot {}"), port + 1);
 		MenuHeading(str.c_str());
 
 		std::string enable_key(fmt::format("Slot{}_Enable", port + 1));


### PR DESCRIPTION
### Description of Changes
Change mentions of "port" when referring to Memory Cards to "slot". Also renamed one GUI element to match this change.

### Rationale behind Changes
"Slot" is the official term, we should use it instead of "port".

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Check Memory Card settings in Qt and ImGui.