### PR TITLE
Counters: Move input poll to after throttle

### DIFF
--- a/pcsx2-gsrunner/Main.cpp
+++ b/pcsx2-gsrunner/Main.cpp
@@ -707,7 +707,7 @@ int main(int argc, char* argv[])
 	return EXIT_SUCCESS;
 }
 
-void Host::VSyncOnCPUThread()
+void Host::PumpMessagesOnCPUThread()
 {
 	// update GS thread copy of frame number
 	MTGS::RunOnGSThread([frame_number = GSDumpReplayer::GetFrameNumber()]() { s_dump_frame_number = frame_number; });

--- a/pcsx2-qt/QtHost.cpp
+++ b/pcsx2-qt/QtHost.cpp
@@ -1122,7 +1122,7 @@ void Host::OnCreateMemoryCardOpenRequested()
 	emit g_emu_thread->onCreateMemoryCardOpenRequested();
 }
 
-void Host::VSyncOnCPUThread()
+void Host::PumpMessagesOnCPUThread()
 {
 	g_emu_thread->getEventLoop()->processEvents(QEventLoop::AllEvents);
 }

--- a/pcsx2/Counters.cpp
+++ b/pcsx2/Counters.cpp
@@ -498,6 +498,9 @@ static __fi void VSyncStart(u32 sCycle)
 
 	gsPostVsyncStart(); // MUST be after framelimit; doing so before causes funk with frame times!
 
+	// Poll input after MTGS frame push, just in case it has to stall to catch up.
+	VMManager::Internal::PollInputOnCPUThread();
+
 	if (EmuConfig.Trace.Enabled && EmuConfig.Trace.EE.m_EnableAll)
 		SysTrace.EE.Counters.Write("    ================  EE COUNTER VSYNC START (frame: %d)  ================", g_FrameCount);
 

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -2484,10 +2484,12 @@ void VMManager::Internal::VSyncOnCPUThread()
 	Achievements::FrameUpdate();
 
 	PollDiscordPresence();
+}
 
+void VMManager::Internal::PollInputOnCPUThread()
+{
+	Host::PumpMessagesOnCPUThread();
 	InputManager::PollSources();
-
-	Host::VSyncOnCPUThread();
 
 	if (EmuConfig.EnableRecordingTools)
 	{

--- a/pcsx2/VMManager.h
+++ b/pcsx2/VMManager.h
@@ -272,6 +272,7 @@ namespace VMManager
 		void ELFLoadingOnCPUThread(std::string elf_path);
 		void EntryPointCompilingOnCPUThread();
 		void VSyncOnCPUThread();
+		void PollInputOnCPUThread();
 	} // namespace Internal
 } // namespace VMManager
 
@@ -317,5 +318,5 @@ namespace Host
 		const std::string& disc_serial, u32 disc_crc, u32 current_crc);
 
 	/// Provided by the host; called once per frame at guest vsync.
-	void VSyncOnCPUThread();
+	void PumpMessagesOnCPUThread();
 } // namespace Host

--- a/tests/ctest/core/StubHost.cpp
+++ b/tests/ctest/core/StubHost.cpp
@@ -169,7 +169,7 @@ void Host::RequestVMShutdown(bool allow_confirm, bool allow_save_state, bool def
 {
 }
 
-void Host::VSyncOnCPUThread()
+void Host::PumpMessagesOnCPUThread()
 {
 }
 


### PR DESCRIPTION
### Description of Changes

Currently, we do emulated vblank start -> poll pads -> throttle -> push frame. This means that pads get polled potentially up to 16ms before the game receives them.

This PR moves the polling to after throttling, and the GS frame push (because that could stall), reducing the amount of delay between polling, and the guest polling the controller (in the vsync handler).

What we _really_ need to do, is move the frame push to before the throttle as well. But that'll introduce pacing issues with VRR setups. So, we need timed present. But the extension for that is held back by **gosh darn wayland**, amongst other issues. This is why we can't have nice things. DirectX has had it since Vista..............

### Rationale behind Changes

Reducing input lag.

### Suggested Testing Steps

Check input lag.
