### PR TITLE
Some small fixes for FreeBSD

### DIFF
--- a/common/Linux/LnxHostSys.cpp
+++ b/common/Linux/LnxHostSys.cpp
@@ -37,6 +37,12 @@
 #define MAP_FIXED_NOREPLACE MAP_FIXED
 #endif
 
+// FreeBSD does not have MAP_FIXED_NOREPLACE, but does have MAP_EXCL.
+// MAP_FIXED combined with MAP_EXCL behaves like MAP_FIXED_NOREPLACE.
+#if defined(__FreeBSD__) && !defined(MAP_FIXED_NOREPLACE)
+#define MAP_FIXED_NOREPLACE MAP_FIXED | MAP_EXCL
+#endif
+
 #include <cerrno>
 #include <fcntl.h>
 #include <sys/mman.h>

--- a/pcsx2-qt/AutoUpdaterDialog.cpp
+++ b/pcsx2-qt/AutoUpdaterDialog.cpp
@@ -897,7 +897,7 @@ void AutoUpdaterDialog::cleanupAfterUpdate()
 
 #else
 
-bool AutoUpdaterDialog::processUpdate(const QByteArray& update_data, QProgressDialog& progress)
+bool AutoUpdaterDialog::processUpdate(const std::vector<u8>& data, QProgressDialog& progress)
 {
 	return false;
 }


### PR DESCRIPTION
### Description of Changes
Corrects type for stub implementation of `AutoUpdaterDialog::processUpdate()`
Define `MAP_FIXED_NOREPLACE` as `MAP_FIXED | MAP_EXCL`, which should serve the same purpose

### Rationale behind Changes
Some socket code is common between Mac and FreeBSD, but not Linux.
Setting up a FreeBSD VM for testing is cheaper then getting a Mac (I mean, it's in the name)

### Suggested Testing Steps
It's still a bit of effort compile for FreeBSD, In addition to this PR you would need to deal with the following issues;

Qt with Multitouch fails to compile, due to code intended to support FreeBSD you can do one of the following;
Disable Multitouch with `-no-mtdev` or apply the same Qt [patches](https://cgit.freebsd.org/ports/tree/devel/qt6-base/files) FreeBSD's port does.

cpuinfo doesn't support FreeBSD
Locally apply either https://github.com/pytorch/cpuinfo/pull/230 or https://github.com/pytorch/cpuinfo/pull/172, I think the port uses the former.

Incorrect shaderc headers being used when system installed shaderc is present.
`/usr/local/include` is not treated as an implicit include (unlike Ubuntu)
This leaves us at the mercy of cmake's ordering, which ends up being incorrect.
Somehow none of the system provided dependencies we use mark this directory as a `SYSTEM`, so cmake see fit to have this as the very first include directory.
`deps/include` gets marked as `SYSTEM`, so appears a fair bit later in the search order.
Providing an environment variable `CXXFLAGS="-isystem /usr/local/include"` manages to get includes in the correct order.

I dunno if that last issue is an problem with my configuration, or something FreeBSD has messed up.
