### PR TITLE
Correctly identify development tool and Namco system 246/256 bios

### DIFF
--- a/pcsx2/ps2/BiosTools.cpp
+++ b/pcsx2/ps2/BiosTools.cpp
@@ -115,7 +115,7 @@ static bool LoadBiosVersion(std::FILE* fp, u32& version, std::string& descriptio
 			// case 'E': zone = "Russia"; region = 3;  break; // Not implemented
 			case 'C': zone = "China";  region = 6;  break;
 			// case 'A': zone = "Mexico"; region = 7;  break; // Not implemented
-			case 'T': zone = "T10K";   region = 8;  break;
+			case 'T': zone = (romver[5]=='Z') ? "COH-H" : "T10K";   region = 8;  break;
 			case 'X': zone = "Test";   region = 9;  break;
 			case 'P': zone = "Free";   region = 10; break;
 			// clang-format on


### PR DESCRIPTION
### Description of Changes
Change the development tool bios detection to be accurate and also detect namco system 246 & system 256 bios files
<!-- Brief description or overview on what was changed in the PR -->

### Rationale behind Changes
I think that detecting a namco rom is important, because due to lots of nonstandard changes (eg: making `rom0:MCMAN` use the same RPC layout than retail `rom0:XMCMAN`) it wont work with any software that uses these files at any given moment. So spotting it right away is useful 
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->

### Suggested Testing Steps
get a devkit bios and a COH-H bios and try if they get detected appropiately
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
