### PR TITLE
GS/SW: Don't use fast reciprocal stq calculation, it's too inaccurate

### DIFF
--- a/pcsx2/GS/Renderers/SW/GSDrawScanlineCodeGenerator.all.cpp
+++ b/pcsx2/GS/Renderers/SW/GSDrawScanlineCodeGenerator.all.cpp
@@ -1173,10 +1173,8 @@ void GSDrawScanlineCodeGenerator::SampleTexture()
 
 	if (!m_sel.fst)
 	{
-		rcpps(xym0, _q);
-
-		MOVE_IF_64(mulps, xym2, _s, xym0);
-		MOVE_IF_64(mulps, xym3, _t, xym0);
+		MOVE_IF_64(divps, xym2, _s, _q);
+		MOVE_IF_64(divps, xym3, _t, _q);
 
 		cvttps2dq(xym2, xym2);
 		cvttps2dq(xym3, xym3);
@@ -1576,10 +1574,8 @@ void GSDrawScanlineCodeGenerator::SampleTextureLOD()
 
 	if (!m_sel.fst)
 	{
-		rcpps(xym0, xym4);
-
-		MOVE_IF_64(mulps, xym2, _s, xym0);
-		MOVE_IF_64(mulps, xym3, _t, xym0);
+		MOVE_IF_64(divps, xym2, _s, xym4);
+		MOVE_IF_64(divps, xym3, _t, xym4);
 
 		cvttps2dq(xym2, xym2);
 		cvttps2dq(xym3, xym3);

--- a/pcsx2/GS/Renderers/SW/GSNewCodeGenerator.h
+++ b/pcsx2/GS/Renderers/SW/GSNewCodeGenerator.h
@@ -256,6 +256,7 @@ public:
 	AFORWARD(2, cvtss2sd,  ARGS_XO)
 	SFORWARD(2, cvttps2dq, ARGS_XO)
 	SFORWARD(2, cvttsd2si, const AddressReg&, const Operand&);
+	AFORWARD(2, divps,	   ARGS_XO)
 	SFORWARD(3, extractps, const Operand&, const Xmm&, u8)
 	AFORWARD(2, maxps,     ARGS_XO)
 	AFORWARD(2, minps,     ARGS_XO)


### PR DESCRIPTION
### Description of Changes
Replaces reciprocal Q with normal ST/Q division.

### Rationale behind Changes
the original method is quite inaccurate, especially when you're dealing with interpolation and is just not adequate.  Sten mentioned that it's likely that there would be a stall with the original multiplication anyway, so the performance difference is negligible. But this fixes a bunch of problems. Faster isn't better if it breaks things.

### Suggested Testing Steps
Test games listed below in SW or any you know that have SW only issues. I've checked Armored Core's radar and GOW's controller screen, plus the lines problem in Mercenaries and Klonoa 2, Crash Twinsanity's weird pixels on curves.

Fixes #3295 Metal Gear Solid 2 Locker
Fixes #4825 Spider-Man 3 texture issues
Fixes #6156 Corrects Castlevania map in software mode (Hardware was already fixed)
Corrects #9151 Bonus Demo 08 images in software.

### Note: All fixes are for Software ONLY

Bonus Demo 08:
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/0793c0e7-000a-4ec0-b1ce-0f323f98921e)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/3be7b103-0b23-4821-88ed-52e281d8f224)

Capcom Vs SNK 2 (Colouring on the healthbars corrected):
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/f4fbe0c8-4ca7-445a-9b9f-71a5eb2156d9)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/56cb0505-c5b2-400b-b17e-5546426aa241)

Castlevania - Curse of Darkness:
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/eab3b0e9-2299-417e-ace4-e44d7c67eb77)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/43eeff5f-c6bf-475d-834f-1e35a5014eae)

Metal Gear Solid 2:
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/e9a6aa46-1d88-49bd-a0cf-6f848d57791b)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/50376f35-c9ec-493d-9571-7fd8a9b3d7af)

Spider-Man 3:
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/16f77d70-63e4-45fe-b86a-4e799234c54b)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/4c88c1c6-99ad-43a8-b804-a256530d98f1)
