### PR TITLE
GS/HW: Remove shuffle misdetection hack

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -2713,29 +2713,6 @@ void GSRendererHW::Draw()
 				&& draw_sprite_tex && (src->m_32_bits_fmt || m_copy_16bit_to_target_shuffle);
 		};
 
-		// Okami mustn't call this code
-		if (m_texture_shuffle && m_vertex.next < 3 && PRIM->FST && ((m_cached_ctx.FRAME.FBMSK & fm_mask) == 0))
-		{
-			// Avious dubious call to m_texture_shuffle on 16 bits games
-			// The pattern is severals column of 8 pixels. A single sprite
-			// smell fishy but a big sprite is wrong.
-
-			// Shadow of Memories/Destiny shouldn't call this code.
-			// Causes shadow flickering.
-			m_texture_shuffle = ((v[1].U - v[0].U) < 256) ||
-				// Tomb Raider Angel of Darkness relies on this behavior to produce a fog effect.
-				// In this case, the address of the framebuffer and texture are the same.
-				// The game will take RG => BA and then the BA => RG of next pixels.
-				// However, only RG => BA needs to be emulated because RG isn't used.
-				m_cached_ctx.FRAME.Block() == m_cached_ctx.TEX0.TBP0 ||
-				// DMC3, Onimusha 3 rely on this behavior.
-				// They do fullscreen rectangle with scissor, then shift by 8 pixels, not done with recursion.
-				// So we check if it's a TS effect by checking the scissor.
-				((m_context->SCISSOR.SCAX1 - m_context->SCISSOR.SCAX0) < 32);
-
-			GL_INS("WARNING: Possible misdetection of effect, texture shuffle is %s", m_texture_shuffle ? "Enabled" : "Disabled");
-		}
-
 		if (m_texture_shuffle && IsSplitTextureShuffle(rt))
 		{
 			// If TEX0 == FBP, we're going to have a source left in the TC.


### PR DESCRIPTION
### Description of Changes
Removes an old hack from when texture shuffle detection was worse.

### Rationale behind Changes
It was actually breaking shuffles in WWE where it shuffles RG -> BA in one sprite, this code was panicking and disabling it.

### Suggested Testing Steps
Test the following games (and the WWE ones mentioned in #3636 ) dump run is fine.

To test:
Devil May Cry 3 (not sure, some shuffle effect, so make sure it looks right, shadows work etc)
Okami (generally make sure it works ok)
Onimusha 3 (not sure, some shuffle effect, possibly post effect, though I think we fixed this previously)
Shadow of Memories/Destiny (shadows)
Tomb Raider - Angel of Darkness (Fog effect)

This is one of the last problems from #3636

WWE Smackdown Vs Raw 2007 (This is fully fixed with Tex in RT, which is coming in a future PR)
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/613e0f42-462d-4053-97e5-0bb071d377e2)
PR;
![image](https://github.com/PCSX2/pcsx2/assets/6278726/28169dee-775d-4cff-977e-7c70e9c9946e)
