### PR TITLE
Qt/PAD: Enable/Disable Player LED for DualSense Controllers in Enhanced mode

### DIFF
--- a/pcsx2-qt/Settings/ControllerGlobalSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/ControllerGlobalSettingsWidget.cpp
@@ -144,6 +144,9 @@ ControllerLEDSettingsDialog::ControllerLEDSettingsDialog(QWidget* parent, Contro
 	linkButton(m_ui.SDL2LED, 2);
 	linkButton(m_ui.SDL3LED, 3);
 
+	SettingsInterface* sif = dialog->getProfileSettingsInterface();
+
+	ControllerSettingWidgetBinder::BindWidgetToInputProfileBool(sif, m_ui.enableSDLPS5PlayerLED, "InputSources", "SDLPS5PlayerLED", false);
 	connect(m_ui.buttonBox->button(QDialogButtonBox::Close), &QPushButton::clicked, this, &QDialog::accept);
 }
 

--- a/pcsx2-qt/Settings/ControllerLEDSettingsDialog.ui
+++ b/pcsx2-qt/Settings/ControllerLEDSettingsDialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>501</width>
-    <height>108</height>
+    <height>128</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -26,14 +26,14 @@
      </layout>
     </widget>
    </item>
-   <item row="0" column="1">
-    <widget class="QGroupBox" name="groupBox_2">
+   <item row="0" column="3">
+    <widget class="QGroupBox" name="groupBox_4">
      <property name="title">
-      <string>SDL-1 LED</string>
+      <string>SDL-3 LED</string>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout_3">
+     <layout class="QVBoxLayout" name="verticalLayout">
       <item>
-       <widget class="ColorPickerButton" name="SDL1LED"/>
+       <widget class="ColorPickerButton" name="SDL3LED"/>
       </item>
      </layout>
     </widget>
@@ -50,24 +50,53 @@
      </layout>
     </widget>
    </item>
-   <item row="0" column="3">
-    <widget class="QGroupBox" name="groupBox_4">
+   <item row="0" column="1">
+    <widget class="QGroupBox" name="groupBox_2">
      <property name="title">
-      <string>SDL-3 LED</string>
+      <string>SDL-1 LED</string>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
+     <layout class="QVBoxLayout" name="verticalLayout_3">
       <item>
-       <widget class="ColorPickerButton" name="SDL3LED"/>
+       <widget class="ColorPickerButton" name="SDL1LED"/>
       </item>
      </layout>
     </widget>
    </item>
-   <item row="1" column="0" colspan="4">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Close</set>
+   <item row="3" column="0" colspan="4">
+    <layout class="QHBoxLayout" name="horizontalLayout" stretch="1,0">
+     <property name="sizeConstraint">
+      <enum>QLayout::SetDefaultConstraint</enum>
      </property>
-    </widget>
+     <property name="bottomMargin">
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="QCheckBox" name="enableSDLPS5PlayerLED">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Enable DualSense Player LED</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QDialogButtonBox" name="buttonBox">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="standardButtons">
+        <set>QDialogButtonBox::Close</set>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>

--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -3916,6 +3916,9 @@ void FullscreenUI::DrawControllerSettingsPage()
 	DrawToggleSetting(bsi, FSUI_ICONSTR(ICON_FA_WIFI, "SDL DualShock 4 / DualSense Enhanced Mode"),
 		FSUI_CSTR("Provides vibration and LED control support over Bluetooth."), "InputSources", "SDLControllerEnhancedMode", false,
 		bsi->GetBoolValue("InputSources", "SDL", true), false);
+	DrawToggleSetting(bsi, FSUI_ICONSTR(ICON_FA_LIGHTBULB, "SDL DualSense Player LED"),
+		FSUI_CSTR("Enable/Disable the Player LED on DualSense controllers."), "InputSources", "SDLPS5PlayerLED", false,
+		bsi->GetBoolValue("InputSources", "SDLControllerEnhancedMode", true), false);
 #ifdef _WIN32
 	DrawToggleSetting(bsi, FSUI_ICONSTR(ICON_FA_COG, "SDL Raw Input"), FSUI_CSTR("Allow SDL to use raw access to input devices."),
 		"InputSources", "SDLRawInput", false, bsi->GetBoolValue("InputSources", "SDL", true), false);

