### PR TITLE
GS/HW: Rearrange color on shuffle if SW Blend or TFX

### DIFF
--- a/bin/resources/shaders/opengl/tfx_fs.glsl
+++ b/bin/resources/shaders/opengl/tfx_fs.glsl
@@ -686,7 +686,7 @@ vec4 ps_color()
 	vec4 T = sample_color(st);
 #endif
 
-	#if SW_BLEND && PS_SHUFFLE && !PS_SHUFFLE_SAME && !PS_READ16_SRC && (PS_SHUFFLE_ACROSS || PS_PROCESS_BA == SHUFFLE_READWRITE || PS_PROCESS_RG == SHUFFLE_READWRITE)
+	#if (SW_BLEND || PS_TFX != 1) && PS_SHUFFLE && !PS_SHUFFLE_SAME && !PS_READ16_SRC && (PS_SHUFFLE_ACROSS || PS_PROCESS_BA == SHUFFLE_READWRITE || PS_PROCESS_RG == SHUFFLE_READWRITE)
 		uvec4 denorm_c_before = uvec4(T);
 		#if (PS_PROCESS_BA & SHUFFLE_READ)
 			T.r = float((denorm_c_before.b << 3) & 0xF8);
@@ -807,6 +807,21 @@ float As = As_rgba.a;
 		float Ad = trunc(RT.a * 255.0f + 0.1f) / 128.0f;
 	#endif
 
+	#if PS_SHUFFLE && SW_BLEND_NEEDS_RT
+		uvec4 denorm_rt = uvec4(RT);
+		#if (PS_PROCESS_BA & SHUFFLE_WRITE)
+			RT.r = float((denorm_rt.b << 3) & 0xF8);
+			RT.g = float(((denorm_rt.b >> 2) & 0x38) | ((denorm_rt.a << 6) & 0xC0));
+			RT.b = float((denorm_rt.a << 1) & 0xF8);
+			RT.a = float(denorm_rt.a & 0x80);
+		#else
+			RT.r = float((denorm_rt.r << 3) & 0xF8);
+			RT.g = float(((denorm_rt.r >> 2) & 0x38) | ((denorm_rt.g << 6) & 0xC0));
+			RT.b = float((denorm_rt.g << 1) & 0xF8);
+			RT.a = float(denorm_rt.g & 0x80);
+		#endif
+	#endif
+		
 	// Let the compiler do its jobs !
 	vec3 Cd = trunc(RT.rgb * 255.0f + 0.1f);
 	vec3 Cs = Color.rgb;
@@ -1024,7 +1039,7 @@ void ps_main()
 
 
 #if PS_SHUFFLE
