### PR TITLE
GS/HW: Make sure RTA doesn't correct when it can't

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -5371,6 +5371,8 @@ __ri void GSRendererHW::DrawPrims(GSTextureCache::Target* rt, GSTextureCache::Ta
 					tex->m_texture = rt->m_texture;
 			}
 		}
+		else if (!rt->m_rt_alpha_scale)
+			m_can_correct_alpha = std::max(blend_alpha_max, rt->m_alpha_max) <= 128;
 
 		m_conf.ps.rta_correction = rt->m_rt_alpha_scale;
 	}


### PR DESCRIPTION
### Description of Changes
Stops it correcting RTA's that can't be corrected.

### Rationale behind Changes
Mistake from 1.7.5625 (#10941) causing it to try to correct targets which can't be corrected.

### Suggested Testing Steps
Already checked.

Fixes poor performance in NFS Most Wanted (and probably other games with high Alphas)
