### PR TITLE
Qt: Deprecate per-game WS/NI toggles in favor of Patches

### DIFF
--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -300,6 +300,26 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* dialog, QWidget* 
 	}
 #endif
 
+	// Get rid of widescreen/no-interlace checkboxes from per-game settings, unless the user previously had them set.
+	if (m_dialog->isPerGameSettings())
+	{
+		if ((m_dialog->containsSettingValue("EmuCore", "EnableWideScreenPatches") || m_dialog->containsSettingValue("EmuCore", "EnableNoInterlacingPatches")) &&
+			QMessageBox::question(QtUtils::GetRootWidget(this), tr("Remove Unsupported Settings"),
+				tr("You currently have the <strong>Enable Widescreen Patches</strong> or <strong>Enable No-Interlacing Patches</strong> options enabled for this game.<br><br>"
+				   "We no longer support these options, instead <strong>you should select the \"Patches\" section, and explicitly enable the patches you want.</strong><br><br>"
+				   "Do you want to remove these options from your game configuration now?"),
+				QMessageBox::Yes, QMessageBox::No) == QMessageBox::Yes)
+		{
+			m_dialog->removeSettingValue("EmuCore", "EnableWideScreenPatches");
+			m_dialog->removeSettingValue("EmuCore", "EnableNoInterlacingPatches");
+		}
+
+		m_ui.gridLayout->removeWidget(m_ui.widescreenPatches);
+		m_ui.gridLayout->removeWidget(m_ui.noInterlacingPatches);
+		safe_delete(m_ui.widescreenPatches);
+		safe_delete(m_ui.noInterlacingPatches);		
+	}
+
 	// Hide advanced options by default.
 	if (!QtHost::ShouldShowAdvancedSettings())
 	{

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
@@ -324,7 +324,7 @@
         </layout>
        </item>
        <item row="8" column="0" colspan="2">
-        <layout class="QGridLayout" name="gridLayout_5">
+        <layout class="QGridLayout" name="displayGridLayout">
          <item row="3" column="0">
           <widget class="QCheckBox" name="PCRTCOffsets">
            <property name="text">

--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -3272,10 +3272,15 @@ void FullscreenUI::DrawGraphicsSettingsPage()
 		"EmuCore/GS", "StretchY", 100, 10, 300, FSUI_CSTR("%d%%"));
 	DrawIntRectSetting(bsi, FSUI_CSTR("Crop"), FSUI_CSTR("Crops the image, while respecting aspect ratio."), "EmuCore/GS", "CropLeft", 0,
 		"CropTop", 0, "CropRight", 0, "CropBottom", 0, 0, 720, 1, FSUI_CSTR("%dpx"));
-	DrawToggleSetting(bsi, FSUI_CSTR("Enable Widescreen Patches"), FSUI_CSTR("Enables loading widescreen patches from pnach files."),
-		"EmuCore", "EnableWideScreenPatches", false);
-	DrawToggleSetting(bsi, FSUI_CSTR("Enable No-Interlacing Patches"),
-		FSUI_CSTR("Enables loading no-interlacing patches from pnach files."), "EmuCore", "EnableNoInterlacingPatches", false);
+
+	if (!IsEditingGameSettings(bsi))
+	{
+		DrawToggleSetting(bsi, FSUI_CSTR("Enable Widescreen Patches"), FSUI_CSTR("Enables loading widescreen patches from pnach files."),
+			"EmuCore", "EnableWideScreenPatches", false);
+		DrawToggleSetting(bsi, FSUI_CSTR("Enable No-Interlacing Patches"),
+			FSUI_CSTR("Enables loading no-interlacing patches from pnach files."), "EmuCore", "EnableNoInterlacingPatches", false);
+	}
+
 	DrawIntListSetting(bsi, FSUI_CSTR("Bilinear Upscaling"), FSUI_CSTR("Smooths out the image when upscaling the console to the screen."),
 		"EmuCore/GS", "linear_present_mode", static_cast<int>(GSPostBilinearMode::BilinearSharp), s_bilinear_present_options,
 		std::size(s_bilinear_present_options), true);


### PR DESCRIPTION
### Description of Changes

We've discouraged setting the WS/NI patch options per-game for some time now. So, formally deprecate them, and give the user the opportunity to remove them from the configuration when they next open Game Properties.

![image](https://github.com/PCSX2/pcsx2/assets/11288319/eec841b3-2c43-4903-aa2a-b3a775911971)

### Rationale behind Changes

Not having two places to enable the same thing in Game Properties.

### Suggested Testing Steps

Use an old version, or manually enable WS/NI patches in game properties.
Open game properties on PR build, make sure it gives you the option to remove them.
Inspect ini file, make sure the keys are removed.
Make sure opening game properties again does not display prompt.
