### PR TITLE
Debugger: Adds editing register values via double click

### DIFF
--- a/pcsx2-qt/Debugger/RegisterWidget.cpp
+++ b/pcsx2-qt/Debugger/RegisterWidget.cpp
@@ -202,6 +202,19 @@ void RegisterWidget::wheelEvent(QWheelEvent* event)
 	this->repaint();
 }
 
+void RegisterWidget::mouseDoubleClickEvent(QMouseEvent* event)
+{
+	if (!m_cpu->isAlive())
+		return;
+	if (m_selectedRow > m_rowEnd) // Unsigned underflow; selectedRow will be > m_rowEnd (technically negative)
+		return;
+	const int categoryIndex = ui.registerTabs->currentIndex();
+	if (m_cpu->getRegisterSize(categoryIndex) == 128)
+		contextChangeSegment();
+	else
+		contextChangeValue();
+}
+
 void RegisterWidget::customMenuRequested(QPoint pos)
 {
 	if (!m_cpu->isAlive())

--- a/pcsx2-qt/Debugger/RegisterWidget.h
+++ b/pcsx2-qt/Debugger/RegisterWidget.h
@@ -26,6 +26,7 @@ public:
 protected:
 	void paintEvent(QPaintEvent* event);
 	void mousePressEvent(QMouseEvent* event);
+	void mouseDoubleClickEvent(QMouseEvent* event);
 	void wheelEvent(QWheelEvent* event);
 
 public slots:


### PR DESCRIPTION
### Description of Changes
Double clicking a register segment will open the segment edit dialogue that normally has to be accessed by the right click menu.

![PCSX2 - DoubleClickRegisterEditing](https://github.com/PCSX2/pcsx2/assets/4957200/068a87c1-255e-424b-a283-548afe0267dd)

### Rationale behind Changes
Ease of use/efficiency. Makes editing register values little more intuitive.

### Suggested Testing Steps
Just verifying the correct value appears when double clicking and pressing okay edits the value expected, as well as no weird behaviors when CPU is off or double clicking on other areas, etc.
