### PR TITLE
DEV9: Improve logic for getting MacAddress

### DIFF
--- a/pcsx2/DEV9/pcap_io.cpp
+++ b/pcsx2/DEV9/pcap_io.cpp
@@ -287,7 +287,7 @@ bool PCAPAdapter::InitPCAP(const std::string& adapter, bool promiscuous)
 	const int dlt = pcap_datalink(hpcap);
 	const char* dlt_name = pcap_datalink_val_to_name(dlt);
 
-	Console.Error("DEV9: Device uses DLT %d: %s", dlt, dlt_name);
+	Console.WriteLn("DEV9: Device uses DLT %d: %s", dlt, dlt_name);
 	switch (dlt)
 	{
 		case DLT_EN10MB:


### PR DESCRIPTION
### Description of Changes
Improving logic for getting MacAddress, now it is working for Apple and FreeBSD


Previously on MacOS:
```
[   12.2374] DEV9: Opening adapter 'en0'...
[   12.2377] DEV9: Device uses DLT 1: EN10MB
[   12.2379] DEV9: Adapter Ok.
[   12.2418] DEV9: Unsupported OS, can't get MAC address
[   12.2420] DEV9: Failed to get MAC address for adapter
[   12.2422] DEV9: Failed to GetNetAdapter()
```

Now:
```
[  443.7172] DEV9: Opening adapter 'en0'...
[  443.7173] DEV9: Device uses DLT 1: EN10MB
[  443.7175] DEV9: Adapter Ok.
```