### PR TITLE
Config/FullscreenUI: Properly disable GPU Palette Conversion.

### DIFF
--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -3721,7 +3721,7 @@ void FullscreenUI::DrawGraphicsSettingsPage()
 				"UserHacks_EstimateTextureRegion", false, manual_hw_fixes);
 			DrawToggleSetting(bsi, FSUI_CSTR("GPU Palette Conversion"),
 				FSUI_CSTR("When enabled GPU converts colormap-textures, otherwise the CPU will. It is a trade-off between GPU and CPU."),
-				"EmuCore/GS", "paltex", false);
+				"EmuCore/GS", "paltex", false, manual_hw_fixes);
 
 			MenuHeading(FSUI_CSTR("Upscaling Fixes"));
 			DrawIntListSetting(bsi, FSUI_CSTR("Half Pixel Offset"), FSUI_CSTR("Adjusts vertices relative to upscaling."), "EmuCore/GS",

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -985,6 +985,7 @@ void Pcsx2Config::GSOptions::MaskUserHacks()
 	UserHacks_HalfPixelOffset = GSHalfPixelOffset::Off;
 	UserHacks_RoundSprite = 0;
 	UserHacks_AutoFlush = GSHWAutoFlushLevel::Disabled;
+	GPUPaletteConversion = false;
 	PreloadFrameWithGSData = false;
 	UserHacks_DisablePartialInvalidation = false;
 	UserHacks_DisableDepthSupport = false;


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Config/FullscreenUI: Properly disable GPU Palette Conversion.
When manual hardware fixes are disabled.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Fixes https://github.com/PCSX2/pcsx2/issues/11029

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test https://github.com/PCSX2/pcsx2/issues/11029
