### PR TITLE
Qt: Fix crash on shutdown settings save

### DIFF
--- a/pcsx2-qt/QtHost.cpp
+++ b/pcsx2-qt/QtHost.cpp
@@ -1298,13 +1298,17 @@ void QtHost::SaveSettings()
 	pxAssertRel(!g_emu_thread->isOnEmuThread(), "Saving should happen on the UI thread.");
 
 	{
+		Error error;
 		auto lock = Host::GetSettingsLock();
-		if (!s_base_settings_interface->Save())
-			Console.Error("Failed to save settings.");
+		if (!s_base_settings_interface->Save(&error))
+			Console.ErrorFmt("Failed to save settings: {}", error.GetDescription());
 	}
 
-	s_settings_save_timer->deleteLater();
-	s_settings_save_timer.release();
+	if (s_settings_save_timer)
+	{
+		s_settings_save_timer->deleteLater();
+		s_settings_save_timer.release();
+	}
 }
 
 void Host::CommitBaseSettingChanges()


### PR DESCRIPTION
### Description of Changes

Null pointer dereference.

### Rationale behind Changes

Crash bad.

### Suggested Testing Steps

Obvious issue. CI passes.
