### PR TITLE
GS/HW: Detect shuffles using quads

### DIFF
--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -2816,7 +2816,7 @@ void GSState::GrowVertexBuffer()
 	m_index.buff = index;
 }
 
-bool GSState::TrianglesAreQuads() const
+bool GSState::TrianglesAreQuads(bool shuffle_check) const
 {
 	// If this is a quad, there should only be two distinct values for both X and Y, which
 	// also happen to be the minimum/maximum bounds of the primitive.
@@ -2829,10 +2829,17 @@ bool GSState::TrianglesAreQuads() const
 		if (idx > 0)
 		{
 			const u16* const prev_tri= m_index.buff + (idx - 3);
-			const GSVertex& vert = v[i[0]];
-			const GSVertex& last_vert = v[i[2]];
-			if (vert.XYZ != m_vertex.buff[prev_tri[0]].XYZ && vert.XYZ != m_vertex.buff[prev_tri[1]].XYZ && vert.XYZ != m_vertex.buff[prev_tri[2]].XYZ &&
-				last_vert.XYZ != m_vertex.buff[prev_tri[0]].XYZ && last_vert.XYZ != m_vertex.buff[prev_tri[1]].XYZ && last_vert.XYZ != m_vertex.buff[prev_tri[2]].XYZ)
+			GIFRegXYZ vert = v[i[0]].XYZ;
+			GIFRegXYZ last_vert = v[i[2]].XYZ;
+
+			if (shuffle_check)
+			{
+				vert.X -= 8 << 4;
+				last_vert.X -= 8 << 4;
+			}
+
+			if (vert != m_vertex.buff[prev_tri[0]].XYZ && vert != m_vertex.buff[prev_tri[1]].XYZ && vert != m_vertex.buff[prev_tri[2]].XYZ &&
+				last_vert != m_vertex.buff[prev_tri[0]].XYZ && last_vert != m_vertex.buff[prev_tri[1]].XYZ && last_vert != m_vertex.buff[prev_tri[2]].XYZ)
 				return false;
 		}
 		// Degenerate triangles should've been culled already, so we can check indices.

--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -409,7 +409,7 @@ public:
 
 	void DumpVertices(const std::string& filename);
 
-	bool TrianglesAreQuads() const;
+	bool TrianglesAreQuads(bool shuffle_check = false) const;
 	PRIM_OVERLAP PrimitiveOverlap();
 	bool PrimitiveCoversWithoutGaps();
 	GIFRegTEX0 GetTex0Layer(u32 lod);

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -2690,8 +2690,9 @@ void GSRendererHW::Draw()
 
 			// Both input and output are 16 bits and texture was initially 32 bits! Same for the target, Sonic Unleash makes a new target which really is 16bit.
 			m_texture_shuffle = ((m_same_group_texture_shuffle || (tex_psm.bpp == 16)) && (GSLocalMemory::m_psm[m_cached_ctx.FRAME.PSM].bpp == 16) &&
-				(shuffle_coords || rt->m_32_bits_fmt))
-				&& draw_sprite_tex && (src->m_32_bits_fmt || m_copy_16bit_to_target_shuffle);
+				(shuffle_coords || rt->m_32_bits_fmt)) &&
+				(src->m_32_bits_fmt || m_copy_16bit_to_target_shuffle) && 
+				(draw_sprite_tex || (m_vt.m_primclass == GS_TRIANGLE_CLASS && (m_index.tail % 6) == 0 && TrianglesAreQuads(true)));
 		};
 
 		// Okami mustn't call this code


### PR DESCRIPTION
### Description of Changes
Detect triangle quads used for shuffles.

### Rationale behind Changes
We only checked for sprites before, so this fixes that.  We do still treat it like sprites when processing further on, but it doesn't seem to matter, so YOLO.

### Suggested Testing Steps
Test Toyko Xtreme Racer Drift 2, nothing else showed in dump run.

Fixes #8203

Hard to see as it's a fade, but this is Toyko Xtreme Racer Drift 2
Master:
![Tokyo_Xtreme_Racer_Drift_2_SLUS-21394_20230217234730_frame3](https://github.com/PCSX2/pcsx2/assets/6278726/7571c457-f86d-4f38-ada6-f2965c91cbca)
PR:
![Tokyo_Xtreme_Racer_Drift_2_SLUS-21394_20230217234730_frame3](https://github.com/PCSX2/pcsx2/assets/6278726/5a5ebf70-ca9b-4c79-9f54-4655963354a0)

