### PR TITLE
GS: Misc fixes

### DIFF
--- a/pcsx2/GS/GS.h
+++ b/pcsx2/GS/GS.h
@@ -57,7 +57,8 @@ s16 GSLookupBeforeDrawFunctionId(const std::string_view& name);
 s16 GSLookupMoveHandlerFunctionId(const std::string_view& name);
 
 bool GSopen(const Pcsx2Config::GSOptions& config, GSRendererType renderer, u8* basemem);
-bool GSreopen(bool recreate_device, GSRendererType new_renderer, std::optional<const Pcsx2Config::GSOptions*> old_config);
+bool GSreopen(bool recreate_device, bool recreate_renderer, GSRendererType new_renderer,
+	std::optional<const Pcsx2Config::GSOptions*> old_config);
 void GSreset(bool hardware_reset);
 void GSclose();
 void GSgifSoftReset(u32 mask);

--- a/pcsx2/GS/Renderers/Common/GSDevice.cpp
+++ b/pcsx2/GS/Renderers/Common/GSDevice.cpp
@@ -396,6 +396,11 @@ bool GSDevice::UpdateImGuiFontTexture()
 	return true;
 }
 
+void GSDevice::TextureRecycleDeleter::operator()(GSTexture* const tex)
+{
+	g_gs_device->Recycle(tex);
+}
+
 GSTexture* GSDevice::FetchSurface(GSTexture::Type type, int width, int height, int levels, GSTexture::Format format, bool clear, bool prefer_unused_texture)
 {
 	const GSVector2i size(width, height);

--- a/pcsx2/GS/Renderers/Common/GSDevice.h
+++ b/pcsx2/GS/Renderers/Common/GSDevice.h
@@ -763,6 +763,12 @@ public:
 		GSHWDrawConfig::ColorMaskSelector wmask; // 0xf for all channels by default
 	};
 
+	struct TextureRecycleDeleter
+	{
+		void operator()(GSTexture* const tex);
+	};
+	using RecycledTexture = std::unique_ptr<GSTexture, TextureRecycleDeleter>;
+
 	enum BlendFactor : u8
 	{
 		// HW blend factors

--- a/pcsx2/GS/Renderers/Common/GSRenderer.cpp
+++ b/pcsx2/GS/Renderers/Common/GSRenderer.cpp
@@ -75,11 +75,6 @@ void GSRenderer::Destroy()
 	GSCapture::EndCapture();
 }
 
-void GSRenderer::PurgePool()
-{
-	g_gs_device->PurgePool();
-}
-
 void GSRenderer::UpdateRenderFixes()
 {
 }
@@ -518,7 +513,7 @@ bool GSRenderer::BeginPresentFrame(bool frame_skip)
 
 	// Device lost, something went really bad.
 	// Let's just toss out everything, and try to hobble on.
-	if (!GSreopen(true, GSGetCurrentRenderer(), std::nullopt))
+	if (!GSreopen(true, false, GSGetCurrentRenderer(), std::nullopt))
 	{
 		pxFailRel("Failed to recreate GS device after loss.");
 		return false;

--- a/pcsx2/GS/Renderers/Common/GSRenderer.h
+++ b/pcsx2/GS/Renderers/Common/GSRenderer.h
@@ -44,8 +44,6 @@ public:
 
 	virtual void UpdateRenderFixes();
 
-	void PurgePool();
-
 	virtual void VSync(u32 field, bool registers_written, bool idle_frame);
 	virtual bool CanUpscale() { return false; }
 	virtual float GetUpscaleMultiplier() { return 1.0f; }

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.h
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.h
@@ -92,10 +92,10 @@ private:
 	void CleanupDraw(bool invalidate_temp_src);
 
 	void EmulateTextureSampler(const GSTextureCache::Target* rt, const GSTextureCache::Target* ds,
-		GSTextureCache::Source* tex, const TextureMinMaxResult& tmm, GSTexture*& src_copy);
+		GSTextureCache::Source* tex, const TextureMinMaxResult& tmm, GSDevice::RecycledTexture& src_copy);
 	void HandleTextureHazards(const GSTextureCache::Target* rt, const GSTextureCache::Target* ds,
 		const GSTextureCache::Source* tex, const TextureMinMaxResult& tmm, GSTextureCache::SourceRegion& source_region,
-		bool& target_region, GSVector2i& unscaled_size, float& scale, GSTexture*& src_copy);
+		bool& target_region, GSVector2i& unscaled_size, float& scale, GSDevice::RecycledTexture& src_copy);
 	bool CanUseTexIsFB(const GSTextureCache::Target* rt, const GSTextureCache::Source* tex,
 		const TextureMinMaxResult& tmm);
 


### PR DESCRIPTION
### Description of Changes

**GS: Fix use-after-free on lost device**
 - Stops PCSX2 accessing freed memory on device loss. I mean, we're probably going to flop anyway since it's just going to crash the GPU again, but use-after-frees are bad.

**GS/HW: Fix invalid self copy from move in DX renderers**
 - Spec violation in DirectX.

**GS/HW: Fix possible texture leak on skipped draw**
 - Temp targets don't get cleaned up. Also very unlikely, but avoids a `goto` here.

### Rationale behind Changes

Correctness

### Suggested Testing Steps

Smoke test because who cares about directx anyway