### PR TITLE
GameDB/GS: Various fixes for db, remove getaway crc hack from gs

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -142,6 +142,20 @@ GUST-00009:
     - SoftwareRendererFMVHack # Vertical lines in FMV.
   gsHWFixes:
     roundSprite: 1 # Fixes misalignment of textures in the Pause Menu.
+PAPX-90020:
+  name: "Ghost in the Shell - Stand Alone Complex [Trial]"
+  region: "NTSC-J"
+  gameFixes:
+    - SoftwareRendererFMVHack # Fixes hash cache disabling itself.
+  gsHWFixes:
+    recommendedBlendingLevel: 4 # Improves banding and effect emulation.
+    halfPixelOffset: 3 # Fixes texture and lighting misalignment.
+    mergeSprite: 1 # Fixes most vertical lines and lighting misalignment.
+    autoFlush: 1 # Fixes light bloom intensity.
+    estimateTextureRegion: 1 # Improves performance and reduces hash cache size.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
+    getSkipCount: "GSC_GiTS"
 PAPX-90201:
   name: ファンタビジョン 体験版
   name-sort: ふぁんたびじょん たいけんばん
@@ -156,6 +170,9 @@ PAPX-90203:
   name: "Gran Turismo 2000 [Trial]"
   region: "NTSC-J"
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 PAPX-90204:
   name: "TVDJ"
@@ -174,16 +191,25 @@ PAPX-90207:
   name: "Gran Turismo 3 - A-Spec - Autobacs Gentei Replay Theater"
   region: "NTSC-J"
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 PAPX-90208:
   name: "Gran Turismo 3 - A-Spec - Replay Theater"
   region: "NTSC-J"
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 PAPX-90209:
   name: "Gran Turismo 3 - A-Spec - Netz Toyota - Replay Theater Disc"
   region: "NTSC-J"
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 PAPX-90210:
   name: "Yappa RPG desho."
@@ -260,6 +286,8 @@ PAPX-90231:
   name-sort: かいとう すらいくーぱー たいけんばん
   name-en: "Kaitou Sly Cooper [Trial]"
   region: "NTSC-J"
+  gsHWFixes:
+    autoFlush: 1 # Fixes Sly's shadow definition.
 PAPX-90232:
   name: "Chain Dive"
   region: "NTSC-J"
@@ -317,6 +345,10 @@ PAPX-90504:
   name-en: "Gran Turismo Concept - Airtrek Turbo Special Edition [Trial]"
   region: "NTSC-J"
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
+    halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 PAPX-90505:
   name: "2002 Natsu no Osusume Soft Otameshi Disc"
@@ -338,6 +370,7 @@ PAPX-90508:
   name: "Gran Turismo 4 - Lupo Cup Training Version"
   region: "NTSC-J"
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
@@ -351,6 +384,7 @@ PAPX-90512:
   clampModes:
     vuClampMode: 2 # Text in GT mode works.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
@@ -375,6 +409,7 @@ PAPX-90517:
   region: "NTSC-J"
   gsHWFixes:
     autoFlush: 2 # Reduces post-processing misalignment.
+    halfPixelOffset: 4 # Reduces post-processing misalignment.
 PAPX-90519:
   name: どこでもいっしょ トロといっぱい 体験版
   name-sort: どこでもいっしょ とろといっぱい たいけんばん
@@ -392,6 +427,7 @@ PAPX-90523:
   name-en: "Gran Turismo 4 - Online Test Version"
   region: "NTSC-J"
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
@@ -524,15 +560,21 @@ PBPX-95502:
   name: "Gran Turismo 3 - A-Spec"
   region: "NTSC-J"
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 PBPX-95503:
   name: "Gran Turismo 3 - A-Spec [PS2 Bundle]"
   region: "NTSC-U"
+  gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
+    getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
   memcardFilters:
     - "PBPX-95503"
     - "SCUS-97102"
-  gsHWFixes:
-    getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 PBPX-95506:
   name: "PlayStation 2 - Demo Disc 2001"
   region: "PAL-M5"
@@ -584,6 +626,7 @@ PBPX-95523:
   name: "Gran Turismo 4 - Prologue [PlayStation 2 Racing Pack]"
   region: "NTSC-J"
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
@@ -594,6 +637,7 @@ PBPX-95524:
   region: "NTSC-C"
   compat: 5
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
@@ -609,6 +653,7 @@ PBPX-95601:
   clampModes:
     vuClampMode: 2 # Text in GT mode works.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
@@ -660,11 +705,17 @@ PCPX-96311:
   name: "Gran Turismo 3 Trial Disk Volume 1"
   region: "NTSC-J"
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 PCPX-96312:
   name: "Gran Turismo 3 - A-Spec - Autobacs Tentou Shiyuu Disc"
   region: "NTSC-J"
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 PCPX-96314:
   name: "The Sky Odyssey"
@@ -846,6 +897,12 @@ PCPX-96633:
 PCPX-96634:
   name: "Gran Turismo - Subaru Driving Simulator Version"
   region: "NTSC-J"
+  gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
+    halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
+    getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 PCPX-96635:
   name: "プレプレ2 VOLUME.8"
   name-sort: "ぷれぷれ2 VOLUME.8"
@@ -879,6 +936,7 @@ PCPX-96649:
   clampModes:
     vuClampMode: 2 # Text in GT mode works.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
@@ -928,7 +986,8 @@ PCPX-98017:
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
-    mipmap: 1
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
     halfPixelOffset: 2 # Fixes misaligned bloom.
     autoFlush: 2 # Helps fix misaligned bloom.
 PCPX-98041:
@@ -939,6 +998,9 @@ PCPX-98042:
   region: "NTSC-J"
   roundModes:
     vu1RoundMode: 1 # Fixes the display of scores and text ingame.
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves court textures to match sw renderer.
+    trilinearFiltering: 1
 PDPX-99109:
   name: "DVD Player Version 3.04"
   name-sort: "DVDぷれーやー Version 3.04"
@@ -961,6 +1023,9 @@ SCAJ-10003:
 SCAJ-10004:
   name: "Time Crisis 2 [PlayStation 2 the Best]"
   region: "NTSC-Unk"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SCAJ-10006:
   name: "Taiko no Tatsujin - Appare Sandaime"
   region: "NTSC-Unk"
@@ -1051,6 +1116,8 @@ SCAJ-20008:
   gsHWFixes:
     preloadFrameData: 1 # Fixes fog and make lights on cars work again.
     autoFlush: 2 # Fixes sun luminosity and penetration of objects.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
   gameFixes:
     - EETimingHack # Fixes random graphical corruption.
 SCAJ-20009:
@@ -1103,6 +1170,8 @@ SCAJ-20016:
 SCAJ-20017:
   name: "Sly Cooper"
   region: "NTSC-Unk"
+  gsHWFixes:
+    autoFlush: 1 # Fixes Sly's shadow definition.
 SCAJ-20018:
   name: "This is Football 2003"
   region: "NTSC-Unk"
@@ -1119,6 +1188,7 @@ SCAJ-20020:
   clampModes:
     eeClampMode: 3 # Characters are visible in-game.
   gsHWFixes:
+    recommendedBlendingLevel: 2
     texturePreloading: 1 # Performs better with partial preload because it is slow on locations outside gameplay foremost.
     mergeSprite: 1 # Fixes misaligned white lines.
     PCRTCOverscan: 1 # Fixes missing HUD.
@@ -1218,6 +1288,8 @@ SCAJ-20044:
   region: "NTSC-Unk"
   gsHWFixes:
     autoFlush: 2 # Fixes lava effect.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SCAJ-20045:
   name: "Shadow Tower Abyss"
   region: "NTSC-Unk"
@@ -1303,6 +1375,7 @@ SCAJ-20066:
   region: "NTSC-Unk"
   compat: 5
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
@@ -1349,9 +1422,16 @@ SCAJ-20070:
 SCAJ-20072:
   name: "Ghost in the Shell - Stand Alone Complex"
   region: "NTSC-Unk"
+  gameFixes:
+    - SoftwareRendererFMVHack # Fixes hash cache disabling itself.
   gsHWFixes:
-    halfPixelOffset: 1 # Fixes texture and lighting misalignment.
+    recommendedBlendingLevel: 4 # Improves banding and effect emulation.
+    halfPixelOffset: 3 # Fixes texture and lighting misalignment.
     mergeSprite: 1 # Fixes most vertical lines and lighting misalignment.
+    autoFlush: 1 # Fixes light bloom intensity.
+    estimateTextureRegion: 1 # Improves performance and reduces hash cache size.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
     getSkipCount: "GSC_GiTS"
 SCAJ-20073:
   name: "Jak and Daxter II"
@@ -1375,6 +1455,8 @@ SCAJ-20076:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
     recommendedBlendingLevel: 3 # Fixes level brightness.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
   memcardFilters:
     - "SCAJ-20076"
     - "SCAJ-20077"
@@ -1388,6 +1470,8 @@ SCAJ-20077:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
     recommendedBlendingLevel: 3 # Fixes level brightness.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
   memcardFilters:
     - "SCAJ-20076"
     - "SCAJ-20077"
@@ -1428,6 +1512,7 @@ SCAJ-20083:
   name: "Bakuso! Mountain Bikers"
   region: "NTSC-Unk"
   gsHWFixes:
+    autoFlush: 2 # Fixes speed effect intensity.
     mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
     trilinearFiltering: 1
 SCAJ-20084:
@@ -1469,7 +1554,10 @@ SCAJ-20088:
   region: "NTSC-C"
 SCAJ-20089:
   name: "Athens 2004"
-  region: "NTSC-Unk"
+  region: "NTSC-J"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SCAJ-20090:
   name: "Gacha Mecha Stadium - Saru Battle"
   region: "NTSC-Unk"
@@ -1481,6 +1569,9 @@ SCAJ-20092:
 SCAJ-20093:
   name: "Tenchu Kurenai"
   region: "NTSC-Unk"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SCAJ-20094:
   name: "Minna no Golf 4 [PlayStation 2 the Best]"
   region: "NTSC-Unk"
@@ -1515,6 +1606,9 @@ SCAJ-20099:
 SCAJ-20100:
   name: "Tenchu Kurenai"
   region: "NTSC-C-J"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SCAJ-20101:
   name: "EyeToy - Saru"
   region: "NTSC-Unk"
@@ -1543,6 +1637,8 @@ SCAJ-20105:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
     recommendedBlendingLevel: 3 # Fixes level brightness.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SCAJ-20107:
   name: "Bakufuu Slash! Kizna Arashi"
   region: "NTSC-Unk"
@@ -1572,10 +1668,11 @@ SCAJ-20110:
   name: "Dragon Quest VIII - Sora to Daichi to Norowareshi Himegimi"
   region: "NTSC-Unk"
   gsHWFixes:
-    autoFlush: 2 # Fixes missing bloom from surfaces like windows.
+    autoFlush: 1 # Fixes missing bloom from surfaces like windows.
     # halfPixelOffset: 1 # Aligns shadows properly, but causes grid lines to appear in sea travel.
     halfPixelOffset: 2 # Sharpens world in far distances, aligns some bloom better.
     roundSprite: 1 # Fixes font artifacts.
+    cpuSpriteRenderBW: 1 # Fixes broken fire sprites.
 SCAJ-20111:
   name: "Crash Bandicoot 5"
   region: "NTSC-Unk"
@@ -1604,6 +1701,10 @@ SCAJ-20116:
   region: "NTSC-C-J"
   gsHWFixes:
     alignSprite: 1 # Fixes FMV lines.
+    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
+    trilinearFiltering: 1
+    cpuSpriteRenderBW: 2 # Prevents Death By VRAM explosion.
+    cpuSpriteRenderLevel: 2 # Needed for above.
     getSkipCount: "GSC_DeathByDegreesTekkenNinaWilliams"
 SCAJ-20117:
   name: "Fu-un Bakumatsu-den"
@@ -1644,6 +1745,8 @@ SCAJ-20121:
     halfPixelOffset: 1 # Fixes misaligned blur.
     cpuSpriteRenderBW: 1 # Fixes broken shadow caused by HPO 1.
     cpuSpriteRenderLevel: 2 # Needed for above.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SCAJ-20122:
   name: "Swords of Destiny"
   region: "NTSC-Unk"
@@ -1677,6 +1780,8 @@ SCAJ-20125:
   gsHWFixes:
     alignSprite: 1
     halfPixelOffset: 4 # Align post.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
     getSkipCount: "GSC_Tekken5"
 SCAJ-20126:
   name: "Tekken 5"
@@ -1686,6 +1791,8 @@ SCAJ-20126:
   gsHWFixes:
     alignSprite: 1
     halfPixelOffset: 4 # Align post.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
     getSkipCount: "GSC_Tekken5"
 SCAJ-20127:
   name: "EyeToy - Play 2 [with Camera]"
@@ -1783,6 +1890,8 @@ SCAJ-20143:
   gsHWFixes:
     halfPixelOffset: 2 # Corrects shadow alignment and reduces blurriness.
     recommendedBlendingLevel: 3 # Fixes level and map menu brightness.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SCAJ-20144:
   name: "Zhuo Hou La 3"
   region: "NTSC-C"
@@ -1837,6 +1946,8 @@ SCAJ-20152:
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
     textureInsideRT: 1 # Fixes corruption.
+    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
+    trilinearFiltering: 1
     getSkipCount: "GSC_UrbanReign"
 SCAJ-20153:
   name: "Code Age Commanders"
@@ -1869,6 +1980,7 @@ SCAJ-20158:
   gameFixes:
     - VIF1StallHack # Fixes black screen on boot.
   gsHWFixes:
+    recommendedBlendingLevel: 2
     autoFlush: 2 # Fixes missing bloom effects.
     halfPixelOffset: 2 # Fixes misaligned lighting and bloom.
 SCAJ-20159:
@@ -2010,6 +2122,8 @@ SCAJ-20179:
     halfPixelOffset: 2 # Fixes lighting misalignment and reduces ground shadows (probably texture cache issue).
     roundSprite: 2 # Fixes font artifacts.
     textureInsideRT: 1 # Fixes bad crystal surfaces.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SCAJ-20180:
   name: "Xenosaga Episode III - Also Sprach Zarathustra [Disc 2 of 2]"
   region: "NTSC-Unk"
@@ -2018,11 +2132,16 @@ SCAJ-20180:
     halfPixelOffset: 2 # Fixes lighting misalignment and reduces ground shadows (probably texture cache issue).
     roundSprite: 2 # Fixes font artifacts.
     textureInsideRT: 1 # Fixes bad crystal surfaces.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SCAJ-20181:
   name: "Minna no Tennis"
   region: "NTSC-Unk"
   roundModes:
     vu1RoundMode: 1 # Fixes the display of scores and text ingame.
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves court textures to match sw renderer.
+    trilinearFiltering: 1
 SCAJ-20182:
   name: "Tales of Destiny"
   region: "NTSC-Unk"
@@ -2102,6 +2221,8 @@ SCAJ-20197:
   compat: 5
   gameFixes:
     - VuAddSubHack
+  speedHacks:
+    instantVU1: 0 # Mostly fixes animation stuttering.
   gsHWFixes:
     halfPixelOffset: 2 # Reduces bloom misalignment.
     roundSprite: 1 # Fixes area transition vertical lines and lessens red forest vertical lines.
@@ -2110,6 +2231,11 @@ SCAJ-20197:
 SCAJ-20198:
   name: "Everybody's Tennis [PlayStation 2 the Best]"
   region: "NTSC-Unk"
+  roundModes:
+    vu1RoundMode: 1 # Fixes the display of scores and text ingame.
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves court textures to match sw renderer.
+    trilinearFiltering: 1
 SCAJ-20199:
   name: "Tekken 5 [PlayStation 2 the Best]"
   region: "NTSC-Unk"
@@ -2118,6 +2244,8 @@ SCAJ-20199:
   gsHWFixes:
     alignSprite: 1
     halfPixelOffset: 4 # Align post.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
     getSkipCount: "GSC_Tekken5"
 SCAJ-25002:
   name: "Shinobi"
@@ -2141,6 +2269,8 @@ SCAJ-25026:
   name: "Kunoichi Shinobi"
   region: "NTSC-Unk"
   gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
     getSkipCount: "GSC_Kunoichi"
 SCAJ-25034:
   name: "Sakura Taisen Monogatari"
@@ -2161,6 +2291,8 @@ SCAJ-25047:
   region: "NTSC-Unk"
   gsHWFixes:
     minimumBlendingLevel: 2 # Fixes dark font to more bright like software mode.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SCAJ-30001:
   name: "Xenosaga - Episode I - Der Wille zur Macht [PlayStation 2 the Best]"
   region: "NTSC-Unk"
@@ -2197,6 +2329,7 @@ SCAJ-30006:
     eeRoundMode: 3 # Using chop for both normal+div fixes crash in B5 license test.
     eeDivRoundMode: 3 # See above.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
@@ -2220,6 +2353,7 @@ SCAJ-30007:
     eeRoundMode: 3 # Using chop for both normal+div fixes crash in B5 license test.
     eeDivRoundMode: 3 # See above.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
@@ -2231,6 +2365,7 @@ SCAJ-30008:
     eeRoundMode: 3 # Using chop for both normal+div fixes crash in B5 license test.
     eeDivRoundMode: 3 # See above.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
@@ -2387,6 +2522,7 @@ SCCS-60002:
   name-en: "Gran Turismo 4 [Review Copy]"
   region: "NTSC-C"
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
@@ -2548,6 +2684,7 @@ SCED-50642:
     eeClampMode: 3 # Fixes animations.
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
+    autoFlush: 1 # Fixes blur effect on attacks.
 SCED-50660:
   name: "Dropship - United Peace Force"
   region: "PAL-A"
@@ -2637,6 +2774,8 @@ SCED-50781:
     vu1RoundMode: 0 # Fixes tyre textures.
   gsHWFixes:
     halfPixelOffset: 2 # Corrects shadow position.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SCED-50783:
   name: "Official PlayStation 2 Magazine-UK Greatest Hits Volume 6 - Special Edition - Awards 2002"
   region: "PAL-M5"
@@ -2676,6 +2815,7 @@ SCED-50907:
     eeClampMode: 3 # Fixes animations.
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
+    autoFlush: 1 # Fixes blur effect on attacks.
 SCED-50916:
   name: "Ratchet & Clank [Demo]"
   region: "PAL-M5"
@@ -2792,11 +2932,16 @@ SCED-51351:
     textureInsideRT: 1
     texturePreloading: 1 # Performs much better with partial preload.
     halfPixelOffset: 2 # Fixes outlines around characters.
-    getSkipCount: "GSC_GetawayGames"
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SCED-51352:
   name: "Gran Turismo - Nissan Micra Edition [Demo]"
   region: "PAL-E"
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
+    halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 SCED-51359:
   name: "Official PlayStation 2 Magazine Demo 27"
@@ -2843,6 +2988,8 @@ SCED-51444:
 SCED-51452:
   name: "Sly Raccoon"
   region: "PAL-M5"
+  gsHWFixes:
+    autoFlush: 1 # Fixes Sly's shadow definition.
 SCED-51454:
   name: "Tango - Game On Demo Disc 1"
   region: "PAL-E"
@@ -3135,7 +3282,10 @@ SCED-52049:
   clampModes:
     vuClampMode: 3 # Fixes minor SPS on characters.
   gsHWFixes:
+    roundSprite: 1 # Fix lines in the sky.
     halfPixelOffset: 2 # Fixes double image.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SCED-52051:
   name: "Official PlayStation 2 Magazine Demo 43"
   region: "PAL-M5"
@@ -3203,6 +3353,8 @@ SCED-52098:
     vu1RoundMode: 0 # Fixes tire textures.
   gsHWFixes:
     halfPixelOffset: 2 # Corrects shadow position.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SCED-52119:
   name: "Official PlayStation 2 Magazine Germany Special Edition 01/2004"
   region: "PAL-G"
@@ -3356,6 +3508,7 @@ SCED-52455:
   name: "Gran Turismo Special Edition 2004 Geneva Version"
   region: "PAL-E"
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
@@ -3367,6 +3520,9 @@ SCED-52461:
 SCED-52491:
   name: "Athens 2004"
   region: "PAL-M6"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SCED-52497:
   name: "This Is Football 2004"
   region: "PAL-M4"
@@ -3377,6 +3533,7 @@ SCED-52578:
   name: "Gran Turismo 4 BMW 1 Series Virtual Drive Dealership [Demo]"
   region: "PAL-M5"
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
@@ -3394,6 +3551,7 @@ SCED-52681:
   name: "Gran Turismo 4 BMW 1 Series Virtual Drive [Demo]"
   region: "PAL-M11"
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
@@ -3453,6 +3611,9 @@ SCED-52847:
 SCED-52848:
   name: "Ratchet & Clank 3 + Sly 2 - Band of Thieves"
   region: "PAL-M5"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SCED-52855:
   name: "Magazine Ufficiale PlayStation 2 Italia 09/04"
   region: "PAL-I"
@@ -3545,7 +3706,8 @@ SCED-52946:
   gsHWFixes:
     textureInsideRT: 1
     halfPixelOffset: 2 # Fixes outlines on screen edges.
-    getSkipCount: "GSC_GetawayGames"
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SCED-52952:
   name: "Jak 3 [Demo]"
   region: "PAL-M5"
@@ -3773,9 +3935,15 @@ SCED-53431:
 SCED-53447:
   name: "Formula One 05 [Press Kit Demo]"
   region: "PAL-E"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SCED-53448:
   name: "Formula One 05 [Demo]"
   region: "PAL-E"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SCED-53513:
   name: "Bonus Demo 10"
   region: "PAL-M5"
@@ -3799,6 +3967,8 @@ SCED-53538:
   gsHWFixes:
     alignSprite: 1
     halfPixelOffset: 4 # Align post.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
     getSkipCount: "GSC_Tekken5"
 SCED-53611:
   name: "Official PlayStation 2 Magazine - German Kids Special"
@@ -4242,6 +4412,9 @@ SCES-50034:
   name: "MotoGP"
   region: "PAL-M5"
   compat: 5
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves road and tree textures to match sw renderer.
+    trilinearFiltering: 1
 SCES-50105:
   name: "Sky Odyssey"
   region: "PAL-M5"
@@ -4278,11 +4451,17 @@ SCES-50246:
 SCES-50293:
   name: "ATV Offroad - All Terrain Vehicle"
   region: "PAL-M5"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SCES-50294:
   name: "Gran Turismo 3 - A-Spec"
   region: "PAL-M5"
   compat: 5
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
+    mipmap: 2 # Mipmap + trilinear, improves track textures to match sw renderer.
+    trilinearFiltering: 1
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 SCES-50295:
   name: "Dark Cloud"
@@ -4296,6 +4475,9 @@ SCES-50300:
   name: "Time Crisis 2"
   region: "PAL-M5"
   compat: 5
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SCES-50354:
   name: "Klonoa 2 - Lunatea's Veil"
   region: "PAL-M5"
@@ -4371,6 +4553,7 @@ SCES-50490:
     eeClampMode: 3 # Fixes animations.
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
+    autoFlush: 1 # Fixes blur effect on attacks.
 SCES-50491:
   name: "Final Fantasy X"
   region: "PAL-F"
@@ -4382,6 +4565,7 @@ SCES-50491:
     eeClampMode: 3 # Fixes animations.
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
+    autoFlush: 1 # Fixes blur effect on attacks.
 SCES-50492:
   name: "Final Fantasy X"
   region: "PAL-G"
@@ -4394,6 +4578,7 @@ SCES-50492:
     eeClampMode: 3 # Fixes animations.
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
+    autoFlush: 1 # Fixes blur effect on attacks.
 SCES-50493:
   name: "Final Fantasy X"
   region: "PAL-I"
@@ -4405,6 +4590,7 @@ SCES-50493:
     eeClampMode: 3 # Fixes animations.
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
+    autoFlush: 1 # Fixes blur effect on attacks.
 SCES-50494:
   name: "Final Fantasy X"
   region: "PAL-S"
@@ -4416,6 +4602,7 @@ SCES-50494:
     eeClampMode: 3 # Fixes animations.
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
+    autoFlush: 1 # Fixes blur effect on attacks.
 SCES-50499:
   name: "Ecco the Dolphin - Defender of the Future"
   region: "PAL-M5"
@@ -4438,15 +4625,15 @@ SCES-50501:
   region: "PAL-M5"
   compat: 5
 SCES-50522:
-  name: "Disney's Peter Pan - Adventures in Neverland"
+  name: "Disney's Peter Pan - The Legend of Never Land"
   region: "PAL-E-S"
   compat: 5
 SCES-50526:
-  name: "Peter Pan"
+  name: "Disney's Peter Pan - The Legend of Never Land"
   region: "PAL-M5"
 SCES-50531:
-  name: "Peter Pan - Legenden om Onskeoen"
-  region: "PAL-M4"
+  name: "Disney's Peter Pan - The Legend of Never Land"
+  region: "PAL-SC"
 SCES-50595:
   name: "Monsters Inc. - Scare Island"
   region: "PAL-E"
@@ -4517,6 +4704,8 @@ SCES-50781:
     vu1RoundMode: 0 # Fixes tyre textures.
   gsHWFixes:
     halfPixelOffset: 2 # Corrects shadow position.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SCES-50791:
   name: "Frequency"
   region: "PAL-M5"
@@ -4524,11 +4713,6 @@ SCES-50791:
 SCES-50810:
   name: "Smash Court Tennis - Pro Tournament"
   region: "PAL-M5"
-SCES-50850:
-  name: "Gran Turismo - Concept 2002 Tokyo-Geneva"
-  region: "PAL-Unk"
-  gsHWFixes:
-    getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 SCES-50858:
   name: "Gran Turismo - Concept 2002 Tokyo-Geneva"
   region: "PAL-M6"
@@ -4592,6 +4776,8 @@ SCES-50916:
 SCES-50917:
   name: "Sly Raccoon"
   region: "PAL-M5"
+  gsHWFixes:
+    autoFlush: 1 # Fixes Sly's shadow definition.
 SCES-50928:
   name: "SOCOM - U.S. Navy SEALs [Beta & Full Release]"
   region: "PAL-M6"
@@ -4734,7 +4920,8 @@ SCES-51159:
     textureInsideRT: 1
     texturePreloading: 1 # Performs much better with partial preload.
     halfPixelOffset: 2 # Fixes outlines around characters.
-    getSkipCount: "GSC_GetawayGames"
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SCES-51164:
   name: "The Mark of Kri"
   name-sort: "Mark of Kri, The"
@@ -4768,7 +4955,10 @@ SCES-51190:
     cpuSpriteRenderLevel: 2 # Needed for above.
 SCES-51224:
   name: "War of the Monsters"
-  region: "PAL-E"
+  region: "PAL-M5"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
+    trilinearFiltering: 1
 SCES-51248:
   name: "Dog's Life"
   region: "PAL-M11"
@@ -4777,6 +4967,8 @@ SCES-51248:
   gsHWFixes:
     roundSprite: 1 # Fix lines in the sky.
     halfPixelOffset: 2 # Fixes double image.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SCES-51407:
   name: "Exclusive PlayStation 2 Summer Sample Disc"
   region: "PAL-A"
@@ -4788,7 +4980,8 @@ SCES-51426:
     textureInsideRT: 1
     texturePreloading: 1 # Performs much better with partial preload.
     halfPixelOffset: 2 # Fixes outlines around characters.
-    getSkipCount: "GSC_GetawayGames"
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SCES-51428:
   name: "Shinobi"
   region: "PAL-M5"
@@ -4898,6 +5091,8 @@ SCES-51635:
     preloadFrameData: 1 # Fixes sun flickering.
     autoFlush: 2 # Fixes sun through objects.
     bilinearUpscale: 1 # Smooths out sun glare textures like native.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SCES-51648:
   name: "Everquest - Online Adventures"
   region: "PAL-E-I"
@@ -4934,6 +5129,7 @@ SCES-51719:
   clampModes:
     vuClampMode: 2 # Text in GT mode works.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
@@ -4961,6 +5157,9 @@ SCES-51904:
   gameFixes:
     - VIF1StallHack # Fixes broken HUD.
     - InstantDMAHack # Fixes texture corruption.
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SCES-51910:
   name: "Arc - Twilight of the Spirits"
   region: "PAL-M5"
@@ -4990,6 +5189,8 @@ SCES-51979:
     vu1RoundMode: 0 # Fixes tire textures.
   gsHWFixes:
     halfPixelOffset: 2 # Corrects shadow position.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SCES-52004:
   name: "Killzone"
   region: "PAL-M6"
@@ -5006,6 +5207,8 @@ SCES-52033:
     autoFlush: 2 # Fixes lights going through walls.
     preloadFrameData: 1 # Fixes light flicker.
     halfPixelOffset: 2 # Corrects light position.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
   gameFixes:
     - EETimingHack # Fixes random hangs.
   patches:
@@ -5067,6 +5270,9 @@ SCES-52306:
   gameFixes:
     - VIF1StallHack # Fixes broken HUD.
     - InstantDMAHack # Fixes texture corruption.
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SCES-52327:
   name: "Forbidden Siren"
   region: "PAL-F"
@@ -5125,9 +5331,15 @@ SCES-52405:
 SCES-52410:
   name: "Athens 2004"
   region: "PAL-M6"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SCES-52411:
   name: "Athens 2004 [Platinum]"
   region: "PAL-M6"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SCES-52412:
   name: "Jackie Chan Adventures"
   region: "PAL-M7"
@@ -5181,6 +5393,7 @@ SCES-52438:
   region: "PAL-M5"
   compat: 5
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
@@ -5251,6 +5464,10 @@ SCES-52586:
   compat: 5
   gsHWFixes:
     alignSprite: 1 # Fixes FMV lines.
+    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
+    trilinearFiltering: 1
+    cpuSpriteRenderBW: 2 # Prevents Death By VRAM explosion.
+    cpuSpriteRenderLevel: 2 # Needed for above.
     getSkipCount: "GSC_DeathByDegreesTekkenNinaWilliams"
 SCES-52596:
   name: "This is Football 2005"
@@ -5283,7 +5500,8 @@ SCES-52758:
   gsHWFixes:
     textureInsideRT: 1
     halfPixelOffset: 2 # Fixes outlines on screen edges.
-    getSkipCount: "GSC_GetawayGames"
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SCES-52762:
   name: "DJ Decks & FX"
   region: "PAL-F"
@@ -5334,16 +5552,24 @@ SCES-52948:
   gsHWFixes:
     textureInsideRT: 1
     halfPixelOffset: 2 # Fixes outlines on screen edges.
-    getSkipCount: "GSC_GetawayGames"
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SCES-53033:
   name: "Formula One 2005"
   region: "PAL-M7"
   compat: 5
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SCES-53053:
   name: "Death by Degrees"
   region: "PAL-F-I"
   gsHWFixes:
     alignSprite: 1 # Fixes FMV lines.
+    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
+    trilinearFiltering: 1
+    cpuSpriteRenderBW: 2 # Prevents Death By VRAM explosion.
+    cpuSpriteRenderLevel: 2 # Needed for above.
     getSkipCount: "GSC_DeathByDegreesTekkenNinaWilliams"
 SCES-53054:
   name: "Death by Degrees"
@@ -5351,6 +5577,10 @@ SCES-53054:
   compat: 5
   gsHWFixes:
     alignSprite: 1 # Fixes FMV lines.
+    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
+    trilinearFiltering: 1
+    cpuSpriteRenderBW: 2 # Prevents Death By VRAM explosion.
+    cpuSpriteRenderLevel: 2 # Needed for above.
     getSkipCount: "GSC_DeathByDegreesTekkenNinaWilliams"
 SCES-53055:
   name: "Eyetoy - Antigrav"
@@ -5396,6 +5626,8 @@ SCES-53202:
   gsHWFixes:
     alignSprite: 1
     halfPixelOffset: 4 # Align post.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
     getSkipCount: "GSC_Tekken5"
 SCES-53247:
   name: "WRC Rally Evolved"
@@ -5450,6 +5682,8 @@ SCES-53300:
     vuClampMode: 3 # Fixes SPS ingame and prevents flickering or invisible characters.
   gsHWFixes:
     minimumBlendingLevel: 4 # Mitigates grayer text font in bottom left.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SCES-53304:
   name: "Buzz! The Music Quiz"
   region: "PAL-E"
@@ -5611,6 +5845,8 @@ SCES-53688:
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
     textureInsideRT: 1 # Fixes corruption.
+    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
+    trilinearFiltering: 1
     getSkipCount: "GSC_UrbanReign"
 SCES-53795:
   name: "SingStar '80s"
@@ -5706,6 +5942,8 @@ SCES-53950:
 SCES-53960:
   name: "B-Boy"
   region: "PAL-M5"
+  gsHWFixes:
+    autoFlush: 1 # Fixes lighting.
 SCES-54025:
   name: "SingStar Rocks!"
   region: "PAL-IR"
@@ -5913,6 +6151,11 @@ SCES-54526:
 SCES-54535:
   name: "Everybody's Tennis"
   region: "PAL-M11"
+  roundModes:
+    vu1RoundMode: 1 # Fixes the display of scores and text ingame.
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves court textures to match sw renderer.
+    trilinearFiltering: 1
 SCES-54538:
   name: "Eyetoy - Play Astro Zoo"
   region: "PAL-M15"
@@ -5983,6 +6226,9 @@ SCES-54637:
 SCES-54638:
   name: "Gaelic Games - Football 2"
   region: "PAL-E-GA"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SCES-54639:
   name: "AFL Premiership 2007"
   region: "PAL-A"
@@ -5995,6 +6241,9 @@ SCES-54676:
 SCES-54688:
   name: "ATV Offroad Fury 4"
   region: "PAL-M12"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SCES-54689:
   name: "Buzz! The Maha Quiz"
   region: "PAL-IN"
@@ -6478,7 +6727,6 @@ SCES-82035:
     autoFlush: 2
   memcardFilters:
     - "SLES-82034"
-    - "SCES-82034"
 SCKA-10001:
   name: "Gangcheol Gigap Sadan - Online Battlefield"
   region: "NTSC-K"
@@ -6503,13 +6751,21 @@ SCKA-20001:
 SCKA-20002:
   name: "Time Crisis II"
   region: "NTSC-K"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SCKA-20003:
   name: "War of the Monsters"
   region: "NTSC-K"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
+    trilinearFiltering: 1
 SCKA-20004:
   name: "Sly Cooper and the Thievius Raccoonus"
   region: "NTSC-K"
   compat: 5
+  gsHWFixes:
+    autoFlush: 1 # Fixes Sly's shadow definition.
 SCKA-20005:
   name: "Let's Bravo Music"
   region: "NTSC-K"
@@ -6594,7 +6850,8 @@ SCKA-20018:
     textureInsideRT: 1
     texturePreloading: 1 # Performs much better with partial preload.
     halfPixelOffset: 2 # Fixes outlines around characters.
-    getSkipCount: "GSC_GetawayGames"
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SCKA-20019:
   name: "Siren"
   region: "NTSC-K"
@@ -6609,10 +6866,14 @@ SCKA-20020:
   gameFixes:
     - VIF1StallHack # Fixes broken HUD.
     - InstantDMAHack # Fixes texture corruption.
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SCKA-20022:
   name: "Gran Turismo 4 Prologue"
   region: "NTSC-K"
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
@@ -6641,9 +6902,16 @@ SCKA-20027:
   name: "Ghost in the Shell - Stand Alone Complex"
   region: "NTSC-K"
   compat: 5
+  gameFixes:
+    - SoftwareRendererFMVHack # Fixes hash cache disabling itself.
   gsHWFixes:
-    halfPixelOffset: 1 # Fixes texture and lighting misalignment.
+    recommendedBlendingLevel: 4 # Improves banding and effect emulation.
+    halfPixelOffset: 3 # Fixes texture and lighting misalignment.
     mergeSprite: 1 # Fixes most vertical lines and lighting misalignment.
+    autoFlush: 1 # Fixes light bloom intensity.
+    estimateTextureRegion: 1 # Improves performance and reduces hash cache size.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
     getSkipCount: "GSC_GiTS"
 SCKA-20028:
   name: "Ico [PlayStation2 Big Hit Series]"
@@ -6667,6 +6935,9 @@ SCKA-20030:
 SCKA-20031:
   name: "Athens 2004"
   region: "NTSC-K"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SCKA-20032:
   name: "Syphon Filter - The Omega Virus"
   region: "NTSC-K"
@@ -6674,6 +6945,8 @@ SCKA-20032:
     autoFlush: 2 # Fixes lights going through walls.
     preloadFrameData: 1 # Fixes light flicker.
     halfPixelOffset: 2 # Corrects light position.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
   gameFixes:
     - EETimingHack # Fixes random hangs.
   patches:
@@ -6724,7 +6997,11 @@ SCKA-20039:
   name: "Tekken Nina Williams In Death By Degree"
   region: "NTSC-K"
   gsHWFixes:
-    alignSprite: 1
+    alignSprite: 1 # Fixes FMV lines.
+    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
+    trilinearFiltering: 1
+    cpuSpriteRenderBW: 2 # Prevents Death By VRAM explosion.
+    cpuSpriteRenderLevel: 2 # Needed for above.
     getSkipCount: "GSC_DeathByDegreesTekkenNinaWilliams"
 SCKA-20040:
   name: "Jak 3"
@@ -6782,6 +7059,8 @@ SCKA-20047:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
     recommendedBlendingLevel: 3 # Fixes level brightness.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
   memcardFilters:
     - "SCKA-20047"
     - "SLKA-25201"
@@ -6801,6 +7080,8 @@ SCKA-20049:
   gsHWFixes:
     alignSprite: 1
     halfPixelOffset: 4 # Align post.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
     getSkipCount: "GSC_Tekken5"
 SCKA-20050:
   name: "Tales of Legendia"
@@ -6833,6 +7114,9 @@ SCKA-20053:
   gameFixes:
     - VIF1StallHack # Fixes broken HUD.
     - InstantDMAHack # Fixes texture corruption.
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SCKA-20054:
   name: "Tales of Destiny 2 [PlayStation 2 Big Hit Series]"
   region: "NTSC-K"
@@ -6920,6 +7204,8 @@ SCKA-20064:
     vuClampMode: 3 # Fixes SPS ingame and prevents flickering or invisible characters.
   gsHWFixes:
     minimumBlendingLevel: 4 # Mitigates grayer text font in bottom left.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SCKA-20065:
   name: "Urban Reign"
   region: "NTSC-K"
@@ -6928,6 +7214,8 @@ SCKA-20065:
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
     textureInsideRT: 1 # Fixes corruption.
+    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
+    trilinearFiltering: 1
     getSkipCount: "GSC_UrbanReign"
 SCKA-20066:
   name: "EyeToy - Play 3"
@@ -7021,6 +7309,8 @@ SCKA-20081:
   gsHWFixes:
     alignSprite: 1
     halfPixelOffset: 4 # Align post.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
     getSkipCount: "GSC_Tekken5"
 SCKA-20082:
   name: "Ace Combat 5 - The Unsung War [PlayStation 2 Big Hit Series]"
@@ -7062,6 +7352,8 @@ SCKA-20089:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SCKA-20090:
   name: "God Hand"
   region: "NTSC-K"
@@ -7099,11 +7391,12 @@ SCKA-20095:
   gsHWFixes:
     roundSprite: 2 # Reduces misalignment issues but the game is just bad for upscaling.
 SCKA-20096:
-  name: "Barnyard"
+  name: "Nickelodeon Barnyard"
   region: "NTSC-K"
   gsHWFixes:
     halfPixelOffset: 2 # Fix text and post blur.
     mipmap: 2 # Base mip level isn't always used.
+    trilinearFiltering: 1
     autoFlush: 2 # Needed for recursive mipmap rendering.
     getSkipCount: "GSC_BlueTongueGames" # Render mipmaps on the CPU.
 SCKA-20097:
@@ -7206,6 +7499,8 @@ SCKA-20120:
   name: "Ratchet & Clank - Size Matters"
   region: "NTSC-K"
   gsHWFixes:
+    recommendedBlendingLevel: 4 # Fixes vendor and other bloom.
+    autoFlush: 2 # Fixes missing bloom and shadow definition.
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
 SCKA-20124:
@@ -7296,6 +7591,10 @@ SCKA-20141:
 SCKA-20142:
   name: "MLB 11 - The Show"
   region: "NTSC-K"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves crowd textures.
+    trilinearFiltering: 1
+    textureInsideRT: 1 # Needed for mipmapping to function correctly.
 SCKA-20171:
   name: "Let's Bravo Music"
   region: "NTSC-K"
@@ -7321,6 +7620,7 @@ SCKA-30001:
   clampModes:
     vuClampMode: 2 # Text in GT mode works.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
@@ -7346,6 +7646,7 @@ SCKA-30004:
   clampModes:
     vuClampMode: 2 # Text in GT mode works.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
@@ -7418,6 +7719,10 @@ SCPM-85301:
   name: "Gran Turismo Concept - Copen Special Edition [Demo]"
   region: "NTSC-J"
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
+    halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 SCPM-85302:
   name: "Minna no Golf Online"
@@ -7429,6 +7734,10 @@ SCPM-85304:
   name: "Gran Turismo 4 - First Preview"
   region: "NTSC-J"
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
+    halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 SCPN-60101:
   name: "PlayStation BB Navigator - Version 0.10 [Prerelease] [Disc 1]"
@@ -7715,6 +8024,9 @@ SCPS-15009:
   name-en: "Gran Turismo 3 - A-Spec"
   region: "NTSC-J"
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
+    mipmap: 2 # Mipmap + trilinear, improves track textures to match sw renderer.
+    trilinearFiltering: 1
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 SCPS-15010:
   name: グランツーリスモ コンセプト 2001 TOKYO
@@ -7915,6 +8227,8 @@ SCPS-15036:
   name-sort: かいとう すらいくーぱー
   name-en: "Kaitou Sly Cooper"
   region: "NTSC-J"
+  gsHWFixes:
+    autoFlush: 1 # Fixes Sly's shadow definition.
 SCPS-15037:
   name: ラチェット＆クランク
   name-sort: らちぇっとあんどくらんく
@@ -8040,6 +8354,7 @@ SCPS-15055:
   name-en: "Gran Turismo 4 - Prologue"
   region: "NTSC-J"
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
@@ -8113,6 +8428,7 @@ SCPS-15062:
   name-en: "Bakuso! Mountain Bikers"
   region: "NTSC-J"
   gsHWFixes:
+    autoFlush: 2 # Fixes speed effect intensity.
     mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
     trilinearFiltering: 1
 SCPS-15063:
@@ -8126,6 +8442,17 @@ SCPS-15064:
   name-en: "Koukaku Kidoutai - Stand Alone Complex"
   region: "NTSC-J"
   compat: 5
+  gameFixes:
+    - SoftwareRendererFMVHack # Fixes hash cache disabling itself.
+  gsHWFixes:
+    recommendedBlendingLevel: 4 # Improves banding and effect emulation.
+    halfPixelOffset: 3 # Fixes texture and lighting misalignment.
+    mergeSprite: 1 # Fixes most vertical lines and lighting misalignment.
+    autoFlush: 1 # Fixes light bloom intensity.
+    estimateTextureRegion: 1 # Improves performance and reduces hash cache size.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
+    getSkipCount: "GSC_GiTS"
   patches:
     A5768F53:
       content: |-
@@ -8164,8 +8491,6 @@ SCPS-15064:
         patch=0,EE,001BDA30,word,4A5DEF40
         patch=0,EE,001BDFE8,word,48588800
         patch=0,EE,001BDFF4,word,4A5DEF40
-  gsHWFixes:
-    getSkipCount: "GSC_GiTS"
 SCPS-15065:
   name: "SOCOM II: U.S. NAVY SEALs"
   name-en: "SOCOM II - U.S. Navy SEALs"
@@ -8174,6 +8499,9 @@ SCPS-15065:
   gameFixes:
     - VIF1StallHack # Fixes broken HUD.
     - InstantDMAHack # Fixes texture corruption.
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SCPS-15066:
   name: プリンス・オブ・ペルシャ 〜時間の砂〜
   name-sort: ぷりんす おぶ ぺるしゃ じかんのすな
@@ -8181,6 +8509,7 @@ SCPS-15066:
   region: "NTSC-J"
   gsHWFixes:
     autoFlush: 2 # Reduces post-processing misalignment.
+    halfPixelOffset: 4 # Reduces post-processing misalignment.
 SCPS-15067:
   name: どこでもいっしょ トロと流れ星
   name-sort: どこでもいっしょ とろとながれぼし
@@ -8224,6 +8553,9 @@ SCPS-15074:
   name-sort: ATHENS 2004
   name-en: "Olympic Summer Games - Athens 2004"
   region: "NTSC-J"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SCPS-15075:
   name: DJbox プレミアムキット
   name-sort: DJbox ぷれみあむきっと
@@ -8421,6 +8753,9 @@ SCPS-15098:
   name-sort: Formula One 2005
   name-en: "Formula One 2005"
   region: "NTSC-J"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SCPS-15099:
   name: ラチェット＆クランク4th ギリギリ銀河のギガバトル （Special Gift Package）
   name-sort: らちぇっとあんどくらんく4th ぎりぎりぎんがのぎがばとる [Special Gift Package]
@@ -8578,6 +8913,9 @@ SCPS-15113:
   region: "NTSC-J"
   roundModes:
     vu1RoundMode: 1 # Fixes the display of scores and text ingame.
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves court textures to match sw renderer.
+    trilinearFiltering: 1
 SCPS-15114:
   name: 機甲装兵アーモダイン
   name-sort: きこうそうへいあーもだいん
@@ -8627,6 +8965,8 @@ SCPS-15120:
   name-en: "Ratchet & Clank 5 Gekitotsu! Dodeka Ginga no Mirimiri Gundan"
   region: "NTSC-J"
   gsHWFixes:
+    recommendedBlendingLevel: 4 # Fixes vendor and other bloom.
+    autoFlush: 2 # Fixes missing bloom and shadow definition.
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
 SCPS-17001:
@@ -8641,6 +8981,7 @@ SCPS-17001:
     eeRoundMode: 3 # Using chop for both normal+div fixes crash in B5 license test.
     eeDivRoundMode: 3 # See above.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
@@ -8669,21 +9010,45 @@ SCPS-17008:
   name-sort: NIKE/ GRAN TURISMO Limited Edition (8inch)
   name-en: "Nike - Gran Turismo [Limited Edition - 8 inch]"
   region: "NTSC-J"
+  gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
+    halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
+    getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 SCPS-17009:
   name: NIKE/ GRAN TURISMO Limited Edition (9inch)
   name-sort: NIKE/ GRAN TURISMO Limited Edition (9inch)
   name-en: "Nike - Gran Turismo [Limited Edition - 9 inch]"
   region: "NTSC-J"
+  gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
+    halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
+    getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 SCPS-17010:
   name: NIKE/ GRAN TURISMO Limited Edition (10inch)
   name-sort: NIKE/ GRAN TURISMO Limited Edition (10inch)
   name-en: "Nike - Gran Turismo [Limited Edition - 10 inch]"
   region: "NTSC-J"
+  gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
+    halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
+    getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 SCPS-17011:
   name: NIKE/ GRAN TURISMO Limited Edition (11inch)
   name-sort: NIKE/ GRAN TURISMO Limited Edition (11inch)
   name-en: "Nike - Gran Turismo [Limited Edition - 11 inch]"
   region: "NTSC-J"
+  gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
+    halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
+    getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 SCPS-17013:
   name: ローグギャラクシー ディレクターズカット
   name-sort: ろーぐぎゃらくしー でぃれくたーずかっと
@@ -8897,6 +9262,7 @@ SCPS-19252:
   clampModes:
     vuClampMode: 2 # Text in GT mode works.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
@@ -8959,6 +9325,7 @@ SCPS-19304:
   name-en: "Gran Turismo 4 - Prologue [PlayStation 2 the Best]"
   region: "NTSC-J"
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
@@ -9268,6 +9635,9 @@ SCPS-19332:
   region: "NTSC-J"
   roundModes:
     vu1RoundMode: 1 # Fixes the display of scores and text ingame.
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves court textures to match sw renderer.
+    trilinearFiltering: 1
 SCPS-19333:
   name: ワイルドアームズ ザ フィフスヴァンガード PlayStation 2 the Best
   name-sort: わいるどあーむず ざ ふぃふすゔぁんがーど [PlayStation 2 the Best]
@@ -9298,6 +9668,7 @@ SCPS-51008:
   region: "NTSC-J"
   gsHWFixes:
     textureInsideRT: 2 # Fixes water reflection.
+    autoFlush: 1 # Fixes shading on objects and foliage.
 SCPS-51009:
   name: "Underwater Unit"
   region: "NTSC-J"
@@ -9380,6 +9751,9 @@ SCPS-55007:
   name: "Gran Turismo 3 - A-Spec"
   region: "NTSC-J"
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
+    mipmap: 2 # Mipmap + trilinear, improves track textures to match sw renderer.
+    trilinearFiltering: 1
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 SCPS-55008:
   name: "Thunderstrike"
@@ -9406,6 +9780,8 @@ SCPS-55014:
   gsHWFixes:
     halfPixelOffset: 2 # Corrects positioning of reflections on suit's surfaces.
     roundSprite: 2 # Reduces garbage on the UI whilst upscaling.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SCPS-55015:
   name: "Zettai Zetsumei Toshi"
   region: "NTSC-J"
@@ -9476,6 +9852,8 @@ SCPS-55029:
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 1 # Sharpens world in far distances.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
   memcardFilters:
     - "SCPS-55029"
     - "SCPS-55042"
@@ -9715,6 +10093,9 @@ SCPS-72001:
   name: "Gran Turismo 3 - A-Spec"
   region: "NTSC-J"
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
+    mipmap: 2 # Mipmap + trilinear, improves track textures to match sw renderer.
+    trilinearFiltering: 1
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 SCPS-72002:
   name: "Minna no Golf 3"
@@ -9788,11 +10169,17 @@ SCUS-97102:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
+    mipmap: 2 # Mipmap + trilinear, improves track textures to match sw renderer.
+    trilinearFiltering: 1
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 SCUS-97104:
   name: "ATV Offroad Fury"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SCUS-97105:
   name: "Fantavision"
   region: "NTSC-U"
@@ -9850,6 +10237,9 @@ SCUS-97115:
   name: "Gran Turismo 3 - A-Spec [Demo]"
   region: "NTSC-U"
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 SCUS-97116:
   name: "Kiosk Demo Disc 2.01"
@@ -9869,6 +10259,9 @@ SCUS-97121:
 SCUS-97122:
   name: "ATV Offroad Fury [Demo]"
   region: "NTSC-U"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SCUS-97123:
   name: "Disney's Monsters Inc."
   region: "NTSC-U"
@@ -9927,7 +10320,8 @@ SCUS-97133:
     textureInsideRT: 1
     texturePreloading: 1 # Performs much better with partial preload.
     halfPixelOffset: 2 # Fixes outlines around characters.
-    getSkipCount: "GSC_GetawayGames"
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SCUS-97134:
   name: "SOCOM - U.S. Navy SEALs"
   region: "NTSC-U"
@@ -10105,6 +10499,7 @@ SCUS-97177:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
+    autoFlush: 2 # Fixes speed effect intensity.
     mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
     trilinearFiltering: 1
 SCUS-97178:
@@ -10164,10 +10559,15 @@ SCUS-97197:
   name: "War of the Monsters"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
+    trilinearFiltering: 1
 SCUS-97198:
   name: "Sly Cooper and the Thievius Raccoonus"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    autoFlush: 1 # Fixes Sly's shadow definition.
 SCUS-97199:
   name: "Ratchet & Clank"
   region: "NTSC-U"
@@ -10224,10 +10624,15 @@ SCUS-97209:
 SCUS-97210:
   name: "Sly Cooper and the Thievius Raccoonus [Demo]"
   region: "NTSC-U"
+  gsHWFixes:
+    autoFlush: 1 # Fixes Sly's shadow definition.
 SCUS-97211:
   name: "ATV Offroad Fury 2"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SCUS-97212:
   name: "My Street"
   region: "NTSC-U"
@@ -10266,11 +10671,14 @@ SCUS-97218:
 SCUS-97219:
   name: "Gran Turismo 3 - A-Spec - Nissan 350Z Edition"
   region: "NTSC-U"
+  gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
+    getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
   memcardFilters:
     - "SCUS-97219"
     - "SCUS-97102"
-  gsHWFixes:
-    getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 SCUS-97220:
   name: "NHL FaceOff 2003"
   region: "NTSC-U"
@@ -10329,8 +10737,10 @@ SCUS-97232:
   region: "NTSC-U"
   gsHWFixes:
     textureInsideRT: 1
+    texturePreloading: 1 # Performs much better with partial preload.
     halfPixelOffset: 2 # Fixes outlines around characters.
-    getSkipCount: "GSC_GetawayGames"
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SCUS-97233:
   name: "World Tour Soccer 2003"
   region: "NTSC-U"
@@ -10346,6 +10756,9 @@ SCUS-97236:
 SCUS-97238:
   name: "ATV Offroad Fury 2 [Demo]"
   region: "NTSC-U"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SCUS-97239:
   name: "Jet X2O [Demo]"
   region: "NTSC-U"
@@ -10421,6 +10834,9 @@ SCUS-97259:
 SCUS-97260:
   name: "War of the Monsters [Demo]"
   region: "NTSC-U"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
+    trilinearFiltering: 1
 SCUS-97261:
   name: "Kiosk Demo Disc 2.08"
   region: "NTSC-U"
@@ -10440,6 +10856,8 @@ SCUS-97264:
     autoFlush: 2 # Fixes lights going through walls.
     preloadFrameData: 1 # Fixes light flicker.
     halfPixelOffset: 2 # Corrects light position.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
   gameFixes:
     - EETimingHack # Fixes random hangs.
   patches:
@@ -10510,6 +10928,9 @@ SCUS-97275:
   gameFixes:
     - VIF1StallHack # Fixes broken HUD.
     - InstantDMAHack # Fixes texture corruption.
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SCUS-97276:
   name: "NFL GameDay 2004"
   region: "NTSC-U"
@@ -10615,6 +11036,7 @@ SCUS-97328:
   clampModes:
     vuClampMode: 2 # Text in GT mode works.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
@@ -10629,6 +11051,7 @@ SCUS-97329:
   name: "Downhill Domination [Demo]"
   region: "NTSC-U"
   gsHWFixes:
+    autoFlush: 2 # Fixes speed effect intensity.
     mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
     trilinearFiltering: 1
 SCUS-97330:
@@ -10737,6 +11160,9 @@ SCUS-97366:
   gameFixes:
     - VIF1StallHack # Fixes broken HUD.
     - InstantDMAHack # Fixes texture corruption.
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SCUS-97367:
   name: "Neopets - The Darkest Faerie"
   region: "NTSC-U"
@@ -10750,10 +11176,16 @@ SCUS-97368:
   gameFixes:
     - VIF1StallHack # Fixes broken HUD.
     - InstantDMAHack # Fixes texture corruption.
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SCUS-97369:
   name: "ATV Offroad Fury 2"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SCUS-97370:
   name: "NCAA Final Four 2004"
   region: "NTSC-U"
@@ -10780,6 +11212,8 @@ SCUS-97377:
     autoFlush: 2 # Fixes lights going through walls.
     preloadFrameData: 1 # Fixes light flicker.
     halfPixelOffset: 2 # Corrects light position.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SCUS-97378:
   name: "EyeToy and EyeToy Play [Demo]"
   region: "NTSC-U"
@@ -10787,6 +11221,9 @@ SCUS-97379:
   name: "Athens 2004"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SCUS-97380:
   name: "Final Fantasy XI - Online [Demo]"
   region: "NTSC-U"
@@ -10814,6 +11251,10 @@ SCUS-97384:
   name: "Gran Turismo Special Edition 2004 Toyota [Demo]"
   region: "NTSC-U"
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
+    halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 SCUS-97392:
   name: "NBA '06 featuring The Life Vol.1 [Demo]"
@@ -10866,6 +11307,9 @@ SCUS-97402:
 SCUS-97403:
   name: "Athens 2004 [Demo]"
   region: "NTSC-U"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SCUS-97405:
   name: "ATV Offroad Fury 3"
   region: "NTSC-U"
@@ -10886,7 +11330,8 @@ SCUS-97408:
   gsHWFixes:
     textureInsideRT: 1
     halfPixelOffset: 2 # Fixes outlines on screen edges.
-    getSkipCount: "GSC_GetawayGames"
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SCUS-97409:
   name: "Gretzky NHL 2005"
   region: "NTSC-U"
@@ -11020,6 +11465,7 @@ SCUS-97436:
   clampModes:
     vuClampMode: 2 # Text in GT mode works.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
@@ -11035,6 +11481,9 @@ SCUS-97437:
   region: "NTSC-U"
   speedHacks:
     mtvu: 0 # Increases FPS drastically.
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SCUS-97438:
   name: "EyeToy - Antigrav [Demo]"
   region: "NTSC-U"
@@ -11053,7 +11502,8 @@ SCUS-97441:
   gsHWFixes:
     textureInsideRT: 1
     halfPixelOffset: 2 # Fixes outlines on screen edges.
-    getSkipCount: "GSC_GetawayGames"
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SCUS-97442:
   name: "Official U.S. PlayStation Magazine Demo Disc 090"
   region: "NTSC-U"
@@ -11182,6 +11632,8 @@ SCUS-97474:
     vuClampMode: 3 # Fixes SPS ingame and prevents flickering or invisible characters.
   gsHWFixes:
     minimumBlendingLevel: 4 # Mitigates grayer text font in bottom left.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
   patches:
     75ED4282:
       content: |-
@@ -11199,6 +11651,8 @@ SCUS-97475:
     vuClampMode: 3 # Fixes SPS ingame and prevents flickering or invisible characters.
   gsHWFixes:
     minimumBlendingLevel: 4 # Mitigates grayer text font in bottom left.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
   patches:
     314F0905:
       content: |-
@@ -11214,6 +11668,9 @@ SCUS-97479:
   name: "ATV Offroad Fury 4"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SCUS-97481:
   name: "God of War II"
   region: "NTSC-U"
@@ -11241,6 +11698,7 @@ SCUS-97483:
   clampModes:
     vuClampMode: 2 # Text in GT mode works.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
@@ -11308,6 +11766,8 @@ SCUS-97489:
     vuClampMode: 3 # Fixes SPS ingame and prevents flickering or invisible characters.
   gsHWFixes:
     minimumBlendingLevel: 4 # Mitigates grayer text font in bottom left.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SCUS-97490:
   name: "Rogue Galaxy"
   region: "NTSC-U"
@@ -11398,6 +11858,9 @@ SCUS-97509:
 SCUS-97510:
   name: "ATV Offroad Fury 2 [Greatest Hits]"
   region: "NTSC-U"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SCUS-97511:
   name: "SOCOM II - U.S. Navy SEALs [Greatest Hits]"
   region: "NTSC-U"
@@ -11405,6 +11868,9 @@ SCUS-97511:
   gameFixes:
     - VIF1StallHack # Fixes broken HUD.
     - InstantDMAHack # Fixes texture corruption.
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SCUS-97512:
   name: "Gran Turismo 3 - A-Spec [Greatest Hits]"
   region: "NTSC-U"
@@ -11412,6 +11878,9 @@ SCUS-97512:
     - "SCUS-97512"
     - "SCUS-97102"
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
+    mipmap: 2 # Mipmap + trilinear, improves track textures to match sw renderer.
+    trilinearFiltering: 1
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 SCUS-97513:
   name: "Ratchet & Clank 2 - Going Commando [Greatest Hits]"
@@ -11419,7 +11888,8 @@ SCUS-97513:
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
-    mipmap: 1
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
     autoFlush: 2
   memcardFilters:
     - "SCUS-97513"
@@ -11429,6 +11899,9 @@ SCUS-97514:
   region: "NTSC-U"
   speedHacks:
     mtvu: 0 # Increases FPS drastically.
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SCUS-97515:
   name: "Hot Shots Golf FORE! [Greatest Hits]"
   region: "NTSC-U"
@@ -11482,6 +11955,8 @@ SCUS-97520:
     autoFlush: 2 # Fixes lights going through walls.
     preloadFrameData: 1 # Fixes light flicker.
     halfPixelOffset: 2 # Corrects light position.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SCUS-97523:
   name: "EyeToy - Operation Spy!"
   region: "NTSC-U"
@@ -11654,6 +12129,9 @@ SCUS-97574:
 SCUS-97579:
   name: "ATV Offroad Fury 4 [Demo]"
   region: "NTSC-U"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SCUS-97580:
   name: "SingStar Pop"
   region: "NTSC-U"
@@ -11710,6 +12188,9 @@ SCUS-97610:
   compat: 5
   roundModes:
     vu1RoundMode: 1 # Fixes the display of scores and text ingame.
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves court textures to match sw renderer.
+    trilinearFiltering: 1
 SCUS-97611:
   name: "SingStar Amped"
   region: "NTSC-U"
@@ -11721,6 +12202,8 @@ SCUS-97615:
   name: "Ratchet & Clank - Size Matters"
   region: "NTSC-U"
   gsHWFixes:
+    recommendedBlendingLevel: 4 # Fixes vendor and other bloom.
+    autoFlush: 2 # Fixes missing bloom and shadow definition.
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
 SCUS-97616:
@@ -11733,6 +12216,11 @@ SCUS-97618:
 SCUS-97619:
   name: "Hot Shots Tennis"
   region: "NTSC-U"
+  roundModes:
+    vu1RoundMode: 1 # Fixes the display of scores and text ingame.
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves court textures to match sw renderer.
+    trilinearFiltering: 1
 SCUS-97620:
   name: "Syphon Filter - Dark Mirror [Demo]"
   region: "NTSC-U"
@@ -11831,6 +12319,10 @@ SCUS-97657:
   name: "MLB 11 - The Show"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves crowd textures.
+    trilinearFiltering: 1
+    textureInsideRT: 1 # Needed for mipmapping to function correctly.
 SCUS-97660:
   name: "SingStar Latino"
   region: "NTSC-U"
@@ -11927,6 +12419,8 @@ SLAJ-25031:
   name: "Kunoichi - Shinobu"
   region: "NTSC-C-J"
   gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
     getSkipCount: "GSC_Kunoichi"
 SLAJ-25033:
   name: "Puyo Puyo Fever"
@@ -11979,6 +12473,8 @@ SLAJ-25047:
   region: "NTSC-C-J"
   gsHWFixes:
     minimumBlendingLevel: 2 # Fixes dark font to more bright like software mode.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLAJ-25048:
   name: "Sengoku Musou Moushouden"
   region: "NTSC-Unk"
@@ -11991,6 +12487,8 @@ SLAJ-25051:
   region: "NTSC-C"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLAJ-25052:
   name: "The Urbz - Sims in the City"
   name-sort: "Urbz, The - Sims in the City"
@@ -12033,6 +12531,9 @@ SLAJ-25060:
 SLAJ-25063:
   name: "Shin Sangoku Musou 4"
   region: "NTSC-Unk"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLAJ-25064:
   name: "MVP Baseball 2005"
   region: "NTSC-Unk"
@@ -12084,6 +12585,8 @@ SLAJ-25073:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLAJ-25075:
   name: "Need for Speed - Most Wanted [Black Edition]"
   region: "NTSC-Unk"
@@ -12092,6 +12595,8 @@ SLAJ-25075:
     halfPixelOffset: 2 # Fixes blurriness.
     cpuCLUTRender: 1 # Final colour adjustment LUT.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
   memcardFilters:
     - "SLAJ-25075"
     - "SLPM-66232"
@@ -12173,9 +12678,14 @@ SLAJ-25091:
   region: "NTSC-J"
   clampModes:
     eeClampMode: 3 # Fixes game hang after opening intro.
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes depth line.
 SLAJ-25092:
   name: "Shin Sangoku Musou 4 [PlayStation 2 the Best]"
   region: "NTSC-Unk"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLAJ-25093:
   name: "Sangoku Musou [PlayStation 2 the Best]"
   region: "NTSC-Unk"
@@ -12200,6 +12710,8 @@ SLAJ-25095:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes lighting misalignment.
     mergeSprite: 1 # Removes occasional vertical lines.
+    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
+    trilinearFiltering: 1
 SLAJ-25096:
   name: "Musou Orochi"
   region: "NTSC-Unk"
@@ -12243,12 +12755,16 @@ SLED-50117:
     - InstantDMAHack # Fixes broken half-bottom artifacts.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLED-50286:
   name: "Red Faction [Demo]"
   region: "PAL-E"
 SLED-50359:
   name: "Devil May Cry [Demo]"
   region: "PAL-E"
+  gameFixes:
+    - SoftwareRendererFMVHack # Fixes PAL interlacing issues.
   clampModes:
     vuClampMode: 3 # Fixes out of place polys (COP2).
   gsHWFixes:
@@ -12273,12 +12789,18 @@ SLED-50489:
   region: "PAL-E"
   gsHWFixes:
     cpuSpriteRenderBW: 4 # Fixes textures.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLED-50587:
   name: "Top Gun - Combat Zones [Demo]"
   region: "PAL-E"
 SLED-50617:
   name: "Burnout [Demo]"
   region: "PAL-E"
+  gsHWFixes:
+    autoFlush: 1 # Fixes missing blur layer on sky.
+    mipmap: 2 # Mipmap + trilinear, improves road textures to match sw renderer.
+    trilinearFiltering: 1
 SLED-50762:
   name: "Maximo [Demo]"
   region: "PAL-E"
@@ -12301,6 +12823,8 @@ SLED-51012:
   region: "PAL-E"
   gsHWFixes:
     cpuSpriteRenderBW: 4 # Fixes textures.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLED-51047:
   name: "Red Faction II"
   region: "PAL-Unk"
@@ -12333,6 +12857,8 @@ SLED-51211:
     autoFlush: 1 # Fixes bloom and sun rendering in front of everything.
     halfPixelOffset: 2 # Aligns bloom effect a little bit better when upscaled.
     bilinearUpscale: 2 # Reduces color banding of the sun glare.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
   roundModes:
     vu1RoundMode: 1 # Bright lights in cars.
 SLED-51212:
@@ -12343,6 +12869,8 @@ SLED-51212:
 SLED-51225:
   name: "Rayman 3 [Demo]"
   region: "PAL-E"
+  gsHWFixes:
+    autoFlush: 1 # Fixes missing blur layer on reflections and surfaces.
 SLED-51264:
   name: "Pro Evolution Soccer 2"
   region: "PAL-Unk"
@@ -12352,6 +12880,8 @@ SLED-51281:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
     alignSprite: 1 # Fixes vertical lines.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLED-51338:
   name: "Tom Clancy's Ghost Recon"
   region: "PAL-Unk"
@@ -12391,6 +12921,9 @@ SLED-51676:
   region: "PAL"
   gameFixes:
     - XGKickHack # Fixes corrupted graphics.
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLED-51807:
   name: "Summer Heat Beach Volleyball"
   region: "PAL-Unk"
@@ -12469,9 +13002,10 @@ SLED-52304:
   name: "Tom Clancy's Rainbow Six 3"
   region: "PAL-Unk"
 SLED-52325:
-  name: "Downhill Domination"
-  region: "PAL-Unk"
+  name: "Downhill Domination [Demo]"
+  region: "PAL-E"
   gsHWFixes:
+    autoFlush: 2 # Fixes speed effect intensity.
     mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
     trilinearFiltering: 1
 SLED-52326:
@@ -12574,6 +13108,8 @@ SLED-52852:
   gsHWFixes:
     halfPixelOffset: 1 # Reduces ghosting.
     roundSprite: 1 # Reduces ghosting even more.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLED-52873:
   name: "Pro Evolution Soccer 4"
   region: "PAL-Unk"
@@ -12610,6 +13146,8 @@ SLED-52979:
   region: "PAL-E"
   gsHWFixes:
     autoFlush: 2 # Fixes missing lighting.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
     # halfPixelOffset: 1 # Fixes lighting misalignment. Do not enable this, it breaks a lot of graphics.
 SLED-53066:
   name: "TimeSplitters - Future Perfect"
@@ -12678,6 +13216,10 @@ SLED-53442:
     - IbitHack # Fixes constant recompilation problems.
   gsHWFixes:
     PCRTCOverscan: 1 # Fixes offscreen image.
+    nativePaletteDraw: 1 # Fixes the look of screen effects.
+    halfPixelOffset: 2 # Corrects the alignment of screen effects.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLED-53445:
   name: "The Incredible Hulk - Ultimate Destruction [Demo]"
   name-sort: "Incredible Hulk, The - Ultimate Destruction [Demo]"
@@ -12709,8 +13251,11 @@ SLED-53537:
   name: "187 - Ride or Die [Demo]"
   region: "PAL-E"
   gsHWFixes:
-    autoFlush: 2 # Softens bloom on objects and cars.
-    halfPixelOffset: 2 # Fixes misaligned bloom on objects and cars.
+    recommendedBlendingLevel: 4 # Improves car color.
+    autoFlush: 1 # Softens bloom on objects and cars.
+    halfPixelOffset: 4 # Fixes misaligned bloom on objects and cars.
+    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
+    trilinearFiltering: 1
 SLED-53543:
   name: "Tiger Woods PGA Tour 06"
   region: "PAL-Unk"
@@ -12753,6 +13298,8 @@ SLED-53650:
     halfPixelOffset: 2 # Fixes blurriness.
     cpuCLUTRender: 1 # Final colour adjustment LUT.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLED-53664:
   name: "FIFA 06 - Demo Pre-Release Version"
   region: "PAL-Unk"
@@ -12764,6 +13311,8 @@ SLED-53673:
   gsHWFixes:
     textureInsideRT: 1 # Required for complex offset shuffles.
     halfPixelOffset: 2 # Fixes center upscaling line during explosions.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
     recommendedBlendingLevel: 4 # Fixes lighting.
 SLED-53681:
   name: "007 - From Russia with Love & Need for Speed Most Wanted & SSX On Tour [Demo]"
@@ -12793,6 +13342,8 @@ SLED-53731:
     autoFlush: 1 # Post-processing.
     halfPixelOffset: 2 # Offset post-processing.
     texturePreloading: 1 # Improves performance.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
     getSkipCount: "GSC_Battlefield2" # Depth clear.
     beforeDraw: "OI_Battlefield2" # Framebuffer copy, fixes rendering for bottom part of screen.
 SLED-53732:
@@ -12859,9 +13410,17 @@ SLED-53954:
     cpuCLUTRender: 1 # Fixes the rest of the bad textures.
     roundSprite: 1 # Reduces misaligned bloom.
     mergeSprite: 1 # Removes bloom explosion around electrical lights and other light sources such as moon/sun.
+    mipmap: 2 # Mipmap + trilinear, improves road textures to match sw renderer.
+    trilinearFiltering: 1
 SLED-53977:
   name: "Dragon Quest - The Journey of the Cursed King"
-  region: "PAL-Unk"
+  region: "PAL-E"
+  gsHWFixes:
+    autoFlush: 1 # Fixes missing bloom from surfaces like windows.
+    # halfPixelOffset: 1 # Aligns shadows properly, but causes grid lines to appear in sea travel.
+    halfPixelOffset: 2 # Sharpens world in far distances, aligns some bloom better.
+    roundSprite: 1 # Fixes font artifacts.
+    cpuSpriteRenderBW: 1 # Fixes broken fire sprites.
 SLED-53980:
   name: "Urban Chaos - Riot Response [Demo]"
   region: "PAL-E"
@@ -12896,6 +13455,8 @@ SLED-54312:
   region: "PAL-E"
   clampModes:
     eeClampMode: 3 # Fixes game hang after opening intro.
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes depth line.
 SLED-54315:
   name: "LEGO Star Wars II - The Original Trilogy [Demo]"
   region: "PAL-M5"
@@ -13039,6 +13600,7 @@ SLES-50031:
   region: "PAL-E"
   compat: 5
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes character models.
     mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
     trilinearFiltering: 1
 SLES-50032:
@@ -13091,7 +13653,7 @@ SLES-50047:
   region: "PAL-M3"
   compat: 5
 SLES-50048:
-  name: "Donald Duck - Quack Attack"
+  name: "Disney's Donald Duck - Quack Attack"
   region: "PAL-M5"
   compat: 5
   patches:
@@ -13119,6 +13681,10 @@ SLES-50050:
   name: "Evergrace"
   region: "PAL-M5"
   compat: 5
+  gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes terrain color rendering.
+    mipmap: 2 # Mipmap + trilinear, fixes miptrick textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-50051:
   name: "Eternal Ring"
   region: "PAL-E"
@@ -13147,6 +13713,9 @@ SLES-50055:
   name: "Smuggler's Run"
   region: "PAL-E"
   compat: 5
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-50056:
   name: "Surfing H3O"
   region: "PAL-M3"
@@ -13164,8 +13733,11 @@ SLES-50060:
   region: "PAL-M3"
 SLES-50061:
   name: "Smuggler's Run"
-  region: "PAL-G"
+  region: "PAL-M5"
   compat: 5
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-50062:
   name: "Orphen - Scion of Sorcery"
   region: "PAL-E"
@@ -13197,6 +13769,8 @@ SLES-50073:
   gsHWFixes:
     textureInsideRT: 1
     roundSprite: 1 # Fixes font misalignment when upscaling.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-50074:
   name: "Unreal Tournament"
   region: "PAL-M5"
@@ -13224,6 +13798,8 @@ SLES-50079:
     eeClampMode: 2 # Fixes Abnormal AI behavior.
   gsHWFixes:
     textureInsideRT: 1 # Fixes texture corruption.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-50080:
   name: "NBA Hoopz"
   region: "PAL-M3"
@@ -13319,6 +13895,9 @@ SLES-50134:
   name: "Oni"
   region: "PAL-E"
   compat: 5
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
   patches:
     22E85E68:
       content: |-
@@ -13381,6 +13960,9 @@ SLES-50176:
   name: "Oni"
   region: "PAL-F"
   compat: 5
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
   patches:
     F77639F1:
       content: |-
@@ -13392,6 +13974,9 @@ SLES-50177:
   name: "Oni"
   region: "PAL-G"
   compat: 5
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
   patches:
     32629F36:
       content: |-
@@ -13402,6 +13987,9 @@ SLES-50177:
 SLES-50178:
   name: "Oni"
   region: "PAL-I"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
   patches:
     172B6971:
       content: |-
@@ -13412,6 +14000,9 @@ SLES-50178:
 SLES-50179:
   name: "Oni"
   region: "PAL-S"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
   patches:
     20F419E9:
       content: |-
@@ -13529,6 +14120,9 @@ SLES-50215:
   compat: 5
   gameFixes:
     - EETimingHack # Fixes credits screen.
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves road and building textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-50217:
   name: "Dave Mirra Freestyle BMX 2"
   region: "PAL-E-S"
@@ -13774,6 +14368,8 @@ SLES-50288:
   compat: 5
   gsHWFixes:
     cpuSpriteRenderBW: 4 # Fixes textures.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-50296:
   name: "Gift"
   region: "PAL-F"
@@ -13854,10 +14450,14 @@ SLES-50356:
     - VUSyncHack # Fixes flickering and missing textures.
   gsHWFixes:
     textureInsideRT: 1 # Fixes graphical corruption.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-50358:
   name: "Devil May Cry"
   region: "PAL-M5"
   compat: 5
+  gameFixes:
+    - SoftwareRendererFMVHack # Fixes PAL interlacing issues.
   gsHWFixes:
     disablePartialInvalidation: 1 # Fixes corrupt textures.
     halfPixelOffset: 2 # Alleviates blur from upscaling.
@@ -13913,6 +14513,8 @@ SLES-50383:
     - InstantDMAHack # Fixes broken half-bottom artifacts.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-50384:
   name: "Metal Gear Solid 2 - Sons of Liberty"
   region: "PAL-I"
@@ -13920,6 +14522,8 @@ SLES-50384:
     - InstantDMAHack # Fixes broken half-bottom artifacts.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-50385:
   name: "Metal Gear Solid 2 - Sons of Liberty"
   region: "PAL-S"
@@ -13927,6 +14531,8 @@ SLES-50385:
     - InstantDMAHack # Fixes broken half-bottom artifacts.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-50386:
   name: "Crash Bandicoot - The Wrath of Cortex"
   region: "PAL-M6"
@@ -13951,6 +14557,9 @@ SLES-50396:
 SLES-50397:
   name: "Prisoner of War"
   region: "PAL-M5"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-50398:
   name: "UEFA Champions League"
   region: "PAL-M5"
@@ -14052,6 +14661,10 @@ SLES-50445:
   name: "Burnout"
   region: "PAL-M5"
   compat: 5
+  gsHWFixes:
+    autoFlush: 1 # Fixes missing blur layer on sky.
+    mipmap: 2 # Mipmap + trilinear, improves road textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-50446:
   name: "Shadow Man - 2econd Coming"
   region: "PAL-M4"
@@ -14173,23 +14786,35 @@ SLES-50504:
   name: "Half-Life"
   region: "PAL-E"
   compat: 5
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-50505:
   name: "Half-Life"
   region: "PAL-G"
   compat: 5
-SLES-50506:
-  name: "Half-Life"
-  region: "PAL-Unk"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-50507:
   name: "Half-Life"
   region: "PAL-F"
   compat: 5
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-50508:
   name: "Half-Life"
   region: "PAL-I"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-50509:
   name: "Half-Life"
   region: "PAL-S"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-50510:
   name: "The Mummy Returns"
   name-sort: "Mummy Returns, The"
@@ -14245,6 +14870,8 @@ SLES-50545:
     eeRoundMode: 0 # Fixes riders vanish into the floor.
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes missing lighting and makes snow not look like snow sludge.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-50546:
   name: "LMA Manager 2002"
   region: "PAL-E"
@@ -14266,6 +14893,9 @@ SLES-50551:
 SLES-50552:
   name: "Jet Ski Riders"
   region: "PAL-M5"
+  gsHWFixes:
+    textureInsideRT: 2 # Fixes water reflection.
+    autoFlush: 1 # Fixes shading on objects and foliage.
 SLES-50553:
   name: "Project Eden"
   region: "PAL-M5"
@@ -14300,6 +14930,9 @@ SLES-50570:
 SLES-50572:
   name: "Robot Wars - Arenas of Destruction"
   region: "PAL-E"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-50575:
   name: "Dark Summit"
   region: "PAL-M3"
@@ -14424,6 +15057,8 @@ SLES-50640:
     - VUSyncHack # Fixes flickering and missing textures.
   gsHWFixes:
     textureInsideRT: 1 # Fixes graphical corruption.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-50641:
   name: "Dynasty Warriors 3"
   region: "PAL-M3"
@@ -14593,6 +15228,8 @@ SLES-50725:
   gsHWFixes:
     preloadFrameData: 1 # Fixes fog and make lights on cars work again.
     autoFlush: 2 # Fixes sun luminosity and penetration of objects.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
   gameFixes:
     - EETimingHack # Fixes random graphical corruption.
 SLES-50726:
@@ -14665,11 +15302,17 @@ SLES-50753:
   name: "Freekstyle"
   region: "PAL-M5"
 SLES-50754:
-  name: "Simpsons Skateboarding"
+  name: "The Simpsons Skateboarding"
   region: "PAL-E"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-50755:
-  name: "Simpsons Skateboarding"
+  name: "The Simpsons Skateboarding"
   region: "PAL-F"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-50757:
   name: "Atlantis III"
   region: "PAL-I-S"
@@ -14703,22 +15346,24 @@ SLES-50770:
   name: "Mad Maestro!"
   region: "PAL-M4"
 SLES-50771:
-  name: "Blood Omen 2 - The Legacy of Kain"
+  name: "Blood Omen 2 - The Legacy of Kain Series"
   region: "PAL-E"
   compat: 5
   roundModes:
     eeRoundMode: 0 # Fixes pathing.
   gsHWFixes:
-    mipmap: 1 # Fixes glitching textures.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-50772:
-  name: "Blood Omen 2 - The Legacy of Kain"
+  name: "Blood Omen 2 - The Legacy of Kain Series"
   region: "PAL-M3"
   roundModes:
     eeRoundMode: 0 # Fixes pathing.
   gsHWFixes:
-    mipmap: 1 # Fixes glitching textures.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-50773:
-  name: "Donald Duck Phantomias Platyrhynchos Kineticus"
+  name: "Disney's Donald Duck - Phantomias - Platyrhynchos Kineticus"
   region: "PAL-M5"
   compat: 5
 SLES-50776:
@@ -14825,26 +15470,36 @@ SLES-50804:
   region: "PAL-E"
   gsHWFixes:
     roundSprite: 1 # Fixes lines in HUD and text boxes.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-50805:
   name: "Deus Ex"
   region: "PAL-G"
   gsHWFixes:
     roundSprite: 1 # Fixes lines in HUD and text boxes.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-50806:
   name: "Deus Ex"
   region: "PAL-F"
   gsHWFixes:
     roundSprite: 1 # Fixes lines in HUD and text boxes.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-50807:
   name: "Deus Ex"
   region: "PAL-I"
   gsHWFixes:
     roundSprite: 1 # Fixes lines in HUD and text boxes.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-50808:
   name: "Deus Ex"
   region: "PAL-S"
   gsHWFixes:
     roundSprite: 1 # Fixes lines in HUD and text boxes.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-50809:
   name: "Next Generation Tennis"
   region: "PAL-M6"
@@ -14877,12 +15532,13 @@ SLES-50814:
     bilinearUpscale: 2 # Smooths out sun glare textures.
   compat: 5
 SLES-50815:
-  name: "Blood Omen 2 - The Legacy of Kain"
+  name: "Blood Omen 2 - The Legacy of Kain Series"
   region: "PAL-G"
   roundModes:
     eeRoundMode: 0 # Fixes pathing.
   gsHWFixes:
-    mipmap: 1 # Fixes glitching textures.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-50816:
   name: "DTM Race Driver"
   region: "PAL-M3"
@@ -15020,6 +15676,9 @@ SLES-50841:
   name: "Largo Winch - Empire Under Threat"
   region: "PAL-M5"
   compat: 5
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-50842:
   name: "Downforce"
   region: "PAL-M5"
@@ -15162,6 +15821,8 @@ SLES-50897:
   gsHWFixes:
     halfPixelOffset: 2 # Gets rid of fog line.
     roundSprite: 1 # Fixes lines in FMVs.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-50898:
   name: "X-Men - The Next Dimension"
   region: "PAL-E"
@@ -15207,6 +15868,8 @@ SLES-50920:
     preloadFrameData: 1 # Fixes invisible lava, there is another issue that needs skipdraw 1 for blurry font but it removes much brightness.
     cpuSpriteRenderBW: 2 # Fixes sky and lava when upscaling.
     cpuSpriteRenderLevel: 2 # Needed for above.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
   patches:
     401F4726:
       content: |-
@@ -15280,6 +15943,9 @@ SLES-50958:
   region: "PAL-M4"
   gameFixes:
     - XGKickHack # Fixes corrupted graphics.
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-50963:
   name: "Riding Spirits"
   region: "PAL-M5"
@@ -15355,6 +16021,9 @@ SLES-50995:
 SLES-50997:
   name: "Rally Fusion - Race of Champions"
   region: "PAL-M3"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-50998:
   name: "Xtreme Express - World Grand Prix"
   region: "PAL-E"
@@ -15433,6 +16102,8 @@ SLES-51044:
     autoFlush: 1 # Fixes bloom and sun rendering in front of everything.
     halfPixelOffset: 2 # Aligns bloom effect a little bit better when upscaled.
     bilinearUpscale: 2 # Reduces color banding of the sun glare.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
   roundModes:
     vu1RoundMode: 1 # Bright lights in cars.
 SLES-51045:
@@ -15499,6 +16170,8 @@ SLES-51063:
   region: "PAL-E"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes the fog line.
+    mipmap: 2 # Mipmap + trilinear, improves track textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-51064:
   name: "Gladius"
   region: "PAL-M3"
@@ -15574,6 +16247,9 @@ SLES-51093:
   name: "Largo Winch - Empire Under Threat"
   region: "PAL-M4"
   compat: 5
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-51094:
   name: "Club Football - FC Internazionale"
   region: "PAL-M3"
@@ -15629,6 +16305,8 @@ SLES-51117:
     alignSprite: 1 # Fixes vertical lines.
     autoFlush: 2 # Fixes the sun flare.
     halfPixelOffset: 2 # Fixes the sun flare.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-51118:
   name: "Wizardry - Tales of the Forsaken Land"
   region: "PAL-E"
@@ -15660,16 +16338,25 @@ SLES-51130:
   compat: 5
   roundModes:
     vu1RoundMode: 0 # Crashes without.
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-51131:
   name: "Tony Hawk's Pro Skater 4"
   region: "PAL-F"
   roundModes:
     vu1RoundMode: 0 # Crashes without.
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-51132:
   name: "Tony Hawk's Pro Skater 4"
   region: "PAL-G"
   roundModes:
     vu1RoundMode: 0 # Crashes without.
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-51133:
   name: "Red Faction II"
   region: "PAL-M3"
@@ -15682,6 +16369,8 @@ SLES-51134:
     eeClampMode: 3 # Fixes hangs in certain locations like building under construction.
   gsHWFixes:
     recommendedBlendingLevel: 2 # Fixes color saturation.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-51141:
   name: "Summoner 2"
   region: "PAL-E"
@@ -15705,6 +16394,8 @@ SLES-51145:
   region: "PAL-M5"
   clampModes:
     vuClampMode: 0 # Fixes missing game board.
+  gsHWFixes:
+    recommendedBlendingLevel: 2
 SLES-51150:
   name: "Scrabble Interactive - 2003 Edition"
   region: "PAL-M3"
@@ -15873,6 +16564,8 @@ SLES-51209:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
     alignSprite: 1 # Fixes vertical lines.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-51214:
   name: "Harry Potter og Hemmelighedernes Kammer"
   region: "PAL-D"
@@ -15946,6 +16639,8 @@ SLES-51220:
 SLES-51222:
   name: "Rayman 3 - Hoodlum Havoc"
   region: "PAL-M5"
+  gsHWFixes:
+    autoFlush: 1 # Fixes missing blur layer on reflections and surfaces.
 SLES-51223:
   name: "Runabout 3 - Neo Age"
   region: "PAL-E"
@@ -15959,6 +16654,8 @@ SLES-51227:
   compat: 5
   gsHWFixes:
     autoFlush: 2 # Fixes lava effect.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
   patches:
     default:
       content: |-
@@ -16034,6 +16731,8 @@ SLES-51252:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misaligned lighting and other effects.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
   clampModes:
     vuClampMode: 3 # Fix white shiny weapons.
 SLES-51253:
@@ -16041,6 +16740,8 @@ SLES-51253:
   region: "PAL-F"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misaligned lighting and other effects.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
   clampModes:
     vuClampMode: 3 # Fix white shiny weapons.
 SLES-51254:
@@ -16048,6 +16749,8 @@ SLES-51254:
   region: "PAL-G"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misaligned lighting and other effects.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
   clampModes:
     vuClampMode: 3 # Fix white shiny weapons.
 SLES-51255:
@@ -16055,6 +16758,8 @@ SLES-51255:
   region: "PAL-I"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misaligned lighting and other effects.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
   clampModes:
     vuClampMode: 3 # Fix white shiny weapons.
 SLES-51256:
@@ -16063,6 +16768,8 @@ SLES-51256:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misaligned lighting and other effects.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
   clampModes:
     vuClampMode: 3 # Fix white shiny weapons.
 SLES-51257:
@@ -16106,6 +16813,9 @@ SLES-51272:
     vuClampMode: 3 # Fixes water rendering.
   gameFixes:
     - XGKickHack # Fixes SPS while ingame.
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-51273:
   name: "Wakeboarding Unleashed"
   region: "PAL-F"
@@ -16113,6 +16823,9 @@ SLES-51273:
     vuClampMode: 3 # Fixes water rendering.
   gameFixes:
     - XGKickHack # Fixes SPS while ingame.
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-51275:
   name: "Summoner 2"
   region: "PAL-I"
@@ -16138,12 +16851,16 @@ SLES-51286:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes upscaling lines.
     autoFlush: 2 # Fixes sun penetration.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-51287:
-  name: "X-Men 2 - Wolverine's Revenge"
+  name: "X-Men 2 - La Vengeance de Wolverine"
   region: "PAL-F"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes upscaling lines.
     autoFlush: 2 # Fixes sun penetration.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-51289:
   name: "Gunfighter 2 - Legend of Jesse James"
   region: "PAL-M5"
@@ -16347,14 +17064,23 @@ SLES-51360:
   name: "The Simpsons Skateboarding"
   name-sort: "Simpsons Skateboarding, The"
   region: "PAL-I"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-51361:
   name: "The Simpsons Skateboarding"
   name-sort: "Simpsons Skateboarding, The"
   region: "PAL-S"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-51362:
   name: "The Simpsons Skateboarding"
   name-sort: "Simpsons Skateboarding, The"
   region: "PAL-G"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-51363:
   name: "Music 3000"
   region: "PAL-M5"
@@ -16400,7 +17126,7 @@ SLES-51381:
         patch=1,EE,00230c10,word,4bc0529c
         patch=1,EE,00230c14,word,4beb03bc
 SLES-51382:
-  name: "Shrek - Super Party"
+  name: "Shrek Super Party"
   region: "PAL-E"
   gsHWFixes:
     mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
@@ -16457,6 +17183,8 @@ SLES-51399:
   gsHWFixes:
     halfPixelOffset: 2 # Corrects positioning of reflections on suit's surfaces.
     roundSprite: 2 # Reduces garbage on the UI whilst upscaling.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-51400:
   name: "Tenchu - Wrath of Heaven"
   region: "PAL-S"
@@ -16534,6 +17262,7 @@ SLES-51448:
     alignSprite: 1 # Fixes vertical lines.
     roundSprite: 2 # Fixes font artifacts.
     mergeSprite: 1 # Fixes flame-like bleeding.
+    autoFlush: 1 # Fixes light bloom intensity.
 SLES-51449:
   name: "Return to Castle Wolfenstein - Operation Resurrection"
   region: "PAL-E"
@@ -16634,6 +17363,9 @@ SLES-51495:
 SLES-51496:
   name: "Breath of Fire - Dragon Quarter"
   region: "PAL-M5"
+  gsHWFixes:
+    halfPixelOffset: 4 # Aligns HUD and HUD bloom to match software.
+    roundSprite: 1 # Helps fix some lines and lines in text.
 SLES-51503:
   name: "Ace Lightning"
   region: "PAL-E"
@@ -16689,13 +17421,6 @@ SLES-51526:
   gsHWFixes:
     estimateTextureRegion: 1 # Improves performance and reduces hash cache size when moving.
     roundSprite: 1 # Fixes HUD garbage.
-SLES-51541:
-  name: "Grand Theft Auto - San Andreas"
-  region: "PAL-Unk"
-  clampModes:
-    eeClampMode: 2 # Fixes Game freezes during "Reuniting The Families" mission.
-  gsHWFixes:
-    autoFlush: 1 # Fixes post processing.
 SLES-51547:
   name: "Next Generation Tennis 2003"
   region: "PAL-M5"
@@ -16709,6 +17434,8 @@ SLES-51548:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes upscaling lines.
     autoFlush: 2 # Fixes sun penetration.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-51553:
   name: "Chaos Legion"
   region: "PAL-M5"
@@ -16907,11 +17634,13 @@ SLES-51670:
   region: "PAL-E"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes side borders.
+    autoFlush: 1 # Fixes broken bloom effect.
 SLES-51671:
   name: "Alter Echo"
   region: "PAL-M5"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes side borders.
+    autoFlush: 1 # Fixes broken bloom effect.
 SLES-51675:
   name: "Psyvariar - Complete Edition"
   region: "PAL-M4"
@@ -16921,9 +17650,17 @@ SLES-51678:
 SLES-51680:
   name: "Splashdown 2 - Rides Gone Wild"
   region: "PAL-M3"
+  gsHWFixes:
+    autoFlush: 1
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-51681:
   name: "Splashdown 2 - Rides Gone Wild"
   region: "PAL-M3"
+  gsHWFixes:
+    autoFlush: 1
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-51682:
   name: "Headhunter - Redemption"
   region: "PAL-E"
@@ -16991,6 +17728,8 @@ SLES-51705:
   region: "PAL-M5"
   gsHWFixes:
     autoFlush: 1 # Fixes missing sun.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-51707:
   name: "Secret Weapons Over Normandy"
   region: "PAL-E"
@@ -17076,11 +17815,8 @@ SLES-51750:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 1 # Helps blur.
-SLES-51752:
-  name: "Tony Hawks Underground"
-  region: "PAL-Unk"
-  roundModes:
-    vu1RoundMode: 0 # Crashes without.
+    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-51753:
   name: "True Crime - Streets of L.A."
   region: "PAL-E"
@@ -17155,7 +17891,10 @@ SLES-51778:
   compat: 5
 SLES-51782:
   name: "Fire Warrior"
-  region: "PAL-Unk"
+  region: "PAL-E"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-51783:
   name: "Starsky & Hutch"
   region: "PAL-F-G"
@@ -17218,6 +17957,9 @@ SLES-51813:
 SLES-51814:
   name: "ATV Offroad Fury 2"
   region: "PAL-E"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-51815:
   name: "Final Fantasy X-2"
   region: "PAL-E"
@@ -17273,6 +18015,8 @@ SLES-51820:
     autoFlush: 2 # Fixes bloom misalignment.
     halfPixelOffset: 2 # Fixes bloom misalignment.
     textureInsideRT: 1 # Fixes sky bloom.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-51821:
   name: "Alias"
   region: "PAL-M5"
@@ -17344,13 +18088,12 @@ SLES-51843:
   name: "Worms 3D"
   region: "PAL-M5"
   compat: 5
-  patches:
-    default:
-      content: |-
-        comment=You need to set the EE cycle speed to -1 to be able to load the game.
 SLES-51845:
   name: "Barbie Horse Adventures - Wild Horse Rescue"
   region: "PAL-M6"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-51846:
   name: "Deutschland sucht den Superstar"
   region: "PAL-G"
@@ -17360,6 +18103,10 @@ SLES-51848:
   compat: 5
   roundModes:
     vu1RoundMode: 0 # Crashes without.
+  gsHWFixes:
+    minimumBlendingLevel: 3 # Fixes broken lighting on ground and buildings.
+    mipmap: 2 # Mipmap + trilinear, improves ground and buildings textures to match software.
+    trilinearFiltering: 1
 SLES-51850:
   name: "Basketball Xciting"
   region: "PAL-E"
@@ -17368,22 +18115,38 @@ SLES-51851:
   region: "PAL-F"
   roundModes:
     vu1RoundMode: 0 # Crashes without.
+  gsHWFixes:
+    minimumBlendingLevel: 3 # Fixes broken lighting on ground and buildings.
+    mipmap: 2 # Mipmap + trilinear, improves ground and buildings textures to match software.
+    trilinearFiltering: 1
 SLES-51852:
   name: "Tony Hawk's Underground"
   region: "PAL-G"
   compat: 5
   roundModes:
     vu1RoundMode: 0 # Crashes without.
+  gsHWFixes:
+    minimumBlendingLevel: 3 # Fixes broken lighting on ground and buildings.
+    mipmap: 2 # Mipmap + trilinear, improves ground and buildings textures to match software.
+    trilinearFiltering: 1
 SLES-51853:
   name: "Tony Hawk's Underground"
   region: "PAL-F"
   roundModes:
     vu1RoundMode: 0 # Crashes without.
+  gsHWFixes:
+    minimumBlendingLevel: 3 # Fixes broken lighting on ground and buildings.
+    mipmap: 2 # Mipmap + trilinear, improves ground and buildings textures to match software.
+    trilinearFiltering: 1
 SLES-51854:
   name: "Tony Hawk's Underground"
   region: "PAL-S"
   roundModes:
     vu1RoundMode: 0 # Crashes without.
+  gsHWFixes:
+    minimumBlendingLevel: 3 # Fixes broken lighting on ground and buildings.
+    mipmap: 2 # Mipmap + trilinear, improves ground and buildings textures to match software.
+    trilinearFiltering: 1
 SLES-51855:
   name: "Tank Elite"
   region: "PAL-E"
@@ -17594,6 +18357,7 @@ SLES-51918:
   compat: 5
   gsHWFixes:
     autoFlush: 2 # Reduces post-processing misalignment.
+    halfPixelOffset: 4 # Reduces post-processing misalignment.
 SLES-51924:
   name: "World War Zero - Ironstorm"
   region: "PAL-M5"
@@ -17601,6 +18365,10 @@ SLES-51924:
 SLES-51925:
   name: "Splashdown 2 - Rides Gone Wild"
   region: "PAL-A"
+  gsHWFixes:
+    autoFlush: 1
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-51926:
   name: "Outlaw Golf"
   region: "PAL-M3"
@@ -17694,6 +18462,7 @@ SLES-51961:
   region: "PAL-E"
   gsHWFixes:
     autoFlush: 2 # Reduces post-processing misalignment.
+    halfPixelOffset: 4 # Reduces post-processing misalignment.
 SLES-51963:
   name: "FIFA 2004"
   region: "PAL-F-G"
@@ -17909,6 +18678,12 @@ SLES-52043:
 SLES-52044:
   name: "Crescent Suzuki Racing - Superbikes and Super Sidecars"
   region: "PAL-E"
+  gameFixes:
+    - XGKickHack # Fixes texture flicker.
+  gsHWFixes:
+    recommendedBlendingLevel: 4 # Fixes road brightness.
+    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-52045:
   name: "GT-R 400"
   region: "PAL-E"
@@ -17932,12 +18707,16 @@ SLES-52047:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 1 # Fixes vertical lines, font and others.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-52048:
   name: "The Sims - Bustin' Out"
   name-sort: "Sims, The - Bustin' Out"
   region: "PAL-M5"
   gsHWFixes:
     halfPixelOffset: 1 # Fixes vertical lines, font and others.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-52055:
   name: "Harry Potter and the Philosopher's Stone"
   region: "PAL-M11"
@@ -18053,6 +18832,8 @@ SLES-52132:
   gsHWFixes:
     texturePreloading: 1 # Performs much better with partial preload.
     autoFlush: 1 # Fixes bloom rendering.
+    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
+    trilinearFiltering: 1
   roundModes:
     vu1RoundMode: 0 # Fixes missing light cones curtains and certain effects.
 SLES-52133:
@@ -18061,6 +18842,8 @@ SLES-52133:
   gsHWFixes:
     texturePreloading: 1 # Performs much better with partial preload.
     autoFlush: 1 # Fixes bloom rendering.
+    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
+    trilinearFiltering: 1
   roundModes:
     vu1RoundMode: 0 # Fixes missing light cones curtains and certain effects.
 SLES-52134:
@@ -18070,6 +18853,8 @@ SLES-52134:
   gsHWFixes:
     texturePreloading: 1 # Performs much better with partial preload.
     autoFlush: 1 # Fixes bloom rendering.
+    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
+    trilinearFiltering: 1
   roundModes:
     vu1RoundMode: 0 # Fixes missing light cones curtains and certain effects.
 SLES-52135:
@@ -18078,6 +18863,8 @@ SLES-52135:
   gsHWFixes:
     texturePreloading: 1 # Performs much better with partial preload.
     autoFlush: 1 # Fixes bloom rendering.
+    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
+    trilinearFiltering: 1
   roundModes:
     vu1RoundMode: 0 # Fixes missing light cones curtains and certain effects.
 SLES-52136:
@@ -18086,6 +18873,8 @@ SLES-52136:
   gsHWFixes:
     texturePreloading: 1 # Performs much better with partial preload.
     autoFlush: 1 # Fixes bloom rendering.
+    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
+    trilinearFiltering: 1
   roundModes:
     vu1RoundMode: 0 # Fixes missing light cones curtains and certain effects.
 SLES-52143:
@@ -18102,7 +18891,8 @@ SLES-52149:
   compat: 5
   gsHWFixes:
     preloadFrameData: 1 # Fixes missing loading screens.
-    mergeSprite: 1 # Fixes misaligned bloom on light sources.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-52150:
   name: "Legacy of Kain - Defiance"
   region: "PAL-M5"
@@ -18187,6 +18977,7 @@ SLES-52202:
   region: "PAL-M5"
   compat: 5
   gsHWFixes:
+    autoFlush: 2 # Fixes speed effect intensity.
     mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
     trilinearFiltering: 1
 SLES-52203:
@@ -18233,6 +19024,8 @@ SLES-52237:
   region: "PAL-M5"
   gsHWFixes:
     halfPixelOffset: 1 # Sharpens world in far distances.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
   memcardFilters:
     - "SLES-52237"
     - "SLES-52467"
@@ -18243,6 +19036,8 @@ SLES-52238:
   region: "PAL-M5"
   compat: 5
   gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
     getSkipCount: "GSC_Kunoichi"
 SLES-52240:
   name: "International Pool Championship"
@@ -18313,8 +19108,11 @@ SLES-52276:
   region: "PAL-M5"
   compat: 5
   gsHWFixes:
-    autoFlush: 2 # Softens bloom on objects and cars.
-    halfPixelOffset: 2 # Fixes misaligned bloom on objects and cars.
+    recommendedBlendingLevel: 4 # Improves car color.
+    autoFlush: 1 # Softens bloom on objects and cars.
+    halfPixelOffset: 4 # Fixes misaligned bloom on objects and cars.
+    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-52277:
   name: "Riding Spirits 2"
   region: "PAL-M5"
@@ -18465,15 +19263,21 @@ SLES-52322:
   clampModes:
     eeClampMode: 3 # Characters are visible in-game.
   gsHWFixes:
+    recommendedBlendingLevel: 2
     texturePreloading: 1 # Performs better with partial preload because it is slow on locations outside gameplay foremost.
     mergeSprite: 1 # Fixes misaligned white lines.
     PCRTCOverscan: 1 # Fixes missing HUD.
 SLES-52323:
   name: "Richard Burns Rally"
   region: "PAL-M5"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-52325:
   name: "Champions of Norrath - Realms of EverQuest"
   region: "PAL-M3"
+  gameFixes:
+    - BlitInternalFPSHack # Fixes internal fps detection in some areas.
   gsHWFixes:
     estimateTextureRegion: 1 # Improves performance.
 SLES-52326:
@@ -18570,6 +19374,8 @@ SLES-52372:
 SLES-52373:
   name: "Champions of Norrath"
   region: "PAL-E-S"
+  gameFixes:
+    - BlitInternalFPSHack # Fixes internal fps detection in some areas.
   gsHWFixes:
     estimateTextureRegion: 1 # Improves performance.
 SLES-52374:
@@ -18694,7 +19500,7 @@ SLES-52418:
   region: "PAL-M5"
   compat: 4
   gsHWFixes:
-    autoFlush: 2
+    autoFlush: 1 # Fixes light penetration.
   patches:
     52085DF1:
       content: |-
@@ -18751,6 +19557,9 @@ SLES-52447:
 SLES-52448:
   name: "Knights of the Temple"
   region: "PAL-M4"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-52449:
   name: "Kidz Sports Basketball"
   region: "PAL-E"
@@ -18826,6 +19635,9 @@ SLES-52478:
 SLES-52479:
   name: "Samurai Jack - The Shadow of Aku"
   region: "PAL-M5"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-52480:
   name: "Yu-Gi-Oh! - The Duelists of the Roses"
   region: "PAL-M4"
@@ -18977,18 +19789,18 @@ SLES-52535:
   region: "PAL-M5"
   compat: 5
 SLES-52536:
-  name: "Shark Tale"
+  name: "DreamWorks Shark Tale"
   region: "PAL-E"
   compat: 2
   speedHacks:
     mtvu: 0 # Fixes bad graphics due to bad T-Bit handling.
 SLES-52537:
-  name: "Shark Tale"
+  name: "DreamWorks Shark Tale"
   region: "PAL-M3"
   speedHacks:
     mtvu: 0 # Fixes bad graphics due to bad T-Bit handling.
 SLES-52539:
-  name: "Shark Tale"
+  name: "DreamWorks Shark Tale"
   region: "PAL-I"
   speedHacks:
     mtvu: 0 # Fixes bad graphics due to bad T-Bit handling.
@@ -19102,6 +19914,7 @@ SLES-52568:
     - XGKickHack # Fixes bad geometry.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
+    PCRTCOverscan: 1 # Fixes offscreen image.
     mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
     trilinearFiltering: 1
 SLES-52569:
@@ -19116,6 +19929,8 @@ SLES-52570:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misaligned lighting and other effects, needs Special otherwise lights flicker.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-52571:
   name: "Pacific Air Warriors 2 - Dogfight"
   region: "PAL-E"
@@ -19185,18 +20000,24 @@ SLES-52588:
   region: "PAL-E"
   gsHWFixes:
     autoFlush: 2 # Fixes missing lighting.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
     # halfPixelOffset: 1 # Fixes lighting misalignment. Do not enable this, it breaks a lot of graphics.
 SLES-52589:
   name: "Mercenaries - Playground of Destruction"
   region: "PAL-F"
   gsHWFixes:
     autoFlush: 2 # Fixes missing lighting.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
     # halfPixelOffset: 1 # Fixes lighting misalignment. Do not enable this, it breaks a lot of graphics.
 SLES-52590:
   name: "Mercenaries - Playground of Destruction"
   region: "PAL-G"
   gsHWFixes:
     autoFlush: 2 # Fixes missing lighting.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
     # halfPixelOffset: 1 # Fixes lighting misalignment. Do not enable this, it breaks a lot of graphics.
 SLES-52591:
   name: "Dynasty Warriors 4 - Empires"
@@ -19309,18 +20130,30 @@ SLES-52636:
   gsHWFixes:
     autoFlush: 2 # Fixes incorrect colors.
     alignSprite: 1 # Fixes vertical lines such as in FMVs.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-52637:
   name: "TOCA Racer Driver 2"
   region: "PAL-M5"
   gsHWFixes:
-    alignSprite: 1 # Fixes vertical lines.
+    alignSprite: 1 # Fixes lighting and vertical lines, also works with normal vertex.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-52638:
   name: "DTM Race Driver 2"
   region: "PAL-M5"
   compat: 5
+  gsHWFixes:
+    alignSprite: 1 # Fixes lighting and vertical lines, also works with normal vertex.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-52639:
   name: "V8 Supercars 2"
   region: "PAL-M5"
+  gsHWFixes:
+    alignSprite: 1 # Fixes lighting and vertical lines, also works with normal vertex.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-52640:
   name: "Dance-UK XL"
   region: "PAL-UK"
@@ -19461,6 +20294,8 @@ SLES-52669:
   gsHWFixes:
     halfPixelOffset: 1 # Reduces ghosting.
     roundSprite: 1 # Reduces ghosting even more.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-52670:
   name: "Second Sight"
   region: "PAL-M5"
@@ -19532,6 +20367,8 @@ SLES-52700:
     cpuSpriteRenderBW: 1 # Fixes shadow rendering.
     cpuSpriteRenderLevel: 1 # Needed for above.
     bilinearUpscale: 1 # Smoothes out shadow textures.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-52701:
   name: "Future Tactics - The Uprising"
   region: "PAL-M5"
@@ -19647,6 +20484,9 @@ SLES-52731:
 SLES-52733:
   name: "Driven to Destruction"
   region: "PAL-E"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-52734:
   name: "Worms Forts - Under Siege"
   region: "PAL-M5"
@@ -19690,14 +20530,26 @@ SLES-52752:
 SLES-52753:
   name: "FlatOut"
   region: "PAL-M4"
+  gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves car reflections.
+    autoFlush: 1
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-52754:
   name: "FlatOut"
   region: "PAL-G"
+  gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves car reflections.
+    autoFlush: 1
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-52755:
   name: "Blood Will Tell - Tezuka Osamu's Dororo"
   region: "PAL-M5"
   gsHWFixes:
     minimumBlendingLevel: 2 # Fixes dark font to more bright like software mode.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-52760:
   name: "Pro Evolution Soccer 4"
   region: "PAL-M4"
@@ -19712,6 +20564,9 @@ SLES-52766:
   name: "Godzilla - Save The Earth"
   region: "PAL-M5"
   compat: 5
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-52767:
   name: "Hugo - Cannon Cruise"
   region: "PAL-M4"
@@ -19796,26 +20651,36 @@ SLES-52801:
   region: "PAL-M5"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-52802:
   name: "Seigneur des anneaux, Le - Le Tiers Âge"
   region: "PAL-F"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-52803:
   name: "Herr der Ringe, Der - Das dritte Zeitalter"
   region: "PAL-G"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-52804:
   name: "Signore degli Anelli, Il - La Terza Era"
   region: "PAL-I"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-52805:
   name: "Señor de Los Anillos, El - La Tercera Edad"
   region: "PAL-S"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-52807:
   name: "Lemony Snicket's A Series of Unfortunate Events"
   region: "PAL-E"
@@ -19857,7 +20722,7 @@ SLES-52812:
     halfPixelOffset: 2 # Fixes bloom misalignment when upscaling.
     cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling.
 SLES-52813:
-  name: "The Incredibles"
+  name: "Disney/Pixar The Incredibles"
   name-sort: "Incredibles, The"
   region: "PAL-NL-F"
   compat: 5
@@ -19867,7 +20732,7 @@ SLES-52813:
     halfPixelOffset: 2 # Fixes bloom misalignment when upscaling.
     cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling.
 SLES-52814:
-  name: "The Incredibles"
+  name: "Disney/Pixar Gli Incredibili"
   name-sort: "Incredibles, The"
   region: "PAL-I"
   gsHWFixes:
@@ -19876,7 +20741,7 @@ SLES-52814:
     halfPixelOffset: 2 # Fixes bloom misalignment when upscaling.
     cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling.
 SLES-52815:
-  name: "Disney/Pixar The Incredibles"
+  name: "Disney/Pixar Die Unglaublichen"
   region: "PAL-G"
   gsHWFixes:
     mipmap: 2 # Mipmap + trilinear, improves the street's textures to match sw renderer.
@@ -19884,7 +20749,8 @@ SLES-52815:
     halfPixelOffset: 2 # Fixes bloom misalignment when upscaling.
     cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling.
 SLES-52816:
-  name: "Increíbles, Los"
+  name: "Disney/Pixar Los Increíbles"
+  name-sort: "Disney/Pixar Increíbles, Los"
   region: "PAL-S"
   gsHWFixes:
     mipmap: 2 # Mipmap + trilinear, improves the street's textures to match sw renderer.
@@ -19892,8 +20758,8 @@ SLES-52816:
     halfPixelOffset: 2 # Fixes bloom misalignment when upscaling.
     cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling.
 SLES-52820:
-  name: "The Incredibles"
-  name-sort: "Incredibles, The"
+  name: "Disney/Pixar The Incredibles"
+  name-sort: "Disney/Pixar Incredibles, The"
   region: "PAL-SC"
   gsHWFixes:
     mipmap: 2 # Mipmap + trilinear, improves the street's textures to match sw renderer.
@@ -19901,8 +20767,7 @@ SLES-52820:
     halfPixelOffset: 2 # Fixes bloom misalignment when upscaling.
     cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling.
 SLES-52821:
-  name: "The Incredibles"
-  name-sort: "Incredibles, The"
+  name: "Disney/Pixar The Incredibles - Os Super-Heróis"
   region: "PAL-P"
   gsHWFixes:
     mipmap: 2 # Mipmap + trilinear, improves the street's textures to match sw renderer.
@@ -20137,7 +21002,7 @@ SLES-52913:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes black squares in water.
 SLES-52915:
-  name: "Shark Tale"
+  name: "DreamWorks Shark Tale - Hajar som Hajar"
   region: "PAL-SW"
   speedHacks:
     mtvu: 0 # Fixes bad graphics due to bad T-Bit handling.
@@ -20147,12 +21012,16 @@ SLES-52917:
   compat: 5
   roundModes:
     eeRoundMode: 2 # Fixes missing text.
+  gsHWFixes:
+    autoFlush: 1 # Fixes player shadow.
 SLES-52918:
   name: "Scaler"
   region: "PAL-M4"
   compat: 5
   roundModes:
     eeRoundMode: 2 # Fixes missing text.
+  gsHWFixes:
+    autoFlush: 1 # Fixes player shadow.
 SLES-52919:
   name: "NRL Rugby League 2"
   region: "PAL-E"
@@ -20200,6 +21069,10 @@ SLES-52941:
 SLES-52942:
   name: "Midnight Club 3 - DUB Edition"
   region: "PAL-M5"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves car and road textures to match sw renderer.
+    trilinearFiltering: 1
+    getSkipCount: "GSC_MidnightClub3"
   patches:
     EBE1972D:
       content: |-
@@ -20210,8 +21083,6 @@ SLES-52942:
         // for VU1 to finish, which reduces the advantage of MTVU to basically zero.
         patch=1,EE,D0525A1C,extended,00000800
         patch=1,EE,20525A1C,extended,00000000
-  gsHWFixes:
-    getSkipCount: "GSC_MidnightClub3"
 SLES-52943:
   name: "ESPN NFL 2K5"
   region: "PAL-E"
@@ -20301,6 +21172,8 @@ SLES-52968:
     autoFlush: 1 # Fixes bloom and sun rendering in front of everything.
     halfPixelOffset: 2 # Aligns bloom effect a little bit better when upscaled.
     bilinearUpscale: 2 # Reduces color banding of the sun glare.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
   roundModes:
     vu1RoundMode: 1 # Bright lights in cars.
 SLES-52973:
@@ -20414,6 +21287,8 @@ SLES-53008:
   region: "PAL-I-S"
   gsHWFixes:
     autoFlush: 2 # Fixes missing lighting.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
     # halfPixelOffset: 1 # Fixes lighting misalignment. Do not enable this, it breaks a lot of graphics.
 SLES-53009:
   name: "Dance Factory"
@@ -20427,28 +21302,50 @@ SLES-53011:
 SLES-53012:
   name: "Tenchu - Fatal Shadows"
   region: "PAL-E"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-53013:
   name: "Tenchu - Fatal Shadows"
   region: "PAL-F"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-53014:
   name: "Tenchu - Fatal Shadows"
   region: "PAL-G"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-53015:
   name: "Tenchu - Fatal Shadows"
   region: "PAL-I"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-53016:
   name: "Tenchu - Fatal Shadows"
   region: "PAL-S"
   compat: 5
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-53017:
   name: "Teenage Mutant Ninja Turtles 2 - Battle Nexus"
   region: "PAL-M5"
 SLES-53020:
   name: "Ghost in the Shell - Stand Alone Complex"
   region: "PAL-M5"
+  gameFixes:
+    - SoftwareRendererFMVHack # Fixes hash cache disabling itself.
   gsHWFixes:
-    halfPixelOffset: 1 # Fixes texture and lighting misalignment.
+    recommendedBlendingLevel: 4 # Improves banding and effect emulation.
+    halfPixelOffset: 3 # Fixes texture and lighting misalignment.
     mergeSprite: 1 # Fixes most vertical lines and lighting misalignment.
+    autoFlush: 1 # Fixes light bloom intensity.
+    estimateTextureRegion: 1 # Improves performance and reduces hash cache size.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
     getSkipCount: "GSC_GiTS"
   patches:
     BF6F101F:
@@ -20517,6 +21414,8 @@ SLES-53028:
     vuClampMode: 0 # Fixes bump mapping issues.
   gsHWFixes:
     textureInsideRT: 1 # Fixes post processing.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
     getSkipCount: "GSC_HitmanBloodMoney"
 SLES-53029:
   name: "Hitman - Blood Money"
@@ -20525,6 +21424,8 @@ SLES-53029:
     vuClampMode: 0 # Fixes bump mapping issues.
   gsHWFixes:
     textureInsideRT: 1 # Fixes post processing.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
     getSkipCount: "GSC_HitmanBloodMoney"
 SLES-53030:
   name: "Hitman - Blood Money"
@@ -20533,6 +21434,8 @@ SLES-53030:
     vuClampMode: 0 # Fixes bump mapping issues.
   gsHWFixes:
     textureInsideRT: 1 # Fixes post processing.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
     getSkipCount: "GSC_HitmanBloodMoney"
 SLES-53031:
   name: "Hitman - Blood Money"
@@ -20541,6 +21444,8 @@ SLES-53031:
     vuClampMode: 0 # Fixes bump mapping issues.
   gsHWFixes:
     textureInsideRT: 1 # Fixes post processing.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
     getSkipCount: "GSC_HitmanBloodMoney"
 SLES-53032:
   name: "Hitman - Blood Money"
@@ -20549,11 +21454,16 @@ SLES-53032:
     vuClampMode: 0 # Fixes bump mapping issues.
   gsHWFixes:
     textureInsideRT: 1 # Fixes post processing.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
     getSkipCount: "GSC_HitmanBloodMoney"
 SLES-53035:
   name: "Masters of the Universe - He-Man - Defender of Greyskull"
   region: "PAL-E"
   compat: 5
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-53036:
   name: "Tak 2 - The Staff of Dreams"
   region: "PAL-M3"
@@ -20564,6 +21474,10 @@ SLES-53037:
   compat: 5
   roundModes:
     eeRoundMode: 1 # Fixes object balls never stopping in the Monkey Billiards DX minigame.
+  gsHWFixes:
+    recommendedBlendingLevel: 4 # Fixes text and foliage color.
+    mipmap: 2 # Mipmap + trilinear, improves stage textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-53038:
   name: "Devil May Cry 3 - Dante's Awakening"
   region: "PAL-M5"
@@ -20611,6 +21525,9 @@ SLES-53046:
   region: "PAL-M5"
   clampModes:
     vu1ClampMode: 3 # Fixes smoke particles.
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-53047:
   name: "The Punisher"
   name-sort: "Punisher, The"
@@ -20626,6 +21543,10 @@ SLES-53049:
 SLES-53052:
   name: "Robots"
   region: "PAL-M5"
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes misaligned bloom.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-53058:
   name: "Ricky Ponting International Cricket"
   region: "PAL-E"
@@ -20676,6 +21597,8 @@ SLES-53075:
   region: "PAL-M5"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misaligned lighting and other effects, needs Special otherwise lights flicker.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-53076:
   name: "Triggerman"
   region: "PAL-M5"
@@ -20761,6 +21684,8 @@ SLES-53098:
   region: "PAL-M5"
   gsHWFixes:
     autoFlush: 2 # Fixes lighting misalignment.
+    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
+    trilinearFiltering: 1
   gameFixes:
     - XGKickHack # Fixes stretched/spikey textures.
 SLES-53099:
@@ -20912,17 +21837,17 @@ SLES-53155:
   region: "PAL-M3"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 1 # Fixes bloom misalignment.
+    halfPixelOffset: 4 # Fixes bloom misalignment.
 SLES-53156:
   name: "Star Wars - Episode III - La Revanche des Sith"
   region: "PAL-F"
   gsHWFixes:
-    halfPixelOffset: 1 # Fixes bloom misalignment.
+    halfPixelOffset: 4 # Fixes bloom misalignment.
 SLES-53157:
   name: "Star Wars - Episode III - Die Rache der Sith"
   region: "PAL-G"
   gsHWFixes:
-    halfPixelOffset: 1 # Fixes bloom misalignment.
+    halfPixelOffset: 4 # Fixes bloom misalignment.
 SLES-53158:
   name: "Cold Fear"
   region: "PAL-M5"
@@ -20966,6 +21891,8 @@ SLES-53192:
   gsHWFixes:
     wildArmsHack: 1 # Fixes blurriness.
     mergeSprite: 1 # Fixes misaligned lights.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-53193:
   name: "Puzzle Party"
   region: "PAL-E"
@@ -20974,6 +21901,9 @@ SLES-53194:
   region: "PAL-M7"
   clampModes:
     vuClampMode: 3 # Fixes bad coordinate spam.
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-53195:
   name: "The Punisher"
   name-sort: "Punisher, The"
@@ -21048,6 +21978,8 @@ SLES-53225:
   gsHWFixes:
     roundSprite: 2 # Improves bloom alignment and clarity.
     halfPixelOffset: 2 # Improves bloom alignment and clarity.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-53226:
   name: "DreamWorks Madagascar"
   region: "PAL-F-G"
@@ -21057,6 +21989,8 @@ SLES-53226:
   gsHWFixes:
     roundSprite: 2 # Improves bloom alignment and clarity.
     halfPixelOffset: 2 # Improves bloom alignment and clarity.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-53227:
   name: "DreamWorks Madagascar"
   region: "PAL-M3"
@@ -21065,6 +21999,8 @@ SLES-53227:
   gsHWFixes:
     roundSprite: 2 # Improves bloom alignment and clarity.
     halfPixelOffset: 2 # Improves bloom alignment and clarity.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-53231:
   name: "Le Avventure di Lupin III - Il Tesoro del Re Stregone"
   region: "PAL-I"
@@ -21098,6 +22034,8 @@ SLES-53242:
   gsHWFixes:
     roundSprite: 2 # Improves bloom alignment and clarity.
     halfPixelOffset: 2 # Improves bloom alignment and clarity.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-53246:
   name: "DreamWorks Madagascar"
   region: "PAL-S"
@@ -21106,6 +22044,8 @@ SLES-53246:
   gsHWFixes:
     roundSprite: 2 # Improves bloom alignment and clarity.
     halfPixelOffset: 2 # Improves bloom alignment and clarity.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-53280:
   name: "7 Sins"
   region: "PAL-M3"
@@ -21150,6 +22090,8 @@ SLES-53300:
     vuClampMode: 3 # Fixes SPS ingame and prevents flickering or invisible characters.
   gsHWFixes:
     minimumBlendingLevel: 4 # Mitigates grayer text font in bottom left.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-53301:
   name: "Bomberman Hardball"
   region: "PAL-E"
@@ -21173,6 +22115,8 @@ SLES-53309:
 SLES-53311:
   name: "Graffiti Kingdom"
   region: "PAL-M5"
+  gsHWFixes:
+    halfPixelOffset: 4 # Fixes distant offset blur.
 SLES-53314:
   name: "Melbourne Cup Challenge"
   region: "PAL-A"
@@ -21208,6 +22152,8 @@ SLES-53332:
     halfPixelOffset: 2 # Fixes misaligned blur.
     cpuSpriteRenderBW: 2 # Fixes black spots appearing on some surfaces and massively reduces RP TC and TU count.
     cpuSpriteRenderLevel: 2 # Needed for above.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-53333:
   name: "Medal of Honor - Les Faucons de Guerre"
   region: "PAL-F"
@@ -21216,6 +22162,8 @@ SLES-53333:
     halfPixelOffset: 2 # Fixes misaligned blur.
     cpuSpriteRenderBW: 2 # Fixes black spots appearing on some surfaces and massively reduces RP TC and TU count.
     cpuSpriteRenderLevel: 2 # Needed for above.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-53334:
   name: "Medal of Honor - European Assault"
   region: "PAL-G"
@@ -21224,6 +22172,8 @@ SLES-53334:
     halfPixelOffset: 2 # Fixes misaligned blur.
     cpuSpriteRenderBW: 2 # Fixes black spots appearing on some surfaces and massively reduces RP TC and TU count.
     cpuSpriteRenderLevel: 2 # Needed for above.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-53335:
   name: "Medal of Honor - European Assault"
   region: "PAL-I"
@@ -21232,6 +22182,8 @@ SLES-53335:
     halfPixelOffset: 2 # Fixes misaligned blur.
     cpuSpriteRenderBW: 2 # Fixes black spots appearing on some surfaces and massively reduces RP TC and TU count.
     cpuSpriteRenderLevel: 2 # Needed for above.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-53336:
   name: "Medal of Honor - European Assault"
   region: "PAL-S"
@@ -21240,18 +22192,29 @@ SLES-53336:
     halfPixelOffset: 2 # Fixes misaligned blur.
     cpuSpriteRenderBW: 2 # Fixes black spots appearing on some surfaces and massively reduces RP TC and TU count.
     cpuSpriteRenderLevel: 2 # Needed for above.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-53338:
   name: "Victorious Boxers 2 - Fighting Spirit"
   region: "PAL-M3"
 SLES-53339:
   name: "Dynasty Warriors 5"
   region: "PAL-E"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-53340:
   name: "Dynasty Warriors 5"
   region: "PAL-F"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-53341:
   name: "Dynasty Warriors 5"
   region: "PAL-G"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
   compat: 5
 SLES-53342:
   name: "EA Sports Cricket 2005"
@@ -21358,6 +22321,8 @@ SLES-53373:
   gsHWFixes:
     roundSprite: 2 # Improves bloom alignment and clarity.
     halfPixelOffset: 2 # Improves bloom alignment and clarity.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-53374:
   name: "X-Men Legends II - Rise of Apocalypse"
   region: "PAL-M3"
@@ -21426,6 +22391,8 @@ SLES-53393:
   gsHWFixes:
     autoFlush: 1 # Fixes missing post processing.
     halfPixelOffset: 1 # Aligns post processing.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-53396:
   name: "Spartan - Total Warrior"
   region: "PAL-M3"
@@ -21434,6 +22401,8 @@ SLES-53396:
   gsHWFixes:
     autoFlush: 1 # Fixes missing post processing.
     halfPixelOffset: 1 # Aligns post processing.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-53398:
   name: "Zombie Zone"
   region: "PAL-E"
@@ -21532,10 +22501,12 @@ SLES-53418:
   region: "PAL-A"
   compat: 5
 SLES-53419:
-  name: "LA Rush"
+  name: "L.A. Rush"
   region: "PAL-M5"
   gsHWFixes:
     cpuSpriteRenderBW: 4 # Fixes textures.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-53420:
   name: "Winnie the Pooh's Rumbly Tumbly Adventure"
   region: "PAL-PL"
@@ -21581,6 +22552,8 @@ SLES-53439:
     PCRTCOverscan: 1 # Fixes offscreen image.
     nativePaletteDraw: 1 # Fixes the look of screen effects.
     halfPixelOffset: 2 # Corrects the alignment of screen effects.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-53441:
   name: "Heroes of the Pacific"
   region: "PAL-M5"
@@ -21588,6 +22561,9 @@ SLES-53443:
   name: "The Warriors"
   name-sort: "Warriors, The"
   region: "PAL-M5"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-53444:
   name: "Panzer Elite Action - Fields of Glory"
   region: "PAL-M5"
@@ -21652,19 +22628,21 @@ SLES-53471:
   name: "LMA Manager 2006"
   region: "PAL-M5"
 SLES-53473:
-  name: "The Incredibles - Rise of the Underminer"
-  name-sort: "Incredibles, The - Rise of the Underminer"
+  name: "Disney/Pixar The Incredibles - Rise of the Underminer"
+  name-sort: "Disney/Pixar Incredibles, The - Rise of the Underminer"
   region: "PAL-M3"
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes building shade and shadows.
     mipmap: 2 # Mipmap + trilinear, improves the street's textures to match sw renderer.
     trilinearFiltering: 1
     halfPixelOffset: 2 # Fixes bloom misalignment when upscaling.
     cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling.
 SLES-53474:
-  name: "The Incredibles - Rise of the Underminer"
-  name-sort: "Incredibles, The - Rise of the Underminer"
+  name: "Disney/Pixar The Incredibles - Rise of the Underminer"
+  name-sort: "Disney/Pixar Incredibles, The - Rise of the Underminer"
   region: "PAL-M3"
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes building shade and shadows.
     mipmap: 2 # Mipmap + trilinear, improves the street's textures to match sw renderer.
     trilinearFiltering: 1
     halfPixelOffset: 2 # Fixes bloom misalignment when upscaling.
@@ -21711,24 +22689,45 @@ SLES-53494:
   name: "Spongebob SquarePants - Lights, Camera, PANTS!"
   region: "PAL-E"
   compat: 5
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-53495:
   name: "Nickelodeon Bob L'éponge - Silence on Tourne!"
   region: "PAL-F"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-53496:
-  name: "Spongebob SquarePants - Lights, Camera, PANTS!"
+  name: "Nickelodeon SpongeBob - Ciak si Gira!"
   region: "PAL-I"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-53497:
   name: "Nickelodeon SpongeBob Schwammkopf - Film ab!"
   region: "PAL-G"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-53498:
   name: "Nickelodeon Bob Esponja - ¡Luces, Cámara, Esponja!"
   region: "PAL-S"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-53499:
   name: "Nickelodeon SpongeBob SquarePants - Licht uit, Camera aan!"
   region: "PAL-NL"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-53500:
   name: "Nickelodeon Svampbob Fyrkant - Tystnad, Tagning, TvÃ¤ttsvamp!"
   region: "PAL-SW"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-53501:
   name: "Star Wars - Battlefront II"
   region: "PAL-M3"
@@ -21834,8 +22833,8 @@ SLES-53523:
     minimumBlendingLevel: 3 # Fixes broken light and shadow rendering.
     mipmap: 2 # Mipmap + trilinear, improves ground textures and water textures and reflections.
     trilinearFiltering: 1
-    halfPixelOffset: 4 # Fixes misaligned bloom and character shadows.
-    autoFlush: 2 # Fixes missing bloom intensity and alignment.
+    halfPixelOffset: 2 # Fixes misaligned bloom and character shadows.
+    autoFlush: 1 # Fixes missing bloom intensity and alignment.
 SLES-53524:
   name: "Mortal Kombat - Shaolin Monks"
   region: "PAL-M5"
@@ -22058,6 +23057,8 @@ SLES-53553:
   gsHWFixes:
     textureInsideRT: 1 # Required for complex offset shuffles.
     halfPixelOffset: 2 # Fixes center upscaling line during explosions.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
     recommendedBlendingLevel: 4 # Fixes lighting.
 SLES-53556:
   name: "Driver - Parallel Lines"
@@ -22069,6 +23070,8 @@ SLES-53556:
     cpuCLUTRender: 1 # Fixes the rest of the bad textures.
     roundSprite: 1 # Reduces misaligned bloom.
     mergeSprite: 1 # Removes bloom explosion around electrical lights and other light sources such as moon/sun.
+    mipmap: 2 # Mipmap + trilinear, improves road textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-53557:
   name: "Need for Speed - Most Wanted"
   region: "PAL-E"
@@ -22078,6 +23081,8 @@ SLES-53557:
     halfPixelOffset: 2 # Fixes blurriness.
     cpuCLUTRender: 1 # Final colour adjustment LUT.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
   memcardFilters: # Reads Underground 2 save for extra money.
     - "SLES-53557"
     - "SLES-53558"
@@ -22092,6 +23097,8 @@ SLES-53558:
     halfPixelOffset: 2 # Fixes blurriness.
     cpuCLUTRender: 1 # Final colour adjustment LUT.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
   memcardFilters:
     - "SLES-53557"
     - "SLES-53558"
@@ -22106,6 +23113,8 @@ SLES-53559:
     halfPixelOffset: 2 # Fixes blurriness.
     cpuCLUTRender: 1 # Final colour adjustment LUT.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
   memcardFilters:
     - "SLES-53557"
     - "SLES-53558"
@@ -22144,6 +23153,8 @@ SLES-53564:
   region: "PAL-M5"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blood vision bloom
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-53566:
   name: "London Taxi - Rush Hour"
   region: "PAL-E"
@@ -22304,6 +23315,8 @@ SLES-53621:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misalignment/bloom when upscaling.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-53623:
   name: "SpongeBob SquarePants - Battle for Bikini Bottom"
   region: "PAL-F"
@@ -22402,8 +23415,8 @@ SLES-53647:
     minimumBlendingLevel: 3 # Fixes broken light and shadow rendering.
     mipmap: 2 # Mipmap + trilinear, improves ground textures and water textures and reflections.
     trilinearFiltering: 1
-    halfPixelOffset: 4 # Fixes misaligned bloom and character shadows.
-    autoFlush: 2 # Fixes missing bloom intensity and alignment.
+    halfPixelOffset: 2 # Fixes misaligned bloom and character shadows.
+    autoFlush: 1 # Fixes missing bloom intensity and alignment.
 SLES-53651:
   name: "WWII - Soldier"
   region: "PAL-E"
@@ -22429,9 +23442,10 @@ SLES-53657:
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes textures.
 SLES-53658:
-  name: "Disney/Pixar The Incredibles - Rise of the Underminer"
+  name: "Disney/Pixar Суперсемейка - Подземная битва"
   region: "PAL-R"
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes building shade and shadows.
     mipmap: 2 # Mipmap + trilinear, improves the street's textures to match sw renderer.
     trilinearFiltering: 1
     halfPixelOffset: 2 # Fixes bloom misalignment when upscaling.
@@ -22546,6 +23560,8 @@ SLES-53702:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-53703:
   name: "King Kong, Peter Jackson's - The Official Game of the Movie"
   region: "PAL-M10"
@@ -22575,51 +23591,69 @@ SLES-53706:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes lighting misalignment.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-53707:
   name: "Chroniken von Narnia, Die - Der König von Narnia"
   region: "PAL-G"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes lighting misalignment.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-53708:
   name: "Cronache di Narnia, Le - Il Leone, La Strega e L'Armadio"
   region: "PAL-I"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes lighting misalignment.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-53709:
   name: "The Chronicles of Narnia - The Lion Witch and The Wardrobe"
   name-sort: "Chronicles of Narnia, The - The Lion, The Witch and The Wardrobe"
   region: "PAL-NL-F"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes lighting misalignment.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-53710:
   name: "Crónicas de Narnia, Las - El León, La Bruja y El Armario"
   region: "PAL-S"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes lighting misalignment.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-53712:
   name: "The Chronicles of Narnia - The Lion Witch and The Wardrobe"
   name-sort: "Chronicles of Narnia, The - The Lion, The Witch and The Wardrobe"
-  region: "PAL-M3"
+  region: "PAL-SC"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes lighting misalignment.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-53713:
-  name: "The Chronicles of Narnia - The Lion Witch and The Wardrobe"
-  name-sort: "Chronicles of Narnia, The - The Lion, The Witch and The Wardrobe"
+  name: "Opowieści z Narnii - Lew Czarownica i Stara Szafa"
   region: "PAL-PL"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes lighting misalignment.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-53715:
-  name: "The Chronicles of Narnia - The Lion Witch and The Wardrobe"
-  name-sort: "Chronicles of Narnia, The - The Lion, The Witch and The Wardrobe"
+  name: "Хроники Нарнии - Лев Колдунья и Волшебный Шкаф"
   region: "PAL-R"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes lighting misalignment.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-53716:
   name: "Without Warning"
   region: "PAL-M5"
 SLES-53717:
   name: "Midnight Club 3 - DUB Edition Remix"
   region: "PAL-M5"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves car and road textures to match sw renderer.
+    trilinearFiltering: 1
+    getSkipCount: "GSC_MidnightClub3"
   patches:
     208183AF:
       content: |-
@@ -22630,8 +23664,6 @@ SLES-53717:
         // for VU1 to finish, which reduces the advantage of MTVU to basically zero.
         patch=1,EE,D0529074,extended,00000800
         patch=1,EE,20529074,extended,00000000
-  gsHWFixes:
-    getSkipCount: "GSC_MidnightClub3"
 SLES-53718:
   name: "The Sims 2"
   name-sort: "Sims 2, The"
@@ -22680,6 +23712,8 @@ SLES-53729:
     autoFlush: 1 # Post-processing.
     halfPixelOffset: 2 # Offset post-processing.
     texturePreloading: 1 # Improves performance.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
     getSkipCount: "GSC_Battlefield2" # Depth clear.
     beforeDraw: "OI_Battlefield2" # Framebuffer copy, fixes rendering for bottom part of screen.
 SLES-53730:
@@ -22690,6 +23724,8 @@ SLES-53730:
     autoFlush: 1 # Post-processing.
     halfPixelOffset: 2 # Offset post-processing.
     texturePreloading: 1 # Improves performance.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
     getSkipCount: "GSC_Battlefield2" # Depth clear.
     beforeDraw: "OI_Battlefield2" # Framebuffer copy, fixes rendering for bottom part of screen.
 SLES-53734:
@@ -22697,6 +23733,8 @@ SLES-53734:
   region: "PAL-E"
   gsHWFixes:
     roundSprite: 1 # Removes chromatic effect when upscaling also works with halfpixeloffset Special Texture.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-53736:
   name: "Billy the Wizard - Rocket Broomstick Racing"
   region: "PAL-E"
@@ -22742,6 +23780,9 @@ SLES-53746:
   region: "PAL-E"
   gameFixes:
     - VUOverflowHack # Fixes SPS.
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-53747:
   name: "Ed, Edd, 'n Eddy - The Misadventure"
   region: "PAL-E"
@@ -22777,6 +23818,9 @@ SLES-53754:
   region: "PAL-M6"
   speedHacks:
     mtvu: 0 # Increases FPS drastically.
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-53755:
   name: "Castlevania - Curse of Darkness"
   region: "PAL-M5"
@@ -22794,6 +23838,8 @@ SLES-53756:
   region: "PAL-M5"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-53758:
   name: "Sniper Elite [Pre-Production]"
   region: "PAL-E"
@@ -22801,6 +23847,8 @@ SLES-53758:
     autoFlush: 2 # Fixes bloom misalignment.
     halfPixelOffset: 2 # Fixes bloom misalignment.
     textureInsideRT: 1 # Fixes sky bloom.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-53759:
   name: "The Matrix - Path of Neo"
   name-sort: "Matrix, The - Path of Neo"
@@ -22859,13 +23907,14 @@ SLES-53775:
     - EETimingHack
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
+    textureInsideRT: 1 # Fixes bottom half screen issues.
 SLES-53777:
   name: "Prince of Persia - The Two Thrones"
   region: "PAL-M5"
   compat: 5
   gsHWFixes:
-    autoFlush: 2 # Reduces post-processing misalignment.
-    halfPixelOffset: 1 # Reduces post-processing misalignment.
+    autoFlush: 1 # Reduces post-processing misalignment.
+    halfPixelOffset: 4 # Reduces post-processing misalignment.
 SLES-53778:
   name: "Jacked"
   region: "PAL-M5"
@@ -22958,6 +24007,8 @@ SLES-53819:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
     recommendedBlendingLevel: 3 # Fixes level brightness.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
   memcardFilters:
     - "SLES-53819"
     - "SLES-82036"
@@ -22968,6 +24019,8 @@ SLES-53820:
   gsHWFixes:
     halfPixelOffset: 2 # Corrects shadow alignment and reduces blurriness.
     recommendedBlendingLevel: 3 # Fixes level and map menu brightness.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-53821:
   name: "Radio Helicopter II"
   region: "PAL-E"
@@ -22985,9 +24038,15 @@ SLES-53826:
   name: "Tom Clancy's Splinter Cell - Double Agent"
   region: "PAL-M5"
   compat: 5
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-53827:
   name: "Tom Clancy's Splinter Cell - Double Agent"
   region: "PAL-M3"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-53828:
   name: "We Love Katamari"
   region: "PAL-M4"
@@ -23038,6 +24097,8 @@ SLES-53852:
 SLES-53853:
   name: "Final Fight - Streetwise"
   region: "PAL-M5"
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes excessive blur.
 SLES-53855:
   name: "Heracles - Battle with the Gods"
   region: "PAL-E"
@@ -23049,6 +24110,8 @@ SLES-53857:
     halfPixelOffset: 2 # Fixes blurriness.
     cpuCLUTRender: 1 # Final colour adjustment LUT.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
   memcardFilters:
     - "SLES-53557"
     - "SLES-53558"
@@ -23075,7 +24138,7 @@ SLES-53863:
   region: "PAL-M5"
   compat: 5
 SLES-53866:
-  name: "Over the Hedge"
+  name: "DreamWorks Over the Hedge"
   region: "PAL-E"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes fog line.
@@ -23175,6 +24238,8 @@ SLES-53906:
   region: "PAL-F"
   gsHWFixes:
     roundSprite: 1 # Removes chromatic effect when upscaling also works with halfpixeloffset Special Texture.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-53908:
   name: "Tomb Raider - Legend"
   region: "PAL-M8"
@@ -23371,24 +24436,24 @@ SLES-53984:
         patch=1,EE,002FF3F0,word,27BDFEE0
         patch=1,EE,002FF42C,word,27BD0120
 SLES-53986:
-  name: "gang del bosco, La"
+  name: "DreamWorks La Gang del Bosco"
   region: "PAL-I"
   speedHacks:
     mtvu: 0 # Fixes bad graphics due to bad T-Bit handling.
 SLES-53987:
-  name: "Vecinos Invasores"
+  name: "DreamWorks Vecinos Invasores"
   region: "PAL-S"
   speedHacks:
     mtvu: 0 # Fixes bad graphics due to bad T-Bit handling.
 SLES-53988:
-  name: "Over the Hedge"
-  region: "PAL-E-G"
+  name: "DreamWorks Over the Hedge"
+  region: "PAL-F-G"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes fog line.
   speedHacks:
     mtvu: 0 # Fixes bad graphics due to bad T-Bit handling.
 SLES-53989:
-  name: "Over the Hedge"
+  name: "DreamWorks Beesten bij de Buren"
   region: "PAL-NL"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes fog line.
@@ -23405,6 +24470,8 @@ SLES-53994:
   region: "PAL-E"
   gsHWFixes:
     roundSprite: 1 # Removes chromatic effect when upscaling also works with halfpixeloffset Special Texture.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-53995:
   name: "World Championship Poker 2 featuring Howard Lederer"
   region: "PAL-M5"
@@ -23538,6 +24605,8 @@ SLES-54027:
     cpuCLUTRender: 1 # Fixes the rest of the bad textures.
     roundSprite: 1 # Reduces misaligned bloom.
     mergeSprite: 1 # Removes bloom explosion around electrical lights and other light sources such as moon/sun.
+    mipmap: 2 # Mipmap + trilinear, improves road textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-54030:
   name: "Black"
   region: "PAL-E"
@@ -23635,9 +24704,15 @@ SLES-54087:
 SLES-54089:
   name: "State of Emergency 2"
   region: "PAL-M3"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-54092:
   name: "State of Emergency 2"
   region: "PAL-M3"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-54093:
   name: "Guitar Hero"
   region: "PAL-M5"
@@ -23746,11 +24821,15 @@ SLES-54135:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 1 # Removes blur due to misaligned fullscreen effect.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-54136:
   name: "Grand Theft Auto - Liberty City Stories"
   region: "PAL-E-G"
   gsHWFixes:
     halfPixelOffset: 1 # Removes blur due to misaligned fullscreen effect.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-54137:
   name: "Just Cause"
   region: "PAL-M3"
@@ -23784,6 +24863,8 @@ SLES-54147:
     eeClampMode: 2 # Fixes occasional SPS on moving around, jumping and falling.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
   patches:
     D9920B66:
       content: |-
@@ -23796,6 +24877,8 @@ SLES-54150:
   region: "PAL-M6"
   gsHWFixes:
     cpuCLUTRender: 1 # Fixes ghosting on objects and people.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-54151:
   name: "Let's Make a Soccer Team!"
   region: "PAL-M5"
@@ -23861,6 +24944,7 @@ SLES-54164:
   region: "PAL-M6"
   compat: 5
   gsHWFixes:
+    halfPixelOffset: 2 # Fixes character outlines and minor bloom.
     beforeDraw: "OI_DBZBTGames"
 SLES-54165:
   name: "One Piece - Grand Adventure"
@@ -23910,7 +24994,7 @@ SLES-54172:
   region: "PAL-M11"
   compat: 5
 SLES-54173:
-  name: "Over The Hedge"
+  name: "DreamWorks På Andra Sidan Häcken"
   region: "PAL-SW"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes fog line.
@@ -24077,6 +25161,9 @@ SLES-54222:
 SLES-54223:
   name: "NASCAR '07"
   region: "PAL-E"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-54224:
   name: "Australian Idol Sing"
   region: "PAL-A"
@@ -24230,13 +25317,15 @@ SLES-54305:
   gameFixes:
     - VIF1StallHack # Fixes black screen on boot.
   gsHWFixes:
+    recommendedBlendingLevel: 2
     autoFlush: 2 # Fixes missing bloom effects.
     halfPixelOffset: 2 # Fixes misaligned lighting and bloom.
 SLES-54306:
   name: "Cartoon Network Racing"
   region: "PAL-E"
   gsHWFixes:
-    mipmap: 1
+    mipmap: 2 # Mipmap + trilinear, fixes flickering and improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-54307:
   name: "Rayman - Raving Rabbids"
   region: "PAL-M6"
@@ -24282,21 +25371,29 @@ SLES-54321:
   compat: 5
   clampModes:
     eeClampMode: 3 # Fixes game hang after opening intro.
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes depth line.
 SLES-54322:
   name: "Need for Speed - Carbon"
   region: "PAL-M8"
   clampModes:
     eeClampMode: 3 # Fixes game hang after opening intro.
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes depth line.
 SLES-54323:
   name: "Need for Speed - Carbon"
   region: "PAL-I-S"
   clampModes:
     eeClampMode: 3 # Fixes game hang after opening intro.
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes depth line.
 SLES-54324:
   name: "Need for Speed - Carbon"
   region: "PAL-R"
   clampModes:
     eeClampMode: 3 # Fixes game hang after opening intro.
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes depth line.
 SLES-54326:
   name: "Raceway - Drag Stock Racing"
   region: "PAL-E"
@@ -24359,26 +25456,40 @@ SLES-54347:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned textures.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-54348:
   name: "Superman Returns"
   region: "PAL-F"
   gameFixes:
     - VUOverflowHack # Fixes SPS.
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-54349:
   name: "Superman Returns"
   region: "PAL-I"
   gameFixes:
     - VUOverflowHack # Fixes SPS.
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-54350:
   name: "Superman Returns"
   region: "PAL-G"
   gameFixes:
     - VUOverflowHack # Fixes SPS.
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-54351:
   name: "Superman Returns"
   region: "PAL-S"
   gameFixes:
     - VUOverflowHack # Fixes SPS.
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-54354:
   name: "Final Fantasy XII"
   region: "PAL-E"
@@ -24448,27 +25559,30 @@ SLES-54374:
   clampModes:
     vuClampMode: 3 # Fixes SPS.
 SLES-54376:
-  name: "Barnyard"
+  name: "Nickelodeon Barnyard"
   region: "PAL-E"
   gsHWFixes:
     halfPixelOffset: 2 # Fix text and post blur.
     mipmap: 2 # Base mip level isn't always used.
+    trilinearFiltering: 1
     autoFlush: 2 # Needed for recursive mipmap rendering.
     getSkipCount: "GSC_BlueTongueGames" # Render mipmaps on the CPU.
 SLES-54377:
-  name: "Barnyard"
+  name: "Nick - Der tierisch verrückte Bauernhof"
   region: "PAL-G"
   gsHWFixes:
     halfPixelOffset: 2 # Fix text and post blur.
     mipmap: 2 # Base mip level isn't always used.
+    trilinearFiltering: 1
     autoFlush: 2 # Needed for recursive mipmap rendering.
     getSkipCount: "GSC_BlueTongueGames" # Render mipmaps on the CPU.
 SLES-54378:
-  name: "Barnyard"
+  name: "Nickelodeon Barnyard"
   region: "PAL-M4"
   gsHWFixes:
     halfPixelOffset: 2 # Fix text and post blur.
     mipmap: 2 # Base mip level isn't always used.
+    trilinearFiltering: 1
     autoFlush: 2 # Needed for recursive mipmap rendering.
     getSkipCount: "GSC_BlueTongueGames" # Render mipmaps on the CPU.
 SLES-54379:
@@ -24509,7 +25623,7 @@ SLES-54385:
     roundSprite: 1 # Fixes font artifacts for health and other sprites.
     texturePreloading: 0 # Improves performance and prevents it disabling itself regardless.
 SLES-54388:
-  name: "Kim Possible - What's the Switch"
+  name: "Disney's Kim Possible - What's the Switch"
   region: "PAL-M3"
   speedHacks:
     instantVU1: 0 # Fixes extreme EE and VU usage.
@@ -24519,12 +25633,20 @@ SLES-54389:
   compat: 5
   roundModes:
     vu1RoundMode: 0 # Fixes invalid VU size spam and likely SPS.
+  gsHWFixes:
+    autoFlush: 1 # Fixes black line down the side of the screen and player shadow.
+    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-54390:
   name: "Tony Hawk's Project 8"
   region: "PAL-M4"
   compat: 5
   roundModes:
     vu1RoundMode: 0 # Fixes invalid VU size spam and likely SPS.
+  gsHWFixes:
+    autoFlush: 1 # Fixes black line down the side of the screen and player shadow.
+    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-54393:
   name: "Pippa Funnell - Take the Reins"
   region: "PAL-M3"
@@ -24786,6 +25908,8 @@ SLES-54483:
     recommendedBlendingLevel: 4 # Fixes car reflections.
     mergeSprite: 1 # Fixes bluriness.
     halfPixelOffset: 4 # Fixes bluriness.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-54485:
   name: "Cinderella"
   region: "PAL-M3"
@@ -24815,11 +25939,15 @@ SLES-54492:
   region: "PAL-E"
   clampModes:
     eeClampMode: 3 # Fixes game hang after opening intro.
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes depth line.
 SLES-54493:
   name: "Need for Speed - Carbon [Collector's Edition]"
   region: "PAL-F-G"
   clampModes:
     eeClampMode: 3 # Fixes game hang after opening intro.
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes depth line.
 SLES-54494:
   name: "Little Britain - The Video Game"
   region: "PAL-E"
@@ -24832,12 +25960,21 @@ SLES-54510:
 SLES-54511:
   name: "UEFA Champions League 2006-2007"
   region: "PAL-E"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-54512:
   name: "UEFA Champions League 2006-2007"
   region: "PAL-F-G"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-54513:
   name: "UEFA Champions League 2006-2007"
   region: "PAL-I-S"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-54516:
   name: "Thrillville"
   region: "PAL-F-G"
@@ -24882,7 +26019,7 @@ SLES-54522:
     autoFlush: 2 # Fixes texture corruptions.
     getSkipCount: "GSC_BlueTongueGames" # Render mipmaps on the CPU.
 SLES-54527:
-  name: "Flushed Away"
+  name: "DreamWorks & Aardman Flushed Away"
   region: "PAL-M5"
 SLES-54532:
   name: "Home Alone"
@@ -24955,7 +26092,7 @@ SLES-54551:
   name: "Premier Manager 2006-2007"
   region: "PAL-G"
 SLES-54553:
-  name: "Shrek - Smash 'n Crash Racing"
+  name: "DreamWorks Shrek - Smash n' Crash Racing"
   region: "PAL-M5"
 SLES-54554:
   name: "Star Trek - Encounters"
@@ -25048,6 +26185,9 @@ SLES-54587:
 SLES-54588:
   name: "Brunswick Pro Bowling"
   region: "PAL-E"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves alley textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-54589:
   name: "Global Defence Force Tactics"
   region: "PAL-E"
@@ -25116,12 +26256,12 @@ SLES-54622:
   region: "PAL-M5"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 1 # Fixes misaligned effect when in-game Trails option is turned on.
+    halfPixelOffset: 2 # Fixes misaligned effect when in-game Trails option is turned on.
 SLES-54623:
   name: "Grand Theft Auto - Vice City Stories"
   region: "PAL-G"
   gsHWFixes:
-    halfPixelOffset: 1 # Fixes misaligned effect when in-game Trails option is turned on.
+    halfPixelOffset: 2 # Fixes misaligned effect when in-game Trails option is turned on.
 SLES-54624:
   name: "Samurai Warriors 2 - Empires"
   region: "PAL-E"
@@ -25249,6 +26389,7 @@ SLES-54658:
   compat: 5
   gsHWFixes:
     recommendedBlendingLevel: 2 # Fixes player shadow definition and color banding.
+    halfPixelOffset: 2 # Fixes misaligned bloom effects.
     autoFlush: 1 # Fixes player shadow.
   patches:
     87109051:
@@ -25264,6 +26405,7 @@ SLES-54659:
   compat: 5
   gsHWFixes:
     recommendedBlendingLevel: 2 # Fixes player shadow definition and color banding.
+    halfPixelOffset: 2 # Fixes misaligned bloom effects.
     autoFlush: 1 # Fixes player shadow.
   patches:
     DAF2145C:
@@ -25342,6 +26484,8 @@ SLES-54683:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes lighting misalignment.
     mergeSprite: 1 # Removes occasional vertical lines.
+    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-54684:
   name: "Peter Pan"
   region: "PAL-M3"
@@ -25641,6 +26785,8 @@ SLES-54788:
   region: "PAL-E"
   gsHWFixes:
     textureInsideRT: 1 # Fixes shadows.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-54789:
   name: "Beta Bloc"
   region: "PAL-E"
@@ -25691,9 +26837,15 @@ SLES-54809:
 SLES-54810:
   name: "Rugby 08"
   region: "PAL-E"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-54811:
   name: "Rugby 08"
   region: "PAL-I"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-54812:
   name: "Madden NFL 08"
   region: "PAL-E"
@@ -25982,6 +27134,8 @@ SLES-54903:
   region: "PAL-M13"
   gsHWFixes:
     halfPixelOffset: 4 # Removes horizontal and vertical lines on the ground, trees and the sky.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-54904:
   name: "The Simpsons Game"
   name-sort: "Simpsons Game, The"
@@ -26092,7 +27246,8 @@ SLES-54945:
   region: "PAL-M6"
   compat: 5
   gsHWFixes:
-    cpuCLUTRender: 1 # Reduces the bloomy blur of characters.
+    halfPixelOffset: 2 # Fixes character outlines and minor bloom.
+    cpuCLUTRender: 1 # Aligns character bloom and some stage bloom.
     beforeDraw: "OI_DBZBTGames"
 SLES-54946:
   name: "Sega Superstars Tennis"
@@ -26101,6 +27256,8 @@ SLES-54946:
     - VUSyncHack # Fixes SPS.
   gsHWFixes:
     halfPixelOffset: 1 # Fixes post bloom alignment.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-54947:
   name: "Dogz"
   region: "PAL-M6"
@@ -26167,6 +27324,9 @@ SLES-54962:
     vu1RoundMode: 0 # Crashes without.
   gsHWFixes:
     textureInsideRT: 1 # Crowd textures.
+    autoFlush: 1 # Fixes bloom intensity.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-54963:
   name: "Tony Hawk's Proving Ground"
   region: "PAL-E"
@@ -26200,6 +27360,9 @@ SLES-54974:
     vu1RoundMode: 0 # Crashes without.
   gsHWFixes:
     textureInsideRT: 1 # Crowd textures.
+    autoFlush: 1 # Fixes bloom intensity.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-54975:
   name: "George Of The Jungle"
   region: "PAL-E"
@@ -26276,26 +27439,41 @@ SLES-54997:
   compat: 5
   gameFixes:
     - EETimingHack # Flickery textures.
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-54998:
-  name: "Mercenaries 2 - World in Flames"
+  name: "Mercenaries 2 - L'enfer des Favelas"
   region: "PAL-F"
   gameFixes:
     - EETimingHack # Flickery textures.
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-54999:
   name: "Mercenaries 2 - Inferno di Fuoco"
   region: "PAL-I"
   gameFixes:
     - EETimingHack # Flickery textures.
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-55000:
   name: "Mercenaries 2 - World in Flames"
   region: "PAL-G"
   gameFixes:
     - EETimingHack # Flickery textures.
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-55001:
   name: "Mercenaries 2 - World in Flames"
   region: "PAL-S"
   gameFixes:
     - EETimingHack # Flickery textures.
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-55002:
   name: "Need for Speed - ProStreet"
   region: "PAL-E"
@@ -26327,6 +27505,8 @@ SLES-55007:
   compat: 4
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes skin colour.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-55008:
   name: "Riding Star 3"
   region: "PAL-M4"
@@ -26371,7 +27551,6 @@ SLES-55016:
   name: "DreamWorks Bee Movie Game"
   region: "PAL-M6"
   gsHWFixes:
-    recommendedBlendingLevel: 3 # Fixes hive color.
     halfPixelOffset: 4 # Fixes bloom on sunlight.
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
@@ -26390,6 +27569,8 @@ SLES-55019:
   name: "Ratchet & Clank - Size Matters"
   region: "PAL-M13"
   gsHWFixes:
+    recommendedBlendingLevel: 4 # Fixes vendor and other bloom.
+    autoFlush: 2 # Fixes missing bloom and shadow definition.
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
 SLES-55020:
@@ -26465,6 +27646,8 @@ SLES-55031:
   region: "PAL-F"
   gsHWFixes:
     cpuSpriteRenderBW: 1 # Fixes textures.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-55032:
   name: "Off Road"
   region: "PAL-M5"
@@ -26590,6 +27773,9 @@ SLES-55102:
   name: "The History Channel - Battle for the Pacific"
   name-sort: "History Channel, The - Battle for the Pacific"
   region: "PAL-E"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-55103:
   name: "Cabela's Big Game Hunter 2008"
   region: "PAL-E"
@@ -26822,6 +28008,9 @@ SLES-55191:
     vu1RoundMode: 0 # Fixes VU size spam and potential graphical issues with GH3 engine.
   gsHWFixes:
     textureInsideRT: 1 # Crowd textures.
+    autoFlush: 1 # Fixes bloom intensity.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-55192:
   name: "Steam Express"
   region: "PAL-M5"
@@ -26872,6 +28061,8 @@ SLES-55198:
   name: "Iron Man"
   region: "PAL-M5"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes misaligned bloom.
 SLES-55199:
   name: "NASCAR 09"
   region: "PAL-M5"
@@ -26885,6 +28076,9 @@ SLES-55200:
     vu1RoundMode: 0 # Fixes VU size spam and potential graphical issues with GH3 engine.
   gsHWFixes:
     textureInsideRT: 1 # Crowd textures.
+    autoFlush: 1 # Fixes bloom intensity.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-55201:
   name: "Riding Star"
   region: "PAL-M4"
@@ -26974,16 +28168,22 @@ SLES-55234:
   region: "PAL-SW"
   gsHWFixes:
     cpuSpriteRenderBW: 1 # Fixes textures.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-55235:
   name: "DreamWorks Kung Fu Panda"
   region: "PAL-I"
   gsHWFixes:
     cpuSpriteRenderBW: 1 # Fixes textures.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-55236:
   name: "DreamWorks Kung Fu Panda"
   region: "PAL-G-S"
   gsHWFixes:
     cpuSpriteRenderBW: 1 # Fixes textures.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-55237:
   name: "Naruto - Ultimate Ninja 3"
   region: "PAL-M5"
@@ -27178,7 +28378,7 @@ SLES-55328:
   name-sort: "Millennium European Paintball Series, The - Championship Paintball 2009"
   region: "PAL-E"
 SLES-55329:
-  name: "Shrek's Carnival Craze"
+  name: "DreamWorks Shrek's Carnival Craze - Party Games"
   region: "PAL-M3"
 SLES-55330:
   name: "Secret Service"
@@ -27493,6 +28693,9 @@ SLES-55442:
   compat: 5
   gsHWFixes:
     textureInsideRT: 1 # Needed for post processing effects.
+    autoFlush: 1 # Fixes missing blur layer.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-55443:
   name: "Mana Khemia - Alchemists of Al-Revis"
   region: "PAL-E"
@@ -27541,7 +28744,7 @@ SLES-55459:
   name: "Jelly Belly - Ballistic Beans"
   region: "PAL-M5"
 SLES-55460:
-  name: "Trivial Pursuit"
+  name: "DreamWorks Shrek's Carnival Craze - Party Games"
   region: "PAL-M3"
 SLES-55461:
   name: "Dance Party Pop Hits"
@@ -27689,6 +28892,9 @@ SLES-55518:
   region: "PAL-A"
   gsHWFixes:
     preloadFrameData: 1 # Fixes icons.
+    autoFlush: 1 # Fixes bloom intensity.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
   roundModes:
     vu1RoundMode: 0 # Fixes VU size spam and potential graphical issues with GH3 engine.
 SLES-55520:
@@ -27886,6 +29092,8 @@ SLES-55610:
   region: "PAL-SC"
   gsHWFixes:
     halfPixelOffset: 1 # Reduces the ghosting effect.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-55622:
   name: "Disney/Pixar Toy Story 3"
   region: "PAL-M6"
@@ -28033,6 +29241,8 @@ SLES-82009:
     roundSprite: 2 # Fixes font artifacts.
     autoFlush: 1 # Fixes depth of field blur.
     recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLES-82010:
   name: "Metal Gear Solid 2, Document of"
   region: "PAL-E"
@@ -28154,32 +29364,14 @@ SLES-82032:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
-SLES-82034:
-  name: "Xenosaga Episode II [Disc 1 of 2]"
-  region: "PAL-M3"
-  gsHWFixes:
-    autoFlush: 2 # Fixes shadows in cutscenes.
-    halfPixelOffset: 2 # Fixes lighting misalignment and shadows.
-    roundSprite: 2 # Fixes font artifacts.
-  memcardFilters:
-    - "SLES-82034"
-    - "SCES-82034"
-SLES-82035:
-  name: "Xenosaga Episode II [Disc 2 of 2]"
-  region: "PAL-M3"
-  gsHWFixes:
-    autoFlush: 2 # Fixes shadows in cutscenes.
-    halfPixelOffset: 2 # Fixes lighting misalignment and shadows.
-    roundSprite: 2 # Fixes font artifacts.
-  memcardFilters:
-    - "SLES-82034"
-    - "SCES-82034"
 SLES-82036:
   name: "Armored Core - Nexus [Disc 1]"
   region: "PAL-M5"
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
     recommendedBlendingLevel: 3 # Fixes level brightness.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
   memcardFilters:
     - "SLES-82036"
     - "SLES-82037"
@@ -28189,6 +29381,8 @@ SLES-82037:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
     recommendedBlendingLevel: 3 # Fixes level brightness.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
   memcardFilters:
     - "SLES-82036"
     - "SLES-82037"
@@ -28638,6 +29832,7 @@ SLKA-25038:
     alignSprite: 1 # Fixes vertical lines.
     roundSprite: 2 # Fixes font artifacts.
     mergeSprite: 1 # Fixes flame-like bleeding.
+    autoFlush: 1 # Fixes light bloom intensity.
 SLKA-25039:
   name: "Burnout 2 - Point of Impact"
   region: "NTSC-K"
@@ -28646,6 +29841,8 @@ SLKA-25039:
     autoFlush: 1 # Fixes bloom and sun rendering in front of everything.
     halfPixelOffset: 2 # Aligns bloom effect a little bit better when upscaled.
     bilinearUpscale: 2 # Reduces color banding of the sun glare.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
   roundModes:
     vu1RoundMode: 1 # Bright lights in cars.
 SLKA-25041:
@@ -28736,7 +29933,7 @@ SLKA-25063:
     alignSprite: 1 # Fixes vertical lines.
     wildArmsHack: 1 # De-blurs the 3D image.
 SLKA-25064:
-  name: "Tenchu 3 Wrath of Heaven"
+  name: "Tenchu - Wrath of Heaven"
   region: "NTSC-K"
   compat: 5
 SLKA-25065:
@@ -28772,6 +29969,8 @@ SLKA-25073:
   region: "NTSC-K"
   gsHWFixes:
     autoFlush: 2 # Fixes lava effect.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLKA-25076:
   name: "Jin Yeosin Jeonsaeng III - Nocturne"
   region: "NTSC-K"
@@ -28787,6 +29986,8 @@ SLKA-25078:
   name: "Rayman 3 - Hoodlum Havoc"
   region: "NTSC-K"
   compat: 5
+  gsHWFixes:
+    autoFlush: 1 # Fixes missing blur layer on reflections and surfaces.
 SLKA-25080:
   name: ".hack//감염확대 Vol.1"
   name-sort: ".hack Infection Part 1"
@@ -28794,6 +29995,8 @@ SLKA-25080:
   region: "NTSC-K"
   gsHWFixes:
     halfPixelOffset: 1 # Sharpens world in far distances.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLKA-25081:
   name: "SD Gundam G Generation Neo"
   region: "NTSC-K"
@@ -28887,6 +30090,9 @@ SLKA-25100:
   name: "Breath of Fire V - Dragon Quarter"
   region: "NTSC-K"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 4 # Aligns HUD and HUD bloom to match software.
+    roundSprite: 1 # Helps fix some lines and lines in text.
 SLKA-25102:
   name: "Batman - Rise of Sin Tzu"
   region: "NTSC-K"
@@ -28955,6 +30161,7 @@ SLKA-25120:
   region: "NTSC-K"
   gsHWFixes:
     autoFlush: 2 # Reduces post-processing misalignment.
+    halfPixelOffset: 4 # Reduces post-processing misalignment.
 SLKA-25121:
   name: "Vexx"
   region: "NTSC-K"
@@ -29001,6 +30208,8 @@ SLKA-25135:
   region: "NTSC-K"
   compat: 5
   gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
     getSkipCount: "GSC_Kunoichi"
 SLKA-25136:
   name: "Need for Speed - Underground"
@@ -29016,6 +30225,8 @@ SLKA-25137:
   region: "NTSC-K"
   gsHWFixes:
     halfPixelOffset: 1 # Fixes vertical lines, font and others.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLKA-25138:
   name: ".hack//악성변이 Vol.2"
   name-sort: ".hack Mutation Part 2"
@@ -29177,7 +30388,8 @@ SLKA-25180:
   region: "NTSC-K"
   gsHWFixes:
     preloadFrameData: 1 # Fixes missing loading screens.
-    mergeSprite: 1 # Fixes misaligned bloom on light sources.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLKA-25181:
   name: "Energy Airforce Aim Strike"
   region: "NTSC-K"
@@ -29239,6 +30451,9 @@ SLKA-25198:
   name: "Tenchu Kurenai"
   region: "NTSC-K"
   compat: 5
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLKA-25199:
   name: "Geomho 3" # Kengo 3
   region: "NTSC-K"
@@ -29258,6 +30473,8 @@ SLKA-25201:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
     recommendedBlendingLevel: 3 # Fixes level brightness.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
   memcardFilters:
     - "SLKA-25201"
     - "SLKA-25202"
@@ -29267,6 +30484,8 @@ SLKA-25202:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
     recommendedBlendingLevel: 3 # Fixes level brightness.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
   memcardFilters:
     - "SLKA-25201"
     - "SLKA-25202"
@@ -29356,6 +30575,8 @@ SLKA-25218:
   gsHWFixes:
     texturePreloading: 1 # Performs much better with partial preload.
     autoFlush: 1 # Fixes bloom rendering.
+    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
+    trilinearFiltering: 1
   roundModes:
     vu1RoundMode: 0 # Fixes missing light cones curtains and certain effects.
 SLKA-25219:
@@ -29394,9 +30615,11 @@ SLKA-25225:
   compat: 5
   gsHWFixes:
     minimumBlendingLevel: 2 # Fixes dark font to more bright like software mode.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLKA-25226:
-  name: "The Incredibles"
-  name-sort: "Incredibles, The"
+  name: "Disney/Pixar The Incredibles"
+  name-sort: "Disney/Pixar Incredibles, The"
   region: "NTSC-K"
   gsHWFixes:
     mipmap: 2 # Mipmap + trilinear, improves the street's textures to match sw renderer.
@@ -29435,6 +30658,8 @@ SLKA-25237:
   region: "NTSC-K"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLKA-25240:
   name: "WWE SmackDown! Shut Your Mouth"
   region: "NTSC-K"
@@ -29454,6 +30679,8 @@ SLKA-25243:
     halfPixelOffset: 2 # Fixes misaligned blur.
     cpuSpriteRenderBW: 2 # Fixes black spots appearing on some surfaces and massively reduces RP TC and TU count.
     cpuSpriteRenderLevel: 2 # Needed for above.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLKA-25244:
   name: "WWE SmackDown! vs. Raw"
   region: "NTSC-K"
@@ -29497,6 +30724,8 @@ SLKA-25252:
   gsHWFixes:
     halfPixelOffset: 1 # Reduces ghosting.
     roundSprite: 1 # Reduces ghosting even more.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLKA-25254:
   name: "Digimon Rumble Arena 2"
   region: "NTSC-K"
@@ -29556,6 +30785,8 @@ SLKA-25270:
     halfPixelOffset: 1 # Fixes misaligned blur.
     cpuSpriteRenderBW: 1 # Fixes broken shadow caused by HPO 1.
     cpuSpriteRenderLevel: 2 # Needed for above.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLKA-25271:
   name: "Harry Potter and the Order of the Phoenix"
   region: "NTSC-K"
@@ -29631,11 +30862,18 @@ SLKA-25288:
 SLKA-25289:
   name: "Jin Samguk Mussang 4"
   region: "NTSC-K"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLKA-25290:
   name: "Super Monkey Ball Deluxe"
   region: "NTSC-K"
   roundModes:
     eeRoundMode: 1 # Fixes object balls never stopping in the Monkey Billiards DX minigame.
+  gsHWFixes:
+    recommendedBlendingLevel: 4 # Fixes text and foliage color.
+    mipmap: 2 # Mipmap + trilinear, improves stage textures to match sw renderer.
+    trilinearFiltering: 1
 SLKA-25291:
   name: "Chains of Power"
   region: "NTSC-K"
@@ -29756,8 +30994,11 @@ SLKA-25318:
   name: "WWE SmackDown! vs. RAW 2006"
   region: "NTSC-K"
 SLKA-25319:
-  name: "Spongebob SquarePants - Lights, Camera, PANTS"
+  name: "보글보글 스폰지밥 - 레디, 액션!"
   region: "NTSC-K"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLKA-25320:
   name: "Ikusa Gami"
   region: "NTSC-K"
@@ -29765,14 +31006,21 @@ SLKA-25320:
   gameFixes:
     - VIF1StallHack # Fixes black screen on boot.
   gsHWFixes:
+    recommendedBlendingLevel: 2
     autoFlush: 2 # Fixes missing bloom effects.
     halfPixelOffset: 2 # Fixes misaligned lighting and bloom.
 SLKA-25321:
   name: "K.League - Winning Eleven 9 - Asia Championship"
   region: "NTSC-K"
 SLKA-25322:
-  name: "Guilty Gear XX - Slash"
+  name: "187 - 라이드 오어 다이"
   region: "NTSC-K"
+  gsHWFixes:
+    recommendedBlendingLevel: 4 # Improves car color.
+    autoFlush: 1 # Softens bloom on objects and cars.
+    halfPixelOffset: 4 # Fixes misaligned bloom on objects and cars.
+    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
+    trilinearFiltering: 1
 SLKA-25323:
   name: "FIFA '06"
   region: "NTSC-K"
@@ -29835,6 +31083,8 @@ SLKA-25334:
     halfPixelOffset: 2 # Fixes blurriness.
     cpuCLUTRender: 1 # Final colour adjustment LUT.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLKA-25335:
   name: "Shadow the Hedgehog"
   region: "NTSC-K"
@@ -29875,6 +31125,8 @@ SLKA-25341:
     cpuCLUTRender: 1 # Fixes the rest of the bad textures.
     roundSprite: 1 # Reduces misaligned bloom.
     mergeSprite: 1 # Removes bloom explosion around electrical lights and other light sources such as moon/sun.
+    mipmap: 2 # Mipmap + trilinear, improves road textures to match sw renderer.
+    trilinearFiltering: 1
 SLKA-25342:
   name: "Ryu ga Gotoku"
   region: "NTSC-K"
@@ -29906,8 +31158,8 @@ SLKA-25346:
   name: "Prince of Persia - The Two Thrones"
   region: "NTSC-K"
   gsHWFixes:
-    autoFlush: 2 # Reduces post-processing misalignment.
-    halfPixelOffset: 1 # Reduces post-processing misalignment.
+    autoFlush: 1 # Reduces post-processing misalignment.
+    halfPixelOffset: 4 # Reduces post-processing misalignment.
 SLKA-25349:
   name: "Jacked"
   region: "NTSC-K"
@@ -29976,10 +31228,11 @@ SLKA-25360:
   name: "Samurai Champloo"
   region: "NTSC-K"
 SLKA-25361:
-  name: "Keroro Gunsou MeroMero Battle Royale Z"
+  name: "Keroro Gunsou - Mero Mero Battle Royale Z"
   region: "NTSC-K"
   gsHWFixes:
     preloadFrameData: 1 # Fixes invisible text.
+    autoFlush: 1
 SLKA-25362:
   name: "Sega Rally 2006"
   region: "NTSC-K"
@@ -30007,6 +31260,9 @@ SLKA-25367:
   region: "NTSC-K"
   gameFixes:
     - VUOverflowHack # Fixes SPS.
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLKA-25368:
   name: "Full Spectrum Warrior - Ten Hammers"
   region: "NTSC-K"
@@ -30051,9 +31307,11 @@ SLKA-25377:
   name: "OutRun 2006 - Coast 2 Coast"
   region: "NTSC-K"
   gsHWFixes:
-    autoFlush: 2 # Reduces post-processing misalignment.
+    autoFlush: 1 # Reduces post-processing misalignment.
     halfPixelOffset: 2 # Fixes bloom misalignment still a bit misaligned.
     roundSprite: 1 # Fixes bloom misalignment still a bit misaligned + font artifacts.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLKA-25378:
   name: "FIFA World Cup Germany 2006"
   region: "NTSC-K"
@@ -30070,6 +31328,10 @@ SLKA-25382:
   name: "The Chronicles of Narnia - The Lion Witch and the Wardrobe"
   name-sort: "Chronicles of Narnia, The - The Lion, The Witch and the Wardrobe"
   region: "NTSC-K"
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes lighting misalignment.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLKA-25384:
   name: "Blazing Souls"
   region: "NTSC-K"
@@ -30120,6 +31382,7 @@ SLKA-25397:
   region: "NTSC-K"
   compat: 5
   gsHWFixes:
+    halfPixelOffset: 2 # Fixes character outlines and minor bloom.
     beforeDraw: "OI_DBZBTGames"
 SLKA-25398:
   name: "Jeonguk Mussang 2 - Empires"
@@ -30129,6 +31392,8 @@ SLKA-25399:
   region: "NTSC-K"
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned textures.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLKA-25401:
   name: "FlatOut 2"
   region: "NTSC-K"
@@ -30159,6 +31424,8 @@ SLKA-25407:
   region: "NTSC-K"
   compat: 5
   gsHWFixes:
+    halfPixelOffset: 2 # Fixes character outlines and minor bloom.
+    cpuCLUTRender: 1 # Aligns character bloom and some stage bloom.
     beforeDraw: "OI_DBZBTGames"
 SLKA-25408:
   name: "FIFA '08"
@@ -30173,6 +31440,8 @@ SLKA-25410:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLKA-25411:
   name: "Need for Speed - ProStreet"
   region: "NTSC-K"
@@ -30191,6 +31460,9 @@ SLKA-25414:
     vu1RoundMode: 0 # Crashes without.
   gsHWFixes:
     textureInsideRT: 1 # Crowd textures.
+    autoFlush: 1 # Fixes bloom intensity.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLKA-25417:
   name: "Jin Samguk Mussang 4 - Empires"
   region: "NTSC-K"
@@ -30405,6 +31677,8 @@ SLKA-35001:
     roundSprite: 2 # Fixes font artifacts.
     autoFlush: 1 # Fixes depth of field blur.
     recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLKA-35003:
   name: "Sakura Taisen - Atsuki Chishioni"
   region: "NTSC-K"
@@ -30454,6 +31728,8 @@ SLPM-55003:
     halfPixelOffset: 2 # Fixes blurriness.
     cpuCLUTRender: 1 # Final colour adjustment LUT.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-55004:
   name: "Burnout Revenge (EASY 1980)"
   region: "NTSC-J"
@@ -30572,6 +31848,8 @@ SLPM-55034:
     autoFlush: 1 # Post-processing.
     halfPixelOffset: 2 # Offset post-processing.
     texturePreloading: 1 # Improves performance.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
     getSkipCount: "GSC_Battlefield2" # Depth clear.
     beforeDraw: "OI_Battlefield2" # Framebuffer copy, fixes rendering for bottom part of screen.
 SLPM-55035:
@@ -30600,11 +31878,15 @@ SLPM-55037:
     halfPixelOffset: 2 # Fixes misaligned blur.
     cpuSpriteRenderBW: 2 # Fixes black spots appearing on some surfaces and massively reduces RP TC and TU count.
     cpuSpriteRenderLevel: 2 # Needed for above.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-55038:
   name: "Grand Theft Auto - Liberty City Stories [Best Price]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 1 # Removes blur due to misaligned fullscreen effect.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-55039:
   name: "Soukoku no Kusabi - Hiiro no Kakera 3 [Limited Edition]"
   region: "NTSC-J"
@@ -30677,6 +31959,8 @@ SLPM-55061:
   region: "NTSC-J"
   clampModes:
     eeClampMode: 3 # Fixes game hang after opening intro.
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes depth line.
 SLPM-55062:
   name: 実況パワフルメジャーリーグ3
   name-sort: じっきょうぱわふるめじゃーりーぐ3
@@ -30725,6 +32009,8 @@ SLPM-55076:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes lighting misalignment.
     mergeSprite: 1 # Removes occasional vertical lines.
+    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-55077:
   name: SSX3 [EASY 1980]
   name-sort: SSX3 [EASY 1980]
@@ -30746,6 +32032,7 @@ SLPM-55080:
   clampModes:
     eeClampMode: 3 # Characters are visible in-game.
   gsHWFixes:
+    recommendedBlendingLevel: 2
     texturePreloading: 1 # Performs better with partial preload because it is slow on locations outside gameplay foremost.
     mergeSprite: 1 # Fixes misaligned white lines.
     PCRTCOverscan: 1 # Fixes missing HUD.
@@ -30912,6 +32199,9 @@ SLPM-55127:
 SLPM-55128:
   name: "Rugby 08"
   region: "NTSC-J"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-55130:
   name: "Pro Yakyuu Spirits 5 - Kanzenban"
   region: "NTSC-J"
@@ -30932,7 +32222,7 @@ SLPM-55135:
   name: "Grand Theft Auto - Vice City Stories [Best Price]"
   region: "NTSC-J"
   gsHWFixes:
-    halfPixelOffset: 1 # Fixes misaligned effect when in-game Trails option is turned on.
+    halfPixelOffset: 2 # Fixes misaligned effect when in-game Trails option is turned on.
 SLPM-55136:
   name: "Clear - Atarashii Kaze no Fuku Oka de"
   region: "NTSC-J"
@@ -31506,6 +32796,7 @@ SLPM-60119:
   name: "Cross Fire [Trial]"
   region: "NTSC-J"
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes character models.
     mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
     trilinearFiltering: 1
 SLPM-60120:
@@ -31870,6 +33161,8 @@ SLPM-60248:
   region: "NTSC-J"
   gsHWFixes:
     minimumBlendingLevel: 2 # Fixes dark font to more bright like software mode.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-60250:
   name: "Need for Speed - Underground 2 [Trial]"
   region: "NTSC-J"
@@ -31910,6 +33203,10 @@ SLPM-60257:
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes FMV lines.
+    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
+    trilinearFiltering: 1
+    cpuSpriteRenderBW: 2 # Prevents Death By VRAM explosion.
+    cpuSpriteRenderLevel: 2 # Needed for above.
     getSkipCount: "GSC_DeathByDegreesTekkenNinaWilliams"
 SLPM-60258:
   name: "The Typing of the Dead - Zombie Panic"
@@ -31972,6 +33269,8 @@ SLPM-60272:
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
     textureInsideRT: 1 # Fixes corruption.
+    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
+    trilinearFiltering: 1
     getSkipCount: "GSC_UrbanReign"
 SLPM-60273:
   name: "Zettai Zetsumei Toshi 2 - Itetsuita Kioku-tachi [Trial B]"
@@ -32099,6 +33398,8 @@ SLPM-61030:
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 2 # Fixes text box opacity.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-61031:
   name: "Dengeki PS2 PlayStation D52"
   region: "NTSC-J"
@@ -32131,6 +33432,7 @@ SLPM-61039:
     alignSprite: 1 # Fixes vertical lines.
     roundSprite: 2 # Fixes font artifacts.
     mergeSprite: 1 # Fixes flame-like bleeding.
+    autoFlush: 1 # Fixes light bloom intensity.
 SLPM-61041:
   name: "Virtua Fighter 4 - Evolution"
   region: "NTSC-J"
@@ -32180,6 +33482,10 @@ SLPM-61058:
 SLPM-61059:
   name: "Kunoichi"
   region: "NTSC-J"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
+    getSkipCount: "GSC_Kunoichi"
 SLPM-61060:
   name: "Busin 0 - Wizardry Alternative Neo"
   region: "NTSC-J"
@@ -32250,6 +33556,8 @@ SLPM-61090:
   gsHWFixes:
     wildArmsHack: 1 # Fixes blurriness.
     mergeSprite: 1 # Fixes misaligned lights.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-61091:
   name: "Berserk - Millennium Falcon-hen - Seima Senki no Shou"
   region: "NTSC-J"
@@ -32367,12 +33675,16 @@ SLPM-61118:
   gsHWFixes:
     halfPixelOffset: 2 # Corrects shadow alignment and reduces blurriness.
     recommendedBlendingLevel: 3 # Fixes level and map menu brightness.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-61119:
   name: "Armored Core - Last Raven [Trial]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Corrects shadow alignment and reduces blurriness.
     recommendedBlendingLevel: 3 # Fixes level and map menu brightness.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-61120:
   name: "Drag-on Dragoon 2 - Fuuin no Aka, Haitoku no Kuro [Trial Version]"
   region: "NTSC-J"
@@ -32410,6 +33722,11 @@ SLPM-61126:
 SLPM-61127:
   name: "FlatOut [Trial]"
   region: "NTSC-J"
+  gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves car reflections.
+    autoFlush: 1
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-61129:
   name: "Famitsu PS2 Special Disc - Capcom Game Collection"
   region: "NTSC-J"
@@ -32419,6 +33736,7 @@ SLPM-61130:
   gameFixes:
     - VIF1StallHack # Fixes black screen on boot.
   gsHWFixes:
+    recommendedBlendingLevel: 2
     autoFlush: 2 # Fixes missing bloom effects.
     halfPixelOffset: 2 # Fixes misaligned lighting and bloom.
 SLPM-61131:
@@ -32430,6 +33748,7 @@ SLPM-61132:
   gameFixes:
     - VIF1StallHack # Fixes black screen on boot.
   gsHWFixes:
+    recommendedBlendingLevel: 2
     autoFlush: 2 # Fixes missing bloom effects.
     halfPixelOffset: 2 # Fixes misaligned lighting and bloom.
 SLPM-61133:
@@ -32457,7 +33776,9 @@ SLPM-61137:
   name: "Sega Rally 2006"
   region: "NTSC-J"
   gsHWFixes:
-    cpuCLUTRender: 1 # Fixes rainbow textures.
+    recommendedBlendingLevel: 3 # Improves car reflections.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-61138:
   name: "Akumajou Dracula - Yami no Juin"
   region: "NTSC-J"
@@ -32489,6 +33810,8 @@ SLPM-61147:
     halfPixelOffset: 2 # Fixes lighting misalignment and reduces ground shadows (probably texture cache issue).
     roundSprite: 2 # Fixes font artifacts.
     textureInsideRT: 1 # Fixes bad crystal surfaces.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-61148:
   name: "Growlanser V - Generations [Trial]"
   region: "NTSC-J"
@@ -32503,6 +33826,9 @@ SLPM-61150:
 SLPM-61152:
   name: "Dragon Ball Z - Sparking! Neo"
   region: "NTSC-J"
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes character outlines and minor bloom.
+    beforeDraw: "OI_DBZBTGames"
 SLPM-61153:
   name: "Dengeki PS2 PlayStation D92"
   region: "NTSC-J"
@@ -32548,6 +33874,9 @@ SLPM-61161:
 SLPM-61162:
   name: "Dragon Ball Z - Sparking! Meteor"
   region: "NTSC-J"
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes character outlines and minor bloom.
+    beforeDraw: "OI_DBZBTGames"
 SLPM-61163:
   name: "Seaman 2 - Pekin Genjin Ikusei Kit"
   region: "NTSC-J"
@@ -32636,6 +33965,9 @@ SLPM-62016:
 SLPM-62019:
   name: "Winning Post 4 Maximum"
   region: "NTSC-J"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-62020:
   name: "G1 Jockey 2"
   region: "NTSC-J"
@@ -32746,6 +34078,8 @@ SLPM-62043:
     - InstantDMAHack # Fixes broken half-bottom artifacts.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-62044:
   name: RCリベンジPro
   name-sort: RCりべんじPro
@@ -32999,6 +34333,9 @@ SLPM-62102:
   region: "NTSC-J"
   gameFixes:
     - EETimingHack # Fixes credits screen.
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves road and building textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-62103:
   name: "EX Okuman Chouja Game - The Money Battle"
   region: "NTSC-J"
@@ -33092,6 +34429,9 @@ SLPM-62123:
   name-sort: ういにんぐぽすと5
   name-en: "Winning Post 5"
   region: "NTSC-J"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-62124:
   name: READY 2 RUMBLE BOXING ROUND 2
   name-sort: READY 2 RUMBLE BOXING ROUND 2
@@ -33354,6 +34694,9 @@ SLPM-62186:
 SLPM-62188:
   name: "Crazy Bump's - Kattobi Car Battle!"
   region: "NTSC-J"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-62190:
   name: ハイヒートメジャーリーグベースボール 2003
   name-sort: はいひーとめじゃーりーぐべーすぼーる 2003
@@ -33680,6 +35023,8 @@ SLPM-62256:
   gsHWFixes:
     halfPixelOffset: 2 # Gets rid of fog line.
     roundSprite: 1 # Fixes lines in FMVs.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-62257:
   name: RALLY CHAMPIONSHIP
   name-sort: RALLY CHAMPIONSHIP
@@ -34797,10 +36142,11 @@ SLPM-62490:
   name-en: "Dragon Quest VIII [Premium Disc]"
   region: "NTSC-J"
   gsHWFixes:
-    autoFlush: 2 # Fixes missing bloom from surfaces like windows.
+    autoFlush: 1 # Fixes missing bloom from surfaces like windows.
     # halfPixelOffset: 1 # Aligns shadows properly, but causes grid lines to appear in sea travel.
     halfPixelOffset: 2 # Sharpens world in far distances, aligns some bloom better.
     roundSprite: 1 # Fixes font artifacts.
+    cpuSpriteRenderBW: 1 # Fixes broken fire sprites.
 SLPM-62491:
   name: ロックマン パワーバトルファイターズ
   name-sort: ろっくまん ぱわーばとるふぁいたーず
@@ -34950,6 +36296,9 @@ SLPM-62517:
   name-sort: ういにんぐぽすと5 [KOEI The Best]
   name-en: "Winning Post 5 [Koei The Best]"
   region: "NTSC-J"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-62518:
   name: 提督の決断IV [KOEI The Best]
   name-sort: ていとくのけつだん4 [KOEI The Best]
@@ -36221,6 +37570,7 @@ SLPM-64507:
   region: "NTSC-K"
   gsHWFixes:
     textureInsideRT: 2 # Fixes water reflection.
+    autoFlush: 1 # Fixes shading on objects and foliage.
 SLPM-64509:
   name: "Crash Bandicoot - Return of the Demon King [English Dub Edition]" # Wrath of Cortex
   region: "NTSC-K"
@@ -36785,6 +38135,8 @@ SLPM-65077:
     - InstantDMAHack # Fixes broken half-bottom artifacts.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
   memcardFilters:
     - "SLPM-65078"
     - "SLPM-65077"
@@ -36797,6 +38149,8 @@ SLPM-65078:
     - InstantDMAHack # Fixes broken half-bottom artifacts.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
   memcardFilters:
     - "SLPM-65078"
     - "SLPM-65077"
@@ -36923,6 +38277,8 @@ SLPM-65104:
     eeRoundMode: 0 # Fixes riders vanish into the floor.
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes missing lighting and makes snow not look like snow sludge.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-65105:
   name: 新コンバットチョロQ
   name-sort: しんこんばっとちょろQ
@@ -37095,6 +38451,8 @@ SLPM-65140:
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 2 # Fixes text box opacity.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-65141:
   name: 続せがれいじり 変珍たませがれ
   name-sort: ぞくせがれいじり へんちんたませがれ
@@ -37317,6 +38675,8 @@ SLPM-65191:
   gsHWFixes:
     preloadFrameData: 1 # Fixes fog and make lights on cars work again.
     autoFlush: 2 # Fixes sun luminosity and penetration of objects.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
   gameFixes:
     - EETimingHack # Fixes random graphical corruption.
 SLPM-65192:
@@ -37336,6 +38696,9 @@ SLPM-65196:
   name-sort: ぶれす おぶ ふぁいあ5 どらごんくぉーたー
   name-en: "Breath of Fire V - Dragon Quarter"
   region: "NTSC-J"
+  gsHWFixes:
+    halfPixelOffset: 4 # Aligns HUD and HUD bloom to match software.
+    roundSprite: 1 # Helps fix some lines and lines in text.
 SLPM-65197:
   name: 信長の野望 Online
   name-sort: のぶながのやぼう おんらいん
@@ -37471,6 +38834,8 @@ SLPM-65212:
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misaligned lighting and other effects.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
   clampModes:
     vuClampMode: 3 # Fixes white shiny weapons.
 SLPM-65213:
@@ -37602,6 +38967,8 @@ SLPM-65234:
   region: "NTSC-J"
   gsHWFixes:
     textureInsideRT: 1 # Fixes inside RT shuffling.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
     getSkipCount: "GSC_BigMuthaTruckers"
 SLPM-65235:
   name: ニュールーマニア ポロリ青春
@@ -37675,6 +39042,7 @@ SLPM-65245:
     alignSprite: 1 # Fixes vertical lines.
     roundSprite: 2 # Fixes font artifacts.
     mergeSprite: 1 # Fixes flame-like bleeding.
+    autoFlush: 1 # Fixes light bloom intensity.
 SLPM-65246:
   name: 街道バトル 〜日光・榛名・六甲・箱根〜
   name-sort: かいどうばとる にっこう はるな ろっこう はこね
@@ -37786,6 +39154,7 @@ SLPM-65266:
   clampModes:
     eeClampMode: 3 # Characters are visible in-game.
   gsHWFixes:
+    recommendedBlendingLevel: 2
     texturePreloading: 1 # Performs better with partial preload because it is slow on locations outside gameplay foremost.
     mergeSprite: 1 # Fixes misaligned white lines.
     PCRTCOverscan: 1 # Fixes missing HUD.
@@ -38557,7 +39926,8 @@ SLPM-65410:
     textureInsideRT: 1
     texturePreloading: 1 # Performs much better with partial preload.
     halfPixelOffset: 2 # Fixes outlines around characters.
-    getSkipCount: "GSC_GetawayGames"
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-65411:
   name: 鬼武者 無頼伝
   name-sort: おにむしゃ ぶらいでん
@@ -38572,6 +39942,9 @@ SLPM-65412:
   name-sort: かいじゅうだいげきせん War of the Monsters
   name-en: "War of the Monsters"
   region: "NTSC-J"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-65413:
   name: 鬼武者3
   name-sort: おにむしゃ3
@@ -38617,6 +39990,9 @@ SLPM-65419:
   region: "NTSC-J"
   roundModes:
     vu1RoundMode: 0 # Crashes without.
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-65420:
   name: ダビつく3 ダービー馬をつくろう!
   name-sort: だびつく3 だーびーばをつくろう!
@@ -38777,6 +40153,8 @@ SLPM-65447:
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
     getSkipCount: "GSC_Kunoichi"
 SLPM-65448:
   name: カンブリアンQTS 〜化石になっても〜
@@ -38957,6 +40335,8 @@ SLPM-65479:
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 1 # Fixes vertical lines, font and others.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-65480:
   name: michigan(ミシガン)
   name-sort: みしがん
@@ -39200,6 +40580,8 @@ SLPM-65526:
   region: "NTSC-J"
   gsHWFixes:
     minimumBlendingLevel: 2 # Fixes dark font to more bright like software mode.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-65527:
   name: FIFAトータルフットボール
   name-sort: FIFAとーたるふっとぼーる
@@ -39270,6 +40652,8 @@ SLPM-65539:
   gsHWFixes:
     preloadFrameData: 1 # Fixes fog and make lights on cars work again.
     autoFlush: 2 # Fixes sun luminosity and penetration of objects.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
   gameFixes:
     - EETimingHack # Fixes random graphical corruption.
 SLPM-65540:
@@ -39467,10 +40851,12 @@ SLPM-65580:
   name-sort: くらっしゅばんでぃくー ばくそう!にとろかーと
   name-en: "Crash Bandicoot - Bakuso! Nitro Kart"
   region: "NTSC-J"
+  gameFixes:
+    - BlitInternalFPSHack # Fixes internal FPS detection.
 SLPM-65581:
   name: ホーンテッドマンション
   name-sort: ほーんてっどまんしょん
-  name-en: "Haunted Mansion"
+  name-en: "Disney's The Haunted Mansion"
   region: "NTSC-J"
 SLPM-65582:
   name: Winning Post6 MAXIMUM 2004
@@ -39785,6 +41171,8 @@ SLPM-65637:
   name-en: "Rakugaki Oukoku 2 - Maoh jou no Tatakai"
   region: "NTSC-J"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 4 # Fixes distant offset blur.
 SLPM-65638:
   name: フルハウスキス
   name-sort: ふるはうすきす
@@ -39912,6 +41300,7 @@ SLPM-65663:
   name-en: "Zwei!!"
   region: "NTSC-J"
   gsHWFixes:
+    recommendedBlendingLevel: 2
     roundSprite: 1 # Fixes vertical lines.
 SLPM-65664:
   name: SuperLite 2000 恋愛アドベンチャー Memories Off Duet
@@ -40348,6 +41737,8 @@ SLPM-65739:
   gsHWFixes:
     wildArmsHack: 1 # Fixes blurriness.
     mergeSprite: 1 # Fixes misaligned lights.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-65740:
   name: Jリーグ ウイニングイレブン8 〜Asia Championship〜
   name-sort: Jりーぐ ういにんぐいれぶん8 〜Asia Championship〜
@@ -40452,6 +41843,8 @@ SLPM-65754:
     - InstantDMAHack # Fixes broken half-bottom artifacts.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-65755:
   name: サムライウエスタン 活劇侍道
   name-sort: さむらいうえすたん かつげきさむらいどう
@@ -40760,6 +42153,9 @@ SLPM-65805:
   name-sort: ごじらかいじゅうだいらんとう 〜ちきゅうさいしゅうけっせん〜
   name-en: "Gojira Monster Fighter"
   region: "NTSC-J"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-65806:
   name: VM JAPAN(ブイエムジャパン)
   name-sort: ぶいえむじゃぱん
@@ -40806,7 +42202,8 @@ SLPM-65815:
   region: "NTSC-J"
   gsHWFixes:
     preloadFrameData: 1 # Fixes missing loading screens.
-    mergeSprite: 1 # Fixes misaligned bloom on light sources.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-65816:
   name: 真・爆走デコトラ伝説 〜天下統一頂上決戦〜
   name-sort: しん・ばくそうでことらでんせつ てんかとういつちょうじょうけっせん
@@ -40986,6 +42383,8 @@ SLPM-65846:
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-65847:
   name: 空色の風琴 〜Remix〜 初回限定版
   name-sort: そらいろのおるがん Remix しょかいげんていばん
@@ -41202,10 +42601,11 @@ SLPM-65888:
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
-    autoFlush: 2 # Fixes missing bloom from surfaces like windows.
+    autoFlush: 1 # Fixes missing bloom from surfaces like windows.
     # halfPixelOffset: 1 # Aligns shadows properly, but causes grid lines to appear in sea travel.
     halfPixelOffset: 2 # Sharpens world in far distances, aligns some bloom better.
     roundSprite: 1 # Fixes font artifacts.
+    cpuSpriteRenderBW: 1 # Fixes broken fire sprites.
     PCRTCOverscan: 1 # Fixes offscreen image.
 SLPM-65889:
   name: 家族計画〜心の絆〜
@@ -41219,6 +42619,9 @@ SLPM-65890:
   name-sort: しんさんごくむそう4
   name-en: "Shin Sangoku Musou 4"
   region: "NTSC-J"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-65891:
   name: 三國志X
   name-sort: さんごくし10
@@ -41315,6 +42718,10 @@ SLPM-65909:
   region: "NTSC-J"
   roundModes:
     eeRoundMode: 1 # Fixes object balls never stopping in the Monkey Billiards DX minigame.
+  gsHWFixes:
+    recommendedBlendingLevel: 4 # Fixes text and foliage color.
+    mipmap: 2 # Mipmap + trilinear, improves stage textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-65910:
   name: カフェ・リンドバーグ -summer season-(Sweet Box 版)
   name-sort: かふぇ りんどばーぐ summer season [Sweet Box ばん]
@@ -41424,6 +42831,8 @@ SLPM-65927:
   gsHWFixes:
     halfPixelOffset: 1 # Reduces ghosting.
     roundSprite: 1 # Reduces ghosting even more.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-65928:
   name: SuperLite 2000 バラエティ メモオフみっくす
   name-sort: すーぱーらいと2000 ばらえてぃ めもおふみっくす
@@ -41496,6 +42905,8 @@ SLPM-65942:
   region: "NTSC-J"
   gsHWFixes:
     autoFlush: 2 # Fixes missing lighting.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
     # halfPixelOffset: 1 # Fixes lighting misalignment. Do not enable this, it breaks a lot of graphics.
 SLPM-65943:
   name: Angel’s Feather −黒の残影−
@@ -41547,6 +42958,8 @@ SLPM-65950:
   name-en: "Gantz - The Game"
   region: "NTSC-J"
   compat: 5
+  gsHWFixes:
+    roundSprite: 2 # Fixes line down right hand side of the screen during text sections.
 SLPM-65951:
   name: トム・クランシーシリーズ ゴーストリコン2
   name-sort: とむくらんしーしりーず ごーすとりこん2
@@ -41798,7 +43211,10 @@ SLPM-65995:
   clampModes:
     vuClampMode: 3 # Fixes minor SPS on characters.
   gsHWFixes:
+    roundSprite: 1 # Fix lines in the sky.
     halfPixelOffset: 2 # Fixes double image.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-65996:
   name: 破滅のマルス 限定版
   name-sort: はめつのまるす [げんていばん]
@@ -41943,6 +43359,8 @@ SLPM-66019:
   region: "NTSC-J"
   gsHWFixes:
     cpuSpriteRenderBW: 4 # Fixes textures.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-66020:
   name: サイオプス サイキック・オペレーション
   name-sort: さいおぷす さいきっく・おぺれーしょん
@@ -42071,6 +43489,11 @@ SLPM-66043:
   name-sort: れーしんぐげーむ「ちゅうい!!!」
   name-en: "Racing Game - Chuui!"
   region: "NTSC-J"
+  gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves car reflections.
+    autoFlush: 1
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-66044:
   name: MVPベースボール2005
   name-sort: MVPべーすぼーる2005
@@ -42090,7 +43513,7 @@ SLPM-66046:
   name-en: "Star Wars - Episode III - Revenge of the Sith"
   region: "NTSC-J"
   gsHWFixes:
-    halfPixelOffset: 1 # Fixes bloom misalignment.
+    halfPixelOffset: 4 # Fixes bloom misalignment.
 SLPM-66047:
   name: FIFA ストリート
   name-sort: FIFA すとりーと
@@ -42157,6 +43580,10 @@ SLPM-66059:
   name-sort: ろぼっつ
   name-en: "Robots"
   region: "NTSC-J"
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes misaligned bloom.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-66060:
   name: 亡国のイージス2035 〜ウォーシップガンナー〜
   name-sort: ぼうこくのいーじす2035 うぉーしっぷがんなー
@@ -42191,11 +43618,16 @@ SLPM-66066:
 SLPM-66067:
   name: "Crash Bandicoot - Bakusou! Nitro Kart"
   region: "NTSC-J"
+  gameFixes:
+    - BlitInternalFPSHack # Fixes internal FPS detection.
 SLPM-66068:
   name: リチャード・バーンズ ラリー
   name-sort: りちゃーど・ばーんず らりー
   name-en: "Richard Burns Rally"
   region: "NTSC-J"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-66069:
   name: 式神の城 七夜月幻想曲
   name-sort: しきがみのしろ ななよづきげんそうきょく
@@ -42275,6 +43707,8 @@ SLPM-66079:
     halfPixelOffset: 2 # Fixes misaligned blur.
     cpuSpriteRenderBW: 2 # Fixes black spots appearing on some surfaces and massively reduces RP TC and TU count.
     cpuSpriteRenderLevel: 2 # Needed for above.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-66080:
   name: GENERATION OF CHAOSIII 〜時の封印〜 [IFコレクション]
   name-sort: じぇねれーしょんおぶかおす 3 ときのふういん [あいであふぁくとりーこれくしょん]
@@ -42336,6 +43770,8 @@ SLPM-66090:
     PCRTCOverscan: 1 # Fixes offscreen image.
     nativePaletteDraw: 1 # Fixes the look of screen effects.
     halfPixelOffset: 2 # Corrects the alignment of screen effects.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-66091:
   name: 忍道 戒
   name-sort: しのびどう いましめ
@@ -42587,6 +44023,7 @@ SLPM-66124:
     eeClampMode: 3 # Fixes animations.
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
+    autoFlush: 1 # Fixes blur effect on attacks.
 SLPM-66125:
   name: ファイナルファンタジーX-2 [アルティメットヒッツ]
   name-sort: ふぁいなるふぁんたじー10-2 [あるてぃめっとひっつ]
@@ -42624,6 +44061,8 @@ SLPM-66131:
   gsHWFixes:
     wildArmsHack: 1 # Fixes blurriness.
     mergeSprite: 1 # Fixes misaligned lights.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-66132:
   name: GLADIATOR ROAD TO FREEDOM REMIX
   name-sort: GLADIATOR ROAD TO FREEDOM REMIX
@@ -42934,7 +44373,8 @@ SLPM-66183:
   gsHWFixes:
     textureInsideRT: 1
     halfPixelOffset: 2 # Fixes outlines on screen edges.
-    getSkipCount: "GSC_GetawayGames"
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-66184:
   name: 戦神 -いくさがみ-
   name-sort: いくさがみ
@@ -42943,6 +44383,7 @@ SLPM-66184:
   gameFixes:
     - VIF1StallHack # Fixes black screen on boot.
   gsHWFixes:
+    recommendedBlendingLevel: 2
     autoFlush: 2 # Fixes missing bloom effects.
     halfPixelOffset: 2 # Fixes misaligned lighting and bloom.
 SLPM-66185:
@@ -43039,6 +44480,9 @@ SLPM-66197:
   name-sort: ごじらかいじゅうだいらんとう ちきゅうさいしゅうけっせん
   name-en: "Godzilla Kaijuu Dairansen - Chikyuu Saishuu Kessen [Atari Hot Series]"
   region: "NTSC-J"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-66201:
   name: フレンズ 〜青春の輝き〜 ベスト版
   name-sort: ふれんず 〜せいしゅんのかがやき〜 べすとばん
@@ -43082,6 +44526,8 @@ SLPM-66206:
     autoFlush: 1 # Post-processing.
     halfPixelOffset: 2 # Offset post-processing.
     texturePreloading: 1 # Improves performance.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
     getSkipCount: "GSC_Battlefield2" # Depth clear.
     beforeDraw: "OI_Battlefield2" # Framebuffer copy, fixes rendering for bottom part of screen.
 SLPM-66207:
@@ -43091,6 +44537,8 @@ SLPM-66207:
   region: "NTSC-J"
   gsHWFixes:
     minimumBlendingLevel: 2 # Fixes dark font to more bright like software mode.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-66208:
   name: サクラ大戦V EPISODE 0 〜荒野のサムライ娘〜 SEGA THE BEST
   name-sort: さくらたいせんV EPISODE 0 〜こうやのさむらいむすめ〜 SEGA THE BEST
@@ -43122,7 +44570,9 @@ SLPM-66212:
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
-    cpuCLUTRender: 1 # Fixes rainbow textures.
+    recommendedBlendingLevel: 3 # Improves car reflections.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-66213:
   name: バイオハザード4
   name-sort: ばいおはざーど4
@@ -43133,6 +44583,8 @@ SLPM-66213:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-66214:
   name: WHITE CLARITY 〜And The tears became you.〜 [初回限定版]
   name-sort: ほわいと くらりてぃー 〜And The tears became you.〜 しょかいげんていばん
@@ -43283,6 +44735,8 @@ SLPM-66232:
     halfPixelOffset: 2 # Fixes blurriness.
     cpuCLUTRender: 1 # Final colour adjustment LUT.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
   memcardFilters:
     - "SLAJ-25075"
     - "SLPM-66232"
@@ -43380,6 +44834,7 @@ SLPM-66248:
   name-en: "Mr. Incredible - Kyouteki Underminer Toujou"
   region: "NTSC-J"
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes building shade and shadows.
     mipmap: 2 # Mipmap + trilinear, improves the street's textures to match sw renderer.
     trilinearFiltering: 1
     halfPixelOffset: 2 # Fixes bloom misalignment when upscaling.
@@ -43408,7 +44863,7 @@ SLPM-66252:
   name: "Star Wars - Episode III - Sith no Fukushuu"
   region: "NTSC-J"
   gsHWFixes:
-    halfPixelOffset: 1 # Fixes bloom misalignment.
+    halfPixelOffset: 4 # Fixes bloom misalignment.
 SLPM-66253:
   name: ふぁいなりすと 初回限定版
   name-sort: ふぁいなりすと しょかいげんていばん
@@ -43830,6 +45285,8 @@ SLPM-66322:
   gsHWFixes:
     textureInsideRT: 1 # Required for complex offset shuffles.
     halfPixelOffset: 2 # Fixes center upscaling line during explosions.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
     recommendedBlendingLevel: 4 # Fixes lighting.
 SLPM-66323:
   name: φなる・あぷろーち [プリンセスソフトコレクション]
@@ -43862,6 +45319,8 @@ SLPM-66327:
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misalignment/bloom when upscaling.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-66328:
   name: Call of Duty 2 Big Red One
   name-sort: Call of Duty 2 Big Red One
@@ -44037,8 +45496,10 @@ SLPM-66354:
         patch=1,EE,0037ECF0,word,4a800460
         patch=1,EE,0037ECF4,word,4b7103bc
 SLPM-66355:
-  name: "Rakugaki Oukoku 2 - Maou-jou no Tatakai"
+  name: "Rakugaki Oukoku 2 - Maou-jou no Tatakai [Taito Best]"
   region: "NTSC-J"
+  gsHWFixes:
+    halfPixelOffset: 4 # Fixes distant offset blur.
 SLPM-66356:
   name: "Baldr Force EXE [Alchemist Best]"
   region: "NTSC-J"
@@ -44209,8 +45670,8 @@ SLPM-66391:
   name-en: "Prince of Persia - The Two Thrones"
   region: "NTSC-J"
   gsHWFixes:
-    autoFlush: 2 # Reduces post-processing misalignment.
-    halfPixelOffset: 1 # Reduces post-processing misalignment.
+    autoFlush: 1 # Reduces post-processing misalignment.
+    halfPixelOffset: 4 # Reduces post-processing misalignment.
 SLPM-66393:
   name: ファイナルファンタジーXI オールインワンパック2006 [プレイオンライン]
   name-sort: ふぁいなるふぁんたじー11 おーるいんわんぱっく2006 [ぷれいおんらいん]
@@ -44418,6 +45879,9 @@ SLPM-66429:
   region: "NTSC-J"
   clampModes:
     vu1ClampMode: 3 # Fixes smoke particles.
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-66430:
   name: デストロイ オール ヒューマンズ!
   name-sort: ですとろい おーる ひゅーまんず!
@@ -44523,6 +45987,8 @@ SLPM-66444:
   gsHWFixes:
     autoFlush: 1 # Fixes missing post processing.
     halfPixelOffset: 1 # Aligns post processing.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-66445:
   name: ペルソナ3
   name-sort: ぺるそな3
@@ -44682,6 +46148,8 @@ SLPM-66465:
   region: "NTSC-J"
   gsHWFixes:
     autoFlush: 2 # Fixes missing lighting.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
     # halfPixelOffset: 1 # Fixes lighting misalignment. Do not enable this, it breaks a lot of graphics.
 SLPM-66467:
   name: ゲーセンUSA ミッドウェイアーケードトレジャーズ
@@ -44695,6 +46163,8 @@ SLPM-66468:
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misaligned lighting and other effects, needs Special otherwise lights flicker.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-66469:
   name: 「ラブ★コン 〜パンチDEコント〜」限定版
   name-sort: らぶこん ぱんちでこんと [げんていばん]
@@ -44791,10 +46261,11 @@ SLPM-66481:
   name-en: "Dragon Quest VIII [Ultimate Hits]"
   region: "NTSC-J"
   gsHWFixes:
-    autoFlush: 2 # Fixes missing bloom from surfaces like windows.
+    autoFlush: 1 # Fixes missing bloom from surfaces like windows.
     # halfPixelOffset: 1 # Aligns shadows properly, but causes grid lines to appear in sea travel.
     halfPixelOffset: 2 # Sharpens world in far distances, aligns some bloom better.
     roundSprite: 1 # Fixes font artifacts.
+    cpuSpriteRenderBW: 1 # Fixes broken fire sprites.
 SLPM-66482:
   name: ときめきメモリアル Girl’s Side 2nd Kiss リピート生産版
   name-sort: ときめきめもりある がーるずさいど 2nd Kiss りぴーとせいさんばん
@@ -44814,6 +46285,9 @@ SLPM-66485:
   name-sort: すてーと おぶ えまーじぇんしー りべんじ
   name-en: "State of Emergency - Revenge"
   region: "NTSC-J"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-66486:
   name: てんたま-1st Sunny Sideー <2800コレクション>
   name-sort: てんたま-1st Sunny Sideー <2800これくしょん>
@@ -44895,6 +46369,8 @@ SLPM-66498:
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes lighting and vertical lines, also works with normal vertex.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-66499:
   name: 神様家族 応援願望
   name-sort: かみさまかぞく おうえんがんぼう
@@ -44931,6 +46407,8 @@ SLPM-66503:
     - DMABusyHack # Fixes broken half-bottom artifacts.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-66504:
   name: 鬼武者2 MEGA HITS!
   name-sort: おにむしゃ2 MEGA HITS!
@@ -44992,13 +46470,15 @@ SLPM-66514:
     halfPixelOffset: 2 # Fixes misaligned blur.
     cpuSpriteRenderBW: 2 # Fixes black spots appearing on some surfaces and massively reduces RP TC and TU count.
     cpuSpriteRenderLevel: 2 # Needed for above.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-66515:
   name: EA BEST HITS スター・ウォーズ エピソード3 シスの復讐
   name-sort: すたーうぉーず えぴそーど3 しすのふくしゅう [EA BEST HITS]
   name-en: "Star Wars - Episode III - Sith no Fukushuu [EA Best Hits]"
   region: "NTSC-J"
   gsHWFixes:
-    halfPixelOffset: 1 # Fixes bloom misalignment.
+    halfPixelOffset: 4 # Fixes bloom misalignment.
 SLPM-66516:
   name: EA BEST HITS ザ・シムズ&ザ・アーブズ シムズ・イン・ザ・シティ
   name-sort: ざ・しむず&ざ・あーぶず しむず・いん・ざ・してぃ [EA BEST HITS]
@@ -45236,6 +46716,8 @@ SLPM-66562:
     halfPixelOffset: 2 # Fixes blurriness.
     cpuCLUTRender: 1 # Final colour adjustment LUT.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
   memcardFilters:
     - "SLAJ-25075"
     - "SLPM-66232"
@@ -45282,6 +46764,8 @@ SLPM-66567:
     cpuCLUTRender: 1 # Fixes the rest of the bad textures.
     roundSprite: 1 # Reduces misaligned bloom.
     mergeSprite: 1 # Removes bloom explosion around electrical lights and other light sources such as moon/sun.
+    mipmap: 2 # Mipmap + trilinear, improves road textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-66568:
   name: ユービーアイソフト ベスト ブラザー イン アームズ ロード トゥ ヒル サーティ
   name-sort: ぶらざー いん あーむず ろーど とぅ ひる さーてぃ [ゆーびーあいそふと べすと]
@@ -45585,6 +47069,8 @@ SLPM-66617:
   region: "NTSC-J"
   clampModes:
     eeClampMode: 3 # Fixes game hang after opening intro.
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes depth line.
 SLPM-66618:
   name: 夢見師 (初回限定版)
   name-sort: ゆめみし しょかいげんていばん
@@ -45747,6 +47233,8 @@ SLPM-66645:
   region: "NTSC-J"
   gsHWFixes:
     cpuCLUTRender: 1 # Fixes ghosting on objects and people.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-66646:
   name: シャイニング・フォース イクサ
   name-sort: しゃいにんぐ・ふぉーす いくさ
@@ -45768,6 +47256,8 @@ SLPM-66651:
     autoFlush: 1 # Post-processing.
     halfPixelOffset: 2 # Offset post-processing.
     texturePreloading: 1 # Improves performance.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
     getSkipCount: "GSC_Battlefield2" # Depth clear.
     beforeDraw: "OI_Battlefield2" # Framebuffer copy, fixes rendering for bottom part of screen.
 SLPM-66652:
@@ -45906,6 +47396,9 @@ SLPM-66672:
   name-sort: すぷりんたーせる にじゅうすぱい
   name-en: "Tom Clancy's Splinter Cell - Double Agent"
   region: "NTSC-J"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-66673:
   name: プリンス・オブ・ペルシャ ケンシ ノ ココロ [ユービーアイソフトベスト]
   name-sort: ぷりんす おぶ ぺるしゃ けんし の こころ [ゆーびーあいそふとべすと]
@@ -46093,6 +47586,8 @@ SLPM-66697:
   gsHWFixes:
     wildArmsHack: 1 # Fixes blurriness.
     mergeSprite: 1 # Fixes misaligned lights.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-66698:
   name: 史上最強の弟子ケンイチ 激闘!ラグナレク八拳豪
   name-sort: しじょうさいきょうのでしけんいち げきとう!らぐなれくはちけんごう
@@ -46121,6 +47616,11 @@ SLPM-66703:
   name-sort: れーしんぐげーむ「ちゅうい!!!!」 こなみ・ざ・べすと
   name-en: "Racing Game - Chuui!!!! [Konami the Best]"
   region: "NTSC-J"
+  gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves car reflections.
+    autoFlush: 1
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-66704:
   name: ネギま!? どりーむたくてぃっく 夢見る乙女はプリンセス 舞姫版
   name-sort: ねぎま!? どりーむたくてぃっく ゆめみるおとめはぷりんせす まいひめばん
@@ -46422,6 +47922,8 @@ SLPM-66752:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes lighting misalignment.
     mergeSprite: 1 # Removes occasional vertical lines.
+    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-66753:
   name: 月面兎兵器ミーナ -ふたつのPROJECT M- [限定版]
   name-sort: げつめんとへいきみーな -ふたつのPROJECT M- [げんていばん]
@@ -46652,6 +48154,8 @@ SLPM-66792:
     - InstantDMAHack # Fixes broken half-bottom artifacts.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-66793:
   name: METAL GEAR 20th ANNIVERSARY METAL GEAR SOLID 2 SONS OF LIBERTY [ディスク2/2]
   name-sort: METAL GEAR 20th ANNIVERSARY METAL GEAR SOLID 2 SONS OF LIBERTY [でぃすく2/2]
@@ -46661,6 +48165,8 @@ SLPM-66793:
     - InstantDMAHack # Fixes broken half-bottom artifacts.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-66794:
   name: MERAL GEAR 20th ANNIVERSARY METAL GEAR SOLID 3 SNAKE EATER
   name-sort: MERAL GEAR 20th ANNIVERSARY METAL GEAR SOLID 3 SNAKE EATER
@@ -46869,6 +48375,9 @@ SLPM-66836:
   name-sort: EA SPORTS らぐびー08
   name-en: "EA Sports Rugby '08"
   region: "NTSC-J"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-66837:
   name: マッデン NFL 08
   name-sort: まっでん NFL 08
@@ -46954,6 +48463,8 @@ SLPM-66851:
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 1 # Removes blur due to misaligned fullscreen effect.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-66852:
   name: カプコン クラシックス コレクション Best Price
   name-sort: かぷこん くらしっくす これくしょん [Best Price]
@@ -46966,6 +48477,8 @@ SLPM-66853:
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 2 # Fixes text box opacity.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-66854:
   name: ストリートファイターゼロ ファイターズ ジェネレーション Best Price
   name-sort: すとりーとふぁいたーぜろ ふぁいたーず じぇねれーしょん Best Price
@@ -47047,6 +48560,9 @@ SLPM-66868:
   name-sort: すぷりんたーせる にじゅうすぱい [ゆーびーあいそふとべすと]
   name-en: "Tom Clancy's Splinter Cell - Double Agent [Ubisoft the Best]"
   region: "NTSC-J"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-66869:
   name: EA BEST HITS ニード・フォー・スピード カーボン
   name-sort: にーど ふぉー すぴーど かーぼん [EA BEST HITS]
@@ -47054,6 +48570,8 @@ SLPM-66869:
   region: "NTSC-J"
   clampModes:
     eeClampMode: 3 # Fixes game hang after opening intro.
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes depth line.
 SLPM-66870:
   name: 星色のおくりもの [初回スペシャル限定版]
   name-sort: ほしいろのおくりもの [しょかいすぺしゃるげんていばん]
@@ -47311,12 +48829,12 @@ SLPM-66916:
   name-en: "Jikkyou Powerful Pro Yakyuu 14 Ketteiban"
   region: "NTSC-J"
 SLPM-66917:
-  name: Grand Theft Auto:Vice City Stories
+  name: グランド・セフト・オート・バイスシティ・ストーリーズ
   name-sort: ぐらんどせふとおーと ばいすしてぃ すとーりーず
   name-en: "Grand Theft Auto - Vice City Stories"
   region: "NTSC-J"
   gsHWFixes:
-    halfPixelOffset: 1 # Fixes misaligned effect when in-game Trails option is turned on.
+    halfPixelOffset: 2 # Fixes misaligned effect when in-game Trails option is turned on.
 SLPM-66918:
   name: プリンセスメーカー5
   name-sort: ぷりんせすめーかー5
@@ -47749,6 +49267,8 @@ SLPM-67002:
     roundSprite: 2 # Fixes font artifacts.
     autoFlush: 1 # Fixes depth of field blur.
     recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-67003:
   name: サクラ大戦 〜熱き血潮に〜
   name-sort: さくらたいせん 〜あつきちしおに〜
@@ -47769,6 +49289,8 @@ SLPM-67005:
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misaligned lighting and other effects.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
   clampModes:
     vuClampMode: 3 # Fix white shiny weapons.
 SLPM-67006:
@@ -47792,6 +49314,8 @@ SLPM-67008:
     roundSprite: 2 # Fixes font artifacts.
     autoFlush: 1 # Fixes depth of field blur.
     recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-67009:
   name: サクラ大戦V 〜さらば愛しき人よ〜
   name-sort: さくらたいせんV 〜さらばいとしきひとよ〜
@@ -47873,6 +49397,8 @@ SLPM-67504:
     eeRoundMode: 0 # Fixes riders vanish into the floor.
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes missing lighting and makes snow not look like snow sludge.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-67505:
   name: "007 - Agent Under Fire"
   region: "NTSC-K"
@@ -47929,6 +49455,8 @@ SLPM-67515:
     - InstantDMAHack # Fixes broken half-bottom artifacts.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-67516:
   name: "Soul Reaver 2"
   region: "NTSC-K"
@@ -47963,6 +49491,8 @@ SLPM-67524:
   gsHWFixes:
     halfPixelOffset: 2 # Corrects positioning of reflections on suit's surfaces.
     roundSprite: 2 # Reduces garbage on the UI whilst upscaling.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-67525:
   name: "Medal of Honor - Frontline"
   region: "NTSC-K"
@@ -48049,6 +49579,8 @@ SLPM-67546:
   region: "NTSC-K"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misaligned lighting and other effects.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
   clampModes:
     vuClampMode: 3 # Fix white shiny weapons.
 SLPM-67550:
@@ -48126,6 +49658,8 @@ SLPM-68503:
     - InstantDMAHack # Fixes broken half-bottom artifacts.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-68504:
   name: "Tokimeki Memorial 3 - Special Sound Track"
   region: "NTSC-J"
@@ -48170,6 +49704,8 @@ SLPM-68520:
   gsHWFixes:
     halfPixelOffset: 2 # Corrects shadow alignment and reduces blurriness.
     recommendedBlendingLevel: 3 # Fixes level and map menu brightness.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-68521:
   name: ".hack frägment [Senkou Release-ban]"
   region: "NTSC-J"
@@ -48386,6 +49922,7 @@ SLPM-74227:
   gameFixes:
     - VIF1StallHack # Fixes black screen on boot.
   gsHWFixes:
+    recommendedBlendingLevel: 2
     autoFlush: 2 # Fixes missing bloom effects.
     halfPixelOffset: 2 # Fixes misaligned lighting and bloom.
 SLPM-74228:
@@ -48400,6 +49937,8 @@ SLPM-74229:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-74230:
   name: Devil May Cry PlayStation 2 the Best
   name-sort: Devil May Cry PlayStation 2 the Best
@@ -48448,6 +49987,9 @@ SLPM-74236:
   name-sort: しんさんごくむそう4 PlayStation 2 the Best
   name-en: "Shin Sangoku Musou 4 [PlayStation 2 the Best]"
   region: "NTSC-J"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-74237:
   name: NEW人生ゲーム PlayStation 2 the Best
   name-sort: NEWじんせいげーむ PlayStation 2 the Best
@@ -48597,6 +50139,8 @@ SLPM-74255:
     - InstantDMAHack # Fixes broken half-bottom artifacts.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-74256:
   name: "Metal Gear Solid 2 - Sons of Liberty [PlayStation 2 the Best] [Disc 2 of 2]"
   region: "NTSC-J"
@@ -48604,6 +50148,8 @@ SLPM-74256:
     - InstantDMAHack # Fixes broken half-bottom artifacts.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-74257:
   name: "Metal Gear Solid 3 - Subsistence (Disc 1) (Subsistence)"
   region: "NTSC-J"
@@ -48630,6 +50176,8 @@ SLPM-74262:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-74263:
   name: "Nobunaga no Yabou - Tenka Sousei"
   region: "NTSC-J"
@@ -48718,6 +50266,8 @@ SLPM-74288:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-74301:
   name: 龍が如く2 PlayStation 2 the Best
   name-sort: りゅうがごとく2 PlayStation 2 the Best
@@ -48777,6 +50327,9 @@ SLPM-74410:
   name-sort: ぶれす おぶ ふぁいあV どらごん くぉーたー PlayStation 2 the Best
   name-en: "Breath of Fire V - Dragon Quarter [PlayStation 2 the Best]"
   region: "NTSC-J"
+  gsHWFixes:
+    halfPixelOffset: 4 # Aligns HUD and HUD bloom to match software.
+    roundSprite: 1 # Helps fix some lines and lines in text.
 SLPM-74411:
   name: カルドセプト セカンド エキスパンション PlayStation 2 the Best
   name-sort: かるどせぷと せかんど えきすぱんしょん PlayStation 2 the Best
@@ -48821,6 +50374,8 @@ SLPM-74901:
     roundSprite: 2 # Fixes font artifacts.
     autoFlush: 1 # Fixes depth of field blur.
     recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLPM-83770:
   name: ペルソナ3フェス [アペンドディスク版]
   name-sort: ぺるそな3ふぇす [あぺんどでぃすくばん]
@@ -48896,6 +50451,8 @@ SLPS-20007:
   gsHWFixes:
     textureInsideRT: 1
     roundSprite: 1 # Fixes font misalignment when upscaling.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLPS-20008:
   name: "Morita Shougi"
   region: "NTSC-J"
@@ -48980,6 +50537,7 @@ SLPS-20023:
   name-en: "Cross Fire"
   region: "NTSC-J"
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes character models.
     mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
     trilinearFiltering: 1
 SLPS-20024:
@@ -49066,6 +50624,9 @@ SLPS-20040:
   name-sort: MotoGP
   name-en: "MotoGP"
   region: "NTSC-J"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves road and tree textures to match sw renderer.
+    trilinearFiltering: 1
 SLPS-20041:
   name: 麻雀悟空 大聖
   name-sort: まーじゃんごくう たいせい
@@ -49197,6 +50758,9 @@ SLPS-20067:
   name-sort: CRAZY BUMP’S かっとびかーばとる!
   name-en: "Crazy Bumps"
   region: "NTSC-J"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLPS-20068:
   name: MIDNIGHT CLUB〜STREET RACING〜
   name-sort: MIDNIGHT CLUB〜STREET RACING〜
@@ -49405,6 +50969,9 @@ SLPS-20113:
   name-sort: たいむくらいしす2＋がんこん2
   name-en: "Time Crisis II [with Guncon 2]"
   region: "NTSC-J"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLPS-20114:
   name: "TVware Jouhou Kakumei Series - Katei no Igaku"
   region: "NTSC-J"
@@ -49434,6 +51001,9 @@ SLPS-20122:
   name-sort: たいむくらいしす2
   name-en: "Time Crisis II"
   region: "NTSC-J"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLPS-20123:
   name: "Initial D - Takahashi Ryousuke no Typing Saisoku Riron"
   region: "NTSC-J"
@@ -49594,6 +51164,7 @@ SLPS-20170:
   region: "NTSC-J"
   gsHWFixes:
     textureInsideRT: 2 # Fixes water reflection.
+    autoFlush: 1 # Fixes shading on objects and foliage.
 SLPS-20171:
   name: スマッシュコート プロトーナメント
   name-sort: すまっしゅこーと ぷろとーなめんと
@@ -50012,6 +51583,8 @@ SLPS-20281:
   region: "NTSC-J"
   clampModes:
     vuClampMode: 0 # Fixes missing game board.
+  gsHWFixes:
+    recommendedBlendingLevel: 2
 SLPS-20282:
   name: 太鼓の達人 タタコンでドドンがドン [ソフト単品]
   name-sort: たいこのたつじん たたこんでどどんがどん [そふとたんぴん]
@@ -50378,11 +51951,15 @@ SLPS-20372:
   name-sort: じっせんぱちすろひっしょうほう! ほくとのけん DXぱっく
   name-en: "Jissen Pachi-Slot Hisshouhou! Hokuto no Ken [Limited Edition]"
   region: "NTSC-J"
+  gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves the shine of the pachi slot machine.
 SLPS-20373:
   name: 実戦パチスロ必勝法! 北斗の拳
   name-sort: じっせんぱちすろひっしょうほう! ほくとのけん
   name-en: "Jissen Pachi-Slot Hisshouhou! Hokuto no Ken"
   region: "NTSC-J"
+  gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves the shine of the pachi slot machine.
 SLPS-20374:
   name: フットボールキングダム トライアルエディション
   name-sort: ふっとぼーるきんぐだむ とらいあるえでぃしょん
@@ -50627,6 +52204,9 @@ SLPS-20423:
   region: "NTSC-J"
   clampModes:
     vuClampMode: 3 # Fixes bad coordinate spam.
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLPS-20424:
   name: 太鼓の達人 とびっきり!アニメスペシャル [「タタコン」同梱版]
   name-sort: たいこのたつじん とびっきり!あにめすぺしゃる [「たたこん」どうこんばん]
@@ -50651,6 +52231,8 @@ SLPS-20426:
   gsHWFixes:
     roundSprite: 2 # Improves bloom alignment and clarity.
     halfPixelOffset: 2 # Improves bloom alignment and clarity.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLPS-20427:
   name: "Pachi-Slot Club Collection - Pachi-Slot da yo Koumon-chama"
   region: "NTSC-J"
@@ -51099,6 +52681,10 @@ SLPS-25003:
   region: "NTSC-J"
   clampModes:
     eeClampMode: 3 # Fixes hanging before going in-game.
+  gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes terrain color rendering.
+    mipmap: 2 # Mipmap + trilinear, fixes miptrick textures to match sw renderer.
+    trilinearFiltering: 1
 SLPS-25004:
   name: 建設重機喧嘩バトル ぶちギレ金剛!!
   name-sort: けんせつじゅうきけんかばとる ぶちぎれこんごう!!
@@ -51125,6 +52711,8 @@ SLPS-25007:
     eeClampMode: 2 # Fixes Abnormal AI behavior.
   gsHWFixes:
     textureInsideRT: 1 # Fixes texture corruption.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLPS-25008:
   name: 魔術士オーフェン
   name-sort: まじゅつしおーふぇん
@@ -51400,6 +52988,7 @@ SLPS-25050:
     eeClampMode: 3 # Fixes animations.
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
+    autoFlush: 1 # Fixes blur effect on attacks.
 SLPS-25051:
   name: MissingBlue
   name-sort: MissingBlue
@@ -51449,6 +53038,8 @@ SLPS-25057:
     preloadFrameData: 1 # Fixes invisible lava, there is another issue that needs skipdraw 1 for blurry font but it removes much brightness.
     cpuSpriteRenderBW: 2 # Fixes sky and lava when upscaling.
     cpuSpriteRenderLevel: 2 # Needed for above.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
   patches:
     04C3765E:
       content: |-
@@ -51564,6 +53155,8 @@ SLPS-25078:
     eeRoundMode: 0 # Fixes riders vanish into the floor.
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes missing lighting and makes snow not look like snow sludge.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLPS-25079:
   name: MADDEN NFL スーパーボウル 2002
   name-sort: MADDEN NFL すーぱーぼうる 2002
@@ -51622,6 +53215,8 @@ SLPS-25089:
     - VUSyncHack # Fixes flickering and missing textures.
   gsHWFixes:
     textureInsideRT: 1 # Fixes graphical corruption.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLPS-25094:
   name: リーヴェルファンタジア 〜マリエルと妖精物語〜
   name-sort: りーゔぇるふぁんたじあ まりえるとようせいものがたり
@@ -51728,6 +53323,8 @@ SLPS-25112:
   gsHWFixes:
     halfPixelOffset: 2 # Corrects positioning of reflections on suit's surfaces.
     roundSprite: 2 # Reduces garbage on the UI whilst upscaling.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLPS-25113:
   name: 絶体絶命都市
   name-sort: ぜったいぜつめいとし
@@ -51790,6 +53387,8 @@ SLPS-25121:
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 1 # Sharpens world in far distances.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
   memcardFilters:
     - "SCPS-55029"
     - "SCPS-55042"
@@ -52459,6 +54058,8 @@ SLPS-25246:
   region: "NTSC-J"
   gsHWFixes:
     autoFlush: 2 # Fixes lava effect.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLPS-25247:
   name: R-TYPE FINAL
   name-sort: R-TYPE FINAL
@@ -52956,6 +54557,8 @@ SLPS-25338:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
     recommendedBlendingLevel: 3 # Fixes level brightness.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
   memcardFilters:
     - "SCAJ-20076"
     - "SCAJ-20077"
@@ -52971,6 +54574,8 @@ SLPS-25339:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
     recommendedBlendingLevel: 3 # Fixes level brightness.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
   memcardFilters:
     - "SCAJ-20076"
     - "SCAJ-20077"
@@ -53047,6 +54652,8 @@ SLPS-25351:
     autoFlush: 1 # Fixes bloom and sun rendering in front of everything.
     halfPixelOffset: 2 # Aligns bloom effect a little bit better when upscaled.
     bilinearUpscale: 2 # Reduces color banding of the sun glare.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
   roundModes:
     vu1RoundMode: 1 # Bright lights in cars.
 SLPS-25352:
@@ -53266,6 +54873,9 @@ SLPS-25384:
   name-sort: てんちゅう くれない
   name-en: "Tenchu Kurenai"
   region: "NTSC-J"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLPS-25385:
   name: フレンズ 〜青春の輝き〜
   name-sort: ふれんず せいしゅんのかがやき
@@ -53393,6 +55003,8 @@ SLPS-25406:
   gsHWFixes:
     texturePreloading: 1 # Performs much better with partial preload.
     autoFlush: 1 # Fixes bloom rendering.
+    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
+    trilinearFiltering: 1
   roundModes:
     vu1RoundMode: 0 # Fixes missing light cones curtains and certain effects.
 SLPS-25407:
@@ -53408,6 +55020,8 @@ SLPS-25408:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
     recommendedBlendingLevel: 3 # Fixes level brightness.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
   memcardFilters:
     - "SLPS-25408"
     - "SCAJ-20076"
@@ -53510,6 +55124,10 @@ SLPS-25422:
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes FMV lines.
+    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
+    trilinearFiltering: 1
+    cpuSpriteRenderBW: 2 # Prevents Death By VRAM explosion.
+    cpuSpriteRenderLevel: 2 # Needed for above.
     getSkipCount: "GSC_DeathByDegreesTekkenNinaWilliams"
 SLPS-25423:
   name: 怪盗アプリコット 完全版 [限定版]
@@ -53717,6 +55335,8 @@ SLPS-25461:
     halfPixelOffset: 1 # Fixes misaligned blur.
     cpuSpriteRenderBW: 1 # Fixes broken shadow caused by HPO 1.
     cpuSpriteRenderLevel: 2 # Needed for above.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLPS-25462:
   name: アーマード・コア ラストレイヴン
   name-sort: あーまーどこあ らすとれいゔん
@@ -53725,6 +55345,8 @@ SLPS-25462:
   gsHWFixes:
     halfPixelOffset: 2 # Corrects shadow alignment and reduces blurriness.
     recommendedBlendingLevel: 3 # Fixes level and map menu brightness.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
   memcardFilters:
     - "SLPS-25338"
     - "SLPS-25339"
@@ -53831,6 +55453,9 @@ SLPS-25480:
   name-sort: じぱんぐ
   name-en: "ZIPANG"
   region: "NTSC-J"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLPS-25481:
   name: ガッツだ!!森の石松
   name-sort: がっつだ もりのいしまつ
@@ -53986,6 +55611,8 @@ SLPS-25510:
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
     halfPixelOffset: 4 # Align post.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
     getSkipCount: "GSC_Tekken5"
 SLPS-25511:
   name: 羅刹 -Alternative-
@@ -54228,6 +55855,8 @@ SLPS-25557:
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
     textureInsideRT: 1 # Fixes corruption.
+    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
+    trilinearFiltering: 1
     getSkipCount: "GSC_UrbanReign"
 SLPS-25558:
   name: ネオジオ バトルコロシアム
@@ -54260,6 +55889,8 @@ SLPS-25563:
   gsHWFixes:
     texturePreloading: 1 # Performs much better with partial preload.
     autoFlush: 1 # Fixes bloom rendering.
+    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
+    trilinearFiltering: 1
   roundModes:
     vu1RoundMode: 0 # Fixes missing light cones curtains and certain effects.
 SLPS-25564:
@@ -54333,6 +55964,7 @@ SLPS-25575:
   compat: 5
   gsHWFixes:
     preloadFrameData: 1 # Fixes invisible text.
+    autoFlush: 1
 SLPS-25576:
   name: ワンピース パイレーツカーニバル
   name-sort: わんぴーす ぱいれーつかーにばる
@@ -54618,6 +56250,8 @@ SLPS-25626:
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes lighting misalignment.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLPS-25627:
   name: 機動戦士ガンダム クライマックスU.C.
   name-sort: きどうせんしがんだむ くらいまっくすU.C.
@@ -54718,6 +56352,8 @@ SLPS-25640:
     halfPixelOffset: 2 # Fixes lighting misalignment and reduces ground shadows (probably texture cache issue).
     roundSprite: 2 # Fixes font artifacts.
     textureInsideRT: 1 # Fixes bad crystal surfaces.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
   memcardFilters: # Allows import of Xenosaga II save data.
     - "SLPS-25640"
     - "SLPS-25368"
@@ -54732,6 +56368,8 @@ SLPS-25641:
     halfPixelOffset: 2 # Fixes lighting misalignment and reduces ground shadows (probably texture cache issue).
     roundSprite: 2 # Fixes font artifacts.
     textureInsideRT: 1 # Fixes bad crystal surfaces.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
   memcardFilters:
     - "SLPS-25640"
     - "SLPS-25368"
@@ -55031,6 +56669,9 @@ SLPS-25686:
   name-sort: じょじょのきみょうなぼうけん ふぁんとむぶらっど
   name-en: "Jojo no Kimyou na Bouken - Phantom Blood"
   region: "NTSC-J"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLPS-25687:
   name: コロボットアドベンチャー
   name-sort: ころぼっとあどべんちゃー
@@ -55053,6 +56694,7 @@ SLPS-25690:
   name-en: "Dragon Ball Z - Sparking Neo"
   region: "NTSC-J"
   gsHWFixes:
+    halfPixelOffset: 2 # Fixes character outlines and minor bloom.
     beforeDraw: "OI_DBZBTGames"
 SLPS-25691:
   name: キャプテン翼
@@ -55741,6 +57383,8 @@ SLPS-25815:
   name-en: "Dragon Ball Z Sparking! Meteor"
   region: "NTSC-J"
   gsHWFixes:
+    halfPixelOffset: 2 # Fixes character outlines and minor bloom.
+    cpuCLUTRender: 1 # Aligns character bloom and some stage bloom.
     beforeDraw: "OI_DBZBTGames"
 SLPS-25816:
   name: 山佐DigiワールドコラボレーションSP パチスロ リッジレーサー
@@ -55897,6 +57541,9 @@ SLPS-25840:
     vu1RoundMode: 0 # Crashes without.
   gsHWFixes:
     textureInsideRT: 1 # Crowd textures.
+    autoFlush: 1 # Fixes bloom intensity.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLPS-25841:
   name: テイルズ オブ デスティニー ディレクターズカット プレミアムBOX
   name-sort: ているず おぶ ですてぃにー でぃれくたーずかっと [ぷれみあむBOX]
@@ -56122,6 +57769,9 @@ SLPS-25886:
     vu1RoundMode: 0 # Fixes VU size spam and potential graphical issues with GH3 engine.
   gsHWFixes:
     textureInsideRT: 1 # Crowd textures.
+    autoFlush: 1 # Fixes bloom intensity.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLPS-25887:
   name: スーパーロボット大戦Ｚ
   name-sort: すーぱーろぼっとたいせんZ
@@ -56135,6 +57785,7 @@ SLPS-25888:
   compat: 5
   gsHWFixes:
     recommendedBlendingLevel: 2 # Fixes player shadow definition and color banding.
+    halfPixelOffset: 2 # Fixes misaligned bloom effects.
     autoFlush: 1 # Fixes player shadow.
   patches:
     CC9BFDE3:
@@ -56153,6 +57804,9 @@ SLPS-25889:
     vu1RoundMode: 0 # Fixes VU size spam and potential graphical issues with GH3 engine.
   gsHWFixes:
     textureInsideRT: 1 # Crowd textures.
+    autoFlush: 1 # Fixes bloom intensity.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLPS-25890:
   name: ギターヒーロー3 レジェンドオブロック
   name-sort: ぎたーひーろー3 れじぇんどおぶろっく
@@ -56162,6 +57816,9 @@ SLPS-25890:
     vu1RoundMode: 0 # Crashes without.
   gsHWFixes:
     textureInsideRT: 1 # Crowd textures.
+    autoFlush: 1 # Fixes bloom intensity.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLPS-25891:
   name: "Nogizaka Haruka no Himitsu - Cosplay, Hajimemashita"
   region: "NTSC-J"
@@ -56300,6 +57957,9 @@ SLPS-25927:
   region: "NTSC-J"
   gsHWFixes:
     textureInsideRT: 1 # Needed for post processing effects.
+    autoFlush: 1 # Fixes missing blur layer.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLPS-25928:
   name: "Little Anchor"
   region: "NTSC-J"
@@ -56464,6 +58124,16 @@ SLPS-25983:
   name-sort: THE KING OF FIGHTERS 2002 UNLIMITED MATCH とうげきver.
   name-en: "King of Fighters 2002, The - Unlimited Match"
   region: "NTSC-J"
+SLPS-25986:
+  name: "TOMB RAIDER: UNDERWORLD"
+  name-sort: "TOMB RAIDER: UNDERWORLD"
+  name-en: "Tomb Raider - Underworld [Spike The Best]"
+  region: "NTSC-J"
+  gsHWFixes:
+    textureInsideRT: 1 # Needed for post processing effects.
+    autoFlush: 1 # Fixes missing blur layer.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLPS-25987:
   name: "Amagami [EBKore+]"
   region: "NTSC-J"
@@ -56537,6 +58207,8 @@ SLPS-29003:
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misaligned lighting and other effects.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
   clampModes:
     vuClampMode: 3 # Fix white shiny weapons.
 SLPS-29004:
@@ -56547,6 +58219,8 @@ SLPS-29004:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misaligned lighting and other effects.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
   clampModes:
     vuClampMode: 3 # Fix white shiny weapons.
 SLPS-29005:
@@ -56579,6 +58253,7 @@ SLPS-72501:
     eeClampMode: 3 # Fixes animations.
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
+    autoFlush: 1 # Fixes blur effect on attacks.
 SLPS-72502:
   name: テイルズ オブ ディスティニー2 MEGA HITS!
   name-sort: ているず おぶ でぃすてぃにー2 MEGA HITS!
@@ -56605,6 +58280,9 @@ SLPS-73006:
   name-sort: たいむくらいしす2 PlayStation 2 the Best
   name-en: "Time Crisis II [PlayStation 2 the Best]"
   region: "NTSC-J"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLPS-73007:
   name: "Kamaitachi no Yoru 2 - Kangoku-jima no Warabe-uta - Special Eizou"
   region: "NTSC-J"
@@ -56682,6 +58360,8 @@ SLPS-73202:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
     recommendedBlendingLevel: 3 # Fixes level brightness.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
   memcardFilters:
     - "SCAJ-20076"
     - "SCAJ-20077"
@@ -56697,6 +58377,8 @@ SLPS-73203:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
     recommendedBlendingLevel: 3 # Fixes level brightness.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
   memcardFilters:
     - "SCAJ-20076"
     - "SCAJ-20077"
@@ -56858,6 +58540,8 @@ SLPS-73223:
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
     halfPixelOffset: 4 # Align post.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
     getSkipCount: "GSC_Tekken5"
 SLPS-73224:
   name: ゼノサーガ エピソードII［善悪の彼岸］ PlayStation 2 the Best [ディスク1/2]
@@ -56896,6 +58580,9 @@ SLPS-73226:
   name-sort: てんちゅう くれない PlayStation 2 the Best
   name-en: "Tenchu Kurenai [PlayStation 2 the Best]"
   region: "NTSC-J"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLPS-73227:
   name: Another Century’s Episode PlayStation 2 the Best
   name-sort: Another Century’s Episode PlayStation 2 the Best
@@ -57077,6 +58764,8 @@ SLPS-73247:
   gsHWFixes:
     halfPixelOffset: 2 # Corrects shadow alignment and reduces blurriness.
     recommendedBlendingLevel: 3 # Fixes level and map menu brightness.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
   memcardFilters:
     - "SLPS-25338"
     - "SLPS-25339"
@@ -57235,6 +58924,8 @@ SLPS-73403:
     eeClampMode: 2 # Fixes Abnormal AI behavior.
   gsHWFixes:
     textureInsideRT: 1 # Fixes texture corruption.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLPS-73404:
   name: 風のクロノア2〜世界が望んだ忘れもの〜PlayStation 2 the Best
   name-sort: かぜのくろのあ2 せかいがのぞんだわすれもの PlayStation 2 the Best
@@ -57331,6 +59022,8 @@ SLPS-73417:
   gsHWFixes:
     halfPixelOffset: 2 # Corrects positioning of reflections on suit's surfaces.
     roundSprite: 2 # Reduces garbage on the UI whilst upscaling.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLPS-73418:
   name: シャドウハーツ PlayStation 2 the Best
   name-sort: しゃどうはーつ [PlayStation 2 the Best]
@@ -57476,6 +59169,8 @@ SLUS-20014:
     eeClampMode: 2 # Fixes Abnormal AI behavior.
   gsHWFixes:
     textureInsideRT: 1 # Fixes texture corruption.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-20015:
   name: "Eternal Ring"
   region: "NTSC-U"
@@ -57488,6 +59183,10 @@ SLUS-20016:
   name: "Evergrace"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes terrain color rendering.
+    mipmap: 2 # Mipmap + trilinear, fixes miptrick textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-20017:
   name: "Maximo - Ghosts to Glory"
   region: "NTSC-U"
@@ -57505,13 +59204,14 @@ SLUS-20021:
   region: "NTSC-U"
   compat: 5
 SLUS-20024:
-  name: "Blood Omen 2 - The Legacy of Kain"
+  name: "Blood Omen 2 - The Legacy of Kain Series"
   region: "NTSC-U"
   compat: 5
   roundModes:
     eeRoundMode: 0 # Fixes pathing.
   gsHWFixes:
-    mipmap: 1 # Fixes glitching textures.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-20028:
   name: "The Operative - No One Lives Forever"
   name-sort: "Operative, The - No One Lives Forever"
@@ -57624,6 +59324,9 @@ SLUS-20058:
   name: "MotoGP"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves road and tree textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-20062:
   name: "Grand Theft Auto III"
   region: "NTSC-U"
@@ -57639,6 +59342,9 @@ SLUS-20064:
   name: "Oni"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
   patches:
     FD9CD8FC:
       content: |-
@@ -57650,10 +59356,16 @@ SLUS-20065:
   name: "Smuggler's Run"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-20066:
   name: "Half-Life"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-20069:
   name: "The Bouncer"
   name-sort: "Bouncer, The"
@@ -57700,7 +59412,7 @@ SLUS-20076:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes blurriness and misaligned shadows.
 SLUS-20077:
-  name: "Donald Duck Goin' Quackers"
+  name: "Disney's Donald Duck - Goin' Quackers"
   region: "NTSC-U"
   compat: 5
   patches:
@@ -57781,6 +59493,7 @@ SLUS-20094:
   name: "X Squad"
   region: "NTSC-U"
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes character models.
     mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
     trilinearFiltering: 1
 SLUS-20095:
@@ -57850,6 +59563,8 @@ SLUS-20111:
   compat: 5
   gsHWFixes:
     roundSprite: 1 # Fixes lines in HUD and text boxes.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-20112:
   name: "Star Trek - Shattered Universe"
   region: "NTSC-U"
@@ -57861,11 +59576,16 @@ SLUS-20113:
   gsHWFixes:
     textureInsideRT: 1
     roundSprite: 1 # Fixes font misalignment when upscaling.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-20114:
-  name: "The Simpsons - Skateboarding"
+  name: "The Simpsons Skateboarding"
   name-sort: "Simpsons, The - Skateboarding"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-20115:
   name: "Super Bust-A-Move"
   region: "NTSC-U"
@@ -57938,6 +59658,8 @@ SLUS-20144:
     - InstantDMAHack # Fixes broken half-bottom artifacts.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-20145:
   name: "Ring of Red"
   region: "NTSC-U"
@@ -58189,6 +59911,9 @@ SLUS-20202:
   compat: 5
   gameFixes:
     - EETimingHack # Fixes credits screen.
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves road and building textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-20204:
   name: "Smuggler's Run 2 - Hostile Territory"
   region: "NTSC-U"
@@ -58295,6 +60020,9 @@ SLUS-20219:
   name: "Time Crisis II"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-20220:
   name: "Dead to Rights"
   region: "NTSC-U"
@@ -58451,6 +60179,8 @@ SLUS-20250:
   compat: 5
   gsHWFixes:
     cpuSpriteRenderBW: 4 # Fixes textures.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-20251:
   name: "Harvest Moon - Save the Homeland"
   region: "NTSC-U"
@@ -58513,6 +60243,8 @@ SLUS-20267:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 1 # Sharpens world in far distances.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
   memcardFilters:
     - "SLUS-20267"
     - "SLUS-20562"
@@ -58695,6 +60427,10 @@ SLUS-20307:
   name: "Burnout"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    autoFlush: 1 # Fixes missing blur layer on sky.
+    mipmap: 2 # Mipmap + trilinear, improves road textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-20308:
   name: "ESPN - NFL Prime Time 2002"
   region: "NTSC-U"
@@ -58728,12 +60464,14 @@ SLUS-20312:
     eeClampMode: 3 # Fixes animations.
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
+    autoFlush: 1 # Fixes blur effect on attacks.
 SLUS-20313:
   name: "Wave Rally"
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
     textureInsideRT: 2 # Fixes water reflection.
+    autoFlush: 1 # Fixes shading on objects and foliage.
 SLUS-20314:
   name: "TimeSplitters 2"
   region: "NTSC-U"
@@ -58760,6 +60498,8 @@ SLUS-20318:
     preloadFrameData: 1 # Fixes invisible lava, there is another issue that needs skipdraw 1 for blurry font but it removes much brightness.
     cpuSpriteRenderBW: 2 # Fixes sky and lava when upscaling.
     cpuSpriteRenderLevel: 2 # Needed for above.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
   patches:
     36E02E91:
       content: |-
@@ -58801,6 +60541,8 @@ SLUS-20326:
     eeRoundMode: 0 # Fixes riders vanish into the floor.
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes missing lighting and makes snow not look like snow sludge.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-20327:
   name: "Aggressive Inline"
   region: "NTSC-U"
@@ -58863,6 +60605,8 @@ SLUS-20337:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes upscaling lines.
     autoFlush: 2 # Fixes sun penetration.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-20339:
   name: "Bass Fishing Duel - Sega Sports"
   region: "NTSC-U"
@@ -58927,6 +60671,8 @@ SLUS-20348:
   compat: 4
   clampModes:
     vuClampMode: 0 # Fixes missing game board.
+  gsHWFixes:
+    recommendedBlendingLevel: 2
 SLUS-20349:
   name: "Scooby-Doo! Night of 100 Frights"
   region: "NTSC-U"
@@ -58941,6 +60687,8 @@ SLUS-20353:
     preloadFrameData: 1 # Fixes invisible lava, there is another issue that needs skipdraw 1 for blurry font but it removes much brightness.
     cpuSpriteRenderBW: 2 # Fixes sky and lava when upscaling.
     cpuSpriteRenderLevel: 2 # Needed for above.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-20354:
   name: "Red Card Soccer 2003"
   region: "NTSC-U"
@@ -58971,6 +60719,9 @@ SLUS-20361:
   name: "Rally Fusion - Race of Champions"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-20362:
   name: "Need for Speed - Hot Pursuit 2"
   region: "NTSC-U"
@@ -59056,6 +60807,8 @@ SLUS-20378:
     - VUSyncHack # Fixes flickering and missing textures.
   gsHWFixes:
     textureInsideRT: 1 # Fixes graphical corruption.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
   patches:
     466D1C13:
       content: |-
@@ -59231,6 +60984,8 @@ SLUS-20412:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes the fog line.
+    mipmap: 2 # Mipmap + trilinear, improves track textures to match sw renderer.
+    trilinearFiltering: 1
   patches:
     E7273BFA:
       content: |-
@@ -59274,6 +61029,9 @@ SLUS-20418:
     vuClampMode: 3 # Fixes water rendering.
   gameFixes:
     - XGKickHack # Fixes SPS while ingame.
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-20419:
   name: "World Rally Championship"
   region: "NTSC-U"
@@ -59377,6 +61135,8 @@ SLUS-20435:
   gsHWFixes:
     halfPixelOffset: 2 # Corrects positioning of reflections on suit's surfaces.
     roundSprite: 2 # Reduces garbage on the UI whilst upscaling.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-20436:
   name: "Guilty Gear X2"
   region: "NTSC-U"
@@ -59513,6 +61273,7 @@ SLUS-20465:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes side borders.
+    autoFlush: 1 # Fixes broken bloom effect.
 SLUS-20466:
   name: "Gravenville - Ghost Master"
   region: "NTSC-U"
@@ -59520,6 +61281,10 @@ SLUS-20467:
   name: "Tomb Raider - The Angel of Darkness"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    autoFlush: 2 # Fixes lava effect.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
   patches:
     3BAEBCC3:
       content: |-
@@ -59531,8 +61296,6 @@ SLUS-20467:
         // Force English - else the game crashes with French or Spanish set
         // in the BIOS configuration - a gamebug, not an emulator bug.
         patch=1,EE,0020520C,word,24020001 // 0C0882C8
-  gsHWFixes:
-    autoFlush: 2 # Fixes lava effect.
 SLUS-20468:
   name: "Dynasty Tactics"
   region: "NTSC-U"
@@ -59687,6 +61450,8 @@ SLUS-20496:
   gsHWFixes:
     preloadFrameData: 1 # Fixes fog and make lights on cars work again.
     autoFlush: 2 # Fixes sun luminosity and penetration of objects.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
   gameFixes:
     - EETimingHack # Fixes random graphical corruption.
 SLUS-20497:
@@ -59698,6 +61463,8 @@ SLUS-20497:
     autoFlush: 1 # Fixes bloom and sun rendering in front of everything.
     halfPixelOffset: 2 # Aligns bloom effect a little bit better when upscaled.
     bilinearUpscale: 2 # Reduces color banding of the sun glare.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
   roundModes:
     vu1RoundMode: 1 # Bright lights in cars.
 SLUS-20498:
@@ -59707,6 +61474,9 @@ SLUS-20499:
   name: "Breath of Fire - Dragon Quarter"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 4 # Aligns HUD and HUD bloom to match software.
+    roundSprite: 1 # Helps fix some lines and lines in text.
 SLUS-20500:
   name: "Red Dead Revolver"
   region: "NTSC-U"
@@ -59722,12 +61492,17 @@ SLUS-20502:
     alignSprite: 1 # Fixes vertical lines.
     autoFlush: 2 # Fixes the sun flare.
     halfPixelOffset: 2 # Fixes the sun flare.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-20504:
   name: "Tony Hawk's Pro Skater 4"
   region: "NTSC-U"
   compat: 5
   roundModes:
     vu1RoundMode: 0 # Crashes without.
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-20505:
   name: "Mace Griffin - Bounty Hunter"
   region: "NTSC-U"
@@ -59782,7 +61557,7 @@ SLUS-20515:
     roundSprite: 1 # Corrects some font artifacts.
     wildArmsHack: 1 # Corrects some more font artifacts a little.
 SLUS-20516:
-  name: "Shrek - Super Party"
+  name: "Shrek Super Party"
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
@@ -59795,6 +61570,8 @@ SLUS-20517:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
     alignSprite: 1 # Fixes vertical lines.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-20519:
   name: "Tak and The Power of Juju"
   region: "NTSC-U"
@@ -59886,6 +61663,8 @@ SLUS-20535:
   compat: 5
   gsHWFixes:
     roundSprite: 1 # Fix horizontal and vertical lines when racing.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
     deinterlace: 8 # Fixes misdetection of game deinterlace.
 SLUS-20536:
   name: "NBA Live 2003"
@@ -59982,6 +61761,8 @@ SLUS-20554:
     roundSprite: 2 # Fixes font artifacts.
     autoFlush: 1 # Fixes depth of field blur.
     recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-20555:
   name: "Reel Fishing 3"
   region: "NTSC-U"
@@ -60057,6 +61838,8 @@ SLUS-20565:
   name: "Champions of Norrath"
   region: "NTSC-U"
   compat: 5
+  gameFixes:
+    - BlitInternalFPSHack # Fixes internal fps detection in some areas.
   gsHWFixes:
     estimateTextureRegion: 1 # Improves performance.
 SLUS-20566:
@@ -60137,6 +61920,8 @@ SLUS-20578:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misaligned lighting and other effects.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
   clampModes:
     vuClampMode: 3 # Fix white shiny weapons.
 SLUS-20579:
@@ -60182,6 +61967,8 @@ SLUS-20585:
     eeClampMode: 3 # Fixes hangs in certain locations like building under construction.
   gsHWFixes:
     recommendedBlendingLevel: 2 # Fixes color saturation.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-20586:
   name: "IHRA Drag Racing 2"
   region: "NTSC-U"
@@ -60231,6 +62018,8 @@ SLUS-20595:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misaligned lighting and other effects, needs Special otherwise lights flicker.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-20596:
   name: "UFC - Ultimate Fighting Championship - Sudden Impact"
   region: "NTSC-U"
@@ -60241,6 +62030,9 @@ SLUS-20597:
   compat: 5
   gameFixes:
     - XGKickHack # Fixes corrupted graphics.
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-20598:
   name: "Everblue 2"
   region: "NTSC-U"
@@ -60274,6 +62066,8 @@ SLUS-20601:
   name: "Rayman 3 - Hoodlum Havoc"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    autoFlush: 1 # Fixes missing blur layer on reflections and surfaces.
 SLUS-20602:
   name: "High Heat - Major League Baseball 2004"
   region: "NTSC-U"
@@ -60573,6 +62367,9 @@ SLUS-20663:
 SLUS-20664:
   name: "Barbie Horse Adventures - Wild Horse Rescue"
   region: "NTSC-U"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-20665:
   name: "Cabela's Deer Hunt - 2004 Season"
   region: "NTSC-U"
@@ -60603,6 +62400,7 @@ SLUS-20669:
     alignSprite: 1 # Fixes vertical lines.
     roundSprite: 2 # Fixes font artifacts.
     mergeSprite: 1 # Fixes flame-like bleeding.
+    autoFlush: 1 # Fixes light bloom intensity.
 SLUS-20670:
   name: "The Great Escape"
   name-sort: "Great Escape, The"
@@ -60718,6 +62516,10 @@ SLUS-20686:
   name: "Splashdown - Rides Gone Wild"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    autoFlush: 1
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-20687:
   name: "RoadKill"
   region: "NTSC-U"
@@ -60934,13 +62736,18 @@ SLUS-20730:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    mipmap: 1 # Fixes textures.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-20731:
   name: "Tony Hawk's Underground"
   region: "NTSC-U"
   compat: 5
   roundModes:
     vu1RoundMode: 0 # Crashes without.
+  gsHWFixes:
+    minimumBlendingLevel: 3 # Fixes broken lighting on ground and buildings.
+    mipmap: 2 # Mipmap + trilinear, improves ground and buildings textures to match software.
+    trilinearFiltering: 1
 SLUS-20732:
   name: "Drakengard"
   region: "NTSC-U"
@@ -60948,6 +62755,7 @@ SLUS-20732:
   clampModes:
     eeClampMode: 3 # Characters are visible in-game.
   gsHWFixes:
+    recommendedBlendingLevel: 2
     texturePreloading: 1 # Performs better with partial preload because it is slow on locations outside gameplay foremost.
     mergeSprite: 1 # Fixes misaligned white lines.
     PCRTCOverscan: 1 # Fixes missing HUD.
@@ -60999,6 +62807,7 @@ SLUS-20743:
   compat: 5
   gsHWFixes:
     autoFlush: 2 # Reduces post-processing misalignment.
+    halfPixelOffset: 4 # Reduces post-processing misalignment.
 SLUS-20744:
   name: "EverQuest - Online Adventures - Frontiers"
   region: "NTSC-U"
@@ -61029,6 +62838,8 @@ SLUS-20748:
   gsHWFixes:
     halfPixelOffset: 2 # Gets rid of fog line.
     roundSprite: 1 # Fixes lines in FMVs.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-20749:
   name: "Rugby 2004"
   region: "NTSC-U"
@@ -61245,6 +63056,8 @@ SLUS-20782:
   compat: 5
   gsHWFixes:
     minimumBlendingLevel: 2 # Fixes dark font to more bright like software mode.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-20784:
   name: "The Italian Job"
   name-sort: "Italian Job, The"
@@ -61274,6 +63087,8 @@ SLUS-20788:
   compat: 5
   gsHWFixes:
     autoFlush: 1 # Fixes missing sun.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-20789:
   name: "Jeopardy!"
   region: "NTSC-U"
@@ -61282,6 +63097,9 @@ SLUS-20790:
   name: "Wheel of Fortune"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    recommendedBlendingLevel: 0 # Not sure how or why but it fixes banding.
+    halfPixelOffset: 2 # Fixes the most rotten nauseating absolutely vile corrupt abhorrent terrible and disgusting offset blur known to humankind.
 SLUS-20791:
   name: "Trivial Pursuit - Unhinged"
   region: "NTSC-U"
@@ -61347,6 +63165,8 @@ SLUS-20804:
   gsHWFixes:
     halfPixelOffset: 1 # Reduces ghosting.
     roundSprite: 1 # Reduces ghosting even more.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-20805:
   name: "Yu Yu Hakusho - Dark Tournament"
   region: "NTSC-U"
@@ -61362,11 +63182,16 @@ SLUS-20809:
   name: "Godzilla - Save the Earth"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-20810:
   name: "Nightshade"
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
     getSkipCount: "GSC_Kunoichi"
 SLUS-20811:
   name: "Need for Speed - Underground"
@@ -61507,6 +63332,8 @@ SLUS-20842:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 1 # Fixes vertical lines, font and others.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-20843:
   name: "Dead to Rights II"
   region: "NTSC-U"
@@ -61594,6 +63421,8 @@ SLUS-20855:
     vu1RoundMode: 0 # Fixes tyre textures.
   gsHWFixes:
     halfPixelOffset: 2 # Corrects shadow position.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-20856:
   name: "Spy Fiction"
   region: "NTSC-U"
@@ -61624,6 +63453,8 @@ SLUS-20860:
   gsHWFixes:
     wildArmsHack: 1 # Fixes blurriness.
     mergeSprite: 1 # Fixes misaligned lights.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-20861:
   name: "MTV Music Generator 3 - This is the Remix"
   region: "NTSC-U"
@@ -61748,6 +63579,8 @@ SLUS-20882:
   gsHWFixes:
     texturePreloading: 1 # Performs much better with partial preload.
     autoFlush: 1 # Fixes bloom rendering.
+    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
+    trilinearFiltering: 1
   roundModes:
     vu1RoundMode: 0 # Fixes missing light cones curtains and certain effects.
 SLUS-20883:
@@ -61778,6 +63611,8 @@ SLUS-20887:
     cpuSpriteRenderBW: 1 # Fixes shadow rendering.
     cpuSpriteRenderLevel: 1 # Needed for above.
     bilinearUpscale: 1 # Smoothes out shadow textures.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-20888:
   name: "Front Mission 4"
   region: "NTSC-U"
@@ -61857,10 +63692,18 @@ SLUS-20899:
   name: "Samurai Jack - The Shadow of Aku"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-20901:
   name: "FlatOut"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves car reflections.
+    autoFlush: 1
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-20902:
   name: "Shadow of Rome"
   region: "NTSC-U"
@@ -61884,7 +63727,7 @@ SLUS-20904:
     halfPixelOffset: 2 # Fixes bloom misalignment when upscaling.
     cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling.
 SLUS-20905:
-  name: "The Incredibles"
+  name: "Disney/Pixar The Incredibles"
   name-sort: "Incredibles, The"
   region: "NTSC-U"
   compat: 5
@@ -61922,6 +63765,9 @@ SLUS-20910:
   name: "Test Drive - Eve of Destruction"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-20911:
   name: "Shin Megami Tensei - Nocturne"
   region: "NTSC-U"
@@ -61972,6 +63818,10 @@ SLUS-20918:
   compat: 5
   roundModes:
     eeRoundMode: 1 # Fixes object balls never stopping in the Monkey Billiards DX minigame.
+  gsHWFixes:
+    recommendedBlendingLevel: 4 # Fixes text and foliage color.
+    mipmap: 2 # Mipmap + trilinear, improves stage textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-20919:
   name: "ESPN - NFL 2K5"
   region: "NTSC-U"
@@ -62023,7 +63873,7 @@ SLUS-20924:
   region: "NTSC-U"
   compat: 5
 SLUS-20925:
-  name: "Shark Tale"
+  name: "DreamWorks Shark Tale"
   region: "NTSC-U"
   compat: 2
   speedHacks:
@@ -62066,6 +63916,8 @@ SLUS-20932:
   compat: 5
   gsHWFixes:
     autoFlush: 2 # Fixes missing lighting.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
     # halfPixelOffset: 1 # Fixes lighting misalignment. Do not enable this, it breaks a lot of graphics.
 SLUS-20933:
   name: "Smash Court Pro Tournament Tennis 2"
@@ -62077,6 +63929,10 @@ SLUS-20934:
   compat: 5
   gsHWFixes:
     alignSprite: 1 # Fixes FMV lines.
+    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
+    trilinearFiltering: 1
+    cpuSpriteRenderBW: 2 # Prevents Death By VRAM explosion.
+    cpuSpriteRenderLevel: 2 # Needed for above.
     getSkipCount: "GSC_DeathByDegreesTekkenNinaWilliams"
 SLUS-20935:
   name: "IHRA Professional Drag Racing 2005"
@@ -62119,6 +63975,10 @@ SLUS-20942:
   name: "Robots"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes misaligned bloom.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-20943:
   name: "Heroes of the Pacific"
   region: "NTSC-U"
@@ -62196,13 +64056,16 @@ SLUS-20957:
   compat: 5
   roundModes:
     eeRoundMode: 2 # Fixes missing text.
+  gsHWFixes:
+    autoFlush: 1 # Fixes player shadow.
 SLUS-20958:
   name: "Tom Clancy's Splinter Cell - Pandora Tomorrow"
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
     preloadFrameData: 1 # Fixes missing loading screens.
-    mergeSprite: 1 # Fixes misaligned bloom on light sources.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-20959:
   name: "The Dukes of Hazzard - Return of the General Lee"
   name-sort: "Dukes of Hazzard, The - Return of the General Lee"
@@ -62262,6 +64125,9 @@ SLUS-20966:
   name: "State of Emergency 2"
   region: "NTSC-U"
   compat: 4
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-20967:
   name: "Enthusia Professional Racing"
   region: "NTSC-U"
@@ -62326,7 +64192,7 @@ SLUS-20978:
   region: "NTSC-U"
   compat: 4
   gsHWFixes:
-    autoFlush: 2
+    autoFlush: 1 # Fixes light penetration.
   patches:
     42E15DEF:
       content: |-
@@ -62377,6 +64243,8 @@ SLUS-20986:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
     recommendedBlendingLevel: 3 # Fixes level brightness.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
   memcardFilters:
     - "SLUS-20986"
     - "SLUS-21079"
@@ -62487,9 +64355,16 @@ SLUS-21006:
   name: "Ghost in the Shell - Stand Alone Complex"
   region: "NTSC-U"
   compat: 5
+  gameFixes:
+    - SoftwareRendererFMVHack # Fixes hash cache disabling itself.
   gsHWFixes:
-    halfPixelOffset: 1 # Fixes texture and lighting misalignment.
+    recommendedBlendingLevel: 4 # Improves banding and effect emulation.
+    halfPixelOffset: 3 # Fixes texture and lighting misalignment.
     mergeSprite: 1 # Fixes most vertical lines and lighting misalignment.
+    autoFlush: 1 # Fixes light bloom intensity.
+    estimateTextureRegion: 1 # Improves performance and reduces hash cache size.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
     getSkipCount: "GSC_GiTS"
   patches:
     default:
@@ -62578,6 +64453,8 @@ SLUS-21015:
   gsHWFixes:
     roundSprite: 2 # Improves bloom alignment and clarity.
     halfPixelOffset: 2 # Improves bloom alignment and clarity.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-21016:
   name: "25 to Life"
   region: "NTSC-U"
@@ -62593,7 +64470,10 @@ SLUS-21018:
   clampModes:
     vuClampMode: 3 # Fixes minor SPS on characters.
   gsHWFixes:
+    roundSprite: 1 # Fix lines in the sky.
     halfPixelOffset: 2 # Fixes double image.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-21019:
   name: "Technic Beat"
   region: "NTSC-U"
@@ -62628,6 +64508,8 @@ SLUS-21026:
     autoFlush: 1 # Post-processing.
     halfPixelOffset: 2 # Offset post-processing.
     texturePreloading: 1 # Improves performance.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
     getSkipCount: "GSC_Battlefield2" # Depth clear.
     beforeDraw: "OI_Battlefield2" # Framebuffer copy, fixes rendering for bottom part of screen.
 SLUS-21027:
@@ -62637,6 +64519,8 @@ SLUS-21027:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-21028:
   name: "World Championship Poker"
   region: "NTSC-U"
@@ -62645,6 +64529,10 @@ SLUS-21029:
   name: "Midnight Club 3 - DUB Edition"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves car and road textures to match sw renderer.
+    trilinearFiltering: 1
+    getSkipCount: "GSC_MidnightClub3"
   patches:
     0DD3417A:
       content: |-
@@ -62664,8 +64552,6 @@ SLUS-21029:
         // for VU1 to finish, which reduces the advantage of MTVU to basically zero.
         patch=1,EE,D05257FC,extended,00000800
         patch=1,EE,205257FC,extended,00000000
-  gsHWFixes:
-    getSkipCount: "GSC_MidnightClub3"
 SLUS-21030:
   name: "Outlaw Golf 2"
   region: "NTSC-U"
@@ -62723,6 +64609,8 @@ SLUS-21039:
   compat: 5
   gsHWFixes:
     alignSprite: 1 # Fixes lighting and vertical lines, also works with normal vertex.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-21040:
   name: "The Shield"
   name-sort: "Shield, The"
@@ -62743,6 +64631,8 @@ SLUS-21042:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blood vision bloom
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-21043:
   name: "Backyard Wrestling 2 - There Goes the Neighborhood"
   region: "NTSC-U"
@@ -62847,6 +64737,8 @@ SLUS-21059:
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
     halfPixelOffset: 4 # Align post.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
     getSkipCount: "GSC_Tekken5"
 SLUS-21060:
   name: "WWE SmackDown! vs. RAW"
@@ -62941,6 +64833,8 @@ SLUS-21079:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
     recommendedBlendingLevel: 3 # Fixes level brightness.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
   memcardFilters:
     - "SLUS-20986"
     - "SLUS-21079"
@@ -62959,12 +64853,17 @@ SLUS-21082:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes lighting misalignment.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-21083:
   name: "LEGO Star Wars - The Video Game"
   region: "NTSC-U"
   compat: 5
   clampModes:
     vuClampMode: 3 # Fixes bad coordinate spam.
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-21084:
   name: "Winnie the Pooh's Rumbly Tumbly Adventure"
   region: "NTSC-U"
@@ -63092,6 +64991,8 @@ SLUS-21108:
     vuClampMode: 0 # Fixes bump mapping issues
   gsHWFixes:
     textureInsideRT: 1 # Fixes post processing.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
     getSkipCount: "GSC_HitmanBloodMoney"
 SLUS-21109:
   name: "Drive to Survive"
@@ -63119,6 +65020,8 @@ SLUS-21112:
   compat: 5
   gsHWFixes:
     cpuSpriteRenderBW: 4 # Fixes textures.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-21113:
   name: "Atelier Iris - Eternal Mana"
   region: "NTSC-U"
@@ -63138,8 +65041,11 @@ SLUS-21116:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    autoFlush: 2 # Softens bloom on objects and cars.
-    halfPixelOffset: 2 # Fixes misaligned bloom on objects and cars.
+    recommendedBlendingLevel: 4 # Improves car color.
+    autoFlush: 1 # Softens bloom on objects and cars.
+    halfPixelOffset: 4 # Fixes misaligned bloom on objects and cars.
+    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-21117:
   name: "World Soccer - Winning Eleven 8 - International"
   region: "NTSC-U"
@@ -63191,6 +65097,8 @@ SLUS-21127:
     preloadFrameData: 1 # Fixes sun flickering.
     autoFlush: 2 # Fixes sun through objects.
     bilinearUpscale: 1 # Smooths out sun glare textures like native.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-21128:
   name: "Blitz - The League"
   region: "NTSC-U"
@@ -63199,6 +65107,9 @@ SLUS-21129:
   name: "Tenchu 4 - Fatal Shadows"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-21130:
   name: "SnoCross 2 featuring Blair Morgan"
   region: "NTSC-U"
@@ -63230,6 +65141,8 @@ SLUS-21134:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-21135:
   name: "MVP Baseball 2005"
   region: "NTSC-U"
@@ -63240,6 +65153,8 @@ SLUS-21136:
   name: "Graffiti Kingdom"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 4 # Fixes distant offset blur.
 SLUS-21137:
   name: "Tom Clancy's Splinter Cell - Chaos Theory"
   region: "NTSC-U"
@@ -63260,8 +65175,8 @@ SLUS-21139:
     minimumBlendingLevel: 3 # Fixes broken light and shadow rendering.
     mipmap: 2 # Mipmap + trilinear, improves ground textures and water textures and reflections.
     trilinearFiltering: 1
-    halfPixelOffset: 4 # Fixes misaligned bloom and character shadows.
-    autoFlush: 2 # Fixes missing bloom intensity and alignment.
+    halfPixelOffset: 2 # Fixes misaligned bloom and character shadows.
+    autoFlush: 1 # Fixes missing bloom intensity and alignment.
 SLUS-21140:
   name: "Mobile Suit Gundam Seed - Never Ending Tomorrow"
   region: "NTSC-U"
@@ -63277,7 +65192,7 @@ SLUS-21143:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 1 # Fixes bloom misalignment.
+    halfPixelOffset: 4 # Fixes bloom misalignment.
 SLUS-21144:
   name: "Tom Clancy's Rainbow Six - Lockdown"
   region: "NTSC-U"
@@ -63336,6 +65251,9 @@ SLUS-21153:
   name: "Dynasty Warriors 5"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-21154:
   name: "Killer7"
   region: "NTSC-U"
@@ -63367,6 +65285,8 @@ SLUS-21160:
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
     halfPixelOffset: 4 # Align post.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
     getSkipCount: "GSC_Tekken5"
 SLUS-21161:
   name: "Fight Night - Round 2"
@@ -63536,6 +65456,8 @@ SLUS-21191:
     PCRTCOverscan: 1 # Fixes offscreen image.
     nativePaletteDraw: 1 # Fixes the look of screen effects.
     halfPixelOffset: 2 # Corrects the alignment of screen effects.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-21192:
   name: "Cabela's Outdoor Adventures 2006"
   region: "NTSC-U"
@@ -63580,6 +65502,8 @@ SLUS-21199:
     halfPixelOffset: 2 # Fixes misaligned blur.
     cpuSpriteRenderBW: 2 # Fixes black spots appearing on some surfaces and massively reduces RP TC and TU count.
     cpuSpriteRenderLevel: 2 # Needed for above.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-21200:
   name: "Armored Core - Nine Breaker"
   region: "NTSC-U"
@@ -63587,6 +65511,8 @@ SLUS-21200:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
     recommendedBlendingLevel: 3 # Fixes level brightness.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
   memcardFilters: # Can import data from AC:Nexus.
     - "SLUS-21200"
     - "SLUS-20986"
@@ -63628,10 +65554,11 @@ SLUS-21207:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    autoFlush: 2 # Fixes missing bloom from surfaces like windows.
+    autoFlush: 1 # Fixes missing bloom from surfaces like windows.
     # halfPixelOffset: 1 # Aligns shadows properly, but causes grid lines to appear in sea travel.
     halfPixelOffset: 2 # Sharpens world in far distances, aligns some bloom better.
     roundSprite: 1 # Fixes font artifacts.
+    cpuSpriteRenderBW: 1 # Fixes broken fire sprites.
 SLUS-21208:
   name: "Tony Hawk's American Wasteland"
   region: "NTSC-U"
@@ -63655,6 +65582,8 @@ SLUS-21209:
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
     textureInsideRT: 1 # Fixes corruption.
+    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
+    trilinearFiltering: 1
     getSkipCount: "GSC_UrbanReign"
 SLUS-21212:
   name: "Spartan - Total Warrior"
@@ -63665,6 +65594,8 @@ SLUS-21212:
   gsHWFixes:
     autoFlush: 1 # Fixes missing post processing.
     halfPixelOffset: 1 # Aligns post processing.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-21213:
   name: "Madden NFL '06"
   region: "NTSC-U"
@@ -63687,6 +65618,9 @@ SLUS-21215:
   name-sort: "Warriors, The"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-21216:
   name: "Soul Calibur III"
   region: "NTSC-U"
@@ -63700,11 +65634,12 @@ SLUS-21216:
     halfPixelOffset: 3 # Fixes blurriness (normal vertex causes vertical lines).
     recommendedBlendingLevel: 3 # Fixes menu transparency.
 SLUS-21217:
-  name: "The Incredibles - Rise of the Underminer"
-  name-sort: "Incredibles, The - Rise of the Underminer"
+  name: "Disney/Pixar The Incredibles - Rise of the Underminer"
+  name-sort: "Disney/Pixar Incredibles, The - Rise of the Underminer"
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes building shade and shadows.
     mipmap: 2 # Mipmap + trilinear, improves the street's textures to match sw renderer.
     trilinearFiltering: 1
     halfPixelOffset: 2 # Fixes bloom misalignment when upscaling.
@@ -63800,6 +65735,8 @@ SLUS-21231:
     autoFlush: 2 # Fixes bloom misalignment.
     halfPixelOffset: 2 # Fixes bloom misalignment.
     textureInsideRT: 1 # Fixes sky bloom.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-21232:
   name: "College Hoops 2K6"
   region: "NTSC-U"
@@ -63854,6 +65791,8 @@ SLUS-21238:
   name: "Final Fight - Streetwise"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes excessive blur.
 SLUS-21239:
   name: "Beatmania"
   region: "NTSC-U"
@@ -63960,6 +65899,9 @@ SLUS-21252:
   name: "SpongeBob SquarePants - Lights, Camera, PANTS!"
   region: "NTSC-U"
   compat: 4
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-21253:
   name: "TY the Tasmanian Tiger 3 - Night of the Quinkan"
   region: "NTSC-U"
@@ -63988,6 +65930,8 @@ SLUS-21257:
     halfPixelOffset: 2 # Fixes blurriness.
     cpuCLUTRender: 1 # Final colour adjustment LUT.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-21258:
   name: ".hack//G.U. Vol.1 - Rebirth"
   region: "NTSC-U"
@@ -64071,6 +66015,8 @@ SLUS-21267:
     halfPixelOffset: 2 # Fixes blurriness.
     cpuCLUTRender: 1 # Final colour adjustment LUT.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
   memcardFilters:
     - "SLUS-21267"
     - "SLUS-21351"
@@ -64113,6 +66059,8 @@ SLUS-21271:
     cpuCLUTRender: 1 # Fixes the rest of the bad textures.
     roundSprite: 1 # Reduces misaligned bloom.
     mergeSprite: 1 # Removes bloom explosion around electrical lights and other light sources such as moon/sun.
+    mipmap: 2 # Mipmap + trilinear, improves road textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-21272:
   name: "Super Monkey Ball Adventure"
   region: "NTSC-U"
@@ -64151,12 +66099,13 @@ SLUS-21276:
   region: "NTSC-U"
   compat: 5
 SLUS-21277:
-  name: "Barnyard"
+  name: "Nickelodeon Barnyard"
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fix text and post blur.
     mipmap: 2 # Base mip level isn't always used.
+    trilinearFiltering: 1
     autoFlush: 2 # Needed for recursive mipmap rendering.
     getSkipCount: "GSC_BlueTongueGames" # Render mipmaps on the CPU.
 SLUS-21278:
@@ -64212,6 +66161,8 @@ SLUS-21282:
   gsHWFixes:
     textureInsideRT: 1 # Required for complex offset shuffles.
     halfPixelOffset: 2 # Fixes center upscaling line during explosions.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
     recommendedBlendingLevel: 4 # Fixes lighting.
 SLUS-21283:
   name: "Total Overdose - A Gunslinger's Tale in Mexico"
@@ -64247,8 +66198,8 @@ SLUS-21287:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    autoFlush: 2 # Reduces post-processing misalignment.
-    halfPixelOffset: 1 # Reduces post-processing misalignment.
+    autoFlush: 1 # Reduces post-processing misalignment.
+    halfPixelOffset: 4 # Reduces post-processing misalignment.
 SLUS-21288:
   name: "American Chopper 2"
   region: "NTSC-U"
@@ -64324,7 +66275,7 @@ SLUS-21299:
   gsHWFixes:
     autoFlush: 2 # Fixes sun luminosity.
 SLUS-21300:
-  name: "Over the Hedge"
+  name: "DreamWorks Over the Hedge"
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
@@ -64396,6 +66347,8 @@ SLUS-21312:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misalignment/bloom when upscaling.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-21313:
   name: "Friends - The One with all the Trivia"
   region: "NTSC-U"
@@ -64419,6 +66372,8 @@ SLUS-21315:
   region: "NTSC-U"
   gsHWFixes:
     roundSprite: 1 # Removes chromatic effect when upscaling also works with halfpixeloffset Special Texture.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-21316:
   name: "Capcom Classics Collection Vol. 1"
   region: "NTSC-U"
@@ -64572,6 +66527,8 @@ SLUS-21338:
   gsHWFixes:
     halfPixelOffset: 2 # Corrects shadow alignment and reduces blurriness.
     recommendedBlendingLevel: 3 # Fixes level and map menu brightness.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-21339:
   name: "Puzzle Collection - Crosswords & More!"
   region: "NTSC-U"
@@ -64657,6 +66614,8 @@ SLUS-21351:
     halfPixelOffset: 2 # Fixes blurriness.
     cpuCLUTRender: 1 # Final colour adjustment LUT.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
   memcardFilters:
     - "SLUS-21267"
     - "SLUS-21351"
@@ -64676,6 +66635,10 @@ SLUS-21355:
   name: "Midnight Club 3 - DUB Edition Remix"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves car and road textures to match sw renderer.
+    trilinearFiltering: 1
+    getSkipCount: "GSC_MidnightClub3"
   patches:
     60A42FF5:
       content: |-
@@ -64686,12 +66649,13 @@ SLUS-21355:
         // for VU1 to finish, which reduces the advantage of MTVU to basically zero.
         patch=1,EE,D052907C,extended,00000800
         patch=1,EE,2052907C,extended,00000000
-  gsHWFixes:
-    getSkipCount: "GSC_MidnightClub3"
 SLUS-21356:
   name: "Tom Clancy's Splinter Cell - Double Agent"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-21357:
   name: "Hummer Badlands"
   region: "NTSC-U"
@@ -64933,6 +66897,8 @@ SLUS-21389:
     halfPixelOffset: 2 # Fixes lighting misalignment and reduces ground shadows.
     roundSprite: 2 # Fixes font artifacts.
     textureInsideRT: 1 # Fixes bad crystal surfaces.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
   memcardFilters: # Allows import of Xenosaga II save data.
     - "SLUS-21389"
     - "SLUS-20892"
@@ -64950,7 +66916,7 @@ SLUS-21391:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
 SLUS-21392:
-  name: "Shrek Smash and Crash"
+  name: "DreamWorks Shrek - Smash n' Crash Racing"
   region: "NTSC-U"
   compat: 5
 SLUS-21393:
@@ -64990,6 +66956,8 @@ SLUS-21399:
     cpuCLUTRender: 1 # Fixes the rest of the bad textures.
     roundSprite: 1 # Reduces misaligned bloom.
     mergeSprite: 1 # Removes bloom explosion around electrical lights and other light sources such as moon/sun.
+    mipmap: 2 # Mipmap + trilinear, improves road textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-21400:
   name: "Monster House"
   region: "NTSC-U"
@@ -65095,6 +67063,8 @@ SLUS-21417:
     halfPixelOffset: 2 # Fixes lighting misalignment and reduces ground shadows.
     roundSprite: 2 # Fixes font artifacts.
     textureInsideRT: 1 # Fixes bad crystal surfaces.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
   memcardFilters:
     - "SLUS-21389"
     - "SLUS-20892"
@@ -65151,6 +67121,8 @@ SLUS-21423:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 1 # Removes blur due to misaligned fullscreen effect.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-21424:
   name: "NBA 2K7"
   region: "NTSC-U"
@@ -65189,6 +67161,8 @@ SLUS-21428:
   compat: 5
   gsHWFixes:
     cpuCLUTRender: 1 # Fixes ghosting on objects and people.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-21430:
   name: "IGPX - Immortal Grand Prix"
   region: "NTSC-U"
@@ -65214,6 +67188,9 @@ SLUS-21434:
   compat: 4
   gameFixes:
     - VUOverflowHack # Fixes SPS.
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-21435:
   name: "One Piece - Grand Adventure"
   region: "NTSC-U"
@@ -65239,7 +67216,8 @@ SLUS-21438:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    mipmap: 1
+    mipmap: 2 # Mipmap + trilinear, fixes flickering and improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-21439:
   name: "Destroy All Humans! 2"
   region: "NTSC-U"
@@ -65262,6 +67240,7 @@ SLUS-21441:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
+    halfPixelOffset: 2 # Fixes character outlines and minor bloom.
     beforeDraw: "OI_DBZBTGames"
 SLUS-21442:
   name: "Super Dragon Ball Z"
@@ -65278,6 +67257,10 @@ SLUS-21444:
   compat: 5
   roundModes:
     vu1RoundMode: 0 # Fixes invalid VU size spam and likely SPS.
+  gsHWFixes:
+    autoFlush: 1 # Fixes black line down the side of the screen and player shadow.
+    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-21445:
   name: "Ar tonelico - Melody of Elemia"
   region: "NTSC-U"
@@ -65309,6 +67292,8 @@ SLUS-21449:
     recommendedBlendingLevel: 4 # Fixes car reflections.
     mergeSprite: 1 # Fixes bluriness.
     halfPixelOffset: 4 # Fixes bluriness.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-21450:
   name: "Super PickUps"
   region: "NTSC-U"
@@ -65379,6 +67364,9 @@ SLUS-21461:
   name: "NASCAR '07"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-21462:
   name: "Samurai Warriors 2"
   region: "NTSC-U"
@@ -65475,6 +67463,7 @@ SLUS-21479:
     - EETimingHack
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
+    textureInsideRT: 1 # Fixes bottom half screen issues.
 SLUS-21480:
   name: ".hack//G.U. Volume 1 - Rebirth - Terminal Disc"
   region: "NTSC-U"
@@ -65510,7 +67499,7 @@ SLUS-21483:
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
 SLUS-21484:
-  name: "Flushed Away"
+  name: "DreamWorks & Aardman Flushed Away"
   region: "NTSC-U"
   compat: 5
 SLUS-21485:
@@ -65580,11 +67569,15 @@ SLUS-21493:
   compat: 5
   clampModes:
     eeClampMode: 3 # Fixes game hang after opening intro.
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes depth line.
 SLUS-21494:
   name: "Need for Speed - Carbon [Collector's Edition]"
   region: "NTSC-U"
   clampModes:
     eeClampMode: 3 # Fixes game hang after opening intro.
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes depth line.
 SLUS-21495:
   name: "Sudoku, Carol Vorderman's"
   region: "NTSC-U"
@@ -65628,6 +67621,8 @@ SLUS-21536:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned textures.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-21537:
   name: "Fatal Fury Battle Archives Vol.1"
   region: "NTSC-U"
@@ -65770,6 +67765,9 @@ SLUS-21566:
   name: "Brunswick Pro Bowling"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves alley textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-21567:
   name: "Shining Force EXA"
   region: "NTSC-U"
@@ -65845,12 +67843,17 @@ SLUS-21581:
   name: "UEFA Champions League 2006-2007"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-21582:
   name: "MVP '07 - NCAA Baseball"
   region: "NTSC-U"
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes broken replay window graphics.
     cpuSpriteRenderLevel: 2 # Needed for above.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-21583:
   name: "Crash of the Titans"
   region: "NTSC-U"
@@ -65888,7 +67891,7 @@ SLUS-21590:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 1 # Fixes misaligned effect when in-game Trails option is turned on.
+    halfPixelOffset: 2 # Fixes misaligned effect when in-game Trails option is turned on.
 SLUS-21591:
   name: "Ski-Doo Snow X Racing"
   region: "NTSC-U"
@@ -65935,6 +67938,8 @@ SLUS-21597:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes lighting misalignment.
     mergeSprite: 1 # Removes occasional vertical lines.
+    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-21598:
   name: "Digimon World - Data Squad"
   region: "NTSC-U"
@@ -66045,6 +68050,7 @@ SLUS-21614:
   compat: 5
   gsHWFixes:
     recommendedBlendingLevel: 2 # Fixes player shadow definition and color banding.
+    halfPixelOffset: 2 # Fixes misaligned bloom effects.
     autoFlush: 1 # Fixes player shadow.
   patches:
     879CDA5E:
@@ -66112,7 +68118,6 @@ SLUS-21622:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    recommendedBlendingLevel: 3 # Fixes hive color.
     halfPixelOffset: 4 # Fixes bloom on sunlight.
     mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
     trilinearFiltering: 1
@@ -66178,6 +68183,8 @@ SLUS-21633:
   compat: 5
   gsHWFixes:
     textureInsideRT: 1 # Fixes shadows.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-21634:
   name: "Crazy Frog Racer 2"
   region: "NTSC-U"
@@ -66233,6 +68240,9 @@ SLUS-21640:
   name: "Rugby '08"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-21641:
   name: "Innocent Life - Harvest Moon - Pure"
   region: "NTSC-U"
@@ -66289,6 +68299,9 @@ SLUS-21650:
   compat: 5
   gameFixes:
     - EETimingHack # Flickery textures.
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-21651:
   name: "Noddy and the Magic Book"
   region: "NTSC-U"
@@ -66342,6 +68355,8 @@ SLUS-21664:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 4 # Removes horizontal and vertical lines on the ground, trees and the sky.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-21665:
   name: "The Simpsons Game"
   name-sort: "Simpsons Game, The"
@@ -66378,6 +68393,9 @@ SLUS-21672:
     vu1RoundMode: 0 # Crashes without.
   gsHWFixes:
     textureInsideRT: 1 # Crowd textures.
+    autoFlush: 1 # Fixes bloom intensity.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-21673:
   name: "College Hoops 2K8"
   region: "NTSC-U"
@@ -66409,7 +68427,8 @@ SLUS-21678:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    cpuCLUTRender: 1 # Reduces the bloomy blur of characters.
+    halfPixelOffset: 2 # Fixes character outlines and minor bloom.
+    cpuCLUTRender: 1 # Aligns character bloom and some stage bloom.
     beforeDraw: "OI_DBZBTGames"
 SLUS-21679:
   name: "Power Rangers - Super Legends"
@@ -66425,6 +68444,8 @@ SLUS-21681:
   compat: 4
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes skin colour.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-21682:
   name: "Rock Band"
   region: "NTSC-U"
@@ -66576,6 +68597,9 @@ SLUS-21712:
   name: "History Channel - Battle for the Pacific"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-21713:
   name: "Winter Sports 2008 - The Ultimate Challenge"
   region: "NTSC-U"
@@ -66693,6 +68717,8 @@ SLUS-21733:
     - VUSyncHack # Fixes SPS.
   gsHWFixes:
     halfPixelOffset: 1 # Fixes post bloom alignment.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-21734:
   name: "Falling Stars"
   region: "NTSC-U"
@@ -66730,6 +68756,8 @@ SLUS-21739:
   name: "Iron Man"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes misaligned bloom.
 SLUS-21740:
   name: "Guitar Hero - Aerosmith"
   region: "NTSC-U"
@@ -66738,6 +68766,9 @@ SLUS-21740:
     vu1RoundMode: 0 # Fixes VU size spam and potential graphical issues with GH3 engine.
   gsHWFixes:
     textureInsideRT: 1 # Crowd textures.
+    autoFlush: 1 # Fixes bloom intensity.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-21741:
   name: "Sea Monsters - A Prehistoric Adventure"
   region: "NTSC-U"
@@ -66815,6 +68846,9 @@ SLUS-21755:
   name: "Are You Smarter Than A 5th Grader - Make The Grade"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, makes the game's textures worse to match software.
+    trilinearFiltering: 1
 SLUS-21756:
   name: "The Chronicles of Narnia - Prince Caspian"
   name-sort: "Chronicles of Narnia, The - Prince Caspian"
@@ -66829,6 +68863,8 @@ SLUS-21757:
   compat: 5
   gsHWFixes:
     cpuSpriteRenderBW: 1 # Fixes textures.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-21758:
   name: "Rock Band - Track Pack Vol.1"
   region: "NTSC-U"
@@ -66849,6 +68885,8 @@ SLUS-21761:
   name: "B-Boy"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    autoFlush: 1 # Fixes lighting.
 SLUS-21763:
   name: "NHL 2K9"
   region: "NTSC-U"
@@ -67009,7 +69047,7 @@ SLUS-21789:
   region: "NTSC-U"
   compat: 5
 SLUS-21790:
-  name: "Shrek's Carnival Craze"
+  name: "DreamWorks Shrek's Carnival Craze - Party Games"
   region: "NTSC-U"
   compat: 5
 SLUS-21791:
@@ -67308,6 +69346,9 @@ SLUS-21858:
   compat: 5
   gsHWFixes:
     textureInsideRT: 1 # Needed for post processing effects.
+    autoFlush: 1 # Fixes missing blur layer.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-21860:
   name: "The Bigs 2"
   name-sort: "Bigs 2, The"
@@ -67352,6 +69393,9 @@ SLUS-21867:
   compat: 5
   gsHWFixes:
     preloadFrameData: 1 # Fixes icons.
+    autoFlush: 1 # Fixes bloom intensity.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
   roundModes:
     vu1RoundMode: 0 # Fixes VU size spam and potential graphical issues with GH3 engine.
 SLUS-21868:
@@ -67561,6 +69605,9 @@ SLUS-21907:
   name: "Jurassic - The Hunted"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-21908:
   name: "NBA 2K10"
   region: "NTSC-U"
@@ -67627,6 +69674,9 @@ SLUS-21924:
   region: "NTSC-U"
   gsHWFixes:
     preloadFrameData: 1 # Fixes icons.
+    autoFlush: 1 # Fixes bloom intensity.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
   roundModes:
     vu1RoundMode: 0 # Fixes VU size spam and potential graphical issues with GH3 engine.
 SLUS-21926:
@@ -67803,6 +69853,9 @@ SLUS-28006:
   region: "NTSC-U"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
+    autoFlush: 1 # Fixes missing blur layer on sky.
+    mipmap: 2 # Mipmap + trilinear, improves road textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-28007:
   name: "All-Star Baseball 2003 [Trade Demo]"
   region: "NTSC-U"
@@ -67840,6 +69893,8 @@ SLUS-28019:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
     alignSprite: 1 # Fixes vertical lines.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-28020:
   name: "Everquest Online Adventures [Beta Vol.1.0]"
   region: "NTSC-U"
@@ -67851,6 +69906,8 @@ SLUS-28023:
   region: "NTSC-U"
   gsHWFixes:
     halfPixelOffset: 1 # Sharpens world in far distances.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-28025:
   name: "Disaster Report [Trade Demo]"
   region: "NTSC-U"
@@ -67908,6 +69965,9 @@ SLUS-28040:
 SLUS-28043:
   name: "Test Drive - Eve of Destruction [Trade Demo]"
   region: "NTSC-U"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-28044:
   name: "Choro Q [Trade Demo]"
   region: "NTSC-U"
@@ -67945,6 +70005,9 @@ SLUS-28054:
 SLUS-28056:
   name: "State of Emergency 2 [Trade Demo]"
   region: "NTSC-U"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-28059:
   name: "Metal Saga [Trade Demo]"
   region: "NTSC-U"
@@ -67999,6 +70062,8 @@ SLUS-29003:
     - InstantDMAHack # Fixes broken half-bottom artifacts.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-29004:
   name: "Unison & Dead or Alive 2 Hardcore [Demo]"
   region: "NTSC-U"
@@ -68038,6 +70103,9 @@ SLUS-29013:
 SLUS-29014:
   name: "Half-Life [Demo]"
   region: "NTSC-U"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-29015:
   name: "Dark Summit [Demo]"
   region: "NTSC-U"
@@ -68112,6 +70180,8 @@ SLUS-29038:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
     alignSprite: 1 # Fixes vertical lines.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-29040:
   name: "Dr. Muto [Demo]"
   region: "NTSC-U"
@@ -68120,6 +70190,8 @@ SLUS-29042:
   region: "NTSC-U"
   gsHWFixes:
     halfPixelOffset: 1 # Sharpens world in far distances.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-29044:
   name: "Pride FC - Fighting Championships [Demo]"
   region: "NTSC-U"
@@ -68137,6 +70209,9 @@ SLUS-29049:
   region: "NTSC-U"
   gameFixes:
     - XGKickHack # Fixes corrupted graphics.
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-29050:
   name: "Everquest Online Adventures [Regular Demo]"
   region: "NTSC-U"
@@ -68154,6 +70229,7 @@ SLUS-29056:
   region: "NTSC-U"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes side borders.
+    autoFlush: 1 # Fixes broken bloom effect.
 SLUS-29057:
   name: "Sphinx and the Shadow of Set [Demo]"
   region: "NTSC-U"
@@ -68193,6 +70269,7 @@ SLUS-29069:
   region: "NTSC-U"
   gsHWFixes:
     autoFlush: 2 # Reduces post-processing misalignment.
+    halfPixelOffset: 4 # Reduces post-processing misalignment.
 SLUS-29070:
   name: "XIII [Demo]"
   region: "NTSC-U"
@@ -68266,6 +70343,8 @@ SLUS-29087:
 SLUS-29088:
   name: "Champions of Norrath - Realms of EverQuest [Demo]"
   region: "NTSC-U"
+  gameFixes:
+    - BlitInternalFPSHack # Fixes internal fps detection in some areas.
   gsHWFixes:
     estimateTextureRegion: 1 # Improves performance.
 SLUS-29089:
@@ -68358,6 +70437,8 @@ SLUS-29117:
     autoFlush: 1 # Post-processing.
     halfPixelOffset: 2 # Offset post-processing.
     texturePreloading: 1 # Improves performance.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
     getSkipCount: "GSC_Battlefield2" # Depth clear.
     beforeDraw: "OI_Battlefield2" # Framebuffer copy, fixes rendering for bottom part of screen.
 SLUS-29118:
@@ -68368,9 +70449,16 @@ SLUS-29118:
 SLUS-29123:
   name: "Ghost in the Shell - Stand Alone Complex [Demo]"
   region: "NTSC-U"
+  gameFixes:
+    - SoftwareRendererFMVHack # Fixes hash cache disabling itself.
   gsHWFixes:
-    halfPixelOffset: 1 # Fixes texture and lighting misalignment.
+    recommendedBlendingLevel: 4 # Improves banding and effect emulation.
+    halfPixelOffset: 3 # Fixes texture and lighting misalignment.
     mergeSprite: 1 # Fixes most vertical lines and lighting misalignment.
+    autoFlush: 1 # Fixes light bloom intensity.
+    estimateTextureRegion: 1 # Improves performance and reduces hash cache size.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
     getSkipCount: "GSC_GiTS"
 SLUS-29124:
   name: "Fight Club [Demo]"
@@ -68422,6 +70510,8 @@ SLUS-29137:
   region: "NTSC-U"
   gsHWFixes:
     autoFlush: 2 # Fixes missing lighting.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
     # halfPixelOffset: 1 # Fixes lighting misalignment. Do not enable this, it breaks a lot of graphics.
 SLUS-29138:
   name: "The Punisher [Demo]"
@@ -68491,6 +70581,8 @@ SLUS-29152:
     autoFlush: 1 # Post-processing.
     halfPixelOffset: 2 # Offset post-processing.
     texturePreloading: 1 # Improves performance.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
     getSkipCount: "GSC_Battlefield2" # Depth clear.
     beforeDraw: "OI_Battlefield2" # Framebuffer copy, fixes rendering for bottom part of screen.
 SLUS-29153:
@@ -68519,6 +70611,8 @@ SLUS-29155:
     halfPixelOffset: 2 # Fixes blurriness.
     cpuCLUTRender: 1 # Final colour adjustment LUT.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-29156:
   name: "Marvel Nemesis - Rise of the Imperfects [Demo]"
   region: "NTSC-U"
@@ -68526,10 +70620,11 @@ SLUS-29157:
   name: "Dragon Quest VIII - Journey of the Cursed King [Demo]"
   region: "NTSC-U"
   gsHWFixes:
-    autoFlush: 2 # Fixes missing bloom from surfaces like windows.
+    autoFlush: 1 # Fixes missing bloom from surfaces like windows.
     # halfPixelOffset: 1 # Aligns shadows properly, but causes grid lines to appear in sea travel.
     halfPixelOffset: 2 # Sharpens world in far distances, aligns some bloom better.
     roundSprite: 1 # Fixes font artifacts.
+    cpuSpriteRenderBW: 1 # Fixes broken fire sprites.
 SLUS-29159:
   name: "One Piece - Grand Battle [Demo]"
   region: "NTSC-U"
@@ -68578,6 +70673,8 @@ SLUS-29168:
   gsHWFixes:
     textureInsideRT: 1 # Required for complex offset shuffles.
     halfPixelOffset: 2 # Fixes center upscaling line during explosions.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
     recommendedBlendingLevel: 4 # Fixes lighting.
 SLUS-29169:
   name: "Resident Evil 4 [Demo]"
@@ -68586,6 +70683,8 @@ SLUS-29169:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-29170:
   name: "Total Overdose - A Gunslinger's Tale in Mexico [Demo]"
   region: "NTSC-U"
@@ -68600,6 +70699,8 @@ SLUS-29172:
     autoFlush: 1 # Post-processing.
     halfPixelOffset: 2 # Offset post-processing.
     texturePreloading: 1 # Improves performance.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
     getSkipCount: "GSC_Battlefield2" # Depth clear.
     beforeDraw: "OI_Battlefield2" # Framebuffer copy, fixes rendering for bottom part of screen.
 SLUS-29173:
@@ -68663,6 +70764,8 @@ SLUS-29185:
     cpuCLUTRender: 1 # Fixes the rest of the bad textures.
     roundSprite: 1 # Reduces misaligned bloom.
     mergeSprite: 1 # Removes bloom explosion around electrical lights and other light sources such as moon/sun.
+    mipmap: 2 # Mipmap + trilinear, improves road textures to match sw renderer.
+    trilinearFiltering: 1
 SLUS-29188:
   name: "Steambot Chronicles [Regular Demo]"
   region: "NTSC-U"
@@ -68695,6 +70798,8 @@ SLUS-29193:
   region: "NTSC-U"
   clampModes:
     eeClampMode: 3 # Fixes game hang after opening intro.
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes depth line.
 SLUS-29194:
   name: "FIFA '07 [Demo]"
   region: "NTSC-U"
@@ -68717,7 +70822,7 @@ SLUS-29196:
     halfPixelOffset: 2 # Fixes misaligned bloom.
     autoFlush: 2 # Fixes sun occlusion and brightness.
 SLUS-29197:
-  name: "Flushed Away [Demo]"
+  name: "DreamWorks & Aardman Flushed Away [Demo]"
   region: "NTSC-U"
 SLUS-29198:
   name: "Guitar Hero II [Demo]"
@@ -68742,24 +70847,14 @@ SLUS-80421:
 SLUS-90009:
   name: "Resident Evil 2 [Trade Demo]"
   region: "NTSC-U"
-SLUS-97133:
-  name: "The Getaway"
-  name-sort: "Getaway, The"
-  region: "NTSC-U"
-  gsHWFixes:
-    textureInsideRT: 1
-    texturePreloading: 1 # Performs much better with partial preload.
-    halfPixelOffset: 2 # Fixes outlines around characters.
-    getSkipCount: "GSC_GetawayGames"
 SLUS-97405:
-  name: "ATV Offroad Fury 3 [Greatest Hits]"
+  name: "ATV Offroad Fury 3"
   region: "NTSC-U"
   speedHacks:
     mtvu: 0 # Increases FPS drastically.
-SLUS-97657:
-  name: "MLB 11 - The Show"
-  region: "NTSC-U"
-  compat: 5
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 SRPM-70201:
   name: "Space Venus Starring Morning Musume."
   region: "NTSC-J"
@@ -68776,6 +70871,9 @@ TCES-51904:
   gameFixes:
     - VIF1StallHack # Fixes broken HUD.
     - InstantDMAHack # Fixes texture corruption.
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 TCES-52004:
   name: "Killzone Beta Trial Code"
   region: "PAL-E"
@@ -68790,6 +70888,8 @@ TCES-52033:
     autoFlush: 2 # Fixes lights going through walls.
     preloadFrameData: 1 # Fixes light flicker.
     halfPixelOffset: 2 # Corrects light position.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
   gameFixes:
     - EETimingHack # Fixes random hangs.
   patches:
@@ -68836,6 +70936,9 @@ TCES-52582:
 TCES-53033:
   name: "Formula One 05 Beta Trial Code"
   region: "PAL-E"
+  gsHWFixes:
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
 TCES-53247:
   name: "WRC - Rally Evolved Beta Trial Code"
   region: "PAL-E"
@@ -68887,6 +70990,13 @@ TCPS-10085:
   name-en: "Densha de Go! Final [Limited Edition]"
   region: "NTSC-J"
   compat: 5
+TCPS-10086:
+  name: ラクガキ王国2 〜魔王城の戦い〜
+  name-sort: らくがきおうこく2 〜まおうじょうのたたかい〜
+  name-en: "Rakugaki Oukoku 2 - Maoh jou no Tatakai"
+  region: "NTSC-J"
+  gsHWFixes:
+    halfPixelOffset: 4 # Fixes distant offset blur.
 TCPS-10094:
   name: イースIII 〜ワンダラーズフロムイース〜
   name-sort: いーす3 わんだらーずふろむいーす
@@ -68999,6 +71109,13 @@ TCPS-10148:
   name-sort: れいしきかんじょうせんとうき 2 [げんていばん]
   name-en: "Zero Shikikan Josentoki Ni [Limited Edition]"
   region: "NTSC-J"
+TCPS-10150:
+  name: ラクガキ王国2 〜魔王城の戦い〜
+  name-sort: らくがきおうこく2 〜まおうじょうのたたかい〜
+  name-en: "Rakugaki Oukoku 2 - Maoh jou no Tatakai [Taito Best]"
+  region: "NTSC-J"
+  gsHWFixes:
+    halfPixelOffset: 4 # Fixes distant offset blur.
 TCPS-10152:
   name: ローゼンメイデン ドゥエルヴァルツァ [通常版]
   name-sort: ろーぜんめいでん どぅえるゔぁるつぁ
@@ -69076,7 +71193,8 @@ TLES-52149:
   region: "PAL-E"
   gsHWFixes:
     preloadFrameData: 1 # Fixes missing loading screens.
-    mergeSprite: 1 # Fixes misaligned bloom on light sources.
+    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
+    trilinearFiltering: 1
 TLES-52339:
   name: "Crash 'N' Burn Beta Trial Code"
   region: "PAL-E"

--- a/bin/resources/RedumpDatabase.yaml
+++ b/bin/resources/RedumpDatabase.yaml
@@ -339,7 +339,7 @@
 - hashes:
   - md5: f50a9731acda9ee6902770f53b331cc6
     size: 4691755008
-  name: Demo Disc (Europe) (En,Fr,De,Es,It) (v1.03)
+  name: Demo Disc (Europe) (En,Fr,De,Es,It) (PBPX-95514)
   serial: PBPX-95514
   version: '1.03'
 - hashes:
@@ -501,7 +501,7 @@
 - hashes:
   - md5: f6485fee7d9c728eb9ad15e6ecab398d
     size: 3598712832
-  name: Demo Disc (Europe) (En,Fr,De,Es,It) (v1.02)
+  name: Demo Disc (Europe) (En,Fr,De,Es,It) (PBPX-95520)
   serial: PBPX-95520
   version: '1.02'
 - hashes:
@@ -585,7 +585,7 @@
 - hashes:
   - md5: d09b5ca1c119ab09bc764febfcb66862
     size: 4641062912
-  name: Demo Disc (Europe) (En,Fr,De,Es,It) (v1.00)
+  name: Demo Disc (Europe) (En,Fr,De,Es,It) (PBPX-95506)
   serial: PBPX-95506
   version: '1.00'
 - hashes:
@@ -609,7 +609,7 @@
 - hashes:
   - md5: f9446f5995144a3b8fac5eb428f51915
     size: 681583728
-  name: Demo Disc (Europe) (En,Fr,De,Es,It) (v1.11)
+  name: Demo Disc (Europe) (En,Fr,De,Es,It) (PBPX-95205)
   serial: PBPX-95205
   version: '1.11'
 - hashes:
@@ -635,7 +635,7 @@
     size: 4098523136
   name: Document of Metal Gear Solid 2, The (Europe)
   serial: SLES-82010
-  version: '1.02'
+  version: '1.00'
 - hashes:
   - md5: 6d4a7a9d9c139a9d93db37538ba6d984
     size: 2693955584
@@ -2230,7 +2230,7 @@
 - hashes:
   - md5: e26d70390e36afab45a457a930c53c30
     size: 4698341376
-  name: SSX On Tour (USA) (Demo)
+  name: SSX on Tour (USA) (Demo)
   serial: SLUS-29161
   version: '1.00'
 - hashes:
@@ -2344,7 +2344,7 @@
 - hashes:
   - md5: 05ea10e36233b5de02bc1cfb8d2a1547
     size: 686826336
-  name: Demo Disc (Europe) (En,Fr,De,Es,It) (v1.10)
+  name: Demo Disc (Europe) (En,Fr,De,Es,It) (PBPX-95204)
   serial: PBPX-95204
   version: '1.10'
 - hashes:
@@ -3932,7 +3932,7 @@
 - hashes:
   - md5: b4b6476e12e9f086bc6233f042937dea
     size: 1285390336
-  name: Mushi-hime-sama (Japan)
+  name: Mushihimesama (Japan)
   serial: SLPM-66056
   version: '1.01'
 - hashes:
@@ -3980,7 +3980,7 @@
 - hashes:
   - md5: 0cb3afc96bbf06602ccc74d5231bcf76
     size: 1401290752
-  name: SSX On Tour (Korea)
+  name: SSX on Tour (Korea)
   serial: SLKA-25325
   version: '1.01'
 - hashes:
@@ -4376,7 +4376,7 @@
 - hashes:
   - md5: cbdd86fc24ddd47c39f70ee031ae812e
     size: 3989209088
-  name: Saint Seiya - The Hades (Europe) (En,Ja,Fr,Es,It)
+  name: Saint Seiya - The Hades (Europe) (En,Fr,Es,It)
   serial: SLES-54162
   version: '1.00'
 - hashes:
@@ -4612,7 +4612,7 @@
 - hashes:
   - md5: 156c714b7fd2828b1ebe411c65226874
     size: 1743847424
-  name: Saint Seiya - The Sanctuary (Europe) (En,Ja,Fr,De,Es,It)
+  name: Saint Seiya - The Sanctuary (Europe) (En,Fr,De,Es,It)
   serial: SLES-53201
   version: '1.00'
 - hashes:
@@ -4673,6 +4673,7 @@
   - md5: c1bf116419fa446b55988ddbf154de53
     size: 669762576
   name: Sega Ages 2500 Series Vol. 32 - Phantasy Star Complete Collection (Japan)
+    (En,Ja)
   serial: SLPM-62775
   version: '1.00'
 - hashes:
@@ -5153,7 +5154,7 @@
 - hashes:
   - md5: 131d8b3dfa8a1a5bf842b58840fed0ac
     size: 4698341376
-  name: SSX On Tour (USA)
+  name: SSX on Tour (USA)
   serial: SLUS-21278
   version: '1.00'
 - hashes:
@@ -5437,7 +5438,7 @@
 - hashes:
   - md5: 3306538778dda2ded87ceaf52c944a98
     size: 2654109696
-  name: Gran Turismo 4 (USA) (Beta)
+  name: Gran Turismo 4 (USA) (Beta) (2006-06-06)
   serial: SCUS-97436
   version: '1.00'
 - hashes:
@@ -5761,7 +5762,7 @@
 - hashes:
   - md5: ccae6f2c86f491ff62c5d52923d8222c
     size: 221581920
-  name: PlayOnline Viewer and Tetra Master (USA) (Beta)
+  name: PlayOnline Viewer and Tetra Master (USA) (Beta) (2003-04-09)
   serial: SCUS-97272
   version: '1.01'
 - hashes:
@@ -5815,19 +5816,19 @@
 - hashes:
   - md5: 2426d3a274777b93b69d3e19c5c16986
     size: 2857435136
-  name: Final Fantasy XI - Online (USA)
+  name: Final Fantasy XI - Online (USA, Canada)
   serial: SCUS-97266
   version: '1.01'
 - hashes:
   - md5: 19f996757147b27235a4270345c77ed1
     size: 2817196032
-  name: Final Fantasy XI - Online (USA) (Beta)
+  name: Final Fantasy XI - Online (USA) (Beta) (2003-04-24)
   serial: SCUS-97271
   version: '1.00'
 - hashes:
   - md5: 03f4c0040eac24cb7a6f4ffc65c8dcb5
     size: 220391808
-  name: PlayOnline Viewer and Tetra Master (USA)
+  name: PlayOnline Viewer and Tetra Master (USA, Canada)
   serial: SCUS-97269
   version: '1.03'
 - hashes:
@@ -5953,7 +5954,7 @@
 - hashes:
   - md5: bb2e77b3a2061b035726978a5e3a900a
     size: 4664262656
-  name: State of Emergency (Europe) (En,Fr,Es,It)
+  name: State of Emergency (Europe) (En,Fr,Es,It) (v1.02)
   serial: SLES-50606
   version: '1.02'
 - hashes:
@@ -6393,7 +6394,7 @@
     size: 746284896
   name: Shox - Rally Reinvented (Australia)
   serial: SLES-51251
-  version: '1.02'
+  version: '1.00'
 - hashes:
   - md5: baa0c750cd811b881211674a0aa9126e
     size: 8262713344
@@ -7660,7 +7661,7 @@
     size: 3478061056
   name: Seven Samurai 20XX (Europe) (En,Fr,De,Es,It)
   serial: SLES-52348
-  version: '1.01'
+  version: '1.00'
 - hashes:
   - md5: be5dd9e4a43e4bcb8e76232e6f2fbfbf
     size: 2764144640
@@ -8120,7 +8121,7 @@
 - hashes:
   - md5: 1f3cd260e7e083d3e4c9269b9e3469cd
     size: 1303281664
-  name: Shinobi (USA) (En,Ja)
+  name: Shinobi (USA)
   serial: SLUS-20459
   version: '1.00'
 - hashes:
@@ -8474,7 +8475,7 @@
 - hashes:
   - md5: 48fb264a7af9e9c283703e98e3b6d74d
     size: 4698341376
-  name: SSX On Tour (Europe)
+  name: SSX on Tour (Europe)
   serial: SLES-53551
   version: '1.00'
 - hashes:
@@ -8632,8 +8633,8 @@
 - hashes:
   - md5: 620fd65733a198bfc716c182328b2a9b
     size: 1258225664
-  name: KOF - Maximum Impact Regulation A (Japan)
-  serial: SLPS-25765
+  name: KOF - Maximum Impact Regulation A (Japan, Korea)
+  serial: SLKA-25406
   version: '1.01'
 - hashes:
   - md5: 2abd5b255ec07123fe8be38ae1be045e
@@ -8940,7 +8941,7 @@
     size: 3795910656
   name: Nanobreaker (Europe) (En,Fr,De,Es,It)
   serial: SLES-52964
-  version: '1.00'
+  version: '1.01'
 - hashes:
   - md5: 38b769666ac35074933af93431ef9233
     size: 178547376
@@ -9626,7 +9627,7 @@
 - hashes:
   - md5: 399de7e6a89f8aae566346840bb069e0
     size: 4698341376
-  name: SSX On Tour (Europe) (En,Fr,De,Es,Nl,Sv,No,Fi)
+  name: SSX on Tour (Europe) (En,Fr,De,Es,Nl,Sv,No,Fi)
   serial: SLES-53552
   version: '1.00'
 - hashes:
@@ -11449,7 +11450,7 @@
 - hashes:
   - md5: 939d1bfb508f6943cc39a84733eb5f31
     size: 4268097536
-  name: Official PlayStation 2 Magazine Demo 49 (Europe) (En,Fr,De,Es,It) (v1.03)
+  name: Official PlayStation 2 Magazine Demo 49 (Europe) (En,Fr,De,Es,It) (SCED-52164)
   serial: SCED-52164
   version: '1.03'
 - hashes:
@@ -11485,7 +11486,7 @@
 - hashes:
   - md5: b81b5b940b9749051edeef639ff425f1
     size: 3683090432
-  name: Official PlayStation 2 Magazine Demo 54 (Europe) (En,Fr,De,Es,It)
+  name: Official PlayStation 2 Magazine Demo 54 (Europe) (En,Fr,De,Es,It) (SCED-52169)
   serial: SCED-52169
   version: '1.01'
 - hashes:
@@ -13077,7 +13078,7 @@
     size: 375776688
   name: Gunfighter II - Revenge of Jesse James (Europe) (En,Fr,De,Es,It)
   serial: SLES-51289
-  version: '1.01'
+  version: '1.02'
 - hashes:
   - md5: a431a42105acd37476f6ebf4e3b57f6c
     size: 3895820288
@@ -13123,7 +13124,7 @@
 - hashes:
   - md5: 7a3986d0c0feee7e99992dff346fbd5e
     size: 2318499840
-  name: Ecco the Dolphin - Defender of the Future (USA)
+  name: Ecco the Dolphin - Defender of the Future (USA) (En,Fr,De,Es,It)
   serial: SLUS-20394
   version: '1.01'
 - hashes:
@@ -15302,8 +15303,8 @@
 - hashes:
   - md5: 25958d0b6fe1ad085a072047ca46ddb4
     size: 751993200
-  name: HDD Utility Disc (USA)
-  serial: SCUS-97395
+  name: HDD Utility Disc Version 1.10 (USA)
+  serial: PTRM-006135
   version: '1.10'
 - hashes:
   - md5: 6325f168500ae2831c4f1fcec6d70a3c
@@ -15555,13 +15556,13 @@
 - hashes:
   - md5: b4c99d9335fad4339618a2f9f7f5b9db
     size: 1432420352
-  name: Auto Modellista (USA) (Beta 1)
+  name: Auto Modellista (USA) (Beta) (2002-12-10)
   serial: SLUS-20498
   version: '1.00'
 - hashes:
   - md5: 6728a222054c2cf005b4d7933c8aeab9
     size: 1528266752
-  name: Auto Modellista (USA) (Beta 2)
+  name: Auto Modellista (USA) (Beta) (2003-01-27)
   serial: SLUS-28031
   version: '1.00'
 - hashes:
@@ -18645,7 +18646,7 @@
   - md5: f7980e2a1f08befbde7f1f02d27323a3
     size: 381673152
   name: Gangcheol Gigap Sadan - Online Battlefield (Korea)
-  serial: SCKA-14001
+  serial: SCKA-10001
   version: '1.03'
 - hashes:
   - md5: 1bafaf840e78b83dd29f7eb0a3ebe4ce
@@ -19274,7 +19275,7 @@
 - hashes:
   - md5: 18bce155d65b81b83c76e340384bc6c0
     size: 4146593792
-  name: Operator's Side (Japan)
+  name: Operator's Side (Japan) (Doukonban)
   serial: SCPS-15038
   version: '1.02'
 - hashes:
@@ -20200,7 +20201,7 @@
 - hashes:
   - md5: 4d1a506c6f0dceb0c37f0fc26962c172
     size: 2832334848
-  name: Incredible Hulk, The (USA)
+  name: Incredible Hulk, The (USA) (En,Fr)
   serial: SLUS-21765
   version: '1.00'
 - hashes:
@@ -20398,8 +20399,8 @@
 - hashes:
   - md5: a2caa137f7c321856e9bc92d87ae1f3c
     size: 4656070656
-  name: Valkyrie Profile 2 - Silmeria (Japan)
-  serial: SLPM-66419
+  name: Valkyrie Profile 2 - Silmeria (Japan, Korea)
+  serial: SCKA-20079
   version: '1.01'
 - hashes:
   - md5: 858120361c4d503eb70f6fdb06c529ec
@@ -20446,8 +20447,8 @@
 - hashes:
   - md5: ef91d9da4f83eb315fbd84c82e1c8928
     size: 3516530688
-  name: Seiken Densetsu 4 (Japan)
-  serial: SLPM-66576
+  name: Seiken Densetsu 4 (Japan, Korea)
+  serial: SCKA-20101
   version: '1.02'
 - hashes:
   - md5: 9cc3610c695ccffe6450b44e6e4bd4a2
@@ -21794,7 +21795,7 @@
 - hashes:
   - md5: 4ba373e3d0bd5160b4c0619a12de6ff2
     size: 1862533120
-  name: Star Wars - Battlefront II (USA) (Beta 1)
+  name: Star Wars - Battlefront II (USA) (Beta) (2005-07-24)
   serial: SLUS-29164
   version: '1.01'
 - hashes:
@@ -22143,7 +22144,7 @@
   - md5: 597a80c8704676321abe90c602e4638a
     size: 3837755392
   name: Tsuyokiss 2-gakki - Swift Love (Japan)
-  serial: SLPM-55154
+  serial: SLPM-55153
   version: '1.02'
 - hashes:
   - md5: 469b4bf9c42436939ef6827dcb2a89e4
@@ -22208,7 +22209,7 @@
 - hashes:
   - md5: 4cbd0e31bcddec071dc36fc71cb5660a
     size: 2760802304
-  name: Ferrari Challenge - Trofeo Pirelli (Europe) (En,Fr,De,Es,It)
+  name: Ferrari Challenge - Trofeo Pirelli (Europe) (En,Fr,De,Es,It) (v1.00)
   serial: SLES-55294
   version: '1.00'
 - hashes:
@@ -22484,7 +22485,7 @@
 - hashes:
   - md5: 6bc9701132b54d919e7bef89f520b7b9
     size: 2044887040
-  name: Fatal Fury - Battle Archives Volume 2 (USA)
+  name: Fatal Fury - Battle Archives Volume 2 (USA, Canada)
   serial: SLUS-21723
   version: '1.00'
 - hashes:
@@ -22550,7 +22551,7 @@
 - hashes:
   - md5: 9586c46286f3269c15dccf84a31cead0
     size: 2969436160
-  name: Samurai Shodown Anthology (USA)
+  name: Samurai Shodown Anthology (USA, Canada)
   serial: SLUS-21629
   version: '1.01'
 - hashes:
@@ -23928,7 +23929,7 @@
 - hashes:
   - md5: 2f6cc4ab09e2ef579b311aa2b4980c5b
     size: 2944237568
-  name: Colosseum - Road to Freedom (USA) (Beta)
+  name: Colosseum - Road to Freedom (USA) (Beta) (2005-03-17)
   serial: SLUS-21179
   version: '1.00'
 - hashes:
@@ -24775,8 +24776,8 @@
 - hashes:
   - md5: 1d586a34d7a331ef8976c7512e3bf5c8
     size: 3651600384
-  name: Shin Sangoku Musou 3 - Empires (Japan)
-  serial: SLPM-65565
+  name: Shin Sangoku Musou 3 - Empires (Japan, Asia)
+  serial: SLAJ-25040
   version: '1.01'
 - hashes:
   - md5: cc4b06e6c310eaf1fd170ee91a941997
@@ -25988,7 +25989,7 @@
 - hashes:
   - md5: 1a7780425ce7a4d8177cdb806c54e27a
     size: 4453203968
-  name: WWE SmackDown vs. Raw 2007 (USA)
+  name: WWE SmackDown vs. Raw 2007 (USA) (v1.01)
   serial: SLUS-21427
   version: '1.01'
 - hashes:
@@ -26552,7 +26553,7 @@
 - hashes:
   - md5: 25ca7c90e7f2e0237276c7daea3479f8
     size: 2060156928
-  name: LEGO Island Xtreme Stunts (Europe) (En,Fr,De,Es,It,Nl,Sv,Da)
+  name: Island Xtreme Stunts (Europe) (En,Fr,De,Es,It,Nl,Sv,Da)
   serial: SLES-51153
   version: '1.00'
 - hashes:
@@ -26993,7 +26994,7 @@
 - hashes:
   - md5: b9ed8f05fbad43b6b09ab5a2f15ccaa7
     size: 1283358720
-  name: Jak X - Combat Racing (USA) (Beta)
+  name: Jak X - Combat Racing (USA) (Beta) (2005-06-23)
   serial: SCUS-97488
   version: '1.01'
 - hashes:
@@ -27412,7 +27413,7 @@
 - hashes:
   - md5: f5adfb992d6d33a8278157d0f4dd0ac0
     size: 2541748224
-  name: Gran Turismo 3 - A-Spec (Japan)
+  name: Gran Turismo 3 - A-Spec (Japan, Asia)
   serial: PBPX-95502
   version: '1.01'
 - hashes:
@@ -29883,7 +29884,7 @@
   - md5: 9eb1bd21b3ef54a4abc54b4c5873177e
     size: 3289874432
   name: Tsuyokiss - Mighty Heart (Japan)
-  serial: SLPM-66624
+  serial: SLPM-66408
   version: '1.03'
 - hashes:
   - md5: 787bb8b3e1540673344122c40bfb8bbd
@@ -30215,7 +30216,7 @@
     size: 3702947840
   name: RTX - Red Rock (Spain)
   serial: SLES-51073
-  version: '1.01'
+  version: '1.02'
 - hashes:
   - md5: 75cf57689e09a8ce4931dfef0f1b1a69
     size: 4286447616
@@ -30249,8 +30250,8 @@
 - hashes:
   - md5: 5f8ef32e8497c403c3a39fbabc4f90ec
     size: 4518150144
-  name: Super Robot Taisen OG - Original Generations (Japan)
-  serial: SLPS-25733
+  name: Super Robot Taisen OG - Original Generations (Japan, Korea)
+  serial: SCKA-20097
   version: '1.04'
 - hashes:
   - md5: a927af5f55706ce781457a47ede5e55b
@@ -30293,7 +30294,7 @@
     size: 4583849984
   name: Juiced (Italy)
   serial: SLES-53151
-  version: '1.00'
+  version: '1.01'
 - hashes:
   - md5: 518b9546feff4c11aeaf47f5abb43de4
     size: 4518969344
@@ -30782,7 +30783,7 @@
     size: 3853090816
   name: Tenchu - Fatal Shadows (Italy)
   serial: SLES-53015
-  version: '1.01'
+  version: '1.00'
 - hashes:
   - md5: 0db09238b26fd7d27f8283d324471f3a
     size: 2523070464
@@ -31135,7 +31136,7 @@
   - md5: a4406c0f44a006652589f5dca3e77f93
     size: 1353318400
   name: Shin Bokujou Monogatari - Pure - Innocent Life (Japan)
-  serial: SLPS-25876
+  serial: SLPS-25763
   version: '1.01'
 - hashes:
   - md5: 7c7bea552cba30f5c562fae0c61af003
@@ -33460,7 +33461,7 @@
 - hashes:
   - md5: 7eee7356a19e2cc049b7162cd7dcb1df
     size: 1239810048
-  name: Shin Seiki GPX Cyber Formula - Road to the Infinity (Japan)
+  name: Future GPX Cyber Formula - Road to the Infinity (Japan)
   serial: SLPS-25307
   version: '1.02'
 - hashes:
@@ -33850,13 +33851,13 @@
 - hashes:
   - md5: c6597ddf5a8b8a349b988d087c174fe6
     size: 259202160
-  name: PlayOnline Viewer & Tetra Master (Japan) (Beta)
+  name: PlayOnline Viewer & Tetra Master (Japan) (Beta) (2001-11-20)
   serial: SLPM-62134
   version: '1.01'
 - hashes:
   - md5: f077470ddb0faf6d79ff103ceb528abe
     size: 681995328
-  name: Final Fantasy XI - Online (Japan) (Beta)
+  name: Final Fantasy XI - Online (Japan) (Beta) (2001-11-20)
   serial: SLPM-62135
   version: '1.02'
 - hashes:
@@ -33874,7 +33875,7 @@
 - hashes:
   - md5: b155f5a09a87a479030dc23e431c2700
     size: 421668912
-  name: Bravo Music - Chou Meikyoku-ban (Japan)
+  name: Bravo Music - Chou Meikyoku-ban (Japan) (Genteiban)
   serial: SCPS-11019
   version: '1.00'
 - hashes:
@@ -33983,7 +33984,7 @@
   - md5: 39645afb869ce758ca2f2b5182981221
     size: 480504192
   name: SuperLite 2000 Vol. 36 - Youkoso Hitsuji-mura (Japan)
-  serial: SLPM-62711
+  serial: SLPM-62442
   version: '1.01'
 - hashes:
   - md5: 337cb9243851cd2c93ed62e5e7e3402a
@@ -34206,7 +34207,7 @@
 - hashes:
   - md5: 7991a66ff3fb85e2a7742c086d8e7d39
     size: 4388290560
-  name: Soulcalibur III (Japan) (v2.00)
+  name: Soulcalibur III (Japan) (En,Ja) (v2.00)
   serial: SLPS-25577
   version: '2.00'
 - hashes:
@@ -34825,7 +34826,7 @@
 - hashes:
   - md5: d17ff08efec19a2aaef259e01cc61584
     size: 2126118912
-  name: Test Drive Unlimited (USA) (Beta)
+  name: Test Drive Unlimited (USA) (Beta) (2006-06-30)
   serial: SLUS-29192
   version: '1.00'
 - hashes:
@@ -34891,7 +34892,7 @@
 - hashes:
   - md5: c217b67fc1d0f5fdda8cdbd258023d8b
     size: 2447015936
-  name: FIFA 2003 - Europe Soccer (Japan)
+  name: FIFA 2003 - European Football (Japan)
   serial: SLPS-25179
   version: '1.01'
 - hashes:
@@ -35427,7 +35428,7 @@
 - hashes:
   - md5: d59cd4e6485940c90d5cb66339417b67
     size: 4625367040
-  name: Happy Breeding - Cheerful Party (Japan)
+  name: Happy Breeding - Cheerful Party (Japan) (Shokai Genteiban)
   serial: SLPM-65219
   version: '1.02'
 - hashes:
@@ -35910,7 +35911,7 @@
 - hashes:
   - md5: dc7f80ed0abbbcd8297d359861c14466
     size: 652303680
-  name: Mahjong Taikai III - Millennium League (Japan)
+  name: Mahjong Taikai III - Millennium League (Japan) (v1.10)
   serial: SLPM-62003
   version: '1.10'
 - hashes:
@@ -36236,7 +36237,7 @@
 - hashes:
   - md5: 4071e4ac02aee331e8d216003991e681
     size: 2150662144
-  name: World Heroes Anthology (USA)
+  name: World Heroes Anthology (USA, Canada)
   serial: SLUS-21725
   version: '1.00'
 - hashes:
@@ -36494,7 +36495,7 @@
 - hashes:
   - md5: 8780f8f8ae58f84d119f77856d9748b2
     size: 4408639488
-  name: Aoi Shiro (Japan)
+  name: Aoi Shiro (Japan) (Genteiban)
   serial: SLPM-66958
   version: '1.02'
 - hashes:
@@ -36626,7 +36627,7 @@
 - hashes:
   - md5: 8f5b2c3cc178f59225a5a2ab0ce4a999
     size: 1253539840
-  name: Nickelodeon Go Diego Go! Great Dinosaur Rescue (USA) (En,Fr)
+  name: Nickelodeon Go Diego Go! Great Dinosaur Rescue (USA, Canada)
   serial: SLUS-21794
   version: '1.00'
 - hashes:
@@ -37140,8 +37141,8 @@
 - hashes:
   - md5: da9e99642d7e6fca112c741705bbec1c
     size: 3672932352
-  name: Minna no Golf 4 (Japan) (v1.04)
-  serial: SCPS-15059
+  name: Minna no Golf 4 (Japan, Asia) (v1.04)
+  serial: SCAJ-20094
   version: '1.04'
 - hashes:
   - md5: 5207b96e7798ee8f11bbddd4d3180ca6
@@ -37423,8 +37424,8 @@
 - hashes:
   - md5: dacc9050bbd855328656130de716d78b
     size: 1071415296
-  name: Vampire Night (Japan)
-  serial: SLPS-25077
+  name: Vampire Night (Japan, Asia)
+  serial: SCPS-55003
   version: '1.00'
 - hashes:
   - md5: 29bb82d1fa1b45867d7725057e385117
@@ -39604,7 +39605,7 @@
   - md5: 090f2409427ae8f1df482994ee54b005
     size: 1452736512
   name: Harukanaru Toki no Naka de - Hachiyou-shou (Japan)
-  serial: SLPM-66655
+  serial: SLPM-65916
   version: '1.01'
 - hashes:
   - md5: 5f598b7a08e2700d67a24d0b3a7a4062
@@ -39952,7 +39953,7 @@
   - md5: 3fbc6b69d113b096c0b1226173cc05cc
     size: 1432780800
   name: Sorcerous Stabber Orphen (Japan)
-  serial: SLPS-25008
+  serial: SLPM-65065
   version: '1.00'
 - hashes:
   - md5: ae781bfe9e202e8a5cce018e797b3b04
@@ -40632,7 +40633,7 @@
 - hashes:
   - md5: 95d1a3cf0a3d9f500fb8e8eed6f691ab
     size: 1587838976
-  name: Front Mission Online (Japan) (Beta)
+  name: Front Mission Online (Japan) (Beta) (2004-09-18)
   serial: SLPM-68514
   version: '1.00'
 - hashes:
@@ -40716,7 +40717,7 @@
 - hashes:
   - md5: 23fa7e30ee943c45a1b92649a080fbdc
     size: 1250951168
-  name: SOCOM 3 - U.S. Navy SEALs (USA) (Beta)
+  name: SOCOM 3 - U.S. Navy SEALs (USA) (Beta) (2005-07-01)
   serial: SCUS-97489
   version: '1.00'
 - hashes:
@@ -40776,7 +40777,7 @@
 - hashes:
   - md5: bdb385070a84f30e902131cb229d35a8
     size: 1358823424
-  name: Battlefield 2 - Modern Combat (USA) (Beta)
+  name: Battlefield 2 - Modern Combat (USA) (Beta) (2005-01-19)
   serial: SLUS-29117
   version: '1.01'
 - hashes:
@@ -41432,7 +41433,7 @@
 - hashes:
   - md5: d95d1f3a4cbfa82b1751d0f376882b82
     size: 522231024
-  name: Dirge of Cerberus - Final Fantasy VII (Japan) (Beta)
+  name: Dirge of Cerberus - Final Fantasy VII (Japan) (Beta) (2005-07-11)
   serial: SLPM-68016
   version: '1.00'
 - hashes:
@@ -41450,7 +41451,7 @@
 - hashes:
   - md5: 21bffd6263462a6025f2ba5fdbd905fa
     size: 1362231296
-  name: Winning Post 7 (Japan)
+  name: Winning Post 7 (Japan) (v1.03)
   serial: SLPM-66087
   version: '1.03'
 - hashes:
@@ -41499,7 +41500,7 @@
   - md5: 333234d852b20869d9095e9cab6dec06
     size: 1472561152
   name: My Home o Tsukurou 2! Takumi (Japan)
-  serial: SLPS-25613
+  serial: SLPS-25463
   version: '1.01'
 - hashes:
   - md5: 79dcf5fd3e12337e6d33da9c4c787171
@@ -41904,7 +41905,7 @@
   - md5: c741115471ce9b8d49ebcc0f7cac6b33
     size: 3583737856
   name: Battlefield 2 - Modern Combat (Japan)
-  serial: SLPM-66206
+  serial: SLPM-55034
   version: '1.01'
 - hashes:
   - md5: 9586ee137c47111b2a92f1b4c8aa805e
@@ -42605,7 +42606,7 @@
   - md5: 44d1b8649583e9e0149b7e1e9f130c5b
     size: 748222944
   name: Doukyuu - Billiard Master 2 (Japan)
-  serial: SLPS-20002
+  serial: SLPM-62242
   version: '2.20'
 - hashes:
   - md5: 2d89d623ef8c3aefad86e0e2e386d46a
@@ -42616,7 +42617,7 @@
 - hashes:
   - md5: faa723a4c49e96e4075b6806e092779a
     size: 720008352
-  name: Karaoke Revolution - Family Pack (Japan)
+  name: Karaoke Revolution - Kazoku Idol-ka Sengen (Japan) (USB Mic Doukonban)
   serial: SLPM-62528
   version: '1.02'
 - hashes:
@@ -42712,7 +42713,7 @@
 - hashes:
   - md5: 7558005d00ff8b5972d769922010a3ca
     size: 1394343936
-  name: Kaitou Apricot Kanzenban (Japan)
+  name: Kaitou Apricot Kanzenban (Japan) (Genteiban)
   serial: SLPS-25423
   version: '1.03'
 - hashes:
@@ -42856,7 +42857,7 @@
 - hashes:
   - md5: 1b1abaca43b0ede31f9d8d4525b941ca
     size: 3431825408
-  name: Yoshitsune Eiyuuden - The Story of Hero Yoshitsune (Japan, Asia)
+  name: Yoshitsune Eiyuuden (Japan, Asia)
   serial: SCAJ-20115
   version: '1.10'
 - hashes:
@@ -42917,7 +42918,7 @@
   - md5: e5474a66fdd37293593f9fb0f680b820
     size: 3698098176
   name: Need for Speed - Carbon (Japan)
-  serial: SLPM-66617
+  serial: SLPM-55061
   version: '1.01'
 - hashes:
   - md5: 1706e041ae87f84a4063471df75aead7
@@ -42984,7 +42985,7 @@
   - md5: a5e7deee0f520c5aaed7c37170f55bbb
     size: 4677795840
   name: Medal of Honor - Europe Kyoushuu (Japan)
-  serial: SLPM-66079
+  serial: SLPM-55037
   version: '1.01'
 - hashes:
   - md5: 3b0afcb36dc7ac5c14147b22548a76dc
@@ -43032,7 +43033,7 @@
   - md5: c11a165ac568fa6200b417b133a0c266
     size: 3422126080
   name: Colorful Box - To Love (Japan)
-  serial: SLPM-66414
+  serial: SLPM-65589
   version: '1.02'
 - hashes:
   - md5: bf62b36fee62c7a1a09858702109efd6
@@ -43497,7 +43498,7 @@
   - md5: c2148b0dd6c2b315accdf691011cf3f9
     size: 2102689792
   name: Kin'iro no Corda 2 (Japan)
-  serial: SLPM-66700
+  serial: SLPM-55249
   version: '1.01'
 - hashes:
   - md5: c56c6f6d645310a91b7715cafc52fb76
@@ -43611,7 +43612,7 @@
 - hashes:
   - md5: 81c87a0d08d8e577085f457e74549e15
     size: 2698870784
-  name: Shin Seiki GPX Cyber Formula - Road to the Infinity 4 (Japan)
+  name: Future GPX Cyber Formula - Road to the Infinity 4 (Japan)
   serial: SLPS-25814
   version: '1.01'
 - hashes:
@@ -43733,7 +43734,7 @@
   - md5: e5269008b82d0a3ffbc1dd3cde95da3d
     size: 2946334720
   name: Moujuutsukai to Oujisama - Snow Bride (Japan)
-  serial: SLPM-55287
+  serial: SLPM-55286
   version: '1.01'
 - hashes:
   - md5: d03c347d090c18fbde36b3ca721a8a64
@@ -44054,7 +44055,7 @@
 - hashes:
   - md5: 7f6c7193b48df4f3c3426ac14606c91f
     size: 3960340480
-  name: Kyou kara Maou! Shin Makoku no Kyuujitsu (Japan)
+  name: Kyou kara Maou! Shin Makoku no Kyuujitsu (Japan) (Limited Box)
   serial: SLPS-25801
   version: '1.00'
 - hashes:
@@ -44140,7 +44141,7 @@
   - md5: f54f22add9d4bae69edeb826e692c003
     size: 40767216
   name: Mahjong Haou - Battle Royale (Japan)
-  serial: SLPM-62772
+  serial: SLPM-62629
   version: '1.00'
 - hashes:
   - md5: a039fb87299410f9948275ea82f84830
@@ -44278,7 +44279,7 @@
   - md5: 9cc3ae8c342f098862b572c633abe4e9
     size: 2317123584
   name: Neo Angelique - Full Voice (Japan)
-  serial: SLPM-66956
+  serial: SLPM-66955
   version: '1.01'
 - hashes:
   - md5: c9f1e4d62b6e51f6eaf583ec142180c2
@@ -44307,7 +44308,7 @@
 - hashes:
   - md5: 2a35f25e50d8544f8fce0ccc366a3454
     size: 1255309312
-  name: Hoshi-iro no Okurimono (Japan)
+  name: Hoshi-iro no Okurimono (Japan) (Shokai Special Genteiban)
   serial: SLPM-66870
   version: '1.01'
 - hashes:
@@ -44332,13 +44333,13 @@
   - md5: 5e1f766a1aeb646e414f3d5015d6afc2
     size: 2956328960
   name: WRC 3 - The Official Game of the FIA World Rally Championship (Japan)
-  serial: SLPM-66103
+  serial: SLPM-65583
   version: '1.01'
 - hashes:
   - md5: da67380a645e6993311a809bc5458fd0
     size: 2920906752
   name: Harukanaru Toki no Naka de 4 (Japan)
-  serial: SLPM-66951
+  serial: SLPM-55296
   version: '1.01'
 - hashes:
   - md5: d2295393df3d9b1003ff2d69c323a1dc
@@ -44385,7 +44386,7 @@
 - hashes:
   - md5: 2e5abe80ccee66d8bb75bf514d88ed56
     size: 4625367040
-  name: Cafe Lindbergh - Summer Season (Japan)
+  name: Cafe Lindbergh - Summer Season (Japan) (Sweet Box)
   serial: SLPM-65910
   version: '1.00'
 - hashes:
@@ -44454,7 +44455,7 @@
   - md5: 7e01e8910956e0630f70c7e8a34e55d5
     size: 4481515520
   name: Final Approach (Japan)
-  serial: SLPM-66323
+  serial: SLPM-65676
   version: '1.00'
 - hashes:
   - md5: 5113cfebc9b0d9e19d9d0fec07edf243
@@ -44502,7 +44503,7 @@
   - md5: 7199b51213dbf6d745806df935888e38
     size: 3331096576
   name: True Crime - Streets of LA (Japan)
-  serial: SLPM-66098
+  serial: SLPM-65729
   version: '1.03'
 - hashes:
   - md5: 5523589c85bfe5cad73ad54f2f0de9df
@@ -44553,7 +44554,7 @@
   - md5: 02a03ddaf8cc8a453e7de2c325297572
     size: 704696832
   name: GetBackers - Dakkan'ya - Dakkan da yo! Zen'in Shuugou!! (Japan)
-  serial: SLPM-62376
+  serial: SLPM-62276
   version: '1.02'
 - hashes:
   - md5: e2183e2072f3e891ec40901a6095ca73
@@ -44716,7 +44717,7 @@
 - hashes:
   - md5: 40ac4bf5fe376b7e564e73ec01beb18f
     size: 1648525312
-  name: D-A - Black (Japan)
+  name: D-A - Black (Japan) (Shokai Genteiban)
   serial: SLPS-25288
   version: '4.00'
 - hashes:
@@ -44735,7 +44736,7 @@
   - md5: 99e264a6718a0395aae23cee3742e52f
     size: 2507309056
   name: Futakoi-jima - Koi to Mizugi no Survival (Japan)
-  serial: SLPS-25625
+  serial: SLPS-25543
   version: '1.03'
 - hashes:
   - md5: ef707544a08eb18936f6b699e03d389e
@@ -44801,7 +44802,7 @@
   - md5: d1106d5d403cd21478f8b81e32eed5cc
     size: 1269563392
   name: Harukanaru Toki no Naka de - Maihitoyo (Japan)
-  serial: SLPM-66548
+  serial: SLPM-55050
   version: '1.02'
 - hashes:
   - md5: 2ad31d6b2837b94a9a050c6dd48f92b4
@@ -44890,7 +44891,7 @@
 - hashes:
   - md5: e05bcdf418e60740d18109bc0bed4f0a
     size: 3440345088
-  name: Trouble Fortune Company - HapiCure (Japan)
+  name: Trouble Fortune Company - HapiCure (Japan) (Shokai Genteiban)
   serial: SLPM-66625
   version: '1.01'
 - hashes:
@@ -44970,7 +44971,7 @@
   - md5: f8f3c88e336e5b65c42c7f275619246f
     size: 101152464
   name: Rilakkuma - Ojama shite masu 2-shuukan (Japan)
-  serial: SLPM-62764
+  serial: SLPM-62680
   version: '1.03'
 - hashes:
   - md5: 7042a3de3e315617f93f9c7483ba2830
@@ -45056,7 +45057,7 @@
     size: 1696792576
   name: Katekyoo Hitman Reborn! Dream Hyper Battle! Shinu Ki no Honoo to Kuroki Kioku
     (Japan)
-  serial: SLPS-25910
+  serial: SLPS-25806
   version: '1.01'
 - hashes:
   - md5: 2f4cff285568a2e19732bdf77a533e15
@@ -45074,7 +45075,7 @@
   - md5: e380776b619aea17b8b343a22c679f83
     size: 1835171840
   name: Secret of Evangelion (Japan)
-  serial: SLPM-66569
+  serial: SLPM-55084
   version: '1.01'
 - hashes:
   - md5: 48fccce4c124d15c5fe8069fac39b3b9
@@ -45129,7 +45130,7 @@
 - hashes:
   - md5: 803303bef104e98c131411fea44503cf
     size: 1472102400
-  name: Tennis no Oujisama - Card Hunter (Japan)
+  name: Tennis no Oujisama - Card Hunter (Japan) (Shokai Genteiban)
   serial: SLPM-66642
   version: '1.02'
 - hashes:
@@ -45208,7 +45209,7 @@
 - hashes:
   - md5: 26b778c0368a08165a477d4e0b85bb03
     size: 1400700928
-  name: Saint Beast - Rasen no Shou (Japan)
+  name: Saint Beast - Rasen no Shou (Japan) (Genteiban)
   serial: SLPS-25807
   version: '1.01'
 - hashes:
@@ -45476,7 +45477,7 @@
   - md5: 35a276e82e8a3734c5b72de9717acd64
     size: 629454000
   name: Fish Eyes 3 - Kioku no Hahen-tachi (Japan)
-  serial: SLPS-20477
+  serial: SLPS-20291
   version: '1.01'
 - hashes:
   - md5: 2137ec888c5390e2ed3729193abd7f5b
@@ -45782,7 +45783,7 @@
   - md5: 7a402d3a408200834eb575980ebc767c
     size: 742947408
   name: EX Billiards (Japan)
-  serial: SLPS-20005
+  serial: SLPM-62187
   version: '0.50'
 - hashes:
   - md5: f76d4b32190a40ee40f824b0d6032694
@@ -45811,7 +45812,7 @@
 - hashes:
   - md5: 866cc274937bf5a1d025729e5ca4d2b8
     size: 4005658624
-  name: Happiness! de Lucks (Japan)
+  name: Happiness! de Lucks (Japan) (Shokai Genteiban)
   serial: SLPS-25719
   version: '1.01'
 - hashes:
@@ -45944,7 +45945,7 @@
   - md5: 8fd0914377479f193b79443087bbb4ba
     size: 2729443328
   name: SSX 3 (Japan)
-  serial: SLPM-65449
+  serial: SLPM-55077
   version: '1.01'
 - hashes:
   - md5: efd2508e07be1aea587f43ad5809b9b2
@@ -45967,13 +45968,14 @@
 - hashes:
   - md5: 840746d07dbafaf95f897407167e951f
     size: 1542029312
-  name: Tennis no Oujisama - Smash Hit! 2 (Japan) (Shokai SP Genteiban)
+  name: Tennis no Oujisama - Smash Hit! 2 (Japan) (Shokai SP Genteiban B-Type)
   serial: SLPM-65451
   version: '1.01'
 - hashes:
   - md5: 103a775d146fce8643e652ba0a6c90c5
     size: 431455584
-  name: Tennis no Oujisama - Smash Hit! 2 - Original Anime Game (Japan)
+  name: Tennis no Oujisama - Smash Hit! 2 - Original Anime Game (Japan) (Shokai SP
+    Genteiban B-Type)
   serial: SLPM-62435
   version: '1.00'
 - hashes:
@@ -46063,8 +46065,8 @@
 - hashes:
   - md5: b69812eb4014a234a4653baa9966c368
     size: 4137877504
-  name: Kidou Senshi Gundam Seed Destiny - Rengou vs. Z.A.F.T. II Plus (Japan)
-  serial: SLPS-25718
+  name: Kidou Senshi Gundam Seed Destiny - Rengou vs. Z.A.F.T. II Plus (Japan, Korea)
+  serial: SLKA-25165
   version: '1.00'
 - hashes:
   - md5: e02a912f466227bb6d4c5494afa93070
@@ -46161,7 +46163,7 @@
   - md5: dd93365570599c5a116046e628c207ca
     size: 4177526784
   name: Angelique Etoile (Japan)
-  serial: SLPM-66524
+  serial: SLPM-65715
   version: '1.01'
 - hashes:
   - md5: dce5edab0cbe1b9a9f162e969bcd0716
@@ -46490,13 +46492,13 @@
 - hashes:
   - md5: 863a644150064aa72cd69f5561b7d5ff
     size: 1089110016
-  name: Linux for PlayStation 2 - Release 1.0 (Japan) (Disc 1) (Runtime Environment)
+  name: Linux (for PlayStation 2) Release 1.0 (Japan) (Disc 1) (Runtime Environment)
   serial: SCPS-17501
   version: '1.12'
 - hashes:
   - md5: 0d042d8c64579cf36f612793d8e850a4
     size: 1425965056
-  name: Linux for PlayStation 2 - Release 1.0 (Japan) (Disc 2) (Software Packages)
+  name: Linux (for PlayStation 2) Release 1.0 (Japan) (Disc 2) (Software Packages)
   serial: SCPS-17502
 - hashes:
   - md5: ece42aa3df0c011647afd84926a02b6b
@@ -46603,7 +46605,7 @@
 - hashes:
   - md5: 2d5aeaf29684f1cb2f2e06291b6e26cd
     size: 2148761600
-  name: Fushigi Yuugi - Suzaku Ibun (Japan)
+  name: Fushigi Yuugi - Suzaku Ibun (Japan) (Genteiban)
   serial: SLPM-66998
   version: '1.01'
 - hashes:
@@ -46873,7 +46875,7 @@
 - hashes:
   - md5: b77e811215af77473623c44ef7204116
     size: 4420796416
-  name: Tennis no Oujisama - Rush & Dream! (Japan)
+  name: Tennis no Oujisama - Rush & Dream! (Japan) (Shokai Seisanban)
   serial: SLPM-65756
   version: '1.00'
 - hashes:
@@ -47041,7 +47043,7 @@
 - hashes:
   - md5: d70446fba8c3072b924228957e0bc838
     size: 2217967616
-  name: Kin'iro no Corda 2 Encore (Japan)
+  name: Kin'iro no Corda 2 Encore (Japan) (Premium Box)
   serial: SLPM-66834
   version: '1.01'
 - hashes:
@@ -47306,7 +47308,7 @@
 - hashes:
   - md5: 40d80cd64fcec325cff06060e5ed3bf4
     size: 1419935744
-  name: SSX On Tour (Japan)
+  name: SSX on Tour (Japan)
   serial: SLPM-66189
   version: '1.00'
 - hashes:
@@ -47716,7 +47718,7 @@
 - hashes:
   - md5: 38d102e46cb495a7f43237fe57166c73
     size: 584622528
-  name: Nobunaga no Yabou Online (Japan) (Beta) (v1.04)
+  name: Nobunaga no Yabou Online (Japan) (Beta) (v1.04) (2002-11-19)
   serial: SLPM-62208
   version: '1.04'
 - hashes:
@@ -47849,7 +47851,7 @@
   - md5: 83ad46205b018481fb41cd79c330edba
     size: 4377346048
   name: SuperLite 2000 Vol. 41 - Tokyo Bus Guide 2 (Japan)
-  serial: SLPM-66555
+  serial: SLPM-65982
   version: '1.02'
 - hashes:
   - md5: 96338e8bcbfdf914fee65be93e9af524
@@ -48439,7 +48441,7 @@
   - md5: f6e021a2a7166778d20c1e999f0d82a8
     size: 2842460160
   name: EA Demo Disc - From Russia with Love + Need for Speed - Most Wanted + SSX
-    On Tour (USA)
+    on Tour (USA)
   serial: SLUS-29167
   version: '1.01'
 - hashes:
@@ -48795,7 +48797,7 @@
 - hashes:
   - md5: f246421facc822656b3d58166377d82f
     size: 3032383488
-  name: Samurai 7 (Japan)
+  name: Samurai 7 (Japan) (Genteiban)
   serial: SLPM-66399
   version: '1.01'
 - hashes:
@@ -49380,7 +49382,7 @@
 - hashes:
   - md5: 5ceb8b44766363697b8d076197023e7e
     size: 736157184
-  name: PS2 Bonus Demo Jan 2001 (Europe) (En,De)
+  name: PS2 Bonus Demo Jan 2001 (Europe) (En,Fr,De,Es,It)
   serial: SCED-50133
   version: '1.00'
 - hashes:
@@ -49833,8 +49835,8 @@
   - md5: eca0e208431d0676b931b2a30cd7c14f
     size: 3511943168
   name: NeoGeo Online Collection Vol. 10 - The King of Fighters '98 - Ultimate Match
-    (Japan) (En,Ja,Es,Pt)
-  serial: SLPS-25935
+    (Japan, Korea) (En,Ja,Es,Pt)
+  serial: SLKA-25432
   version: '1.04'
 - hashes:
   - md5: 20c8ba7f23434219292def9c542b124e
@@ -50300,7 +50302,7 @@
   - md5: d793cf83d372de5e856ce934a5116b8d
     size: 3881730048
   name: S.Y.K - Shinsetsu Saiyuuki (Japan)
-  serial: SLPM-55206
+  serial: SLPM-55205
   version: '1.02'
 - hashes:
   - md5: ebde5b11e68347e8caa03da84c1f0740
@@ -50615,7 +50617,7 @@
   - md5: 598c1d8e340bec4a3707b6fb358262ff
     size: 1360953344
   name: EA Demo Disc - From Russia with Love + Need for Speed - Most Wanted + SSX
-    On Tour (Australia)
+    on Tour (Australia)
   serial: SLED-53681
   version: '1.01'
 - hashes:
@@ -51137,7 +51139,7 @@
 - hashes:
   - md5: 51739d16d2f85d1d005eec1c8718c5bf
     size: 4055269376
-  name: Official PlayStation 2 Magazine Demo 49 (Europe) (En,Fr,De,Es,It)
+  name: Official PlayStation 2 Magazine Demo 49 (Europe) (En,Fr,De,Es,It) (SCED-52728)
   serial: SCED-52728
   version: '1.00'
 - hashes:
@@ -51185,7 +51187,7 @@
 - hashes:
   - md5: 45b80ce05b89a40f238d455c02b6f485
     size: 2384297984
-  name: Ratchet & Clank 3 + Sly 2 - Band of Thieves (Europe) (En,Fr,De,Es,It)
+  name: Ratchet & Clank 3 + Sly 2 - Band of Thieves (Europe) (En,Fr,De,Es,It) (Demo)
   serial: SCED-52848
   version: '1.01'
 - hashes:
@@ -51452,43 +51454,43 @@
 - hashes:
   - md5: 11b0a22f3921996d629fa71c229eebe5
     size: 1492123648
-  name: Commandos - Strike Force (Europe) (Beta)
+  name: Commandos - Strike Force (Europe) (Beta) (2005-02-28)
   serial: TLES-52768
   version: '0.30'
 - hashes:
   - md5: 2d4d8616834fe712d7cd2c29ebeeddc7
     size: 1709277184
-  name: Crash 'n' Burn (Europe) (Beta)
+  name: Crash 'n' Burn (Europe) (Beta) (2004-08-12)
   serial: TLES-52339
   version: '1.00'
 - hashes:
   - md5: 7c8be7db76461bdc752780e235b95ab7
     size: 1276313600
-  name: EyeToy - Chat (Europe) (Beta)
+  name: EyeToy - Chat (Europe) (Beta) (2004-05-10)
   serial: TCES-52154
   version: '0.08'
 - hashes:
   - md5: 140f63ad3b0c6218c93e135512507036
     size: 4698734592
-  name: FIFA 07 (Europe) (Beta)
+  name: FIFA 07 (Europe) (Beta) (2006-08-09)
   serial: TLES-54240
   version: '1.01'
 - hashes:
   - md5: 0955abf9d6f88923e0dad6393267aa5e
     size: 1228832768
-  name: Formula One 04 (Europe) (Beta)
+  name: Formula One 04 (Europe) (Beta) (2004-06-15)
   serial: TCES-52042
   version: '1.00'
 - hashes:
   - md5: 02a9492a3ffbf232aa5df1bc629db270
     size: 3931013120
-  name: Monster Hunter (Europe) (Beta)
+  name: Monster Hunter (Europe) (Beta) (2004-08-13)
   serial: TLES-52707
   version: '0.10'
 - hashes:
   - md5: 8b0b68a57b594b28017f926bafa0159b
     size: 1333592064
-  name: This Is Football 2004 (Europe) (Beta)
+  name: This Is Football 2004 (Europe) (Beta) (2004-02-19)
   serial: TCES-51613
   version: '1.00'
 - hashes:
@@ -51513,37 +51515,37 @@
 - hashes:
   - md5: f4af228793d748c2dcaa8b3e9f041fab
     size: 1399980032
-  name: Everybody's Golf (Europe) (Beta)
+  name: Everybody's Golf (Europe) (Beta) (2005-06-16)
   serial: TCES-52582
   version: '1.00'
 - hashes:
   - md5: 98b00a68a9cbefbb631a0b0f807c7a79
     size: 1249804288
-  name: Formula One 05 (Europe) (Beta)
+  name: Formula One 05 (Europe) (Beta) (2005-04-07)
   serial: TCES-53033
   version: '1.00'
 - hashes:
   - md5: 8fb81feb0aca7fe41f3b82d0b31332af
     size: 2070872064
-  name: Pro Evolution Soccer 5 (Europe) (Beta)
+  name: Pro Evolution Soccer 5 (Europe) (Beta) (2005-07-01)
   serial: TLES-53544
   version: '1.00'
 - hashes:
   - md5: 38666e7ed1aba64ee841b84d66bf7721
     size: 1793130496
-  name: S.L.A.I. - Steel Lancer Arena International (Europe) (Beta)
+  name: S.L.A.I. - Steel Lancer Arena International (Europe) (Beta) (2005-02-01)
   serial: TLES-52940
   version: '0.11'
 - hashes:
   - md5: 747ffd359d87d849842ac7512629cd8c
     size: 1269039104
-  name: Syphon Filter - The Omega Strain (Europe) (Beta)
+  name: Syphon Filter - The Omega Strain (Europe) (Beta) (2004-04-13)
   serial: TCES-52033
   version: '1.00'
 - hashes:
   - md5: 0840c82796333ec6ffdbb03965f33c90
     size: 2467692544
-  name: WRC 5 WT (Europe) (Beta)
+  name: WRC 5 WT (Europe) (Beta) (2005-06-02)
   serial: TCES-53247
   version: '0.01'
 - hashes:
@@ -51686,7 +51688,7 @@
 - hashes:
   - md5: a44554d7f03c867c06f9347f5026b216
     size: 4487905280
-  name: Getaway, The (Australia) (v2.00)
+  name: Getaway, The (Australia) (En,Fr,De,Es,It) (v2.00)
   serial: SCES-51426
   version: '2.00'
 - hashes:
@@ -51836,13 +51838,13 @@
 - hashes:
   - md5: 369cf818d847da184839bf7c9d064686
     size: 3238854656
-  name: This Is Football 2005 (Europe) (Beta)
+  name: This Is Football 2005 (Europe) (Beta) (2004-07-27)
   serial: TCES-52426
   version: '0.02'
 - hashes:
   - md5: 0cb8863ece0c6676032a41578906a562
     size: 1249509376
-  name: WWE SmackDown! vs. Raw (Europe) (Beta)
+  name: WWE SmackDown! vs. Raw (Europe) (Beta) (2004-07-26)
   serial: TLES-52781
   version: '1.00'
 - hashes:
@@ -51896,7 +51898,7 @@
 - hashes:
   - md5: 4c7baefa0e1dfe1dd6c1308595c52f44
     size: 2684747776
-  name: Time Crisis 3 (Europe) (Beta 1)
+  name: Time Crisis 3 (Europe) (Beta) (2003-07-04)
   serial: SLPS-99999
   version: '1.00'
 - hashes:
@@ -52159,7 +52161,7 @@
 - hashes:
   - md5: d8f8fb955dbd45f1e2616b04c5e755dc
     size: 1228832768
-  name: Space Channel 5 - Part 2 Special Demo (Australia)
+  name: Space Channel 5 Part 2 - Special Demo (Australia)
   serial: SCED-51405
   version: '1.00'
 - hashes:
@@ -52292,7 +52294,6 @@
   - md5: 22782dba3a168495b117e2d209911d28
     size: 383808768
   name: Kya - Dark Lineage (USA) (Demo)
-  serial: SLUS-28037
   version: '1.00'
 - hashes:
   - md5: f9e3336f1ae89a7e9a790eb43a0bdac1
@@ -52303,19 +52304,19 @@
 - hashes:
   - md5: a3911ce5ad184dbd2f24178aac98fefa
     size: 3268378624
-  name: Destruction Derby Arenas (Europe) (Beta)
+  name: Destruction Derby Arenas (Europe) (Beta) (2003-09-05)
   serial: SCES-50781
   version: '1.00'
 - hashes:
   - md5: d93ebe05f8cd6f8881866ec06df750b2
     size: 1249378304
-  name: Killzone (Europe) (Beta)
+  name: Killzone (Europe) (Beta) (2004-07-27)
   serial: TCES-52004
   version: '1.00'
 - hashes:
   - md5: f3709ed67c14edcd69074b86f140a515
     size: 540256752
-  name: SOCOM II - U.S. Navy SEALs (Europe) (Beta)
+  name: SOCOM II - U.S. Navy SEALs (Europe) (Beta) (2003-11-25)
   serial: TCES-51904
   version: '1.00'
 - hashes:
@@ -52327,7 +52328,7 @@
 - hashes:
   - md5: 0f9cc8a2f7501637ccd466e7d1154437
     size: 113032416
-  name: Tom Clancy's Splinter Cell - Pandora Tomorrow (Europe) (Beta)
+  name: Tom Clancy's Splinter Cell - Pandora Tomorrow (Europe) (Beta) (2004-03-29)
   serial: TLES-52149
   version: '1.00'
 - hashes:
@@ -52454,13 +52455,13 @@
 - hashes:
   - md5: 8945356dcaa88d03363c6e9323084347
     size: 1283358720
-  name: Jak X (Europe) (Beta)
+  name: Jak X (Europe) (Beta) (2005-06-23)
   serial: TCES-53286
   version: '1.01'
 - hashes:
   - md5: f0e75d9f1e9c074373d6298aa44d431a
     size: 1262387200
-  name: Ratchet & Clank 3 (Europe) (Beta)
+  name: Ratchet & Clank 3 (Europe) (Beta) (2004-07-12)
   serial: TCES-52456
   version: '1.00'
 - hashes:
@@ -52819,7 +52820,7 @@
 - hashes:
   - md5: b77283590a5efe7338719d14a7dc4f02
     size: 1721729024
-  name: Warhammer 40,000 - Fire Warrior (Europe) (En,Fr,De,Es,It) (Beta 2)
+  name: Warhammer 40,000 - Fire Warrior (Europe) (En,Fr,De,Es,It) (Beta) (2003-07-09)
   serial: SLES-50958
   version: '0.02'
 - hashes:
@@ -52891,19 +52892,19 @@
 - hashes:
   - md5: d9b37d2a8011991a7ce7219e86ace22b
     size: 1234436096
-  name: Killzone (USA) (Beta)
+  name: Killzone (USA) (Beta) (2004-07-27)
   serial: SCUS-97431
   version: '1.00'
 - hashes:
   - md5: 7a42930b495229bdc0b4298b8089f1f6
     size: 2222063616
-  name: EverQuest - Online Adventures (USA) (Beta 1)
+  name: EverQuest - Online Adventures (USA) (Beta) (2002-09-18)
   serial: SLUS-28020
   version: '1.00'
 - hashes:
   - md5: 08e835069996b8690af93e27c46e1008
     size: 2333802496
-  name: EverQuest - Online Adventures (USA) (Beta 2)
+  name: EverQuest - Online Adventures (USA) (Beta) (2002-10-20)
   serial: SLUS-28021
   version: '1.00'
 - hashes:
@@ -52957,7 +52958,7 @@
 - hashes:
   - md5: a31bb5fce53b91766dee83416cbca7f7
     size: 1403682816
-  name: EverQuest - Online Adventures (USA) (Beta 3)
+  name: EverQuest - Online Adventures (USA) (Beta) (2002-11-17)
   serial: SLUS-28026
   version: '1.00'
 - hashes:
@@ -52969,7 +52970,7 @@
 - hashes:
   - md5: 73cda5a0504f5d2700c32815c1879891
     size: 2302967808
-  name: S.L.A.I. - Steel Lancer Arena International (USA) (Beta)
+  name: S.L.A.I. - Steel Lancer Arena International (USA) (Beta) (2004-09-10)
   serial: SLUS-29132
   version: '0.11'
 - hashes:
@@ -53017,7 +53018,7 @@
 - hashes:
   - md5: 5eee0978fbc502c1cc4055c909e57119
     size: 709617216
-  name: SOCOM II - U.S. Navy SEALs (USA) (Beta)
+  name: SOCOM II - U.S. Navy SEALs (USA) (Beta) (2003-08-28)
   serial: SCUS-97366
   version: '1.00'
 - hashes:
@@ -53059,7 +53060,7 @@
 - hashes:
   - md5: 684c58825e6696a36493c3e6e151568a
     size: 3743485952
-  name: Secret Weapons over Normandy (USA) (Beta)
+  name: Secret Weapons over Normandy (USA) (Beta) (2003-09-12)
   serial: SLUS-20762
   version: '1.00'
 - hashes:
@@ -53172,19 +53173,19 @@
 - hashes:
   - md5: 0359e0b9eb2aa964efdbdaffe4f50133
     size: 3720884224
-  name: Sims 2, The (USA) (Beta 1)
+  name: Sims 2, The (USA) (Beta) (2005-07-29)
   serial: SLUS-21066
   version: '1.00'
 - hashes:
   - md5: 8f48d00769d25e87df505fbe7e6141c8
     size: 3438063616
-  name: Sims 2, The (USA) (Beta 2)
+  name: Sims 2, The (USA) (Beta) (2005-08-15)
   serial: SLUS-21265
   version: '1.00'
 - hashes:
   - md5: bb2dc8be8fe791d8e9644c33d92f5dc1
     size: 1810954240
-  name: AirBlade (Europe) (En,Fr,De,Es,It) (Beta)
+  name: AirBlade (Europe) (En,Fr,De,Es,It) (Beta) (2001-09-16)
   serial: SCES-50246
   version: '1.00'
 - hashes:
@@ -53256,19 +53257,19 @@
 - hashes:
   - md5: e3005d2e8b42a0da54561839ff247018
     size: 1711472640
-  name: Iron Eagle Max (Europe) (En,Fr,De) (Beta)
+  name: Iron Eagle Max (Europe) (En,Fr,De) (Beta) (2002-01-09)
   serial: SLES-50652
   version: '1.00'
 - hashes:
   - md5: d0cffa3f30ba273ebf234537fd0384fc
     size: 237801312
-  name: Polaroid Pete (Europe) (Beta)
+  name: Polaroid Pete (Europe) (Beta) (2002-01-09)
   serial: SLES-50557
   version: '1.00'
 - hashes:
   - md5: c6121e7d63c912157abac4ef4fc181a4
     size: 4221337600
-  name: Who Wants to Be a Millionaire - 2nd Edition (Europe) (Beta)
+  name: Who Wants to Be a Millionaire - 2nd Edition (Europe) (Beta) (2001-11-01)
   serial: SLES-50495
   version: '1.01'
 - hashes:
@@ -53280,13 +53281,13 @@
 - hashes:
   - md5: 03f676384a289a6be54c0ff0c7bbabf8
     size: 338560992
-  name: Sky Surfer (Europe) (En,Fr,De) (Beta)
+  name: Sky Surfer (Europe) (En,Fr,De) (Beta) (2000-09-25)
   serial: SLPS-20012
   version: '1.05'
 - hashes:
   - md5: 8aad0334046e16912f7fe19ea3bdb3da
     size: 3533438976
-  name: Crash Tag Team Racing (Europe) (Beta)
+  name: Crash Tag Team Racing (Europe) (Beta) (2005-09-28)
   serial: SLUS-21191
   version: '1.01'
 - hashes:
@@ -53310,25 +53311,25 @@
 - hashes:
   - md5: 87899355660568295eaa145d61f0fa92
     size: 1806204928
-  name: Ape Escape 2 (France) (Beta)
+  name: Ape Escape 2 (France) (Beta) (2002-10-28)
   serial: SCES-51102
   version: '1.00'
 - hashes:
   - md5: 1868675bdc8fb35a18b013185b3e525a
     size: 2934929408
-  name: Klonoa 2 - Lunatea's Veil (Europe) (En,Fr,De,Es,It) (Beta)
+  name: Klonoa 2 - Lunatea's Veil (Europe) (En,Fr,De,Es,It) (Beta) (2001-09-20)
   serial: SCES-50354
   version: '1.01'
 - hashes:
   - md5: efaaba1be07596520d82890c0eb0eaf8
     size: 4557078528
-  name: Primal (Europe) (En,Fr,De,Es,It) (Beta)
+  name: Primal (Europe) (En,Fr,De,Es,It) (Beta) (2003-01-08)
   serial: SCES-51135
   version: '1.00'
 - hashes:
   - md5: 67c190de2ae7c71f0624edcd53853fa1
     size: 2318596096
-  name: Ecco the Dolphin - Defender of the Future (Europe) (Beta)
+  name: Ecco the Dolphin - Defender of the Future (Europe) (Beta) (2001-11-07)
   serial: SCES-50499
   version: '1.02'
 - hashes:
@@ -53371,7 +53372,7 @@
 - hashes:
   - md5: f5e7cc8c89e3238a66306f073de2119f
     size: 4541317120
-  name: Dead or Alive 2 (Europe) (Beta)
+  name: Dead or Alive 2 (Europe) (Beta) (2000-09-08)
   serial: SCES-50003
   version: '0.80'
 - hashes:
@@ -53383,19 +53384,19 @@
 - hashes:
   - md5: ba3078ea8729f553600625bd9247da55
     size: 4524767232
-  name: PaRappa the Rapper 2 (Europe) (En,Fr,De,Es,It) (Beta)
+  name: PaRappa the Rapper 2 (Europe) (En,Fr,De,Es,It) (Beta) (2001-12-06)
   serial: SCES-50408
   version: '1.00'
 - hashes:
   - md5: bdbb42b8e0e2eb72bdf16645ffb4d850
     size: 1133805568
-  name: Penny Racers (Europe) (En,Fr,De) (Beta)
+  name: Penny Racers (Europe) (En,Fr,De) (Beta) (2001-08-24)
   serial: SLES-50252
   version: '1.00'
 - hashes:
   - md5: fa19e9961eb2af6e7b296a70cb0a961c
     size: 2347511808
-  name: TimeSplitters - Future Perfect (USA) (Beta)
+  name: TimeSplitters - Future Perfect (USA) (Beta) (2004-11-28)
   serial: SLUS-21148
   version: '1.00'
 - hashes:
@@ -53425,7 +53426,7 @@
 - hashes:
   - md5: 6c24f42b928aa66dcdd61d6f6be8a38d
     size: 4315021312
-  name: SOCOM - U.S. Navy SEALs - Combined Assault (Europe) (Beta)
+  name: SOCOM - U.S. Navy SEALs - Combined Assault (Europe) (Beta) (2007-03-12)
   serial: SCES-54477
   version: '1.00'
 - hashes:
@@ -53468,7 +53469,7 @@
   - md5: f3d4eb3b51c68562f77da6709fce84a7
     size: 4166811648
   name: Scared Rider Xechs (Japan)
-  serial: SLPM-55266
+  serial: SLPM-55265
   version: '1.01'
 - hashes:
   - md5: b4003ce1af68f0e043b91878538ed1c4
@@ -53629,19 +53630,19 @@
 - hashes:
   - md5: 1ad223af7f650813384afce91064c182
     size: 445160688
-  name: SNK vs. Capcom - SVC Chaos (Europe) (Beta)
+  name: SNK vs. Capcom - SVC Chaos (Europe) (Beta) (2004-11-29)
   serial: SLES-53065
   version: '1.00'
 - hashes:
   - md5: 03621b68cd47e77c81f301a843b4e6c4
     size: 1403715584
-  name: Wreckless - The Yakuza Missions (USA) (Beta)
+  name: Wreckless - The Yakuza Missions (USA) (Beta) (2002-09-09)
   serial: SLUS-20431
   version: '1.00'
 - hashes:
   - md5: ac8f4088991729f43cfba39a55949c22
     size: 1787133952
-  name: RoadKill (Europe) (Beta)
+  name: RoadKill (Europe) (Beta) (2003-09-09)
   serial: SLES-51842
   version: '1.00'
 - hashes:
@@ -53653,78 +53654,78 @@
 - hashes:
   - md5: 9a7a28a9a3a6428a58bf7c789787bca4
     size: 914999296
-  name: Prince of Persia - The Two Thrones (Europe) (En,Fr,De,Es,It) (Beta)
+  name: Prince of Persia - The Two Thrones (Europe) (En,Fr,De,Es,It) (Beta) (2005-09-30)
   serial: SLES-53777
   version: '1.00'
 - hashes:
   - md5: 19770e8880494d053f0f7b8f27dfb65f
     size: 4697229312
-  name: Star Wars - Battlefront (Europe) (Beta)
+  name: Star Wars - Battlefront (Europe) (Beta) (2004-08-05)
   serial: SLES-52545
   version: '1.01'
 - hashes:
   - md5: 366317925352888c760f943287a3f36d
     size: 2755952640
-  name: Time Crisis 3 (Europe) (Beta 2)
+  name: Time Crisis 3 (Europe) (Beta) (2003-07-18)
   serial: SCES-51844
   version: '1.00'
 - hashes:
   - md5: 9be93b02653c39f5968b9ef30dc98e97
     size: 1392801792
-  name: Vampire Night (Europe) (Beta)
+  name: Vampire Night (Europe) (Beta) (2001-11-30)
   version: '1.00'
 - hashes:
   - md5: f40ae9defc584564b0883b1fb93625bd
     size: 4417060864
-  name: Tekken's Nina Williams in - Death by Degrees (Europe) (En,De) (Beta)
+  name: Tekken's Nina Williams in - Death by Degrees (Europe) (En,De) (Beta) (2004-12-29)
   serial: SCES-53054
   version: '1.00'
 - hashes:
   - md5: 55bbe9b1489656357c1e02d111bee2eb
     size: 3556913152
-  name: We Love Katamari (Europe) (Beta)
+  name: We Love Katamari (Europe) (Beta) (2005-09-21)
   serial: SLUS-21230
   version: '1.00'
 - hashes:
   - md5: 7cd7c95d47907eee2671fb2fd973a42b
     size: 2669969408
-  name: Atelier Iris - Eternal Mana (Europe) (Beta)
+  name: Atelier Iris - Eternal Mana (Europe) (Beta) (2006-01-04)
   serial: SLES-53764
   version: '1.00'
 - hashes:
   - md5: 13b741917526441633c83e8e79ed7fd2
     size: 2437251072
-  name: Viewtiful Joe (USA) (Beta)
+  name: Viewtiful Joe (USA) (Beta) (2004-07-01)
   serial: SLUS-20951
   version: '1.00'
 - hashes:
   - md5: 90ef88c4d3c3350fd64e31252f90d320
     size: 702281328
-  name: MDK2 - Armageddon (USA) (En,Fr,De,Es,It) (Beta)
+  name: MDK2 - Armageddon (USA) (En,Fr,De,Es,It) (Beta) (2001-03-09)
   serial: SLUS-20105
   version: '1.00'
 - hashes:
   - md5: 319c671d178cf02abdbc8a84f961dcd5
     size: 746872896
-  name: International Superstar Soccer 2 (Europe) (En,De) (Beta)
+  name: International Superstar Soccer 2 (Europe) (En,De) (Beta) (2002-01-11)
   serial: SLPM-62075
   version: '1.00'
 - hashes:
   - md5: 1ee843d5217225efc010ae1da07da01e
     size: 4236937216
-  name: Super Dragon Ball Z (Europe) (Beta)
+  name: Super Dragon Ball Z (Europe) (Beta) (2006-05-02)
   serial: SLES-54161
   version: '0.90'
 - hashes:
   - md5: d1d9cf1fc12813c694bfc33f7f2511d6
     size: 4571201536
-  name: Ace Combat - The Belkan War (Europe) (Beta)
+  name: Ace Combat - The Belkan War (Europe) (Beta) (2006-06-01)
   serial: SCES-54041
   version: '1.00'
 - hashes:
   - md5: 6ce21c7f1cc6a545df294c70a440c6aa
     size: 2157215744
-  name: Red Star, The (Europe) (Beta)
+  name: Red Star, The (Europe) (Beta) (2004-07-23)
   serial: SLES-52741
   version: '1.00'
 - hashes:
@@ -53772,7 +53773,7 @@
 - hashes:
   - md5: dae89603894cc9177899ecb37f517c86
     size: 2187360256
-  name: Tom Clancy's Ghost Recon 2 (Europe) (En,Fr,De,Es,It) (Beta)
+  name: Tom Clancy's Ghost Recon 2 (Europe) (En,Fr,De,Es,It) (Beta) (2004-09-24)
   serial: SLES-52646
   version: '1.00'
 - hashes:
@@ -53796,43 +53797,43 @@
 - hashes:
   - md5: efd0bea98e06813352261fab5b3e7927
     size: 3592486912
-  name: Ace Combat - Distant Thunder (Europe) (Beta)
+  name: Ace Combat - Distant Thunder (Europe) (Beta) (2001-11-15)
   serial: SCES-50410
   version: '1.00'
 - hashes:
   - md5: f84be6db3ac27922ec32d4bf9c366ac8
     size: 3947397120
-  name: Ape Escape 3 (Europe) (En,Fr,De,Es,It) (Beta)
+  name: Ape Escape 3 (Europe) (En,Fr,De,Es,It) (Beta) (2006-02-21)
   serial: SCES-53642
   version: '1.00'
 - hashes:
   - md5: 0f1758117938c27766f9c57dcb227c88
     size: 3914596352
-  name: Black (Europe) (Beta)
+  name: Black (Europe) (Beta) (2006-01-09)
   serial: SLES-53886
   version: '1.00'
 - hashes:
   - md5: d96e9a3679c12063701f7390edcb2d03
     size: 257278224
-  name: Capcom vs. SNK 2 - Millionaire Fighting 2001 (Japan) (Beta)
+  name: Capcom vs. SNK 2 - Millionaire Fighting 2001 (Japan) (Beta) (2001-07-24)
   serial: SLPM-65047
   version: '1.00'
 - hashes:
   - md5: 505c95c2e6c7087ffca6afff43002562
     size: 4038688768
-  name: Crisis Zone (Europe) (En,Fr,De,Es,It) (Beta)
+  name: Crisis Zone (Europe) (En,Fr,De,Es,It) (Beta) (2004-08-02)
   serial: SCES-52530
   version: '1.00'
 - hashes:
   - md5: dac0d9fbd9f6fcc1dea20dda322868db
     size: 561582336
-  name: ESPN International Track & Field (Europe) (Beta)
+  name: ESPN International Track & Field (Europe) (Beta) (2000-09-22)
   serial: SLES-50036
   version: '1.00'
 - hashes:
   - md5: 70e2fbce37b30c26f695fa9fb043fcbc
     size: 4386029568
-  name: Fallout - Brotherhood of Steel (Europe) (En,Es,It) (Beta)
+  name: Fallout - Brotherhood of Steel (Europe) (En,Es,It) (Beta) (2003-12-02)
   serial: SLES-51526
   version: '1.00'
 - hashes:
@@ -53844,37 +53845,37 @@
 - hashes:
   - md5: 998ea870ceca73725a1ab9e81d27db8d
     size: 1632796672
-  name: XGRA - Extreme G Racing Association (USA) (Beta)
+  name: XGRA - Extreme G Racing Association (USA) (Beta) (2003-07-03)
   serial: SLUS-20632
   version: '1.00'
 - hashes:
   - md5: 7ad9d9be7d89b4a0d0f573c59def5f12
     size: 271322016
-  name: Silent Scope (Europe) (Beta)
+  name: Silent Scope (Europe) (Beta) (2000-09-13)
   serial: SLES-50037
   version: '1.00'
 - hashes:
   - md5: 1df17721eff7fae329a3c285b71d76c3
     size: 3711301632
-  name: Project Zero II - Crimson Butterfly (Europe) (En,Fr,De,Es,It) (Beta)
+  name: Project Zero II - Crimson Butterfly (Europe) (En,Fr,De,Es,It) (Beta) (2004-02-06)
   serial: SLES-52384
   version: '1.00'
 - hashes:
   - md5: 87ca878676a810c7f6e0401494c55ba2
     size: 1999568896
-  name: NeoGeo Battle Coliseum (Europe) (Beta)
+  name: NeoGeo Battle Coliseum (Europe) (Beta) (2006-09-15)
   serial: SLES-54395
   version: '1.00'
 - hashes:
   - md5: db14662c812ea2c99100e19a858bad0e
     size: 662572512
-  name: Micro Machines V4 (Europe) (En,Fr,De,Es,It) (Beta)
+  name: Micro Machines V4 (Europe) (En,Fr,De,Es,It) (Beta) (2006-05-24)
   serial: SLES-53668
   version: '1.01'
 - hashes:
   - md5: f8f26de517ec7299de3fcd3c91ff31da
     size: 720765696
-  name: Maximo - Ghosts to Glory (USA) (Beta)
+  name: Maximo - Ghosts to Glory (USA) (Beta) (2001-12-05)
   serial: SLUS-20017
   version: '1.01'
 - hashes:
@@ -53886,7 +53887,7 @@
 - hashes:
   - md5: d17e34819d6d2e8a26dc2b1d90693be6
     size: 2198568960
-  name: 24 - The Game (Europe) (En,Fr,De,Es,It,Pl,Cs,Hu) (Beta)
+  name: 24 - The Game (Europe) (En,Fr,De,Es,It,Pl,Cs,Hu) (Beta) (2005-11-28)
   serial: SCES-53358
   version: '1.00'
 - hashes:
@@ -54043,13 +54044,13 @@
 - hashes:
   - md5: 4bdfc1700cd493d73e68f916579f7f0e
     size: 4698767360
-  name: Resident Evil - Outbreak (USA) (Beta)
+  name: Resident Evil - Outbreak (USA) (Beta) (2003-12-19)
   serial: SLUS-29089
   version: '1.01'
 - hashes:
   - md5: 17804b6d0d7defc8bb75124d9a0edeb8
     size: 1262387200
-  name: Ratchet & Clank - Up Your Arsenal (USA) (Beta)
+  name: Ratchet & Clank - Up Your Arsenal (USA) (Beta) (2004-06-20)
   serial: SCUS-97413
   version: '1.00'
 - hashes:
@@ -54236,7 +54237,7 @@
 - hashes:
   - md5: 5fa94ca9b96e6f11d410f7dbc48a0575
     size: 3104604160
-  name: Buzz! Junior - RoboJam (Europe) (En,Fr,De,Es,It,Nl,Pt) (Beta)
+  name: Buzz! Junior - RoboJam (Europe) (En,Fr,De,Es,It,Nl,Pt) (Beta) (2007-03-14)
   serial: SCES-54676
   version: '1.00'
 - hashes:
@@ -54314,7 +54315,7 @@
 - hashes:
   - md5: 0127d662e9d3744c140dfcfbf17b5893
     size: 3923410944
-  name: Monster Hunter (USA) (Beta)
+  name: Monster Hunter (USA) (Beta) (2004-05-21)
   serial: SLUS-29110
   version: '1.01'
 - hashes:
@@ -54374,7 +54375,7 @@
 - hashes:
   - md5: 65a2fbfe50e69310b0c5c4a1f508cd53
     size: 1266253824
-  name: SpyToy (Europe) (En,Fr,De,Es,It,Nl,Pt,Sv,No,Da,Fi) (Beta)
+  name: SpyToy (Europe) (En,Fr,De,Es,It,Nl,Pt,Sv,No,Da,Fi) (Beta) (2005-08-09)
   serial: SCES-53347
   version: '1.00'
 - hashes:
@@ -54798,13 +54799,14 @@
 - hashes:
   - md5: d6cb33f7eaeb04dc2b32b6e576933da2
     size: 1403060224
-  name: Hardware - Online Arena (Europe) (Beta)
+  name: Hardware - Online Arena (Europe) (Beta) (2003-06-12)
   serial: SCES-51593
   version: '0.01'
 - hashes:
   - md5: dbb9e2095e264130ed5088f0607b475f
     size: 1840775168
   name: WRC 4 - The Official Game of the FIA World Rally Championship (Europe) (Beta)
+    (2004-07-12)
   serial: TCES-52389
   version: '1.00'
 - hashes:
@@ -54930,13 +54932,13 @@
 - hashes:
   - md5: 29156023e8fc20110a64c13b867e0a10
     size: 634746000
-  name: F1 Racing Championship (Europe) (En,Es,It) (Beta)
+  name: F1 Racing Championship (Europe) (En,Es,It) (Beta) (2000-11-14)
   serial: SLPS-20042
   version: '1.00'
 - hashes:
   - md5: 6c887a4092289bf3e21bdc3fde755fa1
     size: 4690182144
-  name: Formula One 06 (Europe) (En,Fr,De,Es,It,Pt,Fi) (Beta 1)
+  name: Formula One 06 (Europe) (En,Fr,De,Es,It,Pt,Fi) (Beta) (2006-06-02)
   serial: SCES-53950
   version: '1.00'
 - hashes:
@@ -54960,7 +54962,7 @@
 - hashes:
   - md5: ea32279a3c5574074c52f3d6d407bea1
     size: 3966337024
-  name: Kingdom Hearts II (USA) (Beta)
+  name: Kingdom Hearts II (USA) (Beta) (2006-02-03)
   serial: SLUS-21005
   version: '0.10'
 - hashes:
@@ -55103,7 +55105,7 @@
 - hashes:
   - md5: 5744e291539bfc384d3b171b69ce8773
     size: 4697260032
-  name: SSX On Tour (Europe) (Demo)
+  name: SSX on Tour (Europe) (Demo)
   serial: SLED-53625
   version: '1.00'
 - hashes:
@@ -55242,7 +55244,7 @@
 - hashes:
   - md5: 947772ce0e7aaf5c118cada4b862df0b
     size: 2323775488
-  name: 25 to Life (USA) (Beta)
+  name: 25 to Life (USA) (Beta) (2005-05-26)
   serial: SLUS-29129
   version: '0.20'
 - hashes:
@@ -55456,7 +55458,7 @@
 - hashes:
   - md5: c8fa4fa8bd535afc2589d0314a5588e9
     size: 1302231040
-  name: Klonoa 2 - Lunatea's Veil (Europe) (Beta)
+  name: Klonoa 2 - Lunatea's Veil (Europe) (Beta) (2001-05-30)
   serial: SLUS-20151
   version: '1.04'
 - hashes:
@@ -55486,7 +55488,7 @@
 - hashes:
   - md5: 0af9c50f6860fd17a79049cfa8f469e3
     size: 4487442432
-  name: ATV Offroad Fury 2 (USA) (Beta)
+  name: ATV Offroad Fury 2 (USA) (Beta) (2002-10-29)
   serial: SCUS-97211
   version: '1.00'
 - hashes:
@@ -55498,7 +55500,7 @@
 - hashes:
   - md5: 93c0e74bd7a055ff2360916e147521fe
     size: 705783456
-  name: SX Superstar (USA) (Beta)
+  name: SX Superstar (USA) (Beta) (2003-04-21)
   serial: SLUS-20600
   version: '1.00'
 - hashes:
@@ -55570,13 +55572,13 @@
 - hashes:
   - md5: 8486da720897ae09a9e4fcb544314102
     size: 4413456384
-  name: Combat Elite - WWII Paratroopers (Europe) (Beta)
+  name: Combat Elite - WWII Paratroopers (Europe) (Beta) (2004-05-12)
   serial: SLES-52392
   version: '1.00'
 - hashes:
   - md5: 062c89e675c3c11f4975f00634da77e0
     size: 2518745088
-  name: ATV Offroad Fury 3 (USA) (Beta)
+  name: ATV Offroad Fury 3 (USA) (Beta) (2004-08-22)
   serial: SCUS-97405
   version: '1.00'
 - hashes:
@@ -55660,13 +55662,13 @@
 - hashes:
   - md5: dcb00fc4e79ea1210143a9aff085c466
     size: 163861488
-  name: AH-64D Apache (Japan) (Beta)
+  name: AH-64D Apache (Japan) (Beta) (2003-03-26)
   serial: SLPS-20000
   version: '1.00'
 - hashes:
   - md5: 09b41f087e1ac5efae7de8eb95ed8e0c
     size: 4536664064
-  name: Evergrace (Europe) (En,Fr,De,Es,It) (Beta)
+  name: Evergrace (Europe) (En,Fr,De,Es,It) (Beta) (2001-01-26)
   serial: SLES-50050
   version: '1.00'
 - hashes:
@@ -55684,7 +55686,7 @@
 - hashes:
   - md5: abb37956d1ed6a7a19c79a8ae8030413
     size: 3575349248
-  name: Armored Core 2 (Europe) (Beta)
+  name: Armored Core 2 (Europe) (Beta) (2000-11-13)
   serial: SLES-50079
   version: '1.10'
 - hashes:
@@ -55696,7 +55698,7 @@
 - hashes:
   - md5: 1bc8707aff84fd6aaa477d9dacd512fc
     size: 512338512
-  name: Twisted Metal - Black Online (Europe) (Beta)
+  name: Twisted Metal - Black Online (Europe) (Beta) (2003-03-14)
   serial: SCES-51480
   version: '1.00'
 - hashes:
@@ -55712,18 +55714,18 @@
 - hashes:
   - md5: d2c18c2671e6b4c70b22f3f4873e347e
     size: 190544928
-  name: White Fear (Europe) (Beta)
+  name: White Fear (Europe) (Beta) (2002-04-05)
   version: '1.00'
 - hashes:
   - md5: ca65ccf5975df4eeea65178039d05f49
     size: 4419321856
-  name: Formula One 06 (Europe) (En,Fr,De,Es,It,Pt,Fi) (Beta 2)
+  name: Formula One 06 (Europe) (En,Fr,De,Es,It,Pt,Fi) (Beta) (2006-06-21)
   serial: SCES-53950
   version: '0.01'
 - hashes:
   - md5: b0e543da2435b1780bba0761342a4541
     size: 3356655616
-  name: Shin Seiki GPX Cyber Formula - Road to the Infinity 3 (Japan)
+  name: Future GPX Cyber Formula - Road to the Infinity 3 (Japan)
   serial: SLPS-25695
   version: '1.01'
 - hashes:
@@ -55764,18 +55766,18 @@
 - hashes:
   - md5: 34bc1e8e5191ecd4fe0936ac54c9788a
     size: 81247488
-  name: Fleet - Shiva's Gate (USA) (Proto)
+  name: Fleet - Shiva's Gate (USA) (Proto) (2002-05-21)
   version: '0.02'
 - hashes:
   - md5: 81be609b13f241ec045f506a05ab059c
     size: 1713078272
-  name: Turok - Evolution (USA) (En,Fr,De,Es,It) (Beta)
+  name: Turok - Evolution (USA) (En,Fr,De,Es,It) (Beta) (2002-07-23)
   serial: SLUS-20333
   version: '1.00'
 - hashes:
   - md5: e08833aaa10084a7571d1477893c07ea
     size: 347209728
-  name: Simpsons, The - Road Rage (USA) (Beta)
+  name: Simpsons, The - Road Rage (USA) (Beta) (2001-09-25)
   serial: SLUS-20305
   version: '1.00'
 - hashes:
@@ -55811,7 +55813,7 @@
 - hashes:
   - md5: 62c75ecf416b9371700aa4b697348104
     size: 696293136
-  name: Psyvariar - Complete Edition (Europe) (En,Ja,Fr,De) (Beta)
+  name: Psyvariar - Complete Edition (Europe) (En,Ja,Fr,De) (Beta) (2003-04-15)
   serial: SLES-51675
   version: '1.00'
 - hashes:
@@ -55827,7 +55829,7 @@
     size: 65402064
   - md5: 5fb9e057b0ff9a2cac06497e514fc871
     size: 36479520
-  name: Dance Factory (Europe) (Beta)
+  name: Dance Factory (Europe) (Beta) (2006-02-06)
   serial: SLES-53009
   version: '1.00'
 - hashes:
@@ -55875,7 +55877,7 @@
 - hashes:
   - md5: a589439f38f813ec8a20a43c23ccc670
     size: 1254293504
-  name: WWE SmackDown! vs. Raw (USA) (Beta)
+  name: WWE SmackDown! vs. Raw (USA) (Beta) (2004-07-06)
   serial: SLUS-29116
   version: '1.00'
 - hashes:
@@ -55994,7 +55996,7 @@
 - hashes:
   - md5: e747320fb280e6f80eed5d105df40e7d
     size: 528275664
-  name: Crash 'n' Burn (USA) (Beta)
+  name: Crash 'n' Burn (USA) (Beta) (2004-08-13)
   serial: SLUS-29130
   version: '1.00'
 - hashes:
@@ -56066,13 +56068,13 @@
 - hashes:
   - md5: 6d7d07b760615529452d3e690abfc885
     size: 1228898304
-  name: Mirage (Europe) (Beta)
+  name: Mirage (Europe) (Beta) (2004-07-16)
   serial: TCES-10001
   version: '0.12'
 - hashes:
   - md5: afbc760d6a20f351fad3135f712e4a31
     size: 1230045184
-  name: SOCOM - U.S. Navy SEALs (Europe) (Beta)
+  name: SOCOM - U.S. Navy SEALs (Europe) (Beta) (2003-03-04)
   serial: SCES-50928
   version: '1.00'
 - hashes:
@@ -56102,13 +56104,13 @@
 - hashes:
   - md5: 32ff756a422387885e23271ccb033bc2
     size: 415478448
-  name: Fatman & Slim (Europe) (Proto)
+  name: Fatman & Slim (Europe) (Proto) (2002-12-06)
   serial: SLES-51425
   version: '1.00'
 - hashes:
   - md5: 683f37453d0aa35739c7215bac9fabc9
     size: 3864854528
-  name: Devil May Cry 3 (Europe) (En,Ja,Fr,De,Es,It,Ko) (Beta)
+  name: Devil May Cry 3 (Europe) (En,Ja,Fr,De,Es,It,Ko) (Beta) (2005-01-11)
   version: '1.00'
 - hashes:
   - md5: 381280d0c18bf658e6dc0601aba7415e
@@ -56119,7 +56121,7 @@
 - hashes:
   - md5: 2d817ecf3b485dc26871d3e5cb290938
     size: 380675904
-  name: 7 Sins (Europe) (Beta)
+  name: 7 Sins (Europe) (Beta) (2004-09-29)
   version: '1.00'
 - hashes:
   - md5: 45d62f1cf862b8e6c47d373a5c55d2f2
@@ -56130,7 +56132,7 @@
 - hashes:
   - md5: f9db023c4a00bc2ff42347c890ab1fb5
     size: 3178692608
-  name: Primal (Europe) (En,Fr) (Beta)
+  name: Primal (Europe) (En,Fr) (Beta) (2002-11-04)
   version: '1.00'
 - hashes:
   - md5: e9447d90c8cd03c9e393f58541e5a9dc
@@ -56159,7 +56161,7 @@
 - hashes:
   - md5: e10ab51a8e8296e42f99da29d66850cf
     size: 534176832
-  name: Crash Bandicoot - The Wrath of Cortex (USA) (Beta)
+  name: Crash Bandicoot - The Wrath of Cortex (USA) (Beta) (2001-09-21)
   serial: SLUS-20238
   version: '1.00'
 - hashes:
@@ -56449,7 +56451,7 @@
 - hashes:
   - md5: c482a447c9ec1870f207304647c27755
     size: 1809909760
-  name: OutRun 2006 - Coast 2 Coast (Europe) (En,Fr,De,Es,It) (Beta)
+  name: OutRun 2006 - Coast 2 Coast (Europe) (En,Fr,De,Es,It) (Beta) (2006-02-13)
   serial: SLES-53998
   version: '1.01'
 - hashes:
@@ -56749,13 +56751,13 @@
 - hashes:
   - md5: 63a42fc12168a9041c37e7a276c8b37e
     size: 806217728
-  name: Gravenville - Ghost Master Chronicles (USA) (Beta)
+  name: Gravenville - Ghost Master Chronicles (USA) (Beta) (2004-05-07)
   serial: SLUS-20466
   version: '1.00'
 - hashes:
   - md5: 5e2c1dcee9e494687eb4c51b3e01fdb2
     size: 1357983744
-  name: 100 Bullets (USA) (Proto)
+  name: 100 Bullets (USA) (Proto) (2004-06-30)
   version: '1.00'
 - hashes:
   - md5: 44260d0f8f451d0b4c9d7f38c2aa36be
@@ -56780,7 +56782,7 @@
 - hashes:
   - md5: 2bd89e4f6a14f69c670b9ced72c09987
     size: 1262387200
-  name: Ratchet - Deadlocked (USA) (Beta)
+  name: Ratchet - Deadlocked (USA) (Beta) (2005-06-30)
   serial: SCUS-97487
   version: '1.00'
 - hashes:
@@ -56810,19 +56812,19 @@
 - hashes:
   - md5: 93689afe84bd5b97b245c719ce076afb
     size: 2999222272
-  name: Dragon Ball Z - Budokai Tenkaichi 2 (USA) (Beta)
+  name: Dragon Ball Z - Budokai Tenkaichi 2 (USA) (Beta) (2006-08-03)
   serial: SLUS-21441
   version: '1.00'
 - hashes:
   - md5: f9358e8226377ca0e7c344185050644c
     size: 3784605696
-  name: Nanobreaker (Japan) (Beta)
+  name: Nanobreaker (Japan) (Beta) (2004-09-17)
   serial: SLPM-65809
   version: '1.02'
 - hashes:
   - md5: ee9cfc917cd6b1131a22c8b30a28faec
     size: 3684927488
-  name: Need for Speed - ProStreet (USA) (Beta)
+  name: Need for Speed - ProStreet (USA) (Beta) (2007-10-04)
   serial: SLUS-21658
   version: '1.00'
 - hashes:
@@ -56846,7 +56848,7 @@
 - hashes:
   - md5: 24192882e013f8425e1a9a2270f70132
     size: 3028975616
-  name: Sniper Elite (Europe) (Beta)
+  name: Sniper Elite (Europe) (Beta) (2005-09-16)
   serial: SLES-53758
   version: '1.00'
 - hashes:
@@ -56954,7 +56956,7 @@
 - hashes:
   - md5: 191083897d9c425105cc56d8de4331b9
     size: 1448019968
-  name: Aeon Flux (USA) (Beta)
+  name: Aeon Flux (USA) (Beta) (2005-06-28)
   version: '1.10'
 - hashes:
   - md5: b239b7ba60c868f7ecb0d2280828438f
@@ -56966,7 +56968,7 @@
   - md5: 237d2cefaa5bb7eab8edb87bca549a78
     size: 761692848
   name: Memory Manager Plus (USA) (Unl) (Version 2.0)
-  version: '1.10'
+  version: '2.0'
 - hashes:
   - md5: 2da8bf56adcc02655e0e84b553e62d81
     size: 4660592640
@@ -56977,7 +56979,7 @@
   - md5: dfafed54c8da80890c2fc9fe0dcb7d78
     size: 761692848
   name: Memory Manager Plus (USA) (Unl) (Version 1.01)
-  version: '1.10'
+  version: '1.01'
 - hashes:
   - md5: 472d55d864b5fcdb2390ebf58371755c
     size: 154161840
@@ -57111,7 +57113,7 @@
   - md5: 3955b7a0a675b20ed9539c0173e3939c
     size: 761692848
   name: Memory Manager Plus (USA) (Unl) (Version 1.9)
-  version: '1.10'
+  version: '1.9'
 - hashes:
   - md5: 8bb88976bb84fbf69e81bef1b5de12cb
     size: 4173496320
@@ -57122,11 +57124,11 @@
   - md5: 624f9ef18459874bb519130ee371864c
     size: 718702992
   name: Mega Memory (USA) (Unl) (Version 2.23)
-  version: '1.10'
+  version: '2.23'
 - hashes:
   - md5: f749a3e916d0e23d11a1d42bee664e03
     size: 1271988224
-  name: Hot Shots Golf Fore! (USA) (Beta)
+  name: Hot Shots Golf Fore! (USA) (Beta) (2004-06-09)
   serial: SCUS-97427
   version: '1.00'
 - hashes:
@@ -57436,7 +57438,7 @@
   - md5: faf76fec9e6f45fd3863bd8d0ac8d7ff
     size: 761692848
   name: Memory Manager Plus (USA) (Unl) (Version 1.8)
-  version: '1.10'
+  version: '1.8'
 - hashes:
   - md5: 5c4bb42728771697f7a2fb45b405a519
     size: 4674387968
@@ -57471,22 +57473,22 @@
 - hashes:
   - md5: 860baacda89179f11eb8502350d05f3a
     size: 718702992
-  name: PS Mania 2.0 Spaccacodici - Killzone (Italy) (Unl)
+  name: Playable Cheats Vol. 25 (Europe) (Unl)
   version: 1.00 (European)
 - hashes:
   - md5: 2d62c85d4b25beda2b0000e045adaff6
     size: 718702992
-  name: PS Mania 2.0 Spaccacodici - Grand Theft Auto - San Andreas (Italy) (Unl) (20050124)
+  name: Playable Cheats Vol. 26 (Europe) (Unl) (2005-01-24)
   version: 1.00 (European)
 - hashes:
   - md5: 682cd8fc66fce36c9d5f38fa1d18c699
     size: 718702992
-  name: PS Mania 2.0 Spaccacodici - Need for Speed - Underground 2 (Italy) (Unl)
+  name: Playable Cheats Vol. 24 (Europe) (Unl)
   version: 1.00 (European)
 - hashes:
   - md5: 3c40b1950ef88ab7efb5785a25aa0dd1
     size: 177757104
-  name: Kung Fu Fighting (USA) (Proto)
+  name: Kung Fu Fighting (USA) (Proto) (2001-04-30)
   version: '1.00'
 - hashes:
   - md5: 0101481134ad55492d8103246f25f95e
@@ -57562,7 +57564,7 @@
 - hashes:
   - md5: 861619a3369332e8205fad62113b8e4a
     size: 4401135616
-  name: Silent Hill 2 (USA) (En,Ja) (Beta)
+  name: Silent Hill 2 (USA) (En,Ja) (Beta) (2001-07-13)
   version: '1.20'
 - hashes:
   - md5: b74fc7a685014224c7fabab872b63cfe
@@ -57661,7 +57663,7 @@
 - hashes:
   - md5: a7346a9c7d3266c0b332cda59a3bea18
     size: 761692848
-  name: Action Replay Max Demo Disc (Europe) (Unl)
+  name: Action Replay Max Demo Disc (UK) (Unl)
   version: '1.00'
 - hashes:
   - md5: 65ae00d6d4f2ce66b5446b201ede2d31
@@ -57867,31 +57869,31 @@
 - hashes:
   - md5: 739a2f519751c64f7291d036105c2c0d
     size: 1670316032
-  name: Buzz! Junior - Robojam (Europe) (Beta)
+  name: Buzz! Junior - Robojam (Europe) (Beta) (2007-01-12)
   serial: SCES-54676
   version: '1.00'
 - hashes:
   - md5: d6c21b8a4c1edfcf8d1c61acb67f6e61
     size: 3493396480
-  name: Drakan - The Ancients' Gates (USA) (En,Fr,De,Es,It) (Beta)
+  name: Drakan - The Ancients' Gates (Europe) (En,Fr,De,Es,It) (Beta) (2001-11-27)
   serial: SCUS-97128
   version: '0.10'
 - hashes:
   - md5: a6629bd2777f51a0f818a08be328a479
     size: 4098752512
-  name: EyeToy - Kinetic Combat (Europe) (Beta)
+  name: EyeToy - Kinetic Combat (Europe) (Beta) (2006-06-13)
   serial: SCES-54148
   version: '1.00'
 - hashes:
   - md5: f90bf2315a3bfd109bd96ba1fca9a735
     size: 2572072960
-  name: Star Wars - Battlefront II (USA) (Beta 2)
+  name: Star Wars - Battlefront II (USA) (Beta) (2005-09-09)
   serial: SLUS-21240
   version: '1.01'
 - hashes:
   - md5: 934c2599b5aebe245c531e2e2ed89329
     size: 1141471232
-  name: This Is Football 2003 (Europe) (Beta)
+  name: This Is Football 2003 (Europe) (Beta) (2002-07-24)
   serial: SCES-51039
   version: '1.00'
 - hashes:
@@ -58376,7 +58378,7 @@
   - md5: 4eb7a93ed6ccf50755ff0df7c970d88e
     size: 2158985216
   name: D-A - White (Japan)
-  serial: SLPS-25619
+  serial: SLPS-25438
   version: '3.00'
 - hashes:
   - md5: 2c6b1e42f6503293d7ed9e0c7873093b
@@ -58429,7 +58431,7 @@
 - hashes:
   - md5: 8e3c256d632806764413999cd3006837
     size: 4170842112
-  name: Yoshitsune Eiyuuden Shura - The Story of Hero Yoshitsune Shura (Japan, Asia)
+  name: Yoshitsune Eiyuuden Shura (Japan, Asia)
   serial: SCAJ-20155
   version: '1.10'
 - hashes:
@@ -58622,13 +58624,13 @@
 - hashes:
   - md5: a5c8bd4f847fbcd0350d92410b0156b4
     size: 4132634624
-  name: Burnout 2 - Point of Impact (Europe) (En,Fr,De,Es,It) (Beta)
+  name: Burnout 2 - Point of Impact (Europe) (En,Fr,De,Es,It) (Beta) (2002-08-31)
   serial: SLES-51044
   version: '1.00'
 - hashes:
   - md5: 008809bc9497a0546ba7ccf3168e1a73
     size: 4405985280
-  name: Tekken's Nina Williams in - Death by Degrees (Europe) (En,Es) (Beta)
+  name: Tekken's Nina Williams in - Death by Degrees (Europe) (En,Es) (Beta) (2004-12-29)
   serial: SCES-52586
   version: '1.00'
 - hashes:
@@ -58835,8 +58837,8 @@
 - hashes:
   - md5: ecb738d10bd36af1de887415f189c3de
     size: 4195155968
-  name: King of Fighters 2002, The - Unlimited Match (Japan)
-  serial: SLPS-25915
+  name: King of Fighters 2002, The - Unlimited Match (Japan, Korea)
+  serial: SLKA-25457
   version: '1.02'
 - hashes:
   - md5: 251e5ff99d2c23990ff83fdeb90d256b
@@ -58860,7 +58862,7 @@
   - md5: beface04f6751f40a958424188bbdd7f
     size: 1238794240
   name: Simple 2000 Series Ultimate Vol. 27 - Houkago no Love Beat (Japan)
-  serial: SLPS-25566
+  serial: SLPM-65579
   version: '1.01'
 - hashes:
   - md5: 34102c3a6f9b540de8434f6456d721dd
@@ -58923,7 +58925,7 @@
   - md5: 57d6b35ad1b162225b512cc0017decfe
     size: 761692848
   name: Memory Manager Plus (USA) (Unl) (Version 1.5)
-  version: '1.10'
+  version: '1.5'
 - hashes:
   - md5: 16c9247fdf88c589a07f9cf181ae0629
     size: 3963387904
@@ -58958,7 +58960,6 @@
   - md5: 1537fbcd2cfdf637eeb2924d631d61cb
     size: 135725056
   name: Star Wars - Jedi Starfighter (USA) (Trade Demo)
-  serial: SLUS-28010
   version: '1.00'
 - hashes:
   - md5: 18335c2492529cd36fdf5eadc8f9a452
@@ -59048,12 +59049,12 @@
   - md5: 16e4757b0a36e6d4c4823bfdc06aba03
     size: 761692848
   name: Mega Memory (USA) (Unl) (Version 2.20)
-  version: '1.10'
+  version: '2.20'
 - hashes:
   - md5: 56c7c48056929108a868ae2948ae36ad
     size: 761692848
   name: Memory Manager Plus (USA) (Unl) (Version 1.3)
-  version: '1.10'
+  version: '1.3'
 - hashes:
   - md5: 19d9ea3e6160ebeb52970fa6de42b4b4
     size: 718702992
@@ -59116,8 +59117,7 @@
 - hashes:
   - md5: 501ece03f653192b62664f2958a6ff2e
     size: 761692848
-  name: PS Mania 2.0 Spaccacodici - Lara Croft Tomb Raider - The Angel of Darkness
-    (Italy) (Unl)
+  name: Playable Cheats Vol. 9 (Europe) (Unl)
   version: 1.00 (European)
 - hashes:
   - md5: ed6c3ef02bd36a7691a5484cb666ed7d
@@ -59137,27 +59137,27 @@
 - hashes:
   - md5: cec6feb2f41fa7a9e29a3ecdf7432c08
     size: 718702992
-  name: PS Mania 2.0 Spaccacodici - Death by Degrees (Italy) (Unl)
+  name: Playable Cheats Vol. 28 (Europe) (Unl)
   version: 1.00 beta (European)
 - hashes:
   - md5: 682b8bfbc38075907fa603c24189b5d9
     size: 718702992
-  name: PS Mania 2.0 Spaccacodici - Speciale Grand Theft Auto (Italy) (Unl)
+  name: Playable Cheats Vol. 29 (Europe) (Unl)
   version: 1.00 (European)
 - hashes:
   - md5: 8ce80fbb73a27ad02fddf0b664e363f8
     size: 718702992
-  name: PS Mania 2.0 Spaccacodici - Metal Gear Solid 3 - Snake Eater (Italy) (Unl)
+  name: Playable Cheats Vol. 30 (Europe) (Unl)
   version: 1.00 (European)
 - hashes:
   - md5: b8d517a9ac7f39916c462770da1bfad1
     size: 718702992
-  name: PS Mania 2.0 Spaccacodici - Resident Evil - Outbreak - File 2 (Italy) (Unl)
+  name: Playable Cheats Vol. 33 (Europe) (Unl)
   version: 1.00 beta (European)
 - hashes:
   - md5: a4afea9a91380080bdc3c973529117cd
     size: 718702992
-  name: PS Mania 2.0 Spaccacodici - FIFA 06 (Italy) (Unl)
+  name: Playable Cheats Vol. 34 (Europe) (Unl)
   version: 1.00 beta (European)
 - hashes:
   - md5: b05ec318d96bb60e189a856f48bae799
@@ -59186,7 +59186,7 @@
 - hashes:
   - md5: c79378de38c97bc4c93c57d51d4c309d
     size: 718702992
-  name: PS Mania 2.0 Spaccacodici - Medal of Honor - Rising Sun (Italy) (Unl)
+  name: Playable Cheats Vol. 14 (Europe) (Unl)
   version: 1.00 (European)
 - hashes:
   - md5: 8a56b1448c7088d695a9740ac2ac7b37
@@ -59231,13 +59231,13 @@
 - hashes:
   - md5: 7bf6a03b64b0abab944f9d8d521e0672
     size: 4125229056
-  name: ATV Offroad Fury 4 (USA) (Layer 0) (Beta)
+  name: ATV Offroad Fury 4 (USA) (Layer 0) (Beta) (2006-10-02)
   serial: SCUS-97479
   version: '1.00'
 - hashes:
   - md5: 084751b50d3f041f670d83ce8fa54c8c
     size: 3756916736
-  name: ATV Offroad Fury 4 (USA) (Layer 1) (Beta)
+  name: ATV Offroad Fury 4 (USA) (Layer 1) (Beta) (2006-10-02)
   serial: SCUS-97479
   version: '1.00'
 - hashes:
@@ -59440,7 +59440,7 @@
   - md5: 70f0458fa677cc46fdce785fd6be605b
     size: 181659072
   name: SuperLite 2000 Vol. 18 - Waku Waku Volley 2 (Japan)
-  serial: SLPM-62481
+  serial: SLPM-62285
   version: '1.01'
 - hashes:
   - md5: 5651588a0ca3700d1e62a856cdfda910
@@ -59721,48 +59721,48 @@
 - hashes:
   - md5: 94aa87d7b91bcb90f907e6d865581e81
     size: 2319515648
-  name: Amplitude (Europe) (Beta)
+  name: Amplitude (Europe) (Beta) (2003-05-27)
   serial: SCES-51706
   version: '1.00'
 - hashes:
   - md5: 1d9844ee3f579161c979dcb4d8893657
     size: 2960097280
-  name: Dot Hack Part 1 - Infection (Europe) (En,Fr,De,Es,It) (Beta)
+  name: Dot Hack Part 1 - Infection (Europe) (En,Fr,De,Es,It) (Beta) (2004-01-09)
   serial: SLES-52237
   version: '0.01'
 - hashes:
   - md5: 8bd0fc2625cfcc9384da17ef7c141a9e
     size: 321584256
-  name: Black (USA) (Beta)
+  name: Black (USA) (Beta) (2005-08-16)
   version: '1.00'
 - hashes:
   - md5: d27c274734f814d81d0c777d8044b214
     size: 1591312384
-  name: BMX XXX (USA) (Beta)
+  name: BMX XXX (USA) (Beta) (2002-10-10)
   serial: SLUS-20415
   version: '1.00'
 - hashes:
   - md5: 0361a26bba549c5d4dffa2c0a05ef19a
     size: 4678377472
-  name: FIFA 06 (Europe) (Beta 1)
+  name: FIFA 06 (Europe) (Beta) (2005-07-12)
   serial: SLES-53529
   version: '1.00'
 - hashes:
   - md5: cd06a6422395d93ba157e218c61acd2d
     size: 4678377472
-  name: FIFA 06 (Europe) (Beta 2)
+  name: FIFA 06 (Europe) (Beta) (2005-08-05)
   serial: SLES-53529
   version: '1.00'
 - hashes:
   - md5: e605dce7fa3b240bd6e8811a0782cc68
     size: 4678377472
-  name: NBA Live 06 (USA) (Beta)
+  name: NBA Live 06 (USA) (Beta) (2005-07-08)
   serial: SLUS-21279
   version: '1.00'
 - hashes:
   - md5: 082d1ce524e4486622f7526b79dbcdce
     size: 2907996160
-  name: Rogue Ops (USA) (Beta)
+  name: Rogue Ops (USA) (Beta) (2003-08-21)
   serial: SLUS-20746
   version: '1.00'
 - hashes:
@@ -59774,55 +59774,55 @@
 - hashes:
   - md5: e3f752a70610389ac299712de93fdcd5
     size: 579248208
-  name: Rumble Racing (USA) (Beta)
+  name: Rumble Racing (USA) (Beta) (2001-02-07)
   serial: SLUS-20174
   version: '1.00'
 - hashes:
   - md5: 332f30172ad5567371074f1b7e588f70
     size: 697972464
-  name: Rumble Racing (Europe) (En,Fr,De) (Beta)
+  name: Rumble Racing (Europe) (En,Fr,De) (Beta) (2001-03-27)
   serial: SLES-50121
   version: '1.00'
 - hashes:
   - md5: 78e6a07be5b5f275328454526af99794
     size: 4698828800
-  name: Tiger Woods PGA Tour 06 (Europe) (En,Fr,De,Sv) (Beta 1)
+  name: Tiger Woods PGA Tour 06 (Europe) (En,Fr,De,Sv) (Beta) (2005-07-19)
   serial: SLES-53541
   version: '1.00'
 - hashes:
   - md5: 48520dbbf685c6edf04eca4491c7c091
     size: 4699041792
-  name: Tiger Woods PGA Tour 06 (Europe) (En,Fr,De,Sv) (Beta 2)
+  name: Tiger Woods PGA Tour 06 (Europe) (En,Fr,De,Sv) (Beta) (2005-08-08)
   serial: SLES-53541
   version: '1.00'
 - hashes:
   - md5: c5adb424f1102146b6ce5c7d28e67d37
     size: 2519400448
-  name: Way of the Samurai 2 (Europe) (En,Fr,De) (Beta)
+  name: Way of the Samurai 2 (Europe) (En,Fr,De) (Beta) (2004-02-10)
   serial: SLES-52275
   version: '1.01'
 - hashes:
   - md5: 4d127bcada70256cadf8f6fa031e85a7
     size: 2372075520
-  name: Capcom Fighting Jam (Europe) (Beta)
+  name: Capcom Fighting Jam (Europe) (Beta) (2004-10-29)
   serial: SLES-52854
   version: '1.00'
 - hashes:
   - md5: 2396e55b5d9fb58533101b6ca2fc3a03
     size: 3612278784
-  name: Cold Winter (USA) (Beta)
+  name: Cold Winter (USA) (Beta) (2005-02-09)
   serial: SLUS-20845
   version: '1.00'
 - hashes:
   - md5: 7f4262203f52498001498979852be14c
     size: 4043177984
-  name: Crisis Zone (Europe) (Beta)
+  name: Crisis Zone (Europe) (Beta) (2004-06-18)
   serial: SCES-52530
   version: '1.00'
 - hashes:
   - md5: e0a76a2917c22de4b03c5d45ebd22e14
     size: 1853992960
-  name: Dead to Rights (Europe) (En,Fr,Es,It) (Beta)
+  name: Dead to Rights (Europe) (En,Fr,Es,It) (Beta) (2003-04-25)
   serial: SLES-51581
   version: '1.00'
 - hashes:
@@ -59847,12 +59847,13 @@
   - md5: 34bd0c3207179f6d561fc25a4567dff8
     size: 3802232832
   name: eJay Clubworld - The Music Making Experience (Europe) (En,Fr,De,Es,It) (Beta)
+    (2002-06-27)
   serial: SLES-50933
   version: '1.00'
 - hashes:
   - md5: 34fff447e90dae2cd981e3caf042b4d8
     size: 571411344
-  name: EyeToy - Play (Europe) (Beta)
+  name: EyeToy - Play (Europe) (Beta) (2003-03-19)
   serial: SCES-51513
   version: '1.00'
 - hashes:
@@ -59876,7 +59877,7 @@
 - hashes:
   - md5: afb4b5f06bf416c3e11281e0d6695409
     size: 1509326848
-  name: Metal Gear Solid 3 - Subsistence (Europe) (En,Fr) (Beta)
+  name: Metal Gear Solid 3 - Subsistence (Europe) (En,Fr) (Beta) (2006-02-16)
   serial: TLES-82043
   version: '0.01'
 - hashes:
@@ -59900,7 +59901,7 @@
 - hashes:
   - md5: 6f445d80840baf5ecf9bec850f2cf471
     size: 4113465344
-  name: Guilty Gear Isuka (Europe) (Beta)
+  name: Guilty Gear Isuka (Europe) (Beta) (2004-10-06)
   serial: SLES-52934
   version: '1.00'
 - hashes:
@@ -59923,61 +59924,61 @@
 - hashes:
   - md5: 370f10479796d8ed9fcba1b40ac30dd9
     size: 4698828800
-  name: Def Jam - Fight for NY (Europe) (En,Fr) (Beta)
+  name: Def Jam - Fight for NY (Europe) (En,Fr) (Beta) (2004-08-13)
   serial: SLES-52507
   version: '1.00'
 - hashes:
   - md5: f3f8591f8be706bb8ddfc14e470dc574
     size: 446454288
-  name: King of Fighters 2002, The (Europe) (Beta)
+  name: King of Fighters 2002, The (Europe) (Beta) (2005-04-07)
   serial: SLES-53381
   version: '1.00'
 - hashes:
   - md5: 97e1cc02baecf33ec2418aee4a01de70
     size: 239330112
-  name: Marvel vs. Capcom 2 - New Age of Heroes (Japan) (Beta)
+  name: Marvel vs. Capcom 2 - New Age of Heroes (Japan) (Beta) (2002-08-08)
   serial: SLPM-62227
   version: '1.00'
 - hashes:
   - md5: 25beeab7002cee432e80b61f285d5b7c
     size: 540795360
-  name: Midnight Club - Street Racing (Europe) (Beta)
+  name: Midnight Club - Street Racing (Europe) (Beta) (2000-10-18)
   serial: SLES-50054
   version: '1.00'
 - hashes:
   - md5: 775df8386e3677d8222f17422c627663
     size: 4650729472
-  name: Onimusha 2 - Samurai's Destiny (Europe) (En,Fr,De,Es,It) (Beta)
+  name: Onimusha 2 - Samurai's Destiny (Europe) (En,Fr,De,Es,It) (Beta) (2002-07-24)
   serial: SLES-50978
   version: '1.00'
 - hashes:
   - md5: 7067699b798e9b68405793352c4007c0
     size: 73845744
-  name: RoboCop (USA) (Beta)
+  name: RoboCop (USA) (Beta) (2001-05-14)
   serial: SLPS-12345
   version: '1.00'
 - hashes:
   - md5: c67ea1a983561eacb0b5f14f1c5bee5c
     size: 4388814848
-  name: Soulcalibur III (Europe) (En,Fr,De,Es,It) (Beta)
+  name: Soulcalibur III (Europe) (En,Fr,De,Es,It) (Beta) (2005-10-04)
   serial: SCES-53312
   version: '1.00'
 - hashes:
   - md5: 69e28e62cae656b08384988322d94c19
     size: 4534239232
-  name: Syphon Filter - Dark Mirror (Europe) (En,Fr,De,Es,It) (Beta)
+  name: Syphon Filter - Dark Mirror (Europe) (En,Fr,De,Es,It) (Beta) (2007-06-22)
   serial: SCES-54794
   version: '1.00'
 - hashes:
   - md5: 754ec2a1d5f28acbf90d3a5a10317f91
     size: 2663186432
-  name: Tekken 4 (USA) (Beta)
+  name: Tekken 4 (USA) (Beta) (2002-06-13)
   serial: SLUS-00000
   version: '1.00'
 - hashes:
   - md5: 5d186f7bc7bb750b2971844b25f78ac1
     size: 2028109824
-  name: TimeSplitters 2 (Europe) (En,Fr,De,Es,It) (Beta)
+  name: TimeSplitters 2 (Europe) (En,Fr,De,Es,It) (Beta) (2002-08-26)
   serial: SLES-50877
   version: '1.01'
 - hashes:
@@ -59989,37 +59990,37 @@
 - hashes:
   - md5: 753a28897e57f9b20b79f5b631195efc
     size: 4546691072
-  name: Transformers (Europe) (En,Fr,De,Es,It) (Beta)
+  name: Transformers (Europe) (En,Fr,De,Es,It) (Beta) (2004-03-22)
   serial: SLES-52388
   version: '1.00'
 - hashes:
   - md5: af5653d1237c684d15450b89acab390f
     size: 3008856064
-  name: Viewtiful Joe (Europe) (En,Fr,De,Es,It) (Beta)
+  name: Viewtiful Joe (Europe) (En,Fr,De,Es,It) (Beta) (2004-09-02)
   serial: SLES-52678
   version: '1.01'
 - hashes:
   - md5: af5d2b8a19b7d44da07186b1c632892f
     size: 2273476608
-  name: Warhammer 40,000 - Fire Warrior (Europe) (En,Fr,De,Es,It) (Beta 1)
+  name: Warhammer 40,000 - Fire Warrior (Europe) (En,Fr,De,Es,It) (Beta) (2003-07-07)
   serial: SLES-50958
   version: '1.10'
 - hashes:
   - md5: 376d3af404b36d4afc03928c3d487d54
     size: 1984286720
-  name: Without Warning (Europe) (En,Fr,De,Es,It) (Beta)
+  name: Without Warning (Europe) (En,Fr,De,Es,It) (Beta) (2005-08-08)
   serial: SLPS-99999
   version: '1.00'
 - hashes:
   - md5: dcb1a62e1223c41cba48e422aace45d4
     size: 2803531776
-  name: XIII (Europe) (En,Fr,De,Es,It) (Beta 1)
+  name: XIII (Europe) (En,Fr,De,Es,It) (Beta) (2003-07-31)
   serial: SLUS-12345
   version: '0.01'
 - hashes:
   - md5: 702d8da2bb43e25eceb9449c0c0a4385
     size: 2223767552
-  name: XIII (Europe) (En,Fr,De,Es,It) (Beta 2)
+  name: XIII (Europe) (En,Fr,De,Es,It) (Beta) (2003-08-07)
   serial: SLUS-12345
   version: '0.01'
 - hashes:
@@ -60043,7 +60044,7 @@
 - hashes:
   - md5: 143c5bef00cfd35845b28f97ac4d5a3d
     size: 761692848
-  name: GT Circuit Breaker (Europe) (Unl)
+  name: GT Circuit Breaker for Use with GT3 (Europe) (Unl)
   version: '1.30'
 - hashes:
   - md5: 2d0faa719b239176c283f81bba82d31e
@@ -60235,7 +60236,7 @@
 - hashes:
   - md5: 737f63556296ffbb966ef62e96fc296b
     size: 4242472960
-  name: Plus Plum 2 (Japan)
+  name: Plus Plumb 2 (Japan)
   serial: SLPS-25639
   version: '1.01'
 - hashes:
@@ -60408,13 +60409,13 @@
 - hashes:
   - md5: 5bdbb948474f445872aa55f72c108eeb
     size: 675170304
-  name: Lemmings (Europe) (En,Fr,De,Es,It,Nl,Sv,No,Da,Fi) (Beta)
+  name: Lemmings (Europe) (En,Fr,De,Es,It,Nl,Sv,No,Da,Fi) (Beta) (2006-08-08)
   serial: SCES-54145
   version: '1.00'
 - hashes:
   - md5: d29b9031957b97e57aa560000790609e
     size: 4653187072
-  name: Rolling (Europe) (En,Fr,De,Es,It) (Beta)
+  name: Rolling (Europe) (En,Fr,De,Es,It) (Beta) (2003-08-04)
   serial: SLES-51906
   version: '1.00'
 - hashes:
@@ -60425,14 +60426,14 @@
 - hashes:
   - md5: 197238c4235af9ad31337ecb703c6d63
     size: 2131820544
-  name: EverQuest - Online Adventures - Frontiers (USA) (Beta)
+  name: EverQuest - Online Adventures - Frontiers (USA) (Beta) (2003-07-18)
   serial: SLUS-29063
   version: '1.00'
 - hashes:
   - md5: bc13e77c8e1b27e7f075980c4b8e8570
     size: 513319296
   name: SimPeople - Ochanoma Gekijou (Japan)
-  serial: SLPS-20078
+  serial: SLPM-62514
   version: '1.01'
 - hashes:
   - md5: 2f3997f37214e2e7c21e8a90b7f62ade
@@ -60507,7 +60508,7 @@
 - hashes:
   - md5: b49c8104add49bdd4bc3e5c989d462e9
     size: 527327808
-  name: Crash Bandicoot - Mawangui Buhwal (Korea)
+  name: Crash Bandicoot - Mawangui Buhwal (Korea) (Ko)
   serial: SLPM-64513
   version: '1.02'
 - hashes:
@@ -60612,37 +60613,37 @@
 - hashes:
   - md5: 1efee833af6425e974724b1434e53699
     size: 1288239104
-  name: Dancing Stage Fusion (Europe) (En,Fr,De,Es,It) (Beta)
+  name: Dancing Stage Fusion (Europe) (En,Fr,De,Es,It) (Beta) (2004-07-08)
   serial: SLES-52598
   version: '1.00'
 - hashes:
   - md5: 1baa8f23ba5da92804f9f7c75ac6d73d
     size: 2991095808
-  name: Full Spectrum Warrior (Europe) (En,Fr,De,Es,It) (Beta)
+  name: Full Spectrum Warrior (Europe) (En,Fr,De,Es,It) (Beta) (2005-03-22)
   serial: SLES-53114
   version: '1.00'
 - hashes:
   - md5: c15815e0361fc5a52163d74836e189a6
     size: 517418832
-  name: Gradius III and IV (Europe) (Beta)
+  name: Gradius III and IV (Europe) (Beta) (2000-09-11)
   serial: SLES-50038
   version: '1.00'
 - hashes:
   - md5: 6dc81d1cec3ab0b8bbd6026c1df4fa37
     size: 3663134720
-  name: Rogue Ops (Europe) (En,Fr,De,Es,It,Nl) (Beta)
+  name: Rogue Ops (Europe) (En,Fr,De,Es,It,Nl) (Beta) (2003-11-06)
   serial: SLES-52002
   version: '1.01'
 - hashes:
   - md5: 7973a9200d21cd3e68f4da55a02ca03f
     size: 1728741376
-  name: Tom Clancy's Rainbow Six - Lockdown (USA) (Beta)
+  name: Tom Clancy's Rainbow Six - Lockdown (USA) (Beta) (2005-01-21)
   serial: SLUS-21144
   version: '1.00'
 - hashes:
   - md5: e3c4f9bae8516bb0a9ba288496d11cce
     size: 155015616
-  name: U-Move Super Sports (Europe) (En,Fr,De,Es,It) (Beta)
+  name: U-Move Super Sports (Europe) (En,Fr,De,Es,It) (Beta) (2004-05-21)
   serial: SLES-52594
   version: '1.00'
 - hashes:
@@ -61140,7 +61141,7 @@
   - md5: 86dbbb4cfbf30f673b6a19f819318ccd
     size: 4288512000
   name: Kono Hareta Sora no Shita de - Under the Blue Sky (Japan)
-  serial: SLPM-66182
+  serial: SLPM-65925
   version: '1.01'
 - hashes:
   - md5: a5bb9cde5541f2087398601ea4e3f618
@@ -61217,7 +61218,7 @@
 - hashes:
   - md5: f371c334368d1f0cd65061697a2d6730
     size: 1285128192
-  name: Minna no Golf Online (Japan) (Beta)
+  name: Minna no Golf Online (Japan) (Beta) (2002-12-13)
   serial: SCPM-85302
   version: '1.04'
 - hashes:
@@ -61254,7 +61255,7 @@
   - md5: c3789d89c5e8cfe3a0782749ca4b1dbe
     size: 3390144512
   name: Shirogane no Soleil - Contract to the Future - Mirai e no Keiyaku (Japan)
-  serial: SLPM-55201
+  serial: SLPM-55026
   version: '1.01'
 - hashes:
   - md5: 5334eb6dcac5c76966e60601f8cd3998
@@ -61277,7 +61278,7 @@
 - hashes:
   - md5: 89dc60c740356e0aa8a1fa341ffbb754
     size: 1791983616
-  name: Nickelodeon Spongebob SquarePants (Japan)
+  name: Nickelodeon SpongeBob SquarePants (Japan)
   serial: SLPM-66694
   version: '1.00'
 - hashes:
@@ -61672,7 +61673,7 @@
   - md5: 5f6ceaef0c7b9ccd6a4b6b6e7c09b588
     size: 1230110720
   name: Junjou Romantica - Koi no Doki Doki Daisakusen (Japan)
-  serial: SLPS-25902
+  serial: SLPS-25901
   version: '1.01'
 - hashes:
   - md5: 3665c22ca35246b3ea715a6d9b8f8906
@@ -61731,7 +61732,7 @@
   - md5: edef939cc6c9d0b2a2fcbdb2dae91b60
     size: 38671584
   name: Mahjong Haou - Shinken Battle (Japan)
-  serial: SLPS-20371
+  serial: SLPM-62755
   version: '1.02'
 - hashes:
   - md5: 39956b740cf13db6ddf2d4698fb73f2f
@@ -61833,22 +61834,22 @@
 - hashes:
   - md5: 2b0b4f13e4c0af16176a3d4f51782c83
     size: 718702992
-  name: PS Mania 2.0 Spaccacodici - Grand Theft Auto - San Andreas (Italy) (Unl)
+  name: Playable Cheats Vol. 23 (Europe) (Unl)
   version: 1.00 (European)
 - hashes:
   - md5: b0736438510ab7051453daac2cf7072e
     size: 718702992
-  name: PS Mania 2.0 Spaccacodici - Gran Turismo 4 (Italy) (Unl)
+  name: Playable Cheats Vol. 27 (Europe) (Unl)
   version: 1.00 (European)
 - hashes:
   - md5: 27061be3e4e65a0aecf39c48b8c564e8
     size: 718702992
-  name: PS Mania 2.0 Spaccacodici - I Capolavori della Storia PS2 (Italy) (Unl)
+  name: Playable Cheats Vol. 32 (Europe) (Unl)
   version: 1.00 beta (European)
 - hashes:
   - md5: 0c05482eb09d5201b217e5301f77bee3
     size: 718702992
-  name: PS Mania 2.0 Spaccacodici - Ultimate Spider-Man (Italy) (Unl)
+  name: Playable Cheats Vol. 35 (Europe) (Unl)
   version: 1.00 beta (European)
 - hashes:
   - md5: 12a3fe133bf1ce50ba5d68f196da5dab
@@ -61889,7 +61890,7 @@
 - hashes:
   - md5: 247aeccd3f60c5b1a5c943cc3274a463
     size: 4487446528
-  name: Rayman Revolution (Europe) (En,Fr,De,Es,It) (Beta)
+  name: Rayman Revolution (Europe) (En,Fr,De,Es,It) (Beta) (2000-11-16)
   version: '0.96'
 - hashes:
   - md5: 73ed65e513426d311da4698df26cc7bb
@@ -61900,7 +61901,7 @@
 - hashes:
   - md5: e1b5585a0def704131c5181305f4ecaf
     size: 761692848
-  name: Play Cheats Vol. 04 (Europe) (Unl)
+  name: Play Cheats Vol. 04 (UK) (Unl)
   version: PLAY_102 EUROPE
 - hashes:
   - md5: 2dd5a5b454d765f5bc1cfdeb1a944b58
@@ -61973,13 +61974,13 @@
 - hashes:
   - md5: 29c16c5370220ad1d94011b9bd3b4bc2
     size: 710913168
-  name: Ninja Assault (Japan)
-  serial: SLPS-20218
+  name: Ninja Assault (Japan, Asia)
+  serial: SCPS-51014
   version: '1.01'
 - hashes:
   - md5: 7ebc769407375554c95e1e277728e7dd
     size: 581332080
-  name: Nobunaga no Yabou Online (Japan) (Beta) (v2.00)
+  name: Nobunaga no Yabou Online (Japan) (Beta) (v2.00) (2003-02-05)
   serial: SLPM-62208
   version: '2.00'
 - hashes:
@@ -62003,7 +62004,7 @@
 - hashes:
   - md5: e3419196633251e866a93461a1c2c53d
     size: 4698767360
-  name: Sonic Mega Collection Plus (USA) (Beta)
+  name: Sonic Mega Collection Plus (USA) (Beta) (2004-08-18)
   version: '0.80'
 - hashes:
   - md5: 63a455deb5612255a9cfdce470864493
@@ -62091,7 +62092,7 @@
 - hashes:
   - md5: 8b9eada741f9af9ecd37f962e4caa41b
     size: 3568107520
-  name: Headhunter (Europe) (En,Fr,De,Es,It) (Beta)
+  name: Headhunter (Europe) (En,Fr,De,Es,It) (Beta) (2001-12-15)
   serial: SCES-50500
   version: '1.00'
 - hashes:
@@ -62115,12 +62116,12 @@
 - hashes:
   - md5: ec13b8b4f67095b11f149c984cc7741c
     size: 42938112
-  name: Scooby-Doo! Night of 100 Frights (USA) (Beta 1)
+  name: Scooby-Doo! Night of 100 Frights (USA) (Beta) (2001-01-31)
   version: '0.00'
 - hashes:
   - md5: 27a7b408aabaa3578bd1046af111ec3d
     size: 25987248
-  name: Scooby-Doo! Night of 100 Frights (USA) (Beta 2)
+  name: Scooby-Doo! Night of 100 Frights (USA) (Beta) (2001-06-11)
   version: '0.00'
 - hashes:
   - md5: 83354371976b92a01159c613feca1347
@@ -62130,7 +62131,7 @@
 - hashes:
   - md5: ca1d586d884c8bb3c9ed25f867d89636
     size: 1959591936
-  name: Lord of the Rings, The - The Fellowship of the Ring (USA) (Beta)
+  name: Lord of the Rings, The - The Fellowship of the Ring (USA) (Beta) (2002-09-01)
   serial: SLUS-20520
   version: '1.01'
 - hashes:
@@ -62329,7 +62330,7 @@
 - hashes:
   - md5: 01d25982681aabea0218ca6983e18441
     size: 1933115392
-  name: ADK Tamashii (Japan)
+  name: ADK Damashii (Japan)
   serial: SLPS-25906
   version: '1.01'
 - hashes:
@@ -62477,7 +62478,7 @@
 - hashes:
   - md5: f7a8036ff530e07cf3a34250d3d9fb64
     size: 1544585216
-  name: Syphon Filter - The Omega Strain (USA) (Beta)
+  name: Syphon Filter - The Omega Strain (USA) (Beta) (2004-01-24)
   serial: SCUS-97397
   version: '1.02'
 - hashes:
@@ -62507,7 +62508,7 @@
 - hashes:
   - md5: 4663d817b80f96793b94977fe39b3684
     size: 4658987008
-  name: Champions of Norrath - Realms of Everquest (USA) (Beta)
+  name: Champions of Norrath - Realms of Everquest (USA) (Beta) (2003-10-29)
   serial: SLUS-29085
   version: '1.01'
 - hashes:
@@ -62562,7 +62563,7 @@
   - md5: 9054ff3a7fef52b7068ae8dfcc84355a
     size: 1242071040
   name: Hot Shots Golf 3 (Korea)
-  serial: SCPS-56007
+  serial: SCKA-20035
   version: '1.00'
 - hashes:
   - md5: eb5d9b0a16d731a575813970eed2651e
@@ -62716,7 +62717,7 @@
 - hashes:
   - md5: 78a90eca93d5fdcfc8bffde172a6efdd
     size: 733118464
-  name: Batman - Vengeance (Europe) (En,Fr,De,Es,It,Nl) (Beta)
+  name: Batman - Vengeance (Europe) (En,Fr,De,Es,It,Nl) (Beta) (2001-09-07)
   serial: SLES-50355
   version: '1.00'
 - hashes:
@@ -62820,7 +62821,7 @@
 - hashes:
   - md5: ec504aa2a95e1633925d9a642736d66d
     size: 1228832768
-  name: EyeToy Special Demo (Europe)
+  name: EyeToy Special Demo (Europe) (En,Fr,De,Es,It)
   serial: SCED-53177
   version: '1.01'
 - hashes:
@@ -62850,7 +62851,7 @@
 - hashes:
   - md5: 6b6fe88e8a0e492aa4cd937af90e0ef1
     size: 1267269632
-  name: Mystical Ninja Goemon Zero (USA) (Beta)
+  name: Mystical Ninja Goemon Zero (USA) (Beta) (2005-08-26)
   version: '1.00'
 - hashes:
   - md5: cf1301155d850b226f5cd20f3b868c05
@@ -63443,7 +63444,7 @@
   - md5: 4cbbd06f0dcbddce1be7cc3c3e9a7516
     size: 1689714688
   name: Bakushou!! Jinsei Kaidou - Nova Usagi ga Miteru zo!! (Japan)
-  serial: SLPM-65812
+  serial: SLPM-65522
   version: '1.02'
 - hashes:
   - md5: 3438524449520a08e072bf5a58a4a94b
@@ -63533,7 +63534,7 @@
   - md5: 3e63ba7686f93d9e11a2c46e55edd3ab
     size: 3806429184
   name: Gift - Prism (Japan)
-  serial: SLPM-66786
+  serial: SLPM-66530
   version: '1.01'
 - hashes:
   - md5: a85c40acf648340933004d95671e75a0
@@ -63654,7 +63655,7 @@
   - md5: 29ad2577588c771ff7f2606019501ec5
     size: 2239758336
   name: Last Escort - Club Katze (Japan)
-  serial: SLPS-25958
+  serial: SLPS-25957
   version: '1.01'
 - hashes:
   - md5: a5d39dcbe6442da0a2e2cfe11f30046c
@@ -63908,7 +63909,7 @@
 - hashes:
   - md5: 084c0a64f2633c05e464a1b43a3de3b4
     size: 2159476736
-  name: Shin Seiki GPX Cyber Formula - Road to the Infinity 2 (Japan)
+  name: Future GPX Cyber Formula - Road to the Infinity 2 (Japan)
   serial: SLPS-25541
   version: '1.02'
 - hashes:
@@ -64004,6 +64005,11 @@
   name: Action Replay 2 (Germany) (Disc 1) (German Edition) (Unl)
   version: '1.92'
 - hashes:
+  - md5: ef5cf1e0c1de482ac8fe1ac0ea60598b
+    size: 718702992
+  name: Playable Cheats Vol. 21 (UK) (Unl) (04090801)
+  version: 1.00 (European)
+- hashes:
   - md5: f935cfb7b4e7dcaf092ad04fb1d2a0f5
     size: 718702992
   name: Instant Cheats - Volume 10 (UK) (Unl)
@@ -64016,7 +64022,7 @@
 - hashes:
   - md5: 486c660207a49b44205d4e738015fd14
     size: 761692848
-  name: PlayStation 2 Cheats - Volume 2 (UK) (Unl)
+  name: PlayStation 2 Cheats - Volume 2 (Europe, Australia) (Unl)
   version: 2003_CH EUROPE
 - hashes:
   - md5: b78e550e63cabd62abf1a14ed3a10a21
@@ -64222,13 +64228,13 @@
 - hashes:
   - md5: 6e903e7ddf5e988ce1197cb97f6d39f7
     size: 718702992
-  name: PS Mania 2.0 Spaccacodici - Tekken 5 (Italy) (Unl)
+  name: Playable Cheats Vol. 31 (Europe) (Unl)
   version: 1.00 beta (European)
 - hashes:
   - md5: f9a57df3181f08448b1faf8ffce0cfda
     size: 4696539136
   name: Aria - The Natural - Tooi Yume no Mirage (Japan)
-  serial: SLPM-66967
+  serial: SLPM-66536
   version: '1.02'
 - hashes:
   - md5: c26cece848b3ad4d4caeecf8d4817ff6
@@ -64544,7 +64550,8 @@
 - hashes:
   - md5: a82662535a9c0ed79e4e6d14cb2235c5
     size: 4689821696
-  name: Ratchet & Clank (USA) (Beta)
+  name: Ratchet & Clank (USA) (Beta) (2002-06-25)
+  version: '1.00'
 - hashes:
   - md5: 674552415c8e2e14b4b434e069d81674
     size: 469929600
@@ -64577,7 +64584,8 @@
 - hashes:
   - md5: 90e36ba24ba255c6c05fc70fca1e0f0a
     size: 316480416
-  name: Jonny Moseley Mad Trix (Europe) (Pre-Alpha)
+  name: Jonny Moseley Mad Trix (Europe) (Pre-Alpha) (2001-09-17)
+  version: '1.00'
 - hashes:
   - md5: cff4fdc98e99c6b0331718a323947fe1
     size: 673751568
@@ -64694,47 +64702,47 @@
 - hashes:
   - md5: a9a92ed184294010007c4fac181be919
     size: 718702992
-  name: PSi2 Spielbare Cheats Volume 18 (Germany) (Unl)
+  name: Spielbare Cheats Volume 18 (Germany) (Unl)
   version: 1.00 (European)
 - hashes:
   - md5: 0152c3adf6517d85d7a47a0de6204cd9
     size: 718702992
-  name: PSi2 Spielbare Cheats Volume 19 (Germany) (Unl)
+  name: Spielbare Cheats Volume 19 (Germany) (Unl)
   version: 1.00 (European)
 - hashes:
   - md5: 756eadacf2c99da8cec536d509eae40d
     size: 718702992
-  name: PSi2 Spielbare Cheats Volume 20 (Germany) (Unl)
+  name: Spielbare Cheats Volume 20 (Germany) (Unl)
   version: 1.00 (European)
 - hashes:
   - md5: 8fa01059ecbc6b48d6006dd8747d094e
     size: 718702992
-  name: PSi2 Spielbare Cheats Volume 21 (Germany) (Unl)
+  name: Spielbare Cheats Volume 21 (Germany) (Unl)
   version: 1.00 (European)
 - hashes:
   - md5: 8f0db79bf28205a68ebb5d84a89f42bd
     size: 718702992
-  name: PSi2 Spielbare Cheats Volume 22 (Germany) (Unl)
+  name: Spielbare Cheats Volume 22 (Germany) (Unl)
   version: 1.00 (European)
 - hashes:
   - md5: 473c0904df628ad2fbbfbc5e2932bed2
     size: 718702992
-  name: PSi2 Spielbare Cheats Volume 25 (Germany) (Unl)
+  name: Spielbare Cheats Volume 25 (Germany) (Unl)
   version: 1.00 beta (European)
 - hashes:
   - md5: 55ae7d5af0baca2ecfcbea290d6df191
     size: 718702992
-  name: PSi2 Spielbare Cheats Volume 26 (Germany) (Unl)
+  name: Spielbare Cheats Volume 26 (Germany) (Unl)
   version: 1.00 beta (European)
 - hashes:
   - md5: 692f3d2a11254a6836416c96fc6c0c22
     size: 718702992
-  name: PSi2 Spielbare Cheats Volume 27 (Germany) (Unl)
+  name: Spielbare Cheats Volume 27 (Germany) (Unl)
   version: 1.00 beta (European)
 - hashes:
   - md5: a2cec6210672114126301a935b7a76dd
     size: 761692848
-  name: Xtreme Cheats - Pro Edition fuer PlayStation 2 (Germany) (Unl)
+  name: Xtreme Cheats - Pro Edition (Germany) (Unl)
   version: '1.30'
 - hashes:
   - md5: ec58bff78d6b984db54167c69a4a00e6
@@ -64840,7 +64848,7 @@
 - hashes:
   - md5: c7f3bea3928bf452e30d1386ec4aa2a2
     size: 718702992
-  name: PSi2 Spielbare Cheats Volume 17 (Germany) (Unl)
+  name: Spielbare Cheats Volume 17 (Germany) (Unl)
   version: 1.00 (European)
 - hashes:
   - md5: d66d0b4353f7dcb7d643cfe001b46e24
@@ -64850,13 +64858,13 @@
 - hashes:
   - md5: 48f89e65506489e26fdd2b2ead60e050
     size: 385090608
-  name: Virtua Cop Re-Birth (Japan)
+  name: Virtua Cop Re-Birth (Japan) (En,Ja)
   serial: SLPM-62205
   version: '1.01'
 - hashes:
   - md5: 06d8bbe2f6efd58fa1fc47840d90a2a4
     size: 1375141888
-  name: Brunswick Pro Bowling (USA) (Beta)
+  name: Brunswick Pro Bowling (USA) (Beta) (2007-04-02)
   serial: SLUS-21566
   version: '1.00'
 - hashes:
@@ -64868,12 +64876,12 @@
 - hashes:
   - md5: 373cf18bee5965877ba4ccafc7cb6079
     size: 718702992
-  name: PSi2 Spielbare Cheats Volume 23 (Germany) (Unl)
+  name: Spielbare Cheats Volume 23 (Germany) (Unl)
   version: 1.10 (European)
 - hashes:
   - md5: 9c32ae9d7691014ca9746b5c533c0b09
     size: 718702992
-  name: PSi2 Spielbare Cheats Volume 24 (Germany) (Unl)
+  name: Spielbare Cheats Volume 24 (Germany) (Unl)
   version: 1.00 beta (European)
 - hashes:
   - md5: 3733209858261271e774a9237a107ed2
@@ -64993,7 +65001,7 @@
   - md5: ef8c7746a97c5dc0d99ac19a995cc1b9
     size: 4677795840
   name: Tsuki wa Higashi ni Hi wa Nishi ni - Operation Sanctuary (Japan)
-  serial: SLPM-66717
+  serial: SLPM-65717
   version: '1.00'
 - hashes:
   - md5: 5b0122260020afc1828dbac8f7659f2e
@@ -65119,7 +65127,7 @@
 - hashes:
   - md5: c622472bdce3c26e921c99c72cb173a2
     size: 1760690176
-  name: EyeToy - Play 2 (Europe) (En,Fr,De,Es,It,Nl,Pt,Sv,No,Da,Fi,El) (Beta)
+  name: EyeToy - Play 2 (Europe) (En,Fr,De,Es,It,Nl,Pt,Sv,No,Da,Fi,El) (Beta) (2004-09-17)
   serial: SCES-52748
   version: '1.00'
 - hashes:
@@ -65375,6 +65383,8 @@
   - md5: fd27f339becc61cc16c3130d6d6d3057
     size: 306980688
   name: Nickelodeon SpongeBob SquarePants - Revenge of the Flying Dutchman (USA) (Beta)
+    (2002-05-21)
+  version: '1.03'
 - hashes:
   - md5: 487a63856e726272a7f1f3d0d115ba0e
     size: 4544299008
@@ -65842,7 +65852,7 @@
 - hashes:
   - md5: 26fc397b7957056cb6e66ea88326fbd9
     size: 483942816
-  name: Fukuhara Ai no Takkyuu Icchokusen (Japan)
+  name: Fukuhara Ai no Takkyuu Itchokusen (Japan)
   serial: SLPM-62505
   version: '1.03'
 - hashes:
@@ -65903,6 +65913,7 @@
   - md5: 0d1927fe8266a182b66e25a8ab3d0563
     size: 115963008
   name: PSi2 27 (UK) (Unl)
+  version: PSI2_27 EUROPE
 - hashes:
   - md5: 0dc0c0664c8a32d5f02950d20ec4eb8b
     size: 1248034816
@@ -66163,7 +66174,7 @@
 - hashes:
   - md5: 3af3ded758e22bea65b7dc917a459efa
     size: 249145008
-  name: LEGO Super Soccer Adventure (Europe) (Proto 3)
+  name: LEGO Super Soccer Adventure (Europe) (Proto) (2003-04-24)
   version: '1.05'
 - hashes:
   - md5: 4a5e8e2ff594f819c4da14d77e721e30
@@ -66186,7 +66197,7 @@
 - hashes:
   - md5: acbd91a95be15827dc8a1b83ad1d46c7
     size: 270710496
-  name: SOCOM - U.S. Navy SEALs (USA) (Beta)
+  name: SOCOM - U.S. Navy SEALs (USA) (Beta) (2002-03-21)
   serial: SCUS-97859
   version: '1.00'
 - hashes:
@@ -66591,15 +66602,18 @@
     size: 271390224
   name: Gitaroo Man (Europe) (Demo)
   serial: SLED-50980
+  version: '1.01'
 - hashes:
   - md5: 4c5ee5f5f13d4b301e8de3dfa9d9441f
     size: 479680992
-  name: Summer Heat Beach Volleyball (Europe)
+  name: Summer Heat Beach Volleyball (Europe) (Demo)
   serial: SLED-51807
+  version: '1.00'
 - hashes:
   - md5: e35188bb8a7bba8143740157a1a411f0
     size: 562097424
   name: Pop Idol (UK) (Demo)
+  version: '1.00'
 - hashes:
   - md5: adc9d410928175afb99383592e3f7ce8
     size: 4241227776
@@ -66634,7 +66648,7 @@
   - md5: c6ee4e258132bb8161e5722385723e22
     size: 761692848
   name: Mega Memory (USA) (Unl) (Version 2.22)
-  version: '1.10'
+  version: '2.22'
 - hashes:
   - md5: d81def3f1f79a11656ba982361e7b6e7
     size: 305287248
@@ -66650,22 +66664,22 @@
 - hashes:
   - md5: 2f898a6a97296a494de5cb12c9632e54
     size: 722014608
-  name: Taz - Wanted (Europe) (Beta 2)
+  name: Taz - Wanted (Europe) (Beta) (2002-04-02)
   version: '0.10'
 - hashes:
   - md5: aabd24f4af82886345a8c4df66da8459
     size: 524366640
-  name: Taz - Wanted (Europe) (Beta 1)
+  name: Taz - Wanted (Europe) (Beta) (2001-11-27)
   version: '1.00'
 - hashes:
   - md5: 5bdd743fe5990e5fc20eb3fbb818320c
     size: 251304144
-  name: LEGO Super Soccer Adventure (Europe) (Proto 1)
+  name: LEGO Super Soccer Adventure (Europe) (Proto) (2003-02-07)
   version: '1.00'
 - hashes:
   - md5: 64df503737e95961d678be4c792d98a3
     size: 177244368
-  name: LEGO Super Soccer Adventure (Europe) (Proto 2)
+  name: LEGO Super Soccer Adventure (Europe) (Proto) (2003-03-27)
   version: '1.00'
 - hashes:
   - md5: abfbf6e1db907debccd0631792c91df0
@@ -66837,7 +66851,7 @@
 - hashes:
   - md5: 7e59221e8f20dd3cfbbd8aeaf8c90c14
     size: 711237744
-  name: Phantom Brave - 2-shuume Hajimemashita. (Japan)
+  name: Phantom Brave - 2-shuume Hajimemashita. (Japan) (v1.00)
   serial: SLPS-73108
   version: '1.00'
 - hashes:
@@ -66879,7 +66893,7 @@
 - hashes:
   - md5: 9244d25301f4bca17837a60df7ab282e
     size: 1772519424
-  name: Kaidou Battle (Korea)
+  name: Kaido Battle (Korea)
   serial: SLKA-25063
   version: '1.01'
 - hashes:
@@ -67113,13 +67127,13 @@
 - hashes:
   - md5: e11446d93ea15f5e0736b30d31ce8baa
     size: 1256914944
-  name: Shin Combat Choro Q (Korea)
+  name: Sin Combat Choro Q (Korea)
   serial: SLKA-25047
   version: '1.00'
 - hashes:
   - md5: d4bb060ff3c58a545cab59368793d729
     size: 352322544
-  name: Simple 2000 Series Ultimate Vol. 6 - Love - Upper! (Korea)
+  name: Simple 2000 Series - Love - Upper! (Korea)
   serial: SLKA-15028
   version: '1.01'
 - hashes:
@@ -67134,3 +67148,1583 @@
   name: Tiger Woods PGA Tour 06 (Europe) (Demo)
   serial: SLED-53543
   version: '1.02'
+- hashes:
+  - md5: 19d35009a4ace21c1ab0ac94b1ba7cf1
+    size: 662734800
+  name: Freekstyle (Korea)
+  serial: SLPM-64517
+  version: '1.00'
+- hashes:
+  - md5: d4f5b7615997b2e9ddfc53c38f4ee329
+    size: 1249804288
+  name: Disney-Pixar The Incredibles - Rise of the Underminer (Korea)
+  serial: SLKA-25316
+  version: '1.00'
+- hashes:
+  - md5: 4f64b053d9f58eed293ae67108617698
+    size: 4418895872
+  name: Gidong Jeonsa Gundam - Climax U.C. (Korea)
+  serial: SLKA-25364
+  version: '1.00'
+- hashes:
+  - md5: 0903d99bea951346b2dee5e216875d8c
+    size: 4343398400
+  name: Gidong Jeonsa Gundam - Gundam vs. Z Gundam (Korea)
+  serial: SLKA-25268
+  version: '1.00'
+- hashes:
+  - md5: b5707c41fcbc0913738ccf40501af7d5
+    size: 3047129088
+  name: Mobile Suit Gundam Seed - Yeonhap vs. Z.A.F.T. (Korea)
+  serial: SLKA-25314
+  version: '1.00'
+- hashes:
+  - md5: 74e5bffcc7dfd8fd97a7eb126dcd3766
+    size: 2843148288
+  name: Seven Samurai 20XX (Korea)
+  serial: SLKA-25154
+  version: '1.00'
+- hashes:
+  - md5: 405482738779761479bc15c831ede81e
+    size: 1582727168
+  name: 187 - Ride or Die (Korea) (En,Fr,Es)
+  serial: SLKA-25322
+  version: '1.00'
+- hashes:
+  - md5: 64bdd839b8e5fbb82348168ebad33e9f
+    size: 3608182784
+  name: Battlefield 2 - Modern Combat (Korea)
+  serial: SLKA-25330
+  version: '1.01'
+- hashes:
+  - md5: 76bace3ff343334cdbccd2e9de93fe39
+    size: 4144267264
+  name: Crouching Tiger, Hidden Dragon (Korea)
+  serial: SLKA-25107
+  version: '1.01'
+- hashes:
+  - md5: 4bf7236e3d1b37fb7cf223c1dea8b28c
+    size: 3913842688
+  name: Fight Night Round 2 (Korea)
+  serial: SLKA-25242
+  version: '1.00'
+- hashes:
+  - md5: f8c1c5d88fc5591925d262d159c258df
+    size: 4360798208
+  name: Full Spectrum Warrior - Ten Hammers (Korea)
+  serial: SLKA-25368
+  version: '1.04'
+- hashes:
+  - md5: b4a69ff9a106c3af06135563672749b4
+    size: 2103115776
+  name: Jacked (Korea)
+  serial: SLKA-25349
+  version: '1.01'
+- hashes:
+  - md5: 1430c5ee23ebf5902b87a01aa047d5e6
+    size: 571726512
+  name: 2002 FIFA World Cup (France) (Demo)
+  serial: SLED-50910
+  version: '1.00'
+- hashes:
+  - md5: 19ec337cdee94bad48a7fc9c8ef6083a
+    size: 141294048
+  name: Shaun Palmer's Pro Snowboarder (Europe) (Demo)
+  serial: SLED-50626
+  version: '1.00'
+- hashes:
+  - md5: 0d49a4b2326c93f8f96c0eab6214cc84
+    size: 4269801472
+  name: Sims 2, The - Pets (Korea)
+  serial: SLKA-25399
+  version: '1.00'
+- hashes:
+  - md5: 0965f29795813a469e144a873a6eae7a
+    size: 4482334720
+  name: Urbz, The - Sims in the City (Korea)
+  serial: SLKA-25099
+  version: '1.00'
+- hashes:
+  - md5: e465be509f7608e428c006cd8dc31308
+    size: 761692848
+  name: Action Replay - Lite Version (UK) (Unl)
+  version: '1.30'
+- hashes:
+  - md5: e70165ac94568c63497651bc3bf658c8
+    size: 761692848
+  name: Xtreme Cheats - Pro Edition (UK) (Unl)
+  version: '1.30'
+- hashes:
+  - md5: f65e6f09cb93ab989b97c34b86c71379
+    size: 3967877120
+  name: Ookami (Korea)
+  serial: SCKA-20095
+  version: '1.00'
+- hashes:
+  - md5: 4ce2f61a16b4cba973484548fe8276b3
+    size: 1309933568
+  name: Everybody's Tennis (Korea)
+  serial: SCKA-20088
+  version: '1.00'
+- hashes:
+  - md5: aa7c08eae548b51a714d546d20ac7c29
+    size: 3489267712
+  name: 007 - Everything or Nothing (Korea)
+  serial: SLKA-25129
+  version: '1.00'
+- hashes:
+  - md5: 4f8820f45087519bda085e9c443074f8
+    size: 4698767360
+  name: Air Ranger 2 - Rescue Helicopter (Korea)
+  serial: SLKA-25052
+  version: '1.04'
+- hashes:
+  - md5: edeed56de8a6e4c567604070604fbcb1
+    size: 3535568896
+  name: Degul Degul Jjondeuk Jjondeuk - Goehon (Korea)
+  serial: SCKA-20051
+  version: '1.00'
+- hashes:
+  - md5: 111da825aee7f66dbe1822f96074e136
+    size: 2047180800
+  name: Hajime-ui Ilbo - The Fighting! Victorious Boxers - Championship Version (Korea)
+  serial: SLPM-67528
+  version: '1.01'
+- hashes:
+  - md5: e8b367b3b7be3156bf6bc9225fd9a0ae
+    size: 4105502720
+  name: Mobile Suit Gundam Seed - Kkeunnaji Anneun Naeillo (Korea)
+  serial: SLKA-25255
+  version: '1.00'
+- hashes:
+  - md5: 5fcb3636a6f1a6ce1bdfd29734ae2a9d
+    size: 3795910656
+  name: Nanobreaker (Korea) (En,Ja)
+  serial: SLKA-25263
+  version: '1.00'
+- hashes:
+  - md5: 33c150dbd9c6b1fa4b0c02f0d8264868
+    size: 3781394432
+  name: NBA Street Vol. 2 (Korea)
+  serial: SLKA-25027
+  version: '1.00'
+- hashes:
+  - md5: e92b98540d6843ed140701f6d2cd8bc1
+    size: 2017624064
+  name: One Piece - Grand Battle! Rush (Korea)
+  serial: SLKA-25299
+  version: '1.00'
+- hashes:
+  - md5: 2aa6bb941e16271530aa5919679dd75e
+    size: 1875083264
+  name: Reign of Fire (Korea)
+  serial: SLKA-25011
+  version: '1.02'
+- hashes:
+  - md5: f58607a0c74a7868d6671525106f2dbb
+    size: 1932787712
+  name: Soul Reaver 2 (Korea)
+  serial: SLPM-67516
+  version: '1.00'
+- hashes:
+  - md5: ef85416bd41ec65168fc14faf25450c6
+    size: 2574516224
+  name: Spy Fiction (Korea)
+  serial: SLKA-25007
+  version: '1.00'
+- hashes:
+  - md5: 92ebd95759e3b70718290792c1a24e22
+    size: 843415552
+  name: Thunder Strike - Operation Phoenix (Korea)
+  serial: SLPM-67506
+  version: '1.00'
+- hashes:
+  - md5: d5e60abd0a7f7df380cdfe034aeedea5
+    size: 3603136512
+  name: Time Crisis - Crisis Zone (Korea)
+  serial: SCKA-20038
+  version: '1.00'
+- hashes:
+  - md5: c1c1c5141fd3f2bba1bdbd6989c5bcd5
+    size: 3260874752
+  name: Transformers - Revenge of the Fallen (Korea)
+  serial: SLKA-25459
+  version: '1.00'
+- hashes:
+  - md5: ca26f348a26e3518cf21e4c4da97f653
+    size: 4286251008
+  name: WWE SmackDown vs. Raw 2008 (Korea)
+  serial: SLKA-25365
+  version: '1.00'
+- hashes:
+  - md5: 78e80f2890047ce79bde9d01b1f54ec7
+    size: 3947167744
+  name: WWE SmackDown vs. Raw 2009 (Korea)
+  serial: SLKA-25448
+  version: '1.00'
+- hashes:
+  - md5: 413b92c72db895dc8b1901e0c7d6142c
+    size: 745943856
+  name: EyeToy - Tales (Korea)
+  serial: SCKA-10007
+  version: '1.00'
+- hashes:
+  - md5: 348abb7b0325df388004679cf3fe3ba9
+    size: 523089504
+  name: EyeToy - EduKids (Korea)
+  serial: SCKA-10005
+  version: '1.01'
+- hashes:
+  - md5: ae4436169daef3b3b10af810ddfd3e3a
+    size: 622442688
+  name: Pucelle, La (Korea)
+  serial: SLPM-64522
+  version: '1.00'
+- hashes:
+  - md5: cd59e791eaa3db7498e2cb21390fd5c8
+    size: 352249632
+  name: Assault Suits Valken (Korea)
+  serial: SLKA-15023
+  version: '1.01'
+- hashes:
+  - md5: 17f74ee7385d0ebed3dfbc2493094421
+    size: 656419680
+  name: Dark Angel - Vampire Apocalypse (Korea)
+  serial: SLPM-64537
+  version: '1.04'
+- hashes:
+  - md5: 988e0ba7b8aac6415714240d2d16450a
+    size: 1462239232
+  name: Pride FC - Fighting Championships (Korea)
+  serial: SLKA-25059
+  version: '1.00'
+- hashes:
+  - md5: 834b8b0920d9b4991cd55831214d6efe
+    size: 4678287360
+  name: TimeSplitters 2 (Korea)
+  serial: SLKA-25020
+  version: '1.01'
+- hashes:
+  - md5: 56cdf0f7ed152f8ceb6f8aa4573eb906
+    size: 527083200
+  name: Barbarian (Korea)
+  serial: SLKA-15001
+  version: '1.03'
+- hashes:
+  - md5: cd89394c4cacba193c2cb34481889364
+    size: 707857920
+  name: Digital Holmes (Korea)
+  serial: SLPM-64532
+  version: '1.03'
+- hashes:
+  - md5: a630a0c92f746bcd28998cea5b449ec6
+    size: 363169968
+  name: Grand Slam 2003 Tennis (Korea)
+  serial: SLKA-15013
+  version: '1.01'
+- hashes:
+  - md5: 8051a0056003f0d20fb6010aaae0eff4
+    size: 15215088
+  name: Jin Samguk Mussang 2 & Maengjangjeon - Choegang Data (Korea)
+  serial: SLKA-90501
+  version: '1.00'
+- hashes:
+  - md5: e6d7c927ff99ac79bbeedd56e2c6da44
+    size: 42759360
+  name: Jin Samguk Mussang 3 & Maengjangjeon - Choegang Data (Korea)
+  serial: SLKA-90504
+  version: '1.00'
+- hashes:
+  - md5: d21e350b697a556053b0b012cc927dcf
+    size: 706491408
+  name: Legends of Wrestling (Korea)
+  serial: SLPM-64514
+  version: '1.00'
+- hashes:
+  - md5: be4f89a0ef63ffd56faebc30dcadb41e
+    size: 314434176
+  name: Silent Scope 3 (Korea) (En,Ko)
+  serial: SLPM-64552
+  version: '1.01'
+- hashes:
+  - md5: f7b7c332ce9951851e39db1ad7979ebe
+    size: 81861360
+  name: Simple 2000 Series - The Block - Hyper (Korea)
+  serial: SLKA-15030
+  version: '1.01'
+- hashes:
+  - md5: 2ae22b6bbb78ae05fe19c12be7b1a889
+    size: 596142624
+  name: Space Invaders Anniversary (Korea)
+  serial: SLKA-15025
+  version: '1.01'
+- hashes:
+  - md5: 3a367e70b3aad58fdf99aa3fd7b7db02
+    size: 620643408
+  name: Super Puzzle Bobble 2 (Korea)
+  serial: SLPM-64550
+  version: '1.00'
+- hashes:
+  - md5: 3dadba35d7e87b2ddcabfa9150b00207
+    size: 40597872
+  name: Super Puzzle Bobble Collection (Korea) (Disc 1)
+  serial: SLKA-15043
+  version: '1.00'
+- hashes:
+  - md5: afc6fc8d392500a3a763941a63a381b6
+    size: 620643408
+  name: Super Puzzle Bobble Collection (Korea) (Disc 2)
+  serial: SLKA-15044
+  version: '1.00'
+- hashes:
+  - md5: 510cc8ea06f1a659e59d8c155a05e93a
+    size: 513319296
+  name: Sims, The (Korea)
+  serial: SLPM-64540
+  version: '1.02'
+- hashes:
+  - md5: 9b06f86ad2adafc03b6afd52ee180d66
+    size: 653606688
+  name: Mahjong Taikai III - Millennium League (Japan) (v1.30)
+  serial: SLPM-62191
+  version: '1.30'
+- hashes:
+  - md5: a8877badbf7bf70c71f57e7ac6898d3c
+    size: 1362231296
+  name: Winning Post 7 (Japan) (v1.00)
+  serial: SLPM-66811
+  version: '1.00'
+- hashes:
+  - md5: 283e421dcf113d301ecc658308c388b4
+    size: 1400700928
+  name: Saint Beast - Rasen no Shou (Japan)
+  serial: SLPS-25808
+  version: '1.01'
+- hashes:
+  - md5: 277defd81c31077a961992a76534cdab
+    size: 1858371584
+  name: Hanakisou (Japan) (v1.01)
+  serial: SLPM-66471
+  version: '1.01'
+- hashes:
+  - md5: 92b06503d13e8f8b805a33cde820d0aa
+    size: 3960340480
+  name: Kyou kara Maou! Shin Makoku no Kyuujitsu (Japan)
+  serial: SLPS-25802
+  version: '1.00'
+- hashes:
+  - md5: 28b4abe4a273a9b62a8d40306c2c92d4
+    size: 1255309312
+  name: Hoshi-iro no Okurimono (Japan)
+  serial: SLPM-66900
+  version: '1.01'
+- hashes:
+  - md5: 3c7b7ed6e4b747900ed5b49908e8ffb8
+    size: 2217967616
+  name: Kin'iro no Corda 2 Encore (Japan)
+  serial: SLPM-66835
+  version: '1.01'
+- hashes:
+  - md5: 8793d87711805d6c63f5813794525137
+    size: 3023929344
+  name: Drastic Killer (Japan) (Drastic Killer Excellent Box)
+  serial: SLPS-25870
+  version: '1.01'
+- hashes:
+  - md5: a95814be816ad16e8757f0c5e997e9f6
+    size: 4677795840
+  name: Otome-teki Koi Kakumei - Love Revo!! (Japan) (Love Revo Box)
+  serial: SLPM-66237
+  version: '1.03'
+- hashes:
+  - md5: e21716fece0629d9fefec443ec6d2073
+    size: 4440719360
+  name: Ace Combat 5 - The Unsung War (Korea) (En,Ja)
+  serial: SCKA-20042
+  version: '1.00'
+- hashes:
+  - md5: 640254ff15943dd5f22bb564ef24d116
+    size: 1249804288
+  name: Inuyasha - Oui Nanmu (Korea)
+  serial: SLKA-25296
+  version: '1.00'
+- hashes:
+  - md5: 4c679bf67123f969ee8888acf1f78ebf
+    size: 713065248
+  name: UFC - Ultimate Fighting Championship 2 - Tapout (Korea)
+  serial: SLPM-64539
+  version: '1.00'
+- hashes:
+  - md5: 2158f990e3fc74a7f55a3fb16af1cc27
+    size: 4146593792
+  name: Operator's Side (Japan)
+  serial: SCPS-15039
+  version: '1.02'
+- hashes:
+  - md5: 4d9a161c232a8220388a8d10d3afe97c
+    size: 2257031168
+  name: Punisher, The (Europe) (Es,It) (Beta) (2005-01-05)
+  version: '1.00'
+- hashes:
+  - md5: c52f5dccb8b0f8a561f7e5c4a113900f
+    size: 1472102400
+  name: Tennis no Oujisama - Card Hunter (Japan)
+  serial: SLPM-66669
+  version: '1.02'
+- hashes:
+  - md5: 6216d6260675eaef75493a3db637994d
+    size: 3440345088
+  name: Trouble Fortune Company - HapiCure (Japan)
+  serial: SLPM-66626
+  version: '1.01'
+- hashes:
+  - md5: 22effb62be0ca7c220c0f34d42b1b6c9
+    size: 4519297024
+  name: Cluster Edge - Kimi o Matsu Mirai e no Akashi (Japan) (Shokai Genteiban)
+  serial: SLPS-25653
+  version: '1.06'
+- hashes:
+  - md5: f4cfe7a93178f4351c67152ab0e162be
+    size: 3082027008
+  name: Samurai 7 (Japan)
+  serial: SLPM-66400
+  version: '1.01'
+- hashes:
+  - md5: bc9d9abb9fc7db1f4460a66096335c6e
+    size: 761692848
+  name: PSi2 35 (UK) (Unl)
+  version: 1.00 (European)
+- hashes:
+  - md5: 4c65e1ec067fb2caf4678a3c3b88fd65
+    size: 761692848
+  name: PSi2 Disc 16 (UK) (Unl)
+  version: '1.30'
+- hashes:
+  - md5: 303e67e333475b97846ca641ad5aeaeb
+    size: 3483336704
+  name: Fugitive Hunter - War on Terror (USA) (Beta) (2003-09-26)
+  version: '1.00'
+- hashes:
+  - md5: b2ec1a4f63287d9f1b60c9171cecb946
+    size: 3547561984
+  name: Armored Core 2 (USA) (Beta) (2000-08-29)
+  version: '0.95'
+- hashes:
+  - md5: 0c01a5d71b9b75262e0b0dd56854719e
+    size: 1970929664
+  name: SpyHunter - Nowhere to Run (USA) (Beta) (2006-06-19)
+  version: '1.00'
+- hashes:
+  - md5: 4e333c004903458489f7827fb3154a8e
+    size: 542894080
+  name: Marc Ecko's Getting Up - Contents Under Pressure (USA) (Beta) (2005-08-14)
+  version: '1.00'
+- hashes:
+  - md5: a6fe047cc783c81af66e28eaf5595673
+    size: 2244640768
+  name: Tokyo Xtreme Racer - Drift (USA) (Beta) (2006-01-13)
+  version: '1.00'
+- hashes:
+  - md5: dfc8f0c639e51d6e52a7b48d12967263
+    size: 2618818560
+  name: Aeon Flux (USA) (Beta) (2005-10-24)
+  version: '1.03'
+- hashes:
+  - md5: 389afcc0e94e287be87db677534df732
+    size: 189702912
+  name: Gradius V (USA) (Beta) (2004-04-28)
+  version: '1.00'
+- hashes:
+  - md5: 6aaa066979e0265fd8575a374c2a1a62
+    size: 2070544384
+  name: Beyond Good & Evil (USA) (En,Fr,Es) (Beta) (2003-10-14)
+  version: '1.01'
+- hashes:
+  - md5: 7cbd08842a6944319d8c0574894af0f2
+    size: 4653023232
+  name: Bujingai (Japan) (Beta) (2003-11-02)
+  version: '1.00'
+- hashes:
+  - md5: bcee737b5afc3c08c47e2f1b955b35e6
+    size: 66855600
+  name: PSi2 19 (UK) (Unl)
+  version: '1.30'
+- hashes:
+  - md5: bc657187e7aad6e6f8ed29fdd3c230ce
+    size: 2126020608
+  name: Zero no Tsukaima - Muma ga Tsumugu Yokaze no Fantasy (Japan)
+  serial: SLPS-25831
+  version: '1.01'
+- hashes:
+  - md5: d9b9cc119d0a7c6935ff651f40482c34
+    size: 1542029312
+  name: Tennis no Oujisama - Smash Hit! 2 (Japan) (Shokai SP Genteiban A-Type)
+  serial: SLPM-65451
+  version: '1.01'
+- hashes:
+  - md5: a08bff798c72cbd423c8d7ea511fe842
+    size: 425961312
+  name: Tennis no Oujisama - Smash Hit! 2 - Original Anime Game (Japan) (Shokai SP
+    Genteiban A-Type)
+  serial: SLPM-62434
+  version: '1.00'
+- hashes:
+  - md5: 5423325bc5f08f9ab0e84521ecce5356
+    size: 438116448
+  name: Tennis no Oujisama - Smash Hit! 2 - Original Anime Game (Japan) (Shokai SP
+    Genteiban C-Type)
+  serial: SLPM-62436
+  version: '1.00'
+- hashes:
+  - md5: b820899a711720864446a6c00e6b6aeb
+    size: 101152464
+  name: Rilakkuma - Ojama shite masu 2-shuukan (Japan) (Shokai Gentei Nuigurumi Pack)
+  serial: SLPM-62679
+  version: '1.03'
+- hashes:
+  - md5: aeb5c203708766c73f7e483f3035854c
+    size: 4624809984
+  name: Killzone (Europe) (Beta) (2004-10-13)
+  version: '1.00'
+- hashes:
+  - md5: 738d5788bd32398d167d915fd94c200a
+    size: 2912059392
+  name: Mermaid Prism (Japan) (Shokai Gentei Mermaid Box)
+  serial: SLPS-25684
+  version: '1.02'
+- hashes:
+  - md5: 188d85e11ceac2afd88f1ace015a7335
+    size: 3422126080
+  name: Colorful Box - To Love (Japan) (Shokai Genteiban)
+  serial: SLPM-65588
+  version: '1.02'
+- hashes:
+  - md5: 788e64783488a0e9f8e9aade112b4c7d
+    size: 4512907264
+  name: Dear My Sun!! Musuko Ikusei Capriccio (Japan) (Genteiban)
+  serial: SLPS-25804
+  version: '1.01'
+- hashes:
+  - md5: b67bbb89fc9e843623583762b7053137
+    size: 3229450240
+  name: Angel's Feather (Japan) (Shokai Genteiban)
+  serial: SLPM-65512
+  version: '1.02'
+- hashes:
+  - md5: 5ec3d2ea661c613f7578b5cea8de95e0
+    size: 2705850368
+  name: Mitsu x Mitsu Drops - Love x Love Honey Life (Japan) (Genteiban)
+  serial: SLPM-66380
+  version: '1.02'
+- hashes:
+  - md5: 5c32a0ac8ea84fbf0faeb6b20c1a0d71
+    size: 1273462784
+  name: Sumomomo Momomo - Chijou Saikyou no Yome - Keishou Shimasho! Koi no Hanamuko
+    Soudatsu-sen!! (Japan) (Shokai Genteiban)
+  serial: SLPS-25777
+  version: '1.01'
+- hashes:
+  - md5: 8d17a6dcbdb604a07fefa8ee2832360d
+    size: 2189426688
+  name: Rebirth Moon (Japan) (Genteiban)
+  serial: SLPM-66142
+  version: '1.09'
+- hashes:
+  - md5: 64de7e8c2f09fc03f48e3a9c538fd569
+    size: 3977281536
+  name: Sakura - Setsu Gekka (Japan) (Genteiban)
+  serial: SLPM-65306
+  version: '1.01'
+- hashes:
+  - md5: e369b7f6f53e717322cb84be638359ee
+    size: 2468544512
+  name: Gunparade Orchestra - Shiro no Shou - Aomori Penguin Densetsu (Japan) (Genteiban)
+  serial: SCPS-15103
+  version: '1.02'
+- hashes:
+  - md5: 88c4474a6d5e60c7deff9e5d89e8c036
+    size: 663216960
+  name: Teitoku no Ketsudan IV with Power-Up Kit (Japan)
+  serial: SLPM-62470
+  version: '1.01'
+- hashes:
+  - md5: 49d47d875350bdc02f0be7577f3922f4
+    size: 718702992
+  name: Xtreme FM (USA) (Unl)
+  version: '1.10'
+- hashes:
+  - md5: 11bdcb29de298f4f0a232b13bd383b9c
+    size: 1499791360
+  name: Project - Snowblind (USA) (Beta) (2004-11-07)
+  serial: SLUS-29131
+  version: '1.01'
+- hashes:
+  - md5: 7adb3abe1b3bef5ac4d3b2b6dffdb54f
+    size: 761692848
+  name: X-Port (USA) (Unl)
+  version: '1.10'
+- hashes:
+  - md5: 89e9cf0ab0cf99f55204cc0ca82057c1
+    size: 761692848
+  name: Xtreme Cheats - Schnupperversion (Germany) (Unl) (PSi2 Ausgabe 10)
+  version: PSI_DE_10 EUROPE
+- hashes:
+  - md5: ab3fb6a94b89b299404f6596361b11c8
+    size: 761692848
+  name: Xtreme Cheats - Schnupperversion (Germany) (Unl) (PSi2 Ausgabe 11)
+  version: pside_10 EUROPE
+- hashes:
+  - md5: acafbf846daa0fb2a2106b126b992896
+    size: 1235779584
+  name: KOF2 - Maximum Impact II (Japan) (Tentou-you Taikenban)
+  serial: SLPM-61145
+  version: '1.01'
+- hashes:
+  - md5: 5838616b02ec8e95baf85314de0dd005
+    size: 1230176256
+  name: Gacha Mecha Stadium - Saru Battle (Japan) (Taikenban)
+  serial: PAPX-90518
+  version: '1.01'
+- hashes:
+  - md5: 5fa25ab39a19d82c399ebd3f14e3b4f7
+    size: 718702992
+  name: Action Replay Max (USA) (Unl) (v3.34)
+  version: 3.34 (American)
+- hashes:
+  - md5: 528fbb9453115cc5b7984e62ff9fc104
+    size: 2071199744
+  name: Official PlayStation 2 Magazine Demo 70 (France)
+  serial: SCED-54024
+  version: '2.00'
+- hashes:
+  - md5: 444514b172b294b262059fbc9a805d7c
+    size: 761692848
+  name: Xtreme Cheats - Full Version (UK) (Unl)
+  version: '1.30'
+- hashes:
+  - md5: 240266ae45272c419507d160f077cd05
+    size: 4683268096
+  name: NBA Live 08 (Asia)
+  serial: SLAJ-25099
+  version: '1.00'
+- hashes:
+  - md5: 266afbafdbfaf5fa84ca95ab7c38dc28
+    size: 4698734592
+  name: FIFA World Cup Germany 2006 (Asia)
+  serial: SLAJ-25081
+  version: '1.00'
+- hashes:
+  - md5: ccdd2da480e3d9a0bb4f5f1205197041
+    size: 96714240
+  name: Play TV 97 (UK) (Unl)
+  serial: DVD-006
+  version: '1.30'
+- hashes:
+  - md5: 1409867c85317cd62a89039bb7e23e0a
+    size: 80356080
+  name: PSi2 30 (UK) (Unl)
+  version: PSIUK_30 EUROPE
+- hashes:
+  - md5: 3ee6a1c04c7b34488967bb9fc1b8f5d9
+    size: 718702992
+  name: Instant Cheats - Volume 15 (UK) (Unl)
+  version: 1.00 beta (European)
+- hashes:
+  - md5: 5b958ea14d8587d1ed41e38fb5b3b3fa
+    size: 718702992
+  name: PlayStation 2 Cheats - Volume 12 (UK) (Unl)
+  version: 1.00 beta (European)
+- hashes:
+  - md5: 0fa750118d146aed840c03fb2502e73b
+    size: 718702992
+  name: P2 Cheats - Volume 20 (UK) (Unl)
+  version: 1.00 beta (European)
+- hashes:
+  - md5: c09d89dd2c5a577411e48156df5084fc
+    size: 718702992
+  name: Playable Cheats Vol. 18 (UK) (Unl)
+  version: 1.00 (European)
+- hashes:
+  - md5: 44d3c012f8f1b449c6c78b0fbb6c41e0
+    size: 761692848
+  name: Action Replay 2 V2 (Europe) (Disc 1) (Unl) (v2.30)
+  version: 2.30 EUROPE
+- hashes:
+  - md5: 855ab8cf3089e82088620ada51c7283a
+    size: 761692848
+  name: Xtreme Cheats - Volume 03 (UK) (Unl)
+  version: '1.30'
+- hashes:
+  - md5: 22d96ab130f8c1d9cdd772e01ecc9295
+    size: 718702992
+  name: P2 Cheats - Volume 22 (UK) (Unl)
+  version: 1.00 beta (European)
+- hashes:
+  - md5: 255793869489f6fd557ae1f2a9246fd8
+    size: 718702992
+  name: Playable Cheats Vol. 20 (UK) (Unl)
+  version: 1.00 (European)
+- hashes:
+  - md5: 2ccb78e904c90c41f5ce221bcc93c8de
+    size: 718702992
+  name: Playable Cheats Vol. 21 (UK) (Unl) (04081101)
+  version: 1.00 (European)
+- hashes:
+  - md5: 3fa7842bbe16d6726b46b62f87500f62
+    size: 718702992
+  name: Playable Cheats Vol. 12 (UK) (Unl)
+  version: 1.00 (European)
+- hashes:
+  - md5: aefdd8b66373e804053b23264f7e577a
+    size: 761692848
+  name: Playable Cheats Vol. 11 (UK) (Unl)
+  version: 1.00 (European)
+- hashes:
+  - md5: c875a47caa532c4c45a1c748b26ce2cc
+    size: 718702992
+  name: Playable Cheats - Volume 3 (UK) (Unl)
+  version: 1.00 (European)
+- hashes:
+  - md5: e10336bf99de7e2372b0ba57945c64e0
+    size: 761692848
+  name: Cheats Vol. 7 (UK) (Unl)
+  version: 1.00 (European)
+- hashes:
+  - md5: 7cb34370825e79b0a54bb5598a4c24f0
+    size: 718702992
+  name: Playable Cheats - Volume 1 (UK) (Unl)
+  version: 1.00 (European)
+- hashes:
+  - md5: 05269e5c905f8bdb343957679502837a
+    size: 718702992
+  name: Playable Cheats - Volume 4 (UK) (Unl)
+  version: 1.00 (European)
+- hashes:
+  - md5: cdde1d64ac5ac120fbb6bb41b7411933
+    size: 761692848
+  name: Action Replay Ultimate Cheats Fast & Furious (Europe) (Unl)
+  version: FAST_FU EUROPE
+- hashes:
+  - md5: f74e740357ed83cfe7c5e2971cf0c1e2
+    size: 2022998016
+  name: Herdy Gerdy (Korea)
+  serial: SLKA-25003
+  version: '1.01'
+- hashes:
+  - md5: a84b3e8409e2554ff54c1ec9c9287278
+    size: 3188948992
+  name: Nickelodeon Tak 2 - The Staff of Dreams (Korea)
+  serial: SLKA-25272
+  version: '1.00'
+- hashes:
+  - md5: 86c5b9b20a3a5f9fc6b0dbd1358f6b3d
+    size: 718702992
+  name: Best of Xtreme Cheats, The (UK) (Unl)
+  version: 1.00 (European)
+- hashes:
+  - md5: 1490c492cae033cb0f1564c4d3fdf013
+    size: 761692848
+  name: Action Replay Ultimate Cheats for Use with Lara Croft Tomb Raider - The Angel
+    of Darkness (UK) (Unl)
+  version: 1.00 (European)
+- hashes:
+  - md5: b76f9b31f5efffea1be6beae051fa158
+    size: 718702992
+  name: P2 Cheats - Volume 18 (UK) (Unl)
+  version: 1.00 beta (European)
+- hashes:
+  - md5: c61ed4d28b4c441daa3ba0bb27c496a2
+    size: 718702992
+  name: Instant Cheats - Volume 8 (UK) (Unl)
+  version: 1.00 (European)
+- hashes:
+  - md5: 89794472a3c702111c9efe6f26e7dd07
+    size: 718702992
+  name: Instant Cheats - Volume 7 (UK) (Unl)
+  version: 1.00 (European)
+- hashes:
+  - md5: b52f0fccbaadcdf61de58b05528ee003
+    size: 718702992
+  name: P2 Cheats - Volume 19 (UK) (Unl)
+  version: 1.00 beta (European)
+- hashes:
+  - md5: 5202aeb8bfa1d040e88db89b15b0c7a4
+    size: 718702992
+  name: PSi2 15 (Germany) (Unl)
+  version: 1.00 (European)
+- hashes:
+  - md5: 32e1db6bbb8683a8cb6e5c51ae6c43ce
+    size: 718702992
+  name: Spielbare Cheats Volume 16 (Germany) (Unl)
+  version: 1.00 (European)
+- hashes:
+  - md5: 6a422444c597a6220da04f04e36d10d2
+    size: 718702992
+  name: Instant Cheats - Volume 12 (UK) (Unl)
+  version: 1.00 (European)
+- hashes:
+  - md5: a15d4a742b8605abb22c09ca45355cd5
+    size: 718702992
+  name: Instant Cheats - Volume 6 (UK) (Unl)
+  version: 1.00 (European)
+- hashes:
+  - md5: cf776862fa14089e67c91fdc515d0c24
+    size: 718702992
+  name: Instant Cheats - Volume 9 (UK) (Unl)
+  version: 1.00 (European)
+- hashes:
+  - md5: 2a9f400e5cdf00829aed4ef5080c5dde
+    size: 761692848
+  name: Cheats Vol. 8 (UK) (Unl)
+  version: 1.00 (European)
+- hashes:
+  - md5: f77a4058c7afb295464359f0219315ba
+    size: 718702992
+  name: Instant Cheats - Volume 17 (UK) (Unl)
+  version: 1.00 beta (European)
+- hashes:
+  - md5: 52da13c26dd4cbb98accb13115dd960d
+    size: 718702992
+  name: Instant Cheats - Volume 13 (UK) (Unl)
+  version: 1.00 beta (European)
+- hashes:
+  - md5: 16a832a530e8d03d2369e38b01035c99
+    size: 718702992
+  name: Instant Cheats - Volume 16 (UK) (Unl)
+  version: 1.00 beta (European)
+- hashes:
+  - md5: d78f449fc032ac9a20b5ec20b431733b
+    size: 4458708992
+  name: Arc - Twilight of the Spirits (Europe) (En,Fr,De,Es,It) (Beta) (2003-11-18)
+  serial: SCES-51910
+  version: '1.00'
+- hashes:
+  - md5: 97e62a83894dfa71e880db0b44b5f1ce
+    size: 718702992
+  name: Instant Cheats - Volume 5 (UK) (Unl)
+  version: 1.00 (European)
+- hashes:
+  - md5: b02bde667794669d5342a734346985e3
+    size: 718702992
+  name: PlayStation 2 Cheats - Volume 8 (UK) (Unl)
+  version: 1.00 (European)
+- hashes:
+  - md5: 6880dc2c3be70e38497f7f30de1fa514
+    size: 4270915584
+  name: Lara Croft Tomb Raider - Legend (Europe) (En,Fr,De,Es,It) (Beta) (2006-02-12)
+  version: '1.00'
+- hashes:
+  - md5: ff41d869b76545d77c01b569d1f93e90
+    size: 761692848
+  name: Xtreme Cheats (UK) (Unl) (03021901)
+  version: DIXONS_01 EUROPE
+- hashes:
+  - md5: e027113d1fb74d58457dbec81656a521
+    size: 761692848
+  name: Xtreme Cheats (UK) (Unl) (03040901)
+  version: UC_BB EUROPE
+- hashes:
+  - md5: e2efc68a1e02c7e2c09241bfb7bd1f0f
+    size: 718702992
+  name: Action Replay Ultimate Cheats fuer Final Fantasy X-2 (Germany) (Unl)
+  version: 1.00 (European)
+- hashes:
+  - md5: 69a169b61a11d6c40f19073b31513a0c
+    size: 718702992
+  name: Playable Cheats - Volume 2 (UK) (Unl)
+  version: 1.00 (European)
+- hashes:
+  - md5: 5af1aba9170e773f5fa3d785224753ca
+    size: 592642048
+  name: Jonny Moseley Mad Trix (Europe) (DVD Preview)
+  serial: SLES-50362
+  version: '1.00'
+- hashes:
+  - md5: f8256d93fb1431ed8c333b5dcbb5d318
+    size: 718702992
+  name: Playable Cheats Vol. 22 (UK) (Unl)
+  version: 1.00 (European)
+- hashes:
+  - md5: d75499d47ef6ff77a4b811934c37248d
+    size: 3570860032
+  name: Routes PE (Japan) (Shokai Genteiban)
+  serial: SLPS-25722
+  version: '1.02'
+- hashes:
+  - md5: f04cba490a5ad4aa2136831a310d6ab8
+    size: 4690509824
+  name: NHL 06 (Europe) (En,Fr,De,Sv,Fi,Cs) (Demo)
+  serial: SLED-53586
+  version: '1.00'
+- hashes:
+  - md5: 199bc20f95c9b757d74027292fca8efd
+    size: 7757430784
+  name: Sakura Daejeon - Tteugeoun Yeoljeongeuro (Korea)
+  serial: SLKA-35003
+  version: '1.00'
+- hashes:
+  - md5: 31f52745df0590e23d05ed6bae89f296
+    size: 7704739840
+  name: Sakura Daejeon V - Annyeong Sarangseureon Geudaeyeo (Korea)
+  serial: SLKA-35004
+  version: '1.00'
+- hashes:
+  - md5: 740d91a1245e0e0cc401d36c3a46bff2
+    size: 604894416
+  name: Ben 10 - Protector of Earth (USA) (Demo)
+  serial: SLUS-29203
+  version: '1.00'
+- hashes:
+  - md5: d77f9a81c8f542b033e62a82c198c33b
+    size: 761692848
+  name: PSi2 Disc 3 (Germany) (Unl)
+  version: '1.30'
+- hashes:
+  - md5: ce404ca97c8a3fc443667e56409094dd
+    size: 3671064576
+  name: Gran Turismo Concept - Nissan Z (Europe)
+  serial: SCED-51097
+  version: '1.00'
+- hashes:
+  - md5: ff2cdaf2448061c04c0206ba2e257910
+    size: 127264368
+  name: Dark Summit (France) (Demo)
+  serial: SLED-50823
+  version: '1.01'
+- hashes:
+  - md5: 683c364b1023d991a85987a2a264e96d
+    size: 4468244480
+  name: Yakuza (Europe) (Beta) (2006-07-03)
+  version: '1.00'
+- hashes:
+  - md5: ecc583a0a585f7e491a1069832ab7292
+    size: 423165952
+  name: Devil May Cry - Trial Edition (Japan) (Disc 2) (Taikenban)
+  serial: SLPM-65025
+  version: '1.00'
+- hashes:
+  - md5: 7f5af5aab43fe6fdc2f340a578072a4c
+    size: 1299906560
+  name: World Quiz 2009 (India)
+  serial: SCES-55484
+  version: '1.00'
+- hashes:
+  - md5: a80f41955cf14fe777a5d7864a0e58d5
+    size: 2113306624
+  name: Demo Natale 2003 (Italy) (En,Fr,De,Es,It)
+  serial: SCED-52130
+  version: '1.00'
+- hashes:
+  - md5: ed1cd6cb69fd2f339e538403c562e8a3
+    size: 143831856
+  name: EyeToy - Monkey Mania (Korea) (Cheheompan)
+  serial: SCKA-90017
+  version: '1.00'
+- hashes:
+  - md5: 940391c09d72012235633ad7c3a6dc15
+    size: 3311435776
+  name: SingStar Motown (France)
+  serial: SCES-55550
+  version: '1.00'
+- hashes:
+  - md5: 7c29db754e6c6fc3576070ac413ac930
+    size: 774144000
+  name: Ico (Europe) (En,Fr,De,Es,It) (Beta) (2001-11-16)
+  serial: SCES-00000
+  version: '1.00'
+- hashes:
+  - md5: 65682e00b71f7540d5cc3949717ccb8f
+    size: 907706368
+  name: Ico (Europe) (En,Fr,De,Es,It) (Beta) (2002-01-16)
+  serial: SCES-50760
+  version: '1.00'
+- hashes:
+  - md5: f9fd20d843a37151e338c156a2ca9a14
+    size: 3666706432
+  name: Shadow of the Colossus (Europe) (En,Fr,De,Es,It) (Beta) (2005-11-02)
+  serial: SCES-53326
+  version: '1.00'
+- hashes:
+  - md5: 782f53e29a100c381a6c79e08290af8f
+    size: 4635918336
+  name: Shadow of the Colossus (Europe) (En,Fr,De,Es,It) (Beta) (2005-12-12)
+  serial: SCES-53326
+  version: '1.00'
+- hashes:
+  - md5: fd93b72ba8215c2b8a762a7b4f4f5756
+    size: 2302312448
+  name: Sonic Heroes (Europe) (Beta) (2003-09-28)
+  version: '1.00'
+- hashes:
+  - md5: 8d7762875cb5608fb0204d756be570fe
+    size: 421668912
+  name: Bravo Music - Chou Meikyoku-ban (Japan)
+  serial: SCPS-11023
+  version: '1.00'
+- hashes:
+  - md5: 80f4c4e597a52985e44aaf365a3bc2d0
+    size: 1648525312
+  name: D-A - Black (Japan)
+  serial: SLPS-25292
+  version: '4.00'
+- hashes:
+  - md5: 825d81bd9576b5a5af48b26cebb22e03
+    size: 3407872000
+  name: Tenshou Gakuen Gekkouroku (Japan) (Asmik Tokudane Series)
+  serial: SLPM-66906
+  version: '1.01'
+- hashes:
+  - md5: 4c47fe3472c1081fe2dfda0b9c827fb0
+    size: 2148761600
+  name: Fushigi Yuugi - Suzaku Ibun (Japan)
+  serial: SLPM-66999
+  version: '1.01'
+- hashes:
+  - md5: 883ebe230048d850e4951d0b864876f2
+    size: 4420796416
+  name: Tennis no Oujisama - Rush & Dream! (Japan)
+  serial: SLPM-65877
+  version: '1.00'
+- hashes:
+  - md5: 15fe869a7d37601851d555c382ad9f7c
+    size: 4625367040
+  name: Cafe Lindbergh - Summer Season (Japan)
+  serial: SLPM-65911
+  version: '1.00'
+- hashes:
+  - md5: 9441aeede7aac0a57c0d47597ddc8579
+    size: 4005658624
+  name: Happiness! de Lucks (Japan)
+  serial: SLPS-25720
+  version: '1.01'
+- hashes:
+  - md5: 76ca1348512f532b72dfc0cfeb7dfc10
+    size: 4529356800
+  name: SuperLite 2000 Vol. 44 - Aoi Shiro (Japan)
+  serial: SLPM-55165
+  version: '1.00'
+- hashes:
+  - md5: c031be06c089ecdfc916f36642a031cf
+    size: 2920087552
+  name: SuperLite 2000 Vol. 43 - Memories Off - Sorekara Again (Japan)
+  serial: SLPM-66696
+  version: '1.00'
+- hashes:
+  - md5: 1c4ac104719cd050814d262b723c849e
+    size: 1903099904
+  name: D.C.P.S. - Da Capo - Plus Situation (Japan) (DX Pack)
+  serial: SLPM-65399
+  version: '1.20'
+- hashes:
+  - md5: 2a0506f48558dd46bf1ee867af297f11
+    size: 2470739968
+  name: Kin'iro no Corda (Japan) (Premium Box)
+  serial: SLPM-65566
+  version: '1.04'
+- hashes:
+  - md5: bbd17ee2b7c80555c7aaeaf377599df7
+    size: 1409875968
+  name: Fushigi Yuugi - Genbu Kaiden Gaiden - Kagami no Miko (Japan) (Genteiban)
+  serial: SLPM-66023
+  version: '1.02'
+- hashes:
+  - md5: 973f3f9fd7d9bb052002b52c99ce5a6f
+    size: 3516366848
+  name: Harukanaru Toki no Naka de 3 - Unmei no Labyrinth (Japan) (Premium Box)
+  serial: SLPM-66347
+  version: '1.02'
+- hashes:
+  - md5: c2a1ac3074edda69dc97dbd674bd1e71
+    size: 1269563392
+  name: Harukanaru Toki no Naka de - Maihitoyo (Japan) (Premium Box)
+  serial: SLPM-66545
+  version: '1.02'
+- hashes:
+  - md5: ab934936c8b1d62ce55f37998640049b
+    size: 295949808
+  name: C@m Station (Japan) (Doukonban)
+  serial: SLPS-20406
+  version: '1.05'
+- hashes:
+  - md5: 877026e92bc3087601156015e25936b1
+    size: 1847394304
+  name: Ppoi! Hito Natsu no Keiken! (Japan) (Genteiban)
+  serial: SLPM-55011
+  version: '1.02'
+- hashes:
+  - md5: a715f2379ca7954c2cb33ea7efcdf9e4
+    size: 3963289600
+  name: Yumemi Hakusho - Second Dream (Japan) (Shokai Genteiban)
+  serial: SLPM-55070
+  version: '1.00'
+- hashes:
+  - md5: e4f499041c44b931351f8fc6646b3174
+    size: 4481515520
+  name: Final Approach (Japan) (Shokai Genteiban)
+  serial: SLPM-65675
+  version: '1.00'
+- hashes:
+  - md5: d3079eb7f1c758281bf9c46175a241d5
+    size: 594602064
+  name: Matching Maker (Japan)
+  serial: SLPM-62066
+  version: '1.03'
+- hashes:
+  - md5: 66323f1eb8b806a463762965d245e69d
+    size: 4329373696
+  name: Memories Off - Sorekara (Japan)
+  serial: SLPM-65610
+  version: '1.01'
+- hashes:
+  - md5: 041f2ba6e9a641abdf64841eaee65101
+    size: 4625367040
+  name: Happy Breeding - Cheerful Party (Japan)
+  serial: SLPM-65220
+  version: '1.02'
+- hashes:
+  - md5: 700aa2bf74e1341ca5a1adc7160c9820
+    size: 4408639488
+  name: Aoi Shiro (Japan)
+  serial: SLPM-66959
+  version: '1.02'
+- hashes:
+  - md5: e9c1c2538af3ddff87f8e3fadd15e504
+    size: 4362469376
+  name: Neo Atlas III (Japan) (v1.00)
+  serial: SLPS-25016
+  version: '1.00'
+- hashes:
+  - md5: 853fd2be7e11862862362ea10a892f4a
+    size: 1738833920
+  name: My Merry May (Japan)
+  serial: SLPS-25193
+  version: '1.03'
+- hashes:
+  - md5: f79bbcb1768c2836a2ad67132adcb7ff
+    size: 1394343936
+  name: Kaitou Apricot Kanzenban (Japan)
+  serial: SLPS-25424
+  version: '1.03'
+- hashes:
+  - md5: 811836973327e8a98ba027ce0a9e12d9
+    size: 182145936
+  name: Inu to Asobou - Dogstation (Japan) (USB Mic Doukonban)
+  serial: SLPM-62260
+  version: '1.03'
+- hashes:
+  - md5: a51ca5aca433700bcdef118772d52624
+    size: 718702992
+  name: GameShark 2 - Video Game Enhancer (USA) (Unl) (v1.2)
+  version: '1.2'
+- hashes:
+  - md5: ab659235456ff67be77714eb8c34f892
+    size: 4453662720
+  name: WWE SmackDown vs. Raw 2007 (USA) (v2.01)
+  serial: SLUS-21427
+  version: '2.01'
+- hashes:
+  - md5: fd9f690efea15aad0eb0fb680ad03300
+    size: 1903525888
+  name: Hello Kitty - Mission Rescue (Korea)
+  serial: SLKA-25279
+  version: '1.00'
+- hashes:
+  - md5: 3399bfbc0ce50fc5d3d4ab3fa4d94ed5
+    size: 634654272
+  name: International Superstar Soccer 2 (Korea)
+  serial: SLPM-64510
+  version: '1.00'
+- hashes:
+  - md5: 4cde5b2f7c749497bed396e15be6aa3b
+    size: 4510285824
+  name: MX vs. ATV Unleashed (Korea)
+  serial: SLKA-25282
+  version: '1.00'
+- hashes:
+  - md5: 85cd1b9ac9058f802ca1615477c96ad6
+    size: 1237450752
+  name: Peter Jackson's King Kong - The Official Game of the Movie (Korea)
+  serial: SLKA-25337
+  version: '1.00'
+- hashes:
+  - md5: 6afc9d13fcb62bb63b18a3b7975772b1
+    size: 4698767360
+  name: Sonic Mega Collection Plus (Korea)
+  serial: SLKA-25233
+  version: '1.00'
+- hashes:
+  - md5: b7b07fb4020a6049a9ef932ee30eb70b
+    size: 1307367424
+  name: Open Season (Europe) (En,Fr,De,Es,It,Nl,Sv,No,Da,Fi) (Beta) (2006-09-15)
+  version: '1.01'
+- hashes:
+  - md5: aabf1c440c1da04e0e2a661a3b6c1039
+    size: 1239285760
+  name: Dynasty Warriors 4 (Europe) (Demo)
+  serial: SLED-51849
+  version: '1.00'
+- hashes:
+  - md5: f063b1563d194a82fc5f5669c4676ac7
+    size: 761692848
+  name: GameShark 2 - Video Game Enhancer - Version 2 Lite (USA)
+  version: '2.13'
+- hashes:
+  - md5: 4da29291047492ee17e1e3e9fcff58d1
+    size: 3660414976
+  name: Zero - Bulgeun Nabi (Korea)
+  serial: SCKA-20023
+  version: '1.02'
+- hashes:
+  - md5: 2e05c350ae460e2388a9f5a06552a917
+    size: 761692848
+  name: Action Replay Ultimate Cheats for WWF SmackDown! Just Bring It (Europe) (Unl)
+  version: '1.2'
+- hashes:
+  - md5: a5960170dfae5748751833ca58aa4f2c
+    size: 718702992
+  name: PlayStation 2 Cheats - Volume 14 (UK) (Unl)
+  version: 1.00 beta (European)
+- hashes:
+  - md5: eecc7db867381b424ab6f56e8c93f90a
+    size: 122576832
+  name: Play TV 98 (UK) (Unl)
+  serial: DVD-007
+- hashes:
+  - md5: fc273893229b3bb44953ab12d898d025
+    size: 159656112
+  name: Play TV 96 (UK) (Unl)
+  serial: DVD-005
+  version: '1.30'
+- hashes:
+  - md5: c8f676bd57a3774c8dd1a1782303ee56
+    size: 761692848
+  name: Action Replay Ultimate Cheats for Final Fantasy X (UK) (Unl)
+  version: '1.3'
+- hashes:
+  - md5: d771fc08d4ccfd72d4278871dc965b95
+    size: 34125168
+  name: Action Replay Ultimate Cheats for Spider-Man (UK) (Unl)
+  version: '1.1'
+- hashes:
+  - md5: 44745a485b06f8158028c589fbec5823
+    size: 761692848
+  name: Interactive PlayStation 2 Cheats (UK) (Unl)
+  version: 1.00 EUROPE
+- hashes:
+  - md5: 1de5f123315fea8b0e2c5392ab9dfb26
+    size: 718702992
+  name: PlayStation 2 Cheats - Volume 9 (UK) (Unl)
+  version: 1.00 (European)
+- hashes:
+  - md5: 946edae14721fa02123a61121d01be65
+    size: 718702992
+  name: P2 Cheats - Volume 21 (UK) (Unl)
+  version: 1.00 beta (European)
+- hashes:
+  - md5: fba9bd5690a8adc0884ba60ff5895e66
+    size: 761692848
+  name: Best Cheat Disc in the World... Volume 2, The (UK) (Unl)
+  version: bcitwe2 EUROPE
+- hashes:
+  - md5: 38604ca2f1764e1b3929276a9be566bc
+    size: 761692848
+  name: Xtreme Cheats (UK) (Unl) (03042801)
+  version: COMET_01 EUROPE
+- hashes:
+  - md5: 47ad5f91e709e6ab5c7d698555778a0f
+    size: 761692848
+  name: Xtreme Cheats - Top 10 (UK) (Unl)
+  version: 1.00beta (European)
+- hashes:
+  - md5: b22b49d71d8068a13cb94244ce14194c
+    size: 761692848
+  name: Playable Cheats Vol. 10 (UK) (Unl)
+  version: 1.00 (European)
+- hashes:
+  - md5: 7b28fe17803bb08b2f2bb15164230be0
+    size: 718702992
+  name: Playable Cheats Vol. 19 (UK) (Unl)
+  version: 1.00 (European)
+- hashes:
+  - md5: 2c90c482f723ba62d806493c89aa370a
+    size: 718702992
+  name: Playable Cheats Vol. 36 (UK) (Unl)
+  version: 1.00 beta (European)
+- hashes:
+  - md5: 3a96b5e746012c7d5a8b3f3e9e915e03
+    size: 718702992
+  name: Playable Cheats Vol. 17 (UK) (Unl)
+  version: 1.00 (European)
+- hashes:
+  - md5: 1b2f6e497bc62a87006f3d5343f525f7
+    size: 718702992
+  name: Playable Cheats Vol. 15 (UK) (Unl)
+  version: 1.00 (European)
+- hashes:
+  - md5: 0630c0e14d30115949739f851a44f365
+    size: 718702992
+  name: Playable Cheats Vol. 16 (UK) (Unl)
+  version: 1.00 (European)
+- hashes:
+  - md5: 444385296b7765db066ce2f93e7098b3
+    size: 718702992
+  name: Playable Cheats Vol. 13 (UK) (Unl)
+  version: 1.00 (European)
+- hashes:
+  - md5: aaf42cc38d27e01353d0ab3836909a75
+    size: 524601840
+  name: Crash Bandicoot - Mawangui Buhwal (Korea) (En)
+  serial: SLPM-64509
+  version: '1.01'
+- hashes:
+  - md5: 0daa26102a44ace104bd4a5f10d125b7
+    size: 4698734592
+  name: FIFA Street (Korea) (En,Es)
+  serial: SLKA-25235
+  version: '1.00'
+- hashes:
+  - md5: 08509d3c3e85d95be87ace86d16b2f7b
+    size: 3524132864
+  name: FlatOut 2 (Korea)
+  serial: SLKA-25401
+  version: '1.01'
+- hashes:
+  - md5: 8558acf83d12323e9e39ec3f0ae5a276
+    size: 3730505728
+  name: Jin Samguk Mussang 4 - Empires (Korea)
+  serial: SLKA-25417
+  version: '1.00'
+- hashes:
+  - md5: 2e0374809ea159cb8297adfa36dc14c7
+    size: 4241784832
+  name: One Piece - Pirates Carnival (Korea)
+  serial: SLKA-25351
+  version: '1.01'
+- hashes:
+  - md5: 09ce7c2697c3c453aa60898ad03481a1
+    size: 4494131200
+  name: Shadow the Hedgehog (Korea) (En,Ja,Fr,De,Es,It)
+  serial: SLKA-25335
+  version: '1.00'
+- hashes:
+  - md5: 46a1429dff8a9f90f126506983775dd0
+    size: 1905033216
+  name: Sonic Riders (Korea) (En,Ja,Fr,De,Es,It)
+  serial: SLKA-25428
+  version: '1.00'
+- hashes:
+  - md5: 4e5c5d61bcf54fa0dd480c07aabf662b
+    size: 2291564544
+  name: Vexx (Korea)
+  serial: SLKA-25121
+  version: '1.00'
+- hashes:
+  - md5: 643eedb41d00210a62f82365193554c1
+    size: 2731835392
+  name: Wander and the Colossus (Korea)
+  serial: SCKA-20061
+  version: '1.00'
+- hashes:
+  - md5: 24a814a962f3970f66e3b5b165146ecb
+    size: 2082308096
+  name: Tabenasai - Demo + Video (Japan)
+  serial: SCED-53776
+  version: '1.00'
+- hashes:
+  - md5: c91f14e86db61887fb9397ce5733b652
+    size: 4300275712
+  name: MVP Baseball 2005 (Korea)
+  serial: SLKA-25278
+  version: '1.00'
+- hashes:
+  - md5: 1b732975d140b36c95dae6aafd643d7c
+    size: 161700000
+  name: Simple 2000 Series - The Catfight (Korea)
+  serial: SLKA-15041
+  version: '1.00'
+- hashes:
+  - md5: c25a02029d47ec0ae2a0af7437588deb
+    size: 2243788800
+  name: Super Monkey Ball Deluxe (Korea)
+  serial: SLKA-25290
+  version: '1.01'
+- hashes:
+  - md5: dcafdbcc7a2e57e7a0b20866c48ebe3a
+    size: 4132929536
+  name: SD Gundam - GGeneration Wars (Korea)
+  serial: SCKA-20139
+  version: '2.00'
+- hashes:
+  - md5: 5b315096f6bfc1897e52fec9c877b81d
+    size: 4250206208
+  name: Offizielle PlayStation 2 Magazin 13-2003, Das - Uncut Edition (Germany)
+  serial: SCED-51937
+  version: '1.00'
+- hashes:
+  - md5: 1e92d76707b9ab2b5a8869cfd5430540
+    size: 1240137728
+  name: Medal of Honor - Vanguard (Asia)
+  serial: SLAJ-25095
+  version: '1.00'
+- hashes:
+  - md5: 9e3287db934261004a31cfdc2c1f37cf
+    size: 761692848
+  name: Action Replay Ultimate Cheats for Use with V8 Supercars Australia - Race Driver
+    (Australia) (Unl)
+  version: V8SUP_AU EUROPE
+- hashes:
+  - md5: 04e408758058b80a487fb6dd9958eff1
+    size: 718702992
+  name: Playable Cheats Vol. 8 (Australia) (Unl)
+  version: 1.00 (European)
+- hashes:
+  - md5: d0ff6000a8507a3abcfd4fd654e268aa
+    size: 718702992
+  name: PlayStation 2 Cheats - Volume 7 (Australia) (Unl)
+  version: 1.00 (European)
+- hashes:
+  - md5: 8b26b6eb63ce602d8aa2991d15922423
+    size: 642512304
+  name: Twisted Metal - Black Online (USA) (Beta)
+  serial: SCUS-97860
+  version: '1.00'
+- hashes:
+  - md5: 7c9ca942c6799dba569be36e6909e2c1
+    size: 4203347968
+  name: All-Star Baseball 2004 featuring Derek Jeter (Korea)
+  serial: SLKA-25057
+  version: '1.03'
+- hashes:
+  - md5: e840ca26a64331d1fcaeda1eedd20822
+    size: 761692848
+  name: GamePro Action Disc Dec 2003 - The Making of Dragon Ball Z (USA)
+  version: 1.00 (American)
+- hashes:
+  - md5: f395565e4845d0164e3376dd5692902b
+    size: 3919609856
+  name: Black (Korea)
+  serial: SLKA-25372
+  version: '1.00'
+- hashes:
+  - md5: f33fb1b516cfbbd78148b26000dea31c
+    size: 3559030784
+  name: King of Fighters 2002, The (Korea)
+  serial: SLKA-25275
+  version: '1.02'
+- hashes:
+  - md5: 481d5aad38c7db5d92466c14402f3d9a
+    size: 1812627456
+  name: King of Fighters 2003, The (Korea)
+  serial: SLKA-25276
+  version: '1.02'
+- hashes:
+  - md5: 7f697d17240e4d3521e9d80b1d862ca1
+    size: 1281261568
+  name: King of Fighters Collection, The - The Orochi Saga (Korea)
+  serial: SLKA-25458
+  version: '1.00'
+- hashes:
+  - md5: 307fc373431205cbddd803ec3d11a530
+    size: 4698734592
+  name: UEFA Champions League 2006-2007 (Korea)
+  serial: SLKA-25256
+  version: '1.00'
+- hashes:
+  - md5: 1e5454dcb9055c8d23fd58ebe01df60e
+    size: 1634271232
+  name: Disney-Pixar The Incredibles (Korea)
+  serial: SLKA-25226
+  version: '1.01'
+- hashes:
+  - md5: 3e63edc6b26120a21ecf728a68442f74
+    size: 2493448192
+  name: Tourist Trophy - The Real Riding Simulator (Japan) (Taikenban)
+  serial: PCPX-96660
+  version: '1.00'
+- hashes:
+  - md5: 731160f0a8c0fd6857f953197339cdb1
+    size: 2101379072
+  name: Fight Night Round 3 (Korea)
+  serial: SLKA-25373
+  version: '1.01'
+- hashes:
+  - md5: 8255a92335bc6402061c49dbf5408126
+    size: 1374158848
+  name: Mission - Impossible - Operation Surma (Korea)
+  serial: SLKA-25028
+  version: '1.02'
+- hashes:
+  - md5: ec974e395178d066b6d7a28230bda96a
+    size: 4391763968
+  name: MLB 11 - The Show (Korea)
+  serial: SCKA-20142
+  version: '1.00'
+- hashes:
+  - md5: 30ba38933863a46954649dc6d6ad7e2e
+    size: 745619280
+  name: Shox (Korea)
+  serial: SLPM-64524
+  version: '1.01'
+- hashes:
+  - md5: e0fda0951c3f40748d2b8a1c668c85c9
+    size: 270141312
+  name: Simple 2000 Series - The Chanbara (Korea)
+  serial: SLKA-15045
+  version: '1.02'
+- hashes:
+  - md5: cd2b655886ddd91e201a25f1349f4694
+    size: 1981186048
+  name: Star Wars - Jedi Starfighter (Korea)
+  serial: SLPM-67543
+  version: '1.01'
+- hashes:
+  - md5: 8ab277db647ba82d40267cd213fc3f9b
+    size: 761692848
+  name: CD avec les Codes Action Replay Exclusivement pour le Jeu Tom Clancy's Splinter
+    Cell (France) (Unl)
+  version: SPLINTER EUROPE
+- hashes:
+  - md5: 6e9d64caa3175778bde0f07fc181b1de
+    size: 761692848
+  name: Playcodes Disc02 (France) (Unl)
+  version: PLAYCOD2 EUROPE
+- hashes:
+  - md5: f6d8b98b72d9e890c6ee3e051a53ab9a
+    size: 761692848
+  name: CD avec les Codes Exclusifs et Inedits de Harry Potter et la Chambre des Secrets
+    (France) (Unl)
+  version: '1.30'
+- hashes:
+  - md5: bbd0042997eae4f6dace6f2b08dc9b14
+    size: 718702992
+  name: Playcodes Disc06 (France) (Unl)
+  version: 1.00 (European)
+- hashes:
+  - md5: e2790a6c9f033c1f5180dfc8efce7c3c
+    size: 761692848
+  name: Action Replay Ultimate Cheats for Use with The Sims (UK) (Unl)
+  version: THE_SIMS EUROPE
+- hashes:
+  - md5: 8b05a780a33223fa68e5f666a86766c4
+    size: 718702992
+  name: CD avec les Codes Action Replay Exclusivement pour le Jeu Gran Turismo 4 (France)
+    (Unl)
+  version: 1.00 beta (European)
+- hashes:
+  - md5: 56c9fd7aa3b9abfaf742f64bdfa03360
+    size: 4685824000
+  name: Thrillville - Off the Rails (Korea)
+  serial: SLKA-25343
+  version: '1.00'
+- hashes:
+  - md5: 60a050913da495d695ca643213dc9f5f
+    size: 3631218688
+  name: Guitar Hero - Aerosmith (Korea) (En,Fr)
+  serial: SLKA-25434
+  version: '1.00'
+- hashes:
+  - md5: 7fd4f3f3722b0876d414b1f02d3f51be
+    size: 174055056
+  name: RedCard (Europe) (Demo)
+  serial: SLED-50931
+  version: '1.00'

--- a/pcsx2/GS/Renderers/HW/GSHwHack.cpp
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.cpp
@@ -581,22 +581,6 @@ bool GSHwHack::GSC_SteambotChronicles(GSRendererHW& r, int& skip)
 	return true;
 }
 
-bool GSHwHack::GSC_GetawayGames(GSRendererHW& r, int& skip)
-{
-	if (GSConfig.AccurateBlendingUnit >= AccBlendLevel::High)
-		return true;
-
-	if (skip == 0)
-	{
-		if ((RFBP == 0 || RFBP == 0x1180 || RFBP == 0x1400) && RTPSM == PSMT8H && RFBMSK == 0)
-		{
-			skip = 1; // Removes fog wall.
-		}
-	}
-
-	return true;
-}
-
 bool GSHwHack::GSC_NFSUndercover(GSRendererHW& r, int& skip)
 {
 	// NFS Undercover does a weird texture shuffle by page, which really isn't supported by our TC.
@@ -1501,9 +1485,6 @@ const GSHwHack::Entry<GSRendererHW::GSC_Ptr> GSHwHack::s_get_skip_count_function
 
 	// Upscaling hacks
 	CRC_F(GSC_UltramanFightingEvolution),
-
-	// Accurate Blending
-	CRC_F(GSC_GetawayGames),
 };
 
 const GSHwHack::Entry<GSRendererHW::OI_Ptr> GSHwHack::s_before_draw_functions[] = {

--- a/pcsx2/GS/Renderers/HW/GSHwHack.h
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.h
@@ -24,7 +24,6 @@ public:
 	static bool GSC_Simple2000Vol114(GSRendererHW& r, int& skip);
 	static bool GSC_UrbanReign(GSRendererHW& r, int& skip);
 	static bool GSC_SteambotChronicles(GSRendererHW& r, int& skip);
-	static bool GSC_GetawayGames(GSRendererHW& r, int& skip);
 	static bool GSC_BlueTongueGames(GSRendererHW& r, int& skip);
 	static bool GSC_Battlefield2(GSRendererHW& r, int& skip);
 	static bool GSC_NFSUndercover(GSRendererHW& r, int& skip);

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -3126,6 +3126,11 @@ void VMManager::WarnAboutUnsafeSettings()
 		append(ICON_FA_EXCLAMATION_CIRCLE,
 			TRANSLATE_SV("VMManager", "Estimate texture region is enabled, this may reduce performance."));
 	}
+	if (EmuConfig.GS.DumpReplaceableTextures)
+	{
+		append(ICON_FA_EXCLAMATION_CIRCLE,
+			TRANSLATE_SV("VMManager", "Texture dumping is enabled, this will continually dump textures to disk."));
+	}
 
 	if (!messages.empty())
 	{


### PR DESCRIPTION
### Description of Changes
We do a little fixing.

Fixes #11057 
Fixes #11074 

Reservoir dogs before:
![Reservoir Dogs_SLUS-21479_20240405124504](https://github.com/PCSX2/pcsx2/assets/80843560/46bb7d47-1794-4bb8-8aca-c1f4222caf7c)

After:
![Reservoir Dogs_SLUS-21479_20240405124506](https://github.com/PCSX2/pcsx2/assets/80843560/9e7e168b-10de-42e0-af23-408761ebf12f)

The Getaway before:
![The Getaway_SCUS-97133_20240412015624](https://github.com/PCSX2/pcsx2/assets/80843560/3842e59c-7d10-4aa2-a1f8-94349a97685d)

After:
![The Getaway_SCUS-97133_20240412015632](https://github.com/PCSX2/pcsx2/assets/80843560/fa967882-7a02-440f-b89d-9a06859c0ebe)

### Rationale behind Changes
Fix good.

### Suggested Testing Steps
Make sure CI is happy.
