### PR TITLE
GS/HW: Compute source alpha min/max based on texture instead of CLUT

### DIFF
--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -3916,17 +3916,25 @@ void GSState::CalcAlphaMinMax(const int tex_alpha_min, const int tex_alpha_max)
 				case 1:
 					// If we're using the alpha from the texture, not the whole range, we can just use tex_alpha_min/max.
 					// AEM and TA0 re precomputed with GSBlock::ReadAndExpandBlock24, so already worked out for tex_alpha.
-					a.y = (tex_alpha_max < 500) ? min : (env.TEXA.AEM ? 0 : env.TEXA.TA0);
-					a.w = (tex_alpha_max < 500) ? max : env.TEXA.TA0;
+					a.y = (tex_alpha_max < INVALID_ALPHA_MINMAX) ? min : (env.TEXA.AEM ? 0 : env.TEXA.TA0);
+					a.w = (tex_alpha_max < INVALID_ALPHA_MINMAX) ? max : env.TEXA.TA0;
 					break;
 				case 2:
 					// If we're using the alpha from the texture, not the whole range, we can just use tex_alpha_min/max.
 					// AEM, TA0 and TA1 are precomputed with GSBlock::ReadAndExpandBlock16, so already worked out for tex_alpha.
-					a.y = (tex_alpha_max < 500) ? min : (env.TEXA.AEM ? 0 : std::min(env.TEXA.TA0, env.TEXA.TA1));
-					a.w = (tex_alpha_max < 500) ? max : std::max(env.TEXA.TA0, env.TEXA.TA1);
+					a.y = (tex_alpha_max < INVALID_ALPHA_MINMAX) ? min : (env.TEXA.AEM ? 0 : std::min(env.TEXA.TA0, env.TEXA.TA1));
+					a.w = (tex_alpha_max < INVALID_ALPHA_MINMAX) ? max : std::max(env.TEXA.TA0, env.TEXA.TA1);
 					break;
 				case 3:
-					m_mem.m_clut.GetAlphaMinMax32(a.y, a.w);
+					if (tex_alpha_max < INVALID_ALPHA_MINMAX)
+					{
+						a.y = min;
+						a.w = max;
+					}
+					else
+					{
+						m_mem.m_clut.GetAlphaMinMax32(a.y, a.w);
+					}
 					break;
 				default:
 					ASSUME(0);

--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -122,6 +122,8 @@ private:
 	} m_tr;
 
 protected:
+	static constexpr int INVALID_ALPHA_MINMAX = 500;
+
 	GSVertex m_v = {};
 	float m_q = 1.0f;
 	GSVector4i m_scissor_cull_min = {};
@@ -163,7 +165,7 @@ protected:
 	GSVertexTrace::VertexAlpha& GetAlphaMinMax()
 	{
 		if (!m_vt.m_alpha.valid)
-			CalcAlphaMinMax(0, 500);
+			CalcAlphaMinMax(0, INVALID_ALPHA_MINMAX);
 		return m_vt.m_alpha;
 	}
 	struct TextureMinMaxResult

--- a/pcsx2/GS/Renderers/HW/GSHwHack.cpp
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.cpp
@@ -1432,11 +1432,7 @@ bool GSHwHack::MV_Ico(GSRendererHW& r)
 	const GSVector4i draw_rc = GSVector4i(0, 0, RWIDTH, RHEIGHT).rintersect(dst->GetUnscaledRect());
 	dst->UpdateValidChannels(PSMCT32, 0);
 	dst->UpdateValidity(draw_rc);
-
-	if (dst->m_rt_alpha_scale)
-	{
-		dst->RTADecorrect(dst);
-	}
+	dst->RTADecorrect();
 
 	GSHWDrawConfig& config = GSRendererHW::GetInstance()->BeginHLEHardwareDraw(
 		dst->GetTexture(), nullptr, dst->GetScale(), src->GetTexture(), src->GetScale(), draw_rc);

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -2489,7 +2489,7 @@ void GSRendererHW::Draw()
 			// We don't know the alpha range of direct sources when we first tried to optimize the alpha test.
 			// Moving the texture lookup before the ATST optimization complicates things a lot, so instead,
 			// recompute it, and everything derived from it again if it changes.
