### PR TITLE
GS/HW: Only allow tex is fb on alpha if draw is recursive

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -15680,11 +15680,13 @@ SLES-51286:
   region: "PAL-E"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes upscaling lines.
+    autoFlush: 2 # Fixes sun penetration.
 SLES-51287:
   name: "X-Men 2 - Wolverine's Revenge"
   region: "PAL-F"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes upscaling lines.
+    autoFlush: 2 # Fixes sun penetration.
 SLES-51289:
   name: "Gunfighter 2 - Legend of Jesse James"
   region: "PAL-M5"
@@ -16228,6 +16230,7 @@ SLES-51548:
   region: "PAL-M3"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes upscaling lines.
+    autoFlush: 2 # Fixes sun penetration.
 SLES-51553:
   name: "Chaos Legion"
   region: "PAL-M5"
@@ -57686,6 +57689,7 @@ SLUS-20337:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes upscaling lines.
+    autoFlush: 2 # Fixes sun penetration.
 SLUS-20339:
   name: "Bass Fishing Duel - Sega Sports"
   region: "NTSC-U"

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -4914,7 +4914,10 @@ bool GSRendererHW::CanUseTexIsFB(const GSTextureCache::Target* rt, const GSTextu
 		// This pattern is used by several games to emulate a stencil (shadow)
 		// Ratchet & Clank, Jak do alpha integer multiplication (tfx) which is mostly equivalent to +1/-1
 		// Tri-Ace (Star Ocean 3/RadiataStories/VP2) uses a palette to handle the +1/-1
-		if (m_cached_ctx.FRAME.FBMSK == 0x00FFFFFF)
+		// Update: This isn't really needed anymore, if you use autoflush, however there's a reasonable speed impact (about 30%) in not using this.
+		// Added the diff check to make sure it's reading the same data seems to be fine for Jak, VP2, Star Ocean, without breaking X2: Wolverine, which broke without that check.
+		const GSVector4 diff(m_vt.m_min.p.upld(m_vt.m_max.p) - m_vt.m_min.t.upld(m_vt.m_max.t));
+		if (m_cached_ctx.FRAME.FBMSK == 0x00FFFFFF && (diff.abs() < GSVector4(1.0f)).alltrue())
 		{
 			GL_CACHE("Tex-is-fb hack for Jak");
 			return true;


### PR DESCRIPTION
### Description of Changes
Avoids speedhacking tex is fb when the draw isn't directly recursive

### Rationale behind Changes
Speedhacks are a great idea, until they aren't.

### Suggested Testing Steps
Test X2: Wolverine / X-Men 2 - Wolverine's Revenge for light penetration

Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/c2bdca66-3b1b-4efa-9855-5f92a31e6bc6)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/17acb8cb-7c38-44f6-98fe-451040f32677)
