### PR TITLE
DebugTools: Add noreturn heuristic

### DIFF
--- a/pcsx2-qt/Debugger/DisassemblyWidget.cpp
+++ b/pcsx2-qt/Debugger/DisassemblyWidget.cpp
@@ -745,19 +745,33 @@ inline QString DisassemblyWidget::DisassemblyStringFromAddress(u32 address, QFon
 	const bool isConditionalMet = line.info.conditionMet;
 	const bool isCurrentPC = m_cpu->getPC() == address;
 
-	const std::string addressSymbol = m_cpu->GetSymbolMap().GetLabelName(address);
+	bool isFunctionNoReturn = false;
 
+	const std::string addressSymbol = m_cpu->GetSymbolMap().GetLabelName(address);
+	if(m_cpu->GetSymbolMap().GetFunctionStart(address) == address)
+	{
+		isFunctionNoReturn = m_cpu->GetSymbolMap().GetFunctionNoReturn(address);
+	}
 	const auto demangler = demangler::CDemangler::createGcc();
 	const bool showOpcode = m_showInstructionOpcode && m_cpu->isAlive();
 
 	QString lineString;
 	if (showOpcode)
 	{
-		lineString = QString("  %1 %2  %3 %4  %5 %6");
+		lineString = QString(" %1 %2 %3  %4 %5  %6 %7");
 	}
 	else
 	{
-		lineString = QString("  %1  %2 %3  %4 %5");
+		lineString = QString(" %1 %2  %3 %4  %5 %6");
+	}
+
+	if(isFunctionNoReturn)
+	{
+		lineString = lineString.arg("NR");
+	}
+	else
+	{
+		lineString = lineString.arg("  ");
 	}
 
 	if (addressSymbol.empty()) // The address wont have symbol text if it's the start of a function for example
@@ -780,7 +794,7 @@ inline QString DisassemblyWidget::DisassemblyStringFromAddress(u32 address, QFon
 			symbolString = QString::fromStdString(addressSymbol);
 		}
 
-		lineString = lineString.arg(metric.elidedText(symbolString, Qt::ElideRight, (selected ? 32.0f : 7.5f) * font.pointSize()));
+		lineString = lineString.arg(metric.elidedText(symbolString, Qt::ElideRight, (selected ? 32 : 7) * font.pointSize()));
 	}
 
 	if (showOpcode)

--- a/pcsx2/DebugTools/MIPSAnalyst.h
+++ b/pcsx2/DebugTools/MIPSAnalyst.h
@@ -25,6 +25,7 @@ namespace MIPSAnalyst
 		u32 size;
 		bool isStraightLeaf;
 		bool hasHash;
+		bool suspectedNoReturn;
 		bool usesVFPU;
 		char name[64];
 	};

--- a/pcsx2/DebugTools/SymbolMap.cpp
+++ b/pcsx2/DebugTools/SymbolMap.cpp
@@ -241,7 +241,7 @@ std::vector<SymbolEntry> SymbolMap::GetAllSymbols(SymbolType symmask) const
 	return result;
 }
 
-void SymbolMap::AddFunction(const std::string& name, u32 address, u32 size)
+void SymbolMap::AddFunction(const std::string& name, u32 address, u32 size, bool noReturn)
 {
 	std::lock_guard<std::recursive_mutex> guard(m_lock);
 
@@ -258,6 +258,7 @@ void SymbolMap::AddFunction(const std::string& name, u32 address, u32 size)
 		func.size = size;
 		func.index = (int)functions.size();
 		func.name = name;
+		func.noReturn = noReturn;
 		functions[address] = func;
 
 		functions.insert(std::make_pair(address, func));
@@ -319,6 +320,16 @@ int SymbolMap::GetFunctionNum(u32 address) const
 		return INVALID_ADDRESS;
 
 	return it->second.index;
+}
+
+bool SymbolMap::GetFunctionNoReturn(u32 address) const
+{
+	std::lock_guard<std::recursive_mutex> guard(m_lock);
+	auto it = functions.find(address);
+	if (it == functions.end())
+		return false;
+
+	return it->second.noReturn;
 }
 
 void SymbolMap::AssignFunctionIndices()

--- a/pcsx2/DebugTools/SymbolMap.h
+++ b/pcsx2/DebugTools/SymbolMap.h
@@ -72,9 +72,10 @@ public:
 	std::string GetDescription(unsigned int address) const;
 	std::vector<SymbolEntry> GetAllSymbols(SymbolType symmask) const;
 
-	void AddFunction(const std::string& name, u32 address, u32 size);
+	void AddFunction(const std::string& name, u32 address, u32 size, bool noReturn = false);
 	u32 GetFunctionStart(u32 address) const;
 	int GetFunctionNum(u32 address) const;
+	bool GetFunctionNoReturn(u32 address) const;
 	u32 GetFunctionSize(u32 startAddress) const;
 	bool SetFunctionSize(u32 startAddress, u32 newSize);
 	bool RemoveFunction(u32 startAddress);
@@ -113,6 +114,7 @@ private:
 		u32 size;
 		int index;
 		std::string name;
+		bool noReturn;
 	};
 
 	struct LabelEntry


### PR DESCRIPTION
### Description of Changes
Fixes #2836
Also adds "NR" to the disassembly dialog when a function is suspected to noreturn.
I'm thinking in the future it would be nice to detect a function epilogue after noreturn functions. If there is no epilogue, it still is technically part of the function despite it being 'technically' impossible to reach. 

### Rationale behind Changes
When searching through functions, there were no heuristics for noreturn function. This would cause the function to sometimes merge into the next.

### Suggested Testing Steps
Look at some non-returning functions and see if they are separated from the next function.

---

Here is an example of these changes

![image](https://github.com/PCSX2/pcsx2/assets/29295048/b4cccbf8-1c2f-4c71-9628-5a9059baf50a)
Before, this would be one long function.