--- a/pcsx2/Input/SDLInputSource.cpp
+++ b/pcsx2/Input/SDLInputSource.cpp
@@ -158,6 +158,7 @@ bool SDLInputSource::Initialize(SettingsInterface& si, std::unique_lock<std::mut
 void SDLInputSource::UpdateSettings(SettingsInterface& si, std::unique_lock<std::mutex>& settings_lock)
 {
 	const bool old_controller_enhanced_mode = m_controller_enhanced_mode;
+	const bool old_controller_ps5_player_led = m_controller_ps5_player_led;
 	const bool old_controller_raw_mode = m_controller_raw_mode;
 
 #ifdef __APPLE__
@@ -175,6 +176,7 @@ void SDLInputSource::UpdateSettings(SettingsInterface& si, std::unique_lock<std:
 #endif
 
 	if (m_controller_enhanced_mode != old_controller_enhanced_mode ||
+		m_controller_ps5_player_led != old_controller_ps5_player_led ||
 		m_controller_raw_mode != old_controller_raw_mode ||
 		drivers_changed)
 	{
@@ -218,6 +220,7 @@ void SDLInputSource::LoadSettings(SettingsInterface& si)
 	m_sdl_hints = si.GetKeyValueList("SDLHints");
 
 	m_controller_enhanced_mode = si.GetBoolValue("InputSources", "SDLControllerEnhancedMode", false);
+	m_controller_ps5_player_led = si.GetBoolValue("InputSources", "SDLPS5PlayerLED", false);
 	m_controller_raw_mode = si.GetBoolValue("InputSources", "SDLRawInput", false);
 
 #ifdef __APPLE__
@@ -264,6 +267,7 @@ void SDLInputSource::SetHints()
 	SDL_SetHint(SDL_HINT_JOYSTICK_RAWINPUT, m_controller_raw_mode ? "1" : "0");
 	SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_PS4_RUMBLE, m_controller_enhanced_mode ? "1" : "0");
 	SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_PS5_RUMBLE, m_controller_enhanced_mode ? "1" : "0");
+	SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_PS5_PLAYER_LED, m_controller_ps5_player_led ? "1" : "0");
 	// Enable Wii U Pro Controller support
 	SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_WII, "1");
 #ifndef _WIN32

--- a/pcsx2/Input/SDLInputSource.h
+++ b/pcsx2/Input/SDLInputSource.h
@@ -93,6 +93,7 @@ private:
 	bool m_sdl_subsystem_initialized = false;
 	bool m_controller_enhanced_mode = false;
 	bool m_controller_raw_mode = false;
+	bool m_controller_ps5_player_led = false;
 
 #ifdef __APPLE__
 	bool m_enable_iokit_driver = false;

--- a/pcsx2/SIO/Pad/Pad.cpp
+++ b/pcsx2/SIO/Pad/Pad.cpp
@@ -159,6 +159,7 @@ void Pad::SetDefaultControllerConfig(SettingsInterface& si)
 			InputManager::GetInputSourceDefaultEnabled(static_cast<InputSourceType>(i)));
 	}
 	si.SetBoolValue("InputSources", "SDLControllerEnhancedMode", false);
+	si.SetBoolValue("InputSources", "SDLPS5PlayerLED", false);
 	si.SetBoolValue("Pad", "MultitapPort1", false);
 	si.SetBoolValue("Pad", "MultitapPort2", false);
 	si.SetFloatValue("Pad", "PointerXScale", 8.0f);
@@ -329,6 +330,7 @@ void Pad::CopyConfiguration(SettingsInterface* dest_si, const SettingsInterface&
 				InputManager::InputSourceToString(static_cast<InputSourceType>(i)));
 		}
 		dest_si->CopyBoolValue(src_si, "InputSources", "SDLControllerEnhancedMode");
+		dest_si->CopyBoolValue(src_si, "InputSources", "SDLPS5PlayerLED");
 	}
 
 	for (u32 port = 0; port < Pad::NUM_CONTROLLER_PORTS; port++)


### PR DESCRIPTION
### Description of Changes
This change adds a toggle to enable/disable the Player LED on DualSense controllers.
Not to be confused with the primary LED. The Player LED is a non-customizable bright white array of white LEDs that indicate the player number. Image of before and after.
![image](https://github.com/PCSX2/pcsx2/assets/14857235/cab139dd-da38-4a70-9327-0d8af3afa1e6)

The UI change is added to the LEDSettingsDialog
![image](https://github.com/PCSX2/pcsx2/assets/14857235/68d01c5b-5e5d-4113-b958-530246330089)


### Rationale behind Changes
* RAW mode does not have Player LEDs on.
* Turning on Enhanced Mode turns on the Player LED in addition to the primary LED.
* There is no option to disable the Player LEDs currently. You can only customize the primary LED.
* A user may want to completely disable all LEDs on their controller. Currently you can disable the Primary LED but not the Player LED. This is distracting/bright when playing in low lighting conditions.
* You can already tell which player is which due to the customized primary LED colors.


### Suggested Testing Steps
1. Connect DualSense controller. Note the player LED is off.
2. Turn on Enhanced DS4/DS5 mode under the PCSX2 Controller Settings.
-- if on master --
3. Note the Player LED is ON. You can customize the Main LED but not the Player LED.
-- if on this branch --
3. Note the Player LED is still OFF.
4. Enter the LED Settings Dialog (The lightbulb icon) and utilize the new Checkbox. You should see all connected controllers enable/disable their player indicator LEDs. You can customize the Main LED per-controller as usual.