### PR TITLE
VMManager: Clear protected pages when resetting VM

### DIFF
--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -1376,6 +1376,7 @@ bool VMManager::Initialize(VMBootParameters boot_params)
 
 	s_cpu_implementation_changed = false;
 	UpdateCPUImplementations();
+	mmap_ResetBlockTracking();
 	memSetExtraMemMode(EmuConfig.Cpu.ExtraMemory);
 	Internal::ClearCPUExecutionCaches();
 	FPControlRegister::SetCurrent(EmuConfig.Cpu.FPUFPCR);
@@ -1617,6 +1618,7 @@ void VMManager::Reset()
 	if (elf_was_changed)
 		HandleELFChange(false);
 
+	mmap_ResetBlockTracking();
 	memSetExtraMemMode(EmuConfig.Cpu.ExtraMemory);
 	Internal::ClearCPUExecutionCaches();
 	memBindConditionalHandlers();

--- a/pcsx2/x86/ix86-32/iR5900.cpp
+++ b/pcsx2/x86/ix86-32/iR5900.cpp
@@ -599,7 +599,6 @@ static void recResetRaw()
 		memset(s_pInstCache, 0, sizeof(EEINST) * s_nInstCacheSize);
 
 	recBlocks.Reset();
-	mmap_ResetBlockTracking();
 	vtlb_ClearLoadStoreInfo();
 
 	g_branch = 0;


### PR DESCRIPTION
### Description of Changes
This PR makes two changes:
* `mmap_ResetBlockTracking` now uses `TotalRam` instead of `ExposedRam`
* `VMManager::Reset` now calls `mmap_ResetBlockTracking` before `SysMemory::Reset` is called

### Rationale behind Changes
`mmap_ResetBlockTracking` is supposed to clear _everything_, so it probably makes more sense for it to use `TotalRam` rather than `ExposedRam`. It is now called from `VMManager::Reset` to fix a crash that occurs when the VM is reset after disabling expanded memory if the program has executed code in high RAM. PCSX2 will AV [here](https://github.com/PCSX2/pcsx2/blob/5f7e97c27c966059ba80e93ba800ae5fc0398de3/pcsx2/Memory.cpp#L1160) when trying to clear `eeMem`, because it has leftover read-only page protection flags from the previous session.

### Suggested Testing Steps
1. Download [mem-reset-elfs.zip](https://github.com/PCSX2/pcsx2/files/15264752/mem-reset-elfs.zip)
2. With host filesystem and 128MB RAM enabled, run `main.elf`
3. Turn off 128MB RAM and then reset the VM
