### PR TITLE
BPM: Light Mode color scheme update

### DIFF
--- a/pcsx2/ImGui/ImGuiFullscreen.cpp
+++ b/pcsx2/ImGui/ImGuiFullscreen.cpp
@@ -2706,19 +2706,19 @@ void ImGuiFullscreen::SetTheme(bool light)
 	else
 	{
 		// light
-		UIBackgroundColor = HEX_TO_IMVEC4(0xf5f5f6, 0xff);
+		UIBackgroundColor = HEX_TO_IMVEC4(0xc8c8c8, 0xff);
 		UIBackgroundTextColor = HEX_TO_IMVEC4(0x000000, 0xff);
 		UIBackgroundLineColor = HEX_TO_IMVEC4(0xe1e2e1, 0xff);
 		UIBackgroundHighlightColor = HEX_TO_IMVEC4(0xe1e2e1, 0xff);
-		UIPrimaryColor = HEX_TO_IMVEC4(0x0d47a1, 0xff);
-		UIPrimaryLightColor = HEX_TO_IMVEC4(0x5472d3, 0xff);
-		UIPrimaryDarkColor = HEX_TO_IMVEC4(0x002171, 0xff);
+		UIPrimaryColor = HEX_TO_IMVEC4(0x2a3e78, 0xff);
+		UIPrimaryLightColor = HEX_TO_IMVEC4(0x235cd9, 0xff);
+		UIPrimaryDarkColor = HEX_TO_IMVEC4(0x1d2953, 0xff);
 		UIPrimaryTextColor = HEX_TO_IMVEC4(0xffffff, 0xff);
-		UIDisabledColor = HEX_TO_IMVEC4(0xaaaaaa, 0xff);
+		UIDisabledColor = HEX_TO_IMVEC4(0x999999, 0xff);
 		UITextHighlightColor = HEX_TO_IMVEC4(0x8e8e8e, 0xff);
 		UIPrimaryLineColor = HEX_TO_IMVEC4(0x000000, 0xff);
-		UISecondaryColor = HEX_TO_IMVEC4(0x3d5afe, 0xff);
-		UISecondaryStrongColor = HEX_TO_IMVEC4(0x0031ca, 0xff);
+		UISecondaryColor = HEX_TO_IMVEC4(0x2a3e78, 0xff);
+		UISecondaryStrongColor = HEX_TO_IMVEC4(0x464db1, 0xff);
 		UISecondaryWeakColor = HEX_TO_IMVEC4(0xc0cfff, 0xff);
 		UISecondaryTextColor = HEX_TO_IMVEC4(0x000000, 0xff);
 	}


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
*For those of you fine folks who doesn't like to be in the dark, here's a present...*

This PR tweaks the color scheme of BPM's Light Mode to be less bright, with less saturated blue accent color, and no more eye-burning.

### Preview

#### Before

![Screenshot_20240410_153841](https://github.com/PCSX2/pcsx2/assets/14798312/541fdca1-13bd-47f0-b91d-0273ccfad65a)

![Screenshot_20240410_153857](https://github.com/PCSX2/pcsx2/assets/14798312/55bdedc1-b582-4579-a9c7-568fd89cf260)

![Screenshot_20240410_153950](https://github.com/PCSX2/pcsx2/assets/14798312/772ef717-d8d2-47af-90ee-ce419ab0c17c)

#### After

![Screenshot_20240410_154014](https://github.com/PCSX2/pcsx2/assets/14798312/32049ecd-ed04-4b0d-ae32-da951eeb8b7a)

![Screenshot_20240410_154025](https://github.com/PCSX2/pcsx2/assets/14798312/1953fbcf-6979-46f5-922a-d2fd0e862ba5)

![Screenshot_20240410_154029](https://github.com/PCSX2/pcsx2/assets/14798312/2a792f8d-8f1c-4d63-9b9d-7a720f3a2374)

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->

Hopefully less retinas being burned.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->

See if it looks good.