### PR TITLE
UI: Add the "points" unit in some RA-related strings

### DIFF
--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -747,7 +747,7 @@ void MainWindow::onAchievementsLoginRequested(Achievements::LoginRequestReason r
 void MainWindow::onAchievementsLoginSucceeded(const QString& display_name, quint32 points, quint32 sc_points, quint32 unread_messages)
 {
 	const QString message =
-		tr("RA: Logged in as %1 (%2, %3 softcore). %4 unread messages.").arg(display_name).arg(points).arg(sc_points).arg(unread_messages);
+		tr("RA: Logged in as %1 (%2 pts, softcore: %3 pts). %4 unread messages.").arg(display_name).arg(points).arg(sc_points).arg(unread_messages);
 	m_ui.statusBar->showMessage(message);
 }
 

--- a/pcsx2/Achievements.cpp
+++ b/pcsx2/Achievements.cpp
@@ -1742,7 +1742,7 @@ void Achievements::ShowLoginSuccess(const rc_client_t* client)
 
 		//: Summary for login notification.
 		std::string title = user->display_name;
-		std::string summary = fmt::format(TRANSLATE_FS("Achievements", "Score: {0} ({1} softcore)\nUnread messages: {2}"), user->score,
+		std::string summary = fmt::format(TRANSLATE_FS("Achievements", "Score: {0} pts (Softcore: {1} pts)\nUnread messages: {2}"), user->score,
 			user->score_softcore, user->num_unread_messages);
 
 		MTGS::RunOnGSThread([title = std::move(title), summary = std::move(summary), badge_path = std::move(badge_path)]() {

--- a/pcsx2/Achievements.cpp
+++ b/pcsx2/Achievements.cpp
@@ -1742,7 +1742,7 @@ void Achievements::ShowLoginSuccess(const rc_client_t* client)
 
 		//: Summary for login notification.
 		std::string title = user->display_name;
-		std::string summary = fmt::format(TRANSLATE_FS("Achievements", "Score: {0} pts (Softcore: {1} pts)\nUnread messages: {2}"), user->score,
+		std::string summary = fmt::format(TRANSLATE_FS("Achievements", "Score: {0} pts (softcore: {1} pts)\nUnread messages: {2}"), user->score,
 			user->score_softcore, user->num_unread_messages);
 
 		MTGS::RunOnGSThread([title = std::move(title), summary = std::move(summary), badge_path = std::move(badge_path)]() {


### PR DESCRIPTION
### Description of Changes
Added the "pts" unit in some RA-related strings. "Your score" strings and the like were not changed since I believe they are about the in-game score and not the RA score. Feel free to correct me.

### Rationale behind Changes
It helps clarify what the number is about.

### Suggested Testing Steps
1. Log in to RA, read the status bar.
2. Trigger the login notification (no idea how you're supposed to do that).
