### PR TITLE
input-rec: Use `toNativeSeparators()` when opening recording

### DIFF
--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -1791,7 +1791,7 @@ void MainWindow::onInputRecPlayActionTriggered()
 			Host::RunOnCPUThread([]() { g_InputRecording.stop(); });
 			m_ui.actionInputRecStop->setEnabled(false);
 		}
-		Host::RunOnCPUThread([&, filename = fileNames.first().toStdString()]() {
+		Host::RunOnCPUThread([&, filename = QDir::toNativeSeparators(fileNames.first()).toStdString()]() {
 			if (g_InputRecording.play(filename))
 			{
 				QtHost::RunOnUIThread([&]() {


### PR DESCRIPTION
### Description of Changes
Use `QDir::toNativeSeparators()` to convert directory separators from `/` to `\` on Windows when opening a file for input playback

### Rationale behind Changes
`QFileDialog` returns paths with unix slashes.
Windows would normally be able to handle paths with unix slashes, except when paths that are prefixed by `\\?\`, (which we do for longer than MAX_PATH support).
Convert the path to use native separators (so `\` on windows) to allow the to be prefixed path to work.

Fixes https://github.com/PCSX2/pcsx2/issues/11060

### Suggested Testing Steps
Open an input recorded file and see if it plays.
