### PR TITLE
CMake: Don't assume all qt utils are in the same place

### DIFF
--- a/cmake/CopyBaseTranslations.cmake
+++ b/cmake/CopyBaseTranslations.cmake
@@ -1,7 +1,4 @@
 function(copy_base_translations target)
-  get_target_property(MOC_EXECUTABLE_LOCATION Qt6::moc IMPORTED_LOCATION)
-  get_filename_component(QT_BINARY_DIRECTORY "${MOC_EXECUTABLE_LOCATION}" DIRECTORY)
-  find_program(LCONVERT_EXE lconvert HINTS "${QT_BINARY_DIRECTORY}")
   set(BASE_TRANSLATIONS_DIR "${QT_BINARY_DIRECTORY}/../translations")
 
   if(NOT APPLE)
@@ -33,7 +30,7 @@ function(copy_base_translations target)
         LIST(APPEND srcQmFiles "${qmFile}")
       endforeach()
       add_custom_command(OUTPUT ${outPath}
-        COMMAND "${LCONVERT_EXE}" -verbose -of qm -o "${outPath}" ${srcQmFiles}
+        COMMAND Qt6::lconvert -verbose -of qm -o "${outPath}" ${srcQmFiles}
         DEPENDS ${srcQmFiles}
       )
       set(path "${outPath}")

--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -1227,9 +1227,6 @@ function(setup_main_executable target)
 	get_property(PCSX2_SOURCE_DIR GLOBAL PROPERTY PCSX2_SOURCE_DIR)
 	get_property(PCSX2_METAL_SHADERS GLOBAL PROPERTY PCSX2_METAL_SHADERS)
 
-	get_target_property(MOC_EXECUTABLE_LOCATION Qt6::moc IMPORTED_LOCATION)
-	get_filename_component(QT_BINARY_DIRECTORY "${MOC_EXECUTABLE_LOCATION}" DIRECTORY)
-
 	if(WIN32)
 		target_sources(${target} PRIVATE
 			${PCSX2_SOURCE_DIR}/windows/PCSX2.manifest
@@ -1248,7 +1245,7 @@ function(setup_main_executable target)
 			install(FILES "${DEPS_BINDIR}/${DEP_TO_COPY}" DESTINATION "${CMAKE_SOURCE_DIR}/bin")
 		endforeach()
 
-		find_program(WINDEPLOYQT_EXE windeployqt HINTS "${QT_BINARY_DIRECTORY}")
+		get_target_property(WINDEPLOYQT_EXE Qt6::windeployqt IMPORTED_LOCATION)
 		install(CODE "execute_process(COMMAND \"${WINDEPLOYQT_EXE}\" \"${CMAKE_SOURCE_DIR}/bin/$<TARGET_FILE_NAME:${target}>\" --plugindir \"${CMAKE_SOURCE_DIR}/bin/QtPlugins\" --no-compiler-runtime --no-system-d3d-compiler --no-system-dxc-compiler --no-translations COMMAND_ERROR_IS_FATAL ANY)")
 		install(CODE "file(WRITE \"${CMAKE_SOURCE_DIR}/bin/qt.conf\" \"[Paths]\\nPlugins = ./QtPlugins\")")
 	endif()
@@ -1324,9 +1321,8 @@ function(setup_main_executable target)
 			set(postprocessBundleType ALL)
 		endif()
 
-		find_program(MACDEPLOYQT_EXE macdeployqt HINTS "${QT_BINARY_DIRECTORY}")
 		add_custom_target(pcsx2-postprocess-bundle ${postprocessBundleType}
-			COMMAND "${MACDEPLOYQT_EXE}" "$<TARGET_FILE_DIR:${target}>/../.." -no-strip
+			COMMAND Qt6::macdeployqt "$<TARGET_FILE_DIR:${target}>/../.." -no-strip
 		)
 		add_dependencies(pcsx2-postprocess-bundle ${target})
 	endif()


### PR DESCRIPTION
### Description of Changes
Avoids using moc's path to find *deployqt and lconvert

Qt supplies targets for all of its executables, not just moc, so use those

CMake seems to support using targets as executables in custom commands, though I wasn't so sure about what variables are available to things run from an `install(CODE` so I pulled it out for that.

### Rationale behind Changes
Fixes building without dependencies (or some other qt installation) on your path (e.g. if using `-DCMAKE_PREFIX_PATH=DEPS_INSTALL_DIR`)
(moc installs to libexec on unix platforms, while lconvert and macdeployqt go in bin)

### Suggested Testing Steps
Try to build on various systems and make sure it still works
