### PR TITLE
UI: Fix dithering description + make it so 4 lines of description fits

### DIFF
--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -485,8 +485,9 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* dialog, QWidget* 
 		dialog->registerWidgetHelp(m_ui.dithering, tr("Dithering"), tr("Unscaled (Default)"),
 			tr("Reduces banding between colors and improves the perceived color depth.<br> "
 			   "Off: Disables any dithering.<br> "
+			   "Scaled: Upscaling-aware / Highest dithering effect.<br> "
 			   "Unscaled: Native Dithering / Lowest dithering effect does not increase size of squares when upscaling.<br> "
-			   "Scaled: Upscaling-aware / Highest dithering effect."));
+			   "Force 32bit: Treat all draws as if they were 32bit to avoid banding and dithering."));
 
 		dialog->registerWidgetHelp(m_ui.blending, tr("Blending Accuracy"), tr("Basic (Recommended)"),
 			tr("Control the accuracy level of the GS blending unit emulation.<br> "

--- a/pcsx2-qt/Settings/SettingsWindow.ui
+++ b/pcsx2-qt/Settings/SettingsWindow.ui
@@ -2,11 +2,6 @@
 <ui version="4.0">
  <class>SettingsWindow</class>
  <widget class="QWidget" name="SettingsWindow">
-  <property name="windowIcon">
-   <iconset>
-    <normalon>:/icons/AppIcon64.png</normalon>
-   </iconset>
-  </property>
   <property name="geometry">
    <rect>
     <x>0</x>
@@ -23,6 +18,11 @@
   </property>
   <property name="windowTitle">
    <string>PCSX2 Settings</string>
+  </property>
+  <property name="windowIcon">
+   <iconset>
+    <normalon>:/icons/AppIcon64.png</normalon>
+   </iconset>
   </property>
   <layout class="QGridLayout" name="gridLayout" columnstretch="0,1">
    <item row="0" column="0">
@@ -68,13 +68,13 @@
      <property name="minimumSize">
       <size>
        <width>0</width>
-       <height>120</height>
+       <height>122</height>
       </size>
      </property>
      <property name="maximumSize">
       <size>
        <width>16777215</width>
-       <height>120</height>
+       <height>122</height>
       </size>
      </property>
      <property name="readOnly">


### PR DESCRIPTION
### Description of Changes
Fixes description content for dithering, and resizes the box so 4 lines actually fits without a scroll bar.

### Rationale behind Changes
Wrong descriptions are gross, scroll bars are gross. Gross.

### Suggested Testing Steps
Quickly check the dithering description in the settings make sure all is fine and dandy
