### PR TITLE
CI: Swap to MacOS 14 runner

### DIFF
--- a/.github/workflows/macos_build.yml
+++ b/.github/workflows/macos_build.yml
@@ -150,7 +150,6 @@ jobs:
 
       - name: Prepare Build Artifacts
         run: |
-          cp /usr/local/lib/libMoltenVK.dylib build/pcsx2*/PCSX2.app/Contents/Frameworks/
           TAG="$(git tag --points-at HEAD)"
           if [ -z "$TAG" ]; then
             APPNAME="${{ steps.artifact-metadata.outputs.artifact-name }}"

--- a/.github/workflows/macos_build.yml
+++ b/.github/workflows/macos_build.yml
@@ -12,7 +12,7 @@ on:
       os:
         required: false
         type: string
-        default: macos-13
+        default: macos-14
       patchesUrl:
         required: false
         type: string
@@ -74,14 +74,12 @@ jobs:
 
       - name: Install Packages
         env:
-          PLATFORM: "x64"
           HOMEBREW_NO_INSTALL_CLEANUP: 1
           HOMEBREW_NO_ANALYTICS: 1
         run: |
-          # Unlike other packages, brew's MoltenVK build uses MoltenVK's minimum macOS version of 10.13 so we can use it
-          if ! brew install molten-vk ccache nasm; then
+          if ! brew install ccache nasm; then
             brew update
-            brew install molten-vk ccache nasm
+            brew install ccache nasm
           fi
 
       - name: Cache Dependencies
@@ -117,11 +115,10 @@ jobs:
         run: |
           cmake -DCMAKE_PREFIX_PATH="$HOME/deps" \
                 -DCMAKE_BUILD_TYPE=Release \
+                -DCMAKE_OSX_ARCHITECTURES="x86_64" \
                 -DUSE_OPENGL=OFF \
                 -DDISABLE_ADVANCE_SIMD=ON \
                 -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON \
-                -DUSE_SYSTEM_LIBS=OFF \
-                -DUSE_SYSTEM_SDL2=ON \
                 -DUSE_LINKED_FFMPEG=ON \
                 -DCMAKE_C_COMPILER_LAUNCHER=ccache \
                 -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \

--- a/.github/workflows/scripts/macos/build-dependencies.sh
+++ b/.github/workflows/scripts/macos/build-dependencies.sh
@@ -18,6 +18,7 @@ LZ4=b8fd2d15309dd4e605070bd4486e26b6ef814e29
 PNG=1.6.37
 WEBP=1.3.2
 FFMPEG=6.0
+MOLTENVK=1.2.8
 QT=6.6.2
 
 if [ "${INSTALLDIR:0:1}" != "/" ]; then
@@ -47,6 +48,7 @@ cat > SHASUMS <<EOF
 505e70834d35383537b6491e7ae8641f1a4bed1876dbfe361201fc80868d88ca  libpng-$PNG.tar.xz
 2a499607df669e40258e53d0ade8035ba4ec0175244869d1025d460562aa09b4  libwebp-$WEBP.tar.gz
 57be87c22d9b49c112b6d24bc67d42508660e6b718b3db89c44e47e289137082  ffmpeg-$FFMPEG.tar.xz
+85beaf8abfcc54d9da0ff0257ae311abd9e7aa96e53da37e1c37d6bc04ac83cd  v$MOLTENVK.tar.gz
 b89b426b9852a17d3e96230ab0871346574d635c7914480a2a27f98ff942677b  qtbase-everywhere-src-$QT.tar.xz
 71584c9136d4983ad19fa2d017abbae57b055eb90c62a36bf3f45d6d21a87cb3  qtimageformats-everywhere-src-$QT.tar.xz
 5a231d59ef1b42bfbaa5174d4ff39f8e1b4ba070ef984a70b069b4b2576d8181  qtsvg-everywhere-src-$QT.tar.xz
@@ -62,6 +64,7 @@ curl -L \
 	-O "https://downloads.sourceforge.net/project/libpng/libpng16/$PNG/libpng-$PNG.tar.xz" \
 	-O "https://storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-$WEBP.tar.gz" \
 	-O "https://ffmpeg.org/releases/ffmpeg-$FFMPEG.tar.xz" \
+	-O "https://github.com/KhronosGroup/MoltenVK/archive/refs/tags/v$MOLTENVK.tar.gz" \
 	-O "https://download.qt.io/official_releases/qt/${QT%.*}/$QT/submodules/qtbase-everywhere-src-$QT.tar.xz" \
 	-O "https://download.qt.io/official_releases/qt/${QT%.*}/$QT/submodules/qtimageformats-everywhere-src-$QT.tar.xz" \
 	-O "https://download.qt.io/official_releases/qt/${QT%.*}/$QT/submodules/qtsvg-everywhere-src-$QT.tar.xz" \
