### PR TITLE
GameDB: FIFA Street 2 Fixes

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -12720,6 +12720,9 @@ SLED-53953:
     - GIFFIFOHack # Fixes flag corruptions.
   speedHacks:
     eeCycleRate: 3 # Fixes corrupted graphics.
+  gsHWFixes:
+    cpuSpriteRenderBW: 2 # Fixes broken icons on HUD.
+    cpuSpriteRenderLevel: 2 # Needed for above.
 SLED-53954:
   name: "Driver - Parallel Lines [Demo]"
   region: "PAL-E"
@@ -22663,6 +22666,9 @@ SLES-53796:
     - GIFFIFOHack # Fixes flag corruptions.
   speedHacks:
     eeCycleRate: 3 # Fixes corrupted graphics.
+  gsHWFixes:
+    cpuSpriteRenderBW: 2 # Fixes broken icons on HUD.
+    cpuSpriteRenderLevel: 2 # Needed for above.
 SLES-53797:
   name: "FIFA Street 2"
   region: "PAL-M6"
@@ -22670,6 +22676,9 @@ SLES-53797:
     - GIFFIFOHack # Fixes flag corruptions.
   speedHacks:
     eeCycleRate: 3 # Fixes corrupted graphics.
+  gsHWFixes:
+    cpuSpriteRenderBW: 2 # Fixes broken icons on HUD.
+    cpuSpriteRenderLevel: 2 # Needed for above.
 SLES-53799:
   name: "The Matrix - Path of Neo"
   name-sort: "Matrix, The - Path of Neo"
@@ -29725,6 +29734,9 @@ SLKA-25374:
     - GIFFIFOHack # Fixes flag corruptions.
   speedHacks:
     eeCycleRate: 3 # Fixes corrupted graphics.
+  gsHWFixes:
+    cpuSpriteRenderBW: 2 # Fixes broken icons on HUD.
+    cpuSpriteRenderLevel: 2 # Needed for above.
 SLKA-25375:
   name: "Transformers - The Game"
   region: "NTSC-K"
@@ -44134,6 +44146,9 @@ SLPM-66443:
     - GIFFIFOHack # Fixes flag corruptions.
   speedHacks:
     eeCycleRate: 3 # Fixes corrupted graphics.
+  gsHWFixes:
+    cpuSpriteRenderBW: 2 # Fixes broken icons on HUD.
+    cpuSpriteRenderLevel: 2 # Needed for above.
 SLPM-66444:
   name: スパルタン 〜古代ギリシャ英雄伝〜
   name-sort: すぱるたん こだいぎりしゃえいゆうでん
@@ -64255,6 +64270,9 @@ SLUS-21369:
     - GIFFIFOHack # Fixes flag corruptions.
   speedHacks:
     eeCycleRate: 3 # Fixes corrupted graphics.
+  gsHWFixes:
+    cpuSpriteRenderBW: 2 # Fixes broken icons on HUD.
+    cpuSpriteRenderLevel: 2 # Needed for above.
 SLUS-21370:
   name: "Mega Man X Collection"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
Fixes broken HUD icons during gameplay. Fixes #10859 

Master:
![image](https://github.com/PCSX2/pcsx2/assets/80843560/0e8ab075-e59a-480c-ab28-830709711407)

PR:
![image](https://github.com/PCSX2/pcsx2/assets/80843560/640d6fe1-9943-4b44-95ec-b24dbfa00689)

### Rationale behind Changes
Less broke more good.

### Suggested Testing Steps
Make sure CI is happy boy.
