### PR TITLE
Qt: Default to No for exit Memcard abort msgbox

### DIFF
--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -1046,10 +1046,10 @@ bool MainWindow::shouldAbortForMemcardBusy(const VMLock& lock)
 {
 	if (MemcardBusy::IsBusy() && !GSDumpReplayer::IsReplayingDump())
 	{
-		const QMessageBox::StandardButton res = QMessageBox::question(
+		const QMessageBox::StandardButton res = QMessageBox::critical(
 			lock.getDialogParent(),
 			tr("WARNING: Memory Card Busy"),
-			tr("WARNING: Your memory card is still writing data. Shutting down now will IRREVERSIBLY DESTROY YOUR MEMORY CARD. It is strongly recommended to resume your game and let it finish writing to your memory card.\n\nDo you wish to shutdown anyways and IRREVERSIBLY DESTROY YOUR MEMORY CARD?"));
+			tr("WARNING: Your memory card is still writing data. Shutting down now <b>WILL IRREVERSIBLY DESTROY YOUR MEMORY CARD.</b> It is strongly recommended to resume your game and let it finish writing to your memory card.<br><br>Do you wish to shutdown anyways and <b>IRREVERSIBLY DESTROY YOUR MEMORY CARD?</b>"), QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
 
 		if (res != QMessageBox::Yes)
 		{


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
This PR makes the Memory Card Busy dialog box defaults its button to No instead of Yes.
Also makes the box critical instead of just a question.

NOTE:
This is possibly a Qt bug, according to documentations `QMessageBox::critical` should defaults to No already, but apparently it wasn't the case?

Preview:
![image](https://github.com/PCSX2/pcsx2/assets/14798312/c4c1312c-e0df-4fd5-bbb1-906fd3acbfb5)

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
We don't want users to accidentally destroy their card when they pressed enter blindly.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Check the functionality.