### PR TITLE
GS/HW: Allow forcing Dither to 32bit for 16bit draws

### DIFF
--- a/bin/resources/shaders/dx11/tfx.fx
+++ b/bin/resources/shaders/dx11/tfx.fx
@@ -803,7 +803,7 @@ void ps_fbmask(inout float4 C, float2 pos_xy)
 
 void ps_dither(inout float3 C, float As, float2 pos_xy)
 {
-	if (PS_DITHER)
+	if (PS_DITHER > 0 && PS_DITHER < 3)
 	{
 		int2 fpos;
 
@@ -833,7 +833,7 @@ void ps_color_clamp_wrap(inout float3 C)
 {
 	// When dithering the bottom 3 bits become meaningless and cause lines in the picture
 	// so we need to limit the color depth on dithered items
-	if (SW_BLEND || PS_DITHER || PS_FBMASK)
+	if (SW_BLEND || (PS_DITHER > 0 && PS_DITHER < 3) || PS_FBMASK)
 	{
 		if (PS_DST_FMT == FMT_16 && PS_BLEND_MIX == 0 && PS_ROUND_INV)
 			C += 7.0f; // Need to round up, not down since the shader will invert
@@ -843,7 +843,7 @@ void ps_color_clamp_wrap(inout float3 C)
 			C = clamp(C, (float3)0.0f, (float3)255.0f);
 
 		// In 16 bits format, only 5 bits of color are used. It impacts shadows computation of Castlevania
-		if (PS_DST_FMT == FMT_16 && (PS_BLEND_MIX == 0 || PS_DITHER))
+		if (PS_DST_FMT == FMT_16 && PS_DITHER != 3 && (PS_BLEND_MIX == 0 || PS_DITHER))
 			C = (float3)((int3)C & (int3)0xF8);
 		else if (PS_COLCLIP == 1 || PS_HDR == 1)
 			C = (float3)((int3)C & (int3)0xFF);

--- a/bin/resources/shaders/opengl/tfx_fs.glsl
+++ b/bin/resources/shaders/opengl/tfx_fs.glsl
@@ -721,7 +721,7 @@ void ps_fbmask(inout vec4 C)
 
 void ps_dither(inout vec3 C, float As)
 {
-#if PS_DITHER
+#if PS_DITHER > 0 && PS_DITHER < 3
 	#if PS_DITHER == 2
 		ivec2 fpos = ivec2(gl_FragCoord.xy);
 	#else
@@ -753,7 +753,7 @@ void ps_color_clamp_wrap(inout vec3 C)
 {
 	// When dithering the bottom 3 bits become meaningless and cause lines in the picture
 	// so we need to limit the color depth on dithered items
-#if SW_BLEND || PS_DITHER || PS_FBMASK
+#if SW_BLEND || (PS_DITHER > 0 && PS_DITHER < 3) || PS_FBMASK
 
 #if PS_DST_FMT == FMT_16 && PS_BLEND_MIX == 0 && PS_ROUND_INV
 	C += 7.0f; // Need to round up, not down since the shader will invert
@@ -771,7 +771,7 @@ void ps_color_clamp_wrap(inout vec3 C)
 	// Warning: normally blending equation is mult(A, B) = A * B >> 7. GPU have the full accuracy
 	// GS: Color = 1, Alpha = 255 => output 1
 	// GPU: Color = 1/255, Alpha = 255/255 * 255/128 => output 1.9921875
-#if PS_DST_FMT == FMT_16 && (PS_BLEND_MIX == 0 || PS_DITHER)
+#if PS_DST_FMT == FMT_16 && PS_DITHER < 3 && (PS_BLEND_MIX == 0 || PS_DITHER)
 	// In 16 bits format, only 5 bits of colors are used. It impacts shadows computation of Castlevania
 	C = vec3(ivec3(C) & ivec3(0xF8));
 #elif PS_COLCLIP == 1 || PS_HDR == 1

--- a/bin/resources/shaders/vulkan/tfx.glsl
+++ b/bin/resources/shaders/vulkan/tfx.glsl
@@ -985,7 +985,7 @@ void ps_fbmask(inout vec4 C)
 
 void ps_dither(inout vec3 C, float As)
 {
-	#if PS_DITHER
+	#if PS_DITHER > 0 && PS_DITHER < 3
 		ivec2 fpos;
 
 		#if PS_DITHER == 2
@@ -1020,7 +1020,7 @@ void ps_color_clamp_wrap(inout vec3 C)
 {
 	// When dithering the bottom 3 bits become meaningless and cause lines in the picture
 	// so we need to limit the color depth on dithered items
-#if SW_BLEND || PS_DITHER || PS_FBMASK
+#if SW_BLEND || (PS_DITHER > 0 && PS_DITHER < 3) || PS_FBMASK
 
 #if PS_DST_FMT == FMT_16 && PS_BLEND_MIX == 0 && PS_ROUND_INV
 	C += 7.0f; // Need to round up, not down since the shader will invert
@@ -1038,7 +1038,7 @@ void ps_color_clamp_wrap(inout vec3 C)
 	// Warning: normally blending equation is mult(A, B) = A * B >> 7. GPU have the full accuracy
 	// GS: Color = 1, Alpha = 255 => output 1
 	// GPU: Color = 1/255, Alpha = 255/255 * 255/128 => output 1.9921875
-#if PS_DST_FMT == FMT_16 && (PS_BLEND_MIX == 0 || PS_DITHER)
+#if PS_DST_FMT == FMT_16 && PS_DITHER != 3 && (PS_BLEND_MIX == 0 || PS_DITHER > 0)
 	// In 16 bits format, only 5 bits of colors are used. It impacts shadows computation of Castlevania
 	C = vec3(ivec3(C) & ivec3(0xF8));
 #elif PS_COLCLIP == 1 || PS_HDR == 1

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
@@ -568,6 +568,11 @@
            <string>Unscaled (Default)</string>
           </property>
          </item>
+         <item>
+          <property name="text">
+           <string>Force 32bit</string>
+          </property>
+         </item>
         </widget>
        </item>
        <item row="6" column="0">

--- a/pcsx2/GS/Renderers/Metal/tfx.metal
+++ b/pcsx2/GS/Renderers/Metal/tfx.metal
@@ -865,7 +865,7 @@ struct PSMain
 
 	void ps_dither(thread float4& C, float As)
 	{
-		if (PS_DITHER == 0)
+		if (PS_DITHER == 0 || PS_DITHER == 3)
 			return;
 		ushort2 fpos;
 		if (PS_DITHER == 2)
@@ -891,7 +891,7 @@ struct PSMain
 	void ps_color_clamp_wrap(thread float4& C)
 	{
 		// When dithering the bottom 3 bits become meaningless and cause lines in the picture so we need to limit the color depth on dithered items
-		if (!SW_BLEND && !PS_DITHER && !PS_FBMASK)
+		if (!SW_BLEND && !(PS_DITHER > 0 && PS_DITHER < 3) && !PS_FBMASK)
 			return;
 
 		if (PS_DST_FMT == FMT_16 && PS_BLEND_MIX == 0 && PS_ROUND_INV)
@@ -907,7 +907,7 @@ struct PSMain
 		// Warning: normally blending equation is mult(A, B) = A * B >> 7. GPU have the full accuracy
 		// GS: Color = 1, Alpha = 255 => output 1
 		// GPU: Color = 1/255, Alpha = 255/255 * 255/128 => output 1.9921875
-		if (PS_DST_FMT == FMT_16 && (PS_BLEND_MIX == 0 || PS_DITHER))
+		if (PS_DST_FMT == FMT_16 && PS_DITHER < 3 && (PS_BLEND_MIX == 0 || PS_DITHER))
 			// In 16 bits format, only 5 bits of colors are used. It impacts shadows computation of Castlevania
 			C.rgb = float3(short3(C.rgb) & 0xF8);
 		else if (PS_COLCLIP || PS_HDR)

--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -3536,6 +3536,7 @@ void FullscreenUI::DrawGraphicsSettingsPage(SettingsInterface* bsi, bool show_ad
 		FSUI_NSTR("Off"),
 		FSUI_NSTR("Scaled"),
 		FSUI_NSTR("Unscaled (Default)"),
+		FSUI_NSTR("Force 32bit"),
 	};
 	static constexpr const char* s_blending_options[] = {
 		FSUI_NSTR("Minimum"),

--- a/pcsx2/ShaderCacheVersion.h
+++ b/pcsx2/ShaderCacheVersion.h
@@ -3,4 +3,4 @@
 
 /// Version number for GS and other shaders. Increment whenever any of the contents of the
 /// shaders change, to invalidate the cache.
-static constexpr u32 SHADER_CACHE_VERSION = 48;
+static constexpr u32 SHADER_CACHE_VERSION = 49;


### PR DESCRIPTION
### Description of Changes
Adds a new option to override dithering and force 32bit pixel depth

### Rationale behind Changes
Disabling dithering stuff truncates colours to 16bit which causes some gross banding.  Disabling dithering *can* force 32bit, but if there's any software blending (which we do a lot), it will bypass it.

### Suggested Testing Steps
Try the new option, most obvious with high blending settings.

Off:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/1c026d57-6cf9-417f-9b3b-d232727e6b55)

Force 32bit:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/a5cc4960-9811-4c4b-b8b8-02225991985f)
