### PR TITLE
GameDB: Fix Overscan on Crash Twinsanity (PAL)

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -18724,6 +18724,7 @@ SLES-52568:
     - XGKickHack # Fixes bad geometry.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
+    PCRTCOverscan: 1 # Fixes offscreen image.
 SLES-52569:
   name: "Spyro - A Hero's Tail"
   region: "PAL-M6"


### PR DESCRIPTION
### Description of Changes
Makes whole image visible.

### Rationale behind Changes
Top part of the image was cut off.

### Suggested Testing Steps
None.

Before:
![Crash Twinsanity_SLES-52568_20240217190819](https://github.com/PCSX2/pcsx2/assets/35299377/2584223f-5ad3-49af-a75e-463f73e1db9f)

After:
![Crash Twinsanity_SLES-52568_20240217190807](https://github.com/PCSX2/pcsx2/assets/35299377/3b38f577-375b-427b-aac5-c67b2c7bc24a)

