### PR TITLE
Chores: VK validation fixes, Qt 6.7 deprecation fixes, Flatpak build consistency

### DIFF
--- a/.github/workflows/scripts/common/shaderc-changes.patch
+++ b/.github/workflows/scripts/common/shaderc-changes.patch
@@ -1,3 +1,13 @@
+--- a/CHANGES
++++ b/CHANGES
+@@ -1,6 +1,6 @@
+ Revision history for Shaderc
+ 
+-v2024.0
++v2024.0 2024-03-09
+  - Update dependencies
+  - Utilities:
+     - Use Python3 explicitly in utility scripts
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -117,6 +117,9 @@ if(MSVC)
@@ -93,34 +103,118 @@
  if(${SHADERC_ENABLE_TESTS})
    add_executable(shaderc_c_smoke_test ./src/shaderc_c_smoke_test.c)
    shaderc_default_c_compile_options(shaderc_c_smoke_test)
-diff --git a/libshaderc_util/src/compiler.cc b/libshaderc_util/src/compiler.cc
-index e5f5d10..f4f0fef 100644
+--- a/libshaderc/include/shaderc/shaderc.h
++++ b/libshaderc/include/shaderc/shaderc.h
+@@ -319,6 +319,10 @@ SHADERC_EXPORT void shaderc_compile_options_set_source_language(
+ SHADERC_EXPORT void shaderc_compile_options_set_generate_debug_info(
+     shaderc_compile_options_t options);
+ 
++// Sets the compiler mode to emit non-semantic debug information in the output.
++SHADERC_EXPORT void shaderc_compile_options_set_emit_non_semantic_debug_info(
++    shaderc_compile_options_t options);
++
+ // Sets the compiler optimization level to the given level. Only the last one
+ // takes effect if multiple calls of this function exist.
+ SHADERC_EXPORT void shaderc_compile_options_set_optimization_level(
+--- a/libshaderc/include/shaderc/shaderc.hpp
++++ b/libshaderc/include/shaderc/shaderc.hpp
+@@ -172,6 +172,12 @@ class CompileOptions {
+     shaderc_compile_options_set_generate_debug_info(options_);
+   }
+ 
++  // Sets the compiler mode to emit non-semantic debug information in the
++  // output.
++  void SetEmitNonSemanticDebugInfo() {
++    shaderc_compile_options_set_emit_non_semantic_debug_info(options_);
++  }
++
+   // Sets the compiler optimization level to the given level. Only the last one
+   // takes effect if multiple calls of this function exist.
+   void SetOptimizationLevel(shaderc_optimization_level level) {
+--- a/libshaderc/src/shaderc.cc
++++ b/libshaderc/src/shaderc.cc
+@@ -422,6 +422,11 @@ void shaderc_compile_options_set_generate_debug_info(
+   options->compiler.SetGenerateDebugInfo();
+ }
+ 
++void shaderc_compile_options_set_emit_non_semantic_debug_info(
++    shaderc_compile_options_t options) {
++  options->compiler.SetEmitNonSemanticDebugInfo();
++}
++
+ void shaderc_compile_options_set_optimization_level(
+     shaderc_compile_options_t options, shaderc_optimization_level level) {
+   auto opt_level = shaderc_util::Compiler::OptimizationLevel::Zero;
+--- a/libshaderc_util/include/libshaderc_util/compiler.h
++++ b/libshaderc_util/include/libshaderc_util/compiler.h
+@@ -195,6 +195,7 @@ class Compiler {
+         warnings_as_errors_(false),
+         suppress_warnings_(false),
+         generate_debug_info_(false),
++        emit_non_semantic_debug_info_(false),
+         enabled_opt_passes_(),
+         target_env_(TargetEnv::Vulkan),
+         target_env_version_(TargetEnvVersion::Default),
+@@ -220,6 +221,10 @@ class Compiler {
+   // such as identifier names and line numbers.
+   void SetGenerateDebugInfo();
+ 
++  // Requests that the compiler emit non-semantic debug information.
++  // Requires VK_KHR_shader_non_semantic_info.
++  void SetEmitNonSemanticDebugInfo();
++
+   // Sets the optimization level to the given level. Only the last one takes
+   // effect if multiple calls of this method exist.
+   void SetOptimizationLevel(OptimizationLevel level);
+@@ -486,6 +491,10 @@ class Compiler {
+   // output.
+   bool generate_debug_info_;
+ 
++  // When true and generate_debug_info_ is also set, generate non-semantic debug
++  // information.
++  bool emit_non_semantic_debug_info_;
++
+   // Optimization passes to be applied.
+   std::vector<PassId> enabled_opt_passes_;
+ 
 --- a/libshaderc_util/src/compiler.cc
 +++ b/libshaderc_util/src/compiler.cc
-@@ -341,6 +341,10 @@ std::tuple<bool, std::vector<uint32_t>, size_t> Compiler::Compile(
+@@ -341,6 +341,11 @@ std::tuple<bool, std::vector<uint32_t>, size_t> Compiler::Compile(
    options.generateDebugInfo = generate_debug_info_;
    options.disableOptimizer = true;
    options.optimizeSize = false;
-+  if (generate_debug_info_) {
-+    options.emitNonSemanticShaderDebugInfo = true;
-+    options.emitNonSemanticShaderDebugSource = true;
-+  }
++  options.emitNonSemanticShaderDebugInfo =
++      generate_debug_info_ && emit_non_semantic_debug_info_;
++  options.emitNonSemanticShaderDebugSource =
++      generate_debug_info_ && emit_non_semantic_debug_info_;
++
    // Note the call to GlslangToSpv also populates compilation_output_data.
    glslang::GlslangToSpv(*program.getIntermediate(used_shader_stage), spirv,
                          &options);
+@@ -438,6 +443,10 @@ void Compiler::SetGenerateDebugInfo() {
+   }
+ }
+ 
++void Compiler::SetEmitNonSemanticDebugInfo() {
++  emit_non_semantic_debug_info_ = true;
++}
++
+ void Compiler::SetOptimizationLevel(Compiler::OptimizationLevel level) {
+   // Clear previous settings first.
+   enabled_opt_passes_.clear();
 --- a/third_party/CMakeLists.txt
 +++ b/third_party/CMakeLists.txt
 @@ -20,9 +20,9 @@ set(SHADERC_TINT_DIR "${SHADERC_THIRD_PARTY_ROOT_DIR}/tint" CACHE STRING
  set(SHADERC_ABSL_DIR "${SHADERC_THIRD_PARTY_ROOT_DIR}/abseil_cpp" CACHE STRING
    "Location of re2 source")
-
+ 
 -set( SKIP_GLSLANG_INSTALL ${SHADERC_SKIP_INSTALL} )
 -set( SKIP_SPIRV_TOOLS_INSTALL ${SHADERC_SKIP_INSTALL} )
 -set( SKIP_GOOGLETEST_INSTALL ${SHADERC_SKIP_INSTALL} )
 +set( SKIP_GLSLANG_INSTALL ON )
 +set( SKIP_SPIRV_TOOLS_INSTALL ON )
 +set( SKIP_GOOGLETEST_INSTALL ON )
-
+ 
  # Configure third party projects.
  if(${SHADERC_ENABLE_TESTS})
 @@ -64,7 +64,10 @@ if (NOT TARGET SPIRV-Tools)
@@ -136,7 +230,7 @@ index e5f5d10..f4f0fef 100644
        if (MSVC)
          if (${MSVC_VERSION} LESS 1920)
 @@ -83,7 +86,7 @@ endif()
-
+ 
  if (NOT TARGET glslang)
    if (IS_DIRECTORY ${SHADERC_GLSLANG_DIR})
 -    add_subdirectory(${SHADERC_GLSLANG_DIR} glslang)

--- a/.github/workflows/scripts/linux/build-dependencies-qt.sh
+++ b/.github/workflows/scripts/linux/build-dependencies-qt.sh
@@ -306,7 +306,7 @@ mv "SPIRV-Headers-$SHADERC_SPIRVHEADERS" "spirv-headers"
 tar xf "../../shaderc-spirv-tools-$SHADERC_SPIRVTOOLS.tar.gz"
 mv "SPIRV-Tools-$SHADERC_SPIRVTOOLS" "spirv-tools"
 cd ..
-patch -p1 < "$SCRIPTDIR/../common/shaderc-install.patch"
+patch -p1 < "$SCRIPTDIR/../common/shaderc-changes.patch"
 cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH="$INSTALLDIR" -DCMAKE_INSTALL_PREFIX="$INSTALLDIR" -DSHADERC_SKIP_TESTS=ON -DSHADERC_SKIP_EXAMPLES=ON -DSHADERC_SKIP_COPYRIGHT_CHECK=ON -B build -G Ninja
 cmake --build build --parallel
 ninja -C build install

--- a/.github/workflows/scripts/linux/flatpak/modules/20-sdl2.json
+++ b/.github/workflows/scripts/linux/flatpak/modules/20-sdl2.json
@@ -1,26 +1,12 @@
 {
   "name": "sdl2",
-  "buildsystem": "autotools",
-  "no-autogen": true,
+  "buildsystem": "cmake-ninja",
+  "builddir": true,
   "config-opts": [
-    "--disable-dbus",
-    "--without-x",
-    "--disable-video-opengl",
-    "--disable-video-opengles",
-    "--disable-video-vulkan",
-    "--disable-wayland-shared",
-    "--disable-ime",
-    "--disable-oss",
-    "--disable-alsa",
-    "--disable-jack",
-    "--disable-esd",
-    "--disable-pipewire",
-    "--disable-pulseaudio",
-    "--disable-arts",
-    "--disable-nas",
-    "--disable-sndio",
-    "--disable-fusionsound",
-    "--disable-diskaudio"
+    "-DBUILD_SHARED_LIBS=ON",
+    "-DSDL_SHARED=ON",
+    "-DSDL_STATIC=OFF",
+    "-DSDL_TESTS=OFF"
   ],
   "build-options": {
     "strip": true
@@ -42,4 +28,3 @@
     "/share/aclocal"
   ]
 }
-

--- a/.github/workflows/scripts/linux/flatpak/modules/22-shaderc.json
+++ b/.github/workflows/scripts/linux/flatpak/modules/22-shaderc.json
@@ -3,6 +3,7 @@
   "buildsystem": "cmake-ninja",
   "builddir": true,
   "config-opts": [
+    "-DCMAKE_BUILD_TYPE=Release",
     "-DSHADERC_SKIP_TESTS=ON",
     "-DSHADERC_SKIP_EXAMPLES=ON",
     "-DSHADERC_SKIP_COPYRIGHT_CHECK=ON"
@@ -36,7 +37,7 @@
     },
     {
       "type": "patch",
-      "path": "../../../common/shaderc-install.patch"
+      "path": "../../../common/shaderc-changes.patch"
     }
   ],
   "cleanup": [

--- a/.github/workflows/scripts/linux/flatpak/net.pcsx2.PCSX2.json
+++ b/.github/workflows/scripts/linux/flatpak/net.pcsx2.PCSX2.json
@@ -1,7 +1,7 @@
 {
   "app-id": "net.pcsx2.PCSX2",
   "runtime": "org.kde.Platform",
-  "runtime-version": "6.6",
+  "runtime-version": "6.7",
   "sdk": "org.kde.Sdk",
   "sdk-extensions": [
     "org.freedesktop.Sdk.Extension.llvm17"

--- a/.github/workflows/scripts/macos/build-dependencies.sh
+++ b/.github/workflows/scripts/macos/build-dependencies.sh
@@ -297,7 +297,7 @@ mv "SPIRV-Headers-$SHADERC_SPIRVHEADERS" "spirv-headers"
 tar xf "../../shaderc-spirv-tools-$SHADERC_SPIRVTOOLS.tar.gz"
 mv "SPIRV-Tools-$SHADERC_SPIRVTOOLS" "spirv-tools"
 cd ..
-patch -p1 < "$SCRIPTDIR/../common/shaderc-install.patch"
+patch -p1 < "$SCRIPTDIR/../common/shaderc-changes.patch"
 cmake "${CMAKE_COMMON[@]}" "$CMAKE_ARCH_UNIVERSAL" -DSHADERC_SKIP_TESTS=ON -DSHADERC_SKIP_EXAMPLES=ON -DSHADERC_SKIP_COPYRIGHT_CHECK=ON -B build
 make -C build "-j$NPROCS"
 make -C build install

--- a/.github/workflows/scripts/windows/build-dependencies.bat
+++ b/.github/workflows/scripts/windows/build-dependencies.bat
@@ -250,7 +250,7 @@ rename "SPIRV-Headers-%SHADERC_SPIRVHEADERS%" "spirv-headers" || goto error
 %SEVENZIP% x "..\..\shaderc-spirv-tools-%SHADERC_SPIRVTOOLS%.zip" || goto error
 rename "SPIRV-Tools-%SHADERC_SPIRVTOOLS%" "spirv-tools" || goto error
 cd .. || goto error
-%PATCH% -p1 < "%SCRIPTDIR%\..\common\shaderc-install.patch" || goto error
+%PATCH% -p1 < "%SCRIPTDIR%\..\common\shaderc-changes.patch" || goto error
 cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH="%INSTALLDIR%" -DCMAKE_INSTALL_PREFIX="%INSTALLDIR%" -DSHADERC_SKIP_TESTS=ON -DSHADERC_SKIP_EXAMPLES=ON -DSHADERC_SKIP_COPYRIGHT_CHECK=ON -DSHADERC_ENABLE_SHARED_CRT=ON -B build -G Ninja || goto error
 cmake --build build --parallel || goto error
 ninja -C build install || goto error

--- a/pcsx2-qt/QtKeyCodes.cpp
+++ b/pcsx2-qt/QtKeyCodes.cpp
@@ -182,7 +182,7 @@ static constexpr const KeyCodeName s_qt_key_names[] = {
 	{Qt::Key_twosuperior, "twosuperior", nullptr},
 	{Qt::Key_threesuperior, "threesuperior", nullptr},
 	{Qt::Key_acute, "acute", nullptr},
-	{Qt::Key_mu, "mu", nullptr},
+	{Qt::Key_micro, "micro", nullptr},
 	{Qt::Key_paragraph, "paragraph", nullptr},
 	{Qt::Key_periodcentered, "periodcentered", nullptr},
 	{Qt::Key_cedilla, "cedilla", nullptr},

--- a/pcsx2-qt/SettingWidgetBinder.h
+++ b/pcsx2-qt/SettingWidgetBinder.h
@@ -252,7 +252,7 @@ namespace SettingWidgetBinder
 		template <typename F>
 		static void connectValueChanged(QCheckBox* widget, F func)
 		{
-			widget->connect(widget, &QCheckBox::stateChanged, func);
+			widget->connect(widget, &QCheckBox::checkStateChanged, func);
 		}
 	};
 

--- a/pcsx2-qt/Settings/AchievementSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/AchievementSettingsWidget.cpp
@@ -46,11 +46,11 @@ AchievementSettingsWidget::AchievementSettingsWidget(SettingsWindow* dialog, QWi
 	dialog->registerWidgetHelp(m_ui.spectatorMode, tr("Enable Spectator Mode"), tr("Unchecked"), tr("When enabled, PCSX2 will assume all achievements are locked and not send any unlock notifications to the server."));
 	dialog->registerWidgetHelp(m_ui.unofficialAchievements, tr("Test Unofficial Achievements"), tr("Unchecked"), tr("When enabled, PCSX2 will list achievements from unofficial sets. Please note that these achievements are not tracked by RetroAchievements, so they unlock every time."));
 
-	connect(m_ui.enable, &QCheckBox::stateChanged, this, &AchievementSettingsWidget::updateEnableState);
-	connect(m_ui.hardcoreMode, &QCheckBox::stateChanged, this, &AchievementSettingsWidget::updateEnableState);
-	connect(m_ui.hardcoreMode, &QCheckBox::stateChanged, this, &AchievementSettingsWidget::onHardcoreModeStateChanged);
-	connect(m_ui.achievementNotifications, &QCheckBox::stateChanged, this, &AchievementSettingsWidget::updateEnableState);
-	connect(m_ui.leaderboardNotifications, &QCheckBox::stateChanged, this, &AchievementSettingsWidget::updateEnableState);
+	connect(m_ui.enable, &QCheckBox::checkStateChanged, this, &AchievementSettingsWidget::updateEnableState);
+	connect(m_ui.hardcoreMode, &QCheckBox::checkStateChanged, this, &AchievementSettingsWidget::updateEnableState);
+	connect(m_ui.hardcoreMode, &QCheckBox::checkStateChanged, this, &AchievementSettingsWidget::onHardcoreModeStateChanged);
+	connect(m_ui.achievementNotifications, &QCheckBox::checkStateChanged, this, &AchievementSettingsWidget::updateEnableState);
+	connect(m_ui.leaderboardNotifications, &QCheckBox::checkStateChanged, this, &AchievementSettingsWidget::updateEnableState);
 	connect(m_ui.achievementNotificationsDuration, &QSlider::valueChanged, this, &AchievementSettingsWidget::onAchievementsNotificationDurationSliderChanged);
 	connect(m_ui.leaderboardNotificationsDuration, &QSlider::valueChanged, this, &AchievementSettingsWidget::onLeaderboardsNotificationDurationSliderChanged);
 

--- a/pcsx2-qt/Settings/AudioSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/AudioSettingsWidget.cpp
@@ -53,8 +53,8 @@ AudioSettingsWidget::AudioSettingsWidget(SettingsWindow* dialog, QWidget* parent
 	connect(m_ui.backend, &QComboBox::currentIndexChanged, this, &AudioSettingsWidget::outputBackendChanged);
 	connect(m_ui.targetLatency, &QSlider::valueChanged, this, &AudioSettingsWidget::updateLatencyLabels);
 	connect(m_ui.outputLatency, &QSlider::valueChanged, this, &AudioSettingsWidget::updateLatencyLabels);
-	connect(m_ui.outputLatencyMinimal, &QCheckBox::stateChanged, this, &AudioSettingsWidget::updateLatencyLabels);
-	connect(m_ui.outputLatencyMinimal, &QCheckBox::stateChanged, this, &AudioSettingsWidget::onMinimalOutputLatencyStateChanged);
+	connect(m_ui.outputLatencyMinimal, &QCheckBox::checkStateChanged, this, &AudioSettingsWidget::updateLatencyLabels);
+	connect(m_ui.outputLatencyMinimal, &QCheckBox::checkStateChanged, this, &AudioSettingsWidget::onMinimalOutputLatencyStateChanged);
 	outputModuleChanged();
 
 	m_ui.volume->setValue(m_dialog->getEffectiveIntValue("SPU2/Mixing", "FinalVolume", DEFAULT_VOLUME));

--- a/pcsx2-qt/Settings/BIOSSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/BIOSSettingsWidget.cpp
@@ -40,7 +40,7 @@ BIOSSettingsWidget::BIOSSettingsWidget(SettingsWindow* dialog, QWidget* parent)
 	connect(m_ui.searchDirectory, &QLineEdit::textChanged, this, &BIOSSettingsWidget::refreshList);
 	connect(m_ui.refresh, &QPushButton::clicked, this, &BIOSSettingsWidget::refreshList);
 	connect(m_ui.fileList, &QTreeWidget::currentItemChanged, this, &BIOSSettingsWidget::listItemChanged);
-	connect(m_ui.fastBoot, &QCheckBox::stateChanged, this, &BIOSSettingsWidget::fastBootChanged);
+	connect(m_ui.fastBoot, &QCheckBox::checkStateChanged, this, &BIOSSettingsWidget::fastBootChanged);
 }
 
 BIOSSettingsWidget::~BIOSSettingsWidget() = default;

--- a/pcsx2-qt/Settings/ControllerGlobalSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/ControllerGlobalSettingsWidget.cpp
@@ -20,7 +20,7 @@ ControllerGlobalSettingsWidget::ControllerGlobalSettingsWidget(QWidget* parent, 
 
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.enableSDLSource, "InputSources", "SDL", true);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.enableSDLEnhancedMode, "InputSources", "SDLControllerEnhancedMode", false);
-	connect(m_ui.enableSDLSource, &QCheckBox::stateChanged, this, &ControllerGlobalSettingsWidget::updateSDLOptionsEnabled);
+	connect(m_ui.enableSDLSource, &QCheckBox::checkStateChanged, this, &ControllerGlobalSettingsWidget::updateSDLOptionsEnabled);
 	connect(m_ui.ledSettings, &QToolButton::clicked, this, &ControllerGlobalSettingsWidget::ledSettingsClicked);
 
 #ifdef _WIN32
@@ -64,7 +64,7 @@ ControllerGlobalSettingsWidget::ControllerGlobalSettingsWidget(QWidget* parent, 
 	if (dialog->isEditingProfile())
 	{
 		m_ui.useProfileHotkeyBindings->setChecked(m_dialog->getBoolValue("Pad", "UseProfileHotkeyBindings", false));
-		connect(m_ui.useProfileHotkeyBindings, &QCheckBox::stateChanged, this, [this](int new_state) {
+		connect(m_ui.useProfileHotkeyBindings, &QCheckBox::checkStateChanged, this, [this](int new_state) {
 			m_dialog->setBoolValue("Pad", "UseProfileHotkeyBindings", (new_state == Qt::Checked));
 			emit bindingSetupChanged();
 		});
@@ -78,7 +78,7 @@ ControllerGlobalSettingsWidget::ControllerGlobalSettingsWidget(QWidget* parent, 
 	}
 
 	for (QCheckBox* cb : {m_ui.multitapPort1, m_ui.multitapPort2})
-		connect(cb, &QCheckBox::stateChanged, this, [this]() { emit bindingSetupChanged(); });
+		connect(cb, &QCheckBox::checkStateChanged, this, [this]() { emit bindingSetupChanged(); });
 
 	updateSDLOptionsEnabled();
 }

--- a/pcsx2-qt/Settings/DEV9SettingsWidget.cpp
+++ b/pcsx2-qt/Settings/DEV9SettingsWidget.cpp
@@ -59,7 +59,7 @@ DEV9SettingsWidget::DEV9SettingsWidget(SettingsWindow* dialog, QWidget* parent)
 	//but we then need to manually call onEthAutoChanged to update the UI on fist load
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.ethEnabled, "DEV9/Eth", "EthEnable", false);
 	onEthEnabledChanged(m_ui.ethEnabled->checkState());
-	connect(m_ui.ethEnabled, QOverload<int>::of(&QCheckBox::stateChanged), this, &DEV9SettingsWidget::onEthEnabledChanged);
+	connect(m_ui.ethEnabled, &QCheckBox::checkStateChanged, this, &DEV9SettingsWidget::onEthEnabledChanged);
 
 	//////////////////////////////////////////////////////////////////////////
 	// Eth Device Settings
@@ -146,7 +146,7 @@ DEV9SettingsWidget::DEV9SettingsWidget(SettingsWindow* dialog, QWidget* parent)
 	//////////////////////////////////////////////////////////////////////////
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.ethInterceptDHCP, "DEV9/Eth", "InterceptDHCP", false);
 	onEthDHCPInterceptChanged(m_ui.ethInterceptDHCP->checkState());
-	connect(m_ui.ethInterceptDHCP, QOverload<int>::of(&QCheckBox::stateChanged), this, &DEV9SettingsWidget::onEthDHCPInterceptChanged);
+	connect(m_ui.ethInterceptDHCP, &QCheckBox::checkStateChanged, this, &DEV9SettingsWidget::onEthDHCPInterceptChanged);
 
 	//IP settings
 	const IPValidator* ipValidator = new IPValidator(this, m_dialog->isPerGameSettings());
@@ -191,11 +191,11 @@ DEV9SettingsWidget::DEV9SettingsWidget(SettingsWindow* dialog, QWidget* parent)
 	//Auto
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.ethNetMaskAuto, "DEV9/Eth", "AutoMask", true);
 	onEthAutoChanged(m_ui.ethNetMaskAuto, m_ui.ethNetMaskAuto->checkState(), m_ui.ethNetMask, "DEV9/Eth", "AutoMask");
-	connect(m_ui.ethNetMaskAuto, QOverload<int>::of(&QCheckBox::stateChanged), this, [&](int state) { onEthAutoChanged(m_ui.ethNetMaskAuto, state, m_ui.ethNetMask, "DEV9/Eth", "AutoMask"); });
+	connect(m_ui.ethNetMaskAuto, &QCheckBox::checkStateChanged, this, [&](Qt::CheckState state) { onEthAutoChanged(m_ui.ethNetMaskAuto, state, m_ui.ethNetMask, "DEV9/Eth", "AutoMask"); });
 
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.ethGatewayAuto, "DEV9/Eth", "AutoGateway", true);
 	onEthAutoChanged(m_ui.ethGatewayAuto, m_ui.ethGatewayAuto->checkState(), m_ui.ethGatewayAddr, "DEV9/Eth", "AutoGateway");
-	connect(m_ui.ethGatewayAuto, QOverload<int>::of(&QCheckBox::stateChanged), this, [&](int state) { onEthAutoChanged(m_ui.ethGatewayAuto, state, m_ui.ethGatewayAddr, "DEV9/Eth", "AutoGateway"); });
+	connect(m_ui.ethGatewayAuto, &QCheckBox::checkStateChanged, this, [&](Qt::CheckState state) { onEthAutoChanged(m_ui.ethGatewayAuto, state, m_ui.ethGatewayAddr, "DEV9/Eth", "AutoGateway"); });
 
 	SettingWidgetBinder::BindWidgetToEnumSetting(sif, m_ui.ethDNS1Mode, "DEV9/Eth", "ModeDNS1",
 		s_dns_name, Pcsx2Config::DEV9Options::DnsModeNames, Pcsx2Config::DEV9Options::DnsModeNames[static_cast<int>(Pcsx2Config::DEV9Options::DnsMode::Auto)], "DEV9SettingsWidget");
@@ -242,7 +242,7 @@ DEV9SettingsWidget::DEV9SettingsWidget(SettingsWindow* dialog, QWidget* parent)
 	//////////////////////////////////////////////////////////////////////////
 	// HDD Settings
 	//////////////////////////////////////////////////////////////////////////
-	connect(m_ui.hddEnabled, QOverload<int>::of(&QCheckBox::stateChanged), this, &DEV9SettingsWidget::onHddEnabledChanged);
+	connect(m_ui.hddEnabled, &QCheckBox::checkStateChanged, this, &DEV9SettingsWidget::onHddEnabledChanged);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.hddEnabled, "DEV9/Hdd", "HddEnable", false);
 
 	if (m_dialog->isPerGameSettings())
@@ -253,7 +253,7 @@ DEV9SettingsWidget::DEV9SettingsWidget(SettingsWindow* dialog, QWidget* parent)
 	else
 		m_ui.hddFile->setText(QString::fromUtf8(m_dialog->getStringValue("DEV9/Hdd", "HddFile", "DEV9hdd.raw").value().c_str()));
 
-	connect(m_ui.hddLBA48, QOverload<int>::of(&QCheckBox::stateChanged), this, &DEV9SettingsWidget::onHddLBA48Changed);
+	connect(m_ui.hddLBA48, &QCheckBox::checkStateChanged, this, &DEV9SettingsWidget::onHddLBA48Changed);
 
 	UpdateHddSizeUIValues();
 
@@ -267,7 +267,7 @@ DEV9SettingsWidget::DEV9SettingsWidget(SettingsWindow* dialog, QWidget* parent)
 	connect(m_ui.hddCreate, &QPushButton::clicked, this, &DEV9SettingsWidget::onHddCreateClicked);
 }
 
-void DEV9SettingsWidget::onEthEnabledChanged(int state)
+void DEV9SettingsWidget::onEthEnabledChanged(Qt::CheckState state)
 {
 	const bool enabled = state == Qt::CheckState::PartiallyChecked ? Host::GetBaseBoolSettingValue("DEV9/Eth", "EthEnable", false) : state;
 
@@ -356,7 +356,7 @@ void DEV9SettingsWidget::onEthDeviceChanged(int index)
 	}
 }
 
-void DEV9SettingsWidget::onEthDHCPInterceptChanged(int state)
+void DEV9SettingsWidget::onEthDHCPInterceptChanged(Qt::CheckState state)
 {
 	const bool enabled = (state == Qt::CheckState::PartiallyChecked ? Host::GetBaseBoolSettingValue("DEV9/Eth", "InterceptDHCP", false) : state) ||
 						 ((m_adapter_options & AdapterOptions::DHCP_ForcedOn) == AdapterOptions::DHCP_ForcedOn);
@@ -411,7 +411,7 @@ void DEV9SettingsWidget::onEthIPChanged(QLineEdit* sender, const char* section, 
 		m_dialog->setStringSettingValue(section, key, neatStr.c_str());
 }
 
-void DEV9SettingsWidget::onEthAutoChanged(QCheckBox* sender, int state, QLineEdit* input, const char* section, const char* key)
+void DEV9SettingsWidget::onEthAutoChanged(QCheckBox* sender, Qt::CheckState state, QLineEdit* input, const char* section, const char* key)
 {
 	if (sender->isEnabled())
 	{
@@ -661,7 +661,7 @@ void DEV9SettingsWidget::onEthHostEdit(QStandardItem* item)
 	}
 }
 
-void DEV9SettingsWidget::onHddEnabledChanged(int state)
+void DEV9SettingsWidget::onHddEnabledChanged(Qt::CheckState state)
 {
 	const bool enabled = state == Qt::CheckState::PartiallyChecked ? Host::GetBaseBoolSettingValue("DEV9/Hdd", "HddEnable", false) : state;
 
@@ -722,17 +722,17 @@ void DEV9SettingsWidget::onHddSizeAccessorSpin()
 	m_ui.hddSizeSlider->setValue(m_ui.hddSizeSpinBox->value());
 }
 
-void DEV9SettingsWidget::onHddLBA48Changed(int state)
+void DEV9SettingsWidget::onHddLBA48Changed(Qt::CheckState state)
 {
-	m_ui.hddSizeSlider->setMaximum(state ? 2000 : 120);
-	m_ui.hddSizeSpinBox->setMaximum(state ? 2000 : 120);
-	m_ui.hddSizeMaxLabel->setText(state ? tr("2000") : tr("120"));
+	m_ui.hddSizeSlider->setMaximum((state != Qt::Unchecked) ? 2000 : 120);
+	m_ui.hddSizeSpinBox->setMaximum((state != Qt::Unchecked) ? 2000 : 120);
+	m_ui.hddSizeMaxLabel->setText((state != Qt::Unchecked) ? tr("2000") : tr("120"));
 	// Bump up min size to have ticks align with 100GiB sizes
-	m_ui.hddSizeSlider->setMinimum(state ? 100 : 40);
-	m_ui.hddSizeSpinBox->setMinimum(state ? 100 : 40);
-	m_ui.hddSizeMinLabel->setText(state ? tr("100") : tr("40"));
+	m_ui.hddSizeSlider->setMinimum((state != Qt::Unchecked) ? 100 : 40);
+	m_ui.hddSizeSpinBox->setMinimum((state != Qt::Unchecked) ? 100 : 40);
+	m_ui.hddSizeMinLabel->setText((state != Qt::Unchecked) ? tr("100") : tr("40"));
 
-	m_ui.hddSizeSlider->setTickInterval(state ? 100 : 5);
+	m_ui.hddSizeSlider->setTickInterval((state != Qt::Unchecked) ? 100 : 5);
 }
 
 void DEV9SettingsWidget::onHddCreateClicked()

--- a/pcsx2-qt/Settings/DEV9SettingsWidget.h
+++ b/pcsx2-qt/Settings/DEV9SettingsWidget.h
@@ -19,12 +19,12 @@ class DEV9SettingsWidget : public QWidget
 	Q_OBJECT
 
 private Q_SLOTS:
-	void onEthEnabledChanged(int state);
+	void onEthEnabledChanged(Qt::CheckState state);
 	void onEthDeviceTypeChanged(int index);
 	void onEthDeviceChanged(int index);
-	void onEthDHCPInterceptChanged(int state);
+	void onEthDHCPInterceptChanged(Qt::CheckState state);
 	void onEthIPChanged(QLineEdit* sender, const char* section, const char* key);
-	void onEthAutoChanged(QCheckBox* sender, int state, QLineEdit* input, const char* section, const char* key);
+	void onEthAutoChanged(QCheckBox* sender, Qt::CheckState state, QLineEdit* input, const char* section, const char* key);
 	void onEthDNSModeChanged(QComboBox* sender, int index, QLineEdit* input, const char* section, const char* key);
 	void onEthHostAdd();
 	void onEthHostDel();
@@ -33,13 +33,13 @@ private Q_SLOTS:
 	void onEthHostPerGame();
 	void onEthHostEdit(QStandardItem* item);
 
-	void onHddEnabledChanged(int state);
+	void onHddEnabledChanged(Qt::CheckState state);
 	void onHddBrowseFileClicked();
 	void onHddFileTextChange();
 	void onHddFileEdit();
 	void onHddSizeSlide(int i);
 	void onHddSizeAccessorSpin();
-	void onHddLBA48Changed(int state);
+	void onHddLBA48Changed(Qt::CheckState state);
 	void onHddCreateClicked();
 
 public:

--- a/pcsx2-qt/Settings/DebugSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/DebugSettingsWidget.cpp
@@ -33,7 +33,7 @@ DebugSettingsWidget::DebugSettingsWidget(SettingsWindow* dialog, QWidget* parent
 	SettingWidgetBinder::BindWidgetToFolderSetting(
 		sif, m_ui.swDumpDirectory, m_ui.swDumpBrowse, m_ui.swDumpOpen, nullptr, "EmuCore/GS", "SWDumpDirectory", std::string(), false);
 
-	connect(m_ui.dumpGSDraws, &QCheckBox::stateChanged, this, &DebugSettingsWidget::onDrawDumpingChanged);
+	connect(m_ui.dumpGSDraws, &QCheckBox::checkStateChanged, this, &DebugSettingsWidget::onDrawDumpingChanged);
 	onDrawDumpingChanged();
 }
 

--- a/pcsx2-qt/Settings/EmulationSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/EmulationSettingsWidget.cpp
@@ -32,7 +32,7 @@ EmulationSettingsWidget::EmulationSettingsWidget(SettingsWindow* dialog, QWidget
 
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.maxFrameLatency, "EmuCore/GS", "VsyncQueueSize", DEFAULT_FRAME_LATENCY);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.syncToHostRefreshRate, "EmuCore/GS", "SyncToHostRefreshRate", false);
-	connect(m_ui.optimalFramePacing, &QCheckBox::stateChanged, this, &EmulationSettingsWidget::onOptimalFramePacingChanged);
+	connect(m_ui.optimalFramePacing, &QCheckBox::checkStateChanged, this, &EmulationSettingsWidget::onOptimalFramePacingChanged);
 	m_ui.optimalFramePacing->setTristate(dialog->isPerGameSettings());
 
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.eeCycleSkipping, "EmuCore/Speedhacks", "EECycleSkip", DEFAULT_EE_CYCLE_SKIP);

--- a/pcsx2-qt/Settings/GameCheatSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GameCheatSettingsWidget.cpp
@@ -25,13 +25,13 @@ GameCheatSettingsWidget::GameCheatSettingsWidget(SettingsWindow* dialog, QWidget
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.allCRCsCheckbox, "EmuCore", "ShowCheatsForAllCRCs", false);
 	updateListEnabled();
 
-	connect(m_ui.enableCheats, &QCheckBox::stateChanged, this, &GameCheatSettingsWidget::updateListEnabled);
+	connect(m_ui.enableCheats, &QCheckBox::checkStateChanged, this, &GameCheatSettingsWidget::updateListEnabled);
 	connect(m_ui.cheatList, &QTreeWidget::itemDoubleClicked, this, &GameCheatSettingsWidget::onCheatListItemDoubleClicked);
 	connect(m_ui.cheatList, &QTreeWidget::itemChanged, this, &GameCheatSettingsWidget::onCheatListItemChanged);
 	connect(m_ui.reloadCheats, &QPushButton::clicked, this, &GameCheatSettingsWidget::onReloadClicked);
 	connect(m_ui.enableAll, &QPushButton::clicked, this, [this]() { setStateForAll(true); });
 	connect(m_ui.disableAll, &QPushButton::clicked, this, [this]() { setStateForAll(false); });
-	connect(m_ui.allCRCsCheckbox, &QCheckBox::stateChanged, this, &GameCheatSettingsWidget::onReloadClicked);
+	connect(m_ui.allCRCsCheckbox, &QCheckBox::checkStateChanged, this, &GameCheatSettingsWidget::onReloadClicked);
 
 	dialog->registerWidgetHelp(m_ui.allCRCsCheckbox, tr("Show Cheats For All CRCs"), tr("Checked"),
 		tr("Toggles scanning patch files for all CRCs of the game. With this enabled available patches for the game serial with different CRCs will also be loaded."));

--- a/pcsx2-qt/Settings/GameListSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GameListSettingsWidget.cpp
@@ -26,7 +26,7 @@ GameListSettingsWidget::GameListSettingsWidget(SettingsWindow* dialog, QWidget* 
 	m_ui.setupUi(this);
 
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.preferEnglishGameList, "UI", "PreferEnglishGameList", false);
-	connect(m_ui.preferEnglishGameList, &QCheckBox::stateChanged, [this]{ emit preferEnglishGameListChanged(); });
+	connect(m_ui.preferEnglishGameList, &QCheckBox::checkStateChanged, this, [this]{ emit preferEnglishGameListChanged(); });
 
 	dialog->registerWidgetHelp(m_ui.preferEnglishGameList, tr("Prefer English Titles"), tr("Unchecked"),
 		tr("For games with both a title in the game's native language and one in English, prefer the English title."));
@@ -111,7 +111,7 @@ void GameListSettingsWidget::addPathToTable(const std::string& path, bool recurs
 	m_ui.searchDirectoryList->setCellWidget(row, 1, cb);
 	cb->setChecked(recursive);
 
-	connect(cb, &QCheckBox::stateChanged, [item](int state) {
+	connect(cb, &QCheckBox::checkStateChanged, this, [item](Qt::CheckState state) {
 		const std::string path(item->text().toStdString());
 		if (state == Qt::Checked)
 		{

--- a/pcsx2-qt/Settings/GamePatchSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GamePatchSettingsWidget.cpp
@@ -31,7 +31,7 @@ GamePatchDetailsWidget::GamePatchDetailsWidget(std::string name, const std::stri
 
 	pxAssert(dialog->getSettingsInterface());
 	m_ui.enabled->setChecked(enabled);
-	connect(m_ui.enabled, &QCheckBox::stateChanged, this, &GamePatchDetailsWidget::onEnabledStateChanged);
+	connect(m_ui.enabled, &QCheckBox::checkStateChanged, this, &GamePatchDetailsWidget::onEnabledStateChanged);
 }
 
 GamePatchDetailsWidget::~GamePatchDetailsWidget() = default;
@@ -61,7 +61,7 @@ GamePatchSettingsWidget::GamePatchSettingsWidget(SettingsWindow* dialog, QWidget
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.allCRCsCheckbox, "EmuCore", "ShowPatchesForAllCRCs", false);
 
 	connect(m_ui.reload, &QPushButton::clicked, this, &GamePatchSettingsWidget::onReloadClicked);
-	connect(m_ui.allCRCsCheckbox, &QCheckBox::stateChanged, this, &GamePatchSettingsWidget::reloadList);
+	connect(m_ui.allCRCsCheckbox, &QCheckBox::checkStateChanged, this, &GamePatchSettingsWidget::reloadList);
 
 	dialog->registerWidgetHelp(m_ui.allCRCsCheckbox, tr("Show Patches For All CRCs"), tr("Checked"),
 		tr("Toggles scanning patch files for all CRCs of the game. With this enabled available patches for the game serial with different CRCs will also be loaded."));

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -135,7 +135,7 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* dialog, QWidget* 
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.casMode, "EmuCore/GS", "CASMode", static_cast<int>(GSCASMode::Disabled));
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.casSharpness, "EmuCore/GS", "CASSharpness", DEFAULT_CAS_SHARPNESS);
 
-	connect(m_ui.shadeBoost, QOverload<int>::of(&QCheckBox::stateChanged), this, &GraphicsSettingsWidget::onShadeBoostChanged);
+	connect(m_ui.shadeBoost, &QCheckBox::checkStateChanged, this, &GraphicsSettingsWidget::onShadeBoostChanged);
 	onShadeBoostChanged();
 
 	//////////////////////////////////////////////////////////////////////////
@@ -188,8 +188,7 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* dialog, QWidget* 
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.gpuPaletteConversion, "EmuCore/GS", "paltex", false);
 	connect(m_ui.cpuSpriteRenderBW, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
 		&GraphicsSettingsWidget::onCPUSpriteRenderBWChanged);
-	connect(m_ui.gpuPaletteConversion, QOverload<int>::of(&QCheckBox::stateChanged), this,
-		&GraphicsSettingsWidget::onGpuPaletteConversionChanged);
+	connect(m_ui.gpuPaletteConversion, &QCheckBox::checkStateChanged, this, &GraphicsSettingsWidget::onGpuPaletteConversionChanged);
 	onCPUSpriteRenderBWChanged();
 	onGpuPaletteConversionChanged(m_ui.gpuPaletteConversion->checkState());
 
@@ -273,7 +272,7 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* dialog, QWidget* 
 	}
 
 	connect(m_ui.renderer, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &GraphicsSettingsWidget::onRendererChanged);
-	connect(m_ui.enableHWFixes, &QCheckBox::stateChanged, this, &GraphicsSettingsWidget::updateRendererDependentOptions);
+	connect(m_ui.enableHWFixes, &QCheckBox::checkStateChanged, this, &GraphicsSettingsWidget::updateRendererDependentOptions);
 	connect(m_ui.textureFiltering, &QComboBox::currentIndexChanged, this, &GraphicsSettingsWidget::onTextureFilteringChange);
 	connect(m_ui.swTextureFiltering, &QComboBox::currentIndexChanged, this, &GraphicsSettingsWidget::onSWTextureFilteringChange);
 	updateRendererDependentOptions();
@@ -366,10 +365,10 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* dialog, QWidget* 
 		SettingWidgetBinder::BindWidgetToBoolSetting(
 			sif, m_ui.enableVideoCaptureArguments, "EmuCore/GS", "EnableVideoCaptureParameters", false);
 		SettingWidgetBinder::BindWidgetToStringSetting(sif, m_ui.videoCaptureArguments, "EmuCore/GS", "VideoCaptureParameters");
-		connect(m_ui.enableVideoCapture, &QCheckBox::stateChanged, this, &GraphicsSettingsWidget::onEnableVideoCaptureChanged);
+		connect(m_ui.enableVideoCapture, &QCheckBox::checkStateChanged, this, &GraphicsSettingsWidget::onEnableVideoCaptureChanged);
 		connect(
-			m_ui.videoCaptureResolutionAuto, &QCheckBox::stateChanged, this, &GraphicsSettingsWidget::onVideoCaptureAutoResolutionChanged);
-		connect(m_ui.enableVideoCaptureArguments, &QCheckBox::stateChanged, this,
+			m_ui.videoCaptureResolutionAuto, &QCheckBox::checkStateChanged, this, &GraphicsSettingsWidget::onVideoCaptureAutoResolutionChanged);
+		connect(m_ui.enableVideoCaptureArguments, &QCheckBox::checkStateChanged, this,
 			&GraphicsSettingsWidget::onEnableVideoCaptureArgumentsChanged);
 
 		SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.enableAudioCapture, "EmuCore/GS", "EnableAudioCapture", true);
@@ -378,8 +377,8 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* dialog, QWidget* 
 		SettingWidgetBinder::BindWidgetToBoolSetting(
 			sif, m_ui.enableAudioCaptureArguments, "EmuCore/GS", "EnableAudioCaptureParameters", false);
 		SettingWidgetBinder::BindWidgetToStringSetting(sif, m_ui.audioCaptureArguments, "EmuCore/GS", "AudioCaptureParameters");
-		connect(m_ui.enableAudioCapture, &QCheckBox::stateChanged, this, &GraphicsSettingsWidget::onEnableAudioCaptureChanged);
-		connect(m_ui.enableAudioCaptureArguments, &QCheckBox::stateChanged, this,
+		connect(m_ui.enableAudioCapture, &QCheckBox::checkStateChanged, this, &GraphicsSettingsWidget::onEnableAudioCaptureChanged);
+		connect(m_ui.enableAudioCaptureArguments, &QCheckBox::checkStateChanged, this,
 			&GraphicsSettingsWidget::onEnableAudioCaptureArgumentsChanged);
 
 		onCaptureContainerChanged();

--- a/pcsx2-qt/Settings/InterfaceSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/InterfaceSettingsWidget.cpp
@@ -76,7 +76,7 @@ InterfaceSettingsWidget::InterfaceSettingsWidget(SettingsWindow* dialog, QWidget
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.renderToSeparateWindow, "UI", "RenderToSeparateWindow", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.hideMainWindow, "UI", "HideMainWindowWhenRunning", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.disableWindowResizing, "UI", "DisableWindowResize", false);
-	connect(m_ui.renderToSeparateWindow, &QCheckBox::stateChanged, this, &InterfaceSettingsWidget::onRenderToSeparateWindowChanged);
+	connect(m_ui.renderToSeparateWindow, &QCheckBox::checkStateChanged, this, &InterfaceSettingsWidget::onRenderToSeparateWindowChanged);
 
 	SettingWidgetBinder::BindWidgetToEnumSetting(sif, m_ui.theme, "UI", "Theme", THEME_NAMES, THEME_VALUES,
 		QtHost::GetDefaultThemeName(), "InterfaceSettingsWidget");

--- a/pcsx2-qt/Settings/MemoryCardSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/MemoryCardSettingsWidget.cpp
@@ -106,7 +106,7 @@ void MemoryCardSettingsWidget::createSlotWidgets(SlotGroup* port, u32 slot)
 	port->enable = new QCheckBox(tr("Slot %1").arg(slot + 1), port->root);
 	SettingWidgetBinder::BindWidgetToBoolSetting(
 		sif, port->enable, CONFIG_SECTION, StringUtil::StdStringFromFormat("Slot%u_Enable", slot + 1), true);
-	connect(port->enable, &QCheckBox::stateChanged, this, &MemoryCardSettingsWidget::refresh);
+	connect(port->enable, &QCheckBox::checkStateChanged, this, &MemoryCardSettingsWidget::refresh);
 
 	port->eject = new QToolButton(port->root);
 	port->eject->setIcon(QIcon::fromTheme(perGame ? QStringLiteral("delete-back-2-line") : QStringLiteral("eject-line")));

--- a/pcsx2-qt/SetupWizardDialog.cpp
+++ b/pcsx2-qt/SetupWizardDialog.cpp
@@ -318,7 +318,7 @@ void SetupWizardDialog::addPathToTable(const std::string& path, bool recursive)
 	m_ui.searchDirectoryList->setCellWidget(row, 1, cb);
 	cb->setChecked(recursive);
 
-	connect(cb, &QCheckBox::stateChanged, [item](int state) {
+	connect(cb, &QCheckBox::checkStateChanged, this, [item](Qt::CheckState state) {
 		const std::string path(item->text().toStdString());
 		if (state == Qt::Checked)
 		{

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
@@ -380,6 +380,8 @@ bool GSDeviceVK::SelectDeviceExtensions(ExtensionList* extension_list, bool enab
 	m_optional_extensions.vk_ext_line_rasterization = SupportsExtension(VK_EXT_LINE_RASTERIZATION_EXTENSION_NAME,
 		require_line_rasterization);
 	m_optional_extensions.vk_khr_driver_properties = SupportsExtension(VK_KHR_DRIVER_PROPERTIES_EXTENSION_NAME, false);
+	m_optional_extensions.vk_khr_shader_non_semantic_info =
+	 SupportsExtension(VK_KHR_SHADER_NON_SEMANTIC_INFO_EXTENSION_NAME, false);
 
 #ifdef _WIN32
 	m_optional_extensions.vk_ext_full_screen_exclusive =

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h
@@ -43,6 +43,7 @@ public:
 		bool vk_ext_full_screen_exclusive : 1;
 		bool vk_ext_line_rasterization : 1;
 		bool vk_khr_driver_properties : 1;
+		bool vk_khr_shader_non_semantic_info : 1;
 	};
 
 	// Global state accessors

--- a/pcsx2/GS/Renderers/Vulkan/VKShaderCache.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/VKShaderCache.cpp
@@ -111,8 +111,11 @@ std::optional<VKShaderCache::SPIRVCodeVector> VKShaderCache::CompileShaderToSPV(
 
 	if (debug)
 	{
-		options.SetOptimizationLevel(shaderc_optimization_level_zero);
 		options.SetGenerateDebugInfo();
+		if (GSDeviceVK::GetInstance()->GetOptionalExtensions().vk_khr_shader_non_semantic_info)
+			options.SetEmitNonSemanticDebugInfo();
+
+		options.SetOptimizationLevel(shaderc_optimization_level_zero);
 	}
 	else
 	{


### PR DESCRIPTION
### Description of Changes

 - Gates the generation of non-semantic debug info behind the extension being present. Fixes the validation error.
 - Swaps Flatpak to using CMake for building SDL2, like the AppImage.
 - Uses Release build type for Flatpak's shaderc.
 - Bump Flatpak to Qt 6.7.
 - Fix deprecation warnings from Qt 6.7.
 - Changed QCheckBox `stateChanged()` signals to `checkStateChanged()` - the latter is strongly typed.
 - Fixes libpng/libjpeg on Windows in Debug builds.

### Rationale behind Changes

Chores.

### Suggested Testing Steps

Make sure checkboxes in UI still works.
Make sure Vulkan renderer still works.
Test saving PNG and JPEG screenshots.