### PR TITLE
Misc: Code exports for use with mods

### DIFF
--- a/pcsx2/ImGui/ImGuiOverlays.cpp
+++ b/pcsx2/ImGui/ImGuiOverlays.cpp
@@ -45,6 +45,8 @@
 #include <tuple>
 #include <unordered_map>
 
+extern "C" bool GetIsThrottlerTempDisabled();
+
 namespace ImGuiManager
 {
 	static void FormatProcessorStat(SmallStringBase& text, double usage, double time);
@@ -251,6 +253,9 @@ __ri void ImGuiManager::DrawPerformanceOverlay(float& position_y, float scale, f
 				else // Unlimited
 					DRAW_LINE(standard_font, ICON_FA_FORWARD, IM_COL32(255, 255, 255, 255));
 			}
+
+			if (GetIsThrottlerTempDisabled())
+				DRAW_LINE(standard_font, ICON_FA_FORWARD, IM_COL32(255, 0, 0, 255));
 		}
 
 		if (GSConfig.OsdShowFrameTimes)


### PR DESCRIPTION
### Description of Changes

This PR adds new code exports which allow to modify emulated game code externally.

New variable:
`s_is_throttler_temp_disabled` - Allows to control emulation throttle state, this in combo with custom external game code can allow to speed up loading times in games.

New function 
`GetVMState()` - Allows to externally check current VM state.

Callbacks:
`AddOnGameElfInitCallback` and `AddOnGameShutdownCallback` - Two new exports for external software to use, allows access to game memory, serial and other metadata which is required to create more advanced mods.

### Rationale behind Changes

Adding external exports will allow external software to take advantage of them to make modifications to emulated games, these changes being exports mean that emulation itself is not really affected.

### Suggested Testing Steps

Check if throttle/unthrottle still works.