### PR TITLE
deps: Bump to SDL2 2.30.0

### DIFF
--- a/.github/workflows/scripts/linux/build-dependencies-qt.sh
+++ b/.github/workflows/scripts/linux/build-dependencies-qt.sh
@@ -9,7 +9,7 @@ fi
 
 INSTALLDIR="$1"
 NPROCS="$(getconf _NPROCESSORS_ONLN)"
-SDL=SDL2-2.28.5
+SDL=SDL2-2.30.0
 QT=6.6.1
 LIBBACKTRACE=ad106d5fdd5d960bd33fae1c48a351af567fd075
 
@@ -17,7 +17,7 @@ mkdir -p deps-build
 cd deps-build
 
 cat > SHASUMS <<EOF
-332cb37d0be20cb9541739c61f79bae5a477427d79ae85e352089afdaf6666e4  $SDL.tar.gz
+36e2e41557e0fa4a1519315c0f5958a87ccb27e25c51776beb6f1239526447b0  $SDL.tar.gz
 fd6f417fe9e3a071cf1424a5152d926a34c4a3c5070745470be6cf12a404ed79  $LIBBACKTRACE.zip
 450c5b4677b2fe40ed07954d7f0f40690068e80a94c9df86c2c905ccd59d02f7  qtbase-everywhere-src-$QT.tar.xz
 ac4ed08950072e375be662cfa64fdb447dd6e935cf29c56a4128d1500492188f  qtimageformats-everywhere-src-$QT.tar.xz

--- a/.github/workflows/scripts/linux/build-dependencies-qt.sh
+++ b/.github/workflows/scripts/linux/build-dependencies-qt.sh
@@ -50,7 +50,7 @@ cd ..
 echo "Building libbacktrace..."
 unzip "$LIBBACKTRACE.zip"
 cd "libbacktrace-$LIBBACKTRACE"
-./configure --prefix="$HOME/deps"
+./configure --prefix="$INSTALLDIR"
 make
 make install
 cd ..

