### PR TITLE
USB: Add d-pad controls to RBDrumKitDevice

### DIFF
--- a/pcsx2/USB/usb-pad/usb-pad.cpp
+++ b/pcsx2/USB/usb-pad/usb-pad.cpp
@@ -937,6 +937,10 @@ namespace usb_pad
 			{"Orange", TRANSLATE_NOOP("USB", "Orange"), nullptr, InputBindingInfo::Type::Button, CID_BUTTON4, GenericInputBinding::Cross},
 			{"Select", TRANSLATE_NOOP("USB", "Select"), nullptr, InputBindingInfo::Type::Button, CID_BUTTON8, GenericInputBinding::Select},
 			{"Start", TRANSLATE_NOOP("USB", "Start"), nullptr, InputBindingInfo::Type::Button, CID_BUTTON9, GenericInputBinding::Start},
+			{"D-Pad Up", TRANSLATE_NOOP("USB", "D-Pad Up"), nullptr, InputBindingInfo::Type::Button, CID_DPAD_UP, GenericInputBinding::DPadUp},
+			{"D-Pad Right", TRANSLATE_NOOP("USB", "D-Pad Right"), nullptr, InputBindingInfo::Type::Button, CID_DPAD_RIGHT, GenericInputBinding::DPadRight},
+			{"D-Pad Down", TRANSLATE_NOOP("USB", "D-Pad Down"), nullptr, InputBindingInfo::Type::Button, CID_DPAD_DOWN, GenericInputBinding::DPadDown},
+			{"D-Pad Left", TRANSLATE_NOOP("USB", "D-Pad Left"), nullptr, InputBindingInfo::Type::Button, CID_DPAD_LEFT, GenericInputBinding::DPadLeft},
 		};
 
 		return bindings;


### PR DESCRIPTION
### Description of Changes
This change adds four d-pad directions to the `RBDrumKitDevice` USB pad, which bind to the `CID_DPAD` directions. This automatically is exposed in the Qt UI, and input can then be provided to games that support this controller.

### Rationale behind Changes
The Rock Band drum kit currently has bindings only for the four pads, the kick pedal (which is named Orange), and the Start and Select buttons. The kit however contains additional buttons, and of note for this PR, the d-pad.
![image](https://github.com/PCSX2/pcsx2/assets/425646/50e18371-a176-4fbd-b5e7-e181d19a1d91)

Rock Band supports menu navigation with the d-pad as well as also using the yellow and blue pads. Guitar Hero, however, does not support menu navigation any other way, which means games such as Guitar Hero World Tour cannot be played fully.

Adding these d-pad controls allows players to operate the menus using the required inputs.

### Suggested Testing Steps
With this change, the Rock Band Drum Kit in the USB controllers now contains four additional binds for the d-pad controls.
![image](https://github.com/PCSX2/pcsx2/assets/425646/589cf3e3-800a-4a18-9d07-919476aca78f)

After binding, two games that can be tested are Rock Band [SLUS-21682] and Guitar Hero World Tour [SLUS-21781]. Both games can move up and down in all menus using the d-pad up and down respectively. The Recording Studio mode in Guitar Hero World Tour also contains menu options that use left and right (which begins a recording and stops the cursor respectively, you can visually see the buttons being pressed in that screen).
![image](https://github.com/PCSX2/pcsx2/assets/425646/2cf02acf-a9b7-479e-b57c-f4af28fa54a1)
