### PR TITLE
VU: Expand IBit hack to work for immediates on several instructions

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -3764,6 +3764,8 @@ SCED-52759:
   region: "PAL-M5"
   clampModes:
     vuClampMode: 0 # Resolves I Reg Clamping / performance impact and yellow graphics in certain areas.
+  gameFixes:
+    - IbitHack # Reduces VU recompilation.
   gsHWFixes:
     halfPixelOffset: 4 # Fixes post positioning.
     nativeScaling: 2 # Fixes post effects.
@@ -3793,6 +3795,8 @@ SCED-52846:
   region: "PAL-E"
   clampModes:
     vuClampMode: 0 # Resolves I Reg Clamping / performance impact and yellow graphics in certain areas.
+  gameFixes:
+    - IbitHack # Reduces VU recompilation.
   gsHWFixes:
     halfPixelOffset: 4 # Fixes post positioning.
     nativeScaling: 2 # Fixes post effects.
@@ -3864,6 +3868,8 @@ SCED-52899:
   region: "PAL-M5"
   clampModes:
     vuClampMode: 0 # Resolves I Reg Clamping / performance impact and yellow graphics in certain areas.
+  gameFixes:
+    - IbitHack # Reduces VU recompilation.
   gsHWFixes:
     halfPixelOffset: 4 # Fixes post positioning.
     nativeScaling: 2 # Fixes post effects.
@@ -5368,6 +5374,8 @@ SCES-52004:
   compat: 5
   clampModes:
     vuClampMode: 0 # Resolves I Reg Clamping / performance impact and yellow graphics in certain areas.
+  gameFixes:
+    - IbitHack # Reduces VU recompilation.
   gsHWFixes:
     halfPixelOffset: 4 # Fixes post positioning.
     nativeScaling: 2 # Fixes post effects.
@@ -5700,6 +5708,8 @@ SCES-52893:
   region: "PAL-E-GR-R"
   clampModes:
     vuClampMode: 0 # Resolves I Reg Clamping / performance impact and yellow graphics in certain areas.
+  gameFixes:
+    - IbitHack # Reduces VU recompilation.
   gsHWFixes:
     halfPixelOffset: 4 # Fixes post positioning.
     nativeScaling: 2 # Fixes post effects.
@@ -7214,6 +7224,8 @@ SCKA-20048:
   region: "NTSC-K"
   clampModes:
     vuClampMode: 0 # Resolves I Reg Clamping / performance impact and yellow graphics in certain areas.
+  gameFixes:
+    - IbitHack # Reduces VU recompilation.
   gsHWFixes:
     halfPixelOffset: 4 # Fixes post positioning.
     nativeScaling: 2 # Fixes post effects.
@@ -7426,6 +7438,8 @@ SCKA-20078:
   region: "NTSC-K"
   clampModes:
     vuClampMode: 0 # Resolves I Reg Clamping / performance impact and yellow graphics in certain areas.
+  gameFixes:
+    - IbitHack # Reduces VU recompilation.
   gsHWFixes:
     halfPixelOffset: 4 # Fixes post positioning.
     nativeScaling: 2 # Fixes post effects.
@@ -11550,6 +11564,8 @@ SCUS-97402:
   compat: 5
   clampModes:
     vuClampMode: 0 # Resolves I Reg Clamping / performance impact and yellow graphics in certain areas.
+  gameFixes:
+    - IbitHack # Reduces VU recompilation.
   gsHWFixes:
     halfPixelOffset: 4 # Fixes post positioning.
     nativeScaling: 2 # Fixes post effects.
@@ -11690,6 +11706,8 @@ SCUS-97431:
   region: "NTSC-U"
   clampModes:
     vuClampMode: 0 # Resolves I Reg Clamping / performance impact and yellow graphics in certain areas.
+  gameFixes:
+    - IbitHack # Reduces VU recompilation.
   gsHWFixes:
     halfPixelOffset: 4 # Fixes post positioning.
     nativeScaling: 2 # Fixes post effects.
@@ -11698,6 +11716,8 @@ SCUS-97432:
   region: "NTSC-U"
   clampModes:
     vuClampMode: 0 # Resolves I Reg Clamping / performance impact and yellow graphics in certain areas.
+  gameFixes:
+    - IbitHack # Reduces VU recompilation.
   gsHWFixes:
     halfPixelOffset: 4 # Fixes post positioning.
     nativeScaling: 2 # Fixes post effects.
