### PR TITLE
Qt: Disable Texture barriers option on Metal.

### DIFF
--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -958,6 +958,7 @@ void GraphicsSettingsWidget::updateRendererDependentOptions()
 	const bool is_software = (type == GSRendererType::SW);
 	const bool is_auto = (type == GSRendererType::Auto);
 	const bool is_vk = (type == GSRendererType::VK);
+	const bool is_disable_barriers = (type == GSRendererType::DX11 || type == GSRendererType::DX12 || type == GSRendererType::Metal || type == GSRendererType::SW);
 	const bool hw_fixes = (is_hardware && m_ui.enableHWFixes && m_ui.enableHWFixes->checkState() == Qt::Checked);
 	const int prev_tab = m_ui.tabs->currentIndex();
 
@@ -991,7 +992,7 @@ void GraphicsSettingsWidget::updateRendererDependentOptions()
 		m_ui.useBlitSwapChain->setEnabled(is_dx11);
 
 	if (m_ui.overrideTextureBarriers)
-		m_ui.overrideTextureBarriers->setDisabled(is_sw_dx);
+		m_ui.overrideTextureBarriers->setDisabled(is_disable_barriers);
 
 	if (m_ui.disableFramebufferFetch)
 		m_ui.disableFramebufferFetch->setDisabled(is_sw_dx);


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Qt: Disable Texture barriers option on Metal.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Not implemented.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Override texture barriers option should only be available on vk/gl.
