### PR TITLE
GS/HW: Extend blend second pass to more blend formulas v2.

### DIFF
--- a/bin/resources/shaders/dx11/tfx.fx
+++ b/bin/resources/shaders/dx11/tfx.fx
@@ -976,8 +976,10 @@ void ps_blend(inout float4 Color, inout float4 As_rgba, float2 pos_xy)
 		}
 		else if (PS_BLEND_HW == 4)
 		{
-			// Needed for Cd * (1 - Ad)
-			Color.rgb = (float3)128.0f;
+			// Needed for Cd * (1 - Ad) and Cd*(1 + Alpha)
+			float Alpha = PS_BLEND_C == 2 ? Af : As;
+			As_rgba.rgb = (float3)Alpha * (float3)(128.0f / 255.0f);
+			Color.rgb = (float3)127.5f;
 		}
 	}
 }

--- a/bin/resources/shaders/opengl/tfx_fs.glsl
+++ b/bin/resources/shaders/opengl/tfx_fs.glsl
@@ -936,8 +936,15 @@ float As = As_rgba.a;
 	float color_compensate = 255.0f / max(128.0f, max_color);
 	Color.rgb *= vec3(color_compensate);
 #elif PS_BLEND_HW == 4
-	// Needed for Cd * (1 - Ad)
-	Color.rgb = vec3(128.0f);
+	// Needed for Cd * (1 - Ad) and Cd*(1 + Alpha)
+
+#if PS_BLEND_C == 2
+	float Alpha = Af;
+#else
+	float Alpha = As;
+#endif
+	As_rgba.rgb = vec3(Alpha) * vec3(128.0f / 255.0f);
+	Color.rgb = vec3(127.5f);
 #endif
 
 #endif

--- a/bin/resources/shaders/vulkan/tfx.glsl
+++ b/bin/resources/shaders/vulkan/tfx.glsl
@@ -1203,8 +1203,16 @@ void ps_blend(inout vec4 Color, inout vec4 As_rgba)
 			float color_compensate = 255.0f / max(128.0f, max_color);
 			Color.rgb *= vec3(color_compensate);
 		#elif PS_BLEND_HW == 4
-			// Needed for Cd * (1 - Ad)
-			Color.rgb = vec3(128.0f);
+			// Needed for Cd * (1 - Ad) and Cd*(1 + Alpha)
+
+			#if PS_BLEND_C == 2
+				float Alpha = Af;
+			#else
+				float Alpha = As;
+			#endif
+
+			As_rgba.rgb = vec3(Alpha) * vec3(128.0f / 255.0f);
+			Color.rgb = vec3(127.5f);
 		#endif
 	#endif
 }

--- a/pcsx2/GS/Renderers/Common/GSDevice.h
+++ b/pcsx2/GS/Renderers/Common/GSDevice.h
@@ -167,6 +167,18 @@ enum ChannelFetch
 	ChannelFetch_GXBY  = 6,
 };
 
+enum class HWBlendType
+{
+	SRC_ONE_DST_FACTOR      = 1, // Use the dest color as blend factor, Cs is set to 1.
+	SRC_ALPHA_DST_FACTOR    = 2, // Use the dest color as blend factor, Cs is set to (Alpha - 1).
+	SRC_DOUBLE              = 3, // Double source color.
+	SRC_HALF_ONE_DST_FACTOR = 4, // Use the dest color as blend factor, Cs is set to 0.5, additionally divide As or Af by 2.
+
+	BMIX1_ALPHA_HIGH_ONE    = 1, // Blend formula is replaced when alpha is higher than 1.
+	BMIX1_SRC_HALF          = 2, // Impossible blend will always be wrong on hw, divide Cs by 2.
+	BMIX2_OVERFLOW          = 3, // Blending Cs might overflow, try to compensate.
+};
+
 struct alignas(16) DisplayConstantBuffer
 {
 	GSVector4 SourceRect; // +0,xyzw


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Cd*(1 + Alpha).
Alpha = As, Ad or Af.
For As or Af case when alpha > 128.
For Ad case when there is no RTA correction.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Accuracy.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test the listed dumps:
There shouldn't be any diffs or minimal since the alpha isn't higher than 128 in these games.
Found a few where it is higher than 128 but with overlap so won't help in those cases.

![image](https://github.com/PCSX2/pcsx2/assets/18107717/454824d7-ae24-4baa-ac70-244e0448aada)
