### PR TITLE
Misc: Always enable full mipmap with ps2 trilinear by default

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -153,8 +153,6 @@ PAPX-90020:
     mergeSprite: 1 # Fixes most vertical lines and lighting misalignment.
     autoFlush: 1 # Fixes light bloom intensity.
     estimateTextureRegion: 1 # Improves performance and reduces hash cache size.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_GiTS"
 PAPX-90201:
   name: ファンタビジョン 体験版
@@ -171,8 +169,6 @@ PAPX-90203:
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 PAPX-90204:
   name: "TVDJ"
@@ -181,8 +177,6 @@ PAPX-90205:
   name: "Dark Cloud"
   region: "NTSC-J"
   gsHWFixes:
-    mipmap: 2 # Fixes mipmapping.
-    trilinearFiltering: 1 # Smoothes out mipmapping.
     halfPixelOffset: 2 # Distance is less blurry, game has reduced LOD so it will still look blurry.
 PAPX-90206:
   name: "Blood - The Last Vampire"
@@ -192,24 +186,18 @@ PAPX-90207:
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 PAPX-90208:
   name: "Gran Turismo 3 - A-Spec - Replay Theater"
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 PAPX-90209:
   name: "Gran Turismo 3 - A-Spec - Netz Toyota - Replay Theater Disc"
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 PAPX-90210:
   name: "Yappa RPG desho."
@@ -244,8 +232,6 @@ PAPX-90222:
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves reflection quality.
-    mipmap: 2 # Fixes broken textures.
-    trilinearFiltering: 1 # Fixes water textures.
     cpuSpriteRenderBW: 4 # Fixes character and water textures.
     cpuSpriteRenderLevel: 2 # Needed for above.
     autoFlush: 2 # Fixes gate warp effect and emissive texture effects.
@@ -256,8 +242,6 @@ PAPX-90223:
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves reflection quality.
-    mipmap: 2 # Fixes broken textures.
-    trilinearFiltering: 1 # Fixes water textures.
     cpuSpriteRenderBW: 4 # Fixes character and water textures.
     cpuSpriteRenderLevel: 2 # Needed for above.
     autoFlush: 2 # Fixes gate warp effect and emissive texture effects.
@@ -283,8 +267,6 @@ PAPX-90230:
   region: "NTSC-J"
   gsHWFixes:
     textureInsideRT: 1 # Fixes on screen garbage.
-    mipmap: 2 # Mipmap + trilinear, corrects the depth of field effect.
-    trilinearFiltering: 1
 PAPX-90231:
   name: 怪盗 スライ・クーパー 体験版
   name-sort: かいとう すらいくーぱー たいけんばん
@@ -326,14 +308,10 @@ PAPX-90330:
     - SoftwareRendererFMVHack # Fixes interlacing.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves shine on surfaces and lights.
-    mipmap: 2 # Fixes miptrick texture effects.
-    trilinearFiltering: 1 # Fixes miptrick blending.
 PAPX-90501:
   name: "Dark Cloud"
   region: "NTSC-J"
   gsHWFixes:
-    mipmap: 2 # Fixes mipmapping.
-    trilinearFiltering: 1 # Smoothes out mipmapping.
     halfPixelOffset: 2 # Distance is less blurry, game has reduced LOD so it will still look blurry.
 PAPX-90502:
   name: "THE 山手線 〜Train Simulator Real 体験版"
@@ -350,8 +328,6 @@ PAPX-90504:
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 PAPX-90505:
@@ -370,16 +346,11 @@ PAPX-90506:
 PAPX-90507:
   name: "Official Disc 2003"
   region: "NTSC-J"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 PAPX-90508:
   name: "Gran Turismo 4 - Lupo Cup Training Version"
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 PAPX-90511:
@@ -396,8 +367,6 @@ PAPX-90512:
     vuClampMode: 2 # Text in GT mode works.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 PAPX-90514:
@@ -410,8 +379,6 @@ PAPX-90516:
   name: "Jak and Daxter II [Trial]"
   region: "NTSC-J"
   gsHWFixes:
-    mipmap: 2 # Fixes broken textures.
-    trilinearFiltering: 1 # Fixes water textures.
     cpuSpriteRenderBW: 4 # Fixes character and water textures.
     cpuSpriteRenderLevel: 2 # Needed for above.
     autoFlush: 2 # Fixes lighting.
@@ -439,8 +406,6 @@ PAPX-90523:
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 PAPX-90524:
@@ -572,16 +537,12 @@ PBPX-95502:
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 PBPX-95503:
   name: "Gran Turismo 3 - A-Spec [PS2 Bundle]"
   region: "NTSC-U"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
   memcardFilters:
     - "PBPX-95503"
@@ -618,9 +579,6 @@ PBPX-95516:
     - EETimingHack # Fixes SPR errors while going in-game.
   roundModes:
     eeRoundMode: 0 # Fixes Hydrodisplacer behaviour.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 PBPX-95517:
   name: "Network Adapter Start-Up Disc"
   region: "NTSC-U"
@@ -638,8 +596,6 @@ PBPX-95523:
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
   # vuClampMode = 2  Text in GT mode works.
@@ -649,8 +605,6 @@ PBPX-95524:
   compat: 5
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
   # vuClampMode = 2  Text in GT mode works.
@@ -665,8 +619,6 @@ PBPX-95601:
     vuClampMode: 2 # Text in GT mode works.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
   memcardFilters:
@@ -717,16 +669,12 @@ PCPX-96311:
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 PCPX-96312:
   name: "Gran Turismo 3 - A-Spec - Autobacs Tentou Shiyuu Disc"
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 PCPX-96314:
   name: "The Sky Odyssey"
@@ -759,8 +707,6 @@ PCPX-96320:
     instantVU1: 0 # Fixes noodles.
     mtvu: 0
   gsHWFixes:
-    mipmap: 2 # Fixes missing floor texture.
-    trilinearFiltering: 1 # Fixes fog effect.
     wildArmsHack: 1 # Fixes misaligment depth of field effect.
 PCPX-96321:
   name: "SkyGunner [Trial]"
@@ -793,8 +739,6 @@ PCPX-96330:
   region: "NTSC-J"
   gsHWFixes:
     textureInsideRT: 1 # Fixes on screen garbage.
-    mipmap: 2 # Mipmap + trilinear, corrects the depth of field effect.
-    trilinearFiltering: 1
 PCPX-96554:
   name: "Games of Our Style - Tokyo Game Show 2003 Disc"
   region: "NTSC-J"
@@ -802,8 +746,6 @@ PCPX-96603:
   name: "Dark Cloud"
   region: "NTSC-J"
   gsHWFixes:
-    mipmap: 2 # Fixes mipmapping.
-    trilinearFiltering: 1 # Smoothes out mipmapping.
     halfPixelOffset: 2 # Distance is less blurry, game has reduced LOD so it will still look blurry.
 PCPX-96605:
   name: "MiruMiru 2000-nen 12-gatsudo Juchuugou"
@@ -870,8 +812,6 @@ PCPX-96624:
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 PCPX-96625:
   name: "プレプレ2 VOLUME.4"
@@ -915,8 +855,6 @@ PCPX-96634:
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 PCPX-96635:
@@ -953,8 +891,6 @@ PCPX-96649:
     vuClampMode: 2 # Text in GT mode works.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 PCPX-96653:
@@ -963,8 +899,6 @@ PCPX-96653:
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     disablePartialInvalidation: 1 # Prevents the situation that a level (Aquatos) doesn't render characters and geometry.
     halfPixelOffset: 2 # Fixes misaligned bloom.
     autoFlush: 2 # Helps fix misaligned bloom.
@@ -985,8 +919,6 @@ PCPX-96657:
     - SoftwareRendererFMVHack # Fixes interlacing.
   gsHWFixes:
     preloadFrameData: 1 # Fixes black background in the pause menu.
-    mipmap: 2 # Fixes miptrick texture effects.
-    trilinearFiltering: 1 # Fixes miptrick blending.
     halfPixelOffset: 2 # Fixes misaligned blur.
     autoFlush: 2 # Fixes corruption in cutscenes and brightens the image.
 PCPX-96660:
@@ -1002,8 +934,6 @@ PCPX-98017:
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     halfPixelOffset: 2 # Fixes misaligned bloom.
     autoFlush: 2 # Helps fix misaligned bloom.
 PCPX-98041:
@@ -1014,9 +944,6 @@ PCPX-98042:
   region: "NTSC-J"
   roundModes:
     vu1RoundMode: 1 # Fixes the display of scores and text ingame.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves court textures to match sw renderer.
-    trilinearFiltering: 1
 PDPX-99109:
   name: "DVD Player Version 3.04"
   name-sort: "DVDぷれーやー Version 3.04"
@@ -1039,9 +966,6 @@ SCAJ-10003:
 SCAJ-10004:
   name: "Time Crisis 2 [PlayStation 2 the Best]"
   region: "NTSC-Unk"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SCAJ-10006:
   name: "Taiko no Tatsujin - Appare Sandaime"
   region: "NTSC-Unk"
@@ -1092,9 +1016,6 @@ SCAJ-20001:
   region: "NTSC-Unk"
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SCAJ-20002:
   name: "Gallop Racer 6 - Revolution"
   region: "NTSC-Unk"
@@ -1132,8 +1053,6 @@ SCAJ-20008:
   gsHWFixes:
     preloadFrameData: 1 # Fixes fog and make lights on cars work again.
     autoFlush: 2 # Fixes sun luminosity and penetration of objects.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
   gameFixes:
     - EETimingHack # Fixes random graphical corruption.
 SCAJ-20009:
@@ -1167,8 +1086,6 @@ SCAJ-20013:
   region: "NTSC-Unk"
   gsHWFixes:
     roundSprite: 2 # Fixes lines at the edges of the HUD.
-    mipmap: 2 # Mipmap + trilinear, improves road and grass textures to match sw renderer.
-    trilinearFiltering: 1
 SCAJ-20014:
   name: "Time Splitter"
   region: "NTSC-Unk"
@@ -1177,9 +1094,6 @@ SCAJ-20015:
   region: "NTSC-J"
   roundModes:
     eeRoundMode: 0 # Ladder glitch in "Assembly of Nihilo B11" level.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, fixes missing lights to match sw renderer.
-    trilinearFiltering: 1
 SCAJ-20016:
   name: "Warrior of Argus"
   region: "NTSC-C-E"
@@ -1196,8 +1110,6 @@ SCAJ-20019:
   region: "NTSC-J"
   gsHWFixes:
     textureInsideRT: 1 # Fixes on screen garbage.
-    mipmap: 2 # Mipmap + trilinear, corrects the depth of field effect.
-    trilinearFiltering: 1
 SCAJ-20020:
   name: "Drag-on Dragoon"
   region: "NTSC-C-J"
@@ -1282,8 +1194,6 @@ SCAJ-20038:
   region: "NTSC-Unk"
   gsHWFixes:
     textureInsideRT: 1 # Fixes on screen garbage.
-    mipmap: 2 # Mipmap + trilinear, corrects the depth of field effect.
-    trilinearFiltering: 1
 SCAJ-20039:
   name: "Sidewinder V"
   region: "NTSC-Unk"
@@ -1304,8 +1214,6 @@ SCAJ-20044:
   region: "NTSC-Unk"
   gsHWFixes:
     autoFlush: 2 # Fixes lava effect.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SCAJ-20045:
   name: "Shadow Tower Abyss"
   region: "NTSC-Unk"
@@ -1335,8 +1243,6 @@ SCAJ-20052:
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     autoFlush: 2
   memcardFilters:
     - "SCAJ-20052"
@@ -1361,9 +1267,6 @@ SCAJ-20058:
 SCAJ-20059:
   name: "Minna no Golf 4"
   region: "NTSC-Unk"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SCAJ-20060:
   name: "Time Crisis 3"
   region: "NTSC-Unk"
@@ -1392,8 +1295,6 @@ SCAJ-20066:
   compat: 5
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
   memcardFilters:
@@ -1423,9 +1324,6 @@ SCAJ-20068:
 SCAJ-20069:
   name: "Gallop Racer - Lucky 7"
   region: "NTSC-Unk"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SCAJ-20070:
   name: "Star Ocean 3 [Director's Cut]"
   region: "NTSC-Unk"
@@ -1446,15 +1344,11 @@ SCAJ-20072:
     mergeSprite: 1 # Fixes most vertical lines and lighting misalignment.
     autoFlush: 1 # Fixes light bloom intensity.
     estimateTextureRegion: 1 # Improves performance and reduces hash cache size.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_GiTS"
 SCAJ-20073:
   name: "Jak and Daxter II"
   region: "NTSC-Unk"
   gsHWFixes:
-    mipmap: 2 # Fixes broken textures.
-    trilinearFiltering: 1 # Fixes water textures.
     cpuSpriteRenderBW: 4 # Fixes character and water textures.
     cpuSpriteRenderLevel: 2 # Needed for above.
     autoFlush: 2 # Fixes lighting.
@@ -1471,8 +1365,6 @@ SCAJ-20076:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
     recommendedBlendingLevel: 3 # Fixes level brightness.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
   memcardFilters:
     - "SCAJ-20076"
     - "SCAJ-20077"
@@ -1486,8 +1378,6 @@ SCAJ-20077:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
     recommendedBlendingLevel: 3 # Fixes level brightness.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
   memcardFilters:
     - "SCAJ-20076"
     - "SCAJ-20077"
@@ -1529,8 +1419,6 @@ SCAJ-20083:
   region: "NTSC-Unk"
   gsHWFixes:
     autoFlush: 2 # Fixes speed effect intensity.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SCAJ-20084:
   name: "MLB '04"
   region: "NTSC-Unk"
@@ -1571,9 +1459,6 @@ SCAJ-20088:
 SCAJ-20089:
   name: "Athens 2004"
   region: "NTSC-J"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SCAJ-20090:
   name: "Gacha Mecha Stadium - Saru Battle"
   region: "NTSC-Unk"
@@ -1585,15 +1470,9 @@ SCAJ-20092:
 SCAJ-20093:
   name: "Tenchu Kurenai"
   region: "NTSC-Unk"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SCAJ-20094:
   name: "Minna no Golf 4 [PlayStation 2 the Best]"
   region: "NTSC-Unk"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SCAJ-20095:
   name: "Digital Devil Saga - Avatar Tuner"
   region: "NTSC-Unk"
@@ -1622,9 +1501,6 @@ SCAJ-20099:
 SCAJ-20100:
   name: "Tenchu Kurenai"
   region: "NTSC-C-J"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SCAJ-20101:
   name: "EyeToy - Saru"
   region: "NTSC-Unk"
@@ -1641,8 +1517,6 @@ SCAJ-20104:
     - SoftwareRendererFMVHack # Fixes FMVs disabling hash cache.
   gsHWFixes:
     recommendedBlendingLevel: 2 # Helps banding when dithering is enabled.
-    mipmap: 2 # Fixes terrain rendering.
-    trilinearFiltering: 1
     halfPixelOffset: 3 # Fixes ghosting in foggy maps.
     roundSprite: 1 # Fixes font and HUD artifacts.
     alignSprite: 1 # Fixes vertical lines.
@@ -1653,8 +1527,6 @@ SCAJ-20105:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
     recommendedBlendingLevel: 3 # Fixes level brightness.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
     cpuSpriteRenderBW: 2 # Fixes broken water on "Upper Sea" level.
     cpuSpriteRenderLevel: 2 # Needed for above.
 SCAJ-20107:
@@ -1663,9 +1535,6 @@ SCAJ-20107:
 SCAJ-20108:
   name: "Arc the Lad - Generation"
   region: "NTSC-Unk"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, corrects the depth of field effect.
-    trilinearFiltering: 1
 SCAJ-20109:
   name: "Ratchet & Clank 3 - Up your Arsenal"
   region: "NTSC-Unk"
@@ -1673,8 +1542,6 @@ SCAJ-20109:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves color and luminosity of surfaces.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     disablePartialInvalidation: 1 # Prevents the situation that a level (Aquatos) doesn't render characters and geometry.
     halfPixelOffset: 2 # Fixes misaligned bloom.
     autoFlush: 2 # Helps fix misaligned bloom.
@@ -1698,8 +1565,6 @@ SCAJ-20111:
     - XGKickHack # Fixes bad Geometry.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SCAJ-20112:
   name: "Tales of Rebirth"
   region: "NTSC-Unk"
@@ -1719,8 +1584,6 @@ SCAJ-20116:
   region: "NTSC-C-J"
   gsHWFixes:
     alignSprite: 1 # Fixes FMV lines.
-    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
-    trilinearFiltering: 1
     cpuSpriteRenderBW: 2 # Prevents Death By VRAM explosion.
     cpuSpriteRenderLevel: 2 # Needed for above.
     getSkipCount: "GSC_DeathByDegreesTekkenNinaWilliams"
@@ -1763,8 +1626,6 @@ SCAJ-20121:
     halfPixelOffset: 1 # Fixes misaligned blur.
     cpuSpriteRenderBW: 1 # Fixes broken shadow caused by HPO 1.
     cpuSpriteRenderLevel: 2 # Needed for above.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SCAJ-20122:
   name: "Swords of Destiny"
   region: "NTSC-Unk"
@@ -1798,8 +1659,6 @@ SCAJ-20125:
   gsHWFixes:
     alignSprite: 1
     halfPixelOffset: 4 # Align post.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_Tekken5"
 SCAJ-20126:
   name: "Tekken 5"
@@ -1809,8 +1668,6 @@ SCAJ-20126:
   gsHWFixes:
     alignSprite: 1
     halfPixelOffset: 4 # Align post.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_Tekken5"
 SCAJ-20127:
   name: "EyeToy - Play 2 [with Camera]"
@@ -1869,8 +1726,6 @@ SCAJ-20136:
     - SoftwareRendererFMVHack # Fixes FMVs disabling hash cache.
   gsHWFixes:
     recommendedBlendingLevel: 2 # Helps banding when dithering is enabled.
-    mipmap: 2 # Fixes terrain rendering.
-    trilinearFiltering: 1
     halfPixelOffset: 3 # Fixes ghosting in foggy maps.
     roundSprite: 1 # Fixes font and HUD artifacts.
     alignSprite: 1 # Fixes vertical lines.
@@ -1887,8 +1742,6 @@ SCAJ-20138:
     - SoftwareRendererFMVHack # Fixes interlacing.
   gsHWFixes:
     preloadFrameData: 1 # Fixes black background in the pause menu.
-    mipmap: 2 # Fixes miptrick texture effects.
-    trilinearFiltering: 1 # Fixes miptrick blending.
     halfPixelOffset: 2 # Fixes misaligned blur.
     autoFlush: 2 # Fixes corruption in cutscenes and brightens the image.
 SCAJ-20139:
@@ -1908,16 +1761,12 @@ SCAJ-20143:
   gsHWFixes:
     halfPixelOffset: 2 # Corrects shadow alignment and reduces blurriness.
     recommendedBlendingLevel: 3 # Fixes level and map menu brightness.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
     preloadFrameData: 1 # Fixes glowing emblems.
 SCAJ-20144:
   name: "Zhuo Hou La 3"
   region: "NTSC-C"
   gsHWFixes:
     preloadFrameData: 1 # Fixes black background in the pause menu.
-    mipmap: 2 # Fixes miptrick texture effects.
-    trilinearFiltering: 1 # Fixes miptrick blending.
     halfPixelOffset: 2 # Fixes misaligned blur.
     autoFlush: 2 # Fixes corruption in cutscenes and brightens the image.
 SCAJ-20145:
@@ -1965,8 +1814,6 @@ SCAJ-20152:
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
     textureInsideRT: 1 # Fixes corruption.
-    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_UrbanReign"
 SCAJ-20153:
   name: "Code Age Commanders"
@@ -1988,8 +1835,6 @@ SCAJ-20157:
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     disablePartialInvalidation: 1 # Prevents world geometry and some models from vanishing when pausing or opening vendor.
     halfPixelOffset: 2 # Fixes misaligned bloom.
     autoFlush: 2 # Helps fix misaligned bloom.
@@ -2071,8 +1916,6 @@ SCAJ-20169:
   region: "NTSC-Unk"
   gsHWFixes:
     autoFlush: 1 # Fixes lighting.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SCAJ-20170:
   name: "Tourist Trophy"
   region: "NTSC-C"
@@ -2096,8 +1939,6 @@ SCAJ-20173:
     - SoftwareRendererFMVHack # Fixes FMVs disabling hash cache.
   gsHWFixes:
     recommendedBlendingLevel: 2 # Helps banding when dithering is enabled.
-    mipmap: 2 # Fixes terrain rendering.
-    trilinearFiltering: 1
     halfPixelOffset: 3 # Fixes ghosting in foggy maps.
     roundSprite: 1 # Fixes HUD artifacts.
     alignSprite: 1 # Fixes vertical lines.
@@ -2142,8 +1983,6 @@ SCAJ-20179:
     halfPixelOffset: 2 # Fixes lighting misalignment and reduces ground shadows (probably texture cache issue).
     roundSprite: 2 # Fixes font artifacts.
     textureInsideRT: 1 # Fixes bad crystal surfaces.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SCAJ-20180:
   name: "Xenosaga Episode III - Also Sprach Zarathustra [Disc 2 of 2]"
   region: "NTSC-Unk"
@@ -2152,16 +1991,11 @@ SCAJ-20180:
     halfPixelOffset: 2 # Fixes lighting misalignment and reduces ground shadows (probably texture cache issue).
     roundSprite: 2 # Fixes font artifacts.
     textureInsideRT: 1 # Fixes bad crystal surfaces.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SCAJ-20181:
   name: "Minna no Tennis"
   region: "NTSC-Unk"
   roundModes:
     vu1RoundMode: 1 # Fixes the display of scores and text ingame.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves court textures to match sw renderer.
-    trilinearFiltering: 1
 SCAJ-20182:
   name: "Tales of Destiny"
   region: "NTSC-Unk"
@@ -2193,8 +2027,6 @@ SCAJ-20190:
     halfPixelOffset: 2 # Fixes misaligned bloom.
     roundSprite: 1 # Fixes chromatic effect.
     autoFlush: 1 # Fixes sun occlusion.
-    mipmap: 2 # Mipmap + trilinear, fixes miptrick textures to match sw renderer.
-    trilinearFiltering: 1
 SCAJ-20191:
   name: "Super Robot Taisen OG - Original Generations Gaiden [Limited Edition]"
   region: "NTSC-Unk"
@@ -2209,9 +2041,6 @@ SCAJ-20193:
 SCAJ-20194:
   name: "Minna no Golf 4 [PlayStation 2 the Best]"
   region: "NTSC-Unk"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SCAJ-20195:
   name: "Ape Escape 3 [PlayStation 2 the Best]"
   region: "NTSC-C"
@@ -2219,8 +2048,6 @@ SCAJ-20195:
     - SoftwareRendererFMVHack # Fixes interlacing.
   gsHWFixes:
     preloadFrameData: 1 # Fixes black background in the pause menu.
-    mipmap: 2 # Fixes miptrick texture effects.
-    trilinearFiltering: 1 # Fixes miptrick blending.
     halfPixelOffset: 2 # Fixes misaligned blur.
     autoFlush: 2 # Fixes corruption in cutscenes and brightens the image.
 SCAJ-20196:
@@ -2255,9 +2082,6 @@ SCAJ-20198:
   region: "NTSC-Unk"
   roundModes:
     vu1RoundMode: 1 # Fixes the display of scores and text ingame.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves court textures to match sw renderer.
-    trilinearFiltering: 1
 SCAJ-20199:
   name: "Tekken 5 [PlayStation 2 the Best]"
   region: "NTSC-Unk"
@@ -2266,8 +2090,6 @@ SCAJ-20199:
   gsHWFixes:
     alignSprite: 1
     halfPixelOffset: 4 # Align post.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_Tekken5"
 SCAJ-25002:
   name: "Shinobi"
@@ -2291,8 +2113,6 @@ SCAJ-25026:
   name: "Kunoichi Shinobi"
   region: "NTSC-Unk"
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_Kunoichi"
 SCAJ-25034:
   name: "Sakura Taisen Monogatari"
@@ -2313,8 +2133,6 @@ SCAJ-25047:
   region: "NTSC-Unk"
   gsHWFixes:
     minimumBlendingLevel: 2 # Fixes dark font to more bright like software mode.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SCAJ-30001:
   name: "Xenosaga - Episode I - Der Wille zur Macht [PlayStation 2 the Best]"
   region: "NTSC-Unk"
@@ -2352,8 +2170,6 @@ SCAJ-30006:
     eeDivRoundMode: 3 # See above.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
   memcardFilters:
@@ -2376,8 +2192,6 @@ SCAJ-30007:
     eeDivRoundMode: 3 # See above.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 SCAJ-30008:
@@ -2388,8 +2202,6 @@ SCAJ-30008:
     eeDivRoundMode: 3 # See above.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
   memcardFilters:
@@ -2420,8 +2232,6 @@ SCAJ-30011:
     halfPixelOffset: 2 # Fixes misaligned bloom.
     roundSprite: 1 # Fixes chromatic effect.
     autoFlush: 1 # Fixes sun occlusion.
-    mipmap: 2 # Mipmap + trilinear, fixes miptrick textures to match sw renderer.
-    trilinearFiltering: 1
 SCCS-40001:
   name: 捉猴啦 2
   name-sort: "Zhuo Hou La 2"
@@ -2431,8 +2241,6 @@ SCCS-40001:
     - SoftwareRendererFMVHack # Fixes interlacing.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves shine on surfaces and lights.
-    mipmap: 2 # Fixes miptrick texture effects.
-    trilinearFiltering: 1 # Fixes miptrick blending.
 SCCS-40002:
   name: 恶魔猎人2 (Disc 1)
   name-sort: "'Emo Lieren 2 Disc 1"
@@ -2473,8 +2281,6 @@ SCCS-40007:
   region: "NTSC-C"
   gsHWFixes:
     textureInsideRT: 1 # Fixes on screen garbage.
-    mipmap: 2 # Mipmap + trilinear, corrects the depth of field effect.
-    trilinearFiltering: 1
 SCCS-40009:
   name: 龙珠二世
   name-sort: "Longzhu Ershi"
@@ -2547,8 +2353,6 @@ SCCS-60002:
   region: "NTSC-C"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 SCED-50041:
@@ -2684,8 +2488,6 @@ SCED-50614:
   name: "Jak and Daxter - The Precursor Legacy [Demo]"
   region: "PAL-M6"
   gsHWFixes:
-    mipmap: 2 # Fixes broken textures.
-    trilinearFiltering: 1 # Fixes water textures.
     cpuSpriteRenderBW: 4 # Fixes character and water textures.
     cpuSpriteRenderLevel: 2 # Needed for above.
 SCED-50615:
@@ -2786,8 +2588,6 @@ SCED-50768:
   region: "PAL-E"
   gsHWFixes:
     PCRTCOffsets: 1 # Fixes viewport shaking.
-    mipmap: 2 # Mipmap + trilinear, improves building textures and reduces pop in.
-    trilinearFiltering: 1
 SCED-50780:
   name: "Official PlayStation 2 Magazine Germany Special Edition 1"
   region: "PAL-G"
@@ -2798,8 +2598,6 @@ SCED-50781:
     vu1RoundMode: 0 # Fixes tyre textures.
   gsHWFixes:
     halfPixelOffset: 2 # Corrects shadow position.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SCED-50783:
   name: "Official PlayStation 2 Magazine-UK Greatest Hits Volume 6 - Special Edition - Awards 2002"
   region: "PAL-M5"
@@ -2845,9 +2643,6 @@ SCED-50916:
   region: "PAL-M5"
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SCED-50932:
   name: "Smash Court Tennis - Pro Tournament [Demo]"
   region: "PAL-M5"
@@ -2870,9 +2665,6 @@ SCED-51075:
     - EETimingHack # Fixes SPR errors while going in-game.
   roundModes:
     eeRoundMode: 0 # Fixes Hydrodisplacer behaviour.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SCED-51111:
   name: "Magazine Ufficiale PlayStation 2 Demo Italia 08-02"
   region: "PAL-M5"
@@ -2956,15 +2748,11 @@ SCED-51351:
     textureInsideRT: 1
     texturePreloading: 1 # Performs much better with partial preload.
     halfPixelOffset: 2 # Fixes outlines around characters.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SCED-51352:
   name: "Gran Turismo - Nissan Micra Edition [Demo]"
   region: "PAL-E"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 SCED-51359:
@@ -2977,8 +2765,6 @@ SCED-51366:
     - SoftwareRendererFMVHack # Fixes interlacing.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves shine on surfaces and lights.
-    mipmap: 2 # Fixes miptrick texture effects.
-    trilinearFiltering: 1 # Fixes miptrick blending.
 SCED-51375:
   name: "Germany Special Issue 3"
   region: "PAL-G"
@@ -3210,8 +2996,6 @@ SCED-51669:
   region: "PAL-E"
   gsHWFixes:
     roundSprite: 2 # Fixes lines at the edges of the HUD.
-    mipmap: 2 # Mipmap + trilinear, improves road and grass textures to match sw renderer.
-    trilinearFiltering: 1
 SCED-51677:
   name: "My Street"
   region: "PAL-M5"
@@ -3231,8 +3015,6 @@ SCED-51700:
   name: "Jak II - Renegade [Demo]"
   region: "PAL-M5"
   gsHWFixes:
-    mipmap: 2 # Fixes broken textures.
-    trilinearFiltering: 1 # Fixes water textures.
     cpuSpriteRenderBW: 4 # Fixes character and water textures.
     cpuSpriteRenderLevel: 2 # Needed for above.
     autoFlush: 2 # Fixes lighting.
@@ -3268,9 +3050,6 @@ SCED-51922:
   region: "PAL-M6"
   clampModes:
     vu1ClampMode: 3 # Fixes sporadic white triangle SPS.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
-    trilinearFiltering: 1
 SCED-51935:
   name: "Official PlayStation 2 Magazine Demo 38" # German
   region: "PAL-E-G"
@@ -3304,8 +3083,6 @@ SCED-52049:
   gsHWFixes:
     roundSprite: 1 # Fix lines in the sky.
     halfPixelOffset: 2 # Fixes double image.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SCED-52051:
   name: "Official PlayStation 2 Magazine Demo 43"
   region: "PAL-M5"
@@ -3373,8 +3150,6 @@ SCED-52098:
     vu1RoundMode: 0 # Fixes tire textures.
   gsHWFixes:
     halfPixelOffset: 2 # Corrects shadow position.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SCED-52119:
   name: "Official PlayStation 2 Magazine Germany Special Edition 01/2004"
   region: "PAL-G"
@@ -3529,8 +3304,6 @@ SCED-52455:
   region: "PAL-E"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
   # vuClampMode = 2  Text in GT mode works.
@@ -3540,9 +3313,6 @@ SCED-52461:
 SCED-52491:
   name: "Athens 2004"
   region: "PAL-M6"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SCED-52497:
   name: "This Is Football 2004"
   region: "PAL-M4"
@@ -3554,8 +3324,6 @@ SCED-52578:
   region: "PAL-M5"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 SCED-52580:
@@ -3572,8 +3340,6 @@ SCED-52681:
   region: "PAL-M11"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 SCED-52687:
@@ -3623,17 +3389,12 @@ SCED-52847:
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     disablePartialInvalidation: 1 # Prevents the situation that a level (Aquatos) doesn't render characters and geometry.
     halfPixelOffset: 2 # Fixes misaligned bloom.
     autoFlush: 2 # Helps fix misaligned bloom.
 SCED-52848:
   name: "Ratchet & Clank 3 + Sly 2 - Band of Thieves"
   region: "PAL-M5"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SCED-52855:
   name: "Magazine Ufficiale PlayStation 2 Italia 09/04"
   region: "PAL-I"
@@ -3726,16 +3487,12 @@ SCED-52946:
   gsHWFixes:
     textureInsideRT: 1
     halfPixelOffset: 2 # Fixes outlines on screen edges.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SCED-52952:
   name: "Jak 3 [Demo]"
   region: "PAL-M5"
   gameFixes:
     - InstantDMAHack # Fixes holes in face geometry.
   gsHWFixes:
-    mipmap: 2 # Fixes broken textures.
-    trilinearFiltering: 1 # Fixes water textures.
     cpuSpriteRenderBW: 4 # Fixes character and water textures.
     cpuSpriteRenderLevel: 2 # Needed for above.
     autoFlush: 2 # Fixes lighting.
@@ -3785,8 +3542,6 @@ SCED-53081:
     - SoftwareRendererFMVHack # Fixes FMVs disabling hash cache.
   gsHWFixes:
     recommendedBlendingLevel: 2 # Helps banding when dithering is enabled.
-    mipmap: 2 # Fixes terrain rendering.
-    trilinearFiltering: 1
     halfPixelOffset: 3 # Fixes ghosting in foggy maps.
     roundSprite: 1 # Fixes font and HUD artifacts.
     alignSprite: 1 # Fixes vertical lines.
@@ -3798,8 +3553,6 @@ SCED-53115:
     - SoftwareRendererFMVHack # Fixes FMVs disabling hash cache.
   gsHWFixes:
     recommendedBlendingLevel: 2 # Helps banding when dithering is enabled.
-    mipmap: 2 # Fixes terrain rendering.
-    trilinearFiltering: 1
     halfPixelOffset: 3 # Fixes ghosting in foggy maps.
     roundSprite: 1 # Fixes font and HUD artifacts.
     alignSprite: 1 # Fixes vertical lines.
@@ -3955,15 +3708,9 @@ SCED-53431:
 SCED-53447:
   name: "Formula One 05 [Press Kit Demo]"
   region: "PAL-E"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SCED-53448:
   name: "Formula One 05 [Demo]"
   region: "PAL-E"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SCED-53513:
   name: "Bonus Demo 10"
   region: "PAL-M5"
@@ -3987,8 +3734,6 @@ SCED-53538:
   gsHWFixes:
     alignSprite: 1
     halfPixelOffset: 4 # Align post.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_Tekken5"
 SCED-53611:
   name: "Official PlayStation 2 Magazine - German Kids Special"
@@ -4004,8 +3749,6 @@ SCED-53622:
   gsHWFixes:
     autoFlush: 1 # Fixes pause menu backgrounds.
     roundSprite: 1 # Corrects proportions of fonts and pause-screen lines, adjusts display closer to software.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SCED-53660:
   name: "Jak X & Ratchet Gladiator [Demo]"
   region: "PAL"
@@ -4082,8 +3825,6 @@ SCED-53962:
   name: "Shadow of the Colossus [Demo]"
   region: "PAL-M5"
   gsHWFixes:
-    mipmap: 2 # Fixes Water with Trilinear.
-    trilinearFiltering: 1 # Fixes Water with Mipmap (Full).
     halfPixelOffset: 1 # Fixes misalignments and borders on side.
 SCED-53978:
   name: "Official PlayStation 2 Magazine Demo 69"
@@ -4330,8 +4071,6 @@ SCED-54680:
     halfPixelOffset: 2 # Fixes misaligned bloom.
     roundSprite: 1 # Fixes chromatic effect.
     autoFlush: 1 # Fixes sun occlusion.
-    mipmap: 2 # Mipmap + trilinear, fixes miptrick textures to match sw renderer.
-    trilinearFiltering: 1
 SCED-54682:
   name: "UPS2 Speciale Platinum 2007"
   region: "PAL-M5"
@@ -4421,8 +4160,6 @@ SCES-50005:
   compat: 5
   gsHWFixes:
     PCRTCOffsets: 1 # Fixes viewport shaking.
-    mipmap: 2 # Mipmap + trilinear, improves building textures and reduces pop in.
-    trilinearFiltering: 1
 SCES-50006:
   name: "Drakan - The Ancients' Gates"
   region: "PAL-M5"
@@ -4434,9 +4171,6 @@ SCES-50034:
   name: "MotoGP"
   region: "PAL-M5"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves road and tree textures to match sw renderer.
-    trilinearFiltering: 1
 SCES-50105:
   name: "Sky Odyssey"
   region: "PAL-M5"
@@ -4473,33 +4207,23 @@ SCES-50246:
 SCES-50293:
   name: "ATV Offroad - All Terrain Vehicle"
   region: "PAL-M5"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SCES-50294:
   name: "Gran Turismo 3 - A-Spec"
   region: "PAL-M5"
   compat: 5
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
-    mipmap: 2 # Mipmap + trilinear, improves track textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 SCES-50295:
   name: "Dark Cloud"
   region: "PAL-M5"
   compat: 5
   gsHWFixes:
-    mipmap: 2 # Fixes mipmapping.
-    trilinearFiltering: 1 # Smoothes out mipmapping.
     halfPixelOffset: 2 # Distance is less blurry, game has reduced LOD so it will still look blurry.
 SCES-50300:
   name: "Time Crisis 2"
   region: "PAL-M5"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SCES-50354:
   name: "Klonoa 2 - Lunatea's Veil"
   region: "PAL-M5"
@@ -4516,8 +4240,6 @@ SCES-50360:
   region: "PAL-M5"
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes menu text brightness.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
     halfPixelOffset: 4 # Fixes misaligned blur during Darkside special.
 SCES-50361:
   name: "Jak and Daxter - The Precursor Legacy"
@@ -4525,8 +4247,6 @@ SCES-50361:
   compat: 5
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves reflection quality.
-    mipmap: 2 # Fixes broken textures.
-    trilinearFiltering: 1 # Fixes water textures.
     cpuSpriteRenderBW: 4 # Fixes character and water textures.
     cpuSpriteRenderLevel: 2 # Needed for above.
     autoFlush: 2 # Fixes gate warp effect and emissive texture effects.
@@ -4538,8 +4258,6 @@ SCES-50408:
     instantVU1: 0 # Fixes noodles.
     mtvu: 0
   gsHWFixes:
-    mipmap: 2 # Fixes missing floor texture.
-    trilinearFiltering: 1 # Fixes fog effect.
     wildArmsHack: 1 # Fixes misaligment depth of field effect.
 SCES-50409:
   name: "MotoGP 2"
@@ -4552,8 +4270,6 @@ SCES-50410:
     - SoftwareRendererFMVHack # Fixes FMVs disabling hash cache.
   gsHWFixes:
     recommendedBlendingLevel: 2 # Helps banding when dithering is enabled.
-    mipmap: 2 # Fixes terrain rendering and edge of screen issues in 16:9 mode.
-    trilinearFiltering: 1
     roundSprite: 1 # Fixes font and HUD artifacts.
     alignSprite: 1 # Fixes vertical lines.
     mergeSprite: 1 # Fixes vertical lines.
@@ -4707,8 +4423,6 @@ SCES-50614:
   region: "PAL-Unk"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves reflection quality.
-    mipmap: 2 # Fixes broken textures.
-    trilinearFiltering: 1 # Fixes water textures.
     cpuSpriteRenderBW: 4 # Fixes character and water textures.
     cpuSpriteRenderLevel: 2 # Needed for above.
     autoFlush: 2 # Fixes gate warp effect and emissive texture effects.
@@ -4735,8 +4449,6 @@ SCES-50781:
     vu1RoundMode: 0 # Fixes tyre textures.
   gsHWFixes:
     halfPixelOffset: 2 # Corrects shadow position.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SCES-50791:
   name: "Frequency"
   region: "PAL-M5"
@@ -4766,8 +4478,6 @@ SCES-50885:
     - SoftwareRendererFMVHack # Fixes interlacing.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves shine on surfaces and lights.
-    mipmap: 2 # Fixes miptrick texture effects.
-    trilinearFiltering: 1 # Fixes miptrick blending.
   patches:
     "09B3AD4D":
       content: |-
@@ -4801,9 +4511,6 @@ SCES-50916:
   compat: 5
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SCES-50917:
   name: "Sly Raccoon"
   region: "PAL-M5"
@@ -4875,8 +4582,6 @@ SCES-50982:
   compat: 5
   gsHWFixes:
     roundSprite: 2 # Fixes lines at the edges of the HUD.
-    mipmap: 2 # Mipmap + trilinear, improves road and grass textures to match sw renderer.
-    trilinearFiltering: 1
 SCES-50987:
   name: "Resident Evil - Outbreak"
   region: "PAL-Unk"
@@ -4904,8 +4609,6 @@ SCES-51102:
     - SoftwareRendererFMVHack # Fixes interlacing.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves shine on surfaces and lights.
-    mipmap: 2 # Fixes miptrick texture effects.
-    trilinearFiltering: 1 # Fixes miptrick blending.
 SCES-51103:
   name: "Ape Escape 2"
   region: "PAL-I"
@@ -4913,8 +4616,6 @@ SCES-51103:
     - SoftwareRendererFMVHack # Fixes interlacing.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves shine on surfaces and lights.
-    mipmap: 2 # Fixes miptrick texture effects.
-    trilinearFiltering: 1 # Fixes miptrick blending.
 SCES-51104:
   name: "Ape Escape 2"
   region: "PAL-G"
@@ -4922,8 +4623,6 @@ SCES-51104:
     - SoftwareRendererFMVHack # Fixes interlacing.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves shine on surfaces and lights.
-    mipmap: 2 # Fixes miptrick texture effects.
-    trilinearFiltering: 1 # Fixes miptrick blending.
 SCES-51105:
   name: "Ape Escape 2"
   region: "PAL-S"
@@ -4931,8 +4630,6 @@ SCES-51105:
     - SoftwareRendererFMVHack # Fixes interlacing.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves shine on surfaces and lights.
-    mipmap: 2 # Fixes miptrick texture effects.
-    trilinearFiltering: 1 # Fixes miptrick blending.
 SCES-51135:
   name: "Primal"
   region: "PAL-M5"
@@ -4951,8 +4648,6 @@ SCES-51159:
     textureInsideRT: 1
     texturePreloading: 1 # Performs much better with partial preload.
     halfPixelOffset: 2 # Fixes outlines around characters.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SCES-51164:
   name: "The Mark of Kri"
   name-sort: "Mark of Kri, The"
@@ -4987,9 +4682,6 @@ SCES-51190:
 SCES-51224:
   name: "War of the Monsters"
   region: "PAL-M5"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
-    trilinearFiltering: 1
 SCES-51248:
   name: "Dog's Life"
   region: "PAL-M11"
@@ -4998,8 +4690,6 @@ SCES-51248:
   gsHWFixes:
     roundSprite: 1 # Fix lines in the sky.
     halfPixelOffset: 2 # Fixes double image.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SCES-51407:
   name: "Exclusive PlayStation 2 Summer Sample Disc"
   region: "PAL-A"
@@ -5011,8 +4701,6 @@ SCES-51426:
     textureInsideRT: 1
     texturePreloading: 1 # Performs much better with partial preload.
     halfPixelOffset: 2 # Fixes outlines around characters.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SCES-51428:
   name: "Shinobi"
   region: "PAL-M5"
@@ -5023,16 +4711,11 @@ SCES-51463:
   compat: 5
   clampModes:
     vu1ClampMode: 3 # Fixes sporadic white triangle SPS.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
-    trilinearFiltering: 1
 SCES-51480:
   name: "Twisted Metal - Black ONLINE"
   region: "PAL-M5"
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes menu text brightness.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
     halfPixelOffset: 4 # Fixes misaligned blur during Darkside special.
 SCES-51513:
   name: "EyeToy - Play"
@@ -5073,8 +4756,6 @@ SCES-51607:
   gameFixes:
     - EETimingHack # Fixes DMA errors.
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     autoFlush: 2
   dynaPatches:
     - pattern:
@@ -5092,8 +4773,6 @@ SCES-51608:
   region: "PAL-M7"
   compat: 5
   gsHWFixes:
-    mipmap: 2 # Fixes broken textures.
-    trilinearFiltering: 1 # Fixes water textures.
     cpuSpriteRenderBW: 4 # Fixes character and water textures.
     cpuSpriteRenderLevel: 2 # Needed for above.
     autoFlush: 2 # Fixes lighting.
@@ -5127,8 +4806,6 @@ SCES-51635:
     preloadFrameData: 1 # Fixes sun flickering.
     autoFlush: 2 # Fixes sun through objects.
     bilinearUpscale: 1 # Smooths out sun glare textures like native.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SCES-51648:
   name: "Everquest - Online Adventures"
   region: "PAL-E-I"
@@ -5166,8 +4843,6 @@ SCES-51719:
     vuClampMode: 2 # Text in GT mode works.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
   memcardFilters:
@@ -5193,17 +4868,12 @@ SCES-51904:
   gameFixes:
     - VIF1StallHack # Fixes broken HUD.
     - InstantDMAHack # Fixes texture corruption.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SCES-51910:
   name: "Arc - Twilight of the Spirits"
   region: "PAL-M5"
   compat: 5
   gsHWFixes:
     textureInsideRT: 1 # Fixes on screen garbage.
-    mipmap: 2 # Mipmap + trilinear, corrects the depth of field effect.
-    trilinearFiltering: 1
 SCES-51920:
   name: "Forbidden Siren"
   region: "PAL-E"
@@ -5225,8 +4895,6 @@ SCES-51979:
     vu1RoundMode: 0 # Fixes tire textures.
   gsHWFixes:
     halfPixelOffset: 2 # Corrects shadow position.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SCES-52004:
   name: "Killzone"
   region: "PAL-M6"
@@ -5243,8 +4911,6 @@ SCES-52033:
     autoFlush: 2 # Fixes lights going through walls.
     preloadFrameData: 1 # Fixes light flicker.
     halfPixelOffset: 2 # Corrects light position.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
   gameFixes:
     - EETimingHack # Fixes random hangs.
   patches:
@@ -5290,9 +4956,6 @@ SCES-52156:
   region: "PAL-M3"
   clampModes:
     vu1ClampMode: 3 # Fixes sporadic white triangle SPS.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
-    trilinearFiltering: 1
 SCES-52268:
   name: "SingStar"
   region: "PAL-E"
@@ -5306,9 +4969,6 @@ SCES-52306:
   gameFixes:
     - VIF1StallHack # Fixes broken HUD.
     - InstantDMAHack # Fixes texture corruption.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SCES-52327:
   name: "Forbidden Siren"
   region: "PAL-F"
@@ -5367,15 +5027,9 @@ SCES-52405:
 SCES-52410:
   name: "Athens 2004"
   region: "PAL-M6"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SCES-52411:
   name: "Athens 2004 [Platinum]"
   region: "PAL-M6"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SCES-52412:
   name: "Jackie Chan Adventures"
   region: "PAL-M7"
@@ -5390,8 +5044,6 @@ SCES-52424:
     - SoftwareRendererFMVHack # Fixes FMVs disabling hash cache.
   gsHWFixes:
     recommendedBlendingLevel: 2 # Helps banding when dithering is enabled.
-    mipmap: 2 # Fixes terrain rendering.
-    trilinearFiltering: 1
     halfPixelOffset: 3 # Fixes ghosting in foggy maps.
     roundSprite: 1 # Fixes font and HUD artifacts.
     alignSprite: 1 # Fixes vertical lines.
@@ -5431,8 +5083,6 @@ SCES-52438:
   compat: 5
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
   memcardFilters:
@@ -5448,8 +5098,6 @@ SCES-52456:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves color and luminosity of surfaces.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     disablePartialInvalidation: 1 # Prevents the situation that a level (Aquatos) doesn't render characters and geometry.
     halfPixelOffset: 2 # Fixes misaligned bloom.
     autoFlush: 2 # Helps fix misaligned bloom.
@@ -5464,8 +5112,6 @@ SCES-52460:
   gameFixes:
     - InstantDMAHack # Fixes holes in face geometry.
   gsHWFixes:
-    mipmap: 2 # Fixes broken textures.
-    trilinearFiltering: 1 # Fixes water textures.
     cpuSpriteRenderBW: 4 # Fixes character and water textures.
     cpuSpriteRenderLevel: 2 # Needed for above.
     autoFlush: 2 # Fixes lighting.
@@ -5492,17 +5138,12 @@ SCES-52566:
 SCES-52582:
   name: "Everybody's Golf"
   region: "PAL-M5"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SCES-52586:
   name: "Death by Degrees"
   region: "PAL-E-S"
   compat: 5
   gsHWFixes:
     alignSprite: 1 # Fixes FMV lines.
-    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
-    trilinearFiltering: 1
     cpuSpriteRenderBW: 2 # Prevents Death By VRAM explosion.
     cpuSpriteRenderLevel: 2 # Needed for above.
     getSkipCount: "GSC_DeathByDegreesTekkenNinaWilliams"
@@ -5537,8 +5178,6 @@ SCES-52758:
   gsHWFixes:
     textureInsideRT: 1
     halfPixelOffset: 2 # Fixes outlines on screen edges.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SCES-52762:
   name: "DJ Decks & FX"
   region: "PAL-F"
@@ -5589,22 +5228,15 @@ SCES-52948:
   gsHWFixes:
     textureInsideRT: 1
     halfPixelOffset: 2 # Fixes outlines on screen edges.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SCES-53033:
   name: "Formula One 2005"
   region: "PAL-M7"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SCES-53053:
   name: "Death by Degrees"
   region: "PAL-F-I"
   gsHWFixes:
     alignSprite: 1 # Fixes FMV lines.
-    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
-    trilinearFiltering: 1
     cpuSpriteRenderBW: 2 # Prevents Death By VRAM explosion.
     cpuSpriteRenderLevel: 2 # Needed for above.
     getSkipCount: "GSC_DeathByDegreesTekkenNinaWilliams"
@@ -5614,8 +5246,6 @@ SCES-53054:
   compat: 5
   gsHWFixes:
     alignSprite: 1 # Fixes FMV lines.
-    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
-    trilinearFiltering: 1
     cpuSpriteRenderBW: 2 # Prevents Death By VRAM explosion.
     cpuSpriteRenderLevel: 2 # Needed for above.
     getSkipCount: "GSC_DeathByDegreesTekkenNinaWilliams"
@@ -5663,8 +5293,6 @@ SCES-53202:
   gsHWFixes:
     alignSprite: 1
     halfPixelOffset: 4 # Align post.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_Tekken5"
 SCES-53247:
   name: "WRC Rally Evolved"
@@ -5691,8 +5319,6 @@ SCES-53285:
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     disablePartialInvalidation: 1 # Prevents world geometry and some models from vanishing when pausing or opening vendor.
     halfPixelOffset: 2 # Fixes misaligned bloom.
     autoFlush: 2 # Helps fix misaligned bloom.
@@ -5702,8 +5328,6 @@ SCES-53286:
   gsHWFixes:
     roundSprite: 1 # Fix lines in the sky.
     autoFlush: 2 # Fixes lighting.
-    mipmap: 2 # Fixes broken textures.
-    trilinearFiltering: 1 # Fixes water textures.
     cpuSpriteRenderBW: 2 # Fixes water textures. Can't use BW 4 here because of post effects.
     cpuSpriteRenderLevel: 2 # Needed for above.
     textureInsideRT: 1 # Fixes broken character models.
@@ -5719,8 +5343,6 @@ SCES-53300:
     vuClampMode: 3 # Fixes SPS ingame and prevents flickering or invisible characters.
   gsHWFixes:
     minimumBlendingLevel: 4 # Mitigates grayer text font in bottom left.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SCES-53304:
   name: "Buzz! The Music Quiz"
   region: "PAL-E"
@@ -5760,8 +5382,6 @@ SCES-53326:
   region: "PAL-E"
   compat: 5
   gsHWFixes:
-    mipmap: 2 # Fixes Water with Trilinear.
-    trilinearFiltering: 1 # Fixes Water with Mipmap (Full).
     halfPixelOffset: 1 # Fixes misalignments and borders on side.
   memcardFilters:
     - "SCES-53326"
@@ -5781,8 +5401,6 @@ SCES-53358:
   gsHWFixes:
     autoFlush: 1 # Fixes pause menu backgrounds.
     roundSprite: 1 # Corrects proportions of fonts and pause-screen lines, adjusts display closer to software.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SCES-53372:
   name: "Tourist Trophy - The Real Riding Simulator"
   region: "PAL-M5"
@@ -5848,8 +5466,6 @@ SCES-53642:
     - SoftwareRendererFMVHack # Fixes interlacing.
   gsHWFixes:
     preloadFrameData: 1 # Fixes black background in the pause menu.
-    mipmap: 2 # Fixes miptrick texture effects.
-    trilinearFiltering: 1 # Fixes miptrick blending.
     halfPixelOffset: 2 # Fixes misaligned blur.
     autoFlush: 2 # Fixes corruption in cutscenes and brightens the image.
 SCES-53663:
@@ -5882,8 +5498,6 @@ SCES-53688:
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
     textureInsideRT: 1 # Fixes corruption.
-    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_UrbanReign"
 SCES-53795:
   name: "SingStar '80s"
@@ -5991,8 +5605,6 @@ SCES-54041:
     - SoftwareRendererFMVHack # Fixes FMVs disabling hash cache.
   gsHWFixes:
     recommendedBlendingLevel: 2 # Helps banding when dithering is enabled.
-    mipmap: 2 # Fixes terrain rendering.
-    trilinearFiltering: 1
     halfPixelOffset: 3 # Fixes ghosting in foggy maps.
     roundSprite: 1 # Fixes HUD artifacts.
     alignSprite: 1 # Fixes vertical lines.
@@ -6064,8 +5676,6 @@ SCES-54206:
     halfPixelOffset: 2 # Fixes misaligned bloom.
     roundSprite: 1 # Fixes chromatic effect.
     autoFlush: 1 # Fixes sun occlusion.
-    mipmap: 2 # Mipmap + trilinear, fixes miptrick textures to match sw renderer.
-    trilinearFiltering: 1
 SCES-54219:
   name: "Buzz! Junior - Jungle Party"
   region: "PAL-M7"
@@ -6192,9 +5802,6 @@ SCES-54535:
   region: "PAL-M11"
   roundModes:
     vu1RoundMode: 1 # Fixes the display of scores and text ingame.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves court textures to match sw renderer.
-    trilinearFiltering: 1
 SCES-54538:
   name: "Eyetoy - Play Astro Zoo"
   region: "PAL-M15"
@@ -6265,9 +5872,6 @@ SCES-54637:
 SCES-54638:
   name: "Gaelic Games - Football 2"
   region: "PAL-E-GA"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SCES-54639:
   name: "AFL Premiership 2007"
   region: "PAL-A"
@@ -6280,9 +5884,6 @@ SCES-54676:
 SCES-54688:
   name: "ATV Offroad Fury 4"
   region: "PAL-M12"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SCES-54689:
   name: "Buzz! The Maha Quiz"
   region: "PAL-IN"
@@ -6393,9 +5994,6 @@ SCES-54941:
 SCES-55019:
   name: "Ratchet & Clank - Size Matters"
   region: "PAL-M5"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SCES-55038:
   name: "EyeToy Play - Hero"
   region: "PAL-M15"
@@ -6622,12 +6220,10 @@ SCES-55510:
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes object glow.
     roundSprite: 1 # Fix lines in the sky.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     autoFlush: 2 # Fixes shadow definition.
     cpuSpriteRenderBW: 4 # Fixes shadow rendering.
     cpuSpriteRenderLevel: 2 # Needed for above.
-    bilinearUpscale: 1 # Smoothes out shadow textures.
+    bilinearUpscale: 1 # Smooths out shadow textures.
 SCES-55513:
   name: "SingStar Polskie Hity"
   region: "PAL-PL"
@@ -6790,15 +6386,9 @@ SCKA-20001:
 SCKA-20002:
   name: "Time Crisis II"
   region: "NTSC-K"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SCKA-20003:
   name: "War of the Monsters"
   region: "NTSC-K"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
-    trilinearFiltering: 1
 SCKA-20004:
   name: "Sly Cooper and the Thievius Raccoonus"
   region: "NTSC-K"
@@ -6830,8 +6420,6 @@ SCKA-20010:
   name: "Jak II"
   region: "NTSC-K"
   gsHWFixes:
-    mipmap: 2 # Fixes broken textures.
-    trilinearFiltering: 1 # Fixes water textures.
     cpuSpriteRenderBW: 4 # Fixes character and water textures.
     cpuSpriteRenderLevel: 2 # Needed for above.
     autoFlush: 2 # Fixes lighting.
@@ -6841,16 +6429,12 @@ SCKA-20011:
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     autoFlush: 2
 SCKA-20012:
   name: "Arc the Lad - Jeongryeongui Hwanghon"
   region: "NTSC-K"
   gsHWFixes:
     textureInsideRT: 1 # Fixes on screen garbage.
-    mipmap: 2 # Mipmap + trilinear, corrects the depth of field effect.
-    trilinearFiltering: 1
 SCKA-20013:
   name: "SOCOM - U.S. Navy SEALs"
   region: "NTSC-K"
@@ -6889,8 +6473,6 @@ SCKA-20018:
     textureInsideRT: 1
     texturePreloading: 1 # Performs much better with partial preload.
     halfPixelOffset: 2 # Fixes outlines around characters.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SCKA-20019:
   name: "Siren"
   region: "NTSC-K"
@@ -6905,16 +6487,11 @@ SCKA-20020:
   gameFixes:
     - VIF1StallHack # Fixes broken HUD.
     - InstantDMAHack # Fixes texture corruption.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SCKA-20022:
   name: "Gran Turismo 4 Prologue"
   region: "NTSC-K"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
   # vuClampMode = 2  Text in GT mode works.
@@ -6949,8 +6526,6 @@ SCKA-20027:
     mergeSprite: 1 # Fixes most vertical lines and lighting misalignment.
     autoFlush: 1 # Fixes light bloom intensity.
     estimateTextureRegion: 1 # Improves performance and reduces hash cache size.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_GiTS"
 SCKA-20028:
   name: "Ico [PlayStation2 Big Hit Series]"
@@ -6974,9 +6549,6 @@ SCKA-20030:
 SCKA-20031:
   name: "Athens 2004"
   region: "NTSC-K"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SCKA-20032:
   name: "Syphon Filter - The Omega Virus"
   region: "NTSC-K"
@@ -6984,8 +6556,6 @@ SCKA-20032:
     autoFlush: 2 # Fixes lights going through walls.
     preloadFrameData: 1 # Fixes light flicker.
     halfPixelOffset: 2 # Corrects light position.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
   gameFixes:
     - EETimingHack # Fixes random hangs.
   patches:
@@ -7019,8 +6589,6 @@ SCKA-20037:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves color and luminosity of surfaces.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     disablePartialInvalidation: 1 # Prevents the situation that a level (Aquatos) doesn't render characters and geometry.
     halfPixelOffset: 2 # Fixes misaligned bloom.
     autoFlush: 2 # Helps fix misaligned bloom.
@@ -7037,8 +6605,6 @@ SCKA-20039:
   region: "NTSC-K"
   gsHWFixes:
     alignSprite: 1 # Fixes FMV lines.
-    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
-    trilinearFiltering: 1
     cpuSpriteRenderBW: 2 # Prevents Death By VRAM explosion.
     cpuSpriteRenderLevel: 2 # Needed for above.
     getSkipCount: "GSC_DeathByDegreesTekkenNinaWilliams"
@@ -7048,8 +6614,6 @@ SCKA-20040:
   gameFixes:
     - InstantDMAHack # Fixes holes in face geometry.
   gsHWFixes:
-    mipmap: 2 # Fixes broken textures.
-    trilinearFiltering: 1 # Fixes water textures.
     cpuSpriteRenderBW: 4 # Fixes character and water textures.
     cpuSpriteRenderLevel: 2 # Needed for above.
     autoFlush: 2 # Fixes lighting.
@@ -7063,8 +6627,6 @@ SCKA-20042:
     - SoftwareRendererFMVHack # Fixes FMVs disabling hash cache.
   gsHWFixes:
     recommendedBlendingLevel: 2 # Helps banding when dithering is enabled.
-    mipmap: 2 # Fixes terrain rendering.
-    trilinearFiltering: 1
     halfPixelOffset: 3 # Fixes ghosting in foggy maps.
     roundSprite: 1 # Fixes font and HUD artifacts.
     alignSprite: 1 # Fixes vertical lines.
@@ -7089,8 +6651,6 @@ SCKA-20046:
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     autoFlush: 2
 SCKA-20047:
   name: "Armored Core - Nine Breaker"
@@ -7098,8 +6658,6 @@ SCKA-20047:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
     recommendedBlendingLevel: 3 # Fixes level brightness.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
     cpuSpriteRenderBW: 2 # Fixes broken water on "Upper Sea" level.
     cpuSpriteRenderLevel: 2 # Needed for above.
   memcardFilters:
@@ -7121,8 +6679,6 @@ SCKA-20049:
   gsHWFixes:
     alignSprite: 1
     halfPixelOffset: 4 # Align post.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_Tekken5"
 SCKA-20050:
   name: "Tales of Legendia"
@@ -7155,9 +6711,6 @@ SCKA-20053:
   gameFixes:
     - VIF1StallHack # Fixes broken HUD.
     - InstantDMAHack # Fixes texture corruption.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SCKA-20054:
   name: "Tales of Destiny 2 [PlayStation 2 Big Hit Series]"
   region: "NTSC-K"
@@ -7170,9 +6723,6 @@ SCKA-20056:
 SCKA-20057:
   name: "Minna no Golf 4 - Everybody's Golf"
   region: "NTSC-K"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SCKA-20058:
   name: "Bumpy Trot"
   region: "NTSC-K"
@@ -7197,8 +6747,6 @@ SCKA-20060:
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     disablePartialInvalidation: 1 # Prevents world geometry and some models from vanishing when pausing or opening vendor.
     halfPixelOffset: 2 # Fixes misaligned bloom.
     autoFlush: 2 # Helps fix misaligned bloom.
@@ -7222,8 +6770,6 @@ SCKA-20062:
     - SoftwareRendererFMVHack # Fixes interlacing.
   gsHWFixes:
     preloadFrameData: 1 # Fixes black background in the pause menu.
-    mipmap: 2 # Fixes miptrick texture effects.
-    trilinearFiltering: 1 # Fixes miptrick blending.
     halfPixelOffset: 2 # Fixes misaligned blur.
     autoFlush: 2 # Fixes corruption in cutscenes and brightens the image.
 SCKA-20063:
@@ -7245,8 +6791,6 @@ SCKA-20064:
     vuClampMode: 3 # Fixes SPS ingame and prevents flickering or invisible characters.
   gsHWFixes:
     minimumBlendingLevel: 4 # Mitigates grayer text font in bottom left.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SCKA-20065:
   name: "Urban Reign"
   region: "NTSC-K"
@@ -7255,8 +6799,6 @@ SCKA-20065:
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
     textureInsideRT: 1 # Fixes corruption.
-    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_UrbanReign"
 SCKA-20066:
   name: "EyeToy - Play 3"
@@ -7270,8 +6812,6 @@ SCKA-20068:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes ground texture flicker and improves car body reflections.
     autoFlush: 1 # Fixes lens flares and missing sun.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SCKA-20069:
   name: "Siren 2"
   region: "NTSC-K"
@@ -7287,8 +6827,6 @@ SCKA-20070:
     - SoftwareRendererFMVHack # Fixes FMVs disabling hash cache.
   gsHWFixes:
     recommendedBlendingLevel: 2 # Helps banding when dithering is enabled.
-    mipmap: 2 # Fixes terrain rendering.
-    trilinearFiltering: 1
     halfPixelOffset: 3 # Fixes ghosting in foggy maps.
     roundSprite: 1 # Fixes HUD artifacts.
     alignSprite: 1 # Fixes vertical lines.
@@ -7350,8 +6888,6 @@ SCKA-20081:
   gsHWFixes:
     alignSprite: 1
     halfPixelOffset: 4 # Align post.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_Tekken5"
 SCKA-20082:
   name: "Ace Combat 5 - The Unsung War [PlayStation 2 Big Hit Series]"
@@ -7360,8 +6896,6 @@ SCKA-20082:
     - SoftwareRendererFMVHack # Fixes FMVs disabling hash cache.
   gsHWFixes:
     recommendedBlendingLevel: 2 # Helps banding when dithering is enabled.
-    mipmap: 2 # Fixes terrain rendering.
-    trilinearFiltering: 1
     halfPixelOffset: 3 # Fixes ghosting in foggy maps.
     roundSprite: 1 # Fixes font and HUD artifacts.
     alignSprite: 1 # Fixes vertical lines.
@@ -7393,8 +6927,6 @@ SCKA-20089:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SCKA-20090:
   name: "God Hand"
   region: "NTSC-K"
@@ -7436,8 +6968,6 @@ SCKA-20096:
   region: "NTSC-K"
   gsHWFixes:
     halfPixelOffset: 2 # Fix text and post blur.
-    mipmap: 2 # Base mip level isn't always used.
-    trilinearFiltering: 1
     autoFlush: 2 # Needed for recursive mipmap rendering.
     getSkipCount: "GSC_BlueTongueGames" # Render mipmaps on the CPU.
 SCKA-20097:
@@ -7471,9 +7001,6 @@ SCKA-20104:
 SCKA-20105:
   name: "Everybody's Golf 4"
   region: "NTSC-K"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SCKA-20106:
   name: "Wander to Kyozou"
   region: "NTSC-K"
@@ -7486,17 +7013,12 @@ SCKA-20108:
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     disablePartialInvalidation: 1 # Prevents world geometry and some models from vanishing when pausing or opening vendor.
     halfPixelOffset: 2 # Fixes misaligned bloom.
     autoFlush: 2 # Helps fix misaligned bloom.
 SCKA-20109:
   name: "Persona 3 FES [Independent Starting Version]"
   region: "NTSC-K"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, fixes flashing windows.
-    trilinearFiltering: 1
   memcardFilters:
     - "SCKA-20109"
     - "SCKA-20099"
@@ -7512,9 +7034,6 @@ SCKA-20111:
 SCKA-20112:
   name: "Persona 3 FES"
   region: "NTSC-K"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, fixes flashing windows.
-    trilinearFiltering: 1
 SCKA-20114:
   name: "Obscure II - The Aftermath"
   region: "NTSC-K"
@@ -7542,8 +7061,6 @@ SCKA-20120:
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes vendor and other bloom.
     autoFlush: 2 # Fixes missing bloom and shadow definition.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SCKA-20124:
   name: "Piposarugetchu 3" # Ape Escape 3
   region: "NTSC-K"
@@ -7559,9 +7076,6 @@ SCKA-20125:
 SCKA-20126:
   name: "Persona 3 FES"
   region: "NTSC-K"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, fixes flashing windows.
-    trilinearFiltering: 1
 SCKA-20127:
   name: "Zero" # Project Zero
   region: "NTSC-K"
@@ -7633,8 +7147,6 @@ SCKA-20142:
   name: "MLB 11 - The Show"
   region: "NTSC-K"
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves crowd textures.
-    trilinearFiltering: 1
     textureInsideRT: 1 # Needed for mipmapping to function correctly.
 SCKA-20171:
   name: "Let's Bravo Music"
@@ -7662,8 +7174,6 @@ SCKA-30001:
     vuClampMode: 2 # Text in GT mode works.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 SCKA-30002:
@@ -7688,8 +7198,6 @@ SCKA-30004:
     vuClampMode: 2 # Text in GT mode works.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 SCKA-30005:
@@ -7706,8 +7214,6 @@ SCKA-30006:
     halfPixelOffset: 2 # Fixes misaligned bloom.
     roundSprite: 1 # Fixes chromatic effect.
     autoFlush: 1 # Fixes sun occlusion.
-    mipmap: 2 # Mipmap + trilinear, fixes miptrick textures to match sw renderer.
-    trilinearFiltering: 1
 SCKA-30007:
   name: "God of War 2 [Big Hit Series]"
   region: "NTSC-K"
@@ -7718,8 +7224,6 @@ SCKA-30007:
     halfPixelOffset: 2 # Fixes misaligned bloom.
     roundSprite: 1 # Fixes chromatic effect.
     autoFlush: 1 # Fixes sun occlusion.
-    mipmap: 2 # Mipmap + trilinear, fixes miptrick textures to match sw renderer.
-    trilinearFiltering: 1
 SCKA-90002:
   name: "Jeolche Jeolmyeong Dosi"
   region: "NTSC-K"
@@ -7738,9 +7242,6 @@ SCKA-90010:
 SCKA-90011:
   name: "Arc the Lad - Jeongryeongui Hwanghon - Premiere Disc"
   region: "NTSC-K"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, corrects the depth of field effect.
-    trilinearFiltering: 1
 SCKA-90016:
   name: "Goehon - Gulryeora! Wangjanim!"
   region: "NTSC-K"
@@ -7758,15 +7259,11 @@ SCPM-85101:
     mtvu: 0
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes metal textures.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SCPM-85301:
   name: "Gran Turismo Concept - Copen Special Edition [Demo]"
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 SCPM-85302:
@@ -7780,8 +7277,6 @@ SCPM-85304:
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 SCPN-60101:
@@ -8038,8 +7533,6 @@ SCPS-15004:
   name-en: "Dark Cloud"
   region: "NTSC-J"
   gsHWFixes:
-    mipmap: 2 # Fixes mipmapping.
-    trilinearFiltering: 1 # Smoothes out mipmapping.
     halfPixelOffset: 2 # Distance is less blurry, game has reduced LOD so it will still look blurry.
 SCPS-15005:
   name: PHASE PARADOX
@@ -8070,8 +7563,6 @@ SCPS-15009:
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
-    mipmap: 2 # Mipmap + trilinear, improves track textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 SCPS-15010:
   name: グランツーリスモ コンセプト 2001 TOKYO
@@ -8081,8 +7572,6 @@ SCPS-15010:
   compat: 5
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 SCPS-15011:
   name: EXTERMINATION
@@ -8130,8 +7619,6 @@ SCPS-15017:
     instantVU1: 0 # Fixes noodles.
     mtvu: 0
   gsHWFixes:
-    mipmap: 2 # Fixes missing floor texture.
-    trilinearFiltering: 1 # Fixes fog effect.
     wildArmsHack: 1 # Fixes misaligment depth of field effect.
 SCPS-15018:
   name: THE 山手線 〜Train Simulator Real
@@ -8159,8 +7646,6 @@ SCPS-15021:
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves reflection quality.
-    mipmap: 2 # Fixes broken textures.
-    trilinearFiltering: 1 # Fixes water textures.
     cpuSpriteRenderBW: 4 # Fixes character and water textures.
     cpuSpriteRenderLevel: 2 # Needed for above.
     autoFlush: 2 # Fixes gate warp effect and emissive texture effects.
@@ -8195,8 +7680,6 @@ SCPS-15025:
     - SoftwareRendererFMVHack # Fixes interlacing.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves shine on surfaces and lights.
-    mipmap: 2 # Fixes miptrick texture effects.
-    trilinearFiltering: 1 # Fixes miptrick blending.
   patches:
     "FE0A6AB6":
       content: |-
@@ -8288,9 +7771,6 @@ SCPS-15037:
   region: "NTSC-J"
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SCPS-15038:
   name: OPERATOR’S SIDE マイク同梱版
   name-sort: おぺれーたーずさいど [まいくどうこんばん]
@@ -8312,8 +7792,6 @@ SCPS-15040:
   region: "NTSC-J"
   gsHWFixes:
     textureInsideRT: 1 # Fixes on screen garbage.
-    mipmap: 2 # Mipmap + trilinear, corrects the depth of field effect.
-    trilinearFiltering: 1
 SCPS-15041:
   name: アークザラッド 精霊の黄昏
   name-sort: あーくざらっど せいれいのたそがれ
@@ -8321,8 +7799,6 @@ SCPS-15041:
   region: "NTSC-J"
   gsHWFixes:
     textureInsideRT: 1 # Fixes on screen garbage.
-    mipmap: 2 # Mipmap + trilinear, corrects the depth of field effect.
-    trilinearFiltering: 1
 SCPS-15042:
   name: デカボイス マイク同梱版
   name-sort: でかぼいす まいくどうこんばん
@@ -8407,8 +7883,6 @@ SCPS-15055:
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
   memcardFilters:
@@ -8431,8 +7905,6 @@ SCPS-15056:
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     autoFlush: 2
   memcardFilters:
     - "SCPS-15056"
@@ -8443,8 +7915,6 @@ SCPS-15057:
   name-en: "Jak and Daxter II"
   region: "NTSC-J"
   gsHWFixes:
-    mipmap: 2 # Fixes broken textures.
-    trilinearFiltering: 1 # Fixes water textures.
     cpuSpriteRenderBW: 4 # Fixes character and water textures.
     cpuSpriteRenderLevel: 2 # Needed for above.
     autoFlush: 2 # Fixes lighting.
@@ -8453,17 +7923,11 @@ SCPS-15058:
   name-sort: あーくざらっど GENERATION
   name-en: "Arc the Lad - Generation"
   region: "NTSC-J"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, corrects the depth of field effect.
-    trilinearFiltering: 1
 SCPS-15059:
   name: みんなのGOLF 4
   name-sort: みんなのごるふ4
   name-en: "Minna no Golf 4"
   region: "NTSC-J"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SCPS-15060:
   name: 幸福操作官
   name-sort: こうふくそうさかん
@@ -8481,8 +7945,6 @@ SCPS-15062:
   region: "NTSC-J"
   gsHWFixes:
     autoFlush: 2 # Fixes speed effect intensity.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SCPS-15063:
   name: ポポロクロイス 月の掟の冒険
   name-sort: ぽぽろくろいす つきのおきてのぼうけん
@@ -8502,8 +7964,6 @@ SCPS-15064:
     mergeSprite: 1 # Fixes most vertical lines and lighting misalignment.
     autoFlush: 1 # Fixes light bloom intensity.
     estimateTextureRegion: 1 # Improves performance and reduces hash cache size.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_GiTS"
   patches:
     A5768F53:
@@ -8551,9 +8011,6 @@ SCPS-15065:
   gameFixes:
     - VIF1StallHack # Fixes broken HUD.
     - InstantDMAHack # Fixes texture corruption.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SCPS-15066:
   name: プリンス・オブ・ペルシャ 〜時間の砂〜
   name-sort: ぷりんす おぶ ぺるしゃ じかんのすな
@@ -8605,9 +8062,6 @@ SCPS-15074:
   name-sort: ATHENS 2004
   name-en: "Olympic Summer Games - Athens 2004"
   region: "NTSC-J"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SCPS-15075:
   name: DJbox プレミアムキット
   name-sort: DJbox ぷれみあむきっと
@@ -8662,8 +8116,6 @@ SCPS-15084:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves color and luminosity of surfaces.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     disablePartialInvalidation: 1 # Prevents the situation that a level (Aquatos) doesn't render characters and geometry.
     halfPixelOffset: 2 # Fixes misaligned bloom.
     autoFlush: 2 # Helps fix misaligned bloom.
@@ -8779,8 +8231,6 @@ SCPS-15096:
     - SoftwareRendererFMVHack # Fixes interlacing.
   gsHWFixes:
     preloadFrameData: 1 # Fixes black background in the pause menu.
-    mipmap: 2 # Fixes miptrick texture effects.
-    trilinearFiltering: 1 # Fixes miptrick blending.
     halfPixelOffset: 2 # Fixes misaligned blur.
     autoFlush: 2 # Fixes corruption in cutscenes and brightens the image.
 SCPS-15097:
@@ -8805,9 +8255,6 @@ SCPS-15098:
   name-sort: Formula One 2005
   name-en: "Formula One 2005"
   region: "NTSC-J"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SCPS-15099:
   name: ラチェット＆クランク4th ギリギリ銀河のギガバトル （Special Gift Package）
   name-sort: らちぇっとあんどくらんく4th ぎりぎりぎんがのぎがばとる [Special Gift Package]
@@ -8816,8 +8263,6 @@ SCPS-15099:
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     disablePartialInvalidation: 1 # Prevents world geometry and some models from vanishing when pausing or opening vendor.
     halfPixelOffset: 2 # Fixes misaligned bloom.
     autoFlush: 2 # Helps fix misaligned bloom.
@@ -8829,8 +8274,6 @@ SCPS-15100:
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     disablePartialInvalidation: 1 # Prevents world geometry and some models from vanishing when pausing or opening vendor.
     halfPixelOffset: 2 # Fixes misaligned bloom.
     autoFlush: 2 # Helps fix misaligned bloom.
@@ -8965,9 +8408,6 @@ SCPS-15113:
   region: "NTSC-J"
   roundModes:
     vu1RoundMode: 1 # Fixes the display of scores and text ingame.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves court textures to match sw renderer.
-    trilinearFiltering: 1
 SCPS-15114:
   name: 機甲装兵アーモダイン
   name-sort: きこうそうへいあーもだいん
@@ -9019,8 +8459,6 @@ SCPS-15120:
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes vendor and other bloom.
     autoFlush: 2 # Fixes missing bloom and shadow definition.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SCPS-17001:
   name: グランツーリスモ4
   name-sort: ぐらんつーりすも4
@@ -9034,8 +8472,6 @@ SCPS-17001:
     eeDivRoundMode: 3 # See above.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
   memcardFilters:
@@ -9064,8 +8500,6 @@ SCPS-17008:
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 SCPS-17009:
@@ -9075,8 +8509,6 @@ SCPS-17009:
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 SCPS-17010:
@@ -9086,8 +8518,6 @@ SCPS-17010:
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 SCPS-17011:
@@ -9097,8 +8527,6 @@ SCPS-17011:
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 SCPS-17013:
@@ -9180,8 +8608,6 @@ SCPS-19152:
     - SoftwareRendererFMVHack # Fixes interlacing.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves shine on surfaces and lights.
-    mipmap: 2 # Fixes miptrick texture effects.
-    trilinearFiltering: 1 # Fixes miptrick blending.
 SCPS-19153:
   name: ピポサル2001 PlayStation 2 the Best
   name-sort: ぴぽさる2001 PlayStation 2 the Best
@@ -9196,8 +8622,6 @@ SCPS-19201:
     instantVU1: 0 # Fixes noodles.
     mtvu: 0
   gsHWFixes:
-    mipmap: 2 # Fixes missing floor texture.
-    trilinearFiltering: 1 # Fixes fog effect.
     wildArmsHack: 1 # Fixes misaligment depth of field effect.
 SCPS-19202:
   name: EXTERMINATION PlayStation 2 the Best
@@ -9212,8 +8636,6 @@ SCPS-19203:
   name-en: "Dark Cloud [PlayStation 2 the Best]"
   region: "NTSC-J"
   gsHWFixes:
-    mipmap: 2 # Fixes mipmapping.
-    trilinearFiltering: 1 # Smoothes out mipmapping.
     halfPixelOffset: 2 # Distance is less blurry, game has reduced LOD so it will still look blurry.
 SCPS-19204:
   name: レガイア デュエルサーガ PlayStation 2 the Best
@@ -9237,8 +8659,6 @@ SCPS-19206:
     - SoftwareRendererFMVHack # Fixes interlacing.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves shine on surfaces and lights.
-    mipmap: 2 # Fixes miptrick texture effects.
-    trilinearFiltering: 1 # Fixes miptrick blending.
 SCPS-19207:
   name: ポポロクロイス〜はじまりの冒険〜 PlayStation 2 the Best
   name-sort: ぽぽろくろいす はじまりのぼうけん PlayStation 2 the Best
@@ -9251,8 +8671,6 @@ SCPS-19208:
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 SCPS-19209:
   name: ぼくのなつやすみ2 海の冒険篇 PlayStation 2 the Best
@@ -9266,8 +8684,6 @@ SCPS-19210:
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves reflection quality.
-    mipmap: 2 # Fixes broken textures.
-    trilinearFiltering: 1 # Fixes water textures.
     cpuSpriteRenderBW: 4 # Fixes character and water textures.
     cpuSpriteRenderLevel: 2 # Needed for above.
     autoFlush: 2 # Fixes gate warp effect and emissive texture effects.
@@ -9278,9 +8694,6 @@ SCPS-19211:
   region: "NTSC-J"
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SCPS-19213:
   name: Operator’s Side USBマイク同梱版 PlayStation 2 the Best
   name-sort: おぺれーたーずさいど [USBまいくどうこんばん] PlayStation 2 the Best
@@ -9322,8 +8735,6 @@ SCPS-19252:
     vuClampMode: 2 # Text in GT mode works.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
   memcardFilters:
@@ -9357,9 +8768,6 @@ SCPS-19301:
   name-sort: みんなのごるふ4 PlayStation 2 the Best
   name-en: "Minna no Golf 4 [PlayStation 2 the Best]"
   region: "NTSC-J"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SCPS-19302:
   name: ラチェット＆クランク2 ガガガ！銀河のコマンドーっす PlayStation 2 the Best
   name-sort: らちぇっとあんどくらんく2 ががが！ぎんがのこまんどーっす PlayStation 2 the Best
@@ -9368,8 +8776,6 @@ SCPS-19302:
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     autoFlush: 2
 SCPS-19303:
   name: ぼくのなつやすみ2 海の冒険篇 PlayStation 2 the Best
@@ -9385,8 +8791,6 @@ SCPS-19304:
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
   memcardFilters:
@@ -9435,8 +8839,6 @@ SCPS-19308:
     - SoftwareRendererFMVHack # Fixes interlacing.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves shine on surfaces and lights.
-    mipmap: 2 # Fixes miptrick texture effects.
-    trilinearFiltering: 1 # Fixes miptrick blending.
 SCPS-19309:
   name: ラチェット＆クランク3 突撃！ガラクチック★レンジャーズ PlayStation 2 the Best
   name-sort: らちぇっとあんどくらんく3 とつげき!がらくちっくれんじゃーず PlayStation 2 the Best
@@ -9446,8 +8848,6 @@ SCPS-19309:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves color and luminosity of surfaces.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     disablePartialInvalidation: 1 # Prevents the situation that a level (Aquatos) doesn't render characters and geometry.
     halfPixelOffset: 2 # Fixes misaligned bloom.
     autoFlush: 2 # Helps fix misaligned bloom.
@@ -9458,9 +8858,6 @@ SCPS-19310:
   region: "NTSC-J"
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SCPS-19311:
   name: サルゲッチュ3 PlayStation 2 the Best
   name-sort: さるげっちゅ3 PlayStation 2 the Best
@@ -9470,8 +8867,6 @@ SCPS-19311:
     - SoftwareRendererFMVHack # Fixes interlacing.
   gsHWFixes:
     preloadFrameData: 1 # Fixes black background in the pause menu.
-    mipmap: 2 # Fixes miptrick texture effects.
-    trilinearFiltering: 1 # Fixes miptrick blending.
     halfPixelOffset: 2 # Fixes misaligned blur.
     autoFlush: 2 # Fixes corruption in cutscenes and brightens the image.
 SCPS-19312:
@@ -9514,9 +8909,6 @@ SCPS-19316:
   region: "NTSC-J"
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SCPS-19317:
   name: ラチェット＆クランク2 ガガガ！銀河のコマンドーっす PlayStation 2 the Best
   name-sort: らちぇっとあんどくらんく2 ががが！ぎんがのこまんどーっす PlayStation 2 the Best
@@ -9525,8 +8917,6 @@ SCPS-19317:
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     autoFlush: 2
   memcardFilters:
     - "SCAJ-20001"
@@ -9544,9 +8934,6 @@ SCPS-19319:
   name-sort: みんなのごるふ4 PlayStation 2 the Best
   name-en: "Minna no Golf 4 [PlayStation 2 the Best]"
   region: "NTSC-J"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SCPS-19320:
   name: ワンダと巨像 PlayStation 2 the Best
   name-sort: わんだときょぞう PlayStation 2 the Best
@@ -9571,8 +8958,6 @@ SCPS-19321:
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     disablePartialInvalidation: 1 # Prevents world geometry and some models from vanishing when pausing or opening vendor.
     halfPixelOffset: 2 # Fixes misaligned bloom.
     autoFlush: 2 # Helps fix misaligned bloom.
@@ -9651,8 +9036,6 @@ SCPS-19327:
     - SoftwareRendererFMVHack # Fixes interlacing.
   gsHWFixes:
     preloadFrameData: 1 # Fixes black background in the pause menu.
-    mipmap: 2 # Fixes miptrick texture effects.
-    trilinearFiltering: 1 # Fixes miptrick blending.
     halfPixelOffset: 2 # Fixes misaligned blur.
     autoFlush: 2 # Fixes corruption in cutscenes and brightens the image.
 SCPS-19328:
@@ -9663,8 +9046,6 @@ SCPS-19328:
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     disablePartialInvalidation: 1 # Prevents world geometry and some models from vanishing when pausing or opening vendor.
     halfPixelOffset: 2 # Fixes misaligned bloom.
     autoFlush: 2 # Helps fix misaligned bloom.
@@ -9694,9 +9075,6 @@ SCPS-19332:
   region: "NTSC-J"
   roundModes:
     vu1RoundMode: 1 # Fixes the display of scores and text ingame.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves court textures to match sw renderer.
-    trilinearFiltering: 1
 SCPS-19333:
   name: ワイルドアームズ ザ フィフスヴァンガード PlayStation 2 the Best
   name-sort: わいるどあーむず ざ ふぃふすゔぁんがーど [PlayStation 2 the Best]
@@ -9744,8 +9122,6 @@ SCPS-51012:
   name: "Gigantic Drive"
   region: "NTSC-J"
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     autoFlush: 2 # Fixes DOF effect.
 SCPS-51013:
   name: "Torneko's Adventure 3"
@@ -9791,8 +9167,6 @@ SCPS-55004:
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves reflection quality.
-    mipmap: 2 # Fixes broken textures.
-    trilinearFiltering: 1 # Fixes water textures.
     cpuSpriteRenderBW: 4 # Fixes character and water textures.
     cpuSpriteRenderLevel: 2 # Needed for above.
     autoFlush: 2 # Fixes gate warp effect and emissive texture effects.
@@ -9801,8 +9175,6 @@ SCPS-55005:
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 SCPS-55006:
   name: "Wild ARMs - Advanced 3rd"
@@ -9815,8 +9187,6 @@ SCPS-55007:
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
-    mipmap: 2 # Mipmap + trilinear, improves track textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 SCPS-55008:
   name: "Thunderstrike"
@@ -9843,16 +9213,12 @@ SCPS-55014:
   gsHWFixes:
     halfPixelOffset: 2 # Corrects positioning of reflections on suit's surfaces.
     roundSprite: 2 # Reduces garbage on the UI whilst upscaling.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SCPS-55015:
   name: "Zettai Zetsumei Toshi"
   region: "NTSC-J"
   gsHWFixes:
     autoFlush: 1 # Fixes incorrect blur effect.
     halfPixelOffset: 4 # Improves blur.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SCPS-55016:
   name: "Jet de Go! 2"
   region: "NTSC-J"
@@ -9915,8 +9281,6 @@ SCPS-55029:
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 1 # Sharpens world in far distances.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
   memcardFilters:
     - "SCPS-55029"
     - "SCPS-55042"
@@ -9946,8 +9310,6 @@ SCPS-55035:
     - SoftwareRendererFMVHack # Fixes interlacing.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves shine on surfaces and lights.
-    mipmap: 2 # Fixes miptrick texture effects.
-    trilinearFiltering: 1 # Fixes miptrick blending.
 SCPS-55038:
   name: "Pac-Man World 2"
   region: "NTSC-J"
@@ -10078,8 +9440,6 @@ SCPS-56003:
   region: "NTSC-K"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves reflection quality.
-    mipmap: 2 # Fixes broken textures.
-    trilinearFiltering: 1 # Fixes water textures.
     cpuSpriteRenderBW: 4 # Fixes character and water textures.
     cpuSpriteRenderLevel: 2 # Needed for above.
     autoFlush: 2 # Fixes gate warp effect and emissive texture effects.
@@ -10129,8 +9489,6 @@ SCPS-56012:
   gsHWFixes:
     autoFlush: 1 # Fixes incorrect blur effect.
     halfPixelOffset: 4 # Improves blur.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SCPS-56013:
   name: "This is Football 2003"
   region: "NTSC-K"
@@ -10152,15 +9510,11 @@ SCPS-56016:
     estimateTextureRegion: 1 # Improves performance and reduces hash cache size.
     gpuPaletteConversion: 2 # Improves performance and reduces hash cache size.
     autoFlush: 1 # Corrects shadows (Currently still broken even with this).
-    mipmap: 2 # Mipmap + trilinear, matches sw renderer.
-    trilinearFiltering: 1
 SCPS-72001:
   name: "Gran Turismo 3 - A-Spec"
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
-    mipmap: 2 # Mipmap + trilinear, improves track textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 SCPS-72002:
   name: "Minna no Golf 3"
@@ -10182,8 +9536,6 @@ SCUS-21295:
     vu1RoundMode: 0 # Crashes without.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes water and grass textures.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
     wildArmsHack: 1 # Reduces post-processing misalignment.
     mergeSprite: 1 # Reduces post-processing misalignment.
 SCUS-21494:
@@ -10209,8 +9561,6 @@ SCUS-90682:
   clampModes:
     vuClampMode: 2 # Text in GT mode works.
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 SCUS-94346:
@@ -10231,8 +9581,6 @@ SCUS-97101:
   compat: 5
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes menu text brightness.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
     halfPixelOffset: 4 # Fixes misaligned blur during Darkside special.
 SCUS-97102:
   name: "Gran Turismo 3 - A-Spec"
@@ -10240,16 +9588,11 @@ SCUS-97102:
   compat: 5
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
-    mipmap: 2 # Mipmap + trilinear, improves track textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 SCUS-97104:
   name: "ATV Offroad Fury"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SCUS-97105:
   name: "Fantavision"
   region: "NTSC-U"
@@ -10275,8 +9618,6 @@ SCUS-97111:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    mipmap: 2 # Fixes mipmapping.
-    trilinearFiltering: 1 # Smoothes out mipmapping.
     halfPixelOffset: 2 # Distance is less blurry, game has reduced LOD so it will still look blurry.
 SCUS-97112:
   name: "Extermination"
@@ -10301,15 +9642,11 @@ SCUS-97114:
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes broken player rendering and skin flashing.
     cpuSpriteRenderLevel: 2 # Needed for above.
-    mipmap: 2 # Mipmap + trilinear, needed for player textures and court textures.
-    trilinearFiltering: 1
 SCUS-97115:
   name: "Gran Turismo 3 - A-Spec [Demo]"
   region: "NTSC-U"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 SCUS-97116:
   name: "Kiosk Demo Disc 2.01"
@@ -10329,9 +9666,6 @@ SCUS-97121:
 SCUS-97122:
   name: "ATV Offroad Fury [Demo]"
   region: "NTSC-U"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SCUS-97123:
   name: "Disney's Monsters Inc."
   region: "NTSC-U"
@@ -10342,8 +9676,6 @@ SCUS-97124:
   compat: 5
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves reflection quality.
-    mipmap: 2 # Fixes broken textures.
-    trilinearFiltering: 1 # Fixes water textures.
     cpuSpriteRenderBW: 4 # Fixes character and water textures.
     cpuSpriteRenderLevel: 2 # Needed for above.
     autoFlush: 2 # Fixes gate warp effect and emissive texture effects.
@@ -10392,8 +9724,6 @@ SCUS-97133:
     textureInsideRT: 1
     texturePreloading: 1 # Performs much better with partial preload.
     halfPixelOffset: 2 # Fixes outlines around characters.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SCUS-97134:
   name: "SOCOM - U.S. Navy SEALs"
   region: "NTSC-U"
@@ -10469,8 +9799,6 @@ SCUS-97152:
   name: "Dark Cloud [Demo]"
   region: "NTSC-U"
   gsHWFixes:
-    mipmap: 2 # Fixes mipmapping.
-    trilinearFiltering: 1 # Smoothes out mipmapping.
     halfPixelOffset: 2 # Distance is less blurry, game has reduced LOD so it will still look blurry.
 SCUS-97153:
   name: "Vans Warped Tour '01 [Demo]"
@@ -10516,8 +9844,6 @@ SCUS-97164:
   region: "NTSC-U"
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes menu text brightness.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
     halfPixelOffset: 4 # Fixes misaligned blur during Darkside special.
 SCUS-97165:
   name: "Official U.S. PlayStation Magazine Demo Disc 051"
@@ -10533,8 +9859,6 @@ SCUS-97167:
     instantVU1: 0 # Fixes noodles.
     mtvu: 0
   gsHWFixes:
-    mipmap: 2 # Fixes missing floor texture.
-    trilinearFiltering: 1 # Fixes fog effect.
     wildArmsHack: 1 # Fixes misaligment depth of field effect.
 SCUS-97169:
   name: "Drakan - The Ancients' Gates [Demo]"
@@ -10544,8 +9868,6 @@ SCUS-97170:
   region: "NTSC-U"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves reflection quality.
-    mipmap: 2 # Fixes broken textures.
-    trilinearFiltering: 1 # Fixes water textures.
     cpuSpriteRenderBW: 4 # Fixes character and water textures.
     cpuSpriteRenderLevel: 2 # Needed for above.
     autoFlush: 2 # Fixes gate warp effect and emissive texture effects.
@@ -10554,8 +9876,6 @@ SCUS-97171:
   region: "NTSC-U"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves reflection quality.
-    mipmap: 2 # Fixes broken textures.
-    trilinearFiltering: 1 # Fixes water textures.
     cpuSpriteRenderBW: 4 # Fixes character and water textures.
     cpuSpriteRenderLevel: 2 # Needed for above.
     autoFlush: 2 # Fixes gate warp effect and emissive texture effects.
@@ -10581,8 +9901,6 @@ SCUS-97177:
   compat: 5
   gsHWFixes:
     autoFlush: 2 # Fixes speed effect intensity.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SCUS-97178:
   name: "NFL GameDay 2002"
   region: "NTSC-U"
@@ -10592,8 +9910,6 @@ SCUS-97179:
   compat: 5
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes menu text brightness.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
     halfPixelOffset: 4 # Fixes misaligned blur during Darkside special.
 SCUS-97181:
   name: "Official U.S. PlayStation Magazine Demo Disc 055"
@@ -10639,8 +9955,6 @@ SCUS-97195:
   region: "NTSC-U"
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes menu text brightness.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
     halfPixelOffset: 4 # Fixes misaligned blur during Darkside special.
 SCUS-97196:
   name: "Twisted Metal - Black ONLINE"
@@ -10648,16 +9962,11 @@ SCUS-97196:
   compat: 5
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes menu text brightness.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
     halfPixelOffset: 4 # Fixes misaligned blur during Darkside special.
 SCUS-97197:
   name: "War of the Monsters"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
-    trilinearFiltering: 1
 SCUS-97198:
   name: "Sly Cooper and the Thievius Raccoonus"
   region: "NTSC-U"
@@ -10670,9 +9979,6 @@ SCUS-97199:
   compat: 5
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SCUS-97200:
   name: "Kiosk Demo Disc 2.05"
   region: "NTSC-U"
@@ -10714,9 +10020,6 @@ SCUS-97209:
   region: "NTSC-U"
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SCUS-97210:
   name: "Sly Cooper and the Thievius Raccoonus [Demo]"
   region: "NTSC-U"
@@ -10726,9 +10029,6 @@ SCUS-97211:
   name: "ATV Offroad Fury 2"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SCUS-97212:
   name: "My Street"
   region: "NTSC-U"
@@ -10759,8 +10059,6 @@ SCUS-97217:
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes broken player rendering and skin flashing.
     cpuSpriteRenderLevel: 2 # Needed for above.
-    mipmap: 2 # Mipmap + trilinear, needed for player textures and court textures.
-    trilinearFiltering: 1
 SCUS-97218:
   name: "Kiosk Demo Disc 2.06"
   region: "NTSC-U"
@@ -10769,8 +10067,6 @@ SCUS-97219:
   region: "NTSC-U"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
   memcardFilters:
     - "SCUS-97219"
@@ -10826,8 +10122,6 @@ SCUS-97231:
   compat: 5
   gsHWFixes:
     textureInsideRT: 1 # Fixes on screen garbage.
-    mipmap: 2 # Mipmap + trilinear, corrects the depth of field effect.
-    trilinearFiltering: 1
 SCUS-97232:
   name: "Getaway [Demo]"
   region: "NTSC-U"
@@ -10835,8 +10129,6 @@ SCUS-97232:
     textureInsideRT: 1
     texturePreloading: 1 # Performs much better with partial preload.
     halfPixelOffset: 2 # Fixes outlines around characters.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SCUS-97233:
   name: "World Tour Soccer 2003"
   region: "NTSC-U"
@@ -10852,9 +10144,6 @@ SCUS-97236:
 SCUS-97238:
   name: "ATV Offroad Fury 2 [Demo]"
   region: "NTSC-U"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SCUS-97239:
   name: "Jet X2O [Demo]"
   region: "NTSC-U"
@@ -10865,9 +10154,6 @@ SCUS-97240:
     - EETimingHack # Fixes SPR errors while going in-game.
   roundModes:
     eeRoundMode: 0 # Fixes Hydrodisplacer behaviour.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SCUS-97241:
   name: "Official U.S. PlayStation Magazine Demo Disc 066"
   region: "NTSC-U"
@@ -10912,8 +10198,6 @@ SCUS-97253:
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes broken player rendering and skin flashing.
     cpuSpriteRenderLevel: 2 # Needed for above.
-    mipmap: 2 # Mipmap + trilinear, needed for player textures and court textures.
-    trilinearFiltering: 1
 SCUS-97256:
   name: "MLB 2004"
   region: "NTSC-U"
@@ -10930,9 +10214,6 @@ SCUS-97259:
 SCUS-97260:
   name: "War of the Monsters [Demo]"
   region: "NTSC-U"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
-    trilinearFiltering: 1
 SCUS-97261:
   name: "Kiosk Demo Disc 2.08"
   region: "NTSC-U"
@@ -10952,8 +10233,6 @@ SCUS-97264:
     autoFlush: 2 # Fixes lights going through walls.
     preloadFrameData: 1 # Fixes light flicker.
     halfPixelOffset: 2 # Corrects light position.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
   gameFixes:
     - EETimingHack # Fixes random hangs.
   patches:
@@ -10968,8 +10247,6 @@ SCUS-97265:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    mipmap: 2 # Fixes broken textures.
-    trilinearFiltering: 1 # Fixes water textures.
     cpuSpriteRenderBW: 4 # Fixes character and water textures.
     cpuSpriteRenderLevel: 2 # Needed for above.
     autoFlush: 2 # Fixes lighting.
@@ -10984,8 +10261,6 @@ SCUS-97268:
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     autoFlush: 2
   memcardFilters:
     - "SCUS-97268"
@@ -11007,8 +10282,6 @@ SCUS-97273:
   name: "Jak II [Demo]"
   region: "NTSC-U"
   gsHWFixes:
-    mipmap: 2 # Fixes broken textures.
-    trilinearFiltering: 1 # Fixes water textures.
     cpuSpriteRenderBW: 4 # Fixes character and water textures.
     cpuSpriteRenderLevel: 2 # Needed for above.
     autoFlush: 2 # Fixes lighting.
@@ -11024,9 +10297,6 @@ SCUS-97275:
   gameFixes:
     - VIF1StallHack # Fixes broken HUD.
     - InstantDMAHack # Fixes texture corruption.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SCUS-97276:
   name: "NFL GameDay 2004"
   region: "NTSC-U"
@@ -11052,8 +10322,6 @@ SCUS-97282:
   region: "NTSC-U"
   gsHWFixes:
     textureInsideRT: 1 # Fixes on screen garbage.
-    mipmap: 2 # Mipmap + trilinear, corrects the depth of field effect.
-    trilinearFiltering: 1
 SCUS-97292:
   name: "Amplitude [Demo]"
   region: "NTSC-U"
@@ -11081,8 +10349,6 @@ SCUS-97318:
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes broken player rendering and skin flashing.
     cpuSpriteRenderLevel: 2 # Needed for above.
-    mipmap: 2 # Mipmap + trilinear, needed for player textures and court textures.
-    trilinearFiltering: 1
 SCUS-97319:
   name: "EyeToy - Play"
   region: "NTSC-U"
@@ -11096,8 +10362,6 @@ SCUS-97322:
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     autoFlush: 2
 SCUS-97323:
   name: "Ratchet & Clank 2 - Going Commando [Retail Employees Demo]"
@@ -11105,8 +10369,6 @@ SCUS-97323:
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     autoFlush: 2
 SCUS-97324:
   name: "Kiosk Demo Disc 2.11"
@@ -11117,8 +10379,6 @@ SCUS-97325:
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes broken player rendering and skin flashing.
     cpuSpriteRenderLevel: 2 # Needed for above.
-    mipmap: 2 # Mipmap + trilinear, needed for player textures and court textures.
-    trilinearFiltering: 1
 SCUS-97326:
   name: "MLB 2005"
   region: "NTSC-U"
@@ -11133,8 +10393,6 @@ SCUS-97328:
     vuClampMode: 2 # Text in GT mode works.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
   memcardFilters: # Allows car imports from GT3 or something.
@@ -11148,8 +10406,6 @@ SCUS-97329:
   region: "NTSC-U"
   gsHWFixes:
     autoFlush: 2 # Fixes speed effect intensity.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SCUS-97330:
   name: "Jak 3"
   region: "NTSC-U"
@@ -11157,8 +10413,6 @@ SCUS-97330:
   gameFixes:
     - InstantDMAHack # Fixes holes in face geometry.
   gsHWFixes:
-    mipmap: 2 # Fixes broken textures.
-    trilinearFiltering: 1 # Fixes water textures.
     cpuSpriteRenderBW: 4 # Fixes character and water textures.
     cpuSpriteRenderLevel: 2 # Needed for above.
     autoFlush: 2 # Fixes lighting.
@@ -11216,8 +10470,6 @@ SCUS-97353:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves color and luminosity of surfaces.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     disablePartialInvalidation: 1 # Prevents the situation that a level (Aquatos) doesn't render characters and geometry.
     halfPixelOffset: 2 # Fixes misaligned bloom.
     autoFlush: 2 # Helps fix misaligned bloom.
@@ -11256,9 +10508,6 @@ SCUS-97366:
   gameFixes:
     - VIF1StallHack # Fixes broken HUD.
     - InstantDMAHack # Fixes texture corruption.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SCUS-97367:
   name: "Neopets - The Darkest Faerie"
   region: "NTSC-U"
@@ -11272,16 +10521,10 @@ SCUS-97368:
   gameFixes:
     - VIF1StallHack # Fixes broken HUD.
     - InstantDMAHack # Fixes texture corruption.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SCUS-97369:
   name: "ATV Offroad Fury 2"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SCUS-97370:
   name: "NCAA Final Four 2004"
   region: "NTSC-U"
@@ -11297,8 +10540,6 @@ SCUS-97374:
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
-    mipmap: 2 # Fixes broken textures.
-    trilinearFiltering: 1 # Fixes water textures.
     cpuSpriteRenderBW: 4 # Fixes character and water textures.
     cpuSpriteRenderLevel: 2 # Needed for above.
 SCUS-97377:
@@ -11308,8 +10549,6 @@ SCUS-97377:
     autoFlush: 2 # Fixes lights going through walls.
     preloadFrameData: 1 # Fixes light flicker.
     halfPixelOffset: 2 # Corrects light position.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SCUS-97378:
   name: "EyeToy and EyeToy Play [Demo]"
   region: "NTSC-U"
@@ -11317,9 +10556,6 @@ SCUS-97379:
   name: "Athens 2004"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SCUS-97380:
   name: "Final Fantasy XI - Online [Demo]"
   region: "NTSC-U"
@@ -11329,8 +10565,6 @@ SCUS-97381:
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     autoFlush: 2
 SCUS-97382:
   name: "NBA Shootout 2004 [Demo]"
@@ -11338,8 +10572,6 @@ SCUS-97382:
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes broken player rendering and skin flashing.
     cpuSpriteRenderLevel: 2 # Needed for above.
-    mipmap: 2 # Mipmap + trilinear, needed for player textures and court textures.
-    trilinearFiltering: 1
 SCUS-97383:
   name: "Kiosk Demo Disc 2.12"
   region: "NTSC-U"
@@ -11348,8 +10580,6 @@ SCUS-97384:
   region: "NTSC-U"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 SCUS-97392:
@@ -11389,9 +10619,6 @@ SCUS-97401:
   name: "Hot Shots Golf FORE!"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SCUS-97402:
   name: "Killzone"
   region: "NTSC-U"
@@ -11403,9 +10630,6 @@ SCUS-97402:
 SCUS-97403:
   name: "Athens 2004 [Demo]"
   region: "NTSC-U"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SCUS-97405:
   name: "ATV Offroad Fury 3"
   region: "NTSC-U"
@@ -11426,8 +10650,6 @@ SCUS-97408:
   gsHWFixes:
     textureInsideRT: 1
     halfPixelOffset: 2 # Fixes outlines on screen edges.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SCUS-97409:
   name: "Gretzky NHL 2005"
   region: "NTSC-U"
@@ -11443,8 +10665,6 @@ SCUS-97411:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves color and luminosity of surfaces.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     disablePartialInvalidation: 1 # Prevents the situation that a level (Aquatos) doesn't render characters and geometry.
     halfPixelOffset: 2 # Fixes misaligned bloom.
     autoFlush: 2 # Helps fix misaligned bloom.
@@ -11454,8 +10674,6 @@ SCUS-97412:
   gameFixes:
     - InstantDMAHack # Fixes holes in face geometry.
   gsHWFixes:
-    mipmap: 2 # Fixes broken textures.
-    trilinearFiltering: 1 # Fixes water textures.
     cpuSpriteRenderBW: 4 # Fixes character and water textures.
     cpuSpriteRenderLevel: 2 # Needed for above.
     autoFlush: 2 # Fixes lighting.
@@ -11466,8 +10684,6 @@ SCUS-97413:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves color and luminosity of surfaces.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     disablePartialInvalidation: 1 # Prevents the situation that a level (Aquatos) doesn't render characters and geometry.
     halfPixelOffset: 2 # Fixes misaligned bloom.
     autoFlush: 2 # Helps fix misaligned bloom.
@@ -11514,9 +10730,6 @@ SCUS-97425:
 SCUS-97427:
   name: "Hot Shots Golf FORE! [Online Public Beta]"
   region: "NTSC-U"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SCUS-97428:
   name: "Kiosk Demo Disc Q3-Q4 2004"
   region: "NTSC-U"
@@ -11527,8 +10740,6 @@ SCUS-97429:
   gsHWFixes:
     roundSprite: 1 # Fix lines in the sky.
     autoFlush: 2 # Fixes lighting.
-    mipmap: 2 # Fixes broken textures.
-    trilinearFiltering: 1 # Fixes water textures.
     cpuSpriteRenderBW: 2 # Fixes water textures. Can't use BW 4 here because of post effects.
     cpuSpriteRenderLevel: 2 # Needed for above.
     textureInsideRT: 1 # Fixes broken character models.
@@ -11538,9 +10749,6 @@ SCUS-97429:
 SCUS-97430:
   name: "Hot Shots Golf FORE! [Regular Demo]"
   region: "NTSC-U"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SCUS-97431:
   name: "Killzone Public Beta V1.0"
   region: "NTSC-U"
@@ -11562,8 +10770,6 @@ SCUS-97436:
     vuClampMode: 2 # Text in GT mode works.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
   memcardFilters:
@@ -11577,9 +10783,6 @@ SCUS-97437:
   region: "NTSC-U"
   speedHacks:
     mtvu: 0 # Increases FPS drastically.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SCUS-97438:
   name: "EyeToy - Antigrav [Demo]"
   region: "NTSC-U"
@@ -11587,8 +10790,6 @@ SCUS-97440:
   name: "Jak and Daxter Trilogy [Demo]"
   region: "NTSC-U"
   gsHWFixes:
-    mipmap: 2 # Fixes broken textures.
-    trilinearFiltering: 1 # Fixes water textures.
     cpuSpriteRenderBW: 4 # Fixes character and water textures.
     cpuSpriteRenderLevel: 2 # Needed for above.
     autoFlush: 2 # Fixes lighting.
@@ -11598,8 +10799,6 @@ SCUS-97441:
   gsHWFixes:
     textureInsideRT: 1
     halfPixelOffset: 2 # Fixes outlines on screen edges.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SCUS-97442:
   name: "Official U.S. PlayStation Magazine Demo Disc 090"
   region: "NTSC-U"
@@ -11677,8 +10876,6 @@ SCUS-97465:
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     disablePartialInvalidation: 1 # Prevents world geometry and some models from vanishing when pausing or opening vendor.
     halfPixelOffset: 2 # Fixes misaligned bloom.
     autoFlush: 2 # Helps fix misaligned bloom.
@@ -11709,8 +10906,6 @@ SCUS-97472:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    mipmap: 2 # Fixes Water with Trilinear.
-    trilinearFiltering: 1 # Fixes Water with Mipmap (Full).
     halfPixelOffset: 1 # Fixes misalignments and borders on side.
   memcardFilters:
     - "SCUS-97472"
@@ -11728,8 +10923,6 @@ SCUS-97474:
     vuClampMode: 3 # Fixes SPS ingame and prevents flickering or invisible characters.
   gsHWFixes:
     minimumBlendingLevel: 4 # Mitigates grayer text font in bottom left.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
   patches:
     75ED4282:
       content: |-
@@ -11747,8 +10940,6 @@ SCUS-97475:
     vuClampMode: 3 # Fixes SPS ingame and prevents flickering or invisible characters.
   gsHWFixes:
     minimumBlendingLevel: 4 # Mitigates grayer text font in bottom left.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
   patches:
     314F0905:
       content: |-
@@ -11764,9 +10955,6 @@ SCUS-97479:
   name: "ATV Offroad Fury 4"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SCUS-97481:
   name: "God of War II"
   region: "NTSC-U"
@@ -11778,8 +10966,6 @@ SCUS-97481:
     halfPixelOffset: 2 # Fixes misaligned bloom.
     roundSprite: 1 # Fixes chromatic effect.
     autoFlush: 1 # Fixes sun occlusion.
-    mipmap: 2 # Mipmap + trilinear, fixes miptrick textures to match sw renderer.
-    trilinearFiltering: 1
 SCUS-97482:
   name: "God of War II - The Colossus Battle [Demo]"
   region: "NTSC-U"
@@ -11790,8 +10976,6 @@ SCUS-97482:
     halfPixelOffset: 2 # Fixes misaligned bloom.
     roundSprite: 1 # Fixes chromatic effect.
     autoFlush: 1 # Fixes sun occlusion.
-    mipmap: 2 # Mipmap + trilinear, fixes miptrick textures to match sw renderer.
-    trilinearFiltering: 1
 SCUS-97483:
   name: "Gran Turismo 4 MX-5 Edition [Demo]"
   region: "NTSC-U"
@@ -11799,8 +10983,6 @@ SCUS-97483:
     vuClampMode: 2 # Text in GT mode works.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 SCUS-97484:
@@ -11818,8 +11000,6 @@ SCUS-97485:
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     disablePartialInvalidation: 1 # Prevents world geometry and some models from vanishing when pausing or opening vendor.
     halfPixelOffset: 2 # Fixes misaligned bloom.
     autoFlush: 2 # Helps fix misaligned bloom.
@@ -11829,8 +11009,6 @@ SCUS-97486:
   gsHWFixes:
     roundSprite: 1 # Fix lines in the sky.
     autoFlush: 2 # Fixes lighting.
-    mipmap: 2 # Fixes broken textures.
-    trilinearFiltering: 1 # Fixes water textures.
     cpuSpriteRenderBW: 2 # Fixes water textures. Can't use BW 4 here because of post effects.
     cpuSpriteRenderLevel: 2 # Needed for above.
     textureInsideRT: 1 # Fixes broken character models.
@@ -11840,8 +11018,6 @@ SCUS-97487:
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     disablePartialInvalidation: 1 # Prevents world geometry and some models from vanishing when pausing or opening vendor.
     halfPixelOffset: 2 # Fixes misaligned bloom.
     autoFlush: 2 # Helps fix misaligned bloom.
@@ -11852,8 +11028,6 @@ SCUS-97488:
   gsHWFixes:
     roundSprite: 1 # Fix lines in the sky.
     autoFlush: 2 # Fixes lighting.
-    mipmap: 2 # Fixes broken textures.
-    trilinearFiltering: 1 # Fixes water textures.
     cpuSpriteRenderBW: 2 # Fixes water textures. Can't use BW 4 here because of post effects.
     cpuSpriteRenderLevel: 2 # Needed for above.
     textureInsideRT: 1 # Fixes broken character models.
@@ -11866,8 +11040,6 @@ SCUS-97489:
     vuClampMode: 3 # Fixes SPS ingame and prevents flickering or invisible characters.
   gsHWFixes:
     minimumBlendingLevel: 4 # Mitigates grayer text font in bottom left.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SCUS-97490:
   name: "Rogue Galaxy"
   region: "NTSC-U"
@@ -11915,8 +11087,6 @@ SCUS-97501:
     - SoftwareRendererFMVHack # Fixes interlacing.
   gsHWFixes:
     preloadFrameData: 1 # Fixes black background in the pause menu.
-    mipmap: 2 # Fixes miptrick texture effects.
-    trilinearFiltering: 1 # Fixes miptrick blending.
     halfPixelOffset: 2 # Fixes misaligned blur.
     autoFlush: 2 # Fixes corruption in cutscenes and brightens the image.
 SCUS-97502:
@@ -11937,8 +11107,6 @@ SCUS-97505:
   name: "Shadow of the Colossus [Demo]"
   region: "NTSC-U"
   gsHWFixes:
-    mipmap: 2 # Fixes Water with Trilinear.
-    trilinearFiltering: 1 # Fixes Water with Mipmap (Full).
     halfPixelOffset: 1 # Fixes misalignments and borders on side.
 SCUS-97506:
   name: "Gretzky NHL '06 [Demo]"
@@ -11950,17 +11118,12 @@ SCUS-97509:
   name: "Jak II [Greatest Hits]"
   region: "NTSC-U"
   gsHWFixes:
-    mipmap: 2 # Fixes broken textures.
-    trilinearFiltering: 1 # Fixes water textures.
     cpuSpriteRenderBW: 4 # Fixes character and water textures.
     cpuSpriteRenderLevel: 2 # Needed for above.
     autoFlush: 2 # Fixes lighting.
 SCUS-97510:
   name: "ATV Offroad Fury 2 [Greatest Hits]"
   region: "NTSC-U"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SCUS-97511:
   name: "SOCOM II - U.S. Navy SEALs [Greatest Hits]"
   region: "NTSC-U"
@@ -11968,9 +11131,6 @@ SCUS-97511:
   gameFixes:
     - VIF1StallHack # Fixes broken HUD.
     - InstantDMAHack # Fixes texture corruption.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SCUS-97512:
   name: "Gran Turismo 3 - A-Spec [Greatest Hits]"
   region: "NTSC-U"
@@ -11979,8 +11139,6 @@ SCUS-97512:
     - "SCUS-97102"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
-    mipmap: 2 # Mipmap + trilinear, improves track textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 SCUS-97513:
   name: "Ratchet & Clank 2 - Going Commando [Greatest Hits]"
@@ -11988,8 +11146,6 @@ SCUS-97513:
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     autoFlush: 2
   memcardFilters:
     - "SCUS-97513"
@@ -11999,23 +11155,15 @@ SCUS-97514:
   region: "NTSC-U"
   speedHacks:
     mtvu: 0 # Increases FPS drastically.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SCUS-97515:
   name: "Hot Shots Golf FORE! [Greatest Hits]"
   region: "NTSC-U"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SCUS-97516:
   name: "Jak 3 [Greatest Hits]"
   region: "NTSC-U"
   gameFixes:
     - InstantDMAHack # Fixes holes in face geometry.
   gsHWFixes:
-    mipmap: 2 # Fixes broken textures.
-    trilinearFiltering: 1 # Fixes water textures.
     cpuSpriteRenderBW: 4 # Fixes character and water textures.
     cpuSpriteRenderLevel: 2 # Needed for above.
     autoFlush: 2 # Fixes lighting.
@@ -12033,8 +11181,6 @@ SCUS-97518:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves color and luminosity of surfaces.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     disablePartialInvalidation: 1 # Prevents the situation that a level (Aquatos) doesn't render characters and geometry.
     halfPixelOffset: 2 # Fixes misaligned bloom.
     autoFlush: 2 # Helps fix misaligned bloom.
@@ -12055,8 +11201,6 @@ SCUS-97520:
     autoFlush: 2 # Fixes lights going through walls.
     preloadFrameData: 1 # Fixes light flicker.
     halfPixelOffset: 2 # Corrects light position.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SCUS-97523:
   name: "EyeToy - Operation Spy!"
   region: "NTSC-U"
@@ -12136,8 +11280,6 @@ SCUS-97548:
     - SoftwareRendererFMVHack # Fixes interlacing.
   gsHWFixes:
     preloadFrameData: 1 # Fixes black background in the pause menu.
-    mipmap: 2 # Fixes miptrick texture effects.
-    trilinearFiltering: 1 # Fixes miptrick blending.
     halfPixelOffset: 2 # Fixes misaligned blur.
     autoFlush: 2 # Fixes corruption in cutscenes and brightens the image.
 SCUS-97553:
@@ -12152,8 +11294,6 @@ SCUS-97555:
   name: "Jak and Daxter Complete Trilogy [Demo]"
   region: "NTSC-U"
   gsHWFixes:
-    mipmap: 2 # Fixes broken textures.
-    trilinearFiltering: 1 # Fixes water textures.
     cpuSpriteRenderBW: 4 # Fixes character and water textures.
     cpuSpriteRenderLevel: 2 # Needed for above.
 SCUS-97556:
@@ -12169,12 +11309,10 @@ SCUS-97558:
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes object glow.
     roundSprite: 1 # Fix lines in the sky.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     autoFlush: 2 # Fixes shadow definition.
     cpuSpriteRenderBW: 4 # Fixes shadow rendering.
     cpuSpriteRenderLevel: 2 # Needed for above.
-    bilinearUpscale: 1 # Smoothes out shadow textures.
+    bilinearUpscale: 1 # Smooths out shadow textures.
 SCUS-97560:
   name: "SOCOM - U.S. Navy SEALs - Combined Assault [Demo]"
   region: "NTSC-U"
@@ -12190,8 +11328,6 @@ SCUS-97563:
   clampModes:
     vuClampMode: 2 # Text in GT mode works.
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post processing.
 SCUS-97564:
@@ -12221,17 +11357,12 @@ SCUS-97574:
   gsHWFixes:
     roundSprite: 1 # Fix lines in the sky.
     autoFlush: 2 # Fixes lighting.
-    mipmap: 2 # Fixes broken textures.
-    trilinearFiltering: 1 # Fixes water textures.
     cpuSpriteRenderBW: 2 # Fixes water textures. Can't use BW 4 here because of post effects.
     cpuSpriteRenderLevel: 2 # Needed for above.
     textureInsideRT: 1 # Fixes broken character models.
 SCUS-97579:
   name: "ATV Offroad Fury 4 [Demo]"
   region: "NTSC-U"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SCUS-97580:
   name: "SingStar Pop"
   region: "NTSC-U"
@@ -12288,9 +11419,6 @@ SCUS-97610:
   compat: 5
   roundModes:
     vu1RoundMode: 1 # Fixes the display of scores and text ingame.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves court textures to match sw renderer.
-    trilinearFiltering: 1
 SCUS-97611:
   name: "SingStar Amped"
   region: "NTSC-U"
@@ -12304,8 +11432,6 @@ SCUS-97615:
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes vendor and other bloom.
     autoFlush: 2 # Fixes missing bloom and shadow definition.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SCUS-97616:
   name: "SingStar 80's"
   region: "NTSC-U"
@@ -12318,9 +11444,6 @@ SCUS-97619:
   region: "NTSC-U"
   roundModes:
     vu1RoundMode: 1 # Fixes the display of scores and text ingame.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves court textures to match sw renderer.
-    trilinearFiltering: 1
 SCUS-97620:
   name: "Syphon Filter - Dark Mirror [Demo]"
   region: "NTSC-U"
@@ -12357,8 +11480,6 @@ SCUS-97623:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misaligned bloom.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SCUS-97625:
   name: "NBA 09 - The Inside"
   region: "NTSC-U"
@@ -12420,8 +11541,6 @@ SCUS-97657:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves crowd textures.
-    trilinearFiltering: 1
     textureInsideRT: 1 # Needed for mipmapping to function correctly.
 SCUS-97660:
   name: "SingStar Latino"
@@ -12519,8 +11638,6 @@ SLAJ-25031:
   name: "Kunoichi - Shinobu"
   region: "NTSC-C-J"
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_Kunoichi"
 SLAJ-25033:
   name: "Puyo Puyo Fever"
@@ -12573,8 +11690,6 @@ SLAJ-25047:
   region: "NTSC-C-J"
   gsHWFixes:
     minimumBlendingLevel: 2 # Fixes dark font to more bright like software mode.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLAJ-25048:
   name: "Sengoku Musou Moushouden"
   region: "NTSC-Unk"
@@ -12587,8 +11702,6 @@ SLAJ-25051:
   region: "NTSC-C"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLAJ-25052:
   name: "The Urbz - Sims in the City"
   name-sort: "Urbz, The - Sims in the City"
@@ -12604,8 +11717,6 @@ SLAJ-25053:
     recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 2 # Fixes blur and obscures sun behind objects.
-    mipmap: 2 # Fixes over sharpening.
-    trilinearFiltering: 1 # Smoothes out mipmapping.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     bilinearUpscale: 2 # Smooths out sun glare textures like native.
     getSkipCount: "GSC_BurnoutGames"
@@ -12631,15 +11742,9 @@ SLAJ-25060:
 SLAJ-25063:
   name: "Shin Sangoku Musou 4"
   region: "NTSC-Unk"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLAJ-25064:
   name: "MVP Baseball 2005"
   region: "NTSC-Unk"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLAJ-25066:
   name: "Burnout Revenge - Battle Racing Ignited"
   region: "NTSC-Unk"
@@ -12649,8 +11754,6 @@ SLAJ-25066:
     recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 2 # Fixes blur and obscures sun behind objects.
-    mipmap: 2 # Fixes over sharpening.
-    trilinearFiltering: 1 # Smoothes out mipmapping.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     bilinearUpscale: 2 # Smooths out sun glare textures like native.
     getSkipCount: "GSC_BurnoutGames"
@@ -12674,8 +11777,6 @@ SLAJ-25072:
   name-sort: "Matrix, The - Path of Neo"
   region: "NTSC-Unk"
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     halfPixelOffset: 2 # Fix effects upscaling.
     autoFlush: 1 # Fixes broken post processing.
 SLAJ-25073:
@@ -12685,8 +11786,6 @@ SLAJ-25073:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLAJ-25075:
   name: "Need for Speed - Most Wanted [Black Edition]"
   region: "NTSC-Unk"
@@ -12695,8 +11794,6 @@ SLAJ-25075:
     halfPixelOffset: 2 # Fixes blurriness.
     cpuCLUTRender: 1 # Final colour adjustment LUT.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
   memcardFilters:
     - "SLAJ-25075"
     - "SLPM-66232"
@@ -12735,8 +11832,6 @@ SLAJ-25078:
     recommendedBlendingLevel: 4 # Improves lighting on buildings and objects.
     autoFlush: 2 # Properly diffuses light instead of strips of light.
     roundSprite: 1 # Fixes lighting misalignment such as the street poles and the sun.
-    mipmap: 2 # Fixes over sharpening.
-    trilinearFiltering: 1 # Smoothes out mipmapping.
     getSkipCount: "GSC_BlackAndBurnoutSky"
     beforeDraw: "OI_BurnoutGames"
 SLAJ-25079:
@@ -12747,16 +11842,11 @@ SLAJ-25080:
   name-sort: "Godfather, The"
   region: "NTSC-Unk"
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
-    trilinearFiltering: 1
     textureInsideRT: 1 # Required for complex offset shuffles.
     halfPixelOffset: 2 # Fixes center line in post processing.
 SLAJ-25081:
   name: "FIFA World Cup - Germany 2006"
   region: "NTSC-Unk"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLAJ-25084:
   name: "Sengoku Musou 2 - Empires"
   region: "NTSC-Unk"
@@ -12771,8 +11861,6 @@ SLAJ-25088:
   region: "NTSC-Unk"
   gsHWFixes:
     halfPixelOffset: 2 # Reduces blurriness.
-    mipmap: 2 # Cleans up texture detail.
-    trilinearFiltering: 1 # Smoothes out mipmapping.
 SLAJ-25091:
   name: "Need for Speed - Carbon [Collector's Edition]"
   region: "NTSC-J"
@@ -12783,9 +11871,6 @@ SLAJ-25091:
 SLAJ-25092:
   name: "Shin Sangoku Musou 4 [PlayStation 2 the Best]"
   region: "NTSC-Unk"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLAJ-25093:
   name: "Sangoku Musou [PlayStation 2 the Best]"
   region: "NTSC-Unk"
@@ -12798,8 +11883,6 @@ SLAJ-25094:
     recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 2 # Fixes blur and obscures sun behind objects.
-    mipmap: 2 # Fixes over sharpening.
-    trilinearFiltering: 1 # Smoothes out mipmapping.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     bilinearUpscale: 2 # Smooths out sun glare textures like native.
     getSkipCount: "GSC_BurnoutGames"
@@ -12810,8 +11893,6 @@ SLAJ-25095:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes lighting misalignment.
     mergeSprite: 1 # Removes occasional vertical lines.
-    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
-    trilinearFiltering: 1
 SLAJ-25096:
   name: "Musou Orochi"
   region: "NTSC-Unk"
@@ -12855,8 +11936,6 @@ SLED-50117:
     - InstantDMAHack # Fixes broken half-bottom artifacts.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLED-50286:
   name: "Red Faction [Demo]"
   region: "PAL-E"
@@ -12891,8 +11970,6 @@ SLED-50489:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     cpuSpriteRenderBW: 4 # Fixes textures.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLED-50587:
   name: "Top Gun - Combat Zones [Demo]"
   region: "PAL-E"
@@ -12901,8 +11978,6 @@ SLED-50617:
   region: "PAL-E"
   gsHWFixes:
     autoFlush: 1 # Fixes missing blur layer on sky.
-    mipmap: 2 # Mipmap + trilinear, improves road textures to match sw renderer.
-    trilinearFiltering: 1
 SLED-50762:
   name: "Maximo [Demo]"
   region: "PAL-E"
@@ -12927,8 +12002,6 @@ SLED-51012:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     cpuSpriteRenderBW: 4 # Fixes textures.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLED-51047:
   name: "Red Faction II"
   region: "PAL-Unk"
@@ -12961,8 +12034,6 @@ SLED-51211:
     autoFlush: 1 # Fixes bloom and sun rendering in front of everything.
     halfPixelOffset: 2 # Aligns bloom effect a little bit better when upscaled.
     bilinearUpscale: 2 # Reduces color banding of the sun glare.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
   roundModes:
     vu1RoundMode: 1 # Bright lights in cars.
 SLED-51212:
@@ -12984,8 +12055,6 @@ SLED-51281:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
     alignSprite: 1 # Fixes vertical lines.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLED-51338:
   name: "Tom Clancy's Ghost Recon"
   region: "PAL-Unk"
@@ -13001,8 +12070,6 @@ SLED-51364:
   region: "PAL-E"
   gsHWFixes:
     recommendedBlendingLevel: 2 # Fixes dither patterns.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLED-51380:
   name: "Zone of the Enders - The 2nd Runner [Demo]"
   region: "PAL-E"
@@ -13017,17 +12084,11 @@ SLED-51645:
 SLED-51651:
   name: "Starsky & Hutch"
   region: "PAL-E"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves building textures.
-    trilinearFiltering: 1
 SLED-51676:
   name: "Warhammer 40,000 - Fire Warrior [Demo]"
   region: "PAL"
   gameFixes:
     - XGKickHack # Fixes corrupted graphics.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLED-51807:
   name: "Summer Heat Beach Volleyball"
   region: "PAL-Unk"
@@ -13049,8 +12110,6 @@ SLED-51902:
     halfPixelOffset: 3 # Fixes double image.
     gpuTargetCLUT: 1 # Fixes sun penetrating buildings.
     autoFlush: 1 # Fixes sun occlusion.
-    mipmap: 2 # Fixes miptrick texture effects.
-    trilinearFiltering: 1 # Fixes miptrick blending.
 SLED-51921:
   name: "Final Fantasy X-2 [Demo]"
   region: "PAL-Unk"
@@ -13110,15 +12169,11 @@ SLED-52325:
   region: "PAL-E"
   gsHWFixes:
     autoFlush: 2 # Fixes speed effect intensity.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLED-52326:
   name: "007 - Everything or Nothing [Demo]"
   region: "PAL-E"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes lines in cutscenes.
-    mipmap: 2 # Cleans up texture detail.
-    trilinearFiltering: 1 # Smoothes out mipmapping.
 SLED-52375:
   name: "Fight Night 2004 [Demo]"
   region: "PAL-E"
@@ -13190,8 +12245,6 @@ SLED-52597:
     recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 2 # Fixes blur and obscures sun behind objects.
-    mipmap: 2 # Fixes over sharpening.
-    trilinearFiltering: 1 # Smoothes out mipmapping.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     bilinearUpscale: 2 # Smooths out sun glare textures like native.
     getSkipCount: "GSC_BurnoutGames"
@@ -13212,8 +12265,6 @@ SLED-52852:
   gsHWFixes:
     halfPixelOffset: 1 # Reduces ghosting.
     roundSprite: 1 # Reduces ghosting even more.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLED-52873:
   name: "Pro Evolution Soccer 4"
   region: "PAL-Unk"
@@ -13250,8 +12301,6 @@ SLED-52979:
   region: "PAL-E"
   gsHWFixes:
     autoFlush: 2 # Fixes missing lighting.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     # halfPixelOffset: 1 # Fixes lighting misalignment. Do not enable this, it breaks a lot of graphics.
 SLED-53066:
   name: "TimeSplitters - Future Perfect"
@@ -13322,8 +12371,6 @@ SLED-53442:
     PCRTCOverscan: 1 # Fixes offscreen image.
     nativePaletteDraw: 1 # Fixes the look of screen effects.
     halfPixelOffset: 2 # Corrects the alignment of screen effects.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLED-53445:
   name: "The Incredible Hulk - Ultimate Destruction [Demo]"
   name-sort: "Incredible Hulk, The - Ultimate Destruction [Demo]"
@@ -13333,8 +12380,6 @@ SLED-53445:
   gsHWFixes:
     nativePaletteDraw: 1 # Fixes lines in certain effects when upscaled.
     halfPixelOffset: 2 # Fixes offset bloom.
-    mipmap: 2 # Mipmap + trilinear, fixes textures.
-    trilinearFiltering: 1
 SLED-53512:
   name: "Burnout Revenge [Demo]"
   region: "PAL-E"
@@ -13345,8 +12390,6 @@ SLED-53512:
     recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 2 # Fixes blur and obscures sun behind objects.
-    mipmap: 2 # Fixes over sharpening.
-    trilinearFiltering: 1 # Smoothes out mipmapping.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     bilinearUpscale: 2 # Smooths out sun glare textures like native.
     getSkipCount: "GSC_BurnoutGames"
@@ -13358,8 +12401,6 @@ SLED-53537:
     recommendedBlendingLevel: 4 # Improves car color.
     autoFlush: 1 # Softens bloom on objects and cars.
     halfPixelOffset: 4 # Fixes misaligned bloom on objects and cars.
-    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
-    trilinearFiltering: 1
 SLED-53543:
   name: "Tiger Woods PGA Tour 06"
   region: "PAL-Unk"
@@ -13374,8 +12415,6 @@ SLED-53625:
   region: "PAL-E"
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes missing lighting and makes snow not look like snow sludge.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLED-53627:
   name: "The Suffering - Ties that Bind"
   region: "PAL-Unk"
@@ -13388,8 +12427,6 @@ SLED-53637:
     recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 2 # Fixes blur and obscures sun behind objects.
-    mipmap: 2 # Fixes over sharpening.
-    trilinearFiltering: 1 # Smoothes out mipmapping.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     bilinearUpscale: 2 # Smooths out sun glare textures like native.
     getSkipCount: "GSC_BurnoutGames"
@@ -13402,8 +12439,6 @@ SLED-53650:
     halfPixelOffset: 2 # Fixes blurriness.
     cpuCLUTRender: 1 # Final colour adjustment LUT.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLED-53664:
   name: "FIFA 06 - Demo Pre-Release Version"
   region: "PAL-Unk"
@@ -13415,8 +12450,6 @@ SLED-53673:
   gsHWFixes:
     textureInsideRT: 1 # Required for complex offset shuffles.
     halfPixelOffset: 2 # Fixes center upscaling line during explosions.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
     recommendedBlendingLevel: 4 # Fixes lighting.
 SLED-53681:
   name: "007 - From Russia with Love & Need for Speed Most Wanted & SSX On Tour [Demo]"
@@ -13446,8 +12479,6 @@ SLED-53731:
     autoFlush: 1 # Post-processing.
     halfPixelOffset: 2 # Offset post-processing.
     texturePreloading: 1 # Improves performance.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_Battlefield2" # Depth clear.
     beforeDraw: "OI_Battlefield2" # Framebuffer copy, fixes rendering for bottom part of screen.
 SLED-53732:
@@ -13464,15 +12495,11 @@ SLED-53770:
   region: "PAL-E"
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned textures.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLED-53845:
   name: "The Matrix - Path of Neo [Demo]"
   name-sort: "Matrix, The - Path of Neo [Demo]"
   region: "PAL-E"
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     halfPixelOffset: 2 # Fix effects upscaling.
     autoFlush: 1 # Fixes broken post processing.
 SLED-53888:
@@ -13487,8 +12514,6 @@ SLED-53937:
     recommendedBlendingLevel: 4 # Improves lighting on buildings and objects.
     autoFlush: 2 # Properly diffuses light instead of strips of light.
     roundSprite: 1 # Fixes lighting misalignment such as the street poles and the sun.
-    mipmap: 2 # Fixes over sharpening.
-    trilinearFiltering: 1 # Smoothes out mipmapping.
     getSkipCount: "GSC_BlackAndBurnoutSky"
     beforeDraw: "OI_BurnoutGames"
 SLED-53951:
@@ -13514,8 +12539,6 @@ SLED-53954:
     cpuCLUTRender: 1 # Fixes the rest of the bad textures.
     roundSprite: 1 # Reduces misaligned bloom.
     mergeSprite: 1 # Removes bloom explosion around electrical lights and other light sources such as moon/sun.
-    mipmap: 2 # Mipmap + trilinear, improves road textures to match sw renderer.
-    trilinearFiltering: 1
 SLED-53977:
   name: "Dragon Quest - The Journey of the Cursed King"
   region: "PAL-E"
@@ -13540,8 +12563,6 @@ SLED-54022:
   name: "Lara Croft Tomb Raider - Legend [Demo]"
   region: "PAL-E"
   gsHWFixes:
-    mipmap: 2 # Fixes distant characters and models.
-    trilinearFiltering: 1
     textureInsideRT: 1 # Needed for post processing effects.
     autoFlush: 1 # Fixes bloom intensity.
     minimumBlendingLevel: 4 # Fixes multiple lighting effects from lights, computers, cave walls and more.
@@ -13566,8 +12587,6 @@ SLED-54315:
   region: "PAL-M5"
   gsHWFixes:
     cpuCLUTRender: 1 # Fixes ghosting on objects and people.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLED-54327:
   name: "FIFA '07"
   region: "PAL-Unk"
@@ -13581,8 +12600,6 @@ SLED-54401:
   name: "Destroy All Humans 2 [Demo]"
   region: "PAL-E"
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     textureInsideRT: 1 # Fixes shadow maps.
     roundSprite: 2 # Fixes misaligned bloom.
     mergeSprite: 1 # Fixes misaligned bloom.
@@ -13665,9 +12682,6 @@ SLES-50021:
   region: "PAL-E"
   clampModes:
     vuClampMode: 3 # Missing geometry with microVU.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-50022:
   name: "NBA Live 2001"
   region: "PAL-E"
@@ -13705,8 +12719,6 @@ SLES-50031:
   compat: 5
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes character models.
-    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-50032:
   name: "Theme Park World"
   region: "PAL-M3"
@@ -13787,8 +12799,6 @@ SLES-50050:
   compat: 5
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes terrain color rendering.
-    mipmap: 2 # Mipmap + trilinear, fixes miptrick textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-50051:
   name: "Eternal Ring"
   region: "PAL-E"
@@ -13800,9 +12810,6 @@ SLES-50052:
   name: "Pool Master"
   region: "PAL-M3"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-50053:
   name: "Aqua Aqua - Wetrix 2"
   region: "PAL-M5"
@@ -13817,9 +12824,6 @@ SLES-50055:
   name: "Smuggler's Run"
   region: "PAL-E"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-50056:
   name: "Surfing H3O"
   region: "PAL-M3"
@@ -13839,9 +12843,6 @@ SLES-50061:
   name: "Smuggler's Run"
   region: "PAL-M5"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-50062:
   name: "Orphen - Scion of Sorcery"
   region: "PAL-E"
@@ -13873,8 +12874,6 @@ SLES-50073:
   gsHWFixes:
     textureInsideRT: 1
     roundSprite: 1 # Fixes font misalignment when upscaling.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-50074:
   name: "Unreal Tournament"
   region: "PAL-M5"
@@ -13902,8 +12901,6 @@ SLES-50079:
     eeClampMode: 2 # Fixes Abnormal AI behavior.
   gsHWFixes:
     textureInsideRT: 1 # Fixes texture corruption.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-50080:
   name: "NBA Hoopz"
   region: "PAL-M3"
@@ -13946,15 +12943,9 @@ SLES-50115:
 SLES-50118:
   name: "Tiger Woods PGA Tour 2001"
   region: "PAL-E"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-50119:
   name: "Tiger Woods PGA Tour 2001"
   region: "PAL-A"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-50120:
   name: "Rumble Racing"
   region: "PAL-M3"
@@ -13999,9 +12990,6 @@ SLES-50134:
   name: "Oni"
   region: "PAL-E"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
   patches:
     22E85E68:
       content: |-
@@ -14064,9 +13052,6 @@ SLES-50176:
   name: "Oni"
   region: "PAL-F"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
   patches:
     F77639F1:
       content: |-
@@ -14078,9 +13063,6 @@ SLES-50177:
   name: "Oni"
   region: "PAL-G"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
   patches:
     32629F36:
       content: |-
@@ -14091,9 +13073,6 @@ SLES-50177:
 SLES-50178:
   name: "Oni"
   region: "PAL-I"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
   patches:
     172B6971:
       content: |-
@@ -14104,9 +13083,6 @@ SLES-50178:
 SLES-50179:
   name: "Oni"
   region: "PAL-S"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
   patches:
     20F419E9:
       content: |-
@@ -14199,8 +13175,6 @@ SLES-50211:
   compat: 5
   gsHWFixes:
     recommendedBlendingLevel: 5 # Corrects lighting to match software.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-50212:
   name: "Paris-Dakar Rally"
   region: "PAL-E"
@@ -14224,15 +13198,9 @@ SLES-50215:
   compat: 5
   gameFixes:
     - EETimingHack # Fixes credits screen.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves road and building textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-50217:
   name: "Dave Mirra Freestyle BMX 2"
   region: "PAL-E-S"
-  gsHWFixes:
-    mipmap: 2 # Fixes noisy bumpy textures.
-    trilinearFiltering: 1 # Smoothes out mipmapping
 SLES-50218:
   name: "All-Star Baseball 2002"
   region: "PAL-E"
@@ -14474,8 +13442,6 @@ SLES-50288:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     cpuSpriteRenderBW: 4 # Fixes textures.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-50296:
   name: "Gift"
   region: "PAL-F"
@@ -14556,8 +13522,6 @@ SLES-50356:
     - VUSyncHack # Fixes flickering and missing textures.
   gsHWFixes:
     textureInsideRT: 1 # Fixes graphical corruption.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-50358:
   name: "Devil May Cry"
   region: "PAL-M5"
@@ -14619,8 +13583,6 @@ SLES-50383:
     - InstantDMAHack # Fixes broken half-bottom artifacts.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-50384:
   name: "Metal Gear Solid 2 - Sons of Liberty"
   region: "PAL-I"
@@ -14628,8 +13590,6 @@ SLES-50384:
     - InstantDMAHack # Fixes broken half-bottom artifacts.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-50385:
   name: "Metal Gear Solid 2 - Sons of Liberty"
   region: "PAL-S"
@@ -14637,8 +13597,6 @@ SLES-50385:
     - InstantDMAHack # Fixes broken half-bottom artifacts.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-50386:
   name: "Crash Bandicoot - The Wrath of Cortex"
   region: "PAL-M6"
@@ -14663,9 +13621,6 @@ SLES-50396:
 SLES-50397:
   name: "Prisoner of War"
   region: "PAL-M5"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-50398:
   name: "UEFA Champions League"
   region: "PAL-M5"
@@ -14695,9 +13650,6 @@ SLES-50422:
   region: "PAL-E"
   clampModes:
     vuClampMode: 3 # Missing geometry with microVU.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-50423:
   name: "F1 2001"
   region: "PAL-M4"
@@ -14769,8 +13721,6 @@ SLES-50445:
   compat: 5
   gsHWFixes:
     autoFlush: 1 # Fixes missing blur layer on sky.
-    mipmap: 2 # Mipmap + trilinear, improves road textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-50446:
   name: "Shadow Man - 2econd Coming"
   region: "PAL-M4"
@@ -14892,35 +13842,20 @@ SLES-50504:
   name: "Half-Life"
   region: "PAL-E"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-50505:
   name: "Half-Life"
   region: "PAL-G"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-50507:
   name: "Half-Life"
   region: "PAL-F"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-50508:
   name: "Half-Life"
   region: "PAL-I"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-50509:
   name: "Half-Life"
   region: "PAL-S"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-50510:
   name: "The Mummy Returns"
   name-sort: "Mummy Returns, The"
@@ -14976,8 +13911,6 @@ SLES-50545:
     eeRoundMode: 0 # Fixes riders vanish into the floor.
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes missing lighting and makes snow not look like snow sludge.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-50546:
   name: "LMA Manager 2002"
   region: "PAL-E"
@@ -15036,9 +13969,6 @@ SLES-50570:
 SLES-50572:
   name: "Robot Wars - Arenas of Destruction"
   region: "PAL-E"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-50575:
   name: "Dark Summit"
   region: "PAL-M3"
@@ -15099,8 +14029,6 @@ SLES-50592:
   region: "PAL-M5"
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes missing lighting.
-    mipmap: 2 # Fixes miptrick texture effects.
-    trilinearFiltering: 1 # Fixes miptrick blending and also needs Full Blending to fix the lighting.
 SLES-50606:
   name: "State of Emergency"
   region: "PAL-M4"
@@ -15142,9 +14070,6 @@ SLES-50632:
 SLES-50636:
   name: "Centre Court - Hard Hitter"
   region: "PAL-M3"
-  gsHWFixes:
-    mipmap: 2 # Improves ground texture rendering.
-    trilinearFiltering: 1
 SLES-50637:
   name: "Pro Rally 2002"
   region: "PAL-M5"
@@ -15163,8 +14088,6 @@ SLES-50640:
     - VUSyncHack # Fixes flickering and missing textures.
   gsHWFixes:
     textureInsideRT: 1 # Fixes graphical corruption.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-50641:
   name: "Dynasty Warriors 3"
   region: "PAL-M3"
@@ -15334,8 +14257,6 @@ SLES-50725:
   gsHWFixes:
     preloadFrameData: 1 # Fixes fog and make lights on cars work again.
     autoFlush: 2 # Fixes sun luminosity and penetration of objects.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
   gameFixes:
     - EETimingHack # Fixes random graphical corruption.
 SLES-50726:
@@ -15360,17 +14281,11 @@ SLES-50728:
   region: "PAL-M3"
   gameFixes:
     - VUSyncHack # Fixes the inverted legs.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-50729:
   name: "Tiger Woods USA Tour 2002"
   region: "PAL-A"
   gameFixes:
     - VUSyncHack # Fixes the inverted legs.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-50730:
   name: "VIP"
   region: "PAL-M5"
@@ -15384,8 +14299,6 @@ SLES-50731:
     vuClampMode: 2 # White textures.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth line and blur.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-50735:
   name: "Jade Cocoon 2"
   region: "PAL-E"
@@ -15410,15 +14323,9 @@ SLES-50753:
 SLES-50754:
   name: "The Simpsons Skateboarding"
   region: "PAL-E"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-50755:
   name: "The Simpsons Skateboarding"
   region: "PAL-F"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-50757:
   name: "Atlantis III"
   region: "PAL-I-S"
@@ -15457,17 +14364,11 @@ SLES-50771:
   compat: 5
   roundModes:
     eeRoundMode: 0 # Fixes pathing.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-50772:
   name: "Blood Omen 2 - The Legacy of Kain Series"
   region: "PAL-M3"
   roundModes:
     eeRoundMode: 0 # Fixes pathing.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-50773:
   name: "Disney's Donald Duck - Phantomias - Platyrhynchos Kineticus"
   region: "PAL-M5"
@@ -15529,42 +14430,24 @@ SLES-50795:
 SLES-50796:
   name: "2002 FIFA World Cup"
   region: "PAL-E-SW"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-50797:
   name: "Coupe du Monde FIFA 2002"
   region: "PAL-F"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-50798:
   name: "FIFA Fussball Weltmeisterschaft 2002"
   region: "PAL-G"
   compat: 5
   gameFixes:
     - EETimingHack
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-50799:
   name: "Mondiali FIFA 2002"
   region: "PAL-I"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-50800:
   name: "Mundial FIFA 2002"
   region: "PAL-S"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-50801:
   name: "FIFA World Cup 2002"
   region: "PAL-GR"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-50802:
   name: "Knockout Kings 2002"
   region: "PAL-G"
@@ -15576,36 +14459,26 @@ SLES-50804:
   region: "PAL-E"
   gsHWFixes:
     roundSprite: 1 # Fixes lines in HUD and text boxes.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-50805:
   name: "Deus Ex"
   region: "PAL-G"
   gsHWFixes:
     roundSprite: 1 # Fixes lines in HUD and text boxes.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-50806:
   name: "Deus Ex"
   region: "PAL-F"
   gsHWFixes:
     roundSprite: 1 # Fixes lines in HUD and text boxes.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-50807:
   name: "Deus Ex"
   region: "PAL-I"
   gsHWFixes:
     roundSprite: 1 # Fixes lines in HUD and text boxes.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-50808:
   name: "Deus Ex"
   region: "PAL-S"
   gsHWFixes:
     roundSprite: 1 # Fixes lines in HUD and text boxes.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-50809:
   name: "Next Generation Tennis"
   region: "PAL-M6"
@@ -15614,8 +14487,6 @@ SLES-50812:
   region: "PAL-E"
   gsHWFixes:
     autoFlush: 1 # Fixes lens flares.
-    mipmap: 2 # Fixes texture flickering during movement.
-    trilinearFiltering: 1
     gpuTargetCLUT: 1 # Fixes lens flares going through objects.
     bilinearUpscale: 2 # Smooths out sun glare textures.
 SLES-50813:
@@ -15623,8 +14494,6 @@ SLES-50813:
   region: "PAL-F"
   gsHWFixes:
     autoFlush: 1 # Fixes lens flares.
-    mipmap: 2 # Fixes texture flickering during movement.
-    trilinearFiltering: 1
     gpuTargetCLUT: 1 # Fixes lens flares going through objects.
     bilinearUpscale: 2 # Smooths out sun glare textures.
 SLES-50814:
@@ -15632,8 +14501,6 @@ SLES-50814:
   region: "PAL-G"
   gsHWFixes:
     autoFlush: 1 # Fixes lens flares.
-    mipmap: 2 # Fixes texture flickering during movement.
-    trilinearFiltering: 1
     gpuTargetCLUT: 1 # Fixes lens flares going through objects.
     bilinearUpscale: 2 # Smooths out sun glare textures.
   compat: 5
@@ -15642,9 +14509,6 @@ SLES-50815:
   region: "PAL-G"
   roundModes:
     eeRoundMode: 0 # Fixes pathing.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-50816:
   name: "DTM Race Driver"
   region: "PAL-M3"
@@ -15782,9 +14646,6 @@ SLES-50841:
   name: "Largo Winch - Empire Under Threat"
   region: "PAL-M5"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-50842:
   name: "Downforce"
   region: "PAL-M5"
@@ -15820,8 +14681,6 @@ SLES-50850:
   region: "PAL-M5"
   gsHWFixes:
     recommendedBlendingLevel: 2 # Fixes dither patterns.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-50852:
   name: "Sven-Goran Eriksson's World Challenge"
   region: "PAL-E"
@@ -15878,8 +14737,6 @@ SLES-50876:
   gsHWFixes:
     autoFlush: 1 # Aligns and corrects shadows.
     roundSprite: 1 # Fixes depth line.
-    mipmap: 2 # Mipmap + trilinear, improves building textures and reduces pop in.
-    trilinearFiltering: 1
     cpuCLUTRender: 1 # Fixes janky coloured cars.
     gpuTargetCLUT: 1 # Fixes janky coloured cars.
     textureInsideRT: 1 # Fixes car textures.
@@ -15927,8 +14784,6 @@ SLES-50897:
   gsHWFixes:
     halfPixelOffset: 2 # Gets rid of fog line.
     roundSprite: 1 # Fixes lines in FMVs.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-50898:
   name: "X-Men - The Next Dimension"
   region: "PAL-E"
@@ -15974,8 +14829,6 @@ SLES-50920:
     preloadFrameData: 1 # Fixes invisible lava, there is another issue that needs skipdraw 1 for blurry font but it removes much brightness.
     cpuSpriteRenderBW: 2 # Fixes sky and lava when upscaling.
     cpuSpriteRenderLevel: 2 # Needed for above.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
   patches:
     401F4726:
       content: |-
@@ -16033,9 +14886,6 @@ SLES-50953:
   region: "PAL-E"
   gameFixes:
     - VUSyncHack # Fixes graphics.
-  gsHWFixes:
-    mipmap: 2 # Fixes ground graphics.
-    trilinearFiltering: 1 # Fixes ground graphics.
 SLES-50954:
   name: "Tokyo Road Race"
   region: "PAL-E"
@@ -16049,9 +14899,6 @@ SLES-50958:
   region: "PAL-M4"
   gameFixes:
     - XGKickHack # Fixes corrupted graphics.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-50963:
   name: "Riding Spirits"
   region: "PAL-M5"
@@ -16063,8 +14910,6 @@ SLES-50965:
   region: "PAL-S"
   gsHWFixes:
     autoFlush: 1 # Fixes lens flares.
-    mipmap: 2 # Fixes texture flickering during movement.
-    trilinearFiltering: 1
     gpuTargetCLUT: 1 # Fixes lens flares going through objects.
     bilinearUpscale: 2 # Smooths out sun glare textures.
 SLES-50972:
@@ -16127,9 +14972,6 @@ SLES-50995:
 SLES-50997:
   name: "Rally Fusion - Race of Champions"
   region: "PAL-M3"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-50998:
   name: "Xtreme Express - World Grand Prix"
   region: "PAL-E"
@@ -16188,16 +15030,11 @@ SLES-51042:
   region: "PAL-E"
   roundModes:
     eeDivRoundMode: 3 # Fixes random game crashing.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves grass rendering to match software.
-    trilinearFiltering: 1
 SLES-51043:
   name: "Spyro - Enter the Dragonfly"
   region: "PAL-M6"
   compat: 5
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
     recommendedBlendingLevel: 3 # Fixes gem reflections.
 SLES-51044:
   name: "Burnout 2 - Point of Impact"
@@ -16208,8 +15045,6 @@ SLES-51044:
     autoFlush: 1 # Fixes bloom and sun rendering in front of everything.
     halfPixelOffset: 2 # Aligns bloom effect a little bit better when upscaled.
     bilinearUpscale: 2 # Reduces color banding of the sun glare.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
   roundModes:
     vu1RoundMode: 1 # Bright lights in cars.
 SLES-51045:
@@ -16221,16 +15056,10 @@ SLES-51046:
 SLES-51053:
   name: "Tom & Jerry's War of the Wiskers"
   region: "PAL-M6"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, cleans up texture detail.
-    trilinearFiltering: 1
 SLES-51054:
   name: "Midnight Club 2"
   region: "PAL-M5"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves road and tree textures to match software.
-    trilinearFiltering: 1
   patches:
     ACB1989A:
       content: |-
@@ -16254,9 +15083,6 @@ SLES-51056:
 SLES-51057:
   name: "Hard Hitter 2"
   region: "PAL-M3"
-  gsHWFixes:
-    mipmap: 2 # Improves ground texture rendering.
-    trilinearFiltering: 1
 SLES-51058:
   name: "Maken Shao - Demon Sword"
   region: "PAL-E"
@@ -16276,8 +15102,6 @@ SLES-51063:
   region: "PAL-E"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes the fog line.
-    mipmap: 2 # Mipmap + trilinear, improves track textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-51064:
   name: "Gladius"
   region: "PAL-M3"
@@ -16353,9 +15177,6 @@ SLES-51093:
   name: "Largo Winch - Empire Under Threat"
   region: "PAL-M4"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-51094:
   name: "Club Football - FC Internazionale"
   region: "PAL-M3"
@@ -16411,8 +15232,6 @@ SLES-51117:
     alignSprite: 1 # Fixes vertical lines.
     autoFlush: 2 # Fixes the sun flare.
     halfPixelOffset: 2 # Fixes the sun flare.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-51118:
   name: "Wizardry - Tales of the Forsaken Land"
   region: "PAL-E"
@@ -16444,25 +15263,16 @@ SLES-51130:
   compat: 5
   roundModes:
     vu1RoundMode: 0 # Crashes without.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-51131:
   name: "Tony Hawk's Pro Skater 4"
   region: "PAL-F"
   roundModes:
     vu1RoundMode: 0 # Crashes without.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-51132:
   name: "Tony Hawk's Pro Skater 4"
   region: "PAL-G"
   roundModes:
     vu1RoundMode: 0 # Crashes without.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-51133:
   name: "Red Faction II"
   region: "PAL-M3"
@@ -16475,8 +15285,6 @@ SLES-51134:
     eeClampMode: 3 # Fixes hangs in certain locations like building under construction.
   gsHWFixes:
     recommendedBlendingLevel: 2 # Fixes color saturation.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-51141:
   name: "Summoner 2"
   region: "PAL-E"
@@ -16492,9 +15300,6 @@ SLES-51144:
   name: "Shox - Rally Reinvented"
   region: "PAL-M7"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-51145:
   name: "Monopoly Party"
   region: "PAL-M5"
@@ -16520,9 +15325,6 @@ SLES-51154:
   region: "PAL-E"
   clampModes:
     vuClampMode: 3 # Missing geometry with microVU.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-51156:
   name: "Silent Hill 2 - Director's Cut"
   region: "PAL-M5"
@@ -16577,8 +15379,6 @@ SLES-51192:
     - EETimingHack # Fixes flickering textures.
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes missing lighting effects.
-    mipmap: 2 # Fixes blurry textures.
-    trilinearFiltering: 1 # Fixes blurry textures.
     cpuFramebufferConversion: 1 # Fixes right side of the screen from garbage textures.
     texturePreloading: 0 # Performs better on certain areas like mid-game in and around the castle as the hash goes easily to 200 MB.
 SLES-51193:
@@ -16588,8 +15388,6 @@ SLES-51193:
     - EETimingHack # Fixes flickering textures.
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes missing lighting effects.
-    mipmap: 2 # Fixes blurry textures.
-    trilinearFiltering: 1 # Fixes blurry textures.
     cpuFramebufferConversion: 1 # Fixes right side of the screen from garbage textures.
     texturePreloading: 0 # Performs better on certain areas like mid-game in and around the castle as the hash goes easily to 200 MB.
 SLES-51194:
@@ -16599,8 +15397,6 @@ SLES-51194:
     - EETimingHack # Fixes flickering textures.
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes missing lighting effects.
-    mipmap: 2 # Fixes blurry textures.
-    trilinearFiltering: 1 # Fixes blurry textures.
     cpuFramebufferConversion: 1 # Fixes right side of the screen from garbage textures.
     texturePreloading: 0 # Performs better on certain areas like mid-game in and around the castle as the hash goes easily to 200 MB.
 SLES-51195:
@@ -16610,8 +15406,6 @@ SLES-51195:
     - EETimingHack # Fixes flickering textures.
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes missing lighting effects.
-    mipmap: 2 # Fixes blurry textures.
-    trilinearFiltering: 1 # Fixes blurry textures.
     cpuFramebufferConversion: 1 # Fixes right side of the screen from garbage textures.
     texturePreloading: 0 # Performs better on certain areas like mid-game in and around the castle as the hash goes easily to 200 MB.
 SLES-51196:
@@ -16621,8 +15415,6 @@ SLES-51196:
     - EETimingHack # Fixes flickering textures.
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes missing lighting effects.
-    mipmap: 2 # Fixes blurry textures.
-    trilinearFiltering: 1 # Fixes blurry textures.
     cpuFramebufferConversion: 1 # Fixes right side of the screen from garbage textures.
     texturePreloading: 0 # Performs better on certain areas like mid-game in and around the castle as the hash goes easily to 200 MB.
 SLES-51197:
@@ -16670,8 +15462,6 @@ SLES-51209:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
     alignSprite: 1 # Fixes vertical lines.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-51214:
   name: "Harry Potter og Hemmelighedernes Kammer"
   region: "PAL-D"
@@ -16679,8 +15469,6 @@ SLES-51214:
     - EETimingHack # Fixes flickering textures.
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes missing lighting effects.
-    mipmap: 2 # Fixes blurry textures.
-    trilinearFiltering: 1 # Fixes blurry textures.
     cpuFramebufferConversion: 1 # Fixes right side of the screen from garbage textures.
     texturePreloading: 0 # Performs better on certain areas like mid-game in and around the castle as the hash goes easily to 200 MB.
 SLES-51215:
@@ -16690,8 +15478,6 @@ SLES-51215:
     - EETimingHack # Fixes flickering textures.
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes missing lighting effects.
-    mipmap: 2 # Fixes blurry textures.
-    trilinearFiltering: 1 # Fixes blurry textures.
     cpuFramebufferConversion: 1 # Fixes right side of the screen from garbage textures.
     texturePreloading: 0 # Performs better on certain areas like mid-game in and around the castle as the hash goes easily to 200 MB.
 SLES-51216:
@@ -16701,8 +15487,6 @@ SLES-51216:
     - EETimingHack # Fixes flickering textures.
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes missing lighting effects.
-    mipmap: 2 # Fixes blurry textures.
-    trilinearFiltering: 1 # Fixes blurry textures.
     cpuFramebufferConversion: 1 # Fixes right side of the screen from garbage textures.
     texturePreloading: 0 # Performs better on certain areas like mid-game in and around the castle as the hash goes easily to 200 MB.
 SLES-51217:
@@ -16712,8 +15496,6 @@ SLES-51217:
     - EETimingHack # Fixes flickering textures.
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes missing lighting effects.
-    mipmap: 2 # Fixes blurry textures.
-    trilinearFiltering: 1 # Fixes blurry textures.
     cpuFramebufferConversion: 1 # Fixes right side of the screen from garbage textures.
     texturePreloading: 0 # Performs better on certain areas like mid-game in and around the castle as the hash goes easily to 200 MB.
 SLES-51218:
@@ -16723,8 +15505,6 @@ SLES-51218:
     - EETimingHack # Fixes flickering textures.
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes missing lighting effects.
-    mipmap: 2 # Fixes blurry textures.
-    trilinearFiltering: 1 # Fixes blurry textures.
     cpuFramebufferConversion: 1 # Fixes right side of the screen from garbage textures.
     texturePreloading: 0 # Performs better on certain areas like mid-game in and around the castle as the hash goes easily to 200 MB.
 SLES-51219:
@@ -16734,8 +15514,6 @@ SLES-51219:
     - EETimingHack # Fixes flickering textures.
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes missing lighting effects.
-    mipmap: 2 # Fixes blurry textures.
-    trilinearFiltering: 1 # Fixes blurry textures.
     cpuFramebufferConversion: 1 # Fixes right side of the screen from garbage textures.
     texturePreloading: 0 # Performs better on certain areas like mid-game in and around the castle as the hash goes easily to 200 MB.
 SLES-51220:
@@ -16760,8 +15538,6 @@ SLES-51227:
   compat: 5
   gsHWFixes:
     autoFlush: 2 # Fixes lava effect.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
   patches:
     default:
       content: |-
@@ -16787,9 +15563,6 @@ SLES-51232:
   compat: 5
   gameFixes:
     - XGKickHack # Fixes black models on certain games in World Tour.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-51233:
   name: "Dragon Ball Z - Budokai"
   region: "PAL-M4"
@@ -16821,15 +15594,9 @@ SLES-51250:
   name: "Shox - Rally Reinvented"
   region: "PAL-E"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-51251:
   name: "Shox - Rally Reinvented"
   region: "PAL-A"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-51252:
   name: "The Lord of the Rings - The Two Towers"
   name-sort: "Lord of the Rings, The - The Two Towers"
@@ -16838,8 +15605,6 @@ SLES-51252:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misaligned lighting and other effects.
     cpuSpriteRenderBW: 1 # Fixes flickering textures caused by mipmapping.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
   clampModes:
     vuClampMode: 3 # Fix white shiny weapons.
 SLES-51253:
@@ -16848,8 +15613,6 @@ SLES-51253:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misaligned lighting and other effects.
     cpuSpriteRenderBW: 1 # Fixes flickering textures caused by mipmapping.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
   clampModes:
     vuClampMode: 3 # Fix white shiny weapons.
 SLES-51254:
@@ -16858,8 +15621,6 @@ SLES-51254:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misaligned lighting and other effects.
     cpuSpriteRenderBW: 1 # Fixes flickering textures caused by mipmapping.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
   clampModes:
     vuClampMode: 3 # Fix white shiny weapons.
 SLES-51255:
@@ -16868,8 +15629,6 @@ SLES-51255:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misaligned lighting and other effects.
     cpuSpriteRenderBW: 1 # Fixes flickering textures caused by mipmapping.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
   clampModes:
     vuClampMode: 3 # Fix white shiny weapons.
 SLES-51256:
@@ -16879,8 +15638,6 @@ SLES-51256:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misaligned lighting and other effects.
     cpuSpriteRenderBW: 1 # Fixes flickering textures caused by mipmapping.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
   clampModes:
     vuClampMode: 3 # Fix white shiny weapons.
 SLES-51257:
@@ -16924,9 +15681,6 @@ SLES-51272:
     vuClampMode: 3 # Fixes water rendering.
   gameFixes:
     - XGKickHack # Fixes SPS while ingame.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-51273:
   name: "Wakeboarding Unleashed"
   region: "PAL-F"
@@ -16934,18 +15688,12 @@ SLES-51273:
     vuClampMode: 3 # Fixes water rendering.
   gameFixes:
     - XGKickHack # Fixes SPS while ingame.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-51275:
   name: "Summoner 2"
   region: "PAL-I"
 SLES-51282:
   name: "Tiger Woods PGA Tour 2003"
   region: "PAL-E"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-51283:
   name: "WWE SmackDown! Shut Your Mouth"
   region: "PAL-E"
@@ -16962,16 +15710,12 @@ SLES-51286:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes upscaling lines.
     autoFlush: 2 # Fixes sun penetration.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-51287:
   name: "X-Men 2 - La Vengeance de Wolverine"
   region: "PAL-F"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes upscaling lines.
     autoFlush: 2 # Fixes sun penetration.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-51289:
   name: "Gunfighter 2 - Legend of Jesse James"
   region: "PAL-M5"
@@ -17020,8 +15764,6 @@ SLES-51301:
   gsHWFixes:
     autoFlush: 1 # Fixes incorrect blur effect.
     halfPixelOffset: 4 # Improves blur.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-51302:
   name: "Bomberman Kart"
   region: "PAL-M3"
@@ -17112,16 +15854,10 @@ SLES-51347:
   name: "Die Hard - Vendetta"
   region: "PAL-M4"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-51348:
   name: "Die Hard - Vendetta"
   region: "PAL-E-G"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-51349:
   name: "Evolution Skateboarding"
   region: "PAL-M3"
@@ -17134,8 +15870,6 @@ SLES-51354:
   compat: 5
   gsHWFixes:
     autoFlush: 2 # Fixes glows. Also needed for recursive mipmap rendering.
-    mipmap: 2 # Better characters and environment but has a texture cache issue that makes it worse.
-    trilinearFiltering: 1 # Using mipmaps, so may as well.
     textureInsideRT: 1 # Fixes rainbow lighting for some areas.
     getSkipCount: "GSC_BlueTongueGames" # Mipmap rendering on CPU.
 SLES-51355:
@@ -17144,8 +15878,6 @@ SLES-51355:
   compat: 5
   gsHWFixes:
     textureInsideRT: 1 # Fixes inside RT shuffling.
-    mipmap: 2 # Mipmap + trilinear, improves road and grass textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_BigMuthaTruckers"
 SLES-51356:
   name: "Road Trip Adventure"
@@ -17164,23 +15896,14 @@ SLES-51360:
   name: "The Simpsons Skateboarding"
   name-sort: "Simpsons Skateboarding, The"
   region: "PAL-I"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-51361:
   name: "The Simpsons Skateboarding"
   name-sort: "Simpsons Skateboarding, The"
   region: "PAL-S"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-51362:
   name: "The Simpsons Skateboarding"
   name-sort: "Simpsons Skateboarding, The"
   region: "PAL-G"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-51363:
   name: "Music 3000"
   region: "PAL-M5"
@@ -17228,9 +15951,6 @@ SLES-51381:
 SLES-51382:
   name: "Shrek Super Party"
   region: "PAL-E"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-51383:
   name: "Beach King Stunt Racer"
   region: "PAL-M4"
@@ -17283,8 +16003,6 @@ SLES-51399:
   gsHWFixes:
     halfPixelOffset: 2 # Corrects positioning of reflections on suit's surfaces.
     roundSprite: 2 # Reduces garbage on the UI whilst upscaling.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-51400:
   name: "Tenchu - Wrath of Heaven"
   region: "PAL-S"
@@ -17392,9 +16110,6 @@ SLES-51461:
 SLES-51462:
   name: "Shrek Super Party"
   region: "PAL-M4"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-51466:
   name: "Tom Clancy's Splinter Cell"
   region: "PAL-M5"
@@ -17477,15 +16192,10 @@ SLES-51507:
   region: "PAL-M5"
   gsHWFixes:
     readTCOnClose: 1 # Fixes render to target getting lost on state/switch.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-51508:
   name: "The Hulk"
   name-sort: "Hulk, The"
   region: "PAL-M5"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-51509:
   name: "World of Outlaws - Sprint Cars"
   region: "PAL-E"
@@ -17536,8 +16246,6 @@ SLES-51548:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes upscaling lines.
     autoFlush: 2 # Fixes sun penetration.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-51553:
   name: "Chaos Legion"
   region: "PAL-M5"
@@ -17627,15 +16335,9 @@ SLES-51617:
   name: "Starsky & Hutch"
   region: "PAL-M5"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves building textures.
-    trilinearFiltering: 1
 SLES-51618:
   name: "Starsky & Hutch"
   region: "PAL-I-S"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves building textures.
-    trilinearFiltering: 1
 SLES-51619:
   name: "Clock Tower 3"
   region: "PAL-M5"
@@ -17697,15 +16399,11 @@ SLES-51653:
   region: "PAL-M4"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves lighting.
-    mipmap: 2 # Mipmap + trilinear, improves ground and wall textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-51654:
   name: "Mace Griffin - Bounty Hunter"
   region: "PAL-G"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves lighting.
-    mipmap: 2 # Mipmap + trilinear, improves ground and wall textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-51658:
   name: "Piglet's Big Game"
   region: "PAL-G"
@@ -17762,15 +16460,11 @@ SLES-51680:
   region: "PAL-M3"
   gsHWFixes:
     autoFlush: 1
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-51681:
   name: "Splashdown 2 - Rides Gone Wild"
   region: "PAL-M3"
   gsHWFixes:
     autoFlush: 1
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-51682:
   name: "Headhunter - Redemption"
   region: "PAL-E"
@@ -17819,8 +16513,6 @@ SLES-51697:
     recommendedBlendingLevel: 4 # Fixes missing lighting and makes snow not look like snow sludge.
     textureInsideRT: 1 # Fixes rainbow effect in the pause menu before a jump.
     halfPixelOffset: 2 # Fixes depth lines.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-51698:
   name: "Mobile Light Force 2"
   region: "PAL-M5"
@@ -17838,8 +16530,6 @@ SLES-51705:
   region: "PAL-M5"
   gsHWFixes:
     autoFlush: 1 # Fixes missing sun.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-51707:
   name: "Secret Weapons Over Normandy"
   region: "PAL-E"
@@ -17925,8 +16615,6 @@ SLES-51750:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 1 # Helps blur.
-    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-51753:
   name: "True Crime - Streets of L.A."
   region: "PAL-E"
@@ -17935,8 +16623,6 @@ SLES-51753:
     halfPixelOffset: 3 # Fixes double image.
     gpuTargetCLUT: 1 # Fixes sun penetrating buildings.
     autoFlush: 1 # Fixes sun occlusion.
-    mipmap: 2 # Fixes miptrick texture effects.
-    trilinearFiltering: 1 # Fixes miptrick blending.
 SLES-51754:
   name: "True Crime - Streets of L.A."
   region: "PAL-M5"
@@ -17946,15 +16632,11 @@ SLES-51754:
     halfPixelOffset: 3 # Fixes double image.
     gpuTargetCLUT: 1 # Fixes sun penetrating buildings.
     autoFlush: 1 # Fixes sun occlusion.
-    mipmap: 2 # Fixes miptrick texture effects.
-    trilinearFiltering: 1 # Fixes miptrick blending.
 SLES-51755:
   name: "Disney/Pixar Finding Nemo"
   region: "PAL-E"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-51756:
   name: "Batman - Rise of Sin Tzu"
   region: "PAL-M5"
@@ -17979,9 +16661,6 @@ SLES-51761:
   name: "The Italian Job - L.A. Heist"
   name-sort: "Italian Job, The - L.A. Heist"
   region: "PAL-M5"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground and building textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-51765:
   name: "Volleyball Xciting"
   region: "PAL-E"
@@ -18002,16 +16681,10 @@ SLES-51778:
 SLES-51782:
   name: "Fire Warrior"
   region: "PAL-E"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-51783:
   name: "Starsky & Hutch"
   region: "PAL-F-G"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves building textures.
-    trilinearFiltering: 1
 SLES-51785:
   name: "Cool Shot"
   region: "PAL-E"
@@ -18031,9 +16704,6 @@ SLES-51797:
   region: "PAL-E"
   clampModes:
     vuClampMode: 3 # Missing geometry with microVU.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-51798:
   name: "NHL 2004"
   region: "PAL-M5"
@@ -18052,9 +16722,6 @@ SLES-51800:
   region: "PAL-M5"
   gameFixes:
     - GIFFIFOHack # Fixes random graphical corruption.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-51806:
   name: "Evil Dead - A Fistful of Boomstick"
   region: "PAL-E"
@@ -18067,9 +16734,6 @@ SLES-51813:
 SLES-51814:
   name: "ATV Offroad Fury 2"
   region: "PAL-E"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-51815:
   name: "Final Fantasy X-2"
   region: "PAL-E"
@@ -18125,8 +16789,6 @@ SLES-51820:
     autoFlush: 2 # Fixes bloom misalignment.
     halfPixelOffset: 2 # Fixes bloom misalignment.
     textureInsideRT: 1 # Fixes sky bloom.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-51821:
   name: "Alias"
   region: "PAL-M5"
@@ -18149,8 +16811,6 @@ SLES-51824:
   region: "PAL-M5"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
-    mipmap: 2 # Mipmap + trilinear, improves road and tree textures to match software.
-    trilinearFiltering: 1
 SLES-51825:
   name: "Pop Idol"
   region: "PAL-E"
@@ -18201,9 +16861,6 @@ SLES-51843:
 SLES-51845:
   name: "Barbie Horse Adventures - Wild Horse Rescue"
   region: "PAL-M6"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-51846:
   name: "Deutschland sucht den Superstar"
   region: "PAL-G"
@@ -18215,8 +16872,6 @@ SLES-51848:
     vu1RoundMode: 0 # Crashes without.
   gsHWFixes:
     minimumBlendingLevel: 3 # Fixes broken lighting on ground and buildings.
-    mipmap: 2 # Mipmap + trilinear, improves ground and buildings textures to match software.
-    trilinearFiltering: 1
 SLES-51850:
   name: "Basketball Xciting"
   region: "PAL-E"
@@ -18227,8 +16882,6 @@ SLES-51851:
     vu1RoundMode: 0 # Crashes without.
   gsHWFixes:
     minimumBlendingLevel: 3 # Fixes broken lighting on ground and buildings.
-    mipmap: 2 # Mipmap + trilinear, improves ground and buildings textures to match software.
-    trilinearFiltering: 1
 SLES-51852:
   name: "Tony Hawk's Underground"
   region: "PAL-G"
@@ -18237,8 +16890,6 @@ SLES-51852:
     vu1RoundMode: 0 # Crashes without.
   gsHWFixes:
     minimumBlendingLevel: 3 # Fixes broken lighting on ground and buildings.
-    mipmap: 2 # Mipmap + trilinear, improves ground and buildings textures to match software.
-    trilinearFiltering: 1
 SLES-51853:
   name: "Tony Hawk's Underground"
   region: "PAL-F"
@@ -18246,8 +16897,6 @@ SLES-51853:
     vu1RoundMode: 0 # Crashes without.
   gsHWFixes:
     minimumBlendingLevel: 3 # Fixes broken lighting on ground and buildings.
-    mipmap: 2 # Mipmap + trilinear, improves ground and buildings textures to match software.
-    trilinearFiltering: 1
 SLES-51854:
   name: "Tony Hawk's Underground"
   region: "PAL-S"
@@ -18255,17 +16904,12 @@ SLES-51854:
     vu1RoundMode: 0 # Crashes without.
   gsHWFixes:
     minimumBlendingLevel: 3 # Fixes broken lighting on ground and buildings.
-    mipmap: 2 # Mipmap + trilinear, improves ground and buildings textures to match software.
-    trilinearFiltering: 1
 SLES-51855:
   name: "Tank Elite"
   region: "PAL-E"
 SLES-51856:
   name: "Monster Attack"
   region: "PAL-E"
-  gsHWFixes:
-    mipmap: 2 # Improves distant textures.
-    trilinearFiltering: 1 # Smooths high frequency textures on distant ground.
 SLES-51859:
   name: "Billiards Xciting"
   region: "PAL-E"
@@ -18307,23 +16951,17 @@ SLES-51870:
   region: "PAL-FI-S"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-51871:
   name: "Disney/Pixar Findet Nemo"
   region: "PAL-F-G"
   compat: 5
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-51872:
   name: "Disney/Pixar Finding Nemo"
   region: "PAL-SC"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-51873:
   name: "Medal of Honor - Rising Sun"
   region: "PAL-M5"
@@ -18344,9 +16982,6 @@ SLES-51877:
 SLES-51879:
   name: "Hot Wheels World Race"
   region: "PAL-E"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-51881:
   name: "Mercedes Bens World Racing"
   region: "PAL-F-G"
@@ -18367,9 +17002,6 @@ SLES-51887:
   region: "PAL-E"
   clampModes:
     vuClampMode: 2 # Fixes black textures on characters.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-51888:
   name: "RTL Ski Jumping 2004"
   region: "PAL-E-G"
@@ -18387,8 +17019,6 @@ SLES-51896:
   region: "PAL-E"
   gsHWFixes:
     recommendedBlendingLevel: 2 # Improves lighting, maximum blending is needed for full accuracy.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-51897:
   name: "The Simpsons - Hit & Run"
   name-sort: "Simpsons, The - Hit & Run"
@@ -18398,8 +17028,6 @@ SLES-51897:
     eeDivRoundMode: 1 # Lens flare appears even when behind objects.
   gsHWFixes:
     autoFlush: 2 # Fixes missing lens flare.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-51903:
   name: "AFL Live 2004 - Aussie Rules Football"
   region: "PAL-E"
@@ -18411,8 +17039,6 @@ SLES-51907:
   region: "PAL-I"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-51908:
   name: "Van Helsing"
   region: "PAL-M5"
@@ -18477,8 +17103,6 @@ SLES-51925:
   region: "PAL-A"
   gsHWFixes:
     autoFlush: 1
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-51926:
   name: "Outlaw Golf"
   region: "PAL-M3"
@@ -18546,8 +17170,6 @@ SLES-51956:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes heat blur layer.
     halfPixelOffset: 2 # Fixes depth line.
-    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-51957:
   name: "Terminator 3 - Rise of the Machines"
   region: "PAL-F"
@@ -18565,8 +17187,6 @@ SLES-51960:
   region: "PAL-P"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-51961:
   name: "Prince of Persia - The Sands of Time" # Pre-order Demo
   region: "PAL-E"
@@ -18604,16 +17224,10 @@ SLES-51967:
 SLES-51968:
   name: "SpongeBob SquarePants - Battle for Bikini Bottom"
   region: "PAL-E"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-51970:
   name: "Spongebob Schwammkopf - Schlacht um Bikini Bottom"
   region: "PAL-G"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-51972:
   name: "NBA Jam 2004"
   region: "PAL-M3"
@@ -18670,9 +17284,6 @@ SLES-51997:
   compat: 5
   clampModes:
     eeClampMode: 3 # For grey screen ingame.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-51998:
   name: "Kao the Kangaroo - Round 2"
   region: "PAL-M5"
@@ -18688,17 +17299,12 @@ SLES-52002:
   region: "PAL-M6"
   speedHacks:
     eeCycleRate: 2 # Fixes hang on opening memory card screen.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-52005:
   name: "007 - Everything or Nothing"
   region: "PAL-M5"
   compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes lines in cutscenes.
-    mipmap: 2 # Cleans up texture detail.
-    trilinearFiltering: 1 # Smoothes out mipmapping.
 SLES-52008:
   name: "NBA Live 2004"
   region: "PAL-M5"
@@ -18758,8 +17364,6 @@ SLES-52034:
   name-sort: "Cat in the Hat, The"
   region: "PAL-M5"
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
-    trilinearFiltering: 1
     autoFlush: 1 # Fixes sun occlusion.
 SLES-52036:
   name: "WWE SmackDown! - Here Comes the Pain!"
@@ -18792,8 +17396,6 @@ SLES-52044:
     - XGKickHack # Fixes texture flicker.
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes road brightness.
-    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-52045:
   name: "GT-R 400"
   region: "PAL-E"
@@ -18808,8 +17410,6 @@ SLES-52046:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes lines in cutscenes.
-    mipmap: 2 # Cleans up texture detail.
-    trilinearFiltering: 1 # Smoothes out mipmapping.
 SLES-52047:
   name: "The Sims - Bustin' Out"
   name-sort: "Sims, The - Bustin' Out"
@@ -18817,16 +17417,12 @@ SLES-52047:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 1 # Fixes vertical lines, font and others.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-52048:
   name: "The Sims - Bustin' Out"
   name-sort: "Sims, The - Bustin' Out"
   region: "PAL-M5"
   gsHWFixes:
     halfPixelOffset: 1 # Fixes vertical lines, font and others.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-52055:
   name: "Harry Potter and the Philosopher's Stone"
   region: "PAL-M11"
@@ -18869,9 +17465,6 @@ SLES-52097:
   compat: 5
   clampModes:
     eeClampMode: 3 # For grey screen ingame.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-52100:
   name: "NRL Rugby League"
   region: "PAL-E"
@@ -18942,8 +17535,6 @@ SLES-52132:
   gsHWFixes:
     texturePreloading: 1 # Performs much better with partial preload.
     autoFlush: 1 # Fixes bloom rendering.
-    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
-    trilinearFiltering: 1
   roundModes:
     vu1RoundMode: 0 # Fixes missing light cones curtains and certain effects.
 SLES-52133:
@@ -18952,8 +17543,6 @@ SLES-52133:
   gsHWFixes:
     texturePreloading: 1 # Performs much better with partial preload.
     autoFlush: 1 # Fixes bloom rendering.
-    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
-    trilinearFiltering: 1
   roundModes:
     vu1RoundMode: 0 # Fixes missing light cones curtains and certain effects.
 SLES-52134:
@@ -18963,8 +17552,6 @@ SLES-52134:
   gsHWFixes:
     texturePreloading: 1 # Performs much better with partial preload.
     autoFlush: 1 # Fixes bloom rendering.
-    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
-    trilinearFiltering: 1
   roundModes:
     vu1RoundMode: 0 # Fixes missing light cones curtains and certain effects.
 SLES-52135:
@@ -18973,8 +17560,6 @@ SLES-52135:
   gsHWFixes:
     texturePreloading: 1 # Performs much better with partial preload.
     autoFlush: 1 # Fixes bloom rendering.
-    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
-    trilinearFiltering: 1
   roundModes:
     vu1RoundMode: 0 # Fixes missing light cones curtains and certain effects.
 SLES-52136:
@@ -18983,8 +17568,6 @@ SLES-52136:
   gsHWFixes:
     texturePreloading: 1 # Performs much better with partial preload.
     autoFlush: 1 # Fixes bloom rendering.
-    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
-    trilinearFiltering: 1
   roundModes:
     vu1RoundMode: 0 # Fixes missing light cones curtains and certain effects.
 SLES-52143:
@@ -19001,8 +17584,6 @@ SLES-52149:
   compat: 5
   gsHWFixes:
     preloadFrameData: 1 # Fixes missing loading screens.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-52150:
   name: "Legacy of Kain - Defiance"
   region: "PAL-M5"
@@ -19022,8 +17603,6 @@ SLES-52153:
   gsHWFixes:
     autoFlush: 1 # Aligns and corrects shadows.
     roundSprite: 1 # Fixes depth line.
-    mipmap: 2 # Mipmap + trilinear, improves building textures and reduces pop in.
-    trilinearFiltering: 1
     cpuCLUTRender: 1 # Fixes janky coloured cars.
     gpuTargetCLUT: 1 # Fixes janky coloured cars.
     textureInsideRT: 1 # Fixes car textures.
@@ -19088,8 +17667,6 @@ SLES-52202:
   compat: 5
   gsHWFixes:
     autoFlush: 2 # Fixes speed effect intensity.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-52203:
   name: "Armored Core 3 - Silent Line"
   region: "PAL-E"
@@ -19120,8 +17697,6 @@ SLES-52219:
     mtvu: 0
   gsHWFixes:
     halfPixelOffset: 3 # Reduces ghosting.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-52230:
   name: "Muppets Party Cruise"
   region: "PAL-E-F"
@@ -19134,8 +17709,6 @@ SLES-52237:
   region: "PAL-M5"
   gsHWFixes:
     halfPixelOffset: 1 # Sharpens world in far distances.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
   memcardFilters:
     - "SLES-52237"
     - "SLES-52467"
@@ -19146,8 +17719,6 @@ SLES-52238:
   region: "PAL-M5"
   compat: 5
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_Kunoichi"
 SLES-52240:
   name: "International Pool Championship"
@@ -19191,9 +17762,6 @@ SLES-52258:
 SLES-52259:
   name: "Outlaw Volleyball"
   region: "PAL-M3"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-52265:
   name: "Energy Airforce - Aim Strike!"
   region: "PAL-E"
@@ -19221,8 +17789,6 @@ SLES-52276:
     recommendedBlendingLevel: 4 # Improves car color.
     autoFlush: 1 # Softens bloom on objects and cars.
     halfPixelOffset: 4 # Fixes misaligned bloom on objects and cars.
-    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-52277:
   name: "Riding Spirits 2"
   region: "PAL-M5"
@@ -19299,8 +17865,6 @@ SLES-52283:
     autoFlush: 2 # Fixes environment lights visible through player model.
     halfPixelOffset: 4 # Fixes depth line and misaligned bloom.
     minimumBlendingLevel: 3 # Fixes incorrect bloom rendering.
-    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-52284:
   name: "Deadly Skies III"
   region: "PAL-M5"
@@ -19380,9 +17944,6 @@ SLES-52322:
 SLES-52323:
   name: "Richard Burns Rally"
   region: "PAL-M5"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-52325:
   name: "Champions of Norrath - Realms of EverQuest"
   region: "PAL-M3"
@@ -19479,8 +18040,6 @@ SLES-52372:
     autoFlush: 2 # Fixes the position of the shadow and makes it not blocky.
     halfPixelOffset: 2 # Fixes shadows.
     gpuPaletteConversion: 0 # Stops potential crashes from too many palette textures.
-    mipmap: 2 # Building textures align more closely with SW mode.
-    trilinearFiltering: 1
 SLES-52373:
   name: "Champions of Norrath"
   region: "PAL-E-S"
@@ -19501,36 +18060,26 @@ SLES-52379:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 4 # Fixes blue seam in ground.
-    mipmap: 2 # Partially fixes the sun effects, but the game suffers from depth/blending issues.
-    trilinearFiltering: 1
 SLES-52380:
   name: "Shrek 2"
   region: "PAL-F"
   gsHWFixes:
     halfPixelOffset: 4 # Fixes blue seam in ground.
-    mipmap: 2 # Partially fixes the sun effects, but the game suffers from depth/blending issues.
-    trilinearFiltering: 1
 SLES-52381:
   name: "Shrek 2"
   region: "PAL-G"
   gsHWFixes:
     halfPixelOffset: 4 # Fixes blue seam in ground.
-    mipmap: 2 # Partially fixes the sun effects, but the game suffers from depth/blending issues.
-    trilinearFiltering: 1
 SLES-52382:
   name: "Shrek 2"
   region: "PAL-S"
   gsHWFixes:
     halfPixelOffset: 4 # Fixes blue seam in ground.
-    mipmap: 2 # Partially fixes the sun effects, but the game suffers from depth/blending issues.
-    trilinearFiltering: 1
 SLES-52383:
   name: "Shrek 2"
   region: "PAL-I"
   gsHWFixes:
     halfPixelOffset: 4 # Fixes blue seam in ground.
-    mipmap: 2 # Partially fixes the sun effects, but the game suffers from depth/blending issues.
-    trilinearFiltering: 1
 SLES-52384:
   name: "Project Zero 2 - Crimson Butterfly"
   region: "PAL-M5"
@@ -19662,14 +18211,9 @@ SLES-52447:
     autoFlush: 2 # Fixes the position of the shadow and makes it not blocky.
     halfPixelOffset: 2 # Fixes shadows.
     gpuPaletteConversion: 0 # Stops potential crashes from too many palette textures.
-    mipmap: 2 # Building textures align more closely with SW mode.
-    trilinearFiltering: 1
 SLES-52448:
   name: "Knights of the Temple"
   region: "PAL-M4"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-52449:
   name: "Kidz Sports Basketball"
   region: "PAL-E"
@@ -19688,8 +18232,6 @@ SLES-52457:
   region: "PAL-SW"
   gsHWFixes:
     halfPixelOffset: 4 # Fixes blue seam in ground.
-    mipmap: 2 # Partially fixes the sun effects, but the game suffers from depth/blending issues.
-    trilinearFiltering: 1
 SLES-52458:
   name: "Disgaea - Hour of Darkness"
   region: "PAL-E"
@@ -19739,15 +18281,9 @@ SLES-52478:
   name: "Red Dead Revolver"
   region: "PAL-M5"
   compat: 4
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-52479:
   name: "Samurai Jack - The Shadow of Aku"
   region: "PAL-M5"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-52480:
   name: "Yu-Gi-Oh! - The Duelists of the Roses"
   region: "PAL-M4"
@@ -19790,8 +18326,6 @@ SLES-52493:
     autoFlush: 2 # Fixes the position of the shadow and makes it not blocky.
     halfPixelOffset: 2 # Fixes shadows.
     gpuPaletteConversion: 0 # Stops potential crashes from too many palette textures.
-    mipmap: 2 # Building textures align more closely with SW mode.
-    trilinearFiltering: 1
 SLES-52495:
   name: "Bujingai - Swordmaster"
   region: "PAL-M5"
@@ -19813,9 +18347,6 @@ SLES-52509:
   region: "PAL-M4"
   clampModes:
     vuClampMode: 2 # Fix black textures on characters.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-52510:
   name: "Neo Contra"
   region: "PAL-M3"
@@ -19933,22 +18464,16 @@ SLES-52545:
   region: "PAL-M3"
   compat: 5
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     recommendedBlendingLevel: 3 # Improves reflections on certain characters and objects on certain levels.
 SLES-52546:
   name: "Star Wars - Battlefront"
   region: "PAL-F"
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     recommendedBlendingLevel: 3 # Improves reflections on certain characters and objects on certain levels.
 SLES-52547:
   name: "Star Wars - Battlefront"
   region: "PAL-G"
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     recommendedBlendingLevel: 3 # Improves reflections on certain characters and objects on certain levels.
 SLES-52551:
   name: "Samurai Warriors"
@@ -20025,8 +18550,6 @@ SLES-52568:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
     PCRTCOverscan: 1 # Fixes offscreen image.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-52569:
   name: "Spyro - A Hero's Tail"
   region: "PAL-M6"
@@ -20039,8 +18562,6 @@ SLES-52570:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misaligned lighting and other effects, needs Special otherwise lights flicker.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-52571:
   name: "Pacific Air Warriors 2 - Dogfight"
   region: "PAL-E"
@@ -20053,9 +18574,6 @@ SLES-52573:
   region: "PAL-M5"
   roundModes:
     eeRoundMode: 2 # Fixes abnormal character behaviour.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-52576:
   name: "Yu-Gi-Oh! Capsule Monster Coliseum"
   region: "PAL-M5"
@@ -20067,9 +18585,6 @@ SLES-52581:
   region: "PAL-E"
   clampModes:
     vuClampMode: 3 # Missing geometry with microVU.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-52584:
   name: "Burnout 3 - Takedown"
   region: "PAL-M4"
@@ -20080,8 +18595,6 @@ SLES-52584:
     recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 2 # Fixes blur and obscures sun behind objects.
-    mipmap: 2 # Fixes over sharpening.
-    trilinearFiltering: 1 # Smoothes out mipmapping.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     bilinearUpscale: 2 # Smooths out sun glare textures like native.
     getSkipCount: "GSC_BurnoutGames"
@@ -20095,8 +18608,6 @@ SLES-52585:
     recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 2 # Fixes blur and obscures sun behind objects.
-    mipmap: 2 # Fixes over sharpening.
-    trilinearFiltering: 1 # Smoothes out mipmapping.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     bilinearUpscale: 2 # Smooths out sun glare textures like native.
     getSkipCount: "GSC_BurnoutGames"
@@ -20110,24 +18621,18 @@ SLES-52588:
   region: "PAL-E"
   gsHWFixes:
     autoFlush: 2 # Fixes missing lighting.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     # halfPixelOffset: 1 # Fixes lighting misalignment. Do not enable this, it breaks a lot of graphics.
 SLES-52589:
   name: "Mercenaries - Playground of Destruction"
   region: "PAL-F"
   gsHWFixes:
     autoFlush: 2 # Fixes missing lighting.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     # halfPixelOffset: 1 # Fixes lighting misalignment. Do not enable this, it breaks a lot of graphics.
 SLES-52590:
   name: "Mercenaries - Playground of Destruction"
   region: "PAL-G"
   gsHWFixes:
     autoFlush: 2 # Fixes missing lighting.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     # halfPixelOffset: 1 # Fixes lighting misalignment. Do not enable this, it breaks a lot of graphics.
 SLES-52591:
   name: "Dynasty Warriors 4 - Empires"
@@ -20174,8 +18679,6 @@ SLES-52605:
   region: "PAL-Unk"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes bottom left and right corner garbage.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-52616:
   name: "Video Poker & Blackjack"
   region: "PAL-M5"
@@ -20193,8 +18696,6 @@ SLES-52621:
     vu1RoundMode: 0 # Crashes without.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes water and grass textures.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
     wildArmsHack: 1 # Reduces post-processing misalignment.
     mergeSprite: 1 # Reduces post-processing misalignment.
 SLES-52622:
@@ -20204,8 +18705,6 @@ SLES-52622:
     vu1RoundMode: 0 # Crashes without.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes water and grass textures.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
     wildArmsHack: 1 # Reduces post-processing misalignment.
     mergeSprite: 1 # Reduces post-processing misalignment.
 SLES-52624:
@@ -20224,8 +18723,6 @@ SLES-52630:
   region: "PAL-M5"
   compat: 5
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     autoFlush: 1 # Fixes missing lights.
 SLES-52631:
   name: "Digimon Rumble Arena 2"
@@ -20244,30 +18741,22 @@ SLES-52636:
     halfPixelOffset: 1 # Fixes 4 split lines in stage intros.
     autoFlush: 1 # Fixes incorrect colors.
     alignSprite: 1 # Fixes vertical lines such as in FMVs.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-52637:
   name: "TOCA Racer Driver 2"
   region: "PAL-M5"
   gsHWFixes:
     alignSprite: 1 # Fixes lighting and vertical lines, also works with normal vertex.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-52638:
   name: "DTM Race Driver 2"
   region: "PAL-M5"
   compat: 5
   gsHWFixes:
     alignSprite: 1 # Fixes lighting and vertical lines, also works with normal vertex.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-52639:
   name: "V8 Supercars 2"
   region: "PAL-M5"
   gsHWFixes:
     alignSprite: 1 # Fixes lighting and vertical lines, also works with normal vertex.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-52640:
   name: "Dance-UK XL"
   region: "PAL-UK"
@@ -20408,8 +18897,6 @@ SLES-52669:
   gsHWFixes:
     halfPixelOffset: 1 # Reduces ghosting.
     roundSprite: 1 # Reduces ghosting even more.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-52670:
   name: "Second Sight"
   region: "PAL-M5"
@@ -20425,9 +18912,6 @@ SLES-52674:
   region: "PAL-M5"
   clampModes:
     vu1ClampMode: 3 # Fixes 3D rendering.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-52675:
   name: "Hugo Cannon Cruise"
   region: "PAL-Unk"
@@ -20450,8 +18934,6 @@ SLES-52685:
   region: "PAL-M5"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes bottom left and right corner garbage.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-52686:
   name: "Backyard Wrestling 2 - There Goes the Neighborhood"
   region: "PAL-E"
@@ -20480,9 +18962,7 @@ SLES-52700:
   gsHWFixes:
     cpuSpriteRenderBW: 1 # Fixes shadow rendering.
     cpuSpriteRenderLevel: 1 # Needed for above.
-    bilinearUpscale: 1 # Smoothes out shadow textures.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
+    bilinearUpscale: 1 # Smooths out shadow textures.
 SLES-52701:
   name: "Future Tactics - The Uprising"
   region: "PAL-M5"
@@ -20598,9 +19078,6 @@ SLES-52731:
 SLES-52733:
   name: "Driven to Destruction"
   region: "PAL-E"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-52734:
   name: "Worms Forts - Under Siege"
   region: "PAL-M5"
@@ -20647,23 +19124,17 @@ SLES-52753:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves car reflections.
     autoFlush: 1
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-52754:
   name: "FlatOut"
   region: "PAL-G"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves car reflections.
     autoFlush: 1
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-52755:
   name: "Blood Will Tell - Tezuka Osamu's Dororo"
   region: "PAL-M5"
   gsHWFixes:
     minimumBlendingLevel: 2 # Fixes dark font to more bright like software mode.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-52760:
   name: "Pro Evolution Soccer 4"
   region: "PAL-M4"
@@ -20678,9 +19149,6 @@ SLES-52766:
   name: "Godzilla - Save The Earth"
   region: "PAL-M5"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-52767:
   name: "Hugo - Cannon Cruise"
   region: "PAL-M4"
@@ -20716,8 +19184,6 @@ SLES-52782:
   region: "PAL-E"
   gsHWFixes:
     cpuSpriteRenderBW: 1 # Fixes textures.
-    mipmap: 2 # Mipmap + trilinear, improves shimmering of terrain, matches SW.
-    trilinearFiltering: 1
   patches:
     0BC05D02:
       content: |-
@@ -20729,8 +19195,6 @@ SLES-52783:
   region: "PAL-F-S-I"
   gsHWFixes:
     cpuSpriteRenderBW: 1 # Fixes textures.
-    mipmap: 2 # Mipmap + trilinear, improves shimmering of terrain, matches SW.
-    trilinearFiltering: 1
   patches:
     30AE5279:
       content: |-
@@ -20742,8 +19206,6 @@ SLES-52784:
   region: "PAL-G"
   gsHWFixes:
     cpuSpriteRenderBW: 1 # Fixes textures.
-    mipmap: 2 # Mipmap + trilinear, improves shimmering of terrain, matches SW.
-    trilinearFiltering: 1
   patches:
     0BC05D02:
       content: |-
@@ -20765,36 +19227,26 @@ SLES-52801:
   region: "PAL-M5"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-52802:
   name: "Seigneur des anneaux, Le - Le Tiers Âge"
   region: "PAL-F"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-52803:
   name: "Herr der Ringe, Der - Das dritte Zeitalter"
   region: "PAL-G"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-52804:
   name: "Signore degli Anelli, Il - La Terza Era"
   region: "PAL-I"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-52805:
   name: "Señor de Los Anillos, El - La Tercera Edad"
   region: "PAL-S"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-52807:
   name: "Lemony Snicket's A Series of Unfortunate Events"
   region: "PAL-E"
@@ -20831,8 +19283,6 @@ SLES-52812:
   region: "PAL-E"
   compat: 5
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves the street's textures to match sw renderer.
-    trilinearFiltering: 1
     halfPixelOffset: 2 # Fixes bloom misalignment when upscaling.
     cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling.
 SLES-52813:
@@ -20841,8 +19291,6 @@ SLES-52813:
   region: "PAL-NL-F"
   compat: 5
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves the street's textures to match sw renderer.
-    trilinearFiltering: 1
     halfPixelOffset: 2 # Fixes bloom misalignment when upscaling.
     cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling.
 SLES-52814:
@@ -20850,16 +19298,12 @@ SLES-52814:
   name-sort: "Incredibles, The"
   region: "PAL-I"
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves the street's textures to match sw renderer.
-    trilinearFiltering: 1
     halfPixelOffset: 2 # Fixes bloom misalignment when upscaling.
     cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling.
 SLES-52815:
   name: "Disney/Pixar Die Unglaublichen"
   region: "PAL-G"
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves the street's textures to match sw renderer.
-    trilinearFiltering: 1
     halfPixelOffset: 2 # Fixes bloom misalignment when upscaling.
     cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling.
 SLES-52816:
@@ -20867,8 +19311,6 @@ SLES-52816:
   name-sort: "Disney/Pixar Increíbles, Los"
   region: "PAL-S"
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves the street's textures to match sw renderer.
-    trilinearFiltering: 1
     halfPixelOffset: 2 # Fixes bloom misalignment when upscaling.
     cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling.
 SLES-52820:
@@ -20876,16 +19318,12 @@ SLES-52820:
   name-sort: "Disney/Pixar Incredibles, The"
   region: "PAL-SC"
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves the street's textures to match sw renderer.
-    trilinearFiltering: 1
     halfPixelOffset: 2 # Fixes bloom misalignment when upscaling.
     cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling.
 SLES-52821:
   name: "Disney/Pixar The Incredibles - Os Super-Heróis"
   region: "PAL-P"
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves the street's textures to match sw renderer.
-    trilinearFiltering: 1
     halfPixelOffset: 2 # Fixes bloom misalignment when upscaling.
     cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling.
 SLES-52822:
@@ -20960,8 +19398,6 @@ SLES-52859:
   region: "PAL-E"
   gsHWFixes:
     autoFlush: 1 # Fixes the post processing positioning.
-    mipmap: 2
-    trilinearFiltering: 1
     textureInsideRT: 1 # Fixes post processing.
 SLES-52861:
   name: "King Arthur"
@@ -21045,8 +19481,6 @@ SLES-52895:
   compat: 5
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes missing lights.
-    mipmap: 2 # Mipmap + trilinear, improves the street's textures to match sw renderer.
-    trilinearFiltering: 1
     halfPixelOffset: 2 # Fixes bloom misalignment when upscaling.
     cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling.
 SLES-52896:
@@ -21054,8 +19488,6 @@ SLES-52896:
   region: "PAL-F-G"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes missing lights.
-    mipmap: 2 # Mipmap + trilinear, improves the street's textures to match sw renderer.
-    trilinearFiltering: 1
     halfPixelOffset: 2 # Fixes bloom misalignment when upscaling.
     cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling.
 SLES-52897:
@@ -21063,8 +19495,6 @@ SLES-52897:
   region: "PAL-I"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes missing lights.
-    mipmap: 2 # Mipmap + trilinear, improves the street's textures to match sw renderer.
-    trilinearFiltering: 1
     halfPixelOffset: 2 # Fixes bloom misalignment when upscaling.
     cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling.
 SLES-52898:
@@ -21184,8 +19614,6 @@ SLES-52942:
   name: "Midnight Club 3 - DUB Edition"
   region: "PAL-M5"
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves car and road textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_MidnightClub3"
   patches:
     EBE1972D:
@@ -21200,9 +19628,6 @@ SLES-52942:
 SLES-52943:
   name: "ESPN NFL 2K5"
   region: "PAL-E"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
-    trilinearFiltering: 1
   patches:
     7D5403E1:
       content: |-
@@ -21286,8 +19711,6 @@ SLES-52968:
     autoFlush: 1 # Fixes bloom and sun rendering in front of everything.
     halfPixelOffset: 2 # Aligns bloom effect a little bit better when upscaled.
     bilinearUpscale: 2 # Reduces color banding of the sun glare.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
   roundModes:
     vu1RoundMode: 1 # Bright lights in cars.
 SLES-52973:
@@ -21327,8 +19750,6 @@ SLES-52985:
   region: "PAL-G"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes missing lights.
-    mipmap: 2 # Mipmap + trilinear, improves the street's textures to match sw renderer.
-    trilinearFiltering: 1
     halfPixelOffset: 2 # Fixes bloom misalignment when upscaling.
     cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling.
 SLES-52986:
@@ -21336,8 +19757,6 @@ SLES-52986:
   region: "PAL-S"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes missing lights.
-    mipmap: 2 # Mipmap + trilinear, improves the street's textures to match sw renderer.
-    trilinearFiltering: 1
     halfPixelOffset: 2 # Fixes bloom misalignment when upscaling.
     cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling.
 SLES-52988:
@@ -21401,8 +19820,6 @@ SLES-53008:
   region: "PAL-I-S"
   gsHWFixes:
     autoFlush: 2 # Fixes missing lighting.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     # halfPixelOffset: 1 # Fixes lighting misalignment. Do not enable this, it breaks a lot of graphics.
 SLES-53009:
   name: "Dance Factory"
@@ -21410,40 +19827,22 @@ SLES-53009:
 SLES-53011:
   name: "Gallop Racer 2"
   region: "PAL-E"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53012:
   name: "Tenchu - Fatal Shadows"
   region: "PAL-E"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53013:
   name: "Tenchu - Fatal Shadows"
   region: "PAL-F"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53014:
   name: "Tenchu - Fatal Shadows"
   region: "PAL-G"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53015:
   name: "Tenchu - Fatal Shadows"
   region: "PAL-I"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53016:
   name: "Tenchu - Fatal Shadows"
   region: "PAL-S"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53017:
   name: "Teenage Mutant Ninja Turtles 2 - Battle Nexus"
   region: "PAL-M5"
@@ -21458,8 +19857,6 @@ SLES-53020:
     mergeSprite: 1 # Fixes most vertical lines and lighting misalignment.
     autoFlush: 1 # Fixes light bloom intensity.
     estimateTextureRegion: 1 # Improves performance and reduces hash cache size.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_GiTS"
   patches:
     BF6F101F:
@@ -21528,8 +19925,6 @@ SLES-53028:
     vuClampMode: 0 # Fixes bump mapping issues.
   gsHWFixes:
     textureInsideRT: 1 # Fixes post processing.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_HitmanBloodMoney"
 SLES-53029:
   name: "Hitman - Blood Money"
@@ -21538,8 +19933,6 @@ SLES-53029:
     vuClampMode: 0 # Fixes bump mapping issues.
   gsHWFixes:
     textureInsideRT: 1 # Fixes post processing.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_HitmanBloodMoney"
 SLES-53030:
   name: "Hitman - Blood Money"
@@ -21548,8 +19941,6 @@ SLES-53030:
     vuClampMode: 0 # Fixes bump mapping issues.
   gsHWFixes:
     textureInsideRT: 1 # Fixes post processing.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_HitmanBloodMoney"
 SLES-53031:
   name: "Hitman - Blood Money"
@@ -21558,8 +19949,6 @@ SLES-53031:
     vuClampMode: 0 # Fixes bump mapping issues.
   gsHWFixes:
     textureInsideRT: 1 # Fixes post processing.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_HitmanBloodMoney"
 SLES-53032:
   name: "Hitman - Blood Money"
@@ -21568,16 +19957,11 @@ SLES-53032:
     vuClampMode: 0 # Fixes bump mapping issues.
   gsHWFixes:
     textureInsideRT: 1 # Fixes post processing.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_HitmanBloodMoney"
 SLES-53035:
   name: "Masters of the Universe - He-Man - Defender of Greyskull"
   region: "PAL-E"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53036:
   name: "Tak 2 - The Staff of Dreams"
   region: "PAL-M3"
@@ -21590,8 +19974,6 @@ SLES-53037:
     eeRoundMode: 1 # Fixes object balls never stopping in the Monkey Billiards DX minigame.
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes text and foliage color.
-    mipmap: 2 # Mipmap + trilinear, improves stage textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53038:
   name: "Devil May Cry 3 - Dante's Awakening"
   region: "PAL-M5"
@@ -21639,9 +20021,6 @@ SLES-53046:
   region: "PAL-M5"
   clampModes:
     vu1ClampMode: 3 # Fixes smoke particles.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53047:
   name: "The Punisher"
   name-sort: "Punisher, The"
@@ -21659,8 +20038,6 @@ SLES-53052:
   region: "PAL-M5"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misaligned bloom.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53058:
   name: "Ricky Ponting International Cricket"
   region: "PAL-E"
@@ -21711,8 +20088,6 @@ SLES-53075:
   region: "PAL-M5"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misaligned lighting and other effects, needs Special otherwise lights flicker.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53076:
   name: "Triggerman"
   region: "PAL-M5"
@@ -21741,8 +20116,6 @@ SLES-53087:
   gsHWFixes:
     alignSprite: 1 # Fixes lighting and vertical lines, also works with normal vertex.
     roundSprite: 1 # Fixes misaligned map.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
     skipDrawStart: 1 # Removes large black box around player car till we properly emulate it.
     skipDrawEnd: 1 # Removes large black box around player car till we properly emulate it.
 SLES-53088:
@@ -21751,8 +20124,6 @@ SLES-53088:
   gsHWFixes:
     alignSprite: 1 # Fixes lighting and vertical lines, also works with normal vertex.
     roundSprite: 1 # Fixes misaligned map.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
     skipDrawStart: 1 # Removes large black box around player car till we properly emulate it.
     skipDrawEnd: 1 # Removes large black box around player car till we properly emulate it.
 SLES-53089:
@@ -21761,8 +20132,6 @@ SLES-53089:
   gsHWFixes:
     alignSprite: 1 # Fixes lighting and vertical lines, also works with normal vertex.
     roundSprite: 1 # Fixes misaligned map.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
     skipDrawStart: 1 # Removes large black box around player car till we properly emulate it.
     skipDrawEnd: 1 # Removes large black box around player car till we properly emulate it.
 SLES-53090:
@@ -21798,8 +20167,6 @@ SLES-53098:
   region: "PAL-M5"
   gsHWFixes:
     autoFlush: 2 # Fixes lighting misalignment.
-    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
-    trilinearFiltering: 1
   gameFixes:
     - XGKickHack # Fixes stretched/spikey textures.
 SLES-53099:
@@ -21852,8 +20219,6 @@ SLES-53124:
   region: "PAL-M4"
   gsHWFixes:
     autoFlush: 1 # Fixes the post processing positioning.
-    mipmap: 2
-    trilinearFiltering: 1
     textureInsideRT: 1 # Fixes post processing.
 SLES-53125:
   name: "Enthusia - Professional Racing"
@@ -21884,9 +20249,6 @@ SLES-53131:
 SLES-53138:
   name: "Outlaw Volleyball Remixed"
   region: "PAL-M4"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53139:
   name: "Alien Hominid"
   region: "PAL-M6"
@@ -22005,8 +20367,6 @@ SLES-53192:
   gsHWFixes:
     wildArmsHack: 1 # Fixes blurriness.
     mergeSprite: 1 # Fixes misaligned lights.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53193:
   name: "Puzzle Party"
   region: "PAL-E"
@@ -22015,9 +20375,6 @@ SLES-53194:
   region: "PAL-M7"
   clampModes:
     vuClampMode: 3 # Fixes bad coordinate spam.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53195:
   name: "The Punisher"
   name-sort: "Punisher, The"
@@ -22028,8 +20385,6 @@ SLES-53196:
   name: "Destroy All Humans!"
   region: "PAL-M4"
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     textureInsideRT: 1 # Fixes shadow maps.
     roundSprite: 2 # Fixes misaligned bloom.
     mergeSprite: 1 # Fixes misaligned bloom.
@@ -22039,8 +20394,6 @@ SLES-53197:
   name: "Destroy All Humans!"
   region: "PAL-G"
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     textureInsideRT: 1 # Fixes shadow maps.
     roundSprite: 2 # Fixes misaligned bloom.
     mergeSprite: 1 # Fixes misaligned bloom.
@@ -22092,8 +20445,6 @@ SLES-53225:
   gsHWFixes:
     roundSprite: 2 # Improves bloom alignment and clarity.
     halfPixelOffset: 2 # Improves bloom alignment and clarity.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53226:
   name: "DreamWorks Madagascar"
   region: "PAL-F-G"
@@ -22103,8 +20454,6 @@ SLES-53226:
   gsHWFixes:
     roundSprite: 2 # Improves bloom alignment and clarity.
     halfPixelOffset: 2 # Improves bloom alignment and clarity.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53227:
   name: "DreamWorks Madagascar"
   region: "PAL-M3"
@@ -22113,8 +20462,6 @@ SLES-53227:
   gsHWFixes:
     roundSprite: 2 # Improves bloom alignment and clarity.
     halfPixelOffset: 2 # Improves bloom alignment and clarity.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53231:
   name: "Le Avventure di Lupin III - Il Tesoro del Re Stregone"
   region: "PAL-I"
@@ -22148,8 +20495,6 @@ SLES-53242:
   gsHWFixes:
     roundSprite: 2 # Improves bloom alignment and clarity.
     halfPixelOffset: 2 # Improves bloom alignment and clarity.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53246:
   name: "DreamWorks Madagascar"
   region: "PAL-S"
@@ -22158,8 +20503,6 @@ SLES-53246:
   gsHWFixes:
     roundSprite: 2 # Improves bloom alignment and clarity.
     halfPixelOffset: 2 # Improves bloom alignment and clarity.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53280:
   name: "7 Sins"
   region: "PAL-M3"
@@ -22204,8 +20547,6 @@ SLES-53300:
     vuClampMode: 3 # Fixes SPS ingame and prevents flickering or invisible characters.
   gsHWFixes:
     minimumBlendingLevel: 4 # Mitigates grayer text font in bottom left.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53301:
   name: "Bomberman Hardball"
   region: "PAL-E"
@@ -22266,8 +20607,6 @@ SLES-53332:
     halfPixelOffset: 2 # Fixes misaligned blur.
     cpuSpriteRenderBW: 2 # Fixes black spots appearing on some surfaces and massively reduces RP TC and TU count.
     cpuSpriteRenderLevel: 2 # Needed for above.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53333:
   name: "Medal of Honor - Les Faucons de Guerre"
   region: "PAL-F"
@@ -22276,8 +20615,6 @@ SLES-53333:
     halfPixelOffset: 2 # Fixes misaligned blur.
     cpuSpriteRenderBW: 2 # Fixes black spots appearing on some surfaces and massively reduces RP TC and TU count.
     cpuSpriteRenderLevel: 2 # Needed for above.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53334:
   name: "Medal of Honor - European Assault"
   region: "PAL-G"
@@ -22286,8 +20623,6 @@ SLES-53334:
     halfPixelOffset: 2 # Fixes misaligned blur.
     cpuSpriteRenderBW: 2 # Fixes black spots appearing on some surfaces and massively reduces RP TC and TU count.
     cpuSpriteRenderLevel: 2 # Needed for above.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53335:
   name: "Medal of Honor - European Assault"
   region: "PAL-I"
@@ -22296,8 +20631,6 @@ SLES-53335:
     halfPixelOffset: 2 # Fixes misaligned blur.
     cpuSpriteRenderBW: 2 # Fixes black spots appearing on some surfaces and massively reduces RP TC and TU count.
     cpuSpriteRenderLevel: 2 # Needed for above.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53336:
   name: "Medal of Honor - European Assault"
   region: "PAL-S"
@@ -22306,29 +20639,18 @@ SLES-53336:
     halfPixelOffset: 2 # Fixes misaligned blur.
     cpuSpriteRenderBW: 2 # Fixes black spots appearing on some surfaces and massively reduces RP TC and TU count.
     cpuSpriteRenderLevel: 2 # Needed for above.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53338:
   name: "Victorious Boxers 2 - Fighting Spirit"
   region: "PAL-M3"
 SLES-53339:
   name: "Dynasty Warriors 5"
   region: "PAL-E"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53340:
   name: "Dynasty Warriors 5"
   region: "PAL-F"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53341:
   name: "Dynasty Warriors 5"
   region: "PAL-G"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
   compat: 5
 SLES-53342:
   name: "EA Sports Cricket 2005"
@@ -22400,9 +20722,6 @@ SLES-53363:
   compat: 5
   roundModes:
     eeRoundMode: 0 # Fixes commands not being visible.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, fixes missing lights to match sw renderer.
-    trilinearFiltering: 1
 SLES-53364:
   name: "7 Sins"
   region: "PAL-G"
@@ -22435,8 +20754,6 @@ SLES-53373:
   gsHWFixes:
     roundSprite: 2 # Improves bloom alignment and clarity.
     halfPixelOffset: 2 # Improves bloom alignment and clarity.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53374:
   name: "X-Men Legends II - Rise of Apocalypse"
   region: "PAL-M3"
@@ -22462,8 +20779,6 @@ SLES-53386:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 4 # Fixes offset bloom.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53387:
   name: "Batman Begins"
   region: "PAL-M7"
@@ -22481,8 +20796,6 @@ SLES-53390:
     vu1ClampMode: 0 # Fixes Spider-Man's eye texture colour.
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes textures.
-    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
-    trilinearFiltering: 1
     autoFlush: 2 # Fixes shadow alignment along with HPO Special (Normal looks better but causes top left glitches).
     halfPixelOffset: 2
 SLES-53391:
@@ -22492,8 +20805,6 @@ SLES-53391:
     vu1ClampMode: 0 # Fixes Spider-Man's eye texture colour.
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes textures.
-    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
-    trilinearFiltering: 1
     autoFlush: 2 # Fixes shadow alignment along with HPO Special (Normal looks better but causes top left glitches).
     halfPixelOffset: 2
 SLES-53393:
@@ -22505,8 +20816,6 @@ SLES-53393:
   gsHWFixes:
     autoFlush: 1 # Fixes missing post processing.
     halfPixelOffset: 1 # Aligns post processing.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53396:
   name: "Spartan - Total Warrior"
   region: "PAL-M3"
@@ -22515,8 +20824,6 @@ SLES-53396:
   gsHWFixes:
     autoFlush: 1 # Fixes missing post processing.
     halfPixelOffset: 1 # Aligns post processing.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53398:
   name: "Zombie Zone"
   region: "PAL-E"
@@ -22534,9 +20841,6 @@ SLES-53402:
   name: "Taxi Rider"
   region: "PAL-E"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Fixes road markings.
-    trilinearFiltering: 1 # Smooths the texture transitions.
   roundModes:
     eeRoundMode: 2 # Positive rounding fixes distant white models.
     vu1RoundMode: 2 # Positive rounding fixes close white models.
@@ -22588,8 +20892,6 @@ SLES-53415:
   gsHWFixes:
     roundSprite: 1 # Fixes lines in sprites.
     cpuSpriteRenderBW: 1 # Fixes textures.
-    mipmap: 2 # Mipmap + trilinear, improves ground and building textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53416:
   name: "Call of Duty 2 - Big Red One"
   region: "PAL-M3"
@@ -22598,8 +20900,6 @@ SLES-53416:
   gsHWFixes:
     roundSprite: 1 # Fixes lines in sprites.
     cpuSpriteRenderBW: 1 # Fixes textures.
-    mipmap: 2 # Mipmap + trilinear, improves ground and building textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53417:
   name: "Call of Duty 2 - Big Red One"
   region: "PAL-G"
@@ -22608,8 +20908,6 @@ SLES-53417:
   gsHWFixes:
     roundSprite: 1 # Fixes lines in sprites.
     cpuSpriteRenderBW: 1 # Fixes textures.
-    mipmap: 2 # Mipmap + trilinear, improves ground and building textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53418:
   name: "Tak - The Great JuJu Challenge"
   region: "PAL-A"
@@ -22619,8 +20917,6 @@ SLES-53419:
   region: "PAL-M5"
   gsHWFixes:
     cpuSpriteRenderBW: 4 # Fixes textures.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53420:
   name: "Winnie the Pooh's Rumbly Tumbly Adventure"
   region: "PAL-PL"
@@ -22638,8 +20934,6 @@ SLES-53430:
   gsHWFixes:
     nativePaletteDraw: 1 # Fixes lines in certain effects when upscaled.
     halfPixelOffset: 2 # Fixes offset bloom.
-    mipmap: 2 # Mipmap + trilinear, fixes textures.
-    trilinearFiltering: 1
 SLES-53433:
   name: "NHL '06"
   region: "PAL-M6"
@@ -22666,8 +20960,6 @@ SLES-53439:
     PCRTCOverscan: 1 # Fixes offscreen image.
     nativePaletteDraw: 1 # Fixes the look of screen effects.
     halfPixelOffset: 2 # Corrects the alignment of screen effects.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53441:
   name: "Heroes of the Pacific"
   region: "PAL-M5"
@@ -22675,9 +20967,6 @@ SLES-53443:
   name: "The Warriors"
   name-sort: "Warriors, The"
   region: "PAL-M5"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53444:
   name: "Panzer Elite Action - Fields of Glory"
   region: "PAL-M5"
@@ -22715,8 +21004,6 @@ SLES-53462:
   name-sort: "Matrix, The - Path of Neo"
   region: "PAL-M5"
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     halfPixelOffset: 2 # Fix effects upscaling.
     autoFlush: 1 # Fixes broken post processing.
 SLES-53463:
@@ -22747,8 +21034,6 @@ SLES-53473:
   region: "PAL-M3"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes building shade and shadows.
-    mipmap: 2 # Mipmap + trilinear, improves the street's textures to match sw renderer.
-    trilinearFiltering: 1
     halfPixelOffset: 2 # Fixes bloom misalignment when upscaling.
     cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling.
 SLES-53474:
@@ -22757,8 +21042,6 @@ SLES-53474:
   region: "PAL-M3"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes building shade and shadows.
-    mipmap: 2 # Mipmap + trilinear, improves the street's textures to match sw renderer.
-    trilinearFiltering: 1
     halfPixelOffset: 2 # Fixes bloom misalignment when upscaling.
     cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling.
 SLES-53480:
@@ -22803,45 +21086,24 @@ SLES-53494:
   name: "Spongebob SquarePants - Lights, Camera, PANTS!"
   region: "PAL-E"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53495:
   name: "Nickelodeon Bob L'éponge - Silence on Tourne!"
   region: "PAL-F"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53496:
   name: "Nickelodeon SpongeBob - Ciak si Gira!"
   region: "PAL-I"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53497:
   name: "Nickelodeon SpongeBob Schwammkopf - Film ab!"
   region: "PAL-G"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53498:
   name: "Nickelodeon Bob Esponja - ¡Luces, Cámara, Esponja!"
   region: "PAL-S"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53499:
   name: "Nickelodeon SpongeBob SquarePants - Licht uit, Camera aan!"
   region: "PAL-NL"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53500:
   name: "Nickelodeon Svampbob Fyrkant - Tystnad, Tagning, TvÃ¤ttsvamp!"
   region: "PAL-SW"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53501:
   name: "Star Wars - Battlefront II"
   region: "PAL-M3"
@@ -22849,24 +21111,18 @@ SLES-53501:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes bloom misalignment.
     autoFlush: 1 # Fixes missing lights.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53502:
   name: "Star Wars - Battlefront II"
   region: "PAL-F"
   gsHWFixes:
     halfPixelOffset: 1 # Fixes bloom misalignment.
     autoFlush: 1 # Fixes missing lights.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53503:
   name: "Star Wars - Battlefront II"
   region: "PAL-G"
   gsHWFixes:
     halfPixelOffset: 1 # Fixes bloom misalignment.
     autoFlush: 1 # Fixes missing lights.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53504:
   name: "Agent Hugo"
   region: "PAL-M11"
@@ -22883,8 +21139,6 @@ SLES-53506:
     recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 2 # Fixes blur and obscures sun behind objects.
-    mipmap: 2 # Fixes over sharpening.
-    trilinearFiltering: 1 # Smoothes out mipmapping.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     bilinearUpscale: 2 # Smooths out sun glare textures like native.
     getSkipCount: "GSC_BurnoutGames"
@@ -22905,8 +21159,6 @@ SLES-53507:
     recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 2 # Fixes blur and obscures sun behind objects.
-    mipmap: 2 # Fixes over sharpening.
-    trilinearFiltering: 1 # Smoothes out mipmapping.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     bilinearUpscale: 2 # Smooths out sun glare textures like native.
     getSkipCount: "GSC_BurnoutGames"
@@ -22929,9 +21181,6 @@ SLES-53510:
   region: "PAL-E"
   clampModes:
     vuClampMode: 3 # Missing geometry with microVU.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53518:
   name: "Castle Shikigami II"
   region: "PAL-E"
@@ -22945,8 +21194,6 @@ SLES-53523:
     vu1RoundMode: 0 # Fixes textures and crashes.
   gsHWFixes:
     minimumBlendingLevel: 3 # Fixes broken light and shadow rendering.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures and water textures and reflections.
-    trilinearFiltering: 1
     halfPixelOffset: 2 # Fixes misaligned bloom and character shadows.
     autoFlush: 1 # Fixes missing bloom intensity and alignment.
 SLES-53524:
@@ -22961,8 +21208,6 @@ SLES-53526:
   region: "PAL-E-F"
   gsHWFixes:
     autoFlush: 2 # Fixes debris and blending on lower part of screen during monster transformation.
-    mipmap: 2
-    trilinearFiltering: 1
   memcardFilters:
     - "SLES-53526"
     - "SLES-53527"
@@ -22977,8 +21222,6 @@ SLES-53527:
   region: "PAL-E-I-S"
   gsHWFixes:
     autoFlush: 2 # Fixes debris and blending on lower part of screen during monster transformation.
-    mipmap: 2
-    trilinearFiltering: 1
   memcardFilters:
     - "SLES-53526"
     - "SLES-53527"
@@ -22993,8 +21236,6 @@ SLES-53528:
   region: "PAL-G"
   gsHWFixes:
     autoFlush: 2 # Fixes debris and blending on lower part of screen during monster transformation.
-    mipmap: 2
-    trilinearFiltering: 1
   memcardFilters:
     - "SLES-53526"
     - "SLES-53527"
@@ -23036,8 +21277,6 @@ SLES-53534:
     vu1RoundMode: 0 # Crashes without.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes water and grass textures.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
     wildArmsHack: 1 # Reduces post-processing misalignment.
     mergeSprite: 1 # Reduces post-processing misalignment.
     autoFlush: 1 # Improves post-processing rendering.
@@ -23049,8 +21288,6 @@ SLES-53535:
     vu1RoundMode: 0 # Crashes without.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes water and grass textures.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
     wildArmsHack: 1 # Reduces post-processing misalignment.
     mergeSprite: 1 # Reduces post-processing misalignment.
     autoFlush: 1 # Improves post-processing rendering.
@@ -23116,17 +21353,12 @@ SLES-53541:
   region: "PAL-M4"
   clampModes:
     vuClampMode: 3 # Fix black textures on characters.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53542:
   name: "Shadow the Hedgehog"
   region: "PAL-M5"
   gsHWFixes:
     recommendedBlendingLevel: 4 # Improves smoke rendering.
     halfPixelOffset: 2 # Fixes misaligned lighting.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53544:
   name: "Pro Evolution Soccer 5"
   region: "PAL-M4"
@@ -23154,15 +21386,11 @@ SLES-53551:
   region: "PAL-E"
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes missing lighting and makes snow not look like snow sludge.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53552:
   name: "SSX On Tour"
   region: "PAL-M8"
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes missing lighting and makes snow not look like snow sludge.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53553:
   name: "007 - From Russia with Love"
   region: "PAL-M7"
@@ -23171,8 +21399,6 @@ SLES-53553:
   gsHWFixes:
     textureInsideRT: 1 # Required for complex offset shuffles.
     halfPixelOffset: 2 # Fixes center upscaling line during explosions.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
     recommendedBlendingLevel: 4 # Fixes lighting.
 SLES-53556:
   name: "Driver - Parallel Lines"
@@ -23184,8 +21410,6 @@ SLES-53556:
     cpuCLUTRender: 1 # Fixes the rest of the bad textures.
     roundSprite: 1 # Reduces misaligned bloom.
     mergeSprite: 1 # Removes bloom explosion around electrical lights and other light sources such as moon/sun.
-    mipmap: 2 # Mipmap + trilinear, improves road textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53557:
   name: "Need for Speed - Most Wanted"
   region: "PAL-E"
@@ -23195,8 +21419,6 @@ SLES-53557:
     halfPixelOffset: 2 # Fixes blurriness.
     cpuCLUTRender: 1 # Final colour adjustment LUT.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
   memcardFilters: # Reads Underground 2 save for extra money.
     - "SLES-53557"
     - "SLES-53558"
@@ -23211,8 +21433,6 @@ SLES-53558:
     halfPixelOffset: 2 # Fixes blurriness.
     cpuCLUTRender: 1 # Final colour adjustment LUT.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
   memcardFilters:
     - "SLES-53557"
     - "SLES-53558"
@@ -23227,8 +21447,6 @@ SLES-53559:
     halfPixelOffset: 2 # Fixes blurriness.
     cpuCLUTRender: 1 # Final colour adjustment LUT.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
   memcardFilters:
     - "SLES-53557"
     - "SLES-53558"
@@ -23239,9 +21457,6 @@ SLES-53560:
   name: "Sonic Riders"
   region: "PAL-M5"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves track and building textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53561:
   name: "Canis Canem Edit"
   region: "PAL-M5"
@@ -23251,15 +21466,11 @@ SLES-53561:
     recommendedBlendingLevel: 2 # Fixes door transitions.
     halfPixelOffset: 4 # Reduces ghosting.
     roundSprite: 2 # Reduces ghosting.
-    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53563:
   name: "Nickelodeon SpongeBob SquarePants and Friends Unite!"
   region: "PAL-M6"
   gsHWFixes:
     autoFlush: 2 # Fixes glows. Also needed for recursive mipmap rendering.
-    mipmap: 2 # Better characters and environment but has a texture cache issue that makes it worse.
-    trilinearFiltering: 1 # Using mipmaps, so may as well.
     textureInsideRT: 1 # Fixes rainbow lighting for some areas.
     getSkipCount: "GSC_BlueTongueGames" # Mipmap rendering on CPU.
 SLES-53564:
@@ -23267,8 +21478,6 @@ SLES-53564:
   region: "PAL-M5"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blood vision bloom
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53566:
   name: "London Taxi - Rush Hour"
   region: "PAL-E"
@@ -23290,33 +21499,18 @@ SLES-53572:
 SLES-53574:
   name: "Bratz - Rock Angelz"
   region: "PAL-E"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53575:
   name: "Bratz - Rock Angelz"
   region: "PAL-S"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53576:
   name: "Bratz - Rock Angelz"
   region: "PAL-G"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53577:
   name: "Bratz - Rock Angelz"
   region: "PAL-I"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53578:
   name: "Bratz - Rock Angelz"
   region: "PAL-Unk"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53579:
   name: "One Piece - Grand Battle"
   region: "PAL-E"
@@ -23393,8 +21587,6 @@ SLES-53616:
     preloadFrameData: 1 # Fixes numberplates and ensures above targets are valid.
     roundSprite: 1 # Fixes lines in some post-effects.
     gpuTargetCLUT: 1 # Fixes light occlusion.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53617:
   name: "True Crime - New York City"
   region: "PAL-G"
@@ -23407,8 +21599,6 @@ SLES-53617:
     preloadFrameData: 1 # Fixes numberplates and ensures above targets are valid.
     roundSprite: 1 # Fixes lines in some post-effects.
     gpuTargetCLUT: 1 # Fixes light occlusion.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53618:
   name: "True Crime - New York City"
   region: "PAL-S"
@@ -23421,22 +21611,15 @@ SLES-53618:
     preloadFrameData: 1 # Fixes numberplates and ensures above targets are valid.
     roundSprite: 1 # Fixes lines in some post-effects.
     gpuTargetCLUT: 1 # Fixes light occlusion.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53621:
   name: "Wallace & Gromit - The Curse of the Were-Rabbit"
   region: "PAL-M5"
   compat: 5
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misalignment/bloom when upscaling.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53623:
   name: "SpongeBob SquarePants - Battle for Bikini Bottom"
   region: "PAL-F"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53624:
   name: "Disney/Pixar Cars"
   region: "PAL-E"
@@ -23444,16 +21627,12 @@ SLES-53624:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes ground texture flicker and improves car body reflections.
     autoFlush: 1 # Fixes lens flares and missing sun.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53626:
   name: "The Suffering - Ties that Bind"
   name-sort: "Suffering, The - Ties that Bind"
   region: "PAL-E-G"
   gsHWFixes:
     autoFlush: 2 # Fixes debris and blending on lower part of screen during monster transformation.
-    mipmap: 2
-    trilinearFiltering: 1
   memcardFilters:
     - "SLES-53526"
     - "SLES-53527"
@@ -23473,8 +21652,6 @@ SLES-53634:
   region: "PAL-A"
   gsHWFixes:
     autoFlush: 2 # Fixes glows. Also needed for recursive mipmap rendering.
-    mipmap: 2 # Better characters and environment but has a texture cache issue that makes it worse.
-    trilinearFiltering: 1 # Using mipmaps, so may as well.
     textureInsideRT: 1 # Fixes rainbow lighting for some areas.
     getSkipCount: "GSC_BlueTongueGames" # Mipmap rendering on CPU.
 SLES-53635:
@@ -23503,8 +21680,6 @@ SLES-53641:
   name: "Destroy All Humans!"
   region: "PAL-R"
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     textureInsideRT: 1 # Fixes shadow maps.
     roundSprite: 2 # Fixes misaligned bloom.
     mergeSprite: 1 # Fixes misaligned bloom.
@@ -23527,8 +21702,6 @@ SLES-53647:
     vu1RoundMode: 0 # Fixes textures and crashes.
   gsHWFixes:
     minimumBlendingLevel: 3 # Fixes broken light and shadow rendering.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures and water textures and reflections.
-    trilinearFiltering: 1
     halfPixelOffset: 2 # Fixes misaligned bloom and character shadows.
     autoFlush: 1 # Fixes missing bloom intensity and alignment.
 SLES-53651:
@@ -23560,8 +21733,6 @@ SLES-53658:
   region: "PAL-R"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes building shade and shadows.
-    mipmap: 2 # Mipmap + trilinear, improves the street's textures to match sw renderer.
-    trilinearFiltering: 1
     halfPixelOffset: 2 # Fixes bloom misalignment when upscaling.
     cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling.
 SLES-53659:
@@ -23591,8 +21762,6 @@ SLES-53672:
     vu1ClampMode: 0 # Fixes Fixes Spider-Man's eye texture colour.
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes textures.
-    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
-    trilinearFiltering: 1
     autoFlush: 2 # Fixes shadow alignment along with HPO Special (Normal looks better but causes top left glitches).
     halfPixelOffset: 2
 SLES-53676:
@@ -23650,9 +21819,6 @@ SLES-53696:
   name: "Zathura"
   region: "PAL-M6"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53697:
   name: "Dora the Explorer"
   region: "PAL-M3"
@@ -23669,17 +21835,12 @@ SLES-53701:
   compat: 5
   gameFixes:
     - XGKickHack # Fixes texture normals.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53702:
   name: "Resident Evil 4"
   region: "PAL-M5"
   compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53703:
   name: "King Kong, Peter Jackson's - The Official Game of the Movie"
   region: "PAL-M10"
@@ -23709,59 +21870,43 @@ SLES-53706:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes lighting misalignment.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53707:
   name: "Chroniken von Narnia, Die - Der König von Narnia"
   region: "PAL-G"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes lighting misalignment.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53708:
   name: "Cronache di Narnia, Le - Il Leone, La Strega e L'Armadio"
   region: "PAL-I"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes lighting misalignment.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53709:
   name: "The Chronicles of Narnia - The Lion Witch and The Wardrobe"
   name-sort: "Chronicles of Narnia, The - The Lion, The Witch and The Wardrobe"
   region: "PAL-NL-F"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes lighting misalignment.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53710:
   name: "Crónicas de Narnia, Las - El León, La Bruja y El Armario"
   region: "PAL-S"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes lighting misalignment.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53712:
   name: "The Chronicles of Narnia - The Lion Witch and The Wardrobe"
   name-sort: "Chronicles of Narnia, The - The Lion, The Witch and The Wardrobe"
   region: "PAL-SC"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes lighting misalignment.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53713:
   name: "Opowieści z Narnii - Lew Czarownica i Stara Szafa"
   region: "PAL-PL"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes lighting misalignment.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53715:
   name: "Хроники Нарнии - Лев Колдунья и Волшебный Шкаф"
   region: "PAL-R"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes lighting misalignment.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53716:
   name: "Without Warning"
   region: "PAL-M5"
@@ -23769,8 +21914,6 @@ SLES-53717:
   name: "Midnight Club 3 - DUB Edition Remix"
   region: "PAL-M5"
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves car and road textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_MidnightClub3"
   patches:
     208183AF:
@@ -23789,8 +21932,6 @@ SLES-53718:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned textures.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53722:
   name: "Call of Duty 2 - Big Red One [Collector's Edition]"
   region: "PAL-E"
@@ -23799,8 +21940,6 @@ SLES-53722:
   gsHWFixes:
     roundSprite: 1 # Fixes lines in sprites.
     cpuSpriteRenderBW: 1 # Fixes textures.
-    mipmap: 2 # Mipmap + trilinear, improves ground and building textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53724:
   name: "World Series of Poker"
   region: "PAL-E"
@@ -23830,8 +21969,6 @@ SLES-53729:
     autoFlush: 1 # Post-processing.
     halfPixelOffset: 2 # Offset post-processing.
     texturePreloading: 1 # Improves performance.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_Battlefield2" # Depth clear.
     beforeDraw: "OI_Battlefield2" # Framebuffer copy, fixes rendering for bottom part of screen.
 SLES-53730:
@@ -23842,8 +21979,6 @@ SLES-53730:
     autoFlush: 1 # Post-processing.
     halfPixelOffset: 2 # Offset post-processing.
     texturePreloading: 1 # Improves performance.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_Battlefield2" # Depth clear.
     beforeDraw: "OI_Battlefield2" # Framebuffer copy, fixes rendering for bottom part of screen.
 SLES-53734:
@@ -23851,56 +21986,33 @@ SLES-53734:
   region: "PAL-E"
   gsHWFixes:
     roundSprite: 1 # Removes chromatic effect when upscaling also works with halfpixeloffset Special Texture.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53736:
   name: "Billy the Wizard - Rocket Broomstick Racing"
   region: "PAL-E"
 SLES-53738:
   name: "Disney's Chicken Little"
   region: "PAL-NL-F"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53739:
   name: "Disney's Chicken Little"
   region: "PAL-F-S"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
   compat: 5
 SLES-53740:
   name: "Disney's Himmel und Huhn"
   region: "PAL-G"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53741:
   name: "Chicken Little - Цыплёнок Цыпа"
   region: "PAL-R"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53743:
   name: "Disney's Lilla Kycklingen"
   region: "PAL-SC"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53744:
   name: "Disney's Chicken Little"
   region: "PAL-E"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53746:
   name: "Superman Returns"
   region: "PAL-E"
   gameFixes:
     - VUOverflowHack # Fixes SPS.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53747:
   name: "Ed, Edd, 'n Eddy - The Misadventure"
   region: "PAL-E"
@@ -23936,9 +22048,6 @@ SLES-53754:
   region: "PAL-M6"
   speedHacks:
     mtvu: 0 # Increases FPS drastically.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53755:
   name: "Castlevania - Curse of Darkness"
   region: "PAL-M5"
@@ -23956,8 +22065,6 @@ SLES-53756:
   region: "PAL-M5"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53758:
   name: "Sniper Elite [Pre-Production]"
   region: "PAL-E"
@@ -23965,15 +22072,11 @@ SLES-53758:
     autoFlush: 2 # Fixes bloom misalignment.
     halfPixelOffset: 2 # Fixes bloom misalignment.
     textureInsideRT: 1 # Fixes sky bloom.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53759:
   name: "The Matrix - Path of Neo"
   name-sort: "Matrix, The - Path of Neo"
   region: "PAL-M5"
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     halfPixelOffset: 2 # Fix effects upscaling.
     autoFlush: 1 # Fixes broken post processing.
 SLES-53760:
@@ -23987,8 +22090,6 @@ SLES-53763:
   region: "PAL-M5"
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes building and ground colours.
-    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53764:
   name: "Atelier Iris - Eternal Mana"
   region: "PAL-E"
@@ -24079,8 +22180,6 @@ SLES-53799:
   region: "PAL-M4"
   compat: 5
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     halfPixelOffset: 2 # Fix effects upscaling.
     autoFlush: 1 # Fixes broken post processing.
 SLES-53800:
@@ -24125,8 +22224,6 @@ SLES-53819:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
     recommendedBlendingLevel: 3 # Fixes level brightness.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
     cpuSpriteRenderBW: 2 # Fixes broken water on "Upper Sea" level.
     cpuSpriteRenderLevel: 2 # Needed for above.
   memcardFilters:
@@ -24139,8 +22236,6 @@ SLES-53820:
   gsHWFixes:
     halfPixelOffset: 2 # Corrects shadow alignment and reduces blurriness.
     recommendedBlendingLevel: 3 # Fixes level and map menu brightness.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
     preloadFrameData: 1 # Fixes glowing emblems.
 SLES-53821:
   name: "Radio Helicopter II"
@@ -24159,15 +22254,9 @@ SLES-53826:
   name: "Tom Clancy's Splinter Cell - Double Agent"
   region: "PAL-M5"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53827:
   name: "Tom Clancy's Splinter Cell - Double Agent"
   region: "PAL-M3"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53828:
   name: "We Love Katamari"
   region: "PAL-M4"
@@ -24231,8 +22320,6 @@ SLES-53857:
     halfPixelOffset: 2 # Fixes blurriness.
     cpuCLUTRender: 1 # Final colour adjustment LUT.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
   memcardFilters:
     - "SLES-53557"
     - "SLES-53558"
@@ -24309,8 +22396,6 @@ SLES-53886:
     recommendedBlendingLevel: 4 # Improves lighting on buildings and objects.
     autoFlush: 2 # Properly diffuses light instead of strips of light.
     roundSprite: 1 # Fixes lighting misalignment such as the street poles and the sun.
-    mipmap: 2 # Fixes over sharpening.
-    trilinearFiltering: 1 # Smoothes out mipmapping.
     getSkipCount: "GSC_BlackAndBurnoutSky"
     beforeDraw: "OI_BurnoutGames"
   patches:
@@ -24352,22 +22437,16 @@ SLES-53904:
     estimateTextureRegion: 1 # Improves performance and reduces hash cache size.
     gpuPaletteConversion: 2 # Improves performance and reduces hash cache size.
     autoFlush: 1 # Corrects shadows (Currently still broken even with this).
-    mipmap: 2 # Mipmap + trilinear, matches sw renderer.
-    trilinearFiltering: 1
 SLES-53906:
   name: "50 Cent - Bulletproof"
   region: "PAL-F"
   gsHWFixes:
     roundSprite: 1 # Removes chromatic effect when upscaling also works with halfpixeloffset Special Texture.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53908:
   name: "Tomb Raider - Legend"
   region: "PAL-M8"
   compat: 5
   gsHWFixes:
-    mipmap: 2 # Fixes distant characters and models.
-    trilinearFiltering: 1
     textureInsideRT: 1 # Needed for post processing effects.
     autoFlush: 1 # Fixes bloom intensity.
     minimumBlendingLevel: 4 # Fixes multiple lighting effects from lights, computers, cave walls and more.
@@ -24458,9 +22537,6 @@ SLES-53959:
   region: "PAL-M5"
   gameFixes:
     - EETimingHack
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53961:
   name: "Rock'N'Roll Adventures"
   region: "PAL-E"
@@ -24484,8 +22560,6 @@ SLES-53967:
   name-sort: "Godfather, The"
   region: "PAL-M6"
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
-    trilinearFiltering: 1
     textureInsideRT: 1 # Required for complex offset shuffles.
     halfPixelOffset: 2 # Fixes center line in post processing.
 SLES-53968:
@@ -24504,16 +22578,12 @@ SLES-53970:
   name: "Padrino, Il"
   region: "PAL-I"
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
-    trilinearFiltering: 1
     textureInsideRT: 1 # Required for complex offset shuffles.
     halfPixelOffset: 2 # Fixes center line in post processing.
 SLES-53971:
   name: "Padrino, El"
   region: "PAL-S"
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
-    trilinearFiltering: 1
     textureInsideRT: 1 # Required for complex offset shuffles.
     halfPixelOffset: 2 # Fixes center line in post processing.
 SLES-53972:
@@ -24591,8 +22661,6 @@ SLES-53994:
   region: "PAL-E"
   gsHWFixes:
     roundSprite: 1 # Removes chromatic effect when upscaling also works with halfpixeloffset Special Texture.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53995:
   name: "World Championship Poker 2 featuring Howard Lederer"
   region: "PAL-M5"
@@ -24608,8 +22676,6 @@ SLES-53998:
     autoFlush: 1 # Reduces post-processing misalignment.
     halfPixelOffset: 2 # Fixes bloom misalignment still a bit misaligned.
     roundSprite: 1 # Fixes bloom misalignment still a bit misaligned + font artifacts.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-53999:
   name: "The King of Fighters - Neo Wave"
   name-sort: "King of Fighters, The - Neo Wave"
@@ -24634,48 +22700,36 @@ SLES-54004:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes ground texture flicker and improves car body reflections.
     autoFlush: 1 # Fixes lens flares and missing sun.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-54006:
   name: "Disney/Pixar Cars"
   region: "PAL-F"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes ground texture flicker and improves car body reflections.
     autoFlush: 1 # Fixes lens flares and missing sun.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-54007:
   name: "Disney/Pixar Cars"
   region: "PAL-S"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes ground texture flicker and improves car body reflections.
     autoFlush: 1 # Fixes lens flares and missing sun.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-54010:
   name: "Disney/Pixar Cars"
   region: "PAL-I"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes ground texture flicker and improves car body reflections.
     autoFlush: 1 # Fixes lens flares and missing sun.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-54011:
   name: "Disney/Pixar Cars"
   region: "PAL-SW"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes ground texture flicker and improves car body reflections.
     autoFlush: 1 # Fixes lens flares and missing sun.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-54012:
   name: "Disney/Pixar Cars"
   region: "PAL-G"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes ground texture flicker and improves car body reflections.
     autoFlush: 1 # Fixes lens flares and missing sun.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-54013:
   name: "World Snooker Championship 2007"
   region: "PAL-E"
@@ -24685,8 +22739,6 @@ SLES-54015:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes ground texture flicker and improves car body reflections.
     autoFlush: 1 # Fixes lens flares and missing sun.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
   patches:
     B36778F5:
       content: |-
@@ -24726,8 +22778,6 @@ SLES-54027:
     cpuCLUTRender: 1 # Fixes the rest of the bad textures.
     roundSprite: 1 # Reduces misaligned bloom.
     mergeSprite: 1 # Removes bloom explosion around electrical lights and other light sources such as moon/sun.
-    mipmap: 2 # Mipmap + trilinear, improves road textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-54030:
   name: "Black"
   region: "PAL-E"
@@ -24738,8 +22788,6 @@ SLES-54030:
     recommendedBlendingLevel: 4 # Improves lighting on buildings and objects.
     autoFlush: 2 # Properly diffuses light instead of strips of light.
     roundSprite: 1 # Fixes lighting misalignment such as the street poles and the sun.
-    mipmap: 2 # Fixes over sharpening.
-    trilinearFiltering: 1 # Smoothes out mipmapping.
     getSkipCount: "GSC_BlackAndBurnoutSky"
     beforeDraw: "OI_BurnoutGames"
   patches:
@@ -24765,27 +22813,15 @@ SLES-54061:
   name: "FIFA World Cup - Germany '06"
   region: "PAL-E"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-54062:
   name: "FIFA World Cup - Germany '06"
   region: "PAL-F-G"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-54063:
   name: "FIFA World Cup 2006"
   region: "PAL-M3"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-54064:
   name: "FIFA World Cup 2006"
   region: "PAL-M3"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-54066:
   name: "X-Men - The Official Game"
   region: "PAL-M4"
@@ -24803,9 +22839,6 @@ SLES-54080:
 SLES-54081:
   name: "FIFA World Cup 2006"
   region: "PAL-PL"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-54083:
   name: "Pirates of the Caribbean - The Legend of Jack Sparrow"
   region: "PAL-E"
@@ -24825,15 +22858,9 @@ SLES-54087:
 SLES-54089:
   name: "State of Emergency 2"
   region: "PAL-M3"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-54092:
   name: "State of Emergency 2"
   region: "PAL-M3"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-54093:
   name: "Guitar Hero"
   region: "PAL-M5"
@@ -24922,9 +22949,6 @@ SLES-54125:
 SLES-54126:
   name: "Family Guy - The Video Game"
   region: "PAL-M5"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves grass and building textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-54130:
   name: "Spy Hunter - Nowhere to Run"
   region: "PAL-M5"
@@ -24943,21 +22967,15 @@ SLES-54135:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 1 # Removes blur due to misaligned fullscreen effect.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-54136:
   name: "Grand Theft Auto - Liberty City Stories"
   region: "PAL-E-G"
   gsHWFixes:
     halfPixelOffset: 1 # Removes blur due to misaligned fullscreen effect.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-54137:
   name: "Just Cause"
   region: "PAL-M3"
   gsHWFixes:
-    mipmap: 2 # Helps clean up water
-    trilinearFiltering: 1 # Helps clean up water
     recommendedBlendingLevel: 3 # High blending accuracy fixes notoriously broken water.
     halfPixelOffset: 1 # Fixes ghosting.
 SLES-54138:
@@ -24985,8 +23003,6 @@ SLES-54147:
     eeClampMode: 2 # Fixes occasional SPS on moving around, jumping and falling.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
   patches:
     D9920B66:
       content: |-
@@ -24999,8 +23015,6 @@ SLES-54150:
   region: "PAL-M6"
   gsHWFixes:
     cpuCLUTRender: 1 # Fixes ghosting on objects and people.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-54151:
   name: "Let's Make a Soccer Team!"
   region: "PAL-M5"
@@ -25039,16 +23053,12 @@ SLES-54159:
   name: "Eragon"
   region: "PAL-M5"
   gsHWFixes:
-    mipmap: 2 # Cleans up texture detail.
-    trilinearFiltering: 1 # Smoothes out mipmapping.
     halfPixelOffset: 2 # Fixes post processing misalignment.
     recommendedBlendingLevel: 3 # Improves reflection quality.
 SLES-54160:
   name: "Eragon"
   region: "PAL-R"
   gsHWFixes:
-    mipmap: 2 # Cleans up texture detail.
-    trilinearFiltering: 1 # Smoothes out mipmapping.
     halfPixelOffset: 2 # Fixes post processing misalignment.
     recommendedBlendingLevel: 3 # Improves reflection quality.
 SLES-54161:
@@ -25146,8 +23156,6 @@ SLES-54182:
     autoFlush: 2 # Fixes post processing overlay.
     roundSprite: 1 # Greatly reduces chromatic effect when upscaling.
     wildArmsHack: 1 # Fixes chromatic fringing.
-    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-54183:
   name: "Scarface - The World is Yours"
   region: "PAL-G"
@@ -25157,8 +23165,6 @@ SLES-54183:
     autoFlush: 2 # Fixes post processing overlay.
     roundSprite: 1 # Greatly reduces chromatic effect when upscaling.
     wildArmsHack: 1 # Fixes chromatic fringing.
-    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-54184:
   name: "Scarface - The World is Yours"
   region: "PAL-R"
@@ -25168,16 +23174,12 @@ SLES-54184:
     autoFlush: 2 # Fixes post processing overlay.
     roundSprite: 1 # Greatly reduces chromatic effect when upscaling.
     wildArmsHack: 1 # Fixes chromatic fringing.
-    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-54185:
   name: "Dirge of Cerberus - Final Fantasy VII"
   region: "PAL-M5"
   compat: 5
   gsHWFixes:
     autoFlush: 1 # Fixes lighting.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-54186:
   name: "Devil May Cry 3 - Dante's Awakening [Special Edition]"
   region: "PAL-M5"
@@ -25208,8 +23210,6 @@ SLES-54200:
   name: "Just Cause"
   region: "PAL-F-G"
   gsHWFixes:
-    mipmap: 2 # Helps clean up water
-    trilinearFiltering: 1 # Helps clean up water
     recommendedBlendingLevel: 3 # High blending accuracy fixes notoriously broken water.
     halfPixelOffset: 1 # Fixes ghosting.
 SLES-54203:
@@ -25272,8 +23272,6 @@ SLES-54221:
   region: "PAL-M6"
   gsHWFixes:
     cpuCLUTRender: 1 # Fixes ghosting on objects and people.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
   memcardFilters: # Allows import of characters from Lego Star Wars 1.
     - "SLES-54221"
     - "SLES-53194"
@@ -25283,9 +23281,6 @@ SLES-54222:
 SLES-54223:
   name: "NASCAR '07"
   region: "PAL-E"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-54224:
   name: "Australian Idol Sing"
   region: "PAL-A"
@@ -25298,16 +23293,12 @@ SLES-54230:
   compat: 5
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes dark stage rendering.
-    mipmap: 2 # Mipmap + trilinear, improves stadium crowd to match sw renderer.
-    trilinearFiltering: 1
     cpuSpriteRenderBW: 4 # Fixes garbage menus.
 SLES-54231:
   name: "Ricky Ponting International Cricket 2007"
   region: "PAL-A"
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes dark stage rendering.
-    mipmap: 2 # Mipmap + trilinear, improves stadium crowd to match sw renderer.
-    trilinearFiltering: 1
     cpuSpriteRenderBW: 4 # Fixes garbage menus.
 SLES-54232:
   name: "Kingdom Hearts II"
@@ -25385,9 +23376,6 @@ SLES-54248:
   region: "PAL-E"
   clampModes:
     vuClampMode: 3 # Missing geometry with microVU.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-54250:
   name: "NBA Live '07"
   region: "PAL-F"
@@ -25411,9 +23399,6 @@ SLES-54253:
   region: "PAL-E"
   clampModes:
     vuClampMode: 2 # Fix black textures on characters.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-54254:
   name: "Evolution GT"
   region: "PAL-PL"
@@ -25434,8 +23419,6 @@ SLES-54271:
     autoFlush: 2 # Fixes post processing overlay.
     roundSprite: 1 # Greatly reduces chromatic effect when upscaling.
     wildArmsHack: 1 # Fixes chromatic fringing.
-    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-54305:
   name: "Demon Chaos"
   region: "PAL-M5"
@@ -25449,9 +23432,6 @@ SLES-54305:
 SLES-54306:
   name: "Cartoon Network Racing"
   region: "PAL-E"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, fixes flickering and improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-54307:
   name: "Rayman - Raving Rabbids"
   region: "PAL-M6"
@@ -25582,40 +23562,26 @@ SLES-54347:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned textures.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-54348:
   name: "Superman Returns"
   region: "PAL-F"
   gameFixes:
     - VUOverflowHack # Fixes SPS.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-54349:
   name: "Superman Returns"
   region: "PAL-I"
   gameFixes:
     - VUOverflowHack # Fixes SPS.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-54350:
   name: "Superman Returns"
   region: "PAL-G"
   gameFixes:
     - VUOverflowHack # Fixes SPS.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-54351:
   name: "Superman Returns"
   region: "PAL-S"
   gameFixes:
     - VUOverflowHack # Fixes SPS.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-54354:
   name: "Final Fantasy XII"
   region: "PAL-E"
@@ -25689,8 +23655,6 @@ SLES-54376:
   region: "PAL-E"
   gsHWFixes:
     halfPixelOffset: 2 # Fix text and post blur.
-    mipmap: 2 # Base mip level isn't always used.
-    trilinearFiltering: 1
     autoFlush: 2 # Needed for recursive mipmap rendering.
     getSkipCount: "GSC_BlueTongueGames" # Render mipmaps on the CPU.
 SLES-54377:
@@ -25698,8 +23662,6 @@ SLES-54377:
   region: "PAL-G"
   gsHWFixes:
     halfPixelOffset: 2 # Fix text and post blur.
-    mipmap: 2 # Base mip level isn't always used.
-    trilinearFiltering: 1
     autoFlush: 2 # Needed for recursive mipmap rendering.
     getSkipCount: "GSC_BlueTongueGames" # Render mipmaps on the CPU.
 SLES-54378:
@@ -25707,8 +23669,6 @@ SLES-54378:
   region: "PAL-M4"
   gsHWFixes:
     halfPixelOffset: 2 # Fix text and post blur.
-    mipmap: 2 # Base mip level isn't always used.
-    trilinearFiltering: 1
     autoFlush: 2 # Needed for recursive mipmap rendering.
     getSkipCount: "GSC_BlueTongueGames" # Render mipmaps on the CPU.
 SLES-54379:
@@ -25733,8 +23693,6 @@ SLES-54384:
   name: "Destroy All Humans 2 - Make War not Love"
   region: "PAL-M5"
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     textureInsideRT: 1 # Fixes shadow maps.
     roundSprite: 2 # Fixes misaligned bloom.
     mergeSprite: 1 # Fixes misaligned bloom.
@@ -25761,8 +23719,6 @@ SLES-54389:
     vu1RoundMode: 0 # Fixes invalid VU size spam and likely SPS.
   gsHWFixes:
     autoFlush: 1 # Fixes black line down the side of the screen and player shadow.
-    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-54390:
   name: "Tony Hawk's Project 8"
   region: "PAL-M4"
@@ -25771,17 +23727,12 @@ SLES-54390:
     vu1RoundMode: 0 # Fixes invalid VU size spam and likely SPS.
   gsHWFixes:
     autoFlush: 1 # Fixes black line down the side of the screen and player shadow.
-    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-54393:
   name: "Pippa Funnell - Take the Reins"
   region: "PAL-M3"
 SLES-54394:
   name: "Family Guy - The Video Game"
   region: "PAL-E"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves grass and building textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-54395:
   name: "NeoGeo Battle Coliseum"
   region: "PAL-E"
@@ -25927,8 +23878,6 @@ SLES-54455:
     vu1ClampMode: 3 # Fixes texture corruption light shimmering and reflective surfaces.
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned bloom effects.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-54456:
   name: "Beverly Hills Cop"
   region: "PAL-M11"
@@ -26034,8 +23983,6 @@ SLES-54483:
     recommendedBlendingLevel: 4 # Fixes car reflections.
     mergeSprite: 1 # Fixes bluriness.
     halfPixelOffset: 4 # Fixes bluriness.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-54485:
   name: "Cinderella"
   region: "PAL-M3"
@@ -26090,21 +24037,12 @@ SLES-54510:
 SLES-54511:
   name: "UEFA Champions League 2006-2007"
   region: "PAL-E"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-54512:
   name: "UEFA Champions League 2006-2007"
   region: "PAL-F-G"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-54513:
   name: "UEFA Champions League 2006-2007"
   region: "PAL-I-S"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-54516:
   name: "Thrillville"
   region: "PAL-F-G"
@@ -26112,8 +24050,6 @@ SLES-54516:
     vu1ClampMode: 3 # Fixes texture corruption light shimmering and reflective surfaces.
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned bloom effects.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-54517:
   name: "Thrillville"
   region: "PAL-M3"
@@ -26121,8 +24057,6 @@ SLES-54517:
     vu1ClampMode: 3 # Fixes texture corruption light shimmering and reflective surfaces.
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned bloom effects.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-54518:
   name: "Clumsy Shumsy"
   region: "PAL-E"
@@ -26136,16 +24070,12 @@ SLES-54521:
   name: "Nickelodeon SpongeBob and Friends - Battle for Volcano Island"
   region: "PAL-M5"
   gsHWFixes:
-    mipmap: 2 # Better characters and environment.
-    trilinearFiltering: 1 # Using mipmaps, so may as well.
     autoFlush: 2 # Fixes texture corruptions.
     getSkipCount: "GSC_BlueTongueGames" # Mipmap rendering on CPU.
 SLES-54522:
   name: "Nickelodeon SpongeBob and Friends - Battle for Volcano Island"
   region: "PAL-A"
   gsHWFixes:
-    mipmap: 2 # Better characters and environment.
-    trilinearFiltering: 1 # Using mipmaps, so may as well.
     autoFlush: 2 # Fixes texture corruptions.
     getSkipCount: "GSC_BlueTongueGames" # Render mipmaps on the CPU.
 SLES-54527:
@@ -26163,8 +24093,6 @@ SLES-54534:
     autoFlush: 2 # Fixes post processing overlay.
     roundSprite: 1 # Greatly reduces chromatic effect when upscaling.
     wildArmsHack: 1 # Fixes chromatic fringing.
-    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-54536:
   name: "Big Idea's VeggieTales - LarryBoy and the Bad Apple"
   region: "PAL-I"
@@ -26210,8 +24138,6 @@ SLES-54549:
   roundModes:
     eeDivRoundMode: 1 # Fixes black fade effects and some overlays texts in the menus.
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves road and grass textures to match sw renderer.
-    trilinearFiltering: 1
     deinterlace: 9 # Fixes disorderly interlacing lines.
 SLES-54550:
   name: "White Van Racer"
@@ -26300,8 +24226,6 @@ SLES-54584:
   region: "PAL-M5"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth line.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
   clampModes:
     vuClampMode: 3 # Fixes bad geometry.
 SLES-54586:
@@ -26315,9 +24239,6 @@ SLES-54587:
 SLES-54588:
   name: "Brunswick Pro Bowling"
   region: "PAL-E"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves alley textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-54589:
   name: "Global Defence Force Tactics"
   region: "PAL-E"
@@ -26349,8 +24270,6 @@ SLES-54607:
   gsHWFixes:
     halfPixelOffset: 4 # Aligns bloom as best it can be.
     autoFlush: 1 # Fixes bloom rendering.
-    mipmap: 2 # Mipmap + trilinear, improves ground and building textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-54608:
   name: "Barbie in The 12 Dancing Princesses"
   region: "PAL-M4"
@@ -26408,8 +24327,6 @@ SLES-54627:
     recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 2 # Fixes blur and obscures sun behind objects.
-    mipmap: 2 # Fixes over sharpening.
-    trilinearFiltering: 1 # Smoothes out mipmapping.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     bilinearUpscale: 2 # Smooths out sun glare textures like native.
     getSkipCount: "GSC_BurnoutGames"
@@ -26434,8 +24351,6 @@ SLES-54632:
   gsHWFixes:
     halfPixelOffset: 4 # Aligns bloom as best it can be.
     autoFlush: 1 # Fixes bloom rendering.
-    mipmap: 2 # Mipmap + trilinear, improves ground and building textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-54633:
   name: "Premier Manager 08"
   region: "PAL-M4"
@@ -26602,8 +24517,6 @@ SLES-54681:
     recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 2 # Fixes blur and obscures sun behind objects.
-    mipmap: 2 # Fixes over sharpening.
-    trilinearFiltering: 1 # Smoothes out mipmapping.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     bilinearUpscale: 2 # Smooths out sun glare textures like native.
     getSkipCount: "GSC_BurnoutGames"
@@ -26614,8 +24527,6 @@ SLES-54683:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes lighting misalignment.
     mergeSprite: 1 # Removes occasional vertical lines.
-    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-54684:
   name: "Peter Pan"
   region: "PAL-M3"
@@ -26823,21 +24734,12 @@ SLES-54755:
   name: "Transformers - The Game"
   region: "PAL-E"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Cleans up texture detail.
-    trilinearFiltering: 1 # Smoothes out texture transitions.
 SLES-54756:
   name: "Transformers - The Game"
   region: "PAL-F-S"
-  gsHWFixes:
-    mipmap: 2 # Cleans up texture detail.
-    trilinearFiltering: 1 # Smoothes out texture transitions.
 SLES-54757:
   name: "Transformers - The Game"
   region: "PAL-G-I"
-  gsHWFixes:
-    mipmap: 2 # Cleans up texture detail.
-    trilinearFiltering: 1 # Smoothes out texture transitions.
 SLES-54767:
   name: "Sniper Assault"
   region: "PAL-E"
@@ -26917,8 +24819,6 @@ SLES-54788:
   region: "PAL-E"
   gsHWFixes:
     textureInsideRT: 1 # Fixes shadows.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-54789:
   name: "Beta Bloc"
   region: "PAL-E"
@@ -26952,8 +24852,6 @@ SLES-54806:
     vu1ClampMode: 3 # Fixes texture corruption light shimmering and reflective surfaces.
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned bloom effects.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-54807:
   name: "Thrillville - Off the Rails"
   region: "PAL-F"
@@ -26961,31 +24859,20 @@ SLES-54807:
     vu1ClampMode: 3 # Fixes texture corruption light shimmering and reflective surfaces.
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned bloom effects.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-54809:
   name: "Charlotte's Web"
   region: "PAL-A"
 SLES-54810:
   name: "Rugby 08"
   region: "PAL-E"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-54811:
   name: "Rugby 08"
   region: "PAL-I"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-54812:
   name: "Madden NFL 08"
   region: "PAL-E"
   clampModes:
     vuClampMode: 3 # Missing geometry with microVU.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-54813:
   name: "NASCAR 08"
   region: "PAL-A-E"
@@ -27119,9 +25006,6 @@ SLES-54867:
   region: "PAL-E-F"
   clampModes:
     vuClampMode: 2 # Fix black textures on characters.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-54870:
   name: "FIFA '08"
   region: "PAL-E"
@@ -27205,8 +25089,6 @@ SLES-54887:
     vu1ClampMode: 3 # Fixes texture corruption light shimmering and reflective surfaces.
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned bloom effects.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-54888:
   name: "Pro Biker 2"
   region: "PAL-E"
@@ -27246,9 +25128,6 @@ SLES-54897:
 SLES-54898:
   name: "Metropolismania 2"
   region: "PAL-E"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-54899:
   name: "EyeToy - Bob the Builder"
   region: "PAL-M5"
@@ -27266,8 +25145,6 @@ SLES-54903:
   region: "PAL-M13"
   gsHWFixes:
     halfPixelOffset: 4 # Removes horizontal and vertical lines on the ground, trees and the sky.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-54904:
   name: "The Simpsons Game"
   name-sort: "Simpsons Game, The"
@@ -27276,8 +25153,6 @@ SLES-54904:
   gsHWFixes:
     halfPixelOffset: 2 # Corrects misaligned cel shading.
     roundSprite: 1 # Further corrects misaligned cel shading.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-54905:
   name: "The Simpsons Game"
   name-sort: "Simpsons Game, The"
@@ -27286,8 +25161,6 @@ SLES-54905:
   gsHWFixes:
     halfPixelOffset: 2 # Corrects misaligned cel shading.
     roundSprite: 1 # Further corrects misaligned cel shading.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-54906:
   name: "The Simpsons Game"
   name-sort: "Simpsons Game, The"
@@ -27295,8 +25168,6 @@ SLES-54906:
   gsHWFixes:
     halfPixelOffset: 2 # Corrects misaligned cel shading.
     roundSprite: 1 # Further corrects misaligned cel shading.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-54913:
   name: "Pro Evolution Soccer 2008"
   region: "PAL-E-S"
@@ -27388,8 +25259,6 @@ SLES-54946:
     - VUSyncHack # Fixes SPS.
   gsHWFixes:
     halfPixelOffset: 1 # Fixes post bloom alignment.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-54947:
   name: "Dogz"
   region: "PAL-M6"
@@ -27457,8 +25326,6 @@ SLES-54962:
   gsHWFixes:
     textureInsideRT: 1 # Crowd textures.
     autoFlush: 1 # Fixes bloom intensity.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-54963:
   name: "Tony Hawk's Proving Ground"
   region: "PAL-E"
@@ -27493,8 +25360,6 @@ SLES-54974:
   gsHWFixes:
     textureInsideRT: 1 # Crowd textures.
     autoFlush: 1 # Fixes bloom intensity.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-54975:
   name: "George Of The Jungle"
   region: "PAL-E"
@@ -27571,41 +25436,26 @@ SLES-54997:
   compat: 5
   gameFixes:
     - EETimingHack # Flickery textures.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-54998:
   name: "Mercenaries 2 - L'enfer des Favelas"
   region: "PAL-F"
   gameFixes:
     - EETimingHack # Flickery textures.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-54999:
   name: "Mercenaries 2 - Inferno di Fuoco"
   region: "PAL-I"
   gameFixes:
     - EETimingHack # Flickery textures.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-55000:
   name: "Mercenaries 2 - World in Flames"
   region: "PAL-G"
   gameFixes:
     - EETimingHack # Flickery textures.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-55001:
   name: "Mercenaries 2 - World in Flames"
   region: "PAL-S"
   gameFixes:
     - EETimingHack # Flickery textures.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-55002:
   name: "Need for Speed - ProStreet"
   region: "PAL-E"
@@ -27637,8 +25487,6 @@ SLES-55007:
   compat: 4
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes skin colour.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-55008:
   name: "Riding Star 3"
   region: "PAL-M4"
@@ -27649,8 +25497,6 @@ SLES-55010:
     vu1ClampMode: 3 # Fixes texture corruption light shimmering and reflective surfaces.
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned bloom effects.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-55011:
   name: "Thrillville - Fuera de Control"
   region: "PAL-S"
@@ -27658,8 +25504,6 @@ SLES-55011:
     vu1ClampMode: 3 # Fixes texture corruption light shimmering and reflective surfaces.
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned bloom effects.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-55012:
   name: "The Golden Compass"
   name-sort: "Golden Compass, The"
@@ -27684,8 +25528,6 @@ SLES-55016:
   region: "PAL-M6"
   gsHWFixes:
     halfPixelOffset: 4 # Fixes bloom on sunlight.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-55017:
   name: "Yu-Gi-Oh! GX - Tag Force Evolution"
   region: "PAL-M5"
@@ -27703,16 +25545,12 @@ SLES-55019:
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes vendor and other bloom.
     autoFlush: 2 # Fixes missing bloom and shadow definition.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-55020:
   name: "Die Simpsons - Das Spiel"
   region: "PAL-G"
   gsHWFixes:
     halfPixelOffset: 2 # Corrects misaligned cel shading.
     roundSprite: 1 # Further corrects misaligned cel shading.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-55021:
   name: "Pro Evolution Soccer 2008"
   region: "PAL-F-G"
@@ -27731,55 +25569,41 @@ SLES-55025:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes ground texture flicker and improves car body reflections.
     autoFlush: 1 # Fixes lens flares and missing sun.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-55026:
   name: "Disney/Pixar Cars - Mater-National Championship"
   region: "PAL-F-DU"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes ground texture flicker and improves car body reflections.
     autoFlush: 1 # Fixes lens flares and missing sun.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-55027:
   name: "Disney/Pixar Cars - Hook International"
   region: "PAL-G"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes ground texture flicker and improves car body reflections.
     autoFlush: 1 # Fixes lens flares and missing sun.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-55028:
   name: "Disney/Pixar Cars - La Coppa Internazionale di Carl Attrezzi"
   region: "PAL-I"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes ground texture flicker and improves car body reflections.
     autoFlush: 1 # Fixes lens flares and missing sun.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-55029:
   name: "Disney/Pixar Cars - La Copa Internacional de Mate"
   region: "PAL-S"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes ground texture flicker and improves car body reflections.
     autoFlush: 1 # Fixes lens flares and missing sun.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-55030:
   name: "Disney/Pixar Cars - Mater-National Championship"
   region: "PAL-SC"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes ground texture flicker and improves car body reflections.
     autoFlush: 1 # Fixes lens flares and missing sun.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-55031:
   name: "DreamWorks Kung Fu Panda"
   region: "PAL-F"
   gsHWFixes:
     cpuSpriteRenderBW: 1 # Fixes textures.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-55032:
   name: "Off Road"
   region: "PAL-M5"
@@ -27865,8 +25689,6 @@ SLES-55075:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes bloom alignment.
     autoFlush: 1
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-55076:
   name: "Saint & Sinner"
   region: "PAL-E"
@@ -27905,9 +25727,6 @@ SLES-55102:
   name: "The History Channel - Battle for the Pacific"
   name-sort: "History Channel, The - Battle for the Pacific"
   region: "PAL-E"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-55103:
   name: "Cabela's Big Game Hunter 2008"
   region: "PAL-E"
@@ -28143,8 +25962,6 @@ SLES-55191:
   gsHWFixes:
     textureInsideRT: 1 # Crowd textures.
     autoFlush: 1 # Fixes bloom intensity.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-55192:
   name: "Steam Express"
   region: "PAL-M5"
@@ -28211,8 +26028,6 @@ SLES-55200:
   gsHWFixes:
     textureInsideRT: 1 # Crowd textures.
     autoFlush: 1 # Fixes bloom intensity.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-55201:
   name: "Riding Star"
   region: "PAL-M4"
@@ -28246,8 +26061,6 @@ SLES-55209:
   gsHWFixes:
     recommendedBlendingLevel: 4 # Needed to render the board and lights correctly.
     halfPixelOffset: 4 # Aligns the 1/4th of the game that does upscale because the game is silly.
-    mipmap: 2 # Mipmap + trilinear, improves the game's stupid rendering but it's still awful.
-    trilinearFiltering: 1
 SLES-55214:
   name: "Disney Hannah Montana - Spotlight World Tour"
   region: "PAL-M4"
@@ -28267,15 +26080,9 @@ SLES-55218:
   region: "PAL-E"
   clampModes:
     vuClampMode: 2 # Fixes black textures on characters.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-55219:
   name: "Hasbro Family Game Night"
   region: "PAL-M4"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, fixes textures on battleships model.
-    trilinearFiltering: 1
 SLES-55220:
   name: "Summer Athletics"
   region: "PAL-M5"
@@ -28302,22 +26109,16 @@ SLES-55234:
   region: "PAL-SW"
   gsHWFixes:
     cpuSpriteRenderBW: 1 # Fixes textures.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-55235:
   name: "DreamWorks Kung Fu Panda"
   region: "PAL-I"
   gsHWFixes:
     cpuSpriteRenderBW: 1 # Fixes textures.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-55236:
   name: "DreamWorks Kung Fu Panda"
   region: "PAL-G-S"
   gsHWFixes:
     cpuSpriteRenderBW: 1 # Fixes textures.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-55237:
   name: "Naruto - Ultimate Ninja 3"
   region: "PAL-M5"
@@ -28331,15 +26132,9 @@ SLES-55238:
   region: "PAL-E"
   clampModes:
     vuClampMode: 3 # Missing geometry with microVU.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-55239:
   name: "Hasbro Family Game Night"
   region: "PAL-I"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, fixes textures on battleships model.
-    trilinearFiltering: 1
 SLES-55240:
   name: "Pipe Mania"
   region: "PAL-M5"
@@ -28449,15 +26244,9 @@ SLES-55266:
 SLES-55271:
   name: "Spongebob SquarePants Featuring Nicktoons - Globs of Doom"
   region: "PAL-E-F"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, fixes graphical errors video.
-    trilinearFiltering: 1
 SLES-55272:
   name: "Spongebob SquarePants Featuring Nicktoons - Globs of Doom"
   region: "PAL-M3"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, fixes graphical errors video.
-    trilinearFiltering: 1
 SLES-55274:
   name: "Diabolik - The Original Sin"
   region: "PAL-M6"
@@ -28475,8 +26264,6 @@ SLES-55278:
   gsHWFixes:
     recommendedBlendingLevel: 4 # Needed to render the board and lights correctly.
     halfPixelOffset: 4 # Aligns the 1/4th of the game that does upscale because the game is silly.
-    mipmap: 2 # Mipmap + trilinear, improves the game's stupid rendering but it's still awful.
-    trilinearFiltering: 1
 SLES-55280:
   name: "King of Fighters '98 - Ultimate Match"
   region: "PAL-E"
@@ -28517,9 +26304,6 @@ SLES-55329:
 SLES-55330:
   name: "Secret Service"
   region: "PAL-E"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-55331:
   name: "Cabela's Dangerous Adventures"
   region: "PAL-E"
@@ -28562,15 +26346,9 @@ SLES-55340:
 SLES-55341:
   name: "Hasbro Family Game Night"
   region: "PAL-G"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, fixes textures on battleships model.
-    trilinearFiltering: 1
 SLES-55342:
   name: "Hasbro Family Game Night"
   region: "PAL-E"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, fixes textures on battleships model.
-    trilinearFiltering: 1
 SLES-55343:
   name: "Tube Mania"
   region: "PAL-F"
@@ -28597,8 +26375,6 @@ SLES-55349:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes blurriness.
-    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_NFSUndercover"
 SLES-55350:
   name: "Need for Speed - Undercover"
@@ -28606,8 +26382,6 @@ SLES-55350:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes blurriness.
-    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_NFSUndercover"
 SLES-55351:
   name: "Need for Speed - Undercover"
@@ -28615,8 +26389,6 @@ SLES-55351:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes blurriness.
-    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_NFSUndercover"
 SLES-55352:
   name: "Need for Speed - Undercover"
@@ -28625,8 +26397,6 @@ SLES-55352:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes blurriness.
-    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_NFSUndercover"
 SLES-55353:
   name: "Need for Speed - Undercover"
@@ -28634,15 +26404,10 @@ SLES-55353:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes blurriness.
-    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_NFSUndercover"
 SLES-55354:
   name: "Shin Megami Tensei - Persona 3 FES"
   region: "PAL-E"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, fixes flashing windows.
-    trilinearFiltering: 1
   memcardFilters:
     - "SLES-55354"
     - "SLES-55018"
@@ -28765,9 +26530,6 @@ SLES-55398:
 SLES-55402:
   name: "Nickelodeon SpongeBob SquarePants featuring Nicktoons - Globs of Doom"
   region: "PAL-A"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, fixes graphical errors video.
-    trilinearFiltering: 1
 SLES-55404:
   name: "Nickelodeon The Naked Brothers Band - The Video Game"
   region: "PAL-E"
@@ -28828,8 +26590,6 @@ SLES-55442:
   gsHWFixes:
     textureInsideRT: 1 # Needed for post processing effects.
     autoFlush: 1 # Fixes missing blur layer.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-55443:
   name: "Mana Khemia - Alchemists of Al-Revis"
   region: "PAL-E"
@@ -28892,9 +26652,6 @@ SLES-55465:
 SLES-55467:
   name: "Trivial Pursuit"
   region: "PAL-M5"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-55468:
   name: "Nickelodeon Dora the Explorer - Dora Saves the Snow Princess"
   region: "PAL-E"
@@ -28978,8 +26735,6 @@ SLES-55496:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misaligned bloom.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-55499:
   name: "Disney G-Force"
   region: "PAL-M4"
@@ -29005,8 +26760,6 @@ SLES-55511:
   gsHWFixes:
     halfPixelOffset: 4 # Aligns bloom as best it can be.
     autoFlush: 1 # Fixes bloom rendering.
-    mipmap: 2 # Mipmap + trilinear, improves ground and building textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-55512:
   name: "Sengoku Anthology"
   region: "PAL-M5"
@@ -29018,17 +26771,12 @@ SLES-55516:
 SLES-55517:
   name: "Trivial Pursuit"
   region: "PAL-SC"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-55518:
   name: "Guitar Hero - Van Halen"
   region: "PAL-A"
   gsHWFixes:
     preloadFrameData: 1 # Fixes icons.
     autoFlush: 1 # Fixes bloom intensity.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
   roundModes:
     vu1RoundMode: 0 # Fixes VU size spam and potential graphical issues with GH3 engine.
 SLES-55520:
@@ -29066,9 +26814,6 @@ SLES-55528:
   region: "PAL-A"
   clampModes:
     vuClampMode: 2 # Fixes black textures on characters.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-55529:
   name: "Germany's Next Topmodel"
   region: "PAL-G"
@@ -29226,8 +26971,6 @@ SLES-55610:
   region: "PAL-SC"
   gsHWFixes:
     halfPixelOffset: 1 # Reduces the ghosting effect.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-55622:
   name: "Disney/Pixar Toy Story 3"
   region: "PAL-M6"
@@ -29285,9 +27028,6 @@ SLES-55648:
   name: "WWE All-Stars"
   region: "PAL-M5"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ring textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-55652:
   name: "FIFA 12"
   region: "PAL-M4"
@@ -29375,8 +27115,6 @@ SLES-82009:
     roundSprite: 2 # Fixes font artifacts.
     autoFlush: 1 # Fixes depth of field blur.
     recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLES-82010:
   name: "Metal Gear Solid 2, Document of"
   region: "PAL-E"
@@ -29403,8 +27141,6 @@ SLES-82013:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     halfPixelOffset: 2 # Fixes blurry characters.
     autoFlush: 2 # Fixes lens flare.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
 SLES-82018:
   name: "Cy Girls [Ice Disc]"
@@ -29431,8 +27167,6 @@ SLES-82024:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     halfPixelOffset: 2 # Fixes blurry characters.
     autoFlush: 2 # Fixes lens flare.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
 SLES-82026:
   name: "Metal Gear Solid 3 - Snake Eater"
@@ -29443,8 +27177,6 @@ SLES-82026:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     halfPixelOffset: 2 # Fixes blurry characters.
     autoFlush: 2 # Fixes lens flare.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
 SLES-82028:
   name: "Star Ocean 3 - Till the End of Time [Disc 1 of 2]"
@@ -29495,8 +27227,6 @@ SLES-82032:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     halfPixelOffset: 2 # Fixes blurry characters.
     autoFlush: 2 # Fixes lens flare.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
 SLES-82036:
   name: "Armored Core - Nexus [Disc 1]"
@@ -29504,8 +27234,6 @@ SLES-82036:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
     recommendedBlendingLevel: 3 # Fixes level brightness.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
   memcardFilters:
     - "SLES-82036"
     - "SLES-82037"
@@ -29515,8 +27243,6 @@ SLES-82037:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
     recommendedBlendingLevel: 3 # Fixes level brightness.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
   memcardFilters:
     - "SLES-82036"
     - "SLES-82037"
@@ -29544,8 +27270,6 @@ SLES-82042:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
     halfPixelOffset: 2 # Fixes blurriness.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
 SLES-82043:
   name: "Metal Gear Solid 3 - Subsistence [Disc 2 of 3]"
@@ -29557,8 +27281,6 @@ SLES-82043:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
     halfPixelOffset: 2 # Fixes blurriness.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
   memcardFilters:
     - "SLES-82042"
@@ -29572,8 +27294,6 @@ SLES-82044:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
     halfPixelOffset: 2 # Fixes blurriness.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
 SLES-82045:
   name: "Metal Gear Solid 3 - Subsistence [Disc 2 of 3]"
@@ -29585,8 +27305,6 @@ SLES-82045:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
     halfPixelOffset: 2 # Fixes blurriness.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
   memcardFilters:
     - "SLES-82044"
@@ -29600,8 +27318,6 @@ SLES-82046:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
     halfPixelOffset: 2 # Fixes blurriness.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
 SLES-82047:
   name: "Metal Gear Solid 3 - Subsistence [Disc 2 of 3]"
@@ -29613,8 +27329,6 @@ SLES-82047:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
     halfPixelOffset: 2 # Fixes blurriness.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
   memcardFilters:
     - "SLES-82046"
@@ -29628,8 +27342,6 @@ SLES-82048:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
     halfPixelOffset: 2 # Fixes blurriness.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
 SLES-82049:
   name: "Metal Gear Solid 3 - Subsistence [Disc 2 of 3]"
@@ -29641,8 +27353,6 @@ SLES-82049:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
     halfPixelOffset: 2 # Fixes blurriness.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
   memcardFilters:
     - "SLES-82048"
@@ -29656,8 +27366,6 @@ SLES-82050:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
     halfPixelOffset: 2 # Fixes blurriness.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
   memcardFilters:
     - "SLES-82042"
@@ -29671,8 +27379,6 @@ SLES-82051:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
     halfPixelOffset: 2 # Fixes blurriness.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
   memcardFilters:
     - "SLES-82044"
@@ -29686,8 +27392,6 @@ SLES-82052:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
     halfPixelOffset: 2 # Fixes blurriness.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
   memcardFilters:
     - "SLES-82046"
@@ -29701,8 +27405,6 @@ SLES-82053:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
     halfPixelOffset: 2 # Fixes blurriness.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
   memcardFilters:
     - "SLES-82048"
@@ -29750,9 +27452,6 @@ SLKA-15011:
 SLKA-15013:
   name: "Grand Slam 2003 Tennis" # Hard Hitter 2
   region: "NTSC-K"
-  gsHWFixes:
-    mipmap: 2 # Improves ground texture rendering.
-    trilinearFiltering: 1
 SLKA-15015:
   name: "Ichigeki Sacchuu!! HoiHoi-San"
   region: "NTSC-K"
@@ -29975,8 +27674,6 @@ SLKA-25039:
     autoFlush: 1 # Fixes bloom and sun rendering in front of everything.
     halfPixelOffset: 2 # Aligns bloom effect a little bit better when upscaled.
     bilinearUpscale: 2 # Reduces color banding of the sun glare.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
   roundModes:
     vu1RoundMode: 1 # Bright lights in cars.
 SLKA-25041:
@@ -30042,8 +27739,6 @@ SLKA-25056:
   region: "NTSC-K"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLKA-25057:
   name: "All-Star Baseball 2004 featuring Derek Jeter"
   region: "NTSC-K"
@@ -30103,16 +27798,11 @@ SLKA-25073:
   region: "NTSC-K"
   gsHWFixes:
     autoFlush: 2 # Fixes lava effect.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLKA-25076:
   name: "Jin Yeosin Jeonsaeng III - Nocturne"
   region: "NTSC-K"
   roundModes:
     eeRoundMode: 0 # Ladder glitch in "Assembly of Nihilo B11" level.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, fixes missing lights to match sw renderer.
-    trilinearFiltering: 1
 SLKA-25077:
   name: "Culdcept II - Expansion"
   region: "NTSC-K"
@@ -30129,8 +27819,6 @@ SLKA-25080:
   region: "NTSC-K"
   gsHWFixes:
     halfPixelOffset: 1 # Sharpens world in far distances.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLKA-25081:
   name: "SD Gundam G Generation Neo"
   region: "NTSC-K"
@@ -30170,9 +27858,6 @@ SLKA-25088:
 SLKA-25090:
   name: "Starsky & Hutch"
   region: "NTSC-K"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves building textures.
-    trilinearFiltering: 1
 SLKA-25091:
   name: "Bansug Yeongung vs. 3D"
   region: "NTSC-K"
@@ -30200,17 +27885,11 @@ SLKA-25095:
   region: "NTSC-K"
   clampModes:
     vuClampMode: 3 # Missing geometry with microVU.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLKA-25097:
   name: "Tiger Woods PGA Tour 2004"
   region: "NTSC-K"
   clampModes:
     vuClampMode: 2 # Fixes black textures on characters.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLKA-25098:
   name: "The Lord of the Rings - The Return of the King"
   name-sort: "Lord of the Rings, The - The Return of the King"
@@ -30288,8 +27967,6 @@ SLKA-25118:
     recommendedBlendingLevel: 4 # Fixes missing lighting and makes snow not look like snow sludge.
     textureInsideRT: 1 # Fixes rainbow effect in the pause menu before a jump.
     halfPixelOffset: 2 # Fixes depth lines.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLKA-25120:
   name: "Prince of Persia - The Sands of Time"
   region: "NTSC-K"
@@ -30319,8 +27996,6 @@ SLKA-25129:
   region: "NTSC-K"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes lines in cutscenes.
-    mipmap: 2 # Cleans up texture detail.
-    trilinearFiltering: 1 # Smoothes out mipmapping.
 SLKA-25130:
   name: "Bloody Roar 4"
   region: "NTSC-K"
@@ -30342,8 +28017,6 @@ SLKA-25135:
   region: "NTSC-K"
   compat: 5
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_Kunoichi"
 SLKA-25136:
   name: "Need for Speed - Underground"
@@ -30359,8 +28032,6 @@ SLKA-25137:
   region: "NTSC-K"
   gsHWFixes:
     halfPixelOffset: 1 # Fixes vertical lines, font and others.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLKA-25138:
   name: ".hack//악성변이 Vol.2"
   name-sort: ".hack Mutation Part 2"
@@ -30447,9 +28118,6 @@ SLKA-25160:
   region: "NTSC-K"
   roundModes:
     eeRoundMode: 0 # Ladder glitch in "Assembly of Nihilo B11" level.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, fixes missing lights to match sw renderer.
-    trilinearFiltering: 1
 SLKA-25161:
   name: "Aqua Kids"
   region: "NTSC-K"
@@ -30524,8 +28192,6 @@ SLKA-25180:
   region: "NTSC-K"
   gsHWFixes:
     preloadFrameData: 1 # Fixes missing loading screens.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLKA-25181:
   name: "Energy Airforce Aim Strike"
   region: "NTSC-K"
@@ -30575,8 +28241,6 @@ SLKA-25196:
   gsHWFixes:
     autoFlush: 1 # Aligns and corrects shadows.
     roundSprite: 1 # Fixes depth line.
-    mipmap: 2 # Mipmap + trilinear, improves building textures and reduces pop in.
-    trilinearFiltering: 1
     cpuCLUTRender: 1 # Fixes janky coloured cars.
     gpuTargetCLUT: 1 # Fixes janky coloured cars.
     textureInsideRT: 1 # Fixes car textures.
@@ -30587,9 +28251,6 @@ SLKA-25198:
   name: "Tenchu Kurenai"
   region: "NTSC-K"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLKA-25199:
   name: "Geomho 3" # Kengo 3
   region: "NTSC-K"
@@ -30601,16 +28262,12 @@ SLKA-25200:
     recommendedBlendingLevel: 4 # Fixes missing lighting and makes snow not look like snow sludge.
     textureInsideRT: 1 # Fixes rainbow effect in the pause menu before a jump.
     halfPixelOffset: 2 # Fixes depth lines.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLKA-25201:
   name: "Armored Core - Nexus [Disc 1]"
   region: "NTSC-K"
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
     recommendedBlendingLevel: 3 # Fixes level brightness.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
   memcardFilters:
     - "SLKA-25201"
     - "SLKA-25202"
@@ -30620,8 +28277,6 @@ SLKA-25202:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
     recommendedBlendingLevel: 3 # Fixes level brightness.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
   memcardFilters:
     - "SLKA-25201"
     - "SLKA-25202"
@@ -30643,8 +28298,6 @@ SLKA-25206:
     recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 2 # Fixes blur and obscures sun behind objects.
-    mipmap: 2 # Fixes over sharpening.
-    trilinearFiltering: 1 # Smoothes out mipmapping.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     bilinearUpscale: 2 # Smooths out sun glare textures like native.
     getSkipCount: "GSC_BurnoutGames"
@@ -30711,8 +28364,6 @@ SLKA-25218:
   gsHWFixes:
     texturePreloading: 1 # Performs much better with partial preload.
     autoFlush: 1 # Fixes bloom rendering.
-    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
-    trilinearFiltering: 1
   roundModes:
     vu1RoundMode: 0 # Fixes missing light cones curtains and certain effects.
 SLKA-25219:
@@ -30751,15 +28402,11 @@ SLKA-25225:
   compat: 5
   gsHWFixes:
     minimumBlendingLevel: 2 # Fixes dark font to more bright like software mode.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLKA-25226:
   name: "Disney/Pixar The Incredibles"
   name-sort: "Disney/Pixar Incredibles, The"
   region: "NTSC-K"
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves the street's textures to match sw renderer.
-    trilinearFiltering: 1
     halfPixelOffset: 2 # Fixes bloom misalignment when upscaling.
     cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling.
 SLKA-25227:
@@ -30794,8 +28441,6 @@ SLKA-25237:
   region: "NTSC-K"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLKA-25240:
   name: "WWE SmackDown! Shut Your Mouth"
   region: "NTSC-K"
@@ -30815,8 +28460,6 @@ SLKA-25243:
     halfPixelOffset: 2 # Fixes misaligned blur.
     cpuSpriteRenderBW: 2 # Fixes black spots appearing on some surfaces and massively reduces RP TC and TU count.
     cpuSpriteRenderLevel: 2 # Needed for above.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLKA-25244:
   name: "WWE SmackDown! vs. Raw"
   region: "NTSC-K"
@@ -30849,8 +28492,6 @@ SLKA-25251:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     halfPixelOffset: 2 # Fixes blurriness.
     autoFlush: 2 # Fixes lens flare.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
 SLKA-25252:
   name: "Forgotten Realms - Demon Stone"
@@ -30860,8 +28501,6 @@ SLKA-25252:
   gsHWFixes:
     halfPixelOffset: 1 # Reduces ghosting.
     roundSprite: 1 # Reduces ghosting even more.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLKA-25254:
   name: "Digimon Rumble Arena 2"
   region: "NTSC-K"
@@ -30921,8 +28560,6 @@ SLKA-25270:
     halfPixelOffset: 1 # Fixes misaligned blur.
     cpuSpriteRenderBW: 1 # Fixes broken shadow caused by HPO 1.
     cpuSpriteRenderLevel: 2 # Needed for above.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLKA-25271:
   name: "Harry Potter and the Order of the Phoenix"
   region: "NTSC-K"
@@ -30952,9 +28589,6 @@ SLKA-25277:
 SLKA-25278:
   name: "MVP Baseball 2005"
   region: "NTSC-K"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLKA-25279:
   name: "Hello Kitty - Rescue Mission"
   region: "NTSC-K"
@@ -30998,9 +28632,6 @@ SLKA-25288:
 SLKA-25289:
   name: "Jin Samguk Mussang 4"
   region: "NTSC-K"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLKA-25290:
   name: "Super Monkey Ball Deluxe"
   region: "NTSC-K"
@@ -31008,8 +28639,6 @@ SLKA-25290:
     eeRoundMode: 1 # Fixes object balls never stopping in the Monkey Billiards DX minigame.
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes text and foliage color.
-    mipmap: 2 # Mipmap + trilinear, improves stage textures to match sw renderer.
-    trilinearFiltering: 1
 SLKA-25291:
   name: "Chains of Power"
   region: "NTSC-K"
@@ -31056,8 +28685,6 @@ SLKA-25303:
   name-sort: "Matrix, The - Path of Neo"
   region: "NTSC-K"
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     halfPixelOffset: 2 # Fix effects upscaling.
     autoFlush: 1 # Fixes broken post processing.
 SLKA-25304:
@@ -31069,8 +28696,6 @@ SLKA-25304:
     recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 2 # Fixes blur and obscures sun behind objects.
-    mipmap: 2 # Fixes over sharpening.
-    trilinearFiltering: 1 # Smoothes out mipmapping.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     bilinearUpscale: 2 # Smooths out sun glare textures like native.
     getSkipCount: "GSC_BurnoutGames"
@@ -31134,9 +28759,6 @@ SLKA-25318:
 SLKA-25319:
   name: "보글보글 스폰지밥 - 레디, 액션!"
   region: "NTSC-K"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLKA-25320:
   name: "Ikusa Gami"
   region: "NTSC-K"
@@ -31157,8 +28779,6 @@ SLKA-25322:
     recommendedBlendingLevel: 4 # Improves car color.
     autoFlush: 1 # Softens bloom on objects and cars.
     halfPixelOffset: 4 # Fixes misaligned bloom on objects and cars.
-    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
-    trilinearFiltering: 1
 SLKA-25323:
   name: "FIFA '06"
   region: "NTSC-K"
@@ -31169,8 +28789,6 @@ SLKA-25325:
   region: "NTSC-K"
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes missing lighting and makes snow not look like snow sludge.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLKA-25327:
   name: "Harry Potter and the Goblet of Fire"
   region: "NTSC-K"
@@ -31221,16 +28839,12 @@ SLKA-25334:
     halfPixelOffset: 2 # Fixes blurriness.
     cpuCLUTRender: 1 # Final colour adjustment LUT.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLKA-25335:
   name: "Shadow the Hedgehog"
   region: "NTSC-K"
   gsHWFixes:
     recommendedBlendingLevel: 4 # Improves smoke rendering.
     halfPixelOffset: 2 # Fixes misaligned lighting.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLKA-25337:
   name: "Peter Jackson's King Kong - The Official Game of the Movie"
   region: "NTSC-K"
@@ -31243,8 +28857,6 @@ SLKA-25338:
   name-sort: "Godfather, The"
   region: "NTSC-K"
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
-    trilinearFiltering: 1
     textureInsideRT: 1 # Required for complex offset shuffles.
     halfPixelOffset: 2 # Fixes center line in post processing.
 SLKA-25339:
@@ -31263,8 +28875,6 @@ SLKA-25341:
     cpuCLUTRender: 1 # Fixes the rest of the bad textures.
     roundSprite: 1 # Reduces misaligned bloom.
     mergeSprite: 1 # Removes bloom explosion around electrical lights and other light sources such as moon/sun.
-    mipmap: 2 # Mipmap + trilinear, improves road textures to match sw renderer.
-    trilinearFiltering: 1
 SLKA-25342:
   name: "Ryu ga Gotoku"
   region: "NTSC-K"
@@ -31277,21 +28887,14 @@ SLKA-25343:
     vu1ClampMode: 3 # Fixes texture corruption light shimmering and reflective surfaces.
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned bloom effects.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLKA-25344:
   name: "Tom Clancy's Ghost Recon - Advanced Warfighter"
   region: "NTSC-K"
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes building and ground colours.
-    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
-    trilinearFiltering: 1
 SLKA-25345:
   name: "Disney's Chicken Little"
   region: "NTSC-K"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLKA-25346:
   name: "Prince of Persia - The Two Thrones"
   region: "NTSC-K"
@@ -31318,8 +28921,6 @@ SLKA-25353:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
     halfPixelOffset: 2 # Fixes blurriness.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
 SLKA-25354:
   name: "Metal Gear Solid 3 - Subsistence [Limited Edition] [Disc 2 of 3]"
@@ -31332,8 +28933,6 @@ SLKA-25354:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
     halfPixelOffset: 2 # Fixes blurriness.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
   memcardFilters:
     - "SLKA-25353"
@@ -31348,17 +28947,12 @@ SLKA-25355:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
     halfPixelOffset: 2 # Fixes blurriness.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
   memcardFilters:
     - "SLKA-25353"
 SLKA-25358:
   name: "Sonic Riders"
   region: "NTSC-K"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves track and building textures to match sw renderer.
-    trilinearFiltering: 1
 SLKA-25359:
   name: "Winning Eleven 9 - Liveware Edition"
   region: "NTSC-K"
@@ -31398,9 +28992,6 @@ SLKA-25367:
   region: "NTSC-K"
   gameFixes:
     - VUOverflowHack # Fixes SPS.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLKA-25368:
   name: "Full Spectrum Warrior - Ten Hammers"
   region: "NTSC-K"
@@ -31418,8 +29009,6 @@ SLKA-25372:
     recommendedBlendingLevel: 4 # Improves lighting on buildings and objects.
     autoFlush: 2 # Properly diffuses light instead of strips of light.
     roundSprite: 1 # Fixes lighting misalignment such as the street poles and the sun.
-    mipmap: 2 # Fixes over sharpening.
-    trilinearFiltering: 1 # Smoothes out mipmapping.
     getSkipCount: "GSC_BlackAndBurnoutSky"
     beforeDraw: "OI_BurnoutGames"
 SLKA-25373:
@@ -31438,9 +29027,6 @@ SLKA-25374:
 SLKA-25375:
   name: "Transformers - The Game"
   region: "NTSC-K"
-  gsHWFixes:
-    mipmap: 2 # Cleans up texture detail.
-    trilinearFiltering: 1 # Smoothes out texture transitions.
 SLKA-25377:
   name: "OutRun 2006 - Coast 2 Coast"
   region: "NTSC-K"
@@ -31448,8 +29034,6 @@ SLKA-25377:
     autoFlush: 1 # Reduces post-processing misalignment.
     halfPixelOffset: 2 # Fixes bloom misalignment still a bit misaligned.
     roundSprite: 1 # Fixes bloom misalignment still a bit misaligned + font artifacts.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLKA-25378:
   name: "FIFA World Cup Germany 2006"
   region: "NTSC-K"
@@ -31468,8 +29052,6 @@ SLKA-25382:
   region: "NTSC-K"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes lighting misalignment.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLKA-25384:
   name: "Blazing Souls"
   region: "NTSC-K"
@@ -31531,8 +29113,6 @@ SLKA-25399:
   region: "NTSC-K"
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned textures.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLKA-25401:
   name: "FlatOut 2"
   region: "NTSC-K"
@@ -31579,8 +29159,6 @@ SLKA-25410:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLKA-25411:
   name: "Need for Speed - ProStreet"
   region: "NTSC-K"
@@ -31600,8 +29178,6 @@ SLKA-25414:
   gsHWFixes:
     textureInsideRT: 1 # Crowd textures.
     autoFlush: 1 # Fixes bloom intensity.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLKA-25417:
   name: "Jin Samguk Mussang 4 - Empires"
   region: "NTSC-K"
@@ -31689,8 +29265,6 @@ SLKA-25446:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes blurriness.
-    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_NFSUndercover"
 SLKA-25447:
   name: "FIFA '09"
@@ -31778,8 +29352,6 @@ SLKA-25472:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     halfPixelOffset: 2 # Fixes blurriness.
     autoFlush: 2 # Fixes lens flare.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
 SLKA-25475:
   name: "FIFA 11"
@@ -31816,8 +29388,6 @@ SLKA-35001:
     roundSprite: 2 # Fixes font artifacts.
     autoFlush: 1 # Fixes depth of field blur.
     recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLKA-35003:
   name: "Sakura Taisen - Atsuki Chishioni"
   region: "NTSC-K"
@@ -31838,8 +29408,6 @@ SLKA-90502:
     recommendedBlendingLevel: 4 # Fixes missing lighting and makes snow not look like snow sludge.
     textureInsideRT: 1 # Fixes rainbow effect in the pause menu before a jump.
     halfPixelOffset: 2 # Fixes depth lines.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLKA-90503:
   name: "Need for Speed - Underground"
   region: "NTSC-K"
@@ -31867,8 +29435,6 @@ SLPM-55003:
     halfPixelOffset: 2 # Fixes blurriness.
     cpuCLUTRender: 1 # Final colour adjustment LUT.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-55004:
   name: "Burnout Revenge (EASY 1980)"
   region: "NTSC-J"
@@ -31878,8 +29444,6 @@ SLPM-55004:
     recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 2 # Fixes blur and obscures sun behind objects.
-    mipmap: 2 # Fixes over sharpening.
-    trilinearFiltering: 1 # Smoothes out mipmapping.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     bilinearUpscale: 2 # Smooths out sun glare textures like native.
     getSkipCount: "GSC_BurnoutGames"
@@ -31988,8 +29552,6 @@ SLPM-55034:
     autoFlush: 1 # Post-processing.
     halfPixelOffset: 2 # Offset post-processing.
     texturePreloading: 1 # Improves performance.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_Battlefield2" # Depth clear.
     beforeDraw: "OI_Battlefield2" # Framebuffer copy, fixes rendering for bottom part of screen.
 SLPM-55035:
@@ -32004,8 +29566,6 @@ SLPM-55036:
     recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 2 # Fixes blur and obscures sun behind objects.
-    mipmap: 2 # Fixes over sharpening.
-    trilinearFiltering: 1 # Smoothes out mipmapping.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     bilinearUpscale: 2 # Smooths out sun glare textures like native.
     getSkipCount: "GSC_BurnoutGames"
@@ -32018,15 +29578,11 @@ SLPM-55037:
     halfPixelOffset: 2 # Fixes misaligned blur.
     cpuSpriteRenderBW: 2 # Fixes black spots appearing on some surfaces and massively reduces RP TC and TU count.
     cpuSpriteRenderLevel: 2 # Needed for above.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-55038:
   name: "Grand Theft Auto - Liberty City Stories [Best Price]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 1 # Removes blur due to misaligned fullscreen effect.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-55039:
   name: "Soukoku no Kusabi - Hiiro no Kakera 3 [Limited Edition]"
   region: "NTSC-J"
@@ -32048,8 +29604,6 @@ SLPM-55046:
   gsHWFixes:
     alignSprite: 1 # Fixes lighting and vertical lines, also works with normal vertex.
     roundSprite: 1 # Fixes misaligned map.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
     skipDrawStart: 1 # Removes large black box around player car till we properly emulate it.
     skipDrawEnd: 1 # Removes large black box around player car till we properly emulate it.
 SLPM-55047:
@@ -32149,8 +29703,6 @@ SLPM-55076:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes lighting misalignment.
     mergeSprite: 1 # Removes occasional vertical lines.
-    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-55077:
   name: SSX3 [EASY 1980]
   name-sort: SSX3 [EASY 1980]
@@ -32160,8 +29712,6 @@ SLPM-55077:
     recommendedBlendingLevel: 4 # Fixes missing lighting and makes snow not look like snow sludge.
     textureInsideRT: 1 # Fixes rainbow effect in the pause menu before a jump.
     halfPixelOffset: 2 # Fixes depth lines.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-55079:
   name: "Scarlet - Nichijou no Kyoukaisen"
   region: "NTSC-J"
@@ -32333,15 +29883,10 @@ SLPM-55127:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes blurriness.
-    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_NFSUndercover"
 SLPM-55128:
   name: "Rugby 08"
   region: "NTSC-J"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-55130:
   name: "Pro Yakyuu Spirits 5 - Kanzenban"
   region: "NTSC-J"
@@ -32388,8 +29933,6 @@ SLPM-55141:
   name: "Destroy All Humans! [THQ Collection]"
   region: "NTSC-J"
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     textureInsideRT: 1 # Fixes shadow maps.
     roundSprite: 2 # Fixes misaligned bloom.
     mergeSprite: 1 # Fixes misaligned bloom.
@@ -32684,8 +30227,6 @@ SLPM-55236:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
     halfPixelOffset: 2 # Fixes blurriness.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
 SLPM-55237:
   name: "Metal Gear & Metal Gear 2 - Solid Snake"
@@ -32715,8 +30256,6 @@ SLPM-55244:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes blurriness.
-    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_NFSUndercover"
 SLPM-55245:
   name: ひまわり -Pebble in the Sky-
@@ -32937,8 +30476,6 @@ SLPM-60119:
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes character models.
-    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-60120:
   name: "Greatest Striker"
   region: "NTSC-J"
@@ -33034,8 +30571,6 @@ SLPM-60149:
     - SoftwareRendererFMVHack # Fixes FMVs disabling hash cache.
   gsHWFixes:
     recommendedBlendingLevel: 2 # Helps banding when dithering is enabled.
-    mipmap: 2 # Fixes terrain rendering and edge of screen issues in 16:9 mode.
-    trilinearFiltering: 1
     roundSprite: 1 # Fixes font and HUD artifacts.
     alignSprite: 1 # Fixes vertical lines.
     mergeSprite: 1 # Fixes vertical lines.
@@ -33092,8 +30627,6 @@ SLPM-60174:
   gsHWFixes:
     autoFlush: 1 # Fixes incorrect blur effect.
     halfPixelOffset: 4 # Improves blur.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-60175:
   name: "Wangan Midnight [Trial]"
   region: "NTSC-J"
@@ -33114,9 +30647,6 @@ SLPM-60180:
   region: "NTSC-J"
   roundModes:
     eeDivRoundMode: 3 # Fixes random game crashing.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves grass rendering to match software.
-    trilinearFiltering: 1
 SLPM-60181:
   name: "Street Golfer"
   region: "NTSC-J"
@@ -33161,8 +30691,6 @@ SLPM-60198:
   region: "NTSC-J"
   gsHWFixes:
     roundSprite: 2 # Fixes lines at the edges of the HUD.
-    mipmap: 2 # Mipmap + trilinear, improves road and grass textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-60199:
   name: "Dengeki PS2 PlayStation D58"
   region: "NTSC-J"
@@ -33287,8 +30815,6 @@ SLPM-60246:
     recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 2 # Fixes blur and obscures sun behind objects.
-    mipmap: 2 # Fixes over sharpening.
-    trilinearFiltering: 1 # Smoothes out mipmapping.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     bilinearUpscale: 2 # Smooths out sun glare textures like native.
     getSkipCount: "GSC_BurnoutGames"
@@ -33301,8 +30827,6 @@ SLPM-60248:
   region: "NTSC-J"
   gsHWFixes:
     minimumBlendingLevel: 2 # Fixes dark font to more bright like software mode.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-60250:
   name: "Need for Speed - Underground 2 [Trial]"
   region: "NTSC-J"
@@ -33343,8 +30867,6 @@ SLPM-60257:
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes FMV lines.
-    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
-    trilinearFiltering: 1
     cpuSpriteRenderBW: 2 # Prevents Death By VRAM explosion.
     cpuSpriteRenderLevel: 2 # Needed for above.
     getSkipCount: "GSC_DeathByDegreesTekkenNinaWilliams"
@@ -33409,8 +30931,6 @@ SLPM-60272:
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
     textureInsideRT: 1 # Fixes corruption.
-    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_UrbanReign"
 SLPM-60273:
   name: "Zettai Zetsumei Toshi 2 - Itetsuita Kioku-tachi [Trial B]"
@@ -33538,8 +31058,6 @@ SLPM-61030:
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 2 # Fixes text box opacity.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-61031:
   name: "Dengeki PS2 PlayStation D52"
   region: "NTSC-J"
@@ -33623,8 +31141,6 @@ SLPM-61059:
   name: "Kunoichi"
   region: "NTSC-J"
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_Kunoichi"
 SLPM-61060:
   name: "Busin 0 - Wizardry Alternative Neo"
@@ -33696,8 +31212,6 @@ SLPM-61090:
   gsHWFixes:
     wildArmsHack: 1 # Fixes blurriness.
     mergeSprite: 1 # Fixes misaligned lights.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-61091:
   name: "Berserk - Millennium Falcon-hen - Seima Senki no Shou"
   region: "NTSC-J"
@@ -33713,8 +31227,6 @@ SLPM-61092:
   gsHWFixes:
     autoFlush: 1 # Aligns and corrects shadows.
     roundSprite: 1 # Fixes depth line.
-    mipmap: 2 # Mipmap + trilinear, improves building textures and reduces pop in.
-    trilinearFiltering: 1
     cpuCLUTRender: 1 # Fixes janky coloured cars.
     gpuTargetCLUT: 1 # Fixes janky coloured cars.
     textureInsideRT: 1 # Fixes car textures.
@@ -33815,8 +31327,6 @@ SLPM-61118:
   gsHWFixes:
     halfPixelOffset: 2 # Corrects shadow alignment and reduces blurriness.
     recommendedBlendingLevel: 3 # Fixes level and map menu brightness.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
     preloadFrameData: 1 # Fixes glowing emblems.
 SLPM-61119:
   name: "Armored Core - Last Raven [Trial]"
@@ -33824,8 +31334,6 @@ SLPM-61119:
   gsHWFixes:
     halfPixelOffset: 2 # Corrects shadow alignment and reduces blurriness.
     recommendedBlendingLevel: 3 # Fixes level and map menu brightness.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
     preloadFrameData: 1 # Fixes glowing emblems.
 SLPM-61120:
   name: "Drag-on Dragoon 2 - Fuuin no Aka, Haitoku no Kuro [Trial Version]"
@@ -33867,8 +31375,6 @@ SLPM-61127:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves car reflections.
     autoFlush: 1
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-61129:
   name: "Famitsu PS2 Special Disc - Capcom Game Collection"
   region: "NTSC-J"
@@ -33919,8 +31425,6 @@ SLPM-61137:
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves car reflections.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-61138:
   name: "Akumajou Dracula - Yami no Juin"
   region: "NTSC-J"
@@ -33952,8 +31456,6 @@ SLPM-61147:
     halfPixelOffset: 2 # Fixes lighting misalignment and reduces ground shadows (probably texture cache issue).
     roundSprite: 2 # Fixes font artifacts.
     textureInsideRT: 1 # Fixes bad crystal surfaces.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-61148:
   name: "Growlanser V - Generations [Trial]"
   region: "NTSC-J"
@@ -33981,8 +31483,6 @@ SLPM-61155:
   name: "Lara Croft Tomb Raider - Legend [Trial]"
   region: "NTSC-J"
   gsHWFixes:
-    mipmap: 2 # Fixes distant characters and models.
-    trilinearFiltering: 1
     textureInsideRT: 1 # Needed for post processing effects.
     autoFlush: 1 # Fixes bloom intensity.
     minimumBlendingLevel: 4 # Fixes multiple lighting effects from lights, computers, cave walls and more.
@@ -34013,8 +31513,6 @@ SLPM-61161:
     halfPixelOffset: 2 # Fixes misaligned bloom.
     roundSprite: 1 # Fixes chromatic effect.
     autoFlush: 1 # Fixes sun occlusion.
-    mipmap: 2 # Mipmap + trilinear, fixes miptrick textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-61162:
   name: "Dragon Ball Z - Sparking! Meteor"
   region: "NTSC-J"
@@ -34109,9 +31607,6 @@ SLPM-62016:
 SLPM-62019:
   name: "Winning Post 4 Maximum"
   region: "NTSC-J"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-62020:
   name: "G1 Jockey 2"
   region: "NTSC-J"
@@ -34222,8 +31717,6 @@ SLPM-62043:
     - InstantDMAHack # Fixes broken half-bottom artifacts.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-62044:
   name: RCリベンジPro
   name-sort: RCりべんじPro
@@ -34477,9 +31970,6 @@ SLPM-62102:
   region: "NTSC-J"
   gameFixes:
     - EETimingHack # Fixes credits screen.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves road and building textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-62103:
   name: "EX Okuman Chouja Game - The Money Battle"
   region: "NTSC-J"
@@ -34573,9 +32063,6 @@ SLPM-62123:
   name-sort: ういにんぐぽすと5
   name-en: "Winning Post 5"
   region: "NTSC-J"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-62124:
   name: READY 2 RUMBLE BOXING ROUND 2
   name-sort: READY 2 RUMBLE BOXING ROUND 2
@@ -34588,8 +32075,6 @@ SLPM-62125:
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 5 # Corrects lighting to match software.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-62126:
   name: "Hyper Sports 2002 Winter"
   region: "NTSC-J"
@@ -34764,9 +32249,6 @@ SLPM-62168:
   region: "NTSC-J"
   roundModes:
     eeDivRoundMode: 3 # Fixes random game crashing.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves grass rendering to match software.
-    trilinearFiltering: 1
 SLPM-62169:
   name: 実況ワールドサッカー2002
   name-sort: じっきょうわーるどさっかー2002
@@ -34838,9 +32320,6 @@ SLPM-62186:
 SLPM-62188:
   name: "Crazy Bump's - Kattobi Car Battle!"
   region: "NTSC-J"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-62190:
   name: ハイヒートメジャーリーグベースボール 2003
   name-sort: はいひーとめじゃーりーぐべーすぼーる 2003
@@ -34935,8 +32414,6 @@ SLPM-62209:
   name-en: "Gigantic Drive"
   region: "NTSC-J"
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     autoFlush: 2 # Fixes DOF effect.
 SLPM-62211:
   name: 18WHEELER
@@ -35061,9 +32538,6 @@ SLPM-62236:
   compat: 5
   gameFixes:
     - XGKickHack # Fixes black models on certain games in World Tour.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-62237:
   name: 学園都市ヴァラノワール（限定版）
   name-sort: がくえんとし ゔぁらのわーる [げんていばん]
@@ -35089,17 +32563,12 @@ SLPM-62241:
     - EETimingHack # Fixes flickering textures.
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes missing lighting effects.
-    mipmap: 2 # Fixes blurry textures.
-    trilinearFiltering: 1 # Fixes blurry textures.
     cpuFramebufferConversion: 1 # Fixes right side of the screen from garbage textures.
 SLPM-62242:
   name: 撞球 ビリヤードマスター2
   name-sort: どうきゅう びりやーどますたー2
   name-en: "Doukyu Billiards [LowPrice Version]"
   region: "NTSC-J"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-62244:
   name: チョロQHG3
   name-sort: ちょろQHG3
@@ -35167,8 +32636,6 @@ SLPM-62256:
   gsHWFixes:
     halfPixelOffset: 2 # Gets rid of fog line.
     roundSprite: 1 # Fixes lines in FMVs.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-62257:
   name: RALLY CHAMPIONSHIP
   name-sort: RALLY CHAMPIONSHIP
@@ -35211,9 +32678,6 @@ SLPM-62265:
   region: "NTSC-J"
   gameFixes:
     - XGKickHack # Fixes black models on certain games in World Tour.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-62266:
   name: 桃太郎電鉄11 ブラックボンビー出現の巻
   name-sort: ももたろうでんてつ11 ぶらっくぼんびーしゅつげんのまき
@@ -35567,9 +33031,6 @@ SLPM-62344:
   name-sort: しんぷる2000しりーずVol.31 THEちきゅうぼうえいぐん
   name-en: "Simple 2000 Series Vol. 31 - The Chikyuu Boueigun"
   region: "NTSC-J"
-  gsHWFixes:
-    mipmap: 2 # Improves distant textures.
-    trilinearFiltering: 1 # Smooths high frequency textures on distant ground.
 SLPM-62345:
   name: SIMPLE2000シリーズVol.32 THE戦車
   name-sort: しんぷる2000しりーずVol.32 THEせんしゃ
@@ -35580,8 +33041,6 @@ SLPM-62346:
   region: "NTSC-J"
   gsHWFixes:
     autoFlush: 2 # Fixes glows. Also needed for recursive mipmap rendering.
-    mipmap: 2 # Better characters and environment but has a texture cache issue that makes it worse.
-    trilinearFiltering: 1 # Using mipmaps, so may as well.
     textureInsideRT: 1 # Fixes rainbow lighting for some areas.
     getSkipCount: "GSC_BlueTongueGames" # Mipmap rendering on CPU.
 SLPM-62348:
@@ -35723,8 +33182,6 @@ SLPM-62378:
   region: "NTSC-J"
   gsHWFixes:
     textureInsideRT: 1 # Fixes inside RT shuffling.
-    mipmap: 2 # Mipmap + trilinear, improves road and grass textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_BigMuthaTruckers"
 SLPM-62379:
   name: カラオケレボリューション (J-POPベストVol.2)
@@ -35802,9 +33259,6 @@ SLPM-62394:
   region: "NTSC-J"
   gameFixes:
     - XGKickHack # Fixes black models on certain games in World Tour.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-62395:
   name: SIMPLE2000シリーズVol.37 THEシューティング 〜ダブル紫炎龍〜
   name-sort: しんぷる2000しりーずVol.37 THEしゅーてぃんぐ だぶるしえんりゅう
@@ -35883,9 +33337,6 @@ SLPM-62411:
   region: "NTSC-J"
   gameFixes:
     - GIFFIFOHack # Fixes random graphical corruption.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-62412:
   name: SIMPLE2000シリーズVol.41 THEバレーボール
   name-sort: しんぷる2000しりーずVol.41 THEばれーぼーる
@@ -36063,9 +33514,6 @@ SLPM-62449:
   name-sort: とむとじぇりー ひげひげだいせんそう
   name-en: "Tom & Jerry - War of the Whiskers"
   region: "NTSC-J"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, cleans up texture detail.
-    trilinearFiltering: 1
 SLPM-62450:
   name: カラオケレボリューション 〜アニメソングコレクション〜
   name-sort: からおけれぼりゅーしょん あにめそんぐこれくしょん
@@ -36241,9 +33689,6 @@ SLPM-62483:
   name-sort: しんぷる2000しりーず Vol.48 THE たくしー うんてんしゅはきみだ
   name-en: "Simple 2000 Series Vol. 48 - The Taxi - Untenshu ha Kimi da"
   region: "NTSC-J"
-  gsHWFixes:
-    mipmap: 2 # Fixes road markings.
-    trilinearFiltering: 1 # Smooths the texture transitions.
   roundModes:
     eeRoundMode: 2 # Positive rounding fixes distant white models.
     vu1RoundMode: 2 # Positive rounding fixes close white models.
@@ -36401,8 +33846,6 @@ SLPM-62512:
   region: "NTSC-J"
   gsHWFixes:
     autoFlush: 2 # Fixes glows. Also needed for recursive mipmap rendering.
-    mipmap: 2 # Better characters and environment but has a texture cache issue that makes it worse.
-    trilinearFiltering: 1 # Using mipmaps, so may as well.
     textureInsideRT: 1 # Fixes rainbow lighting for some areas.
     getSkipCount: "GSC_BlueTongueGames" # Mipmap rendering on CPU.
 SLPM-62513:
@@ -36414,8 +33857,6 @@ SLPM-62513:
     - EETimingHack # Fixes flickering textures.
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes missing lighting effects.
-    mipmap: 2 # Fixes blurry textures.
-    trilinearFiltering: 1 # Fixes blurry textures.
     cpuFramebufferConversion: 1 # Fixes right side of the screen from garbage textures.
 SLPM-62514:
   name: EA BEST HITS シムピープル 〜お茶の間劇場〜
@@ -36440,9 +33881,6 @@ SLPM-62517:
   name-sort: ういにんぐぽすと5 [KOEI The Best]
   name-en: "Winning Post 5 [Koei The Best]"
   region: "NTSC-J"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-62518:
   name: 提督の決断IV [KOEI The Best]
   name-sort: ていとくのけつだん4 [KOEI The Best]
@@ -37758,9 +35196,6 @@ SLPM-64523:
 SLPM-64524:
   name: "Rally Shox"
   region: "NTSC-K"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-64525:
   name: "Guilty Gear X Plus 'By Your Side'"
   region: "NTSC-K"
@@ -37777,8 +35212,6 @@ SLPM-64528:
     - EETimingHack # Fixes flickering textures.
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes missing lighting effects.
-    mipmap: 2 # Fixes blurry textures.
-    trilinearFiltering: 1 # Fixes blurry textures.
     cpuFramebufferConversion: 1 # Fixes right side of the screen from garbage textures.
 SLPM-64532:
   name: "Digital Holmes"
@@ -38279,8 +35712,6 @@ SLPM-65077:
     - InstantDMAHack # Fixes broken half-bottom artifacts.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
   memcardFilters:
     - "SLPM-65078"
     - "SLPM-65077"
@@ -38293,8 +35724,6 @@ SLPM-65078:
     - InstantDMAHack # Fixes broken half-bottom artifacts.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
   memcardFilters:
     - "SLPM-65078"
     - "SLPM-65077"
@@ -38421,8 +35850,6 @@ SLPM-65104:
     eeRoundMode: 0 # Fixes riders vanish into the floor.
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes missing lighting and makes snow not look like snow sludge.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-65105:
   name: 新コンバットチョロQ
   name-sort: しんこんばっとちょろQ
@@ -38595,8 +36022,6 @@ SLPM-65140:
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 2 # Fixes text box opacity.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-65141:
   name: 続せがれいじり 変珍たませがれ
   name-sort: ぞくせがれいじり へんちんたませがれ
@@ -38819,8 +36244,6 @@ SLPM-65191:
   gsHWFixes:
     preloadFrameData: 1 # Fixes fog and make lights on cars work again.
     autoFlush: 2 # Fixes sun luminosity and penetration of objects.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
   gameFixes:
     - EETimingHack # Fixes random graphical corruption.
 SLPM-65192:
@@ -38895,8 +36318,6 @@ SLPM-65205:
   region: "NTSC-J"
   gsHWFixes:
     autoFlush: 1 # Fixes lens flares.
-    mipmap: 2 # Fixes texture flickering during movement.
-    trilinearFiltering: 1
     gpuTargetCLUT: 1 # Fixes lens flares going through objects.
     bilinearUpscale: 2 # Smooths out sun glare textures.
 SLPM-65206:
@@ -38979,8 +36400,6 @@ SLPM-65212:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misaligned lighting and other effects.
     cpuSpriteRenderBW: 1 # Fixes flickering textures caused by mipmapping.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
   clampModes:
     vuClampMode: 3 # Fixes white shiny weapons.
 SLPM-65213:
@@ -39112,8 +36531,6 @@ SLPM-65234:
   region: "NTSC-J"
   gsHWFixes:
     textureInsideRT: 1 # Fixes inside RT shuffling.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_BigMuthaTruckers"
 SLPM-65235:
   name: ニュールーマニア ポロリ青春
@@ -39153,9 +36570,6 @@ SLPM-65241:
   region: "NTSC-J"
   roundModes:
     eeRoundMode: 0 # Ladder glitch in "Assembly of Nihilo B11" level.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, fixes missing lights to match sw renderer.
-    trilinearFiltering: 1
 SLPM-65242:
   name: 真・女神転生 III-NOCTURNE
   name-sort: しんめがみてんせい3-NOCTURNE
@@ -39163,9 +36577,6 @@ SLPM-65242:
   region: "NTSC-J"
   roundModes:
     eeRoundMode: 0 # Ladder glitch in "Assembly of Nihilo B11" level.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, fixes missing lights to match sw renderer.
-    trilinearFiltering: 1
 SLPM-65243:
   name: 電車でGO!プロフェッショナル2
   name-sort: でんしゃでごーぷろふぇっしょなる2
@@ -39265,9 +36676,6 @@ SLPM-65259:
   region: "NTSC-J"
   roundModes:
     eeRoundMode: 0 # Ladder glitch in "Assembly of Nihilo B11" level.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, fixes missing lights to match sw renderer.
-    trilinearFiltering: 1
 SLPM-65260:
   name: 凱歌の号砲
   name-sort: がいかのごうほう
@@ -40071,8 +37479,6 @@ SLPM-65410:
     textureInsideRT: 1
     texturePreloading: 1 # Performs much better with partial preload.
     halfPixelOffset: 2 # Fixes outlines around characters.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-65411:
   name: 鬼武者 無頼伝
   name-sort: おにむしゃ ぶらいでん
@@ -40087,9 +37493,6 @@ SLPM-65412:
   name-sort: かいじゅうだいげきせん War of the Monsters
   name-en: "War of the Monsters"
   region: "NTSC-J"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-65413:
   name: 鬼武者3
   name-sort: おにむしゃ3
@@ -40135,9 +37538,6 @@ SLPM-65419:
   region: "NTSC-J"
   roundModes:
     vu1RoundMode: 0 # Crashes without.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-65420:
   name: ダビつく3 ダービー馬をつくろう!
   name-sort: だびつく3 だーびーばをつくろう!
@@ -40289,8 +37689,6 @@ SLPM-65446:
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes lines in cutscenes.
-    mipmap: 2 # Cleans up texture detail.
-    trilinearFiltering: 1 # Smoothes out mipmapping.
 SLPM-65447:
   name: Kunoichi-忍-
   name-sort: Kunoichi
@@ -40298,8 +37696,6 @@ SLPM-65447:
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_Kunoichi"
 SLPM-65448:
   name: カンブリアンQTS 〜化石になっても〜
@@ -40315,8 +37711,6 @@ SLPM-65449:
     recommendedBlendingLevel: 4 # Fixes missing lighting and makes snow not look like snow sludge.
     textureInsideRT: 1 # Fixes rainbow effect in the pause menu before a jump.
     halfPixelOffset: 2 # Fixes depth lines.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-65450:
   name: 探偵学園Q 〜奇翁館の殺意〜 [初回生産分]
   name-sort: たんていがくえんQ 〜きおきなかんのさつい〜 [しょかいせいさんぶん]
@@ -40388,9 +37782,6 @@ SLPM-65462:
   compat: 5
   roundModes:
     eeRoundMode: 0 # Ladder glitch in "Assembly of Nihilo B11" level.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, fixes missing lights to match sw renderer.
-    trilinearFiltering: 1
 SLPM-65463:
   name: ROCKY
   name-sort: ROCKY
@@ -40480,8 +37871,6 @@ SLPM-65479:
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 1 # Fixes vertical lines, font and others.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-65480:
   name: michigan(ミシガン)
   name-sort: みしがん
@@ -40725,8 +38114,6 @@ SLPM-65526:
   region: "NTSC-J"
   gsHWFixes:
     minimumBlendingLevel: 2 # Fixes dark font to more bright like software mode.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-65527:
   name: FIFAトータルフットボール
   name-sort: FIFAとーたるふっとぼーる
@@ -40764,9 +38151,6 @@ SLPM-65534:
   region: "NTSC-J"
   speedHacks:
     eeCycleRate: 2 # Fixes hang on opening memory card screen.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-65535:
   name: おしえて! ぽぽたん
   name-sort: おしえて! ぽぽたん
@@ -40797,8 +38181,6 @@ SLPM-65539:
   gsHWFixes:
     preloadFrameData: 1 # Fixes fog and make lights on cars work again.
     autoFlush: 2 # Fixes sun luminosity and penetration of objects.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
   gameFixes:
     - EETimingHack # Fixes random graphical corruption.
 SLPM-65540:
@@ -41418,8 +38800,6 @@ SLPM-65655:
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-65657:
   name: ワールドサッカーウイニングイレブン8
   name-sort: わーるどさっかーういにんぐいれぶん8
@@ -41439,8 +38819,6 @@ SLPM-65662:
     autoFlush: 2 # Fixes the position of the shadow and makes it not blocky.
     halfPixelOffset: 2 # Fixes shadows.
     gpuPaletteConversion: 0 # Stops potential crashes from too many palette textures.
-    mipmap: 2 # Building textures align more closely with SW mode.
-    trilinearFiltering: 1
 SLPM-65663:
   name: ツヴァイ!!
   name-sort: つゔぁい!!
@@ -41573,8 +38951,6 @@ SLPM-65687:
   name-en: "Star Wars - Battlefront"
   region: "NTSC-J"
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     recommendedBlendingLevel: 3 # Improves reflections on certain characters and objects on certain levels.
 SLPM-65688:
   name: ベルセルク 千年帝国の鷹篇 聖魔戦記の章 通常版
@@ -41653,8 +39029,6 @@ SLPM-65697:
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 4 # Fixes blue seam in ground.
-    mipmap: 2 # Partially fixes the sun effects, but the game suffers from depth/blending issues.
-    trilinearFiltering: 1
 SLPM-65698:
   name: LoveSongs♪ADV 双葉理保14歳〜夏〜
   name-sort: LoveSongs あどべんちゃー ふたばりほ14さい なつ
@@ -41679,9 +39053,6 @@ SLPM-65701:
   region: "NTSC-J"
   clampModes:
     vu1ClampMode: 3 # Fixes sporadic white triangle SPS.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-65702:
   name: コーエー定番シリーズ 三國志戦記
   name-sort: さんごくしせんき [こーえーていばんしりーず]
@@ -41753,8 +39124,6 @@ SLPM-65719:
     recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 2 # Fixes blur and obscures sun behind objects.
-    mipmap: 2 # Fixes over sharpening.
-    trilinearFiltering: 1 # Smoothes out mipmapping.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     bilinearUpscale: 2 # Smooths out sun glare textures like native.
     getSkipCount: "GSC_BurnoutGames"
@@ -41791,8 +39160,6 @@ SLPM-65725:
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes lines in cutscenes.
-    mipmap: 2 # Cleans up texture detail.
-    trilinearFiltering: 1 # Smoothes out mipmapping.
 SLPM-65726:
   name: EA BEST HITS スター・ウォーズ ジャンゴ・フェット
   name-sort: すたーうぉーず じゃんご ふぇっと [EA BEST HITS]
@@ -41824,8 +39191,6 @@ SLPM-65729:
     halfPixelOffset: 3 # Fixes double image.
     gpuTargetCLUT: 1 # Fixes sun penetrating buildings.
     autoFlush: 1 # Fixes sun occlusion.
-    mipmap: 2 # Fixes miptrick texture effects.
-    trilinearFiltering: 1 # Fixes miptrick blending.
 SLPM-65730:
   name: ロックマンX8
   name-sort: ろっくまんえっくす8
@@ -41884,8 +39249,6 @@ SLPM-65739:
   gsHWFixes:
     wildArmsHack: 1 # Fixes blurriness.
     mergeSprite: 1 # Fixes misaligned lights.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-65740:
   name: Jリーグ ウイニングイレブン8 〜Asia Championship〜
   name-sort: Jりーぐ ういにんぐいれぶん8 〜Asia Championship〜
@@ -41901,8 +39264,6 @@ SLPM-65741:
   gsHWFixes:
     autoFlush: 1 # Aligns and corrects shadows.
     roundSprite: 1 # Fixes depth line.
-    mipmap: 2 # Mipmap + trilinear, improves building textures and reduces pop in.
-    trilinearFiltering: 1
     cpuCLUTRender: 1 # Fixes janky coloured cars.
     gpuTargetCLUT: 1 # Fixes janky coloured cars.
     textureInsideRT: 1 # Fixes car textures.
@@ -41939,9 +39300,6 @@ SLPM-65746:
   region: "NTSC-J"
   gameFixes:
     - EETimingHack # Fixes broken rendering.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-65747:
   name: 鋼の錬金術師２ 赤きエリクシルの悪魔
   name-sort: はがねのれんきんじゅつし2 あかきえりくしるのあくま
@@ -41990,8 +39348,6 @@ SLPM-65754:
     - InstantDMAHack # Fixes broken half-bottom artifacts.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-65755:
   name: サムライウエスタン 活劇侍道
   name-sort: さむらいうえすたん かつげきさむらいどう
@@ -42024,8 +39380,6 @@ SLPM-65759:
   name-en: "Mr. Incredible"
   region: "NTSC-J"
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves the street's textures to match sw renderer.
-    trilinearFiltering: 1
     halfPixelOffset: 2 # Fixes bloom misalignment when upscaling.
     cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling.
 SLPM-65760:
@@ -42175,8 +39529,6 @@ SLPM-65789:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     halfPixelOffset: 2 # Fixes blurriness.
     autoFlush: 2 # Fixes lens flare.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
 SLPM-65790:
   name: METAL GEAR SOLID 3 SNAKE EATER
@@ -42189,8 +39541,6 @@ SLPM-65790:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     halfPixelOffset: 2 # Fixes blurriness.
     autoFlush: 2 # Fixes lens flare.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
 SLPM-65791:
   name: S.L.A.I -STEEL LANCER ARENA INTERNATIONAL-
@@ -42208,8 +39558,6 @@ SLPM-65793:
     recommendedBlendingLevel: 4 # Fixes missing lighting and makes snow not look like snow sludge.
     textureInsideRT: 1 # Fixes rainbow effect in the pause menu before a jump.
     halfPixelOffset: 2 # Fixes depth lines.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-65794:
   name: カプコン ファイティング ジャム
   name-sort: かぷこん ふぁいてぃんぐ じゃむ
@@ -42248,9 +39596,6 @@ SLPM-65798:
   region: "NTSC-J"
   clampModes:
     vuClampMode: 3 # Missing geometry with microVU.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-65799:
   name: NEW人生ゲーム
   name-sort: NEWじんせいげーむ
@@ -42278,8 +39623,6 @@ SLPM-65801:
     - XGKickHack # Fixes bad geometry.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-65802:
   name: EA BEST HITS DEF JAM VENDETTA
   name-sort: DEF JAM VENDETTA [EA BEST HITS]
@@ -42300,9 +39643,6 @@ SLPM-65805:
   name-sort: ごじらかいじゅうだいらんとう 〜ちきゅうさいしゅうけっせん〜
   name-en: "Gojira Monster Fighter"
   region: "NTSC-J"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-65806:
   name: VM JAPAN(ブイエムジャパン)
   name-sort: ぶいえむじゃぱん
@@ -42349,8 +39689,6 @@ SLPM-65815:
   region: "NTSC-J"
   gsHWFixes:
     preloadFrameData: 1 # Fixes missing loading screens.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-65816:
   name: 真・爆走デコトラ伝説 〜天下統一頂上決戦〜
   name-sort: しん・ばくそうでことらでんせつ てんかとういつちょうじょうけっせん
@@ -42468,8 +39806,6 @@ SLPM-65837:
     autoFlush: 2 # Fixes environment lights visible through player model.
     halfPixelOffset: 4 # Fixes depth line and misaligned bloom.
     minimumBlendingLevel: 3 # Fixes incorrect bloom rendering.
-    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-65838:
   name: 半熟銀河弁当 半熟英雄4 〜7人の半熟英雄〜 [限定版]
   name-sort: はんじゅくぎんがべんとう はんじゅくひーろー4 7にんのはんじゅくひーろー [げんていばん]
@@ -42530,8 +39866,6 @@ SLPM-65846:
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-65847:
   name: 空色の風琴 〜Remix〜 初回限定版
   name-sort: そらいろのおるがん Remix しょかいげんていばん
@@ -42558,9 +39892,6 @@ SLPM-65854:
   name-sort: れっど・でっど・りぼるばー
   name-en: "Red Dead Revolver"
   region: "NTSC-J"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-65855:
   name: GIRLSブラボー Romance15’s DXパック
   name-sort: GIRLSぶらぼー Romance15’s DXぱっく
@@ -42766,9 +40097,6 @@ SLPM-65890:
   name-sort: しんさんごくむそう4
   name-en: "Shin Sangoku Musou 4"
   region: "NTSC-J"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-65891:
   name: 三國志X
   name-sort: さんごくし10
@@ -42867,8 +40195,6 @@ SLPM-65909:
     eeRoundMode: 1 # Fixes object balls never stopping in the Monkey Billiards DX minigame.
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes text and foliage color.
-    mipmap: 2 # Mipmap + trilinear, improves stage textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-65910:
   name: カフェ・リンドバーグ -summer season-(Sweet Box 版)
   name-sort: かふぇ りんどばーぐ summer season [Sweet Box ばん]
@@ -42978,8 +40304,6 @@ SLPM-65927:
   gsHWFixes:
     halfPixelOffset: 1 # Reduces ghosting.
     roundSprite: 1 # Reduces ghosting even more.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-65928:
   name: SuperLite 2000 バラエティ メモオフみっくす
   name-sort: すーぱーらいと2000 ばらえてぃ めもおふみっくす
@@ -43052,8 +40376,6 @@ SLPM-65942:
   region: "NTSC-J"
   gsHWFixes:
     autoFlush: 2 # Fixes missing lighting.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     # halfPixelOffset: 1 # Fixes lighting misalignment. Do not enable this, it breaks a lot of graphics.
 SLPM-65943:
   name: Angel’s Feather −黒の残影−
@@ -43148,8 +40470,6 @@ SLPM-65958:
     recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 2 # Fixes blur and obscures sun behind objects.
-    mipmap: 2 # Fixes over sharpening.
-    trilinearFiltering: 1 # Smoothes out mipmapping.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     bilinearUpscale: 2 # Smooths out sun glare textures like native.
     getSkipCount: "GSC_BurnoutGames"
@@ -43360,8 +40680,6 @@ SLPM-65995:
   gsHWFixes:
     roundSprite: 1 # Fix lines in the sky.
     halfPixelOffset: 2 # Fixes double image.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-65996:
   name: 破滅のマルス 限定版
   name-sort: はめつのまるす [げんていばん]
@@ -43508,8 +40826,6 @@ SLPM-66019:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     cpuSpriteRenderBW: 4 # Fixes textures.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-66020:
   name: サイオプス サイキック・オペレーション
   name-sort: さいおぷす さいきっく・おぺれーしょん
@@ -43641,16 +40957,11 @@ SLPM-66043:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves car reflections.
     autoFlush: 1
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-66044:
   name: MVPベースボール2005
   name-sort: MVPべーすぼーる2005
   name-en: "MVP Baseball 2005"
   region: "NTSC-J"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-66045:
   name: My Merry May with be
   name-sort: My Merry May with be
@@ -43731,8 +41042,6 @@ SLPM-66059:
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misaligned bloom.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-66060:
   name: 亡国のイージス2035 〜ウォーシップガンナー〜
   name-sort: ぼうこくのいーじす2035 うぉーしっぷがんなー
@@ -43776,9 +41085,6 @@ SLPM-66068:
   name-sort: りちゃーど・ばーんず らりー
   name-en: "Richard Burns Rally"
   region: "NTSC-J"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-66069:
   name: 式神の城 七夜月幻想曲
   name-sort: しきがみのしろ ななよづきげんそうきょく
@@ -43858,8 +41164,6 @@ SLPM-66079:
     halfPixelOffset: 2 # Fixes misaligned blur.
     cpuSpriteRenderBW: 2 # Fixes black spots appearing on some surfaces and massively reduces RP TC and TU count.
     cpuSpriteRenderLevel: 2 # Needed for above.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-66080:
   name: GENERATION OF CHAOSIII 〜時の封印〜 [IFコレクション]
   name-sort: じぇねれーしょんおぶかおす 3 ときのふういん [あいであふぁくとりーこれくしょん]
@@ -43921,8 +41225,6 @@ SLPM-66090:
     PCRTCOverscan: 1 # Fixes offscreen image.
     nativePaletteDraw: 1 # Fixes the look of screen effects.
     halfPixelOffset: 2 # Corrects the alignment of screen effects.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-66091:
   name: 忍道 戒
   name-sort: しのびどう いましめ
@@ -43971,8 +41273,6 @@ SLPM-66098:
     halfPixelOffset: 3 # Fixes double image.
     gpuTargetCLUT: 1 # Fixes sun penetrating buildings.
     autoFlush: 1 # Fixes sun occlusion.
-    mipmap: 2 # Fixes miptrick texture effects.
-    trilinearFiltering: 1 # Fixes miptrick blending.
 SLPM-66099:
   name: "Harukanaru Toki no Naka de 3 - Izayoiki [Premium Box-Triple Pack]"
   region: "NTSC-J"
@@ -44040,8 +41340,6 @@ SLPM-66108:
     recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 2 # Fixes blur and obscures sun behind objects.
-    mipmap: 2 # Fixes over sharpening.
-    trilinearFiltering: 1 # Smoothes out mipmapping.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     bilinearUpscale: 2 # Smooths out sun glare textures like native.
     getSkipCount: "GSC_BurnoutGames"
@@ -44108,8 +41406,6 @@ SLPM-66117:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
     halfPixelOffset: 2 # Fixes blurriness.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
 SLPM-66118:
   name: METAL GEAR SOLID 3 SUBSISTENCE [ヘッドセット同梱版] [ディスク2/3]
@@ -44123,8 +41419,6 @@ SLPM-66118:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
     halfPixelOffset: 2 # Fixes blurriness.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
 SLPM-66119:
   name: METAL GEAR SOLID 3 SUBSISTENCE [ヘッドセット同梱版] [ディスク2/3]
@@ -44138,8 +41432,6 @@ SLPM-66119:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
     halfPixelOffset: 2 # Fixes blurriness.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
 SLPM-66121:
   name: "Spider-Man 2 [Taito Best]"
@@ -44149,8 +41441,6 @@ SLPM-66121:
     autoFlush: 2 # Fixes the position of the shadow and makes it not blocky.
     halfPixelOffset: 2 # Fixes shadows.
     gpuPaletteConversion: 0 # Stops potential crashes from too many palette textures.
-    mipmap: 2 # Building textures align more closely with SW mode.
-    trilinearFiltering: 1
 SLPM-66122:
   name: キングダム ハーツ [アルティメットヒッツ]
   name-sort: きんぐだむ はーつ [あるてぃめっとひっつ]
@@ -44212,8 +41502,6 @@ SLPM-66131:
   gsHWFixes:
     wildArmsHack: 1 # Fixes blurriness.
     mergeSprite: 1 # Fixes misaligned lights.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-66132:
   name: GLADIATOR ROAD TO FREEDOM REMIX
   name-sort: GLADIATOR ROAD TO FREEDOM REMIX
@@ -44317,8 +41605,6 @@ SLPM-66148:
   name-en: "Star Wars - Battlefront [EA Best Hits]"
   region: "NTSC-J"
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     recommendedBlendingLevel: 3 # Improves reflections on certain characters and objects on certain levels.
 SLPM-66149:
   name: しろがねの鳥籠 限定版
@@ -44421,8 +41707,6 @@ SLPM-66166:
   gsHWFixes:
     recommendedBlendingLevel: 4 # Improves smoke rendering.
     halfPixelOffset: 2 # Fixes misaligned lighting.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-66167:
   name: "God of War"
   region: "NTSC-J"
@@ -44487,8 +41771,6 @@ SLPM-66177:
   name-en: "Matrix, The - Path of Neo"
   region: "NTSC-J"
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     halfPixelOffset: 2 # Fix effects upscaling.
     autoFlush: 1 # Fixes broken post processing.
 SLPM-66178:
@@ -44524,8 +41806,6 @@ SLPM-66183:
   gsHWFixes:
     textureInsideRT: 1
     halfPixelOffset: 2 # Fixes outlines on screen edges.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-66184:
   name: 戦神 -いくさがみ-
   name-sort: いくさがみ
@@ -44576,8 +41856,6 @@ SLPM-66189:
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes missing lighting and makes snow not look like snow sludge.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-66190:
   name: スター・ウォーズ バトルフロントII
   name-sort: すたーうぉーず ばとるふろんとII
@@ -44586,8 +41864,6 @@ SLPM-66190:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes bloom misalignment.
     autoFlush: 1 # Fixes missing lights.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-66191:
   name: タイガー・ウッズ PGA TOUR 06
   name-sort: たいがー・うっず PGA TOUR 06
@@ -44595,9 +41871,6 @@ SLPM-66191:
   region: "NTSC-J"
   clampModes:
     vuClampMode: 3 # Fixes black textures on characters.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-66192:
   name: IZUMO2 猛き剣の閃記
   name-sort: いずも2 たけきつるぎのせんき
@@ -44631,9 +41904,6 @@ SLPM-66197:
   name-sort: ごじらかいじゅうだいらんとう ちきゅうさいしゅうけっせん
   name-en: "Godzilla Kaijuu Dairansen - Chikyuu Saishuu Kessen [Atari Hot Series]"
   region: "NTSC-J"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-66201:
   name: フレンズ 〜青春の輝き〜 ベスト版
   name-sort: ふれんず 〜せいしゅんのかがやき〜 べすとばん
@@ -44656,9 +41926,6 @@ SLPM-66204:
   region: "NTSC-J"
   clampModes:
     vuClampMode: 3 # Missing geometry with microVU.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-66205:
   name: FRONT MISSION 5 〜Scars of the War〜
   name-sort: FRONT MISSION 5 〜Scars of the War〜
@@ -44677,8 +41944,6 @@ SLPM-66206:
     autoFlush: 1 # Post-processing.
     halfPixelOffset: 2 # Offset post-processing.
     texturePreloading: 1 # Improves performance.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_Battlefield2" # Depth clear.
     beforeDraw: "OI_Battlefield2" # Framebuffer copy, fixes rendering for bottom part of screen.
 SLPM-66207:
@@ -44688,8 +41953,6 @@ SLPM-66207:
   region: "NTSC-J"
   gsHWFixes:
     minimumBlendingLevel: 2 # Fixes dark font to more bright like software mode.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-66208:
   name: サクラ大戦V EPISODE 0 〜荒野のサムライ娘〜 SEGA THE BEST
   name-sort: さくらたいせんV EPISODE 0 〜こうやのさむらいむすめ〜 SEGA THE BEST
@@ -44722,8 +41985,6 @@ SLPM-66212:
   compat: 5
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves car reflections.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-66213:
   name: バイオハザード4
   name-sort: ばいおはざーど4
@@ -44734,8 +41995,6 @@ SLPM-66213:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-66214:
   name: WHITE CLARITY 〜And The tears became you.〜 [初回限定版]
   name-sort: ほわいと くらりてぃー 〜And The tears became you.〜 しょかいげんていばん
@@ -44773,8 +42032,6 @@ SLPM-66220:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
     halfPixelOffset: 2 # Fixes blurriness.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
   memcardFilters:
     - "SLPM-66117"
@@ -44790,8 +42047,6 @@ SLPM-66221:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
     halfPixelOffset: 2 # Fixes blurriness.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
   memcardFilters:
     - "SLPM-66117"
@@ -44807,8 +42062,6 @@ SLPM-66222:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
     halfPixelOffset: 2 # Fixes blurriness.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
   memcardFilters:
     - "SLPM-66117"
@@ -44824,8 +42077,6 @@ SLPM-66223:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
     halfPixelOffset: 2 # Fixes blurriness.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
   memcardFilters:
     - "SLPM-66117"
@@ -44841,8 +42092,6 @@ SLPM-66224:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
     halfPixelOffset: 2 # Fixes blurriness.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
   memcardFilters:
     - "SLPM-66117"
@@ -44886,8 +42135,6 @@ SLPM-66232:
     halfPixelOffset: 2 # Fixes blurriness.
     cpuCLUTRender: 1 # Final colour adjustment LUT.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
   memcardFilters:
     - "SLAJ-25075"
     - "SLPM-66232"
@@ -44987,8 +42234,6 @@ SLPM-66248:
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes building shade and shadows.
-    mipmap: 2 # Mipmap + trilinear, improves the street's textures to match sw renderer.
-    trilinearFiltering: 1
     halfPixelOffset: 2 # Fixes bloom misalignment when upscaling.
     cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling.
 SLPM-66249:
@@ -45127,8 +42372,6 @@ SLPM-66271:
   compat: 5
   gsHWFixes:
     autoFlush: 1 # Fixes lighting.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-66272:
   name: I/O
   name-sort: あいおー
@@ -45207,9 +42450,6 @@ SLPM-66281:
   name-sort: そにっくらいだーず
   name-en: "Sonic Riders"
   region: "NTSC-J"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves track and building textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-66282:
   name: SuperLite 2000 Memories Off AfterRain Vol.2 〜想演〜
   name-sort: すーぱーらいと2000 Memories Off AfterRain Vol.2 〜そうえん〜
@@ -45439,8 +42679,6 @@ SLPM-66322:
   gsHWFixes:
     textureInsideRT: 1 # Required for complex offset shuffles.
     halfPixelOffset: 2 # Fixes center upscaling line during explosions.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
     recommendedBlendingLevel: 4 # Fixes lighting.
 SLPM-66323:
   name: φなる・あぷろーち [プリンセスソフトコレクション]
@@ -45473,8 +42711,6 @@ SLPM-66327:
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misalignment/bloom when upscaling.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-66328:
   name: Call of Duty 2 Big Red One
   name-sort: Call of Duty 2 Big Red One
@@ -45485,8 +42721,6 @@ SLPM-66328:
   gsHWFixes:
     roundSprite: 1 # Fixes lines in sprites.
     cpuSpriteRenderBW: 1 # Fixes textures.
-    mipmap: 2 # Mipmap + trilinear, improves ground and building textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-66329:
   name: 魔法先生ネギま! 課外授業 乙女のドキドキ・ビーチサイド
   name-sort: まほうせんせいねぎま! かがいじゅぎょう おとめのどきどき びーちさいど
@@ -45636,8 +42870,6 @@ SLPM-66354:
     recommendedBlendingLevel: 4 # Improves lighting on buildings and objects.
     autoFlush: 2 # Properly diffuses light instead of strips of light.
     roundSprite: 1 # Fixes lighting misalignment such as the street poles and the sun.
-    mipmap: 2 # Fixes over sharpening.
-    trilinearFiltering: 1 # Smoothes out mipmapping.
     getSkipCount: "GSC_BlackAndBurnoutSky"
     beforeDraw: "OI_BurnoutGames"
   patches:
@@ -45800,9 +43032,6 @@ SLPM-66386:
   name-sort: 2006 FIFA わーるどかっぷ どいつたいかい
   name-en: "FIFA World Cup - Germany 2006"
   region: "NTSC-J"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-66387:
   name: Spike the Best 真・爆走デコトラ伝説 〜天下統一頂上決戦〜
   name-sort: しん・ばくそうでことらでんせつてんかとういつちょうじょうけっせん [Spike The Best]
@@ -45901,8 +43130,6 @@ SLPM-66404:
     vu1ClampMode: 0 # Fixes Spider-Man's eye texture colour.
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes textures.
-    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
-    trilinearFiltering: 1
     autoFlush: 2 # Fixes shadow alignment along with HPO Special (Normal looks better but causes top left glitches).
     halfPixelOffset: 2
 SLPM-66405:
@@ -46033,17 +43260,12 @@ SLPM-66429:
   region: "NTSC-J"
   clampModes:
     vu1ClampMode: 3 # Fixes smoke particles.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-66430:
   name: デストロイ オール ヒューマンズ!
   name-sort: ですとろい おーる ひゅーまんず!
   name-en: "Destroy All Humans!"
   region: "NTSC-J"
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     textureInsideRT: 1 # Fixes shadow maps.
     roundSprite: 2 # Fixes misaligned bloom.
     mergeSprite: 1 # Fixes misaligned bloom.
@@ -46141,8 +43363,6 @@ SLPM-66444:
   gsHWFixes:
     autoFlush: 1 # Fixes missing post processing.
     halfPixelOffset: 1 # Aligns post processing.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-66445:
   name: ペルソナ3
   name-sort: ぺるそな3
@@ -46273,8 +43493,6 @@ SLPM-66461:
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes  building and ground colours.
-    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-66462:
   name: カーズ
   name-sort: かーず
@@ -46283,8 +43501,6 @@ SLPM-66462:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes ground texture flicker and improves car body reflections.
     autoFlush: 1 # Fixes lens flares and missing sun.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-66463:
   name: EA BEST HITS デフジャム・ファイト・フォー・NY
   name-sort: でふじゃむ・ふぁいと・ふぉー・NY [EA BEST HITS]
@@ -46302,8 +43518,6 @@ SLPM-66465:
   region: "NTSC-J"
   gsHWFixes:
     autoFlush: 2 # Fixes missing lighting.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     # halfPixelOffset: 1 # Fixes lighting misalignment. Do not enable this, it breaks a lot of graphics.
 SLPM-66467:
   name: ゲーセンUSA ミッドウェイアーケードトレジャーズ
@@ -46317,8 +43531,6 @@ SLPM-66468:
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misaligned lighting and other effects, needs Special otherwise lights flicker.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-66469:
   name: 「ラブ★コン 〜パンチDEコント〜」限定版
   name-sort: らぶこん ぱんちでこんと [げんていばん]
@@ -46354,8 +43566,6 @@ SLPM-66473:
     preloadFrameData: 1 # Fixes numberplates and ensures above targets are valid.
     roundSprite: 1 # Fixes lines in some post-effects.
     gpuTargetCLUT: 1 # Fixes light occlusion.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-66474:
   name: オーディンスフィア
   name-sort: おーでぃんすふぃあ
@@ -46439,9 +43649,6 @@ SLPM-66485:
   name-sort: すてーと おぶ えまーじぇんしー りべんじ
   name-en: "State of Emergency - Revenge"
   region: "NTSC-J"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-66486:
   name: てんたま-1st Sunny Sideー <2800コレクション>
   name-sort: てんたま-1st Sunny Sideー <2800これくしょん>
@@ -46523,8 +43730,6 @@ SLPM-66498:
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes lighting and vertical lines, also works with normal vertex.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-66499:
   name: 神様家族 応援願望
   name-sort: かみさまかぞく おうえんがんぼう
@@ -46561,8 +43766,6 @@ SLPM-66503:
     - DMABusyHack # Fixes broken half-bottom artifacts.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-66504:
   name: 鬼武者2 MEGA HITS!
   name-sort: おにむしゃ2 MEGA HITS!
@@ -46624,8 +43827,6 @@ SLPM-66514:
     halfPixelOffset: 2 # Fixes misaligned blur.
     cpuSpriteRenderBW: 2 # Fixes black spots appearing on some surfaces and massively reduces RP TC and TU count.
     cpuSpriteRenderLevel: 2 # Needed for above.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-66515:
   name: EA BEST HITS スター・ウォーズ エピソード3 シスの復讐
   name-sort: すたーうぉーず えぴそーど3 しすのふくしゅう [EA BEST HITS]
@@ -46837,8 +44038,6 @@ SLPM-66558:
   name-en: "Tomb Raider - Legend"
   region: "NTSC-J"
   gsHWFixes:
-    mipmap: 2 # Fixes distant characters and models.
-    trilinearFiltering: 1
     textureInsideRT: 1 # Needed for post processing effects.
     autoFlush: 1 # Fixes bloom intensity.
     minimumBlendingLevel: 4 # Fixes multiple lighting effects from lights, computers, cave walls and more.
@@ -46870,8 +44069,6 @@ SLPM-66562:
     halfPixelOffset: 2 # Fixes blurriness.
     cpuCLUTRender: 1 # Final colour adjustment LUT.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
   memcardFilters:
     - "SLAJ-25075"
     - "SLPM-66232"
@@ -46918,8 +44115,6 @@ SLPM-66567:
     cpuCLUTRender: 1 # Fixes the rest of the bad textures.
     roundSprite: 1 # Reduces misaligned bloom.
     mergeSprite: 1 # Removes bloom explosion around electrical lights and other light sources such as moon/sun.
-    mipmap: 2 # Mipmap + trilinear, improves road textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-66568:
   name: ユービーアイソフト ベスト ブラザー イン アームズ ロード トゥ ヒル サーティ
   name-sort: ぶらざー いん あーむず ろーど とぅ ひる さーてぃ [ゆーびーあいそふと べすと]
@@ -46951,8 +44146,6 @@ SLPM-66572:
   region: "NTSC-J"
   gsHWFixes:
     cpuCLUTRender: 1 # Fixes ghosting on objects and people.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
   memcardFilters:
     - "SLPM-66572"
     - "SLPS-20423"
@@ -47118,9 +44311,6 @@ SLPM-66600:
   region: "NTSC-J"
   clampModes:
     vuClampMode: 3 # Missing geometry with microVU.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-66601:
   name: EA BEST HITS SSX on tour
   name-sort: SSX on tour [EA BEST HITS]
@@ -47128,8 +44318,6 @@ SLPM-66601:
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes missing lighting and makes snow not look like snow sludge.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-66602:
   name: 龍が如く 2 [ディスク1/2]
   name-sort: りゅうがごとく2 [でぃすく1/2]
@@ -47214,8 +44402,6 @@ SLPM-66616:
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes lines in cutscenes.
-    mipmap: 2 # Cleans up texture detail.
-    trilinearFiltering: 1 # Smoothes out mipmapping.
 SLPM-66617:
   name: ニード・フォー・スピード カーボン
   name-sort: にーど ふぉー すぴーど かーぼん
@@ -47294,8 +44480,6 @@ SLPM-66629:
   region: "NTSC-J"
   gsHWFixes:
     autoFlush: 1 # Fixes lighting.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-66630:
   name: メルヘヴン ARM FIGHT DREAM コナミ・ザ・ベスト
   name-sort: めるへゔん ARM FIGHT DREAM こなみ・ざ・べすと
@@ -47389,8 +44573,6 @@ SLPM-66645:
   region: "NTSC-J"
   gsHWFixes:
     cpuCLUTRender: 1 # Fixes ghosting on objects and people.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-66646:
   name: シャイニング・フォース イクサ
   name-sort: しゃいにんぐ・ふぉーす いくさ
@@ -47412,8 +44594,6 @@ SLPM-66651:
     autoFlush: 1 # Post-processing.
     halfPixelOffset: 2 # Offset post-processing.
     texturePreloading: 1 # Improves performance.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_Battlefield2" # Depth clear.
     beforeDraw: "OI_Battlefield2" # Framebuffer copy, fixes rendering for bottom part of screen.
 SLPM-66652:
@@ -47427,8 +44607,6 @@ SLPM-66652:
     recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 2 # Fixes blur and obscures sun behind objects.
-    mipmap: 2 # Fixes over sharpening.
-    trilinearFiltering: 1 # Smoothes out mipmapping.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     bilinearUpscale: 2 # Smooths out sun glare textures like native.
     getSkipCount: "GSC_BurnoutGames"
@@ -47552,9 +44730,6 @@ SLPM-66672:
   name-sort: すぷりんたーせる にじゅうすぱい
   name-en: "Tom Clancy's Splinter Cell - Double Agent"
   region: "NTSC-J"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-66673:
   name: プリンス・オブ・ペルシャ ケンシ ノ ココロ [ユービーアイソフトベスト]
   name-sort: ぷりんす おぶ ぺるしゃ けんし の こころ [ゆーびーあいそふとべすと]
@@ -47569,9 +44744,6 @@ SLPM-66674:
   region: "NTSC-J"
   clampModes:
     vuClampMode: 2 # Fixes black textures on characters.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-66675:
   name: KINGDOM HEARTS II FINAL MIX+ 通常版
   name-sort: KINGDOM HEARTS II FINAL MIX+
@@ -47636,9 +44808,6 @@ SLPM-66681:
   compat: 5
   roundModes:
     eeRoundMode: 0 # Ladder glitch in "Assembly of Nihilo B11" level.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, fixes missing lights to match sw renderer.
-    trilinearFiltering: 1
 SLPM-66683:
   name: デビルサマナー 葛葉ライドウ 対 アバドン王 初回生産版
   name-sort: でびるさまなー くずのはらいどう たい あばどんおう しょかいせいさんばん
@@ -47682,9 +44851,6 @@ SLPM-66689:
   name-sort: ぺるそな3ふぇす [あぺんどでぃすくばん]
   name-en: "Persona 3 FES [Append Edition]"
   region: "NTSC-J"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, fixes flashing windows.
-    trilinearFiltering: 1
   memcardFilters:
     - "SLPM-66445"
     - "SLPM-66689"
@@ -47694,9 +44860,6 @@ SLPM-66690:
   name-sort: ぺるそな3ふぇす
   name-en: "Persona 3 FES [Independent Starting Version]"
   region: "NTSC-J"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, fixes flashing windows.
-    trilinearFiltering: 1
   memcardFilters:
     - "SLPM-66445"
     - "SLPM-66689"
@@ -47743,8 +44906,6 @@ SLPM-66697:
   gsHWFixes:
     wildArmsHack: 1 # Fixes blurriness.
     mergeSprite: 1 # Fixes misaligned lights.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-66698:
   name: 史上最強の弟子ケンイチ 激闘!ラグナレク八拳豪
   name-sort: しじょうさいきょうのでしけんいち げきとう!らぐなれくはちけんごう
@@ -47776,8 +44937,6 @@ SLPM-66703:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves car reflections.
     autoFlush: 1
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-66704:
   name: ネギま!? どりーむたくてぃっく 夢見る乙女はプリンセス 舞姫版
   name-sort: ねぎま!? どりーむたくてぃっく ゆめみるおとめはぷりんせす まいひめばん
@@ -47811,8 +44970,6 @@ SLPM-66710:
   name-en: "Godfather, The"
   region: "NTSC-J"
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
-    trilinearFiltering: 1
     textureInsideRT: 1 # Required for complex offset shuffles.
     halfPixelOffset: 2 # Fixes center line in post processing.
 SLPM-66712:
@@ -47929,8 +45086,6 @@ SLPM-66731:
     recommendedBlendingLevel: 4 # Improves lighting on buildings and objects.
     autoFlush: 2 # Properly diffuses light instead of strips of light.
     roundSprite: 1 # Fixes lighting misalignment such as the street poles and the sun.
-    mipmap: 2 # Fixes over sharpening.
-    trilinearFiltering: 1 # Smoothes out mipmapping.
     getSkipCount: "GSC_BlackAndBurnoutSky"
     beforeDraw: "OI_BurnoutGames"
 SLPM-66732:
@@ -47993,8 +45148,6 @@ SLPM-66739:
     recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 2 # Fixes blur and obscures sun behind objects.
-    mipmap: 2 # Fixes over sharpening.
-    trilinearFiltering: 1 # Smoothes out mipmapping.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     bilinearUpscale: 2 # Smooths out sun glare textures like native.
     getSkipCount: "GSC_BurnoutGames"
@@ -48079,8 +45232,6 @@ SLPM-66752:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes lighting misalignment.
     mergeSprite: 1 # Removes occasional vertical lines.
-    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-66753:
   name: 月面兎兵器ミーナ -ふたつのPROJECT M- [限定版]
   name-sort: げつめんとへいきみーな -ふたつのPROJECT M- [げんていばん]
@@ -48311,8 +45462,6 @@ SLPM-66792:
     - InstantDMAHack # Fixes broken half-bottom artifacts.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-66793:
   name: METAL GEAR 20th ANNIVERSARY METAL GEAR SOLID 2 SONS OF LIBERTY [ディスク2/2]
   name-sort: METAL GEAR 20th ANNIVERSARY METAL GEAR SOLID 2 SONS OF LIBERTY [でぃすく2/2]
@@ -48322,8 +45471,6 @@ SLPM-66793:
     - InstantDMAHack # Fixes broken half-bottom artifacts.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-66794:
   name: MERAL GEAR 20th ANNIVERSARY METAL GEAR SOLID 3 SNAKE EATER
   name-sort: MERAL GEAR 20th ANNIVERSARY METAL GEAR SOLID 3 SNAKE EATER
@@ -48335,8 +45482,6 @@ SLPM-66794:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     halfPixelOffset: 2 # Fixes blurriness.
     autoFlush: 2 # Fixes lens flare.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
 SLPM-66795:
   name: "Metal Gear & Metal Gear 2 - Solid Snake"
@@ -48406,8 +45551,6 @@ SLPM-66808:
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes  building and ground colours.
-    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-66809:
   name: 最終試験くじら−Alive−
   name-sort: さいしゅうしけんくじら-Alive-
@@ -48532,9 +45675,6 @@ SLPM-66836:
   name-sort: EA SPORTS らぐびー08
   name-en: "EA Sports Rugby '08"
   region: "NTSC-J"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-66837:
   name: マッデン NFL 08
   name-sort: まっでん NFL 08
@@ -48542,9 +45682,6 @@ SLPM-66837:
   region: "NTSC-J"
   clampModes:
     vuClampMode: 3 # Missing geometry with microVU.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-66838:
   name: ファンタスティックフォーチュン2☆☆☆(トリプルスター) BEST HIT セレクション
   name-sort: ふぁんたすてぃっくふぉーちゅん2とりぷるすたー BEST HIT せれくしょん
@@ -48620,8 +45757,6 @@ SLPM-66851:
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 1 # Removes blur due to misaligned fullscreen effect.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-66852:
   name: カプコン クラシックス コレクション Best Price
   name-sort: かぷこん くらしっくす これくしょん [Best Price]
@@ -48634,8 +45769,6 @@ SLPM-66853:
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 2 # Fixes text box opacity.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-66854:
   name: ストリートファイターゼロ ファイターズ ジェネレーション Best Price
   name-sort: すとりーとふぁいたーぜろ ふぁいたーず じぇねれーしょん Best Price
@@ -48717,9 +45850,6 @@ SLPM-66868:
   name-sort: すぷりんたーせる にじゅうすぱい [ゆーびーあいそふとべすと]
   name-en: "Tom Clancy's Splinter Cell - Double Agent [Ubisoft the Best]"
   region: "NTSC-J"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-66869:
   name: EA BEST HITS ニード・フォー・スピード カーボン
   name-sort: にーど ふぉー すぴーど かーぼん [EA BEST HITS]
@@ -48793,8 +45923,6 @@ SLPM-66881:
   gsHWFixes:
     alignSprite: 1 # Fixes lighting and vertical lines, also works with normal vertex.
     roundSprite: 1 # Fixes misaligned map.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
     skipDrawStart: 1 # Removes large black box around player car till we properly emulate it.
     skipDrawEnd: 1 # Removes large black box around player car till we properly emulate it.
 SLPM-66882:
@@ -49217,8 +46345,6 @@ SLPM-66961:
     recommendedBlendingLevel: 4 # Improves lighting on buildings and objects.
     autoFlush: 2 # Properly diffuses light instead of strips of light.
     roundSprite: 1 # Fixes lighting misalignment such as the street poles and the sun.
-    mipmap: 2 # Fixes over sharpening.
-    trilinearFiltering: 1 # Smoothes out mipmapping.
     getSkipCount: "GSC_BlackAndBurnoutSky"
     beforeDraw: "OI_BurnoutGames"
 SLPM-66962:
@@ -49232,8 +46358,6 @@ SLPM-66962:
     recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 2 # Fixes blur and obscures sun behind objects.
-    mipmap: 2 # Fixes over sharpening.
-    trilinearFiltering: 1 # Smoothes out mipmapping.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     bilinearUpscale: 2 # Smooths out sun glare textures like native.
     getSkipCount: "GSC_BurnoutGames"
@@ -49260,8 +46384,6 @@ SLPM-66966:
   name-en: "Godfather, The [EA-SY! 1980]"
   region: "NTSC-J"
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
-    trilinearFiltering: 1
     textureInsideRT: 1 # Required for complex offset shuffles.
     halfPixelOffset: 2 # Fixes center line in post processing.
 SLPM-66967:
@@ -49424,8 +46546,6 @@ SLPM-67002:
     roundSprite: 2 # Fixes font artifacts.
     autoFlush: 1 # Fixes depth of field blur.
     recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-67003:
   name: サクラ大戦 〜熱き血潮に〜
   name-sort: さくらたいせん 〜あつきちしおに〜
@@ -49447,8 +46567,6 @@ SLPM-67005:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misaligned lighting and other effects.
     cpuSpriteRenderBW: 1 # Fixes flickering textures caused by mipmapping.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
   clampModes:
     vuClampMode: 3 # Fix white shiny weapons.
 SLPM-67006:
@@ -49472,8 +46590,6 @@ SLPM-67008:
     roundSprite: 2 # Fixes font artifacts.
     autoFlush: 1 # Fixes depth of field blur.
     recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-67009:
   name: サクラ大戦V 〜さらば愛しき人よ〜
   name-sort: さくらたいせんV 〜さらばいとしきひとよ〜
@@ -49518,8 +46634,6 @@ SLPM-67013:
     halfPixelOffset: 2 # Fixes misaligned bloom.
     roundSprite: 1 # Fixes chromatic effect.
     autoFlush: 1 # Fixes sun occlusion.
-    mipmap: 2 # Mipmap + trilinear, fixes miptrick textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-67014:
   name: "Sengoku Musou 2 - Moushouden"
   region: "NTSC-J"
@@ -49538,8 +46652,6 @@ SLPM-67017:
     halfPixelOffset: 2 # Fixes misaligned bloom.
     roundSprite: 1 # Fixes chromatic effect.
     autoFlush: 1 # Fixes sun occlusion.
-    mipmap: 2 # Mipmap + trilinear, fixes miptrick textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-67502:
   name: "Devil May Cry"
   region: "NTSC-K"
@@ -49559,8 +46671,6 @@ SLPM-67504:
     eeRoundMode: 0 # Fixes riders vanish into the floor.
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes missing lighting and makes snow not look like snow sludge.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-67505:
   name: "007 - Agent Under Fire"
   region: "NTSC-K"
@@ -49594,9 +46704,6 @@ SLPM-67508:
 SLPM-67512:
   name: "2002 FIFA World Cup"
   region: "NTSC-K"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-67513:
   name: "Final Fantasy X International"
   region: "NTSC-K"
@@ -49617,8 +46724,6 @@ SLPM-67515:
     - InstantDMAHack # Fixes broken half-bottom artifacts.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-67516:
   name: "Soul Reaver 2"
   region: "NTSC-K"
@@ -49653,8 +46758,6 @@ SLPM-67524:
   gsHWFixes:
     halfPixelOffset: 2 # Corrects positioning of reflections on suit's surfaces.
     roundSprite: 2 # Reduces garbage on the UI whilst upscaling.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-67525:
   name: "Medal of Honor - Frontline"
   region: "NTSC-K"
@@ -49671,8 +46774,6 @@ SLPM-67527:
     vuClampMode: 2 # White textures.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth line and blur.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-67528:
   name: "Hajime no Ippo - Victorious Boxers [Championship Edition]"
   region: "NTSC-K"
@@ -49742,8 +46843,6 @@ SLPM-67546:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misaligned lighting and other effects.
     cpuSpriteRenderBW: 1 # Fixes flickering textures caused by mipmapping.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
   clampModes:
     vuClampMode: 3 # Fix white shiny weapons.
 SLPM-67550:
@@ -49762,8 +46861,6 @@ SLPM-68005:
     - EETimingHack # Fixes flickering textures.
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes missing lighting effects.
-    mipmap: 2 # Fixes blurry textures.
-    trilinearFiltering: 1 # Fixes blurry textures.
     cpuFramebufferConversion: 1 # Fixes right side of the screen from garbage textures.
 SLPM-68007:
   name: "Karaoke Revolution-you Mic Doukon Online Otameshi Disc"
@@ -49784,8 +46881,6 @@ SLPM-68016:
   region: "NTSC-J"
   gsHWFixes:
     autoFlush: 1 # Fixes lighting.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-68017:
   name: "Shin Onimusha - Dawn of Dreams [Saikyou Save Data]"
   region: "NTSC-J"
@@ -49821,8 +46916,6 @@ SLPM-68503:
     - InstantDMAHack # Fixes broken half-bottom artifacts.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-68504:
   name: "Tokimeki Memorial 3 - Special Sound Track"
   region: "NTSC-J"
@@ -49847,8 +46940,6 @@ SLPM-68516:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     halfPixelOffset: 2 # Fixes blurriness.
     autoFlush: 2 # Fixes lens flare.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
 SLPM-68519:
   name: "Enthusia Professional Racing - Subaru Impreza WRX STI"
@@ -49867,8 +46958,6 @@ SLPM-68520:
   gsHWFixes:
     halfPixelOffset: 2 # Corrects shadow alignment and reduces blurriness.
     recommendedBlendingLevel: 3 # Fixes level and map menu brightness.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
     preloadFrameData: 1 # Fixes glowing emblems.
 SLPM-68521:
   name: ".hack frägment [Senkou Release-ban]"
@@ -49983,9 +47072,6 @@ SLPM-74205:
   region: "NTSC-J"
   roundModes:
     eeRoundMode: 0 # Ladder glitch in "Assembly of Nihilo B11" level.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, fixes missing lights to match sw renderer.
-    trilinearFiltering: 1
 SLPM-74206:
   name: 鬼武者 PlayStation 2 the Best
   name-sort: おにむしゃ PlayStation 2 the Best
@@ -50101,8 +47187,6 @@ SLPM-74229:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-74230:
   name: Devil May Cry PlayStation 2 the Best
   name-sort: Devil May Cry PlayStation 2 the Best
@@ -50151,9 +47235,6 @@ SLPM-74236:
   name-sort: しんさんごくむそう4 PlayStation 2 the Best
   name-en: "Shin Sangoku Musou 4 [PlayStation 2 the Best]"
   region: "NTSC-J"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-74237:
   name: NEW人生ゲーム PlayStation 2 the Best
   name-sort: NEWじんせいげーむ PlayStation 2 the Best
@@ -50207,8 +47288,6 @@ SLPM-74243:
     preloadFrameData: 1 # Fixes numberplates and ensures above targets are valid.
     roundSprite: 1 # Fixes lines in some post-effects.
     gpuTargetCLUT: 1 # Fixes light occlusion.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-74244:
   name: ファンタシー スター ユニバース PlayStation 2 the Best
   name-sort: ふぁんたしーすたーゆにばーす PlayStation 2 the Best
@@ -50303,8 +47382,6 @@ SLPM-74255:
     - InstantDMAHack # Fixes broken half-bottom artifacts.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-74256:
   name: "Metal Gear Solid 2 - Sons of Liberty [PlayStation 2 the Best] [Disc 2 of 2]"
   region: "NTSC-J"
@@ -50312,8 +47389,6 @@ SLPM-74256:
     - InstantDMAHack # Fixes broken half-bottom artifacts.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-74257:
   name: "Metal Gear Solid 3 - Subsistence (Disc 1) (Subsistence)"
   region: "NTSC-J"
@@ -50340,8 +47415,6 @@ SLPM-74262:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-74263:
   name: "Nobunaga no Yabou - Tenka Sousei"
   region: "NTSC-J"
@@ -50392,9 +47465,6 @@ SLPM-74277:
   name-en: "Persona 3 FES [PlayStation 2 the Best]"
   region: "NTSC-J"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, fixes flashing windows.
-    trilinearFiltering: 1
 SLPM-74278:
   name: ペルソナ4 PlayStation 2 the Best
   name-sort: ぺるそな4 PlayStation 2 the Best
@@ -50430,8 +47500,6 @@ SLPM-74288:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-74301:
   name: 龍が如く2 PlayStation 2 the Best
   name-sort: りゅうがごとく2 PlayStation 2 the Best
@@ -50538,16 +47606,11 @@ SLPM-74901:
     roundSprite: 2 # Fixes font artifacts.
     autoFlush: 1 # Fixes depth of field blur.
     recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLPM-83770:
   name: ペルソナ3フェス [アペンドディスク版]
   name-sort: ぺるそな3ふぇす [あぺんどでぃすくばん]
   name-en: "Persona 3 FES [Append Edition]"
   region: "NTSC-J"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, fixes flashing windows.
-    trilinearFiltering: 1
 SLPM-84075:
   name: "Anubis Zone of Enders Special Edition [Konami Dendou Selection]"
   region: "NTSC-J"
@@ -50578,9 +47641,6 @@ SLPS-20002:
   name-en: "Doukyu Billiards"
   region: "NTSC-J"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLPS-20003:
   name: ストリートファイターEX3
   name-sort: すとりーとふぁいたーEX3
@@ -50615,8 +47675,6 @@ SLPS-20007:
   gsHWFixes:
     textureInsideRT: 1
     roundSprite: 1 # Fixes font misalignment when upscaling.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLPS-20008:
   name: "Morita Shougi"
   region: "NTSC-J"
@@ -50702,8 +47760,6 @@ SLPS-20023:
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes character models.
-    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
-    trilinearFiltering: 1
 SLPS-20024:
   name: フレースヴェルグ
   name-sort: ふれーすゔぇるぐ
@@ -50788,9 +47844,6 @@ SLPS-20040:
   name-sort: MotoGP
   name-en: "MotoGP"
   region: "NTSC-J"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves road and tree textures to match sw renderer.
-    trilinearFiltering: 1
 SLPS-20041:
   name: 麻雀悟空 大聖
   name-sort: まーじゃんごくう たいせい
@@ -50909,9 +47962,6 @@ SLPS-20065:
   region: "NTSC-J"
   clampModes:
     vuClampMode: 3 # Missing geometry with microVU.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLPS-20066:
   name: 天使のプレゼント マール王国物語
   name-sort: てんしのぷれぜんと まーるおうこくものがたり
@@ -50922,9 +47972,6 @@ SLPS-20067:
   name-sort: CRAZY BUMP’S かっとびかーばとる!
   name-en: "Crazy Bumps"
   region: "NTSC-J"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLPS-20068:
   name: MIDNIGHT CLUB〜STREET RACING〜
   name-sort: MIDNIGHT CLUB〜STREET RACING〜
@@ -50983,9 +48030,6 @@ SLPS-20083:
   region: "NTSC-J"
   gameFixes:
     - VUSyncHack # Fixes graphics.
-  gsHWFixes:
-    mipmap: 2 # Fixes ground graphics.
-    trilinearFiltering: 1 # Fixes ground graphics.
 SLPS-20084:
   name: BASIC STUDIO パワフルゲーム工房 [ディスク1/2]
   name-sort: BASIC STUDIO ぱわふるげーむこうぼう [でぃすく1/2]
@@ -51026,9 +48070,6 @@ SLPS-20092:
   name-sort: たいがー・うっず PGA TOUR 2001
   name-en: "Tiger Woods PGA Tour 2001"
   region: "NTSC-J"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLPS-20093:
   name: "Super Mic-chan"
   region: "NTSC-J"
@@ -51057,9 +48098,6 @@ SLPS-20098:
   name-sort: まじかるすぽーつ Hard Hitter
   name-en: "Magical Sports - Hard Hitter"
   region: "NTSC-J"
-  gsHWFixes:
-    mipmap: 2 # Improves ground texture rendering.
-    trilinearFiltering: 1
 SLPS-20099:
   name: "Dream Audition 3"
   region: "NTSC-J"
@@ -51133,9 +48171,6 @@ SLPS-20113:
   name-sort: たいむくらいしす2＋がんこん2
   name-en: "Time Crisis II [with Guncon 2]"
   region: "NTSC-J"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLPS-20114:
   name: "TVware Jouhou Kakumei Series - Katei no Igaku"
   region: "NTSC-J"
@@ -51165,9 +48200,6 @@ SLPS-20122:
   name-sort: たいむくらいしす2
   name-en: "Time Crisis II"
   region: "NTSC-J"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLPS-20123:
   name: "Initial D - Takahashi Ryousuke no Typing Saisoku Riron"
   region: "NTSC-J"
@@ -51340,9 +48372,6 @@ SLPS-20172:
 SLPS-20173:
   name: "Magical Sports - Hard Hitter 2"
   region: "NTSC-J"
-  gsHWFixes:
-    mipmap: 2 # Improves ground texture rendering.
-    trilinearFiltering: 1
 SLPS-20174:
   name: "Typing Renai Hakusho - Boys Be... [with Keyboard]"
   region: "NTSC-J"
@@ -51493,9 +48522,6 @@ SLPS-20216:
   region: "NTSC-J"
   gameFixes:
     - VUSyncHack # Fixes graphics.
-  gsHWFixes:
-    mipmap: 2 # Fixes ground graphics.
-    trilinearFiltering: 1 # Fixes ground graphics.
 SLPS-20217:
   name: "Hokka Hoka Sentou"
   region: "NTSC-J"
@@ -51578,8 +48604,6 @@ SLPS-20234:
     - EETimingHack # Fixes flickering textures.
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes missing lighting effects.
-    mipmap: 2 # Fixes blurry textures.
-    trilinearFiltering: 1 # Fixes blurry textures.
     cpuFramebufferConversion: 1 # Fixes right side of the screen from garbage textures.
 SLPS-20237:
   name: "Saikyou Toudai Shougi 3"
@@ -51619,9 +48643,6 @@ SLPS-20245:
 SLPS-20246:
   name: "Rally Shox"
   region: "NTSC-J"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
-    trilinearFiltering: 1
 SLPS-20247:
   name: "Lotus Challenge"
   region: "NTSC-J"
@@ -52368,9 +49389,6 @@ SLPS-20423:
   region: "NTSC-J"
   clampModes:
     vuClampMode: 3 # Fixes bad coordinate spam.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLPS-20424:
   name: 太鼓の達人 とびっきり!アニメスペシャル [「タタコン」同梱版]
   name-sort: たいこのたつじん とびっきり!あにめすぺしゃる [「たたこん」どうこんばん]
@@ -52395,8 +49413,6 @@ SLPS-20426:
   gsHWFixes:
     roundSprite: 2 # Improves bloom alignment and clarity.
     halfPixelOffset: 2 # Improves bloom alignment and clarity.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLPS-20427:
   name: "Pachi-Slot Club Collection - Pachi-Slot da yo Koumon-chama"
   region: "NTSC-J"
@@ -52609,9 +49625,6 @@ SLPS-20469:
   name-en: "Matching Maker 2 - Zoku Boku no Machi-zukuri"
   region: "NTSC-J"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLPS-20470:
   name: SIMPLE2000シリーズ Vol.103 THE地球防衛軍タクティクス
   name-sort: しんぷる2000しりーず Vol.103 THEちきゅうぼうえいぐんたくてぃくす
@@ -52718,8 +49731,6 @@ SLPS-20489:
   name-en: "Simple 2000 Series Vol. 114 - The Onna Okappichi Torimonochou - Oharu-chan GoGoGo!"
   region: "NTSC-J"
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, cleans up texture detail.
-    trilinearFiltering: 1
     getSkipCount: "GSC_Simple2000Vol114"
 SLPS-20490:
   name: パチスロ倶楽部コレクション アイムジャグラーEX〜ジャグラーセレクション〜
@@ -52847,8 +49858,6 @@ SLPS-25003:
     eeClampMode: 3 # Fixes hanging before going in-game.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes terrain color rendering.
-    mipmap: 2 # Mipmap + trilinear, fixes miptrick textures to match sw renderer.
-    trilinearFiltering: 1
 SLPS-25004:
   name: 建設重機喧嘩バトル ぶちギレ金剛!!
   name-sort: けんせつじゅうきけんかばとる ぶちぎれこんごう!!
@@ -52875,8 +49884,6 @@ SLPS-25007:
     eeClampMode: 2 # Fixes Abnormal AI behavior.
   gsHWFixes:
     textureInsideRT: 1 # Fixes texture corruption.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLPS-25008:
   name: 魔術士オーフェン
   name-sort: まじゅつしおーふぇん
@@ -53116,8 +50123,6 @@ SLPS-25044:
     preloadFrameData: 1 # Fixes textures and flickering such as the wall and sky.
     roundSprite: 2 # Fixes black lines in character sprites.
     textureInsideRT: 1 # Fixes missing effects.
-    mipmap: 2 # Fixes shimmering noisy textures
-    trilinearFiltering: 1 # Fixes shimmering noisy textures
 SLPS-25045:
   name: リリーのアトリエ 〜ザールブルグの錬金術士3〜
   name-sort: りりーのあとりえ ざーるぶるぐのれんきんじゅつし3
@@ -53168,8 +50173,6 @@ SLPS-25052:
     - SoftwareRendererFMVHack # Fixes FMVs disabling hash cache.
   gsHWFixes:
     recommendedBlendingLevel: 2 # Helps banding when dithering is enabled.
-    mipmap: 2 # Fixes terrain rendering and edge of screen issues in 16:9 mode.
-    trilinearFiltering: 1
     roundSprite: 1 # Fixes font and HUD artifacts.
     alignSprite: 1 # Fixes vertical lines.
     mergeSprite: 1 # Fixes vertical lines.
@@ -53202,8 +50205,6 @@ SLPS-25057:
     preloadFrameData: 1 # Fixes invisible lava, there is another issue that needs skipdraw 1 for blurry font but it removes much brightness.
     cpuSpriteRenderBW: 2 # Fixes sky and lava when upscaling.
     cpuSpriteRenderLevel: 2 # Needed for above.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
   patches:
     04C3765E:
       content: |-
@@ -53319,8 +50320,6 @@ SLPS-25078:
     eeRoundMode: 0 # Fixes riders vanish into the floor.
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes missing lighting and makes snow not look like snow sludge.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLPS-25079:
   name: MADDEN NFL スーパーボウル 2002
   name-sort: MADDEN NFL すーぱーぼうる 2002
@@ -53328,9 +50327,6 @@ SLPS-25079:
   region: "NTSC-J"
   clampModes:
     vuClampMode: 3 # Missing geometry with microVU.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLPS-25080:
   name: 宇宙戦艦ヤマト イスカンダルへの追憶(初回生産限定版)
   name-sort: うちゅうせんかんやまと いすかんだるへのついおく [しょかいせいさんげんていばん]
@@ -53379,8 +50375,6 @@ SLPS-25089:
     - VUSyncHack # Fixes flickering and missing textures.
   gsHWFixes:
     textureInsideRT: 1 # Fixes graphical corruption.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLPS-25094:
   name: リーヴェルファンタジア 〜マリエルと妖精物語〜
   name-sort: りーゔぇるふぁんたじあ まりえるとようせいものがたり
@@ -53487,8 +50481,6 @@ SLPS-25112:
   gsHWFixes:
     halfPixelOffset: 2 # Corrects positioning of reflections on suit's surfaces.
     roundSprite: 2 # Reduces garbage on the UI whilst upscaling.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLPS-25113:
   name: 絶体絶命都市
   name-sort: ぜったいぜつめいとし
@@ -53498,8 +50490,6 @@ SLPS-25113:
   gsHWFixes:
     autoFlush: 1 # Fixes incorrect blur effect.
     halfPixelOffset: 4 # Improves blur.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLPS-25114:
   name: 機甲武装Gブレイカー 第三次クラウディア大戦
   name-sort: きこうぶそうGぶれいかー だいさんじくらうでぃあたいせん
@@ -53520,9 +50510,6 @@ SLPS-25118:
   name-sort: 2002FIFAわーるどかっぷ
   name-en: "2002 FIFA World Cup"
   region: "NTSC-J"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLPS-25119:
   name: ガレリアンズ:アッシュ
   name-sort: がれりあんず あっしゅ
@@ -53551,8 +50538,6 @@ SLPS-25121:
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 1 # Sharpens world in far distances.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
   memcardFilters:
     - "SCPS-55029"
     - "SCPS-55042"
@@ -53656,9 +50641,6 @@ SLPS-25142:
   region: "NTSC-J"
   gameFixes:
     - VUSyncHack # Fixes the inverted legs.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLPS-25143:
   name: .hack//悪性変異 Vol.2
   name-sort: どっとはっく あくせいへんい Vol.2
@@ -53742,9 +50724,6 @@ SLPS-25157:
   region: "NTSC-J"
   clampModes:
     vuClampMode: 3 # Missing geometry with microVU.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLPS-25158:
   name: .hack//侵食汚染 Vol.3
   name-sort: どっとはっく しんしょくおせん Vol.3
@@ -53854,8 +50833,6 @@ SLPS-25177:
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 2 # Improves lighting, maximum blending is needed for full accuracy.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLPS-25178:
   name: アルゴスの戦士
   name-sort: あるごすのせんし
@@ -54014,8 +50991,6 @@ SLPS-25204:
   region: "NTSC-J"
   gsHWFixes:
     roundSprite: 2 # Fixes lines at the edges of the HUD.
-    mipmap: 2 # Mipmap + trilinear, improves road and grass textures to match sw renderer.
-    trilinearFiltering: 1
 SLPS-25205:
   name: イース I・II エターナルストーリー [特別限定版]
   name-sort: いーす I・II えたーなるすとーりー [とくべつげんていばん]
@@ -54222,8 +51197,6 @@ SLPS-25246:
   region: "NTSC-J"
   gsHWFixes:
     autoFlush: 2 # Fixes lava effect.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLPS-25247:
   name: R-TYPE FINAL
   name-sort: R-TYPE FINAL
@@ -54378,9 +51351,6 @@ SLPS-25272:
   name-sort: HULK
   name-en: "Hulk, The"
   region: "NTSC-J"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLPS-25274:
   name: あいかぎ 〜ぬくもりとひだまりの中で〜
   name-sort: あいかぎ ぬくもりとひだまりのなかで
@@ -54555,8 +51525,6 @@ SLPS-25310:
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLPS-25311:
   name: SPY FICTION
   name-sort: SPY FICTION
@@ -54678,9 +51646,6 @@ SLPS-25333:
   name-sort: ぎゃろっぷれーさー らっきー7
   name-en: "Gallop Racer Lucky 7"
   region: "NTSC-J"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLPS-25334:
   name: シャドウハーツ II [通常版] [ディスク1/2]
   name-sort: しゃどうはーつ II [でぃすく1/2]
@@ -54721,8 +51686,6 @@ SLPS-25338:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
     recommendedBlendingLevel: 3 # Fixes level brightness.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
   memcardFilters:
     - "SCAJ-20076"
     - "SCAJ-20077"
@@ -54738,8 +51701,6 @@ SLPS-25339:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
     recommendedBlendingLevel: 3 # Fixes level brightness.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
   memcardFilters:
     - "SCAJ-20076"
     - "SCAJ-20077"
@@ -54816,8 +51777,6 @@ SLPS-25351:
     autoFlush: 1 # Fixes bloom and sun rendering in front of everything.
     halfPixelOffset: 2 # Aligns bloom effect a little bit better when upscaled.
     bilinearUpscale: 2 # Reduces color banding of the sun glare.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
   roundModes:
     vu1RoundMode: 1 # Bright lights in cars.
 SLPS-25352:
@@ -55037,9 +51996,6 @@ SLPS-25384:
   name-sort: てんちゅう くれない
   name-en: "Tenchu Kurenai"
   region: "NTSC-J"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLPS-25385:
   name: フレンズ 〜青春の輝き〜
   name-sort: ふれんず せいしゅんのかがやき
@@ -55167,8 +52123,6 @@ SLPS-25406:
   gsHWFixes:
     texturePreloading: 1 # Performs much better with partial preload.
     autoFlush: 1 # Fixes bloom rendering.
-    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
-    trilinearFiltering: 1
   roundModes:
     vu1RoundMode: 0 # Fixes missing light cones curtains and certain effects.
 SLPS-25407:
@@ -55184,8 +52138,6 @@ SLPS-25408:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
     recommendedBlendingLevel: 3 # Fixes level brightness.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
     cpuSpriteRenderBW: 2 # Fixes broken water on "Upper Sea" level.
     cpuSpriteRenderLevel: 2 # Needed for above.
   memcardFilters:
@@ -55250,8 +52202,6 @@ SLPS-25418:
     - SoftwareRendererFMVHack # Fixes FMVs disabling hash cache.
   gsHWFixes:
     recommendedBlendingLevel: 2 # Helps banding when dithering is enabled.
-    mipmap: 2 # Fixes terrain rendering.
-    trilinearFiltering: 1
     halfPixelOffset: 3 # Fixes ghosting in foggy maps.
     roundSprite: 1 # Fixes font and HUD artifacts.
     alignSprite: 1 # Fixes vertical lines.
@@ -55290,8 +52240,6 @@ SLPS-25422:
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes FMV lines.
-    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
-    trilinearFiltering: 1
     cpuSpriteRenderBW: 2 # Prevents Death By VRAM explosion.
     cpuSpriteRenderLevel: 2 # Needed for above.
     getSkipCount: "GSC_DeathByDegreesTekkenNinaWilliams"
@@ -55501,8 +52449,6 @@ SLPS-25461:
     halfPixelOffset: 1 # Fixes misaligned blur.
     cpuSpriteRenderBW: 1 # Fixes broken shadow caused by HPO 1.
     cpuSpriteRenderLevel: 2 # Needed for above.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLPS-25462:
   name: アーマード・コア ラストレイヴン
   name-sort: あーまーどこあ らすとれいゔん
@@ -55511,8 +52457,6 @@ SLPS-25462:
   gsHWFixes:
     halfPixelOffset: 2 # Corrects shadow alignment and reduces blurriness.
     recommendedBlendingLevel: 3 # Fixes level and map menu brightness.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
     preloadFrameData: 1 # Fixes glowing emblems.
   memcardFilters:
     - "SLPS-25338"
@@ -55620,9 +52564,6 @@ SLPS-25480:
   name-sort: じぱんぐ
   name-en: "ZIPANG"
   region: "NTSC-J"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLPS-25481:
   name: ガッツだ!!森の石松
   name-sort: がっつだ もりのいしまつ
@@ -55778,8 +52719,6 @@ SLPS-25510:
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
     halfPixelOffset: 4 # Align post.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_Tekken5"
 SLPS-25511:
   name: 羅刹 -Alternative-
@@ -56022,8 +52961,6 @@ SLPS-25557:
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
     textureInsideRT: 1 # Fixes corruption.
-    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_UrbanReign"
 SLPS-25558:
   name: ネオジオ バトルコロシアム
@@ -56056,8 +52993,6 @@ SLPS-25563:
   gsHWFixes:
     texturePreloading: 1 # Performs much better with partial preload.
     autoFlush: 1 # Fixes bloom rendering.
-    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
-    trilinearFiltering: 1
   roundModes:
     vu1RoundMode: 0 # Fixes missing light cones curtains and certain effects.
 SLPS-25564:
@@ -56177,9 +53112,6 @@ SLPS-25580:
   name-sort: ちきん りとる
   name-en: "Chicken Little"
   region: "NTSC-J"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLPS-25581:
   name: SIMPLE2000シリーズ Vol.92 THE 呪いのゲーム
   name-sort: しんぷる2000しりーず Vol.92 THE のろいのげーむ
@@ -56417,8 +53349,6 @@ SLPS-25626:
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes lighting misalignment.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLPS-25627:
   name: 機動戦士ガンダム クライマックスU.C.
   name-sort: きどうせんしがんだむ くらいまっくすU.C.
@@ -56438,8 +53368,6 @@ SLPS-25629:
     - SoftwareRendererFMVHack # Fixes FMVs disabling hash cache.
   gsHWFixes:
     recommendedBlendingLevel: 2 # Helps banding when dithering is enabled.
-    mipmap: 2 # Fixes terrain rendering.
-    trilinearFiltering: 1
     halfPixelOffset: 3 # Fixes ghosting in foggy maps.
     roundSprite: 1 # Fixes HUD artifacts.
     alignSprite: 1 # Fixes vertical lines.
@@ -56519,8 +53447,6 @@ SLPS-25640:
     halfPixelOffset: 2 # Fixes lighting misalignment and reduces ground shadows (probably texture cache issue).
     roundSprite: 2 # Fixes font artifacts.
     textureInsideRT: 1 # Fixes bad crystal surfaces.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
   memcardFilters: # Allows import of Xenosaga II save data.
     - "SLPS-25640"
     - "SLPS-25368"
@@ -56535,8 +53461,6 @@ SLPS-25641:
     halfPixelOffset: 2 # Fixes lighting misalignment and reduces ground shadows (probably texture cache issue).
     roundSprite: 2 # Fixes font artifacts.
     textureInsideRT: 1 # Fixes bad crystal surfaces.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
   memcardFilters:
     - "SLPS-25640"
     - "SLPS-25368"
@@ -56836,9 +53760,6 @@ SLPS-25686:
   name-sort: じょじょのきみょうなぼうけん ふぁんとむぶらっど
   name-en: "Jojo no Kimyou na Bouken - Phantom Blood"
   region: "NTSC-J"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLPS-25687:
   name: コロボットアドベンチャー
   name-sort: ころぼっとあどべんちゃー
@@ -57091,8 +54012,6 @@ SLPS-25730:
   gsHWFixes:
     halfPixelOffset: 2 # Corrects shadow alignment and reduces blurriness.
     recommendedBlendingLevel: 3 # Fixes level and map menu brightness.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
     preloadFrameData: 1 # Fixes glowing emblems.
 SLPS-25731:
   name: ARMORED CORE 2 (ARMORED CORE PREMIUM BOX同梱用)
@@ -57667,9 +54586,6 @@ SLPS-25834:
   name-sort: とらんすふぉーまー THE GAME
   name-en: "Transformers - The Game"
   region: "NTSC-J"
-  gsHWFixes:
-    mipmap: 2 # Cleans up texture detail.
-    trilinearFiltering: 1 # Smoothes out texture transitions.
 SLPS-25835:
   name: スーパーロボット大戦OG外伝 [限定版]
   name-sort: すーぱーろぼっとたいせんOGがいでん [げんていばん]
@@ -57713,8 +54629,6 @@ SLPS-25840:
   gsHWFixes:
     textureInsideRT: 1 # Crowd textures.
     autoFlush: 1 # Fixes bloom intensity.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLPS-25841:
   name: テイルズ オブ デスティニー ディレクターズカット プレミアムBOX
   name-sort: ているず おぶ ですてぃにー でぃれくたーずかっと [ぷれみあむBOX]
@@ -57904,8 +54818,6 @@ SLPS-25879:
     recommendedBlendingLevel: 2 # Fixes door transitions.
     halfPixelOffset: 4 # Reduces ghosting.
     roundSprite: 2 # Reduces ghosting.
-    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
-    trilinearFiltering: 1
 SLPS-25880:
   name: "True Fortune"
   region: "NTSC-J"
@@ -57941,8 +54853,6 @@ SLPS-25886:
   gsHWFixes:
     textureInsideRT: 1 # Crowd textures.
     autoFlush: 1 # Fixes bloom intensity.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLPS-25887:
   name: スーパーロボット大戦Ｚ
   name-sort: すーぱーろぼっとたいせんZ
@@ -57976,8 +54886,6 @@ SLPS-25889:
   gsHWFixes:
     textureInsideRT: 1 # Crowd textures.
     autoFlush: 1 # Fixes bloom intensity.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLPS-25890:
   name: ギターヒーロー3 レジェンドオブロック
   name-sort: ぎたーひーろー3 れじぇんどおぶろっく
@@ -57988,8 +54896,6 @@ SLPS-25890:
   gsHWFixes:
     textureInsideRT: 1 # Crowd textures.
     autoFlush: 1 # Fixes bloom intensity.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLPS-25891:
   name: "Nogizaka Haruka no Himitsu - Cosplay, Hajimemashita"
   region: "NTSC-J"
@@ -58135,8 +55041,6 @@ SLPS-25927:
   gsHWFixes:
     textureInsideRT: 1 # Needed for post processing effects.
     autoFlush: 1 # Fixes missing blur layer.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLPS-25928:
   name: "Little Anchor"
   region: "NTSC-J"
@@ -58208,8 +55112,6 @@ SLPS-25945:
   name: "Lara Croft Tomb Raider - Legend [Best of Spike]"
   region: "NTSC-J"
   gsHWFixes:
-    mipmap: 2 # Fixes distant characters and models.
-    trilinearFiltering: 1
     textureInsideRT: 1 # Needed for post processing effects.
     autoFlush: 1 # Fixes bloom intensity.
     minimumBlendingLevel: 4 # Fixes multiple lighting effects from lights, computers, cave walls and more.
@@ -58232,8 +55134,6 @@ SLPS-25950:
     recommendedBlendingLevel: 2 # Fixes door transitions.
     halfPixelOffset: 4 # Reduces ghosting.
     roundSprite: 2 # Reduces ghosting.
-    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
-    trilinearFiltering: 1
 SLPS-25953:
   name: "Daisenryaku VII - Exceed"
   region: "NTSC-J"
@@ -58315,8 +55215,6 @@ SLPS-25986:
   gsHWFixes:
     textureInsideRT: 1 # Needed for post processing effects.
     autoFlush: 1 # Fixes missing blur layer.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLPS-25987:
   name: "Amagami [EBKore+]"
   region: "NTSC-J"
@@ -58391,8 +55289,6 @@ SLPS-29003:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misaligned lighting and other effects.
     cpuSpriteRenderBW: 1 # Fixes flickering textures caused by mipmapping.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
   clampModes:
     vuClampMode: 3 # Fix white shiny weapons.
 SLPS-29004:
@@ -58404,8 +55300,6 @@ SLPS-29004:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misaligned lighting and other effects.
     cpuSpriteRenderBW: 1 # Fixes flickering textures caused by mipmapping.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
   clampModes:
     vuClampMode: 3 # Fix white shiny weapons.
 SLPS-29005:
@@ -58465,9 +55359,6 @@ SLPS-73006:
   name-sort: たいむくらいしす2 PlayStation 2 the Best
   name-en: "Time Crisis II [PlayStation 2 the Best]"
   region: "NTSC-J"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLPS-73007:
   name: "Kamaitachi no Yoru 2 - Kangoku-jima no Warabe-uta - Special Eizou"
   region: "NTSC-J"
@@ -58545,8 +55436,6 @@ SLPS-73202:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
     recommendedBlendingLevel: 3 # Fixes level brightness.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
   memcardFilters:
     - "SCAJ-20076"
     - "SCAJ-20077"
@@ -58562,8 +55451,6 @@ SLPS-73203:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
     recommendedBlendingLevel: 3 # Fixes level brightness.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
   memcardFilters:
     - "SCAJ-20076"
     - "SCAJ-20077"
@@ -58579,8 +55466,6 @@ SLPS-73204:
   gsHWFixes:
     autoFlush: 1 # Fixes incorrect blur effect.
     halfPixelOffset: 4 # Improves blur.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLPS-73205:
   name: エースコンバット04 シャッタードスカイ PlayStation 2 the Best
   name-sort: えーすこんばっと04 しゃったーどすかい PlayStation 2 the Best
@@ -58590,8 +55475,6 @@ SLPS-73205:
     - SoftwareRendererFMVHack # Fixes FMVs disabling hash cache.
   gsHWFixes:
     recommendedBlendingLevel: 2 # Helps banding when dithering is enabled.
-    mipmap: 2 # Fixes terrain rendering and edge of screen issues in 16:9 mode.
-    trilinearFiltering: 1
     roundSprite: 1 # Fixes font and HUD artifacts.
     alignSprite: 1 # Fixes vertical lines.
     mergeSprite: 1 # Fixes vertical lines.
@@ -58686,8 +55569,6 @@ SLPS-73218:
     - SoftwareRendererFMVHack # Fixes FMVs disabling hash cache.
   gsHWFixes:
     recommendedBlendingLevel: 2 # Helps banding when dithering is enabled.
-    mipmap: 2 # Fixes terrain rendering.
-    trilinearFiltering: 1
     halfPixelOffset: 3 # Fixes ghosting in foggy maps.
     roundSprite: 1 # Fixes font and HUD artifacts.
     alignSprite: 1 # Fixes vertical lines.
@@ -58725,8 +55606,6 @@ SLPS-73223:
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
     halfPixelOffset: 4 # Align post.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_Tekken5"
 SLPS-73224:
   name: ゼノサーガ エピソードII［善悪の彼岸］ PlayStation 2 the Best [ディスク1/2]
@@ -58765,9 +55644,6 @@ SLPS-73226:
   name-sort: てんちゅう くれない PlayStation 2 the Best
   name-en: "Tenchu Kurenai [PlayStation 2 the Best]"
   region: "NTSC-J"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLPS-73227:
   name: Another Century’s Episode PlayStation 2 the Best
   name-sort: Another Century’s Episode PlayStation 2 the Best
@@ -58949,8 +55825,6 @@ SLPS-73247:
   gsHWFixes:
     halfPixelOffset: 2 # Corrects shadow alignment and reduces blurriness.
     recommendedBlendingLevel: 3 # Fixes level and map menu brightness.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
     preloadFrameData: 1 # Fixes glowing emblems.
   memcardFilters:
     - "SLPS-25338"
@@ -58981,8 +55855,6 @@ SLPS-73250:
     - SoftwareRendererFMVHack # Fixes FMVs disabling hash cache.
   gsHWFixes:
     recommendedBlendingLevel: 2 # Helps banding when dithering is enabled.
-    mipmap: 2 # Fixes terrain rendering.
-    trilinearFiltering: 1
     halfPixelOffset: 3 # Fixes ghosting in foggy maps.
     roundSprite: 1 # Fixes HUD artifacts.
     alignSprite: 1 # Fixes vertical lines.
@@ -59110,8 +55982,6 @@ SLPS-73403:
     eeClampMode: 2 # Fixes Abnormal AI behavior.
   gsHWFixes:
     textureInsideRT: 1 # Fixes texture corruption.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLPS-73404:
   name: 風のクロノア2〜世界が望んだ忘れもの〜PlayStation 2 the Best
   name-sort: かぜのくろのあ2 せかいがのぞんだわすれもの PlayStation 2 the Best
@@ -59158,8 +56028,6 @@ SLPS-73410:
     - SoftwareRendererFMVHack # Fixes FMVs disabling hash cache.
   gsHWFixes:
     recommendedBlendingLevel: 2 # Helps banding when dithering is enabled.
-    mipmap: 2 # Fixes terrain rendering and edge of screen issues in 16:9 mode.
-    trilinearFiltering: 1
     roundSprite: 1 # Fixes font and HUD artifacts.
     alignSprite: 1 # Fixes vertical lines.
     mergeSprite: 1 # Fixes vertical lines.
@@ -59191,8 +56059,6 @@ SLPS-73415:
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 2 # Improves lighting, maximum blending is needed for full accuracy.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLPS-73416:
   name: スーパーロボット大戦IMPACT PlayStation 2 the Best
   name-sort: すーぱーろぼっとたいせんIMPACT PlayStation 2 the Best
@@ -59208,8 +56074,6 @@ SLPS-73417:
   gsHWFixes:
     halfPixelOffset: 2 # Corrects positioning of reflections on suit's surfaces.
     roundSprite: 2 # Reduces garbage on the UI whilst upscaling.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLPS-73418:
   name: シャドウハーツ PlayStation 2 the Best
   name-sort: しゃどうはーつ [PlayStation 2 the Best]
@@ -59355,8 +56219,6 @@ SLUS-20014:
     eeClampMode: 2 # Fixes Abnormal AI behavior.
   gsHWFixes:
     textureInsideRT: 1 # Fixes texture corruption.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20015:
   name: "Eternal Ring"
   region: "NTSC-U"
@@ -59371,8 +56233,6 @@ SLUS-20016:
   compat: 5
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes terrain color rendering.
-    mipmap: 2 # Mipmap + trilinear, fixes miptrick textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20017:
   name: "Maximo - Ghosts to Glory"
   region: "NTSC-U"
@@ -59395,9 +56255,6 @@ SLUS-20024:
   compat: 5
   roundModes:
     eeRoundMode: 0 # Fixes pathing.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20028:
   name: "The Operative - No One Lives Forever"
   name-sort: "Operative, The - No One Lives Forever"
@@ -59405,8 +56262,6 @@ SLUS-20028:
   compat: 5
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes missing lighting.
-    mipmap: 2 # Fixes miptrick texture effects.
-    trilinearFiltering: 1 # Fixes miptrick blending and also needs Full Blending to fix the lighting.
 SLUS-20029:
   name: "Top Gear Daredevil"
   region: "NTSC-U"
@@ -59478,8 +56333,6 @@ SLUS-20047:
   compat: 5
   gsHWFixes:
     recommendedBlendingLevel: 5 # Corrects lighting to match software.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20048:
   name: "Legion - The Legend of Excalibur"
   region: "NTSC-U"
@@ -59510,9 +56363,6 @@ SLUS-20058:
   name: "MotoGP"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves road and tree textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20062:
   name: "Grand Theft Auto III"
   region: "NTSC-U"
@@ -59528,9 +56378,6 @@ SLUS-20064:
   name: "Oni"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
   patches:
     FD9CD8FC:
       content: |-
@@ -59542,16 +56389,10 @@ SLUS-20065:
   name: "Smuggler's Run"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20066:
   name: "Half-Life"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20069:
   name: "The Bouncer"
   name-sort: "Bouncer, The"
@@ -59560,9 +56401,6 @@ SLUS-20069:
 SLUS-20070:
   name: "Q-Ball Billiards Master"
   region: "NTSC-U"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20071:
   name: "DOA 2 - Hardcore"
   region: "NTSC-U"
@@ -59672,16 +56510,11 @@ SLUS-20093:
   region: "NTSC-U"
   clampModes:
     vuClampMode: 3 # Missing geometry with microVU.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20094:
   name: "X Squad"
   region: "NTSC-U"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes character models.
-    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20095:
   name: "SSX"
   region: "NTSC-U"
@@ -59728,9 +56561,6 @@ SLUS-20104:
   name: "Tiger Woods PGA Tour 2001"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20105:
   name: "MDK 2 - Armageddon"
   region: "NTSC-U"
@@ -59749,8 +56579,6 @@ SLUS-20111:
   compat: 5
   gsHWFixes:
     roundSprite: 1 # Fixes lines in HUD and text boxes.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20112:
   name: "Star Trek - Shattered Universe"
   region: "NTSC-U"
@@ -59762,16 +56590,11 @@ SLUS-20113:
   gsHWFixes:
     textureInsideRT: 1
     roundSprite: 1 # Fixes font misalignment when upscaling.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20114:
   name: "The Simpsons Skateboarding"
   name-sort: "Simpsons, The - Skateboarding"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20115:
   name: "Super Bust-A-Move"
   region: "NTSC-U"
@@ -59844,8 +56667,6 @@ SLUS-20144:
     - InstantDMAHack # Fixes broken half-bottom artifacts.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20145:
   name: "Ring of Red"
   region: "NTSC-U"
@@ -59872,8 +56693,6 @@ SLUS-20149:
   compat: 5
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves reflections on weapons and metalic surfaces.
-    mipmap: 2 # Mipmap + trilinear, improves ground and building textures to match sw renderer.
-    trilinearFiltering: 1
     roundSprite: 1 # Fixes font artifacts.
 SLUS-20150:
   name: "Knockout Kings 2001"
@@ -59900,8 +56719,6 @@ SLUS-20152:
     - SoftwareRendererFMVHack # Fixes FMVs disabling hash cache.
   gsHWFixes:
     recommendedBlendingLevel: 2 # Helps banding when dithering is enabled.
-    mipmap: 2 # Fixes terrain rendering and edge of screen issues in 16:9 mode.
-    trilinearFiltering: 1
     roundSprite: 1 # Fixes font and HUD artifacts.
     alignSprite: 1 # Fixes vertical lines.
     mergeSprite: 1 # Fixes vertical lines.
@@ -59940,9 +56757,6 @@ SLUS-20159:
   name: "Dave Mirra Freestyle BMX 2"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Fixes noisy bumpy textures.
-    trilinearFiltering: 1 # Smoothes out mipmapping
 SLUS-20160:
   name: "Winback - Covert Operations"
   region: "NTSC-U"
@@ -60080,9 +56894,6 @@ SLUS-20197:
   roundModes:
     eeRoundMode: 2 # Fixes game board jittering.
     vu0RoundMode: 2 # Fixes Gauntlet Golf drawbridges not operating.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20198:
   name: "FireBlade"
   region: "NTSC-U"
@@ -60097,9 +56908,6 @@ SLUS-20202:
   compat: 5
   gameFixes:
     - EETimingHack # Fixes credits screen.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves road and building textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20204:
   name: "Smuggler's Run 2 - Hostile Territory"
   region: "NTSC-U"
@@ -60123,9 +56931,6 @@ SLUS-20209:
   name: "Midnight Club II"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves road and tree textures to match software.
-    trilinearFiltering: 1
   patches:
     E5F2DF38:
       content: |-
@@ -60206,9 +57011,6 @@ SLUS-20219:
   name: "Time Crisis II"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20220:
   name: "Dead to Rights"
   region: "NTSC-U"
@@ -60325,9 +57127,6 @@ SLUS-20241:
   region: "NTSC-U"
   clampModes:
     vuClampMode: 3 # Missing geometry with microVU.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20242:
   name: "Legends of Wrestling"
   region: "NTSC-U"
@@ -60367,8 +57166,6 @@ SLUS-20250:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     cpuSpriteRenderBW: 4 # Fixes textures.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20251:
   name: "Harvest Moon - Save the Homeland"
   region: "NTSC-U"
@@ -60405,9 +57202,6 @@ SLUS-20263:
   region: "NTSC-U"
   clampModes:
     vuClampMode: 3 # Missing geometry with microVU.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20264:
   name: "F1 2001"
   region: "NTSC-U"
@@ -60431,8 +57225,6 @@ SLUS-20267:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 1 # Sharpens world in far distances.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
   memcardFilters:
     - "SLUS-20267"
     - "SLUS-20562"
@@ -60548,8 +57340,6 @@ SLUS-20291:
   compat: 5
   gsHWFixes:
     textureInsideRT: 1 # Fixes inside RT shuffling.
-    mipmap: 2 # Mipmap + trilinear, improves road and grass textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_BigMuthaTruckers"
 SLUS-20292:
   name: "Tsugunai - Atonement"
@@ -60617,8 +57407,6 @@ SLUS-20307:
   compat: 5
   gsHWFixes:
     autoFlush: 1 # Fixes missing blur layer on sky.
-    mipmap: 2 # Mipmap + trilinear, improves road textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20308:
   name: "ESPN - NFL Prime Time 2002"
   region: "NTSC-U"
@@ -60671,8 +57459,6 @@ SLUS-20315:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
     recommendedBlendingLevel: 3 # Fixes gem reflections.
 SLUS-20316:
   name: "WWF SmackDown! - Just Bring It!"
@@ -60686,8 +57472,6 @@ SLUS-20318:
     preloadFrameData: 1 # Fixes invisible lava, there is another issue that needs skipdraw 1 for blurry font but it removes much brightness.
     cpuSpriteRenderBW: 2 # Fixes sky and lava when upscaling.
     cpuSpriteRenderLevel: 2 # Needed for above.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
   patches:
     36E02E91:
       content: |-
@@ -60729,8 +57513,6 @@ SLUS-20326:
     eeRoundMode: 0 # Fixes riders vanish into the floor.
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes missing lighting and makes snow not look like snow sludge.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20327:
   name: "Aggressive Inline"
   region: "NTSC-U"
@@ -60782,8 +57564,6 @@ SLUS-20336:
   compat: 5
   gsHWFixes:
     autoFlush: 1 # Fixes lens flares.
-    mipmap: 2 # Fixes texture flickering during movement.
-    trilinearFiltering: 1
     gpuTargetCLUT: 1 # Fixes lens flares going through objects.
     bilinearUpscale: 2 # Smooths out sun glare textures.
 SLUS-20337:
@@ -60793,8 +57573,6 @@ SLUS-20337:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes upscaling lines.
     autoFlush: 2 # Fixes sun penetration.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20339:
   name: "Bass Fishing Duel - Sega Sports"
   region: "NTSC-U"
@@ -60818,8 +57596,6 @@ SLUS-20343:
     preloadFrameData: 1 # Fixes textures and flickering such as the wall and sky.
     roundSprite: 2 # Fixes black lines in character sprites.
     textureInsideRT: 1 # Fixes missing effects.
-    mipmap: 2 # Fixes shimmering noisy textures
-    trilinearFiltering: 1 # Fixes shimmering noisy textures
 SLUS-20344:
   name: "Rez"
   region: "NTSC-U"
@@ -60875,8 +57651,6 @@ SLUS-20353:
     preloadFrameData: 1 # Fixes invisible lava, there is another issue that needs skipdraw 1 for blurry font but it removes much brightness.
     cpuSpriteRenderBW: 2 # Fixes sky and lava when upscaling.
     cpuSpriteRenderLevel: 2 # Needed for above.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20354:
   name: "Red Card Soccer 2003"
   region: "NTSC-U"
@@ -60885,9 +57659,6 @@ SLUS-20355:
   name: "Tom & Jerry - War of the Whiskers"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, cleans up texture detail.
-    trilinearFiltering: 1
 SLUS-20356:
   name: "TransWorld Surf"
   region: "NTSC-U"
@@ -60907,9 +57678,6 @@ SLUS-20361:
   name: "Rally Fusion - Race of Champions"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20362:
   name: "Need for Speed - Hot Pursuit 2"
   region: "NTSC-U"
@@ -60920,8 +57688,6 @@ SLUS-20362:
     vuClampMode: 2 # White textures.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth line and blur.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20363:
   name: "Sled Storm"
   region: "NTSC-U"
@@ -60933,9 +57699,6 @@ SLUS-20364:
   region: "NTSC-U"
   gameFixes:
     - VUSyncHack # Fixes the inverted legs.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20365:
   name: "Pirates - Legend of Black Kat"
   region: "NTSC-U"
@@ -60995,8 +57758,6 @@ SLUS-20378:
     - VUSyncHack # Fixes flickering and missing textures.
   gsHWFixes:
     textureInsideRT: 1 # Fixes graphical corruption.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
   patches:
     466D1C13:
       content: |-
@@ -61015,8 +57776,6 @@ SLUS-20380:
   region: "NTSC-U"
   gsHWFixes:
     autoFlush: 2 # Fixes glows. Also needed for recursive mipmap rendering.
-    mipmap: 2 # Better characters and environment but has a texture cache issue that makes it worse.
-    trilinearFiltering: 1 # Using mipmaps, so may as well.
     textureInsideRT: 1 # Fixes rainbow lighting for some areas.
     getSkipCount: "GSC_BlueTongueGames" # Mipmap rendering on CPU.
 SLUS-20381:
@@ -61136,9 +57895,6 @@ SLUS-20403:
 SLUS-20404:
   name: "2002 FIFA World Cup"
   region: "NTSC-U"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20405:
   name: "Downforce"
   region: "NTSC-U"
@@ -61172,8 +57928,6 @@ SLUS-20412:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes the fog line.
-    mipmap: 2 # Mipmap + trilinear, improves track textures to match sw renderer.
-    trilinearFiltering: 1
   patches:
     E7273BFA:
       content: |-
@@ -61217,9 +57971,6 @@ SLUS-20418:
     vuClampMode: 3 # Fixes water rendering.
   gameFixes:
     - XGKickHack # Fixes SPS while ingame.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20419:
   name: "World Rally Championship"
   region: "NTSC-U"
@@ -61245,9 +57996,6 @@ SLUS-20422:
   name-sort: "Hulk, The"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20423:
   name: "Mortal Kombat - Deadly Alliance"
   region: "NTSC-U"
@@ -61299,9 +58047,6 @@ SLUS-20433:
   compat: 5
   clampModes:
     eeClampMode: 3 # For grey screen ingame.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20434:
   name: "Myst III - Exile"
   region: "NTSC-U"
@@ -61323,8 +58068,6 @@ SLUS-20435:
   gsHWFixes:
     halfPixelOffset: 2 # Corrects positioning of reflections on suit's surfaces.
     roundSprite: 2 # Reduces garbage on the UI whilst upscaling.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20436:
   name: "Guilty Gear X2"
   region: "NTSC-U"
@@ -61343,8 +58086,6 @@ SLUS-20439:
   compat: 5
   gsHWFixes:
     readTCOnClose: 1 # Fixes render to target getting lost on state/switch.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20440:
   name: "Kya - Dark Lineage"
   region: "NTSC-U"
@@ -61375,8 +58116,6 @@ SLUS-20445:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     autoFlush: 2 # Fixes DOF effect.
 SLUS-20446:
   name: "Agassi Tennis Generation"
@@ -61440,8 +58179,6 @@ SLUS-20462:
   compat: 5
   gsHWFixes:
     PCRTCOffsets: 1 # Fixes viewport shaking.
-    mipmap: 2 # Mipmap + trilinear, improves building textures and reduces pop in.
-    trilinearFiltering: 1
 SLUS-20463:
   name: "Dropship - United Peace Force"
   region: "NTSC-U"
@@ -61471,8 +58208,6 @@ SLUS-20467:
   compat: 5
   gsHWFixes:
     autoFlush: 2 # Fixes lava effect.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
   patches:
     3BAEBCC3:
       content: |-
@@ -61558,9 +58293,6 @@ SLUS-20480:
   compat: 5
   gameFixes:
     - XGKickHack # Fixes black models on certain games in World Tour.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20482:
   name: "Sphinx and the Cursed Mummy"
   region: "NTSC-U"
@@ -61638,8 +58370,6 @@ SLUS-20496:
   gsHWFixes:
     preloadFrameData: 1 # Fixes fog and make lights on cars work again.
     autoFlush: 2 # Fixes sun luminosity and penetration of objects.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
   gameFixes:
     - EETimingHack # Fixes random graphical corruption.
 SLUS-20497:
@@ -61651,8 +58381,6 @@ SLUS-20497:
     autoFlush: 1 # Fixes bloom and sun rendering in front of everything.
     halfPixelOffset: 2 # Aligns bloom effect a little bit better when upscaled.
     bilinearUpscale: 2 # Reduces color banding of the sun glare.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
   roundModes:
     vu1RoundMode: 1 # Bright lights in cars.
 SLUS-20498:
@@ -61669,9 +58397,6 @@ SLUS-20500:
   name: "Red Dead Revolver"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20502:
   name: "Colin McRae Rally 3"
   region: "NTSC-U"
@@ -61680,25 +58405,18 @@ SLUS-20502:
     alignSprite: 1 # Fixes vertical lines.
     autoFlush: 2 # Fixes the sun flare.
     halfPixelOffset: 2 # Fixes the sun flare.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20504:
   name: "Tony Hawk's Pro Skater 4"
   region: "NTSC-U"
   compat: 5
   roundModes:
     vu1RoundMode: 0 # Crashes without.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20505:
   name: "Mace Griffin - Bounty Hunter"
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves lighting.
-    mipmap: 2 # Mipmap + trilinear, improves ground and wall textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20506:
   name: "Black & Bruised"
   region: "NTSC-U"
@@ -61752,9 +58470,6 @@ SLUS-20516:
   name: "Shrek Super Party"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20517:
   name: "Haven - Call of the King"
   region: "NTSC-U"
@@ -61762,8 +58477,6 @@ SLUS-20517:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
     alignSprite: 1 # Fixes vertical lines.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20519:
   name: "Tak and The Power of Juju"
   region: "NTSC-U"
@@ -61812,17 +58525,11 @@ SLUS-20529:
   region: "NTSC-U"
   clampModes:
     vuClampMode: 3 # Missing geometry with microVU.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20530:
   name: "NCAA Football 2003"
   region: "NTSC-U"
   clampModes:
     vuClampMode: 3 # Missing geometry with microVU.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20531:
   name: "NHL 2003"
   region: "NTSC-U"
@@ -61835,16 +58542,10 @@ SLUS-20532:
   compat: 5
   roundModes:
     eeDivRoundMode: 3 # Fixes random game crashing.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves grass rendering to match software.
-    trilinearFiltering: 1
 SLUS-20533:
   name: "Shox"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20534:
   name: "Cabela's Big Game Hunter"
   region: "NTSC-U"
@@ -61855,8 +58556,6 @@ SLUS-20535:
   compat: 5
   gsHWFixes:
     roundSprite: 1 # Fix horizontal and vertical lines when racing.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
     deinterlace: 8 # Fixes misdetection of game deinterlace.
 SLUS-20536:
   name: "NBA Live 2003"
@@ -61933,8 +58632,6 @@ SLUS-20550:
     halfPixelOffset: 3 # Fixes double image.
     gpuTargetCLUT: 1 # Fixes sun penetrating buildings.
     autoFlush: 1 # Fixes sun occlusion.
-    mipmap: 2 # Fixes miptrick texture effects.
-    trilinearFiltering: 1 # Fixes miptrick blending.
 SLUS-20552:
   name: "Grand Theft Auto - Vice City"
   region: "NTSC-U"
@@ -61953,8 +58650,6 @@ SLUS-20554:
     roundSprite: 2 # Fixes font artifacts.
     autoFlush: 1 # Fixes depth of field blur.
     recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20555:
   name: "Reel Fishing 3"
   region: "NTSC-U"
@@ -61986,8 +58681,6 @@ SLUS-20561:
   gsHWFixes:
     autoFlush: 1 # Fixes incorrect blur effect.
     halfPixelOffset: 4 # Improves blur.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20562:
   name: ".hack Mutation Part 2"
   region: "NTSC-U"
@@ -62034,9 +58727,6 @@ SLUS-20567:
 SLUS-20568:
   name: "Hard Hitter Tennis"
   region: "NTSC-U"
-  gsHWFixes:
-    mipmap: 2 # Improves ground texture rendering.
-    trilinearFiltering: 1
 SLUS-20569:
   name: "All-Star Baseball 2004"
   region: "NTSC-U"
@@ -62046,8 +58736,6 @@ SLUS-20570:
   compat: 5
   gsHWFixes:
     recommendedBlendingLevel: 2 # Fixes dither patterns.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20571:
   name: "TY the Tasmanian Tiger"
   region: "NTSC-U"
@@ -62056,9 +58744,6 @@ SLUS-20572:
   name: "Tiger Woods PGA Tour 2003"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20573:
   name: "The Sims"
   name-sort: "Sims, The"
@@ -62083,8 +58768,6 @@ SLUS-20576:
     - EETimingHack # Fixes flickering textures.
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes missing lighting effects.
-    mipmap: 2 # Fixes blurry textures.
-    trilinearFiltering: 1 # Fixes blurry textures.
     cpuFramebufferConversion: 1 # Fixes right side of the screen from garbage textures.
 SLUS-20577:
   name: "Drome Racers"
@@ -62102,8 +58785,6 @@ SLUS-20578:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misaligned lighting and other effects.
     cpuSpriteRenderBW: 1 # Fixes flickering textures caused by mipmapping.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
   clampModes:
     vuClampMode: 3 # Fix white shiny weapons.
 SLUS-20579:
@@ -62149,8 +58830,6 @@ SLUS-20585:
     eeClampMode: 3 # Fixes hangs in certain locations like building under construction.
   gsHWFixes:
     recommendedBlendingLevel: 2 # Fixes color saturation.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20586:
   name: "IHRA Drag Racing 2"
   region: "NTSC-U"
@@ -62164,8 +58843,6 @@ SLUS-20587:
   gsHWFixes:
     autoFlush: 1 # Aligns and corrects shadows.
     roundSprite: 1 # Fixes depth line.
-    mipmap: 2 # Mipmap + trilinear, improves building textures and reduces pop in.
-    trilinearFiltering: 1
     cpuCLUTRender: 1 # Fixes janky coloured cars.
     gpuTargetCLUT: 1 # Fixes janky coloured cars.
     textureInsideRT: 1 # Fixes car textures.
@@ -62200,8 +58877,6 @@ SLUS-20595:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misaligned lighting and other effects, needs Special otherwise lights flicker.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20596:
   name: "UFC - Ultimate Fighting Championship - Sudden Impact"
   region: "NTSC-U"
@@ -62212,9 +58887,6 @@ SLUS-20597:
   compat: 5
   gameFixes:
     - XGKickHack # Fixes corrupted graphics.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20598:
   name: "Everblue 2"
   region: "NTSC-U"
@@ -62268,8 +58940,6 @@ SLUS-20605:
   region: "NTSC-U"
   gsHWFixes:
     textureInsideRT: 1 # Fixes inside RT shuffling.
-    mipmap: 2 # Mipmap + trilinear, improves road and grass textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_BigMuthaTruckers"
 SLUS-20606:
   name: "Bounty Hunter - Seek & Destroy"
@@ -62319,17 +58989,11 @@ SLUS-20619:
   name: "Starsky & Hutch"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves building textures.
-    trilinearFiltering: 1
 SLUS-20620:
   name: "Smash Cars"
   region: "NTSC-U"
   gameFixes:
     - GIFFIFOHack # Fixes random graphical corruption.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20621:
   name: "Seven Samurai 20XX"
   region: "NTSC-U"
@@ -62359,15 +59023,11 @@ SLUS-20624:
     eeDivRoundMode: 1 # Lens flare appears even when behind objects.
   gsHWFixes:
     autoFlush: 2 # Fixes missing lens flare.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20625:
   name: "MotoGP 3"
   region: "NTSC-U"
   gsHWFixes:
     roundSprite: 2 # Fixes lines at the edges of the HUD.
-    mipmap: 2 # Mipmap + trilinear, improves road and grass textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20626:
   name: "Deer Hunter"
   region: "NTSC-U"
@@ -62382,8 +59042,6 @@ SLUS-20628:
   region: "NTSC-U"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20630:
   name: "Grand Prix Challenge"
   region: "NTSC-U"
@@ -62542,8 +59200,6 @@ SLUS-20662:
   region: "NTSC-U"
   gsHWFixes:
     recommendedBlendingLevel: 2 # Improves lighting, maximum blending is needed for full accuracy.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20663:
   name: "Naval Ops - Warship Gunner"
   region: "NTSC-U"
@@ -62551,9 +59207,6 @@ SLUS-20663:
 SLUS-20664:
   name: "Barbie Horse Adventures - Wild Horse Rescue"
   region: "NTSC-U"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20665:
   name: "Cabela's Deer Hunt - 2004 Season"
   region: "NTSC-U"
@@ -62651,9 +59304,6 @@ SLUS-20680:
   name: "SpongeBob SquarePants - Battle for Bikini Bottom"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20681:
   name: "Disney's The Haunted Mansion"
   region: "NTSC-U"
@@ -62682,8 +59332,6 @@ SLUS-20685:
     - SoftwareRendererFMVHack # Fixes interlacing.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves shine on surfaces and lights.
-    mipmap: 2 # Fixes miptrick texture effects.
-    trilinearFiltering: 1 # Fixes miptrick blending.
   patches:
     BDD9F5E1:
       content: |-
@@ -62702,8 +59350,6 @@ SLUS-20686:
   compat: 5
   gsHWFixes:
     autoFlush: 1
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20687:
   name: "RoadKill"
   region: "NTSC-U"
@@ -62846,9 +59492,6 @@ SLUS-20719:
   region: "NTSC-U"
   clampModes:
     vuClampMode: 3 # Missing geometry with microVU.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
   memcardFilters:
     - "PSCD10088" # Enables EA Sports BIO.
     - "SLUS-20719"
@@ -62882,8 +59525,6 @@ SLUS-20725:
   compat: 5
   gsHWFixes:
     cpuSpriteRenderBW: 1 # Fixes textures.
-    mipmap: 2 # Mipmap + trilinear, improves shimmering of terrain, matches SW.
-    trilinearFiltering: 1
   patches:
     30AE5278:
       content: |-
@@ -62919,9 +59560,6 @@ SLUS-20730:
   name: "NARC"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20731:
   name: "Tony Hawk's Underground"
   region: "NTSC-U"
@@ -62930,8 +59568,6 @@ SLUS-20731:
     vu1RoundMode: 0 # Crashes without.
   gsHWFixes:
     minimumBlendingLevel: 3 # Fixes broken lighting on ground and buildings.
-    mipmap: 2 # Mipmap + trilinear, improves ground and buildings textures to match software.
-    trilinearFiltering: 1
 SLUS-20732:
   name: "Drakengard"
   region: "NTSC-U"
@@ -62964,9 +59600,6 @@ SLUS-20737:
   name: "Hot Wheels - World Race"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20738:
   name: "Van Helsing"
   region: "NTSC-U"
@@ -63002,17 +59635,12 @@ SLUS-20745:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 4 # Fixes blue seam in ground.
-    mipmap: 2 # Partially fixes the sun effects, but the game suffers from depth/blending issues.
-    trilinearFiltering: 1
 SLUS-20746:
   name: "Rogue Ops"
   region: "NTSC-U"
   compat: 5
   speedHacks:
     eeCycleRate: 2 # Fixes hang on opening memory card screen.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20748:
   name: "Super Trucks Racing"
   region: "NTSC-U"
@@ -63022,8 +59650,6 @@ SLUS-20748:
   gsHWFixes:
     halfPixelOffset: 2 # Gets rid of fog line.
     roundSprite: 1 # Fixes lines in FMVs.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20749:
   name: "Rugby 2004"
   region: "NTSC-U"
@@ -63044,16 +59670,11 @@ SLUS-20751:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes lines in cutscenes.
-    mipmap: 2 # Cleans up texture detail.
-    trilinearFiltering: 1 # Smoothes out mipmapping.
 SLUS-20752:
   name: "Madden NFL 2004"
   region: "NTSC-U"
   clampModes:
     vuClampMode: 3 # Missing geometry with microVU.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
   memcardFilters:
     - "PSCD10088" # Enables EA Sports BIO.
     - "SLUS-20752"
@@ -63092,9 +59713,6 @@ SLUS-20757:
   compat: 5
   clampModes:
     vuClampMode: 2 # Fixes black textures on characters.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
   memcardFilters:
     - "PSCD10088" # Enables EA Sports BIO.
     - "SLUS-20757"
@@ -63197,8 +59815,6 @@ SLUS-20772:
     recommendedBlendingLevel: 4 # Fixes missing lighting and makes snow not look like snow sludge.
     textureInsideRT: 1 # Fixes rainbow effect in the pause menu before a jump.
     halfPixelOffset: 2 # Fixes depth lines.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20773:
   name: "Legacy of Kain - Defiance"
   region: "NTSC-U"
@@ -63218,8 +59834,6 @@ SLUS-20776:
     autoFlush: 2 # Fixes the position of the shadow and makes it not blocky.
     halfPixelOffset: 2 # Fixes shadows.
     gpuPaletteConversion: 0 # Stops potential crashes from too many palette textures.
-    mipmap: 2 # Building textures align more closely with SW mode.
-    trilinearFiltering: 1
 SLUS-20777:
   name: "Obscure"
   region: "NTSC-U"
@@ -63240,16 +59854,11 @@ SLUS-20782:
   compat: 5
   gsHWFixes:
     minimumBlendingLevel: 2 # Fixes dark font to more bright like software mode.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20784:
   name: "The Italian Job"
   name-sort: "Italian Job, The"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground and building textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20785:
   name: "Funkmaster Flex - Digital Hitz Factory"
   region: "NTSC-U"
@@ -63271,8 +59880,6 @@ SLUS-20788:
   compat: 5
   gsHWFixes:
     autoFlush: 1 # Fixes missing sun.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20789:
   name: "Jeopardy!"
   region: "NTSC-U"
@@ -63314,8 +59921,6 @@ SLUS-20797:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
-    trilinearFiltering: 1
     autoFlush: 1 # Fixes sun occlusion.
 SLUS-20798:
   name: "Starcraft - Ghost"
@@ -63349,8 +59954,6 @@ SLUS-20804:
   gsHWFixes:
     halfPixelOffset: 1 # Reduces ghosting.
     roundSprite: 1 # Reduces ghosting even more.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20805:
   name: "Yu Yu Hakusho - Dark Tournament"
   region: "NTSC-U"
@@ -63366,16 +59969,11 @@ SLUS-20809:
   name: "Godzilla - Save the Earth"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20810:
   name: "Nightshade"
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_Kunoichi"
 SLUS-20811:
   name: "Need for Speed - Underground"
@@ -63416,8 +60014,6 @@ SLUS-20818:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes heat blur layer.
     halfPixelOffset: 2 # Fixes depth line.
-    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20820:
   name: "Tom Clancy's Ghost Recon - Jungle Storm"
   region: "NTSC-U"
@@ -63516,8 +60112,6 @@ SLUS-20842:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 1 # Fixes vertical lines, font and others.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20843:
   name: "Dead to Rights II"
   region: "NTSC-U"
@@ -63562,8 +60156,6 @@ SLUS-20851:
     - SoftwareRendererFMVHack # Fixes FMVs disabling hash cache.
   gsHWFixes:
     recommendedBlendingLevel: 2 # Helps banding when dithering is enabled.
-    mipmap: 2 # Fixes terrain rendering.
-    trilinearFiltering: 1
     halfPixelOffset: 3 # Fixes ghosting in foggy maps.
     roundSprite: 1 # Fixes font and HUD artifacts.
     alignSprite: 1 # Fixes vertical lines.
@@ -63585,8 +60177,6 @@ SLUS-20852:
     autoFlush: 2 # Fixes environment lights visible through player model.
     halfPixelOffset: 4 # Fixes depth line and misaligned bloom.
     minimumBlendingLevel: 3 # Fixes incorrect bloom rendering.
-    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20853:
   name: "Looney Tunes - Back in Action"
   region: "NTSC-U"
@@ -63605,8 +60195,6 @@ SLUS-20855:
     vu1RoundMode: 0 # Fixes tyre textures.
   gsHWFixes:
     halfPixelOffset: 2 # Corrects shadow position.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20856:
   name: "Spy Fiction"
   region: "NTSC-U"
@@ -63624,8 +60212,6 @@ SLUS-20858:
     mtvu: 0
   gsHWFixes:
     halfPixelOffset: 3 # Reduces ghosting.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20859:
   name: "Future Tactics - The Uprising"
   region: "NTSC-U"
@@ -63637,8 +60223,6 @@ SLUS-20860:
   gsHWFixes:
     wildArmsHack: 1 # Fixes blurriness.
     mergeSprite: 1 # Fixes misaligned lights.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20861:
   name: "MTV Music Generator 3 - This is the Remix"
   region: "NTSC-U"
@@ -63694,8 +60278,6 @@ SLUS-20870:
     vu1ClampMode: 0 # Fixes wrong texture colour.
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes textures.
-    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
-    trilinearFiltering: 1
     autoFlush: 2 # Fixes shadow alignment along with HPO Special (Normal looks better but causes top left glitches).
     halfPixelOffset: 2
 SLUS-20871:
@@ -63763,8 +60345,6 @@ SLUS-20882:
   gsHWFixes:
     texturePreloading: 1 # Performs much better with partial preload.
     autoFlush: 1 # Fixes bloom rendering.
-    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
-    trilinearFiltering: 1
   roundModes:
     vu1RoundMode: 0 # Fixes missing light cones curtains and certain effects.
 SLUS-20883:
@@ -63794,9 +60374,7 @@ SLUS-20887:
   gsHWFixes:
     cpuSpriteRenderBW: 1 # Fixes shadow rendering.
     cpuSpriteRenderLevel: 1 # Needed for above.
-    bilinearUpscale: 1 # Smoothes out shadow textures.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
+    bilinearUpscale: 1 # Smooths out shadow textures.
 SLUS-20888:
   name: "Front Mission 4"
   region: "NTSC-U"
@@ -63865,16 +60443,11 @@ SLUS-20898:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     recommendedBlendingLevel: 3 # Improves reflections on certain characters and objects on certain levels.
 SLUS-20899:
   name: "Samurai Jack - The Shadow of Aku"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20901:
   name: "FlatOut"
   region: "NTSC-U"
@@ -63882,8 +60455,6 @@ SLUS-20901:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves car reflections.
     autoFlush: 1
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20902:
   name: "Shadow of Rome"
   region: "NTSC-U"
@@ -63902,8 +60473,6 @@ SLUS-20904:
   compat: 5
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes missing lights.
-    mipmap: 2 # Mipmap + trilinear, improves the street's textures to match sw renderer.
-    trilinearFiltering: 1
     halfPixelOffset: 2 # Fixes bloom misalignment when upscaling.
     cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling.
 SLUS-20905:
@@ -63912,8 +60481,6 @@ SLUS-20905:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves the street's textures to match sw renderer.
-    trilinearFiltering: 1
     halfPixelOffset: 2 # Fixes bloom misalignment when upscaling.
     cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling.
 SLUS-20906:
@@ -63939,24 +60506,16 @@ SLUS-20909:
     - XGKickHack # Fixes bad geometry.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20910:
   name: "Test Drive - Eve of Destruction"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20911:
   name: "Shin Megami Tensei - Nocturne"
   region: "NTSC-U"
   compat: 5
   roundModes:
     eeRoundMode: 0 # Ladder glitch in "Assembly of Nihilo B11" level.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, fixes missing lights to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20912:
   name: "Superbikes TT"
   region: "NTSC-U"
@@ -63978,8 +60537,6 @@ SLUS-20915:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     halfPixelOffset: 2 # Fixes blurriness.
     autoFlush: 2 # Fixes lens flare.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
 SLUS-20916:
   name: "Dance Dance Revolution EXTREME"
@@ -64000,15 +60557,10 @@ SLUS-20918:
     eeRoundMode: 1 # Fixes object balls never stopping in the Monkey Billiards DX minigame.
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes text and foliage color.
-    mipmap: 2 # Mipmap + trilinear, improves stage textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20919:
   name: "ESPN - NFL 2K5"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
-    trilinearFiltering: 1
   patches:
     42F9D5AF:
       content: |-
@@ -64096,8 +60648,6 @@ SLUS-20932:
   compat: 5
   gsHWFixes:
     autoFlush: 2 # Fixes missing lighting.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     # halfPixelOffset: 1 # Fixes lighting misalignment. Do not enable this, it breaks a lot of graphics.
 SLUS-20933:
   name: "Smash Court Pro Tournament Tennis 2"
@@ -64109,8 +60659,6 @@ SLUS-20934:
   compat: 5
   gsHWFixes:
     alignSprite: 1 # Fixes FMV lines.
-    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
-    trilinearFiltering: 1
     cpuSpriteRenderBW: 2 # Prevents Death By VRAM explosion.
     cpuSpriteRenderLevel: 2 # Needed for above.
     getSkipCount: "GSC_DeathByDegreesTekkenNinaWilliams"
@@ -64149,16 +60697,12 @@ SLUS-20941:
   gsHWFixes:
     nativePaletteDraw: 1 # Fixes lines in certain effects when upscaled.
     halfPixelOffset: 2 # Fixes offset bloom.
-    mipmap: 2 # Mipmap + trilinear, fixes textures.
-    trilinearFiltering: 1
 SLUS-20942:
   name: "Robots"
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misaligned bloom.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20943:
   name: "Heroes of the Pacific"
   region: "NTSC-U"
@@ -64172,8 +60716,6 @@ SLUS-20945:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     textureInsideRT: 1 # Fixes shadow maps.
     roundSprite: 2 # Fixes misaligned bloom.
     mergeSprite: 1 # Fixes misaligned bloom.
@@ -64244,8 +60786,6 @@ SLUS-20958:
   compat: 5
   gsHWFixes:
     preloadFrameData: 1 # Fixes missing loading screens.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20959:
   name: "The Dukes of Hazzard - Return of the General Lee"
   name-sort: "Dukes of Hazzard, The - Return of the General Lee"
@@ -64297,17 +60837,12 @@ SLUS-20965:
     vu1RoundMode: 0 # Crashes without.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes water and grass textures.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
     wildArmsHack: 1 # Reduces post-processing misalignment.
     mergeSprite: 1 # Reduces post-processing misalignment.
 SLUS-20966:
   name: "State of Emergency 2"
   region: "NTSC-U"
   compat: 4
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20967:
   name: "Enthusia Professional Racing"
   region: "NTSC-U"
@@ -64423,8 +60958,6 @@ SLUS-20986:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
     recommendedBlendingLevel: 3 # Fixes level brightness.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
   memcardFilters:
     - "SLUS-20986"
     - "SLUS-21079"
@@ -64443,8 +60976,6 @@ SLUS-20989:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes bottom left and right corner garbage.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20990:
   name: "Metal Slug 4 & 5 [Disc 2 of 2]"
   region: "NTSC-U"
@@ -64454,9 +60985,6 @@ SLUS-20991:
   region: "NTSC-U"
   clampModes:
     vuClampMode: 3 # Missing geometry with microVU.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20992:
   name: "Catwoman"
   region: "NTSC-U"
@@ -64471,9 +60999,6 @@ SLUS-20993:
   compat: 5
   clampModes:
     vu1ClampMode: 3 # Fixes sporadic white triangle SPS.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-20994:
   name: "Full Metal Alchemist and The Broken Angel"
   region: "NTSC-U"
@@ -64502,9 +61027,6 @@ SLUS-21000:
   compat: 5
   clampModes:
     vuClampMode: 3 # Missing geometry with microVU.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21001:
   name: "NHL 2005"
   region: "NTSC-U"
@@ -64514,9 +61036,6 @@ SLUS-21002:
   compat: 5
   clampModes:
     vuClampMode: 2 # Fixes black textures on characters.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21003:
   name: "NASCAR 2005 - Chase for the Cup"
   region: "NTSC-U"
@@ -64544,8 +61063,6 @@ SLUS-21006:
     mergeSprite: 1 # Fixes most vertical lines and lighting misalignment.
     autoFlush: 1 # Fixes light bloom intensity.
     estimateTextureRegion: 1 # Improves performance and reduces hash cache size.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_GiTS"
   patches:
     default:
@@ -64634,8 +61151,6 @@ SLUS-21015:
   gsHWFixes:
     roundSprite: 2 # Improves bloom alignment and clarity.
     halfPixelOffset: 2 # Improves bloom alignment and clarity.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21016:
   name: "25 to Life"
   region: "NTSC-U"
@@ -64653,8 +61168,6 @@ SLUS-21018:
   gsHWFixes:
     roundSprite: 1 # Fix lines in the sky.
     halfPixelOffset: 2 # Fixes double image.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21019:
   name: "Technic Beat"
   region: "NTSC-U"
@@ -64677,9 +61190,6 @@ SLUS-21025:
   region: "NTSC-U"
   clampModes:
     vuClampMode: 3 # Missing geometry with microVU.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21026:
   name: "Battlefield 2 - Modern Combat"
   region: "NTSC-U"
@@ -64689,8 +61199,6 @@ SLUS-21026:
     autoFlush: 1 # Post-processing.
     halfPixelOffset: 2 # Offset post-processing.
     texturePreloading: 1 # Improves performance.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_Battlefield2" # Depth clear.
     beforeDraw: "OI_Battlefield2" # Framebuffer copy, fixes rendering for bottom part of screen.
 SLUS-21027:
@@ -64700,8 +61208,6 @@ SLUS-21027:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21028:
   name: "World Championship Poker"
   region: "NTSC-U"
@@ -64711,8 +61217,6 @@ SLUS-21029:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves car and road textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_MidnightClub3"
   patches:
     0DD3417A:
@@ -64740,9 +61244,6 @@ SLUS-21030:
 SLUS-21031:
   name: "Gallop Racer 2004"
   region: "NTSC-U"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21032:
   name: "Marc Ecko's Getting Up - Contents Under Pressure"
   region: "NTSC-U"
@@ -64777,8 +61278,6 @@ SLUS-21037:
   compat: 5
   gsHWFixes:
     autoFlush: 1 # Fixes the post processing positioning.
-    mipmap: 2
-    trilinearFiltering: 1
     textureInsideRT: 1 # Fixes post processing.
 SLUS-21038:
   name: "Pinball Hall of Fame - The Gottlieb Collection"
@@ -64790,8 +61289,6 @@ SLUS-21039:
   compat: 5
   gsHWFixes:
     alignSprite: 1 # Fixes lighting and vertical lines, also works with normal vertex.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21040:
   name: "The Shield"
   name-sort: "Shield, The"
@@ -64812,8 +61309,6 @@ SLUS-21042:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blood vision bloom
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21043:
   name: "Backyard Wrestling 2 - There Goes the Neighborhood"
   region: "NTSC-U"
@@ -64834,8 +61329,6 @@ SLUS-21045:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     autoFlush: 1 # Fixes missing lights.
 SLUS-21046:
   name: "King Arthur"
@@ -64853,9 +61346,6 @@ SLUS-21049:
   name: "Outlaw Volleyball Remixed"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21050:
   name: "Burnout 3 - Takedown"
   region: "NTSC-U"
@@ -64866,8 +61356,6 @@ SLUS-21050:
     recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 2 # Fixes blur and obscures sun behind objects.
-    mipmap: 2 # Fixes over sharpening.
-    trilinearFiltering: 1 # Smoothes out mipmapping.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     bilinearUpscale: 2 # Smooths out sun glare textures like native.
     getSkipCount: "GSC_BurnoutGames"
@@ -64918,8 +61406,6 @@ SLUS-21059:
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
     halfPixelOffset: 4 # Align post.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_Tekken5"
 SLUS-21060:
   name: "WWE SmackDown! vs. RAW"
@@ -65014,8 +61500,6 @@ SLUS-21079:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
     recommendedBlendingLevel: 3 # Fixes level brightness.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
   memcardFilters:
     - "SLUS-20986"
     - "SLUS-21079"
@@ -65034,17 +61518,12 @@ SLUS-21082:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes lighting misalignment.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21083:
   name: "LEGO Star Wars - The Video Game"
   region: "NTSC-U"
   compat: 5
   clampModes:
     vuClampMode: 3 # Fixes bad coordinate spam.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21084:
   name: "Winnie the Pooh's Rumbly Tumbly Adventure"
   region: "NTSC-U"
@@ -65061,9 +61540,6 @@ SLUS-21087:
 SLUS-21088:
   name: "Disney's Chicken Little"
   region: "NTSC-U"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21089:
   name: "Karaoke Revolution Volume 3"
   region: "NTSC-U"
@@ -65091,8 +61567,6 @@ SLUS-21095:
     estimateTextureRegion: 1 # Improves performance and reduces hash cache size.
     gpuPaletteConversion: 2 # Improves performance and reduces hash cache size.
     autoFlush: 1 # Corrects shadows (Currently still broken even with this).
-    mipmap: 2 # Mipmap + trilinear, matches sw renderer.
-    trilinearFiltering: 1
 SLUS-21096:
   name: "Ape Escape - Pumped & Primed"
   region: "NTSC-U"
@@ -65158,8 +61632,6 @@ SLUS-21106:
     preloadFrameData: 1 # Fixes numberplates and ensures above targets are valid.
     roundSprite: 1 # Fixes lines in some post-effects.
     gpuTargetCLUT: 1 # Fixes light occlusion.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21107:
   name: "X-Men - The Official Game"
   region: "NTSC-U"
@@ -65172,8 +61644,6 @@ SLUS-21108:
     vuClampMode: 0 # Fixes bump mapping issues
   gsHWFixes:
     textureInsideRT: 1 # Fixes post processing.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_HitmanBloodMoney"
 SLUS-21109:
   name: "Drive to Survive"
@@ -65193,16 +61663,12 @@ SLUS-21111:
     autoFlush: 2 # Fixes post processing overlay.
     roundSprite: 1 # Greatly reduces chromatic effect when upscaling.
     wildArmsHack: 1 # Fixes chromatic fringing.
-    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21112:
   name: "L.A. Rush"
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
     cpuSpriteRenderBW: 4 # Fixes textures.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21113:
   name: "Atelier Iris - Eternal Mana"
   region: "NTSC-U"
@@ -65225,8 +61691,6 @@ SLUS-21116:
     recommendedBlendingLevel: 4 # Improves car color.
     autoFlush: 1 # Softens bloom on objects and cars.
     halfPixelOffset: 4 # Fixes misaligned bloom on objects and cars.
-    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21117:
   name: "World Soccer - Winning Eleven 8 - International"
   region: "NTSC-U"
@@ -65278,8 +61742,6 @@ SLUS-21127:
     preloadFrameData: 1 # Fixes sun flickering.
     autoFlush: 2 # Fixes sun through objects.
     bilinearUpscale: 1 # Smooths out sun glare textures like native.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21128:
   name: "Blitz - The League"
   region: "NTSC-U"
@@ -65288,9 +61750,6 @@ SLUS-21129:
   name: "Tenchu 4 - Fatal Shadows"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21130:
   name: "SnoCross 2 featuring Blair Morgan"
   region: "NTSC-U"
@@ -65322,14 +61781,9 @@ SLUS-21134:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21135:
   name: "MVP Baseball 2005"
   region: "NTSC-U"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21136:
   name: "Graffiti Kingdom"
   region: "NTSC-U"
@@ -65354,8 +61808,6 @@ SLUS-21139:
     vu1RoundMode: 0 # Fixes textures and crashes.
   gsHWFixes:
     minimumBlendingLevel: 3 # Fixes broken light and shadow rendering.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures and water textures and reflections.
-    trilinearFiltering: 1
     halfPixelOffset: 2 # Fixes misaligned bloom and character shadows.
     autoFlush: 1 # Fixes missing bloom intensity and alignment.
 SLUS-21140:
@@ -65412,8 +61864,6 @@ SLUS-21151:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes ground texture flicker and improves car body reflections.
     autoFlush: 1 # Fixes lens flares and missing sun.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
   patches:
     F2A25D7B:
       content: |-
@@ -65432,9 +61882,6 @@ SLUS-21153:
   name: "Dynasty Warriors 5"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21154:
   name: "Killer7"
   region: "NTSC-U"
@@ -65466,8 +61913,6 @@ SLUS-21160:
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
     halfPixelOffset: 4 # Align post.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_Tekken5"
 SLUS-21161:
   name: "Fight Night - Round 2"
@@ -65489,9 +61934,6 @@ SLUS-21165:
   name: "Arc the Lad - End of Darkness"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, corrects the depth of field effect.
-    trilinearFiltering: 1
 SLUS-21166:
   name: "Full Metal Alchemist 2 - Curse of the Crimson Elixir"
   region: "NTSC-U"
@@ -65531,9 +61973,6 @@ SLUS-21172:
   compat: 5
   roundModes:
     eeRoundMode: 2 # Fixes abnormal character behaviour.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21173:
   name: "Dora the Explorer - To the Purple Planet"
   region: "NTSC-U"
@@ -65582,8 +62021,6 @@ SLUS-21182:
   gsHWFixes:
     alignSprite: 1 # Fixes lighting and vertical lines, also works with normal vertex.
     roundSprite: 1 # Fixes misaligned map.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
     skipDrawStart: 1 # Removes large black box around player car till we properly emulate it.
     skipDrawEnd: 1 # Removes large black box around player car till we properly emulate it.
 SLUS-21183:
@@ -65618,8 +62055,6 @@ SLUS-21189:
     instantVU1: 1 # Fixes SPS.
   gsHWFixes:
     autoFlush: 2 # Fixes debris and blending on lower part of screen during monster transformation.
-    mipmap: 2
-    trilinearFiltering: 1
   memcardFilters:
     - "SLUS-21189"
     - "SLUS-20636"
@@ -65637,8 +62072,6 @@ SLUS-21191:
     PCRTCOverscan: 1 # Fixes offscreen image.
     nativePaletteDraw: 1 # Fixes the look of screen effects.
     halfPixelOffset: 2 # Corrects the alignment of screen effects.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21192:
   name: "Cabela's Outdoor Adventures 2006"
   region: "NTSC-U"
@@ -65683,8 +62116,6 @@ SLUS-21199:
     halfPixelOffset: 2 # Fixes misaligned blur.
     cpuSpriteRenderBW: 2 # Fixes black spots appearing on some surfaces and massively reduces RP TC and TU count.
     cpuSpriteRenderLevel: 2 # Needed for above.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21200:
   name: "Armored Core - Nine Breaker"
   region: "NTSC-U"
@@ -65692,8 +62123,6 @@ SLUS-21200:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned blur.
     recommendedBlendingLevel: 3 # Fixes level brightness.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
     cpuSpriteRenderBW: 2 # Fixes broken water on "Upper Sea" level.
     cpuSpriteRenderLevel: 2 # Needed for above.
   memcardFilters: # Can import data from AC:Nexus.
@@ -65715,8 +62144,6 @@ SLUS-21203:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    mipmap: 2 # Fixes distant characters and models.
-    trilinearFiltering: 1
     textureInsideRT: 1 # Needed for post processing effects.
     autoFlush: 1 # Fixes bloom intensity.
     minimumBlendingLevel: 4 # Fixes multiple lighting effects from lights, computers, cave walls and more.
@@ -65750,8 +62177,6 @@ SLUS-21208:
     vu1RoundMode: 0 # Crashes without.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes water and grass textures.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
     wildArmsHack: 1 # Reduces post-processing misalignment.
     mergeSprite: 1 # Reduces post-processing misalignment.
     autoFlush: 1 # Improves post-processing rendering.
@@ -65765,8 +62190,6 @@ SLUS-21209:
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
     textureInsideRT: 1 # Fixes corruption.
-    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_UrbanReign"
 SLUS-21212:
   name: "Spartan - Total Warrior"
@@ -65777,33 +62200,22 @@ SLUS-21212:
   gsHWFixes:
     autoFlush: 1 # Fixes missing post processing.
     halfPixelOffset: 1 # Aligns post processing.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21213:
   name: "Madden NFL '06"
   region: "NTSC-U"
   compat: 5
   clampModes:
     vuClampMode: 3 # Missing geometry with microVU.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21214:
   name: "NCAA Football 2006"
   region: "NTSC-U"
   clampModes:
     vuClampMode: 3 # Missing geometry with microVU.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21215:
   name: "The Warriors"
   name-sort: "Warriors, The"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21216:
   name: "Soul Calibur III"
   region: "NTSC-U"
@@ -65823,8 +62235,6 @@ SLUS-21217:
   compat: 5
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes building shade and shadows.
-    mipmap: 2 # Mipmap + trilinear, improves the street's textures to match sw renderer.
-    trilinearFiltering: 1
     halfPixelOffset: 2 # Fixes bloom misalignment when upscaling.
     cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling.
 SLUS-21218:
@@ -65837,9 +62247,6 @@ SLUS-21219:
   compat: 5
   gameFixes:
     - EETimingHack
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21220:
   name: "World Soccer - Winning Eleven 9 International"
   region: "NTSC-U"
@@ -65865,9 +62272,6 @@ SLUS-21224:
 SLUS-21225:
   name: "Bratz - Rock Angelz"
   region: "NTSC-U"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21226:
   name: "Velocity"
   region: "NTSC-U"
@@ -65887,8 +62291,6 @@ SLUS-21228:
   gsHWFixes:
     roundSprite: 1 # Fixes lines in sprites.
     cpuSpriteRenderBW: 1 # Fixes textures.
-    mipmap: 2 # Mipmap + trilinear, improves ground and building textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21229:
   name: "Motocross Mania 3"
   region: "NTSC-U"
@@ -65918,8 +62320,6 @@ SLUS-21231:
     autoFlush: 2 # Fixes bloom misalignment.
     halfPixelOffset: 2 # Fixes bloom misalignment.
     textureInsideRT: 1 # Fixes sky bloom.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21232:
   name: "College Hoops 2K6"
   region: "NTSC-U"
@@ -65987,8 +62387,6 @@ SLUS-21240:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes bloom misalignment.
     autoFlush: 1 # Fixes missing lights.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21241:
   name: "NHL '06"
   region: "NTSC-U"
@@ -66003,8 +62401,6 @@ SLUS-21242:
     recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 2 # Fixes blur and obscures sun behind objects.
-    mipmap: 2 # Fixes over sharpening.
-    trilinearFiltering: 1 # Smoothes out mipmapping.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     bilinearUpscale: 2 # Smooths out sun glare textures like native.
     getSkipCount: "GSC_BurnoutGames"
@@ -66024,8 +62420,6 @@ SLUS-21243:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
     halfPixelOffset: 2 # Fixes blurriness.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
   memcardFilters:
     - "SLUS-21359"
@@ -66048,8 +62442,6 @@ SLUS-21246:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 4 # Fixes offset bloom.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21247:
   name: "Jackie Chan Adventures"
   region: "NTSC-U"
@@ -66082,9 +62474,6 @@ SLUS-21252:
   name: "SpongeBob SquarePants - Lights, Camera, PANTS!"
   region: "NTSC-U"
   compat: 4
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21253:
   name: "TY the Tasmanian Tiger 3 - Night of the Quinkan"
   region: "NTSC-U"
@@ -66113,8 +62502,6 @@ SLUS-21257:
     halfPixelOffset: 2 # Fixes blurriness.
     cpuCLUTRender: 1 # Final colour adjustment LUT.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21258:
   name: ".hack//G.U. Vol.1 - Rebirth"
   region: "NTSC-U"
@@ -66148,8 +62535,6 @@ SLUS-21261:
   gsHWFixes:
     recommendedBlendingLevel: 4 # Improves smoke rendering.
     halfPixelOffset: 2 # Fixes misaligned lighting.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21262:
   name: "Radiata Stories"
   region: "NTSC-U"
@@ -66171,9 +62556,6 @@ SLUS-21264:
   compat: 5
   clampModes:
     vuClampMode: 3 # Fix black textures on characters.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21265:
   name: "The Sims 2"
   name-sort: "Sims 2, The"
@@ -66181,8 +62563,6 @@ SLUS-21265:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned textures.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21266:
   name: "NASCAR '06 - Total Team Control"
   region: "NTSC-U"
@@ -66198,8 +62578,6 @@ SLUS-21267:
     halfPixelOffset: 2 # Fixes blurriness.
     cpuCLUTRender: 1 # Final colour adjustment LUT.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
   memcardFilters:
     - "SLUS-21267"
     - "SLUS-21351"
@@ -66213,8 +62591,6 @@ SLUS-21268:
   gsHWFixes:
     autoFlush: 1 # Fixes pause menu backgrounds.
     roundSprite: 1 # Corrects proportions of fonts and pause-screen lines, adjusts display closer to software.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21269:
   name: "Bully"
   region: "NTSC-U"
@@ -66225,8 +62601,6 @@ SLUS-21269:
     recommendedBlendingLevel: 2 # Fixes door transitions.
     halfPixelOffset: 4 # Reduces ghosting.
     roundSprite: 2 # Reduces ghosting.
-    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21270:
   name: "MS Saga - A New Dawn"
   region: "NTSC-U"
@@ -66242,25 +62616,18 @@ SLUS-21271:
     cpuCLUTRender: 1 # Fixes the rest of the bad textures.
     roundSprite: 1 # Reduces misaligned bloom.
     mergeSprite: 1 # Removes bloom explosion around electrical lights and other light sources such as moon/sun.
-    mipmap: 2 # Mipmap + trilinear, improves road textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21272:
   name: "Super Monkey Ball Adventure"
   region: "NTSC-U"
   compat: 5
   gameFixes:
     - XGKickHack # Fixes texture normals.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21273:
   name: "The Matrix - Path of Neo"
   name-sort: "Matrix, The - Path of Neo"
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     halfPixelOffset: 2 # Fix effects upscaling.
     autoFlush: 1 # Fixes broken post processing.
 SLUS-21274:
@@ -66271,8 +62638,6 @@ SLUS-21274:
     autoFlush: 1 # Reduces post-processing misalignment.
     halfPixelOffset: 2 # Fixes bloom misalignment still a bit misaligned.
     roundSprite: 1 # Fixes bloom misalignment still a bit misaligned + font artifacts.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21275:
   name: "River King - A Wonderful Journey"
   region: "NTSC-U"
@@ -66287,8 +62652,6 @@ SLUS-21277:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fix text and post blur.
-    mipmap: 2 # Base mip level isn't always used.
-    trilinearFiltering: 1
     autoFlush: 2 # Needed for recursive mipmap rendering.
     getSkipCount: "GSC_BlueTongueGames" # Render mipmaps on the CPU.
 SLUS-21278:
@@ -66297,8 +62660,6 @@ SLUS-21278:
   compat: 5
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes missing lighting and makes snow not look like snow sludge.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
   patches:
     0F27ED9B:
       content: |-
@@ -66344,8 +62705,6 @@ SLUS-21282:
   gsHWFixes:
     textureInsideRT: 1 # Required for complex offset shuffles.
     halfPixelOffset: 2 # Fixes center upscaling line during explosions.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
     recommendedBlendingLevel: 4 # Fixes lighting.
 SLUS-21283:
   name: "Total Overdose - A Gunslinger's Tale in Mexico"
@@ -66356,8 +62715,6 @@ SLUS-21284:
   region: "NTSC-U"
   gsHWFixes:
     autoFlush: 2 # Fixes glows. Also needed for recursive mipmap rendering.
-    mipmap: 2 # Better characters and environment but has a texture cache issue that makes it worse.
-    trilinearFiltering: 1 # Using mipmaps, so may as well.
     textureInsideRT: 1 # Fixes rainbow lighting for some areas.
     getSkipCount: "GSC_BlueTongueGames" # Mipmap rendering on CPU.
 SLUS-21285:
@@ -66368,8 +62725,6 @@ SLUS-21285:
     vu1ClampMode: 0 # Fixes Spider-Man's eyes texture.
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes textures.
-    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
-    trilinearFiltering: 1
     autoFlush: 2 # Fixes shadow alignment along with HPO Special (Normal looks better but causes top left glitches).
     halfPixelOffset: 2
 SLUS-21286:
@@ -66429,8 +62784,6 @@ SLUS-21295:
     vu1RoundMode: 0 # Crashes without.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes water and grass textures.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
     wildArmsHack: 1 # Reduces post-processing misalignment.
     mergeSprite: 1 # Reduces post-processing misalignment.
     autoFlush: 1 # Improves post-processing rendering.
@@ -66532,8 +62885,6 @@ SLUS-21312:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misalignment/bloom when upscaling.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21313:
   name: "Friends - The One with all the Trivia"
   region: "NTSC-U"
@@ -66557,8 +62908,6 @@ SLUS-21315:
   region: "NTSC-U"
   gsHWFixes:
     roundSprite: 1 # Removes chromatic effect when upscaling also works with halfpixeloffset Special Texture.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21316:
   name: "Capcom Classics Collection Vol. 1"
   region: "NTSC-U"
@@ -66578,8 +62927,6 @@ SLUS-21318:
   gsHWFixes:
     roundSprite: 1 # Fixes lines in sprites.
     cpuSpriteRenderBW: 1 # Fixes textures.
-    mipmap: 2 # Mipmap + trilinear, improves ground and building textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21319:
   name: "Flow - Urban Dance Uprising"
   region: "NTSC-U"
@@ -66601,8 +62948,6 @@ SLUS-21322:
   clampModes:
     vuClampMode: 3 # Fixes SPS and spawn issues.
   gsHWFixes:
-    mipmap: 2 # Cleans up texture detail.
-    trilinearFiltering: 1 # Smoothes out mipmapping.
     halfPixelOffset: 2 # Fixes post processing misalignment.
     recommendedBlendingLevel: 3 # Improves reflection quality.
 SLUS-21323:
@@ -66649,8 +62994,6 @@ SLUS-21328:
     vuClampMode: 3 # Fixes bad geometry.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth line.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
   patches:
     default:
       content: |-
@@ -66672,9 +63015,6 @@ SLUS-21331:
   name: "Sonic Riders"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves track and building textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21332:
   name: "Real World Golf"
   region: "NTSC-U"
@@ -66696,9 +63036,6 @@ SLUS-21336:
   name: "Zathura"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21337:
   name: "Arena Football"
   region: "NTSC-U"
@@ -66712,8 +63049,6 @@ SLUS-21338:
   gsHWFixes:
     halfPixelOffset: 2 # Corrects shadow alignment and reduces blurriness.
     recommendedBlendingLevel: 3 # Fixes level and map menu brightness.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
     preloadFrameData: 1 # Fixes glowing emblems.
 SLUS-21339:
   name: "Puzzle Collection - Crosswords & More!"
@@ -66756,8 +63091,6 @@ SLUS-21346:
     - SoftwareRendererFMVHack # Fixes FMVs disabling hash cache.
   gsHWFixes:
     recommendedBlendingLevel: 2 # Helps banding when dithering is enabled.
-    mipmap: 2 # Fixes terrain rendering.
-    trilinearFiltering: 1
     halfPixelOffset: 3 # Fixes ghosting in foggy maps.
     roundSprite: 1 # Fixes HUD artifacts.
     alignSprite: 1 # Fixes vertical lines.
@@ -66800,8 +63133,6 @@ SLUS-21351:
     halfPixelOffset: 2 # Fixes blurriness.
     cpuCLUTRender: 1 # Final colour adjustment LUT.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
   memcardFilters:
     - "SLUS-21267"
     - "SLUS-21351"
@@ -66822,8 +63153,6 @@ SLUS-21355:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves car and road textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_MidnightClub3"
   patches:
     60A42FF5:
@@ -66839,9 +63168,6 @@ SLUS-21356:
   name: "Tom Clancy's Splinter Cell - Double Agent"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21357:
   name: "Hummer Badlands"
   region: "NTSC-U"
@@ -66861,8 +63187,6 @@ SLUS-21359:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
     halfPixelOffset: 2 # Fixes blurriness.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
 SLUS-21360:
   name: "Metal Gear Solid 3 - Subsistence [Disc 3 of 3]"
@@ -66874,8 +63198,6 @@ SLUS-21360:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
     halfPixelOffset: 2 # Fixes blurriness.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
   memcardFilters:
     - "SLUS-21359"
@@ -66985,8 +63307,6 @@ SLUS-21376:
     recommendedBlendingLevel: 4 # Improves lighting on buildings and objects.
     autoFlush: 2 # Properly diffuses light instead of strips of light.
     roundSprite: 1 # Fixes lighting misalignment such as the street poles and the sun.
-    mipmap: 2 # Fixes over sharpening.
-    trilinearFiltering: 1 # Smoothes out mipmapping.
     getSkipCount: "GSC_BlackAndBurnoutSky"
     beforeDraw: "OI_BurnoutGames"
   patches:
@@ -67013,8 +63333,6 @@ SLUS-21380:
   clampModes:
     vuClampMode: 3 # Fixes bad textures and missing geometry.
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     halfPixelOffset: 2 # Fixes fog line.
   patches:
     213DCAC9:
@@ -67052,8 +63370,6 @@ SLUS-21385:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
-    trilinearFiltering: 1
     textureInsideRT: 1 # Required for complex offset shuffles.
     halfPixelOffset: 2 # Fixes center line in post processing.
 SLUS-21386:
@@ -67083,8 +63399,6 @@ SLUS-21389:
     halfPixelOffset: 2 # Fixes lighting misalignment and reduces ground shadows.
     roundSprite: 2 # Fixes font artifacts.
     textureInsideRT: 1 # Fixes bad crystal surfaces.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
   memcardFilters: # Allows import of Xenosaga II save data.
     - "SLUS-21389"
     - "SLUS-20892"
@@ -67142,8 +63456,6 @@ SLUS-21399:
     cpuCLUTRender: 1 # Fixes the rest of the bad textures.
     roundSprite: 1 # Reduces misaligned bloom.
     mergeSprite: 1 # Removes bloom explosion around electrical lights and other light sources such as moon/sun.
-    mipmap: 2 # Mipmap + trilinear, improves road textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21400:
   name: "Monster House"
   region: "NTSC-U"
@@ -67175,8 +63487,6 @@ SLUS-21406:
   name-sort: "Godfather, The - Collector's Edition"
   region: "NTSC-U"
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
-    trilinearFiltering: 1
     textureInsideRT: 1 # Required for complex offset shuffles.
     halfPixelOffset: 2 # Fixes center line in post processing.
 SLUS-21407:
@@ -67191,16 +63501,11 @@ SLUS-21408:
   name: "FIFA World Cup Germany '06"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21409:
   name: "LEGO Star Wars II - The Original Trilogy"
   region: "NTSC-U"
   gsHWFixes:
     cpuCLUTRender: 1 # Fixes ghosting on objects and people.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
   memcardFilters:
     - "SLUS-21409"
     - "SLUS-21083"
@@ -67223,8 +63528,6 @@ SLUS-21413:
     vu1ClampMode: 3 # Fixes texture corruption light shimmering and reflective surfaces.
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned bloom effects.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21414:
   name: "Delta Force - Black Hawk Down - Team Sabre"
   region: "NTSC-U"
@@ -67249,8 +63552,6 @@ SLUS-21417:
     halfPixelOffset: 2 # Fixes lighting misalignment and reduces ground shadows.
     roundSprite: 2 # Fixes font artifacts.
     textureInsideRT: 1 # Fixes bad crystal surfaces.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
   memcardFilters:
     - "SLUS-21389"
     - "SLUS-20892"
@@ -67284,8 +63585,6 @@ SLUS-21419:
   compat: 5
   gsHWFixes:
     autoFlush: 1 # Fixes lighting.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21420:
   name: "Disney's Chicken Little - Ace in Action"
   region: "NTSC-U"
@@ -67299,16 +63598,12 @@ SLUS-21422:
   compat: 5
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes  building and ground colours.
-    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21423:
   name: "Grand Theft Auto - Liberty City Stories"
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
     halfPixelOffset: 1 # Removes blur due to misaligned fullscreen effect.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21424:
   name: "NBA 2K7"
   region: "NTSC-U"
@@ -67349,8 +63644,6 @@ SLUS-21428:
   compat: 5
   gsHWFixes:
     cpuCLUTRender: 1 # Fixes ghosting on objects and people.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21430:
   name: "IGPX - Immortal Grand Prix"
   region: "NTSC-U"
@@ -67376,9 +63669,6 @@ SLUS-21434:
   compat: 4
   gameFixes:
     - VUOverflowHack # Fixes SPS.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21435:
   name: "One Piece - Grand Adventure"
   region: "NTSC-U"
@@ -67390,8 +63680,6 @@ SLUS-21436:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    mipmap: 2 # Helps clean up water
-    trilinearFiltering: 1 # Helps clean up water
     recommendedBlendingLevel: 3 # High blending accuracy fixes notoriously broken water.
     halfPixelOffset: 1 # Fixes ghosting.
 SLUS-21437:
@@ -67403,9 +63691,6 @@ SLUS-21438:
   name: "Cartoon Network Racing"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, fixes flickering and improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21439:
   name: "Destroy All Humans! 2"
   region: "NTSC-U"
@@ -67413,8 +63698,6 @@ SLUS-21439:
   clampModes:
     eeClampMode: 3 # Fixes material stretching across screen that appears for a split second.
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     textureInsideRT: 1 # Fixes shadow maps.
     roundSprite: 2 # Fixes misaligned bloom.
     mergeSprite: 1 # Fixes misaligned bloom.
@@ -67447,8 +63730,6 @@ SLUS-21444:
     vu1RoundMode: 0 # Fixes invalid VU size spam and likely SPS.
   gsHWFixes:
     autoFlush: 1 # Fixes black line down the side of the screen and player shadow.
-    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21445:
   name: "Ar tonelico - Melody of Elemia"
   region: "NTSC-U"
@@ -67480,8 +63761,6 @@ SLUS-21449:
     recommendedBlendingLevel: 4 # Fixes car reflections.
     mergeSprite: 1 # Fixes bluriness.
     halfPixelOffset: 4 # Fixes bluriness.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21450:
   name: "Super PickUps"
   region: "NTSC-U"
@@ -67539,9 +63818,6 @@ SLUS-21459:
   region: "NTSC-U"
   clampModes:
     vuClampMode: 3 # Missing geometry with microVU.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21460:
   name: "NBA Live '07"
   region: "NTSC-U"
@@ -67552,9 +63828,6 @@ SLUS-21461:
   name: "NASCAR '07"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21462:
   name: "Samurai Warriors 2"
   region: "NTSC-U"
@@ -67572,9 +63845,6 @@ SLUS-21464:
   name: "Winning Eleven - Pro Evolution Soccer 2007"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Fixes grass field.
-    trilinearFiltering: 1 # Using mipmaps, so may as well.
 SLUS-21465:
   name: "Raiden III"
   region: "NTSC-U"
@@ -67596,8 +63866,6 @@ SLUS-21469:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    mipmap: 2 # Better characters and environment.
-    trilinearFiltering: 1 # Using mipmaps, so may as well.
     autoFlush: 2 # Fixes texture corruptions.
     getSkipCount: "GSC_BlueTongueGames" # Render mipmaps on the CPU.
 SLUS-21470:
@@ -67628,17 +63896,11 @@ SLUS-21476:
   compat: 5
   clampModes:
     vuClampMode: 3 # Missing geometry with microVU.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21477:
   name: "Madden NFL '07 [Hall of Fame Edition]"
   region: "NTSC-U"
   clampModes:
     vuClampMode: 3 # Missing geometry with microVU.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21478:
   name: "Pirates - Legend of the Black Buccaneer"
   region: "NTSC-U"
@@ -67683,9 +63945,6 @@ SLUS-21483:
   compat: 5
   clampModes:
     vuClampMode: 2 # Fix black textures on characters.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21484:
   name: "DreamWorks & Aardman Flushed Away"
   region: "NTSC-U"
@@ -67749,8 +64008,6 @@ SLUS-21492:
     autoFlush: 2 # Fixes post processing overlay.
     roundSprite: 1 # Greatly reduces chromatic effect when upscaling.
     wildArmsHack: 1 # Fixes chromatic fringing.
-    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21493:
   name: "Need for Speed - Carbon"
   region: "NTSC-U"
@@ -67809,8 +64066,6 @@ SLUS-21536:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned textures.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21537:
   name: "Fatal Fury Battle Archives Vol.1"
   region: "NTSC-U"
@@ -67925,9 +64180,6 @@ SLUS-21560:
   name: "Family Guy - The Video Game"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves grass and building textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21561:
   name: "Major League Baseball 2K7"
   region: "NTSC-U"
@@ -67954,9 +64206,6 @@ SLUS-21566:
   name: "Brunswick Pro Bowling"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves alley textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21567:
   name: "Shining Force EXA"
   region: "NTSC-U"
@@ -68026,23 +64275,16 @@ SLUS-21580:
   gsHWFixes:
     halfPixelOffset: 4 # Aligns bloom as best it can be.
     autoFlush: 1 # Fixes bloom rendering.
-    mipmap: 2 # Mipmap + trilinear, improves ground and building textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21581:
   name: "UEFA Champions League 2006-2007"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21582:
   name: "MVP '07 - NCAA Baseball"
   region: "NTSC-U"
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes broken replay window graphics.
     cpuSpriteRenderLevel: 2 # Needed for above.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21583:
   name: "Crash of the Titans"
   region: "NTSC-U"
@@ -68114,8 +64356,6 @@ SLUS-21596:
     recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 2 # Fixes blur and obscures sun behind objects.
-    mipmap: 2 # Fixes over sharpening.
-    trilinearFiltering: 1 # Smoothes out mipmapping.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     bilinearUpscale: 2 # Smooths out sun glare textures like native.
     getSkipCount: "GSC_BurnoutGames"
@@ -68127,8 +64367,6 @@ SLUS-21597:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes lighting misalignment.
     mergeSprite: 1 # Removes occasional vertical lines.
-    mipmap: 2 # Mipmap + trilinear, improves building textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21598:
   name: "Digimon World - Data Squad"
   region: "NTSC-U"
@@ -68167,9 +64405,6 @@ SLUS-21602:
   name: "Transformers - The Game"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Cleans up texture detail.
-    trilinearFiltering: 1 # Smoothes out texture transitions.
 SLUS-21603:
   name: "Soul Nomad & The World Eaters"
   region: "NTSC-U"
@@ -68189,9 +64424,6 @@ SLUS-21606:
   name: "Metropolismania 2"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21607:
   name: "The Legend of Spyro - The Eternal Night"
   name-sort: "Legend of Spyro, The - The Eternal Night"
@@ -68221,8 +64453,6 @@ SLUS-21611:
     vu1ClampMode: 3 # Fixes texture corruption light shimmering and reflective surfaces.
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned bloom effects.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21612:
   name: "Legend of the Dragon"
   region: "NTSC-U"
@@ -68289,16 +64519,10 @@ SLUS-21620:
   region: "NTSC-U"
   clampModes:
     vuClampMode: 3 # Missing geometry with microVU.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21621:
   name: "Shin Megami Tensei - Persona 3 FES"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, fixes flashing windows.
-    trilinearFiltering: 1
   memcardFilters:
     - "SLUS-21621"
     - "SLUS-21569"
@@ -68308,8 +64532,6 @@ SLUS-21622:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 4 # Fixes bloom on sunlight.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21623:
   name: "The Bigs"
   name-sort: "Bigs, The"
@@ -68372,8 +64594,6 @@ SLUS-21633:
   compat: 5
   gsHWFixes:
     textureInsideRT: 1 # Fixes shadows.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21634:
   name: "Crazy Frog Racer 2"
   region: "NTSC-U"
@@ -68381,8 +64601,6 @@ SLUS-21634:
   roundModes:
     eeDivRoundMode: 1 # Fixes black fade effects and some overlays texts in the menus.
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves road and grass textures to match sw renderer.
-    trilinearFiltering: 1
     deinterlace: 9 # Fixes disorderly interlacing lines.
 SLUS-21635:
   name: "Monster Jam"
@@ -68401,8 +64619,6 @@ SLUS-21637:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes ground texture flicker and improves car body reflections.
     autoFlush: 1 # Fixes lens flares and missing sun.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
   patches:
     57F534F4:
       content: |-
@@ -68416,9 +64632,6 @@ SLUS-21638:
   compat: 5
   clampModes:
     vuClampMode: 3 # Missing geometry with microVU.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21639:
   name: "NASCAR '08"
   region: "NTSC-U"
@@ -68429,9 +64642,6 @@ SLUS-21640:
   name: "Rugby '08"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21641:
   name: "Innocent Life - Harvest Moon - Pure"
   region: "NTSC-U"
@@ -68463,9 +64673,6 @@ SLUS-21646:
   compat: 5
   clampModes:
     vuClampMode: 2 # Fix black textures on characters.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21647:
   name: "NHL '08"
   region: "NTSC-U"
@@ -68488,9 +64695,6 @@ SLUS-21650:
   compat: 5
   gameFixes:
     - EETimingHack # Flickery textures.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21651:
   name: "Noddy and the Magic Book"
   region: "NTSC-U"
@@ -68544,8 +64748,6 @@ SLUS-21664:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 4 # Removes horizontal and vertical lines on the ground, trees and the sky.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21665:
   name: "The Simpsons Game"
   name-sort: "Simpsons Game, The"
@@ -68554,8 +64756,6 @@ SLUS-21665:
   gsHWFixes:
     halfPixelOffset: 2 # Corrects misaligned cel shading.
     roundSprite: 1 # Further corrects misaligned cel shading.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21666:
   name: "Mountain Bike Adrenaline"
   region: "NTSC-U"
@@ -68583,8 +64783,6 @@ SLUS-21672:
   gsHWFixes:
     textureInsideRT: 1 # Crowd textures.
     autoFlush: 1 # Fixes bloom intensity.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21673:
   name: "College Hoops 2K8"
   region: "NTSC-U"
@@ -68633,8 +64831,6 @@ SLUS-21681:
   compat: 4
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes skin colour.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21682:
   name: "Rock Band"
   region: "NTSC-U"
@@ -68749,9 +64945,6 @@ SLUS-21705:
   region: "NTSC-U"
   clampModes:
     vuClampMode: 3 # Missing geometry with microVU.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21706:
   name: "Alvin and the Chipmunks"
   region: "NTSC-U"
@@ -68786,9 +64979,6 @@ SLUS-21712:
   name: "History Channel - Battle for the Pacific"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21713:
   name: "Winter Sports 2008 - The Ultimate Challenge"
   region: "NTSC-U"
@@ -68906,8 +65096,6 @@ SLUS-21733:
     - VUSyncHack # Fixes SPS.
   gsHWFixes:
     halfPixelOffset: 1 # Fixes post bloom alignment.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21734:
   name: "Falling Stars"
   region: "NTSC-U"
@@ -68956,8 +65144,6 @@ SLUS-21740:
   gsHWFixes:
     textureInsideRT: 1 # Crowd textures.
     autoFlush: 1 # Fixes bloom intensity.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21741:
   name: "Sea Monsters - A Prehistoric Adventure"
   region: "NTSC-U"
@@ -69017,9 +65203,6 @@ SLUS-21752:
   compat: 5
   clampModes:
     vuClampMode: 3 # Missing geometry with microVU.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21753:
   name: "Monopoly"
   region: "NTSC-U"
@@ -69027,8 +65210,6 @@ SLUS-21753:
   gsHWFixes:
     recommendedBlendingLevel: 4 # Needed to render the board and lights correctly.
     halfPixelOffset: 4 # Aligns the 1/4th of the game that does upscale because the game is silly.
-    mipmap: 2 # Mipmap + trilinear, improves the game's stupid rendering but it's still awful.
-    trilinearFiltering: 1
 SLUS-21754:
   name: "CID the Dummy"
   region: "NTSC-U"
@@ -69037,9 +65218,6 @@ SLUS-21755:
   name: "Are You Smarter Than A 5th Grader - Make The Grade"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, makes the game's textures worse to match software.
-    trilinearFiltering: 1
 SLUS-21756:
   name: "The Chronicles of Narnia - Prince Caspian"
   name-sort: "Chronicles of Narnia, The - Prince Caspian"
@@ -69054,8 +65232,6 @@ SLUS-21757:
   compat: 5
   gsHWFixes:
     cpuSpriteRenderBW: 1 # Fixes textures.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21758:
   name: "Rock Band - Track Pack Vol.1"
   region: "NTSC-U"
@@ -69124,9 +65300,6 @@ SLUS-21770:
   compat: 5
   clampModes:
     vuClampMode: 3 # Missing geometry with microVU.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21771:
   name: "NHL 2009"
   region: "NTSC-U"
@@ -69137,9 +65310,6 @@ SLUS-21772:
   compat: 5
   clampModes:
     vuClampMode: 2 # Fixes black textures on characters.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21773:
   name: "PDC World Championship Darts 2008"
   region: "NTSC-U"
@@ -69252,8 +65422,6 @@ SLUS-21793:
     estimateTextureRegion: 1 # Improves performance and reduces hash cache size.
     gpuPaletteConversion: 2 # Improves performance and reduces hash cache size.
     autoFlush: 1 # Corrects shadows (Currently still broken even with this).
-    mipmap: 2 # Mipmap + trilinear, matches sw renderer.
-    trilinearFiltering: 1
 SLUS-21794:
   name: "Go, Diego, Go! Great Dinosaur Rescue"
   region: "NTSC-U"
@@ -69295,8 +65463,6 @@ SLUS-21801:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes blurriness.
-    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_NFSUndercover"
 SLUS-21802:
   name: "Naked Brothers Band - The Video Game"
@@ -69313,9 +65479,6 @@ SLUS-21805:
   name: "Hasbro Family Game Night"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, fixes textures on battleships model.
-    trilinearFiltering: 1
 SLUS-21806:
   name: "Barbie Horse Adventures - Riding Camp"
   region: "NTSC-U"
@@ -69353,8 +65516,6 @@ SLUS-21812:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes bloom alignment.
     autoFlush: 1
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21813:
   name: "007 - Quantum of Solace"
   region: "NTSC-U"
@@ -69379,9 +65540,6 @@ SLUS-21818:
   name: "Spongebob SquarePants Featuring Nicktoons - Globs of Doom"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, fixes graphical errors video.
-    trilinearFiltering: 1
 SLUS-21819:
   name: "High School Musical 3 - Senior Year Dance!"
   region: "NTSC-U"
@@ -69439,9 +65597,6 @@ SLUS-21836:
   name: "Secret Service"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21838:
   name: "Monster Lab"
   region: "NTSC-U"
@@ -69538,8 +65693,6 @@ SLUS-21858:
   gsHWFixes:
     textureInsideRT: 1 # Needed for post processing effects.
     autoFlush: 1 # Fixes missing blur layer.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21860:
   name: "The Bigs 2"
   name-sort: "Bigs 2, The"
@@ -69585,8 +65738,6 @@ SLUS-21867:
   gsHWFixes:
     preloadFrameData: 1 # Fixes icons.
     autoFlush: 1 # Fixes bloom intensity.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
   roundModes:
     vu1RoundMode: 0 # Fixes VU size spam and potential graphical issues with GH3 engine.
 SLUS-21868:
@@ -69596,9 +65747,6 @@ SLUS-21868:
 SLUS-21869:
   name: "Trivial Pursuit"
   region: "NTSC-U"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21870:
   name: "Monsters VS Aliens"
   region: "NTSC-U"
@@ -69618,8 +65766,6 @@ SLUS-21872:
   gsHWFixes:
     halfPixelOffset: 4 # Aligns bloom as best it can be.
     autoFlush: 1 # Fixes bloom rendering.
-    mipmap: 2 # Mipmap + trilinear, improves ground and building textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21873:
   name: "Dynasty Warriors - Gundam 2"
   region: "NTSC-U"
@@ -69640,9 +65786,6 @@ SLUS-21877:
   compat: 5
   clampModes:
     vuClampMode: 2 # Fixes black textures on characters.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21878:
   name: "Ice Age 3 - Dawn of the Dinosaurs"
   region: "NTSC-U"
@@ -69720,18 +65863,12 @@ SLUS-21892:
   region: "NTSC-U"
   clampModes:
     vuClampMode: 3 # Missing geometry with microVU.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21893:
   name: "Madden NFL 10"
   region: "NTSC-U"
   compat: 5
   clampModes:
     vuClampMode: 3 # Missing geometry with microVU.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21895:
   name: "Astro Boy - The Video Game"
   region: "NTSC-U"
@@ -69796,9 +65933,6 @@ SLUS-21907:
   name: "Jurassic - The Hunted"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21908:
   name: "NBA 2K10"
   region: "NTSC-U"
@@ -69866,8 +66000,6 @@ SLUS-21924:
   gsHWFixes:
     preloadFrameData: 1 # Fixes icons.
     autoFlush: 1 # Fixes bloom intensity.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
   roundModes:
     vu1RoundMode: 0 # Fixes VU size spam and potential graphical issues with GH3 engine.
 SLUS-21926:
@@ -69910,9 +66042,6 @@ SLUS-21932:
   region: "NTSC-U"
   clampModes:
     vuClampMode: 3 # Missing geometry with microVU.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21933:
   name: "Despicable Me"
   region: "NTSC-U"
@@ -69932,9 +66061,6 @@ SLUS-21937:
   compat: 5
   clampModes:
     vuClampMode: 3 # Shows the crowd in the back.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21938:
   name: "Ben 10 - Ultimate Alien - Cosmic Destruction"
   region: "NTSC-U"
@@ -69947,9 +66073,6 @@ SLUS-21940:
   name: "WWE All-Stars"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ring textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21941:
   name: "FIFA Soccer 11"
   region: "NTSC-U"
@@ -69976,9 +66099,6 @@ SLUS-21946:
   compat: 5
   clampModes:
     vuClampMode: 3 # Missing geometry with microVU.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-21947:
   name: "FIFA Soccer 12"
   region: "NTSC-U"
@@ -70045,8 +66165,6 @@ SLUS-28006:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 1 # Fixes missing blur layer on sky.
-    mipmap: 2 # Mipmap + trilinear, improves road textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-28007:
   name: "All-Star Baseball 2003 [Trade Demo]"
   region: "NTSC-U"
@@ -70084,8 +66202,6 @@ SLUS-28019:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
     alignSprite: 1 # Fixes vertical lines.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-28020:
   name: "Everquest Online Adventures [Beta Vol.1.0]"
   region: "NTSC-U"
@@ -70097,16 +66213,12 @@ SLUS-28023:
   region: "NTSC-U"
   gsHWFixes:
     halfPixelOffset: 1 # Sharpens world in far distances.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-28025:
   name: "Disaster Report [Trade Demo]"
   region: "NTSC-U"
   gsHWFixes:
     autoFlush: 1 # Fixes incorrect blur effect.
     halfPixelOffset: 4 # Improves blur.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-28026:
   name: "Everquest Online Adventures [Beta Vol.3.0]"
   region: "NTSC-U"
@@ -70139,9 +66251,6 @@ SLUS-28039:
   region: "NTSC-U"
   speedHacks:
     eeCycleRate: 2 # Fixes hang on opening memory card screen.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-28040:
   name: "Transformers [Trade Demo]"
   region: "NTSC-U"
@@ -70156,9 +66265,6 @@ SLUS-28040:
 SLUS-28043:
   name: "Test Drive - Eve of Destruction [Trade Demo]"
   region: "NTSC-U"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-28044:
   name: "Choro Q [Trade Demo]"
   region: "NTSC-U"
@@ -70167,9 +66273,6 @@ SLUS-28045:
   region: "NTSC-U"
   roundModes:
     eeRoundMode: 0 # Ladder glitch in "Assembly of Nihilo B11" level.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, fixes missing lights to match sw renderer.
-    trilinearFiltering: 1
 SLUS-28046:
   name: "Guilty Gear Isuka [Trade Demo]"
   region: "NTSC-U"
@@ -70196,9 +66299,6 @@ SLUS-28054:
 SLUS-28056:
   name: "State of Emergency 2 [Trade Demo]"
   region: "NTSC-U"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-28059:
   name: "Metal Saga [Trade Demo]"
   region: "NTSC-U"
@@ -70236,9 +66336,6 @@ SLUS-28067:
 SLUS-28068:
   name: "Shin Megami Tensei - Persona 3 FES [Trade Demo]"
   region: "NTSC-U"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, fixes flashing windows.
-    trilinearFiltering: 1
 SLUS-28069:
   name: "Shin Megami Tensei - Persona 4 [Trade Demo]"
   region: "NTSC-U"
@@ -70253,8 +66350,6 @@ SLUS-29003:
     - InstantDMAHack # Fixes broken half-bottom artifacts.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes broken skin colour on Vlad and others.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-29004:
   name: "Unison & Dead or Alive 2 Hardcore [Demo]"
   region: "NTSC-U"
@@ -70294,9 +66389,6 @@ SLUS-29013:
 SLUS-29014:
   name: "Half-Life [Demo]"
   region: "NTSC-U"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-29015:
   name: "Dark Summit [Demo]"
   region: "NTSC-U"
@@ -70322,8 +66414,6 @@ SLUS-29025:
   name: "R.A.D. - Robot Alchemic Drive [Demo]"
   region: "NTSC-U"
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     autoFlush: 2 # Fixes DOF effect.
 SLUS-29026:
   name: "MX SuperFly [Demo]"
@@ -70371,8 +66461,6 @@ SLUS-29038:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
     alignSprite: 1 # Fixes vertical lines.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-29040:
   name: "Dr. Muto [Demo]"
   region: "NTSC-U"
@@ -70381,8 +66469,6 @@ SLUS-29042:
   region: "NTSC-U"
   gsHWFixes:
     halfPixelOffset: 1 # Sharpens world in far distances.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-29044:
   name: "Pride FC - Fighting Championships [Demo]"
   region: "NTSC-U"
@@ -70400,9 +66486,6 @@ SLUS-29049:
   region: "NTSC-U"
   gameFixes:
     - XGKickHack # Fixes corrupted graphics.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-29050:
   name: "Everquest Online Adventures [Regular Demo]"
   region: "NTSC-U"
@@ -70556,8 +66639,6 @@ SLUS-29095:
   region: "NTSC-U"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes lines in cutscenes.
-    mipmap: 2 # Cleans up texture detail.
-    trilinearFiltering: 1 # Smoothes out mipmapping.
 SLUS-29096:
   name: "Final Night 2004 [Demo]"
   region: "NTSC-U"
@@ -70613,8 +66694,6 @@ SLUS-29113:
     recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 2 # Fixes blur and obscures sun behind objects.
-    mipmap: 2 # Fixes over sharpening.
-    trilinearFiltering: 1 # Smoothes out mipmapping.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     bilinearUpscale: 2 # Smooths out sun glare textures like native.
     getSkipCount: "GSC_BurnoutGames"
@@ -70630,8 +66709,6 @@ SLUS-29117:
     autoFlush: 1 # Post-processing.
     halfPixelOffset: 2 # Offset post-processing.
     texturePreloading: 1 # Improves performance.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_Battlefield2" # Depth clear.
     beforeDraw: "OI_Battlefield2" # Framebuffer copy, fixes rendering for bottom part of screen.
 SLUS-29118:
@@ -70650,8 +66727,6 @@ SLUS-29123:
     mergeSprite: 1 # Fixes most vertical lines and lighting misalignment.
     autoFlush: 1 # Fixes light bloom intensity.
     estimateTextureRegion: 1 # Improves performance and reduces hash cache size.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_GiTS"
 SLUS-29124:
   name: "Fight Club [Demo]"
@@ -70681,8 +66756,6 @@ SLUS-29131:
   region: "NTSC-U"
   gsHWFixes:
     autoFlush: 1 # Fixes the post processing positioning.
-    mipmap: 2
-    trilinearFiltering: 1
     textureInsideRT: 1 # Fixes post processing.
 SLUS-29132:
   name: "S.L.A.I. - Steel Lancer Arena International - Phantom Crash [Public Beta Vol.1.0]"
@@ -70703,8 +66776,6 @@ SLUS-29137:
   region: "NTSC-U"
   gsHWFixes:
     autoFlush: 2 # Fixes missing lighting.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     # halfPixelOffset: 1 # Fixes lighting misalignment. Do not enable this, it breaks a lot of graphics.
 SLUS-29138:
   name: "The Punisher [Demo]"
@@ -70747,8 +66818,6 @@ SLUS-29148:
   gsHWFixes:
     nativePaletteDraw: 1 # Fixes lines in certain effects when upscaled.
     halfPixelOffset: 2 # Fixes offset bloom.
-    mipmap: 2 # Mipmap + trilinear, fixes textures.
-    trilinearFiltering: 1
 SLUS-29149:
   name: "Flipnic - Ultimate Pinball [Demo]"
   region: "NTSC-U"
@@ -70756,8 +66825,6 @@ SLUS-29150:
   name: "Destroy All Humans! [Demo]"
   region: "NTSC-U"
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     textureInsideRT: 1 # Fixes shadow maps.
     roundSprite: 2 # Fixes misaligned bloom.
     mergeSprite: 1 # Fixes misaligned bloom.
@@ -70774,8 +66841,6 @@ SLUS-29152:
     autoFlush: 1 # Post-processing.
     halfPixelOffset: 2 # Offset post-processing.
     texturePreloading: 1 # Improves performance.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_Battlefield2" # Depth clear.
     beforeDraw: "OI_Battlefield2" # Framebuffer copy, fixes rendering for bottom part of screen.
 SLUS-29153:
@@ -70787,8 +66852,6 @@ SLUS-29153:
     recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 2 # Fixes blur and obscures sun behind objects.
-    mipmap: 2 # Fixes over sharpening.
-    trilinearFiltering: 1 # Smoothes out mipmapping.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     bilinearUpscale: 2 # Smooths out sun glare textures like native.
     getSkipCount: "GSC_BurnoutGames"
@@ -70804,8 +66867,6 @@ SLUS-29155:
     halfPixelOffset: 2 # Fixes blurriness.
     cpuCLUTRender: 1 # Final colour adjustment LUT.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-29156:
   name: "Marvel Nemesis - Rise of the Imperfects [Demo]"
   region: "NTSC-U"
@@ -70849,8 +66910,6 @@ SLUS-29164:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes bloom misalignment.
     autoFlush: 1 # Fixes missing lights.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-29167:
   name: "007 - From Russia with Love, Need for Speed - Most Wanted, SSX World Tour [Demo]"
   region: "NTSC-U"
@@ -70866,8 +66925,6 @@ SLUS-29168:
   gsHWFixes:
     textureInsideRT: 1 # Required for complex offset shuffles.
     halfPixelOffset: 2 # Fixes center upscaling line during explosions.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
     recommendedBlendingLevel: 4 # Fixes lighting.
 SLUS-29169:
   name: "Resident Evil 4 [Demo]"
@@ -70876,8 +66933,6 @@ SLUS-29169:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-29170:
   name: "Total Overdose - A Gunslinger's Tale in Mexico [Demo]"
   region: "NTSC-U"
@@ -70892,8 +66947,6 @@ SLUS-29172:
     autoFlush: 1 # Post-processing.
     halfPixelOffset: 2 # Offset post-processing.
     texturePreloading: 1 # Improves performance.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_Battlefield2" # Depth clear.
     beforeDraw: "OI_Battlefield2" # Framebuffer copy, fixes rendering for bottom part of screen.
 SLUS-29173:
@@ -70902,8 +66955,6 @@ SLUS-29173:
   region: "NTSC-U"
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned textures.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-29174:
   name: "Namco Transmission Demo Disc Vol. 3.1"
   region: "NTSC-U"
@@ -70921,16 +66972,11 @@ SLUS-29178:
   gsHWFixes:
     alignSprite: 1 # Fixes lighting and vertical lines, also works with normal vertex.
     roundSprite: 1 # Fixes misaligned map.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
     skipDrawStart: 1 # Removes large black box around player car till we properly emulate it.
     skipDrawEnd: 1 # Removes large black box around player car till we properly emulate it.
 SLUS-29179:
   name: "Sonic Riders [Demo]"
   region: "NTSC-U"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves track and building textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-29180:
   name: "Black [Demo]"
   region: "NTSC-U"
@@ -70940,8 +66986,6 @@ SLUS-29180:
     recommendedBlendingLevel: 4 # Improves lighting on buildings and objects.
     autoFlush: 2 # Properly diffuses light instead of strips of light.
     roundSprite: 1 # Fixes lighting misalignment such as the street poles and the sun.
-    mipmap: 2 # Fixes over sharpening.
-    trilinearFiltering: 1 # Smoothes out mipmapping.
     getSkipCount: "GSC_BlackAndBurnoutSky"
     beforeDraw: "OI_BurnoutGames"
 SLUS-29183:
@@ -70957,8 +67001,6 @@ SLUS-29185:
     cpuCLUTRender: 1 # Fixes the rest of the bad textures.
     roundSprite: 1 # Reduces misaligned bloom.
     mergeSprite: 1 # Removes bloom explosion around electrical lights and other light sources such as moon/sun.
-    mipmap: 2 # Mipmap + trilinear, improves road textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-29188:
   name: "Steambot Chronicles [Regular Demo]"
   region: "NTSC-U"
@@ -70968,9 +67010,6 @@ SLUS-29188:
 SLUS-29189:
   name: "FIFA World Cup - Germany 2006 [Demo]"
   region: "NTSC-U"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 SLUS-29191:
   name: "Hitman - Blood Money & Urban Chaos [Demo]"
   region: "NTSC-U"
@@ -71007,8 +67046,6 @@ SLUS-29196:
   name: "Destroy All Humans! 2 [Demo]"
   region: "NTSC-U"
   gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     textureInsideRT: 1 # Fixes shadow maps.
     roundSprite: 2 # Fixes misaligned bloom.
     mergeSprite: 1 # Fixes misaligned bloom.
@@ -71045,9 +67082,6 @@ SLUS-97405:
   region: "NTSC-U"
   speedHacks:
     mtvu: 0 # Increases FPS drastically.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 SRPM-70201:
   name: "Space Venus Starring Morning Musume."
   region: "NTSC-J"
@@ -71064,9 +67098,6 @@ TCES-51904:
   gameFixes:
     - VIF1StallHack # Fixes broken HUD.
     - InstantDMAHack # Fixes texture corruption.
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 TCES-52004:
   name: "Killzone Beta Trial Code"
   region: "PAL-E"
@@ -71081,8 +67112,6 @@ TCES-52033:
     autoFlush: 2 # Fixes lights going through walls.
     preloadFrameData: 1 # Fixes light flicker.
     halfPixelOffset: 2 # Corrects light position.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
   gameFixes:
     - EETimingHack # Fixes random hangs.
   patches:
@@ -71115,23 +67144,15 @@ TCES-52456:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves color and luminosity of surfaces.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     disablePartialInvalidation: 1 # Prevents the situation that a level (Aquatos) doesn't render characters and geometry.
     halfPixelOffset: 2 # Fixes misaligned bloom.
     autoFlush: 2 # Helps fix misaligned bloom.
 TCES-52582:
   name: "Everybody's Golf 4 Beta Trial Code"
   region: "PAL-E"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 TCES-53033:
   name: "Formula One 05 Beta Trial Code"
   region: "PAL-E"
-  gsHWFixes:
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
 TCES-53247:
   name: "WRC - Rally Evolved Beta Trial Code"
   region: "PAL-E"
@@ -71147,8 +67168,6 @@ TCES-53286:
   gsHWFixes:
     roundSprite: 1 # Fix lines in the sky.
     autoFlush: 2 # Fixes lighting.
-    mipmap: 2 # Fixes broken textures.
-    trilinearFiltering: 1 # Fixes water textures.
     cpuSpriteRenderBW: 2 # Fixes water textures. Can't use BW 4 here because of post effects.
     cpuSpriteRenderLevel: 2 # Needed for above.
     textureInsideRT: 1 # Fixes broken character models.
@@ -71329,8 +67348,6 @@ TCPS-10158:
     vu1ClampMode: 0 # Fixes Spider-Man's eye texture colour.
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes textures.
-    mipmap: 2 # Mipmap + trilinear, improves textures to match sw renderer.
-    trilinearFiltering: 1
     autoFlush: 2 # Fixes shadow alignment along with HPO Special (Normal looks better but causes top left glitches).
     halfPixelOffset: 2
 TCPS-10159:
@@ -71386,8 +67403,6 @@ TLES-52149:
   region: "PAL-E"
   gsHWFixes:
     preloadFrameData: 1 # Fixes missing loading screens.
-    mipmap: 2 # Mipmap + trilinear, improves some textures to match sw renderer.
-    trilinearFiltering: 1
 TLES-52339:
   name: "Crash 'N' Burn Beta Trial Code"
   region: "PAL-E"
@@ -71423,6 +67438,4 @@ TLES-82043:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
     halfPixelOffset: 2 # Fixes blurriness.
-    mipmap: 2 # Mipmap + trilinear, improves ground textures to match sw renderer.
-    trilinearFiltering: 1
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -154,8 +154,7 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* dialog, QWidget* 
 	SettingWidgetBinder::BindWidgetToEnumSetting(sif, m_ui.anisotropicFiltering, "EmuCore/GS", "MaxAnisotropy",
 		s_anisotropic_filtering_entries, s_anisotropic_filtering_values, "0");
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.dithering, "EmuCore/GS", "dithering_ps2", 2);
-	SettingWidgetBinder::BindWidgetToIntSetting(
-		sif, m_ui.mipmapping, "EmuCore/GS", "mipmap_hw", static_cast<int>(HWMipmapLevel::Automatic), -1);
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.mipmapping, "EmuCore/GS", "hw_mipmap", true);
 	SettingWidgetBinder::BindWidgetToIntSetting(
 		sif, m_ui.blending, "EmuCore/GS", "accurate_blending_unit", static_cast<int>(AccBlendLevel::Basic));
 	SettingWidgetBinder::BindWidgetToIntSetting(
@@ -477,7 +476,7 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* dialog, QWidget* 
 			   "FMV resolution will remain unchanged, as the video files are pre-rendered."));
 
 		dialog->registerWidgetHelp(
-			m_ui.mipmapping, tr("Mipmapping"), tr("Automatic (Default)"), tr("Control the accuracy level of the mipmapping emulation."));
+			m_ui.mipmapping, tr("Mipmapping"), tr("Checked"), tr("Enables mipmapping, which some games require to render correctly."));
 
 		dialog->registerWidgetHelp(
 			m_ui.textureFiltering, tr("Texture Filtering"), tr("Bilinear (PS2)"), tr("Control the texture filtering of the emulation."));

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
@@ -472,37 +472,6 @@
        <item row="0" column="1">
         <widget class="QComboBox" name="upscaleMultiplier"/>
        </item>
-       <item row="1" column="0">
-        <widget class="QLabel" name="label_6">
-         <property name="text">
-          <string>Mipmapping:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="1">
-        <widget class="QComboBox" name="mipmapping">
-         <item>
-          <property name="text">
-           <string>Automatic (Default)</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Off</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Basic (Generated Mipmaps)</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Full (PS2 Mipmaps)</string>
-          </property>
-         </item>
-        </widget>
-       </item>
        <item row="2" column="0">
         <widget class="QLabel" name="label_13">
          <property name="text">
@@ -678,9 +647,9 @@
           </widget>
          </item>
          <item row="1" column="0">
-          <widget class="QCheckBox" name="enableHWFixes">
-           <property name="text">
-            <string>Manual Hardware Renderer Fixes</string>
+          <widget class="QCheckBox" name="mipmapping">
+            <property name="text">
+             <string>Mipmapping</string>
            </property>
           </widget>
          </item>
@@ -688,6 +657,13 @@
           <widget class="QCheckBox" name="spinCPUDuringReadbacks">
            <property name="text">
             <string>Spin CPU During Readbacks</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QCheckBox" name="enableHWFixes">
+           <property name="text">
+            <string>Manual Hardware Renderer Fixes</string>
            </property>
           </widget>
          </item>

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -286,14 +286,6 @@ enum class TriFiltering : s8
 	Forced,
 };
 
-enum class HWMipmapLevel : s8
-{
-	Automatic = -1,
-	Off,
-	Basic,
-	Full
-};
-
 enum class AccBlendLevel : u8
 {
 	Minimum,
@@ -620,6 +612,7 @@ struct Pcsx2Config
 					AutoFlushSW : 1,
 					PreloadFrameWithGSData : 1,
 					Mipmap : 1,
+					HWMipmap : 1,
 					ManualUserHacks : 1,
 					UserHacks_AlignSpriteX : 1,
 					UserHacks_CPUFBConversion : 1,
@@ -673,7 +666,6 @@ struct Pcsx2Config
 		GSRendererType Renderer = GSRendererType::Auto;
 		float UpscaleMultiplier = 1.0f;
 
-		HWMipmapLevel HWMipmap = HWMipmapLevel::Automatic;
 		AccBlendLevel AccurateBlendingUnit = AccBlendLevel::Basic;
 		BiFiltering TextureFiltering = BiFiltering::PS2;
 		TexturePreloadingLevel TexturePreloading = TexturePreloadingLevel::Full;

--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -1113,28 +1113,18 @@ BEGIN_HOTKEY_LIST(g_gs_hotkeys){"Screenshot", TRANSLATE_NOOP("Hotkeys", "Graphic
 					Pcsx2Config::GSOptions::AspectRatioNames[static_cast<int>(EmuConfig.CurrentAspectRatio)]),
 				Host::OSD_QUICK_DURATION);
 		}},
-	{"CycleMipmapMode", TRANSLATE_NOOP("Hotkeys", "Graphics"), TRANSLATE_NOOP("Hotkeys", "Cycle Hardware Mipmapping"),
+	{"ToggleMipmapMode", TRANSLATE_NOOP("Hotkeys", "Graphics"), TRANSLATE_NOOP("Hotkeys", "Toggle Hardware Mipmapping"),
 		[](s32 pressed) {
-			if (pressed)
-				return;
-
-			static constexpr s32 CYCLE_COUNT = 4;
-			static constexpr std::array<const char*, CYCLE_COUNT> option_names = {
-				{"Automatic", "Off", "Basic (Generated)", "Full (PS2)"}};
-
-			const HWMipmapLevel new_level =
-				static_cast<HWMipmapLevel>(((static_cast<s32>(EmuConfig.GS.HWMipmap) + 2) % CYCLE_COUNT) - 1);
-			Host::AddKeyedOSDMessage("CycleMipmapMode",
-				fmt::format(TRANSLATE_FS("Hotkeys", "Hardware mipmapping set to '{}'."),
-					option_names[static_cast<s32>(new_level) + 1]),
-				Host::OSD_QUICK_DURATION);
-			EmuConfig.GS.HWMipmap = new_level;
-
-			MTGS::RunOnGSThread([new_level]() {
-				GSConfig.HWMipmap = new_level;
-				g_gs_renderer->PurgeTextureCache(true, false, true);
-				g_gs_device->PurgePool();
-			});
+			if (!pressed)
+			{
+				EmuConfig.GS.HWMipmap = !EmuConfig.GS.HWMipmap;
+				Host::AddKeyedOSDMessage("ToggleMipmapMode",
+					EmuConfig.GS.HWMipmap ?
+						TRANSLATE_STR("Hotkeys", "Hardware mipmapping is now enabled.") :
+						TRANSLATE_STR("Hotkeys", "Hardware mipmapping is now disabled."),
+					Host::OSD_INFO_DURATION);
+				MTGS::ApplySettings();
+			}
 		}},
 	{"CycleInterlaceMode", TRANSLATE_NOOP("Hotkeys", "Graphics"), TRANSLATE_NOOP("Hotkeys", "Cycle Deinterlace Mode"),
 		[](s32 pressed) {

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -4370,7 +4370,7 @@ GSTextureCache::Source* GSTextureCache::CreateSource(const GIFRegTEX0& TEX0, con
 	{
 		// lod won't contain the full range when using basic mipmapping, only that
 		// which is hashed, so we just allocate the full thing.
-		tlevels = (GSConfig.HWMipmap != HWMipmapLevel::Full) ? -1 : std::min(lod->y - lod->x + 1, GSDevice::GetMipmapLevelsForSize(tw, th));
+		tlevels = GSConfig.HWMipmap ? std::min(lod->y - lod->x + 1, GSDevice::GetMipmapLevelsForSize(tw, th)) : -1;
 		src->m_lod = *lod;
 	}
 
@@ -5304,7 +5304,7 @@ GSTextureCache::HashCacheEntry* GSTextureCache::LookupHashCache(const GIFRegTEX0
 	// expand/upload texture
 	const int tw = region.HasX() ? region.GetWidth() : (1 << TEX0.TW);
 	const int th = region.HasY() ? region.GetHeight() : (1 << TEX0.TH);
-	const int tlevels = lod ? ((GSConfig.HWMipmap != HWMipmapLevel::Full) ? -1 : std::min(lod->y - lod->x + 1, GSDevice::GetMipmapLevelsForSize(tw, th))) : 1;
+	const int tlevels = lod ? (GSConfig.HWMipmap ? std::min(lod->y - lod->x + 1, GSDevice::GetMipmapLevelsForSize(tw, th)) : -1) : 1;
 	GSTexture* tex = g_gs_device->CreateTexture(tw, th, tlevels, paltex ? GSTexture::Format::UNorm8 : GSTexture::Format::Color);
 	if (!tex)
 	{

--- a/pcsx2/GS/Renderers/HW/GSTextureReplacements.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureReplacements.cpp
@@ -661,8 +661,7 @@ void GSTextureReplacements::PrecacheReplacementTextures()
 
 	// predict whether the requests will come with mipmaps
 	// TODO: This will be wrong for hw mipmap games like Jak.
-	const bool mipmap = GSConfig.HWMipmap >= HWMipmapLevel::Basic ||
-						GSConfig.TriFilter == TriFiltering::Forced;
+	const bool mipmap = GSConfig.HWMipmap || GSConfig.TriFilter == TriFiltering::Forced;
 
 	// pretty simple, just go through the filenames and if any aren't cached, cache them
 	for (const auto& it : s_replacement_texture_filenames)

--- a/pcsx2/GameDatabase.cpp
+++ b/pcsx2/GameDatabase.cpp
@@ -370,13 +370,13 @@ static const char* s_gs_hw_fix_names[] = {
 	"textureInsideRT",
 	"alignSprite",
 	"mergeSprite",
+	"mipmap",
 	"wildArmsHack",
 	"bilinearUpscale",
 	"nativePaletteDraw",
 	"estimateTextureRegion",
 	"PCRTCOffsets",
 	"PCRTCOverscan",
-	"mipmap",
 	"trilinearFiltering",
 	"skipDrawStart",
 	"skipDrawEnd",
@@ -621,7 +621,7 @@ bool GameDatabaseSchema::GameEntry::configMatchesHWFix(const Pcsx2Config::GSOpti
 			return (static_cast<int>(config.PCRTCOverscan) == value);
 
 		case GSHWFixId::Mipmap:
-			return (config.HWMipmap == HWMipmapLevel::Automatic || static_cast<int>(config.HWMipmap) == value);
+			return (static_cast<int>(config.HWMipmap) == value);
 
 		case GSHWFixId::TrilinearFiltering:
 			return (config.TriFilter == TriFiltering::Automatic || static_cast<int>(config.TriFilter) == value);
@@ -775,16 +775,8 @@ void GameDatabaseSchema::GameEntry::applyGSHardwareFixes(Pcsx2Config::GSOptions&
 				break;
 
 			case GSHWFixId::Mipmap:
-			{
-				if (value >= 0 && value <= static_cast<int>(HWMipmapLevel::Full))
-				{
-					if (config.HWMipmap == HWMipmapLevel::Automatic)
-						config.HWMipmap = static_cast<HWMipmapLevel>(value);
-					else if (config.HWMipmap == HWMipmapLevel::Off)
-						Console.Warning("[GameDB] Game requires mipmapping but it has been force disabled.");
-				}
-			}
-			break;
+				config.HWMipmap = (value > 0);
+				break;
 
 			case GSHWFixId::TrilinearFiltering:
 			{
@@ -792,8 +784,8 @@ void GameDatabaseSchema::GameEntry::applyGSHardwareFixes(Pcsx2Config::GSOptions&
 				{
 					if (config.TriFilter == TriFiltering::Automatic)
 						config.TriFilter = static_cast<TriFiltering>(value);
-					else if (config.TriFilter == TriFiltering::Off)
-						Console.Warning("[GameDB] Game requires trilinear filtering but it has been force disabled.");
+					else if (config.TriFilter > TriFiltering::Off)
+						Console.Warning("[GameDB] Game requires trilinear filtering to be disabled.");
 				}
 			}
 			break;

--- a/pcsx2/GameDatabase.h
+++ b/pcsx2/GameDatabase.h
@@ -53,6 +53,7 @@ namespace GameDatabaseSchema
 		TextureInsideRT,
 		AlignSprite,
 		MergeSprite,
+		Mipmap,
 		WildArmsHack,
 		BilinearUpscale,
 		NativePaletteDraw,
@@ -61,7 +62,6 @@ namespace GameDatabaseSchema
 		PCRTCOverscan,
 
 		// integer settings
-		Mipmap,
 		TrilinearFiltering,
 		SkipDrawStart,
 		SkipDrawEnd,

--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -3520,12 +3520,6 @@ void FullscreenUI::DrawGraphicsSettingsPage(SettingsInterface* bsi, bool show_ad
 		"7",
 		"8",
 	};
-	static constexpr const char* s_mipmapping_options[] = {
-		FSUI_NSTR("Automatic (Default)"),
-		FSUI_NSTR("Off"),
-		FSUI_NSTR("Basic (Generated Mipmaps)"),
-		FSUI_NSTR("Full (PS2 Mipmaps)"),
-	};
 	static constexpr const char* s_bilinear_options[] = {
 		FSUI_NSTR("Nearest"),
 		FSUI_NSTR("Bilinear (Forced)"),
@@ -3660,9 +3654,6 @@ void FullscreenUI::DrawGraphicsSettingsPage(SettingsInterface* bsi, bool show_ad
 		DrawStringListSetting(bsi, FSUI_CSTR("Internal Resolution"),
 			FSUI_CSTR("Multiplies the render resolution by the specified factor (upscaling)."), "EmuCore/GS", "upscale_multiplier",
 			"1.000000", s_resolution_options, s_resolution_values, std::size(s_resolution_options), true);
-		DrawIntListSetting(bsi, FSUI_CSTR("Mipmapping"), FSUI_CSTR("Determines how mipmaps are used when rendering textures."),
-			"EmuCore/GS", "mipmap_hw", static_cast<int>(HWMipmapLevel::Automatic), s_mipmapping_options, std::size(s_mipmapping_options),
-			true, -1);
 		DrawIntListSetting(bsi, FSUI_CSTR("Bilinear Filtering"),
 			FSUI_CSTR("Selects where bilinear filtering is utilized when rendering textures."), "EmuCore/GS", "filter",
 			static_cast<int>(BiFiltering::PS2), s_bilinear_options, std::size(s_bilinear_options), true);
@@ -3682,6 +3673,8 @@ void FullscreenUI::DrawGraphicsSettingsPage(SettingsInterface* bsi, bool show_ad
 				"Uploads full textures to the GPU on use, rather than only the utilized regions. Can improve performance in some games."),
 			"EmuCore/GS", "texture_preloading", static_cast<int>(TexturePreloadingLevel::Off), s_preloading_options,
 			std::size(s_preloading_options), true);
+		DrawToggleSetting(
+			bsi, FSUI_CSTR("Mipmapping"), FSUI_CSTR("Enables emulation of the GS's texture mipmapping."), "EmuCore/GS", "hw_mipmap", true);
 	}
 	else
 	{

--- a/pcsx2/ImGui/ImGuiOverlays.cpp
+++ b/pcsx2/ImGui/ImGuiOverlays.cpp
@@ -374,8 +374,8 @@ __ri void ImGuiManager::DrawSettingsOverlay(float scale, float margin, float spa
 		if (GSConfig.HWDownloadMode != GSHardwareDownloadMode::Enabled)
 			APPEND("DL={} ", static_cast<unsigned>(GSConfig.HWDownloadMode));
 
-		if (GSConfig.HWMipmap != HWMipmapLevel::Automatic)
-			APPEND("MM={} ", static_cast<unsigned>(GSConfig.HWMipmap));
+		if (GSConfig.HWMipmap)
+			APPEND("MM ");
 
 		// deliberately test global and print local here for auto values
 		if (EmuConfig.GS.TextureFiltering != BiFiltering::PS2)

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -642,6 +642,7 @@ Pcsx2Config::GSOptions::GSOptions()
 	AutoFlushSW = true;
 	PreloadFrameWithGSData = false;
 	Mipmap = true;
+	HWMipmap = true;
 
 	ManualUserHacks = false;
 	UserHacks_AlignSpriteX = false;
@@ -708,7 +709,6 @@ bool Pcsx2Config::GSOptions::OptionsAreEqual(const GSOptions& right) const
 		OpEqu(Renderer) &&
 		OpEqu(UpscaleMultiplier) &&
 
-		OpEqu(HWMipmap) &&
 		OpEqu(AccurateBlendingUnit) &&
 		OpEqu(TextureFiltering) &&
 		OpEqu(TexturePreloading) &&
@@ -893,7 +893,7 @@ void Pcsx2Config::GSOptions::LoadSave(SettingsWrapper& wrap)
 	// ~51x would the upper bound here for 32768x32768 textures, but you'll run out VRAM long before then.
 	UpscaleMultiplier = std::clamp(UpscaleMultiplier, 0.5f, 50.0f);
 
-	SettingsWrapIntEnumEx(HWMipmap, "mipmap_hw");
+	SettingsWrapBitBoolEx(HWMipmap, "hw_mipmap");
 	SettingsWrapIntEnumEx(AccurateBlendingUnit, "accurate_blending_unit");
 	SettingsWrapIntEnumEx(TextureFiltering, "filter");
 	SettingsWrapIntEnumEx(TexturePreloading, "texture_preloading");

--- a/pcsx2/SIO/Pad/Pad.cpp
+++ b/pcsx2/SIO/Pad/Pad.cpp
@@ -214,7 +214,7 @@ void Pad::SetDefaultHotkeyConfig(SettingsInterface& si)
 	// PCSX2 Controller Settings - Hotkeys - Graphics
 	si.SetStringValue("Hotkeys", "CycleAspectRatio", "Keyboard/F6");
 	si.SetStringValue("Hotkeys", "CycleInterlaceMode", "Keyboard/F5");
-	si.SetStringValue("Hotkeys", "CycleMipmapMode", "Keyboard/Insert");
+	si.SetStringValue("Hotkeys", "ToggleMipmapMode", "Keyboard/Insert");
 	//	si.SetStringValue("Hotkeys", "DecreaseUpscaleMultiplier", "Keyboard"); TBD
 	//	si.SetStringValue("Hotkeys", "IncreaseUpscaleMultiplier", "Keyboard"); TBD
 	//  si.SetStringValue("Hotkeys", "ReloadTextureReplacements", "Keyboard"); TBD

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -3016,10 +3016,10 @@ void VMManager::WarnAboutUnsafeSettings()
 	}
 	if (EmuConfig.GS.UpscaleMultiplier < 1.0f)
 		append(ICON_FA_TV, TRANSLATE_SV("VMManager", "Upscale multiplier is below native, this will break rendering."));
-	if (EmuConfig.GS.HWMipmap != HWMipmapLevel::Automatic)
+	if (!EmuConfig.GS.HWMipmap)
 	{
 		append(ICON_FA_IMAGES,
-			TRANSLATE_SV("VMManager", "Mipmapping is not set to automatic. This may break rendering in some games."));
+			TRANSLATE_SV("VMManager", "Mipmapping is disabled. This may break rendering in some games."));
 	}
 	if (EmuConfig.GS.TextureFiltering != BiFiltering::PS2)
 	{


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Always enable full mipmap with ps2 trilinear by default.
Change mipmap option from a drop down to a bool with on off option only, remove automatic and basic options.

TODO for the future: remove support of trilinear and mipmap from db.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Accuracy, less hassle to keep adding gamefixes, instead we will add gamefixes to force disable mipmap on some games that break.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test variety of games that use mipmap + triliear, make sure to disable gamefixes .
DB list needs to be updated.
