### PR TITLE
R3000: Serialize IOP->EE ticks carry

### DIFF
--- a/pcsx2/R3000A.cpp
+++ b/pcsx2/R3000A.cpp
@@ -44,6 +44,7 @@ void psxReset()
 
 	psxRegs.iopBreak = 0;
 	psxRegs.iopCycleEE = -1;
+	psxRegs.iopCycleEECarry = 0;
 	psxRegs.iopNextEventCycle = psxRegs.cycle + 4;
 
 	psxHwReset();

--- a/pcsx2/R3000A.h
+++ b/pcsx2/R3000A.h
@@ -110,6 +110,7 @@ struct psxRegisters {
 	// Tracks current number of cycles IOP can run in EE cycles. When it dips below zero,
 	// control is returned to the EE.
 	s32 iopCycleEE;
+	u32 iopCycleEECarry;
 
 	u32 sCycle[32];		// start cycle for signaled ints
 	s32 eCycle[32];		// cycle delta for signaled ints (sCycle + eCycle == branch cycle)

--- a/pcsx2/R3000AInterpreter.cpp
+++ b/pcsx2/R3000AInterpreter.cpp
@@ -279,10 +279,9 @@ static s32 intExecuteBlock( s32 eeCycles )
 			const u32 cdenom = 147; // PSXCLK / F
 
 			//One of the Iop to EE delta clocks to be set in PS1 mode.
-			static u32 carry;
-			const u32 t = ((cnum * (psxRegs.cycle - lastIOPCycle)) + carry);
+			const u32 t = ((cnum * (psxRegs.cycle - lastIOPCycle)) + psxRegs.iopCycleEECarry);
 			psxRegs.iopCycleEE -= t / cdenom;
-			carry = t % cdenom;
+			psxRegs.iopCycleEECarry = t % cdenom;
 		}
 		else
 		{ 

--- a/pcsx2/SaveState.h
+++ b/pcsx2/SaveState.h
@@ -25,7 +25,7 @@ enum class FreezeAction
 // [SAVEVERSION+]
 // This informs the auto updater that the users savestates will be invalidated.
 
-static const u32 g_SaveVersion = (0x9A4E << 16) | 0x0000;
+static const u32 g_SaveVersion = (0x9A4F << 16) | 0x0000;
 
 
 // the freezing data between submodules and core

--- a/pcsx2/x86/iR3000A.cpp
+++ b/pcsx2/x86/iR3000A.cpp
@@ -1141,15 +1141,13 @@ static void iPsxAddEECycles(u32 blockCycles)
 	const u32 cnum = 1280; // PS2CLK / F
 	const u32 cdenom = 147; // PSXCLK / F
 
-	static u32 ticks_carry = 0;
-
 	if (blockCycles != 0xFFFFFFFF)
 		xMOV(eax, blockCycles * cnum);
-	xADD(eax, ptr32[&ticks_carry]);
+	xADD(eax, ptr32[&psxRegs.iopCycleEECarry]);
 	xMOV(ecx, cdenom);
 	xXOR(edx, edx);
 	xUDIV(ecx);
-	xMOV(ptr32[&ticks_carry], edx);
+	xMOV(ptr32[&psxRegs.iopCycleEECarry], edx);
 	xSUB(ptr32[&psxRegs.iopCycleEE], eax);
 }
 


### PR DESCRIPTION
### Description of Changes

Gotta be deterministic.

### Rationale behind Changes

I didn't add it in for the patch #11253 because it was 2am.

### Suggested Testing Steps

Check (grumbles) PSX mode.
