### PR TITLE
Qt: Fix deprecated Key_mu

### DIFF
--- a/pcsx2-qt/QtKeyCodes.cpp
+++ b/pcsx2-qt/QtKeyCodes.cpp
@@ -182,7 +182,7 @@ static constexpr const KeyCodeName s_qt_key_names[] = {
 	{Qt::Key_twosuperior, "twosuperior", nullptr},
 	{Qt::Key_threesuperior, "threesuperior", nullptr},
 	{Qt::Key_acute, "acute", nullptr},
-	{Qt::Key_mu, "mu", nullptr},
+	{Qt::Key_micro, "micro", nullptr},
 	{Qt::Key_paragraph, "paragraph", nullptr},
 	{Qt::Key_periodcentered, "periodcentered", nullptr},
 	{Qt::Key_cedilla, "cedilla", nullptr},


### PR DESCRIPTION
### Description of Changes
Replaced Key_mu with Key_micro

### Rationale behind Changes
Qt misnamed Key_mu and deprecated it. The warning emitted was such:
`warning: 'Key_mu' is deprecated: This key was misnamed, use Key_micro instead [-Wdeprecated-declarations]`

### Suggested Testing Steps
See if the CI passes without -Wdeprecated-declarations warnings
