### PR TITLE
SPU: Only fire IRQ for Reverb reads when FxEnable

### DIFF
--- a/pcsx2/SPU2/Reverb.cpp
+++ b/pcsx2/SPU2/Reverb.cpp
@@ -102,7 +102,7 @@ StereoOut32 V_Core::DoReverb(StereoOut32 Input)
 
 	for (int i = 0; i < 2; i++)
 	{
-		if (Cores[i].IRQEnable && ((Cores[i].IRQA >= EffectsStartA) && (Cores[i].IRQA <= EffectsEndA)))
+		if (FxEnable && Cores[i].IRQEnable && ((Cores[i].IRQA >= EffectsStartA) && (Cores[i].IRQA <= EffectsEndA)))
 		{
 			if ((Cores[i].IRQA == same_src) || (Cores[i].IRQA == diff_src) ||
 				(Cores[i].IRQA == same_dst) || (Cores[i].IRQA == diff_dst) ||


### PR DESCRIPTION
### Description of Changes
Fixes spurious SPU IRQ's that trip up Colin McRae 2005

### Rationale behind Changes
Hardware tested.

### Suggested Testing Steps
Check if Nicky still has a stutter.
