### PR TITLE
Debugger: Memory search increased/decreased/changed + results count

### DIFF
--- a/pcsx2-qt/Debugger/CpuWidget.cpp
+++ b/pcsx2-qt/Debugger/CpuWidget.cpp
@@ -33,7 +33,6 @@
 using namespace QtUtils;
 using namespace MipsStackWalk;
 
-
 CpuWidget::CpuWidget(QWidget* parent, DebugInterface& cpu)
 	: m_cpu(cpu)
 	, m_bpModel(cpu)

--- a/pcsx2-qt/Debugger/CpuWidget.h
+++ b/pcsx2-qt/Debugger/CpuWidget.h
@@ -33,9 +33,6 @@ public:
 	CpuWidget(QWidget* parent, DebugInterface& cpu);
 	~CpuWidget();
 
-
-	// Note: The order of these enum values must reflect the order in thee Search Comparison combobox.
-
 public slots:
 	void paintEvent(QPaintEvent* event);
 
@@ -91,7 +88,6 @@ public slots:
 		m_ui.disassemblyWidget->update();
 		m_ui.memoryviewWidget->update();
 	};
-
 
 	void saveBreakpointsToDebuggerSettings();
 	void saveSavedAddressesToDebuggerSettings();

--- a/pcsx2-qt/Debugger/CpuWidget.ui
+++ b/pcsx2-qt/Debugger/CpuWidget.ui
@@ -180,7 +180,7 @@
           <attribute name="title">
            <string>Memory Search</string>
           </attribute>
-          <layout class="QHBoxLayout" name="horizontalLayout_6">
+          <layout class="QHBoxLayout" name="horizontalLayout_10">
            <property name="spacing">
             <number>0</number>
            </property>

--- a/pcsx2-qt/Debugger/DisassemblyWidget.cpp
+++ b/pcsx2-qt/Debugger/DisassemblyWidget.cpp
@@ -410,7 +410,6 @@ void DisassemblyWidget::paintEvent(QPaintEvent* event)
 	std::vector<BranchLine> branchLines = m_disassemblyManager.getBranchLines(m_visibleStart, visibleEnd - m_visibleStart);
 
 	s32 branchCount = 0;
