### PR TITLE
GS/HW: Initial implementation of HW(HDR) FbMask.

### DIFF
--- a/bin/resources/shaders/dx11/convert.fx
+++ b/bin/resources/shaders/dx11/convert.fx
@@ -21,6 +21,8 @@ cbuffer cb0 : register(b0)
 	int EMODA;
 	int EMODC;
 	int DOFFSET;
+	float cb0_pad1;
+	uint4 FbMask;
 };
 
 static const float3x3 rgb2yuv =
@@ -163,7 +165,9 @@ PS_OUTPUT ps_hdr_resolve(PS_INPUT input)
 {
 	PS_OUTPUT output;
 	float4 value = sample_c(input.t);
-	output.c = float4(float3(uint3(value.rgb * 65535.5) & 255) / 255, value.a);
+	output.c = float4(float3(uint3(value.rgb * 65535.5) & 255), value.a * 255.5);
+	output.c = (float4)(((uint4)output.c & ~FbMask));
+	output.c /= 255.0f;
 	return output;
 }
 

--- a/bin/resources/shaders/dx11/merge.fx
+++ b/bin/resources/shaders/dx11/merge.fx
@@ -9,7 +9,9 @@ cbuffer cb0 : register(b0)
 	float4 BGColor;
 	int EMODA;
 	int EMODC;
-	int cb0_pad[2];
+	uint cb0_pad1;
+	float cb0_pad2;
+	uint cb0_pad3[4];
 };
 
 struct PS_INPUT

--- a/bin/resources/shaders/dx11/tfx.fx
+++ b/bin/resources/shaders/dx11/tfx.fx
@@ -50,6 +50,7 @@
 #define PS_TALES_OF_ABYSS_HLE 0
 #define PS_URBAN_CHAOS_HLE 0
 #define PS_HDR 0
+#define PS_HDR_FBMASK 0
 #define PS_RTA_CORRECTION 0
 #define PS_RTA_SRC_CORRECTION 0
 #define PS_COLCLIP 0
@@ -840,9 +841,9 @@ void ps_color_clamp_wrap(inout float3 C)
 			C = clamp(C, (float3)0.0f, (float3)255.0f);
 
 		// In 16 bits format, only 5 bits of color are used. It impacts shadows computation of Castlevania
-		if (PS_DST_FMT == FMT_16 && (PS_BLEND_MIX == 0 || PS_DITHER))
+		if (PS_DST_FMT == FMT_16 && PS_HDR_FBMASK == 0 && (PS_BLEND_MIX == 0 || PS_DITHER))
 			C = (float3)((int3)C & (int3)0xF8);
-		else if (PS_COLCLIP == 1 || PS_HDR == 1)
+		else if (PS_HDR_FBMASK == 0 && (PS_COLCLIP == 1 || PS_HDR == 1))
 			C = (float3)((int3)C & (int3)0xFF);
 	}
 }

--- a/pcsx2/GS/Renderers/Common/GSDevice.h
+++ b/pcsx2/GS/Renderers/Common/GSDevice.h
@@ -209,8 +209,9 @@ struct alignas(16) MergeConstantBuffer
 	u32 EMODC;
 	u32 DOFFSET;
 	float ScaleFactor;
+	GSVector4i HDR_FbMask;
 };
-static_assert(sizeof(MergeConstantBuffer) == 32, "MergeConstantBuffer is correct size");
+static_assert(sizeof(MergeConstantBuffer) == 48, "MergeConstantBuffer is correct size");
 
 struct alignas(16) InterlaceConstantBuffer
 {
@@ -320,6 +321,7 @@ struct alignas(16) GSHWDrawConfig
 				u32 read_ba  : 1;
 				u32 write_rg : 1;
 				u32 fbmask   : 1;
+				u32 hdr_fbmask : 1;
 
 				// Blend and Colclip
 				u32 blend_a        : 2;
@@ -654,6 +656,7 @@ struct alignas(16) GSHWDrawConfig
 	GSVector4i scissor; ///< Scissor rect
 	GSVector4i drawarea; ///< Area in the framebuffer which will be modified.
 	Topology topology;  ///< Draw topology
+	GSVector4i HDR_FbMask;
 
 	alignas(8) PSSelector ps;
 	VSSelector vs;


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Allows us to use fbmask on hdr mode.
Idea is to mask on hdr resolve to get a better accurate result when using hw blend or accumulation blend.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Accuracy, dx only, might do them for other renderers but it's only useful when barriers aren't supported.
Fixes superman shadows of apokolips dark shadow, will require minimum blend to properly render the effects, it could be made to work on basic but will add more complexity.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test the following dump using medium blending on dx:
[superman_shadow_of_apokolips.gs.zip](https://github.com/PCSX2/pcsx2/files/14666254/superman_shadow_of_apokolips.gs.zip)
Dump run showed a few more games but barely any difference, could be alpha precision that might need tweaking.
