### PR TITLE
Qt: Ensure settings are writable before running setup wizard

### DIFF
--- a/common/Error.cpp
+++ b/common/Error.cpp
@@ -1,12 +1,14 @@
-// SPDX-FileCopyrightText: 2002-2023 PCSX2 Dev Team
+// SPDX-FileCopyrightText: 2002-2024 PCSX2 Dev Team
 // SPDX-License-Identifier: LGPL-3.0+
 
 #include "Error.h"
+#include "StringUtil.h"
+
+#include "fmt/format.h"
+
 #include <cstdlib>
 #include <cstring>
 #include <type_traits>
-
-#include "fmt/format.h"
 
 // Platform-specific includes
 #if defined(_WIN32)
@@ -30,20 +32,25 @@ void Error::Clear()
 
 void Error::SetErrno(int err)
 {
+	SetErrno(std::string_view(), err);
+}
+
+void Error::SetErrno(std::string_view prefix, int err)
+{
 	m_type = Type::Errno;
 
 #ifdef _MSC_VER
 	char buf[128];
 	if (strerror_s(buf, sizeof(buf), err) == 0)
-		m_description = fmt::format("errno {}: {}", err, buf);
+		m_description = fmt::format("{}errno {}: {}", prefix, err, buf);
 	else
-		m_description = fmt::format("errno {}: <Could not get error message>", err);
+		m_description = fmt::format("{}errno {}: <Could not get error message>", prefix, err);
 #else
 	const char* buf = std::strerror(err);
 	if (buf)
-		m_description = fmt::format("errno {}: {}", err, buf);
+		m_description = fmt::format("{}errno {}: {}", prefix, err, buf);
 	else
-		m_description = fmt::format("errno {}: <Could not get error message>", err);
+		m_description = fmt::format("{}errno {}: <Could not get error message>", prefix, err);
 #endif
 }
 
@@ -53,10 +60,22 @@ void Error::SetErrno(Error* errptr, int err)
 		errptr->SetErrno(err);
 }
 
+void Error::SetErrno(Error* errptr, std::string_view prefix, int err)
+{
+	if (errptr)
+		errptr->SetErrno(prefix, err);
+}
+
 void Error::SetString(std::string description)
 {
 	m_type = Type::User;
 	m_description = std::move(description);
+}
+
+void Error::SetStringView(std::string_view description)
+{
+	m_type = Type::User;
+	m_description = std::string(description);
 }
 
 void Error::SetString(Error* errptr, std::string description)
@@ -65,17 +84,35 @@ void Error::SetString(Error* errptr, std::string description)
 		errptr->SetString(std::move(description));
 }
 
+void Error::SetStringView(Error* errptr, std::string_view description)
+{
+	if (errptr)
+		errptr->SetStringView(std::move(description));
+}
+
 #ifdef _WIN32
+
 void Error::SetWin32(unsigned long err)
+{
+	SetWin32(std::string_view(), err);
+}
+
+void Error::SetWin32(std::string_view prefix, unsigned long err)
 {
 	m_type = Type::Win32;
 
-	char buf[128];
-	const DWORD r = FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM, nullptr, err, 0, buf, sizeof(buf), nullptr);
+	WCHAR buf[128];
+	const DWORD r = FormatMessageW(FORMAT_MESSAGE_FROM_SYSTEM, nullptr, err, LANG_USER_DEFAULT, buf,
+		static_cast<DWORD>(std::size(buf)), nullptr);
 	if (r > 0)
-		m_description = fmt::format("Win32 Error {}: {}", err, std::string_view(buf, r));
+	{
+		m_description =
+			fmt::format("{}Win32 Error {}: {}", prefix, err, StringUtil::WideStringToUTF8String(std::wstring_view(buf, r)));
+	}
 	else
-		m_description = fmt::format("Win32 Error {}: <Could not resolve system error ID>", err);
+	{
+		m_description = fmt::format("{}Win32 Error {}: <Could not resolve system error ID>", prefix, err);
+	}
 }
 
 void Error::SetWin32(Error* errptr, unsigned long err)
@@ -84,16 +121,33 @@ void Error::SetWin32(Error* errptr, unsigned long err)
 		errptr->SetWin32(err);
 }
 
+void Error::SetWin32(Error* errptr, std::string_view prefix, unsigned long err)
+{
+	if (errptr)
+		errptr->SetWin32(prefix, err);
+}
+
 void Error::SetHResult(long err)
