### PR TITLE
Misc: More DuckStation backports

### DIFF
--- a/.github/workflows/scripts/linux/flatpak/modules/20-sdl2.json
+++ b/.github/workflows/scripts/linux/flatpak/modules/20-sdl2.json
@@ -14,8 +14,8 @@
   "sources": [
     {
       "type": "archive",
-      "url": "https://libsdl.org/release/SDL2-2.30.2.tar.gz",
-      "sha256": "891d66ac8cae51361d3229e3336ebec1c407a8a2a063b61df14f5fdf3ab5ac31"
+      "url": "https://libsdl.org/release/SDL2-2.30.3.tar.gz",
+      "sha256": "820440072f8f5b50188c1dae104f2ad25984de268785be40c41a099a510f0aec"
     }
   ],
   "cleanup": [

--- a/cmake/SearchForStuff.cmake
+++ b/cmake/SearchForStuff.cmake
@@ -17,7 +17,7 @@ find_package(ZLIB REQUIRED) # v1.3, but Mac uses the SDK version.
 find_package(Zstd 1.5.5 REQUIRED)
 find_package(LZ4 REQUIRED)
 find_package(WebP REQUIRED) # v1.3.2, spews an error on Linux because no pkg-config.
-find_package(SDL2 2.30.2 REQUIRED)
+find_package(SDL2 2.30.3 REQUIRED)
 find_package(Freetype 2.11.1 REQUIRED)
 
 if(USE_VULKAN)

--- a/common/CrashHandler.h
+++ b/common/CrashHandler.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2002-2023 PCSX2 Dev Team
+// SPDX-FileCopyrightText: 2002-2024 PCSX2 Dev Team
 // SPDX-License-Identifier: LGPL-3.0+
 
 #include <string_view>
@@ -6,7 +6,6 @@
 namespace CrashHandler
 {
 	bool Install();
-	void SetWriteDirectory(const std::string_view& dump_directory);
+	void SetWriteDirectory(std::string_view dump_directory);
 	void WriteDumpForCaller();
-	void Uninstall();
 } // namespace CrashHandler

--- a/common/DynamicLibrary.cpp
+++ b/common/DynamicLibrary.cpp
@@ -100,6 +100,15 @@ bool DynamicLibrary::Open(const char* filename, Error* error)
 #endif
 }
 
+void DynamicLibrary::Adopt(void* handle)
+{
+	pxAssertRel(handle, "Handle is valid");
+
+	Close();
+
+	m_handle = handle;
+}
+
 void DynamicLibrary::Close()
 {
 	if (!IsOpen())

--- a/common/DynamicLibrary.h
+++ b/common/DynamicLibrary.h
@@ -45,6 +45,9 @@ public:
 	/// Returns true if the library was loaded and can be used.
 	bool Open(const char* filename, Error* error);
 
+	/// Adopts, or takes ownership of an existing opened library.
+	void Adopt(void* handle);
+
 	/// Unloads the library, any function pointers from this library are no longer valid.
 	void Close();
 
@@ -60,6 +63,9 @@ public:
 		*ptr = reinterpret_cast<T>(GetSymbolAddress(name));
 		return *ptr != nullptr;
 	}
+
+	/// Returns the opaque OS-specific handle.
+	void* GetHandle() const { return m_handle; }
 
 	/// Move assignment, transfer ownership.
 	DynamicLibrary& operator=(DynamicLibrary&& move);

--- a/common/Error.cpp
+++ b/common/Error.cpp
@@ -141,12 +141,13 @@ void Error::SetHResult(std::string_view prefix, long err)
 		static_cast<DWORD>(std::size(buf)), nullptr);
 	if (r > 0)
 	{
-		m_description =
-			fmt::format("{}HRESULT {:08X}: {}", prefix, err, StringUtil::WideStringToUTF8String(std::wstring_view(buf, r)));
+		m_description = fmt::format("{}HRESULT {:08X}: {}", prefix, static_cast<unsigned>(err),
+			StringUtil::WideStringToUTF8String(std::wstring_view(buf, r)));
 	}
 	else
 	{
-		m_description = fmt::format("{}HRESULT {:08X}: <Could not resolve system error ID>", prefix, err);
+		m_description = fmt::format("{}HRESULT {:08X}: <Could not resolve system error ID>", prefix,
+			static_cast<unsigned>(err));
 	}
 }
 

--- a/common/Linux/LnxHostSys.cpp
+++ b/common/Linux/LnxHostSys.cpp
@@ -40,7 +40,7 @@
 
 static std::recursive_mutex s_exception_handler_mutex;
 static bool s_in_exception_handler = false;
-static bool s_exception_handler_installed = true;
+static bool s_exception_handler_installed = false;
 
 #ifdef __APPLE__
 #include <mach/task.h>

--- a/common/Windows/WinHostSys.cpp
+++ b/common/Windows/WinHostSys.cpp
@@ -19,7 +19,7 @@
 
 static std::recursive_mutex s_exception_handler_mutex;
 static bool s_in_exception_handler = false;
