### PR TITLE
GameDB: Various fixes

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -5040,6 +5040,8 @@ SCES-52529:
 SCES-52530:
   name: "Crisis Zone"
   region: "PAL-M5"
+  gsHWFixes:
+    textureInsideRT: 2 # Fixes Grassmarket district boss model.
 SCES-52564:
   name: "SingStar"
   region: "PAL-F"
@@ -6516,6 +6518,8 @@ SCKA-20037:
 SCKA-20038:
   name: "Time Crisis - Crisis Zone"
   region: "NTSC-K"
+  gsHWFixes:
+    textureInsideRT: 2 # Fixes Grassmarket district boss model.
 SCKA-20039:
   name: "Tekken Nina Williams In Death By Degree"
   region: "NTSC-K"
@@ -14184,10 +14188,12 @@ SLES-50731:
   name: "Need for Speed - Hot Pursuit 2"
   region: "PAL-M6"
   compat: 5
+  speedHacks:
+    eeCycleRate: 3 # Fixes intro audio desync.
   clampModes:
     vuClampMode: 2 # White textures.
   gsHWFixes:
-    halfPixelOffset: 1 # Fixes blurriness.
+    halfPixelOffset: 2 # Fixes depth line and blur.
 SLES-50735:
   name: "Jade Cocoon 2"
   region: "PAL-E"
@@ -19461,6 +19467,7 @@ SLES-52877:
   gsHWFixes:
     halfPixelOffset: 2 # Reduces blurriness. Normal Vertex works better, but causes some lights to disappear.
     roundSprite: 1 # Further reduces blurriness.
+    bilinearUpscale: 1 # Smooths out fire textures.
     beforeDraw: "OI_HauntingGround" # Fix bloom.
 SLES-52882:
   name: "Stolen"
@@ -21533,6 +21540,8 @@ SLES-53561:
     recommendedBlendingLevel: 2 # Fixes door transitions.
     halfPixelOffset: 4 # Reduces ghosting.
     roundSprite: 2 # Reduces ghosting.
+    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-53563:
   name: "Nickelodeon SpongeBob SquarePants and Friends Unite!"
   region: "PAL-M6"
@@ -40329,7 +40338,9 @@ SLPM-65913:
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 1 # Fixes blurriness.
+    halfPixelOffset: 2 # Reduces blurriness. Normal Vertex works better, but causes some lights to disappear.
+    roundSprite: 1 # Further reduces blurriness.
+    bilinearUpscale: 1 # Smooths out fire textures.
     beforeDraw: "OI_HauntingGround" # Fix bloom.
 SLPM-65914:
   name: NANA
@@ -44650,7 +44661,9 @@ SLPM-66638:
   name-en: "Demento [CapKore]"
   region: "NTSC-J"
   gsHWFixes:
-    halfPixelOffset: 1 # Fixes blurriness.
+    halfPixelOffset: 2 # Reduces blurriness. Normal Vertex works better, but causes some lights to disappear.
+    roundSprite: 1 # Further reduces blurriness.
+    bilinearUpscale: 1 # Smooths out fire textures.
     beforeDraw: "OI_HauntingGround" # Fix bloom.
 SLPM-66639:
   name: ストリートファイターIII 3rd STRIKE Fight for the future カプコレ
@@ -46891,10 +46904,12 @@ SLPM-67527:
   name: "Need for Speed - Hot Pursuit 2"
   region: "NTSC-K"
   compat: 5
+  speedHacks:
+    eeCycleRate: 3 # Fixes intro audio desync.
   clampModes:
     vuClampMode: 2 # White textures.
   gsHWFixes:
-    halfPixelOffset: 1 # Fixes blurriness.
+    halfPixelOffset: 2 # Fixes depth line and blur.
 SLPM-67528:
   name: "Hajime no Ippo - Victorious Boxers [Championship Edition]"
   region: "NTSC-K"
@@ -54917,6 +54932,8 @@ SLPS-25879:
     recommendedBlendingLevel: 2 # Fixes door transitions.
     halfPixelOffset: 4 # Reduces ghosting.
     roundSprite: 2 # Reduces ghosting.
+    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
+    trilinearFiltering: 1
 SLPS-25880:
   name: "True Fortune"
   region: "NTSC-J"
@@ -55218,6 +55235,8 @@ SLPS-25950:
     recommendedBlendingLevel: 2 # Fixes door transitions.
     halfPixelOffset: 4 # Reduces ghosting.
     roundSprite: 2 # Reduces ghosting.
+    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
+    trilinearFiltering: 1
 SLPS-25953:
   name: "Daisenryaku VII - Exceed"
   region: "NTSC-J"
@@ -57780,10 +57799,12 @@ SLUS-20362:
   name: "Need for Speed - Hot Pursuit 2"
   region: "NTSC-U"
   compat: 5
+  speedHacks:
+    eeCycleRate: 3 # Fixes intro audio desync.
   clampModes:
     vuClampMode: 2 # White textures.
   gsHWFixes:
-    halfPixelOffset: 1 # Fixes blurriness.
+    halfPixelOffset: 2 # Fixes depth line and blur.
 SLUS-20363:
   name: "Sled Storm"
   region: "NTSC-U"
@@ -60767,6 +60788,8 @@ SLUS-20927:
   name: "Time Crisis - Crisis Zone"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    textureInsideRT: 2 # Fixes Grassmarket district boss model.
 SLUS-20928:
   name: "Echo Night - Beyond"
   region: "NTSC-U"
@@ -61632,6 +61655,7 @@ SLUS-21075:
   gsHWFixes:
     halfPixelOffset: 2 # Reduces blurriness. Normal Vertex works better, but causes some lights to disappear.
     roundSprite: 1 # Further reduces blurriness.
+    bilinearUpscale: 1 # Smooths out fire textures.
     beforeDraw: "OI_HauntingGround" # Fix bloom.
 SLUS-21076:
   name: "Atari Anthology"
@@ -62776,6 +62800,8 @@ SLUS-21269:
     recommendedBlendingLevel: 2 # Fixes door transitions.
     halfPixelOffset: 4 # Reduces ghosting.
     roundSprite: 2 # Reduces ghosting.
+    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-21270:
   name: "MS Saga - A New Dawn"
   region: "NTSC-U"
@@ -65805,6 +65831,8 @@ SLUS-21834:
   name: "Goosebumps Horrorland - Happy Halloween"
   region: "NTSC-U"
   compat: 5
+  clampModes:
+    vuClampMode: 3 # Needs both vu0 and vu1 extra+sign clamping to fix crash on flume ride.
 SLUS-21835:
   name: "History Channel - Civil War Secret Mission"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
Fixes intro desync in NFS HP2 NTSC-U and adds mipmapping+tri to Bully.

Helps #7877 
Fixes #10768 

Before:
![Bully_SLUS-21269_20240203142733](https://github.com/PCSX2/pcsx2/assets/80843560/f6538200-af87-483b-8596-4f929dd1c26e)

After:
![Bully_SLUS-21269_20240203142737](https://github.com/PCSX2/pcsx2/assets/80843560/4cbb19c6-b7bc-4420-b302-048e999bb1fc)

### Rationale behind Changes
Less desync more good.

### Suggested Testing Steps
Make sure CI is happy.
