### PR TITLE
DEV9: Adjustments to HDD logs

### DIFF
--- a/pcsx2/DEV9/ATA/ATA_Info.cpp
+++ b/pcsx2/DEV9/ATA/ATA_Info.cpp
@@ -42,8 +42,8 @@ void ATA::CreateHDDinfo(u64 sizeSectors)
 	sizeSectors = std::min<u64>(sizeSectors, maxSize);
 
 	constexpr u16 sectorSize = 512;
-	DevCon.WriteLn("DEV9: HddSize : %i", sizeSectors * sectorSize / (1024 * 1024));
-	DevCon.WriteLn("DEV9: sizeSectors : %i", sizeSectors); // SizeSectors will keep 48-bit size
+	DevCon.WriteLn("DEV9: ATA: HddSize : %i", sizeSectors * sectorSize / (1024 * 1024));
+	DevCon.WriteLn("DEV9: ATA: sizeSectors : %i", sizeSectors); // SizeSectors will keep 48-bit size
 
 	memset(&identifyData, 0, sizeof(identifyData));
 	//Defualt CHS translation
@@ -399,6 +399,4 @@ void ATA::CreateHDDinfoCsum()
 
 	for (int i = 0; i < (512); i++)
 		counter += identifyData[i];
-
-	DevCon.WriteLn("DEV9: %i", counter);
 }

--- a/pcsx2/DEV9/ATA/ATA_State.cpp
+++ b/pcsx2/DEV9/ATA/ATA_State.cpp
@@ -40,6 +40,8 @@ int ATA::Open(const std::string& hddPath)
 	readBuffer = new u8[readBufferLen];
 	memset(sceSec, 0, sizeof(sceSec));
 
+	DevCon.WriteLn("DEV9: ATA: HddFile : %s", hddPath.c_str());
+
 	//Open File
 	if (!FileSystem::FileExists(hddPath.c_str()))
 		return -1;
@@ -48,7 +50,7 @@ int ATA::Open(const std::string& hddPath)
 	const s64 size = hddImage ? FileSystem::FSize64(hddImage) : -1;
 	if (!hddImage || size < 0)
 	{
-		Console.Error("Failed to open HDD image '%s'", hddPath.c_str());
+		Console.Error("DEV9: ATA: Failed to open HDD image '%s'", hddPath.c_str());
 		return -1;
 	}
 

--- a/pcsx2/DEV9/ATA/HddCreate.cpp
+++ b/pcsx2/DEV9/ATA/HddCreate.cpp
@@ -251,12 +251,12 @@ void HddCreate::WriteImage(const std::string& hddPath, u64 fileBytes, u64 zeroSi
 
 void HddCreate::SetFileProgress(u64 currentSize)
 {
-	Console.WriteLn(fmt::format("{} / {} Bytes", currentSize, neededSize).c_str());
+	Console.WriteLn(fmt::format("DEV9: HddCreate: {} / {} Bytes", currentSize, neededSize).c_str());
 }
 
 void HddCreate::SetError()
 {
-	Console.WriteLn("Failed to create HDD file");
+	Console.WriteLn("DEV9: HddCreate: Failed to create HDD file");
 }
 
 void HddCreate::SetCanceled()

--- a/pcsx2/DEV9/DEV9.cpp
+++ b/pcsx2/DEV9/DEV9.cpp
@@ -180,7 +180,6 @@ void DEV9shutdown()
 s32 DEV9open()
 {
 	DevCon.WriteLn("DEV9: DEV9open");
-	DevCon.WriteLn("DEV9: open r+: %s", EmuConfig.DEV9.HddFile.c_str());
 
 	std::string hddPath(GetHDDPath());
 


### PR DESCRIPTION
### Description of Changes
Fix inconsistent log formats
Remove a pointless log that always printed `0`
Only log the HDD file path if HDD is enabled

### Rationale behind Changes
Consistency in logs
Logging the HDD path when HDD is off is unneeded.

### Suggested Testing Steps
Look at logs with and without HDD enabled
