### PR TITLE
DEV9: Lazy load ethernet adapters in the settings UI

### DIFF
--- a/pcsx2-qt/Settings/DEV9SettingsWidget.cpp
+++ b/pcsx2-qt/Settings/DEV9SettingsWidget.cpp
@@ -65,81 +65,8 @@ DEV9SettingsWidget::DEV9SettingsWidget(SettingsWindow* dialog, QWidget* parent)
 	// Eth Device Settings
 	//////////////////////////////////////////////////////////////////////////
 	connect(m_ui.ethDevType, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &DEV9SettingsWidget::onEthDeviceTypeChanged);
-
-	m_api_list.push_back(Pcsx2Config::DEV9Options::NetApi::Unset);
-
-	for (const AdapterEntry& adapter : PCAPAdapter::GetAdapters())
-		AddAdapter(adapter);
-#ifdef _WIN32
-	for (const AdapterEntry& adapter : TAPAdapter::GetAdapters())
-		AddAdapter(adapter);
-#endif
-	for (const AdapterEntry& adapter : SocketAdapter::GetAdapters())
-		AddAdapter(adapter);
-
-	std::sort(m_api_list.begin(), m_api_list.end());
-	for (auto& list : m_adapter_list)
-		std::sort(list.begin(), list.end(), [](const AdapterEntry& a, AdapterEntry& b) { return a.name < b.name; });
-
-	for (const Pcsx2Config::DEV9Options::NetApi& na : m_api_list)
-	{
-		m_api_namelist.push_back(s_api_name[static_cast<int>(na)]);
-		m_api_valuelist.push_back(Pcsx2Config::DEV9Options::NetApiNames[static_cast<int>(na)]);
-	}
-
-	m_api_namelist.push_back(nullptr);
-	m_api_valuelist.push_back(nullptr);
-
-	//We replace the blank entry with one for global settings
-	if (m_dialog->isPerGameSettings())
-	{
-		const std::string valueAPI = Host::GetBaseStringSettingValue("DEV9/Eth", "EthApi", Pcsx2Config::DEV9Options::NetApiNames[static_cast<int>(Pcsx2Config::DEV9Options::NetApi::Unset)]);
-		for (int i = 0; Pcsx2Config::DEV9Options::NetApiNames[i] != nullptr; i++)
-		{
-			if (valueAPI == Pcsx2Config::DEV9Options::NetApiNames[i])
-			{
-				m_global_api = static_cast<Pcsx2Config::DEV9Options::NetApi>(i);
-				break;
-			}
-		}
-
-		std::vector<AdapterEntry> baseList = m_adapter_list[static_cast<u32>(m_global_api)];
-
-		std::string baseAdapter = " ";
-		const std::string valueGUID = Host::GetBaseStringSettingValue("DEV9/Eth", "EthDevice", "");
-		for (size_t i = 0; i < baseList.size(); i++)
-		{
-			if (baseList[i].guid == valueGUID)
-			{
-				baseAdapter = baseList[i].name;
-				break;
-			}
-		}
-
-		m_adapter_list[static_cast<u32>(Pcsx2Config::DEV9Options::NetApi::Unset)][0].name = baseAdapter;
-	}
-
-	if (m_dialog->isPerGameSettings())
-		m_ui.ethDevType->addItem(tr("Use Global Setting [%1]").arg(QString::fromUtf8(Pcsx2Config::DEV9Options::NetApiNames[static_cast<u32>(m_global_api)])));
-	else
-		m_ui.ethDevType->addItem(qApp->translate("DEV9SettingsWidget", m_api_namelist[0]));
-
-	for (int i = 1; m_api_namelist[i] != nullptr; i++)
-		m_ui.ethDevType->addItem(qApp->translate("DEV9SettingsWidget", m_api_namelist[i]));
-
-	const std::string value = m_dialog->getStringValue("DEV9/Eth", "EthApi", Pcsx2Config::DEV9Options::NetApiNames[static_cast<int>(Pcsx2Config::DEV9Options::NetApi::Unset)]).value();
-
-	for (int i = 0; m_api_namelist[i] != nullptr; i++)
-	{
-		if (value == m_api_valuelist[i])
-		{
-			m_ui.ethDevType->setCurrentIndex(i);
-			break;
-		}
-	}
-	//onEthDeviceTypeChanged gets called automatically
-
 	connect(m_ui.ethDev, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &DEV9SettingsWidget::onEthDeviceChanged);
