### PR TITLE
DEV9: Fix MacOS crash upon receiving an ICMP reply

### DIFF
--- a/pcsx2/DEV9/Sessions/ICMP_Session/ICMP_Session.cpp
+++ b/pcsx2/DEV9/Sessions/ICMP_Session/ICMP_Session.cpp
@@ -430,13 +430,10 @@ namespace Sessions
 
 						offset = headerLength;
 #ifdef __APPLE__
+						//Apple (old BSD)'s raw IP sockets implementation converts the ip_len field to host byte order
+            //and additionally subtracts the header length.
 						//https://www.unix.com/man-page/mojave/4/ip/
-						//"Note that the ip_off and ip_len fields are in host byte order."
-						//Any other bugs? FreeBSD notes the following
-						//Before FreeBSD 11.0 packets received on raw IP sockets had the ip_len and ip_off fields converted to host byte order.
-						//Before FreeBSD 10.0 packets received on raw IP sockets had the ip_hl sub-tracted from the ip_len field.
-						//TODO, test
-						length = ipHeader->ip_len - headerLength;
+						length = ipHeader->ip_len;
 #else
 						length = ntohs(ipHeader->ip_len) - headerLength;
 #endif


### PR DESCRIPTION
### Description of Changes
Apple (old BSD)'s raw IP sockets implementation converts the `ip_len` field to host byte order, but also subtracts the IP header length as well. This caused us to effectively subtract the header length twice and allocate the return ping in `ICMP_Session::Recv()` with a negative size, crashing PCSX2.

[crash log of reproduction on a Mac M-series](https://github.com/PCSX2/pcsx2/files/15158240/message.txt)

### Rationale behind Changes
Fixes a crash which occurs in Twisted Metal Black: Online if there are any P2P game rooms whose hosts are accessible via ICMP.

This was encountered after an update to the community-run <<removed>>, which now correctly emulates and broadcasts the "game stats" field in SCERT `MediusWorldReport` packets. In TMBO specifically, this allows users in the lobby to get the IP of any room host and use ICMP ping to determine their latency to the game room. (Previously we forced the IP to be `127.0.0.1`, which did not bring out this issue.)

### Suggested Testing Steps
- Twisted Metal Black: Online:
  - Connect to the server lobby while another room is up whose host is accessible via ICMP. (The bot hosting the `TEST ROOM` at all times is not accessible via ICMP, so this will require another system (PS2 or PCSX2) or another user to host who is accessible.)
  - Ensure PCSX2 doesn't crash upon loading the room list.
- Test other network-enabled games or homebrew which makes use of ICMP.
  - Not sure what other games use ICMP.
