### PR TITLE
GS/HW: Favour newer draw on source overlap + improve target overwrite

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -2753,7 +2753,11 @@ void GSRendererHW::Draw()
 			if (rt)
 			{
 				m_last_channel_shuffle_fbp = rt->m_TEX0.TBP0;
-				m_last_channel_shuffle_end_block = rt->m_end_block;
+				// Urban Chaos goes from Z16 to C32, so let's just use the rt's original end block.
+				if (GSLocalMemory::m_psm[src->m_from_target_TEX0.PSM].bpp != GSLocalMemory::m_psm[rt->m_TEX0.PSM].bpp)
+					m_last_channel_shuffle_end_block = rt->m_end_block;
+				else
+					m_last_channel_shuffle_end_block = (rt->m_TEX0.TBP0 + (src->m_from_target->m_end_block - src->m_from_target_TEX0.TBP0));
 			}
 		}
 		else
@@ -2926,7 +2930,7 @@ void GSRendererHW::Draw()
 		// The FBW should also be okay, since it's coming from the source.
 		if (rt)
 		{
-			rt->m_TEX0.TBW = std::max(rt->m_TEX0.TBW, FRAME_TEX0.TBW);
+			rt->m_TEX0.TBW = (m_channel_shuffle && (!PRIM->ABE || IsOpaque() || m_context->ALPHA.IsBlack())) ? FRAME_TEX0.TBW : std::max(rt->m_TEX0.TBW, FRAME_TEX0.TBW);
 			rt->m_TEX0.PSM = FRAME_TEX0.PSM;
 		}
 		if (ds)

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.h
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.h
@@ -226,10 +226,13 @@ public:
 	/// Called by the texture cache to know for certain whether there is a channel shuffle.
 	bool TestChannelShuffle(GSTextureCache::Target* src);
 
-	/// Returns true if the specified texture address matches the frame or Z buffer.
-	bool IsTBPFrameOrZ(u32 tbp);
+	/// Returns true if the Frame and TEX0 are sharing channels
+	bool ChannelsSharedTEX0FRAME();
 
-	//// Returns true if the draws appear to be a manual deswizzle.
+	/// Returns true if the specified texture address matches the frame or Z buffer.
+	bool IsTBPFrameOrZ(u32 tbp, bool frame_only = false);
+
+	/// Returns true if the draws appear to be a manual deswizzle.
 	void HandleManualDeswizzle();
 
 	/// Offsets the current draw, used for RT-in-RT. Offsets are relative to the *current* FBP, not the new FBP.

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -4811,6 +4811,13 @@ GSTextureCache::Source* GSTextureCache::CreateSource(const GIFRegTEX0& TEX0, con
 			g_texture_cache->InvalidateVideoMemType(GSTextureCache::DepthStencil, TEX0.TBP0, TEX0.PSM, GSRendererHW::GetInstance()->GetCachedCtx()->FRAME.FBMSK, true);
 		}
 
+		// kill source immediately after the draw if it's the RT, because that'll get invalidated immediately.
+		if (GSRendererHW::GetInstance()->IsTBPFrameOrZ(TEX0.TBP0, true) && GSRendererHW::GetInstance()->ChannelsSharedTEX0FRAME())
+		{
+			GL_CACHE("TC: Source == RT before RT creation, invalidating after draw.");
+			m_temporary_source = src;
+		}
+
 		// maintain the clut even when paltex is on for the dump/replacement texture lookup
 		bool paltex = (GSConfig.GPUPaletteConversion && psm.pal > 0) || gpu_clut;
 		const u32* clut = (psm.pal > 0) ? static_cast<const u32*>(g_gs_renderer->m_mem.m_clut) : nullptr;

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -845,7 +845,7 @@ GSTextureCache::Source* GSTextureCache::LookupDepthSource(const bool is_depth, c
 
 		if (GSUtil::HasSharedBits(bp, psm, t->m_TEX0.TBP0, t->m_TEX0.PSM))
 		{
-			pxAssert(GSLocalMemory::m_psm[t->m_TEX0.PSM].depth);
+			GL_INS("Found target in Depth list BP: %x but is RenderTarget", t->m_TEX0.TBP0);
 			if (t->m_age == 0)
 			{
 				// Perfect Match


### PR DESCRIPTION
### Description of Changes
Improve target selection on tex in rt and improve detection of targets to be deleted.

### Rationale behind Changes
Just the way some games do things confuses the TC, this improves it

### Suggested Testing Steps
Test games below, make sure everything is okay. Any Tex in RT games are probably a good shout too (including Valkyrie Profile 2)

### Guitar Hero III - Legends of Rock:
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/0207a8fa-12a6-4bff-8b72-b9eb1e17813f)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/8e525d93-e79f-4bf5-8f32-c44e883b5711)

Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/3525403d-749b-45e4-89f1-5b7c7475d505)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/290cc069-4984-4707-a3a7-506295cf6855)

### Project Snowblind:
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/83c14880-fcd2-4d2b-b3d9-3345fe0564d4)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/51b84c85-7af2-4ae1-aabf-28a7d2979777)

Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/21edaacb-a623-42c7-ac2c-99703f702851)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/bc4b53f4-47fc-4215-9ac2-514a02fcbe98)

### Tomb Raider Legend:
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/817ea997-11ca-4f50-a228-7ddfaf2a45c0)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/3935de38-0dce-45ae-9e9b-5c2868923c2d)

Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/56ea9a57-0e2e-4916-94db-c040693d6997)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/45a40858-32e8-4207-b159-6a06b703ffb4)

### Urban Chaos:
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/628d7ee0-80dc-4451-8a55-fb0011e3e1b1)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/d06d0820-7da8-4302-9650-ad0780f2d0ea)
