### PR TITLE
GS/HW: Ensure tex shuffles, masking are render target draws.

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -5233,7 +5233,8 @@ __ri void GSRendererHW::DrawPrims(GSTextureCache::Target* rt, GSTextureCache::Ta
 
 	m_prim_overlap = PrimitiveOverlap();
 
-	EmulateTextureShuffleAndFbmask(rt, tex);
+	if (rt)
+		EmulateTextureShuffleAndFbmask(rt, tex);
 
 	const GSDevice::FeatureSupport features = g_gs_device->Features();
 


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS/HW: Ensure tex shuffles, masking are render target draws.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Fixes Castlevania Curse of Darkness crashing.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Check the dump if it still crashes on dx.
https://cdn.discordapp.com/attachments/923492653788692480/1229064937050214411/Castlevania_-_Curse_of_Darkness_SLUS-21168_20240414104422.gs.zst?ex=662e52eb&is=661bddeb&hm=f5572bbdaa1d68da4a12061542428427e5d44899be3b6f06f604388283f034c1&
Smoke test, no diffs showed up.
Edit: tested and crash is fixed.