### PR TITLE
DEV9: Inherit from QStyledItemDelegate for Address fields in DNS hosts table

### DIFF
--- a/pcsx2-qt/Settings/DEV9UiCommon.cpp
+++ b/pcsx2-qt/Settings/DEV9UiCommon.cpp
@@ -39,7 +39,7 @@ QValidator::State IPValidator::validate(QString& input, int& pos) const
 }
 
 IPItemDelegate::IPItemDelegate(QObject* parent)
-	: QItemDelegate(parent)
+	: QStyledItemDelegate(parent)
 {
 }
 

--- a/pcsx2-qt/Settings/DEV9UiCommon.h
+++ b/pcsx2-qt/Settings/DEV9UiCommon.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include <QtGui/QValidator>
-#include <QtWidgets/QItemDelegate>
+#include <QtWidgets/QStyledItemDelegate>
 
 struct HostEntryUi
 {
@@ -29,7 +29,7 @@ private:
 	bool m_allowEmpty;
 };
 
-class IPItemDelegate : public QItemDelegate
+class IPItemDelegate : public QStyledItemDelegate
 {
 	Q_OBJECT
 


### PR DESCRIPTION
### Description of Changes
Make `IPItemDelegate` Inherit from `QStyledItemDelegate` instead `QItemDelegate`

### Rationale behind Changes
`QStyledItemDelegate` better respects the selected theme
This corrects the selection highlight for the `Address` field in the `Internal DNS` host list on the Windows 11 Native theme.
Other themes may also have be affected.

Old
![image](https://github.com/PCSX2/pcsx2/assets/4604733/ad1518cb-39ed-447b-81fb-21b516aa71d0)

New
![image](https://github.com/PCSX2/pcsx2/assets/4604733/834882b2-5f93-4ebe-8e74-616df452a109)


### Suggested Testing Steps
Make sure the style of the `Address` field in the Internal DNS host panel matches the style of the other fields (and then rest of the window) 