### PR TITLE
GS/HW: Check for overlap on GS move and flush whole texture

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -1990,8 +1990,6 @@ SCAJ-25012:
 SCAJ-25026:
   name: "Kunoichi Shinobi"
   region: "NTSC-Unk"
-  gsHWFixes:
-    getSkipCount: "GSC_Kunoichi"
 SCAJ-25034:
   name: "Sakura Taisen Monogatari"
   region: "NTSC-Unk"
@@ -11471,8 +11469,6 @@ SLAJ-25023:
 SLAJ-25026:
   name: "Kunoichi Shinobi"
   region: "NTSC-Unk"
-  gsHWFixes:
-    getSkipCount: "GSC_Kunoichi"
 SLAJ-25027:
   name: "Sonic Heroes"
   region: "NTSC-Unk"
@@ -11485,8 +11481,6 @@ SLAJ-25030:
 SLAJ-25031:
   name: "Kunoichi - Shinobu"
   region: "NTSC-C-J"
-  gsHWFixes:
-    getSkipCount: "GSC_Kunoichi"
 SLAJ-25033:
   name: "Puyo Puyo Fever"
   region: "NTSC-Unk"
@@ -17650,8 +17644,6 @@ SLES-52238:
   name: "Nightshade"
   region: "PAL-M5"
   compat: 5
-  gsHWFixes:
-    getSkipCount: "GSC_Kunoichi"
 SLES-52240:
   name: "International Pool Championship"
   region: "PAL-M5"
@@ -28169,8 +28161,6 @@ SLKA-25135:
   name: "Kunoichi"
   region: "NTSC-K"
   compat: 5
-  gsHWFixes:
-    getSkipCount: "GSC_Kunoichi"
 SLKA-25136:
   name: "Need for Speed - Underground"
   region: "NTSC-K"
@@ -37704,8 +37694,6 @@ SLPM-65447:
   name-en: "Kunoichi"
   region: "NTSC-J"
   compat: 5
-  gsHWFixes:
-    getSkipCount: "GSC_Kunoichi"
 SLPM-65448:
   name: カンブリアンQTS 〜化石になっても〜
   name-sort: かんぶりあんQTS 〜かせきになっても〜
@@ -59959,8 +59947,6 @@ SLUS-20810:
   name: "Nightshade"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    getSkipCount: "GSC_Kunoichi"
 SLUS-20811:
   name: "Need for Speed - Underground"
   region: "NTSC-U"

--- a/pcsx2/GS/Renderers/HW/GSHwHack.cpp
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.cpp
@@ -389,31 +389,6 @@ bool GSHwHack::GSC_TalesOfLegendia(GSRendererHW& r, int& skip)
 	return true;
 }
 
-bool GSHwHack::GSC_Kunoichi(GSRendererHW& r, int& skip)
-{
-	if (skip == 0)
-	{
-		if (!RTME && (RFBP == 0x0 || RFBP == 0x00700 || RFBP == 0x00800) && RFPSM == PSMCT32 && RFBMSK == 0x00FFFFFF)
-		{
-			// Removes depth effects(shadows) not rendered correctly on all renders.
-			skip = 3;
-		}
-		if (RTME && (RFBP == 0x0700 || RFBP == 0) && RTBP0 == 0x0e00 && RTPSM == 0 && RFBMSK == 0)
-		{
-			skip = 1; // Removes black screen (not needed anymore maybe)?
-		}
-	}
-	else
-	{
-		if (RTME && (RFBP == 0x0e00) && RFPSM == PSMCT32 && RFBMSK == 0xFF000000)
-		{
-			skip = 0;
-		}
-	}
-
-	return true;
-}
-
 bool GSHwHack::GSC_ZettaiZetsumeiToshi2(GSRendererHW& r, int& skip)
 {
 	if (skip == 0)
@@ -1465,7 +1440,6 @@ bool GSHwHack::MV_Ico(GSRendererHW& r)
 #define CRC_F(name) { #name, &GSHwHack::name }
 
 const GSHwHack::Entry<GSRendererHW::GSC_Ptr> GSHwHack::s_get_skip_count_functions[] = {
-	CRC_F(GSC_Kunoichi),
 	CRC_F(GSC_Manhunt2),
 	CRC_F(GSC_MidnightClub3),
 	CRC_F(GSC_SacredBlaze),

--- a/pcsx2/GS/Renderers/HW/GSHwHack.h
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.h
@@ -16,7 +16,6 @@ public:
 	static bool GSC_BlackAndBurnoutSky(GSRendererHW& r, int& skip);
 	static bool GSC_MidnightClub3(GSRendererHW& r, int& skip);
 	static bool GSC_TalesOfLegendia(GSRendererHW& r, int& skip);
-	static bool GSC_Kunoichi(GSRendererHW& r, int& skip);
 	static bool GSC_ZettaiZetsumeiToshi2(GSRendererHW& r, int& skip);
 	static bool GSC_SakuraWarsSoLongMyLove(GSRendererHW& r, int& skip);
 	static bool GSC_UltramanFightingEvolution(GSRendererHW& r, int& skip);

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -1336,8 +1336,12 @@ void GSRendererHW::InvalidateLocalMem(const GIFRegBITBLTBUF& BITBLTBUF, const GS
 
 	if (!skip)
 	{
-		const bool recursive_copy = (BITBLTBUF.SBP == BITBLTBUF.DBP) && (m_env.TRXDIR.XDIR == 2);
-		g_texture_cache->InvalidateLocalMem(m_mem.GetOffset(BITBLTBUF.SBP, BITBLTBUF.SBW, BITBLTBUF.SPSM), r, recursive_copy);
+		const int sx = m_env.TRXPOS.DSAX;
+		const int sy = m_env.TRXPOS.DSAY;
+		const int w = m_env.TRXREG.RRW;
+		const int h = m_env.TRXREG.RRH;
+		const bool recursive_copy = (BITBLTBUF.DBP <= BITBLTBUF.SBP) && GSLocalMemory::GetEndBlockAddress(BITBLTBUF.DBP, BITBLTBUF.DBW, BITBLTBUF.DPSM, GSVector4i(sx, sy, sx + w, sy + h)) >= BITBLTBUF.SBP && (m_env.TRXDIR.XDIR == 2);
+		g_texture_cache->InvalidateLocalMem(m_mem.GetOffset(BITBLTBUF.SBP, BITBLTBUF.SBW, BITBLTBUF.SPSM), r, true);
 	}
 }
 


### PR DESCRIPTION
### Description of Changes
Flushes whole texture from GPU if the move overlaps the source

### Rationale behind Changes
In Nightshade (Kunoichi) This wasn't happening, dirtying part of the next part of the move, then never downloading it ever again. Ideally we do this in a hardware move, but it's kinda complex because of the overlap, I'll revisit this at a later date, but this is at least working for now.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->

Fixes #3988 Nightshade (Kunoichi)

Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/691c74df-cfe4-4b98-a58c-8148209e25c8)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/b7d82528-ed1b-407c-8ea2-c09ddab2f278)
