### PR TITLE
Qt: added Catppuccin Mocha theme

### DIFF
--- a/pcsx2-qt/Settings/InterfaceSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/InterfaceSettingsWidget.cpp
@@ -36,6 +36,8 @@ const char* InterfaceSettingsWidget::THEME_NAMES[] = {
 	QT_TRANSLATE_NOOP("InterfaceSettingsWidget", "Ruby (Black/Red) [Dark]"),
 	//: Ignore what Crowdin says in this string about "[Light]/[Dark]" being untouchable here, these are not variables in this case and must be translated.
 	QT_TRANSLATE_NOOP("InterfaceSettingsWidget", "Sapphire (Black/Blue) [Dark]"),
+	//: Ignore what Crowdin says in this string about "[Light]/[Dark]" being untouchable here, these are not variables in this case and must be translated.
+	QT_TRANSLATE_NOOP("InterfaceSettingsWidget", "Catppuccin Mocha [Dark]"),
 	//: "Custom.qss" must be kept as-is.
 	QT_TRANSLATE_NOOP("InterfaceSettingsWidget", "Custom.qss [Drop in PCSX2 Folder]"),
 	nullptr};
@@ -55,6 +57,7 @@ const char* InterfaceSettingsWidget::THEME_VALUES[] = {
 	"CobaltSky",
 	"Ruby",
 	"Sapphire",
+	"CatppuccinMocha",
 	"Custom",
 	nullptr};
 

--- a/pcsx2-qt/Themes.cpp
+++ b/pcsx2-qt/Themes.cpp
@@ -465,57 +465,14 @@ void QtHost::SetStyleFromSettings()
 	{
 		qApp->setStyle(QStyleFactory::create("Fusion"));
 
+		QString sheet_content;
+		QFile sheets(QString::fromStdString(":/qss/CatppuccinMocha.qss"));
 
-		const QColor rosewater(245, 224, 220);
-		const QColor flamingo(242, 205, 205);
-		const QColor pink(245, 194, 231);
-		const QColor mauve(203, 166, 247);
-		const QColor red(243, 139, 168);
-		const QColor maroon(235, 160, 172);
-		const QColor peach(250, 179, 135);
-		const QColor yellow(249, 226, 175);
-		const QColor green(166, 227, 161);
-		const QColor teal(148, 226, 213);
-		const QColor sky(137, 220, 235);
-		const QColor sapphire(116, 199, 236);
-		const QColor blue(137, 180, 250);
-		const QColor lavender(180, 190, 254);
-		const QColor text(205, 214, 244);
-		const QColor subtext1(186, 194, 222);
-		const QColor subtext0(166, 173, 200);
-		const QColor overlay2(147, 153, 178);
-		const QColor overlay1(127, 132, 156);
-		const QColor overlay0(108, 112, 134);
-		const QColor surface2(88, 91, 112);
-		const QColor surface1(69, 71, 90);
-		const QColor surface0(49, 50, 68);
-		const QColor base(30, 30, 46);
-		const QColor mantle(24, 24, 37);
-		const QColor crust(17, 17, 27);
-
-
-
-		QPalette darkPalette;
-		darkPalette.setColor(QPalette::Window, base);
-		darkPalette.setColor(QPalette::WindowText, text);
-		darkPalette.setColor(QPalette::Base, base);
-		darkPalette.setColor(QPalette::AlternateBase, surface0);
-		darkPalette.setColor(QPalette::ToolTipBase, base);
-		darkPalette.setColor(QPalette::ToolTipText, text);
-		darkPalette.setColor(QPalette::Text, text);
-		darkPalette.setColor(QPalette::Button, base);
-		darkPalette.setColor(QPalette::ButtonText, text);
-		darkPalette.setColor(QPalette::Link, text);
-		darkPalette.setColor(QPalette::Highlight, pink);
-		darkPalette.setColor(QPalette::HighlightedText, base);
-
-		darkPalette.setColor(QPalette::Active, QPalette::Button, base);
-		darkPalette.setColor(QPalette::Disabled, QPalette::ButtonText, text);
-		darkPalette.setColor(QPalette::Disabled, QPalette::WindowText, text);
-		darkPalette.setColor(QPalette::Disabled, QPalette::Text, text);
-		darkPalette.setColor(QPalette::Disabled, QPalette::Light, surface1);
-
-		qApp->setPalette(darkPalette);
+		if (sheets.open(QFile::ReadOnly))
+		{
+			QString sheet_content = QString::fromUtf8(sheets.readAll().data());
+			qApp->setStyleSheet(sheet_content);
+		}
 	}
 	else if (theme == "Custom")
 	{

--- a/pcsx2-qt/Themes.cpp
+++ b/pcsx2-qt/Themes.cpp
@@ -461,6 +461,62 @@ void QtHost::SetStyleFromSettings()
 
 		qApp->setPalette(darkPalette);
 	}
