### PR TITLE
Debugger: Stability improvements

### DIFF
--- a/pcsx2-qt/Debugger/CpuWidget.cpp
+++ b/pcsx2-qt/Debugger/CpuWidget.cpp
@@ -43,7 +43,7 @@ CpuWidget::CpuWidget(QWidget* parent, DebugInterface& cpu)
 	m_ui.setupUi(this);
 
 	connect(g_emu_thread, &EmuThread::onVMPaused, this, &CpuWidget::onVMPaused);
-	connect(g_emu_thread, &EmuThread::onGameChanged, [this](const QString& title) {
+	connect(g_emu_thread, &EmuThread::onGameChanged, this, [this](const QString& title) {
 		if (title.isEmpty())
 			return;
 		// Don't overwrite users BPs/Saved Addresses unless they have a clean state.

--- a/pcsx2-qt/Debugger/CpuWidget.cpp
+++ b/pcsx2-qt/Debugger/CpuWidget.cpp
@@ -57,8 +57,8 @@ CpuWidget::CpuWidget(QWidget* parent, DebugInterface& cpu)
 	connect(m_ui.memoryviewWidget, &MemoryViewWidget::gotoInDisasm, m_ui.disassemblyWidget, &DisassemblyWidget::gotoAddress);
 	connect(m_ui.memoryviewWidget, &MemoryViewWidget::addToSavedAddresses, this, &CpuWidget::addAddressToSavedAddressesList);
 
-	connect(m_ui.registerWidget, &RegisterWidget::gotoInMemory, m_ui.memoryviewWidget, &MemoryViewWidget::gotoAddress);
-	connect(m_ui.disassemblyWidget, &DisassemblyWidget::gotoInMemory, m_ui.memoryviewWidget, &MemoryViewWidget::gotoAddress);
+	connect(m_ui.registerWidget, &RegisterWidget::gotoInMemory, this, &CpuWidget::onGotoInMemory);
+	connect(m_ui.disassemblyWidget, &DisassemblyWidget::gotoInMemory, this, &CpuWidget::onGotoInMemory);
 
 	connect(m_ui.memoryviewWidget, &MemoryViewWidget::VMUpdate, this, &CpuWidget::reloadCPUWidgets);
 	connect(m_ui.registerWidget, &RegisterWidget::VMUpdate, this, &CpuWidget::reloadCPUWidgets);
@@ -385,6 +385,12 @@ void CpuWidget::onBPListContextMenu(QPoint pos)
 	}
 
 	contextMenu->popup(m_ui.breakpointList->viewport()->mapToGlobal(pos));
+}
+
+void CpuWidget::onGotoInMemory(u32 address)
+{
+	m_ui.memoryviewWidget->gotoAddress(address);
+	m_ui.tabWidget->setCurrentWidget(m_ui.tab_memory);
 }
 
 void CpuWidget::contextBPListCopy()
@@ -752,6 +758,7 @@ void CpuWidget::onFuncListContextMenu(QPoint pos)
 		QAction* gotoMemory = new QAction(tr("Go to in Memory View"), m_ui.listFunctions);
 		connect(gotoMemory, &QAction::triggered, [this] {
 			m_ui.memoryviewWidget->gotoAddress(m_ui.listFunctions->selectedItems().first()->data(Qt::UserRole).toUInt());
+			m_ui.tabWidget->setCurrentWidget(m_ui.tab_memory);
 		});
 
 		m_funclistContextMenu->addAction(gotoMemory);
@@ -827,6 +834,7 @@ void CpuWidget::onModuleTreeContextMenu(QPoint pos)
 		QAction* gotoMemory = new QAction(tr("Go to in Memory View"), m_ui.treeModules);
 		connect(gotoMemory, &QAction::triggered, [this] {
 			m_ui.memoryviewWidget->gotoAddress(m_ui.treeModules->selectedItems().first()->data(0, Qt::UserRole).toUInt());
+			m_ui.tabWidget->setCurrentWidget(m_ui.tab_memory);
 		});
 		m_moduleTreeContextMenu->addAction(gotoMemory);
 	}

--- a/pcsx2-qt/Debugger/CpuWidget.h
+++ b/pcsx2-qt/Debugger/CpuWidget.h
@@ -76,7 +76,11 @@ public slots:
 	{
 		if (!QtHost::IsOnUIThread())
 		{
-			QtHost::RunOnUIThread(CBreakPoints::GetUpdateHandler());
+			const auto& updateHandler = CBreakPoints::GetUpdateHandler();
+			if (updateHandler)
+			{
+				QtHost::RunOnUIThread(updateHandler);
+			}
 			return;
 		}
 

--- a/pcsx2-qt/Debugger/CpuWidget.h
+++ b/pcsx2-qt/Debugger/CpuWidget.h
@@ -6,9 +6,6 @@
 #include "ui_CpuWidget.h"
 
 #include "DebugTools/DebugInterface.h"
-#include "DebugTools/Breakpoints.h"
-#include "DebugTools/BiosDebugData.h"
-#include "DebugTools/MipsStackWalk.h"
 
 #include "Models/BreakpointModel.h"
 #include "Models/ThreadModel.h"
@@ -72,26 +69,7 @@ public slots:
 	void onModuleTreeContextMenu(QPoint pos);
 	void onModuleTreeDoubleClick(QTreeWidgetItem* item);
 	void refreshDebugger();
-	void reloadCPUWidgets()
-	{
-		if (!QtHost::IsOnUIThread())
-		{
-			const auto& updateHandler = CBreakPoints::GetUpdateHandler();
-			if (updateHandler)
-			{
-				QtHost::RunOnUIThread(updateHandler);
-			}
-			return;
-		}
-
-		updateBreakpoints();
-		updateThreads();
-		updateStackFrames();
-
-		m_ui.registerWidget->update();
-		m_ui.disassemblyWidget->update();
-		m_ui.memoryviewWidget->update();
-	};
+	void reloadCPUWidgets();
 
 	void saveBreakpointsToDebuggerSettings();
 	void saveSavedAddressesToDebuggerSettings();

--- a/pcsx2-qt/Debugger/CpuWidget.h
+++ b/pcsx2-qt/Debugger/CpuWidget.h
@@ -42,6 +42,7 @@ public slots:
 	void updateBreakpoints();
 	void onBPListDoubleClicked(const QModelIndex& index);
 	void onBPListContextMenu(QPoint pos);
+	void onGotoInMemory(u32 address);
 
 	void contextBPListCopy();
 	void contextBPListDelete();

--- a/pcsx2-qt/Debugger/DebuggerWindow.cpp
+++ b/pcsx2-qt/Debugger/DebuggerWindow.cpp
@@ -45,14 +45,9 @@ DebuggerWindow::DebuggerWindow(QWidget* parent)
 
 	m_ui.cpuTabs->addTab(m_cpuWidget_r5900, "R5900");
 	m_ui.cpuTabs->addTab(m_cpuWidget_r3000, "R3000");
-
-	CBreakPoints::SetUpdateHandler(std::bind(&DebuggerWindow::onBreakpointsChanged, this));
 }
 
-DebuggerWindow::~DebuggerWindow()
-{
-	CBreakPoints::SetUpdateHandler(nullptr);
-}
+DebuggerWindow::~DebuggerWindow() = default;
 
 // There is no straightforward way to set the tab text to bold in Qt
 // Sorry colour blind people, but this is the best we can do for now
@@ -131,10 +126,4 @@ void DebuggerWindow::onStepOut()
 {
 	CpuWidget* currentCpu = static_cast<CpuWidget*>(m_ui.cpuTabs->currentWidget());
 	currentCpu->onStepOut();
-}
-
-void DebuggerWindow::onBreakpointsChanged()
-{
-	m_cpuWidget_r5900->reloadCPUWidgets();
-	m_cpuWidget_r3000->reloadCPUWidgets();
 }

--- a/pcsx2-qt/Debugger/DebuggerWindow.cpp
+++ b/pcsx2-qt/Debugger/DebuggerWindow.cpp
@@ -47,11 +47,12 @@ DebuggerWindow::DebuggerWindow(QWidget* parent)
 	m_ui.cpuTabs->addTab(m_cpuWidget_r3000, "R3000");
 
 	CBreakPoints::SetUpdateHandler(std::bind(&DebuggerWindow::onBreakpointsChanged, this));
-
-	return;
 }
 
