### PR TITLE
ImGuiOverlays: Fix possible crash in save state selector

### DIFF
--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -5289,7 +5289,8 @@ void FullscreenUI::DrawSaveStateSelector(bool is_loading)
 
 	bool close_handled = false;
 	if (s_save_state_selector_open &&
-		ImGui::BeginChild("state_list", ImVec2(io.DisplaySize.x, io.DisplaySize.y - heading_size.y), false, ImGuiWindowFlags_NavFlattened))
+		ImGui::BeginChild("state_list", ImVec2(io.DisplaySize.x, io.DisplaySize.y - LayoutScale(LAYOUT_FOOTER_HEIGHT) - heading_size.y),
+			false, ImGuiWindowFlags_NavFlattened))
 	{
 		BeginMenuButtons();
 

--- a/pcsx2/ImGui/ImGuiOverlays.cpp
+++ b/pcsx2/ImGui/ImGuiOverlays.cpp
@@ -1004,18 +1004,19 @@ void SaveStateSelectorUI::Draw()
 				ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoBackground);
 		{
 			ImGui::SetCursorPosX(padding);
-			ImGui::BeginTable("table", 2);
+			if (ImGui::BeginTable("table", 2))
+			{
+				ImGui::TableNextColumn();
+				ImGui::TextUnformatted(s_load_legend.c_str());
+				ImGui::TableNextColumn();
+				ImGui::TextUnformatted(s_prev_legend.c_str());
+				ImGui::TableNextColumn();
+				ImGui::TextUnformatted(s_save_legend.c_str());
+				ImGui::TableNextColumn();
+				ImGui::TextUnformatted(s_next_legend.c_str());
 
-			ImGui::TableNextColumn();
-			ImGui::TextUnformatted(s_load_legend.c_str());
-			ImGui::TableNextColumn();
-			ImGui::TextUnformatted(s_prev_legend.c_str());
-			ImGui::TableNextColumn();
-			ImGui::TextUnformatted(s_save_legend.c_str());
-			ImGui::TableNextColumn();
-			ImGui::TextUnformatted(s_next_legend.c_str());
-
-			ImGui::EndTable();
+				ImGui::EndTable();
+			}
 		}
 		ImGui::EndChild();
 	}


### PR DESCRIPTION
### Description of Changes

what the title says

### Rationale behind Changes

boom 

### Suggested Testing Steps

try double clicking in the display area while the save state selector (function keys) is open