+{
+	SetHResult(std::string_view(), err);
+}
+
+void Error::SetHResult(std::string_view prefix, long err)
 {
 	m_type = Type::HResult;
 
-	char buf[128];
-	const DWORD r = FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM, nullptr, err, 0, buf, sizeof(buf), nullptr);
+	WCHAR buf[128];
+	const DWORD r = FormatMessageW(FORMAT_MESSAGE_FROM_SYSTEM, nullptr, err, LANG_USER_DEFAULT, buf,
+		static_cast<DWORD>(std::size(buf)), nullptr);
 	if (r > 0)
-		m_description = fmt::format("HRESULT {:08X}: {}", err, std::string_view(buf, r));
+	{
+		m_description =
+			fmt::format("{}HRESULT {:08X}: {}", prefix, err, StringUtil::WideStringToUTF8String(std::wstring_view(buf, r)));
+	}
 	else
-		m_description = fmt::format("HRESULT {:08X}: <Could not resolve system error ID>", err);
+	{
+		m_description = fmt::format("{}HRESULT {:08X}: <Could not resolve system error ID>", prefix, err);
+	}
 }
 
 void Error::SetHResult(Error* errptr, long err)
@@ -102,15 +156,26 @@ void Error::SetHResult(Error* errptr, long err)
 		errptr->SetHResult(err);
 }
 
+void Error::SetHResult(Error* errptr, std::string_view prefix, long err)
+{
+	if (errptr)
+		errptr->SetHResult(prefix, err);
+}
+
 #endif
 
 void Error::SetSocket(int err)
 {
+	SetSocket(std::string_view(), err);
+}
+
+void Error::SetSocket(std::string_view prefix, int err)
+{
 	// Socket errors are win32 errors on windows
 #ifdef _WIN32
-	SetWin32(err);
+	SetWin32(prefix, err);
 #else
-	SetErrno(err);
+	SetErrno(prefix, err);
 #endif
 	m_type = Type::Socket;
 }
@@ -119,6 +184,12 @@ void Error::SetSocket(Error* errptr, int err)
 {
 	if (errptr)
 		errptr->SetSocket(err);
+}
+
+void Error::SetSocket(Error* errptr, std::string_view prefix, int err)
+{
+	if (errptr)
+		errptr->SetSocket(prefix, err);
 }
 
 Error Error::CreateNone()
@@ -163,6 +234,28 @@ Error Error::CreateHResult(long err)
 }
 
 #endif
+
+void Error::AddPrefix(std::string_view prefix)
+{
+	m_description.insert(0, prefix);
+}
+
+void Error::AddSuffix(std::string_view suffix)
+{
+	m_description.append(suffix);
+}
+
+void Error::AddPrefix(Error* errptr, std::string_view prefix)
+{
+	if (errptr)
+		errptr->AddPrefix(prefix);
+}
+
+void Error::AddSuffix(Error* errptr, std::string_view prefix)
+{
+	if (errptr)
+		errptr->AddSuffix(prefix);
+}
 
 Error& Error::operator=(const Error& e) = default;
 

--- a/common/Error.h
+++ b/common/Error.h
@@ -1,8 +1,12 @@
-// SPDX-FileCopyrightText: 2002-2023 PCSX2 Dev Team
+// SPDX-FileCopyrightText: 2002-2024 PCSX2 Dev Team
 // SPDX-License-Identifier: LGPL-3.0+
 
 #pragma once
+
 #include "Pcsx2Defs.h"
+
+#include "fmt/core.h"
+
 #include <string>
 
 class Error
@@ -24,25 +28,32 @@ public:
 	};
 
 	__fi Type GetType() const { return m_type; }
+	__fi bool IsValid() const { return (m_type != Type::None); }
 	__fi const std::string& GetDescription() const { return m_description; }
 
 	void Clear();
 
 	/// Error that is set by system functions, such as open().
 	void SetErrno(int err);
+	void SetErrno(std::string_view prefix, int err);
 
 	/// Error that is set by socket functions, such as socket(). On Unix this is the same as errno.
 	void SetSocket(int err);
+	void SetSocket(std::string_view prefix, int err);
 
 	/// Set both description and message.
 	void SetString(std::string description);
+	void SetStringView(std::string_view description);
 
 #ifdef _WIN32
-	/// Error that is returned by some Win32 functions, such as RegOpenKeyEx. Also used by other APIs through GetLastError().
+	/// Error that is returned by some Win32 functions, such as RegOpenKeyEx. Also used by other APIs through
+	/// GetLastError().
 	void SetWin32(unsigned long err);
