### PR TITLE
GS/HW: Adjust conditions for CPU sprite renderer

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -26689,6 +26689,7 @@ SLES-54723:
     eeRoundMode: 0 # Fixes idle camera behaviour.
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes textures.
+    cpuSpriteRenderLevel: 2 # Fixes the sun when using the above.
     halfPixelOffset: 2 # Fixes bloom alignment.
     autoFlush: 1 # Fixes bloom intensity.
 SLES-54724:
@@ -26698,6 +26699,7 @@ SLES-54724:
     eeRoundMode: 0 # Fixes idle camera behaviour.
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes textures.
+    cpuSpriteRenderLevel: 2 # Fixes the sun when using the above.
     halfPixelOffset: 2 # Fixes bloom alignment.
     autoFlush: 1 # Fixes bloom intensity.
 SLES-54725:
@@ -31472,6 +31474,7 @@ SLKA-25385:
     eeRoundMode: 0 # Fixes idle camera behaviour.
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes textures.
+    cpuSpriteRenderLevel: 2 # Fixes the sun when using the above.
     halfPixelOffset: 2 # Fixes bloom alignment.
     autoFlush: 1 # Fixes bloom intensity.
 SLKA-25388:
@@ -57598,6 +57601,7 @@ SLPS-25823:
     eeRoundMode: 0 # Fixes idle camera behaviour.
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes textures.
+    cpuSpriteRenderLevel: 2 # Fixes the sun when using the above.
     halfPixelOffset: 2 # Fixes bloom alignment.
     autoFlush: 1 # Fixes bloom intensity.
 SLPS-25825:
@@ -67874,6 +67878,7 @@ SLUS-21552:
     eeRoundMode: 0 # Fixes idle camera behaviour.
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes textures.
+    cpuSpriteRenderLevel: 2 # Fixes the sun when using the above.
     halfPixelOffset: 2 # Fixes bloom alignment.
     autoFlush: 1 # Fixes bloom intensity.
 SLUS-21553:

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -6203,6 +6203,7 @@ bool GSRendererHW::CanUseSwPrimRender(bool no_rt, bool no_ds, bool draw_sprite_t
 	// Master enable.
 	const int bw = GSConfig.UserHacks_CPUSpriteRenderBW;
 	const int level = GSConfig.UserHacks_CPUSpriteRenderLevel;
+
 	if (bw == 0)
 		return false;
 
@@ -6228,23 +6229,46 @@ bool GSRendererHW::CanUseSwPrimRender(bool no_rt, bool no_ds, bool draw_sprite_t
 			if (!src_target->m_dirty.empty())
 			{
 				const GSVector4i tr(GetTextureMinMax(m_cached_ctx.TEX0, m_cached_ctx.CLAMP, m_vt.IsLinear(), false, m_vt.m_primclass == GS_SPRITE_CLASS && PrimitiveCoversWithoutGaps()).coverage);
+
+				const u32 start_bp = GSLocalMemory::GetStartBlockAddress(m_cached_ctx.TEX0.TBP0, m_cached_ctx.TEX0.TBW, m_cached_ctx.TEX0.PSM, tr);
+				const u32 end_bp = GSLocalMemory::GetEndBlockAddress(m_cached_ctx.TEX0.TBP0, m_cached_ctx.TEX0.TBW, m_cached_ctx.TEX0.PSM, tr);
+
 				for (GSDirtyRect& rc : src_target->m_dirty)
 				{
-					if (!rc.GetDirtyRect(m_cached_ctx.TEX0, false).rintersect(tr).rempty())
-						return true;
-				}
+					const GSVector4i dirty_rect = rc.GetDirtyRect(src_target->m_TEX0, false);
+					const u32 dirty_start_bp = GSLocalMemory::GetStartBlockAddress(src_target->m_TEX0.TBP0, src_target->m_TEX0.TBW, src_target->m_TEX0.PSM, dirty_rect);
+					const u32 dirty_end_bp = GSLocalMemory::GetEndBlockAddress(src_target->m_TEX0.TBP0, src_target->m_TEX0.TBW, src_target->m_TEX0.PSM, dirty_rect);
 
-				// Make sure it actually makes sense to use this target as a source, given the formats, and it wouldn't just sample as garbage.
-				// We can't rely exclusively on the dirty rect check above, because sometimes the targets are from older frames and too large.
-				if (!GSUtil::HasSameSwizzleBits(m_cached_ctx.TEX0.PSM, src_target->m_TEX0.PSM) &&
-					(!src_target->m_32_bits_fmt || GSLocalMemory::m_psm[m_cached_ctx.TEX0.PSM].bpp != 16))
-				{
-					return true;
+					if (start_bp < dirty_end_bp && end_bp > dirty_start_bp)
+					{
+						if (dirty_start_bp > start_bp || dirty_end_bp < end_bp)
+						{
+							return true;
+						}
+						else if (GSUtil::HasSameSwizzleBits(m_cached_ctx.TEX0.PSM, src_target->m_TEX0.PSM) || PrimitiveCoversWithoutGaps())
+							return false;
+					}
 				}
 			}
+			// Make sure it actually makes sense to use this target as a source, given the formats, and it wouldn't just sample as garbage.
+			// We can't rely exclusively on the dirty rect check above, because sometimes the targets are from older frames and too large.
+			if (!GSUtil::HasSameSwizzleBits(m_cached_ctx.TEX0.PSM, src_target->m_TEX0.PSM) &&
+				(!src_target->m_32_bits_fmt || GSLocalMemory::m_psm[m_cached_ctx.TEX0.PSM].bpp != 16))
+					return true;
 
 			return false;
 		}
+	}
+
+	if (PRIM->ABE && m_vt.m_eq.rgba == 0xffff)
+	{
+		GSTextureCache::Target* rt = g_texture_cache->GetTargetWithSharedBits(m_cached_ctx.FRAME.Block(), m_cached_ctx.FRAME.PSM);
+
+		if (!rt)
+			return true;
+
+		rt = nullptr;
+		return false;
 	}
 
 	// We can use the sw prim render path!


### PR DESCRIPTION
### Description of Changes
Adjusts the conditions for CPU sprite renderer triggering.

### Rationale behind Changes
Some games like Spider-Man 3 and Driv3r require a high level of software drawing to fix some issues, but break other things as a result as they need the information in the render target, however these draws don't really the software renderer to be successful.

### Suggested Testing Steps
Test Driv3r and Spider-Man 3, Wall-E, Jak 3, Jak-X Combat Racing and some random stuff.

Jak and Daxter - The Lost Frontier's upscaled shadow that was fudged with the software sprite renderer is no longer fixed by it, it's a casualty, but what can you do.

Driv3r:
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/56da129d-fd81-4aa7-8e97-b7b26f8d6ba2)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/57fbcc35-d52e-43e1-b64c-695d22426b08)

Spider-Man 3 (with the higher sprite level required for some upcoming changes in #11241 ):
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/7662181c-0dd5-495c-91e7-5fd7622235f4)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/8e248fbc-a8c0-4236-93e7-97e2e55ea133)

Jak-X Combat Racing:
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/2f7c0c65-62ad-4fb7-a664-68649c580859)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/72e09cce-cb23-49cb-acf8-31429c84dbf4)

Wall-E:
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/1cf5b25c-05f3-4968-bf6d-3e7010abccb3)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/f22ff631-edc8-4685-a5a6-e2f1c6a288be)
