### PR TITLE
GS/DX: Fix ALT+ENTER causing mode switch

### DIFF
--- a/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2002-2023 PCSX2 Dev Team
+// SPDX-FileCopyrightText: 2002-2024 PCSX2 Dev Team
 // SPDX-License-Identifier: LGPL-3.0+
 
 #include "GS.h"
@@ -10,6 +10,7 @@
 #include "Host.h"
 
 #include "common/BitUtils.h"
+#include "common/Error.h"
 #include "common/Path.h"
 #include "common/StringUtil.h"
 
@@ -711,9 +712,19 @@ bool GSDevice11::CreateSwapChain()
 		}
 	}
 
-	hr = m_dxgi_factory->MakeWindowAssociation(window_hwnd, DXGI_MWA_NO_WINDOW_CHANGES);
-	if (FAILED(hr))
-		Console.Warning("MakeWindowAssociation() to disable ALT+ENTER failed");
+	// MWA needs to be called on the correct factory.
+	wil::com_ptr_nothrow<IDXGIFactory> swap_chain_factory;
+	hr = m_swap_chain->GetParent(IID_PPV_ARGS(swap_chain_factory.put()));
+	if (SUCCEEDED(hr))
+	{
+		hr = swap_chain_factory->MakeWindowAssociation(window_hwnd, DXGI_MWA_NO_WINDOW_CHANGES);
+		if (FAILED(hr))
+			Console.ErrorFmt("MakeWindowAssociation() to disable ALT+ENTER failed: {}", Error::CreateHResult(hr).GetDescription());
+	}
+	else
+	{
+		Console.ErrorFmt("GetParent() on swap chain to get factory failed: {}", Error::CreateHResult(hr).GetDescription());
+	}	
 
 	if (!CreateSwapChainRTV())
 	{


### PR DESCRIPTION
### Description of Changes

ALT+ENTER wasn't getting correctly disabled, which caused DXGI to freak out.

### Rationale behind Changes

Spec violation.

### Suggested Testing Steps

Test ALT+ENTER on DX11/DX12.
