### PR TITLE
GS/Vulkan: Fix incorrect clear colour for fast colclip

### DIFF
--- a/pcsx2/GS/Renderers/DX12/GSDevice12.h
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.h
@@ -510,7 +510,7 @@ public:
 		D3D12_RENDER_PASS_ENDING_ACCESS_TYPE depth_end = D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_NO_ACCESS,
 		D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE stencil_begin = D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_NO_ACCESS,
 		D3D12_RENDER_PASS_ENDING_ACCESS_TYPE stencil_end = D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_NO_ACCESS,
-		const u32 clear_color = 0, float clear_depth = 0.0f, u8 clear_stencil = 0);
+		GSVector4 clear_color = GSVector4::zero(), float clear_depth = 0.0f, u8 clear_stencil = 0);
 	void EndRenderPass();
 
 	void SetViewport(const D3D12_VIEWPORT& viewport);


### PR DESCRIPTION
### Description of Changes

I got blamed for breaking Brave, but turns out my clear fix just masked the real issue :cry:

### Rationale behind Changes

Fixes shadows in Brave, how many times I don't know now.

![image](https://github.com/PCSX2/pcsx2/assets/11288319/0d17425f-3f13-4266-bdd3-499222385db3)

(spike in the bottom left of the shadow)

### Suggested Testing Steps

Smoke test.
Check Brave if you have it.
