### PR TITLE
Debugger: Fixes crash on debugger open when cpu not alive

### DIFF
--- a/pcsx2-qt/Debugger/DisassemblyWidget.cpp
+++ b/pcsx2-qt/Debugger/DisassemblyWidget.cpp
@@ -746,12 +746,12 @@ inline QString DisassemblyWidget::DisassemblyStringFromAddress(u32 address, QFon
 	const bool isCurrentPC = m_cpu->getPC() == address;
 
 	const std::string addressSymbol = m_cpu->GetSymbolMap().GetLabelName(address);
-	const u32 opcode = m_cpu->read32(address);
 
 	const auto demangler = demangler::CDemangler::createGcc();
+	const bool showOpcode = m_showInstructionOpcode && m_cpu->isAlive();
 
 	QString lineString;
-	if (m_showInstructionOpcode)
+	if (showOpcode)
 	{
 		lineString = QString("  %1 %2  %3 %4  %5 %6");
 	}
@@ -783,8 +783,11 @@ inline QString DisassemblyWidget::DisassemblyStringFromAddress(u32 address, QFon
 		lineString = lineString.arg(metric.elidedText(symbolString, Qt::ElideRight, (selected ? 32.0f : 7.5f) * font.pointSize()));
 	}
 
-	if (m_showInstructionOpcode)
+	if (showOpcode)
+	{
+		const u32 opcode = m_cpu->read32(address);
 		lineString = lineString.arg(QtUtils::FilledQStringFromValue(opcode, 16));
+	}
 
 	lineString = lineString.leftJustified(4, ' ') // Address / symbol
 					 .arg(line.name.c_str())


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
The debugger was crashing on open if no game was running due to failing to read from the CPU while the cpu was not alive.

The opcode was read before checking if it should be shown, so I have moved it to only read if the showOpcode boolean is true, and set it to not show opcodes if the cpu is not alive.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Less crash more good.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Open the debugger without opening a game, should open fine now.