### PR TITLE
3rdparty: Update xbyak to 7.06

### DIFF
--- a/3rdparty/xbyak/xbyak/xbyak.h
+++ b/3rdparty/xbyak/xbyak/xbyak.h
@@ -155,7 +155,7 @@ namespace Xbyak {
 
 enum {
 	DEFAULT_MAX_CODE_SIZE = 4096,
-	VERSION = 0x7051 /* 0xABCD = A.BC(.D) */
+	VERSION = 0x7060 /* 0xABCD = A.BC(.D) */
 };
 
 #ifndef MIE_INTEGER_TYPE_DEFINED

--- a/3rdparty/xbyak/xbyak/xbyak_mnemonic.h
+++ b/3rdparty/xbyak/xbyak/xbyak_mnemonic.h
@@ -1,4 +1,4 @@
-const char *getVersionString() const { return "7.05.1"; }
+const char *getVersionString() const { return "7.06"; }
 void aadd(const Address& addr, const Reg32e &reg) { opMR(addr, reg, T_0F38, 0x0FC, T_APX); }
 void aand(const Address& addr, const Reg32e &reg) { opMR(addr, reg, T_0F38|T_66, 0x0FC, T_APX|T_66); }
 void adc(const Operand& op, uint32_t imm) { opOI(op, imm, 0x10, 2); }


### PR DESCRIPTION
### Description of Changes
Updates to latest xbyak release.

### Rationale behind Changes
Might fix https://github.com/PCSX2/pcsx2/issues/11345 a crash on older AMD CPUs apparently.

### Suggested Testing Steps
Make sure nothing explodes.
