### PR TITLE
GSLzma: Fix a file handle leak in GSDumpLzma

### DIFF
--- a/pcsx2/GS/GSLzma.h
+++ b/pcsx2/GS/GSLzma.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include "common/FileSystem.h"
+
 #include <memory>
 #include <string>
 #include <vector>
@@ -305,9 +307,12 @@ public:
 protected:
 	GSDumpFile();
 
-	virtual bool Open(std::FILE* fp, Error* error) = 0;
+	virtual bool Open(FileSystem::ManagedCFilePtr fp, Error* error) = 0;
 	virtual bool IsEof() = 0;
 	virtual size_t Read(void* ptr, size_t size) = 0;
+
+protected:
+	FileSystem::ManagedCFilePtr m_fp;
 
 private:
 	std::string m_serial;


### PR DESCRIPTION
### Description of Changes
Moves the file handle to a base GSDump class and makes it managed, to make it impossible to miss closing it again.

### Rationale behind Changes
Playing back LZMA dumps leaked the file handle.

### Suggested Testing Steps
1. Launch PCSX2.
2. Play back any LZMA GSDump and shut it down without shutting down PCSX2.
3. Observe that it is now possible to delete the dump from disk without shutting down PCSX2, long as the dump is not running of course. Without this PR, PCSX2 must be entirely closed to allow to close the file.