+	else if (theme == "CatppuccinMocha")
+	{
+		qApp->setStyle(QStyleFactory::create("Fusion"));
+
+
+		const QColor rosewater(245, 224, 220);
+		const QColor flamingo(242, 205, 205);
+		const QColor pink(245, 194, 231);
+		const QColor mauve(203, 166, 247);
+		const QColor red(243, 139, 168);
+		const QColor maroon(235, 160, 172);
+		const QColor peach(250, 179, 135);
+		const QColor yellow(249, 226, 175);
+		const QColor green(166, 227, 161);
+		const QColor teal(148, 226, 213);
+		const QColor sky(137, 220, 235);
+		const QColor sapphire(116, 199, 236);
+		const QColor blue(137, 180, 250);
+		const QColor lavender(180, 190, 254);
+		const QColor text(205, 214, 244);
+		const QColor subtext1(186, 194, 222);
+		const QColor subtext0(166, 173, 200);
+		const QColor overlay2(147, 153, 178);
+		const QColor overlay1(127, 132, 156);
+		const QColor overlay0(108, 112, 134);
+		const QColor surface2(88, 91, 112);
+		const QColor surface1(69, 71, 90);
+		const QColor surface0(49, 50, 68);
+		const QColor base(30, 30, 46);
+		const QColor mantle(24, 24, 37);
+		const QColor crust(17, 17, 27);
+
+
+
+		QPalette darkPalette;
+		darkPalette.setColor(QPalette::Window, base);
+		darkPalette.setColor(QPalette::WindowText, text);
+		darkPalette.setColor(QPalette::Base, base);
+		darkPalette.setColor(QPalette::AlternateBase, surface0);
+		darkPalette.setColor(QPalette::ToolTipBase, base);
+		darkPalette.setColor(QPalette::ToolTipText, text);
+		darkPalette.setColor(QPalette::Text, text);
+		darkPalette.setColor(QPalette::Button, base);
+		darkPalette.setColor(QPalette::ButtonText, text);
+		darkPalette.setColor(QPalette::Link, text);
+		darkPalette.setColor(QPalette::Highlight, pink);
+		darkPalette.setColor(QPalette::HighlightedText, base);
+
+		darkPalette.setColor(QPalette::Active, QPalette::Button, base);
+		darkPalette.setColor(QPalette::Disabled, QPalette::ButtonText, text);
+		darkPalette.setColor(QPalette::Disabled, QPalette::WindowText, text);
+		darkPalette.setColor(QPalette::Disabled, QPalette::Text, text);
+		darkPalette.setColor(QPalette::Disabled, QPalette::Light, surface1);
+
+		qApp->setPalette(darkPalette);
+	}
 	else if (theme == "Custom")
 	{
 		//Additional Theme option than loads .qss from main PCSX2 Directory

--- a/pcsx2-qt/resources/qss/CatppuccinMocha.qss
+++ b/pcsx2-qt/resources/qss/CatppuccinMocha.qss
@@ -1,0 +1,166 @@
+/* * {
+    color : #cdd6f4;
+    background-color: #cdd6f4;
+} */
+QWidget {
+    background-color: #1e1e2e;
+    color: #cdd6f4;
+}
+
+
+
+QComboBox  {
+    color : #cdd6f4;
+    background-color: #313244;
+    border: 1px solid #313244;
+    border-radius: 5px;
+    padding: 1px 18px 1px 3px;
+}
+
+QComboBox::drop-down { /*  ! todo fix broken arrows on drop downs */
+  /* subcontrol-origin: padding;
+  subcontrol-position: top right; */
+  width: 15px;
+    background-color: #313244;
+    color : #cdd6f4;
+    border-radius: 5px;
+    padding: 1px 18px 1px 3px;
+    /* border: 1px solid #313244; */
+}
+QComboBox::down-arrow {
+    /* image: url(resources/icons/white/svg/arrow-left-right-line.svg); */
+    /* image: url(:/icons/white/svg/arrow-left-right-line.svg); */
+    image: url(:icons/CatppuccinMocha/text/caret-down-fill-svgrepo-com.svg);
+}
+
+QCheckBox  {
+    color : #cdd6f4;
+    background-color: #1e1e2e;
+    border: 0px solid #1e1e2e;
+}
+QCheckBox::indicator {
+    width: 8px;
+    height: 8px;
+    color : #cdd6f4;
+    background-color: #313244;
+    border: 1px solid #313244;
+    border-radius: 3px;
+    padding: 1px 1px 1px 1px;
+}
+
+QCheckBox::indicator:checked {
+    background-color: #f5c2e7;
+}
+
+QCheckBox::indicator:unchecked {
+    background-color: #313244;
+}
+
+QWidget::item:selected {
+    background-color: #fdd6f4;
+    color: #1e1e2e;
+}
+
+
+
+QAbstractScrollArea {
+    background-color: #1e1e2e;
+    color : #cd6f4;
+}
+
+QFrame {
+    background-color: #1e1e2e;
+    color : #cdd6f4;
+}
+
+
+
+QGroupBox {
+    background-color: #1e1e2e;
+    color : #cdd6f4;
+}
+
+
+
+QLabel {
+    background-color: #1e1e2e;
+    color : #cdd6f4;
+}
+
+QGroupBox#gameDisplayTab {
+    background-color: #1e1e2e;
+    color : #fdd6f4;
+}
+
+
+
+QGridLayout {
+    background-color: #fdd6f4;
+}
+
+QListWidget::item:selected {
+    background-color: #fdd6f4;
+    color: #1e1e2e;
+}
+
+QLineEdit {
+    background-color: #313244;
+    color: #cdd6f4;
+    border-radius: 5px;
+    padding: 1px 18px 1px 3px;
+}
+
+QPushButton {
+    background-color: #313244;
+    color: #cdd6f4;
+    padding: 1px 10px;
+    border-top: 2px solid #313244;
+    border-bottom: 2px solid #313244;
+    border-left: 3px solid #313244;
+    border-right: 3px solid #313244;
+    border-radius: 5px;
+}
+
+QSpinBox {
+    background-color: #313244;
+    color: #cdd6f4;
+    padding: 1px 10px;
+    border-top: 2px solid #313244;
+    border-bottom: 2px solid #313244;
+    border-left: 3px solid #313244;
+    border-right: 3px solid #313244;
+    border-radius: 5px;
+}
+
+#actionViewGameList {
+    background-color: #313244;
+    color: #cdd6f4;
+    padding: 1px 10px;
+    border-top: 2px solid #313244;
+    border-bottom: 2px solid #313244;
+    border-left: 3px solid #313244;
+    border-right: 3px solid #313244;
+    border-radius: 5px;
+}
+
+
+
+QScrollBar:vertical {
+    background-color: #1e1e2e;
+    width: 10px;
+    margin: 16px 0;
+}
+
+QScrollBar::handle:vertical {
+    background-color: #313244;
+    min-height: 20px;
+    border-top: 3px solid #313244;
+    border-bottom: 3px solid #313244;
+    border-left: 3px solid #313244;
+    border-right: 3px solid #313244;
+    border-radius: 4px;
+}
+
+QScrollBar::handle:vertical:hover {
+    background-color: #cdd6f4;
+}

--- a/pcsx2-qt/resources/resources.qrc
+++ b/pcsx2-qt/resources/resources.qrc
@@ -193,5 +193,6 @@
 		<file>images/GT_Force.svg</file>
 		<file>images/Guitar.svg</file>
 		<file>images/Popn.svg</file>
+		<file>qss/CatppuccinMocha.qss</file>
 	</qresource>
 </RCC>


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
added the [Catppuccin Mocha](https://github.com/catppuccin/catppuccin) theme

there are still some issue i don't know if can be fixed with just a theme:
- the icons are not themed they are just white
- the search bar text is not themed
- seperators are not themed
- non-highlighted outlines are not themed
- check boxes are too low contrast
- dropdown menus have gradients which doesn't look very good
- some selection boxes with arrows on the side like `emulation>maximum frame latency` are also too low contrast
- some sub-menus are weird colors like `graphics>osd` the box where the options are there looks odd
- the window title on windows is not themed (this is probably not fixable)
​

also other Catppuccin flavors should also probably be added if mocha is