### PR TITLE
GameDB: NTSC-J Overhaul

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -34,12 +34,12 @@
 
 ALCH-00001:
   name: 片神名〜喪われた因果律〜
-  name-sort: かたかむな〜うしなわれたいんがりつ〜
+  name-sort: かたかむな うしなわれたいんがりつ
   name-en: "Katakamuna - Ushinawareta Ingaritsu [Deluxe Pack]"
   region: "NTSC-J"
 ALCH-00003:
   name: ショコラ　〜maid cafe curio〜 限定版
-  name-sort: しょこら　〜maid cafe curio〜 げんていばん
+  name-sort: しょこら maid cafe curio [げんていばん]
   name-en: "Chocolat Maid Cafe Curio [Limited Edition]"
   region: "NTSC-J"
 ALCH-00005:
@@ -48,42 +48,42 @@ ALCH-00005:
   region: "NTSC-J"
 ALCH-00007:
   name: パルフェ Chocolat Second Style 限定版
-  name-sort: ぱるふぇ Chocolat Second Style げんていばん
+  name-sort: ぱるふぇ Chocolat Second Style [げんていばん]
   name-en: "Parfait - Chocolat Second Style [Limited Edition]"
   region: "NTSC-J"
 ALCH-00008:
   name: ARIA The NATURAL 〜遠い記憶のミラージュ〜 限定版
-  name-sort: ARIA The NATURAL 〜とおいきおくのみらーじゅ〜
+  name-sort: ありあ ざ なちゅらる とおいきおくのみらーじゅ
   name-en: "Aria - The Natural - Tooi Yume no Mirage [Limited Edition]"
   region: "NTSC-J"
 ALCH-00009:
   name: ひぐらしのなく頃に祭 初回限定版
-  name-sort: ひぐらしのなくころにまつり　しょかいげんていばん
+  name-sort: ひぐらしのなくころにまつり しょかいげんていばん
   name-en: "Higurashi no Naku Koro ni Matsuri [First Print Limited Edition]"
   region: "NTSC-J"
 ALCH-00010:
   name: この青空に約束を　〜melody of the sun and sea〜 限定版
-  name-sort: このあおぞらにやくそくを　〜melody of the sun and sea〜 げんていばん
+  name-sort: このあおぞらにやくそくを melody of the sun and sea [げんていばん]
   name-en: "Kono Aozora ni Yakusoku wo - Melody of the Sun and Sea [Limited Edition]"
   region: "NTSC-J"
 ALCH-00011:
   name: "Pure×Cure Re:covery 恋と救急セット"
-  name-sort: "Pure×Cure Re:covery こいときゅうきゅうせっと"
+  name-sort: "ぴゅあきゅあ りかばりー こいときゅうきゅうせっと"
   name-en: "Pure x Cure RE-Covery [Koi no Kyuukyuu Set]"
   region: "NTSC-J"
 ALCH-00014:
   name: ARIA The ORIGINATION 〜蒼い惑星のエルシエロ〜 限定版
-  name-sort: ARIA The ORIGINATION 〜あおいほしののえるしえろ〜 げんていばん
+  name-sort: ありあ じ おりじねーしょん あおいほしののえるしえろ [げんていばん]
   name-en: "Aria - The Origination ~Aoi Hoshi no El Cielo~ [Limited Edition]"
   region: "NTSC-J"
 ALCH-00015:
-  name: Sugar+Spice! ～あの子のステキな何もかも～ 初回限定版
-  name-sort: Sugar+Spice! ～あのこのすてきななにもかも～ しょかいげんていばん
+  name: Sugar+Spice! 〜あの子のステキな何もかも〜 初回限定版
+  name-sort: しゅがーすぱいす あのこのすてきななにもかも しょかいげんていばん
   name-en: "Sugar+Spice! - Anoko no Suteki na Nanimokamo [First Press Limited Edition]"
   region: "NTSC-J"
 ALCH-00016:
   name: 恋する乙女と守護の楯 -The shield of AIGIS- 限定版
-  name-sort: こいするおとめとしゅごのたて -The shield of AIGIS- げんていばん
+  name-sort: こいするおとめとしゅごのたて The shield of AIGIS [げんていばん]
   name-en: "Koisuru Otome to Shugo no Tate - The Shield of Aigis [Limited Edition]"
   region: "NTSC-J"
 ALCH-00017:
@@ -92,23 +92,23 @@ ALCH-00017:
   name-en: "Triggerheart Exelica Enhanced [Nendroid Super Set]"
   region: "NTSC-J"
 ALCH-00021:
-  name: セキレイ ～未来からのおくりもの～ 幾久しく！スペシャルパック
-  name-sort: せきれい 〜みらいからのおくりもの〜 いくひさしく！すぺしゃるぱっく
+  name: セキレイ 〜未来からのおくりもの〜 幾久しく！スペシャルパック
+  name-sort: せきれい みらいからのおくりもの いくひさしく すぺしゃるぱっく
   name-en: "Sekirei - Mirai Kara no Okurimono [Special Pack]"
   region: "NTSC-J"
 ALCH-00027:
-  name: スズノネセブン！～Rebirth Knot〜 限定版
-  name-sort: すずのねせぶん！～Rebirth Knot〜 げんていばん
+  name: スズノネセブン！〜Rebirth Knot〜 限定版
+  name-sort: すずのねせぶん Rebirth Knot [げんていばん]
   name-en: "Suzunone Seven - Rebirth Knot [Limited Edition]"
   region: "NTSC-J"
 ALCH-00028:
   name: 花と乙女に祝福を 〜春風の贈り物〜 聖ルピナスBOX
-  name-sort: はなとおとめにしゅくふくを 〜はるかぜのおくりもの〜 せいんとるぴなすBOX
+  name-sort: はなとおとめにしゅくふくを はるかぜのおくりもの せいんとるぴなすBOX
   name-en: "Hana to Otome ni Shukufuku wo - Harukaze no Okurimono [Saint Box]"
   region: "NTSC-J"
 ALCH-0004:
   name: デュエルセイヴァー　ディスティニー メサイアボックス
-  name-sort: でゅえるせいゔぁー　でぃすてぃにー めさいあぼっくす
+  name-sort: でゅえるせいゔぁー でぃすてぃにー めさいあぼっくす
   name-en: "Duel Savior Destiny [Messiah Box]"
   region: "NTSC-J"
 CPCS-01005:
@@ -123,7 +123,7 @@ CPCS-01005:
     mergeSprite: 1 # Fixes flame-like bleeding.
 CPCS-01020:
   name: モンスターハンター2 DXハンターボックス
-  name-sort: もんすたーはんたー2 DXはんたーぼっくす
+  name-sort: もんすたーはんたー2 [DXはんたーぼっくす]
   name-en: "Monster Hunter 2 [DX Hunters Box]"
   region: "NTSC-J"
   compat: 5
@@ -133,7 +133,7 @@ CPCS-01020:
     maximumBlendingLevel: 0 # Fixes unnecessary load on the GPU.
 GUST-00009:
   name: マナケミア 〜学園の錬金術師たち〜 プレミアムボックス
-  name-sort: まなけみあ 〜がくえんのれんきんじゅつしたち〜 ぷれみあむぼっくす
+  name-sort: まなけみあ がくえんのれんきんじゅつしたち ぷれみあむぼっくす
   name-en: "Mana Khemia - Alchemists of Al-Revis [Premium Box]"
   region: "NTSC-J"
   roundModes:
@@ -145,12 +145,12 @@ GUST-00009:
 PAPX-90201:
   name: ファンタビジョン 体験版
   name-sort: ふぁんたびじょん たいけんばん
-  name-en: "Fantavision [Taikenban]"
+  name-en: "Fantavision [Trial]"
   region: "NTSC-J"
 PAPX-90202:
-  name: I.Q REMIX＋ 体験版
-  name-sort: I.Q REMIX＋ たいけんばん
-  name-en: "IQ Remix - Intelligent Qube [Trial]"
+  name: I.Q REMIX+ 体験版
+  name-sort: あいきゅー りみっくすぷらす たいけんばん
+  name-en: "I.Q Remix+ - Intelligent Qube [Trial]"
   region: "NTSC-J"
 PAPX-90203:
   name: "Gran Turismo 2000 [Trial]"
@@ -209,8 +209,8 @@ PAPX-90220:
   region: "NTSC-J"
 PAPX-90222:
   name: ジャック×ダクスター 旧世界の遺産 体験版
-  name-sort: じゃっく×だくすたー きゅうせかいのいさん たいけんばん
-  name-en: "Jak x Daxter - Kyuu Sekai no Isan [Demo, Taikenban]"
+  name-sort: じゃっくだくすたー きゅうせかいのいさん [たいけんばん]
+  name-en: "Jak x Daxter - Kyuu Sekai no Isan [Demo]"
   region: "NTSC-J"
   gsHWFixes:
     mipmap: 2 # Fixes broken textures.
@@ -219,8 +219,8 @@ PAPX-90222:
     cpuSpriteRenderLevel: 2 # Needed for above.
 PAPX-90223:
   name: ジャック×ダクスター 旧世界の遺産 体験版
-  name-sort: じゃっく×だくすたー きゅうせかいのいさん たいけんばん
-  name-en: "Jak x Daxter - Kyuu Sekai no Isan [Demo, Taikenban]"
+  name-sort: じゃっくだくすたー きゅうせかいのいさん たいけんばん
+  name-en: "Jak x Daxter - Kyuu Sekai no Isan [Demo]"
   region: "NTSC-J"
   gsHWFixes:
     mipmap: 2 # Fixes broken textures.
@@ -240,7 +240,9 @@ PAPX-90228:
   name: "Otostaz"
   region: "NTSC-J"
 PAPX-90229:
-  name: "XI [sÃ¡i] - XI-Go"
+  name: "XIゴ 目からウロコ体験版"
+  name-sort: "さいご めからうろこたいけんばん"
+  name-en: "Xi-go [Trial]"
   region: "NTSC-J"
 PAPX-90230:
   name: "Arc the Lad - Seirei no Tasogare - Premiere Disc"
@@ -250,8 +252,8 @@ PAPX-90230:
     trilinearFiltering: 1
 PAPX-90231:
   name: 怪盗 スライ・クーパー 体験版
-  name-sort: かいとう すらい・くーぱー たいけんばん
-  name-en: "Kaitou Sly Cooper [Demo, Taikenban]"
+  name-sort: かいとう すらいくーぱー たいけんばん
+  name-en: "Kaitou Sly Cooper [Trial]"
   region: "NTSC-J"
 PAPX-90232:
   name: "Chain Dive"
@@ -260,16 +262,22 @@ PAPX-90233:
   name: "Bakusou Mountain Bikers"
   region: "NTSC-J"
 PAPX-90234:
-  name: "Katamari Damacy"
+  name: 塊魂 体験版
+  name-sort: かたまりだましい たいけんばん
+  name-en: "Katamari Damacy [Trial]"
   region: "NTSC-J"
 PAPX-90235:
   name: "XIII"
   region: "NTSC-J"
 PAPX-90236:
-  name: "Minna Daisuki Katamari Damacy"
+  name: みんな大好き塊魂 体験版
+  name-sort: みんなだいすきかたまりだましい たいけんばん
+  name-en: "Minna Daisuki Katamari Damacy [Trial]"
   region: "NTSC-J"
 PAPX-90330:
-  name: "Saru! Get You! 2 - Ukki Ukki Disc"
+  name: "サルゲッチュ2 ウッキーウッキーディスク"
+  name-sort: さるげっちゅ2 うっきーうっきーでぃすく
+  name-en: "Saru! Get You! 2 - Ukki Ukki Disc"
   region: "NTSC-J"
   gameFixes:
     - SoftwareRendererFMVHack # Fixes interlacing.
@@ -280,13 +288,17 @@ PAPX-90501:
   name: "Dark Cloud"
   region: "NTSC-J"
 PAPX-90502:
-  name: "The Yamanote-sen - Train Simulator Real"
+  name: "THE 山手線 〜Train Simulator Real 体験版"
+  name-sort: THE やまのてせん Train Simulator Real [たいけんばん]
+  name-en: "Yamanote-sen - Train Simulator Real [Trial], The"
   region: "NTSC-J"
 PAPX-90503:
   name: "PoPoLoCrois - Hajimari no Bouken [Fan Gentei Disc]"
   region: "NTSC-J"
 PAPX-90504:
-  name: "Gran Turismo Concept - Airtrek Turbo Special Edition [Demo]"
+  name: "GRAN TURISMO Concept AIRTREK TURBO Special Edition 体験版"
+  name-sort: "ぐらんつーりすも こんせぷと えあとれっくたーぼ すぺしゃるえでぃしょん たいけんばん"
+  name-en: "Gran Turismo Concept - Airtrek Turbo Special Edition [Trial]"
   region: "NTSC-J"
   gsHWFixes:
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
@@ -294,7 +306,7 @@ PAPX-90505:
   name: "2002 Natsu no Osusume Soft Otameshi Disc"
   region: "NTSC-J"
 PAPX-90506:
-  name: "Dark Chronicle [Demo, Taikenban]"
+  name: "Dark Chronicle [Trial]"
   region: "NTSC-J"
   compat: 5
   clampModes:
@@ -310,7 +322,7 @@ PAPX-90508:
   name: "Gran Turismo 4 - Lupo Cup Training Version"
   region: "NTSC-J"
 PAPX-90511:
-  name: "Siren - Trial Disc"
+  name: "Siren [Trial]"
   region: "NTSC-J"
 PAPX-90512:
   name: "Gran Turismo 4 - Toyota Prius [Trial]"
@@ -343,7 +355,9 @@ PAPX-90517:
   gsHWFixes:
     autoFlush: 2 # Reduces post-processing misalignment.
 PAPX-90519:
-  name: "Doko Demo Issho - Toro to Ippai"
+  name: どこでもいっしょ トロといっぱい 体験版
+  name-sort: どこでもいっしょ とろといっぱい たいけんばん
+  name-en: "Dokodemo Issyo - Toro to Ippai [Trial]"
   region: "NTSC-J"
 PAPX-90521:
   name: "Waga Ryuu o Miyo - Pride of the Dragon Peace"
@@ -352,7 +366,9 @@ PAPX-90522:
   name: "Genji"
   region: "NTSC-J"
 PAPX-90523:
-  name: "Gran Turismo 4 - Online Test Version"
+  name: "Gran Turismo 4 - オンライン実験バージョン"
+  name-sort: "Gran Turismo 4 - おんらいんじっけんばーじょん"
+  name-en: "Gran Turismo 4 - Online Test Version"
   region: "NTSC-J"
 PAPX-90524:
   name: "Wild Arms - The Vth Vanguard"
@@ -369,13 +385,19 @@ PBGP-0065:
   gsHWFixes:
     roundSprite: 2 # Reduces sprite artifacts like in the menu.
 PBPX-95201:
-  name: "Utility Disc [Version 1.00]"
+  name: "ユーティリティディスク Version 1.00"
+  name-sort: "ゆーてぃりてぃでぃすく Version 1.00"
+  name-en: "Utility Disc Version 1.00"
   region: "NTSC-J"
 PBPX-95202:
-  name: "Utility Disc [Version 1.01]"
+  name: "ユーティリティディスク Version 1.01"
+  name-sort: "ゆーてぃりてぃでぃすく Version 1.01"
+  name-en: "Utility Disc Version 1.01"
   region: "NTSC-J"
 PBPX-95203:
-  name: "Utility Disc [Version 1.01]"
+  name: "ユーティリティディスク Version 1.01"
+  name-sort: "ゆーてぃりてぃでぃすく Version 1.01"
+  name-en: "Utility Disc Version 1.01"
   region: "NTSC-J"
 PBPX-95204:
   name: "PlayStation 2 - Demo Disc 2000"
@@ -384,10 +406,14 @@ PBPX-95205:
   name: "PlayStation 2 - Demo Disc 2000"
   region: "PAL-M5"
 PBPX-95206:
-  name: "DVD Player Version 2.01"
+  name: "DVDプレーヤー Version 2.01"
+  name-sort: "DVDぷれーやー Version 2.01"
+  name-en: "DVD Player Version 2.01"
   region: "NTSC-J"
 PBPX-95207:
-  name: "DVD Player Version 2.10"
+  name: "DVDプレーヤー Version 2.10"
+  name-sort: "DVDぷれーやー Version 2.10"
+  name-en: "DVD Player Version 2.10"
   region: "NTSC-J"
 PBPX-95208:
   name: "DVD Player Version 2.10"
@@ -399,8 +425,10 @@ PBPX-95210:
   name: "DVD Player Version 2.10"
   region: "NTSC-U"
 PBPX-95211:
-  name: "HDD Utility Disc Version 1.00"
-  region: "NTSC-U"
+  name: "HDD ユーティリティディスク Version 1.00"
+  name-sort: "HDD ゆーてぃりてぃでぃすく Version 1.00"
+  name-en: "HDD Utility Disc Version 1.00"
+  region: "NTSC-J"
 PBPX-95216:
   name: "HDD Utility Disc Version 1.00 [Beta]"
   region: "NTSC-U"
@@ -414,19 +442,27 @@ PBPX-95220:
   name: "DVD Player Version 2.14"
   region: "PAL-M7"
 PBPX-95221:
-  name: "DVD Player Version 2.12"
+  name: "DVDプレーヤー Version 2.12"
+  name-sort: "DVDぷれーやー Version 2.12"
+  name-en: "DVD Player Version 2.12"
   region: "NTSC-J"
 PBPX-95222:
-  name: "DVD Player Version 2.14"
+  name: "DVDプレーヤー Version 2.14"
+  name-sort: "DVDぷれーやー Version 2.14"
+  name-en: "DVD Player Version 2.14"
   region: "NTSC-J"
 PBPX-95223:
   name: "DVD Player Version 2.14"
   region: "NTSC-U"
 PBPX-95224:
-  name: "DVD Player Version 2.16"
+  name: "DVDプレーヤー Version 2.16"
+  name-sort: "DVDぷれーやー Version 2.16"
+  name-en: "DVD Player Version 2.16"
   region: "NTSC-J"
 PBPX-95228:
-  name: "DVD Player Version 3.00"
+  name: "DVDプレーヤー Version 3.00"
+  name-sort: "DVDぷれーやー Version 3.00"
+  name-en: "DVD Player Version 3.00"
   region: "NTSC-J"
 PBPX-95237:
   name: "HDD Utility Disc"
@@ -456,7 +492,7 @@ PBPX-95251:
   name: "Online Start-Up Disc 4.0 - Broadband Only"
   region: "NTSC-U"
 PBPX-95501:
-  name: "PS2 Linux Beta Release 1"
+  name: "PS2 Linux Beta Release1"
   region: "NTSC-J"
 PBPX-95502:
   name: "Gran Turismo 3 - A-Spec"
@@ -488,7 +524,7 @@ PBPX-95508:
   name: "Linux (for PlayStation 2) Release 1.0 (Disc 2) (Software Packages)"
   region: "NTSC-U"
 PBPX-95509:
-  name: "Linux Release 1.0 Runtime Environment [Disc 1]"
+  name: "Linux (for PlayStation 2) Release 1.0 (Disc 1) (Runtime Environment)"
   region: "PAL-E"
 PBPX-95510:
   name: "Linux (for PlayStation 2) Release 1.0 (Disc 2) (Software Packages)"
@@ -563,10 +599,14 @@ PBPX-95601:
     - "SCPS-15009"
     - "SCPS-55007"
 PCPX-96301:
-  name: "I.Q Remix+ - Intelligent Qube"
+  name: I.Q REMIX+ 体験版
+  name-sort: あいきゅー りみっくすぷらす たいけんばん
+  name-en: "I.Q Remix+ - Intelligent Qube [Trial]"
   region: "NTSC-J"
 PCPX-96302:
-  name: "Fantavision"
+  name: "Fantavision 体験版"
+  name-sort: "ふぁんたびじょん たいけんばん"
+  name-en: "Fantavision [Trial]"
   region: "NTSC-J"
 PCPX-96303:
   name: "6-gatsu Hatsubai Title Promotion Disc (Aconcagua - Boku no Natsuyasumi - TVDJ)"
@@ -575,7 +615,9 @@ PCPX-96304:
   name: "Scandal"
   region: "NTSC-J"
 PCPX-96305:
-  name: "Play-Pre Plus 004 - 2000 June (Disc 2)"
+  name: "プレプレPLUS 004 2000 June (Disc 2)"
+  name-sort: "ぷれぷれぷらす 004 2000 June (Disc 2)"
+  name-en: "Play-Pre Plus 004 - 2000 June (Disc 2)"
   region: "NTSC-J"
 PCPX-96306:
   name: "Bikkuri Mouse"
@@ -610,19 +652,23 @@ PCPX-96317:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
 PCPX-96318:
-  name: "Rimococoron"
+  name: リモココロン たいけんばん
+  name-sort: りもこころん たいけんばん
+  name-en: "Rimococoron [Trial]"
   region: "NTSC-J"
 PCPX-96319:
-  name: "Piposaru 2001"
+  name: "Piposaru 2001 [Trial]"
   region: "NTSC-J"
 PCPX-96320:
-  name: "PaRappa the Rapper 2"
+  name: "PaRappa the Rapper 2 [Trial]"
   region: "NTSC-J"
 PCPX-96321:
   name: "SkyGunner [Trial]"
   region: "NTSC-J"
 PCPX-96322:
-  name: "Ico [Trial]"
+  name: "ICO 体験版"
+  name-sort: "いこ [たいけんばん]"
+  name-en: "Ico [Trial]"
   region: "NTSC-J"
   clampModes:
     eeClampMode: 2 # Otherwise freezes in various spots, check full intro.
@@ -635,10 +681,12 @@ PCPX-96323:
   name: "Toro to Kyuujitsu"
   region: "NTSC-J"
 PCPX-96324:
-  name: "Dual Hearts"
+  name: "Dual Hearts [Trial]"
   region: "NTSC-J"
 PCPX-96328:
-  name: "3 Title Special Disc (Saru! Get You! 2 - PoPoLoCrois: Hajimari no Bouken - Boku no Natsuyasumi 2)"
+  name: "3タイトルスペシャルディスク「サルゲッチュ2・ポポロクロイス-はじまりの冒険-・ぼくのなつやすみ2」"
+  name-sort: "3たいとるすぺしゃるでぃすく さるげっちゅ2 ぽぽぽくろいす はじまりのぼうけん ぼくのなつやすみ2"
+  name-en: "3 Title Special Disc (Saru! Get You! 2 - PoPoLoCrois: Hajimari no Bouken - Boku no Natsuyasumi 2)"
   region: "NTSC-J"
 PCPX-96330:
   name: "Arc the Lad - Seirei no Tasogare - Premiere Disc"
@@ -700,19 +748,25 @@ PCPX-96619:
   name: "Genshi no Kotoba"
   region: "NTSC-J"
 PCPX-96620:
-  name: "MiruMiru 2001-nen 9-gatsudo Juchuugou"
+  name: 見る見る 2001年9月度受注号
+  name-sort: みるみる 2001ねん9がつどじゅちゅうごう
+  name-en: "MiruMiru 2001-nen 9-gatsudo Juchuugou"
   region: "NTSC-J"
 PCPX-96621:
   name: "MiruMiru 2001-nen 10-gatsudo Juchuugou"
   region: "NTSC-J"
 PCPX-96622:
-  name: "Play-Pre 2 Volume 3 - 2001 December"
+  name: "プレプレ2 VOLUME.3"
+  name-sort: "ぷれぷれ2 VOLUME.3"
+  name-en: "Play-Pre 2 Volume 3 - 2001 December"
   region: "NTSC-J"
 PCPX-96624:
   name: "Gran Turismo Concept - 2001 Tokyo"
   region: "NTSC-J"
 PCPX-96625:
-  name: "Play-Pre 2 Volume 4 - 2002 April"
+  name: "プレプレ2 VOLUME.4"
+  name-sort: "ぷれぷれ2 VOLUME.4"
+  name-en: "Play-Pre 2 Volume 4 - 2002 April"
   region: "NTSC-J"
 PCPX-96626:
   name: "PlayStation Index (DVD-ROM-ban) - PlayStation 2 Official Soft Catalog 2002 April"
@@ -721,19 +775,27 @@ PCPX-96627:
   name: "2002 Natsu no Osusume Soft Otameshi Disc"
   region: "NTSC-J"
 PCPX-96628:
-  name: "Play-Pre 2 Volume 5 - 2002 August"
+  name: "プレプレ2 VOLUME.5"
+  name-sort: "ぷれぷれ2 VOLUME.5"
+  name-en: "Play-Pre 2 Volume 5 - 2002 August"
   region: "NTSC-J"
 PCPX-96629:
   name: "Fuyu no Osusume Soft Otameshi Disc 2002"
   region: "NTSC-J"
 PCPX-96630:
-  name: "Play-Pre 2 Volume 6 - 2002 December"
+  name: "プレプレ2 VOLUME.6"
+  name-sort: "ぷれぷれ2 VOLUME.6"
+  name-en: "Play-Pre 2 Volume 6 - 2002 December"
   region: "NTSC-J"
 PCPX-96631:
-  name: "Koedashite Ikou. Taikenban"
+  name: "声出していこー。 体験版"
+  name-sort: こえだしていこー たいけんばん
+  name-en: "Koedashite Ikou. [Trial]"
   region: "NTSC-J"
 PCPX-96632:
-  name: "Play-Pre 2 Volume 7 - 2003 April"
+  name: "プレプレ2 VOLUME.7"
+  name-sort: "ぷれぷれ2 VOLUME.7"
+  name-en: "Play-Pre 2 Volume 7 - 2003 April"
   region: "NTSC-J"
 PCPX-96633:
   name: "Play-Pre 2 Volume 7 - 2003 April - CM Collection"
@@ -742,25 +804,33 @@ PCPX-96634:
   name: "Gran Turismo - Subaru Driving Simulator Version"
   region: "NTSC-J"
 PCPX-96635:
-  name: "Play-Pre 2 Volume 8 - 2003 August"
+  name: "プレプレ2 VOLUME.8"
+  name-sort: "ぷれぷれ2 VOLUME.8"
+  name-en: "Play-Pre 2 Volume 8 - 2003 August"
   region: "NTSC-J"
 PCPX-96636:
-  name: "Siren"
+  name: "Siren [Demo]"
   region: "NTSC-J"
 PCPX-96638:
   name: "EyeToy - Play"
   region: "NTSC-J"
 PCPX-96639:
-  name: "Play-Pre 2 Volume 9 - 2003 December"
+  name: "プレプレ2 VOLUME.9"
+  name-sort: "ぷれぷれ2 VOLUME.9"
+  name-en: "Play-Pre 2 Volume 9 - 2003 December"
   region: "NTSC-J"
 PCPX-96641:
-  name: "Play-Pre 2 Volume 10 - 2004 April"
+  name: "プレプレ2 VOLUME.10"
+  name-sort: "ぷれぷれ2 VOLUME.10"
+  name-en: "Play-Pre 2 Volume 10 - 2004 April"
   region: "NTSC-J"
 PCPX-96646:
-  name: "Play-Pre 2 Volume 11 - 2004 August"
+  name: "プレプレ2 VOLUME.11"
+  name-sort: "ぷれぷれ2 VOLUME.11"
+  name-en: "Play-Pre 2 Volume 11 - 2004 August"
   region: "NTSC-J"
 PCPX-96649:
-  name: "Gran Turismo 4 [Demo]"
+  name: "Gran Turismo 4 [Trial]"
   region: "NTSC-J"
   compat: 5
   clampModes:
@@ -782,13 +852,17 @@ PCPX-96653:
     halfPixelOffset: 2 # Fixes misaligned bloom.
     autoFlush: 2 # Helps fix misaligned bloom.
 PCPX-96655:
-  name: "Play-Pre 2 Volume 12 - 2004 December"
+  name: "プレプレ2 VOLUME.12"
+  name-sort: "ぷれぷれ2 VOLUME.12"
+  name-en: "Play-Pre 2 Volume 12 - 2004 December"
   region: "NTSC-J"
 PCPX-96656:
   name: "Play-Pre 2 Volume 12 - 2004 December - PSP Movie Collection & CM Collection"
   region: "NTSC-J"
 PCPX-96657:
-  name: "Saru! Get You! 3"
+  name: サルゲッチュ3 店頭用体験版
+  name-sort: さるげっちゅ3 てんとうようたいけんばん
+  name-en: "Saru! Get You! 3 [Demo]"
   region: "NTSC-J"
   gameFixes:
     - SoftwareRendererFMVHack # Fixes interlacing.
@@ -818,15 +892,17 @@ PCPX-98041:
   name: "Saru! Get You! Million Monkeys"
   region: "NTSC-J"
 PCPX-98042:
-  name: "Minna no Tennis"
+  name: "Minna no Tennis [Trial]"
   region: "NTSC-J"
   roundModes:
     vu1RoundMode: 1 # Fixes the display of scores and text ingame.
 PDPX-99109:
   name: "DVD Player Version 3.04"
+  name-sort: "DVDぷれーやー Version 3.04"
+  name-en: "DVD Player Version 3.04"
   region: "NTSC-J"
 PKP2-00702:
-  name: "Pandora - Kimi no Namae o Boku wa Shiru [Limited Edition]"
+  name: "Pandora - Kimi no Namae o Boku ha Shiru [Limited Edition]"
   region: "NTSC-J"
   gameFixes:
     - SoftwareRendererFMVHack # Vertical and horizontal lines in FMV.
@@ -840,7 +916,7 @@ SCAJ-10003:
   name: "Taiko no Tatsujin - Doki! Shinkyoku Darake no Haru Matsuri"
   region: "NTSC-Unk"
 SCAJ-10004:
-  name: "Time Crisis 2 [PS2 The Best]"
+  name: "Time Crisis 2 [PlayStation 2 the Best]"
   region: "NTSC-Unk"
 SCAJ-10006:
   name: "Taiko no Tatsujin - Appare Sandaime"
@@ -902,7 +978,7 @@ SCAJ-20003:
   name: "Warrior in Argus"
   region: "NTSC-J"
 SCAJ-20004:
-  name: "dot hack - Outbreak Part 3"
+  name: ".hack Outbreak Part 3"
   region: "NTSC-Unk"
   memcardFilters:
     - "SCPS-55029"
@@ -1017,7 +1093,7 @@ SCAJ-20023:
     alignSprite: 1 # Fixes vertical lines.
     recommendedBlendingLevel: 3 # Fixes menu transparency.
 SCAJ-20024:
-  name: "dot hack - Quarantine Part 4"
+  name: ".hack Quarantine Part 4"
   region: "NTSC-Unk"
   memcardFilters:
     - "SCPS-55029"
@@ -1355,7 +1431,7 @@ SCAJ-20093:
   name: "Tenchu Kurenai"
   region: "NTSC-Unk"
 SCAJ-20094:
-  name: "Minna no Golf 4 [PS2 The Best]"
+  name: "Minna no Golf 4 [PlayStation 2 the Best]"
   region: "NTSC-Unk"
   gsHWFixes:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
@@ -1608,7 +1684,7 @@ SCAJ-20135:
     - "SLPS-73210"
     - "SLPS-73240"
 SCAJ-20136:
-  name: "Ace Combat 5 - The Unsung War [PS2 The Best]"
+  name: "Ace Combat 5 - The Unsung War [PlayStation 2 the Best]"
   region: "NTSC-Unk"
   gameFixes:
     - SoftwareRendererFMVHack # Fixes FMVs disabling hash cache.
@@ -1934,13 +2010,13 @@ SCAJ-20193:
   gameFixes:
     - FpuMulHack
 SCAJ-20194:
-  name: "Minna no Golf 4 [PS2 The Best]"
+  name: "Minna no Golf 4 [PlayStation 2 the Best]"
   region: "NTSC-Unk"
   gsHWFixes:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
 SCAJ-20195:
-  name: "Ape Escape 3 [PS2 The Best]"
+  name: "Ape Escape 3 [PlayStation 2 the Best]"
   region: "NTSC-C"
   gameFixes:
     - SoftwareRendererFMVHack # Fixes interlacing.
@@ -1951,7 +2027,7 @@ SCAJ-20195:
     halfPixelOffset: 2 # Fixes misaligned blur.
     autoFlush: 2 # Fixes corruption in cutscenes and brightens the image.
 SCAJ-20196:
-  name: "Wang Da Yu Ju Xiang [PS2 The Best]"
+  name: "Wang Da Yu Ju Xiang [PlayStation 2 the Best]"
   region: "NTSC-C"
   gsHWFixes:
     mipmap: 1
@@ -1976,10 +2052,10 @@ SCAJ-20197:
     textureInsideRT: 1 # Required for swirl battle transition.
     nativePaletteDraw: 1
 SCAJ-20198:
-  name: "Everybody's Tennis [PS2 The Best]"
+  name: "Everybody's Tennis [PlayStation 2 the Best]"
   region: "NTSC-Unk"
 SCAJ-20199:
-  name: "Tekken 5 [PS2 The Best]"
+  name: "Tekken 5 [PlayStation 2 the Best]"
   region: "NTSC-Unk"
   clampModes:
     eeClampMode: 2 # Fixes camera and stops constant coin noises on Pirates Cove.
@@ -2030,7 +2106,7 @@ SCAJ-25047:
   gsHWFixes:
     minimumBlendingLevel: 2 # Fixes dark font to more bright like software mode.
 SCAJ-30001:
-  name: "Xenosaga - Episode I - Der Wille zur Macht [PS2 The Best]"
+  name: "Xenosaga - Episode I - Der Wille zur Macht [PlayStation 2 the Best]"
   region: "NTSC-Unk"
   compat: 5
   gsHWFixes:
@@ -2093,7 +2169,7 @@ SCAJ-30007:
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 SCAJ-30008:
-  name: "Gran Turismo 4 [PS2 The Best]"
+  name: "Gran Turismo 4 [PlayStation 2 the Best]"
   region: "NTSC-C"
   roundModes:
     eeRoundMode: 3 # Using chop for both normal+div fixes crash in B5 license test.
@@ -2206,7 +2282,7 @@ SCCS-40014:
   name-en: "World Soccer Winning Eleven 7 - International"
   region: "NTSC-C"
 SCCS-40015:
-  name: "薇欧蕾特的工房 ～古拉姆那特的炼金术士2～"
+  name: "薇欧蕾特的工房 〜古拉姆那特的炼金术士2〜"
   name-sort: "Weiouleite De Gongfang Gulamunate De Lianjinshushi 2"
   name-en: "Viorate no Atelier - Gramnad no Renkinjutsushi 2"
   region: "NTSC-C"
@@ -7164,13 +7240,14 @@ SCPN-60160:
   name: "PlayStation BB Navigator - Version 0.32"
   region: "NTSC-J"
 SCPS-11001:
-  name: I.Q REMIX＋
-  name-en: "I.Q. Remix+ - Intelligent Qube"
+  name: I.Q REMIX+
+  name-sort: あいきゅー りみっくすぷらす
+  name-en: "I.Q Remix+ - Intelligent Qube"
   region: "NTSC-J"
   compat: 5
 SCPS-11002:
   name: FANTAVISION
-  name-sort: FANTAVISION
+  name-sort: ふぁんたびじょん
   name-en: "Fantavision"
   region: "NTSC-J"
   compat: 5
@@ -7204,7 +7281,7 @@ SCPS-11006:
   compat: 5
 SCPS-11007:
   name: tsugunai 〜つぐない〜
-  name-sort: tsugunai 〜つぐない〜
+  name-sort: つぐない
   name-en: "Tsuganai"
   region: "NTSC-J"
 SCPS-11008:
@@ -7253,8 +7330,8 @@ SCPS-11014:
   compat: 5
 SCPS-11015:
   name: Check-i-TV きょうから「チェキッ」パック
-  name-sort: Check-i-TV きょうから「ちぇきっ」ぱっく
-  name-en: "Check-i-TV [Kyou kara Check! Pack]"
+  name-sort: Check-i-TV きょうからちぇきっぱっく
+  name-en: "Check-i-TV [Kyou kara Check It Pack]"
   region: "NTSC-J"
 SCPS-11016:
   name: 正義の味方
@@ -7273,7 +7350,7 @@ SCPS-11018:
   region: "NTSC-J"
 SCPS-11019:
   name: ブラボーミュージック 超名曲盤（限定版）
-  name-sort: ぶらぼーみゅーじっく ちょうめいきょくばん（げんていばん）
+  name-sort: ぶらぼーみゅーじっく ちょうめいきょくばん [げんていばん]
   name-en: "Bravo Music - Chou-Meikyokuban [Genteiban]"
   region: "NTSC-J"
   memcardFilters:
@@ -7281,7 +7358,7 @@ SCPS-11019:
     - "SCPS-11019"
     - "SCPS-11020"
 SCPS-11020:
-  name: "Otostaz [Taikenban]"
+  name: "Otostaz [Trial]"
   region: "NTSC-J"
 SCPS-11021:
   name: 夜明けのマリコ 2ndAct パフォーマンスパック
@@ -7362,7 +7439,7 @@ SCPS-11033:
   compat: 5
 SCPS-11034:
   name: ガチャろく2 〜今度は世界一周よ!!〜
-  name-sort: がちゃろく2 〜こんどはせかいいっしゅうよ!!〜
+  name-sort: がちゃろく2 こんどはせかいいっしゅうよ!!
   name-en: "Gacharoku 2"
   region: "NTSC-J"
 SCPS-15001:
@@ -7375,7 +7452,7 @@ SCPS-15001:
     - InstantDMAHack # Fixes graphical corruption.
 SCPS-15002:
   name: TVDJ〜ティービィーディージェー〜
-  name-sort: TVDJ〜てぃーびぃーでぃーじぇー〜
+  name-sort: てぃーびぃーでぃーじぇー
   name-en: "TV DJ"
   region: "NTSC-J"
   compat: 5
@@ -7402,7 +7479,7 @@ SCPS-15005:
   region: "NTSC-J"
 SCPS-15006:
   name: ポポロクロイス〜はじまりの冒険〜 プレミアムボックス
-  name-sort: ぽぽろくろいす〜はじまりのぼうけん〜 ぷれみあむぼっくす
+  name-sort: ぽぽろくろいす はじまりのぼうけん ぷれみあむぼっくす
   name-en: "Popolocrois Story 3 [Limited Edition]"
   region: "NTSC-J"
 SCPS-15007:
@@ -7464,7 +7541,7 @@ SCPS-15015:
   compat: 5
 SCPS-15016:
   name: みんなのGOLF 3
-  name-sort: みんなのGOLF 3
+  name-sort: みんなのごるふ3
   name-en: "Minna no Golf 3"
   region: "NTSC-J"
 SCPS-15017:
@@ -7481,8 +7558,8 @@ SCPS-15017:
     wildArmsHack: 1 # Fixes misaligment depth of field effect.
 SCPS-15018:
   name: THE 山手線 〜Train Simulator Real
-  name-sort: THE やまてせん 〜Train Simulator Real
-  name-en: "Train Simulator Real, The - Yamanote Sen"
+  name-sort: THE やまのてせん Train Simulator Real
+  name-en: "Train Simulator Real, The Yamanote Sen"
   region: "NTSC-J"
 SCPS-15019:
   name: Formula One 2001
@@ -7500,7 +7577,7 @@ SCPS-15020:
     halfPixelOffset: 2 # Reduces ghosting.
 SCPS-15021:
   name: ジャック×ダクスター 旧世界の遺産
-  name-sort: じゃっく×だくすたー きゅうせかいのいさん
+  name-sort: じゃっくだくすたー きゅうせかいのいさん
   name-en: "Jak x Daxter - Kyuusekai no Isan"
   region: "NTSC-J"
   gsHWFixes:
@@ -7514,16 +7591,16 @@ SCPS-15022:
   name-en: "Dual Hearts"
   region: "NTSC-J"
 SCPS-15023:
-  name: WILD ARMS Advanced 3rd プレミアムボックス
-  name-sort: WILD ARMS Advanced 3rd ぷれみあむぼっくす
+  name: ワイルドアームズ アドヴァンスドサード プレミアムボックス
+  name-sort: わいるどあーむず あどゔぁんすどさーど [ぷれみあむぼっくす]
   name-en: "Wild ARMs - Advanced 3rd"
   region: "NTSC-J"
   gsHWFixes:
     wildArmsHack: 1 # Fixes font artifacts and out-of-bound 2D textures.
     gpuPaletteConversion: 2 # Fixes micro-stuttering and drops in performance while also reducing hash cache explosions and GS usage.
 SCPS-15024:
-  name: WILD ARMS Advanced 3rd
-  name-sort: WILD ARMS Advanced 3rd
+  name: ワイルドアームズ アドヴァンスドサード
+  name-sort: わいるどあーむず あどゔぁんすどさーど
   name-en: "Wild ARMs - Advanced 3rd"
   region: "NTSC-J"
   gsHWFixes:
@@ -7549,29 +7626,29 @@ SCPS-15026:
     roundSprite: 1 # Fixes menu text.
 SCPS-15027:
   name: ポポロクロイス〜はじまりの冒険〜 通常版 [初回生産]
-  name-sort: ぽぽろくろいす〜はじまりのぼうけん〜 つうじょうばん [しょかいせいさん]
+  name-sort: ぽぽろくろいす はじまりのぼうけん [つうじょうばん] [しょかいせいさん]
   name-en: "PoPoLoCrois - Hajimari no Bouken [Limited]"
   region: "NTSC-J"
 SCPS-15028:
   name: ポポロクロイス〜はじまりの冒険〜
-  name-sort: ぽぽろくろいす〜はじまりのぼうけん〜
+  name-sort: ぽぽろくろいす はじまりのぼうけん
   name-en: "PoPoLoCrois - Hajimari no Bouken"
   region: "NTSC-J"
 SCPS-15029:
   name: XIゴ
-  name-sort: XIご
-  name-en: "Xi (Sai) Jumbo"
+  name-sort: さいご
+  name-en: "Xi-go"
   region: "NTSC-J"
 SCPS-15030:
   name: ふたりのFANTAVISION
-  name-sort: ふたりのFANTAVISION
-  name-en: "Fantavision"
+  name-sort: ふたりのふぁんたびじょん
+  name-en: "Futari no Fantavision"
   region: "NTSC-J"
   compat: 5
 SCPS-15031:
-  name: THE 京浜急行　〜Train Simulator Real〜 （限定版）
-  name-sort: THE けいひんきゅうこう　〜Train Simulator Real〜 （げんていばん）
-  name-en: "Train Simulator Real, The"
+  name: THE 京浜急行 〜Train Simulator Real〜 （限定版）
+  name-sort: THE けいひんきゅうこう Train Simulator Real [げんていばん]
+  name-en: "Keihin Kyuukou - Train Simulator Real [Limited Edition], The"
   region: "NTSC-J"
   gsHWFixes:
     texturePreloading: 1 # Increases performance due to massive hash cache size.
@@ -7601,18 +7678,18 @@ SCPS-15034:
 SCPS-15035:
   name: THE 京浜急行 〜Train Simulator Real
   name-sort: THE けいひんきゅうこう 〜Train Simulator Real
-  name-en: "Train Simulator Real, The - Keihin Keikyu"
+  name-en: "Keihin Kyuukou - Train Simulator Real, The"
   region: "NTSC-J"
   gsHWFixes:
     texturePreloading: 1 # Increases performance due to massive hash cache size.
 SCPS-15036:
   name: 怪盗 スライ・クーパー
-  name-sort: かいとう すらい・くーぱー
+  name-sort: かいとう すらいくーぱー
   name-en: "Kaitou Sly Cooper"
   region: "NTSC-J"
 SCPS-15037:
   name: ラチェット＆クランク
-  name-sort: らちぇっと＆くらんく
+  name-sort: らちぇっとあんどくらんく
   name-en: "Ratchet & Clank"
   region: "NTSC-J"
   gameFixes:
@@ -7622,21 +7699,21 @@ SCPS-15037:
     trilinearFiltering: 1
 SCPS-15038:
   name: OPERATOR’S SIDE マイク同梱版
-  name-sort: OPERATOR’S SIDE まいくどうこんばん
+  name-sort: おぺれーたーずさいど [まいくどうこんばん]
   name-en: "Operator's Side"
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
 SCPS-15039:
   name: OPERATOR’S SIDE
-  name-sort: OPERATOR’S SIDE
+  name-sort: おぺれーたーずさいど
   name-en: "Operator's Side"
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
 SCPS-15040:
   name: アークザラッド 精霊の黄昏 プレミアムBOX
-  name-sort: あーくざらっど せいれいのたそがれ ぷれみあむBOX
+  name-sort: あーくざらっど せいれいのたそがれ [ぷれみあむBOX]
   name-en: "Arc the Lad - Twilight of the Spirits [Limited Edition]"
   region: "NTSC-J"
   gsHWFixes:
@@ -7672,7 +7749,7 @@ SCPS-15044:
 SCPS-15045:
   name: 蚊2 レッツゴーハワイ
   name-sort: か2 れっつごーはわい
-  name-en: "Ka 2- Let's Go Hawaiian"
+  name-en: "Ka 2 - Let's Go Hawaiian"
   region: "NTSC-J"
   compat: 5
 SCPS-15046:
@@ -7688,7 +7765,7 @@ SCPS-15047:
   region: "NTSC-J"
 SCPS-15049:
   name: みんなのGOLF オンライン
-  name-sort: みんなのGOLF おんらいん
+  name-sort: みんなのごるふおんらいん
   name-en: "Minna no Golf Online"
   region: "NTSC-J"
 SCPS-15050:
@@ -7704,8 +7781,8 @@ SCPS-15051:
   region: "NTSC-J"
 SCPS-15052:
   name: SAINTS（セインツ） 聖なる魔物
-  name-sort: SAINTS（せいんつ） せいなるまもの
-  name-en: "Saints Seinaru Mamono"
+  name-sort: せいんつ せいなるまもの
+  name-en: "Saints - Seinaru Mamono"
   region: "NTSC-J"
   roundModes:
     vu1RoundMode: 1 # Fixes SPS.
@@ -7714,7 +7791,7 @@ SCPS-15052:
     vu1ClampMode: 0 # Fix other SPS.
 SCPS-15053:
   name: SIREN
-  name-sort: SIREN
+  name-sort: さいれん
   name-en: "Siren"
   region: "NTSC-J"
   compat: 5
@@ -7729,7 +7806,7 @@ SCPS-15054:
   region: "NTSC-J"
 SCPS-15055:
   name: グランツーリスモ4 “プロローグ”版
-  name-sort: ぐらんつーりすも4 “ぷろろーぐ”ばん
+  name-sort: ぐらんつーりすも4 ぷろろーぐばん
   name-en: "Gran Turismo 4 - Prologue"
   region: "NTSC-J"
   gsHWFixes:
@@ -7751,7 +7828,7 @@ SCPS-15055:
   # vuClampMode = 2  Text in GT mode works.
 SCPS-15056:
   name: ラチェット＆クランク2 ガガガ！銀河のコマンドーっす
-  name-sort: らちぇっと＆くらんく2 ががが！ぎんがのこまんどーっす
+  name-sort: らちぇっとあんどくらんく2 ががが!ぎんがのこまんどーっす
   name-en: "Ratchet & Clank 2"
   region: "NTSC-J"
   gameFixes:
@@ -7765,7 +7842,7 @@ SCPS-15056:
     - "SCPS-15037"
 SCPS-15057:
   name: ジャック×ダクスター2
-  name-sort: じゃっく×だくすたー2
+  name-sort: じゃっくだくすたー2
   name-en: "Jak and Daxter II"
   region: "NTSC-J"
   gsHWFixes:
@@ -7776,7 +7853,7 @@ SCPS-15057:
     autoFlush: 2 # Fixes lighting.
 SCPS-15058:
   name: Arc The Lad GENERATION
-  name-sort: Arc The Lad GENERATION
+  name-sort: あーくざらっど GENERATION
   name-en: "Arc the Lad - Generation"
   region: "NTSC-J"
   gsHWFixes:
@@ -7784,7 +7861,7 @@ SCPS-15058:
     trilinearFiltering: 1
 SCPS-15059:
   name: みんなのGOLF 4
-  name-sort: みんなのGOLF 4
+  name-sort: みんなのごるふ4
   name-en: "Minna no Golf 4"
   region: "NTSC-J"
   gsHWFixes:
@@ -7796,7 +7873,7 @@ SCPS-15060:
   name-en: "Koufuku Sousakan"
   region: "NTSC-J"
 SCPS-15061:
-  name: "EyeToy: Play(アイトーイ プレイ)"
+  name: "アイトーイ プレイ"
   name-sort: あいとーい ぷれい
   name-en: "EyeToy - Play [with Camera]"
   region: "NTSC-J"
@@ -7866,7 +7943,7 @@ SCPS-15065:
     - InstantDMAHack # Fixes texture corruption.
 SCPS-15066:
   name: プリンス・オブ・ペルシャ 〜時間の砂〜
-  name-sort: ぷりんす・おぶ・ぺるしゃ 〜じかんのすな〜
+  name-sort: ぷりんす おぶ ぺるしゃ じかんのすな
   name-en: "Prince of Persia - The Sands of Time"
   region: "NTSC-J"
   gsHWFixes:
@@ -7894,19 +7971,19 @@ SCPS-15070:
   region: "NTSC-J"
 SCPS-15071:
   name: みんなのGOLF オンライン“PlayStation BB Unit”パック〜オンラインはじめてパック〜
-  name-sort: みんなのGOLF おんらいん“PlayStation BB Unit”ぱっく〜おんらいんはじめてぱっく〜
+  name-sort: みんなのごるふおんらいん [“PlayStation BB Unit”ぱっく おんらいんはじめてぱっく]
   name-en: "Minna no Golf Online"
   region: "NTSC-J"
 SCPS-15072:
-  name: ガチャメカスタジアム サルバト～レ
-  name-sort: がちゃめかすたじあむ さるばと～れ
+  name: ガチャメカスタジアム サルバト〜レ
+  name-sort: がちゃめかすたじあむ さるばとーれ
   name-en: "Gacha Mecha Stadium - Saru Battle"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Corrects fullscreen bloom misalignment.
 SCPS-15073:
   name: アイトーイ フリフリダンス天国（EyeToyカメラ同梱版）
-  name-sort: あいとーい ふりふりだんすてんごく（EyeToyかめらどうこんばん）
+  name-sort: あいとーい ふりふりだんすてんごく あいとーいかめらどうこんばん
   name-en: "EyeToy - Groove [with Camera]"
   region: "NTSC-J"
 SCPS-15074:
@@ -7926,17 +8003,17 @@ SCPS-15076:
   region: "NTSC-J"
 SCPS-15077:
   name: サルアイトーイ 大騒ぎ！ウッキウキゲームてんこもりっ!! EyeToy USBカメラ同梱版
-  name-sort: さるあいとーい おおさわぎ！うっきうきげーむてんこもりっ!! EyeToy USBかめらどうこんばん
+  name-sort: さるあいとーい おおさわぎ!うっきうきげーむてんこもりっ!! あいとーいUSBかめらどうこんばん
   name-en: "EyeToy - Uki Uki Panic [with Camera]"
   region: "NTSC-J"
 SCPS-15078:
   name: サルアイトーイ 大騒ぎ！ウッキウキゲームてんこもりっ!!
-  name-sort: さるあいとーい おおさわぎ！うっきうきげーむてんこもりっ!!
+  name-sort: さるあいとーい おおさわぎ!うっきうきげーむてんこもりっ!!
   name-en: "EyeToy - Uki Uki Panic [Game Only]"
   region: "NTSC-J"
 SCPS-15079:
   name: 爆封スラッシュ! キズナ 嵐 EyeToyカメラ同梱版
-  name-sort: 爆封すらっしゅ! きずな あらし EyeToyかめらどうこんばん
+  name-sort: ばくふうすらっしゅ! きずな あらし あいとーいかめらどうこんばん
   name-en: "Bakufuu Slash! Kizna Arashi [EyeToy Camera Doukonban]"
   region: "NTSC-J"
 SCPS-15080:
@@ -7950,7 +8027,7 @@ SCPS-15081:
   name-en: "Dokodemo Issyo - Toro to Ippai"
   region: "NTSC-J"
 SCPS-15082:
-  name: DJbox
+  name: DJbox(ソフト単品)
   name-sort: DJbox
   name-en: "DJ Box"
   region: "NTSC-J"
@@ -7961,7 +8038,7 @@ SCPS-15083:
   region: "NTSC-J"
 SCPS-15084:
   name: ラチェット＆クランク3 突撃！ガラクチック★レンジャーズ
-  name-sort: らちぇっと＆くらんく3 とつげき！がらくちっく★れんじゃーず
+  name-sort: らちぇっとあんどくらんく3 とつげき!がらくちっくれんじゃーず
   name-en: "Ratchet & Clank 3"
   region: "NTSC-J"
   gameFixes:
@@ -7987,12 +8064,12 @@ SCPS-15085:
     roundSprite: 2 # Fix font gap and some texture.
 SCPS-15086:
   name: 爆封スラッシュ! キズナ 嵐
-  name-sort: 爆封すらっしゅ! きずな あらし
+  name-sort: ばくふうすらっしゅ! きずな あらし
   name-en: "Bakufuu Slash! Kizna Arashi [Game Only]"
   region: "NTSC-J"
 SCPS-15087:
   name: BLEACH 〜選ばれし魂〜
-  name-sort: BLEACH 〜えらばれしたましい〜
+  name-sort: ぶりーち えらばれしたましい
   name-en: "Bleach - Erabareshi Tamashii"
   region: "NTSC-J"
 SCPS-15088:
@@ -8003,20 +8080,20 @@ SCPS-15088:
   compat: 5
 SCPS-15089:
   name: アイトーイ プレイ2 [“PlayStation 2”専用 EyeToy USBカメラ同梱版]
-  name-sort: あいとーい ぷれい2 [“PlayStation 2”せんよう EyeToy USBかめらどうこんばん]
+  name-sort: あいとーい ぷれい2 PlayStation 2せんよう あいとーいUSBかめらどうこんばん
   name-en: "EyeToy - Play 2 [With Camera]"
   region: "NTSC-J"
 SCPS-15090:
   name: 怪盗スライ・クーパー2
-  name-sort: かいとうすらい・くーぱー2
+  name-sort: かいとうすらいくーぱー2
   name-en: "Kaitou Sly Cooper 2"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes chromatic effect.
 SCPS-15091:
-  name: WILD ARMS the 4th Detonator 初回生産版
-  name-sort: WILD ARMS the 4th Detonator しょかいせいさんばん
+  name: ワイルドアームズ ザ フォースデトネイター 初回生産版
+  name-sort: わいるどあーむず ざ ふぉーすでとねいたー [しょかいせいさんばん]
   name-en: "Wild ARMs - The 4th Detonator"
   region: "NTSC-J"
   gsHWFixes:
@@ -8036,8 +8113,8 @@ SCPS-15091:
     - "SCPS-19251"
     - "SCPS-19253"
 SCPS-15092:
-  name: WILD ARMS the 4th Detonator
-  name-sort: WILD ARMS the 4th Detonator
+  name: ワイルドアームズ ザ フォースデトネイター
+  name-sort: わいるどあーむず ざ ふぉーすでとねいたー
   name-en: "Wild ARMs - The 4th Detonator"
   region: "NTSC-J"
   gsHWFixes:
@@ -8057,7 +8134,7 @@ SCPS-15092:
     - "SCPS-19251"
     - "SCPS-19253"
 SCPS-15093:
-  name: RULE of ROSE (ルール オブ ローズ)
+  name: RULE of ROSE
   name-sort: るーる おぶ ろーず
   name-en: "Rule of Rose"
   region: "NTSC-J"
@@ -8090,7 +8167,7 @@ SCPS-15096:
     autoFlush: 2 # Fixes corruption in cutscenes and brightens the image.
 SCPS-15097:
   name: ワンダと巨像
-  name-sort: わんだと巨像
+  name-sort: わんだときょぞう
   name-en: "Wanda to Kyozou"
   region: "NTSC-J"
   compat: 5
@@ -8112,7 +8189,7 @@ SCPS-15098:
   region: "NTSC-J"
 SCPS-15099:
   name: ラチェット＆クランク4th ギリギリ銀河のギガバトル （Special Gift Package）
-  name-sort: らちぇっと＆くらんく4th ぎりぎりぎんがのぎがばとる （Special Gift Package）
+  name-sort: らちぇっとあんどくらんく4th ぎりぎりぎんがのぎがばとる [Special Gift Package]
   name-en: "Ratchet & Clank 4th - GiriGiri Ginga no Giga Battle"
   region: "NTSC-J"
   gameFixes:
@@ -8125,7 +8202,7 @@ SCPS-15099:
     autoFlush: 2 # Helps fix misaligned bloom.
 SCPS-15100:
   name: ラチェット＆クランク4th ギリギリ銀河のギガバトル
-  name-sort: らちぇっと＆くらんく4th ぎりぎりぎんがのぎがばとる
+  name-sort: らちぇっとあんどくらんく4th ぎりぎりぎんがのぎがばとる
   name-en: "Ratchet & Clank 4th - GiriGiri Ginga no Giga Battle"
   region: "NTSC-J"
   gameFixes:
@@ -8138,7 +8215,7 @@ SCPS-15100:
     autoFlush: 2 # Helps fix misaligned bloom.
 SCPS-15101:
   name: BLEACH 〜放たれし野望〜
-  name-sort: BLEACH 〜はなたれしやぼう〜
+  name-sort: ぶりーち はなたれしやぼう
   name-en: "Bleach - Hanatareshi Yabou"
   region: "NTSC-J"
 SCPS-15102:
@@ -8153,7 +8230,7 @@ SCPS-15102:
     disablePartialInvalidation: 1 # Prevents UI and subtitles from disappearing.
 SCPS-15103:
   name: ガンパレード・オーケストラ 白の章 〜青森ペンギン伝説〜（限定版）
-  name-sort: がんぱれーど・おーけすとら しろのしょう 〜あおもりぺんぎんでんせつ〜（げんていばん）
+  name-sort: がんぱれーど おーけすとら しろのしょう あおもりぺんぎんでんせつ [げんていばん]
   name-en: "Gunparade Orchestra - Shiro no Shou - Aomori Penguin Densetsu [Limited Edition]"
   region: "NTSC-J"
   gsHWFixes:
@@ -8163,7 +8240,7 @@ SCPS-15103:
     - "SCPS-15104"
 SCPS-15104:
   name: ガンパレード・オーケストラ 白の章 〜青森ペンギン伝説〜
-  name-sort: がんぱれーど・おーけすとら しろのしょう 〜あおもりぺんぎんでんせつ〜
+  name-sort: がんぱれーど おーけすとら しろのしょう あおもりぺんぎんでんせつ
   name-en: "Gunparade Orchestra - Shiro no Shou - Aomori Penguin Densetsu"
   region: "NTSC-J"
   gsHWFixes:
@@ -8173,7 +8250,7 @@ SCPS-15104:
     - "SCPS-15104"
 SCPS-15105:
   name: ツーリスト・トロフィー
-  name-sort: つーりすと・とろふぃー
+  name-sort: つーりすととろふぃー
   name-en: "Tourist Trophy - The Real Riding Simulator"
   region: "NTSC-J"
   clampModes:
@@ -8182,7 +8259,7 @@ SCPS-15105:
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 SCPS-15106:
   name: SIREN2
-  name-sort: SIREN2
+  name-sort: さいれん2
   name-en: "Siren 2"
   region: "NTSC-J"
   compat: 5
@@ -8199,7 +8276,7 @@ SCPS-15106:
         patch=0,EE,0013AB6C,word,4BC949FF
 SCPS-15107:
   name: ガンパレード・オーケストラ 緑の章 〜狼と彼の少年〜 限定版
-  name-sort: がんぱれーど・おーけすとら みどりのしょう 〜おおかみとかれのしょうねん〜 げんていばん
+  name-sort: がんぱれーど おーけすとら みどりのしょう おおかみとかのしょうねん [げんていばん]
   name-en: "Gunparade Orchestra - Midori no Shou [Limited Edition]"
   region: "NTSC-J"
   gsHWFixes:
@@ -8211,7 +8288,7 @@ SCPS-15107:
     - "SCPS-15108"
 SCPS-15108:
   name: ガンパレード・オーケストラ 緑の章 〜狼と彼の少年〜
-  name-sort: がんぱれーど・おーけすとら みどりのしょう 〜おおかみとかれのしょうねん〜
+  name-sort: がんぱれーど おーけすとら みどりのしょう おおかみとかのしょうねん
   name-en: "Gunparade Orchestra - Midori no Shou"
   region: "NTSC-J"
   gsHWFixes:
@@ -8223,7 +8300,7 @@ SCPS-15108:
     - "SCPS-15108"
 SCPS-15109:
   name: ガンパレード・オーケストラ 青の章 〜光の海から手紙を送ります〜 限定版
-  name-sort: がんぱれーど・おーけすとら あおのしょう 〜ひかりのうみからてがみをおくります〜 げんていばん
+  name-sort: がんぱれーど おーけすとら あおのしょう ひかりのうみからてがみをおくります [げんていばん]
   name-en: "Gunparade Orchestra - Ao no Shou [Limited Edition]"
   region: "NTSC-J"
   gsHWFixes:
@@ -8237,7 +8314,7 @@ SCPS-15109:
     - "SCPS-15110"
 SCPS-15110:
   name: ガンパレード・オーケストラ 青の章 〜光の海から手紙を送ります〜
-  name-sort: がんぱれーど・おーけすとら あおのしょう 〜ひかりのうみからてがみをおくります〜
+  name-sort: がんぱれーど おーけすとら あおのしょう ひかりのうみからてがみをおくります
   name-en: "Gunparade Orchestra - Ao no Shou"
   region: "NTSC-J"
   gsHWFixes:
@@ -8255,8 +8332,8 @@ SCPS-15111:
   name-en: "Brave Story - Wataru no Bouken"
   region: "NTSC-J"
 SCPS-15112:
-  name: BLOOD+ 〜双翼のバトル輪舞曲(ロンド)〜
-  name-sort: BLOOD+ 〜そうよくのばとるろんど〜
+  name: BLOOD+ 〜双翼のバトル輪舞曲〜
+  name-sort: BLOOD+ そうよくのばとるろんど
   name-en: "Blood+ - Souyoku no Battle Rondo"
   region: "NTSC-J"
   compat: 5
@@ -8282,7 +8359,7 @@ SCPS-15115:
   compat: 5
 SCPS-15116:
   name: BLEACH 〜ブレイド・バトラーズ〜
-  name-sort: BLEACH 〜ぶれいど・ばとらーず〜
+  name-sort: ぶりーち ぶれいど ばとらーず
   name-en: "Bleach - Blade Battlers"
   region: "NTSC-J"
   compat: 5
@@ -8292,7 +8369,7 @@ SCPS-15117:
   name-en: "Formula One 2006"
   region: "NTSC-J"
 SCPS-15118:
-  name: WILD ARMS the Vth Vanguard
+  name: ワイルドアームズ ザ フィフスヴァンガード(WILD ARMS the Vth Vanguard)
   name-sort: WILD ARMS the Vth Vanguard
   name-en: "Wild ARMs - The Vth Vanguard"
   region: "NTSC-J"
@@ -8302,7 +8379,7 @@ SCPS-15118:
     gpuPaletteConversion: 2 # Fixes micro-stuttering and drops in performance while also reducing hash cache explosions and GS usage.
 SCPS-15119:
   name: BLEACH 〜ブレイド・バトラーズ2nd〜
-  name-sort: BLEACH 〜ぶれいど・ばとらーず2nd〜
+  name-sort: ぶりーち ぶれいど ばとらーず2nd
   name-en: "Bleach - Blade Battlers 2nd"
   region: "NTSC-J"
   compat: 5
@@ -8312,7 +8389,7 @@ SCPS-15119:
     preloadFrameData: 1 # Fixes removed bloom.
 SCPS-15120:
   name: ラチェット＆クランク5 激突！ドデカ銀河のミリミリ軍団
-  name-sort: らちぇっと＆くらんく5 げきとつ！どでかぎんがのみりみりぐんだん
+  name-sort: らちぇっとあんどくらんく5 げきとつ！どでかぎんがのみりみりぐんだん
   name-en: "Ratchet & Clank 5 Gekitotsu! Dodeka Ginga no Mirimiri Gundan"
   region: "NTSC-J"
   gsHWFixes:
@@ -8346,9 +8423,9 @@ SCPS-17001:
     - "SCPS-15009"
     - "SCPS-55007"
 SCPS-17002:
-  name: "WILD ARMS Alter code:F"
-  name-sort: "WILD ARMS Alter code:F"
-  name-en: "Wild ARMs - Alter Code F"
+  name: "ワイルドアームズ アルターコード:F"
+  name-sort: "わいるどあーむず あるたーこーど:F"
+  name-en: "Wild ARMs - Alter Code:F"
   region: "NTSC-J"
   gsHWFixes:
     wildArmsHack: 1 # Fixes font artifacts and out-of-bound 2D textures.
@@ -8390,29 +8467,29 @@ SCPS-17013:
         // Fixes Vedan Myna out of bounds glitch.
         patch=1,EE,00124898,word,3442fffe
 SCPS-17501:
-  name: "Linux for PlayStation 2 - Release 1.0 (Disc 1) (Runtime Environment)"
+  name: "Linux (for PlayStation 2) - Release 1.0 (Disc 1) (Runtime Environment)"
   region: "NTSC-J"
 SCPS-17502:
-  name: "Linux for PlayStation 2 - Release 1.0 (Disc 2) (Software Packages)"
+  name: "Linux (for PlayStation 2) - Release 1.0 (Disc 2) (Software Packages)"
   region: "NTSC-J"
 SCPS-19101:
-  name: 蚊 PS2 the Best
-  name-sort: か PS2 the Best
-  name-en: "Mosquito [PS2 The Best]"
+  name: 蚊 PlayStation 2 the Best
+  name-sort: か PlayStation 2 the Best
+  name-en: "Mosquito [PlayStation 2 the Best]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
 SCPS-19102:
-  name: ボクと魔王 PS2 the Best
-  name-sort: ぼくとまおう PS2 the Best
-  name-en: "Boku to Maou [PS2 The Best]"
+  name: ボクと魔王 PlayStation 2 the Best
+  name-sort: ぼくとまおう PlayStation 2 the Best
+  name-en: "Boku to Maou [PlayStation 2 the Best]"
   region: "NTSC-J"
   gsHWFixes:
     autoFlush: 1 # Depth of field blur is incorrect without it.
 SCPS-19103:
-  name: ICO PS2 the Best
-  name-sort: ICO PS2 the Best
-  name-en: "ICO [PS2 The Best]"
+  name: ICO PlayStation 2 the Best
+  name-sort: いこ [PlayStation 2 the Best]
+  name-en: "ICO [PlayStation 2 the Best]"
   region: "NTSC-J"
   compat: 5
   clampModes:
@@ -8423,19 +8500,19 @@ SCPS-19103:
     halfPixelOffset: 1 # Fixes effect misalignment.
     moveHandler: "MV_Ico" # Fixes depth buffer post-processing.
 SCPS-19104:
-  name: ピポサル2001 PS2 the Best
-  name-sort: ぴぽさる2001 PS2 the Best
-  name-en: "Pipo Saru 2001 [PS2 The Best]"
+  name: ピポサル2001 PlayStation 2 the Best
+  name-sort: ぴぽさる2001 PlayStation 2 the Best
+  name-en: "Pipo Saru 2001 [PlayStation 2 the Best]"
   region: "NTSC-J"
 SCPS-19105:
-  name: ブラボーミュージック PS2 the Best
-  name-sort: ぶらぼーみゅーじっく PS2 the Best
-  name-en: "Bravo Music [PS2 The Best]"
+  name: ブラボーミュージック PlayStation 2 the Best
+  name-sort: ぶらぼーみゅーじっく PlayStation 2 the Best
+  name-en: "Bravo Music [PlayStation 2 the Best]"
   region: "NTSC-J"
 SCPS-19151:
-  name: ICO PS2 the Best
-  name-sort: ICO PS2 the Best
-  name-en: "ICO [PS2 The Best]"
+  name: ICO PlayStation 2 the Best
+  name-sort: ICO PlayStation 2 the Best
+  name-en: "ICO [PlayStation 2 the Best]"
   region: "NTSC-J"
   compat: 5
   clampModes:
@@ -8446,7 +8523,7 @@ SCPS-19151:
     halfPixelOffset: 1 # Fixes effect misalignment.
     moveHandler: "MV_Ico" # Fixes depth buffer post-processing.
 SCPS-19152:
-  name: "Saru Get You! 2 [PS2 The Best]"
+  name: "Saru Get You! 2 [PlayStation 2 the Best]"
   region: "NTSC-J"
   gameFixes:
     - SoftwareRendererFMVHack # Fixes interlacing.
@@ -8454,14 +8531,14 @@ SCPS-19152:
     mipmap: 2 # Fixes miptrick texture effects.
     trilinearFiltering: 1 # Fixes miptrick blending.
 SCPS-19153:
-  name: ピポサル2001 PS2 the Best
-  name-sort: ぴぽさる2001 PS2 the Best
-  name-en: "Pipo Saru 2001 [PS2 The Best]"
+  name: ピポサル2001 PlayStation 2 the Best
+  name-sort: ぴぽさる2001 PlayStation 2 the Best
+  name-en: "Pipo Saru 2001 [PlayStation 2 the Best]"
   region: "NTSC-J"
 SCPS-19201:
-  name: パラッパラッパー2 PS2 the Best
-  name-sort: ぱらっぱらっぱー2 PS2 the Best
-  name-en: "PaRappa the Rapper 2 [PS2 The Best]"
+  name: パラッパラッパー2 PlayStation 2 the Best
+  name-sort: ぱらっぱらっぱー2 PlayStation 2 the Best
+  name-en: "PaRappa the Rapper 2 [PlayStation 2 the Best]"
   region: "NTSC-J"
   speedHacks:
     instantVU1: 0 # Fixes noodles.
@@ -8471,38 +8548,38 @@ SCPS-19201:
     trilinearFiltering: 1 # Fixes fog effect.
     wildArmsHack: 1 # Fixes misaligment depth of field effect.
 SCPS-19202:
-  name: EXTERMINATION PS2 the Best
-  name-sort: EXTERMINATION PS2 the Best
-  name-en: "Extermination [PS2 The Best]"
+  name: EXTERMINATION PlayStation 2 the Best
+  name-sort: EXTERMINATION PlayStation 2 the Best
+  name-en: "Extermination [PlayStation 2 the Best]"
   region: "NTSC-J"
   gameFixes:
     - SoftwareRendererFMVHack # Black FMV.
 SCPS-19203:
-  name: ダーククラウド PS2 the Best
-  name-sort: だーくくらうど PS2 the Best
-  name-en: "Dark Cloud [PS2 The Best]"
+  name: ダーククラウド PlayStation 2 the Best
+  name-sort: だーくくらうど PlayStation 2 the Best
+  name-en: "Dark Cloud [PlayStation 2 the Best]"
   region: "NTSC-J"
   gsHWFixes:
     mipmap: 2 # Fixes mipmapping.
     trilinearFiltering: 1 # Smoothes out mipmapping.
     halfPixelOffset: 2 # Distance is less blurry, game has reduced LOD so it will still look blurry.
 SCPS-19204:
-  name: レガイア デュエルサーガ PS2 the Best
-  name-sort: れがいあ でゅえるさーが PS2 the Best
-  name-en: "Legaia - Duel Saga [PS2 The Best]"
+  name: レガイア デュエルサーガ PlayStation 2 the Best
+  name-sort: れがいあ でゅえるさーが PlayStation 2 the Best
+  name-en: "Legaia - Duel Saga [PlayStation 2 the Best]"
   region: "NTSC-J"
 SCPS-19205:
-  name: WILD ARMS Advanced 3rd PS2 the Best
-  name-sort: WILD ARMS Advanced 3rd PS2 the Best
-  name-en: "Wild ARMs - Advanced 3rd [PS2 The Best]"
+  name: ワイルドアームズ アドヴァンスドサード PlayStation 2 the Best
+  name-sort: わいるどあーむず あどゔぁんすどさーど PlayStation 2 the Best
+  name-en: "Wild ARMs - Advanced 3rd [PlayStation 2 the Best]"
   region: "NTSC-J"
   gsHWFixes:
     wildArmsHack: 1 # Fixes font artifacts and out-of-bound 2D textures.
     gpuPaletteConversion: 2 # Fixes micro-stuttering and drops in performance while also reducing hash cache explosions and GS usage.
 SCPS-19206:
-  name: サルゲッチュ2 PS2 the Best
-  name-sort: さるげっちゅ2 PS2 the Best
-  name-en: "Ape Escape 2 [PS2 The Best]"
+  name: サルゲッチュ2 PlayStation 2 the Best
+  name-sort: さるげっちゅ2 PlayStation 2 the Best
+  name-en: "Ape Escape 2 [PlayStation 2 the Best]"
   region: "NTSC-J"
   gameFixes:
     - SoftwareRendererFMVHack # Fixes interlacing.
@@ -8510,24 +8587,24 @@ SCPS-19206:
     mipmap: 2 # Fixes miptrick texture effects.
     trilinearFiltering: 1 # Fixes miptrick blending.
 SCPS-19207:
-  name: ポポロクロイス〜はじまりの冒険〜 PS2 the Best
-  name-sort: ぽぽろくろいす〜はじまりのぼうけん〜 PS2 the Best
-  name-en: "Popolocrois Story - Hajime no Bouken [PS2 The Best]"
+  name: ポポロクロイス〜はじまりの冒険〜 PlayStation 2 the Best
+  name-sort: ぽぽろくろいす はじまりのぼうけん PlayStation 2 the Best
+  name-en: "Popolocrois - Hajimari no Bouken [PlayStation 2 the Best]"
   region: "NTSC-J"
 SCPS-19208:
-  name: グランツーリスモ Concept2001 TOKYO PS2 the Best
-  name-sort: ぐらんつーりすも Concept2001 TOKYO PS2 the Best
-  name-en: "Gran Turismo - Concept 2001 Tokyo [PS2 The Best]"
+  name: グランツーリスモ Concept2001 TOKYO PlayStation 2 the Best
+  name-sort: ぐらんつーりすも Concept2001 TOKYO PlayStation 2 the Best
+  name-en: "Gran Turismo - Concept 2001 Tokyo [PlayStation 2 the Best]"
   region: "NTSC-J"
 SCPS-19209:
-  name: ぼくのなつやすみ2 海の冒険篇 PlayStation® 2 the Best
-  name-sort: ぼくのなつやすみ2 うみのぼうけんへん PlayStation® 2 the Best
-  name-en: "Boku no Summer Vacation [PS2 The Best]"
+  name: ぼくのなつやすみ2 海の冒険篇 PlayStation 2 the Best
+  name-sort: ぼくのなつやすみ2 うみのぼうけんへん PlayStation 2 the Best
+  name-en: "Boku no Summer Vacation 2 [PlayStation 2 the Best]"
   region: "NTSC-J"
 SCPS-19210:
-  name: ジャック×ダクスター PS2 the Best
-  name-sort: じゃっく×だくすたー PS2 the Best
-  name-en: "Jak x Daxter - Kyuusekai no Isan [PS2 The Best]"
+  name: ジャック×ダクスター PlayStation 2 the Best
+  name-sort: じゃっくだくすたー PlayStation 2 the Best
+  name-en: "Jak x Daxter - Kyuusekai no Isan [PlayStation 2 the Best]"
   region: "NTSC-J"
   gsHWFixes:
     mipmap: 2 # Fixes broken textures.
@@ -8535,9 +8612,9 @@ SCPS-19210:
     cpuSpriteRenderBW: 4 # Fixes character and water textures.
     cpuSpriteRenderLevel: 2 # Needed for above.
 SCPS-19211:
-  name: ラチェット＆クランク PS2 the Best
-  name-sort: らちぇっと＆くらんく PS2 the Best
-  name-en: "Ratchet & Clank [PS2 The Best]"
+  name: ラチェット＆クランク PlayStation 2 the Best
+  name-sort: らちぇっとあんどくらんく PlayStation 2 the Best
+  name-en: "Ratchet & Clank [PlayStation 2 the Best]"
   region: "NTSC-J"
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
@@ -8545,23 +8622,23 @@ SCPS-19211:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
 SCPS-19213:
-  name: OPERATOR’S SIDE マイク同梱版 PS2 the Best
-  name-sort: OPERATOR’S SIDE まいくどうこんばん PS2 the Best
-  name-en: "Operator's Side [PS2 The Best] [with Microphone]"
+  name: OPERATOR’S SIDE マイク同梱版 PlayStation 2 the Best
+  name-sort: おぺれーたーずさいど [まいくどうこんばん] PlayStation 2 the Best
+  name-en: "Operator's Side [PlayStation 2 the Best] [with Microphone]"
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
 SCPS-19214:
-  name: OPERATOR’S SIDE PS2 the Best
-  name-sort: OPERATOR’S SIDE PS2 the Best
-  name-en: "Operator's Side [PS2 The Best]"
+  name: OPERATOR’S SIDE PlayStation 2 the Best
+  name-sort: おぺれーたーずさいど PlayStation 2 the Best
+  name-en: "Operator's Side [PlayStation 2 the Best]"
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
 SCPS-19215:
-  name: ダーククロニクル PS2 the Best
-  name-sort: だーくくろにくる PS2 the Best
-  name-en: "Dark Chronicle [PS2 The Best]"
+  name: ダーククロニクル PlayStation 2 the Best
+  name-sort: だーくくろにくる PlayStation 2 the Best
+  name-en: "Dark Chronicle [PlayStation 2 the Best]"
   region: "NTSC-J"
   clampModes:
     eeClampMode: 3 # Fixes textbox.
@@ -8570,16 +8647,16 @@ SCPS-19215:
     cpuSpriteRenderBW: 2 # Fixes lines in geometry.
     cpuSpriteRenderLevel: 2 # Needed for above.
 SCPS-19251:
-  name: "WILD ARMS Alter code:F [PS2 the Best]"
-  name-sort: "WILD ARMS Alter code:F [PS2 the Best]"
-  name-en: "Wild ARMs - Alter Code F [PS2 The Best]"
+  name: "ワイルドアームズ アルターコード:F PlayStation 2 the Best"
+  name-sort: "わいるどあーむず あるたーこーど:F [PlayStation 2 the Best]"
+  name-en: "Wild ARMs - Alter Code:F [PlayStation 2 the Best]"
   region: "NTSC-J"
   gsHWFixes:
     wildArmsHack: 1 # Fixes font artifacts and out-of-bound 2D textures.
 SCPS-19252:
-  name: グランツーリスモ4 PS2 the Best
-  name-sort: ぐらんつーりすも4 PS2 the Best
-  name-en: "Gran Turismo 4 [PS2 The Best]"
+  name: グランツーリスモ4 PlayStation 2 the Best
+  name-sort: ぐらんつーりすも4 PlayStation 2 the Best
+  name-en: "Gran Turismo 4 [PlayStation 2 the Best]"
   region: "NTSC-J"
   clampModes:
     vuClampMode: 2 # Text in GT mode works.
@@ -8600,14 +8677,14 @@ SCPS-19252:
     - "SCPS-15009"
     - "SCPS-55007"
 SCPS-19253:
-  name: "WILD ARMS Alter code:F [PS2 the Best]"
-  name-sort: "WILD ARMS Alter code:F [PS2 the Best]"
-  name-en: "Wild ARMs - Alter Code F [PS2 The Best - Reprint]"
+  name: "ワイルドアームズ アルターコード:F PlayStation 2 the Best"
+  name-sort: わいるどあーむず あるたーこーど:F PlayStation 2 the Best
+  name-en: "Wild ARMs - Alter Code F [PlayStation 2 the Best - Reprint]"
   region: "NTSC-J"
   gsHWFixes:
     wildArmsHack: 1 # Fixes font artifacts and out-of-bound 2D textures.
 SCPS-19254:
-  name: "Rogue Galaxy [PS2 The Best]"
+  name: "Rogue Galaxy [PlayStation 2 the Best]"
   region: "NTSC-J"
   gsHWFixes:
     autoFlush: 2 # Fix glow effects from lamps.
@@ -8615,17 +8692,17 @@ SCPS-19254:
     preloadFrameData: 1 # Fixes corrupt textures especially on water.
     disablePartialInvalidation: 1 # Prevents UI and subtitles from disappearing.
 SCPS-19301:
-  name: みんなのGOLF 4 PS2 the Best
-  name-sort: みんなのGOLF 4 PS2 the Best
-  name-en: "Minna no Golf 4 [PS2 The Best]"
+  name: みんなのGOLF 4 PlayStation 2 the Best
+  name-sort: みんなのごるふ4 PlayStation 2 the Best
+  name-en: "Minna no Golf 4 [PlayStation 2 the Best]"
   region: "NTSC-J"
   gsHWFixes:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
 SCPS-19302:
-  name: ラチェット＆クランク2 ガガガ！銀河のコマンドーっす PS2 the Best
-  name-sort: らちぇっと＆くらんく2 ががが！ぎんがのこまんどーっす PS2 the Best
-  name-en: "Ratchet & Clank 2 [PS2 The Best]"
+  name: ラチェット＆クランク2 ガガガ！銀河のコマンドーっす PlayStation 2 the Best
+  name-sort: らちぇっとあんどくらんく2 ががが！ぎんがのこまんどーっす PlayStation 2 the Best
+  name-en: "Ratchet & Clank 2 [PlayStation 2 the Best]"
   region: "NTSC-J"
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
@@ -8634,16 +8711,16 @@ SCPS-19302:
     trilinearFiltering: 1
     autoFlush: 2
 SCPS-19303:
-  name: ぼくのなつやすみ2 海の冒険篇 PS2 the Best
-  name-sort: ぼくのなつやすみ2 うみのぼうけんへん PS2 the Best
-  name-en: "Boku no Natsuyasumi 2 [PS2 The Best]"
+  name: ぼくのなつやすみ2 海の冒険篇 PlayStation 2 the Best
+  name-sort: ぼくのなつやすみ2 うみのぼうけんへん PlayStation 2 the Best
+  name-en: "Boku no Natsuyasumi 2 [PlayStation 2 the Best]"
   region: "NTSC-J"
   gsHWFixes:
     roundSprite: 1 # Fixes menu text.
 SCPS-19304:
-  name: グランツーリスモ 4 “プロローグ版” PS2 the Best
-  name-sort: ぐらんつーりすも 4 “ぷろろーぐばん” PS2 the Best
-  name-en: "Gran Turismo 4 - Prologue [PS2 The Best]"
+  name: グランツーリスモ4 “プロローグ版” PlayStation 2 the Best
+  name-sort: ぐらんつーりすも4 ぷろろーぐばん PlayStation 2 the Best
+  name-en: "Gran Turismo 4 - Prologue [PlayStation 2 the Best]"
   region: "NTSC-J"
   gsHWFixes:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
@@ -8663,18 +8740,18 @@ SCPS-19304:
     - "SCPS-55007"
   # vuClampMode = 2  Text in GT mode works.
 SCPS-19305:
-  name: SIREN PS2 the Best
-  name-sort: SIREN PS2 the Best
-  name-en: "Siren [PS2 The Best]"
+  name: SIREN PlayStation 2 the Best
+  name-sort: さいれん PlayStation 2 the Best
+  name-en: "Siren [PlayStation 2 the Best]"
   region: "NTSC-J"
   gsHWFixes:
     roundSprite: 1 # Fixes gaps between menu options.
     cpuSpriteRenderBW: 4 # Fixes sky rendering.
     cpuSpriteRenderLevel: 2 # Needed for above.
 SCPS-19306:
-  name: ダーククロニクル PS2 the Best
-  name-sort: だーくくろにくる PS2 the Best
-  name-en: "Dark Chronicle [PS2 The Best]"
+  name: ダーククロニクル PlayStation 2 the Best
+  name-sort: だーくくろにくる PlayStation 2 the Best
+  name-en: "Dark Chronicle [PlayStation 2 the Best]"
   region: "NTSC-J"
   clampModes:
     eeClampMode: 3 # Fixes textbox.
@@ -8683,14 +8760,14 @@ SCPS-19306:
     cpuSpriteRenderBW: 2 # Fixes lines in geometry.
     cpuSpriteRenderLevel: 2 # Needed for above.
 SCPS-19307:
-  name: ポポロクロイス〜はじまりの冒険〜 PS2 the Best
-  name-sort: ぽぽろくろいす〜はじまりのぼうけん〜 PS2 the Best
-  name-en: "Popolocrois - The First Adventure [PS2 The Best]"
+  name: ポポロクロイス〜はじまりの冒険〜 PlayStation 2 the Best
+  name-sort: ぽぽろくろいす はじまりのぼうけん PlayStation 2 the Best
+  name-en: "Popolocrois - The First Adventure [PlayStation 2 the Best]"
   region: "NTSC-J"
 SCPS-19308:
-  name: サルゲッチュ2 PS2 the Best
-  name-sort: さるげっちゅ2 PS2 the Best
-  name-en: "Saru Get You 2 [PS2 The Best]"
+  name: サルゲッチュ2 PlayStation 2 the Best
+  name-sort: さるげっちゅ2 PlayStation 2 the Best
+  name-en: "Saru Get You 2 [PlayStation 2 the Best]"
   region: "NTSC-J"
   gameFixes:
     - SoftwareRendererFMVHack # Fixes interlacing.
@@ -8698,9 +8775,9 @@ SCPS-19308:
     mipmap: 2 # Fixes miptrick texture effects.
     trilinearFiltering: 1 # Fixes miptrick blending.
 SCPS-19309:
-  name: ラチェット＆クランク3 突撃！ガラクチック★レンジャーズ PS2 the Best
-  name-sort: らちぇっと＆くらんく3 とつげき！がらくちっく★れんじゃーず PS2 the Best
-  name-en: "Ratchet & Clank 3 - Up Your Arsenal [PS2 The Best]"
+  name: ラチェット＆クランク3 突撃！ガラクチック★レンジャーズ PlayStation 2 the Best
+  name-sort: らちぇっとあんどくらんく3 とつげき!がらくちっくれんじゃーず PlayStation 2 the Best
+  name-en: "Ratchet & Clank 3 - Up Your Arsenal [PlayStation 2 the Best]"
   region: "NTSC-J"
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
@@ -8711,9 +8788,9 @@ SCPS-19309:
     halfPixelOffset: 2 # Fixes misaligned bloom.
     autoFlush: 2 # Helps fix misaligned bloom.
 SCPS-19310:
-  name: ラチェット＆クランク PS2 the Best
-  name-sort: らちぇっと＆くらんく PS2 the Best
-  name-en: "Ratchet & Clank [PS2 The Best]"
+  name: ラチェット＆クランク PlayStation 2 the Best
+  name-sort: らちぇっとあんどくらんく PlayStation 2 the Best
+  name-en: "Ratchet & Clank [PlayStation 2 the Best]"
   region: "NTSC-J"
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
@@ -8721,9 +8798,9 @@ SCPS-19310:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
 SCPS-19311:
-  name: サルゲッチュ3 PS2 the Best
-  name-sort: さるげっちゅ3 PS2 the Best
-  name-en: "Saru Get You 3 [PS2 The Best]"
+  name: サルゲッチュ3 PlayStation 2 the Best
+  name-sort: さるげっちゅ3 PlayStation 2 the Best
+  name-en: "Saru Get You 3 [PlayStation 2 the Best]"
   region: "NTSC-J"
   gameFixes:
     - SoftwareRendererFMVHack # Fixes interlacing.
@@ -8734,18 +8811,18 @@ SCPS-19311:
     halfPixelOffset: 2 # Fixes misaligned blur.
     autoFlush: 2 # Fixes corruption in cutscenes and brightens the image.
 SCPS-19312:
-  name: SIREN PS2 the Best
-  name-sort: SIREN PS2 the Best
-  name-en: "Siren [PS2 The Best]"
+  name: SIREN PlayStation 2 the Best
+  name-sort: さいれん PlayStation 2 the Best
+  name-en: "Siren [PlayStation 2 the Best]"
   region: "NTSC-J"
   gsHWFixes:
     roundSprite: 1 # Fixes gaps between menu options.
     cpuSpriteRenderBW: 4 # Fixes sky rendering.
     cpuSpriteRenderLevel: 2 # Needed for above.
 SCPS-19313:
-  name: WILD ARMS the 4th Detonator PS2 the Best
-  name-sort: WILD ARMS the 4th Detonator PS2 the Best
-  name-en: "Wild ARMs - The 4th Detonator [PS2 The Best]"
+  name: ワイルドアームズ ザ フォースデトネイター PlayStation 2 the Best
+  name-sort: わいるどあーむず ざ ふぉーすでとねいたー PlayStation 2 the Best
+  name-en: "Wild ARMs - The 4th Detonator [PlayStation 2 the Best]"
   region: "NTSC-J"
   gsHWFixes:
     textureInsideRT: 1
@@ -8764,12 +8841,12 @@ SCPS-19313:
     - "SCPS-19251"
     - "SCPS-19253"
 SCPS-19315:
-  name: "EyeToy - Play [PS2 The Best]"
+  name: "EyeToy - Play [PlayStation 2 the Best]"
   region: "NTSC-J"
 SCPS-19316:
-  name: ラチェット＆クランク PS2 the Best
-  name-sort: らちぇっと＆くらんく PS2 the Best
-  name-en: "Ratchet & Clank [PS2 The Best]"
+  name: ラチェット＆クランク PlayStation 2 the Best
+  name-sort: らちぇっとあんどくらんく PlayStation 2 the Best
+  name-en: "Ratchet & Clank [PlayStation 2 the Best]"
   region: "NTSC-J"
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
@@ -8777,9 +8854,9 @@ SCPS-19316:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
 SCPS-19317:
-  name: ラチェット＆クランク2 ガガガ！銀河のコマンドーっす PS2 the Best
-  name-sort: らちぇっと＆くらんく2 ががが！ぎんがのこまんどーっす PS2 the Best
-  name-en: "Ratchet & Clank 2 - Going Commando [PS2 The Best]"
+  name: ラチェット＆クランク2 ガガガ！銀河のコマンドーっす PlayStation 2 the Best
+  name-sort: らちぇっとあんどくらんく2 ががが！ぎんがのこまんどーっす PlayStation 2 the Best
+  name-en: "Ratchet & Clank 2 - Going Commando [PlayStation 2 the Best]"
   region: "NTSC-J"
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
@@ -8794,22 +8871,22 @@ SCPS-19317:
     - "SCPS-19310"
     - "SCPS-19316"
 SCPS-19318:
-  name: GENJI PS2 the Best
-  name-sort: GENJI PS2 the Best
-  name-en: "Genji - Dawn of the Samurai [PS2 The Best]"
+  name: GENJI PlayStation 2 the Best
+  name-sort: GENJI PlayStation 2 the Best
+  name-en: "Genji - Dawn of the Samurai [PlayStation 2 the Best]"
   region: "NTSC-J"
 SCPS-19319:
-  name: みんなのGOLF 4 PS2 the Best
-  name-sort: みんなのGOLF 4 PS2 the Best
-  name-en: "Minna no Golf 4 [PS2 The Best]"
+  name: みんなのGOLF 4 PlayStation 2 the Best
+  name-sort: みんなのごるふ4 PlayStation 2 the Best
+  name-en: "Minna no Golf 4 [PlayStation 2 the Best]"
   region: "NTSC-J"
   gsHWFixes:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
 SCPS-19320:
-  name: ワンダと巨像 PS2 the Best
-  name-sort: わんだと巨像 PS2 the Best
-  name-en: "Wanda to Kyozou [PS2 The Best]"
+  name: ワンダと巨像 PlayStation 2 the Best
+  name-sort: わんだときょぞう PlayStation 2 the Best
+  name-en: "Wanda to Kyozou [PlayStation 2 the Best]"
   region: "NTSC-J"
   gsHWFixes:
     mipmap: 1
@@ -8823,9 +8900,9 @@ SCPS-19320:
     - "SCPS-19151"
     - "SCPS-55001"
 SCPS-19321:
-  name: ラチェット＆クランク4th ギリギリ銀河のギガバトル PS2 the Best
-  name-sort: らちぇっと＆くらんく4th ぎりぎりぎんがのぎがばとる PS2 the Best
-  name-en: "Ratchet & Clank 4th - GiriGiri Ginga no Giga Battle [PS2 The Best]"
+  name: ラチェット＆クランク4th ギリギリ銀河のギガバトル PlayStation 2 the Best
+  name-sort: らちぇっとあんどくらんく4th ぎりぎりぎんがのぎがばとる PlayStation 2 the Best
+  name-en: "Ratchet & Clank 4th - GiriGiri Ginga no Giga Battle [PlayStation 2 the Best]"
   region: "NTSC-J"
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
@@ -8836,9 +8913,9 @@ SCPS-19321:
     halfPixelOffset: 2 # Fixes misaligned bloom.
     autoFlush: 2 # Helps fix misaligned bloom.
 SCPS-19322:
-  name: WILD ARMS the 4th Detonator PS2 the Best
-  name-sort: WILD ARMS the 4th Detonator PS2 the Best
-  name-en: "Wild ARMs - The 4th Detonator [PS2 The Best - Reprint]"
+  name: ワイルドアームズ ザ フォースデトネイター PlayStation 2 the Best
+  name-sort: わいるどあーむず ざ ふぉーすでとねいたー PlayStation 2 the Best
+  name-en: "Wild ARMs - The 4th Detonator [PlayStation 2 the Best - Reprint]"
   region: "NTSC-J"
   gsHWFixes:
     textureInsideRT: 1
@@ -8857,9 +8934,9 @@ SCPS-19322:
     - "SCPS-19251"
     - "SCPS-19253"
 SCPS-19323:
-  name: WILD ARMS Advanced 3rd PS2 the Best
-  name-sort: WILD ARMS Advanced 3rd PS2 the Best
-  name-en: "Wild ARMs - The 4th Detonator [PS2 The Best - Reprint]"
+  name: ワイルドアームズ アドヴァンスドサード PlayStation 2 the Best
+  name-sort: わいるどあーむず あどゔぁんすどさーど PlayStation 2 the Best
+  name-en: "Wild ARMs - The 4th Detonator [PlayStation 2 the Best - Reprint]"
   region: "NTSC-J"
   gsHWFixes:
     textureInsideRT: 1
@@ -8878,23 +8955,23 @@ SCPS-19323:
     - "SCPS-19251"
     - "SCPS-19253"
 SCPS-19324:
-  name: ツーリスト・トロフィー PS2 the Best
-  name-sort: つーりすと・とろふぃー PS2 the Best
-  name-en: "Tourist Trophy - The Real Riding Simulator [PS2 The Best]"
+  name: ツーリスト・トロフィー PlayStation 2 the Best
+  name-sort: つーりすととろふぃー PlayStation 2 the Best
+  name-en: "Tourist Trophy - The Real Riding Simulator [PlayStation 2 the Best]"
   region: "NTSC-J"
   clampModes:
     vuClampMode: 2 # Fixes SPS in TT Mode menu caused by the moving tooltips.
   gsHWFixes:
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 SCPS-19325:
-  name: サルゲッチュ ミリオンモンキーズ PS2 the Best
-  name-sort: さるげっちゅ みりおんもんきーず PS2 the Best
-  name-en: "Ape Escape - Million Monkeys [PS2 The Best]"
+  name: サルゲッチュ ミリオンモンキーズ PlayStation 2 the Best
+  name-sort: さるげっちゅ みりおんもんきーず PlayStation 2 the Best
+  name-en: "Ape Escape - Million Monkeys [PlayStation 2 the Best]"
   region: "NTSC-J"
 SCPS-19326:
-  name: SIREN2 PS2 the Best
-  name-sort: SIREN2 PS2 the Best
-  name-en: "Siren 2 [PS2 The Best]"
+  name: SIREN2 PlayStation 2 the Best
+  name-sort: さいれん2 PlayStation 2 the Best
+  name-en: "Siren 2 [PlayStation 2 the Best]"
   region: "NTSC-J"
   gameFixes:
     - XGKickHack # Fixes SPS.
@@ -8902,9 +8979,9 @@ SCPS-19326:
     mergeSprite: 1 # Fixes vertical lines in-game.
     preloadFrameData: 1 # Fixes some missing effects.
 SCPS-19327:
-  name: サルゲッチュ3 PS2 the Best
-  name-sort: さるげっちゅ3 PS2 the Best
-  name-en: "Ape Escape 3 [PS2 the Best - Reprint]"
+  name: サルゲッチュ3 PlayStation 2 the Best
+  name-sort: さるげっちゅ3 PlayStation 2 the Best
+  name-en: "Ape Escape 3 [PlayStation 2 the Best - Reprint]"
   region: "NTSC-J"
   gameFixes:
     - SoftwareRendererFMVHack # Fixes interlacing.
@@ -8915,9 +8992,9 @@ SCPS-19327:
     halfPixelOffset: 2 # Fixes misaligned blur.
     autoFlush: 2 # Fixes corruption in cutscenes and brightens the image.
 SCPS-19328:
-  name: ラチェット＆クランク4th ギリギリ銀河のギガバトル PS2 the Best
-  name-sort: らちぇっと＆くらんく4th ぎりぎりぎんがのぎがばとる PS2 the Best
-  name-en: "Ratchet & Clank 4th - GiriGiri Ginga no Giga Battle [PS2 the Best - Reprint]"
+  name: ラチェット＆クランク4th ギリギリ銀河のギガバトル PlayStation 2 the Best
+  name-sort: らちぇっとあんどくらんく4th ぎりぎりぎんがのぎがばとる PlayStation 2 the Best
+  name-en: "Ratchet & Clank 4th - GiriGiri Ginga no Giga Battle [PlayStation 2 the Best - Reprint]"
   region: "NTSC-J"
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
@@ -8928,36 +9005,38 @@ SCPS-19328:
     halfPixelOffset: 2 # Fixes misaligned bloom.
     autoFlush: 2 # Helps fix misaligned bloom.
 SCPS-19329:
-  name: BLEACH 〜ブレイド・バトラーズ〜 PS2 the Best
-  name-sort: BLEACH 〜ぶれいど・ばとらーず〜 PS2 the Best
-  name-en: "Bleach - Blade Battlers [PS2 The Best]"
+  name: BLEACH 〜ブレイド・バトラーズ〜 PlayStation 2 the Best
+  name-sort: ぶりーち ぶれいど ばとらーず PlayStation 2 the Best
+  name-en: "Bleach - Blade Battlers [PlayStation 2 the Best]"
   region: "NTSC-J"
   gameFixes:
     - OPHFlagHack # Special moves "Bankai" hang otherwise.
   gsHWFixes:
     preloadFrameData: 1 # Fixes removed bloom.
 SCPS-19330:
-  name: BLEACH 〜放たれし野望〜 PS2 the Best
-  name-sort: BLEACH 〜はなたれしやぼう〜 PS2 the Best
-  name-en: "Bleach - Hanatareshi Yabou [PS2 The Best]"
+  name: BLEACH 〜放たれし野望〜 PlayStation 2 the Best
+  name-sort: ぶりーち はなたれしやぼう PlayStation 2 the Best
+  name-en: "Bleach - Hanatareshi Yabou [PlayStation 2 the Best]"
   region: "NTSC-J"
 SCPS-19331:
-  name: BLEACH 〜選ばれし魂〜 PS2 the Best
-  name-sort: BLEACH 〜えらばれしたましい〜 PS2 the Best
-  name-en: "Bleach - Selected Soul [PS2 The Best]"
+  name: BLEACH 〜選ばれし魂〜 PlayStation 2 the Best
+  name-sort: ぶりーち えらばれしたましい PlayStation 2 the Best
+  name-en: "Bleach - Selected Soul [PlayStation 2 the Best]"
   region: "NTSC-J"
 SCPS-19332:
-  name: みんなのテニスPS2 the Best
-  name-sort: みんなのてにすPS2 the Best
-  name-en: "Minna no Tennis [PS2 The Best]"
+  name: みんなのテニス PlayStation 2 the Best
+  name-sort: みんなのてにす PlayStation 2 the Best
+  name-en: "Minna no Tennis [PlayStation 2 the Best]"
   region: "NTSC-J"
   roundModes:
     vu1RoundMode: 1 # Fixes the display of scores and text ingame.
 SCPS-19333:
-  name: "Wild Arms - The Vth Vanguard"
+  name: ワイルドアームズ ザ フィフスヴァンガード PlayStation 2 the Best
+  name-sort: WILD ARMS the Vth Vanguard [PlayStation 2 the Best]
+  name-en: "Wild ARMs - The Vth Vanguard [PlayStation 2 the Best]"
   region: "NTSC-J"
 SCPS-19335:
-  name: "Wanda to Kyozou [PS2 The Best Reprint]"
+  name: "Wanda to Kyozou [PlayStation 2 the Best Reprint]"
   region: "NTSC-J"
   gsHWFixes:
     mipmap: 1
@@ -9017,7 +9096,8 @@ SCPS-51016:
   clampModes:
     vuClampMode: 3 # Fixes SPS and bad textures.
 SCPS-55001:
-  name: "Ico"
+  name: "ICO"
+  name-sort: "いこ"
   region: "NTSC-J"
   compat: 5
   clampModes:
@@ -9145,10 +9225,10 @@ SCPS-55027:
   name: "Runabout 3 - Neo Age"
   region: "NTSC-J"
 SCPS-55028:
-  name: "Popolocrois Story - Hajime no Bouken"
+  name: "Popolocrois - Hajimari no Bouken"
   region: "NTSC-J"
 SCPS-55029:
-  name: "dot hack - Infection Part 1"
+  name: ".hack Infection Part 1"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 1 # Sharpens world in far distances.
@@ -9166,7 +9246,7 @@ SCPS-55029:
     - "SLPS-73232"
     - "SLPS-73233"
 SCPS-55030:
-  name: "First Step Victorious Boxers [PS2 The Best]"
+  name: "First Step Victorious Boxers [PlayStation 2 the Best]"
   region: "NTSC-J"
 SCPS-55031:
   name: "Ghost Vibration"
@@ -9194,7 +9274,7 @@ SCPS-55041:
   name: "Memories Off"
   region: "NTSC-J"
 SCPS-55042:
-  name: "dot hack - Mutation Part 2"
+  name: ".hack Mutation Part 2"
   region: "NTSC-J"
   memcardFilters:
     - "SCPS-55029"
@@ -11512,7 +11592,7 @@ SLAJ-25019:
   name: "The Lord of the Rings - The Return of the King"
   region: "NTSC-C"
 SLAJ-25023:
-  name: "Shin Sangoku Musou 3 - Mushoden"
+  name: "Shin Sangoku Musou 3 - Moushouden"
   region: "NTSC-Unk"
 SLAJ-25026:
   name: "Kunoichi Shinobi"
@@ -11580,7 +11660,7 @@ SLAJ-25047:
   gsHWFixes:
     minimumBlendingLevel: 2 # Fixes dark font to more bright like software mode.
 SLAJ-25048:
-  name: "Sengoku Musou Mushoden"
+  name: "Sengoku Musou Moushouden"
   region: "NTSC-Unk"
 SLAJ-25049:
   name: "Kengo 3"
@@ -11661,7 +11741,7 @@ SLAJ-25066:
     - "SLAJ-25053"
     - "SLPM-66204"
 SLAJ-25068:
-  name: "Shin Sangoku Musou 4 - Mushoden"
+  name: "Shin Sangoku Musou 4 - Moushouden"
   region: "NTSC-Unk"
   gsHWFixes:
     autoFlush: 2 # Fixes sun luminosity.
@@ -11775,10 +11855,10 @@ SLAJ-25091:
     halfPixelOffset: 2 # Fixes blurriness.
     roundSprite: 2 # Fixes blurriness.
 SLAJ-25092:
-  name: "Shin Sangoku Musou 4 [PS2 The Best]"
+  name: "Shin Sangoku Musou 4 [PlayStation 2 the Best]"
   region: "NTSC-Unk"
 SLAJ-25093:
-  name: "Sangoku Musou [PS2 The Best]"
+  name: "Sangoku Musou [PlayStation 2 the Best]"
   region: "NTSC-Unk"
 SLAJ-25094:
   name: "Burnout Dominator"
@@ -17695,7 +17775,7 @@ SLES-52230:
   gameFixes:
     - OPHFlagHack # Fixes some hanging throughout the game.
 SLES-52237:
-  name: "dot hack - Infection Part 1"
+  name: ".hack Infection Part 1"
   region: "PAL-M5"
   gsHWFixes:
     halfPixelOffset: 1 # Sharpens world in far distances.
@@ -18241,7 +18321,7 @@ SLES-52466:
   name: "Ribbit King"
   region: "PAL-M5"
 SLES-52467:
-  name: "dot hack - Mutation Part 2"
+  name: ".hack Mutation Part 2"
   region: "PAL-M5"
   compat: 5
   memcardFilters:
@@ -18250,7 +18330,7 @@ SLES-52467:
     - "SLES-52468"
     - "SLES-52469"
 SLES-52468:
-  name: "dot hack - Quarantine Part 4"
+  name: ".hack Quarantine Part 4"
   region: "PAL-M5"
   compat: 5
   memcardFilters:
@@ -18259,7 +18339,7 @@ SLES-52468:
     - "SLES-52468"
     - "SLES-52469"
 SLES-52469:
-  name: "dot hack - Outbreak Part 3"
+  name: ".hack Outbreak Part 3"
   region: "PAL-M5"
   compat: 5
   memcardFilters:
@@ -27993,7 +28073,7 @@ SLKA-25059:
   name: "Pride FC - Fighting Championships"
   region: "NTSC-K"
 SLKA-25060:
-  name: "I.Q. Remix+ - Intelligent Qube"
+  name: "I.Q Remix+ - Intelligent Qube"
   region: "NTSC-K"
 SLKA-25061:
   name: "Tom Clancy's Splinter Cell"
@@ -28059,9 +28139,9 @@ SLKA-25078:
   region: "NTSC-K"
   compat: 5
 SLKA-25080:
-  name: "dot hack - 감염확대 Vol.1"
-  name-sort: "dot hack - Infection Part 1"
-  name-en: "dot hack - Infection Part 1"
+  name: ".hack//감염확대 Vol.1"
+  name-sort: ".hack Infection Part 1"
+  name-en: ".hack//Infection Part 1"
   region: "NTSC-K"
   gsHWFixes:
     halfPixelOffset: 1 # Sharpens world in far distances.
@@ -28277,9 +28357,9 @@ SLKA-25137:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes vertical lines, font and others.
 SLKA-25138:
-  name: "dot hack - 악성변이 Vol.2"
-  name-sort: "dot hack - Mutation Part 2"
-  name-en: "dot hack - Mutation Part 2"
+  name: ".hack//악성변이 Vol.2"
+  name-sort: ".hack Mutation Part 2"
+  name-en: ".hack//Mutation Part 2"
   region: "NTSC-K"
 SLKA-25139:
   name: "Fu-un Shinsengumi"
@@ -28304,9 +28384,9 @@ SLKA-25144:
   gsHWFixes:
     roundSprite: 1 # Fixes font artifacts.
 SLKA-25145:
-  name: "dot hack - 침식오염 Vol.3"
-  name-sort: "dot hack - Outbreak Part 3"
-  name-en: "dot hack - Outbreak Part 3"
+  name: ".hack//침식오염 Vol.3"
+  name-sort: ".hack Outbreak Part 3"
+  name-en: ".hack//Outbreak Part 3"
   region: "NTSC-K"
 SLKA-25146:
   name: "Kaido Battle 2 - Chain Reaction"
@@ -28410,9 +28490,9 @@ SLKA-25173:
   name: "Tom Clancy's Rainbow Six 3"
   region: "NTSC-K"
 SLKA-25174:
-  name: "dot hack - 절대포위 Vol.4"
-  name-sort: "dot hack - Quarantine Part 4"
-  name-en: "dot hack - Quarantine Part 4"
+  name: ".hack//절대포위 Vol.4"
+  name-sort: ".hack Quarantine Part 4"
+  name-en: ".hack//Quarantine Part 4"
   region: "NTSC-K"
 SLKA-25175:
   name: "Transformers"
@@ -29628,7 +29708,7 @@ SLPM-55004:
     beforeDraw: "OI_BurnoutGames"
 SLPM-55005:
   name: マナケミア2 〜おちた学園と錬金術士たち〜
-  name-sort: まなけみあ2 〜おちたがくえんとれんきんじゅつしたち〜
+  name-sort: まなけみあ2 おちたがくえんとれんきんじゅつしたち
   name-en: "Mana Khemia 2 - Ochita Gakuen to Renkinjutsushi Tachi"
   region: "NTSC-J"
   gsHWFixes:
@@ -29640,7 +29720,7 @@ SLPM-55006:
   region: "NTSC-J"
 SLPM-55008:
   name: 戦国BASARA X
-  name-sort: せんごくBASARA X
+  name-sort: せんごくばさら X
   name-en: "Sengoku Basara X"
   region: "NTSC-J"
   compat: 5
@@ -29658,7 +29738,7 @@ SLPM-55013:
   region: "NTSC-J"
 SLPM-55014:
   name: ARIA The ORIGINATION 〜蒼い惑星のエルシエロ〜
-  name-sort: ARIA The ORIGINATION 〜あおいほしののえるしえろ〜
+  name-sort: ありあ じ おりじねーしょん あおいほしののえるしえろ
   name-en: "Aria - The Origination - Aoi Hoshi no El Cielo"
   region: "NTSC-J"
 SLPM-55015:
@@ -29688,7 +29768,7 @@ SLPM-55021:
   region: "NTSC-J"
 SLPM-55022:
   name: ファイナルファンタジーXII [アルティメットヒッツ]
-  name-sort: ふぁいなるふぁんたじーXII [あるてぃめっとひっつ]
+  name-sort: ふぁいなるふぁんたじー12 [あるてぃめっとひっつ]
   name-en: "Final Fantasy XII [Ultimate Hits]"
   region: "NTSC-J"
 SLPM-55023:
@@ -29698,7 +29778,7 @@ SLPM-55023:
   region: "NTSC-J"
 SLPM-55024:
   name: 実況パワフルプロ野球１５
-  name-sort: じっきょうぱわふるぷろやきゅう１５
+  name-sort: じっきょうぱわふるぷろやきゅう15
   name-en: "Jikkyou Powerful Pro Yakyuu 15"
   region: "NTSC-J"
 SLPM-55028:
@@ -29781,8 +29861,8 @@ SLPM-55046:
     skipDrawStart: 1 # Removes large black box around player car till we properly emulate it.
     skipDrawEnd: 1 # Removes large black box around player car till we properly emulate it.
 SLPM-55047:
-  name: Sugar+Spice! ～あの子のステキな何もかも～
-  name-sort: Sugar+Spice! ～あのこのすてきななにもかも～
+  name: Sugar+Spice! 〜あの子のステキな何もかも〜
+  name-sort: しゅがーすぱいす あのこのすてきななにもかも
   name-en: "Sugar+Spice! - Anoko no Suteki na Nanimokamo"
   region: "NTSC-J"
 SLPM-55048:
@@ -29838,7 +29918,7 @@ SLPM-55062:
   region: "NTSC-J"
 SLPM-55063:
   name: 薄桜鬼 新選組奇譚 限定版
-  name-sort: はくおうき しんせんぐみきたん げんていばん
+  name-sort: はくおうき しんせんぐみきたん [げんていばん]
   name-en: "Hakuouki - Shinsengumi Kitan [Limited Edition]"
   region: "NTSC-J"
 SLPM-55064:
@@ -29871,7 +29951,7 @@ SLPM-55071:
   name: "Yumemi Hakusho - Second Dream"
   region: "NTSC-J"
 SLPM-55072:
-  name: "GI Jockey 4 2008"
+  name: "G1 Jockey 4 2008"
   region: "NTSC-J"
 SLPM-55076:
   name: "Medal of Honor - Vanguard"
@@ -29902,7 +29982,7 @@ SLPM-55080:
     PCRTCOverscan: 1 # Fixes missing HUD.
 SLPM-55081:
   name: ドラッグオンドラグーン2 〜封印の紅 背徳の黒〜
-  name-sort: どらっぐおんどらぐーん2 〜ふういんのあか はいとくのくろ〜
+  name-sort: どらっぐおんどらぐーん2 ふういんのあか はいとくのくろ
   name-en: "Drag-on Dragoon 2 - Fuuin no Aka, Haitoku no Kuro [Ultimate Hits]"
   region: "NTSC-J"
   clampModes:
@@ -29967,7 +30047,7 @@ SLPM-55101:
   name: "Memories Off Duet - 1st and 2nd Stories [Renai Game Selection]"
   region: "NTSC-J"
 SLPM-55102:
-  name: "Pia Carrot e Youkoso!! G.P. Gakuen Princess"
+  name: "Pia Carrot he Youkoso!! G.P. Gakuen Princess"
   region: "NTSC-J"
   gsHWFixes:
     beforeDraw: "OI_PointListPalette"
@@ -30004,7 +30084,7 @@ SLPM-55113:
   region: "NTSC-J"
 SLPM-55114:
   name: マナケミア２ 〜おちた学園と錬金術士たち〜 [ガストベストプライス]
-  name-sort: まなけみあに 〜おちたがくえんとれんきんじゅつしたち〜 [がすとべすとぷらいす]
+  name-sort: まなけみあ2 おちたがくえんとれんきんじゅつしたち [がすとべすとぷらいす]
   name-en: "Mana Khemia 2 - Ochita Gakuen to Renkinjutsushi Tachi"
   region: "NTSC-J"
   gsHWFixes:
@@ -30051,7 +30131,7 @@ SLPM-55125:
   region: "NTSC-J"
 SLPM-55127:
   name: ニード・フォー・スピード アンダーカバー
-  name-sort: にーど・ふぉー・すぴーど あんだーかばー
+  name-sort: にーど ふぉー すぴーど あんだーかばー
   name-en: "Need for Speed - Undercover"
   region: "NTSC-J"
   gsHWFixes:
@@ -30287,7 +30367,7 @@ SLPM-55200:
   name: "Touka Gettan - Koufuu no Ryouou"
   region: "NTSC-J"
 SLPM-55201:
-  name: "Shirogane no Soleil - Contract to the Future - Mirai e no Keiyaku"
+  name: "Shirogane no Soleil - Contract to the Future - Mirai he no Keiyaku"
   region: "NTSC-J"
 SLPM-55202:
   name: "Shuumatsu Shoujo Gensou Alicematic Apocalypse [Russel Games Best]"
@@ -30303,7 +30383,7 @@ SLPM-55206:
   region: "NTSC-J"
 SLPM-55207:
   name: 薄桜鬼 随想録 限定版
-  name-sort: はくおうき ずいそうろく げんていばん
+  name-sort: はくおうき ずいそうろく [げんていばん]
   name-en: "Hakuouki - Zuisouroku [Limited Edition]"
   region: "NTSC-J"
 SLPM-55208:
@@ -30316,7 +30396,7 @@ SLPM-55209:
   region: "NTSC-J"
 SLPM-55210:
   name: ファイナルファンタジーXII インターナショナル ゾディアックジョブシステム [アルティメットヒッツ]
-  name-sort: ふぁいなるふぁんたじーXII いんたーなしょなる ぞでぃあっくじょぶしすてむ [あるてぃめっとひっつ]
+  name-sort: ふぁいなるふぁんたじー12 いんたーなしょなる ぞでぃあっくじょぶしすてむ [あるてぃめっとひっつ]
   name-en: "Final Fantasy XII International Zodiac Job System [Ultimate Hits]"
   region: "NTSC-J"
 SLPM-55211:
@@ -30375,7 +30455,7 @@ SLPM-55228:
   region: "NTSC-J"
 SLPM-55229:
   name: ファイナルファンタジーXI ヴァナ・ディール コレクション2
-  name-sort: ふぁいなるふぁんたじーXI ゔぁな・でぃーる これくしょん2
+  name-sort: ふぁいなるふぁんたじー11 ゔぁな・でぃーる これくしょん2
   name-en: "Final Fantasy XI - Vana'diel Collection 2"
   region: "NTSC-J"
 SLPM-55231:
@@ -30406,13 +30486,13 @@ SLPM-55242:
   name: "Gundam Musou 2"
   region: "NTSC-J"
 SLPM-55243:
-  name: スズノネセブン！～Rebirth Knot〜
-  name-sort: すずのねせぶん！～Rebirth Knot〜
+  name: スズノネセブン！〜Rebirth Knot〜
+  name-sort: すずのねせぶん Rebirth Knot
   name-en: "Suzunone Seven - Rebirth Knot"
   region: "NTSC-J"
 SLPM-55244:
   name: EA:SY!1980ニード・フォー・スピード アンダーカバー
-  name-sort: EA:SY!1980にーど・ふぉー・すぴーど あんだーかばー
+  name-sort: にーど ふぉー すぴーど あんだーかばー [EA:SY!1980]
   name-en: "Need for Speed - Undercover [Ea-SY! 1980]"
   region: "NTSC-J"
   gsHWFixes:
@@ -30427,7 +30507,7 @@ SLPM-55245:
   name-en: "Himawari - Pebble in the Sky"
   region: "NTSC-J"
 SLPM-55246:
-  name: "Wand of Fortune - Mirai e no Prologue"
+  name: "Wand of Fortune - Mirai he no Prologue"
   region: "NTSC-J"
 SLPM-55247:
   name: "S.Y.K Renshouden"
@@ -30439,7 +30519,7 @@ SLPM-55250:
   name: "Warship Gunner 2 - Kurogane no Houkou"
   region: "NTSC-J"
 SLPM-55251:
-  name: 太閤立志伝V [コーエー定番シリーズ]
+  name: コーエー定番シリーズ 太閤立志伝V
   name-sort: たいこうりっしでんV [こーえーていばんしりーず]
   name-en: "WWE SmackDown vs. Raw 2009"
   region: "NTSC-J"
@@ -30475,7 +30555,7 @@ SLPM-55262:
   region: "NTSC-J"
 SLPM-55263:
   name: 花と乙女に祝福を 〜春風の贈り物〜
-  name-sort: はなとおとめにしゅくふくを 〜はるかぜのおくりもの〜
+  name-sort: はなとおとめにしゅくふくを はるかぜのおくりもの
   name-en: "Hana to Otome ni Shukufuku o - Harukaze no Okurimono [St. Lupinus Box]"
   region: "NTSC-J"
 SLPM-55264:
@@ -30491,7 +30571,7 @@ SLPM-55268:
   name: "Nobunaga no Yabou - Kakushin with Power-Up Kit [Koei Tecmo the Best]"
   region: "NTSC-J"
 SLPM-55269:
-  name: "Pandora - Kimi no Namae o Boku wa Shiru"
+  name: "Pandora - Kimi no Namae o Boku ha Shiru"
   region: "NTSC-J"
   gameFixes:
     - SoftwareRendererFMVHack # Vertical and horizontal lines in FMV.
@@ -30509,7 +30589,7 @@ SLPM-55273:
   name-en: "Hakuouki - Reimeiroku"
   region: "NTSC-J"
 SLPM-55274:
-  name: "Uragiri wa Boku no Namae o Shitteiru - Tasogare ni Ochita Inori"
+  name: "Uragiri ha Boku no Namae o Shitteiru - Tasogare ni Ochita Inori"
   region: "NTSC-J"
 SLPM-55275:
   name: "Slotter Up Core 12 - Ping Pong"
@@ -30535,7 +30615,7 @@ SLPM-55282:
   region: "NTSC-J"
 SLPM-55283:
   name: 薄桜鬼 黎明録 限定版
-  name-sort: はくおうき れいめいろく げんていばん
+  name-sort: はくおうき れいめいろく [げんていばん]
   name-en: "Hakuouki - Reimeiroku [Limited Edition]"
   region: "NTSC-J"
 SLPM-55285:
@@ -30573,11 +30653,11 @@ SLPM-55294:
   region: "NTSC-J"
 SLPM-55298:
   name: ファイナルファンタジーXI アドゥリンの魔境
-  name-sort: ふぁいなるふぁんたじーXI あどぅりんのまきょう
+  name-sort: ふぁいなるふぁんたじー11 あどぅりんのまきょう
   name-en: "Final Fantasy XI - Adoulin no Makyou"
   region: "NTSC-J"
 SLPM-60101:
-  name: "0 Story [Taikenban]"
+  name: "0 Story [Trial]"
   region: "NTSC-J"
   gameFixes:
     - SoftwareRendererFMVHack # Fixes removed bloom in FMV.
@@ -30585,10 +30665,10 @@ SLPM-60102:
   name: "From Software First Previews"
   region: "NTSC-J"
 SLPM-60104:
-  name: "Konami PlayStation 2 Taikeban"
+  name: "Konami PlayStation 2 [Trial]"
   region: "NTSC-J"
 SLPM-60105:
-  name: "Street Fighter EX3 [Taikeban]"
+  name: "Street Fighter EX3 [Trial]"
   region: "NTSC-J"
   gsHWFixes:
     getSkipCount: "GSC_SFEX3"
@@ -30623,7 +30703,7 @@ SLPM-60115:
   name: "Super Puzzle Bobble"
   region: "NTSC-J"
 SLPM-60116:
-  name: "Magical Sports Go Go Golf [Taikenban]"
+  name: "Magical Sports Go Go Golf [Trial]"
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves brightness on terrain textures.
@@ -30646,7 +30726,7 @@ SLPM-60121:
   name: "Gungriffon Blaze & Silpheed - The Lost Planet"
   region: "NTSC-J"
 SLPM-60122:
-  name: "Ring of Red [Taikenban trial]"
+  name: "Ring of Red [Trial]"
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
@@ -30657,13 +30737,13 @@ SLPM-60124:
   name: "Shadow Hearts II [Demo]"
   region: "NTSC-J"
 SLPM-60125:
-  name: "GI Jockey 2 [Demo]"
+  name: "G1 Jockey 2 [Demo]"
   region: "NTSC-J"
 SLPM-60126:
   name: "Hajime no Ippo - Victorious Boxers [Trial]"
   region: "NTSC-J"
 SLPM-60127:
-  name: "Kurikuri Mix [Taikenban trial]"
+  name: "Kurikuri Mix [Trial]"
   region: "NTSC-J"
   speedHacks:
     mtvu: 0 # Prevents broken textures and graphics.
@@ -30790,7 +30870,7 @@ SLPM-60174:
   name: "Zettai Zetsumei Toshi"
   region: "NTSC-J"
 SLPM-60175:
-  name: "Wangan Midnight [Taikenban]"
+  name: "Wangan Midnight [Trial]"
   region: "NTSC-J"
 SLPM-60176:
   name: "U - Underwater Unit"
@@ -30841,7 +30921,7 @@ SLPM-60194:
   name: "Kotoba no Puzzle - Mojipittan"
   region: "NTSC-J"
 SLPM-60195:
-  name: "Kaido Battle - Nikko, Haruna, Rokko, Hakone [Taikenban]"
+  name: "Kaido Battle - Nikko, Haruna, Rokko, Hakone [Trial]"
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
@@ -30872,7 +30952,7 @@ SLPM-60205:
   name: "Initial D - Special Stage"
   region: "NTSC-J"
 SLPM-60206:
-  name: "Shutokou Battle 01 [Taikenban]"
+  name: "Shutokou Battle 01 [Trial]"
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
@@ -30931,7 +31011,7 @@ SLPM-60226:
   name: "Shadow Hearts II"
   region: "NTSC-J"
 SLPM-60228:
-  name: "Kaido Battle 2 - Chain Reaction [Taikenban]"
+  name: "Kaido Battle 2 - Chain Reaction [Trial]"
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
@@ -31002,12 +31082,12 @@ SLPM-60252:
   name: "Futakoi"
   region: "NTSC-J"
 SLPM-60253:
-  name: "Zettai Zetsumei Toshi 2 - Itetsuita Kioku-tachi [Taikenban Type-B]"
+  name: "Zettai Zetsumei Toshi 2 - Itetsuita Kioku-tachi [Trial Type-B]"
   region: "NTSC-J"
   gsHWFixes:
     getSkipCount: "GSC_ZettaiZetsumeiToshi2"
 SLPM-60254:
-  name: "Zettai Zetsumei Toshi 2 - Itetsuita Kioku-tachi [Taikenban Type-A]"
+  name: "Zettai Zetsumei Toshi 2 - Itetsuita Kioku-tachi [Trial Type-A]"
   region: "NTSC-J"
   gsHWFixes:
     getSkipCount: "GSC_ZettaiZetsumeiToshi2"
@@ -31033,7 +31113,7 @@ SLPM-60259:
   name: "Jissen Pachi-Slot Hisshouhou! Hokuto no Ken Premium Disc"
   region: "NTSC-J"
 SLPM-60260:
-  name: "D1 Professional Drift Grand Prix Series [Taikenban]"
+  name: "D1 Professional Drift Grand Prix Series [Trial]"
   region: "NTSC-J"
   clampModes:
     eeClampMode: 3 # Fixes black void.
@@ -31056,7 +31136,7 @@ SLPM-60266:
     getSkipCount: "GSC_SteambotChronicles" # Causes green (incorrect) water but removes depth and blur issues.
     roundSprite: 1 # Fixes colored 3D anaglyph bleeding effects.
 SLPM-60267:
-  name: "Garouden Breakblow [Taikenban]"
+  name: "Garouden Breakblow [Trial]"
   region: "NTSC-J"
 SLPM-60268:
   name: "Minna Daisuki Katamari Damacy"
@@ -31451,7 +31531,7 @@ SLPM-61114:
   name: "Shadow of Rome"
   region: "NTSC-J"
 SLPM-61115:
-  name: "Racing Battle - C1 Grand Prix [Taikenban]"
+  name: "Racing Battle - C1 Grand Prix [Trial]"
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
@@ -31486,7 +31566,7 @@ SLPM-61120:
     mergeSprite: 1 # Align sprite fixes FMVs but not garbage in-game, so needs merge sprite instead.
     texturePreloading: 1 # Performs better with partial preload because it is slow on locations outside gameplay foremost.
 SLPM-61121:
-  name: "Kaido - Touge no Densetsu [Taikenban]"
+  name: "Kaido - Touge no Densetsu [Trial]"
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
@@ -31585,7 +31665,7 @@ SLPM-61147:
     roundSprite: 2 # Fixes font artifacts.
     textureInsideRT: 1 # Fixes bad crystal surfaces.
 SLPM-61148:
-  name: "Growlanser V - Generations [Taikenban Demo]"
+  name: "Growlanser V - Generations [Trial]"
   region: "NTSC-J"
   gsHWFixes:
     moveHandler: "MV_Growlanser" # Fixes precomputed depth buffer.
@@ -31658,12 +31738,12 @@ SLPM-62003:
   region: "NTSC-J"
 SLPM-62004:
   name: 麻雀やろうぜ！2
-  name-sort: まーじゃんやろうぜ！2
+  name-sort: まーじゃんやろうぜ!2
   name-en: "Mahjong Yarouze! 2"
   region: "NTSC-J"
 SLPM-62005:
   name: 真・三國無双
-  name-sort: しん・さんごくむそう
+  name-sort: しんさんごくむそう
   name-en: "Shin Sangoku Musou"
   region: "NTSC-J"
 SLPM-62006:
@@ -31689,7 +31769,7 @@ SLPM-62009:
   region: "NTSC-J"
 SLPM-62010:
   name: 三國志VII
-  name-sort: さんごくしVII
+  name-sort: さんごくし7
   name-en: "Romance of the Three Kingdoms VII"
   region: "NTSC-J"
 SLPM-62011:
@@ -31725,11 +31805,11 @@ SLPM-62019:
   name: "Winning Post 4 Maximum"
   region: "NTSC-J"
 SLPM-62020:
-  name: "GI Jockey 2"
+  name: "G1 Jockey 2"
   region: "NTSC-J"
 SLPM-62021:
   name: アンジェリーク トロワ プレミアムBOX
-  name-sort: あんじぇりーく とろわ ぷれみあむBOX
+  name-sort: あんじぇりーく とろわ [ぷれみあむBOX]
   name-en: "Angelique Trois [Premium Box]"
   region: "NTSC-J"
 SLPM-62022:
@@ -31795,7 +31875,7 @@ SLPM-62034:
   region: "NTSC-J"
 SLPM-62035:
   name: いくぜ！温泉卓球！！
-  name-sort: いくぜ！おんせんたっきゅう！！
+  name-sort: いくぜ!おんせんたっきゅう!!
   name-en: "Iku ze! Onsen Takkyuu!!"
   region: "NTSC-J"
 SLPM-62036:
@@ -31826,7 +31906,9 @@ SLPM-62042:
   name: "Kurogane no Houkou - Warship Commander"
   region: "NTSC-J"
 SLPM-62043:
-  name: "Metal Gear Solid 2 - Sons of Liberty [Trial version]"
+  name: METAL GEAR SOLID 2 SONS OF LIBERTY 初体験版
+  name-sort: めたるぎあそりっど2 さんずおぶりばてぃ [はつたいけんばん]
+  name-en: "Metal Gear Solid 2 [Trial]"
   region: "NTSC-J"
   gameFixes:
     - InstantDMAHack # Fixes broken half-bottom artifacts.
@@ -31860,7 +31942,7 @@ SLPM-62048:
   region: "NTSC-J"
 SLPM-62049:
   name: 電車でGO!3 通勤編
-  name-sort: でんしゃでGO!3 つうきんへん
+  name-sort: でんしゃでごー3 つうきんへん
   name-en: "Densha de Go! 3 - Tsuukin-hen"
   region: "NTSC-J"
 SLPM-62050:
@@ -31873,7 +31955,7 @@ SLPM-62051:
   region: "NTSC-J"
 SLPM-62052:
   name: beatmania打打打!!
-  name-sort: beatmaniaだだだ!!
+  name-sort: びーとまにあだだだ!!
   name-en: "Beatmania Da Da Da!!"
   region: "NTSC-J"
 SLPM-62053:
@@ -31901,17 +31983,17 @@ SLPM-62058:
   name: "Winning Post 4 Maximum 2001"
   region: "NTSC-J"
 SLPM-62059:
-  name: "GI Jockey 2 2001"
+  name: "G1 Jockey 2 2001"
   region: "NTSC-J"
 SLPM-62060:
   name: Winning Post 4 MAXIMUM 2001
-  name-sort: Winning Post 4 MAXIMUM 2001
+  name-sort: ういにんぐぽすと4 MAXIMUM 2001
   name-en: "Winning Post 4 Maximum 2001"
   region: "NTSC-J"
   gsHWFixes:
     mipmap: 1 # Improves ground textures to match sw renderer.
 SLPM-62061:
-  name: "GI Jockey 2 2001"
+  name: "G1 Jockey 2 2001"
   region: "NTSC-J"
 SLPM-62062:
   name: ギタルマンワン
@@ -31921,8 +32003,8 @@ SLPM-62062:
   roundModes:
     eeRoundMode: 1 # Fixes disappearing characters.
 SLPM-62063:
-  name: グラディウスIII&IV～復活の神話～ コナミ ザ・ベスト
-  name-sort: ぐらでぃうすIII&IV～ふっかつのしんわ～ こなみ ざ・べすと
+  name: グラディウスIII&IV〜復活の神話〜 コナミ ザ・ベスト
+  name-sort: ぐらでぃうす3&4 ふっかつのしんわ こなみ ざ・べすと
   name-en: "Gradius III & IV [Konami The Best]"
   region: "NTSC-J"
 SLPM-62065:
@@ -31930,7 +32012,7 @@ SLPM-62065:
   region: "NTSC-J"
 SLPM-62067:
   name: HUNTER×HUNTER 龍派の祭壇
-  name-sort: HUNTER×HUNTER りゅうはのさいだん
+  name-sort: はんたーはんたー りゅうはのさいだん
   name-en: "Hunter X Hunter - Ryumyaku no Saidan"
   region: "NTSC-J"
 SLPM-62068:
@@ -31945,8 +32027,8 @@ SLPM-62069:
   region: "NTSC-J"
 SLPM-62070:
   name: うちゅ〜じんってなぁに？
-  name-sort: うちゅ〜じんってなぁに？
-  name-en: "Uchu-Jintte Naani"
+  name-sort: うちゅーじんってなぁに?
+  name-en: "Uchu-Jintte Naani?"
   region: "NTSC-J"
 SLPM-62071:
   name: 実況パワフルプロ野球8
@@ -31986,7 +32068,7 @@ SLPM-62077:
   region: "NTSC-J"
 SLPM-62078:
   name: マエストロムジークII
-  name-sort: まえすとろむじーくII
+  name-sort: まえすとろむじーく2
   name-en: "Maestro Music 2, The"
   region: "NTSC-J"
 SLPM-62079:
@@ -32001,7 +32083,7 @@ SLPM-62081:
 SLPM-62082:
   name: プロ野球 JAPAN2001
   name-sort: ぷろやきゅう JAPAN2001
-  name-en: "Professional Baseball Japan 2001"
+  name-en: "Pro Yakyuu Japan 2001"
   region: "NTSC-J"
 SLPM-62084:
   name: ESPN XGames skateboarding
@@ -32056,7 +32138,7 @@ SLPM-62096:
   region: "NTSC-J"
 SLPM-62097:
   name: ザ・警察官 新宿24時
-  name-sort: ざ・けいさつかん しんじゅく24じ
+  name-sort: ざ けいさつかん しんじゅく24じ
   name-en: "Keisatsukan, The - Shinjuku 24-ji"
   region: "NTSC-J"
 SLPM-62098:
@@ -32069,12 +32151,12 @@ SLPM-62099:
   region: "NTSC-J"
 SLPM-62100:
   name: Rez SPECIAL PACKAGE
-  name-sort: Rez SPECIAL PACKAGE
+  name-sort: れず SPECIAL PACKAGE
   name-en: "Rez [Special Package]"
   region: "NTSC-J"
 SLPM-62101:
   name: Rez
-  name-sort: Rez
+  name-sort: れず
   name-en: "Rez"
   region: "NTSC-J"
   compat: 5
@@ -32100,13 +32182,13 @@ SLPM-62105:
   region: "NTSC-J"
 SLPM-62107:
   name: グローランサーIII 萌え萌えラッキーパック
-  name-sort: ぐろーらんさーIII もえもえらっきーぱっく
+  name-sort: ぐろーらんさー3 もえもえらっきーぱっく
   name-en: "Growlanser 3 - The Duel Darkness"
   region: "NTSC-J"
   compat: 4
 SLPM-62108:
   name: グローランサーIII
-  name-sort: ぐろーらんさーIII
+  name-sort: ぐろーらんさー3
   name-en: "Growlanser 3 - The Duel Darkness"
   region: "NTSC-J"
   compat: 4
@@ -32120,7 +32202,7 @@ SLPM-62111:
   region: "NTSC-J"
 SLPM-62112:
   name: いただきストリート3 億万長者にしてあげる! 〜家庭教師付き!〜
-  name-sort: いただきすとりーと3 おくまんちょうじゃにしてあげる! 〜かていきょうしつき!〜
+  name-sort: いただきすとりーと3 おくまんちょうじゃにしてあげる! かていきょうしつき
   name-en: "Itadaki Street 3"
   region: "NTSC-J"
 SLPM-62113:
@@ -32129,7 +32211,9 @@ SLPM-62113:
   name-en: "World Soccer Winning Eleven 5 - Final Evolution"
   region: "NTSC-J"
 SLPM-62114:
-  name: "Crash Bandicoot 4 - Sakuretsu! Majin Power"
+  name: "クラッシュ・バンディクー4 さくれつ!魔神パワー"
+  name-sort: "くらっしゅばんでぃくー4 さくれつ まじんぱわー"
+  name-en: "Crash Bandicoot 4 - Sakuretsu! Majin Power"
   region: "NTSC-J"
   gsHWFixes:
     nativePaletteDraw: 1
@@ -32141,8 +32225,8 @@ SLPM-62116:
   name: "EX Jinsei Game"
   region: "NTSC-J"
 SLPM-62117:
-  name: 桃太郎電鉄X（ばってん）〜九州編もあるばい〜
-  name-sort: ももたろうでんてつX（ばってん）〜きゅうしゅうへんもあるばい〜
+  name: 桃太郎電鉄X〜九州編もあるばい〜
+  name-sort: ももたろうでんてつばってん きゅうしゅうへんもあるばい
   name-en: "Momotaro Train X"
   region: "NTSC-J"
 SLPM-62118:
@@ -32173,7 +32257,7 @@ SLPM-62122:
   region: "NTSC-J"
 SLPM-62123:
   name: Winning Post5
-  name-sort: Winning Post5
+  name-sort: ういにんぐぽすと5
   name-en: "Winning Post 5"
   region: "NTSC-J"
 SLPM-62124:
@@ -32182,8 +32266,8 @@ SLPM-62124:
   name-en: "Ready 2 Rumble Boxing - Round 2"
   region: "NTSC-J"
 SLPM-62125:
-  name: GAUNTLET DARK LEGACY
-  name-sort: GAUNTLET DARK LEGACY
+  name: Gauntlet Dark Legacy
+  name-sort: Gauntlet Dark Legacy
   name-en: "Gauntlet - Dark Legacy"
   region: "NTSC-J"
   gsHWFixes:
@@ -32217,7 +32301,7 @@ SLPM-62130:
   compat: 5
 SLPM-62131:
   name: 三國志VIII
-  name-sort: さんごくししVIII
+  name-sort: さんごくし8
   name-en: "Romance of the Three Kingdoms VIII"
   region: "NTSC-J"
 SLPM-62132:
@@ -32232,12 +32316,12 @@ SLPM-62133:
   region: "NTSC-J"
 SLPM-62134:
   name: ファイナルファンタジーXI β Version
-  name-sort: ふぁいなるふぁんたじーXI β Version
+  name-sort: ふぁいなるふぁんたじー11 β Version
   name-en: "Final Fantasy XI [Beta Edition]"
   region: "NTSC-J"
 SLPM-62135:
   name: ファイナルファンタジーXI β Version
-  name-sort: ふぁいなるふぁんたじーXI β Version
+  name-sort: ふぁいなるふぁんたじー11 β Version
   name-en: "Final Fantasy XI - Online"
   region: "NTSC-J"
 SLPM-62136:
@@ -32267,12 +32351,12 @@ SLPM-62141:
   region: "NTSC-J"
 SLPM-62142:
   name: 鉄1 〜電車でバトル!〜 WORLD GRAND PRIX
-  name-sort: てつ1 〜でんしゃでばとる!〜 WORLD GRAND PRIX
-  name-en: "World Grand Prix"
+  name-sort: てつわん でんしゃでばとる WORLD GRAND PRIX
+  name-en: "Tetsu-one Densha de Battle World Grand Prix"
   region: "NTSC-J"
 SLPM-62143:
   name: 箱庭鉄道〜ブルートレイン・特急編〜
-  name-sort: はこにわてつどう〜ぶるーとれいん・とっきゅうへん〜
+  name-sort: はこにわてつどう ぶるーとれいん とっきゅうへん
   name-en: "Hakoniwa Tetsudou - Blue Train Express"
   region: "NTSC-J"
 SLPM-62144:
@@ -32286,7 +32370,7 @@ SLPM-62146:
   region: "NTSC-J"
 SLPM-62147:
   name: BASS STRIKE〜バス ストライク〜
-  name-sort: BASS STRIKE〜ばす すとらいく〜
+  name-sort: BASS STRIKE ばす すとらいく
   name-en: "Bass Strike"
   region: "NTSC-J"
 SLPM-62148:
@@ -32304,7 +32388,7 @@ SLPM-62151:
   region: "NTSC-J"
 SLPM-62153:
   name: まげるつけるはしーる俺☆デットヒート
-  name-sort: まげるつけるはしーるおれ☆でっとひーと
+  name-sort: まげるつけるはしーるおれ でっとひーと
   name-en: "Racing Construction - Mareru Tsukeru Hahiiru Ore - Dead Heat"
   region: "NTSC-J"
 SLPM-62154:
@@ -32348,7 +32432,7 @@ SLPM-62163:
   region: "NTSC-C-E-J"
 SLPM-62164:
   name: GENERATION OF CHAOS NEXT 〜失われし絆〜
-  name-sort: GENERATION OF CHAOS NEXT 〜うしなわれしきずな〜
+  name-sort: GENERATION OF CHAOS NEXT うしなわれしきずな
   name-en: "Generation of Chaos - Next"
   region: "NTSC-J"
 SLPM-62165:
@@ -32386,7 +32470,7 @@ SLPM-62174:
   region: "NTSC-J"
 SLPM-62175:
   name: beatmania打打打!!THE BEST打
-  name-sort: beatmaniaだだだ!!THE BESTだ
+  name-sort: びーとまにあだだだ!!THE BESTだ
   name-en: "Beatmania Da Da Da!! THE BEST Da"
   region: "NTSC-J"
 SLPM-62176:
@@ -32406,8 +32490,8 @@ SLPM-62179:
   name: "Simple 2000 Honkaku Shikou Series Vol. 2 - The Igo"
   region: "NTSC-J"
 SLPM-62180:
-  name: SIMPLE2000本格思考シリーズVol.1 THE将棋〜森田和郎の将棋指南〜
-  name-sort: SIMPLE2000ほんかくしこうしりーずVol.1 THEしょうぎ〜もりたかずおのしょうぎしなん〜
+  name: SIMPLE2000本格思考シリーズVol.1 THE 将棋〜森田和郎の将棋指南〜
+  name-sort: SIMPLE2000ほんかくしこうしりーずVol.1 THE しょうぎ もりたかずおのしょうぎしなん
   name-en: "Simple 2000 Honkaku Shikou Series Vol. 1 - The Shogi"
   region: "NTSC-J"
   compat: 5
@@ -32455,7 +32539,9 @@ SLPM-62194:
   name: "Nihon Sumou Kyoukai Kounin - Nihon Oozumou - Gekitou Honbasho-hen"
   region: "NTSC-J"
 SLPM-62195:
-  name: "Online Games - Dai Guru Guru Onsen"
+  name: "大ぐるぐる温泉"
+  name-sort: "だいぐるぐるおんせん"
+  name-en: "Dai Guru Guru Onsen"
   region: "NTSC-J"
 SLPM-62196:
   name: "Simple 2000 Series Vol. 6 - The Snowboard"
@@ -32468,13 +32554,13 @@ SLPM-62197:
   gameFixes:
     - XGKickHack # Fixes graphical issues.
 SLPM-62198:
-  name: SIMPLE2000本格思考シリーズVol.4 THE麻雀
-  name-sort: SIMPLE2000ほんかくしこうしりーずVol.4 THEまーじゃん
+  name: SIMPLE2000本格思考シリーズVol.4 THE 麻雀
+  name-sort: SIMPLE2000ほんかくしこうしりーずVol.4 THE まーじゃん
   name-en: "Simple 2000 Honkaku Shikou Series Vol. 4 - The Mahjong"
   region: "NTSC-J"
 SLPM-62199:
   name: ドラゴンクエスト・キャラクターズ トルネコの大冒険3 〜不思議のダンジョン〜
-  name-sort: どらごんくえすと・きゃらくたーず とるねこのだいぼうけん3 〜ふしぎのだんじょん〜
+  name-sort: どらごんくえすと きゃらくたーず とるねこのだいぼうけん3 ふしぎのだんじょん
   name-en: "Dragon Quest Characters - Toruneko no Daibouken 3"
   region: "NTSC-J"
 SLPM-62200:
@@ -32510,7 +32596,7 @@ SLPM-62205:
   compat: 5
 SLPM-62206:
   name: グローランサーII <アトラスベストコレクション>
-  name-sort: ぐろーらんさーII <あとらすべすとこれくしょん>
+  name-sort: ぐろーらんさー2 <あとらすべすとこれくしょん>
   name-en: "Growlanser 2 [Atlus The Best]"
   region: "NTSC-J"
   compat: 4
@@ -32566,7 +32652,7 @@ SLPM-62217:
   region: "NTSC-J"
 SLPM-62218:
   name: SIMPLE2000シリーズVol.10 THEテーブルゲーム 世界編 〜チェス・バックギャモン・ダイヤモンド・軍人将棋 etc〜
-  name-sort: SIMPLE2000しりーずVol.10 THEてーぶるげーむ せかいへん 〜ちぇす・ばっくぎゃもん・だいやもんど・ぐんじんしょうぎ etc〜
+  name-sort: SIMPLE2000しりーずVol.10 THEてーぶるげーむ せかいへん ちぇす ばっくぎゃもん だいやもんど ぐんじんしょうぎ etc
   name-en: "Simple 2000 Series Vol. 10 - The Table Game Sekai-Hen"
   region: "NTSC-J"
 SLPM-62219:
@@ -32581,7 +32667,7 @@ SLPM-62220:
   region: "NTSC-J"
 SLPM-62221:
   name: Winning Post5 MAXIMUM 2002
-  name-sort: Winning Post5 MAXIMUM 2002
+  name-sort: ういにんぐぽすと5 MAXIMUM 2002
   name-en: "Winning Post 5 Maximum 2002"
   region: "NTSC-J"
   gsHWFixes:
@@ -32593,8 +32679,8 @@ SLPM-62223:
   region: "NTSC-J"
 SLPM-62224:
   name: SIMPLE2000シリーズ アルティメットVol.3 最速!族車キング〜仏恥義理伝説〜
-  name-sort: SIMPLE2000しりーず あるてぃめっとVol.3 さいそく!ぞくしゃきんぐ〜ふつはじぎりでんせつ〜
-  name-en: "Simple 2000 Series Ultimate Vol. 3 - Saisoku! Zokusha King - Buchigiri Densetsu"
+  name-sort: SIMPLE2000しりーず あるてぃめっとVol.3 さいそく ぞくしゃきんぐ ぶっちぎりでんせつ
+  name-en: "Simple 2000 Series Ultimate Vol. 3 - Saisoku! Zokusha King - Bucchigiri Densetsu"
   region: "NTSC-J"
 SLPM-62225:
   name: 信長の野望 嵐世記withパワーアップキット
@@ -32633,12 +32719,12 @@ SLPM-62232:
   region: "NTSC-J"
 SLPM-62233:
   name: SIMPLE2000シリーズ アルティメットVol.4 裏技イカサ麻雀街 〜兄ィさん、つかんじまったようだね〜
-  name-sort: SIMPLE2000しりーず あるてぃめっとVol.4 うらわざいかさまーじゃんがい 〜あにぃさん、つかんじまったようだね〜
+  name-sort: SIMPLE2000しりーず あるてぃめっとVol.4 うらわざいかさまーじゃんがい にぃさん つかんじまったようだね
   name-en: "Simple 2000 Series Ultimate Vol. 4 - Urawaza Ikasa Mahjong Machi"
   region: "NTSC-J"
 SLPM-62234:
   name: SIMPLE2000シリーズVol.13 女の子のためのTHE恋愛アドベンチャー〜硝子の森〜
-  name-sort: SIMPLE2000しりーずVol.13 おんなのこのためのTHEれんあいあどべんちゃー〜がらすのもり〜
+  name-sort: SIMPLE2000しりーずVol.13 おんなのこのためのTHEれんあいあどべんちゃー がらすのもり
   name-en: "Simple 2000 Series Vol. 13 - Onna no Ko no Tame no - The Renai Adventure - Garasu no Mori"
   region: "NTSC-J"
 SLPM-62235:
@@ -32710,14 +32796,14 @@ SLPM-62247:
   region: "NTSC-J"
 SLPM-62248:
   name: SIMPLE2000シリーズ アルティメットVol.5 ラブ★マージャン!
-  name-sort: SIMPLE2000しりーず あるてぃめっとVol.5 らぶ★まーじゃん!
+  name-sort: SIMPLE2000しりーず あるてぃめっとVol.5 らぶまーじゃん!
   name-en: "Simple 2000 Series Ultimate Vol. 5 - Love - Mahjong!"
   region: "NTSC-J"
   gameFixes:
     - XGKickHack # Fixes SPS.
 SLPM-62249:
   name: SIMPLE2000シリーズ ハローキティVol.1 スターライト★パズル〜いそがしキューブ★どっすんフワワ(ハート) 〜
-  name-sort: SIMPLE2000しりーず はろーきてぃVol.1 すたーらいと★ぱずる〜いそがしきゅーぶ★どっすんふわわ(はーと) 〜
+  name-sort: SIMPLE2000しりーず はろーきてぃVol.1 すたーらいとぱずる いそがしきゅーぶどっすんふわわ(はーと) 〜
   name-en: "Hello Kitty Star Light - Isogasi Cube"
   region: "NTSC-J"
 SLPM-62250:
@@ -32732,7 +32818,7 @@ SLPM-62251:
   region: "NTSC-J"
 SLPM-62252:
   name: SIMPLE2000シリーズVol.17 THE推理〜新たなる20の事件簿〜
-  name-sort: SIMPLE2000しりーずVol.17 THEすいり〜あらたなる20のじけんぼ〜
+  name-sort: SIMPLE2000しりーずVol.17 THEすいり あらたなる20のじけんぼ
   name-en: "Simple 2000 Series Vol. 17 - The Suiri-Aratanaru 20 no Jikenbo"
   region: "NTSC-J"
 SLPM-62253:
@@ -32742,7 +32828,7 @@ SLPM-62253:
   region: "NTSC-J"
 SLPM-62254:
   name: 歸らずの森
-  name-sort: 歸らずのもり
+  name-sort: かえらずのもり
   name-en: "Kaerazu no Mori"
   region: "NTSC-J"
 SLPM-62255:
@@ -32784,7 +32870,7 @@ SLPM-62261:
   name-en: "DogStation"
   region: "NTSC-J"
 SLPM-62262:
-  name: "GI Jockey 2 [Koei the best]"
+  name: "G1 Jockey 2 [Koei the best]"
   region: "NTSC-J"
 SLPM-62263:
   name: スノーボードヘヴン [カプコレ]
@@ -32808,7 +32894,7 @@ SLPM-62265:
 SLPM-62266:
   name: 桃太郎電鉄11 ブラックボンビー出現の巻
   name-sort: ももたろうでんてつ11 ぶらっくぼんびーしゅつげんのまき
-  name-en: "Momotaro Densetsu XI"
+  name-en: "Momotarou Dentetsu XI"
   region: "NTSC-J"
 SLPM-62268:
   name: ワールドサッカーウイニングイレブン6 ファイナルエヴォリューション
@@ -32823,13 +32909,13 @@ SLPM-62269:
   region: "NTSC-J"
 SLPM-62270:
   name: SIMPLE2000シリーズVol.19 THE恋愛シミュレーション〜私におまカフェ〜
-  name-sort: SIMPLE2000しりーずVol.19 THEれんあいしみゅれーしょん〜わたしにおまかふぇ〜
+  name-sort: SIMPLE2000しりーずVol.19 THEれんあいしみゅれーしょん わたしにおまかふぇ
   name-en: "Simple 2000 Series Vol. 19 - The Love Simulation - The Coffee Shop"
   region: "NTSC-J"
 SLPM-62271:
   name: SIMPLE2000シリーズVol.20 THEダンジョンRPG忍〜魔物の棲む城〜
-  name-sort: SIMPLE2000しりーずVol.20 THEだんじょんRPGにん〜まもののすむしろ〜
-  name-en: "Simple 2000 Series Vol. 20 - The Dungeon RPG"
+  name-sort: SIMPLE2000しりーずVol.20 THEだんじょんRPGにん まもののすむしろ
+  name-en: "Simple 2000 Series Vol. 20 - The Dungeon RPG Nin"
   region: "NTSC-J"
   gameFixes:
     - XGKickHack # Fixes missing blue lines on the characters in dark areas.
@@ -32855,23 +32941,23 @@ SLPM-62275:
   region: "NTSC-J"
 SLPM-62276:
   name: GetBackers奪還屋 奪還だヨ！全員集合！！
-  name-sort: GetBackersだっかんや だっかんだよ！ぜんいんしゅうごう！！
+  name-sort: GetBackersだっかんや だっかんだよ!ぜんいんしゅうごう!!
   name-en: "Get Backers - All Members Gather"
   region: "NTSC-J"
 SLPM-62277:
   name: ジーワンジョッキー3
   name-sort: じーわんじょっきー3
-  name-en: "GI Jockey 3"
+  name-en: "G1 Jockey 3"
   region: "NTSC-J"
 SLPM-62278:
   name: HUNTER×HUNTER 龍派の祭壇 コナミ ザ ベスト
-  name-sort: HUNTER×HUNTER りゅうはのさいだん こなみ ざ べすと
+  name-sort: はんたーはんたー りゅうはのさいだん こなみ ざ べすと
   name-en: "Hunter x Hunter"
   region: "NTSC-J"
 SLPM-62279:
   name: ジーワンジョッキー3&ウイニングポスト5 マキシマム2002 プレミアムパック
   name-sort: じーわんじょっきー3&ういにんぐぽすと5 まきしまむ2002 ぷれみあむぱっく
-  name-en: "GI Jockey 3 [Premium Pack]"
+  name-en: "G1 Jockey 3 [Premium Pack]"
   region: "NTSC-J"
 SLPM-62280:
   name: "Winning Post 5 Maximum 2002 [Premium Pack]"
@@ -32899,22 +32985,26 @@ SLPM-62285:
   region: "NTSC-J"
   compat: 5
 SLPM-62286:
-  name: "Monster Bass"
+  name: モンスターバス
+  name-sort: もんすたーばす
+  name-en: "Monster Bass"
   region: "NTSC-J"
 SLPM-62287:
   name: ファイヤープロレスリングZ 闘辞苑 同梱BOX
   name-sort: ふぁいやーぷろれすりんぐZ とうじえん どうこんBOX
-  name-en: "Fire Pro Wrestling Z [Limited Edition]"
+  name-en: "Fire Pro Wrestling Z [with Toujien BOX]"
   region: "NTSC-J"
   gameFixes:
     - InstantDMAHack # Fixes bad ring/UI textures.
 SLPM-62288:
   name: ポップンミュージック ベストヒッツ！
-  name-sort: ぽっぷんみゅーじっく べすとひっつ！
+  name-sort: ぽっぷんみゅーじっく べすとひっつ!
   name-en: "Pop'n music Best Hits!"
   region: "NTSC-J"
 SLPM-62290:
-  name: "TV Kuraemon"
+  name: TV蔵衛門
+  name-sort: TVくらえもん
+  name-en: "TV Kuraemon"
   region: "NTSC-J"
 SLPM-62291:
   name: ボンバーマンランド2 ゲーム史上最大のテーマパーク
@@ -32923,7 +33013,7 @@ SLPM-62291:
   region: "NTSC-J"
 SLPM-62292:
   name: Warrior Blade - ラスタン VS バーバリアン編 -
-  name-sort: Warrior Blade - らすたん VS ばーばりあんへん -
+  name-sort: Warrior Blade らすたん VS ばーばりあんへん
   name-en: "Warrior Blade - Rastan vs. Barbarian"
   region: "NTSC-J"
 SLPM-62293:
@@ -32935,20 +33025,20 @@ SLPM-62294:
   name-en: "Simple 2000 Series Vol. 21 - The Moonlight Tale RPG"
   region: "NTSC-J"
 SLPM-62295:
-  name: SIMPLE2000シリーズVol.22 THE通勤電車運転士 ～電車でGO!3通勤編～
-  name-sort: SIMPLE2000しりーずVol.22 THEつうきんでんしゃうんてんし ～でんしゃでGO!3つうきんへん～
+  name: SIMPLE2000シリーズVol.22 THE通勤電車運転士 〜電車でGO!3通勤編〜
+  name-sort: SIMPLE2000しりーずVol.22 THEつうきんでんしゃうんてんし 〜でんしゃでごー3つうきんへん〜
   name-en: "Simple 2000 Series Vol. 22 - The Tsuukin Densha Untenshi - Densha de Go! 3 Tsuukin Hen"
   region: "NTSC-J"
 SLPM-62296:
   name: SIMPLE2000シリーズ アルティメット Vol.6 ラブ★アッパー！
-  name-sort: SIMPLE2000しりーず あるてぃめっと Vol.6 らぶ★あっぱー！
-  name-en: "Simple 2000 Series Ultimate Vol. 6 - Love - Upper!"
+  name-sort: SIMPLE2000しりーず あるてぃめっと Vol.6 らぶあっぱー
+  name-en: "Simple 2000 Series Ultimate Vol. 6 - Love Upper!"
   region: "NTSC-J"
   compat: 5
 SLPM-62297:
   name: 彩京べすと いくぜ！温泉卓球
-  name-sort: さいきょうべすと いくぜ！おんせんたっきゅう
-  name-en: "Got To Do! Hot Spring Table Tennis"
+  name-sort: さいきょうべすと いくぜ!おんせんたっきゅう
+  name-en: "Got To Do! Hot Spring Table Tennis [Psikyo Best]"
   region: "NTSC-J"
 SLPM-62298:
   name: プチコプター
@@ -32992,22 +33082,26 @@ SLPM-62308:
   name-en: "Simple 2000 Series Vol. 24 - The Bowling"
   region: "NTSC-J"
 SLPM-62309:
-  name: "Simple 2000 Series Vol. 25 - The Menkyo Shutoku Simulation"
+  name: SIMPLE2000シリーズVol.25 THE 免許取得シミュレーション
+  name-sort: SIMPLE2000しりーずVol.25 THE めんきょしゅとくしみゅれーしょん
+  name-en: "Simple 2000 Series Vol. 25 - The Menkyo Shutoku Simulation"
   region: "NTSC-J"
 SLPM-62310:
   name: 蒼天龍　THE　ARCADE
-  name-sort: そうてんりゅう　THE　ARCADE
+  name-sort: そうてんりゅう THE ARCADE
   name-en: "Souten Ryuu - The Arcade"
   region: "NTSC-J"
 SLPM-62312:
   name: "Saikyou no Igo 2"
   region: "NTSC-J"
 SLPM-62313:
-  name: "Simple 2000 Series Vol. 23 - The Puzzle Collection 2000-mon"
+  name: SIMPLE2000シリーズ Vol.23 THE パズルコレクション2000問
+  name-sort: SIMPLE2000しりーずVol.23 THE ぱずるこれくしょん2000もん
+  name-en: "Simple 2000 Series Vol. 23 - The Puzzle Collection 2000-mon"
   region: "NTSC-J"
 SLPM-62314:
-  name: SIMPLE2000シリーズ アルティメットVol.7 最強!白バイキング～SECURITY POLICE～
-  name-sort: SIMPLE2000しりーず あるてぃめっとVol.7 さいきょう!しろばいきんぐ～SECURITY POLICE～
+  name: SIMPLE2000シリーズ アルティメットVol.7 最強!白バイキング〜SECURITY POLICE〜
+  name-sort: SIMPLE2000しりーず あるてぃめっとVol.7 さいきょう!しろばいきんぐ SECURITY POLICE
   name-en: "Simple 2000 Series Vol. 7 - Saikyou! Shiro Biking Security Police"
   region: "NTSC-J"
 SLPM-62315:
@@ -33021,7 +33115,9 @@ SLPM-62316:
   name-en: "Table Mahjong [Superlite 2000 Series]"
   region: "NTSC-J"
 SLPM-62317:
-  name: "SuperLite 2000 Vol. 3 - Igo"
+  name: SuperLite 2000囲碁
+  name-sort: SuperLite 2000いご
+  name-en: "SuperLite 2000 Vol. 3 - Igo"
   region: "NTSC-J"
 SLPM-62318:
   name: トゥエルブスタッグ
@@ -33030,20 +33126,20 @@ SLPM-62318:
   region: "NTSC-J"
 SLPM-62319:
   name: 三國志VIII with パワーアップキット
-  name-sort: さんごくしVIII with ぱわーあっぷきっと
+  name-sort: さんごくし8 with ぱわーあっぷきっと
   name-en: "Romance of the Three Kingdoms VIII"
   region: "NTSC-J"
 SLPM-62320:
   name: "2003-nen Kaimaku - Ganbare Kyuukai-ou - Iwayuru Pro Yakyuu desu ne"
   region: "NTSC-J"
 SLPM-62321:
-  name: ロボコップ～新たなる危機～
-  name-sort: ろぼこっぷ～あらたなるきき～
+  name: ロボコップ〜新たなる危機〜
+  name-sort: ろぼこっぷ あらたなるきき
   name-en: "Robocop"
   region: "NTSC-J"
 SLPM-62322:
   name: ザ・コンビニ3 〜あの町を独占せよ〜
-  name-sort: ざ・こんびに3 〜あのまちをどくせんせよ〜
+  name-sort: ざ こんびに3 あのまちをどくせんせよ
   name-en: "Conveni 3, The - Ano Machi o Dokusen seyo"
   region: "NTSC-J"
 SLPM-62323:
@@ -33061,17 +33157,17 @@ SLPM-62325:
   region: "NTSC-J"
 SLPM-62326:
   name: G-taste麻雀 フィギュア同梱スペシャル版
-  name-sort: G-tasteまーじゃん ふぃぎゅあどうこんすぺしゃるばん
+  name-sort: じーていすとまーじゃん ふぃぎゅあどうこんすぺしゃるばん
   name-en: "G-Taste Mahjong [Limited Edition]"
   region: "NTSC-J"
 SLPM-62327:
   name: G-taste麻雀
-  name-sort: G-tasteまーじゃん
+  name-sort: じーていすとまーじゃん
   name-en: "G-Taste Mahjong"
   region: "NTSC-J"
 SLPM-62328:
-  name: SIMPLE2000シリーズVol.27 THEプロ野球 ～2003ペナントレース～
-  name-sort: SIMPLE2000しりーずVol.27 THEぷろやきゅう ～2003ぺなんとれーす～
+  name: SIMPLE2000シリーズVol.27 THEプロ野球 〜2003ペナントレース〜
+  name-sort: SIMPLE2000しりーずVol.27 THEぷろやきゅう 2003ぺなんとれーす
   name-en: "Simple 2000 Series Vol. 27 - The Pro Yakyuu 2003 Pennant Race"
   region: "NTSC-J"
 SLPM-62329:
@@ -33090,18 +33186,18 @@ SLPM-62333:
   name: "PlayOnline Viewer - Tetra Master & Janhourou"
   region: "NTSC-J"
 SLPM-62334:
-  name: SIMPLE2000シリーズVol.29 THE恋愛ボードゲーム ～青春18ラヂオ～
-  name-sort: SIMPLE2000しりーずVol.29 THEれんあいぼーどげーむ ～せいしゅん18らぢお～
+  name: SIMPLE2000シリーズVol.29 THE恋愛ボードゲーム 〜青春18ラヂオ〜
+  name-sort: SIMPLE2000しりーずVol.29 THEれんあいぼーどげーむ せいしゅん18らじお
   name-en: "Simple 2000 Series Vol. 29 - The Renai Board Game"
   region: "NTSC-J"
 SLPM-62335:
-  name: SIMPLE2000シリーズVol.28 THE武士道～辻斬一代～
-  name-sort: SIMPLE2000しりーずVol.28 THEぶしどう～つじぎりいちだい～
+  name: SIMPLE2000シリーズVol.28 THE武士道〜辻斬一代〜
+  name-sort: SIMPLE2000しりーずVol.28 THEぶしどう つじぎりいちだい
   name-en: "Simple 2000 Series Vol. 28 - The Bushido - Tsujigiri Ichi-dai"
   region: "NTSC-J"
 SLPM-62336:
   name: SIMPLE2000シリーズ Vol.44 THE はじめてのRPG〜伝説の継承者〜
-  name-sort: SIMPLE2000しりーず Vol.44 THE はじめてのRPG〜でんせつのけいしょうしゃ〜
+  name-sort: SIMPLE2000しりーず Vol.44 THE はじめてのRPG でんせつのけいしょうしゃ
   name-en: "Simple 2000 Series Vol. 44 - The Hajimete no RPG - Densetsu no Keishousha"
   region: "NTSC-J"
   compat: 5
@@ -33117,7 +33213,7 @@ SLPM-62338:
   region: "NTSC-J"
 SLPM-62339:
   name: 機甲兵団J-PHOENIX2 序章編
-  name-sort: きこうへいだんJ-PHOENIX2 じょしょうへん
+  name-sort: きこうへいだん じぇいふぇにっくす2 じょしょうへん
   name-en: "Kikou Heidan J-Phoenix 2 - Joshou-hen"
   region: "NTSC-J"
 SLPM-62340:
@@ -33139,8 +33235,8 @@ SLPM-62342:
   gameFixes:
     - InstantDMAHack # Fixes bad ring/UI textures.
 SLPM-62343:
-  name: SIMPLE2000シリーズVol.34 THE恋愛ホラーアドベンチャー～漂流少女～
-  name-sort: SIMPLE2000しりーずVol.34 THEれんあいほらーあどべんちゃー～ひょうりゅうしょうじょ～
+  name: SIMPLE2000シリーズVol.34 THE恋愛ホラーアドベンチャー〜漂流少女〜
+  name-sort: SIMPLE2000しりーずVol.34 THEれんあいほらーあどべんちゃー〜ひょうりゅうしょうじょ〜
   name-en: "Simple 2000 Series Vol. 34 - The Renai Horror Adventure - Hyouryuu Shoujo"
   region: "NTSC-J"
 SLPM-62344:
@@ -33166,9 +33262,9 @@ SLPM-62346:
     textureInsideRT: 1 # Fixes rainbow lighting for some areas.
     getSkipCount: "GSC_BlueTongueGames" # Mipmap rendering on CPU.
 SLPM-62348:
-  name: IFコレクション　THE MECHSMITH
-  name-sort: IFこれくしょん　THE MECHSMITH
-  name-en: "Mechsmith, The - Rum"
+  name: THE MECHSMITH [IFコレクション]
+  name-sort: THE MECHSMITH [IFこれくしょん]
+  name-en: "Mechsmith, The"
   region: "NTSC-J"
 SLPM-62349:
   name: WELCOME TO UNIVERSAL STUDIOS JAPAN(TM)
@@ -33238,7 +33334,7 @@ SLPM-62364:
     - XGKickHack # Fixes black and white vehicle previews.
 SLPM-62365:
   name: カルディナル アーク 〜混沌の封札〜
-  name-sort: かるでぃなる あーく 〜こんとんのふうさつ〜
+  name-sort: かるでぃなる あーく こんとんのふうさつ
   name-en: "Cardinal Arc - Konton no Fuusatsu"
   region: "NTSC-J"
 SLPM-62366:
@@ -33289,7 +33385,7 @@ SLPM-62375:
   region: "NTSC-J"
 SLPM-62376:
   name: GetBackers奪還屋 奪還だョ!全員集合! [コナミ ザ ベスト]
-  name-sort: GetBackersだっかんや だっかんだょ!ぜんいんしゅうごう! [こなみ ざ べすと]
+  name-sort: GetBackersだっかんや だっかんだよ!ぜんいんしゅうごう!! [こなみ ざ べすと]
   name-en: "Get Backers - All Members Gather [Konami The Best]"
   region: "NTSC-J"
 SLPM-62377:
@@ -33299,22 +33395,22 @@ SLPM-62377:
   region: "NTSC-J"
 SLPM-62378:
   name: 爆走コンボイ伝説 〜男花道アメリカ浪漫〜
-  name-sort: ばくそうこんぼいでんせつ 〜おとこはなみちあめりかろまん〜
+  name-sort: ばくそうこんぼいでんせつ おとこはなみちあめりかろまん
   name-en: "Bakusou Convoy Densetsu"
   region: "NTSC-J"
 SLPM-62379:
-  name: カラオケレボリュ-ション(J-POPベストVol.2)
-  name-sort: からおけれぼりゅ-しょん(J-POPべすとVol.2)
+  name: カラオケレボリューション (J-POPベストVol.2)
+  name-sort: からおけれぼりゅーしょん J-POPべすとVol.2
   name-en: "Karaoke Revolution - J-Pop Vol.2"
   region: "NTSC-J"
 SLPM-62380:
-  name: カラオケレボリューション(JーPOPベストVol.3)
-  name-sort: からおけれぼりゅーしょん(JーPOPべすとVol.3)
+  name: カラオケレボリューション (J-POPベストVol.3)
+  name-sort: からおけれぼりゅーしょん J-POPべすとVol.3
   name-en: "Karaoke Revolution - J-Pop Vol.3"
   region: "NTSC-J"
 SLPM-62381:
-  name: カラオケレボリューション(J-POPベストVol.4)
-  name-sort: からおけれぼりゅーしょん(J-POPべすとVol.4)
+  name: カラオケレボリューション (J-POPベストVol.4)
+  name-sort: からおけれぼりゅーしょん J-POPべすとVol.4
   name-en: "Karaoke Revolution - J-Pop Vol.4"
   region: "NTSC-J"
 SLPM-62382:
@@ -33350,12 +33446,12 @@ SLPM-62388:
   region: "NTSC-J"
 SLPM-62389:
   name: SuperLite 2000釣り　ビッグバス 〜バス釣り完全攻略〜
-  name-sort: SuperLite 2000つり　びっぐばす 〜ばすづりかんぜんこうりゃく〜
+  name-sort: SuperLite 2000つり びっぐばす ばすづりかんぜんこうりゃく
   name-en: "Big Bass - Bass Tsuri Kanzen Kouryaku [SuperLite 2000 Series]"
   region: "NTSC-J"
 SLPM-62390:
   name: 一撃殺虫!!ホイホイさん 限定版
-  name-sort: いちげきさっちゅう!!ほいほいさん げんていばん
+  name-sort: いちげきさっちゅう!!ほいほいさん [げんていばん]
   name-en: "Ichigeki Sacchuu! HoiHoi-san [Limited Edition]"
   region: "NTSC-J"
 SLPM-62391:
@@ -33369,7 +33465,7 @@ SLPM-62392:
   name-en: "G1 Jockey 3 2003"
   region: "NTSC-J"
 SLPM-62393:
-  name: "GI Jockey 3 2003 [Premium Pack]"
+  name: "G1 Jockey 3 2003 [Premium Pack]"
   region: "NTSC-J"
 SLPM-62394:
   name: Power Smash 2 SEGA THE BEST 2800
@@ -33383,7 +33479,7 @@ SLPM-62394:
     trilinearFiltering: 1
 SLPM-62395:
   name: SIMPLE2000シリーズVol.37 THEシューティング 〜ダブル紫炎龍〜
-  name-sort: SIMPLE2000しりーずVol.37 THEしゅーてぃんぐ 〜だぶるしえんりゅう〜
+  name-sort: SIMPLE2000しりーずVol.37 THEしゅーてぃんぐ だぶるしえんりゅう
   name-en: "Simple 2000 Series Vol. 37 - The Shooting - Double Shienryu"
   region: "NTSC-J"
   compat: 5
@@ -33394,7 +33490,7 @@ SLPM-62396:
   region: "NTSC-J"
 SLPM-62397:
   name: SIMPLE2000本格思考シリーズVol.5 THE棋力検定〜楽しく学べる囲碁入門〜
-  name-sort: SIMPLE2000ほんかくしこうしりーずVol.5 THEきりょくけんてい〜たのしくまなべるいごにゅうもん〜
+  name-sort: SIMPLE2000ほんかくしこうしりーずVol.5 THEきりょくけんてい たのしくまなべるいごにゅうもん
   name-en: "Simple 2000 Honkaku Shikou Series Vol. 5 - Kiryoku Kentei"
   region: "NTSC-J"
 SLPM-62398:
@@ -33405,7 +33501,7 @@ SLPM-62399:
   region: "NTSC-J"
 SLPM-62400:
   name: SEGA AGES 2500 シリーズ Vol.12 ぷよぷよ通 パーフェクト・セット
-  name-sort: SEGA AGES 2500 しりーず Vol.12 ぷよぷよつう ぱーふぇくと・せっと
+  name-sort: SEGA AGES 2500 しりーず Vol.12 ぷよぷよつう ぱーふぇくと せっと
   name-en: "Sega Ages 2500 Series Vol.12 - Puyo Puyo Tsu Perfect Set"
   region: "NTSC-J"
 SLPM-62401:
@@ -33415,7 +33511,7 @@ SLPM-62401:
   region: "NTSC-J"
 SLPM-62403:
   name: 超兄貴 〜聖なるプロテイン伝説〜
-  name-sort: ちょうあにき 〜せいなるぷろていんでんせつ〜
+  name-sort: ちょうあにき せいなるぷろていんでんせつ
   name-en: "Chou Aniki - Seinaru Protein Densetsu"
   region: "NTSC-J"
   compat: 5
@@ -33429,7 +33525,7 @@ SLPM-62405:
   region: "NTSC-J"
 SLPM-62406:
   name: 鋼鉄の咆哮 〜ウォーシップコマンダー〜 KOEI The BEST
-  name-sort: くろがねのほうこう 〜うぉーしっぷこまんだー〜 KOEI The BEST
+  name-sort: くろがねのほうこう うぉーしっぷこまんだー KOEI The BEST
   name-en: "Kurogane no Houkou - Warship Commander [Koei The Best]"
   region: "NTSC-J"
 SLPM-62407:
@@ -33441,12 +33537,12 @@ SLPM-62407:
     preloadFrameData: 1 # Fixes missing text.
 SLPM-62408:
   name: ハリー・ポッター クィディッチ ワールドカップ
-  name-sort: はりー・ぽったー くぃでぃっち わーるどかっぷ
+  name-sort: はりーぽったー くぃでぃっち わーるどかっぷ
   name-en: "Harry Potter - Quidditch World Cup"
   region: "NTSC-J"
 SLPM-62409:
   name: ウィザードリィ エンパイアIII 〜覇王の系譜〜
-  name-sort: うぃざーどりぃ えんぱいあIII 〜はおうのけいふ〜
+  name-sort: うぃざーどりぃ えんぱいあIII はおうのけいふ
   name-en: "Wizardry Empire III - Ancestry of the Emperor"
   region: "NTSC-J"
 SLPM-62410:
@@ -33476,18 +33572,18 @@ SLPM-62414:
   region: "NTSC-J"
 SLPM-62415:
   name: コーエー定番シリーズ　ジーワン ジョッキー２
-  name-sort: こーえーていばんしりーず　じーわん じょっきーに
+  name-sort: じーわん じょっきー2 [こーえーていばんしりーず]
   name-en: "G1 Jockey 2 [Koei Teiban Series]"
   region: "NTSC-J"
 SLPM-62416:
   name: 桃太郎電鉄12 西日本編もありまっせー!
   name-sort: ももたろうでんてつ12 にしにほんへんもありまっせー!
-  name-en: "Momotaro Densetsu XII - West Japan Hen"
+  name-en: "Momotarou Dentetsu XII - West Japan Hen"
   region: "NTSC-J"
 SLPM-62417:
   name: 魁!!クロマティ高校 これはひょっとしてゲームなのか?
   name-sort: さきがけ!!くろまてぃこうこう これはひょっとしてげーむなのか?
-  name-en: "Sakigake!! Cromatier High School - Kore wa Hyottoshite Game Nanoka! Hen"
+  name-en: "Sakigake!! Cromatier High School - Kore ha Hyottoshite Game Nanoka! Hen"
   region: "NTSC-J"
 SLPM-62418:
   name: ハドソンセレクションVOL.3 PC原人
@@ -33528,7 +33624,7 @@ SLPM-62425:
   compat: 5
 SLPM-62426:
   name: SIMPLE2000シリーズ Vol.42 異種格闘技 〜ボクシングVSキックVS空手VSプロレスVS柔術VS・・・〜
-  name-sort: SIMPLE2000しりーず Vol.42 いしゅかくとうぎ 〜ぼくしんぐVSきっくVSからてVSぷろれすVSじゅうじゅつVS・・・〜
+  name-sort: SIMPLE2000しりーず Vol.42 いしゅかくとうぎ ぼくしんぐVSきっくVSからてVSぷろれすVSじゅうじゅつVS・・・
   name-en: "Simple 2000 Series Vol. 42 - The Ishu Kakutou Waza"
   region: "NTSC-J"
 SLPM-62427:
@@ -33544,7 +33640,7 @@ SLPM-62428:
   region: "NTSC-J"
 SLPM-62429:
   name: SIMPLE2000シリーズ アルティメット Vol.15 ラブ★ピンポン
-  name-sort: SIMPLE2000しりーず あるてぃめっと Vol.15 らぶ★ぴんぽん
+  name-sort: SIMPLE2000しりーず あるてぃめっと Vol.15 らぶぴんぽん
   name-en: "Simple 2000 Series Ultimate Vol. 15 - Love - Ping Pong!"
   region: "NTSC-J"
 SLPM-62430:
@@ -33563,7 +33659,7 @@ SLPM-62432:
   compat: 5
 SLPM-62433:
   name: SEGA AGES 2500 シリーズ Vol.6 イチニのタントアールとボナンザブラザーズ。
-  name-sort: SEGA AGES 2500 しりーず Vol.6 いちにのたんとあーるとぼなんざぶらざーず。
+  name-sort: SEGA AGES 2500 しりーず Vol.6 いちにのたんとあーるとぼなんざぶらざーず
   name-en: "Sega Ages 2500 Series Vol.06 - Bonanza Brothers"
   region: "NTSC-J"
   compat: 5
@@ -33572,7 +33668,7 @@ SLPM-62435:
   region: "NTSC-J"
 SLPM-62437:
   name: すいすい Sweet 〜あまい恋のみつけ方〜
-  name-sort: すいすい Sweet 〜あまいこいのみつけかた〜
+  name-sort: すいすい すいーと あまいこいのみつけかた
   name-en: "Sui Sui Sweet - Amai Koi no Mitsuke-kata"
   region: "NTSC-J"
 SLPM-62438:
@@ -33587,7 +33683,7 @@ SLPM-62439:
   compat: 4
 SLPM-62440:
   name: グローランサーIII [Atlus Best Collection]
-  name-sort: ぐろーらんさーIII [Atlus Best Collection]
+  name-sort: ぐろーらんさー3 [Atlus Best Collection]
   name-en: "Growlanser III [Atlus The Best]"
   region: "NTSC-J"
   compat: 4
@@ -33640,7 +33736,7 @@ SLPM-62449:
     disableDepthSupport: 1 # Fixes shadow flicker.
 SLPM-62450:
   name: カラオケレボリューション 〜アニメソングコレクション〜
-  name-sort: からおけれぼりゅーしょん 〜あにめそんぐこれくしょん〜
+  name-sort: からおけれぼりゅーしょん あにめそんぐこれくしょん
   name-en: "Karaoke Revolution - Anime Song Selection"
   region: "NTSC-J"
 SLPM-62451:
@@ -33650,7 +33746,7 @@ SLPM-62451:
   region: "NTSC-J"
 SLPM-62453:
   name: 彩京べすと G-taste麻雀
-  name-sort: さいきょうべすと G-tasteまーじゃん
+  name-sort: さいきょうべすと じーていすとまーじゃん
   name-en: "G-Taste Mahjong"
   region: "NTSC-J"
 SLPM-62454:
@@ -33670,7 +33766,7 @@ SLPM-62456:
   region: "NTSC-J"
 SLPM-62457:
   name: カラオケレボリューション 〜Snow & Party〜
-  name-sort: からおけれぼりゅーしょん 〜Snow & Party〜
+  name-sort: からおけれぼりゅーしょん Snow & Party
   name-en: "Karaoke Revolution - Snow & Party"
   region: "NTSC-J"
 SLPM-62458:
@@ -33685,19 +33781,19 @@ SLPM-62459:
   region: "NTSC-J"
   compat: 5
 SLPM-62460:
-  name: SuperLite2000 シミュレーション 箱庭鉄道 ～ブルートレイン・特急編～
-  name-sort: SuperLite2000 しみゅれーしょん はこにわてつどう ～ぶるーとれいん・とっきゅうへん～
+  name: SuperLite2000 シミュレーション 箱庭鉄道 〜ブルートレイン・特急編〜
+  name-sort: SuperLite2000 しみゅれーしょん はこにわてつどう ぶるーとれいんとっきゅうへん
   name-en: "Kakoniwa Tetsudou - Blue Train Tokkyuuhen [SuperLite 2000 Series]"
   region: "NTSC-J"
 SLPM-62461:
-  name: 式神の城II
-  name-sort: しきがみのしろII
+  name: 式神の城II(通常版)
+  name-sort: しきがみのしろ2
   name-en: "Shikigami no Shiro II"
   region: "NTSC-J"
   compat: 5
 SLPM-62462:
   name: グラディウスV
-  name-sort: ぐらでぃうすV
+  name-sort: ぐらでぃうす5
   name-en: "Gradius V"
   region: "NTSC-J"
   compat: 5
@@ -33708,7 +33804,7 @@ SLPM-62463:
   region: "NTSC-J"
 SLPM-62464:
   name: pop’n対戦ぱずるだまONLINE
-  name-sort: pop’nたいせんぱずるだまONLINE
+  name-sort: ぽっぷんたいせんぱずるだまONLINE
   name-en: "pop'n Taisen Pazurudama Online"
   region: "NTSC-J"
   compat: 5
@@ -33725,7 +33821,7 @@ SLPM-62466:
   compat: 5
 SLPM-62467:
   name: SIMPLE2000シリーズ アルティメットVol.18 ラブ★エアロビ
-  name-sort: SIMPLE2000しりーず あるてぃめっとVol.18 らぶ★えあろび
+  name-sort: SIMPLE2000しりーず あるてぃめっとVol.18 らぶえあろび
   name-en: "Simple 2000 Series Ultimate Vol. 18 - Love - Aerobics"
   region: "NTSC-J"
   compat: 5
@@ -33736,7 +33832,7 @@ SLPM-62468:
   region: "NTSC-J"
 SLPM-62469:
   name: GUNBIRD 1＆2
-  name-sort: GUNBIRD 1＆2
+  name-sort: GUNBIRD 1&2
   name-en: "Gunbird 1&2"
   region: "NTSC-J"
   compat: 5
@@ -33759,7 +33855,7 @@ SLPM-62472:
   region: "NTSC-J"
 SLPM-62473:
   name: 信長の野望 嵐世紀 [KOEI The Best]
-  name-sort: のぶながのやぼう あらしせいき [KOEI The Best]
+  name-sort: のぶながのやぼう らんせいき [KOEI The Best]
   name-en: "Nobunaga no Yabou - Ranseiki [Koei The Best]"
   region: "NTSC-J"
 SLPM-62474:
@@ -33770,7 +33866,7 @@ SLPM-62474:
 SLPM-62475:
   name: 桃太郎電鉄11 ハドソン・ザ・ベスト
   name-sort: ももたろうでんてつ11 はどそん・ざ・べすと
-  name-en: "Momotaro Densetsu XI [Hudson The Best]"
+  name-en: "Momotarou Dentetsu XI [Hudson The Best]"
   region: "NTSC-J"
 SLPM-62476:
   name: GetBackers奪還屋 裏新宿最強バトル
@@ -33780,7 +33876,7 @@ SLPM-62476:
 SLPM-62477:
   name: SIMPLE2000シリーズ Vol.47 THE 合戦 関が原
   name-sort: SIMPLE2000しりーず Vol.47 THE かっせん せきがはら
-  name-en: "Simple 2000 Series Vol. 47 - The Gassen Sekigahara"
+  name-en: "Simple 2000 Series Vol. 47 - The Kassen Sekigahara"
   region: "NTSC-J"
 SLPM-62478:
   name: ボンバーマンランドシリーズ ボンバーマンカートDX
@@ -33809,8 +33905,8 @@ SLPM-62482:
   name-en: "Pachinko Slot Tokodensho - Inoki Festival"
   region: "NTSC-J"
 SLPM-62483:
-  name: SIMPLE2000シリーズ Vol.48 THE タクシー ～運転手は君だ～
-  name-sort: SIMPLE2000しりーず Vol.48 THE たくしー ～うんてんしゅはきみだ～
+  name: SIMPLE2000シリーズ Vol.48 THE タクシー 〜運転手は君だ〜
+  name-sort: SIMPLE2000しりーず Vol.48 THE たくしー うんてんしゅはきみだ
   name-en: "Simple 2000 Series Vol. 48 - The Taxi - Untenshu ha Kimi da"
   region: "NTSC-J"
   gsHWFixes:
@@ -33825,13 +33921,13 @@ SLPM-62484:
   name-en: "Simple 2000 Series Vol. 50 - The Daibijin"
   region: "NTSC-J"
 SLPM-62485:
-  name: SIMPLE2000シリーズVol.49 THE ドッヂボール ～World Champion Dodge Baller〜～
-  name-sort: SIMPLE2000しりーずVol.49 THE どっぢぼーる ～World Champion Dodge Baller〜～
+  name: SIMPLE2000シリーズVol.49 THE ドッヂボール 〜World Champion Dodge Baller〜〜
+  name-sort: SIMPLE2000しりーずVol.49 THE どっぢぼーる 〜World Champion Dodge Baller〜〜
   name-en: "Simple 2000 Series Vol. 49 - The World Champ Dodge Baller"
   region: "NTSC-J"
 SLPM-62486:
-  name: 超最速!族車キングBU～仏恥義理伝説2～
-  name-sort: ちょうさいそく!ぞくしゃきんぐBU～ふつはじぎりでんせつ2～
+  name: 超最速!族車キングBU〜仏恥義理伝説2〜
+  name-sort: ちょうさいそく ぞくしゃきんぐBU ぶっちぎりでんせつ2
   name-en: "Chou Saisoku! Zokusha King B.U. [Simple Series DX]"
   region: "NTSC-J"
   gameFixes:
@@ -33854,7 +33950,7 @@ SLPM-62489:
   compat: 5
 SLPM-62490:
   name: 「ドラゴンクエストVIII」プレミアム映像ディスク
-  name-sort: 「どらごんくえすとVIII」ぷれみあむえいぞうでぃすく
+  name-sort: どらごんくえすと8 ぷれみあむえいぞうでぃすく
   name-en: "Dragon Quest VIII [Premium Disc]"
   region: "NTSC-J"
   gsHWFixes:
@@ -33889,8 +33985,8 @@ SLPM-62495:
   name-en: "Simple 2000 Series Vol. 53 - The Camera Kozo"
   region: "NTSC-J"
 SLPM-62496:
-  name: SIMPLE2000シリーズ Vol.52 THE 地球侵略群～スペースレイダース～
-  name-sort: SIMPLE2000しりーず Vol.52 THE ちきゅうしんりゃくぐん～すぺーすれいだーす～
+  name: SIMPLE2000シリーズ Vol.52 THE 地球侵略群〜スペースレイダース〜
+  name-sort: SIMPLE2000しりーず Vol.52 THE ちきゅうしんりゃくぐん すぺーすれいだーす
   name-en: "Simple 2000 Series Vol. 52 - The Space Raiders"
   region: "NTSC-J"
 SLPM-62497:
@@ -33903,7 +33999,7 @@ SLPM-62498:
   region: "NTSC-J"
 SLPM-62499:
   name: 勝負師伝説 哲也 DIGEST
-  name-sort: しょうぶしでんせつ てつや DIGEST
+  name-sort: ぎゃんぶらーでんせつ てつや DIGEST
   name-en: "Gambler Densetsu Tetsuya Digest"
   region: "NTSC-J"
 SLPM-62500:
@@ -33938,7 +34034,7 @@ SLPM-62505:
   region: "NTSC-J"
 SLPM-62506:
   name: ヴァンパイアパニック 限定版
-  name-sort: ゔぁんぱいあぱにっく げんていばん
+  name-sort: ゔぁんぱいあぱにっく [げんていばん]
   name-en: "Vampire Panic"
   region: "NTSC-J"
   compat: 5
@@ -33960,7 +34056,7 @@ SLPM-62510:
   compat: 5
 SLPM-62511:
   name: ヴィクトリー・ウイングス 〜ゼロ・パイロット シリーズ〜
-  name-sort: ゔぃくとりー・ういんぐす 〜ぜろ・ぱいろっと しりーず〜
+  name-sort: ゔぃくとりー・ういんぐす ぜろ ぱいろっと しりーず
   name-en: "Victory Wings - Zero Pilot Series"
   region: "NTSC-J"
 SLPM-62512:
@@ -33975,8 +34071,8 @@ SLPM-62512:
     textureInsideRT: 1 # Fixes rainbow lighting for some areas.
     getSkipCount: "GSC_BlueTongueGames" # Mipmap rendering on CPU.
 SLPM-62513:
-  name: ハリー・ポッターと秘密の部屋 [EA BEST HITS]
-  name-sort: はりー・ぽったーとひみつのへや [EA BEST HITS]
+  name: EA BEST HITS ハリー・ポッターと秘密の部屋
+  name-sort: はりーぽったーとひみつのへや [EA BEST HITS]
   name-en: "Harry Potter and the Chamber of Secrets [EA Best Hits]"
   region: "NTSC-J"
   gameFixes:
@@ -33987,13 +34083,13 @@ SLPM-62513:
     trilinearFiltering: 1 # Fixes blurry textures.
     cpuFramebufferConversion: 1 # Fixes right side of the screen from garbage textures.
 SLPM-62514:
-  name: シムピープル ～お茶の間劇場～ [EA BEST HITS]
-  name-sort: しむぴーぷる ～おちゃのまげきじょう～ [EA BEST HITS]
+  name: EA BEST HITS シムピープル 〜お茶の間劇場〜
+  name-sort: しむぴーぷる おちゃのまげきじょう [EA BEST HITS]
   name-en: "Sim People [EA Best Hits]"
   region: "NTSC-J"
 SLPM-62515:
   name: 彩京シューティングコレクション Vol.1 STRIKERS1945 I＆II
-  name-sort: さいきょうしゅーてぃんぐこれくしょん Vol.1 STRIKERS1945 I＆II
+  name-sort: さいきょうしゅーてぃんぐこれくしょん Vol.1 STRIKERS1945 I&II
   name-en: "Psikyo Shooting Collection Vol.1 - Strikers 1945 1-2"
   region: "NTSC-J"
   compat: 5
@@ -34006,17 +34102,17 @@ SLPM-62516:
   region: "NTSC-J"
 SLPM-62517:
   name: WinningPost 5 [KOEI The Best]
-  name-sort: WinningPost 5 [KOEI The Best]
+  name-sort: ういにんぐぽすと5 [KOEI The Best]
   name-en: "Winning Post 5 [Koei The Best]"
   region: "NTSC-J"
 SLPM-62518:
   name: 提督の決断IV [KOEI The Best]
-  name-sort: ていとくのけつだんIV [KOEI The Best]
+  name-sort: ていとくのけつだん4 [KOEI The Best]
   name-en: "Teitoku no Ketsudan IV [Koei the Best]"
   region: "NTSC-J"
 SLPM-62519:
   name: 三國志VIII [KOEI The Best]
-  name-sort: さんごくしVIII [KOEI The Best]
+  name-sort: さんごくし8 [KOEI The Best]
   name-en: "Sangokushi VIII [Koei The Best]"
   region: "NTSC-J"
 SLPM-62520:
@@ -34031,14 +34127,14 @@ SLPM-62523:
   name: "Shikigami no Shiro [Taito The Best]"
   region: "NTSC-J"
 SLPM-62524:
-  name: SIMPLE2000シリーズ Vol.59 THE 宇宙人と話そう!～うちゅ～じんってなぁに?～
-  name-sort: SIMPLE2000しりーず Vol.59 THE うちゅうじんとはなそう!～うちゅ～じんってなぁに?～
-  name-en: "Simple 2000 Series Vol. 59 - The Uchyujin to Hanashi Sou!"
+  name: SIMPLE2000シリーズ Vol.59 THE 宇宙人と話そう!〜うちゅ〜じんってなぁに?〜
+  name-sort: SIMPLE2000しりーず Vol.59 THE うちゅうじんとはなそう! うちゅーじんってなぁに?
+  name-en: "Simple 2000 Series Vol. 59 - The Uchyujin to Hanasou!"
   region: "NTSC-J"
   compat: 5
 SLPM-62525:
   name: SIMPLE2000シリーズ Vol.61 THE お姉チャンバラ
-  name-sort: SIMPLE2000しりーず Vol.61 THE おあねちゃんばら
+  name-sort: SIMPLE2000しりーず Vol.61 THE おねえちゃんばら
   name-en: "Simple 2000 Series Vol. 61 - The OneeChanBara"
   region: "NTSC-J"
   compat: 5
@@ -34056,22 +34152,22 @@ SLPM-62528:
   region: "NTSC-J"
 SLPM-62529:
   name: カラオケレボリューション☆家族アイドル化宣言☆
-  name-sort: からおけれぼりゅーしょん☆かぞくあいどるかせんげん☆
+  name-sort: からおけれぼりゅーしょん かぞくあいどるかせんげん
   name-en: "Karaoke Revolution - Kazoku Idol Sengen"
   region: "NTSC-J"
 SLPM-62530:
-  name: グラディウスIII＆IV〜復活の神話〜 [コナミ殿堂セレクション]
-  name-sort: ぐらでぃうすIII＆IV〜ふっかつのしんわ〜 [こなみでんどうせれくしょん]
+  name: グラディウスIII＆IV〜復活の神話〜(コナミ殿堂セレクション)
+  name-sort: ぐらでぃうす3&4 ふっかつのしんわ [こなみでんどうせれくしょん]
   name-en: "Gradius III & IV [Konami Dendou Collection]"
   region: "NTSC-J"
 SLPM-62531:
-  name: 麻雀やろうぜ!2 [コナミ殿堂セレクション]
+  name: 麻雀やろうぜ!2(コナミ殿堂セレクション)
   name-sort: まーじゃんやろうぜ!2 [こなみでんどうせれくしょん]
   name-en: "Mahjong Yarouze! 2 [Konami Palace Selection]"
   region: "NTSC-J"
 SLPM-62532:
-  name: イースIII ～ワンダラーズ フロム イース～
-  name-sort: いーすIII ～わんだらーず ふろむ いーす～
+  name: イースIII 〜ワンダラーズ フロム イース〜
+  name-sort: いーす3 わんだらーず ふろむ いーす
   name-en: "Ys III - Wanderers from Ys [Limited Edition]"
   region: "NTSC-J"
   compat: 5
@@ -34081,7 +34177,7 @@ SLPM-62533:
 SLPM-62534:
   name: SIMPLE2000シリーズ Vol.63 もぎたて水着!女まみれの THE 水泳大会
   name-sort: SIMPLE2000しりーず Vol.63 もぎたてみずぎ!おんなまみれの THE すいえいたいかい
-  name-en: "Simple 2000 Series Vol. 63 - The Suieitaikai"
+  name-en: "Simple 2000 Series Vol. 63 - Mogitate Mizugi! Onna Mamire no The Suieitaikai"
   region: "NTSC-J"
   compat: 5
 SLPM-62536:
@@ -34090,13 +34186,13 @@ SLPM-62536:
   name-en: "G1 Jockey 3 [Koei The Best]"
   region: "NTSC-J"
 SLPM-62537:
-  name: スター・ウォーズ スターファイター [EA BEST HITS]
-  name-sort: すたー・うぉーず すたーふぁいたー [EA BEST HITS]
+  name: EA BEST HITS スター・ウォーズ スターファイター
+  name-sort: すたーうぉーず すたーふぁいたー [EA BEST HITS]
   name-en: "Star Wars - Starfighter [EA Best Hits]"
   region: "NTSC-J"
 SLPM-62538:
   name: 強襲機甲部隊〜攻撃ヘリコプター戦記〜
-  name-sort: きょうしゅうきこうぶたい〜こうげきへりこぷたーせんき〜
+  name-sort: きょうしゅうきこうぶたい こうげきへりこぷたーせんき
   name-en: "Kyoushuu Kidou Butai - Kougeki Helicopter Senki"
   region: "NTSC-J"
 SLPM-62539:
@@ -34116,7 +34212,7 @@ SLPM-62541:
   region: "NTSC-J"
 SLPM-62542:
   name: SIMPLE2000シリーズ アルティメット Vol.20 ラブ★マージャン!2
-  name-sort: SIMPLE2000しりーず あるてぃめっと Vol.20 らぶ★まーじゃん!2
+  name-sort: SIMPLE2000しりーず あるてぃめっと Vol.20 らぶまーじゃん!2
   name-en: "Simple 2000 Series Vol. 20 - The Love Mahjong 2"
   region: "NTSC-J"
 SLPM-62543:
@@ -34136,8 +34232,8 @@ SLPM-62545:
   region: "NTSC-J"
   compat: 5
 SLPM-62546:
-  name: 三國志VII [コーエー定番シリーズ]
-  name-sort: さんごくしVII [こーえーていばんしりーず]
+  name: コーエー定番シリーズ 三國志VII
+  name-sort: さんごくし7 [こーえーていばんしりーず]
   name-en: "Sangokushi VII [Koei Collection Series]"
   region: "NTSC-J"
 SLPM-62547:
@@ -34190,13 +34286,13 @@ SLPM-62553:
   compat: 5
 SLPM-62554:
   name: セガ スーパースターズ“EyeToy”カメラ同梱版
-  name-sort: せが すーぱーすたーず“EyeToy”かめらどうこんばん
+  name-sort: せが すーぱーすたーず あいとーいかめらどうこんばん
   name-en: "EyeToy - Sega Superstars [with Camera]"
   region: "NTSC-J"
 SLPM-62555:
   name: 桃太郎電鉄USA
   name-sort: ももたろうでんてつUSA
-  name-en: "Momotaro Densetsu"
+  name-en: "Momotarou Dentetsu USA"
   region: "NTSC-J"
 SLPM-62556:
   name: SIMPLE2000シリーズ Vol.66 THE パーティー右脳クイズ
@@ -34220,7 +34316,7 @@ SLPM-62559:
   region: "NTSC-J"
 SLPM-62560:
   name: グローランサーIV Return
-  name-sort: ぐろーらんさーIV Return
+  name-sort: ぐろーらんさー4 Return
   name-en: "Growlanser IV - Return"
   region: "NTSC-J"
 SLPM-62562:
@@ -34231,7 +34327,7 @@ SLPM-62562:
   compat: 5
 SLPM-62563:
   name: 彩京シューティングコレクション Vol.2 戦国エース＆戦国ブレード
-  name-sort: さいきょうしゅーてぃんぐこれくしょん Vol.2 せんごくえーす＆せんごくぶれーど
+  name-sort: さいきょうしゅーてぃんぐこれくしょん Vol.2 せんごくえーす&せんごくぶれーど
   name-en: "Psikyo Shooting Collection Vol.2 - Sengoku Ace & Sengoku Blade"
   region: "NTSC-J"
   compat: 5
@@ -34253,36 +34349,36 @@ SLPM-62566:
   name-en: "Typing of the Dead - Zombie Panic"
   region: "NTSC-J"
 SLPM-62567:
-  name: WIN BACK [コーエー定番シリーズ]
+  name: コーエー定番シリーズ WIN BACK
   name-sort: WIN BACK [こーえーていばんしりーず]
   name-en: "Winback [Koei Best Series]"
   region: "NTSC-J"
   clampModes:
     vuClampMode: 3 # Fixes missing 3D polygons when going ingame.
 SLPM-62568:
-  name: 真・三國無双 [コーエー定番シリーズ]
-  name-sort: しん・さんごくむそう [こーえーていばんしりーず]
+  name: コーエー定番シリーズ 真・三國無双
+  name-sort: しんさんごくむそう [こーえーていばんしりーず]
   name-en: "Shin Sangoku Musou [Koei The Best]"
   region: "NTSC-J"
 SLPM-62569:
   name: PC原人　ハドソン・ザ・ベスト
-  name-sort: PCげんじん　はどそん・ざ・べすと
+  name-sort: PCげんじん はどそん・ざ・べすと
   name-en: "PC Genjin [Hudson The Best]"
   region: "NTSC-J"
 SLPM-62570:
   name: 高橋名人の冒険島　ハドソン・ザ・ベスト
-  name-sort: たかはしめいじんのぼうけんじま　はどそん・ざ・べすと
+  name-sort: たかはしめいじんのぼうけんじま はどそん・ざ・べすと
   name-en: "Takahashi Meijin no Adventure Island [Hudson The Best]"
   region: "NTSC-J"
 SLPM-62571:
-  name: SIMPLE2000シリーズ アルティメット Vol.22 スタイリッシュ麻雀 〜兎-野生の闘牌- ＆ 兎-野生の闘牌 THE ARCADE- ダブルパック〜
-  name-sort: SIMPLE2000しりーず あるてぃめっと Vol.22 すたいりっしゅまーじゃん 〜うさぎ-やせいの闘牌- ＆ うさぎ-やせいの闘牌 THE ARCADE- だぶるぱっく〜
+  name: SIMPLE2000シリーズ アルティメット Vol.22 THE スタイリッシュ麻雀〜兎-野性の闘牌-＆兎-野性の闘牌 THE ARCADE- ダブルパック〜
+  name-sort: SIMPLE2000しりーず あるてぃめっと Vol.22 THE すたいりっしゅまーじゃん うさぎ やせいのとうはい うさぎ やせいのとうはい THE ARCADE だぶるぱっく
   name-en: "Simple 2000 Series Ultimate Vol. 22 - Stylish Mahjong"
   region: "NTSC-J"
   compat: 5
 SLPM-62572:
   name: ボボボーボ・ボーボボ 集まれ!!体感ボーボボ
-  name-sort: ぼぼぼーぼ・ぼーぼぼ あつまれ!!たいかんぼーぼぼ
+  name-sort: ぼぼぼーぼ ぼーぼぼ あつまれ たいかんぼーぼぼ
   name-en: "Boboboubo Boubobo - Atsumare!! Taikan Boubobo"
   region: "NTSC-J"
 SLPM-62573:
@@ -34290,7 +34386,7 @@ SLPM-62573:
   region: "NTSC-J"
 SLPM-62574:
   name: 勝負師伝説 哲也 DIGEST Athena Best Collection Vol.3
-  name-sort: しょうぶしでんせつ てつや DIGEST Athena Best Collection Vol.3
+  name-sort: ぎゃんぶらーでんせつ てつや DIGEST Athena Best Collection Vol.3
   name-en: "Gambler Densetsu Tetsuya Digest [Athena Best Collection Vol.3]"
   region: "NTSC-J"
 SLPM-62576:
@@ -34298,12 +34394,12 @@ SLPM-62576:
   region: "NTSC-J"
 SLPM-62577:
   name: 実戦パチスロ必勝法! 北斗の拳 Plus
-  name-sort: じっせんぱちすろひっしょうほう! ほくとのけん Plus
+  name-sort: じっせんぱちすろひっしょうほう ほくとのけん Plus
   name-en: "Jissen Pachi-Slot Hisshouhou! Hokuto no Ken Plus"
   region: "NTSC-J"
 SLPM-62578:
   name: バズロッド 〜フィッシングファンタジー
-  name-sort: ばずろっど 〜ふぃっしんぐふぁんたじー
+  name-sort: ばずろっど ふぃっしんぐふぁんたじー
   name-en: "Buzz Rod Fishing Fantasy"
   region: "NTSC-J"
 SLPM-62579:
@@ -34333,7 +34429,7 @@ SLPM-62581:
         patch=1,EE,00301e08,word,0000948c
 SLPM-62582:
   name: スロッターUPコア6 爆炎打! 巨人の星II
-  name-sort: すろったーUPこあ6 爆炎だ! きょじんのほしII
+  name-sort: すろったーUPこあ6 ばくえんだ! きょじんのほし2
   name-en: "Slotter-Up Core 6"
   region: "NTSC-J"
 SLPM-62583:
@@ -34358,13 +34454,13 @@ SLPM-62586:
   region: "NTSC-J"
 SLPM-62588:
   name: SIMPLE2000シリーズ Vol.73 THE 西遊闘猿伝
-  name-sort: SIMPLE2000しりーず Vol.73 THE せいゆう闘猿でん
-  name-en: "Simple 2000 Series Vol. 73 - The Saiyuki Saruden"
+  name-sort: SIMPLE2000しりーず Vol.73 THE さいゆうとうえんでん
+  name-en: "Simple 2000 Series Vol. 73 - The Saiyuu Touenden"
   region: "NTSC-J"
 SLPM-62589:
   name: SIMPLE2000シリーズ Vol.72 THE 任侠
   name-sort: SIMPLE2000しりーず Vol.72 THE にんきょう
-  name-en: "Simple 2000 Series Vol. 72 - Ninhaza"
+  name-en: "Simple 2000 Series Vol. 72 - Ninkyou"
   region: "NTSC-J"
 SLPM-62590:
   name: ジーワンジョッキー3 2005年度版 プレミアムパック
@@ -34374,18 +34470,18 @@ SLPM-62590:
 SLPM-62591:
   name: ジーワンジョッキー3 2005年度版
   name-sort: じーわんじょっきー3 2005ねんどばん
-  name-en: "GI Jockey 3 2005"
+  name-en: "G1 Jockey 3 2005"
   region: "NTSC-J"
 SLPM-62593:
   name: 彩京シューティングコレクション Vol.3 ソルディバイド＆ドラゴンブレイズ
-  name-sort: さいきょうしゅーてぃんぐこれくしょん Vol.3 そるでぃばいど＆どらごんぶれいず
+  name-sort: さいきょうしゅーてぃんぐこれくしょん Vol.3 そるでぃばいど&どらごんぶれいず
   name-en: "Psikyo Shooting Collection Vol.3 - Sol Divide & Dragon Blaze"
   region: "NTSC-J"
   compat: 5
 SLPM-62594:
   name: 彩京べすと 対戦ホットギミック コスプレ雀
   name-sort: さいきょうべすと たいせんほっとぎみっく こすぷれじゃん
-  name-en: "Hot Gimmick Cosplay Mahjong - Pure"
+  name-en: "Battle Hot Gimmick Cosplay Mahjong [Psikyo Best]"
   region: "NTSC-J"
 SLPM-62595:
   name: チョロQ HG3 THE BEST タカラモノ
@@ -34407,18 +34503,18 @@ SLPM-62598:
   region: "NTSC-J"
 SLPM-62599:
   name: ボンバーマンカートDX ハドソン・ザ・ベスト
-  name-sort: ぼんばーまんかーとDX はどそん・ざ・べすと
+  name-sort: ぼんばーまんかーとDX はどそん ざ べすと
   name-en: "Bomberman Kart DX"
   region: "NTSC-J"
 SLPM-62600:
   name: SIMPLE2000シリーズ Vol.75 THE 特ダネ 〜日本全国スクープ列島〜
-  name-sort: SIMPLE2000しりーず Vol.75 THE とくだね 〜にほんぜんこくすくーぷれっとう〜
+  name-sort: SIMPLE2000しりーず Vol.75 THE とくだね にほんぜんこくすくーぷれっとう
   name-en: "Simple 2000 Series Vol. 75 - The Tokudane"
   region: "NTSC-J"
 SLPM-62601:
   name: ザ・コンビニ3 〜あの町を独占せよ〜 HAMSTER the Best
-  name-sort: ざ・こんびに3 〜あのまちをどくせんせよ〜 HAMSTER the Best
-  name-en: "Conveti 3, The [Hamster The Best]"
+  name-sort: ざ こんびに3 あのまちをどくせんせよ HAMSTER the Best
+  name-en: "Conveni 3, The [Hamster The Best]"
   region: "NTSC-J"
 SLPM-62602:
   name: 翼神 ギガウイングジェネレーションズ
@@ -34460,7 +34556,7 @@ SLPM-62608:
   region: "NTSC-J"
 SLPM-62609:
   name: MYCOM BEST 麻雀覇王 段級バトル
-  name-sort: MYCOM BEST まーじゃんはおう だんきゅうばとる
+  name-sort: まーじゃんはおう だんきゅうばとる [MYCOM BEST]
   name-en: "Majhong Haoh - Shinken Battle [Mycom The Best]"
   region: "NTSC-J"
 SLPM-62610:
@@ -34486,7 +34582,7 @@ SLPM-62613:
   region: "NTSC-J"
   compat: 5
 SLPM-62614:
-  name: ホースブレーカー [コーエー定番シリーズ]
+  name: コーエー定番シリーズ ホースブレーカー
   name-sort: ほーすぶれーかー [こーえーていばんしりーず]
   name-en: "Horse Breaker [Koei Teiban Series]"
   region: "NTSC-J"
@@ -34497,7 +34593,7 @@ SLPM-62615:
   region: "NTSC-J"
 SLPM-62616:
   name: SIMPLE2000シリーズ Ultimate Vol.25 超最速!族車キングBUのBU 〜仏恥義理伝説2改〜
-  name-sort: SIMPLE2000しりーず Ultimate Vol.25 ちょうさいそく!ぞくしゃきんぐBUのBU 〜ふつはじぎりでんせつ2かい〜
+  name-sort: SIMPLE2000しりーず Ultimate Vol.25 ちょうさいそく!ぞくしゃきんぐBUのBU ぶっちぎりでんせつ2 かい
   name-en: "Simple 2000 Series Ultimate Vol. 25 - Chou-Saisoku! Zokusha King BU no BU"
   region: "NTSC-J"
 SLPM-62617:
@@ -34518,7 +34614,7 @@ SLPM-62620:
   region: "NTSC-J"
 SLPM-62621:
   name: グラディウスV [コナミ ザ ベスト]
-  name-sort: ぐらでぃうすV [こなみ ざ べすと]
+  name-sort: ぐらでぃうす5 [こなみ ざ べすと]
   name-en: "Gradius V [Konami The Best]"
   region: "NTSC-J"
 SLPM-62622:
@@ -34528,7 +34624,7 @@ SLPM-62622:
   region: "NTSC-J"
 SLPM-62623:
   name: エレメンタルジェレイド-纏え、翠風の剣-
-  name-sort: えれめんたるじぇれいど-まとえ、すいふうのつるぎ-
+  name-sort: えれめんたるじぇれいど まとえ すいふうのつるぎ
   name-en: "Elemental Gerad"
   region: "NTSC-J"
   compat: 5
@@ -34590,58 +34686,58 @@ SLPM-62632:
   region: "NTSC-J"
 SLPM-62633:
   name: SIMPLE2000シリーズ 2in1 Vol.2 THE バスフィッシング ＆ THE ボウリングHYPER [ディスク1/2]
-  name-sort: SIMPLE2000しりーず 2in1 Vol.2 THE ばすふぃっしんぐ ＆ THE ぼうりんぐHYPER [でぃすく1/2]
+  name-sort: SIMPLE2000しりーず 2in1 Vol.2 THE ばすふぃっしんぐ & THE ぼうりんぐHYPER [でぃすく1/2]
   name-en: "Simple 2000 Series 2-in-1 Vol. 2 - The Bass Fishing & The Bowling Hyper [Disc 1 of 2]"
   region: "NTSC-J"
 SLPM-62634:
   name: SIMPLE2000シリーズ 2in1 Vol.2 THE バスフィッシング ＆ THE ボウリングHYPER [ディスク2/2]
-  name-sort: SIMPLE2000しりーず 2in1 Vol.2 THE ばすふぃっしんぐ ＆ THE ぼうりんぐHYPER [でぃすく2/2]
+  name-sort: SIMPLE2000しりーず 2in1 Vol.2 THE ばすふぃっしんぐ & THE ぼうりんぐHYPER [でぃすく2/2]
   name-en: "Simple 2000 Series 2-in-1 Vol. 2 - The Bass Fishing & The Bowling Hyper [Disc 2 of 2]"
   region: "NTSC-J"
 SLPM-62635:
   name: SIMPLE2000シリーズ Ultimate Vol.26 ラブ★スマッシュ!5.1 〜テニスロボの反乱〜
-  name-sort: SIMPLE2000しりーず Ultimate Vol.26 らぶ★すまっしゅ!5.1 〜てにすろぼのはんらん〜
+  name-sort: SIMPLE2000しりーず Ultimate Vol.26 らぶすまっしゅ!5.1 〜てにすろぼのはんらん〜
   name-en: "Simple 2000 Series Ultimate Vol. 26 - Love - Smash! 5.1 - Tennis Robo no Gyakushuu"
   region: "NTSC-J"
   gameFixes:
     - XGKickHack # Fixes bad Geometry.
 SLPM-62636:
   name: SIMPLE2000シリーズ 2in1 Vol.1 THE テニス ＆ THE スノーボード [ディスク1/2]
-  name-sort: SIMPLE2000しりーず 2in1 Vol.1 THE てにす ＆ THE すのーぼーど [でぃすく1/2]
+  name-sort: SIMPLE2000しりーず 2in1 Vol.1 THE てにす & THE すのーぼーど [でぃすく1/2]
   name-en: "Simple 2000 Series 2-in-1 Vol. 1 - The Tennis & The Snowboard [Disc 1 of 2]"
   region: "NTSC-J"
   gameFixes:
     - XGKickHack # Fixes SPS and console spam (The Tennis).
 SLPM-62637:
   name: SIMPLE2000シリーズ 2in1 Vol.1 THE テニス ＆ THE スノーボード [ディスク2/2]
-  name-sort: SIMPLE2000しりーず 2in1 Vol.1 THE てにす ＆ THE すのーぼーど [でぃすく2/2]
+  name-sort: SIMPLE2000しりーず 2in1 Vol.1 THE てにす & THE すのーぼーど [でぃすく2/2]
   name-en: "Simple 2000 Series 2-in-1 Vol. 1 - The Tennis & The Snowboard [Disc 2 of 2]"
   region: "NTSC-J"
 SLPM-62638:
   name: SIMPLE2000シリーズ Vol.80 THE お姉チャンプルゥ 〜THE姉チャン特別編〜
-  name-sort: SIMPLE2000しりーず Vol.80 THE おあねちゃんぷるぅ 〜THEあねちゃんとくべつへん〜
+  name-sort: SIMPLE2000しりーず Vol.80 THE おねえちゃんぷるぅ 〜THEねえちゃんとくべつへん〜
   name-en: "Simple 2000 Series Vol. 80 - The OneeChanPuruu"
   region: "NTSC-J"
   gameFixes:
     - XGKickHack # Fixes characters clothing.
 SLPM-62639:
-  name: 麻雀大会III ミレニアムリーグ [コーエー定番シリーズ]
+  name: コーエー定番シリーズ 麻雀大会III ミレニアムリーグ
   name-sort: まーじゃんたいかいIII みれにあむりーぐ [こーえーていばんしりーず]
   name-en: "Mahjong Taikai III - Millennium League [Koei Selection Series]"
   region: "NTSC-J"
 SLPM-62640:
-  name: 太閤立志伝IV [コーエー定番シリーズ]
+  name: コーエー定番シリーズ 太閤立志伝IV
   name-sort: たいこうりっしでんIV [こーえーていばんしりーず]
   name-en: "Taikou Risshiden IV [Koei Selection Series]"
   region: "NTSC-J"
 SLPM-62641:
   name: 三國志VIII with パワーアップキット [KOEI The BEST]
-  name-sort: さんごくしVIII with ぱわーあっぷきっと [KOEI The BEST]
+  name-sort: さんごくし8 with ぱわーあっぷきっと [KOEI The BEST]
   name-en: "Sangokushi VIII [with Power-Up Kit] [Koei The Best]"
   region: "NTSC-J"
 SLPM-62642:
   name: 信長の野望・嵐世記 with パワーアップキット [KOEI The BEST]
-  name-sort: のぶながのやぼう・らんせいき with ぱわーあっぷきっと [KOEI The BEST]
+  name-sort: のぶながのやぼう らんせいき with ぱわーあっぷきっと [KOEI The BEST]
   name-en: "Nobunaga no Yabou - Ranseiki [with Power-Up Kit] [Koei The Best]"
   region: "NTSC-J"
 SLPM-62643:
@@ -34723,27 +34819,27 @@ SLPM-62661:
   region: "NTSC-J"
 SLPM-62662:
   name: SIMPLE2000シリーズ 2in1 Vol.5 THE シューティング〜ダブル紫炎龍〜 ＆ THE ヘリコプター [ディスク1/2]
-  name-sort: SIMPLE2000しりーず 2in1 Vol.5 THE しゅーてぃんぐ〜だぶるしえんりゅう〜 ＆ THE へりこぷたー [でぃすく1/2]
+  name-sort: SIMPLE2000しりーず 2in1 Vol.5 THE しゅーてぃんぐ〜だぶるしえんりゅう〜 & THE へりこぷたー [でぃすく1/2]
   name-en: "Simple 2000 Series 2-in-1 Vol. 5 - The Shooting & The Helicopter [Disc 1 of 2]"
   region: "NTSC-J"
 SLPM-62663:
   name: SIMPLE2000シリーズ 2in1 Vol.5 THE シューティング〜ダブル紫炎龍〜 ＆ THE ヘリコプター [ディスク2/2]
-  name-sort: SIMPLE2000しりーず 2in1 Vol.5 THE しゅーてぃんぐ〜だぶるしえんりゅう〜 ＆ THE へりこぷたー [でぃすく2/2]
+  name-sort: SIMPLE2000しりーず 2in1 Vol.5 THE しゅーてぃんぐ〜だぶるしえんりゅう〜 & THE へりこぷたー [でぃすく2/2]
   name-en: "Simple 2000 Series 2-in-1 Vol. 5 - The Shooting & The Helicopter [Disc 2 of 2]"
   region: "NTSC-J"
 SLPM-62664:
   name: SIMPLE2000シリーズ 2in1 Vol.4 THE 武士道 〜辻斬り一代〜 ＆ THE スナイパー2 〜悪夢の銃弾〜 [ディスク1/2]
-  name-sort: SIMPLE2000しりーず 2in1 Vol.4 THE ぶしどう 〜つじぎりいちだい〜 ＆ THE すないぱー2 〜あくむのじゅうだん〜 [でぃすく1/2]
+  name-sort: SIMPLE2000しりーず 2in1 Vol.4 THE ぶしどう 〜つじぎりいちだい〜 & THE すないぱー2 〜あくむのじゅうだん〜 [でぃすく1/2]
   name-en: "Simple 2000 Series 2-in-1 Vol. 4 - The Bushidou & The Sniper 2 [Disc 1 of 2]"
   region: "NTSC-J"
 SLPM-62665:
   name: SIMPLE2000シリーズ 2in1 Vol.4 THE 武士道 〜辻斬り一代〜 ＆ THE スナイパー2 〜悪夢の銃弾〜 [ディスク2/2]
-  name-sort: SIMPLE2000しりーず 2in1 Vol.4 THE ぶしどう 〜つじぎりいちだい〜 ＆ THE すないぱー2 〜あくむのじゅうだん〜 [でぃすく2/2]
+  name-sort: SIMPLE2000しりーず 2in1 Vol.4 THE ぶしどう 〜つじぎりいちだい〜 & THE すないぱー2 〜あくむのじゅうだん〜 [でぃすく2/2]
   name-en: "Simple 2000 Series 2-in-1 Vol. 4 - The Bushidou & The Sniper 2 [Disc 2 of 2]"
   region: "NTSC-J"
 SLPM-62666:
   name: SEGA AGES 2500シリーズ Vol.1 PHANTASY STAR generation:1 通常版
-  name-sort: SEGA AGES 2500しりーず Vol.1 PHANTASY STAR generation:1 つうじょうばん
+  name-sort: SEGA AGES 2500しりーず Vol.1 PHANTASY STAR generation:1 [つうじょうばん]
   name-en: "Sega Ages 2500 Series Vol.01 - Phantasy Star Generation 1"
   region: "NTSC-J"
 SLPM-62668:
@@ -34759,7 +34855,7 @@ SLPM-62670:
   region: "NTSC-J"
 SLPM-62671:
   name: SEGA AGES 2500シリーズ Vol.6 イチニのタントアールとボナンザブラザーズ。
-  name-sort: SEGA AGES 2500しりーず Vol.6 いちにのたんとあーるとぼなんざぶらざーず。
+  name-sort: SEGA AGES 2500しりーず Vol.6 いちにのたんとあーるとぼなんざぶらざーず
   name-en: "Sega Ages 2500 Series Vol.06 - Bonanza Bros. & Tant-R"
   region: "NTSC-J"
 SLPM-62672:
@@ -34776,7 +34872,7 @@ SLPM-62677:
   name-en: "Sega Ages 2500 Series Vol.15 - Decathlete Collection"
   region: "NTSC-J"
 SLPM-62678:
-  name: 鋼鉄の咆哮 〜ウォーシップコマンダー〜 [コーエー定番シリーズ]
+  name: コーエー定番シリーズ 鋼鉄の咆哮 〜ウォーシップコマンダー〜
   name-sort: くろがねのほうこう 〜うぉーしっぷこまんだー〜 [こーえーていばんしりーず]
   name-en: "Kurogane no Houkou - Warship Commander [Koei Selection Series]"
   region: "NTSC-J"
@@ -34791,8 +34887,8 @@ SLPM-62680:
   name-en: "Relakuma - Ojama Shitemasu 2"
   region: "NTSC-J"
 SLPM-62681:
-  name: 信長の野望・嵐世記 [コーエー定番シリーズ]
-  name-sort: のぶながのやぼう・らんせいき [こーえーていばんしりーず]
+  name: コーエー定番シリーズ 信長の野望・嵐世記
+  name-sort: のぶながのやぼう らんせいき [こーえーていばんしりーず]
   name-en: "Nobunaga no Yabou - Ranseiki [Koei Selection Series]"
   region: "NTSC-J"
 SLPM-62682:
@@ -34802,12 +34898,12 @@ SLPM-62682:
   region: "NTSC-J"
 SLPM-62683:
   name: MYCOM BEST 麻雀覇王 大会バトル
-  name-sort: MYCOM BEST まーじゃんはおう たいかいばとる
+  name-sort: まーじゃんはおう たいかいばとる [MYCOM BEST]
   name-en: "Mahjong Taikai Battle [Mycom The Best]"
   region: "NTSC-J"
 SLPM-62684:
   name: MYCOM BEST 東大将棋 定跡道場 完結編
-  name-sort: MYCOM BEST とうだいしょうぎ じょうせきどうじょう かんけつへん
+  name-sort: とうだいしょうぎ じょうせきどうじょう かんけつへん [MYCOM BEST]
   name-en: "Toudai Shogi - Jouseki Dojo Kanketsuhen [Mycom The Best]"
   region: "NTSC-J"
 SLPM-62685:
@@ -34846,7 +34942,7 @@ SLPM-62691:
   compat: 5
 SLPM-62692:
   name: SEGA AGES 2500シリーズ Vol.21 SDI ＆ カルテット 〜SEGA SYSTEM 16 COLLECTION〜
-  name-sort: SEGA AGES 2500しりーず Vol.21 SDI ＆ かるてっと 〜SEGA SYSTEM 16 COLLECTION〜
+  name-sort: SEGA AGES 2500しりーず Vol.21 SDI & かるてっと 〜SEGA SYSTEM 16 COLLECTION〜
   name-en: "Sega Ages 2500 Series Vol.21 - SDI & Quartet"
   region: "NTSC-J"
 SLPM-62693:
@@ -34870,7 +34966,7 @@ SLPM-62696:
   name-en: "Oretachi Geasen Zoku Sono - Yie Ar Kung-fu"
   region: "NTSC-J"
 SLPM-62697:
-  name: ジェネレーション オブ カオス ネクスト 〜失われし絆〜 [IFコレクション]
+  name: IFコレクション ジェネレーション オブ カオス ネクスト 〜失われし絆〜
   name-sort: じぇねれーしょん おぶ かおす ねくすと 〜うしなわれしきずな〜 [IFこれくしょん]
   name-en: "Generation of Chaos Next [Idea Factory Collection]"
   region: "NTSC-J"
@@ -34880,8 +34976,8 @@ SLPM-62698:
   name-en: "Ultimate Pro Pinball"
   region: "NTSC-J"
 SLPM-62699:
-  name: カルディナル アーク 〜混沌の封札〜 [IFコレクション]
-  name-sort: かるでぃなる あーく 〜こんとんのふうさつ〜 [IFこれくしょん]
+  name: IFコレクション カルディナル アーク 〜混沌の封札〜
+  name-sort: かるでぃなる あーく こんとんのふうさつ [IFこれくしょん]
   name-en: "Neverland Card War Cardinal Arc - Konton no Fuusatsu [Idea Factory Collection]"
   region: "NTSC-J"
 SLPM-62700:
@@ -34897,7 +34993,7 @@ SLPM-62701:
 SLPM-62702:
   name: 桃太郎電鉄15 五大ボンビー登場!の巻
   name-sort: ももたろうでんてつ15 ごだいぼんびーとうじょう!のまき
-  name-en: "Momotaro Densetsu 15"
+  name-en: "Momotarou Dentetsu 15"
   region: "NTSC-J"
 SLPM-62703:
   name: SEGA RALLY CHAMPIONSHIP [「セガラリー2007」同梱用]
@@ -34940,8 +35036,8 @@ SLPM-62709:
   name-en: "Sega Ages 2500 Series Vol.23 - Sega Memorial Selection"
   region: "NTSC-J"
 SLPM-62710:
-  name: 三國志VIII [コーエー定番シリーズ]
-  name-sort: さんごくしVIII [こーえーていばんしりーず]
+  name: コーエー定番シリーズ 三國志VIII
+  name-sort: さんごくし8 [こーえーていばんしりーず]
   name-en: "San Goku Shi VIII"
   region: "NTSC-J"
 SLPM-62711:
@@ -34960,7 +35056,7 @@ SLPM-62713:
   region: "NTSC-J"
 SLPM-62714:
   name: 真・三國無双シリーズコレクション　上巻
-  name-sort: しん・さんごくむそうしりーずこれくしょん　じょうかん
+  name-sort: しんさんごくむそうしりーずこれくしょん　じょうかん
   name-en: "Shin Sangoku Musou Series Collection Joukan"
   region: "NTSC-J"
 SLPM-62715:
@@ -34997,7 +35093,7 @@ SLPM-62722:
   region: "NTSC-J"
 SLPM-62724:
   name: ザ・コンビニ4 〜あの町を占拠せよ〜
-  name-sort: ざ・こんびに4 〜あのまちをせんきょせよ〜
+  name-sort: ざ こんびに4 あのまちをせんきょせよ
   name-en: "Conveni 4, The - Ano Machi o Dokusen seyo"
   region: "NTSC-J"
 SLPM-62725:
@@ -35007,7 +35103,7 @@ SLPM-62725:
   region: "NTSC-J"
 SLPM-62726:
   name: シューティング ラブ。 〜TRIZEAL〜
-  name-sort: しゅーてぃんぐ らぶ。 〜TRIZEAL〜
+  name-sort: しゅーてぃんぐ らぶ TRIZEAL
   name-en: "Shooting Love - Trizeal"
   region: "NTSC-J"
 SLPM-62727:
@@ -35051,7 +35147,7 @@ SLPM-62736:
   name-en: "Slotter Up Mania [Dorart Value Series]"
   region: "NTSC-J"
 SLPM-62737:
-  name: ラリーショックス&フリークスタイル モトクロス [EA BEST HITS]
+  name: EA BEST HITS ラリーショックス&フリークスタイル モトクロス
   name-sort: らりーしょっくす&ふりーくすたいる もとくろす [EA BEST HITS]
   name-en: "Rally Shox & Freestyle Motorcross [EA Best Hits]"
   region: "NTSC-J"
@@ -35060,7 +35156,7 @@ SLPM-62738:
   region: "NTSC-J"
 SLPM-62739:
   name: パチスロ完全攻略 スロ原人・鬼浜爆走愚連隊激闘編
-  name-sort: ぱちすろかんぜんこうりゃく すろげんじん・おにはまばくそうぐれんたいげきとうへん
+  name-sort: ぱちすろかんぜんこうりゃく すろげんじん おにはまばくそうぐれんたいげきとうへん
   name-en: "Suro Genjin"
   region: "NTSC-J"
 SLPM-62740:
@@ -35083,7 +35179,7 @@ SLPM-62744:
   region: "NTSC-J"
 SLPM-62745:
   name: オレたちゲーセン族 トリオ・ザ・パンチ
-  name-sort: おれたちげーせんぞく とりお・ざ・ぱんち
+  name-sort: おれたちげーせんぞく とりお ざ ぱんち
   name-en: "Oretachi Geasen Zoku Sono Vol.19 - Trio the Punch"
   region: "NTSC-J"
 SLPM-62746:
@@ -35093,13 +35189,13 @@ SLPM-62746:
   region: "NTSC-J"
   compat: 5
 SLPM-62747:
-  name: ジーワン ジョッキー3 [コーエー定番シリーズ]
+  name: コーエー定番シリーズ ジーワン ジョッキー3
   name-sort: じーわん じょっきー3 [こーえーていばんしりーず]
   name-en: "G1 Jockey 3 [Koei Selection Series]"
   region: "NTSC-J"
 SLPM-62748:
-  name: 信長の野望・嵐世記 with パワーアップキット [コーエー定番シリーズ]
-  name-sort: のぶながのやぼう・らんせいき with ぱわーあっぷきっと [こーえーていばんしりーず]
+  name: コーエー定番シリーズ 信長の野望・嵐世記 with パワーアップキット
+  name-sort: のぶながのやぼう らんせいき with ぱわーあっぷきっと [こーえーていばんしりーず]
   name-en: "Nobunaga no Yabou - Renseiki [with Power-Up Kit] [Koei Selection Series]"
   region: "NTSC-J"
 SLPM-62749:
@@ -35110,7 +35206,7 @@ SLPM-62749:
 SLPM-62750:
   name: 桃太郎電鉄16 北海道大移動!の巻
   name-sort: ももたろうでんてつ16 ほっかいどうだいいどう!のまき
-  name-en: "Momotaro Densetsu 16"
+  name-en: "Momotarou Dentetsu 16"
   region: "NTSC-J"
 SLPM-62751:
   name: "Shin Sangoku Musou Series Collection Gekan Saikyou Data"
@@ -35132,12 +35228,12 @@ SLPM-62754:
   region: "NTSC-J"
 SLPM-62755:
   name: MYCOM BEST 麻雀覇王 真剣バトル
-  name-sort: MYCOM BEST まーじゃんはおう しんけんばとる
+  name-sort: まーじゃんはおう しんけんばとる [MYCOM BEST]
   name-en: "Mahjong Haoh - Shinken Battle [Mycom The Best]"
   region: "NTSC-J"
 SLPM-62756:
   name: MYCOM BEST 最強 東大将棋6
-  name-sort: MYCOM BEST さいきょう とうだいしょうぎ6
+  name-sort: さいきょう とうだいしょうぎ6 [MYCOM BEST]
   name-en: "Saikyou Toudai Shogi 6 [Mycom The Best]"
   region: "NTSC-J"
 SLPM-62757:
@@ -35151,8 +35247,8 @@ SLPM-62758:
   name-en: "River Ride Adventure featuring Salomon"
   region: "NTSC-J"
 SLPM-62759:
-  name: 信長の野望・蒼天録 [コーエー定番シリーズ]
-  name-sort: のぶながのやぼう・そうてんろく [こーえーていばんしりーず]
+  name: コーエー定番シリーズ 信長の野望 蒼天録
+  name-sort: のぶながのやぼう そうてんろく [こーえーていばんしりーず]
   name-en: "Nobunaga no Yabou - Soutenroku [Koei Selection Series]"
   region: "NTSC-J"
 SLPM-62760:
@@ -35169,8 +35265,8 @@ SLPM-62761:
   gsHWFixes:
     roundSprite: 2 # Fixes sprite ghosting.
 SLPM-62762:
-  name: 三國志VIII withパワーアップキット [コーエー定番シリーズ]
-  name-sort: さんごくしVIII withぱわーあっぷきっと [こーえーていばんしりーず]
+  name: コーエー定番シリーズ 三國志VIII withパワーアップキット
+  name-sort: さんごくし8 withぱわーあっぷきっと [こーえーていばんしりーず]
   name-en: "Sangokushi VIII [with Power-Up Kit] [Koei Selection Series]"
   region: "NTSC-J"
 SLPM-62763:
@@ -35218,12 +35314,12 @@ SLPM-62771:
   region: "NTSC-J"
 SLPM-62772:
   name: マイコミBEST 麻雀覇王バトルロイヤル
-  name-sort: まいこみBEST まーじゃんはおうばとるろいやる
+  name-sort: まーじゃんはおうばとるろいやる [まいこみBEST]
   name-en: "Mahjong Haoh - Battle Royal [Mycom Best]"
   region: "NTSC-J"
 SLPM-62773:
   name: スロッターUPマニア9　アツ沖だぜ！めんそーれ-30＆めんそーれ2-30
-  name-sort: すろったーUPまにあ9　あつおきだぜ！めんそーれ-30＆めんそーれ2-30
+  name-sort: すろったーUPまにあ9 あつおきだぜ めんそーれ 30&めんそーれ2 30
   name-en: "Slotter Up Mania 9"
   region: "NTSC-J"
 SLPM-62774:
@@ -35410,17 +35506,17 @@ SLPM-65003:
     - "SLPM-65002"
 SLPM-65004:
   name: ライゼリート 〜エフェメラルファンタジア〜
-  name-sort: らいぜりーと 〜えふぇめらるふぁんたじあ〜
+  name-sort: らいぜりーと えふぇめらるふぁんたじあ
   name-en: "Reiselied - Ephemeral Fantasia"
   region: "NTSC-J"
 SLPM-65005:
   name: オレが監督だ！ 〜激闘ペナントレース〜
-  name-sort: おれがかんとくだ！ 〜げきとうぺなんとれーす〜
+  name-sort: おれがかんとくだ！ げきとうぺなんとれーす
   name-en: "I am the Coach"
   region: "NTSC-J"
 SLPM-65006:
   name: beatmania IIDX 3rd style
-  name-sort: beatmania IIDX 3rd style
+  name-sort: びーとまにあ つーでぃーえっくす 3rd style
   name-en: "Beatmania IIDX 3rd style"
   region: "NTSC-J"
 SLPM-65007:
@@ -35499,12 +35595,12 @@ SLPM-65015:
         patch=0,EE,0016ae9c,word,4BE72B3C
 SLPM-65016:
   name: Love Songs アイドルがクラスメ〜ト 限定版
-  name-sort: Love Songs あいどるがくらすめ〜と げんていばん
+  name-sort: Love Songs あいどるがくらすめーと [げんていばん]
   name-en: "Love Songs [Limited Edition]"
   region: "NTSC-J"
 SLPM-65017:
   name: Love Songs アイドルがクラスメ〜ト
-  name-sort: Love Songs あいどるがくらすめ〜と
+  name-sort: Love Songs あいどるがくらすめーと
   name-en: "Love Songs - Idol is my Classmate"
   region: "NTSC-J"
 SLPM-65018:
@@ -35534,19 +35630,19 @@ SLPM-65021:
   region: "NTSC-J"
 SLPM-65022:
   name: バイオハザード コード:ベロニカ 完全版
-  name-sort: ばいおはざーど こーど:べろにか かんぜんばん
+  name-sort: ばいおはざーど こーど べろにか かんぜんばん
   name-en: "BioHazard - Code Veronica - Perfect Version"
   region: "NTSC-J"
   compat: 5
 SLPM-65023:
-  name: "Devil May Cry [Demo] [BioHazard - Code Veronica - Perfect Version - Bonus Disc]"
+  name: "Devil May Cry [Trial] [BioHazard - Code Veronica - Perfect Version - Bonus Disc]"
   region: "NTSC-J"
   gsHWFixes:
     disablePartialInvalidation: 1 # Fixes corrupt textures.
     halfPixelOffset: 2 # Alleviates blur from upscaling.
 SLPM-65024:
   name: バイオハザード コード:ベロニカ 完全版 [ディスク1/2]
-  name-sort: ばいおはざーど こーど:べろにか かんぜんばん [でぃすく1/2]
+  name-sort: ばいおはざーど こーど べろにか かんぜんばん [でぃすく1/2]
   name-en: "BioHazard - 5th Anniversary Package - Nightmare Returns [Disc 1 of 2]"
   region: "NTSC-J"
 SLPM-65025:
@@ -35556,7 +35652,7 @@ SLPM-65025:
   region: "NTSC-J"
 SLPM-65026:
   name: beatmania IIDX 4th style -new songs collection-
-  name-sort: beatmania IIDX 4th style -new songs collection-
+  name-sort: びーとまにあ つーでぃーえっくす 4th style -new songs collection-
   name-en: "Beatmania IIDX 4th style -new songs collection-"
   region: "NTSC-J"
 SLPM-65027:
@@ -35591,7 +35687,7 @@ SLPM-65032:
   compat: 5
 SLPM-65033:
   name: 機甲兵団 J-PHOENIX
-  name-sort: きこうへいだん J-PHOENIX
+  name-sort: きこうへいだん じぇいふぇにっくす
   name-en: "Kikou Heidan J-Phoenix"
   region: "NTSC-J"
   memcardFilters:
@@ -35620,12 +35716,12 @@ SLPM-65038:
     halfPixelOffset: 2 # Alleviates blur from upscaling.
 SLPM-65039:
   name: 電車でGO!新幹線 山陽新幹線編
-  name-sort: でんしゃでGO!しんかんせん さんようしんかんせんへん
+  name-sort: でんしゃでごーしんかんせん さんようしんかんせんへん
   name-en: "Densha de Go! Shinkansen"
   region: "NTSC-J"
 SLPM-65040:
   name: ザ・フィアー [ディスク1/4]
-  name-sort: ざ・ふぃあー [でぃすく1/4]
+  name-sort: ざ ふぃあー [でぃすく1/4]
   name-en: "Fear, The [Disc 1 of 4]"
   region: "NTSC-J"
   memcardFilters:
@@ -35635,7 +35731,7 @@ SLPM-65040:
     - "SLPM-65043"
 SLPM-65041:
   name: ザ・フィアー [ディスク2/4]
-  name-sort: ざ・ふぃあー [でぃすく2/4]
+  name-sort: ざ ふぃあー [でぃすく2/4]
   name-en: "Fear, The [Disc 2 of 4]"
   region: "NTSC-J"
   memcardFilters:
@@ -35645,7 +35741,7 @@ SLPM-65041:
     - "SLPM-65043"
 SLPM-65042:
   name: ザ・フィアー [ディスク3/4]
-  name-sort: ざ・ふぃあー [でぃすく3/4]
+  name-sort: ざ ふぃあー [でぃすく3/4]
   name-en: "Fear, The [Disc 3of 4]"
   region: "NTSC-J"
   compat: 5
@@ -35656,7 +35752,7 @@ SLPM-65042:
     - "SLPM-65043"
 SLPM-65043:
   name: ザ・フィアー [ディスク4/4]
-  name-sort: ざ・ふぃあー [でぃすく4/4]
+  name-sort: ざ ふぃあー [でぃすく4/4]
   name-en: "Fear, The [Disc 4 of 4]"
   region: "NTSC-J"
   memcardFilters:
@@ -35683,7 +35779,7 @@ SLPM-65048:
   region: "NTSC-J"
 SLPM-65049:
   name: beatmania IIDX 5th style -new songs collection-
-  name-sort: beatmania IIDX 5th style -new songs collection-
+  name-sort: びーとまにあ つーでぃーえっくす 5th style -new songs collection-
   name-en: "Beatmania IIDX 5th style -new songs collection-"
   region: "NTSC-J"
 SLPM-65050:
@@ -35713,7 +35809,7 @@ SLPM-65052:
   compat: 5
 SLPM-65053:
   name: 真・三國無双2
-  name-sort: しん・さんごくむそう2
+  name-sort: しんさんごくむそう2
   name-en: "Shin Sangoku Musou 2"
   region: "NTSC-J"
   compat: 5
@@ -35783,8 +35879,8 @@ SLPM-65072:
   region: "NTSC-J"
 SLPM-65073:
   name: 幻想水滸伝III（初回生産分：特殊仕様）
-  name-sort: げんそうすいこでんIII（しょかいせいさんぶん：とくしゅしよう）
-  name-en: "Genso Suikoden III"
+  name-sort: げんそうすいこでん3 [しょかいせいさんぶん:とくしゅしよう]
+  name-en: "Gensou Suikoden III"
   region: "NTSC-J"
   memcardFilters: # This looks like a mess because it includes all serials for Suikoden 3, Suikoden 2, Suikogaiden 1, and Suikogaiden 2. A lot of these probably aren't actually required but it's not really hurting anything to have them here.
     - "SLPM-65073"
@@ -35802,8 +35898,8 @@ SLPM-65073:
     - "SLPM-87262"
 SLPM-65074:
   name: 幻想水滸伝III
-  name-sort: げんそうすいこでんIII
-  name-en: "Genso Suikoden III"
+  name-sort: げんそうすいこでん3
+  name-en: "Gensou Suikoden III"
   region: "NTSC-J"
   memcardFilters:
     - "SLPM-65073"
@@ -35831,7 +35927,7 @@ SLPM-65076:
   region: "NTSC-J"
 SLPM-65077:
   name: METAL GEAR SOLID 2 SONS OF LIBERTY PREMIUM PACKAGE
-  name-sort: METAL GEAR SOLID 2 SONS OF LIBERTY PREMIUM PACKAGE
+  name-sort: めたるぎあそりっど2 さんずおぶりばてぃ PREMIUM PACKAGE
   name-en: "Metal Gear Solid 2 - Sons of Liberty [Premium Package]"
   region: "NTSC-J"
   gameFixes:
@@ -35843,7 +35939,7 @@ SLPM-65077:
     - "SLPM-65077"
 SLPM-65078:
   name: METAL GEAR SOLID 2 SONS OF LIBERTY
-  name-sort: METAL GEAR SOLID 2 SONS OF LIBERTY
+  name-sort: めたるぎあそりっど2 さんずおぶりばてぃ
   name-en: "Metal Gear Solid 2 - Sons of Liberty"
   region: "NTSC-J"
   gameFixes:
@@ -35879,7 +35975,7 @@ SLPM-65085:
   region: "NTSC-J"
 SLPM-65086:
   name: “A” VISUAL MIX [ディスク1/2]
-  name-sort: “A” VISUAL MIX [ディスク1/2]
+  name-sort: A VISUAL MIX [でぃすく1/2]
   name-en: "Visual Mix - Ayumi Hamasaki Dome Tour 2001 [Disc 1 of 2]"
   region: "NTSC-J"
   compat: 5
@@ -35890,7 +35986,7 @@ SLPM-65086:
     - "SLPM-65087"
 SLPM-65087:
   name: “A” VISUAL MIX [ディスク2/2]
-  name-sort: “A” VISUAL MIX [ディスク2/2]
+  name-sort: A VISUAL MIX [でぃすく2/2]
   name-en: "Visual Mix - Ayumi Hamasaki Dome Tour 2001 [Disc 2 of 2]"
   region: "NTSC-J"
   compat: 5
@@ -35913,7 +36009,7 @@ SLPM-65090:
     - VIF1StallHack # Fixes loading hang.
 SLPM-65091:
   name: 遙かなる時空の中で2 プレミアムBOX
-  name-sort: はるかなるときのなかで2 ぷれみあむBOX
+  name-sort: はるかなるときのなかで2 [ぷれみあむBOX]
   name-en: "Harukanaru Toki no Naka de 2 [Limited Edition]"
   region: "NTSC-J"
 SLPM-65092:
@@ -35949,7 +36045,7 @@ SLPM-65097:
   compat: 5
 SLPM-65098:
   name: サイレントヒル2 最期の詩
-  name-sort: さいれんとひる2 さいごのし
+  name-sort: さいれんとひる2 さいごのうた
   name-en: "Silent Hill 2 - Saigo no Uta"
   region: "NTSC-J"
   compat: 5
@@ -35994,7 +36090,7 @@ SLPM-65109:
   region: "NTSC-J"
 SLPM-65110:
   name: ROOMMANIA#203
-  name-sort: ROOMMANIA#203
+  name-sort: るーまにあ#203
   name-en: "Roommania #203"
   region: "NTSC-J"
 SLPM-65111:
@@ -36009,7 +36105,7 @@ SLPM-65113:
   region: "NTSC-J"
 SLPM-65115:
   name: ファイナルファンタジーX インターナショナル
-  name-sort: ふぁいなるふぁんたじーX いんたーなしょなる
+  name-sort: ふぁいなるふぁんたじー10 いんたーなしょなる
   name-en: "Final Fantasy X International"
   region: "NTSC-J"
   roundModes:
@@ -36026,7 +36122,7 @@ SLPM-65116:
   region: "NTSC-J"
 SLPM-65117:
   name: ザ・ベスト・タカラモノ 機甲兵団 J-PHOENIX
-  name-sort: ざ・べすと・たからもの きこうへいだん J-PHOENIX
+  name-sort: ざ・べすと・たからもの きこうへいだん じぇいふぇにっくす
   name-en: "Kikou Heidan J-Phoenix [Takara The Best]"
   region: "NTSC-J"
   memcardFilters:
@@ -36040,7 +36136,7 @@ SLPM-65118:
   region: "NTSC-J"
 SLPM-65119:
   name: SHINE 〜言葉を紡いで〜 限定版
-  name-sort: SHINE 〜ことばをつむいで〜 げんていばん
+  name-sort: SHINE 〜ことばをつむいで〜 [げんていばん]
   name-en: "Shine - Spinning World"
   region: "NTSC-J"
 SLPM-65120:
@@ -36056,7 +36152,7 @@ SLPM-65121:
   compat: 5
 SLPM-65122:
   name: 機甲兵団 J-PHOENIX BURST TACTICS LIMITED EDITION
-  name-sort: きこうへいだん J-PHOENIX BURST TACTICS LIMITED EDITION
+  name-sort: きこうへいだん じぇいふぇにっくす BURST TACTICS LIMITED EDITION
   name-en: "Kikou Heidan J-Phoenix Burst Tactics [Limited Edition]"
   region: "NTSC-J"
   memcardFilters:
@@ -36067,7 +36163,7 @@ SLPM-65122:
     - "SLPM-65123"
 SLPM-65123:
   name: 機甲兵団 J-PHOENIX BURST TACTICS
-  name-sort: きこうへいだん J-PHOENIX BURST TACTICS
+  name-sort: きこうへいだん じぇいふぇにっくす BURST TACTICS
   name-en: "Kikou Heidan J-Phoenix Burst Tactics"
   region: "NTSC-J"
   memcardFilters:
@@ -36083,12 +36179,12 @@ SLPM-65124:
   region: "NTSC-J"
 SLPM-65125:
   name: 夏色の砂時計（初回限定生産版）
-  name-sort: なついろのすなどけい（しょかいげんていせいさんばん）
-  name-en: "NBA 2K3"
+  name-sort: なついろのすなどけい [しょかいげんていせいさんばん]
+  name-en: "Natsuiro no Sunadokei"
   region: "NTSC-J"
 SLPM-65126:
   name: ときめきメモリアル Girl’s Side 初回生産版
-  name-sort: ときめきめもりある Girl’s Side しょかいせいさんばん
+  name-sort: ときめきめもりある がーるずさいど しょかいせいさんばん
   name-en: "Tokimeki Memorial Girl's Side [Limited Edition]"
   region: "NTSC-J"
 SLPM-65130:
@@ -36098,7 +36194,7 @@ SLPM-65130:
   region: "NTSC-J"
 SLPM-65131:
   name: ユーディーのアトリエ 〜グラムナートの錬金術士〜
-  name-sort: ゆーでぃーのあとりえ 〜ぐらむなーとのれんきんじゅつし〜
+  name-sort: ゆーでぃーのあとりえ ぐらむなーとのれんきんじゅつし
   name-en: "Judie no Atelier - Gramnad no Renkinjutsushi"
   region: "NTSC-J"
 SLPM-65132:
@@ -36108,12 +36204,12 @@ SLPM-65132:
   region: "NTSC-J"
 SLPM-65133:
   name: 此花2 〜届かないレクイエム〜
-  name-sort: このはな2 〜とどかないれくいえむ〜
+  name-sort: このはな2 とどかないれくいえむ
   name-en: "Konohana 2"
   region: "NTSC-J"
 SLPM-65134:
   name: RED CARD レッド・カード
-  name-sort: RED CARD れっど・かーど
+  name-sort: れっどかーど
   name-en: "Red Card"
   region: "NTSC-J"
 SLPM-65135:
@@ -36139,7 +36235,7 @@ SLPM-65139:
     vu1ClampMode: 3 # Fixes flashing in some scenes.
 SLPM-65140:
   name: ジョジョの奇妙な冒険 黄金の旋風
-  name-sort: じょじょのきみょうなぼうけん おうごんのせんぷう
+  name-sort: じょじょのきみょうなぼうけん おうごんのかぜ
   name-en: "Jojo no Kimyou na Bouken - Ougon no Kaze"
   region: "NTSC-J"
   gsHWFixes:
@@ -36162,7 +36258,7 @@ SLPM-65143:
   region: "NTSC-J"
 SLPM-65144:
   name: 魔剣爻 アトラス・ベストコレクション
-  name-sort: まけんしゃお アトラス・ベストコレクション
+  name-sort: まけんしゃお あとらす・べすとこれくしょん
   name-en: "Maken Shao"
   region: "NTSC-J"
   speedHacks:
@@ -36175,7 +36271,7 @@ SLPM-65146:
   region: "NTSC-J"
 SLPM-65148:
   name: 電車でGO!〜旅情編〜
-  name-sort: でんしゃでGO!〜りょじょうへん〜
+  name-sort: でんしゃでごー りょじょうへん
   name-en: "Densha de Go! Ryojou-hen"
   region: "NTSC-J"
 SLPM-65149:
@@ -36200,23 +36296,23 @@ SLPM-65153:
   name-en: "GunGrave"
   region: "NTSC-J"
 SLPM-65154:
-  name: 君が望む永遠　～Rumbling hearts～ （初回限定版）
-  name-sort: きみがのぞむえいえん　～Rumbling hearts～ （しょかいげんていばん）
+  name: 君が望む永遠　〜Rumbling hearts〜 （初回限定版）
+  name-sort: きみがのぞむえいえん Rumbling hearts しょかいげんていばん
   name-en: "Rumbling Hearts"
   region: "NTSC-J"
 SLPM-65155:
-  name: 君が望む永遠　～Rumbling hearts～
-  name-sort: きみがのぞむえいえん　～Rumbling hearts～
+  name: 君が望む永遠　〜Rumbling hearts〜
+  name-sort: きみがのぞむえいえん Rumbling hearts
   name-en: "Rumbling Hearts"
   region: "NTSC-J"
 SLPM-65156:
   name: beatmania IIDX 6th style -new songs collection-
-  name-sort: beatmania IIDX 6th style -new songs collection-
+  name-sort: びーとまにあ つーでぃーえっくす 6th style -new songs collection-
   name-en: "Beatmania IIDX 6th style -new songs collection-"
   region: "NTSC-J"
 SLPM-65158:
   name: RS〜ライディング スピリッツ〜
-  name-sort: RS〜らいでぃんぐ すぴりっつ〜
+  name-sort: らいでぃんぐ すぴりっつ
   name-en: "Riding Spirits"
   region: "NTSC-J"
 SLPM-65159:
@@ -36245,12 +36341,12 @@ SLPM-65163:
         patch=0,EE,0027617c,word,4BE521AC
 SLPM-65164:
   name: PROJECT MINERVA 限定版
-  name-sort: PROJECT MINERVA げんていばん
+  name-sort: ぷろじぇくと みねるゔぁ [げんていばん]
   name-en: "Project Minerva [Limited Edition]"
   region: "NTSC-J"
 SLPM-65165:
   name: PROJECT MINERVA
-  name-sort: PROJECT MINERVA
+  name-sort: ぷろじぇくと みねるゔぁ
   name-en: "Project Minerva"
   region: "NTSC-J"
 SLPM-65166:
@@ -36272,8 +36368,8 @@ SLPM-65169:
   compat: 5
 SLPM-65170:
   name: 真・三國無双2 猛将伝
-  name-sort: しん・さんごくむそう2 もうしょうでん
-  name-en: "Shin Sangoku Musou 2 - Mushoden"
+  name-sort: しんさんごくむそう2 もうしょうでん
+  name-en: "Shin Sangoku Musou 2 - Moushouden"
   region: "NTSC-J"
 SLPM-65171:
   name: "Shin Sangoku Musou 2"
@@ -36293,7 +36389,7 @@ SLPM-65174:
   region: "NTSC-J"
 SLPM-65176:
   name: キング オブ コロシアム(赤) 新日本×全日本×パンクラスディスク
-  name-sort: きんぐ おぶ ころしあむ(あか) しんにほん×ぜんにほん×ぱんくらすでぃすく
+  name-sort: きんぐ おぶ ころしあむ(あか) しんにほん ぜんにほん ぱんくらすでぃすく
   name-en: "King of Colosseum - Red"
   region: "NTSC-J"
   gameFixes:
@@ -36335,7 +36431,7 @@ SLPM-65183:
   region: "NTSC-J"
 SLPM-65184:
   name: THE DOCUMENT OF METAL GEAR SOLID 2
-  name-sort: THE DOCUMENT OF METAL GEAR SOLID 2
+  name-sort: めたるぎあそりっど2 [どきゅめんと]
   name-en: "Document of Metal Gear Solid 2, The"
   region: "NTSC-J"
   gameFixes:
@@ -36347,13 +36443,13 @@ SLPM-65185:
     roundSprite: 1 # Fixes text alignment.
 SLPM-65186:
   name: Thread Colors(スレッドカラーズ)〜さよならの向こう側〜 [限定生産初回BOX]
-  name-sort: すれっどからーず 〜さよならのむこうがわ〜 [げんていせいさんしょかいBOX]
+  name-sort: すれっどからーず さよならのむこうがわ [げんていせいさんしょかいBOX]
   name-en: "Thread Colors [Limited Edition]"
   region: "NTSC-J"
 SLPM-65187:
   name: Thread Colors(スレッドカラーズ)〜さよならの向こう側〜 [量産型ふつう版]
-  name-sort: すれっどからーず 〜さよならのむこうがわ〜 [りょうさんがたふつうばん]
-  name-en: "Thread Colors"
+  name-sort: すれっどからーず さよならのむこうがわ [りょうさんがたふつうばん]
+  name-en: "Thread Colors [Standard Edition]"
   region: "NTSC-J"
 SLPM-65190:
   name: "Tony Hawk's Pro Skater 3"
@@ -36382,12 +36478,12 @@ SLPM-65193:
     mipmap: 1 # Fixes broken player textures.
 SLPM-65196:
   name: ブレス オブ ファイア V ドラゴンクォーター
-  name-sort: ぶれす おぶ ふぁいあ V どらごんくぉーたー
+  name-sort: ぶれす おぶ ふぁいあ5 どらごんくぉーたー
   name-en: "Breath of Fire V - Dragon Quarter"
   region: "NTSC-J"
 SLPM-65197:
   name: 信長の野望 Online
-  name-sort: のぶながのやぼう Online
+  name-sort: のぶながのやぼう おんらいん
   name-en: "Nobunaga's Ambition Online"
   region: "NTSC-J"
 SLPM-65198:
@@ -36395,7 +36491,7 @@ SLPM-65198:
   region: "NTSC-J"
 SLPM-65199:
   name: 機甲兵団J-PHOENIX コバルト小隊篇
-  name-sort: きこうへいだんJ-PHOENIX こばるとしょうたいへん
+  name-sort: きこうへいだん じぇいふぇにっくす こばるとしょうたいへん
   name-en: "Kikou Heidan J-Phoenix Cobalt Shoutai-hen"
   region: "NTSC-J"
   memcardFilters:
@@ -36422,12 +36518,12 @@ SLPM-65202:
   region: "NTSC-J"
 SLPM-65203:
   name: ファントム-PHANTOM OF INFERNO- [初回限定版]
-  name-sort: ふぁんとむ-PHANTOM OF INFERNO- [しょかいげんていばん]
+  name-sort: ふぁんとむ PHANTOM OF INFERNO しょかいげんていばん
   name-en: "Phantom of Inferno [Limited Edition]"
   region: "NTSC-J"
 SLPM-65204:
   name: ファントム-PHANTOM OF INFERNO-
-  name-sort: ふぁんとむ-PHANTOM OF INFERNO-
+  name-sort: ふぁんとむ PHANTOM OF INFERNO
   name-en: "Phantom of Inferno"
   region: "NTSC-J"
 SLPM-65205:
@@ -36529,7 +36625,7 @@ SLPM-65213:
   region: "NTSC-J"
 SLPM-65215:
   name: 超・バトル封神&真・三國無双2 猛将伝 プレミアムパック
-  name-sort: ちょう・ばとるほうしん&しん・さんごくむそう2 もうしょうでん ぷれみあむぱっく
+  name-sort: ちょう・ばとるほうしん&しんさんごくむそう2 もうしょうでん ぷれみあむぱっく
   name-en: "Chou Battle Houshin - Bundle #2"
   region: "NTSC-J"
 SLPM-65217:
@@ -36594,8 +36690,8 @@ SLPM-65226:
         patch=0,EE,00163134,word,27bd0030
 SLPM-65227:
   name: J.LEAGUE プロサッカークラブをつくろう!3
-  name-sort: J.LEAGUE ぷろさっかーくらぶをつくろう!3
-  name-en: "J-League Pro Soccer Club - Tsukuku! 3"
+  name-sort: Jりーぐ ぷろさっかーくらぶをつくろう!3
+  name-en: "J-League Pro Soccer Club - Tsukurou! 3"
   region: "NTSC-J"
 SLPM-65228:
   name: 大正もののけ異聞録
@@ -36610,7 +36706,7 @@ SLPM-65229:
   region: "NTSC-J"
 SLPM-65230:
   name: ときめきメモリアル3 約束のあの場所で コナミ ザ・ベスト
-  name-sort: ときめきめもりある3 やくそくのあのばしょで こなみ ざ・べすと
+  name-sort: ときめきめもりある3 やくそくのあのばしょで こなみ ざ べすと
   name-en: "Tokimeki Memorial 3 [Konami The Best]"
   region: "NTSC-J"
 SLPM-65231:
@@ -36642,7 +36738,7 @@ SLPM-65233:
     - "SLPM-65232"
 SLPM-65234:
   name: 爆走デコトラ伝説 〜男花道夢浪漫〜
-  name-sort: ばくそうでことらでんせつ 〜おとこはなみちゆめろまん〜
+  name-sort: ばくそうでことらでんせつ おとこはなみちゆめろまん
   name-en: "Bakusou Dekotora Densetsu - Otoko Hanamichi Yume Roman"
   region: "NTSC-J"
   gsHWFixes:
@@ -36656,24 +36752,24 @@ SLPM-65235:
   compat: 5
 SLPM-65236:
   name: ANUBIS ZONE OF THE ENDERS
-  name-sort: ANUBIS ZONE OF THE ENDERS
+  name-sort: あぬびす ぞーん おぶ えんだーず
   name-en: "Anubis - Zone of the Enders"
   region: "NTSC-J"
 SLPM-65237:
-  name: ZONE OF THE ENDERS PS2 the Best
-  name-sort: ZONE OF THE ENDERS PS2 the Best
-  name-en: "Z.O.E. - Zone of the Enders [PS2 The Best]"
+  name: ZONE OF THE ENDERS PlayStation 2 the Best
+  name-sort: ぞーん おぶ えんだーず PlayStation 2 the Best
+  name-en: "Z.O.E. - Zone of the Enders [PlayStation 2 the Best]"
   region: "NTSC-J"
   gsHWFixes:
     gpuPaletteConversion: 2 # Improves FPS and reduces HC size.
 SLPM-65238:
   name: エンジェリック・コンサート スペシャルボックス
-  name-sort: えんじぇりっく・こんさーと すぺしゃるぼっくす
+  name-sort: えんじぇりっく こんさーと [すぺしゃるぼっくす]
   name-en: "Angelic Concert [Limited Edition]"
   region: "NTSC-J"
 SLPM-65239:
   name: エンジェリック・コンサート
-  name-sort: えんじぇりっく・こんさーと
+  name-sort: えんじぇりっく こんさーと
   name-en: "Angelic Concert"
   region: "NTSC-J"
 SLPM-65240:
@@ -36681,7 +36777,7 @@ SLPM-65240:
   region: "NTSC-J"
 SLPM-65241:
   name: 真・女神転生 III-NOCTURNE デラックスパック
-  name-sort: しん・めがみてんせい III-NOCTURNE でらっくすぱっく
+  name-sort: しんめがみてんせい3-NOCTURNE でらっくすぱっく
   name-en: "Shin Megami Tensei III - Nocturne [Limited Edition]"
   region: "NTSC-J"
   roundModes:
@@ -36691,7 +36787,7 @@ SLPM-65241:
     trilinearFiltering: 1
 SLPM-65242:
   name: 真・女神転生 III-NOCTURNE
-  name-sort: しん・めがみてんせい III-NOCTURNE
+  name-sort: しんめがみてんせい3-NOCTURNE
   name-en: "Shin Megami Tensei III - Nocturne"
   region: "NTSC-J"
   roundModes:
@@ -36701,12 +36797,12 @@ SLPM-65242:
     trilinearFiltering: 1
 SLPM-65243:
   name: 電車でGO!プロフェッショナル2
-  name-sort: でんしゃでGO!ぷろふぇっしょなる2
+  name-sort: でんしゃでごーぷろふぇっしょなる2
   name-en: "Densha de Go! Professional 2"
   region: "NTSC-J"
 SLPM-65244:
   name: トム・クランシーシリーズ ゴーストリコン
-  name-sort: とむ・くらんしーしりーず ごーすとりこん
+  name-sort: とむくらんしーしりーず ごーすとりこん
   name-en: "Tom Clancy's Ghost Recon"
   region: "NTSC-J"
 SLPM-65245:
@@ -36722,7 +36818,7 @@ SLPM-65245:
     mergeSprite: 1 # Fixes flame-like bleeding.
 SLPM-65246:
   name: 街道バトル 〜日光・榛名・六甲・箱根〜
-  name-sort: かいどうばとる 〜にっこう・はるな・ろっこう・はこね〜
+  name-sort: かいどうばとる にっこう はるな ろっこう はこね
   name-en: "Kaido Battle - Nikko, Haruna, Rokko, Hakone"
   region: "NTSC-J"
   gsHWFixes:
@@ -36735,7 +36831,7 @@ SLPM-65247:
   region: "NTSC-J"
 SLPM-65248:
   name: 真・三國無双3
-  name-sort: しん・さんごくむそう3
+  name-sort: しんさんごくむそう3
   name-en: "Shin Sangoku Musou 3"
   region: "NTSC-J"
 SLPM-65249:
@@ -36759,15 +36855,15 @@ SLPM-65254:
   name-en: "Galaxy Angel"
   region: "NTSC-J"
 SLPM-65255:
-  name: ちょびっツ ～ちぃだけのヒト～
-  name-sort: ちょびっつ ～ちぃだけのひと～
+  name: ちょびっツ 〜ちぃだけのヒト〜
+  name-sort: ちょびっつ ちぃだけのひと
   name-en: "Chobits - Chii dake no Hito"
   region: "NTSC-J"
   gsHWFixes:
     roundSprite: 2 # Reduces font artifacts.
 SLPM-65256:
   name: ファーストKiss☆物語(ストーリーズ) スペシャルCD同梱版
-  name-sort: ふぁーすとKiss☆すとーりーず すぺしゃるCDどうこんばん
+  name-sort: ふぁーすときすすとーりーず すぺしゃるCDどうこんばん
   name-en: "First Kiss Story 1&2 [Limited Edition]"
   region: "NTSC-J"
 SLPM-65257:
@@ -36790,7 +36886,7 @@ SLPM-65257:
     - "SLPM-65631"
 SLPM-65259:
   name: 真・女神転生 III-NOCTURNE TSUTAYAオリジナルバージョン
-  name-sort: しん・めがみてんせい III-NOCTURNE TSUTAYAおりじなるばーじょん
+  name-sort: しんめがみてんせい3-NOCTURNE TSUTAYAおりじなるばーじょん
   name-en: "Shin Megami Tensei III - Nocturne TSUTAYA Original Version"
   region: "NTSC-J"
   roundModes:
@@ -36813,13 +36909,13 @@ SLPM-65262:
   region: "NTSC-J"
 SLPM-65263:
   name: コーエーメガパック 真・三國無双2&真・三國無双2 猛将伝 [ディスク1/2]
-  name-sort: こーえーめがぱっく しん・さんごくむそう2&しん・さんごくむそう2 もうしょうでん [でぃすく1/2]
-  name-en: "Shin Sangoku Musou 2 & Shin Sangoku Musou 2 Mushoden [Koei Mega Pack] [Disc 1 of 2]"
+  name-sort: こーえーめがぱっく しんさんごくむそう2&しんさんごくむそう2 もうしょうでん [でぃすく1/2]
+  name-en: "Shin Sangoku Musou 2 & Shin Sangoku Musou 2 Moushouden [Koei Mega Pack] [Disc 1 of 2]"
   region: "NTSC-J"
 SLPM-65264:
   name: コーエーメガパック 真・三國無双2&真・三國無双2 猛将伝 [ディスク2/2]
-  name-sort: こーえーめがぱっく しん・さんごくむそう2&しん・さんごくむそう2 もうしょうでん [でぃすく2/2]
-  name-en: "Shin Sangoku Musou 2 & Shin Sangoku Musou 2 Mushoden [Koei Mega Pack] [Disc 2 of 2]"
+  name-sort: こーえーめがぱっく しんさんごくむそう2&しんさんごくむそう2 もうしょうでん [でぃすく2/2]
+  name-en: "Shin Sangoku Musou 2 & Shin Sangoku Musou 2 Moushouden [Koei Mega Pack] [Disc 2 of 2]"
   region: "NTSC-J"
 SLPM-65266:
   name: ドラッグ オン ドラグーン
@@ -36839,7 +36935,7 @@ SLPM-65267:
   region: "NTSC-J"
 SLPM-65268:
   name: 頭文字D Special Stage
-  name-sort: かしらもじD Special Stage
+  name-sort: いにしゃるD Special Stage
   name-en: "Initial D - Special Stage"
   region: "NTSC-J"
   patches:
@@ -36888,7 +36984,7 @@ SLPM-65273:
   region: "NTSC-J"
 SLPM-65274:
   name: 最終兵器彼女 限定版
-  name-sort: さいしゅうへいきかのじょ げんていばん
+  name-sort: さいしゅうへいきかのじょ [げんていばん]
   name-en: "Saishuu Heiki Kanojo [Limited Edition]"
   region: "NTSC-J"
 SLPM-65275:
@@ -36910,33 +37006,33 @@ SLPM-65277:
   region: "NTSC-J"
   compat: 5
 SLPM-65278:
-  name: GENERATION OF CHAOS 3 ～時の封印～ （限定版）
-  name-sort: GENERATION OF CHAOS 3 ～じのふういん～ （げんていばん）
+  name: GENERATION OF CHAOS 3 〜時の封印〜 （限定版）
+  name-sort: GENERATION OF CHAOS 3 ときのふういん [げんていばん]
   name-en: "Generation of Chaos 3 [Limited Edition]"
   region: "NTSC-J"
 SLPM-65279:
-  name: GENERATION OF CHAOS 3 ～時の封印～
-  name-sort: GENERATION OF CHAOS 3 ～じのふういん～
+  name: GENERATION OF CHAOS 3 〜時の封印〜
+  name-sort: GENERATION OF CHAOS 3 ときのふういん
   name-en: "Generation of Chaos 3"
   region: "NTSC-J"
 SLPM-65280:
-  name: グリーングリーン ～鐘の音ダイナミック～ [デラックスパック]
-  name-sort: ぐりーんぐりーん ～かねのおとだいなみっく～ [でらっくすぱっく]
+  name: グリーングリーン 〜鐘の音ダイナミック〜 [デラックスパック]
+  name-sort: ぐりーんぐりーん かねのおとだいなみっく でらっくすぱっく
   name-en: "Green Green - Sound of the Ring Dynamic [Limited Edition]"
   region: "NTSC-J"
 SLPM-65281:
-  name: グリーングリーン ～鐘の音ダイナミック～ [通常版]
-  name-sort: ぐりーんぐりーん ～かねのおとだいなみっく～ [つうじょうばん]
+  name: グリーングリーン 〜鐘の音ダイナミック〜 [通常版]
+  name-sort: ぐりーんぐりーん かねのおとだいなみっく [つうじょうばん]
   name-en: "Green Green - Sound of the Ring Dynamic"
   region: "NTSC-J"
 SLPM-65282:
-  name: グリーングリーン ～鐘の音ロマンティック～ [デラックスパック]
-  name-sort: ぐりーんぐりーん ～かねのおとろまんてぃっく～ [でらっくすぱっく]
+  name: グリーングリーン 〜鐘の音ロマンティック〜 [デラックスパック]
+  name-sort: ぐりーんぐりーん かねのおとろまんてぃっく でらっくすぱっく
   name-en: "Green Green - Sound of the Ring Romantic [Limited Edition]"
   region: "NTSC-J"
 SLPM-65283:
   name: グリーングリーン 〜鐘の音ロマンティック〜 [通常版]
-  name-sort: ぐりーんぐりーん 〜かねのおとろまんてぃっく〜 [つうじょうばん]
+  name-sort: ぐりーんぐりーん かねのおとろまんてぃっく [つうじょうばん]
   name-en: "Green Green - Sound of the Ring Romantic"
   region: "NTSC-J"
 SLPM-65284:
@@ -36949,8 +37045,8 @@ SLPM-65284:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes texture misalignment.
 SLPM-65285:
-  name: ラブひな ごーじゃす ～チラっとハプニング!!～ 初回限定版
-  name-sort: らぶひな ごーじゃす ～ちらっとはぷにんぐ!!～ しょかいげんていばん
+  name: ラブひな ごーじゃす 〜チラっとハプニング!!〜 初回限定版
+  name-sort: らぶひな ごーじゃす 〜ちらっとはぷにんぐ!!〜 しょかいげんていばん
   name-en: "Love Hina Gorgeous [First Limited Edition]"
   region: "NTSC-J"
   compat: 5
@@ -36961,76 +37057,76 @@ SLPM-65286:
   region: "NTSC-J"
 SLPM-65287:
   name: ファイナルファンタジーXI ジラートの幻影 拡張データディスク
-  name-sort: ふぁいなるふぁんたじーXI じらーとのげんえい かくちょうでーたでぃすく
+  name-sort: ふぁいなるふぁんたじー11 じらーとのげんえい かくちょうでーたでぃすく
   name-en: "Final Fantasy XI - Girade no Genei"
   region: "NTSC-J"
 SLPM-65288:
   name: ファイナルファンタジーXI ジラートの幻影 オールインワンパック2003 [プレイオンライン]
-  name-sort: ふぁいなるふぁんたじーXI じらーとのげんえい おーるいんわんぱっく2003 [ぷれいおんらいん]
+  name-sort: ふぁいなるふぁんたじー11 じらーとのげんえい おーるいんわんぱっく2003 [ぷれいおんらいん]
   name-en: "Final Fantasy XI - Girade no Genei [All-in-One Pack]"
   region: "NTSC-J"
 SLPM-65289:
   name: ファイナルファンタジーXI エントリーディスク [プレイオンライン]
-  name-sort: ふぁいなるふぁんたじーXI えんとりーでぃすく [ぷれいおんらいん]
+  name-sort: ふぁいなるふぁんたじー11 えんとりーでぃすく [ぷれいおんらいん]
   name-en: "Final Fantasy XI [Entry Disc]"
   region: "NTSC-J"
 SLPM-65290:
-  name: マージ ～あの時の遠い約束を～ 初回限定版
-  name-sort: まーじ ～あのときのとおいやくそくを～ しょかいげんていばん
+  name: マージ 〜あの時の遠い約束を〜 初回限定版
+  name-sort: まーじ 〜あのときのとおいやくそくを〜 しょかいげんていばん
   name-en: "Merge Marginal [Limited Edition]"
   region: "NTSC-J"
 SLPM-65291:
-  name: マージ ～あの時の遠い約束を～
-  name-sort: まーじ ～あのときのとおいやくそくを～
+  name: マージ 〜あの時の遠い約束を〜
+  name-sort: まーじ 〜あのときのとおいやくそくを〜
   name-en: "Merge Marginal"
   region: "NTSC-J"
 SLPM-65292:
   name: "Love Hina Gorgeous - Chiratto Happening!!"
   region: "NTSC-J"
 SLPM-65294:
-  name: カフェ・リトルウィッシュ ～魔法のレシピ～ 初回限定版
-  name-sort: かふぇ・りとるうぃっしゅ ～まほうのれしぴ～ しょかいげんていばん
+  name: カフェ・リトルウィッシュ 〜魔法のレシピ〜 初回限定版
+  name-sort: かふぇ・りとるうぃっしゅ 〜まほうのれしぴ〜 しょかいげんていばん
   name-en: "Cafe Little Wish - Mahou no Recipe [Limited Edition]"
   region: "NTSC-J"
 SLPM-65295:
-  name: カフェ・リトルウィッシュ ～魔法のレシピ～
-  name-sort: かふぇ・りとるうぃっしゅ ～まほうのれしぴ～
+  name: カフェ・リトルウィッシュ 〜魔法のレシピ〜
+  name-sort: かふぇ りとるうぃっしゅ まほうのれしぴ
   name-en: "Cafe Little Wish - Mahou no Recipe"
   region: "NTSC-J"
 SLPM-65296:
-  name: F～ファナティック～ [初回限定版]
-  name-sort: F～ふぁなてぃっく～ [しょかいげんていばん]
+  name: F〜ファナティック〜 [初回限定版]
+  name-sort: F〜ふぁなてぃっく〜 しょかいげんていばん
   name-en: "F - Fanatic [Limited Edition]"
   region: "NTSC-J"
 SLPM-65297:
-  name: F～ファナティック～
-  name-sort: F～ふぁなてぃっく～
+  name: F〜ファナティック〜
+  name-sort: F〜ふぁなてぃっく〜
   name-en: "F - Fanatic"
   region: "NTSC-J"
 SLPM-65298:
   name: Winning Post5 MAXIMAM 2003
-  name-sort: Winning Post5 MAXIMAM 2003
+  name-sort: ういにんぐぽすと5 MAXIMAM 2003
   name-en: "Winning Post 5 Maximum 2003"
   region: "NTSC-J"
 SLPM-65299:
-  name: 此花3 ～偽りの影の向こうに～
-  name-sort: このはな3 ～いつわりのかげのむこうに～
+  name: 此花3 〜偽りの影の向こうに〜
+  name-sort: このはな3 いつわりのかげのむこうに
   name-en: "Konohana 3"
   region: "NTSC-J"
 SLPM-65300:
   name: オールスター・プロレスリングIII
-  name-sort: おーるすたー・ぷろれすりんぐIII
+  name-sort: おーるすたー ぷろれすりんぐIII
   name-en: "All-Star Pro Wrestling III"
   region: "NTSC-J"
   compat: 5
 SLPM-65301:
   name: とらかぷっ!だーっしゅ!!でらっくすぱっく
-  name-sort: とらかぷっ!だーっしゅ!!でらっくすぱっく
+  name-sort: とらかぷっ だーっしゅ でらっくすぱっく
   name-en: "Torakapuu! Dash [Limited Edition]"
   region: "NTSC-J"
 SLPM-65302:
   name: とらかぷっ!だーっしゅ!!
-  name-sort: とらかぷっ!だーっしゅ!!
+  name-sort: とらかぷっ だーっしゅ
   name-en: "Torakapuu! Dash"
   region: "NTSC-J"
 SLPM-65303:
@@ -37045,7 +37141,7 @@ SLPM-65303:
 SLPM-65305:
   name: 幻想水滸伝 III KONAMI THE BEST
   name-sort: げんそうすいこでん III KONAMI THE BEST
-  name-en: "Genso Suikoden 3"
+  name-en: "Gensou Suikoden 3"
   region: "NTSC-J"
   memcardFilters:
     - "SLPM-65073"
@@ -37062,13 +37158,13 @@ SLPM-65305:
     - "SLPM-86953"
     - "SLPM-87262"
 SLPM-65306:
-  name: SAKURA～雪月華～ 初回限定版
-  name-sort: SAKURA～せつげっか～ しょかいげんていばん
+  name: SAKURA〜雪月華〜 初回限定版
+  name-sort: さくら せつげっか しょかいげんていばん
   name-en: "Sakura - Yuki Gekka [First Print Limited Edition]"
   region: "NTSC-J"
 SLPM-65307:
-  name: SAKURA～雪月華～
-  name-sort: SAKURA～せつげっか～
+  name: SAKURA〜雪月華〜
+  name-sort: さくら せつげっか
   name-en: "Sakura - Yuki Gekka"
   region: "NTSC-J"
 SLPM-65308:
@@ -37082,23 +37178,23 @@ SLPM-65308:
     wildArmsHack: 1 # Improves visual clarity whilst upscaling.
     roundSprite: 1 # Reduces graphics garbage on UI whilst upscaling.
 SLPM-65309:
-  name: "Splashdown [PS2 The Best]"
+  name: "Splashdown [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPM-65310:
-  name: The Mark of KRI(マーク オブ クリィ)
+  name: The Mark of KRI
   name-sort: まーく おぶ くりぃ
   name-en: "Mark of Kri, The"
   region: "NTSC-J"
 SLPM-65311:
   name: ヴィオラートのアトリエ 〜グラムナートの錬金術士2〜
-  name-sort: ゔぃおらーとのあとりえ 〜ぐらむなーとのれんきんじゅつし2〜
+  name-sort: ゔぃおらーとのあとりえ ぐらむなーとのれんきんじゅつし2
   name-en: "Violet no Atelier - Gramnad no Renkinjutsushi"
   region: "NTSC-J"
   gsHWFixes:
     roundSprite: 1 # Aligns text boxes.
 SLPM-65313:
-  name: ファーストKiss☆物語(ストーリーズ)
-  name-sort: ふぁーすとKiss☆すとーりーず
+  name: ファーストKiss☆物語
+  name-sort: ふぁーすと きす すとーりーず
   name-en: "First Kiss Story 1&2"
   region: "NTSC-J"
 SLPM-65314:
@@ -37124,12 +37220,12 @@ SLPM-65317:
   region: "NTSC-J"
 SLPM-65318:
   name: 勝負師伝説 哲也2 玄人頂上決戦
-  name-sort: しょうぶしでんせつ てつや2 くろうとちょうじょうけっせん
-  name-en: "Shoubushi Tetsuya 2"
+  name-sort: ぎゃんぶらーでんせつ てつや2 くろうとちょうじょうけっせん
+  name-en: "Gambler Densetsu Tetsuya 2"
   region: "NTSC-J"
 SLPM-65319:
   name: EVE burst error PLUS 限定版 DVD-BOX
-  name-sort: EVE burst error PLUS げんていばん DVD-BOX
+  name-sort: EVE burst error PLUS [げんていばん] DVD-BOX
   name-en: "Eve Burst Error Plus [Limited Edition]"
   region: "NTSC-J"
 SLPM-65320:
@@ -37159,7 +37255,7 @@ SLPM-65324:
   region: "NTSC-J"
 SLPM-65325:
   name: レスキューヘリ　エアレンジャー2 低価格版
-  name-sort: れすきゅーへり　えあれんじゃー2 ていかかくばん
+  name-sort: れすきゅーへり えあれんじゃー2 ていかかくばん
   name-en: "Air Ranger 2 - Rescue Helicopter [Best]"
   region: "NTSC-J"
 SLPM-65326:
@@ -37179,17 +37275,17 @@ SLPM-65328:
   region: "NTSC-J"
 SLPM-65329:
   name: 魔界転生
-  name-sort: まかいてんしょう
+  name-sort: まかいてんせい
   name-en: "Makai Tensei"
   region: "NTSC-J"
 SLPM-65330:
   name: 悪代官2〜妄想伝〜
-  name-sort: あくだいかん2〜もうそうでん〜
+  name-sort: あくだいかん2 もうそうでん
   name-en: "Akudaikan 2 - Mousouden"
   region: "NTSC-J"
 SLPM-65331:
   name: ロックマンX7
-  name-sort: ろっくまんX7
+  name-sort: ろっくまんえっくす7
   name-en: "Rockman X7"
   region: "NTSC-J"
   compat: 5
@@ -37199,12 +37295,12 @@ SLPM-65331:
     disablePartialInvalidation: 1 # Fixes Fixes black screens.
 SLPM-65332:
   name: まほろまてぃっく 萌っと≠きらきらメイドさん。 限定版
-  name-sort: まほろまてぃっく もえっと≠きらきらめいどさん。 げんていばん
+  name-sort: まほろまてぃっく もえっときらきらめいどさん [げんていばん]
   name-en: "Mahoromatic Automatic Maiden [Limited Edition]"
   region: "NTSC-J"
 SLPM-65333:
   name: まほろまてぃっく 萌っと≠きらきらメイドさん。
-  name-sort: まほろまてぃっく もえっと≠きらきらめいどさん。
+  name-sort: まほろまてぃっく もえっときらきらめいどさん
   name-en: "Mahoromatic Automatic Maiden"
   region: "NTSC-J"
 SLPM-65334:
@@ -37216,7 +37312,7 @@ SLPM-65334:
 SLPM-65335:
   name: 激闘プロ野球 水島新司オールスターズ VS プロ野球
   name-sort: げきとうぷろやきゅう みずしましんじおーるすたーず VS ぷろやきゅう
-  name-en: "Gekitou Professional Baseball"
+  name-en: "Gekitou Pro Yakyuu"
   region: "NTSC-J"
 SLPM-65336:
   name: K-1 WORLD GRAND PRIX THE BEAST ATTACK!
@@ -37226,9 +37322,9 @@ SLPM-65336:
   gsHWFixes:
     alignSprite: 1 # Fixes upscaling lines.
 SLPM-65337:
-  name: ゲゲゲの鬼太郎 異聞妖怪奇
-  name-sort: げげげのきたろう いぶんようかいき
-  name-en: "Gegege no Kitaro - Ibun Youkaitan"
+  name: ゲゲゲの鬼太郎 異聞妖怪奇譚
+  name-sort: げげげのきたろう いぶんようかいきたん
+  name-en: "Gegege no Kitaro - Ibun Youkaikitan"
   region: "NTSC-J"
   compat: 5
 SLPM-65338:
@@ -37248,21 +37344,21 @@ SLPM-65340:
   region: "NTSC-J"
 SLPM-65341:
   name: サイレントヒル2 最期の詩 [コナミ・ザ・ベスト]
-  name-sort: さいれんとひる2 さいごのし [こなみ・ざ・べすと]
-  name-en: "Silent Hill 2 - Saigo No Uta [Konami The Best]"
+  name-sort: さいれんとひる2 さいごのうた [こなみ・ざ・べすと]
+  name-en: "Silent Hill 2 - Saigo no Uta [Konami The Best]"
   region: "NTSC-J"
   speedHacks:
     eeCycleRate: 1 # Fixes FMV hangs.
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes menu transparancy and effects.
 SLPM-65342:
-  name: 恐怖新聞【平成版】〜怪奇!心霊ファイル〜(PS2)
-  name-sort: きょうふしんぶん【へいせいばん】〜かいき!しんれいふぁいる〜(PS2)
+  name: 恐怖新聞【平成版】〜怪奇!心霊ファイル〜
+  name-sort: きょうふしんぶん へいせいばん かいき!しんれいふぁいる
   name-en: "Kyoufu Shinbun (Heisei) Kaiki! Shinrei File"
   region: "NTSC-J"
 SLPM-65343:
   name: 機甲兵団 J-PHOENIX2
-  name-sort: きこうへいだん J-PHOENIX2
+  name-sort: きこうへいだん じぇいふぇにっくす2
   name-en: "Kikou Heidan J-Phoenix 2"
   region: "NTSC-J"
   memcardFilters:
@@ -37270,7 +37366,7 @@ SLPM-65343:
     - "SLPM-65343"
 SLPM-65344:
   name: プロジェクト・ミネルヴァ・プロフェッショナル
-  name-sort: ぷろじぇくと・みねるゔぁ・ぷろふぇっしょなる
+  name-sort: ぷろじぇくと みねるゔぁ ぷろふぇっしょなる
   name-en: "Project Minerva - Professional"
   region: "NTSC-J"
 SLPM-65345:
@@ -37280,7 +37376,7 @@ SLPM-65345:
   region: "NTSC-J"
 SLPM-65346:
   name: WinningPost 6
-  name-sort: WinningPost 6
+  name-sort: ういにんぐぽすと6
   name-en: "Winning Post 6"
   region: "NTSC-J"
 SLPM-65347:
@@ -37290,22 +37386,22 @@ SLPM-65347:
   region: "NTSC-J"
 SLPM-65348:
   name: ビストロ・きゅーぴっと2 通常版
-  name-sort: びすとろ・きゅーぴっと2 つうじょうばん
+  name-sort: びすとろ・きゅーぴっと2 [つうじょうばん]
   name-en: "Bistro Cupid 2"
   region: "NTSC-J"
 SLPM-65349:
   name: SuperLite 2000シミュレーション 東京バス案内〜今日から君も運転手〜
-  name-sort: SuperLite 2000しみゅれーしょん とうきょうばすあんない〜きょうからきみもうんてんしゅ〜
+  name-sort: SuperLite 2000しみゅれーしょん とうきょうばすあんない きょうからきみもうんてんしゅ
   name-en: "Tokyo Bus Guide [Superlite 2000 Series]"
   region: "NTSC-J"
 SLPM-65350:
   name: SIMPLE2000シリーズ アルティメットVol.11 ワンダバスタイル〜突撃!みっくす生JUICE〜
-  name-sort: SIMPLE2000しりーず あるてぃめっとVol.11 わんだばすたいる〜とつげき!みっくすなまJUICE〜
+  name-sort: SIMPLE2000しりーず あるてぃめっとVol.11 わんだばすたいる とつげき!みっくすなまじゅーす
   name-en: "Simple 2000 Series Ultimate Vol. 11 - Wandaba Style - Totsugeki! Mix Ki Juice"
   region: "NTSC-J"
 SLPM-65352:
   name: SIMPLE2000シリーズ アルティメットVol.10 ラブ★ソングス♪
-  name-sort: SIMPLE2000しりーず あるてぃめっとVol.10 らぶ★そんぐす♪
+  name-sort: SIMPLE2000しりーず あるてぃめっとVol.10 らぶそんぐす
   name-en: "Simple 2000 Series Ultimate Vol. 10 - Love - Songs"
   region: "NTSC-J"
 SLPM-65353:
@@ -37321,7 +37417,7 @@ SLPM-65355:
   region: "NTSC-J"
 SLPM-65356:
   name: 夏色小町【一日千夏】 [通常版]
-  name-sort: なついろこまち【いちじつせんか】 [つうじょうばん]
+  name-sort: なついろこまち いちじつせんか [つうじょうばん]
   name-en: "Natsuiro Komachi"
   region: "NTSC-J"
 SLPM-65357:
@@ -37342,13 +37438,13 @@ SLPM-65359:
   region: "NTSC-J"
 SLPM-65361:
   name: ANUBIS ZONE OF THE ENDERS SPECIAL EDITION [限定版]
-  name-sort: ANUBIS ZONE OF THE ENDERS SPECIAL EDITION [げんていばん]
+  name-sort: あぬびす ぞーん おぶ えんだーず SPECIAL EDITION [げんていばん]
   name-en: "Anubis - Zone of the Enders Special Edition [Limited Edition]"
   region: "NTSC-J"
   compat: 5
 SLPM-65362:
   name: NHK 天才ビットくん グラモンバトル
-  name-sort: NHK てんさいびっとくん ぐらもんばとる
+  name-sort: えぬえいちけい てんさいびっとくん ぐらもんばとる
   name-en: "NHK Tensai Bit-Kun - Guramon Battle"
   region: "NTSC-J"
 SLPM-65363:
@@ -37361,7 +37457,7 @@ SLPM-65364:
   region: "NTSC-J"
 SLPM-65365:
   name: ときめきメモリアル Girl’s Side [コナミ ザ ベスト]
-  name-sort: ときめきめもりある Girl’s Side [こなみ ざ べすと]
+  name-sort: ときめきめもりある がーるずさいど [こなみ ざ べすと]
   name-en: "Tokimeki Memorial - Girl's Side [Konami The Best]"
   region: "NTSC-J"
 SLPM-65366:
@@ -37371,7 +37467,7 @@ SLPM-65366:
   region: "NTSC-J"
 SLPM-65367:
   name: 魔界英雄記マキシモ 〜マシンモンスターの野望〜
-  name-sort: まかいえいゆうきまきしも 〜ましんもんすたーのやぼう〜
+  name-sort: まかいえいゆうきまきしも ましんもんすたーのやぼう
   name-en: "Makai Eiyuuki Maximo - Machine Monster no Yabou"
   region: "NTSC-J"
   compat: 5
@@ -37379,7 +37475,7 @@ SLPM-65367:
     halfPixelOffset: 2 # Fixes outlines around environmental objects.
 SLPM-65368:
   name: D・N・ANGEL TV Animation Series 〜紅の翼〜
-  name-sort: D・N・ANGEL TV Animation Series 〜くれないのつばさ〜
+  name-sort: D・N・ANGEL TV Animation Series くれないのつばさ
   name-en: "D.N. Angel - TV Animation Series"
   region: "NTSC-J"
 SLPM-65369:
@@ -37399,14 +37495,14 @@ SLPM-65372:
   name-en: "Soccer Kantoku Saihai Simulation - Formation Final"
   region: "NTSC-J"
 SLPM-65373:
-  name: 玻璃の薔薇(ガラスノバラ)
+  name: 玻璃の薔薇 (ガラスノバラ)
   name-sort: がらすのばら
   name-en: "Glass Rose"
   region: "NTSC-J"
   compat: 5
 SLPM-65374:
   name: エナジーエアフォース エイムストライク
-  name-sort: えなじーえあふぉーす えいむすとらいく
+  name-sort: えなじーえあふぉーす えいむすとらいく!
   name-en: "Energy Airforce - Aim Strike!"
   region: "NTSC-J"
   speedHacks:
@@ -37416,16 +37512,16 @@ SLPM-65374:
     autoFlush: 2 # Corrects post-processing effect on jet exhausts.
 SLPM-65375:
   name: 真・三國無双3 プレミアムパック(真・三國無双3&真・三國無双3 猛将伝)
-  name-sort: しん・さんごくむそう3 ぷれみあむぱっく(しん・さんごくむそう3&しん・さんごくむそう3 もうしょうでん)
-  name-en: "Shin Sangoku Musou 3 - Mushoden [Premium Pack]"
+  name-sort: しんさんごくむそう3 ぷれみあむぱっく(しんさんごくむそう3&しんさんごくむそう3 もうしょうでん)
+  name-en: "Shin Sangoku Musou 3 - Moushouden [Premium Pack]"
   region: "NTSC-J"
 SLPM-65376:
   name: "Shin Sangoku Musou 3 - Moushouden"
   region: "NTSC-J"
 SLPM-65377:
   name: 真・三國無双3 猛将伝
-  name-sort: しん・さんごくむそう3 もうしょうでん
-  name-en: "Shin Sangoku Musou 3 - Mushoden"
+  name-sort: しんさんごくむそう3 もうしょうでん
+  name-en: "Shin Sangoku Musou 3 - Moushouden"
   region: "NTSC-J"
 SLPM-65378:
   name: BUSIN 0 Wizardry Alternative NEO
@@ -37442,7 +37538,7 @@ SLPM-65379:
   region: "NTSC-J"
 SLPM-65380:
   name: 侍道2 〜WAY OF THE SAMURAI 2〜
-  name-sort: さむらいどう2 〜WAY OF THE SAMURAI 2〜
+  name-sort: さむらいどう2 WAY OF THE SAMURAI 2
   name-en: "Samurai Michi 2"
   region: "NTSC-J"
 SLPM-65381:
@@ -37457,7 +37553,7 @@ SLPM-65382:
   region: "NTSC-J"
 SLPM-65383:
   name: GROWLANSER IV 〜Wayfarer of the time〜 [デラックスパック]
-  name-sort: GROWLANSER IV 〜Wayfarer of the time〜 [でらっくすぱっく]
+  name-sort: GROWLANSER IV Wayfarer of the time でらっくすぱっく
   name-en: "Growlanser IV - Wayfarer of the Time [Limited Edition]"
   region: "NTSC-J"
 SLPM-65384:
@@ -37481,17 +37577,17 @@ SLPM-65387:
   region: "NTSC-J"
 SLPM-65388:
   name: Lost Passage 〜失われた一節〜 [初回限定版]
-  name-sort: Lost Passage 〜うしなわれたいっせつ〜 [しょかいげんていばん]
+  name-sort: Lost Passage うしなわれたいっせつ しょかいげんていばん
   name-en: "Lost Passage [Limited Edition]"
   region: "NTSC-J"
 SLPM-65389:
   name: Lost Passage 〜失われた一節〜 [通常版]
-  name-sort: Lost Passage 〜うしなわれたいっせつ〜 [つうじょうばん]
+  name-sort: Lost Passage うしなわれたいっせつ [つうじょうばん]
   name-en: "Lost Passage"
   region: "NTSC-J"
 SLPM-65390:
   name: 新紀幻想 スペクトラル ソウルズ 限定版
-  name-sort: しんきげんそう すぺくとらる そうるず げんていばん
+  name-sort: しんきげんそう すぺくとらる そうるず [げんていばん]
   name-en: "Shinki Gensou - Spectral Souls [Limited Edition]"
   region: "NTSC-J"
 SLPM-65391:
@@ -37501,17 +37597,17 @@ SLPM-65391:
   region: "NTSC-J"
 SLPM-65392:
   name: 彼女の伝説、僕の石版〜アリミリオンの剣とともに〜
-  name-sort: かのじょのでんせつ、ぼくのせきばん〜ありみりおんのけんとともに〜
+  name-sort: かのじょのでんせつ ぼくのせきばん ありみりおんのけんとともに
   name-en: "Kanojo no Densetsu - Boku no Sekiban"
   region: "NTSC-J"
 SLPM-65393:
-  name: SIMPLE2000シリーズVol.39 漢のためのバイブルTHE友情アドベンチャー 〜炎多留・魂〜
-  name-sort: SIMPLE2000しりーずVol.39 おとこのためのばいぶるTHEゆうじょうあどべんちゃー 〜ほたる・そうる〜
+  name: SIMPLE2000シリーズVol.39 漢のためのバイブル THE 友情アドベンチャー 〜炎多留・魂〜
+  name-sort: SIMPLE2000しりーずVol.39 おとこのためのばいぶる THE ゆうじょうあどべんちゃー ほたる そうる
   name-en: "Simple 2000 Series Vol. 38 - The Yuujou Adventure - Hotaru Soul"
   region: "NTSC-J"
 SLPM-65394:
   name: ラブ★スマッシュ!5〜テニスロボの反乱〜
-  name-sort: らぶ★すまっしゅ!5〜てにすろぼのはんらん〜
+  name-sort: らぶすまっしゅ!5〜てにすろぼのはんらん〜
   name-en: "Love Smash! 5"
   region: "NTSC-J"
   gameFixes:
@@ -37526,27 +37622,27 @@ SLPM-65396:
   region: "NTSC-J"
 SLPM-65397:
   name: テニスの王子様 〜Kiss of Prince〜 Ice version
-  name-sort: てにすのおうじさま 〜Kiss of Prince〜 Ice version
+  name-sort: てにすのおうじさま Kiss of Prince Ice version
   name-en: "Prince of Tennis - Kiss of Prince - Ice Version"
   region: "NTSC-J"
 SLPM-65398:
   name: テニスの王子様 〜Kiss of Prince〜 Flame version
-  name-sort: てにすのおうじさま 〜Kiss of Prince〜 Flame version
+  name-sort: てにすのおうじさま Kiss of Prince Flame version
   name-en: "Prince of Tennis - Kiss of Prince - Flame Version"
   region: "NTSC-J"
 SLPM-65399:
   name: D.C.P.S. 〜ダ・カーポ〜 プラスシチュエーション DXパック
-  name-sort: D.C.P.S. 〜だ・かーぽ〜 ぷらすしちゅえーしょん DXぱっく
+  name-sort: だかーぽ ぷらすしちゅえーしょん DXぱっく
   name-en: "D.C.P.S. [Limited Edition]"
   region: "NTSC-J"
 SLPM-65400:
   name: D.C.P.S. 〜ダ・カーポ〜 プラスシチュエーション
-  name-sort: D.C.P.S. 〜だ・かーぽ〜 ぷらすしちゅえーしょん
+  name-sort: だかーぽ ぷらすしちゅえーしょん
   name-en: "D.C.P.S."
   region: "NTSC-J"
 SLPM-65401:
   name: 天外魔境II MANJI MARU
-  name-sort: てんがいまきょうII MANJI MARU
+  name-sort: てんがいまきょう2 MANJI MARU
   name-en: "Tengai Makyou II - Manji Maru"
   region: "NTSC-J"
 SLPM-65402:
@@ -37557,8 +37653,8 @@ SLPM-65403:
   region: "NTSC-J"
 SLPM-65404:
   name: 北へ。〜Diamond Dust〜
-  name-sort: きたへ。〜Diamond Dust〜
-  name-en: "Kita He - Diamond Dust"
+  name-sort: きたへ Diamond Dust
+  name-en: "Kita he - Diamond Dust"
   region: "NTSC-J"
 SLPM-65405:
   name: 超時空要塞マクロス
@@ -37570,7 +37666,7 @@ SLPM-65405:
     texturePreloading: 1 # Performs much better with partial preload.
 SLPM-65406:
   name: キャッスルヴァニア 限定版
-  name-sort: きゃっするゔぁにあ げんていばん
+  name-sort: きゃっするゔぁにあ [げんていばん]
   name-en: "Castlevania [Limited Edition]"
   region: "NTSC-J"
   clampModes:
@@ -37583,7 +37679,7 @@ SLPM-65407:
   compat: 5
 SLPM-65408:
   name: GROWLANSER IV 〜Wayfarer of thetime〜
-  name-sort: GROWLANSER IV 〜Wayfarer of thetime〜
+  name-sort: GROWLANSER IV Wayfarer of thetime
   name-en: "Growlanser IV - Wayfarer of the Time"
   region: "NTSC-J"
 SLPM-65409:
@@ -37592,7 +37688,7 @@ SLPM-65409:
   name-en: "Air Ranger 2 Plus - Rescue Helicopter"
   region: "NTSC-J"
 SLPM-65410:
-  name: ゲッタウェイ(the Getaway)
+  name: ゲッタウェイ (the Getaway)
   name-sort: げったうぇい
   name-en: "Getaway, The"
   region: "NTSC-J"
@@ -37633,7 +37729,7 @@ SLPM-65413:
     bilinearUpscale: 2 # Gets rid of center vertical line when upscaling.
 SLPM-65414:
   name: SIMPLE2000シリーズ Vol.45 THE 恋と涙と、追憶と・・・。〜スレッドカラーズ さよならの向こう側〜
-  name-sort: SIMPLE2000しりーず Vol.45 THE こいとなみだと、ついおくと・・・。〜すれっどからーず さよならのむこうがわ〜
+  name-sort: SIMPLE2000しりーず Vol.45 THE こいとなみだと ついおくと すれっどからーず さよならのむこうがわ
   name-en: "Simple 2000 Series Vol. 45 - The Koi to Namida to, Tsuioku to..."
   region: "NTSC-J"
 SLPM-65415:
@@ -37646,17 +37742,17 @@ SLPM-65416:
   region: "NTSC-J"
 SLPM-65417:
   name: Mat Hoffman’s Pro BMX 2003 マット・ホフマン プロBMX
-  name-sort: Mat Hoffman’s Pro BMX 2003 まっと・ほふまん ぷろBMX
+  name-sort: まっとほふまん ぷろ BMX 2003
   name-en: "Mat Hoffman's Pro BMX 2003"
   region: "NTSC-J"
 SLPM-65418:
   name: Kelly Slater’s Pro Surfer 2003 ケリー・スレーター プロサーファー
-  name-sort: Kelly Slater’s Pro Surfer 2003 けりー・すれーたー ぷろさーふぁー
+  name-sort: けりーすれーたー ぷろさーふぁー 2003
   name-en: "Kelly Slater's Pro Surfer 2003"
   region: "NTSC-J"
 SLPM-65419:
   name: Tony Hawk’s Pro Skater 2003 トニー・ホーク プロスケーター
-  name-sort: Tony Hawk’s Pro Skater 2003 とにー・ほーく ぷろすけーたー
+  name-sort: とにーほーく ぷろすけーたー 2003
   name-en: "Tony Hawk's Pro Skater 2003"
   region: "NTSC-J"
   roundModes:
@@ -37673,7 +37769,7 @@ SLPM-65421:
   region: "NTSC-J"
 SLPM-65422:
   name: トム・クランシーシリーズ スプリンターセル
-  name-sort: とむ・くらんしーしりーず すぷりんたーせる
+  name-sort: とむくらんしーしりーず すぷりんたーせる
   name-en: "Tom Clancy's Splinter Cell"
   region: "NTSC-J"
 SLPM-65423:
@@ -37683,22 +37779,22 @@ SLPM-65423:
   region: "NTSC-J"
 SLPM-65424:
   name: モエかん 〜もえっ娘島へようこそ〜 [初回限定版]
-  name-sort: もえかん 〜もえっこしまへようこそ〜 [しょかいげんていばん]
+  name-sort: もえかん もえっこしまへようこそ しょかいげんていばん
   name-en: "Moekko Company [Limited Edition]"
   region: "NTSC-J"
 SLPM-65425:
   name: モエかん 〜もえっ娘島へようこそ〜 [通常版]
-  name-sort: もえかん 〜もえっこしまへようこそ〜 [つうじょうばん]
+  name-sort: もえかん もえっこしまへようこそ [つうじょうばん]
   name-en: "Moekko Company"
   region: "NTSC-J"
 SLPM-65426:
   name: プロ野球チームをつくろう!2003
-  name-sort: ぷろやきゅうちーむをつくろう!2003
+  name-sort: ぷろやきゅうちーむをつくろう2003
   name-en: "Pro Baseball Team Tsukuro! 2003"
   region: "NTSC-J"
 SLPM-65427:
   name: RSII 〜ライディングスピリッツ2〜
-  name-sort: RSII 〜らいでぃんぐすぴりっつ2〜
+  name-sort: RSII らいでぃんぐすぴりっつ2
   name-en: "Riding Spirits 2"
   region: "NTSC-J"
 SLPM-65428:
@@ -37739,8 +37835,8 @@ SLPM-65434:
     vuClampMode: 3 # Stops car from falling through track.
 SLPM-65435:
   name: 北へ。〜Diamond Dust〜
-  name-sort: きたへ。〜Diamond Dust〜
-  name-en: "Diamond Dust"
+  name-sort: きたへ Diamond Dust
+  name-en: "Kita he - Diamond Dust"
   region: "NTSC-J"
 SLPM-65436:
   name: "Shin Sangoku Musou 3 - Moushouden"
@@ -37776,7 +37872,7 @@ SLPM-65439:
     - "SLPM-65438"
 SLPM-65441:
   name: あしたのジョー 〜まっ白に燃え尽きろ!〜
-  name-sort: あしたのじょー 〜まっしろにもえつきろ!〜
+  name-sort: あしたのじょー まっしろにもえつきろ!
   name-en: "Ashita no Joe - Masshiro ni Moe Tsukiro!"
   region: "NTSC-J"
 SLPM-65442:
@@ -37862,13 +37958,13 @@ SLPM-65455:
   region: "NTSC-J"
 SLPM-65456:
   name: ナースウィッチ小麦ちゃん マジカルて [初回限定版]
-  name-sort: なーすうぃっちこむぎちゃん まじかるて [しょかいげんていばん]
+  name-sort: なーすうぃっちこむぎちゃん まじかるて しょかいげんていばん
   name-en: "Magical Nurse Witch Komugi-chan [Limited Edition]"
   region: "NTSC-J"
 SLPM-65457:
   name: ナースウィッチ小麦ちゃん マジカルて [通常版]
   name-sort: なーすうぃっちこむぎちゃん まじかるて [つうじょうばん]
-  name-en: "Magical Nurse Witch Komugi-chan"
+  name-en: "Magical Nurse Witch Komugi-chan [Standard Edition]"
   region: "NTSC-J"
 SLPM-65458:
   name: 鋼鉄の咆哮2 ウォーシップコマンダー
@@ -37892,7 +37988,7 @@ SLPM-65461:
   region: "NTSC-J"
 SLPM-65462:
   name: 真・女神転生III-NOCTURNE マニアクス
-  name-sort: しん・めがみてんせいIII-NOCTURNE まにあくす
+  name-sort: しんめがみてんせい3-NOCTURNE まにあくす
   name-en: "Shin Megami Tensei III - Nocturne Maniax"
   region: "NTSC-J"
   compat: 5
@@ -37917,14 +38013,14 @@ SLPM-65464:
   region: "NTSC-J"
 SLPM-65465:
   name: ハリー・ポッターと賢者の石
-  name-sort: はりー・ぽったーとけんじゃのいし
-  name-en: "Harry Potter to Kenja no Ishi"
+  name-sort: はりーぽったーとけんじゃのいし
+  name-en: "Harry Potter and the Philosopher's Stone"
   region: "NTSC-J"
   gameFixes:
     - EETimingHack
 SLPM-65466:
-  name: 黄泉がえり ～リフレイン～
-  name-sort: よみがえり ～りふれいん～
+  name: 黄泉がえり 〜リフレイン〜
+  name-sort: よみがえり 〜りふれいん〜
   name-en: "Yomigaeri - Refrain"
   region: "NTSC-J"
 SLPM-65468:
@@ -37942,12 +38038,12 @@ SLPM-65470:
   region: "NTSC-J"
 SLPM-65471:
   name: ニード・フォー・スピード アンダーグラウンド
-  name-sort: にーど・ふぉー・すぴーど あんだーぐらうんど
+  name-sort: にーど ふぉー すぴーど あんだーぐらうんど
   name-en: "Need for Speed - Underground"
   region: "NTSC-J"
 SLPM-65472:
   name: TrainSimulator+電車でGO! 東京急行編
-  name-sort: TrainSimulator+でんしゃでGO! とうきょうきゅうこうへん
+  name-sort: TrainSimulator+でんしゃでごー とうきょうきゅうこうへん
   name-en: "Train Simulator & Densha de Go! Tokyo Kyuukouhen"
   region: "NTSC-J"
 SLPM-65473:
@@ -37962,13 +38058,13 @@ SLPM-65474:
   name-en: "Kurogane no Houkou 2 - Warship Commander [Limited Edition]"
   region: "NTSC-J"
 SLPM-65477:
-  name: 紅の海2 ～Crimson Sea～
-  name-sort: くれないのうみ2 ～Crimson Sea～
+  name: 紅の海2 〜Crimson Sea〜
+  name-sort: くれないのうみ2 〜Crimson Sea〜
   name-en: "Crimson Sea 2"
   region: "NTSC-J"
 SLPM-65478:
   name: ファイナルファンタジーX-2 インターナショナル+ラストミッション
-  name-sort: ふぁいなるふぁんたじーX-2 いんたーなしょなる+らすとみっしょん
+  name-sort: ふぁいなるふぁんたじー10-2 いんたーなしょなる+らすとみっしょん
   name-en: "Final Fantasy X-2 International"
   region: "NTSC-J"
   clampModes:
@@ -37993,12 +38089,12 @@ SLPM-65480:
 SLPM-65481:
   name: After...〜忘れえぬ絆〜 初回限定版
   name-sort: After...〜わすれえぬきずな〜 しょかいげんていばん
-  name-en: "After... Wasureenu Kizuna [Shokai Genteiban]"
+  name-en: "After... Wasureenu Kizuna [First Print Limited Edition]"
   region: "NTSC-J"
 SLPM-65482:
   name: After...〜忘れえぬ絆〜 通常版
-  name-sort: After...〜わすれえぬきずな〜 つうじょうばん
-  name-en: "After..."
+  name-sort: After...〜わすれえぬきずな〜 [つうじょうばん]
+  name-en: "After... [Standard Edition]"
   region: "NTSC-J"
 SLPM-65483:
   name: シークレット・ウェポン・オーバー・ノルマンディ
@@ -38087,7 +38183,7 @@ SLPM-65499:
 SLPM-65500:
   name: ANUBIS ZONE OF THE ENDERS SPECIAL EDITION [通常版]
   name-sort: ANUBIS ZONE OF THE ENDERS SPECIAL EDITION [つうじょうばん]
-  name-en: "Anubis - Zone of the Enders Special Edition"
+  name-en: "Anubis - Zone of the Enders Special Edition [Standard Edition]"
   region: "NTSC-J"
 SLPM-65501:
   name: フロッガーレスキュー
@@ -38101,7 +38197,7 @@ SLPM-65502:
   region: "NTSC-J"
 SLPM-65503:
   name: ロード・オブ・ザ・リング/王の帰還
-  name-sort: ろーど・おぶ・ざ・りんぐ/おうのきかん
+  name-sort: ろーど おぶ ざ りんぐ/おうのきかん
   name-en: "Lord of the Rings, The - The Return of the King"
   region: "NTSC-J"
   compat: 5
@@ -38161,7 +38257,7 @@ SLPM-65512:
 SLPM-65513:
   name: Angel’s Feather [通常版]
   name-sort: Angel’s Feather [つうじょうばん]
-  name-en: "Angel's Feather"
+  name-en: "Angel's Feather [Standard Edition]"
   region: "NTSC-J"
 SLPM-65514:
   name: 街道バトル2 CHAIN REACTION
@@ -38183,12 +38279,12 @@ SLPM-65517:
   region: "NTSC-J"
 SLPM-65518:
   name: らいむいろ戦奇譚☆純 DXパック
-  name-sort: らいむいろせんきたん☆じゅん DXぱっく
+  name-sort: らいむいろせんきたん じゅん DXぱっく
   name-en: "Raimuiro Senkitan Jun [Limited Edition]"
   region: "NTSC-J"
 SLPM-65519:
   name: らいむいろ戦奇譚☆純
-  name-sort: らいむいろせんきたん☆じゅん
+  name-sort: らいむいろせんきたん じゅん
   name-en: "Raimuiro Senkitan Jun"
   region: "NTSC-J"
 SLPM-65520:
@@ -38199,7 +38295,7 @@ SLPM-65520:
 SLPM-65521:
   name: てんたま2wins [通常版]
   name-sort: てんたま2wins [つうじょうばん]
-  name-en: "Tentama 2 Wins"
+  name-en: "Tentama 2 Wins [Standard Edition]"
   region: "NTSC-J"
 SLPM-65522:
   name: 爆笑!! 人生回道 NOVAうさぎが見てるぞ!!
@@ -38208,8 +38304,8 @@ SLPM-65522:
   region: "NTSC-J"
 SLPM-65523:
   name: ふらせら Hurrah!Sailor 通常版
-  name-sort: ふらせら Hurrah!Sailor つうじょうばん
-  name-en: "Hurrah! Sailor"
+  name-sort: ふらせら Hurrah!Sailor [つうじょうばん]
+  name-en: "Hurrah! Sailor [Standard Edition]"
   region: "NTSC-J"
 SLPM-65524:
   name: オレンジポケット -リュート- 初回限定版
@@ -38235,17 +38331,17 @@ SLPM-65527:
   region: "NTSC-J"
 SLPM-65529:
   name: ミッション:インポッシブル -オペレーション・サルマ-
-  name-sort: みっしょん:いんぽっしぶる -おぺれーしょん・さるま-
+  name-sort: みっしょん いんぽっしぶる おぺれーしょん さるま
   name-en: "Mission Impossible - Operation Surma"
   region: "NTSC-J"
 SLPM-65530:
   name: J.LEAGUE プロサッカークラブをつくろう!’04
-  name-sort: J.LEAGUE ぷろさっかーくらぶをつくろう!’04
+  name-sort: Jりーぐ ぷろさっかーくらぶをつくろう!’04
   name-en: "J-League Pro Soccer Club - Tsukuku 2004"
   region: "NTSC-J"
 SLPM-65531:
-  name: サクラ大戦V EPISODE 0 ～荒野のサムライ娘～
-  name-sort: さくらたいせんV EPISODE 0 ～こうやのさむらいむすめ～
+  name: サクラ大戦V EPISODE 0 〜荒野のサムライ娘〜
+  name-sort: さくらたいせんV EPISODE 0 〜こうやのさむらいむすめ〜
   name-en: "Sakura Taisen V - Episode 0"
   region: "NTSC-J"
 SLPM-65532:
@@ -38255,7 +38351,7 @@ SLPM-65532:
   region: "NTSC-J"
 SLPM-65533:
   name: ピューと吹く!ジャガー 明日のジャンプ [初回限定版]
-  name-sort: ぴゅーとふく!じゃがー あしたのじゃんぷ [しょかいげんていばん]
+  name-sort: ぴゅーとふく!じゃがー あしたのじゃんぷ しょかいげんていばん
   name-en: "Pyu to Fuku! Jaguar Ashita no Japan"
   region: "NTSC-J"
 SLPM-65534:
@@ -38277,7 +38373,7 @@ SLPM-65537:
   name-en: "Chou Battle Houshin [Koei The Best]"
   region: "NTSC-J"
 SLPM-65538:
-  name: 007 ナイトファイア [EA BEST HITS]
+  name: EA BEST HITS 007 ナイトファイア
   name-sort: 007 ないとふぁいあ [EA BEST HITS]
   name-en: "007 - Nightfire [EA Best Hits]"
   region: "NTSC-J"
@@ -38332,22 +38428,22 @@ SLPM-65547:
   region: "NTSC-J"
 SLPM-65548:
   name: フリーダム・ファイターズ
-  name-sort: ふりーだむ・ふぁいたーず
+  name-sort: ふりーだむふぁいたーず
   name-en: "Freedom Fighters"
   region: "NTSC-J"
 SLPM-65549:
   name: Remember 11 〜the age of infinity〜 [限定版]
-  name-sort: Remember 11 〜the age of infinity〜 [げんていばん]
+  name-sort: Remember 11 the age of infinity [げんていばん]
   name-en: "Remember 11 - The Age of Infinity [Limited Edition]"
   region: "NTSC-J"
 SLPM-65550:
   name: Remember 11 〜the age of infinity〜 [通常版]
-  name-sort: Remember 11 〜the age of infinity〜 [つうじょうばん]
-  name-en: "Remember 11 - The Age of Infinity"
+  name-sort: Remember 11 the age of infinity [つうじょうばん]
+  name-en: "Remember 11 - The Age of Infinity [Standard Edition]"
   region: "NTSC-J"
 SLPM-65551:
   name: ASTRO BOY 鉄腕アトム
-  name-sort: ASTRO BOY てつわんあとむ
+  name-sort: あすとろぼーい てつわんあとむ
   name-en: "Astro Boy Atom"
   region: "NTSC-J"
   roundModes:
@@ -38362,17 +38458,17 @@ SLPM-65552:
   region: "NTSC-J"
 SLPM-65553:
   name: メタルウルフREV 通常版
-  name-sort: めたるうるふREV つうじょうばん
-  name-en: "Metal Wolf Rev"
+  name-sort: めたるうるふREV [つうじょうばん]
+  name-en: "Metal Wolf Rev [Standard Edition]"
   region: "NTSC-J"
 SLPM-65554:
-  name: コロッケ!～バン王の危機を救え～
-  name-sort: ころっけ!～ばんおうのききをすくえ～
+  name: コロッケ!〜バン王の危機を救え〜
+  name-sort: ころっけ! ばんおうのききをすくえ
   name-en: "Croket! Ban-King no Kiki o Sukue"
   region: "NTSC-J"
 SLPM-65555:
   name: ドラゴンクエストV　天空の花嫁
-  name-sort: どらごんくえすとV　てんくうのはなよめ
+  name-sort: どらごんくえすと5 てんくうのはなよめ
   name-en: "Dragon Quest V - Bride of the Sky"
   region: "NTSC-J"
   compat: 5
@@ -38392,33 +38488,33 @@ SLPM-65558:
   name-en: "Steady X Study"
   region: "NTSC-J"
 SLPM-65559:
-  name: てのひらをたいように ～永久の絆～ [初回限定版]
-  name-sort: てのひらをたいように ～えいきゅうのきずな～ [しょかいげんていばん]
+  name: てのひらをたいように 〜永久の絆〜(初回限定版)
+  name-sort: てのひらをたいように 〜えいきゅうのきずな〜 しょかいげんていばん
   name-en: "Tenohira wo Taiyou ni [Limited Edition]"
   region: "NTSC-J"
 SLPM-65560:
-  name: てのひらをたいように ～永久の絆～
-  name-sort: てのひらをたいように ～えいきゅうのきずな～
+  name: てのひらをたいように 〜永久の絆〜
+  name-sort: てのひらをたいように 〜えいきゅうのきずな〜
   name-en: "Tenohira wo Taiyou ni"
   region: "NTSC-J"
 SLPM-65561:
   name: 真・三國無双3  スーパープレミアムBOX
-  name-sort: しん・さんごくむそう3  すーぱーぷれみあむBOX
+  name-sort: しんさんごくむそう3 すーぱーぷれみあむBOX
   name-en: "Shin Sangoku Musou 3 [Super Premium Pack]"
   region: "NTSC-J"
 SLPM-65564:
   name: 真・三國無双3　Empires＆猛将伝 プレミアムBOX
-  name-sort: しん・さんごくむそう3　Empires＆もうしょうでん ぷれみあむBOX
+  name-sort: しんさんごくむそう3 えんぱいあーず&もうしょうでん [ぷれみあむBOX]
   name-en: "Shin Sangoku Musou 3 - Empires"
   region: "NTSC-J"
 SLPM-65565:
   name: 真・三國無双3 Empires
-  name-sort: しん・さんごくむそう3 Empires
+  name-sort: しんさんごくむそう3 えんぱいあーず
   name-en: "Shin Sangoku Musou 3 - Empires"
   region: "NTSC-J"
 SLPM-65566:
   name: 金色のコルダ プレミアムBOX
-  name-sort: きんいろのこるだ ぷれみあむBOX
+  name-sort: きんいろのこるだ [ぷれみあむBOX]
   name-en: "La Corda d'Oro [Premium Box]"
   region: "NTSC-J"
 SLPM-65567:
@@ -38428,17 +38524,17 @@ SLPM-65567:
   region: "NTSC-J"
 SLPM-65569:
   name: 北へ。Diamond Dust + Kiss is Beginning
-  name-sort: きたへ。Diamond Dust + Kiss is Beginning
-  name-en: "Kita He - Diamond Dust + Kiss is Beginning"
+  name-sort: きたへ Diamond Dust + Kiss is Beginning
+  name-en: "Kita he - Diamond Dust + Kiss is Beginning"
   region: "NTSC-J"
 SLPM-65570:
-  name: フロッガー [コナミ殿堂セレクション]
+  name: フロッガー(コナミ殿堂セレクション)
   name-sort: ふろっがー [こなみでんどうせれくしょん]
   name-en: "Frogger [Konami Palace Collection]"
   region: "NTSC-J"
 SLPM-65571:
   name: 新天魔界 GENERATION OF CHAOS 4 限定版
-  name-sort: しんてんまかい GENERATION OF CHAOS 4 げんていばん
+  name-sort: しんてんまかい GENERATION OF CHAOS 4 [げんていばん]
   name-en: "Generation of Chaos 4 [Limited Edition]"
   region: "NTSC-J"
 SLPM-65572:
@@ -38447,8 +38543,8 @@ SLPM-65572:
   name-en: "Generation of Chaos 4"
   region: "NTSC-J"
 SLPM-65573:
-  name: WRC II ～EXTREME～ [Spike The Best]
-  name-sort: WRC II ～EXTREME～ [Spike The Best]
+  name: Spike the Best WRC II 〜EXTREME〜
+  name-sort: WRC II 〜EXTREME〜 [Spike The Best]
   name-en: "WRC II Extreme [Spike The Best]"
   region: "NTSC-J"
   gameFixes:
@@ -38486,8 +38582,8 @@ SLPM-65579:
   name-en: "Houkago no Love Beat"
   region: "NTSC-J"
 SLPM-65580:
-  name: クラッシュ・バンディクー爆走!ニトロカート
-  name-sort: くらっしゅ・ばんでぃくーばくそう!にとろかーと
+  name: クラッシュ・バンディクー 爆走!ニトロカート
+  name-sort: くらっしゅばんでぃくー ばくそう!にとろかーと
   name-en: "Crash Bandicoot - Bakuso! Nitro Kart"
   region: "NTSC-J"
 SLPM-65581:
@@ -38497,7 +38593,7 @@ SLPM-65581:
   region: "NTSC-J"
 SLPM-65582:
   name: Winning Post6 MAXIMUM 2004
-  name-sort: Winning Post6 MAXIMUM 2004
+  name-sort: ういにんぐぽすと6 MAXIMUM 2004
   name-en: "Winning Post 6 Maximum 2004"
   region: "NTSC-J"
 SLPM-65583:
@@ -38515,8 +38611,8 @@ SLPM-65584:
   name: "Shin Sangoku Musou 3 - Moushouden"
   region: "NTSC-J"
 SLPM-65585:
-  name: Princess Holiday～転がるりんご亭千夜一夜～
-  name-sort: Princess Holiday～ころがるりんごていせんやいちや～
+  name: Princess Holiday〜転がるりんご亭千夜一夜〜
+  name-sort: Princess Holiday ころがるりんごていせんやいちや
   name-en: "Princess Holiday"
   region: "NTSC-J"
 SLPM-65586:
@@ -38530,33 +38626,33 @@ SLPM-65587:
   name-en: "Fight Night 2004"
   region: "NTSC-J"
 SLPM-65588:
-  name: カラフルBOX 〜to LOVE〜 （初回限定版）
-  name-sort: からふるBOX 〜to LOVE〜 （しょかいげんていばん）
+  name: カラフルBOX 〜to LOVE〜(限定版)
+  name-sort: からふるBOX to LOVE [げんていばん]
   name-en: "Colorful Box - To Love [Limited Edition]"
   region: "NTSC-J"
 SLPM-65589:
-  name: カラフルBOX 〜to LOVE〜
-  name-sort: からふるBOX 〜to LOVE〜
-  name-en: "Colorful Box - To Love"
+  name: カラフルBOX 〜to LOVE〜(通常版)
+  name-sort: からふるBOX to LOVE
+  name-en: "Colorful Box - To Love [Standard Edition]"
   region: "NTSC-J"
 SLPM-65590:
   name: 電車でGO! -FINAL-
-  name-sort: でんしゃでGO! -FINAL-
+  name-sort: でんしゃでごー -FINAL-
   name-en: "Densha de Go! Final"
   region: "NTSC-J"
 SLPM-65591:
   name: ロスト・アヤ・ソフィア [限定版]
-  name-sort: ろすと・あや・そふぃあ [げんていばん]
+  name-sort: ろすと あや そふぃあ [げんていばん]
   name-en: "Lost Aya Sophia [Limited Edition]"
   region: "NTSC-J"
 SLPM-65592:
   name: ロスト・アヤ・ソフィア
-  name-sort: ろすと・あや・そふぃあ
+  name-sort: ろすと あや そふぃあ
   name-en: "Lost Aya Sophia"
   region: "NTSC-J"
 SLPM-65593:
   name: beatmania IIDX 7th style
-  name-sort: beatmania IIDX 7th style
+  name-sort: びーとまにあ つーでぃーえっくす 7th style
   name-en: "Beatmania IIDX 7th style"
   region: "NTSC-J"
 SLPM-65594:
@@ -38566,8 +38662,8 @@ SLPM-65594:
   region: "NTSC-J"
 SLPM-65595:
   name: 勝負師伝説 哲也2 玄人頂上決戦
-  name-sort: しょうぶしでんせつ てつや2 くろうとちょうじょうけっせん
-  name-en: "Shoubushi Gambler Densetsu - Tetsuya 2 [Athena Best]"
+  name-sort: ぎゃんぶらーでんせつ てつや2 くろうとちょうじょうけっせん
+  name-en: "Gambler Densetsu Tetsuya 2 [Athena Best]"
   region: "NTSC-J"
 SLPM-65596:
   name: 十二国記 赫々たる王道紅緑の羽化
@@ -38575,8 +38671,8 @@ SLPM-65596:
   name-en: "Juuni Kuniki - Kakukaku Taru Ou Michi Beni Midori no Uka"
   region: "NTSC-J"
 SLPM-65597:
-  name: DIGITAL DEVIL SAGA(デジタル・デビル・サーガ)〜アバタール・チューナー〜
-  name-sort: でじたる・でびる・さーが〜あばたーる・ちゅーなー〜
+  name: DIGITAL DEVIL SAGA〜アバタール・チューナー〜
+  name-sort: でじたる でびる さーが あばたーるちゅーなー
   name-en: "Digital Devil Saga - Avatar Tuner"
   region: "NTSC-J"
   gameFixes:
@@ -38588,17 +38684,17 @@ SLPM-65598:
   region: "NTSC-J"
 SLPM-65599:
   name: 幻想水滸伝IV 限定版
-  name-sort: げんそうすいこでんIV げんていばん
-  name-en: "Genso Suikoden 4 [Limited Edition]"
+  name-sort: げんそうすいこでん4 [げんていばん]
+  name-en: "Gensou Suikoden 4 [Limited Edition]"
   region: "NTSC-J"
 SLPM-65600:
   name: 幻想水滸伝IV
-  name-sort: げんそうすいこでんIV
-  name-en: "Genso Suikoden 4"
+  name-sort: げんそうすいこでん4
+  name-en: "Gensou Suikoden 4"
   region: "NTSC-J"
 SLPM-65601:
-  name: SuperLite 2000思い出にかわる君～Memories Off～
-  name-sort: SuperLite 2000おもいでにかわるきみ～Memories Off～
+  name: SuperLite 2000思い出にかわる君〜Memories Off〜
+  name-sort: SuperLite 2000おもいでにかわるきみ Memories Off
   name-en: "Omoide ni Kawaru-Kimi - Memories Off [SuperLite 2000 Series]"
   region: "NTSC-J"
 SLPM-65602:
@@ -38609,44 +38705,44 @@ SLPM-65602:
   compat: 5
 SLPM-65603:
   name: ラン・ライク・ヘル
-  name-sort: らん・らいく・へる
+  name-sort: らん らいく へる
   name-en: "Run Like Hell"
   region: "NTSC-J"
 SLPM-65604:
   name: アニメバトル 烈火の炎 FINAL BURNING <初回生産限定仕様>
-  name-sort: あにめばとる れっかのほのお FINAL BURNING <しょかいせいさんげんていしよう>
+  name-sort: あにめばとる れっかのほのお FINAL BURNING [しょかいせいさんげんていしよう]
   name-en: "Anime Battle - Rekka no Honoo - Flame of Recca - Final Burning"
   region: "NTSC-J"
   compat: 5
 SLPM-65607:
   name: 3LDK 〜幸せになろうよ〜 [初回限定版]
-  name-sort: 3LDK 〜しあわせになろうよ〜 [しょかいげんていばん]
-  name-en: "3LDK - Shiawase ni Narou yo [Limited Edition]"
+  name-sort: 3LDK しあわせになろうよ しょかいげんていばん
+  name-en: "3LDK - Shiawase ni Narou yo [First Print Limited Edition]"
   region: "NTSC-J"
 SLPM-65608:
-  name: 3LDK ～幸せになろうよ～
-  name-sort: 3LDK ～しあわせになろうよ～
+  name: 3LDK 〜幸せになろうよ〜
+  name-sort: 3LDK しあわせになろうよ
   name-en: "3LDK - Shiawase ni Narou yo"
   region: "NTSC-J"
 SLPM-65609:
-  name: メモリーズ・オフ～それから～ 限定版
-  name-sort: めもりーず・おふ～それから～ げんていばん
+  name: メモリーズ・オフ〜それから〜 限定版
+  name-sort: めもりーず おふ それから [げんていばん]
   name-en: "Memories Off... - Sorekara [Limited Edition]"
   region: "NTSC-J"
 SLPM-65610:
   name: メモリーズ・オフ〜それから〜 通常版
-  name-sort: めもりーず・おふ〜それから〜 つうじょうばん
-  name-en: "Memories Off... - Sorekara"
+  name-sort: めもりーず おふ それから [つうじょうばん]
+  name-en: "Memories Off... - Sorekara [Standard Edition]"
   region: "NTSC-J"
 SLPM-65611:
-  name: PIZZICATO POLKA ～縁鎖現夜～
-  name-sort: PIZZICATO POLKA ～えんさげんや～
+  name: PIZZICATO POLKA 〜縁鎖現夜〜
+  name-sort: PIZZICATO POLKA えんさげんや
   name-en: "Pizzicato Polka"
   region: "NTSC-J"
 SLPM-65612:
   name: ハリー・ポッターとアズカバンの囚人
-  name-sort: はりー・ぽったーとあずかばんのしゅうじん
-  name-en: "Harry Potter to Azkaban no Shuujin"
+  name-sort: はりーぽったーとあずかばんのしゅうじん
+  name-en: "Harry Potter and the Prisoner of Azkaban"
   region: "NTSC-J"
   gsHWFixes:
     mipmap: 1
@@ -38658,8 +38754,8 @@ SLPM-65613:
   name-en: "Yu-Gi-Oh! Capsule Monster Coliseum"
   region: "NTSC-J"
 SLPM-65614:
-  name: ニード・フォー・スピード アンダーグラウンド [EA BEST HITS]
-  name-sort: にーど・ふぉー・すぴーど あんだーぐらうんど [EA BEST HITS]
+  name: EA BEST HITS ニード・フォー・スピード アンダーグラウンド
+  name-sort: にーど ふぉー すぴーど あんだーぐらうんど [EA BEST HITS]
   name-en: "Need for Speed - Underground J"
   region: "NTSC-J"
   gameFixes:
@@ -38675,7 +38771,7 @@ SLPM-65616:
   name-en: "Juunikoku-ki - Guren no Shirube Koejin no Michi [Konami The Best]"
   region: "NTSC-J"
 SLPM-65617:
-  name: 冒険時代活劇ゴエモン [コナミ殿堂セレクション]
+  name: 冒険時代活劇ゴエモン(コナミ殿堂セレクション)
   name-sort: ぼうけんじだいかつげきごえもん [こなみでんどうせれくしょん]
   name-en: "Bouken Jidai Katsugeki Goemon [Konami Collection]"
   region: "NTSC-J"
@@ -38686,12 +38782,12 @@ SLPM-65618:
   region: "NTSC-J"
 SLPM-65619:
   name: トム・クランシーシリーズ ゴーストリコン ジャングルストーム
-  name-sort: とむ・くらんしーしりーず ごーすとりこん じゃんぐるすとーむ
+  name-sort: とむくらんしーしりーず ごーすとりこん じゃんぐるすとーむ
   name-en: "Tom Clancy's Ghost Recon - Jungle Storm"
   region: "NTSC-J"
 SLPM-65620:
-  name: 悪代官2～妄想伝～ [グローバル ザ・ベスト]
-  name-sort: あくだいかん2～もうそうでん～ [ぐろーばる ざ・べすと]
+  name: 悪代官2〜妄想伝〜 [グローバル ザ・ベスト]
+  name-sort: あくだいかん2〜もうそうでん〜 [ぐろーばる ざ・べすと]
   name-en: "Akudaikan 2 - Mousouden [Global The Best]"
   region: "NTSC-J"
 SLPM-65621:
@@ -38719,37 +38815,37 @@ SLPM-65622:
     - "SLPM-65631"
 SLPM-65623:
   name: 探偵学園Q奇翁館の殺意 [コナミ ザ ベスト]
-  name-sort: たんていがくえんQきおきなかんのさつい [こなみ ざ べすと]
+  name-sort: たんていがくえんQきおうかんのさつい [こなみ ざ べすと]
   name-en: "Tantei Gakuen Q - Kiokan no Satsui [Konami The Best]"
   region: "NTSC-J"
 SLPM-65624:
-  name: DEAR BOYS Fast Break! [コナミ殿堂セレクション]
+  name: DEAR BOYS Fast Break!(コナミ殿堂セレクション)
   name-sort: DEAR BOYS Fast Break! [こなみでんどうせれくしょん]
   name-en: "Dear Boys Fast Break! [Konami Palace Collection]"
   region: "NTSC-J"
 SLPM-65625:
-  name: あしたのジョー～まっ白に燃え尽きろ!～ [コナミ ザ ベスト]
-  name-sort: あしたのじょー～まっしろにもえつきろ!～ [こなみ ざ べすと]
+  name: あしたのジョー〜まっ白に燃え尽きろ!〜 [コナミ ザ ベスト]
+  name-sort: あしたのじょー まっしろにもえつきろ! [こなみ ざ べすと]
   name-en: "Ashita no Joe - Masshiro ni Moetsukuru [Konami The Best]"
   region: "NTSC-J"
 SLPM-65626:
-  name: 恐怖新聞【平成版】～怪奇!心霊ファイル～ [コナミ ザ ベスト]
-  name-sort: きょうふしんぶん【へいせいばん】～かいき!しんれいふぁいる～ [こなみ ざ べすと]
+  name: 恐怖新聞【平成版】〜怪奇!心霊ファイル〜 [コナミ ザ ベスト]
+  name-sort: きょうふしんぶん へいせいばん かいき!しんれいふぁいる [こなみ ざ べすと]
   name-en: "Kyoufu Shinbun (Heisei-Han) Kaiki! Shinrei File [Konami The Best]"
   region: "NTSC-J"
 SLPM-65627:
   name: ゲゲゲの鬼太郎 異聞妖怪奇譚  コナミ・ザ・ベスト
-  name-sort: げげげのきたろう いぶんようかいきたん  こなみ・ざ・べすと
+  name-sort: げげげのきたろう いぶんようかいきたん こなみ・ざ・べすと
   name-en: "Gegege no Kitarou [Konami The Best]"
   region: "NTSC-J"
 SLPM-65628:
-  name: SuperLite 2000 アドベンチャー此花パック～3つの事件簿～
-  name-sort: SuperLite 2000 あどべんちゃーこのはなぱっく～3つのじけんぼ～
+  name: SuperLite 2000 アドベンチャー此花パック〜3つの事件簿〜
+  name-sort: SuperLite 2000 あどべんちゃーこのはなぱっく 3つのじけんぼ
   name-en: "Konohana Pack Vol.21 - 3-tsu no Jikenbo [SuperLite 2000 Series]"
   region: "NTSC-J"
 SLPM-65629:
   name: カッパの飼い方 -How to breed kappas-
-  name-sort: かっぱのかいかた -How to breed kappas-
+  name-sort: かっぱのかいかた How to breed kappas
   name-en: "Kappa no Kai-Kata - How to Breed Kappas"
   region: "NTSC-J"
 SLPM-65630:
@@ -38758,8 +38854,8 @@ SLPM-65630:
   name-en: "Jikkyou Powerful Pro Yakyuu 11"
   region: "NTSC-J"
 SLPM-65631:
-  name: サイレントヒル2 最後の詩 [コナミ殿堂セレクション]
-  name-sort: さいれんとひる2 さいごのし [こなみでんどうせれくしょん]
+  name: サイレントヒル2 最後の詩(コナミ殿堂セレクション)
+  name-sort: さいれんとひる2 さいごのうた [こなみでんどうせれくしょん]
   name-en: "Silent Hill 2 [Konami The Best]"
   region: "NTSC-J"
   speedHacks:
@@ -38767,8 +38863,8 @@ SLPM-65631:
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes menu transparancy and effects.
 SLPM-65632:
-  name: バーチャファイターサイバージェネレーション ～ジャッジメントシックスの野望～
-  name-sort: ばーちゃふぁいたーさいばーじぇねれーしょん ～じゃっじめんとしっくすのやぼう～
+  name: バーチャファイターサイバージェネレーション 〜ジャッジメントシックスの野望〜
+  name-sort: ばーちゃふぁいたーさいばーじぇねれーしょん 〜じゃっじめんとしっくすのやぼう〜
   name-en: "Virtua Fighter Cyber Generation - Ambition of the Judgement Six"
   region: "NTSC-J"
   compat: 5
@@ -38784,8 +38880,8 @@ SLPM-65634:
   region: "NTSC-J"
 SLPM-65635:
   name: 爆炎覚醒 ネバーランド戦記ZERO
-  name-sort: 爆炎かくせい ねばーらんどせんきZERO
-  name-en: "Bakuen Kakeshi Neverland Senki Zero"
+  name-sort: ばくえんかくせい ねばーらんどせんきZERO
+  name-en: "Bakuen Kakusei Neverland Senki Zero"
   region: "NTSC-J"
 SLPM-65636:
   name: 三國志戦記2 [KOEI The Best]
@@ -38793,9 +38889,9 @@ SLPM-65636:
   name-en: "Sangokushi Senki 2 [Koei The Best]"
   region: "NTSC-J"
 SLPM-65637:
-  name: ラクガキ王国2 ～魔王城の戦い～
-  name-sort: らくがきおうこく2 ～まおうじょうのたたかい～
-  name-en: "Rakugaki Oukoku 2 - Majo no Tataki"
+  name: ラクガキ王国2 〜魔王城の戦い〜
+  name-sort: らくがきおうこく2 〜まおうじょうのたたかい〜
+  name-en: "Rakugaki Oukoku 2 - Maoh jou no Tatakai"
   region: "NTSC-J"
   compat: 5
 SLPM-65638:
@@ -38804,18 +38900,18 @@ SLPM-65638:
   name-en: "Full House Kiss"
   region: "NTSC-J"
 SLPM-65639:
-  name: パティシエなにゃんこ ～初恋はいちご味～ 限定版
-  name-sort: ぱてぃしえなにゃんこ ～はつこいはいちごあじ～ げんていばん
-  name-en: "Party Shana Nanco [Limited Edition]"
+  name: パティシエなにゃんこ 〜初恋はいちご味〜 限定版
+  name-sort: ぱてぃしえなにゃんこ 〜はつこいはいちごあじ〜 [げんていばん]
+  name-en: "Patissier na Nyanko [Limited Edition]"
   region: "NTSC-J"
 SLPM-65640:
-  name: パティシエなにゃんこ ～初恋はいちご味～
-  name-sort: ぱてぃしえなにゃんこ ～はつこいはいちごあじ～
-  name-en: "Party Shana Nanco"
+  name: パティシエなにゃんこ 〜初恋はいちご味〜
+  name-sort: ぱてぃしえなにゃんこ 〜はつこいはいちごあじ〜
+  name-en: "Patissier na Nyanko"
   region: "NTSC-J"
 SLPM-65641:
-  name: うたう♪タンブリング・ダイス ～私たち3人、あ・げ・る～
-  name-sort: うたう♪たんぶりんぐ・だいす ～わたしたち3にん、あ・げ・る～
+  name: うたう♪タンブリング・ダイス 〜私たち3人、あ・げ・る〜
+  name-sort: うたうたんぶりんぐだいす わたしたち3にんあげる
   name-en: "Utau - Tumbling Dice"
   region: "NTSC-J"
 SLPM-65642:
@@ -38826,7 +38922,7 @@ SLPM-65642:
   compat: 5
 SLPM-65643:
   name: ロックマンX コマンドミッション
-  name-sort: ろっくまんX こまんどみっしょん
+  name-sort: ろっくまんえっくす こまんどみっしょん
   name-en: "RockMan X - Command Mission"
   region: "NTSC-J"
   clampModes:
@@ -38840,7 +38936,7 @@ SLPM-65646:
   name: "Komorebi no Namikimichi - Utsurikawaru Kisetsu no Naka de"
   region: "NTSC-J"
 SLPM-65647:
-  name: 遊戯王真デュエルモンスターズ II 継承されし記憶 [コナミ殿堂セレクション]
+  name: 遊戯王真デュエルモンスターズ II 継承されし記憶(コナミ殿堂セレクション)
   name-sort: ゆうぎおうまでゅえるもんすたーず II けいしょうされしきおく [こなみでんどうせれくしょん]
   name-en: "Yu-Gi-Oh! 2 [Konami Dendou Collection]"
   region: "NTSC-J"
@@ -38849,23 +38945,23 @@ SLPM-65647:
   clampModes:
     eeClampMode: 2 # Partially fixes battle animation.
 SLPM-65648:
-  name: メダルオブオナー 史上最大の作戦 [EA BEST HITS]
+  name: EA BEST HITS メダルオブオナー 史上最大の作戦
   name-sort: めだるおぶおなー しじょうさいだいのさくせん [EA BEST HITS]
   name-en: "Medal of Honor - Frontline [EA Best Hits]"
   region: "NTSC-J"
 SLPM-65649:
-  name: NBAストリート2 ダンク天国 [EA BEST HITS]
+  name: EA BEST HITS NBAストリート2 ダンク天国
   name-sort: NBAすとりーと2 だんくてんごく [EA BEST HITS]
   name-en: "NBA Street Vol. 2 [EA Best Hits]"
   region: "NTSC-J"
 SLPM-65650:
-  name: ハリー・ポッターと賢者の石 [EA BEST HITS]
-  name-sort: はりー・ぽったーとけんじゃのいし [EA BEST HITS]
-  name-en: "Harry Potter and the Sorcerer's Stone [EA Best Hits]"
+  name: EA BEST HITS ハリー・ポッターと賢者の石
+  name-sort: はりーぽったーとけんじゃのいし [EA BEST HITS]
+  name-en: "Harry Potter and the Philosopher's Stone [EA Best Hits]"
   region: "NTSC-J"
 SLPM-65651:
   name: 九龍妖魔學園紀 [デラックスパック]
-  name-sort: くうろんようまがくえんき [でらっくすぱっく]
+  name-sort: くうろんようまがくえんき でらっくすぱっく
   name-en: "Kowloon Youma Gakuenki [Limited Edition]"
   region: "NTSC-J"
 SLPM-65652:
@@ -38874,8 +38970,8 @@ SLPM-65652:
   name-en: "Kowloon Youma Gakuenki"
   region: "NTSC-J"
 SLPM-65653:
-  name: Darling Special Backlash ～恋のエキゾースト・ヒート～
-  name-sort: Darling Special Backlash ～こいのえきぞーすと・ひーと～
+  name: Darling Special Backlash 〜恋のエキゾースト・ヒート〜
+  name-sort: Darling Special Backlash こいのえきぞーすと ひーと
   name-en: "Darling Special Backlash - Koi no Exhaust Heat"
   region: "NTSC-J"
 SLPM-65654:
@@ -38885,7 +38981,7 @@ SLPM-65654:
   region: "NTSC-J"
 SLPM-65655:
   name: ファインディング・ニモ YUKE’S the BEST
-  name-sort: ふぁいんでぃんぐ・にも YUKE’S the BEST
+  name-sort: ふぁいんでぃんぐ にも YUKE’S the BEST
   name-en: "Finding Nemo [Yuke's The Best]"
   region: "NTSC-J"
   gsHWFixes:
@@ -38930,7 +39026,7 @@ SLPM-65665:
   name-en: "BloodRayne"
   region: "NTSC-J"
 SLPM-65666:
-  name: NBAライブ2004 [EA BEST HITS]
+  name: EA BEST HITS NBAライブ2004
   name-sort: NBAらいぶ2004 [EA BEST HITS]
   name-en: "NBA Live 2004 [EA Best Hits]"
   region: "NTSC-J"
@@ -38938,7 +39034,7 @@ SLPM-65666:
     vuClampMode: 2 # Missing geometry with microVU.
 SLPM-65668:
   name: スペクトラルフォース ラジカルエレメンツ 限定版
-  name-sort: すぺくとらるふぉーす らじかるえれめんつ げんていばん
+  name-sort: すぺくとらるふぉーす らじかるえれめんつ [げんていばん]
   name-en: "Spectral Force - Radical Elements [Limited Edition]"
   region: "NTSC-J"
 SLPM-65669:
@@ -38953,8 +39049,8 @@ SLPM-65670:
   region: "NTSC-J"
 SLPM-65671:
   name: W 〜ウィッシュ〜 [初回限定版]
-  name-sort: W 〜うぃっしゅ〜 [しょかいげんていばん]
-  name-en: "W - Wish [Limited Edition]"
+  name-sort: うぃっしゅ しょかいげんていばん
+  name-en: "W - Wish [First Print Limited Edition]"
   region: "NTSC-J"
 SLPM-65672:
   name: W 〜ウィッシュ〜
@@ -38971,12 +39067,12 @@ SLPM-65674:
   region: "NTSC-J"
 SLPM-65675:
   name: ふぁいなる・アプローチ [初回限定版]
-  name-sort: ふぁいなる・あぷろーち [しょかいげんていばん]
-  name-en: "Final Approach [Limited Edition]"
+  name-sort: ふぁいなる あぷろーち しょかいげんていばん
+  name-en: "Final Approach [First Print Limited Edition]"
   region: "NTSC-J"
 SLPM-65676:
   name: ふぁいなる・アプローチ
-  name-sort: ふぁいなる・あぷろーち
+  name-sort: ふぁいなる あぷろーち
   name-en: "Final Approach"
   region: "NTSC-J"
 SLPM-65677:
@@ -38991,7 +39087,7 @@ SLPM-65678:
   region: "NTSC-J"
 SLPM-65679:
   name: テニスの王子様 SWEAT＆TEARS 2 [コナミ ザ ベスト]
-  name-sort: てにすのおうじさま SWEAT＆TEARS 2 [こなみ ざ べすと]
+  name-sort: てにすのおうじさま SWEAT&TEARS 2 [こなみ ざ べすと]
   name-en: "Prince of Tennis - Sweat 2 [Konami The Best]"
   region: "NTSC-J"
 SLPM-65680:
@@ -39002,16 +39098,16 @@ SLPM-65680:
 SLPM-65681:
   name: Monochrome(モノクローム) 初回限定版
   name-sort: ものくろーむ しょかいげんていばん
-  name-en: "Monochrome [Limited Edition]"
+  name-en: "Monochrome [First Print Limited Edition]"
   region: "NTSC-J"
 SLPM-65682:
-  name: Monochrome(モノクローム)
+  name: Monochrome (モノクローム)
   name-sort: ものくろーむ
   name-en: "Monochrome"
   region: "NTSC-J"
 SLPM-65683:
-  name: ヴィオラートのアトリエ～グラムナートの錬金術士2～ [ガストベストプライス]
-  name-sort: ゔぃおらーとのあとりえ～ぐらむなーとのれんきんじゅつし2～ [がすとべすとぷらいす]
+  name: ヴィオラートのアトリエ〜グラムナートの錬金術士2〜 [ガストベストプライス]
+  name-sort: ゔぃおらーとのあとりえ ぐらむなーとのれんきんじゅつし2 [がすとべすとぷらいす]
   name-en: "Violet no Atelier - Gramnad no Renkinjutsushi [Gust Best Price]"
   region: "NTSC-J"
   gsHWFixes:
@@ -39027,8 +39123,8 @@ SLPM-65685:
   name-en: "Stella Deus"
   region: "NTSC-J"
 SLPM-65686:
-  name: ベルセルク 千年帝国の鷹(ミレニアム・ファルコン)篇 聖魔戦記の章 限定版
-  name-sort: べるせるく みれにあむ・ふぁるこんへん せいませんきのしょう げんていばん
+  name: ベルセルク 千年帝国の鷹篇 聖魔戦記の章 限定版
+  name-sort: べるせるく みれにあむ ふぁるこんへん せいませんきのしょう [げんていばん]
   name-en: "Berserk - Millennium Falcon-hen - Seima Senki no Shou [Branded Box]"
   region: "NTSC-J"
   gsHWFixes:
@@ -39039,7 +39135,7 @@ SLPM-65686:
     - SoftwareRendererFMVHack # Fixes subtitles not showing during FMVs.
 SLPM-65687:
   name: スター・ウォーズ バトルフロント
-  name-sort: すたー・うぉーず ばとるふろんと
+  name-sort: すたーうぉーず ばとるふろんと
   name-en: "Star Wars - Battlefront"
   region: "NTSC-J"
   gsHWFixes:
@@ -39047,9 +39143,9 @@ SLPM-65687:
     trilinearFiltering: 1
     recommendedBlendingLevel: 3 # Improves reflections on certain characters and objects on certain levels.
 SLPM-65688:
-  name: ベルセルク 千年帝国の鷹(ミレニアム・ファルコン)篇 聖魔戦記の章 通常版
-  name-sort: べるせるく みれにあむ・ふぁるこんへん せいませんきのしょう つうじょうばん
-  name-en: "Berserk - Millennium Falcon-hen - Seima Senki no Shou"
+  name: ベルセルク 千年帝国の鷹篇 聖魔戦記の章 通常版
+  name-sort: べるせるく みれにあむ・ふぁるこんへん せいませんきのしょう [つうじょうばん]
+  name-en: "Berserk - Millennium Falcon-hen - Seima Senki no Shou [Standard Edition]"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
@@ -39059,13 +39155,13 @@ SLPM-65688:
   gameFixes:
     - SoftwareRendererFMVHack # Fixes subtitles not showing during FMVs.
 SLPM-65689:
-  name: SuperLite 2000 恋愛アドベンチャー Never7～the end of infinity～
-  name-sort: SuperLite 2000 れんあいあどべんちゃー Never7～the end of infinity～
+  name: SuperLite 2000 恋愛アドベンチャー Never7〜the end of infinity〜
+  name-sort: SuperLite 2000 れんあいあどべんちゃー Never7〜the end of infinity〜
   name-en: "Never 7 - The End of Infinity [SuperLite 2000 Series]"
   region: "NTSC-J"
 SLPM-65690:
-  name: 此花4～闇を祓う祈り～
-  name-sort: このはな4～やみをはらういのり～
+  name: 此花4〜闇を祓う祈り〜
+  name-sort: このはな4〜やみをはらういのり〜
   name-en: "Konohana 4 - Yami wo Harau Inori"
   region: "NTSC-J"
   compat: 5
@@ -39085,14 +39181,14 @@ SLPM-65692:
     - "SLPM-65428"
     - "SLPM-74201"
 SLPM-65693:
-  name: ときめきメモリアル3～約束のあの場所で～ [コナミ殿堂セレクション]
-  name-sort: ときめきめもりある3～やくそくのあのばしょで～ [こなみでんどうせれくしょん]
+  name: ときめきメモリアル3〜約束のあの場所で〜(コナミ殿堂セレクション)
+  name-sort: ときめきめもりある3 やくそくのあのばしょで [こなみでんどうせれくしょん]
   name-en: "Tokimeki Memorial 3 [Konami Palace Selection]"
   region: "NTSC-J"
 SLPM-65694:
-  name: 幻想水滸伝III [コナミ殿堂セレクション]
-  name-sort: げんそうすいこでんIII [こなみでんどうせれくしょん]
-  name-en: "Genso Suikoden 3 [Konami Dendou Collection]"
+  name: 幻想水滸伝III(コナミ殿堂セレクション)
+  name-sort: げんそうすいこでん3 [こなみでんどうせれくしょん]
+  name-en: "Gensou Suikoden 3 [Konami Dendou Collection]"
   region: "NTSC-J"
   memcardFilters:
     - "SLPM-65073"
@@ -39129,7 +39225,7 @@ SLPM-65697:
     trilinearFiltering: 1
 SLPM-65698:
   name: LoveSongs♪ADV 双葉理保14歳〜夏〜
-  name-sort: LoveSongs♪ADV ふたばりほ14さい〜なつ〜
+  name-sort: LoveSongs あどべんちゃー ふたばりほ14さい なつ
   name-en: "Love Songs - ADV Futaba Riho 14-sai Natsu"
   region: "NTSC-J"
 SLPM-65699:
@@ -39150,7 +39246,7 @@ SLPM-65701:
   name-en: "Ghost Hunter"
   region: "NTSC-J"
 SLPM-65702:
-  name: 三國志戦記 [コーエー定番シリーズ]
+  name: コーエー定番シリーズ 三國志戦記
   name-sort: さんごくしせんき [こーえーていばんしりーず]
   name-en: "Sangokushi Senki [Koei Collection Series]"
   region: "NTSC-J"
@@ -39166,12 +39262,12 @@ SLPM-65704:
   region: "NTSC-J"
 SLPM-65705:
   name: ファイナルファンタジーXI プロマシアの呪縛 拡張データディスク
-  name-sort: ふぁいなるふぁんたじーXI ぷろましあのじゅばく かくちょうでーたでぃすく
+  name-sort: ふぁいなるふぁんたじー11 ぷろましあのじゅばく かくちょうでーたでぃすく
   name-en: "Final Fantasy XI - Chains of Promathia [Expansion Disc]"
   region: "NTSC-J"
 SLPM-65706:
   name: ファイナルファンタジーXI オールインワンパック2004 [プレイオンライン]
-  name-sort: ふぁいなるふぁんたじーXI おーるいんわんぱっく2004 [ぷれいおんらいん]
+  name-sort: ふぁいなるふぁんたじー11 おーるいんわんぱっく2004 [ぷれいおんらいん]
   name-en: "Final Fantasy XI - Chains of Promathia [All-in-One Pack]"
   region: "NTSC-J"
 SLPM-65708:
@@ -39181,12 +39277,12 @@ SLPM-65708:
   region: "NTSC-J"
 SLPM-65710:
   name: Apocripha/0 通常版
-  name-sort: Apocripha/0 つうじょうばん
-  name-en: "Apocripha-0"
+  name-sort: Apocripha/0 [つうじょうばん]
+  name-en: "Apocripha-0 [Standard Edition]"
   region: "NTSC-J"
 SLPM-65714:
-  name: アンジェリークエトワール　プレミアムBOX
-  name-sort: あんじぇりーくえとわーる　ぷれみあむBOX
+  name: アンジェリーク エトワール　プレミアムBOX
+  name-sort: あんじぇりーくえとわーる [ぷれみあむBOX]
   name-en: "Angelique Etoile [Premium Box]"
   region: "NTSC-J"
 SLPM-65715:
@@ -39202,12 +39298,12 @@ SLPM-65716:
 SLPM-65717:
   name: 月は東に日は西に-Operation Sanctuary-
   name-sort: つきはひがしにひはにしに-Operation Sanctuary-
-  name-en: "Tsuki wa Higashi ni Ha wa Nishi ni - Operation Sanctuary"
+  name-en: "Tsuki ha Higashi ni Ha ha Nishi ni - Operation Sanctuary"
   region: "NTSC-J"
 SLPM-65718:
   name: 戦国無双 猛将伝
   name-sort: せんごくむそう もうしょうでん
-  name-en: "Sengoku Musou Mushoden"
+  name-en: "Sengoku Musou Moushouden"
   region: "NTSC-J"
 SLPM-65719:
   name: バーンアウト3:テイクダウン
@@ -39228,8 +39324,8 @@ SLPM-65719:
     beforeDraw: "OI_BurnoutGames"
 SLPM-65720:
   name: 真・三國無双2 猛将伝 [KOEI The Best]
-  name-sort: しん・さんごくむそう2 もうしょうでん [KOEI The Best]
-  name-en: "Shin Sangoku Musou 2 Mushoden [Koei the Best]"
+  name-sort: しんさんごくむそう2 もうしょうでん [KOEI The Best]
+  name-en: "Shin Sangoku Musou 2 Moushouden [Koei the Best]"
   region: "NTSC-J"
 SLPM-65721:
   name: プロ野球スピリッツ 2004 クライマックス
@@ -39237,13 +39333,13 @@ SLPM-65721:
   name-en: "Pro Yakyuu Spirits 2004 Climax"
   region: "NTSC-J"
 SLPM-65722:
-  name: Airforce Delta ～Blue Wing Knights～ [コナミ ザ ベスト]
-  name-sort: Airforce Delta ～Blue Wing Knights～ [こなみ ざ べすと]
+  name: Airforce Delta 〜Blue Wing Knights〜 [コナミ ザ ベスト]
+  name-sort: Airforce Delta 〜Blue Wing Knights〜 [こなみ ざ べすと]
   name-en: "Airforce Delta - Blue Wing Knights [Konami the Best]"
   region: "NTSC-J"
 SLPM-65723:
   name: ヴァン・ヘルシング
-  name-sort: ゔぁん・へるしんぐ
+  name-sort: ゔぁん へるしんぐ
   name-en: "Van Helsing"
   region: "NTSC-J"
 SLPM-65724:
@@ -39252,7 +39348,7 @@ SLPM-65724:
   name-en: "Choro Q Works"
   region: "NTSC-J"
 SLPM-65725:
-  name: 007エブリシング オア ナッシング [EA BEST HITS]
+  name: EA BEST HITS 007エブリシング オア ナッシング
   name-sort: 007えぶりしんぐ おあ なっしんぐ [EA BEST HITS]
   name-en: "007 - Everything or Nothing [EA Best Hits]"
   region: "NTSC-J"
@@ -39261,8 +39357,8 @@ SLPM-65725:
     mipmap: 2 # Cleans up texture detail.
     trilinearFiltering: 1 # Smoothes out mipmapping.
 SLPM-65726:
-  name: スター・ウォーズ ジャンゴ・フェット [EA BEST HITS]
-  name-sort: すたー・うぉーず じゃんご・ふぇっと [EA BEST HITS]
+  name: EA BEST HITS スター・ウォーズ ジャンゴ・フェット
+  name-sort: すたーうぉーず じゃんご ふぇっと [EA BEST HITS]
   name-en: "Star Wars - Jango Fett [EA Best Hits]"
   region: "NTSC-J"
   compat: 5
@@ -39272,8 +39368,8 @@ SLPM-65726:
     vuClampMode: 3
     eeClampMode: 2 # Fixes missing/grey texture or geometry ingame.
 SLPM-65727:
-  name: ロード・オブ・ザ・リング/王の帰還 [EA BEST HITS]
-  name-sort: ろーど・おぶ・ざ・りんぐ/おうのきかん [EA BEST HITS]
+  name: EA BEST HITS ロード・オブ・ザ・リング/王の帰還
+  name-sort: ろーど おぶ ざ りんぐ おうのきかん [EA BEST HITS]
   name-en: "Lord of the Rings, The - The Return of the King [EA Best Hits]"
   region: "NTSC-J"
 SLPM-65728:
@@ -39283,7 +39379,7 @@ SLPM-65728:
   region: "NTSC-J"
 SLPM-65729:
   name: トゥルークライム -STREETS OF L.A.-
-  name-sort: とぅるーくらいむ -STREETS OF L.A.-
+  name-sort: とぅるーくらいむ STREETS OF L.A.
   name-en: "True Crime - Streets of L.A."
   region: "NTSC-J"
   gsHWFixes:
@@ -39293,7 +39389,7 @@ SLPM-65729:
     autoFlush: 1 # Fixes sun occlusion.
 SLPM-65730:
   name: ロックマンX8
-  name-sort: ろっくまんX8
+  name-sort: ろっくまんえっくす8
   name-en: "Rockman X8"
   region: "NTSC-J"
   gsHWFixes:
@@ -39306,7 +39402,7 @@ SLPM-65730:
     - "SLPM-65643"
 SLPM-65731:
   name: トム・クランシーシリーズ レインボーシックス3
-  name-sort: とむ・くらんしーしりーず れいんぼーしっくす3
+  name-sort: とむくらんしーしりーず れいんぼーしっくす3
   name-en: "Tom Clancy's Rainbow Six 3"
   region: "NTSC-J"
 SLPM-65732:
@@ -39317,17 +39413,17 @@ SLPM-65732:
   compat: 5
 SLPM-65734:
   name: 北へ。Diamond Dust ハドソン・ザ・ベスト
-  name-sort: きたへ。Diamond Dust はどそん・ざ・べすと
-  name-en: "Kita He - Diamond Dust [Hudson The Best]"
+  name-sort: きたへ Diamond Dust はどそん・ざ・べすと
+  name-en: "Kita he - Diamond Dust [Hudson The Best]"
   region: "NTSC-J"
 SLPM-65735:
   name: 蒼のままで・・・・・・ 限定版
-  name-sort: あおのままで・・・・・・ げんていばん
+  name-sort: あおのままで [げんていばん]
   name-en: "Ao no Mamade [Treasure Box]"
   region: "NTSC-J"
 SLPM-65736:
   name: 蒼のままで・・・・・・
-  name-sort: あおのままで・・・・・・
+  name-sort: あおのままで
   name-en: "Ao no Mamade"
   region: "NTSC-J"
 SLPM-65737:
@@ -39337,12 +39433,12 @@ SLPM-65737:
   region: "NTSC-J"
 SLPM-65738:
   name: LoveSongs♪ADV(アドベンチャー)『双葉理保 19歳〜冬〜』
-  name-sort: LoveSongs♪あどべんちゃー『ふたばりほ 19さい〜ふゆ〜』
-  name-en: "Love Songs Adv - Futaba Riho 19 Sai"
+  name-sort: LoveSongs あどべんちゃー ふたばりほ 19さい ふゆ
+  name-en: "Love Songs Adv - Futaba Riho 19 Sai Winter"
   region: "NTSC-J"
 SLPM-65739:
   name: ティム・バートン ナイトメアー・ビフォア・クリスマス ブギーの逆襲
-  name-sort: てぃむ・ばーとん ないとめあー・びふぉあ・くりすます ぶぎーのぎゃくしゅう
+  name-sort: てぃむばーとん ないとめあー びふぉあ くりすます ぶぎーのぎゃくしゅう
   name-en: "Nightmare Before Christmas"
   region: "NTSC-J"
   compat: 5
@@ -39356,7 +39452,7 @@ SLPM-65740:
   region: "NTSC-J"
 SLPM-65741:
   name: DRIV3R
-  name-sort: DRIV3R
+  name-sort: どらいばー3
   name-en: "Driv3r"
   region: "NTSC-J"
   gameFixes:
@@ -39391,8 +39487,8 @@ SLPM-65744:
   name-en: "Firefighter F.D. 18 [Konami The Best]"
   region: "NTSC-J"
 SLPM-65745:
-  name: ときめきメモリアル Girl’s Side [コナミ殿堂セレクション]
-  name-sort: ときめきめもりある Girl’s Side [こなみでんどうせれくしょん]
+  name: ときめきメモリアル Girl’s Side(コナミ殿堂セレクション)
+  name-sort: ときめきめもりある がーるずさいど [こなみでんどうせれくしょん]
   name-en: "Tokimeki Memorial - Girl's Side [Konami Dendou Collection]"
   region: "NTSC-J"
 SLPM-65746:
@@ -39406,7 +39502,9 @@ SLPM-65746:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
 SLPM-65747:
-  name: "Hagane no Renkinjutsushi 2 - Akaki Elixir no Akuma"
+  name: 鋼の錬金術師２ 赤きエリクシルの悪魔
+  name-sort: はがねのれんきんじゅつし2 あかきえりくしるのあくま
+  name-en: "Hagane no Renkinjutsushi 2 - Akaki Elixir no Akuma"
   region: "NTSC-J"
 SLPM-65748:
   name: ZOIDS STRUGGLE
@@ -39415,12 +39513,12 @@ SLPM-65748:
   region: "NTSC-J"
 SLPM-65749:
   name: ZOIDSインフィニティ フューザーズ
-  name-sort: ZOIDSいんふぃにてぃ ふゅーざーず
+  name-sort: ぞいどいんふぃにてぃ ふゅーざーず
   name-en: "Zoids Infinity"
   region: "NTSC-J"
 SLPM-65750:
   name: ドカポン・ザ・ワールド
-  name-sort: どかぽん・ざ・わーるど
+  name-sort: どかぽん ざ わーるど
   name-en: "Dokapon the World"
   region: "NTSC-J"
 SLPM-65751:
@@ -39438,13 +39536,13 @@ SLPM-65752:
   clampModes:
     eeClampMode: 2 # Reduces FPU calculation errors.
 SLPM-65753:
-  name: 決戦 [コーエー定番シリーズ]
+  name: コーエー定番シリーズ 決戦
   name-sort: けっせん [こーえーていばんしりーず]
   name-en: "Kessen [Koei Collection Series]"
   region: "NTSC-J"
 SLPM-65754:
   name: METAL GEAR SOLID 2 SONS OF LIBERTY コナミ殿堂セレクション
-  name-sort: METAL GEAR SOLID 2 SONS OF LIBERTY こなみでんどうせれくしょん
+  name-sort: めたるぎあそりっど2 さんずおぶりばてぃ [こなみでんどうせれくしょん]
   name-en: "Metal Gear Solid 2 [Konami Dendou Collection]"
   region: "NTSC-J"
   gameFixes:
@@ -39460,11 +39558,11 @@ SLPM-65755:
     halfPixelOffset: 2 # Fixes line across the middle of the screen and offset blur.
 SLPM-65756:
   name: テニスの王子様 RUSH＆DREAM!
-  name-sort: てにすのおうじさま RUSH＆DREAM!
+  name-sort: てにすのおうじさま RUSH&DREAM!
   name-en: "Tennis no Oji-Sama - Rush & Dream"
   region: "NTSC-J"
 SLPM-65757:
-  name: メダル オブ オナー ライジングサン [EA BEST HITS]
+  name: EA BEST HITS メダル オブ オナー ライジングサン
   name-sort: めだる おぶ おなー らいじんぐさん [EA BEST HITS]
   name-en: "Medal of Honor - Rising Sun [EA Best Hits]"
   region: "NTSC-J"
@@ -39479,7 +39577,7 @@ SLPM-65758:
     - "SLPM-65431"
 SLPM-65759:
   name: Mr.インクレディブル
-  name-sort: Mr.いんくれでぃぶる
+  name-sort: みすたーいんくれでぃぶる
   name-en: "Mr. Incredible"
   region: "NTSC-J"
   gsHWFixes:
@@ -39494,14 +39592,14 @@ SLPM-65760:
   region: "NTSC-J"
 SLPM-65761:
   name: 高速機動隊 〜World Super Police〜
-  name-sort: こうそくきどうたい 〜World Super Police〜
+  name-sort: こうそくきどうたい World Super Police
   name-en: "World Super Police"
   region: "NTSC-J"
   gameFixes:
     - EETimingHack # Fixes game hanging at mission 1.
 SLPM-65762:
-  name: 片神名～喪われた因果律～
-  name-sort: かたかむな～うしなわれたいんがりつ～
+  name: 片神名〜喪われた因果律〜
+  name-sort: かたかむな うしなわれたいんがりつ
   name-en: "Katakamuna"
   region: "NTSC-J"
 SLPM-65763:
@@ -39512,7 +39610,7 @@ SLPM-65763:
 SLPM-65764:
   name: メンアットワーク!3 愛と青春のハンター学園 初回限定版
   name-sort: めんあっとわーく!3 あいとせいしゅんのはんたーがくえん しょかいげんていばん
-  name-en: "Men at Work! 3 [Limited Edition]"
+  name-en: "Men at Work! 3 [First Print Limited Edition]"
   region: "NTSC-J"
 SLPM-65765:
   name: メンアットワーク!3 愛と青春のハンター学園
@@ -39521,7 +39619,7 @@ SLPM-65765:
   region: "NTSC-J"
 SLPM-65766:
   name: ニード・フォー・スピード アンダーグラウンド2
-  name-sort: にーど・ふぉー・すぴーど あんだーぐらうんど2
+  name-sort: にーど ふぉー すぴーど あんだーぐらうんど2
   name-en: "Need for Speed - Underground 2"
   region: "NTSC-J"
   gsHWFixes:
@@ -39534,12 +39632,12 @@ SLPM-65767:
   region: "NTSC-J"
 SLPM-65768:
   name: beatmania IIDX 8th style
-  name-sort: beatmania IIDX 8th style
+  name-sort: びーとまにあ つーでぃーえっくす 8th style
   name-en: "Beatmania IIDX 8th style"
   region: "NTSC-J"
 SLPM-65769:
   name: pop’n music コントローラセット
-  name-sort: pop’n music こんとろーらせっと
+  name-sort: ぽっぷんみゅーじっく [こんとろーらせっと]
   name-en: "Pop'n music 10 [Controller Set]"
   region: "NTSC-J"
 SLPM-65770:
@@ -39555,7 +39653,7 @@ SLPM-65771:
 SLPM-65772:
   name: ナチュラル2 −DUO− 桜色の季節
   name-sort: なちゅらる2 -DUO- さくらいろのきせつ
-  name-en: "Natural 2 Duo"
+  name-en: "Natural 2 Duo - Sakurairo no Kisetsu"
   region: "NTSC-J"
 SLPM-65773:
   name: シャイニング・ティアーズ
@@ -39570,7 +39668,7 @@ SLPM-65775:
   compat: 5
 SLPM-65776:
   name: 天空断罪 スケルターヘブン 限定版
-  name-sort: てんくうだんざい すけるたーへぶん げんていばん
+  name-sort: てんくうだんざい すけるたーへぶん [げんていばん]
   name-en: "Tenkuu Danzai - Skelter Heaven [Limited Edition]"
   region: "NTSC-J"
 SLPM-65777:
@@ -39593,22 +39691,22 @@ SLPM-65780:
   region: "NTSC-J"
 SLPM-65781:
   name: 決戦III
-  name-sort: けっせんIII
+  name-sort: けっせん3
   name-en: "Kessen III"
   region: "NTSC-J"
 SLPM-65783:
   name: 信長の野望 Online 〜飛龍の章〜
-  name-sort: のぶながのやぼう Online 〜ひりゅうのしょう〜
+  name-sort: のぶながのやぼう おんらいん ひりゅうのしょう
   name-en: "Nobunaga no Yabou Online - Tappi no Shou"
   region: "NTSC-J"
 SLPM-65785:
   name: なついろ〜星屑のメモリー〜 [初回限定版]
-  name-sort: なついろ〜ほしくずのめもりー〜 [しょかいげんていばん]
-  name-en: "Natsuiro - Hoshikuzu no Memory [Limited Edition]"
+  name-sort: なついろ ほしくずのめもりー しょかいげんていばん
+  name-en: "Natsuiro - Hoshikuzu no Memory [First Print Limited Edition]"
   region: "NTSC-J"
 SLPM-65786:
   name: なついろ〜星屑のメモリー〜
-  name-sort: なついろ〜ほしくずのめもりー〜
+  name-sort: なついろ ほしくずのめもりー
   name-en: "Natsuiro - Hoshikuzu no Memory"
   region: "NTSC-J"
 SLPM-65787:
@@ -39626,7 +39724,7 @@ SLPM-65788:
   region: "NTSC-J"
 SLPM-65789:
   name: METAL GEAR SOLID 3 SNAKE EATER PREMIUM PACKAGE
-  name-sort: METAL GEAR SOLID 3 SNAKE EATER PREMIUM PACKAGE
+  name-sort: めたるぎあそりっど3 すねーくいーたー [PREMIUM PACKAGE]
   name-en: "Metal Gear Solid 3 - Snake Eater [Premium Pack]"
   region: "NTSC-J"
   gameFixes:
@@ -39640,7 +39738,7 @@ SLPM-65789:
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
 SLPM-65790:
   name: METAL GEAR SOLID 3 SNAKE EATER
-  name-sort: METAL GEAR SOLID 3 SNAKE EATER
+  name-sort: めたるぎあそりっど3 すねーくいーたー
   name-en: "Metal Gear Solid 3 - Snake Eater"
   region: "NTSC-J"
   gameFixes:
@@ -39660,7 +39758,7 @@ SLPM-65791:
   gsHWFixes:
     halfPixelOffset: 4 # Fixes double image and aligns glow effects.
 SLPM-65793:
-  name: SSX3 [EA BEST HITS]
+  name: EA BEST HITS SSX3
   name-sort: SSX3 [EA BEST HITS]
   name-en: "SSX 3 [EA Best Hits]"
   region: "NTSC-J"
@@ -39678,7 +39776,7 @@ SLPM-65794:
   compat: 5
 SLPM-65795:
   name: DIGITAL DEVIL SAGA(デジタル・デビル・サーガ) 〜アバタール・チューナー2〜
-  name-sort: でじたる・でびる・さーが 〜あばたーる・ちゅーなー2〜
+  name-sort: でじたるでびるさーが あばたーるちゅーなー2
   name-en: "Digital Devil Saga - Avatar Tuner 2"
   region: "NTSC-J"
   gameFixes:
@@ -39697,7 +39795,7 @@ SLPM-65796:
   region: "NTSC-J"
 SLPM-65797:
   name: ドラゴンクエスト＆ファイナルファンタジー in いただきストリートSpecial
-  name-sort: どらごんくえすと＆ふぁいなるふぁんたじー in いただきすとりーとSpecial
+  name-sort: どらごんくえすと&ふぁいなるふぁんたじー in いただきすとりーとSpecial
   name-en: "Dragon Quest & Final Fantasy in Itadaki Street"
   region: "NTSC-J"
   compat: 5
@@ -39729,9 +39827,9 @@ SLPM-65800:
     alignSprite: 1 # Fixes vertical bars.
     halfPixelOffset: 2 # Fixes misalignment bloom effects.
 SLPM-65801:
-  name: クラッシュ・バンディクー5 え～っクラッシュとコルテックスの野望?!?
-  name-sort: くらっしゅ・ばんでぃくー5 え～っくらっしゅとこるてっくすのやぼう?!?
-  name-en: "Crash Bandicoot 5"
+  name: クラッシュ・バンディクー5 え〜っクラッシュとコルテックスの野望?!?
+  name-sort: くらっしゅばんでぃくー5 えーっくらっしゅとこるてっくすのやぼう?!?
+  name-en: "Crash Bandicoot 5 - Eh Crash to Cortex no Yabou?!?"
   region: "NTSC-J"
   compat: 5
   gameFixes:
@@ -39739,12 +39837,12 @@ SLPM-65801:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
 SLPM-65802:
-  name: DEF JAM VENDETTA [EA BEST HITS]
+  name: EA BEST HITS DEF JAM VENDETTA
   name-sort: DEF JAM VENDETTA [EA BEST HITS]
   name-en: "Def Jam - Vendetta [EA Best Hits]"
   region: "NTSC-J"
 SLPM-65803:
-  name: フリーダム・ファイターズ [EA BEST HITS]
+  name: EA BEST HITS フリーダム・ファイターズ
   name-sort: ふりーだむ・ふぁいたーず [EA BEST HITS]
   name-en: "Freedom Fighters [EA Best Hits]"
   region: "NTSC-J"
@@ -39765,7 +39863,7 @@ SLPM-65806:
   region: "NTSC-J"
 SLPM-65807:
   name: ザ・アーブズ シムズ・イン・ザ・シティ
-  name-sort: ざ・あーぶず しむず・いん・ざ・してぃ
+  name-sort: ざ あーぶず しむず いん ざ してぃ
   name-en: "Urbz, The - Sims in the City"
   region: "NTSC-J"
   gsHWFixes:
@@ -39799,7 +39897,7 @@ SLPM-65813:
   compat: 5
 SLPM-65815:
   name: トム・クランシーシリーズ スプリンターセル パンドラトゥモロー
-  name-sort: とむ・くらんしーしりーず すぷりんたーせる ぱんどらとぅもろー
+  name-sort: とむくらんしーしりーず すぷりんたーせる ぱんどらとぅもろー
   name-en: "Tom Clancy's Splinter Cell - Pandora Tomorrow"
   region: "NTSC-J"
   gsHWFixes:
@@ -39807,26 +39905,26 @@ SLPM-65815:
     mergeSprite: 1 # Fixes misaligned bloom on light sources.
 SLPM-65816:
   name: 真・爆走デコトラ伝説 〜天下統一頂上決戦〜
-  name-sort: しん・ばくそうでことらでんせつ 〜てんかとういつちょうじょうけっせん〜
+  name-sort: しん・ばくそうでことらでんせつ てんかとういつちょうじょうけっせん
   name-en: "Shin Bakusou Dekotora Densetsu"
   region: "NTSC-J"
 SLPM-65817:
-  name: テニスの王子様 Love of Prince Sweet [コナミ殿堂セレクション]
+  name: テニスの王子様 Love of Prince Sweet(コナミ殿堂セレクション)
   name-sort: てにすのおうじさま Love of Prince Sweet [こなみでんどうせれくしょん]
   name-en: "Tennis no Oji-Sama - Love of Prince Sweet [Konami Palace Selection]"
   region: "NTSC-J"
 SLPM-65818:
-  name: テニスの王子様 Love of Prince Bitter [コナミ殿堂セレクション]
+  name: テニスの王子様 Love of Prince Bitter(コナミ殿堂セレクション)
   name-sort: てにすのおうじさま Love of Prince Bitter [こなみでんどうせれくしょん]
   name-en: "Tennis no Oji-Sama - Love of Prince Bitter [Konami Palace Selection]"
   region: "NTSC-J"
 SLPM-65819:
-  name: テニスの王子様 Kiss of Prince ICE [コナミ殿堂セレクション]
+  name: テニスの王子様 Kiss of Prince ICE(コナミ殿堂セレクション)
   name-sort: てにすのおうじさま Kiss of Prince ICE [こなみでんどうせれくしょん]
   name-en: "Tennis no Oji-Sama - Kiss of Prince - Ice Version [Konami Palace Selection]"
   region: "NTSC-J"
 SLPM-65820:
-  name: テニスの王子様 Kiss of Prince FLAME [コナミ殿堂セレクション]
+  name: テニスの王子様 Kiss of Prince FLAME(コナミ殿堂セレクション)
   name-sort: てにすのおうじさま Kiss of Prince FLAME [こなみでんどうせれくしょん]
   name-en: "Tennis no Oji-Sama - Kiss of Prince - Flame Version [Konami Palace Selection]"
   region: "NTSC-J"
@@ -39836,8 +39934,8 @@ SLPM-65821:
   name-en: "Shinseiki Yuusha Taisen"
   region: "NTSC-J"
 SLPM-65822:
-  name: いちご100ストロベリーダイアリー
-  name-sort: いちご100すとろべりーだいありー
+  name: いちご100% ストロベリーダイアリー
+  name-sort: いちご100ぱーせんと すとろべりーだいありー
   name-en: "Ichigo 100% Strawberry Diary"
   region: "NTSC-J"
 SLPM-65823:
@@ -39864,19 +39962,19 @@ SLPM-65826:
   compat: 5
 SLPM-65828:
   name: AngelWish 君の笑顔にチュッ!
-  name-sort: AngelWish くんのえがおにちゅっ!
+  name-sort: AngelWish きみのえがおにちゅっ
   name-en: "Angel Wish - Kimi no Egao ni Chu!"
   region: "NTSC-J"
 SLPM-65829:
   name: イース -ナピシュテムの匣- 限定版
-  name-sort: いーす -なぴしゅてむのはこ- げんていばん
+  name-sort: いーす なぴしゅてむのはこ [げんていばん]
   name-en: "Ys - The Ark of Napishtim [Limited Edition]"
   region: "NTSC-J"
   gameFixes:
     - EETimingHack
 SLPM-65830:
   name: イース -ナピシュテムの匣- 初回生産版
-  name-sort: いーす -なぴしゅてむのはこ- しょかいせいさんばん
+  name-sort: いーす なぴしゅてむのはこ しょかいせいさんばん
   name-en: "Ys - The Ark of Napishtim"
   region: "NTSC-J"
   gameFixes:
@@ -39892,19 +39990,19 @@ SLPM-65832:
   name-en: "Izumo Complete"
   region: "NTSC-J"
 SLPM-65833:
-  name: 遙かなる時空の中で 2 [KOEI The Best]
-  name-sort: はるかなるときのなかで 2 [KOEI The Best]
-  name-en: "Harukanaru Jikuu no Naka De 2 [Koei the Best]"
+  name: 遙かなる時空の中で2 [KOEI The Best]
+  name-sort: はるかなるときのなかで2 [KOEI The Best]
+  name-en: "Harukanaru Toki no Naka de 2 [Koei the Best]"
   region: "NTSC-J"
 SLPM-65834:
   name: 遙かなる時空の中で3
   name-sort: はるかなるときのなかで3
-  name-en: "Harukanaru Jikuu no Naka De 3"
+  name-en: "Harukanaru Toki no Naka de 3"
   region: "NTSC-J"
 SLPM-65835:
   name: 幕末恋華・新選組
   name-sort: ばくまつれんか・しんせんぐみ
-  name-en: "Bakumatsu Renka - Shinsengumi"
+  name-en: "Bakumatsu Renka Shinsengumi"
   region: "NTSC-J"
 SLPM-65836:
   name: イース ナピシュテムの匣
@@ -39920,7 +40018,7 @@ SLPM-65837:
   region: "NTSC-J"
 SLPM-65838:
   name: 半熟銀河弁当 半熟英雄4 〜7人の半熟英雄〜 [限定版]
-  name-sort: はんじゅくぎんがべんとう はんじゅくえいゆう4 〜7にんのはんじゅくえいゆう〜 [げんていばん]
+  name-sort: はんじゅくぎんがべんとう はんじゅくえいゆう4 7にんのはんじゅくえいゆう [げんていばん]
   name-en: "Hanjuku Hero 4 [Limited Edition]"
   region: "NTSC-J"
   gsHWFixes:
@@ -39928,7 +40026,7 @@ SLPM-65838:
     cpuSpriteRenderLevel: 2 # Needed for above.
 SLPM-65839:
   name: 半熟英雄4 〜7人の半熟英雄〜
-  name-sort: はんじゅくえいゆう4 〜7にんのはんじゅくえいゆう〜
+  name-sort: はんじゅくえいゆう4 7にんのはんじゅくえいゆう
   name-en: "Hanjuku Hero 4"
   region: "NTSC-J"
   compat: 5
@@ -39937,7 +40035,7 @@ SLPM-65839:
     cpuSpriteRenderLevel: 2 # Needed for above.
 SLPM-65840:
   name: ウィザードリィ エクス 〜前線の学府〜
-  name-sort: うぃざーどりぃ えくす 〜ぜんせんのがくふ〜
+  name-sort: うぃざーどりぃ えくす ぜんせんのがくふ
   name-en: "Wizardry X - Zensen no Gakufu"
   region: "NTSC-J"
 SLPM-65841:
@@ -39947,19 +40045,19 @@ SLPM-65841:
   region: "NTSC-J"
 SLPM-65842:
   name: Kanon ベスト版
-  name-sort: Kanon べすとばん
+  name-sort: かのん べすとばん
   name-en: "Kanon [Best]"
   region: "NTSC-J"
 SLPM-65843:
   name: 120円の春
   name-sort: 120えんのはる
-  name-en: "120 Yen no Haru - 120 Yen Stories"
+  name-en: "120 Yen no Haru"
   region: "NTSC-J"
   gsHWFixes:
     cpuCLUTRender: 1 # Fixes CLUT generation.
 SLPM-65844:
   name: AIR ベスト版
-  name-sort: AIR べすとばん
+  name-sort: えあー べすとばん
   name-en: "Air [Best]"
   region: "NTSC-J"
 SLPM-65845:
@@ -39973,20 +40071,20 @@ SLPM-65845:
     estimateTextureRegion: 1 # Improves performance.
 SLPM-65846:
   name: ロード・オブ・ザ・リング 中つ国第三紀
-  name-sort: ろーど・おぶ・ざ・りんぐ なかつくにだいさんき
-  name-en: "Lord of the Rings, The - Uchitsu Kuni Daisanki"
+  name-sort: ろーど おぶ ざ りんぐ なかつくにだいさんき
+  name-en: "Lord of the Rings, The - The Third Age"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
 SLPM-65847:
   name: 空色の風琴 〜Remix〜 初回限定版
-  name-sort: そらいろのおるがん 〜Remix〜 しょかいげんていばん
-  name-en: "Soriaro no Fuukin Remix [First Print - Limited Edition]"
+  name-sort: そらいろのおるがん Remix しょかいげんていばん
+  name-en: "Soriaro no Organ Remix [First Print Limited Edition]"
   region: "NTSC-J"
 SLPM-65848:
   name: 空色の風琴 〜Remix〜
-  name-sort: そらいろのおるがん 〜Remix〜
-  name-en: "Soriaro no Fuukin Remix"
+  name-sort: そらいろのおるがん Remix
+  name-en: "Soriaro no Organ Remix"
   region: "NTSC-J"
 SLPM-65850:
   name: "Harukanaru Toki no Naka de 3 [Triple Pack]"
@@ -40032,7 +40130,7 @@ SLPM-65859:
   region: "NTSC-J"
 SLPM-65860:
   name: 新紀幻想 スペクトラルソウルズ II 限定版
-  name-sort: しんきげんそう すぺくとらるそうるず II げんていばん
+  name-sort: しんきげんそう すぺくとらるそうるず II [げんていばん]
   name-en: "Shinki Gensou Spectral Souls II [Premium Box]"
   region: "NTSC-J"
 SLPM-65861:
@@ -40054,13 +40152,13 @@ SLPM-65863:
     eeClampMode: 3 # Fixes black void.
 SLPM-65864:
   name: 信長の野望・天下創世 with パワーアップキット
-  name-sort: のぶながのやぼう・てんかそうせい with ぱわーあっぷきっと
+  name-sort: のぶながのやぼう てんかそうせい with ぱわーあっぷきっと
   name-en: "Nobunaga no Yabou - Tenka Sousei [with Power-Up Kit]"
   region: "NTSC-J"
 SLPM-65866:
   name: 何処へ行くの、あの日 〜光る明日へ…〜
-  name-sort: どこへいくの、あのひ 〜ひかるあしたへ…〜
-  name-en: "Izuku e Iku no, Anohi"
+  name-sort: どこへいくの あのひ ひかるあしたへ
+  name-en: "Doko he Iku no, Anohi"
   region: "NTSC-J"
 SLPM-65867:
   name: 新世紀エヴァンゲリオン 鋼鉄のガールフレンド2nd
@@ -40070,7 +40168,7 @@ SLPM-65867:
   compat: 5
 SLPM-65868:
   name: METAL SAGA 〜砂塵の鎖〜
-  name-sort: METAL SAGA 〜さじんのくさり〜
+  name-sort: めたるさーが さじんのくさり
   name-en: "Metal Saga - Chain of Cloud"
   region: "NTSC-J"
   gsHWFixes:
@@ -40092,33 +40190,33 @@ SLPM-65869:
     - "SLPM-65869"
 SLPM-65870:
   name: 魔法先生ネギま! 1時間目 お子ちゃま先生は魔法使い!〜優等生版
-  name-sort: まほうせんせいねぎま! 1じかんめ おこちゃませんせいはまほうつかい!〜ゆうとうせいばん
+  name-sort: まほうせんせいねぎま 1じかんめ おこちゃませんせいはまほうつかい ゆうとうせいばん
   name-en: "Magic Teacher Negima - Honor Version"
   region: "NTSC-J"
 SLPM-65871:
   name: 魔法先生ネギま! 1時間目 お子ちゃま先生は魔法使い!〜特待生版
-  name-sort: まほうせんせいねぎま! 1じかんめ おこちゃませんせいはまほうつかい!〜とくたいせいばん
+  name-sort: まほうせんせいねぎま 1じかんめ おこちゃませんせいはまほうつかい とくたいせいばん
   name-en: "Magic Teacher Negima - Scholarship Version"
   region: "NTSC-J"
   compat: 5
 SLPM-65872:
   name: SIMPLE2000シリーズUltimate Vol.24 魔界転生
-  name-sort: SIMPLE2000しりーずUltimate Vol.24 まかいてんしょう
+  name-sort: SIMPLE2000しりーずあるてぃめっと Vol.24 まかいてんせい
   name-en: "Simple 2000 Series Ultimate Vol. 24 - Makai Tenshou"
   region: "NTSC-J"
 SLPM-65873:
   name: SIMPLE2000シリーズUltimate Vol.23 プロジェクト・ミネルヴァ プロフェッショナル
-  name-sort: SIMPLE2000しりーずUltimate Vol.23 ぷろじぇくと・みねるゔぁ ぷろふぇっしょなる
+  name-sort: SIMPLE2000しりーずあるてぃめっと Vol.23 ぷろじぇくと みねるゔぁ ぷろふぇっしょなる
   name-en: "Simple 2000 Series Ultimate Vol. 23 - Project Minerva Professional"
   region: "NTSC-J"
 SLPM-65874:
   name: SIMPLE2000シリーズ Vol.71 THE ファンタジー恋愛アドベンチャー〜彼女の伝説、僕の石版〜
-  name-sort: SIMPLE2000しりーず Vol.71 THE ふぁんたじーれんあいあどべんちゃー〜かのじょのでんせつ、ぼくのせきばん〜
+  name-sort: SIMPLE2000しりーず Vol.71 THE ふぁんたじーれんあいあどべんちゃー かのじょのでんせつ ぼくのせきばん
   name-en: "Simple 2000 Series Vol. 71 - The Fantasy Renai Adventure - Kanojo no Densetsu"
   region: "NTSC-J"
 SLPM-65875:
   name: グローランサーIV 〜 Wayfarer of the time 〜 [Atlus Best Collection]
-  name-sort: ぐろーらんさーIV 〜 Wayfarer of the time 〜 [Atlus Best Collection]
+  name-sort: ぐろーらんさー4 〜 Wayfarer of the time 〜 [Atlus Best Collection]
   name-en: "Growlanser IV - Wayfarer of the Time [Atlus The Best]"
   region: "NTSC-J"
 SLPM-65876:
@@ -40135,8 +40233,8 @@ SLPM-65878:
   name-en: "Galaxy Angel - Eternal Lovers"
   region: "NTSC-J"
 SLPM-65879:
-  name: ラブひな ご〜じゃす チラッとハプニング [コナミ殿堂セレクション]
-  name-sort: らぶひな ご〜じゃす ちらっとはぷにんぐ [こなみでんどうせれくしょん]
+  name: ラブひな ご〜じゃす チラッとハプニング(コナミ殿堂セレクション)
+  name-sort: らぶひな ごーじゃす ちらっとはぷにんぐ [こなみでんどうせれくしょん]
   name-en: "Love Hina Gorgeous [Konami Dendou Selection]"
   region: "NTSC-J"
 SLPM-65880:
@@ -40153,11 +40251,11 @@ SLPM-65880:
 SLPM-65881:
   name: エキサイティングプロレス6 SMACKDOWN! Vs RAW
   name-sort: えきさいてぃんぐぷろれす6 SMACKDOWN! Vs RAW
-  name-en: "SmackDown vs. Raw - Exciting Professional Wrestling 6"
+  name-en: "Exciting Professional Wrestling 6 - SmackDown vs. Raw"
   region: "NTSC-J"
 SLPM-65882:
-  name: デュエル・マスターズ 〜邪封超龍転生(バース・オブ・スーパードラゴン)〜
-  name-sort: でゅえる・ますたーず 〜ばーす・おぶ・すーぱーどらごん〜
+  name: デュエル・マスターズ　〜邪封超龍転生〜
+  name-sort: でゅえるますたーず ばーす おぶ すーぱーどらごん
   name-en: "Duel Masters"
   region: "NTSC-J"
 SLPM-65883:
@@ -40173,13 +40271,13 @@ SLPM-65884:
   name-en: "Remote Control Dandy SF"
   region: "NTSC-J"
 SLPM-65885:
-  name: RUMBLE ROSES(ランブルローズ)
+  name: RUMBLE ROSES
   name-sort: らんぶるろーず
   name-en: "Rumble Roses"
   region: "NTSC-J"
 SLPM-65886:
   name: ガイザード・レボリューション 〜 僕らは想いを身に纏う 〜
-  name-sort: がいざーど・れぼりゅーしょん 〜 ぼくらはおもいをみにまとう 〜
+  name-sort: がいざーど・れぼりゅーしょん ぼくらはおもいをみにまとう
   name-en: "Guisard Revolution"
   region: "NTSC-J"
 SLPM-65887:
@@ -40189,7 +40287,7 @@ SLPM-65887:
   region: "NTSC-J"
 SLPM-65888:
   name: ドラゴンクエストVIII　空と海と大地と呪われし姫君
-  name-sort: どらごんくえすとVIII　そらとうみとだいちとのろわれしひめぎみ
+  name-sort: どらごんくえすと8 そらとうみとだいちとのろわれしひめぎみ
   name-en: "Dragon Quest VIII"
   region: "NTSC-J"
   compat: 5
@@ -40201,14 +40299,14 @@ SLPM-65888:
     PCRTCOverscan: 1 # Fixes offscreen image.
 SLPM-65889:
   name: 家族計画〜心の絆〜
-  name-sort: かぞくけいかく〜こころのきずな〜
+  name-sort: かぞくけいかく こころのきずな
   name-en: "Kazoku Keikaku - Kokoro no Kizuna"
   region: "NTSC-J"
   gsHWFixes:
     cpuCLUTRender: 1 # Fixes broken colors.
 SLPM-65890:
   name: 真・三國無双4
-  name-sort: しん・さんごくむそう4
+  name-sort: しんさんごくむそう4
   name-en: "Shin Sangoku Musou 4"
   region: "NTSC-J"
 SLPM-65891:
@@ -40218,26 +40316,26 @@ SLPM-65891:
   region: "NTSC-J"
 SLPM-65892:
   name: Zill O’ll 〜infinite〜
-  name-sort: Zill O’ll 〜infinite〜
+  name-sort: じるおーる 〜infinite〜
   name-en: "Zill O'll Infinite"
   region: "NTSC-J"
 SLPM-65893:
   name: Winning Post 6 Maximum 2005 プレミアムパック
-  name-sort: Winning Post 6 Maximum 2005 ぷれみあむぱっく
+  name-sort: ういにんぐぽすと6 Maximum 2005 ぷれみあむぱっく
   name-en: "Winning Post 6 Maximum 2005 [Premium Pack]"
   region: "NTSC-J"
 SLPM-65894:
   name: WinningPost6 2005年度版
-  name-sort: WinningPost6 2005ねんどばん
+  name-sort: ういにんぐぽすと6 2005ねんどばん
   name-en: "Winning Post 6 2005 Version"
   region: "NTSC-J"
 SLPM-65895:
-  name: "Tsuki wa Kirisaku [Limited Edition]"
+  name: "Tsuki ha Kirisaku [Limited Edition]"
   region: "NTSC-J"
 SLPM-65896:
   name: 月は切り裂く〜探偵 相楽恭一郎〜
-  name-sort: つきはきりさく〜たんてい さがらきょういちろう〜
-  name-en: "Tsuki wa Kirisaku"
+  name-sort: つきはきりさく たんてい さがらきょういちろう〜
+  name-en: "Tsuki ha Kirisaku"
   region: "NTSC-J"
 SLPM-65897:
   name: レーシングバトル -C1 GRAND PRIX-
@@ -40259,7 +40357,7 @@ SLPM-65899:
   region: "NTSC-J"
 SLPM-65900:
   name: サクラ大戦3 〜巴里は燃えているか〜初回プレス版
-  name-sort: さくらたいせん3 〜ぱりはもえているか〜しょかいぷれすばん
+  name-sort: さくらたいせん3 ぱりはもえているか しょかいぷれすばん
   name-en: "Sakura Taisen 3 - Remake"
   region: "NTSC-J"
   compat: 2
@@ -40287,7 +40385,7 @@ SLPM-65904:
   region: "NTSC-J"
 SLPM-65906:
   name: サクラ大戦3 〜巴里は燃えているか〜
-  name-sort: さくらたいせん3 〜ぱりはもえているか〜
+  name-sort: さくらたいせん3 ぱりはもえているか
   name-en: "Sakura Taisen 3 - Remake"
   region: "NTSC-J"
 SLPM-65907:
@@ -40308,18 +40406,18 @@ SLPM-65909:
   roundModes:
     eeRoundMode: 1 # Fixes object balls never stopping in the Monkey Billiards DX minigame.
 SLPM-65910:
-  name: カフェ・リンドバーグ -summer season- [Sweet Box 版]
-  name-sort: かふぇ・りんどばーぐ -summer season- [Sweet Box ばん]
-  name-en: "Cafe Lindbergh - Summer Season [Sweet Box]"
+  name: カフェ・リンドバーグ -summer season-(Sweet Box 版)
+  name-sort: かふぇ りんどばーぐ summer season [Sweet Box ばん]
+  name-en: "Cafe Lindbergh - Summer Season [Sweet Box Edition]"
   region: "NTSC-J"
 SLPM-65911:
-  name: カフェ・リンドバーグ −summer season−
-  name-sort: かふぇ・りんどばーぐ −summer season−
-  name-en: "Cafe Lindbergh - Summer Season"
+  name: カフェ・リンドバーグ −summer season-(通常版)
+  name-sort: かふぇ りんどばーぐ summer season
+  name-en: "Cafe Lindbergh - Summer Season [Standard Edition]"
   region: "NTSC-J"
 SLPM-65912:
   name: ボボボーボ・ボーボボ ハジけ祭 ハドソン・ザ・ベスト
-  name-sort: ぼぼぼーぼ・ぼーぼぼ はじけまつり はどそん・ざ・べすと
+  name-sort: ぼぼぼーぼ ぼーぼぼ はじけまつり [はどそん・ざ・べすと]
   name-en: "Boboboubo Boubobo [Hudson the Best]"
   region: "NTSC-J"
 SLPM-65913:
@@ -40348,7 +40446,7 @@ SLPM-65915:
 SLPM-65916:
   name: 遙かなる時空の中で 〜八葉抄〜
   name-sort: はるかなるときのなかで 〜はちようしょう〜
-  name-en: "Harukanaru Jikuu no Kade - Hachiha Katsunori"
+  name-en: "Harukanaru Toki no Naka de - Hachiyou-shou"
   region: "NTSC-J"
 SLPM-65917:
   name: トランスフォーマー [THE BEST タカラモノ]
@@ -40362,7 +40460,7 @@ SLPM-65918:
   region: "NTSC-J"
 SLPM-65919:
   name: THE RUMBLE FISH(ザ・ランブルフィッシュ)
-  name-sort: ざ・らんぶるふぃっしゅ
+  name-sort: ざ らんぶるふぃっしゅ
   name-en: "Rumble Fish, The"
   region: "NTSC-J"
   compat: 5
@@ -40374,12 +40472,12 @@ SLPM-65920:
   compat: 5
 SLPM-65921:
   name: Piaキャロットへようこそ!!3 [ベスト版]
-  name-sort: Piaきゃろっとへようこそ!!3 [べすとばん]
-  name-en: "Pia Carrot e Youkoso!! 3 [Best Version]"
+  name-sort: ぴあきゃろっとへようこそ!!3 [べすとばん]
+  name-en: "Pia Carrot he Youkoso!! 3 [Best Version]"
   region: "NTSC-J"
 SLPM-65922:
   name: あいかぎ 〜ぬくもりとひだまりの中で〜 [ベスト版]
-  name-sort: あいかぎ 〜ぬくもりとひだまりのなかで〜 [べすとばん]
+  name-sort: あいかぎ ぬくもりとひだまりのなかで [べすとばん]
   name-en: "Aikagi [Best Version]"
   region: "NTSC-J"
 SLPM-65923:
@@ -40399,14 +40497,14 @@ SLPM-65925:
   region: "NTSC-J"
 SLPM-65926:
   name: イースIV 〜Mask of the Sun -a new theory〜
-  name-sort: いーすIV 〜Mask of the Sun -a new theory〜
+  name-sort: いーす4 〜Mask of the Sun -a new theory〜
   name-en: "Ys IV - Mask of the Sun - A New Theory"
   region: "NTSC-J"
   clampModes:
     eeClampMode: 3 # Fixes camera going off screen.
 SLPM-65927:
   name: DEMON STONE デーモンストーン
-  name-sort: DEMON STONE でーもんすとーん
+  name-sort: でーもんすとーん
   name-en: "Forgotten Realms - Demon Stone"
   region: "NTSC-J"
   clampModes:
@@ -40436,12 +40534,12 @@ SLPM-65931:
   region: "NTSC-J"
 SLPM-65932:
   name: 戦闘国家・改 NEW OPERATIONS
-  name-sort: せんとうこっか・かい NEW OPERATIONS
+  name-sort: せんとうこっかかい NEW OPERATIONS
   name-en: "Sento Country Kai - New Operation [with Bonus DVD]"
   region: "NTSC-J"
 SLPM-65934:
   name: メイプルカラーズ 〜決戦は学園祭〜
-  name-sort: めいぷるからーず 〜けっせんはがくえんさい〜
+  name-sort: めいぷるからーず けっせんはがくえんさい
   name-en: "Maple Colors"
   region: "NTSC-J"
 SLPM-65935:
@@ -40457,7 +40555,7 @@ SLPM-65936:
 SLPM-65937:
   name: 星界の戦旗
   name-sort: せいかいのせんき
-  name-en: "Siekai no Senki"
+  name-en: "Seikai no Senki"
   region: "NTSC-J"
 SLPM-65938:
   name: メモリーズオフ アフターレイン vol.3 卒業 SPECIAL EDITION
@@ -40474,7 +40572,7 @@ SLPM-65940:
   region: "NTSC-J"
 SLPM-65941:
   name: マビノ×スタイル
-  name-sort: まびの×すたいる
+  name-sort: まびのすたいる
   name-en: "Mabino x Style"
   region: "NTSC-J"
 SLPM-65942:
@@ -40487,7 +40585,7 @@ SLPM-65942:
     # halfPixelOffset: 1 # Fixes lighting misalignment. Do not enable this, it breaks a lot of graphics.
 SLPM-65943:
   name: Angel’s Feather −黒の残影−
-  name-sort: Angel’s Feather -くろのざんかげ-
+  name-sort: Angel’s Feather くろのざんえい
   name-en: "Angel's Feather"
   region: "NTSC-J"
 SLPM-65944:
@@ -40497,12 +40595,12 @@ SLPM-65944:
   region: "NTSC-J"
 SLPM-65945:
   name: 紅忍 〜血河の舞〜
-  name-sort: れっどにんじゃ 〜ちかわのまい〜
+  name-sort: れっどにんじゃ けっかのまい
   name-en: "Red Ninja - End of Honor"
   region: "NTSC-J"
 SLPM-65946:
   name: beatmania IIDX 9th style
-  name-sort: beatmania IIDX 9th style
+  name-sort: びーとまにあ つーでぃーえっくす 9th style
   name-en: "Beatmania IIDX 9th style"
   region: "NTSC-J"
   compat: 5
@@ -40526,47 +40624,47 @@ SLPM-65948:
     - SoftwareRendererFMVHack # Fixes upscale lines in FMVs.
 SLPM-65949:
   name: Get Ride!アムドライバー 〜相克の真実〜
-  name-sort: Get Ride!あむどらいばー 〜そうこくのしんじつ〜
+  name-sort: Get Ride!あむどらいばー そうこくのしんじつ
   name-en: "Get Ride! AM Driver - The Truth of Xiangke"
   region: "NTSC-J"
 SLPM-65950:
   name: GANTZ
-  name-sort: GANTZ
+  name-sort: がんつ
   name-en: "Gantz - The Game"
   region: "NTSC-J"
   compat: 5
 SLPM-65951:
   name: トム・クランシーシリーズ ゴーストリコン2
-  name-sort: とむ・くらんしーしりーず ごーすとりこん2
+  name-sort: とむくらんしーしりーず ごーすとりこん2
   name-en: "Tom Clancy's Ghost Recon 2"
   region: "NTSC-J"
 SLPM-65952:
   name: 天外魔境III NAMIDA
-  name-sort: てんがいまきょうIII NAMIDA
+  name-sort: てんがいまきょう3 NAMIDA
   name-en: "Tengai Makyou III - Namida"
   region: "NTSC-J"
 SLPM-65953:
   name: ファイナルファンタジーXI エントリーディスク2005 [プレイオンライン]
-  name-sort: ふぁいなるふぁんたじーXI えんとりーでぃすく2005 [ぷれいおんらいん]
+  name-sort: ふぁいなるふぁんたじー11 えんとりーでぃすく2005 [ぷれいおんらいん]
   name-en: "Final Fantasy XI [Entry Disc 2005]"
   region: "NTSC-J"
 SLPM-65954:
   name: トム・クランシーシリーズ ゴーストリコン [ユービーアイベスト]
-  name-sort: とむ・くらんしーしりーず ごーすとりこん [ゆーびーあいべすと]
+  name-sort: とむくらんしーしりーず ごーすとりこん [ゆーびーあいべすと]
   name-en: "Tom Clancy's Ghost Recon [Ubisoft Best]"
   region: "NTSC-J"
 SLPM-65955:
   name: トム・クランシーシリーズ スプリンターセル [ユービーアイソフトベスト]
-  name-sort: とむ・くらんしーしりーず すぷりんたーせる [ゆーびーあいそふとべすと]
+  name-sort: とむくらんしーしりーず すぷりんたーせる [ゆーびーあいそふとべすと]
   name-en: "Tom Clancy's Splinter Cell [Ubisoft Best]"
   region: "NTSC-J"
 SLPM-65957:
   name: 遙かなる時空の中で　〜八葉抄〜プレミアムBOX
-  name-sort: はるかなるときのなかで　〜はちようしょう〜ぷれみあむBOX
-  name-en: "Harukanaru Jikuu no Kade Hachiha Katsunori"
+  name-sort: はるかなるときのなかで はちようしょう [ぷれみあむBOX]
+  name-en: "Harukanaru Toki no Naka de Hachiyou-shou"
   region: "NTSC-J"
 SLPM-65958:
-  name: バーンアウト3:テイクダウン [EA BEST HITS]
+  name: EA BEST HITS バーンアウト3:テイクダウン
   name-sort: ばーんあうと3:ていくだうん [EA BEST HITS]
   name-en: "Burnout 3 - Takedown [EA Best Hits]"
   region: "NTSC-J"
@@ -40590,7 +40688,7 @@ SLPM-65959:
 SLPM-65960:
   name: North Wind 〜永遠の約束〜 初回限定版
   name-sort: North Wind 〜えいえんのやくそく〜 しょかいげんていばん
-  name-en: "North Wind Promise Forever [Limited Edition]"
+  name-en: "North Wind Promise Forever [First Print Limited Edition]"
   region: "NTSC-J"
 SLPM-65961:
   name: North Wind 〜永遠の約束〜
@@ -40599,22 +40697,22 @@ SLPM-65961:
   region: "NTSC-J"
 SLPM-65962:
   name: ホームメイド 〜終の館〜 [初回限定版]
-  name-sort: ほーむめいど 〜ついのやかた〜 [しょかいげんていばん]
-  name-en: "Home Maid - Owari no Tachi [Limited Edition]"
+  name-sort: ほーむめいど ついのやかた しょかいげんていばん
+  name-en: "Home Maid - Owari no Tachi [First Print Limited Edition]"
   region: "NTSC-J"
 SLPM-65963:
   name: ホームメイド 〜終の館〜
-  name-sort: ほーむめいど 〜ついのやかた〜
+  name-sort: ほーむめいど ついのやかた
   name-en: "Home Maid - Owari no Tachi"
   region: "NTSC-J"
 SLPM-65964:
   name: まじかる☆ている 〜ちっちゃな魔法使い〜 [初回限定版]
-  name-sort: まじかる☆ている 〜ちっちゃなまほうつかい〜 [しょかいげんていばん]
-  name-en: "Magical Tale - Chitchana Mahoutsukai [Limited Edition]"
+  name-sort: まじかるている ちっちゃなまほうつかい しょかいげんていばん
+  name-en: "Magical Tale - Chitchana Mahoutsukai [First Print Limited Edition]"
   region: "NTSC-J"
 SLPM-65965:
   name: まじかる☆ている 〜ちっちゃな魔法使い〜
-  name-sort: まじかる☆ている 〜ちっちゃなまほうつかい〜
+  name-sort: まじかるている ちっちゃなまほうつかい
   name-en: "Magical Tale - Chitchana Mahoutsukai"
   region: "NTSC-J"
 SLPM-65966:
@@ -40630,7 +40728,7 @@ SLPM-65967:
 SLPM-65968:
   name: らぶドル 〜Lovely Idol〜 初回限定版
   name-sort: らぶどる 〜Lovely Idol〜 しょかいげんていばん
-  name-en: "Lovely Doll - Lovely Idol [Limited Edition]"
+  name-en: "Lovely Doll - Lovely Idol [First Print Limited Edition]"
   region: "NTSC-J"
 SLPM-65969:
   name: らぶドル 〜Lovely Idol〜
@@ -40638,13 +40736,13 @@ SLPM-65969:
   name-en: "Lovely Doll - Lovely Idol"
   region: "NTSC-J"
 SLPM-65970:
-  name: カッパの飼い方 -How to breed kappas- [コナミ殿堂セレクション]
+  name: カッパの飼い方 -How to breed kappas-(コナミ殿堂セレクション)
   name-sort: かっぱのかいかた -How to breed kappas- [こなみでんどうせれくしょん]
   name-en: "Kappa no Kai-Kata - How to Breed Kappas [Konami Palace Selection]"
   region: "NTSC-J"
 SLPM-65971:
   name: そして僕らは、・・・and he said
-  name-sort: そしてぼくらは、・・・and he said
+  name-sort: そしてぼくらは and he said
   name-en: "Soshite Bokura wa... and He Said"
   region: "NTSC-J"
 SLPM-65972:
@@ -40717,14 +40815,14 @@ SLPM-65981:
   name-en: "Front Mission Online"
   region: "NTSC-J"
 SLPM-65982:
-  name: 東京バス案内(ガイド)2
-  name-sort: とうきょうばすあんない(がいど)2
+  name: 東京バス案内2
+  name-sort: とうきょうばすがいど2
   name-en: "Tokyo Bus Guide 2"
   region: "NTSC-J"
   compat: 5
 SLPM-65984:
   name: Grand Theft Auto:San Andreas
-  name-sort: Grand Theft Auto:San Andreas
+  name-sort: ぐらんどせふとおーと さんあんどれあす
   name-en: "Grand Theft Auto - San Andreas"
   region: "NTSC-J"
   clampModes:
@@ -40740,27 +40838,27 @@ SLPM-65985:
     roundSprite: 1 # Fixes font artifacts for health and other sprites.
     texturePreloading: 0 # Improves performance and prevents it disabling itself regardless.
 SLPM-65986:
-  name: Quartett!〜THE STAGE OF LOVE〜 [初回限定版]
-  name-sort: Quartett!〜THE STAGE OF LOVE〜 [しょかいげんていばん]
-  name-en: "Quartett! The Stage of Love [Limited Edition]"
+  name: Quartett!〜THE STAGE OF LOVE〜(初回限定版)
+  name-sort: Quartett!〜THE STAGE OF LOVE〜 しょかいげんていばん
+  name-en: "Quartett! The Stage of Love [First Print Limited Edition]"
   region: "NTSC-J"
 SLPM-65987:
-  name: Quartett!〜THE STAGE OF LOVE〜
+  name: Quartett!〜THE STAGE OF LOVE〜(通常版)
   name-sort: Quartett!〜THE STAGE OF LOVE〜
-  name-en: "Quartett! The Stage of Love"
+  name-en: "Quartett! The Stage of Love [Standard Edition]"
   region: "NTSC-J"
 SLPM-65988:
   name: 少女義経伝・弐 〜刻を超える契り〜 [特別版]
-  name-sort: しょうじょよしつねでん・に 〜こくをこえるちぎり〜 [とくべつばん]
+  name-sort: しょうじょよしつねでん2 こくをこえるちぎり [とくべつばん]
   name-en: "Shoujo Yoshitsune Den 2 [Premium Pack]"
   region: "NTSC-J"
 SLPM-65989:
   name: 少女義経伝・弐 〜刻を超える契り〜
-  name-sort: しょうじょよしつねでん・に 〜こくをこえるちぎり〜
+  name-sort: しょうじょよしつねでん2 こくをこえるちぎり
   name-en: "Shoujo Yoshitsune Den 2"
   region: "NTSC-J"
 SLPM-65990:
-  name: NEO CONTRA [コナミ殿堂セレクション]
+  name: NEO CONTRA(コナミ殿堂セレクション)
   name-sort: NEO CONTRA [こなみでんどうせれくしょん]
   name-en: "Neo Contra [Konami Palace Selection]"
   region: "NTSC-J"
@@ -40769,7 +40867,7 @@ SLPM-65990:
   clampModes:
     eeClampMode: 2 # Reduces FPU calculation errors.
 SLPM-65991:
-  name: ANUBIS ZONE OF THE ENDERS SPECIAL EDITION [コナミ殿堂セレクション]
+  name: ANUBIS ZONE OF THE ENDERS SPECIAL EDITION(コナミ殿堂セレクション)
   name-sort: ANUBIS ZONE OF THE ENDERS SPECIAL EDITION [こなみでんどうせれくしょん]
   name-en: "Anubis - Zone of the Enders Special Edition [Konami Dendou Collection]"
   region: "NTSC-J"
@@ -40789,7 +40887,7 @@ SLPM-65995:
     halfPixelOffset: 2 # Fixes double image.
 SLPM-65996:
   name: 破滅のマルス 限定版
-  name-sort: はめつのまるす げんていばん
+  name-sort: はめつのまるす [げんていばん]
   name-en: "Hametsu no Mars [Limited Edition]"
   region: "NTSC-J"
 SLPM-65997:
@@ -40807,7 +40905,7 @@ SLPM-65998:
     roundSprite: 1 # Fixes squares around sprites when upscaling.
 SLPM-65999:
   name: ドラッグ オン ドラグーン2 -封印の紅、背徳の黒-
-  name-sort: どらっぐ おん どらぐーん2 -ふういんのあか、はいとくのくろ-
+  name-sort: どらっぐ おん どらぐーん2 ふういんのあか はいとくのくろ
   name-en: "Drag-on Dragoon 2 - Fuuin no Aka, Haitoku no Kuro"
   region: "NTSC-J"
   clampModes:
@@ -40818,19 +40916,19 @@ SLPM-65999:
     texturePreloading: 1 # Performs better with partial preload because it is slow on locations outside gameplay foremost.
 SLPM-66000:
   name: コンフリクトデルタII 〜湾岸戦争1991〜
-  name-sort: こんふりくとでるたII 〜わんがんせんそう1991〜
+  name-sort: こんふりくとでるたII わんがんせんそう1991
   name-en: "Conflict Delta II - Gulf War 1991"
   region: "NTSC-J"
   gameFixes:
     - SoftwareRendererFMVHack # Fixes seizure inducing FMVs.
 SLPM-66001:
   name: ショコラ　〜maid cafe curio〜
-  name-sort: しょこら　〜maid cafe curio〜
+  name-sort: しょこら maid cafe curio
   name-en: "Chocolat - Maid Cafe Curio"
   region: "NTSC-J"
 SLPM-66002:
   name: プリンス・オブ・ペルシャ ケンシ ノ ココロ
-  name-sort: ぷりんす・おぶ・ぺるしゃ けんし の こころ
+  name-sort: ぷりんす おぶ ぺるしゃ けんし の こころ
   name-en: "Prince of Persia - Warrior Within"
   region: "NTSC-J"
   gsHWFixes:
@@ -40845,7 +40943,7 @@ SLPM-66005:
   name: "Harukanaru Toki no Naka de 3"
   region: "NTSC-J"
 SLPM-66006:
-  name: 愛蔵版 アンジェリークトロワ [コーエー定番シリーズ]
+  name: コーエー定番シリーズ 愛蔵版 アンジェリークトロワ
   name-sort: あいぞうばん あんじぇりーくとろわ [こーえーていばんしりーず]
   name-en: "Angelique Trois - Aizouhen [Koei Selection]"
   region: "NTSC-J"
@@ -40866,27 +40964,27 @@ SLPM-66009:
   region: "NTSC-J"
   compat: 5
 SLPM-66010:
-  name: テニスの王子様 Smash Hit! [コナミ殿堂セレクション]
+  name: テニスの王子様 Smash Hit!(コナミ殿堂セレクション)
   name-sort: てにすのおうじさま Smash Hit! [こなみでんどうせれくしょん]
   name-en: "Tennis no Oji-Sama - Smash-Hit! [Konami Palace Selection]"
   region: "NTSC-J"
 SLPM-66011:
-  name: テニスの王子様 Smash Hit!2 [コナミ殿堂セレクション]
+  name: テニスの王子様 Smash Hit!2(コナミ殿堂セレクション)
   name-sort: てにすのおうじさま Smash Hit!2 [こなみでんどうせれくしょん]
   name-en: "Tennis no Oji-Sama - Smash-Hit! 2 [Konami Palace Selection]"
   region: "NTSC-J"
 SLPM-66012:
-  name: テニスの王子様SWEAT&TEARS 2 [コナミ殿堂セレクション]
+  name: テニスの王子様SWEAT&TEARS 2(コナミ殿堂セレクション)
   name-sort: てにすのおうじさまSWEAT&TEARS 2 [こなみでんどうせれくしょん]
   name-en: "Tennis no Oji-Sama - Sweat & Tears 2 [Konami Palace Selection]"
   region: "NTSC-J"
 SLPM-66013:
-  name: テニスの王子様最強チームを結成せよ! [コナミ殿堂セレクション]
+  name: テニスの王子様最強チームを結成せよ!(コナミ殿堂セレクション)
   name-sort: てにすのおうじさまさいきょうちーむをけっせいせよ! [こなみでんどうせれくしょん]
   name-en: "Tennis no Oji-Sama - Form the Strongest Team [Konami Palace Selection]"
   region: "NTSC-J"
 SLPM-66014:
-  name: テニスの王子様 RUSH&DREAM! [コナミ殿堂セレクション]
+  name: テニスの王子様 RUSH&DREAM!(コナミ殿堂セレクション)
   name-sort: てにすのおうじさま RUSH&DREAM! [こなみでんどうせれくしょん]
   name-en: "Tennis no Oji-Sama - Rush & Dream [Konami Palace Selection]"
   region: "NTSC-J"
@@ -40904,7 +41002,7 @@ SLPM-66017:
   name: "Firefighter F.D.18"
   region: "NTSC-J"
 SLPM-66018:
-  name: サイレントヒル3 [コナミ殿堂セレクション]
+  name: サイレントヒル3(コナミ殿堂セレクション)
   name-sort: さいれんとひる3 [こなみでんどうせれくしょん]
   name-en: "Silent Hill 3 [Konami Dendou Collection]"
   region: "NTSC-J"
@@ -40922,7 +41020,7 @@ SLPM-66018:
     - "SLPM-65631"
 SLPM-66019:
   name: STUNTMAN スタントマン
-  name-sort: STUNTMAN すたんとまん
+  name-sort: すたんとまん
   name-en: "Stuntman"
   region: "NTSC-J"
   gsHWFixes:
@@ -40940,8 +41038,8 @@ SLPM-66021:
   name-en: "NBA Street V3"
   region: "NTSC-J"
 SLPM-66022:
-  name: KAIDO -峠の伝説-
-  name-sort: KAIDO -とうげのでんせつ-
+  name: KAIDO　－峠の伝説－
+  name-sort: KAIDO とうげのでんせつ
   name-en: "Kaido Touge no Densetsu"
   region: "NTSC-J"
   gsHWFixes:
@@ -40949,12 +41047,12 @@ SLPM-66022:
     wildArmsHack: 1 # De-blurs the 3D image.
 SLPM-66023:
   name: 〜ふしぎ遊戯玄武開伝外伝〜 鏡の巫女 限定版
-  name-sort: 〜ふしぎゆうぎげんぶかいでんがいでん〜 かがみのみこ げんていばん
+  name-sort: ふしぎゆうぎげんぶかいでんがいでん かがみのみこ [げんていばん]
   name-en: "Fushigi Yuugi - ShigiYuugi Kurotake Kaiden Gaiden - Kagami no Fujo [Limited Edition]"
   region: "NTSC-J"
 SLPM-66024:
   name: 〜ふしぎ遊戯玄武開伝外伝〜 鏡の巫女
-  name-sort: 〜ふしぎゆうぎげんぶかいでんがいでん〜 かがみのみこ
+  name-sort: ふしぎゆうぎげんぶかいでんがいでん かがみのみこ
   name-en: "Fushigi Yuugi - ShigiYuugi Kurotake Kaiden Gaiden - Kagami no Fujo"
   region: "NTSC-J"
 SLPM-66025:
@@ -40964,12 +41062,12 @@ SLPM-66025:
   region: "NTSC-J"
 SLPM-66026:
   name: 初恋-first kiss- 初回限定版
-  name-sort: はつこい-first kiss- しょかいげんていばん
-  name-en: "Hatsukoi - First Kiss [Limited Edition]"
+  name-sort: はつこい first kiss しょかいげんていばん
+  name-en: "Hatsukoi - First Kiss [First Print Limited Edition]"
   region: "NTSC-J"
 SLPM-66027:
   name: 初恋−first kiss−
-  name-sort: はつこい-first kiss-
+  name-sort: はつこい first kiss
   name-en: "Hatsukoi - First Kiss"
   region: "NTSC-J"
 SLPM-66028:
@@ -40990,8 +41088,8 @@ SLPM-66030:
   region: "NTSC-J"
   compat: 5
 SLPM-66031:
-  name: ファンタシー スター  ユニバース (Phantasy Star Universe)
-  name-sort: ふぁんたしー すたー  ゆにばーす
+  name: ファンタシー スター ユニバース (Phantasy Star Universe)
+  name-sort: ふぁんたしーすたーゆにばーす
   name-en: "Phantasy Star Universe"
   region: "NTSC-J"
   roundModes:
@@ -41007,7 +41105,7 @@ SLPM-66032:
     halfPixelOffset: 1 # Fixes dark sides.
 SLPM-66033:
   name: OZ -オズ-
-  name-sort: OZ -おず-
+  name-sort: おず
   name-en: "Oz"
   region: "NTSC-J"
   gsHWFixes:
@@ -41015,7 +41113,7 @@ SLPM-66033:
     autoFlush: 2 # Fixes misaligned bloom on sun.
 SLPM-66034:
   name: Grand Theft Auto:Vice City カプコレ
-  name-sort: Grand Theft Auto:Vice City かぷこれ
+  name-sort: ぐらんどせふとおーと ばいすしてぃ かぷこれ
   name-en: "Grand Theft Auto - Vice City"
   region: "NTSC-J"
 SLPM-66035:
@@ -41025,12 +41123,12 @@ SLPM-66035:
   region: "NTSC-J"
 SLPM-66038:
   name: ジオラマ戦線異状なし 〜スターリングラードへの道〜
-  name-sort: じおらませんせんいじょうなし 〜すたーりんぐらーどへのみち〜
+  name-sort: じおらませんせんいじょうなし すたーりんぐらーどへのみち
   name-en: "Georama Sensen Ijou Nashi"
   region: "NTSC-J"
 SLPM-66039:
   name: SuperLite 2000シリーズ Memories Off 〜それから〜
-  name-sort: SuperLite 2000しりーず Memories Off 〜それから〜
+  name-sort: SuperLite 2000しりーず Memories Off それから
   name-en: "SuperLite 2000 Series - Memories Off... Sorekara"
   region: "NTSC-J"
 SLPM-66040:
@@ -41067,7 +41165,7 @@ SLPM-66045:
   region: "NTSC-J"
 SLPM-66046:
   name: スター・ウォーズ エピソード3 シスの復讐
-  name-sort: すたー・うぉーず えぴそーど3 しすのふくしゅう
+  name-sort: すたーうぉーず えぴそーど3 しすのふくしゅう
   name-en: "Star Wars - Episode III - Revenge of the Sith"
   region: "NTSC-J"
   gsHWFixes:
@@ -41079,7 +41177,7 @@ SLPM-66047:
   region: "NTSC-J"
 SLPM-66049:
   name: D.C.P.S. 〜ダ・カーポ〜 プラスシチュエーション KADOKAWA THE Best
-  name-sort: D.C.P.S. 〜だ・かーぽ〜 ぷらすしちゅえーしょん KADOKAWA THE Best
+  name-sort: だかーぽ ぷらすしちゅえーしょん KADOKAWA THE Best
   name-en: "D.C.P.S. - Da Capo Plus Situation [Kadokawa the Best]"
   region: "NTSC-J"
 SLPM-66050:
@@ -41088,8 +41186,8 @@ SLPM-66050:
   name-en: "Daisan Teikoku Koubouki II - Aufstieg und Fall des Dritten Reich"
   region: "NTSC-J"
 SLPM-66051:
-  name: ニード・フォー・スピード アンダーグラウンド2 車道 [EA BEST HITS]
-  name-sort: にーど・ふぉー・すぴーど あんだーぐらうんど2 しゃどう [EA BEST HITS]
+  name: EA BEST HITS ニード・フォー・スピード アンダーグラウンド2 車道
+  name-sort: にーど ふぉー すぴーど あんだーぐらうんど2 しゃどう [EA BEST HITS]
   name-en: "Need for Speed Underground 2 [EA Best Hits] - SHA_DO"
   region: "NTSC-J"
   gsHWFixes:
@@ -41097,17 +41195,17 @@ SLPM-66051:
     halfPixelOffset: 2 # Fixes depth lines.
 SLPM-66052:
   name: 巫女舞 〜永遠の想い〜
-  name-sort: みこまい 〜えいえんのおもい〜
+  name-sort: みこまい えいえんのおもい
   name-en: "Miko Mai - Eien no Omoi"
   region: "NTSC-J"
 SLPM-66053:
   name: アスミック得だねシリーズ ドカポンDX -わたる世界はオニだらけ-
-  name-sort: あすみっくとくだねしりーず どかぽんDX -わたるせかいはおにだらけ-
+  name-sort: どかぽんDX わたるせかいはおにだらけ [あすみっくとくだねしりーず]
   name-en: "Dokapon DX [Asmik Ace Best Series]"
   region: "NTSC-J"
 SLPM-66054:
   name: 新天魔界 ジェネレーション オブ カオス V(ファイブ) 限定版
-  name-sort: しんてんまかい じぇねれーしょん おぶ かおす ふぁいぶ げんていばん
+  name-sort: しんてんまかい じぇねれーしょん おぶ かおす ふぁいぶ [げんていばん]
   name-en: "Generation of Chaos 5 [Limited Edition]"
   region: "NTSC-J"
 SLPM-66055:
@@ -41131,7 +41229,7 @@ SLPM-66057:
     roundSprite: 1 # Fixes vertical and horizontal lines.
 SLPM-66058:
   name: 戦国BASARA
-  name-sort: せんごくBASARA
+  name-sort: せんごくばさら
   name-en: "Sengoku Basara"
   region: "NTSC-J"
 SLPM-66059:
@@ -41141,7 +41239,7 @@ SLPM-66059:
   region: "NTSC-J"
 SLPM-66060:
   name: 亡国のイージス2035 〜ウォーシップガンナー〜
-  name-sort: ぼうこくのいーじす2035 〜うぉーしっぷがんなー〜
+  name-sort: ぼうこくのいーじす2035 うぉーしっぷがんなー
   name-en: "Boukoku no Aegis 2035 - Warship Gunner"
   region: "NTSC-J"
 SLPM-66061:
@@ -41187,7 +41285,7 @@ SLPM-66069:
 SLPM-66070:
   name: シャドウハーツ フロム・ザ・ニュー・ワールド PREMIUM BOX
   name-sort: しゃどうはーつ ふろむ・ざ・にゅー・わーるど PREMIUM BOX
-  name-en: "Shadow Hearts - From the New World [Limited Edition]"
+  name-en: "Shadow Hearts - From the New World [PREMIUM BOX]"
   region: "NTSC-J"
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts and reduces text box artifacts.
@@ -41232,7 +41330,7 @@ SLPM-66076:
   region: "NTSC-J"
 SLPM-66077:
   name: K-1 WORLD MAX 2005 〜世界王者への道〜
-  name-sort: K-1 WORLD MAX 2005 〜せかいおうじゃへのみち〜
+  name-sort: K-1 WORLD MAX 2005 せかいおうじゃへのみち
   name-en: "K-1 World Max 2005"
   region: "NTSC-J"
   compat: 5
@@ -41246,7 +41344,7 @@ SLPM-66077:
         patch=1,EE,003dfe88,word,0000948c
 SLPM-66078:
   name: White Princess the second 〜やはり一途にイってもそうじゃなくてもOKなご都合主義学園アドベンチャー〜
-  name-sort: White Princess the second 〜やはりいちずにいってもそうじゃなくてもOKなごつごうしゅぎがくえんあどべんちゃー〜
+  name-sort: White Princess the second やはりいちずにいってもそうじゃなくてもOKなごつごうしゅぎがくえんあどべんちゃー
   name-en: "White Princess the Second"
   region: "NTSC-J"
 SLPM-66079:
@@ -41257,7 +41355,7 @@ SLPM-66079:
     halfPixelOffset: 2 # Fixes misaligned blur.
 SLPM-66080:
   name: GENERATION OF CHAOSIII 〜時の封印〜 [IFコレクション]
-  name-sort: GENERATION OF CHAOSIII 〜ときのふういん〜 [IFこれくしょん]
+  name-sort: GENERATION OF CHAOSIII ときのふういん [IFこれくしょん]
   name-en: "Generation of Chaos 3 [IF Collection]"
   region: "NTSC-J"
 SLPM-66081:
@@ -41267,19 +41365,19 @@ SLPM-66081:
   region: "NTSC-J"
 SLPM-66082:
   name: ファイプロ・リターンズ
-  name-sort: ふぁいぷろ・りたーんず
+  name-sort: ふぁいぷろ りたーんず
   name-en: "Fire Pro Wrestling Returns"
   region: "NTSC-J"
 SLPM-66083:
   name: ラムネ〜ガラスびんに映る海〜 初回限定版
-  name-sort: らむね〜がらすびんにうつるうみ〜 しょかいげんていばん
-  name-en: "Ramune - Garasu-Bin ni Utsuru Umi [Limited Edition]"
+  name-sort: らむね がらすびんにうつるうみ しょかいげんていばん
+  name-en: "Ramune - Garasu-Bin ni Utsuru Umi [First Print Limited Edition]"
   region: "NTSC-J"
   gsHWFixes:
     beforeDraw: "OI_PointListPalette"
 SLPM-66084:
-  name: ラムネ～ガラスびんに映る海～
-  name-sort: らむね～がらすびんにうつるうみ～
+  name: ラムネ〜ガラスびんに映る海〜
+  name-sort: らむね がらすびんにうつるうみ
   name-en: "Ramune - Garasu-Bin ni Utsuru Umi"
   region: "NTSC-J"
   gsHWFixes:
@@ -41296,7 +41394,7 @@ SLPM-66086:
   region: "NTSC-J"
 SLPM-66087:
   name: Winning Post 7
-  name-sort: Winning Post 7
+  name-sort: ういにんぐぽすと7
   name-en: "Winning Post 7"
   region: "NTSC-J"
 SLPM-66088:
@@ -41304,12 +41402,12 @@ SLPM-66088:
   region: "NTSC-J"
 SLPM-66089:
   name: 3年B組金八先生 伝説の教壇に立て! 完全版
-  name-sort: 3ねんBぐみきんぱちせんせい でんせつのきょうだんにたて! かんぜんばん
+  name-sort: 3ねんBぐみきんぱちせんせい でんせつのきょうだんにたて かんぜんばん
   name-en: "3-nen B-gumi Kinpachi Sensei - Densetsu no Kyoudan ni Tate! Kanzenban"
   region: "NTSC-J"
 SLPM-66090:
   name: クラッシュ・バンディクー がっちゃんこワールド
-  name-sort: くらっしゅ・ばんでぃくー がっちゃんこわーるど
+  name-sort: くらっしゅばんでぃくー がっちゃんこわーるど
   name-en: "Crash Bandicoot - Gacchanko World"
   region: "NTSC-J"
   gsHWFixes:
@@ -41332,31 +41430,31 @@ SLPM-66092:
   gsHWFixes:
     roundSprite: 1 # Fixes vertical and horizontal lines.
 SLPM-66093:
-  name: 決戦II [コーエー定番シリーズ]
+  name: コーエー定番シリーズ 決戦II
   name-sort: けっせんII [こーえーていばんしりーず]
   name-en: "Kessen II [Koei Selection Series]"
   region: "NTSC-J"
 SLPM-66094:
-  name: 真・三國無双2 [コーエー定番シリーズ]
-  name-sort: しん・さんごくむそう2 [こーえーていばんしりーず]
+  name: コーエー定番シリーズ 真・三國無双2
+  name-sort: しんさんごくむそう2 [こーえーていばんしりーず]
   name-en: "Shin Sangoku Musou 2 [Koei Selection Series]"
   region: "NTSC-J"
 SLPM-66095:
   name: "Chou Battle Houshin"
   region: "NTSC-J"
 SLPM-66096:
-  name: 真・三國無双2猛将伝 [コーエー定番シリーズ]
-  name-sort: しん・さんごくむそう2もうしょうでん [こーえーていばんしりーず]
-  name-en: "Shin Sangoku Musou 2 - Mushoden [Koei Selection Series]"
+  name: コーエー定番シリーズ 真・三國無双2猛将伝
+  name-sort: しんさんごくむそう2もうしょうでん [こーえーていばんしりーず]
+  name-en: "Shin Sangoku Musou 2 - Moushouden [Koei Selection Series]"
   region: "NTSC-J"
 SLPM-66097:
   name: Broccoli Best Quality 新世紀エヴァンゲリオン 綾波育成計画withアスカ補完計画
-  name-sort: Broccoli Best Quality しんせいきえゔぁんげりおん あやなみいくせいけいかくwithあすかほかんけいかく
+  name-sort: しんせいきえゔぁんげりおん あやなみいくせいけいかくwithあすかほかんけいかく [Broccoli Best Quality]
   name-en: "Shinseiki Evangelion - Ayanami Ikusai Keikaku with Asuka Hokan Keikaku [Broccoli Best Quality]"
   region: "NTSC-J"
 SLPM-66098:
   name: トゥルークライム -STREETS OF L.A.- [カプコレ]
-  name-sort: とぅるーくらいむ -STREETS OF L.A.- [かぷこれ]
+  name-sort: とぅるーくらいむ STREETS OF L.A. [かぷこれ]
   name-en: "True Crime - Streets of L.A. [CapKore]"
   region: "NTSC-J"
   gsHWFixes:
@@ -41370,12 +41468,12 @@ SLPM-66099:
 SLPM-66100:
   name: 遙かなる時空の中で3 十六夜記
   name-sort: はるかなるときのなかで3 いざよいき
-  name-en: "Harukanaru Jikuu no Kade 3"
+  name-en: "Harukanaru Toki no Naka de 3"
   region: "NTSC-J"
 SLPM-66101:
   name: 真・三國無双4 猛将伝
-  name-sort: しん・さんごくむそう4 もうしょうでん
-  name-en: "Shin Sangoku Musou 4 - Mushoden"
+  name-sort: しんさんごくむそう4 もうしょうでん
+  name-en: "Shin Sangoku Musou 4 - Moushouden"
   region: "NTSC-J"
   gsHWFixes:
     autoFlush: 2 # Fixes sun luminosity.
@@ -41397,7 +41495,7 @@ SLPM-66103:
     autoFlush: 2 # Fixes sun luminosity.
 SLPM-66104:
   name: ぷよぷよフィーバー2 [チュー!]
-  name-sort: ぷよぷよふぃーばー2 [ちゅー!]
+  name-sort: ぷよぷよふぃーばー2
   name-en: "Puyo Puyo Fever 2"
   region: "NTSC-J"
 SLPM-66105:
@@ -41412,13 +41510,13 @@ SLPM-66105:
     - "SLPM-65600"
 SLPM-66106:
   name: 星の降る刻 限定版
-  name-sort: ほしのふるこく げんていばん
-  name-en: "Hoshi no Furu Koku [Limited Edition]"
+  name-sort: ほしのふるとき [げんていばん]
+  name-en: "Hoshi no Furu Toki [Limited Edition]"
   region: "NTSC-J"
 SLPM-66107:
   name: 星の降る刻
-  name-sort: ほしのふるこく
-  name-en: "Hoshi no Furu Koku"
+  name-sort: ほしのふるとき
+  name-en: "Hoshi no Furu Toki"
   region: "NTSC-J"
 SLPM-66108:
   name: バーンアウト リベンジ
@@ -41448,21 +41546,21 @@ SLPM-66108:
     - "SLPM-66204"
 SLPM-66109:
   name: コード・エイジ コマンダーズ 〜継ぐ者 継がれる者〜
-  name-sort: こーど・えいじ こまんだーず 〜つぐもの つがれるもの〜
+  name-sort: こーど えいじ こまんだーず つぐもの つがれるもの
   name-en: "Code Age Commanders - Tsugumono Tsugarerumono"
   region: "NTSC-J"
 SLPM-66110:
   name: ふしぎの海のナディア コレクターズエディション
   name-sort: ふしぎのうみのなでぃあ これくたーずえでぃしょん
-  name-en: "Fushigi no Umi no Nadia - Inherit the Blue Water [Limited Edition]"
+  name-en: "Fushigi no Umi no Nadia - Inherit the Blue Water [Collector's Edition]"
   region: "NTSC-J"
 SLPM-66111:
   name: "Fushigi no Umi no Nadia - Dennou Battle - Miss Nautilus Contest"
   region: "NTSC-J"
 SLPM-66112:
   name: ふしぎの海のナディア 通常版
-  name-sort: ふしぎのうみのなでぃあ つうじょうばん
-  name-en: "Fushigi no Umi no Nadia - Inherit the Blue Water"
+  name-sort: ふしぎのうみのなでぃあ [つうじょうばん]
+  name-en: "Fushigi no Umi no Nadia - Inherit the Blue Water [Standard Edition]"
   region: "NTSC-J"
 SLPM-66113:
   name: 必殺裏稼業
@@ -41471,16 +41569,16 @@ SLPM-66113:
   region: "NTSC-J"
 SLPM-66114:
   name: 水の旋律 [初回限定版]
-  name-sort: みずのせんりつ [しょかいげんていばん]
-  name-en: "Mizu no Senritsu [Limited Edition]"
+  name-sort: みずのせんりつ しょかいげんていばん
+  name-en: "Mizu no Senritsu [First Print Limited Edition]"
   region: "NTSC-J"
 SLPM-66115:
   name: 水の旋律 [通常版]
   name-sort: みずのせんりつ [つうじょうばん]
-  name-en: "Mizu no Senritsu"
+  name-en: "Mizu no Senritsu [Standard Edition]"
   region: "NTSC-J"
 SLPM-66116:
-  name: NBA ライブ 2005 [EA BEST HITS]
+  name: EA BEST HITS NBA ライブ 2005
   name-sort: NBA らいぶ 2005 [EA BEST HITS]
   name-en: "NBA Live 2005 [EA Best Hits]"
   region: "NTSC-J"
@@ -41489,7 +41587,7 @@ SLPM-66116:
     cpuSpriteRenderLevel: 2 # Needed for above.
 SLPM-66117:
   name: METAL GEAR SOLID 3 SUBSISTENCE [ヘッドセット同梱版] [ディスク1/3]
-  name-sort: METAL GEAR SOLID 3 SUBSISTENCE [へっどせっとどうこんばん] [でぃすく1/3]
+  name-sort: めたるぎあそりっど3 さぶしすたんす [へっどせっとどうこんばん] [でぃすく1/3]
   name-en: "Metal Gear Solid 3 - Subsistence [with Headset] [Disc 1 of 3]"
   region: "NTSC-J"
   gameFixes:
@@ -41504,7 +41602,7 @@ SLPM-66117:
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
 SLPM-66118:
   name: METAL GEAR SOLID 3 SUBSISTENCE [ヘッドセット同梱版] [ディスク2/3]
-  name-sort: METAL GEAR SOLID 3 SUBSISTENCE [へっどせっとどうこんばん] [でぃすく2/3]
+  name-sort: めたるぎあそりっど3 さぶしすたんす [へっどせっとどうこんばん] [でぃすく2/3]
   name-en: "Metal Gear Solid 3 - Subsistence [with Headset] [Disc 2 of 3]"
   region: "NTSC-J"
   gameFixes:
@@ -41519,7 +41617,7 @@ SLPM-66118:
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
 SLPM-66119:
   name: METAL GEAR SOLID 3 SUBSISTENCE [ヘッドセット同梱版] [ディスク2/3]
-  name-sort: METAL GEAR SOLID 3 SUBSISTENCE [へっどせっとどうこんばん] [でぃすく2/3]
+  name-sort: めたるぎあそりっど3 さぶしすたんす [へっどせっとどうこんばん] [でぃすく2/3]
   name-en: "Metal Gear Solid 3 - Subsistence [with Headset] [Disc 3 of 3]"
   region: "NTSC-J"
   gameFixes:
@@ -41548,13 +41646,13 @@ SLPM-66122:
   name-en: "Kingdom Hearts [Ultimate Hits]"
   region: "NTSC-J"
 SLPM-66123:
-  name: キングダム ハーツ -ファイナル   ミックス- [アルティメットヒッツ]
-  name-sort: きんぐだむ はーつ -ふぁいなる   みっくす- [あるてぃめっとひっつ]
+  name: キングダム ハーツ -ファイナル ミックス- [アルティメットヒッツ]
+  name-sort: きんぐだむ はーつ ふぁいなる みっくす [あるてぃめっとひっつ]
   name-en: "Kingdom Hearts - Final Mix [Ultimate Hits]"
   region: "NTSC-J"
 SLPM-66124:
   name: ファイナルファンタジーX [アルティメットヒッツ]
-  name-sort: ふぁいなるふぁんたじーX [あるてぃめっとひっつ]
+  name-sort: ふぁいなるふぁんたじー10 [あるてぃめっとひっつ]
   name-en: "Final Fantasy X [Ultimate Hits]"
   region: "NTSC-J"
   gameFixes:
@@ -41567,7 +41665,7 @@ SLPM-66124:
     roundSprite: 2 # Fixes font artifacts.
 SLPM-66125:
   name: ファイナルファンタジーX-2 [アルティメットヒッツ]
-  name-sort: ふぁいなるふぁんたじーX-2 [あるてぃめっとひっつ]
+  name-sort: ふぁいなるふぁんたじー10-2 [あるてぃめっとひっつ]
   name-en: "Final Fantasy X-2 [Ultimate Hits]"
   region: "NTSC-J"
   clampModes:
@@ -41583,18 +41681,20 @@ SLPM-66128:
   name: "Harukanaru Toki no Naka de 3"
   region: "NTSC-J"
 SLPM-66129:
-  name: "Guilty Gear XX #Reload"
+  name: "GUILTY GEAR XX #RELOAD"
+  name-sort: ぎるてぃぎあ いぐぜくす しゃーぷりろーど
+  name-en: "Guilty Gear XX #Reload"
   region: "NTSC-J"
 SLPM-66130:
   name: トム・クランシーシリーズ スプリンターセル カオスセオリー
-  name-sort: とむ・くらんしーしりーず すぷりんたーせる かおすせおりー
+  name-sort: とむくらんしーしりーず すぷりんたーせる かおすせおりー
   name-en: "Tom Clancy's Splinter Cell - Chaos Theory"
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes missing lights especially in NVGs.
 SLPM-66131:
   name: ティム・バートン ナイトメアー・ビフォア・クリスマス ブギーの逆襲 プレミアムパック
-  name-sort: てぃむ・ばーとん ないとめあー・びふぉあ・くりすます ぶぎーのぎゃくしゅう ぷれみあむぱっく
+  name-sort: てぃむばーとん ないとめあー びふぉあ くりすます ぶぎーのぎゃくしゅう ぷれみあむぱっく
   name-en: "Tim Burton's The Nightmare Before Christmas [Premium Pack]"
   region: "NTSC-J"
   gsHWFixes:
@@ -41614,7 +41714,7 @@ SLPM-66133:
   region: "NTSC-J"
 SLPM-66134:
   name: シャッフル!オン・ザ・ステージ
-  name-sort: しゃっふる!おん・ざ・すてーじ
+  name-sort: しゃっふる おん ざ すてーじ
   name-en: "Shuffle! On the Stage"
   region: "NTSC-J"
 SLPM-66135:
@@ -41641,26 +41741,26 @@ SLPM-66138:
   region: "NTSC-J"
 SLPM-66139:
   name: デュエルセイヴァー　ディスティニー
-  name-sort: でゅえるせいゔぁー　でぃすてぃにー
+  name-sort: でゅえるせいゔぁー でぃすてぃにー
   name-en: "Duel Savior Destiny"
   region: "NTSC-J"
   gsHWFixes:
     beforeDraw: "OI_PointListPalette"
 SLPM-66140:
   name: アトリエ マリー+エリー ザールブルグの錬金術士1・2
-  name-sort: あとりえ まりー+えりー ざーるぶるぐのれんきんじゅつし1・2
+  name-sort: あとりえ まりーえりー ざーるぶるぐのれんきんじゅつし1 2
   name-en: "Atelier Marie + Elie - Salburg no Renkinjutsushi 1 & 2"
   region: "NTSC-J"
   gsHWFixes:
     roundSprite: 2 # Fixes the sprites on textbox and characters.
 SLPM-66141:
   name: 魔探偵ロキRAGNAROK 魔妖画〜失われた微笑〜
-  name-sort: またんていろきRAGNAROK ま妖画〜うしなわれたびしょう〜
-  name-en: "Matantei Loki Ragnarok Mayoukaku"
+  name-sort: またんていろきらぐなろく まようが うしなわれたほほえみ
+  name-en: "Matantei Loki Ragnarok - Mayouga Ushinawareta Hohoemi"
   region: "NTSC-J"
 SLPM-66142:
   name: リバース ムーン 限定版
-  name-sort: りばーす むーん げんていばん
+  name-sort: りばーす むーん [げんていばん]
   name-en: "Rebirth Moon [Limited Edition]"
   region: "NTSC-J"
 SLPM-66143:
@@ -41683,14 +41783,14 @@ SLPM-66144:
   clampModes:
     eeClampMode: 3 # Fixes black screen.
 SLPM-66145:
-  name: ゴールデンアイ ダークエージェント [EA BEST HITS]
+  name: EA BEST HITS ゴールデンアイ ダークエージェント
   name-sort: ごーるでんあい だーくえーじぇんと [EA BEST HITS]
   name-en: "GoldenEye - Rogue Agent [EA Best Hits]"
   region: "NTSC-J"
 SLPM-66146:
   name: Memories Off #5th とぎれたフィルム 初回限定版
   name-sort: Memories Off #5th とぎれたふぃるむ しょかいげんていばん
-  name-en: "Memories Off #5 - Togireta Film [Limited Edition]"
+  name-en: "Memories Off #5 - Togireta Film [First Print Limited Edition]"
   region: "NTSC-J"
 SLPM-66147:
   name: Memories Off #5th とぎれたフィルム
@@ -41698,7 +41798,7 @@ SLPM-66147:
   name-en: "Memories Off #5 - Togireta Film"
   region: "NTSC-J"
 SLPM-66148:
-  name: スターウォーズ バトルフロント [EA BEST HITS]
+  name: EA BEST HITS スターウォーズ バトルフロント
   name-sort: すたーうぉーず ばとるふろんと [EA BEST HITS]
   name-en: "Star Wars - Battlefront [EA Best Hits]"
   region: "NTSC-J"
@@ -41708,13 +41808,13 @@ SLPM-66148:
     recommendedBlendingLevel: 3 # Improves reflections on certain characters and objects on certain levels.
 SLPM-66149:
   name: しろがねの鳥籠 限定版
-  name-sort: しろがねのとりかご げんていばん
+  name-sort: しろがねのとりかご [げんていばん]
   name-en: "Shirogane no Torikago [Limited Edition]"
   region: "NTSC-J"
 SLPM-66150:
   name: しろがねの鳥籠 通常版
-  name-sort: しろがねのとりかご つうじょうばん
-  name-en: "Shirogane no Torikago"
+  name-sort: しろがねのとりかご [つうじょうばん]
+  name-en: "Shirogane no Torikago [Standard Edition]"
   region: "NTSC-J"
 SLPM-66151:
   name: KILLZONE
@@ -41728,7 +41828,7 @@ SLPM-66151:
 SLPM-66152:
   name: こんねこ 〜Keep a memory green〜 初回限定版
   name-sort: こんねこ 〜Keep a memory green〜 しょかいげんていばん
-  name-en: "Konneko - Keep a Memory Green [Limited Edition]"
+  name-en: "Konneko - Keep a Memory Green [First Print Limited Edition]"
   region: "NTSC-J"
 SLPM-66153:
   name: こんねこ 〜Keep a memory green〜
@@ -41736,7 +41836,7 @@ SLPM-66153:
   name-en: "Konneko - Keep a Memory Green"
   region: "NTSC-J"
 SLPM-66155:
-  name: アニメバトル 烈火の炎 FINAL BURNING [コナミ殿堂セレクション]
+  name: アニメバトル 烈火の炎 FINAL BURNING(コナミ殿堂セレクション)
   name-sort: あにめばとる れっかのほのお FINAL BURNING [こなみでんどうせれくしょん]
   name-en: "Flame of Recca - Final Burning [Konami Palace Selection]"
   region: "NTSC-J"
@@ -41748,7 +41848,7 @@ SLPM-66156:
 SLPM-66157:
   name: ルーンプリンセス 初回限定版
   name-sort: るーんぷりんせす しょかいげんていばん
-  name-en: "Rune Princess [First Print - Limited Edition]"
+  name-en: "Rune Princess [First Print Limited Edition]"
   region: "NTSC-J"
 SLPM-66158:
   name: ルーンプリンセス
@@ -41796,8 +41896,8 @@ SLPM-66164:
   compat: 5
 SLPM-66165:
   name: 乙女はお姉さまに恋してる
-  name-sort: おとめはおあねさまにこいしてる
-  name-en: "Otome Hao Anesama ni Koi Shiteru"
+  name-sort: おとめはおねえさまにこいしてる
+  name-en: "Otome ha Oneesama ni Koi Shiteru"
   region: "NTSC-J"
 SLPM-66166:
   name: シャドウ・ザ・ヘッジホッグ
@@ -41826,8 +41926,8 @@ SLPM-66169:
   region: "NTSC-J"
 SLPM-66170:
   name: 幻想水滸伝V 限定版
-  name-sort: げんそうすいこでんV げんていばん
-  name-en: "Genso Suikoden V [Limited Edition]"
+  name-sort: げんそうすいこでんV [げんていばん]
+  name-en: "Gensou Suikoden V [Limited Edition]"
   region: "NTSC-J"
 SLPM-66171:
   name: NBAライブ06
@@ -41874,8 +41974,8 @@ SLPM-66177:
     halfPixelOffset: 2 # Fix effects upscaling.
     autoFlush: 1 # Fixes broken post processing.
 SLPM-66178:
-  name: ポップンミュージック 7 [コナミザベスト]
-  name-sort: ぽっぷんみゅーじっく 7 [こなみざ・べすと]
+  name: ポップンミュージック 7 [コナミ・ザ・ベスト]
+  name-sort: ぽっぷんみゅーじっく 7 [こなみ・ざ・べすと]
   name-en: "Pop'n music 7 [Konami The Best]"
   region: "NTSC-J"
 SLPM-66179:
@@ -41885,7 +41985,7 @@ SLPM-66179:
   region: "NTSC-J"
 SLPM-66180:
   name: beatmania IIDX 10th style
-  name-sort: beatmania IIDX 10th style
+  name-sort: びーとまにあ つーでぃーえっくす 10th style
   name-en: "Beatmania IIDX 10th style"
   region: "NTSC-J"
 SLPM-66181:
@@ -41920,7 +42020,7 @@ SLPM-66184:
     halfPixelOffset: 2 # Fixes misaligned lighting and bloom.
 SLPM-66185:
   name: ゲームになったよ!ドクロちゃん〜健康診断大作戦〜 限定版
-  name-sort: げーむになったよ!どくろちゃん〜けんこうしんだんだいさくせん〜 げんていばん
+  name-sort: げーむになったよ!どくろちゃん けんこうしんだんだいさくせん [げんていばん]
   name-en: "Game ni Nattayo! Dokuro-chan [Limited Edition]"
   region: "NTSC-J"
   patches:
@@ -41932,7 +42032,7 @@ SLPM-66185:
         patch=1,EE,00156608,word,10000003
 SLPM-66186:
   name: ゲームになったよ!ドクロちゃん〜健康診断大作戦〜
-  name-sort: げーむになったよ!どくろちゃん〜けんこうしんだんだいさくせん〜
+  name-sort: げーむになったよ どくろちゃん けんこうしんだんだいさくせん
   name-en: "Game ni Nattayo! Dokuro-chan"
   region: "NTSC-J"
   patches:
@@ -41959,7 +42059,7 @@ SLPM-66189:
     recommendedBlendingLevel: 4 # Fixes missing lighting and makes snow not look like snow sludge.
 SLPM-66190:
   name: スター・ウォーズ バトルフロントII
-  name-sort: すたー・うぉーず ばとるふろんとII
+  name-sort: すたーうぉーず ばとるふろんとII
   name-en: "Star Wars - Battlefront II"
   region: "NTSC-J"
   gsHWFixes:
@@ -42023,7 +42123,7 @@ SLPM-66202:
 SLPM-66203:
   name: フラグメンツ・ブルー [通常版]
   name-sort: ふらぐめんつ・ぶるー [つうじょうばん]
-  name-en: "Fragments Blue"
+  name-en: "Fragments Blue [Standard Edition]"
   region: "NTSC-J"
 SLPM-66204:
   name: MADDEN NFL 06
@@ -42068,13 +42168,13 @@ SLPM-66208:
   name-en: "Sakura Taisen V - Episode 0 - Samurai Girl of Wild [Sega the Best]"
   region: "NTSC-J"
 SLPM-66209:
-  name: ポップンミュージック 9 [コナミザベスト]
-  name-sort: ぽっぷんみゅーじっく 9 [こなみざ・べすと]
+  name: ポップンミュージック 9 [コナミ・ザ・ベスト]
+  name-sort: ぽっぷんみゅーじっく 9 [こなみ・ざ・べすと]
   name-en: "Pop'n music 9 [Konami The Best]"
   region: "NTSC-J"
 SLPM-66210:
-  name: ポップンミュージック 10 [コナミザベスト]
-  name-sort: ぽっぷんみゅーじっく 10 [こなみざ・べすと]
+  name: ポップンミュージック 10 [コナミ・ザ・ベスト]
+  name-sort: ぽっぷんみゅーじっく 10 [こなみ・ざ・べすと]
   name-en: "Pop'n music 10 [Konami The Best]"
   region: "NTSC-J"
 SLPM-66211:
@@ -42105,13 +42205,13 @@ SLPM-66213:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
 SLPM-66214:
-  name: WHITE CLARITY(ホワイト クラリティー)〜And The tears became you.〜 [初回限定版]
-  name-sort: ほわいと くらりてぃー 〜And The tears became you.〜 [しょかいげんていばん]
+  name: WHITE CLARITY 〜And The tears became you.〜 [初回限定版]
+  name-sort: ほわいと くらりてぃー 〜And The tears became you.〜 しょかいげんていばん
   name-en: "White Clarity - And, the Tears Became You [First Print Limited Edition]"
   region: "NTSC-J"
 SLPM-66215:
   name: WHITE CLARITY 〜And The tears became you.〜
-  name-sort: WHITE CLARITY 〜And The tears became you.〜
+  name-sort: WHITE CLARITY And The tears became you.
   name-en: "White Clarity - And, the Tears Became You"
   region: "NTSC-J"
 SLPM-66217:
@@ -42121,7 +42221,7 @@ SLPM-66217:
   region: "NTSC-J"
 SLPM-66218:
   name: アイシールド21 〜アメフトやろうぜ!Ya-!Ha-!〜
-  name-sort: あいしーるど21 〜あめふとやろうぜ!Ya-!Ha-!〜
+  name-sort: あいしーるど21 あめふとやろうぜYa-!Ha-!
   name-en: "Eyeshield 21 Amefoot Yarouze! Ya-!Ha-!"
   region: "NTSC-J"
 SLPM-66219:
@@ -42131,7 +42231,7 @@ SLPM-66219:
   region: "NTSC-J"
 SLPM-66220:
   name: METAL GEAR SOLID 3 SUBSISTENCE [初回生産版] [ディスク1/3]
-  name-sort: METAL GEAR SOLID 3 SUBSISTENCE [しょかいせいさんばん] [でぃすく1/3]
+  name-sort: めたるぎあそりっど3 さぶしすたんす [しょかいせいさんばん] [でぃすく1/3]
   name-en: "Metal Gear Solid 3 - Subsistence [First Print Limited Edition] [Disc 1 of 3]"
   region: "NTSC-J"
   gameFixes:
@@ -42148,7 +42248,7 @@ SLPM-66220:
     - "SLPM-66117"
 SLPM-66221:
   name: METAL GEAR SOLID 3 SUBSISTENCE [初回生産版] [ディスク2/3]
-  name-sort: METAL GEAR SOLID 3 SUBSISTENCE [しょかいせいさんばん] [でぃすく2/3]
+  name-sort: めたるぎあそりっど3 さぶしすたんす [しょかいせいさんばん] [でぃすく2/3]
   name-en: "Metal Gear Solid 3 - Subsistence [First Print Limited Edition] [Disc 2 of 3]"
   region: "NTSC-J"
   gameFixes:
@@ -42165,7 +42265,7 @@ SLPM-66221:
     - "SLPM-66117"
 SLPM-66222:
   name: METAL GEAR SOLID 3 SUBSISTENCE [初回生産版] [ディスク3/3]
-  name-sort: METAL GEAR SOLID 3 SUBSISTENCE [しょかいせいさんばん] [でぃすく3/3]
+  name-sort: めたるぎあそりっど3 さぶしすたんす [しょかいせいさんばん] [でぃすく3/3]
   name-en: "Metal Gear Solid 3 - Subsistence [First Print Limited Edition] [Disc 3 of 3]"
   region: "NTSC-J"
   gameFixes:
@@ -42182,7 +42282,7 @@ SLPM-66222:
     - "SLPM-66117"
 SLPM-66223:
   name: METAL GEAR SOLID 3 SUBSISTENCE [ディスク1/2]
-  name-sort: METAL GEAR SOLID 3 SUBSISTENCE [でぃすく1/2]
+  name-sort: めたるぎあそりっど3 さぶしすたんす [でぃすく1/2]
   name-en: "Metal Gear Solid 3 - Subsistence [Disc 1 of 2]"
   region: "NTSC-J"
   gameFixes:
@@ -42199,7 +42299,7 @@ SLPM-66223:
     - "SLPM-66117"
 SLPM-66224:
   name: METAL GEAR SOLID 3 SUBSISTENCE [ディスク2/2]
-  name-sort: METAL GEAR SOLID 3 SUBSISTENCE [でぃすく2/2]
+  name-sort: めたるぎあそりっど3 さぶしすたんす [でぃすく2/2]
   name-en: "Metal Gear Solid 3 - Subsistence [Disc 2 of 2]"
   region: "NTSC-J"
   gameFixes:
@@ -42216,37 +42316,37 @@ SLPM-66224:
     - "SLPM-66117"
 SLPM-66225:
   name: D.C.F.S. 〜ダ・カーポ〜 フォーシーズンズ DXパック
-  name-sort: D.C.F.S. 〜だ・かーぽ〜 ふぉーしーずんず DXぱっく
+  name-sort: だかーぽ ふぉーしーずんず [DXぱっく]
   name-en: "Da Capo Four Seasons [Deluxe Pack]"
   region: "NTSC-J"
 SLPM-66226:
   name: D.C.F.S. 〜ダ・カーポ〜 フォーシーズンズ
-  name-sort: D.C.F.S. 〜だ・かーぽ〜 ふぉーしーずんず
+  name-sort: だかーぽ ふぉーしーずんず
   name-en: "Da Capo Four Seasons"
   region: "NTSC-J"
 SLPM-66227:
   name: ジーワンジョッキー 4 & WinningPost 7 ツインパック
   name-sort: じーわんじょっきー 4 & WinningPost 7 ついんぱっく
-  name-en: "GI Jockey 4 + Winning Post 7 [Twin Pack] [GI Jockey 4 Disc]"
+  name-en: "G1 Jockey 4 + Winning Post 7 [Twin Pack] [G1 Jockey 4 Disc]"
   region: "NTSC-J"
 SLPM-66228:
   name: ウイニングポスト7 [ジーワンジョッキー4&ウイニングポストツインパック用]
   name-sort: ういにんぐぽすと7 [じーわんじょっきー4&ういにんぐぽすとついんぱっくよう]
-  name-en: "GI Jockey 4 + Winning Post 7 [Twin Pack] [Winning Post 7 Disc]"
+  name-en: "G1 Jockey 4 + Winning Post 7 [Twin Pack] [Winning Post 7 Disc]"
   region: "NTSC-J"
 SLPM-66229:
   name: ジーワンジョッキー 4
   name-sort: じーわんじょっきー 4
-  name-en: "GI Jockey 4"
+  name-en: "G1 Jockey 4"
   region: "NTSC-J"
 SLPM-66231:
   name: カルタグラ 〜魂の苦悩〜
-  name-sort: かるたぐら 〜たましいのくのう〜
+  name-sort: かるたぐら たましいのくのう
   name-en: "Cartagra - Tamashii no Kunou"
   region: "NTSC-J"
 SLPM-66232:
   name: ニード・フォー・スピード モスト・ウォンテッド
-  name-sort: にーど・ふぉー・すぴーど もすと・うぉんてっど
+  name-sort: にーど ふぉー すぴーど もすと うぉんてっど
   name-en: "Need for Speed - Most Wanted"
   region: "NTSC-J"
   gsHWFixes:
@@ -42272,7 +42372,7 @@ SLPM-66233:
   compat: 5
 SLPM-66234:
   name: ウィザードリィ エクス 〜前線の学府〜 ワンダープライス
-  name-sort: うぃざーどりぃ えくす 〜ぜんせんのがくふ〜 わんだーぷらいす
+  name-sort: うぃざーどりぃ えくす ぜんせんのがくふ [わんだーぷらいす]
   name-en: "Wizardry X - Zensen no Gakufu [Wonder Price]"
   region: "NTSC-J"
 SLPM-66235:
@@ -42283,12 +42383,12 @@ SLPM-66235:
   compat: 5
 SLPM-66237:
   name: 乙女的恋革命★ラブレボ!!ラブレボックス
-  name-sort: おとめてきこいかくめい★らぶれぼ!!らぶれぼっくす
+  name-sort: おとめてきこいかくめい らぶれぼ!! [らぶれぼっくす]
   name-en: "Otometeki Koi Kakumei Rabu Rebo!! [Love Revo Box]"
   region: "NTSC-J"
 SLPM-66238:
   name: 乙女的恋革命★ラブレボ!!
-  name-sort: おとめてきこいかくめい★らぶれぼ!!
+  name-sort: おとめてきこいかくめい らぶれぼ!!
   name-en: "Otometeki Koi Kakumei Rabu Rebo!!"
   region: "NTSC-J"
 SLPM-66239:
@@ -42317,8 +42417,8 @@ SLPM-66242:
   compat: 5
 SLPM-66243:
   name: ギャラクシーエンジェルII 〜絶対領域の扉〜 通常版
-  name-sort: ぎゃらくしーえんじぇるII 〜ぜったいりょういきのとびら〜 つうじょうばん
-  name-en: "Galaxy Angel II"
+  name-sort: ぎゃらくしーえんじぇるII ぜったいりょういきのとびら [つうじょうばん]
+  name-en: "Galaxy Angel II [Standard Edition]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 1 # Reduces misaligned lighting and other effects.
@@ -42342,12 +42442,12 @@ SLPM-66246:
     minimumBlendingLevel: 3 # Fixes broken effect rendering.
 SLPM-66247:
   name: マイネリーベII 〜誇りと正義と愛〜
-  name-sort: まいねりーべII 〜ほこりとせいぎとあい〜
+  name-sort: まいねりーべII ほこりとせいぎとあい
   name-en: "Meine Liebe II - Hokori to Seigi to Ai"
   region: "NTSC-J"
 SLPM-66248:
   name: Mr.インクレディブル 〜強敵アンダーマイナー登場〜
-  name-sort: Mr.いんくれでぃぶる 〜きょうてきあんだーまいなーとうじょう〜
+  name-sort: みすたーいんくれでぃぶる きょうてきあんだーまいなーとうじょう
   name-en: "Mr. Incredible - Kyouteki Underminer Toujou"
   region: "NTSC-J"
   gsHWFixes:
@@ -42358,14 +42458,14 @@ SLPM-66248:
 SLPM-66249:
   name: グローランサーV ジェネレーションズ 初回限定生産版
   name-sort: ぐろーらんさーV じぇねれーしょんず しょかいげんていせいさんばん
-  name-en: "Growlanser V - Generations [Limited Edition]"
+  name-en: "Growlanser V - Generations [First Print Limited Edition]"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
     moveHandler: "MV_Growlanser" # Fixes precomputed depth buffer.
 SLPM-66250:
   name: アトラスベストコレクション　チョロＱＨＧ4
-  name-sort: あとらすべすとこれくしょん　ちょろＱＨＧ4
+  name-sort: あとらすべすとこれくしょん ちょろQHG4
   name-en: "Choro Q HG 4 [Takara Best]"
   region: "NTSC-J"
 SLPM-66251:
@@ -42381,12 +42481,12 @@ SLPM-66252:
 SLPM-66253:
   name: ふぁいなりすと 初回限定版
   name-sort: ふぁいなりすと しょかいげんていばん
-  name-en: "Finalist [Limited First Edition]"
+  name-en: "Finalist [First Print Limited Edition]"
   region: "NTSC-J"
 SLPM-66254:
   name: ふぁいなりすと 通常版
-  name-sort: ふぁいなりすと つうじょうばん
-  name-en: "Finalist"
+  name-sort: ふぁいなりすと [つうじょうばん]
+  name-en: "Finalist [Standard Edition]"
   region: "NTSC-J"
 SLPM-66255:
   name: ワールドサッカーウイニングイレブン 9 ボーナスパック
@@ -42410,23 +42510,23 @@ SLPM-66257:
   gameFixes:
     - SoftwareRendererFMVHack # Fixes upscale lines in FMVs.
 SLPM-66258:
-  name: 魔法先生ネギま! 1時間目 お子ちゃま先生は魔法使い! [コナミザベスト]
-  name-sort: まほうせんせいねぎま! 1じかんめ おこちゃませんせいはまほうつかい! [こなみざ・べすと]
+  name: 魔法先生ネギま! 1時間目 お子ちゃま先生は魔法使い! [コナミ・ザ・ベスト]
+  name-sort: まほうせんせいねぎま! 1じかんめ おこちゃませんせいはまほうつかい! [こなみ・ざ・べすと]
   name-en: "Magic Teacher Negima - Honor Version [Konami The Best]"
   region: "NTSC-J"
 SLPM-66259:
   name: 魔法先生ネギま! 2時間目 戦う乙女たち!麻帆良大運動会SP! コナミ・ザ・ベスト
-  name-sort: まほうせんせいねぎま! 2じかんめ たたかうおとめたち!まほらだいうんどうかいSP! こなみ・ざ・べすと
+  name-sort: まほうせんせいねぎま! 2じかんめ たたかうおとめたち!まほらだいうんどうかいSP! [こなみ・ざ・べすと]
   name-en: "Mahou Sensei Negima! Silver Medal [Konami The Best]"
   region: "NTSC-J"
 SLPM-66260:
-  name: リモートコントロールダンディSF [コナミザベスト]
-  name-sort: りもーとこんとろーるだんでぃSF [こなみざ・べすと]
+  name: リモートコントロールダンディSF [コナミ・ザ・ベスト]
+  name-sort: りもーとこんとろーるだんでぃSF [こなみ・ざ・べすと]
   name-en: "Remote Control Dandy SF [Konami the Best]"
   region: "NTSC-J"
 SLPM-66261:
-  name: OZ -オズ- [コナミザベスト]
-  name-sort: OZ -おず- [こなみざ・べすと]
+  name: OZ -オズ- [コナミ・ザ・ベスト]
+  name-sort: おず [こなみ・ざ・べすと]
   name-en: "Oz [Konami The Best]"
   region: "NTSC-J"
   gsHWFixes:
@@ -42434,7 +42534,7 @@ SLPM-66261:
     autoFlush: 2 # Fixes misaligned bloom on sun.
 SLPM-66262:
   name: トム・クランシーシリーズ レインボーシックス3 [ユービーアイソフトベスト]
-  name-sort: とむ・くらんしーしりーず れいんぼーしっくす3 [ゆーびーあいそふとべすと]
+  name-sort: とむくらんしーしりーず れいんぼーしっくす3 [ゆーびーあいそふとべすと]
   name-en: "Tom Clancy's Rainbow Six 3 [Ubisoft The Best]"
   region: "NTSC-J"
 SLPM-66263:
@@ -42452,7 +42552,7 @@ SLPM-66264:
 SLPM-66265:
   name: Canvas2 〜虹色のスケッチ〜 [通常版]
   name-sort: Canvas2 〜にじいろのすけっち〜 [つうじょうばん]
-  name-en: "Canvas 2 - Nijiiro no Sketch"
+  name-en: "Canvas 2 - Nijiiro no Sketch [Standard Edition]"
   region: "NTSC-J"
 SLPM-66266:
   name: 鋼鉄の咆哮2 ウォーシップコマンダー [KOEI The Best]
@@ -42471,17 +42571,17 @@ SLPM-66268:
   region: "NTSC-J"
 SLPM-66269:
   name: ブレイジング ソウルズ 限定版
-  name-sort: ぶれいじんぐ そうるず げんていばん
+  name-sort: ぶれいじんぐ そうるず [げんていばん]
   name-en: "Blazing Souls [Limited Edition]"
   region: "NTSC-J"
 SLPM-66270:
   name: ブレイジング ソウルズ 通常版
-  name-sort: ぶれいじんぐ そうるず つうじょうばん
-  name-en: "Blazing Souls"
+  name-sort: ぶれいじんぐ そうるず [つうじょうばん]
+  name-en: "Blazing Souls [Standard Edition]"
   region: "NTSC-J"
 SLPM-66271:
   name: ダージュ・オブ・ケルベロス -ファイナルファンタジーVII-
-  name-sort: だーじゅ・おぶ・けるべろす -ふぁいなるふぁんたじーVII-
+  name-sort: だーじゅ おぶ けるべろす ふぁいなるふぁんたじー7
   name-en: "Dirge of Cerberus - Final Fantasy VII"
   region: "NTSC-J"
   compat: 5
@@ -42491,7 +42591,7 @@ SLPM-66271:
     trilinearFiltering: 1
 SLPM-66272:
   name: I/O
-  name-sort: I/O
+  name-sort: あいおー
   name-en: "I-O"
   region: "NTSC-J"
 SLPM-66273:
@@ -42524,7 +42624,7 @@ SLPM-66276:
     - "SLPM-66275"
 SLPM-66277:
   name: Juiced〜チューンドカー伝説〜
-  name-sort: Juiced〜ちゅーんどかーでんせつ〜
+  name-sort: Juiced ちゅーんどかーでんせつ
   name-en: "Juiced"
   region: "NTSC-J"
   speedHacks:
@@ -42538,17 +42638,17 @@ SLPM-66277:
     minimumBlendingLevel: 3
 SLPM-66278:
   name: 新・豪血寺一族 -煩悩解放-
-  name-sort: しん・ごうちてらいちぞく -ぼんのうかいほう-
+  name-sort: しん ごうけつじいちぞく ぼんのうかいほう
   name-en: "Shin Gouketuji Ichizoku - Bonnou Kaihou"
   region: "NTSC-J"
 SLPM-66279:
   name: 信長の野望・革新
-  name-sort: のぶながのやぼう・かくしん
+  name-sort: のぶながのやぼう かくしん
   name-en: "Nobunaga no Yabou - Kakushin"
   region: "NTSC-J"
 SLPM-66280:
   name: モンスターハンター2（dos）
-  name-sort: もんすたーはんたー2（dos）
+  name-sort: もんすたーはんたー2 # 2 is pronounced "dos", but keep it for correct sorting
   name-en: "Monster Hunter 2"
   region: "NTSC-J"
   compat: 5
@@ -42585,16 +42685,16 @@ SLPM-66284:
 SLPM-66285:
   name: プリンセスコンチェルト [通常版]
   name-sort: ぷりんせすこんちぇると [つうじょうばん]
-  name-en: "Princess Concerto"
+  name-en: "Princess Concerto [Standard Edition]"
   region: "NTSC-J"
 SLPM-66286:
   name: 幻想水滸伝V
   name-sort: げんそうすいこでんV
-  name-en: "Genso Suikoden V"
+  name-en: "Gensou Suikoden V"
   region: "NTSC-J"
 SLPM-66287:
   name: 戦国BASARA カプコレ
-  name-sort: せんごくBASARA かぷこれ
+  name-sort: せんごくばさら かぷこれ
   name-en: "Sengoku Basara"
   region: "NTSC-J"
 SLPM-66288:
@@ -42609,12 +42709,12 @@ SLPM-66289:
   region: "NTSC-J"
 SLPM-66290:
   name: Broccoli Best Quality ギャラクシーエンジェル
-  name-sort: Broccoli Best Quality ぎゃらくしーえんじぇる
+  name-sort: ぎゃらくしーえんじぇる [Broccoli Best Quality]
   name-en: "Galaxy Angel [The Best]"
   region: "NTSC-J"
 SLPM-66291:
   name: 天下人
-  name-sort: てんかじん
+  name-sort: てんかびと
   name-en: "Tenka-bito"
   region: "NTSC-J"
 SLPM-66292:
@@ -42624,7 +42724,7 @@ SLPM-66292:
   region: "NTSC-J"
 SLPM-66293:
   name: 学園アリス 〜きらきら★メモリーキッス〜
-  name-sort: がくえんありす 〜きらきら★めもりーきっす〜
+  name-sort: がくえんありす きらきらめもりーきっす
   name-en: "Gakuen Alice - KiraKira Memory Kiss"
   region: "NTSC-J"
   gsHWFixes:
@@ -42636,7 +42736,7 @@ SLPM-66294:
   region: "NTSC-J"
 SLPM-66295:
   name: 闇夜にささやく 〜探偵 相楽恭一郎〜 限定版
-  name-sort: やみよにささやく 〜たんてい さがらきょういちろう〜 げんていばん
+  name-sort: やみよにささやく 〜たんてい さがらきょういちろう〜 [げんていばん]
   name-en: "Yamiyo ni Sasayaku - Tantei Sagara Kyouichirou [Limited Edition]"
   region: "NTSC-J"
   patches:
@@ -42648,8 +42748,8 @@ SLPM-66295:
         patch=1,EE,00156888,word,10000003
 SLPM-66296:
   name: 闇夜にささやく 〜探偵 相楽恭一郎〜 通常版
-  name-sort: やみよにささやく 〜たんてい さがらきょういちろう〜 つうじょうばん
-  name-en: "Yamiyo ni Sasayaku - Tantei Sagara Kyouichirou"
+  name-sort: やみよにささやく 〜たんてい さがらきょういちろう〜 [つうじょうばん]
+  name-en: "Yamiyo ni Sasayaku - Tantei Sagara Kyouichirou [Standard Edition]"
   region: "NTSC-J"
   patches:
     23A9A026:
@@ -42660,17 +42760,17 @@ SLPM-66296:
         patch=1,EE,00156888,word,10000003
 SLPM-66297:
   name: セパレイトハーツ 限定版
-  name-sort: せぱれいとはーつ げんていばん
+  name-sort: せぱれいとはーつ [げんていばん]
   name-en: "Separate Hearts [Limited Edition]"
   region: "NTSC-J"
 SLPM-66298:
   name: セパレイトハーツ 通常版
-  name-sort: せぱれいとはーつ つうじょうばん
-  name-en: "Separate Hearts"
+  name-sort: せぱれいとはーつ [つうじょうばん]
+  name-en: "Separate Hearts [Standard Edition]"
   region: "NTSC-J"
 SLPM-66299:
   name: 零式艦上戦闘記 弐
-  name-sort: れいしきかんじょうせんとうき 弐
+  name-sort: れいしきかんじょうせんとうき2
   name-en: "Reishiki Kanjou Sentouki 2"
   region: "NTSC-J"
 SLPM-66300:
@@ -42686,7 +42786,7 @@ SLPM-66301:
   compat: 5
 SLPM-66302:
   name: CLANNAD
-  name-sort: CLANNAD
+  name-sort: くらなど
   name-en: "Clannad"
   region: "NTSC-J"
   gsHWFixes:
@@ -42726,8 +42826,8 @@ SLPM-66307:
     - "SLPM-74249"
 SLPM-66308:
   name: 遙かなる時空の中で　プレミアムBOXコンプリート
-  name-sort: はるかなるときのなかで　ぷれみあむBOXこんぷりーと
-  name-en: "Harukanaru Toki no Naka Premium Boxset"
+  name-sort: はるかなるときのなかで [ぷれみあむBOXこんぷりーと]
+  name-en: "Harukanaru Toki no Naka de Premium Boxset"
   region: "NTSC-J"
 SLPM-66312:
   name: "Saishuu Heiki Kanojo [Konami the Best]"
@@ -42746,7 +42846,7 @@ SLPM-66314:
   compat: 5
 SLPM-66315:
   name: Broccoli Best Quality 新世紀エヴァンゲリオン 鋼鉄のガールフレンド2nd
-  name-sort: Broccoli Best Quality しんせいきえゔぁんげりおん こうてつのがーるふれんど2nd
+  name-sort: しんせいきえゔぁんげりおん こうてつのがーるふれんど2nd [Broccoli Best Quality]
   name-en: "Shinseiki Evangelion - Koutetsu no Girlfriend 2nd [Broccoli Best Quality]"
   region: "NTSC-J"
 SLPM-66316:
@@ -42767,23 +42867,23 @@ SLPM-66317:
   region: "NTSC-J"
 SLPM-66318:
   name: はるのあしおと -Step of Spring-
-  name-sort: はるのあしおと -Step of Spring-
+  name-sort: はるのあしおと Step of Spring
   name-en: "Haru no Ashioto - Step of Spring"
   region: "NTSC-J"
 SLPM-66319:
   name: 新コンバットチョロQ アトラス・ベストコレクション
-  name-sort: しんこんばっとちょろQ あとらす・べすとこれくしょん
+  name-sort: しんこんばっとちょろQ [あとらす べすとこれくしょん]
   name-en: "New Choro Q [Atlus Best Collection]"
   region: "NTSC-J"
 SLPM-66320:
   name: ファイナルファンタジーXII
-  name-sort: ふぁいなるふぁんたじーXII
+  name-sort: ふぁいなるふぁんたじー12
   name-en: "Final Fantasy XII"
   region: "NTSC-J"
   compat: 5
 SLPM-66321:
   name: ウォーシップガンナー2 〜鋼鉄の咆哮〜
-  name-sort: うぉーしっぷがんなー2 〜くろがねのほうこう〜
+  name-sort: うぉーしっぷがんなー2 くろがねのほうこう
   name-en: "Kurogane no Houkou - Warship Gunner 2"
   region: "NTSC-J"
 SLPM-66322:
@@ -42795,9 +42895,9 @@ SLPM-66322:
     textureInsideRT: 1 # Required for complex offset shuffles.
     recommendedBlendingLevel: 4 # Fixes lighting.
 SLPM-66323:
-  name: ふぁいなる・あぷろーち [プリンセスソフトコレクション]
-  name-sort: ふぁいなる・あぷろーち [ぷりんせすそふとこれくしょん]
-  name-en: "Princess Software Collection, The"
+  name: φなる・あぷろーち [プリンセスソフトコレクション]
+  name-sort: ふぁいなる あぷろーち [ぷりんせすそふとこれくしょん]
+  name-en: "Final Approach [Princess Software Collection]"
   region: "NTSC-J"
 SLPM-66324:
   name: ワールドフットボール クライマックス 日本代表パッケージ
@@ -42809,7 +42909,7 @@ SLPM-66324:
     - "SLPM-66316"
     - "SLPM-66442"
 SLPM-66325:
-  name: キャッスルヴァニア [コナミ殿堂セレクション]
+  name: キャッスルヴァニア(コナミ殿堂セレクション)
   name-sort: きゃっするゔぁにあ [こなみでんどうせれくしょん]
   name-en: "Castlevania [Konami Palace Selection]"
   region: "NTSC-J"
@@ -42839,7 +42939,7 @@ SLPM-66328:
     trilinearFiltering: 1
 SLPM-66329:
   name: 魔法先生ネギま! 課外授業 乙女のドキドキ・ビーチサイド
-  name-sort: まほうせんせいねぎま! かがいじゅぎょう おとめのどきどき・びーちさいど
+  name-sort: まほうせんせいねぎま! かがいじゅぎょう おとめのどきどき びーちさいど
   name-en: "Mahou Sensei Negima! Kagai Jugyou"
   region: "NTSC-J"
   compat: 5
@@ -42847,18 +42947,18 @@ SLPM-66329:
     - XGKickHack # Fixes rendering problems.
 SLPM-66330:
   name: ときめきメモリアル Girl’s Side 2nd Kiss 初回生産版
-  name-sort: ときめきめもりある Girl’s Side 2nd Kiss しょかいせいさんばん
+  name-sort: ときめきめもりある がーるずさいど 2nd Kiss [しょかいせいさんばん]
   name-en: "Tokimeki Memorial - Girl's Side - 2nd Kiss"
   region: "NTSC-J"
 SLPM-66331:
-  name: 高円寺女子サッカー  1st stage限定版
-  name-sort: こうえんじじょしさっかー  1st stageげんていばん
+  name: 高円寺女子サッカー 1st stage限定版
+  name-sort: こうえんじじょしさっかー [1st stageげんていばん]
   name-en: "Kouenji Onago Soccer [1st Stage Limited Edition]"
   region: "NTSC-J"
 SLPM-66332:
   name: 高円寺女子サッカー 通常版
-  name-sort: こうえんじじょしさっかー つうじょうばん
-  name-en: "Kouenji Onago Soccer"
+  name-sort: こうえんじじょしさっかー [つうじょうばん]
+  name-en: "Kouenji Onago Soccer [Standard Edition]"
   region: "NTSC-J"
 SLPM-66333:
   name: GUILTY GEAR XX SLASH (ギルティギア イグゼクス スラッシュ)
@@ -42867,7 +42967,7 @@ SLPM-66333:
   region: "NTSC-J"
   compat: 5
 SLPM-66334:
-  name: WRC4 [Spike the Best]
+  name: Spike the Best WRC4
   name-sort: WRC4 [Spike the Best]
   name-en: "WRC 4 [Spike the Best]"
   region: "NTSC-J"
@@ -42894,22 +42994,22 @@ SLPM-66335:
   region: "NTSC-J"
 SLPM-66336:
   name: 新世紀エヴァンゲリオン 鋼鉄のガールフレンド<特別編>
-  name-sort: しんせいきえゔぁんげりおん こうてつのがーるふれんど<とくべつへん>
+  name-sort: しんせいきえゔぁんげりおん こうてつのがーるふれんど [とくべつへん]
   name-en: "Shinseiki Evangelion - Koutetsu no Girlfriend [Special Edition]"
   region: "NTSC-J"
 SLPM-66337:
   name: イブ〜ニュージェネレーション〜 DXパック
-  name-sort: いぶ〜にゅーじぇねれーしょん〜 DXぱっく
+  name-sort: いぶ にゅーじぇねれーしょん DXぱっく
   name-en: "EVE New Generation [Deluxe Pack]"
   region: "NTSC-J"
 SLPM-66338:
   name: イブ〜ニュージェネレーション〜
-  name-sort: いぶ〜にゅーじぇねれーしょん〜
+  name-sort: いぶ にゅーじぇねれーしょん
   name-en: "EVE New Generation"
   region: "NTSC-J"
 SLPM-66339:
   name: ネオ アンジェリーク プレミアムBOX
-  name-sort: ねお あんじぇりーく ぷれみあむBOX
+  name-sort: ねお あんじぇりーく [ぷれみあむBOX]
   name-en: "Neo Angelique [Premium Box]"
   region: "NTSC-J"
 SLPM-66340:
@@ -42919,17 +43019,17 @@ SLPM-66340:
   region: "NTSC-J"
 SLPM-66341:
   name: 雀・三國無双
-  name-sort: じゃん・さんごくむそう
+  name-sort: じゃんさんごくむそう
   name-en: "Jan Sangoku Musou"
   region: "NTSC-J"
 SLPM-66342:
   name: WinningPost7 MAXIMUM 2006
-  name-sort: WinningPost7 MAXIMUM 2006
+  name-sort: ういにんぐぽすと7 MAXIMUM 2006
   name-en: "Winning Post 7 Maximum 2006"
   region: "NTSC-J"
 SLPM-66343:
   name: 真・三國無双4 Empires
-  name-sort: しん・さんごくむそう4 Empires
+  name-sort: しんさんごくむそう4 えんぱいあーず
   name-en: "Shin Sangoku Musou 4 - Empires"
   region: "NTSC-J"
 SLPM-66344:
@@ -42943,13 +43043,13 @@ SLPM-66346:
   region: "NTSC-J"
 SLPM-66347:
   name: 遙かなる時空の中で3 運命の迷宮 プレミアムBOX
-  name-sort: はるかなるときのなかで3 うんめいのめいきゅう ぷれみあむBOX
-  name-en: "Harukanaru Jikuu no Kade 3 - Unmei no Meikyuu [Premium Box]"
+  name-sort: はるかなるときのなかで3 うんめいのめいきゅう [ぷれみあむBOX]
+  name-en: "Harukanaru Toki no Naka de 3 - Unmei no Meikyuu [Premium Box]"
   region: "NTSC-J"
 SLPM-66348:
   name: 遙かなる時空の中で3 運命の迷宮
   name-sort: はるかなるときのなかで3 うんめいのめいきゅう
-  name-en: "Harukanaru Jikuu no Kade 3 - Unmei no Meikyuu"
+  name-en: "Harukanaru Toki no Naka de 3 - Unmei no Meikyuu"
   region: "NTSC-J"
 SLPM-66349:
   name: スペクトラルフォース クロニクル [IFコレクション]
@@ -42961,18 +43061,18 @@ SLPM-66350:
   region: "NTSC-J"
 SLPM-66351:
   name: そしてこの宇宙にきらめく君の詩
-  name-sort: そしてこのうちゅうにきらめくきみのし
-  name-en: "Soshite Kono Uchuu ni Kirameku Kimi no Shi"
+  name-sort: そしてこのうちゅうにきらめくきみのうた
+  name-en: "Soshite Kono Uchuu ni Kirameku Kimi no Uta"
   region: "NTSC-J"
 SLPM-66352:
   name: Memories Off〜それから〜Again 限定版
-  name-sort: Memories Off〜それから〜Again げんていばん
+  name-sort: Memories Off〜それから〜Again [げんていばん]
   name-en: "Memories Off - Sorekara Again [Limited Edition]"
   region: "NTSC-J"
 SLPM-66353:
   name: Memories Off〜それから〜Again 通常版
-  name-sort: Memories Off〜それから〜Again つうじょうばん
-  name-en: "Memories Off - Sorekara Again"
+  name-sort: Memories Off〜それから〜Again [つうじょうばん]
+  name-en: "Memories Off - Sorekara Again [Standard Edition]"
   region: "NTSC-J"
 SLPM-66354:
   name: BLACK
@@ -43017,7 +43117,7 @@ SLPM-66358:
     eeClampMode: 3 # Fixes crash after main menu.
 SLPM-66359:
   name: 六ツ星きらり〜ほしふるみやこ〜
-  name-sort: むっつぼしきらり〜ほしふるみやこ〜
+  name-sort: むつぼしきらり ほしふるみやこ
   name-en: "Mutsu-boshi Kirari - Hoshifuru Miyako"
   region: "NTSC-J"
 SLPM-66360:
@@ -43048,19 +43148,19 @@ SLPM-66369:
   region: "NTSC-J"
 SLPM-66371:
   name: Train Simulator+電車でGO!東京急行編ベスト
-  name-sort: Train Simulator+でんしゃでGO!とうきょうきゅうこうへんべすと
+  name-sort: Train Simulator+でんしゃでごーとうきょうきゅうこうへんべすと
   name-en: "Train Simulator & Densha de Go! Tokyo Kyuukouhen [Ongakukan Pocket Books]"
   region: "NTSC-J"
 SLPM-66372:
   name: DIGITAL DEVIL SAGA 〜アバタール・チューナー〜 [ATLUS BEST COLLECTION]
-  name-sort: DIGITAL DEVIL SAGA 〜あばたーる・ちゅーなー〜 [ATLUS BEST COLLECTION]
+  name-sort: でじたるでびるさーが あばたーるちゅーなー2 [ATLUS BEST COLLECTION]
   name-en: "Digital Devil Saga - Avatar Tuner [Atlus Best Collection]"
   region: "NTSC-J"
   gameFixes:
     - EETimingHack
 SLPM-66373:
   name: DIGITAL DEVIL SAGA 〜アバタール・チューナー2〜 [ATLUS BEST COLLECTION]
-  name-sort: DIGITAL DEVIL SAGA 〜あばたーる・ちゅーなー2〜 [ATLUS BEST COLLECTION]
+  name-sort: でじたるでびるさーが あばたーるちゅーなー2 [ATLUS BEST COLLECTION]
   name-en: "Digital Devil Saga - Avatar Tuner 2 [Atlus Best Collection]"
   region: "NTSC-J"
   gameFixes:
@@ -43080,21 +43180,21 @@ SLPM-66374:
   compat: 5
 SLPM-66375:
   name: 大神
-  name-sort: おおがみ
-  name-en: "Ookami"
+  name-sort: おおかみ
+  name-en: "Okami"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
     roundSprite: 2 # Reduces misalignment issues but the game is just bad for upscaling.
 SLPM-66376:
   name: きみスタ〜きみとスタディ〜BGMコレクションパッケージ
-  name-sort: きみすた〜きみとすたでぃ〜BGMこれくしょんぱっけーじ
-  name-en: "KimiStar - Kimi to Study [BGM Collection Package]"
+  name-sort: きみすた きみとすたでぃ BGMこれくしょんぱっけーじ
+  name-en: "KimiStu - Kimi to Study [BGM Collection Package]"
   region: "NTSC-J"
 SLPM-66377:
   name: きみスタ〜きみとスタディ〜 通常パッケージ
-  name-sort: きみすた〜きみとすたでぃ〜 つうじょうぱっけーじ
-  name-en: "KimiStar - Kimi to Study"
+  name-sort: きみすた きみとすたでぃ つうじょうぱっけーじ
+  name-en: "KimiStu - Kimi to Study"
   region: "NTSC-J"
 SLPM-66378:
   name: ガーフィールド アーリーンを救え!
@@ -43108,13 +43208,13 @@ SLPM-66379:
   region: "NTSC-J"
 SLPM-66380:
   name: 蜜×蜜ドロップス LOVE×LOVE HONEY LIFE [限定版]
-  name-sort: みつ×みつどろっぷす LOVE×LOVE HONEY LIFE [げんていばん]
+  name-sort: みつみつどろっぷす LOVE×LOVE HONEY LIFE [げんていばん]
   name-en: "Mitsu x Mitsu Drops - Love x Love Honey Life [Limited Edition]"
   region: "NTSC-J"
 SLPM-66381:
   name: 蜜×蜜ドロップス LOVE×LOVE HONEY LIFE [通常版]
-  name-sort: みつ×みつどろっぷす LOVE×LOVE HONEY LIFE [つうじょうばん]
-  name-en: "Mitsu x Mitsu Drops - Love x Love Honey Life"
+  name-sort: みつみつどろっぷす LOVE×LOVE HONEY LIFE [つうじょうばん]
+  name-en: "Mitsu x Mitsu Drops - Love x Love Honey Life [Standard Edition]"
   region: "NTSC-J"
   patches:
     A37C886C:
@@ -43125,7 +43225,7 @@ SLPM-66381:
         patch=1,EE,00157318,word,10000003
 SLPM-66382:
   name: アスミック得だねシリーズ 転生學園幻蒼録
-  name-sort: あすみっくとくだねしりーず てんしょうがくえんげんそうろく
+  name-sort: てんしょうがくえんげんそうろく [あすみっくとくだねしりーず]
   name-en: "Tenshou Gakuen Gensouroku [Tokudane Price]"
   region: "NTSC-J"
 SLPM-66383:
@@ -43152,23 +43252,23 @@ SLPM-66386:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
 SLPM-66387:
-  name: 真・爆走デコトラ伝説 〜天下統一頂上決戦〜 [Spike The Best]
-  name-sort: しん・ばくそうでことらでんせつ 〜てんかとういつちょうじょうけっせん〜 [Spike The Best]
+  name: Spike the Best 真・爆走デコトラ伝説 〜天下統一頂上決戦〜
+  name-sort: しん・ばくそうでことらでんせつてんかとういつちょうじょうけっせん [Spike The Best]
   name-en: "Shin Bakusou Dekotora Densetsu [Spike the Best]"
   region: "NTSC-J"
 SLPM-66388:
-  name: ファイプロ・リターンズ [Spike The Best]
-  name-sort: ふぁいぷろ・りたーんず [Spike The Best]
+  name: Spike the Best ファイプロ・リターンズ
+  name-sort: ふぁいぷろ りたーんず [Spike The Best]
   name-en: "Fire Pro Wrestling Returns [Spike The Best]"
   region: "NTSC-J"
 SLPM-66390:
   name: 薔薇ノ木ニ薔薇ノ花咲ク -Das Versprechen-
-  name-sort: ばらのきにばらのはなさきく -Das Versprechen-
+  name-sort: ばらのきにばらのはなさく -Das Versprechen-
   name-en: "Bara no Ki ni Bara no Hanasaku - Das Versprechen"
   region: "NTSC-J"
 SLPM-66391:
   name: プリンス・オブ・ペルシャ 二つの魂
-  name-sort: ぷりんす・おぶ・ぺるしゃ ふたつのたましい
+  name-sort: ぷりんす おぶ ぺるしゃ ふたつのたましい
   name-en: "Prince of Persia - The Two Thrones"
   region: "NTSC-J"
   gsHWFixes:
@@ -43176,12 +43276,12 @@ SLPM-66391:
     halfPixelOffset: 1 # Reduces post-processing misalignment.
 SLPM-66393:
   name: ファイナルファンタジーXI オールインワンパック2006 [プレイオンライン]
-  name-sort: ふぁいなるふぁんたじーXI おーるいんわんぱっく2006 [ぷれいおんらいん]
+  name-sort: ふぁいなるふぁんたじー11 おーるいんわんぱっく2006 [ぷれいおんらいん]
   name-en: "Final Fantasy XI - All-in-One Pack 2006"
   region: "NTSC-J"
 SLPM-66394:
   name: ファイナルファンタジーXI アトルガンの秘宝 拡張データディスク
-  name-sort: ふぁいなるふぁんたじーXI あとるがんのひほう かくちょうでーたでぃすく
+  name-sort: ふぁいなるふぁんたじー11 あとるがんのひほう かくちょうでーたでぃすく
   name-en: "Final Fantasy XI - Aht Urhgan no Hihou"
   region: "NTSC-J"
 SLPM-66395:
@@ -43202,7 +43302,7 @@ SLPM-66398:
   region: "NTSC-J"
 SLPM-66399:
   name: SAMURAI 7 限定版
-  name-sort: SAMURAI 7 げんていばん
+  name-sort: SAMURAI 7 [げんていばん]
   name-en: "Samurai 7 [Limited Edition]"
   region: "NTSC-J"
   patches:
@@ -43214,8 +43314,8 @@ SLPM-66399:
         patch=1,EE,00157F78,word,10000003
 SLPM-66400:
   name: SAMURAI 7 通常版
-  name-sort: SAMURAI 7 つうじょうばん
-  name-en: "Samurai 7"
+  name-sort: SAMURAI 7 [つうじょうばん]
+  name-en: "Samurai 7 [Standard Edition]"
   region: "NTSC-J"
   patches:
     836F4606:
@@ -43234,7 +43334,7 @@ SLPM-66401:
     alignSprite: 1 # Fixes vertical lines.
 SLPM-66402:
   name: タイトーメモリーズ 上巻 TAITO BEST
-  name-sort: たいとーめもりーず じょうかん TAITO BEST
+  name-sort: たいとーめもりーず じょうかん [TAITO BEST]
   name-en: "Taito Memories - Joukan [Taito The Best]"
   region: "NTSC-J"
   gsHWFixes:
@@ -43255,13 +43355,13 @@ SLPM-66404:
     halfPixelOffset: 2
 SLPM-66405:
   name: ラジルギ・プレシャス
-  name-sort: らじるぎ・ぷれしゃす
+  name-sort: らじるぎ ぷれしゃす
   name-en: "Radirgy Precious"
   region: "NTSC-J"
   compat: 5
 SLPM-66406:
   name: 桜華 〜心輝かせる桜〜
-  name-sort: さくらはな 〜こころかがやかせるさくら〜
+  name-sort: さくらはな こころかがやかせるさくら
   name-en: "Sakura Hana"
   region: "NTSC-J"
 SLPM-66407:
@@ -43271,8 +43371,8 @@ SLPM-66407:
   region: "NTSC-J"
 SLPM-66408:
   name: つよきす 〜Mighty Heart〜 通常版
-  name-sort: つよきす 〜Mighty Heart〜 つうじょうばん
-  name-en: "Tsuyo Kiss - Mighty Heart"
+  name-sort: つよきす 〜Mighty Heart〜 [つうじょうばん]
+  name-en: "Tsuyo Kiss - Mighty Heart [Standard Edition]"
   region: "NTSC-J"
 SLPM-66409:
   name: ストリートファイターZERO ファイターズ ジェネレーション
@@ -43302,12 +43402,12 @@ SLPM-66414:
   region: "NTSC-J"
 SLPM-66415:
   name: ミステリート 〜八十神かおるの事件ファイル〜 [初回限定版]
-  name-sort: みすてりーと 〜やそがみかおるのじけんふぁいる〜 [しょかいげんていばん]
-  name-en: "Mystereet [First Print - Limited Edition]"
+  name-sort: みすてりーと やそがみかおるのじけんふぁいる しょかいげんていばん
+  name-en: "Mystereet [First Print Limited Edition]"
   region: "NTSC-J"
 SLPM-66416:
   name: ミステリート 〜八十神かおるの事件ファイル〜
-  name-sort: みすてりーと 〜やそがみかおるのじけんふぁいる〜
+  name-sort: みすてりーと やそがみかおるのじけんふぁいる
   name-en: "Mystereet"
   region: "NTSC-J"
 SLPM-66417:
@@ -43317,15 +43417,15 @@ SLPM-66417:
   region: "NTSC-J"
 SLPM-66418:
   name: グローランサーV ジェネレーションズ 通常版
-  name-sort: ぐろーらんさーV じぇねれーしょんず つうじょうばん
-  name-en: "Growlanser V - Generations"
+  name-sort: ぐろーらんさーV じぇねれーしょんず [つうじょうばん]
+  name-en: "Growlanser V - Generations [Standard Edition]"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
     moveHandler: "MV_Growlanser" # Fixes precomputed depth buffer.
 SLPM-66419:
   name: ヴァルキリープロファイル2 -シルメリア-
-  name-sort: ゔぁるきりーぷろふぁいる2 -しるめりあ-
+  name-sort: ゔぁるきりーぷろふぁいる2 しるめりあ
   name-en: "Valkyrie Profile 2 - Silmeria"
   region: "NTSC-J"
   compat: 5
@@ -43364,7 +43464,7 @@ SLPM-66425:
   region: "NTSC-J"
 SLPM-66426:
   name: beatmania IIDX 11 IIDX RED
-  name-sort: beatmania IIDX 11 IIDX RED
+  name-sort: びーとまにあ つーでぃーえっくす 11 IIDX RED
   name-en: "Beatmania IIDX 11 IIDX RED"
   region: "NTSC-J"
 SLPM-66427:
@@ -43401,23 +43501,23 @@ SLPM-66431:
   region: "NTSC-J"
 SLPM-66432:
   name: 魂響(たまゆら)〜御霊送りの詩〜 初回限定版
-  name-sort: たまゆら〜ごたまおくりのし〜 しょかいげんていばん
-  name-en: "Tamashii Kyou [Limited Edition]"
+  name-sort: たまゆら みたまおくりのうた しょかいげんていばん
+  name-en: "Tamayura [First Print Limited Edition]"
   region: "NTSC-J"
 SLPM-66433:
   name: 魂響(たまゆら)〜御霊送りの詩〜
-  name-sort: たまゆら〜ごたまおくりのし〜
-  name-en: "Tamashii Kyou"
+  name-sort: たまゆら みたまおくりのうた
+  name-en: "Tamayura"
   region: "NTSC-J"
 SLPM-66434:
   name: Festa!!HYPER GIRLS PARTY 限定版
-  name-sort: Festa!!HYPER GIRLS PARTY げんていばん
+  name-sort: Festa!!HYPER GIRLS PARTY [げんていばん]
   name-en: "Festa!! Hyper Girls Party [Limited Edition]"
   region: "NTSC-J"
 SLPM-66435:
   name: Festa!!HYPER GIRLS PARTY 通常版
-  name-sort: Festa!!HYPER GIRLS PARTY つうじょうばん
-  name-en: "Festa!! Hyper Girls Party"
+  name-sort: Festa!!HYPER GIRLS PARTY [つうじょうばん]
+  name-en: "Festa!! Hyper Girls Party [Standard Edition]"
   region: "NTSC-J"
 SLPM-66436:
   name: イリスのアトリエ グランファンタズム
@@ -43441,14 +43541,14 @@ SLPM-66438:
   gameFixes:
     - EETimingHack # Fixes non-working game (BSOD/crash otherwise).
 SLPM-66439:
-  name: 保健室へようこそ [初回限定版]
-  name-sort: ほけんしつへようこそ [しょかいげんていばん]
-  name-en: "Hokenshitsu e Youkoso [Limited Edition]"
+  name: 保健室へようこそ (初回限定版)
+  name-sort: ほけんしつへようこそ しょかいげんていばん
+  name-en: "Hokenshitsu he Youkoso [First Print Limited Edition]"
   region: "NTSC-J"
 SLPM-66440:
-  name: 保健室へようこそ
+  name: 保健室へようこそ (通常版)
   name-sort: ほけんしつへようこそ
-  name-en: "Hokenshitsu e Youkoso"
+  name-en: "Hokenshitsu he Youkoso [Standard Edition]"
   region: "NTSC-J"
 SLPM-66441:
   name: 大奥記
@@ -43475,7 +43575,7 @@ SLPM-66443:
     eeCycleRate: 3 # Fixes corrupted graphics.
 SLPM-66444:
   name: スパルタン 〜古代ギリシャ英雄伝〜
-  name-sort: すぱるたん 〜こだいぎりしゃえいゆうでん〜
+  name-sort: すぱるたん こだいぎりしゃえいゆうでん
   name-en: "Spartan - Kodai Greece Eiyuuden"
   region: "NTSC-J"
   gameFixes:
@@ -43500,19 +43600,19 @@ SLPM-66446:
   region: "NTSC-J"
 SLPM-66447:
   name: 戦国BASARA2
-  name-sort: せんごくBASARA2
+  name-sort: せんごくばさら2
   name-en: "Sengoku Basara 2"
   region: "NTSC-J"
   compat: 5
 SLPM-66448:
   name: We Are* 限定版
-  name-sort: We Are* げんていばん
+  name-sort: We Are* [げんていばん]
   name-en: "We Are [Limited Edition]"
   region: "NTSC-J"
 SLPM-66449:
   name: We Are* 通常版
-  name-sort: We Are* つうじょうばん
-  name-en: "We Are"
+  name-sort: We Are* [つうじょうばん]
+  name-en: "We Are [Standard Edition]"
   region: "NTSC-J"
 SLPM-66450:
   name: 実況パワフルプロ野球13
@@ -43533,12 +43633,12 @@ SLPM-66451:
         patch=1,EE,0035d8b8,word,00000000
 SLPM-66452:
   name: かまいたちの夜×3 三日月島事件の真相
-  name-sort: かまいたちのよる×3 みかづきじまじけんのしんそう
+  name-sort: かまいたちのよる3 みかづきじまじけんのしんそう
   name-en: "Kamaitachi no Yoru 3"
   region: "NTSC-J"
 SLPM-66453:
   name: 緋色の欠片 限定版
-  name-sort: ひいろのかけら げんていばん
+  name-sort: ひいろのかけら [げんていばん]
   name-en: "Hiiro no Kakera [Limited Edition]"
   region: "NTSC-J"
   patches:
@@ -43560,7 +43660,7 @@ SLPM-66455:
   region: "NTSC-J"
 SLPM-66456:
   name: あそびにいくヨ! 〜ちきゅうぴんちのこんやくせんげん〜 限定版
-  name-sort: あそびにいくよ! 〜ちきゅうぴんちのこんやくせんげん〜 げんていばん
+  name-sort: あそびにいくよ! ちきゅうぴんちのこんやくせんげん [げんていばん]
   name-en: "Asobi ni Iku yo! Chikyuu Pinch no Kon'yaku Sengen [Genteiban]"
   region: "NTSC-J"
   patches:
@@ -43572,7 +43672,7 @@ SLPM-66456:
         patch=1,EE,001579D8,word,10000003
 SLPM-66457:
   name: あそびにいくヨ! 〜ちきゅうぴんちのこんやくせんげん〜
-  name-sort: あそびにいくよ! 〜ちきゅうぴんちのこんやくせんげん〜
+  name-sort: あそびにいくよ! ちきゅうぴんちのこんやくせんげん
   name-en: "Asobi ni Iku yo! Chikyuu Pinch no Kon'yaku Sengen"
   region: "NTSC-J"
   patches:
@@ -43596,12 +43696,12 @@ SLPM-66458:
         patch=1,EE,0023122c,word,00000000
 SLPM-66459:
   name: ゼロパイロット・零
-  name-sort: ぜろぱいろっと・れい
+  name-sort: ぜろぱいろっと ぜろ
   name-en: "Zero Pilot - Zero"
   region: "NTSC-J"
 SLPM-66460:
   name: _summer##
-  name-sort: _summer##
+  name-sort: あんだーばーさまー だぶるしゃーぷ
   name-en: "_summer ##"
   region: "NTSC-J"
 SLPM-66461:
@@ -43624,17 +43724,17 @@ SLPM-66462:
     mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
     trilinearFiltering: 1
 SLPM-66463:
-  name: デフジャム・ファイト・フォー・NY [EA BEST HITS]
+  name: EA BEST HITS デフジャム・ファイト・フォー・NY
   name-sort: でふじゃむ・ふぁいと・ふぉー・NY [EA BEST HITS]
   name-en: "Def Jam - Fight for NY [EA Best Hits]"
   region: "NTSC-J"
 SLPM-66464:
-  name: MVP ベースボール2005 [EA BEST HITS]
+  name: EA BEST HITS MVP ベースボール2005
   name-sort: MVP べーすぼーる2005 [EA BEST HITS]
   name-en: "MVP Baseball 2005 [EA Best Hits]"
   region: "NTSC-J"
 SLPM-66465:
-  name: マーセナリーズ [EA BEST HITS]
+  name: EA BEST HITS マーセナリーズ
   name-sort: まーせなりーず [EA BEST HITS]
   name-en: "Mercenaries - Playground of Destruction [EA Best Hits]"
   region: "NTSC-J"
@@ -43654,29 +43754,29 @@ SLPM-66468:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misaligned lighting and other effects, needs Special otherwise lights flicker.
 SLPM-66469:
-  name: 「ラブ★コン ～パンチDEコント～」限定版
-  name-sort: 「らぶ★こん ～ぱんちDEこんと～」げんていばん
+  name: 「ラブ★コン 〜パンチDEコント〜」限定版
+  name-sort: らぶこん ぱんちでこんと [げんていばん]
   name-en: "Love-Com - Punch de Court [Limited Edition]"
   region: "NTSC-J"
 SLPM-66470:
-  name: 「ラブ★コン ～パンチDEコント～」通常版
-  name-sort: 「らぶ★こん ～ぱんちDEこんと～」つうじょうばん
-  name-en: "Love-Com - Punch de Court"
+  name: 「ラブ★コン 〜パンチDEコント〜」通常版
+  name-sort: らぶこん ぱんちでこんと [つうじょうばん]
+  name-en: "Love-Com - Punch de Court [Standard Edition]"
   region: "NTSC-J"
   compat: 5
 SLPM-66471:
   name: 花帰葬
   name-sort: はなきそう
-  name-en: "Hanaki"
+  name-en: "Hanakisou"
   region: "NTSC-J"
 SLPM-66472:
   name: planetarian 〜ちいさなほしのゆめ〜
-  name-sort: planetarian 〜ちいさなほしのゆめ〜
+  name-sort: ぷらねたりあん ちいさなほしのゆめ
   name-en: "Planetarian - The Reverie of a Little Planet"
   region: "NTSC-J"
 SLPM-66473:
   name: トゥルー・クライム 〜ニューヨークシティ〜
-  name-sort: とぅるー・くらいむ 〜にゅーよーくしてぃ〜
+  name-sort: とぅるー くらいむ にゅーよーくしてぃ
   name-en: "True Crime - New York City"
   region: "NTSC-J"
   clampModes:
@@ -43739,13 +43839,13 @@ SLPM-66479:
     - "SLPM-66478"
 SLPM-66480:
   name: ドラゴンクエスト V 天空の花嫁 [アルティメットヒッツ]
-  name-sort: どらごんくえすと V てんくうのはなよめ [あるてぃめっとひっつ]
+  name-sort: どらごんくえすと5 てんくうのはなよめ [あるてぃめっとひっつ]
   name-en: "Dragon Quest V - Bride of the Sky [Ultimate Hits]"
   region: "NTSC-J"
   compat: 5
 SLPM-66481:
   name: ドラゴンクエスト VIII 空と海と大地と呪われし姫君 [アルティメットヒッツ]
-  name-sort: どらごんくえすと VIII そらとうみとだいちとのろわれしひめぎみ [あるてぃめっとひっつ]
+  name-sort: どらごんくえすと8 そらとうみとだいちとのろわれしひめぎみ [あるてぃめっとひっつ]
   name-en: "Dragon Quest VIII [Ultimate Hits]"
   region: "NTSC-J"
   gsHWFixes:
@@ -43755,7 +43855,7 @@ SLPM-66481:
     roundSprite: 1 # Fixes font artifacts.
 SLPM-66482:
   name: ときめきメモリアル Girl’s Side 2nd Kiss リピート生産版
-  name-sort: ときめきめもりある Girl’s Side 2nd Kiss りぴーとせいさんばん
+  name-sort: ときめきめもりある がーるずさいど 2nd Kiss りぴーとせいさんばん
   name-en: "Tokimeki Memorial - Girl's Side 2nd Kiss"
   region: "NTSC-J"
 SLPM-66483:
@@ -43769,7 +43869,7 @@ SLPM-66484:
   compat: 5
 SLPM-66485:
   name: ステート・オブ・エマージェンシー リベンジ
-  name-sort: すてーと・おぶ・えまーじぇんしー りべんじ
+  name-sort: すてーと おぶ えまーじぇんしー りべんじ
   name-en: "State of Emergency - Revenge"
   region: "NTSC-J"
 SLPM-66486:
@@ -43789,13 +43889,13 @@ SLPM-66488:
   region: "NTSC-J"
 SLPM-66489:
   name: マビノ×スタイル <2800コレクション>
-  name-sort: まびの×すたいる <2800これくしょん>
+  name-sort: まびのすたいる <2800これくしょん>
   name-en: "Mabino x Style [2800 Collection]"
   region: "NTSC-J"
 SLPM-66491:
   name: あやかしびと -幻妖異聞録- [通常版]
-  name-sort: あやかしびと -げんよういぶんろく- [つうじょうばん]
-  name-en: "Ayakashi-bito - Gen'you Ibunroku"
+  name-sort: あやかしびと げんよういぶんろく [つうじょうばん]
+  name-en: "Ayakashi-bito - Gen'you Ibunroku [Standard Edition]"
   region: "NTSC-J"
   gsHWFixes:
     cpuCLUTRender: 1 # Fixes rendering.
@@ -43813,7 +43913,7 @@ SLPM-66493:
   region: "NTSC-J"
 SLPM-66494:
   name: 女子高生 GAME’S-HIGH! 限定版
-  name-sort: じょしこうせい GAME’S-HIGH! げんていばん
+  name-sort: じょしこうせい GAME’S-HIGH! [げんていばん]
   name-en: "Joshikousei Game's High! [Limited Edition]"
   region: "NTSC-J"
 SLPM-66495:
@@ -43829,8 +43929,8 @@ SLPM-66495:
         // This patch skips over the stack code, allowing the game to boot.
         patch=1,EE,00149F18,word,10000003
 SLPM-66496:
-  name: トム・クランシーシリーズ スプリンターセル カオスセオリー [ユービーアイソフト ベスト]
-  name-sort: とむ・くらんしーしりーず すぷりんたーせる かおすせおりー [ゆーびーあいそふと べすと]
+  name: ユービーアイソフト ベスト トム・クランシーシリーズ スプリンターセル カオスセオリー
+  name-sort: とむくらんしーしりーず すぷりんたーせる かおすせおりー [ゆーびーあいそふと べすと]
   name-en: "Tom Clancy's Splinter Cell - Chaos Theory"
   region: "NTSC-J"
   gsHWFixes:
@@ -43882,7 +43982,7 @@ SLPM-66502:
     halfPixelOffset: 2 # Alleviates blur from upscaling.
 SLPM-66503:
   name: METAL GEAR SOLID 2 SONS OF LIBERTY MEGA HITS!
-  name-sort: METAL GEAR SOLID 2 SONS OF LIBERTY MEGA HITS!
+  name-sort: めたるぎあそりっど2 さんずおぶりばてぃ [MEGA HITS!]
   name-en: "Metal Gear Solid 2 [Mega Hits]"
   region: "NTSC-J"
   gameFixes:
@@ -43896,7 +43996,7 @@ SLPM-66504:
   region: "NTSC-J"
 SLPM-66505:
   name: 真・三國無双2 MEGA HITS!
-  name-sort: しん・さんごくむそう2 MEGA HITS!
+  name-sort: しんさんごくむそう2 MEGA HITS!
   name-en: "Shin Sangoku Musou 2 [Mega Hits]"
   region: "NTSC-J"
 SLPM-66506:
@@ -43905,14 +44005,14 @@ SLPM-66506:
   name-en: "Gundam - Federation vs. Zeon DX [Mega Hits]"
   region: "NTSC-J"
 SLPM-66507:
-  name: 乙女の事情 [初回限定版]
-  name-sort: おとめのじじょう [しょかいげんていばん]
-  name-en: "Otome no Jijou [Limited Edition]"
+  name: 乙女の事情 (初回限定版)
+  name-sort: おとめのじじょう しょかいげんていばん
+  name-en: "Otome no Jijou [First Print Limited Edition]"
   region: "NTSC-J"
 SLPM-66508:
-  name: 乙女の事情
+  name: 乙女の事情 (通常版)
   name-sort: おとめのじじょう
-  name-en: "Otome no Jijou"
+  name-en: "Otome no Jijou [Standard Edition]"
   region: "NTSC-J"
 SLPM-66509:
   name: ラグビー06
@@ -43926,22 +44026,22 @@ SLPM-66510:
   region: "NTSC-J"
 SLPM-66511:
   name: 九龍妖魔學園紀 再装填 (re:charge)
-  name-sort: くうろんようまがくえんき さいそうてん (re:charge)
+  name-sort: くうろんようまがくえんき りちゃーじ
   name-en: "Kyuuryuu Youma Gakuenki Re-charge"
   region: "NTSC-J"
   compat: 5
 SLPM-66512:
   name: Fate/stay night[Realta Nua] extra edition
-  name-sort: Fate/stay night[Realta Nua] extra edition
+  name-sort: ふぇいと すていないと れあるたぬあ extra edition
   name-en: "Fate-stay Night - Realta Nua [Extra Edition]"
   region: "NTSC-J"
 SLPM-66513:
   name: Fate/stay night[Realta Nua]
-  name-sort: Fate/stay night[Realta Nua]
+  name-sort: ふぇいと すていないと れあるたぬあ
   name-en: "Fate-stay Night - Realta Nua"
   region: "NTSC-J"
 SLPM-66514:
-  name: メダル オブ オナー ヨーロッパ強襲 [EA BEST HITS]
+  name: EA BEST HITS メダル オブ オナー ヨーロッパ強襲
   name-sort: めだる おぶ おなー よーろっぱきょうしゅう [EA BEST HITS]
   name-en: "Medal of Honor - European Assault [EA Best Hits]"
   region: "NTSC-J"
@@ -43949,14 +44049,14 @@ SLPM-66514:
     autoFlush: 1 # Fixes sun shinging through surfaces and graphical corruptions.
     halfPixelOffset: 2 # Fixes misaligned blur.
 SLPM-66515:
-  name: スター・ウォーズ エピソード3 シスの復讐 [EA BEST HITS]
-  name-sort: すたー・うぉーず えぴそーど3 しすのふくしゅう [EA BEST HITS]
+  name: EA BEST HITS スター・ウォーズ エピソード3 シスの復讐
+  name-sort: すたーうぉーず えぴそーど3 しすのふくしゅう [EA BEST HITS]
   name-en: "Star Wars - Episode III - Sith no Fukushuu [EA Best Hits]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 1 # Fixes bloom misalignment.
 SLPM-66516:
-  name: ザ・シムズ&ザ・アーブズ シムズ・イン・ザ・シティ [EA BEST HITS]
+  name: EA BEST HITS ザ・シムズ&ザ・アーブズ シムズ・イン・ザ・シティ
   name-sort: ざ・しむず&ざ・あーぶず しむず・いん・ざ・してぃ [EA BEST HITS]
   name-en: "Sims, The & The Urbz - Sims in the City [EA Best Hits]"
   region: "NTSC-J"
@@ -43987,8 +44087,8 @@ SLPM-66521:
   region: "NTSC-J"
   compat: 5
 SLPM-66522:
-  name: 真・三國無双3 [コーエー定番シリーズ]
-  name-sort: しん・さんごくむそう3 [こーえーていばんしりーず]
+  name: コーエー定番シリーズ 真・三國無双3
+  name-sort: しんさんごくむそう3 [こーえーていばんしりーず]
   name-en: "Shin Sangoku Musou 3 [KOEI Selection]"
   region: "NTSC-J"
 SLPM-66523:
@@ -44003,22 +44103,22 @@ SLPM-66524:
   region: "NTSC-J"
 SLPM-66525:
   name: Zill O’ll 〜infinite〜 [KOEI The Best]
-  name-sort: Zill O’ll 〜infinite〜 [KOEI The Best]
+  name-sort: じるおーる 〜infinite〜 [KOEI The Best]
   name-en: "Zill O'll Infinite [Koei The Best]"
   region: "NTSC-J"
 SLPM-66526:
-  name: 凱歌の号砲 エアランドフォース [コーエー定番シリーズ]
+  name: コーエー定番シリーズ 凱歌の号砲 エアランドフォース
   name-sort: がいかのごうほう えあらんどふぉーす [こーえーていばんしりーず]
   name-en: "Gaika no Gouhou - Air Land Force [KOEI Selection]"
   region: "NTSC-J"
 SLPM-66527:
-  name: 三國志戦記2 [コーエー定番シリーズ]
+  name: コーエー定番シリーズ 三國志戦記2
   name-sort: さんごくしせんき2 [こーえーていばんしりーず]
   name-en: "Sangokushi Senki 2 [KOEI Selection]"
   region: "NTSC-J"
 SLPM-66528:
   name: 信長の野望・天下創世 with パワーアップキット [KOEI The Best]
-  name-sort: のぶながのやぼう・てんかそうせい with ぱわーあっぷきっと [KOEI The Best]
+  name-sort: のぶながのやぼう てんかそうせい with ぱわーあっぷきっと [KOEI The Best]
   name-en: "Nobunaga no Yabou - Tenka Sousei [with Power Up Kit] [KOEI the Best]"
   region: "NTSC-J"
 SLPM-66529:
@@ -44028,17 +44128,17 @@ SLPM-66529:
   region: "NTSC-J"
 SLPM-66530:
   name: Gift -prism- 通常版
-  name-sort: Gift -prism- つうじょうばん
-  name-en: "Gift Prism"
+  name-sort: Gift -prism- [つうじょうばん]
+  name-en: "Gift Prism [Standard Edition]"
   region: "NTSC-J"
 SLPM-66531:
   name: 水の旋律2〜緋の記憶〜 限定版
-  name-sort: みずのせんりつ2〜ひのきおく〜 げんていばん
+  name-sort: みずのせんりつ2 ひのきおく [げんていばん]
   name-en: "Mizu no Senritsu 2 [Limited Edition]"
   region: "NTSC-J"
 SLPM-66532:
   name: 水の旋律2〜緋の記憶〜
-  name-sort: みずのせんりつ2〜ひのきおく〜
+  name-sort: みずのせんりつ2 ひのきおく
   name-en: "Mizu no Senritsu 2"
   region: "NTSC-J"
 SLPM-66533:
@@ -44048,21 +44148,21 @@ SLPM-66533:
   region: "NTSC-J"
 SLPM-66534:
   name: 龍刻 Ryu-Koku 限定版
-  name-sort: りゅうこく Ryu-Koku げんていばん
+  name-sort: りゅうこく [げんていばん]
   name-en: "Ryu Koku [Limited Edition]"
   region: "NTSC-J"
 SLPM-66535:
   name: 龍刻 Ryu-Koku 通常版
-  name-sort: りゅうこく Ryu-Koku つうじょうばん
-  name-en: "Ryu Koku"
+  name-sort: りゅうこく [つうじょうばん]
+  name-en: "Ryu Koku [Standard Edition]"
   region: "NTSC-J"
 SLPM-66536:
   name: ARIA The NATURAL 〜遠い記憶のミラージュ〜
-  name-sort: ARIA The NATURAL 〜とおいきおくのみらーじゅ〜
+  name-sort: ありあ ざ なちゅらる とおいきおくのみらーじゅ
   name-en: "Aria - The Natural - Tooi Yume no Mirage"
   region: "NTSC-J"
 SLPM-66537:
-  name: イリスのアトリエ エターナルマナ2 [ガスト ベスト プライス]
+  name: ガスト ベスト プライス イリスのアトリエ エターナルマナ2
   name-sort: いりすのあとりえ えたーなるまな2 [がすと べすと ぷらいす]
   name-en: "Iris no Atelier - Eternal Mana 2 [Gust Best Price]"
   region: "NTSC-J"
@@ -44074,7 +44174,7 @@ SLPM-66537:
 SLPM-66538:
   name: ジーワン ジョッキー4 2006
   name-sort: じーわん じょっきー4 2006
-  name-en: "GI Jockey 4 2006"
+  name-en: "G1 Jockey 4 2006"
   region: "NTSC-J"
 SLPM-66539:
   name: 信長の野望Online 破天の章
@@ -44083,23 +44183,23 @@ SLPM-66539:
   region: "NTSC-J"
 SLPM-66542:
   name: 戦国無双2 Empires
-  name-sort: せんごくむそう2 Empires
+  name-sort: せんごくむそう2 えんぱいあーず
   name-en: "Sengoku Musou 2 Empires"
   region: "NTSC-J"
 SLPM-66543:
   name: Yo-Jin-Bo 〜運命のフロイデ〜
-  name-sort: Yo-Jin-Bo 〜うんめいのふろいで〜
+  name-sort: ようじんぼう うんめいのふろいで
   name-en: "Youjinbou - Unmei no Freud"
   region: "NTSC-J"
 SLPM-66544:
   name: 世界ノ全テ 〜two of us〜
-  name-sort: せかいのぜんて 〜two of us〜
-  name-en: "Sekai no Zente - Two of Us"
+  name-sort: せかいのすべて 〜two of us〜
+  name-en: "Sekai no Subete - Two of Us"
   region: "NTSC-J"
 SLPM-66548:
   name: 遙かなる時空の中で 舞一夜 通常版
-  name-sort: はるかなるときのなかで まいひとよ つうじょうばん
-  name-en: "Harukanaru Jikuu no Uchi de Mai Ichi Yoru"
+  name-sort: はるかなるときのなかで まいひとよ [つうじょうばん]
+  name-en: "Harukanaru Toki no Naka de Maihitoyo [Standard Edition]"
   region: "NTSC-J"
 SLPM-66549:
   name: 三國志11
@@ -44135,25 +44235,25 @@ SLPM-66554:
   name-en: "Interlude [Best Version]"
   region: "NTSC-J"
 SLPM-66555:
-  name: SuperLite2000シリーズ 東京バス案内 (ガイド) 2
-  name-sort: SuperLite2000しりーず とうきょうばすあんない (がいど) 2
+  name: SuperLite2000シリーズ 東京バス案内2
+  name-sort: SuperLite2000しりーず とうきょうばすがいど2
   name-en: "SuperLite 2000 Series - Tokyo Bus Guide 2"
   region: "NTSC-J"
 SLPM-66556:
-  name: 忍道 戒 [Spike the Best]
+  name: Spike the Best 忍道 戒
   name-sort: しのびどう いましめ [Spike the Best]
   name-en: "Shinobido Imashime [Spike The Best]"
   region: "NTSC-J"
   clampModes:
     eeClampMode: 3 # Fixes hang going in to the gardens.
 SLPM-66557:
-  name: FIFAストリート [EA BEST HITS]
+  name: EA BEST HITS FIFAストリート
   name-sort: FIFAすとりーと [EA BEST HITS]
   name-en: "FIFA Street [EA Best Hits]"
   region: "NTSC-J"
 SLPM-66558:
   name: "トゥームレイダー: レジェンド"
-  name-sort: "とぅーむれいだー: れじぇんど"
+  name-sort: とぅーむれいだー:れじぇんど
   name-en: "Tomb Raider - Legend"
   region: "NTSC-J"
   gsHWFixes:
@@ -44163,7 +44263,7 @@ SLPM-66558:
     autoFlush: 1 # Fixes bloom intensity.
     minimumBlendingLevel: 4 # Fixes multiple lighting effects from lights, computers, cave walls and more.
 SLPM-66559:
-  name: Winning Post6 [コーエー定番シリーズ]
+  name: コーエー定番シリーズ Winning Post6
   name-sort: Winning Post6 [こーえーていばんしりーず]
   name-en: "Winning Post 6 [KOEI Selection]"
   region: "NTSC-J"
@@ -44173,7 +44273,7 @@ SLPM-66560:
   name-en: "Sangokushi X [KOEI The Best]"
   region: "NTSC-J"
 SLPM-66561:
-  name: NBAライブ 06 [EA BEST HITS]
+  name: EA BEST HITS NBAライブ 06
   name-sort: NBAらいぶ 06 [EA BEST HITS]
   name-en: "NBA Live '06 [EA Best Hits]"
   region: "NTSC-J"
@@ -44181,8 +44281,8 @@ SLPM-66561:
     cpuSpriteRenderBW: 2 # Fixes broken sprite rendering and crowd rendering.
     cpuSpriteRenderLevel: 2 # Needed for above.
 SLPM-66562:
-  name: ニード・フォー・スピード モスト・ウォンテッド [EA BEST HITS]
-  name-sort: にーど・ふぉー・すぴーど もすと・うぉんてっど [EA BEST HITS]
+  name: EA BEST HITS ニード・フォー・スピード モスト・ウォンテッド
+  name-sort: にーど ふぉー すぴーど もすと うぉんてっど [EA BEST HITS]
   name-en: "Need for Speed - Most Wanted [EA Best Hits]"
   region: "NTSC-J"
   gsHWFixes:
@@ -44204,13 +44304,13 @@ SLPM-66563:
   region: "NTSC-J"
 SLPM-66564:
   name: REC☆ドキドキ声優パラダイス☆ 限定版
-  name-sort: REC☆どきどきせいゆうぱらだいす☆ げんていばん
+  name-sort: REC どきどきせいゆうぱらだいす [げんていばん]
   name-en: "REC - DokiDoki Seiyuu Paradise [Limited Edition]"
   region: "NTSC-J"
 SLPM-66565:
   name: REC☆ドキドキ声優パラダイス☆ 通常版
-  name-sort: REC☆どきどきせいゆうぱらだいす☆ つうじょうばん
-  name-en: "REC - DokiDoki Seiyuu Paradise"
+  name-sort: REC どきどきせいゆうぱらだいす [つうじょうばん]
+  name-en: "REC - DokiDoki Seiyuu Paradise [Standard Edition]"
   region: "NTSC-J"
   patches:
     17E04DE7:
@@ -44237,7 +44337,7 @@ SLPM-66567:
     roundSprite: 1 # Reduces misaligned bloom.
     mergeSprite: 1 # Removes bloom explosion around electrical lights and other light sources such as moon/sun.
 SLPM-66568:
-  name: ブラザー イン アームズ ロード トゥ ヒル サーティ [ユービーアイソフト ベスト]
+  name: ユービーアイソフト ベスト ブラザー イン アームズ ロード トゥ ヒル サーティ
   name-sort: ぶらざー いん あーむず ろーど とぅ ひる さーてぃ [ゆーびーあいそふと べすと]
   name-en: "Brothers In Arms - Road to Hill 30 [Ubisoft Best]"
   region: "NTSC-J"
@@ -44245,8 +44345,8 @@ SLPM-66568:
     halfPixelOffset: 2 # Reduces blurriness, there are still ghosting issues for like lighting poles.
 SLPM-66569:
   name: シークレット・オブ・エヴァンゲリオン 通常版
-  name-sort: しーくれっと・おぶ・えゔぁんげりおん つうじょうばん
-  name-en: "Secret of Evangelion"
+  name-sort: しーくれっと おぶ えゔぁんげりおん [つうじょうばん]
+  name-en: "Secret of Evangelion [Standard Edition]"
   region: "NTSC-J"
   gsHWFixes:
     roundSprite: 2 # Reduces artifacts like vertical lines in main menu but there are many other artifacts still.
@@ -44262,7 +44362,7 @@ SLPM-66571:
   region: "NTSC-J"
 SLPM-66572:
   name: レゴ スター・ウォーズII
-  name-sort: れご すたー・うぉーずII
+  name-sort: れご すたーうぉーずII
   name-en: "LEGO Star Wars II - The Original Trilogy"
   region: "NTSC-J"
   gsHWFixes:
@@ -44273,7 +44373,7 @@ SLPM-66572:
     - "SLPM-66572"
     - "SLPS-20423"
 SLPM-66573:
-  name: 鋼鉄の咆哮2ウォーシップガンナー [コーエー定番シリーズ]
+  name: コーエー定番シリーズ 鋼鉄の咆哮2ウォーシップガンナー
   name-sort: くろがねのほうこう2うぉーしっぷがんなー [こーえーていばんしりーず]
   name-en: "Kurogane no Houkou 2 - Warship Gunner [KOEI Selection]"
   region: "NTSC-J"
@@ -44289,13 +44389,13 @@ SLPM-66575:
   region: "NTSC-J"
 SLPM-66576:
   name: 聖剣伝説4
-  name-sort: きよしけんでんせつ4
+  name-sort: せいけんでんせつ4
   name-en: "Seiken Densetsu 4"
   region: "NTSC-J"
   compat: 5
 SLPM-66577:
   name: GLADIATOR ROAD TO FREEDOM REMIX アーティン ベスト
-  name-sort: GLADIATOR ROAD TO FREEDOM REMIX あーてぃん べすと
+  name-sort: GLADIATOR ROAD TO FREEDOM REMIX [あーてぃん べすと]
   name-en: "Gladiator - Road to Freedom [Special Remix] [Ertain the Best]"
   region: "NTSC-J"
   gsHWFixes:
@@ -44303,20 +44403,26 @@ SLPM-66577:
     roundSprite: 1 # Fixes bloom misalignment still a bit misaligned.
     cpuCLUTRender: 1 # Fixes sun background on the windows when selecting your 'race'.
 SLPM-66578:
-  name: "Shin Sangoku Musou 3 - Empires"
+  name: "真・三國無双3 Empires(真・三國無双シリーズコレクション 下巻 同梱用)"
+  name-sort: しんさんごくむそう3 えんぱいあーず [しんさんごくむそうしりーずこれくしょん げかん どうこんよう]
+  name-en: "Shin Sangoku Musou 3 - Empires"
   region: "NTSC-J"
 SLPM-66579:
   name: "Shin Sangoku Musou 4"
   region: "NTSC-J"
 SLPM-66580:
-  name: "Shin Sangoku Musou 4 - Moushouden"
+  name: "真・三國無双4 猛将伝(真・三國無双シリーズコレクション 下巻 同梱用)"
+  name-sort: しんさんごくむそう4 もうしょうでん [しんさんごくむそうしりーずこれくしょん げかん どうこんよう]
+  name-en: "Shin Sangoku Musou 4 - Moushouden"
   region: "NTSC-J"
 SLPM-66581:
-  name: "Shin Sangoku Musou 4 - Empires"
+  name: "真・三國無双4 Empires(真・三國無双シリーズコレクション 下巻 同梱用)"
+  name-sort: しんさんごくむそう4 えんぱいあーず [しんさんごくむそうしりーずこれくしょん げかん どうこんよう]
+  name-en: "Shin Sangoku Musou 4 - Empires"
   region: "NTSC-J"
 SLPM-66582:
   name: 仔羊捕獲ケーカク! スイートボーイズライフ 初回限定版
-  name-sort: 仔羊ほかくけーかく! すいーとぼーいずらいふ しょかいげんていばん
+  name-sort: こひつじほかくけーかく! すいーとぼーいずらいふ しょかいげんていばん
   name-en: "Kohitsuji Hokaku Keikaku! Sweet Boys Life [Limited Edition]"
   region: "NTSC-J"
   patches:
@@ -44328,12 +44434,12 @@ SLPM-66582:
         patch=1,EE,0014A148,word,10000003
 SLPM-66583:
   name: 仔羊捕獲ケーカク! スイートボーイズライフ 通常版
-  name-sort: 仔羊ほかくけーかく! すいーとぼーいずらいふ つうじょうばん
-  name-en: "Kohitsuji Hokaku Keikaku! Sweet Boys Life"
+  name-sort: こひつじほかくけーかく! すいーとぼーいずらいふ [つうじょうばん]
+  name-en: "Kohitsuji Hokaku Keikaku! Sweet Boys Life [Standard Edition]"
   region: "NTSC-J"
 SLPM-66584:
   name: 夜明け前より瑠璃色な 〜Brighter than dawning blue〜
-  name-sort: よあけまえよりるりいろな 〜Brighter than dawning blue〜
+  name-sort: よあけまえよりるりいろな Brighter than dawning blue
   name-en: "Yoake Yori Ruriiro na - Brighter than Dawning Blue"
   region: "NTSC-J"
 SLPM-66585:
@@ -44375,7 +44481,7 @@ SLPM-66590:
   region: "NTSC-J"
 SLPM-66591:
   name: FLATOUT 2 GTR(がんばれ!とびだせ!レーシング!!)
-  name-sort: FLATOUT 2 GTR(がんばれ!とびだせ!れーしんぐ!!)
+  name-sort: FLATOUT 2 がんばれ!とびだせ!れーしんぐ!!
   name-en: "FlatOut 2 GTR"
   region: "NTSC-J"
   compat: 5
@@ -44384,12 +44490,12 @@ SLPM-66591:
     halfPixelOffset: 2 # Corrects most vertical lines.
 SLPM-66592:
   name: ネギま!?3時間目〜恋と魔法と世界樹伝説!〜 演劇版
-  name-sort: ねぎま!?3じかんめ〜こいとまほうとせかいじゅでんせつ!〜 えんげきばん
+  name-sort: ねぎま!?3じかんめ こいとまほうとせかいじゅでんせつ! えんげきばん
   name-en: "Negima! 3-Jikanme [Theater Version]"
   region: "NTSC-J"
 SLPM-66593:
   name: ネギま!?3時間目〜恋と魔法と世界樹伝説!〜 ライブ版
-  name-sort: ねぎま!?3じかんめ〜こいとまほうとせかいじゅでんせつ!〜 らいぶばん
+  name-sort: ねぎま!?3じかんめ こいとまほうとせかいじゅでんせつ! らいぶばん
   name-en: "Negima! 3-Jikanme [Live Version]"
   region: "NTSC-J"
   compat: 5
@@ -44404,8 +44510,8 @@ SLPM-66594:
     - "SLPM-65599"
     - "SLPM-65600"
 SLPM-66595:
-  name: Jリーグ ウイニングイレブン 10+欧州リーグ ’06   -’07
-  name-sort: Jりーぐ ういにんぐいれぶん 10+おうしゅうりーぐ ’06   -’07
+  name: Jリーグ ウイニングイレブン 10+欧州リーグ ’06 -’07
+  name-sort: Jりーぐ ういにんぐいれぶん 10+おうしゅうりーぐ ’06-’07
   name-en: "J-League Winning Eleven 10 - Europa League '06-'07"
   region: "NTSC-J"
 SLPM-66596:
@@ -44418,7 +44524,7 @@ SLPM-66597:
   region: "NTSC-J"
 SLPM-66598:
   name: 夜刀姫斬鬼行 -剣の巻-
-  name-sort: やとひめざんきこう -けんのまき-
+  name-sort: やとひめざんきこう けんのまき
   name-en: "Yatohime Zankikou"
   region: "NTSC-J"
 SLPM-66600:
@@ -44432,7 +44538,7 @@ SLPM-66600:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
 SLPM-66601:
-  name: SSX on tour [EA BEST HITS]
+  name: EA BEST HITS SSX on tour
   name-sort: SSX on tour [EA BEST HITS]
   name-en: "SSX On Tour [EA Best Hits]"
   region: "NTSC-J"
@@ -44440,7 +44546,7 @@ SLPM-66601:
     recommendedBlendingLevel: 4 # Fixes missing lighting and makes snow not look like snow sludge.
 SLPM-66602:
   name: 龍が如く 2 [ディスク1/2]
-  name-sort: りゅうがごとく 2 [でぃすく1/2]
+  name-sort: りゅうがごとく2 [でぃすく1/2]
   name-en: "Ryu ga Gotoku 2 [Disc 1 of 2]"
   region: "NTSC-J"
   memcardFilters:
@@ -44451,7 +44557,7 @@ SLPM-66602:
     - "SLPM-74253"
 SLPM-66603:
   name: 龍が如く 2 [ディスク2/2]
-  name-sort: りゅうがごとく 2 [でぃすく2/2]
+  name-sort: りゅうがごとく2 [でぃすく2/2]
   name-en: "Ryu ga Gotoku 2 [Disc 2 of 2]"
   region: "NTSC-J"
   memcardFilters:
@@ -44462,7 +44568,7 @@ SLPM-66603:
     - "SLPM-74253"
 SLPM-66604:
   name: Broccoli Best Quality ギャラクシーエンジェル Moonlit Lovers
-  name-sort: Broccoli Best Quality ぎゃらくしーえんじぇる Moonlit Lovers
+  name-sort: ぎゃらくしーえんじぇる Moonlit Lovers [Broccoli Best Quality]
   name-en: "Galaxy Angel - Moonlit Lovers [Banpresido the Best]"
   region: "NTSC-J"
 SLPM-66605:
@@ -44472,17 +44578,17 @@ SLPM-66605:
   region: "NTSC-J"
 SLPM-66606:
   name: ホワイトブレス〜絆〜 限定版
-  name-sort: ほわいとぶれす〜きずな〜 げんていばん
-  name-en: "White Breath - Kizuna [First Print - Limited Edition]"
+  name-sort: ほわいとぶれす〜きずな〜 [げんていばん]
+  name-en: "White Breath - Kizuna [First Print Limited Edition]"
   region: "NTSC-J"
 SLPM-66607:
   name: ホワイトブレス〜絆〜 通常版
-  name-sort: ほわいとぶれす〜きずな〜 つうじょうばん
-  name-en: "White Breath - Kizuna"
+  name-sort: ほわいとぶれす〜きずな〜 [つうじょうばん]
+  name-en: "White Breath - Kizuna [Standard Edition]"
   region: "NTSC-J"
 SLPM-66608:
   name: テニスの王子様 ドキドキサバイバル 山麓のMystic
-  name-sort: てにすのおうじさま どきどきさばいばる さんろくのMystic
+  name-sort: てにすのおうじさま どきどきさばいばる さんろくのみすてぃっく
   name-en: "Prince of Tennis - DokiDoki Survival - Sanroku no Mystic"
   region: "NTSC-J"
 SLPM-66609:
@@ -44496,24 +44602,24 @@ SLPM-66610:
   name-en: "Prince of Tennis - DokiDoki Survival - Umibe no Secret"
   region: "NTSC-J"
 SLPM-66611:
-  name: 智代アフター ～It’s a Wonderful Life～ CS Edition
-  name-sort: ともよあふたー ～It’s a Wonderful Life～ CS Edition
+  name: 智代アフター 〜It’s a Wonderful Life〜 CS Edition
+  name-sort: ともよあふたー 〜It’s a Wonderful Life〜 CS Edition
   name-en: "Tomoyo After - It's Wonderful Life [CS Edition]"
   region: "NTSC-J"
   gsHWFixes:
     cpuCLUTRender: 1 # Fixes Colours.
 SLPM-66612:
   name: すくぅ〜る らぶっ!〜恋と希望のメトロノーム〜 初回限定版
-  name-sort: すくぅ〜る らぶっ!〜こいときぼうのめとろのーむ〜 しょかいげんていばん
+  name-sort: すくぅーる らぶっ! こいときぼうのめとろのーむ しょかいげんていばん
   name-en: "School Love [Limited Edition]"
   region: "NTSC-J"
 SLPM-66613:
-  name: メダル オブ オナー 史上最大の作戦&メダル オブ オナー ライジングサン [EA BEST HITS]
+  name: EA BEST HITS メダル オブ オナー 史上最大の作戦&メダル オブ オナー ライジングサン
   name-sort: めだる おぶ おなー しじょうさいだいのさくせん&めだる おぶ おなー らいじんぐさん [EA BEST HITS]
   name-en: "Medal of Honor - Rising Sun & Frontline [EA Best Hits]"
   region: "NTSC-J"
 SLPM-66615:
-  name: 007 ナイト ファイア&007 エブリシング オア ナッシング [EA BEST HITS]
+  name: EA BEST HITS 007 ナイト ファイア&007 エブリシング オア ナッシング
   name-sort: 007 ないと ふぁいあ&007 えぶりしんぐ おあ なっしんぐ [EA BEST HITS]
   name-en: "007 - Nightfire [EA Best Hits Dual Pack]"
   region: "NTSC-J"
@@ -44522,7 +44628,7 @@ SLPM-66616:
   region: "NTSC-J"
 SLPM-66617:
   name: ニード・フォー・スピード カーボン
-  name-sort: にーど・ふぉー・すぴーど かーぼん
+  name-sort: にーど ふぉー すぴーど かーぼん
   name-en: "Need for Speed - Carbon"
   region: "NTSC-J"
   clampModes:
@@ -44532,12 +44638,12 @@ SLPM-66617:
     halfPixelOffset: 2 # Fixes blurriness.
     roundSprite: 2 # Fixes blurriness.
 SLPM-66618:
-  name: 夢見師 [初回限定版]
-  name-sort: ゆめみし [しょかいげんていばん]
+  name: 夢見師 (初回限定版)
+  name-sort: ゆめみし しょかいげんていばん
   name-en: "Yumemishi [First Print Limited Edition]"
   region: "NTSC-J"
 SLPM-66619:
-  name: 夢見師
+  name: 夢見師 (通常版)
   name-sort: ゆめみし
   name-en: "Yumemishi"
   region: "NTSC-J"
@@ -44548,32 +44654,32 @@ SLPM-66620:
   region: "NTSC-J"
 SLPM-66621:
   name: beatmania IIDX 12 HAPPY SKY
-  name-sort: beatmania IIDX 12 HAPPY SKY
+  name-sort: びーとまにあ つーでぃーえっくす 12 HAPPY SKY
   name-en: "Beatmania IIDX 12 HAPPY SKY"
   region: "NTSC-J"
 SLPM-66622:
-  name: トム・クランシーシリーズ ゴーストリコン2 [ユービーアイソフト ベスト]
-  name-sort: とむ・くらんしーしりーず ごーすとりこん2 [ゆーびーあいそふと べすと]
+  name: ユービーアイソフト ベスト トム・クランシーシリーズ ゴーストリコン2
+  name-sort: とむくらんしーしりーず ごーすとりこん2 [ゆーびーあいそふと べすと]
   name-en: "Tom Clancy's Ghost Recon 2 [Ubisoft Best]"
   region: "NTSC-J"
 SLPM-66623:
   name: アスミック得だねシリーズ ドカポン・ザ・ワールド
-  name-sort: あすみっくとくだねしりーず どかぽん・ざ・わーるど
+  name-sort: どかぽん・ざ・わーるど [あすみっくとくだねしりーず]
   name-en: "Dokapon the World [Asmik Tokudane Series]"
   region: "NTSC-J"
 SLPM-66624:
-  name: つよきす〜Mighy Heart〜 [プリンセスソフトコレクション]
+  name: つよきす〜Mighy Heart〜(プリンセスソフトコレクション)
   name-sort: つよきす〜Mighy Heart〜 [ぷりんせすそふとこれくしょん]
   name-en: "Tsuyo Kiss - Mighty Heart [Princess Soft Collection]"
   region: "NTSC-J"
 SLPM-66625:
   name: とらぶるふぉうちゅん COMPANY★はぴCURE [初回限定版]
-  name-sort: とらぶるふぉうちゅん COMPANY★はぴCURE [しょかいげんていばん]
+  name-sort: とらぶるふぉうちゅん COMPANY はぴCURE しょかいげんていばん
   name-en: "Trouble Fortune Company - HapiCure [Limited Edition]"
   region: "NTSC-J"
 SLPM-66626:
   name: とらぶるふぉうちゅん COMPANY★はぴCURE [通常版]
-  name-sort: とらぶるふぉうちゅん COMPANY★はぴCURE [つうじょうばん]
+  name-sort: とらぶるふぉうちゅん COMPANY はぴCURE [つうじょうばん]
   name-en: "Trouble Fortune Company - HapiCure"
   region: "NTSC-J"
 SLPM-66627:
@@ -44583,7 +44689,7 @@ SLPM-66627:
   region: "NTSC-J"
 SLPM-66628:
   name: OutRun2 SP(アウトラン2 スペシャルツアーズ) [初回限定版]
-  name-sort: あうとらん2 すぺしゃるつあーず [しょかいげんていばん]
+  name-sort: あうとらん2 すぺしゃるつあーず しょかいげんていばん
   name-en: "OutRun 2 SP [First Print Limited Edition]"
   region: "NTSC-J"
   compat: 5
@@ -44593,7 +44699,7 @@ SLPM-66628:
     roundSprite: 1 # Fixes bloom misalignment still a bit misaligned + font artifacts.
 SLPM-66629:
   name: ダージュ・オブ・ケルベロス -ファイナルファンタジーVII- インターナショナル [アルティメットヒッツ]
-  name-sort: だーじゅ・おぶ・けるべろす -ふぁいなるふぁんたじーVII- いんたーなしょなる [あるてぃめっとひっつ]
+  name-sort: だーじゅ・おぶ・けるべろす ふぁいなるふぁんたじー7 いんたーなしょなる [あるてぃめっとひっつ]
   name-en: "Dirge of Cerberus - Final Fantasy VII International"
   region: "NTSC-J"
   gsHWFixes:
@@ -44612,12 +44718,12 @@ SLPM-66631:
   region: "NTSC-J"
 SLPM-66632:
   name: 喧嘩番長2 〜FULLTHROTTLE〜(フルスロットル)
-  name-sort: けんかばんちょう2 〜ふるすろっとる〜
+  name-sort: けんかばんちょう2 ふるすろっとる
   name-en: "Kenka Banchou 2 - Full Throttle"
   region: "NTSC-J"
 SLPM-66633:
   name: 少女魔法学リトルウィッチロマネスク 〜アリアとカヤと黒の塔〜
-  name-sort: しょうじょまほうがくりとるうぃっちろまねすく 〜ありあとかやとくろのとう〜
+  name-sort: しょうじょまほうがくりとるうぃっちろまねすく ありあとかやとくろのとう
   name-en: "Shoujo Mahou Gaku Little Witch Romanesque"
   region: "NTSC-J"
 SLPM-66634:
@@ -44664,7 +44770,7 @@ SLPM-66640:
   region: "NTSC-J"
 SLPM-66641:
   name: すくぅ〜る らぶっ!〜恋と希望のメトロノーム〜
-  name-sort: すくぅ〜る らぶっ!〜こいときぼうのめとろのーむ〜
+  name-sort: すくぅーる らぶっ! こいときぼうのめとろのーむ
   name-en: "School Love"
   region: "NTSC-J"
 SLPM-66642:
@@ -44681,7 +44787,7 @@ SLPM-66643:
     roundSprite: 1 # Fixes bloom misalignment still a bit misaligned + font artifacts.
 SLPM-66644:
   name: J.LEAGUE プロサッカークラブをつくろう!5
-  name-sort: J.LEAGUE ぷろさっかーくらぶをつくろう!5
+  name-sort: Jりーぐ ぷろさっかーくらぶをつくろう!5
   name-en: "J-League Pro Soccer Club o Tsukurou 5"
   region: "NTSC-J"
 SLPM-66645:
@@ -44703,7 +44809,7 @@ SLPM-66649:
   gsHWFixes:
     roundSprite: 1 # Fixes vertical and horizontal lines.
 SLPM-66651:
-  name: バトルフィールド2 モダンコンバット [EA BEST HITS]
+  name: EA BEST HITS バトルフィールド2 モダンコンバット
   name-sort: ばとるふぃーるど2 もだんこんばっと [EA BEST HITS]
   name-en: "Battlefield 2 - Modern Combat [EA Best Hits]"
   region: "NTSC-J"
@@ -44715,7 +44821,7 @@ SLPM-66651:
     getSkipCount: "GSC_Battlefield2" # Depth clear.
     beforeDraw: "OI_Battlefield2" # Framebuffer copy, fixes rendering for bottom part of screen.
 SLPM-66652:
-  name: バーンアウト リベンジ [EA BEST HITS]
+  name: EA BEST HITS バーンアウト リベンジ
   name-sort: ばーんあうと りべんじ [EA BEST HITS]
   name-en: "Burnout Revenge [EA Best Hits]"
   region: "NTSC-J"
@@ -44746,14 +44852,14 @@ SLPM-66653:
   name-en: "Akudaikan 3"
   region: "NTSC-J"
 SLPM-66654:
-  name: 遙かなる時空の中で2 [コーエー定番シリーズ]
+  name: コーエー定番シリーズ 遙かなる時空の中で2
   name-sort: はるかなるときのなかで2 [こーえーていばんしりーず]
   name-en: "Harukanaru Toki no Naka de 2 [Koei Selection]"
   region: "NTSC-J"
 SLPM-66655:
-  name: 遙かなる時空の中で 〜八葉抄〜 [KOEI The Best]
-  name-sort: はるかなるときのなかで 〜はちようしょう〜
-  name-en: "Harukanaru Jikuu no Kade - Hachiha Katsunori [Koei the Best]"
+  name: KOEI The Best 遙かなる時空の中で 〜八葉抄〜
+  name-sort: はるかなるときのなかで 〜はちようしょう〜 [KOEI The Best]
+  name-en: "Harukanaru Toki no Naka de - Hachiyou-shou [Koei the Best]"
   region: "NTSC-J"
 SLPM-66656:
   name: ウォーシップガンナー2 〜鋼鉄の咆哮〜 [KOEI The Best]
@@ -44761,23 +44867,23 @@ SLPM-66656:
   name-en: "Warship Gunner 2 - Change of Direction [Koei the Best]"
   region: "NTSC-J"
 SLPM-66657:
-  name: 真・三國無双3 猛将伝 [コーエー定番シリーズ]
-  name-sort: しん・さんごくむそう3 もうしょうでん [こーえーていばんしりーず]
-  name-en: "Shin Sangoku Musou 3 Mushoden [Koei Selection]"
+  name: コーエー定番シリーズ 真・三國無双3 猛将伝
+  name-sort: しんさんごくむそう3 もうしょうでん [こーえーていばんしりーず]
+  name-en: "Shin Sangoku Musou 3 Moushouden [Koei Selection]"
   region: "NTSC-J"
 SLPM-66658:
-  name: 真・三國無双3 Empiers [コーエー定番シリーズ]
-  name-sort: しん・さんごくむそう3 Empiers [こーえーていばんしりーず]
+  name: コーエー定番シリーズ 真・三國無双3 Empires
+  name-sort: しんさんごくむそう3 えんぱいあーず [こーえーていばんしりーず]
   name-en: "Shin Sangoku Musou 3 Empires [Koei Selection]"
   region: "NTSC-J"
 SLPM-66659:
   name: そしてこの宇宙にきらめく君の詩 XXX
-  name-sort: そしてこのうちゅうにきらめくきみのし XXX
-  name-en: "Soshite Kono Uchuu ni Kirameku Kimi no Shi XXX"
+  name-sort: そしてこのうちゅうにきらめくきみのうた XXX
+  name-en: "Soshite Kono Uchuu ni Kirameku Kimi no Uta XXX"
   region: "NTSC-J"
 SLPM-66660:
   name: 北斗の拳 〜審判の双蒼星 拳豪列伝〜
-  name-sort: ほくとのけん 〜しんぱんのそうそうせい けんごうれつでん〜
+  name-sort: ほくとのけん しんぱんのそうそうせい けんごうれつでん
   name-en: "Hokuto no Ken"
   region: "NTSC-J"
   compat: 5
@@ -44797,7 +44903,7 @@ SLPM-66662:
     alignSprite: 1 # Fixes almost all vertical lines.
 SLPM-66663:
   name: PHANTASY STAR UNIVERSE イルミナスの野望
-  name-sort: PHANTASY STAR UNIVERSE いるみなすのやぼう
+  name-sort: ふぁんたしーすたーゆにばーす いるみなすのやぼう
   name-en: "Phantasy Star Universe - Ambition of the Illuminus"
   region: "NTSC-J"
   roundModes:
@@ -44809,7 +44915,7 @@ SLPM-66664:
   region: "NTSC-J"
 SLPM-66667:
   name: マイネリーベII 〜誇りと正義と愛〜 コナミ殿堂セレクション
-  name-sort: まいねりーべII 〜ほこりとせいぎとあい〜 こなみでんどうせれくしょん
+  name-sort: まいねりーべ2 ほこりとせいぎとあい こなみでんどうせれくしょん
   name-en: "Meine Liebe II [Konami Palace Selection]"
   region: "NTSC-J"
 SLPM-66668:
@@ -44852,7 +44958,7 @@ SLPM-66672:
   region: "NTSC-J"
 SLPM-66673:
   name: プリンス・オブ・ペルシャ ケンシ ノ ココロ [ユービーアイソフトベスト]
-  name-sort: ぷりんす・おぶ・ぺるしゃ けんし の こころ [ゆーびーあいそふとべすと]
+  name-sort: ぷりんす おぶ ぺるしゃ けんし の こころ [ゆーびーあいそふとべすと]
   name-en: "Prince of Persia - Warrior Within [Ubisoft the Best]"
   region: "NTSC-J"
   gsHWFixes:
@@ -44869,7 +44975,7 @@ SLPM-66674:
     trilinearFiltering: 1
 SLPM-66675:
   name: KINGDOM HEARTS II FINAL MIX+ 通常版
-  name-sort: KINGDOM HEARTS II FINAL MIX+ つうじょうばん
+  name-sort: KINGDOM HEARTS II FINAL MIX+ [つうじょうばん]
   name-en: "Kingdom Hearts II - Final Mix +"
   region: "NTSC-J"
   gsHWFixes:
@@ -44891,7 +44997,7 @@ SLPM-66676:
     - "SLPM-66676"
 SLPM-66677:
   name: ファイナルファンタジーX インターナショナル [アルティメットヒッツ]
-  name-sort: ふぁいなるふぁんたじーX いんたーなしょなる [あるてぃめっとひっつ]
+  name-sort: ふぁいなるふぁんたじー10 いんたーなしょなる [あるてぃめっとひっつ]
   name-en: "Final Fantasy X - International [Ultimate Hits]"
   region: "NTSC-J"
   roundModes:
@@ -44903,7 +45009,7 @@ SLPM-66677:
     roundSprite: 2 # Fixes font artifacts.
 SLPM-66678:
   name: ファイナルファンタジーX-2 インターナショナル+ラストミッション [アルティメットヒッツ]
-  name-sort: ふぁいなるふぁんたじーX-2 いんたーなしょなる+らすとみっしょん [あるてぃめっとひっつ]
+  name-sort: ふぁいなるふぁんたじー10-2 いんたーなしょなる+らすとみっしょん [あるてぃめっとひっつ]
   name-en: "Final Fantasy X-2 - International + Last Mission [Ultimate Hits]"
   region: "NTSC-J"
   clampModes:
@@ -44924,7 +45030,7 @@ SLPM-66679:
     - "SLPM-66634"
 SLPM-66681:
   name: 真・女神転生III-NOCTURNE マニアクス クロニクルエディション
-  name-sort: しん・めがみてんせいIII-NOCTURNE まにあくす くろにくるえでぃしょん
+  name-sort: しんめがみてんせい3-NOCTURNE まにあくす くろにくるえでぃしょん
   name-en: "Shin Megami Tensei III - Nocturne Maniax Chronicle Edition"
   region: "NTSC-J"
   compat: 5
@@ -44945,7 +45051,7 @@ SLPM-66683:
     - "SLPM-66634"
 SLPM-66685:
   name: シーマン2 〜北京原人育成キット〜
-  name-sort: しーまん2 〜ぺきんげんじんいくせいきっと〜
+  name-sort: しーまん2 ぺきんげんじんいくせいきっと
   name-en: "Seaman 2 - Peking Genjin Ikusei Kit"
   region: "NTSC-J"
   compat: 2
@@ -44956,7 +45062,7 @@ SLPM-66686:
   region: "NTSC-J"
 SLPM-66687:
   name: 緋色の欠片 〜あの空の下で〜
-  name-sort: ひいろのかけら 〜あのそらのしたで〜
+  name-sort: ひいろのかけら あのそらのしたで
   name-en: "Hiiro no Kakera - Ano Sora no Shita de"
   region: "NTSC-J"
   patches:
@@ -44969,7 +45075,7 @@ SLPM-66687:
 SLPM-66688:
   name: 遙かなる時空の中で3 [KOEI The Best]
   name-sort: はるかなるときのなかで3 KOEI The Best
-  name-en: "Harukanaru Jikuu no Kade 3 [Koei the Best]"
+  name-en: "Harukanaru Toki no Naka de 3 [Koei the Best]"
   region: "NTSC-J"
 SLPM-66689:
   name: ペルソナ3フェス [アペンドディスク版]
@@ -44995,7 +45101,7 @@ SLPM-66690:
     - "SLPM-66690"
 SLPM-66691:
   name: 戦国BASARA2 カプコレ
-  name-sort: せんごくBASARA2 かぷこれ
+  name-sort: せんごくばさら2 かぷこれ
   name-en: "Sengoku Basara 2 [CapKore]"
   region: "NTSC-J"
 SLPM-66692:
@@ -45017,7 +45123,7 @@ SLPM-66694:
     halfPixelOffset: 2 # Fixes ghosting.
 SLPM-66695:
   name: この青空に約束を　〜melody of the sun and sea〜
-  name-sort: このあおぞらにやくそくを　〜melody of the sun and sea〜
+  name-sort: このあおぞらにやくそくを 〜melody of the sun and sea〜
   name-en: "Kono Aozora ni Yakusoku o - Melody of the Sun and Sea"
   region: "NTSC-J"
 SLPM-66696:
@@ -45044,7 +45150,7 @@ SLPM-66699:
 SLPM-66700:
   name: 金色のコルダ2
   name-sort: きんいろのこるだ2
-  name-en: "Konjiki no Corda 2"
+  name-en: "Kin'iro no Corda 2"
   region: "NTSC-J"
 SLPM-66701:
   name: 三國志11 withパワーアップキット
@@ -45053,7 +45159,7 @@ SLPM-66701:
   region: "NTSC-J"
 SLPM-66702:
   name: Winning Post 7 MAXIMUM2007
-  name-sort: Winning Post 7 MAXIMUM2007
+  name-sort: ういにんぐぽすと7 MAXIMUM2007
   name-en: "Winning Post 7 Maximum 2007"
   region: "NTSC-J"
 SLPM-66703:
@@ -45085,7 +45191,7 @@ SLPM-66708:
     halfPixelOffset: 2 # Fixes blurriness.
 SLPM-66709:
   name: エンジェル・プロファイル
-  name-sort: えんじぇる・ぷろふぁいる
+  name-sort: えんじぇる ぷろふぁいる
   name-en: "Angel Profile"
   region: "NTSC-J"
 SLPM-66710:
@@ -45143,7 +45249,7 @@ SLPM-66718:
   region: "NTSC-J"
 SLPM-66719:
   name: 天下人 [SEGA THE BEST]
-  name-sort: てんかじん [SEGA THE BEST]
+  name-sort: てんかびと [SEGA THE BEST]
   name-en: "Tenka-bito [Sega the Best]"
   region: "NTSC-J"
 SLPM-66720:
@@ -45178,13 +45284,13 @@ SLPM-66725:
   region: "NTSC-J"
 SLPM-66726:
   name: お嬢様組曲 -Sweet Concert- [通常版]
-  name-sort: おじょうさまくみきょく -Sweet Concert- [つうじょうばん]
+  name-sort: おじょうさまくみきょく Sweet Concert [つうじょうばん]
   name-en: "Ojousama Kumikyoku - Sweet Concert"
   region: "NTSC-J"
 SLPM-66727:
   name: らぶ☆どろ〜LoveDrops〜
-  name-sort: らぶ☆どろ〜LoveDrops〜
-  name-en: "Love Drops"
+  name-sort: らぶ どろ LoveDrops
+  name-en: "Love Doro - Love Drops"
   region: "NTSC-J"
 SLPM-66728:
   name: プロ野球スピリッツ4
@@ -45193,13 +45299,13 @@ SLPM-66728:
   region: "NTSC-J"
 SLPM-66729:
   name: 少年陰陽師 翼よいま、天へ還れ DXパック
-  name-sort: しょうねんおんみょうじ つばさよいま、てんへかえれ DXぱっく
-  name-en: "Shounen Onyouji - Tsubasa Yoima, Ten e Kare [Deluxe Box]"
+  name-sort: しょうねんおんみょうじ つばさよいま てんへかえれ DXぱっく
+  name-en: "Shounen Onmyouji - Tsubasa yo Ima, Ten he Kaere [Deluxe Box]"
   region: "NTSC-J"
 SLPM-66730:
   name: 少年陰陽師 翼よいま、天へ還れ 通常版
-  name-sort: しょうねんおんみょうじ つばさよいま、てんへかえれ つうじょうばん
-  name-en: "Shounen Onyouji - Tsubasa Yoima, Ten e Kare"
+  name-sort: しょうねんおんみょうじ つばさよいま てんへかえれ [つうじょうばん]
+  name-en: "Shounen Onmyouji - Tsubasa yo Ima, Ten he Kaere"
   region: "NTSC-J"
 SLPM-66731:
   name: BLACK THE BEST
@@ -45218,7 +45324,7 @@ SLPM-66731:
     beforeDraw: "OI_BurnoutGames"
 SLPM-66732:
   name: 許嫁(いいなずけ) [初回限定版]
-  name-sort: いいなずけ [しょかいげんていばん]
+  name-sort: いいなずけ しょかいげんていばん
   name-en: "Iinazuke [Limited Edition]"
   region: "NTSC-J"
 SLPM-66733:
@@ -45228,12 +45334,12 @@ SLPM-66733:
   region: "NTSC-J"
 SLPM-66734:
   name: きると〜貴方と紡ぐ夢と恋のドレス〜 [初回限定版]
-  name-sort: きると〜あなたとつむぐゆめとこいのどれす〜 [しょかいげんていばん]
+  name-sort: きると あなたとつむぐゆめとこいのどれす しょかいげんていばん
   name-en: "Kiruto - Anata to Tsumugu Yume to Koi no Dress [Limited Edition]"
   region: "NTSC-J"
 SLPM-66735:
   name: きると〜貴方と紡ぐ夢と恋のドレス〜 [通常版]
-  name-sort: きると〜あなたとつむぐゆめとこいのどれす〜 [つうじょうばん]
+  name-sort: きると あなたとつむぐゆめとこいのどれす [つうじょうばん]
   name-en: "Kiruto - Anata to Tsumugu Yume to Koi no Dress"
   region: "NTSC-J"
 SLPM-66736:
@@ -45243,7 +45349,7 @@ SLPM-66736:
   region: "NTSC-J"
 SLPM-66737:
   name: 桜蘭高校ホスト部 限定版
-  name-sort: おうらんこうこうほすとぶ げんていばん
+  name-sort: おうらんこうこうほすとぶ [げんていばん]
   name-en: "Ouran Koukou Host Club [Limited Edition]"
   region: "NTSC-J"
   patches:
@@ -45289,7 +45395,7 @@ SLPM-66740:
   region: "NTSC-J"
 SLPM-66741:
   name: 戦闘国家・改・レジェンド [通常版]
-  name-sort: せんとうこっか・かい・れじぇんど [つうじょうばん]
+  name-sort: せんとうこっか かい れじぇんど [つうじょうばん]
   name-en: "Sentou Kokka Kai - Legend"
   region: "NTSC-J"
 SLPM-66742:
@@ -45305,18 +45411,19 @@ SLPM-66743:
   region: "NTSC-J"
 SLPM-66744:
   name: Killer7 カプコレ
-  name-sort: Killer7 かぷこれ
+  name-sort: Killer7 [かぷこれ]
   name-en: "Killer7 [CapKore]"
   region: "NTSC-J"
 SLPM-66745:
   name: シャドウ・オブ・ローマ カプコレ
-  name-sort: しゃどう・おぶ・ろーま かぷこれ
+  name-sort: しゃどう おぶ ろーま [かぷこれ]
   name-en: "Shadow of Rome [CapKore]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness and misaligned garbage when upscaling.
 SLPM-66746:
   name: GUILTY GEAR XX ΛCORE(ギルティギア イグゼクス アクセントコア)
+  name-sort: ぎるてぃぎあ いぐぜくす あくせんとこあ
   name-en: "Guilty Gear XX - Accent Core"
   region: "NTSC-J"
   compat: 5
@@ -45329,8 +45436,8 @@ SLPM-66747:
     halfPixelOffset: 1 # Fixes ghosting of characters.
 SLPM-66748:
   name: マナケミア 〜学園の錬金術師たち〜
-  name-sort: まなけみあ 〜がくえんのれんきんじゅつしたち〜
-  name-en: "Mana-Khemia - Gakuen no Renkinjutsu Shitachi"
+  name-sort: まなけみあ がくえんのれんきんじゅつしたち
+  name-en: "Mana-Khemia - Gakuen no Renkinjutsushi Tachi"
   region: "NTSC-J"
   roundModes:
     eeRoundMode: 0 # Fixes jump issue.
@@ -45339,12 +45446,12 @@ SLPM-66748:
     - SoftwareRendererFMVHack # Vertical lines in FMV.
 SLPM-66749:
   name: ウィザードリィエクス2 〜無限の学徒〜 ワンダープライス
-  name-sort: うぃざーどりぃえくす2 〜むげんのがくと〜 わんだーぷらいす
+  name-sort: うぃざーどりぃえくす2 むげんのがくと わんだーぷらいす
   name-en: "Wizardry X 2 - Mugen no Gakuto [Wonder Price]"
   region: "NTSC-J"
 SLPM-66750:
   name: ファイナルファンタジーXII インターナショナル ゾディアックジョブシステム
-  name-sort: ふぁいなるふぁんたじーXII いんたーなしょなる ぞでぃあっくじょぶしすてむ
+  name-sort: ふぁいなるふぁんたじー12 いんたーなしょなる ぞでぃあっくじょぶしすてむ
   name-en: "Final Fantasy XII International - Zodiac Job System [with Bonus DVD]"
   region: "NTSC-J"
   compat: 5
@@ -45363,24 +45470,24 @@ SLPM-66752:
     mergeSprite: 1 # Removes occasional vertical lines.
 SLPM-66753:
   name: 月面兎兵器ミーナ -ふたつのPROJECT M- [限定版]
-  name-sort: げつめんうさぎへいきみーな -ふたつのPROJECT M- [げんていばん]
+  name-sort: げつめんとへいきみーな -ふたつのPROJECT M- [げんていばん]
   name-en: "Getsumento Heiki Mina - Futatsu no Project M [Limited Edition]"
   region: "NTSC-J"
 SLPM-66754:
   name: 月面兎兵器ミーナ -ふたつのPROJECT M- [通常版]
-  name-sort: げつめんうさぎへいきみーな -ふたつのPROJECT M- [つうじょうばん]
+  name-sort: げつめんとへいきみーな -ふたつのPROJECT M- [つうじょうばん]
   name-en: "Getsumento Heiki Mina - Futatsu no Project M"
   region: "NTSC-J"
 SLPM-66755:
-  name: 魔女っ娘ア・ラ・モードII〜魔女と剣のストラグル〜 [通常版]
-  name-sort: まじょっこあ・ら・もーどII〜まじょとけんのすとらぐる〜 [つうじょうばん]
+  name: 魔女っ娘ア・ラ・モードII〜魔法と剣のストラグル〜 [通常版]
+  name-sort: まじょっこあらもーど2 まほうとけんのすとらぐる [つうじょうばん]
   name-en: "Majo-musume - A La Mode II"
   region: "NTSC-J"
   gsHWFixes:
     cpuCLUTRender: 1 # Fixes bad colour rendering.
 SLPM-66756:
   name: Que〜エンシェントリーフの妖精〜 [初回限定版]
-  name-sort: Que〜えんしぇんとりーふのようせい〜 [しょかいげんていばん]
+  name-sort: Que〜えんしぇんとりーふのようせい〜 しょかいげんていばん
   name-en: "Que - Ancient Leaf no Yousei [Limited Edition]"
   region: "NTSC-J"
 SLPM-66757:
@@ -45396,11 +45503,11 @@ SLPM-66758:
 SLPM-66759:
   name: 遙かなる時空の中で3 十六夜記 [KOEI The Best]
   name-sort: はるかなるときのなかで3 いざよいき [KOEI The Best]
-  name-en: "Harukanaru Jikuu no Kade 3 - Izayoiki [Koei the Best]"
+  name-en: "Harukanaru Toki no Naka de 3 - Izayoiki [Koei the Best]"
   region: "NTSC-J"
 SLPM-66760:
-  name: 信長の野望・蒼天録 with パワーアップキット [コーエー定番シリーズ]
-  name-sort: のぶながのやぼう・そうてんろく with ぱわーあっぷきっと [こーえーていばんしりーず]
+  name: コーエー定番シリーズ 信長の野望・蒼天録 with パワーアップキット
+  name-sort: のぶながのやぼう そうてんろく with ぱわーあっぷきっと [こーえーていばんしりーず]
   name-en: "Nobunaga no Yabou - Soutenroku [with Power-Up Kit] [Koei Selection]"
   region: "NTSC-J"
 SLPM-66761:
@@ -45426,13 +45533,13 @@ SLPM-66764:
   region: "NTSC-J"
 SLPM-66765:
   name: 十次元立方体サイファー ゲーム・オブ・サバイバル [初回限定版]
-  name-sort: じゅうじげんりっぽうたいさいふぁー げーむ・おぶ・さばいばる [しょかいげんていばん]
-  name-en: "Juujimoto Ripputai Sypher - Game of Survival [Limited Edition]"
+  name-sort: じゅうじげんりっぽうたいさいふぁー げーむ・おぶ・さばいばる しょかいげんていばん
+  name-en: "Juujigen Rippoutai Sypher - Game of Survival [Limited Edition]"
   region: "NTSC-J"
 SLPM-66766:
   name: 十次元立方体サイファー ゲーム・オブ・サバイバル [通常版]
   name-sort: じゅうじげんりっぽうたいさいふぁー げーむ・おぶ・さばいばる [つうじょうばん]
-  name-en: "Juujimoto Ripputai Sypher - Game of Survival"
+  name-en: "Juujigen Ripoutai Sypher - Game of Survival"
   region: "NTSC-J"
 SLPM-66767:
   name: アーバンカオス
@@ -45459,35 +45566,35 @@ SLPM-66770:
   region: "NTSC-J"
 SLPM-66771:
   name: 電車でGO!山陽新幹線編 [エターナルヒッツ]
-  name-sort: でんしゃでGO!さんようしんかんせんへん [えたーなるひっつ]
-  name-en: "Densha de Go! Shinkansen [PS2 The Best]"
+  name-sort: でんしゃでごーさんようしんかんせんへん [えたーなるひっつ]
+  name-en: "Densha de Go! Sanyo Shinkansen [Eternal Hits]"
   region: "NTSC-J"
 SLPM-66772:
   name: 電車でGO!FINAL [エターナルヒッツ]
-  name-sort: でんしゃでGO!FINAL [えたーなるひっつ]
-  name-en: "Densha de Go! Final [PS2 The Best]"
+  name-sort: でんしゃでごーFINAL [えたーなるひっつ]
+  name-en: "Densha de Go! Final [Eternal Hits]"
   region: "NTSC-J"
 SLPM-66773:
   name: ジェットでGO!2 [エターナルヒッツ]
   name-sort: じぇっとでGO!2 [えたーなるひっつ]
-  name-en: "Densha de Go! Professional 2 [Taito Best]"
+  name-en: "Jet de Go! 2 [Eternal Hits]"
   region: "NTSC-J"
 SLPM-66774:
   name: エナジーエアーフォース [エターナルヒッツ]
   name-sort: えなじーえあーふぉーす [えたーなるひっつ]
-  name-en: "Energy Airforce - AimStrike! [Taito Best]"
+  name-en: "Energy Airforce - AimStrike! [Eternal Hits]"
   region: "NTSC-J"
 SLPM-66775:
   name: タイトーメモリーズ 上巻 [エターナルヒッツ]
   name-sort: たいとーめもりーず じょうかん [えたーなるひっつ]
-  name-en: "Taito Memories - Joukan [Taito Best]"
+  name-en: "Taito Memories - Joukan [Eternal Hits]"
   region: "NTSC-J"
   gsHWFixes:
     roundSprite: 1 # Fixes vertical and horizontal lines.
 SLPM-66776:
   name: タイトーメモリーズ 下巻 [エターナルヒッツ]
   name-sort: たいとーめもりーず げかん [えたーなるひっつ]
-  name-en: "Taito Memories Gekan [Taito Best]"
+  name-en: "Taito Memories Gekan [Eternal Hits]"
   region: "NTSC-J"
   gsHWFixes:
     roundSprite: 1 # Fixes vertical and horizontal lines.
@@ -45497,20 +45604,20 @@ SLPM-66777:
   name-en: "Jikkyou Powerful Pro Yakyuu 14"
   region: "NTSC-J"
 SLPM-66778:
-  name: ギャラクシーエンジェル Eternal Lovers Broccoli Best Quality
-  name-sort: ぎゃらくしーえんじぇる Eternal Lovers Broccoli Best Quality
+  name: Broccoli Best Quality ギャラクシーエンジェル Moonlit Lovers
+  name-sort: ぎゃらくしーえんじぇる Eternal Lovers [Broccoli Best Quality]
   name-en: "Galaxy Angel - Eternal Lovers [Broccoli The Best Quality]"
   region: "NTSC-J"
 SLPM-66779:
   name: ギャラクシーエンジェルII 無限回廊の鍵【通常版】 [ディスク1/2]
-  name-sort: ぎゃらくしーえんじぇるII むげんかいろうのかぎ【つうじょうばん】 [でぃすく1/2]
+  name-sort: ぎゃらくしーえんじぇるII むげんかいろうのかぎ [つうじょうばん] [でぃすく1/2]
   name-en: "Galaxy Angel II - Mugen Kairou no Kagi [Disc 1 of 2]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 1 # Reduces misaligned lighting and other effects.
 SLPM-66780:
   name: ギャラクシーエンジェルII 無限回廊の鍵【通常版】 [ディスク2/2]
-  name-sort: ぎゃらくしーえんじぇるII むげんかいろうのかぎ【つうじょうばん】 [でぃすく2/2]
+  name-sort: ぎゃらくしーえんじぇるII むげんかいろうのかぎ [つうじょうばん] [でぃすく2/2]
   name-en: "Galaxy Angel II - Mugen Kairou no Kagi [Disc 2 of 2]"
   region: "NTSC-J"
   gsHWFixes:
@@ -45550,12 +45657,12 @@ SLPM-66785:
   region: "NTSC-J"
 SLPM-66786:
   name: Broccoli Best Quality gift -prism- Sweets So Sweet
-  name-sort: Broccoli Best Quality gift -prism- Sweets So Sweet
+  name-sort: gift -prism- Sweets So Sweet [Broccoli Best Quality]
   name-en: "Gift - Prism [Broccoli Best Quality]"
   region: "NTSC-J"
 SLPM-66787:
   name: 水夏A.S+ Eternal Name 通常版
-  name-sort: すいかA.S+ Eternal Name つうじょうばん
+  name-sort: すいかA.S+ Eternal Name [つうじょうばん]
   name-en: "Suika A.S+ Eternal Name"
   region: "NTSC-J"
 SLPM-66788:
@@ -45569,12 +45676,12 @@ SLPM-66788:
     autoFlush: 1 # Fixes post processing.
 SLPM-66789:
   name: Grand Theft Auto III ベストプライス
-  name-sort: Grand Theft Auto III べすとぷらいす
+  name-sort: ぐらんどせふとおーと3 べすとぷらいす
   name-en: "Grand Theft Auto III [Best Price]"
   region: "NTSC-J"
 SLPM-66790:
   name: Grand Theft Auto:Vice City ベストプライス
-  name-sort: Grand Theft Auto:Vice City べすとぷらいす
+  name-sort: ぐらんどせふとおーと ばいすしてぃ べすとぷらいす
   name-en: "Grand Theft Auto - Vice City [Best Price]"
   region: "NTSC-J"
 SLPM-66791:
@@ -45650,7 +45757,7 @@ SLPM-66803:
   region: "NTSC-J"
 SLPM-66804:
   name: カラフルアクアリウム〜My Little Mermaid〜 [初回限定版]
-  name-sort: からふるあくありうむ〜My Little Mermaid〜 [しょかいげんていばん]
+  name-sort: からふるあくありうむ〜My Little Mermaid〜 しょかいげんていばん
   name-en: "Colorful Aquarium - My Little Mermaid [Limited Edition]"
   region: "NTSC-J"
 SLPM-66805:
@@ -45696,16 +45803,16 @@ SLPM-66810:
   region: "NTSC-J"
 SLPM-66811:
   name: Winning Post 7 [KOEI The Best]
-  name-sort: Winning Post 7 [KOEI The Best]
+  name-sort: ういにんぐぽすと7 [KOEI The Best]
   name-en: "Winning Post 7 [Koei the Best]"
   region: "NTSC-J"
 SLPM-66812:
   name: ジーワンジョッキー4 [KOEI The Best]
   name-sort: じーわんじょっきー4 [KOEI The Best]
-  name-en: "GI Jockey 4 [Koei the Best]"
+  name-en: "G1 Jockey 4 [Koei the Best]"
   region: "NTSC-J"
 SLPM-66813:
-  name: 三國志IX [コーエー定番シリーズ]
+  name: コーエー定番シリーズ 三國志IX
   name-sort: さんごくしIX [こーえーていばんしりーず]
   name-en: "Sangokushi IX [Koei Selection]"
   region: "NTSC-J"
@@ -45721,8 +45828,8 @@ SLPM-66815:
   region: "NTSC-J"
 SLPM-66816:
   name: Chanter〜キミの歌がとどいたら#〜
-  name-sort: Chanter〜きみのうたがとどいたら#〜
-  name-en: "Chanter# - Kimi no Uta ga Todoitara"
+  name-sort: Chanter きみのうたがとどいたら
+  name-en: "Chanter - Kimi no Uta ga Todoitara#"
   region: "NTSC-J"
 SLPM-66817:
   name: Palais de Reine
@@ -45731,7 +45838,7 @@ SLPM-66817:
   region: "NTSC-J"
 SLPM-66818:
   name: クイズ&バラエティ すくすく犬福2 〜もっとすくすく〜
-  name-sort: くいず&ばらえてぃ すくすくいぬふく2 〜もっとすくすく〜
+  name-sort: くいず&ばらえてぃ すくすくいぬふく2 もっとすくすく
   name-en: "Quiz & Variety SukuSuku Inufuku 2 - Motto SukuSuku"
   region: "NTSC-J"
 SLPM-66819:
@@ -45745,7 +45852,7 @@ SLPM-66820:
   name-en: "Jissen Pachinko Hisshouhou! CR Sakura Taisen"
   region: "NTSC-J"
 SLPM-66821:
-  name: "Sengoku Musou 2 Mushoden"
+  name: "Sengoku Musou 2 Moushouden"
   region: "NTSC-J"
 SLPM-66822:
   name: GuitarFreaks & DrumMania V3
@@ -45754,18 +45861,18 @@ SLPM-66822:
   region: "NTSC-J"
 SLPM-66823:
   name: 高レート裏麻雀列伝 むこうぶち 〜御無礼、終了ですね〜
-  name-sort: こうれーとうらまーじゃんれつでん むこうぶち 〜ごぶれい、しゅうりょうですね〜
-  name-en: "Taka Reet Ura Mahjong Retsuden - Mukoubushi"
+  name-sort: こうれーとうらまーじゃんれつでん むこうぶち ごぶれいしゅうりょうですね
+  name-en: "Kou Rate Ura Mahjong Retsuden Mukoubuchi"
   region: "NTSC-J"
 SLPM-66824:
   name: 翡翠の雫 〜緋色の欠片2〜 [限定版]
   name-sort: ひすいのしずく 〜ひいろのかけら2〜 [げんていばん]
-  name-en: "Hiiro no Kakera 2 [Limited Edition]"
+  name-en: "Hisui no Shizuku - Hiiro no Kakera 2 [Limited Edition]"
   region: "NTSC-J"
 SLPM-66825:
   name: 翡翠の雫 〜緋色の欠片2〜
   name-sort: ひすいのしずく 〜ひいろのかけら2〜
-  name-en: "Hiiro no Kakera 2"
+  name-en: "Hisui no Shizuku - Hiiro no Kakera 2"
   region: "NTSC-J"
 SLPM-66826:
   name: 妖鬼姫伝 〜あやかし幻灯話〜 [限定版]
@@ -45779,7 +45886,7 @@ SLPM-66827:
   region: "NTSC-J"
 SLPM-66828:
   name: beatmania IIDX 13 DistorteD
-  name-sort: beatmania IIDX 13 DistorteD
+  name-sort: びーとまにあ つーでぃーえっくす 13 DistorteD
   name-en: "Beatmania IIDX 13 DistorteD"
   region: "NTSC-J"
 SLPM-66829:
@@ -45825,22 +45932,22 @@ SLPM-66838:
   region: "NTSC-J"
 SLPM-66839:
   name: We Are* BEST HIT セレクション
-  name-sort: We Are* BEST HIT せれくしょん
+  name-sort: We Are* BEST HIT せれくしょん]
   name-en: "We Are [Best Hit Selection]"
   region: "NTSC-J"
 SLPM-66840:
   name: 水の旋律2〜緋の記憶〜 BEST HIT セレクション
-  name-sort: みずのせんりつ2〜ひのきおく〜 BEST HIT せれくしょん
+  name-sort: みずのせんりつ2 ひのきおく [BEST HIT せれくしょん]
   name-en: "Mizu no Senritsu 2 [Best Hit Selection]"
   region: "NTSC-J"
 SLPM-66841:
   name: ウィル・オ・ウィスプ 限定版
-  name-sort: うぃる・お・うぃすぷ げんていばん
+  name-sort: うぃる お うぃすぷ [げんていばん]
   name-en: "Will O' Wisp [Limited Edition]"
   region: "NTSC-J"
 SLPM-66842:
   name: ウィル・オ・ウィスプ
-  name-sort: うぃる・お・うぃすぷ
+  name-sort: うぃる お うぃすぷ
   name-en: "Will O' Wisp"
   region: "NTSC-J"
 SLPM-66843:
@@ -45865,12 +45972,12 @@ SLPM-66846:
   region: "NTSC-J"
 SLPM-66847:
   name: アラビアンズ・ロスト〜The engagement on desert〜
-  name-sort: あらびあんず・ろすと〜The engagement on desert〜
+  name-sort: あらびあんず ろすと The engagement on desert
   name-en: "Arabians Lost - The Engagement on Desert"
   region: "NTSC-J"
 SLPM-66848:
   name: 戦国BASARA2 英雄外伝(HEROES)
-  name-sort: せんごくBASARA2 HEROES
+  name-sort: せんごくばさら2 HEROES
   name-en: "Sengoku Basara 2 Heroes"
   region: "NTSC-J"
 SLPM-66849:
@@ -45895,12 +46002,12 @@ SLPM-66851:
     halfPixelOffset: 1 # Removes blur due to misaligned fullscreen effect.
 SLPM-66852:
   name: カプコン クラシックス コレクション Best Price
-  name-sort: かぷこん くらしっくす これくしょん Best Price
+  name-sort: かぷこん くらしっくす これくしょん [Best Price]
   name-en: "Capcom Classics Collection [Best Price]"
   region: "NTSC-J"
 SLPM-66853:
   name: ジョジョの奇妙な冒険 黄金の旋風 Best Price
-  name-sort: じょじょのきみょうなぼうけん おうごんのせんぷう Best Price
+  name-sort: じょじょのきみょうなぼうけん おうごんのせんぷう [Best Price]
   name-en: "Jojo no Kimyouna Bouken - Ougon no Kaze [Best Price]"
   region: "NTSC-J"
   gsHWFixes:
@@ -45924,33 +46031,33 @@ SLPM-66856:
   region: "NTSC-J"
 SLPM-66857:
   name: いつか、届く、あの空に。 〜陽の道と緋の昏と〜 [初回限定版]
-  name-sort: いつか、とどく、あのそらに。 〜ようのみちとひのたそがれと〜 [しょかいげんていばん]
+  name-sort: いつかとどくあのそらに ようのみちとひのたそがれと しょかいげんていばん
   name-en: "Itsuka, Todoku, Ano Sora ni [Limited Edition]"
   region: "NTSC-J"
 SLPM-66858:
   name: いつか、届く、あの空に。 〜陽の道と緋の昏と〜 [通常版]
-  name-sort: いつか、とどく、あのそらに。 〜ようのみちとひのたそがれと〜 [つうじょうばん]
+  name-sort: いつかとどくあのそらに ようのみちとひのたそがれと [つうじょうばん]
   name-en: "Itsuka, Todoku, Ano Sora ni"
   region: "NTSC-J"
 SLPM-66859:
-  name: 戦国BASARA Best Prise
-  name-sort: せんごくBASARA Best Prise
+  name: 戦国BASARA Best Price
+  name-sort: せんごくばさら Best Price
   name-en: "Sengoku Basara [Best Price]"
   region: "NTSC-J"
 SLPM-66860:
   name: 熱帯低気圧少女 [初回限定版]
-  name-sort: ねったいていきあつしょうじょ [しょかいげんていばん]
-  name-en: "Nettai Teikiatsu Otome [Limited Edition]"
+  name-sort: ねったいていきあつしょうじょ しょかいげんていばん
+  name-en: "Nettai Teikiatsu Shoujo [Limited Edition]"
   region: "NTSC-J"
 SLPM-66861:
   name: 熱帯低気圧少女 [通常版]
   name-sort: ねったいていきあつしょうじょ [つうじょうばん]
-  name-en: "Nettai Teikiatsu Otome"
+  name-en: "Nettai Teikiatsu Shoujo"
   region: "NTSC-J"
 SLPM-66862:
   name: あやかしびとー幻妖異聞録ー [BestSelection]
-  name-sort: あやかしびとーげんよういぶんろくー [BestSelection]
-  name-en: "Ayaka Shibito [Best Selection]"
+  name-sort: あやかしびと げんよういぶんろく [BestSelection]
+  name-en: "Ayakashi Bito [Best Selection]"
   region: "NTSC-J"
 SLPM-66863:
   name: WWE2008 SmackDown vs Raw
@@ -45983,8 +46090,8 @@ SLPM-66868:
   name-en: "Tom Clancy's Splinter Cell - Double Agent [Ubisoft the Best]"
   region: "NTSC-J"
 SLPM-66869:
-  name: ニード・フォー・スピード カーボン [EA BEST HITS]
-  name-sort: にーど・ふぉー・すぴーど かーぼん [EA BEST HITS]
+  name: EA BEST HITS ニード・フォー・スピード カーボン
+  name-sort: にーど ふぉー すぴーど かーぼん [EA BEST HITS]
   name-en: "Need for Speed - Carbon [EA Best Hits]"
   region: "NTSC-J"
   clampModes:
@@ -46000,23 +46107,23 @@ SLPM-66870:
   region: "NTSC-J"
 SLPM-66871:
   name: 召喚少女-ElementalGirl Calling- [DXパック]
-  name-sort: しょうかんしょうじょ-ElementalGirl Calling- [DXぱっく]
+  name-sort: しょうかんしょうじょ ElementalGirl Calling [DXぱっく]
   name-en: "Shoukan Shoujo - Elemental Girl Calling [DX Pack]"
   region: "NTSC-J"
 SLPM-66872:
   name: 召喚少女-ElementalGirl Calling- [通常版]
-  name-sort: しょうかんしょうじょ-ElementalGirl Calling- [つうじょうばん]
+  name-sort: しょうかんしょうじょ ElementalGirl Calling [つうじょうばん]
   name-en: "Shoukan Shoujo - Elemental Girl Calling"
   region: "NTSC-J"
   compat: 5
 SLPM-66873:
   name: らき☆すた 〜陵桜学園 桜藤祭〜 DXパック
-  name-sort: らき☆すた 〜りょうおうがくえん おうとうさい〜 DXぱっく
+  name-sort: らきすた りょうおうがくえん おうとうさい DXぱっく
   name-en: "Lucky Star [DX Pack]"
   region: "NTSC-J"
 SLPM-66874:
   name: らき☆すた 〜陵桜学園 桜藤祭〜
-  name-sort: らき☆すた 〜りょうおうがくえん おうとうさい〜
+  name-sort: らきすた りょうおうがくえん おうとうさい
   name-en: "Lucky Star"
   region: "NTSC-J"
 SLPM-66875:
@@ -46026,12 +46133,12 @@ SLPM-66875:
   region: "NTSC-J"
 SLPM-66876:
   name: IZUMO2 -猛き剣の戦記- ベスト版
-  name-sort: IZUMO2 -もうきけんのせんき- べすとばん
+  name-sort: IZUMO2 もうきけんのせんき べすとばん
   name-en: "Izumo 2 [GN Software Best]"
   region: "NTSC-J"
 SLPM-66877:
-  name: _summer## アンダーバーサマーダブルシャープ ベスト版
-  name-sort: _summer## あんだーばーさまーだぶるしゃーぷ べすとばん
+  name: _summer## ベスト版
+  name-sort: あんだーばーさまーだぶるしゃーぷ [べすとばん]
   name-en: "_summer ## [GNsoftware Best]"
   region: "NTSC-J"
 SLPM-66878:
@@ -46041,7 +46148,7 @@ SLPM-66878:
   region: "NTSC-J"
 SLPM-66879:
   name: StarTRain -your past makes your future- [初回限定版]
-  name-sort: StarTRain -your past makes your future- [しょかいげんていばん]
+  name-sort: StarTRain -your past makes your future- しょかいげんていばん
   name-en: "StarTRain - Your Past Makes Your Future [Limited Edition]"
   region: "NTSC-J"
 SLPM-66880:
@@ -46063,12 +46170,12 @@ SLPM-66881:
     skipDrawEnd: 1 # Removes large black box around player car till we properly emulate it.
 SLPM-66882:
   name: はかれなはーと 〜君がために輝きを〜 [限定版・サントラボイスCD付]
-  name-sort: はかれなはーと 〜きみがためにかがやきを〜 [げんていばん・さんとらぼいすCDづけ]
+  name-sort: はかれなはーと きみがためにかがやきを [げんていばん さんとらぼいすCDつき]
   name-en: "Hakarena Heart [Limited Edition]"
   region: "NTSC-J"
 SLPM-66883:
   name: はかれなはーと 〜君がために輝きを〜
-  name-sort: はかれなはーと 〜きみがためにかがやきを〜
+  name-sort: はかれなはーと きみがためにかがやきを
   name-en: "Hakarena Heart"
   region: "NTSC-J"
 SLPM-66884:
@@ -46086,7 +46193,7 @@ SLPM-66885:
   region: "NTSC-J"
 SLPM-66886:
   name: ハリー・ポッターと不死鳥の騎士団
-  name-sort: はりー・ぽったーとふしちょうのきしだん
+  name-sort: はりーぽったーとふしちょうのきしだん
   name-en: "Harry Potter and the Order of the Phoenix"
   region: "NTSC-J"
   gsHWFixes:
@@ -46096,41 +46203,41 @@ SLPM-66886:
 SLPM-66887:
   name: 遙かなる時空の中で3 運命の迷宮 [KOEI The Best]
   name-sort: はるかなるときのなかで3 うんめいのめいきゅう [KOEI The Best]
-  name-en: "Harukanaru Jikuu no Kade 3 - Unmei no Meikyuu [Koei the Best]"
+  name-en: "Harukanaru Toki no Naka de 3 - Unmei no Meikyuu [Koei the Best]"
   region: "NTSC-J"
 SLPM-66888:
   name: ジーワン ジョッキー4 2007
   name-sort: じーわん じょっきー4 2007
-  name-en: "GI Jockey 4 - 2007"
+  name-en: "G1 Jockey 4 - 2007"
   region: "NTSC-J"
 SLPM-66889:
   name: ぷりサガ〜プリンセスをさがせ〜 初回限定版
-  name-sort: ぷりさが〜ぷりんせすをさがせ〜 しょかいげんていばん
+  name-sort: ぷりさが ぷりんせすをさがせ [しょかいげんていばん]
   name-en: "Puri-Saga! Princess o Sagase! [Limited Edition]"
   region: "NTSC-J"
 SLPM-66890:
   name: ぷりサガ〜プリンセスをさがせ〜
-  name-sort: ぷりさが〜ぷりんせすをさがせ〜
+  name-sort: ぷりさが ぷりんせすをさがせ
   name-en: "Puri-Saga! Princess o Sagase!"
   region: "NTSC-J"
 SLPM-66891:
   name: Myself;Yourself [初回限定版]
-  name-sort: Myself;Yourself [しょかいげんていばん]
+  name-sort: まいせるふ ゆあせるふ しょかいげんていばん
   name-en: "Myself, Yourself [Limited Edition]"
   region: "NTSC-J"
 SLPM-66892:
   name: Myself;Yourself
-  name-sort: Myself;Yourself
+  name-sort: まいせるふ ゆあせるふ
   name-en: "Myself, Yourself"
   region: "NTSC-J"
 SLPM-66893:
   name: ファイナルファンタジーXI ヴァナ・ディール コレクション [プレイオンライン]
-  name-sort: ふぁいなるふぁんたじーXI ゔぁな・でぃーる これくしょん [ぷれいおんらいん]
+  name-sort: ふぁいなるふぁんたじー11 ゔぁな・でぃーる これくしょん [ぷれいおんらいん]
   name-en: "Final Fantasy XI - Vana'diel Collection"
   region: "NTSC-J"
 SLPM-66894:
   name: ファイナルファンタジーXI アルタナの神兵 拡張データディスク
-  name-sort: ふぁいなるふぁんたじーXI あるたなのかみへい かくちょうでーたでぃすく
+  name-sort: ふぁいなるふぁんたじー11 あるたなのかみへい かくちょうでーたでぃすく
   name-en: "Final Fantasy XI - Wings of the Goddess"
   region: "NTSC-J"
 SLPM-66895:
@@ -46140,13 +46247,13 @@ SLPM-66895:
   region: "NTSC-J"
 SLPM-66896:
   name: Piaキャロットへようこそ！！G.O. 〜サマーフェア〜
-  name-sort: Piaきゃろっとへようこそ！！G.O. 〜さまーふぇあ〜
-  name-en: "Pia Carrot e Youkoso!! G.O. Summer Fair"
+  name-sort: ぴあきゃろっとへようこそ!! G.O. さまーふぇあ
+  name-en: "Pia Carrot he Youkoso!! G.O. Summer Fair"
   region: "NTSC-J"
 SLPM-66897:
   name: XYANIDE：ザイナイド
-  name-sort: XYANIDE：ざいないど
-  name-en: "Tales of the Abyss"
+  name-sort: ざいないど
+  name-en: "Xyanide"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
@@ -46163,8 +46270,8 @@ SLPM-66899:
   region: "NTSC-J"
 SLPM-66900:
   name: 星色のおくりもの
-  name-sort: ほししょくのおくりもの
-  name-en: "Kuri no Okurimono"
+  name-sort: ほしいろのおくりもの
+  name-en: "Hoshi Iro no Okurimono"
   region: "NTSC-J"
 SLPM-66901:
   name: 12RIVEN - the Ψcliminal of integral -
@@ -46177,27 +46284,27 @@ SLPM-66902:
   region: "NTSC-J"
 SLPM-66903:
   name: ジーワン ジョッキー4 2007 & Winning Post7 2007 プレミアムパック
-  name-sort: じーわん じょっきー4 2007 & Winning Post7 2007 ぷれみあむぱっく
-  name-en: "GI Jockey 4 - 2007 [with Winning Post 7 Maximum 2007 - Premium Pack]"
+  name-sort: じーわん じょっきー4 2007 & ういにんぐぽすと7 2007 ぷれみあむぱっく
+  name-en: "G1 Jockey 4 - 2007 [with Winning Post 7 Maximum 2007 - Premium Pack]"
   region: "NTSC-J"
 SLPM-66904:
-  name: "Winning Post 7 Maximum 2007 [with GI Jockey 4 - 2007 - Premium Pack]"
+  name: "Winning Post 7 Maximum 2007 [with G1 Jockey 4 - 2007 - Premium Pack]"
   region: "NTSC-J"
 SLPM-66905:
   name: D.C. 〜ダ・カーポ〜 the Origin
-  name-sort: D.C. 〜だ・かーぽ〜 the Origin
+  name-sort: だかーぽ the Origin
   name-en: "D.C. Da Capo The Origin"
   region: "NTSC-J"
   gsHWFixes:
     roundSprite: 2 # Reduces sprite artifacts like in the menu.
 SLPM-66906:
   name: アスミック得だねシリーズ　転生學園月光録
-  name-sort: あすみっくとくだねしりーず　てんしょうがくえんげっこうろく
+  name-sort: てんしょうがくえんげっこうろく [あすみっくとくだねしりーず]
   name-en: "Tenshou Gakuen Gekkouroku [Tokudane Price]"
   region: "NTSC-J"
 SLPM-66907:
   name: 許婚 [プリンセスソフト・コレクション]
-  name-sort: きょこん [ぷりんせすそふと・これくしょん]
+  name-sort: いいなずけ [ぷりんせすそふと・これくしょん]
   name-en: "Iinazuke [Princess Soft Collection]"
   region: "NTSC-J"
 SLPM-66908:
@@ -46207,8 +46314,8 @@ SLPM-66908:
   region: "NTSC-J"
 SLPM-66909:
   name: 神曲奏界ポリフォニカ　３＆４話完結編
-  name-sort: しんきょくそうかいぽりふぉにか　３＆４わかんけつへん
-  name-en: "Shinkyoku Soukai Polyphonica 3&4 Hanashi Kanketsuhen"
+  name-sort: しんきょくそうかいぽりふぉにか 3&4わかんけつへん
+  name-en: "Shinkyoku Soukai Polyphonica Episode 3&4 Kanketsuhen"
   region: "NTSC-J"
 SLPM-66910:
   name: スタントマン:イグニッション
@@ -46226,18 +46333,18 @@ SLPM-66911:
   region: "NTSC-J"
 SLPM-66912:
   name: ひぐらしのなく頃に祭　カケラ遊び　アペンド版
-  name-sort: ひぐらしのなくころにまつり　かけらあそび　あぺんどばん
+  name-sort: ひぐらしのなくころにまつり かけらあそび あぺんどばん
   name-en: "Higurashi no Naku Koro ni Matsuri - Kakera Asobi [Append Version]"
   region: "NTSC-J"
 SLPM-66913:
   name: ひぐらしのなく頃に祭　カケラ遊び
-  name-sort: ひぐらしのなくころにまつり　かけらあそび
+  name-sort: ひぐらしのなくころにまつり かけらあそび
   name-en: "Higurashi no Naku Koro ni Matsuri - Kakera Asobi"
   region: "NTSC-J"
 SLPM-66914:
   name: 放課後は白銀の調べ
   name-sort: ほうかごははくぎんのしらべ
-  name-en: "Houkago wa Hakugin no Shirabe"
+  name-en: "Houkago ha Hakugin no Shirabe"
   region: "NTSC-J"
 SLPM-66915:
   name: 遊戯王GX タッグフォース エヴォリューション
@@ -46251,7 +46358,7 @@ SLPM-66916:
   region: "NTSC-J"
 SLPM-66917:
   name: Grand Theft Auto:Vice City Stories
-  name-sort: Grand Theft Auto:Vice City Stories
+  name-sort: ぐらんどせふとおーと ばいすしてぃ すとーりーず
   name-en: "Grand Theft Auto - Vice City Stories"
   region: "NTSC-J"
   gsHWFixes:
@@ -46270,7 +46377,7 @@ SLPM-66919:
     beforeDraw: "OI_PointListPalette"
 SLPM-66920:
   name: ほしフル〜星の降る街〜
-  name-sort: ほしふる〜ほしのふるまち〜
+  name-sort: ほしふる ほしのふるまち
   name-en: "Hoshi Furu"
   region: "NTSC-J"
 SLPM-66921:
@@ -46280,19 +46387,23 @@ SLPM-66921:
   region: "NTSC-J"
 SLPM-66922:
   name: D.C.II P.S. 〜ダ・カーポII〜 プラスシチュエーション DXパック
-  name-sort: D.C.II P.S. 〜だ・かーぽII〜 ぷらすしちゅえーしょん DXぱっく
+  name-sort: だかーぽ2 ぷらすしちゅえーしょん DXぱっく
   name-en: "D.C.II P.S. - Da Capo II - Plus Situation [DX Pack]"
   region: "NTSC-J"
 SLPM-66923:
-  name: "D.C.II P.S. - Da Capo II - Plus Situation [Disc 2] [DX Pack]"
+  name: D.C.II P.S. 〜ダ・カーポII〜 プラスシチュエーション DXパック [ディスク2]
+  name-sort: だかーぽ2 ぷらすしちゅえーしょん DXぱっく
+  name-en: "D.C.II P.S. - Da Capo II - Plus Situation [DX Pack] [ディスク2]"
   region: "NTSC-J"
 SLPM-66924:
   name: D.C.II P.S. 〜ダ・カーポII〜 プラスシチュエーション
-  name-sort: D.C.II P.S. 〜だ・かーぽII〜 ぷらすしちゅえーしょん
+  name-sort: だかーぽ2 ぷらすしちゅえーしょん
   name-en: "D.C.II P.S. - Da Capo II - Plus Situation"
   region: "NTSC-J"
 SLPM-66925:
-  name: "D.C.II P.S. - Da Capo II - Plus Situation (Disc 2)"
+  name: D.C.II P.S. 〜ダ・カーポII〜 プラスシチュエーション [ディスク2]
+  name-sort: だかーぽ2 ぷらすしちゅえーしょん
+  name-en: "D.C.II P.S. - Da Capo II - Plus Situation [Disc 2]"
   region: "NTSC-J"
 SLPM-66926:
   name: NiGHTS into Dreams...
@@ -46313,7 +46424,7 @@ SLPM-66928:
   region: "NTSC-J"
 SLPM-66929:
   name: エルミナージュ 〜闇の巫女と神々の指輪〜
-  name-sort: えるみなーじゅ 〜やみのみことかみ々のゆびわ〜
+  name-sort: えるみなーじゅ やみのみことかみがみのゆびわ
   name-en: "Elminage - Yami no Fujo to Kamigami no Yubiwa"
   region: "NTSC-J"
 SLPM-66930:
@@ -46326,25 +46437,25 @@ SLPM-66931:
   region: "NTSC-J"
 SLPM-66932:
   name: ニード・フォー・スピード　プロストリート
-  name-sort: にーど・ふぉー・すぴーど　ぷろすとりーと
+  name-sort: にーど ふぉー すぴーど ぷろすとりーと
   name-en: "Need for Speed - ProStreet"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth line.
 SLPM-66933:
   name: 君が主で執事が俺で〜お仕え日記〜 初回限定版
-  name-sort: きみがおもでしつじがおれで〜おつかえにっき〜 しょかいげんていばん
+  name-sort: きみがあるじでしつじがおれで おつかえにっき しょかいげんていばん
   name-en: "Kimi ga Aruji de Shitsuji ga Ore de - Oshie Nikki [Limited Edition]"
   region: "NTSC-J"
 SLPM-66934:
   name: 君が主で執事が俺で〜お仕え日記〜
-  name-sort: きみがおもでしつじがおれで〜おつかえにっき〜
+  name-sort: きみがあるじでしつじがおれで おつかえにっき
   name-en: "Kimi ga Aruji de Shitsuji ga Ore de - Oshie Nikki"
   region: "NTSC-J"
 SLPM-66935:
   name: true tears〜トゥルーティアーズ〜
-  name-sort: true tears〜とぅるーてぃあーず〜
-  name-en: "True Tears"
+  name-sort: とぅるーてぃあーず
+  name-en: "true tears"
   region: "NTSC-J"
 SLPM-66936:
   name: ナイトウィザード The VIDEO GAME 〜Denial of the World〜
@@ -46353,17 +46464,17 @@ SLPM-66936:
   region: "NTSC-J"
 SLPM-66937:
   name: 雀・三國無双 [KOEI The Best]
-  name-sort: じゃん・さんごくむそう [KOEI The Best]
+  name-sort: じゃんさんごくむそう [KOEI The Best]
   name-en: "Jan Sangoku Musou [Koei the Best]"
   region: "NTSC-J"
 SLPM-66938:
-  name: アンジェリークエトワール [コーエー定番シリーズ]
+  name: コーエー定番シリーズ アンジェリークエトワール
   name-sort: あんじぇりーくえとわーる [こーえーていばんしりーず]
   name-en: "Angelique Etoile [Koei Selection]"
   region: "NTSC-J"
 SLPM-66939:
-  name: 亡国のイージス2035　〜ウォーシップガンナー〜 [コーエー定番シリーズ]
-  name-sort: ぼうこくのいーじす2035　〜うぉーしっぷがんなー〜 [こーえーていばんしりーず]
+  name: コーエー定番シリーズ 亡国のイージス2035　〜ウォーシップガンナー〜
+  name-sort: ぼうこくのいーじす2035 うぉーしっぷがんなー [こーえーていばんしりーず]
   name-en: "Boukoku no Aegis 2035 - Warship Gunner [Koei Selection]"
   region: "NTSC-J"
 SLPM-66940:
@@ -46378,17 +46489,17 @@ SLPM-66941:
   region: "NTSC-J"
 SLPM-66942:
   name: Φ(ふぁい)なる・あぷろーち 2 〜1st priority〜 ＜初回限定版＞
-  name-sort: ふぁいなる・あぷろーち 2 〜1st priority〜 ＜しょかいげんていばん＞
+  name-sort: ふぁいなる・あぷろーち2 〜1st priority〜 ＜しょかいげんていばん＞
   name-en: "Final Approach 2 - 1st Priority [First Print Limited Edition]"
   region: "NTSC-J"
 SLPM-66943:
   name: Φ(ふぁい)なる・あぷろーち 2 〜1st priority〜
-  name-sort: ふぁいなる・あぷろーち 2 〜1st priority〜
+  name-sort: ふぁいなる・あぷろーち2 〜1st priority〜
   name-en: "Final Approach 2 - 1st Priority"
   region: "NTSC-J"
 SLPM-66944:
   name: プティフール 限定版
-  name-sort: ぷてぃふーる げんていばん
+  name-sort: ぷてぃふーる [げんていばん]
   name-en: "Petit Four [Limited Edition]"
   region: "NTSC-J"
 SLPM-66945:
@@ -46397,7 +46508,7 @@ SLPM-66945:
   name-en: "Petit Four"
   region: "NTSC-J"
 SLPM-66946:
-  name: NBAライブ 07 [EA BEST HITS]
+  name: EA BEST HITS NBAライブ 07
   name-sort: NBAらいぶ 07 [EA BEST HITS]
   name-en: "NBA Live '07 [EA Best Hits]"
   region: "NTSC-J"
@@ -46406,26 +46517,28 @@ SLPM-66946:
     cpuSpriteRenderLevel: 2 # Needed for above.
 SLPM-66947:
   name: 信長の野望・革新 with パワーアップキット
-  name-sort: のぶながのやぼう・かくしん with ぱわーあっぷきっと
+  name-sort: のぶながのやぼう かくしん with ぱわーあっぷきっと
   name-en: "Nobunaga no Yabou - Kakushin [with Power-Up Kit]"
   region: "NTSC-J"
 SLPM-66948:
   name: 信長の野望・革新 with パワーアップキット ＆ 三國志11 with パワーアップキット ツインパック
-  name-sort: のぶながのやぼう・かくしん with ぱわーあっぷきっと ＆ さんごくし11 with ぱわーあっぷきっと ついんぱっく
+  name-sort: のぶながのやぼう かくしん with ぱわーあっぷきっと & さんごくし11 with ぱわーあっぷきっと ついんぱっく
   name-en: "Nobunaga no Yabou - Kakushin [with Power-Up Kit and Sangokushi XI]"
   region: "NTSC-J"
 SLPM-66950:
   name: ウイニングポスト７ マキシマム2008
-  name-sort: ういにんぐぽすとなな まきしまむ2008
+  name-sort: ういにんぐぽすと7 まきしまむ2008
   name-en: "Winning Post 7 Maximum 2008"
   region: "NTSC-J"
 SLPM-66951:
-  name: "Harukanaru Toki no Naka de 4"
+  name: 遙かなる時空の中で4 プレミアムBOX
+  name-sort: はるかなるときのなかで4 [ぷれみあむBOX]
+  name-en: "Harukanaru Toki no Naka de 4"
   region: "NTSC-J"
 SLPM-66952:
   name: 遙かなる時空の中で4
   name-sort: はるかなるときのなかで4
-  name-en: "Harukanaru Jikuu no Kade 4"
+  name-en: "Harukanaru Toki no Naka de 4"
   region: "NTSC-J"
 SLPM-66953:
   name: 無双OROCHI 魔王再臨
@@ -46434,7 +46547,7 @@ SLPM-66953:
   region: "NTSC-J"
 SLPM-66954:
   name: 信長の野望 Online 争覇の章
-  name-sort: のぶながのやぼう Online そうはのしょう
+  name-sort: のぶながのやぼう おんらいん そうはのしょう
   name-en: "Nobunaga no Yabou - Online - Souha no Shou"
   region: "NTSC-J"
 SLPM-66956:
@@ -46444,7 +46557,7 @@ SLPM-66956:
   region: "NTSC-J"
 SLPM-66957:
   name: Broccoli Best Quality 新世紀エヴァンゲリオン バトルオーケストラ
-  name-sort: Broccoli Best Quality しんせいきえゔぁんげりおん ばとるおーけすとら
+  name-sort: しんせいきえゔぁんげりおん ばとるおーけすとら [Broccoli Best Quality]
   name-en: "Neon Genesis Evangelion - Battle Orchestra [Broccoli Best Quality]"
   region: "NTSC-J"
 SLPM-66958:
@@ -46459,7 +46572,7 @@ SLPM-66959:
   region: "NTSC-J"
 SLPM-66960:
   name: EA:SY!1980 ニード・フォー・スピード アンダーグラウンド 2 車道
-  name-sort: EA:SY!1980 にーど・ふぉー・すぴーど あんだーぐらうんど 2 しゃどう
+  name-sort: にーど ふぉー すぴーど あんだーぐらうんど 2 しゃどう [EA:SY!1980]
   name-en: "Need for Speed - Underground 2 [EA-SY! 1980]"
   region: "NTSC-J"
   gsHWFixes:
@@ -46467,7 +46580,7 @@ SLPM-66960:
     halfPixelOffset: 2 # Fixes depth lines.
 SLPM-66961:
   name: EA:SY!1980 BLACK
-  name-sort: EA:SY!1980 BLACK
+  name-sort: BLACK [EA:SY!1980]
   name-en: "Black [EA-SY! 1980]"
   region: "NTSC-J"
   clampModes:
@@ -46482,7 +46595,7 @@ SLPM-66961:
     beforeDraw: "OI_BurnoutGames"
 SLPM-66962:
   name: EA:SY!1980 バーンアウト 3 テイクダウン
-  name-sort: EA:SY!1980 ばーんあうと 3 ていくだうん
+  name-sort: ばーんあうと 3 ていくだうん [EA:SY!1980]
   name-en: "Burnout 3 - Takedown [EA-SY! 1980]"
   region: "NTSC-J"
   clampModes:
@@ -46499,23 +46612,23 @@ SLPM-66962:
     beforeDraw: "OI_BurnoutGames"
 SLPM-66963:
   name: EA:SY!1980 MEDAL OF HONOR 史上最大の作戦
-  name-sort: EA:SY!1980 MEDAL OF HONOR しじょうさいだいのさくせん
+  name-sort: MEDAL OF HONOR しじょうさいだいのさくせん [EA:SY!1980]
   name-en: "Medal of Honor - Frontline [EA-SY! 1980]"
   region: "NTSC-J"
 SLPM-66964:
   name: GUILTY GEAR XX Λ CORE PLUS アペンド版
-  name-sort: GUILTY GEAR XX Λ CORE PLUS あぺんどばん
+  name-sort: ぎるてぃぎあ いぐぜくす あくせんと こあ ぷらす あぺんどばん
   name-en: "Guilty Gear XX - Accent Core Plus [Append Edition]"
   region: "NTSC-J"
 SLPM-66965:
   name: GUILTY GEAR XX Λ CORE PLUS
-  name-sort: GUILTY GEAR XX Λ CORE PLUS
+  name-sort: ぎるてぃぎあ いぐぜくす あくせんと こあ ぷらす
   name-en: "Guilty Gear XX - Accent Core Plus"
   region: "NTSC-J"
   compat: 5
 SLPM-66966:
   name: EA:SY!1980 ゴッドファーザー
-  name-sort: EA:SY!1980 ごっどふぁーざー
+  name-sort: ごっどふぁーざー [EA:SY!1980]
   name-en: "Godfather, The [EA-SY! 1980]"
   region: "NTSC-J"
   gsHWFixes:
@@ -46525,12 +46638,12 @@ SLPM-66966:
     halfPixelOffset: 2 # Fixes center line in post processing.
 SLPM-66967:
   name: ARIA the NATURAL 〜遠い記憶のミラージュ〜 アルケベスト
-  name-sort: ARIA the NATURAL 〜とおいきおくのみらーじゅ〜 あるけべすと
+  name-sort: ありあ ざ なちゅらる とおいきおくのみらーじゅ あるけべすと
   name-en: "Aria - The Natural - Tooi Yume no Mirage [Alchemist Best Collection]"
   region: "NTSC-J"
 SLPM-66968:
   name: ACQUIRE THE BEST 神業
-  name-sort: ACQUIRE THE BEST かみわざ
+  name-sort: かみわざ [ACQUIRE THE BEST]
   name-en: "Kamiwaza [Acquire the Best]"
   region: "NTSC-J"
 SLPM-66969:
@@ -46540,16 +46653,16 @@ SLPM-66969:
   region: "NTSC-J"
 SLPM-66970:
   name: プロ野球スピリッツ５
-  name-sort: ぷろやきゅうすぴりっつご
+  name-sort: ぷろやきゅうすぴりっつ5
   name-en: "Pro Yakyuu Spirits 5"
   region: "NTSC-J"
 SLPM-66971:
-  name: 三國志IX with パワーアップキット [コーエー定番シリーズ]
+  name: コーエー定番シリーズ 三國志IX with パワーアップキット
   name-sort: さんごくしIX with ぱわーあっぷきっと [こーえーていばんしりーず]
   name-en: "Sangokushi IX [with Power-Up Kit] [Koei Selection]"
   region: "NTSC-J"
 SLPM-66972:
-  name: 鋼鉄の咆哮2 ウォーシップコマンダー [コーエー定番シリーズ]
+  name: コーエー定番シリーズ 鋼鉄の咆哮2 ウォーシップコマンダー
   name-sort: くろがねのほうこう2 うぉーしっぷこまんだー [こーえーていばんしりーず]
   name-en: "Kurogane no Houkou 2 - Warship Commander [Koei Selection]"
   region: "NTSC-J"
@@ -46572,7 +46685,7 @@ SLPM-66976:
 SLPM-66977:
   name: 神曲奏界ポリフォニカ 0〜4話フルパック
   name-sort: しんきょくそうかいぽりふぉにか 0〜4わふるぱっく
-  name-en: "Shinkyoku Soukai Polyphonica 0-4 Hanashi Full Pack"
+  name-en: "Shinkyoku Soukai Polyphonica Story 0-4 Full Pack"
   region: "NTSC-J"
 SLPM-66978:
   name: ペルソナ4
@@ -46584,17 +46697,21 @@ SLPM-66980:
   name: "Gin no Eclipse"
   region: "NTSC-J"
 SLPM-66981:
-  name: "Clannad"
+  name: "CLANNAD 新版"
+  name-sort: "くらなど しんばん"
+  name-en: "Clannad [New Edition]"
   region: "NTSC-J"
 SLPM-66982:
-  name: "Air"
+  name: "AIR ベスト版"
+  name-sort: "えあー べすとばん"
+  name-en: "AIR [Best]"
   region: "NTSC-J"
 SLPM-66984:
   name: "Gakuen Heaven - Boy's Love Scramble!"
   region: "NTSC-J"
 SLPM-66987:
   name: 九龍妖魔学園紀 再装填(re:charge) アトラスベストコレクション
-  name-sort: くうろんようまがくえんき さいそうてん(re:charge) あとらすべすとこれくしょん
+  name-sort: くうろんようまがくえんき りちゃーじ [あとらすべすとこれくしょん]
   name-en: "Kowloon Youma Gakuen Ki [Best Version]"
   region: "NTSC-J"
 SLPM-66988:
@@ -46607,8 +46724,8 @@ SLPM-66989:
   region: "NTSC-J"
 SLPM-66990:
   name: 魔女っ娘ア・ラ・モードII 〜魔法と剣のストラグル〜 ベスト版
-  name-sort: まじょっこあ・ら・もーどII 〜まほうとけんのすとらぐる〜 べすとばん
-  name-en: "Majo-musume A La Mode II [Best Version]"
+  name-sort: まじょっこあらもーど2 まほうとけんのすとらぐる べすとばん
+  name-en: "Majo-kko A La Mode II [Best Version]"
   region: "NTSC-J"
   gsHWFixes:
     beforeDraw: "OI_PointListPalette"
@@ -46619,7 +46736,7 @@ SLPM-66991:
   region: "NTSC-J"
 SLPM-66992:
   name: 風雨来記２ nice price！
-  name-sort: ふううらいきに nice price！
+  name-sort: ふううらいき2 nice price！
   name-en: "Fuuuraiki 2 [Best Version]"
   region: "NTSC-J"
 SLPM-66993:
@@ -46643,16 +46760,16 @@ SLPM-66995:
 SLPM-66996:
   name: 終末少女幻想アリスマチック 〜Apocalypse〜 初回限定版
   name-sort: しゅうまつしょうじょげんそうありすまちっく 〜Apocalypse〜 しょかいげんていばん
-  name-en: "Shuumatsu Otome Gensou Alicematic Apocalypse [Limited Edition]"
+  name-en: "Shuumatsu Shoujo Gensou Alicematic Apocalypse [Limited Edition]"
   region: "NTSC-J"
 SLPM-66997:
   name: 終末少女幻想アリスマチック 〜Apocalypse〜
   name-sort: しゅうまつしょうじょげんそうありすまちっく 〜Apocalypse〜
-  name-en: "Shuumatsu Otome Gensou Alicematic Apocalypse"
+  name-en: "Shuumatsu Shoujo Gensou Alicematic Apocalypse"
   region: "NTSC-J"
 SLPM-66998:
   name: ふしぎ遊戯 朱雀異聞 限定版
-  name-sort: ふしぎゆうぎ すざくいぶん げんていばん
+  name-sort: ふしぎゆうぎ すざくいぶん [げんていばん]
   name-en: "Fushigi Yuugi - Suzaku Ibun [Limited Edition]"
   region: "NTSC-J"
 SLPM-66999:
@@ -46682,7 +46799,7 @@ SLPM-67002:
 SLPM-67003:
   name: サクラ大戦 〜熱き血潮に〜
   name-sort: さくらたいせん 〜あつきちしおに〜
-  name-en: "Sakura Taisen - Atsuki Chishioni"
+  name-en: "Sakura Taisen - Atsuki Chishio ni"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
@@ -46694,7 +46811,7 @@ SLPM-67004:
   region: "NTSC-J"
 SLPM-67005:
   name: ロード・オブ・ザ・リング / 王の帰還
-  name-sort: ろーど・おぶ・ざ・りんぐ / おうのきかん
+  name-sort: ろーど おぶ ざ りんぐ / おうのきかん
   name-en: "Lord of the Rings, The - The Two Towers [EA Best Hits]"
   region: "NTSC-J"
   gsHWFixes:
@@ -46708,8 +46825,8 @@ SLPM-67006:
   region: "NTSC-J"
 SLPM-67007:
   name: Train Simulator 京成・都営浅草・京急線
-  name-sort: Train Simulator けいせい・とえいあさくさ・きょうきゅうせん
-  name-en: "Train Simulator - Keisei Toei Keikyu"
+  name-sort: Train Simulator けいせい・とえいあさくさ・けいきゅうせん
+  name-en: "Train Simulator - Keisei Toei Asakusa Keikyu Line"
   region: "NTSC-J"
 SLPM-67008:
   name: METAL GEAR SOLID 2 SUBSTANCE コナミ殿堂セレクション
@@ -46994,7 +47111,7 @@ SLPM-68014:
   region: "NTSC-J"
 SLPM-68016:
   name: ダージュ・オブ・ケルベロス -ファイナルファンタジーVII-
-  name-sort: だーじゅ・おぶ・けるべろす -ふぁいなるふぁんたじーVII-
+  name-sort: だーじゅ・おぶ・けるべろす ふぁいなるふぁんたじー7
   name-en: "Dirge of Cerberus - Final Fantasy VII Beta Version"
   region: "NTSC-J"
   gsHWFixes:
@@ -47081,7 +47198,7 @@ SLPM-68520:
     halfPixelOffset: 2 # Corrects shadow alignment and reduces blurriness.
     recommendedBlendingLevel: 3 # Fixes level and map menu brightness.
 SLPM-68521:
-  name: "dot hack - frägment [Senkou Release-ban]"
+  name: ".hack frägment [Senkou Release-ban]"
   region: "NTSC-J"
 SLPM-68523:
   name: "Phantasy Star Universe (Premiere Disc)"
@@ -47105,81 +47222,81 @@ SLPM-69006:
   name: "PictureParadise Club Vol. 2"
   region: "NTSC-J"
 SLPM-74001:
-  name: ガングリフォンブレイズ PS2 the Best
-  name-sort: がんぐりふぉんぶれいず PS2 the Best
-  name-en: "Gungriffon Blaze [PS2 The Best]"
+  name: ガングリフォンブレイズ PlayStation 2 the Best
+  name-sort: がんぐりふぉんぶれいず PlayStation 2 the Best
+  name-en: "Gungriffon Blaze [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPM-74002:
-  name: 真・三國無双 PS2 the Best
-  name-sort: しん・さんごくむそう PS2 the Best
-  name-en: "Shin Sangoku Musou [PS2 The Best]"
+  name: 真・三國無双 PlayStation 2 the Best
+  name-sort: しんさんごくむそう PlayStation 2 the Best
+  name-en: "Shin Sangoku Musou [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPM-74003:
-  name: クラッシュ・バンディクー4 さくれつ!魔神パワー PS2 the Best
-  name-sort: くらっしゅ・ばんでぃくー4 さくれつ!まじんぱわー PS2 the Best
-  name-en: "Crash Bandicoot 4 - Sakuretsu! Majin Power! [PS2 The Best]"
+  name: クラッシュ・バンディクー4 さくれつ!魔神パワー PlayStation 2 the Best
+  name-sort: くらっしゅばんでぃくー4 さくれつ!まじんぱわー PlayStation 2 the Best
+  name-en: "Crash Bandicoot 4 - Sakuretsu! Majin Power [PlayStation 2 the Best]"
   region: "NTSC-J"
   gsHWFixes:
     nativePaletteDraw: 1
     autoFlush: 2 # Fixes refraction effect.
 SLPM-74004:
-  name: マキシモ PS2 the Best
-  name-sort: まきしも PS2 the Best
-  name-en: "Maximo - Ghosts to Glory [PS2 The Best]"
+  name: マキシモ PlayStation 2 the Best
+  name-sort: まきしも PlayStation 2 the Best
+  name-en: "Maximo - Ghosts to Glory [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPM-74005:
-  name: "Romance of the Three Kingdoms VII [PS2 The Best]"
+  name: "Romance of the Three Kingdoms VII [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPM-74006:
-  name: Rez PS2 the Best
-  name-sort: Rez PS2 the Best
-  name-en: "Rez [PS2 The Best]"
+  name: Rez PlayStation 2 the Best
+  name-sort: れず PlayStation 2 the Best
+  name-en: "Rez [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPM-74007:
-  name: BUSIN〜Wizardry Alternative〜 PS2 the Best
-  name-sort: BUSIN〜Wizardry Alternative〜 PS2 the Best
-  name-en: "Busin - Wizardry Alternative [PS2 The Best]"
+  name: BUSIN〜Wizardry Alternative〜 PlayStation 2 the Best
+  name-sort: BUSIN〜Wizardry Alternative〜 PlayStation 2 the Best
+  name-en: "Busin - Wizardry Alternative [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPM-74044:
-  name: "Space Channel 5 - Part 2 [PS2 The Best]"
+  name: "Space Channel 5 - Part 2 [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPM-74101:
-  name: ボンバーマンランド2 PS2 the Best
-  name-sort: ぼんばーまんらんど2 PS2 the Best
-  name-en: "Bomberman Land 2 [PS2 The Best]"
+  name: ボンバーマンランド2 PlayStation 2 the Best
+  name-sort: ぼんばーまんらんど2 PlayStation 2 the Best
+  name-en: "Bomberman Land 2 [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPM-74102:
-  name: 桃太郎電鉄12 西日本編もありまっせー! PS2 the Best
-  name-sort: ももたろうでんてつ12 にしにほんへんもありまっせー! PS2 the Best
-  name-en: "Momotaro Densetsu 12 [PS2 The Best]"
+  name: 桃太郎電鉄12 西日本編もありまっせー! PlayStation 2 the Best
+  name-sort: ももたろうでんてつ12 にしにほんへんもありまっせー! PlayStation 2 the Best
+  name-en: "Momotarou Dentetsu 12 [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPM-74103:
-  name: 桃太郎電鉄USA PS2 the Best
-  name-sort: ももたろうでんてつUSA PS2 the Best
-  name-en: "Momotaro Dentetsu USA [PS2 The Best]"
+  name: 桃太郎電鉄USA PlayStation 2 the Best
+  name-sort: ももたろうでんてつUSA PlayStation 2 the Best
+  name-en: "Momotarou Dentetsu USA [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPM-74104:
-  name: 桃太郎電鉄15 PS2 the Best
-  name-sort: ももたろうでんてつ15 PS2 the Best
-  name-en: "Momotarou Densetsu 15 [PS2 The Best]"
+  name: 桃太郎電鉄15 PlayStation 2 the Best
+  name-sort: ももたろうでんてつ15 PlayStation 2 the Best
+  name-en: "Momotarou Dentetsu 15 [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPM-74105:
   name: "Momotarou Dentetsu 16 - Hokkaido Daiidou no Maki!"
   region: "NTSC-J"
 SLPM-74201:
-  name: バイオハザード アウトブレイク PS2 the Best
-  name-sort: ばいおはざーど あうとぶれいく PS2 the Best
-  name-en: "BioHazard Outbreak [PS2 The Best]"
+  name: バイオハザード アウトブレイク PlayStation 2 the Best
+  name-sort: ばいおはざーど あうとぶれいく PlayStation 2 the Best
+  name-en: "BioHazard Outbreak [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPM-74202:
-  name: 風雲 新撰組 PS2 the Best
-  name-sort: ふううん しんせんぐみ PS2 the Best
-  name-en: "Fuuun Shinsengumi [PS2 The Best]"
+  name: 風雲 新撰組 PlayStation 2 the Best
+  name-sort: ふううん しんせんぐみ PlayStation 2 the Best
+  name-en: "Fuuun Shinsengumi [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPM-74204:
-  name: 首都高バトル 01 PS2 the Best
-  name-sort: しゅとこうばとる 01 PS2 the Best
-  name-en: "Shutokou Battle 01 [PS2 The Best]"
+  name: 首都高バトル 01 PlayStation 2 the Best
+  name-sort: しゅとこうばとる 01 PlayStation 2 the Best
+  name-en: "Shutokou Battle 01 [PlayStation 2 the Best]"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
@@ -47187,9 +47304,9 @@ SLPM-74204:
     wildArmsHack: 1 # Improves visual clarity whilst upscaling.
     roundSprite: 1 # Reduces graphics garbage on UI whilst upscaling.
 SLPM-74205:
-  name: 真・女神転生 III - NOCTURNE PS2 the Best
-  name-sort: しん・めがみてんせい III - NOCTURNE PS2 the Best
-  name-en: "Shin Megami Tensei III - Nocturne [PS2 The Best]"
+  name: 真・女神転生 III - NOCTURNE PlayStation 2 the Best
+  name-sort: しんめがみてんせい3 - NOCTURNE PlayStation 2 the Best
+  name-en: "Shin Megami Tensei III - Nocturne [PlayStation 2 the Best]"
   region: "NTSC-J"
   roundModes:
     eeRoundMode: 0 # Ladder glitch in "Assembly of Nihilo B11" level.
@@ -47197,37 +47314,37 @@ SLPM-74205:
     mipmap: 2 # Mipmap + trilinear, fixes missing lights to match sw renderer.
     trilinearFiltering: 1
 SLPM-74206:
-  name: 鬼武者 PS2 the Best
-  name-sort: おにむしゃ PS2 the Best
-  name-en: "Onimusha [PS2 The Best]"
+  name: 鬼武者 PlayStation 2 the Best
+  name-sort: おにむしゃ PlayStation 2 the Best
+  name-en: "Onimusha [PlayStation 2 the Best]"
   region: "NTSC-J"
   gsHWFixes:
     texturePreloading: 1 # Performs much better with partial preload.
   gameFixes:
     - SoftwareRendererFMVHack # Fixes FMVs.
 SLPM-74208:
-  name: 天外魔境II MANJI MARU PS2 the Best
-  name-sort: てんがいまきょうII MANJI MARU PS2 the Best
-  name-en: "Tengai Makyou 2 - Manjimaru [PS2 The Best]"
+  name: 天外魔境II MANJI MARU PlayStation 2 the Best
+  name-sort: てんがいまきょう2 MANJI MARU PlayStation 2 the Best
+  name-en: "Tengai Makyou 2 - Manjimaru [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPM-74209:
-  name: 侍道2 決闘版 PS2 the Best
-  name-sort: さむらいどう2 けっとうばん PS2 the Best
-  name-en: "Samurai Michi 2 [PS2 The Best]"
+  name: 侍道2 決闘版 PlayStation 2 the Best
+  name-sort: さむらいどう2 けっとうばん PlayStation 2 the Best
+  name-en: "Samurai Michi 2 [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPM-74210:
-  name: ぷよぷよフィーバー お買い得版 PS2 the Best
-  name-sort: ぷよぷよふぃーばー おかいどくばん PS2 the Best
-  name-en: "Puyo Puyo Fever [PS2 The Best]"
+  name: ぷよぷよフィーバー お買い得版 PlayStation 2 the Best
+  name-sort: ぷよぷよふぃーばー おかいどくばん PlayStation 2 the Best
+  name-en: "Puyo Puyo Fever [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPM-74211:
-  name: 首都高バトル 0 PS2 The Best
-  name-sort: しゅとこうばとる 0 PS2 The Best
-  name-en: "Shutokou Battle 0 [PS2 The Best]"
+  name: 首都高バトル 0 PlayStation 2 the Best
+  name-sort: しゅとこうばとる 0 PlayStation 2 the Best
+  name-en: "Shutokou Battle 0 [PlayStation 2 the Best]"
   region: "NTSC-J"
   compat: 5
 SLPM-74212:
-  name: "Sengoku Musou [PS2 The Best]"
+  name: "Sengoku Musou [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPM-74213:
   name: "Gensou Suikoden IV"
@@ -47236,37 +47353,37 @@ SLPM-74214:
   name: "Densha de Go! Final"
   region: "NTSC-J"
 SLPM-74215:
-  name: 真・三國無双3 PS2 the Best
-  name-sort: しん・さんごくむそう3 PS2 the Best
-  name-en: "Shin Sangoku Musou 3 [PS2 The Best]"
+  name: 真・三國無双3 PlayStation 2 the Best
+  name-sort: しんさんごくむそう3 PlayStation 2 the Best
+  name-en: "Shin Sangoku Musou 3 [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPM-74217:
   name: "Shin Sangoku Musou 3"
   region: "NTSC-J"
 SLPM-74218:
-  name: シャイニング・ティアーズ PS2 the Best
-  name-sort: しゃいにんぐ・てぃあーず PS2 the Best
-  name-en: "Shining Tears [PS2 The Best]"
+  name: シャイニング・ティアーズ PlayStation 2 the Best
+  name-sort: しゃいにんぐ・てぃあーず PlayStation 2 the Best
+  name-en: "Shining Tears [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPM-74219:
-  name: 真・三國無双3Empires PS2 the best
-  name-sort: しん・さんごくむそう3Empires PS2 the best
-  name-en: "Shin Sangoku Musou 3 - Empires [PS2 The Best]"
+  name: 真・三國無双3Empires PlayStation 2 the Best
+  name-sort: しんさんごくむそう3 えんぱいあーず PlayStation 2 the Best
+  name-en: "Shin Sangoku Musou 3 - Empires [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPM-74220:
-  name: 剣豪3 PS2 the Best
-  name-sort: けんごう3 PS2 the Best
-  name-en: "Kengo 3 [PS2 The Best]"
+  name: 剣豪3 PlayStation 2 the Best
+  name-sort: けんごう3 PlayStation 2 the Best
+  name-en: "Kengo 3 [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPM-74221:
-  name: 喧嘩番長 PS2 the Best
-  name-sort: けんかばんちょう PS2 the Best
-  name-en: "Kenka Banchou [PS2 The Best]"
+  name: 喧嘩番長 PlayStation 2 the Best
+  name-sort: けんかばんちょう PlayStation 2 the Best
+  name-en: "Kenka Banchou [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPM-74222:
-  name: 侍〜完全版〜 PS2 the Best
-  name-sort: さむらい〜かんぜんばん〜 PS2 the Best
-  name-en: "Samurai Kanzenban [PS2 The Best]"
+  name: 侍〜完全版〜 PlayStation 2 the Best
+  name-sort: さむらい かんぜんばん PlayStation 2 the Best
+  name-en: "Samurai Kanzenban [PlayStation 2 the Best]"
   region: "NTSC-J"
   gameFixes:
     - EETimingHack # Stops crash after intro movie.
@@ -47274,24 +47391,24 @@ SLPM-74223:
   name: "Kessen III"
   region: "NTSC-J"
 SLPM-74224:
-  name: "Sengoku Musou Mushoden [PS2 The Best]"
+  name: "Sengoku Musou Moushouden [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPM-74225:
-  name: 信長の野望・天下創世 PS2 the Best
-  name-sort: のぶながのやぼう・てんかそうせい PS2 the Best
-  name-en: "Nobunaga no Yabou - Tenka Sousei [PS2 The Best]"
+  name: 信長の野望・天下創世 PlayStation 2 the Best
+  name-sort: のぶながのやぼう てんかそうせい PlayStation 2 the Best
+  name-en: "Nobunaga no Yabou - Tenka Sousei [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPM-74226:
-  name: METAL SAGA 〜砂塵の鎖〜 PS2 the Best
-  name-sort: METAL SAGA 〜さじんのくさり〜 PS2 the Best
-  name-en: "Metal Saga - Sajin no Kusari [PS2 The Best]"
+  name: METAL SAGA 〜砂塵の鎖〜 PlayStation 2 the Best
+  name-sort: めたるさーが さじんのくさり PlayStation 2 the Best
+  name-en: "Metal Saga - Sajin no Kusari [PlayStation 2 the Best]"
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes combat interface.
 SLPM-74227:
-  name: 戦神-いくさがみ- PS2 the Best
-  name-sort: いくさがみ PS2 the Best
-  name-en: "Ikusa Gami [PS2 The Best]"
+  name: 戦神-いくさがみ- PlayStation 2 the Best
+  name-sort: いくさがみ PlayStation 2 the Best
+  name-en: "Ikusa Gami [PlayStation 2 the Best]"
   region: "NTSC-J"
   gameFixes:
     - VIF1StallHack # Fixes black screen on boot.
@@ -47299,34 +47416,34 @@ SLPM-74227:
     autoFlush: 2 # Fixes missing bloom effects.
     halfPixelOffset: 2 # Fixes misaligned lighting and bloom.
 SLPM-74228:
-  name: 風雲幕末伝 PS2 the Best
-  name-sort: ふううんばくまつでん PS2 the Best
-  name-en: "Fuuun Bakumatsu-den [PS2 The Best]"
+  name: 風雲幕末伝 PlayStation 2 the Best
+  name-sort: ふううんばくまつでん PlayStation 2 the Best
+  name-en: "Fuuun Bakumatsu-den [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPM-74229:
-  name: "BioHazard 4 [PS2 The Best]"
+  name: "BioHazard 4 [PlayStation 2 the Best]"
   region: "NTSC-J"
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
 SLPM-74230:
-  name: Devil May Cry PS2 the Best
-  name-sort: Devil May Cry PS2 the Best
-  name-en: "Devil May Cry [PS2 The Best]"
+  name: Devil May Cry PlayStation 2 the Best
+  name-sort: Devil May Cry PlayStation 2 the Best
+  name-en: "Devil May Cry [PlayStation 2 the Best]"
   region: "NTSC-J"
   gsHWFixes:
     disablePartialInvalidation: 1 # Fixes corrupt textures.
     halfPixelOffset: 2 # Alleviates blur from upscaling.
 SLPM-74231:
-  name: 決戦III PS2 the Best
-  name-sort: けっせんIII PS2 the Best
-  name-en: "Kessen III [PS2 The Best]"
+  name: 決戦III PlayStation 2 the Best
+  name-sort: けっせん3 PlayStation 2 the Best
+  name-en: "Kessen III [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPM-74232:
-  name: 新鬼武者 DAWN OF DREAMS PS2 the Best
-  name-sort: しんおにむしゃ DAWN OF DREAMS PS2 the Best
-  name-en: "Shin Onimusha - Dawn of Dreams [PS2 The Best]"
+  name: 新鬼武者 DAWN OF DREAMS PlayStation 2 the Best
+  name-sort: しんおにむしゃ DAWN OF DREAMS PlayStation 2 the Best
+  name-en: "Shin Onimusha - Dawn of Dreams [PlayStation 2 the Best]"
   region: "NTSC-J"
   gameFixes:
     - SoftwareRendererFMVHack # Wrong white textures in FMV.
@@ -47335,60 +47452,60 @@ SLPM-74232:
   memcardFilters:
     - "SLPM-66275"
 SLPM-74233:
-  name: "Shin Onimusha - Dawn of Dreams [PS2 The Best][Disc 2]"
+  name: "Shin Onimusha - Dawn of Dreams [PlayStation 2 the Best][Disc 2]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misalignment and upscaling lines.
   memcardFilters:
     - "SLPM-74232"
 SLPM-74234:
-  name: 龍が如く PS2 the Best
-  name-sort: りゅうがごとく PS2 the Best
-  name-en: "Ryu Ga Gotoku [PS2 The Best]"
+  name: 龍が如く PlayStation 2 the Best
+  name-sort: りゅうがごとく PlayStation 2 the Best
+  name-en: "Ryu Ga Gotoku [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPM-74235:
-  name: 戦国無双 PS2 the Best
-  name-sort: せんごくむそう PS2 the Best
-  name-en: "Sengoku Musou [PS2 The Best]"
+  name: 戦国無双 PlayStation 2 the Best(価格改定版)
+  name-sort: せんごくむそう PlayStation 2 the Best
+  name-en: "Sengoku Musou [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPM-74236:
-  name: 真・三國無双4 PS2 the Best
-  name-sort: しん・さんごくむそう4 PS2 the Best
-  name-en: "Shin Sangoku Musou 4 [PS2 The Best]"
+  name: 真・三國無双4 PlayStation 2 the Best
+  name-sort: しんさんごくむそう4 PlayStation 2 the Best
+  name-en: "Shin Sangoku Musou 4 [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPM-74237:
-  name: NEW人生ゲーム PS2 the Best
-  name-sort: NEWじんせいげーむ PS2 the Best
-  name-en: "New Jinsei Game [PS2 The Best]"
+  name: NEW人生ゲーム PlayStation 2 the Best
+  name-sort: NEWじんせいげーむ PlayStation 2 the Best
+  name-en: "New Jinsei Game [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPM-74238:
-  name: 幻想水滸伝V PS2 the Best
-  name-sort: げんそうすいこでんV PS2 the Best
-  name-en: "Genso Suikoden V [PS2 The Best]"
+  name: 幻想水滸伝V PlayStation 2 the Best
+  name-sort: げんそうすいこでんV PlayStation 2 the Best
+  name-en: "Gensou Suikoden V [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPM-74239:
-  name: 大神 PS2 the Best
-  name-sort: おおがみ PS2 the Best
-  name-en: "Okami [PS2 The Best]"
+  name: 大神 PlayStation 2 the Best
+  name-sort: おおかみ PlayStation 2 the Best
+  name-en: "Okami [PlayStation 2 the Best]"
   region: "NTSC-J"
   gsHWFixes:
     roundSprite: 2 # Reduces misalignment issues but the game is just bad for upscaling.
 SLPM-74240:
-  name: 天外魔境III NAMIDA PS2 the Best
-  name-sort: てんがいまきょうIII NAMIDA PS2 the Best
+  name: 天外魔境III NAMIDA PlayStation 2 the Best
+  name-sort: てんがいまきょう3 NAMIDA PlayStation 2 the Best
   name-en: "Tengai Makyou III - Namida [Best Version]"
   region: "NTSC-J"
 SLPM-74241:
-  name: GOD HAND PS2 the Best
-  name-sort: GOD HAND PS2 the Best
-  name-en: "God Hand [PS2 The Best]"
+  name: GOD HAND PlayStation 2 the Best
+  name-sort: GOD HAND PlayStation 2 the Best
+  name-en: "God Hand [PlayStation 2 the Best]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Depth of field effect aligned properly + Shifts buildings correctly.
 SLPM-74242:
-  name: Devil May Cry 3 Special Edition PS2 the Best
-  name-sort: Devil May Cry 3 Special Edition PS2 the Best
-  name-en: "Devil May Cry 3 [Special Edition] [PS2 The Best]"
+  name: Devil May Cry 3 Special Edition PlayStation 2 the Best
+  name-sort: Devil May Cry 3 Special Edition PlayStation 2 the Best
+  name-en: "Devil May Cry 3 [Special Edition] [PlayStation 2 the Best]"
   region: "NTSC-J"
   roundModes:
     eeRoundMode: 0 # Fixes inability to enter door in Mission 18.
@@ -47396,9 +47513,9 @@ SLPM-74242:
     halfPixelOffset: 2 # Reduces ghosting but still an issue compared to native.
     roundSprite: 2 # Clears up much of the blurring that HPO Special does not.
 SLPM-74243:
-  name: トゥルー・クライム〜ニューヨークシティ〜 PS2 the Best
-  name-sort: とぅるー・くらいむ〜にゅーよーくしてぃ〜 PS2 the Best
-  name-en: "True Crime - New York City [PS2 The Best]"
+  name: トゥルー・クライム〜ニューヨークシティ〜 PlayStation 2 the Best
+  name-sort: とぅるー くらいむ にゅーよーくしてぃ PlayStation 2 the Best
+  name-en: "True Crime - New York City [PlayStation 2 the Best]"
   region: "NTSC-J"
   clampModes:
     eeClampMode: 2 # Fixes SPS on highway.
@@ -47412,30 +47529,30 @@ SLPM-74243:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
 SLPM-74244:
-  name: ファンタシー スター ユニバース PS2 the Best
-  name-sort: ふぁんたしー すたー ゆにばーす PS2 the Best
-  name-en: "Phantasy Star Universe [PS2 The Best]"
+  name: ファンタシー スター ユニバース PlayStation 2 the Best
+  name-sort: ふぁんたしーすたーゆにばーす PlayStation 2 the Best
+  name-en: "Phantasy Star Universe [PlayStation 2 the Best]"
   region: "NTSC-J"
   roundModes:
     eeRoundMode: 0 # Fixes enemies not moving (especially Chapter 7 boss).
 SLPM-74245:
-  name: モンスターハンター2（dos） PS2 the Best
-  name-sort: もんすたーはんたー2（dos） PS2 the Best
-  name-en: "Monster Hunter 2 [PS2 The Best]"
+  name: モンスターハンター2（dos） PlayStation 2 the Best
+  name-sort: もんすたーはんたー2 PlayStation 2 the Best
+  name-en: "Monster Hunter 2 [PlayStation 2 the Best]"
   region: "NTSC-J"
   clampModes:
     vuClampMode: 3 # Fixes lighting on character models as caves and other locations don't turn mobs into glow-in-the-dark creatures by themselves.
   gsHWFixes:
     maximumBlendingLevel: 0 # Fixes unnecessary load on the GPU.
 SLPM-74246:
-  name: CAPCOM VS.SNK 2 MILLIONAIRE FIGHTING 2001 PS2 the Best
-  name-sort: CAPCOM VS.SNK 2 MILLIONAIRE FIGHTING 2001 PS2 the Best
-  name-en: "Capcom vs. SNK 2 - Millionaire Fighting 2001 [PS2 the Best - Reprint]"
+  name: CAPCOM VS.SNK 2 MILLIONAIRE FIGHTING 2001 PlayStation 2 the Best
+  name-sort: CAPCOM VS.SNK 2 MILLIONAIRE FIGHTING 2001 PlayStation 2 the Best
+  name-en: "Capcom vs. SNK 2 - Millionaire Fighting 2001 [PlayStation 2 the Best - Reprint]"
   region: "NTSC-J"
 SLPM-74247:
-  name: 戦国無双2 PS2 the Best
-  name-sort: せんごくむそう2 PS2 the Best
-  name-en: "Sengoku Musou 2 [PS2 The Best]"
+  name: 戦国無双2 PlayStation 2 the Best
+  name-sort: せんごくむそう2 PlayStation 2 the Best
+  name-en: "Sengoku Musou 2 [PlayStation 2 the Best]"
   region: "NTSC-J"
   gsHWFixes:
     roundSprite: 2 # Helps to alleviate misaligned text.
@@ -47452,61 +47569,61 @@ SLPM-74247:
     - "SLPM-74224"
     - "SLPM-74249"
 SLPM-74248:
-  name: モンスターハンターG PS2 the Best
-  name-sort: もんすたーはんたーG PS2 the Best
-  name-en: "Monster Hunter G [PS2 The Best]"
+  name: モンスターハンターG PlayStation 2 the Best
+  name-sort: もんすたーはんたーG PlayStation 2 the Best
+  name-en: "Monster Hunter G [PlayStation 2 the Best]"
   region: "NTSC-J"
   clampModes:
     vuClampMode: 3 # Fixes lighting on character models as caves and other locations don't turn mobs into glow-in-the-dark creatures by themselves.
   gsHWFixes:
     maximumBlendingLevel: 0 # Fixes unnecessary load on the GPU.
 SLPM-74249:
-  name: 戦国無双 猛将伝 PS2 the Best
-  name-sort: せんごくむそう もうしょうでん PS2 the Best
-  name-en: "Sengoku Musou Mushoden [PS2 The Best]"
+  name: 戦国無双 猛将伝 PlayStation 2 the Best
+  name-sort: せんごくむそう もうしょうでん PlayStation 2 the Best
+  name-en: "Sengoku Musou Moushouden [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPM-74250:
-  name: 真・三國無双4 猛将伝 PS2 the Best
-  name-sort: しん・さんごくむそう4 もうしょうでん PS2 the Best
-  name-en: "Shin Sangoku Musou 4 Mushoden [PS2 The Best]"
+  name: 真・三國無双4 猛将伝 PlayStation 2 the Best
+  name-sort: しんさんごくむそう4 もうしょうでん PlayStation 2 the Best
+  name-en: "Shin Sangoku Musou 4 Moushouden [PlayStation 2 the Best]"
   region: "NTSC-J"
   gsHWFixes:
     autoFlush: 2 # Fixes sun luminosity.
 SLPM-74251:
-  name: 新鬼武者 PS2 the Best
-  name-sort: しんおにむしゃ PS2 the Best
-  name-en: "Shin Onimusha - Dawn of Dreams [PS2 the Best - Reprint Disc 1]"
+  name: 新鬼武者 PlayStation 2 the Best
+  name-sort: しんおにむしゃ PlayStation 2 the Best
+  name-en: "Shin Onimusha - Dawn of Dreams [PlayStation 2 the Best - Reprint Disc 1]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misalignment and upscaling lines.
   memcardFilters:
     - "SLPM-66275"
 SLPM-74252:
-  name: "Shin Onimusha - Dawn of Dreams [PS2 the Best - Reprint Disc 2]"
+  name: "Shin Onimusha - Dawn of Dreams [PlayStation 2 the Best - Reprint Disc 2]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misalignment and upscaling lines.
   memcardFilters:
     - "SLPM-74251"
 SLPM-74253:
-  name: 龍が如く PS2 the Best
-  name-sort: りゅうがごとく PS2 the Best
-  name-en: "Ryu ga Gotoku [PS2 the Best - Reprint]"
+  name: 龍が如く PlayStation 2 the Best
+  name-sort: りゅうがごとく PlayStation 2 the Best
+  name-en: "Ryu ga Gotoku [PlayStation 2 the Best - Reprint]"
   region: "NTSC-J"
 SLPM-74254:
-  name: EX人生ゲームII PS2 the Best
-  name-sort: EXじんせいげーむII PS2 the Best
-  name-en: "EX Jinsei Game II [PS2 the Best - Reprint]"
+  name: EX人生ゲームII PlayStation 2 the Best
+  name-sort: EXじんせいげーむII PlayStation 2 the Best
+  name-en: "EX Jinsei Game II [PlayStation 2 the Best - Reprint]"
   region: "NTSC-J"
 SLPM-74255:
-  name: "Metal Gear Solid 2 - Sons of Liberty [PS2 The Best] [Disc 1 of 2]"
+  name: "Metal Gear Solid 2 - Sons of Liberty [PlayStation 2 the Best] [Disc 1 of 2]"
   region: "NTSC-J"
   gameFixes:
     - InstantDMAHack # Fixes broken half-bottom artifacts.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
 SLPM-74256:
-  name: "Metal Gear Solid 2 - Sons of Liberty [PS2 The Best] [Disc 2 of 2]"
+  name: "Metal Gear Solid 2 - Sons of Liberty [PlayStation 2 the Best] [Disc 2 of 2]"
   region: "NTSC-J"
   gameFixes:
     - InstantDMAHack # Fixes broken half-bottom artifacts.
@@ -47519,15 +47636,15 @@ SLPM-74258:
   name: "Metal Gear & Metal Gear 2 - Solid Snake"
   region: "NTSC-J"
 SLPM-74259:
-  name: オーディンスフィア PS2 the Best
-  name-sort: おーでぃんすふぃあ PS2 the Best
-  name-en: "Odin Sphere [PS2 The Best]"
+  name: オーディンスフィア PlayStation 2 the Best
+  name-sort: おーでぃんすふぃあ PlayStation 2 the Best
+  name-en: "Odin Sphere [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPM-74260:
   name: "Shining Force EXA"
   region: "NTSC-J"
 SLPM-74261:
-  name: "Shining Wind [PS2 The Best]"
+  name: "Shining Wind [PlayStation 2 the Best]"
   region: "NTSC-J"
   gameFixes:
     - DMABusyHack
@@ -47541,9 +47658,9 @@ SLPM-74264:
   name: "Sengoku Basara 2 - Heroes"
   region: "NTSC-J"
 SLPM-74265:
-  name: 信長の野望・革新 PS2 the Best
-  name-sort: のぶながのやぼう・かくしん PS2 the Best
-  name-en: "Nobunaga no Yabou - Kakushin [PS2 The Best]"
+  name: 信長の野望・革新 PlayStation 2 the Best
+  name-sort: のぶながのやぼう かくしん PlayStation 2 the Best
+  name-en: "Nobunaga no Yabou - Kakushin [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPM-74266:
   name: "Sengoku Musou 2 - Empires"
@@ -47558,7 +47675,9 @@ SLPM-74269:
   name: "Ryuu ga Gotoku"
   region: "NTSC-J"
 SLPM-74270:
-  name: "Fate/stay night - RÃ©alta Nua"
+  name: Fate/stay night[Realta Nua] PlayStation 2 the Best
+  name-sort: ふぇいと すていないと れあるたぬあ PlayStation 2 the Best
+  name-en: "Fate-stay Night - Realta Nua [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPM-74273:
   name: "New Jinsei Game"
@@ -47570,22 +47689,22 @@ SLPM-74275:
   name: "Sengoku Basara 2 - Heroes"
   region: "NTSC-J"
 SLPM-74276:
-  name: ガンダム無双2 PS2 the Best
-  name-sort: がんだむむそう2 PS2 the Best
-  name-en: "Sangoku Musou 2 [PS2 The Best]"
+  name: ガンダム無双2 PlayStation 2 the Best
+  name-sort: がんだむむそう2 PlayStation 2 the Best
+  name-en: "Sangoku Musou 2 [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPM-74277:
-  name: ペルソナ3フェス PS2 the Best
-  name-sort: ぺるそな3ふぇす PS2 the Best
-  name-en: "Persona 3 FES [PS2 The Best]"
+  name: ペルソナ3フェス PlayStation 2 the Best
+  name-sort: ぺるそな3ふぇす PlayStation 2 the Best
+  name-en: "Persona 3 FES [PlayStation 2 the Best]"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
     mipmap: 2 # Fixes flashing windows.
 SLPM-74278:
-  name: ペルソナ4 PS2 the Best
-  name-sort: ぺるそな4 PS2 the Best
-  name-en: "Persona 4 [PS2 The Best]"
+  name: ペルソナ4 PlayStation 2 the Best
+  name-sort: ぺるそな4 PlayStation 2 the Best
+  name-en: "Persona 4 [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPM-74279:
   name: "Shin Sangoku Musou 4 - Moushouden"
@@ -47603,9 +47722,9 @@ SLPM-74284:
   name: "Sengoku Musou 2 - Empires"
   region: "NTSC-J"
 SLPM-74286:
-  name: 真・三國無双5 Special PS2 the Best
-  name-sort: しん・さんごくむそう5 Special PS2 the Best
-  name-en: "Shin Sangoku Musou 5 Special [PS2 The Best]"
+  name: 真・三國無双5 Special PlayStation 2 the Best
+  name-sort: しんさんごくむそう5 Special PlayStation 2 the Best
+  name-en: "Shin Sangoku Musou 5 Special [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPM-74287:
   name: "Shin Sangoku Musou 5 Special (Disc 2)"
@@ -47618,9 +47737,9 @@ SLPM-74288:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
 SLPM-74301:
-  name: 龍が如く2 PS2 the Best
-  name-sort: りゅうがごとく2 PS2 the Best
-  name-en: "Ryu ga Gotoku 2 [PS2 The Best]"
+  name: 龍が如く2 PlayStation 2 the Best
+  name-sort: りゅうがごとく2 PlayStation 2 the Best
+  name-en: "Ryu ga Gotoku 2 [PlayStation 2 the Best]"
   region: "NTSC-J"
   memcardFilters:
     - "SLPM-66602"
@@ -47632,80 +47751,80 @@ SLPM-74401:
   name: "Kessen"
   region: "NTSC-J"
 SLPM-74402:
-  name: CAPCOM VS. SNK2 MILLIONAIRE FIGHTING 2001 PS2 the Best
-  name-sort: CAPCOM VS. SNK2 MILLIONAIRE FIGHTING 2001 PS2 the Best
-  name-en: "Capcom vs. SNK 2 [PS2 The Best]"
+  name: CAPCOM VS. SNK2 MILLIONAIRE FIGHTING 2001 PlayStation 2 the Best
+  name-sort: CAPCOM VS. SNK2 MILLIONAIRE FIGHTING 2001 PlayStation 2 the Best
+  name-en: "Capcom vs. SNK 2 [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPM-74403:
-  name: "Densha de Go! Shinkansen [PS2 The Best]"
+  name: "Densha de Go! Shinkansen [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPM-74404:
-  name: スペースチャンネル5 Part2 PS2 the Best
-  name-sort: すぺーすちゃんねる5 Part2 PS2 the Best
-  name-en: "Space Channel 5 - Part 2 [PS2 The Best]"
+  name: スペースチャンネル5 Part2 PlayStation 2 the Best
+  name-sort: すぺーすちゃんねる5 Part2 PlayStation 2 the Best
+  name-en: "Space Channel 5 - Part 2 [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPM-74405:
-  name: 侍〜完全版〜 PS2 the Best
-  name-sort: さむらい〜かんぜんばん〜 PS2 the Best
-  name-en: "Samurai Complete Edition [PS2 The Best]"
+  name: 侍〜完全版〜 PlayStation 2 the Best
+  name-sort: さむらい かんぜんばん PlayStation 2 the Best
+  name-en: "Samurai Complete Edition [PlayStation 2 the Best]"
   region: "NTSC-J"
   gameFixes:
     - EETimingHack # Stops crash after intro movie.
 SLPM-74406:
-  name: WRC〜ワールド・ラリー・チャンピオンシップ〜 PS2 the Best
-  name-sort: WRC〜わーるど・らりー・ちゃんぴおんしっぷ〜 PS2 the Best
-  name-en: "World Rally Championship [PS2 The Best]"
+  name: WRC〜ワールド・ラリー・チャンピオンシップ〜 PlayStation 2 the Best
+  name-sort: WRC〜わーるど・らりー・ちゃんぴおんしっぷ〜 PlayStation 2 the Best
+  name-en: "World Rally Championship [PlayStation 2 the Best]"
   region: "NTSC-J"
   roundModes:
     eeRoundMode: 0 # Fixes crash when using the Subaru.
   gameFixes:
     - XGKickHack # Fixes SPS while ingame.
 SLPM-74407:
-  name: "Jet de Go! 2 [PS2 The Best]"
+  name: "Jet de Go! 2 [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPM-74408:
-  name: "Rakugaki Kingdom [PS2 The Best]"
+  name: "Rakugaki Kingdom [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPM-74409:
-  name: ガンサバイバー2 バイオハザード コード:ベロニカ PS2 the Best
-  name-sort: がんさばいばー2 ばいおはざーど こーど:べろにか PS2 the Best
-  name-en: "Gun Survivor 2 - BioHazard Code - Veronica [PS2 The Best]"
+  name: ガンサバイバー2 バイオハザード コード:ベロニカ PlayStation 2 the Best
+  name-sort: がんさばいばー2 ばいおはざーど こーど:べろにか PlayStation 2 the Best
+  name-en: "Gun Survivor 2 - BioHazard Code - Veronica [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPM-74410:
-  name: ブレス オブ ファイアV ドラゴン クォーター PS2 the Best
-  name-sort: ぶれす おぶ ふぁいあV どらごん くぉーたー PS2 the Best
-  name-en: "Breath of Fire V - Dragon Quarter [PS2 The Best]"
+  name: ブレス オブ ファイアV ドラゴン クォーター PlayStation 2 the Best
+  name-sort: ぶれす おぶ ふぁいあV どらごん くぉーたー PlayStation 2 the Best
+  name-en: "Breath of Fire V - Dragon Quarter [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPM-74411:
-  name: カルドセプト セカンド エキスパンション PS2 the Best
-  name-sort: かるどせぷと せかんど えきすぱんしょん PS2 the Best
-  name-en: "Culdcept II - Expansion [PS2 The Best]"
+  name: カルドセプト セカンド エキスパンション PlayStation 2 the Best
+  name-sort: かるどせぷと せかんど えきすぱんしょん PlayStation 2 the Best
+  name-en: "Culdcept II - Expansion [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPM-74412:
-  name: 剣豪2 PS2 the Best
-  name-sort: けんごう2 PS2 the Best
-  name-en: "Kengo 2 [PS2 The Best]"
+  name: 剣豪2 PlayStation 2 the Best
+  name-sort: けんごう2 PlayStation 2 the Best
+  name-en: "Kengo 2 [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPM-74414:
   name: "Energy Airforce"
   region: "NTSC-J"
 SLPM-74415:
-  name: Shinobi PS2 the Best
-  name-sort: Shinobi PS2 the Best
-  name-en: "Shinobi [PS2 The Best]"
+  name: Shinobi PlayStation 2 the Best
+  name-sort: Shinobi PlayStation 2 the Best
+  name-en: "Shinobi [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPM-74416:
   name: "Clock Tower 3"
   region: "NTSC-J"
 SLPM-74420:
-  name: 頭文字D Special Stage PS2 the Best
-  name-sort: かしらもじD Special Stage PS2 the Best
-  name-en: "Initial D - Special Stage [PS2 The Best]"
+  name: 頭文字D Special Stage PlayStation 2 the Best
+  name-sort: いにしゃるD Special Stage PlayStation 2 the Best
+  name-en: "Initial D - Special Stage [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPM-74421:
-  name: 電脳戦機バーチャロン マーズ PS2 the Best
-  name-sort: でんのうせんきばーちゃろん まーず PS2 the Best
-  name-en: "Dennou Senki - Virtual-On Marz [PS2 The Best]"
+  name: 電脳戦機バーチャロン マーズ PlayStation 2 the Best
+  name-sort: でんのうせんきばーちゃろん まーず PlayStation 2 the Best
+  name-en: "Dennou Senki - Virtual-On Marz [PlayStation 2 the Best]"
   region: "NTSC-J"
   gsHWFixes:
     cpuSpriteRenderBW: 1 # Fixes CLUT colours.
@@ -48014,7 +48133,7 @@ SLPS-20052:
   region: "NTSC-J"
 SLPS-20053:
   name: 天使のプレゼント マール王国物語 限定版
-  name-sort: てんしのぷれぜんと まーるおうこくものがたり げんていばん
+  name-sort: てんしのぷれぜんと まーるおうこくものがたり [げんていばん]
   name-en: "Tenshi no Present - Māru Oukoku Monogatari"
   region: "NTSC-J"
 SLPS-20054:
@@ -48137,7 +48256,7 @@ SLPS-20081:
 SLPS-20082:
   name: 最強 東大将棋3
   name-sort: さいきょう とうだいしょうぎ3
-  name-en: "Saikyou Toudai Shogi 3 [Mycom Best]"
+  name-en: "Saikyou Toudai Shogi 3"
   region: "NTSC-J"
 SLPS-20083:
   name: レスキューヘリ エアレンジャー
@@ -48167,7 +48286,7 @@ SLPS-20085:
     - "SLPS-20085"
 SLPS-20086:
   name: GENERATION OF CHAOS 限定版
-  name-sort: GENERATION OF CHAOS げんていばん
+  name-sort: GENERATION OF CHAOS [げんていばん]
   name-en: "Generation of Chaos [Limited Edition]"
   region: "NTSC-J"
 SLPS-20087:
@@ -48253,13 +48372,13 @@ SLPS-20104:
   region: "NTSC-J"
 SLPS-20105:
   name: グローランサーII デラックスパック
-  name-sort: ぐろーらんさーII でらっくすぱっく
+  name-sort: ぐろーらんさー2 でらっくすぱっく
   name-en: "Growlanser II - The Sense of Justice [Deluxe Pack]"
   region: "NTSC-J"
   compat: 4
 SLPS-20106:
   name: グローランサーII
-  name-sort: ぐろーらんさーII
+  name-sort: ぐろーらんさー2
   name-en: "Growlanser II - The Sense of Justice"
   region: "NTSC-J"
   compat: 4
@@ -48338,7 +48457,7 @@ SLPS-20127:
   region: "NTSC-J"
 SLPS-20128:
   name: マールDEジグソー 限定版
-  name-sort: まーるDEじぐそー げんていばん
+  name-sort: まーるDEじぐそー [げんていばん]
   name-en: "Toshiyuki Morikawa Private Collection - Puppet Princess of Marl's Kingdom"
   region: "NTSC-J"
 SLPS-20129:
@@ -48350,7 +48469,7 @@ SLPS-20129:
 SLPS-20130:
   name: 新ベストプレープロ野球
   name-sort: しんべすとぷれーぷろやきゅう
-  name-en: "New Best Play Professional Baseball"
+  name-en: "New Best Play Pro Yakyuu"
   region: "NTSC-J"
 SLPS-20131:
   name: "Jissen Pachi-Slot Hisshouhou! Juuou"
@@ -48466,7 +48585,7 @@ SLPS-20164:
   region: "NTSC-J"
 SLPS-20165:
   name: ラ・ピュセル 光の聖女伝説 限定版
-  name-sort: ら・ぴゅせる ひかりのせいじょでんせつ げんていばん
+  name-sort: ら・ぴゅせる ひかりのせいじょでんせつ [げんていばん]
   name-en: "La Pucelle - Hikari no Seijo Densetsu [Limited Edition]"
   region: "NTSC-J"
 SLPS-20167:
@@ -48529,7 +48648,7 @@ SLPS-20183:
   name: "Motto Golful Golf"
   region: "NTSC-J"
 SLPS-20184:
-  name: "Eikan wa Kimi ni 2002 - Koushien no Kodou"
+  name: "Eikan ha Kimi ni 2002 - Koushien no Kodou"
   region: "NTSC-J"
 SLPS-20185:
   name: 湾岸ミッドナイト
@@ -48565,8 +48684,8 @@ SLPS-20193:
   name: "Jissen Pachi-Slot Hisshouhou! Sammy's Collection"
   region: "NTSC-J"
 SLPS-20194:
-  name: ーUー underwater unit
-  name-sort: ーUー underwater unit
+  name: U underwater unit
+  name-sort: U underwater unit
   name-en: "Underwater Unit"
   region: "NTSC-J"
 SLPS-20195:
@@ -48575,8 +48694,8 @@ SLPS-20195:
   gameFixes:
     - FullVU0SyncHack # Fixes SPS.
 SLPS-20196:
-  name: 月の光 ～沈める鐘の殺人～
-  name-sort: つきのひかり ～しずめるかねのさつじん～
+  name: 月の光 〜沈める鐘の殺人〜
+  name-sort: つきのひかり 〜しずめるかねのさつじん〜
   name-en: "Akagawa Jirou - Tsuki no Hikari - Shizumeru Kane no Satsujin"
   region: "NTSC-J"
 SLPS-20197:
@@ -48599,7 +48718,7 @@ SLPS-20199:
     halfPixelOffset: 1 # Fixes black void when upscaling.
 SLPS-20200:
   name: ファイナルファンタジーXI [ディスク2/2]
-  name-sort: ふぁいなるふぁんたじーXI [でぃすく2/2]
+  name-sort: ふぁいなるふぁんたじー11 [でぃすく2/2]
   name-en: "Final Fantasy XI [Disc 2 of 2]"
   region: "NTSC-J"
 SLPS-20202:
@@ -48614,12 +48733,14 @@ SLPS-20204:
   name: "Magical Sports 2001 Koushien"
   region: "NTSC-J"
 SLPS-20207:
-  name: "Usagi - Yasei no Topai"
+  name: "兎　〜野生の闘牌〜"
+  name-sort: "うさぎ やせいのとうはい"
+  name-en: "Usagi - Yasei no Touhai"
   region: "NTSC-J"
 SLPS-20208:
   name: ボクは小さい
   name-sort: ぼくはちいさい
-  name-en: "Boku wa Chiisai"
+  name-en: "Boku ha Chiisai"
   region: "NTSC-J"
   compat: 5
 SLPS-20209:
@@ -48662,7 +48783,7 @@ SLPS-20218:
     preloadFrameData: 1 # Fixes intro captions not displaying.
 SLPS-20219:
   name: エッグマニア つかんで!まわして!どっすんぱず〜る!!
-  name-sort: えっぐまにあ つかんで!まわして!どっすんぱず〜る!!
+  name-sort: えっぐまにあ つかんで!まわして!どっすんぱずーる!!
   name-en: "Tsukande! Mawashite! Dossun Pazuru Egg Mania"
   region: "NTSC-J"
   patches:
@@ -48677,14 +48798,14 @@ SLPS-20220:
   region: "NTSC-J"
 SLPS-20221:
   name: 太鼓の達人 タタコンでドドンがドン [※タタコン同梱セット]
-  name-sort: たいこのたつじん たたこんでどどんがどん [※たたこんどうこんせっと]
+  name-sort: たいこのたつじん たたこんでどどんがどん [たたこんどうこんせっと]
   name-en: "Taiko no Tatsujin - Tatacon de Dodon ga Don [with Tatacon]"
   region: "NTSC-J"
   compat: 5
 SLPS-20222:
   name: いなか暮らし 南の島の物語
-  name-sort: いなかくらし みなみのしまのものがたり
-  name-en: "Inaka Kurasi - Nan no Shima no Monogatari"
+  name-sort: いなかぐらし みなみのしまのものがたり
+  name-en: "Inaka Gurashi - Minami no Shima no Monogatari"
   region: "NTSC-J"
 SLPS-20223:
   name: "Exciting Pro Wres 4"
@@ -48697,11 +48818,13 @@ SLPS-20225:
   region: "NTSC-J"
 SLPS-20226:
   name: 山佐DigiワールドSP DX
-  name-sort: やまさDigiわーるどSP DX
+  name-sort: やまさでじわーるどSP DX
   name-en: "Yamasa Digi World SP DX - Neo Planett XX"
   region: "NTSC-J"
 SLPS-20227:
-  name: "Yamasa Digi World SP - Neo Planett XX"
+  name: 山佐DigiワールドSP
+  name-sort: やまさでじわーるどSP
+  name-en: "Yamasa Digi World SP DX - Neo Planett XX"
   region: "NTSC-J"
 SLPS-20228:
   name: "Daisenryaku 1941 - Gyakuten no Taiheiyou"
@@ -48723,8 +48846,8 @@ SLPS-20233:
   region: "NTSC-J"
 SLPS-20234:
   name: ハリー・ポッターと秘密の部屋
-  name-sort: はりー・ぽったーとひみつのへや
-  name-en: "Harry Potter to Himitsu no Heya"
+  name-sort: はりーぽったーとひみつのへや
+  name-en: "Harry Potter and the Chamber of Secrets"
   region: "NTSC-J"
   gameFixes:
     - EETimingHack # Fixes flickering textures.
@@ -48747,7 +48870,7 @@ SLPS-20240:
   region: "NTSC-J"
 SLPS-20241:
   name: 上海 三国牌闘儀
-  name-sort: しゃんはい さんごく はいとうぎ
+  name-sort: しゃんはい さんごくはいとうぎ
   name-en: "Shanghai Sangoku Hai Tougi"
   region: "NTSC-J"
 SLPS-20242:
@@ -48781,7 +48904,7 @@ SLPS-20248:
   region: "NTSC-J"
 SLPS-20250:
   name: 魔界戦記 ディスガイア 限定版
-  name-sort: まかいせんき でぃすがいあ げんていばん
+  name-sort: まかいせんき でぃすがいあ [げんていばん]
   name-en: "Makai Senki Disgaea [Limited Edition]"
   region: "NTSC-J"
 SLPS-20251:
@@ -48797,8 +48920,8 @@ SLPS-20255:
   region: "NTSC-J"
 SLPS-20256:
   name: COOL SHOT 夕川景子のプロフェッショナルビリヤード
-  name-sort: COOL SHOT ゆうがわけいこのぷろふぇっしょなるびりやーど
-  name-en: "Cool Shot - Yukawa Keiko"
+  name-sort: COOL SHOT ゆうかわけいこのぷろふぇっしょなるびりやーど
+  name-en: "Cool Shot - Professional Billiards by Yuukawa Keiko"
   region: "NTSC-J"
   compat: 5
 SLPS-20257:
@@ -48806,7 +48929,7 @@ SLPS-20257:
   region: "NTSC-J"
 SLPS-20258:
   name: 山佐Digiワールド4
-  name-sort: やまさDigiわーるど4
+  name-sort: やまさでじわーるど4
   name-en: "Yamasa Digi World 4 - Penguin Paradise, Crazy Shaman R, Zakzak Senryoubako R, Destroyer XX, King Pulsar"
   region: "NTSC-J"
 SLPS-20259:
@@ -48837,7 +48960,7 @@ SLPS-20264:
   region: "NTSC-J"
 SLPS-20265:
   name: FEVER7 SANKYO公式パチンコシミュレーション
-  name-sort: FEVER7 SANKYOこうしきぱちんこしみゅれーしょん
+  name-sort: FEVER7 さんきょうこうしきぱちんこしみゅれーしょん
   name-en: "Fever 7"
   region: "NTSC-J"
 SLPS-20266:
@@ -48857,8 +48980,8 @@ SLPS-20272:
   compat: 5
 SLPS-20273:
   name: 熱チュー!プロ野球2003
-  name-sort: ねつちゅー!ぷろやきゅう2003
-  name-en: "Netsu Chu! Pro Yakyuu 2003"
+  name-sort: ねっちゅー!ぷろやきゅう2003
+  name-en: "Necchu! Pro Yakyuu 2003"
   region: "NTSC-J"
   patches:
     34FB1FB7:
@@ -48867,7 +48990,7 @@ SLPS-20273:
         // Fixes game hanging before going ingame.
         patch=1,EE,001023d0,word,00000000
 SLPS-20274:
-  name: "Eikan wa Kimi ni 2002 - Koushien no Kodou"
+  name: "Eikan ha Kimi ni 2002 - Koushien no Kodou"
   region: "NTSC-J"
 SLPS-20275:
   name: "Pachitte Chonmage Tatsujin 3 - CR P-Man & CR Yawara Kids Kyoku-hen"
@@ -48892,8 +49015,8 @@ SLPS-20280:
   name-en: "Mahou no Pumpkin"
   region: "NTSC-J"
 SLPS-20281:
-  name: モノポリー ～めざせっ!!大富豪人生!!～
-  name-sort: ものぽりー ～めざせっ!!だいふごうじんせい!!～
+  name: モノポリー 〜めざせっ!!大富豪人生!!〜
+  name-sort: ものぽりー 〜めざせっ!!だいふごうじんせい!!〜
   name-en: "Monopoly - Mezase!! Daifugou Jinsei!!"
   region: "NTSC-J"
   clampModes:
@@ -48907,8 +49030,8 @@ SLPS-20283:
   name: "Chulip"
   region: "NTSC-J"
 SLPS-20284:
-  name: マールDEジグソー ～日本一ソフトウェア the Best～
-  name-sort: まーるDEじぐそー ～にっぽんいちそふとうぇあ the Best～
+  name: マールDEジグソー 〜日本一ソフトウェア the Best〜
+  name-sort: まーるDEじぐそー にっぽんいちそふとうぇあ the Best
   name-en: "Marl de Jigsaw"
   region: "NTSC-J"
 SLPS-20285:
@@ -48931,12 +49054,12 @@ SLPS-20288:
   region: "NTSC-J"
 SLPS-20289:
   name: 山佐DigiワールドSP海一番R
-  name-sort: やまさDigiわーるどSPうみいちばんR
+  name-sort: やまさでじわーるどSPうみいちばんR
   name-en: "Yamasa Digi World SP - Umi Ichiban R"
   region: "NTSC-J"
 SLPS-20291:
   name: FISH EYES 3〜記憶の破片たち〜
-  name-sort: FISH EYES 3〜きおくのはへんたち〜
+  name-sort: FISH EYES 3 きおくのかけらたち
   name-en: "Fish Eyes 3"
   region: "NTSC-J"
 SLPS-20292:
@@ -48973,29 +49096,29 @@ SLPS-20299:
   region: "NTSC-J"
 SLPS-20300:
   name: 機動戦士ガンダムSEED
-  name-sort: きどうせんしがんだむSEED
+  name-sort: きどうせんしがんだむしーど
   name-en: "Mobile Suit - Gundam Seed"
   region: "NTSC-J"
 SLPS-20301:
   name: ガチンコプロ野球
   name-sort: がちんこぷろやきゅう
-  name-en: "Gachinko Professional Baseball"
+  name-en: "Gachinko Pro Yakyuu"
   region: "NTSC-J"
 SLPS-20302:
   name: "Gokuraku-jong Premium"
   region: "NTSC-J"
 SLPS-20303:
-  name: いなか暮らし～南の島の物語 ベストコレクション
-  name-sort: いなかくらし～みなみのしまのものがたり べすとこれくしょん
-  name-en: "Inaka Kurasi [Best Collection]"
+  name: いなか暮らし〜南の島の物語 ベストコレクション
+  name-sort: いなかぐらし みなみのしまのものがたり べすとこれくしょん
+  name-en: "Inaka Gurashi - Minami no Shima no Monogatari [Best Collection]"
   region: "NTSC-J"
 SLPS-20304:
-  name: "Boku wa Chiisai"
+  name: "Boku ha Chiisai"
   region: "NTSC-J"
 SLPS-20305:
   name: REAL SPORTS プロ野球
   name-sort: REAL SPORTS ぷろやきゅう
-  name-en: "Real Sports Professional Baseball"
+  name-en: "Real Sports Pro Yakyuu"
   region: "NTSC-J"
 SLPS-20306:
   name: "Slotter Up Mania 2 - Kokuchi no Kyoku! Juggler Special"
@@ -49014,13 +49137,13 @@ SLPS-20310:
   region: "NTSC-J"
 SLPS-20311:
   name: プリモプエル おしゃべりは〜とな〜 コプエルマイク同梱版
-  name-sort: ぷりもぷえる おしゃべりは〜とな〜 こぷえるまいくどうこんばん
-  name-en: "Primopuel - My Special Partner [Limited Edition]"
+  name-sort: ぷりもぷえる おしゃべりはーとなー こぷえるまいくどうこんばん
+  name-en: "Primopuel - Oshaberi Heartner [Limited Edition]"
   region: "NTSC-J"
 SLPS-20312:
   name: プリモプエル おしゃべりは〜とな〜
-  name-sort: ぷりもぷえる おしゃべりは〜とな〜
-  name-en: "Primopuel - My Special Partner"
+  name-sort: ぷりもぷえる おしゃべりはーとなー
+  name-en: "Primopuel - Oshaberi Heartner"
   region: "NTSC-J"
 SLPS-20313:
   name: "Mahjong Haou - Taikai Battle"
@@ -49058,8 +49181,8 @@ SLPS-20321:
   compat: 5
 SLPS-20322:
   name: 熱チュー!プロ野球2003 秋のナイター祭り
-  name-sort: ねつちゅー!ぷろやきゅう2003 あきのないたーまつり
-  name-en: "Netsu Chu! Pro Yakyuu 2003 - Aki no Night Matsuri"
+  name-sort: ねっちゅー!ぷろやきゅう2003 あきのないたーまつり
+  name-en: "Necchu! Pro Yakyuu 2003 - Aki no Night Matsuri"
   region: "NTSC-J"
   patches:
     D3DAF7F4:
@@ -49101,7 +49224,7 @@ SLPS-20330:
   compat: 5
 SLPS-20331:
   name: FEVER9 SANKYO公式パチンコシミュレーション
-  name-sort: FEVER9 SANKYOこうしきぱちんこしみゅれーしょん
+  name-sort: FEVER9 さんきょうこうしきぱちんこしみゅれーしょん
   name-en: "Fever 9 - Sankyo"
   region: "NTSC-J"
 SLPS-20332:
@@ -49109,22 +49232,22 @@ SLPS-20332:
   region: "NTSC-J"
 SLPS-20333:
   name: TAISEN (1) 将棋
-  name-sort: TAISEN (1) しょうぎ
+  name-sort: たいせん (1) しょうぎ
   name-en: "Taisen 1 - Shogi"
   region: "NTSC-J"
 SLPS-20334:
   name: TAISEN (2) 囲碁
-  name-sort: TAISEN (2) いご
+  name-sort: たいせん (2) いご
   name-en: "Taisen 2 - Go"
   region: "NTSC-J"
 SLPS-20335:
   name: TAISEN (3) 麻雀
-  name-sort: TAISEN (3) まーじゃん
+  name-sort: たいせん (3) まーじゃん
   name-en: "Taisen 3 - Mahjong"
   region: "NTSC-J"
 SLPS-20336:
   name: TAISEN (4) ソルジャー 〜企業戦士将棋〜
-  name-sort: TAISEN (4) そるじゃー 〜きぎょうせんししょうぎ〜
+  name-sort: たいせん (4) そるじゃー きぎょうせんししょうぎ
   name-en: "Taisen 4 - Soldier"
   region: "NTSC-J"
 SLPS-20337:
@@ -49151,13 +49274,13 @@ SLPS-20343:
   name-en: "Net de Bomberman"
   region: "NTSC-J"
 SLPS-20344:
-  name: ファントム・ブレイブ [限定版]
-  name-sort: ふぁんとむ・ぶれいぶ [げんていばん]
+  name: ファントム・ブレイブ(限定版)
+  name-sort: ふぁんとむ ぶれいぶ [げんていばん]
   name-en: "Phantom Brave [Limited Edition]"
   region: "NTSC-J"
 SLPS-20345:
-  name: ファントム・ブレイブ [通常版]
-  name-sort: ふぁんとむ・ぶれいぶ [つうじょうばん]
+  name: ファントム・ブレイブ(通常版)
+  name-sort: ふぁんとむ ぶれいぶ [つうじょうばん]
   name-en: "Phantom Brave"
   region: "NTSC-J"
 SLPS-20347:
@@ -49186,26 +49309,26 @@ SLPS-20352:
   name-en: "Sukisyo - First Limit & Target Nights"
   region: "NTSC-J"
 SLPS-20353:
-  name: "Suki na Mono wa Suki dakara Shou ga Nai!! First Limit & Target Nights - Sukishou! Episode #01+#02 (Disc 2) (Target Nights - Sukishou! Episode #02)"
+  name: "Suki na Mono ha Suki dakara Shou ga Nai!! First Limit & Target Nights - Sukishou! Episode #01+#02 (Disc 2) (Target Nights - Sukishou! Episode #02)"
   region: "NTSC-J"
 SLPS-20354:
   name: 山佐Digiワールド3 [ベストオブベスト]
-  name-sort: さんさDigiわーるど3 [べすとおぶべすと]
+  name-sort: やまさでじわーるど3 [べすとおぶべすと]
   name-en: "Yamasa Digi World 3 [Best of Best]"
   region: "NTSC-J"
 SLPS-20355:
   name: 山佐DigiワールドSPネオプラネットXX [ベストオブベスト]
-  name-sort: さんさDigiわーるどSPねおぷらねっとXX [べすとおぶべすと]
+  name-sort: やまさでじわーるどSPねおぷらねっとXX [べすとおぶべすと]
   name-en: "Yamasa Digi World SP - Neo Planett XX [Best of Best]"
   region: "NTSC-J"
 SLPS-20356:
   name: 山佐Digiワールド4 [ベストオブベスト]
-  name-sort: さんさDigiわーるど4 [べすとおぶべすと]
+  name-sort: やまさでじわーるど4 [べすとおぶべすと]
   name-en: "Yamasa Digi World 4 [Best of Best]"
   region: "NTSC-J"
 SLPS-20357:
   name: 山佐DigiワールドSP 海一番R [ベストオブベスト]
-  name-sort: さんさDigiわーるどSP うみいちばんR [べすとおぶべすと]
+  name-sort: やまさでじわーるどSP うみいちばんR [べすとおぶべすと]
   name-en: "Yamasa Digi World SP - Umi Ichiban R [Best of Best]"
   region: "NTSC-J"
 SLPS-20361:
@@ -49215,7 +49338,7 @@ SLPS-20361:
   region: "NTSC-J"
 SLPS-20362:
   name: かいけつゾロリ めざせ！いたずらキング EyeToy USBカメラ同梱版
-  name-sort: かいけつぞろり めざせ！いたずらきんぐ EyeToy USBかめらどうこんばん
+  name-sort: かいけつぞろり めざせ!いたずらきんぐ あいとーいUSBかめらどうこんばん
   name-en: "Kaiketsu Zorro Mezase! Itazura King [Limited Edition]"
   region: "NTSC-J"
 SLPS-20364:
@@ -49235,7 +49358,7 @@ SLPS-20366:
   region: "NTSC-J"
 SLPS-20367:
   name: カレーハウスCoCo壱番屋 今日も元気だ!カレーがうまい!!
-  name-sort: かれーはうすCoCoいちばんや きょうもげんきだ!かれーがうまい!!
+  name-sort: かれーはうすここいちばんや きょうもげんきだ!かれーがうまい!!
   name-en: "Curry House CoCo Ichiban'ya - Kyou mo Genki da! Curry ga Umai!!"
   region: "NTSC-J"
   compat: 5
@@ -49251,7 +49374,7 @@ SLPS-20369:
   region: "NTSC-J"
 SLPS-20370:
   name: スロッターUPコア3 愉打! ドロンジョにおまかせ
-  name-sort: すろったーUPこあ3 愉打! どろんじょにおまかせ
+  name-sort: すろったーUPこあ3 ゆだ! どろんじょにおまかせ
   name-en: "Slotter Up Core 3 - Doronjo ni Omakase!"
   region: "NTSC-J"
 SLPS-20371:
@@ -49277,8 +49400,8 @@ SLPS-20374:
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
 SLPS-20375:
-  name: 三洋パチンコパラダイス10 ～源さん おかえりっ!～
-  name-sort: さんようぱちんこぱらだいす10 ～げんさん おかえりっ!～
+  name: 三洋パチンコパラダイス10 〜源さん おかえりっ!〜
+  name-sort: さんようぱちんこぱらだいす10 げんさん おかえりっ!
   name-en: "Sanyo Pachinko Paradise 10 - Gen-san Okaeri"
   region: "NTSC-J"
 SLPS-20376:
@@ -49287,8 +49410,8 @@ SLPS-20376:
   name-en: "Daito Giken Koushiki Pachi-Slot Simulator Yoshimune"
   region: "NTSC-J"
 SLPS-20377:
-  name: FISH EYES 3 ～記憶の破片たち～ Best Collection
-  name-sort: FISH EYES 3 ～きおくのはへんたち～ Best Collection
+  name: FISH EYES 3 〜記憶の破片たち〜 Best Collection
+  name-sort: FISH EYES 3 〜きおくのかけらたち〜 Best Collection
   name-en: "Fish Eyes 3 [Best Collection]"
   region: "NTSC-J"
 SLPS-20378:
@@ -49298,9 +49421,9 @@ SLPS-20378:
   region: "NTSC-J"
   compat: 5
 SLPS-20379:
-  name: ARTDINK BEST CHOICE 栄冠は君に2004～甲子園の鼓動～
-  name-sort: ARTDINK BEST CHOICE えいかんはきみに2004～こうしえんのこどう～
-  name-en: "Eikan wa Kimi ni 2004 - Koushien no Kodou [Artdink Best Choice]"
+  name: ARTDINK BEST CHOICE 栄冠は君に2004〜甲子園の鼓動〜
+  name-sort: ARTDINK BEST CHOICE えいかんはきみに2004 こうしえんのこどう
+  name-en: "Eikan ha Kimi ni 2004 - Koushien no Kodou [Artdink Best Choice]"
   region: "NTSC-J"
 SLPS-20380:
   name: 神魂合体ゴーダンナー!!
@@ -49314,21 +49437,21 @@ SLPS-20381:
   region: "NTSC-J"
 SLPS-20382:
   name: 太鼓の達人 あつまれ！祭りだ！！四代目 タタコン同梱セット
-  name-sort: たいこのたつじん あつまれ！まつりだ！！よんだいめ たたこんどうこんせっと
+  name-sort: たいこのたつじん あつまれ!まつりだ!!よんだいめ たたこんどうこんせっと
   name-en: "Taiko no Tatsujin - Atsumare! Matsuri da!! Yondaime [with Tatacon]"
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
 SLPS-20383:
   name: 太鼓の達人 あつまれ！祭りだ！！四代目
-  name-sort: たいこのたつじん あつまれ！まつりだ！！よんだいめ
+  name-sort: たいこのたつじん あつまれ!まつりだ!!よんだいめ
   name-en: "Taiko no Tatsujin - Atsumare! Matsuri da!! Yondaime"
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
 SLPS-20384:
   name: 流行り神 警視庁怪異事件ファイル （初回限定版）
-  name-sort: はやりがみ けいしちょうかいいじけんふぁいる （しょかいげんていばん）
+  name-sort: はやりがみ けいしちょうかいいじけんふぁいる [しょかいげんていばん]
   name-en: "Hayarigami - Keishichou Kaii Jiken File"
   region: "NTSC-J"
 SLPS-20386:
@@ -49348,7 +49471,7 @@ SLPS-20388:
   region: "NTSC-J"
 SLPS-20389:
   name: MYCOM BEST 最強東大将棋5
-  name-sort: MYCOM BEST さいきょうとうだいしょうぎ5
+  name-sort: さいきょうとうだいしょうぎ5 [MYCOM BEST]
   name-en: "Saikyou Toudai Shogi 5 [Mycom Best]"
   region: "NTSC-J"
 SLPS-20391:
@@ -49369,11 +49492,11 @@ SLPS-20393:
 SLPS-20394:
   name: 好きなものは好きだからしょうがない!! -RAIN- Sukisyo! Episode #03
   name-sort: すきなものはすきだからしょうがない!! -RAIN- Sukisyo! Episode #03
-  name-en: "Suki na Mono wa Sukida Rashouganai + White Flower + Sukisyo!"
+  name-en: "Suki na Mono ha Sukida Rashouganai + White Flower + Sukisyo!"
   region: "NTSC-J"
 SLPS-20396:
   name: スロッターUPマニア5 爽快激打!マッハGoGoGo＆だるま猫
-  name-sort: すろったーUPまにあ5 そうかいげきだ!まっはGoGoGo＆だるまねこ
+  name-sort: すろったーUPまにあ5 そうかいげきだ!まっはごーごーごー&だるまねこ
   name-en: "Slotter UP - Mania 5"
   region: "NTSC-J"
 SLPS-20397:
@@ -49381,7 +49504,7 @@ SLPS-20397:
   region: "NTSC-J"
 SLPS-20398:
   name: ラ・ピュセル 光の聖女伝説 2周目はじめました。
-  name-sort: ら・ぴゅせる ひかりのせいじょでんせつ 2しゅうめはじめました。
+  name-sort: ら ぴゅせる ひかりのせいじょでんせつ 2しゅうめはじめました
   name-en: "La Pucelle - Hikari no Seijo Densetsu - 2-shuume Hajimemashita"
   region: "NTSC-J"
 SLPS-20399:
@@ -49411,8 +49534,8 @@ SLPS-20402:
   compat: 5
 SLPS-20403:
   name: 上海〜三国牌闘儀〜 [super value 2800]
-  name-sort: しゃんはい〜さんこくぱい闘儀〜 [super value 2800]
-  name-en: "Shanghai - Sangoku Pai Tatagi [Super Value 2800]"
+  name-sort: しゃんはい さんこくはいとうぎ [super value 2800]
+  name-en: "Shanghai - Sangoku Hai Tougi [Super Value 2800]"
   region: "NTSC-J"
 SLPS-20404:
   name: "Rakushou! Pachi-Slot Sengen 2 - Juujika, Deka Dan"
@@ -49424,7 +49547,7 @@ SLPS-20405:
   region: "NTSC-J"
 SLPS-20406:
   name: C@M-STATION カム・ステーション 同梱版 [“EyeToy”カメラ＆USBヘッドセット同梱版]
-  name-sort: C@M-STATION かむ・すてーしょん どうこんばん [“EyeToy”かめら＆USBへっどせっとどうこんばん]
+  name-sort: かむすてーしょん どうこんばん [あいとーいかめら&USBへっどせっとどうこんばん]
   name-en: "Cam-Station [with EyeToy & USB Headset]"
   region: "NTSC-J"
 SLPS-20407:
@@ -49434,18 +49557,18 @@ SLPS-20407:
   region: "NTSC-J"
 SLPS-20408:
   name: カードキャプターさくら 「さくらちゃんとあそぼ!」
-  name-sort: かーどきゃぷたーさくら 「さくらちゃんとあそぼ!」
+  name-sort: かーどきゃぷたーさくら さくらちゃんとあそぼ!
   name-en: "Card Captor Sakura - Sakura-Chan to Asobo!"
   region: "NTSC-J"
   compat: 5
 SLPS-20409:
   name: ファントム・キングダム [初回限定版]
-  name-sort: ふぁんとむ・きんぐだむ [しょかいげんていばん]
+  name-sort: ふぁんとむ・きんぐだむ しょかいげんていばん
   name-en: "Phantom Kingdom [Limited Edition]"
   region: "NTSC-J"
 SLPS-20410:
   name: ファントム・キングダム
-  name-sort: ふぁんとむ・きんぐだむ
+  name-sort: ふぁんとむ きんぐだむ
   name-en: "Phantom Kingdom [Limited Edition]"
   region: "NTSC-J"
 SLPS-20411:
@@ -49475,17 +49598,17 @@ SLPS-20414:
     alignSprite: 1 # Fixes vertical lines.
 SLPS-20416:
   name: 陰陽大戦記 白虎演舞 [“EyeToy”カメラ同梱版]
-  name-sort: いんようだいせんき びゃっこえんぶ [“EyeToy”かめらどうこんばん]
-  name-en: "Inyou Taisenki - Byakko Enbu [with EyeToy]"
+  name-sort: おんみょうたいせんき びゃっこえんぶ [あいとーいかめらどうこんばん]
+  name-en: "Onmyou Taisenki - Byakko Enbu [with EyeToy]"
   region: "NTSC-J"
 SLPS-20417:
   name: 陰陽大戦記 白虎演舞
-  name-sort: いんようだいせんき びゃっこえんぶ
-  name-en: "Inyou Taisenki - Byakko Enbu"
+  name-sort: おんみょうたいせんき びゃっこえんぶ
+  name-en: "Onmyou Taisenki - Byakko Enbu"
   region: "NTSC-J"
 SLPS-20418:
   name: C@M-STATION カム・ステーション
-  name-sort: C@M-STATION かむ・すてーしょん
+  name-sort: かむすてーしょん
   name-en: "Cam-Station"
   region: "NTSC-J"
 SLPS-20419:
@@ -49508,7 +49631,7 @@ SLPS-20422:
   region: "NTSC-J"
 SLPS-20423:
   name: レゴ スター・ウォーズ
-  name-sort: れご すたー・うぉーず
+  name-sort: れご すたーうぉーず
   name-en: "LEGO Star Wars - The Video Game"
   region: "NTSC-J"
   clampModes:
@@ -49528,7 +49651,9 @@ SLPS-20425:
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
 SLPS-20426:
-  name: "Dreamworks Madagascar"
+  name: マダガスカル
+  name-sort: まだかすかる
+  name-en: "Madagascar"
   region: "NTSC-J"
   roundModes:
     vu1RoundMode: 0 # Fixes graphical issues.
@@ -49550,7 +49675,7 @@ SLPS-20429:
   region: "NTSC-J"
 SLPS-20430:
   name: SIMPLE2000シリーズ Vol.91 THE ALL★STAR格闘祭
-  name-sort: SIMPLE2000しりーず Vol.91 THE ALL★STARかくとうさい
+  name-sort: SIMPLE2000しりーず Vol.91 THE おーるすたーかくとうさい
   name-en: "Simple 2000 Series Vol. 91 - The All-Star Kakutou"
   region: "NTSC-J"
   compat: 5
@@ -49572,12 +49697,12 @@ SLPS-20439:
   name-en: "Simple 2000 Series Vol. 79 - The Party Quiz - Akko ni Omakase"
   region: "NTSC-J"
 SLPS-20440:
-  name: SIMPLE 2000シリーズ Vol.88 THE ミニ美女警官
+  name: SIMPLE2000シリーズ Vol.88 THE ミニ美女警官
   name-sort: SIMPLE 2000しりーず Vol.88 THE みにびじょけいかん
   name-en: "Simple 2000 Series Vol. 88 - The Mini Bijo Keikan"
   region: "NTSC-J"
 SLPS-20441:
-  name: SIMPLE 2000シリーズ Vol.87 THE 戦娘
+  name: SIMPLE2000シリーズ Vol.87 THE 戦娘
   name-sort: SIMPLE 2000しりーず Vol.87 THE なでしこ
   name-en: "Simple 2000 Series Vol. 87 - The Nadesiko"
   region: "NTSC-J"
@@ -49595,7 +49720,7 @@ SLPS-20443:
     recommendedBlendingLevel: 4 # Fixes water reflections.
 SLPS-20444:
   name: SIMPLE2000シリーズ Vol.90 THE お姉チャンバラ2
-  name-sort: SIMPLE2000しりーず Vol.90 THE おあねちゃんばら2
+  name-sort: SIMPLE2000しりーず Vol.90 THE おねえちゃんばら2
   name-en: "Simple 2000 Series Vol. 90 - The OneeChanBara 2"
   region: "NTSC-J"
   compat: 5
@@ -49610,7 +49735,7 @@ SLPS-20445:
   name-en: "Simple 2000 Series Ultimate Vol. 28 - Tousou! Kenka Grand Prix - Drive to Survive"
   region: "NTSC-J"
 SLPS-20446:
-  name: SIMPLE 2000シリーズ Vol.89 THE パーティーゲーム2
+  name: SIMPLE2000シリーズ Vol.89 THE パーティーゲーム2
   name-sort: SIMPLE 2000しりーず Vol.89 THE ぱーてぃーげーむ2
   name-en: "Simple 2000 Series Vol. 89 - The Party Game 2"
   region: "NTSC-J"
@@ -49638,14 +49763,14 @@ SLPS-20451:
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
 SLPS-20452:
-  name: SIMPLE 2000シリーズ Ultimate Vol.30 降臨!族車ゴッド〜仏恥義理★愛羅武勇〜
-  name-sort: SIMPLE 2000しりーず Ultimate Vol.30 こうりん!ぞくしゃごっど〜ふっちぎり★あいらぶゆう〜
+  name: SIMPLE2000シリーズ Ultimate Vol.30 降臨!族車ゴッド〜仏恥義理★愛羅武勇〜
+  name-sort: SIMPLE 2000しりーず Ultimate Vol.30 こうりん!ぞくしゃごっど ぶっちぎりあいらぶゆう
   name-en: "Simple 2000 Series Ultimate Vol. 30 - Kourin! Zokusha Goddo!"
   region: "NTSC-J"
   gameFixes:
     - XGKickHack # Fixes car colours.
 SLPS-20453:
-  name: SIMPLE 2000シリーズ Ultimate Vol.29 K-1 PREMIUM 2005 Dynamite!!
+  name: SIMPLE2000シリーズ Ultimate Vol.29 K-1 PREMIUM 2005 Dynamite!!
   name-sort: SIMPLE 2000しりーず Ultimate Vol.29 K-1 PREMIUM 2005 Dynamite!!
   name-en: "Simple 2000 Series Ultimate Vol. 29 - K-1 Premium 2005 Dynamite!!"
   region: "NTSC-J"
@@ -49665,12 +49790,12 @@ SLPS-20454:
   name-en: "Simple 2000 Series Vol. 93 - The Unou Drill"
   region: "NTSC-J"
 SLPS-20455:
-  name: SIMPLE 2000シリーズ Vol.94 THE 赤ちゃんぴおん〜COME ON BABY〜
+  name: SIMPLE2000シリーズ Vol.94 THE 赤ちゃんぴおん〜COME ON BABY〜
   name-sort: SIMPLE 2000しりーず Vol.94 THE あかちゃんぴおん〜COME ON BABY〜
   name-en: "Simple 2000 Series Vol. 94 - The Aka-Champion - Come on Baby"
   region: "NTSC-J"
 SLPS-20456:
-  name: SIMPLE 2000シリーズ Vol.95 THE ゾンビV.S.救急車
+  name: SIMPLE2000シリーズ Vol.95 THE ゾンビV.S.救急車
   name-sort: SIMPLE 2000しりーず Vol.95 THE ぞんびV.S.きゅうきゅうしゃ
   name-en: "Simple 2000 Series Vol. 95 - The Zombie vs. Kyuukyuusha"
   region: "NTSC-J"
@@ -49680,34 +49805,34 @@ SLPS-20457:
   name-en: "Hissatsu Pachislo Evolution 2 - Osomatsu-Kun"
   region: "NTSC-J"
 SLPS-20458:
-  name: SIMPLE 2000シリーズ Vol.96 THE 海賊 〜ガイコツいっぱいれーつ!〜
+  name: SIMPLE2000シリーズ Vol.96 THE 海賊 〜ガイコツいっぱいれーつ!〜
   name-sort: SIMPLE 2000しりーず Vol.96 THE かいぞく 〜がいこついっぱいれーつ!〜
   name-en: "Simple 2000 Series Vol. 96 - The Kaizoku - Gaikotsu Ippaire~tsu!"
   region: "NTSC-J"
 SLPS-20459:
   name: 山佐DigiワールドSP 燃えよ!功夫淑女
-  name-sort: やまさDigiわーるどSP もえよ!かんふーれでぃ
+  name-sort: やまさでじわーるどSP もえよ!かんふーれでぃ
   name-en: "Yamasa Digi World SP - Isao Lady"
   region: "NTSC-J"
 SLPS-20460:
   name: 楽勝!パチスロ宣言4 真モグモグ風林火山・リオデカーニバル
-  name-sort: らくしょう!ぱちすろせんげん4 しんもぐもぐふうりんかざん・りおでかーにばる
+  name-sort: らくしょう!ぱちすろせんげん4 しんもぐもぐふうりんかざん りおでかーにばる
   name-en: "Rakushou! Pachi-Slot Sengen 4"
   region: "NTSC-J"
 SLPS-20461:
-  name: SIMPLE 2000シリーズ Vol.99 THE 原始人
+  name: SIMPLE2000シリーズ Vol.99 THE 原始人
   name-sort: SIMPLE 2000しりーず Vol.99 THE げんしじん
   name-en: "Simple 2000 Series Vol. 99 - The Genshijin"
   region: "NTSC-J"
   compat: 5
 SLPS-20462:
   name: 黄金騎士 牙狼<GARO>[限定版]
-  name-sort: おうごんきし がろ[げんていばん]
+  name-sort: おうごんきし がろう [げんていばん]
   name-en: "Ougon Kishi Garo [Limited Edition]"
   region: "NTSC-J"
 SLPS-20463:
   name: 黄金騎士 牙狼<GARO>[通常版]
-  name-sort: おうごんきし がろ[つうじょうばん]
+  name-sort: おうごんきし がろう つうじょうばん
   name-en: "Ougon Kishi Garo"
   region: "NTSC-J"
 SLPS-20464:
@@ -49722,7 +49847,7 @@ SLPS-20465:
   region: "NTSC-J"
 SLPS-20466:
   name: SIMPLE2000シリーズ Vol.101 THE お姉チャンポン 〜THE 姉チャン2 特別編〜
-  name-sort: SIMPLE2000しりーず Vol.101 THE おあねちゃんぽん 〜THE あねちゃん2 とくべつへん〜
+  name-sort: SIMPLE2000しりーず Vol.101 THE おねえちゃんぽん 〜THE ねえちゃん2 とくべつへん〜
   name-en: "Simple 2000 Series Vol. 101 - The OneeChanpon - OneeChan 2 Special Edition"
   region: "NTSC-J"
   gsHWFixes:
@@ -49743,7 +49868,7 @@ SLPS-20468:
   compat: 5
 SLPS-20469:
   name: 街ingメーカー2 〜続・ぼくの街づくり〜
-  name-sort: まちingめーかー2 〜ぞく・ぼくのまちづくり〜
+  name-sort: まちingめーかー2 〜ぞく ぼくのまちづくり〜
   name-en: "Matching Maker 2"
   region: "NTSC-J"
   compat: 5
@@ -49767,12 +49892,12 @@ SLPS-20473:
   region: "NTSC-J"
 SLPS-20474:
   name: SIMPLE2000シリーズ Vol.107 THE 炎の格闘番長
-  name-sort: SIMPLE2000しりーず Vol.107 THE えんのかくとうばんちょう
+  name-sort: SIMPLE2000しりーず Vol.107 THE ほのおのかくとうばんちょう
   name-en: "Simple 2000 Series Vol. 107 - The Honoo no Kakutou Banchou"
   region: "NTSC-J"
 SLPS-20475:
   name: 山佐DigiワールドSP ジャイアントパルサー
-  name-sort: やまさDigiわーるどSP じゃいあんとぱるさー
+  name-sort: やまさでじわーるどSP じゃいあんとぱるさー
   name-en: "Yamasa Digi World SP - Giant Pulsar"
   region: "NTSC-J"
   compat: 5
@@ -49824,14 +49949,14 @@ SLPS-20484:
   name-en: "Simple 2000 Series Ultimate Vol. 34 - Sakigake!! Otokojuku"
   region: "NTSC-J"
 SLPS-20485:
-  name: 太鼓の達人 ドカッ!と大盛り七代目 [タタコン同梱]
+  name: 太鼓の達人 ドカッ!と大盛り七代目(タタコン同梱)
   name-sort: たいこのたつじん どかっ!とおおもりななだいめ [たたこんどうこん]
   name-en: "Taiko no Tatsujin - Doka! to Oomori Nanadaime [with Tatacon]"
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
 SLPS-20486:
-  name: 太鼓の達人 ドカッ!と大盛り七代目
+  name: 太鼓の達人 ドカッ!と大盛り七代目(ソフト単体)
   name-sort: たいこのたつじん どかっ!とおおもりななだいめ
   name-en: "Taiko no Tatsujin - Doka! to Oomori Nanadaime"
   region: "NTSC-J"
@@ -49857,22 +49982,22 @@ SLPS-20489:
     getSkipCount: "GSC_Simple2000Vol114"
 SLPS-20490:
   name: パチスロ倶楽部コレクション アイムジャグラーEX〜ジャグラーセレクション〜
-  name-sort: ぱちすろくらぶこれくしょん あいむじゃぐらーEX〜じゃぐらーせれくしょん〜
+  name-sort: ぱちすろくらぶこれくしょん あいむじゃぐらーEX じゃぐらーせれくしょん
   name-en: "Pachi-Slot Club Collection - IM Juggler EX - Juggler Selection"
   region: "NTSC-J"
 SLPS-20491:
   name: SIMPLE2000シリーズVol.118 THE落武者 〜怒獲武サムライ登場〜
-  name-sort: SIMPLE2000しりーずVol.118 THEおちむしゃ 〜どえむさむらいとうじょう〜
+  name-sort: SIMPLE2000しりーずVol.118 THEおちむしゃ どえむさむらいとうじょう
   name-en: "Simple 2000 Series Vol. 118 - The Ochimusha - Doemu Samurai Toujou"
   region: "NTSC-J"
 SLPS-20492:
   name: SIMPLE2000シリーズ Vol.115 THEルームシェアという生活。
-  name-sort: SIMPLE2000しりーず Vol.115 THEるーむしぇあというせいかつ。
+  name-sort: SIMPLE2000しりーず Vol.115 THEるーむしぇあというせいかつ
   name-en: "Simple 2000 Series Vol. 115 - The Roomshare to Iu Seikatsu"
   region: "NTSC-J"
 SLPS-20493:
   name: SIMPLE2000シリーズVol.116 THE ネコ村の人々 〜パグ代官の悪行三昧〜
-  name-sort: SIMPLE2000しりーずVol.116 THE ねこむらのひとびと 〜ぱぐだいかんのあくぎょうさんまい〜
+  name-sort: SIMPLE2000しりーずVol.116 THE ねこむらのひとびと ぱぐだいかんのあくぎょうさんまい
   name-en: "Simple 2000 Series Vol. 116 - The Neko-Mura no Ninnin - Pagu Daikan no Akugyou Sanmai"
   region: "NTSC-J"
   compat: 5
@@ -49893,13 +50018,13 @@ SLPS-20497:
   region: "NTSC-J"
 SLPS-20499:
   name: いなか暮らし 南の島の物語 Super Best Collection
-  name-sort: いなかくらし みなみのしまのものがたり Super Best Collection
-  name-en: "Inaka Kurashi - Nan no Shima no Monogatari [Super Best Collection]"
+  name-sort: いなかぐらし みなみのしまのものがたり Super Best Collection
+  name-en: "Inaka Gurashi - Minami no Shima no Monogatari [Super Best Collection]"
   region: "NTSC-J"
 SLPS-20500:
   name: SIMPLE2000シリーズ Vol.120 THE 最後の日本兵〜美しき国土奪還作戦〜
-  name-sort: SIMPLE2000しりーず Vol.120 THE さいごのにほんへい〜うつくしきこくどだっかんさくせん〜
-  name-en: "Simple 2000 Series Vol. 120 - The Saigo no Nippon Tsuwamono"
+  name-sort: SIMPLE2000しりーず Vol.120 THE さいごのにほんへい うつくしきこくどだっかんさくせん
+  name-en: "Simple 2000 Series Vol. 120 - The Saigo no Nihon hei"
   region: "NTSC-J"
 SLPS-20501:
   name: 流行り神2 警視庁怪異事件ファイル
@@ -49907,7 +50032,9 @@ SLPS-20501:
   name-en: "Hayarigami 2"
   region: "NTSC-J"
 SLPS-20502:
-  name: "Zero no Tsukaima - Fantasy Force"
+  name: ゼロの使い魔 ファンタジー・フォース
+  name-sort: ぜろのつかいま ふぁんたじーふぉーす
+  name-en: "Zero no Tsukaima - Fantasy Force"
   region: "NTSC-J"
 SLPS-20503:
   name: SIMPLE2000シリーズ Vol.121 THE ぼくの街づくり2 〜街ingメーカー2.1〜
@@ -49916,7 +50043,7 @@ SLPS-20503:
   region: "NTSC-J"
 SLPS-20504:
   name: 大都技研公式パチスロシュミレーター 新・吉宗
-  name-sort: だいとぎけんこうしきぱちすろしゅみれーたー しん・よしたかし
+  name-sort: だいとぎけんこうしきぱちすろしゅみれーたー しん よしむね
   name-en: "Daito Giken Koushiki Pachi-Slot Simulator - Shin Yoshimune"
   region: "NTSC-J"
 SLPS-20505:
@@ -49946,7 +50073,7 @@ SLPS-25001:
     disablePartialInvalidation: 1 # Fixes raphics issues.
 SLPS-25002:
   name: DEAD OR ALIVE 2
-  name-sort: DEAD OR ALIVE 2
+  name-sort: でっど おあ あらいぶ2
   name-en: "Dead or Alive 2"
   region: "NTSC-J"
   compat: 5
@@ -49996,7 +50123,7 @@ SLPS-25006:
   region: "NTSC-J"
 SLPS-25007:
   name: アーマード・コア 2
-  name-sort: あーまーど・こあ 2
+  name-sort: あーまーどこあ 2
   name-en: "Armored Core 2"
   region: "NTSC-J"
   clampModes:
@@ -50102,7 +50229,7 @@ SLPS-25024:
   region: "NTSC-J"
 SLPS-25025:
   name: 7(セブン)〜モールモースの騎兵隊〜
-  name-sort: せぶん〜もーるもーすのきへいたい〜
+  name-sort: せぶん もーるもーすのきへいたい
   name-en: "7 (Seven) - Molmorth no Kiheitai"
   region: "NTSC-J"
   compat: 5
@@ -50110,7 +50237,7 @@ SLPS-25025:
     - EETimingHack # Correct graphics after changing scene.
 SLPS-25026:
   name: DOA2 HARD・CORE
-  name-sort: DOA2 HARD・CORE
+  name-sort: でっどおああらいぶ2 はーどこあ
   name-en: "DOA 2 - Hardcore"
   region: "NTSC-J"
   compat: 5
@@ -50131,7 +50258,7 @@ SLPS-25028:
   compat: 5
 SLPS-25029:
   name: レイマン レボリューション！
-  name-sort: れいまん れぼりゅーしょん！
+  name-sort: れいまん れぼりゅーしょん!
   name-en: "Rayman 2 Revolution"
   region: "NTSC-J"
   roundModes:
@@ -50146,12 +50273,12 @@ SLPS-25031:
   region: "NTSC-J"
 SLPS-25032:
   name: ゴルフルGOLF
-  name-sort: ごるふるGOLF
+  name-sort: ごるふるごるふ
   name-en: "Golful Golf"
   region: "NTSC-J"
 SLPS-25033:
   name: 風のクロノア2〜世界が望んだ忘れもの〜
-  name-sort: かぜのくろのあ2〜せかいがのぞんだわすれもの〜
+  name-sort: かぜのくろのあ2 せかいがのぞんだわすれもの
   name-en: "Kaze no Klonoa 2 - Sekai ga Nozonda Wasuremono"
   region: "NTSC-J"
   compat: 5
@@ -50198,7 +50325,7 @@ SLPS-25039:
   region: "NTSC-J"
 SLPS-25040:
   name: アーマード・コア 2　アナザーエイジ
-  name-sort: あーまーど・こあ 2　あなざーえいじ
+  name-sort: あーまーどこあ 2 あなざーえいじ
   name-en: "Armored Core 2 - Another Age"
   region: "NTSC-J"
   compat: 5
@@ -50221,7 +50348,7 @@ SLPS-25041:
     textureInsideRT: 2 # Fixes Post and transition effects.
 SLPS-25042:
   name: 魔剣爻 -MAKEN SHAO-（初回限定版）
-  name-sort: まけんしゃお -MAKEN SHAO-（しょかいげんていばん）
+  name-sort: まけんしゃお [しょかいげんていばん]
   name-en: "Maken Shao [Limited Edition]"
   region: "NTSC-J"
   speedHacks:
@@ -50246,7 +50373,7 @@ SLPS-25044:
     trilinearFiltering: 1 # Fixes shimmering noisy textures
 SLPS-25045:
   name: リリーのアトリエ 〜ザールブルグの錬金術士3〜
-  name-sort: りりーのあとりえ 〜ざーるぶるぐのれんきんじゅつし3〜
+  name-sort: りりーのあとりえ ざーるぶるぐのれんきんじゅつし3
   name-en: "Lilie no Atelier - Salburg no Renkinjutsushi 3"
   region: "NTSC-J"
 SLPS-25046:
@@ -50266,7 +50393,7 @@ SLPS-25048:
   region: "NTSC-J"
 SLPS-25050:
   name: ファイナルファンタジーX
-  name-sort: ふぁいなるふぁんたじーX
+  name-sort: ふぁいなるふぁんたじー10
   name-en: "Final Fantasy X"
   region: "NTSC-J"
   compat: 5
@@ -50303,11 +50430,11 @@ SLPS-25052:
 SLPS-25053:
   name: 栄冠は君に 甲子園の覇者
   name-sort: えいかんはきみに こうしえんのはしゃ
-  name-en: "Eikan wa Kimi ni - Koushien no Hasha"
+  name-en: "Eikan ha Kimi ni - Koushien no Hasha"
   region: "NTSC-J"
 SLPS-25054:
   name: 玉繭物語2〜滅びの蟲〜
-  name-sort: たままゆものがたり2〜ほろびの蟲〜
+  name-sort: たままゆものがたり2 ほろびのむし
   name-en: "Tamamayu Story 2"
   region: "NTSC-J"
 SLPS-25055:
@@ -50354,7 +50481,7 @@ SLPS-25062:
   region: "NTSC-J"
 SLPS-25064:
   name: シーマン 〜禁断のペット〜 ガゼー博士の実験島（シーマイクコントローラ同梱版）
-  name-sort: しーまん 〜きんだんのぺっと〜 がぜーはかせのじっけんとう（しーまいくこんとろーらどうこんばん）
+  name-sort: しーまん きんだんのぺっと がぜーはかせのじっけんとう（しーまいくこんとろーらどうこんばん）
   name-en: "Sea-Man"
   region: "NTSC-J"
 SLPS-25065:
@@ -50368,7 +50495,7 @@ SLPS-25068:
   region: "NTSC-J"
 SLPS-25069:
   name: FIFA 2002 ロード・トゥ・FIFAワールドカップ
-  name-sort: FIFA 2002 ろーど・とぅ・FIFAわーるどかっぷ
+  name-sort: FIFA 2002 ろーど とぅ FIFAわーるどかっぷ
   name-en: "FIFA 2002 - Road to World Cup"
   region: "NTSC-J"
   gsHWFixes:
@@ -50380,7 +50507,7 @@ SLPS-25070:
   region: "NTSC-J"
 SLPS-25071:
   name: “A” VISUAL MIX [ディスク1/2]
-  name-sort: “A” VISUAL MIX [でぃすく1/2]
+  name-sort: A VISUAL MIX [でぃすく1/2]
   name-en: "Visual Mix - Ayumi Hamasaki Dome Tour 2001 [Disc 1 of 2]"
   region: "NTSC-J"
   memcardFilters:
@@ -50390,7 +50517,7 @@ SLPS-25071:
     - "SLPM-65087"
 SLPS-25072:
   name: “A” VISUAL MIX [ディスク2/2]
-  name-sort: “A” VISUAL MIX [でぃすく2/2]
+  name-sort: A VISUAL MIX [でぃすく2/2]
   name-en: "Visual Mix - Ayumi Hamasaki Dome Tour 2001 [Disc 2 of 2]"
   region: "NTSC-J"
   memcardFilters:
@@ -50403,7 +50530,7 @@ SLPS-25073:
   region: "NTSC-J"
 SLPS-25074:
   name: 零 〜zero〜
-  name-sort: ぜろ 〜zero〜
+  name-sort: ぜろ
   name-en: "Project Zero"
   region: "NTSC-J"
   compat: 5
@@ -50453,7 +50580,7 @@ SLPS-25079:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
 SLPS-25080:
-  name: 宇宙戦艦ヤマト イスカンダルへの追憶 [初回生産限定版]
+  name: 宇宙戦艦ヤマト イスカンダルへの追憶(初回生産限定版)
   name-sort: うちゅうせんかんやまと いすかんだるへのついおく [しょかいせいさんげんていばん]
   name-en: "Uchuu Senkan Yamato - Iscandar he no Tsuioku [Special Edition]"
   region: "NTSC-J"
@@ -50482,7 +50609,7 @@ SLPS-25087:
   region: "NTSC-J"
 SLPS-25088:
   name: ファイナルファンタジーX インターナショナル
-  name-sort: ふぁいなるふぁんたじーX いんたーなしょなる
+  name-sort: ふぁいなるふぁんたじー10 いんたーなしょなる
   name-en: "Final Fantasy X International"
   region: "NTSC-J"
   compat: 5
@@ -50502,7 +50629,7 @@ SLPS-25089:
     textureInsideRT: 1 # Fixes graphical corruption.
 SLPS-25094:
   name: リーヴェルファンタジア 〜マリエルと妖精物語〜
-  name-sort: りーゔぇるふぁんたじあ 〜まりえるとようせいものがたり〜
+  name-sort: りーゔぇるふぁんたじあ まりえるとようせいものがたり
   name-en: "Reveal Fantasia"
   region: "NTSC-J"
   gameFixes:
@@ -50529,7 +50656,7 @@ SLPS-25098:
   region: "NTSC-J"
 SLPS-25099:
   name: WRC〜ワールドラリーチャンピオンシップ〜
-  name-sort: WRC〜わーるどらりーちゃんぴおんしっぷ〜
+  name-sort: わーるどらりーちゃんぴおんしっぷ
   name-en: "World Rally Championship"
   region: "NTSC-J"
   roundModes:
@@ -50556,7 +50683,7 @@ SLPS-25102:
   region: "NTSC-J"
 SLPS-25103:
   name: スーパーロボット大戦IMPACT 限定版
-  name-sort: すーぱーろぼっとたいせんIMPACT げんていばん
+  name-sort: すーぱーろぼっとたいせんIMPACT [げんていばん]
   name-en: "Super Robot Taisen Impact [Limited Edition]"
   region: "NTSC-J"
   gsHWFixes:
@@ -50599,7 +50726,7 @@ SLPS-25111:
   region: "NTSC-J"
 SLPS-25112:
   name: アーマード・コア 3
-  name-sort: あーまーど・こあ 3
+  name-sort: あーまーどこあ3
   name-en: "Armored Core 3"
   region: "NTSC-J"
   compat: 5
@@ -50621,12 +50748,12 @@ SLPS-25114:
   region: "NTSC-J"
 SLPS-25115:
   name: E.O.E 〜崩壊の前夜〜
-  name-sort: E.O.E 〜ほうかいのぜんや〜
+  name-sort: E.O.E ほうかいのぜんや
   name-en: "EOE - Eve of Extinction - Houkai no Zen'ya"
   region: "NTSC-J"
 SLPS-25117:
   name: FEVER6 SANKYO公式パチンコシミュレーション
-  name-sort: FEVER6 SANKYOこうしきぱちんこしみゅれーしょん
+  name-sort: FEVER6 さんきょうこうしきぱちんこしみゅれーしょん
   name-en: "Sankyo Fever 6"
   region: "NTSC-J"
 SLPS-25118:
@@ -50639,7 +50766,7 @@ SLPS-25118:
     trilinearFiltering: 1
 SLPS-25119:
   name: ガレリアンズ:アッシュ
-  name-sort: がれりあんず:あっしゅ
+  name-sort: がれりあんず あっしゅ
   name-en: "Galerians 2"
   region: "NTSC-J"
   patches:
@@ -50659,9 +50786,9 @@ SLPS-25120:
   name-en: "Gundam Gihren's Ambition"
   region: "NTSC-J"
 SLPS-25121:
-  name: dot hack - 感染拡大 Vol.1
-  name-sort: dot hack - かんせんかくだい Vol.1
-  name-en: "dot hack - Infection Part 1"
+  name: .hack//感染拡大 Vol.1
+  name-sort: どっとはっく かんせんかくだい Vol.1
+  name-en: ".hack//Infection Part 1"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 1 # Sharpens world in far distances.
@@ -50700,21 +50827,21 @@ SLPS-25125:
   region: "NTSC-J"
 SLPS-25127:
   name: AIR
-  name-sort: AIR
+  name-sort: えあー
   name-en: "Air"
   region: "NTSC-J"
 SLPS-25128:
   name: "Victorious Boxer - Championship Version"
   region: "NTSC-J"
 SLPS-25129:
-  name: はじめの一歩 VICTORIOUS BOXERS 〜CHAMPIONSHIP VERSION〜 PS2 the Best
-  name-sort: はじめのいっぽ VICTORIOUS BOXERS 〜CHAMPIONSHIP VERSION〜 PS2 the Best
-  name-en: "Victorious Boxers - Championship Edition [PS2 The Best]"
+  name: はじめの一歩 VICTORIOUS BOXERS 〜CHAMPIONSHIP VERSION〜 PlayStation 2 the Best
+  name-sort: はじめのいっぽ VICTORIOUS BOXERS CHAMPIONSHIP VERSION PlayStation 2 the Best
+  name-en: "Victorious Boxers - Championship Edition [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPS-25130:
   name: ルームメイト・麻美-おくさまは女子高生-
-  name-sort: るーむめいと・あさみ-おくさまはじょしこうせい-
-  name-en: "Roommate Asami - Okusama wa Joshikousei"
+  name-sort: るーむめいとあさみ おくさまはじょしこうせい
+  name-en: "Roommate Asami - Okusama ha Joshikousei"
   region: "NTSC-J"
 SLPS-25131:
   name: ゴーストヴァイブレーション
@@ -50726,7 +50853,7 @@ SLPS-25132:
   region: "NTSC-J"
 SLPS-25135:
   name: かまいたちの夜2〜監獄島のわらべ唄〜
-  name-sort: かまいたちのよる2〜かんごくじまのわらべうた〜
+  name-sort: かまいたちのよる2 かんごくじまのわらべうた
   name-en: "Kamaitachi no Yoru 2"
   region: "NTSC-J"
 SLPS-25136:
@@ -50736,7 +50863,7 @@ SLPS-25136:
   region: "NTSC-J"
 SLPS-25138:
   name: Ever17〜the out of infinity〜 [限定版]
-  name-sort: Ever17〜the out of infinity〜 [げんていばん]
+  name-sort: Ever17 the out of infinity [げんていばん]
   name-en: "Ever 17 - The Out of Infinity"
   region: "NTSC-J"
 SLPS-25139:
@@ -50763,7 +50890,7 @@ SLPS-25141:
     - EETimingHack # Fixes hanging in Butane Pain, Ghost Bayou, Pinky's Revenge and Clyde in the Caldera levels.
 SLPS-25142:
   name: タイガー・ウッズ PGA TOUR 2002
-  name-sort: たいがー・うっず PGA TOUR 2002
+  name-sort: たいがーうっず PGA TOUR 2002
   name-en: "Tiger Woods PGA Tour 2002"
   region: "NTSC-J"
   gameFixes:
@@ -50772,9 +50899,9 @@ SLPS-25142:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
 SLPS-25143:
-  name: dot hack - 悪性変異 Vol.2
-  name-sort: dot hack - あくせいへんい Vol.2
-  name-en: "dot hack - Mutation Part 2"
+  name: .hack//悪性変異 Vol.2
+  name-sort: どっとはっく あくせいへんい Vol.2
+  name-en: ".hack//Mutation Part 2"
   region: "NTSC-J"
   memcardFilters:
     - "SCPS-55029"
@@ -50796,12 +50923,12 @@ SLPS-25144:
   region: "NTSC-J"
 SLPS-25145:
   name: フーリガン〜君のなかの勇気〜 [限定版]
-  name-sort: ふーりがん〜きみのなかのゆうき〜 [げんていばん]
+  name-sort: ふーりがん きみのなかのゆうき [げんていばん]
   name-en: "Hooligan [Limited Edition]"
   region: "NTSC-J"
 SLPS-25146:
   name: フーリガン〜君のなかの勇気〜
-  name-sort: ふーりがん〜きみのなかのゆうき〜
+  name-sort: ふーりがん きみのなかのゆうき
   name-en: "Hooligan"
   region: "NTSC-J"
 SLPS-25147:
@@ -50810,11 +50937,13 @@ SLPS-25147:
   clampModes:
     vuClampMode: 3 # Fixes SPS on menu.
 SLPS-25148:
-  name: "Panel Quiz Attack 25"
+  name: "パネルクイズ アタック25"
+  name-sort: "ぱねるくいず あたっく25"
+  name-en: "Panel Quiz Attack 25"
   region: "NTSC-J"
 SLPS-25149:
   name: Ever17〜the out of infinity〜
-  name-sort: Ever17〜the out of infinity〜
+  name-sort: Ever17 the out of infinity
   name-en: "Ever 17 - The Out of Infinity"
   region: "NTSC-J"
 SLPS-25150:
@@ -50824,7 +50953,7 @@ SLPS-25150:
   region: "NTSC-J"
 SLPS-25151:
   name: メダル・オブ・オナー 史上最大の作戦
-  name-sort: めだる・おぶ・おなー しじょうさいだいのさくせん
+  name-sort: めだる おぶ おなー しじょうさいだいのさくせん
   name-en: "Medal of Honor - Shijou Saidai no Sakusen"
   region: "NTSC-J"
 SLPS-25153:
@@ -50844,7 +50973,7 @@ SLPS-25155:
   region: "NTSC-J"
 SLPS-25156:
   name: ザ・キング・オブ・ファイターズ2000
-  name-sort: ざ・きんぐ・おぶ・ふぁいたーず2000
+  name-sort: ざ きんぐ おぶ ふぁいたーず2000
   name-en: "King of Fighters 2000, The"
   region: "NTSC-J"
 SLPS-25157:
@@ -50856,9 +50985,9 @@ SLPS-25157:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
 SLPS-25158:
-  name: dot hack - 侵食汚染 Vol.3
-  name-sort: dot hack - しんしょくおせん Vol.3
-  name-en: "dot hack - Outbreak Part 3"
+  name: .hack//侵食汚染 Vol.3
+  name-sort: どっとはっく しんしょくおせん Vol.3
+  name-en: ".hack//Outbreak Part 3"
   region: "NTSC-J"
   memcardFilters:
     - "SCPS-55029"
@@ -50880,7 +51009,7 @@ SLPS-25159:
   region: "NTSC-J"
 SLPS-25160:
   name: ファイナルファンタジーXI 2002 SPECIAL ART BOX
-  name-sort: ふぁいなるふぁんたじーXI 2002 SPECIAL ART BOX
+  name-sort: ふぁいなるふぁんたじー11 2002 SPECIAL ART BOX
   name-en: "Final Fantasy XI 2002 [Special Art Box]"
   region: "NTSC-J"
 SLPS-25161:
@@ -50918,7 +51047,7 @@ SLPS-25168:
   region: "NTSC-J"
 SLPS-25169:
   name: アーマード・コア 3　サイレントライン
-  name-sort: あーまーど・こあ 3　サイレントライン
+  name-sort: あーまーどこあ3 さいれんとらいん
   name-en: "Armored Core 3 - Silent Line"
   region: "NTSC-J"
   gsHWFixes:
@@ -50990,12 +51119,12 @@ SLPS-25181:
   region: "NTSC-J"
 SLPS-25182:
   name: アイドル雀士R 雀ぐる★プロジェクト [限定版]
-  name-sort: あいどるじゃんしR じゃんぐる★ぷろじぇくと [げんていばん]
+  name-sort: あいどるじゃんしR じゃんぐるぷろじぇくと [げんていばん]
   name-en: "Idol Janshi R - Jan-Guru Project [Limited Edition]"
   region: "NTSC-J"
 SLPS-25183:
   name: アイドル雀士R 雀ぐる★プロジェクト
-  name-sort: あいどるじゃんしR じゃんぐる★ぷろじぇくと
+  name-sort: あいどるじゃんしR じゃんぐるぷろじぇくと
   name-en: "Idol Janshi R - Jan-Guru Project"
   region: "NTSC-J"
 SLPS-25184:
@@ -51025,7 +51154,7 @@ SLPS-25189:
   region: "NTSC-J"
 SLPS-25190:
   name: スイートレガシー 〜ボクと彼女の名もないお菓子〜
-  name-sort: すいーとれがしー 〜ぼくとかのじょのなもないおかし〜
+  name-sort: すいーとれがしー ぼくとかのじょのなもないおかし
   name-en: "Sweet Legacy"
   region: "NTSC-J"
 SLPS-25191:
@@ -51048,7 +51177,7 @@ SLPS-25194:
   region: "NTSC-J"
 SLPS-25195:
   name: ヴィーナス&ブレイブス 〜魔女と女神と滅びの予言〜 プレミアムボックス
-  name-sort: ゔぃーなす&ぶれいぶす 〜まじょとめがみとほろびのよげん〜 ぷれみあむぼっくす
+  name-sort: ゔぃーなす&ぶれいぶす まじょとめがみとほろびのよげん ぷれみあむぼっくす
   name-en: "Venus & Braves [Premium Pack]"
   region: "NTSC-J"
   compat: 5
@@ -51056,7 +51185,7 @@ SLPS-25195:
     - EETimingHack
 SLPS-25196:
   name: ヴィーナス&ブレイブス 〜魔女と女神と滅びの予言〜
-  name-sort: ゔぃーなす&ぶれいぶす 〜まじょとめがみとほろびのよげん〜
+  name-sort: ゔぃーなす&ぶれいぶす まじょとめがみとほろびのよげん
   name-en: "Venus & Braves"
   region: "NTSC-J"
   compat: 5
@@ -51085,7 +51214,7 @@ SLPS-25199:
   compat: 5
 SLPS-25200:
   name: ファイナルファンタジーXI
-  name-sort: ふぁいなるふぁんたじーXI
+  name-sort: ふぁいなるふぁんたじー11
   name-en: "Final Fantasy XI"
   region: "NTSC-J"
   compat: 3
@@ -51097,9 +51226,9 @@ SLPS-25201:
   gameFixes:
     - InstantDMAHack # Fixes NULL GIFChain hang.
 SLPS-25202:
-  name: dot hack - 絶対包囲 Vol.4
-  name-sort: dot hack - ぜったいほうい Vol.4
-  name-en: "dot hack - Quarantine Part 4"
+  name: .hack//絶対包囲 Vol.4
+  name-sort: どっとはっく ぜったいほうい Vol.4
+  name-en: ".hack//Quarantine Part 4"
   region: "NTSC-J"
   memcardFilters:
     - "SCPS-55029"
@@ -51179,35 +51308,35 @@ SLPS-25216:
   region: "NTSC-J"
   compat: 5
 SLPS-25217:
-  name: SHADOW TOWER ABYSS(シャドウタワー アビス)
+  name: SHADOW TOWER ABYSS (シャドウタワー アビス)
   name-sort: しゃどうたわー あびす
   name-en: "Shadow Tower Abyss"
   region: "NTSC-J"
   compat: 5
 SLPS-25219:
-  name: カナリア～この想いを歌に乗せて～
-  name-sort: かなりあ～このおもいをうたにのせて～
+  name: カナリア〜この想いを歌に乗せて〜
+  name-sort: かなりあ このおもいをうたにのせて
   name-en: "Canary"
   region: "NTSC-J"
 SLPS-25220:
   name: エリュシオン〜永遠のサンクチュアリ〜
-  name-sort: えりゅしおん〜えいえんのさんくちゅあり〜
+  name-sort: えりゅしおん えいえんのさんくちゅあり
   name-en: "Elysion"
   region: "NTSC-J"
 SLPS-25221:
   name: Piaキャロットへようこそ!!3〜round summer〜（初回限定版）
-  name-sort: Piaきゃろっとへようこそ!!3〜round summer〜（しょかいげんていばん）
-  name-en: "Pia - Welcome to Carrot 3"
+  name-sort: ぴあきゃろっとへようこそ!!3 round summer しょかいげんていばん
+  name-en: "Welcome to Pia Carrot!! 3"
   region: "NTSC-J"
 SLPS-25223:
   name: Canvas〜セピア色のモチーフ〜
-  name-sort: Canvas〜せぴあいろのもちーふ〜
+  name-sort: Canvas せぴあいろのもちーふ
   name-en: "Canvas - Sepia-iro no Motif"
   region: "NTSC-J"
 SLPS-25224:
   name: 藍より青し 初回限定版
   name-sort: あいよりあおし しょかいげんていばん
-  name-en: "Ai yori Aoshi [Shokai Genteiban]"
+  name-en: "Ai yori Aoshi [First Print Limited Edition]"
   region: "NTSC-J"
 SLPS-25225:
   name: 藍より青し
@@ -51215,8 +51344,8 @@ SLPS-25225:
   name-en: "Ai Yori Aoshi"
   region: "NTSC-J"
 SLPS-25226:
-  name: メモリーズオフ デュエット～1st ＆ 2ndストーリーズ～
-  name-sort: めもりーずおふ でゅえっと～1st ＆ 2ndすとーりーず～
+  name: メモリーズオフ デュエット〜1st ＆ 2ndストーリーズ〜
+  name-sort: めもりーずおふ でゅえっと 1st & 2ndすとーりーず
   name-en: "Memories Off - Duet"
   region: "NTSC-J"
 SLPS-25227:
@@ -51242,7 +51371,7 @@ SLPS-25230:
     recommendedBlendingLevel: 3 # Fixes menu transparency.
 SLPS-25231:
   name: ミストIII:エグザイル
-  name-sort: みすとIII:えぐざいる
+  name-sort: みすとIII えぐざいる
   name-en: "Myst III - Exile"
   region: "NTSC-J"
   patches:
@@ -51262,7 +51391,7 @@ SLPS-25233:
   compat: 5
 SLPS-25234:
   name: 天誅 参
-  name-sort: てんちゅう さん
+  name-sort: てんちゅう3
   name-en: "Tenchu 3"
   region: "NTSC-J"
 SLPS-25235:
@@ -51290,25 +51419,25 @@ SLPS-25238:
   region: "NTSC-J"
 SLPS-25240:
   name: MEGUMI / モーショングラビアシリーズ(仮)
-  name-sort: MEGUMI / もーしょんぐらびあしりーず(かり)
+  name-sort: MEGUMI もーしょんぐらびあしりーず(かり)
   name-en: "Motion Gravure Series - Megumi"
   region: "NTSC-J"
   compat: 5
 SLPS-25241:
   name: 森ひろこ / モーショングラビアシリーズ(仮)
-  name-sort: もりひろこ / もーしょんぐらびあしりーず(かり)
+  name-sort: もりひろこ もーしょんぐらびあしりーず(かり)
   name-en: "Motion Gravure Series - Hiroko Mori"
   region: "NTSC-J"
   compat: 5
 SLPS-25242:
   name: 北川友美 / モーショングラビアシリーズ(仮)
-  name-sort: きたがわともみ / もーしょんぐらびあしりーず(かり)
+  name-sort: きたがわともみ もーしょんぐらびあしりーず(かり)
   name-en: "Motion Gravure Series - Tomomi Kitagawa"
   region: "NTSC-J"
   compat: 5
 SLPS-25243:
   name: 根本はるみ / モーショングラビアシリーズ(仮)
-  name-sort: ねもとはるみ / もーしょんぐらびあしりーず(かり)
+  name-sort: ねもとはるみ もーしょんぐらびあしりーず(かり)
   name-en: "Motion Gravure Series - Harumi Nemoto"
   region: "NTSC-J"
   compat: 5
@@ -51339,7 +51468,7 @@ SLPS-25247:
   compat: 5
 SLPS-25248:
   name: キノの旅 -the Beautiful World-
-  name-sort: きののたび -the Beautiful World-
+  name-sort: きののたび the Beautiful World
   name-en: "Kino no Tabi - The Beautiful World"
   region: "NTSC-J"
 SLPS-25249:
@@ -51347,7 +51476,7 @@ SLPS-25249:
   region: "NTSC-J"
 SLPS-25250:
   name: ファイナルファンタジーX-2
-  name-sort: ふぁいなるふぁんたじーX-2
+  name-sort: ふぁいなるふぁんたじー10-2
   name-en: "Final Fantasy X-2"
   region: "NTSC-J"
   clampModes:
@@ -51391,42 +51520,44 @@ SLPS-25255:
   region: "NTSC-J"
 SLPS-25256:
   name: Never7 〜the end of infinity〜
-  name-sort: Never7 〜the end of infinity〜
+  name-sort: Never7 the end of infinity
   name-en: "Never 7 - The End of Infinity"
   region: "NTSC-J"
 SLPS-25257:
-  name: 想いのかけら ～Close to ～
-  name-sort: おもいのかけら ～Close to ～
+  name: 想いのかけら 〜Close to 〜
+  name-sort: おもいのかけら Close to
   name-en: "Close To"
   region: "NTSC-J"
 SLPS-25258:
   name: ヴァーチャルビュー R.C.T エイゾープレイ
   name-sort: ゔぁーちゃるびゅー R.C.T えいぞーぷれい
-  name-en: "Virtual View - R.C.T. Eyes Play"
+  name-en: "Virtual View - R.C.T. Video Play"
   region: "NTSC-J"
 SLPS-25259:
   name: ヴァーチャル・ビュー 根本はるみ エイゾープレイ
-  name-sort: ゔぁーちゃる・びゅー ねもとはるみ えいぞーぷれい
+  name-sort: ゔぁーちゃるびゅー ねもとはるみ えいぞーぷれい
   name-en: "Virtual View - Nemoto Harumi"
   region: "NTSC-J"
 SLPS-25260:
   name: ヴァーチャル・ビュー MEGUMI エイゾープレイ
-  name-sort: ゔぁーちゃる・びゅー MEGUMI えいぞーぷれい
+  name-sort: ゔぁーちゃるびゅー MEGUMI えいぞーぷれい
   name-en: "Virtual View - Megumi"
   region: "NTSC-J"
 SLPS-25261:
-  name: GUILTY GEAR XX #RELOAD ～THE MIDNIGHT CARNIVAL～
-  name-sort: GUILTY GEAR XX #RELOAD ～THE MIDNIGHT CARNIVAL～
-  name-en: "Guilty Gear XX #Reload"
+  name: GUILTY GEAR XX #RELOAD 〜THE MIDNIGHT CARNIVAL〜
+  name-sort: ぎるてぃぎあ いぐぜくす しゃーぷりろーど THE MIDNIGHT CARNIVAL
+  name-en: "Guilty Gear XX #Reload - The Midnight Carnival"
   region: "NTSC-J"
 SLPS-25262:
   name: プライベートナース -まりあ-
-  name-sort: ぷらいべーとなーす -まりあ-
+  name-sort: ぷらいべーとなーす まりあ
   name-en: "Private Nurse Maria"
   region: "NTSC-J"
   compat: 5
 SLPS-25263:
-  name: "Monster Farm 4"
+  name: モンスターファーム4
+  name-sort: もんすたーふぁーむ4
+  name-en: "Monster Farm 4"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
@@ -51443,7 +51574,7 @@ SLPS-25264:
 SLPS-25265:
   name: ラーゼフォン 蒼穹幻想曲 [通常版]
   name-sort: らーぜふぉん そうきゅうげんそうきょく [つうじょうばん]
-  name-en: "RAhXEPhON - Soukyuu Gensoukyoku"
+  name-en: "RAhXEPhON - Soukyuu Gensoukyoku [Standard Edition]"
   region: "NTSC-J"
   roundModes:
     eeDivRoundMode: 3 # Fixes floating chairs.
@@ -51451,7 +51582,7 @@ SLPS-25265:
     autoFlush: 2 # Fixes DOF effect.
 SLPS-25266:
   name: ザ・キング・オブ・ファイターズ 2001
-  name-sort: ざ・きんぐ・おぶ・ふぁいたーず 2001
+  name-sort: ざ きんぐ おぶ ふぁいたーず 2001
   name-en: "King of Fighters 2001, The"
   region: "NTSC-J"
 SLPS-25267:
@@ -51472,7 +51603,7 @@ SLPS-25270:
   region: "NTSC-J"
 SLPS-25271:
   name: サイドワインダー V
-  name-sort: さいどわいんだー V
+  name-sort: さいどわいんだーV
   name-en: "Sidewinder V"
   region: "NTSC-J"
   compat: 5
@@ -51486,7 +51617,7 @@ SLPS-25272:
     trilinearFiltering: 1
 SLPS-25274:
   name: あいかぎ 〜ぬくもりとひだまりの中で〜
-  name-sort: あいかぎ 〜ぬくもりとひだまりのなかで〜
+  name-sort: あいかぎ ぬくもりとひだまりのなかで
   name-en: "Aikagi"
   region: "NTSC-J"
 SLPS-25275:
@@ -51548,7 +51679,7 @@ SLPS-25290:
     texturePreloading: 0 # Performs much better with no preload.
 SLPS-25291:
   name: バルダーズゲート・ダークアライアンス [PCCWジャパン・ザ・ベスト]
-  name-sort: ばるだーずげーと・だーくあらいあんす [PCCWじゃぱん・ざ・べすと]
+  name-sort: ばるだーずげーと だーくあらいあんす [PCCWじゃぱん・ざ・べすと]
   name-en: "Baldur's Gate - Dark Alliance [PCCW The Best]"
   region: "NTSC-J"
   compat: 5
@@ -51562,7 +51693,7 @@ SLPS-25292:
   region: "NTSC-J"
 SLPS-25293:
   name: NARUTO -ナルト- ナルティメットヒーロー
-  name-sort: NARUTO -なると- なるてぃめっとひーろー
+  name-sort: なると なるてぃめっとひーろー
   name-en: "Naruto - Narutimett Hero"
   region: "NTSC-J"
   compat: 5
@@ -51572,7 +51703,7 @@ SLPS-25294:
   name-en: "Uchuu no Stellvia"
   region: "NTSC-J"
 SLPS-25295:
-  name: Kaena(ケイナ)
+  name: Kaena
   name-sort: けいな
   name-en: "Kaena"
   region: "NTSC-J"
@@ -51613,7 +51744,7 @@ SLPS-25302:
   region: "NTSC-J"
 SLPS-25303:
   name: 零〜紅い蝶〜
-  name-sort: ぜろ〜あかいちょう〜
+  name-sort: ぜろ あかいちょう
   name-en: "Zero - Crimson Butterfly"
   region: "NTSC-J"
   compat: 5
@@ -51634,7 +51765,7 @@ SLPS-25307:
   region: "NTSC-J"
 SLPS-25308:
   name: クラウチングタイガー・ヒドゥンドラゴン
-  name-sort: くらうちんぐたいがー・ひどぅんどらごん
+  name-sort: くらうちんぐたいがー ひどぅんどらごん
   name-en: "Crouching Tiger, Hidden Dragon"
   region: "NTSC-J"
   gameFixes:
@@ -51646,7 +51777,7 @@ SLPS-25309:
   region: "NTSC-J"
 SLPS-25310:
   name: ファインディング・ニモ
-  name-sort: ふぁいんでぃんぐ・にも
+  name-sort: ふぁいんでぃんぐ にも
   name-en: "Disney-Pixar's Finding Nemo"
   region: "NTSC-J"
   gsHWFixes:
@@ -51659,7 +51790,7 @@ SLPS-25311:
   region: "NTSC-J"
 SLPS-25312:
   name: ZERO PIROT 〜孤空の奇蹟〜
-  name-sort: ZERO PIROT 〜こくうのきせき〜
+  name-sort: ZERO PIROT こくうのきせき
   name-en: "Zero Pilot - The Miracle in Lonely Air"
   region: "NTSC-J"
 SLPS-25313:
@@ -51725,12 +51856,12 @@ SLPS-25321:
 SLPS-25323:
   name: 兎 -野性の闘牌-山城麻雀篇
   name-sort: うさぎ -やせいのとうはい-やましろまーじゃんへん
-  name-en: "Usagi - Yasei no Topai - Yamashiro Mahjong-Hen"
+  name-en: "Usagi - Yasei no Touhai - Yamashiro Mahjong-Hen"
   region: "NTSC-J"
 SLPS-25324:
   name: 西風の狂詩曲(ラプソディ) [初回限定版]
-  name-sort: にしかぜのらぷそでぃ [しょかいげんていばん]
-  name-en: "Rhapsody of Zephyr"
+  name-sort: にしかぜのらぷそでぃ しょかいげんていばん
+  name-en: "Rhapsody of Zephyr, The"
   region: "NTSC-J"
 SLPS-25326:
   name: エキサイティングプロレス5
@@ -51763,7 +51894,7 @@ SLPS-25330:
   region: "NTSC-J"
 SLPS-25332:
   name: SNOW [初回限定版]
-  name-sort: SNOW [しょかいげんていばん]
+  name-sort: SNOW しょかいげんていばん
   name-en: "Snow [First Limited Edition]"
   region: "NTSC-J"
   gsHWFixes:
@@ -51800,7 +51931,7 @@ SLPS-25335:
     - "SLPS-25334"
 SLPS-25336:
   name: バスランディング3 [サミーベスト] [つりコン2+ 同梱版]
-  name-sort: ばすらんでぃんぐ3 [さみーべすと] [つりこん2+ どうこんばん]
+  name-sort: ばすらんでぃんぐ3 [さみーべすと] [つりこん2 どうこんばん]
   name-en: "Bass Landing 3 [with TsuriCon2+] [Sammy Best]"
   region: "NTSC-J"
 SLPS-25337:
@@ -51810,7 +51941,7 @@ SLPS-25337:
   region: "NTSC-J"
 SLPS-25338:
   name: アーマード・コア ネクサス [DISC 1]
-  name-sort: あーまーど・こあ ねくさす [DISC 1]
+  name-sort: あーまーどこあ ねくさす [DISC 1]
   name-en: "Armored Core - Nexus [Disc 1]"
   region: "NTSC-J"
   gsHWFixes:
@@ -51825,7 +51956,7 @@ SLPS-25338:
     - "SLPS-73203"
 SLPS-25339:
   name: アーマード・コア ネクサス [DISC 2]
-  name-sort: あーまーど・こあ ねくさす [DISC 2]
+  name-sort: あーまーどこあ ねくさす [DISC 2]
   name-en: "Armored Core - Nexus [Disc 2]"
   region: "NTSC-J"
   gsHWFixes:
@@ -51857,7 +51988,7 @@ SLPS-25342:
     minimumBlendingLevel: 4 # Fixes transparancy.
 SLPS-25343:
   name: ガンスリンガー・ガール Volume.I
-  name-sort: がんすりんがー・がーる Volume.I
+  name-sort: がんすりんがー がーる Volume.I
   name-en: "Gunslinger Girl Vol.1"
   region: "NTSC-J"
   compat: 5
@@ -51894,8 +52025,8 @@ SLPS-25349:
   region: "NTSC-J"
 SLPS-25350:
   name: 熱チュー!プロ野球2004
-  name-sort: ねつちゅー!ぷろやきゅう2004
-  name-en: "Netsu Chu! Pro Baseball 2004"
+  name-sort: ねっちゅー!ぷろやきゅう2004
+  name-en: "Necchu! Pro Baseball 2004"
   region: "NTSC-J"
 SLPS-25351:
   name: BURNOUT2:POINT OF IMPACT
@@ -51934,7 +52065,7 @@ SLPS-25355:
   region: "NTSC-J"
 SLPS-25356:
   name: ブロークン・ソード〜眠れる竜の伝説〜
-  name-sort: ぶろーくん・そーど〜ねむれるりゅうのでんせつ〜
+  name-sort: ぶろーくん そーど ねむれるりゅうのでんせつ
   name-en: "Broken Sword - Nenereru Ryuu no Densetsu"
   region: "NTSC-J"
 SLPS-25357:
@@ -51944,7 +52075,7 @@ SLPS-25357:
   region: "NTSC-J"
 SLPS-25358:
   name: 金色のガッシュベル!! 友情タッグバトル
-  name-sort: きんいろのがっしゅべる!! ゆうじょうたっぐばとる
+  name-sort: こんじきのがっしゅべる!! ゆうじょうたっぐばとる
   name-en: "Gold Gasho Bell! - Friendship Tag Battle"
   region: "NTSC-J"
 SLPS-25359:
@@ -51954,7 +52085,7 @@ SLPS-25359:
   region: "NTSC-J"
 SLPS-25360:
   name: 塊魂
-  name-sort: かたまりたましい
+  name-sort: かたまりだましい
   name-en: "Katamari Damacy"
   region: "NTSC-J"
   compat: 5
@@ -51991,7 +52122,7 @@ SLPS-25365:
   region: "NTSC-J"
 SLPS-25366:
   name: ゼノサーガ エピソードII [善悪の彼岸] プレミアムボックス [ディスク1/2]
-  name-sort: ぜのさーが えぴそーどII [ぜんあくのひがん] ぷれみあむぼっくす [でぃすく1/2]
+  name-sort: ぜのさーが えぴそーどII ぜんあくのひがん ぷれみあむぼっくす [でぃすく1/2]
   name-en: "Xenosaga Episode II - Jenseits von Gut und Bose [Premium Box] [Disc 1 of 2]"
   region: "NTSC-J"
   gsHWFixes:
@@ -52007,7 +52138,7 @@ SLPS-25366:
     - "SLPS-73224"
 SLPS-25367:
   name: ゼノサーガ エピソードII［善悪の彼岸］ プレミアムボックス [ディスク2/2]
-  name-sort: ぜのさーが えぴそーどII［ぜんあくのひがん］ ぷれみあむぼっくす [でぃすく2/2]
+  name-sort: ぜのさーが えぴそーどII ぜんあくのひがん ぷれみあむぼっくす [でぃすく2/2]
   name-en: "Xenosaga Episode II - Jenseits von Gut und Bose [Premium Box] [Disc 2 of 2]"
   region: "NTSC-J"
   gsHWFixes:
@@ -52023,7 +52154,7 @@ SLPS-25367:
     - "SLPS-73224"
 SLPS-25368:
   name: ゼノサーガ エピソードII［善悪の彼岸］ [ディスク1/2]
-  name-sort: ぜのさーが えぴそーどII［ぜんあくのひがん］ [でぃすく1/2]
+  name-sort: ぜのさーが えぴそーどII ぜんあくのひがん [でぃすく1/2]
   name-en: "Xenosaga Episode II - Jenseits von Gut und Bose [Disc 1 of 2]"
   region: "NTSC-J"
   gsHWFixes:
@@ -52039,7 +52170,7 @@ SLPS-25368:
     - "SLPS-73224"
 SLPS-25369:
   name: ゼノサーガ エピソードII［善悪の彼岸］ [ディスク2/2]
-  name-sort: ぜのさーが えぴそーどII［ぜんあくのひがん］ [でぃすく2/2]
+  name-sort: ぜのさーが えぴそーどII ぜんあくのひがん [でぃすく2/2]
   name-en: "Xenosaga Episode II - Jenseits von Gut und Bose [Disc 2 of 2]"
   region: "NTSC-J"
   gsHWFixes:
@@ -52070,7 +52201,7 @@ SLPS-25372:
   region: "NTSC-J"
 SLPS-25373:
   name: ガンスリンガー・ガール Volume.II
-  name-sort: がんすりんがー・がーる Volume.II
+  name-sort: がんすりんがー がーる Volume.II
   name-en: "Gunslinger Girl Vol.2"
   region: "NTSC-J"
 SLPS-25374:
@@ -52080,7 +52211,7 @@ SLPS-25374:
   region: "NTSC-J"
 SLPS-25375:
   name: XIII[サーティーン]大統領を殺した男
-  name-sort: XIII[さーてぃーん]だいとうりょうをころしたおとこ
+  name-sort: さーてぃーん だいとうりょうをころしたおとこ
   name-en: "XIII"
   region: "NTSC-J"
 SLPS-25376:
@@ -52091,11 +52222,11 @@ SLPS-25376:
   compat: 5
 SLPS-25377:
   name: ザ・ナイトメア・オブ・ドルアーガ 不思議のダンジョン
-  name-sort: ざ・ないとめあ・おぶ・どるあーが ふしぎのだんじょん
+  name-sort: ざ ないとめあ おぶ どるあーが ふしぎのだんじょん
   name-en: "Nightmare of Druaga, The - Fushigi no Dungeon"
   region: "NTSC-J"
 SLPS-25378:
-  name: 東京魔人學園外法帖血風録 [初回限定版]
+  name: 東京魔人學園外法帖血風録(初回限定版)
   name-sort: とうきょうまじんがくえんげほうちょうけっぷうろく [しょかいげんていばん]
   name-en: "Tokyo Majin Gakuen - Kaihoujyou Kefurokou [Limited Edition]"
   region: "NTSC-J"
@@ -52106,7 +52237,7 @@ SLPS-25379:
   region: "NTSC-J"
 SLPS-25381:
   name: 学園ヘヴン BOY’S LOVE SCRAMBLE!
-  name-sort: がくえんへゔん BOY’S LOVE SCRAMBLE!
+  name-sort: がくえんへゔん ぼーいずらぶすくらんぶる!
   name-en: "Gakuen Heaven - Boy's Love Scramble! Type B"
   region: "NTSC-J"
 SLPS-25382:
@@ -52128,7 +52259,7 @@ SLPS-25384:
   region: "NTSC-J"
 SLPS-25385:
   name: フレンズ 〜青春の輝き〜
-  name-sort: ふれんず 〜せいしゅんのかがやき〜
+  name-sort: ふれんず せいしゅんのかがやき
   name-en: "Friends Seishun no Kagayaki"
   region: "NTSC-J"
 SLPS-25386:
@@ -52143,23 +52274,23 @@ SLPS-25387:
   region: "NTSC-J"
 SLPS-25388:
   name: ガンスリンガー・ガール Volume.III
-  name-sort: がんすりんがー・がーる Volume.III
+  name-sort: がんすりんがー がーる Volume.III
   name-en: "Gunslinger Girl Vol.3"
   region: "NTSC-J"
 SLPS-25389:
   name: 機動戦士ガンダムSEED 終わらない明日へ
-  name-sort: きどうせんしがんだむSEED おわらないあしたへ
+  name-sort: きどうせんしがんだむしーど おわらないあしたへ
   name-en: "Gundam Seed - Never Ending Tomorrow"
   region: "NTSC-J"
 SLPS-25390:
-  name: クローバーハーツ ルッキングフォーハピネス [初回限定版]
-  name-sort: くろーばーはーつ るっきんぐふぉーはぴねす [しょかいげんていばん]
+  name: クローバーハーツ ルッキングフォーハピネス(初回限定版)
+  name-sort: くろーばーはーつ るっきんぐふぉーはぴねす しょかいげんていばん
   name-en: "Clover Heart's - Looking for Happiness [Limited Edition]"
   region: "NTSC-J"
   gsHWFixes:
     minimumBlendingLevel: 4 # Fixes transparancy.
 SLPS-25391:
-  name: クローバーハーツ ルッキングフォーハピネス
+  name: クローバーハーツ ルッキングフォーハピネス(通常版)
   name-sort: くろーばーはーつ るっきんぐふぉーはぴねす
   name-en: "Clover Heart's - Looking for Happiness"
   region: "NTSC-J"
@@ -52197,7 +52328,7 @@ SLPS-25397:
   region: "NTSC-J"
 SLPS-25398:
   name: NARUTO-ナルト-ナルティメットヒーロー2
-  name-sort: NARUTO-なると-なるてぃめっとひーろー2
+  name-sort: なると なるてぃめっとひーろー2
   name-en: "Naruto - Narutimett Hero 2"
   region: "NTSC-J"
   clampModes:
@@ -52232,7 +52363,7 @@ SLPS-25402:
   compat: 5
 SLPS-25403:
   name: ヒットマン:サイレントアサシン アイドスベスト
-  name-sort: ひっとまん:さいれんとあさしん あいどすべすと
+  name-sort: ひっとまん さいれんとあさしん あいどすべすと
   name-en: "Hitman - Silent Assassin [Eidos The Best]"
   region: "NTSC-J"
 SLPS-25404:
@@ -52246,8 +52377,8 @@ SLPS-25405:
   name-en: "Tokyo Majin Gakuen - Kaihoujyou Kefurokou [Best Collection]"
   region: "NTSC-J"
 SLPS-25406:
-  name: ヒットマン:コントラクト
-  name-sort: ひっとまん:こんとらくと
+  name: ヒットマン：コントラクト
+  name-sort: ひっとまん こんとらくと
   name-en: "Hitman - Contracts"
   region: "NTSC-J"
   gsHWFixes:
@@ -52261,7 +52392,7 @@ SLPS-25407:
   region: "NTSC-J"
 SLPS-25408:
   name: アーマード・コア ナインブレイカー
-  name-sort: あーまーど・こあ ないんぶれいかー
+  name-sort: あーまーどこあ ないんぶれいかー
   name-en: "Armored Core - Nine Breaker"
   region: "NTSC-J"
   gsHWFixes:
@@ -52277,40 +52408,41 @@ SLPS-25408:
     - "SLPS-73203"
 SLPS-25409:
   name: 双恋—フタコイ— 初回限定版
-  name-sort: そうこい—ふたこい— しょかいげんていばん
+  name-sort: ふたこい しょかいげんていばん
   name-en: "Futakoi [Limited Edition]"
   region: "NTSC-J"
 SLPS-25410:
   name: 双恋—フタコイ—
-  name-sort: そうこい—ふたこい—
+  name-sort: ふたこい
   name-en: "Futakoi"
   region: "NTSC-J"
 SLPS-25411:
   name: ToHeart & ToHeart2 限定デラックスパック
-  name-sort: ToHeart & ToHeart2 げんていでらっくすぱっく
+  name-sort: とぅはーと & とぅはーと2 げんていでらっくすぱっく
   name-en: "To Heart 2 [Deluxe Edition]"
   region: "NTSC-J"
 SLPS-25412:
   name: "ToHeart"
+  name-sort: "とぅはーと"
   region: "NTSC-J"
 SLPS-25413:
   name: ToHeart2 初回限定版
-  name-sort: ToHeart2 しょかいげんていばん
-  name-en: "To Heart 2 [Limited Edition]"
+  name-sort: とぅはーと2 しょかいげんていばん
+  name-en: "ToHeart 2 [Limited Edition]"
   region: "NTSC-J"
 SLPS-25414:
   name: ToHeart2
-  name-sort: ToHeart2
-  name-en: "To Heart 2"
+  name-sort: とぅはーと2
+  name-en: "ToHeart 2"
   region: "NTSC-J"
 SLPS-25415:
   name: ちゅ〜かな雀士 てんほー牌娘 コレクターズエディション
-  name-sort: ちゅ〜かなじゃんし てんほーぱいにゃん これくたーずえでぃしょん
+  name-sort: ちゅーかなじゃんし てんほーぱいにゃん これくたーずえでぃしょん
   name-en: "Chuuka na Janshi - Tenhoo Painyan [Collector's Edition]"
   region: "NTSC-J"
 SLPS-25416:
   name: ちゅ〜かな雀士 てんほー牌娘 [通常版]
-  name-sort: ちゅ〜かなじゃんし てんほーぱいにゃん [つうじょうばん]
+  name-sort: ちゅーかなじゃんし てんほーぱいにゃん [つうじょうばん]
   name-en: "Chuuka na Janshi - Tenhoo Painyan"
   region: "NTSC-J"
 SLPS-25417:
@@ -52320,7 +52452,7 @@ SLPS-25417:
   region: "NTSC-J"
 SLPS-25418:
   name: エースコンバット5 ジ・アンサング・ウォー
-  name-sort: えーすこんばっと5 じ・あんさんぐ・うぉー
+  name-sort: えーすこんばっと5 じ あんさんぐ うぉー
   name-en: "Ace Combat 5 - The Unsung War"
   region: "NTSC-J"
   compat: 5
@@ -52348,11 +52480,11 @@ SLPS-25419:
   name-en: "Mobile Suit Gundam - Gundam vs. Z-Gundam"
   region: "NTSC-J"
 SLPS-25420:
-  name: "Sinbad Adventure wa Enomoto Kanako de Dou desu ka"
+  name: "Sinbad Adventure ha Enomoto Kanako de Dou desu ka"
   region: "NTSC-J"
 SLPS-25421:
   name: 牧場物語 Oh!ワンダフルライフ [初回版]
-  name-sort: ぼくじょうものがたり Oh!わんだふるらいふ [しょかいばん]
+  name-sort: ぼくじょうものがたり Oh わんだふるらいふ [しょかいばん]
   name-en: "Bokujou Monogatari - Oh! Wonderful Life [First Print Limited Edition]"
   region: "NTSC-J"
   patches:
@@ -52363,7 +52495,7 @@ SLPS-25421:
         patch=1,EE,002bd36c,word,00000000
 SLPS-25422:
   name: デス バイ ディグリーズ 鉄拳:ニーナ ウィリアムズ
-  name-sort: です ばい でぃぐりーず てっけん:にーな うぃりあむず
+  name-sort: です ばい でぃぐりーず てっけん にーな うぃりあむず
   name-en: "Death by Degrees - Tekken - Nina Williams"
   region: "NTSC-J"
   gsHWFixes:
@@ -52381,7 +52513,7 @@ SLPS-25424:
   region: "NTSC-J"
 SLPS-25425:
   name: SDガンダムフォース 大決戦!次元海賊デ・スカール
-  name-sort: SDがんだむふぉーす だいけっせん!じげんかいぞくで・すかーる
+  name-sort: SDがんだむふぉーす だいけっせん じげんかいぞくですかーる
   name-en: "SD Gundam Force Daikessen!"
   region: "NTSC-J"
   clampModes:
@@ -52393,7 +52525,7 @@ SLPS-25426:
   region: "NTSC-J"
 SLPS-25427:
   name: レジェンズ 激闘!サーガバトル
-  name-sort: れじぇんず げきとう!さーがばとる
+  name-sort: れじぇんず げきとう さーがばとる
   name-en: "Legions Gekitou! Saga Battle"
   region: "NTSC-J"
   compat: 5
@@ -52412,7 +52544,7 @@ SLPS-25429:
 SLPS-25430:
   name: ルパン三世 コロンブスの遺産は朱に染まる
   name-sort: るぱんさんせい ころんぶすのいさんはしゅにそまる
-  name-en: "Lupin III - Columbus no Isan wa Akenisomaru"
+  name-en: "Lupin III - Columbus no Isan ha Akenisomaru"
   region: "NTSC-J"
   roundModes:
     eeDivRoundMode: 1 # Fixes game softlock after prison level.
@@ -52421,23 +52553,23 @@ SLPS-25431:
   region: "NTSC-J"
 SLPS-25432:
   name: 魔女っ娘ア・ラ・モード 唱えて、恋の魔法! [初回限定版]
-  name-sort: まじょっこあ・ら・もーど となえて、こいのまほう! [しょかいげんていばん]
-  name-en: "Majo-musume A La Mode [Magical Box]"
+  name-sort: まじょっこあらもーど となえて こいのまほう! しょかいげんていばん
+  name-en: "Majo-kko A La Mode [Magical Box]"
   region: "NTSC-J"
 SLPS-25433:
   name: 帝国千戦記 [初回限定版]
-  name-sort: ていこくせんせんき [しょかいげんていばん]
+  name-sort: ていこくせんせんき しょかいげんていばん
   name-en: "Teikoku Sensenki [Limited Edition]"
   region: "NTSC-J"
 SLPS-25434:
   name: 西風の狂詩曲〜The Rhapsody of Zephyr〜 Best Collection
-  name-sort: にしかぜのらぷそでぃ〜The Rhapsody of Zephyr〜 Best Collection
+  name-sort: にしかぜのらぷそでぃ Best Collection
   name-en: "Rhapsody of Zephyr, The [Best Collection]"
   region: "NTSC-J"
 SLPS-25435:
   name: 魔女っ娘ア・ラ・モード 唱えて、恋の魔法!
-  name-sort: まじょっこあ・ら・もーど となえて、こいのまほう!
-  name-en: "Majo-musume A La Mode"
+  name-sort: まじょっこあらもーど となえて こいのまほう
+  name-en: "Majo-kko A La Mode"
   region: "NTSC-J"
 SLPS-25436:
   name: 帝国千戦記
@@ -52455,13 +52587,13 @@ SLPS-25438:
   name-en: "D A - White [Limited Edition]"
   region: "NTSC-J"
 SLPS-25439:
-  name: はじめの一歩 ALL☆STARS(オール☆スターズ)
-  name-sort: はじめのいっぽ おーる☆すたーず
+  name: はじめの一歩 ALL☆STARS
+  name-sort: はじめのいっぽ おーるすたーず
   name-en: "Hajime no Ippo - All-Stars"
   region: "NTSC-J"
 SLPS-25440:
   name: 金色のガッシュベル!! 激闘!最強の魔物達
-  name-sort: きんいろのがっしゅべる!! げきとう!さいきょうのまものたち
+  name-sort: こんじきのがっしゅべる げきとう さいきょうのまものたち
   name-en: "Gold Gashbell!! Gekitou! Saikyou no Mamonotachi"
   region: "NTSC-J"
 SLPS-25441:
@@ -52476,7 +52608,7 @@ SLPS-25443:
   region: "NTSC-J"
 SLPS-25444:
   name: Cherry blossom 〜チェリーブロッサム〜
-  name-sort: Cherry blossom 〜ちぇりーぶろっさむ〜
+  name-sort: Cherry blossom ちぇりーぶろっさむ
   name-en: "Cherry Blossom"
   region: "NTSC-J"
 SLPS-25445:
@@ -52486,7 +52618,7 @@ SLPS-25445:
   region: "NTSC-J"
 SLPS-25447:
   name: トップをねらえ!
-  name-sort: とっぷをねらえ!
+  name-sort: とっぷをねらえ
   name-en: "Top wo Nerae! Gunbuster"
   region: "NTSC-J"
 SLPS-25448:
@@ -52516,7 +52648,7 @@ SLPS-25451:
     textureInsideRT: 1 # Fixes some of the many graphical issues.
 SLPS-25452:
   name: キノの旅 -the Beautiful World- 電撃SP
-  name-sort: きののたび -the Beautiful World- でんげきSP
+  name-sort: きののたび the Beautiful World でんげきSP
   name-en: "Kino no Tabi - The Beautiful World [MediaWorks Best]"
   region: "NTSC-J"
 SLPS-25453:
@@ -52531,7 +52663,7 @@ SLPS-25454:
   region: "NTSC-J"
 SLPS-25455:
   name: 三洋パチンコパラダイス11〜新海とさらば銀玉の狼〜
-  name-sort: さんようぱちんこぱらだいす11〜しんかいとさらばぎんだまのおおかみ〜
+  name-sort: さんようぱちんこぱらだいす11 しんかいとさらばぎんだまのおおかみ
   name-en: "Sanyo Pachinko Paradise 11"
   region: "NTSC-J"
 SLPS-25456:
@@ -52568,7 +52700,7 @@ SLPS-25460:
   region: "NTSC-J"
 SLPS-25461:
   name: アーマード・コア フォーミュラフロント
-  name-sort: あーまーど・こあ ふぉーみゅらふろんと
+  name-sort: あーまーどこあ ふぉーみゅらふろんと
   name-en: "Armored Core - Formula Front"
   region: "NTSC-J"
   gsHWFixes:
@@ -52577,7 +52709,7 @@ SLPS-25461:
     cpuSpriteRenderLevel: 2 # Needed for above.
 SLPS-25462:
   name: アーマード・コア ラストレイヴン
-  name-sort: あーまーど・こあ らすとれいゔん
+  name-sort: あーまーどこあ らすとれいゔん
   name-en: "Armored Core - Last Raven"
   region: "NTSC-J"
   gsHWFixes:
@@ -52593,12 +52725,12 @@ SLPS-25462:
     - "SLPS-73247"
 SLPS-25463:
   name: マイホームをつくろう2!匠
-  name-sort: まいほーむをつくろう2!たくみ
+  name-sort: まいほーむをつくろう2 たくみ
   name-en: "My Home o Tsukurou 2! Takumi"
   region: "NTSC-J"
 SLPS-25464:
   name: 大戦略VII エクシード
-  name-sort: だいせんりゃくVII えくしーど
+  name-sort: だいせんりゃく7 えくしーど
   name-en: "Daisenryaku VII Exceed"
   region: "NTSC-J"
 SLPS-25465:
@@ -52607,13 +52739,13 @@ SLPS-25465:
   name-en: "Azumi"
   region: "NTSC-J"
 SLPS-25466:
-  name: 永遠のアセリア -この大地の果てでー 初回限定版
-  name-sort: えいえんのあせりあ -このだいちのはてでー しょかいげんていばん
+  name: 永遠のアセリア -この大地の果てで- 初回限定版
+  name-sort: えいえんのあせりあ このだいちのはてで しょかいげんていばん
   name-en: "Eternal Aselia - The Spirit of Eternity Sword [Limited Edition]"
   region: "NTSC-J"
 SLPS-25467:
   name: みんな大好き塊魂
-  name-sort: みんなだいすきかたまりたましい
+  name-sort: みんなだいすきかたまりだましい
   name-en: "Minna Daisuki Katamari Damacy"
   region: "NTSC-J"
   compat: 5
@@ -52635,7 +52767,7 @@ SLPS-25467:
     - "SLPS-73240"
 SLPS-25468:
   name: 永遠のアセリア −この大地の果てで−
-  name-sort: えいえんのあせりあ -このだいちのはてで-
+  name-sort: えいえんのあせりあ このだいちのはてで
   name-en: "Eternal Aselia - The Spirit of Eternity Sword"
   region: "NTSC-J"
 SLPS-25469:
@@ -52655,7 +52787,7 @@ SLPS-25471:
   region: "NTSC-J"
 SLPS-25472:
   name: XIII[サーティーン] 大統領を殺した男 Best Collection
-  name-sort: XIII[さーてぃーん] だいとうりょうをころしたおとこ Best Collection
+  name-sort: さーてぃーん だいとうりょうをころしたおとこ Best Collection
   name-en: "XIII [Best Collection]"
   region: "NTSC-J"
 SLPS-25473:
@@ -52681,7 +52813,7 @@ SLPS-25478:
   region: "NTSC-J"
 SLPS-25479:
   name: 金色のガッシュベル!!友情タッグバトル2
-  name-sort: きんいろのがっしゅべる!!ゆうじょうたっぐばとる2
+  name-sort: こんじきのがっしゅべる!!ゆうじょうたっぐばとる2
   name-en: "Gold Gashbell - Friendship Tag Battle 2"
   region: "NTSC-J"
 SLPS-25480:
@@ -52691,17 +52823,17 @@ SLPS-25480:
   region: "NTSC-J"
 SLPS-25481:
   name: ガッツだ!!森の石松
-  name-sort: がっつだ!!もりのいしまつ
+  name-sort: がっつだ もりのいしまつ
   name-en: "Gattsu!! Mori no Ishimatsu"
   region: "NTSC-J"
 SLPS-25482:
   name: 雪語り リニューアル版
-  name-sort: ゆきかたり りにゅーあるばん
-  name-en: "Yuki Katari [Renewal Version]"
+  name-sort: ゆきがたり りにゅーあるばん
+  name-en: "Yuki Gatari [Renewal Version]"
   region: "NTSC-J"
 SLPS-25483:
-  name: すい～とし～ずん
-  name-sort: すい～とし～ずん
+  name: すい〜とし〜ずん
+  name-sort: すいーとしーずん
   name-en: "Sui-Toshi-Zun"
   region: "NTSC-J"
 SLPS-25484:
@@ -52731,12 +52863,12 @@ SLPS-25488:
   region: "NTSC-J"
 SLPS-25489:
   name: 機動戦士ガンダム ギレンの野望 ジオン独立戦争記+攻略指令書 GUNDAM THE BEST
-  name-sort: きどうせんしがんだむ ぎれんのやぼう じおんどくりつせんそうき+こうりゃくしれいしょ GUNDAM THE BEST
+  name-sort: きどうせんしがんだむ ぎれんのやぼう じおんどくりつせんそうき こうりゃくしれいしょ GUNDAM THE BEST
   name-en: "Ambition of Giren - Zeon Independence War + Direction Book of Capture [Gundam the Best]"
   region: "NTSC-J"
 SLPS-25491:
   name: SDガンダム G GENERATION—NEO GUNDAM THE BEST
-  name-sort: SDがんだむ G GENERATION—NEO GUNDAM THE BEST
+  name-sort: SDがんだむ G GENERATION NEO GUNDAM THE BEST
   name-en: "SD Gundam G Generation Neo [Gundam The Best]"
   region: "NTSC-J"
 SLPS-25492:
@@ -52751,7 +52883,7 @@ SLPS-25493:
   region: "NTSC-J"
 SLPS-25494:
   name: Fragrance Tale 〜フレグランス テイル〜
-  name-sort: Fragrance Tale 〜ふれぐらんす ている〜
+  name-sort: ふれぐらんす ている
   name-en: "Fragrance Tale"
   region: "NTSC-J"
 SLPS-25495:
@@ -52777,7 +52909,7 @@ SLPS-25498:
   region: "NTSC-J"
 SLPS-25499:
   name: 幽★遊★白書 FOREVER
-  name-sort: ゆう★ゆう★はくしょ FOREVER
+  name-sort: ゆうゆうはくしょ FOREVER
   name-en: "Yu Yu Hakusho Forever"
   region: "NTSC-J"
 SLPS-25500:
@@ -52787,7 +52919,7 @@ SLPS-25500:
   region: "NTSC-J"
 SLPS-25501:
   name: 陰陽大戦記 覇者の印
-  name-sort: いんようだいせんき はしゃのしるし
+  name-sort: おんみょうたいせんき はしゃのしるし
   name-en: "Onmyou Taisenki - Hasha no In"
   region: "NTSC-J"
 SLPS-25502:
@@ -52815,17 +52947,17 @@ SLPS-25505:
   compat: 5
 SLPS-25506:
   name: for Symphony 〜with all one’s heart〜
-  name-sort: for Symphony 〜with all one’s heart〜
+  name-sort: for Symphony with all one’s heart
   name-en: "For Symphony - With All One's Heart"
   region: "NTSC-J"
 SLPS-25507:
   name: 舞-HiME 運命の系統樹 DXパック
-  name-sort: まい-HiME うんめいのけいとうじゅ DXぱっく
+  name-sort: まいひめ うんめいのけいとうじゅ DXぱっく
   name-en: "Mai-Hime [Limited Edition]"
   region: "NTSC-J"
 SLPS-25508:
   name: 舞-HiME 運命の系統樹
-  name-sort: まい-HiME うんめいのけいとうじゅ
+  name-sort: まいひめ うんめいのけいとうじゅ
   name-en: "Mai-Hime - The Another"
   region: "NTSC-J"
 SLPS-25509:
@@ -52834,7 +52966,7 @@ SLPS-25509:
   name-en: "Garou - Mark of the Wolves"
   region: "NTSC-J"
 SLPS-25510:
-  name: 鉄拳5 (TEKKEN 5)
+  name: 鉄拳5
   name-sort: てっけん5
   name-en: "Tekken 5"
   region: "NTSC-J"
@@ -52852,17 +52984,17 @@ SLPS-25511:
   region: "NTSC-J"
 SLPS-25513:
   name: 蒼い海のトリスティア 〜ナノカ・フランカ発明工房記〜 [初回限定版]
-  name-sort: あおいうみのとりすてぃあ 〜なのか・ふらんかはつめいこうぼうき〜 [しょかいげんていばん]
-  name-en: "Aoi Umi no Tristia - Nanoca Flanka Hatsumei Koubouki [Shokai Genteiban]"
+  name-sort: あおいうみのとりすてぃあ なのか ふらんかはつめいこうぼうき しょかいげんていばん
+  name-en: "Aoi Umi no Tristia - Nanoca Flanka Hatsumei Koubouki [First Print Limited Edition]"
   region: "NTSC-J"
 SLPS-25514:
   name: 蒼い海のトリスティア 〜ナノカ・フランカ発明工房記〜
-  name-sort: あおいうみのとりすてぃあ 〜なのか・ふらんかはつめいこうぼうき〜
+  name-sort: あおいうみのとりすてぃあ なのか ふらんかはつめいこうぼうき
   name-en: "Aoi Umi no Tristia - Nanoca Flanka Hatsumei Koubouki"
   region: "NTSC-J"
 SLPS-25515:
   name: フタコイ オルタナティブ 恋と少女とマシンガン 限定版
-  name-sort: ふたこい おるたなてぃぶ こいとしょうじょとましんがん げんていばん
+  name-sort: ふたこい おるたなてぃぶ こいとしょうじょとましんがん [げんていばん]
   name-en: "Futakoi Alternative [Limited Edition]"
   region: "NTSC-J"
 SLPS-25516:
@@ -52887,7 +53019,7 @@ SLPS-25519:
   region: "NTSC-J"
 SLPS-25520:
   name: ガンダム トゥルーオデッセイ 〜失われしGの伝説〜
-  name-sort: がんだむ とぅるーおでっせい 〜うしなわれしGのでんせつ〜
+  name-sort: がんだむ とぅるーおでっせい うしなわれしGのでんせつ
   name-en: "Gundam True Odyssey"
   region: "NTSC-J"
 SLPS-25521:
@@ -52897,7 +53029,7 @@ SLPS-25521:
   region: "NTSC-J"
 SLPS-25522:
   name: 義経紀 限定版 豪華絢爛BOX
-  name-sort: よしつねき げんていばん ごうかけんらんBOX
+  name-sort: よしつねき [げんていばん] ごうかけんらんBOX
   name-en: "Yoshitsuneki [Gouka Kenran Box]"
   region: "NTSC-J"
 SLPS-25523:
@@ -52917,14 +53049,14 @@ SLPS-25526:
   name-en: "Medical 91"
   region: "NTSC-J"
 SLPS-25527:
-  name: dot hack - fragment オンライン / オフライン
-  name-sort: dot hack - fragment おんらいん / おふらいん
-  name-en: "dot hack - Fragment"
+  name: .hack//fragment オンライン / オフライン
+  name-sort: どっとはっく fragment おんらいん / おふらいん
+  name-en: ".hack//fragment"
   region: "NTSC-J"
   compat: 5
 SLPS-25528:
   name: サモンナイトエクステーゼ 〜夜明けの翼〜
-  name-sort: さもんないとえくすてーぜ 〜よあけのつばさ〜
+  name-sort: さもんないとえくすてーぜ よあけのつばさ
   name-en: "Summon Night EX Thesis - Yoake no Tsubasa"
   region: "NTSC-J"
 SLPS-25529:
@@ -52950,7 +53082,7 @@ SLPS-25532:
   name-en: "Critical Velocity"
   region: "NTSC-J"
 SLPS-25533:
-  name: テイルズ オブ レジェンディア (Tales of Legendia)
+  name: テイルズ オブ レジェンディア
   name-sort: ているず おぶ れじぇんでぃあ
   name-en: "Tales of Legendia"
   region: "NTSC-J"
@@ -52958,8 +53090,8 @@ SLPS-25533:
   gsHWFixes:
     getSkipCount: "GSC_TalesOfLegendia"
 SLPS-25534:
-  name: ティンクルスタースプライツ 〜La Petite Princesse〜
-  name-sort: てぃんくるすたーすぷらいつ 〜La Petite Princesse〜
+  name: ティンクルスタースプライツーLa Petite Princesse-
+  name-sort: てぃんくるすたーすぷらいつ La Petite Princesse
   name-en: "Twinkle Star Sprites - La Petite Princesse"
   region: "NTSC-J"
   compat: 5
@@ -52970,7 +53102,7 @@ SLPS-25535:
   region: "NTSC-J"
 SLPS-25537:
   name: 第3次スーパーロボット大戦α 〜終焉の銀河へ〜
-  name-sort: だい3じすーぱーろぼっとたいせんあるふぁ 〜しゅうえんのぎんがへ〜
+  name-sort: だい3じすーぱーろぼっとたいせんあるふぁ しゅうえんのぎんがへ
   name-en: "Super Robot Wars - Alpha 3"
   region: "NTSC-J"
   compat: 5
@@ -52981,12 +53113,12 @@ SLPS-25538:
   region: "NTSC-J"
 SLPS-25539:
   name: スクールランブル ねる娘は育つ。 DXパック
-  name-sort: すくーるらんぶる ねるむすめはそだつ。 DXぱっく
+  name-sort: すくーるらんぶる ねるこはそだつ DXぱっく
   name-en: "School Rumble [Limited Edition]"
   region: "NTSC-J"
 SLPS-25540:
   name: スクールランブル ねる娘は育つ。
-  name-sort: すくーるらんぶる ねるむすめはそだつ。
+  name-sort: すくーるらんぶる ねるこはそだつ
   name-en: "School Rumble"
   region: "NTSC-J"
 SLPS-25541:
@@ -52996,7 +53128,7 @@ SLPS-25541:
   region: "NTSC-J"
 SLPS-25542:
   name: NARUTO-ナルト- うずまき忍伝
-  name-sort: NARUTO-なると- うずまきにんでん
+  name-sort: なると うずまきにんでん
   name-en: "Naruto Uzumaki Ninden"
   region: "NTSC-J"
   compat: 5
@@ -53009,7 +53141,7 @@ SLPS-25543:
   region: "NTSC-J"
 SLPS-25544:
   name: 零 〜刺青の聲〜
-  name-sort: ぜろ 〜しせいのこえ〜
+  name-sort: ぜろ しせいのこえ
   name-en: "Fatal Frame - Zero"
   region: "NTSC-J"
   compat: 5
@@ -53036,7 +53168,7 @@ SLPS-25548:
   region: "NTSC-J"
 SLPS-25549:
   name: 機動戦士ガンダムSEED DESTINY 〜GENERATION of C.E.〜
-  name-sort: きどうせんしがんだむSEED DESTINY 〜GENERATION of C.E.〜
+  name-sort: きどうせんしがんだむしーど ですてぃにー GENERATION of C.E.
   name-en: "Gundam Seed Destiny - Generation of C.E."
   region: "NTSC-J"
 SLPS-25550:
@@ -53056,7 +53188,7 @@ SLPS-25551:
   compat: 5
 SLPS-25552:
   name: 犬夜叉〜呪詛の仮面〜 BANDAI THE BEST
-  name-sort: いぬやしゃ〜じゅそのかめん〜 BANDAI THE BEST
+  name-sort: いぬやしゃ じゅそのかめん BANDAI THE BEST
   name-en: "Inuyasha - Juuso no Kamen [Bandai the Best]"
   region: "NTSC-J"
 SLPS-25553:
@@ -53121,8 +53253,8 @@ SLPS-25565:
   name-en: "Hisshou Pachinko Kouryoku Series Vol.1 - CR Shinseiki Evangelion"
   region: "NTSC-J"
 SLPS-25566:
-  name: SIMPLE 2000シリーズ Ultimate Vol.27 放課後のラブ★ビート♪
-  name-sort: SIMPLE 2000しりーず Ultimate Vol.27 ほうかごのらぶ★びーと♪
+  name: SIMPLE2000シリーズ Ultimate Vol.27 放課後のラブ★ビート♪
+  name-sort: SIMPLE 2000しりーず Ultimate Vol.27 ほうかごのらぶびーと
   name-en: "Simple 2000 Series Ultimate Vol. 27 - Houkago no Love Beat"
   region: "NTSC-J"
 SLPS-25567:
@@ -53139,7 +53271,7 @@ SLPS-25568:
     preloadFrameData: 1 # Fixes invisible text.
 SLPS-25569:
   name: 機動戦士ガンダムSEED 連合vs.Z.A.F.T
-  name-sort: きどうせんしがんだむSEED れんごうvs.Z.A.F.T
+  name-sort: きどうせんしがんだむしーど れんごうvs.Z.A.F.T
   name-en: "Kidou Senshi Gundam SEED - Rengou vs. Z.A.F.T."
   region: "NTSC-J"
   roundModes:
@@ -53162,12 +53294,12 @@ SLPS-25572:
   region: "NTSC-J"
 SLPS-25573:
   name: ザ・キング・オブ・ファイターズ 2002 [SNK Best Collection]
-  name-sort: ざ・きんぐ・おぶ・ふぁいたーず 2002 [SNK Best Collection]
+  name-sort: ざ きんぐ おぶ ふぁいたーず 2002 [SNK Best Collection]
   name-en: "King of Fighters 2002, The [SNK Best Collection]"
   region: "NTSC-J"
 SLPS-25574:
   name: パチパラ12 〜大海と夏の思い出〜
-  name-sort: ぱちぱら12 〜たいかいとなつのおもいで〜
+  name-sort: ぱちぱら12 たいかいとなつのおもいで
   name-en: "Sanyo Pachinko Paradise 12"
   region: "NTSC-J"
   gsHWFixes:
@@ -53221,11 +53353,11 @@ SLPS-25579:
   region: "NTSC-J"
 SLPS-25580:
   name: チキン・リトル
-  name-sort: ちきん・りとる
+  name-sort: ちきん りとる
   name-en: "Chicken Little"
   region: "NTSC-J"
 SLPS-25581:
-  name: SIMPLE 2000シリーズ Vol.92 THE 呪いのゲーム
+  name: SIMPLE2000シリーズ Vol.92 THE 呪いのゲーム
   name-sort: SIMPLE 2000しりーず Vol.92 THE のろいのげーむ
   name-en: "Simple 2000 Series Vol. 92 - The Game of a Curse"
   region: "NTSC-J"
@@ -53268,7 +53400,7 @@ SLPS-25588:
   region: "NTSC-J"
 SLPS-25589:
   name: NARUTO-ナルト-ナルティメットヒーロー3
-  name-sort: NARUTO-なると-なるてぃめっとひーろー3
+  name-sort: なると なるてぃめっとひーろー3
   name-en: "Naruto Narutimett Hero 3"
   region: "NTSC-J"
   clampModes:
@@ -53282,7 +53414,7 @@ SLPS-25590:
   region: "NTSC-J"
 SLPS-25591:
   name: ラスト・エスコート〜深夜の黒蝶物語〜
-  name-sort: らすと・えすこーと〜しんやのくろちょうものがたり〜
+  name-sort: らすと・えすこーと しんやのくろちょうものがたり
   name-en: "Last Escort - Shinya no Kokuchou Monogatari"
   region: "NTSC-J"
 SLPS-25592:
@@ -53301,7 +53433,7 @@ SLPS-25595:
   region: "NTSC-J"
 SLPS-25596:
   name: 金色のガッシュベル!!ゴー!ゴー!魔物ファイト!! ソフト単品
-  name-sort: きんいろのがっしゅべる!!ごー!ごー!まものふぁいと!! そふとたんぴん
+  name-sort: こんじきのがっしゅべる!!ごー!ごー!まものふぁいと!! そふとたんぴん
   name-en: "Konjiki no Gashbell! - Go!Go! Mamono Fight"
   region: "NTSC-J"
 SLPS-25597:
@@ -53316,7 +53448,7 @@ SLPS-25598:
   region: "NTSC-J"
 SLPS-25599:
   name: 灼眼のシャナ
-  name-sort: 灼眼のしゃな
+  name-sort: しゃくがんのしゃな
   name-en: "Shakugan no Shana"
   region: "NTSC-J"
 SLPS-25600:
@@ -53331,7 +53463,7 @@ SLPS-25601:
   region: "NTSC-J"
 SLPS-25602:
   name: 必勝パチンコ★パチスロ攻略シリーズ Vol.2 ボンバーパワフル&夢夢ワールドDX
-  name-sort: ひっしょうぱちんこ★ぱちすろこうりゃくしりーず Vol.2 ぼんばーぱわふる&ゆめゆめわーるどDX
+  name-sort: ひっしょうぱちんこぱちすろこうりゃくしりーず Vol.2 ぼんばーぱわふる&ゆめゆめわーるどDX
   name-en: "Hisshou Pachinko-Pachislot Kouryaku Series Vol.2 - Bomber Powerful & Yume Yume World DX"
   region: "NTSC-J"
 SLPS-25603:
@@ -53341,7 +53473,7 @@ SLPS-25603:
   region: "NTSC-J"
 SLPS-25604:
   name: アルトネリコ 世界の終わりで詩い続ける少女
-  name-sort: あるとねりこ せかいのおわりでしいつづけるしょうじょ
+  name-sort: あるとねりこ せかいのおわりでうたいつづけるしょうじょ
   name-en: "Ar tonelico - Sekai no Owari de Utai Tsuzukeru Shoujo"
   region: "NTSC-J"
   gsHWFixes:
@@ -53377,17 +53509,17 @@ SLPS-25609:
   region: "NTSC-J"
 SLPS-25610:
   name: 龍虎の拳〜天・地・人〜 [NEOGEOオンラインコレクション]
-  name-sort: りゅうこのけん〜てん・ち・じん〜 [NEOGEOおんらいんこれくしょん]
+  name-sort: りゅうこのけん てんちじん [NEOGEOおんらいんこれくしょん]
   name-en: "Ryuuko no Ken - Ten-Chi-Jin [Art of Fighting Collection]"
   region: "NTSC-J"
 SLPS-25611:
-  name: Strawberry Panic!ストロベリー・パニック! [初回限定版]
-  name-sort: Strawberry Panic!すとろべりー・ぱにっく! [しょかいげんていばん]
+  name: Strawberry Panic! [初回限定版]
+  name-sort: すとろべりーぱにっく! [しょかいげんていばん]
   name-en: "Strawberry Panic [Limited Edition]"
   region: "NTSC-J"
 SLPS-25612:
-  name: Strawberry Panic!ストロベリー・パニック! [通常版]
-  name-sort: Strawberry Panic!すとろべりー・ぱにっく! [つうじょうばん]
+  name: Strawberry Panic! [通常版]
+  name-sort: すとろべりーぱにっく! [つうじょうばん]
   name-en: "Strawberry Panic"
   region: "NTSC-J"
 SLPS-25613:
@@ -53397,7 +53529,7 @@ SLPS-25613:
   region: "NTSC-J"
 SLPS-25614:
   name: 舞-HiME 運命の系統樹 Best Collection
-  name-sort: まい-HiME うんめいのけいとうじゅ Best Collection
+  name-sort: まいひめ うんめいのけいとうじゅ Best Collection
   name-en: "Mai-Hime - Unmei no Keitouju [Best Collection]"
   region: "NTSC-J"
 SLPS-25615:
@@ -53407,38 +53539,38 @@ SLPS-25615:
   region: "NTSC-J"
 SLPS-25616:
   name: スキージャンプ・ペア Reloaded
-  name-sort: すきーじゃんぷ・ぺあ Reloaded
+  name-sort: すきーじゃんぷ ぺあ Reloaded
   name-en: "Ski Jumping Pairs Reloaded"
   region: "NTSC-J"
 SLPS-25617:
   name: e’tude prologue 〜揺れ動く心のかたち〜
-  name-sort: e’tude prologue 〜ゆれうごくこころのかたち〜
+  name-sort: e’tude prologue ゆれうごくこころのかたち
   name-en: "Etude Prologue - Yureugoku Kokoro no Katachi"
   region: "NTSC-J"
 SLPS-25618:
   name: ベストプライス D→A:BLACK
-  name-sort: べすとぷらいす D→A:BLACK
+  name-sort: D→A:BLACK べすとぷらいす
   name-en: "D-A - Black [Best Price]"
   region: "NTSC-J"
 SLPS-25619:
   name: ベストプライス D→A:WHITE
-  name-sort: べすとぷらいす D→A:WHITE
+  name-sort: D→A:WHITE べすとぷらいす
   name-en: "D-A - White [Best Price]"
   region: "NTSC-J"
 SLPS-25620:
   name: 必勝パチンコ★パチスロ攻略シリーズ Vol.3 CRマリリン・モンロー
-  name-sort: ひっしょうぱちんこ★ぱちすろこうりゃくしりーず Vol.3 CRまりりん・もんろー
+  name-sort: ひっしょうぱちんこぱちすろこうりゃくしりーず Vol.3 CRまりりん・もんろー
   name-en: "Hisshou Pachinko-Pachislot Kouryaku Series Vol.3 - CR Marilyn Monroe"
   region: "NTSC-J"
 SLPS-25621:
   name: かしまし 〜ガールミーツガール〜「初めての夏物語。」限定版
-  name-sort: かしまし 〜がーるみーつがーる〜「はじめてのなつものご。」げんていばん
-  name-en: "Kashimashi! Girl Meets Girl [Limited Edition]"
+  name-sort: かしまし がーるみーつがーる「はじめてのなつものがたり」げんていばん
+  name-en: "Kashimashi! - Girl Meets Girl [Limited Edition]"
   region: "NTSC-J"
 SLPS-25622:
   name: かしまし 〜ガールミーツガール〜「初めての夏物語。」通常版
-  name-sort: かしまし 〜がーるみーつがーる〜「はじめてのなつものご。」つうじょうばん
-  name-en: "Kashimashi! Girl Meets Girl"
+  name-sort: かしまし がーるみーつがーる「はじめてのなつものがたり」つうじょうばん
+  name-en: "Kashimashi! - Girl Meets Girl"
   region: "NTSC-J"
 SLPS-25623:
   name: Another Century’s Episode 2
@@ -53456,7 +53588,7 @@ SLPS-25625:
   region: "NTSC-J"
 SLPS-25626:
   name: ナルニア国物語 〜第1章 ライオンと魔女〜
-  name-sort: なるにあこくものがたり 〜だい1しょう らいおんとまじょ〜
+  name-sort: なるにあこくものがたり だい1しょう らいおんとまじょ
   name-en: "Chronicles of Narnia, The - The Lion, The Witch and The Wardrobe"
   region: "NTSC-J"
   gsHWFixes:
@@ -53511,12 +53643,12 @@ SLPS-25630:
   name-en: "Pro Yakyuu Netsu Star 2006"
   region: "NTSC-J"
 SLPS-25631:
-  name: SIMPLE 2000シリーズ Vol.98 THE 浪漫茶房
+  name: SIMPLE2000シリーズ Vol.98 THE 浪漫茶房
   name-sort: SIMPLE 2000しりーず Vol.98 THE ろまんさぼう
   name-en: "Simple 2000 Series Vol. 98 - Roman Sabou"
   region: "NTSC-J"
 SLPS-25632:
-  name: SIMPLE 2000シリーズ Vol.97 THE 恋のエンジン
+  name: SIMPLE2000シリーズ Vol.97 THE 恋のエンジン
   name-sort: SIMPLE 2000しりーず Vol.97 THE こいのえんじん
   name-en: "Simple 2000 Series Vol. 97 - The Koi no Engine"
   region: "NTSC-J"
@@ -53580,25 +53712,25 @@ SLPS-25641:
     - "SLPS-25368"
 SLPS-25642:
   name: 超ドラゴンボールZ
-  name-sort: ちょうどらごんぼーるZ
+  name-sort: すーぱーどらごんぼーるZ
   name-en: "Super Dragon Ball Z"
   region: "NTSC-J"
   compat: 5
 SLPS-25643:
   name: キミキス
   name-sort: きみきす
-  name-en: "Kimikisu"
+  name-en: "Kimikiss"
   region: "NTSC-J"
   gsHWFixes:
     roundSprite: 1 # Fixes textboxes and character portraits.
 SLPS-25644:
-  name: SIMPLE 2000シリーズ Ultimate Vol.31 K-1 WORLD MAX 2005 〜世界王者への道〜
-  name-sort: SIMPLE 2000しりーず Ultimate Vol.31 K-1 WORLD MAX 2005 〜せかいおうじゃへのみち〜
+  name: SIMPLE2000シリーズ Ultimate Vol.31 K-1 WORLD MAX 2005 〜世界王者への道〜
+  name-sort: SIMPLE 2000しりーず Ultimate Vol.31 K-1 WORLD MAX 2005 せかいおうじゃへのみち
   name-en: "Simple 2000 Series Ultimate Vol. 31 - K-1 World Max 2005"
   region: "NTSC-J"
 SLPS-25645:
   name: 必勝パチンコ★パチスロ攻略シリーズ Vol.4 CR明日があるさ よしもとワールド
-  name-sort: ひっしょうぱちんこ★ぱちすろこうりゃくしりーず Vol.4 CRあしたがあるさ よしもとわーるど
+  name-sort: ひっしょうぱちんこぱちすろこうりゃくしりーず Vol.4 CRあしたがあるさ よしもとわーるど
   name-en: "Hisshou Pachinko-Pachislot Kouryaku Series Vol.4 - CR Ashita Gaarusa Yoshimoto World"
   region: "NTSC-J"
   gameFixes:
@@ -53609,13 +53741,13 @@ SLPS-25646:
   name-en: "Eureka Seven - New Vision"
   region: "NTSC-J"
 SLPS-25647:
-  name: SIMPLE 2000シリーズ Ultimate Vol.32 あずみ
+  name: SIMPLE2000シリーズ Ultimate Vol.32 あずみ
   name-sort: SIMPLE 2000しりーず Ultimate Vol.32 あずみ
   name-en: "Simple 2000 Series Ultimate Vol. 32 - Azumi"
   region: "NTSC-J"
 SLPS-25648:
   name: 必勝パチンコ★パチスロ攻略シリーズ Vol.5 CR新世紀エヴァンゲリオン セカンドインパクト&パチスロ新世紀エヴァンゲリオン
-  name-sort: ひっしょうぱちんこ★ぱちすろこうりゃくしりーず Vol.5 CRしんせいきえゔぁんげりおん せかんどいんぱくと&ぱちすろしんせいきえゔぁんげりおん
+  name-sort: ひっしょうぱちんこぱちすろこうりゃくしりーず Vol.5 CRしんせいきえゔぁんげりおん せかんどいんぱくと&ぱちすろしんせいきえゔぁんげりおん
   name-en: "Hisshou Pachinko-Pachislot Kouryaku Series Vol.5 - CR Shinseiki Evangelion Second Impact & Pachisuro Shinseiki Evangelion"
   region: "NTSC-J"
 SLPS-25649:
@@ -53632,9 +53764,9 @@ SLPS-25650:
   region: "NTSC-J"
   compat: 5
 SLPS-25651:
-  name: dot hack - G.U. Vol.1 再誕
-  name-sort: dot hack - G.U. Vol.1 さい誕
-  name-en: "dot hack G.U. Vol.1 - Saitan"
+  name: .hack//G.U. Vol.1 再誕
+  name-sort: どっとはっく じーゆー Vol.1 さいたん
+  name-en: ".hack//G.U. Vol.1 - Saitan"
   region: "NTSC-J"
   memcardFilters:
     - "SCPS-55029"
@@ -53654,22 +53786,22 @@ SLPS-25651:
     - "SLPS-25656"
     - "SLPS-25756"
 SLPS-25652:
-  name: "dot hack G.U. Vol. 1 - Saitan [Terminal Disc - The End of the World]"
+  name: ".hack//G.U. Vol. 1 - Saitan [Terminal Disc - The End of the World]"
   region: "NTSC-J"
 SLPS-25653:
   name: クラスターエッジ 君を待つ未来への証 初回限定版
-  name-sort: くらすたーえっじ くんをまつみらいへのあかし しょかいげんていばん
+  name-sort: くらすたーえっじ きみをまつみらいへのあかし しょかいげんていばん
   name-en: "Cluster Edge [Limited Edition]"
   region: "NTSC-J"
 SLPS-25654:
   name: クラスターエッジ 君を待つ未来への証
-  name-sort: くらすたーえっじ くんをまつみらいへのあかし
-  name-en: "Cluster Edge - Kimi o Matsu Mirai e no Akashi"
+  name-sort: くらすたーえっじ きみをまつみらいへのあかし
+  name-en: "Cluster Edge - Kimi o Matsu Mirai he no Akashi"
   region: "NTSC-J"
 SLPS-25655:
-  name: dot hack - G.U. Vol.2 君想フ声
-  name-sort: dot hack - G.U. Vol.2 きみおもふごえ
-  name-en: "dot hack G.U. Vol.2 - Kimi Omou Koe"
+  name: .hack//G.U. Vol.2 君想フ声
+  name-sort: どっとはっく じーゆー Vol.2 きみおもふこえ
+  name-en: ".hack//G.U. Vol.2 - Kimi Omou Koe"
   region: "NTSC-J"
   memcardFilters:
     - "SCPS-55029"
@@ -53689,9 +53821,9 @@ SLPS-25655:
     - "SLPS-25656"
     - "SLPS-25756"
 SLPS-25656:
-  name: dot hack - G.U. Vol.3 歩くような速さで
-  name-sort: dot hack - G.U. Vol.3 あるくようなはやさで
-  name-en: "dot hack - G.U. Vol.3 - Aruku Youna Hayasa de"
+  name: .hack//G.U. Vol.3 歩くような速さで
+  name-sort: どっとはっく じーゆー Vol.3 あるくようなはやさで
+  name-en: ".hack//G.U. Vol.3 - Aruku Youna Hayasa de"
   region: "NTSC-J"
   memcardFilters:
     - "SCPS-55029"
@@ -53721,8 +53853,8 @@ SLPS-25657:
     halfPixelOffset: 2 # Helps ghosting when upscaling.
 SLPS-25658:
   name: びんちょうタン しあわせ暦 [初回限定版]
-  name-sort: びんちょうたん しあわせごよみ [しょかいげんていばん]
-  name-en: "Binchou-Tan - Shiwase Goyomi [Shokai Genteiban]"
+  name-sort: びんちょうたん しあわせごよみ しょかいげんていばん
+  name-en: "Binchou-Tan - Shiwase Goyomi [First Print Limited Edition]"
   region: "NTSC-J"
 SLPS-25659:
   name: びんちょうタン しあわせ暦 [通常版]
@@ -53731,13 +53863,13 @@ SLPS-25659:
   region: "NTSC-J"
 SLPS-25660:
   name: ザ・キング・オブ・ファイターズXI
-  name-sort: ざ・きんぐ・おぶ・ふぁいたーずXI
+  name-sort: ざ きんぐ おぶ ふぁいたーずXI
   name-en: "King of Fighters XI, The"
   region: "NTSC-J"
   compat: 5
 SLPS-25661:
   name: ザ・キング・オブ・ファイターズ -ネスツ編- [NEOGEOオンラインコレクション]
-  name-sort: ざ・きんぐ・おぶ・ふぁいたーず -ねすつへん- [NEOGEOおんらいんこれくしょん]
+  name-sort: ざ きんぐ おぶ ふぁいたーず -ねすつへん- [NEOGEOおんらいんこれくしょん]
   name-en: "King of Fighters, The - Nests"
   region: "NTSC-J"
 SLPS-25662:
@@ -53776,7 +53908,7 @@ SLPS-25668:
   region: "NTSC-J"
 SLPS-25669:
   name: スクールランブル二学期 恐怖の(?)夏合宿! 洋館に幽霊現る!? お宝を巡って真っ向勝負!!!の巻 [初回限定版]
-  name-sort: すくーるらんぶるにがっき きょうふの(?)なつがっしゅく! ようかんにゆうれいあらわる!? おたからをめぐってまっこうしょうぶ!!!のまき [しょかいげんていばん]
+  name-sort: すくーるらんぶるにがっき きょうふの(?)なつがっしゅく! ようかんにゆうれいあらわる!? おたからをめぐってまっこうしょうぶ!!!のまき しょかいげんていばん
   name-en: "School Rumble 2nd Term [Limited Edition]"
   region: "NTSC-J"
   compat: 5
@@ -53787,17 +53919,17 @@ SLPS-25670:
   region: "NTSC-J"
 SLPS-25671:
   name: SchoolRumble スクールランブル ねる娘は育つ。Best Collection
-  name-sort: SchoolRumble すくーるらんぶる ねるむすめはそだつ。Best Collection
+  name-sort: SchoolRumble すくーるらんぶる ねるむすめはそだつ Best Collection
   name-en: "School Rumble [Best Collection]"
   region: "NTSC-J"
 SLPS-25672:
   name: 必勝パチンコ★パチスロ攻略シリーズ Vol.6 7Cafe〜型式名ボンバーパワフル2〜
-  name-sort: ひっしょうぱちんこ★ぱちすろこうりゃくしりーず Vol.6 7Cafe〜けいしきめいぼんばーぱわふる2〜
+  name-sort: ひっしょうぱちんこぱちすろこうりゃくしりーず Vol.6 7Cafe けいしきめいぼんばーぱわふる2
   name-en: "7Cafe - Katashiki Mei Bonba Pawafuru 2"
   region: "NTSC-J"
 SLPS-25673:
   name: ラスト・エスコート〜黒蝶スペシャルナイト〜
-  name-sort: らすと・えすこーと〜くろちょうすぺしゃるないと〜
+  name-sort: らすと・えすこーと くろちょうすぺしゃるないと
   name-en: "Last Escort - The Black Butterfly Special Night"
   region: "NTSC-J"
 SLPS-25674:
@@ -53824,28 +53956,28 @@ SLPS-25677:
   region: "NTSC-J"
   compat: 5
 SLPS-25678:
-  name: うたわれるもの 散りゆく者への子守唄 [初回限定版]
-  name-sort: うたわれるもの ちりゆくものへのこもりうた [しょかいげんていばん]
+  name: うたわれるもの 散りゆく者への子守唄(初回限定版)
+  name-sort: うたわれるもの ちりゆくものへのこもりうた しょかいげんていばん
   name-en: "Utawareru Mono [Limited Edition]"
   region: "NTSC-J"
 SLPS-25679:
-  name: うたわれるもの 散りゆく者への子守唄
+  name: うたわれるもの 散りゆく者への子守唄(通常版)
   name-sort: うたわれるもの ちりゆくものへのこもりうた
   name-en: "Utawareru Mono"
   region: "NTSC-J"
 SLPS-25680:
   name: 舞ー乙HiME 乙女舞闘史!! [Limited Edition]
   name-sort: まいおとめ おとめぶとうし!! [Limited Edition]
-  name-en: "Mai-Kinoto Hime [Limited Edition]"
+  name-en: "Mai-Otome [Limited Edition]"
   region: "NTSC-J"
 SLPS-25681:
   name: 舞ー乙HiME 乙女舞闘史!!
   name-sort: まいおとめ おとめぶとうし!!
-  name-en: "Mai-Kinoto Hime"
+  name-en: "Mai-Otome"
   region: "NTSC-J"
 SLPS-25682:
   name: パチパラ13〜スーパー海とパチプロ風雲録〜
-  name-sort: ぱちぱら13〜すーぱーうみとぱちぷろふううんろく〜
+  name-sort: ぱちぱら13 すーぱーうみとぱちぷろふううんろく
   name-en: "Sanyo Pachinko Paradise 13"
   region: "NTSC-J"
   gsHWFixes:
@@ -53860,13 +53992,13 @@ SLPS-25683:
     getSkipCount: "GSC_SteambotChronicles" # Causes green (incorrect) water but removes depth and blur issues.
     roundSprite: 1 # Fixes colored 3D anaglyph bleeding effects.
 SLPS-25684:
-  name: マーメイドプリズム [限定版BOX]
+  name: マーメイドプリズム(限定版BOX)
   name-sort: まーめいどぷりずむ [げんていばんBOX]
   name-en: "Mermaid Prism [Limited Edition]"
   region: "NTSC-J"
 SLPS-25685:
   name: るろうに剣心-明治剣客浪漫譚- 炎上!京都輪廻
-  name-sort: るろうにけんしん-めいじけんかくろまんたん- えんじょう!きょうとりんね
+  name-sort: るろうにけんしん めいじけんかくろまんたん えんじょう!きょうとりんね
   name-en: "Rurouni Kenshin - Enjou! Kyoto Rinne"
   region: "NTSC-J"
 SLPS-25686:
@@ -53882,12 +54014,12 @@ SLPS-25687:
   compat: 5
 SLPS-25688:
   name: シムーン 異薔薇戦争 封印のリ・マージョン 初回限定版
-  name-sort: しむーん いばらせんそう ふういんのり・まーじょん しょかいげんていばん
-  name-en: "Simoun - Shoubi Sensou - Fuuin no Remersion [First Print - Limited Edition]"
+  name-sort: しむーん いばらせんそう ふういんのりまーじょん しょかいげんていばん
+  name-en: "Simoun - Shoubi Sensou - Fuuin no Remersion [First Print Limited Edition]"
   region: "NTSC-J"
 SLPS-25689:
   name: シムーン 異薔薇戦争 封印のリ・マージョン 通常版
-  name-sort: しむーん いばらせんそう ふういんのり・まーじょん つうじょうばん
+  name-sort: しむーん いばらせんそう ふういんのりまーじょん [つうじょうばん]
   name-en: "Simoun - Shoubi Sensou - Fuuin no Remersion"
   region: "NTSC-J"
 SLPS-25690:
@@ -53907,13 +54039,13 @@ SLPS-25691:
     halfPixelOffset: 1 # Fixes extreme ghosting.
     wildArmsHack: 1 # Aligns vertical blurring.
 SLPS-25693:
-  name: プリンセス・プリンセス 姫たちのアブナい放課後 [初回限定版]
-  name-sort: ぷりんせす・ぷりんせす ひめたちのあぶないほうかご [しょかいげんていばん]
+  name: プリンセス・プリンセス 姫たちのアブナい放課後 (初回限定版)
+  name-sort: ぷりんせすぷりんせす ひめたちのあぶないほうかご しょかいげんていばん
   name-en: "Shinseiki GPX - Road to the Infinity 3"
   region: "NTSC-J"
 SLPS-25694:
-  name: プリンセス・プリンセス 姫たちのアブナい放課後
-  name-sort: ぷりんせす・ぷりんせす ひめたちのあぶないほうかご
+  name: プリンセス・プリンセス 姫たちのアブナい放課後 (通常版)
+  name-sort: ぷりんせすぷりんせす ひめたちのあぶないほうかご
   name-en: "Princess Princess"
   region: "NTSC-J"
 SLPS-25695:
@@ -53922,13 +54054,13 @@ SLPS-25695:
   name-en: "New Century GPX Cyber Formula - Road to the Infinity 3"
   region: "NTSC-J"
 SLPS-25696:
-  name: マーメイドプリズム
+  name: マーメイドプリズム(通常版)
   name-sort: まーめいどぷりずむ
   name-en: "Simple 2000 Series Vol. 122 - The Ningyo Hime Monogatari - Mermaid Prism"
   region: "NTSC-J"
 SLPS-25697:
   name: 必勝パチンコ★パチスロ攻略シリーズ Vol.7 CRフィーバー パワフルZERO
-  name-sort: ひっしょうぱちんこ★ぱちすろこうりゃくしりーず Vol.7 CRふぃーばー ぱわふるZERO
+  name-sort: ひっしょうぱちんこぱちすろこうりゃくしりーず Vol.7 CRふぃーばー ぱわふるZERO
   name-en: "Hisshou Pachinko-PachiSlot Kouryaku Series Vol.7 - CR Fever Powerful Zero"
   region: "NTSC-J"
   compat: 5
@@ -53941,12 +54073,12 @@ SLPS-25698:
   region: "NTSC-J"
 SLPS-25699:
   name: 必勝パチンコ★パチスロ攻略シリーズ Vol.8 CR松浦亜弥
-  name-sort: ひっしょうぱちんこ★ぱちすろこうりゃくしりーず Vol.8 CRまつうらあや
+  name-sort: ひっしょうぱちんこぱちすろこうりゃくしりーず Vol.8 CRまつうらあや
   name-en: "Hisshou Pachinko-Pachislot Kouryaku Series Vol.8"
   region: "NTSC-J"
 SLPS-25700:
   name: 蒼い海のトリスティア 〜ナノカ・フランカ発明工房記〜 The Best Price
-  name-sort: あおいうみのとりすてぃあ 〜なのか・ふらんかはつめいこうぼうき〜 The Best Price
+  name-sort: あおいうみのとりすてぃあ なのかふらんかはつめいこうぼうき The Best Price
   name-en: "Aoi no Tristia [The Best Price]"
   region: "NTSC-J"
 SLPS-25701:
@@ -53955,13 +54087,13 @@ SLPS-25701:
   name-en: "Gallop Racer Inbreed"
   region: "NTSC-J"
 SLPS-25702:
-  name: 雨格子の館(あまごうしのやかた)
-  name-sort: あめごうしのやかた
+  name: 雨格子の館
+  name-sort: あまごうしのやかた
   name-en: "Amagoushi no Yakata"
   region: "NTSC-J"
 SLPS-25703:
   name: SIMPLE2000シリーズ Vol.111 THE いただきライダー 〜お前のバイクは俺のモノ / Jacked〜
-  name-sort: SIMPLE2000しりーず Vol.111 THE いただきらいだー 〜おまえのばいくはおれのもの / Jacked〜
+  name-sort: SIMPLE2000しりーず Vol.111 THE いただきらいだー おまえのばいくはおれのもの / Jacked
   name-en: "Simple 2000 Series Vol. 111 - The Itadaki Raider"
   region: "NTSC-J"
 SLPS-25704:
@@ -54010,22 +54142,22 @@ SLPS-25710:
         patch=1,EE,004574D8,word,0000948c
 SLPS-25711:
   name: かしまし 〜ガールミーツガール「初めての夏物語。」Best Collection
-  name-sort: かしまし 〜がーるみーつがーる「はじめてのなつものご。」Best Collection
+  name-sort: かしまし がーるみーつがーる「はじめてのなつものがたり」Best Collection
   name-en: "Kashimashi! Girl Meets Girl [Best Collection]"
   region: "NTSC-J"
 SLPS-25712:
-  name: THE KING OF FIGHTERS NEOWAVE [SNK BEST COLLECTION]
+  name: SNK BEST COLLECTION THE KING OF FIGHTERS NEOWAVE
   name-sort: THE KING OF FIGHTERS NEOWAVE [SNK BEST COLLECTION]
   name-en: "King of Fighters Neowave [SNK the Best]"
   region: "NTSC-J"
 SLPS-25713:
-  name: ティンクルスタースプライツーLa Petite Princesse- [SNK BEST COLLECTION]
+  name: SNK BEST COLLECTION ティンクルスタースプライツーLa Petite Princesse-
   name-sort: てぃんくるすたーすぷらいつーLa Petite Princesse- [SNK BEST COLLECTION]
   name-en: "Twinkle Star Sprites - La Petite Princesse [SNK the Best]"
   region: "NTSC-J"
 SLPS-25714:
   name: NARUTO-ナルト- 木ノ葉スピリッツ!!
-  name-sort: NARUTO-なると- きのはすぴりっつ!!
+  name-sort: なると きのはすぴりっつ!!
   name-en: "Naruto - Konoha Spirits"
   region: "NTSC-J"
   gameFixes:
@@ -54049,7 +54181,7 @@ SLPS-25717:
   region: "NTSC-J"
 SLPS-25718:
   name: 機動戦士ガンダムSEED DESTINY 連合vs.Z.A.F.T.II PLUS
-  name-sort: きどうせんしがんだむSEED DESTINY れんごうvs.Z.A.F.T.II PLUS
+  name-sort: きどうせんしがんだむしーど ですてぃにー れんごうvs.Z.A.F.T.II PLUS
   name-en: "Mobile Suit Gundam Seed Destiny - Rengou vs. Z.A.F.T. II Plus"
   region: "NTSC-J"
   compat: 5
@@ -54069,7 +54201,7 @@ SLPS-25719:
   region: "NTSC-J"
 SLPS-25720:
   name: はぴねす!でらっくす 通常版
-  name-sort: はぴねす!でらっくす つうじょうばん
+  name-sort: はぴねす!でらっくす [つうじょうばん]
   name-en: "Happiness! Deluxe"
   region: "NTSC-J"
 SLPS-25721:
@@ -54079,13 +54211,13 @@ SLPS-25721:
   region: "NTSC-J"
 SLPS-25722:
   name: Routes PE [初回限定版]
-  name-sort: Routes PE [しょかいげんていばん]
+  name-sort: Routes PE しょかいげんていばん
   name-en: "Routes PE [Limited Edition]"
   region: "NTSC-J"
 SLPS-25723:
   name: 令嬢探偵〜オフィスラブ事件慕〜
-  name-sort: れいじょうたんてい〜おふぃすらぶじけん慕〜
-  name-en: "Simple 2000 Series Vol. 123 - The Office Love Jikenbou - Reijou Tantei"
+  name-sort: れいじょうたんてい おふぃすらぶじけんぼ
+  name-en: "Simple 2000 Series Vol. 123 - The Office Love Jikenbo - Reijou Tantei"
   region: "NTSC-J"
 SLPS-25724:
   name: ぱちんこ華王 美空ひばり
@@ -54109,31 +54241,31 @@ SLPS-25727:
   region: "NTSC-J"
 SLPS-25728:
   name: くじびき アンバランス 会長お願いすま〜っしゅファイト☆ [初回限定版]
-  name-sort: くじびき あんばらんす かいちょうおねがいすま〜っしゅふぁいと☆ [しょかいげんていばん]
+  name-sort: くじびき あんばらんす かいちょうおねがいすまーっしゅふぁいと しょかいげんていばん
   name-en: "Kujibiki Ambulance [Limited Edition]"
   region: "NTSC-J"
 SLPS-25729:
   name: くじびき アンバランス 会長お願いすま〜っしゅファイト☆ [通常版]
-  name-sort: くじびき あんばらんす かいちょうおねがいすま〜っしゅふぁいと☆ [つうじょうばん]
+  name-sort: くじびき あんばらんす かいちょうおねがいすまーっしゅふぁいと [つうじょうばん]
   name-en: "Kujibiki Unbalance"
   region: "NTSC-J"
 SLPS-25730:
-  name: アーマード・コア ラストレイヴン -MACHINE SIDE BOX-
-  name-sort: あーまーど・こあ らすとれいゔん -MACHINE SIDE BOX-
+  name: ARMORED CORE -MACHINE SIDE BOX-
+  name-sort: あーまーどこあ [MACHINE SIDE BOX]
   name-en: "Armored Core - Last Raven [Machine Side Box]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Corrects shadow alignment and reduces blurriness.
     recommendedBlendingLevel: 3 # Fixes level and map menu brightness.
 SLPS-25731:
-  name: アーマード・コア 2 -MACHINE SIDE BOX-
-  name-sort: あーまーど・こあ 2 -MACHINE SIDE BOX-
-  name-en: "Armored Core 2 [Machine Side Box]"
+  name: ARMORED CORE 2 (ARMORED CORE PREMIUM BOX同梱用)
+  name-sort: あーまーどこあ2
+  name-en: "Armored Core 2"
   region: "NTSC-J"
 SLPS-25732:
-  name: アーマード・コア 3 -MACHINE SIDE BOX-
-  name-sort: あーまーど・こあ 3 -MACHINE SIDE BOX-
-  name-en: "Armored Core 3 [Machine Side Box]"
+  name: ARMORED CORE 3 (ARMORED CORE PREMIUM BOX同梱用)
+  name-sort: あーまーどこあ3
+  name-en: "Armored Core 3"
   region: "NTSC-J"
 SLPS-25733:
   name: スーパーロボット大戦OG ORIGINAL GENERATIONS
@@ -54142,7 +54274,7 @@ SLPS-25733:
   region: "NTSC-J"
 SLPS-25734:
   name: THE BATTLE OF 幽★遊★白書〜死闘!暗黒武術会〜120%
-  name-sort: THE BATTLE OF ゆう★ゆう★はくしょ〜しとう!あんこくぶじゅつかい〜120%
+  name-sort: THE BATTLE OF ゆうゆうはくしょ しとう あんこくぶじゅつかい 120%
   name-en: "Battle of Yuu Yuu Hakusho, The - Shitou! Ankoku Bujutsukai - 120% Full Power"
   region: "NTSC-J"
 SLPS-25735:
@@ -54162,7 +54294,7 @@ SLPS-25737:
   region: "NTSC-J"
 SLPS-25738:
   name: SOUL CRADLE(ソウルクレイドル) 世界を喰らう者 [初回限定版]
-  name-sort: そうるくれいどる せかいをくらうもの [しょかいげんていばん]
+  name-sort: そうるくれいどる せかいをくらうもの しょかいげんていばん
   name-en: "Soul Cradle Sekai o Kurau Mono [Limited Edition]"
   region: "NTSC-J"
   compat: 5
@@ -54173,12 +54305,12 @@ SLPS-25739:
   region: "NTSC-J"
 SLPS-25740:
   name: ルパン三世 ルパンには死を、銭形には恋を
-  name-sort: るぱんさんせい るぱんにはしを、ぜにがたにはこいを
-  name-en: "Lupin III - Lupin ni wa Shi o, Zenigata ni wa Koi o"
+  name-sort: るぱんさんせい るぱんにはしを ぜにがたにはこいを
+  name-en: "Lupin III - Lupin ni ha Shi o, Zenigata ni ha Koi o"
   region: "NTSC-J"
 SLPS-25742:
   name: ああっ女神さまっ [初回限定版]
-  name-sort: ああっめがみさまっ [しょかいげんていばん]
+  name-sort: ああっめがみさまっ しょかいげんていばん
   name-en: "Aa Megami-sama [Holy Box]"
   region: "NTSC-J"
 SLPS-25743:
@@ -54193,12 +54325,12 @@ SLPS-25744:
   region: "NTSC-J"
 SLPS-25745:
   name: 必勝パチンコ★パチスロ攻略シリーズ vol.1 CR新世紀エヴァンゲリオン
-  name-sort: ひっしょうぱちんこ★ぱちすろこうりゃくしりーず vol.1 CRしんせいきえゔぁんげりおん
+  name-sort: ひっしょうぱちんこぱちすろこうりゃくしりーず vol.1 CRしんせいきえゔぁんげりおん
   name-en: "Hisshou Pachinko-Pachislot Kouryaku Series Vol.1 - CR Shinseiki Evangelion"
   region: "NTSC-J"
 SLPS-25746:
   name: 必勝パチンコ★パチスロ攻略シリーズ Vol.9 CRフィーバー キャプテンハーロック
-  name-sort: ひっしょうぱちんこ★ぱちすろこうりゃくしりーず Vol.9 CRふぃーばー きゃぷてんはーろっく
+  name-sort: ひっしょうぱちんこぱちすろこうりゃくしりーず Vol.9 CRふぃーばー きゃぷてんはーろっく
   name-en: "CR Fever Captain Harlock"
   region: "NTSC-J"
 SLPS-25747:
@@ -54208,12 +54340,12 @@ SLPS-25747:
   region: "NTSC-J"
 SLPS-25748:
   name: 蒼い空のネオスフィア〜ナノカ・フランカ発明工房記2〜 [初回限定版]
-  name-sort: あおいそらのねおすふぃあ〜なのか・ふらんかはつめいこうぼうき2〜 [しょかいげんていばん]
-  name-en: "Aoi Sora no Neosphere - Nanoca Flanka Hatsumei Koubouki 2 [Shokai Genteiban]"
+  name-sort: あおいそらのねおすふぃあ なのかふらんかはつめいこうぼうき2 しょかいげんていばん
+  name-en: "Aoi Sora no Neosphere - Nanoca Flanka Hatsumei Koubouki 2 [First Print Limited Edition]"
   region: "NTSC-J"
 SLPS-25749:
   name: 蒼い空のネオスフィア〜ナノカ・フランカ発明工房記2〜 [通常版]
-  name-sort: あおいそらのねおすふぃあ〜なのか・ふらんかはつめいこうぼうき2〜 [つうじょうばん]
+  name-sort: あおいそらのねおすふぃあ なのかふらんかはつめいこうぼうき2 [つうじょうばん]
   name-en: "Aoi Sora no Neosphere - Nanoca Flanka Hatsumei Koubouki 2"
   region: "NTSC-J"
 SLPS-25750:
@@ -54223,12 +54355,12 @@ SLPS-25750:
   region: "NTSC-J"
 SLPS-25751:
   name: がくえんゆーとぴあ まなびストレート! キラキラ☆ Happy Festa! [初回限定版]
-  name-sort: がくえんゆーとぴあ まなびすとれーと! きらきら☆ Happy Festa! [しょかいげんていばん]
+  name-sort: がくえんゆーとぴあ まなびすとれーと! きらきら Happy Festa! しょかいげんていばん
   name-en: "Gakuen Utopia - Manabi Straight! KiraKira Happy Festa! [Limited Edition]"
   region: "NTSC-J"
 SLPS-25752:
   name: がくえんゆーとぴあ まなびストレート! キラキラ☆ Happy Festa!
-  name-sort: がくえんゆーとぴあ まなびすとれーと! きらきら☆ Happy Festa!
+  name-sort: がくえんゆーとぴあ まなびすとれーと! きらきら Happy Festa!
   name-en: "Gakuen Utopia - Manabi Straight! KiraKira Happy Festa!"
   region: "NTSC-J"
 SLPS-25753:
@@ -54242,10 +54374,10 @@ SLPS-25754:
   name-en: "Kino no Tabi 2 - The Beautiful World [Electric Shock SP]"
   region: "NTSC-J"
 SLPS-25755:
-  name: "Dot Hack G.U. Vol. 1 - Saitan"
+  name: ".hack//G.U. Vol. 1 - Saitan"
   region: "NTSC-J"
 SLPS-25756:
-  name: "dot hack G.U. Vol.1 - Saitan [Bandai the Best]"
+  name: ".hack//G.U. Vol.1 - Saitan [Bandai the Best]"
   region: "NTSC-J"
   memcardFilters:
     - "SCPS-55029"
@@ -54266,12 +54398,12 @@ SLPS-25756:
     - "SLPS-25756"
 SLPS-25757:
   name: ななついろ★ドロップスPure!! [初回限定版]
-  name-sort: ななついろ★どろっぷすPure!! [しょかいげんていばん]
+  name-sort: ななついろどろっぷすPure!! しょかいげんていばん
   name-en: "Nanatsu Iro - Drops Pure!! [First Print Limited Edition]"
   region: "NTSC-J"
 SLPS-25758:
   name: ななついろ★ドロップス Pure!! [通常版]
-  name-sort: ななついろ★どろっぷす Pure!! [つうじょうばん]
+  name-sort: ななついろどろっぷす Pure!! [つうじょうばん]
   name-en: "Nanatsu Iro - Drops Pure!!"
   region: "NTSC-J"
 SLPS-25759:
@@ -54303,7 +54435,7 @@ SLPS-25763:
   compat: 5
 SLPS-25764:
   name: 武装錬金 〜ようこそ パピヨンパークへ〜
-  name-sort: ぶそうれんきん 〜ようこそ ぱぴよんぱーくへ〜
+  name-sort: ぶそうれんきん ようこそ ぱぴよんぱーくへ
   name-en: "Busou Renkin - Youkoso Papillon Park e"
   region: "NTSC-J"
 SLPS-25765:
@@ -54313,17 +54445,17 @@ SLPS-25765:
   region: "NTSC-J"
 SLPS-25766:
   name: オレンジハニー 僕はキミに恋してる [初回限定版]
-  name-sort: おれんじはにー ぼくはきみにこいしてる [しょかいげんていばん]
-  name-en: "Orange Honey - Boku wa Kimi ni Koishiteru [Limited Edition]"
+  name-sort: おれんじはにー ぼくはきみにこいしてる しょかいげんていばん
+  name-en: "Orange Honey - Boku ha Kimi ni Koishiteru [Limited Edition]"
   region: "NTSC-J"
 SLPS-25767:
   name: オレンジハニー 僕はキミに恋してる [通常版]
   name-sort: おれんじはにー ぼくはきみにこいしてる [つうじょうばん]
-  name-en: "Orange Honey - Boku wa Kimi ni Koishiteru"
+  name-en: "Orange Honey - Boku ha Kimi ni Koishiteru"
   region: "NTSC-J"
 SLPS-25768:
   name: NARUTO-ナルト- 疾風伝 ナルティメットアクセル
-  name-sort: NARUTO-なると- しっぷうでん なるてぃめっとあくせる
+  name-sort: なると しっぷうでん なるてぃめっとあくせる
   name-en: "Naruto Shippuuden Narutimate Accel"
   region: "NTSC-J"
   gameFixes:
@@ -54375,12 +54507,12 @@ SLPS-25776:
   region: "NTSC-J"
 SLPS-25777:
   name: すもももももも 〜地上最強のヨメ〜 継承しましょ!? 恋の花ムコ争奪戦!! [初回限定版]
-  name-sort: すもももももも 〜ちじょうさいきょうのよめ〜 けいしょうしましょ!? こいのはなむこそうだつせん!! [しょかいげんていばん]
+  name-sort: すもももももも ちじょうさいきょうのよめ けいしょうしましょ!? こいのはなむこそうだつせん!! しょかいげんていばん
   name-en: "Sumomomomomo - Chijou Saikyou no Yome [Limited Edition]"
   region: "NTSC-J"
 SLPS-25778:
   name: すもももももも 〜地上最強のヨメ〜 継承しましょ!? 恋の花ムコ争奪戦!! [通常版]
-  name-sort: すもももももも 〜ちじょうさいきょうのよめ〜 けいしょうしましょ!? こいのはなむこそうだつせん!! [つうじょうばん]
+  name-sort: すもももももも ちじょうさいきょうのよめ けいしょうしましょ!? こいのはなむこそうだつせん!! [つうじょうばん]
   name-en: "Sumomomo Momomo - Chijou Saikyou no Yome - Keishou Shimasho! Koi no Hanamuko Soudatsu-sen!!"
   region: "NTSC-J"
 SLPS-25779:
@@ -54406,7 +54538,7 @@ SLPS-25782:
   region: "NTSC-J"
 SLPS-25783:
   name: ザ・キング・オブ・ファイターズ98アルティメットマッチ [NEOGEOオンラインコレクション]
-  name-sort: ざ・きんぐ・おぶ・ふぁいたーず98あるてぃめっとまっち [NEOGEOおんらいんこれくしょん]
+  name-sort: ざ きんぐ おぶ ふぁいたーず98あるてぃめっとまっち [NEOGEOおんらいんこれくしょん]
   name-en: "King of Fighters '98, The - Ultimate Match"
   region: "NTSC-J"
 SLPS-25784:
@@ -54418,14 +54550,14 @@ SLPS-25784:
     vuClampMode: 3 # Was used to fix game crash, but not sure it's required anymore.
 SLPS-25786:
   name: 必勝パチンコ★パチスロ攻略シリーズ Vol.10 CR新世紀エヴァンゲリオン〜奇跡の価値は〜
-  name-sort: ひっしょうぱちんこ★ぱちすろこうりゃくしりーず Vol.10 CRしんせいきえゔぁんげりおん〜きせきのかちは〜
+  name-sort: ひっしょうぱちんこぱちすろこうりゃくしりーず Vol.10 CRしんせいきえゔぁんげりおん きせきのかちは
   name-en: "Hisshou Pachinko-Pachislot Kouryaku Series Vol.10 - CR Shinseiki Evangelion - Kiseki no kachi Ha"
   region: "NTSC-J"
   gameFixes:
     - EETimingHack # Fixes FMV hanging.
 SLPS-25787:
   name: パチパラ14 〜風と雲とスーパー海IN沖縄〜
-  name-sort: ぱちぱら14 〜かぜとくもとすーぱーうみINおきなわ〜
+  name-sort: ぱちぱら14 かぜとくもとすーぱーうみINおきなわ
   name-en: "Sanyo Pachinko Paradise 14"
   region: "NTSC-J"
   compat: 5
@@ -54444,12 +54576,12 @@ SLPS-25789:
   region: "NTSC-J"
 SLPS-25790:
   name: NEOGEO ONLINE COLLECTION THE BEST 龍虎の拳 〜天・地・人〜
-  name-sort: NEOGEO ONLINE COLLECTION THE BEST りゅうこのけん 〜てん・ち・じん〜
+  name-sort: NEOGEO ONLINE COLLECTION THE BEST りゅうこのけん てんちじん
   name-en: "Art of Fighting Collection [NeoGeo Online Collection the Best]"
   region: "NTSC-J"
 SLPS-25791:
   name: NEOGEO ONLINE COLLECTION THE BEST THE KING OF FIGHTERS 〜オロチ編〜
-  name-sort: NEOGEO ONLINE COLLECTION THE BEST THE KING OF FIGHTERS 〜おろちへん〜
+  name-sort: NEOGEO ONLINE COLLECTION THE BEST THE KING OF FIGHTERS おろちへん
   name-en: "King of Fighters, The - Orochi Collection [NeoGeo Online Collection the Best]"
   region: "NTSC-J"
 SLPS-25792:
@@ -54464,17 +54596,17 @@ SLPS-25793:
   region: "NTSC-J"
 SLPS-25794:
   name: クラスターエッジ〜君を待つ未来への証〜 Best Collection
-  name-sort: くらすたーえっじ〜きみをまつみらいへのあかし〜 Best Collection
+  name-sort: くらすたーえっじ きみをまつみらいへのあかし Best Collection
   name-en: "Cluster Edge [Best Collection]"
   region: "NTSC-J"
 SLPS-25795:
   name: スクールランブル二学期 恐怖の(?)夏合宿! 洋館に幽霊現る!?お宝を巡って真っ向勝負!!!の巻 Best Collection
-  name-sort: すくーるらんぶるにがっき きょうふの(?)なつがっしゅく! ようかんにゆうれいあらわる!?おたからをめぐってまっこうしょうぶ!!!のまき Best Collection
+  name-sort: すくーるらんぶるにがっき きょうふのなつがっしゅく! ようかんにゆうれいあらわる!?おたからをめぐってまっこうしょうぶ!!!のまき Best Collection
   name-en: "School Rumble - 2nd Term [Best Collection]"
   region: "NTSC-J"
 SLPS-25796:
   name: 俺の下でAGAKE
-  name-sort: おれのしたでAGAKE
+  name-sort: おれのしたであがけ
   name-en: "Ore no Shite Agake"
   region: "NTSC-J"
 SLPS-25797:
@@ -54494,50 +54626,50 @@ SLPS-25798:
     roundSprite: 1 # Aligns bloom effect.
 SLPS-25799:
   name: ウルトラマン Fighting Evolution 3 バンプレストベスト
-  name-sort: うるとらまん Fighting Evolution 3 ばんぷれすとべすと
+  name-sort: うるとらまん Fighting Evolution 3 [ばんぷれすとべすと]
   name-en: "Ultraman Fighting Evolution 3 [Banpresto Best]"
   region: "NTSC-J"
 SLPS-25800:
   name: ウルトラマン Fighting Evolution Rebirth バンプレストベスト
-  name-sort: うるとらまん Fighting Evolution Rebirth ばんぷれすとべすと
+  name-sort: うるとらまん Fighting Evolution Rebirth [ばんぷれすとべすと]
   name-en: "Ultraman Fighting Evolution - Rebirth [Banpresto Best]"
   region: "NTSC-J"
   gsHWFixes:
     getSkipCount: "GSC_UltramanFightingEvolution"
 SLPS-25801:
   name: 今日からマ王！ 眞マ国の休日
-  name-sort: きょうからまおう！ まことまこくのきゅうじつ
-  name-en: "Kyou Kara Maou! Shin Ma-Kuni no Kyuujitsu [Limited Edition]"
+  name-sort: きょうからまおう しんまこくのきゅうじつ
+  name-en: "Kyou Kara Maou! Shin Ma-Koku no Kyuujitsu [Limited Edition]"
   region: "NTSC-J"
 SLPS-25802:
   name: 今日からマ王！ 眞マ国の休日
-  name-sort: きょうからまおう！ まことまこくのきゅうじつ
-  name-en: "Kyou Kara Maou! Shin Ma-Kuni no Kyuujitsu"
+  name-sort: きょうからまおう しんまこくのきゅうじつ
+  name-en: "Kyou Kara Maou! Shin Ma-Koku no Kyuujitsu"
   region: "NTSC-J"
 SLPS-25803:
   name: xxx HOLiC〜四月一日の十六夜草話〜
-  name-sort: xxx HOLiC〜わたぬきのいざよいそうわ〜
+  name-sort: ほりっく わたぬきのいざよいそうわ
   name-en: "xxxHolic - Shigatsu Tsuitachi no Izayoi Sowa"
   region: "NTSC-J"
 SLPS-25804:
   name: DEAR My SUN!! 〜ムスコ★育成★狂騒曲〜 [限定版]
-  name-sort: DEAR My SUN!! 〜むすこ★いくせい★きょうそうきょく〜 [げんていばん]
+  name-sort: DEAR My SUN!! むすこいくせいきょうそうきょく [げんていばん]
   name-en: "Dear My Sun [Limited Edition]"
   region: "NTSC-J"
 SLPS-25806:
   name: 家庭教師ヒットマン REBORN!ドリームハイパーバトル!死ぬ気の炎と黒き記憶
-  name-sort: かていきょうしひっとまん REBORN!どりーむはいぱーばとる!しぬきのほのおとくろききおく
-  name-en: "Kateikyoushi Hitman Reborn! Dream Hyper Battle"
+  name-sort: かてきょーひっとまんりぼーん どりーむはいぱーばとる!しぬきのほのおとくろききおく
+  name-en: "Katekyoo Hitman Reborn! Dream Hyper Battle"
   region: "NTSC-J"
   compat: 5
 SLPS-25807:
   name: セイント・ビースト 〜螺旋の章〜 [限定版]
-  name-sort: せいんと・びーすと 〜らせんのしょう〜 [げんていばん]
+  name-sort: せいんと びーすと らせんのしょう [げんていばん]
   name-en: "Saint Beast - Rasen no Shou [Limited Edition]"
   region: "NTSC-J"
 SLPS-25808:
   name: セイント・ビースト 〜螺旋の章〜 [通常版]
-  name-sort: せいんと・びーすと 〜らせんのしょう〜 [つうじょうばん]
+  name-sort: せいんと びーすと らせんのしょう [つうじょうばん]
   name-en: "Saint Beast - Rasen no Shou"
   region: "NTSC-J"
 SLPS-25809:
@@ -54547,7 +54679,7 @@ SLPS-25809:
   region: "NTSC-J"
 SLPS-25810:
   name: DEAR My SUN!! 〜ムスコ★育成★狂騒曲〜 [通常版]
-  name-sort: DEAR My SUN!! 〜むすこ★いくせい★きょうそうきょく〜 [つうじょうばん]
+  name-sort: DEAR My SUN!! むすこいくせいきょうそうきょく [つうじょうばん]
   name-en: "Dear My Sun"
   region: "NTSC-J"
 SLPS-25811:
@@ -54557,12 +54689,12 @@ SLPS-25811:
   region: "NTSC-J"
 SLPS-25812:
   name: トリノホシ 〜Aerial Planet〜
-  name-sort: とりのほし 〜Aerial Planet〜
+  name-sort: とりのほし Aerial Planet
   name-en: "Tori no Hoshi - Aerial Planet"
   region: "NTSC-J"
 SLPS-25813:
   name: 必勝パチンコ★パチスロ攻略シリーズ Vol.11 新世紀エヴァンゲリオン〜まごころを、君に〜
-  name-sort: ひっしょうぱちんこ★ぱちすろこうりゃくしりーず Vol.11 しんせいきえゔぁんげりおん〜まごころを、きみに〜
+  name-sort: ひっしょうぱちんこぱちすろこうりゃくしりーず Vol.11 しんせいきえゔぁんげりおん まごころをきみに
   name-en: "Hisshou Pachinko - Pachi-Slot Kouryoku Series Vol.11 - Shinseiki Evangelion - Magokoro o, Kimi ni"
   region: "NTSC-J"
 SLPS-25814:
@@ -54572,26 +54704,26 @@ SLPS-25814:
   region: "NTSC-J"
 SLPS-25815:
   name: ドラゴンボールZ スパーキング!メテオ
-  name-sort: どらごんぼーるZ すぱーきんぐ!めてお
+  name-sort: どらごんぼーるZ すぱーきんぐ めてお
   name-en: "Dragon Ball Z Sparking! Meteor"
   region: "NTSC-J"
   gsHWFixes:
     beforeDraw: "OI_DBZBTGames"
 SLPS-25816:
   name: 山佐DigiワールドコラボレーションSP パチスロ リッジレーサー
-  name-sort: やまさDigiわーるどこらぼれーしょんSP ぱちすろ りっじれーさー
+  name-sort: やまさでじわーるどこらぼれーしょんSP ぱちすろ りっじれーさー
   name-en: "Yamasa Digi World Collaboration SP - Pachi-Slot Ridge Racer"
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
 SLPS-25817:
   name: 幕末恋華・花柳剣士伝 雅の玉手箱
-  name-sort: ばくまつれんか・かりゅうけんしでん みやびのたまてばこ
+  name-sort: ばくまつれんか かりゅうけんしでん みやびのたまてばこ
   name-en: "Bakumatsu Renka - Karyuu Kenshiden [Genteiban]"
   region: "NTSC-J"
 SLPS-25818:
   name: 幕末恋華・花柳剣士伝
-  name-sort: ばくまつれんか・かりゅうけんしでん
+  name-sort: ばくまつれんか かりゅうけんしでん
   name-en: "Bakumatsu Renka - Karyuu Kenshiden"
   region: "NTSC-J"
 SLPS-25819:
@@ -54607,8 +54739,8 @@ SLPS-25819:
     beforeDraw: "OI_ArTonelico2"
 SLPS-25820:
   name: 家庭教師ヒットマンREBORN! Let’s暗殺!? 狙われた10代目!
-  name-sort: かていきょうしひっとまんREBORN! Let’sあんさつ!? ねらわれた10だいめ!
-  name-en: "Kateikyoushi Hitman Reborn!! Let's Ansatsu! Nerawareta 10 Daime!"
+  name-sort: かてきょーひっとまんREBORN! れっつあんさつ!? ねらわれた10だいめ!
+  name-en: "Katekyoo Hitman Reborn!! Let's Ansatsu! Nerawareta 10 Daime!"
   region: "NTSC-J"
   gsHWFixes:
     roundSprite: 2 # Reduces font artifacts but characters still have major artifacts.
@@ -54675,7 +54807,7 @@ SLPS-25832:
   region: "NTSC-J"
 SLPS-25833:
   name: SIMPLE2000シリーズ Vol.122 THE 人魚姫物語〜マーメイドプリズム〜
-  name-sort: SIMPLE2000しりーず Vol.122 THE にんぎょひめものがたり〜まーめいどぷりずむ〜
+  name-sort: SIMPLE2000しりーず Vol.122 THE にんぎょひめものがたり まーめいどぷりずむ
   name-en: "Simple 2000 Series Vol. 122 - The Ningyo Hime Monogatari - Mermaid Prism"
   region: "NTSC-J"
 SLPS-25834:
@@ -54698,7 +54830,7 @@ SLPS-25836:
   region: "NTSC-J"
 SLPS-25837:
   name: NARUTO-ナルト- 疾風伝 ナルティメットアクセル2
-  name-sort: NARUTO-なると- しっぷうでん なるてぃめっとあくせる2
+  name-sort: なると しっぷうでん なるてぃめっとあくせる2
   name-en: "Naruto Shippuuden - Narutimate Accel 2"
   region: "NTSC-J"
   gameFixes:
@@ -54711,7 +54843,7 @@ SLPS-25837:
     vu1ClampMode: 3 # Fixes SPS on characters.
 SLPS-25838:
   name: 太平洋の嵐　〜戦艦大和、暁に出撃す〜
-  name-sort: たいへいようのあらし　〜せんかんやまと、あかつきにしゅつげきす〜
+  name-sort: たいへいようのあらし せんかんやまと あかつきにしゅつげきす
   name-en: "Taiheiyou no Arashi - Senkan Yamato, Akatsuki ni Shutsugeki su"
   region: "NTSC-J"
 SLPS-25839:
@@ -54721,7 +54853,7 @@ SLPS-25839:
   region: "NTSC-J"
 SLPS-25840:
   name: ギターヒーロー３ レジェンド オブ ロック （ギターヒーロー３専用ワイヤレス クレイマー®ストライカー コントローラ同梱セット）
-  name-sort: ぎたーひーろーさん れじぇんど おぶ ろっく （ぎたーひーろーさんせんようわいやれす くれいまー®すとらいかー こんとろーらどうこんせっと）
+  name-sort: ぎたーひーろー3 れじぇんど おぶ ろっく （ぎたーひーろー3せんようわいやれす くれいまーすとらいかー こんとろーらどうこんせっと）
   name-en: "Guitar Hero III - Legends of Rock [with Guitar]"
   region: "NTSC-J"
   roundModes:
@@ -54730,7 +54862,7 @@ SLPS-25840:
     textureInsideRT: 1 # Crowd textures.
 SLPS-25841:
   name: テイルズ オブ デスティニー ディレクターズカット プレミアムBOX
-  name-sort: ているず おぶ ですてぃにー でぃれくたーずかっと ぷれみあむBOX
+  name-sort: ているず おぶ ですてぃにー でぃれくたーずかっと [ぷれみあむBOX]
   name-en: "Tales of Destiny [Director's Cut] [Premium Box]"
   region: "NTSC-J"
   gameFixes:
@@ -54753,27 +54885,27 @@ SLPS-25842:
     - "SLPS-25715"
 SLPS-25843:
   name: ティル・ナ・ノーグ 〜悠久の仁〜
-  name-sort: てぃる・な・のーぐ 〜ゆうきゅうのひとし〜
+  name-sort: てぃる・な・のーぐ ゆうきゅうのひと
   name-en: "Tir-Na-Nog"
   region: "NTSC-J"
 SLPS-25844:
   name: ラスト・エスコート 2 〜深夜の甘い棘〜 Gorgeous版
-  name-sort: らすと・えすこーと 2 〜しんやのあまいとげ〜 Gorgeousばん
-  name-en: "Last Escort 2 - Shiya no Amai Ira [Gorgeous Version]"
+  name-sort: らすと えすこーと 2 しんやのあまいとげ Gorgeousばん
+  name-en: "Last Escort 2 - Shiya no Amai Toge [Gorgeous Version]"
   region: "NTSC-J"
 SLPS-25845:
   name: ラスト・エスコート 2 〜深夜の甘い棘〜
-  name-sort: らすと・えすこーと 2 〜しんやのあまいとげ〜
-  name-en: "Last Escort 2 - Shiya no Amai Ira"
+  name-sort: らすと えすこーと 2 しんやのあまいとげ
+  name-en: "Last Escort 2 - Shiya no Amai Toge"
   region: "NTSC-J"
 SLPS-25847:
   name: 雨格子の館 一柳和、最初の受難 The Best Price
-  name-sort: あめこうしのやかた いちやなぎなごむ、さいしょのじゅなん The Best Price
+  name-sort: あめこうしのやかた いちやなぎなごむ さいしょのじゅなん The Best Price
   name-en: "Amekoushi no Kan [The Best Price]"
   region: "NTSC-J"
 SLPS-25848:
   name: 奈落の城 一柳和、2度目の受難
-  name-sort: ならくのしろ いちやなぎなごむ、2どめのじゅなん
+  name-sort: ならくのしろ いちやなぎなごむ 2どめのじゅなん
   name-en: "Naraku no Shiro"
   region: "NTSC-J"
 SLPS-25849:
@@ -54798,7 +54930,7 @@ SLPS-25851:
     getSkipCount: "GSC_ZettaiZetsumeiToshi2"
 SLPS-25852:
   name: パチパラ13 〜スーパー海とパチプロ風雲録〜 [アイレムコレクション]
-  name-sort: ぱちぱら13 〜すーぱーうみとぱちぷろふううんろく〜 [あいれむこれくしょん]
+  name-sort: ぱちぱら13 すーぱーうみとぱちぷろふううんろく [あいれむこれくしょん]
   name-en: "Sanyo Pachinko Paradise 13 [Irem Collection]"
   region: "NTSC-J"
   gsHWFixes:
@@ -54833,13 +54965,13 @@ SLPS-25856:
     textureInsideRT: 1 # Needed for post processing effects.
 SLPS-25858:
   name: 電撃SP 灼眼のシャナ
-  name-sort: でんげきSP 灼眼のしゃな
+  name-sort: でんげきSP しゃくがんのしゃな
   name-en: "Dengeki SP - Shakugan no Shana"
   region: "NTSC-J"
 SLPS-25859:
   name: オレンジハニー 僕はキミに恋してる Best Collection
   name-sort: おれんじはにー ぼくはきみにこいしてる Best Collection
-  name-en: "Orange Honey - Boku wa Kimi ni Koishiteru [Best Version]"
+  name-en: "Orange Honey - Boku ha Kimi ni Koishiteru [Best Version]"
   region: "NTSC-J"
 SLPS-25860:
   name: コードギアス 反逆のルルーシュ LOST COLORS
@@ -54848,12 +54980,12 @@ SLPS-25860:
   region: "NTSC-J"
 SLPS-25861:
   name: CR新世紀エヴァンゲリオン〜奇跡の価値は〜 [スペシャルプライス版]
-  name-sort: CRしんせいきえゔぁんげりおん〜きせきのかちは〜 [すぺしゃるぷらいすばん]
+  name-sort: CRしんせいきえゔぁんげりおん きせきのかちは [すぺしゃるぷらいすばん]
   name-en: "Hisshou Pachinko - Pachi-Slot Kouryoku Series Vol.10 [Special Price Edition]"
   region: "NTSC-J"
 SLPS-25862:
   name: CR新世紀エヴァンゲリオン〜セカンドインパクト〜 [スペシャルプライス版]
-  name-sort: CRしんせいきえゔぁんげりおん〜せかんどいんぱくと〜 [すぺしゃるぷらいすばん]
+  name-sort: CRしんせいきえゔぁんげりおん せかんどいんぱくと [すぺしゃるぷらいすばん]
   name-en: "Hisshou Pachinko - Pachi-Slot Kouryoku Series Vol.05 - CR Neon Genesis Evangelion Sekandoinpakuto & Pachislot Neon Genesis Evangelion [Special Price Edition]"
   region: "NTSC-J"
 SLPS-25863:
@@ -54868,7 +55000,7 @@ SLPS-25864:
   region: "NTSC-J"
 SLPS-25865:
   name: THE BEST ザ・キング・オブ・ファイターズ〜ネスツ編〜 [NEOGEOオンラインコレクション]
-  name-sort: THE BEST ざ・きんぐ・おぶ・ふぁいたーず〜ねすつへん〜 [NEOGEOおんらいんこれくしょん]
+  name-sort: THE BEST ざ きんぐ おぶ ふぁいたーず ねすつへん [NEOGEOおんらいんこれくしょん]
   name-en: "King of Fighters, The - Nests [SNK the Best]"
   region: "NTSC-J"
 SLPS-25866:
@@ -54878,7 +55010,7 @@ SLPS-25866:
   region: "NTSC-J"
 SLPS-25867:
   name: 花宵ロマネスク 愛と哀しみ−それは君のためのアリア 限定版
-  name-sort: はなよいろまねすく あいとかなしみ-それはきみのためのありあ げんていばん
+  name-sort: はなよいろまねすく あいとかなしみ-それはきみのためのありあ [げんていばん]
   name-en: "Hanayoi Romanesque - Ai to Kanashimi [Limited Edition]"
   region: "NTSC-J"
 SLPS-25868:
@@ -54888,7 +55020,7 @@ SLPS-25868:
   region: "NTSC-J"
 SLPS-25869:
   name: 必勝パチンコ★パチスロ攻略シリーズ Vol.12 CR新世紀エヴァンゲリオン〜使徒、再び〜
-  name-sort: ひっしょうぱちんこ★ぱちすろこうりゃくしりーず Vol.12 CRしんせいきえゔぁんげりおん〜しと、ふたたび〜
+  name-sort: ひっしょうぱちんこぱちすろこうりゃくしりーず Vol.12 CRしんせいきえゔぁんげりおん しと ふたたび
   name-en: "CR Shinseiki Evangelion - Shito, Futatabi"
   region: "NTSC-J"
 SLPS-25871:
@@ -54958,7 +55090,7 @@ SLPS-25887:
   region: "NTSC-J"
 SLPS-25888:
   name: スター・ウォーズ・フォース・アンリーシュド
-  name-sort: すたー・うぉーず・ふぉーす・あんりーしゅど
+  name-sort: すたー うぉーず ふぉーす あんりーしゅど
   name-en: "Star Wars - The Force Unleashed"
   region: "NTSC-J"
   compat: 5
@@ -54996,25 +55128,25 @@ SLPS-25891:
   region: "NTSC-J"
 SLPS-25892:
   name: 乃木坂春香の秘密 こすぷれ、はじめました♥
-  name-sort: のぎざかはるかのひみつ こすぷれ、はじめました♥
+  name-sort: のぎざかはるかのひみつ こすぷれ はじめました
   name-en: "Nogizaka Haruka no Himitsu - Cosplay Hajimemashita"
   region: "NTSC-J"
 SLPS-25893:
-  name: "Zero no Tsukaima - Muma ga Tsumugu Yokaze no Fantasy [PS2 The Best]"
+  name: "Zero no Tsukaima - Muma ga Tsumugu Yokaze no Fantasy [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPS-25894:
   name: ああっ女神さまっ Best Collection
   name-sort: ああっめがみさまっ Best Collection
-  name-en: "Aa Megami-sama [PS2 The Best]"
+  name-en: "Aa Megami-sama [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPS-25896:
   name: 萌え萌え2次大戦（略）☆デラックス
-  name-sort: もえもえにじたいせん（りゃく）☆でらっくす
+  name-sort: もえもえにじたいせん でらっくす
   name-en: "Moe Moe 2ji Taisen(Ryaku) Deluxe"
   region: "NTSC-J"
 SLPS-25897:
   name: ゼロの使い魔 迷子の終止符と幾千の交響曲 限定版
-  name-sort: ぜろのつかいま まいごのしゅうしふといくせんのこうきょうきょく げんていばん
+  name-sort: ぜろのつかいま まいごのしゅうしふといくせんのこうきょうきょく [げんていばん]
   name-en: "Zero no Tsukaima - Maigo no Period to Ikusen no Symphony [Limited Edition]"
   region: "NTSC-J"
 SLPS-25898:
@@ -55081,7 +55213,7 @@ SLPS-25914:
     eeDivRoundMode: 1
 SLPS-25915:
   name: ザ・キング・オブ・ファイターズ 2002 アンリミテッドマッチ
-  name-sort: ざ・きんぐ・おぶ・ふぁいたーず 2002 あんりみてっどまっち
+  name-sort: ざ きんぐ おぶ ふぁいたーず 2002 あんりみてっどまっち
   name-en: "King of Fighters 2002, The - Unlimited Match"
   region: "NTSC-J"
 SLPS-25916:
@@ -55157,7 +55289,7 @@ SLPS-25934:
   region: "NTSC-J"
 SLPS-25935:
   name: THE BEST ザ・キング・オブ・ファイターズ'98 アルティメットマッチ [NEOGEOオンラインコレクション]
-  name-sort: THE BEST ざ・きんぐ・おぶ・ふぁいたーず'98 あるてぃめっとまっち [NEOGEOおんらいんこれくしょん]
+  name-sort: THE BEST ざ きんぐ おぶ ふぁいたーず'98 あるてぃめっとまっち [NEOGEOおんらいんこれくしょん]
   name-en: "King of Fighters '98 Ultimate Match, The [NeoGeo Online Collection the Best]"
   region: "NTSC-J"
 SLPS-25936:
@@ -55229,8 +55361,8 @@ SLPS-25955:
   region: "NTSC-J"
 SLPS-25956:
   name: 萌え萌え2次大戦(略)2[chu〜♪]
-  name-sort: もえもえ2じたいせん(りゃく)2[chu〜♪]
-  name-en: "Moe Moe 2-ji Taisen Ryoku 2"
+  name-sort: もえもえ2じたいせん2 chu
+  name-en: "Moe Moe 2-ji Taisen 2"
   region: "NTSC-J"
 SLPS-25958:
   name: "Last Escort - Club Katze"
@@ -55244,7 +55376,7 @@ SLPS-25959:
     eeDivRoundMode: 1
 SLPS-25961:
   name: 機動戦士ガンダムSEED DESTINY 連合 vs. Z.A.F.T. II plus GUNDAM 30th ANNIVERSARY COLLECTION
-  name-sort: きどうせんしがんだむSEED DESTINY れんごう vs. Z.A.F.T. II plus GUNDAM 30th ANNIVERSARY COLLECTION
+  name-sort: きどうせんしがんだむしーど ですてぃにー れんごう vs. Z.A.F.T. II plus GUNDAM 30th ANNIVERSARY COLLECTION
   name-en: "Kidou Senshi Gundam SEED - Rengou vs. Z.A.F.T."
   region: "NTSC-K"
   roundModes:
@@ -55359,7 +55491,7 @@ SLPS-29002:
         patch=1,EE,00285f64,word,00000000
 SLPS-29003:
   name: ロード・オブ・ザ・リング 二つの塔 限定版
-  name-sort: ろーど・おぶ・ざ・りんぐ ふたつのとう げんていばん
+  name-sort: ろーど おぶ ざ りんぐ ふたつのとう [げんていばん]
   name-en: "Lord of the Rings - The Two Towers [Collector's Box]"
   region: "NTSC-J"
   gsHWFixes:
@@ -55368,7 +55500,7 @@ SLPS-29003:
     vuClampMode: 3 # Fix white shiny weapons.
 SLPS-29004:
   name: ロード・オブ・ザ・リング 二つの塔
-  name-sort: ろーど・おぶ・ざ・りんぐ ふたつのとう
+  name-sort: ろーど おぶ ざ りんぐ ふたつのとう
   name-en: "Lord of the Rings, The - The Two Towers"
   region: "NTSC-J"
   compat: 5
@@ -55395,7 +55527,7 @@ SLPS-71502:
   region: "NTSC-J"
 SLPS-72501:
   name: ファイナルファンタジーX MEGA HITS!
-  name-sort: ふぁいなるふぁんたじーX MEGA HITS!
+  name-sort: ふぁいなるふぁんたじー10 MEGA HITS!
   name-en: "Final Fantasy X [Mega Hits]"
   region: "NTSC-J"
   gameFixes:
@@ -55407,104 +55539,104 @@ SLPS-72501:
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
 SLPS-72502:
-  name: テイルズ・オブ・ディスティニー2 MEGA HITS!
-  name-sort: ているず・おぶ・でぃすてぃにー2 MEGA HITS!
+  name: テイルズ オブ ディスティニー2 MEGA HITS!
+  name-sort: ているず おぶ でぃすてぃにー2 MEGA HITS!
   name-en: "Tales of Destiny 2 [Mega Hits]"
   region: "NTSC-J"
 SLPS-73001:
   name: "Pilot ni Narou! 2"
   region: "NTSC-J"
 SLPS-73003:
-  name: 牧場物語3 ハートに火をつけて PS2 the Best
-  name-sort: ぼくじょうものがたり3 はーとにひをつけて PS2 the Best
-  name-en: "Farms Story 3 [PS2 The Best]"
+  name: 牧場物語3 ハートに火をつけて PlayStation 2 the Best
+  name-sort: ぼくじょうものがたり3 はーとにひをつけて PlayStation 2 the Best
+  name-en: "Farms Story 3 [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPS-73004:
   name: "Gambler Densetsu Tetsuya"
   region: "NTSC-J"
 SLPS-73005:
-  name: ギルティギアゼクスプラス PS2 the Best
-  name-sort: ぎるてぃぎあぜくすぷらす PS2 the Best
-  name-en: "Guilty Gear X - Plus [PS2 The Best]"
+  name: ギルティギアゼクスプラス PlayStation 2 the Best
+  name-sort: ぎるてぃぎあ ぜくすぷらす PlayStation 2 the Best
+  name-en: "Guilty Gear X - Plus [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPS-73006:
-  name: タイムクライシス2 PS2 the Best
-  name-sort: たいむくらいしす2 PS2 the Best
-  name-en: "Time Crisis II [PS2 The Best]"
+  name: タイムクライシス2 PlayStation 2 the Best
+  name-sort: たいむくらいしす2 PlayStation 2 the Best
+  name-en: "Time Crisis II [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPS-73007:
   name: "Kamaitachi no Yoru 2 - Kangoku-jima no Warabe-uta - Special Eizou"
   region: "NTSC-J"
 SLPS-73101:
-  name: ことばのパズル もじぴったん PS2 the Best
-  name-sort: ことばのぱずる もじぴったん PS2 the Best
-  name-en: "Kotoba no Puzzle - Mojipittan [PS2 The Best]"
+  name: ことばのパズル もじぴったん PlayStation 2 the Best
+  name-sort: ことばのぱずる もじぴったん PlayStation 2 the Best
+  name-en: "Kotoba no Puzzle - Mojipittan [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPS-73102:
-  name: 牧場物語3 ～ハートに火をつけて PS2 the Best
-  name-sort: ぼくじょうものがたり3 ～はーとにひをつけて PS2 the Best
-  name-en: "Bokujou Monogatari 3 - Heart ni Hi o Tsukete [PS2 The Best]"
+  name: 牧場物語3 〜ハートに火をつけて PlayStation 2 the Best
+  name-sort: ぼくじょうものがたり3 はーとにひをつけて PlayStation 2 the Best
+  name-en: "Bokujou Monogatari 3 - Heart ni Hi o Tsukete [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPS-73103:
-  name: 魔界戦記ディスガイア PS2 the Best
-  name-sort: まかいせんきでぃすがいあ PS2 the Best
-  name-en: "Makai Senki Disgaea [PS2 The Best]"
+  name: 魔界戦記ディスガイア PlayStation 2 the Best
+  name-sort: まかいせんきでぃすがいあ PlayStation 2 the Best
+  name-en: "Makai Senki Disgaea [PlayStation 2 the Best]"
   region: "NTSC-J"
   compat: 5
 SLPS-73104:
-  name: 鉄拳タッグトーナメント PS2 the Best
-  name-sort: てっけんたっぐとーなめんと PS2 the Best
-  name-en: "Tekken Tag Tournament [PS2 The Best]"
+  name: 鉄拳タッグトーナメント PlayStation 2 the Best
+  name-sort: てっけんたっぐとーなめんと PlayStation 2 the Best
+  name-en: "Tekken Tag Tournament [PlayStation 2 the Best]"
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
 SLPS-73105:
-  name: キン肉マン ジェネレーションズ PS2 the Best
-  name-sort: きんにくまん じぇねれーしょんず PS2 the Best
-  name-en: "Kinnikuman Generations [PS2 The Best]"
+  name: キン肉マン ジェネレーションズ PlayStation 2 the Best
+  name-sort: きんにくまん じぇねれーしょんず PlayStation 2 the Best
+  name-en: "Kinnikuman Generations [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPS-73106:
-  name: パイロットになろう!2 PS2 the Best
-  name-sort: ぱいろっとになろう!2 PS2 the Best
-  name-en: "Pilot Nina Rou! 2 [PS2 The Best]"
+  name: パイロットになろう!2 PlayStation 2 the Best
+  name-sort: ぱいろっとになろう2 PlayStation 2 the Best
+  name-en: "Pilot Nina Rou! 2 [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPS-73107:
-  name: 太鼓の達人 ゴー!ゴー!五代目 PS2 the Best
-  name-sort: たいこのたつじん ごー!ごー!ごだいめ PS2 the Best
-  name-en: "Taiko no Tatsujin - Go! Go! Godaime [PS2 The Best]"
+  name: 太鼓の達人 ゴー!ゴー!五代目 PlayStation 2 the Best
+  name-sort: たいこのたつじん ごーごーごだいめ PlayStation 2 the Best
+  name-en: "Taiko no Tatsujin - Go! Go! Godaime [PlayStation 2 the Best]"
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
 SLPS-73108:
-  name: ファントム・ブレイブ 2周目はじめました。 PS2 the Best
-  name-sort: ふぁんとむ・ぶれいぶ 2しゅうめはじめました。 PS2 the Best
-  name-en: "Phantom Brave [PS2 The Best]"
+  name: ファントム・ブレイブ 2周目はじめました。 PlayStation 2 the Best
+  name-sort: ふぁんとむ ぶれいぶ 2しゅうめはじめました PlayStation 2 the Best
+  name-en: "Phantom Brave [PlayStation 2 the Best]"
   region: "NTSC-J"
   compat: 5
 SLPS-73109:
-  name: 牧場物語3〜 ハートに火をつけて PS2 the Best
-  name-sort: ぼくじょうものがたり3〜 はーとにひをつけて PS2 the Best
-  name-en: "Bokujou Monogatari 3 - Heart ni Hi o Tsukete [PS2 The Best]"
+  name: 牧場物語3〜 ハートに火をつけて PlayStation 2 the Best
+  name-sort: ぼくじょうものがたり3 はーとにひをつけて PlayStation 2 the Best
+  name-en: "Bokujou Monogatari 3 - Heart ni Hi o Tsukete [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPS-73110:
-  name: 太鼓の達人 あっぱれ三代目 PS2 the Best
-  name-sort: たいこのたつじん あっぱれさんだいめ PS2 the Best
-  name-en: "Taiko no Tatsujin - Appare Sandaime [PS2 The Best]"
+  name: 太鼓の達人 あっぱれ三代目 PlayStation 2 the Best
+  name-sort: たいこのたつじん あっぱれさんだいめ PlayStation 2 the Best
+  name-en: "Taiko no Tatsujin - Appare Sandaime [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPS-73111:
-  name: 太鼓の達人 わくわくアニメ祭り PS2 the Best
-  name-sort: たいこのたつじん わくわくあにめまつり PS2 the Best
-  name-en: "Taiko no Tatsujin - Waku Waku Anime Matsuri [PS2 The Best]"
+  name: 太鼓の達人 わくわくアニメ祭り PlayStation 2 the Best
+  name-sort: たいこのたつじん わくわくあにめまつり PlayStation 2 the Best
+  name-en: "Taiko no Tatsujin - Waku Waku Anime Matsuri [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPS-73201:
-  name: 零～紅い蝶～ PS2 the Best
-  name-sort: れい～あかいちょう～ PS2 the Best
-  name-en: "Fatal Frame II - Crimson Butterfly [PS2 The Best]"
+  name: 零〜紅い蝶〜 PlayStation 2 the Best
+  name-sort: ぜろ あかいちょう PlayStation 2 the Best
+  name-en: "Fatal Frame II - Crimson Butterfly [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPS-73202:
-  name: アーマード・コア ネクサス [DISC 1] PS2 the Best
-  name-sort: あーまーど・こあ ねくさす [DISC 1] PS2 the Best
-  name-en: "Armored Core - Nexus [Disc 1] [PS2 The Best]"
+  name: アーマード・コア ネクサス [DISC 1] PlayStation 2 the Best
+  name-sort: あーまーどこあ ねくさす [DISC 1] PlayStation 2 the Best
+  name-en: "Armored Core - Nexus [Disc 1] [PlayStation 2 the Best]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
@@ -55517,9 +55649,9 @@ SLPS-73202:
     - "SLPS-73202"
     - "SLPS-73203"
 SLPS-73203:
-  name: アーマード・コア ネクサス [DISC 2] PS2 the Best
-  name-sort: あーまーど・こあ ねくさす [DISC 2] PS2 the Best
-  name-en: "Armored Core - Nexus [Disc 2] [PS2 The Best]"
+  name: アーマード・コア ネクサス [DISC 2] PlayStation 2 the Best
+  name-sort: あーまーどこあ ねくさす [DISC 2] PlayStation 2 the Best
+  name-en: "Armored Core - Nexus [Disc 2] [PlayStation 2 the Best]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
@@ -55532,16 +55664,16 @@ SLPS-73203:
     - "SLPS-73202"
     - "SLPS-73203"
 SLPS-73204:
-  name: 絶体絶命都市 PS2 the Best
-  name-sort: ぜったいぜつめいとし PS2 the Best
-  name-en: "Zettai Zetsumei Toshi [PS2 The Best]"
+  name: 絶体絶命都市 PlayStation 2 the Best
+  name-sort: ぜったいぜつめいとし PlayStation 2 the Best
+  name-en: "Zettai Zetsumei Toshi [PlayStation 2 the Best]"
   region: "NTSC-J"
   gsHWFixes:
     autoFlush: 2 # Fixes incorrect blur effect.
 SLPS-73205:
-  name: エースコンバット04 シャッタードスカイ PS2 the Best
-  name-sort: えーすこんばっと04 しゃったーどすかい PS2 the Best
-  name-en: "Ace Combat 04 - Shattered Skies [PS2 The Best]"
+  name: エースコンバット04 シャッタードスカイ PlayStation 2 the Best
+  name-sort: えーすこんばっと04 しゃったーどすかい PlayStation 2 the Best
+  name-en: "Ace Combat 04 - Shattered Skies [PlayStation 2 the Best]"
   region: "NTSC-J"
   gameFixes:
     - SoftwareRendererFMVHack # Fixes FMVs disabling hash cache.
@@ -55555,33 +55687,33 @@ SLPS-73205:
     cpuSpriteRenderLevel: 0 # Needed for above.
     estimateTextureRegion: 1 # Improves performance and reduces HC size.
 SLPS-73206:
-  name: 第2次スーパーロボット大戦α PS2 the Best
-  name-sort: だい2じすーぱーろぼっとたいせんあるふぁ PS2 the Best
-  name-en: "Super Robot Taisen Alpha 2nd [PS2 The Best]"
+  name: 第2次スーパーロボット大戦α PlayStation 2 the Best
+  name-sort: だい2じすーぱーろぼっとたいせんあるふぁ PlayStation 2 the Best
+  name-en: "Super Robot Taisen Alpha 2nd [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPS-73207:
-  name: ドラゴンボールZ PS2 the Best
-  name-sort: どらごんぼーるZ PS2 the Best
-  name-en: "Dragon Ball Z [PS2 The Best]"
+  name: ドラゴンボールZ PlayStation 2 the Best
+  name-sort: どらごんぼーるZ PlayStation 2 the Best
+  name-en: "Dragon Ball Z [PlayStation 2 the Best]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes lines when powering up.
 SLPS-73208:
-  name: ドラゴンボールZ2 PS2 the Best
-  name-sort: どらごんぼーるZ2 PS2 the Best
-  name-en: "Dragon Ball Z 2 [PS2 The Best]"
+  name: ドラゴンボールZ2 PlayStation 2 the Best
+  name-sort: どらごんぼーるZ2 PlayStation 2 the Best
+  name-en: "Dragon Ball Z 2 [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPS-73209:
-  name: 鉄拳4 PS2 the Best
-  name-sort: てっけん4 PS2 the Best
-  name-en: "Tekken 4 [PS2 The Best]"
+  name: 鉄拳4 PlayStation 2 the Best
+  name-sort: てっけん4 PlayStation 2 the Best
+  name-en: "Tekken 4 [PlayStation 2 the Best]"
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
 SLPS-73210:
-  name: 塊魂 PS2 the Best
-  name-sort: かたまりたましい PS2 the Best
-  name-en: "Katamari Damacy [PS2 The Best]"
+  name: 塊魂 PlayStation 2 the Best
+  name-sort: かたまりだましい PlayStation 2 the Best
+  name-en: "Katamari Damacy [PlayStation 2 the Best]"
   region: "NTSC-J"
   roundModes:
     vu1RoundMode: 0 # Fixes SPS.
@@ -55590,19 +55722,19 @@ SLPS-73210:
   speedHacks:
     mvuFlag: 0 # Fixes performance and falling through floor and other gameplay.
 SLPS-73211:
-  name: サモンナイト3 PS2 the Best
-  name-sort: さもんないと3 PS2 the Best
-  name-en: "Summon Night 3 [PS2 The Best]"
+  name: サモンナイト3 PlayStation 2 the Best
+  name-sort: さもんないと3 PlayStation 2 the Best
+  name-en: "Summon Night 3 [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPS-73212:
-  name: NARUTO -ナルト-ナルティメットヒーロー PS2 the Best
-  name-sort: NARUTO -なると-なるてぃめっとひーろー PS2 the Best
-  name-en: "Naruto Narutimett Hero [PS2 The Best]"
+  name: NARUTO -ナルト-ナルティメットヒーロー PlayStation 2 the Best
+  name-sort: なると なるてぃめっとひーろー PlayStation 2 the Best
+  name-en: "Naruto Narutimett Hero [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPS-73214:
-  name: シャドウ ハーツ II ディレクターズカット PS2 the Best [ディスク1/2]
-  name-sort: しゃどう はーつ II でぃれくたーずかっと PS2 the Best [でぃすく1/2]
-  name-en: "Shadow Hearts 2 [Director's Cut] [PS2 The Best] [Disc 1 of 2]"
+  name: シャドウ ハーツ II ディレクターズカット PlayStation 2 the Best [ディスク1/2]
+  name-sort: しゃどう はーつ II でぃれくたーずかっと PlayStation 2 the Best [でぃすく1/2]
+  name-en: "Shadow Hearts 2 [Director's Cut] [PlayStation 2 the Best] [Disc 1 of 2]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurrines, preload frame for FMV breaks visuals with this setting.
@@ -55610,9 +55742,9 @@ SLPS-73214:
     roundSprite: 2 # Fixes the position of monster sprites and reduces garbage in the UI.
     autoFlush: 2 # Makes the shadow monsters appear.
 SLPS-73215:
-  name: シャドウ ハーツ II ディレクターズカット PS2 the Best [ディスク2/2]
-  name-sort: しゃどう はーつ II でぃれくたーずかっと PS2 the Best [でぃすく2/2]
-  name-en: "Shadow Hearts 2 [Director's Cut] [PS2 The Best] [Disc 2 of 2]"
+  name: シャドウ ハーツ II ディレクターズカット PlayStation 2 the Best [ディスク2/2]
+  name-sort: しゃどう はーつ II でぃれくたーずかっと PlayStation 2 the Best [でぃすく2/2]
+  name-en: "Shadow Hearts 2 [Director's Cut] [PlayStation 2 the Best] [Disc 2 of 2]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurrines, preload frame for FMV breaks visuals with this setting.
@@ -55622,22 +55754,22 @@ SLPS-73215:
   memcardFilters:
     - "SLPS-73214"
 SLPS-73216:
-  name: マグナカルタ PS2 the Best
-  name-sort: まぐなかるた PS2 the Best
-  name-en: "Magna Carta [PS2 The Best]"
+  name: マグナカルタ PlayStation 2 the Best
+  name-sort: まぐなかるた PlayStation 2 the Best
+  name-en: "Magna Carta [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPS-73217:
-  name: テイルズ オブ シンフォニア PS2 the Best
-  name-sort: ているず おぶ しんふぉにあ PS2 the Best
-  name-en: "Tales of Symphonia [PS2 The Best]"
+  name: テイルズ オブ シンフォニア PlayStation 2 the Best
+  name-sort: ているず おぶ しんふぉにあ PlayStation 2 the Best
+  name-en: "Tales of Symphonia [PlayStation 2 the Best]"
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
     getSkipCount: "GSC_TalesofSymphonia"
 SLPS-73218:
-  name: エースコンバット5 ジ・アンサング・ウォー PS2 the Best
-  name-sort: えーすこんばっと5 じ・あんさんぐ・うぉー PS2 the Best
-  name-en: "Ace Combat 5 - The Unsung War [PS2 The Best]"
+  name: エースコンバット5 ジ・アンサング・ウォー PlayStation 2 the Best
+  name-sort: えーすこんばっと5 じ・あんさんぐ・うぉー PlayStation 2 the Best
+  name-en: "Ace Combat 5 - The Unsung War [PlayStation 2 the Best]"
   region: "NTSC-J"
   gameFixes:
     - SoftwareRendererFMVHack # Fixes FMVs disabling hash cache.
@@ -55650,32 +55782,32 @@ SLPS-73218:
     mergeSprite: 1 # Fixes vertical lines.
     estimateTextureRegion: 1 # Improves performance and reduces HC size.
 SLPS-73219:
-  name: テイルズ・オブ・ディスティニー2 PS2 the Best
-  name-sort: ているず・おぶ・でぃすてぃにー2 PS2 the Best
-  name-en: "Tales of Destiny 2 [PS2 The Best]"
+  name: テイルズ オブ ディスティニー2 PlayStation 2 the Best
+  name-sort: ているず おぶ でぃすてぃにー2 PlayStation 2 the Best
+  name-en: "Tales of Destiny 2 [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPS-73220:
-  name: ウルトラマン PS2 the Best
-  name-sort: うるとらまん PS2 the Best
-  name-en: "Ultraman [PS2 The Best]"
+  name: ウルトラマン PlayStation 2 the Best
+  name-sort: うるとらまん PlayStation 2 the Best
+  name-en: "Ultraman [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPS-73221:
-  name: NARUTO -ナルト-ナルティメットヒーロー2 PS2 the Best
-  name-sort: NARUTO -なると-なるてぃめっとひーろー2 PS2 the Best
-  name-en: "Naruto Narutimett Hero 2 [PS2 The Best]"
+  name: NARUTO -ナルト-ナルティメットヒーロー2 PlayStation 2 the Best
+  name-sort: なると なるてぃめっとひーろー2 PlayStation 2 the Best
+  name-en: "Naruto Narutimett Hero 2 [PlayStation 2 the Best]"
   region: "NTSC-J"
   clampModes:
     vu0ClampMode: 0 # Fixes glow effects.
     vu1ClampMode: 3 # Fixes rare SPS.
 SLPS-73222:
-  name: 牧場物語 Oh!ワンダフルライフ PS2 the Best
-  name-sort: ぼくじょうものがたり Oh!わんだふるらいふ PS2 the Best
-  name-en: "Harvest Moon - A Wonderful Life [PS2 The Best]"
+  name: 牧場物語 Oh!ワンダフルライフ PlayStation 2 the Best
+  name-sort: ぼくじょうものがたり Oh!わんだふるらいふ PlayStation 2 the Best
+  name-en: "Harvest Moon - A Wonderful Life [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPS-73223:
-  name: 鉄拳5 PS2 the Best
-  name-sort: てっけん5 PS2 the Best
-  name-en: "Tekken 5 [PS2 The Best]"
+  name: 鉄拳5　PlayStation 2 the Best
+  name-sort: てっけん5 PlayStation 2 the Best
+  name-en: "Tekken 5 [PlayStation 2 the Best]"
   region: "NTSC-J"
   clampModes:
     eeClampMode: 2 # Fixes camera and stops constant coin noises on Pirates Cove.
@@ -55684,9 +55816,9 @@ SLPS-73223:
     halfPixelOffset: 4 # Align post.
     getSkipCount: "GSC_Tekken5"
 SLPS-73224:
-  name: ゼノサーガ エピソードII［善悪の彼岸］ PS2 the Best [ディスク1/2]
-  name-sort: ぜのさーが えぴそーどII［ぜんあくのひがん］ PS2 the Best [でぃすく1/2]
-  name-en: "Xenosaga Episode II - Jenseits von Gut und Bose [PS2 The Best] [Disc 1 of 2]"
+  name: ゼノサーガ エピソードII［善悪の彼岸］ PlayStation 2 the Best [ディスク1/2]
+  name-sort: ぜのさーが えぴそーどII ぜんあくのひがん PlayStation 2 the Best [でぃすく1/2]
+  name-en: "Xenosaga Episode II - Jenseits von Gut und Bose [PlayStation 2 the Best] [Disc 1 of 2]"
   region: "NTSC-J"
   gsHWFixes:
     autoFlush: 2 # Fixes shadows in cutscenes.
@@ -55700,9 +55832,9 @@ SLPS-73224:
     - "SLPS-25353"
     - "SLPS-73224"
 SLPS-73225:
-  name: ゼノサーガ エピソードII［善悪の彼岸］ PS2 the Best [ディスク2/2]
-  name-sort: ぜのさーが えぴそーどII［ぜんあくのひがん］ PS2 the Best [でぃすく2/2]
-  name-en: "Xenosaga Episode II - Jenseits von Gut und Bose [PS2 The Best] [Disc 2 of 2]"
+  name: ゼノサーガ エピソードII［善悪の彼岸］ PlayStation 2 the Best [ディスク2/2]
+  name-sort: ぜのさーが えぴそーどII ぜんあくのひがん PlayStation 2 the Best [でぃすく2/2]
+  name-en: "Xenosaga Episode II - Jenseits von Gut und Bose [PlayStation 2 the Best] [Disc 2 of 2]"
   region: "NTSC-J"
   gsHWFixes:
     autoFlush: 2 # Fixes shadows in cutscenes.
@@ -55716,27 +55848,27 @@ SLPS-73225:
     - "SLPS-25353"
     - "SLPS-73224"
 SLPS-73226:
-  name: 天誅 紅 PS2 the Best
-  name-sort: てんちゅう くれない PS2 the Best
-  name-en: "Tenchu Kurenai [PS2 The Best]"
+  name: 天誅 紅 PlayStation 2 the Best
+  name-sort: てんちゅう くれない PlayStation 2 the Best
+  name-en: "Tenchu Kurenai [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPS-73227:
-  name: Another Century’s Episode PS2 the Best
-  name-sort: Another Century’s Episode PS2 the Best
-  name-en: "Another Century's Episode [PS2 The Best]"
+  name: Another Century’s Episode PlayStation 2 the Best
+  name-sort: Another Century’s Episode PlayStation 2 the Best
+  name-en: "Another Century's Episode [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPS-73228:
-  name: "Fuuun Bakumatsuden [PS2 The Best]"
+  name: "Fuuun Bakumatsuden [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPS-73229:
-  name: ベルウィックサーガ PS2 the Best
-  name-sort: べるうぃっくさーが PS2 the Best
-  name-en: "TearRing Saga Series - Berwick Saga [PS2 The Best]"
+  name: ベルウィックサーガ PlayStation 2 the Best
+  name-sort: べるうぃっくさーが PlayStation 2 the Best
+  name-en: "TearRing Saga Series - Berwick Saga [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPS-73230:
-  name: dot hack - Vol.1×Vol.2 PS2 the Best
-  name-sort: dot hack - Vol.1×Vol.2 PS2 the Best
-  name-en: "dot hack - Vol.1 & Vol.2 [PS2 The Best] [Vol.1 Disc]"
+  name: .hack Vol.1×Vol.2 PlayStation 2 the Best
+  name-sort: どっとはっく Vol.1×Vol.2 PlayStation 2 the Best
+  name-en: ".hack Vol.1 & Vol.2 [PlayStation 2 the Best] [Vol.1 Disc]"
   region: "NTSC-J"
   memcardFilters:
     - "SCPS-55029"
@@ -55752,7 +55884,7 @@ SLPS-73230:
     - "SLPS-73232"
     - "SLPS-73233"
 SLPS-73231:
-  name: "dot hack - Vol.1 & Vol.2 [PS2 The Best] [Vol.2 Disc]"
+  name: ".hack Vol.1 & Vol.2 [PlayStation 2 the Best] [Vol.2 Disc]"
   region: "NTSC-J"
   memcardFilters:
     - "SCPS-55029"
@@ -55768,9 +55900,9 @@ SLPS-73231:
     - "SLPS-73232"
     - "SLPS-73233"
 SLPS-73232:
-  name: dot hack - Vol.3×Vol.4 PS2 the Best
-  name-sort: dot hack - Vol.3×Vol.4 PS2 the Best
-  name-en: "dot hack - Vol.3 & Vol.4 [PS2 The Best] [Vol.3 Disc]"
+  name: .hack Vol.3×Vol.4 PlayStation 2 the Best
+  name-sort: どっとはっく Vol.3×Vol.4 PlayStation 2 the Best
+  name-en: ".hack Vol.3 & Vol.4 [PlayStation 2 the Best] [Vol.3 Disc]"
   region: "NTSC-J"
   memcardFilters:
     - "SCPS-55029"
@@ -55786,7 +55918,7 @@ SLPS-73232:
     - "SLPS-73232"
     - "SLPS-73233"
 SLPS-73233:
-  name: "dot hack - Vol.3 & Vol.4 [PS2 The Best] [Vol.4 Disc]"
+  name: ".hack Vol.3 & Vol.4 [PlayStation 2 the Best] [Vol.4 Disc]"
   region: "NTSC-J"
   memcardFilters:
     - "SCPS-55029"
@@ -55802,39 +55934,39 @@ SLPS-73233:
     - "SLPS-73232"
     - "SLPS-73233"
 SLPS-73234:
-  name: 機動戦士Zガンダム エゥーゴVS.ティターンズ PS2 the Best
-  name-sort: きどうせんしZがんだむ えぅーごVS.てぃたーんず PS2 the Best
-  name-en: "Kidou Senshi Z-Gundam - AEUG vs. Titans [PS2 The Best]"
+  name: 機動戦士Zガンダム エゥーゴVS.ティターンズ PlayStation 2 the Best
+  name-sort: きどうせんしZがんだむ えぅーごVS.てぃたーんず PlayStation 2 the Best
+  name-en: "Kidou Senshi Z-Gundam - AEUG vs. Titans [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPS-73235:
-  name: ドラゴンボールZ3 PS2 the Best
-  name-sort: どらごんぼーるZ3 PS2 the Best
-  name-en: "Dragon Ball Z 3 [PS2 The Best]"
+  name: ドラゴンボールZ3 PlayStation 2 the Best
+  name-sort: どらごんぼーるZ3 PlayStation 2 the Best
+  name-en: "Dragon Ball Z 3 [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPS-73236:
-  name: ヴィーナスアンドブレイブス〜魔女と女神と滅びの予言〜 PS2 the Best
-  name-sort: ゔぃーなすあんどぶれいぶす〜まじょとめがみとほろびのよげん〜 PS2 the Best
-  name-en: "Venus & Braves [PS2 The Best]"
+  name: ヴィーナスアンドブレイブス〜魔女と女神と滅びの予言〜 PlayStation 2 the Best
+  name-sort: ゔぃーなすあんどぶれいぶす まじょとめがみとほろびのよげん PlayStation 2 the Best
+  name-en: "Venus & Braves [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPS-73237:
-  name: 天誅 参 PS2 the Best
-  name-sort: てんちゅう さん PS2 the Best
-  name-en: "Tenchu San [PS2 The Best]"
+  name: 天誅 参 PlayStation 2 the Best
+  name-sort: てんちゅう3 PlayStation 2 the Best
+  name-en: "Tenchu San [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPS-73238:
-  name: 第3次スーパーロボット大戦α -終焉の銀河へー PS2 the Best
-  name-sort: だい3じすーぱーろぼっとたいせんあるふぁ -しゅうえんのぎんがへー PS2 the Best
-  name-en: "Super Robot Wars - Alpha 3 [PS2 The Best]"
+  name: 第3次スーパーロボット大戦α -終焉の銀河へー PlayStation 2 the Best
+  name-sort: だい3じすーぱーろぼっとたいせんあるふぁ -しゅうえんのぎんがへー PlayStation 2 the Best
+  name-en: "Super Robot Wars - Alpha 3 [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPS-73239:
-  name: 幽★遊★白書 FOREVER PS2 the Best
-  name-sort: ゆう★ゆう★はくしょ FOREVER PS2 the Best
-  name-en: "Yu Yu Hakusho Forever [PS2 The Best]"
+  name: 幽★遊★白書 FOREVER PlayStation 2 the Best
+  name-sort: ゆうゆうはくしょ FOREVER PlayStation 2 the Best
+  name-en: "Yu Yu Hakusho Forever [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPS-73240:
-  name: 塊魂 PS2 the Best
-  name-sort: かたまりたましい PS2 the Best
-  name-en: "Katamari Damacy [PS2 The Best]"
+  name: 塊魂 PlayStation 2 the Best
+  name-sort: かたまりだましい PlayStation 2 the Best
+  name-en: "Katamari Damacy [PlayStation 2 the Best]"
   region: "NTSC-J"
   roundModes:
     vu1RoundMode: 0 # Fixes SPS.
@@ -55843,9 +55975,9 @@ SLPS-73240:
   speedHacks:
     mvuFlag: 0 # Fixes performance and falling through floor and other gameplay.
 SLPS-73241:
-  name: みんな大好き塊魂 PS2 the Best
-  name-sort: みんなだいすきかたまりたましい PS2 the Best
-  name-en: "Minna Daisuki Katamari Damacy [PS2 The Best]"
+  name: みんな大好き塊魂 PlayStation 2 the Best
+  name-sort: みんなだいすきかたまりだましい PlayStation 2 the Best
+  name-en: "Minna Daisuki Katamari Damacy [PlayStation 2 the Best]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes right edge artifact.
@@ -55864,37 +55996,37 @@ SLPS-73241:
     - "SLPS-73210"
     - "SLPS-73240"
 SLPS-73242:
-  name: テイルズ オブ レジェンディア PS2 the Best
-  name-sort: ているず おぶ れじぇんでぃあ PS2 the Best
-  name-en: "Tales of Legendia [PS2 The Best]"
+  name: テイルズ オブ レジェンディア PlayStation 2 the Best
+  name-sort: ているず おぶ れじぇんでぃあ PlayStation 2 the Best
+  name-en: "Tales of Legendia [PlayStation 2 the Best]"
   region: "NTSC-J"
   gsHWFixes:
     getSkipCount: "GSC_TalesOfLegendia"
 SLPS-73243:
-  name: ナムコ クロス カプコン PS2 the Best
-  name-sort: なむこ くろす かぷこん PS2 the Best
-  name-en: "Namco X Capcom [PS2 The Best]"
+  name: ナムコ クロス カプコン PlayStation 2 the Best
+  name-sort: なむこ くろす かぷこん PlayStation 2 the Best
+  name-en: "Namco X Capcom [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPS-73244:
-  name: R・TYPE FINAL PS2 the Best
-  name-sort: R・TYPE FINAL PS2 the Best
-  name-en: "R-Type Final [PS2 The Best]"
+  name: R・TYPE FINAL PlayStation 2 the Best
+  name-sort: R・TYPE FINAL PlayStation 2 the Best
+  name-en: "R-Type Final [PlayStation 2 the Best]"
   region: "NTSC-J"
   compat: 5
 SLPS-73245:
-  name: 零 〜刺青の聲〜 PS2 the Best
-  name-sort: ぜろ 〜しせいのこえ〜 PS2 the Best
-  name-en: "Fatal Frame - Zero [PS2 The Best]"
+  name: 零 〜刺青の聲〜 PlayStation 2 the Best
+  name-sort: ぜろ しせいのこえ PlayStation 2 the Best
+  name-en: "Fatal Frame - Zero [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPS-73246:
-  name: ガンダム トゥルーオデッセイ 〜失われしGの伝説〜 PS2 the Best
-  name-sort: がんだむ とぅるーおでっせい 〜うしなわれしGのでんせつ〜 PS2 the Best
-  name-en: "Gundam True Odyssey [PS2 The Best]"
+  name: ガンダム トゥルーオデッセイ 〜失われしGの伝説〜 PlayStation 2 the Best
+  name-sort: がんだむ とぅるーおでっせい うしなわれしGのでんせつ PlayStation 2 the Best
+  name-en: "Gundam True Odyssey [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPS-73247:
-  name: アーマード・コア ラストレイヴン PS2 the Best
-  name-sort: あーまーど・こあ らすとれいゔん PS2 the Best
-  name-en: "Armored Core - Last Raven [PS2 The Best]"
+  name: ARMORED CORE -LAST RAVEN- PlayStation 2 the Best
+  name-sort: あーまーどこあ らすとれいゔん PlayStation 2 the Best
+  name-en: "Armored Core - Last Raven [PlayStation 2 the Best]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Corrects shadow alignment and reduces blurriness.
@@ -55908,21 +56040,21 @@ SLPS-73247:
     - "SLPS-25462"
     - "SLPS-73247"
 SLPS-73248:
-  name: 影牢II -Dark illusion- PS2 the Best
-  name-sort: かげろうII -Dark illusion- PS2 the Best
-  name-en: "Kagero 2 - Dark Illusion [PS2 The Best]"
+  name: 影牢II -Dark illusion- PlayStation 2 the Best
+  name-sort: かげろうII -Dark illusion- PlayStation 2 the Best
+  name-en: "Kagero 2 - Dark Illusion [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPS-73249:
-  name: アルトネリコ 世界の終わりで詩い続ける少女 PS2 the Best
-  name-sort: あるとねりこ せかいのおわりでしいつづけるしょうじょ PS2 the Best
-  name-en: "Ar tonelico - Sekai no Owari de Utai Tsuzukeru Shoujo [PS2 The Best]"
+  name: アルトネリコ 世界の終わりで詩い続ける少女 PlayStation 2 the Best
+  name-sort: あるとねりこ せかいのおわりでうたいつづけるしょうじょ PlayStation 2 the Best
+  name-en: "Ar tonelico - Sekai no Owari de Utai Tsuzukeru Shoujo [PlayStation 2 the Best]"
   region: "NTSC-J"
   gsHWFixes:
     roundSprite: 1 # Fixes vertical lines in FMVs, character portraits and other sprites.
 SLPS-73250:
-  name: エースコンバット・ゼロ・ザ・ベルカン・ウォー PS2 the Best
-  name-sort: えーすこんばっと・ぜろ・ざ・べるかん・うぉー PS2 the Best
-  name-en: "Ace Combat Zero - The Belkan War [PS2 The Best]"
+  name: エースコンバット・ゼロ・ザ・ベルカン・ウォー PlayStation 2 the Best
+  name-sort: えーすこんばっと・ぜろ・ざ・べるかん・うぉー PlayStation 2 the Best
+  name-en: "Ace Combat Zero - The Belkan War [PlayStation 2 the Best]"
   region: "NTSC-J"
   gameFixes:
     - SoftwareRendererFMVHack # Fixes FMVs disabling hash cache.
@@ -55946,66 +56078,66 @@ SLPS-73250:
     - "SLPS-25418"
     - "SLPS-73218"
 SLPS-73251:
-  name: NARUTO-ナルト-ナルティメットヒーロー3 PS2 the Best
-  name-sort: NARUTO-なると-なるてぃめっとひーろー3 PS2 the Best
-  name-en: "Naruto - Narutimett Hero 3 [PS2 The Best]"
+  name: NARUTO-ナルト-ナルティメットヒーロー3 PlayStation 2 the Best
+  name-sort: なると なるてぃめっとひーろー3 PlayStation 2 the Best
+  name-en: "Naruto - Narutimett Hero 3 [PlayStation 2 the Best]"
   region: "NTSC-J"
   clampModes:
     vuClampMode: 2 # Fixes invisible QTE button prompts and overbright in some scenes.
   gameFixes:
     - SoftwareRendererFMVHack # Fixes vertical lines in FMVs.
 SLPS-73252:
-  name: テイルズ オブ ジ アビス PS2 the Best
-  name-sort: ているず おぶ じ あびす PS2 the Best
-  name-en: "Tales of the Abyss [PS2 The Best]"
+  name: テイルズ オブ ジ アビス PlayStation 2 the Best
+  name-sort: ているず おぶ じ あびす PlayStation 2 the Best
+  name-en: "Tales of the Abyss [PlayStation 2 the Best]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
     autoFlush: 2 # Fixes post lighting.
 SLPS-73253:
-  name: るろうに剣心-明治剣客浪漫譚- 炎上!京都輪廻 PS2 the Best
-  name-sort: るろうにけんしん-めいじけんかくろまんたん- えんじょう!きょうとりんね PS2 the Best
-  name-en: "Rurouni Kenshin - Enjou! Kyoto Rinne [PS2 The Best]"
+  name: るろうに剣心-明治剣客浪漫譚- 炎上!京都輪廻 PlayStation 2 the Best
+  name-sort: るろうにけんしん めいじけんかくろまんたん えんじょう きょうとりんね PlayStation 2 the Best
+  name-en: "Rurouni Kenshin - Enjou! Kyoto Rinne [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPS-73254:
-  name: 魔界戦記ディスガイア2 PS2 the Best
-  name-sort: まかいせんきでぃすがいあ2 PS2 the Best
-  name-en: "Makai Senki Disgaea [PS2 The Best]"
+  name: 魔界戦記ディスガイア2 PlayStation 2 the Best
+  name-sort: まかいせんきでぃすがいあ2 PlayStation 2 the Best
+  name-en: "Makai Senki Disgaea [PlayStation 2 the Best]"
   region: "NTSC-J"
   gameFixes:
     - SoftwareRendererFMVHack # Fixes flickering FMV's.
 SLPS-73255:
-  name: 零〜zero〜 PS2 the Best
-  name-sort: ぜろ〜zero〜 PS2 the Best
-  name-en: "Fatal Frame [PS2 the Best - Reprint]"
+  name: 零〜zero〜 PlayStation 2 the Best
+  name-sort: ぜろ PlayStation 2 the Best
+  name-en: "Fatal Frame [PlayStation 2 the Best - Reprint]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Reduces blurriness.
     alignSprite: 1 # Fixes vertical lines on hidden ghosts.
 SLPS-73256:
-  name: 零〜紅い蝶〜 PS2 the Best
-  name-sort: ぜろ〜あかいちょう〜 PS2 the Best
-  name-en: "Fatal Frame II - Crimson Butterfly [PS2 the Best - Reprint]"
+  name: 零〜紅い蝶〜 PlayStation 2 the Best
+  name-sort: ぜろ あかいちょう PlayStation 2 the Best
+  name-en: "Fatal Frame II - Crimson Butterfly [PlayStation 2 the Best - Reprint]"
   region: "NTSC-J"
 SLPS-73257:
-  name: 零〜刺青の聲〜 PS2 the Best
-  name-sort: ぜろ〜しせいのこえ〜 PS2 the Best
-  name-en: "Fatal Frame III - The Tormented [PS2 the Best - Reprint]"
+  name: 零〜刺青の聲〜 PlayStation 2 the Best
+  name-sort: ぜろ しせいのこえ PlayStation 2 the Best
+  name-en: "Fatal Frame III - The Tormented [PlayStation 2 the Best - Reprint]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 1 # Reduces blurriness.
 SLPS-73258:
-  name: 喧嘩番長2 〜フルスロットル〜 PS2 the Best
-  name-sort: けんかばんちょう2 〜ふるすろっとる〜 PS2 the Best
-  name-en: "Kenka Banchou 2 - Full Throttle [PS2 The Best]"
+  name: 喧嘩番長2 〜フルスロットル〜 PlayStation 2 the Best
+  name-sort: けんかばんちょう2 ふるすろっとる PlayStation 2 the Best
+  name-en: "Kenka Banchou 2 - Full Throttle [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPS-73259:
-  name: "Dot Hack G.U. Vol. 1 - Saitan"
+  name: ".hack//G.U. Vol. 1 - Saitan"
   region: "NTSC-J"
 SLPS-73263:
-  name: アルトネリコ2 世界に響く少女たちの創造詩 PS2 the Best
-  name-sort: あるとねりこ2 せかいにひびくしょうじょたちのそうぞうし PS2 the Best
-  name-en: "Ar tonelico II - Sekai ni Hibiku Shoujo-Tachi no Metafalica [PS2 The Best]"
+  name: アルトネリコ2 世界に響く少女たちの創造詩 PlayStation 2 the Best
+  name-sort: あるとねりこ2 せかいにひびくしょうじょたちのそうぞうし PlayStation 2 the Best
+  name-en: "Ar tonelico II - Sekai ni Hibiku Shoujo-Tachi no Metafalica [PlayStation 2 the Best]"
   region: "NTSC-J"
   roundModes:
     eeRoundMode: 0 # Fixes "Fall through floor" bug when approaching chests.
@@ -56019,46 +56151,48 @@ SLPS-73265:
   name: "Kagero II - Dark Illusion"
   region: "NTSC-J"
 SLPS-73266:
-  name: "Dot Hack G.U. Vol. 2 - Kimi Omou Koe"
+  name: ".hack//G.U. Vol. 2 - Kimi Omou Koe"
   region: "NTSC-J"
 SLPS-73267:
-  name: "Dot Hack G.U. Vol. 3 - Aruku You na Hayasa de"
+  name: ".hack//G.U. Vol. 3 - Aruku You na Hayasa de"
   region: "NTSC-J"
 SLPS-73269:
-  name: 機動戦士ガンダムSEED DESTINY 連合VS. Z.A.F.T. II PLUS PS2 the Best
-  name-sort: きどうせんしがんだむSEED DESTINY れんごうVS. Z.A.F.T. II PLUS PS2 the Best
+  name: 機動戦士ガンダムSEED DESTINY 連合VS. Z.A.F.T. II PLUS PlayStation 2 the Best
+  name-sort: きどうせんしがんだむしーど ですてぃにー れんごうVS. Z.A.F.T. II PLUS PlayStation 2 the Best
   name-en: "Kidou Senshi Gundam SEED - Rengou vs. Z.A.F.T."
   region: "NTSC-K"
   roundModes:
     eeRoundMode: 1 # Fixes camera issue.
     eeDivRoundMode: 1 # Fixes target loss issue.
 SLPS-73270:
-  name: "Super Robot Taisen Z [PS2 The Best]"
+  name: スーパーロボット大戦Ｚ PlayStation 2 the Best
+  name-sort: すーぱーろぼっとたいせんZ PlayStation 2 the Best
+  name-en: "Super Robot Taisen Z PlayStation 2 the Best"
   region: "NTSC-J"
 SLPS-73401:
-  name: はじめの一歩 VICTORIOUS BOXERS 〜CHAMPIONSHIP VERSION〜 PS2 the Best
-  name-sort: はじめのいっぽ VICTORIOUS BOXERS 〜CHAMPIONSHIP VERSION〜 PS2 the Best
-  name-en: "Victorious Boxers - Championship Edition [PS2 The Best]"
+  name: はじめの一歩 VICTORIOUS BOXERS 〜CHAMPIONSHIP VERSION〜 PlayStation 2 the Best
+  name-sort: はじめのいっぽ VICTORIOUS BOXERS CHAMPIONSHIP VERSION PlayStation 2 the Best
+  name-en: "Victorious Boxers - Championship Edition [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPS-73402:
-  name: 首都高バトル0 PS2 the Best
-  name-sort: しゅとこうばとる0 PS2 the Best
-  name-en: "Shutokou Battle 0 [PS2 The Best]"
+  name: 首都高バトル0 PlayStation 2 the Best
+  name-sort: しゅとこうばとる0 PlayStation 2 the Best
+  name-en: "Shutokou Battle 0 [PlayStation 2 the Best]"
   region: "NTSC-J"
   compat: 5
 SLPS-73403:
-  name: アーマード・コア 2 PS2 the Best
-  name-sort: あーまーど・こあ 2 PS2 the Best
-  name-en: "Armored Core 2 [PS2 The Best]"
+  name: アーマード・コア 2 PlayStation 2 the Best
+  name-sort: あーまーどこあ2 PlayStation 2 the Best
+  name-en: "Armored Core 2 [PlayStation 2 the Best]"
   region: "NTSC-J"
   clampModes:
     eeClampMode: 2 # Fixes Abnormal AI behavior.
   gsHWFixes:
     textureInsideRT: 1 # Fixes texture corruption.
 SLPS-73404:
-  name: 風のクロノア2〜世界が望んだ忘れもの〜PS2 the Best
-  name-sort: かぜのくろのあ2〜せかいがのぞんだわすれもの〜PS2 the Best
-  name-en: "Klonoa 2 [PS2 The Best]"
+  name: 風のクロノア2〜世界が望んだ忘れもの〜PlayStation 2 the Best
+  name-sort: かぜのくろのあ2 せかいがのぞんだわすれもの PlayStation 2 the Best
+  name-en: "Klonoa 2 [PlayStation 2 the Best]"
   region: "NTSC-J"
   clampModes:
     eeClampMode: 3 # Objects appear in wrong places without it.
@@ -56068,34 +56202,34 @@ SLPS-73404:
   gsHWFixes:
     cpuCLUTRender: 1 # Fixes shadows, object and enemy colours, platform transitions.
 SLPS-73405:
-  name: 零〜zero〜 PS2 the Best
-  name-sort: ぜろ〜zero〜 PS2 the Best
-  name-en: "Zero [PS2 The Best]"
+  name: 零〜zero〜 PlayStation 2 the Best
+  name-sort: ぜろ PlayStation 2 the Best
+  name-en: "Zero [PlayStation 2 the Best]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Reduces blurriness.
     alignSprite: 1 # Fixes vertical lines on hidden ghosts.
 SLPS-73406:
-  name: DOA2 HARD・CORE PS2 the Best
-  name-sort: DOA2 HARD・CORE PS2 the Best
-  name-en: "DOA 2 - Hardcore [PS2 The Best]"
+  name: DOA2 HARD・CORE PlayStation 2 the Best
+  name-sort: でっどおああらいぶ2 はーどこあ PlayStation 2 the Best
+  name-en: "DOA 2 - Hardcore [PlayStation 2 the Best]"
   region: "NTSC-J"
   compat: 5
 SLPS-73407:
-  name: サイドワインダーMAX PS2 the Best
-  name-sort: さいどわいんだーMAX PS2 the Best
-  name-en: "Sidewinder MAX [PS2 The Best]"
+  name: サイドワインダーMAX PlayStation 2 the Best
+  name-sort: さいどわいんだーMAX PlayStation 2 the Best
+  name-en: "Sidewinder MAX [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPS-73408:
-  name: "7 (Seven) - Molmorth no Kiheitai [PS2 the Best]"
+  name: "7 (Seven) - Molmorth no Kiheitai [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPS-73409:
   name: "Exciting Pro Wres 3"
   region: "NTSC-J"
 SLPS-73410:
-  name: エースコンバット04 シャッタードスカイ PS2 the Best
-  name-sort: えーすこんばっと04 しゃったーどすかい PS2 the Best
-  name-en: "Ace Combat 04 - Shattered Skies [PS2 The Best]"
+  name: エースコンバット04 シャッタードスカイ PlayStation 2 the Best
+  name-sort: えーすこんばっと04 しゃったーどすかい PlayStation 2 the Best
+  name-en: "Ace Combat 04 - Shattered Skies [PlayStation 2 the Best]"
   region: "NTSC-J"
   gameFixes:
     - SoftwareRendererFMVHack # Fixes FMVs disabling hash cache.
@@ -56109,7 +56243,7 @@ SLPS-73410:
     cpuSpriteRenderLevel: 0 # Needed for above.
     estimateTextureRegion: 1 # Improves performance and reduces HC size.
 SLPS-73411:
-  name: "Armored Core 2 - Another Age [PS2 The Best]"
+  name: "Armored Core 2 - Another Age [PlayStation 2 the Best]"
   region: "NTSC-J"
   clampModes:
     eeClampMode: 2 # Fixes Abnormal AI behavior.
@@ -56120,53 +56254,53 @@ SLPS-73411:
     - "SLPS-73403"
     - "SLPS-73411"
 SLPS-73412:
-  name: ヴァンパイアナイト PS2 the Best
-  name-sort: ゔぁんぱいあないと PS2 the Best
-  name-en: "Vampire Night [PS2 The Best]"
+  name: ヴァンパイアナイト PlayStation 2 the Best
+  name-sort: ゔぁんぱいあないと PlayStation 2 the Best
+  name-en: "Vampire Night [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPS-73413:
   name: "Kamaitachi no Yoru 2 - Kangoku-jima no Warabe-uta"
   region: "NTSC-J"
 SLPS-73415:
-  name: Gallop Racer 6 -Revolution- PS2 the Best
-  name-sort: Gallop Racer 6 -Revolution- PS2 the Best
-  name-en: "Gallop Racer 6 - Revolution [PS2 The Best]"
+  name: Gallop Racer 6 -Revolution- PlayStation 2 the Best
+  name-sort: Gallop Racer 6 -Revolution- PlayStation 2 the Best
+  name-en: "Gallop Racer 6 - Revolution [PlayStation 2 the Best]"
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 2 # Improves lighting, maximum blending is needed for full accuracy.
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
 SLPS-73416:
-  name: スーパーロボット大戦IMPACT PS2 the Best
-  name-sort: すーぱーろぼっとたいせんIMPACT PS2 the Best
-  name-en: "Super Robot Wars - Impact [PS2 The Best]"
+  name: スーパーロボット大戦IMPACT PlayStation 2 the Best
+  name-sort: すーぱーろぼっとたいせんIMPACT PlayStation 2 the Best
+  name-en: "Super Robot Wars - Impact [PlayStation 2 the Best]"
   region: "NTSC-J"
   gsHWFixes:
     estimateTextureRegion: 1 # Reduces hash cache size.
 SLPS-73417:
-  name: アーマード・コア 3 PS2 the Best
-  name-sort: あーまーど・こあ 3 PS2 the Best
-  name-en: "Armored Core 3 [PS2 The Best]"
+  name: アーマード・コア 3 PlayStation 2 the Best
+  name-sort: あーまーどこあ3 PlayStation 2 the Best
+  name-en: "Armored Core 3 [PlayStation 2 the Best]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Corrects positioning of reflections on suit's surfaces.
     roundSprite: 2 # Reduces garbage on the UI whilst upscaling.
 SLPS-73418:
-  name: シャドウハーツ PlayStation® 2 the Best
-  name-sort: しゃどうはーつ PlayStation® 2 the Best
-  name-en: "Shadow Hearts [PS2 The Best]"
+  name: シャドウハーツ PlayStation 2 the Best
+  name-sort: しゃどうはーつ [PlayStation 2 the Best]
+  name-en: "Shadow Hearts [PlayStation 2 the Best]"
   region: "NTSC-J"
   clampModes:
     eeClampMode: 3 # Fixes invisible characters in various scenes.
 SLPS-73419:
-  name: ルパン三世 魔術王の遺産 PS2 the Best
-  name-sort: るぱんさんせい まじゅつおうのいさん PS2 the Best
-  name-en: "Lupin III - Majutsu-Ou no Isan [PS2 The Best]"
+  name: ルパン三世 魔術王の遺産 PlayStation 2 the Best
+  name-sort: るぱんさんせい まじゅつおうのいさん PlayStation 2 the Best
+  name-en: "Lupin III - Majutsu-Ou no Isan [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPS-73420:
-  name: アーマード・コア 3　サイレントライン PS2 the Best
-  name-sort: あーまーど・こあ 3　さいれんとらいん PS2 the Best
-  name-en: "Armored Core 3 - Silent Line [PS2 The Best]"
+  name: アーマード・コア 3　サイレントライン PlayStation 2 the Best
+  name-sort: あーまーどこあ3 さいれんとらいん PlayStation 2 the Best
+  name-en: "Armored Core 3 - Silent Line [PlayStation 2 the Best]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Corrects positioning of reflections on suit's surfaces.
@@ -56178,32 +56312,32 @@ SLPS-73420:
     - "SLPS-73417"
     - "SLPS-73420"
 SLPS-73421:
-  name: 天誅 参 PS2 the Best
-  name-sort: てんちゅう さん PS2 the Best
-  name-en: "Tenchu 3 [PS2 The Best]"
+  name: 天誅 参 PlayStation 2 the Best
+  name-sort: てんちゅう3 [PlayStation 2 the Best]
+  name-en: "Tenchu 3 [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPS-73422:
-  name: ウルトラマン ファイティングエボリューション2 PS2 the Best
-  name-sort: うるとらまん ふぁいてぃんぐえぼりゅーしょん2 PS2 the Best
-  name-en: "Ultraman Fighting Evolution 2 [PS2 The Best]"
+  name: ウルトラマン ファイティングエボリューション2 PlayStation 2 the Best
+  name-sort: うるとらまん ふぁいてぃんぐえぼりゅーしょん2 [PlayStation 2 the Best]
+  name-en: "Ultraman Fighting Evolution 2 [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPS-73423:
-  name: モンスターファーム4 PS2 the Best
-  name-sort: もんすたーふぁーむ4 PS2 the Best
-  name-en: "Monster Farm 4 [PS2 The Best]"
+  name: モンスターファーム4 PlayStation 2 the Best
+  name-sort: もんすたーふぁーむ4 [PlayStation 2 the Best]
+  name-en: "Monster Farm 4 [PlayStation 2 the Best]"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
     halfPixelOffset: 1 # Corrects shadow misalignment.
 SLPS-73424:
-  name: GUILTY GEAR XX PS2 the Best
-  name-sort: GUILTY GEAR XX PS2 the Best
-  name-en: "Guilty Gear XX [PS2 The Best]"
+  name: GUILTY GEAR XX PlayStation 2 the Best
+  name-sort: ぎるてぃぎあ いぐぜくす PlayStation 2 the Best
+  name-en: "Guilty Gear XX [PlayStation 2 the Best]"
   region: "NTSC-J"
 SLPS-73901:
-  name: ゼノサーガ エピソードI 力への意志 PS2 the Best
-  name-sort: ぜのさーが えぴそーどI ちからへのいし PS2 the Best
-  name-en: "Xenosaga Episode 1 - Der Wille zur Macht [PS2 The Best]"
+  name: ゼノサーガ エピソードI 力への意志 PlayStation 2 the Best
+  name-sort: ぜのさーが えぴそーどI ちからへのいし PlayStation 2 the Best
+  name-en: "Xenosaga Episode 1 - Der Wille zur Macht [PlayStation 2 the Best]"
   region: "NTSC-J"
   gsHWFixes:
     autoFlush: 2 # Fixes shadows in cutscenes.
@@ -57323,7 +57457,7 @@ SLUS-20266:
   region: "NTSC-U"
   compat: 5
 SLUS-20267:
-  name: "dot hack - Infection Part 1"
+  name: ".hack Infection Part 1"
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
@@ -58811,7 +58945,7 @@ SLUS-20561:
   gsHWFixes:
     autoFlush: 2 # Fixes incorrect blur effect.
 SLUS-20562:
-  name: "dot hack - Mutation Part 2"
+  name: ".hack Mutation Part 2"
   region: "NTSC-U"
   compat: 5
   memcardFilters:
@@ -58820,7 +58954,7 @@ SLUS-20562:
     - "SLUS-20563"
     - "SLUS-20564"
 SLUS-20563:
-  name: "dot hack - Outbreak Part 3"
+  name: ".hack Outbreak Part 3"
   region: "NTSC-U"
   compat: 5
   memcardFilters:
@@ -58829,7 +58963,7 @@ SLUS-20563:
     - "SLUS-20563"
     - "SLUS-20564"
 SLUS-20564:
-  name: "dot hack - Quarantine Part 4"
+  name: ".hack Quarantine Part 4"
   region: "NTSC-U"
   compat: 5
   memcardFilters:
@@ -62675,7 +62809,7 @@ SLUS-21256:
   region: "NTSC-U"
   compat: 5
 SLUS-21258:
-  name: "dot hack - G.U. Vol.1 - Rebirth"
+  name: ".hack//G.U. Vol.1 - Rebirth"
   region: "NTSC-U"
   compat: 5
   memcardFilters:
@@ -64117,7 +64251,7 @@ SLUS-21479:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
 SLUS-21480:
-  name: "dot hack G.U. Volume 1 - Rebirth - Terminal Disc"
+  name: ".hack//G.U. Volume 1 - Rebirth - Terminal Disc"
   region: "NTSC-U"
   compat: 5
   memcardFilters:
@@ -64166,7 +64300,7 @@ SLUS-21487:
   region: "NTSC-U"
   compat: 5
 SLUS-21488:
-  name: "dot hack - G.U. Vol.2 - Reminisce"
+  name: ".hack//G.U. Vol.2 - Reminisce"
   region: "NTSC-U"
   compat: 5
   memcardFilters:
@@ -64179,7 +64313,7 @@ SLUS-21488:
     - "SLUS-21489"
     - "SLUS-21480"
 SLUS-21489:
-  name: "dot hack - G.U. Vol.3 - Redemption"
+  name: ".hack//G.U. Vol.3 - Redemption"
   region: "NTSC-U"
   compat: 5
   memcardFilters:
@@ -66428,7 +66562,7 @@ SLUS-28021:
   name: "Everquest Online Adventures [Beta Vol.2.0]"
   region: "NTSC-U"
 SLUS-28023:
-  name: "dot hack - Infection Part 1 [Trade Demo]"
+  name: ".hack Infection Part 1 [Trade Demo]"
   region: "NTSC-U"
   gsHWFixes:
     halfPixelOffset: 1 # Sharpens world in far distances.
@@ -66450,7 +66584,7 @@ SLUS-28031:
   name: "Auto Modellista - Public Beta Volume 2.0"
   region: "NTSC-U"
 SLUS-28032:
-  name: "dot hack - Mutation Part 2 [Trade Demo]"
+  name: ".hack Mutation Part 2 [Trade Demo]"
   region: "NTSC-U"
 SLUS-28034:
   name: "Disgaea - Hour of Darkness [Trade Demo]"
@@ -66688,7 +66822,7 @@ SLUS-29040:
   name: "Dr. Muto [Demo]"
   region: "NTSC-U"
 SLUS-29042:
-  name: "dot hack - Infection Part 1 [Regular Demo]"
+  name: ".hack Infection Part 1 [Regular Demo]"
   region: "NTSC-U"
   gsHWFixes:
     halfPixelOffset: 1 # Sharpens world in far distances.
@@ -66719,7 +66853,7 @@ SLUS-29054:
   name: "Splashdown - Rides Gone Wild [Demo]"
   region: "NTSC-U"
 SLUS-29055:
-  name: "dot hack - Mutation Part 2 [Regular Demo]"
+  name: ".hack Mutation Part 2 [Regular Demo]"
   region: "NTSC-U"
 SLUS-29056:
   name: "Alter Echo [Demo]"
@@ -66750,7 +66884,7 @@ SLUS-29063:
   name: "Everquest Online Adventures - Frontiers [Public Beta Ver.1.0]"
   region: "NTSC-U"
 SLUS-29065:
-  name: "dot hack - Outbreak Part 3 [Demo]"
+  name: ".hack Outbreak Part 3 [Demo]"
   region: "NTSC-U"
 SLUS-29067:
   name: "Tak and the Power of Juju [Demo]"
@@ -66818,7 +66952,7 @@ SLUS-29083:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes outlines around environmental objects.
 SLUS-29084:
-  name: "dot hack - Quarantine Part 4 [Demo]"
+  name: ".hack Quarantine Part 4 [Demo]"
   region: "NTSC-U"
 SLUS-29085:
   name: "Champions of Norrath - Realms of Everquest"
@@ -67287,7 +67421,7 @@ SLUS-29198:
   roundModes:
     vu1RoundMode: 0 # Massages the Z on the score meter for hardware mode, software doesn't really need this.
 SLUS-29199:
-  name: "dot hack - G.U. Vol.1 - Rebirth [Demo]"
+  name: ".hack//G.U. Vol.1 - Rebirth [Demo]"
   region: "NTSC-U"
   gsHWFixes:
     halfPixelOffset: 2 # Sharpens world in far distances.
@@ -67419,13 +67553,13 @@ TCES-53286:
     cpuSpriteRenderLevel: 2 # Needed for above.
     textureInsideRT: 1 # Fixes broken character models.
 TCPS-10058:
-  name: 電車でGO!新幹線 山陽新幹線編 運転士セット PS2 the Best
-  name-sort: でんしゃでGO!しんかんせん さんようしんかんせんへん うんてんしせっと PS2 the Best
+  name: 電車でGO!新幹線 山陽新幹線編 運転士セット PlayStation 2 the Best
+  name-sort: でんしゃでごーしんかんせん さんようしんかんせんへん うんてんしせっと PlayStation 2 the Best
   name-en: "Densha de Go! Shinkansen [with Controller]"
   region: "NTSC-J"
 TCPS-10068:
   name: 電車でGO! 旅情編コントローラ同梱セット
-  name-sort: でんしゃでGO! りょじょうへんこんとろーらどうこんせっと
+  name-sort: でんしゃでごー りょじょうへんこんとろーらどうこんせっと
   name-en: "Densha de Go! Ryojou-hen [with Controller]"
   region: "NTSC-J"
 TCPS-10074:
@@ -67445,13 +67579,13 @@ TCPS-10084:
   region: "NTSC-J"
 TCPS-10085:
   name: 電車でGO!FINAL
-  name-sort: でんしゃでGO!FINAL
+  name-sort: でんしゃでごーFINAL
   name-en: "Densha de Go! Final [Limited Edition]"
   region: "NTSC-J"
   compat: 5
 TCPS-10094:
   name: イースIII 〜ワンダラーズフロムイース〜
-  name-sort: いーすIII 〜わんだらーずふろむいーす〜
+  name-sort: いーす3 わんだらーずふろむいーす
   name-en: "Ys III - Wanderers from Ys"
   region: "NTSC-J"
 TCPS-10106:
@@ -67465,13 +67599,13 @@ TCPS-10107:
   name-en: "Giga Wing Generations"
   region: "NTSC-J"
 TCPS-10109:
-  name: イースIII ～ワンダラーズ フロム イース～ [初回限定版]
-  name-sort: いーすIII ～わんだらーず ふろむ いーす～ [しょかいげんていばん]
+  name: イースIII 〜ワンダラーズ フロム イース〜 [初回限定版]
+  name-sort: いーす3 わんだらーず ふろむ いーす しょかいげんていばん
   name-en: "Ys III - Wanderers from Ys [Limited Edition]"
   region: "NTSC-J"
 TCPS-10111:
   name: エレメンタル ジェレイド -纏え、翠風の剣-
-  name-sort: えれめんたる じぇれいど -まとえ、すいふうのつるぎ-
+  name-sort: えれめんたる じぇれいど まとえ すいふうのつるぎ
   name-en: "Erementar Gerad"
   region: "NTSC-J"
   gameFixes:
@@ -67483,7 +67617,7 @@ TCPS-10113:
   region: "NTSC-J"
 TCPS-10114:
   name: 魔探偵ロキRAGNAROK 魔妖画 〜失われた微笑〜
-  name-sort: またんていろきRAGNAROK ま妖画 〜うしなわれたびしょう〜
+  name-sort: またんていろきらぐなろく まようが うしなわれたほほえみ
   name-en: "Matantei Loki Ragnarok Mayoukaku"
   region: "NTSC-J"
 TCPS-10115:
@@ -67553,12 +67687,12 @@ TCPS-10136:
   region: "NTSC-J"
 TCPS-10147:
   name: 零式艦上戦闘記 弐
-  name-sort: れいしきかんじょうせんとうき 弐
+  name-sort: れいしきかんじょうせんとうき 2
   name-en: "Zero Shikikan Josentoki Ni"
   region: "NTSC-J"
 TCPS-10148:
   name: 零式艦上戦闘記 弐 [限定版]
-  name-sort: れいしきかんじょうせんとうき 弐 [げんていばん]
+  name-sort: れいしきかんじょうせんとうき 2 [げんていばん]
   name-en: "Zero Shikikan Josentoki Ni [Limited Edition]"
   region: "NTSC-J"
 TCPS-10152:
@@ -67586,7 +67720,7 @@ TCPS-10158:
     autoFlush: 2 # Fixes shadow alignment along with HPO Special (Normal looks better but causes top left glitches).
     halfPixelOffset: 2
 TCPS-10159:
-  name: TT SUPERBIKES(TTスーパーバイクス)
+  name: TT SUPERBIKES
   name-sort: TTすーぱーばいくす
   name-en: "Suzuki TT Super Bikes - Real Road Racing"
   region: "NTSC-J"
@@ -67602,7 +67736,7 @@ TCPS-10164:
     roundSprite: 1 # Fixes vertical and horizontal lines.
 TCPS-10166:
   name: ウィザードリィ・外伝 〜戦闘の監獄〜
-  name-sort: うぃざーどりぃ・がいでん 〜せんとうのかんごく〜
+  name-sort: うぃざーどりぃ がいでん せんとうのかんごく
   name-en: "Wizardry Gaiden - Sentou no Kangoku - Prisoners of the Battles"
   region: "NTSC-J"
 TCPS-10168:
@@ -67677,9 +67811,3 @@ TLES-82043:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
-VW067-J1:
-  name: "Crash Bandicoot 4 - Sakuretsu! Majin Power!"
-  region: "NTSC-J"
-  gsHWFixes:
-    nativePaletteDraw: 1
-    autoFlush: 2 # Fixes refraction effect.


### PR DESCRIPTION
### Description of Changes
* Fixed typo/wrong name/name-sort/name-en.
* Replaced full-width tilde (U+FF5E) with wave dash (U+301C).
* Removed VW067-J1 since it is a mere number for catalog purpose but not game ID.
* According to SCE's internal title database (mentioned in PS3 compatibility list):
  * Preffixed some suffixed "low-cost edition" suffix.
  * Replaced "PS2 the Best" with "PlayStation 2 the Best".

### Rationale behind Changes
More accurate name/name-sort/name-en.