### PR TITLE
DEV9: UDP Cleanup + Various fixes

### DIFF
--- a/pcsx2/DEV9/Sessions/UDP_Session/UDP_FixedPort.cpp
+++ b/pcsx2/DEV9/Sessions/UDP_Session/UDP_FixedPort.cpp
@@ -106,7 +106,7 @@ namespace Sessions
 		if (ret == SOCKET_ERROR)
 		{
 			hasData = false;
-			Console.Error("DEV9: UDP: select failed. Error Code: %d",
+			Console.Error("DEV9: UDP: select failed. Error code: %d",
 #ifdef _WIN32
 				WSAGetLastError());
 #elif defined(__POSIX__)
@@ -121,14 +121,14 @@ namespace Sessions
 #ifdef _WIN32
 			int len = sizeof(error);
 			if (getsockopt(client, SOL_SOCKET, SO_ERROR, reinterpret_cast<char*>(&error), &len) < 0)
-				Console.Error("DEV9: UDP: Unkown UDP Connection Error (getsockopt Error: %d)", WSAGetLastError());
+				Console.Error("DEV9: UDP: Unknown UDP connection error (getsockopt error: %d)", WSAGetLastError());
 #elif defined(__POSIX__)
 			socklen_t len = sizeof(error);
 			if (getsockopt(client, SOL_SOCKET, SO_ERROR, reinterpret_cast<char*>(&error), &len) < 0)
-				Console.Error("DEV9: UDP: Unkown UDP Connection Error (getsockopt Error: %d)", errno);
+				Console.Error("DEV9: UDP: Unknown UDP connection error (getsockopt error: %d)", errno);
 #endif
 			else
-				Console.Error("DEV9: UDP: Recv Error: %d", error);
+				Console.Error("DEV9: UDP: Recv error: %d", error);
 		}
 		else
 			hasData = FD_ISSET(client, &sReady);
@@ -161,7 +161,7 @@ namespace Sessions
 
 			if (ret == SOCKET_ERROR)
 			{
-				Console.Error("UDP Recv Error: %d",
+				Console.Error("DEV9: UDP: UDP recv error: %d",
 #ifdef _WIN32
 					WSAGetLastError());
 #elif defined(__POSIX__)

--- a/pcsx2/DEV9/Sessions/UDP_Session/UDP_FixedPort.h
+++ b/pcsx2/DEV9/Sessions/UDP_Session/UDP_FixedPort.h
@@ -20,7 +20,7 @@ namespace Sessions
 	class UDP_FixedPort : public BaseSession
 	{
 	private:
-		std::atomic<bool> open{true};
+		std::atomic<bool> open{false};
 
 #ifdef _WIN32
 		SOCKET client = INVALID_SOCKET;
@@ -37,6 +37,8 @@ namespace Sessions
 
 	public:
 		UDP_FixedPort(ConnectionKey parKey, PacketReader::IP::IP_Address parAdapterIP, u16 parPort);
+
+		void Init();
 
 		virtual PacketReader::IP::IP_Payload* Recv();
 		virtual bool Send(PacketReader::IP::IP_Payload* payload);

--- a/pcsx2/DEV9/Sessions/UDP_Session/UDP_Session.cpp
+++ b/pcsx2/DEV9/Sessions/UDP_Session/UDP_Session.cpp
@@ -70,7 +70,7 @@ namespace Sessions
 			if (std::chrono::steady_clock::now() - deathClockStart.load() > MAX_IDLE)
 			{
 				CloseSocket();
-				Console.WriteLn("DEV9: UDP: UDPFixed Max Idle Reached");
+				Console.WriteLn("DEV9: UDP: Fixed port max idle reached");
 				RaiseEventConnectionClosed();
 			}
 			return nullptr;
@@ -91,7 +91,7 @@ namespace Sessions
 		if (ret == SOCKET_ERROR)
 		{
 			hasData = false;
-			Console.Error("DEV9: UDP: Select Failed. Error Code: %d",
+			Console.Error("DEV9: UDP: Select failed. Error code: %d",
 #ifdef _WIN32
 				WSAGetLastError());
 #elif defined(__POSIX__)
@@ -106,14 +106,14 @@ namespace Sessions
 #ifdef _WIN32
 			int len = sizeof(error);
 			if (getsockopt(client, SOL_SOCKET, SO_ERROR, reinterpret_cast<char*>(&error), &len) < 0)
-				Console.Error("DEV9: UDP: Unkown UDP Connection Error (getsockopt Error: %d)", WSAGetLastError());
+				Console.Error("DEV9: UDP: Unknown UDP connection error (getsockopt error: %d)", WSAGetLastError());
 #elif defined(__POSIX__)
 			socklen_t len = sizeof(error);
 			if (getsockopt(client, SOL_SOCKET, SO_ERROR, reinterpret_cast<char*>(&error), &len) < 0)
-				Console.Error("DEV9: UDP: Unkown UDP Connection Error (getsockopt Error: %d)", errno);
+				Console.Error("DEV9: UDP: Unknown UDP connection error (getsockopt error: %d)", errno);
 #endif
 			else
-				Console.Error("DEV9: UDP: Recv Error: %d", error);
+				Console.Error("DEV9: UDP: Recv error: %d", error);
 		}
 		else
 			hasData = FD_ISSET(client, &sReady);
@@ -146,7 +146,7 @@ namespace Sessions
 
 			if (ret == SOCKET_ERROR)
 			{
-				Console.Error("DEV9: UDP: Recv Error: %d",
+				Console.Error("DEV9: UDP: Recv error: %d",
 #ifdef _WIN32
 					WSAGetLastError());
 #elif defined(__POSIX__)
@@ -171,7 +171,7 @@ namespace Sessions
 		if (std::chrono::steady_clock::now() - deathClockStart.load() > MAX_IDLE)
 		{
 			//CloseSocket();
-			Console.WriteLn("DEV9: UDP: Max Idle Reached");
+			Console.WriteLn("DEV9: UDP: Max idle reached");
 			RaiseEventConnectionClosed();
 		}
 
@@ -203,7 +203,7 @@ namespace Sessions
 			//client already created
 			if (!(udp.destinationPort == destPort && udp.sourcePort == srcPort))
 			{
-				Console.Error("DEV9: UDP: Packet invalid for current session (Duplicate key?)");
+				Console.Error("DEV9: UDP: Packet invalid for current session (duplicate key?)");
 				return false;
 			}
 		}
@@ -217,7 +217,7 @@ namespace Sessions
 			if ((destIP.bytes[0] & 0xF0) == 0xE0)
 			{
 				isMulticast = true;
-				Console.Error("DEV9: UDP: Unexpected Multicast Connection");
+				Console.Error("DEV9: UDP: Unexpected multicast connection");
 			}
 
 			int ret;
@@ -319,7 +319,7 @@ namespace Sessions
 #elif defined(__POSIX__)
 			ret = errno;
 #endif
-			Console.Error("DEV9: UDP: Send Error %d", ret);
+			Console.Error("DEV9: UDP: Send error %d", ret);
 
 			//We can recive an ICMP Port Unreacable error, which can get raised in send (and maybe sendto?)
 			//On Windows this an WSAECONNRESET error, although I've not been able to reproduce in testing
@@ -348,7 +348,7 @@ namespace Sessions
 
 				if (ret == SOCKET_ERROR)
 				{
-					Console.Error("DEV9: UDP: Send Error (Second attempt) %d",
+					Console.Error("DEV9: UDP: Send error (second attempt) %d",
 #ifdef _WIN32
 						WSAGetLastError());
 #elif defined(__POSIX__)

--- a/pcsx2/DEV9/Sessions/UDP_Session/UDP_Session.h
+++ b/pcsx2/DEV9/Sessions/UDP_Session/UDP_Session.h
@@ -30,7 +30,7 @@ namespace Sessions
 		u16 destPort = 0;
 		// UDP_Session flags
 		const bool isBroadcast;
-		bool isMulticast = false;
+		const bool isMulticast;
 		const bool isFixedPort;
 
 		std::atomic<std::chrono::steady_clock::time_point> deathClockStart;

--- a/pcsx2/DEV9/Sessions/UDP_Session/UDP_Session.h
+++ b/pcsx2/DEV9/Sessions/UDP_Session/UDP_Session.h
@@ -28,19 +28,18 @@ namespace Sessions
 
 		u16 srcPort = 0;
 		u16 destPort = 0;
-		//Broadcast
-		const bool isBroadcast; // = false;
+		// UDP_Session flags
+		const bool isBroadcast;
 		bool isMulticast = false;
-		const bool isFixedPort; // = false;
-		//EndBroadcast
+		const bool isFixedPort;
 
 		std::atomic<std::chrono::steady_clock::time_point> deathClockStart;
 		const static std::chrono::duration<std::chrono::steady_clock::rep, std::chrono::steady_clock::period> MAX_IDLE;
 
 	public:
-		//Normal Port
+		// Normal Port
 		UDP_Session(ConnectionKey parKey, PacketReader::IP::IP_Address parAdapterIP);
-		//Fixed Port
+		// Fixed Port
 #ifdef _WIN32
 		UDP_Session(ConnectionKey parKey, PacketReader::IP::IP_Address parAdapterIP, bool parIsBroadcast, bool parIsMulticast, SOCKET parClient);
 #elif defined(__POSIX__)

--- a/pcsx2/DEV9/Sessions/UDP_Session/UDP_Session.h
+++ b/pcsx2/DEV9/Sessions/UDP_Session/UDP_Session.h
@@ -52,8 +52,5 @@ namespace Sessions
 		virtual void Reset();
 
 		virtual ~UDP_Session();
-
-	private:
-		void CloseSocket();
 	};
 } // namespace Sessions

--- a/pcsx2/DEV9/sockets.cpp
+++ b/pcsx2/DEV9/sockets.cpp
@@ -531,12 +531,20 @@ bool SocketAdapter::SendUDP(ConnectionKey Key, IP_Packet* ipPkt)
 
 				connections.Add(fKey, fPort);
 				fixedUDPPorts.Add(udp.sourcePort, fPort);
+
+				fPort->Init();
 			}
 
 			Console.WriteLn("DEV9: Socket: Creating New UDP Connection from FixedPort %d to %d", udp.sourcePort, udp.destinationPort);
 			s = fPort->NewClientSession(Key,
 				ipPkt->destinationIP == dhcpServer.broadcastIP || ipPkt->destinationIP == IP_Address{{{255, 255, 255, 255}}},
 				(ipPkt->destinationIP.bytes[0] & 0xF0) == 0xE0);
+
+			if (s == nullptr)
+			{
+				Console.Error("DEV9: Socket: Failed to Create New UDP Connection from FixedPort");
+				return false;
+			}
 		}
 		else
 		{


### PR DESCRIPTION
### Description of Changes
Replace C-Style casts with C++ equivalents.
Make capitalisation of text in log messages consistent.
Format comments to (hopefully) be more inline with PCSX2's comment style
Simplify closing of UDP sockets slightly,
Improve handling of sent multicast packets
Improve error handling when creating certain UDP connections

It may be easier to review each commit one by one rather than the whole pr at once

### Rationale behind Changes
Improve code quality
Better error handling

This ended up picking up more changes then I had intended, I can split this into separate PRs if that makes this easier

### Suggested Testing Steps
Test networked games using the sockets backend.
