### PR TITLE
GS/Metal: Fix Wunused-const-variable warning.

### DIFF
--- a/pcsx2/GS/Renderers/Metal/tfx.metal
+++ b/pcsx2/GS/Renderers/Metal/tfx.metal
@@ -8,7 +8,7 @@ constant uint FMT_24 = 1;
 constant uint FMT_16 = 2;
 
 constant uint SHUFFLE_READ = 1;
-constant uint SHUFFLE_WRITE = 2;
+[[maybe_unused]] constant uint SHUFFLE_WRITE = 2;
 constant uint SHUFFLE_READWRITE = 3;
 
 constant bool HAS_FBFETCH           [[function_constant(GSMTLConstantIndex_FRAMEBUFFER_FETCH)]];


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS/Metal: Fix Wunused-const-variable warning.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Less warnings.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
CI compiles.