@@ -12141,6 +12161,8 @@ SCUS-97517:
   region: "NTSC-U"
   clampModes:
     vuClampMode: 0 # Resolves I Reg Clamping / performance impact and yellow graphics in certain areas.
+  gameFixes:
+    - IbitHack # Reduces VU recompilation.
   gsHWFixes:
     halfPixelOffset: 4 # Fixes post positioning.
     nativeScaling: 2 # Fixes post effects.
@@ -13335,6 +13357,8 @@ SLED-52899:
   region: "PAL-M5"
   clampModes:
     vuClampMode: 0 # Resolves I Reg Clamping / performance impact and yellow graphics in certain areas.
+  gameFixes:
+    - IbitHack # Reduces VU recompilation.
   gsHWFixes:
     halfPixelOffset: 4 # Fixes post positioning.
     nativeScaling: 2 # Fixes post effects.
@@ -18467,6 +18491,8 @@ SLES-51981:
   region: "PAL-E"
   clampModes:
     vuClampMode: 0 # Resolves I Reg Clamping / performance impact and yellow graphics in certain areas.
+  gameFixes:
+    - IbitHack # Reduces VU recompilation.
   gsHWFixes:
     roundSprite: 1 # Fixes slight blur.
     halfPixelOffset: 2 # Aligns sun post processing.
@@ -18476,6 +18502,8 @@ SLES-51982:
   region: "PAL-M3"
   clampModes:
     vuClampMode: 0 # Resolves I Reg Clamping / performance impact and yellow graphics in certain areas.
+  gameFixes:
+    - IbitHack # Reduces VU recompilation.
   gsHWFixes:
     roundSprite: 1 # Fixes slight blur.
     halfPixelOffset: 2 # Aligns sun post processing.
@@ -45826,6 +45854,8 @@ SLPM-66151:
   region: "NTSC-J"
   clampModes:
     vuClampMode: 0 # Resolves I Reg Clamping / performance impact and yellow graphics in certain areas.
+  gameFixes:
+    - IbitHack # Reduces VU recompilation.
   gsHWFixes:
     halfPixelOffset: 4 # Fixes post positioning.
     nativeScaling: 2 # Fixes post effects.
@@ -65595,6 +65625,8 @@ SLUS-20828:
   compat: 5
   clampModes:
     vuClampMode: 0 # Resolves I Reg Clamping / performance impact and yellow graphics in certain areas.
+  gameFixes:
+    - IbitHack # Reduces VU recompilation.
   gsHWFixes:
     roundSprite: 1 # Fixes slight blur.
     halfPixelOffset: 2 # Aligns sun post processing.
@@ -73175,6 +73207,8 @@ TCES-52004:
   region: "PAL-E"
   clampModes:
     vuClampMode: 0 # Resolves I Reg Clamping / performance impact and yellow graphics in certain areas.
+  gameFixes:
+    - IbitHack # Reduces VU recompilation.
   gsHWFixes:
     halfPixelOffset: 4 # Fixes post positioning.
     nativeScaling: 2 # Fixes post effects.

--- a/pcsx2/x86/microVU_Analyze.inl
+++ b/pcsx2/x86/microVU_Analyze.inl
@@ -228,7 +228,7 @@ __fi void mVUanalyzeIALU2(mV, int Is, int It)
 __fi void mVUanalyzeIADDI(mV, int Is, int It, s16 imm)
 {
 	mVUanalyzeIALU2(mVU, Is, It);
-	if (!Is)
+	if (!Is && !EmuConfig.Gamefixes.IbitHack)
 	{
 		setConstReg(It, imm);
 	}


### PR DESCRIPTION
### Description of Changes
Expand the IBit hack to several commands using immediates, to help reduce recompilation on games which modify these values a lot.

### Rationale behind Changes
Games like Shellshock - Nam '67 and Killzone modify their VU programs a lot, changing immediate values and nothing else in several cases, This expands the IBit hack to try and ignore these differences and load the values from RAM instead of compiling  new program.

### Suggested Testing Steps
Test Shellshock - Nam '67, Killzone, Scarface and Crash Tag Team racing.  If you know any other games that recompile constantly, try enabling the IBit gamefix and see if that helps.

Reduces VU compilation in Killzone by about half
Reduces VU compilation in Shellshock - Nam '67 by roughly 10% (reduces hitching by a bit)
