### PR TITLE
GS/HW: Take render target end block for channel shuffles if bigger

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -2792,6 +2792,10 @@ void GSRendererHW::Draw()
 
 				if (m_last_channel_shuffle_end_block < rt->m_TEX0.TBP0)
 					m_last_channel_shuffle_end_block += MAX_BLOCKS;
+
+				// if the RT is bigger, then use that instead.
+				if (m_last_channel_shuffle_end_block < rt->m_end_block)
+					m_last_channel_shuffle_end_block = rt->m_end_block;
 			}
 		}
 		else


### PR DESCRIPTION
### Description of Changes
Takes the render target end block if bigger than calculated end on channel shuffle

### Rationale behind Changes
Source isn't a perfect source of truth, if it's not drawn the entire size of it the end block may be incorrect.  We kinda cheat with channel shuffles anyways, so if the render target end is larger, assume that ending.

### Suggested Testing Steps
Test Mercenaries (already done)

Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/96ad5adb-4f30-4028-bad2-6de748bd4d8c)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/78f5323f-bfcd-4138-9e3c-965818770228)

