### PR TITLE
Qt: Make "Open Containing Directory" action select the file

### DIFF
--- a/cmake/Pcsx2Utils.cmake
+++ b/cmake/Pcsx2Utils.cmake
@@ -213,6 +213,9 @@ function(fixup_file_properties target)
 			if("${source}" MATCHES "\\.(inl|h)$")
 				set_source_files_properties("${source}" PROPERTIES XCODE_EXPLICIT_FILE_TYPE sourcecode.cpp.h)
 			endif()
+			if("${source}" MATCHES "\\.(qm)$")
+				set_source_files_properties("${source}" PROPERTIES XCODE_EXPLICIT_FILE_TYPE compiled)
+			endif()
 			# CMake makefile and ninja generators will attempt to share one PCH for both cpp and mm files
 			# That's not actually OK
 			if("${source}" MATCHES "\\.mm$")

--- a/common/CocoaTools.h
+++ b/common/CocoaTools.h
@@ -23,6 +23,8 @@ namespace CocoaTools
 	std::optional<std::string> MoveToTrash(std::string_view file);
 	/// Launch the given application once this one quits
 	bool DelayedLaunch(std::string_view file);
+	/// Open a Finder window to the given URL
+	bool ShowInFinder(std::string_view file);
 }
 
 #endif // __APPLE__

--- a/common/CocoaTools.mm
+++ b/common/CocoaTools.mm
@@ -176,3 +176,12 @@ bool CocoaTools::DelayedLaunch(std::string_view file)
 		return [task launchAndReturnError:nil];
 	}
 }
+
+// MARK: - Directory Services
+
+bool CocoaTools::ShowInFinder(std::string_view file)
+{
+	NSString* str = [[NSString alloc] initWithBytes:file.data() length:file.size() encoding:NSUTF8StringEncoding];
+	return [[NSWorkspace sharedWorkspace] selectFile:str
+	                        inFileViewerRootedAtPath:nil];
+}

--- a/common/CocoaTools.mm
+++ b/common/CocoaTools.mm
@@ -17,6 +17,11 @@
 
 // MARK: - Metal Layers
 
+static NSString*_Nonnull NSStringFromStringView(std::string_view sv)
+{
+	return [[NSString alloc] initWithBytes:sv.data() length:sv.size() encoding:NSUTF8StringEncoding];
+}
+
 bool CocoaTools::CreateMetalLayer(WindowInfo* wi)
 {
 	if (![NSThread isMainThread])
@@ -156,7 +161,7 @@ std::optional<std::string> CocoaTools::GetNonTranslocatedBundlePath()
 
 std::optional<std::string> CocoaTools::MoveToTrash(std::string_view file)
 {
-	NSURL* url = [NSURL fileURLWithPath:[[NSString alloc] initWithBytes:file.data() length:file.size() encoding:NSUTF8StringEncoding]];
+	NSURL* url = [NSURL fileURLWithPath:NSStringFromStringView(file)];
 	NSURL* new_url;
 	if (![[NSFileManager defaultManager] trashItemAtURL:url resultingItemURL:&new_url error:nil])
 		return std::nullopt;
@@ -170,7 +175,7 @@ bool CocoaTools::DelayedLaunch(std::string_view file)
 		[task setExecutableURL:[NSURL fileURLWithPath:@"/bin/sh"]];
 		[task setEnvironment:@{
 			@"WAITPID": [NSString stringWithFormat:@"%d", [[NSProcessInfo processInfo] processIdentifier]],
-			@"LAUNCHAPP": [[NSString alloc] initWithBytes:file.data() length:file.size() encoding:NSUTF8StringEncoding],
+			@"LAUNCHAPP": NSStringFromStringView(file),
 		}];
 		[task setArguments:@[@"-c", @"while /bin/ps -p $WAITPID > /dev/null; do /bin/sleep 0.1; done; exec /usr/bin/open \"$LAUNCHAPP\";"]];
 		return [task launchAndReturnError:nil];
@@ -181,7 +186,6 @@ bool CocoaTools::DelayedLaunch(std::string_view file)
 
 bool CocoaTools::ShowInFinder(std::string_view file)
 {
-	NSString* str = [[NSString alloc] initWithBytes:file.data() length:file.size() encoding:NSUTF8StringEncoding];
-	return [[NSWorkspace sharedWorkspace] selectFile:str
+	return [[NSWorkspace sharedWorkspace] selectFile:NSStringFromStringView(file)
 	                        inFileViewerRootedAtPath:nil];
 }

--- a/pcsx2-qt/CMakeLists.txt
+++ b/pcsx2-qt/CMakeLists.txt
@@ -249,4 +249,5 @@ if(WIN32)
 	)
 endif()
 
+fixup_file_properties(pcsx2-qt)
 setup_main_executable(pcsx2-qt)

--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -1318,11 +1318,10 @@ void MainWindow::onGameListEntryContextMenuRequested(const QPoint& point)
 			});
 		}
 
