### PR TITLE
FS: Fix cover text truncation

### DIFF
--- a/common/FileSystem.cpp
+++ b/common/FileSystem.cpp
@@ -53,7 +53,7 @@ static std::time_t ConvertFileTimeToUnixTime(const FILETIME& ft)
 }
 #endif
 
-static inline bool FileSystemCharacterIsSane(char c, bool strip_slashes)
+static inline bool FileSystemCharacterIsSane(char32_t c, bool strip_slashes)
 {
 #ifdef _WIN32
 	// https://docs.microsoft.com/en-gb/windows/win32/fileio/naming-a-file?redirectedfrom=MSDN#naming-conventions


### PR DESCRIPTION
### Description of Changes
Per TellowKrinkle "Looks like we accidentally truncate our characters to 8 bits before doing the detection
So any unicode character whose lower 8 bits are not allowed in paths will get replaced "

Fixes #10783 

### Rationale behind Changes
Broken names bad.

### Suggested Testing Steps
Make sure CI is happy.
