### PR TITLE
GS/TC: Read indexed texture from GS memory if complete dirty overlap

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -4381,7 +4381,7 @@ void GSRendererHW::EmulateBlending(int rt_alpha_min, int rt_alpha_max, bool& DAT
 		{
 			const bool afail_always_fb_alpha = m_cached_ctx.TEST.AFAIL == AFAIL_FB_ONLY || (m_cached_ctx.TEST.AFAIL == AFAIL_RGB_ONLY && GSLocalMemory::m_psm[m_cached_ctx.FRAME.PSM].trbpp != 32);
 			const bool always_passing_alpha = !m_cached_ctx.TEST.ATE || afail_always_fb_alpha || (m_cached_ctx.TEST.ATE && m_cached_ctx.TEST.ATST == ATST_ALWAYS);
-			const bool full_cover = (rt->m_valid.rintersect(m_r).eq(rt->m_valid) && PrimitiveCoversWithoutGaps() && !(DATE_PRIMID || DATE_BARRIER || !always_passing_alpha || (m_cached_ctx.TEST.ZTE && m_cached_ctx.TEST.ZTST != ZTST_ALWAYS)) || m_channel_shuffle);
+			const bool full_cover = rt->m_valid.rintersect(m_r).eq(rt->m_valid) && PrimitiveCoversWithoutGaps() && !(DATE_PRIMID || DATE_BARRIER || !always_passing_alpha || !IsDepthAlwaysPassing());
 
 			if (!full_cover)
 			{

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -1308,6 +1308,9 @@ GSTextureCache::Source* GSTextureCache::LookupSource(const bool is_color, const 
 					const u32 dirty_end = GSLocalMemory::GetUnwrappedEndBlockAddress(t->m_TEX0.TBP0, t->m_TEX0.TBW, t->m_TEX0.PSM, dirty_rect);
 
 					overlapping_dirty = read_start <= dirty_end && read_end >= dirty_start;
+
+					if (overlapping_dirty && (psm == PSMT8 || psm == PSMT4))
+						continue;
 				}
 
 				const bool t_clean = ((t->m_dirty.GetDirtyChannels() & GSUtil::GetChannelMask(psm)) == 0) || rect_clean;


### PR DESCRIPTION
### Description of Changes
Avoids reading indexed data from a target if the area completely overlaps (meaning there was an upload)

### Rationale behind Changes
There were false positives and breaks in some games due to it reading this out of targets. Plus these changes saved a few uploads.

### Suggested Testing Steps
Test a smattering of games including those listed below.

Fixes WW1 - Red Baron

Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/6371adeb-a7fb-4e0a-9e21-3eca742a6a96)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/d189e63a-23cd-4fff-af1b-6e3df878ee70)

Other changes shown in the GS dump run

catwoman_ghost
Draw Calls: +7 [381=>388]
Render Passes: +2 [124=>126]
Uploads: +3 [40=>43]

cod2
Draw Calls: -12 [93=>81]
Render Passes: -21 [54=>33]
Copies: -8 [9=>1]
Uploads: -7 [40=>33]

Crime_Life_-_Gang_Wars__PAL-M5__SLES-52122
Draw Calls: -3 [398=>395]
Render Passes: -4 [78=>74]
Copies: -2 [20=>18]
Uploads: -3 [29=>26]

Fight Night - Round 3_SLUS-21383_20220618124952
Draw Calls: -2 [839=>837]
Render Passes: -3 [27=>24]
Copies: -1 [6=>5]
Uploads: -1 [6=>5]

Project_-_Snowblind_SLUS-21037_20240316203245
Draw Calls: +22 [302=>324]
Render Passes: +12 [152=>164]
Copies: +1 [8=>9]
Uploads: +9 [100=>109]

Silent Hill 3_SLUS-20622_20220911173117
Draw Calls: -1 [829=>828]
Render Passes: -1 [18=>17]
Copies: -1 [6=>5]
Uploads: -1 [9=>8]

sniper_elite
Draw Calls: -7 [1321=>1314]
Render Passes: -9 [468=>459]
Copies: -3 [16=>13]
Uploads: -1 [27=>26]