### PR TITLE
GS/HW: Don't allow conversion to indexed is read is outside the target

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -1334,8 +1334,10 @@ GSTextureCache::Source* GSTextureCache::LookupSource(const bool is_color, const 
 						}
 						else
 						{
+							const bool outside_target = !t->Overlaps(bp, bw, psm, r);
+
 							// We don't have a shader for this.
-							if (!possible_shuffle && TEX0.PSM == PSMT8 && GSLocalMemory::m_psm[t->m_TEX0.PSM].bpp != 32)
+							if (!possible_shuffle && TEX0.PSM == PSMT8 && ((GSLocalMemory::m_psm[t->m_TEX0.PSM].bpp != 32) || outside_target))
 							{
 								continue;
 							}


### PR DESCRIPTION
### Description of Changes
Don't try to convert outside of targets to indexed, since there is no data to convert.

### Rationale behind Changes
Seems silly just thinking about it, doesn't it.

### Suggested Testing Steps
Test Ace combat 04, make sure terrain doesn't disappear.

Fixes #10789 

Ace Combat 04:
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/8fb66da0-4bf0-42b4-851a-176d31622f82)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/d96d82fb-ff9c-4de6-956e-f4fc2fb841ec)
