### PR TITLE
GS/HW: Improve RT/Blend min max detection based on DATE and ATE.

### DIFF
--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -3962,6 +3962,41 @@ void GSState::CalcAlphaMinMax(const int tex_alpha_min, const int tex_alpha_max)
 	m_vt.m_alpha.valid = true;
 }
 
+void GSState::CorrectATEAlphaMinMax(const u32 atst, const int aref)
+{
+	const GSVertexTrace::VertexAlpha& aminmax = GetAlphaMinMax();
+	int amin = aminmax.min;
+	int amax = aminmax.max;
+	switch (atst)
+	{
+		case ATST_LESS:
+			amin = std::min(amin, std::max(aref - 1, amin));
+			amax = std::min(amax, std::max(aref - 1, amin));
+			break;
+		case ATST_LEQUAL:
+			amin = std::min(amin, std::max(aref, amin));
+			amax = std::min(amax, std::max(aref, amin));
+			break;
+		case ATST_EQUAL:
+			amax = aref;
+			amin = aref;
+			break;
+		case ATST_GEQUAL:
+			amax = std::max(amax, std::min(aref, amax));
+			amin = std::max(amin, std::min(aref, amax));
+			break;
+		case ATST_GREATER:
+			amax = std::max(amax, std::min(aref + 1, amax));
+			amin = std::max(amin, std::min(aref + 1, amax));
+			break;
+		default:
+			break;
+	}
+
+	m_vt.m_alpha.min = amin;
+	m_vt.m_alpha.max = amax;
+}
+
 bool GSState::TryAlphaTest(u32& fm, u32& zm)
 {
 	// Shortcut for the easy case

--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -187,6 +187,7 @@ protected:
 	bool IsMipMapActive();
 	bool IsCoverageAlpha();
 	void CalcAlphaMinMax(const int tex_min, const int tex_max);
+	void CorrectATEAlphaMinMax(const u32 atst, const int aref);
 
 public:
 	struct GSUploadQueue

--- a/pcsx2/GS/Renderers/HW/GSHwHack.cpp
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.cpp
@@ -682,6 +682,8 @@ bool GSHwHack::GSC_PolyphonyDigitalGames(GSRendererHW& r, int& skip)
 	{
 		GL_PUSH("GSC_PolyphonyDigitalGames(): HLE Gran Turismo RGB channel shuffle");
 
+		src->m_alpha_max = 255;
+		src->m_alpha_min = 0;
 		GSHWDrawConfig& config = r.BeginHLEHardwareDraw(
 			src->GetTexture(), nullptr, src->GetScale(), src->GetTexture(), src->GetScale(), src->GetUnscaledRect());
 		config.pal = palette->GetPaletteGSTexture();

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -5147,6 +5147,17 @@ __ri void GSRendererHW::DrawPrims(GSTextureCache::Target* rt, GSTextureCache::Ta
 	// DATE: selection of the algorithm. Must be done before blending because GL42 is not compatible with blending
 	if (DATE)
 	{
+		if (m_cached_ctx.TEST.DATM)
+		{
+			blend_alpha_min = std::max(blend_alpha_min, 128);
+			blend_alpha_max = std::max(blend_alpha_max, 128);
+		}
+		else
+		{
+			blend_alpha_min = std::min(blend_alpha_min, 127);
+			blend_alpha_max = std::min(blend_alpha_max, 127);
+		}
+
 		// It is way too complex to emulate texture shuffle with DATE, so use accurate path.
 		// No overlap should be triggered on gl/vk only as they support DATE_BARRIER.
 		if (features.framebuffer_fetch)


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS/HW: Calculate blend/rt alpha min/max based on alpha test.

GS/HW: Adjust blend_alpha_min/max based on DATE.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Accuracy, will improve hw blending with Ad operations, requires less sw blend (less barriers, copies, draw calls).
Will also help https://github.com/PCSX2/pcsx2/pull/10853 requiring less copies.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Persona 3 shows a slight difference matching it more to sw renderer, I expect dx11/12 to show more differences, other than that shows slight barrier reductions in other games.
