### PR TITLE
Qt: Enable unifiedTitleAndToolBarOnMac for main window

### DIFF
--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -1975,7 +1975,8 @@ void MainWindow::closeEvent(QCloseEvent* event)
 		saveStateToConfig();
 		if (m_display_created)
 			g_emu_thread->stopFullscreenUI();
-		quit();
+		destroySubWindows();
+		QMainWindow::closeEvent(event);
 		return;
 	}
 

--- a/pcsx2-qt/MainWindow.ui
+++ b/pcsx2-qt/MainWindow.ui
@@ -21,6 +21,9 @@
     <normalon>:/icons/AppIcon64.png</normalon>
    </iconset>
   </property>
+  <property name="unifiedTitleAndToolBarOnMac">
+   <bool>true</bool>
+  </property>
   <widget class="QStackedWidget" name="mainContainer"/>
   <widget class="QMenuBar" name="menuBar">
    <property name="geometry">


### PR DESCRIPTION
### Description of Changes

Did this for duckstation a while back, forgot to backport.

### Rationale behind Changes

Before:
![image](https://github.com/PCSX2/pcsx2/assets/11288319/d2a41ef5-c757-45ec-bff0-aac181f2decb)

After:
![image](https://github.com/PCSX2/pcsx2/assets/11288319/6eaf7b54-a465-4d39-b130-f27bd0c3802d)

### Suggested Testing Steps

Check mac main window.
