### PR TITLE
GS/HW: Check both edges of current triangle for quads

### DIFF
--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -2823,7 +2823,9 @@ bool GSState::TrianglesAreQuads() const
 		{
 			const u16* const prev_tri= m_index.buff + (idx - 3);
 			const GSVertex& vert = v[i[0]];
-			if (vert.XYZ != m_vertex.buff[prev_tri[0]].XYZ && vert.XYZ != m_vertex.buff[prev_tri[1]].XYZ && vert.XYZ != m_vertex.buff[prev_tri[2]].XYZ)
+			const GSVertex& last_vert = v[i[2]];
+			if (vert.XYZ != m_vertex.buff[prev_tri[0]].XYZ && vert.XYZ != m_vertex.buff[prev_tri[1]].XYZ && vert.XYZ != m_vertex.buff[prev_tri[2]].XYZ &&
+				last_vert.XYZ != m_vertex.buff[prev_tri[0]].XYZ && last_vert.XYZ != m_vertex.buff[prev_tri[1]].XYZ && last_vert.XYZ != m_vertex.buff[prev_tri[2]].XYZ)
 				return false;
 		}
 		// Degenerate triangles should've been culled already, so we can check indices.


### PR DESCRIPTION
### Description of Changes
Checks both edges of the current triangle during quad check

### Rationale behind Changes
When using DX and VK they can have different settings for "provoking vertex", meaning the first and last point can be swapped, this was causing the quad check to fail as the first vert wasn't connected to the previous triangle. In Transformers on DX, this meant that it ended up using an image from a previous draw as depth.

### Suggested Testing Steps
Smoke test mostly.

### Fixes in Vulkan

Splinter Cell - Chaos Theory:
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/4e3323b1-8328-4a2b-9013-84a1c2114244)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/f7d2071c-a7dd-4a78-95eb-4ae75b3b14f8)

### Fixes in Direct3D11

Transformers:
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/f2474c01-2fe0-4593-8850-f98008d8dc58)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/49a8c4da-e365-47e5-86a8-925f91c9b502)
