### PR TITLE
GS/HW: Allow preload if FBW = 0 on small draw

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -2408,8 +2408,9 @@ bool GSTextureCache::PreloadTarget(GIFRegTEX0 TEX0, const GSVector2i& size, cons
 	const GSLocalMemory::psm_t& psm_s = GSLocalMemory::m_psm[TEX0.PSM];
 	const bool supported_fmt = !GSConfig.UserHacks_DisableDepthSupport || psm_s.depth == 0;
 	std::optional<bool> hw_clear;
+	const bool valid_draw_size = TEX0.TBW > 0 || (psm_s.pgs.x >= size.x && psm_s.pgs.y >= size.y);
 
-	if (TEX0.TBW > 0 && supported_fmt)
+	if (valid_draw_size && supported_fmt)
 	{
 		const GSVector4i newrect = GSVector4i::loadh(size);
 		const u32 rect_end = GSLocalMemory::GetUnwrappedEndBlockAddress(TEX0.TBP0, TEX0.TBW, TEX0.PSM, newrect);


### PR DESCRIPTION
### Description of Changes
Allows preloading on FBW = 0 targets if the draw is less than or equal to one page.

### Rationale behind Changes
if it's legit a small target, this could be true. There's no reason to not allow it if the draw size is less than a page.

### Suggested Testing Steps
Dump run says it's fine, I guess try Armored Core - Nine Breaker

Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/e093cb04-7aa8-43c2-b317-475d0ecc3631)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/12c9e54d-6e90-4b00-8c04-f44e398df4f5)

Mips are still wrong on the water, but that will need a lot of work (or cpu sprite 2/2)