### PR TITLE
GS/HW: Avoid deleting depth targets on shuffles

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -2104,7 +2104,7 @@ GSTextureCache::Target* GSTextureCache::LookupTarget(GIFRegTEX0 TEX0, const GSVe
 				// puzzle of pages and can't be expecting to have legitimate data. Tokimeki Memorial 3 reuses a BW 17
 				// buffer as BW 10, and if we don't discard the BW 17 buffer, the BW 10 buffer ends up twice the size.
 				const u32 shuffle_bw = (psm_s.bpp > t_psm_s.bpp) ? (TEX0.TBW / 2u) : (TEX0.TBW * 2u);
-				if (t->m_TEX0.TBW != TEX0.TBW && t->m_TEX0.TBW != shuffle_bw)
+				if (t->m_TEX0.TBW != TEX0.TBW && (t->m_TEX0.TBW != shuffle_bw && !is_shuffle))
 				{
 					// But we'll make sure the whole existing target's actually being drawn over to be safe.
 					const u32 end_block = GSLocalMemory::GetUnwrappedEndBlockAddress(TEX0.TBP0, TEX0.TBW, TEX0.PSM, draw_rect);


### PR DESCRIPTION
### Description of Changes
Avoid deleting depth targets on shuffles

### Rationale behind Changes
Bee Movie does a weird size to a shuffle (essentially 640x448 over a 512x512) and it was deleting the depth target when it was attached to the source, but we shouldn't really be deleting targets on shuffles, the was causing null exceptions later on, which crashed PCSX2, not to mention broke the graphics.

### Suggested Testing Steps
Smoke test mostly and Bee Movie. Dump run was fine.

Fixes #11004

Bee Movie:
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/6b8e1ddf-02c4-4c85-9538-d06cde565efa)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/35f7bf29-f210-4b77-be0e-371dc5c1cf6d)

