### PR TITLE
UI: Add ELF filename filters to IMGUI, All Files to normal open dialog

### DIFF
--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -65,7 +65,8 @@ const char* MainWindow::OPEN_FILE_FILTER =
 									"ELF Executables (*.elf);;"
 									"IRX Executables (*.irx);;"
 									"GS Dumps (*.gs *.gs.xz *.gs.zst);;"
-									"Block Dumps (*.dump)");
+									"Block Dumps (*.dump);;"
+									"All Files (*)");
 
 const char* MainWindow::DISC_IMAGE_FILTER = QT_TRANSLATE_NOOP("MainWindow", "All File Types (*.bin *.iso *.cue *.mdf *.chd *.cso *.zso *.gz *.dump);;"
 																			"Single-Track Raw Images (*.bin *.iso);;"

--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -827,7 +827,7 @@ void FullscreenUI::DestroyResources()
 
 ImGuiFullscreen::FileSelectorFilters FullscreenUI::GetOpenFileFilters()
 {
-	return {"*.bin", "*.iso", "*.cue", "*.mdf", "*.chd", "*.cso", "*.zso", "*.gz", "*.elf", "*.irx", "*.gs", "*.gs.xz", "*.gs.zst", "*.dump"};
+	return {"*.bin", "*.iso", "*.cue", "*.mdf", "*.chd", "*.cso", "*.zso", "*.gz", "*.elf", "*.irx", "*.gs", "*.gs.xz", "*.gs.zst", "*.dump", "ALCH_???.??", "PBPX_???.??", "S???_???.??", "TC?S_???.??"};
 }
 
 ImGuiFullscreen::FileSelectorFilters FullscreenUI::GetDiscImageFilters()


### PR DESCRIPTION
### Description of Changes
Adds more file filters to aid opening ELF files from discs.

### Rationale behind Changes
retail disc ELF files do not have a .elf extension, they are usually 2 numbers as the filename will be for example SLES_123.45, but our current filters did not allow for this. 

With full screen UI we can use wildcards, so I added those (should keep false matches to a bare minimum), for the normal Qt UI I added a new All Files option as there's no way to do wildcards with that, that I can find.

### Suggested Testing Steps
Try loading an ELF from a disc in BPM and normal UI's with the "All Files" filter.

BPM:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/e99fdf4c-8121-4330-908c-82c770969c10)

Normal UI:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/b5f29bcd-78e8-4d15-8cc8-c302f6f71754)
