### PR TITLE
IOP: Adjust cycle counts slightly more accurately in some situations

### DIFF
--- a/pcsx2/R3000A.cpp
+++ b/pcsx2/R3000A.cpp
@@ -135,8 +135,8 @@ __fi void PSX_INT( IopEventId n, s32 ecycle )
 	psxRegs.eCycle[n] = ecycle;
 
 	psxSetNextBranchDelta(ecycle);
-
-	const s32 iopDelta = (psxRegs.iopNextEventCycle - psxRegs.cycle) * 8;
+	const float mutiplier = static_cast<float>(PS2CLK) / static_cast<float>(PSXCLK);
+	const s32 iopDelta = (psxRegs.iopNextEventCycle - psxRegs.cycle) * mutiplier;
 
 	if (psxRegs.iopCycleEE < iopDelta)
 	{

--- a/pcsx2/R5900.cpp
+++ b/pcsx2/R5900.cpp
@@ -432,8 +432,8 @@ __fi void _cpuEventTest_Shared()
 	CpuVU1->ExecuteBlock();
 
 	// ---- Schedule Next Event Test --------------
-
-	const int nextIopEventDeta = ((psxRegs.iopNextEventCycle - psxRegs.cycle) * 8);
+	const float mutiplier = static_cast<float>(PS2CLK) / static_cast<float>(PSXCLK);
+	const int nextIopEventDeta = ((psxRegs.iopNextEventCycle - psxRegs.cycle) * mutiplier);
 	// 8 or more cycles behind and there's an event scheduled
 	if (EEsCycle >= nextIopEventDeta)
 	{
@@ -446,7 +446,7 @@ __fi void _cpuEventTest_Shared()
 	else
 	{
 		// Otherwise IOP is caught up/not doing anything so we can wait for the next event.
-		cpuSetNextEventDelta(((psxRegs.iopNextEventCycle - psxRegs.cycle) * 8) - EEsCycle);
+		cpuSetNextEventDelta(((psxRegs.iopNextEventCycle - psxRegs.cycle) * mutiplier) - EEsCycle);
 	}
 
 	// Apply vsync and other counter nextCycles


### PR DESCRIPTION
### Description of Changes
Adjusts the IOP cycle count slightly more accurately with the EE.

### Rationale behind Changes
It was very wrong in PS1 mode, this is still wrong, just by a fraction of a cycle per block instead of 1 cycle per 3 instructions.

### Suggested Testing Steps
Make sure nothing explodes.