-			if (GSLocalMemory::m_psm[src->m_TEX0.PSM].pal == 0)
+			if (src->m_valid_alpha_minmax)
 			{
 				CalcAlphaMinMax(src->m_alpha_minmax.first, src->m_alpha_minmax.second);
 

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -4368,7 +4368,7 @@ void GSRendererHW::EmulateBlending(int rt_alpha_min, int rt_alpha_max, bool& DAT
 		const bool rta_correction = m_can_correct_alpha && !blend_ad_alpha_masked && m_conf.ps.blend_c == 1 && !(blend_flag & BLEND_A_MAX);
 		if (rta_correction)
 		{
-			rt->RTACorrect(rt);
+			rt->RTACorrect();
 			m_conf.ps.rta_correction = rt->m_rt_alpha_scale;
 			m_conf.rt = rt->m_texture;
 		}
@@ -5411,7 +5411,7 @@ __ri void GSRendererHW::DrawPrims(GSTextureCache::Target* rt, GSTextureCache::Ta
 				{
 					m_can_correct_alpha = false;
 
-					rt->RTADecorrect(rt);
+					rt->RTADecorrect();
 					m_conf.rt = rt->m_texture;
 
 					if (req_src_update)
@@ -5427,7 +5427,7 @@ __ri void GSRendererHW::DrawPrims(GSTextureCache::Target* rt, GSTextureCache::Ta
 					else if (m_cached_ctx.FRAME.FBMSK & 0xFFFC0000)
 					{
 						m_can_correct_alpha = false;
-						rt->RTADecorrect(rt);
+						rt->RTADecorrect();
 						m_conf.rt = rt->m_texture;
 
 						if (req_src_update)
@@ -5440,7 +5440,7 @@ __ri void GSRendererHW::DrawPrims(GSTextureCache::Target* rt, GSTextureCache::Ta
 				if (m_conf.ps.tales_of_abyss_hle || (tex && tex->m_from_target && tex->m_from_target == rt && m_conf.ps.channel == ChannelFetch_ALPHA) || partial_fbmask || rt->m_alpha_max > 128)
 				{
 					m_can_correct_alpha = false;
-					rt->RTADecorrect(rt);
+					rt->RTADecorrect();
 					m_conf.rt = rt->m_texture;
 
 					if (req_src_update)
@@ -5455,7 +5455,7 @@ __ri void GSRendererHW::DrawPrims(GSTextureCache::Target* rt, GSTextureCache::Ta
 			else
 			{
 				m_can_correct_alpha = false;
-				rt->RTADecorrect(rt);
+				rt->RTADecorrect();
 				m_conf.rt = rt->m_texture;
 
 				if (req_src_update)
@@ -5489,7 +5489,7 @@ __ri void GSRendererHW::DrawPrims(GSTextureCache::Target* rt, GSTextureCache::Ta
 
 			if (!full_cover)
 			{
-				rt->RTACorrect(rt);
+				rt->RTACorrect();
 				m_conf.rt = rt->m_texture;
 			}
 			else
@@ -5959,7 +5959,7 @@ GSRendererHW::CLUTDrawTestResult GSRendererHW::PossibleCLUTDraw()
 				m_cached_ctx.TEX0.TBP0, m_cached_ctx.TEX0.TBW, m_cached_ctx.TEX0.PSM, r);
 			if (tgt)
 			{
-				tgt->RTADecorrect(tgt);
+				tgt->RTADecorrect();
 				bool is_dirty = false;
 				for (const GSDirtyRect& rc : tgt->m_dirty)
 				{

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -993,7 +993,7 @@ GSTextureCache::Source* GSTextureCache::LookupDepthSource(const bool is_depth, c
 
 		if (palette)
 		{
-			AttachPaletteToSource(src, psm_s.pal, true);
+			AttachPaletteToSource(src, psm_s.pal, true, true);
 		}
 	}
 	else
@@ -1645,7 +1645,7 @@ GSTextureCache::Source* GSTextureCache::LookupSource(const bool is_color, const 
 								if (TEX0.PSM == PSMT8H)
 								{
 									// Attach palette for GPU texture conversion
-									AttachPaletteToSource(src, psm_s.pal, true);
+									AttachPaletteToSource(src, psm_s.pal, true, true);
 								}
 
 								return src;
@@ -1666,7 +1666,7 @@ GSTextureCache::Source* GSTextureCache::LookupSource(const bool is_color, const 
 									if (TEX0.PSM == PSMT8H)
 									{
 										// Attach palette for GPU texture conversion
-										AttachPaletteToSource(src, psm_s.pal, true);
+										AttachPaletteToSource(src, psm_s.pal, true, true);
 									}
 
 									return src;
@@ -1715,6 +1715,8 @@ GSTextureCache::Source* GSTextureCache::LookupSource(const bool is_color, const 
 		// Guard against merged targets which don't actually link.
 		if (src->m_target && src->m_from_target)
 		{
+			src->m_valid_alpha_minmax = true;
+
 			if ((src->m_TEX0.PSM & 0xf) == PSMCT24)
 			{
 				src->m_alpha_minmax.first = TEXA.AEM ? 0 : TEXA.TA0;
@@ -1739,7 +1741,7 @@ GSTextureCache::Source* GSTextureCache::LookupSource(const bool is_color, const 
 		if (gpu_clut)
 			AttachPaletteToSource(src, gpu_clut);
 		else if (src->m_palette && (!src->m_palette_obj || !src->ClutMatch({clut, psm_s.pal})))
-			AttachPaletteToSource(src, psm_s.pal, true);
+			AttachPaletteToSource(src, psm_s.pal, true, true);
 	}
 
 	src->Update(r);
@@ -4375,6 +4377,7 @@ GSTextureCache::Source* GSTextureCache::CreateSource(const GIFRegTEX0& TEX0, con
 		src->m_from_target = dst;
 		src->m_from_target_TEX0 = dst->m_TEX0;
 
+		src->m_valid_alpha_minmax = true;
 		if ((src->m_TEX0.PSM & 0xf) == PSMCT24)
 		{
 			src->m_alpha_minmax.first = TEXA.AEM ? 0 : TEXA.TA0;
@@ -4399,7 +4402,7 @@ GSTextureCache::Source* GSTextureCache::CreateSource(const GIFRegTEX0& TEX0, con
 		if (psm.pal > 0)
 		{
 			// Attach palette for GPU texture conversion
-			AttachPaletteToSource(src, psm.pal, true);
+			AttachPaletteToSource(src, psm.pal, true, true);
 		}
 
 #ifdef PCSX2_DEVBUILD
@@ -4455,6 +4458,7 @@ GSTextureCache::Source* GSTextureCache::CreateSource(const GIFRegTEX0& TEX0, con
 		// Do this first as we could be adding in alpha from an upgraded 24bit target.
 		dst->Update();
 
+		src->m_valid_alpha_minmax = true;
 		if ((src->m_TEX0.PSM & 0xf) == PSMCT24)
 		{
 			src->m_alpha_minmax.first = TEXA.AEM ? 0 : TEXA.TA0;
@@ -4710,7 +4714,7 @@ GSTextureCache::Source* GSTextureCache::CreateSource(const GIFRegTEX0& TEX0, con
 		// Because the texture is already on the GPU, CPU can't convert it.
 		if (psm.pal > 0)
 		{
-			AttachPaletteToSource(src, psm.pal, true);
+			AttachPaletteToSource(src, psm.pal, true, true);
 		}
 
 		// Offset hack. Can be enabled via GS options.
@@ -4742,11 +4746,12 @@ GSTextureCache::Source* GSTextureCache::CreateSource(const GIFRegTEX0& TEX0, con
 		{
 			src->m_texture = src->m_from_hash_cache->texture;
 			src->m_alpha_minmax = src->m_from_hash_cache->alpha_minmax;
+			src->m_valid_alpha_minmax = src->m_from_hash_cache->valid_alpha_minmax;
 
 			if (gpu_clut)
 				AttachPaletteToSource(src, gpu_clut);
 			else if (psm.pal > 0)
-				AttachPaletteToSource(src, psm.pal, paltex);
+				AttachPaletteToSource(src, psm.pal, paltex, false);
 		}
 		else if (paltex)
 		{
@@ -4762,7 +4767,7 @@ GSTextureCache::Source* GSTextureCache::CreateSource(const GIFRegTEX0& TEX0, con
 			if (gpu_clut)
 				AttachPaletteToSource(src, gpu_clut);
 			else
-				AttachPaletteToSource(src, psm.pal, true);
+				AttachPaletteToSource(src, psm.pal, true, true);
 		}
 		else
 		{
@@ -4778,7 +4783,7 @@ GSTextureCache::Source* GSTextureCache::CreateSource(const GIFRegTEX0& TEX0, con
 			if (gpu_clut)
 				AttachPaletteToSource(src, gpu_clut);
 			else if (psm.pal > 0)
-				AttachPaletteToSource(src, psm.pal, false);
+				AttachPaletteToSource(src, psm.pal, false, true);
 		}
 
 #ifdef PCSX2_DEVBUILD
@@ -5231,10 +5236,12 @@ GSTextureCache::HashCacheEntry* GSTextureCache::LookupHashCache(const GIFRegTEX0
 		return nullptr;
 	}
 
-	// upload base level
-	const bool is_direct = (GSLocalMemory::m_psm[TEX0.PSM].pal == 0);
+	// compute alpha minmax on all textures, unless paltex is on, because not all CLUT colors are used.
+	const bool compute_alpha_minmax = !paltex;
 	std::pair<u8, u8> alpha_minmax = {0u, 255u};
-	PreloadTexture(TEX0, TEXA, region, g_gs_renderer->m_mem, paltex, tex, 0, is_direct ? &alpha_minmax : nullptr);
+
+	// upload base level
+	PreloadTexture(TEX0, TEXA, region, g_gs_renderer->m_mem, paltex, tex, 0, compute_alpha_minmax ? &alpha_minmax : nullptr);
 
 	// upload mips if present
 	if (lod)
@@ -5246,8 +5253,8 @@ GSTextureCache::HashCacheEntry* GSTextureCache::LookupHashCache(const GIFRegTEX0
 			const GIFRegTEX0 MIP_TEX0{g_gs_renderer->GetTex0Layer(basemip + mip)};
 			std::pair<u8, u8> mip_alpha_minmax;
 			PreloadTexture(MIP_TEX0, TEXA, region.AdjustForMipmap(mip), g_gs_renderer->m_mem, paltex, tex, mip,
-				is_direct ? &mip_alpha_minmax : nullptr);
-			if (!is_direct)
+				compute_alpha_minmax ? &mip_alpha_minmax : nullptr);
+			if (compute_alpha_minmax)
 			{
 				alpha_minmax.first = std::min(alpha_minmax.first, mip_alpha_minmax.first);
 				alpha_minmax.second = std::max(alpha_minmax.second, mip_alpha_minmax.second);
@@ -5260,7 +5267,7 @@ GSTextureCache::HashCacheEntry* GSTextureCache::LookupHashCache(const GIFRegTEX0
 		key.RemoveCLUTHash();
 
 	// insert into the cache cache, and we're done
-	const HashCacheEntry entry{tex, 1u, 0u, alpha_minmax, false};
+	const HashCacheEntry entry{tex, 1u, 0u, alpha_minmax, compute_alpha_minmax, false};
 	m_hash_cache_memory_usage += tex->GetMemUsage();
 	return &m_hash_cache.emplace(key, entry).first->second;
 }
@@ -5916,7 +5923,7 @@ void GSTextureCache::Source::PreloadLevel(int level)
 	m_layer_hash[level] = hash;
 
 	// And upload the texture.
-	if (IsPaletteFormat())
+	if (!m_valid_alpha_minmax)
 	{
 		PreloadTexture(m_TEX0, m_TEXA, m_region.AdjustForMipmap(level), g_gs_renderer->m_mem, m_palette != nullptr,
 			m_texture, level, nullptr);
@@ -6435,11 +6442,15 @@ void GSTextureCache::SourceMap::RemoveAt(Source* s)
 	delete s;
 }
 
-void GSTextureCache::AttachPaletteToSource(Source* s, u16 pal, bool need_gs_texture)
+void GSTextureCache::AttachPaletteToSource(Source* s, u16 pal, bool need_gs_texture, bool update_alpha_minmax)
 {
 	s->m_palette_obj = m_palette_map.LookupPalette(pal, need_gs_texture);
 	s->m_palette = need_gs_texture ? s->m_palette_obj->GetPaletteGSTexture() : nullptr;
-	s->m_alpha_minmax = s->m_palette_obj->GetAlphaMinMax();
+	if (update_alpha_minmax)
+	{
+		s->m_alpha_minmax = s->m_palette_obj->GetAlphaMinMax();
+		s->m_valid_alpha_minmax = true;
+	}
 }
 
 void GSTextureCache::AttachPaletteToSource(Source* s, GSTexture* gpu_clut)
@@ -6448,6 +6459,7 @@ void GSTextureCache::AttachPaletteToSource(Source* s, GSTexture* gpu_clut)
 	s->m_palette = gpu_clut;
 
 	// Unknown.
+	s->m_valid_alpha_minmax = false;
 	s->m_alpha_minmax.first = 0;
 	s->m_alpha_minmax.second = 255;
 }
@@ -6657,7 +6669,7 @@ void GSTextureCache::InjectHashCacheTexture(const HashCacheKey& key, GSTexture* 
 	{
 		// We must've got evicted before we finished loading. No matter, add it in there anyway;
 		// if it's not used again, it'll get tossed out later.
-		const HashCacheEntry entry{tex, 1u, 0u, alpha_minmax, true};
+		const HashCacheEntry entry{tex, 1u, 0u, alpha_minmax, true, true};
 		m_hash_cache.emplace(key, entry);
 		return;
 	}
@@ -6665,6 +6677,7 @@ void GSTextureCache::InjectHashCacheTexture(const HashCacheKey& key, GSTexture* 
 	// Reset age so we don't get thrown out too early.
 	it->second.age = 0;
 	it->second.alpha_minmax = alpha_minmax;
+	it->second.valid_alpha_minmax = true;
 
 	// Update memory usage, swap the textures, and recycle the old one for reuse.
 	if (!it->second.is_replacement)

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -7119,11 +7119,10 @@ void GSTextureCache::PreloadTexture(const GIFRegTEX0& TEX0, const GIFRegTEXA& TE
 	{
 		rtx(mem, off, block_rect, map.bits, map.pitch, TEXA);
 		tex->Unmap();
+
 		// Temporary, can't read the texture here so we need to come up with a smarter solution, but this will get around it being broken.
 		if (alpha_minmax)
-		{
 			*alpha_minmax = std::make_pair<u8, u8>(0, 255);
-		}
 	}
 	else
 	{
@@ -7134,11 +7133,10 @@ void GSTextureCache::PreloadTexture(const GIFRegTEX0& TEX0, const GIFRegTEXA& TE
 
 		const u8* ptr = buff + (pitch * static_cast<u32>(rect.top - block_rect.top)) +
 						(static_cast<u32>(rect.left - block_rect.left) << (paltex ? 0 : 2));
+
 		if (alpha_minmax)
-		{
-			pxAssert(GSLocalMemory::m_psm[TEX0.PSM].pal == 0);
-			*alpha_minmax = GSGetRGBA8AlphaMinMax(buff, unoffset_rect.width(), unoffset_rect.height(), pitch);
-		}
+			*alpha_minmax = GSGetRGBA8AlphaMinMax(ptr, unoffset_rect.width(), unoffset_rect.height(), pitch);
+
 		tex->Update(unoffset_rect, ptr, pitch, level);
 	}
 }

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.h
@@ -116,6 +116,7 @@ public:
 		u32 refcount;
 		u16 age;
 		std::pair<u8, u8> alpha_minmax;
+		bool valid_alpha_minmax;
 		bool is_replacement;
 	};
 
@@ -286,6 +287,7 @@ public:
 		bool m_target = false;
 		bool m_target_direct = false;
 		bool m_repeating = false;
+		bool m_valid_alpha_minmax = false;
 		std::pair<u8, u8> m_alpha_minmax = {0u, 255u};
 		std::vector<GSVector2i>* m_p2t = nullptr;
 		// Keep a trace of the target origin. There is no guarantee that pointer will
@@ -537,7 +539,7 @@ public:
 		return (type == DepthStencil) ? "Depth" : "Color";
 	}
 
-	void AttachPaletteToSource(Source* s, u16 pal, bool need_gs_texture);
+	void AttachPaletteToSource(Source* s, u16 pal, bool need_gs_texture, bool update_alpha_minmax);
 	void AttachPaletteToSource(Source* s, GSTexture* gpu_clut);
 	SurfaceOffset ComputeSurfaceOffset(const GSOffset& off, const GSVector4i& r, const Target* t);
 	SurfaceOffset ComputeSurfaceOffset(const uint32_t bp, const uint32_t bw, const uint32_t psm, const GSVector4i& r, const Target* t);

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.h
@@ -242,8 +242,8 @@ public:
 		void ResizeValidity(const GSVector4i& rect);
 		void UpdateValidity(const GSVector4i& rect, bool can_resize = true);
 
-		void RTACorrect(Target* rt);
-		void RTADecorrect(Target* rt);
+		void RTACorrect();
+		void RTADecorrect();
 
 		void Update(bool cannot_scale = false);
 


### PR DESCRIPTION
### Description of Changes

Stops alpha from unused CLUT colours from leaking into the alpha range, saves a good number of draw calls on many games, and some RTA conversions.

Some small render fixes in Urban Chaos (lighting), Tomb Raider (lighting), NBA (bandanna), Sims Bustin Out/Urbz (shadows).

Some notable mentions:
```
EA_Sports_Rugby_2004_SLES-51732_20220817213743 ['Draw Calls: -1228 [5360=>4132]']
Grand Theft Auto - San Andreas_SLUS-20946_20231011210201 ['Draw Calls: -569 [2222=>1653]']
Manhunt_SLUS-20827ugh ['Draw Calls: -224 [884=>660]']
Mark of Kri, The_SCUS-97140_20221211064922 ['Draw Calls: -184 [601=>417]', 'Barriers: -3 [5=>2]']
Metal Gear Solid 3 - Snake Eater_SLES-82024_20231022135932 ['Draw Calls: -284 [1015=>731]', 'Barriers: -4 [32=>28]']
Metal Gear Solid 3 - Subsistence Disc1of3_SLUS-21359_20220920084941 ['Draw Calls: -706 [2020=>1314]', 'Barriers: -116 [292=>176]']
Monster_Attack_SLES-51856_20221212133100 ['Draw Calls: -1158 [4498=>3340]']
Naruto_-_Narutimett_Hero_2_SLPS-25398_20220731134652 ['Draw Calls: -212 [1016=>804]']
NBAStreetVol2-SLUS-20651-DATE ['Draw Calls: -209 [2030=>1821]']
Ratchet & Clank_SCUS-97199_20230212034141 ['Draw Calls: -504 [3478=>2974]']
rugby08pitch ['Draw Calls: -424 [1375=>951]', 'Render Passes: -17 [543=>526]', 'Barriers: -1 [31=>30]']
Shin Megami Tensei - Persona 4_SLUS-21782_20230625185737 ['Draw Calls: -1 [151=>150]', 'Render Passes: -3 [7=>4]', 'Copies: -1 [1=>0]']
Simple 2000 Series Vol.81 - The Chikyuu Boueigun 2 _NTSC-J__SLPM-62652_20220404193151 ['Draw Calls: -5348 [10042=>4694]', 'Barriers: -5935 [6714=>779]']
Sly 2 - Band of Thieves_SCUS-97316_20230422201628 ['Draw Calls: -341 [6303=>5962]']
Tekken 4_SLUS-20328_20230127161708 ['Draw Calls: -228 [1173=>945]', 'Barriers: -10 [15=>5]']
Tekken Tag Tournament_SLUS-20001_20230202131207 ['Draw Calls: -107 [1551=>1444]']
TOCArd2_GS_BrokenShadows ['Draw Calls: -158 [2075=>1917]', 'Barriers: -51 [126=>75]']
Zone_of_the_Enders_-_The_2nd_Runner_SLUS-20545_20230305201802 ['Draw Calls: -484 [2464=>1980]', 'Barriers: +62 [64=>126]']
```

### Rationale behind Changes

Vroom vroom, more RTA

### Suggested Testing Steps

Test a few games.