+	void SetWin32(std::string_view prefix, unsigned long err);
 
 	/// Error that is returned by Win32 COM methods, e.g. S_OK.
 	void SetHResult(long err);
+	void SetHResult(std::string_view prefix, long err);
 #endif
 
 	static Error CreateNone();
@@ -56,10 +67,31 @@ public:
 
 	// helpers for setting
 	static void SetErrno(Error* errptr, int err);
+	static void SetErrno(Error* errptr, std::string_view prefix, int err);
 	static void SetSocket(Error* errptr, int err);
+	static void SetSocket(Error* errptr, std::string_view prefix, int err);
 	static void SetString(Error* errptr, std::string description);
+	static void SetStringView(Error* errptr, std::string_view description);
+
+#ifdef _WIN32
 	static void SetWin32(Error* errptr, unsigned long err);
+	static void SetWin32(Error* errptr, std::string_view prefix, unsigned long err);
 	static void SetHResult(Error* errptr, long err);
+	static void SetHResult(Error* errptr, std::string_view prefix, long err);
+#endif
+
+	/// Sets a formatted message.
+	template <typename... T>
+	static void SetStringFmt(Error* errptr, fmt::format_string<T...> fmt, T&&... args)
+	{
+		if (errptr)
+			Error::SetString(errptr, fmt::vformat(fmt, fmt::make_format_args(args...)));
+	}
+
+	void AddPrefix(std::string_view prefix);
+	void AddSuffix(std::string_view suffix);
+	static void AddPrefix(Error* errptr, std::string_view prefix);
+	static void AddSuffix(Error* errptr, std::string_view prefix);
 
 	Error& operator=(const Error& e);
 	Error& operator=(Error&& e);

--- a/common/FileSystem.cpp
+++ b/common/FileSystem.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2002-2023 PCSX2 Dev Team
+// SPDX-FileCopyrightText: 2002-2024 PCSX2 Dev Team
 // SPDX-License-Identifier: LGPL-3.0+
 
 #include "FileSystem.h"
@@ -8,6 +8,7 @@
 #include "Console.h"
 #include "StringUtil.h"
 #include "Path.h"
+
 #include <algorithm>
 #include <cerrno>
 #include <cstdlib>
@@ -1093,13 +1094,13 @@ bool FileSystem::WriteStringToFile(const char* filename, const std::string_view&
 	return true;
 }
 
-bool FileSystem::EnsureDirectoryExists(const char* path, bool recursive)
+bool FileSystem::EnsureDirectoryExists(const char* path, bool recursive, Error* error)
 {
 	if (FileSystem::DirectoryExists(path))
 		return true;
 
 	// if it fails to create, we're not going to be able to use it anyway
-	return FileSystem::CreateDirectoryPath(path, recursive);
+	return FileSystem::CreateDirectoryPath(path, recursive, error);
 }
 
 bool FileSystem::RecursiveDeleteDirectory(const char* path)
@@ -1545,33 +1546,39 @@ bool FileSystem::DirectoryIsEmpty(const char* path)
 	return true;
 }
 
-bool FileSystem::CreateDirectoryPath(const char* Path, bool Recursive)
+bool FileSystem::CreateDirectoryPath(const char* Path, bool Recursive, Error* error)
 {
 	const std::wstring wpath(StringUtil::UTF8StringToWideString(Path));
 
 	// has a path
-	if (wpath.empty())
+	if (wpath.empty()) [[unlikely]]
+	{
+		Error::SetStringView(error, "Path is empty.");
 		return false;
+	}
 
 	// try just flat-out, might work if there's no other segments that have to be made
 	if (CreateDirectoryW(wpath.c_str(), nullptr))
 		return true;
-
-	if (!Recursive)
-		return false;
 
 	// check error
 	DWORD lastError = GetLastError();
 	if (lastError == ERROR_ALREADY_EXISTS)
 	{
 		// check the attributes
-		u32 Attributes = GetFileAttributesW(wpath.c_str());
+		const u32 Attributes = GetFileAttributesW(wpath.c_str());
 		if (Attributes != INVALID_FILE_ATTRIBUTES && Attributes & FILE_ATTRIBUTE_DIRECTORY)
 			return true;
-		else
-			return false;
 	}
-	else if (lastError == ERROR_PATH_NOT_FOUND)
+
+	if (!Recursive)
+	{
+		Error::SetWin32(error, "CreateDirectoryW() failed: ", lastError);
+		return false;
+	}
+
+	// check error
+	if (lastError == ERROR_PATH_NOT_FOUND)
 	{
 		// part of the path does not exist, so we'll create the parent folders, then
 		// the full path again.
@@ -1589,7 +1596,10 @@ bool FileSystem::CreateDirectoryPath(const char* Path, bool Recursive)
 				{
 					lastError = GetLastError();
 					if (lastError != ERROR_ALREADY_EXISTS) // fine, continue to next path segment
+					{
+						Error::SetWin32(error, "CreateDirectoryW() failed: ", lastError);
 						return false;
+					}
 				}
 
 				// replace / with \.
@@ -1609,7 +1619,10 @@ bool FileSystem::CreateDirectoryPath(const char* Path, bool Recursive)
 			{
 				lastError = GetLastError();
 				if (lastError != ERROR_ALREADY_EXISTS)
+				{
+					Error::SetWin32(error, "CreateDirectoryW() failed: ", lastError);
 					return false;
+				}
 			}
 		}
 
@@ -1619,6 +1632,7 @@ bool FileSystem::CreateDirectoryPath(const char* Path, bool Recursive)
 	else
 	{
 		// unhandled error
+		Error::SetWin32(error, "CreateDirectoryW() failed: ", lastError);
 		return false;
 	}
 }
