### PR TITLE
Config: Allow the use of portable.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,6 +91,7 @@ oprofile_data/
 /bin/inputprofiles
 /bin/videos
 /bin/portable.ini
+/bin/portable.txt
 
 # Manually added by user.
 /bin/resources/patches.zip

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -1898,7 +1898,7 @@ void EmuFolders::SetResourcesDirectory()
 bool EmuFolders::ShouldUsePortableMode()
 {
 	// Check whether portable.ini exists in the program directory.
-	return FileSystem::FileExists(Path::Combine(AppRoot, "portable.ini").c_str());
+	return FileSystem::FileExists(Path::Combine(AppRoot, "portable.ini").c_str()) || FileSystem::FileExists(Path::Combine(AppRoot, "portable.txt").c_str());
 }
 
 void EmuFolders::SetDataDirectory()

--- a/updater/Updater.cpp
+++ b/updater/Updater.cpp
@@ -192,8 +192,7 @@ bool Updater::ParseZip()
 		{
 			// skip updater itself, since it was already pre-extracted.
 			// also skips portable.ini to not mess with future non-portable installs.
-			if (StringUtil::Strcasecmp(entry.destination_filename.c_str(), "updater.exe") != 0 &&
-				StringUtil::Strcasecmp(entry.destination_filename.c_str(), "portable.ini") != 0)
+			if (StringUtil::Strcasecmp(entry.destination_filename.c_str(), "updater.exe") != 0)
 			{
 				m_progress->DisplayFormattedInformation("Found file in zip: '%s'", entry.destination_filename.c_str());
 				m_update_paths.push_back(std::move(entry));


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
allows the use of portable.txt as well as portable.ini 
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
on some OS's  it may be difficult to create ini files  automatically , thus makes its  more easier for the users on this OS to create the portable file 
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
create a portable.txt /.ini and make sure portable mode works 

updater needs checked 