### PR TITLE
Debugger: Disable pseudo ops

### DIFF
--- a/pcsx2-qt/Debugger/Models/BreakpointModel.cpp
+++ b/pcsx2-qt/Debugger/Models/BreakpointModel.cpp
@@ -103,7 +103,7 @@ QVariant BreakpointModel::data(const QModelIndex& index, int role) const
 					return m_cpu.GetSymbolMap().GetLabelName(bp->addr).c_str();
 				case BreakpointColumns::OPCODE:
 					// Note: Fix up the disassemblymanager so we can use it here, instead of calling a function through the disassemblyview (yuck)
-					return m_cpu.disasm(bp->addr, true).c_str();
+					return m_cpu.disasm(bp->addr, false).c_str();
 				case BreakpointColumns::CONDITION:
 					return bp->hasCond ? QString::fromLocal8Bit(bp->cond.expressionString) : "";
 				case BreakpointColumns::HITS:
@@ -149,7 +149,7 @@ QVariant BreakpointModel::data(const QModelIndex& index, int role) const
 					return m_cpu.GetSymbolMap().GetLabelName(bp->addr).c_str();
 				case BreakpointColumns::OPCODE:
 					// Note: Fix up the disassemblymanager so we can use it here, instead of calling a function through the disassemblyview (yuck)
-					return m_cpu.disasm(bp->addr, true).c_str();
+					return m_cpu.disasm(bp->addr, false).c_str();
 				case BreakpointColumns::CONDITION:
 					return bp->hasCond ? QString::fromLocal8Bit(bp->cond.expressionString) : "";
 				case BreakpointColumns::HITS:

--- a/pcsx2/DebugTools/DisassemblyManager.cpp
+++ b/pcsx2/DebugTools/DisassemblyManager.cpp
@@ -562,7 +562,7 @@ void DisassemblyFunction::load()
 		}
 
 		MIPSAnalyst::MipsOpcodeInfo opInfo = MIPSAnalyst::GetOpcodeInfo(cpu,funcPos);
-		u32 opAddress = funcPos;
+		//u32 opAddress = funcPos;
 		funcPos += 4;
 
 		// skip branches and their delay slots
@@ -572,6 +572,25 @@ void DisassemblyFunction::load()
 			continue;
 		}
 
+/*
+	The QT debugger doesn't follow the same logic as the disassembler
+	It _should_ follow the path of the disassembler, but instead it is naively reading the
+	disassembler output for every single instruction.
+	This causes issues disassembling:
+		0x1000 lui $t0, 0x1234
+		0x1004 ori $t0, $t0, 0x5678
+		0x1008 nop
+	Into:
+		0x1000 li $t0, 0x12345678
+		0x1004 li $t0, 0x12346789
+		0x1008 nop
+	Where it should be:
+		0x1000 li $t0, 0x12345678
+		0x1008 nop
+
+	As a quick remedy, I'm disabling the macro generation.
+*/
+#if 0
 		// lui
 		if (MIPS_GET_OP(opInfo.encodedOpcode) == 0x0F && funcPos < funcEnd && funcPos != nextData)
 		{
@@ -660,7 +679,7 @@ void DisassemblyFunction::load()
 				}
 			}
 		}
-
+#endif
 		// just a normal opcode
 	}
 


### PR DESCRIPTION
### Description of Changes
Disassembly is a pain point. There are multiple disassembler interfaces, and the "good" one we don't even use properly.
I've disabled another heuristic to prevent pseudo ops like `li`,

### Rationale behind Changes
Fixes: #10702 

### Suggested Testing Steps
See if pseudo instructions such as `li` shows up in the disassembly widget, or in the breakpoint listing.

#### I did not see any conflicts with #10224, to be really sure though, maybe merge that pr first.
