### PR TITLE
GS/Capture: Show video timestamp instead of wall time

### DIFF
--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -20,6 +20,7 @@
 #include "GS/Renderers/Null/GSRendererNull.h"
 #include "GS/Renderers/HW/GSRendererHW.h"
 #include "GS/Renderers/HW/GSTextureReplacements.h"
+#include "VMManager.h"
 
 #ifdef ENABLE_OPENGL
 #include "GS/Renderers/OpenGL/GSDeviceOGL.h"
@@ -333,6 +334,9 @@ bool GSopen(const Pcsx2Config::GSOptions& config, GSRendererType renderer, u8* b
 
 void GSclose()
 {
+	if (GSCapture::IsCapturing())
+		GSCapture::EndCapture();
+
 	CloseGSRenderer();
 	CloseGSDevice(true);
 	Host::ReleaseRenderWindow();
@@ -492,6 +496,9 @@ void GSGameChanged()
 {
 	if (GSIsHardwareRenderer())
 		GSTextureReplacements::GameChanged();
+
+	if (!VMManager::HasValidVM() && GSCapture::IsCapturing())
+		GSCapture::EndCapture();
 }
 
 bool GSHasDisplayWindow()

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -1537,6 +1537,7 @@ void VMManager::Shutdown(bool save_resume_state)
 	{
 		MTGS::WaitGS(false, false, false);
 		MTGS::ResetGS(true);
+		MTGS::GameChanged();
 	}
 	else
 	{


### PR DESCRIPTION
### Description of Changes

Further improvement to #10619 as suggested in https://github.com/PCSX2/pcsx2/pull/10619#issuecomment-1908659085.

Also fixes recording persisting through VM shutdown.

![image](https://github.com/PCSX2/pcsx2/assets/11288319/8adcb131-d4af-4756-919c-a996f252dab7)

### Rationale behind Changes

QoL improvement.

### Suggested Testing Steps

Test capture overlay.
Make sure recording stops when VM is shutdown in Big Picture, and without.
