### PR TITLE
CMake:macOS: Tell Xcode to sign with `--deep`

### DIFF
--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -1283,6 +1283,8 @@ function(setup_main_executable target)
 			MACOSX_BUNDLE true
 			MACOSX_BUNDLE_INFO_PLIST "${PCSX2_SOURCE_DIR}/Resources/Info.plist.in"
 			OUTPUT_NAME PCSX2
+			# Fixes complaints when Xcode tries to sign for running locally about MoltenVK not being signed
+			XCODE_ATTRIBUTE_OTHER_CODE_SIGN_FLAGS --deep
 		)
 
 		pcsx2_resource(${target} ${PCSX2_SOURCE_DIR}/Resources/PCSX2.icns ${PCSX2_SOURCE_DIR}/Resources)


### PR DESCRIPTION
### Description of Changes
Fixes errors about MoltenVK not getting signed 

### Rationale behind Changes
Things building successfully is generally preferred

### Suggested Testing Steps
Attempt to build an Xcode project generated with `cmake -G Xcode` (tested)