### PR TITLE
GS: Don't be inclusive of textures edges in all cases

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -52580,6 +52580,8 @@ SLPS-25478:
   name-sort: きどうせんしがんだむ いちねんせんそう
   name-en: "Mobile Suit Gundam - One Year War"
   region: "NTSC-J"
+  gsHWFixes:
+    textureInsideRT: 1 # Fixes cut off screens.
 SLPS-25479:
   name: 金色のガッシュベル!!友情タッグバトル2
   name-sort: こんじきのがっしゅべる!!ゆうじょうたっぐばとる2


### PR DESCRIPTION
### Description of Changes
Checks gradient of draw to if it should use inclusive edges of textures

### Rationale behind Changes
Before it was always on causing silly expansion of textures and missing lookups because they went outside of the texture.  The rects are technically already inclusive, but depending on the gradient it may need a bit more, so this checks the gradient before calculating the boundaries. Mobile Suit Gundam was copying the screen in strips and the last strip was trying to grab 65x225 instead of 64x224, so the tex in rt check was saying it was out of bounds.

As a result a bunch of copies no longer happen, or uploads, or resizes, which is always good. Raw Danger seems to run better than master, I actually get a playable speed.

### Suggested Testing Steps
Test random stuff make sure everything is peachy, and Mobile Suit Gundam - One Year War listed below.

Fixies #10989

Mobile Suit Gundam - One Year War:
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/e95a69d8-b7af-47ec-af52-838aa4b85cdf)
Master with TexisRT:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/d440a392-d7e2-474c-be71-a14ec7ef5c95)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/5e664383-7403-4ba8-86d4-e28dea5f4ca4)