### PR TITLE
Qt: Fix controller type combo box width

### DIFF
--- a/pcsx2-qt/Settings/ControllerBindingWidget.ui
+++ b/pcsx2-qt/Settings/ControllerBindingWidget.ui
@@ -32,7 +32,11 @@
       <item>
        <layout class="QHBoxLayout" name="horizontalLayout">
         <item>
-         <widget class="QComboBox" name="controllerType"/>
+         <widget class="QComboBox" name="controllerType">
+          <property name="sizeAdjustPolicy">
+           <enum>QComboBox::AdjustToContents</enum>
+          </property>
+         </widget>
         </item>
         <item>
          <widget class="QToolButton" name="bindings">

--- a/pcsx2-qt/Settings/USBDeviceWidget.ui
+++ b/pcsx2-qt/Settings/USBDeviceWidget.ui
@@ -32,10 +32,18 @@
       <item>
        <layout class="QHBoxLayout" name="horizontalLayout">
         <item>
-         <widget class="QComboBox" name="deviceType"/>
+         <widget class="QComboBox" name="deviceType">
+          <property name="sizeAdjustPolicy">
+           <enum>QComboBox::AdjustToContents</enum>
+          </property>
+         </widget>
         </item>
         <item>
-         <widget class="QComboBox" name="deviceSubtype"/>
+         <widget class="QComboBox" name="deviceSubtype">
+          <property name="sizeAdjustPolicy">
+           <enum>QComboBox::AdjustToContents</enum>
+          </property>
+         </widget>
         </item>
         <item>
          <widget class="QToolButton" name="bindings">


### PR DESCRIPTION
### Description of Changes
Apparently our combo boxes don't properly adjust their size to match the contents on Windows
Maybe this will help?  (Completely untested)

### Rationale behind Changes
Allow people to put long translations in the box

### Suggested Testing Steps
Try to put long translations in the list of devices