### PR TITLE
GS/HW: Fix unscaled rect in CopyRGBFromDepthToColor()

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -2924,8 +2924,9 @@ bool GSTextureCache::CopyRGBFromDepthToColor(Target* dst, Target* depth_src)
 	{
 		if (dst->m_valid_alpha_low || dst->m_valid_alpha_high)
 		{
-			g_gs_device->StretchRect(dst->m_texture, GSVector4::cxpr(0.0f, 0.0f, 1.0f, 1.0f), tex,
-				GSVector4(GSVector4i::loadh(dst->m_unscaled_size)), false, false, false, true);
+			const GSVector4 copy_rect = GSVector4(tex->GetRect().rintersect(dst->m_texture->GetRect()));
+			g_gs_device->StretchRect(dst->m_texture, copy_rect / GSVector4(GSVector4i(dst->m_texture->GetSize()).xyxy()), tex,
+				copy_rect, false, false, false, true);
 			g_perfmon.Put(GSPerfMon::TextureCopies, 1);
 		}
 

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -2872,7 +2872,7 @@ bool GSTextureCache::CopyRGBFromDepthToColor(Target* dst, Target* depth_src)
 		dst->m_TEX0.TBP0, psm_str(dst->m_TEX0.PSM));
 
 	// The depth target might be larger (Driv3r).
-	const GSVector2i new_size = depth_src->GetUnscaledSize().max(dst->GetUnscaledSize());
+	const GSVector2i new_size = dst->GetUnscaledSize().max(GSVector2i(depth_src->m_valid.z, depth_src->m_valid.w));
 	const GSVector2i new_scaled_size = ScaleRenderTargetSize(new_size, dst->GetScale());
 	const bool needs_new_tex = (new_size != dst->m_unscaled_size);
 	GSTexture* tex = dst->m_texture;
@@ -2884,6 +2884,9 @@ bool GSTextureCache::CopyRGBFromDepthToColor(Target* dst, Target* depth_src)
 			return false;
 
 		m_target_memory_usage = (m_target_memory_usage - dst->m_texture->GetMemUsage()) + tex->GetMemUsage();
+
+		// Inject new size into hash cache to avoid future resizes.
+		GetTargetSize(dst->m_TEX0.TBP0, dst->m_TEX0.TBW, dst->m_TEX0.PSM, new_size.x, new_size.y);
 	}
 
 	// Remove any dirty rectangles contained by this update, we don't want to pull from local memory.


### PR DESCRIPTION
### Description of Changes

Fixes fade transitions when upscaling in GT3.

### Rationale behind Changes

I wrote terribly incorrect code last year.

### Suggested Testing Steps

Check GT3/GT4 with upscaling.
~~Still need to dump run.~~