@@ -1636,14 +1650,16 @@ bool FileSystem::DeleteFilePath(const char* path)
 	return (DeleteFileW(wpath.c_str()) == TRUE);
 }
 
-bool FileSystem::RenamePath(const char* old_path, const char* new_path)
+bool FileSystem::RenamePath(const char* old_path, const char* new_path, Error* error)
 {
 	const std::wstring old_wpath(StringUtil::UTF8StringToWideString(old_path));
 	const std::wstring new_wpath(StringUtil::UTF8StringToWideString(new_path));
 
 	if (!MoveFileExW(old_wpath.c_str(), new_wpath.c_str(), MOVEFILE_REPLACE_EXISTING))
 	{
-		Console.Error("MoveFileEx('%s', '%s') failed: %08X", old_path, new_path, GetLastError());
+		const DWORD err = GetLastError();
+		Error::SetWin32(error, "MoveFileExW() failed: ", err);
+		Console.Error("MoveFileEx('%s', '%s') failed: %08X", old_path, new_path, err);
 		return false;
 	}
 
@@ -2031,7 +2047,7 @@ bool FileSystem::DirectoryIsEmpty(const char* path)
 	return true;
 }
 
-bool FileSystem::CreateDirectoryPath(const char* path, bool recursive)
+bool FileSystem::CreateDirectoryPath(const char* path, bool recursive, Error* error)
 {
 	// has a path
 	const size_t pathLength = std::strlen(path);
@@ -2042,9 +2058,6 @@ bool FileSystem::CreateDirectoryPath(const char* path, bool recursive)
 	if (mkdir(path, 0777) == 0)
 		return true;
 
-	if (!recursive)
-		return false;
-
 	// check error
 	int lastError = errno;
 	if (lastError == EEXIST)
@@ -2053,10 +2066,15 @@ bool FileSystem::CreateDirectoryPath(const char* path, bool recursive)
 		struct stat sysStatData;
 		if (stat(path, &sysStatData) == 0 && S_ISDIR(sysStatData.st_mode))
 			return true;
-		else
-			return false;
 	}
-	else if (lastError == ENOENT)
+
+	if (!recursive)
+	{
+		Error::SetErrno(error, "mkdir() failed: ", lastError);
+		return false;
+	}
+
+	if (lastError == ENOENT)
 	{
 		// part of the path does not exist, so we'll create the parent folders, then
 		// the full path again.
@@ -2072,7 +2090,10 @@ bool FileSystem::CreateDirectoryPath(const char* path, bool recursive)
 				{
 					lastError = errno;
 					if (lastError != EEXIST) // fine, continue to next path segment
+					{
+						Error::SetErrno(error, "mkdir() failed: ", lastError);
 						return false;
+					}
 				}
 			}
 
@@ -2086,7 +2107,10 @@ bool FileSystem::CreateDirectoryPath(const char* path, bool recursive)
 			{
 				lastError = errno;
 				if (lastError != EEXIST)
+				{
+					Error::SetErrno(error, "mkdir() failed: ", lastError);
 					return false;
+				}
 			}
 		}
 
@@ -2096,6 +2120,7 @@ bool FileSystem::CreateDirectoryPath(const char* path, bool recursive)
 	else
 	{
 		// unhandled error
+		Error::SetErrno(error, "mkdir() failed: ", lastError);
 		return false;
 	}
 }
