### PR TITLE
GS/HW: Allow palette lookups from depth and deswizzle manual deswizzles

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -245,6 +245,9 @@ PAPX-90229:
 PAPX-90230:
   name: "Arc the Lad - Seirei no Tasogare - Premiere Disc"
   region: "NTSC-J"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, corrects the depth of field effect.
+    trilinearFiltering: 1
 PAPX-90231:
   name: 怪盗 スライ・クーパー 体験版
   name-sort: かいとう すらい・くーぱー たいけんばん
@@ -640,6 +643,9 @@ PCPX-96328:
 PCPX-96330:
   name: "Arc the Lad - Seirei no Tasogare - Premiere Disc"
   region: "NTSC-J"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, corrects the depth of field effect.
+    trilinearFiltering: 1
 PCPX-96554:
   name: "Games of Our Style - Tokyo Game Show 2003 Disc"
   region: "NTSC-J"
@@ -979,6 +985,9 @@ SCAJ-20018:
 SCAJ-20019:
   name: "Arc the Lad - Twilight of the Spirits"
   region: "NTSC-J"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, corrects the depth of field effect.
+    trilinearFiltering: 1
 SCAJ-20020:
   name: "Drag-on Dragoon"
   region: "NTSC-C-J"
@@ -1059,6 +1068,9 @@ SCAJ-20037:
 SCAJ-20038:
   name: "Arc the Lad - Twilight of the Spirits"
   region: "NTSC-Unk"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, corrects the depth of field effect.
+    trilinearFiltering: 1
 SCAJ-20039:
   name: "Sidewinder V"
   region: "NTSC-Unk"
@@ -1407,6 +1419,9 @@ SCAJ-20107:
 SCAJ-20108:
   name: "Arc the Lad - Generation"
   region: "NTSC-Unk"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, corrects the depth of field effect.
+    trilinearFiltering: 1
 SCAJ-20109:
   name: "Ratchet & Clank 3 - Up your Arsenal"
   region: "NTSC-Unk"
@@ -2159,6 +2174,9 @@ SCCS-40007:
   name-sort: "Yake Chuancheng Jingling Zhi Huanghun"
   name-en: "Arc the Lad - Seirei no Tasogare"
   region: "NTSC-C"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, corrects the depth of field effect.
+    trilinearFiltering: 1
 SCCS-40009:
   name: 龙珠二世
   name-sort: "Longzhu Ershi"
@@ -6325,6 +6343,9 @@ SCKA-20011:
 SCKA-20012:
   name: "Arc the Lad - Jeongryeongui Hwanghon"
   region: "NTSC-K"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, corrects the depth of field effect.
+    trilinearFiltering: 1
 SCKA-20013:
   name: "SOCOM - U.S. Navy SEALs"
   region: "NTSC-K"
@@ -7079,6 +7100,9 @@ SCKA-90010:
 SCKA-90011:
   name: "Arc the Lad - Jeongryeongui Hwanghon - Premiere Disc"
   region: "NTSC-K"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, corrects the depth of field effect.
+    trilinearFiltering: 1
 SCKA-90016:
   name: "Goehon - Gulryeora! Wangjanim!"
   region: "NTSC-K"
@@ -7608,11 +7632,17 @@ SCPS-15040:
   name-sort: あーくざらっど せいれいのたそがれ ぷれみあむBOX
   name-en: "Arc the Lad - Twilight of the Spirits [Limited Edition]"
   region: "NTSC-J"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, corrects the depth of field effect.
+    trilinearFiltering: 1
 SCPS-15041:
   name: アークザラッド 精霊の黄昏
   name-sort: あーくざらっど せいれいのたそがれ
   name-en: "Arc the Lad - Seirei no Koukon"
   region: "NTSC-J"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, corrects the depth of field effect.
+    trilinearFiltering: 1
 SCPS-15042:
   name: デカボイス マイク同梱版
   name-sort: でかぼいす まいくどうこんばん
@@ -7742,6 +7772,9 @@ SCPS-15058:
   name-sort: Arc The Lad GENERATION
   name-en: "Arc the Lad - Generation"
   region: "NTSC-J"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, corrects the depth of field effect.
+    trilinearFiltering: 1
 SCPS-15059:
   name: みんなのGOLF 4
   name-sort: みんなのGOLF 4
@@ -9937,6 +9970,9 @@ SCUS-97231:
   name: "Arc the Lad - Twilight of the Spirits"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, corrects the depth of field effect.
