### PR TITLE
Qt: Fix log window disabling itself on close

### DIFF
--- a/pcsx2-qt/LogWindow.cpp
+++ b/pcsx2-qt/LogWindow.cpp
@@ -76,7 +76,6 @@ void LogWindow::updateSettings()
 	}
 	else if (g_log_window)
 	{
-		g_log_window->m_destroying = true;
 		g_log_window->close();
 		g_log_window->deleteLater();
 		g_log_window = nullptr;
@@ -89,7 +88,6 @@ void LogWindow::destroy()
 	if (!g_log_window)
 		return;
 
-	g_log_window->m_destroying = true;
 	g_log_window->close();
 	g_log_window->deleteLater();
 	g_log_window = nullptr;
@@ -100,8 +98,6 @@ void LogWindow::reattachToMainWindow()
 	// Skip when maximized.
 	if (g_main_window->windowState() & (Qt::WindowMaximized | Qt::WindowFullScreen))
 		return;
-
-	resize(width(), g_main_window->height());
 
 	const QPoint new_pos = g_main_window->pos() + QPoint(g_main_window->width() + 10, 0);
 	if (pos() != new_pos)
@@ -130,6 +126,7 @@ void LogWindow::updateWindowTitle()
 void LogWindow::createUi()
 {
 	setWindowIcon(QtHost::GetAppIcon());
+	setWindowFlag(Qt::WindowCloseButtonHint, false);
 	updateWindowTitle();
 
 	QAction* action;
@@ -253,16 +250,7 @@ void LogWindow::closeEvent(QCloseEvent* event)
 {
 	Log::SetHostOutputLevel(LOGLEVEL_NONE, nullptr);
 
-	// Save size when actually closing, disable ourselves if the user closed us.
-	if (m_destroying)
-	{
-		saveSize();
-	}
-	else
-	{
-		Host::SetBaseBoolSettingValue("Logging", "EnableLogWindow", false);
-		Host::CommitBaseSettingChanges();
-	}
+	saveSize();
 
 	QMainWindow::closeEvent(event);
 }

--- a/pcsx2-qt/LogWindow.h
+++ b/pcsx2-qt/LogWindow.h
@@ -48,7 +48,6 @@ private:
 	QMenu* m_level_menu;
 
 	bool m_attached_to_main_window = true;
-	bool m_destroying = false;
 };
 
 extern LogWindow* g_log_window;


### PR DESCRIPTION
### Description of Changes

What the title says. Originally I wanted it to stay active if PCSX2 was closing, and disable itself if the user pressed the X button. However, it is not possible to differentiate between the window being closed as a result of the task ending, or an actual user action. 

So, disable the button instead, if the user wants to disable the log window, they can do so via the Tools menu.

I also made the height adjustable/saveable, and independent to the main window at the same time.

### Rationale behind Changes

Fixing log window disabling itself.

### Suggested Testing Steps

Make sure log window doesn't disable itself.
