### PR TITLE
Qt: Fix crash on shutdown with BP mode open

### DIFF
--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -1972,6 +1972,7 @@ void MainWindow::closeEvent(QCloseEvent* event)
 	// If there's no VM, we can just exit as normal.
 	if (!s_vm_valid || !m_display_created)
 	{
+		m_is_closing = true;
 		saveStateToConfig();
 		if (m_display_created)
 			g_emu_thread->stopFullscreenUI();
@@ -2213,6 +2214,13 @@ std::optional<WindowInfo> MainWindow::acquireRenderWindow(bool recreate_window, 
 	// if we're going to surfaceless, we're done here
 	if (surfaceless)
 		return WindowInfo();
+
+	// very low-chance race here, if the user starts the fullscreen UI, and immediately closes the window.
+	if (m_is_closing)
+	{
+		m_display_created = false;
+		return std::nullopt;
+	}
 
 	createDisplayWidget(fullscreen, render_to_main);
 

--- a/pcsx2-qt/QtHost.h
+++ b/pcsx2-qt/QtHost.h
@@ -61,7 +61,7 @@ public:
 	__fi bool isExclusiveFullscreen() const { return m_is_exclusive_fullscreen; }
 	__fi bool isRenderingToMain() const { return m_is_rendering_to_main; }
 	__fi bool isSurfaceless() const { return m_is_surfaceless; }
-	__fi bool isRunningFullscreenUI() const { return m_run_fullscreen_ui; }
+	__fi bool isRunningFullscreenUI() const { return m_run_fullscreen_ui.load(std::memory_order_acquire); }
 
 	__fi bool isOnEmuThread() const { return (QThread::currentThread() == this); }
 	__fi bool isOnUIThread() const { return (QThread::currentThread() == m_ui_thread); }
@@ -206,9 +206,9 @@ private:
 	QTimer* m_background_controller_polling_timer = nullptr;
 
 	std::atomic_bool m_shutdown_flag{false};
+	std::atomic_bool m_run_fullscreen_ui{false};
 
 	bool m_verbose_status = false;
-	bool m_run_fullscreen_ui = false;
 	bool m_is_rendering_to_main = false;
 	bool m_is_fullscreen = false;
 	bool m_is_exclusive_fullscreen = false;


### PR DESCRIPTION
### Description of Changes

Yay race conditions

### Rationale behind Changes

Fixes #10995

### Suggested Testing Steps

Test closing with BP mode active
