### PR TITLE
Qt: Fix vanishing status bar renderer info

### DIFF
--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -1913,7 +1913,14 @@ void MainWindow::onVMStopped()
 {
 	s_vm_valid = false;
 	s_vm_paused = false;
-	m_last_fps_status = QString();
+
+	const QString empty_string;
+	m_last_fps_status = empty_string;
+	m_status_renderer_widget->setText(empty_string);
+	m_status_resolution_widget->setText(empty_string);
+	m_status_fps_widget->setText(empty_string);
+	m_status_vps_widget->setText(empty_string);
+
 	updateEmulationActions(false, false, false);
 	updateGameDependentActions();
 	updateWindowTitle();

--- a/pcsx2-qt/QtHost.cpp
+++ b/pcsx2-qt/QtHost.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2002-2023 PCSX2 Dev Team
+// SPDX-FileCopyrightText: 2002-2024 PCSX2 Dev Team
 // SPDX-License-Identifier: LGPL-3.0+
 
 #include "AutoUpdaterDialog.h"
@@ -927,6 +927,7 @@ void Host::OnVMStarting()
 
 void Host::OnVMStarted()
 {
+	g_emu_thread->updatePerformanceMetrics(true);
 	emit g_emu_thread->onVMStarted();
 }
 
@@ -1001,49 +1002,41 @@ void EmuThread::updatePerformanceMetrics(bool force)
 	if (iwidth != m_last_internal_width || iheight != m_last_internal_height || speed != m_last_speed || gfps != m_last_game_fps ||
 		vfps != m_last_video_fps || renderer != m_last_renderer || force)
 	{
-		if (iwidth == 0 && iheight == 0)
+		if (renderer != m_last_renderer || force)
 		{
-			// if we don't have width/height yet, we're not going to have fps either.
-			// and we'll probably be <100% due to compiling. so just leave it blank for now.
-			QString blank;
-			QMetaObject::invokeMethod(
-				g_main_window->getStatusRendererWidget(), "setText", Qt::QueuedConnection, Q_ARG(const QString&, blank));
-			QMetaObject::invokeMethod(
-				g_main_window->getStatusResolutionWidget(), "setText", Qt::QueuedConnection, Q_ARG(const QString&, blank));
-			QMetaObject::invokeMethod(g_main_window->getStatusFPSWidget(), "setText", Qt::QueuedConnection, Q_ARG(const QString&, blank));
-			QMetaObject::invokeMethod(g_main_window->getStatusVPSWidget(), "setText", Qt::QueuedConnection, Q_ARG(const QString&, blank));
-			return;
+			QMetaObject::invokeMethod(g_main_window->getStatusRendererWidget(), "setText", Qt::QueuedConnection,
+				Q_ARG(const QString&, QString::fromUtf8(Pcsx2Config::GSOptions::GetRendererName(renderer))));
+			m_last_renderer = renderer;
 		}
-		else
+
+		if (iwidth != m_last_internal_width || iheight != m_last_internal_height || force)
 		{
-			if (renderer != m_last_renderer || force)
-			{
-				QMetaObject::invokeMethod(g_main_window->getStatusRendererWidget(), "setText", Qt::QueuedConnection,
-					Q_ARG(const QString&, QString::fromUtf8(Pcsx2Config::GSOptions::GetRendererName(renderer))));
-				m_last_renderer = renderer;
-			}
-			if (iwidth != m_last_internal_width || iheight != m_last_internal_height || force)
-			{
-				QMetaObject::invokeMethod(g_main_window->getStatusResolutionWidget(), "setText", Qt::QueuedConnection,
-					Q_ARG(const QString&, tr("%1x%2").arg(iwidth).arg(iheight)));
-				m_last_internal_width = iwidth;
-				m_last_internal_height = iheight;
-			}
+			QString text;
+			if (iwidth == 0 || iheight == 0)
+				text = tr("N/A");
+			else
+				text = tr("%1x%2").arg(iwidth).arg(iheight);
 
-			if (gfps != m_last_game_fps || force)
-			{
-				QMetaObject::invokeMethod(g_main_window->getStatusFPSWidget(), "setText", Qt::QueuedConnection,
-					Q_ARG(const QString&, tr("Game: %1 FPS").arg(gfps, 0, 'f', 0)));
-				m_last_game_fps = gfps;
-			}
+			QMetaObject::invokeMethod(
+				g_main_window->getStatusResolutionWidget(), "setText", Qt::QueuedConnection, Q_ARG(const QString&, text));
 
-			if (speed != m_last_speed || vfps != m_last_video_fps || force)
-			{
-				QMetaObject::invokeMethod(g_main_window->getStatusVPSWidget(), "setText", Qt::QueuedConnection,
-					Q_ARG(const QString&, tr("Video: %1 FPS (%2%)").arg(vfps, 0, 'f', 0).arg(speed, 0, 'f', 0)));
-				m_last_speed = speed;
-				m_last_video_fps = vfps;
-			}
+			m_last_internal_width = iwidth;
+			m_last_internal_height = iheight;
+		}
+
+		if (gfps != m_last_game_fps || force)
+		{
+			QMetaObject::invokeMethod(g_main_window->getStatusFPSWidget(), "setText", Qt::QueuedConnection,
+				Q_ARG(const QString&, tr("Game: %1 FPS").arg(gfps, 0, 'f', 0)));
+			m_last_game_fps = gfps;
+		}
+
+		if (speed != m_last_speed || vfps != m_last_video_fps || force)
+		{
+			QMetaObject::invokeMethod(g_main_window->getStatusVPSWidget(), "setText", Qt::QueuedConnection,
+				Q_ARG(const QString&, tr("Video: %1 FPS (%2%)").arg(vfps, 0, 'f', 0).arg(speed, 0, 'f', 0)));
+			m_last_speed = speed;
+			m_last_video_fps = vfps;
 		}
 	}
 }

