### PR TITLE
GS: Improve vsync mode selection

### DIFF
--- a/common/CocoaTools.h
+++ b/common/CocoaTools.h
@@ -13,6 +13,8 @@ namespace CocoaTools
 {
 	bool CreateMetalLayer(WindowInfo* wi);
 	void DestroyMetalLayer(WindowInfo* wi);
+	std::optional<float> GetViewRefreshRate(const WindowInfo& wi);
+
 	/// Add a handler to be run when macOS changes between dark and light themes
 	void AddThemeChangeHandler(void* ctx, void(handler)(void* ctx));
 	/// Remove a handler previously added using AddThemeChangeHandler with the given context

--- a/common/CocoaTools.mm
+++ b/common/CocoaTools.mm
@@ -64,6 +64,27 @@ void CocoaTools::DestroyMetalLayer(WindowInfo* wi)
 	[view setWantsLayer:NO];
 }
 
+std::optional<float> CocoaTools::GetViewRefreshRate(const WindowInfo& wi)
+{
+	if (![NSThread isMainThread])
+	{
+		std::optional<float> ret;
+		dispatch_sync(dispatch_get_main_queue(), [&ret, wi]{ ret = GetViewRefreshRate(wi); });
+		return ret;
+	}
+
+	std::optional<float> ret;
+	NSView* const view = (__bridge NSView*)wi.window_handle;
+	const u32 did = [[[[[view window] screen] deviceDescription] valueForKey:@"NSScreenNumber"] unsignedIntValue];
+	if (CGDisplayModeRef mode = CGDisplayCopyDisplayMode(did))
+	{
+		ret = CGDisplayModeGetRefreshRate(mode);
+		CGDisplayModeRelease(mode);
+	}
+	
+	return ret;
+}
+
 // MARK: - Theme Change Handlers
 
 @interface PCSX2KVOHelper : NSObject

--- a/common/Darwin/DarwinMisc.cpp
+++ b/common/Darwin/DarwinMisc.cpp
@@ -4,6 +4,7 @@
 #if defined(__APPLE__)
 
 #include "common/Darwin/DarwinMisc.h"
+#include "common/HostSys.h"
 
 #include <cstring>
 #include <cstdlib>
@@ -102,7 +103,7 @@ std::string GetOSVersionString()
 
 static IOPMAssertionID s_pm_assertion;
 