@@ -2112,14 +2137,19 @@ bool FileSystem::DeleteFilePath(const char* path)
 	return (unlink(path) == 0);
 }
 
-bool FileSystem::RenamePath(const char* old_path, const char* new_path)
+bool FileSystem::RenamePath(const char* old_path, const char* new_path, Error* error)
 {
 	if (old_path[0] == '\0' || new_path[0] == '\0')
+	{
+		Error::SetStringView(error, "Path is empty.");
 		return false;
+	}
 
 	if (rename(old_path, new_path) != 0)
 	{
-		Console.Error("rename('%s', '%s') failed: %d", old_path, new_path, errno);
+		const int err = errno;
+		Error::SetErrno(error, "rename() failed: ", err);
+		Console.Error("rename('%s', '%s') failed: %d", old_path, new_path, err);
 		return false;
 	}
 

--- a/common/FileSystem.h
+++ b/common/FileSystem.h
@@ -1,8 +1,10 @@
-// SPDX-FileCopyrightText: 2002-2023 PCSX2 Dev Team
+// SPDX-FileCopyrightText: 2002-2024 PCSX2 Dev Team
 // SPDX-License-Identifier: LGPL-3.0+
 
 #pragma once
+
 #include "Pcsx2Defs.h"
+
 #include <cstdio>
 #include <ctime>
 #include <memory>
@@ -88,7 +90,7 @@ namespace FileSystem
 	bool DeleteFilePath(const char* path);
 
 	/// Rename file
-	bool RenamePath(const char* OldPath, const char* NewPath);
+	bool RenamePath(const char* OldPath, const char* NewPath, Error* error = nullptr);
 
 	/// Deleter functor for managed file pointers
 	struct FileDeleter
@@ -134,11 +136,11 @@ namespace FileSystem
 	/// if the directory already exists, the return value will be true.
 	/// if Recursive is specified, all parent directories will be created
 	/// if they do not exist.
-	bool CreateDirectoryPath(const char* path, bool recursive);
+	bool CreateDirectoryPath(const char* path, bool recursive, Error* error = nullptr);
 
 	/// Creates a directory if it doesn't already exist.
 	/// Returns false if it does not exist and creation failed.
-	bool EnsureDirectoryExists(const char* path, bool recursive);
+	bool EnsureDirectoryExists(const char* path, bool recursive, Error* error = nullptr);
 
 	/// Removes a directory.
 	bool DeleteDirectory(const char* path);

--- a/common/MemorySettingsInterface.cpp
+++ b/common/MemorySettingsInterface.cpp
@@ -1,15 +1,17 @@
-// SPDX-FileCopyrightText: 2002-2023 PCSX2 Dev Team
+// SPDX-FileCopyrightText: 2002-2024 PCSX2 Dev Team
 // SPDX-License-Identifier: LGPL-3.0+
 
-#include "common/MemorySettingsInterface.h"
-#include "common/StringUtil.h"
+#include "MemorySettingsInterface.h"
+#include "Error.h"
+#include "StringUtil.h"
 
 MemorySettingsInterface::MemorySettingsInterface() = default;
 
 MemorySettingsInterface::~MemorySettingsInterface() = default;
 
-bool MemorySettingsInterface::Save()
+bool MemorySettingsInterface::Save(Error* error)
 {
+	Error::SetStringView(error, "Memory settings cannot be saved.");
 	return false;
 }
 

--- a/common/MemorySettingsInterface.h
+++ b/common/MemorySettingsInterface.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2002-2023 PCSX2 Dev Team
+// SPDX-FileCopyrightText: 2002-2024 PCSX2 Dev Team
 // SPDX-License-Identifier: LGPL-3.0+
 
 #pragma once
@@ -12,7 +12,7 @@ public:
 	MemorySettingsInterface();
 	~MemorySettingsInterface();
 
-	bool Save() override;
+	bool Save(Error* error = nullptr) override;
 
 	void Clear() override;
 

--- a/common/SettingsInterface.h
+++ b/common/SettingsInterface.h
@@ -1,19 +1,22 @@
-// SPDX-FileCopyrightText: 2002-2023 PCSX2 Dev Team
+// SPDX-FileCopyrightText: 2002-2024 PCSX2 Dev Team
 // SPDX-License-Identifier: LGPL-3.0+
 
 #pragma once
 
 #include "Pcsx2Defs.h"
+
 #include <string>
 #include <optional>
 #include <vector>
+
+class Error;
 
 class SettingsInterface
 {
 public:
 	virtual ~SettingsInterface() = default;
 
-	virtual bool Save() = 0;
+	virtual bool Save(Error* error = nullptr) = 0;
 	virtual void Clear() = 0;
 
 	virtual bool GetIntValue(const char* section, const char* key, int* value) const = 0;

--- a/pcsx2-gsrunner/Main.cpp
+++ b/pcsx2-gsrunner/Main.cpp
@@ -88,7 +88,8 @@ static u32 s_total_drawn_frames = 0;
 
 bool GSRunner::InitializeConfig()
 {
-	if (!EmuFolders::InitializeCriticalFolders())
+	EmuFolders::SetAppRoot();
+	if (!EmuFolders::SetResourcesDirectory() || !EmuFolders::SetDataDirectory(nullptr))
 		return false;
 
 	const char* error;

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2002-2023 PCSX2 Dev Team
+// SPDX-FileCopyrightText: 2002-2024 PCSX2 Dev Team
 // SPDX-License-Identifier: LGPL-3.0+
 
 #pragma once
@@ -24,6 +24,7 @@
 	} \
 	;
 
+class Error;
 class SettingsInterface;
 class SettingsWrapper;
 
@@ -1226,7 +1227,9 @@ namespace EmuFolders
 	extern std::string Videos;
 
 	/// Initializes critical folders (AppRoot, DataRoot, Settings). Call once on startup.
-	bool InitializeCriticalFolders();
+	void SetAppRoot();
+	bool SetResourcesDirectory();
+	bool SetDataDirectory(Error* error);
 
 	// Assumes that AppRoot and DataRoot have been initialized.
 	void SetDefaults(SettingsInterface& si);

--- a/pcsx2/INISettingsInterface.h
+++ b/pcsx2/INISettingsInterface.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2002-2023 PCSX2 Dev Team
+// SPDX-FileCopyrightText: 2002-2024 PCSX2 Dev Team
 // SPDX-License-Identifier: LGPL-3.0+
 
 #pragma once
@@ -20,7 +20,7 @@ public:
 	bool IsDirty() const { return m_dirty; }
 
 	bool Load();
-	bool Save() override;
+	bool Save(Error* error = nullptr) override;
 
 	void Clear() override;
 

--- a/pcsx2/LayeredSettingsInterface.cpp
+++ b/pcsx2/LayeredSettingsInterface.cpp
@@ -1,7 +1,8 @@
-// SPDX-FileCopyrightText: 2002-2023 PCSX2 Dev Team
+// SPDX-FileCopyrightText: 2002-2024 PCSX2 Dev Team
 // SPDX-License-Identifier: LGPL-3.0+
 
 #include "LayeredSettingsInterface.h"
+
 #include "common/Assertions.h"
 
 #include <unordered_set>
@@ -10,7 +11,7 @@ LayeredSettingsInterface::LayeredSettingsInterface() = default;
 
 LayeredSettingsInterface::~LayeredSettingsInterface() = default;
 
-bool LayeredSettingsInterface::Save()
+bool LayeredSettingsInterface::Save(Error* error)
 {
 	pxFailRel("Attempting to save layered settings interface");
 	return false;

--- a/pcsx2/LayeredSettingsInterface.h
+++ b/pcsx2/LayeredSettingsInterface.h
@@ -1,8 +1,10 @@
-// SPDX-FileCopyrightText: 2002-2023 PCSX2 Dev Team
+// SPDX-FileCopyrightText: 2002-2024 PCSX2 Dev Team
 // SPDX-License-Identifier: LGPL-3.0+
 
 #pragma once
+
 #include "common/SettingsInterface.h"
+
 #include <array>
 
 class LayeredSettingsInterface final : public SettingsInterface
@@ -23,7 +25,7 @@ public:
 	SettingsInterface* GetLayer(Layer layer) const { return m_layers[layer]; }
 	void SetLayer(Layer layer, SettingsInterface* sif) { m_layers[layer] = sif; }
 
-	bool Save() override;
+	bool Save(Error* error = nullptr) override;
 
 	void Clear() override;
 


### PR DESCRIPTION
### Description of Changes

![image](https://github.com/PCSX2/pcsx2/assets/11288319/e2c00f7a-7f5e-4eb2-bc64-77303e0c5d90)

### Rationale behind Changes

Stops users from losing data when they somehow don't have a writable documents directory...

### Suggested Testing Steps

Make sure setup process works.
Make sure existing setups still load.
