### PR TITLE
Qt: Simplify incompatible savestate message

### DIFF
--- a/pcsx2/SaveState.cpp
+++ b/pcsx2/SaveState.cpp
@@ -1052,9 +1052,10 @@ static bool CheckVersion(const std::string& filename, zip_t* zf, Error* error)
 	// than the emulator recognizes.  99% chance that trying to load it will just corrupt emulation or crash.
 	if (savever > g_SaveVersion || (savever >> 16) != (g_SaveVersion >> 16))
 	{
-		Error::SetString(error, fmt::format(TRANSLATE_FS("SaveState","This savestate is an unsupported version and cannot be used.\n\n"
-											"You can download PCSX2 {} from pcsx2.net and make a normal memory card save.\n"
-											"Otherwise delete the savestate and do a fresh boot."),
+		Error::SetString(error, fmt::format(TRANSLATE_FS("SaveState","This save state is outdated and is no longer compatible "
+											"with the current version of PCSX2.\n\n"
+											"If you have any unsaved progress on this save state, you can download the compatible version (PCSX2 {}) "
+											"from pcsx2.net, load the save state, and save your progress to the memory card."),
 											version_string));
 		return false;
 	}


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
This PR attempts to simplify the incompatible savestate warning message to be more easily understandable and digestible.

Preview:

![Screenshot_20240513_211027](https://github.com/PCSX2/pcsx2/assets/14798312/8b49d612-4ca4-4da7-8608-6728f1ecf533)


### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->

Hoping that people would actually read the message.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->

Check if the message shows up properly.
