### PR TITLE
DEV9: Adapter Utils Cleanup

### DIFF
--- a/pcsx2/DEV9/AdapterUtils.cpp
+++ b/pcsx2/DEV9/AdapterUtils.cpp
@@ -121,7 +121,7 @@ bool AdapterUtils::GetAdapter(const std::string& name, Adapter* adapter, Adapter
 
 	do
 	{
-		if (strcmp(pAdapter->AdapterName, name.c_str()) == 0)
+		if (name == pAdapter->AdapterName)
 		{
 			*adapter = *pAdapter;
 			buffer->swap(adapterInfo);
@@ -203,7 +203,7 @@ bool AdapterUtils::GetAdapter(const std::string& name, Adapter* adapter, Adapter
 	{
 		if (pAdapter->ifa_addr != nullptr &&
 			ReadAddressFamily(pAdapter->ifa_addr) == AF_INET &&
-			strcmp(pAdapter->ifa_name, name.c_str()) == 0)
+			name == pAdapter->ifa_name)
 		{
 			*adapter = *pAdapter;
 			buffer->swap(adapterInfo);

--- a/pcsx2/DEV9/AdapterUtils.cpp
+++ b/pcsx2/DEV9/AdapterUtils.cpp
@@ -204,17 +204,14 @@ bool AdapterUtils::GetAdapter(const std::string& name, Adapter* adapter, Adapter
 		if (pAdapter->ifa_addr != nullptr &&
 			ReadAddressFamily(pAdapter->ifa_addr) == AF_INET &&
 			strcmp(pAdapter->ifa_name, name.c_str()) == 0)
-			break;
+		{
+			*adapter = *pAdapter;
+			buffer->swap(adapterInfo);
+			return true;
+		}
 
 		pAdapter = pAdapter->ifa_next;
 	} while (pAdapter);
-
-	if (pAdapter != nullptr)
-	{
-		*adapter = *pAdapter;
-		buffer->swap(adapterInfo);
-		return true;
-	}
 
 	return false;
 }

--- a/pcsx2/DEV9/AdapterUtils.h
+++ b/pcsx2/DEV9/AdapterUtils.h
@@ -32,6 +32,15 @@ namespace AdapterUtils
 	};
 	typedef std::unique_ptr<ifaddrs, IfAdaptersDeleter> AdapterBuffer;
 #endif
+	// Adapter is a structure that contains ptrs to data stored within AdapterBuffer.
+	// We need to return this buffer the caller can free it after it's finished with Adapter.
+	// AdapterBuffer is a unique_ptr, so will be freed when it leaves scope.
+#ifdef _WIN32
+	// includeHidden sets GAA_FLAG_INCLUDE_ALL_INTERFACES, used by TAPAdapter
+	Adapter* GetAllAdapters(AdapterBuffer* buffer, bool includeHidden = false);
+#elif defined(__POSIX__)
+	Adapter* GetAllAdapters(AdapterBuffer* buffer);
+#endif
 	bool GetAdapter(const std::string& name, Adapter* adapter, AdapterBuffer* buffer);
 	bool GetAdapterAuto(Adapter* adapter, AdapterBuffer* buffer);
 

--- a/pcsx2/DEV9/AdapterUtils.h
+++ b/pcsx2/DEV9/AdapterUtils.h
@@ -23,7 +23,7 @@ namespace AdapterUtils
 {
 #ifdef _WIN32
 	typedef IP_ADAPTER_ADDRESSES Adapter;
-	typedef std::unique_ptr<IP_ADAPTER_ADDRESSES[]> AdapterBuffer;
+	typedef std::unique_ptr<std::byte[]> AdapterBuffer;
 #elif defined(__POSIX__)
 	typedef ifaddrs Adapter;
 	struct IfAdaptersDeleter

--- a/pcsx2/DEV9/AdapterUtils.h
+++ b/pcsx2/DEV9/AdapterUtils.h
@@ -32,6 +32,9 @@ namespace AdapterUtils
 	};
 	typedef std::unique_ptr<ifaddrs, IfAdaptersDeleter> AdapterBuffer;
 #endif
+
+	u16 ReadAddressFamily(const sockaddr* unknownAddr);
+
 	// Adapter is a structure that contains ptrs to data stored within AdapterBuffer.
 	// We need to return this buffer the caller can free it after it's finished with Adapter.
 	// AdapterBuffer is a unique_ptr, so will be freed when it leaves scope.

--- a/pcsx2/DEV9/AdapterUtils.h
+++ b/pcsx2/DEV9/AdapterUtils.h
@@ -47,9 +47,9 @@ namespace AdapterUtils
 	bool GetAdapter(const std::string& name, Adapter* adapter, AdapterBuffer* buffer);
 	bool GetAdapterAuto(Adapter* adapter, AdapterBuffer* buffer);
 
-	std::optional<PacketReader::MAC_Address> GetAdapterMAC(Adapter* adapter);
-	std::optional<PacketReader::IP::IP_Address> GetAdapterIP(Adapter* adapter);
+	std::optional<PacketReader::MAC_Address> GetAdapterMAC(const Adapter* adapter);
+	std::optional<PacketReader::IP::IP_Address> GetAdapterIP(const Adapter* adapter);
 	// Mask.
-	std::vector<PacketReader::IP::IP_Address> GetGateways(Adapter* adapter);
-	std::vector<PacketReader::IP::IP_Address> GetDNS(Adapter* adapter);
+	std::vector<PacketReader::IP::IP_Address> GetGateways(const Adapter* adapter);
+	std::vector<PacketReader::IP::IP_Address> GetDNS(const Adapter* adapter);
 }; // namespace AdapterUtils

--- a/pcsx2/DEV9/pcap_io.cpp
+++ b/pcsx2/DEV9/pcap_io.cpp
@@ -221,7 +221,7 @@ std::vector<AdapterEntry> PCAPAdapter::GetAdapters()
 		entry.guid = std::string(&d->name[strlen(PCAPPREFIX)]);
 
 		IP_ADAPTER_ADDRESSES adapterInfo;
-		std::unique_ptr<IP_ADAPTER_ADDRESSES[]> buffer;
+		AdapterUtils::AdapterBuffer buffer;
 
 		if (AdapterUtils::GetAdapter(entry.guid, &adapterInfo, &buffer))
 			entry.name = StringUtil::WideStringToUTF8String(std::wstring(adapterInfo.FriendlyName));

--- a/pcsx2/DEV9/sockets.cpp
+++ b/pcsx2/DEV9/sockets.cpp
@@ -82,7 +82,7 @@ std::vector<AdapterEntry> SocketAdapter::GetAdapters()
 		if ((pAdapter->ifa_flags & IFF_LOOPBACK) == 0 &&
 			(pAdapter->ifa_flags & IFF_UP) != 0 &&
 			pAdapter->ifa_addr != nullptr &&
-			pAdapter->ifa_addr->sa_family == AF_INET)
+			AdapterUtils::ReadAddressFamily(pAdapter->ifa_addr) == AF_INET)
 		{
 			AdapterEntry entry;
 			entry.type = Pcsx2Config::DEV9Options::NetApi::Sockets;


### PR DESCRIPTION
### Description of Changes
Merge code related to getting a network adapter.
Corrected the buffer type used for `GetAdaptersAddresses()`, as other structures where also placed in there.
Replace C-Style casts with C++ equivalents.

It may be easier to review each commit one by one rather than the whole pr at once

### Rationale behind Changes
This effort was mostly born this https://github.com/PCSX2/pcsx2/pull/10937#discussion_r1560557998, regarding type punning
The socket api does not make it easy to avoid UB type punning, due to strict aliasing rules, The general consensus appears to be that these types are passed in an aliased form and we just cast back to get the true type.


### Suggested Testing Steps
Test connection with pcap. sockets and tap
Test the above (where supported) on Windows, Linux and FreeBSD/Mac
