### PR TITLE
Qt: Fix rare crash during update download

### DIFF
--- a/pcsx2-qt/AutoUpdaterDialog.cpp
+++ b/pcsx2-qt/AutoUpdaterDialog.cpp
@@ -503,6 +503,11 @@ void AutoUpdaterDialog::downloadUpdateClicked()
 		},
 		&progress);
 
+
+	// Since we're going to block, don't allow the timer to poll, otherwise the progress callback can cause the timer to
+	// run, and recursively poll again.
+	m_http_poll_timer->stop();
+
 	// Block until completion.
 	while (m_http->HasAnyRequests())
 	{


### PR DESCRIPTION
### Description of Changes
Fixes a possible crash when initiating the update download before the changelog has finished fetching. Port of https://github.com/stenzek/duckstation/commit/52bdbf35dbc9a484bf2d4385a6665399a5de0a2c

### Rationale behind Changes
Crash bad, parity with DuckStation good.

### Suggested Testing Steps
Verify that the updater works, fetches the changelog, downloads the update etc.
