### PR TITLE
VMManager: Log entry point in hexadecimal

### DIFF
--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -2621,7 +2621,7 @@ void VMManager::Internal::EntryPointCompilingOnCPUThread()
 	const bool reset_speed_limiter = (EmuConfig.EnableFastBootFastForward && IsFastBootInProgress());
 
 	Console.WriteLn(
-		Color_StrongGreen, fmt::format("ELF {} with entry point at 0x{} is executing.", s_elf_path, s_elf_entry_point));
+		Color_StrongGreen, fmt::format("ELF {} with entry point at 0x{:08X} is executing.", s_elf_path, s_elf_entry_point));
 	s_elf_executed = true;
 
 	if (reset_speed_limiter)


### PR DESCRIPTION
### Description of Changes
`VMManager` will log an ELF's entry point to the console prefixed with `0x`, but the actual value is not formatted in hexadecimal.

### Rationale behind Changes
The value was clearly intended to be formatted in hexadecimal but the `:08X` format specifier was left out by mistake.