### PR TITLE
Debugger: Disable the debugger toolbar ctx menu

### DIFF
--- a/pcsx2-qt/Debugger/DebuggerWindow.ui
+++ b/pcsx2-qt/Debugger/DebuggerWindow.ui
@@ -26,6 +26,9 @@
    </layout>
   </widget>
   <widget class="QToolBar" name="toolBar">
+   <property name="contextMenuPolicy">
+    <enum>Qt::PreventContextMenu</enum>
+   </property>
    <property name="toolButtonStyle">
     <enum>Qt::ToolButtonTextBesideIcon</enum>
    </property>


### PR DESCRIPTION
### Description of Changes
Disables the context menu for the toolbar in the debugger window.

### Rationale behind Changes
Fixes #10473

### Suggested Testing Steps
See if you can hide the toolbar.