--- a/.github/workflows/scripts/linux/flatpak/modules/20-sdl2.json
+++ b/.github/workflows/scripts/linux/flatpak/modules/20-sdl2.json
@@ -28,8 +28,8 @@
   "sources": [
     {
       "type": "archive",
-      "url": "https://libsdl.org/release/SDL2-2.28.5.tar.gz",
-      "sha256": "332cb37d0be20cb9541739c61f79bae5a477427d79ae85e352089afdaf6666e4"
+      "url": "https://libsdl.org/release/SDL2-2.30.0.tar.gz",
+      "sha256": "36e2e41557e0fa4a1519315c0f5958a87ccb27e25c51776beb6f1239526447b0"
     }
   ],
   "cleanup": [

--- a/.github/workflows/scripts/macos/build-dependencies.sh
+++ b/.github/workflows/scripts/macos/build-dependencies.sh
@@ -11,7 +11,7 @@ export MACOSX_DEPLOYMENT_TARGET=11.0
 
 INSTALLDIR="$1"
 NPROCS="$(getconf _NPROCESSORS_ONLN)"
-SDL=SDL2-2.28.5
+SDL=SDL2-2.30.0
 XZ=5.4.5
 ZSTD=1.5.5
 LZ4=b8fd2d15309dd4e605070bd4486e26b6ef814e29
@@ -29,7 +29,7 @@ export CFLAGS="-I$INSTALLDIR/include $CFLAGS"
 export CXXFLAGS="-I$INSTALLDIR/include $CXXFLAGS"
 
 cat > SHASUMS <<EOF
-332cb37d0be20cb9541739c61f79bae5a477427d79ae85e352089afdaf6666e4  $SDL.tar.gz
+36e2e41557e0fa4a1519315c0f5958a87ccb27e25c51776beb6f1239526447b0  $SDL.tar.gz
 135c90b934aee8fbc0d467de87a05cb70d627da36abe518c357a873709e5b7d6  xz-$XZ.tar.gz
 9c4396cc829cfae319a6e2615202e82aad41372073482fce286fac78646d3ee4  zstd-$ZSTD.tar.gz
 0728800155f3ed0a0c87e03addbd30ecbe374f7b080678bbca1506051d50dec3  $LZ4.tar.gz
@@ -62,24 +62,6 @@ shasum -a 256 --check SHASUMS
 echo "Installing SDL..."
 tar xf "$SDL.tar.gz"
 cd "$SDL"
-
-# MFI causes multiple joystick connection events, I'm guessing because both the HIDAPI and MFI interfaces
-# race each other, and sometimes both end up getting through. So, just force MFI off.
-patch -u CMakeLists.txt <<EOF
---- CMakeLists.txt	2023-08-03 01:33:11
-+++ CMakeLists.txt	2023-08-26 12:58:53
-@@ -2105,7 +2105,7 @@
-           #import <Foundation/Foundation.h>
-           #import <CoreHaptics/CoreHaptics.h>
-           int main() { return 0; }" HAVE_FRAMEWORK_COREHAPTICS)
--      if(HAVE_FRAMEWORK_GAMECONTROLLER AND HAVE_FRAMEWORK_COREHAPTICS)
-+      if(HAVE_FRAMEWORK_GAMECONTROLLER AND HAVE_FRAMEWORK_COREHAPTICS AND FALSE)
-         # Only enable MFI if we also have CoreHaptics to ensure rumble works
-         set(SDL_JOYSTICK_MFI 1)
-         set(SDL_FRAMEWORK_GAMECONTROLLER 1)
-
-EOF
-
 cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH="$INSTALLDIR" -DCMAKE_INSTALL_PREFIX="$INSTALLDIR" -DCMAKE_OSX_ARCHITECTURES="x86_64" -DSDL_X11=OFF -DBUILD_SHARED_LIBS=ON
 make -C build "-j$NPROCS"
 make -C build install

--- a/.github/workflows/scripts/windows/build-dependencies.bat
+++ b/.github/workflows/scripts/windows/build-dependencies.bat
@@ -39,9 +39,9 @@ cd "%BUILDDIR%"
 
 set QT=6.6.1
 set QTMINOR=6.6
-set SDL=SDL2-2.28.5
+set SDL=SDL2-2.30.0
 
-call :downloadfile "%SDL%.zip" "https://libsdl.org/release/%SDL%.zip" 97bd14ee0ec67494d2b93f1a4f7da2bf891103c57090d96fdcc2b019d885c76a || goto error
+call :downloadfile "%SDL%.zip" "https://libsdl.org/release/%SDL%.zip" 80b0c02b6018630cd40639ac9fc8e5c1d8eec14d8fe3e6dfa76343e3ba8b78d9 || goto error
 call :downloadfile "qtbase-everywhere-src-%QT%.zip" "https://download.qt.io/official_releases/qt/%QTMINOR%/%QT%/submodules/qtbase-everywhere-src-%QT%.zip" 818f92518d1a89ee98ae818891a7d2f0e41aa45b933d55215da2df6d5459428e || goto error
 call :downloadfile "qtimageformats-everywhere-src-%QT%.zip" "https://download.qt.io/official_releases/qt/%QTMINOR%/%QT%/submodules/qtimageformats-everywhere-src-%QT%.zip" 03f01042f86b4dbf7329a179f20835817c660a183178c11570cc0535b3c3ba58 || goto error
 call :downloadfile "qtsvg-everywhere-src-%QT%.zip" "https://download.qt.io/official_releases/qt/%QTMINOR%/%QT%/submodules/qtsvg-everywhere-src-%QT%.zip" d44d5ead8d4682f54c91687b5e32f2735f086419e3889e05609feae1a7f02da9 || goto error

--- a/cmake/SearchForStuff.cmake
+++ b/cmake/SearchForStuff.cmake
@@ -90,7 +90,7 @@ endif(WIN32)
 find_package(Threads REQUIRED)
 
 # Also need SDL2.
-find_package(SDL2 2.28.5 REQUIRED)
+find_package(SDL2 2.30.0 REQUIRED)
 
 set(ACTUALLY_ENABLE_TESTS ${ENABLE_TESTS})
 if(ENABLE_TESTS)

--- a/pcsx2-qt/Settings/ControllerGlobalSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/ControllerGlobalSettingsWidget.cpp
@@ -26,9 +26,21 @@ ControllerGlobalSettingsWidget::ControllerGlobalSettingsWidget(QWidget* parent, 
 #ifdef _WIN32
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.enableSDLRawInput, "InputSources", "SDLRawInput", false);
 #else
-	m_ui.gridLayout_2->removeWidget(m_ui.enableSDLRawInput);
+	m_ui.sdlGridLayout->removeWidget(m_ui.enableSDLRawInput);
 	m_ui.enableSDLRawInput->deleteLater();
 	m_ui.enableSDLRawInput = nullptr;
+#endif
+
+#ifdef __APPLE__
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.enableSDLIOKitDriver, "InputSources", "SDLIOKitDriver", true);
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.enableSDLMFIDriver, "InputSources", "SDLMFIDriver", true);
+#else
+	m_ui.sdlGridLayout->removeWidget(m_ui.enableSDLIOKitDriver);
+	m_ui.enableSDLIOKitDriver->deleteLater();
+	m_ui.enableSDLIOKitDriver = nullptr;
+	m_ui.sdlGridLayout->removeWidget(m_ui.enableSDLMFIDriver);
+	m_ui.enableSDLMFIDriver->deleteLater();
+	m_ui.enableSDLMFIDriver = nullptr;
 #endif
 
 	ControllerSettingWidgetBinder::BindWidgetToInputProfileBool(sif, m_ui.enableMouseMapping, "UI", "EnableMouseMapping", false);