-	s32 skippedBranches = 0;
 	for (const auto& branchLine : branchLines)
 	{
 		if (branchCount == (m_showInstructionOpcode ? 3 : 5))
@@ -451,12 +450,6 @@ void DisassemblyWidget::paintEvent(QPaintEvent* event)
 		else
 		{
 			bottom = (((branchLine.second - m_visibleStart) / 4) * m_rowHeight) + (m_rowHeight / 2);
-		}
-
-		if ((top < 0 && bottom < 0) || (top > winBottom && bottom > winBottom) || (top < 0 && bottom > winBottom) || (top > winBottom && bottom < 0))
-		{
-			skippedBranches++;
-			continue;
 		}
 
 		branchCount++;

--- a/pcsx2-qt/Debugger/MemorySearchWidget.h
+++ b/pcsx2-qt/Debugger/MemorySearchWidget.h
@@ -9,6 +9,7 @@
 
 #include <QtWidgets/QWidget>
 #include <QtCore/QTimer>
+#include <QtCore/QMap>
 
 class MemorySearchWidget final : public QWidget
 {
@@ -39,12 +40,86 @@ public:
 		GreaterThan,
 		GreaterThanOrEqual,
 		LessThan,
-		LessThanOrEqual
+		LessThanOrEqual,
+		Increased,
+		IncreasedBy,
+		Decreased,
+		DecreasedBy,
+		Changed,
+		ChangedBy,
+		NotChanged,
+		Invalid
+	};
+
+	class SearchComparisonLabelMap
+	{
+	public:
+		SearchComparisonLabelMap()
+		{
+			insert(SearchComparison::Equals, tr("Equals"));
+			insert(SearchComparison::NotEquals, tr("Not Equals"));
+			insert(SearchComparison::GreaterThan, tr("Greater Than"));
+			insert(SearchComparison::GreaterThanOrEqual, tr("Greater Than Or Equal"));
+			insert(SearchComparison::LessThan, tr("Less Than"));
+			insert(SearchComparison::LessThanOrEqual, tr("Less Than Or Equal"));
+			insert(SearchComparison::Increased, tr("Increased"));
+			insert(SearchComparison::IncreasedBy, tr("Increased By"));
+			insert(SearchComparison::Decreased, tr("Decreased"));
+			insert(SearchComparison::DecreasedBy, tr("Decreased By"));
+			insert(SearchComparison::Changed, tr("Changed"));
+			insert(SearchComparison::ChangedBy, tr("Changed By"));
+			insert(SearchComparison::NotChanged, tr("Not Changed"));
+			insert(SearchComparison::Invalid, "");
+		}
+		SearchComparison labelToEnum(QString comparisonLabel)
+		{
+			return labelToEnumMap.value(comparisonLabel, SearchComparison::Invalid);
+		}
+		QString enumToLabel(SearchComparison comparison) {
+			return enumToLabelMap.value(comparison, "");
+		}
+	private:
+		QMap<SearchComparison, QString> enumToLabelMap;
+		QMap<QString, SearchComparison> labelToEnumMap;
+		void insert(SearchComparison comparison, QString comparisonLabel)
+		{
+			enumToLabelMap.insert(comparison, comparisonLabel);
+			labelToEnumMap.insert(comparisonLabel, comparison);
+		};
+	};
+
+	class SearchResult
+	{
+	private:
+		u32 address;
+		QVariant value;
+		SearchType type;
+
+	public:
+		SearchResult() {}
+		SearchResult(u32 address, const QVariant& value, SearchType type)
+			: address(address), value(value), type(type)
+		{
+		}
+		bool isIntegerValue() const { return type == SearchType::ByteType || type == SearchType::Int16Type || type == SearchType::Int32Type || type == SearchType::Int64Type; }
+		bool isFloatValue() const { return type == SearchType::FloatType; }
+		bool isDoubleValue() const { return type == SearchType::DoubleType; }
+		bool isArrayValue() const { return type == SearchType::ArrayType || type == SearchType::StringType; }
+		u32 getAddress() const { return address; }
+		SearchType getType() const { return type; }
+		QByteArray getArrayValue() const { return isArrayValue() ? value.toByteArray() : QByteArray(); }
+
+		template<typename T>
+		T getValue() const
+		{
+			return value.value<T>();
+		}
 	};
 
 public slots:
 	void onSearchButtonClicked();
 	void onSearchResultsListScroll(u32 value);
+	void onSearchTypeChanged(int newIndex);
 	void loadSearchResults();
 	void contextSearchResultGoToDisassembly();
 	void contextRemoveSearchResult();
@@ -58,13 +133,17 @@ signals:
 	void switchToMemoryViewTab();
 
 private:
-    std::vector<u32> m_searchResults;
+	QMap<u32, SearchResult> m_searchResultsMap;
+	SearchComparisonLabelMap m_searchComparisonLabelMap;
+	Ui::MemorySearchWidget m_ui;
+	DebugInterface* m_cpu;
+	QTimer m_resultsLoadTimer;
 
-    Ui::MemorySearchWidget m_ui;
-
-    DebugInterface* m_cpu;
-    QTimer m_resultsLoadTimer;
-
-    u32 m_initialResultsLoadLimit = 20000;
+	u32 m_initialResultsLoadLimit = 20000;
 	u32 m_numResultsAddedPerLoad = 10000;
+
+	void updateSearchComparisonSelections();
+	std::vector<SearchComparison> getValidSearchComparisonsForState(SearchType type, QMap<u32, MemorySearchWidget::SearchResult> existingResults);
+	SearchType getCurrentSearchType();
+	SearchComparison getCurrentSearchComparison();
 };

--- a/pcsx2-qt/Debugger/MemorySearchWidget.ui
+++ b/pcsx2-qt/Debugger/MemorySearchWidget.ui
@@ -22,7 +22,7 @@
    <item>
     <layout class="QGridLayout" name="gridLayout_2">
      <item row="0" column="0">
