### PR TITLE
EE: Correct update of EE cycles on low cycle counts when overclocking

### DIFF
--- a/pcsx2/x86/iCOP0.cpp
+++ b/pcsx2/x86/iCOP0.cpp
@@ -140,9 +140,6 @@ void recMFC0()
 		xMOV(ptr32[&cpuRegs.cycle], ecx); // update cycles
 		xMOV(eax, ecx);
 		xSUB(eax, ptr[&cpuRegs.lastCOP0Cycle]);
-		u8* skipInc = JNZ8(0);
-		xINC(eax);
-		x86SetJ8(skipInc);
 		xADD(ptr[&cpuRegs.CP0.n.Count], eax);
 		xMOV(ptr[&cpuRegs.lastCOP0Cycle], ecx);
 

--- a/pcsx2/x86/ix86-32/iR5900.cpp
+++ b/pcsx2/x86/ix86-32/iR5900.cpp
@@ -1325,9 +1325,10 @@ u32 scaleblockcycles_clear()
 	DevCon.WriteLn(L"Unscaled overall: %d,  scaled overall: %d,  relative EE clock speed: %d %%",
 		unscaled_overall, scaled_overall, static_cast<int>(100 * ratio));
 #endif
-	s8 cyclerate = EmuConfig.Speedhacks.EECycleRate;
+	const s8 cyclerate = EmuConfig.Speedhacks.EECycleRate;
+	const bool lowcycles = (s_nBlockCycles <= 40);
 
-	if (cyclerate > 1)
+	if (!lowcycles && cyclerate > 1)
 	{
 		s_nBlockCycles &= (0x1 << (cyclerate + 2)) - 1;
 	}


### PR DESCRIPTION
### Description of Changes
Corrects cycle masking when a block has a low cycle count while overclocking.

### Rationale behind Changes
The mask to retain fractional values was different to what was actually being used when the cycle count was low, causing the cycle count to be wrong. This regressed Panzer Elite Action - Fields of Glory

I also removed the hack from MFC0 where it was fudging adding a cycle to the COP0 counter, this was wrong.

### Suggested Testing Steps
Try Panzer Elite Action - Fields of Glory, and any other games which use overclocking in the gamedb, don't care too much about others.

Fixes #4793