-		//: Refers to the directory where a game is contained.
-		action = menu.addAction(tr("Open Containing Directory..."));
+		action = menu.addAction(QtUtils::GetShowInFileExplorerMessage());
 		connect(action, &QAction::triggered, [this, entry]() {
 			const QFileInfo fi(QString::fromStdString(entry->path));
-			QtUtils::OpenURL(this, QUrl::fromLocalFile(fi.absolutePath()));
+			QtUtils::ShowInFileExplorer(this, fi);
 		});
 
 		action = menu.addAction(tr("Set Cover Image..."));

--- a/pcsx2-qt/QtUtils.cpp
+++ b/pcsx2-qt/QtUtils.cpp
@@ -172,8 +172,8 @@ namespace QtUtils
 	{
 		if (!QDesktopServices::openUrl(qurl))
 		{
-			QMessageBox::critical(parent, QObject::tr("Failed to open URL"),
-				QObject::tr("Failed to open URL.\n\nThe URL was: %1").arg(qurl.toString()));
+			QMessageBox::critical(parent, QCoreApplication::translate("FileOperations", "Failed to open URL"),
+				QCoreApplication::translate("FileOperations", "Failed to open URL.\n\nThe URL was: %1").arg(qurl.toString()));
 		}
 	}
 

--- a/pcsx2-qt/QtUtils.h
+++ b/pcsx2-qt/QtUtils.h
@@ -18,6 +18,7 @@ class ByteStream;
 
 class QAction;
 class QComboBox;
+class QFileInfo;
 class QFrame;
 class QKeyEvent;
 class QTableView;
@@ -48,6 +49,12 @@ namespace QtUtils
 	/// Returns a key id for a key event, including any modifiers that we need (e.g. Keypad).
 	/// NOTE: Defined in QtKeyCodes.cpp, not QtUtils.cpp.
 	u32 KeyEventToCode(const QKeyEvent* ev);
+
+	/// Shows a file, or the containing folder if unsupported, with the system file explorer
+	void ShowInFileExplorer(QWidget* parent, const QFileInfo& file);
+
+	/// Get the context menu name for the action performed by ShowInFileExplorer
+	QString GetShowInFileExplorerMessage();
 
 	/// Opens a URL with the default handler.
 	void OpenURL(QWidget* parent, const QUrl& qurl);


### PR DESCRIPTION
### Description of Changes
Replaces "Open Containing Directory" button with "Show in Folder/Finder" button, which actually selects the file in the file explorer it opens.

For the name, "Show in Finder" is very standard on macOS, and for Windows I took "Show in Folder" from the option for the equivalent action in web browsers' download managers, but I've seen other applications use "Show in Explorer" (e.g. JetBrains IDEs), or even "Show in Windows Explorer", and am open to changing it.

Note: I don't know how to do this on Linux, so Linux remains "Open Containing Directory".  If anyone knows, they're welcome to add the appropriate code to `QtUtils::ShowInFileExplorer`.

### Rationale behind Changes
More useful

### Suggested Testing Steps
Right click on a game and select the new option
(I don't remember if I tested it on Windows, so it definitely needs testing there)