-	#if SW_BLEND && PS_SHUFFLE && !PS_SHUFFLE_SAME && !PS_READ16_SRC && (PS_SHUFFLE_ACROSS || PS_PROCESS_BA == SHUFFLE_READWRITE || PS_PROCESS_RG == SHUFFLE_READWRITE)
+	#if (SW_BLEND || PS_TFX != 1) &&  PS_SHUFFLE && !PS_SHUFFLE_SAME && !PS_READ16_SRC && (PS_SHUFFLE_ACROSS || PS_PROCESS_BA == SHUFFLE_READWRITE || PS_PROCESS_RG == SHUFFLE_READWRITE)
 		uvec4 denorm_c_after = uvec4(C);
 		#if (PS_PROCESS_BA & SHUFFLE_READ)
 			C.b = float(((denorm_c_after.r >> 3) & 0x1F) | ((denorm_c_after.g << 2) & 0xE0));

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -4018,7 +4018,7 @@ void GSRendererHW::EmulateBlending(int rt_alpha_min, int rt_alpha_max, bool& DAT
 	// Condition 1: Require full sw blend for full barrier.
 	// Condition 2: One barrier is already enabled, prims don't overlap so let's use sw blend instead.
 	// Condition 3: A shuffle is unlikely to overlap, so when a barrier is enabled like from fbmask we can prefer full sw blend.
-	const bool prefer_sw_blend = (features.texture_barrier && m_conf.require_full_barrier) || (m_conf.require_one_barrier && (no_prim_overlap || m_conf.ps.shuffle));
+	const bool prefer_sw_blend = (features.texture_barrier && m_conf.require_full_barrier) || (m_conf.require_one_barrier && no_prim_overlap) || m_conf.ps.shuffle;
 	const bool free_blend = blend_non_recursive // Free sw blending, doesn't require barriers or reading fb
 							|| accumulation_blend; // Mix of hw/sw blending
 

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -948,7 +948,6 @@ GSTextureCache::Source* GSTextureCache::LookupDepthSource(const bool is_depth, c
 			// FIXME: do I need to allow m_age == 1 as a potential match (as DepthStencil) ???
 			if (t->m_age <= 1 && t->m_used && t->m_dirty.empty() && GSUtil::HasSharedBits(bp, psm, t->m_TEX0.TBP0, t->m_TEX0.PSM))
 			{
-				pxAssert(GSLocalMemory::m_psm[t->m_TEX0.PSM].depth);
 				dst = t;
 				inside_target = false;
 				break;

--- a/pcsx2/GS/Renderers/Metal/tfx.metal
+++ b/pcsx2/GS/Renderers/Metal/tfx.metal
@@ -831,7 +831,7 @@ struct PSMain
 		else
 			T = sample_color(st);
 
-		if (SW_BLEND && PS_SHUFFLE && !PS_SHUFFLE_SAME && !PS_READ16_SRC && (PS_SHUFFLE_ACROSS || PS_PROCESS_BA == SHUFFLE_READWRITE || PS_PROCESS_RG == SHUFFLE_READWRITE))
+		if ((SW_BLEND || PS_TFX != 1) && PS_SHUFFLE && !PS_SHUFFLE_SAME && !PS_READ16_SRC && (PS_SHUFFLE_ACROSS || PS_PROCESS_BA == SHUFFLE_READWRITE || PS_PROCESS_RG == SHUFFLE_READWRITE))
 		{
 			uint4 denorm_c_before = uint4(T);
 			if (PS_PROCESS_BA & SHUFFLE_READ)
@@ -935,6 +935,25 @@ struct PSMain
 			}
 
 			float Ad = PS_RTA_CORRECTION ? trunc(current_color.a * 128.1f) / 128.f : trunc(current_color.a * 255.1f) / 128.f;
+
+			if (PS_SHUFFLE && NEEDS_RT)
+			{
+				uint4 denorm_rt = uint4(current_color);
+				if (PS_PROCESS_BA & SHUFFLE_WRITE)
+				{
+					current_color.r = float((denorm_rt.b << 3) & 0xF8);
+					current_color.g = float(((denorm_rt.b >> 2) & 0x38) | ((denorm_rt.a << 6) & 0xC0));
+					current_color.b = float((denorm_rt.a << 1) & 0xF8);
+					current_color.a = float(denorm_rt.a & 0x80);
+				}
+				else
+				{
+					current_color.r = float((denorm_rt.r << 3) & 0xF8);
+					current_color.g = float(((denorm_rt.r >> 2) & 0x38) | ((denorm_rt.g << 6) & 0xC0));
+					current_color.b = float((denorm_rt.g << 1) & 0xF8);
+					current_color.a = float(denorm_rt.g & 0x80);
+				}
+			}
 
 			float3 Cd = trunc(current_color.rgb * 255.5f);
 			float3 Cs = Color.rgb;
@@ -1105,7 +1124,7 @@ struct PSMain
 
 		if (PS_SHUFFLE)
 		{
-			if (SW_BLEND && PS_SHUFFLE && !PS_SHUFFLE_SAME && !PS_READ16_SRC && (PS_SHUFFLE_ACROSS || PS_PROCESS_BA == SHUFFLE_READWRITE || PS_PROCESS_RG == SHUFFLE_READWRITE))
+			if ((SW_BLEND || PS_TFX != 1) && PS_SHUFFLE && !PS_SHUFFLE_SAME && !PS_READ16_SRC && (PS_SHUFFLE_ACROSS || PS_PROCESS_BA == SHUFFLE_READWRITE || PS_PROCESS_RG == SHUFFLE_READWRITE))
 			{
 				uint4 denorm_c_after = uint4(C);
 				if (PS_PROCESS_BA & SHUFFLE_READ)

--- a/pcsx2/ShaderCacheVersion.h
+++ b/pcsx2/ShaderCacheVersion.h
@@ -3,4 +3,4 @@
 
 /// Version number for GS and other shaders. Increment whenever any of the contents of the
 /// shaders change, to invalidate the cache.
-static constexpr u32 SHADER_CACHE_VERSION = 44;
+static constexpr u32 SHADER_CACHE_VERSION = 45;


### PR DESCRIPTION
### Description of Changes
Enables colour rearranging on shuffle on SW blend or TFX (not decal)

### Rationale behind Changes
The colour can be modulated by the vertex colour, which means that the incoming colour will be wrong, this was happening on Ratchet & Clank Up Your Arsenal.

### Suggested Testing Steps
Test Ratchet & Clank UYA, and a smattering of other games.

Ratchet:
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/565c2f3f-01bb-4874-8125-409ae7b76e32)

PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/b9b05782-6987-4cd2-90d7-dd2744ebecfb)