@@ -102,6 +114,10 @@ void ControllerGlobalSettingsWidget::updateSDLOptionsEnabled()
 	m_ui.ledSettings->setEnabled(enabled);
 #ifdef _WIN32
 	m_ui.enableSDLRawInput->setEnabled(enabled);
+#endif
+#ifdef __APPLE__
+	m_ui.enableSDLIOKitDriver->setEnabled(enabled);
+	m_ui.enableSDLMFIDriver->setEnabled(enabled);
 #endif
 }
 

--- a/pcsx2-qt/Settings/ControllerGlobalSettingsWidget.ui
+++ b/pcsx2-qt/Settings/ControllerGlobalSettingsWidget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>902</width>
-    <height>593</height>
+    <height>665</height>
    </rect>
   </property>
   <layout class="QGridLayout" name="mainLayout" columnstretch="1,0">
@@ -31,7 +31,7 @@
      <property name="sizeHint" stdset="0">
       <size>
        <width>20</width>
-       <height>45</height>
+       <height>0</height>
       </size>
      </property>
     </spacer>

--- a/pcsx2-qt/Settings/ControllerGlobalSettingsWidget.ui
+++ b/pcsx2-qt/Settings/ControllerGlobalSettingsWidget.ui
@@ -126,7 +126,7 @@
      <property name="title">
       <string>SDL Input Source</string>
      </property>
-     <layout class="QGridLayout" name="gridLayout_2">
+     <layout class="QGridLayout" name="sdlGridLayout">
       <item row="1" column="0">
        <widget class="QCheckBox" name="enableSDLSource">
         <property name="text">
@@ -170,6 +170,20 @@
        <widget class="QCheckBox" name="enableSDLRawInput">
         <property name="text">
          <string>Enable SDL Raw Input</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QCheckBox" name="enableSDLIOKitDriver">
+        <property name="text">
+         <string>Enable IOKit Driver</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QCheckBox" name="enableSDLMFIDriver">
+        <property name="text">
+         <string>Enable MFI Driver</string>
         </property>
        </widget>
       </item>

--- a/pcsx2-qt/Settings/ControllerSettingsWindow.ui
+++ b/pcsx2-qt/Settings/ControllerSettingsWindow.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>1305</width>
-    <height>680</height>
+    <height>690</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -129,7 +129,8 @@
           <string>Mapping Settings</string>
          </property>
          <property name="icon">
-          <iconset theme="settings-3-line"/>
+          <iconset theme="settings-3-line">
+           <normaloff>.</normaloff>.</iconset>
          </property>
         </widget>
        </item>

--- a/pcsx2/Input/SDLInputSource.h
+++ b/pcsx2/Input/SDLInputSource.h
@@ -2,8 +2,11 @@
 // SPDX-License-Identifier: LGPL-3.0+
 
 #pragma once
+
 #include "Input/InputSource.h"
-#include "SDL.h"
+
+#include <SDL.h>
+
 #include <array>
 #include <functional>
 #include <mutex>
@@ -84,9 +87,15 @@ private:
 
 	ControllerDataVector m_controllers;
 
+	std::array<u32, MAX_LED_COLORS> m_led_colors{};
+	std::vector<std::pair<std::string, std::string>> m_sdl_hints;
+
 	bool m_sdl_subsystem_initialized = false;
 	bool m_controller_enhanced_mode = false;
 	bool m_controller_raw_mode = false;
-	std::array<u32, MAX_LED_COLORS> m_led_colors{};
-	std::vector<std::pair<std::string, std::string>> m_sdl_hints;
+
+#ifdef __APPLE__
+	bool m_enable_iokit_driver = false;
+	bool m_enable_mfi_driver = false;
+#endif
 };


### PR DESCRIPTION
### Description of Changes

Also exposes the new MFI/IOKit backend hints introduced in 2.30. Should let users prevent duplicate devices from showing up, without the downside to breaking MFI-only devices.

### Rationale behind Changes

Bumpity bump.

### Suggested Testing Steps

Test controllers on all platforms.
