### PR TITLE
Qt: Shrink settings window by ~30 pixels

### DIFF
--- a/pcsx2-qt/Settings/DEV9SettingsWidget.cpp
+++ b/pcsx2-qt/Settings/DEV9SettingsWidget.cpp
@@ -755,7 +755,6 @@ void DEV9SettingsWidget::onHddCreateClicked()
 
 	if (FileSystem::FileExists(hddPath.c_str()))
 	{
-		//GHC uses UTF8 on all platforms
 		QMessageBox::StandardButton selection =
 			QMessageBox::question(this, tr("Overwrite File?"),
 				tr("HDD image \"%1\" already exists.\n\n"

--- a/pcsx2-qt/Settings/DEV9SettingsWidget.ui
+++ b/pcsx2-qt/Settings/DEV9SettingsWidget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>600</width>
-    <height>500</height>
+    <height>482</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
@@ -274,14 +274,38 @@
       <string>Hard Disk Drive</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_2">
-      <item row="1" column="0">
-       <widget class="QLabel" name="hddFileLabel">
+      <item row="1" column="2">
+       <widget class="QPushButton" name="hddBrowseFile">
         <property name="text">
-         <string>HDD File:</string>
+         <string>Browse</string>
         </property>
        </widget>
       </item>
-      <item row="2" column="1">
+      <item row="1" column="1">
+       <widget class="QLineEdit" name="hddFile"/>
+      </item>
+      <item row="0" column="0" colspan="3">
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
+        <item>
+         <widget class="QCheckBox" name="hddEnabled">
+          <property name="text">
+           <string comment="HDD">Enabled</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="hddLBA48">
+          <property name="text">
+           <string>Enable 48-Bit LBA</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="2" column="1" colspan="2">
        <layout class="QHBoxLayout" name="horizontalLayout">
         <item>
          <widget class="QLabel" name="hddSizeMinLabel">
@@ -319,15 +343,29 @@
           </property>
          </widget>
         </item>
+        <item>
+         <widget class="QSpinBox" name="hddSizeSpinBox">
+          <property name="minimum">
+           <number>40</number>
+          </property>
+          <property name="maximum">
+           <number>120</number>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="hddCreate">
+          <property name="text">
+           <string>Create Image</string>
+          </property>
+         </widget>
+        </item>
        </layout>
       </item>
-      <item row="2" column="2">
-       <widget class="QSpinBox" name="hddSizeSpinBox">
-        <property name="minimum">
-         <number>40</number>
-        </property>
-        <property name="maximum">
-         <number>120</number>
+      <item row="1" column="0">
+       <widget class="QLabel" name="hddFileLabel">
+        <property name="text">
+         <string>HDD File:</string>
         </property>
        </widget>
       </item>
@@ -335,47 +373,6 @@
        <widget class="QLabel" name="hddSizeLabel">
         <property name="text">
          <string>HDD Size (GiB):</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0">
-       <widget class="QCheckBox" name="hddEnabled">
-        <property name="text">
-         <string comment="HDD">Enabled</string>
-        </property>
-        <property name="checked">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="2">
-       <widget class="QPushButton" name="hddBrowseFile">
-        <property name="text">
-         <string>Browse</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QLineEdit" name="hddFile"/>
-      </item>
-      <item row="4" column="2">
-       <widget class="QPushButton" name="hddCreate">
-        <property name="text">
-         <string>Create Image</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="0">
-       <widget class="QLabel" name="hddLBA48Label">
-        <property name="text">
-         <string>48-bit LBA:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="1">
-       <widget class="QCheckBox" name="hddLBA48">
-        <property name="text">
-         <string>Enabled</string>
         </property>
        </widget>
       </item>

--- a/pcsx2-qt/Settings/InterfaceSettingsWidget.ui
+++ b/pcsx2-qt/Settings/InterfaceSettingsWidget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>698</width>
-    <height>740</height>
+    <height>494</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
@@ -167,15 +167,19 @@
       <string>Automatic Updater</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_2">
+      <item row="1" column="1">
+       <widget class="QLabel" name="autoUpdateCurrentVersion">
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
       <item row="0" column="0">
        <widget class="QLabel" name="label_4">
         <property name="text">
          <string>Update Channel:</string>
         </property>
        </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QComboBox" name="autoUpdateTag"/>
       </item>
       <item row="1" column="0">
        <widget class="QLabel" name="label_5">
@@ -184,34 +188,17 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="1">
-       <widget class="QLabel" name="autoUpdateCurrentVersion">
-        <property name="text">
-         <string/>
-        </property>
-       </widget>
+      <item row="0" column="1">
+       <widget class="QComboBox" name="autoUpdateTag"/>
       </item>
       <item row="2" column="0" colspan="2">
-       <widget class="QCheckBox" name="autoUpdateEnabled">
-        <property name="text">
-         <string>Enable Automatic Update Check</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0" colspan="2">
-       <layout class="QHBoxLayout" name="horizontalLayout_2">
+       <layout class="QHBoxLayout" name="horizontalLayout" stretch="1,0">
         <item>
-         <spacer name="horizontalSpacer">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
+         <widget class="QCheckBox" name="autoUpdateEnabled">
+          <property name="text">
+           <string>Enable Automatic Update Check</string>
           </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
+         </widget>
         </item>
         <item>
          <widget class="QPushButton" name="checkForUpdates">


### PR DESCRIPTION
### Description of Changes

Moves some widgets around to free up approximately 30 pixels of height in the settings window, so it can fit on displays for users unfortunate enough to still be using a 768p display.

![image](https://github.com/PCSX2/pcsx2/assets/11288319/9b2b9ecb-d7cb-4502-8a23-30162c29d866)
=>
![image](https://github.com/PCSX2/pcsx2/assets/11288319/220f950d-ef70-4f01-a4f3-51b8a40309e5)

![image](https://github.com/PCSX2/pcsx2/assets/11288319/dfddb26c-9a4d-40f2-bfc2-e51755162cf9)
=>
![image](https://github.com/PCSX2/pcsx2/assets/11288319/da10623d-5d3e-4feb-9dcc-87c1a6ecdea7)


### Rationale behind Changes

Less user cry cry.

### Suggested Testing Steps

Make sure settings dialog looks okay.
