### PR TITLE
Misc: Add gstreamer fallback to aplay

### DIFF
--- a/common/Linux/LnxMisc.cpp
+++ b/common/Linux/LnxMisc.cpp
@@ -4,8 +4,11 @@
 #if !defined(_WIN32) && !defined(__APPLE__)
 
 #include "common/Pcsx2Types.h"
+#include "common/Console.h"
 #include "common/HostSys.h"
+#include "common/Path.h"
 #include "common/ScopedGuard.h"
+#include "common/SmallString.h"
 #include "common/StringUtil.h"
 #include "common/Threading.h"
 #include "common/WindowInfo.h"
@@ -173,7 +176,28 @@ bool Common::PlaySoundAsync(const char* path)
 
 	// Since we set SA_NOCLDWAIT in Qt, we don't need to wait here.
 	int res = posix_spawnp(&pid, cmdname, nullptr, nullptr, const_cast<char**>(argv), environ);
-	return (res == 0);
+	if (res == 0)
+		return true;
+
+	// Try gst-play-1.0.
+	const char* gst_play_cmdname = "gst-play-1.0";
+	const char* gst_play_argv[] = {cmdname, path, nullptr};
+	res = posix_spawnp(&pid, gst_play_cmdname, nullptr, nullptr, const_cast<char**>(gst_play_argv), environ);
+	if (res == 0)
+		return true;
+
+	// gst-launch? Bit messier for sure.
+	TinyString location_str = TinyString::from_format("location={}", path);
+	TinyString parse_str = TinyString::from_format("{}parse", Path::GetExtension(path));
+	const char* gst_launch_cmdname = "gst-launch-1.0";
+	const char* gst_launch_argv[] = {
+		gst_launch_cmdname, "filesrc", location_str.c_str(), "!", parse_str.c_str(), "!", "alsasink", nullptr};
+	res = posix_spawnp(&pid, gst_launch_cmdname, nullptr, nullptr, const_cast<char**>(gst_launch_argv), environ);
+	if (res == 0)
+		return true;
+
+	Console.ErrorFmt("Failed to play sound effect {}. Make sure you have aplay, gst-play-1.0, or gst-launch-1.0 available.", path);
+	return false;
 #else
 	return false;
 #endif


### PR DESCRIPTION
### Description of Changes

Apparently the Freedesktop/KDE runtime doesn't have aplay... but it does have `gst-play-1.0`, so we can use that instead.

### Rationale behind Changes

Compatibility with Linux systems that do not have aplay.

### Suggested Testing Steps

Check achievements sound effects on Linux.
