### PR TITLE
GS: Move input recording shutdown to VMManager

### DIFF
--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -15,7 +15,6 @@
 #include "GS/MultiISA.h"
 #include "Host.h"
 #include "Input/InputManager.h"
-#include "Recording/InputRecording.h"
 #include "MTGS.h"
 #include "pcsx2/GS.h"
 #include "GS/Renderers/Null/GSRendererNull.h"
@@ -338,9 +337,6 @@ void GSclose()
 	if (GSCapture::IsCapturing())
 		GSCapture::EndCapture();
 
-	if (g_InputRecording.isActive())
-		g_InputRecording.stop();
-
 	CloseGSRenderer();
 	CloseGSDevice(true);
 	Host::ReleaseRenderWindow();
@@ -503,9 +499,6 @@ void GSGameChanged()
 
 	if (!VMManager::HasValidVM() && GSCapture::IsCapturing())
 		GSCapture::EndCapture();
-
-	if (!VMManager::HasValidVM() && g_InputRecording.isActive())
-		g_InputRecording.stop();
 }
 
 bool GSHasDisplayWindow()

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -1496,6 +1496,10 @@ void VMManager::Shutdown(bool save_resume_state)
 			Console.Error("Failed to save resume state");
 	}
 
+	// end input recording before clearing state
+	if (g_InputRecording.isActive())
+		g_InputRecording.stop();
+
 	SaveSessionTime(s_disc_serial);
 	s_elf_override = {};
 	ClearELFInfo();


### PR DESCRIPTION
### Description of Changes

Regression from #10741.

### Rationale behind Changes

Messing with CPU thread state on the GS thread is a bad idea (TM), even if the main thread is blocking waiting for the GS thread to close.

Also, it wouldn't work if you were using Big Picture mode.

### Suggested Testing Steps

Test shutting down with input recording active in both "normal" and BP mode.
