### PR TITLE
Core: Refactor a lot of timer work and fix a couple of bugs

### DIFF
--- a/pcsx2/CDVD/CDVD.h
+++ b/pcsx2/CDVD/CDVD.h
@@ -123,7 +123,7 @@ struct cdvdStruct
 
 	// Calculates the number of Vsyncs and once it reaches a total number of Vsyncs worth a second with respect to
 	// the videomode's vertical frequency, it updates the real time clock.
-	int RTCcount;
+	double RTCcount;
 	cdvdRTC RTC;
 
 	u32 CurrentSector;

--- a/pcsx2/Counters.h
+++ b/pcsx2/Counters.h
@@ -60,14 +60,14 @@ struct Counter
 	};
 	u32 target, hold;
 	u32 rate, interrupt;
-	u32 sCycleT;		// delta values should be signed.
+	u32 startCycle;		// delta values should be signed.
 };
 
 struct SyncCounter
 {
 	u32 Mode;
-	u32 sCycle;					// start cycle of timer
-	s32 CycleT;
+	u32 startCycle;					// start cycle of timer
+	s32 deltaCycles;
 };
 
 //------------------------------------------------------------------
@@ -107,9 +107,6 @@ struct SyncCounter
 #define MODE_VRENDER	0x0		//Set during the Render/Frame Scanlines
 #define MODE_VBLANK		0x1		//Set during the Blanking Scanlines
 #define MODE_GSBLANK	0x2		//Set during the Syncing Scanlines (Delayed GS CSR Swap)
-#define MODE_VSYNC		0x3		//Set during the Syncing Scanlines
-#define MODE_VBLANK1	0x0		//Set during the Blanking Scanlines (half-frame 1)
-#define MODE_VBLANK2	0x1		//Set during the Blanking Scanlines (half-frame 2)
 
 #define MODE_HRENDER	0x0		//Set for ~5/6 of 1 Scanline
 #define MODE_HBLANK		0x1		//Set for the remaining ~1/6 of 1 Scanline
@@ -120,13 +117,14 @@ extern Counter counters[4];
 extern SyncCounter hsyncCounter;
 extern SyncCounter vsyncCounter;
 
-extern s32 nextCounter;		// delta until the next counter event (must be signed)
-extern u32 nextsCounter;
+extern s32 nextDeltaCounter;		// delta until the next counter event (must be signed)
+extern u32 nextStartCounter;
 extern uint g_FrameCount;
 
 extern void rcntUpdate_hScanline();
 extern void rcntUpdate_vSync();
 extern bool rcntCanCount(int i);
+extern void rcntSyncCounter(int i);
 extern void rcntUpdate();
 
 extern void rcntInit();

--- a/pcsx2/GS.h
+++ b/pcsx2/GS.h
@@ -6,6 +6,7 @@
 #include "Common.h"
 #include "Gif.h"
 #include "GS/GS.h"
+#include "GS/GSRegs.h"
 
 #include "common/SingleRegisterTypes.h"
 
@@ -194,42 +195,6 @@ union tGS_IMR
 };
 
 // --------------------------------------------------------------------------------------
-//  GSRegSMODE1
-// --------------------------------------------------------------------------------------
-// Previously, the union was used to get the CMOD bit of the SMODE1 register
-// Commenting it out as it's unused right now. (Might potentially be useful in the future)
-//union GSRegSMODE1
-//{
-//	struct
-//	{
-//		u32 RC : 3;
-//		u32 LC : 7;
-//		u32 T1248 : 2;
-//		u32 SLCK : 1;
-//		u32 CMOD : 2;
-//		u32 EX : 1;
-//		u32 PRST : 1;
-//		u32 SINT : 1;
-//		u32 XPCK : 1;
-//		u32 PCK2 : 2;
-//		u32 SPML : 4;
-//		u32 GCONT : 1;
-//		u32 PHS : 1;
-//		u32 PVS : 1;
-//		u32 PEHS : 1;
-//		u32 PEVS : 1;
-//		u32 CLKSEL : 2;
-//		u32 NVCK : 1;
-//		u32 SLCK2 : 1;
-//		u32 VCKSEL : 2;
-//		u32 VHP : 1;
-//		u32 _PAD1 : 27;
-//	};
-//
-//	u64 SMODE1;
-//};
-
-// --------------------------------------------------------------------------------------
 //  GSRegSIGBLID
 // --------------------------------------------------------------------------------------
 struct GSRegSIGBLID
@@ -242,7 +207,7 @@ struct GSRegSIGBLID
 #define PS2GS_BASE(mem) (PS2MEM_GS + (mem & 0x13ff))
 
 #define CSRreg ((tGS_CSR&)*(PS2MEM_GS + 0x1000))
-
+#define GSSMODE1reg ((GSRegSMODE1&)*(PS2MEM_GS + 0x0010))
 #define GSCSRr ((u32&)*(PS2MEM_GS + 0x1000))
 #define GSIMR ((tGS_IMR&)*(PS2MEM_GS + 0x1010))
 #define GSSIGLBLID ((GSRegSIGBLID&)*(PS2MEM_GS + 0x1080))
@@ -264,6 +229,7 @@ enum class GS_VideoMode : int
 };
 
 extern GS_VideoMode gsVideoMode;
+extern u32 lastCSRFlag;
 extern bool gsIsInterlaced;
 
 /////////////////////////////////////////////////////////////////////////////

--- a/pcsx2/IopCounters.cpp
+++ b/pcsx2/IopCounters.cpp
@@ -32,8 +32,8 @@
 #define PSXSOUNDCLK ((int)(48000))
 
 psxCounter psxCounters[NUM_COUNTERS];
-s32 psxNextCounter;
-u32 psxNextsCounter;
+s32 psxNextDeltaCounter;
+u32 psxNextStartCounter;
 
 bool hBlanking = false;
 bool vBlanking = false;
@@ -44,44 +44,27 @@ bool vBlanking = false;
 // used to disable targets until after an overflow
 #define IOPCNT_FUTURE_TARGET (0x1000000000ULL)
 #define IOPCNT_MODE_WRITE_MSK 0x63FF
-#define IOPCNT_MODE_FLAG_MSK 0x1800
+#define IOPCNT_MODE_FLAG_MSK 0x1C00
 
-#define IOPCNT_ENABLE_GATE (1 << 0)    // enables gate-based counters
-#define IOPCNT_MODE_GATE (3 << 1)      // 0x6  Gate mode (dependant on counter)
-#define IOPCNT_MODE_RESET_CNT (1 << 3) // 0x8  resets the counter on target (if interrupt only?)
-#define IOPCNT_INT_TARGET (1 << 4)     // 0x10  triggers an interrupt on targets
-#define IOPCNT_INT_OVERFLOW (1 << 5)   // 0x20  triggers an interrupt on overflows
-#define IOPCNT_INT_REPEAT (1 << 6)     // 0x40  0=One shot (ignore TOGGLE bit 7) 1=Repeat Fire (Check TOGGLE bit 7)
-#define IOPCNT_INT_TOGGLE (1 << 7)     // 0x80  0=Pulse (reset on read), 1=toggle each interrupt condition (in 1 shot not reset after fired)
-#define IOPCNT_ALT_SOURCE (1 << 8)     // 0x100 uses hblank on counters 1 and 3, and PSXCLOCK on counter 0
-#define IOPCNT_INT_REQ (1 << 10)       // 0x400 1=Can fire interrupt, 0=Interrupt Fired (reset on read if not 1 shot)
-#define IOPCNT_INT_CMPFLAG  (1 << 11)  // 0x800 1=Target interrupt raised
-#define IOPCNT_INT_OFLWFLAG (1 << 12)  // 0x1000 1=Overflow interrupt raised
+#define IOPCNT_GATE_CNT_LOW 0           // Counts only when signal is low (V/H RENDER).
+#define IOPCNT_GATE_CLR_END 1           // Counts continuously, clears at end of BLANK.
+#define IOPCNT_GATE_CNT_HIGH_ZERO_OFF 2 // Starts at beginning of next BLANK, counts only during BLANK, returns zero any other time.
+#define IOPCNT_GATE_START_AT_END 3      // Starts at end of next BLANK, continuous count, no clear.
 
 // Use an arbitrary value to flag HBLANK counters.
 // These counters will be counted by the hblank gates coming from the EE,
 // which ensures they stay 100% in sync with the EE's hblank counters.
 #define PSXHBLANK 0x2001
 
