### PR TITLE
GS/Vulkan: Use fbfetch flag for subpass dependency

### DIFF
--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
@@ -1579,7 +1579,7 @@ VkRenderPass GSDeviceVK::CreateCachedRenderPass(RenderPassCacheKey key)
 				input_reference_ptr = &input_reference;
 			}
 
-			if (!m_optional_extensions.vk_ext_rasterization_order_attachment_access)
+			if (!m_features.framebuffer_fetch)
 			{
 				// don't need the framebuffer-local dependency when we have rasterization order attachment access
 				subpass_dependency.srcSubpass = 0;


### PR DESCRIPTION
### Description of Changes

llvmpipe apparently supports raster order attachment access now, and if you force-disable fbfetch, it wasn't creating the render passes with the self-dependency declared.

### Rationale behind Changes

Spec violations.

### Suggested Testing Steps

Smoke test barriers.
