### PR TITLE
GS: GSVector maintenance/tidyup

### DIFF
--- a/pcsx2-gsrunner/Main.cpp
+++ b/pcsx2-gsrunner/Main.cpp
@@ -17,6 +17,7 @@
 
 #include "common/Assertions.h"
 #include "common/Console.h"
+#include "common/CrashHandler.h"
 #include "common/FileSystem.h"
 #include "common/MemorySettingsInterface.h"
 #include "common/Path.h"
@@ -93,6 +94,8 @@ bool GSRunner::InitializeConfig()
 	EmuFolders::SetAppRoot();
 	if (!EmuFolders::SetResourcesDirectory() || !EmuFolders::SetDataDirectory(nullptr))
 		return false;
+
+	CrashHandler::SetWriteDirectory(EmuFolders::DataRoot);
 
 	const char* error;
 	if (!VMManager::PerformEarlyHardwareChecks(&error))
@@ -675,6 +678,7 @@ void GSRunner::DumpStats()
 
 int main(int argc, char* argv[])
 {
+	CrashHandler::Install();
 	GSRunner::InitializeConsole();
 
 	if (!GSRunner::InitializeConfig())

--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -2939,7 +2939,7 @@ GSState::PRIM_OVERLAP GSState::PrimitiveOverlap()
 
 			if (all.rintersect(sprite).rempty())
 			{
-				all = all.runion_ordered(sprite);
+				all = all.runion(sprite);
 			}
 			else
 			{

--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -1749,7 +1749,7 @@ void GSState::FlushPrim()
 					GSVector4i* RESTRICT vert_ptr = (GSVector4i*)&m_vertex.buff[i];
 					GSVector4i v = vert_ptr[1];
 					v = v.xxxx().u16to32().sub32(m_xyof);
-					v = v.blend32<12>(v.sra32(4));
+					v = v.blend32<12>(v.sra32<4>());
 					m_vertex.xy[i & 3] = v;
 					m_vertex.xy_tail = unused;
 				}

--- a/pcsx2/GS/GSVector4i.h
+++ b/pcsx2/GS/GSVector4i.h
@@ -169,28 +169,6 @@ public:
 
 	__forceinline GSVector4i runion(const GSVector4i& a) const
 	{
-		int i = (upl64(a) < uph64(a)).mask();
-
-		if (i == 0xffff)
-		{
-			return runion_ordered(a);
-		}
-
-		if ((i & 0x00ff) == 0x00ff)
-		{
-			return *this;
-		}
-
-		if ((i & 0xff00) == 0xff00)
-		{
-			return a;
-		}
-
-		return GSVector4i::zero();
-	}
-
-	__forceinline GSVector4i runion_ordered(const GSVector4i& a) const
-	{
 		return min_i32(a).upl64(max_i32(a).srl<8>());
 	}
 

--- a/pcsx2/GS/GSVector4i.h
+++ b/pcsx2/GS/GSVector4i.h
@@ -177,6 +177,16 @@ public:
 		return sat_i32(a);
 	}
 
+	__forceinline bool rintersects(const GSVector4i& v) const
+	{
+		return !rintersect(v).rempty();
+	}
+
+	__forceinline bool rcontains(const GSVector4i& v) const
+	{
+		return rintersect(v).eq(v);
+	}
+
 	template <Align_Mode mode>
 	GSVector4i _ralign_helper(const GSVector4i& mask) const
 	{
@@ -671,40 +681,66 @@ public:
 		return GSVector4i(_mm_slli_si128(m, i));
 	}
 
-	template <int i>
-	__forceinline GSVector4i sra16() const
-	{
-		return GSVector4i(_mm_srai_epi16(m, i));
-	}
-
-	template <int i>
-	__forceinline GSVector4i sra32() const
-	{
-		return GSVector4i(_mm_srai_epi32(m, i));
-	}
-
-	__forceinline GSVector4i sra32(int i) const
-	{
-		return GSVector4i(_mm_srai_epi32(m, i));
-	}
-
-#if _M_SSE >= 0x501
-	__forceinline GSVector4i srav32(const GSVector4i& v) const
-	{
-		return GSVector4i(_mm_srav_epi32(m, v.m));
-	}
-#endif
-
-	template<int i>
+	template <s32 i>
 	__forceinline GSVector4i sll16() const
 	{
 		return GSVector4i(_mm_slli_epi16(m, i));
 	}
 