+	//Comboboxes populated in show event
 
 	//////////////////////////////////////////////////////////////////////////
 	// DHCP Settings
@@ -830,6 +757,9 @@ void DEV9SettingsWidget::showEvent(QShowEvent* event)
 {
 	QWidget::showEvent(event);
 
+	//Populate Eth Device Settings
+	LoadAdapters();
+
 	//The API combobox dosn't set the EthApi field, that is performed by the device combobox (in addition to saving the device)
 	//This means that this setting can get out of sync with true value, so revert to that if the ui is closed and opened
 	const std::string value = m_dialog->getStringValue("DEV9/Eth", "EthApi", Pcsx2Config::DEV9Options::NetApiNames[static_cast<int>(Pcsx2Config::DEV9Options::NetApi::Unset)]).value();
@@ -889,6 +819,89 @@ void DEV9SettingsWidget::AddAdapter(const AdapterEntry& adapter)
 	}
 
 	m_adapter_list[idx].push_back(adapter);
+}
+
+void DEV9SettingsWidget::LoadAdapters()
+{
+	if (m_adaptersLoaded)
+		return;
+
+	QSignalBlocker sb(m_ui.ethDev);
+
+	m_api_list.push_back(Pcsx2Config::DEV9Options::NetApi::Unset);
+
+	for (const AdapterEntry& adapter : PCAPAdapter::GetAdapters())
+		AddAdapter(adapter);
+#ifdef _WIN32
+	for (const AdapterEntry& adapter : TAPAdapter::GetAdapters())
+		AddAdapter(adapter);
+#endif
+	for (const AdapterEntry& adapter : SocketAdapter::GetAdapters())
+		AddAdapter(adapter);
+
+	std::sort(m_api_list.begin(), m_api_list.end());
+	for (auto& list : m_adapter_list)
+		std::sort(list.begin(), list.end(), [](const AdapterEntry& a, AdapterEntry& b) { return a.name < b.name; });
+
+	for (const Pcsx2Config::DEV9Options::NetApi& na : m_api_list)
+	{
+		m_api_namelist.push_back(s_api_name[static_cast<int>(na)]);
+		m_api_valuelist.push_back(Pcsx2Config::DEV9Options::NetApiNames[static_cast<int>(na)]);
+	}
+
+	m_api_namelist.push_back(nullptr);
+	m_api_valuelist.push_back(nullptr);
+
+	//We replace the blank entry with one for global settings
+	if (m_dialog->isPerGameSettings())
+	{
+		const std::string valueAPI = Host::GetBaseStringSettingValue("DEV9/Eth", "EthApi", Pcsx2Config::DEV9Options::NetApiNames[static_cast<int>(Pcsx2Config::DEV9Options::NetApi::Unset)]);
+		for (int i = 0; Pcsx2Config::DEV9Options::NetApiNames[i] != nullptr; i++)
+		{
+			if (valueAPI == Pcsx2Config::DEV9Options::NetApiNames[i])
+			{
+				m_global_api = static_cast<Pcsx2Config::DEV9Options::NetApi>(i);
+				break;
+			}
+		}
+
+		std::vector<AdapterEntry> baseList = m_adapter_list[static_cast<u32>(m_global_api)];
+
+		std::string baseAdapter = " ";
+		const std::string valueGUID = Host::GetBaseStringSettingValue("DEV9/Eth", "EthDevice", "");
+		for (size_t i = 0; i < baseList.size(); i++)
+		{
+			if (baseList[i].guid == valueGUID)
+			{
+				baseAdapter = baseList[i].name;
+				break;
+			}
+		}
+
+		m_adapter_list[static_cast<u32>(Pcsx2Config::DEV9Options::NetApi::Unset)][0].name = baseAdapter;
+	}
+
+	if (m_dialog->isPerGameSettings())
+		m_ui.ethDevType->addItem(tr("Use Global Setting [%1]").arg(QString::fromUtf8(Pcsx2Config::DEV9Options::NetApiNames[static_cast<u32>(m_global_api)])));
+	else
+		m_ui.ethDevType->addItem(qApp->translate("DEV9SettingsWidget", m_api_namelist[0]));
+
+	for (int i = 1; m_api_namelist[i] != nullptr; i++)
+		m_ui.ethDevType->addItem(qApp->translate("DEV9SettingsWidget", m_api_namelist[i]));
+
+	const std::string value = m_dialog->getStringValue("DEV9/Eth", "EthApi", Pcsx2Config::DEV9Options::NetApiNames[static_cast<int>(Pcsx2Config::DEV9Options::NetApi::Unset)]).value();
+
+	for (int i = 0; m_api_namelist[i] != nullptr; i++)
+	{
+		if (value == m_api_valuelist[i])
+		{
+			m_ui.ethDevType->setCurrentIndex(i);
+			break;
+		}
+	}
+	//onEthDeviceTypeChanged gets called automatically
+
+	m_adaptersLoaded = true;
 }
 
 void DEV9SettingsWidget::RefreshHostList()