-#if 0
-// Unused
-static void psxRcntReset(int index)
-{
-	psxCounters[index].count = 0;
-	psxCounters[index].mode &= ~0x18301C00;
-	psxCounters[index].sCycleT = psxRegs.cycle;
-}
-#endif
-
 static bool psxRcntCanCount(int cntidx)
 {
-	if (psxCounters[cntidx].mode & IOPCNT_STOPPED)
+	if (psxCounters[cntidx].mode.stopped)
 		return false;
 
-	if (!(psxCounters[cntidx].mode & IOPCNT_ENABLE_GATE))
+	if (!(psxCounters[cntidx].mode.gateEnable))
 		return true;
 
-	const u32 gateMode = (psxCounters[cntidx].mode & IOPCNT_MODE_GATE) >> 1;
+	const u32 gateMode = psxCounters[cntidx].mode.gateMode;
 
 	if (cntidx == 2 || cntidx == 4 || cntidx == 5)
 	{
@@ -92,11 +75,38 @@ static bool psxRcntCanCount(int cntidx)
 	const bool blanking = cntidx == 0 ? hBlanking : vBlanking;
 
 	// Stop counting if Gate mode 0 (only count when rendering) and blanking or Gate mode 2 (only count when blanking) when not blanking
-	if ((gateMode == 0 && blanking == true) || (gateMode == 2 && blanking == false))
+	if ((gateMode == IOPCNT_GATE_CNT_LOW && blanking == true) || (gateMode == IOPCNT_GATE_CNT_HIGH_ZERO_OFF && blanking == false))
 		return false;
 
 	// All other cases allow counting.
 	return true;
+}
+
+static void psxRcntSync(int cntidx)
+{
+	if ((psxCounters[cntidx].currentIrqMode.repeatInterrupt) && !(psxCounters[cntidx].currentIrqMode.toggleInterrupt))
+	{ //Repeat IRQ mode Pulsed, resets a few cycles after the interrupt, this should do.
+		psxCounters[cntidx].mode.intrEnable = true;
+	}
+
+	if (psxRcntCanCount(cntidx) && psxCounters[cntidx].rate != PSXHBLANK)
+	{
+		const u32 change = (psxRegs.cycle - psxCounters[cntidx].startCycle) / psxCounters[cntidx].rate;
+		if (change > 0)
+		{
+			psxCounters[cntidx].count += change;
+			psxCounters[cntidx].startCycle += change * psxCounters[cntidx].rate;
+
+			psxCounters[cntidx].startCycle &= ~(psxCounters[cntidx].rate - 1);
+		}
+	}
+	else
+	{
+		if (psxCounters[cntidx].mode.gateEnable && psxCounters[cntidx].mode.gateMode == IOPCNT_GATE_CNT_HIGH_ZERO_OFF)
+			psxCounters[cntidx].count = 0;
+
+		psxCounters[cntidx].startCycle = psxRegs.cycle;
+	}
 }
 
 static void _rcntSet(int cntidx)
@@ -114,36 +124,33 @@ static void _rcntSet(int cntidx)
 	if (counter.rate == PSXHBLANK || !psxRcntCanCount(cntidx))
 		return;
 
-	if (!(counter.mode & (IOPCNT_INT_TARGET | IOPCNT_INT_OVERFLOW)))
-		return;
 	// check for special cases where the overflow or target has just passed
 	// (we probably missed it because we're doing/checking other things)
 	if (counter.count > overflowCap || counter.count > counter.target)
 	{
-		psxNextCounter = 4;
+		psxNextDeltaCounter = 4;
 		return;
 	}
 
-	c = (u64)((overflowCap - counter.count) * counter.rate) - (psxRegs.cycle - counter.sCycleT);
-	c += psxRegs.cycle - psxNextsCounter; // adjust for time passed since last rcntUpdate();
+	c = (u64)((overflowCap - counter.count) * counter.rate) - (psxRegs.cycle - counter.startCycle);
+	c += psxRegs.cycle - psxNextStartCounter; // adjust for time passed since last rcntUpdate();
 
-	if (c < (u64)psxNextCounter)
+	if (c < (u64)psxNextDeltaCounter)
 	{
-		psxNextCounter = (u32)c;
-		psxSetNextBranch(psxNextsCounter, psxNextCounter); //Need to update on counter resets/target changes
+		psxNextDeltaCounter = (u32)c;
+		psxSetNextBranch(psxNextStartCounter, psxNextDeltaCounter); //Need to update on counter resets/target changes
 	}
 
-	//if((counter.mode & 0x10) == 0 || psxCounters[i].target > 0xffff) continue;
 	if (counter.target & IOPCNT_FUTURE_TARGET)
 		return;
 
-	c = (s64)((counter.target - counter.count) * counter.rate) - (psxRegs.cycle - counter.sCycleT);
-	c += psxRegs.cycle - psxNextsCounter; // adjust for time passed since last rcntUpdate();
+	c = (s64)((counter.target - counter.count) * counter.rate) - (psxRegs.cycle - counter.startCycle);
+	c += psxRegs.cycle - psxNextStartCounter; // adjust for time passed since last rcntUpdate();
 
-	if (c < (u64)psxNextCounter)
+	if (c < (u64)psxNextDeltaCounter)
 	{
-		psxNextCounter = (u32)c;
-		psxSetNextBranch(psxNextsCounter, psxNextCounter); //Need to update on counter resets/target changes
+		psxNextDeltaCounter = (u32)c;
+		psxSetNextBranch(psxNextStartCounter, psxNextDeltaCounter); //Need to update on counter resets/target changes
 	}
 }
 
@@ -157,14 +164,18 @@ void psxRcntInit()
 	for (i = 0; i < 3; i++)
 	{
 		psxCounters[i].rate = 1;
-		psxCounters[i].mode |= IOPCNT_INT_REQ;
+		psxCounters[i].mode.intrEnable = true;
 		psxCounters[i].target = IOPCNT_FUTURE_TARGET;
+		psxCounters[i].currentIrqMode.repeatInterrupt = false;
+		psxCounters[i].currentIrqMode.toggleInterrupt = false;
 	}
 	for (i = 3; i < 6; i++)
 	{
 		psxCounters[i].rate = 1;
-		psxCounters[i].mode |= IOPCNT_INT_REQ;
+		psxCounters[i].mode.intrEnable = true;
 		psxCounters[i].target = IOPCNT_FUTURE_TARGET;
+		psxCounters[i].currentIrqMode.repeatInterrupt = false;
+		psxCounters[i].currentIrqMode.toggleInterrupt = false;
 	}
 
 	psxCounters[0].interrupt = 0x10;