-      <widget class="QLabel" name="label">
+      <widget class="QLabel" name="valueLabel">
        <property name="text">
         <string>Value</string>
        </property>
@@ -32,7 +32,7 @@
       <widget class="QLineEdit" name="txtSearchValue"/>
      </item>
      <item row="2" column="0">
-      <widget class="QLabel" name="label_2">
+      <widget class="QLabel" name="typeLabel">
        <property name="text">
         <string>Type</string>
        </property>
@@ -83,7 +83,7 @@
       </widget>
      </item>
      <item row="2" column="2">
-      <widget class="QLabel" name="label_3">
+      <widget class="QLabel" name="hexLabel">
        <property name="text">
         <string>Hex</string>
        </property>
@@ -162,7 +162,7 @@
    <item>
     <layout class="QGridLayout" name="gridLayout_3">
      <item row="0" column="0" alignment="Qt::AlignLeft">
-      <widget class="QLabel" name="label_4">
+      <widget class="QLabel" name="startLabel">
        <property name="text">
         <string>Start</string>
        </property>
@@ -176,7 +176,7 @@
       </widget>
      </item>
      <item row="0" column="2">
-      <widget class="QLabel" name="label_5">
+      <widget class="QLabel" name="endLabel">
        <property name="text">
         <string>End</string>
        </property>
@@ -193,6 +193,16 @@
    </item>
    <item>
     <widget class="QListWidget" name="listSearchResults"/>
+   </item>
+   <item>
+    <widget class="QLabel" name="resultsCountLabel">
+     <property name="visible">
+      <bool>false</bool>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
- For Int/Float types, adds the following search comparisons: `Increased, Increased By, Decreased, Decreased By, Changed, Changed By, Not Changed`.
- For String/Array types, adds the following search comparisons (when **_filtering_**): `Not Equals, Changed, Not Changed` 
- Shows `Searching...` when a memory search is in progress, and `<number> results found` on search completion.
- Now only displays the comparison types that are valid for the given selected search state. If a comparison type is not supported for a type it will not appear, and if a comparison type requires search results to filter, it will not appear until a search has been performed.
- Switching search types disables filter search until a new search is performed. (Can't search for ints, then filter by float or string. If you want to filter, stick to the same type you did your initial search with).

Refactors how search results are stored so that we can identify the prior value of a search result to compare against when filtering (as is required for all of the new search comparisons).

Adds a 2 way lookup table so that we can manage which comparison types are in the `QComboBox` since we can no longer convert the selection index directly to an enum since the options change depending on the selected search type and if there are existing results that match the current search type.

### Rationale behind Changes
- Being able to search for increased/decreased/changed/not changed makes it significantly easier to filter to find the memory addresses one is looking for.
- Displaying results count makes it easier to see if your filters are making an impact, and makes it more clear when the debugger is still searching.
- Displaying only the currently use-able comparison types reduces visual pollution when selecting a comparison and avoids confusing warnings that a comparison can't be used for X or Y reason. There are a lot of comparison types now, and few apply to string/array for example (and about half only apply once an initial search occurs). (Also fixes #10480)

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
This impacts all search types/comparisons. Thorough testing/sanity checking of search results would be excellent.
I highly recommend testing with at least one integer type (e.g. 16 bit), at least one decimal type (decimal or float), and at least one array style type (string or array) as these are each handled different from each other in some ways.

### Note:
Some minor cleanup of comments, and renaming of some `.ui` components that had generic names.

### Quick Demonstrations
<details>
<summary>Increased/Decreased/Changed (and results count)</summary>
<img src='https://github.com/PCSX2/pcsx2/assets/4957200/7957d014-9b86-4d56-a948-27ade7653a49'/>
</details>

<details>
<summary>Array/String comparison options when filtering</summary>
<img src='https://github.com/PCSX2/pcsx2/assets/4957200/7541625d-821e-4224-92e3-c7070298be29'/>
</details>

<details>
<summary>Showing comparisons that are for filtering only *only after* initial search</summary>
<img src='https://github.com/PCSX2/pcsx2/assets/4957200/ee07cb7e-f793-4af2-adf7-0656c11b7e2e'/>
</details>


