### PR TITLE
DEV9: TCP Cleanup

### DIFF
--- a/pcsx2/DEV9/Sessions/TCP_Session/TCP_Session.cpp
+++ b/pcsx2/DEV9/Sessions/TCP_Session/TCP_Session.cpp
@@ -90,21 +90,21 @@ namespace Sessions
 		if (delta > 0.5 * UINT_MAX)
 		{
 			delta = -static_cast<s64>(UINT_MAX) + a - b - 1;
-			Console.Error("DEV9: TCP: [PS2] SequenceNumber Overflow Detected");
-			Console.Error("DEV9: TCP: [PS2] New Data Offset: %d bytes", delta);
+			Console.Error("DEV9: TCP: [PS2] Sequence number overflow detected");
+			Console.Error("DEV9: TCP: [PS2] New data offset: %d bytes", delta);
 		}
 		if (delta < -0.5 * UINT_MAX)
 		{
 			delta = UINT_MAX - b + a + 1;
-			Console.Error("DEV9: TCP: [PS2] SequenceNumber Overflow Detected");
-			Console.Error("DEV9: TCP: [PS2] New Data Offset: %d bytes", delta);
+			Console.Error("DEV9: TCP: [PS2] Sequence number overflow detected");
+			Console.Error("DEV9: TCP: [PS2] New data offset: %d bytes", delta);
 		}
 		return delta;
 	}
 
 	TCP_Packet* TCP_Session::CreateBasePacket(PayloadData* data)
 	{
-		//DevCon.WriteLn("Creating Base Packet");
+		//DevCon.WriteLn("Creating base packet");
 		if (data == nullptr)
 			data = new PayloadData(0);
 

--- a/pcsx2/DEV9/Sessions/TCP_Session/TCP_Session.cpp
+++ b/pcsx2/DEV9/Sessions/TCP_Session/TCP_Session.cpp
@@ -110,7 +110,7 @@ namespace Sessions
 
 		TCP_Packet* ret = new TCP_Packet(data);
 
-		//and now to setup THE ENTIRE THING
+		// Setup common packet infomation
 		ret->sourcePort = destPort;
 		ret->destinationPort = srcPort;
 
@@ -149,7 +149,6 @@ namespace Sessions
 
 	void TCP_Session::Reset()
 	{
-		//CloseSocket();
 		RaiseEventConnectionClosed();
 	}
 
@@ -157,7 +156,7 @@ namespace Sessions
 	{
 		CloseSocket();
 
-		//Clear out _recvBuff
+		// Clear out _recvBuff
 		while (!_recvBuff.IsQueueEmpty())
 		{
 			TCP_Packet* retPay;

--- a/pcsx2/DEV9/Sessions/TCP_Session/TCP_Session_In.cpp
+++ b/pcsx2/DEV9/Sessions/TCP_Session/TCP_Session_In.cpp
@@ -50,18 +50,20 @@ namespace Sessions
 				return nullptr;
 			}
 			case TCP_State::SentSYN_ACK:
-				//Don't read data untill PS2 ACKs connection
+				// Don't read data untill PS2 ACKs connection
 				return nullptr;
 			case TCP_State::CloseCompletedFlushBuffer:
-				//When TCP connection is closed by the server
-				//the server is the last to send a packet
-				//so the event must be raised here
+				/*
+				 * When TCP connection is closed by the server
+				 * the server is the last to send a packet
+				 * so the event must be raised here
+				 */
 				state = TCP_State::CloseCompleted;
 				RaiseEventConnectionClosed();
 				return nullptr;
 			case TCP_State::Connected:
 			case TCP_State::Closing_ClosedByPS2:
-				//Only accept data in above two states
+				// Only accept data in above two states
 				break;
 			default:
 				return nullptr;
@@ -70,8 +72,8 @@ namespace Sessions
 		if (ShouldWaitForAck())
 			return nullptr;
 
-		//Note, windowSize will be updated before _ReceivedAckNumber, potential race condition
-		//in practice, we just get a smaller or -ve maxSize
+		// Note, windowSize will be updated before _ReceivedAckNumber, potential race condition
+		// in practice, we just get a smaller or -ve maxSize
 		const u32 outstanding = GetOutstandingSequenceLength();
 
 		int maxSize = 0;
@@ -86,8 +88,8 @@ namespace Sessions
 			int err = 0;
 			int recived;
 
-			//FIONREAD uses unsigned long on windows and int on linux
-			//Zero init so we don't have bad data on any unused bytes
+			// FIONREAD uses unsigned long on windows and int on linux
+			// Zero init so we don't have bad data on any unused bytes
 			unsigned long available = 0;
 #ifdef _WIN32
 			err = ioctlsocket(client, FIONREAD, &available);
@@ -113,9 +115,8 @@ namespace Sessions
 #ifdef _WIN32
 					case WSAEINVAL:
 					case WSAESHUTDOWN:
-						//In theory, this should only occur when the PS2 has RST the connection
-						//and the call to TCPSession.Recv() occurs at just the right time.
-
+						// In theory, this should only occur when the PS2 has RST the connection
+						// and the call to TCPSession.Recv() occurs at just the right time.
 						//Console.WriteLn("DEV9: TCP: Recv() on shutdown socket");
 						return nullptr;
 					case WSAEWOULDBLOCK:
@@ -123,7 +124,7 @@ namespace Sessions
 #elif defined(__POSIX__)
 					case EINVAL:
 					case ESHUTDOWN:
-						//See WSAESHUTDOWN
+						// See WSAESHUTDOWN
 						//Console.WriteLn("DEV9: TCP: Recv() on shutdown socket");
 						return nullptr;
 					case EWOULDBLOCK:
@@ -137,7 +138,7 @@ namespace Sessions
 						return nullptr;
 				}
 
-				//Server Closed Socket
+				// Server closed the Socket
 				if (recived == 0)
 				{
 					int result = shutdown(client, SD_RECEIVE);
@@ -189,7 +190,7 @@ namespace Sessions
 			state = TCP_State::SentSYN_ACK;
 
 			TCP_Packet* ret = new TCP_Packet(new PayloadData(0));
-			//Return the fact we connected
+			// Send packet to say we connected
 			ret->sourcePort = destPort;
 			ret->destinationPort = srcPort;
 

--- a/pcsx2/DEV9/Sessions/TCP_Session/TCP_Session_In.cpp
+++ b/pcsx2/DEV9/Sessions/TCP_Session/TCP_Session_In.cpp
@@ -141,7 +141,7 @@ namespace Sessions
 				// Server closed the Socket
 				if (recived == 0)
 				{
-					int result = shutdown(client, SD_RECEIVE);
+					const int result = shutdown(client, SD_RECEIVE);
 					if (result == SOCKET_ERROR)
 						Console.Error("DEV9: TCP: Shutdown SD_RECEIVE error: %d",
 #ifdef _WIN32

--- a/pcsx2/DEV9/Sessions/TCP_Session/TCP_Session_In.cpp
+++ b/pcsx2/DEV9/Sessions/TCP_Session/TCP_Session_In.cpp
@@ -100,7 +100,7 @@ namespace Sessions
 					Console.WriteLn("DEV9: TCP: Got a lot of data: %lu Using: %d", available, maxSize);
 
 				buffer = std::make_unique<u8[]>(maxSize);
-				recived = recv(client, (char*)buffer.get(), maxSize, 0);
+				recived = recv(client, reinterpret_cast<char*>(buffer.get()), maxSize, 0);
 				if (recived == -1)
 #ifdef _WIN32
 					err = WSAGetLastError();
@@ -223,11 +223,11 @@ namespace Sessions
 			int error = 0;
 #ifdef _WIN32
 			int len = sizeof(error);
-			if (getsockopt(client, SOL_SOCKET, SO_ERROR, (char*)&error, &len) < 0)
+			if (getsockopt(client, SOL_SOCKET, SO_ERROR, reinterpret_cast<char*>(&error), &len) < 0)
 				Console.Error("DEV9: TCP: Unkown TCP Connection Error (getsockopt Error: %d)", WSAGetLastError());
 #elif defined(__POSIX__)
 			socklen_t len = sizeof(error);
-			if (getsockopt(client, SOL_SOCKET, SO_ERROR, (char*)&error, &len) < 0)
+			if (getsockopt(client, SOL_SOCKET, SO_ERROR, reinterpret_cast<char*>(&error), &len) < 0)
 				Console.Error("DEV9: TCP: Unkown TCP Connection Error (getsockopt Error: %d)", errno);
 #endif
 			else

--- a/pcsx2/DEV9/Sessions/TCP_Session/TCP_Session_In.cpp
+++ b/pcsx2/DEV9/Sessions/TCP_Session/TCP_Session_In.cpp
@@ -97,7 +97,7 @@ namespace Sessions
 			if (err != SOCKET_ERROR)
 			{
 				if (available > static_cast<uint>(maxSize))
-					Console.WriteLn("DEV9: TCP: Got a lot of data: %lu Using: %d", available, maxSize);
+					Console.WriteLn("DEV9: TCP: Got a lot of data: %lu using: %d", available, maxSize);
 
 				buffer = std::make_unique<u8[]>(maxSize);
 				recived = recv(client, reinterpret_cast<char*>(buffer.get()), maxSize, 0);
@@ -133,7 +133,7 @@ namespace Sessions
 						break;
 					default:
 						CloseByRemoteRST();
-						Console.Error("DEV9: TCP: Recv Error: %d", err);
+						Console.Error("DEV9: TCP: Recv error: %d", err);
 						return nullptr;
 				}
 
@@ -142,7 +142,7 @@ namespace Sessions
 				{
 					int result = shutdown(client, SD_RECEIVE);
 					if (result == SOCKET_ERROR)
-						Console.Error("DEV9: TCP: Shutdown SD_RECEIVE Error: %d",
+						Console.Error("DEV9: TCP: Shutdown SD_RECEIVE error: %d",
 #ifdef _WIN32
 							WSAGetLastError());
 #elif defined(__POSIX__)
@@ -157,7 +157,7 @@ namespace Sessions
 							return CloseByPS2Stage3();
 						default:
 							CloseByRemoteRST();
-							Console.Error("DEV9: TCP: Remote Close In Invalid State");
+							Console.Error("DEV9: TCP: Remote close occured with invalid TCP state");
 							break;
 					}
 					return nullptr;
@@ -174,7 +174,7 @@ namespace Sessions
 				iRet->SetPSH(true);
 
 				myNumberACKed.store(false);
-				//DevCon.WriteLn("DEV9: TCP: myNumberACKed Reset");
+				//DevCon.WriteLn("DEV9: TCP: myNumberACKed reset");
 				return iRet;
 			}
 		}
@@ -224,14 +224,14 @@ namespace Sessions
 #ifdef _WIN32
 			int len = sizeof(error);
 			if (getsockopt(client, SOL_SOCKET, SO_ERROR, reinterpret_cast<char*>(&error), &len) < 0)
-				Console.Error("DEV9: TCP: Unkown TCP Connection Error (getsockopt Error: %d)", WSAGetLastError());
+				Console.Error("DEV9: TCP: Unkown TCP connection error (getsockopt error: %d)", WSAGetLastError());
 #elif defined(__POSIX__)
 			socklen_t len = sizeof(error);
 			if (getsockopt(client, SOL_SOCKET, SO_ERROR, reinterpret_cast<char*>(&error), &len) < 0)
-				Console.Error("DEV9: TCP: Unkown TCP Connection Error (getsockopt Error: %d)", errno);
+				Console.Error("DEV9: TCP: Unkown TCP connection error (getsockopt error: %d)", errno);
 #endif
 			else
-				Console.Error("DEV9: TCP: Send Error: %d", error);
+				Console.Error("DEV9: TCP: Send error: %d", error);
 
 			state = TCP_State::CloseCompleted;
 			RaiseEventConnectionClosed();
@@ -250,7 +250,7 @@ namespace Sessions
 		ret->SetFIN(true);
 
 		myNumberACKed.store(false);
-		//DevCon.WriteLn("myNumberACKed Reset");
+		//DevCon.WriteLn("myNumberACKed reset");
 
 		state = TCP_State::Closing_ClosedByPS2ThenRemote_WaitingForAck;
 		return ret;
@@ -267,7 +267,7 @@ namespace Sessions
 		ret->SetFIN(true);
 
 		myNumberACKed.store(false);
-		//DevCon.WriteLn("myNumberACKed Reset");
+		//DevCon.WriteLn("myNumberACKed reset");
 
 		state = TCP_State::Closing_ClosedByRemote;
 		return ret;

--- a/pcsx2/DEV9/Sessions/TCP_Session/TCP_Session_Out.cpp
+++ b/pcsx2/DEV9/Sessions/TCP_Session/TCP_Session_Out.cpp
@@ -335,7 +335,7 @@ namespace Sessions
 				PayloadPtr* payload = static_cast<PayloadPtr*>(tcp->GetPayload());
 				while (sent != payload->GetLength())
 				{
-					int ret = send(client, reinterpret_cast<const char*>(&payload->data[sent]), payload->GetLength() - sent, 0);
+					const int ret = send(client, reinterpret_cast<const char*>(&payload->data[sent]), payload->GetLength() - sent, 0);
 
 					if (ret == SOCKET_ERROR)
 					{
@@ -475,7 +475,7 @@ namespace Sessions
 	}
 	bool TCP_Session::ValidateEmptyPacket(TCP_Packet* tcp, bool ignoreOld)
 	{
-		NumCheckResult ResultFIN = CheckNumbers(tcp, !ignoreOld);
+		const NumCheckResult ResultFIN = CheckNumbers(tcp, !ignoreOld);
 		if (ResultFIN == NumCheckResult::Bad)
 		{
 			CloseByRemoteRST();
@@ -578,7 +578,7 @@ namespace Sessions
 		receivedPS2SeqNumbers.push_back(expectedSeqNumber);
 		expectedSeqNumber += 1;
 
-		int result = shutdown(client, SD_SEND);
+		const int result = shutdown(client, SD_SEND);
 		if (result == SOCKET_ERROR)
 			Console.Error("DEV9: TCP: Shutdown SD_SEND error: %d",
 #ifdef _WIN32

--- a/pcsx2/DEV9/Sessions/TCP_Session/TCP_Session_Out.cpp
+++ b/pcsx2/DEV9/Sessions/TCP_Session/TCP_Session_Out.cpp
@@ -337,7 +337,7 @@ namespace Sessions
 				{
 					int ret = send(client, reinterpret_cast<const char*>(&payload->data[sent]), payload->GetLength() - sent, 0);
 
-					if (sent == SOCKET_ERROR)
+					if (ret == SOCKET_ERROR)
 					{
 #ifdef _WIN32
 						const int err = WSAGetLastError();

--- a/pcsx2/DEV9/Sessions/TCP_Session/TCP_Session_Out.cpp
+++ b/pcsx2/DEV9/Sessions/TCP_Session/TCP_Session_Out.cpp
@@ -168,7 +168,7 @@ namespace Sessions
 			endpoint.sin_family = AF_INET;
 			endpoint.sin_addr = std::bit_cast<in_addr>(adapterIP);
 
-			ret = bind(client, (const sockaddr*)&endpoint, sizeof(endpoint));
+			ret = bind(client, reinterpret_cast<const sockaddr*>(&endpoint), sizeof(endpoint));
 
 			if (ret != 0)
 				Console.Error("DEV9: UDP: Failed to bind socket. Error: %d",
@@ -212,7 +212,7 @@ namespace Sessions
 		endpoint.sin_addr = std::bit_cast<in_addr>(destIP);
 		endpoint.sin_port = htons(destPort);
 
-		ret = connect(client, (const sockaddr*)&endpoint, sizeof(endpoint));
+		ret = connect(client, reinterpret_cast<const sockaddr*>(&endpoint), sizeof(endpoint));
 
 		if (ret != 0)
 		{

--- a/pcsx2/DEV9/Sessions/TCP_Session/TCP_Session_Out.cpp
+++ b/pcsx2/DEV9/Sessions/TCP_Session/TCP_Session_Out.cpp
@@ -46,7 +46,7 @@ namespace Sessions
 			if (client != INVALID_SOCKET)
 				CloseSocket();
 			else
-				Console.Error("DEV9: TCP: RESET CLOSED CONNECTION");
+				Console.Error("DEV9: TCP: Reset closed connection");
 			//PS2 sent RST
 			//clearly not expecting
 			//more data
@@ -62,7 +62,7 @@ namespace Sessions
 			case TCP_State::SendingSYN_ACK:
 				if (CheckRepeatSYNNumbers(&tcp) == NumCheckResult::Bad)
 				{
-					Console.Error("DEV9: TCP: Invalid Repeated SYN (SendingSYN_ACK)");
+					Console.Error("DEV9: TCP: Invalid repeated SYN (SendingSYN_ACK)");
 					return false;
 				}
 				return true; //Ignore reconnect attempts while we are still attempting connection
@@ -91,7 +91,7 @@ namespace Sessions
 				return false;
 			default:
 				CloseByRemoteRST();
-				Console.Error("DEV9: TCP: Invalid TCP State");
+				Console.Error("DEV9: TCP: Invalid TCP state");
 				return true;
 		}
 	}
@@ -106,7 +106,7 @@ namespace Sessions
 		if (tcp->GetSYN() == false)
 		{
 			CloseByRemoteRST();
-			Console.Error("DEV9: TCP: Attempt To Send Data On Non Connected Connection");
+			Console.Error("DEV9: TCP: Attempt to send data to a non connected connection");
 			return true;
 		}
 		expectedSeqNumber = tcp->sequenceNumber + 1;
@@ -130,7 +130,7 @@ namespace Sessions
 				case 3: //WindowScale
 					windowScale = static_cast<TCPopWS*>(tcp->options[i])->windowScale;
 					if (windowScale > 0)
-						Console.Error("DEV9: TCP: Non-Zero WindowScale Option");
+						Console.Error("DEV9: TCP: Non-zero window scale option");
 					break;
 				case 8: //TimeStamp
 					lastRecivedTimeStamp = static_cast<TCPopTS*>(tcp->options[i])->senderTimeStamp;
@@ -138,7 +138,7 @@ namespace Sessions
 					timeStampStart = std::chrono::steady_clock::now();
 					break;
 				default:
-					Console.Error("DEV9: TCP: Got Unknown Option %d", tcp->options[i]->GetCode());
+					Console.Error("DEV9: TCP: Got unknown option %d", tcp->options[i]->GetCode());
 					break;
 			}
 		}
@@ -188,7 +188,7 @@ namespace Sessions
 #endif
 
 		if (ret != 0)
-			Console.Error("DEV9: TCP: Failed to set non blocking. Error: %d",
+			Console.Error("DEV9: TCP: Failed to set non-blocking. Error: %d",
 #ifdef _WIN32
 				WSAGetLastError());
 #elif defined(__POSIX__)
@@ -243,7 +243,7 @@ namespace Sessions
 			if (CheckRepeatSYNNumbers(tcp) == NumCheckResult::Bad)
 			{
 				CloseByRemoteRST();
-				Console.Error("DEV9: TCP: Invalid Repeated SYN (SentSYN_ACK)");
+				Console.Error("DEV9: TCP: Invalid repeated SYN (SentSYN_ACK)");
 				return true;
 			}
 			return true; //Ignore reconnect attempts while we are still attempting connection
@@ -252,7 +252,7 @@ namespace Sessions
 		if (Result == NumCheckResult::Bad)
 		{
 			CloseByRemoteRST();
-			Console.Error("DEV9: TCP: Bad TCP Numbers Received");
+			Console.Error("DEV9: TCP: Bad TCP numbers received");
 			return true;
 		}
 
@@ -267,7 +267,7 @@ namespace Sessions
 					lastRecivedTimeStamp = static_cast<TCPopTS*>(tcp->options[i])->senderTimeStamp;
 					break;
 				default:
-					Console.Error("DEV9: TCP: Got Unknown Option %d", tcp->options[i]->GetCode());
+					Console.Error("DEV9: TCP: Got unknown option %d", tcp->options[i]->GetCode());
 					break;
 			}
 		}
@@ -281,13 +281,13 @@ namespace Sessions
 		if (tcp->GetSYN())
 		{
 			CloseByRemoteRST();
-			Console.Error("DEV9: TCP: Attempt to Connect to an open Port");
+			Console.Error("DEV9: TCP: Attempt to connect to an existing connection");
 			return true;
 		}
 		if (tcp->GetURG())
 		{
 			CloseByRemoteRST();
-			Console.Error("DEV9: TCP: Urgent Data Not Supported");
+			Console.Error("DEV9: TCP: Urgent data not supported");
 			return true;
 		}
 		for (size_t i = 0; i < tcp->options.size(); i++)
@@ -301,7 +301,7 @@ namespace Sessions
 					lastRecivedTimeStamp = static_cast<TCPopTS*>(tcp->options[i])->senderTimeStamp;
 					break;
 				default:
-					Console.Error("DEV9: TCP: Got Unknown Option %d", tcp->options[i]->GetCode());
+					Console.Error("DEV9: TCP: Got unknown option %d", tcp->options[i]->GetCode());
 					break;
 			}
 		}
@@ -313,7 +313,7 @@ namespace Sessions
 		if (Result == NumCheckResult::Bad)
 		{
 			CloseByRemoteRST();
-			Console.Error("DEV9: TCP: Bad TCP Numbers Received");
+			Console.Error("DEV9: TCP: Bad TCP numbers received");
 			return true;
 		}
 		if (tcp->GetPayload()->GetLength() != 0)
@@ -323,8 +323,8 @@ namespace Sessions
 			pxAssert(delta >= 0);
 			//if (Result == NumCheckResult::OldSeq)
 			//{
-			//	DevCon.WriteLn("[PS2] New Data Offset: %d bytes", delta);
-			//	DevCon.WriteLn("[PS2] New Data Length: %d bytes", tcp->GetPayload()->GetLength() - delta);
+			//	DevCon.WriteLn("[PS2] New data offset: %d bytes", delta);
+			//	DevCon.WriteLn("[PS2] New data length: %d bytes", tcp->GetPayload()->GetLength() - delta);
 			//}
 			if (tcp->GetPayload()->GetLength() - delta > 0)
 			{
@@ -353,7 +353,7 @@ namespace Sessions
 						else
 						{
 							CloseByRemoteRST();
-							Console.Error("DEV9: TCP: Send Error: %d", err);
+							Console.Error("DEV9: TCP: Send error: %d", err);
 							return true;
 						}
 					}
@@ -365,7 +365,7 @@ namespace Sessions
 				//Done send
 			}
 			//ACK data
-			//DevCon.WriteLn("[SRV] ACK Data: %u", expectedSeqNumber);
+			//DevCon.WriteLn("[SRV] ACK data: %u", expectedSeqNumber);
 			TCP_Packet* ret = CreateBasePacket();
 			ret->SetACK(true);
 
@@ -379,7 +379,7 @@ namespace Sessions
 		if (tcp->GetSYN() == true)
 		{
 			CloseByRemoteRST();
-			Console.Error("DEV9: TCP: Attempt to Connect to an open Port");
+			Console.Error("DEV9: TCP: Attempt to connect to an existing connection");
 			return true;
 		}
 		for (size_t i = 0; i < tcp->options.size(); i++)
@@ -406,11 +406,11 @@ namespace Sessions
 	TCP_Session::NumCheckResult TCP_Session::CheckRepeatSYNNumbers(TCP_Packet* tcp)
 	{
 		//DevCon.WriteLn("DEV9: TCP: CHECK_REPEAT_SYN_NUMBERS");
-		//DevCon.WriteLn("DEV9: TCP: [SRV] CurrAckNumber = %u [PS2] Seq Number = %u", expectedSeqNumber, tcp->sequenceNumber);
+		//DevCon.WriteLn("DEV9: TCP: [SRV] CurrAckNumber = %u [PS2] Seq number = %u", expectedSeqNumber, tcp->sequenceNumber);
 
 		if (tcp->sequenceNumber != expectedSeqNumber - 1)
 		{
-			Console.Error("DEV9: TCP: [PS2] Sent Unexpected Sequence Number From Repeated SYN Packet, Got %u Expected %u", tcp->sequenceNumber, (expectedSeqNumber - 1));
+			Console.Error("DEV9: TCP: [PS2] Sent unexpected sequence number from repeated SYN packet, got %u expected %u", tcp->sequenceNumber, (expectedSeqNumber - 1));
 			return NumCheckResult::Bad;
 		}
 		return NumCheckResult::OK;
@@ -423,24 +423,24 @@ namespace Sessions
 		std::tie(seqNum, oldSeqNums) = GetAllMyNumbers();
 
 		//DevCon.WriteLn("DEV9: TCP: CHECK_NUMBERS");
-		//DevCon.WriteLn("DEV9: TCP: [SRV] CurrSeqNumber = %u [PS2] Ack Number = %u", seqNum, tcp->acknowledgementNumber);
-		//DevCon.WriteLn("DEV9: TCP: [SRV] CurrAckNumber = %u [PS2] Seq Number = %u", expectedSeqNumber, tcp->sequenceNumber);
-		//DevCon.WriteLn("DEV9: TCP: [PS2] Data Length = %u",  tcp->GetPayload()->GetLength());
+		//DevCon.WriteLn("DEV9: TCP: [SRV] CurrSeqNumber = %u [PS2] Ack number = %u", seqNum, tcp->acknowledgementNumber);
+		//DevCon.WriteLn("DEV9: TCP: [SRV] CurrAckNumber = %u [PS2] Seq number = %u", expectedSeqNumber, tcp->sequenceNumber);
+		//DevCon.WriteLn("DEV9: TCP: [PS2] Data length = %u",  tcp->GetPayload()->GetLength());
 
 		if (tcp->acknowledgementNumber != seqNum)
 		{
-			//DevCon.WriteLn("DEV9: TCP: [PS2] Sent Outdated Acknowledgement Number, Got %u Expected %u", tcp->acknowledgementNumber, seqNum);
+			//DevCon.WriteLn("DEV9: TCP: [PS2] Sent outdated acknowledgement number, got %u expected %u", tcp->acknowledgementNumber, seqNum);
 
 			//Check if oldSeqNums contains tcp->acknowledgementNumber
 			if (std::find(oldSeqNums.begin(), oldSeqNums.end(), tcp->acknowledgementNumber) == oldSeqNums.end())
 			{
-				Console.Error("DEV9: TCP: [PS2] Sent Unexpected Acknowledgement Number, did not Match Old Numbers, Got %u Expected %u", tcp->acknowledgementNumber, seqNum);
+				Console.Error("DEV9: TCP: [PS2] Sent unexpected acknowledgement number, did not match old numbers, got %u expected %u", tcp->acknowledgementNumber, seqNum);
 				return NumCheckResult::Bad;
 			}
 		}
 		else
 		{
-			//DevCon.WriteLn("[PS2] CurrSeqNumber Acknowleged By PS2");
+			//DevCon.WriteLn("[PS2] CurrSeqNumber acknowledged by PS2");
 			myNumberACKed.store(true);
 		}
 
@@ -450,12 +450,12 @@ namespace Sessions
 		{
 			if (rejectOldSeq)
 			{
-				Console.Error("DEV9: TCP: [PS2] Sent Unexpected Sequence Number, Got %u Expected %u", tcp->sequenceNumber, expectedSeqNumber);
+				Console.Error("DEV9: TCP: [PS2] Sent unexpected sequence number, got %u expected %u", tcp->sequenceNumber, expectedSeqNumber);
 				return NumCheckResult::Bad;
 			} 
 			else if (tcp->GetPayload()->GetLength() == 0)
 			{
-				Console.Error("DEV9: TCP: [PS2] Sent Unexpected Sequence Number From ACK Packet, Got %u Expected %u", tcp->sequenceNumber, expectedSeqNumber);
+				Console.Error("DEV9: TCP: [PS2] Sent unexpected sequence number in a empty packet, got %u expected %u", tcp->sequenceNumber, expectedSeqNumber);
 				return NumCheckResult::OldSeq;
 			}
 			else
@@ -463,12 +463,12 @@ namespace Sessions
 				//Check if receivedPS2SeqNumbers contains tcp->sequenceNumber
 				if (std::find(receivedPS2SeqNumbers.begin(), receivedPS2SeqNumbers.end(), tcp->sequenceNumber) == receivedPS2SeqNumbers.end())
 				{
-					Console.Error("DEV9: TCP: [PS2] Sent an Old Seq Number on an Data packet, Got %u Expected %u", tcp->sequenceNumber, expectedSeqNumber);
+					Console.Error("DEV9: TCP: [PS2] Sent outdated sequence number in an data packet, got %u expected %u", tcp->sequenceNumber, expectedSeqNumber);
 					return NumCheckResult::OldSeq;
 				}
 				else
 				{
-					Console.Error("DEV9: TCP: [PS2] Sent Unexpected Sequence Number From Data Packet, Got %u Expected %u", tcp->sequenceNumber, expectedSeqNumber);
+					Console.Error("DEV9: TCP: [PS2] Sent unexpected sequence number in a data packet, got %u expected %u", tcp->sequenceNumber, expectedSeqNumber);
 					return NumCheckResult::Bad;
 				}
 			}
@@ -482,7 +482,7 @@ namespace Sessions
 		if (ResultFIN == NumCheckResult::Bad)
 		{
 			CloseByRemoteRST();
-			Console.Error("DEV9: TCP: Bad TCP Numbers Received");
+			Console.Error("DEV9: TCP: Bad TCP numbers received");
 			return true;
 		}
 		if (tcp->GetPayload()->GetLength() > 0)
@@ -494,7 +494,7 @@ namespace Sessions
 				return false;
 
 			CloseByRemoteRST();
-			Console.Error("DEV9: TCP: Invalid Packet, Packet Has Data");
+			Console.Error("DEV9: TCP: Invalid packet, packet has data");
 			return true;
 		}
 		return false;
@@ -516,7 +516,7 @@ namespace Sessions
 
 		const int result = shutdown(client, SD_SEND);
 		if (result == SOCKET_ERROR)
-			Console.Error("DEV9: TCP: Shutdown SD_SEND Error: %d",
+			Console.Error("DEV9: TCP: Shutdown SD_SEND error: %d",
 #ifdef _WIN32
 				WSAGetLastError());
 #elif defined(__POSIX__)
@@ -536,7 +536,7 @@ namespace Sessions
 	bool TCP_Session::CloseByPS2Stage4(TCP_Packet* tcp)
 	{
 		//Close Part 4, Receive ACK from PS2
-		//Console.WriteLn("DEV9: TCP: Completed Close By PS2");
+		//Console.WriteLn("DEV9: TCP: Completed close by PS2");
 
 		if (ValidateEmptyPacket(tcp))
 			return true;
@@ -555,7 +555,7 @@ namespace Sessions
 
 	bool TCP_Session::CloseByRemoteStage2_ButAfter4(TCP_Packet* tcp)
 	{
-		//Console.WriteLn("DEV9: TCP: Completed Close By PS2");
+		//Console.WriteLn("DEV9: TCP: Completed close by PS2");
 
 		if (ValidateEmptyPacket(tcp))
 			return true;
@@ -583,7 +583,7 @@ namespace Sessions
 
 		int result = shutdown(client, SD_SEND);
 		if (result == SOCKET_ERROR)
-			Console.Error("DEV9: TCP: Shutdown SD_SEND Error: %d",
+			Console.Error("DEV9: TCP: Shutdown SD_SEND error: %d",
 #ifdef _WIN32
 				WSAGetLastError());
 #elif defined(__POSIX__)


### PR DESCRIPTION
### Description of Changes
Replace C-Style casts with C++ equivalents.
Make capitalisation of text in log messages consistent.
Format comments to (hopefully) be more inline with PCSX2's comment style
Fix incorrect error check on TCP send
Add a few missing const

It may be easier to review each commit one by one rather than the whole pr at once

### Rationale behind Changes
Improve code quality
Fix a broken error check

### Suggested Testing Steps
Test networked games using the sockets backend.
