### PR TITLE
gitignore: Add deps-build path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,6 +102,7 @@ oprofile_data/
 /bin/resources/fonts/NotoSansSC-Regular.ttf
 /bin/resources/fonts/NotoSansTC-Regular.ttf
 
+/deps-build
 /deps
 /ipch
 


### PR DESCRIPTION
### Description of Changes
Adds `/deps-build` to gitignore

### Rationale behind Changes
vscode complains about the number of changes if you have open while building dependencies

### Suggested Testing Steps
`git status` while building dependencies
