### PR TITLE
GS/DX11: Re-enable FL10 support with a warning

### DIFF
--- a/bin/resources/shaders/common/fxaa.fx
+++ b/bin/resources/shaders/common/fxaa.fx
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: 2002-2023 PCSX2 Dev Team
 // SPDX-License-Identifier: LGPL-3.0+
 
-#ifndef FXAA_HLSL_5
-    #define FXAA_HLSL_5 0
+#ifndef FXAA_HLSL
+    #define FXAA_HLSL 0
 #endif
 #ifndef FXAA_GLSL_130
     #define FXAA_GLSL_130 0
@@ -31,7 +31,7 @@ layout(location = 0) in vec2 PSin_t;
 layout(location = 0) out vec4 SV_Target0;
 layout(set = 0, binding = 0) uniform sampler2D TextureSampler;
 
-#elif (FXAA_HLSL_5 == 1)
+#elif (FXAA_HLSL == 1)
 Texture2D Texture : register(t0);
 SamplerState TextureSampler : register(s0);
 
@@ -60,12 +60,10 @@ static constexpr sampler MAIN_SAMPLER(coord::normalized, address::clamp_to_edge,
                              [FXAA CODE SECTION]
 ------------------------------------------------------------------------------*/
 
-#if (FXAA_HLSL_5 == 1)
+#if (FXAA_HLSL == 1)
 struct FxaaTex { SamplerState smpl; Texture2D tex; };
 #define FxaaTexTop(t, p) t.tex.SampleLevel(t.smpl, p, 0.0)
 #define FxaaTexOff(t, p, o, r) t.tex.SampleLevel(t.smpl, p, 0.0, o)
-#define FxaaTexAlpha4(t, p) t.tex.GatherAlpha(t.smpl, p)
-#define FxaaTexOffAlpha4(t, p, o) t.tex.GatherAlpha(t.smpl, p, o)
 #define FxaaDiscard clip(-1)
 #define FxaaSat(x) saturate(x)
 
@@ -84,8 +82,6 @@ struct FxaaTex { SamplerState smpl; Texture2D tex; };
 #define FxaaTex texture2d<float>
 #define FxaaTexTop(t, p) t.sample(MAIN_SAMPLER, p)
 #define FxaaTexOff(t, p, o, r) t.sample(MAIN_SAMPLER, p, o)
-#define FxaaTexAlpha4(t, p) t.gather(MAIN_SAMPLER, p, 0, component::w)
-#define FxaaTexOffAlpha4(t, p, o) t.gather(MAIN_SAMPLER, p, o, component::w)
 #define FxaaDiscard discard_fragment()
 #define FxaaSat(x) saturate(x)
 #endif
@@ -444,14 +440,14 @@ float4 FxaaPixelShader(float2 pos, FxaaTex tex, float2 fxaaRcpFrame, float fxaaS
 
 #if (FXAA_GLSL_130 == 1 || FXAA_GLSL_VK == 1)
 float4 FxaaPass(float4 FxaaColor, float2 uv0)
-#elif (FXAA_HLSL_5 == 1)
+#elif (FXAA_HLSL == 1)
 float4 FxaaPass(float4 FxaaColor : COLOR0, float2 uv0 : TEXCOORD0)
 #elif defined(__METAL_VERSION__)
 float4 FxaaPass(float4 FxaaColor, float2 uv0, texture2d<float> tex)
 #endif
 {
 
-	#if (FXAA_HLSL_5 == 1)
+	#if (FXAA_HLSL == 1)
 	FxaaTex tex;
 	tex.tex = Texture;
 	tex.smpl = TextureSampler;
@@ -485,7 +481,7 @@ void main()
 	SV_Target0 = float4(color.rgb, 1.0);
 }
 
-#elif (FXAA_HLSL_5 == 1)
+#elif (FXAA_HLSL == 1)
 PS_OUTPUT main(VS_OUTPUT input)
 {
 	PS_OUTPUT output;

--- a/pcsx2/GS/Renderers/DX11/D3D.cpp
+++ b/pcsx2/GS/Renderers/DX11/D3D.cpp
@@ -359,6 +359,7 @@ GSRendererType D3D::GetPreferredRenderer()
 		static const D3D_FEATURE_LEVEL check[] = {
 			D3D_FEATURE_LEVEL_12_0,
 			D3D_FEATURE_LEVEL_11_0,
+			D3D_FEATURE_LEVEL_10_0,
 		};
 
 		D3D_FEATURE_LEVEL feature_level;
@@ -484,6 +485,13 @@ wil::com_ptr_nothrow<ID3DBlob> D3D::CompileShader(D3D::ShaderType type, D3D_FEAT
 	const char* target;
 	switch (feature_level)
 	{
+		case D3D_FEATURE_LEVEL_10_0:
+		{
+			static constexpr std::array<const char*, 4> targets = {{"vs_4_0", "ps_4_0", "cs_4_0"}};
+			target = targets[static_cast<int>(type)];
+		}
+		break;
+
 		case D3D_FEATURE_LEVEL_11_0:
 		{
 			static constexpr std::array<const char*, 4> targets = {{"vs_5_0", "ps_5_0", "cs_5_0"}};

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.h
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.h
@@ -91,6 +91,7 @@ private:
 	};
 
 	void SetFeatures(IDXGIAdapter1* adapter);
+	int GetMaxTextureSize() const;
 
 	bool CreateSwapChain();
 	bool CreateSwapChainRTV();
@@ -125,6 +126,8 @@ private:
 	wil::com_ptr_nothrow<ID3D11Buffer> m_expand_vb;
 	wil::com_ptr_nothrow<ID3D11Buffer> m_expand_ib;
 	wil::com_ptr_nothrow<ID3D11ShaderResourceView> m_expand_vb_srv;
+
+	D3D_FEATURE_LEVEL m_feature_level = D3D_FEATURE_LEVEL_10_0;
 	u32 m_vb_pos = 0; // bytes
 	u32 m_ib_pos = 0; // indices/sizeof(u32)
 	u32 m_structured_vb_pos = 0; // bytes
@@ -136,8 +139,8 @@ private:
 
 	struct
 	{
-		ID3D11InputLayout* layout;
 		D3D11_PRIMITIVE_TOPOLOGY topology;
+		ID3D11InputLayout* layout;
 		ID3D11Buffer* index_buffer;
 		ID3D11VertexShader* vs;
 		ID3D11Buffer* vs_cb;


### PR DESCRIPTION
### Description of Changes

Since I removed optional clip-control, apparently some GPUs from the mesozoic era can no longer run PCSX2.
DX11 feature level 10 is going to be better than GL on these GPUs, if anything even runs at all, because at least the depth is correct. GL provides no benefit, since texture barrier isn't supported, so no SW blend.

But add a warning, because we can't fix any bugs that happen on these setups.
![image](https://github.com/PCSX2/pcsx2/assets/11288319/9cdcc3b5-5cd8-452d-88cf-d902d6a1959d)

### Rationale behind Changes

Digging for fossils?

### Suggested Testing Steps

Make sure DX11 still works.
