### PR TITLE
ImGui: Avoid frame count display race condition for input recording and display correct value

### DIFF
--- a/pcsx2/ImGui/ImGuiOverlays.cpp
+++ b/pcsx2/ImGui/ImGuiOverlays.cpp
@@ -45,6 +45,8 @@
 #include <tuple>
 #include <unordered_map>
 
+InputRecordingUI::InputRecordingData g_InputRecordingData;
+
 namespace ImGuiManager
 {
 	static void FormatProcessorStat(SmallStringBase& text, double usage, double time);
@@ -637,7 +639,7 @@ __ri void ImGuiManager::DrawInputRecordingOverlay(float& position_y, float scale
 	} while (0)
 
 	// Status Indicators
-	if (g_InputRecording.getControls().isRecording())
+	if (g_InputRecordingData.is_recording)
 	{
 		DRAW_LINE(standard_font, TinyString::from_format(TRANSLATE_FS("ImGuiOverlays", "{} Recording Input"), ICON_PF_CIRCLE).c_str(), IM_COL32(255, 0, 0, 255));
 	}
@@ -647,9 +649,9 @@ __ri void ImGuiManager::DrawInputRecordingOverlay(float& position_y, float scale
 	}
 
 	// Input Recording Metadata
-	DRAW_LINE(fixed_font, TinyString::from_format(TRANSLATE_FS("ImGuiOverlays", "Input Recording Active: {}"), g_InputRecording.getData().getFilename()).c_str(), IM_COL32(117, 255, 241, 255));
-	DRAW_LINE(fixed_font, TinyString::from_format(TRANSLATE_FS("ImGuiOverlays", "Frame: {}/{} ({})"), g_InputRecording.getFrameCounter() + 1, g_InputRecording.getData().getTotalFrames(), g_FrameCount).c_str(), IM_COL32(117, 255, 241, 255));
-	DRAW_LINE(fixed_font, TinyString::from_format(TRANSLATE_FS("ImGuiOverlays", "Undo Count: {}"), g_InputRecording.getData().getUndoCount()).c_str(), IM_COL32(117, 255, 241, 255));
+	DRAW_LINE(fixed_font, g_InputRecordingData.recording_active_message.c_str(), IM_COL32(117, 255, 241, 255));
+	DRAW_LINE(fixed_font, g_InputRecordingData.frame_data_message.c_str(), IM_COL32(117, 255, 241, 255));
+	DRAW_LINE(fixed_font, g_InputRecordingData.undo_count_message.c_str(), IM_COL32(117, 255, 241, 255));
 
 #undef DRAW_LINE
 }

--- a/pcsx2/ImGui/ImGuiOverlays.h
+++ b/pcsx2/ImGui/ImGuiOverlays.h
@@ -27,3 +27,16 @@ namespace SaveStateSelectorUI
 	void LoadCurrentSlot();
 	void SaveCurrentSlot();
 } // namespace SaveStateSelectorUI
+
+namespace InputRecordingUI
+{
+	struct InputRecordingData
+	{
+		bool is_recording = false;
+		TinyString recording_active_message = "";
+		TinyString frame_data_message = "";
+		TinyString undo_count_message = "";
+	};
+}
+
+extern InputRecordingUI::InputRecordingData g_InputRecordingData;

--- a/pcsx2/Recording/InputRecording.h
+++ b/pcsx2/Recording/InputRecording.h
@@ -22,13 +22,18 @@ public:
 	bool play(const std::string& path);
 	void stop();
 
+	static void InformGSThread();
 	void handleControllerDataUpdate();
 	void saveControllerData(const PadData& data, const int port, const int slot);
 	std::optional<PadData> updateControllerData(const int port, const int slot);
 	void incFrameCounter();
-	u64 getFrameCounter() const;
+	u32 getFrameCounter() const;
+	u32 getFrameCounterStateless() const;
 	bool isActive() const;
 	void processRecordQueue();
+
+	void setStartingFrame(u32 startingFrame);
+	u32 getStartingFrame();
 
 	void handleExceededFrameCounter();
 	void handleReset();
@@ -53,11 +58,11 @@ private:
 	std::queue<std::function<void()>> m_recordingQueue;
 
 	u32 m_frame_counter = 0;
+	u32 m_frame_counter_stateless = 0;
 	// Either 0 for a power-on movie, or the g_FrameCount that is stored on the starting frame
 	u32 m_starting_frame = 0;
 
 	void initializeState();
-	void setStartingFrame(u32 startingFrame);
 	void closeActiveFile();
 };
 

--- a/pcsx2/Recording/InputRecordingFile.cpp
+++ b/pcsx2/Recording/InputRecordingFile.cpp
@@ -7,6 +7,7 @@
 
 #include "common/FileSystem.h"
 #include "DebugTools/Debug.h"
+#include "InputRecording.h"
 #include "MemoryTypes.h"
 #include "svnrev.h"
 
@@ -91,6 +92,7 @@ void InputRecordingFile::incrementUndoCount()
 	}
 	fseek(m_recordingFile, s_seekpointUndoCount, SEEK_SET);
 	fwrite(&m_undoCount, 4, 1, m_recordingFile);
+	InputRecording::InformGSThread();
 }
 
 bool InputRecordingFile::openNew(const std::string& path, bool fromSavestate)
@@ -106,6 +108,7 @@ bool InputRecordingFile::openNew(const std::string& path, bool fromSavestate)
 	m_undoCount = 0;
 	m_header.init();
 	m_savestate = fromSavestate;
+	InputRecording::InformGSThread();
 	return true;
 }
 
@@ -125,6 +128,7 @@ bool InputRecordingFile::openExisting(const std::string& path)
 	}
 
 	m_filename = path;
+	InputRecording::InformGSThread();
 	return true;
 }
 
@@ -149,13 +153,14 @@ std::optional<PadData> InputRecordingFile::readPadData(const uint frame, const u
 
 void InputRecordingFile::setTotalFrames(u32 frame)
 {
-	if (m_recordingFile == nullptr || m_totalFrames >= frame)
+	if (m_recordingFile == nullptr)
 	{
 		return;
 	}
 	m_totalFrames = frame;
 	fseek(m_recordingFile, s_seekpointTotalFrames, SEEK_SET);
 	fwrite(&m_totalFrames, 4, 1, m_recordingFile);
+	InputRecording::InformGSThread();
 }
 
 bool InputRecordingFile::writeHeader() const


### PR DESCRIPTION
### Description of Changes
Remove the "+ 1" for the frame count to be displayed during input recording/playback by ImGui.

### Rationale behind Changes
Previously, we displayed the incorrect value for the current frame while creating an input recording. Namely, if the internal counter was n, we displayed n+1. This meant that, for example, the first frame of a fresh recording reads "1/0 (0)", where '1' is the current frame, and '0' is the total frames for the recording. Essentially, we were always displaying the wrong value for what the current frame was. Fixes **part of** (_but not all_) #8128.

### Suggested Testing Steps
This does not change the actual internal logic of how input recording works, just what's displayed on the user's screen. Basically, create new recordings, play back current ones, etc., and see if the current frame counter (the one on the left of the slash) is ever incorrect.

### Screenshots

Incorrect (current)

![Frames](https://github.com/PCSX2/pcsx2/assets/12673964/7ebf9808-821a-4c4b-8ec7-18531007da87)

Fixed:

![Frames_fixed](https://github.com/PCSX2/pcsx2/assets/12673964/3cb2617a-b943-44d2-843f-863fd201fe2a)

For both of these, please look at the frame counter in the top right.