### PR TITLE
GS: Correct TEXA behaviour on shuffles

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -4739,6 +4739,7 @@ __ri void GSRendererHW::EmulateTextureSampler(const GSTextureCache::Target* rt, 
 		// m_ps_sel.tex_fmt = 0; // removed as an optimization
 
 		//ASSERT(tex->m_target);
+		m_conf.ps.aem = TEXA.AEM;
 
 		// Require a float conversion if the texure is a depth otherwise uses Integral scaling
 		if (psm.depth)
@@ -4749,16 +4750,10 @@ __ri void GSRendererHW::EmulateTextureSampler(const GSTextureCache::Target* rt, 
 		// Shuffle is a 16 bits format, so aem is always required
 		if (m_cached_ctx.TEX0.TCC)
 		{
-			m_conf.ps.aem = TEXA.AEM;
 			GSVector4 ta(TEXA & GSVector4i::x000000ff());
 			ta /= 255.0f;
 			m_conf.cb_ps.TA_MaxDepth_Af.x = ta.x;
 			m_conf.cb_ps.TA_MaxDepth_Af.y = ta.y;
-		}
-		else
-		{
-			m_conf.cb_ps.TA_MaxDepth_Af.x = 0;
-			m_conf.cb_ps.TA_MaxDepth_Af.y = 1.0f;
 		}
 
 		// The purpose of texture shuffle is to move color channel. Extra interpolation is likely a bad idea.

--- a/pcsx2/ShaderCacheVersion.h
+++ b/pcsx2/ShaderCacheVersion.h
@@ -3,4 +3,4 @@
 
 /// Version number for GS and other shaders. Increment whenever any of the contents of the
 /// shaders change, to invalidate the cache.
-static constexpr u32 SHADER_CACHE_VERSION = 49;
+static constexpr u32 SHADER_CACHE_VERSION = 50;


### PR DESCRIPTION
### Description of Changes
Corrects TEXA usages on shuffles

### Rationale behind Changes
Order of operations was a little backward here, it was being added *after* blends and modulation when it was a shuffle, which makes no sense, but also AEM was non-functional, snoopy relied on this behaviour for converting the depth to a fog effect.

### Suggested Testing Steps
Normal testing, plus the two dumps in the archive below, especially Metal.

[testdumps.zip](https://github.com/user-attachments/files/15569901/testdumps.zip)

Fixes #5240 Snoopy last outstanding issue.

Master:
![snoopy_frame3](https://github.com/PCSX2/pcsx2/assets/6278726/c4d05312-170e-4ea8-b66d-c5be5b609c61)
PR:
![snoopy_frame3](https://github.com/PCSX2/pcsx2/assets/6278726/75777eab-d964-4dee-a84d-d2fb83a0a37d)
