### PR TITLE
GS: Purge GSinit() and GSshutdown()

### DIFF
--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -58,21 +58,6 @@ static GSRendererType GSCurrentRenderer;
 
 static u64 s_next_manual_present_time;
 
-void GSinit()
-{
-	GSVertexSW::InitStatic();
-
-	GSUtil::Init();
-}
-
-void GSshutdown()
-{
-	GSclose();
-
-	// ensure all screenshots have been saved
-	GSJoinSnapshotThreads();
-}
-
 GSRendererType GSGetCurrentRenderer()
 {
 	return GSCurrentRenderer;
@@ -191,6 +176,8 @@ static bool OpenGSRenderer(GSRendererType renderer, u8* basemem)
 {
 	// Must be done first, initialization routines in GSState use GSIsHardwareRenderer().
 	GSCurrentRenderer = renderer;
+
+	GSVertexSW::InitStatic();
 
 	if (renderer == GSRendererType::Null)
 	{

--- a/pcsx2/GS/GS.h
+++ b/pcsx2/GS/GS.h
@@ -56,8 +56,6 @@ s16 GSLookupGetSkipCountFunctionId(const std::string_view& name);
 s16 GSLookupBeforeDrawFunctionId(const std::string_view& name);
 s16 GSLookupMoveHandlerFunctionId(const std::string_view& name);
 
-void GSinit();
-void GSshutdown();
 bool GSopen(const Pcsx2Config::GSOptions& config, GSRendererType renderer, u8* basemem);
 bool GSreopen(bool recreate_device, GSRendererType new_renderer, std::optional<const Pcsx2Config::GSOptions*> old_config);
 void GSreset(bool hardware_reset);

--- a/pcsx2/GS/GSUtil.cpp
+++ b/pcsx2/GS/GSUtil.cpp
@@ -22,18 +22,17 @@
 #include <wil/com.h>
 #endif
 
-static class GSUtilMaps
+namespace {
+struct GSUtilMaps
 {
-public:
-	u8 PrimClassField[8];
-	u8 VertexCountField[8];
-	u8 ClassVertexCountField[4];
-	u32 CompatibleBitsField[64][2];
-	u32 SharedBitsField[64][2];
-	u32 SwizzleField[64][2];
+	u8 PrimClassField[8] = {};
+	u8 VertexCountField[8] = {};
+	u8 ClassVertexCountField[4] = {};
+	u32 CompatibleBitsField[64][2] = {};
+	u32 SharedBitsField[64][2] = {};
+	u32 SwizzleField[64][2] = {};
 
-	// Defer init to avoid AVX2 illegal instructions
-	void Init()
+	constexpr GSUtilMaps()
 	{
 		PrimClassField[GS_POINTLIST] = GS_POINT_CLASS;
 		PrimClassField[GS_LINELIST] = GS_LINE_CLASS;
@@ -58,8 +57,6 @@ public:
 		ClassVertexCountField[GS_TRIANGLE_CLASS] = 3;
 		ClassVertexCountField[GS_SPRITE_CLASS] = 2;
 
-		memset(CompatibleBitsField, 0, sizeof(CompatibleBitsField));
-
 		for (int i = 0; i < 64; i++)
 		{
 			CompatibleBitsField[i][i >> 5] |= 1U << (i & 0x1f);
@@ -73,8 +70,6 @@ public:
 		CompatibleBitsField[PSMZ24][PSMZ32 >> 5] |= 1 << (PSMZ32 & 0x1f);
 		CompatibleBitsField[PSMZ16][PSMZ16S >> 5] |= 1 << (PSMZ16S & 0x1f);
 		CompatibleBitsField[PSMZ16S][PSMZ16 >> 5] |= 1 << (PSMZ16 & 0x1f);
-
-		memset(SwizzleField, 0, sizeof(SwizzleField));
 
 		for (int i = 0; i < 64; i++)
 		{
@@ -92,8 +87,6 @@ public:
 		SwizzleField[PSMZ32][PSMZ24 >> 5] |= 1 << (PSMZ24 & 0x1f);
 		SwizzleField[PSMZ24][PSMZ32 >> 5] |= 1 << (PSMZ32 & 0x1f);
 
-		memset(SharedBitsField, 0, sizeof(SharedBitsField));
-
 		SharedBitsField[PSMCT24][PSMT8H >> 5] |= 1 << (PSMT8H & 0x1f);
 		SharedBitsField[PSMCT24][PSMT4HL >> 5] |= 1 << (PSMT4HL & 0x1f);
 		SharedBitsField[PSMCT24][PSMT4HH >> 5] |= 1 << (PSMT4HH & 0x1f);
@@ -109,13 +102,10 @@ public:
 		SharedBitsField[PSMT4HH][PSMZ24 >> 5] |= 1 << (PSMZ24 & 0x1f);
 		SharedBitsField[PSMT4HH][PSMT4HL >> 5] |= 1 << (PSMT4HL & 0x1f);
 	}
-
-} s_maps;
-
-void GSUtil::Init()
-{
-	s_maps.Init();
+};
 }
+
+static constexpr const GSUtilMaps s_maps;
 
 const char* GSUtil::GetATSTName(u32 atst)
 {

--- a/pcsx2/GS/GSUtil.h
+++ b/pcsx2/GS/GSUtil.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2002-2023 PCSX2 Dev Team
+// SPDX-FileCopyrightText: 2002-2024 PCSX2 Dev Team
 // SPDX-License-Identifier: LGPL-3.0+
 
 #pragma once
@@ -9,8 +9,6 @@
 class GSUtil
 {
 public:
-	static void Init();
-
 	static const char* GetATSTName(u32 atst);
 	static const char* GetAFAILName(u32 afail);
 

--- a/pcsx2/MTGS.cpp
+++ b/pcsx2/MTGS.cpp
@@ -190,8 +190,6 @@ void MTGS::ThreadEntryPoint()
 		// we need to reset sem_event here, because MainLoop() kills it.
 		s_sem_event.Reset();
 	}
-
-	GSshutdown();
 }
 
 void MTGS::ResetGS(bool hardware_reset)

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -392,7 +392,6 @@ bool VMManager::Internal::CPUThreadInitialize()
 
 	InitializeCPUProviders();
 
-	GSinit();
 	USBinit();
 
 	// We want settings loaded so we choose the correct renderer for big picture mode.
@@ -424,9 +423,9 @@ void VMManager::Internal::CPUThreadShutdown()
 	PerformanceMetrics::SetCPUThread(Threading::ThreadHandle());
 
 	USBshutdown();
-	GSshutdown();
 
 	MTGS::ShutdownThread();
+	GSJoinSnapshotThreads();
 
 	ShutdownCPUProviders();
 


### PR DESCRIPTION
### Description of Changes

The PSM mappings can be determined at compile time, instead of runtime.
This renders init/shutdown redundant.

### Rationale behind Changes

Less code, fewer plugin memories.

### Suggested Testing Steps

Smoke test.
