### PR TITLE
ImGuiManager: Defer scale updates

### DIFF
--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -701,7 +701,7 @@ void GSUpdateConfig(const Pcsx2Config::GSOptions& new_config)
 
 	// Handle OSD scale changes by pushing a window resize through.
 	if (new_config.OsdScale != old_config.OsdScale)
-		ImGuiManager::WindowResized();
+		ImGuiManager::RequestScaleUpdate();
 
 	// Options which need a full teardown/recreate.
 	if (!GSConfig.RestartOptionsAreEqual(old_config))

--- a/pcsx2/ImGui/ImGuiManager.h
+++ b/pcsx2/ImGui/ImGuiManager.h
@@ -35,7 +35,7 @@ namespace ImGuiManager
 	void WindowResized();
 
 	/// Updates scaling of the on-screen elements.
-	void UpdateScale();
+	void RequestScaleUpdate();
 
 	/// Call at the beginning of the frame to set up ImGui state.
 	void NewFrame();


### PR DESCRIPTION
### Description of Changes

Fixes OSD spinbox closing on click, and popups closing on window resize.

UpdateScale() was pushing a dummy frame, which would make the popup window inactive -> nav gets reset -> popup gets closed.

### Suggested Testing Steps

Make sure big picture mode isn't broken.
Try resizing window with an option popup open.
Try changing the OSD scale via BP mode.