-static bool s_exception_handler_installed = true;
+static bool s_exception_handler_installed = false;
 
 long __stdcall SysPageFaultExceptionFilter(EXCEPTION_POINTERS* eps)
 {

--- a/pcsx2-qt/Settings/GameListSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GameListSettingsWidget.cpp
@@ -40,16 +40,14 @@ GameListSettingsWidget::GameListSettingsWidget(SettingsWindow* dialog, QWidget* 
 	m_ui.searchDirectoryList->setCurrentIndex({});
 	m_ui.searchDirectoryList->setContextMenuPolicy(Qt::ContextMenuPolicy::CustomContextMenu);
 
-	connect(m_ui.searchDirectoryList, &QTableWidget::customContextMenuRequested, this,
-		&GameListSettingsWidget::onDirectoryListContextMenuRequested);
-	connect(m_ui.addSearchDirectoryButton, &QPushButton::clicked, this,
-		&GameListSettingsWidget::onAddSearchDirectoryButtonClicked);
-	connect(m_ui.removeSearchDirectoryButton, &QPushButton::clicked, this,
-		&GameListSettingsWidget::onRemoveSearchDirectoryButtonClicked);
+	connect(m_ui.searchDirectoryList, &QTableWidget::customContextMenuRequested, this, &GameListSettingsWidget::onDirectoryListContextMenuRequested);
+	connect(m_ui.searchDirectoryList, &QTableWidget::itemSelectionChanged, this, &GameListSettingsWidget::onDirectoryListSelectionChanged);
+	connect(m_ui.addSearchDirectoryButton, &QPushButton::clicked, this, &GameListSettingsWidget::onAddSearchDirectoryButtonClicked);
+	connect(m_ui.removeSearchDirectoryButton, &QPushButton::clicked, this, &GameListSettingsWidget::onRemoveSearchDirectoryButtonClicked);
 	connect(m_ui.addExcludedFile, &QPushButton::clicked, this, &GameListSettingsWidget::onAddExcludedFileButtonClicked);
 	connect(m_ui.addExcludedPath, &QPushButton::clicked, this, &GameListSettingsWidget::onAddExcludedPathButtonClicked);
-	connect(m_ui.removeExcludedPath, &QPushButton::clicked, this,
-		&GameListSettingsWidget::onRemoveExcludedPathButtonClicked);
+	connect(m_ui.removeExcludedPath, &QPushButton::clicked, this, &GameListSettingsWidget::onRemoveExcludedPathButtonClicked);
+	connect(m_ui.excludedPaths, &QListWidget::itemSelectionChanged, this, &GameListSettingsWidget::onExcludedPathsSelectionChanged);
 	connect(m_ui.rescanAllGames, &QPushButton::clicked, this, &GameListSettingsWidget::onRescanAllGamesClicked);
 	connect(m_ui.scanForNewGames, &QPushButton::clicked, this, &GameListSettingsWidget::onScanForNewGamesClicked);
 
@@ -77,6 +75,8 @@ void GameListSettingsWidget::refreshExclusionList()
 	const std::vector<std::string> paths(Host::GetBaseStringListSetting("GameList", "ExcludedPaths"));
 	for (const std::string& path : paths)
 		m_ui.excludedPaths->addItem(QString::fromStdString(path));
+
+	m_ui.removeExcludedPath->setEnabled(false);
 }
 
 bool GameListSettingsWidget::event(QEvent* event)
@@ -142,6 +142,8 @@ void GameListSettingsWidget::refreshDirectoryList()
 		addPathToTable(entry, true);
 
 	m_ui.searchDirectoryList->sortByColumn(0, Qt::AscendingOrder);
+
+	m_ui.removeSearchDirectoryButton->setEnabled(false);
 }
 
 void GameListSettingsWidget::addSearchDirectory(const QString& path, bool recursive)
@@ -183,6 +185,11 @@ void GameListSettingsWidget::onDirectoryListContextMenuRequested(const QPoint& p
 		QtUtils::OpenURL(this, QUrl::fromLocalFile(m_ui.searchDirectoryList->item(row, 0)->text()));
 	});
 	menu.exec(m_ui.searchDirectoryList->mapToGlobal(point));
+}
+
+void GameListSettingsWidget::onDirectoryListSelectionChanged()
+{
+	m_ui.removeSearchDirectoryButton->setEnabled(m_ui.searchDirectoryList->selectionModel()->hasSelection());
 }
 
 void GameListSettingsWidget::addSearchDirectory(QWidget* parent_widget)
@@ -256,6 +263,11 @@ void GameListSettingsWidget::onRemoveExcludedPathButtonClicked()
 	delete item;
 
 	g_main_window->refreshGameList(false);
