### PR TITLE
InputManager: Fix exit menu button forwarding to game

### DIFF
--- a/pcsx2/Input/InputManager.cpp
+++ b/pcsx2/Input/InputManager.cpp
@@ -963,7 +963,7 @@ bool InputManager::ProcessEvent(InputBindingKey key, float value, bool skip_butt
 			// and 0 on release (when the full state changes).
 			if (IsAxisHandler(binding->handler))
 			{
-				if (value_to_pass >= 0.0f)
+				if (value_to_pass >= 0.0f && (!skip_button_handlers || value_to_pass == 0.0f))
 					std::get<InputAxisEventHandler>(binding->handler)(value_to_pass);
 			}
 			else if (binding->num_keys >= min_num_keys)


### PR DESCRIPTION
### Description of Changes

Backport of https://github.com/stenzek/duckstation/commit/a7f2ad37de936d68e8881aa6878e91ed213d228a

### Rationale behind Changes

Fixes the activate menu button from being forwarded to the game after the menu is closed.

### Suggested Testing Steps

Test pressing the menu activate button (e.g. enter or X/A on controller) with it also bound to a PS2 controller button. Input shouldn't be forwarded to game anymore.

