### PR TITLE
Qt: Fix closing log window via taskbar

### DIFF
--- a/pcsx2-qt/LogWindow.cpp
+++ b/pcsx2-qt/LogWindow.cpp
@@ -76,6 +76,7 @@ void LogWindow::updateSettings()
 	}
 	else if (g_log_window)
 	{
+		g_log_window->m_destroying = true;
 		g_log_window->close();
 		g_log_window->deleteLater();
 		g_log_window = nullptr;
@@ -88,6 +89,7 @@ void LogWindow::destroy()
 	if (!g_log_window)
 		return;
 
+	g_log_window->m_destroying = true;
 	g_log_window->close();
 	g_log_window->deleteLater();
 	g_log_window = nullptr;
@@ -248,6 +250,11 @@ void LogWindow::logCallback(LOGLEVEL level, ConsoleColors color, std::string_vie
 
 void LogWindow::closeEvent(QCloseEvent* event)
 {
+	if (!m_destroying)
+	{
+		event->ignore();
+		return;
+	}
 	Log::SetHostOutputLevel(LOGLEVEL_NONE, nullptr);
 
 	saveSize();

--- a/pcsx2-qt/LogWindow.h
+++ b/pcsx2-qt/LogWindow.h
@@ -48,6 +48,7 @@ private:
 	QMenu* m_level_menu;
 
 	bool m_attached_to_main_window = true;
+	bool m_destroying = false;
 };
 
 extern LogWindow* g_log_window;


### PR DESCRIPTION
### Description of Changes
Backport from Duckstation.

Fixes #10939 

### Rationale behind Changes
It's silly.

### Suggested Testing Steps
Make sure you can't close the log window from the task bar.