@@ -135,6 +138,15 @@ cmake "${CMAKE_COMMON[@]}" -B build \
 	-DWEBP_BUILD_VWEBP=OFF -DWEBP_BUILD_WEBPINFO=OFF -DWEBP_BUILD_WEBPMUX=OFF -DWEBP_BUILD_EXTRAS=OFF -DBUILD_SHARED_LIBS=ON
 make -C build "-j$NPROCS"
 make -C build install
+cd ..
+
+# MoltenVK already builds universal binaries, nothing special to do here.
+echo "Installing MoltenVK..."
+tar xf "v$MOLTENVK.tar.gz"
+cd "MoltenVK-${MOLTENVK}"
+./fetchDependencies --macos
+make macos
+cp Package/Latest/MoltenVK/dynamic/dylib/macOS/libMoltenVK.dylib "$INSTALLDIR/lib/"
 cd ..
 
 echo "Installing Qt Base..."

--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -1314,6 +1314,20 @@ function(setup_main_executable target)
 
 		pcsx2_resource(${target} ${PCSX2_SOURCE_DIR}/Resources/PCSX2.icns ${PCSX2_SOURCE_DIR}/Resources)
 
+		# Copy MoltenVK into the bundle
+		unset(MOLTENVK_PATH CACHE)
+		find_file(MOLTENVK_PATH NAMES
+			libMoltenVK.dylib
+			lib/libMoltenVK.dylib
+		)
+		if (MOLTENVK_PATH)
+			target_sources(${target} PRIVATE "${MOLTENVK_PATH}")
+			set_source_files_properties("${MOLTENVK_PATH}" PROPERTIES MACOSX_PACKAGE_LOCATION Frameworks)
+			message(STATUS "Using MoltenVK from ${MOLTENVK_PATH}")
+		else()
+			message(WARNING "MoltenVK not found in path, it will depend on the target system having it.")
+		endif()
+
 		# If they say to skip postprocess bundle, leave the target in but make it so they have
 		# to manually run it
 		if (SKIP_POSTPROCESS_BUNDLE)

--- a/tests/ctest/core/CMakeLists.txt
+++ b/tests/ctest/core/CMakeLists.txt
@@ -26,13 +26,23 @@ if(DISABLE_ADVANCE_SIMD)
 		set(compile_options_avx  -march=sandybridge -mtune=sandybridge)
 		set(compile_options_sse4 -msse4.1 -mtune=nehalem)
 	endif()
+
+	# This breaks when running on Apple Silicon, because even though we skip the test itself, the
+	# gtest constructor still generates AVX code, and that's a global object which gets constructed
+	# at binary load time. So, for now, only compile SSE4 if running on ARM64.
+	if (NOT APPLE OR "${CMAKE_HOST_SYSTEM_PROCESSOR}" STREQUAL "x86_64")
+		set(isa_list "sse4" "avx" "avx2")
+	else()
+		set(isa_list "sse4")
+	endif()
+
 	# ODR violation time!
 	# Everything would be fine if we only defined things in cpp files, but C++ tends to like inline functions (STL anyone?)
 	# Each ISA will bring with it its own copies of these inline header functions, and the linker gets to choose whichever one it wants!  Not fun if the linker chooses the avx2 version and uses it with everything
 	# Thankfully, most linkers don't choose at random.  When presented with a bunch of .o files, most linkers seem to choose the first implementation they see, so make sure you order these from oldest to newest
 	# Note: ld64 (macOS's linker) does not act the same way when presented with .a files, unless linked with `-force_load` (cmake WHOLE_ARCHIVE).
 	set(is_first_isa "1")
-	foreach(isa "sse4" "avx" "avx2")
+	foreach(isa IN LISTS isa_list)
 		add_library(core_test_${isa} STATIC ${multi_isa_sources})
 		target_link_libraries(core_test_${isa} PRIVATE PCSX2_FLAGS gtest)
 		target_compile_definitions(core_test_${isa} PRIVATE MULTI_ISA_UNSHARED_COMPILATION=isa_${isa} MULTI_ISA_IS_FIRST=${is_first_isa} ${pcsx2_defs_${isa}})


### PR DESCRIPTION
### Description of Changes

GitHub recently enabled M1 runners for public projects. They bring a considerable speed boost to CI runtimes, DuckStation went from 15mins+ down to 3mins after switching.

Can't use MoltenVK from brew anymore, because that's going to be arm64. So, build it ourselves as part of the deps package. It doesn't take long on M1 :-).

Only caveat is now we're building on ARM, so we have to be careful and make sure we actually create an x86 build. Luckily I'd already done most of this so I could run the x86 build script on my Macbook.

### Rationale behind Changes

Vroom vroom.

### Suggested Testing Steps

Test Mac builds ~~, once I actually get it working. I have a feeling it's going to explode at first~~ .
