### PR TITLE
DEV9: Defer deletion of socket sessions

### DIFF
--- a/pcsx2/DEV9/sockets.h
+++ b/pcsx2/DEV9/sockets.h
@@ -28,6 +28,10 @@ class SocketAdapter : public NetAdapter
 	ThreadSafeMap<Sessions::ConnectionKey, Sessions::BaseSession*> connections;
 	ThreadSafeMap<u16, Sessions::BaseSession*> fixedUDPPorts;
 
+	std::thread::id sendThreadId;
+	std::vector<Sessions::BaseSession*> deleteQueueSendThread;
+	std::vector<Sessions::BaseSession*> deleteQueueRecvThread;
+
 public:
 	SocketAdapter();
 	virtual bool blocks();


### PR DESCRIPTION
### Description of Changes
Defer deleting the closed session until the end of the send/recv call

### Rationale behind Changes
Turns out, this did cause issues (certain UDP sessions was crashing debug builds when closing)

Maybe there is a better way to do this

### Suggested Testing Steps
Test networking games
