### PR TITLE
FSUI: Automatically hide advanced graphics settings

### DIFF
--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -3912,35 +3912,37 @@ void FullscreenUI::DrawGraphicsSettingsPage()
 
 	static constexpr const char* s_gsdump_compression[] = {FSUI_NSTR("Uncompressed"), FSUI_NSTR("LZMA (xz)"), FSUI_NSTR("Zstandard (zst)")};
 
-	MenuHeading(FSUI_CSTR("Advanced"));
-	DrawToggleSetting(bsi, FSUI_CSTR("Skip Presenting Duplicate Frames"),
-		FSUI_CSTR("Skips displaying frames that don't change in 25/30fps games. Can improve speed, but increase input lag/make frame pacing "
-				  "worse."),
-		"EmuCore/GS", "SkipDuplicateFrames", false);
-	DrawToggleSetting(bsi, FSUI_CSTR("Disable Threaded Presentation"),
-		FSUI_CSTR("Presents frames on the main GS thread instead of a worker thread. Used for debugging frametime issues."),
-		"EmuCore/GS", "DisableThreadedPresentation", false);
-	if (hw_fixes_visible)
+	const bool show_advanced_settings = ShouldShowAdvancedSettings(bsi);
+
+	if (show_advanced_settings)
 	{
+		MenuHeading(FSUI_CSTR("Advanced"));
+		DrawToggleSetting(bsi, FSUI_CSTR("Skip Presenting Duplicate Frames"),
+			FSUI_CSTR("Skips displaying frames that don't change in 25/30fps games. Can improve speed, but increase input lag/make frame pacing "
+					  "worse."),
+			"EmuCore/GS", "SkipDuplicateFrames", false);
+		DrawToggleSetting(bsi, FSUI_CSTR("Disable Threaded Presentation"),
+			FSUI_CSTR("Presents frames on the main GS thread instead of a worker thread. Used for debugging frametime issues."),
+			"EmuCore/GS", "DisableThreadedPresentation", false);
 		DrawIntListSetting(bsi, FSUI_CSTR("Hardware Download Mode"), FSUI_CSTR("Changes synchronization behavior for GS downloads."),
 			"EmuCore/GS", "HWDownloadMode", static_cast<int>(GSHardwareDownloadMode::Enabled), s_hw_download, std::size(s_hw_download),
 			true);
+		DrawIntListSetting(bsi, FSUI_CSTR("Allow Exclusive Fullscreen"),
+			FSUI_CSTR("Overrides the driver's heuristics for enabling exclusive fullscreen, or direct flip/scanout."), "EmuCore/GS",
+			"ExclusiveFullscreenControl", -1, s_generic_options, std::size(s_generic_options), true, -1,
+			(renderer == GSRendererType::Auto || renderer == GSRendererType::VK));
+		DrawIntListSetting(bsi, FSUI_CSTR("Override Texture Barriers"),
+			FSUI_CSTR("Forces texture barrier functionality to the specified value."), "EmuCore/GS", "OverrideTextureBarriers", -1,
+			s_generic_options, std::size(s_generic_options), true, -1);
+		DrawIntListSetting(bsi, FSUI_CSTR("GS Dump Compression"), FSUI_CSTR("Sets the compression algorithm for GS dumps."), "EmuCore/GS",
+			"GSDumpCompression", static_cast<int>(GSDumpCompressionMethod::LZMA), s_gsdump_compression, std::size(s_gsdump_compression), true);
+		DrawToggleSetting(bsi, FSUI_CSTR("Disable Framebuffer Fetch"),
+			FSUI_CSTR("Prevents the usage of framebuffer fetch when supported by host GPU."), "EmuCore/GS", "DisableFramebufferFetch", false);
+		DrawToggleSetting(bsi, FSUI_CSTR("Disable Shader Cache"), FSUI_CSTR("Prevents the loading and saving of shaders/pipelines to disk."),
+			"EmuCore/GS", "DisableShaderCache", false);
+		DrawToggleSetting(bsi, FSUI_CSTR("Disable Vertex Shader Expand"), FSUI_CSTR("Falls back to the CPU for expanding sprites/lines."),
+			"EmuCore/GS", "DisableVertexShaderExpand", false);
 	}
-	DrawIntListSetting(bsi, FSUI_CSTR("Allow Exclusive Fullscreen"),
-		FSUI_CSTR("Overrides the driver's heuristics for enabling exclusive fullscreen, or direct flip/scanout."), "EmuCore/GS",
-		"ExclusiveFullscreenControl", -1, s_generic_options, std::size(s_generic_options), true, -1,
-		(renderer == GSRendererType::Auto || renderer == GSRendererType::VK));
-	DrawIntListSetting(bsi, FSUI_CSTR("Override Texture Barriers"),
-		FSUI_CSTR("Forces texture barrier functionality to the specified value."), "EmuCore/GS", "OverrideTextureBarriers", -1,
-		s_generic_options, std::size(s_generic_options), true, -1);
-	DrawIntListSetting(bsi, FSUI_CSTR("GS Dump Compression"), FSUI_CSTR("Sets the compression algorithm for GS dumps."), "EmuCore/GS",
-		"GSDumpCompression", static_cast<int>(GSDumpCompressionMethod::LZMA), s_gsdump_compression, std::size(s_gsdump_compression), true);
-	DrawToggleSetting(bsi, FSUI_CSTR("Disable Framebuffer Fetch"),
-		FSUI_CSTR("Prevents the usage of framebuffer fetch when supported by host GPU."), "EmuCore/GS", "DisableFramebufferFetch", false);
-	DrawToggleSetting(bsi, FSUI_CSTR("Disable Shader Cache"), FSUI_CSTR("Prevents the loading and saving of shaders/pipelines to disk."),
-		"EmuCore/GS", "DisableShaderCache", false);
-	DrawToggleSetting(bsi, FSUI_CSTR("Disable Vertex Shader Expand"), FSUI_CSTR("Falls back to the CPU for expanding sprites/lines."),
-		"EmuCore/GS", "DisableVertexShaderExpand", false);
 
 	EndMenuButtons();
 }


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Automatically hide advanced graphics settings on BPM depending on global advanced settings visibility.
Forgot about it when i added the functionality on Qt

![image](https://github.com/PCSX2/pcsx2/assets/14798312/fb70d094-5873-498f-9977-d4fb7c64d88c)

Closes #11239 

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Consistency 100

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->

Test the functionality, toggle the global advanced settings option and see if the advanced graphics settings section gets hidden.
