### PR TITLE
GS/HW: Cross-reference RT alpha with CLUT for P8H/P4HL/P4HH

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.h
@@ -177,6 +177,7 @@ public:
 		~Palette();
 
 		__fi std::pair<u8, u8> GetAlphaMinMax() const { return m_alpha_minmax; }
+		std::pair<u8, u8> GetAlphaMinMax(u8 min_index, u8 max_index) const;
 
 		// Disable copy constructor and copy operator
 		Palette(const Palette&) = delete;


### PR DESCRIPTION
### Description of Changes

Since we have the RT alpha range, we can potentially reduce the range of the CLUT that's used to determine the source alpha min/max.

Unfortunately, in the few games I looked at, they were all 0/255 anyway, so it doesn't really help much.
But it did for True Crime: NYC, which enables RTA, and knocks off up to 700 barriers depending on the scene.

### Rationale behind Changes

Small wins add up.

### Suggested Testing Steps

Smoke test, runner says we good.
