### PR TITLE
Debugger: Add automatic refreshing on 1 second interval

### DIFF
--- a/pcsx2-qt/Debugger/CpuWidget.cpp
+++ b/pcsx2-qt/Debugger/CpuWidget.cpp
@@ -142,9 +142,24 @@ CpuWidget::CpuWidget(QWidget* parent, DebugInterface& cpu)
 	connect(m_ui.memorySearchWidget, &MemorySearchWidget::goToAddressInMemoryView, m_ui.memoryviewWidget, &MemoryViewWidget::gotoAddress);
 	connect(m_ui.memorySearchWidget, &MemorySearchWidget::switchToMemoryViewTab, [this]() { m_ui.tabWidget->setCurrentWidget(m_ui.tab_memory); });
 	m_ui.memorySearchWidget->setCpu(&m_cpu);
+
+	m_refreshDebuggerTimer.setInterval(1000);
+	connect(&m_refreshDebuggerTimer, &QTimer::timeout, this, &CpuWidget::refreshDebugger);
+	m_refreshDebuggerTimer.start();
 }
 
 CpuWidget::~CpuWidget() = default;
+
+void CpuWidget::refreshDebugger()
+{
+	if (m_cpu.isAlive())
+	{
+		m_ui.registerWidget->update();
+		m_ui.disassemblyWidget->update();
+		m_ui.memoryviewWidget->update();
+		m_ui.memorySearchWidget->update();
+	}
+}
 
 void CpuWidget::paintEvent(QPaintEvent* event)
 {

--- a/pcsx2-qt/Debugger/CpuWidget.h
+++ b/pcsx2-qt/Debugger/CpuWidget.h
@@ -74,6 +74,7 @@ public slots:
 	bool getDemangleFunctions() const { return m_demangleFunctions; }
 	void onModuleTreeContextMenu(QPoint pos);
 	void onModuleTreeDoubleClick(QTreeWidgetItem* item);
+	void refreshDebugger();
 	void reloadCPUWidgets()
 	{
 		if (!QtHost::IsOnUIThread())
@@ -101,6 +102,7 @@ private:
 	QMenu* m_stacklistContextMenu = 0;
 	QMenu* m_funclistContextMenu = 0;
 	QMenu* m_moduleTreeContextMenu = 0;
+	QTimer m_refreshDebuggerTimer;
 
 	Ui::CpuWidget m_ui;
 


### PR DESCRIPTION
Implements #10840
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
The debugger now refreshes/updates it's widgets once a second so that the user does not need to interact with the debugger to know when data/state changes.

![PCSX2 - Auto-Refresh](https://github.com/PCSX2/pcsx2/assets/4957200/79a207f8-a05c-4ca6-a8de-9e1ebc7692a5)

Note: I am also considering eventually allowing the user to configure this interval, however have not implemented it here. It is fixed to a one second interval agreed upon in #10840.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Allows the user to watch data/state changes without intervention/interaction.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Validating everything that should be updating gets updated while the cpu is alive.