+}
+
+void GameListSettingsWidget::onExcludedPathsSelectionChanged()
+{
+	m_ui.removeExcludedPath->setEnabled(!m_ui.excludedPaths->selectedItems().isEmpty());
 }
 
 void GameListSettingsWidget::onRescanAllGamesClicked()

--- a/pcsx2-qt/Settings/GameListSettingsWidget.h
+++ b/pcsx2-qt/Settings/GameListSettingsWidget.h
@@ -28,11 +28,13 @@ public Q_SLOTS:
 
 private Q_SLOTS:
 	void onDirectoryListContextMenuRequested(const QPoint& point);
+	void onDirectoryListSelectionChanged();
 	void onAddSearchDirectoryButtonClicked();
 	void onRemoveSearchDirectoryButtonClicked();
 	void onAddExcludedFileButtonClicked();
 	void onAddExcludedPathButtonClicked();
 	void onRemoveExcludedPathButtonClicked();
+	void onExcludedPathsSelectionChanged();
 	void onScanForNewGamesClicked();
 	void onRescanAllGamesClicked();
 

--- a/pcsx2-qt/SetupWizardDialog.cpp
+++ b/pcsx2-qt/SetupWizardDialog.cpp
@@ -237,12 +237,10 @@ void SetupWizardDialog::setupGameListPage()
 	m_ui.searchDirectoryList->setCurrentIndex({});
 	m_ui.searchDirectoryList->setContextMenuPolicy(Qt::ContextMenuPolicy::CustomContextMenu);
 
-	connect(m_ui.searchDirectoryList, &QTableWidget::customContextMenuRequested, this,
-		&SetupWizardDialog::onDirectoryListContextMenuRequested);
-	connect(m_ui.addSearchDirectoryButton, &QPushButton::clicked, this,
-		&SetupWizardDialog::onAddSearchDirectoryButtonClicked);
-	connect(m_ui.removeSearchDirectoryButton, &QPushButton::clicked, this,
-		&SetupWizardDialog::onRemoveSearchDirectoryButtonClicked);
+	connect(m_ui.searchDirectoryList, &QTableWidget::customContextMenuRequested, this, &SetupWizardDialog::onDirectoryListContextMenuRequested);
+	connect(m_ui.searchDirectoryList, &QTableWidget::itemSelectionChanged, this, &SetupWizardDialog::onDirectoryListSelectionChanged);
+	connect(m_ui.addSearchDirectoryButton, &QPushButton::clicked, this, &SetupWizardDialog::onAddSearchDirectoryButtonClicked);
+	connect(m_ui.removeSearchDirectoryButton, &QPushButton::clicked, this, &SetupWizardDialog::onRemoveSearchDirectoryButtonClicked);
 
 	refreshDirectoryList();
 }
@@ -261,6 +259,11 @@ void SetupWizardDialog::onDirectoryListContextMenuRequested(const QPoint& point)
 	menu.addAction(tr("Open Directory..."),
 		[this, row]() { QtUtils::OpenURL(this, QUrl::fromLocalFile(m_ui.searchDirectoryList->item(row, 0)->text())); });
 	menu.exec(m_ui.searchDirectoryList->mapToGlobal(point));
+}
+
+void SetupWizardDialog::onDirectoryListSelectionChanged()
+{
+	m_ui.removeSearchDirectoryButton->setEnabled(!m_ui.searchDirectoryList->selectedItems().isEmpty());
 }
 
 void SetupWizardDialog::onAddSearchDirectoryButtonClicked()
@@ -349,6 +352,7 @@ void SetupWizardDialog::refreshDirectoryList()
 		addPathToTable(entry, true);
 
 	m_ui.searchDirectoryList->sortByColumn(0, Qt::AscendingOrder);
+	m_ui.removeSearchDirectoryButton->setEnabled(false);
 }
 
 void SetupWizardDialog::resizeDirectoryListColumns()

--- a/pcsx2-qt/SetupWizardDialog.h
+++ b/pcsx2-qt/SetupWizardDialog.h
@@ -33,6 +33,7 @@ private Q_SLOTS:
 	void biosListItemChanged(const QTreeWidgetItem* current, const QTreeWidgetItem* previous);
 
 	void onDirectoryListContextMenuRequested(const QPoint& point);
+	void onDirectoryListSelectionChanged();
 	void onAddSearchDirectoryButtonClicked();
 	void onRemoveSearchDirectoryButtonClicked();
 	void refreshDirectoryList();


### PR DESCRIPTION
### Description of Changes

- Bumps SDL version for Flatpak, since both Jordan and I forgot about it.
- Simplifies the page fault handler logic, also provides the host with whether it was a write or read.
- Stops the crash handler from leaking zombie PCSX2 processes when it crashes. Hopefully this'll fix the random "permission denied" error some users get when updating.
- Fix remove game directory/excluded path tool button being enabled without a selection.

### Rationale behind Changes

See above.

### Suggested Testing Steps

Make sure games still boot.
Make sure when adding/removing a game/exclusion directory, the remove button behaves as expected.
