### PR TITLE
Qt: Allow higher Internal Resolution values up to 12×

### DIFF
--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -142,10 +142,11 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* dialog, QWidget* 
 	// HW Settings
 	//////////////////////////////////////////////////////////////////////////
 	static const char* upscale_entries[] = {"Native (PS2) (Default)", "1.25x Native", "1.5x Native", "1.75x Native", "2x Native (~720p)",
-		"2.25x Native", "2.5x Native", "2.75x Native", "3x Native (~1080p)", "3.5x Native", "4x Native (~1440p/2K)", "5x Native (~1620p)",
-		"6x Native (~2160p/4K)", "7x Native (~2520p)", "8x Native (~2880p/5K)", nullptr};
+		"2.25x Native", "2.5x Native", "2.75x Native", "3x Native (~1080p)", "3.5x Native", "4x Native (~1440p/2K)", "5x Native (~1800p)",
+		"6x Native (~2160p/4K)", "7x Native (~2520p)", "8x Native (~2880p/5K)", "9x Native (~3240p)", "10x Native (~3600p)",
+		"11x Native (~3960p)", "12x Native (~4320p/8K)", nullptr};
 	static const char* upscale_values[] = {
-		"1", "1.25", "1.5", "1.75", "2", "2.25", "2.5", "2.75", "3", "3.5", "4", "5", "6", "7", "8", nullptr};
+		"1", "1.25", "1.5", "1.75", "2", "2.25", "2.5", "2.75", "3", "3.5", "4", "5", "6", "7", "8", "9", "10", "11", "12", nullptr};
 	SettingWidgetBinder::BindWidgetToEnumSetting(
 		sif, m_ui.upscaleMultiplier, "EmuCore/GS", "upscale_multiplier", upscale_entries, upscale_values, "1.0");
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.textureFiltering, "EmuCore/GS", "filter", static_cast<int>(BiFiltering::PS2));
@@ -472,7 +473,10 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* dialog, QWidget* 
 		dialog->registerWidgetHelp(m_ui.upscaleMultiplier, tr("Internal Resolution"), tr("Native (PS2) (Default)"),
 			tr("Control the resolution at which games are rendered. High resolutions can impact performance on "
 			   "older or lower-end GPUs.<br>Non-native resolution may cause minor graphical issues in some games.<br>"
-			   "FMV resolution will remain unchanged, as the video files are pre-rendered."));
+			   "FMV resolution will remain unchanged, as the video files are pre-rendered.<br><br>"
+			   "If the resolution scale is much higher than the output window size, you may see aliasing "
+			   "resulting from a lack of proper downsampling. To resolve this, go to the <b>Post-Processing</b> "
+			   "section and set <b>TV Shader</b> to <b>4xRGSS downsampling</b> or <b>NxAGSS downsampling</b>."));
 
 		dialog->registerWidgetHelp(
 			m_ui.mipmapping, tr("Mipmapping"), tr("Automatic (Default)"), tr("Control the accuracy level of the mipmapping emulation."));

--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -3134,10 +3134,14 @@ void FullscreenUI::DrawGraphicsSettingsPage()
 		FSUI_NSTR("3x Native (~1080p)"),
 		FSUI_NSTR("3.5x Native"),
 		FSUI_NSTR("4x Native (~1440p/2K)"),
-		FSUI_NSTR("5x Native (~1620p)"),
+		FSUI_NSTR("5x Native (~1800p)"),
 		FSUI_NSTR("6x Native (~2160p/4K)"),
 		FSUI_NSTR("7x Native (~2520p)"),
 		FSUI_NSTR("8x Native (~2880p)"),
+		FSUI_NSTR("9x Native (~3240p)"),
+		FSUI_NSTR("10x Native (~3600p)"),
+		FSUI_NSTR("11x Native (~3960p)"),
+		FSUI_NSTR("12x Native (~4320p/8K)"),
 	};
 	static const char* s_resolution_values[] = {
 		"1",
@@ -3155,6 +3159,10 @@ void FullscreenUI::DrawGraphicsSettingsPage()
 		"6",
 		"7",
 		"8",
+		"9",
+		"10",
+		"11",
+		"12",
 	};
 	static constexpr const char* s_mipmapping_options[] = {
 		FSUI_NSTR("Automatic (Default)"),
@@ -6961,10 +6969,14 @@ TRANSLATE_NOOP("FullscreenUI", "2.75x Native");
 TRANSLATE_NOOP("FullscreenUI", "3x Native (~1080p)");
 TRANSLATE_NOOP("FullscreenUI", "3.5x Native");
 TRANSLATE_NOOP("FullscreenUI", "4x Native (~1440p/2K)");
-TRANSLATE_NOOP("FullscreenUI", "5x Native (~1620p)");
+TRANSLATE_NOOP("FullscreenUI", "5x Native (~1800p)");
 TRANSLATE_NOOP("FullscreenUI", "6x Native (~2160p/4K)");
 TRANSLATE_NOOP("FullscreenUI", "7x Native (~2520p)");
 TRANSLATE_NOOP("FullscreenUI", "8x Native (~2880p)");
+TRANSLATE_NOOP("FullscreenUI", "9x Native (~3240p)");
+TRANSLATE_NOOP("FullscreenUI", "10x Native (~3600p)");
+TRANSLATE_NOOP("FullscreenUI", "11x Native (~3960p)");
+TRANSLATE_NOOP("FullscreenUI", "12x Native (~4320p/8K)");
 TRANSLATE_NOOP("FullscreenUI", "Basic (Generated Mipmaps)");
 TRANSLATE_NOOP("FullscreenUI", "Full (PS2 Mipmaps)");
 TRANSLATE_NOOP("FullscreenUI", "Nearest");


### PR DESCRIPTION
### Description of Changes

This PR allows using internal resolution values up to 12× in Qt and FullscreenUI (FSUI). This was previously only feasible by modifying the configuration file in a text editor.

This also amends the description of the Internal Resolution setting to point at the downsampling options that are available.

### Rationale behind Changes

This makes the [downsampling shaders](https://github.com/PCSX2/pcsx2/pull/7647) more useful at high output resolutions such as 4K. Modern high-end GPUs can handle resolution scales above 8× without too much trouble, even in games that target 60 FPS.

Values that are higher than 12× can be useful for interlaced games with no known way to make them progressive, but they can be pretty demanding so they're not exposed here. In any case, the configuration file can still be edited in a text editor if you need a resolution scale factor higher than 12×.

### Suggested Testing Steps

Test resolution scales between 9× and 12× in various games. It's all good on my test system (RTX 4090), but I expect this will be useful on GPUs like the Radeon 7900 XT(X), RTX 3090 (Ti), RTX 4070 and above, etc. We may want to consider that new GPUs will be released over time as well, so more and more GPUs will be able to use these resolution scales in 1 year from now.
