### PR TITLE
DEV9: Refine tracking of PS2's TCP sequence numbers during connection closing

### DIFF
--- a/pcsx2/DEV9/Sessions/TCP_Session/TCP_Session.h
+++ b/pcsx2/DEV9/Sessions/TCP_Session/TCP_Session.h
@@ -38,7 +38,7 @@ namespace Sessions
 		enum struct NumCheckResult
 		{
 			OK,
-			GotOldData,
+			OldSeq,
 			Bad
 		};
 
@@ -98,10 +98,10 @@ namespace Sessions
 		void ResetMyNumbers();
 
 		NumCheckResult CheckRepeatSYNNumbers(PacketReader::IP::TCP::TCP_Packet* tcp);
-		NumCheckResult CheckNumbers(PacketReader::IP::TCP::TCP_Packet* tcp);
+		NumCheckResult CheckNumbers(PacketReader::IP::TCP::TCP_Packet* tcp, bool rejectOldSeq = false);
 		s32 GetDelta(u32 a, u32 b); //Returns a - b
 		//Returns true if errored
-		bool ErrorOnNonEmptyPacket(PacketReader::IP::TCP::TCP_Packet* tcp);
+		bool ValidateEmptyPacket(PacketReader::IP::TCP::TCP_Packet* tcp, bool ignoreOld = true);
 
 		//PS2 sent SYN
 		PacketReader::IP::TCP::TCP_Packet* ConnectTCPComplete(bool success);

--- a/pcsx2/DEV9/Sessions/TCP_Session/TCP_Session_Out.cpp
+++ b/pcsx2/DEV9/Sessions/TCP_Session/TCP_Session_Out.cpp
@@ -308,9 +308,6 @@ namespace Sessions
 		windowSize.store(tcp->windowSize << windowScale);
 
 		const NumCheckResult Result = CheckNumbers(tcp);
-		//Check if we already have some of the data sent
-		const uint delta = GetDelta(expectedSeqNumber, tcp->sequenceNumber);
-		pxAssert(delta >= 0);
 
 		if (Result == NumCheckResult::Bad)
 		{
@@ -320,6 +317,9 @@ namespace Sessions
 		}
 		if (tcp->GetPayload()->GetLength() != 0)
 		{
+			//Check if we already have sent some of this data
+			const int delta = GetDelta(expectedSeqNumber, tcp->sequenceNumber);
+			pxAssert(delta >= 0);
 			//if (Result == NumCheckResult::OldSeq)
 			//{
 			//	DevCon.WriteLn("[PS2] New Data Offset: %d bytes", delta);
@@ -486,7 +486,8 @@ namespace Sessions
 		}
 		if (tcp->GetPayload()->GetLength() > 0)
 		{
-			uint delta = GetDelta(expectedSeqNumber, tcp->sequenceNumber);
+			const int delta = GetDelta(expectedSeqNumber, tcp->sequenceNumber);
+			pxAssert(delta >= 0);
 			//Check if packet contains only old data
 			if (delta >= tcp->GetPayload()->GetLength())
 				return false;


### PR DESCRIPTION
### Description of Changes
Better track PS2's sequence number when closing connection

### Rationale behind Changes
Previous code didn't properly validate PS2's sequence number when handling connection closing packets

### Suggested Testing Steps
Test networking games using sockets