### PR TITLE
Debugger: Allow copying address of memory search results

### DIFF
--- a/pcsx2-qt/Debugger/CpuWidget.cpp
+++ b/pcsx2-qt/Debugger/CpuWidget.cpp
@@ -592,6 +592,17 @@ void CpuWidget::contextRemoveSearchResult()
 	delete rowToRemove;
 }
 
+void CpuWidget::contextCopySearchResultAddress()
+{
+	if (!m_ui.listSearchResults->selectionModel()->hasSelection())
+		return;
+
+	const u32 selectedResultIndex = m_ui.listSearchResults->row(m_ui.listSearchResults->selectedItems().first());
+	const u32 rowAddress = m_ui.listSearchResults->item(selectedResultIndex)->data(Qt::UserRole).toUInt();
+	const QString addressString = FilledQStringFromValue(rowAddress, 16);
+	QApplication::clipboard()->setText(addressString);
+}
+
 void CpuWidget::updateFunctionList(bool whenEmpty)
 {
 	if (!m_cpu.isAlive())
@@ -894,6 +905,10 @@ void CpuWidget::onListSearchResultsContextMenu(QPoint pos)
 
 	if (selModel->hasSelection())
 	{
+		QAction* copyAddressAction = new QAction(tr("Copy Address"), m_ui.listSearchResults);
+		connect(copyAddressAction, &QAction::triggered, this, &CpuWidget::contextCopySearchResultAddress);
+		contextMenu->addAction(copyAddressAction);
+
 		QAction* goToDisassemblyAction = new QAction(tr("Go to in Disassembly"), m_ui.listSearchResults);
 		connect(goToDisassemblyAction, &QAction::triggered, this, &CpuWidget::contextSearchResultGoToDisassembly);
 		contextMenu->addAction(goToDisassemblyAction);

--- a/pcsx2-qt/Debugger/CpuWidget.h
+++ b/pcsx2-qt/Debugger/CpuWidget.h
@@ -116,6 +116,7 @@ public slots:
 	void loadSearchResults();
 	void contextSearchResultGoToDisassembly();
 	void contextRemoveSearchResult();
+	void contextCopySearchResultAddress();
 	void onListSearchResultsContextMenu(QPoint pos);
 
 	void saveBreakpointsToDebuggerSettings();


### PR DESCRIPTION
### Description of Changes
Adds the ability to copy the address directly of a memory search result through the right click context menu.

![image](https://github.com/PCSX2/pcsx2/assets/4957200/54e2a1ea-91c6-4bc6-9192-23435d18c110)

### Rationale behind Changes
Makes it quick & easy instead of having to go to the memory address in memory view and then copy.

### Suggested Testing Steps
- Perform any memory search with results and verify the copied address matches the selection and is in hexadecimal. 
