### PR TITLE
input-rec: Use toNativeSeparators() when using the recording viewing

### DIFF
--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -1748,6 +1748,12 @@ void MainWindow::onInputRecNewActionTriggered()
 						m_ui.actionToolbarReset->setEnabled(!g_InputRecording.isTypeSavestate());
 					});
 				}
+				else
+				{
+					Host::ReportErrorAsync(
+						TRANSLATE_SV("MainWindow", "Input Recording Failed"),
+						fmt::format(TRANSLATE_FS("MainWindow", "Failed to create file: {}"), filePath));
+				}
 			});
 	}
 
@@ -1800,6 +1806,12 @@ void MainWindow::onInputRecPlayActionTriggered()
 					m_ui.actionReset->setEnabled(!g_InputRecording.isTypeSavestate());
 					m_ui.actionToolbarReset->setEnabled(!g_InputRecording.isTypeSavestate());
 				});
+			}
+			else
+			{
+				Host::ReportErrorAsync(
+					TRANSLATE_SV("MainWindow", "Input Playback Failed"),
+					fmt::format(TRANSLATE_FS("MainWindow", "Failed to open file: {}"), filename));
 			}
 		});
 	}

--- a/pcsx2-qt/Tools/InputRecording/InputRecordingViewer.cpp
+++ b/pcsx2-qt/Tools/InputRecording/InputRecordingViewer.cpp
@@ -4,6 +4,7 @@
 #include "InputRecordingViewer.h"
 
 #include "QtUtils.h"
+#include <QtCore/QDir>
 #include <QtCore/QString>
 #include <QtWidgets/QDialog>
 #include <QtWidgets/qfiledialog.h>
@@ -89,7 +90,7 @@ void InputRecordingViewer::openFile()
 	}
 	if (!fileNames.isEmpty())
 	{
-		const std::string fileName = fileNames.first().toStdString();
+		const std::string fileName = QDir::toNativeSeparators(fileNames.first()).toStdString();
 		m_file_open = m_file.openExisting(fileName);
 		m_ui.actionClose->setEnabled(m_file_open);
 		if (m_file_open)

--- a/pcsx2-qt/Tools/InputRecording/InputRecordingViewer.cpp
+++ b/pcsx2-qt/Tools/InputRecording/InputRecordingViewer.cpp
@@ -7,6 +7,7 @@
 #include <QtCore/QDir>
 #include <QtCore/QString>
 #include <QtWidgets/QDialog>
+#include <QtWidgets/QMessageBox>
 #include <QtWidgets/qfiledialog.h>
 
 // TODO - for now this uses a very naive implementation that fills the entire table
@@ -96,7 +97,11 @@ void InputRecordingViewer::openFile()
 		if (m_file_open)
 		{
 			loadTable();
-		} // TODO else error
+		}
+		else
+		{
+			QMessageBox::critical(this, tr("Opening Recording Failed"), tr("Failed to open file: %1").arg(QString::fromUtf8(fileName.c_str())));
+		}
 	}
 }
 


### PR DESCRIPTION
### Description of Changes
Use `QDir::toNativeSeparators()` to convert directory separators from / to \ on Windows when opening a file for input playback
Also adds a message box when we are unable to open the file

### Rationale behind Changes
I saw it mentioned in the discord that this was also broken
See #11332 for the need to use `QDir::toNativeSeparators()`
Provide a message box to make the failure clear (also this was mentioned as a TODO in the recording viewer)

### Suggested Testing Steps
Open a recording in the input recording viewer and see if it loads.
