### PR TITLE
GameDB: Jak 1 and CMR 2005 fixes

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -243,20 +243,24 @@ PAPX-90222:
   name-en: "Jak x Daxter - Kyuu Sekai no Isan [Demo]"
   region: "NTSC-J"
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves reflection quality.
     mipmap: 2 # Fixes broken textures.
     trilinearFiltering: 1 # Fixes water textures.
     cpuSpriteRenderBW: 4 # Fixes character and water textures.
     cpuSpriteRenderLevel: 2 # Needed for above.
+    autoFlush: 2 # Fixes gate warp effect and emissive texture effects.
 PAPX-90223:
   name: ジャック×ダクスター 旧世界の遺産 体験版
   name-sort: じゃっくだくすたー きゅうせかいのいさん たいけんばん
   name-en: "Jak x Daxter - Kyuu Sekai no Isan [Demo]"
   region: "NTSC-J"
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves reflection quality.
     mipmap: 2 # Fixes broken textures.
     trilinearFiltering: 1 # Fixes water textures.
     cpuSpriteRenderBW: 4 # Fixes character and water textures.
     cpuSpriteRenderLevel: 2 # Needed for above.
+    autoFlush: 2 # Fixes gate warp effect and emissive texture effects.
 PAPX-90224:
   name: "Sidewinder F"
   region: "NTSC-J"
@@ -4505,10 +4509,12 @@ SCES-50361:
   region: "PAL-M6"
   compat: 5
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves reflection quality.
     mipmap: 2 # Fixes broken textures.
     trilinearFiltering: 1 # Fixes water textures.
     cpuSpriteRenderBW: 4 # Fixes character and water textures.
     cpuSpriteRenderLevel: 2 # Needed for above.
+    autoFlush: 2 # Fixes gate warp effect and emissive texture effects.
 SCES-50408:
   name: "PaRappa the Rapper 2"
   region: "PAL-M5"
@@ -4685,10 +4691,12 @@ SCES-50614:
   name: "Jak and Daxter - The Precursor Legacy"
   region: "PAL-Unk"
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves reflection quality.
     mipmap: 2 # Fixes broken textures.
     trilinearFiltering: 1 # Fixes water textures.
     cpuSpriteRenderBW: 4 # Fixes character and water textures.
     cpuSpriteRenderLevel: 2 # Needed for above.
+    autoFlush: 2 # Fixes gate warp effect and emissive texture effects.
 SCES-50759:
   name: "Virtua Fighter 4"
   region: "PAL-M5"
@@ -8123,10 +8131,12 @@ SCPS-15021:
   name-en: "Jak x Daxter - Kyuusekai no Isan"
   region: "NTSC-J"
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves reflection quality.
     mipmap: 2 # Fixes broken textures.
     trilinearFiltering: 1 # Fixes water textures.
     cpuSpriteRenderBW: 4 # Fixes character and water textures.
     cpuSpriteRenderLevel: 2 # Needed for above.
+    autoFlush: 2 # Fixes gate warp effect and emissive texture effects.
 SCPS-15022:
   name: デュアルハーツ
   name-sort: でゅあるはーつ
@@ -9223,10 +9233,12 @@ SCPS-19210:
   name-en: "Jak x Daxter - Kyuusekai no Isan [PlayStation 2 the Best]"
   region: "NTSC-J"
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves reflection quality.
     mipmap: 2 # Fixes broken textures.
     trilinearFiltering: 1 # Fixes water textures.
     cpuSpriteRenderBW: 4 # Fixes character and water textures.
     cpuSpriteRenderLevel: 2 # Needed for above.
+    autoFlush: 2 # Fixes gate warp effect and emissive texture effects.
 SCPS-19211:
   name: ラチェット＆クランク PlayStation 2 the Best
   name-sort: らちぇっとあんどくらんく PlayStation 2 the Best
@@ -9746,13 +9758,12 @@ SCPS-55004:
   name: "Jak x Daxter - Kyuu Sekai no Isan"
   region: "NTSC-J"
   gsHWFixes:
-    roundSprite: 1 # Fix lines in the sky.
-    autoFlush: 2 # Fixes lighting.
+    recommendedBlendingLevel: 3 # Improves reflection quality.
     mipmap: 2 # Fixes broken textures.
     trilinearFiltering: 1 # Fixes water textures.
-    cpuSpriteRenderBW: 2 # Fixes water textures. Can't use BW 4 here because of post effects.
+    cpuSpriteRenderBW: 4 # Fixes character and water textures.
     cpuSpriteRenderLevel: 2 # Needed for above.
-    textureInsideRT: 1 # Fixes broken character models.
+    autoFlush: 2 # Fixes gate warp effect and emissive texture effects.
 SCPS-55005:
   name: "Gran Turismo - Concept 2001 Tokyo"
   region: "NTSC-J"