-bool WindowInfo::InhibitScreensaver(const WindowInfo& wi, bool inhibit)
+bool Common::InhibitScreensaver(bool inhibit)
 {
 	if (s_pm_assertion)
 	{

--- a/common/HostSys.h
+++ b/common/HostSys.h
@@ -180,6 +180,9 @@ extern std::string GetOSVersionString();
 
 namespace Common
 {
+	/// Enables or disables the screen saver from starting.
+	bool InhibitScreensaver(bool inhibit);
+
 	/// Abstracts platform-specific code for asynchronously playing a sound.
 	/// On Windows, this will use PlaySound(). On Linux, it will shell out to aplay. On MacOS, it uses NSSound.
 	bool PlaySoundAsync(const char* path);

--- a/common/Linux/LnxMisc.cpp
+++ b/common/Linux/LnxMisc.cpp
@@ -161,7 +161,7 @@ static bool SetScreensaverInhibitDBus(const bool inhibit_requested, const char* 
 	return true;
 }
 
-bool WindowInfo::InhibitScreensaver(const WindowInfo& wi, bool inhibit)
+bool Common::InhibitScreensaver(bool inhibit)
 {
 	return SetScreensaverInhibitDBus(inhibit, "PCSX2", "PCSX2 VM is running.");
 }

--- a/common/WindowInfo.cpp
+++ b/common/WindowInfo.cpp
@@ -1,19 +1,90 @@
-// SPDX-FileCopyrightText: 2002-2023 PCSX2 Dev Team
+// SPDX-FileCopyrightText: 2002-2024 PCSX2 Dev Team
 // SPDX-License-Identifier: LGPL-3.0+
 
 #include "WindowInfo.h"
 #include "Console.h"
+#include "Error.h"
+#include "HeapArray.h"
 
 #if defined(_WIN32)
 
 #include "RedtapeWindows.h"
 #include <dwmapi.h>
 
-static bool GetRefreshRateFromDWM(HWND hwnd, float* refresh_rate)
+static std::optional<float> GetRefreshRateFromDisplayConfig(HWND hwnd)
+{
+	// Partially based on Chromium ui/display/win/display_config_helper.cc.
+	const HMONITOR monitor = MonitorFromWindow(hwnd, 0);
+	if (!monitor) [[unlikely]]
+	{
+		ERROR_LOG("{}() failed: {}", "MonitorFromWindow", Error::CreateWin32(GetLastError()).GetDescription());
+		return std::nullopt;
+	}
+
+	MONITORINFOEXW mi = {};
+	mi.cbSize = sizeof(mi);
+	if (!GetMonitorInfoW(monitor, &mi))
+	{
+		ERROR_LOG("{}() failed: {}", "GetMonitorInfoW", Error::CreateWin32(GetLastError()).GetDescription());
+		return std::nullopt;
+	}
+
+	DynamicHeapArray<DISPLAYCONFIG_PATH_INFO> path_info;
+	DynamicHeapArray<DISPLAYCONFIG_MODE_INFO> mode_info;
+
+	// I guess this could fail if it changes inbetween two calls... unlikely.
+	for (;;)
+	{
+		UINT32 path_size = 0, mode_size = 0;
+		LONG res = GetDisplayConfigBufferSizes(QDC_ONLY_ACTIVE_PATHS, &path_size, &mode_size);
+		if (res != ERROR_SUCCESS)
+		{
+			ERROR_LOG("{}() failed: {}", "GetDisplayConfigBufferSizes", Error::CreateWin32(res).GetDescription());
+			return std::nullopt;
+		}
+
+		path_info.resize(path_size);
+		mode_info.resize(mode_size);
+		res =
+			QueryDisplayConfig(QDC_ONLY_ACTIVE_PATHS, &path_size, path_info.data(), &mode_size, mode_info.data(), nullptr);
+		if (res == ERROR_SUCCESS)
+			break;
+		if (res != ERROR_INSUFFICIENT_BUFFER)
+		{
+			ERROR_LOG("{}() failed: {}", "QueryDisplayConfig", Error::CreateWin32(res).GetDescription());
+			return std::nullopt;
+		}
+	}
+
+	for (const DISPLAYCONFIG_PATH_INFO& pi : path_info)
+	{
+		DISPLAYCONFIG_SOURCE_DEVICE_NAME sdn = {.header = {.type = DISPLAYCONFIG_DEVICE_INFO_GET_SOURCE_NAME,
+													.size = sizeof(DISPLAYCONFIG_SOURCE_DEVICE_NAME),
+													.adapterId = pi.sourceInfo.adapterId,
+													.id = pi.sourceInfo.id}};
+		LONG res = DisplayConfigGetDeviceInfo(&sdn.header);
+		if (res != ERROR_SUCCESS)
+		{
+			ERROR_LOG("{}() failed: {}", "DisplayConfigGetDeviceInfo", Error::CreateWin32(res).GetDescription());
+			continue;
+		}
+
+		if (std::wcscmp(sdn.viewGdiDeviceName, mi.szDevice) == 0)
+		{
+			// Found the monitor!
+			return static_cast<float>(static_cast<double>(pi.targetInfo.refreshRate.Numerator) /
+									  static_cast<double>(pi.targetInfo.refreshRate.Denominator));
+		}
+	}
+
+	return std::nullopt;
+}
+
+static std::optional<float> GetRefreshRateFromDWM(HWND hwnd)
 {
 	BOOL composition_enabled;
 	if (FAILED(DwmIsCompositionEnabled(&composition_enabled)))
-		return false;
+		return std::nullopt;
 
 	DWM_TIMING_INFO ti = {};
 	ti.cbSize = sizeof(ti);
@@ -21,20 +92,19 @@ static bool GetRefreshRateFromDWM(HWND hwnd, float* refresh_rate)
 	if (SUCCEEDED(hr))
 	{
 		if (ti.rateRefresh.uiNumerator == 0 || ti.rateRefresh.uiDenominator == 0)
-			return false;
+			return std::nullopt;
 
-		*refresh_rate = static_cast<float>(ti.rateRefresh.uiNumerator) / static_cast<float>(ti.rateRefresh.uiDenominator);
-		return true;
+		return static_cast<float>(ti.rateRefresh.uiNumerator) / static_cast<float>(ti.rateRefresh.uiDenominator);
 	}
 
-	return false;
+	return std::nullopt;
 }
 
-static bool GetRefreshRateFromMonitor(HWND hwnd, float* refresh_rate)
+static std::optional<float> GetRefreshRateFromMonitor(HWND hwnd)
 {
 	HMONITOR mon = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
 	if (!mon)
-		return false;
+		return std::nullopt;
 
 	MONITORINFOEXW mi = {};
 	mi.cbSize = sizeof(mi);
@@ -45,23 +115,41 @@ static bool GetRefreshRateFromMonitor(HWND hwnd, float* refresh_rate)
 
 		// 0/1 are reserved for "defaults".
 		if (EnumDisplaySettingsW(mi.szDevice, ENUM_CURRENT_SETTINGS, &dm) && dm.dmDisplayFrequency > 1)
-		{
-			*refresh_rate = static_cast<float>(dm.dmDisplayFrequency);
-			return true;
-		}
+			return static_cast<float>(dm.dmDisplayFrequency);
 	}
 
-	return false;
+	return std::nullopt;
 }
 
-bool WindowInfo::QueryRefreshRateForWindow(const WindowInfo& wi, float* refresh_rate)
+std::optional<float> WindowInfo::QueryRefreshRateForWindow(const WindowInfo& wi)
 {
+	std::optional<float> ret;
 	if (wi.type != Type::Win32 || !wi.window_handle)
-		return false;
+		return ret;
 
 	// Try DWM first, then fall back to integer values.
 	const HWND hwnd = static_cast<HWND>(wi.window_handle);
-	return GetRefreshRateFromDWM(hwnd, refresh_rate) || GetRefreshRateFromMonitor(hwnd, refresh_rate);
+	ret = GetRefreshRateFromDisplayConfig(hwnd);
+	if (!ret.has_value())
+	{
+		ret = GetRefreshRateFromDWM(hwnd);
+		if (!ret.has_value())
+			ret = GetRefreshRateFromMonitor(hwnd);
+	}
+
+	return ret;
+}
+
+#elif defined(__APPLE__)
+
+#include "common/CocoaTools.h"
+
+std::optional<float> WindowInfo::QueryRefreshRateForWindow(const WindowInfo& wi)
+{
+	if (wi.type == WindowInfo::Type::MacOS)
+		return CocoaTools::GetViewRefreshRate(wi);
+
+	return std::nullopt;
 }
 
 #else
@@ -72,18 +160,18 @@ bool WindowInfo::QueryRefreshRateForWindow(const WindowInfo& wi, float* refresh_
 #include <X11/extensions/Xrandr.h>
 #include <X11/Xlib.h>
 
-static bool GetRefreshRateFromXRandR(const WindowInfo& wi, float* refresh_rate)
+static std::optional<float> GetRefreshRateFromXRandR(const WindowInfo& wi)
 {
 	Display* display = static_cast<Display*>(wi.display_connection);
 	Window window = static_cast<Window>(reinterpret_cast<uintptr_t>(wi.window_handle));
 	if (!display || !window)
-		return false;
+		return std::nullopt;
 
 	XRRScreenResources* res = XRRGetScreenResources(display, window);
 	if (!res)
 	{
 		Console.Error("(GetRefreshRateFromXRandR) XRRGetScreenResources() failed");
-		return false;
+		return std::nullopt;
 	}
 
 	ScopedGuard res_guard([res]() { XRRFreeScreenResources(res); });
@@ -93,7 +181,7 @@ static bool GetRefreshRateFromXRandR(const WindowInfo& wi, float* refresh_rate)
 	if (num_monitors < 0)
 	{
 		Console.Error("(GetRefreshRateFromXRandR) XRRGetMonitors() failed");
-		return false;
+		return std::nullopt;
 	}
 	else if (num_monitors > 1)
 	{
@@ -104,7 +192,7 @@ static bool GetRefreshRateFromXRandR(const WindowInfo& wi, float* refresh_rate)
 	if (mi->noutput <= 0)
 	{
 		Console.Error("(GetRefreshRateFromXRandR) Monitor has no outputs");
-		return false;
+		return std::nullopt;
 	}
 	else if (mi->noutput > 1)
 	{
@@ -115,7 +203,7 @@ static bool GetRefreshRateFromXRandR(const WindowInfo& wi, float* refresh_rate)
 	if (!oi)
 	{
 		Console.Error("(GetRefreshRateFromXRandR) XRRGetOutputInfo() failed");
-		return false;
+		return std::nullopt;
 	}
 
 	ScopedGuard oi_guard([oi]() { XRRFreeOutputInfo(oi); });
@@ -124,7 +212,7 @@ static bool GetRefreshRateFromXRandR(const WindowInfo& wi, float* refresh_rate)
 	if (!ci)
 	{
 		Console.Error("(GetRefreshRateFromXRandR) XRRGetCrtcInfo() failed");
-		return false;
+		return std::nullopt;
 	}
 
 	ScopedGuard ci_guard([ci]() { XRRFreeCrtcInfo(ci); });
@@ -141,30 +229,29 @@ static bool GetRefreshRateFromXRandR(const WindowInfo& wi, float* refresh_rate)
 	if (!mode)
 	{
 		Console.Error("(GetRefreshRateFromXRandR) Failed to look up mode %d (of %d)", static_cast<int>(ci->mode), res->nmode);
-		return false;
+		return std::nullopt;
 	}
 
 	if (mode->dotClock == 0 || mode->hTotal == 0 || mode->vTotal == 0)
 	{
 		Console.Error("(GetRefreshRateFromXRandR) Modeline is invalid: %ld/%d/%d", mode->dotClock, mode->hTotal, mode->vTotal);
-		return false;
+		return std::nullopt;
 	}
 
-	*refresh_rate =
-		static_cast<double>(mode->dotClock) / (static_cast<double>(mode->hTotal) * static_cast<double>(mode->vTotal));
-	return true;
+	return static_cast<float>(
+		static_cast<double>(mode->dotClock) / (static_cast<double>(mode->hTotal) * static_cast<double>(mode->vTotal)));
 }
 
 #endif // X11_API
 
-bool WindowInfo::QueryRefreshRateForWindow(const WindowInfo& wi, float* refresh_rate)
+std::optional<float> WindowInfo::QueryRefreshRateForWindow(const WindowInfo& wi)
 {
 #if defined(X11_API)
 	if (wi.type == WindowInfo::Type::X11)
-		return GetRefreshRateFromXRandR(wi, refresh_rate);
+		return GetRefreshRateFromXRandR(wi);
 #endif
 
-	return false;
+	return std::nullopt;
 }
 
 #endif

--- a/common/WindowInfo.h
+++ b/common/WindowInfo.h
@@ -4,6 +4,8 @@
 #pragma once
 #include "Pcsx2Defs.h"
 
+#include <optional>
+
 /// Contains the information required to create a graphics context in a window.
 struct WindowInfo
 {
@@ -41,8 +43,5 @@ struct WindowInfo
 	float surface_refresh_rate = 0.0f;
 
 	/// Returns the host's refresh rate for the given window, if available.
-	static bool QueryRefreshRateForWindow(const WindowInfo& wi, float* refresh_rate);
-
-	/// Enables or disables the screen saver from starting.
-	static bool InhibitScreensaver(const WindowInfo& wi, bool inhibit);
+	static std::optional<float> QueryRefreshRateForWindow(const WindowInfo& wi);
 };

--- a/common/Windows/WinMisc.cpp
+++ b/common/Windows/WinMisc.cpp
@@ -81,7 +81,7 @@ std::string GetOSVersionString()
 	return retval;
 }
 
-bool WindowInfo::InhibitScreensaver(const WindowInfo& wi, bool inhibit)
+bool Common::InhibitScreensaver(bool inhibit)
 {
 	EXECUTION_STATE flags = ES_CONTINUOUS;
 	if (inhibit)

--- a/pcsx2-qt/QtUtils.cpp
+++ b/pcsx2-qt/QtUtils.cpp
@@ -302,6 +302,21 @@ namespace QtUtils
 		wi.surface_width = static_cast<u32>(static_cast<qreal>(widget->width()) * dpr);
 		wi.surface_height = static_cast<u32>(static_cast<qreal>(widget->height()) * dpr);
 		wi.surface_scale = static_cast<float>(dpr);
+
+		// Query refresh rate, we need it for sync.
+		std::optional<float> surface_refresh_rate = WindowInfo::QueryRefreshRateForWindow(wi);
+		if (!surface_refresh_rate.has_value())
+		{
+			// Fallback to using the screen, getting the rate for Wayland is an utter mess otherwise.
+			const QScreen* widget_screen = widget->screen();
+			if (!widget_screen)
+				widget_screen = QGuiApplication::primaryScreen();
+			surface_refresh_rate = widget_screen ? static_cast<float>(widget_screen->refreshRate()) : 0.0f;
+		}
+
+		wi.surface_refresh_rate = surface_refresh_rate.value();
+		INFO_LOG("Surface refresh rate: {} hz", wi.surface_refresh_rate);
+
 		return wi;
 	}
 

--- a/pcsx2-qt/Settings/EmulationSettingsWidget.h
+++ b/pcsx2-qt/Settings/EmulationSettingsWidget.h
@@ -24,6 +24,7 @@ private:
 	void initializeSpeedCombo(QComboBox* cb, const char* section, const char* key, float default_value);
 	void handleSpeedComboChange(QComboBox* cb, const char* section, const char* key);
 	void updateOptimalFramePacing();
+	void updateUseVSyncForTimingEnabled();
 
 	SettingsWindow* m_dialog;
 

--- a/pcsx2-qt/Settings/EmulationSettingsWidget.ui
+++ b/pcsx2-qt/Settings/EmulationSettingsWidget.ui
@@ -261,6 +261,20 @@
       </item>
       <item row="3" column="0" colspan="2">
        <layout class="QGridLayout" name="basicCheckboxGridLayout">
+        <item row="1" column="1">
+         <widget class="QCheckBox" name="useVSyncForTiming">
+          <property name="text">
+           <string>Use Host VSync Timing</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="QCheckBox" name="syncToHostRefreshRate">
+          <property name="text">
+           <string>Sync to Host Refresh Rate</string>
+          </property>
+         </widget>
+        </item>
         <item row="0" column="0">
          <widget class="QCheckBox" name="optimalFramePacing">
           <property name="text">
@@ -268,10 +282,10 @@
           </property>
          </widget>
         </item>
-        <item row="0" column="1">
-         <widget class="QCheckBox" name="syncToHostRefreshRate">
+        <item row="1" column="0">
+         <widget class="QCheckBox" name="vsync">
           <property name="text">
-           <string>Scale To Host Refresh Rate</string>
+           <string>Vertical Sync (VSync)</string>
           </property>
          </widget>
         </item>
@@ -283,7 +297,7 @@
    <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -74,7 +74,6 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* dialog, QWidget* 
 	// Global Settings
 	//////////////////////////////////////////////////////////////////////////
 	SettingWidgetBinder::BindWidgetToStringSetting(sif, m_ui.adapter, "EmuCore/GS", "Adapter");
-	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.vsync, "EmuCore/GS", "VsyncEnable", 0);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.enableHWFixes, "EmuCore/GS", "UserHacks", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.spinGPUDuringReadbacks, "EmuCore/GS", "HWSpinGPUForReadbacks", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.spinCPUDuringReadbacks, "EmuCore/GS", "HWSpinCPUForReadbacks", false);
@@ -421,10 +420,6 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* dialog, QWidget* 
 
 		dialog->registerWidgetHelp(m_ui.PCRTCAntiBlur, tr("Anti-Blur"), tr("Checked"),
 			tr("Enables internal Anti-Blur hacks. Less accurate to PS2 rendering but will make a lot of games look less blurry."));
-
-		dialog->registerWidgetHelp(m_ui.vsync, tr("VSync"), tr("Unchecked"),
-			tr("Enable this option to match PCSX2's refresh rate with your current monitor or screen. VSync is automatically disabled when "
-			   "it is not possible (eg. running at non-100% speed)."));
 
 		dialog->registerWidgetHelp(m_ui.integerScaling, tr("Integer Scaling"), tr("Unchecked"),
 			tr("Adds padding to the display area to ensure that the ratio between pixels on the host to pixels in the console is an "

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
@@ -224,6 +224,75 @@
          </item>
         </widget>
        </item>
+       <item row="5" column="0">
+        <widget class="QLabel" name="label_21">
+         <property name="text">
+          <string>Screenshot Size:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="1">
+        <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="1,0,0,0">
+         <item>
+          <widget class="QComboBox" name="screenshotSize">
+           <item>
+            <property name="text">
+             <string>Window Resolution (Aspect Corrected)</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Internal Resolution (Aspect Corrected)</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Internal Resolution (No Aspect Correction)</string>
+            </property>
+           </item>
+          </widget>
+         </item>
+         <item>
+          <widget class="QComboBox" name="screenshotFormat">
+           <item>
+            <property name="text">
+             <string>PNG</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>JPEG</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>WebP</string>
+            </property>
+           </item>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="label_44">
+           <property name="text">
+            <string>Quality:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QSpinBox" name="screenshotQuality">
+           <property name="suffix">
+            <string>%</string>
+           </property>
+           <property name="minimum">
+            <number>1</number>
+           </property>
+           <property name="maximum">
+            <number>100</number>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
        <item row="6" column="0">
         <widget class="QLabel" name="label_24">
          <property name="text">
@@ -325,31 +394,10 @@
        </item>
        <item row="8" column="0" colspan="2">
         <layout class="QGridLayout" name="displayGridLayout">
-         <item row="3" column="0">
-          <widget class="QCheckBox" name="PCRTCOffsets">
-           <property name="text">
-            <string>Screen Offsets</string>
-           </property>
-          </widget>
-         </item>
          <item row="1" column="1">
           <widget class="QCheckBox" name="integerScaling">
            <property name="text">
             <string>Integer Scaling</string>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="0">
-          <widget class="QCheckBox" name="vsync">
-           <property name="text">
-            <string>VSync</string>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="1">
-          <widget class="QCheckBox" name="PCRTCOverscan">
-           <property name="text">
-            <string>Show Overscan</string>
            </property>
           </widget>
          </item>
@@ -384,72 +432,17 @@
            </property>
           </widget>
          </item>
-        </layout>
-       </item>
-       <item row="5" column="0">
-        <widget class="QLabel" name="label_21">
-         <property name="text">
-          <string>Screenshot Size:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="5" column="1">
-        <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="1,0,0,0">
-         <item>
-          <widget class="QComboBox" name="screenshotSize">
-           <item>
-            <property name="text">
-             <string>Window Resolution (Aspect Corrected)</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>Internal Resolution (Aspect Corrected)</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>Internal Resolution (No Aspect Correction)</string>
-            </property>
-           </item>
-          </widget>
-         </item>
-         <item>
-          <widget class="QComboBox" name="screenshotFormat">
-           <item>
-            <property name="text">
-             <string>PNG</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>JPEG</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>WebP</string>
-            </property>
-           </item>
-          </widget>
-         </item>
-         <item>
-          <widget class="QLabel" name="label_44">
+         <item row="2" column="0">
+          <widget class="QCheckBox" name="PCRTCOffsets">
            <property name="text">
-            <string>Quality:</string>
+            <string>Screen Offsets</string>
            </property>
           </widget>
          </item>
-         <item>
-          <widget class="QSpinBox" name="screenshotQuality">
-           <property name="suffix">
-            <string>%</string>
-           </property>
-           <property name="minimum">
-            <number>1</number>
-           </property>
-           <property name="maximum">
-            <number>100</number>
+         <item row="3" column="0">
+          <widget class="QCheckBox" name="PCRTCOverscan">
+           <property name="text">
+            <string>Show Overscan</string>
            </property>
           </widget>
          </item>
@@ -648,8 +641,8 @@
          </item>
          <item row="1" column="0">
           <widget class="QCheckBox" name="mipmapping">
-            <property name="text">
-             <string>Mipmapping</string>
+           <property name="text">
+            <string>Mipmapping</string>
            </property>
           </widget>
          </item>

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -247,6 +247,14 @@ enum class GSRendererType : s8
 	DX12 = 15,
 };
 
+enum class GSVSyncMode : u8
+{
+	Disabled,
+	FIFO,
+	Mailbox,
+	Count
+};
+
 enum class GSInterlaceMode : u8
 {
 	Automatic,
@@ -971,6 +979,7 @@ struct Pcsx2Config
 	{
 		BITFIELD32()
 		bool SyncToHostRefreshRate : 1;
+		bool UseVSyncForTiming : 1;
 		BITFIELD_END
 
 		float NominalScalar{1.0f};

--- a/pcsx2/GS/GS.h
+++ b/pcsx2/GS/GS.h
@@ -56,7 +56,8 @@ s16 GSLookupGetSkipCountFunctionId(const std::string_view name);
 s16 GSLookupBeforeDrawFunctionId(const std::string_view name);
 s16 GSLookupMoveHandlerFunctionId(const std::string_view name);
 
-bool GSopen(const Pcsx2Config::GSOptions& config, GSRendererType renderer, u8* basemem);
+bool GSopen(const Pcsx2Config::GSOptions& config, GSRendererType renderer, u8* basemem,
+	GSVSyncMode vsync_mode, bool allow_present_throttle);
 bool GSreopen(bool recreate_device, bool recreate_renderer, GSRendererType new_renderer,
 	std::optional<const Pcsx2Config::GSOptions*> old_config);
 void GSreset(bool hardware_reset);
@@ -84,12 +85,12 @@ void GSSetDisplayAlignment(GSDisplayAlignment alignment);
 bool GSHasDisplayWindow();
 void GSResizeDisplayWindow(int width, int height, float scale);
 void GSUpdateDisplayWindow();
-void GSSetVSyncEnabled(bool enabled);
+void GSSetVSyncMode(GSVSyncMode mode, bool allow_present_throttle);
 
 GSRendererType GSGetCurrentRenderer();
 bool GSIsHardwareRenderer();
 bool GSWantsExclusiveFullscreen();
-bool GSGetHostRefreshRate(float* refresh_rate);
+std::optional<float> GSGetHostRefreshRate();
 void GSGetAdaptersAndFullscreenModes(
 	GSRendererType renderer, std::vector<std::string>* adapters, std::vector<std::string>* fullscreen_modes);
 GSVideoMode GSgetDisplayMode();
@@ -125,9 +126,6 @@ namespace Host
 
 	/// Alters fullscreen state of hosting application.
 	void SetFullscreen(bool enabled);
-
-	/// Returns the desired vsync mode, depending on the runtime environment.
-	bool IsVsyncEffectivelyEnabled();
 
 	/// Called when video capture starts or stops. Called on the MTGS thread.
 	void OnCaptureStarted(const std::string& filename);

--- a/pcsx2/GS/GSCapture.cpp
+++ b/pcsx2/GS/GSCapture.cpp
@@ -971,7 +971,7 @@ void GSCapture::StopEncoderThread(std::unique_lock<std::mutex>& lock)
 
 bool GSCapture::SendFrame(const PendingFrame& pf)
 {
-	const AVPixelFormat source_format = g_gs_device->IsRBSwapped() ? AV_PIX_FMT_BGRA : AV_PIX_FMT_RGBA;
+	const AVPixelFormat source_format = AV_PIX_FMT_RGBA;
 	const u8* source_ptr = pf.tex->GetMapPointer();
 	const int source_width = static_cast<int>(pf.tex->GetWidth());
 	const int source_height = static_cast<int>(pf.tex->GetHeight());

--- a/pcsx2/GS/Renderers/Common/GSRenderer.cpp
+++ b/pcsx2/GS/Renderers/Common/GSRenderer.cpp
@@ -580,12 +580,13 @@ void GSRenderer::VSync(u32 field, bool registers_written, bool idle_frame)
 	m_last_draw_n = s_n;
 	m_last_transfer_n = s_transfer_n;
 
-	if (skip_frame)
+	// Skip presentation when running uncapped while vsync is on.
+	if (skip_frame || g_gs_device->ShouldSkipPresentingFrame())
 	{
 		if (BeginPresentFrame(true))
 			EndPresentFrame();
 
-		PerformanceMetrics::Update(registers_written, fb_sprite_frame, true);
+		PerformanceMetrics::Update(registers_written, fb_sprite_frame, skip_frame);
 		return;
 	}
 

--- a/pcsx2/GS/Renderers/Common/GSTexture.cpp
+++ b/pcsx2/GS/Renderers/Common/GSTexture.cpp
@@ -61,7 +61,7 @@ bool GSTexture::Save(const std::string& fn)
 	}
 
 	const int compression = GSConfig.PNGCompressionLevel;
-	return GSPng::Save(format, fn, dl->GetMapPointer(), m_size.x, m_size.y, dl->GetMapPitch(), compression, g_gs_device->IsRBSwapped());
+	return GSPng::Save(format, fn, dl->GetMapPointer(), m_size.x, m_size.y, dl->GetMapPitch(), compression, false);
 }
 
 const char* GSTexture::GetFormatName(Format format)

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.h
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.h
@@ -93,6 +93,7 @@ private:
 	void SetFeatures(IDXGIAdapter1* adapter);
 	int GetMaxTextureSize() const;
 
+	u32 GetSwapChainBufferCount() const;
 	bool CreateSwapChain();
 	bool CreateSwapChainRTV();
 	void DestroySwapChain();
@@ -259,7 +260,7 @@ public:
 	__fi ID3D11Device1* GetD3DDevice() const { return m_dev.get(); }
 	__fi ID3D11DeviceContext1* GetD3DContext() const { return m_ctx.get(); }
 
-	bool Create() override;
+	bool Create(GSVSyncMode vsync_mode, bool allow_present_throttle) override;
 	void Destroy() override;
 
 	RenderAPI GetRenderAPI() const override;
@@ -271,9 +272,7 @@ public:
 	void DestroySurface() override;
 	std::string GetDriverInfo() const override;
 
-	bool GetHostRefreshRate(float* refresh_rate) override;
-
-	void SetVSyncEnabled(bool enabled) override;
+	void SetVSyncMode(GSVSyncMode mode, bool allow_present_throttle) override;
 
 	PresentResult BeginPresent(bool frame_skip) override;
 	void EndPresent() override;

--- a/pcsx2/GS/Renderers/DX12/GSDevice12.h
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.h
@@ -341,6 +341,7 @@ private:
 	void LookupNativeFormat(GSTexture::Format format, DXGI_FORMAT* d3d_format, DXGI_FORMAT* srv_format,
 		DXGI_FORMAT* rtv_format, DXGI_FORMAT* dsv_format) const;
 
+	u32 GetSwapChainBufferCount() const;
 	bool CreateSwapChain();
 	bool CreateSwapChainRTV();
 	void DestroySwapChainRTVs();
@@ -398,7 +399,7 @@ public:
 	RenderAPI GetRenderAPI() const override;
 	bool HasSurface() const override;
 
-	bool Create() override;
+	bool Create(GSVSyncMode vsync_mode, bool allow_present_throttle) override;
 	void Destroy() override;
 
 	bool UpdateWindow() override;
@@ -407,9 +408,7 @@ public:
 	void DestroySurface() override;
 	std::string GetDriverInfo() const override;
 
-	bool GetHostRefreshRate(float* refresh_rate) override;
-
-	void SetVSyncEnabled(bool enabled) override;
+	void SetVSyncMode(GSVSyncMode mode, bool allow_present_throttle) override;
 
 	PresentResult BeginPresent(bool frame_skip) override;
 	void EndPresent() override;

--- a/pcsx2/GS/Renderers/Metal/GSDeviceMTL.h
+++ b/pcsx2/GS/Renderers/Metal/GSDeviceMTL.h
@@ -373,7 +373,7 @@ public:
 	MRCOwned<id<MTLFunction>> LoadShader(NSString* name);
 	MRCOwned<id<MTLRenderPipelineState>> MakePipeline(MTLRenderPipelineDescriptor* desc, id<MTLFunction> vertex, id<MTLFunction> fragment, NSString* name);
 	MRCOwned<id<MTLComputePipelineState>> MakeComputePipeline(id<MTLFunction> compute, NSString* name);
-	bool Create() override;
+	bool Create(GSVSyncMode vsync_mode, bool allow_present_throttle) override;
 	void Destroy() override;
 
 	void AttachSurfaceOnMainThread();
@@ -392,9 +392,7 @@ public:
 
 	PresentResult BeginPresent(bool frame_skip) override;
 	void EndPresent() override;
-	void SetVSyncEnabled(bool enabled) override;
-
-	bool GetHostRefreshRate(float* refresh_rate) override;
+	void SetVSyncMode(GSVSyncMode mode, bool allow_present_throttle) override;
 
 	bool SetGPUTimingEnabled(bool enabled) override;
 	float GetAndResetAccumulatedGPUTime() override;

--- a/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
+++ b/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
@@ -822,9 +822,9 @@ static MRCOwned<id<MTLSamplerState>> CreateSampler(id<MTLDevice> dev, GSHWDrawCo
 	return ret;
 }
 
-bool GSDeviceMTL::Create()
+bool GSDeviceMTL::Create(GSVSyncMode vsync_mode, bool allow_present_throttle)
 { @autoreleasepool {
-	if (!GSDevice::Create())
+	if (!GSDevice::Create(vsync_mode, allow_present_throttle))
 		return false;
 
 	NSString* ns_adapter_name = [NSString stringWithUTF8String:GSConfig.Adapter.c_str()];
@@ -877,7 +877,10 @@ bool GSDeviceMTL::Create()
 		{
 			AttachSurfaceOnMainThread();
 		});
-		[m_layer setDisplaySyncEnabled:m_vsync_enabled];
+
+		// Metal does not support mailbox.
+		m_vsync_mode = (m_vsync_mode == GSVSyncMode::Mailbox) ? GSVSyncMode::FIFO : m_vsync_mode;
+		[m_layer setDisplaySyncEnabled:m_vsync_mode == GSVSyncMode::FIFO];
 	}
 	else
 	{
@@ -1305,7 +1308,7 @@ void GSDeviceMTL::EndPresent()
 	if (m_current_drawable)
 	{
 		const bool use_present_drawable = m_use_present_drawable == UsePresentDrawable::Always ||
-			(m_use_present_drawable == UsePresentDrawable::IfVsync && m_vsync_enabled);
+			(m_use_present_drawable == UsePresentDrawable::IfVsync && m_vsync_mode == GSVSyncMode::FIFO);
 
 		if (use_present_drawable)
 			[m_current_render_cmdbuf presentDrawable:m_current_drawable];
@@ -1367,31 +1370,15 @@ void GSDeviceMTL::EndPresent()
 	}
 }}
 
-void GSDeviceMTL::SetVSyncEnabled(bool enabled)
+void GSDeviceMTL::SetVSyncMode(GSVSyncMode mode, bool allow_present_throttle)
 {
-	if (m_vsync_enabled == enabled)
+	m_allow_present_throttle = allow_present_throttle;
+
+	if (m_vsync_mode == mode)
 		return;
 
-	[m_layer setDisplaySyncEnabled:enabled];
-	m_vsync_enabled = enabled;
-}
-
-bool GSDeviceMTL::GetHostRefreshRate(float* refresh_rate)
-{
-	OnMainThread([this, refresh_rate]
-	{
-		u32 did = [[[[[m_view window] screen] deviceDescription] valueForKey:@"NSScreenNumber"] unsignedIntValue];
-		if (CGDisplayModeRef mode = CGDisplayCopyDisplayMode(did))
-		{
-			*refresh_rate = CGDisplayModeGetRefreshRate(mode);
-			CGDisplayModeRelease(mode);
-		}
-		else
-		{
-			*refresh_rate = 0;
-		}
-	});
-	return *refresh_rate != 0;
+	m_vsync_mode = (mode == GSVSyncMode::Mailbox) ? GSVSyncMode::FIFO : mode;
+	[m_layer setDisplaySyncEnabled:m_vsync_mode == GSVSyncMode::FIFO];
 }
 
 bool GSDeviceMTL::SetGPUTimingEnabled(bool enabled)

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.h
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.h
@@ -283,7 +283,7 @@ public:
 	RenderAPI GetRenderAPI() const override;
 	bool HasSurface() const override;
 
-	bool Create() override;
+	bool Create(GSVSyncMode vsync_mode, bool allow_present_throttle) override;
 	void Destroy() override;
 
 	bool UpdateWindow() override;
@@ -292,7 +292,7 @@ public:
 	void DestroySurface() override;
 	std::string GetDriverInfo() const override;
 
-	void SetVSyncEnabled(bool enabled) override;
+	void SetVSyncMode(GSVSyncMode mode, bool allow_present_throttle) override;
 
 	PresentResult BeginPresent(bool frame_skip) override;
 	void EndPresent() override;

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h
@@ -515,7 +515,7 @@ public:
 	RenderAPI GetRenderAPI() const override;
 	bool HasSurface() const override;
 
-	bool Create() override;
+	bool Create(GSVSyncMode vsync_mode, bool allow_present_throttle) override;
 	void Destroy() override;
 
 	bool UpdateWindow() override;
@@ -524,7 +524,7 @@ public:
 	void DestroySurface() override;
 	std::string GetDriverInfo() const override;
 
-	void SetVSyncEnabled(bool enabled) override;
+	void SetVSyncMode(GSVSyncMode mode, bool allow_present_throttle) override;
 
 	PresentResult BeginPresent(bool frame_skip) override;
 	void EndPresent() override;

--- a/pcsx2/GS/Renderers/Vulkan/VKSwapChain.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/VKSwapChain.cpp
@@ -18,12 +18,12 @@
 #include <X11/Xlib.h>
 #endif
 
-VKSwapChain::VKSwapChain(
-	const WindowInfo& wi, VkSurfaceKHR surface, bool vsync, std::optional<bool> exclusive_fullscreen_control)
+VKSwapChain::VKSwapChain(const WindowInfo& wi, VkSurfaceKHR surface, VkPresentModeKHR present_mode,
+	std::optional<bool> exclusive_fullscreen_control)
 	: m_window_info(wi)
 	, m_surface(surface)
+	, m_present_mode(present_mode)
 	, m_exclusive_fullscreen_control(exclusive_fullscreen_control)
-	, m_vsync_enabled(vsync)
 {
 }
 
@@ -135,11 +135,11 @@ void VKSwapChain::DestroyVulkanSurface(VkInstance instance, WindowInfo* wi, VkSu
 #endif
 }
 
-std::unique_ptr<VKSwapChain> VKSwapChain::Create(
-	const WindowInfo& wi, VkSurfaceKHR surface, bool vsync, std::optional<bool> exclusive_fullscreen_control)
+std::unique_ptr<VKSwapChain> VKSwapChain::Create(const WindowInfo& wi, VkSurfaceKHR surface,
+	VkPresentModeKHR present_mode, std::optional<bool> exclusive_fullscreen_control)
 {
 	std::unique_ptr<VKSwapChain> swap_chain =
-		std::unique_ptr<VKSwapChain>(new VKSwapChain(wi, surface, vsync, exclusive_fullscreen_control));
+		std::unique_ptr<VKSwapChain>(new VKSwapChain(wi, surface, present_mode, exclusive_fullscreen_control));
 	if (!swap_chain->CreateSwapChain())
 		return nullptr;
 
@@ -227,7 +227,7 @@ static const char* PresentModeToString(VkPresentModeKHR mode)
 	}
 }
 
-std::optional<VkPresentModeKHR> VKSwapChain::SelectPresentMode(VkSurfaceKHR surface, VkPresentModeKHR requested_mode)
+bool VKSwapChain::SelectPresentMode(VkSurfaceKHR surface, GSVSyncMode* vsync_mode, VkPresentModeKHR* present_mode)
 {
 	VkResult res;
 	u32 mode_count;
@@ -236,7 +236,7 @@ std::optional<VkPresentModeKHR> VKSwapChain::SelectPresentMode(VkSurfaceKHR surf
 	if (res != VK_SUCCESS || mode_count == 0)
 	{
 		LOG_VULKAN_ERROR(res, "vkGetPhysicalDeviceSurfaceFormatsKHR failed: ");
-		return std::nullopt;
+		return false;
 	}
 
 	std::vector<VkPresentModeKHR> present_modes(mode_count);
@@ -245,48 +245,70 @@ std::optional<VkPresentModeKHR> VKSwapChain::SelectPresentMode(VkSurfaceKHR surf
 	pxAssert(res == VK_SUCCESS);
 
 	// Checks if a particular mode is supported, if it is, returns that mode.
-	auto CheckForMode = [&present_modes](VkPresentModeKHR check_mode) {
+	const auto CheckForMode = [&present_modes](VkPresentModeKHR check_mode) {
 		auto it = std::find_if(present_modes.begin(), present_modes.end(),
 			[check_mode](VkPresentModeKHR mode) { return check_mode == mode; });
 		return it != present_modes.end();
 	};
 
-	// Use preferred mode if available.
-	VkPresentModeKHR selected_mode;
-	if (CheckForMode(requested_mode))
+	switch (*vsync_mode)
 	{
-		selected_mode = requested_mode;
-	}
-	else if (requested_mode == VK_PRESENT_MODE_IMMEDIATE_KHR && CheckForMode(VK_PRESENT_MODE_MAILBOX_KHR))
-	{
-		// Prefer mailbox over FIFO for vsync-off, since we don't want to block.
-		selected_mode = VK_PRESENT_MODE_MAILBOX_KHR;
-	}
-	else
-	{
-		// Fallback to FIFO if we we can't use mailbox. This should never fail, FIFO is mandated.
-		selected_mode = VK_PRESENT_MODE_FIFO_KHR;
+		case GSVSyncMode::Disabled:
+		{
+			// Prefer immediate > mailbox > fifo.
+			if (CheckForMode(VK_PRESENT_MODE_IMMEDIATE_KHR))
+			{
+				*present_mode = VK_PRESENT_MODE_IMMEDIATE_KHR;
+			}
+			else if (CheckForMode(VK_PRESENT_MODE_MAILBOX_KHR))
+			{
+				WARNING_LOG("Immediate not supported for vsync-disabled, using mailbox.");
+				*present_mode = VK_PRESENT_MODE_MAILBOX_KHR;
+				*vsync_mode = GSVSyncMode::Mailbox;
+			}
+			else
+			{
+				WARNING_LOG("Mailbox not supported for vsync-disabled, using FIFO.");
+				*present_mode = VK_PRESENT_MODE_FIFO_KHR;
+				*vsync_mode = GSVSyncMode::FIFO;
+			}
+		}
+		break;
+
+		case GSVSyncMode::FIFO:
+		{
+			// FIFO is always available.
+			*present_mode = VK_PRESENT_MODE_FIFO_KHR;
+		}
+		break;
+
+		case GSVSyncMode::Mailbox:
+		{
+			// Mailbox > fifo.
+			if (CheckForMode(VK_PRESENT_MODE_MAILBOX_KHR))
+			{
+				*present_mode = VK_PRESENT_MODE_MAILBOX_KHR;
+			}
+			else
+			{
+				WARNING_LOG("Mailbox not supported for vsync-mailbox, using FIFO.");
+				*present_mode = VK_PRESENT_MODE_FIFO_KHR;
+				*vsync_mode = GSVSyncMode::FIFO;
+			}
+		}
+		break;
+
+			jNO_DEFAULT
 	}
 
-	DevCon.WriteLn("(SwapChain) Preferred present mode: %s, selected: %s", PresentModeToString(requested_mode),
-		PresentModeToString(selected_mode));
-
-	return selected_mode;
+	return true;
 }
 
 bool VKSwapChain::CreateSwapChain()
 {
-	// Select swap chain format and present mode
+	// Select swap chain format
 	std::optional<VkSurfaceFormatKHR> surface_format = SelectSurfaceFormat(m_surface);
-
-	// Prefer mailbox if not syncing to host refresh, because that requires "real" vsync.
-	const VkPresentModeKHR requested_mode =
-		m_vsync_enabled ? (VMManager::IsUsingVSyncForTiming() ?
-								  VK_PRESENT_MODE_FIFO_KHR :
-								  VK_PRESENT_MODE_MAILBOX_KHR) :
-						  VK_PRESENT_MODE_IMMEDIATE_KHR;
-	std::optional<VkPresentModeKHR> present_mode = SelectPresentMode(m_surface, requested_mode);
-	if (!surface_format.has_value() || !present_mode.has_value())
+	if (!surface_format.has_value())
 		return false;
 
 	// Look up surface properties to determine image count and dimensions
@@ -299,12 +321,12 @@ bool VKSwapChain::CreateSwapChain()
 		return false;
 	}
 
-	// Select number of images in swap chain, we prefer one buffer in the background to work on
-	u32 image_count = std::max(surface_capabilities.minImageCount + 1u, 2u);
-
+	// Select number of images in swap chain, we prefer one buffer in the background to work on in triple-buffered mode.
 	// maxImageCount can be zero, in which case there isn't an upper limit on the number of buffers.
-	if (surface_capabilities.maxImageCount > 0)
-		image_count = std::min(image_count, surface_capabilities.maxImageCount);
+	u32 image_count = std::clamp<u32>(
+		(m_present_mode == VK_PRESENT_MODE_MAILBOX_KHR) ? 3 : 2, surface_capabilities.minImageCount,
+		(surface_capabilities.maxImageCount == 0) ? std::numeric_limits<u32>::max() : surface_capabilities.maxImageCount);
+	DEV_LOG("Creating a swap chain with {} images in present mode {}", image_count, PresentModeToString(m_present_mode));
 
 	// Determine the dimensions of the swap chain. Values of -1 indicate the size we specify here
 	// determines window size?
@@ -348,7 +370,7 @@ bool VKSwapChain::CreateSwapChain()
 	// Now we can actually create the swap chain
 	VkSwapchainCreateInfoKHR swap_chain_info = {VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR, nullptr, 0, m_surface,
 		image_count, surface_format->format, surface_format->colorSpace, size, 1u, image_usage,
-		VK_SHARING_MODE_EXCLUSIVE, 0, nullptr, transform, alpha, present_mode.value(), VK_TRUE, old_swap_chain};
+		VK_SHARING_MODE_EXCLUSIVE, 0, nullptr, transform, alpha, m_present_mode, VK_TRUE, old_swap_chain};
 	std::array<uint32_t, 2> indices = {{
 		GSDeviceVK::GetInstance()->GetGraphicsQueueFamilyIndex(),
 		GSDeviceVK::GetInstance()->GetPresentQueueFamilyIndex(),
@@ -405,7 +427,6 @@ bool VKSwapChain::CreateSwapChain()
 
 	m_window_info.surface_width = std::max(1u, size.width);
 	m_window_info.surface_height = std::max(1u, size.height);
-	m_actual_present_mode = present_mode.value();
 
 	// Get and create images.
 	pxAssert(m_images.empty());
@@ -550,15 +571,15 @@ bool VKSwapChain::ResizeSwapChain(u32 new_width, u32 new_height, float new_scale
 	return true;
 }
 
-bool VKSwapChain::SetVSyncEnabled(bool enabled)
+bool VKSwapChain::SetPresentMode(VkPresentModeKHR present_mode)
 {
-	if (m_vsync_enabled == enabled)
+	if (m_present_mode == present_mode)
 		return true;
 
-	m_vsync_enabled = enabled;
+	m_present_mode = present_mode;
 
 	// Recreate the swap chain with the new present mode.
-	DevCon.WriteLn("Recreating swap chain to change present mode.");
+	INFO_LOG("Recreating swap chain to change present mode.");
 	DestroySwapChainImages();
 	if (!CreateSwapChain())
 	{

--- a/pcsx2/GS/Renderers/Vulkan/VKSwapChain.h
+++ b/pcsx2/GS/Renderers/Vulkan/VKSwapChain.h
@@ -8,6 +8,7 @@
 
 #include "common/WindowInfo.h"
 
+#include <array>
 #include <memory>
 #include <optional>
 #include <vector>
@@ -15,6 +16,11 @@
 class VKSwapChain
 {
 public:
+	// We don't actually need +1 semaphores, or, more than one really.
+	// But, the validation layer gets cranky if we don't fence wait before the next image acquire.
+	// So, add an additional semaphore to ensure that we're never acquiring before fence waiting.
+	static constexpr u32 NUM_SEMAPHORES = 4; // Should be command buffers + 1
+
 	~VKSwapChain();
 
 	// Creates a vulkan-renderable surface for the specified window handle.
@@ -81,8 +87,6 @@ private:
 
 	bool CreateSwapChain();
 	void DestroySwapChain();
-
-	bool SetupSwapChainImages(VkFormat image_format);
 	void DestroySwapChainImages();
 
 	void DestroySurface();
@@ -99,7 +103,7 @@ private:
 	VkSwapchainKHR m_swap_chain = VK_NULL_HANDLE;
 
 	std::vector<std::unique_ptr<GSTextureVK>> m_images;
-	std::vector<ImageSemaphores> m_semaphores;
+	std::array<ImageSemaphores, NUM_SEMAPHORES> m_semaphores = {};
 
 	u32 m_current_image = 0;
 	u32 m_current_semaphore = 0;

--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -3345,8 +3345,15 @@ void FullscreenUI::DrawEmulationSettingsPage()
 		SetSettingsChanged(bsi);
 	}
 
-	DrawToggleSetting(bsi, FSUI_CSTR("Scale To Host Refresh Rate"),
+	DrawToggleSetting(bsi, FSUI_CSTR("Vertical Sync (VSync)"), FSUI_CSTR("Synchronizes frame presentation with host refresh."),
+		"EmuCore/GS", "VsyncEnable", false);
+
+	DrawToggleSetting(bsi, FSUI_CSTR("Sync to Host Refresh Rate"),
 		FSUI_CSTR("Speeds up emulation so that the guest refresh rate matches the host."), "EmuCore/GS", "SyncToHostRefreshRate", false);
+
+	DrawToggleSetting(bsi, FSUI_CSTR("Use Host VSync Timing"),
+		FSUI_CSTR("Disables PCSX2's internal frame timing, and uses host vsync instead."), "EmuCore/GS", "UseVSyncForTiming", false,
+		GetEffectiveBoolSetting(bsi, "EmuCore/GS", "VsyncEnable", false) && GetEffectiveBoolSetting(bsi, "EmuCore/GS", "SyncToHostRefreshRate", false));
 
 	EndMenuButtons();
 }
@@ -3597,8 +3604,6 @@ void FullscreenUI::DrawGraphicsSettingsPage(SettingsInterface* bsi, bool show_ad
 	MenuHeading(FSUI_CSTR("Renderer"));
 	DrawStringListSetting(bsi, FSUI_CSTR("Renderer"), FSUI_CSTR("Selects the API used to render the emulated GS."), "EmuCore/GS",
 		"Renderer", "-1", s_renderer_names, s_renderer_values, std::size(s_renderer_names), true);
-	DrawToggleSetting(bsi, FSUI_CSTR("Sync To Host Refresh (VSync)"), FSUI_CSTR("Synchronizes frame presentation with host refresh."),
-		"EmuCore/GS", "VsyncEnable", false);
 
 	MenuHeading(FSUI_CSTR("Display"));
 	DrawStringListSetting(bsi, FSUI_CSTR("Aspect Ratio"), FSUI_CSTR("Selects the aspect ratio to display the game content at."),

--- a/pcsx2/ImGui/ImGuiOverlays.cpp
+++ b/pcsx2/ImGui/ImGuiOverlays.cpp
@@ -190,8 +190,10 @@ __ri void ImGuiManager::DrawPerformanceOverlay(float& position_y, float scale, f
 		if (GSConfig.OsdShowCPU)
 		{
 			text.clear();
-			text.append_format("{:.2f}ms | {:.2f}ms | {:.2f}ms", PerformanceMetrics::GetMinimumFrameTime(),
-				PerformanceMetrics::GetAverageFrameTime(), PerformanceMetrics::GetMaximumFrameTime());
+			text.append_format("{} QF | {:.2f}ms | {:.2f}ms | {:.2f}ms",
+				MTGS::GetCurrentVsyncQueueSize() - 1, // we subtract one for the current frame
+				PerformanceMetrics::GetMinimumFrameTime(), PerformanceMetrics::GetAverageFrameTime(),
+				PerformanceMetrics::GetMaximumFrameTime());
 			DRAW_LINE(fixed_font, text.c_str(), IM_COL32(255, 255, 255, 255));
 
 			text.clear();

--- a/pcsx2/MTGS.cpp
+++ b/pcsx2/MTGS.cpp
@@ -213,6 +213,11 @@ void MTGS::ResetGS(bool hardware_reset)
 		SetEvent();
 }
 
+int MTGS::GetCurrentVsyncQueueSize()
+{
+	return s_QueuedFrameCount.load(std::memory_order_acquire);
+}
+
 struct RingCmdPacket_Vsync
 {
 	u8 regset1[0x0f0];

--- a/pcsx2/MTGS.h
+++ b/pcsx2/MTGS.h
@@ -62,6 +62,7 @@ namespace MTGS
 	void WaitForClose();
 	void Freeze(FreezeAction mode, FreezeData& data);
 
+	int GetCurrentVsyncQueueSize();
 	void PostVsyncStart(bool registers_written);
 	void InitAndReadFIFO(u8* mem, u32 qwc);
 

--- a/pcsx2/MTGS.h
+++ b/pcsx2/MTGS.h
@@ -71,8 +71,8 @@ namespace MTGS
 	void ApplySettings();
 	void ResizeDisplayWindow(int width, int height, float scale);
 	void UpdateDisplayWindow();
-	void SetVSyncEnabled(bool enabled);
-	void UpdateVSyncEnabled();
+	void SetVSyncMode(GSVSyncMode mode, bool allow_present_throttle);
+	void UpdateVSyncMode();
 	void SetSoftwareRendering(bool software, GSInterlaceMode interlace, bool display_message = true);
 	void ToggleSoftwareRendering();
 	bool SaveMemorySnapshot(u32 window_width, u32 window_height, bool apply_aspect, bool crop_borders,

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -1494,6 +1494,7 @@ void Pcsx2Config::EmulationSpeedOptions::LoadSave(SettingsWrapper& wrap)
 	// This was in the wrong place... but we can't change it without breaking existing configs.
 	//SettingsWrapBitBool(SyncToHostRefreshRate);
 	SyncToHostRefreshRate = wrap.EntryBitBool("EmuCore/GS", "SyncToHostRefreshRate", SyncToHostRefreshRate, SyncToHostRefreshRate);
+	UseVSyncForTiming = wrap.EntryBitBool("EmuCore/GS", "UseVSyncForTiming", UseVSyncForTiming, UseVSyncForTiming);
 }
 
 bool Pcsx2Config::EmulationSpeedOptions::operator==(const EmulationSpeedOptions& right) const

--- a/pcsx2/VMManager.h
+++ b/pcsx2/VMManager.h
@@ -159,11 +159,14 @@ namespace VMManager
 	/// Returns true if the target speed is being synchronized with the host's refresh rate.
 	bool IsTargetSpeedAdjustedToHost();
 
-	/// Returns true if host vsync is being used for frame timing/pacing, and not its internal throttler.
-	bool IsUsingVSyncForTiming();
-
 	/// Returns the current frame rate of the virtual machine.
 	float GetFrameRate();
+
+	/// Returns the desired vsync mode, depending on the runtime environment.
+	GSVSyncMode GetEffectiveVSyncMode();
+
+	/// Returns true if presents can be skipped, when running outside of normal speed.
+	bool ShouldAllowPresentThrottle();
 
 	/// Runs the virtual machine for the specified number of video frames, and then automatically pauses.
 	void FrameAdvance(u32 num_frames = 1);


### PR DESCRIPTION
### Description of Changes

All games use mailbox/triple buffering. Except when you enable sync to host refresh, in which case FIFO/double buffering is used.

This means vsync enabled will ever tear, but at the same time, never drop to 30fps on a missed frame due to frame rate differences. Unless you're using OpenGL, because that doesn't support triple buffering, in which case, too bad.

To have the "best of both worlds", you should enable vsync and sync to host refresh. Previously, this resulted in additional input lag, since the host vsync would drive the EE frame timing. Now, this behaviour is disabled by default, unless you enable "Use Host VSync Timing".

### Rationale behind Changes

Trying to make both stutter-wanters and tear-wanters happy.

### Suggested Testing Steps

Hammer vsync options.