@@ -176,72 +187,71 @@ void psxRcntInit()
 	psxCounters[5].interrupt = 0x10000;
 
 	psxCounters[6].rate = 768;
-	psxCounters[6].CycleT = psxCounters[6].rate;
-	psxCounters[6].mode = 0x8;
+	psxCounters[6].deltaCycles = psxCounters[6].rate;
+	psxCounters[6].mode.modeval = 0x8;
 
 	psxCounters[7].rate = PSXCLK / 1000;
-	psxCounters[7].CycleT = psxCounters[7].rate;
-	psxCounters[7].mode = 0x8;
+	psxCounters[7].deltaCycles = psxCounters[7].rate;
+	psxCounters[7].mode.modeval = 0x8;
 
 	for (i = 0; i < 8; i++)
-		psxCounters[i].sCycleT = psxRegs.cycle;
+		psxCounters[i].startCycle = psxRegs.cycle;
 
 	// Tell the IOP to branch ASAP, so that timers can get
 	// configured properly.
-	psxNextCounter = 1;
-	psxNextsCounter = psxRegs.cycle;
+	psxNextDeltaCounter = 1;
+	psxNextStartCounter = psxRegs.cycle;
 }
 
-static bool _rcntFireInterrupt(int i, bool isOverflow)
+static void _rcntFireInterrupt(int i, bool isOverflow)
 {
-	bool ret = false;
-#
-	if (psxCounters[i].mode & IOPCNT_INT_REQ)
+	bool updateIntr = psxCounters[i].currentIrqMode.repeatInterrupt;
+
+	if (psxCounters[i].mode.intrEnable)
 	{
-		// IRQ fired
-		PSXCNT_LOG("Counter %d %s IRQ Fired count %x", i, isOverflow ? "Overflow" : "Target", psxCounters[i].count);
-		psxHu32(0x1070) |= psxCounters[i].interrupt;
-		iopTestIntc();
-		ret = true;
-	}
-	else
-	{
-		//DevCon.Warning("Counter %d IRQ not fired count %x", i, psxCounters[i].count);
-		if (!(psxCounters[i].mode & IOPCNT_INT_REPEAT)) // One shot
+		bool already_set = isOverflow ? psxCounters[i].mode.overflowFlag : psxCounters[i].mode.targetFlag;
+		if (updateIntr || !already_set)
 		{
-			PSXCNT_LOG("Counter %x ignoring %s interrupt (One Shot)", i, isOverflow ? "Overflow" : "Target");
-			return false;
+			// IRQ fired
+			//DevCon.Warning("Counter %d %s IRQ Fired count %x target %x psx Cycle %d", i, isOverflow ? "Overflow" : "Target", psxCounters[i].count, psxCounters[i].target, psxRegs.cycle);
+			psxHu32(0x1070) |= psxCounters[i].interrupt;
+			iopTestIntc();
+		}
+
+		updateIntr |= psxCounters[i].currentIrqMode.toggleInterrupt;
+	}
+
+	if (updateIntr)
+	{
+		if (psxCounters[i].currentIrqMode.toggleInterrupt)
+		{
+			// Toggle mode
+			psxCounters[i].mode.intrEnable ^= true; // Interrupt flag inverted
+		}
+		else
+		{
+			psxCounters[i].mode.intrEnable = false; // Interrupt flag set low
 		}
 	}
-
-	if (psxCounters[i].mode & IOPCNT_INT_TOGGLE)
-	{
-		// Toggle mode
-		psxCounters[i].mode ^= IOPCNT_INT_REQ; // Interrupt flag inverted
-	}
-	else
-	{
-		psxCounters[i].mode &= ~IOPCNT_INT_REQ; // Interrupt flag set low
-	}
-
-	return ret;
 }
+
 static void _rcntTestTarget(int i)
 {
 	if (psxCounters[i].count < psxCounters[i].target)
 		return;
 
 	PSXCNT_LOG("IOP Counter[%d] target 0x%I64x >= 0x%I64x (mode: %x)",
-			   i, psxCounters[i].count, psxCounters[i].target, psxCounters[i].mode);
+			   i, psxCounters[i].count, psxCounters[i].target, psxCounters[i].mode.modeval);
 
-	if (psxCounters[i].mode & IOPCNT_INT_TARGET)
+	if (psxCounters[i].mode.targetIntr)
 	{
 		// Target interrupt
-		if (_rcntFireInterrupt(i, false))
-			psxCounters[i].mode |= IOPCNT_INT_CMPFLAG;
+		_rcntFireInterrupt(i, false);
 	}
 
-	if (psxCounters[i].mode & IOPCNT_MODE_RESET_CNT)
+	psxCounters[i].mode.targetFlag = true;
+
+	if (psxCounters[i].mode.zeroReturn)
 	{
 		// Reset on target
 		psxCounters[i].count -= psxCounters[i].target;
@@ -258,20 +268,20 @@ static __fi void _rcntTestOverflow(int i)
 		return;
 
 	PSXCNT_LOG("IOP Counter[%d] overflow 0x%I64x >= 0x%I64x (mode: %x)",
-			   i, psxCounters[i].count, maxTarget, psxCounters[i].mode);
+			   i, psxCounters[i].count, maxTarget, psxCounters[i].mode.modeval);
 
-	if ((psxCounters[i].mode & IOPCNT_INT_OVERFLOW))
+	if (psxCounters[i].mode.overflIntr)
 	{
 		// Overflow interrupt
-		if (_rcntFireInterrupt(i, true))
-			psxCounters[i].mode |= IOPCNT_INT_OFLWFLAG; // Overflow flag
+		_rcntFireInterrupt(i, true);
 	}
+
+	psxCounters[i].mode.overflowFlag = true;
 
 	// Update count.
 	// Count wraps around back to zero, while the target is restored (if not in one shot mode).
 	// (high bit of the target gets set by rcntWtarget when the target is behind
 	// the counter value, and thus should not be flagged until after an overflow)
-
 	psxCounters[i].count -= maxTarget + 1;
 	psxCounters[i].target &= maxTarget;
 }
