### PR TITLE
CI: Tempfix windows clang builds

### DIFF
--- a/.github/workflows/windows_build_qt.yml
+++ b/.github/workflows/windows_build_qt.yml
@@ -55,6 +55,10 @@ jobs:
       POWERSHELL_TELEMETRY_OPTOUT: 1
 
     steps:
+      - name: Tempfix Clang
+        if: inputs.configuration == 'CMake'
+        run: choco upgrade llvm
+        
       - name: Checkout Repository
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
### Description of Changes
temp fix the clang cmake builds until the action runner gets fixed. See [#10001](https://github.com/actions/runner-images/issues/10001)

### Rationale behind Changes
Runner broked.

### Suggested Testing Steps
Watch runner
