### PR TITLE
DEV9: Properly disable/enable labels/checkboxes in the settings UI

### DIFF
--- a/pcsx2-qt/Settings/DEV9SettingsWidget.cpp
+++ b/pcsx2-qt/Settings/DEV9SettingsWidget.cpp
@@ -336,6 +336,7 @@ void DEV9SettingsWidget::onEthDeviceTypeChanged(int index)
 			break;
 	}
 
+	m_ui.ethInterceptDHCPLabel->setEnabled((m_adapter_options & AdapterOptions::DHCP_ForcedOn) == AdapterOptions::None);
 	m_ui.ethInterceptDHCP->setEnabled((m_adapter_options & AdapterOptions::DHCP_ForcedOn) == AdapterOptions::None);
 	onEthDHCPInterceptChanged(m_ui.ethInterceptDHCP->checkState());
 }

--- a/pcsx2-qt/Settings/DEV9SettingsWidget.cpp
+++ b/pcsx2-qt/Settings/DEV9SettingsWidget.cpp
@@ -790,6 +790,7 @@ void DEV9SettingsWidget::UpdateHddSizeUIEnabled()
 	else
 		enableSizeUI = m_ui.hddFile->isEnabled();
 
+	m_ui.hddLBA48->setEnabled(enableSizeUI);
 	m_ui.hddSizeLabel->setEnabled(enableSizeUI);
 	m_ui.hddSizeSlider->setEnabled(enableSizeUI);
 	m_ui.hddSizeMaxLabel->setEnabled(enableSizeUI);

--- a/pcsx2-qt/Settings/DEV9SettingsWidget.ui
+++ b/pcsx2-qt/Settings/DEV9SettingsWidget.ui
@@ -305,7 +305,7 @@
         </item>
        </layout>
       </item>
-      <item row="2" column="1" colspan="2">
+      <item row="2" column="1">
        <layout class="QHBoxLayout" name="horizontalLayout">
         <item>
          <widget class="QLabel" name="hddSizeMinLabel">
@@ -353,13 +353,6 @@
           </property>
          </widget>
         </item>
-        <item>
-         <widget class="QPushButton" name="hddCreate">
-          <property name="text">
-           <string>Create Image</string>
-          </property>
-         </widget>
-        </item>
        </layout>
       </item>
       <item row="1" column="0">
@@ -373,6 +366,13 @@
        <widget class="QLabel" name="hddSizeLabel">
         <property name="text">
          <string>HDD Size (GiB):</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="2">
+       <widget class="QPushButton" name="hddCreate">
+        <property name="text">
+         <string>Create Image</string>
         </property>
        </widget>
       </item>

--- a/pcsx2-qt/Settings/DEV9SettingsWidget.ui
+++ b/pcsx2-qt/Settings/DEV9SettingsWidget.ui
@@ -101,7 +101,7 @@
            </widget>
           </item>
           <item row="0" column="0">
-           <widget class="QLabel" name="label_3">
+           <widget class="QLabel" name="ethInterceptDHCPLabel">
             <property name="text">
              <string>Intercept DHCP:</string>
             </property>


### PR DESCRIPTION
### Description of Changes
The LBA48 checkbox is now disabled correctly when HDD is disabled
The DHCP Intercept label is now disabled correctly
Adjusted how the layout of the HDD section is created, ensuring the Browse and Create Image buttons are the same size

### Rationale behind Changes
Consistency

### Suggested Testing Steps
Ensure that the LBA48 checkbox is disabled/enabled with the HDD enabled checkbox
Ensure that the DHCP Intercept label is disabled/enabled when the ethernet type is changed to/from Sockets
