### PR TITLE
Timers: Fix up some timer behaviour

### DIFF
--- a/pcsx2/IopCounters.cpp
+++ b/pcsx2/IopCounters.cpp
@@ -524,7 +524,8 @@ void psxRcntWcount16(int index, u16 value)
 		const u32 change = (psxRegs.cycle - psxCounters[index].sCycleT) / psxCounters[index].rate;
 		psxCounters[index].sCycleT += change * psxCounters[index].rate;
 	}
-
+	else
+		psxCounters[index].sCycleT = psxRegs.cycle;
 	psxCounters[index].count = value & 0xffff;
 
 	psxCounters[index].target &= 0xffff;
@@ -554,7 +555,8 @@ void psxRcntWcount32(int index, u32 value)
 		const u32 change = (psxRegs.cycle - psxCounters[index].sCycleT) / psxCounters[index].rate;
 		psxCounters[index].sCycleT += change * psxCounters[index].rate;
 	}
-
+	else
+		psxCounters[index].sCycleT = psxRegs.cycle;
 	psxCounters[index].count = value;
 
 	psxCounters[index].target &= 0xffffffff;
@@ -752,6 +754,8 @@ void psxRcntWtarget16(int index, u32 value)
 		psxCounters[index].count += change;
 		psxCounters[index].sCycleT += change * psxCounters[index].rate;
 	}
+	else
+		psxCounters[index].sCycleT = psxRegs.cycle;
 
 	// protect the target from an early arrival.
 	// if the target is behind the current count, then set the target overflow
@@ -786,6 +790,8 @@ void psxRcntWtarget32(int index, u32 value)
 		psxCounters[index].count += change;
 		psxCounters[index].sCycleT += change * psxCounters[index].rate;
 	}
+	else
+		psxCounters[index].sCycleT = psxRegs.cycle;
 	// protect the target from an early arrival.
 	// if the target is behind the current count, then set the target overflow
 	// flag, so that the target won't be active until after the next overflow.


### PR DESCRIPTION
### Description of Changes
Fix up some timer behaviour on EE and IOP

### Rationale behind Changes
Introduced a bug in the previous PR by accident, realised that if the game didn't update gated counters before hsync/vsync and the counter got reset, it would retain the old value.

Also tested HSync timing on the PS2, and corrected it in PCSX2.

### Suggested Testing Steps
test hsync timing sensitive games, i guess.  No known fixes.