### PR TITLE
CDVD: Fix my regressions

### DIFF
--- a/.github/workflows/scripts/linux/appimage-qt.sh
+++ b/.github/workflows/scripts/linux/appimage-qt.sh
@@ -41,11 +41,6 @@ BINARY=pcsx2-qt
 APPDIRNAME=PCSX2.AppDir
 STRIP=strip
 
-declare -a EXCLUDE_LIBS=(
-	'libcrypto.so*'
-	'libssl.so*'
-)
-
 declare -a MANUAL_QT_LIBS=(
 	"libQt6WaylandEglClientHwIntegration.so.6"
 )
@@ -81,11 +76,6 @@ fi
 OUTDIR=$(realpath "./$APPDIRNAME")
 rm -fr "$OUTDIR"
 
-declare -a EXCLUDE_LIBS_ARGS=()
-for lib in "${EXCLUDE_LIBS[@]}"; do
-	EXCLUDE_LIBS_ARGS+=("--exclude-library=$lib")
-done
-
 # Why the nastyness? linuxdeploy strips our main binary, and there's no option to turn it off.
 # It also doesn't strip the Qt libs. We can't strip them after running linuxdeploy, because
 # patchelf corrupts the libraries (but they still work), but patchelf+strip makes them crash
@@ -113,7 +103,6 @@ DEPLOY_PLATFORM_THEMES="1" \
 QMAKE="$DEPSDIR/bin/qmake" \
 NO_STRIP="1" \
 $LINUXDEPLOY --plugin qt --appdir="$OUTDIR" --executable="$BUILDDIR/bin/pcsx2-qt" \
-"${EXCLUDE_LIBS_ARGS[@]}" \
 --desktop-file="net.pcsx2.PCSX2.desktop" --icon-file="PCSX2.png"
 
 echo "Copying resources into AppDir..."

--- a/pcsx2/CDVD/CsoFileReader.cpp
+++ b/pcsx2/CDVD/CsoFileReader.cpp
@@ -33,7 +33,7 @@ CsoFileReader::CsoFileReader() = default;
 
 CsoFileReader::~CsoFileReader()
 {
-	pxAssert(m_src);
+	pxAssert(!m_src);
 }
 
 bool CsoFileReader::ValidateHeader(const CsoHeader& hdr, Error* error)

--- a/pcsx2/CDVD/GzippedFileReader.cpp
+++ b/pcsx2/CDVD/GzippedFileReader.cpp
@@ -232,7 +232,7 @@ ThreadedFileReader::Chunk GzippedFileReader::ChunkForOffset(u64 offset)
 
 int GzippedFileReader::ReadChunk(void* dst, s64 chunkID)
 {
-	if (chunkID < 0 || chunkID >= m_index->size)
+	if (chunkID < 0)
 		return -1;
 
 	const s64 file_offset = chunkID * m_index->span;


### PR DESCRIPTION
### Description of Changes

Fixes an inverted assertion in the CSO reader, and the gzip reader crapping out at the end of some files.

Re-bundles libssl since it didn't help #11230.

### Rationale behind Changes

Regressions from #11258.

### Suggested Testing Steps

Already tested, CI passes.
