### PR TITLE
GS/Vulkan: Use dynamic rendering instead of render passes

### DIFF
--- a/pcsx2/GS/Renderers/Vulkan/GSTextureVK.h
+++ b/pcsx2/GS/Renderers/Vulkan/GSTextureVK.h
@@ -70,11 +70,6 @@ public:
 	void TransitionSubresourcesToLayout(
 		VkCommandBuffer command_buffer, int start_level, int num_levels, Layout old_layout, Layout new_layout);
 
-	/// Framebuffers are lazily allocated.
-	VkFramebuffer GetFramebuffer(bool feedback_loop);
-
-	VkFramebuffer GetLinkedFramebuffer(GSTextureVK* depth_texture, bool feedback_loop);
-
 	// Call when the texture is bound to the pipeline, or read from in a copy.
 	__fi void SetUseFenceCounter(u64 counter) { m_use_fence_counter = counter; }
 
@@ -100,10 +95,6 @@ private:
 
 	int m_map_level = std::numeric_limits<int>::max();
 	GSVector4i m_map_area = GSVector4i::zero();
-
-	// linked framebuffer is combined with depth texture
-	// list of color textures this depth texture is linked to or vice versa
-	std::vector<std::tuple<GSTextureVK*, VkFramebuffer, bool>> m_framebuffers;
 };
 
 class GSDownloadTextureVK final : public GSDownloadTexture

--- a/pcsx2/GS/Renderers/Vulkan/VKBuilders.h
+++ b/pcsx2/GS/Renderers/Vulkan/VKBuilders.h
@@ -21,6 +21,7 @@ namespace Vulkan
 {
 	// Adds a structure to a chain.
 	void AddPointerToChain(void* head, const void* ptr);
+	void RemovePointerFromChain(void* head, const void* ptr);
 
 	const char* VkResultToString(VkResult res);
 	void LogVulkanResult(const char* func_name, VkResult res, const char* msg, ...);
@@ -81,6 +82,7 @@ namespace Vulkan
 			MAX_VERTEX_ATTRIBUTES = 16,
 			MAX_VERTEX_BUFFERS = 8,
 			MAX_ATTACHMENTS = 2,
+			MAX_INPUT_ATTACHMENTS = 1,
 			MAX_DYNAMIC_STATE = 8
 		};
 
@@ -141,6 +143,12 @@ namespace Vulkan
 
 		void SetProvokingVertex(VkProvokingVertexModeEXT mode);
 
+		void SetDynamicRendering();
+		void AddDynamicRenderingColorAttachment(VkFormat format);
+		void SetDynamicRenderingDepthAttachment(VkFormat depth_format, VkFormat stencil_format);
+		void AddDynamicRenderingInputAttachment(u32 color_attachment_index);
+		void ClearDynamicRenderingAttachments();
+
 	private:
 		VkGraphicsPipelineCreateInfo m_ci;
 		std::array<VkPipelineShaderStageCreateInfo, MAX_SHADER_STAGES> m_shader_stages;
@@ -168,6 +176,11 @@ namespace Vulkan
 
 		VkPipelineRasterizationProvokingVertexStateCreateInfoEXT m_provoking_vertex;
 		VkPipelineRasterizationLineStateCreateInfoEXT m_line_rasterization_state;
+
+		VkPipelineRenderingCreateInfoKHR m_rendering;
+		VkRenderingAttachmentLocationInfoKHR m_rendering_input_attachment_locations;
+		std::array<VkFormat, MAX_ATTACHMENTS> m_rendering_color_formats;
+		std::array<u32, MAX_INPUT_ATTACHMENTS> m_rendering_input_attachment_indices;
 	};
 
 	class ComputePipelineBuilder

--- a/pcsx2/GS/Renderers/Vulkan/VKEntryPoints.inl
+++ b/pcsx2/GS/Renderers/Vulkan/VKEntryPoints.inl
@@ -235,7 +235,14 @@ VULKAN_DEVICE_ENTRY_POINT(vkReleaseFullScreenExclusiveModeEXT, false)
 // VK_EXT_calibrated_timestamps
 VULKAN_DEVICE_ENTRY_POINT(vkGetCalibratedTimestampsEXT, false)
 
+// VK_KHR_dynamic_rendering
+VULKAN_DEVICE_ENTRY_POINT(vkCmdBeginRenderingKHR, false)
+VULKAN_DEVICE_ENTRY_POINT(vkCmdEndRenderingKHR, false)
+
 // VK_KHR_push_descriptor
 VULKAN_DEVICE_ENTRY_POINT(vkCmdPushDescriptorSetKHR, false)
+
+// VK_KHR_synchronization2
+VULKAN_DEVICE_ENTRY_POINT(vkCmdPipelineBarrier2KHR, false)
 
 #endif // VULKAN_DEVICE_ENTRY_POINT


### PR DESCRIPTION
### Description of Changes

Since `VK_KHR_dynamic_rendering_local_read` is a thing now, we can use dynamic rendering and still have our feedback loops.

I'm mainly PRing this since it's a different approach that _may_ help with the RDNA3 crashes. I don't have a RDNA3 GPU, so I have no idea if it does or not.

If it does help with RDNA3, then I'll re-add a render pass fallback path for Kepler and Polaris, since it doesn't support the local read extension, and we'd lose Vulkan support for those GPUs otherwise. But if it doesn't, it's potentially not worth bothering with this change in the first place.

### Rationale behind Changes

~10% lower CPU usage on GS thread in barrier-heavy situations.

### Suggested Testing Steps

Check RDNA3.
