### PR TITLE
GS/HW: Restrict CPU Sprite abort to non-opaque draws

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -6281,7 +6281,7 @@ bool GSRendererHW::CanUseSwPrimRender(bool no_rt, bool no_ds, bool draw_sprite_t
 		}
 	}
 
-	if (PRIM->ABE && m_vt.m_eq.rgba == 0xffff)
+	if (PRIM->ABE && m_vt.m_eq.rgba == 0xffff && !m_context->ALPHA.IsOpaque(GetAlphaMinMax().min, GetAlphaMinMax().max))
 	{
 		GSTextureCache::Target* rt = g_texture_cache->GetTargetWithSharedBits(m_cached_ctx.FRAME.Block(), m_cached_ctx.FRAME.PSM);
 


### PR DESCRIPTION
### Description of Changes
Fixes Jak

### Rationale behind Changes
I broke Jak

### Suggested Testing Steps
Test Jak
