### PR TITLE
GS/Vulkan: Always issue first barrier on RDNA3

### DIFF
--- a/pcsx2/GS/Renderers/Common/GSDevice.h
+++ b/pcsx2/GS/Renderers/Common/GSDevice.h
@@ -387,7 +387,7 @@ struct alignas(16) GSHWDrawConfig
 		__fi bool IsFeedbackLoop() const
 		{
 			const u32 sw_blend_bits = blend_a | blend_b | blend_d;
-			const bool sw_blend_needs_rt = sw_blend_bits != 0 && ((sw_blend_bits | blend_c) & 1u);
+			const bool sw_blend_needs_rt = (sw_blend_bits != 0 && ((sw_blend_bits | blend_c) & 1u)) || ((a_masked & blend_c) != 0);
 			return tex_is_fb || fbmask || (date > 0 && date != 3) || sw_blend_needs_rt;
 		}
 
@@ -688,7 +688,9 @@ struct alignas(16) GSHWDrawConfig
 	struct AlphaPass
 	{
 		alignas(8) PSSelector ps;
-		bool enable;
+		bool enable : 1;
+		bool require_one_barrier : 1;
+		bool require_full_barrier : 1;
 		ColorMaskSelector colormask;
 		DepthStencilSelector depth;
 		float ps_aref;

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -5910,11 +5910,10 @@ __ri void GSRendererHW::DrawPrims(GSTextureCache::Target* rt, GSTextureCache::Ta
 
 	SetupIA(rtscale, sx, sy);
 
-	m_conf.alpha_second_pass.enable = ate_second_pass;
-
 	if (ate_second_pass)
 	{
 		pxAssert(!env.PABE.PABE);
+
 		std::memcpy(&m_conf.alpha_second_pass.ps, &m_conf.ps, sizeof(m_conf.ps));
 		std::memcpy(&m_conf.alpha_second_pass.colormask, &m_conf.colormask, sizeof(m_conf.colormask));
 		std::memcpy(&m_conf.alpha_second_pass.depth, &m_conf.depth, sizeof(m_conf.depth));
@@ -5958,6 +5957,8 @@ __ri void GSRendererHW::DrawPrims(GSTextureCache::Target* rt, GSTextureCache::Ta
 			r = g = b = a = false;
 		}
 
+		m_conf.alpha_second_pass.enable = true;
+
 		if (z || r || g || b || a)
 		{
 			m_conf.alpha_second_pass.depth.zwe = z;
@@ -5966,7 +5967,14 @@ __ri void GSRendererHW::DrawPrims(GSTextureCache::Target* rt, GSTextureCache::Ta
 			m_conf.alpha_second_pass.colormask.wb = b;
 			m_conf.alpha_second_pass.colormask.wa = a;
 			if (m_conf.alpha_second_pass.colormask.wrgba == 0)
+			{
 				m_conf.alpha_second_pass.ps.DisableColorOutput();
+			}
+			if (m_conf.alpha_second_pass.ps.IsFeedbackLoop())
+			{
+				m_conf.alpha_second_pass.require_one_barrier = m_conf.require_one_barrier;
+				m_conf.alpha_second_pass.require_full_barrier = m_conf.require_full_barrier;
+			}
 		}
 		else
 		{

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h
@@ -68,6 +68,9 @@ public:
 	/// Returns true if running on an NVIDIA GPU.
 	__fi bool IsDeviceNVIDIA() const { return (m_device_properties.vendorID == 0x10DE); }
 
+	/// Returns true if running on an AMD GPU.
+	__fi bool IsDeviceAMD() const { return (m_device_properties.vendorID == 0x1002); }
+
 	// Creates a simple render pass.
 	VkRenderPass GetRenderPass(VkFormat color_format, VkFormat depth_format,
 		VkAttachmentLoadOp color_load_op = VK_ATTACHMENT_LOAD_OP_LOAD,

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h
@@ -588,7 +588,8 @@ public:
 	void UpdateHWPipelineSelector(GSHWDrawConfig& config, PipelineSelector& pipe);
 	void UploadHWDrawVerticesAndIndices(const GSHWDrawConfig& config);
 	VkImageMemoryBarrier GetColorBufferBarrier(GSTextureVK* rt) const;
-	void SendHWDraw(const GSHWDrawConfig& config, GSTextureVK* draw_rt, bool skip_first_barrier);
+	void SendHWDraw(const GSHWDrawConfig& config, GSTextureVK* draw_rt,
+		bool one_barrier, bool full_barrier, bool skip_first_barrier);
 
 	//////////////////////////////////////////////////////////////////////////
 	// Vulkan State


### PR DESCRIPTION
### Description of Changes

So I bought a 7900GRE to debug this issue and...

It turns out *not* doing this causes GPU resets on RDNA3, specifically Windows drivers. Despite the layout changing enforcing the execution dependency between previous draws and the first input attachment read, it still wants the region/fragment-local barrier...

### Rationale behind Changes

(Hopefully) Fixes the RDNA3 crashes.
Fixes #10720.

### Suggested Testing Steps

Smoke test Vulkan renderer.
See if RDNA3 no longer crashes.
