### PR TITLE
GS: Remove MSVC macro hack and use MSVC's new preprocessor

### DIFF
--- a/cmake/BuildParameters.cmake
+++ b/cmake/BuildParameters.cmake
@@ -112,6 +112,7 @@ if(MSVC AND NOT USE_CLANG_CL)
 		"$<$<COMPILE_LANGUAGE:CXX>:/Zc:externConstexpr>"
 		"$<$<COMPILE_LANGUAGE:CXX>:/Zc:__cplusplus>"
 		"$<$<COMPILE_LANGUAGE:CXX>:/permissive->"
+		"$<$<COMPILE_LANGUAGE:CXX>:/Zc:preprocessor>"
 		"/Zo"
 		"/utf-8"
 	)

--- a/common/vsprops/common.props
+++ b/common/vsprops/common.props
@@ -43,6 +43,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <MinimalRebuild>false</MinimalRebuild>
       <ConformanceMode>true</ConformanceMode>
+      <UseStandardPreprocessor>true</UseStandardPreprocessor>
 
       <!-- SH 2/3 flashlight, explicitly set here don't change -->
       <!-- https://github.com/PCSX2/pcsx2/commit/16431653e4d92fda4069031897e24fbe4688d36a -->

--- a/pcsx2/GS/Renderers/SW/GSNewCodeGenerator.h
+++ b/pcsx2/GS/Renderers/SW/GSNewCodeGenerator.h
@@ -91,10 +91,6 @@ public:
 // ACTUAL_FORWARD_*: Actually forward the function of the given type
 // FORWARD#: First validates the arguments (e.g. make sure you're not passing registers over 7 on x86), then forwards to an ACTUAL_FORWARD_*
 
-// Big thanks to https://stackoverflow.com/a/24028231 for helping me figure out how to work around MSVC's terrible macro expander
-// Of course GCC/Clang don't like the workaround so enjoy the ifdefs
-#define EXPAND_ARGS(macro, args) macro args
-
 #define ACTUAL_FORWARD_BASE(name, ...) \
 	actual.name(__VA_ARGS__);
 
@@ -152,15 +148,9 @@ public:
 		ACTUAL_FORWARD_##category(name, a, b, c, d) \
 	}
 
-#if defined(__GNUC__) || (defined(_MSC_VER) && defined(__clang__))
-	#define FORWARD_(argcount, ...) FORWARD##argcount(__VA_ARGS__)
-	// Gets the macro evaluator to evaluate in the right order
-	#define FORWARD(...) FORWARD_(__VA_ARGS__)
-#else
-	#define FORWARD_(argcount, ...) EXPAND_ARGS(FORWARD##argcount, (__VA_ARGS__))
-	// Gets the macro evaluator to evaluate in the right order
-	#define FORWARD(...) EXPAND_ARGS(FORWARD_, (__VA_ARGS__))
-#endif
+#define FORWARD_(argcount, ...) FORWARD##argcount(__VA_ARGS__)
+// Gets the macro evaluator to evaluate in the right order
+#define FORWARD(...) FORWARD_(__VA_ARGS__)
 
 #define FORWARD_SSE_XMM0(name) \
 	void name(const Xmm& a, const Operand& b) \
@@ -180,21 +170,12 @@ public:
 #define ADD_ONE_2 3
 #define ADD_ONE_3 4
 
-#if defined(__GNUC__) || defined(_MSC_VER) && defined(__clang__)
-	#define SFORWARD(argcount, name, ...) FORWARD(argcount, SSE, name, __VA_ARGS__)
-	#define AFORWARD_(argcount, name, arg1, ...) \
-		SFORWARD(argcount, name, arg1, __VA_ARGS__) \
-		FORWARD(ADD_ONE_##argcount, AVX, v##name, arg1, arg1, __VA_ARGS__)
-	// Gets the macro evaluator to evaluate in the right order
-	#define AFORWARD(...) EXPAND_ARGS(AFORWARD_, (__VA_ARGS__))
-#else
-	#define SFORWARD(argcount, name, ...) EXPAND_ARGS(FORWARD, (argcount, SSE, name, __VA_ARGS__))
-	#define AFORWARD_(argcount, name, arg1, ...) \
-		EXPAND_ARGS(SFORWARD, (argcount, name, arg1, __VA_ARGS__)) \
-		EXPAND_ARGS(FORWARD, (ADD_ONE_##argcount, AVX, v##name, arg1, arg1, __VA_ARGS__))
-	// Gets the macro evaluator to evaluate in the right order
-	#define AFORWARD(...) EXPAND_ARGS(AFORWARD_, (__VA_ARGS__))
-#endif
+#define SFORWARD(argcount, name, ...) FORWARD(argcount, SSE, name, __VA_ARGS__)
+#define AFORWARD_(argcount, name, arg1, ...) \
+	SFORWARD(argcount, name, arg1, __VA_ARGS__) \
+	FORWARD(ADD_ONE_##argcount, AVX, v##name, arg1, arg1, __VA_ARGS__)
+// Gets the macro evaluator to evaluate in the right order
+#define AFORWARD(...) AFORWARD_(__VA_ARGS__)
 
 #define FORWARD_OO_OI(name) \
 	FORWARD(2, BASE, name, ARGS_OO) \


### PR DESCRIPTION
### Description of Changes
Instruct MSVC to use its newer preprocessor, which has better standards conformance
Remove the preprocessor hack present in `GSNewCodeGenerator.h`

### Rationale behind Changes
I had switched to the new preprocessor as I had wanted to use `__VA_OPT__` on the macros in pcap
That ended up being not really worthwhile, however, I had noticed that GS  `GSNewCodeGenerator.h` had a hack for the old preprocessor.
May as well have each compiler's preprocessor behave the same, and remove this hack.

### Suggested Testing Steps
Test MSVC Builds
