### PR TITLE
GS/HW: Handle redundant FRAME+Z buffer clears

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.h
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.h
@@ -38,6 +38,7 @@ private:
 	void ClearGSLocalMemory(const GSOffset& off, const GSVector4i& r, u32 vert_color);
 	bool DetectDoubleHalfClear(bool& no_rt, bool& no_ds);
 	bool DetectStripedDoubleClear(bool& no_rt, bool& no_ds);
+	bool DetectRedundantBufferClear(bool& no_rt, bool& no_ds, u32 fm_mask);
 	bool TryTargetClear(GSTextureCache::Target* rt, GSTextureCache::Target* ds, bool preserve_rt_color, bool preserve_depth);
 	void SetNewFRAME(u32 bp, u32 bw, u32 psm);
 	void SetNewZBUF(u32 bp, u32 psm);


### PR DESCRIPTION
### Description of Changes

Flatout 2 (redundantly) clears a buffer through both FRAME and Z, which was causing the TC to get confused when I added overlapping buffer support.

Interestingly, they do so with two 32-wide sprites; if they had omitted the second half of it, we'd have a powerdrome-style clear where the right half gets written through Z, and it would be faster. But what they did is no faster.

Amusingly, there's a few other games that do this as well (DMC3, Ratchet, Tom & Jerry), except they do it on 640x448-style buffers :rofl:.

### Rationale behind Changes

Fixes #10865.
Before:
![image](https://github.com/PCSX2/pcsx2/assets/11288319/f1b0b2d4-c03d-48fa-abe1-5f64042438be)
After:
![image](https://github.com/PCSX2/pcsx2/assets/11288319/9c7c4a3d-c255-44ec-80d2-af764b836a27)

### Suggested Testing Steps

Test Flatout.
