### PR TITLE
GS/HW: Improve shuffle width/height detection

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSHwHack.cpp
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.cpp
@@ -608,7 +608,7 @@ bool GSHwHack::GSC_NFSUndercover(GSRendererHW& r, int& skip)
 	if (RPRIM->TME && Frame.PSM == PSMCT16S && Frame.FBMSK != 0 && Frame.FBW == 10 && Texture.TBW == 1 && Texture.TBP0 == 0x02800 && Texture.PSM == PSMZ16S)
 	{
 		GSVertex* v = &r.m_vertex.buff[1];
-		v[0].XYZ.X = static_cast<u16>(RCONTEXT->XYOFFSET.OFX + (r.m_r.z << 4));
+		v[0].XYZ.X = static_cast<u16>(RCONTEXT->XYOFFSET.OFX + ((r.m_r.z * 2) << 4));
 		v[0].XYZ.Y = static_cast<u16>(RCONTEXT->XYOFFSET.OFY + (r.m_r.w << 4));
 		v[0].U = r.m_r.z << 4;
 		v[0].V = r.m_r.w << 4;


### PR DESCRIPTION
### Description of Changes
Improve detection of texture shuffle width/height and tidy up some of the variable naming

### Rationale behind Changes
There were some cases of misdetection thanks to magic numbers, but also the variable naming made following the code confusing, so I corrected it.

### Suggested Testing Steps
Check Superman - Shadow of Apokolips. Also check The Getaway, Dog's Life (smell-o-vision) and Smugglers Run shadows are all okay/no change.

Fixes #10908

Superman:
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/464a415c-c46c-4233-b74d-1bffed89b2ee)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/0141cc96-733c-4347-821d-6497de17b077)