-	template <int i>
+	__forceinline GSVector4i sll16(s32 i) const
+	{
+		return GSVector4i(_mm_sll_epi16(m, _mm_cvtsi32_si128(i)));
+	}
+
+#if _M_SSE >= 0x501
+	__forceinline GSVector4i sllv16(const GSVector4i& v) const { return GSVector4i(_mm_sllv_epi16(m, v.m)); }
+#endif
+
+	template <s32 i>
+	__forceinline GSVector4i srl16() const
+	{
+		return GSVector4i(_mm_srli_epi16(m, i));
+	}
+
+	__forceinline GSVector4i srl16(s32 i) const
+	{
+		return GSVector4i(_mm_srl_epi16(m, _mm_cvtsi32_si128(i)));
+	}
+
+#if _M_SSE >= 0x501
+	__forceinline GSVector4i srlv16(const GSVector4i& v) const
+	{
+		return GSVector4i(_mm_srlv_epi16(m, v.m));
+	}
+#endif
+
+	template <s32 i>
+	__forceinline GSVector4i sra16() const
+	{
+		return GSVector4i(_mm_srai_epi16(m, i));
+	}
+
+	__forceinline GSVector4i sra16(s32 i) const
+	{
+		return GSVector4i(_mm_sra_epi16(m, _mm_cvtsi32_si128(i)));
+	}
+
+#if _M_SSE >= 0x501
+	__forceinline GSVector4i srav16(const GSVector4i& v) const
+	{
+		return GSVector4i(_mm_srav_epi16(m, v.m));
+	}
+#endif
+
+	template <s32 i>
 	__forceinline GSVector4i sll32() const
 	{
 		return GSVector4i(_mm_slli_epi32(m, i));
+	}
+
+	__forceinline GSVector4i sll32(s32 i) const
+	{
+		return GSVector4i(_mm_sll_epi32(m, _mm_cvtsi32_si128(i)));
 	}
 
 #if _M_SSE >= 0x501
@@ -714,38 +750,87 @@ public:
 	}
 #endif
 
-	template <int i>
-	__forceinline GSVector4i sll64() const
-	{
-		return GSVector4i(_mm_slli_epi64(m, i));
-	}
-
-	template <int i>
-	__forceinline GSVector4i srl16() const
-	{
-		return GSVector4i(_mm_srli_epi16(m, i));
-	}
-
-	__forceinline GSVector4i srl16(int i) const
-	{
-		return GSVector4i(_mm_srli_epi16(m, i));
-	}
-
-	template <int i>
+	template <s32 i>
 	__forceinline GSVector4i srl32() const
 	{
 		return GSVector4i(_mm_srli_epi32(m, i));
 	}
 
-	__forceinline GSVector4i srl32(int i) const
+	__forceinline GSVector4i srl32(s32 i) const
 	{
-		return GSVector4i(_mm_srli_epi32(m, i));
+		return GSVector4i(_mm_srl_epi32(m, _mm_cvtsi32_si128(i)));
 	}
 
 #if _M_SSE >= 0x501
 	__forceinline GSVector4i srlv32(const GSVector4i& v) const
 	{
 		return GSVector4i(_mm_srlv_epi32(m, v.m));
+	}
+#endif
+
+	template <s32 i>
+	__forceinline GSVector4i sra32() const
+	{
+		return GSVector4i(_mm_srai_epi32(m, i));
+	}
+
+	__forceinline GSVector4i sra32(s32 i) const
+	{
+		return GSVector4i(_mm_sra_epi32(m, _mm_cvtsi32_si128(i)));
+	}
+
+#if _M_SSE >= 0x501
+	__forceinline GSVector4i srav32(const GSVector4i& v) const
+	{
+		return GSVector4i(_mm_srav_epi32(m, v.m));
+	}
+#endif
+
+	template <s64 i>
+	__forceinline GSVector4i sll64() const
+	{
+		return GSVector4i(_mm_slli_epi64(m, i));
+	}
+
+	__forceinline GSVector4i sll64(s32 i) const
+	{
+		return GSVector4i(_mm_sll_epi64(m, _mm_cvtsi32_si128(i)));
+	}
+
+#if _M_SSE >= 0x501
+	__forceinline GSVector4i sllv64(const GSVector4i& v) const
+	{
+		return GSVector4i(_mm_sllv_epi64(m, v.m));
+	}
+#endif
+
+	template <s64 i>
+	__forceinline GSVector4i srl64() const
+	{
+		return GSVector4i(_mm_srli_epi64(m, i));
+	}
+
+	__forceinline GSVector4i srl64(s32 i) const
+	{
+		return GSVector4i(_mm_srl_epi64(m, _mm_cvtsi32_si128(i)));
+	}
+
+#if _M_SSE >= 0x501
+	__forceinline GSVector4i srlv64(const GSVector4i& v) const
+	{
+		return GSVector4i(_mm_srlv_epi64(m, v.m));
+	}
+#endif
+
+	__forceinline GSVector4i sra64(s32 i) const
+	{
+		return GSVector4i(_mm_sra_epi64(m, _mm_cvtsi32_si128(i)));
+	}
+
+#if _M_SSE >= 0x501
+	__forceinline GSVector4i srav64(const GSVector4i& v) const
+	{
+		return GSVector4i(_mm_srav_epi64(m, v.m));
 	}
 #endif
 
