### PR TITLE
GS/HW: Check for format combinations that make sense for CSBW

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -6219,6 +6219,14 @@ bool GSRendererHW::CanUseSwPrimRender(bool no_rt, bool no_ds, bool draw_sprite_t
 					if (!rc.GetDirtyRect(m_cached_ctx.TEX0, false).rintersect(tr).rempty())
 						return true;
 				}
+
+				// Make sure it actually makes sense to use this target as a source, given the formats, and it wouldn't just sample as garbage.
+				// We can't rely exclusively on the dirty rect check above, because sometimes the targets are from older frames and too large.
+				if (!GSUtil::HasSameSwizzleBits(m_cached_ctx.TEX0.PSM, src_target->m_TEX0.PSM) &&
+					(!src_target->m_32_bits_fmt || GSLocalMemory::m_psm[m_cached_ctx.TEX0.PSM].bpp != 16))
+				{
+					return true;
+				}
 			}
 
 			return false;

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -2586,7 +2586,7 @@ bool GSTextureCache::PreloadTarget(GIFRegTEX0 TEX0, const GSVector2i& size, cons
 								// Clear the dirty first
 								dst->Update();
 								// Invalidate has been moved to after DrawPrims(), because we might kill the current sources' backing.
-								if (!t->m_valid_rgb || !(t->m_valid_alpha_high || t->m_valid_alpha_low))
+								if (!t->m_valid_rgb || !(t->m_valid_alpha_high || t->m_valid_alpha_low) || t->m_scale != dst->m_scale)
 								{
 									const GSVector4 src_rect = GSVector4(0, 0, copy_width, copy_height) / (GSVector4(t->m_texture->GetSize()).xyxy());
 									const GSVector4 dst_rect = GSVector4(0, dst_offset, copy_width, copy_height);


### PR DESCRIPTION
### Description of Changes

True Crime: New York City strikes again...

A downsampling target prevents CSBW from kicking in, resulting in corruption to one of the dynamically drawn/decompressed mipmaps.

### Rationale behind Changes

Fixes flickering/garbage texture in TC:NYC, sorry, I don't know the name of the level.

Also fixes a GPU crash I noticed when scrollwheeling resolutions.

Before:
![image](https://github.com/PCSX2/pcsx2/assets/11288319/0b321d53-c9b8-4f94-b0ac-c5d79ac1678f)
After:
![image](https://github.com/PCSX2/pcsx2/assets/11288319/4307c008-b91d-44f0-8560-00a64f700058)


### Suggested Testing Steps

Smoke test TC:NYC.