@@ -314,10 +324,10 @@ Gate:
 
 static void _psxCheckStartGate(int i)
 {
-	if (!(psxCounters[i].mode & IOPCNT_ENABLE_GATE))
+	if (!(psxCounters[i].mode.gateEnable))
 		return; // Ignore Gate
 
-	switch ((psxCounters[i].mode & 0x6) >> 1)
+	switch (psxCounters[i].mode.gateMode)
 	{
 		case 0x0: // GATE_ON_count - count while gate signal is low (RENDER)
 
@@ -327,7 +337,7 @@ static void _psxCheckStartGate(int i)
 									   psxRcntRcount32(i);
 
 			// Not strictly necessary.
-			psxCounters[i].sCycleT = psxRegs.cycle;
+			psxCounters[i].startCycle = psxRegs.cycle & ~(psxCounters[i].rate - 1);
 			break;
 
 		case 0x1: // GATE_ON_ClearStart - Counts constantly, clears on Blank END
@@ -335,10 +345,10 @@ static void _psxCheckStartGate(int i)
 			break;
 
 		case 0x2: // GATE_ON_Clear_OFF_Start - Counts only when Blanking, clears on both ends, starts counting on next Blank Start.
-			psxCounters[i].mode &= ~IOPCNT_STOPPED;
+			psxRcntSync(i);
+			psxCounters[i].mode.stopped = false;
 			psxCounters[i].count = 0;
 			psxCounters[i].target &= ~IOPCNT_FUTURE_TARGET;
-			psxCounters[i].sCycleT = psxRegs.cycle;
 			break;
 
 		case 0x3: //GATE_ON_Start - Starts counting when the next Blank Ends, no clear.
@@ -349,33 +359,34 @@ static void _psxCheckStartGate(int i)
 
 static void _psxCheckEndGate(int i)
 {
-	if (!(psxCounters[i].mode & IOPCNT_ENABLE_GATE))
+	if (!(psxCounters[i].mode.gateEnable))
 		return; // Ignore Gate
 
 	// NOTE: Starting and stopping of modes 0 and 2 are checked in psxRcntCanCount(), only need to update the start cycle and counts.
-	switch ((psxCounters[i].mode & 0x6) >> 1)
+	switch (psxCounters[i].mode.gateMode)
 	{
 		case 0x0: // GATE_ON_count - count while gate signal is low (RENDER)
-			psxCounters[i].sCycleT = psxRegs.cycle;
+			psxCounters[i].startCycle = psxRegs.cycle & ~(psxCounters[i].rate - 1);
 			break;
 
 		case 0x1: // GATE_ON_ClearStart - Counts constantly, clears on Blank END
+			psxRcntSync(i);
 			psxCounters[i].count = 0;
 			psxCounters[i].target &= ~IOPCNT_FUTURE_TARGET;
 			break;
 
 		case 0x2: // GATE_ON_Clear_OFF_Start - Counts only when Blanking, clears on both ends, starts counting on next Blank Start.
 			// No point in updating the count, since we're gonna clear it.
+			psxRcntSync(i);
 			psxCounters[i].count = 0;
 			psxCounters[i].target &= ~IOPCNT_FUTURE_TARGET;
-			psxCounters[i].sCycleT = psxRegs.cycle;
 			break; // do not set the counter
 
 		case 0x3: // GATE_ON_Start - Starts counting when the next Blank Ends, no clear.
-			if (psxCounters[i].mode & IOPCNT_STOPPED)
+			if (psxCounters[i].mode.stopped)
 			{
-				psxCounters[i].sCycleT = psxRegs.cycle;
-				psxCounters[i].mode &= ~IOPCNT_STOPPED;
+				psxCounters[i].startCycle = psxRegs.cycle & ~(psxCounters[i].rate - 1);
+				psxCounters[i].mode.stopped = false;
 			}
 			break;
 	}
@@ -446,8 +457,8 @@ void psxRcntUpdate()
 {
 	int i;
 
-	psxNextCounter = 0x7fffffff;
-	psxNextsCounter = psxRegs.cycle;
+	psxNextDeltaCounter = 0x7fffffff;
+	psxNextStartCounter = psxRegs.cycle;
 
 	for (i = 0; i < 6; i++)
 	{
@@ -455,58 +466,39 @@ void psxRcntUpdate()
 		// We can't check the ALTSOURCE flag because the PSXCLOCK source *should*
 		// be counted here.
 
-		if (!psxRcntCanCount(i))
-			continue;
-
-		if ((psxCounters[i].mode & IOPCNT_INT_REPEAT) && !(psxCounters[i].mode & IOPCNT_INT_TOGGLE))
-		{ //Repeat IRQ mode Pulsed, resets a few cycles after the interrupt, this should do.
-			psxCounters[i].mode |= IOPCNT_INT_REQ;
-		}
+		psxRcntSync(i);
 
 		if (psxCounters[i].rate == PSXHBLANK)
 			continue;
 
-		if (psxCounters[i].rate != 1)
-		{
-			const u32 change = (psxRegs.cycle - psxCounters[i].sCycleT) / psxCounters[i].rate;
-
-			if (change > 0)
-			{
-				psxCounters[i].count += change;
-				psxCounters[i].sCycleT += change * psxCounters[i].rate;
-			}
-		}
-		else
-		{
-			psxCounters[i].count += psxRegs.cycle - psxCounters[i].sCycleT;
-			psxCounters[i].sCycleT = psxRegs.cycle;
-		}
+		if (!psxRcntCanCount(i))
+			continue;
 
 		_rcntTestOverflow(i);
 		_rcntTestTarget(i);
 	}
 
 	const u32 spu2_delta = (psxRegs.cycle - lClocks) % 768;
-	psxCounters[6].sCycleT = psxRegs.cycle;
-	psxCounters[6].CycleT = psxCounters[6].rate - spu2_delta;
+	psxCounters[6].startCycle = psxRegs.cycle - spu2_delta;
+	psxCounters[6].deltaCycles = psxCounters[6].rate;
 	SPU2async();
-	psxNextCounter = psxCounters[6].CycleT;
+	psxNextDeltaCounter = psxCounters[6].deltaCycles;
 
-	DEV9async(1);
-	const s32 diffusb = psxRegs.cycle - psxCounters[7].sCycleT;
-	s32 cusb = psxCounters[7].CycleT;
+	DEV9async(1);    
+	const s32 diffusb = psxRegs.cycle - psxCounters[7].startCycle;
+	s32 cusb = psxCounters[7].deltaCycles;
 
-	if (diffusb >= psxCounters[7].CycleT)
+	if (diffusb >= psxCounters[7].deltaCycles)
 	{
 		USBasync(diffusb);
-		psxCounters[7].sCycleT += psxCounters[7].rate * (diffusb / psxCounters[7].rate);
-		psxCounters[7].CycleT = psxCounters[7].rate;
+		psxCounters[7].startCycle += psxCounters[7].rate * (diffusb / psxCounters[7].rate);
+		psxCounters[7].deltaCycles = psxCounters[7].rate;
 	}
 	else
 		cusb -= diffusb;
 
-	if (cusb < psxNextCounter)
-		psxNextCounter = cusb;
+	if (cusb < psxNextDeltaCounter)
+		psxNextDeltaCounter = cusb;
 
 	for (i = 0; i < 6; i++)
 		_rcntSet(i);
@@ -517,15 +509,10 @@ void psxRcntUpdate()
 void psxRcntWcount16(int index, u16 value)
 {
 	pxAssert(index < 3);
-	//DevCon.Warning("16bit IOP Counter[%d] writeCount16 = %x", index, value);
+	PSXCNT_LOG("16bit IOP Counter[%d] writeCount16 = %x", index, value);
 
-	if (psxCounters[index].rate != PSXHBLANK)
-	{
-		const u32 change = (psxRegs.cycle - psxCounters[index].sCycleT) / psxCounters[index].rate;
-		psxCounters[index].sCycleT += change * psxCounters[index].rate;
-	}
-	else
-		psxCounters[index].sCycleT = psxRegs.cycle;
+	psxRcntSync(index);
+
 	psxCounters[index].count = value & 0xffff;
 
 	psxCounters[index].target &= 0xffff;
@@ -547,16 +534,8 @@ void psxRcntWcount32(int index, u32 value)
 	pxAssert(index >= 3 && index < 6);
 	PSXCNT_LOG("32bit IOP Counter[%d] writeCount32 = %x", index, value);
 
-	if (psxCounters[index].rate != PSXHBLANK)
-	{
-		// Re-adjust the sCycleT to match where the counter is currently
-		// (remainder of the rate divided into the time passed will do the trick)
+	psxRcntSync(index);
 
-		const u32 change = (psxRegs.cycle - psxCounters[index].sCycleT) / psxCounters[index].rate;
-		psxCounters[index].sCycleT += change * psxCounters[index].rate;
-	}
-	else
-		psxCounters[index].sCycleT = psxRegs.cycle;
 	psxCounters[index].count = value;
 
 	psxCounters[index].target &= 0xffffffff;
@@ -580,10 +559,16 @@ __fi void psxRcntWmode16(int index, u32 value)
 
 	pxAssume(index >= 0 && index < 3);
 	psxCounter& counter = psxCounters[index];
+	psxCounterMode oldMode = counter.mode;
 
-	counter.mode = (value & IOPCNT_MODE_WRITE_MSK) | (counter.mode & IOPCNT_MODE_FLAG_MSK); // Write new value, preserve flags
-	counter.mode |= IOPCNT_INT_REQ; // IRQ Enable
+	counter.mode.modeval = (value & IOPCNT_MODE_WRITE_MSK) | (counter.mode.modeval & IOPCNT_MODE_FLAG_MSK); // Write new value, preserve flags
 
+	if (!((oldMode.targetFlag || oldMode.overflowFlag) && (oldMode.targetIntr || oldMode.overflIntr)))
+		psxRcntSetNewIntrMode(index);
+
+	if (counter.mode.repeatIntr != counter.currentIrqMode.repeatInterrupt || counter.mode.toggleIntr != counter.currentIrqMode.toggleInterrupt)
+		DevCon.Warning("Write to psxCounter[%d] mode old repeat %d new %d old toggle %d new %d", index, counter.currentIrqMode.repeatInterrupt, counter.mode.repeatIntr, counter.currentIrqMode.toggleInterrupt, counter.mode.toggleIntr);
+	
 	if (value & (1 << 4))
 	{
 		irqmode += 1;
@@ -610,35 +595,27 @@ __fi void psxRcntWmode16(int index, u32 value)
 	}
 	if (index == 2)
 	{
-		switch (value & 0x200)
-		{
-			case 0x000:
-				psxCounters[2].rate = 1;
-				break;
-			case 0x200:
-				psxCounters[2].rate = 8;
-				break;
-				jNO_DEFAULT;
-		}
+		if (counter.mode.t2Prescale)
+			psxCounters[2].rate = 8;
+		else
+			psxCounters[2].rate = 1;
 	}
 	else
 	{
 		// Counters 0 and 1 can select PIXEL or HSYNC as an alternate source:
 		counter.rate = 1;
 
-		if (value & IOPCNT_ALT_SOURCE)
+		if (counter.mode.extSignal)
 			counter.rate = (index == 0) ? PSXPIXEL : PSXHBLANK;
 
 		if (counter.rate == PSXPIXEL)
 			Console.Warning("PSX Pixel clock set to time 0, sync may be incorrect");
 
-		if (counter.mode & IOPCNT_ENABLE_GATE)
+		if (counter.mode.gateEnable)
 		{
-			// If set to gate mode 3, the counting starts at the end of the next blank depending on which counter.
-			if ((counter.mode & IOPCNT_MODE_GATE) == 0x4 && !psxRcntCanCount(index))
-				counter.mode |= IOPCNT_STOPPED;
-			else if ((counter.mode & IOPCNT_MODE_GATE) == 0x6)
-				counter.mode |= IOPCNT_STOPPED;
+			// If set to gate mode 2 or 3, the counting starts at the start and end of the next blank respectively depending on which counter.
+			if (counter.mode.gateMode >= IOPCNT_GATE_CNT_HIGH_ZERO_OFF)
+				counter.mode.stopped = true;
 
 			PSXCNT_LOG("IOP Counter[%d] Gate Check set, value = 0x%04X", index, value);
 		}
@@ -646,8 +623,7 @@ __fi void psxRcntWmode16(int index, u32 value)
 
 	// Current counter *always* resets on mode write.
 	counter.count = 0;
-	counter.sCycleT = psxRegs.cycle;
-
+	counter.startCycle = psxRegs.cycle & ~(counter.rate - 1);
 	counter.target &= 0xffff;
 
 	_rcntSet(index);
@@ -661,10 +637,16 @@ __fi void psxRcntWmode32(int index, u32 value)
 	int irqmode = 0;
 	pxAssume(index >= 3 && index < 6);
 	psxCounter& counter = psxCounters[index];
+	psxCounterMode oldMode = counter.mode;
 
-	counter.mode = (value & IOPCNT_MODE_WRITE_MSK) | (counter.mode & IOPCNT_MODE_FLAG_MSK); // Write new value, preserve flags
-	counter.mode |= IOPCNT_INT_REQ; // IRQ Enable
+	counter.mode.modeval = (value & IOPCNT_MODE_WRITE_MSK) | (counter.mode.modeval & IOPCNT_MODE_FLAG_MSK); // Write new value, preserve flags
 
+	if (!((oldMode.targetFlag || oldMode.overflowFlag) && (oldMode.targetIntr || oldMode.overflIntr)))
+		psxRcntSetNewIntrMode(index);
+
+	if (counter.mode.repeatIntr != counter.currentIrqMode.repeatInterrupt || counter.mode.toggleIntr != counter.currentIrqMode.toggleInterrupt)
+		DevCon.Warning("Write to psxCounter[%d] mode old repeat %d new %d old toggle %d new %d", index, counter.currentIrqMode.repeatInterrupt, counter.mode.repeatIntr, counter.currentIrqMode.toggleInterrupt, counter.mode.toggleIntr);
+	
 	if (value & (1 << 4))
 	{
 		irqmode += 1;
@@ -693,39 +675,40 @@ __fi void psxRcntWmode32(int index, u32 value)
 	{
 		// Counter 3 has the HBlank as an alternate source.
 		counter.rate = 1;
-		if (value & IOPCNT_ALT_SOURCE)
+
+		if (counter.mode.extSignal)
 			counter.rate = PSXHBLANK;
 
-		if (counter.mode & IOPCNT_ENABLE_GATE)
+		if (counter.mode.gateEnable)
 		{
 			PSXCNT_LOG("IOP Counter[3] Gate Check set, value = %x", value);
 			// If set to gate mode 2 or 3, the counting starts at the start and end of the next blank respectively depending on which counter.
-			if ((counter.mode & IOPCNT_MODE_GATE) > 0x2)
-				counter.mode |= IOPCNT_STOPPED;
+			if (counter.mode.gateMode >= IOPCNT_GATE_CNT_HIGH_ZERO_OFF)
+				counter.mode.stopped = true;
 		}
 	}
 	else
 	{
-		switch (value & 0x6000)
+		switch (counter.mode.t4_5Prescale)
 		{
-			case 0x0000:
-				counter.rate = 1;
-				break;
-			case 0x2000:
+			case 0x1:
 				counter.rate = 8;
 				break;
-			case 0x4000:
+			case 0x2:
 				counter.rate = 16;
 				break;
-			case 0x6000:
+			case 0x3:
 				counter.rate = 256;
+				break;
+			default:
+				counter.rate = 1;
 				break;
 		}
 	}
 
 	// Current counter *always* resets on mode write.
 	counter.count = 0;
-	counter.sCycleT = psxRegs.cycle;
+	counter.startCycle = psxRegs.cycle & ~(counter.rate - 1);
 	counter.target &= 0xffffffff;
 	_rcntSet(index);
 }
@@ -738,24 +721,7 @@ void psxRcntWtarget16(int index, u32 value)
 	PSXCNT_LOG("IOP Counter[%d] writeTarget16 = %lx", index, value);
 	psxCounters[index].target = value & 0xffff;
 
-	if (!(psxCounters[index].mode & IOPCNT_INT_TOGGLE))
-	{
-		// Pulse mode reset
-		psxCounters[index].mode |= IOPCNT_INT_REQ; // Interrupt flag reset to high
-	}
-
-	if (psxRcntCanCount(index) &&
-		(psxCounters[index].rate != PSXHBLANK))
-	{
-		// Re-adjust the sCycleT to match where the counter is currently
-		// (remainder of the rate divided into the time passed will do the trick)
-
-		const u32 change = (psxRegs.cycle - psxCounters[index].sCycleT) / psxCounters[index].rate;
-		psxCounters[index].count += change;
-		psxCounters[index].sCycleT += change * psxCounters[index].rate;
-	}
-	else
-		psxCounters[index].sCycleT = psxRegs.cycle;
+	psxRcntSync(index);
 
 	// protect the target from an early arrival.
 	// if the target is behind the current count, then set the target overflow
@@ -770,28 +736,11 @@ void psxRcntWtarget16(int index, u32 value)
 void psxRcntWtarget32(int index, u32 value)
 {
 	pxAssert(index >= 3 && index < 6);
-	PSXCNT_LOG("IOP Counter[%d] writeTarget32 = %lx mode %x", index, value, psxCounters[index].mode);
+	PSXCNT_LOG("IOP Counter[%d] writeTarget32 = %lx mode %x", index, value, psxCounters[index].mode.modeval);
 
 	psxCounters[index].target = value;
 
-	if (!(psxCounters[index].mode & IOPCNT_INT_TOGGLE))
-	{
-		// Pulse mode reset
-		psxCounters[index].mode |= IOPCNT_INT_REQ; // Interrupt flag reset to high
-	}
-
-	if (psxRcntCanCount(index) &&
-		(psxCounters[index].rate != PSXHBLANK))
-	{
-		// Re-adjust the sCycleT to match where the counter is currently
-		// (remainder of the rate divided into the time passed will do the trick)
-
-		const u32 change = (psxRegs.cycle - psxCounters[index].sCycleT) / psxCounters[index].rate;
-		psxCounters[index].count += change;
-		psxCounters[index].sCycleT += change * psxCounters[index].rate;
-	}
-	else
-		psxCounters[index].sCycleT = psxRegs.cycle;
+	psxRcntSync(index);
 	// protect the target from an early arrival.
 	// if the target is behind the current count, then set the target overflow
 	// flag, so that the target won't be active until after the next overflow.
@@ -804,46 +753,40 @@ void psxRcntWtarget32(int index, u32 value)
 
 u16 psxRcntRcount16(int index)
 {
-	u32 retval = (u32)psxCounters[index].count;
+	psxRcntSync(index);
+	const u32 retval = (u32)psxCounters[index].count;
 
 	pxAssert(index < 3);
 
 	PSXCNT_LOG("IOP Counter[%d] readCount16 = %lx", index, (u16)retval);
-
-	// Don't count HBLANK timers
-	// Don't count stopped gates either.
-	const bool canCount = psxRcntCanCount(index);
-	if ((psxCounters[index].rate != PSXHBLANK) && canCount)
-	{
-		u32 delta = (u32)((psxRegs.cycle - psxCounters[index].sCycleT) / psxCounters[index].rate);
-		retval += delta;
-		PSXCNT_LOG("              (delta = %lx)", delta);
-	}
-	else if (!canCount && (psxCounters[index].mode & IOPCNT_ENABLE_GATE) && (psxCounters[index].mode & IOPCNT_MODE_GATE) == 4)
-		retval = 0;
 
 	return (u16)retval;
 }
 
 u32 psxRcntRcount32(int index)
 {
-	u32 retval = (u32)psxCounters[index].count;
+	psxRcntSync(index);
+	
+	const u32 retval = (u32)psxCounters[index].count;
 
 	pxAssert(index >= 3 && index < 6);
 
 	PSXCNT_LOG("IOP Counter[%d] readCount32 = %lx", index, retval);
 
-	const bool canCount = psxRcntCanCount(index);
-	if ((psxCounters[index].rate != PSXHBLANK) && canCount)
-	{
-		u32 delta = (u32)((psxRegs.cycle - psxCounters[index].sCycleT) / psxCounters[index].rate);
-		retval += delta;
-		PSXCNT_LOG("               (delta = %lx)", delta);
-	}
-	else if (!canCount && (psxCounters[index].mode & IOPCNT_ENABLE_GATE) && (psxCounters[index].mode & IOPCNT_MODE_GATE) == 4)
-		retval = 0;
-
 	return retval;
+}
+
+void psxRcntSetNewIntrMode(int index)
+{
+	psxCounters[index].mode.targetFlag = false;
+	psxCounters[index].mode.overflowFlag = false;
+	psxCounters[index].mode.intrEnable = true;
+
+	if (psxCounters[index].mode.repeatIntr != psxCounters[index].currentIrqMode.repeatInterrupt || psxCounters[index].mode.toggleIntr != psxCounters[index].currentIrqMode.toggleInterrupt)
+		DevCon.Warning("Updating psxCounter[%d] mode old repeat %d new %d old toggle %d new %d", index, psxCounters[index].mode.repeatIntr, psxCounters[index].currentIrqMode.repeatInterrupt, psxCounters[index].mode.toggleIntr, psxCounters[index].currentIrqMode.toggleInterrupt);
+	
+	psxCounters[index].currentIrqMode.repeatInterrupt = psxCounters[index].mode.repeatIntr;
+	psxCounters[index].currentIrqMode.toggleInterrupt = psxCounters[index].mode.toggleIntr;
 }
 
 bool SaveStateBase::psxRcntFreeze()
@@ -852,8 +795,8 @@ bool SaveStateBase::psxRcntFreeze()
 		return false;
 
 	Freeze(psxCounters);
-	Freeze(psxNextCounter);
-	Freeze(psxNextsCounter);
+	Freeze(psxNextDeltaCounter);
+	Freeze(psxNextStartCounter);
 	Freeze(hBlanking);
 	Freeze(vBlanking);
 

--- a/pcsx2/IopCounters.h
+++ b/pcsx2/IopCounters.h
@@ -5,12 +5,44 @@
 
 #include "common/Pcsx2Defs.h"
 
+struct CounterIRQBehaviour
+{
+	bool repeatInterrupt;
+	bool toggleInterrupt;
+};
+
+union psxCounterMode
+{
+	struct
+	{
+		u32 gateEnable : 1;
+		u32 gateMode : 2;
+		u32 zeroReturn : 1;
+		u32 targetIntr : 1;
+		u32 overflIntr : 1;
+		u32 repeatIntr : 1;
+		u32 toggleIntr : 1;
+		u32 extSignal : 1;
+		u32 t2Prescale : 1;
+		u32 intrEnable : 1;
+		u32 targetFlag : 1;
+		u32 overflowFlag : 1;
+		u32 t4_5Prescale : 2;
+		u32 stopped : 1;
+	};
+
+	u32 modeval;
+};
+
 struct psxCounter {
 	u64 count, target;
-    u32 mode;
+	
 	u32 rate, interrupt;
-	u32 sCycleT;
-	s32 CycleT;
+	u32 startCycle;
+	s32 deltaCycles;
+
+	psxCounterMode mode;
+	CounterIRQBehaviour currentIrqMode;
 };
 
 #define NUM_COUNTERS 8
@@ -25,6 +57,7 @@ extern void psxRcntWmode16(int index, u32 value);
 extern void psxRcntWmode32(int index, u32 value);
 extern void psxRcntWtarget16(int index, u32 value);
 extern void psxRcntWtarget32(int index, u32 value);
+extern void psxRcntSetNewIntrMode(int index);
 extern u16  psxRcntRcount16(int index);
 extern u32  psxRcntRcount32(int index);
 extern u64  psxRcntCycles(int index);

--- a/pcsx2/IopDma.cpp
+++ b/pcsx2/IopDma.cpp
@@ -32,20 +32,20 @@ static void psxDmaGeneric(u32 madr, u32 bcr, u32 chcr, u32 spuCore)
 	// Update the spu2 to the current cycle before initiating the DMA
 
 	SPU2async();
-	//Console.Status("cycles sent to SPU2 %x\n", psxRegs.cycle - psxCounters[6].sCycleT);
+	//Console.Status("cycles sent to SPU2 %x\n", psxRegs.cycle - psxCounters[6].startCycle);
 
-	psxCounters[6].sCycleT = psxRegs.cycle;
-	psxCounters[6].CycleT = size * 4;
+	psxCounters[6].startCycle = psxRegs.cycle;
+	psxCounters[6].deltaCycles = size * 4;
 
-	psxNextCounter -= (psxRegs.cycle - psxNextsCounter);
-	psxNextsCounter = psxRegs.cycle;
-	if (psxCounters[6].CycleT < psxNextCounter)
-		psxNextCounter = psxCounters[6].CycleT;
+	psxNextDeltaCounter -= (psxRegs.cycle - psxNextStartCounter);
+	psxNextStartCounter = psxRegs.cycle;
+	if (psxCounters[6].deltaCycles < psxNextDeltaCounter)
+		psxNextDeltaCounter = psxCounters[6].deltaCycles;
 
-	if ((psxRegs.iopNextEventCycle - psxNextsCounter) > (u32)psxNextCounter)
+	if ((psxRegs.iopNextEventCycle - psxNextStartCounter) > (u32)psxNextDeltaCounter)
 	{
-		//DevCon.Warning("SPU2async Setting new counter branch, old %x new %x ((%x - %x = %x) > %x delta)", g_iopNextEventCycle, psxNextsCounter + psxNextCounter, g_iopNextEventCycle, psxNextsCounter, (g_iopNextEventCycle - psxNextsCounter), psxNextCounter);
-		psxRegs.iopNextEventCycle = psxNextsCounter + psxNextCounter;
+		//DevCon.Warning("SPU2async Setting new counter branch, old %x new %x ((%x - %x = %x) > %x delta)", g_iopNextEventCycle, psxNextStartCounter + psxNextCounter, g_iopNextEventCycle, psxNextStartCounter, (g_iopNextEventCycle - psxNextStartCounter), psxNextCounter);
+		psxRegs.iopNextEventCycle = psxNextStartCounter + psxNextDeltaCounter;
 	}
 
 	switch (chcr)

--- a/pcsx2/R3000A.cpp
+++ b/pcsx2/R3000A.cpp
@@ -207,7 +207,7 @@ __ri void iopEventTest()
 {
 	psxRegs.iopNextEventCycle = psxRegs.cycle + iopWaitCycles;
 
-	if (psxTestCycle(psxNextsCounter, psxNextCounter))
+	if (psxTestCycle(psxNextStartCounter, psxNextDeltaCounter))
 	{
 		psxRcntUpdate();
 		iopEventAction = true;
@@ -216,8 +216,8 @@ __ri void iopEventTest()
 	{
 		// start the next branch at the next counter event by default
 		// the interrupt code below will assign nearer branches if needed.
-		if (psxNextCounter < static_cast<s32>(psxRegs.iopNextEventCycle - psxNextsCounter))
-			psxRegs.iopNextEventCycle = psxNextsCounter + psxNextCounter;
+		if (psxNextDeltaCounter < static_cast<s32>(psxRegs.iopNextEventCycle - psxNextStartCounter))
+			psxRegs.iopNextEventCycle = psxNextStartCounter + psxNextDeltaCounter;
 	}
 
 	if (psxRegs.interrupt)

--- a/pcsx2/R3000A.h
+++ b/pcsx2/R3000A.h
@@ -168,8 +168,8 @@ extern u32 EEoCycle;
 
 #endif
 
-extern s32 psxNextCounter;
-extern u32 psxNextsCounter;
+extern s32 psxNextDeltaCounter;
+extern u32 psxNextStartCounter;
 extern bool iopEventAction;
 extern bool iopEventTestIsActive;
 

--- a/pcsx2/R5900.cpp
+++ b/pcsx2/R5900.cpp
@@ -398,7 +398,7 @@ __fi void _cpuEventTest_Shared()
 
 	iopEventTest();
 
-	if (cpuTestCycle(nextsCounter, nextCounter))
+	if (cpuTestCycle(nextStartCounter, nextDeltaCounter))
 	{
 		rcntUpdate();
 		_cpuTestPERF();
@@ -450,7 +450,7 @@ __fi void _cpuEventTest_Shared()
 	}
 
 	// Apply vsync and other counter nextCycles
-	cpuSetNextEvent(nextsCounter, nextCounter);
+	cpuSetNextEvent(nextStartCounter, nextDeltaCounter);
 
 	eeEventTestIsActive = false;
 }

--- a/pcsx2/SPU2/Dma.cpp
+++ b/pcsx2/SPU2/Dma.cpp
@@ -345,15 +345,15 @@ void V_Core::FinishDMAwrite()
 
 	DMAICounter = (DMAICounter - ReadSize) * 4;
 
-	if (((psxCounters[6].sCycleT + psxCounters[6].CycleT) - psxRegs.cycle) > (u32)DMAICounter)
+	if (((psxCounters[6].startCycle + psxCounters[6].deltaCycles) - psxRegs.cycle) > (u32)DMAICounter)
 	{
-		psxCounters[6].sCycleT = psxRegs.cycle;
-		psxCounters[6].CycleT = DMAICounter;
+		psxCounters[6].startCycle = psxRegs.cycle;
+		psxCounters[6].deltaCycles = DMAICounter;
 
-		psxNextCounter -= (psxRegs.cycle - psxNextsCounter);
-		psxNextsCounter = psxRegs.cycle;
-		if (psxCounters[6].CycleT < psxNextCounter)
-			psxNextCounter = psxCounters[6].CycleT;
+		psxNextDeltaCounter -= (psxRegs.cycle - psxNextStartCounter);
+		psxNextStartCounter = psxRegs.cycle;
+		if (psxCounters[6].deltaCycles < psxNextDeltaCounter)
+			psxNextDeltaCounter = psxCounters[6].deltaCycles;
 	}
 
 	ActiveTSA = TDA;
@@ -439,15 +439,15 @@ void V_Core::FinishDMAread()
 	else
 		DMAICounter = 4;
 
-	if (((psxCounters[6].sCycleT + psxCounters[6].CycleT) - psxRegs.cycle) > (u32)DMAICounter)
+	if (((psxCounters[6].startCycle + psxCounters[6].deltaCycles) - psxRegs.cycle) > (u32)DMAICounter)
 	{
-		psxCounters[6].sCycleT = psxRegs.cycle;
-		psxCounters[6].CycleT = DMAICounter;
+		psxCounters[6].startCycle = psxRegs.cycle;
+		psxCounters[6].deltaCycles = DMAICounter;
 
-		psxNextCounter -= (psxRegs.cycle - psxNextsCounter);
-		psxNextsCounter = psxRegs.cycle;
-		if (psxCounters[6].CycleT < psxNextCounter)
-			psxNextCounter = psxCounters[6].CycleT;
+		psxNextDeltaCounter -= (psxRegs.cycle - psxNextStartCounter);
+		psxNextStartCounter = psxRegs.cycle;
+		if (psxCounters[6].deltaCycles < psxNextDeltaCounter)
+			psxNextDeltaCounter = psxCounters[6].deltaCycles;
 	}
 
 	ActiveTSA = TDA;
@@ -470,15 +470,15 @@ void V_Core::DoDMAread(u16* pMem, u32 size)
 	//Regs.ATTR |= 0x30;
 	TADR = MADR + (size << 1);
 
-	if (((psxCounters[6].sCycleT + psxCounters[6].CycleT) - psxRegs.cycle) > (u32)DMAICounter)
+	if (((psxCounters[6].startCycle + psxCounters[6].deltaCycles) - psxRegs.cycle) > (u32)DMAICounter)
 	{
-		psxCounters[6].sCycleT = psxRegs.cycle;
-		psxCounters[6].CycleT = DMAICounter;
+		psxCounters[6].startCycle = psxRegs.cycle;
+		psxCounters[6].deltaCycles = DMAICounter;
 
-		psxNextCounter -= (psxRegs.cycle - psxNextsCounter);
-		psxNextsCounter = psxRegs.cycle;
-		if (psxCounters[6].CycleT < psxNextCounter)
-			psxNextCounter = psxCounters[6].CycleT;
+		psxNextDeltaCounter -= (psxRegs.cycle - psxNextStartCounter);
+		psxNextStartCounter = psxRegs.cycle;
+		if (psxCounters[6].deltaCycles < psxNextDeltaCounter)
+			psxNextDeltaCounter = psxCounters[6].deltaCycles;
 	}
 
 	if (SPU2::MsgDMA())

--- a/pcsx2/SPU2/spu2sys.cpp
+++ b/pcsx2/SPU2/spu2sys.cpp
@@ -349,15 +349,15 @@ __forceinline void TimeUpdate(u32 cClocks)
 		}
 		else
 		{
-			if (((psxCounters[6].sCycleT + psxCounters[6].CycleT) - psxRegs.cycle) > (u32)Cores[0].DMAICounter)
+			if (((psxCounters[6].startCycle + psxCounters[6].deltaCycles) - psxRegs.cycle) > (u32)Cores[0].DMAICounter)
 			{
-				psxCounters[6].sCycleT = psxRegs.cycle;
-				psxCounters[6].CycleT = Cores[0].DMAICounter;
+				psxCounters[6].startCycle = psxRegs.cycle;
+				psxCounters[6].deltaCycles = Cores[0].DMAICounter;
 
-				psxNextCounter -= (psxRegs.cycle - psxNextsCounter);
-				psxNextsCounter = psxRegs.cycle;
-				if (psxCounters[6].CycleT < psxNextCounter)
-					psxNextCounter = psxCounters[6].CycleT;
+				psxNextDeltaCounter -= (psxRegs.cycle - psxNextStartCounter);
+				psxNextStartCounter = psxRegs.cycle;
+				if (psxCounters[6].deltaCycles < psxNextDeltaCounter)
+					psxNextDeltaCounter = psxCounters[6].deltaCycles;
 			}
 		}
 	}
@@ -402,15 +402,15 @@ __forceinline void TimeUpdate(u32 cClocks)
 		}
 		else
 		{
-			if (((psxCounters[6].sCycleT + psxCounters[6].CycleT) - psxRegs.cycle) > (u32)Cores[1].DMAICounter)
+			if (((psxCounters[6].startCycle + psxCounters[6].deltaCycles) - psxRegs.cycle) > (u32)Cores[1].DMAICounter)
 			{
-				psxCounters[6].sCycleT = psxRegs.cycle;
-				psxCounters[6].CycleT = Cores[1].DMAICounter;
+				psxCounters[6].startCycle = psxRegs.cycle;
+				psxCounters[6].deltaCycles = Cores[1].DMAICounter;
 
-				psxNextCounter -= (psxRegs.cycle - psxNextsCounter);
-				psxNextsCounter = psxRegs.cycle;
-				if (psxCounters[6].CycleT < psxNextCounter)
-					psxNextCounter = psxCounters[6].CycleT;
+				psxNextDeltaCounter -= (psxRegs.cycle - psxNextStartCounter);
+				psxNextStartCounter = psxRegs.cycle;
+				if (psxCounters[6].deltaCycles < psxNextDeltaCounter)
+					psxNextDeltaCounter = psxCounters[6].deltaCycles;
 			}
 		}
 	}

--- a/pcsx2/SaveState.cpp
+++ b/pcsx2/SaveState.cpp
@@ -192,10 +192,10 @@ bool SaveStateBase::FreezeInternals(Error* error)
 
 	Freeze(EEsCycle);
 	Freeze(EEoCycle);
-	Freeze(nextCounter);
-	Freeze(nextsCounter);
-	Freeze(psxNextsCounter);
-	Freeze(psxNextCounter);
+	Freeze(nextDeltaCounter);
+	Freeze(nextStartCounter);
+	Freeze(psxNextStartCounter);
+	Freeze(psxNextDeltaCounter);
 
 	// Fourth Block - EE-related systems
 	// ---------------------------------

--- a/pcsx2/SaveState.h
+++ b/pcsx2/SaveState.h
@@ -25,7 +25,7 @@ enum class FreezeAction
 // [SAVEVERSION+]
 // This informs the auto updater that the users savestates will be invalidated.
 
-static const u32 g_SaveVersion = (0x9A4D << 16) | 0x0000;
+static const u32 g_SaveVersion = (0x9A4E << 16) | 0x0000;
 
 
 // the freezing data between submodules and core

--- a/pcsx2/ps2/Iop/IopHwRead.cpp
+++ b/pcsx2/ps2/Iop/IopHwRead.cpp
@@ -161,13 +161,9 @@ static __fi T _HwRead_16or32_Page1( u32 addr )
 			break;
 
 			case 0x4:
-				ret = psxCounters[cntidx].mode;
+				ret = psxCounters[cntidx].mode.modeval;
 
-				// hmm!  The old code only did this bitwise math for 16 bit reads.
-				// Logic indicates it should do the math consistently.  Question is,
-				// should it do the logic for both 16 and 32, or not do logic at all?
-
-				psxCounters[cntidx].mode &= ~0x1800;
+				psxRcntSetNewIntrMode(cntidx);
 			break;
 
 			case 0x8:
@@ -197,13 +193,10 @@ static __fi T _HwRead_16or32_Page1( u32 addr )
 			break;
 
 			case 0x4:
-				ret = psxCounters[cntidx].mode;
+				ret = psxCounters[cntidx].mode.modeval;
 				PSXCNT_LOG("IOP Counter[%d] modeRead%d = %lx", cntidx, sizeof(T) * 8, ret);
-				// hmm!  The old code only did the following bitwise math for 16 bit reads.
-				// Logic indicates it should do the math consistently.  Question is,
-				// should it do the logic for both 16 and 32, or not do logic at all?
 
-				psxCounters[cntidx].mode &= ~0x1800;
+				psxRcntSetNewIntrMode(cntidx);
 			break;
 
 			case 0x8:


### PR DESCRIPTION
### Description of Changes
Refactor timers a bit to be a little less gross and more readable, also fix a couple of bugs.

### Rationale behind Changes
There was a bunch of repeated code and legacy naming which wasn't obvious to what it was, which I wanted to sort out.
Also fixed the slight inaccuracy of counting time for framerates which weren't whole numbers.
Correct start cycles so they are on clock tick boundaries.
Disable sending V/H sync interrupts etc when SINT (this is the PCRTC initialization mode)  is enabled, nothing happens during this sequence on a PS2.

### Suggested Testing Steps
Test a whole bunch of things, make sure everything is fine.
Unfortunately I don't think anything is fixed :(
Double unfortunate this required a savestate bump.
