### PR TITLE
GameDB: Tokyo Xtreme Racer Drift/Kaido Racer - Upscaling fixes

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -20326,6 +20326,7 @@ SLES-53191:
   name: "Kaido Racer"
   region: "PAL-M5"
   gsHWFixes:
+    halfPixelOffset: 2 # Fixes ghosting during Rain/Storm.
     alignSprite: 1 # Fixes vertical lines.
     wildArmsHack: 1 # De-blurs the 3D image.
 SLES-53192:
@@ -22386,6 +22387,7 @@ SLES-53900:
   name: "Kaido Racer 2"
   region: "PAL-M3"
   gsHWFixes:
+    halfPixelOffset: 2 # Fixes ghosting during Storm.
     alignSprite: 1 # Fixes black lines when upscaling.
     wildArmsHack: 1 # De-blurs the 3D image.
 SLES-53901:
@@ -27736,6 +27738,7 @@ SLKA-25063:
   name: "Kaido Battle"
   region: "NTSC-K"
   gsHWFixes:
+    halfPixelOffset: 2 # Fixes ghosting during Rain.
     alignSprite: 1 # Fixes vertical lines.
     wildArmsHack: 1 # De-blurs the 3D image.
 SLKA-25064:
@@ -28043,6 +28046,7 @@ SLKA-25146:
   name: "Kaido Battle 2 - Chain Reaction"
   region: "NTSC-K"
   gsHWFixes:
+    halfPixelOffset: 2 # Fixes ghosting during Rain/Storm.
     alignSprite: 1 # Fixes vertical lines.
     wildArmsHack: 1 # De-blurs the 3D image.
 SLKA-25148:
@@ -30670,6 +30674,7 @@ SLPM-60195:
   name: "Kaido Battle - Nikko, Haruna, Rokko, Hakone [Trial]"
   region: "NTSC-J"
   gsHWFixes:
+    halfPixelOffset: 2 # Fixes ghosting during Rain.
     alignSprite: 1 # Fixes vertical lines.
     wildArmsHack: 1 # De-blurs the 3D image.
 SLPM-60197:
@@ -30766,6 +30771,7 @@ SLPM-60228:
   name: "Kaido Battle 2 - Chain Reaction [Trial]"
   region: "NTSC-J"
   gsHWFixes:
+    halfPixelOffset: 2 # Fixes ghosting during Rain/Storm.
     alignSprite: 1 # Fixes vertical lines.
     wildArmsHack: 1 # De-blurs the 3D image.
 SLPM-60237:
@@ -31339,6 +31345,7 @@ SLPM-61121:
   name: "Kaido - Touge no Densetsu [Trial]"
   region: "NTSC-J"
   gsHWFixes:
+    halfPixelOffset: 2 # Fixes ghosting during Rain/Storm.
     alignSprite: 1 # Fixes vertical lines.
     wildArmsHack: 1 # De-blurs the 3D image.
 SLPM-61122:
@@ -36599,6 +36606,7 @@ SLPM-65246:
   name-en: "Kaido Battle - Nikko, Haruna, Rokko, Hakone"
   region: "NTSC-J"
   gsHWFixes:
+    halfPixelOffset: 2 # Fixes ghosting during Rain.
     alignSprite: 1 # Fixes vertical lines.
     wildArmsHack: 1 # De-blurs the 3D image.
 SLPM-65247:
@@ -38049,6 +38057,7 @@ SLPM-65514:
   name-en: "Kaido Battle 2 - Chain Reaction"
   region: "NTSC-J"
   gsHWFixes:
+    halfPixelOffset: 2 # Fixes ghosting during Rain/Storm.
     alignSprite: 1 # Fixes vertical lines.
     wildArmsHack: 1 # De-blurs the 3D image.
 SLPM-65515:
@@ -40838,6 +40847,7 @@ SLPM-66022:
   name-en: "Kaido Touge no Densetsu"
   region: "NTSC-J"
   gsHWFixes:
+    halfPixelOffset: 2 # Fixes ghosting during Rain/Storm.
     alignSprite: 1 # Fixes vertical lines.
     wildArmsHack: 1 # De-blurs the 3D image.
 SLPM-66023:
@@ -62395,6 +62405,7 @@ SLUS-21236:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
+    halfPixelOffset: 2 # Fixes ghosting during Rain.
     alignSprite: 1 # Fixes vertical lines.
     wildArmsHack: 1 # Fixes double image.
 SLUS-21237:
@@ -63460,6 +63471,7 @@ SLUS-21394:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
+    halfPixelOffset: 2 # Fixes ghosting during Rain/Storm.
     alignSprite: 1 # Fixes vertical lines.
     wildArmsHack: 1 # De-blurs the 3D image.
 SLUS-21395:


### PR DESCRIPTION
### Description of Changes
Fixes ghosting in all Tokyo Xtreme Racer Drift/Kaido Racer/Kaido Battle games during Rainy/Stormy weather where applicable.

**Tokyo Xtreme Racer: Drift/Kaido Battle**
Before
![Tokyo Xtreme Racer Drift_SLUS-21236_20240602202907](https://github.com/PCSX2/pcsx2/assets/4414625/bc4600b0-1b1e-4ccd-9dba-4fb61eb3a661)
After
![Tokyo Xtreme Racer Drift_SLUS-21236_20240602202912](https://github.com/PCSX2/pcsx2/assets/4414625/40dfa229-7078-41f2-982d-9fb0d753e2cc)

**Kaido Racer/Kaido Battle 2**
Before
![Kaido Racer_SLES-53191_20240602203032](https://github.com/PCSX2/pcsx2/assets/4414625/af0014a3-6bf4-40f5-9ce3-4e81c899a548)
After
![Kaido Racer_SLES-53191_20240602203038](https://github.com/PCSX2/pcsx2/assets/4414625/6789ea76-fcb9-4cd0-ba25-3ddf0d7f1780)

**Tokyo Xtreme Racer: Drift 2/Kaido Battle 2**
Before
![Tokyo Xtreme Racer Drift 2_SLUS-21394_20240602203322](https://github.com/PCSX2/pcsx2/assets/4414625/2f555863-cf5a-47f0-9b61-101cf608fe0b)
After
![Tokyo Xtreme Racer Drift 2_SLUS-21394_20240602203330](https://github.com/PCSX2/pcsx2/assets/4414625/4ee6a47a-b836-455a-bb37-548510648316)

### Rationale behind Changes
Clearer picture!

### Suggested Testing Steps
Test the games if something isn't broken. I have already 100%'d both TXRD1/2 with those fixes and all seemed fine to me.