### PR TITLE
DEV9: Fix HDD Response when no HDD is connected

### DIFF
--- a/pcsx2/DEV9/ATA/ATA_State.cpp
+++ b/pcsx2/DEV9/ATA/ATA_State.cpp
@@ -381,6 +381,10 @@ u16 ATA::Read16(u32 addr)
 			[[fallthrough]];
 		case ATA_R_ALT_STATUS:
 			//DevCon.WriteLn("DEV9: *ATA_R_ALT_STATUS 16bit read at address % x, value % x, Active %s", addr, regStatus, (GetSelectedDevice() == 0) ? " True " : " False ");
+
+			if (!EmuConfig.DEV9.HddEnable)
+				return 0xff7f; // PS2 confirmed response when no HDD is actually connected. The Expansion bay always says HDD support is connected.
+
 			//raise IRQ?
 			if (GetSelectedDevice() != 0)
 				return 0;

--- a/pcsx2/DEV9/DEV9.cpp
+++ b/pcsx2/DEV9/DEV9.cpp
@@ -357,6 +357,7 @@ u16 DEV9read16(u32 addr)
 	{
 		return dev9.ata->Read16(addr);
 	}
+	
 	if (addr >= SMAP_REGBASE && addr < FLASH_REGBASE)
 	{
 		//smap
@@ -419,16 +420,18 @@ u16 DEV9read16(u32 addr)
 			return hard;
 
 		case SPD_R_REV_3:
-			if (EmuConfig.DEV9.HddEnable)
-				hard |= SPD_CAPS_ATA;
+			// The Expansion bay always says HDD and Ethernet are supported, we need to keep HDD enabled and we handle it elsewhere.
+			// Ethernet we will turn off as not sure on what that would do right now, but no known game cares if it's off.
 			if (EmuConfig.DEV9.EthEnable)
 				hard |= SPD_CAPS_SMAP;
-			hard |= SPD_CAPS_FLASH;
+
+			// TODO: Do we need flash? my 50003 model doesn't report this, but it does report DVR capable aka (1<<4), was that intended?
+			hard |= SPD_CAPS_ATA | SPD_CAPS_FLASH;
 			//DevCon.WriteLn("DEV9: SPD_R_REV_3 16bit read %x", hard);
 			return hard;
 
 		case SPD_R_0e:
-			hard = 0x0002; //Have HDD inserted
+			hard = 0x0002; //Have HDD module inserted
 			DevCon.WriteLn("DEV9: SPD_R_0e 16bit read %x", hard);
 			return hard;
 		case SPD_R_XFR_CTRL:


### PR DESCRIPTION
### Description of Changes
Correctly reports no device connected when HDD is not enabled

### Rationale behind Changes
The PS2 always reports HDD functionality if you have an expansion bay addon. The device status/control register however reports all bits set (except the reset bit) if the game/program tries to poll it, which will result in it being reported as missing.

### Suggested Testing Steps
Test Final Fantasy X International with Ethernet enabled but HDD disabled

Fixes #10754
