### PR TITLE
GS/HW: Kill old source using target if rect is outside target surface

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -13973,6 +13973,8 @@ SLES-50677:
   compat: 5
   clampModes:
     eeClampMode: 3 # Fixes invisible characters in various scenes.
+  gsHWFixes:
+    textureInsideRT: 2 # Fixes Post and transition effects.
 SLES-50679:
   name: "Tenchu 3 - Wrath of Heaven"
   region: "PAL-E"
@@ -14391,6 +14393,8 @@ SLES-50822:
   region: "PAL-M3"
   clampModes:
     eeClampMode: 3 # Fixes invisible characters in various scenes.
+  gsHWFixes:
+    textureInsideRT: 2 # Fixes Post and transition effects.
 SLES-50826:
   name: "Star Wars - Clone Wars"
   region: "PAL-E"
@@ -30586,6 +30590,8 @@ SLPM-60143:
 SLPM-60145:
   name: "Shadow Hearts"
   region: "NTSC-J"
+  gsHWFixes:
+    textureInsideRT: 2 # Fixes Post and transition effects.
 SLPM-60146:
   name: "Tetsu One - Densha de Battle!"
   region: "NTSC-J"
@@ -50047,6 +50053,8 @@ SLPS-25041:
   region: "NTSC-J"
   clampModes:
     eeClampMode: 3 # Fixes invisible characters in various scenes.
+  gsHWFixes:
+    textureInsideRT: 2 # Fixes Post and transition effects.
 SLPS-25042:
   name: 魔剣爻 -MAKEN SHAO-（初回限定版）
   name-sort: まけんしゃお -MAKEN SHAO-（しょかいげんていばん）
@@ -57534,6 +57542,8 @@ SLUS-20347:
   compat: 5
   clampModes:
     eeClampMode: 3 # Fixes invisible characters in various scenes.
+  gsHWFixes:
+    textureInsideRT: 2 # Fixes Post and transition effects.
   patches:
     default:
       content: |-

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -1039,6 +1039,12 @@ GSTextureCache::Source* GSTextureCache::LookupSource(const bool is_color, const 
 	if (!src)
 		src = FindSourceInMap(TEX0, TEXA, psm_s, clut, gpu_clut, compare_lod, region, is_fixed_tex0, m_src.m_map[lookup_page]);
 
+	if (src && src->m_from_target && GSConfig.UserHacks_TextureInsideRt >= GSTextureInRtMode::MergeTargets && GSLocalMemory::GetUnwrappedEndBlockAddress(TEX0.TBP0, TEX0.TBW, TEX0.PSM, r) > src->m_from_target->m_end_block)
+	{
+		m_src.RemoveAt(src);
+		src = nullptr;
+	}
+
 	Target* dst = nullptr;
 	bool half_right = false;
 	int x_offset = 0;


### PR DESCRIPTION
### Description of Changes
Kills the source that was found if it's connected to a target, but the read is outside of that target, if we are using merged targets, of course.

Also adds Texture in RT (Merge Targets) to Shadow Hearts

### Rationale behind Changes
Because the game in question (Shadow Hearts) uses double buffering, then reads those double buffers both at 0x00000 but using an offset, the original source doesn't get invalidated, since the target hasn't been invalidated.  This PR will invalidate it so targets can be merged together in to a single source if this happens.

### Suggested Testing Steps
Test Shadow Hearts, make sure transitions for fights no longer flicker, opening the menu doesn't cover the screen in garbage, and special effects for Fusion moves work correctly.

Fixes #6742

Fusion Effect:
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/87cde5e6-6e10-452d-bf5c-074450a49137)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/c84523db-f7db-44cf-a220-d0d686227a9e)

Battle Transition:
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/f5f3d042-7d5b-4821-afe0-52976f5a119b)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/1f92d94e-b734-46bc-a702-9c5711ee0c38)

Menu:
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/9db5c5e1-b238-4fa9-a2cc-cbc0086f22a0)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/4d6ca697-00bb-40e7-b8a0-5664ae24ed7a)
