### PR TITLE
GameDB: Crash Nitro Kart fixes

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -17477,6 +17477,8 @@ SLES-51511:
   region: "PAL-M6"
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
+  clampModes:
+    vu1ClampMode: 3 # Fixes missing vertices on ramps.
 SLES-51522:
   name: "Return to Castle Wolfenstein - Operation Resurrection"
   region: "PAL-S"
@@ -40958,6 +40960,8 @@ SLPM-65580:
   region: "NTSC-J"
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
+  clampModes:
+    vu1ClampMode: 3 # Fixes missing vertices on ramps.
 SLPM-65581:
   name: ホーンテッドマンション
   name-sort: ほーんてっどまんしょん
@@ -43727,6 +43731,8 @@ SLPM-66067:
   region: "NTSC-J"
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
+  clampModes:
+    vu1ClampMode: 3 # Fixes missing vertices on ramps.
 SLPM-66068:
   name: リチャード・バーンズ ラリー
   name-sort: りちゃーど・ばーんず らりー
@@ -62440,6 +62446,8 @@ SLUS-20649:
   compat: 5
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
+  clampModes:
+    vu1ClampMode: 3 # Fixes missing vertices on ramps.
 SLUS-20650:
   name: "MVP Baseball 2003"
   region: "NTSC-U"
@@ -70401,6 +70409,8 @@ SLUS-29068:
   region: "NTSC-U"
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
+  clampModes:
+    vu1ClampMode: 3 # Fixes missing vertices on ramps.
 SLUS-29069:
   name: "Prince of Persia - The Sands of Time [Demo]"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
Adds VU1 Extra+Sign clamp to fix missing vertices on ramps.
Fixes #11160 

Before:
![187 - Ride or Die_SLUS-21116_20240429090103](https://github.com/PCSX2/pcsx2/assets/80843560/5f94c7d4-92d5-4360-ba6c-8b9cbe7522a0)

After:
![187 - Ride or Die_SLUS-21116_20240429090111](https://github.com/PCSX2/pcsx2/assets/80843560/8b1476b5-ba04-4b96-aa6d-40fc6a7a832c)

### Rationale behind Changes
Less broken game more good.

### Suggested Testing Steps
Make sure CI is happy.