@@ -10029,10 +10040,12 @@ SCPS-56003:
   name: "Jak and Daxter - The Precursor Legacy"
   region: "NTSC-K"
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves reflection quality.
     mipmap: 2 # Fixes broken textures.
     trilinearFiltering: 1 # Fixes water textures.
     cpuSpriteRenderBW: 4 # Fixes character and water textures.
     cpuSpriteRenderLevel: 2 # Needed for above.
+    autoFlush: 2 # Fixes gate warp effect and emissive texture effects.
 SCPS-56004:
   name: "Otostaz"
   region: "NTSC-K"
@@ -10291,10 +10304,12 @@ SCUS-97124:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves reflection quality.
     mipmap: 2 # Fixes broken textures.
     trilinearFiltering: 1 # Fixes water textures.
     cpuSpriteRenderBW: 4 # Fixes character and water textures.
     cpuSpriteRenderLevel: 2 # Needed for above.
+    autoFlush: 2 # Fixes gate warp effect and emissive texture effects.
 SCUS-97125:
   name: "Frequency"
   region: "NTSC-U"
@@ -10491,18 +10506,22 @@ SCUS-97170:
   name: "Jak and Daxter - The Precursor Legacy [Cingular Wireless Demo]"
   region: "NTSC-U"
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves reflection quality.
     mipmap: 2 # Fixes broken textures.
     trilinearFiltering: 1 # Fixes water textures.
     cpuSpriteRenderBW: 4 # Fixes character and water textures.
     cpuSpriteRenderLevel: 2 # Needed for above.
+    autoFlush: 2 # Fixes gate warp effect and emissive texture effects.
 SCUS-97171:
   name: "Jak and Daxter - The Precursor Legacy [PS Underground Demo]"
   region: "NTSC-U"
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves reflection quality.
     mipmap: 2 # Fixes broken textures.
     trilinearFiltering: 1 # Fixes water textures.
     cpuSpriteRenderBW: 4 # Fixes character and water textures.
     cpuSpriteRenderLevel: 2 # Needed for above.
+    autoFlush: 2 # Fixes gate warp effect and emissive texture effects.
 SCUS-97172:
   name: "World Tour Soccer 2002"
   region: "NTSC-U"
@@ -20173,7 +20192,9 @@ SLES-52636:
   region: "PAL-M5"
   compat: 5
   gsHWFixes:
-    autoFlush: 2 # Fixes incorrect colors.
+    recommendedBlendingLevel: 3 # Fixes missing lighting and car reflections.
+    halfPixelOffset: 1 # Fixes 4 split lines in stage intros.
+    autoFlush: 1 # Fixes incorrect colors.
     alignSprite: 1 # Fixes vertical lines such as in FMVs.
     mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
     trilinearFiltering: 1


### PR DESCRIPTION
### Description of Changes
Fixes for Jak 1 with specific effects and reflections and for CMR 2005 with lines during intro and missing lighting.

Jak 1 Before:
![Jak and Daxter - The Precursor Legacy_SCUS-97124_20240425101043](https://github.com/PCSX2/pcsx2/assets/80843560/b5699eb9-35d6-4a1f-b4da-4a82b7a06309)

![Jak and Daxter - The Precursor Legacy_SCUS-97124_20240425101149](https://github.com/PCSX2/pcsx2/assets/80843560/28b47be7-4226-4ca0-b887-eabd29d36e4b)

![Jak and Daxter - The Precursor Legacy_SCUS-97124_20240425101209](https://github.com/PCSX2/pcsx2/assets/80843560/2f345150-fd3d-49c1-a43e-06662e9e59a2)

Jak 1 After:
![Jak and Daxter - The Precursor Legacy_SCUS-97124_20240425101055](https://github.com/PCSX2/pcsx2/assets/80843560/e60d6b92-cda1-4f3a-be99-a0170eea41b2)

![Jak and Daxter - The Precursor Legacy_SCUS-97124_20240425101152](https://github.com/PCSX2/pcsx2/assets/80843560/159b2bb1-8144-42b2-a7a6-9b8e9e7f8bb5)

![Jak and Daxter - The Precursor Legacy_SCUS-97124_20240425101213](https://github.com/PCSX2/pcsx2/assets/80843560/ad65c7e9-232f-473a-b751-03897a06fe86)

CMR 2005 Before:
![Colin McRae Rally 2005_SLES-52636_20240425161356](https://github.com/PCSX2/pcsx2/assets/80843560/97a6d79d-cb54-4c53-80bc-d10507cbfc64)

After:
![Colin McRae Rally 2005_SLES-52636_20240425161404](https://github.com/PCSX2/pcsx2/assets/80843560/a8010184-5fb8-402c-b6e0-c09650063946)

### Rationale behind Changes
More fix more good.

### Suggested Testing Steps
Make sure CI Is happy boi.
