### PR TITLE
GS/HW: Fix up RTA correction behaviour and preloading valid areas

### DIFF
--- a/bin/resources/shaders/dx11/convert.fx
+++ b/bin/resources/shaders/dx11/convert.fx
@@ -139,7 +139,7 @@ PS_OUTPUT ps_rta_correction(PS_INPUT input)
 {
 	PS_OUTPUT output;
 	float4 value = sample_c(input.t);
-	output.c = float4(value.rgb, value.a / (127.5f / 255.0f));
+	output.c = float4(value.rgb, value.a / (128.25f / 255.0f));
 	return output;
 }
 

--- a/bin/resources/shaders/opengl/convert.glsl
+++ b/bin/resources/shaders/opengl/convert.glsl
@@ -309,7 +309,7 @@ void ps_datm0_rta_correction()
 void ps_rta_correction()
 {
 	vec4 value = sample_c();
-	SV_Target0 = vec4(value.rgb, value.a / (127.5f / 255.0f));
+	SV_Target0 = vec4(value.rgb, value.a / (128.25f / 255.0f));
 }
 #endif
 

--- a/bin/resources/shaders/vulkan/convert.glsl
+++ b/bin/resources/shaders/vulkan/convert.glsl
@@ -114,7 +114,7 @@ void ps_datm0_rta_correction()
 void ps_rta_correction()
 {
 	vec4 value = sample_c(v_tex);
-	o_col0 = vec4(value.rgb, value.a / (127.5f / 255.0f));
+	o_col0 = vec4(value.rgb, value.a / (128.25f / 255.0f));
 }
 #endif
 

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -5396,7 +5396,7 @@ __ri void GSRendererHW::DrawPrims(GSTextureCache::Target* rt, GSTextureCache::Ta
 	// If we Correct/Decorrect and tex is rt, we will need to update the texture reference
 	const bool req_src_update = tex && rt && tex->m_target && tex->m_target_direct && tex->m_texture == rt->m_texture;
 
-	m_can_correct_alpha = !needs_ad;
+	m_can_correct_alpha = !needs_ad && (GSUtil::GetChannelMask(m_cached_ctx.FRAME.PSM) & 0x8);
 
 	if (rt)
 	{
@@ -5463,7 +5463,7 @@ __ri void GSRendererHW::DrawPrims(GSTextureCache::Target* rt, GSTextureCache::Ta
 			}
 		}
 		else if (!rt->m_rt_alpha_scale)
-			m_can_correct_alpha = rt->m_alpha_max <= 128 && !needs_ad;
+			m_can_correct_alpha = rt->m_alpha_max <= 128 && m_can_correct_alpha;
 
 		m_conf.ps.rta_correction = rt->m_rt_alpha_scale;
 	}
@@ -6411,7 +6411,8 @@ bool GSRendererHW::TryTargetClear(GSTextureCache::Target* rt, GSTextureCache::Ta
 		{
 			const u32 c = GetConstantDirectWriteMemClearColor();
 			u32 clear_c = c;
-			const bool alpha_one_or_less = (c >> 24) <= 0x80;
+			const bool has_alpha = GSLocalMemory::m_psm[rt->m_TEX0.PSM].trbpp != 24;
+			const bool alpha_one_or_less = has_alpha && (c >> 24) <= 0x80;
 			GL_INS("TryTargetClear(): RT at %x <= %08X", rt->m_TEX0.TBP0, c);
 
 			if (rt->m_rt_alpha_scale || alpha_one_or_less)
@@ -6430,7 +6431,7 @@ bool GSRendererHW::TryTargetClear(GSTextureCache::Target* rt, GSTextureCache::Ta
 
 			g_gs_device->ClearRenderTarget(rt->m_texture, clear_c);
 
-			if (GSLocalMemory::m_psm[rt->m_TEX0.PSM].trbpp != 24)
+			if (has_alpha)
 			{
 				rt->m_alpha_max = c >> 24;
 				rt->m_alpha_min = c >> 24;

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.h
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.h
@@ -120,6 +120,7 @@ private:
 	void FinishSplitClear();
 
 	bool IsRTWritten();
+	bool IsDepthAlwaysPassing();
 	bool IsUsingCsInBlend();
 	bool IsUsingAsInBlend();
 

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -2367,7 +2367,7 @@ GSTextureCache::Target* GSTextureCache::CreateTarget(GIFRegTEX0 TEX0, const GSVe
 
 	dst->m_last_draw = GSState::s_n;
 
-	if (dst->m_dirty.empty())
+	if (dst->m_dirty.empty() && (GSUtil::GetChannelMask(TEX0.PSM) & 0x8))
 		dst->m_rt_alpha_scale = true;
 	else
 		dst->m_last_draw -= 1; // If we preload and it needs to decorrect and we couldn't catch it early, we need to make sure it decorrects the data.

--- a/pcsx2/GS/Renderers/Metal/convert.metal
+++ b/pcsx2/GS/Renderers/Metal/convert.metal
@@ -129,7 +129,7 @@ fragment float4 ps_primid_rta_init_datm0(float4 p [[position]], DirectReadTextur
 fragment float4 ps_rta_correction(ConvertShaderData data [[stage_in]], ConvertPSRes res)
 {
 	float4 in = res.sample(data.t);
-	return float4(in.rgb, in.a / (127.5f / 255.0f));
+	return float4(in.rgb, in.a / (128.25f / 255.0f));
 }
 
 fragment float4 ps_rta_decorrection(ConvertShaderData data [[stage_in]], ConvertPSRes res)


### PR DESCRIPTION
### Description of Changes
Fix up some RTA behaviour and reduce the number of copies
Also correct the valid size when preloading from GS memory (and using uploaded data)

### Rationale behind Changes
There were places where it was doing RTA correction where it didn't need to, especially for 24 bit targets where the alpha doesn't exist, but also some times when the alpha was actually zero before the draw and non-zero after, but because we were updating it, it was doing it the copy way.

### Suggested Testing Steps
Test games, especially Shadow Hearts - Covenant

Fixes #10999
Fixes #10979

Shadow Hearts:
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/10c1f801-bc69-451d-a44a-b2fea2f668cc)
PR;
![image](https://github.com/PCSX2/pcsx2/assets/6278726/8b84ddb6-efc7-4251-913b-9bbfb904e661)
