### PR TITLE
CI/Windows: Disable Qt's PCRE2 JIT

### DIFF
--- a/.github/workflows/scripts/windows/build-dependencies.bat
+++ b/.github/workflows/scripts/windows/build-dependencies.bat
@@ -189,6 +189,10 @@ echo Building Qt base...
 rmdir /S /Q "qtbase-everywhere-src-%QT%"
 %SEVENZIP% x "qtbase-everywhere-src-%QT%.zip" || goto error
 cd "qtbase-everywhere-src-%QT%" || goto error
+
+rem Disable the PCRE2 JIT, it doesn't properly verify AVX2 support.
+%PATCH% -p1 < "%SCRIPTDIR%\qtbase-disable-pcre2-jit.patch" || goto error
+
 cmake -B build -DFEATURE_sql=OFF -DCMAKE_INSTALL_PREFIX="%INSTALLDIR%" %FORCEPDB% -DINPUT_gui=yes -DINPUT_widgets=yes -DINPUT_ssl=yes -DINPUT_openssl=no -DINPUT_schannel=yes -DFEATURE_system_png=ON -DFEATURE_system_jpeg=ON -DFEATURE_system_zlib=ON -DFEATURE_system_freetype=ON -DFEATURE_system_harfbuzz=ON %QTBUILDSPEC% || goto error
 cmake --build build --parallel || goto error
 ninja -C build install || goto error

--- a/.github/workflows/scripts/windows/qtbase-disable-pcre2-jit.patch
+++ b/.github/workflows/scripts/windows/qtbase-disable-pcre2-jit.patch
@@ -1,0 +1,35 @@
+--- qtbase/src/3rdparty/pcre2/CMakeLists.txt	2024-03-19 08:46:43.000000000 -0700
++++ qtbase/src/3rdparty/pcre2/CMakeLists.txt	2024-06-06 21:52:20.539619500 -0700
+@@ -41,6 +41,7 @@
+         src/pcre2_xclass.c
+     DEFINES
+         HAVE_CONFIG_H
++        PCRE2_DISABLE_JIT
+     PUBLIC_DEFINES
+         PCRE2_CODE_UNIT_WIDTH=16
+     PUBLIC_INCLUDE_DIRECTORIES
+@@ -52,23 +53,8 @@
+ ## Scopes:
+ #####################################################################
+ 
+-qt_internal_extend_target(BundledPcre2 CONDITION QNX OR UIKIT
+-    DEFINES
+-        PCRE2_DISABLE_JIT
+-)
+-
+-qt_internal_extend_target(BundledPcre2 CONDITION (TEST_architecture_arch STREQUAL "arm") AND WIN32
+-    DEFINES
+-        PCRE2_DISABLE_JIT
+-)
+-
+-qt_internal_extend_target(BundledPcre2 CONDITION (TEST_architecture_arch STREQUAL "arm64") AND WIN32
+-    DEFINES
+-        PCRE2_DISABLE_JIT
+-)
+-
+ if (APPLE)
+-    target_compile_options(BundledPcre2 PRIVATE "SHELL:-Xarch_arm64 -DPCRE2_DISABLE_JIT")
++    target_compile_options(BundledPcre2 PRIVATE "SHELL:-Xarch_arm64")
+ endif()
+ 
+ qt_internal_extend_target(BundledPcre2 CONDITION WIN32


### PR DESCRIPTION
### Description of Changes

Backport of https://github.com/stenzek/duckstation/commit/daed75de20e8d533bf0ef3a53b314780ba1d136e

### Rationale behind Changes

For some reason that I can't be bothered to debug, the AVX2 detection in PCRE2 doesn't behave correctly in a VM that has `xsave` disabled via `bcdedit`, which is the only way I have of testing SSE4 builds.

So just disable the JIT instead, it's not like we're heavily using regexp.

### Suggested Testing Steps

Make sure it still runs.
