### PR TITLE
GS/HW: Fix some small errors updating depth in RT targets

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -1359,7 +1359,7 @@ GSTextureCache::Source* GSTextureCache::LookupSource(const bool is_color, const 
 							}
 							else
 							{
-								if ((psm == PSMT4 || psm == PSMT8) && t->m_was_dst_matched && !t->m_valid_rgb)
+								if (req_color && t->m_was_dst_matched && !t->m_valid_rgb)
 								{
 
 									GL_CACHE("TC: Attempt to repopulate RGB for target [%x] on source lookup", t->m_TEX0.TBP0);
@@ -2008,8 +2008,6 @@ GSTextureCache::Target* GSTextureCache::LookupTarget(GIFRegTEX0 TEX0, const GSVe
 					dst->m_was_dst_matched = true;
 					dst->m_TEX0.TBW = dst_match->m_TEX0.TBW;
 					dst->UpdateValidity(dst->m_valid);
-
-					dst->m_rt_alpha_scale = false;
 
 					if (!CopyRGBFromDepthToColor(dst, dst_match))
 					{


### PR DESCRIPTION
### Description of Changes
Fixes an RTA bug with depth textures , but also fixes some other bugs (which some how didn't affect things) along the way

### Rationale behind Changes
Previous depth dstmatch code was incorrect, causing bugs.

### Suggested Testing Steps
Fixes Area 51, nothing else showed in dump run


Area 51:
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/60d8a554-5f23-4591-aa73-e58f0347ead0)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/8ab64492-8ec2-46e2-a6cf-e5004f481eba)

