### PR TITLE
GitHub: Update macOS versions on issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/app_bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/app_bug_report.yaml
@@ -67,11 +67,10 @@ body:
       - Windows 11
       - Windows 10 (64bit)
       - Linux (64bit) - Specify distro below
+      - macOS 14 (Sonoma)
       - macOS 13 (Ventura)
       - macOS 12 (Monterey)
       - macOS 11 (Big Sur)
-      - macOS 10.15 (Catalina)
-      - macOS 10.14 (Mojave)
     validations:
       required: true
   - type: input

--- a/.github/ISSUE_TEMPLATE/emu_bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/emu_bug_report.yaml
@@ -82,11 +82,10 @@ body:
       - Windows 11
       - Windows 10 (64bit)
       - Linux (64bit) - Specify distro below
+      - macOS 14 (Sonoma)
       - macOS 13 (Ventura)
       - macOS 12 (Monterey)
       - macOS 11 (Big Sur)
-      - macOS 10.15 (Catalina)
-      - macOS 10.14 (Mojave)
     validations:
       required: true
   - type: input


### PR DESCRIPTION
### Description of Changes
Removes 10.14 and 10.15, and adds 14

### Rationale behind Changes
10.14 and 10.15 are no longer supported
14 now exists

### Suggested Testing Steps
None
