### PR TITLE
CMake: Force /usr/local/include to come last

### DIFF
--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -1209,6 +1209,10 @@ if (NOT APPLE)
 endif()
 
 fixup_file_properties(PCSX2)
+# Directories like /usr/local/include, /opt/local/include, etc tend to include lots of headers from lots of libraries.
+# Possibly including libraries that we compiled versions of with the dependency build script.
+# To ensure the dependency build script's headers are preferred, push any directories that look like */local/include to the end.
+force_include_last(PCSX2_FLAGS "/(usr|local)/include/?$")
 
 if (APPLE)
 	find_library(METAL_LIBRARY Metal)


### PR DESCRIPTION
### Description of Changes
Not a huge fan of this solution, but it was the best I could think of.  If anyone has a better solution please say so.
Fixes the issue mentioned in #11287, as well as building on macOS with homebrew ffmpeg (that you want) and a homebrew-installed shaderc that you don't want.

There's actually two parts to the problem:
1. The `deps` directory gets marked as a system include by one of the packages in it
2. `/usr/local/include` does not (at least if the only thing in it is ffmpeg)
3. ffmpeg is ordered before everything else when we set up PCSX2_FLAGS, so even if both are marked system, `/usr/local/include` ends up coming first.

So this patch adds a function that both marks matching include directories as system, and puts the dependencies that contain them at the end of the list.  ~~It can only reorder dependencies at the same depth (e.g. if a depends on b and c, b depends on d, and c depends on e, the only possible orders would be a b d c e or a c e b d), but it should work for our current set of externally-imported libraries.~~

### Rationale behind Changes
Less broken compilation

### Suggested Testing Steps
@TheLastRar please test freebsd