### PR TITLE
GameDB: Fix Crash Bandicoot The Wrath of Cortex blurriness and shakiness (PAL)

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -13842,6 +13842,7 @@ SLES-50386:
   region: "PAL-M6"
   compat: 5
   gsHWFixes:
+    deinterlace: 5 # Fixes blurriness.
     nativePaletteDraw: 1
     autoFlush: 2 # Fixes refraction effect.
 SLES-50390:


### PR DESCRIPTION
### Description of Changes
Fixes a slight blur and prevents shakiness present in the PAL version of Crash Bandicoot: The Wrath of Cortex.

No deinterlacing (You can see the gem and the number 3 are not properly focused, and Crash has some subtle ghosting effect):
![Bad](https://github.com/PCSX2/pcsx2/assets/126416290/b511b6f7-7a8a-465d-ae8c-9362b2f92221)

Deinterlacing Bob (Bottom Field first, full frames):
![Good](https://github.com/PCSX2/pcsx2/assets/126416290/34341c37-1f6d-47f6-9078-6f2daead37ca)

### Rationale behind Changes
Improves the user experience by making the image clearer and more stable.

### Suggested Testing Steps
Starting a new game and looking around the main area.