+    trilinearFiltering: 1
 SCUS-97232:
   name: "Getaway [Demo]"
   region: "NTSC-U"
@@ -10140,6 +10176,9 @@ SCUS-97281:
 SCUS-97282:
   name: "Arc the Lad - Twilight of the Spirits [Demo]"
   region: "NTSC-U"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, corrects the depth of field effect.
+    trilinearFiltering: 1
 SCUS-97292:
   name: "Amplitude [Demo]"
   region: "NTSC-U"
@@ -61932,6 +61971,9 @@ SLUS-21165:
   name: "Arc the Lad - End of Darkness"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, corrects the depth of field effect.
+    trilinearFiltering: 1
 SLUS-21166:
   name: "Full Metal Alchemist 2 - Curse of the Crimson Elixir"
   region: "NTSC-U"

--- a/bin/resources/shaders/dx11/tfx.fx
+++ b/bin/resources/shaders/dx11/tfx.fx
@@ -491,6 +491,10 @@ float4 sample_depth(float2 st, float2 pos)
 	{
 		t.a = t.a >= 128.0f ? 255.0f * TA.y : ((PS_AEM == 0) || any(bool3(t.rgb))) ? 255.0f * TA.x : 0.0f;
 	}
+	else if (PS_PAL_FMT != 0 && !PS_TALES_OF_ABYSS_HLE && !PS_URBAN_CHAOS_HLE)
+	{
+		t = trunc(sample_4p(uint4(t.aaaa))[0] * 255.0f + 0.05f);
+	}
 
 	return t;
 }

--- a/bin/resources/shaders/opengl/tfx_fs.glsl
+++ b/bin/resources/shaders/opengl/tfx_fs.glsl
@@ -440,14 +440,14 @@ vec4 sample_depth(vec2 st)
 
 #endif
 
-
 	// warning t ranges from 0 to 255
 #if (PS_AEM_FMT == FMT_24)
 	t.a = ( (PS_AEM == 0) || any(bvec3(t.rgb))  ) ? 255.0f * TA.x : 0.0f;
 #elif (PS_AEM_FMT == FMT_16)
 	t.a = t.a >= 128.0f ? 255.0f * TA.y : ( (PS_AEM == 0) || any(bvec3(t.rgb)) ) ? 255.0f * TA.x : 0.0f;
+#elif PS_PAL_FMT != 0 && !PS_TALES_OF_ABYSS_HLE && !PS_URBAN_CHAOS_HLE
+	t = trunc(sample_4p(uvec4(t.aaaa))[0] * 255.0f + 0.05f);
 #endif
-
 
 	return t;
 }

--- a/bin/resources/shaders/vulkan/tfx.glsl
+++ b/bin/resources/shaders/vulkan/tfx.glsl
@@ -689,6 +689,10 @@ vec4 sample_depth(vec2 st, ivec2 pos)
 	{
 		t.a = t.a >= 128.0f ? 255.0f * TA.y : ((PS_AEM == 0) || any(bvec3(t.rgb))) ? 255.0f * TA.x : 0.0f;
 	}
+	#elif PS_PAL_FMT != 0 && !PS_TALES_OF_ABYSS_HLE && !PS_URBAN_CHAOS_HLE
+	{
+		t = trunc(sample_4p(uvec4(t.aaaa))[0] * 255.0f + 0.05f);
+	}
 	#endif
 
 	return t;

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -1248,8 +1248,8 @@ bool GSRendererHW::IsUsingAsInBlend()
 
 bool GSRendererHW::IsTBPFrameOrZ(u32 tbp)
 {
-	const bool is_frame = (m_cached_ctx.FRAME.Block() == tbp);
-	const bool is_z = (m_cached_ctx.ZBUF.Block() == tbp);
+	const bool is_frame = (m_cached_ctx.FRAME.Block() == tbp) && (GSUtil::GetChannelMask(m_cached_ctx.FRAME.PSM) & GSUtil::GetChannelMask(m_cached_ctx.TEX0.PSM));
+	const bool is_z = (m_cached_ctx.ZBUF.Block() == tbp) && (GSUtil::GetChannelMask(m_cached_ctx.ZBUF.PSM) & GSUtil::GetChannelMask(m_cached_ctx.TEX0.PSM));
 	if (!is_frame && !is_z)
 		return false;
 
@@ -1273,6 +1273,27 @@ bool GSRendererHW::IsTBPFrameOrZ(u32 tbp)
 	return (is_frame && !no_rt) || (is_z && !no_ds);
 }
 
