### PR TITLE
Fix GCC builds

### DIFF
--- a/common/Console.h
+++ b/common/Console.h
@@ -132,10 +132,10 @@ struct ConsoleLogWriter
 	} while (0)
 
 	// clang-format off
-	__fi static void Error(const char* format, ...) { MAKE_PRINTF_CONSOLE_WRITER(Color_StrongRed); }
-	__fi static void Warning(const char* format, ...) { MAKE_PRINTF_CONSOLE_WRITER(Color_StrongOrange); }
-	__fi static void WriteLn(const char* format, ...) { MAKE_PRINTF_CONSOLE_WRITER(Color_Default); }
-	__fi static void WriteLn(ConsoleColors color, const char* format, ...) { MAKE_PRINTF_CONSOLE_WRITER(color); }
+	static void Error(const char* format, ...) { MAKE_PRINTF_CONSOLE_WRITER(Color_StrongRed); }
+	static void Warning(const char* format, ...) { MAKE_PRINTF_CONSOLE_WRITER(Color_StrongOrange); }
+	static void WriteLn(const char* format, ...) { MAKE_PRINTF_CONSOLE_WRITER(Color_Default); }
+	static void WriteLn(ConsoleColors color, const char* format, ...) { MAKE_PRINTF_CONSOLE_WRITER(color); }
 	// clang-format on	
 
 #undef MAKE_PRINTF_CONSOLE_WRITER

--- a/pcsx2/PrecompiledHeader.h
+++ b/pcsx2/PrecompiledHeader.h
@@ -41,5 +41,7 @@
 #include <sys/stat.h>
 
 // We use fmt a fair bit now.
+// fmt pch breaks GCC in debug builds: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=114370
+#if !defined(__GNUC__) || defined(__clang__)
 #include "fmt/core.h"
-
+#endif


### PR DESCRIPTION
### Description of Changes
Works around GCC issues that were breaking builds

### Rationale behind Changes
We don't officially support GCC but it would be nice if the builds didn't fail completely

### Suggested Testing Steps
Build a debug build with GCC