--- a/pcsx2-qt/QtHost.h
+++ b/pcsx2-qt/QtHost.h
@@ -223,7 +223,7 @@ private:
 	float m_last_video_fps = 0.0f;
 	int m_last_internal_width = 0;
 	int m_last_internal_height = 0;
-	GSRendererType m_last_renderer = GSRendererType::Null;
+	GSRendererType m_last_renderer = GSRendererType::Auto;
 };
 
 extern EmuThread* g_emu_thread;

--- a/pcsx2/GS/Renderers/Common/GSRenderer.cpp
+++ b/pcsx2/GS/Renderers/Common/GSRenderer.cpp
@@ -97,7 +97,10 @@ bool GSRenderer::Merge(int field)
 	PCRTCDisplays.CheckSameSource();
 
 	if (!PCRTCDisplays.PCRTCDisplays[0].enabled && !PCRTCDisplays.PCRTCDisplays[1].enabled)
+	{
+		m_real_size = GSVector2i(0, 0);
 		return false;
+	}
 
 	// Need to do this here, if the user has Anti-Blur enabled, these offsets can get wiped out/changed.
 	const bool game_deinterlacing = (m_regs->DISP[0].DISPFB.DBY != PCRTCDisplays.PCRTCDisplays[0].prevFramebufferReg.DBY) !=
@@ -127,7 +130,10 @@ bool GSRenderer::Merge(int field)
 	}
 
 	if (!tex[0] && !tex[1])
+	{
+		m_real_size = GSVector2i(0, 0);
 		return false;
+	}
 
 	s_n++;
 


### PR DESCRIPTION
### Description of Changes

Fixes renderer information getting stuck blank when switching renderers, or loading GS dumps.
Also replaces the "previous" resolution being displayed with "No Image" if PCRTC displays are off.

### Rationale behind Changes

Closes #11006.

### Suggested Testing Steps

@JordanTheToaster knows what to do.
