### PR TITLE
Fix RTA when upscaling on Metal

### DIFF
--- a/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
@@ -1570,8 +1570,8 @@ void GSDevice12::DoMultiStretchRects(
 	SetUtilityTexture(rects[0].src, rects[0].linear ? m_linear_sampler_cpu : m_point_sampler_cpu);
 
 	pxAssert(shader == ShaderConvert::COPY || shader == ShaderConvert::RTA_CORRECTION || rects[0].wmask.wrgba == 0xf);
-	int rta_offset = (shader == ShaderConvert::RTA_CORRECTION) ? 16 : 0;
-	SetPipeline((rects[0].wmask.wrgba != 0xf) ? m_color_copy[rects[0].wmask.wrgba + rta_offset].get() :
+	int rta_bit = (shader == ShaderConvert::RTA_CORRECTION) ? 16 : 0;
+	SetPipeline((rects[0].wmask.wrgba != 0xf) ? m_color_copy[rects[0].wmask.wrgba | rta_bit].get() :
 												m_convert[static_cast<int>(shader)].get());
 
 	if (ApplyUtilityState())

--- a/pcsx2/GS/Renderers/Metal/GSTextureMTL.mm
+++ b/pcsx2/GS/Renderers/Metal/GSTextureMTL.mm
@@ -140,8 +140,8 @@ void GSTextureMTL::SetDebugName(std::string_view name)
 			initWithBytes:name.data()
 			length:static_cast<NSUInteger>(name.length())
 			encoding:NSUTF8StringEncoding];
-    [m_texture setLabel:label];
-  }
+		[m_texture setLabel:label];
+	}
 }
 
 #endif
@@ -273,8 +273,8 @@ void GSDownloadTextureMTL::SetDebugName(std::string_view name)
 			initWithBytes:name.data()
 			length:static_cast<NSUInteger>(name.length())
 			encoding:NSUTF8StringEncoding];
-    [m_buffer setLabel:label];
-  }
+		[m_buffer setLabel:label];
+	}
 }
 
 #endif

--- a/pcsx2/GS/Renderers/Metal/convert.metal
+++ b/pcsx2/GS/Renderers/Metal/convert.metal
@@ -126,15 +126,15 @@ fragment float4 ps_primid_rta_init_datm0(float4 p [[position]], DirectReadTextur
 	return tex.read(p).a > (254.5f / 255.f) ? -1 : FLT_MAX;
 }
 
-fragment float4 ps_rta_correction(float4 p [[position]], DirectReadTextureIn<float> tex)
+fragment float4 ps_rta_correction(ConvertShaderData data [[stage_in]], ConvertPSRes res)
 {
-	float4 in = tex.read(p);
+	float4 in = res.sample(data.t);
 	return float4(in.rgb, in.a / (127.5f / 255.0f));
 }
 
-fragment float4 ps_rta_decorrection(float4 p [[position]], DirectReadTextureIn<float> tex)
+fragment float4 ps_rta_decorrection(ConvertShaderData data [[stage_in]], ConvertPSRes res)
 {
-	float4 in = tex.read(p);
+	float4 in = res.sample(data.t);
 	return float4(in.rgb, in.a * (128.25f / 255.0f));
 }
 

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
@@ -3048,9 +3048,9 @@ void GSDeviceVK::DoMultiStretchRects(
 	SetUtilityTexture(rects[0].src, rects[0].linear ? m_linear_sampler : m_point_sampler);
 
 	pxAssert(shader == ShaderConvert::COPY || shader == ShaderConvert::RTA_CORRECTION || rects[0].wmask.wrgba == 0xf);
-	int rta_offset = (shader == ShaderConvert::RTA_CORRECTION) ? 16 : 0;
+	int rta_bit = (shader == ShaderConvert::RTA_CORRECTION) ? 16 : 0;
 	SetPipeline(
-		(rects[0].wmask.wrgba != 0xf) ? m_color_copy[rects[0].wmask.wrgba + rta_offset] : m_convert[static_cast<int>(shader)]);
+		(rects[0].wmask.wrgba != 0xf) ? m_color_copy[rects[0].wmask.wrgba | rta_bit] : m_convert[static_cast<int>(shader)]);
 
 	if (ApplyUtilityState())
 		DrawIndexedPrimitive();


### PR DESCRIPTION
### Description of Changes
Fixes an issue where textures would be the wrong size when upscaling
Also treat rta flag like a bit instead of an offset, as that's how we use it

### Rationale behind Changes
Less broken

### Suggested Testing Steps
Test [rc2scale.gs.xz.zip](https://github.com/PCSX2/pcsx2/files/14751708/rc2scale.gs.xz.zip)
