### PR TITLE
GameDB: Add patch for Samurai Warriors 2 - Xtreme legends

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -65283,6 +65283,11 @@ SLUS-21726:
   name: "Samurai Warriors 2 - Xtreme Legends"
   region: "NTSC-U"
   compat: 5
+  patches:
+    3C93E16A:
+      content: |-
+        // Fixes the AI in Sugoroku.
+        patch=1,EE,00102230,word,00000000
 SLUS-21727:
   name: "Naruto - Ultimate Ninja 3"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
This patch nops an instruction that relies on behavior not currently emulated by PCSX2.

### Rationale behind Changes
The AI enemies were surrounding the players during 'reveal', and some enemies along with gold were nowhere to be found in 'steal' all due to this issue. Additionally, this issue could only be fixed by reducing the ee's clock speed to 50%, and even that couldn't fix the issue 100% of the time. Fixes #10622

### Suggested Testing Steps
Already tested on PCSX2 and OPL. Additional testing does not harm.