--- a/pcsx2-qt/Settings/DEV9SettingsWidget.cpp
+++ b/pcsx2-qt/Settings/DEV9SettingsWidget.cpp
@@ -834,8 +834,8 @@ void DEV9SettingsWidget::showEvent(QShowEvent* event)
 	//This means that this setting can get out of sync with true value, so revert to that if the ui is closed and opened
 	const std::string value = m_dialog->getStringValue("DEV9/Eth", "EthApi", Pcsx2Config::DEV9Options::NetApiNames[static_cast<int>(Pcsx2Config::DEV9Options::NetApi::Unset)]).value();
 
-	//disconnect temporally to prevent saving a vaule already in the config file
-	disconnect(m_ui.ethDev, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &DEV9SettingsWidget::onEthDeviceChanged);
+	//SignalBlocker to prevent saving a value already in the config file
+	QSignalBlocker sb(m_ui.ethDev);
 	for (int i = 0; m_api_namelist[i] != nullptr; i++)
 	{
 		if (value == m_api_valuelist[i])
@@ -844,7 +844,6 @@ void DEV9SettingsWidget::showEvent(QShowEvent* event)
 			break;
 		}
 	}
-	connect(m_ui.ethDev, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &DEV9SettingsWidget::onEthDeviceChanged);
 }
 
 /*

--- a/pcsx2-qt/Settings/DEV9SettingsWidget.cpp
+++ b/pcsx2-qt/Settings/DEV9SettingsWidget.cpp
@@ -56,9 +56,8 @@ DEV9SettingsWidget::DEV9SettingsWidget(SettingsWindow* dialog, QWidget* parent)
 	// Eth Enabled
 	//////////////////////////////////////////////////////////////////////////
 	//Connect needs to be after BindWidgetToBoolSetting to ensure correct order of execution for disabling a per game setting
-	//but we then need to manually call onEthAutoChanged to update the UI on fist load
+	//we then need to manually call onEthAutoChanged to update the UI on fist load (done in show)
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.ethEnabled, "DEV9/Eth", "EthEnable", false);
-	onEthEnabledChanged(m_ui.ethEnabled->checkState());
 	connect(m_ui.ethEnabled, &QCheckBox::checkStateChanged, this, &DEV9SettingsWidget::onEthEnabledChanged);
 
 	//////////////////////////////////////////////////////////////////////////
@@ -197,6 +196,10 @@ DEV9SettingsWidget::DEV9SettingsWidget(SettingsWindow* dialog, QWidget* parent)
 void DEV9SettingsWidget::onEthEnabledChanged(Qt::CheckState state)
 {
 	const bool enabled = state == Qt::CheckState::PartiallyChecked ? Host::GetBaseBoolSettingValue("DEV9/Eth", "EthEnable", false) : state;
+
+	//Populate Eth Device Settings
+	if (enabled)
+		LoadAdapters();
 
 	m_ui.ethDevType->setEnabled(enabled);
 	m_ui.ethDevTypeLabel->setEnabled(enabled);
@@ -757,23 +760,29 @@ void DEV9SettingsWidget::showEvent(QShowEvent* event)
 {
 	QWidget::showEvent(event);
 
-	//Populate Eth Device Settings
-	LoadAdapters();
+	//Update the ethernet UI, as not done by constructor
+	if (m_firstShow)
+		onEthEnabledChanged(m_ui.ethEnabled->checkState());
 
-	//The API combobox dosn't set the EthApi field, that is performed by the device combobox (in addition to saving the device)
-	//This means that this setting can get out of sync with true value, so revert to that if the ui is closed and opened
-	const std::string value = m_dialog->getStringValue("DEV9/Eth", "EthApi", Pcsx2Config::DEV9Options::NetApiNames[static_cast<int>(Pcsx2Config::DEV9Options::NetApi::Unset)]).value();
-
-	//SignalBlocker to prevent saving a value already in the config file
-	QSignalBlocker sb(m_ui.ethDev);
-	for (int i = 0; m_api_namelist[i] != nullptr; i++)
+	if (m_adaptersLoaded)
 	{
-		if (value == m_api_valuelist[i])
+		//The API combobox dosn't set the EthApi field, that is performed by the device combobox (in addition to saving the device)
+		//This means that this setting can get out of sync with true value, so revert to that if the ui is closed and opened
+		const std::string value = m_dialog->getStringValue("DEV9/Eth", "EthApi", Pcsx2Config::DEV9Options::NetApiNames[static_cast<int>(Pcsx2Config::DEV9Options::NetApi::Unset)]).value();
+
+		//SignalBlocker to prevent saving a value already in the config file
+		QSignalBlocker sb(m_ui.ethDev);
+		for (int i = 0; m_api_namelist[i] != nullptr; i++)
 		{
-			m_ui.ethDevType->setCurrentIndex(i);
-			break;
+			if (value == m_api_valuelist[i])
+			{
+				m_ui.ethDevType->setCurrentIndex(i);
+				break;
+			}
 		}
 	}
+
+	m_firstShow = false;
 }
 
 /*

--- a/pcsx2-qt/Settings/DEV9SettingsWidget.h
+++ b/pcsx2-qt/Settings/DEV9SettingsWidget.h
@@ -67,6 +67,8 @@ private:
 
 	Ui::DEV9SettingsWidget m_ui;
 
+	bool m_firstShow{true};
+
 	QStandardItemModel* m_ethHost_model;
 	QSortFilterProxyModel* m_ethHosts_proxy;
 

--- a/pcsx2-qt/Settings/DEV9SettingsWidget.h
+++ b/pcsx2-qt/Settings/DEV9SettingsWidget.h
@@ -52,6 +52,7 @@ protected:
 
 private:
 	void AddAdapter(const AdapterEntry& adapter);
+	void LoadAdapters();
 	void RefreshHostList();
 	int CountHostsConfig();
 	std::optional<std::vector<HostEntryUi>> ListHostsConfig();
@@ -69,6 +70,7 @@ private:
 	QStandardItemModel* m_ethHost_model;
 	QSortFilterProxyModel* m_ethHosts_proxy;
 
+	bool m_adaptersLoaded{false};
 	std::vector<Pcsx2Config::DEV9Options::NetApi> m_api_list;
 	std::vector<const char*> m_api_namelist;
 	std::vector<const char*> m_api_valuelist;


### PR DESCRIPTION
### Description of Changes
Delays the population of the ethernet devices until the network UI is visible.

### Rationale behind Changes
No need to load this if the user might not even look at the relevant UI panel.
Maybe it speeds loading the settings widget.

### Suggested Testing Steps
Make sure the ethernet devices list is still populated in the UI
