### PR TITLE
Qt: Fix incorrectly labeled Reset Volume button

### DIFF
--- a/pcsx2-qt/Settings/AudioSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/AudioSettingsWidget.cpp
@@ -120,11 +120,11 @@ AudioSettingsWidget::AudioSettingsWidget(SettingsWindow* dialog, QWidget* parent
 	dialog->registerWidgetHelp(m_ui.stretchSettings, tr("Stretch Settings"), tr("N/A"),
 		tr("These settings fine-tune the behavior of the SoundTouch audio time stretcher when running outside of 100% speed."));
 	dialog->registerWidgetHelp(m_ui.resetVolume, tr("Reset Volume"), tr("N/A"),
-		m_dialog->isPerGameSettings() ? tr("Resets volume back to the global/inherited setting.") :
-										tr("Resets volume back to the default, i.e. full."));
+		m_dialog->isPerGameSettings() ? tr("Resets output volume back to the global/inherited setting.") :
+										tr("Resets output volume back to the default."));
 	dialog->registerWidgetHelp(m_ui.resetFastForwardVolume, tr("Reset Fast Forward Volume"), tr("N/A"),
-		m_dialog->isPerGameSettings() ? tr("Resets volume back to the global/inherited setting.") :
-										tr("Resets volume back to the default, i.e. full."));
+		m_dialog->isPerGameSettings() ? tr("Resets fast forward volume back to the global/inherited setting.") :
+										tr("Resets fast forward volume back to the default."));
 }
 
 AudioSettingsWidget::~AudioSettingsWidget() = default;

--- a/pcsx2-qt/Settings/AudioSettingsWidget.ui
+++ b/pcsx2-qt/Settings/AudioSettingsWidget.ui
@@ -252,10 +252,10 @@
         <item>
          <widget class="QToolButton" name="resetVolume">
           <property name="toolTip">
-           <string>Stretch Settings</string>
+           <string>Reset Volume</string>
           </property>
           <property name="icon">
-           <iconset theme="refresh-line"/>
+           <iconset theme="restart-line"/>
           </property>
          </widget>
         </item>
@@ -301,10 +301,10 @@
         <item>
          <widget class="QToolButton" name="resetFastForwardVolume">
           <property name="toolTip">
-           <string>Stretch Settings</string>
+           <string>Reset Fast Forward Volume</string>
           </property>
           <property name="icon">
-           <iconset theme="refresh-line"/>
+           <iconset theme="restart-line"/>
           </property>
          </widget>
         </item>


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->

This PR fixes the wrongly labeled Reset Volume button.

Before:

![image](https://github.com/PCSX2/pcsx2/assets/14798312/5b45cb01-a0fa-4035-b64c-c98a92a76fad)


After:

![image](https://github.com/PCSX2/pcsx2/assets/14798312/d0d5bcc7-f3fe-4554-83ef-f313aa94fd6a)


### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->

Correctness 100

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->

See if the button is correctly labeled.
