### PR TITLE
GS/HW: Ensure valid alpha doesn't get cleared on 24-bit targets

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -2631,12 +2631,16 @@ void GSRendererHW::Draw()
 				return;
 			}
 		}
-	}
 
-	if (rt && m_channel_shuffle)
-	{
-		m_last_channel_shuffle_fbp = rt->m_TEX0.TBP0;
-		m_last_channel_shuffle_end_block = rt->m_end_block;
+		// The target might have previously been a C32 format with valid alpha. If we're switching to C24, we need to preserve it.
+		preserve_rt_alpha |= (GSLocalMemory::m_psm[m_cached_ctx.FRAME.PSM].trbpp == 24 && rt->HasValidAlpha());
+		preserve_rt_color = preserve_rt_rgb || preserve_rt_alpha;
+
+		if (m_channel_shuffle)
+		{
+			m_last_channel_shuffle_fbp = rt->m_TEX0.TBP0;
+			m_last_channel_shuffle_end_block = rt->m_end_block;
+		}
 	}
 
 	GSTextureCache::Target* ds = nullptr;


### PR DESCRIPTION
### Description of Changes

Pitfall: The Lost Expedition clears a Z24 depth buffer via a colour write, that was previously the target of a G->A channel shuffle, then uses it as a texture. We were clearing the target, despite it still having valid data in the alpha channel. So, don't do that.

### Rationale behind Changes

Fixes #11150.

### Suggested Testing Steps

Check linked GS dump / game.
