### PR TITLE
Qt: Fix main window stuck open after update

### DIFF
--- a/pcsx2-qt/MainWindow.h
+++ b/pcsx2-qt/MainWindow.h
@@ -87,6 +87,7 @@ public:
 	void connectVMThreadSignals(EmuThread* thread);
 	void startupUpdateCheck();
 	void resetSettings(bool ui);
+	void quit();
 
 	/// Locks the VM by pausing it, while a popup dialog is displayed.
 	VMLock pauseAndLockVM();


### PR DESCRIPTION
Regression from #10949.

Silly me for thinking `QGuiApplication::quit()` couldn't get cancelled by the log window being closed first...