-DebuggerWindow::~DebuggerWindow() = default;
+DebuggerWindow::~DebuggerWindow()
+{
+	CBreakPoints::SetUpdateHandler(nullptr);
+}
 
 // There is no straightforward way to set the tab text to bold in Qt
 // Sorry colour blind people, but this is the best we can do for now

--- a/pcsx2-qt/Debugger/DebuggerWindow.h
+++ b/pcsx2-qt/Debugger/DebuggerWindow.h
@@ -21,7 +21,6 @@ public slots:
 	void onStepInto();
 	void onStepOver();
 	void onStepOut();
-	void onBreakpointsChanged();
 
 private:
 	Ui::DebuggerWindow m_ui;

--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -776,7 +776,9 @@ void MainWindow::onAchievementsHardcoreModeChanged(bool enabled)
 	m_ui.actionDebugger->setDisabled(enabled);
 	if (enabled)
 	{
-		if (m_debugger_window)
+		// If PauseOnEntry is enabled, we prompt the user to disable Hardcore Mode
+		// or cancel the action later, so we should keep the debugger around
+		if (m_debugger_window && !DebugInterface::getPauseOnEntry())
 		{
 			m_debugger_window->close();
 			m_debugger_window->deleteLater();

--- a/pcsx2/DebugTools/Breakpoints.cpp
+++ b/pcsx2/DebugTools/Breakpoints.cpp
@@ -18,7 +18,6 @@ std::vector<MemCheck*> CBreakPoints::cleanupMemChecks_;
 bool CBreakPoints::breakpointTriggered_ = false;
 BreakPointCpu CBreakPoints::breakpointTriggeredCpu_;
 bool CBreakPoints::corePaused = false;
-std::function<void()> CBreakPoints::cb_bpUpdated_;
 
 // called from the dynarec
 u32 standardizeBreakpointAddress(u32 addr)
@@ -440,7 +439,4 @@ void CBreakPoints::Update(BreakPointCpu cpu, u32 addr)
 
 	if (resume)
 		r5900Debug.resumeCpu();
-
-	if (cb_bpUpdated_)
-		cb_bpUpdated_();
 }

--- a/pcsx2/DebugTools/Breakpoints.h
+++ b/pcsx2/DebugTools/Breakpoints.h
@@ -151,8 +151,8 @@ public:
 	static void SetCorePaused(bool b) { corePaused = b; };
 
 	// This will have to do until a full fledged debugger host interface is made
-	static void SetUpdateHandler(std::function<void()> f) {cb_bpUpdated_ = f; };
-	static std::function<void()> GetUpdateHandler() { return cb_bpUpdated_; };
+	static void SetUpdateHandler(std::function<void()> f) {cb_bpUpdated_ = std::move(f); };
+	static const std::function<void()>& GetUpdateHandler() { return cb_bpUpdated_; };
 
 private:
 	static size_t FindBreakpoint(BreakPointCpu cpu, u32 addr, bool matchTemp = false, bool temp = false);

--- a/pcsx2/DebugTools/Breakpoints.h
+++ b/pcsx2/DebugTools/Breakpoints.h
@@ -4,7 +4,6 @@
 #pragma once
 
 #include <algorithm>
-#include <functional>
 #include <iterator>
 #include <vector>
 
@@ -150,10 +149,6 @@ public:
 	static bool GetCorePaused() { return corePaused; };
 	static void SetCorePaused(bool b) { corePaused = b; };
 
-	// This will have to do until a full fledged debugger host interface is made
-	static void SetUpdateHandler(std::function<void()> f) {cb_bpUpdated_ = std::move(f); };
-	static const std::function<void()>& GetUpdateHandler() { return cb_bpUpdated_; };
-
 private:
 	static size_t FindBreakpoint(BreakPointCpu cpu, u32 addr, bool matchTemp = false, bool temp = false);
 	// Finds exactly, not using a range check.
@@ -168,8 +163,6 @@ private:
 	static bool breakpointTriggered_;
 	static BreakPointCpu breakpointTriggeredCpu_;
 	static bool corePaused;
-
-	static std::function<void()> cb_bpUpdated_;
 
 	static std::vector<MemCheck> memChecks_;
 	static std::vector<MemCheck *> cleanupMemChecks_;

--- a/pcsx2/DebugTools/DebugInterface.cpp
+++ b/pcsx2/DebugTools/DebugInterface.cpp
@@ -700,7 +700,8 @@ bool R5900DebugInterface::isValidAddress(u32 addr)
 		case 0xA:
 		case 0xB:
 			// [ 8000_0000 - BFFF_FFFF ] kernel
-			return true;
+			if (lopart >= 0xFC00000)
+				return true;
 		case 0xF:
 			// [ 8000_0000 - BFFF_FFFF ] IOP or kernel stack
 			if (lopart >= 0xfff8000)


### PR DESCRIPTION
### Description of Changes

This PR fixes numerous issues related to the debugger:
1. Fixes an use-after-free where breakpoints were updated after DebuggerWindow shut down already.
2. Adds a Hardcore Mode disable prompt when starting Boot and Debug with HC enabled.
3. Marks addresses `< 0xBFC00000` as invalid, fixing asserts in Debug and possible crashes in Release (by @F0bes).
4. Fixes numerous data races in the code, such as:
   * Unbinding a debug interface update CB while it's in use, causing a possible use-after-free.
   * Binding breakpoints via the disassembly widget that would read a stale local variable, and bind the breakpoint to a bogus address.

### Rationale behind Changes
Stability good.

### Suggested Testing Steps
1. Test Boot and Debug with Hardcore Mode **disabled**.
2. Test Boot and Debug with Hardcore Mode **enabled**.
3. Test binding and unbinding breakpoints by double clicking on the Disassembly Widget.
5. Test binding and unbinding breakpoints by adding them to the Breakpoints tab manually.