### PR TITLE
GameDB: Add missing GT Concept 2001 fixes

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -868,6 +868,11 @@ PCPX-96622:
 PCPX-96624:
   name: "Gran Turismo Concept - 2001 Tokyo"
   region: "NTSC-J"
+  gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
+    getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 PCPX-96625:
   name: "プレプレ2 VOLUME.4"
   name-sort: "ぷれぷれ2 VOLUME.4"
@@ -8076,6 +8081,11 @@ SCPS-15010:
   name-en: "Gran Turismo - Concept 2001 Tokyo"
   region: "NTSC-J"
   compat: 5
+  gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
+    getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 SCPS-15011:
   name: EXTERMINATION
   name-sort: EXTERMINATION
@@ -9241,6 +9251,11 @@ SCPS-19208:
   name-sort: ぐらんつーりすも Concept2001 TOKYO PlayStation 2 the Best
   name-en: "Gran Turismo - Concept 2001 Tokyo [PlayStation 2 the Best]"
   region: "NTSC-J"
+  gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
+    getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 SCPS-19209:
   name: ぼくのなつやすみ2 海の冒険篇 PlayStation 2 the Best
   name-sort: ぼくのなつやすみ2 うみのぼうけんへん PlayStation 2 the Best
@@ -9786,6 +9801,11 @@ SCPS-55004:
 SCPS-55005:
   name: "Gran Turismo - Concept 2001 Tokyo"
   region: "NTSC-J"
+  gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
+    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
+    trilinearFiltering: 1
+    getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 SCPS-55006:
   name: "Wild ARMs - Advanced 3rd"
   region: "NTSC-J"
@@ -17076,17 +17096,6 @@ SLES-51341:
 SLES-51343:
   name: "Galerians - Ash"
   region: "PAL-M5"
-  patches:
-    1AE08CF5:
-      content: |-
-        author=kozarovv
-        // Floats workaround to make HW GSDX mode working.
-        // There is still overflow on GS, but this time GSDX can handle it just fine in HW mode.
-        patch=1,EE,001e7130,word,3c017e00
-        patch=1,EE,001e7138,word,44812800
-        patch=1,EE,001e7150,word,44813000
-        patch=1,EE,001e7160,word,44813800
-        patch=1,EE,001e7170,word,44810000
 SLES-51344:
   name: "Guilty Gear X2"
   region: "PAL-E"
@@ -61944,17 +61953,6 @@ SLUS-20560:
   name: "Galerians - Ash"
   region: "NTSC-U"
   compat: 5
-  patches:
-    B506C936:
-      content: |-
-        author=kozarovv
-        // Floats workaround to make HW GSDX mode working.
-        // There is still overflow on GS, but this time GSDX can handle it just fine in HW mode.
-        patch=1,EE,001e12a8,word,3c017e00
-        patch=1,EE,001e12b0,word,44812800
-        patch=1,EE,001e12c8,word,44813000
-        patch=1,EE,001e12d8,word,44813800
-        patch=1,EE,001e12e8,word,44810000
 SLUS-20561:
   name: "Disaster Report"
   region: "NTSC-U"
@@ -63821,10 +63819,6 @@ SLUS-20894:
   name: "Worms 3D"
   region: "NTSC-U"
   compat: 5
-  patches:
-    default:
-      content: |-
-        comment=You need to set the EE cycle speed to -1 to be able to load the game.
 SLUS-20895:
   name: "Bujingai - The Forsaken City"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
Adds missing GSC to GT Concept 2001 and also removes patches that are no longer needed due to being fixed by #11163 

### Rationale behind Changes
Missing fix bad.

### Suggested Testing Steps
Make sure CI is happy boi.
