### PR TITLE
GS/HW: Don't include TBW in hash cache key

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -7016,9 +7016,8 @@ GSTextureCache::HashCacheKey GSTextureCache::HashCacheKey::Create(const GIFRegTE
 {
 	const GSLocalMemory::psm_t& psm = GSLocalMemory::m_psm[TEX0.PSM];
 
-	// This should arguably include CPSM, but old replacement textures didn't have it...
 	HashCacheKey ret;
-	ret.TEX0.U64 = TEX0.U64 & 0x00000003FFFFC000ULL; // TBW, PSM, TW, TH
+	ret.TEX0.U64 = TEX0.U64 & 0x00000003FFF00000ULL; // PSM, TW, TH
 	ret.TEXA.U64 = (psm.pal == 0 && psm.fmt > 0) ? (TEXA.U64 & 0x000000FF000080FFULL) : 0;
 	ret.CLUTHash = clut ? GSTextureCache::PaletteKeyHash{}({clut, psm.pal}) : 0;
 	ret.region_width = static_cast<u16>(region.GetWidth());


### PR DESCRIPTION
### Description of Changes

Since we're hashing at the block level, a different TBW that causes a different-looking texture should cause different blocks to get hashed, and thus, a different hash.

### Rationale behind Changes

Fixes async texture replacement loading.

### Suggested Testing Steps

Check async texture loading.
