### PR TITLE
GS/HW: Handle more double-half clear edge cases

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.h
@@ -523,7 +523,7 @@ public:
 
 	void IncAge();
 
-	const char* to_string(int type)
+	static const char* to_string(int type)
 	{
 		return (type == DepthStencil) ? "Depth" : "Color";
 	}


### PR DESCRIPTION
### Description of Changes

Spiderman: Web of Shadows clears its depth buffer with 32-bit FRAME and 24-bit Z. So the upper 8 bits of half the depth buffer are not cleared, yay. We can't turn this into a 32-bit clear, because then it'll zero out those bits, which other games need (e.g. Jak 2). We can't do a 24-bit clear, because something might rely on half those bits actually getting zeroed. So, instead, we toss the depth buffer, and let the mem clear path write out FRAME and Z separately, with their associated masks. Limit it to black to avoid false positives.

Also fixes FBW getting blown out to 20 for a horizontal double-half clear in Wakeboarding Unleashed.

### Rationale behind Changes

![image](https://github.com/PCSX2/pcsx2/assets/11288319/f3ce28be-73ad-4a47-a85e-997c9ef0ed56)
![image](https://github.com/PCSX2/pcsx2/assets/11288319/2222d27e-c8ed-4f8a-8468-7cbbfd05560b)


### Suggested Testing Steps

Test spodermen and wakeboarding unleashed.
