### PR TITLE
HeapArray: Avoid writing out of bounds in internal_resize

### DIFF
--- a/common/HeapArray.h
+++ b/common/HeapArray.h
@@ -362,7 +362,7 @@ private:
 
 			if (prev_ptr)
 			{
-				std::memcpy(m_data, prev_ptr, prev_size * sizeof(T));
+				std::memcpy(m_data, prev_ptr, std::min(size, prev_size) * sizeof(T));
 				std::free(prev_ptr);
 			}
 #endif


### PR DESCRIPTION
### Description of Changes
The non-MSVC implementation of `DynamicHeapArray<T>::internal_resize` contains a buffer overrun when the new size is smaller than the previous size, as it just performs a `memcpy(data, prev, prev_size)` without checking the size of `data`. This PR fixes the problem by using `min(size, prev_size)` instead of `prev_size`.

### Rationale behind Changes
This issue caused a crash when changing from 128MB RAM back to the default 32MB RAM in https://github.com/PCSX2/pcsx2/pull/11111 on Linux.