### PR TITLE
GS/HW: Natively downscale targets - General post processing

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -117,10 +117,10 @@ CPCS-01005:
   name-en: "Gun Survivor 4 - BioHazard - Heroes Never Die [with GunCon2]"
   region: "NTSC-J"
   gsHWFixes:
-    halfPixelOffset: 1 # Fixes character offset with flashlight and blurriness.
-    alignSprite: 1 # Fixes vertical lines.
+    halfPixelOffset: 4 # Fixes character offset with flashlight and blurriness.
     roundSprite: 2 # Fixes font artifacts.
-    mergeSprite: 1 # Fixes flame-like bleeding.
+    autoFlush: 1 # Fixes light bloom intensity.
+    nativeScaling: 2 # Fixes post processing.
 CPCS-01020:
   name: モンスターハンター2 DXハンターボックス
   name-sort: もんすたーはんたー2 [DXはんたーぼっくす]
@@ -149,10 +149,10 @@ PAPX-90020:
     - SoftwareRendererFMVHack # Fixes hash cache disabling itself.
   gsHWFixes:
     recommendedBlendingLevel: 4 # Improves banding and effect emulation.
-    halfPixelOffset: 3 # Fixes texture and lighting misalignment.
-    mergeSprite: 1 # Fixes most vertical lines and lighting misalignment.
     autoFlush: 1 # Fixes light bloom intensity.
     estimateTextureRegion: 1 # Improves performance and reduces hash cache size.
+    halfPixelOffset: 4 # Aligns post effects.
+    nativeScaling: 1 # Fixes post effects.
     getSkipCount: "GSC_GiTS"
 PAPX-90201:
   name: ファンタビジョン 体験版
@@ -388,6 +388,7 @@ PAPX-90517:
   gsHWFixes:
     autoFlush: 2 # Reduces post-processing misalignment.
     halfPixelOffset: 4 # Reduces post-processing misalignment.
+    nativeScaling: 2 # Fixes post effects.
 PAPX-90519:
   name: どこでもいっしょ トロといっぱい 体験版
   name-sort: どこでもいっしょ とろといっぱい たいけんばん
@@ -579,6 +580,9 @@ PBPX-95516:
     - EETimingHack # Fixes SPR errors while going in-game.
   roundModes:
     eeRoundMode: 0 # Fixes Hydrodisplacer behaviour.
+  gsHWFixes:
+    halfPixelOffset: 4 # Aligns post bloom.
+    nativeScaling: 1 # Fixes light blooms.
 PBPX-95517:
   name: "Network Adapter Start-Up Disc"
   region: "NTSC-U"
@@ -708,7 +712,8 @@ PCPX-96320:
     instantVU1: 0 # Fixes noodles.
     mtvu: 0
   gsHWFixes:
-    forceEvenSpritePosition: 1 # Fixes misaligment depth of field effect.
+    halfPixelOffset: 4 # Aligns depth of field effect.
+    nativeScaling: 2 # Fixes post effect.
 PCPX-96321:
   name: "SkyGunner [Trial]"
   region: "NTSC-J"
@@ -900,7 +905,8 @@ PCPX-96653:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
     disablePartialInvalidation: 1 # Prevents the situation that a level (Aquatos) doesn't render characters and geometry.
-    halfPixelOffset: 2 # Fixes misaligned bloom.
+    halfPixelOffset: 4 # Aligns post bloom.
+    nativeScaling: 1 # Fixes light blooms.
     autoFlush: 2 # Helps fix misaligned bloom.
 PCPX-96655:
   name: "プレプレ2 VOLUME.12"
@@ -934,8 +940,9 @@ PCPX-98017:
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes misaligned bloom.
     autoFlush: 2 # Helps fix misaligned bloom.
+    halfPixelOffset: 4 # Aligns post bloom.
+    nativeScaling: 1 # Fixes light blooms.
 PCPX-98041:
   name: "Saru! Get You! Million Monkeys"
   region: "NTSC-J"
@@ -1016,6 +1023,9 @@ SCAJ-20001:
   region: "NTSC-Unk"
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
+  gsHWFixes:
+    halfPixelOffset: 4 # Aligns post bloom.
+    nativeScaling: 1 # Fixes light blooms.
 SCAJ-20002:
   name: "Gallop Racer 6 - Revolution"
   region: "NTSC-Unk"
@@ -1244,6 +1254,8 @@ SCAJ-20052:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
     autoFlush: 2
+    halfPixelOffset: 4 # Aligns post bloom.
+    nativeScaling: 1 # Fixes light blooms.
   memcardFilters:
     - "SCAJ-20052"
     - "SCAJ-20001"
@@ -1330,7 +1342,8 @@ SCAJ-20070:
   gameFixes:
     - VuAddSubHack
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes bloom and ghosting in certain areas.
+    halfPixelOffset: 4 # Fix effects upscaling.
+    nativeScaling: 2 # Fixes post effects.
     roundSprite: 1 # Fixes door transition vertical lines and mini-map artifacts.
     textureInsideRT: 1 # Fixes missing battle effects.
 SCAJ-20072:
@@ -1340,10 +1353,10 @@ SCAJ-20072:
     - SoftwareRendererFMVHack # Fixes hash cache disabling itself.
   gsHWFixes:
     recommendedBlendingLevel: 4 # Improves banding and effect emulation.
-    halfPixelOffset: 3 # Fixes texture and lighting misalignment.
-    mergeSprite: 1 # Fixes most vertical lines and lighting misalignment.
     autoFlush: 1 # Fixes light bloom intensity.
     estimateTextureRegion: 1 # Improves performance and reduces hash cache size.
+    halfPixelOffset: 4 # Aligns post effects.
+    nativeScaling: 1 # Fixes post effects.
     getSkipCount: "GSC_GiTS"
 SCAJ-20073:
   name: "Jak and Daxter II"
@@ -1544,7 +1557,8 @@ SCAJ-20109:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves color and luminosity of surfaces.
     disablePartialInvalidation: 1 # Prevents the situation that a level (Aquatos) doesn't render characters and geometry.
-    halfPixelOffset: 2 # Fixes misaligned bloom.
+    halfPixelOffset: 4 # Aligns post bloom.
+    nativeScaling: 1 # Fixes light blooms.
     autoFlush: 2 # Helps fix misaligned bloom.
   memcardFilters:
     - "SCAJ-20109"
@@ -1605,9 +1619,8 @@ SCAJ-20119:
   name: "Gladiator - Road to Freedom"
   region: "NTSC-J"
   gsHWFixes:
-    halfPixelOffset: 3 # Fixes bloom misalignment still a bit misaligned.
-    roundSprite: 1 # Fixes bloom misalignment still a bit misaligned.
-    cpuCLUTRender: 1 # Fixes sun background on the windows when selecting your 'race'.
+    halfPixelOffset: 4 # Aligns post effects.
+    nativeScaling: 1 # Fixes post effects.
 SCAJ-20120:
   name: "Digital Devil Saga - Avatar Tuner 2"
   region: "NTSC-Unk"
@@ -1660,6 +1673,7 @@ SCAJ-20125:
   gsHWFixes:
     alignSprite: 1
     halfPixelOffset: 4 # Align post.
+    nativeScaling: 1 # Fixes depth of field effect.
     getSkipCount: "GSC_Tekken5"
 SCAJ-20126:
   name: "Tekken 5"
@@ -1669,6 +1683,7 @@ SCAJ-20126:
   gsHWFixes:
     alignSprite: 1
     halfPixelOffset: 4 # Align post.
+    nativeScaling: 1 # Fixes depth of field effect.
     getSkipCount: "GSC_Tekken5"
 SCAJ-20127:
   name: "EyeToy - Play 2 [with Camera]"
@@ -1783,6 +1798,7 @@ SCAJ-20146:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misalignments and borders on side.
+    nativeScaling: 2 # Fixes post processing position and smoothness of shadows and depth of field.
   memcardFilters:
     - "SCAJ-20146"
     - "SCAJ-20196"
@@ -1823,6 +1839,8 @@ SCAJ-20154:
   region: "NTSC-Unk"
   gsHWFixes:
     autoFlush: 2 # Reduces post-processing misalignment.
+    halfPixelOffset: 4 # Fixes post positioning.
+    nativeScaling: 2 # Fixes post effects.
 SCAJ-20155:
   name: "Yoshitsune Eiyuuden Shura - The Story of Hero Yoshitsune Shura"
   region: "NTSC-Unk"
@@ -1836,7 +1854,8 @@ SCAJ-20157:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
     disablePartialInvalidation: 1 # Prevents world geometry and some models from vanishing when pausing or opening vendor.
-    halfPixelOffset: 2 # Fixes misaligned bloom.
+    halfPixelOffset: 4 # Aligns post bloom.
+    nativeScaling: 1 # Fixes light blooms.
     autoFlush: 2 # Helps fix misaligned bloom.
 SCAJ-20158:
   name: "Ikusa Gami"
@@ -1890,7 +1909,8 @@ SCAJ-20164:
   gsHWFixes:
     autoFlush: 1 # Fixes effects.
     roundSprite: 1 # Fixes upscaling artifacts.
-    halfPixelOffset: 4 # Fixes upscaling artifacts.
+    halfPixelOffset: 2 # Fixes post bloom positioning.
+    nativeScaling: 2 # Fixes lighting effects due to upscaling.
 SCAJ-20165:
   name: "Bleach - Hanatareshi Yabou"
   region: "NTSC-Unk"
@@ -1968,10 +1988,10 @@ SCAJ-20177:
   gameFixes:
     - VuAddSubHack
   gsHWFixes:
-    halfPixelOffset: 2 # Reduces bloom misalignment.
-    roundSprite: 1 # Fixes area transition vertical lines and lessens red forest vertical lines.
+    halfPixelOffset: 4 # Reduces bloom misalignment.
     textureInsideRT: 1 # Required for swirl battle transition.
     nativePaletteDraw: 1
+    nativeScaling: 2 # Fixes depth of field effects and bloom.
 SCAJ-20178:
   name: "Ape Escape - Million Monkeys"
   region: "NTSC-Unk"
@@ -1980,18 +2000,18 @@ SCAJ-20179:
   name: "Xenosaga Episode III - Also Sprach Zarathustra [Disc 1 of 2]"
   region: "NTSC-Unk"
   gsHWFixes:
-    autoFlush: 2 # Fixes shadows in cutscenes.
-    halfPixelOffset: 2 # Fixes lighting misalignment and reduces ground shadows (probably texture cache issue).
-    roundSprite: 2 # Fixes font artifacts.
+    autoFlush: 1 # Fixes shadows.
     textureInsideRT: 1 # Fixes bad crystal surfaces.
+    halfPixelOffset: 4 # Fixes lighting misalignment.
+    nativeScaling: 2 # Fixes lighting smoothness.
 SCAJ-20180:
   name: "Xenosaga Episode III - Also Sprach Zarathustra [Disc 2 of 2]"
   region: "NTSC-Unk"
   gsHWFixes:
-    autoFlush: 2 # Fixes shadows in cutscenes.
-    halfPixelOffset: 2 # Fixes lighting misalignment and reduces ground shadows (probably texture cache issue).
-    roundSprite: 2 # Fixes font artifacts.
+    autoFlush: 1 # Fixes shadows.
     textureInsideRT: 1 # Fixes bad crystal surfaces.
+    halfPixelOffset: 4 # Fixes lighting misalignment.
+    nativeScaling: 2 # Fixes lighting smoothness.
 SCAJ-20181:
   name: "Minna no Tennis"
   region: "NTSC-Unk"
@@ -2056,6 +2076,7 @@ SCAJ-20196:
   region: "NTSC-C"
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misalignments and borders on side.
+    nativeScaling: 2 # Fixes post processing position and smoothness of shadows and depth of field.
   memcardFilters:
     - "SCAJ-20146"
     - "SCAJ-20196"
@@ -2073,10 +2094,10 @@ SCAJ-20197:
   speedHacks:
     instantVU1: 0 # Mostly fixes animation stuttering.
   gsHWFixes:
-    halfPixelOffset: 2 # Reduces bloom misalignment.
-    roundSprite: 1 # Fixes area transition vertical lines and lessens red forest vertical lines.
+    halfPixelOffset: 4 # Reduces bloom misalignment.
     textureInsideRT: 1 # Required for swirl battle transition.
     nativePaletteDraw: 1
+    nativeScaling: 2 # Fixes depth of field effects and bloom.
 SCAJ-20198:
   name: "Everybody's Tennis [PlayStation 2 the Best]"
   region: "NTSC-Unk"
@@ -2090,6 +2111,7 @@ SCAJ-20199:
   gsHWFixes:
     alignSprite: 1
     halfPixelOffset: 4 # Align post.
+    nativeScaling: 1 # Fixes depth of field effect.
     getSkipCount: "GSC_Tekken5"
 SCAJ-25002:
   name: "Shinobi"
@@ -2672,6 +2694,9 @@ SCED-51075:
     - EETimingHack # Fixes SPR errors while going in-game.
   roundModes:
     eeRoundMode: 0 # Fixes Hydrodisplacer behaviour.
+  gsHWFixes:
+    halfPixelOffset: 4 # Aligns post bloom.
+    nativeScaling: 1 # Fixes light blooms.
 SCED-51111:
   name: "Magazine Ufficiale PlayStation 2 Demo Italia 08-02"
   region: "PAL-M5"
@@ -2731,13 +2756,17 @@ SCED-51280:
 SCED-51304:
   name: "WRC II Extreme - Peugeot Special Demo"
   region: "PAL-F"
+  gsHWFixes:
+    halfPixelOffset: 2 # Aligns Depth of Field.
+    nativeScaling: 2 # Fixes Depth of Field effect.
 SCED-51305:
   name: "WRC II Extreme [Press Kit]"
   region: "PAL-E"
   gameFixes:
     - XGKickHack # Fixes SPS.
   gsHWFixes:
-    halfPixelOffset: 1 # Fixes texture misalignment.
+    halfPixelOffset: 2 # Aligns Depth of Field.
+    nativeScaling: 2 # Fixes Depth of Field effect.
 SCED-51314:
   name: "Kingdom Hearts"
   region: "PAL-M5"
@@ -2981,7 +3010,8 @@ SCED-51632:
   gameFixes:
     - XGKickHack # Fixes SPS.
   gsHWFixes:
-    halfPixelOffset: 1 # Fixes texture misalignment.
+    halfPixelOffset: 2 # Aligns Depth of Field.
+    nativeScaling: 2 # Fixes Depth of Field effect.
 SCED-51643:
   name: "Tango - Game On Demo Disc 2"
   region: "PAL-E"
@@ -3169,8 +3199,10 @@ SCED-52137:
   gameFixes:
     - XGKickHack # Fixes SPS.
   gsHWFixes:
-    roundSprite: 2 # Correct misaligned font, better aligns car shadow.
+    roundSprite: 1 # Correct misaligned font, better aligns car shadow.
     autoFlush: 2 # Fixes sun luminosity.
+    halfPixelOffset: 2 # Aligns Depth of Field.
+    nativeScaling: 2 # Fixes Depth of Field effect.
 SCED-52141:
   name: "WRC 3 [Demo]"
   region: "PAL-E"
@@ -3178,8 +3210,10 @@ SCED-52141:
   gameFixes:
     - XGKickHack # Fixes SPS.
   gsHWFixes:
-    roundSprite: 2 # Correct misaligned font, better aligns car shadow.
+    roundSprite: 1 # Correct misaligned font, better aligns car shadow.
     autoFlush: 2 # Fixes sun luminosity.
+    halfPixelOffset: 2 # Aligns Depth of Field.
+    nativeScaling: 2 # Fixes Depth of Field effect.
 SCED-52147:
   name: "EyeToy - Christmas Wishi Washi"
   region: "PAL-E"
@@ -3364,7 +3398,8 @@ SCED-52759:
   clampModes:
     vuClampMode: 0 # Resolves I Reg Clamping / performance impact and yellow graphics in certain areas.
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes blurriness.
+    halfPixelOffset: 4 # Fixes post positioning.
+    nativeScaling: 2 # Fixes post effects.
 SCED-52785:
   name: "Official PlayStation 2 Magazine Demo 50"
   region: "PAL-M5"
@@ -3389,7 +3424,8 @@ SCED-52846:
   clampModes:
     vuClampMode: 0 # Resolves I Reg Clamping / performance impact and yellow graphics in certain areas.
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes blurriness.
+    halfPixelOffset: 4 # Fixes post positioning.
+    nativeScaling: 2 # Fixes post effects.
 SCED-52847:
   name: "Ratchet & Clank 3 [Demo]"
   region: "PAL-E"
@@ -3397,11 +3433,15 @@ SCED-52847:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
     disablePartialInvalidation: 1 # Prevents the situation that a level (Aquatos) doesn't render characters and geometry.
-    halfPixelOffset: 2 # Fixes misaligned bloom.
+    halfPixelOffset: 4 # Aligns post bloom.
+    nativeScaling: 1 # Fixes light blooms.
     autoFlush: 2 # Helps fix misaligned bloom.
 SCED-52848:
   name: "Ratchet & Clank 3 + Sly 2 - Band of Thieves"
   region: "PAL-M5"
+  gsHWFixes:
+    halfPixelOffset: 4 # Aligns post bloom.
+    nativeScaling: 1 # Fixes light blooms.
 SCED-52855:
   name: "Magazine Ufficiale PlayStation 2 Italia 09/04"
   region: "PAL-I"
@@ -3423,7 +3463,8 @@ SCED-52869:
   gsHWFixes:
     autoFlush: 2 # Fixes sun luminosity and car shadows.
     roundSprite: 1 # Fixes misaligned text.
-    halfPixelOffset: 2 # Fixes minor ghosting on objects.
+    halfPixelOffset: 2 # Aligns Depth of Field.
+    nativeScaling: 2 # Fixes Depth of Field effect.
   roundModes:
     eeRoundMode: 2 # Fixes rainbow highlighting on cars.
 SCED-52880:
@@ -3444,7 +3485,8 @@ SCED-52880:
   gsHWFixes:
     autoFlush: 2 # Fixes sun luminosity and car shadows.
     roundSprite: 1 # Fixes misaligned text.
-    halfPixelOffset: 2 # Fixes minor ghosting on objects.
+    halfPixelOffset: 2 # Aligns Depth of Field.
+    nativeScaling: 2 # Fixes Depth of Field effect.
   roundModes:
     eeRoundMode: 2 # Fixes rainbow highlighting on cars.
 SCED-52899:
@@ -3453,7 +3495,8 @@ SCED-52899:
   clampModes:
     vuClampMode: 0 # Resolves I Reg Clamping / performance impact and yellow graphics in certain areas.
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes blurriness.
+    halfPixelOffset: 4 # Fixes post positioning.
+    nativeScaling: 2 # Fixes post effects.
 SCED-52932:
   name: "Bonus Demo 8"
   region: "PAL-M5"
@@ -3484,7 +3527,8 @@ SCED-52945:
   gsHWFixes:
     autoFlush: 2 # Fixes sun luminosity and car shadows.
     roundSprite: 1 # Fixes misaligned text.
-    halfPixelOffset: 2 # Fixes minor ghosting on objects.
+    halfPixelOffset: 2 # Aligns Depth of Field.
+    nativeScaling: 2 # Fixes Depth of Field effect.
   roundModes:
     eeRoundMode: 2 # Fixes rainbow highlighting on cars.
 SCED-52946:
@@ -3504,6 +3548,7 @@ SCED-52952:
     cpuSpriteRenderBW: 4 # Fixes character and water textures.
     cpuSpriteRenderLevel: 2 # Needed for above.
     autoFlush: 2 # Fixes lighting.
+    nativeScaling: 2 # Fixes lighting effects due to upscaling.
 SCED-52969:
   name: "EyeToy - Play 2"
   region: "PAL-M12"
@@ -3742,6 +3787,7 @@ SCED-53538:
   gsHWFixes:
     alignSprite: 1
     halfPixelOffset: 4 # Align post.
+    nativeScaling: 1 # Fixes depth of field effect.
     getSkipCount: "GSC_Tekken5"
 SCED-53611:
   name: "Official PlayStation 2 Magazine - German Kids Special"
@@ -3760,6 +3806,9 @@ SCED-53622:
 SCED-53660:
   name: "Jak X & Ratchet Gladiator [Demo]"
   region: "PAL"
+  gsHWFixes:
+    halfPixelOffset: 4 # Aligns post bloom.
+    nativeScaling: 1 # Fixes light blooms.
 SCED-53662:
   name: "Official PlayStation 2 Magazine Germany Special 2/2005"
   region: "PAL-G"
@@ -3834,12 +3883,15 @@ SCED-53962:
   region: "PAL-M5"
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misalignments and borders on side.
+    nativeScaling: 2 # Fixes post processing position and smoothness of shadows and depth of field.
 SCED-53978:
   name: "Official PlayStation 2 Magazine Demo 69"
   region: "PAL-M5"
 SCED-53990:
   name: "Shadow of the Colossus + Ico"
   region: "PAL-M5"
+  gsHWFixes:
+    nativeScaling: 2 # Fixes post processing position and smoothness of shadows and depth of field in Shadow of the Colossus.
 SCED-54001:
   name: "Official PlayStation 2 Magazine Demo 69"
   region: "PAL-M5"
@@ -4136,7 +4188,8 @@ SCES-50000:
     halfPixelOffset: 2 # Fixes title screen and some intro post processing alignment.
     roundSprite: 1 # Fixes ui and hud alignment.
     gpuPaletteConversion: 2 # Lots of CLUTs in large textures.
-    cpuCLUTRender: 1 # Fixes car textures.
+    cpuSpriteRenderBW: 1 # Fixes car textures.
+    cpuSpriteRenderLevel: 1 # Needed for above.
 SCES-50001:
   name: "Tekken Tag Tournament"
   region: "PAL-M5"
@@ -4266,7 +4319,8 @@ SCES-50408:
     instantVU1: 0 # Fixes noodles.
     mtvu: 0
   gsHWFixes:
-    forceEvenSpritePosition: 1 # Fixes misaligment depth of field effect.
+    halfPixelOffset: 4 # Aligns depth of field effect.
+    nativeScaling: 2 # Fixes post effect.
 SCES-50409:
   name: "MotoGP 2"
   region: "PAL-M5"
@@ -4518,6 +4572,9 @@ SCES-50916:
   compat: 5
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
+  gsHWFixes:
+    halfPixelOffset: 4 # Aligns post bloom.
+    nativeScaling: 1 # Fixes light blooms.
 SCES-50917:
   name: "Sly Raccoon"
   region: "PAL-M5"
@@ -4537,14 +4594,16 @@ SCES-50934:
   gameFixes:
     - XGKickHack # Fixes SPS.
   gsHWFixes:
-    halfPixelOffset: 1 # Fixes texture misalignment.
+    halfPixelOffset: 2 # Aligns Depth of Field.
+    nativeScaling: 2 # Fixes Depth of Field effect.
 SCES-50935:
   name: "WRC II Extreme"
   region: "PAL-Unk"
   gameFixes:
     - XGKickHack # Fixes SPS.
   gsHWFixes:
-    halfPixelOffset: 1 # Fixes texture misalignment.
+    halfPixelOffset: 2 # Aligns Depth of Field.
+    nativeScaling: 2 # Fixes Depth of Field effect.
 SCES-50956:
   name: "Ferrari F355 Challenge"
   region: "PAL-M5"
@@ -4764,6 +4823,8 @@ SCES-51607:
     - EETimingHack # Fixes DMA errors.
   gsHWFixes:
     autoFlush: 2
+    halfPixelOffset: 4 # Aligns post bloom.
+    nativeScaling: 1 # Fixes light blooms.
   dynaPatches:
     - pattern:
         - { offset: 0x0, value: 0x0280202d }
@@ -4809,10 +4870,11 @@ SCES-51635:
   name: "Brave - The Search for Spirit Dancer"
   region: "PAL-M5"
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes lighting/shadows.
+    halfPixelOffset: 4 # Fixes lighting/shadows.
     preloadFrameData: 1 # Fixes sun flickering.
     autoFlush: 2 # Fixes sun through objects.
     bilinearUpscale: 1 # Smooths out sun glare textures like native.
+    nativeScaling: 1 # Fixes post effects.
 SCES-51648:
   name: "Everquest - Online Adventures"
   region: "PAL-E-I"
@@ -4828,8 +4890,10 @@ SCES-51684:
   gameFixes:
     - XGKickHack # Fixes SPS.
   gsHWFixes:
-    roundSprite: 2 # Correct misaligned font, better aligns car shadow.
+    roundSprite: 1 # Correct misaligned font, better aligns car shadow.
     autoFlush: 2 # Fixes sun luminosity.
+    halfPixelOffset: 2 # Aligns Depth of Field.
+    nativeScaling: 2 # Fixes Depth of Field effect.
 SCES-51685:
   name: "Primal"
   region: "PAL-E-R"
@@ -4910,7 +4974,8 @@ SCES-52004:
   clampModes:
     vuClampMode: 0 # Resolves I Reg Clamping / performance impact and yellow graphics in certain areas.
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes blurriness.
+    halfPixelOffset: 4 # Fixes post positioning.
+    nativeScaling: 2 # Fixes post effects.
 SCES-52033:
   name: "Syphon Filter - The Omega Strain"
   region: "PAL-M5"
@@ -4953,8 +5018,10 @@ SCES-52137:
   gameFixes:
     - XGKickHack # Fixes SPS.
   gsHWFixes:
-    roundSprite: 2 # Correct misaligned font, better aligns car shadow.
+    roundSprite: 1 # Correct misaligned font, better aligns car shadow.
     autoFlush: 2 # Fixes sun luminosity.
+    halfPixelOffset: 2 # Aligns Depth of Field.
+    nativeScaling: 2 # Fixes Depth of Field effect.
 SCES-52154:
   name: "EyeToy - Chat"
   region: "PAL-M11"
@@ -5027,7 +5094,8 @@ SCES-52389:
   gsHWFixes:
     autoFlush: 2 # Fixes sun luminosity and car shadows.
     roundSprite: 1 # Fixes misaligned text.
-    halfPixelOffset: 2 # Fixes minor ghosting on objects.
+    halfPixelOffset: 2 # Aligns Depth of Field.
+    nativeScaling: 2 # Fixes Depth of Field effect.
   roundModes:
     eeRoundMode: 2 # Fixes rainbow highlighting on cars.
 SCES-52405:
@@ -5109,7 +5177,8 @@ SCES-52456:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves color and luminosity of surfaces.
     disablePartialInvalidation: 1 # Prevents the situation that a level (Aquatos) doesn't render characters and geometry.
-    halfPixelOffset: 2 # Fixes misaligned bloom.
+    halfPixelOffset: 4 # Aligns post bloom.
+    nativeScaling: 1 # Fixes light blooms.
     autoFlush: 2 # Helps fix misaligned bloom.
   memcardFilters: # Reads Ratchet 1 & 2 data.
     - "SCES-52456"
@@ -5125,6 +5194,7 @@ SCES-52460:
     cpuSpriteRenderBW: 4 # Fixes character and water textures.
     cpuSpriteRenderLevel: 2 # Needed for above.
     autoFlush: 2 # Fixes lighting.
+    nativeScaling: 2 # Fixes lighting effects due to upscaling.
 SCES-52529:
   name: "Sly 2 - Band of Thieves"
   region: "PAL-M11"
@@ -5172,8 +5242,10 @@ SCES-52684:
   gameFixes:
     - XGKickHack # Fixes SPS.
   gsHWFixes:
-    roundSprite: 2 # Correct misaligned font, better aligns car shadow.
+    roundSprite: 1 # Correct misaligned font, better aligns car shadow.
     autoFlush: 2 # Fixes sun luminosity.
+    halfPixelOffset: 2 # Aligns Depth of Field.
+    nativeScaling: 2 # Fixes Depth of Field effect.
 SCES-52748:
   name: "EyeToy - Play 2"
   region: "PAL-M12"
@@ -5227,7 +5299,8 @@ SCES-52893:
   clampModes:
     vuClampMode: 0 # Resolves I Reg Clamping / performance impact and yellow graphics in certain areas.
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes blurriness.
+    halfPixelOffset: 4 # Fixes post positioning.
+    nativeScaling: 2 # Fixes post effects.
 SCES-52930:
   name: "EyeToy - Monkey Mania"
   region: "PAL-M5"
@@ -5305,6 +5378,7 @@ SCES-53202:
   gsHWFixes:
     alignSprite: 1
     halfPixelOffset: 4 # Align post.
+    nativeScaling: 1 # Fixes depth of field effect.
     getSkipCount: "GSC_Tekken5"
 SCES-53247:
   name: "WRC Rally Evolved"
@@ -5332,7 +5406,8 @@ SCES-53285:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
     disablePartialInvalidation: 1 # Prevents world geometry and some models from vanishing when pausing or opening vendor.
-    halfPixelOffset: 2 # Fixes misaligned bloom.
+    halfPixelOffset: 4 # Aligns post bloom.
+    nativeScaling: 1 # Fixes light blooms.
     autoFlush: 2 # Helps fix misaligned bloom.
 SCES-53286:
   name: "Jak X - Combat Racing"
@@ -5343,6 +5418,8 @@ SCES-53286:
     cpuSpriteRenderBW: 2 # Fixes water textures. Can't use BW 4 here because of post effects.
     cpuSpriteRenderLevel: 2 # Needed for above.
     textureInsideRT: 1 # Fixes broken character models.
+    halfPixelOffset: 4 # Aligns post bloom.
+    nativeScaling: 1 # Fixes light blooms.
   memcardFilters: # Reads Ratchet Gladiator data.
     - "SCES-53286"
     - "SCES-53285"
@@ -5395,6 +5472,7 @@ SCES-53326:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misalignments and borders on side.
+    nativeScaling: 2 # Fixes post processing position and smoothness of shadows and depth of field.
   memcardFilters:
     - "SCES-53326"
     - "SCES-50760"
@@ -5494,6 +5572,8 @@ SCES-53680:
   gsHWFixes:
     roundSprite: 1 # Fixes misaligned text.
     autoFlush: 2 # Fixes sun luminosity.
+    halfPixelOffset: 2 # Aligns Depth of Field.
+    nativeScaling: 2 # Fixes Depth of Field effect.
   patches:
     79BAD675:
       content: |-
@@ -5607,6 +5687,8 @@ SCES-53960:
   region: "PAL-M5"
   gsHWFixes:
     autoFlush: 1 # Fixes lighting.
+    halfPixelOffset: 4 # Aligns post effects.
+    nativeScaling: 1 # Fixes post processing position.
 SCES-54025:
   name: "SingStar Rocks!"
   region: "PAL-IR"
@@ -5952,6 +6034,7 @@ SCES-54794:
   region: "PAL-M5"
   gsHWFixes:
     autoFlush: 2
+    nativeScaling: 2 # Fixes post processing.
 SCES-54823:
   name: "SingStar Bollywood"
   region: "PAL-E"
@@ -6439,6 +6522,8 @@ SCKA-20011:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
     autoFlush: 2
+    halfPixelOffset: 4 # Aligns post bloom.
+    nativeScaling: 1 # Fixes light blooms.
 SCKA-20012:
   name: "Arc the Lad - Jeongryeongui Hwanghon"
   region: "NTSC-K"
@@ -6531,10 +6616,10 @@ SCKA-20027:
     - SoftwareRendererFMVHack # Fixes hash cache disabling itself.
   gsHWFixes:
     recommendedBlendingLevel: 4 # Improves banding and effect emulation.
-    halfPixelOffset: 3 # Fixes texture and lighting misalignment.
-    mergeSprite: 1 # Fixes most vertical lines and lighting misalignment.
     autoFlush: 1 # Fixes light bloom intensity.
     estimateTextureRegion: 1 # Improves performance and reduces hash cache size.
+    halfPixelOffset: 4 # Aligns post effects.
+    nativeScaling: 1 # Fixes post effects.
     getSkipCount: "GSC_GiTS"
 SCKA-20028:
   name: "Ico [PlayStation2 Big Hit Series]"
@@ -6599,7 +6684,8 @@ SCKA-20037:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves color and luminosity of surfaces.
     disablePartialInvalidation: 1 # Prevents the situation that a level (Aquatos) doesn't render characters and geometry.
-    halfPixelOffset: 2 # Fixes misaligned bloom.
+    halfPixelOffset: 4 # Aligns post bloom.
+    nativeScaling: 1 # Fixes light blooms.
     autoFlush: 2 # Helps fix misaligned bloom.
   memcardFilters:
     - "SCKA-20037"
@@ -6626,6 +6712,7 @@ SCKA-20040:
     cpuSpriteRenderBW: 4 # Fixes character and water textures.
     cpuSpriteRenderLevel: 2 # Needed for above.
     autoFlush: 2 # Fixes lighting.
+    nativeScaling: 2 # Fixes lighting effects due to upscaling.
 SCKA-20041:
   name: "EyeToy - Play 2"
   region: "NTSC-K"
@@ -6661,6 +6748,8 @@ SCKA-20046:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
     autoFlush: 2
+    halfPixelOffset: 4 # Aligns post bloom.
+    nativeScaling: 1 # Fixes light blooms.
 SCKA-20047:
   name: "Armored Core - Nine Breaker"
   region: "NTSC-K"
@@ -6679,7 +6768,8 @@ SCKA-20048:
   clampModes:
     vuClampMode: 0 # Resolves I Reg Clamping / performance impact and yellow graphics in certain areas.
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes blurriness.
+    halfPixelOffset: 4 # Fixes post positioning.
+    nativeScaling: 2 # Fixes post effects.
 SCKA-20049:
   name: "Tekken 5"
   region: "NTSC-K"
@@ -6688,6 +6778,7 @@ SCKA-20049:
   gsHWFixes:
     alignSprite: 1
     halfPixelOffset: 4 # Align post.
+    nativeScaling: 1 # Fixes depth of field effect.
     getSkipCount: "GSC_Tekken5"
 SCKA-20050:
   name: "Tales of Legendia"
@@ -6757,7 +6848,8 @@ SCKA-20060:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
     disablePartialInvalidation: 1 # Prevents world geometry and some models from vanishing when pausing or opening vendor.
-    halfPixelOffset: 2 # Fixes misaligned bloom.
+    halfPixelOffset: 4 # Aligns post bloom.
+    nativeScaling: 1 # Fixes light blooms.
     autoFlush: 2 # Helps fix misaligned bloom.
 SCKA-20061:
   name: "Wanda to Kyozou"
@@ -6876,7 +6968,8 @@ SCKA-20078:
   clampModes:
     vuClampMode: 0 # Resolves I Reg Clamping / performance impact and yellow graphics in certain areas.
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes blurriness.
+    halfPixelOffset: 4 # Fixes post positioning.
+    nativeScaling: 2 # Fixes post effects.
 SCKA-20079:
   name: "Valkyrie Profile 2 - Silmeria"
   region: "NTSC-K"
@@ -6884,10 +6977,10 @@ SCKA-20079:
   gameFixes:
     - VuAddSubHack
   gsHWFixes:
-    halfPixelOffset: 2 # Reduces bloom misalignment.
-    roundSprite: 1 # Fixes area transition vertical lines and lessens red forest vertical lines.
+    halfPixelOffset: 4 # Reduces bloom misalignment.
     textureInsideRT: 1 # Required for swirl battle transition.
     nativePaletteDraw: 1
+    nativeScaling: 2 # Fixes depth of field effects and bloom.
 SCKA-20081:
   name: "Tekken 5 [PlayStation 2 Big Hit Series]"
   region: "NTSC-K"
@@ -6896,6 +6989,7 @@ SCKA-20081:
   gsHWFixes:
     alignSprite: 1
     halfPixelOffset: 4 # Align post.
+    nativeScaling: 1 # Fixes depth of field effect.
     getSkipCount: "GSC_Tekken5"
 SCKA-20082:
   name: "Ace Combat 5 - The Unsung War [PlayStation 2 Big Hit Series]"
@@ -6911,6 +7005,9 @@ SCKA-20082:
 SCKA-20084:
   name: "Monster House"
   region: "NTSC-K"
+  gsHWFixes:
+    halfPixelOffset: 4 # Reduces post misalignment.
+    nativeScaling: 2 # Fixes remaining post misalignment.
 SCKA-20085:
   name: "Minna no Tennis"
   region: "NTSC-K"
@@ -6920,12 +7017,14 @@ SCKA-20086:
   name: "Shin Onimusha - Dawn of Dreams [Disc 1 of 2]"
   region: "NTSC-K"
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes misalignment and upscaling lines.
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 2 # Fixes post processing smoothness and position.
 SCKA-20087:
   name: "Shin Onimusha - Dawn of Dreams [Disc 2 of 2]"
   region: "NTSC-K"
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes misalignment and upscaling lines.
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 2 # Fixes post processing smoothness and position.
   memcardFilters:
     - "SCKA-20086"
 SCKA-20089:
@@ -6958,19 +7057,21 @@ SCKA-20093:
   roundModes:
     vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
   gsHWFixes:
-    halfPixelOffset: 2 # Reduces blooming misalignment.
-    forceEvenSpritePosition: 1 # Reduces blooming misalignment.
+    halfPixelOffset: 4 # Aligns Post Effect.
+    nativeScaling: 2 # Fixes Post effect.
     autoFlush: 2 # Fixes glows.
 SCKA-20094:
   name: "Okami"
   region: "NTSC-K"
   gsHWFixes:
-    roundSprite: 2 # Reduces misalignment issues but the game is just bad for upscaling.
+    halfPixelOffset: 4 # Aligns post effects.
+    nativeScaling: 2 # Fixes post effects.
 SCKA-20095:
   name: "Okami"
   region: "NTSC-K"
   gsHWFixes:
-    roundSprite: 2 # Reduces misalignment issues but the game is just bad for upscaling.
+    halfPixelOffset: 4 # Aligns post effects.
+    nativeScaling: 2 # Fixes post effects.
 SCKA-20096:
   name: "Nickelodeon Barnyard"
   region: "NTSC-K"
@@ -7010,6 +7111,9 @@ SCKA-20105:
 SCKA-20106:
   name: "Wander to Kyozou"
   region: "NTSC-K"
+  gsHWFixes:
+    halfPixelOffset: 1 # Fixes misalignments and borders on side.
+    nativeScaling: 2 # Fixes post processing position and smoothness of shadows and depth of field.
 SCKA-20107:
   name: "Odin Sphere"
   region: "NTSC-K"
@@ -7020,7 +7124,8 @@ SCKA-20108:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
     disablePartialInvalidation: 1 # Prevents world geometry and some models from vanishing when pausing or opening vendor.
-    halfPixelOffset: 2 # Fixes misaligned bloom.
+    halfPixelOffset: 4 # Aligns post bloom.
+    nativeScaling: 1 # Fixes light blooms.
     autoFlush: 2 # Helps fix misaligned bloom.
 SCKA-20109:
   name: "Persona 3 FES [Independent Starting Version]"
@@ -7633,7 +7738,8 @@ SCPS-15017:
     instantVU1: 0 # Fixes noodles.
     mtvu: 0
   gsHWFixes:
-    forceEvenSpritePosition: 1 # Fixes misaligment depth of field effect.
+    halfPixelOffset: 4 # Aligns depth of field effect.
+    nativeScaling: 2 # Fixes post effect.
 SCPS-15018:
   name: THE 山手線 〜Train Simulator Real
   name-sort: THE やまのてせん Train Simulator Real
@@ -7785,6 +7891,9 @@ SCPS-15037:
   region: "NTSC-J"
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
+  gsHWFixes:
+    halfPixelOffset: 4 # Aligns post bloom.
+    nativeScaling: 1 # Fixes light blooms.
 SCPS-15038:
   name: OPERATOR’S SIDE マイク同梱版
   name-sort: おぺれーたーずさいど [まいくどうこんばん]
@@ -7922,6 +8031,8 @@ SCPS-15056:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
     autoFlush: 2
+    halfPixelOffset: 4 # Aligns post bloom.
+    nativeScaling: 1 # Fixes light blooms.
   memcardFilters:
     - "SCPS-15056"
     - "SCPS-15037"
@@ -8034,7 +8145,8 @@ SCPS-15066:
   region: "NTSC-J"
   gsHWFixes:
     autoFlush: 2 # Reduces post-processing misalignment.
-    halfPixelOffset: 4 # Reduces post-processing misalignment.
+    halfPixelOffset: 4 # Fixes post positioning.
+    nativeScaling: 2 # Fixes post effects.
 SCPS-15067:
   name: どこでもいっしょ トロと流れ星
   name-sort: どこでもいっしょ とろとながれぼし
@@ -8135,7 +8247,8 @@ SCPS-15084:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves color and luminosity of surfaces.
     disablePartialInvalidation: 1 # Prevents the situation that a level (Aquatos) doesn't render characters and geometry.
-    halfPixelOffset: 2 # Fixes misaligned bloom.
+    halfPixelOffset: 4 # Aligns post bloom.
+    nativeScaling: 1 # Fixes light blooms.
     autoFlush: 2 # Helps fix misaligned bloom.
   memcardFilters:
     - "SCPS-15084"
@@ -8281,7 +8394,8 @@ SCPS-15099:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
     disablePartialInvalidation: 1 # Prevents world geometry and some models from vanishing when pausing or opening vendor.
-    halfPixelOffset: 2 # Fixes misaligned bloom.
+    halfPixelOffset: 4 # Aligns post bloom.
+    nativeScaling: 1 # Fixes light blooms.
     autoFlush: 2 # Helps fix misaligned bloom.
 SCPS-15100:
   name: ラチェット＆クランク4th ギリギリ銀河のギガバトル
@@ -8292,7 +8406,8 @@ SCPS-15100:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
     disablePartialInvalidation: 1 # Prevents world geometry and some models from vanishing when pausing or opening vendor.
-    halfPixelOffset: 2 # Fixes misaligned bloom.
+    halfPixelOffset: 4 # Aligns post bloom.
+    nativeScaling: 1 # Fixes light blooms.
     autoFlush: 2 # Helps fix misaligned bloom.
 SCPS-15101:
   name: BLEACH 〜放たれし野望〜
@@ -8476,6 +8591,8 @@ SCPS-15120:
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes vendor and other bloom.
     autoFlush: 2 # Fixes missing bloom and shadow definition.
+    halfPixelOffset: 4 # Aligns post bloom.
+    nativeScaling: 1 # Fixes light blooms.
 SCPS-17001:
   name: グランツーリスモ4
   name-sort: ぐらんつーりすも4
@@ -8639,7 +8756,8 @@ SCPS-19201:
     instantVU1: 0 # Fixes noodles.
     mtvu: 0
   gsHWFixes:
-    forceEvenSpritePosition: 1 # Fixes misaligment depth of field effect.
+    halfPixelOffset: 4 # Aligns depth of field effect.
+    nativeScaling: 2 # Fixes post effect.
 SCPS-19202:
   name: EXTERMINATION PlayStation 2 the Best
   name-sort: EXTERMINATION PlayStation 2 the Best
@@ -8711,6 +8829,9 @@ SCPS-19211:
   region: "NTSC-J"
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
+  gsHWFixes:
+    halfPixelOffset: 4 # Aligns post bloom.
+    nativeScaling: 1 # Fixes light blooms.
 SCPS-19213:
   name: Operator’s Side USBマイク同梱版 PlayStation 2 the Best
   name-sort: おぺれーたーずさいど [USBまいくどうこんばん] PlayStation 2 the Best
@@ -8799,6 +8920,8 @@ SCPS-19302:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
     autoFlush: 2
+    halfPixelOffset: 4 # Aligns post bloom.
+    nativeScaling: 1 # Fixes light blooms.
 SCPS-19303:
   name: ぼくのなつやすみ2 海の冒険篇 PlayStation 2 the Best
   name-sort: ぼくのなつやすみ2 うみのぼうけんへん PlayStation 2 the Best
@@ -8871,7 +8994,8 @@ SCPS-19309:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves color and luminosity of surfaces.
     disablePartialInvalidation: 1 # Prevents the situation that a level (Aquatos) doesn't render characters and geometry.
-    halfPixelOffset: 2 # Fixes misaligned bloom.
+    halfPixelOffset: 4 # Aligns post bloom.
+    nativeScaling: 1 # Fixes light blooms.
     autoFlush: 2 # Helps fix misaligned bloom.
 SCPS-19310:
   name: ラチェット＆クランク PlayStation 2 the Best
@@ -8880,6 +9004,9 @@ SCPS-19310:
   region: "NTSC-J"
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
+  gsHWFixes:
+    halfPixelOffset: 4 # Aligns post bloom.
+    nativeScaling: 1 # Fixes light blooms.
 SCPS-19311:
   name: サルゲッチュ3 PlayStation 2 the Best
   name-sort: さるげっちゅ3 PlayStation 2 the Best
@@ -8931,6 +9058,9 @@ SCPS-19316:
   region: "NTSC-J"
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
+  gsHWFixes:
+    halfPixelOffset: 4 # Aligns post bloom.
+    nativeScaling: 1 # Fixes light blooms.
 SCPS-19317:
   name: ラチェット＆クランク2 ガガガ！銀河のコマンドーっす PlayStation 2 the Best
   name-sort: らちぇっとあんどくらんく2 ががが！ぎんがのこまんどーっす PlayStation 2 the Best
@@ -8940,6 +9070,8 @@ SCPS-19317:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
     autoFlush: 2
+    halfPixelOffset: 4 # Aligns post bloom.
+    nativeScaling: 1 # Fixes light blooms.
   memcardFilters:
     - "SCAJ-20001"
     - "SCPS-15037"
@@ -8980,7 +9112,8 @@ SCPS-19321:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
     disablePartialInvalidation: 1 # Prevents world geometry and some models from vanishing when pausing or opening vendor.
-    halfPixelOffset: 2 # Fixes misaligned bloom.
+    halfPixelOffset: 4 # Aligns post bloom.
+    nativeScaling: 1 # Fixes light blooms.
     autoFlush: 2 # Helps fix misaligned bloom.
 SCPS-19322:
   name: ワイルドアームズ ザ フォースデトネイター PlayStation 2 the Best
@@ -9068,7 +9201,8 @@ SCPS-19328:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
     disablePartialInvalidation: 1 # Prevents world geometry and some models from vanishing when pausing or opening vendor.
-    halfPixelOffset: 2 # Fixes misaligned bloom.
+    halfPixelOffset: 4 # Aligns post bloom.
+    nativeScaling: 1 # Fixes light blooms.
     autoFlush: 2 # Helps fix misaligned bloom.
 SCPS-19329:
   name: BLEACH 〜ブレイド・バトラーズ〜 PlayStation 2 the Best
@@ -9255,7 +9389,8 @@ SCPS-55019:
   gameFixes:
     - VuAddSubHack
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes bloom and ghosting in certain areas.
+    halfPixelOffset: 4 # Fix effects upscaling.
+    nativeScaling: 2 # Fixes post effects.
     roundSprite: 1 # Fixes door transition vertical lines and mini-map artifacts.
     textureInsideRT: 1 # Fixes missing battle effects.
 SCPS-55020:
@@ -9297,7 +9432,7 @@ SCPS-55029:
   name: ".hack Infection Part 1"
   region: "NTSC-J"
   gsHWFixes:
-    halfPixelOffset: 1 # Sharpens world in far distances.
+    halfPixelOffset: 2 # Aligns DoF effects.
   memcardFilters:
     - "SCPS-55029"
     - "SCPS-55042"
@@ -9405,9 +9540,8 @@ SCPS-55901:
   name: "Xenosaga Episode I - Der Wille zur Macht"
   region: "NTSC-J"
   gsHWFixes:
-    autoFlush: 2 # Fixes shadows in cutscenes.
-    halfPixelOffset: 2 # Removes puppet lines shadows.
-    roundSprite: 2 # Fixes font artifacts.
+    autoFlush: 1 # Fixes shadows in cutscenes.
+    halfPixelOffset: 4 # Removes puppet lines shadows.
   patches:
     A3D63039:
       content: |-
@@ -9539,8 +9673,8 @@ SCUS-10380:
   name: "LEGO Batman - The Videogame"
   region: "NTSC-U"
   gsHWFixes:
-    cpuCLUTRender: 1 # Fixes ghosting on objects and people.
-    halfPixelOffset: 2 # Fixes depth line. HPO Normal required if not using CLUT Renderer.
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 1 # Fixes post processing smoothness and position.
 SCUS-21052:
   name: "Disney/Pixar Monsters, Inc."
   region: "NTSC-U"
@@ -9552,8 +9686,8 @@ SCUS-21295:
     vu1RoundMode: 0 # Crashes without.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes water and grass textures.
-    forceEvenSpritePosition: 1 # Reduces post-processing misalignment.
-    mergeSprite: 1 # Reduces post-processing misalignment.
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 1 # Fixes post processing smoothness and position.
 SCUS-21494:
   name: "Need for Speed - Carbon Collector's Edition"
   region: "NTSC-U"
@@ -9569,8 +9703,8 @@ SCUS-90174:
   roundModes:
     vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
   gsHWFixes:
-    halfPixelOffset: 2 # Reduces the ghosting effect.
-    forceEvenSpritePosition: 1 # Reduces the ghosting effect.
+    halfPixelOffset: 4 # Aligns Post Effect.
+    nativeScaling: 2 # Fixes Post effect.
 SCUS-90682:
   name: "Gran Turismo 4"
   region: "NTSC-U"
@@ -9870,7 +10004,8 @@ SCUS-97167:
     instantVU1: 0 # Fixes noodles.
     mtvu: 0
   gsHWFixes:
-    forceEvenSpritePosition: 1 # Fixes misaligment depth of field effect.
+    halfPixelOffset: 4 # Aligns depth of field effect.
+    nativeScaling: 2 # Fixes post effect.
 SCUS-97169:
   name: "Drakan - The Ancients' Gates [Demo]"
   region: "NTSC-U"
@@ -9990,6 +10125,9 @@ SCUS-97199:
   compat: 5
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
+  gsHWFixes:
+    halfPixelOffset: 4 # Aligns post bloom.
+    nativeScaling: 1 # Fixes light blooms.
 SCUS-97200:
   name: "Kiosk Demo Disc 2.05"
   region: "NTSC-U"
@@ -10023,11 +10161,17 @@ SCUS-97208:
   speedHacks:
     instantVU1: 0 # Fixes noodles on Parappa 2.
     mtvu: 0
+  gsHWFixes:
+    halfPixelOffset: 4 # Aligns depth of field effect.
+    nativeScaling: 2 # Fixes post effect.
 SCUS-97209:
   name: "Ratchet & Clank [E3 Demo]"
   region: "NTSC-U"
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
+  gsHWFixes:
+    halfPixelOffset: 4 # Aligns post bloom.
+    nativeScaling: 1 # Fixes light blooms.
 SCUS-97210:
   name: "Sly Cooper and the Thievius Raccoonus [Demo]"
   region: "NTSC-U"
@@ -10162,6 +10306,9 @@ SCUS-97240:
     - EETimingHack # Fixes SPR errors while going in-game.
   roundModes:
     eeRoundMode: 0 # Fixes Hydrodisplacer behaviour.
+  gsHWFixes:
+    halfPixelOffset: 4 # Aligns post bloom.
+    nativeScaling: 1 # Fixes light blooms.
 SCUS-97241:
   name: "Official U.S. PlayStation Magazine Demo Disc 066"
   region: "NTSC-U"
@@ -10270,6 +10417,8 @@ SCUS-97268:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
     autoFlush: 2
+    halfPixelOffset: 4 # Aligns post bloom.
+    nativeScaling: 1 # Fixes light blooms.
   memcardFilters:
     - "SCUS-97268"
     - "SCUS-97199"
@@ -10371,6 +10520,8 @@ SCUS-97322:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
     autoFlush: 2
+    halfPixelOffset: 4 # Aligns post bloom.
+    nativeScaling: 1 # Fixes light blooms.
 SCUS-97323:
   name: "Ratchet & Clank 2 - Going Commando [Retail Employees Demo]"
   region: "NTSC-U"
@@ -10378,6 +10529,8 @@ SCUS-97323:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
     autoFlush: 2
+    halfPixelOffset: 4 # Aligns post bloom.
+    nativeScaling: 1 # Fixes light blooms.
 SCUS-97324:
   name: "Kiosk Demo Disc 2.11"
   region: "NTSC-U"
@@ -10425,6 +10578,7 @@ SCUS-97330:
     cpuSpriteRenderBW: 4 # Fixes character and water textures.
     cpuSpriteRenderLevel: 2 # Needed for above.
     autoFlush: 2 # Fixes lighting.
+    nativeScaling: 2 # Fixes lighting effects due to upscaling.
 SCUS-97331:
   name: "Official U.S. PlayStation Magazine Demo Disc 078"
   region: "NTSC-U"
@@ -10480,7 +10634,8 @@ SCUS-97353:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves color and luminosity of surfaces.
     disablePartialInvalidation: 1 # Prevents the situation that a level (Aquatos) doesn't render characters and geometry.
-    halfPixelOffset: 2 # Fixes misaligned bloom.
+    halfPixelOffset: 4 # Aligns post bloom.
+    nativeScaling: 1 # Fixes light blooms.
     autoFlush: 2 # Helps fix misaligned bloom.
   memcardFilters:
     - "SCUS-97353"
@@ -10507,6 +10662,7 @@ SCUS-97362:
   compat: 5
   gsHWFixes:
     autoFlush: 2
+    nativeScaling: 2 # Fixes post processing.
 SCUS-97365:
   name: "World Tour Soccer 2005"
   region: "NTSC-U"
@@ -10551,6 +10707,8 @@ SCUS-97374:
   gsHWFixes:
     cpuSpriteRenderBW: 4 # Fixes character and water textures.
     cpuSpriteRenderLevel: 2 # Needed for above.
+    halfPixelOffset: 4 # Aligns post bloom.
+    nativeScaling: 1 # Fixes light blooms.
 SCUS-97377:
   name: "Syphon Filter - The Omega Strain [Regular Demo]"
   region: "NTSC-U"
@@ -10575,6 +10733,8 @@ SCUS-97381:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
     autoFlush: 2
+    halfPixelOffset: 4 # Aligns post bloom.
+    nativeScaling: 1 # Fixes light blooms.
 SCUS-97382:
   name: "NBA Shootout 2004 [Demo]"
   region: "NTSC-U"
@@ -10639,7 +10799,8 @@ SCUS-97402:
   clampModes:
     vuClampMode: 0 # Resolves I Reg Clamping / performance impact and yellow graphics in certain areas.
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes blurriness.
+    halfPixelOffset: 4 # Fixes post positioning.
+    nativeScaling: 2 # Fixes post effects.
 SCUS-97403:
   name: "Athens 2004 [Demo]"
   region: "NTSC-U"
@@ -10680,7 +10841,8 @@ SCUS-97411:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves color and luminosity of surfaces.
     disablePartialInvalidation: 1 # Prevents the situation that a level (Aquatos) doesn't render characters and geometry.
-    halfPixelOffset: 2 # Fixes misaligned bloom.
+    halfPixelOffset: 4 # Aligns post bloom.
+    nativeScaling: 1 # Fixes light blooms.
     autoFlush: 2 # Helps fix misaligned bloom.
 SCUS-97412:
   name: "Jak 3 [Demo]"
@@ -10691,6 +10853,7 @@ SCUS-97412:
     cpuSpriteRenderBW: 4 # Fixes character and water textures.
     cpuSpriteRenderLevel: 2 # Needed for above.
     autoFlush: 2 # Fixes lighting.
+    nativeScaling: 2 # Fixes lighting effects due to upscaling.
 SCUS-97413:
   name: "Ratchet & Clank - Up Your Arsenal [Public Beta v1.0]"
   region: "NTSC-U"
@@ -10699,7 +10862,8 @@ SCUS-97413:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves color and luminosity of surfaces.
     disablePartialInvalidation: 1 # Prevents the situation that a level (Aquatos) doesn't render characters and geometry.
-    halfPixelOffset: 2 # Fixes misaligned bloom.
+    halfPixelOffset: 4 # Aligns post bloom.
+    nativeScaling: 1 # Fixes light blooms.
     autoFlush: 2 # Helps fix misaligned bloom.
 SCUS-97414:
   name: "EyeToy - AntiGrav"
@@ -10769,14 +10933,16 @@ SCUS-97431:
   clampModes:
     vuClampMode: 0 # Resolves I Reg Clamping / performance impact and yellow graphics in certain areas.
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes blurriness.
+    halfPixelOffset: 4 # Fixes post positioning.
+    nativeScaling: 2 # Fixes post effects.
 SCUS-97432:
   name: "Killzone [Regular Demo]"
   region: "NTSC-U"
   clampModes:
     vuClampMode: 0 # Resolves I Reg Clamping / performance impact and yellow graphics in certain areas.
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes blurriness.
+    halfPixelOffset: 4 # Fixes post positioning.
+    nativeScaling: 2 # Fixes post effects.
 SCUS-97436:
   name: "Gran Turismo 4 [Online Public Beta]"
   region: "NTSC-U"
@@ -10892,7 +11058,8 @@ SCUS-97465:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
     disablePartialInvalidation: 1 # Prevents world geometry and some models from vanishing when pausing or opening vendor.
-    halfPixelOffset: 2 # Fixes misaligned bloom.
+    halfPixelOffset: 4 # Aligns post bloom.
+    nativeScaling: 1 # Fixes light blooms.
     autoFlush: 2 # Helps fix misaligned bloom.
 SCUS-97466:
   name: "Gretzky NHL '06"
@@ -10922,6 +11089,7 @@ SCUS-97472:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misalignments and borders on side.
+    nativeScaling: 2 # Fixes post processing position and smoothness of shadows and depth of field.
   memcardFilters:
     - "SCUS-97472"
     - "SCUS-97113"
@@ -11034,7 +11202,8 @@ SCUS-97487:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
     disablePartialInvalidation: 1 # Prevents world geometry and some models from vanishing when pausing or opening vendor.
-    halfPixelOffset: 2 # Fixes misaligned bloom.
+    halfPixelOffset: 4 # Aligns post bloom.
+    nativeScaling: 1 # Fixes light blooms.
     autoFlush: 2 # Helps fix misaligned bloom.
 SCUS-97488:
   name: "Jak X - Combat Racing [Public Beta v.1]"
@@ -11123,6 +11292,7 @@ SCUS-97505:
   region: "NTSC-U"
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misalignments and borders on side.
+    nativeScaling: 2 # Fixes post processing position and smoothness of shadows and depth of field.
 SCUS-97506:
   name: "Gretzky NHL '06 [Demo]"
   region: "NTSC-U"
@@ -11162,6 +11332,8 @@ SCUS-97513:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
     autoFlush: 2
+    halfPixelOffset: 4 # Aligns post bloom.
+    nativeScaling: 1 # Fixes light blooms.
   memcardFilters:
     - "SCUS-97513"
     - "SCUS-97199"
@@ -11182,13 +11354,15 @@ SCUS-97516:
     cpuSpriteRenderBW: 4 # Fixes character and water textures.
     cpuSpriteRenderLevel: 2 # Needed for above.
     autoFlush: 2 # Fixes lighting.
+    nativeScaling: 2 # Fixes lighting effects due to upscaling.
 SCUS-97517:
   name: "Killzone [Greatest Hits]"
   region: "NTSC-U"
   clampModes:
     vuClampMode: 0 # Resolves I Reg Clamping / performance impact and yellow graphics in certain areas.
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes blurriness.
+    halfPixelOffset: 4 # Fixes post positioning.
+    nativeScaling: 2 # Fixes post effects.
 SCUS-97518:
   name: "Ratchet & Clank - Up Your Arsenal [Greatest Hits]"
   region: "NTSC-U"
@@ -11197,7 +11371,8 @@ SCUS-97518:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves color and luminosity of surfaces.
     disablePartialInvalidation: 1 # Prevents the situation that a level (Aquatos) doesn't render characters and geometry.
-    halfPixelOffset: 2 # Fixes misaligned bloom.
+    halfPixelOffset: 4 # Aligns post bloom.
+    nativeScaling: 1 # Fixes light blooms.
     autoFlush: 2 # Helps fix misaligned bloom.
   memcardFilters:
     - "SCUS-97518"
@@ -11393,6 +11568,7 @@ SCUS-97584:
   gsHWFixes:
     autoFlush: 2
     preloadFrameData: 1
+    nativeScaling: 2 # Fixes post processing.
 SCUS-97589:
   name: "NBA '08 featuring The Life Vol.3"
   region: "NTSC-U"
@@ -11464,6 +11640,7 @@ SCUS-97620:
   region: "NTSC-U"
   gsHWFixes:
     autoFlush: 2
+    nativeScaling: 2 # Fixes post processing.
 SCUS-97621:
   name: "Twisted Metal - Head-On [Extra Twisted Edition]"
   region: "NTSC-U"
@@ -11715,7 +11892,8 @@ SLAJ-25051:
   name-sort: "Lord of the Rings, The - The Third Age"
   region: "NTSC-C"
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes ghosting.
+    halfPixelOffset: 4 # Aligns post processing.
+    nativeScaling: 2 # Corrects post processing smoothness.
 SLAJ-25052:
   name: "The Urbz - Sims in the City"
   name-sort: "Urbz, The - Sims in the City"
@@ -11733,11 +11911,15 @@ SLAJ-25053:
     autoFlush: 2 # Fixes blur and obscures sun behind objects.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     bilinearUpscale: 2 # Smooths out sun glare textures like native.
+    nativeScaling: 2 # Smooths speed blur and corrects some lighting.
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
 SLAJ-25055:
   name: "Def Jam - Fight for N.Y."
   region: "NTSC-Unk"
+  gsHWFixes:
+    halfPixelOffset: 4 # Reduces post misalignment.
+    nativeScaling: 2 # Fixes remaining post misalignment.
 SLAJ-25056:
   name: "Shining Tears"
   region: "NTSC-Unk"
@@ -11770,6 +11952,7 @@ SLAJ-25066:
     autoFlush: 2 # Fixes blur and obscures sun behind objects.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     bilinearUpscale: 2 # Smooths out sun glare textures like native.
+    nativeScaling: 2 # Smooths speed blur and corrects some lighting.
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
   memcardFilters:
@@ -11844,6 +12027,8 @@ SLAJ-25078:
     recommendedBlendingLevel: 4 # Improves lighting on buildings and objects.
     autoFlush: 2 # Properly diffuses light instead of strips of light.
     roundSprite: 1 # Fixes lighting misalignment such as the street poles and the sun.
+    halfPixelOffset: 2 # Mostly aligns post processing.
+    nativeScaling: 2 # Improves post processing smoothness.
     getSkipCount: "GSC_BlackAndBurnoutSky"
     beforeDraw: "OI_BurnoutGames"
 SLAJ-25079:
@@ -11898,6 +12083,7 @@ SLAJ-25094:
     autoFlush: 2 # Fixes blur and obscures sun behind objects.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     bilinearUpscale: 2 # Smooths out sun glare textures like native.
+    nativeScaling: 2 # Smooths speed blur and corrects some lighting.
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
 SLAJ-25095:
@@ -12047,8 +12233,9 @@ SLED-51211:
   gsHWFixes:
     gpuTargetCLUT: 1 # Fixes bloom and sun rendering in front of everything.
     autoFlush: 1 # Fixes bloom and sun rendering in front of everything.
-    halfPixelOffset: 2 # Aligns bloom effect a little bit better when upscaled.
+    halfPixelOffset: 4 # Aligns bloom effect.
     bilinearUpscale: 2 # Reduces color banding of the sun glare.
+    nativeScaling: 2 # Fixes post lighting.
   roundModes:
     vu1RoundMode: 1 # Bright lights in cars.
 SLED-51212:
@@ -12091,9 +12278,16 @@ SLED-51380:
   region: "PAL-E"
   gameFixes:
     - InstantDMAHack # Fixes cut-off text.
+  gsHWFixes:
+    halfPixelOffset: 1 # Aligns post effects.
+    nativeScaling: 2 # Fixes post effects.
 SLED-51472:
   name: "Tom Clancy's Splinter Cell"
   region: "PAL-Unk"
+  gsHWFixes:
+    halfPixelOffset: 4 # Aligns post processing.
+    nativeScaling: 2 # Fixes post effects.
+    recommendedBlendingLevel: 4 # Fixes lighting effects but has high barrier count.
 SLED-51645:
   name: "Def Jam - Vendetta [Demo]"
   region: "PAL-E"
@@ -12140,6 +12334,8 @@ SLED-51961:
   region: "PAL-E"
   gsHWFixes:
     autoFlush: 2 # Reduces post-processing misalignment.
+    halfPixelOffset: 4 # Fixes post positioning.
+    nativeScaling: 2 # Fixes post effects.
 SLED-51962:
   name: "Nordic Fall 2003 Demo"
   region: "PAL-SC"
@@ -12242,6 +12438,10 @@ SLED-52488:
   region: "PAL-E"
   speedHacks:
     instantVU1: 1 # Fixes SPS.
+  gsHWFixes:
+    autoFlush: 2 # Fixes debris and blending on lower part of screen during monster transformation.
+    halfPixelOffset: 4 # Aligns post processing, might sometimes cause edge bleed which must be cropped.
+    nativeScaling: 2 # Fixes post effects like lights.
 SLED-52506:
   name: "Mashed - Drive to Survive [Demo]"
   region: "PAL-M5"
@@ -12263,6 +12463,7 @@ SLED-52597:
     autoFlush: 2 # Fixes blur and obscures sun behind objects.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     bilinearUpscale: 2 # Smooths out sun glare textures like native.
+    nativeScaling: 2 # Smooths speed blur and corrects some lighting.
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
 SLED-52736:
@@ -12306,17 +12507,21 @@ SLED-52899:
   clampModes:
     vuClampMode: 0 # Resolves I Reg Clamping / performance impact and yellow graphics in certain areas.
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes blurriness.
+    halfPixelOffset: 4 # Fixes post positioning.
+    nativeScaling: 2 # Fixes post effects.
 SLED-52929:
   name: "Prince of Persia - Warrior Within [Demo]"
   region: "PAL-M5"
   gsHWFixes:
     autoFlush: 2 # Reduces post-processing misalignment.
+    halfPixelOffset: 4 # Fixes post positioning.
+    nativeScaling: 2 # Fixes post effects.
 SLED-52979:
   name: "Mercenaries - Playground of Destruction [Demo]"
   region: "PAL-E"
   gsHWFixes:
     autoFlush: 2 # Fixes missing lighting.
+    nativeScaling: 1 # Fixes post lighting.
     # halfPixelOffset: 1 # Fixes lighting misalignment. Do not enable this, it breaks a lot of graphics.
 SLED-53066:
   name: "TimeSplitters - Future Perfect"
@@ -12378,6 +12583,7 @@ SLED-53440:
   region: "PAL-Unk"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misaligned lighting and other effects, needs Special otherwise lights flicker.
+    nativeScaling: 2 # Fixes lights.
 SLED-53442:
   name: "Crash Tag Team Racing [Demo]"
   region: "PAL-E"
@@ -12395,7 +12601,8 @@ SLED-53445:
     eeCycleRate: 1 # Fixes occasional post process flickering.
   gsHWFixes:
     nativePaletteDraw: 1 # Fixes lines in certain effects when upscaled.
-    halfPixelOffset: 2 # Fixes offset bloom.
+    halfPixelOffset: 4 # Fixes post positioning.
+    nativeScaling: 1 # Fixes post effects.
 SLED-53512:
   name: "Burnout Revenge [Demo]"
   region: "PAL-E"
@@ -12408,6 +12615,7 @@ SLED-53512:
     autoFlush: 2 # Fixes blur and obscures sun behind objects.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     bilinearUpscale: 2 # Smooths out sun glare textures like native.
+    nativeScaling: 2 # Smooths speed blur and corrects some lighting.
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
 SLED-53537:
@@ -12423,6 +12631,9 @@ SLED-53543:
 SLED-53591:
   name: "Fahrenheit [Demo]"
   region: "PAL-E"
+  gsHWFixes:
+    halfPixelOffset: 4 # Aligns post processing.
+    nativeScaling: 2 # Fixes post processing position.
 SLED-53619:
   name: "Tom Clancy's Rainbow Six - Lockdown"
   region: "PAL-Unk"
@@ -12434,6 +12645,10 @@ SLED-53625:
 SLED-53627:
   name: "The Suffering - Ties that Bind"
   region: "PAL-Unk"
+  gsHWFixes:
+    autoFlush: 2 # Fixes debris and blending on lower part of screen during monster transformation.
+    halfPixelOffset: 4 # Aligns post processing, might sometimes cause edge bleed which must be cropped.
+    nativeScaling: 2 # Fixes post effects like lights.
 SLED-53637:
   name: "Burnout Revenge [Demo]"
   region: "PAL-M2"
@@ -12445,6 +12660,7 @@ SLED-53637:
     autoFlush: 2 # Fixes blur and obscures sun behind objects.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     bilinearUpscale: 2 # Smooths out sun glare textures like native.
+    nativeScaling: 2 # Smooths speed blur and corrects some lighting.
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
 SLED-53650:
@@ -12505,6 +12721,9 @@ SLED-53732:
 SLED-53745:
   name: "Total Overdose [Demo]"
   region: "PAL-M5"
+  gsHWFixes:
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 1 # Fixes post processing smoothness and position.
 SLED-53770:
   name: "The Sims 2 [Demo]"
   name-sort: "Sims 2, The [Demo]"
@@ -12521,6 +12740,13 @@ SLED-53845:
 SLED-53888:
   name: "TOCA Race Driver 3 + V8 Supercars Australia 3"
   region: "PAL-A"
+  gsHWFixes:
+    alignSprite: 1 # Fixes lighting and vertical lines, also works with normal vertex.
+    roundSprite: 1 # Fixes misaligned map.
+    skipDrawStart: 1 # Removes large black box around player car till we properly emulate it.
+    skipDrawEnd: 1 # Removes large black box around player car till we properly emulate it.
+    halfPixelOffset: 2 # Fixes depth of field alignment.
+    nativeScaling: 1 # Fixes depth of field.
 SLED-53937:
   name: "Black [Demo]"
   region: "PAL-M5"
@@ -12530,6 +12756,8 @@ SLED-53937:
     recommendedBlendingLevel: 4 # Improves lighting on buildings and objects.
     autoFlush: 2 # Properly diffuses light instead of strips of light.
     roundSprite: 1 # Fixes lighting misalignment such as the street poles and the sun.
+    halfPixelOffset: 2 # Mostly aligns post processing.
+    nativeScaling: 2 # Improves post processing smoothness.
     getSkipCount: "GSC_BlackAndBurnoutSky"
     beforeDraw: "OI_BurnoutGames"
 SLED-53951:
@@ -12582,6 +12810,8 @@ SLED-54022:
     textureInsideRT: 1 # Needed for post processing effects.
     autoFlush: 1 # Fixes bloom intensity.
     minimumBlendingLevel: 4 # Fixes multiple lighting effects from lights, computers, cave walls and more.
+    nativeScaling: 1 # Fixes post processing.
+    halfPixelOffset: 4 # Fixes offset post processing.
 SLED-54032:
   name: "Sonic Riders [Demo]"
   region: "PAL-E"
@@ -12603,7 +12833,8 @@ SLED-54315:
   name: "LEGO Star Wars II - The Original Trilogy [Demo]"
   region: "PAL-M5"
   gsHWFixes:
-    cpuCLUTRender: 1 # Fixes ghosting on objects and people.
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 1 # Fixes post processing smoothness and position.
 SLED-54327:
   name: "FIFA '07"
   region: "PAL-Unk"
@@ -12618,10 +12849,9 @@ SLED-54401:
   region: "PAL-E"
   gsHWFixes:
     textureInsideRT: 1 # Fixes shadow maps.
-    roundSprite: 2 # Fixes misaligned bloom.
-    mergeSprite: 1 # Fixes misaligned bloom.
     halfPixelOffset: 2 # Fixes misaligned bloom.
     autoFlush: 2 # Fixes sun occlusion and brightness.
+    nativeScaling: 2 # Fixes post processing and lighting smoothness and position.
 SLED-54445:
   name: "Pro Evolution Soccer 6 [Demo]"
   region: "PAL-M5"
@@ -14222,6 +14452,8 @@ SLES-50717:
   compat: 5
   gsHWFixes:
     roundSprite: 1 # Fixes blue font artifacts.
+    halfPixelOffset: 4 # Aligns post effects.
+    nativeScaling: 1 # Fixes post effects.
 SLES-50720:
   name: "FMX - Freestyle Metal X"
   region: "PAL-M5"
@@ -14599,6 +14831,8 @@ SLES-50836:
     - EETimingHack # For texture flicker.
   gsHWFixes:
     textureInsideRT: 1
+    halfPixelOffset: 4 # Reduces post misalignment.
+    nativeScaling: 2 # Fixes remaining post misalignment.
 SLES-50837:
   name: "Indiana Jones et le Tombeau de L'Empereur"
   region: "PAL-F"
@@ -14606,6 +14840,8 @@ SLES-50837:
     - EETimingHack # For texture flicker.
   gsHWFixes:
     textureInsideRT: 1
+    halfPixelOffset: 4 # Reduces post misalignment.
+    nativeScaling: 2 # Fixes remaining post misalignment.
 SLES-50838:
   name: "Indiana Jones und die Legende der Kaisergruft"
   region: "PAL-G"
@@ -14614,6 +14850,8 @@ SLES-50838:
     - EETimingHack # For texture flicker.
   gsHWFixes:
     textureInsideRT: 1
+    halfPixelOffset: 4 # Reduces post misalignment.
+    nativeScaling: 2 # Fixes remaining post misalignment.
 SLES-50839:
   name: "Indiana Jones e la Tomba dell'Imperatore"
   region: "PAL-I"
@@ -14621,6 +14859,8 @@ SLES-50839:
     - EETimingHack # For texture flicker.
   gsHWFixes:
     textureInsideRT: 1
+    halfPixelOffset: 4 # Reduces post misalignment.
+    nativeScaling: 2 # Fixes remaining post misalignment.
 SLES-50840:
   name: "Indiana Jones y la Tumba del Emperador"
   region: "PAL-S"
@@ -14628,6 +14868,8 @@ SLES-50840:
     - EETimingHack # For texture flicker.
   gsHWFixes:
     textureInsideRT: 1
+    halfPixelOffset: 4 # Reduces post misalignment.
+    nativeScaling: 2 # Fixes remaining post misalignment.
 SLES-50841:
   name: "Largo Winch - Empire Under Threat"
   region: "PAL-M5"
@@ -14722,7 +14964,7 @@ SLES-50876:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     autoFlush: 1 # Aligns and corrects shadows.
-    roundSprite: 1 # Fixes depth line.
+    halfPixelOffset: 2 # Fixes sun and depth line.
     cpuCLUTRender: 1 # Fixes janky coloured cars.
     gpuTargetCLUT: 1 # Fixes janky coloured cars.
     textureInsideRT: 1 # Fixes car textures.
@@ -14918,6 +15160,9 @@ SLES-50978:
   name: "Onimusha 2 - Samurai's Destiny"
   region: "PAL-M5"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 2 # Fixes post processing smoothness and position.
 SLES-50981:
   name: "RC Sports Copter Challenge"
   region: "PAL-E"
@@ -15029,8 +15274,9 @@ SLES-51044:
   gsHWFixes:
     gpuTargetCLUT: 1 # Fixes bloom and sun rendering in front of everything.
     autoFlush: 1 # Fixes bloom and sun rendering in front of everything.
-    halfPixelOffset: 2 # Aligns bloom effect a little bit better when upscaled.
+    halfPixelOffset: 4 # Aligns bloom effect.
     bilinearUpscale: 2 # Reduces color banding of the sun glare.
+    nativeScaling: 2 # Fixes post lighting.
   roundModes:
     vu1RoundMode: 1 # Bright lights in cars.
 SLES-51045:
@@ -15208,6 +15454,9 @@ SLES-51113:
   compat: 5
   gameFixes:
     - InstantDMAHack # Fixes cut-off text.
+  gsHWFixes:
+    halfPixelOffset: 1 # Aligns post effects.
+    nativeScaling: 2 # Fixes post effects.
 SLES-51114:
   name: "Pro Evolution Soccer 2"
   region: "PAL-M5"
@@ -15286,6 +15535,9 @@ SLES-51144:
   name: "Shox - Rally Reinvented"
   region: "PAL-M7"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 4 # Aligns UI.
+    nativeScaling: 2 # Fixes window reflections.
 SLES-51145:
   name: "Monopoly Party"
   region: "PAL-M5"
@@ -15552,7 +15804,8 @@ SLES-51233:
   region: "PAL-M4"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes lines when powering up.
+    halfPixelOffset: 4 # Aligns post effects.
+    nativeScaling: 2 # Fixes post processing and lighting smoothness and position.
 SLES-51235:
   name: "Raging Blades"
   region: "PAL-M5"
@@ -15578,9 +15831,15 @@ SLES-51250:
   name: "Shox - Rally Reinvented"
   region: "PAL-E"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 4 # Aligns UI.
+    nativeScaling: 2 # Fixes window reflections.
 SLES-51251:
   name: "Shox - Rally Reinvented"
   region: "PAL-A"
+  gsHWFixes:
+    halfPixelOffset: 4 # Aligns UI.
+    nativeScaling: 2 # Fixes window reflections.
 SLES-51252:
   name: "The Lord of the Rings - The Two Towers"
   name-sort: "Lord of the Rings, The - The Two Towers"
@@ -15665,6 +15924,8 @@ SLES-51272:
     vuClampMode: 3 # Fixes water rendering.
   gameFixes:
     - XGKickHack # Fixes SPS while ingame.
+  gsHWFixes:
+    nativeScaling: 2 # Fixes water reflections.
 SLES-51273:
   name: "Wakeboarding Unleashed"
   region: "PAL-F"
@@ -15672,6 +15933,8 @@ SLES-51273:
     vuClampMode: 3 # Fixes water rendering.
   gameFixes:
     - XGKickHack # Fixes SPS while ingame.
+  gsHWFixes:
+    nativeScaling: 2 # Fixes water reflections.
 SLES-51275:
   name: "Summoner 2"
   region: "PAL-I"
@@ -15903,6 +16166,8 @@ SLES-51372:
   compat: 5
   clampModes:
     vuClampMode: 3 # Fixes minor SPS on characters.
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes post alignment.
 SLES-51374:
   name: "RoboCop"
   region: "PAL-M5"
@@ -16041,6 +16306,8 @@ SLES-51439:
   region: "PAL-M5"
   gsHWFixes:
     roundSprite: 1 # Fixes blue font artifacts.
+    halfPixelOffset: 4 # Aligns post effects.
+    nativeScaling: 1 # Fixes post effects.
 SLES-51441:
   name: "Dynasty Warriors 3 - Extreme Legends"
   region: "PAL-E"
@@ -16060,11 +16327,10 @@ SLES-51448:
   region: "PAL-M5"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 1 # Fixes character offset with flashlight and blurriness.
-    alignSprite: 1 # Fixes vertical lines.
+    halfPixelOffset: 4 # Fixes character offset with flashlight and blurriness.
     roundSprite: 2 # Fixes font artifacts.
-    mergeSprite: 1 # Fixes flame-like bleeding.
     autoFlush: 1 # Fixes light bloom intensity.
+    nativeScaling: 2 # Fixes post processing.
 SLES-51449:
   name: "Return to Castle Wolfenstein - Operation Resurrection"
   region: "PAL-E"
@@ -16098,6 +16364,10 @@ SLES-51466:
   name: "Tom Clancy's Splinter Cell"
   region: "PAL-M5"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 4 # Aligns post processing.
+    nativeScaling: 2 # Fixes post effects.
+    recommendedBlendingLevel: 4 # Fixes lighting effects but has high barrier count.
 SLES-51467:
   name: "Freedom Fighters"
   region: "PAL-E"
@@ -16453,7 +16723,8 @@ SLES-51682:
   name: "Headhunter - Redemption"
   region: "PAL-E"
   gsHWFixes:
-    halfPixelOffset: 1 # Fixes ghosting.
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 2 # Fixes post processing smoothness and position.
 SLES-51686:
   name: "Pitfall - The Lost Expedition"
   region: "PAL-E"
@@ -16484,6 +16755,10 @@ SLES-51693:
   name: "The Suffering"
   name-sort: "Suffering, The"
   region: "PAL-E-F-G"
+  gsHWFixes:
+    autoFlush: 2 # Fixes debris and blending on lower part of screen during monster transformation.
+    halfPixelOffset: 4 # Aligns post processing, might sometimes cause edge bleed which must be cropped.
+    nativeScaling: 2 # Fixes post effects like lights.
 SLES-51696:
   name: "Dragon's Lair 3D - Special Edition"
   region: "PAL-M5"
@@ -16514,6 +16789,8 @@ SLES-51705:
   region: "PAL-M5"
   gsHWFixes:
     autoFlush: 1 # Fixes missing sun.
+    halfPixelOffset: 4 # Aligns shadows.
+    nativeScaling: 1 # Softens Shadows.
 SLES-51707:
   name: "Secret Weapons Over Normandy"
   region: "PAL-E"
@@ -16653,8 +16930,8 @@ SLES-51766:
   name: "Gladiator - Sword of Vengeance"
   region: "PAL-M5"
   gsHWFixes:
-    roundSprite: 2 # Helps glow misalignment.
-    halfPixelOffset: 1 # Helps glow misalignment.
+    halfPixelOffset: 4 # Aligns post effects.
+    nativeScaling: 1 # Fixes post effects.
 SLES-51772:
   name: "Bad Boys II"
   region: "PAL-E"
@@ -16773,6 +17050,7 @@ SLES-51820:
     autoFlush: 2 # Fixes bloom misalignment.
     halfPixelOffset: 2 # Fixes bloom misalignment.
     textureInsideRT: 1 # Fixes sky bloom.
+    nativeScaling: 2 # Fixes post processing.
 SLES-51821:
   name: "Alias"
   region: "PAL-M5"
@@ -16805,14 +17083,14 @@ SLES-51827:
   name: "Gladiator - Sword of Vengeance"
   region: "PAL-E-FR"
   gsHWFixes:
-    roundSprite: 2 # Helps glow misalignment.
-    halfPixelOffset: 1 # Helps glow misalignment.
+    halfPixelOffset: 4 # Aligns post effects.
+    nativeScaling: 1 # Fixes post effects.
 SLES-51828:
   name: "Gladiator - Sword of Vengeance"
   region: "PAL-G"
   gsHWFixes:
-    roundSprite: 2 # Helps glow misalignment.
-    halfPixelOffset: 1 # Helps glow misalignment.
+    halfPixelOffset: 4 # Aligns post effects.
+    nativeScaling: 1 # Fixes post effects.
 SLES-51831:
   name: "Sphinx and The Cursed Mummy"
   region: "PAL-M5"
@@ -16829,6 +17107,9 @@ SLES-51839:
   name: "Dragon Ball Z - Budokai 2"
   region: "PAL-M5"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 4 # Aligns post effects.
+    nativeScaling: 2 # Fixes post processing and lighting smoothness and position.
 SLES-51840:
   name: "NHL Hitz Pro"
   region: "PAL-E"
@@ -16859,6 +17140,8 @@ SLES-51848:
     vu1RoundMode: 0 # Crashes without.
   gsHWFixes:
     minimumBlendingLevel: 3 # Fixes broken lighting on ground and buildings.
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 1 # Fixes post processing smoothness and position.
 SLES-51850:
   name: "Basketball Xciting"
   region: "PAL-E"
@@ -16869,6 +17152,8 @@ SLES-51851:
     vu1RoundMode: 0 # Crashes without.
   gsHWFixes:
     minimumBlendingLevel: 3 # Fixes broken lighting on ground and buildings.
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 1 # Fixes post processing smoothness and position.
 SLES-51852:
   name: "Tony Hawk's Underground"
   region: "PAL-G"
@@ -16877,6 +17162,8 @@ SLES-51852:
     vu1RoundMode: 0 # Crashes without.
   gsHWFixes:
     minimumBlendingLevel: 3 # Fixes broken lighting on ground and buildings.
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 1 # Fixes post processing smoothness and position.
 SLES-51853:
   name: "Tony Hawk's Underground"
   region: "PAL-F"
@@ -16884,6 +17171,8 @@ SLES-51853:
     vu1RoundMode: 0 # Crashes without.
   gsHWFixes:
     minimumBlendingLevel: 3 # Fixes broken lighting on ground and buildings.
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 1 # Fixes post processing smoothness and position.
 SLES-51854:
   name: "Tony Hawk's Underground"
   region: "PAL-S"
@@ -16891,12 +17180,16 @@ SLES-51854:
     vu1RoundMode: 0 # Crashes without.
   gsHWFixes:
     minimumBlendingLevel: 3 # Fixes broken lighting on ground and buildings.
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 1 # Fixes post processing smoothness and position.
 SLES-51855:
   name: "Tank Elite"
   region: "PAL-E"
 SLES-51856:
   name: "Monster Attack"
   region: "PAL-E"
+  gsHWFixes:
+    halfPixelOffset: 4 # Fixes depth of field positioning.
 SLES-51859:
   name: "Billiards Xciting"
   region: "PAL-E"
@@ -17052,7 +17345,8 @@ SLES-51914:
     - "SLES-51913"
     - "SLES-51914"
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes ghosting.
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 2 # Fixes post processing smoothness and position.
     roundSprite: 2 # Fixes various lines / reduces bars on right edge.
     disablePartialInvalidation: 1 # Fixes textureless graphics ingame.
     bilinearUpscale: 2 # Gets rid of center vertical line when upscaling.
@@ -17175,7 +17469,8 @@ SLES-51961:
   region: "PAL-E"
   gsHWFixes:
     autoFlush: 2 # Reduces post-processing misalignment.
-    halfPixelOffset: 4 # Reduces post-processing misalignment.
+    halfPixelOffset: 4 # Fixes post positioning.
+    nativeScaling: 2 # Fixes post effects.
 SLES-51963:
   name: "FIFA 2004"
   region: "PAL-F-G"
@@ -17251,6 +17546,8 @@ SLES-51989:
   compat: 5
   clampModes:
     vuClampMode: 3 # Fixes minor SPS on characters.
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes post alignment.
 SLES-51991:
   name: "Dance UK"
   region: "PAL-E"
@@ -17335,6 +17632,8 @@ SLES-52026:
   compat: 5
   clampModes:
     vuClampMode: 3 # Fixes minor SPS on characters.
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes post alignment.
 SLES-52028:
   name: "Junior Sports Basketball"
   region: "PAL-M5"
@@ -17581,7 +17880,7 @@ SLES-52153:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     autoFlush: 1 # Aligns and corrects shadows.
-    roundSprite: 1 # Fixes depth line.
+    halfPixelOffset: 2 # Fixes sun and depth line.
     cpuCLUTRender: 1 # Fixes janky coloured cars.
     gpuTargetCLUT: 1 # Fixes janky coloured cars.
     textureInsideRT: 1 # Fixes car textures.
@@ -17638,8 +17937,8 @@ SLES-52190:
   compat: 5
   gsHWFixes:
     autoFlush: 1
-    roundSprite: 2 # Aligns bloom effect
-    forceEvenSpritePosition: 1 # Aligns bloom effect
+    halfPixelOffset: 2 # Corrects post processing positioning.
+    nativeScaling: 2 # Fixes post processing effect and position.
 SLES-52202:
   name: "Downhill Domination"
   region: "PAL-M5"
@@ -17675,7 +17974,8 @@ SLES-52219:
     instantVU1: 1 # Increases FPS drastically.
     mtvu: 0
   gsHWFixes:
-    halfPixelOffset: 3 # Reduces ghosting.
+    halfPixelOffset: 4 # Aligns Post.
+    nativeScaling: 2 # Corrects post effect and reflections on cars.
 SLES-52230:
   name: "Muppets Party Cruise"
   region: "PAL-E-F"
@@ -17687,7 +17987,7 @@ SLES-52237:
   name: ".hack Infection Part 1"
   region: "PAL-M5"
   gsHWFixes:
-    halfPixelOffset: 1 # Sharpens world in far distances.
+    halfPixelOffset: 2 # Aligns DoF effects.
   memcardFilters:
     - "SLES-52237"
     - "SLES-52467"
@@ -18133,6 +18433,9 @@ SLES-52413:
   name: "Malice"
   region: "PAL-M5"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 4 # Fixes post positioning.
+    nativeScaling: 1 # Fixes post effects.
 SLES-52418:
   name: "Power Drome"
   region: "PAL-M5"
@@ -18159,6 +18462,10 @@ SLES-52439:
   name-sort: "Suffering, The"
   region: "PAL-E-I-S"
   compat: 5
+  gsHWFixes:
+    autoFlush: 2 # Fixes debris and blending on lower part of screen during monster transformation.
+    halfPixelOffset: 4 # Aligns post processing, might sometimes cause edge bleed which must be cropped.
+    nativeScaling: 2 # Fixes post effects like lights.
 SLES-52440:
   name: "Harry Potter and the Prisoner of Azkaban"
   region: "PAL-M7"
@@ -18317,6 +18624,9 @@ SLES-52507:
   name: "Def Jam - Fight for New York"
   region: "PAL-E-F"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 4 # Reduces post misalignment.
+    nativeScaling: 2 # Fixes remaining post misalignment.
 SLES-52508:
   name: "Obscure"
   region: "PAL-G"
@@ -18337,12 +18647,14 @@ SLES-52511:
   name: "Headhunter - Redemption"
   region: "PAL-E"
   gsHWFixes:
-    halfPixelOffset: 1 # Fixes ghosting.
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 2 # Fixes post processing smoothness and position.
 SLES-52512:
   name: "Headhunter - Redemption"
   region: "PAL-M4"
   gsHWFixes:
-    halfPixelOffset: 1 # Fixes ghosting.
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 2 # Fixes post processing smoothness and position.
 SLES-52515:
   name: "Ultimate Casino"
   region: "PAL-E"
@@ -18389,6 +18701,10 @@ SLES-52531:
   region: "PAL-G"
   speedHacks:
     instantVU1: 1 # Fixes SPS.
+  gsHWFixes:
+    autoFlush: 2 # Fixes debris and blending on lower part of screen during monster transformation.
+    halfPixelOffset: 4 # Aligns post processing, might sometimes cause edge bleed which must be cropped.
+    nativeScaling: 2 # Fixes post effects like lights.
 SLES-52532:
   name: "Aces of War"
   region: "PAL-E"
@@ -18399,8 +18715,8 @@ SLES-52534:
   name: "Crimson Tears"
   region: "PAL-M3"
   gsHWFixes:
-    forceEvenSpritePosition: 1 # Fixes blurriness.
-    roundSprite: 2 # Reduces misalignment bloom effects.
+    halfPixelOffset: 1 # Aligns post effects.
+    nativeScaling: 2 # Fixes post effects.
 #    deinterlace: 6 # Game requires blend tff de-interlacing when auto for 'fixing' shimmer on character models and more flickering or half weaved, though the game suffers from the field order.
 SLES-52535:
   name: "Rumble Roses"
@@ -18442,16 +18758,22 @@ SLES-52545:
   compat: 5
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves reflections on certain characters and objects on certain levels.
+    halfPixelOffset: 4 # Corrects post processing positioning.
+    nativeScaling: 2 # Smooths post processing.
 SLES-52546:
   name: "Star Wars - Battlefront"
   region: "PAL-F"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves reflections on certain characters and objects on certain levels.
+    halfPixelOffset: 4 # Corrects post processing positioning.
+    nativeScaling: 2 # Smooths post processing.
 SLES-52547:
   name: "Star Wars - Battlefront"
   region: "PAL-G"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves reflections on certain characters and objects on certain levels.
+    halfPixelOffset: 4 # Corrects post processing positioning.
+    nativeScaling: 2 # Smooths post processing.
 SLES-52551:
   name: "Samurai Warriors"
   region: "PAL-E"
@@ -18518,6 +18840,8 @@ SLES-52567:
     recommendedBlendingLevel: 4 # Fixes bloom.
     autoFlush: 1 # Fixes ghosting.
     textureInsideRT: 1 # Required for offset RTs/textures for post-processing.
+    halfPixelOffset: 2 # Aligns post effects.
+    nativeScaling: 2 # Fixes post effects.
 SLES-52568:
   name: "Crash Twinsanity"
   region: "PAL-M5"
@@ -18539,6 +18863,7 @@ SLES-52570:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misaligned lighting and other effects, needs Special otherwise lights flicker.
+    nativeScaling: 2 # Fixes lights.
 SLES-52571:
   name: "Pacific Air Warriors 2 - Dogfight"
   region: "PAL-E"
@@ -18574,6 +18899,7 @@ SLES-52584:
     autoFlush: 2 # Fixes blur and obscures sun behind objects.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     bilinearUpscale: 2 # Smooths out sun glare textures like native.
+    nativeScaling: 2 # Smooths speed blur and corrects some lighting.
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
 SLES-52585:
@@ -18587,6 +18913,7 @@ SLES-52585:
     autoFlush: 2 # Fixes blur and obscures sun behind objects.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     bilinearUpscale: 2 # Smooths out sun glare textures like native.
+    nativeScaling: 2 # Smooths speed blur and corrects some lighting.
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
 SLES-52587:
@@ -18598,18 +18925,21 @@ SLES-52588:
   region: "PAL-E"
   gsHWFixes:
     autoFlush: 2 # Fixes missing lighting.
+    nativeScaling: 1 # Fixes post lighting.
     # halfPixelOffset: 1 # Fixes lighting misalignment. Do not enable this, it breaks a lot of graphics.
 SLES-52589:
   name: "Mercenaries - Playground of Destruction"
   region: "PAL-F"
   gsHWFixes:
     autoFlush: 2 # Fixes missing lighting.
+    nativeScaling: 1 # Fixes post lighting.
     # halfPixelOffset: 1 # Fixes lighting misalignment. Do not enable this, it breaks a lot of graphics.
 SLES-52590:
   name: "Mercenaries - Playground of Destruction"
   region: "PAL-G"
   gsHWFixes:
     autoFlush: 2 # Fixes missing lighting.
+    nativeScaling: 1 # Fixes post lighting.
     # halfPixelOffset: 1 # Fixes lighting misalignment. Do not enable this, it breaks a lot of graphics.
 SLES-52591:
   name: "Dynasty Warriors 4 - Empires"
@@ -18673,8 +19003,8 @@ SLES-52621:
   gsHWFixes:
     preloadFrameData: 1 # Fixes missing loading screens.
     recommendedBlendingLevel: 3 # Fixes water and grass textures.
-    forceEvenSpritePosition: 1 # Reduces post-processing misalignment.
-    mergeSprite: 1 # Reduces post-processing misalignment.
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 1 # Fixes post processing smoothness and position.
 SLES-52622:
   name: "Tony Hawk's Underground 2"
   region: "PAL-M4"
@@ -18683,8 +19013,8 @@ SLES-52622:
   gsHWFixes:
     preloadFrameData: 1 # Fixes missing loading screens.
     recommendedBlendingLevel: 3 # Fixes water and grass textures.
-    forceEvenSpritePosition: 1 # Reduces post-processing misalignment.
-    mergeSprite: 1 # Reduces post-processing misalignment.
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 1 # Fixes post processing smoothness and position.
 SLES-52624:
   name: "X-Men Legends"
   region: "PAL-E"
@@ -19050,6 +19380,9 @@ SLES-52730:
   name: "Dragon Ball Z - Budokai 3"
   region: "PAL-M5"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 4 # Aligns post effects.
+    nativeScaling: 2 # Fixes post processing and lighting smoothness and position.
 SLES-52731:
   name: "One Piece - Round the Land!"
   region: "PAL-M3"
@@ -19206,7 +19539,8 @@ SLES-52801:
   name-sort: "Lord of the Rings, The - The Third Age"
   region: "PAL-M5"
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes ghosting.
+    halfPixelOffset: 4 # Aligns post processing.
+    nativeScaling: 2 # Corrects post processing smoothness.
 SLES-52802:
   name: "Seigneur des anneaux, Le - Le Tiers Âge"
   region: "PAL-F"
@@ -19233,28 +19567,32 @@ SLES-52807:
   clampModes:
     eeClampMode: 3 # Fixes the inability to collect items.
   gsHWFixes:
-    halfPixelOffset: 1 # Reduces lighting misalignment but doesn't fully fix it.
+    halfPixelOffset: 4 # Aligns post effects.
+    nativeScaling: 2 # Fixes post effects.
 SLES-52808:
   name: "Désastreuses Aventures des orphelins Baudelaire, Les"
   region: "PAL-F"
   clampModes:
     eeClampMode: 3 # Fixes the inability to collect items.
   gsHWFixes:
-    halfPixelOffset: 1 # Reduces lighting misalignment but doesn't fully fix it.
+    halfPixelOffset: 4 # Aligns post effects.
+    nativeScaling: 2 # Fixes post effects.
 SLES-52809:
   name: "Lemony Snicket - Schauriger Schlamassel"
   region: "PAL-G"
   clampModes:
     eeClampMode: 3 # Fixes the inability to collect items.
   gsHWFixes:
-    halfPixelOffset: 1 # Reduces lighting misalignment but doesn't fully fix it.
+    halfPixelOffset: 4 # Aligns post effects.
+    nativeScaling: 2 # Fixes post effects.
 SLES-52810:
   name: "Lemony Snicket Una Serie Di Sfortunati Eventi"
   region: "PAL-I"
   clampModes:
     eeClampMode: 3 # Fixes the inability to collect items.
   gsHWFixes:
-    halfPixelOffset: 1 # Reduces lighting misalignment but doesn't fully fix it.
+    halfPixelOffset: 4 # Aligns post effects.
+    nativeScaling: 2 # Fixes post effects.
 SLES-52811:
   name: "Get on da Mic"
   region: "PAL-M3"
@@ -19263,55 +19601,57 @@ SLES-52812:
   region: "PAL-E"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes bloom misalignment when upscaling.
-    cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling.
+    halfPixelOffset: 4 # Aligns post effects.
+    nativeScaling: 2 # Fixes post effects.
 SLES-52813:
   name: "Disney/Pixar The Incredibles"
   name-sort: "Incredibles, The"
   region: "PAL-NL-F"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes bloom misalignment when upscaling.
-    cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling.
+    halfPixelOffset: 4 # Aligns post effects.
+    nativeScaling: 2 # Fixes post effects.
 SLES-52814:
   name: "Disney/Pixar Gli Incredibili"
   name-sort: "Incredibles, The"
   region: "PAL-I"
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes bloom misalignment when upscaling.
-    cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling.
+    halfPixelOffset: 4 # Aligns post effects.
+    nativeScaling: 2 # Fixes post effects.
 SLES-52815:
   name: "Disney/Pixar Die Unglaublichen"
   region: "PAL-G"
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes bloom misalignment when upscaling.
-    cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling.
+    halfPixelOffset: 4 # Aligns post effects.
+    nativeScaling: 2 # Fixes post effects.
 SLES-52816:
   name: "Disney/Pixar Los Increíbles"
   name-sort: "Disney/Pixar Increíbles, Los"
   region: "PAL-S"
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes bloom misalignment when upscaling.
-    cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling.
+    halfPixelOffset: 4 # Aligns post effects.
+    nativeScaling: 2 # Fixes post effects.
 SLES-52820:
   name: "Disney/Pixar The Incredibles"
   name-sort: "Disney/Pixar Incredibles, The"
   region: "PAL-SC"
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes bloom misalignment when upscaling.
-    cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling.
+    halfPixelOffset: 4 # Aligns post effects.
+    nativeScaling: 2 # Fixes post effects.
 SLES-52821:
   name: "Disney/Pixar The Incredibles - Os Super-Heróis"
   region: "PAL-P"
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes bloom misalignment when upscaling.
-    cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling.
+    halfPixelOffset: 4 # Aligns post effects.
+    nativeScaling: 2 # Fixes post effects.
 SLES-52822:
   name: "Prince of Persia - Warrior Within"
   region: "PAL-M6"
   compat: 5
   gsHWFixes:
     autoFlush: 2 # Reduces post-processing misalignment.
+    halfPixelOffset: 4 # Fixes post positioning.
+    nativeScaling: 2 # Fixes post effects.
 SLES-52824:
   name: "Furry Tales"
   region: "PAL-E-F"
@@ -19321,7 +19661,8 @@ SLES-52825:
   clampModes:
     eeClampMode: 3 # Fixes the inability to collect items.
   gsHWFixes:
-    halfPixelOffset: 1 # Reduces lighting misalignment but doesn't fully fix it.
+    halfPixelOffset: 4 # Aligns post effects.
+    nativeScaling: 2 # Fixes post effects.
 SLES-52831:
   name: "Syberia 2"
   region: "PAL-M5"
@@ -19379,6 +19720,8 @@ SLES-52859:
   gsHWFixes:
     autoFlush: 1 # Fixes the post processing positioning.
     textureInsideRT: 1 # Fixes post processing.
+    halfPixelOffset: 4 # Aligns bloom effect.
+    nativeScaling: 2 # Fixes post processing smoothness and position.
 SLES-52861:
   name: "King Arthur"
   region: "PAL-M5"
@@ -19462,22 +19805,22 @@ SLES-52895:
   compat: 5
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes missing lights.
-    halfPixelOffset: 2 # Fixes bloom misalignment when upscaling.
-    cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling.
+    halfPixelOffset: 4 # Aligns post processing.
+    nativeScaling: 2 # Fixes post effects.
 SLES-52896:
   name: "Nickelodeon SpongeBob SquarePants - The Movie"
   region: "PAL-F-G"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes missing lights.
-    halfPixelOffset: 2 # Fixes bloom misalignment when upscaling.
-    cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling.
+    halfPixelOffset: 4 # Aligns post processing.
+    nativeScaling: 2 # Fixes post effects.
 SLES-52897:
   name: "Nickelodeon SpongeBob - Il Film"
   region: "PAL-I"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes missing lights.
-    halfPixelOffset: 2 # Fixes bloom misalignment when upscaling.
-    cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling.
+    halfPixelOffset: 4 # Aligns post processing.
+    nativeScaling: 2 # Fixes post effects.
 SLES-52898:
   name: "King of Fighters - Maximum Impact"
   region: "PAL-E-JP"
@@ -19595,6 +19938,8 @@ SLES-52942:
   name: "Midnight Club 3 - DUB Edition"
   region: "PAL-M5"
   gsHWFixes:
+    halfPixelOffset: 2 # Aligns post bloom.
+    nativeScaling: 2 # Fixes light blooms.
     getSkipCount: "GSC_MidnightClub3"
   patches:
     EBE1972D:
@@ -19626,7 +19971,8 @@ SLES-52950:
   region: "PAL-M5"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes blurriness and misaligned garbage when upscaling.
+    halfPixelOffset: 4 # Fixes post positioning.
+    nativeScaling: 2 # Fixes post effects.
 SLES-52951:
   name: "Phantom Brave"
   region: "PAL-E"
@@ -19690,8 +20036,9 @@ SLES-52968:
   gsHWFixes:
     gpuTargetCLUT: 1 # Fixes bloom and sun rendering in front of everything.
     autoFlush: 1 # Fixes bloom and sun rendering in front of everything.
-    halfPixelOffset: 2 # Aligns bloom effect a little bit better when upscaled.
+    halfPixelOffset: 4 # Aligns bloom effect.
     bilinearUpscale: 2 # Reduces color banding of the sun glare.
+    nativeScaling: 2 # Fixes post lighting.
   roundModes:
     vu1RoundMode: 1 # Bright lights in cars.
 SLES-52973:
@@ -19731,15 +20078,15 @@ SLES-52985:
   region: "PAL-G"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes missing lights.
-    halfPixelOffset: 2 # Fixes bloom misalignment when upscaling.
-    cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling.
+    halfPixelOffset: 4 # Aligns post processing.
+    nativeScaling: 2 # Fixes post effects.
 SLES-52986:
   name: "Nickelodeon Bob Esponja - La Película"
   region: "PAL-S"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes missing lights.
-    halfPixelOffset: 2 # Fixes bloom misalignment when upscaling.
-    cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling.
+    halfPixelOffset: 4 # Aligns post processing.
+    nativeScaling: 2 # Fixes post processing position.
 SLES-52988:
   name: "Mega Man X8"
   region: "PAL-M5"
@@ -19801,6 +20148,7 @@ SLES-53008:
   region: "PAL-I-S"
   gsHWFixes:
     autoFlush: 2 # Fixes missing lighting.
+    nativeScaling: 1 # Fixes post lighting.
     # halfPixelOffset: 1 # Fixes lighting misalignment. Do not enable this, it breaks a lot of graphics.
 SLES-53009:
   name: "Dance Factory"
@@ -19834,10 +20182,10 @@ SLES-53020:
     - SoftwareRendererFMVHack # Fixes hash cache disabling itself.
   gsHWFixes:
     recommendedBlendingLevel: 4 # Improves banding and effect emulation.
-    halfPixelOffset: 3 # Fixes texture and lighting misalignment.
-    mergeSprite: 1 # Fixes most vertical lines and lighting misalignment.
     autoFlush: 1 # Fixes light bloom intensity.
     estimateTextureRegion: 1 # Improves performance and reduces hash cache size.
+    halfPixelOffset: 4 # Aligns post effects.
+    nativeScaling: 1 # Fixes post effects.
     getSkipCount: "GSC_GiTS"
   patches:
     BF6F101F:
@@ -19962,8 +20310,8 @@ SLES-53038:
   roundModes:
     eeRoundMode: 0 # Fixes inability to enter door in Mission 18.
   gsHWFixes:
-    halfPixelOffset: 2 # Reduces ghosting but still an issue compared to native.
-    roundSprite: 2 # Clears up much of the blurring that HPO Special does not.
+    halfPixelOffset: 4 # Aligns post effects.
+    nativeScaling: 2 # Fixes post processing and lighting smoothness and position.
 SLES-53039:
   name: "Champions - Return to Arms" # aka "Champions of Norrath 2"
   region: "PAL-M4"
@@ -20069,6 +20417,7 @@ SLES-53075:
   region: "PAL-M5"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misaligned lighting and other effects, needs Special otherwise lights flicker.
+    nativeScaling: 2 # Fixes lights.
 SLES-53076:
   name: "Triggerman"
   region: "PAL-M5"
@@ -20099,6 +20448,8 @@ SLES-53087:
     roundSprite: 1 # Fixes misaligned map.
     skipDrawStart: 1 # Removes large black box around player car till we properly emulate it.
     skipDrawEnd: 1 # Removes large black box around player car till we properly emulate it.
+    halfPixelOffset: 2 # Fixes depth of field alignment.
+    nativeScaling: 1 # Fixes depth of field.
 SLES-53088:
   name: "DTM Race Driver 3"
   region: "PAL-M5"
@@ -20107,6 +20458,8 @@ SLES-53088:
     roundSprite: 1 # Fixes misaligned map.
     skipDrawStart: 1 # Removes large black box around player car till we properly emulate it.
     skipDrawEnd: 1 # Removes large black box around player car till we properly emulate it.
+    halfPixelOffset: 2 # Fixes depth of field alignment.
+    nativeScaling: 1 # Fixes depth of field.
 SLES-53089:
   name: "V8 Supercars Australia 3"
   region: "PAL-E"
@@ -20115,6 +20468,8 @@ SLES-53089:
     roundSprite: 1 # Fixes misaligned map.
     skipDrawStart: 1 # Removes large black box around player car till we properly emulate it.
     skipDrawEnd: 1 # Removes large black box around player car till we properly emulate it.
+    halfPixelOffset: 2 # Fixes depth of field alignment.
+    nativeScaling: 1 # Fixes depth of field.
 SLES-53090:
   name: "Circuit Blasters"
   region: "PAL-M5"
@@ -20196,11 +20551,13 @@ SLES-53121:
   region: "PAL-G"
   compat: 5
 SLES-53124:
-  name: "Project Snowblind"
+  name: "Project - Snowblind"
   region: "PAL-M4"
   gsHWFixes:
     autoFlush: 1 # Fixes the post processing positioning.
     textureInsideRT: 1 # Fixes post processing.
+    halfPixelOffset: 4 # Aligns bloom effect.
+    nativeScaling: 2 # Fixes post processing smoothness and position.
 SLES-53125:
   name: "Enthusia - Professional Racing"
   region: "PAL-M5"
@@ -20369,19 +20726,17 @@ SLES-53196:
   region: "PAL-M4"
   gsHWFixes:
     textureInsideRT: 1 # Fixes shadow maps.
-    roundSprite: 2 # Fixes misaligned bloom.
-    mergeSprite: 1 # Fixes misaligned bloom.
     halfPixelOffset: 2 # Fixes misaligned bloom.
     autoFlush: 2 # Fixes sun occlusion and brightness.
+    nativeScaling: 2 # Fixes post processing and lighting smoothness and position.
 SLES-53197:
   name: "Destroy All Humans!"
   region: "PAL-G"
   gsHWFixes:
     textureInsideRT: 1 # Fixes shadow maps.
-    roundSprite: 2 # Fixes misaligned bloom.
-    mergeSprite: 1 # Fixes misaligned bloom.
     halfPixelOffset: 2 # Fixes misaligned bloom.
     autoFlush: 2 # Fixes sun occlusion and brightness.
+    nativeScaling: 2 # Fixes post processing and lighting smoothness and position.
 SLES-53199:
   name: "25 to Life"
   region: "PAL-E"
@@ -20390,8 +20745,8 @@ SLES-53200:
   region: "PAL-M6"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes lines when powering up.
-    cpuCLUTRender: 1 # Reduces the bloomy blur of characters.
+    halfPixelOffset: 4 # Aligns post effects.
+    nativeScaling: 2 # Fixes post processing and lighting smoothness and position.
 SLES-53201:
   name: "Saint Seiya Chapter Sanctuary"
   region: "PAL-M5"
@@ -20428,8 +20783,8 @@ SLES-53225:
   roundModes:
     vu1RoundMode: 0 # Fixes graphical issues.
   gsHWFixes:
-    roundSprite: 2 # Improves bloom alignment and clarity.
-    halfPixelOffset: 2 # Improves bloom alignment and clarity.
+    halfPixelOffset: 2 # Helps align the post effects, ATN is better but causes edge bleed.
+    nativeScaling: 2 # Fixes Depth of Field effect.
 SLES-53226:
   name: "DreamWorks Madagascar"
   region: "PAL-F-G"
@@ -20437,16 +20792,16 @@ SLES-53226:
   roundModes:
     vu1RoundMode: 0 # Fixes graphical issues.
   gsHWFixes:
-    roundSprite: 2 # Improves bloom alignment and clarity.
-    halfPixelOffset: 2 # Improves bloom alignment and clarity.
+    halfPixelOffset: 2 # Helps align the post effects, ATN is better but causes edge bleed.
+    nativeScaling: 2 # Fixes Depth of Field effect.
 SLES-53227:
   name: "DreamWorks Madagascar"
   region: "PAL-M3"
   roundModes:
     vu1RoundMode: 0 # Fixes graphical issues.
   gsHWFixes:
-    roundSprite: 2 # Improves bloom alignment and clarity.
-    halfPixelOffset: 2 # Improves bloom alignment and clarity.
+    halfPixelOffset: 2 # Helps align the post effects, ATN is better but causes edge bleed.
+    nativeScaling: 2 # Fixes Depth of Field effect.
 SLES-53231:
   name: "Le Avventure di Lupin III - Il Tesoro del Re Stregone"
   region: "PAL-I"
@@ -20478,16 +20833,16 @@ SLES-53242:
   roundModes:
     vu1RoundMode: 0 # Fixes graphical issues.
   gsHWFixes:
-    roundSprite: 2 # Improves bloom alignment and clarity.
-    halfPixelOffset: 2 # Improves bloom alignment and clarity.
+    halfPixelOffset: 2 # Helps align the post effects, ATN is better but causes edge bleed.
+    nativeScaling: 2 # Fixes Depth of Field effect.
 SLES-53246:
   name: "DreamWorks Madagascar"
   region: "PAL-S"
   roundModes:
     vu1RoundMode: 0 # Fixes graphical issues.
   gsHWFixes:
-    roundSprite: 2 # Improves bloom alignment and clarity.
-    halfPixelOffset: 2 # Improves bloom alignment and clarity.
+    halfPixelOffset: 2 # Helps align the post effects, ATN is better but causes edge bleed.
+    nativeScaling: 2 # Fixes Depth of Field effect.
 SLES-53280:
   name: "7 Sins"
   region: "PAL-M3"
@@ -20658,6 +21013,9 @@ SLES-53346:
   name: "Dragon Ball Z - Budokai 3 [Collector's Edition]"
   region: "PAL-M5"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 4 # Aligns post effects.
+    nativeScaling: 2 # Fixes post processing and lighting smoothness and position.
 SLES-53350:
   name: "Sonic Gems Collection"
   region: "PAL-M5"
@@ -20689,9 +21047,8 @@ SLES-53356:
   name: "Colosseum - Road to Freedom"
   region: "PAL-E"
   gsHWFixes:
-    halfPixelOffset: 3 # Fixes bloom misalignment still a bit misaligned.
-    roundSprite: 1 # Fixes bloom misalignment still a bit misaligned.
-    cpuCLUTRender: 1 # Fixes sun background on the windows when selecting your 'race'.
+    halfPixelOffset: 4 # Aligns post effects.
+    nativeScaling: 1 # Fixes post effects.
 SLES-53357:
   name: "21 Card Games"
   region: "PAL-E"
@@ -20742,8 +21099,8 @@ SLES-53373:
   roundModes:
     vu1RoundMode: 0 # Fixes graphical issues.
   gsHWFixes:
-    roundSprite: 2 # Improves bloom alignment and clarity.
-    halfPixelOffset: 2 # Improves bloom alignment and clarity.
+    halfPixelOffset: 2 # Helps align the post effects, ATN is better but causes edge bleed.
+    nativeScaling: 2 # Fixes Depth of Field effect.
 SLES-53374:
   name: "X-Men Legends II - Rise of Apocalypse"
   region: "PAL-M3"
@@ -20923,7 +21280,8 @@ SLES-53430:
     eeCycleRate: 1 # Fixes occasional post process flickering.
   gsHWFixes:
     nativePaletteDraw: 1 # Fixes lines in certain effects when upscaled.
-    halfPixelOffset: 2 # Fixes offset bloom.
+    halfPixelOffset: 4 # Fixes post positioning.
+    nativeScaling: 1 # Fixes post effects.
 SLES-53433:
   name: "NHL '06"
   region: "PAL-M6"
@@ -20996,6 +21354,7 @@ SLES-53462:
   gsHWFixes:
     halfPixelOffset: 2 # Fix effects upscaling.
     autoFlush: 1 # Fixes broken post processing.
+    nativeScaling: 2 # Fixes post effects.
 SLES-53463:
   name: "NHL '06"
   region: "PAL-E"
@@ -21024,16 +21383,16 @@ SLES-53473:
   region: "PAL-M3"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes building shade and shadows.
-    halfPixelOffset: 2 # Fixes bloom misalignment when upscaling.
-    cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling.
+    halfPixelOffset: 4 # Aligns post effects.
+    nativeScaling: 2 # Fixes post effects.
 SLES-53474:
   name: "Disney/Pixar The Incredibles - Rise of the Underminer"
   name-sort: "Disney/Pixar Incredibles, The - Rise of the Underminer"
   region: "PAL-M3"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes building shade and shadows.
-    halfPixelOffset: 2 # Fixes bloom misalignment when upscaling.
-    cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling.
+    halfPixelOffset: 4 # Aligns post effects.
+    nativeScaling: 2 # Fixes post effects.
 SLES-53480:
   name: "Harvest Moon - A Wonderful Life [Special Edition]"
   region: "PAL-E"
@@ -21072,6 +21431,9 @@ SLES-53491:
 SLES-53492:
   name: "Total Overdose"
   region: "PAL-M5"
+  gsHWFixes:
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 1 # Fixes post processing smoothness and position.
 SLES-53494:
   name: "Spongebob SquarePants - Lights, Camera, PANTS!"
   region: "PAL-E"
@@ -21085,6 +21447,10 @@ SLES-53496:
 SLES-53497:
   name: "Nickelodeon SpongeBob Schwammkopf - Film ab!"
   region: "PAL-G"
+  gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes missing lights.
+    halfPixelOffset: 4 # Aligns post processing.
+    nativeScaling: 2 # Fixes post effects.
 SLES-53498:
   name: "Nickelodeon Bob Esponja - ¡Luces, Cámara, Esponja!"
   region: "PAL-S"
@@ -21099,19 +21465,22 @@ SLES-53501:
   region: "PAL-M3"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 1 # Fixes bloom misalignment.
+    halfPixelOffset: 4 # Corrects post processing positioning.
+    nativeScaling: 2 # Smooths post processing.
     autoFlush: 1 # Fixes missing lights.
 SLES-53502:
   name: "Star Wars - Battlefront II"
   region: "PAL-F"
   gsHWFixes:
-    halfPixelOffset: 1 # Fixes bloom misalignment.
+    halfPixelOffset: 4 # Corrects post processing positioning.
+    nativeScaling: 2 # Smooths post processing.
     autoFlush: 1 # Fixes missing lights.
 SLES-53503:
   name: "Star Wars - Battlefront II"
   region: "PAL-G"
   gsHWFixes:
-    halfPixelOffset: 1 # Fixes bloom misalignment.
+    halfPixelOffset: 4 # Corrects post processing positioning.
+    nativeScaling: 2 # Smooths post processing.
     autoFlush: 1 # Fixes missing lights.
 SLES-53504:
   name: "Agent Hugo"
@@ -21131,6 +21500,7 @@ SLES-53506:
     autoFlush: 2 # Fixes blur and obscures sun behind objects.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     bilinearUpscale: 2 # Smooths out sun glare textures like native.
+    nativeScaling: 2 # Smooths speed blur and corrects some lighting.
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
   memcardFilters:
@@ -21151,6 +21521,7 @@ SLES-53507:
     autoFlush: 2 # Fixes blur and obscures sun behind objects.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     bilinearUpscale: 2 # Smooths out sun glare textures like native.
+    nativeScaling: 2 # Smooths speed blur and corrects some lighting.
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
   memcardFilters:
@@ -21198,6 +21569,8 @@ SLES-53526:
   region: "PAL-E-F"
   gsHWFixes:
     autoFlush: 2 # Fixes debris and blending on lower part of screen during monster transformation.
+    halfPixelOffset: 4 # Aligns post processing, might sometimes cause edge bleed which must be cropped.
+    nativeScaling: 2 # Fixes post effects like lights.
   memcardFilters:
     - "SLES-53526"
     - "SLES-53527"
@@ -21212,6 +21585,8 @@ SLES-53527:
   region: "PAL-E-I-S"
   gsHWFixes:
     autoFlush: 2 # Fixes debris and blending on lower part of screen during monster transformation.
+    halfPixelOffset: 4 # Aligns post processing, might sometimes cause edge bleed which must be cropped.
+    nativeScaling: 2 # Fixes post effects like lights.
   memcardFilters:
     - "SLES-53526"
     - "SLES-53527"
@@ -21226,6 +21601,8 @@ SLES-53528:
   region: "PAL-G"
   gsHWFixes:
     autoFlush: 2 # Fixes debris and blending on lower part of screen during monster transformation.
+    halfPixelOffset: 4 # Aligns post processing, might sometimes cause edge bleed which must be cropped.
+    nativeScaling: 2 # Fixes post effects like lights.
   memcardFilters:
     - "SLES-53526"
     - "SLES-53527"
@@ -21267,8 +21644,8 @@ SLES-53534:
     vu1RoundMode: 0 # Crashes without.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes water and grass textures.
-    forceEvenSpritePosition: 1 # Reduces post-processing misalignment.
-    mergeSprite: 1 # Reduces post-processing misalignment.
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 1 # Fixes post processing smoothness and position.
     autoFlush: 1 # Improves post-processing rendering.
     preloadFrameData: 1 # Fixes missing loading screens.
 SLES-53535:
@@ -21278,8 +21655,8 @@ SLES-53535:
     vu1RoundMode: 0 # Crashes without.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes water and grass textures.
-    forceEvenSpritePosition: 1 # Reduces post-processing misalignment.
-    mergeSprite: 1 # Reduces post-processing misalignment.
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 1 # Fixes post processing smoothness and position.
     autoFlush: 1 # Improves post-processing rendering.
     preloadFrameData: 1 # Fixes missing loading screens.
 SLES-53536:
@@ -21291,7 +21668,8 @@ SLES-53539:
   region: "PAL-M4"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 1 # Slight lighting misalignment.
+    halfPixelOffset: 4 # Aligns post processing.
+    nativeScaling: 2 # Fixes post processing position.
   patches:
     default:
       content: |-
@@ -21317,7 +21695,8 @@ SLES-53540:
   region: "PAL-M4"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 1 # Slight lighting misalignment.
+    halfPixelOffset: 4 # Aligns post processing.
+    nativeScaling: 2 # Fixes post processing position.
   patches:
     default:
       content: |-
@@ -21348,7 +21727,8 @@ SLES-53542:
   region: "PAL-M5"
   gsHWFixes:
     recommendedBlendingLevel: 4 # Improves smoke rendering.
-    halfPixelOffset: 2 # Fixes misaligned lighting.
+    halfPixelOffset: 4 # Fixes post positioning.
+    nativeScaling: 2 # Fixes post effects.
 SLES-53544:
   name: "Pro Evolution Soccer 5"
   region: "PAL-M4"
@@ -21577,6 +21957,8 @@ SLES-53616:
     preloadFrameData: 1 # Fixes numberplates and ensures above targets are valid.
     roundSprite: 1 # Fixes lines in some post-effects.
     gpuTargetCLUT: 1 # Fixes light occlusion.
+    halfPixelOffset: 4 # Reduces post misalignment.
+    nativeScaling: 2 # Fixes remaining post misalignment and light bloom and shadows.
 SLES-53617:
   name: "True Crime - New York City"
   region: "PAL-G"
@@ -21589,6 +21971,8 @@ SLES-53617:
     preloadFrameData: 1 # Fixes numberplates and ensures above targets are valid.
     roundSprite: 1 # Fixes lines in some post-effects.
     gpuTargetCLUT: 1 # Fixes light occlusion.
+    halfPixelOffset: 4 # Reduces post misalignment.
+    nativeScaling: 2 # Fixes remaining post misalignment and light bloom and shadows.
 SLES-53618:
   name: "True Crime - New York City"
   region: "PAL-S"
@@ -21601,12 +21985,15 @@ SLES-53618:
     preloadFrameData: 1 # Fixes numberplates and ensures above targets are valid.
     roundSprite: 1 # Fixes lines in some post-effects.
     gpuTargetCLUT: 1 # Fixes light occlusion.
+    halfPixelOffset: 4 # Reduces post misalignment.
+    nativeScaling: 2 # Fixes remaining post misalignment and light bloom and shadows.
 SLES-53621:
   name: "Wallace & Gromit - The Curse of the Were-Rabbit"
   region: "PAL-M5"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 1 # Fixes misalignment/bloom when upscaling.
+    halfPixelOffset: 4 # Fixes post alignment.
+    nativeScaling: 1 # Fixes post effect.
 SLES-53623:
   name: "SpongeBob SquarePants - Battle for Bikini Bottom"
   region: "PAL-F"
@@ -21623,6 +22010,8 @@ SLES-53626:
   region: "PAL-E-G"
   gsHWFixes:
     autoFlush: 2 # Fixes debris and blending on lower part of screen during monster transformation.
+    halfPixelOffset: 4 # Aligns post processing, might sometimes cause edge bleed which must be cropped.
+    nativeScaling: 2 # Fixes post effects like lights.
   memcardFilters:
     - "SLES-53526"
     - "SLES-53527"
@@ -21671,10 +22060,9 @@ SLES-53641:
   region: "PAL-R"
   gsHWFixes:
     textureInsideRT: 1 # Fixes shadow maps.
-    roundSprite: 2 # Fixes misaligned bloom.
-    mergeSprite: 1 # Fixes misaligned bloom.
     halfPixelOffset: 2 # Fixes misaligned bloom.
     autoFlush: 2 # Fixes sun occlusion and brightness.
+    nativeScaling: 2 # Fixes post processing and lighting smoothness and position.
 SLES-53644:
   name: "Gene Troopers"
   region: "PAL-M5"
@@ -21723,8 +22111,8 @@ SLES-53658:
   region: "PAL-R"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes building shade and shadows.
-    halfPixelOffset: 2 # Fixes bloom misalignment when upscaling.
-    cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling.
+    halfPixelOffset: 4 # Aligns post processing.
+    nativeScaling: 2 # Fixes post processing position.
 SLES-53659:
   name: "Brothers In Arms - Earned in Blood"
   region: "PAL-M5"
@@ -21904,6 +22292,8 @@ SLES-53717:
   name: "Midnight Club 3 - DUB Edition Remix"
   region: "PAL-M5"
   gsHWFixes:
+    halfPixelOffset: 2 # Aligns post bloom.
+    nativeScaling: 2 # Fixes light blooms.
     getSkipCount: "GSC_MidnightClub3"
   patches:
     208183AF:
@@ -22004,7 +22394,8 @@ SLES-53747:
   roundModes:
     eeRoundMode: 2 # Fixes missing text.
   gsHWFixes:
-    halfPixelOffset: 1 # Fixes ghosting.
+    halfPixelOffset: 4 # Aligns post processing.
+    nativeScaling: 2 # Fixes post effects.
 SLES-53748:
   name: "Quest for Sleeping Beauty"
   region: "PAL-M7"
@@ -22058,6 +22449,7 @@ SLES-53758:
     autoFlush: 2 # Fixes bloom misalignment.
     halfPixelOffset: 2 # Fixes bloom misalignment.
     textureInsideRT: 1 # Fixes sky bloom.
+    nativeScaling: 2 # Fixes post processing.
 SLES-53759:
   name: "The Matrix - Path of Neo"
   name-sort: "Matrix, The - Path of Neo"
@@ -22065,6 +22457,7 @@ SLES-53759:
   gsHWFixes:
     halfPixelOffset: 2 # Fix effects upscaling.
     autoFlush: 1 # Fixes broken post processing.
+    nativeScaling: 2 # Fixes post effects.
 SLES-53760:
   name: "Rugby Challenge 2006"
   region: "PAL-M5"
@@ -22119,7 +22512,8 @@ SLES-53777:
   compat: 5
   gsHWFixes:
     autoFlush: 1 # Reduces post-processing misalignment.
-    halfPixelOffset: 4 # Reduces post-processing misalignment.
+    halfPixelOffset: 4 # Fixes post positioning.
+    nativeScaling: 2 # Fixes post effects.
 SLES-53778:
   name: "Jacked"
   region: "PAL-M5"
@@ -22136,7 +22530,8 @@ SLES-53794:
   clampModes:
     eeClampMode: 2 # Fixes wrong color on some characters and breakable objects.
   gsHWFixes:
-    halfPixelOffset: 1 # Fixes ghosting characters.
+    halfPixelOffset: 4 # Fix effects upscaling.
+    nativeScaling: 2 # Fixes post effects.
     mergeSprite: 1 # Align sprite fixes FMVs but not garbage in-game, so needs merge sprite instead.
     texturePreloading: 1 # Performs better with partial preload because it is slow on locations outside gameplay foremost.
 SLES-53796:
@@ -22168,6 +22563,7 @@ SLES-53799:
   gsHWFixes:
     halfPixelOffset: 2 # Fix effects upscaling.
     autoFlush: 1 # Fixes broken post processing.
+    nativeScaling: 2 # Fixes post effects.
 SLES-53800:
   name: "Rampage - Total Destruction"
   region: "PAL-M5"
@@ -22382,6 +22778,8 @@ SLES-53886:
     recommendedBlendingLevel: 4 # Improves lighting on buildings and objects.
     autoFlush: 2 # Properly diffuses light instead of strips of light.
     roundSprite: 1 # Fixes lighting misalignment such as the street poles and the sun.
+    halfPixelOffset: 2 # Mostly aligns post processing.
+    nativeScaling: 2 # Improves post processing smoothness.
     getSkipCount: "GSC_BlackAndBurnoutSky"
     beforeDraw: "OI_BurnoutGames"
   patches:
@@ -22437,6 +22835,8 @@ SLES-53908:
     textureInsideRT: 1 # Needed for post processing effects.
     autoFlush: 1 # Fixes bloom intensity.
     minimumBlendingLevel: 4 # Fixes multiple lighting effects from lights, computers, cave walls and more.
+    nativeScaling: 1 # Fixes post processing.
+    halfPixelOffset: 4 # Fixes offset post processing.
 SLES-53909:
   name: "Full Spectrum Warrior - Ten Hammers"
   region: "PAL-G"
@@ -22744,6 +23144,7 @@ SLES-54021:
     - EETimingHack # Fixes game engine errors when going ingame.
   gsHWFixes:
     halfPixelOffset: 4 # Fixes misalignment like volcano lighting.
+    nativeScaling: 1 # Makes the lava bloom look more correct (very minor shimmer).
   patches:
     B02C81E5:
       content: |-
@@ -22773,6 +23174,8 @@ SLES-54030:
     recommendedBlendingLevel: 4 # Improves lighting on buildings and objects.
     autoFlush: 2 # Properly diffuses light instead of strips of light.
     roundSprite: 1 # Fixes lighting misalignment such as the street poles and the sun.
+    halfPixelOffset: 2 # Mostly aligns post processing.
+    nativeScaling: 2 # Improves post processing smoothness.
     getSkipCount: "GSC_BlackAndBurnoutSky"
     beforeDraw: "OI_BurnoutGames"
   patches:
@@ -22891,7 +23294,8 @@ SLES-54114:
   gsHWFixes:
     autoFlush: 1 # Fixes effects.
     roundSprite: 1 # Fixes upscaling artifacts.
-    halfPixelOffset: 4 # Fixes upscaling artifacts.
+    halfPixelOffset: 2 # Fixes post bloom positioning.
+    nativeScaling: 2 # Fixes lighting effects due to upscaling.
 SLES-54115:
   name: "Delta Force - Black Hawk Down - Team Sabre"
   region: "PAL-M5"
@@ -22962,7 +23366,8 @@ SLES-54137:
   region: "PAL-M3"
   gsHWFixes:
     recommendedBlendingLevel: 3 # High blending accuracy fixes notoriously broken water.
-    halfPixelOffset: 1 # Fixes ghosting.
+    halfPixelOffset: 2 # Fixes ghosting.
+    nativeScaling: 2 # Fixes artifacts due to upscaling.
 SLES-54138:
   name: "Steambot Chronicles"
   region: "PAL-E"
@@ -22999,7 +23404,8 @@ SLES-54150:
   name: "Bionicle Heroes"
   region: "PAL-M6"
   gsHWFixes:
-    cpuCLUTRender: 1 # Fixes ghosting on objects and people.
+    halfPixelOffset: 2 # Aligns post effects.
+    nativeScaling: 2 # Fixes post processing and position.
 SLES-54151:
   name: "Let's Make a Soccer Team!"
   region: "PAL-M5"
@@ -23056,12 +23462,16 @@ SLES-54162:
 SLES-54163:
   name: "Naruto - Ultimate Ninja"
   region: "PAL-F"
+  gsHWFixes:
+    halfPixelOffset: 2 # Aligns post effects.
+    nativeScaling: 2 # Fixes post effects.
 SLES-54164:
   name: "Dragon Ball Z Budokai - Tenkaichi 2"
   region: "PAL-M6"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes character outlines and minor bloom.
+    halfPixelOffset: 4 # Aligns post effects.
+    nativeScaling: 2 # Fixes post processing and lighting smoothness and position.
     beforeDraw: "OI_DBZBTGames"
 SLES-54165:
   name: "One Piece - Grand Adventure"
@@ -23108,6 +23518,7 @@ SLES-54171:
     - EETimingHack # Fixes flickering.
   gsHWFixes:
     alignSprite: 1 # Helps align bloom.
+    nativeScaling: 2 # Fixes post processing and lighting smoothness.
 SLES-54172:
   name: "Garfield 2 - Tale of Two Kitties"
   region: "PAL-M11"
@@ -23143,6 +23554,7 @@ SLES-54182:
     autoFlush: 2 # Fixes post processing overlay.
     roundSprite: 1 # Greatly reduces chromatic effect when upscaling.
     forceEvenSpritePosition: 1 # Fixes chromatic fringing.
+    nativeScaling: 1 # Fixes post processing effect and position.
 SLES-54183:
   name: "Scarface - The World is Yours"
   region: "PAL-G"
@@ -23152,6 +23564,7 @@ SLES-54183:
     autoFlush: 2 # Fixes post processing overlay.
     roundSprite: 1 # Greatly reduces chromatic effect when upscaling.
     forceEvenSpritePosition: 1 # Fixes chromatic fringing.
+    nativeScaling: 1 # Fixes post processing effect and position.
 SLES-54184:
   name: "Scarface - The World is Yours"
   region: "PAL-R"
@@ -23161,6 +23574,7 @@ SLES-54184:
     autoFlush: 2 # Fixes post processing overlay.
     roundSprite: 1 # Greatly reduces chromatic effect when upscaling.
     forceEvenSpritePosition: 1 # Fixes chromatic fringing.
+    nativeScaling: 1 # Fixes post processing effect and position.
 SLES-54185:
   name: "Dirge of Cerberus - Final Fantasy VII"
   region: "PAL-M5"
@@ -23173,8 +23587,8 @@ SLES-54186:
   roundModes:
     eeRoundMode: 0 # Fixes inability to enter door in Mission 18.
   gsHWFixes:
-    halfPixelOffset: 2 # Reduces ghosting but still an issue compared to native.
-    roundSprite: 2 # Clears up much of the blurring that HPO Special does not.
+    halfPixelOffset: 4 # Aligns post effects.
+    nativeScaling: 2 # Fixes post processing and lighting smoothness and position.
 SLES-54187:
   name: "Real World Golf 2007"
   region: "PAL-M3"
@@ -23198,7 +23612,8 @@ SLES-54200:
   region: "PAL-F-G"
   gsHWFixes:
     recommendedBlendingLevel: 3 # High blending accuracy fixes notoriously broken water.
-    halfPixelOffset: 1 # Fixes ghosting.
+    halfPixelOffset: 2 # Fixes ghosting.
+    nativeScaling: 2 # Fixes artifacts due to upscaling.
 SLES-54203:
   name: "Pro Evolution Soccer 6"
   region: "PAL-E"
@@ -23243,12 +23658,21 @@ SLES-54215:
   name: "Monster House"
   region: "PAL-M4"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 4 # Reduces post misalignment.
+    nativeScaling: 2 # Fixes remaining post misalignment.
 SLES-54216:
   name: "Monster House"
   region: "PAL-I"
+  gsHWFixes:
+    halfPixelOffset: 4 # Reduces post misalignment.
+    nativeScaling: 2 # Fixes remaining post misalignment.
 SLES-54217:
   name: "Monster House"
   region: "PAL-E"
+  gsHWFixes:
+    halfPixelOffset: 4 # Reduces post misalignment.
+    nativeScaling: 2 # Fixes remaining post misalignment.
 SLES-54218:
   name: "Rule of Rose"
   region: "PAL-M5"
@@ -23258,7 +23682,8 @@ SLES-54221:
   name: "LEGO Star Wars II - The Original Trilogy"
   region: "PAL-M6"
   gsHWFixes:
-    cpuCLUTRender: 1 # Fixes ghosting on objects and people.
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 1 # Fixes post processing smoothness and position.
   memcardFilters: # Allows import of characters from Lego Star Wars 1.
     - "SLES-54221"
     - "SLES-53194"
@@ -23293,28 +23718,32 @@ SLES-54232:
   gsHWFixes:
     autoFlush: 1 # Fixes effects.
     roundSprite: 1 # Fixes upscaling artifacts.
-    halfPixelOffset: 4 # Fixes upscaling artifacts.
+    halfPixelOffset: 2 # Fixes post bloom positioning.
+    nativeScaling: 2 # Fixes lighting effects due to upscaling.
 SLES-54233:
   name: "Kingdom Hearts II"
   region: "PAL-G"
   gsHWFixes:
     autoFlush: 1 # Fixes effects.
     roundSprite: 1 # Fixes upscaling artifacts.
-    halfPixelOffset: 4 # Fixes upscaling artifacts.
+    halfPixelOffset: 2 # Fixes post bloom positioning.
+    nativeScaling: 2 # Fixes lighting effects due to upscaling.
 SLES-54234:
   name: "Kingdom Hearts II"
   region: "PAL-I"
   gsHWFixes:
     autoFlush: 1 # Fixes effects.
     roundSprite: 1 # Fixes upscaling artifacts.
-    halfPixelOffset: 4 # Fixes upscaling artifacts.
+    halfPixelOffset: 2 # Fixes post bloom positioning.
+    nativeScaling: 2 # Fixes lighting effects due to upscaling.
 SLES-54235:
   name: "Kingdom Hearts II"
   region: "PAL-S"
   gsHWFixes:
     autoFlush: 1 # Fixes effects.
     roundSprite: 1 # Fixes upscaling artifacts.
-    halfPixelOffset: 4 # Fixes upscaling artifacts.
+    halfPixelOffset: 2 # Fixes post bloom positioning.
+    nativeScaling: 2 # Fixes lighting effects due to upscaling.
 SLES-54237:
   name: "Pirates of the Caribbean - The Legend of Jack Sparrow"
   region: "PAL-M5"
@@ -23406,6 +23835,7 @@ SLES-54271:
     autoFlush: 2 # Fixes post processing overlay.
     roundSprite: 1 # Greatly reduces chromatic effect when upscaling.
     forceEvenSpritePosition: 1 # Fixes chromatic fringing.
+    nativeScaling: 1 # Fixes post processing effect and position.
 SLES-54305:
   name: "Demon Chaos"
   region: "PAL-M5"
@@ -23686,10 +24116,9 @@ SLES-54384:
   region: "PAL-M5"
   gsHWFixes:
     textureInsideRT: 1 # Fixes shadow maps.
-    roundSprite: 2 # Fixes misaligned bloom.
-    mergeSprite: 1 # Fixes misaligned bloom.
     halfPixelOffset: 2 # Fixes misaligned bloom.
     autoFlush: 2 # Fixes sun occlusion and brightness.
+    nativeScaling: 2 # Fixes post processing and lighting smoothness and position.
 SLES-54385:
   name: "Atelier Iris 2 - The Azoth of Destiny"
   region: "PAL-E"
@@ -23719,6 +24148,8 @@ SLES-54390:
     vu1RoundMode: 0 # Fixes invalid VU size spam and likely SPS.
   gsHWFixes:
     autoFlush: 1 # Fixes black line down the side of the screen and player shadow.
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 1 # Fixes post processing smoothness and position.
 SLES-54393:
   name: "Pippa Funnell - Take the Reins"
   region: "PAL-M3"
@@ -23812,7 +24243,8 @@ SLES-54439:
   name: "Okami"
   region: "PAL-M3"
   gsHWFixes:
-    roundSprite: 2 # Reduces misalignment issues but the game is just bad for upscaling.
+    halfPixelOffset: 4 # Aligns post effects.
+    nativeScaling: 2 # Fixes post effects.
 SLES-54440:
   name: "GT-R Touring"
   region: "PAL-E"
@@ -23870,6 +24302,7 @@ SLES-54455:
   gsHWFixes:
     recommendedBlendingLevel: 3
     halfPixelOffset: 1 # Fixes misaligned bloom effects.
+    nativeScaling: 2 # Corrects post processing.
 SLES-54456:
   name: "Beverly Hills Cop"
   region: "PAL-M11"
@@ -23921,8 +24354,8 @@ SLES-54464:
   region: "PAL-E"
   compat: 5
   gsHWFixes:
-    roundSprite: 1 # Fixes HUD artifacts.
-    forceEvenSpritePosition: 1 # Lessens the bloom misalignment but still an issue.
+    halfPixelOffset: 4 # Fixes post processing positioning.
+    nativeScaling: 1 # Fixes post processing effects caused by upscaling.
 SLES-54465:
   name: "CSI - 3 Dimensions of Murder"
   region: "PAL-M5"
@@ -23975,6 +24408,8 @@ SLES-54483:
     recommendedBlendingLevel: 4 # Fixes car reflections.
     mergeSprite: 1 # Fixes bluriness.
     halfPixelOffset: 4 # Fixes bluriness.
+    nativeScaling: 1 # Fixes post lighting.
+    autoFlush: 1 # Fixes post alignment.
 SLES-54485:
   name: "Cinderella"
   region: "PAL-M3"
@@ -24045,6 +24480,7 @@ SLES-54516:
   gsHWFixes:
     recommendedBlendingLevel: 3
     halfPixelOffset: 1 # Fixes misaligned bloom effects.
+    nativeScaling: 2 # Corrects post processing.
 SLES-54517:
   name: "Thrillville"
   region: "PAL-M3"
@@ -24053,6 +24489,7 @@ SLES-54517:
   gsHWFixes:
     recommendedBlendingLevel: 3
     halfPixelOffset: 1 # Fixes misaligned bloom effects.
+    nativeScaling: 2 # Corrects post processing.
 SLES-54518:
   name: "Clumsy Shumsy"
   region: "PAL-E"
@@ -24089,6 +24526,7 @@ SLES-54534:
     autoFlush: 2 # Fixes post processing overlay.
     roundSprite: 1 # Greatly reduces chromatic effect when upscaling.
     forceEvenSpritePosition: 1 # Fixes chromatic fringing.
+    nativeScaling: 1 # Fixes post processing effect and position.
 SLES-54536:
   name: "Big Idea's VeggieTales - LarryBoy and the Bad Apple"
   region: "PAL-I"
@@ -24325,6 +24763,7 @@ SLES-54627:
     autoFlush: 2 # Fixes blur and obscures sun behind objects.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     bilinearUpscale: 2 # Smooths out sun glare textures like native.
+    nativeScaling: 2 # Smooths speed blur and corrects some lighting.
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
 SLES-54628:
@@ -24366,20 +24805,20 @@ SLES-54644:
   gameFixes:
     - VuAddSubHack
   gsHWFixes:
-    halfPixelOffset: 2 # Reduces bloom misalignment.
-    roundSprite: 1 # Fixes area transition vertical lines and lessens red forest vertical lines.
+    halfPixelOffset: 4 # Reduces bloom misalignment.
     textureInsideRT: 1 # Required for swirl battle transition.
     nativePaletteDraw: 1
+    nativeScaling: 2 # Fixes depth of field effects and bloom.
 SLES-54645:
   name: "Valkyrie Profile 2 - Silmeria"
   region: "PAL-F"
   gameFixes:
     - VuAddSubHack
   gsHWFixes:
-    halfPixelOffset: 2 # Reduces bloom misalignment.
-    roundSprite: 1 # Fixes area transition vertical lines and lessens red forest vertical lines.
+    halfPixelOffset: 4 # Reduces bloom misalignment.
     textureInsideRT: 1 # Required for swirl battle transition.
     nativePaletteDraw: 1
+    nativeScaling: 2 # Fixes depth of field effects and bloom.
 SLES-54646:
   name: "Valkyrie Profile 2 - Silmeria"
   region: "PAL-G"
@@ -24387,10 +24826,10 @@ SLES-54646:
   gameFixes:
     - VuAddSubHack
   gsHWFixes:
-    halfPixelOffset: 2 # Reduces bloom misalignment.
-    roundSprite: 1 # Fixes area transition vertical lines and lessens red forest vertical lines.
+    halfPixelOffset: 4 # Reduces bloom misalignment.
     textureInsideRT: 1 # Required for swirl battle transition.
     nativePaletteDraw: 1
+    nativeScaling: 2 # Fixes depth of field effects and bloom.
 SLES-54647:
   name: "Valkyrie Profile 2 - Silmeria"
   region: "PAL-I"
@@ -24398,20 +24837,20 @@ SLES-54647:
   gameFixes:
     - VuAddSubHack
   gsHWFixes:
-    halfPixelOffset: 2 # Reduces bloom misalignment.
-    roundSprite: 1 # Fixes area transition vertical lines and lessens red forest vertical lines.
+    halfPixelOffset: 4 # Reduces bloom misalignment.
     textureInsideRT: 1 # Required for swirl battle transition.
     nativePaletteDraw: 1
+    nativeScaling: 2 # Fixes depth of field effects and bloom.
 SLES-54648:
   name: "Valkyrie Profile 2 - Silmeria"
   region: "PAL-S"
   gameFixes:
     - VuAddSubHack
   gsHWFixes:
-    halfPixelOffset: 2 # Reduces bloom misalignment.
-    roundSprite: 1 # Fixes area transition vertical lines and lessens red forest vertical lines.
+    halfPixelOffset: 4 # Reduces bloom misalignment.
     textureInsideRT: 1 # Required for swirl battle transition.
     nativePaletteDraw: 1
+    nativeScaling: 2 # Fixes depth of field effects and bloom.
 SLES-54653:
   name: "Freak Out - Extreme Freeride"
   region: "PAL-M5"
@@ -24514,6 +24953,7 @@ SLES-54681:
     autoFlush: 2 # Fixes blur and obscures sun behind objects.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     bilinearUpscale: 2 # Smooths out sun glare textures like native.
+    nativeScaling: 2 # Smooths speed blur and corrects some lighting.
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
 SLES-54683:
@@ -24570,16 +25010,16 @@ SLES-54714:
   roundModes:
     vu1RoundMode: 0 # Crashes without.
   gsHWFixes:
-    forceEvenSpritePosition: 1 # Reduces post-processing misalignment.
-    mergeSprite: 1 # Reduces post-processing misalignment.
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 1 # Fixes post processing smoothness and position.
 SLES-54715:
   name: "Tony Hawk's Downhill Jam"
   region: "PAL-M4"
   roundModes:
     vu1RoundMode: 0 # Crashes without.
   gsHWFixes:
-    forceEvenSpritePosition: 1 # Reduces post-processing misalignment.
-    mergeSprite: 1 # Reduces post-processing misalignment.
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 1 # Fixes post processing smoothness and position.
 SLES-54716:
   name: "Skateboard Madness - Xtreme Edition"
   region: "PAL-E"
@@ -24626,7 +25066,8 @@ SLES-54727:
   gameFixes:
     - OPHFlagHack
   gsHWFixes:
-    mergeSprite: 1 # Reduces bloom but fixes blurriness around models + Recommended to use Shadeboost brightness 80.
+    halfPixelOffset: 2 # Aligns post effects.
+    nativeScaling: 2 # Fixes post effects.
 SLES-54728:
   name: "Mountain Bike Adrenaline featuring Salomon"
   region: "PAL-M5"
@@ -24640,8 +25081,8 @@ SLES-54733:
   roundModes:
     vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
   gsHWFixes:
-    halfPixelOffset: 2 # Reduces blooming misalignment.
-    forceEvenSpritePosition: 1 # Reduces blooming misalignment.
+    halfPixelOffset: 4 # Aligns Post Effect.
+    nativeScaling: 2 # Fixes Post effect.
     autoFlush: 2 # Fixes glows.
 SLES-54734:
   name: "Disney/Pixar Ratatouille"
@@ -24649,8 +25090,8 @@ SLES-54734:
   roundModes:
     vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
   gsHWFixes:
-    halfPixelOffset: 2 # Reduces blooming misalignment.
-    forceEvenSpritePosition: 1 # Reduces blooming misalignment.
+    halfPixelOffset: 4 # Aligns Post Effect.
+    nativeScaling: 2 # Fixes Post effect.
     autoFlush: 2 # Fixes glows.
 SLES-54735:
   name: "Disney/Pixar Ratatouille"
@@ -24659,8 +25100,8 @@ SLES-54735:
   roundModes:
     vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
   gsHWFixes:
-    halfPixelOffset: 2 # Reduces blooming misalignment.
-    forceEvenSpritePosition: 1 # Reduces blooming misalignment.
+    halfPixelOffset: 4 # Aligns Post Effect.
+    nativeScaling: 2 # Fixes Post effect.
     autoFlush: 2 # Fixes glows.
 SLES-54736:
   name: "Disney/Pixar Ratatouille"
@@ -24669,8 +25110,8 @@ SLES-54736:
   roundModes:
     vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
   gsHWFixes:
-    halfPixelOffset: 2 # Reduces blooming misalignment.
-    forceEvenSpritePosition: 1 # Reduces blooming misalignment.
+    halfPixelOffset: 4 # Aligns Post Effect.
+    nativeScaling: 2 # Fixes Post effect.
     autoFlush: 2 # Fixes glows.
 SLES-54737:
   name: "Disney/Pixar Ratatouille"
@@ -24679,8 +25120,8 @@ SLES-54737:
   roundModes:
     vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
   gsHWFixes:
-    halfPixelOffset: 2 # Reduces blooming misalignment.
-    forceEvenSpritePosition: 1 # Reduces blooming misalignment.
+    halfPixelOffset: 4 # Aligns Post Effect.
+    nativeScaling: 2 # Fixes Post effect.
     autoFlush: 2 # Fixes glows.
 SLES-54738:
   name: "Thunderbirds"
@@ -24692,8 +25133,8 @@ SLES-54744:
   roundModes:
     vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
   gsHWFixes:
-    halfPixelOffset: 2 # Reduces blooming misalignment.
-    forceEvenSpritePosition: 1 # Reduces blooming misalignment.
+    halfPixelOffset: 4 # Aligns Post Effect.
+    nativeScaling: 2 # Fixes Post effect.
     autoFlush: 2 # Fixes glows.
 SLES-54745:
   name: "Disney/Pixar Ratatouille"
@@ -24702,8 +25143,8 @@ SLES-54745:
   roundModes:
     vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
   gsHWFixes:
-    halfPixelOffset: 2 # Reduces blooming misalignment.
-    forceEvenSpritePosition: 1 # Reduces blooming misalignment.
+    halfPixelOffset: 4 # Aligns Post Effect.
+    nativeScaling: 2 # Fixes Post effect.
     autoFlush: 2 # Fixes glows.
 SLES-54746:
   name: "Disney/Pixar Ratatouille"
@@ -24712,8 +25153,8 @@ SLES-54746:
   roundModes:
     vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
   gsHWFixes:
-    halfPixelOffset: 2 # Reduces blooming misalignment.
-    forceEvenSpritePosition: 1 # Reduces blooming misalignment.
+    halfPixelOffset: 4 # Aligns Post Effect.
+    nativeScaling: 2 # Fixes Post effect.
     autoFlush: 2 # Fixes glows.
 SLES-54747:
   name: "Disney/Pixar Ratatouille"
@@ -24722,19 +25163,28 @@ SLES-54747:
   roundModes:
     vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
   gsHWFixes:
-    halfPixelOffset: 2 # Reduces blooming misalignment.
-    forceEvenSpritePosition: 1 # Reduces blooming misalignment.
+    halfPixelOffset: 4 # Aligns Post Effect.
+    nativeScaling: 2 # Fixes Post effect.
     autoFlush: 2 # Fixes glows.
 SLES-54755:
   name: "Transformers - The Game"
   region: "PAL-E"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes alignment of post processing.
+    nativeScaling: 1 # Fixes post processing effect.
 SLES-54756:
   name: "Transformers - The Game"
   region: "PAL-F-S"
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes alignment of post processing.
+    nativeScaling: 1 # Fixes post processing effect.
 SLES-54757:
   name: "Transformers - The Game"
   region: "PAL-G-I"
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes alignment of post processing.
+    nativeScaling: 1 # Fixes post processing effect.
 SLES-54767:
   name: "Sniper Assault"
   region: "PAL-E"
@@ -24843,7 +25293,8 @@ SLES-54806:
     vu1ClampMode: 3 # Fixes texture corruption light shimmering and reflective surfaces.
   gsHWFixes:
     recommendedBlendingLevel: 3
-    halfPixelOffset: 1 # Fixes misaligned bloom effects.
+    halfPixelOffset: 4 # Fixes misaligned bloom effects.
+    nativeScaling: 2 # Fixes bloom effects.
 SLES-54807:
   name: "Thrillville - Off the Rails"
   region: "PAL-F"
@@ -24851,7 +25302,8 @@ SLES-54807:
     vu1ClampMode: 3 # Fixes texture corruption light shimmering and reflective surfaces.
   gsHWFixes:
     recommendedBlendingLevel: 3
-    halfPixelOffset: 1 # Fixes misaligned bloom effects.
+    halfPixelOffset: 4 # Fixes misaligned bloom effects.
+    nativeScaling: 2 # Fixes bloom effects.
 SLES-54809:
   name: "Charlotte's Web"
   region: "PAL-A"
@@ -24880,7 +25332,8 @@ SLES-54815:
   region: "PAL-M6"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes lighting on mushrooms + others.
+    halfPixelOffset: 1 # Reduces post misalignment.
+    nativeScaling: 1 # Fixes remaining post misalignment.
   patches:
     8AE9536D:
       content: |-
@@ -24893,7 +25346,8 @@ SLES-54816:
   region: "PAL-R"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes lighting on mushrooms + others.
+    halfPixelOffset: 1 # Reduces post misalignment.
+    nativeScaling: 1 # Fixes remaining post misalignment.
   patches:
     C95F0198:
       content: |-
@@ -24941,6 +25395,9 @@ SLES-54834:
 SLES-54835:
   name: "Power Rangers - Super Legends"
   region: "PAL-M5"
+  gsHWFixes:
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 2 # Fixes post processing position.
 SLES-54836:
   name: "Disney High School Musical - Sing It!"
   region: "PAL-M5"
@@ -24974,11 +25431,17 @@ SLES-54859:
   compat: 5
   roundModes:
     vu1RoundMode: 0 # Massages the Z on the score meter for hardware mode, software doesn't really need this.
+  gsHWFixes:
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 1 # Fixes post processing smoothness and position.
 SLES-54860:
   name: "Guitar Hero - Rocks The 80's"
   region: "PAL-M4"
   roundModes:
     vu1RoundMode: 0 # Massages the Z on the score meter for hardware mode, software doesn't really need this.
+  gsHWFixes:
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 1 # Fixes post processing smoothness and position.
 SLES-54861:
   name: "Thomas & Friends - A Day at the Races"
   region: "PAL-SC"
@@ -25039,6 +25502,9 @@ SLES-54878:
   clampModes:
     vu0ClampMode: 0 # Fixes glow effects.
     vu1ClampMode: 3 # Fixes rare SPS.
+  gsHWFixes:
+    halfPixelOffset: 2 # Aligns post effects.
+    nativeScaling: 2 # Fixes post effects.
 SLES-54879:
   name: "WWE SmackDown vs. Raw 2008"
   region: "PAL-M5"
@@ -25082,7 +25548,8 @@ SLES-54887:
     vu1ClampMode: 3 # Fixes texture corruption light shimmering and reflective surfaces.
   gsHWFixes:
     recommendedBlendingLevel: 3
-    halfPixelOffset: 1 # Fixes misaligned bloom effects.
+    halfPixelOffset: 4 # Fixes misaligned bloom effects.
+    nativeScaling: 2 # Fixes bloom effects.
 SLES-54888:
   name: "Pro Biker 2"
   region: "PAL-E"
@@ -25243,8 +25710,8 @@ SLES-54945:
   region: "PAL-M6"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes character outlines and minor bloom.
-    cpuCLUTRender: 1 # Aligns character bloom and some stage bloom.
+    halfPixelOffset: 4 # Aligns post effects.
+    nativeScaling: 2 # Fixes post processing and lighting smoothness and position.
     beforeDraw: "OI_DBZBTGames"
 SLES-54946:
   name: "Sega Superstars Tennis"
@@ -25252,7 +25719,8 @@ SLES-54946:
   gameFixes:
     - VUSyncHack # Fixes SPS.
   gsHWFixes:
-    halfPixelOffset: 1 # Fixes post bloom alignment.
+    halfPixelOffset: 4 # Correct shadow position.
+    nativeScaling: 2 # Smooths shadows.
 SLES-54947:
   name: "Dogz"
   region: "PAL-M6"
@@ -25320,17 +25788,25 @@ SLES-54962:
   gsHWFixes:
     textureInsideRT: 1 # Crowd textures.
     autoFlush: 1 # Fixes bloom intensity.
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 1 # Fixes post processing smoothness and position.
 SLES-54963:
   name: "Tony Hawk's Proving Ground"
   region: "PAL-E"
   compat: 5
   roundModes:
     vu1RoundMode: 0 # Crashes without.
+  gsHWFixes:
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 1 # Fixes post processing smoothness and position.
 SLES-54964:
   name: "Tony Hawk's Proving Ground"
   region: "PAL-M4"
   roundModes:
     vu1RoundMode: 0 # Crashes without.
+  gsHWFixes:
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 1 # Fixes post processing smoothness and position.
 SLES-54971:
   name: "Hot Wheels - Beat That!"
   region: "PAL-M4"
@@ -25354,6 +25830,8 @@ SLES-54974:
   gsHWFixes:
     textureInsideRT: 1 # Crowd textures.
     autoFlush: 1 # Fixes bloom intensity.
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 1 # Fixes post processing smoothness and position.
 SLES-54975:
   name: "George Of The Jungle"
   region: "PAL-E"
@@ -25489,7 +25967,8 @@ SLES-55010:
     vu1ClampMode: 3 # Fixes texture corruption light shimmering and reflective surfaces.
   gsHWFixes:
     recommendedBlendingLevel: 3
-    halfPixelOffset: 1 # Fixes misaligned bloom effects.
+    halfPixelOffset: 4 # Fixes misaligned bloom effects.
+    nativeScaling: 2 # Fixes bloom effects.
 SLES-55011:
   name: "Thrillville - Fuera de Control"
   region: "PAL-S"
@@ -25497,7 +25976,8 @@ SLES-55011:
     vu1ClampMode: 3 # Fixes texture corruption light shimmering and reflective surfaces.
   gsHWFixes:
     recommendedBlendingLevel: 3
-    halfPixelOffset: 1 # Fixes misaligned bloom effects.
+    halfPixelOffset: 4 # Fixes misaligned bloom effects.
+    nativeScaling: 2 # Fixes bloom effects.
 SLES-55012:
   name: "The Golden Compass"
   name-sort: "Golden Compass, The"
@@ -25522,6 +26002,7 @@ SLES-55016:
   region: "PAL-M6"
   gsHWFixes:
     halfPixelOffset: 4 # Fixes bloom on sunlight.
+    nativeScaling: 2 # Fixes lighting positioning.
 SLES-55017:
   name: "Yu-Gi-Oh! GX - Tag Force Evolution"
   region: "PAL-M5"
@@ -25712,6 +26193,9 @@ SLES-55090:
   region: "PAL-M5"
   gameFixes:
     - OPHFlagHack # Fixes game freezing.
+  gsHWFixes:
+    halfPixelOffset: 2 # Aligns post effects.
+    nativeScaling: 2 # Fixes post effects.
 SLES-55091:
   name: "Hoppie"
   region: "PAL-E"
@@ -25781,7 +26265,8 @@ SLES-55133:
   name: "LEGO Indiana Jones - The Original Adventure"
   region: "PAL-M6"
   gsHWFixes:
-    halfPixelOffset: 1 # Corrects bloom misalignment.
+    halfPixelOffset: 4 # Fixes post positioning.
+    nativeScaling: 1 # Fixes post effects.
 SLES-55134:
   name: "Monster Jam"
   region: "PAL-M5"
@@ -25789,8 +26274,8 @@ SLES-55135:
   name: "LEGO Batman - The VideoGame"
   region: "PAL-M6"
   gsHWFixes:
-    cpuCLUTRender: 1 # Fixes ghosting on objects and people.
-    halfPixelOffset: 2 # Fixes depth line. HPO Normal required if not using CLUT Renderer.
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 1 # Fixes post processing smoothness and position.
 SLES-55136:
   name: "Let's Ride! Silver Buckle Stables"
   region: "PAL-M4"
@@ -25805,28 +26290,28 @@ SLES-55143:
   region: "PAL-G-I"
   gsHWFixes:
     halfPixelOffset: 2 # Reduces ghosting but on normal vertex is less ghosting but causes corruption at the sides.
-    cpuCLUTRender: 1 # Fixes title-screen bloom and church windows on new game and other locations.
+    nativeScaling: 1 # Fixes post processing position.
 SLES-55144:
   name: "The Chronicles of Narnia - Prince Caspian"
   name-sort: "Chronicles of Narnia, The - Prince Caspian"
   region: "PAL-M6"
   gsHWFixes:
     halfPixelOffset: 2 # Reduces ghosting but on normal vertex is less ghosting but causes corruption at the sides.
-    cpuCLUTRender: 1 # Fixes title-screen bloom and church windows on new game and other locations.
+    nativeScaling: 1 # Fixes post processing position.
 SLES-55145:
   name: "The Chronicles of Narnia - Prince Caspian"
   name-sort: "Chronicles of Narnia, The - Prince Caspian"
   region: "PAL-F-DU"
   gsHWFixes:
     halfPixelOffset: 2 # Reduces ghosting but on normal vertex is less ghosting but causes corruption at the sides.
-    cpuCLUTRender: 1 # Fixes title-screen bloom and church windows on new game and other locations.
+    nativeScaling: 1 # Fixes post processing position.
 SLES-55146:
   name: "The Chronicles of Narnia - Prince Caspian"
   name-sort: "Chronicles of Narnia, The - Prince Caspian"
   region: "PAL-UK"
   gsHWFixes:
     halfPixelOffset: 2 # Reduces ghosting but on normal vertex is less ghosting but causes corruption at the sides.
-    cpuCLUTRender: 1 # Fixes title-screen bloom and church windows on new game and other locations.
+    nativeScaling: 1 # Fixes post processing position.
 SLES-55147:
   name: "Silent Hill - Origins"
   region: "PAL-M5"
@@ -25852,9 +26337,8 @@ SLES-55163:
   region: "PAL-M6"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes ghosting and bloom misalignment.
-    cpuSpriteRenderBW: 1 # Rainbow spots if alone applied but needs cpuCLUTrender to look like software mode.
-    cpuCLUTRender: 1 # Blue horizontal lines on it's own but needs cpuSpriteRenderBW to look like software mode.
+    halfPixelOffset: 4 # Reduces post misalignment.
+    nativeScaling: 2 # Fixes remaining post misalignment.
 SLES-55165:
   name: "The Mummy - Tomb of the Dragon Emperor"
   name-sort: "Mummy, The - Tomb of the Dragon Emperor"
@@ -25895,50 +26379,40 @@ SLES-55184:
   roundModes:
     vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
   gsHWFixes:
-    cpuSpriteRenderBW: 2 # Fixes bloom on HW renderer.
-    cpuSpriteRenderLevel: 2 # Needed for above.
-    halfPixelOffset: 4 # Reduces the ghosting effect.
-    roundSprite: 2 # Reduces the ghosting effect.
+    halfPixelOffset: 4 # Aligns Post Effect.
+    nativeScaling: 2 # Fixes Post effect.
 SLES-55185:
   name: "Disney/Pixar WALL-E"
   region: "PAL-UK"
   roundModes:
     vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
   gsHWFixes:
-    cpuSpriteRenderBW: 2 # Fixes bloom on HW renderer.
-    cpuSpriteRenderLevel: 2 # Needed for above.
-    halfPixelOffset: 4 # Reduces the ghosting effect.
-    roundSprite: 2 # Reduces the ghosting effect.
+    halfPixelOffset: 4 # Aligns Post Effect.
+    nativeScaling: 2 # Fixes Post effect.
 SLES-55186:
   name: "Disney/Pixar WALL-E"
   region: "PAL-S-P"
   roundModes:
     vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
   gsHWFixes:
-    cpuSpriteRenderBW: 2 # Fixes bloom on HW renderer.
-    cpuSpriteRenderLevel: 2 # Needed for above.
-    halfPixelOffset: 4 # Reduces the ghosting effect.
-    roundSprite: 2 # Reduces the ghosting effect.
+    halfPixelOffset: 4 # Aligns Post Effect.
+    nativeScaling: 2 # Fixes Post effect.
 SLES-55187:
   name: "Disney/Pixar WALL-E"
   region: "PAL-F-G"
   roundModes:
     vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
   gsHWFixes:
-    cpuSpriteRenderBW: 2 # Fixes bloom on HW renderer.
-    cpuSpriteRenderLevel: 2 # Needed for above.
-    halfPixelOffset: 4 # Reduces the ghosting effect.
-    roundSprite: 2 # Reduces the ghosting effect.
+    halfPixelOffset: 4 # Aligns Post Effect.
+    nativeScaling: 2 # Fixes Post effect.
 SLES-55188:
   name: "Disney/Pixar WALL-E"
   region: "PAL-G"
   roundModes:
     vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
   gsHWFixes:
-    cpuSpriteRenderBW: 2 # Fixes bloom on HW renderer.
-    cpuSpriteRenderLevel: 2 # Needed for above.
-    halfPixelOffset: 4 # Reduces the ghosting effect.
-    roundSprite: 2 # Reduces the ghosting effect.
+    halfPixelOffset: 4 # Aligns Post Effect.
+    nativeScaling: 2 # Fixes Post effect.
 SLES-55189:
   name: "Nick Jr. Go Diego Go! Safari Rescue"
   region: "PAL-E-F"
@@ -25953,6 +26427,8 @@ SLES-55191:
   gsHWFixes:
     textureInsideRT: 1 # Crowd textures.
     autoFlush: 1 # Fixes bloom intensity.
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 1 # Fixes post processing smoothness and position.
 SLES-55192:
   name: "Steam Express"
   region: "PAL-M5"
@@ -25962,40 +26438,32 @@ SLES-55193:
   roundModes:
     vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
   gsHWFixes:
-    cpuSpriteRenderBW: 2 # Fixes bloom on HW renderer.
-    cpuSpriteRenderLevel: 2 # Needed for above.
-    halfPixelOffset: 4 # Reduces the ghosting effect.
-    roundSprite: 2 # Reduces the ghosting effect.
+    halfPixelOffset: 4 # Aligns Post Effect.
+    nativeScaling: 2 # Fixes Post effect.
 SLES-55194:
   name: "Disney/Pixar WALL-E"
   region: "PAL-SC"
   roundModes:
     vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
   gsHWFixes:
-    cpuSpriteRenderBW: 2 # Fixes bloom on HW renderer.
-    cpuSpriteRenderLevel: 2 # Needed for above.
-    halfPixelOffset: 4 # Reduces the ghosting effect.
-    roundSprite: 2 # Reduces the ghosting effect.
+    halfPixelOffset: 4 # Aligns Post Effect.
+    nativeScaling: 2 # Fixes Post effect.
 SLES-55195:
   name: "Disney/Pixar WALL-E"
   region: "PAL-GR-I"
   roundModes:
     vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
   gsHWFixes:
-    cpuSpriteRenderBW: 2 # Fixes bloom on HW renderer.
-    cpuSpriteRenderLevel: 2 # Needed for above.
-    halfPixelOffset: 4 # Reduces the ghosting effect.
-    roundSprite: 2 # Reduces the ghosting effect.
+    halfPixelOffset: 4 # Aligns Post Effect.
+    nativeScaling: 2 # Fixes Post effect.
 SLES-55196:
   name: "Disney/Pixar WALL-E"
   region: "PAL-PL-CR"
   roundModes:
     vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
   gsHWFixes:
-    cpuSpriteRenderBW: 2 # Fixes bloom on HW renderer.
-    cpuSpriteRenderLevel: 2 # Needed for above.
-    halfPixelOffset: 4 # Reduces the ghosting effect.
-    roundSprite: 2 # Reduces the ghosting effect.
+    halfPixelOffset: 4 # Aligns Post Effect.
+    nativeScaling: 2 # Fixes Post effect.
 SLES-55197:
   name: "Dancing Stage SuperNOVA 2"
   region: "PAL-M5"
@@ -26004,7 +26472,8 @@ SLES-55198:
   region: "PAL-M5"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes misaligned bloom.
+    halfPixelOffset: 4 # Fixes post positioning.
+    nativeScaling: 2 # Fixes post effects.
 SLES-55199:
   name: "NASCAR 09"
   region: "PAL-M5"
@@ -26019,6 +26488,8 @@ SLES-55200:
   gsHWFixes:
     textureInsideRT: 1 # Crowd textures.
     autoFlush: 1 # Fixes bloom intensity.
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 1 # Fixes post processing smoothness and position.
 SLES-55201:
   name: "Riding Star"
   region: "PAL-M4"
@@ -26084,9 +26555,8 @@ SLES-55227:
   region: "PAL-SC"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes ghosting and bloom misalignment.
-    cpuSpriteRenderBW: 1 # Rainbow spots if alone applied but needs cpuCLUTrender to look like software mode.
-    cpuCLUTRender: 1 # Blue horizontal lines on it's own but needs cpuSpriteRenderBW to look like software mode.
+    halfPixelOffset: 4 # Reduces post misalignment.
+    nativeScaling: 2 # Fixes remaining post misalignment.
 SLES-55231:
   name: "Fatal Fury - Battle Archives Volume 1"
   region: "PAL-E"
@@ -26119,6 +26589,9 @@ SLES-55237:
     vuClampMode: 2 # Fixes invisible QTE button prompts and overbright in some scenes.
   gameFixes:
     - SoftwareRendererFMVHack # Fixes vertical lines in FMVs.
+  gsHWFixes:
+    halfPixelOffset: 2 # Aligns post effects.
+    nativeScaling: 2 # Fixes post effects.
 SLES-55238:
   name: "Madden NFL 09"
   region: "PAL-E"
@@ -26135,6 +26608,7 @@ SLES-55242:
   region: "PAL-E"
   gsHWFixes:
     alignSprite: 1 # Helps align bloom.
+    nativeScaling: 2 # Fixes post processing and lighting smoothness.
   memcardFilters: # Allows import of Yakuza 1 data.
     - "SLES-55242"
     - "SLES-54171"
@@ -26226,9 +26700,8 @@ SLES-55265:
   region: "PAL-R-E"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes ghosting and bloom misalignment.
-    cpuSpriteRenderBW: 1 # Rainbow spots if alone applied but needs cpuCLUTrender to look like software mode.
-    cpuCLUTRender: 1 # Blue horizontal lines on it's own but needs cpuSpriteRenderBW to look like software mode.
+    halfPixelOffset: 4 # Reduces post misalignment.
+    nativeScaling: 2 # Fixes remaining post misalignment.
 SLES-55266:
   name: "MotoGP 08"
   region: "PAL-M5"
@@ -26410,6 +26883,9 @@ SLES-55355:
     instantVU1: 0 # Corrects note board position.
   roundModes:
     vu1RoundMode: 0 # Fixes graphical issues ingame.
+  gsHWFixes:
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 1 # Fixes post processing smoothness and position.
 SLES-55356:
   name: "Bratz - Girlz Really Rock"
   region: "PAL-M3"
@@ -26446,6 +26922,9 @@ SLES-55369:
 SLES-55371:
   name: "Barbie Horse Adventures - Riding Camp"
   region: "PAL-M6"
+  gsHWFixes:
+    halfPixelOffset: 4 # Fixes post positioning.
+    nativeScaling: 1 # Fixes post effects.
 SLES-55372:
   name: "Spiderman - Web of Shadows"
   region: "PAL-M5"
@@ -26582,6 +27061,8 @@ SLES-55442:
   gsHWFixes:
     textureInsideRT: 1 # Needed for post processing effects.
     autoFlush: 1 # Fixes missing blur layer.
+    nativeScaling: 1 # Fixes post processing.
+    halfPixelOffset: 4 # Fixes offset post processing.
 SLES-55443:
   name: "Mana Khemia - Alchemists of Al-Revis"
   region: "PAL-E"
@@ -26605,7 +27086,8 @@ SLES-55448:
   name: "Indiana Jones and the Staff of Kings"
   region: "PAL-M5"
   gsHWFixes:
-    halfPixelOffset: 1 # Fixes ghosting.
+    halfPixelOffset: 4 # Reduces post misalignment.
+    nativeScaling: 2 # Fixes remaining post misalignment.
 SLES-55450:
   name: "PES 2009 - Pro Evolution Soccer"
   region: "PAL-I"
@@ -26661,6 +27143,9 @@ SLES-55474:
   region: "PAL-E"
   clampModes:
     vuClampMode: 2 # Fix flickering floor during cutscenes in school.
+  gsHWFixes:
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 1 # Fixes post processing smoothness and position.
 SLES-55476:
   name: "Scooby-Doo! First Frights"
   region: "PAL-M5"
@@ -26678,8 +27163,8 @@ SLES-55481:
   gameFixes:
     - SoftwareRendererFMVHack # Fixes vertical lines in FMVs.
   gsHWFixes:
-    roundSprite: 2 # Corrects post processing position + fixes subsequent runs of starter FMV vertical lines.
-    cpuCLUTRender: 1 # Reduces the bloomy blur of characters.
+    halfPixelOffset: 2 # Aligns post effects.
+    nativeScaling: 2 # Fixes post effects.
   clampModes:
     vu0ClampMode: 3 # Fixes bad dialog backgrounds.
     vu1ClampMode: 3 # Fixes SPS on characters.
@@ -26689,8 +27174,8 @@ SLES-55482:
   gameFixes:
     - SoftwareRendererFMVHack # Fixes vertical lines in FMVs.
   gsHWFixes:
-    roundSprite: 2 # Corrects post processing position + fixes subsequent runs of starter FMV vertical lines.
-    cpuCLUTRender: 1 # Reduces the bloomy blur of characters.
+    halfPixelOffset: 2 # Aligns post effects.
+    nativeScaling: 2 # Fixes post effects.
   clampModes:
     vu0ClampMode: 3 # Fixes bad dialog backgrounds.
     vu1ClampMode: 3 # Fixes SPS on characters.
@@ -26769,6 +27254,8 @@ SLES-55518:
   gsHWFixes:
     preloadFrameData: 1 # Fixes icons.
     autoFlush: 1 # Fixes bloom intensity.
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 1 # Fixes post processing smoothness and position.
   roundModes:
     vu1RoundMode: 0 # Fixes VU size spam and potential graphical issues with GH3 engine.
 SLES-55520:
@@ -26777,7 +27264,8 @@ SLES-55520:
   compat: 5
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes textures.
-    halfPixelOffset: 2 # Fixes misaligned bloom.
+    halfPixelOffset: 4 # Aligns post processing, needed for below, but does cause a line around the edge, can be cropped out with 3 px left and top.
+    nativeScaling: 2 # Fixes post processing smoothness, causes edge bleed without Align to Native.
     autoFlush: 2 # Fixes soft shadows.
   patches:
     9E36E023:
@@ -26820,6 +27308,9 @@ SLES-55533:
   region: "PAL-M5"
   roundModes:
     vu1RoundMode: 0 # Fixes SPS and VU size spam.
+  gsHWFixes:
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 1 # Fixes post processing smoothness and position.
 SLES-55536:
   name: "Disney/Pixar Cars - Race-O-Rama"
   region: "PAL-M5"
@@ -26878,6 +27369,7 @@ SLES-55578:
   gsHWFixes:
     autoFlush: 1 # Fixes character shadow misalignment.
     preloadFrameData: 1 # Fixes icons.
+    halfPixelOffset: 4 # Aligns UI and other elements.
 SLES-55579:
   name: "Bakugan - Battle Brawlers"
   region: "PAL-M7"
@@ -26950,8 +27442,8 @@ SLES-55605:
   gameFixes:
     - SoftwareRendererFMVHack # Fixes vertical lines in FMVs.
   gsHWFixes:
-    roundSprite: 2 # Corrects post processing position + fixes subsequent runs of starter FMV vertical lines.
-    cpuCLUTRender: 1 # Reduces the bloomy blur of characters.
+    halfPixelOffset: 2 # Aligns post effects.
+    nativeScaling: 2 # Fixes post effects.
   clampModes:
     vu0ClampMode: 3 # Fixes bad dialog backgrounds.
     vu1ClampMode: 3 # Fixes SPS on characters.
@@ -26962,7 +27454,8 @@ SLES-55610:
   name: "Springdale"
   region: "PAL-SC"
   gsHWFixes:
-    halfPixelOffset: 1 # Reduces the ghosting effect.
+    halfPixelOffset: 4 # Aligns post processing.
+    nativeScaling: 2 # Fixes post processing position.
 SLES-55622:
   name: "Disney/Pixar Toy Story 3"
   region: "PAL-M6"
@@ -26970,16 +27463,16 @@ SLES-55622:
   roundModes:
     vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
   gsHWFixes:
-    halfPixelOffset: 2 # Reduces the ghosting effect.
-    forceEvenSpritePosition: 1 # Reduces the ghosting effect.
+    halfPixelOffset: 4 # Aligns Post Effect.
+    nativeScaling: 2 # Fixes Post effect.
 SLES-55623:
   name: "Disney/Pixar Toy Story 3"
   region: "PAL-R"
   roundModes:
     vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
   gsHWFixes:
-    halfPixelOffset: 2 # Reduces the ghosting effect.
-    forceEvenSpritePosition: 1 # Reduces the ghosting effect.
+    halfPixelOffset: 4 # Aligns Post Effect.
+    nativeScaling: 2 # Fixes Post effect.
 SLES-55625:
   name: "Despicable Me - The Game"
   region: "PAL-M9"
@@ -27131,7 +27624,8 @@ SLES-82013:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
-    halfPixelOffset: 2 # Fixes blurry characters.
+    halfPixelOffset: 4 # Aligns depth of field effect.
+    nativeScaling: 2 # Fixes post lighting.
     autoFlush: 2 # Fixes lens flare.
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
 SLES-82018:
@@ -27157,7 +27651,8 @@ SLES-82024:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
-    halfPixelOffset: 2 # Fixes blurry characters.
+    halfPixelOffset: 4 # Aligns depth of field effect.
+    nativeScaling: 2 # Fixes post lighting.
     autoFlush: 2 # Fixes lens flare.
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
 SLES-82026:
@@ -27167,7 +27662,8 @@ SLES-82026:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
-    halfPixelOffset: 2 # Fixes blurry characters.
+    halfPixelOffset: 4 # Aligns depth of field effect.
+    nativeScaling: 2 # Fixes post lighting.
     autoFlush: 2 # Fixes lens flare.
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
 SLES-82028:
@@ -27177,7 +27673,8 @@ SLES-82028:
   gameFixes:
     - VuAddSubHack
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes bloom and ghosting in certain areas.
+    halfPixelOffset: 4 # Fix effects upscaling.
+    nativeScaling: 2 # Fixes post effects.
     roundSprite: 1 # Fixes door transition vertical lines and mini-map artifacts.
     textureInsideRT: 1 # Fixes missing battle effects.
 SLES-82029:
@@ -27187,7 +27684,8 @@ SLES-82029:
   gameFixes:
     - VuAddSubHack
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes bloom and ghosting in certain areas.
+    halfPixelOffset: 4 # Fix effects upscaling.
+    nativeScaling: 2 # Fixes post effects.
     roundSprite: 1 # Fixes door transition vertical lines and mini-map artifacts.
     textureInsideRT: 1 # Fixes missing battle effects.
   memcardFilters:
@@ -27196,17 +27694,13 @@ SLES-82030:
   name: "Shadow Hearts - Covenant [Disc 1 of 2]"
   region: "PAL-M3"
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes blurrines, preload frame for FMV breaks visuals with this setting.
-    disablePartialInvalidation: 1 # Fixes shadows when upscaling.
-    roundSprite: 2 # Fixes the position of monster sprites and reduces garbage in the UI.
+    halfPixelOffset: 4 # Fixes shadow positioning.
     autoFlush: 2 # Makes the shadow monsters appear.
 SLES-82031:
   name: "Shadow Hearts - Covenant [Disc 2 of 2]"
   region: "PAL-M3"
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes blurrines, preload frame for FMV breaks visuals with this setting.
-    disablePartialInvalidation: 1 # Fixes shadows when upscaling.
-    roundSprite: 2 # Fixes the position of monster sprites and reduces garbage in the UI.
+    halfPixelOffset: 4 # Fixes shadow positioning.
     autoFlush: 2 # Makes the shadow monsters appear.
   memcardFilters:
     - "SLES-82030"
@@ -27217,7 +27711,8 @@ SLES-82032:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
-    halfPixelOffset: 2 # Fixes blurry characters.
+    halfPixelOffset: 4 # Aligns depth of field effect.
+    nativeScaling: 2 # Fixes post lighting.
     autoFlush: 2 # Fixes lens flare.
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
 SLES-82036:
@@ -27243,13 +27738,15 @@ SLES-82038:
   region: "PAL-M5"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes misalignment and upscaling lines.
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 2 # Fixes post processing smoothness and position.
 SLES-82039:
   name: "Onimusha - Dawn of Dreams [Disc 2 of 2]"
   region: "PAL-M5"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes misalignment and upscaling lines.
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 2 # Fixes post processing smoothness and position.
   memcardFilters:
     - "SLES-82038"
 SLES-82042:
@@ -27261,7 +27758,8 @@ SLES-82042:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
-    halfPixelOffset: 2 # Fixes blurriness.
+    halfPixelOffset: 4 # Aligns depth of field effect.
+    nativeScaling: 2 # Fixes post lighting.
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
 SLES-82043:
   name: "Metal Gear Solid 3 - Subsistence [Disc 2 of 3]"
@@ -27272,7 +27770,8 @@ SLES-82043:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
-    halfPixelOffset: 2 # Fixes blurriness.
+    halfPixelOffset: 4 # Aligns depth of field effect.
+    nativeScaling: 2 # Fixes post lighting.
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
   memcardFilters:
     - "SLES-82042"
@@ -27285,7 +27784,8 @@ SLES-82044:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
-    halfPixelOffset: 2 # Fixes blurriness.
+    halfPixelOffset: 4 # Aligns depth of field effect.
+    nativeScaling: 2 # Fixes post lighting.
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
 SLES-82045:
   name: "Metal Gear Solid 3 - Subsistence [Disc 2 of 3]"
@@ -27296,7 +27796,8 @@ SLES-82045:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
-    halfPixelOffset: 2 # Fixes blurriness.
+    halfPixelOffset: 4 # Aligns depth of field effect.
+    nativeScaling: 2 # Fixes post lighting.
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
   memcardFilters:
     - "SLES-82044"
@@ -27309,7 +27810,8 @@ SLES-82046:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
-    halfPixelOffset: 2 # Fixes blurriness.
+    halfPixelOffset: 4 # Aligns depth of field effect.
+    nativeScaling: 2 # Fixes post lighting.
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
 SLES-82047:
   name: "Metal Gear Solid 3 - Subsistence [Disc 2 of 3]"
@@ -27320,7 +27822,8 @@ SLES-82047:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
-    halfPixelOffset: 2 # Fixes blurriness.
+    halfPixelOffset: 4 # Aligns depth of field effect.
+    nativeScaling: 2 # Fixes post lighting.
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
   memcardFilters:
     - "SLES-82046"
@@ -27333,7 +27836,8 @@ SLES-82048:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
-    halfPixelOffset: 2 # Fixes blurriness.
+    halfPixelOffset: 4 # Aligns depth of field effect.
+    nativeScaling: 2 # Fixes post lighting.
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
 SLES-82049:
   name: "Metal Gear Solid 3 - Subsistence [Disc 2 of 3]"
@@ -27344,7 +27848,8 @@ SLES-82049:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
-    halfPixelOffset: 2 # Fixes blurriness.
+    halfPixelOffset: 4 # Aligns depth of field effect.
+    nativeScaling: 2 # Fixes post lighting.
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
   memcardFilters:
     - "SLES-82048"
@@ -27357,7 +27862,8 @@ SLES-82050:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
-    halfPixelOffset: 2 # Fixes blurriness.
+    halfPixelOffset: 4 # Aligns depth of field effect.
+    nativeScaling: 2 # Fixes post lighting.
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
   memcardFilters:
     - "SLES-82042"
@@ -27370,7 +27876,8 @@ SLES-82051:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
-    halfPixelOffset: 2 # Fixes blurriness.
+    halfPixelOffset: 4 # Aligns depth of field effect.
+    nativeScaling: 2 # Fixes post lighting.
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
   memcardFilters:
     - "SLES-82044"
@@ -27383,7 +27890,8 @@ SLES-82052:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
-    halfPixelOffset: 2 # Fixes blurriness.
+    halfPixelOffset: 4 # Aligns depth of field effect.
+    nativeScaling: 2 # Fixes post lighting.
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
   memcardFilters:
     - "SLES-82046"
@@ -27396,7 +27904,8 @@ SLES-82053:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
-    halfPixelOffset: 2 # Fixes blurriness.
+    halfPixelOffset: 4 # Aligns depth of field effect.
+    nativeScaling: 2 # Fixes post lighting.
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
   memcardFilters:
     - "SLES-82048"
@@ -27538,6 +28047,9 @@ SLKA-15058:
   name: "The Terra Defence Force 2"
   name-sort: "Terra Defence Force, The 2"
   region: "NTSC-K"
+  gsHWFixes:
+    halfPixelOffset: 4 # Fixes post processing positioning.
+    nativeScaling: 1 # Fixes post processing effects caused by upscaling.
 SLKA-15060:
   name: "Raiden III"
   region: "NTSC-K"
@@ -27653,19 +28165,19 @@ SLKA-25038:
   name: "Gun Survivor 4 - BioHazard - Heroes Never Die"
   region: "NTSC-K"
   gsHWFixes:
-    halfPixelOffset: 1 # Fixes character offset with flashlight and blurriness.
-    alignSprite: 1 # Fixes vertical lines.
+    halfPixelOffset: 4 # Fixes character offset with flashlight and blurriness.
     roundSprite: 2 # Fixes font artifacts.
-    mergeSprite: 1 # Fixes flame-like bleeding.
     autoFlush: 1 # Fixes light bloom intensity.
+    nativeScaling: 2 # Fixes post processing.
 SLKA-25039:
   name: "Burnout 2 - Point of Impact"
   region: "NTSC-K"
   gsHWFixes:
     gpuTargetCLUT: 1 # Fixes bloom and sun rendering in front of everything.
     autoFlush: 1 # Fixes bloom and sun rendering in front of everything.
-    halfPixelOffset: 2 # Aligns bloom effect a little bit better when upscaled.
+    halfPixelOffset: 4 # Aligns bloom effect.
     bilinearUpscale: 2 # Reduces color banding of the sun glare.
+    nativeScaling: 2 # Fixes post lighting.
   roundModes:
     vu1RoundMode: 1 # Bright lights in cars.
 SLKA-25041:
@@ -27743,6 +28255,10 @@ SLKA-25060:
 SLKA-25061:
   name: "Tom Clancy's Splinter Cell"
   region: "NTSC-K"
+  gsHWFixes:
+    halfPixelOffset: 4 # Aligns post processing.
+    nativeScaling: 2 # Fixes post effects.
+    recommendedBlendingLevel: 4 # Fixes lighting effects but has high barrier count.
 SLKA-25062:
   name: "Dragon Ball Z 2"
   region: "NTSC-K"
@@ -27771,6 +28287,9 @@ SLKA-25066:
   name: "Zone of the Enders - The 2nd Runner SE"
   region: "NTSC-K"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 1 # Aligns post effects.
+    nativeScaling: 2 # Fixes post effects.
 SLKA-25067:
   name: "Unlimited Saga"
   region: "NTSC-K"
@@ -27811,7 +28330,7 @@ SLKA-25080:
   name-en: ".hack//Infection Part 1"
   region: "NTSC-K"
   gsHWFixes:
-    halfPixelOffset: 1 # Sharpens world in far distances.
+    halfPixelOffset: 2 # Aligns DoF effects.
 SLKA-25081:
   name: "SD Gundam G Generation Neo"
   region: "NTSC-K"
@@ -27867,7 +28386,8 @@ SLKA-25093:
     - "SLKA-25092"
     - "SLKA-25093"
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes ghosting.
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 2 # Fixes post processing smoothness and position.
     roundSprite: 2 # Fixes various lines / reduces bars on right edge.
     disablePartialInvalidation: 1 # Fixes textureless graphics ingame.
     bilinearUpscale: 2 # Gets rid of center vertical line when upscaling.
@@ -27963,7 +28483,8 @@ SLKA-25120:
   region: "NTSC-K"
   gsHWFixes:
     autoFlush: 2 # Reduces post-processing misalignment.
-    halfPixelOffset: 4 # Reduces post-processing misalignment.
+    halfPixelOffset: 4 # Fixes post positioning.
+    nativeScaling: 2 # Fixes post effects.
 SLKA-25121:
   name: "Vexx"
   region: "NTSC-K"
@@ -28231,7 +28752,7 @@ SLKA-25196:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     autoFlush: 1 # Aligns and corrects shadows.
-    roundSprite: 1 # Fixes depth line.
+    halfPixelOffset: 2 # Fixes sun and depth line.
     cpuCLUTRender: 1 # Fixes janky coloured cars.
     gpuTargetCLUT: 1 # Fixes janky coloured cars.
     textureInsideRT: 1 # Fixes car textures.
@@ -28291,6 +28812,7 @@ SLKA-25206:
     autoFlush: 2 # Fixes blur and obscures sun behind objects.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     bilinearUpscale: 2 # Smooths out sun glare textures like native.
+    nativeScaling: 2 # Smooths speed blur and corrects some lighting.
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
 SLKA-25207:
@@ -28396,8 +28918,8 @@ SLKA-25226:
   name-sort: "Disney/Pixar Incredibles, The"
   region: "NTSC-K"
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes bloom misalignment when upscaling.
-    cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling.
+    halfPixelOffset: 4 # Aligns post effects.
+    nativeScaling: 2 # Fixes post effects.
 SLKA-25227:
   name: "Neo Contra"
   region: "NTSC-K"
@@ -28411,10 +28933,16 @@ SLKA-25228:
 SLKA-25230:
   name: "Def Jam - Fight for NY"
   region: "NTSC-K"
+  gsHWFixes:
+    halfPixelOffset: 4 # Reduces post misalignment.
+    nativeScaling: 2 # Fixes remaining post misalignment.
 SLKA-25232:
   name: "Naruto Narutimett Hero International"
   region: "NTSC-K"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 2 # Aligns post effects.
+    nativeScaling: 2 # Fixes post effects.
 SLKA-25233:
   name: "Sonic - Mega Collection Plus"
   region: "NTSC-K"
@@ -28429,7 +28957,8 @@ SLKA-25237:
   name-sort: "Lord of the Rings, The - The Third Age"
   region: "NTSC-K"
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes ghosting.
+    halfPixelOffset: 4 # Aligns post processing.
+    nativeScaling: 2 # Corrects post processing smoothness.
 SLKA-25240:
   name: "WWE SmackDown! Shut Your Mouth"
   region: "NTSC-K"
@@ -28467,6 +28996,8 @@ SLKA-25247:
   region: "NTSC-K"
   gsHWFixes:
     autoFlush: 2 # Reduces post-processing misalignment.
+    halfPixelOffset: 4 # Fixes post positioning.
+    nativeScaling: 2 # Fixes post effects.
 SLKA-25249:
   name: "Ys - The Ark of Napishtim [with Guide Book]"
   region: "NTSC-K"
@@ -28482,7 +29013,8 @@ SLKA-25251:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
-    halfPixelOffset: 2 # Fixes blurriness.
+    halfPixelOffset: 4 # Aligns depth of field effect.
+    nativeScaling: 2 # Fixes post lighting.
     autoFlush: 2 # Fixes lens flare.
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
 SLKA-25252:
@@ -28516,6 +29048,17 @@ SLKA-25259:
 SLKA-25260:
   name: "Burnout Dominator"
   region: "NTSC-K"
+  clampModes:
+    vuClampMode: 3 # Fixes buggy lighting in the garage.
+  gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves car reflections.
+    halfPixelOffset: 2 # Fixes depth lines.
+    autoFlush: 2 # Fixes blur and obscures sun behind objects.
+    gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
+    bilinearUpscale: 2 # Smooths out sun glare textures like native.
+    nativeScaling: 2 # Smooths speed blur and corrects some lighting.
+    getSkipCount: "GSC_BurnoutGames"
+    beforeDraw: "OI_BurnoutGames"
 SLKA-25261:
   name: "Tsukiyo ni Saraba"
   region: "NTSC-K"
@@ -28537,8 +29080,8 @@ SLKA-25265:
   roundModes:
     eeRoundMode: 0 # Fixes inability to enter door in Mission 18.
   gsHWFixes:
-    halfPixelOffset: 2 # Reduces ghosting but still an issue compared to native.
-    roundSprite: 2 # Clears up much of the blurring that HPO Special does not.
+    halfPixelOffset: 4 # Aligns post effects.
+    nativeScaling: 2 # Fixes post processing and lighting smoothness and position.
 SLKA-25266:
   name: "Sangokushi IX [PlayStation 2 - Big Hit Series]"
   region: "NTSC-K"
@@ -28683,6 +29226,7 @@ SLKA-25303:
   gsHWFixes:
     halfPixelOffset: 2 # Fix effects upscaling.
     autoFlush: 1 # Fixes broken post processing.
+    nativeScaling: 2 # Fixes post effects.
 SLKA-25304:
   name: "Burnout Revenge"
   region: "NTSC-K"
@@ -28694,6 +29238,7 @@ SLKA-25304:
     autoFlush: 2 # Fixes blur and obscures sun behind objects.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     bilinearUpscale: 2 # Smooths out sun glare textures like native.
+    nativeScaling: 2 # Smooths speed blur and corrects some lighting.
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
 SLKA-25305:
@@ -28728,7 +29273,8 @@ SLKA-25313:
   gameFixes:
     - OPHFlagHack
   gsHWFixes:
-    mergeSprite: 1 # Reduces bloom but fixes blurriness around models + Recommended to use Shadeboost brightness 80.
+    halfPixelOffset: 2 # Aligns post effects.
+    nativeScaling: 2 # Fixes post effects.
 SLKA-25314:
   name: "Kidou Senshi Gundam SEED - Rengou vs. Z.A.F.T."
   region: "NTSC-K"
@@ -28744,6 +29290,10 @@ SLKA-25315:
 SLKA-25316:
   name: "Disney/Pixar Mr. Incredible - Kyouteki Underminer Toujou"
   region: "NTSC-K"
+  gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes building shade and shadows.
+    halfPixelOffset: 4 # Aligns post effects.
+    nativeScaling: 2 # Fixes post effects.
 SLKA-25317:
   name: "Shin Sangoku Musou 3 [PlayStation 2 - Big Hit Series]"
   region: "NTSC-K"
@@ -28839,7 +29389,8 @@ SLKA-25335:
   region: "NTSC-K"
   gsHWFixes:
     recommendedBlendingLevel: 4 # Improves smoke rendering.
-    halfPixelOffset: 2 # Fixes misaligned lighting.
+    halfPixelOffset: 4 # Fixes post positioning.
+    nativeScaling: 2 # Fixes post effects.
 SLKA-25337:
   name: "Peter Jackson's King Kong - The Official Game of the Movie"
   region: "NTSC-K"
@@ -28884,7 +29435,8 @@ SLKA-25343:
     vu1ClampMode: 3 # Fixes texture corruption light shimmering and reflective surfaces.
   gsHWFixes:
     recommendedBlendingLevel: 3
-    halfPixelOffset: 1 # Fixes misaligned bloom effects.
+    halfPixelOffset: 4 # Fixes misaligned bloom effects.
+    nativeScaling: 2 # Fixes bloom effects.
 SLKA-25344:
   name: "Tom Clancy's Ghost Recon - Advanced Warfighter"
   region: "NTSC-K"
@@ -28898,7 +29450,8 @@ SLKA-25346:
   region: "NTSC-K"
   gsHWFixes:
     autoFlush: 1 # Reduces post-processing misalignment.
-    halfPixelOffset: 4 # Reduces post-processing misalignment.
+    halfPixelOffset: 4 # Fixes post positioning.
+    nativeScaling: 2 # Fixes post effects.
 SLKA-25349:
   name: "Jacked"
   region: "NTSC-K"
@@ -28918,7 +29471,8 @@ SLKA-25353:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
-    halfPixelOffset: 2 # Fixes blurriness.
+    halfPixelOffset: 4 # Aligns depth of field effect.
+    nativeScaling: 2 # Fixes post lighting.
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
 SLKA-25354:
   name: "Metal Gear Solid 3 - Subsistence [Limited Edition] [Disc 2 of 3]"
@@ -28930,7 +29484,8 @@ SLKA-25354:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
-    halfPixelOffset: 2 # Fixes blurriness.
+    halfPixelOffset: 4 # Aligns depth of field effect.
+    nativeScaling: 2 # Fixes post lighting.
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
   memcardFilters:
     - "SLKA-25353"
@@ -28944,7 +29499,8 @@ SLKA-25355:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
-    halfPixelOffset: 2 # Fixes blurriness.
+    halfPixelOffset: 4 # Aligns depth of field effect.
+    nativeScaling: 2 # Fixes post lighting.
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
   memcardFilters:
     - "SLKA-25353"
@@ -28967,7 +29523,8 @@ SLKA-25362:
   name: "Sega Rally 2006"
   region: "NTSC-K"
   gsHWFixes:
-    cpuCLUTRender: 1 # Fixes rainbow textures.
+    halfPixelOffset: 4 # Correct shadow position.
+    nativeScaling: 2 # Smooths shadows.
 SLKA-25363:
   name: "Guitar Hero III - Legends of Rock"
   region: "NTSC-K"
@@ -28976,6 +29533,8 @@ SLKA-25363:
   gsHWFixes:
     textureInsideRT: 1 # Crowd textures.
     autoFlush: 1 # Fixes bloom intensity.
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 1 # Fixes post processing smoothness and position.
 SLKA-25364:
   name: "Mobile Suit Gundam - Climax U.C."
   region: "NTSC-K"
@@ -28988,6 +29547,9 @@ SLKA-25366:
   compat: 5
   gameFixes:
     - OPHFlagHack # Fixes game freezing.
+  gsHWFixes:
+    halfPixelOffset: 2 # Aligns post effects.
+    nativeScaling: 2 # Fixes post effects.
 SLKA-25367:
   name: "Superman Returns"
   region: "NTSC-K"
@@ -29010,6 +29572,8 @@ SLKA-25372:
     recommendedBlendingLevel: 4 # Improves lighting on buildings and objects.
     autoFlush: 2 # Properly diffuses light instead of strips of light.
     roundSprite: 1 # Fixes lighting misalignment such as the street poles and the sun.
+    halfPixelOffset: 2 # Mostly aligns post processing.
+    nativeScaling: 2 # Improves post processing smoothness.
     getSkipCount: "GSC_BlackAndBurnoutSky"
     beforeDraw: "OI_BurnoutGames"
 SLKA-25373:
@@ -29028,6 +29592,9 @@ SLKA-25374:
 SLKA-25375:
   name: "Transformers - The Game"
   region: "NTSC-K"
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes alignment of post processing.
+    nativeScaling: 1 # Fixes post processing effect.
 SLKA-25377:
   name: "OutRun 2006 - Coast 2 Coast"
   region: "NTSC-K"
@@ -29126,8 +29693,8 @@ SLKA-25402:
   roundModes:
     eeRoundMode: 0 # Fixes inability to enter door in Mission 18.
   gsHWFixes:
-    halfPixelOffset: 2 # Reduces ghosting but still an issue compared to native.
-    roundSprite: 2 # Clears up much of the blurring that HPO Special does not.
+    halfPixelOffset: 4 # Aligns post effects.
+    nativeScaling: 2 # Fixes post processing and lighting smoothness and position.
 SLKA-25404:
   name: "NBA Live 08"
   region: "NTSC-K"
@@ -29178,6 +29745,8 @@ SLKA-25414:
   gsHWFixes:
     textureInsideRT: 1 # Crowd textures.
     autoFlush: 1 # Fixes bloom intensity.
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 1 # Fixes post processing smoothness and position.
 SLKA-25417:
   name: "Jin Samguk Mussang 4 - Empires"
   region: "NTSC-K"
@@ -29193,7 +29762,8 @@ SLKA-25423:
   name: "Sega Rally 2006"
   region: "NTSC-K"
   gsHWFixes:
-    cpuCLUTRender: 1 # Fixes rainbow textures.
+    halfPixelOffset: 4 # Correct shadow position.
+    nativeScaling: 2 # Smooths shadows.
 SLKA-25424:
   name: "SNK Arcade Classics Vol.1"
   region: "NTSC-K"
@@ -29230,6 +29800,8 @@ SLKA-25434:
   gsHWFixes:
     textureInsideRT: 1 # Crowd textures.
     autoFlush: 1 # Fixes bloom intensity.
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 1 # Fixes post processing smoothness and position.
 SLKA-25435:
   name: "Sengoku Basara X"
   region: "NTSC-J-K"
@@ -29293,9 +29865,15 @@ SLKA-25452:
 SLKA-25453:
   name: "Shin Onimusha - Dawn of Dreams [Disc 1 of 2]"
   region: "NTSC-K"
+  gsHWFixes:
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 2 # Fixes post processing smoothness and position.
 SLKA-25454:
   name: "Shin Onimusha - Dawn of Dreams [Disc 2 of 2]"
   region: "NTSC-K"
+  gsHWFixes:
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 2 # Fixes post processing smoothness and position.
 SLKA-25455:
   name: "World Soccer Winning Eleven 2009"
   region: "NTSC-K"
@@ -29316,7 +29894,8 @@ SLKA-25459:
   compat: 5
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes textures.
-    halfPixelOffset: 2 # Fixes misaligned bloom.
+    halfPixelOffset: 4 # Aligns post processing, needed for below, but does cause a line around the edge, can be cropped out with 3 px left and top.
+    nativeScaling: 2 # Fixes post processing smoothness, causes edge bleed without Align to Native.
     autoFlush: 2 # Fixes soft shadows.
   patches:
     9E36E023:
@@ -29346,6 +29925,9 @@ SLKA-25468:
 SLKA-25470:
   name: "Zone of the Enders - The 2nd Runner - Special Edition"
   region: "NTSC-K"
+  gsHWFixes:
+    halfPixelOffset: 1 # Aligns post effects.
+    nativeScaling: 2 # Fixes post effects.
 SLKA-25471:
   name: "Metal Gear Solid 2 - Sons of Liberty"
   region: "NTSC-K"
@@ -29360,7 +29942,8 @@ SLKA-25472:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
-    halfPixelOffset: 2 # Fixes blurriness.
+    halfPixelOffset: 4 # Aligns depth of field effect.
+    nativeScaling: 2 # Fixes post lighting.
     autoFlush: 2 # Fixes lens flare.
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
 SLKA-25475:
@@ -29456,6 +30039,7 @@ SLPM-55004:
     autoFlush: 2 # Fixes blur and obscures sun behind objects.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     bilinearUpscale: 2 # Smooths out sun glare textures like native.
+    nativeScaling: 2 # Smooths speed blur and corrects some lighting.
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
 SLPM-55005:
@@ -29515,10 +30099,16 @@ SLPM-55019:
   gsHWFixes:
     autoFlush: 1 # Fixes effects.
     roundSprite: 1 # Fixes upscaling artifacts.
-    halfPixelOffset: 4 # Fixes upscaling artifacts.
+    halfPixelOffset: 2 # Fixes post bloom positioning.
+    nativeScaling: 2 # Fixes lighting effects due to upscaling.
 SLPM-55020:
   name: "Kingdom Hearts II - Final Mix"
   region: "NTSC-J"
+  gsHWFixes:
+    autoFlush: 1 # Corrects lighting bloom effect and somewhat corrects position.
+    roundSprite: 1 # Fixes upscaling artifacts.
+    halfPixelOffset: 2 # Fixes post bloom positioning.
+    nativeScaling: 2 # Fixes lighting effects due to upscaling.
 SLPM-55021:
   name: "Kingdom Hearts - Re -Chain of Memories"
   region: "NTSC-J"
@@ -29578,6 +30168,7 @@ SLPM-55036:
     autoFlush: 2 # Fixes blur and obscures sun behind objects.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     bilinearUpscale: 2 # Smooths out sun glare textures like native.
+    nativeScaling: 2 # Smooths speed blur and corrects some lighting.
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
 SLPM-55037:
@@ -29617,6 +30208,8 @@ SLPM-55046:
     roundSprite: 1 # Fixes misaligned map.
     skipDrawStart: 1 # Removes large black box around player car till we properly emulate it.
     skipDrawEnd: 1 # Removes large black box around player car till we properly emulate it.
+    halfPixelOffset: 2 # Fixes depth of field alignment.
+    nativeScaling: 1 # Fixes depth of field.
 SLPM-55047:
   name: Sugar+Spice! 〜あの子のステキな何もかも〜
   name-sort: しゅがーすぱいす あのこのすてきななにもかも
@@ -29951,10 +30544,9 @@ SLPM-55141:
   region: "NTSC-J"
   gsHWFixes:
     textureInsideRT: 1 # Fixes shadow maps.
-    roundSprite: 2 # Fixes misaligned bloom.
-    mergeSprite: 1 # Fixes misaligned bloom.
     halfPixelOffset: 2 # Fixes misaligned bloom.
     autoFlush: 2 # Fixes sun occlusion and brightness.
+    nativeScaling: 2 # Fixes post processing and lighting smoothness and position.
 SLPM-55143:
   name: "Biohazard - Code - Veronica - Kanzenban"
   region: "NTSC-J"
@@ -30243,7 +30835,8 @@ SLPM-55236:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
-    halfPixelOffset: 2 # Fixes blurriness.
+    halfPixelOffset: 4 # Aligns depth of field effect.
+    nativeScaling: 2 # Fixes post lighting.
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
 SLPM-55237:
   name: "Metal Gear & Metal Gear 2 - Solid Snake"
@@ -30464,7 +31057,8 @@ SLPM-60109:
     halfPixelOffset: 2 # Fixes title screen and some intro post processing alignment.
     roundSprite: 1 # Fixes ui and hud alignment.
     gpuPaletteConversion: 2 # Lots of CLUTs in large textures.
-    cpuCLUTRender: 1 # Fixes car textures.
+    cpuSpriteRenderBW: 1 # Fixes car textures.
+    cpuSpriteRenderLevel: 1 # Needed for above.
 SLPM-60112:
   name: "Hresvelgr"
   region: "NTSC-J"
@@ -30510,6 +31104,9 @@ SLPM-60123:
 SLPM-60124:
   name: "Shadow Hearts II [Demo]"
   region: "NTSC-J"
+  gsHWFixes:
+    halfPixelOffset: 4 # Fixes shadow positioning.
+    autoFlush: 2 # Makes the shadow monsters appear.
 SLPM-60125:
   name: "G1 Jockey 2 [Demo]"
   region: "NTSC-J"
@@ -30593,6 +31190,7 @@ SLPM-60149:
     mergeSprite: 1 # Fixes vertical lines.
     cpuSpriteRenderBW: 1 # Fixes missing sun sprite.
     cpuSpriteRenderLevel: 0 # Needed for above.
+    nativeScaling: 2 # Smooths post processing.
 SLPM-60150:
   name: "Tamamayu Monogatari 2 - Horobi no Mushi"
   region: "NTSC-J"
@@ -30763,6 +31361,9 @@ SLPM-60213:
 SLPM-60214:
   name: "Shadow Hearts II"
   region: "NTSC-J"
+  gsHWFixes:
+    halfPixelOffset: 4 # Fixes shadow positioning.
+    autoFlush: 2 # Makes the shadow monsters appear.
 SLPM-60215:
   name: "Dengeki PS2 PlayStation D63"
   region: "NTSC-J"
@@ -30782,6 +31383,9 @@ SLPM-60218:
 SLPM-60219:
   name: "Shadow Hearts II"
   region: "NTSC-J"
+  gsHWFixes:
+    halfPixelOffset: 4 # Fixes shadow positioning.
+    autoFlush: 2 # Makes the shadow monsters appear.
 SLPM-60220:
   name: "Hajime no Ippo 2 - Victorious Road"
   region: "NTSC-J"
@@ -30791,6 +31395,9 @@ SLPM-60225:
 SLPM-60226:
   name: "Shadow Hearts II"
   region: "NTSC-J"
+  gsHWFixes:
+    halfPixelOffset: 4 # Fixes shadow positioning.
+    autoFlush: 2 # Makes the shadow monsters appear.
 SLPM-60228:
   name: "Kaido Battle 2 - Chain Reaction [Trial]"
   region: "NTSC-J"
@@ -30836,6 +31443,7 @@ SLPM-60246:
     autoFlush: 2 # Fixes blur and obscures sun behind objects.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     bilinearUpscale: 2 # Smooths out sun glare textures like native.
+    nativeScaling: 2 # Smooths speed blur and corrects some lighting.
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
 SLPM-60247:
@@ -30857,8 +31465,8 @@ SLPM-60251:
   roundModes:
     eeRoundMode: 0 # Fixes inability to enter door in Mission 18.
   gsHWFixes:
-    halfPixelOffset: 2 # Reduces ghosting but still an issue compared to native.
-    roundSprite: 2 # Clears up much of the blurring that HPO Special does not.
+    halfPixelOffset: 4 # Aligns post effects.
+    nativeScaling: 2 # Fixes post processing and lighting smoothness and position.
 SLPM-60252:
   name: "Futakoi"
   region: "NTSC-J"
@@ -31107,11 +31715,10 @@ SLPM-61039:
   name: "Gun Survivor 4 - BioHazard - Heroes Never Die [Demo]"
   region: "NTSC-J"
   gsHWFixes:
-    halfPixelOffset: 1 # Fixes character offset with flashlight and blurriness.
-    alignSprite: 1 # Fixes vertical lines.
+    halfPixelOffset: 4 # Fixes character offset with flashlight and blurriness.
     roundSprite: 2 # Fixes font artifacts.
-    mergeSprite: 1 # Fixes flame-like bleeding.
     autoFlush: 1 # Fixes light bloom intensity.
+    nativeScaling: 2 # Fixes post processing.
 SLPM-61041:
   name: "Virtua Fighter 4 - Evolution"
   region: "NTSC-J"
@@ -31247,7 +31854,7 @@ SLPM-61092:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     autoFlush: 1 # Aligns and corrects shadows.
-    roundSprite: 1 # Fixes depth line.
+    halfPixelOffset: 2 # Fixes sun and depth line.
     cpuCLUTRender: 1 # Fixes janky coloured cars.
     gpuTargetCLUT: 1 # Fixes janky coloured cars.
     textureInsideRT: 1 # Fixes car textures.
@@ -31302,7 +31909,8 @@ SLPM-61109:
   name: "Shadow of Rome [Trial]"
   region: "NTSC-J"
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes blurriness and misaligned garbage when upscaling.
+    halfPixelOffset: 4 # Fixes post positioning.
+    nativeScaling: 2 # Fixes post effects.
 SLPM-61110:
   name: "Enthusia - Professional Racing [Trial]"
   region: "NTSC-J"
@@ -31327,7 +31935,8 @@ SLPM-61114:
   name: "Shadow of Rome [Trial]"
   region: "NTSC-J"
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes blurriness and misaligned garbage when upscaling.
+    halfPixelOffset: 4 # Fixes post positioning.
+    nativeScaling: 2 # Fixes post effects.
 SLPM-61115:
   name: "Racing Battle - C1 Grand Prix [Trial]"
   region: "NTSC-J"
@@ -31381,10 +31990,14 @@ SLPM-61123:
   gameFixes:
     - OPHFlagHack
   gsHWFixes:
-    mergeSprite: 1 # Reduces bloom but fixes blurriness around models + Recommended to use Shadeboost brightness 80.
+    halfPixelOffset: 2 # Aligns post effects.
+    nativeScaling: 2 # Fixes post effects.
 SLPM-61124:
   name: "Ookami - Fude-hajime no Maki"
   region: "NTSC-J"
+  gsHWFixes:
+    halfPixelOffset: 4 # Aligns post effects.
+    nativeScaling: 2 # Fixes post effects.
 SLPM-61125:
   name: "Tokyo Game Show Bandai Namco Booth Distribution Disc 2005"
   region: "NTSC-J"
@@ -31444,11 +32057,16 @@ SLPM-61135:
     vuClampMode: 2 # Fixes invisible QTE button prompts and overbright in some scenes.
   gameFixes:
     - SoftwareRendererFMVHack # Fixes vertical lines in FMVs.
+  gsHWFixes:
+    halfPixelOffset: 2 # Aligns post effects.
+    nativeScaling: 2 # Fixes post effects.
 SLPM-61137:
   name: "Sega Rally 2006"
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves car reflections.
+    halfPixelOffset: 4 # Correct shadow position.
+    nativeScaling: 2 # Smooths shadows.
 SLPM-61138:
   name: "Akumajou Dracula - Yami no Juin"
   region: "NTSC-J"
@@ -31468,6 +32086,9 @@ SLPM-61141:
 SLPM-61142:
   name: "Shin Onimusha - Dawn of Dreams / Ookami"
   region: "NTSC-J"
+  gsHWFixes:
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 2 # Fixes post processing smoothness and position.
 SLPM-61144:
   name: "Ninkyouden - Toseinin Ichidaiki"
   region: "NTSC-J"
@@ -31478,10 +32099,10 @@ SLPM-61147:
   name: "Xenosaga Episode III - Also Sprach Zarathustra [Demo]"
   region: "NTSC-J"
   gsHWFixes:
-    autoFlush: 2 # Fixes shadows in cutscenes.
-    halfPixelOffset: 2 # Fixes lighting misalignment and reduces ground shadows (probably texture cache issue).
-    roundSprite: 2 # Fixes font artifacts.
+    autoFlush: 1 # Fixes shadows.
     textureInsideRT: 1 # Fixes bad crystal surfaces.
+    halfPixelOffset: 4 # Fixes lighting misalignment.
+    nativeScaling: 2 # Fixes lighting smoothness.
 SLPM-61148:
   name: "Growlanser V - Generations [Trial]"
   region: "NTSC-J"
@@ -31512,6 +32133,8 @@ SLPM-61155:
     textureInsideRT: 1 # Needed for post processing effects.
     autoFlush: 1 # Fixes bloom intensity.
     minimumBlendingLevel: 4 # Fixes multiple lighting effects from lights, computers, cave walls and more.
+    nativeScaling: 1 # Fixes post processing.
+    halfPixelOffset: 4 # Fixes offset post processing.
 SLPM-61156:
   name: "Dengeki PS2 PlayStation D93"
   region: "NTSC-J"
@@ -31521,8 +32144,8 @@ SLPM-61157:
   gameFixes:
     - SoftwareRendererFMVHack # Fixes vertical lines in FMVs.
   gsHWFixes:
-    roundSprite: 2 # Corrects post processing position + fixes subsequent runs of starter FMV vertical lines.
-    cpuCLUTRender: 1 # Reduces the bloomy blur of characters.
+    halfPixelOffset: 2 # Aligns post effects.
+    nativeScaling: 2 # Fixes post effects.
   clampModes:
     vu0ClampMode: 3 # Fixes bad dialog backgrounds.
     vu1ClampMode: 3 # Fixes SPS on characters.
@@ -33054,6 +33677,8 @@ SLPM-62344:
   name-sort: しんぷる2000しりーずVol.31 THEちきゅうぼうえいぐん
   name-en: "Simple 2000 Series Vol. 31 - The Chikyuu Boueigun"
   region: "NTSC-J"
+  gsHWFixes:
+    halfPixelOffset: 4 # Fixes depth of field positioning.
 SLPM-62345:
   name: SIMPLE2000シリーズVol.32 THE戦車
   name-sort: しんぷる2000しりーずVol.32 THEせんしゃ
@@ -34586,8 +35211,8 @@ SLPM-62652:
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
-    roundSprite: 1 # Fixes HUD artifacts.
-    forceEvenSpritePosition: 1 # Lessens the bloom misalignment but still an issue.
+    halfPixelOffset: 4 # Fixes depth of field positioning.
+    nativeScaling: 1 # Fixes post processing effects due to upscaling.
 SLPM-62653:
   name: "Psikyo Shooting Collection Vol.1 - Strikers 1945 1-2 [Taito The Best]"
   region: "NTSC-J"
@@ -34950,6 +35575,9 @@ SLPM-62737:
   name-sort: らりーしょっくす&ふりーくすたいる もとくろす [EA BEST HITS]
   name-en: "Rally Shox & Freestyle Motorcross [EA Best Hits]"
   region: "NTSC-J"
+  gsHWFixes:
+    halfPixelOffset: 4 # Aligns UI in Rally Shox.
+    nativeScaling: 2 # Fixes window reflections in Rally Shox.
 SLPM-62738:
   name: "Freekstyle Motocross"
   region: "NTSC-J"
@@ -35219,6 +35847,9 @@ SLPM-64523:
 SLPM-64524:
   name: "Rally Shox"
   region: "NTSC-K"
+  gsHWFixes:
+    halfPixelOffset: 4 # Aligns UI.
+    nativeScaling: 2 # Fixes window reflections.
 SLPM-64525:
   name: "Guilty Gear X Plus 'By Your Side'"
   region: "NTSC-K"
@@ -35863,11 +36494,19 @@ SLPM-65100:
   name-sort: おにむしゃ2 [しょかいせいさんげんていばん]
   name-en: "Onimusha 2"
   region: "NTSC-J"
+  gsHWFixes:
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 2 # Fixes post processing smoothness and position.
+    roundSprite: 2 # Fixes text.
 SLPM-65101:
   name: 鬼武者2
   name-sort: おにむしゃ2
   name-en: "Onimusha 2"
   region: "NTSC-J"
+  gsHWFixes:
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 2 # Fixes post processing smoothness and position.
+    roundSprite: 2 # Fixes text.
   memcardFilters:
     - "SLPM-65100"
 SLPM-65104:
@@ -36371,7 +37010,8 @@ SLPM-65209:
   gameFixes:
     - VuAddSubHack
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes bloom and ghosting in certain areas.
+    halfPixelOffset: 4 # Fix effects upscaling.
+    nativeScaling: 2 # Fixes post effects.
     roundSprite: 1 # Fixes door transition vertical lines and mini-map artifacts.
     textureInsideRT: 1 # Fixes missing battle effects.
   patches:
@@ -36619,11 +37259,10 @@ SLPM-65245:
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 1 # Fixes character offset with flashlight and blurriness.
-    alignSprite: 1 # Fixes vertical lines.
+    halfPixelOffset: 4 # Fixes character offset with flashlight and blurriness.
     roundSprite: 2 # Fixes font artifacts.
-    mergeSprite: 1 # Fixes flame-like bleeding.
     autoFlush: 1 # Fixes light bloom intensity.
+    nativeScaling: 2 # Fixes post processing.
 SLPM-65246:
   name: 街道バトル 〜日光・榛名・六甲・箱根〜
   name-sort: かいどうばとる にっこう はるな ろっこう はこね
@@ -36852,7 +37491,8 @@ SLPM-65284:
   gameFixes:
     - XGKickHack # Fixes SPS.
   gsHWFixes:
-    halfPixelOffset: 1 # Fixes texture misalignment.
+    halfPixelOffset: 2 # Aligns Depth of Field.
+    nativeScaling: 2 # Fixes Depth of Field effect.
 SLPM-65285:
   name: ラブひな ごーじゃす 〜チラっとハプニング!!〜 初回限定版
   name-sort: らぶひな ごーじゃす 〜ちらっとはぷにんぐ!!〜 しょかいげんていばん
@@ -37530,8 +38170,8 @@ SLPM-65413:
     - "SLPM-65411"
     - "SLPM-65413"
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes ghosting.
-    roundSprite: 2 # Fixes various lines / reduces bars on right edge.
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 2 # Fixes post processing smoothness and position.
     disablePartialInvalidation: 1 # Fixes textureless graphics ingame.
     bilinearUpscale: 2 # Gets rid of center vertical line when upscaling.
 SLPM-65414:
@@ -37579,6 +38219,10 @@ SLPM-65422:
   name-sort: とむくらんしーしりーず すぷりんたーせる
   name-en: "Tom Clancy's Splinter Cell"
   region: "NTSC-J"
+  gsHWFixes:
+    halfPixelOffset: 4 # Aligns post processing.
+    nativeScaling: 2 # Fixes post effects.
+    recommendedBlendingLevel: 4 # Fixes lighting effects but has high barrier count.
 SLPM-65423:
   name: 三國志IX
   name-sort: さんごくし9
@@ -37660,7 +38304,8 @@ SLPM-65438:
   gameFixes:
     - VuAddSubHack # Fixes ELF decryption.
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes bloom and ghosting in certain areas.
+    halfPixelOffset: 4 # Fix effects upscaling.
+    nativeScaling: 2 # Fixes post effects.
     roundSprite: 1 # Fixes door transition vertical lines and mini-map artifacts.
     textureInsideRT: 1 # Fixes missing battle effects.
 SLPM-65439:
@@ -37672,7 +38317,8 @@ SLPM-65439:
   gameFixes:
     - VuAddSubHack # Fixes ELF decryption.
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes bloom and ghosting in certain areas.
+    halfPixelOffset: 4 # Fix effects upscaling.
+    nativeScaling: 2 # Fixes post effects.
     roundSprite: 1 # Fixes door transition vertical lines and mini-map artifacts.
     textureInsideRT: 1 # Fixes missing battle effects.
   memcardFilters:
@@ -38369,7 +39015,8 @@ SLPM-65573:
   gameFixes:
     - XGKickHack # Fixes SPS.
   gsHWFixes:
-    halfPixelOffset: 1 # Fixes texture misalignment.
+    halfPixelOffset: 2 # Aligns Depth of Field.
+    nativeScaling: 2 # Fixes Depth of Field effect.
 SLPM-65574:
   name: サイレントヒル4 THE ROOM
   name-sort: さいれんとひる4 THE ROOM
@@ -38387,8 +39034,8 @@ SLPM-65575:
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
-    forceEvenSpritePosition: 1 # Fixes blurriness.
-    roundSprite: 2 # Reduces misalignment bloom effects.
+    halfPixelOffset: 1 # Aligns post effects.
+    nativeScaling: 2 # Fixes post effects.
 #    deinterlace: 6 # Game requires blend tff de-interlacing when auto for 'fixing' shimmer on character models and more flickering or half weaved, though the game suffers from the field order.
 SLPM-65576:
   name: 探偵 神宮寺三郎 KIND OF BLUE
@@ -38428,8 +39075,10 @@ SLPM-65583:
   gameFixes:
     - XGKickHack # Fixes SPS.
   gsHWFixes:
-    roundSprite: 2 # Correct misaligned font, better aligns car shadow.
+    roundSprite: 1 # Correct misaligned font, better aligns car shadow.
     autoFlush: 2 # Fixes sun luminosity.
+    halfPixelOffset: 2 # Aligns Depth of Field.
+    nativeScaling: 2 # Fixes Depth of Field effect.
 SLPM-65584:
   name: "Shin Sangoku Musou 3 - Moushouden"
   region: "NTSC-J"
@@ -38978,6 +39627,8 @@ SLPM-65687:
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves reflections on certain characters and objects on certain levels.
+    halfPixelOffset: 4 # Corrects post processing positioning.
+    nativeScaling: 2 # Smooths post processing.
 SLPM-65688:
   name: ベルセルク 千年帝国の鷹篇 聖魔戦記の章 通常版
   name-sort: べるせるく みれにあむ・ふぁるこんへん せいませんきのしょう
@@ -39152,6 +39803,7 @@ SLPM-65719:
     autoFlush: 2 # Fixes blur and obscures sun behind objects.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     bilinearUpscale: 2 # Smooths out sun glare textures like native.
+    nativeScaling: 2 # Smooths speed blur and corrects some lighting.
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
 SLPM-65720:
@@ -39289,7 +39941,7 @@ SLPM-65741:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     autoFlush: 1 # Aligns and corrects shadows.
-    roundSprite: 1 # Fixes depth line.
+    halfPixelOffset: 2 # Fixes sun and depth line.
     cpuCLUTRender: 1 # Fixes janky coloured cars.
     gpuTargetCLUT: 1 # Fixes janky coloured cars.
     textureInsideRT: 1 # Fixes car textures.
@@ -39407,8 +40059,9 @@ SLPM-65759:
   name-en: "Mr. Incredible"
   region: "NTSC-J"
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes bloom misalignment when upscaling.
-    cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling.
+    recommendedBlendingLevel: 3 # Fixes building shade and shadows.
+    halfPixelOffset: 4 # Aligns post effects.
+    nativeScaling: 2 # Fixes post effects.
 SLPM-65760:
   name: Grand Theft Auto III カプコレ
   name-sort: Grand Theft Auto III かぷこれ
@@ -39554,7 +40207,8 @@ SLPM-65789:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
-    halfPixelOffset: 2 # Fixes blurriness.
+    halfPixelOffset: 4 # Aligns depth of field effect.
+    nativeScaling: 2 # Fixes post lighting.
     autoFlush: 2 # Fixes lens flare.
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
 SLPM-65790:
@@ -39566,7 +40220,8 @@ SLPM-65790:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
-    halfPixelOffset: 2 # Fixes blurriness.
+    halfPixelOffset: 4 # Aligns depth of field effect.
+    nativeScaling: 2 # Fixes post lighting.
     autoFlush: 2 # Fixes lens flare.
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
 SLPM-65791:
@@ -39655,6 +40310,9 @@ SLPM-65802:
   name-sort: DEF JAM VENDETTA [EA BEST HITS]
   name-en: "Def Jam - Vendetta [EA Best Hits]"
   region: "NTSC-J"
+  gsHWFixes:
+    halfPixelOffset: 4 # Reduces post misalignment.
+    nativeScaling: 2 # Fixes remaining post misalignment.
 SLPM-65803:
   name: EA BEST HITS フリーダム・ファイターズ
   name-sort: ふりーだむ・ふぁいたーず [EA BEST HITS]
@@ -39892,7 +40550,8 @@ SLPM-65846:
   name-en: "Lord of the Rings, The - The Third Age"
   region: "NTSC-J"
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes ghosting.
+    halfPixelOffset: 4 # Aligns post processing.
+    nativeScaling: 2 # Corrects post processing smoothness.
 SLPM-65847:
   name: 空色の風琴 〜Remix〜 初回限定版
   name-sort: そらいろのおるがん Remix しょかいげんていばん
@@ -40060,8 +40719,8 @@ SLPM-65880:
   roundModes:
     eeRoundMode: 0 # Fixes inability to enter door in Mission 18.
   gsHWFixes:
-    halfPixelOffset: 2 # Reduces ghosting but still an issue compared to native.
-    roundSprite: 2 # Clears up much of the blurring that HPO Special does not.
+    halfPixelOffset: 4 # Aligns post effects.
+    nativeScaling: 2 # Fixes post processing and lighting smoothness and position.
 SLPM-65881:
   name: エキサイティングプロレス6 SMACKDOWN! Vs RAW
   name-sort: えきさいてぃんぐぷろれす6 SMACKDOWN! Vs RAW
@@ -40078,7 +40737,8 @@ SLPM-65883:
   name-en: "Shadow of Rome"
   region: "NTSC-J"
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes blurriness and misaligned garbage when upscaling.
+    halfPixelOffset: 4 # Fixes post positioning.
+    nativeScaling: 2 # Fixes post effects.
 SLPM-65884:
   name: リモートコントロールダンディSF
   name-sort: りもーとこんとろーるだんでぃSF
@@ -40208,6 +40868,9 @@ SLPM-65907:
   name-sort: DEF JAM FIGHT FOR NY
   name-en: "Def Jam Fight for NY"
   region: "NTSC-J"
+  gsHWFixes:
+    halfPixelOffset: 4 # Reduces post misalignment.
+    nativeScaling: 2 # Fixes remaining post misalignment.
 SLPM-65908:
   name: シャイニング・フォース ネオ
   name-sort: しゃいにんぐ・ふぉーす ねお
@@ -40403,6 +41066,7 @@ SLPM-65942:
   region: "NTSC-J"
   gsHWFixes:
     autoFlush: 2 # Fixes missing lighting.
+    nativeScaling: 1 # Fixes post lighting.
     # halfPixelOffset: 1 # Fixes lighting misalignment. Do not enable this, it breaks a lot of graphics.
 SLPM-65943:
   name: Angel’s Feather −黒の残影−
@@ -40499,6 +41163,7 @@ SLPM-65958:
     autoFlush: 2 # Fixes blur and obscures sun behind objects.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     bilinearUpscale: 2 # Smooths out sun glare textures like native.
+    nativeScaling: 2 # Smooths speed blur and corrects some lighting.
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
 SLPM-65959:
@@ -40603,7 +41268,8 @@ SLPM-65975:
   gsHWFixes:
     autoFlush: 2 # Fixes sun luminosity and car shadows.
     roundSprite: 1 # Fixes misaligned text.
-    halfPixelOffset: 2 # Fixes minor ghosting on objects.
+    halfPixelOffset: 2 # Aligns Depth of Field.
+    nativeScaling: 2 # Fixes Depth of Field effect.
   roundModes:
     eeRoundMode: 2 # Fixes rainbow highlighting on cars.
 SLPM-65976:
@@ -40755,6 +41421,8 @@ SLPM-66002:
   region: "NTSC-J"
   gsHWFixes:
     autoFlush: 2 # Reduces post-processing misalignment.
+    halfPixelOffset: 4 # Fixes post positioning.
+    nativeScaling: 2 # Fixes post effects.
 SLPM-66003:
   name: "Harukanaru Toki no Naka de - Hachiyou-shou"
   region: "NTSC-J"
@@ -41070,7 +41738,8 @@ SLPM-66059:
   name-en: "Robots"
   region: "NTSC-J"
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes misaligned bloom.
+    halfPixelOffset: 4 # Fixes post bloom positioning.
+    nativeScaling: 2 # Fixes bloom effects.
 SLPM-66060:
   name: 亡国のイージス2035 〜ウォーシップガンナー〜
   name-sort: ぼうこくのいーじす2035 うぉーしっぷがんなー
@@ -41335,6 +42004,8 @@ SLPM-66103:
   gsHWFixes:
     roundSprite: 2 # Correct misaligned font, better aligns car shadow.
     autoFlush: 2 # Fixes sun luminosity.
+    halfPixelOffset: 2 # Aligns Depth of Field.
+    nativeScaling: 2 # Fixes Depth of Field effect.
 SLPM-66104:
   name: ぷよぷよフィーバー2 [チュー!]
   name-sort: ぷよぷよふぃーばー2
@@ -41373,6 +42044,7 @@ SLPM-66108:
     autoFlush: 2 # Fixes blur and obscures sun behind objects.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     bilinearUpscale: 2 # Smooths out sun glare textures like native.
+    nativeScaling: 2 # Smooths speed blur and corrects some lighting.
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
   memcardFilters:
@@ -41436,7 +42108,8 @@ SLPM-66117:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
-    halfPixelOffset: 2 # Fixes blurriness.
+    halfPixelOffset: 4 # Aligns depth of field effect.
+    nativeScaling: 2 # Fixes post lighting.
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
 SLPM-66118:
   name: METAL GEAR SOLID 3 SUBSISTENCE [ヘッドセット同梱版] [ディスク2/3]
@@ -41449,7 +42122,8 @@ SLPM-66118:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
-    halfPixelOffset: 2 # Fixes blurriness.
+    halfPixelOffset: 4 # Aligns depth of field effect.
+    nativeScaling: 2 # Fixes post lighting.
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
 SLPM-66119:
   name: METAL GEAR SOLID 3 SUBSISTENCE [ヘッドセット同梱版] [ディスク2/3]
@@ -41462,7 +42136,8 @@ SLPM-66119:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
-    halfPixelOffset: 2 # Fixes blurriness.
+    halfPixelOffset: 4 # Aligns depth of field effect.
+    nativeScaling: 2 # Fixes post lighting.
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
 SLPM-66121:
   name: "Spider-Man 2 [Taito Best]"
@@ -41539,9 +42214,8 @@ SLPM-66132:
   name-en: "Gladiator - Road to Freedom - Remix"
   region: "NTSC-J"
   gsHWFixes:
-    halfPixelOffset: 3 # Fixes bloom misalignment still a bit misaligned.
-    roundSprite: 1 # Fixes bloom misalignment still a bit misaligned.
-    cpuCLUTRender: 1 # Fixes sun background on the windows when selecting your 'race'.
+    halfPixelOffset: 4 # Aligns post effects.
+    nativeScaling: 1 # Fixes post effects.
 SLPM-66133:
   name: "Shuffle! On the Stage [Deluxe Pack]"
   region: "NTSC-J"
@@ -41637,6 +42311,8 @@ SLPM-66148:
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves reflections on certain characters and objects on certain levels.
+    halfPixelOffset: 4 # Corrects post processing positioning.
+    nativeScaling: 2 # Smooths post processing.
 SLPM-66149:
   name: しろがねの鳥籠 限定版
   name-sort: しろがねのとりかご [げんていばん]
@@ -41655,7 +42331,8 @@ SLPM-66151:
   clampModes:
     vuClampMode: 0 # Resolves I Reg Clamping / performance impact and yellow graphics in certain areas.
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes blurriness.
+    halfPixelOffset: 4 # Fixes post positioning.
+    nativeScaling: 2 # Fixes post effects.
 SLPM-66152:
   name: こんねこ 〜Keep a memory green〜 初回限定版
   name-sort: こんねこ 〜Keep a memory green〜 しょかいげんていばん
@@ -41702,8 +42379,8 @@ SLPM-66160:
   roundModes:
     eeRoundMode: 0 # Fixes inability to enter door in Mission 18.
   gsHWFixes:
-    halfPixelOffset: 2 # Reduces ghosting but still an issue compared to native.
-    roundSprite: 2 # Clears up much of the blurring that HPO Special does not.
+    halfPixelOffset: 4 # Aligns post effects.
+    nativeScaling: 2 # Fixes post processing and lighting smoothness and position.
 SLPM-66161:
   name: "Kokoro no Tobira"
   region: "NTSC-J"
@@ -41737,7 +42414,8 @@ SLPM-66166:
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 4 # Improves smoke rendering.
-    halfPixelOffset: 2 # Fixes misaligned lighting.
+    halfPixelOffset: 4 # Fixes post positioning.
+    nativeScaling: 2 # Fixes post effects.
 SLPM-66167:
   name: "God of War"
   region: "NTSC-J"
@@ -41806,6 +42484,7 @@ SLPM-66177:
   gsHWFixes:
     halfPixelOffset: 2 # Fix effects upscaling.
     autoFlush: 1 # Fixes broken post processing.
+    nativeScaling: 2 # Fixes post effects.
 SLPM-66178:
   name: ポップンミュージック 7 [コナミ・ザ・ベスト]
   name-sort: ぽっぷんみゅーじっく 7 [こなみ・ざ・べすと]
@@ -41897,7 +42576,8 @@ SLPM-66190:
   name-en: "Star Wars - Battlefront II"
   region: "NTSC-J"
   gsHWFixes:
-    halfPixelOffset: 1 # Fixes bloom misalignment.
+    halfPixelOffset: 4 # Corrects post processing positioning.
+    nativeScaling: 2 # Smooths post processing.
     autoFlush: 1 # Fixes missing lights.
 SLPM-66191:
   name: タイガー・ウッズ PGA TOUR 06
@@ -41917,7 +42597,8 @@ SLPM-66193:
   name-en: "Fahrenheit"
   region: "NTSC-J"
   gsHWFixes:
-    halfPixelOffset: 1 # Slight lighting misalignment.
+    halfPixelOffset: 4 # Aligns post processing.
+    nativeScaling: 2 # Fixes post processing position.
 SLPM-66194:
   name: おとなのギャル雀2 〜恋して倍満!〜
   name-sort: おとなのぎゃるじゃん2 〜こいしてばいまん!〜
@@ -42020,6 +42701,8 @@ SLPM-66212:
   compat: 5
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves car reflections.
+    halfPixelOffset: 4 # Correct shadow position.
+    nativeScaling: 2 # Smooths shadows.
 SLPM-66213:
   name: バイオハザード4
   name-sort: ばいおはざーど4
@@ -42066,7 +42749,8 @@ SLPM-66220:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
-    halfPixelOffset: 2 # Fixes blurriness.
+    halfPixelOffset: 4 # Aligns depth of field effect.
+    nativeScaling: 2 # Fixes post lighting.
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
   memcardFilters:
     - "SLPM-66117"
@@ -42081,7 +42765,8 @@ SLPM-66221:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
-    halfPixelOffset: 2 # Fixes blurriness.
+    halfPixelOffset: 4 # Aligns depth of field effect.
+    nativeScaling: 2 # Fixes post lighting.
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
   memcardFilters:
     - "SLPM-66117"
@@ -42096,7 +42781,8 @@ SLPM-66222:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
-    halfPixelOffset: 2 # Fixes blurriness.
+    halfPixelOffset: 4 # Aligns depth of field effect.
+    nativeScaling: 2 # Fixes post lighting.
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
   memcardFilters:
     - "SLPM-66117"
@@ -42111,7 +42797,8 @@ SLPM-66223:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
-    halfPixelOffset: 2 # Fixes blurriness.
+    halfPixelOffset: 4 # Aligns depth of field effect.
+    nativeScaling: 2 # Fixes post lighting.
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
   memcardFilters:
     - "SLPM-66117"
@@ -42126,7 +42813,8 @@ SLPM-66224:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
-    halfPixelOffset: 2 # Fixes blurriness.
+    halfPixelOffset: 4 # Aligns depth of field effect.
+    nativeScaling: 2 # Fixes post lighting.
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
   memcardFilters:
     - "SLPM-66117"
@@ -42186,7 +42874,8 @@ SLPM-66233:
   gsHWFixes:
     autoFlush: 1 # Fixes effects.
     roundSprite: 1 # Fixes upscaling artifacts.
-    halfPixelOffset: 4 # Fixes upscaling artifacts.
+    halfPixelOffset: 2 # Fixes post bloom positioning.
+    nativeScaling: 2 # Fixes lighting effects due to upscaling.
 SLPM-66234:
   name: ウィザードリィ エクス 〜前線の学府〜 ワンダープライス
   name-sort: うぃざーどりぃ えくす ぜんせんのがくふ [わんだーぷらいす]
@@ -42269,8 +42958,8 @@ SLPM-66248:
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes building shade and shadows.
-    halfPixelOffset: 2 # Fixes bloom misalignment when upscaling.
-    cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling.
+    halfPixelOffset: 4 # Aligns post effects.
+    nativeScaling: 2 # Fixes post effects.
 SLPM-66249:
   name: グローランサーV ジェネレーションズ 初回限定生産版
   name-sort: ぐろーらんさーV じぇねれーしょんず しょかいげんていせいさんばん
@@ -42429,7 +43118,8 @@ SLPM-66275:
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes misalignment and upscaling lines.
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 2 # Fixes post processing smoothness and position.
 SLPM-66276:
   name: 新 鬼武者 DAWN OF DREAMS [ディスク2/2]
   name-sort: しん おにむしゃ DAWN OF DREAMS [でぃすく2/2]
@@ -42437,7 +43127,8 @@ SLPM-66276:
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes misalignment and upscaling lines.
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 2 # Fixes post processing smoothness and position.
   memcardFilters:
     - "SLPM-66275"
 SLPM-66277:
@@ -42745,7 +43436,8 @@ SLPM-66327:
   name-en: "Wallace & Gromit - The Curse of the Were-Rabbit"
   region: "NTSC-J"
   gsHWFixes:
-    halfPixelOffset: 1 # Fixes misalignment/bloom when upscaling.
+    halfPixelOffset: 4 # Fixes post alignment.
+    nativeScaling: 1 # Fixes post effect.
 SLPM-66328:
   name: Call of Duty 2 Big Red One
   name-sort: Call of Duty 2 Big Red One
@@ -42805,7 +43497,8 @@ SLPM-66334:
   gsHWFixes:
     autoFlush: 2 # Fixes sun luminosity and car shadows.
     roundSprite: 1 # Fixes misaligned text.
-    halfPixelOffset: 2 # Fixes minor ghosting on objects.
+    halfPixelOffset: 2 # Aligns Depth of Field.
+    nativeScaling: 2 # Fixes Depth of Field effect.
   roundModes:
     eeRoundMode: 2 # Fixes rainbow highlighting on cars.
 SLPM-66335:
@@ -42905,6 +43598,8 @@ SLPM-66354:
     recommendedBlendingLevel: 4 # Improves lighting on buildings and objects.
     autoFlush: 2 # Properly diffuses light instead of strips of light.
     roundSprite: 1 # Fixes lighting misalignment such as the street poles and the sun.
+    halfPixelOffset: 2 # Mostly aligns post processing.
+    nativeScaling: 2 # Improves post processing smoothness.
     getSkipCount: "GSC_BlackAndBurnoutSky"
     beforeDraw: "OI_BurnoutGames"
   patches:
@@ -43004,7 +43699,8 @@ SLPM-66375:
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
-    roundSprite: 2 # Reduces misalignment issues but the game is just bad for upscaling.
+    halfPixelOffset: 4 # Aligns post effects.
+    nativeScaling: 2 # Fixes post effects.
 SLPM-66376:
   name: きみスタ〜きみとスタディ〜BGMコレクションパッケージ
   name-sort: きみすた きみとすたでぃ BGMこれくしょんぱっけーじ
@@ -43089,7 +43785,8 @@ SLPM-66391:
   region: "NTSC-J"
   gsHWFixes:
     autoFlush: 1 # Reduces post-processing misalignment.
-    halfPixelOffset: 4 # Reduces post-processing misalignment.
+    halfPixelOffset: 4 # Fixes post positioning.
+    nativeScaling: 2 # Fixes post effects.
 SLPM-66393:
   name: ファイナルファンタジーXI オールインワンパック2006 [プレイオンライン]
   name-sort: ふぁいなるふぁんたじー11 おーるいんわんぱっく2006 [ぷれいおんらいん]
@@ -43246,10 +43943,10 @@ SLPM-66419:
   gameFixes:
     - VuAddSubHack
   gsHWFixes:
-    halfPixelOffset: 2 # Reduces bloom misalignment.
-    roundSprite: 1 # Fixes area transition vertical lines and lessens red forest vertical lines.
+    halfPixelOffset: 4 # Reduces bloom misalignment.
     textureInsideRT: 1 # Required for swirl battle transition.
     nativePaletteDraw: 1
+    nativeScaling: 2 # Fixes depth of field effects and bloom.
 SLPM-66420:
   name: フロントミッション4 [アルティメットヒッツ]
   name-sort: ふろんとみっしょん4 [あるてぃめっとひっつ]
@@ -43302,10 +43999,9 @@ SLPM-66430:
   region: "NTSC-J"
   gsHWFixes:
     textureInsideRT: 1 # Fixes shadow maps.
-    roundSprite: 2 # Fixes misaligned bloom.
-    mergeSprite: 1 # Fixes misaligned bloom.
     halfPixelOffset: 2 # Fixes misaligned bloom.
     autoFlush: 2 # Fixes sun occlusion and brightness.
+    nativeScaling: 2 # Fixes post processing and lighting smoothness and position.
 SLPM-66431:
   name: WINBACK 2 Project Poseidon
   name-sort: WINBACK 2 Project Poseidon
@@ -43539,6 +44235,9 @@ SLPM-66463:
   name-sort: でふじゃむ・ふぁいと・ふぉー・NY [EA BEST HITS]
   name-en: "Def Jam - Fight for NY [EA Best Hits]"
   region: "NTSC-J"
+  gsHWFixes:
+    halfPixelOffset: 4 # Reduces post misalignment.
+    nativeScaling: 2 # Fixes remaining post misalignment.
 SLPM-66464:
   name: EA BEST HITS MVP ベースボール2005
   name-sort: MVP べーすぼーる2005 [EA BEST HITS]
@@ -43551,6 +44250,7 @@ SLPM-66465:
   region: "NTSC-J"
   gsHWFixes:
     autoFlush: 2 # Fixes missing lighting.
+    nativeScaling: 1 # Fixes post lighting.
     # halfPixelOffset: 1 # Fixes lighting misalignment. Do not enable this, it breaks a lot of graphics.
 SLPM-66467:
   name: ゲーセンUSA ミッドウェイアーケードトレジャーズ
@@ -43564,6 +44264,7 @@ SLPM-66468:
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misaligned lighting and other effects, needs Special otherwise lights flicker.
+    nativeScaling: 2 # Fixes lights.
 SLPM-66469:
   name: 「ラブ★コン 〜パンチDEコント〜」限定版
   name-sort: らぶこん ぱんちでこんと [げんていばん]
@@ -43599,6 +44300,8 @@ SLPM-66473:
     preloadFrameData: 1 # Fixes numberplates and ensures above targets are valid.
     roundSprite: 1 # Fixes lines in some post-effects.
     gpuTargetCLUT: 1 # Fixes light occlusion.
+    halfPixelOffset: 4 # Reduces post misalignment.
+    nativeScaling: 2 # Fixes remaining post misalignment and light bloom and shadows.
 SLPM-66474:
   name: オーディンスフィア
   name-sort: おーでぃんすふぃあ
@@ -43629,7 +44332,8 @@ SLPM-66478:
   gameFixes:
     - VuAddSubHack
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes bloom and ghosting in certain areas.
+    halfPixelOffset: 4 # Fix effects upscaling.
+    nativeScaling: 2 # Fixes post effects.
     roundSprite: 1 # Fixes door transition vertical lines and mini-map artifacts.
     textureInsideRT: 1 # Fixes missing battle effects.
 SLPM-66479:
@@ -43641,7 +44345,8 @@ SLPM-66479:
   gameFixes:
     - VuAddSubHack
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes bloom and ghosting in certain areas.
+    halfPixelOffset: 4 # Fix effects upscaling.
+    nativeScaling: 2 # Fixes post effects.
     roundSprite: 1 # Fixes door transition vertical lines and mini-map artifacts.
     textureInsideRT: 1 # Fixes missing battle effects.
   memcardFilters:
@@ -43806,6 +44511,10 @@ SLPM-66504:
   name-sort: おにむしゃ2 MEGA HITS!
   name-en: "Onimusha 2 [Mega Hits]"
   region: "NTSC-J"
+  gsHWFixes:
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 2 # Fixes post processing smoothness and position.
+    roundSprite: 2 # Fixes text.
 SLPM-66505:
   name: 真・三國無双2 MEGA HITS!
   name-sort: しんさんごくむそう2 MEGA HITS!
@@ -44077,6 +44786,8 @@ SLPM-66558:
     textureInsideRT: 1 # Needed for post processing effects.
     autoFlush: 1 # Fixes bloom intensity.
     minimumBlendingLevel: 4 # Fixes multiple lighting effects from lights, computers, cave walls and more.
+    nativeScaling: 1 # Fixes post processing.
+    halfPixelOffset: 4 # Fixes offset post processing.
 SLPM-66559:
   name: コーエー定番シリーズ Winning Post6
   name-sort: Winning Post6 [こーえーていばんしりーず]
@@ -44182,7 +44893,8 @@ SLPM-66572:
   name-en: "LEGO Star Wars II - The Original Trilogy"
   region: "NTSC-J"
   gsHWFixes:
-    cpuCLUTRender: 1 # Fixes ghosting on objects and people.
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 1 # Fixes post processing smoothness and position.
   memcardFilters:
     - "SLPM-66572"
     - "SLPS-20423"
@@ -44213,9 +44925,8 @@ SLPM-66577:
   name-en: "Gladiator - Road to Freedom [Special Remix] [Ertain the Best]"
   region: "NTSC-J"
   gsHWFixes:
-    halfPixelOffset: 3 # Fixes bloom misalignment still a bit misaligned.
-    roundSprite: 1 # Fixes bloom misalignment still a bit misaligned.
-    cpuCLUTRender: 1 # Fixes sun background on the windows when selecting your 'race'.
+    halfPixelOffset: 4 # Aligns post effects.
+    nativeScaling: 1 # Fixes post effects.
 SLPM-66578:
   name: "真・三國無双3 Empires(真・三國無双シリーズコレクション 下巻 同梱用)"
   name-sort: しんさんごくむそう3 えんぱいあーず [しんさんごくむそうしりーずこれくしょん げかん どうこんよう]
@@ -44613,7 +45324,8 @@ SLPM-66645:
   name-en: "Bionicle Heroes"
   region: "NTSC-J"
   gsHWFixes:
-    cpuCLUTRender: 1 # Fixes ghosting on objects and people.
+    halfPixelOffset: 2 # Aligns post effects.
+    nativeScaling: 2 # Fixes post processing and position.
 SLPM-66646:
   name: シャイニング・フォース イクサ
   name-sort: しゃいにんぐ・ふぉーす いくさ
@@ -44650,6 +45362,7 @@ SLPM-66652:
     autoFlush: 2 # Fixes blur and obscures sun behind objects.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     bilinearUpscale: 2 # Smooths out sun glare textures like native.
+    nativeScaling: 2 # Smooths speed blur and corrects some lighting.
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
   memcardFilters:
@@ -44778,6 +45491,8 @@ SLPM-66673:
   region: "NTSC-J"
   gsHWFixes:
     autoFlush: 2 # Reduces post-processing misalignment.
+    halfPixelOffset: 4 # Fixes post positioning.
+    nativeScaling: 2 # Fixes post effects.
 SLPM-66674:
   name: タイガー・ウッズ PGA TOUR(R)07
   name-sort: たいがー・うっず PGA TOUR(R)07
@@ -44793,7 +45508,8 @@ SLPM-66675:
   gsHWFixes:
     autoFlush: 1 # Fixes effects.
     roundSprite: 1 # Fixes upscaling artifacts.
-    halfPixelOffset: 4 # Fixes upscaling artifacts.
+    halfPixelOffset: 2 # Fixes post bloom positioning.
+    nativeScaling: 2 # Fixes lighting effects due to upscaling.
   compat: 5
   memcardFilters: # Reads Re:Chain data and vice-versa.
     - "SLPM-66675"
@@ -45127,6 +45843,8 @@ SLPM-66731:
     recommendedBlendingLevel: 4 # Improves lighting on buildings and objects.
     autoFlush: 2 # Properly diffuses light instead of strips of light.
     roundSprite: 1 # Fixes lighting misalignment such as the street poles and the sun.
+    halfPixelOffset: 2 # Mostly aligns post processing.
+    nativeScaling: 2 # Improves post processing smoothness.
     getSkipCount: "GSC_BlackAndBurnoutSky"
     beforeDraw: "OI_BurnoutGames"
 SLPM-66732:
@@ -45191,6 +45909,7 @@ SLPM-66739:
     autoFlush: 2 # Fixes blur and obscures sun behind objects.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     bilinearUpscale: 2 # Smooths out sun glare textures like native.
+    nativeScaling: 2 # Smooths speed blur and corrects some lighting.
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
 SLPM-66740:
@@ -45225,7 +45944,8 @@ SLPM-66745:
   name-en: "Shadow of Rome [CapKore]"
   region: "NTSC-J"
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes blurriness and misaligned garbage when upscaling.
+    halfPixelOffset: 4 # Fixes post positioning.
+    nativeScaling: 2 # Fixes post effects.
 SLPM-66746:
   name: GUILTY GEAR XX ΛCORE(ギルティギア イグゼクス アクセントコア)
   name-sort: ぎるてぃぎあ いぐぜくす あくせんとこあ
@@ -45443,10 +46163,10 @@ SLPM-66782:
   gameFixes:
     - VuAddSubHack
   gsHWFixes:
-    halfPixelOffset: 2 # Reduces bloom misalignment.
-    roundSprite: 1 # Fixes area transition vertical lines and lessens red forest vertical lines.
+    halfPixelOffset: 4 # Reduces bloom misalignment.
     textureInsideRT: 1 # Required for swirl battle transition.
     nativePaletteDraw: 1
+    nativeScaling: 2 # Fixes depth of field effects and bloom.
 SLPM-66783:
   name: アイドル雀士 スーチーパイIV 「完全限定版・コレクターズエディション」
   name-sort: あいどるじゃんし すーちーぱい4 [かんぜんげんていばん・これくたーずえでぃしょん]
@@ -45523,7 +46243,8 @@ SLPM-66794:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
-    halfPixelOffset: 2 # Fixes blurriness.
+    halfPixelOffset: 4 # Aligns depth of field effect.
+    nativeScaling: 2 # Fixes post lighting.
     autoFlush: 2 # Fixes lens flare.
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
 SLPM-66795:
@@ -45540,6 +46261,9 @@ SLPM-66797:
 SLPM-66798:
   name: "Metal Gear Solid 3 - Subsistence (Disc 1) (Subsistence)"
   region: "NTSC-J"
+  gsHWFixes:
+    halfPixelOffset: 4 # Aligns depth of field effect.
+    nativeScaling: 2 # Fixes post lighting.
 SLPM-66800:
   name: パイレーツ・オブ・カリビアン/ワールド・エンド
   name-sort: ぱいれーつ・おぶ・かりびあん/わーるど・えんど
@@ -45969,6 +46693,8 @@ SLPM-66881:
     roundSprite: 1 # Fixes misaligned map.
     skipDrawStart: 1 # Removes large black box around player car till we properly emulate it.
     skipDrawEnd: 1 # Removes large black box around player car till we properly emulate it.
+    halfPixelOffset: 2 # Fixes depth of field alignment.
+    nativeScaling: 1 # Fixes depth of field.
 SLPM-66882:
   name: はかれなはーと 〜君がために輝きを〜 [限定版・サントラボイスCD付]
   name-sort: はかれなはーと きみがためにかがやきを [げんていばん さんとらぼいすCDつき]
@@ -46388,6 +47114,8 @@ SLPM-66961:
     recommendedBlendingLevel: 4 # Improves lighting on buildings and objects.
     autoFlush: 2 # Properly diffuses light instead of strips of light.
     roundSprite: 1 # Fixes lighting misalignment such as the street poles and the sun.
+    halfPixelOffset: 2 # Mostly aligns post processing.
+    nativeScaling: 2 # Improves post processing smoothness.
     getSkipCount: "GSC_BlackAndBurnoutSky"
     beforeDraw: "OI_BurnoutGames"
 SLPM-66962:
@@ -46403,6 +47131,7 @@ SLPM-66962:
     autoFlush: 2 # Fixes blur and obscures sun behind objects.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     bilinearUpscale: 2 # Smooths out sun glare textures like native.
+    nativeScaling: 2 # Smooths speed blur and corrects some lighting.
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
 SLPM-66963:
@@ -46776,6 +47505,10 @@ SLPM-67517:
 SLPM-67518:
   name: "Onimusha 2 Samurai's Destiny"
   region: "NTSC-K"
+  gsHWFixes:
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 2 # Fixes post processing smoothness and position.
+    roundSprite: 2 # Fixes text.
 SLPM-67519:
   name: "Rayman 2 Revolution"
   region: "NTSC-K"
@@ -46925,6 +47658,9 @@ SLPM-68016:
 SLPM-68017:
   name: "Shin Onimusha - Dawn of Dreams [Saikyou Save Data]"
   region: "NTSC-J"
+  gsHWFixes:
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 2 # Fixes post processing smoothness and position.
   memcardFilters:
     - "SLPM-66275"
 SLPM-68018:
@@ -46936,8 +47672,8 @@ SLPM-68019:
   gameFixes:
     - SoftwareRendererFMVHack # Fixes vertical lines in FMVs.
   gsHWFixes:
-    roundSprite: 2 # Corrects post processing position + fixes subsequent runs of starter FMV vertical lines.
-    cpuCLUTRender: 1 # Reduces the bloomy blur of characters.
+    halfPixelOffset: 2 # Aligns post effects.
+    nativeScaling: 2 # Fixes post effects.
   clampModes:
     vu0ClampMode: 3 # Fixes bad dialog backgrounds.
     vu1ClampMode: 3 # Fixes SPS on characters.
@@ -46970,6 +47706,9 @@ SLPM-68509:
 SLPM-68513:
   name: "Dragon Ball Z - Budokai 2 V"
   region: "NTSC-J"
+  gsHWFixes:
+    halfPixelOffset: 4 # Aligns post effects.
+    nativeScaling: 2 # Fixes post processing and lighting smoothness and position.
 SLPM-68514:
   name: "Front Mission Online"
   region: "NTSC-J"
@@ -46980,7 +47719,8 @@ SLPM-68516:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
-    halfPixelOffset: 2 # Fixes blurriness.
+    halfPixelOffset: 4 # Aligns depth of field effect.
+    nativeScaling: 2 # Fixes post lighting.
     autoFlush: 2 # Fixes lens flare.
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
 SLPM-68519:
@@ -47252,14 +47992,16 @@ SLPM-74232:
   gameFixes:
     - SoftwareRendererFMVHack # Wrong white textures in FMV.
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes misalignment and upscaling lines.
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 2 # Fixes post processing smoothness and position.
   memcardFilters:
     - "SLPM-66275"
 SLPM-74233:
   name: "Shin Onimusha - Dawn of Dreams [PlayStation 2 the Best][Disc 2]"
   region: "NTSC-J"
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes misalignment and upscaling lines.
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 2 # Fixes post processing smoothness and position.
   memcardFilters:
     - "SLPM-74232"
 SLPM-74234:
@@ -47297,7 +48039,8 @@ SLPM-74239:
   name-en: "Okami [PlayStation 2 the Best]"
   region: "NTSC-J"
   gsHWFixes:
-    roundSprite: 2 # Reduces misalignment issues but the game is just bad for upscaling.
+    halfPixelOffset: 4 # Aligns post effects.
+    nativeScaling: 2 # Fixes post effects.
 SLPM-74240:
   name: 天外魔境III NAMIDA PlayStation 2 the Best
   name-sort: てんがいまきょう3 NAMIDA PlayStation 2 the Best
@@ -47318,8 +48061,8 @@ SLPM-74242:
   roundModes:
     eeRoundMode: 0 # Fixes inability to enter door in Mission 18.
   gsHWFixes:
-    halfPixelOffset: 2 # Reduces ghosting but still an issue compared to native.
-    roundSprite: 2 # Clears up much of the blurring that HPO Special does not.
+    halfPixelOffset: 4 # Aligns post effects.
+    nativeScaling: 2 # Fixes post processing and lighting smoothness and position.
 SLPM-74243:
   name: トゥルー・クライム〜ニューヨークシティ〜 PlayStation 2 the Best
   name-sort: とぅるー くらいむ にゅーよーくしてぃ PlayStation 2 the Best
@@ -47334,6 +48077,8 @@ SLPM-74243:
     preloadFrameData: 1 # Fixes numberplates and ensures above targets are valid.
     roundSprite: 1 # Fixes lines in some post-effects.
     gpuTargetCLUT: 1 # Fixes light occlusion.
+    halfPixelOffset: 4 # Reduces post misalignment.
+    nativeScaling: 2 # Fixes remaining post misalignment and light bloom and shadows.
 SLPM-74244:
   name: ファンタシー スター ユニバース PlayStation 2 the Best
   name-sort: ふぁんたしーすたーゆにばーす PlayStation 2 the Best
@@ -47401,14 +48146,16 @@ SLPM-74251:
   name-en: "Shin Onimusha - Dawn of Dreams [PlayStation 2 the Best - Reprint Disc 1]"
   region: "NTSC-J"
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes misalignment and upscaling lines.
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 2 # Fixes post processing smoothness and position.
   memcardFilters:
     - "SLPM-66275"
 SLPM-74252:
   name: "Shin Onimusha - Dawn of Dreams [PlayStation 2 the Best - Reprint Disc 2]"
   region: "NTSC-J"
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes misalignment and upscaling lines.
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 2 # Fixes post processing smoothness and position.
   memcardFilters:
     - "SLPM-74251"
 SLPM-74253:
@@ -47444,6 +48191,9 @@ SLPM-74256:
 SLPM-74257:
   name: "Metal Gear Solid 3 - Subsistence (Disc 1) (Subsistence)"
   region: "NTSC-J"
+  gsHWFixes:
+    halfPixelOffset: 4 # Aligns depth of field effect.
+    nativeScaling: 2 # Fixes post lighting.
 SLPM-74258:
   name: "Metal Gear & Metal Gear 2 - Solid Snake"
   region: "NTSC-J"
@@ -47487,6 +48237,9 @@ SLPM-74267:
 SLPM-74268:
   name: "Devil May Cry 3 - Special Edition"
   region: "NTSC-J"
+  gsHWFixes:
+    halfPixelOffset: 4 # Aligns post effects.
+    nativeScaling: 2 # Fixes post processing and lighting smoothness and position.
 SLPM-74269:
   name: "Ryuu ga Gotoku [PlayStation 2 the Best - 2nd Reprint]"
   region: "NTSC-J"
@@ -47703,7 +48456,8 @@ SLPS-20001:
     halfPixelOffset: 2 # Fixes title screen and some intro post processing alignment.
     roundSprite: 1 # Fixes ui and hud alignment.
     gpuPaletteConversion: 2 # Lots of CLUTs in large textures.
-    cpuCLUTRender: 1 # Fixes car textures.
+    cpuSpriteRenderBW: 1 # Fixes car textures.
+    cpuSpriteRenderLevel: 1 # Needed for above.
 SLPS-20002:
   name: 撞球 ビリヤードマスター2
   name-sort: どうきゅう びりやーどますたー2
@@ -48708,6 +49462,9 @@ SLPS-20245:
 SLPS-20246:
   name: "Rally Shox"
   region: "NTSC-J"
+  gsHWFixes:
+    halfPixelOffset: 4 # Aligns UI.
+    nativeScaling: 2 # Fixes window reflections.
 SLPS-20247:
   name: "Lotus Challenge"
   region: "NTSC-J"
@@ -49476,8 +50233,8 @@ SLPS-20426:
   roundModes:
     vu1RoundMode: 0 # Fixes graphical issues.
   gsHWFixes:
-    roundSprite: 2 # Improves bloom alignment and clarity.
-    halfPixelOffset: 2 # Improves bloom alignment and clarity.
+    halfPixelOffset: 2 # Helps align the post effects, ATN is better but causes edge bleed.
+    nativeScaling: 2 # Fixes Depth of Field effect.
 SLPS-20427:
   name: "Pachi-Slot Club Collection - Pachi-Slot da yo Koumon-chama"
   region: "NTSC-J"
@@ -50244,6 +51001,7 @@ SLPS-25052:
     mergeSprite: 1 # Fixes vertical lines.
     cpuSpriteRenderBW: 1 # Fixes missing sun sprite.
     cpuSpriteRenderLevel: 0 # Needed for above.
+    nativeScaling: 2 # Smooths post processing.
 SLPS-25053:
   name: 栄冠は君に 甲子園の覇者
   name-sort: えいかんはきみに こうしえんのはしゃ
@@ -50473,6 +51231,9 @@ SLPS-25099:
     eeRoundMode: 0 # Fixes crash when using the Subaru.
   gameFixes:
     - XGKickHack # Fixes SPS while ingame.
+  gsHWFixes:
+    halfPixelOffset: 2 # Aligns Depth of Field.
+    nativeScaling: 2 # Fixes Depth of Field effect.
 SLPS-25100:
   name: 鉄拳4
   name-sort: てっけん4
@@ -50599,7 +51360,7 @@ SLPS-25121:
   name-en: ".hack//Infection Part 1"
   region: "NTSC-J"
   gsHWFixes:
-    halfPixelOffset: 1 # Sharpens world in far distances.
+    halfPixelOffset: 2 # Aligns DoF effects.
   memcardFilters:
     - "SCPS-55029"
     - "SCPS-55042"
@@ -50882,6 +51643,9 @@ SLPS-25174:
   name-sort: どらごんぼーるZ
   name-en: "Dragon Ball Z - Budokai"
   region: "NTSC-J"
+  gsHWFixes:
+    halfPixelOffset: 4 # Aligns post effects.
+    nativeScaling: 2 # Fixes post processing and lighting smoothness and position.
 SLPS-25175:
   name: "A Ressha de Ikou 2001"
   region: "NTSC-J"
@@ -51197,8 +51961,8 @@ SLPS-25235:
   compat: 5
   gsHWFixes:
     autoFlush: 2 # Fixes double image.
-    halfPixelOffset: 1 # Fixes ghosting.
-    roundSprite: 1 # Fixes font artifacts.
+    halfPixelOffset: 2 # Mostly aligns post processing.
+    nativeScaling: 2 # Fixes post processing smoothness and position.
 SLPS-25236:
   name: ファンタスティックフォーチュン2
   name-sort: ふぁんたすてぃっくふぉーちゅん2
@@ -51493,6 +52257,9 @@ SLPS-25293:
   name-en: "Naruto - Narutimett Hero"
   region: "NTSC-J"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 2 # Aligns post effects.
+    nativeScaling: 2 # Fixes post effects.
 SLPS-25294:
   name: 宇宙のステルヴィア
   name-sort: うちゅうのすてるゔぃあ
@@ -51624,9 +52391,7 @@ SLPS-25317:
   name-en: "Shadow Hearts 2 [Deluxe Pack] [Disc 1 of 2]"
   region: "NTSC-J"
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes blurrines, preload frame for FMV breaks visuals with this setting.
-    disablePartialInvalidation: 1 # Fixes shadows when upscaling.
-    roundSprite: 2 # Fixes the position of monster sprites and reduces garbage in the UI.
+    halfPixelOffset: 4 # Fixes shadow positioning.
     autoFlush: 2 # Makes the shadow monsters appear.
 SLPS-25318:
   name: シャドウハーツ II DXパック [ディスク2/2]
@@ -51634,9 +52399,7 @@ SLPS-25318:
   name-en: "Shadow Hearts 2 [Deluxe Pack] [Disc 2 of 2]"
   region: "NTSC-J"
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes blurrines, preload frame for FMV breaks visuals with this setting.
-    disablePartialInvalidation: 1 # Fixes shadows when upscaling.
-    roundSprite: 2 # Fixes the position of monster sprites and reduces garbage in the UI.
+    halfPixelOffset: 4 # Fixes shadow positioning.
     autoFlush: 2 # Makes the shadow monsters appear.
   memcardFilters:
     - "SLPS-25317"
@@ -51694,6 +52457,9 @@ SLPS-25330:
   name-sort: どらごんぼーるZ2
   name-en: "Dragon Ball Z - Budokai 2"
   region: "NTSC-J"
+  gsHWFixes:
+    halfPixelOffset: 4 # Aligns post effects.
+    nativeScaling: 2 # Fixes post processing and lighting smoothness and position.
 SLPS-25332:
   name: SNOW [初回限定版]
   name-sort: SNOW しょかいげんていばん
@@ -51712,9 +52478,7 @@ SLPS-25334:
   name-en: "Shadow Hearts 2 [Disc 1 of 2]"
   region: "NTSC-J"
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes blurrines, preload frame for FMV breaks visuals with this setting.
-    disablePartialInvalidation: 1 # Fixes shadows when upscaling.
-    roundSprite: 2 # Fixes the position of monster sprites and reduces garbage in the UI.
+    halfPixelOffset: 4 # Fixes shadow positioning.
     autoFlush: 2 # Makes the shadow monsters appear.
 SLPS-25335:
   name: シャドウハーツ II [通常版] [ディスク2/2]
@@ -51722,9 +52486,7 @@ SLPS-25335:
   name-en: "Shadow Hearts 2 [Disc 2 of 2]"
   region: "NTSC-J"
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes blurrines, preload frame for FMV breaks visuals with this setting.
-    disablePartialInvalidation: 1 # Fixes shadows when upscaling.
-    roundSprite: 2 # Fixes the position of monster sprites and reduces garbage in the UI.
+    halfPixelOffset: 4 # Fixes shadow positioning.
     autoFlush: 2 # Makes the shadow monsters appear.
   memcardFilters:
     - "SLPS-25334"
@@ -51835,8 +52597,9 @@ SLPS-25351:
   gsHWFixes:
     gpuTargetCLUT: 1 # Fixes bloom and sun rendering in front of everything.
     autoFlush: 1 # Fixes bloom and sun rendering in front of everything.
-    halfPixelOffset: 2 # Aligns bloom effect a little bit better when upscaled.
+    halfPixelOffset: 4 # Aligns bloom effect.
     bilinearUpscale: 2 # Reduces color banding of the sun glare.
+    nativeScaling: 2 # Fixes post lighting.
   roundModes:
     vu1RoundMode: 1 # Bright lights in cars.
 SLPS-25352:
@@ -52133,6 +52896,9 @@ SLPS-25398:
   clampModes:
     vu0ClampMode: 0 # Fixes glow effects.
     vu1ClampMode: 3 # Fixes rare SPS.
+  gsHWFixes:
+    halfPixelOffset: 2 # Aligns post effects.
+    nativeScaling: 2 # Fixes post effects.
 SLPS-25399:
   name: ケロロ軍曹 メロメロバトルロイヤル
   name-sort: けろろぐんそう めろめろばとるろいやる
@@ -52474,9 +53240,8 @@ SLPS-25456:
   name-en: "Gladiator - Road to Freedom"
   region: "NTSC-J"
   gsHWFixes:
-    halfPixelOffset: 3 # Fixes bloom misalignment still a bit misaligned.
-    roundSprite: 1 # Fixes bloom misalignment still a bit misaligned.
-    cpuCLUTRender: 1 # Fixes sun background on the windows when selecting your 'race'.
+    halfPixelOffset: 4 # Aligns post effects.
+    nativeScaling: 1 # Fixes post effects.
 SLPS-25457:
   name: ポンコツ浪漫大活劇バンピートロット
   name-sort: ぽんこつろまんだいかつげきばんぴーとろっと
@@ -52781,6 +53546,7 @@ SLPS-25510:
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
     halfPixelOffset: 4 # Align post.
+    nativeScaling: 1 # Fixes depth of field effect.
     getSkipCount: "GSC_Tekken5"
 SLPS-25511:
   name: 羅刹 -Alternative-
@@ -52859,6 +53625,8 @@ SLPS-25527:
   name-en: ".hack//fragment"
   region: "NTSC-J"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 2 # Aligns DoF effects.
 SLPS-25528:
   name: サモンナイトエクステーゼ 〜夜明けの翼〜
   name-sort: さもんないとえくすてーぜ よあけのつばさ
@@ -52940,7 +53708,8 @@ SLPS-25542:
   gameFixes:
     - OPHFlagHack
   gsHWFixes:
-    mergeSprite: 1 # Reduces bloom but fixes blurriness around models + Recommended to use Shadeboost brightness 80.
+    halfPixelOffset: 2 # Aligns post effects.
+    nativeScaling: 2 # Fixes post effects.
 SLPS-25543:
   name: 双恋島 恋と水着のサバイバル!
   name-sort: ふたこいじま こいとみずぎのさばいばる!
@@ -53204,7 +53973,8 @@ SLPS-25586:
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes ghosting.
+    halfPixelOffset: 4 # Fixes post positioning.
+    nativeScaling: 1 # Fixes post effects.
     autoFlush: 2 # Fixes post lighting.
 SLPS-25587:
   name: シュガシュガルーン 恋もおしゃれもピックアップ!
@@ -53225,6 +53995,9 @@ SLPS-25589:
     vuClampMode: 2 # Fixes invisible QTE button prompts and overbright in some scenes.
   gameFixes:
     - SoftwareRendererFMVHack # Fixes vertical lines in FMVs.
+  gsHWFixes:
+    halfPixelOffset: 2 # Aligns post effects.
+    nativeScaling: 2 # Fixes post effects.
 SLPS-25590:
   name: ナムコミュージアム アーケードHITS!
   name-sort: なむこみゅーじあむ あーけーどHITS!
@@ -53505,10 +54278,10 @@ SLPS-25640:
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
-    autoFlush: 2 # Fixes shadows in cutscenes.
-    halfPixelOffset: 2 # Fixes lighting misalignment and reduces ground shadows (probably texture cache issue).
-    roundSprite: 2 # Fixes font artifacts.
+    autoFlush: 1 # Fixes shadows.
     textureInsideRT: 1 # Fixes bad crystal surfaces.
+    halfPixelOffset: 4 # Fixes lighting misalignment.
+    nativeScaling: 2 # Fixes lighting smoothness.
   memcardFilters: # Allows import of Xenosaga II save data.
     - "SLPS-25640"
     - "SLPS-25368"
@@ -53519,10 +54292,10 @@ SLPS-25641:
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
-    autoFlush: 2 # Fixes shadows in cutscenes.
-    halfPixelOffset: 2 # Fixes lighting misalignment and reduces ground shadows (probably texture cache issue).
-    roundSprite: 2 # Fixes font artifacts.
+    autoFlush: 1 # Fixes shadows.
     textureInsideRT: 1 # Fixes bad crystal surfaces.
+    halfPixelOffset: 4 # Fixes lighting misalignment.
+    nativeScaling: 2 # Fixes lighting smoothness.
   memcardFilters:
     - "SLPS-25640"
     - "SLPS-25368"
@@ -53822,6 +54595,9 @@ SLPS-25686:
   name-sort: じょじょのきみょうなぼうけん ふぁんとむぶらっど
   name-en: "Jojo no Kimyou na Bouken - Phantom Blood"
   region: "NTSC-J"
+  gsHWFixes:
+    halfPixelOffset: 4 # Fixes post positioning.
+    nativeScaling: 2 # Fixes post effects.
 SLPS-25687:
   name: コロボットアドベンチャー
   name-sort: ころぼっとあどべんちゃー
@@ -53979,6 +54755,9 @@ SLPS-25714:
   region: "NTSC-J"
   gameFixes:
     - OPHFlagHack
+  gsHWFixes:
+    halfPixelOffset: 2 # Aligns post effects.
+    nativeScaling: 2 # Fixes post effects.
 SLPS-25715:
   name: テイルズ オブ デスティニー
   name-sort: ているず おぶ ですてぃにー
@@ -54285,8 +55064,8 @@ SLPS-25768:
   gameFixes:
     - SoftwareRendererFMVHack # Fixes vertical lines in FMVs.
   gsHWFixes:
-    roundSprite: 2 # Corrects post processing position + fixes subsequent runs of starter FMV vertical lines.
-    cpuCLUTRender: 1 # Reduces the bloomy blur of characters.
+    halfPixelOffset: 2 # Aligns post effects.
+    nativeScaling: 2 # Fixes post effects.
   clampModes:
     vu0ClampMode: 3 # Fixes bad dialog backgrounds.
     vu1ClampMode: 3 # Fixes SPS on characters.
@@ -54534,8 +55313,8 @@ SLPS-25815:
   name-en: "Dragon Ball Z Sparking! Meteor"
   region: "NTSC-J"
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes character outlines and minor bloom.
-    cpuCLUTRender: 1 # Aligns character bloom and some stage bloom.
+    halfPixelOffset: 4 # Aligns post effects.
+    nativeScaling: 2 # Fixes post processing and lighting smoothness and position.
     beforeDraw: "OI_DBZBTGames"
 SLPS-25816:
   name: 山佐DigiワールドコラボレーションSP パチスロ リッジレーサー
@@ -54648,6 +55427,9 @@ SLPS-25834:
   name-sort: とらんすふぉーまー THE GAME
   name-en: "Transformers - The Game"
   region: "NTSC-J"
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes alignment of post processing.
+    nativeScaling: 1 # Fixes post processing effect.
 SLPS-25835:
   name: スーパーロボット大戦OG外伝 [限定版]
   name-sort: すーぱーろぼっとたいせんOGがいでん [げんていばん]
@@ -54666,8 +55448,8 @@ SLPS-25837:
   gameFixes:
     - SoftwareRendererFMVHack # Fixes vertical lines in FMVs.
   gsHWFixes:
-    roundSprite: 2 # Corrects post processing position + fixes subsequent runs of starter FMV vertical lines.
-    cpuCLUTRender: 1 # Reduces the bloomy blur of characters.
+    halfPixelOffset: 2 # Aligns post effects.
+    nativeScaling: 2 # Fixes post effects.
   clampModes:
     vu0ClampMode: 3 # Fixes bad dialog backgrounds.
     vu1ClampMode: 3 # Fixes SPS on characters.
@@ -54691,6 +55473,8 @@ SLPS-25840:
   gsHWFixes:
     textureInsideRT: 1 # Crowd textures.
     autoFlush: 1 # Fixes bloom intensity.
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 1 # Fixes post processing smoothness and position.
 SLPS-25841:
   name: テイルズ オブ デスティニー ディレクターズカット プレミアムBOX
   name-sort: ているず おぶ ですてぃにー でぃれくたーずかっと [ぷれみあむBOX]
@@ -54909,6 +55693,8 @@ SLPS-25885:
   gsHWFixes:
     textureInsideRT: 1 # Crowd textures.
     autoFlush: 1 # Fixes bloom intensity.
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 1 # Fixes post processing smoothness and position.
 SLPS-25886:
   name: "Guitar Hero - Aerosmith on Tour"
   region: "NTSC-J"
@@ -54917,6 +55703,8 @@ SLPS-25886:
   gsHWFixes:
     textureInsideRT: 1 # Crowd textures.
     autoFlush: 1 # Fixes bloom intensity.
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 1 # Fixes post processing smoothness and position.
 SLPS-25887:
   name: スーパーロボット大戦Ｚ
   name-sort: すーぱーろぼっとたいせんZ
@@ -54950,6 +55738,8 @@ SLPS-25889:
   gsHWFixes:
     textureInsideRT: 1 # Crowd textures.
     autoFlush: 1 # Fixes bloom intensity.
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 1 # Fixes post processing smoothness and position.
 SLPS-25890:
   name: ギターヒーロー3 レジェンドオブロック
   name-sort: ぎたーひーろー3 れじぇんどおぶろっく
@@ -54960,6 +55750,8 @@ SLPS-25890:
   gsHWFixes:
     textureInsideRT: 1 # Crowd textures.
     autoFlush: 1 # Fixes bloom intensity.
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 1 # Fixes post processing smoothness and position.
 SLPS-25891:
   name: "Nogizaka Haruka no Himitsu - Cosplay, Hajimemashita"
   region: "NTSC-J"
@@ -55027,8 +55819,8 @@ SLPS-25908:
   name: "LEGO Batman - The Videogame"
   region: "NTSC-J"
   gsHWFixes:
-    cpuCLUTRender: 1 # Fixes ghosting on objects and people.
-    halfPixelOffset: 2 # Fixes depth line. HPO Normal required if not using CLUT Renderer.
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 1 # Fixes post processing smoothness and position.
 SLPS-25909:
   name: "Hisshou Pachinko Pachi-Slot Kouryaku Series Vol. 13 - Shin Seiki Evangelion - Yakusoku no Toki"
   region: "NTSC-J"
@@ -55105,6 +55897,8 @@ SLPS-25927:
   gsHWFixes:
     textureInsideRT: 1 # Needed for post processing effects.
     autoFlush: 1 # Fixes missing blur layer.
+    nativeScaling: 1 # Fixes post processing.
+    halfPixelOffset: 4 # Fixes offset post processing.
 SLPS-25928:
   name: "Little Anchor"
   region: "NTSC-J"
@@ -55179,6 +55973,8 @@ SLPS-25945:
     textureInsideRT: 1 # Needed for post processing effects.
     autoFlush: 1 # Fixes bloom intensity.
     minimumBlendingLevel: 4 # Fixes multiple lighting effects from lights, computers, cave walls and more.
+    nativeScaling: 1 # Fixes post processing.
+    halfPixelOffset: 4 # Fixes offset post processing.
 SLPS-25947:
   name: サモンナイトグランテーゼ 滅びの剣と約束の騎士
   name-sort: さもんないとぐらんてーぜ ほろびのけんとやくそくのきし
@@ -55279,6 +56075,8 @@ SLPS-25986:
   gsHWFixes:
     textureInsideRT: 1 # Needed for post processing effects.
     autoFlush: 1 # Fixes missing blur layer.
+    nativeScaling: 1 # Fixes post processing
+    halfPixelOffset: 4 # Fixes offset post processing.
 SLPS-25987:
   name: "Amagami [EBKore+]"
   region: "NTSC-J"
@@ -55298,9 +56096,8 @@ SLPS-29001:
   name-en: "Xenosaga Episode 1 - Der Wille zur Macht [Premium Box]"
   region: "NTSC-J"
   gsHWFixes:
-    autoFlush: 2 # Fixes shadows in cutscenes.
-    halfPixelOffset: 2 # Removes puppet lines shadows.
-    roundSprite: 2 # Fixes font artifacts.
+    autoFlush: 1 # Fixes shadows in cutscenes.
+    halfPixelOffset: 4 # Removes puppet lines shadows.
   patches:
     A3D63039:
       content: |-
@@ -55325,9 +56122,8 @@ SLPS-29002:
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
-    autoFlush: 2 # Fixes shadows in cutscenes.
-    halfPixelOffset: 2 # Removes puppet lines shadows.
-    roundSprite: 2 # Fixes font artifacts.
+    autoFlush: 1 # Fixes shadows in cutscenes.
+    halfPixelOffset: 4 # Removes puppet lines shadows.
   patches:
     A3D63039:
       content: |-
@@ -55372,9 +56168,8 @@ SLPS-29005:
   name-en: "Xenosaga Episode 1 - Der Wille zur Macht [Reloaded]"
   region: "NTSC-J"
   gsHWFixes:
-    autoFlush: 2 # Fixes shadows in cutscenes.
-    halfPixelOffset: 2 # Removes puppet lines shadows.
-    roundSprite: 2 # Fixes font artifacts.
+    autoFlush: 1 # Fixes shadows in cutscenes.
+    halfPixelOffset: 4 # Removes puppet lines shadows.
 SLPS-71501:
   name: "Tekken Tag Tournament [Mega Hits]"
   region: "NTSC-J"
@@ -55383,6 +56178,14 @@ SLPS-71501:
 SLPS-71502:
   name: "Ridge Racer V"
   region: "NTSC-J"
+  gsHWFixes:
+    cpuFramebufferConversion: 1
+    textureInsideRT: 1
+    halfPixelOffset: 2 # Fixes title screen and some intro post processing alignment.
+    roundSprite: 1 # Fixes ui and hud alignment.
+    gpuPaletteConversion: 2 # Lots of CLUTs in large textures.
+    cpuSpriteRenderBW: 1 # Fixes car textures.
+    cpuSpriteRenderLevel: 1 # Needed for above.
 SLPS-72501:
   name: ファイナルファンタジーX MEGA HITS!
   name-sort: ふぁいなるふぁんたじー10 MEGA HITS!
@@ -55544,6 +56347,7 @@ SLPS-73205:
     mergeSprite: 1 # Fixes vertical lines.
     cpuSpriteRenderBW: 1 # Fixes missing sun sprite.
     cpuSpriteRenderLevel: 0 # Needed for above.
+    nativeScaling: 2 # Smooths post processing.
 SLPS-73206:
   name: 第2次スーパーロボット大戦α PlayStation 2 the Best
   name-sort: だい2じすーぱーろぼっとたいせんあるふぁ PlayStation 2 the Best
@@ -55555,12 +56359,16 @@ SLPS-73207:
   name-en: "Dragon Ball Z [PlayStation 2 the Best]"
   region: "NTSC-J"
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes lines when powering up.
+    halfPixelOffset: 4 # Aligns post effects.
+    nativeScaling: 2 # Fixes post processing and lighting smoothness and position.
 SLPS-73208:
   name: ドラゴンボールZ2 PlayStation 2 the Best
   name-sort: どらごんぼーるZ2 PlayStation 2 the Best
   name-en: "Dragon Ball Z 2 [PlayStation 2 the Best]"
   region: "NTSC-J"
+  gsHWFixes:
+    halfPixelOffset: 4 # Aligns post effects.
+    nativeScaling: 2 # Fixes post processing and lighting smoothness and position.
 SLPS-73209:
   name: 鉄拳4 PlayStation 2 the Best
   name-sort: てっけん4 PlayStation 2 the Best
@@ -55589,15 +56397,16 @@ SLPS-73212:
   name-sort: なると なるてぃめっとひーろー PlayStation 2 the Best
   name-en: "Naruto Narutimett Hero [PlayStation 2 the Best]"
   region: "NTSC-J"
+  gsHWFixes:
+    halfPixelOffset: 2 # Aligns post effects.
+    nativeScaling: 2 # Fixes post effects.
 SLPS-73214:
   name: シャドウ ハーツ II ディレクターズカット PlayStation 2 the Best [ディスク1/2]
   name-sort: しゃどう はーつ II でぃれくたーずかっと PlayStation 2 the Best [でぃすく1/2]
   name-en: "Shadow Hearts 2 [Director's Cut] [PlayStation 2 the Best] [Disc 1 of 2]"
   region: "NTSC-J"
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes blurrines, preload frame for FMV breaks visuals with this setting.
-    disablePartialInvalidation: 1 # Fixes shadows when upscaling.
-    roundSprite: 2 # Fixes the position of monster sprites and reduces garbage in the UI.
+    halfPixelOffset: 4 # Fixes shadow positioning.
     autoFlush: 2 # Makes the shadow monsters appear.
 SLPS-73215:
   name: シャドウ ハーツ II ディレクターズカット PlayStation 2 the Best [ディスク2/2]
@@ -55605,9 +56414,7 @@ SLPS-73215:
   name-en: "Shadow Hearts 2 [Director's Cut] [PlayStation 2 the Best] [Disc 2 of 2]"
   region: "NTSC-J"
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes blurrines, preload frame for FMV breaks visuals with this setting.
-    disablePartialInvalidation: 1 # Fixes shadows when upscaling.
-    roundSprite: 2 # Fixes the position of monster sprites and reduces garbage in the UI.
+    halfPixelOffset: 4 # Fixes shadow positioning.
     autoFlush: 2 # Makes the shadow monsters appear.
   memcardFilters:
     - "SLPS-73214"
@@ -55655,6 +56462,9 @@ SLPS-73221:
   clampModes:
     vu0ClampMode: 0 # Fixes glow effects.
     vu1ClampMode: 3 # Fixes rare SPS.
+  gsHWFixes:
+    halfPixelOffset: 2 # Aligns post effects.
+    nativeScaling: 2 # Fixes post effects.
 SLPS-73222:
   name: 牧場物語 Oh!ワンダフルライフ PlayStation 2 the Best
   name-sort: ぼくじょうものがたり Oh!わんだふるらいふ PlayStation 2 the Best
@@ -55670,6 +56480,7 @@ SLPS-73223:
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
     halfPixelOffset: 4 # Align post.
+    nativeScaling: 1 # Fixes depth of field effect.
     getSkipCount: "GSC_Tekken5"
 SLPS-73224:
   name: ゼノサーガ エピソードII［善悪の彼岸］ PlayStation 2 the Best [ディスク1/2]
@@ -55799,6 +56610,9 @@ SLPS-73235:
   name-sort: どらごんぼーるZ3 PlayStation 2 the Best
   name-en: "Dragon Ball Z 3 [PlayStation 2 the Best]"
   region: "NTSC-J"
+  gsHWFixes:
+    halfPixelOffset: 4 # Aligns post effects.
+    nativeScaling: 2 # Fixes post processing and lighting smoothness and position.
 SLPS-73236:
   name: ヴィーナスアンドブレイブス〜魔女と女神と滅びの予言〜 PlayStation 2 the Best
   name-sort: ゔぃーなすあんどぶれいぶす まじょとめがみとほろびのよげん PlayStation 2 the Best
@@ -55943,13 +56757,17 @@ SLPS-73251:
     vuClampMode: 2 # Fixes invisible QTE button prompts and overbright in some scenes.
   gameFixes:
     - SoftwareRendererFMVHack # Fixes vertical lines in FMVs.
+  gsHWFixes:
+    halfPixelOffset: 2 # Aligns post effects.
+    nativeScaling: 2 # Fixes post effects.
 SLPS-73252:
   name: テイルズ オブ ジ アビス PlayStation 2 the Best
   name-sort: ているず おぶ じ あびす PlayStation 2 the Best
   name-en: "Tales of the Abyss [PlayStation 2 the Best]"
   region: "NTSC-J"
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes ghosting.
+    halfPixelOffset: 4 # Fixes post positioning.
+    nativeScaling: 1 # Fixes post effects.
     autoFlush: 2 # Fixes post lighting.
 SLPS-73253:
   name: るろうに剣心-明治剣客浪漫譚- 炎上!京都輪廻 PlayStation 2 the Best
@@ -56098,6 +56916,7 @@ SLPS-73410:
     mergeSprite: 1 # Fixes vertical lines.
     cpuSpriteRenderBW: 1 # Fixes missing sun sprite.
     cpuSpriteRenderLevel: 0 # Needed for above.
+    nativeScaling: 2 # Smooths post processing.
 SLPS-73411:
   name: "Armored Core 2 - Another Age [PlayStation 2 the Best]"
   region: "NTSC-J"
@@ -56194,9 +57013,8 @@ SLPS-73901:
   name-en: "Xenosaga Episode 1 - Der Wille zur Macht [PlayStation 2 the Best]"
   region: "NTSC-J"
   gsHWFixes:
-    autoFlush: 2 # Fixes shadows in cutscenes.
-    halfPixelOffset: 2 # Removes puppet lines shadows.
-    roundSprite: 2 # Fixes font artifacts.
+    autoFlush: 1 # Fixes shadows in cutscenes.
+    halfPixelOffset: 4 # Removes puppet lines shadows.
   patches:
     A3D63039:
       content: |-
@@ -56238,7 +57056,8 @@ SLUS-20002:
     halfPixelOffset: 2 # Fixes title screen and some intro post processing alignment.
     roundSprite: 1 # Fixes ui and hud alignment.
     gpuPaletteConversion: 2 # Lots of CLUTs in large textures.
-    cpuCLUTRender: 1 # Fixes car textures.
+    cpuSpriteRenderBW: 1 # Fixes car textures.
+    cpuSpriteRenderLevel: 1 # Needed for above.
 SLUS-20003:
   name: "Portal Runner"
   region: "NTSC-U"
@@ -56789,6 +57608,7 @@ SLUS-20152:
     mergeSprite: 1 # Fixes vertical lines.
     cpuSpriteRenderBW: 1 # Fixes missing sun sprite.
     cpuSpriteRenderLevel: 0 # Needed for above.
+    nativeScaling: 2 # Smooths post processing.
   patches:
     A32F7CD0:
       content: |-
@@ -57288,7 +58108,7 @@ SLUS-20267:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 1 # Sharpens world in far distances.
+    halfPixelOffset: 2 # Aligns DoF effects.
   memcardFilters:
     - "SLUS-20267"
     - "SLUS-20562"
@@ -57732,6 +58552,9 @@ SLUS-20358:
   name: "Malice"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 4 # Fixes post positioning.
+    nativeScaling: 1 # Fixes post effects.
 SLUS-20360:
   name: "Blade II"
   region: "NTSC-U"
@@ -57908,6 +58731,9 @@ SLUS-20393:
   name: "Onimusha 2 - Samurai's Destiny"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 2 # Fixes post processing smoothness and position.
 SLUS-20394:
   name: "Ecco the Dolphin - Defender of the Future"
   region: "NTSC-U"
@@ -58033,6 +58859,8 @@ SLUS-20418:
     vuClampMode: 3 # Fixes water rendering.
   gameFixes:
     - XGKickHack # Fixes SPS while ingame.
+  gsHWFixes:
+    nativeScaling: 2 # Fixes water reflections.
 SLUS-20419:
   name: "World Rally Championship"
   region: "NTSC-U"
@@ -58064,6 +58892,8 @@ SLUS-20423:
   compat: 5
   gsHWFixes:
     roundSprite: 1 # Fixes blue font artifacts.
+    halfPixelOffset: 4 # Aligns post effects.
+    nativeScaling: 1 # Fixes post effects.
 SLUS-20424:
   name: "The Scorpion King - Rise of the Akkadian"
   name-sort: "Scorpion King, The - Rise of the Akkadian"
@@ -58390,7 +59220,8 @@ SLUS-20488:
   gameFixes:
     - VuAddSubHack
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes bloom and ghosting in certain areas.
+    halfPixelOffset: 4 # Fix effects upscaling.
+    nativeScaling: 2 # Fixes post effects.
     roundSprite: 1 # Fixes door transition vertical lines and mini-map artifacts.
     textureInsideRT: 1 # Fixes missing battle effects.
 SLUS-20489:
@@ -58441,8 +59272,9 @@ SLUS-20497:
   gsHWFixes:
     gpuTargetCLUT: 1 # Fixes bloom and sun rendering in front of everything.
     autoFlush: 1 # Fixes bloom and sun rendering in front of everything.
-    halfPixelOffset: 2 # Aligns bloom effect a little bit better when upscaled.
+    halfPixelOffset: 4 # Aligns bloom effect.
     bilinearUpscale: 2 # Reduces color banding of the sun glare.
+    nativeScaling: 2 # Fixes post lighting.
   roundModes:
     vu1RoundMode: 1 # Bright lights in cars.
 SLUS-20498:
@@ -58495,6 +59327,8 @@ SLUS-20508:
     - EETimingHack # Fixes texture flicker.
   gsHWFixes:
     textureInsideRT: 1
+    halfPixelOffset: 4 # Reduces post misalignment.
+    nativeScaling: 2 # Fixes remaining post misalignment.
 SLUS-20509:
   name: "Soccer Slam - Sega Sports"
   region: "NTSC-U"
@@ -58608,6 +59442,9 @@ SLUS-20533:
   name: "Shox"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 4 # Aligns UI.
+    nativeScaling: 2 # Fixes window reflections.
 SLUS-20534:
   name: "Cabela's Big Game Hunter"
   region: "NTSC-U"
@@ -58657,10 +59494,16 @@ SLUS-20543:
 SLUS-20544:
   name: "Malice"
   region: "NTSC-U"
+  gsHWFixes:
+    halfPixelOffset: 4 # Fixes post positioning.
+    nativeScaling: 1 # Fixes post effects.
 SLUS-20545:
   name: "Zone of the Enders - The 2nd Runner"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 1 # Aligns post effects.
+    nativeScaling: 2 # Fixes post effects.
 SLUS-20546:
   name: "Evolution Snowboarding"
   region: "NTSC-U"
@@ -58902,7 +59745,7 @@ SLUS-20587:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     autoFlush: 1 # Aligns and corrects shadows.
-    roundSprite: 1 # Fixes depth line.
+    halfPixelOffset: 2 # Fixes sun and depth line.
     cpuCLUTRender: 1 # Fixes janky coloured cars.
     gpuTargetCLUT: 1 # Fixes janky coloured cars.
     textureInsideRT: 1 # Fixes car textures.
@@ -58922,7 +59765,8 @@ SLUS-20591:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes lines when powering up.
+    halfPixelOffset: 4 # Aligns post effects.
+    nativeScaling: 2 # Fixes post processing and lighting smoothness and position.
 SLUS-20592:
   name: "HyperSonic Xtreme - HSX"
   region: "NTSC-U"
@@ -58937,6 +59781,7 @@ SLUS-20595:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes misaligned lighting and other effects, needs Special otherwise lights flicker.
+    nativeScaling: 2 # Fixes lights.
 SLUS-20596:
   name: "UFC - Ultimate Fighting Championship - Sudden Impact"
   region: "NTSC-U"
@@ -59136,6 +59981,10 @@ SLUS-20636:
   name-sort: "Suffering, The"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    autoFlush: 2 # Fixes debris and blending on lower part of screen during monster transformation.
+    halfPixelOffset: 4 # Aligns post processing, might sometimes cause edge bleed which must be cropped.
+    nativeScaling: 2 # Fixes post effects like lights.
 SLUS-20637:
   name: "Chessmaster"
   region: "NTSC-U"
@@ -59201,6 +60050,8 @@ SLUS-20647:
   compat: 5
   clampModes:
     vuClampMode: 3 # Fixes minor SPS on characters.
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes post alignment.
 SLUS-20648:
   name: "NBA Jam 2004"
   region: "NTSC-U"
@@ -59227,6 +60078,10 @@ SLUS-20652:
   name: "Tom Clancy's Splinter Cell"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 4 # Aligns post processing.
+    nativeScaling: 2 # Fixes post effects.
+    recommendedBlendingLevel: 4 # Fixes lighting effects but has high barrier count.
 SLUS-20653:
   name: "Dynasty Warriors 4"
   region: "NTSC-U"
@@ -59296,11 +60151,10 @@ SLUS-20669:
   gsHWFixes:
     PCRTCOverscan: 1 # Shows full image frame.
     PCRTCOffsets: 1 # Shows full image frame.
-    halfPixelOffset: 1 # Fixes character offset with flashlight and blurriness.
-    alignSprite: 1 # Fixes vertical lines.
+    halfPixelOffset: 4 # Fixes character offset with flashlight and blurriness.
     roundSprite: 2 # Fixes font artifacts.
-    mergeSprite: 1 # Fixes flame-like bleeding.
     autoFlush: 1 # Fixes light bloom intensity.
+    nativeScaling: 2 # Fixes post processing.
 SLUS-20670:
   name: "The Great Escape"
   name-sort: "Great Escape, The"
@@ -59448,7 +60302,8 @@ SLUS-20694:
     - "SLUS-20694"
     - "SLUS-20710"
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes ghosting.
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 2 # Fixes post processing smoothness and position.
     roundSprite: 2 # Fixes various lines / reduces bars on right edge.
     disablePartialInvalidation: 1 # Fixes textureless graphics ingame.
     bilinearUpscale: 2 # Gets rid of center vertical line when upscaling.
@@ -59621,6 +60476,9 @@ SLUS-20730:
   name: "NARC"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 4 # Aligns post effects.
+    nativeScaling: 2 # Fixes post effects.
 SLUS-20731:
   name: "Tony Hawk's Underground"
   region: "NTSC-U"
@@ -59629,6 +60487,8 @@ SLUS-20731:
     vu1RoundMode: 0 # Crashes without.
   gsHWFixes:
     minimumBlendingLevel: 3 # Fixes broken lighting on ground and buildings.
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 1 # Fixes post processing smoothness and position.
 SLUS-20732:
   name: "Drakengard"
   region: "NTSC-U"
@@ -59685,7 +60545,8 @@ SLUS-20743:
   compat: 5
   gsHWFixes:
     autoFlush: 2 # Reduces post-processing misalignment.
-    halfPixelOffset: 4 # Reduces post-processing misalignment.
+    halfPixelOffset: 4 # Fixes post positioning.
+    nativeScaling: 2 # Fixes post effects.
 SLUS-20744:
   name: "EverQuest - Online Adventures - Frontiers"
   region: "NTSC-U"
@@ -59898,6 +60759,9 @@ SLUS-20777:
 SLUS-20779:
   name: "Dragon Ball Z - Budokai 2"
   region: "NTSC-U"
+  gsHWFixes:
+    halfPixelOffset: 4 # Aligns post effects.
+    nativeScaling: 2 # Fixes post processing and lighting smoothness and position.
 SLUS-20780:
   name: "R-Type Final"
   region: "NTSC-U"
@@ -59937,6 +60801,8 @@ SLUS-20788:
   compat: 5
   gsHWFixes:
     autoFlush: 1 # Fixes missing sun.
+    halfPixelOffset: 4 # Aligns shadows.
+    nativeScaling: 1 # Softens shadows.
 SLUS-20789:
   name: "Jeopardy!"
   region: "NTSC-U"
@@ -59961,8 +60827,8 @@ SLUS-20793:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    roundSprite: 2 # Helps glow misalignment.
-    halfPixelOffset: 1 # Helps glow misalignment.
+    halfPixelOffset: 4 # Aligns post effects.
+    nativeScaling: 1 # Fixes post effects.
 SLUS-20794:
   name: "ESPN - Major League Baseball"
   region: "NTSC-U"
@@ -60063,7 +60929,8 @@ SLUS-20817:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 1 # Fixes ghosting.
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 2 # Fixes post processing smoothness and position.
 SLUS-20818:
   name: "Bionicle"
   region: "NTSC-U"
@@ -60268,7 +61135,8 @@ SLUS-20858:
     instantVU1: 1 # Increases FPS drastically.
     mtvu: 0
   gsHWFixes:
-    halfPixelOffset: 3 # Reduces ghosting.
+    halfPixelOffset: 4 # Aligns Post.
+    nativeScaling: 2 # Corrects post effect and reflections on cars.
 SLUS-20859:
   name: "Future Tactics - The Uprising"
   region: "NTSC-U"
@@ -60457,7 +61325,8 @@ SLUS-20891:
   gameFixes:
     - VuAddSubHack
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes bloom and ghosting in certain areas.
+    halfPixelOffset: 4 # Fix effects upscaling.
+    nativeScaling: 2 # Fixes post effects.
     roundSprite: 1 # Fixes door transition vertical lines and mini-map artifacts.
     textureInsideRT: 1 # Fixes missing battle effects.
   memcardFilters:
@@ -60502,6 +61371,8 @@ SLUS-20898:
   compat: 5
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves reflections on certain characters and objects on certain levels.
+    halfPixelOffset: 4 # Corrects post processing positioning.
+    nativeScaling: 2 # Smooths post processing.
 SLUS-20899:
   name: "Samurai Jack - The Shadow of Aku"
   region: "NTSC-U"
@@ -60518,7 +61389,8 @@ SLUS-20902:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes blurriness and misaligned garbage when upscaling.
+    halfPixelOffset: 4 # Fixes post positioning.
+    nativeScaling: 2 # Fixes post effects.
 SLUS-20903:
   name: "Mega Man X - Command Mission"
   region: "NTSC-U"
@@ -60531,16 +61403,16 @@ SLUS-20904:
   compat: 5
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes missing lights.
-    halfPixelOffset: 2 # Fixes bloom misalignment when upscaling.
-    cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling.
+    halfPixelOffset: 4 # Aligns post processing.
+    nativeScaling: 2 # Fixes post effects.
 SLUS-20905:
   name: "Disney/Pixar The Incredibles"
   name-sort: "Incredibles, The"
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes bloom misalignment when upscaling.
-    cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling.
+    halfPixelOffset: 4 # Aligns post effects.
+    nativeScaling: 2 # Fixes post effects.
 SLUS-20906:
   name: "Fight Night 2004"
   region: "NTSC-U"
@@ -60593,7 +61465,8 @@ SLUS-20915:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
-    halfPixelOffset: 2 # Fixes blurriness.
+    halfPixelOffset: 4 # Aligns depth of field effect.
+    nativeScaling: 2 # Fixes post lighting.
     autoFlush: 2 # Fixes lens flare.
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
 SLUS-20916:
@@ -60705,6 +61578,7 @@ SLUS-20932:
   compat: 5
   gsHWFixes:
     autoFlush: 2 # Fixes missing lighting.
+    nativeScaling: 1 # Fixes post lighting.
     # halfPixelOffset: 1 # Fixes lighting misalignment. Do not enable this, it breaks a lot of graphics.
 SLUS-20933:
   name: "Smash Court Pro Tournament Tennis 2"
@@ -60754,13 +61628,15 @@ SLUS-20941:
     eeCycleRate: 1 # Fixes occasional post process flickering.
   gsHWFixes:
     nativePaletteDraw: 1 # Fixes lines in certain effects when upscaled.
-    halfPixelOffset: 2 # Fixes offset bloom.
+    halfPixelOffset: 4 # Fixes post positioning.
+    nativeScaling: 1 # Fixes post effects.
 SLUS-20942:
   name: "Robots"
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes misaligned bloom.
+    halfPixelOffset: 4 # Fixes post bloom positioning.
+    nativeScaling: 2 # Fixes bloom effects.
 SLUS-20943:
   name: "Heroes of the Pacific"
   region: "NTSC-U"
@@ -60775,10 +61651,9 @@ SLUS-20945:
   compat: 5
   gsHWFixes:
     textureInsideRT: 1 # Fixes shadow maps.
-    roundSprite: 2 # Fixes misaligned bloom.
-    mergeSprite: 1 # Fixes misaligned bloom.
     halfPixelOffset: 2 # Fixes misaligned bloom.
     autoFlush: 2 # Fixes sun occlusion and brightness.
+    nativeScaling: 2 # Fixes post processing and lighting smoothness and position.
 SLUS-20946:
   name: "Grand Theft Auto - San Andreas"
   region: "NTSC-U"
@@ -60796,8 +61671,8 @@ SLUS-20948:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    forceEvenSpritePosition: 1 # Fixes blurriness.
-    roundSprite: 2 # Reduces misalignment bloom effects.
+    halfPixelOffset: 1 # Aligns post effects.
+    nativeScaling: 2 # Fixes post effects.
 SLUS-20949:
   name: "Street Fighter Anniversary Collection"
   region: "NTSC-U"
@@ -60887,8 +61762,8 @@ SLUS-20964:
   roundModes:
     eeRoundMode: 0 # Fixes inability to enter door in Mission 18.
   gsHWFixes:
-    halfPixelOffset: 2 # Reduces ghosting but still an issue compared to native.
-    roundSprite: 2 # Clears up much of the blurring that HPO Special does not.
+    halfPixelOffset: 4 # Aligns post effects.
+    nativeScaling: 2 # Fixes post processing and lighting smoothness and position.
 SLUS-20965:
   name: "Tony Hawk's Underground 2"
   region: "NTSC-U"
@@ -60898,8 +61773,8 @@ SLUS-20965:
   gsHWFixes:
     preloadFrameData: 1 # Fixes missing loading screens.
     recommendedBlendingLevel: 3 # Fixes water and grass textures.
-    forceEvenSpritePosition: 1 # Reduces post-processing misalignment.
-    mergeSprite: 1 # Reduces post-processing misalignment.
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 1 # Fixes post processing smoothness and position.
 SLUS-20966:
   name: "State of Emergency 2"
   region: "NTSC-U"
@@ -61054,6 +61929,8 @@ SLUS-20992:
     recommendedBlendingLevel: 4 # Fixes bloom.
     autoFlush: 1 # Fixes ghosting.
     textureInsideRT: 1 # Required for offset RTs/textures for post-processing.
+    halfPixelOffset: 2 # Aligns post effects.
+    nativeScaling: 2 # Fixes post effects.
 SLUS-20993:
   name: "Ghosthunter"
   region: "NTSC-U"
@@ -61078,6 +61955,9 @@ SLUS-20998:
   name: "Dragon Ball Z - Budokai 3"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 4 # Aligns post effects.
+    nativeScaling: 2 # Fixes post processing and lighting smoothness and position.
 SLUS-20999:
   name: "Sega Superstars"
   region: "NTSC-U"
@@ -61104,6 +61984,9 @@ SLUS-21004:
   name: "Def Jam - Fight for NY"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 4 # Reduces post misalignment.
+    nativeScaling: 2 # Fixes remaining post misalignment.
 SLUS-21005:
   name: "Kingdom Hearts II"
   region: "NTSC-U"
@@ -61111,7 +61994,8 @@ SLUS-21005:
   gsHWFixes:
     autoFlush: 1 # Fixes effects.
     roundSprite: 1 # Fixes upscaling artifacts.
-    halfPixelOffset: 4 # Fixes upscaling artifacts.
+    halfPixelOffset: 2 # Fixes post bloom positioning.
+    nativeScaling: 2 # Fixes lighting effects due to upscaling.
 SLUS-21006:
   name: "Ghost in the Shell - Stand Alone Complex"
   region: "NTSC-U"
@@ -61120,10 +62004,10 @@ SLUS-21006:
     - SoftwareRendererFMVHack # Fixes hash cache disabling itself.
   gsHWFixes:
     recommendedBlendingLevel: 4 # Improves banding and effect emulation.
-    halfPixelOffset: 3 # Fixes texture and lighting misalignment.
-    mergeSprite: 1 # Fixes most vertical lines and lighting misalignment.
     autoFlush: 1 # Fixes light bloom intensity.
     estimateTextureRegion: 1 # Improves performance and reduces hash cache size.
+    halfPixelOffset: 4 # Aligns post effects.
+    nativeScaling: 1 # Fixes post effects.
     getSkipCount: "GSC_GiTS"
   patches:
     default:
@@ -61210,8 +62094,8 @@ SLUS-21015:
   roundModes:
     vu1RoundMode: 0 # Fixes graphical issues.
   gsHWFixes:
-    roundSprite: 2 # Improves bloom alignment and clarity.
-    halfPixelOffset: 2 # Improves bloom alignment and clarity.
+    halfPixelOffset: 2 # Helps align the post effects, ATN is better but causes edge bleed.
+    nativeScaling: 2 # Fixes Depth of Field effect.
 SLUS-21016:
   name: "25 to Life"
   region: "NTSC-U"
@@ -61246,6 +62130,8 @@ SLUS-21022:
   compat: 5
   gsHWFixes:
     autoFlush: 2 # Reduces post-processing misalignment.
+    halfPixelOffset: 4 # Fixes post positioning.
+    nativeScaling: 2 # Fixes post effects.
 SLUS-21025:
   name: "Madden NFL 2005 [Special Collectors Edition]"
   region: "NTSC-U"
@@ -61268,7 +62154,8 @@ SLUS-21027:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes ghosting.
+    halfPixelOffset: 4 # Aligns post processing.
+    nativeScaling: 2 # Corrects post processing smoothness.
 SLUS-21028:
   name: "World Championship Poker"
   region: "NTSC-U"
@@ -61278,6 +62165,8 @@ SLUS-21029:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
+    halfPixelOffset: 2 # Aligns post bloom.
+    nativeScaling: 2 # Fixes light blooms.
     getSkipCount: "GSC_MidnightClub3"
   patches:
     0DD3417A:
@@ -61340,6 +62229,8 @@ SLUS-21037:
   gsHWFixes:
     autoFlush: 1 # Fixes the post processing positioning.
     textureInsideRT: 1 # Fixes post processing.
+    halfPixelOffset: 4 # Aligns bloom effect.
+    nativeScaling: 2 # Fixes post processing smoothness and position.
 SLUS-21038:
   name: "Pinball Hall of Fame - The Gottlieb Collection"
   region: "NTSC-U"
@@ -61360,9 +62251,7 @@ SLUS-21041:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes blurrines, preload frame for FMV breaks visuals with this setting.
-    disablePartialInvalidation: 1 # Fixes shadows when upscaling.
-    roundSprite: 2 # Fixes the position of monster sprites and reduces garbage in the UI.
+    halfPixelOffset: 4 # Fixes shadow positioning.
     autoFlush: 2 # Makes the shadow monsters appear.
 SLUS-21042:
   name: "Darkwatch"
@@ -61379,9 +62268,7 @@ SLUS-21044:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes blurrines, preload frame for FMV breaks visuals with this setting.
-    disablePartialInvalidation: 1 # Fixes shadows when upscaling.
-    roundSprite: 2 # Fixes the position of monster sprites and reduces garbage in the UI.
+    halfPixelOffset: 4 # Fixes shadow positioning.
     autoFlush: 2 # Makes the shadow monsters appear.
   memcardFilters:
     - "SLUS-21041"
@@ -61419,6 +62306,7 @@ SLUS-21050:
     autoFlush: 2 # Fixes blur and obscures sun behind objects.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     bilinearUpscale: 2 # Smooths out sun glare textures like native.
+    nativeScaling: 2 # Smooths speed blur and corrects some lighting.
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
 SLUS-21051:
@@ -61467,6 +62355,7 @@ SLUS-21059:
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
     halfPixelOffset: 4 # Align post.
+    nativeScaling: 1 # Fixes depth of field effect.
     getSkipCount: "GSC_Tekken5"
 SLUS-21060:
   name: "WWE SmackDown! vs. RAW"
@@ -61554,7 +62443,8 @@ SLUS-21078:
   clampModes:
     eeClampMode: 3 # Fixes the inability to collect items.
   gsHWFixes:
-    halfPixelOffset: 1 # Reduces lighting misalignment but doesn't fully fix it.
+    halfPixelOffset: 4 # Aligns post effects.
+    nativeScaling: 2 # Fixes post effects.
 SLUS-21079:
   name: "Armored Core - Nexus [Disc 2]"
   region: "NTSC-U"
@@ -61695,6 +62585,8 @@ SLUS-21106:
     preloadFrameData: 1 # Fixes numberplates and ensures above targets are valid.
     roundSprite: 1 # Fixes lines in some post-effects.
     gpuTargetCLUT: 1 # Fixes light occlusion.
+    halfPixelOffset: 4 # Reduces post misalignment.
+    nativeScaling: 2 # Fixes remaining post misalignment and light bloom and shadows.
 SLUS-21107:
   name: "X-Men - The Official Game"
   region: "NTSC-U"
@@ -61726,6 +62618,7 @@ SLUS-21111:
     autoFlush: 2 # Fixes post processing overlay.
     roundSprite: 1 # Greatly reduces chromatic effect when upscaling.
     forceEvenSpritePosition: 1 # Fixes chromatic fringing.
+    nativeScaling: 1 # Fixes post processing effect and position.
 SLUS-21112:
   name: "L.A. Rush"
   region: "NTSC-U"
@@ -61745,7 +62638,8 @@ SLUS-21115:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    roundSprite: 2 # Reduces misalignment issues but the game is just bad for upscaling.
+    halfPixelOffset: 4 # Aligns post effects.
+    nativeScaling: 2 # Fixes post effects.
 SLUS-21116:
   name: "187 - Ride or Die"
   region: "NTSC-U"
@@ -61780,6 +62674,9 @@ SLUS-21122:
 SLUS-21123:
   name: "Dragon Ball Z - Budokai 3 [Limited Edition]"
   region: "NTSC-U"
+  gsHWFixes:
+    halfPixelOffset: 4 # Aligns post effects.
+    nativeScaling: 2 # Fixes post processing and lighting smoothness and position.
 SLUS-21124:
   name: "Delta Force - Black Hawk Down"
   region: "NTSC-U"
@@ -61801,10 +62698,11 @@ SLUS-21127:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes lighting/shadows.
+    halfPixelOffset: 4 # Fixes lighting/shadows.
     preloadFrameData: 1 # Fixes sun flickering.
     autoFlush: 2 # Fixes sun through objects.
     bilinearUpscale: 1 # Smooths out sun glare textures like native.
+    nativeScaling: 1 # Fixes post effects.
 SLUS-21128:
   name: "Blitz - The League"
   region: "NTSC-U"
@@ -61978,6 +62876,7 @@ SLUS-21160:
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
     halfPixelOffset: 4 # Align post.
+    nativeScaling: 1 # Fixes depth of field effect.
     getSkipCount: "GSC_Tekken5"
 SLUS-21161:
   name: "Fight Night - Round 2"
@@ -62067,15 +62966,15 @@ SLUS-21179:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 3 # Fixes bloom misalignment still a bit misaligned.
-    roundSprite: 1 # Fixes bloom misalignment still a bit misaligned.
-    cpuCLUTRender: 1 # Fixes sun background on the windows when selecting your 'race'.
+    halfPixelOffset: 4 # Aligns post effects.
+    nativeScaling: 1 # Fixes post effects.
 SLUS-21180:
   name: "Onimusha - Dawn of Dreams [Disc 1 of 2]"
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes misalignment and upscaling lines.
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 2 # Fixes post processing smoothness and position.
 SLUS-21181:
   name: "D.I.C.E. - DNA Integrated Cybernetic Enterprises"
   region: "NTSC-U"
@@ -62089,6 +62988,8 @@ SLUS-21182:
     roundSprite: 1 # Fixes misaligned map.
     skipDrawStart: 1 # Removes large black box around player car till we properly emulate it.
     skipDrawEnd: 1 # Removes large black box around player car till we properly emulate it.
+    halfPixelOffset: 2 # Fixes depth of field alignment.
+    nativeScaling: 1 # Fixes depth of field.
 SLUS-21183:
   name: "Teen Titans"
   region: "NTSC-U"
@@ -62121,6 +63022,8 @@ SLUS-21189:
     instantVU1: 1 # Fixes SPS.
   gsHWFixes:
     autoFlush: 2 # Fixes debris and blending on lower part of screen during monster transformation.
+    halfPixelOffset: 4 # Aligns post processing, might sometimes cause edge bleed which must be cropped.
+    nativeScaling: 2 # Fixes post effects like lights.
   memcardFilters:
     - "SLUS-21189"
     - "SLUS-20636"
@@ -62214,6 +63117,8 @@ SLUS-21203:
     textureInsideRT: 1 # Needed for post processing effects.
     autoFlush: 1 # Fixes bloom intensity.
     minimumBlendingLevel: 4 # Fixes multiple lighting effects from lights, computers, cave walls and more.
+    nativeScaling: 1 # Fixes post processing.
+    halfPixelOffset: 4 # Fixes offset post processing.
 SLUS-21204:
   name: "Victorious Boxers 2 - Fighting Spirit"
   region: "NTSC-U"
@@ -62244,8 +63149,8 @@ SLUS-21208:
     vu1RoundMode: 0 # Crashes without.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes water and grass textures.
-    forceEvenSpritePosition: 1 # Reduces post-processing misalignment.
-    mergeSprite: 1 # Reduces post-processing misalignment.
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 1 # Fixes post processing smoothness and position.
     autoFlush: 1 # Improves post-processing rendering.
     preloadFrameData: 1 # Fixes missing loading screens.
 SLUS-21209:
@@ -62302,8 +63207,8 @@ SLUS-21217:
   compat: 5
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes building shade and shadows.
-    halfPixelOffset: 2 # Fixes bloom misalignment when upscaling.
-    cpuCLUTRender: 1 # Fixes duplicated bloom when upscaling.
+    halfPixelOffset: 4 # Aligns post effects.
+    nativeScaling: 2 # Fixes post effects.
 SLUS-21218:
   name: "Tak - The Great Juju Challenge"
   region: "NTSC-U"
@@ -62347,8 +63252,8 @@ SLUS-21227:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes lines when powering up.
-    cpuCLUTRender: 1 # Reduces the bloomy blur of characters.
+    halfPixelOffset: 4 # Aligns post effects.
+    nativeScaling: 2 # Fixes post processing and lighting smoothness and position.
 SLUS-21228:
   name: "Call of Duty 2 - Big Red One"
   region: "NTSC-U"
@@ -62387,6 +63292,7 @@ SLUS-21231:
     autoFlush: 2 # Fixes bloom misalignment.
     halfPixelOffset: 2 # Fixes bloom misalignment.
     textureInsideRT: 1 # Fixes sky bloom.
+    nativeScaling: 2 # Fixes post processing.
 SLUS-21232:
   name: "College Hoops 2K6"
   region: "NTSC-U"
@@ -62453,7 +63359,8 @@ SLUS-21240:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 1 # Fixes bloom misalignment.
+    halfPixelOffset: 4 # Corrects post processing positioning.
+    nativeScaling: 2 # Smooths post processing.
     autoFlush: 1 # Fixes missing lights.
 SLUS-21241:
   name: "NHL '06"
@@ -62471,6 +63378,7 @@ SLUS-21242:
     autoFlush: 2 # Fixes blur and obscures sun behind objects.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     bilinearUpscale: 2 # Smooths out sun glare textures like native.
+    nativeScaling: 2 # Smooths speed blur and corrects some lighting.
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
   memcardFilters: # Reads Burnout 3 and NFL 06 saves for unlockables.
@@ -62487,7 +63395,8 @@ SLUS-21243:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
-    halfPixelOffset: 2 # Fixes blurriness.
+    halfPixelOffset: 4 # Aligns depth of field effect.
+    nativeScaling: 2 # Fixes post lighting.
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
   memcardFilters:
     - "SLUS-21359"
@@ -62596,14 +63505,16 @@ SLUS-21260:
   roundModes:
     eeRoundMode: 2 # Fixes missing text.
   gsHWFixes:
-    halfPixelOffset: 1 # Fixes ghosting.
+    halfPixelOffset: 4 # Aligns post processing.
+    nativeScaling: 2 # Fixes post effects.
 SLUS-21261:
   name: "Shadow the Hedgehog"
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
     recommendedBlendingLevel: 4 # Improves smoke rendering.
-    halfPixelOffset: 2 # Fixes misaligned lighting.
+    halfPixelOffset: 4 # Fixes post positioning.
+    nativeScaling: 2 # Fixes post effects.
 SLUS-21262:
   name: "Radiata Stories"
   region: "NTSC-U"
@@ -62699,6 +63610,7 @@ SLUS-21273:
   gsHWFixes:
     halfPixelOffset: 2 # Fix effects upscaling.
     autoFlush: 1 # Fixes broken post processing.
+    nativeScaling: 2 # Fixes post effects.
 SLUS-21274:
   name: "OutRun 2006 - Coast 2 Coast"
   region: "NTSC-U"
@@ -62779,6 +63691,9 @@ SLUS-21283:
   name: "Total Overdose - A Gunslinger's Tale in Mexico"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 1 # Fixes post processing smoothness and position.
 SLUS-21284:
   name: "Nicktoons Unite!"
   region: "NTSC-U"
@@ -62808,7 +63723,8 @@ SLUS-21287:
   compat: 5
   gsHWFixes:
     autoFlush: 1 # Reduces post-processing misalignment.
-    halfPixelOffset: 4 # Reduces post-processing misalignment.
+    halfPixelOffset: 4 # Fixes post positioning.
+    nativeScaling: 2 # Fixes post effects.
 SLUS-21288:
   name: "American Chopper 2"
   region: "NTSC-U"
@@ -62853,8 +63769,8 @@ SLUS-21295:
     vu1RoundMode: 0 # Crashes without.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes water and grass textures.
-    forceEvenSpritePosition: 1 # Reduces post-processing misalignment.
-    mergeSprite: 1 # Reduces post-processing misalignment.
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 1 # Fixes post processing smoothness and position.
     autoFlush: 1 # Improves post-processing rendering.
     preloadFrameData: 1 # Fixes missing loading screens.
   memcardFilters: # Game saves use the normal edition serial.
@@ -62953,7 +63869,8 @@ SLUS-21312:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 1 # Fixes misalignment/bloom when upscaling.
+    halfPixelOffset: 4 # Fixes post alignment.
+    nativeScaling: 1 # Fixes post effect.
 SLUS-21313:
   name: "Friends - The One with all the Trivia"
   region: "NTSC-U"
@@ -62966,6 +63883,7 @@ SLUS-21314:
     - EETimingHack # Needed to go ingame.
   gsHWFixes:
     halfPixelOffset: 4 # Fixes misalignment like volcano lighting.
+    nativeScaling: 1 # Makes the lava bloom look more correct (very minor shimmer).
   patches:
     F73488D5:
       content: |-
@@ -63186,6 +64104,7 @@ SLUS-21348:
     - EETimingHack # Fixes flickering.
   gsHWFixes:
     alignSprite: 1 # Helps align bloom.
+    nativeScaling: 2 # Fixes post processing and lighting smoothness.
 SLUS-21349:
   name: "Taito Legends 2"
   region: "NTSC-U"
@@ -63222,6 +64141,8 @@ SLUS-21355:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
+    halfPixelOffset: 2 # Aligns post bloom.
+    nativeScaling: 2 # Fixes light blooms.
     getSkipCount: "GSC_MidnightClub3"
   patches:
     60A42FF5:
@@ -63245,6 +64166,9 @@ SLUS-21358:
   name: "Naruto - Ultimate Ninja"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 2 # Aligns post effects.
+    nativeScaling: 2 # Fixes post effects.
 SLUS-21359:
   name: "Metal Gear Solid 3 - Subsistence [Disc 1 of 3]"
   region: "NTSC-U"
@@ -63255,7 +64179,8 @@ SLUS-21359:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
-    halfPixelOffset: 2 # Fixes blurriness.
+    halfPixelOffset: 4 # Aligns depth of field effect.
+    nativeScaling: 2 # Fixes post lighting.
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
 SLUS-21360:
   name: "Metal Gear Solid 3 - Subsistence [Disc 3 of 3]"
@@ -63266,7 +64191,8 @@ SLUS-21360:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
-    halfPixelOffset: 2 # Fixes blurriness.
+    halfPixelOffset: 4 # Aligns depth of field effect.
+    nativeScaling: 2 # Fixes post lighting.
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.
   memcardFilters:
     - "SLUS-21359"
@@ -63277,14 +64203,15 @@ SLUS-21361:
   roundModes:
     eeRoundMode: 0 # Fixes inability to enter door in Mission 18.
   gsHWFixes:
-    halfPixelOffset: 2 # Reduces ghosting but still an issue compared to native.
-    roundSprite: 2 # Clears up much of the blurring that HPO Special does not.
+    halfPixelOffset: 4 # Aligns post effects.
+    nativeScaling: 2 # Fixes post processing and lighting smoothness and position.
 SLUS-21362:
   name: "Onimusha - Dawn of Dreams [Disc 2 of 2]"
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes misalignment and upscaling lines.
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 2 # Fixes post processing smoothness and position.
   memcardFilters:
     - "SLUS-21180"
 SLUS-21363:
@@ -63351,7 +64278,8 @@ SLUS-21373:
   clampModes:
     eeClampMode: 2 # Fixes wrong color on some characters and breakable objects.
   gsHWFixes:
-    halfPixelOffset: 1 # Fixes ghosting characters.
+    halfPixelOffset: 4 # Fix effects upscaling.
+    nativeScaling: 2 # Fixes post effects.
     mergeSprite: 1 # Align sprite fixes FMVs but not garbage in-game, so needs merge sprite instead.
     texturePreloading: 1 # Performs better with partial preload because it is slow on locations outside gameplay foremost.
 SLUS-21374:
@@ -63376,6 +64304,8 @@ SLUS-21376:
     recommendedBlendingLevel: 4 # Improves lighting on buildings and objects.
     autoFlush: 2 # Properly diffuses light instead of strips of light.
     roundSprite: 1 # Fixes lighting misalignment such as the street poles and the sun.
+    halfPixelOffset: 2 # Mostly aligns post processing.
+    nativeScaling: 2 # Improves post processing smoothness.
     getSkipCount: "GSC_BlackAndBurnoutSky"
     beforeDraw: "OI_BurnoutGames"
   patches:
@@ -63446,7 +64376,8 @@ SLUS-21386:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes ghosting.
+    halfPixelOffset: 4 # Fixes post positioning.
+    nativeScaling: 1 # Fixes post effects.
     autoFlush: 2 # Fixes post lighting.
 SLUS-21387:
   name: "Warship Gunner 2"
@@ -63464,10 +64395,10 @@ SLUS-21389:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    autoFlush: 2
-    halfPixelOffset: 2 # Fixes lighting misalignment and reduces ground shadows.
-    roundSprite: 2 # Fixes font artifacts.
+    autoFlush: 1 # Fixes shadows.
     textureInsideRT: 1 # Fixes bad crystal surfaces.
+    halfPixelOffset: 4 # Fixes lighting misalignment.
+    nativeScaling: 2 # Fixes lighting smoothness.
   memcardFilters: # Allows import of Xenosaga II save data.
     - "SLUS-21389"
     - "SLUS-20892"
@@ -63530,6 +64461,9 @@ SLUS-21400:
   name: "Monster House"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 4 # Reduces post misalignment.
+    nativeScaling: 2 # Fixes remaining post misalignment.
 SLUS-21401:
   name: "Lucinda Green's Equestrian Challenge"
   region: "NTSC-U"
@@ -63575,7 +64509,8 @@ SLUS-21409:
   name: "LEGO Star Wars II - The Original Trilogy"
   region: "NTSC-U"
   gsHWFixes:
-    cpuCLUTRender: 1 # Fixes ghosting on objects and people.
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 1 # Fixes post processing smoothness and position.
   memcardFilters:
     - "SLUS-21409"
     - "SLUS-21083"
@@ -63599,6 +64534,7 @@ SLUS-21413:
   gsHWFixes:
     recommendedBlendingLevel: 3
     halfPixelOffset: 1 # Fixes misaligned bloom effects.
+    nativeScaling: 2 # Corrects post processing.
 SLUS-21414:
   name: "Delta Force - Black Hawk Down - Team Sabre"
   region: "NTSC-U"
@@ -63619,10 +64555,10 @@ SLUS-21417:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    autoFlush: 2
-    halfPixelOffset: 2 # Fixes lighting misalignment and reduces ground shadows.
-    roundSprite: 2 # Fixes font artifacts.
+    autoFlush: 1 # Fixes shadows.
     textureInsideRT: 1 # Fixes bad crystal surfaces.
+    halfPixelOffset: 4 # Fixes lighting misalignment.
+    nativeScaling: 2 # Fixes lighting smoothness.
   memcardFilters:
     - "SLUS-21389"
     - "SLUS-20892"
@@ -63714,7 +64650,8 @@ SLUS-21428:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    cpuCLUTRender: 1 # Fixes ghosting on objects and people.
+    halfPixelOffset: 2 # Aligns post effects.
+    nativeScaling: 2 # Fixes post processing and position.
 SLUS-21430:
   name: "IGPX - Immortal Grand Prix"
   region: "NTSC-U"
@@ -63752,7 +64689,8 @@ SLUS-21436:
   compat: 5
   gsHWFixes:
     recommendedBlendingLevel: 3 # High blending accuracy fixes notoriously broken water.
-    halfPixelOffset: 1 # Fixes ghosting.
+    halfPixelOffset: 2 # Fixes ghosting.
+    nativeScaling: 2 # Fixes artifacts due to upscaling.
 SLUS-21437:
   name: "Disney's Kim Possible - What's the Switch"
   region: "NTSC-U"
@@ -63770,10 +64708,9 @@ SLUS-21439:
     eeClampMode: 3 # Fixes material stretching across screen that appears for a split second.
   gsHWFixes:
     textureInsideRT: 1 # Fixes shadow maps.
-    roundSprite: 2 # Fixes misaligned bloom.
-    mergeSprite: 1 # Fixes misaligned bloom.
     halfPixelOffset: 2 # Fixes misaligned bloom.
     autoFlush: 2 # Fixes sun occlusion and brightness.
+    nativeScaling: 2 # Fixes post processing and lighting smoothness and position.
 SLUS-21440:
   name: "Big Idea's VeggieTales - LarryBoy and the Bad Apple"
   region: "NTSC-U"
@@ -63782,7 +64719,8 @@ SLUS-21441:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes character outlines and minor bloom.
+    halfPixelOffset: 4 # Aligns post effects.
+    nativeScaling: 2 # Fixes post processing and lighting smoothness and position.
     beforeDraw: "OI_DBZBTGames"
 SLUS-21442:
   name: "Super Dragon Ball Z"
@@ -63801,6 +64739,8 @@ SLUS-21444:
     vu1RoundMode: 0 # Fixes invalid VU size spam and likely SPS.
   gsHWFixes:
     autoFlush: 1 # Fixes black line down the side of the screen and player shadow.
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 1 # Fixes post processing smoothness and position.
 SLUS-21445:
   name: "Ar tonelico - Melody of Elemia"
   region: "NTSC-U"
@@ -63832,6 +64772,8 @@ SLUS-21449:
     recommendedBlendingLevel: 4 # Fixes car reflections.
     mergeSprite: 1 # Fixes bluriness.
     halfPixelOffset: 4 # Fixes bluriness.
+    nativeScaling: 1 # Fixes post lighting.
+    autoFlush: 1 # Fixes post alignment.
 SLUS-21450:
   name: "Super PickUps"
   region: "NTSC-U"
@@ -63847,10 +64789,10 @@ SLUS-21452:
   gameFixes:
     - VuAddSubHack
   gsHWFixes:
-    halfPixelOffset: 2 # Reduces bloom misalignment.
-    roundSprite: 1 # Fixes area transition vertical lines and lessens red forest vertical lines.
+    halfPixelOffset: 4 # Reduces bloom misalignment.
     textureInsideRT: 1 # Required for swirl battle transition.
     nativePaletteDraw: 1
+    nativeScaling: 2 # Fixes depth of field effects and bloom.
 SLUS-21453:
   name: "Disney's Meet the Robinsons"
   region: "NTSC-U"
@@ -63874,8 +64816,8 @@ SLUS-21456:
   roundModes:
     vu1RoundMode: 0 # Crashes without.
   gsHWFixes:
-    forceEvenSpritePosition: 1 # Reduces post-processing misalignment.
-    mergeSprite: 1 # Reduces post-processing misalignment.
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 1 # Fixes post processing smoothness and position.
 SLUS-21457:
   name: "World Championship Paintball"
   region: "NTSC-U"
@@ -64079,6 +65021,7 @@ SLUS-21492:
     autoFlush: 2 # Fixes post processing overlay.
     roundSprite: 1 # Greatly reduces chromatic effect when upscaling.
     forceEvenSpritePosition: 1 # Fixes chromatic fringing.
+    nativeScaling: 1 # Fixes post processing effect and position.
 SLUS-21493:
   name: "Need for Speed - Carbon"
   region: "NTSC-U"
@@ -64114,7 +65057,8 @@ SLUS-21498:
   gameFixes:
     - OPHFlagHack
   gsHWFixes:
-    mergeSprite: 1 # Reduces bloom but fixes blurriness around models + Recommended to use Shadeboost brightness 80.
+    halfPixelOffset: 2 # Aligns post effects.
+    nativeScaling: 2 # Fixes post effects.
 SLUS-21499:
   name: "Corvette Evolution GT"
   region: "NTSC-U"
@@ -64161,9 +65105,9 @@ SLUS-21541:
   roundModes:
     vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
   gsHWFixes:
-    halfPixelOffset: 2 # Reduces blooming misalignment.
-    forceEvenSpritePosition: 1 # Reduces blooming misalignment.
     autoFlush: 2 # Fixes glows.
+    halfPixelOffset: 4 # Aligns Post Effect.
+    nativeScaling: 2 # Fixes Post effect.
 SLUS-21542:
   name: "Sega Genesis Collection"
   region: "NTSC-U"
@@ -64322,6 +65266,9 @@ SLUS-21575:
   clampModes:
     vu0ClampMode: 0 # Fixes glow effects.
     vu1ClampMode: 3 # Fixes rare SPS.
+  gsHWFixes:
+    halfPixelOffset: 2 # Aligns post effects.
+    nativeScaling: 2 # Fixes post effects.
 SLUS-21576:
   name: "Rayman - Raving Rabbids"
   region: "NTSC-U"
@@ -64373,6 +65320,9 @@ SLUS-21586:
   compat: 5
   roundModes:
     vu1RoundMode: 0 # Massages the Z on the score meter for hardware mode, software doesn't really need this.
+  gsHWFixes:
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 1 # Fixes post processing smoothness and position.
 SLUS-21587:
   name: "Made Man - Confessions of the Family Blood"
   region: "NTSC-U"
@@ -64412,6 +65362,9 @@ SLUS-21594:
   compat: 5
   gameFixes:
     - OPHFlagHack # Fixes game freezing.
+  gsHWFixes:
+    halfPixelOffset: 2 # Aligns post effects.
+    nativeScaling: 2 # Fixes post effects.
 SLUS-21595:
   name: "T.M.N.T. - Teenage Mutant Ninja Turtles"
   region: "NTSC-U"
@@ -64428,6 +65381,7 @@ SLUS-21596:
     autoFlush: 2 # Fixes blur and obscures sun behind objects.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     bilinearUpscale: 2 # Smooths out sun glare textures like native.
+    nativeScaling: 2 # Smooths speed blur and corrects some lighting.
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
 SLUS-21597:
@@ -64475,6 +65429,9 @@ SLUS-21602:
   name: "Transformers - The Game"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes alignment of post processing.
+    nativeScaling: 1 # Fixes post processing effect.
 SLUS-21603:
   name: "Soul Nomad & The World Eaters"
   region: "NTSC-U"
@@ -64499,7 +65456,8 @@ SLUS-21607:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes lighting on mushrooms + others.
+    halfPixelOffset: 1 # Reduces post misalignment.
+    nativeScaling: 1 # Fixes remaining post misalignment.
   patches:
     B80CE8EC:
       content: |-
@@ -64522,7 +65480,8 @@ SLUS-21611:
     vu1ClampMode: 3 # Fixes texture corruption light shimmering and reflective surfaces.
   gsHWFixes:
     recommendedBlendingLevel: 3
-    halfPixelOffset: 1 # Fixes misaligned bloom effects.
+    halfPixelOffset: 4 # Fixes misaligned bloom effects.
+    nativeScaling: 2 # Fixes bloom effects.
 SLUS-21612:
   name: "Legend of the Dragon"
   region: "NTSC-U"
@@ -64563,6 +65522,9 @@ SLUS-21616:
   compat: 5
   roundModes:
     vu1RoundMode: 0 # Fixes SPS and VU size spam.
+  gsHWFixes:
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 1 # Fixes post processing smoothness and position.
 SLUS-21617:
   name: "Spiderman 3"
   region: "NTSC-U"
@@ -64601,6 +65563,7 @@ SLUS-21622:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 4 # Fixes bloom on sunlight.
+    nativeScaling: 2 # Fixes lighting positioning.
 SLUS-21623:
   name: "The Bigs"
   name-sort: "Bigs, The"
@@ -64852,6 +65815,8 @@ SLUS-21672:
   gsHWFixes:
     textureInsideRT: 1 # Crowd textures.
     autoFlush: 1 # Fixes bloom intensity.
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 1 # Fixes post processing smoothness and position.
 SLUS-21673:
   name: "College Hoops 2K8"
   region: "NTSC-U"
@@ -64883,13 +65848,16 @@ SLUS-21678:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes character outlines and minor bloom.
-    cpuCLUTRender: 1 # Aligns character bloom and some stage bloom.
+    halfPixelOffset: 4 # Aligns post effects.
+    nativeScaling: 2 # Fixes post processing and lighting smoothness and position.
     beforeDraw: "OI_DBZBTGames"
 SLUS-21679:
   name: "Power Rangers - Super Legends"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 2 # Fixes post processing position.
 SLUS-21680:
   name: "Harvey Birdman - Attorney at Law"
   region: "NTSC-U"
@@ -65119,6 +66087,9 @@ SLUS-21727:
     vuClampMode: 2 # Fixes invisible QTE button prompts and overbright in some scenes.
   gameFixes:
     - SoftwareRendererFMVHack # Fixes vertical lines in FMVs.
+  gsHWFixes:
+    halfPixelOffset: 2 # Aligns post effects.
+    nativeScaling: 2 # Fixes post effects.
 SLUS-21728:
   name: "Crash - Mind Over Mutant"
   region: "NTSC-U"
@@ -65163,7 +66134,8 @@ SLUS-21733:
   gameFixes:
     - VUSyncHack # Fixes SPS.
   gsHWFixes:
-    halfPixelOffset: 1 # Fixes post bloom alignment.
+    halfPixelOffset: 4 # Correct shadow position.
+    nativeScaling: 2 # Smooths shadows.
 SLUS-21734:
   name: "Falling Stars"
   region: "NTSC-U"
@@ -65185,10 +66157,8 @@ SLUS-21736:
   roundModes:
     vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
   gsHWFixes:
-    cpuSpriteRenderBW: 2 # Fixes bloom on HW renderer.
-    cpuSpriteRenderLevel: 2 # Needed for above.
-    halfPixelOffset: 4 # Reduces the ghosting effect.
-    roundSprite: 2 # Reduces the ghosting effect.
+    halfPixelOffset: 4 # Aligns Post Effect.
+    nativeScaling: 2 # Fixes Post effect.
 SLUS-21737:
   name: "Riding Star"
   region: "NTSC-U"
@@ -65202,7 +66172,8 @@ SLUS-21739:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes misaligned bloom.
+    halfPixelOffset: 4 # Fixes post positioning.
+    nativeScaling: 2 # Fixes post effects.
 SLUS-21740:
   name: "Guitar Hero - Aerosmith"
   region: "NTSC-U"
@@ -65212,6 +66183,8 @@ SLUS-21740:
   gsHWFixes:
     textureInsideRT: 1 # Crowd textures.
     autoFlush: 1 # Fixes bloom intensity.
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 1 # Fixes post processing smoothness and position.
 SLUS-21741:
   name: "Sea Monsters - A Prehistoric Adventure"
   region: "NTSC-U"
@@ -65293,7 +66266,7 @@ SLUS-21756:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Reduces ghosting but on normal vertex is less ghosting but causes corruption at the sides.
-    cpuCLUTRender: 1 # Fixes title-screen bloom and church windows on new game and other locations.
+    nativeScaling: 1 # Fixes post processing position.
 SLUS-21757:
   name: "DreamWorks Kung Fu Panda"
   region: "NTSC-U"
@@ -65309,7 +66282,8 @@ SLUS-21759:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 1 # Corrects bloom misalignment.
+    halfPixelOffset: 4 # Fixes post positioning.
+    nativeScaling: 1 # Fixes post effects.
 SLUS-21760:
   name: "Jeep Thrills"
   region: "NTSC-U"
@@ -65322,6 +66296,8 @@ SLUS-21761:
   compat: 5
   gsHWFixes:
     autoFlush: 1 # Fixes lighting.
+    halfPixelOffset: 4 # Aligns post effects.
+    nativeScaling: 1 # Fixes post processing position.
 SLUS-21763:
   name: "NHL 2K9"
   region: "NTSC-U"
@@ -65361,6 +66337,7 @@ SLUS-21769:
   compat: 5
   gsHWFixes:
     alignSprite: 1 # Helps align bloom.
+    nativeScaling: 2 # Fixes post processing and lighting smoothness.
   memcardFilters: # Allows import of Yakuza 1 data.
     - "SLUS-21769"
     - "SLUS-21348"
@@ -65436,6 +66413,9 @@ SLUS-21781:
     instantVU1: 0 # Corrects note board position.
   roundModes:
     vu1RoundMode: 0 # Fixes graphical issues ingame.
+  gsHWFixes:
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 1 # Fixes post processing smoothness and position.
 SLUS-21782:
   name: "Shin Megami Tensei - Persona 4"
   region: "NTSC-U"
@@ -65453,8 +66433,8 @@ SLUS-21785:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    cpuCLUTRender: 1 # Fixes ghosting on objects and people.
-    halfPixelOffset: 2 # Fixes depth line. HPO Normal required if not using CLUT Renderer.
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 1 # Fixes post processing smoothness and position.
 SLUS-21786:
   name: "Summer Athletics - The Ultimate Challenge"
   region: "NTSC-U"
@@ -65552,6 +66532,9 @@ SLUS-21805:
 SLUS-21806:
   name: "Barbie Horse Adventures - Riding Camp"
   region: "NTSC-U"
+  gsHWFixes:
+    halfPixelOffset: 4 # Fixes post positioning.
+    nativeScaling: 1 # Fixes post effects.
 SLUS-21807:
   name: "Monster Jam - Urban Assault"
   region: "NTSC-U"
@@ -65619,9 +66602,8 @@ SLUS-21820:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes ghosting and bloom misalignment.
-    cpuSpriteRenderBW: 1 # Rainbow spots if alone applied but needs cpuCLUTrender to look like software mode.
-    cpuCLUTRender: 1 # Blue horizontal lines on it's own but needs cpuSpriteRenderBW to look like software mode.
+    halfPixelOffset: 4 # Reduces post misalignment.
+    nativeScaling: 2 # Fixes remaining post misalignment.
 SLUS-21821:
   name: "Pro Evolution Soccer 2009"
   region: "NTSC-U"
@@ -65697,6 +66679,8 @@ SLUS-21843:
     vu1RoundMode: 0 # Crashes without.
   gsHWFixes:
     cpuCLUTRender: 1 # Fixes bad colours during play.
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 1 # Fixes post processing smoothness and position.
 SLUS-21844:
   name: "Bolt"
   region: "NTSC-U"
@@ -65762,6 +66746,8 @@ SLUS-21858:
   gsHWFixes:
     textureInsideRT: 1 # Needed for post processing effects.
     autoFlush: 1 # Fixes missing blur layer.
+    nativeScaling: 1 # Fixes post processing.
+    halfPixelOffset: 4 # Fixes offset post processing.
 SLUS-21860:
   name: "The Bigs 2"
   name-sort: "Bigs 2, The"
@@ -65776,8 +66762,8 @@ SLUS-21862:
   gameFixes:
     - SoftwareRendererFMVHack # Fixes vertical lines in FMVs.
   gsHWFixes:
-    roundSprite: 2 # Corrects post processing position + fixes subsequent runs of starter FMV vertical lines.
-    cpuCLUTRender: 1 # Reduces the bloomy blur of characters.
+    halfPixelOffset: 2 # Aligns post effects.
+    nativeScaling: 2 # Fixes post effects.
   clampModes:
     vu0ClampMode: 3 # Fixes bad dialog backgrounds.
     vu1ClampMode: 3 # Fixes SPS on characters.
@@ -65794,12 +66780,18 @@ SLUS-21865:
   compat: 5
   roundModes:
     vu1RoundMode: 0 # Fixes SPS and VU size spam.
+  gsHWFixes:
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 1 # Fixes post processing smoothness and position.
 SLUS-21866:
   name: "Guitar Hero - Smash Hits"
   region: "NTSC-U"
   compat: 5
   roundModes:
     vu1RoundMode: 0 # Fixes VU size spam and potential graphical issues with GH3 engine.
+  gsHWFixes:
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 1 # Fixes post processing smoothness and position.
 SLUS-21867:
   name: "Guitar Hero - Van Halen"
   region: "NTSC-U"
@@ -65807,6 +66799,8 @@ SLUS-21867:
   gsHWFixes:
     preloadFrameData: 1 # Fixes icons.
     autoFlush: 1 # Fixes bloom intensity.
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 1 # Fixes post processing smoothness and position.
   roundModes:
     vu1RoundMode: 0 # Fixes VU size spam and potential graphical issues with GH3 engine.
 SLUS-21868:
@@ -65877,7 +66871,8 @@ SLUS-21881:
   compat: 5
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes textures.
-    halfPixelOffset: 2 # Fixes misaligned bloom.
+    halfPixelOffset: 4 # Aligns post processing, needed for below, but does cause a line around the edge, can be cropped out with 3 px left and top.
+    nativeScaling: 2 # Fixes post processing smoothness, causes edge bleed without Align to Native.
     autoFlush: 2 # Fixes soft shadows.
   patches:
     137C792E:
@@ -65900,7 +66895,8 @@ SLUS-21885:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 1 # Fixes ghosting.
+    halfPixelOffset: 4 # Reduces post misalignment.
+    nativeScaling: 2 # Fixes remaining post misalignment.
 SLUS-21886:
   name: "G.I. Joe - The Rise of Cobra"
   region: "NTSC-U"
@@ -65959,6 +66955,7 @@ SLUS-21898:
   gsHWFixes:
     autoFlush: 1 # Fixes character shadow misalignment.
     preloadFrameData: 1 # Fixes icons.
+    halfPixelOffset: 4 # Aligns UI and other elements.
 SLUS-21899:
   name: "Silent Hill - Shattered Memories"
   region: "NTSC-U"
@@ -66069,6 +67066,8 @@ SLUS-21924:
   gsHWFixes:
     preloadFrameData: 1 # Fixes icons.
     autoFlush: 1 # Fixes bloom intensity.
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 1 # Fixes post processing smoothness and position.
   roundModes:
     vu1RoundMode: 0 # Fixes VU size spam and potential graphical issues with GH3 engine.
 SLUS-21926:
@@ -66104,8 +67103,8 @@ SLUS-21931:
   roundModes:
     vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
   gsHWFixes:
-    halfPixelOffset: 2 # Reduces the ghosting effect.
-    forceEvenSpritePosition: 1 # Reduces the ghosting effect.
+    halfPixelOffset: 4 # Aligns Post Effect.
+    nativeScaling: 2 # Fixes Post effect.
 SLUS-21932:
   name: "NCAA Football 11"
   region: "NTSC-U"
@@ -66281,7 +67280,7 @@ SLUS-28023:
   name: ".hack Infection Part 1 [Trade Demo]"
   region: "NTSC-U"
   gsHWFixes:
-    halfPixelOffset: 1 # Sharpens world in far distances.
+    halfPixelOffset: 2 # Aligns DoF effects.
 SLUS-28025:
   name: "Disaster Report [Trade Demo]"
   region: "NTSC-U"
@@ -66537,7 +67536,7 @@ SLUS-29042:
   name: ".hack Infection Part 1 [Regular Demo]"
   region: "NTSC-U"
   gsHWFixes:
-    halfPixelOffset: 1 # Sharpens world in far distances.
+    halfPixelOffset: 2 # Aligns DoF effects.
 SLUS-29044:
   name: "Pride FC - Fighting Championships [Demo]"
   region: "NTSC-U"
@@ -66550,6 +67549,10 @@ SLUS-29047:
 SLUS-29048:
   name: "Splinter Cell [Demo]"
   region: "NTSC-U"
+  gsHWFixes:
+    halfPixelOffset: 4 # Aligns post processing.
+    nativeScaling: 2 # Fixes post effects.
+    recommendedBlendingLevel: 4 # Fixes lighting effects but has high barrier count.
 SLUS-29049:
   name: "Warhammer 40,000 - Fire Warrior [Demo]"
   region: "NTSC-U"
@@ -66616,7 +67619,8 @@ SLUS-29069:
   region: "NTSC-U"
   gsHWFixes:
     autoFlush: 2 # Reduces post-processing misalignment.
-    halfPixelOffset: 4 # Reduces post-processing misalignment.
+    halfPixelOffset: 4 # Fixes post positioning.
+    nativeScaling: 2 # Fixes post effects.
 SLUS-29070:
   name: "XIII [Demo]"
   region: "NTSC-U"
@@ -66744,6 +67748,9 @@ SLUS-29107:
 SLUS-29108:
   name: "Def Jam - Fight For NY [Demo]"
   region: "NTSC-U"
+  gsHWFixes:
+    halfPixelOffset: 4 # Reduces post misalignment.
+    nativeScaling: 2 # Fixes remaining post misalignment.
 SLUS-29110:
   name: "Monster Hunter [Public Beta Vol.1 - Ver.1.01]"
   region: "NTSC-U"
@@ -66765,6 +67772,7 @@ SLUS-29113:
     autoFlush: 2 # Fixes blur and obscures sun behind objects.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     bilinearUpscale: 2 # Smooths out sun glare textures like native.
+    nativeScaling: 2 # Smooths speed blur and corrects some lighting.
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
 SLUS-29116:
@@ -66792,10 +67800,10 @@ SLUS-29123:
     - SoftwareRendererFMVHack # Fixes hash cache disabling itself.
   gsHWFixes:
     recommendedBlendingLevel: 4 # Improves banding and effect emulation.
-    halfPixelOffset: 3 # Fixes texture and lighting misalignment.
-    mergeSprite: 1 # Fixes most vertical lines and lighting misalignment.
     autoFlush: 1 # Fixes light bloom intensity.
     estimateTextureRegion: 1 # Improves performance and reduces hash cache size.
+    halfPixelOffset: 4 # Aligns post effects.
+    nativeScaling: 1 # Fixes post effects.
     getSkipCount: "GSC_GiTS"
 SLUS-29124:
   name: "Fight Club [Demo]"
@@ -66821,11 +67829,13 @@ SLUS-29130:
   name: "Crash 'N' Burn [Public Beta Vol.1.0]"
   region: "NTSC-U"
 SLUS-29131:
-  name: "Project Snowblind [Public Beta Vol.1.0]"
+  name: "Project - Snowblind [Public Beta Vol.1.0]"
   region: "NTSC-U"
   gsHWFixes:
     autoFlush: 1 # Fixes the post processing positioning.
     textureInsideRT: 1 # Fixes post processing.
+    halfPixelOffset: 4 # Aligns bloom effect.
+    nativeScaling: 2 # Fixes post processing smoothness and position.
 SLUS-29132:
   name: "S.L.A.I. - Steel Lancer Arena International - Phantom Crash [Public Beta Vol.1.0]"
   region: "NTSC-U"
@@ -66845,6 +67855,7 @@ SLUS-29137:
   region: "NTSC-U"
   gsHWFixes:
     autoFlush: 2 # Fixes missing lighting.
+    nativeScaling: 1 # Fixes post lighting.
     # halfPixelOffset: 1 # Fixes lighting misalignment. Do not enable this, it breaks a lot of graphics.
 SLUS-29138:
   name: "The Punisher [Demo]"
@@ -66857,7 +67868,8 @@ SLUS-29139:
   name: "Shadow of Rome [Demo]"
   region: "NTSC-U"
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes blurriness and misaligned garbage when upscaling.
+    halfPixelOffset: 4 # Fixes post positioning.
+    nativeScaling: 2 # Fixes post effects.
 SLUS-29140:
   name: "MX vs. ATV Unleashed [Demo]"
   region: "NTSC-U"
@@ -66887,7 +67899,8 @@ SLUS-29148:
     eeCycleRate: 1 # Fixes occasional post process flickering.
   gsHWFixes:
     nativePaletteDraw: 1 # Fixes lines in certain effects when upscaled.
-    halfPixelOffset: 2 # Fixes offset bloom.
+    halfPixelOffset: 4 # Fixes post positioning.
+    nativeScaling: 1 # Fixes post effects.
 SLUS-29149:
   name: "Flipnic - Ultimate Pinball [Demo]"
   region: "NTSC-U"
@@ -66898,10 +67911,9 @@ SLUS-29150:
   region: "NTSC-U"
   gsHWFixes:
     textureInsideRT: 1 # Fixes shadow maps.
-    roundSprite: 2 # Fixes misaligned bloom.
-    mergeSprite: 1 # Fixes misaligned bloom.
     halfPixelOffset: 2 # Fixes misaligned bloom.
     autoFlush: 2 # Fixes sun occlusion and brightness.
+    nativeScaling: 2 # Fixes post processing and lighting smoothness and position.
 SLUS-29151:
   name: "Enthusia - Professional Racing"
   region: "NTSC-U"
@@ -66926,6 +67938,7 @@ SLUS-29153:
     autoFlush: 2 # Fixes blur and obscures sun behind objects.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
     bilinearUpscale: 2 # Smooths out sun glare textures like native.
+    nativeScaling: 2 # Smooths speed blur and corrects some lighting.
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
 SLUS-29154:
@@ -66980,7 +67993,8 @@ SLUS-29164:
   name: "Star Wars - Battlefront II [Online Public Beta]"
   region: "NTSC-U"
   gsHWFixes:
-    halfPixelOffset: 1 # Fixes bloom misalignment.
+    halfPixelOffset: 4 # Corrects post processing positioning.
+    nativeScaling: 2 # Smooths post processing.
     autoFlush: 1 # Fixes missing lights.
 SLUS-29167:
   name: "007 - From Russia with Love, Need for Speed - Most Wanted, SSX World Tour [Demo]"
@@ -67008,6 +68022,9 @@ SLUS-29169:
 SLUS-29170:
   name: "Total Overdose - A Gunslinger's Tale in Mexico [Demo]"
   region: "NTSC-U"
+  gsHWFixes:
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 1 # Fixes post processing smoothness and position.
 SLUS-29171:
   name: "Final Fantasy XII [Demo]"
   region: "NTSC-U"
@@ -67046,6 +68063,8 @@ SLUS-29178:
     roundSprite: 1 # Fixes misaligned map.
     skipDrawStart: 1 # Removes large black box around player car till we properly emulate it.
     skipDrawEnd: 1 # Removes large black box around player car till we properly emulate it.
+    halfPixelOffset: 2 # Fixes depth of field alignment.
+    nativeScaling: 1 # Fixes depth of field.
 SLUS-29179:
   name: "Sonic Riders [Demo]"
   region: "NTSC-U"
@@ -67058,6 +68077,8 @@ SLUS-29180:
     recommendedBlendingLevel: 4 # Improves lighting on buildings and objects.
     autoFlush: 2 # Properly diffuses light instead of strips of light.
     roundSprite: 1 # Fixes lighting misalignment such as the street poles and the sun.
+    halfPixelOffset: 2 # Mostly aligns post processing.
+    nativeScaling: 2 # Improves post processing smoothness.
     getSkipCount: "GSC_BlackAndBurnoutSky"
     beforeDraw: "OI_BurnoutGames"
 SLUS-29183:
@@ -67117,15 +68138,15 @@ SLUS-29195:
     - EETimingHack # Fixes flickering.
   gsHWFixes:
     alignSprite: 1 # Helps align bloom.
+    nativeScaling: 2 # Fixes post processing and lighting smoothness.
 SLUS-29196:
   name: "Destroy All Humans! 2 [Demo]"
   region: "NTSC-U"
   gsHWFixes:
     textureInsideRT: 1 # Fixes shadow maps.
-    roundSprite: 2 # Fixes misaligned bloom.
-    mergeSprite: 1 # Fixes misaligned bloom.
     halfPixelOffset: 2 # Fixes misaligned bloom.
     autoFlush: 2 # Fixes sun occlusion and brightness.
+    nativeScaling: 2 # Fixes post processing and lighting smoothness and position.
 SLUS-29197:
   name: "DreamWorks & Aardman Flushed Away [Demo]"
   region: "NTSC-U"
@@ -67179,7 +68200,8 @@ TCES-52004:
   clampModes:
     vuClampMode: 0 # Resolves I Reg Clamping / performance impact and yellow graphics in certain areas.
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes blurriness.
+    halfPixelOffset: 4 # Fixes post positioning.
+    nativeScaling: 2 # Fixes post effects.
 TCES-52033:
   name: "Syphon Filter - The Omega Strain Beta Trial Code"
   region: "PAL-E"
@@ -67220,7 +68242,8 @@ TCES-52456:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves color and luminosity of surfaces.
     disablePartialInvalidation: 1 # Prevents the situation that a level (Aquatos) doesn't render characters and geometry.
-    halfPixelOffset: 2 # Fixes misaligned bloom.
+    halfPixelOffset: 4 # Aligns post bloom.
+    nativeScaling: 1 # Fixes light blooms.
     autoFlush: 2 # Helps fix misaligned bloom.
 TCES-52582:
   name: "Everybody's Golf 4 Beta Trial Code"
@@ -67512,5 +68535,6 @@ TLES-82043:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
-    halfPixelOffset: 2 # Fixes blurriness.
+    halfPixelOffset: 4 # Aligns depth of field effect.
+    nativeScaling: 2 # Fixes post lighting.
     getSkipCount: "GSC_MetalGearSolid3" # Fixes depth of field blur.

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -194,6 +194,7 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* dialog, QWidget* 
 	// HW Upscaling Fixes
 	//////////////////////////////////////////////////////////////////////////
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.halfPixelOffset, "EmuCore/GS", "UserHacks_HalfPixelOffset", 0);
+	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.nativeScaling, "EmuCore/GS", "UserHacks_native_scaling", 0);
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.roundSprite, "EmuCore/GS", "UserHacks_round_sprite_offset", 0);
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.bilinearHack, "EmuCore/GS", "UserHacks_BilinearHack", 0);
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.textureOffsetX, "EmuCore/GS", "UserHacks_TCOffsetX", 0);
@@ -1139,6 +1140,7 @@ void GraphicsSettingsWidget::resetManualHardwareFixes()
 		check_bool("EmuCore/GS", "UserHacks_EstimateTextureRegion", false);
 		check_bool("EmuCore/GS", "paltex", false);
 		check_int("EmuCore/GS", "UserHacks_HalfPixelOffset", 0);
+		check_int("EmuCore/GS", "UserHacks_native_scaling", static_cast<int>(GSNativeScaling::Off));
 		check_int("EmuCore/GS", "UserHacks_round_sprite_offset", 0);
 		check_int("EmuCore/GS", "UserHacks_TCOffsetX", 0);
 		check_int("EmuCore/GS", "UserHacks_TCOffsetY", 0);

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
@@ -1091,13 +1091,39 @@
         </widget>
        </item>
        <item row="1" column="0">
+        <widget class="QLabel" name="nativeScalingLabel">
+         <property name="text">
+          <string>Native Scaling</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="QComboBox" name="nativeScaling">
+         <item>
+          <property name="text">
+           <string>Off</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Normal</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Aggressive</string>
+          </property>
+         </item>
+        </widget>
+       </item>
+       <item row="2" column="0">
         <widget class="QLabel" name="roundSpriteLabel">
          <property name="text">
           <string>Round Sprite:</string>
          </property>
         </widget>
        </item>
-       <item row="1" column="1">
+       <item row="2" column="1">
         <widget class="QComboBox" name="roundSprite">
          <item>
           <property name="text">
@@ -1117,13 +1143,39 @@
         </widget>
        </item>
        <item row="3" column="0">
+        <widget class="QLabel" name="bilinearHackLabel">
+         <property name="text">
+          <string>Bilinear Dirty Upscale:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="1">
+        <widget class="QComboBox" name="bilinearHack">
+         <item>
+          <property name="text">
+           <string>Automatic (Default)</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Force Bilinear</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Force Nearest</string>
+          </property>
+         </item>
+        </widget>
+       </item>
+       <item row="4" column="0">
         <widget class="QLabel" name="textureOffsetLabel">
          <property name="text">
           <string>Texture Offsets:</string>
          </property>
         </widget>
        </item>
-       <item row="3" column="1">
+       <item row="4" column="1">
         <layout class="QHBoxLayout" name="textureOffsetLayout" stretch="0,1,0,1">
          <item>
           <widget class="QLabel" name="textureOffsetXLabel">
@@ -1155,7 +1207,7 @@
          </item>
         </layout>
        </item>
-       <item row="4" column="0" colspan="2">
+       <item row="5" column="0" colspan="2">
         <layout class="QGridLayout" name="upscalingFixesLayout_2">
          <item row="0" column="0">
           <widget class="QCheckBox" name="alignSprite">
@@ -1171,13 +1223,6 @@
            </property>
           </widget>
          </item>
-         <item row="1" column="1">
-          <widget class="QCheckBox" name="forceEvenSpritePosition">
-           <property name="text">
-            <string>Force Even Sprite Position</string>
-           </property>
-          </widget>
-         </item>
          <item row="1" column="0">
           <widget class="QCheckBox" name="mergeSprite">
            <property name="text">
@@ -1185,33 +1230,14 @@
            </property>
           </widget>
          </item>
+         <item row="1" column="1">
+          <widget class="QCheckBox" name="forceEvenSpritePosition">
+           <property name="text">
+            <string>Force Even Sprite Position</string>
+           </property>
+          </widget>
+         </item>
         </layout>
-       </item>
-       <item row="2" column="0">
-        <widget class="QLabel" name="bilinearHackLabel">
-         <property name="text">
-          <string>Bilinear Dirty Upscale:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="1">
-        <widget class="QComboBox" name="bilinearHack">
-         <item>
-          <property name="text">
-           <string>Automatic (Default)</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Force Bilinear</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Force Nearest</string>
-          </property>
-         </item>
-        </widget>
        </item>
       </layout>
      </widget>

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -387,6 +387,14 @@ enum class GSHalfPixelOffset : u8
 	MaxCount
 };
 
+enum class GSNativeScaling : u8
+{
+	Off,
+	Normal,
+	Aggressive,
+	MaxCount
+};
+
 // --------------------------------------------------------------------------------------
 //  TraceFiltersEE
 // --------------------------------------------------------------------------------------
@@ -692,6 +700,7 @@ struct Pcsx2Config
 		GSHWAutoFlushLevel UserHacks_AutoFlush = GSHWAutoFlushLevel::Disabled;
 		GSHalfPixelOffset UserHacks_HalfPixelOffset = GSHalfPixelOffset::Off;
 		s8 UserHacks_RoundSprite = 0;
+		GSNativeScaling UserHacks_NativeScaling = GSNativeScaling::Off;
 		s32 UserHacks_TCOffsetX = 0;
 		s32 UserHacks_TCOffsetY = 0;
 		u8 UserHacks_CPUSpriteRenderBW = 0;

--- a/pcsx2/Docs/GameIndex.md
+++ b/pcsx2/Docs/GameIndex.md
@@ -179,6 +179,7 @@ The clamp modes are also numerically based.
 * skipDrawStart              [Value between `0` to `10000`]             {0-10000}                          Default: Off (`0`)
 * skipDrawEnd                [Value between `0` to `10000`]             {0-10000}                          Default: Off (`0`)
 * halfPixelOffset            [`0` or `1` or `2` or `3` or `4`] {Off, Normal Vertex, Special (Texture), Special (Texture Aggressive), Align to Native} Default: Off (`0`)
+* nativeScaling              [`0` or `1` or `2`]    {Normal, Aggressive or Off}             Default: Normal (`0`)
 * nativePaletteDraw          [`0` or `1`]           {Off, On}                               Default: Off (`0`)
 * roundSprite                [`0` or `1` or `2`]    {Off, Half or Full}                     Default: Off (`0`)
 

--- a/pcsx2/Docs/gamedb-schema.json
+++ b/pcsx2/Docs/gamedb-schema.json
@@ -239,6 +239,11 @@
               "minimum": 0,
               "maximum": 4
             },
+            "nativeScaling": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 2
+            },
             "roundSprite": {
               "type": "integer",
               "minimum": 0,

--- a/pcsx2/GS/GSRegs.h
+++ b/pcsx2/GS/GSRegs.h
@@ -531,6 +531,7 @@ REG_END2
 
 	// output will be Cd, Cs is discarded
 	__forceinline bool IsCdOutput() const { return (C == 2 && D != 1 && FIX == 0x00); }
+	__forceinline bool IsCdInBlend() const { return (A == 1 || B == 1 || D == 1); }
 	__forceinline bool IsUsingCs() const { return (A == 0 || B == 0 || D == 0); }
 	__forceinline bool IsUsingAs() const { return (A != B && C == 0); }
 

--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -3082,7 +3082,7 @@ bool GSState::PrimitiveCoversWithoutGaps()
 			}
 			else
 			{
-				if (std::abs(dpX - first_dpX) >= 16 || std::abs(this_start_X - last_pX) >= 16)
+				if ((std::abs(dpX - first_dpX) >= 16 && (i + 2) < m_vertex.next) || std::abs(this_start_X - last_pX) >= 16)
 				{
 					m_primitive_covers_without_gaps = false;
 					return false;

--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -2998,6 +2998,62 @@ GSState::PRIM_OVERLAP GSState::PrimitiveOverlap()
 	return overlap;
 }
 
+bool GSState::SpriteDrawWithoutGaps()
+{
+	// Check that the height matches. Xenosaga 3 draws a letterbox around
+	// the FMV with a sprite at the top and bottom of the framebuffer.
+	const GSVertex* v = &m_vertex.buff[0];
+	const int first_dpY = v[1].XYZ.Y - v[0].XYZ.Y;
+	const int first_dpX = v[1].XYZ.X - v[0].XYZ.X;
+
+	// Horizontal Match.
+	if (((first_dpX + 8) >> 4) == m_r_no_scissor.z)
+	{
+		// Borrowed from MergeSprite() modified to calculate heights.
+		for (u32 i = 2; i < m_vertex.next; i += 2)
+		{
+			const int last_pY = v[i - 1].XYZ.Y;
+			const int dpY = v[i + 1].XYZ.Y - v[i].XYZ.Y;
+
+			if (std::abs(dpY - first_dpY) >= 16 || std::abs(static_cast<int>(v[i].XYZ.Y) - last_pY) >= 16)
+				return false;
+		}
+
+		return true;
+	}
+
+	// Vertical Match.
+	if (((first_dpY + 8) >> 4) == m_r_no_scissor.w)
+	{
+		// Borrowed from MergeSprite().
+		const int offset_X = m_context->XYOFFSET.OFX;
+		for (u32 i = 2; i < m_vertex.next; i += 2)
+		{
+			const int last_pX = v[i - 1].XYZ.X;
+			const int this_start_X = v[i].XYZ.X;
+			const int last_start_X = v[i - 2].XYZ.X;
+
+			const int dpX = v[i + 1].XYZ.X - v[i].XYZ.X;
+
+			if (this_start_X < last_start_X)
+			{
+				const int prev_X = last_start_X - offset_X;
+				if (std::abs(dpX - prev_X) >= 16 || std::abs(this_start_X - offset_X) >= 16)
+					return false;
+			}
+			else
+			{
+				if ((std::abs(dpX - first_dpX) >= 16 && (i + 2) < m_vertex.next) || std::abs(this_start_X - last_pX) >= 16)
+					return false;
+			}
+		}
+
+		return true;
+	}
+
+	return false;
+}
+
 bool GSState::PrimitiveCoversWithoutGaps()
 {
 	if (m_primitive_covers_without_gaps.has_value())
@@ -3033,69 +3089,10 @@ bool GSState::PrimitiveCoversWithoutGaps()
 		return true;
 	}
 
-	// Check that the height matches. Xenosaga 3 draws a letterbox around
-	// the FMV with a sprite at the top and bottom of the framebuffer.
-	const GSVertex* v = &m_vertex.buff[0];
-	const int first_dpY = v[1].XYZ.Y - v[0].XYZ.Y;
-	const int first_dpX = v[1].XYZ.X - v[0].XYZ.X;
+	const bool result = SpriteDrawWithoutGaps();
+	m_primitive_covers_without_gaps = result;
 
-	// Horizontal Match.
-	if (((first_dpX + 8) >> 4) == m_r_no_scissor.z)
-	{
-		// Borrowed from MergeSprite() modified to calculate heights.
-		for (u32 i = 2; i < m_vertex.next; i += 2)
-		{
-			const int last_pY = v[i - 1].XYZ.Y;
-			const int dpY = v[i + 1].XYZ.Y - v[i].XYZ.Y;
-			if (std::abs(dpY - first_dpY) >= 16 || std::abs(static_cast<int>(v[i].XYZ.Y) - last_pY) >= 16)
-			{
-				m_primitive_covers_without_gaps = false;
-				return false;
-			}
-		}
-
-		m_primitive_covers_without_gaps = true;
-		return true;
-	}
-
-	// Vertical Match.
-	if (((first_dpY + 8) >> 4) == m_r_no_scissor.w)
-	{
-		// Borrowed from MergeSprite().
-		const int offset_X = m_context->XYOFFSET.OFX;
-		for (u32 i = 2; i < m_vertex.next; i += 2)
-		{
-			const int last_pX = v[i - 1].XYZ.X;
-			const int this_start_X = v[i].XYZ.X;
-			const int last_start_X = v[i - 2].XYZ.X;
-
-			const int dpX = v[i + 1].XYZ.X - v[i].XYZ.X;
-
-			if (this_start_X < last_start_X)
-			{
-				const int prev_X = last_start_X - offset_X;
-				if (std::abs(dpX - prev_X) >= 16 || std::abs(this_start_X - offset_X) >= 16)
-				{
-					m_primitive_covers_without_gaps = false;
-					return false;
-				}
-			}
-			else
-			{
-				if ((std::abs(dpX - first_dpX) >= 16 && (i + 2) < m_vertex.next) || std::abs(this_start_X - last_pX) >= 16)
-				{
-					m_primitive_covers_without_gaps = false;
-					return false;
-				}
-			}
-		}
-
-		m_primitive_covers_without_gaps = true;
-		return true;
-	}
-
-	m_primitive_covers_without_gaps = false;
-	return false;
+	return result;
 }
 
 __forceinline bool GSState::IsAutoFlushDraw(u32 prim)

--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -410,6 +410,7 @@ public:
 
 	bool TrianglesAreQuads(bool shuffle_check = false) const;
 	PRIM_OVERLAP PrimitiveOverlap();
+	bool SpriteDrawWithoutGaps();
 	bool PrimitiveCoversWithoutGaps();
 	GIFRegTEX0 GetTex0Layer(u32 lod);
 };

--- a/pcsx2/GS/Renderers/Common/GSRenderer.h
+++ b/pcsx2/GS/Renderers/Common/GSRenderer.h
@@ -30,6 +30,7 @@ protected:
 	bool m_process_texture = false;
 	bool m_copy_16bit_to_target_shuffle = false;
 	bool m_same_group_texture_shuffle = false;
+	bool m_downscale_source = false;
 
 	virtual GSTexture* GetOutput(int i, float& scale, int& y_offset) = 0;
 	virtual GSTexture* GetFeedbackOutput(float& scale) { return nullptr; }

--- a/pcsx2/GS/Renderers/HW/GSHwHack.cpp
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.cpp
@@ -280,8 +280,8 @@ bool GSHwHack::GSC_BurnoutGames(GSRendererHW& r, int& skip)
 
 		case 2: // downsample
 		{
-			const GSVector4i downsample_rect = GSVector4i(0, 0, ((main_fb_size.x / 2) - 1), ((main_fb_size.y / 2) - 1));
-			const GSVector4i uv_rect = GSVector4i(0, 0, (downsample_rect.z * 2) - std::min(r.GetUpscaleMultiplier()-1.0f, 4.0f) * 3 , (downsample_rect.w * 2) - std::min(r.GetUpscaleMultiplier()-1.0f, 4.0f) * 3);
+			const GSVector4i downsample_rect = GSVector4i(0, 0, ((main_fb_size.x / 2)), ((main_fb_size.y / 2)));
+			const GSVector4i uv_rect = GSVector4i(0, 0, main_fb_size.x, main_fb_size.y);
 			r.ReplaceVerticesWithSprite(downsample_rect, uv_rect, main_fb_size, downsample_rect);
 			downsample_fb = GIFRegTEX0::Create(RFBP, RFBW, RFPSM);
 			state = 3;

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -2612,18 +2612,26 @@ void GSRendererHW::Draw()
 		m_r = m_r.rintersect(t_size_rect);
 
 	float target_scale = GetTextureScaleFactor();
-	
-	if (isDownscaleDraw(src, no_gaps) || (IsPossibleChannelShuffle() && src && src->m_from_target && src->m_from_target->GetScale() == 1.0f))
+	const int scale_draw = IsScalingDraw(src, no_gaps);
+	if (target_scale > 1.0f && scale_draw > 0)
 	{
-		target_scale = 1.0f;
+		// 1 == Downscale, so we need to reduce the size of the target also.
+		// 2 == Upscale, so likely putting it over the top of the render target.
+		if(scale_draw == 1)
+			target_scale = 1.0f;
 		m_downscale_source = src->m_from_target->GetScale() > 1.0f;
 	}
 	else
 		m_downscale_source = false;
+
+	if (IsPossibleChannelShuffle() && src && src->m_from_target && src->m_from_target->GetScale() != target_scale)
+	{
+		target_scale = src->m_from_target->GetScale();
+	}
 	// This upscaling hack is for games which construct P8 textures by drawing a bunch of small sprites in C32,
 	// then reinterpreting it as P8. We need to keep the off-screen intermediate textures at native resolution,
 	// but not propagate that through to the normal render targets. Test Case: Crash Wrath of Cortex.
-	if (no_ds && src && !m_channel_shuffle && GSConfig.UserHacks_NativePaletteDraw && src->m_from_target &&
+	if (no_ds && src && !m_channel_shuffle && src->m_from_target && (GSConfig.UserHacks_NativePaletteDraw || (src->m_from_target->m_downscaled && scale_draw <= 1)) &&
 		src->m_scale == 1.0f && (src->m_TEX0.PSM == PSMT8 || src->m_TEX0.TBP0 == m_cached_ctx.FRAME.Block()))
 	{
 		GL_CACHE("Using native resolution for target based on texture source");
@@ -2660,7 +2668,7 @@ void GSRendererHW::Draw()
 															  GSLocalMemory::m_psm[m_cached_ctx.TEX0.PSM].bpp == 16 && GSLocalMemory::m_psm[m_cached_ctx.FRAME.PSM].bpp == 16) ||
 															 IsPossibleChannelShuffle());
 		rt = g_texture_cache->LookupTarget(FRAME_TEX0, t_size, target_scale, GSTextureCache::RenderTarget, true,
-			fm, false, force_preload, preserve_rt_rgb, preserve_rt_alpha, unclamped_draw_rect, possible_shuffle, is_possible_mem_clear && FRAME_TEX0.TBP0 != m_cached_ctx.ZBUF.Block(), src);
+			fm, false, force_preload, preserve_rt_rgb, preserve_rt_alpha, unclamped_draw_rect, possible_shuffle, is_possible_mem_clear && FRAME_TEX0.TBP0 != m_cached_ctx.ZBUF.Block());
 
 		// Draw skipped because it was a clear and there was no target.
 		if (!rt)
@@ -2692,7 +2700,16 @@ void GSRendererHW::Draw()
 			}
 		}
 		else
+		{
+			if (src && src->m_from_target && src->m_target_direct && src->m_from_target == rt)
+			{
+				src->m_texture = rt->m_texture;
+				src->m_scale = rt->m_scale;
+				src->m_unscaled_size = rt->m_unscaled_size;
+			}
+
 			target_scale = rt->GetScale();
+		}
 
 		// The target might have previously been a C32 format with valid alpha. If we're switching to C24, we need to preserve it.
 		preserve_rt_alpha |= (GSLocalMemory::m_psm[m_cached_ctx.FRAME.PSM].trbpp == 24 && rt->HasValidAlpha());
@@ -4968,7 +4985,8 @@ __ri void GSRendererHW::EmulateTextureSampler(const GSTextureCache::Target* rt, 
 		// Apply a small offset (based on upscale amount) for edges of textures to avoid reading garbage during a clamp+stscale down
 		// Bigger problem when WH is 1024x1024 and the target is only small.
 		// This "fixes" a lot of the rainbow garbage in games when upscaling (and xenosaga shadows + VP2 forest seem quite happy).
-		const GSVector4 region_clamp_offset = GSVector4::cxpr(0.5f, 0.5f, 0.1f, 0.1f) + (GSVector4::cxpr(0.1f, 0.1f, 0.0f, 0.0f) * scale);
+		// Note that this is done on the original texture scale, during upscales it can mess up otherwise.
+		const GSVector4 region_clamp_offset = GSVector4::cxpr(0.5f, 0.5f, 0.1f, 0.1f) + (GSVector4::cxpr(0.1f, 0.1f, 0.0f, 0.0f) * tex->GetScale());
 		
 		const GSVector4 region_clamp = (GSVector4(clamp) + region_clamp_offset) / WH.xyxy();
 		if (wms >= CLAMP_REGION_CLAMP)
@@ -5169,7 +5187,7 @@ __ri void GSRendererHW::HandleTextureHazards(const GSTextureCache::Target* rt, c
 	}
 
 	unscaled_size = copy_size;
-	scale = m_downscale_source ? 1 : src_target->GetScale();
+	scale = m_downscale_source ? 1.0f : src_target->GetScale();
 	const float src_scale = src_target->GetScale();
 	GL_CACHE("Copy size: %dx%d, range: %d,%d -> %d,%d (%dx%d) @ %.1f", copy_size.x, copy_size.y, copy_range.x,
 		copy_range.y, copy_range.z, copy_range.w, copy_range.width(), copy_range.height(), scale);
@@ -5184,7 +5202,7 @@ __ri void GSRendererHW::HandleTextureHazards(const GSTextureCache::Target* rt, c
 	src_copy.reset(src_target->m_texture->IsDepthStencil() ?
 				   g_gs_device->CreateDepthStencil(
 						   scaled_copy_size.x, scaled_copy_size.y, src_target->m_texture->GetFormat(), false) :
-				   (m_downscale_source ? g_gs_device->CreateRenderTarget(scaled_copy_size.x, scaled_copy_size.y, src_target->m_texture->GetFormat(), false,
+				   (m_downscale_source ? g_gs_device->CreateRenderTarget(scaled_copy_size.x, scaled_copy_size.y, src_target->m_texture->GetFormat(), true,
 							 true) : 
 				   g_gs_device->CreateTexture(
 					   scaled_copy_size.x, scaled_copy_size.y, 1, src_target->m_texture->GetFormat(), true)));
@@ -5197,10 +5215,10 @@ __ri void GSRendererHW::HandleTextureHazards(const GSTextureCache::Target* rt, c
 	}
 	if (m_downscale_source)
 	{
-		DevCon.Warning("Resizing to scale %f", scale);
+		GL_INS("Rescaling %f -> %f", src_scale, scale);
 		const GSVector4 dst_rect = GSVector4(0, 0, src_unscaled_size.x, src_unscaled_size.y);
 		const GSVector4 src_rect = GSVector4(scaled_copy_range) / GSVector4(src_unscaled_size * src_scale).xyxy();
-		g_gs_device->StretchRect(src_target->m_texture, GSVector4(0.0f,0.0f,1.0f,1.0f), src_copy.get(), dst_rect, src_target->m_texture->IsDepthStencil() ? ShaderConvert::DEPTH_COPY : ShaderConvert::COPY, true);
+		g_gs_device->StretchRect(src_target->m_texture, GSVector4::cxpr(0.0f,0.0f,1.0f,1.0f), src_copy.get(), dst_rect, src_target->m_texture->IsDepthStencil() ? ShaderConvert::DEPTH_COPY : ShaderConvert::COPY, false);
 	}
 	else
 	{
@@ -7172,24 +7190,29 @@ bool GSRendererHW::TextureCoversWithoutGapsNotEqual()
 	return false;
 }
 
-bool GSRendererHW::isDownscaleDraw(GSTextureCache::Source* src, bool no_gaps)
+int GSRendererHW::IsScalingDraw(GSTextureCache::Source* src, bool no_gaps)
 {
+	// Try to detect if a game is downscaling/upscaling the image in order to do post processing/bloom effects.
 	const GSVector2i draw_size = GSVector2i(m_vt.m_max.p.x - m_vt.m_min.p.x, m_vt.m_max.p.y - m_vt.m_min.p.y);
-
-	if (draw_size.x >= PCRTCDisplays.GetResolution().x)
-		return false;
-
 	const GSVector2i tex_size = GSVector2i(m_vt.m_max.t.x - m_vt.m_min.t.x, m_vt.m_max.t.y - m_vt.m_min.t.y);
+	const bool is_downscale = (tex_size.x / 2.0f) >= draw_size.x && (tex_size.y / 2.0f) >= draw_size.y;
+	if (is_downscale && draw_size.x >= PCRTCDisplays.GetResolution().x)
+		return 0;
 
-	if (no_gaps && m_vt.m_primclass >= GS_TRIANGLE_CLASS && m_cached_ctx.FRAME.Block() != m_cached_ctx.TEX0.TBP0 && !IsMipMapDraw() && IsDiscardingDstColor() && 
-		src && src->m_from_target && m_context->TEX1.MMAG == 1 &&
-		(tex_size.x / 2.0f) >= draw_size.x && (tex_size.y / 2.0f) >= draw_size.y)
+	const bool is_upscale = (draw_size.x / 2.0f) >= tex_size.x && (draw_size.y / 2.0f) >= tex_size.y;
+	
+	// DMC does a blit in strips with the scissor to keep it inside page boundaries, so that's not technically full coverage
+	// but good enough for what we want.
+	const bool no_gaps_or_single_sprite = (no_gaps || (m_vt.m_primclass == GS_SPRITE_CLASS && m_index.tail == 2));
+	if (no_gaps_or_single_sprite && m_vt.m_primclass >= GS_TRIANGLE_CLASS && GSLocalMemory::m_psm[m_cached_ctx.TEX0.PSM].trbpp > 8 && m_cached_ctx.FRAME.Block() != m_cached_ctx.TEX0.TBP0 && !IsMipMapDraw() && 
+		((is_upscale && !IsDiscardingDstColor()) || (IsDiscardingDstColor() && is_downscale)) && 
+		src && src->m_from_target && !src->m_from_target->m_downscaled && m_context->TEX1.MMAG == 1)
 	{
-		DevCon.Warning("Draw %d is a downscale draw from %dx%d to %dx%d", s_n, tex_size.x, tex_size.y, draw_size.x, draw_size.y);
-		return true;
+		GL_INS("%s draw detected - from %dx%d to %dx%d", is_downscale ? "Downscale" : "Upscale", tex_size.x, tex_size.y, draw_size.x, draw_size.y);
+		return is_upscale ? 2 : 1;
 	}
 
-	return false;
+	return 0;
 }
 
 bool GSRendererHW::IsConstantDirectWriteMemClear()

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -7113,7 +7113,7 @@ bool GSRendererHW::IsDiscardingDstColor()
 
 bool GSRendererHW::IsDiscardingDstRGB()
 {
-	return ((!PRIM->ABE || IsOpaque() || m_context->ALPHA.IsBlack()) && // no blending or writing black
+	return ((!PRIM->ABE || IsOpaque() || m_context->ALPHA.IsBlack() || !m_context->ALPHA.IsCdInBlend()) && // no blending or writing black
 			((m_cached_ctx.FRAME.FBMSK & GSLocalMemory::m_psm[m_cached_ctx.FRAME.PSM].fmsk) & 0xFFFFFFu) == 0); // RGB isn't masked
 }
 
@@ -7226,8 +7226,8 @@ int GSRendererHW::IsScalingDraw(GSTextureCache::Source* src, bool no_gaps)
 	// but good enough for what we want.
 	const bool no_gaps_or_single_sprite = (is_downscale || is_upscale) && (no_gaps || (m_vt.m_primclass == GS_SPRITE_CLASS && SpriteDrawWithoutGaps()));
 
-	const bool dst_discarded = IsDiscardingDstColor();
-	if (no_gaps_or_single_sprite && ((is_upscale && !dst_discarded) ||
+	const bool dst_discarded = IsDiscardingDstRGB() || IsDiscardingDstAlpha();
+	if (no_gaps_or_single_sprite && ((is_upscale && !m_context->ALPHA.IsOpaque()) ||
 		(is_downscale && (dst_discarded || (PRIM->ABE && m_context->ALPHA.C == 2 && m_context->ALPHA.FIX == 255)))))
 	{
 		GL_INS("%s draw detected - from %dx%d to %dx%d draw %d", is_downscale ? "Downscale" : "Upscale", tex_size.x, tex_size.y, draw_size.x, draw_size.y, s_n);

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -2623,7 +2623,7 @@ void GSRendererHW::Draw()
 			m_downscale_source = src->m_from_target->GetScale() > 1.0f;
 		}
 		else
-			m_downscale_source = false; //src->m_from_target->GetScale() > 1.0f; // Bad for GTA + Full Spectrum Warrior, good for Sacred Blaze + Parappa.
+			m_downscale_source = GSConfig.UserHacks_NativeScaling != GSNativeScaling::Aggressive ? false : src->m_from_target->GetScale() > 1.0f; // Bad for GTA + Full Spectrum Warrior, good for Sacred Blaze + Parappa.
 	}
 	else
 		m_downscale_source = false;
@@ -7200,6 +7200,9 @@ int GSRendererHW::IsScalingDraw(GSTextureCache::Source* src, bool no_gaps)
 	const GSVector2i tex_size = GSVector2i(m_vt.m_max.t.x - m_vt.m_min.t.x, m_vt.m_max.t.y - m_vt.m_min.t.y);
 	const bool is_downscale = (tex_size.x / 2.0f) >= draw_size.x && (tex_size.y / 2.0f) >= draw_size.y;
 	if (is_downscale && draw_size.x >= PCRTCDisplays.GetResolution().x)
+		return 0;
+
+	if (GSConfig.UserHacks_NativeScaling == GSNativeScaling::Off)
 		return 0;
 
 	// Check if we're already downscaled and drawing in current size, try not to rescale it.

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -2617,9 +2617,13 @@ void GSRendererHW::Draw()
 	{
 		// 1 == Downscale, so we need to reduce the size of the target also.
 		// 2 == Upscale, so likely putting it over the top of the render target.
-		if(scale_draw == 1)
+		if (scale_draw == 1)
+		{
 			target_scale = 1.0f;
-		m_downscale_source = src->m_from_target->GetScale() > 1.0f;
+			m_downscale_source = src->m_from_target->GetScale() > 1.0f;
+		}
+		else
+			m_downscale_source = false; //src->m_from_target->GetScale() > 1.0f; // Bad for GTA + Full Spectrum Warrior, good for Sacred Blaze + Parappa.
 	}
 	else
 		m_downscale_source = false;
@@ -5202,7 +5206,7 @@ __ri void GSRendererHW::HandleTextureHazards(const GSTextureCache::Target* rt, c
 	src_copy.reset(src_target->m_texture->IsDepthStencil() ?
 				   g_gs_device->CreateDepthStencil(
 						   scaled_copy_size.x, scaled_copy_size.y, src_target->m_texture->GetFormat(), false) :
-				   (m_downscale_source ? g_gs_device->CreateRenderTarget(scaled_copy_size.x, scaled_copy_size.y, src_target->m_texture->GetFormat(), true,
+					   (m_downscale_source ? g_gs_device->CreateRenderTarget(scaled_copy_size.x, scaled_copy_size.y, src_target->m_texture->GetFormat(), true,
 							 true) : 
 				   g_gs_device->CreateTexture(
 					   scaled_copy_size.x, scaled_copy_size.y, 1, src_target->m_texture->GetFormat(), true)));
@@ -5215,10 +5219,9 @@ __ri void GSRendererHW::HandleTextureHazards(const GSTextureCache::Target* rt, c
 	}
 	if (m_downscale_source)
 	{
-		GL_INS("Rescaling %f -> %f", src_scale, scale);
 		const GSVector4 dst_rect = GSVector4(0, 0, src_unscaled_size.x, src_unscaled_size.y);
 		const GSVector4 src_rect = GSVector4(scaled_copy_range) / GSVector4(src_unscaled_size * src_scale).xyxy();
-		g_gs_device->StretchRect(src_target->m_texture, GSVector4::cxpr(0.0f,0.0f,1.0f,1.0f), src_copy.get(), dst_rect, src_target->m_texture->IsDepthStencil() ? ShaderConvert::DEPTH_COPY : ShaderConvert::COPY, false);
+		g_gs_device->StretchRect(src_target->m_texture, GSVector4::cxpr(0.0f, 0.0f, 1.0f, 1.0f), src_copy.get(), dst_rect, src_target->m_texture->IsDepthStencil() ? ShaderConvert::DEPTH_COPY : ShaderConvert::COPY, false);
 	}
 	else
 	{
@@ -7199,14 +7202,18 @@ int GSRendererHW::IsScalingDraw(GSTextureCache::Source* src, bool no_gaps)
 	if (is_downscale && draw_size.x >= PCRTCDisplays.GetResolution().x)
 		return 0;
 
+	// Check if we're already downscaled and drawing in current size, try not to rescale it.
+	if (src && src->m_from_target && src->m_from_target->m_downscaled && std::abs(draw_size.x - tex_size.x) <= 1 && std::abs(draw_size.y - tex_size.y) <= 1)
+		return 1;
+
 	const bool is_upscale = (draw_size.x / 2.0f) >= tex_size.x && (draw_size.y / 2.0f) >= tex_size.y;
-	
+	const bool target_scale = is_downscale ? true : false;
 	// DMC does a blit in strips with the scissor to keep it inside page boundaries, so that's not technically full coverage
 	// but good enough for what we want.
-	const bool no_gaps_or_single_sprite = (no_gaps || (m_vt.m_primclass == GS_SPRITE_CLASS && m_index.tail == 2));
-	if (no_gaps_or_single_sprite && m_vt.m_primclass >= GS_TRIANGLE_CLASS && GSLocalMemory::m_psm[m_cached_ctx.TEX0.PSM].trbpp > 8 && m_cached_ctx.FRAME.Block() != m_cached_ctx.TEX0.TBP0 && !IsMipMapDraw() && 
-		((is_upscale && !IsDiscardingDstColor()) || (IsDiscardingDstColor() && is_downscale)) && 
-		src && src->m_from_target && !src->m_from_target->m_downscaled && m_context->TEX1.MMAG == 1)
+	const bool no_gaps_or_single_sprite = (no_gaps || (m_vt.m_primclass == GS_SPRITE_CLASS && SpriteDrawWithoutGaps()));
+	if (no_gaps_or_single_sprite && m_vt.m_primclass >= GS_TRIANGLE_CLASS && m_context->TEX1.MMAG == 1 && src && src->m_from_target && 
+		GSLocalMemory::m_psm[m_cached_ctx.TEX0.PSM].trbpp > 8 && m_cached_ctx.FRAME.Block() != m_cached_ctx.TEX0.TBP0 && !IsMipMapDraw() && 
+		((is_upscale && !IsDiscardingDstColor()) || (IsDiscardingDstColor() && is_downscale)))
 	{
 		GL_INS("%s draw detected - from %dx%d to %dx%d", is_downscale ? "Downscale" : "Upscale", tex_size.x, tex_size.y, draw_size.x, draw_size.y);
 		return is_upscale ? 2 : 1;

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -2672,8 +2672,8 @@ void GSRendererHW::Draw()
 															  GSLocalMemory::m_psm[m_cached_ctx.TEX0.PSM].bpp == 16 && GSLocalMemory::m_psm[m_cached_ctx.FRAME.PSM].bpp == 16) ||
 															 IsPossibleChannelShuffle());
 
-		rt = g_texture_cache->LookupTarget(FRAME_TEX0, t_size, ((src && src->m_scale != 1) && GSConfig.UserHacks_NativeScaling != GSNativeScaling::Aggressive && !possible_shuffle) ? GetTextureScaleFactor() : target_scale, GSTextureCache::RenderTarget, true,
-			fm, false, force_preload, preserve_rt_rgb, preserve_rt_alpha, unclamped_draw_rect, possible_shuffle, is_possible_mem_clear && FRAME_TEX0.TBP0 != m_cached_ctx.ZBUF.Block(), scale_draw != 1);
+		rt = g_texture_cache->LookupTarget(FRAME_TEX0, t_size, ((src && src->m_scale != 1) && GSConfig.UserHacks_NativeScaling == GSNativeScaling::Normal && !possible_shuffle) ? GetTextureScaleFactor() : target_scale, GSTextureCache::RenderTarget, true,
+			fm, false, force_preload, preserve_rt_rgb, preserve_rt_alpha, unclamped_draw_rect, possible_shuffle, is_possible_mem_clear && FRAME_TEX0.TBP0 != m_cached_ctx.ZBUF.Block(), GSConfig.UserHacks_NativeScaling != GSNativeScaling::Off && scale_draw != 1);
 
 		// Draw skipped because it was a clear and there was no target.
 		if (!rt)
@@ -5223,7 +5223,6 @@ __ri void GSRendererHW::HandleTextureHazards(const GSTextureCache::Target* rt, c
 	if (m_downscale_source)
 	{
 		const GSVector4 dst_rect = GSVector4(0, 0, src_unscaled_size.x, src_unscaled_size.y);
-		const GSVector4 src_rect = GSVector4(scaled_copy_range) / GSVector4(src_unscaled_size * src_scale).xyxy();
 		g_gs_device->StretchRect(src_target->m_texture, GSVector4::cxpr(0.0f, 0.0f, 1.0f, 1.0f), src_copy.get(), dst_rect, src_target->m_texture->IsDepthStencil() ? ShaderConvert::DEPTH_COPY : ShaderConvert::COPY, false);
 	}
 	else
@@ -7202,27 +7201,36 @@ int GSRendererHW::IsScalingDraw(GSTextureCache::Source* src, bool no_gaps)
 	if (GSConfig.UserHacks_NativeScaling == GSNativeScaling::Off)
 		return 0;
 
+	if (m_context->TEX1.MMAG != 1 || m_vt.m_primclass < GS_TRIANGLE_CLASS || m_cached_ctx.FRAME.Block() == m_cached_ctx.TEX0.TBP0 ||
+		IsMipMapDraw() || GSLocalMemory::m_psm[m_cached_ctx.TEX0.PSM].trbpp <= 8 || !src || !src->m_from_target)
+		return 0;
+
 	const GSVector2i draw_size = GSVector2i(m_vt.m_max.p.x - m_vt.m_min.p.x, m_vt.m_max.p.y - m_vt.m_min.p.y);
 	const GSVector2i tex_size = GSVector2i(m_vt.m_max.t.x - m_vt.m_min.t.x, m_vt.m_max.t.y - m_vt.m_min.t.y);
-	// Check if we're already downscaled and drawing in current size, try not to rescale it.
-	if (src && src->m_from_target && (std::abs(draw_size.x - tex_size.x) <= 1 && std::abs(draw_size.y - tex_size.y) <= 1))
+
+	// Try to catch cases of stupid draws like Manhunt and Syphon Filter where they sample a single pixel.
+	if(tex_size.x == 0 || tex_size.y == 0 || draw_size.x == 0 || draw_size.y == 0)
+		return 0;
+
+	if (std::abs(draw_size.x - tex_size.x) <= 1 && std::abs(draw_size.y - tex_size.y) <= 1)
 		return -1;
 
-	// Try to detect if a game is downscaling/upscaling the image in order to do post processing/bloom effects.
-	const bool is_downscale = (tex_size.x / 2.0f) >= (draw_size.x - 1) && (tex_size.y / 2.0f) >= (draw_size.y - 1);
+	// Should usually be 2x but some games like Monster House goes from 512x448 -> 128x128
+	const bool is_downscale = draw_size.x <= (tex_size.x * 0.75f) && draw_size.y <= (tex_size.y * 0.75f);
+
 	if (is_downscale && draw_size.x >= PCRTCDisplays.GetResolution().x)
 		return 0;
 
-	const bool is_upscale = (draw_size.x / 2.0f) >= (tex_size.x - 1) && (draw_size.y / 2.0f) >= (tex_size.y - 1);
-
+	const bool is_upscale = (draw_size.x / tex_size.x) >= 4 || (draw_size.y / tex_size.y) >= 4;
 	// DMC does a blit in strips with the scissor to keep it inside page boundaries, so that's not technically full coverage
 	// but good enough for what we want.
-	const bool no_gaps_or_single_sprite = (no_gaps || (m_vt.m_primclass == GS_SPRITE_CLASS && SpriteDrawWithoutGaps()));
-	if (no_gaps_or_single_sprite && m_vt.m_primclass >= GS_TRIANGLE_CLASS && m_context->TEX1.MMAG == 1 && src && src->m_from_target && 
-		GSLocalMemory::m_psm[m_cached_ctx.TEX0.PSM].trbpp > 8 && m_cached_ctx.FRAME.Block() != m_cached_ctx.TEX0.TBP0 && !IsMipMapDraw() && 
-		((is_upscale && !IsDiscardingDstColor()) || (((PRIM->ABE && m_context->ALPHA.C == 2 && m_context->ALPHA.FIX == 255) || IsDiscardingDstColor()) && is_downscale)))
+	const bool no_gaps_or_single_sprite = (is_downscale || is_upscale) && (no_gaps || (m_vt.m_primclass == GS_SPRITE_CLASS && SpriteDrawWithoutGaps()));
+
+	const bool dst_discarded = IsDiscardingDstColor();
+	if (no_gaps_or_single_sprite && ((is_upscale && !dst_discarded) ||
+		(is_downscale && (dst_discarded || (PRIM->ABE && m_context->ALPHA.C == 2 && m_context->ALPHA.FIX == 255)))))
 	{
-		GL_INS("%s draw detected - from %dx%d to %dx%d", is_downscale ? "Downscale" : "Upscale", tex_size.x, tex_size.y, draw_size.x, draw_size.y);
+		GL_INS("%s draw detected - from %dx%d to %dx%d draw %d", is_downscale ? "Downscale" : "Upscale", tex_size.x, tex_size.y, draw_size.x, draw_size.y, s_n);
 		return is_upscale ? 2 : 1;
 	}
 

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -2671,8 +2671,9 @@ void GSRendererHW::Draw()
 		const bool possible_shuffle = draw_sprite_tex && (((src && src->m_target && src->m_from_target && src->m_from_target->m_32_bits_fmt) &&
 															  GSLocalMemory::m_psm[m_cached_ctx.TEX0.PSM].bpp == 16 && GSLocalMemory::m_psm[m_cached_ctx.FRAME.PSM].bpp == 16) ||
 															 IsPossibleChannelShuffle());
-		rt = g_texture_cache->LookupTarget(FRAME_TEX0, t_size, target_scale, GSTextureCache::RenderTarget, true,
-			fm, false, force_preload, preserve_rt_rgb, preserve_rt_alpha, unclamped_draw_rect, possible_shuffle, is_possible_mem_clear && FRAME_TEX0.TBP0 != m_cached_ctx.ZBUF.Block(), scale_draw < 0);
+
+		rt = g_texture_cache->LookupTarget(FRAME_TEX0, t_size, ((src && src->m_scale != 1) && GSConfig.UserHacks_NativeScaling != GSNativeScaling::Aggressive && !possible_shuffle) ? GetTextureScaleFactor() : target_scale, GSTextureCache::RenderTarget, true,
+			fm, false, force_preload, preserve_rt_rgb, preserve_rt_alpha, unclamped_draw_rect, possible_shuffle, is_possible_mem_clear && FRAME_TEX0.TBP0 != m_cached_ctx.ZBUF.Block(), scale_draw != 1);
 
 		// Draw skipped because it was a clear and there was no target.
 		if (!rt)

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.h
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.h
@@ -48,7 +48,7 @@ private:
 	float alpha1(int L, int X0, int X1);
 	void SwSpriteRender();
 	bool CanUseSwSpriteRender();
-	bool isDownscaleDraw(GSTextureCache::Source* src, bool no_gaps);
+	int IsScalingDraw(GSTextureCache::Source* src, bool no_gaps);
 	bool IsConstantDirectWriteMemClear();
 	u32 GetConstantDirectWriteMemClearColor() const;
 	u32 GetConstantDirectWriteMemClearDepth() const;

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.h
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.h
@@ -48,6 +48,7 @@ private:
 	float alpha1(int L, int X0, int X1);
 	void SwSpriteRender();
 	bool CanUseSwSpriteRender();
+	bool isDownscaleDraw(GSTextureCache::Source* src, bool no_gaps);
 	bool IsConstantDirectWriteMemClear();
 	u32 GetConstantDirectWriteMemClearColor() const;
 	u32 GetConstantDirectWriteMemClearDepth() const;

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -2595,7 +2595,7 @@ bool GSTextureCache::PreloadTarget(GIFRegTEX0 TEX0, const GSVector2i& size, cons
 								continue;
 							}
 
-							if (!hw_clear && (preserve_target || preload))
+							if (!hw_clear && (preserve_target || preload) && dst->GetScale() == t->GetScale())
 							{
 								const int copy_width = (t->m_texture->GetWidth()) > (dst->m_texture->GetWidth()) ? (dst->m_texture->GetWidth()) : t->m_texture->GetWidth();
 								const int copy_height = overlapping_pages_height * t->m_scale;

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -2397,7 +2397,6 @@ GSTextureCache::Target* GSTextureCache::CreateTarget(GIFRegTEX0 TEX0, const GSVe
 	dst->readbacks_since_draw = 0;
 
 	dst->m_last_draw = GSState::s_n;
-	dst->m_downscaled = scale != GSRendererHW::GetInstance()->GetTextureScaleFactor();
 
 	if (dst->m_dirty.empty() && GSLocalMemory::m_psm[TEX0.PSM].depth == 0 && (GSUtil::GetChannelMask(TEX0.PSM) & 0x8))
 		dst->m_rt_alpha_scale = true;

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -1796,7 +1796,7 @@ GSVector2i GSTextureCache::ScaleRenderTargetSize(const GSVector2i& sz, float sca
 }
 
 GSTextureCache::Target* GSTextureCache::LookupTarget(GIFRegTEX0 TEX0, const GSVector2i& size, float scale, int type,
-	bool used, u32 fbmask, bool is_frame, bool preload, bool preserve_rgb, bool preserve_alpha, const GSVector4i draw_rect, bool is_shuffle, bool possible_clear)
+	bool used, u32 fbmask, bool is_frame, bool preload, bool preserve_rgb, bool preserve_alpha, const GSVector4i draw_rect, bool is_shuffle, bool possible_clear, Source* src)
 {
 	const GSLocalMemory::psm_t& psm_s = GSLocalMemory::m_psm[TEX0.PSM];
 	const u32 bp = TEX0.TBP0;
@@ -2001,7 +2001,7 @@ GSTextureCache::Target* GSTextureCache::LookupTarget(GIFRegTEX0 TEX0, const GSVe
 			if (!tex)
 				return nullptr;
 
-			g_gs_device->StretchRect(dst->m_texture, sRect, tex, dRect, (type == RenderTarget) ? ShaderConvert::COPY : ShaderConvert::DEPTH_COPY, false);
+			g_gs_device->StretchRect(dst->m_texture, sRect, tex, dRect, (type == RenderTarget) ? ShaderConvert::COPY : ShaderConvert::DEPTH_COPY, dst->m_scale == 1.0f);
 			g_perfmon.Put(GSPerfMon::TextureCopies, 1);
 			m_target_memory_usage = (m_target_memory_usage - dst->m_texture->GetMemUsage()) + tex->GetMemUsage();
 

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -1996,7 +1996,7 @@ GSTextureCache::Target* GSTextureCache::LookupTarget(GIFRegTEX0 TEX0, const GSVe
 				dst->m_TEX0.TBP0, dst->m_TEX0.TBW, psm_str(dst->m_TEX0.PSM));
 		}
 
-		if (dst->m_scale != scale && !preserve_scale)
+		if (dst->m_scale != scale && (!preserve_scale || is_shuffle || !dst->m_downscaled || TEX0.TBW != dst->m_TEX0.TBW))
 		{
 			calcRescale(dst);
 			GSTexture* tex = type == RenderTarget ? g_gs_device->CreateRenderTarget(new_scaled_size.x, new_scaled_size.y, GSTexture::Format::Color, clear) :
@@ -2017,7 +2017,7 @@ GSTextureCache::Target* GSTextureCache::LookupTarget(GIFRegTEX0 TEX0, const GSVe
 			dst->m_texture = tex;
 			dst->m_scale = scale;
 			dst->m_unscaled_size = new_size;
-			dst->m_downscaled = scale == 1.0f;
+			dst->m_downscaled = scale == 1.0f && g_gs_renderer->GetUpscaleMultiplier() > 1.0f;
 		}
 		else if (dst->m_scale != scale)
 			scale = dst->m_scale;
@@ -6066,6 +6066,7 @@ GSTextureCache::Target::Target(GIFRegTEX0 TEX0, int type, const GSVector2i& unsc
 	m_unscaled_size = unscaled_size;
 	m_scale = scale;
 	m_texture = texture;
+	m_downscaled = scale == 1.0f && g_gs_renderer->GetUpscaleMultiplier() > 1.0f;
 
 	if ((m_TEX0.PSM & 0xf) == PSMCT24)
 	{

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.h
@@ -490,7 +490,7 @@ public:
 	Target* FindTargetOverlap(Target* target, int type, int psm);
 	Target* LookupTarget(GIFRegTEX0 TEX0, const GSVector2i& size, float scale, int type, bool used = true, u32 fbmask = 0,
 		bool is_frame = false, bool preload = GSConfig.PreloadFrameWithGSData, bool preserve_rgb = true, bool preserve_alpha = true,
-		const GSVector4i draw_rc = GSVector4i::zero(), bool is_shuffle = false, bool possible_clear = false);
+		const GSVector4i draw_rc = GSVector4i::zero(), bool is_shuffle = false, bool possible_clear = false, Source* src = nullptr);
 	Target* CreateTarget(GIFRegTEX0 TEX0, const GSVector2i& size, const GSVector2i& valid_size,float scale, int type, bool used = true, u32 fbmask = 0,
 		bool is_frame = false, bool preload = GSConfig.PreloadFrameWithGSData, bool preserve_target = true,
 		const GSVector4i draw_rc = GSVector4i::zero(), GSTextureCache::Source* src = nullptr);

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.h
@@ -220,6 +220,7 @@ public:
 		bool m_valid_alpha_high = false;
 		bool m_valid_rgb = false;
 		bool m_rt_alpha_scale = false;
+		bool m_downscaled = false;
 		int m_last_draw = 0;
 
 		bool m_is_frame = false;
@@ -490,7 +491,7 @@ public:
 	Target* FindTargetOverlap(Target* target, int type, int psm);
 	Target* LookupTarget(GIFRegTEX0 TEX0, const GSVector2i& size, float scale, int type, bool used = true, u32 fbmask = 0,
 		bool is_frame = false, bool preload = GSConfig.PreloadFrameWithGSData, bool preserve_rgb = true, bool preserve_alpha = true,
-		const GSVector4i draw_rc = GSVector4i::zero(), bool is_shuffle = false, bool possible_clear = false, Source* src = nullptr);
+		const GSVector4i draw_rc = GSVector4i::zero(), bool is_shuffle = false, bool possible_clear = false);
 	Target* CreateTarget(GIFRegTEX0 TEX0, const GSVector2i& size, const GSVector2i& valid_size,float scale, int type, bool used = true, u32 fbmask = 0,
 		bool is_frame = false, bool preload = GSConfig.PreloadFrameWithGSData, bool preserve_target = true,
 		const GSVector4i draw_rc = GSVector4i::zero(), GSTextureCache::Source* src = nullptr);

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.h
@@ -490,8 +490,8 @@ public:
 
 	Target* FindTargetOverlap(Target* target, int type, int psm);
 	Target* LookupTarget(GIFRegTEX0 TEX0, const GSVector2i& size, float scale, int type, bool used = true, u32 fbmask = 0,
-		bool is_frame = false, bool preload = GSConfig.PreloadFrameWithGSData, bool preserve_rgb = true, bool preserve_alpha = true,
-		const GSVector4i draw_rc = GSVector4i::zero(), bool is_shuffle = false, bool possible_clear = false);
+						 bool is_frame = false, bool preload = GSConfig.PreloadFrameWithGSData, bool preserve_rgb = true, bool preserve_alpha = true,
+						 const GSVector4i draw_rc = GSVector4i::zero(), bool is_shuffle = false, bool possible_clear = false, bool preserve_scale = false);
 	Target* CreateTarget(GIFRegTEX0 TEX0, const GSVector2i& size, const GSVector2i& valid_size,float scale, int type, bool used = true, u32 fbmask = 0,
 		bool is_frame = false, bool preload = GSConfig.PreloadFrameWithGSData, bool preserve_target = true,
 		const GSVector4i draw_rc = GSVector4i::zero(), GSTextureCache::Source* src = nullptr);

--- a/pcsx2/GameDatabase.cpp
+++ b/pcsx2/GameDatabase.cpp
@@ -383,6 +383,7 @@ static const char* s_gs_hw_fix_names[] = {
 	"halfBottomOverride",
 	"halfPixelOffset",
 	"roundSprite",
+	"nativeScaling",
 	"texturePreloading",
 	"deinterlace",
 	"cpuSpriteRenderBW",
@@ -638,6 +639,9 @@ bool GameDatabaseSchema::GameEntry::configMatchesHWFix(const Pcsx2Config::GSOpti
 		case GSHWFixId::RoundSprite:
 			return (config.UpscaleMultiplier <= 1.0f || config.UserHacks_RoundSprite == value);
 
+		case GSHWFixId::NativeScaling:
+			return (static_cast<int>(config.UserHacks_NativeScaling) == value);
+
 		case GSHWFixId::TexturePreloading:
 			return (static_cast<int>(config.TexturePreloading) <= value);
 
@@ -807,6 +811,10 @@ void GameDatabaseSchema::GameEntry::applyGSHardwareFixes(Pcsx2Config::GSOptions&
 
 			case GSHWFixId::RoundSprite:
 				config.UserHacks_RoundSprite = value;
+				break;
+
+			case GSHWFixId::NativeScaling:
+				config.UserHacks_NativeScaling = static_cast<GSNativeScaling>(value);
 				break;
 
 			case GSHWFixId::TexturePreloading:

--- a/pcsx2/GameDatabase.h
+++ b/pcsx2/GameDatabase.h
@@ -68,6 +68,7 @@ namespace GameDatabaseSchema
 		HalfBottomOverride,
 		HalfPixelOffset,
 		RoundSprite,
+		NativeScaling,
 		TexturePreloading,
 		Deinterlace,
 		CPUSpriteRenderBW,

--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -3742,6 +3742,11 @@ void FullscreenUI::DrawGraphicsSettingsPage(SettingsInterface* bsi, bool show_ad
 				FSUI_NSTR("Special (Texture - Aggressive)"),
 				FSUI_NSTR("Align To Native"),
 			};
+			static constexpr const char* s_native_scaling_options[] = {
+				FSUI_NSTR("Normal (Default)"),
+				FSUI_NSTR("Aggressive"),
+				FSUI_NSTR("Off"),
+			};
 			static constexpr const char* s_round_sprite_options[] = {
 				FSUI_NSTR("Off (Default)"),
 				FSUI_NSTR("Half"),
@@ -3807,6 +3812,8 @@ void FullscreenUI::DrawGraphicsSettingsPage(SettingsInterface* bsi, bool show_ad
 			MenuHeading(FSUI_CSTR("Upscaling Fixes"));
 			DrawIntListSetting(bsi, FSUI_CSTR("Half Pixel Offset"), FSUI_CSTR("Adjusts vertices relative to upscaling."), "EmuCore/GS",
 				"UserHacks_HalfPixelOffset", 0, s_half_pixel_offset_options, std::size(s_half_pixel_offset_options), true);
+			DrawIntListSetting(bsi, FSUI_CSTR("Native Scaling"), FSUI_CSTR("Attempt to do rescaling at native resolution."), "EmuCore/GS",
+				"UserHacks_native_scaling", 0, s_native_scaling_options, std::size(s_native_scaling_options), true);
 			DrawIntListSetting(bsi, FSUI_CSTR("Round Sprite"), FSUI_CSTR("Adjusts sprite coordinates."), "EmuCore/GS",
 				"UserHacks_round_sprite_offset", 0, s_round_sprite_options, std::size(s_round_sprite_options), true);
 			DrawIntListSetting(bsi, FSUI_CSTR("Bilinear Upscale"),

--- a/pcsx2/ImGui/ImGuiOverlays.cpp
+++ b/pcsx2/ImGui/ImGuiOverlays.cpp
@@ -392,6 +392,8 @@ __ri void ImGuiManager::DrawSettingsOverlay(float scale, float margin, float spa
 			APPEND("HPO={} ", static_cast<u32>(GSConfig.UserHacks_HalfPixelOffset));
 		if (GSConfig.UserHacks_RoundSprite > 0)
 			APPEND("RS={} ", GSConfig.UserHacks_RoundSprite);
+		if (GSConfig.UserHacks_NativeScaling > GSNativeScaling::Off)
+			APPEND("NS={} ", static_cast<unsigned>(GSConfig.UserHacks_NativeScaling));
 		if (GSConfig.UserHacks_TCOffsetX != 0 || GSConfig.UserHacks_TCOffsetY != 0)
 			APPEND("TCO={}/{} ", GSConfig.UserHacks_TCOffsetX, GSConfig.UserHacks_TCOffsetY);
 		if (GSConfig.UserHacks_CPUSpriteRenderBW != 0)

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -727,6 +727,7 @@ bool Pcsx2Config::GSOptions::OptionsAreEqual(const GSOptions& right) const
 		OpEqu(UserHacks_AutoFlush) &&
 		OpEqu(UserHacks_HalfPixelOffset) &&
 		OpEqu(UserHacks_RoundSprite) &&
+		OpEqu(UserHacks_NativeScaling) &&
 		OpEqu(UserHacks_TCOffsetX) &&
 		OpEqu(UserHacks_TCOffsetY) &&
 		OpEqu(UserHacks_CPUSpriteRenderBW) &&
@@ -908,6 +909,7 @@ void Pcsx2Config::GSOptions::LoadSave(SettingsWrapper& wrap)
 
 	SettingsWrapIntEnumEx(UserHacks_HalfPixelOffset, "UserHacks_HalfPixelOffset");
 	SettingsWrapBitfieldEx(UserHacks_RoundSprite, "UserHacks_round_sprite_offset");
+	SettingsWrapIntEnumEx(UserHacks_NativeScaling, "UserHacks_native_scaling");
 	SettingsWrapBitfieldEx(UserHacks_TCOffsetX, "UserHacks_TCOffsetX");
 	SettingsWrapBitfieldEx(UserHacks_TCOffsetY, "UserHacks_TCOffsetY");
 	SettingsWrapBitfieldEx(UserHacks_CPUSpriteRenderBW, "UserHacks_CPUSpriteRenderBW");
@@ -964,6 +966,7 @@ void Pcsx2Config::GSOptions::MaskUserHacks()
 	UserHacks_DisableRenderFixes = false;
 	UserHacks_HalfPixelOffset = GSHalfPixelOffset::Off;
 	UserHacks_RoundSprite = 0;
+	UserHacks_NativeScaling = GSNativeScaling::Off;
 	UserHacks_AutoFlush = GSHWAutoFlushLevel::Disabled;
 	GPUPaletteConversion = false;
 	PreloadFrameWithGSData = false;
@@ -996,6 +999,7 @@ void Pcsx2Config::GSOptions::MaskUpscalingHacks()
 	UserHacks_NativePaletteDraw = false;
 	UserHacks_HalfPixelOffset = GSHalfPixelOffset::Off;
 	UserHacks_RoundSprite = 0;
+	UserHacks_NativeScaling = GSNativeScaling::Off;
 	UserHacks_TCOffsetX = 0;
 	UserHacks_TCOffsetY = 0;
 }


### PR DESCRIPTION
### Description of Changes
Downscales targets when being shrunk for post processing/bloom reaosns

### Rationale behind Changes
A lot of games do bloom effects which rely on bilinear filtering, when you upscale this filtering gets completely broken or becomes exponentially more intensive to compute (if we did so). This PR will downscale the target to native resolution before bilinearly shrinking it.

This won't fix everything magically, but it will improve some games.

### Suggested Testing Steps
Test games which have horrible looking post processing at high resolution.

Keep in mind, this option is forced on in this PR but will become an upscaling fix later.

Screenshots from x8 or x3
Tomb Raider Legend:
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/05bc85c7-4c8d-4870-9519-9cad54715572)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/fc16ece4-3b2a-4d2c-89aa-db0cccf84133)


Project Snowblind:
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/4970de2e-e897-44dd-8526-9beb4c591b9b)
PR (SW looks like this too):
![image](https://github.com/PCSX2/pcsx2/assets/6278726/5efe1387-3fb7-457f-bda4-c6b8b4ac3f57)

Valkyrie Profile 2:
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/40c5886d-8b27-4b1a-8260-bb3b1b268bae)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/8d00cf08-df7f-4bd7-8d69-cf6ac7fb1e77)

Devil May Cry 3:
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/52c95efe-3eb3-4233-94a3-c81b290fcaca)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/81759a5b-804d-448a-921f-47241b61904a)

Tony Hawk Project 8:
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/4617f103-0b07-49e1-99de-13bd13ac0a49)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/41e3f4e5-b131-42e9-898c-cbf339e89607)

Dragonball Z BT 3:
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/089bd92a-250a-43c7-b9ec-8cf0cc7123b5)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/c5138e52-1465-4513-835e-57a3851eb279)

Yakuza:
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/79e18fec-005b-472a-a19b-6a6c6f2419aa)

PR;
![image](https://github.com/PCSX2/pcsx2/assets/6278726/a15f2b43-468b-41ae-983a-3aadbe3a8261)

Complete list of games affected by this PR are as follows:

.hack infection/fragment - Special texture (fixes Depth of field alignment)
Ace Combat 04 - Aggressive
Area 51 - Aggressive
B-Boy - Align native
Band Hero - Align to native
Barbie Horse Adventures - Riding Camp - Normal + Align to Native
Bee Movie - Aggressive + Align to Native
Bionacle Heroes - Aggressive
Black - Aggressive + special texture (align native is more correct but the low resolution lights look more obvious)
Brave - The Spirit Dancer - Normal + Align to Native
Burnout 2 onward - aggressive
Cat woman - Aggressive + special texture (Fixes post processing alignment) - keep AF and Tex in RT
Chronicles of Narnia - Prince Caspian - Normal + Special Texture
Colosseum - Road to Victory - Normal + Align Native - remove round sprite + CLUT Render
Corvette - Aggressive + align native (fixes reflections and post positioning)
Crimson Tears - Aggressive + Normal vertex (fixes post position) - remove round sprite + force even
DBZ - BT - Aggressive + align native, remove CPU CLUT
DBZ - BT2 - Aggressive + align native
DBZ - BT3 - Aggressive + align native, remove CPU CLUT
Def Jam - Normal + align native
Destroy All Humans! - Aggressive + Special Texture
Destroy All Humans! 2 - Aggressive + Special Texture
Devil May Cry 3 - Aggressive + Align to native, remove round sprite
Drakengard 2 - Aggressive + Align to Native
Driv3r - Special Texture - remove round sprite
Ed, Edd and Eddy - Aggressive + align native - fixes post processing
Fahrenheit - Aggressive + Align Native (Fixes lighting smoothness and positioning)
Fast and the Furious - Normal + Autoflush
Ford Racing 2 - Aggressive + Align Native (nice soft cloud shadow)
Ghost in the Shell - Normal + Align Native + AF 1 + Estimate Region - Remove Merge sprite
Gladitator - Road to Freedom - Normal + Align Native - remove round sprite + CLUT Render
Gladitator - Sword of Vengeance - Normal + Align Native - remove round sprite
Guitar Hero 3 onward - Normal + Align to native
Headhunter - Aggressive + Align native
Incredible Hulk, The - Ultimate Destruction - Normal + Align to Native 
Incredibles - Aggressive + Align Native (fixes post effects and position)
Indiana Jones Emperors Tomb + Staff of Kings = aggressive + align native
Iron Man - Aggressive + Align to Native
Jojo no Kimyou na Bouken - Phantom Blood - Aggressive + Align to Native
Just Cause - Aggressive + (Special Texture)
Killzone - Aggressive + Align to Native
Kingdom Hearts II + Final Mix  - Aggressive + Special Texture (ATN causes some glitches)
LEGO Batman - Normal + Align to Native - Remove CPU CLUT Render
LEGO Indiana Jones - Normal + Align to Native
LEGO Star Wars II - Normal + Align Native - Remove CPU CLUT Render
Lemony Snicket's Series of Unfortunate Events - aggressive + align native
Lord of the Rings - The Third Age - Aggressive + Align Native (post effect)
Madagascar - Aggressive - Removed round sprite
Malice - Normal + Align to Native
Matrix, The - Path of Neo - Aggressive
Mercenaries - Normal
Metal Gear Solid 3 - aggressive + align to native
Midnight club 3 - aggressive + align native
Monster House - aggressive + align native
Mortal Kombat - Deadly Alliance - Aggressive + align native (soft shadows) - keep round sprite
Narc - Aggressive + Align Native (fixes post positioning)
Naruto - All games - Aggressive + Special Texture (fixes post blending and alignment)
Okami - Aggressive + align native - Remove round sprite full
Onimusha - Dawn of Dreams - Aggressive + align native
Onimusha 2 - align native + round sprite full for text
Onimusha 3 - Aggressive + align native
Parappa the Rapper 2 - aggressive + align to native
Power Rangers - Super Legends - Aggressive + align native (fixes post process alignment)
Prince of Persia - Sands of Time - Aggressive + Align to Native
Prince of Persia - Two Thrones  - Aggressive + Align to Native
Prince of Persia - Warrior Within  - Aggressive + Align to Native
Project Snowblind - aggressive + Align Native
Ratatouille - aggressive + align native - remove even sprite (fixes post processing position)
Ratchet + Clank (all games) - Normal + align native
Resident Evil - Dead Aim / Gun Survivor 4 - Aggressive + Align to Native
Ridge Racer V - replace CLUT renderer with CSBW 1/1
Robots - Aggressive + Align to Native
RPM Tuning - Aggressive + Special Texture
Ruff Trigger - The Vanocore Conspiracy - Normal native scaling
Scarface - The World is Ours - Normal
Sega Rally 2006 - Aggressive + Align native (soft shadows)
Sega Superstar Tennis - Normal + Align native
Shadow of the Colossus - Aggressive
Shadow of Rome - Aggressive + Align to Native
Shadow the  Hedgehog  - Aggressive + Align to Native
Shadow Hearts - Covenant - No Native Scaling, just replacing hacks with Align to Native.
Shox - Aggressive (fixes window reflection) + Align Native (UI positioning)
Sniper Elite - Aggressive
Splinter Cell - aggressive + align native (fixes post processing) + recommend full blending to full to fix lighting effects (high barriers)
Spongebob - the movie - Aggressive + align native to fix post - Remove CLUT renderer
Springdale - Aggressive + Align Native (Fixes post alignment)
Spyro - The Eternal Night - Normal + Normal Vertex (fixes lighting post, aggressive makes shadows low res, ATN causes obvious edge garbage)
Spyro Dawn of the Dragon - remove CLUT and CSBW, add NS aggressive + align native
Star Ocean 3 - Aggressive + Align to Native
Star Wars Battlefront - Aggressive + Align Native
Star Wars Battlefront 2 - Aggressive + Align Native
Syphon Filter Dark Mirror - aggressive
Syphon Filter: Logan's Shadow - Aggressive
Tales of the Abyss - Normal + Align to Native
Tekken 5 - Normal
The Chikyuu Boueigun/Monster Attack - Align to Native
The Chikyuu Boueigun 2/Global Defence Force/Terra Defence Force - Normal + Align to Naitive
The Suffering - aggressive + align native (does get a small bit of top edge bleed in some cases)
Thrillville - Aggressive
Thrillville - Off the Rails - Aggressive + Align to Native
TOCA Race Driver 3 - Normal + Special + RS half - remove align sprite (V8 Supercars and DTM Race)
Tomb raider legend + underworld = normal
Tony Hawk games after 4 - Normal + Align native - remove merge sprites and force even
Total Overdose - Normal + Align Native
Toy Story 3 - aggressive + align native - remove even sprite (fixes post processing position)
Transformers - Revenge of the Fallen - Aggressive + Align to Native
Transformers - The Game - Normal + Special Texture
True Crime NYC - Aggressive
True Crime - Streets of LA - Align to Native
Valkyrie Profile 2 - aggressive (also change to align native)
Wakeboarding Unleashed - Aggressive (water reflections)
WALL-E - aggressive + align native - remove even sprite (fixes post processing position) - remove round sprite + CSBW
Wallace and Gromit - Curse of the were-rabbit - Normal + Align native
Wallace and Gromit - Project Zoo - special texture - native scaling is more right but low res makes it gross.
WRC 1, 2, 4 - Aggressive + special texture
Xenosaga Episode III - aggressive + change to align to native remove round sprite full - autoflush sprite only
Xenosage Episode I - change to align to native remove round sprite full - autoflush sprite only
Yakuza - Aggressive - maybe note ATN corrects the alignment but currently causes visual problems
Yakuza 2 - Aggressive - maybe note ATN and no align sprite corrects the alignment but currently causes visual problems
Yumeria - aggressive + special texture (fix post alignment and text alignment)
Zone of Enders 2nd runner - aggressive + normal vertex fix DoF