@@ -967,6 +1052,21 @@ public:
 		return GSVector4i(_mm_cmpgt_epi32(m, v.m));
 	}
 
+	__forceinline GSVector4i ge8(const GSVector4i& v) const
+	{
+		return ~GSVector4i(_mm_cmplt_epi8(m, v.m));
+	}
+
+	__forceinline GSVector4i ge16(const GSVector4i& v) const
+	{
+		return ~GSVector4i(_mm_cmplt_epi16(m, v.m));
+	}
+
+	__forceinline GSVector4i ge32(const GSVector4i& v) const
+	{
+		return ~GSVector4i(_mm_cmplt_epi32(m, v.m));
+	}
+
 	__forceinline GSVector4i lt8(const GSVector4i& v) const
 	{
 		return GSVector4i(_mm_cmplt_epi8(m, v.m));
@@ -980,6 +1080,19 @@ public:
 	__forceinline GSVector4i lt32(const GSVector4i& v) const
 	{
 		return GSVector4i(_mm_cmplt_epi32(m, v.m));
+	}
+
+	__forceinline GSVector4i le8(const GSVector4i& v) const
+	{
+		return ~GSVector4i(_mm_cmpgt_epi8(m, v.m));
+	}
+	__forceinline GSVector4i le16(const GSVector4i& v) const
+	{
+		return ~GSVector4i(_mm_cmpgt_epi16(m, v.m));
+	}
+	__forceinline GSVector4i le32(const GSVector4i& v) const
+	{
+		return ~GSVector4i(_mm_cmpgt_epi32(m, v.m));
 	}
 
 	__forceinline GSVector4i andnot(const GSVector4i& v) const

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -429,7 +429,7 @@ void GSRendererHW::ConvertSpriteTextureShuffle(u32& process_rg, u32& process_ba,
 		// So, halve it ourselves.
 
 		const GSVector4i dr = m_r;
-		const GSVector4i r = half_bottom_vert ? dr.blend32<0xA>(dr.sra32(1)) : dr.blend32<5>(dr.sra32(1)); // Half Y : Half X
+		const GSVector4i r = half_bottom_vert ? dr.blend32<0xA>(dr.sra32<1>()) : dr.blend32<5>(dr.sra32<1>()); // Half Y : Half X
 		GL_CACHE("ConvertSpriteTextureShuffle: Rewrite from %d,%d => %d,%d to %d,%d => %d,%d",
 			static_cast<int>(m_vt.m_min.p.x), static_cast<int>(m_vt.m_min.p.y), static_cast<int>(m_vt.m_min.p.z),
 			static_cast<int>(m_vt.m_min.p.w), r.x, r.y, r.z, r.w);
@@ -1746,10 +1746,10 @@ void GSRendererHW::SwSpriteRender()
 				const GSVector4i A = alpha_a == 0 ? sc : alpha_a == 1 ? dc0 : GSVector4i::zero();
 				const GSVector4i B = alpha_b == 0 ? sc : alpha_b == 1 ? dc0 : GSVector4i::zero();
 				const GSVector4i C = alpha_c == 2 ? GSVector4i(alpha_fix).xxxx().ps32()
-				                                  : (alpha_c == 0 ? sc : dc0).yyww()    // 0x00AA00BB00AA00BB00aa00bb00aa00bb
-				                                                             .srl32(16) // 0x000000AA000000AA000000aa000000aa
-				                                                             .ps32()    // 0x00AA00AA00aa00aa00AA00AA00aa00aa
-				                                                             .xxyy();   // 0x00AA00AA00AA00AA00aa00aa00aa00aa
+				                                  : (alpha_c == 0 ? sc : dc0).yyww()      // 0x00AA00BB00AA00BB00aa00bb00aa00bb
+				                                                             .srl32<16>() // 0x000000AA000000AA000000aa000000aa
+				                                                             .ps32()      // 0x00AA00AA00aa00aa00AA00AA00aa00aa
+				                                                             .xxyy();     // 0x00AA00AA00AA00AA00aa00aa00aa00aa
 				const GSVector4i D = alpha_d == 0 ? sc : alpha_d == 1 ? dc0 : GSVector4i::zero();
 				dc = A.sub16(B).mul16l(C).sra16<7>().add16(D); // (((A - B) * C) >> 7) + D, must use sra16 due to signed 16 bit values.
 				// dc alpha channels (dc.u16[3], dc.u16[7]) dirty

--- a/pcsx2/GS/Renderers/SW/GSDrawScanline.cpp
+++ b/pcsx2/GS/Renderers/SW/GSDrawScanline.cpp
@@ -103,21 +103,7 @@ void GSDrawScanline::BeginDraw(const GSRasterizerData& data, GSScanlineLocalData
 
 	if (global.sel.mmin && global.sel.lcm)
 	{
-#if defined(__GNUC__) && _M_SSE >= 0x501
-		// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=80286
-		//
-		// GCC 4.9/5/6 doesn't generate correct AVX2 code for extract32<0>. It is fixed in GCC7
-		// Intrinsic code is _mm_cvtsi128_si32(_mm256_castsi256_si128(m))
-		// It seems recent Clang got _mm256_cvtsi256_si32(m) instead. I don't know about GCC.
-		//
-		// Generated code keep the integer in an XMM register but bit [64:32] aren't cleared.
-		// So the srl16 shift will be huge and v will be 0.
-		//
-		int lod_x = global.lod.i.x0;
-		GSVector4i v = global.t.minmax.srl16(lod_x);
-#else
 		GSVector4i v = global.t.minmax.srl16(global.lod.i.extract32<0>()); //.x);
-#endif
 
 		v = v.upl16(v);
 

--- a/pcsx2/GS/Renderers/SW/GSTextureCacheSW.cpp
+++ b/pcsx2/GS/Renderers/SW/GSTextureCacheSW.cpp
@@ -225,10 +225,15 @@ bool GSTextureCacheSW::Texture::Update(const GSVector4i& rect)
 	if (!m_buff)
 	{
 		const u32 pitch = (1 << m_tw) << shift;
+		const size_t size = pitch * th * 4;
 
-		m_buff = _aligned_malloc(pitch * th * 4, VECTOR_ALIGNMENT);
+		m_buff = _aligned_malloc(size, VECTOR_ALIGNMENT);
 		if (!m_buff)
 			return false;
+
+		// This _shouldn't_ be necessary, but apparently our texture min/max is wrong somewhere,
+		// and we end up sampling from "random" malloc memory, which breaks GS dump runs.
+		std::memset(m_buff, 0, size);
 	}
 
 	GSLocalMemory& mem = g_gs_renderer->m_mem;


### PR DESCRIPTION
### Description of Changes

Replaces a few non-immediate constant shifts with the templated version.

Adds `rcontains()` and `rintersects()` helpers.

Removes `runion_ordered()`, and replaces `runion()` with the previous "ordered' version. All our rects are, well, rects, and thus ordered.

Adds `geNN()` and `leNN()` methods.

### Rationale behind Changes

Needed for Apple Silicon.

### Suggested Testing Steps

Smoke test hardware and software renderers.
HW dump runs fine, SW is acting.... strange. Need to look into it further.
