### PR TITLE
Debugger: Check for successful QString conversion in MemoryViewerWidget.cpp before writing

### DIFF
--- a/pcsx2-qt/Debugger/MemoryViewWidget.cpp
+++ b/pcsx2-qt/Debugger/MemoryViewWidget.cpp
@@ -277,9 +277,11 @@ bool MemoryViewTable::KeyPress(int key, QChar keychar)
 
 		if (keyCharIsText)
 		{
-			InsertIntoSelectedHexView(((u8)QString(QChar(key)).toInt(&pressHandled, 16)));
+			// Check if key pressed is hex before insertion (QString conversion fails otherwise)
+			const u8 keyPressed = (u8)QString(QChar(key)).toInt(&pressHandled, 16);
 			if (pressHandled)
 			{
+				InsertIntoSelectedHexView(keyPressed);
 				// Increment to the next nibble or byte
 				if ((selectedNibbleHI = !selectedNibbleHI))
 					UpdateSelectedAddress(selectedAddress + 1);


### PR DESCRIPTION
### Description of Changes
Checks the status of a QString conversion of the keypress being entered into the hex nibble of the memory viewer widget before they're entered to ensure they're valid.

### Rationale behind Changes
Before, pressing a key other than 0–9 or a–f in the hex viewer would result in a failed QString conversion resulting in a 0. This fixes #10745 by @Berylskid. Credit to @Daniel-McCarthy for pointing out that the function call was failing because the QString conversion was failing and for noting that the status of this conversion was stored in pressHandled, which I hadn't realized.

### Suggested Testing Steps
Go to the debugger while in a game, go to the hex viewer at the bottom, and try entering usual values into the hex viewer. Then try to add an unusual one (not 0–9 a–f) and see what happens.