+void GSRendererHW::HandleManualDeswizzle()
+{
+	// Check if it's doing manual deswizzling first (draws are 32x16), if they are, check if the Z is flat, if not, we're gonna have to get creative and swap around the quandrants, but that's a TODO.
+	GSVertex* v = &m_vertex.buff[0];
+
+	for (u32 i = 0; i < m_vertex.tail; i += 2)
+	{
+		if ((abs((v[i + 1].U) - (v[i].U)) >> 4) != 32 || (abs((v[i + 1].V) - (v[i].V)) >> 4) != 16)
+			return;
+	}
+
+	if (m_vt.m_eq.z)
+	{
+		GSVector4i tex_rect = GSVector4i(m_vt.m_min.t.x, m_vt.m_min.t.y, m_vt.m_max.t.x, m_vt.m_max.t.y);
+		ReplaceVerticesWithSprite(m_r, tex_rect, GSVector2i(1 << m_cached_ctx.TEX0.TW, 1 << m_cached_ctx.TEX0.TH), m_context->scissor.in);
+	}
+	else
+	{
+		DevCon.Warning("Swizzled depth palette draw with non-flat Z draw %d", s_n);
+	}
+}
 
 void GSRendererHW::InvalidateVideoMem(const GIFRegBITBLTBUF& BITBLTBUF, const GSVector4i& r)
 {
@@ -2411,7 +2432,7 @@ void GSRendererHW::Draw()
 		// create that target, because the clear isn't black, it'll hang around and never get invalidated.
 		const bool is_square = (t_size.y == t_size.x) && m_r.w >= 1023 && PrimitiveCoversWithoutGaps();
 		const bool is_clear = is_possible_mem_clear && is_square;
-		const bool possible_shuffle = draw_sprite_tex && (((src && src->m_target && src->m_from_target && src->m_from_target->m_32_bits_fmt && GSLocalMemory::m_psm[src->m_from_target_TEX0.PSM].depth == GSLocalMemory::m_psm[m_cached_ctx.TEX0.PSM].depth) &&
+		const bool possible_shuffle = draw_sprite_tex && (((src && src->m_target && src->m_from_target && src->m_from_target->m_32_bits_fmt) &&
 															  GSLocalMemory::m_psm[m_cached_ctx.TEX0.PSM].bpp == 16 && GSLocalMemory::m_psm[m_cached_ctx.FRAME.PSM].bpp == 16) ||
 															 IsPossibleChannelShuffle());
 		rt = g_texture_cache->LookupTarget(FRAME_TEX0, t_size, target_scale, GSTextureCache::RenderTarget, true,
@@ -4495,6 +4516,11 @@ __ri void GSRendererHW::EmulateTextureSampler(const GSTextureCache::Target* rt, 
 
 		const GSVector4 half_pixel = RealignTargetTextureCoordinate(tex);
 		m_conf.cb_vs.texture_offset = GSVector2(half_pixel.x, half_pixel.y);
+
+		if (m_vt.m_primclass == GS_SPRITE_CLASS && GSLocalMemory::m_psm[m_cached_ctx.TEX0.PSM].pal > 0 && (tex->m_from_target_TEX0.PSM & 0x30) == 0x30 && m_index.tail >= 4)
+		{
+			HandleManualDeswizzle();
+		}
 	}
 	else if (tex->m_palette)
 	{

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -6719,6 +6719,9 @@ void GSRendererHW::ReplaceVerticesWithSprite(const GSVector4i& unscaled_rect, co
 	m_r = unscaled_rect;
 	m_context->scissor.in = scissor;
 	m_vt.m_primclass = GS_SPRITE_CLASS;
+
+	m_drawlist.clear();
+	m_prim_overlap = PRIM_OVERLAP_NO;
 }
 
 void GSRendererHW::ReplaceVerticesWithSprite(const GSVector4i& unscaled_rect, const GSVector2i& unscaled_size)

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.h
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.h
@@ -221,6 +221,9 @@ public:
 	/// Returns true if the specified texture address matches the frame or Z buffer.
 	bool IsTBPFrameOrZ(u32 tbp);
 
+	//// Returns true if the draws appear to be a manual deswizzle.
+	void HandleManualDeswizzle();
+
 	/// Offsets the current draw, used for RT-in-RT. Offsets are relative to the *current* FBP, not the new FBP.
 	void OffsetDraw(s32 fbp_offset, s32 zbp_offset, s32 xoffset, s32 yoffset);
 

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -1626,8 +1626,17 @@ GSTextureCache::Source* GSTextureCache::LookupSource(const bool is_color, const 
 							depth_TEX0.U32[1] = TEX0.U32[1];
 							src = LookupDepthSource(false, depth_TEX0, TEXA, CLAMP, req_rect, possible_shuffle, linear, frame_fbp, req_color, req_alpha);
 
-							if(src != nullptr)
+							if (src != nullptr)
+							{
+
+								if (TEX0.PSM == PSMT8H)
+								{
+									// Attach palette for GPU texture conversion
+									AttachPaletteToSource(src, psm_s.pal, true);
+								}
+
 								return src;
+							}
 						}
 						else
 						{
@@ -1640,7 +1649,15 @@ GSTextureCache::Source* GSTextureCache::LookupSource(const bool is_color, const 
 								src = LookupDepthSource(false, TEX0, TEXA, CLAMP, req_rect, possible_shuffle, linear, frame_fbp, req_color, req_alpha, true);
 
 								if (src != nullptr)
+								{
+									if (TEX0.PSM == PSMT8H)
+									{
+										// Attach palette for GPU texture conversion
+										AttachPaletteToSource(src, psm_s.pal, true);
+									}
+
 									return src;
+								}
 							}
 						}
 					}

--- a/pcsx2/GS/Renderers/Metal/tfx.metal
+++ b/pcsx2/GS/Renderers/Metal/tfx.metal
@@ -604,7 +604,9 @@ struct PSMain
 			t.a = (!PS_AEM || any(t.rgb != 0)) ? 255.f * cb.ta.x : 0.f;
 		else if (PS_AEM_FMT == FMT_16)
 			t.a = t.a >= 128.f ? 255.f * cb.ta.y : (!PS_AEM || any(t.rgb != 0)) ? 255.f * cb.ta.x : 0.f;
-
+		else if (PS_PAL_FMT != 0 && !PS_TALES_OF_ABYSS_HLE && !PS_URBAN_CHAOS_HLE)
+			t = trunc(sample_4p(uint4(t.aaaa))[0] * 255.0f + 0.05f);
+			
 		return t;
 	}
 

--- a/pcsx2/ShaderCacheVersion.h
+++ b/pcsx2/ShaderCacheVersion.h
@@ -3,4 +3,4 @@
 
 /// Version number for GS and other shaders. Increment whenever any of the contents of the
 /// shaders change, to invalidate the cache.
-static constexpr u32 SHADER_CACHE_VERSION = 38;
+static constexpr u32 SHADER_CACHE_VERSION = 39;


### PR DESCRIPTION
### Description of Changes
Allows palettes to be used in P8H lookups on depth textures.
Deswizzles draws which are manually deswizzling depth to be used on a colour target.

Also added mipmapping to Arc the Lad to help with the depth of field effect.

### Rationale behind Changes
We don't swizzle the depth like the GS does, this would be slow if we did, but gamedevs who tried to be clever and deswizzle it themselves kinda screwed us there, so this replaces the draw with a single sprite.

If the Z is different on each sprite there is no handling for this, but it will throw a log message.

### Suggested Testing Steps
Test Crash N Burn, Arc the Lad - End of Darkness/Generation and Vampire Panic.  Maybe just random spattering of games. Mercenaries 1 & 2 also showed very small differences but nothing scary, maybe check them.

Fixes #7528 Arc the Lad - Twilight of the Spirits
Fixes #3610 Vampire Panic

Arc the Lad - End of Darkness:
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/a66549c4-2acc-4547-9323-01523c99ee79)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/eb4892c1-ebbe-4467-9a12-c01e2262ec3f)

Arc the Lad - Twilight of the Spirits:
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/4ccf3d14-df45-4474-a880-fcc36c36ce3b)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/9b13e0cd-31cc-4edb-9273-0da8f4314ceb)

Crash N Burn:
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/f4d778f9-97df-4442-9bf6-25f9eeee4e2d)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/19d438cb-c530-4714-a89a-3257da1d2fd4)

Vampire Panic:
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/a23cfc56-7d57-4717-9387-83d9615406de)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/55be5d63-97a2-40df-97d2-8690ca27cc71)

Vampire Panic (second comparison):
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/abb7e6c6-3359-4d0f-a8a1-359bcf9c74c5)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/ece34ea4-46e6-4716-b584-92a7c6e8f2df)
