### PR TITLE
Updater: Add VC Runtime check

### DIFF
--- a/pcsx2-qt/VCRuntimeChecker.cpp
+++ b/pcsx2-qt/VCRuntimeChecker.cpp
@@ -7,10 +7,10 @@
 #include "fmt/format.h"
 
 // Minimum version is 14.38.33135.0.
-static constexpr u32 MIN_VERSION_V0 = 14;
-static constexpr u32 MIN_VERSION_V1 = 38;
-static constexpr u32 MIN_VERSION_V2 = 33135;
-static constexpr u32 MIN_VERSION_V3 = 0;
+static constexpr DWORD MIN_VERSION_V0 = 14;
+static constexpr DWORD MIN_VERSION_V1 = 38;
+static constexpr DWORD MIN_VERSION_V2 = 33135;
+static constexpr DWORD MIN_VERSION_V3 = 0;
 static constexpr const char* DOWNLOAD_URL = "https://aka.ms/vs/17/release/vc_redist.x64.exe";
 
 struct VCRuntimeCheckObject

--- a/updater/CMakeLists.txt
+++ b/updater/CMakeLists.txt
@@ -9,6 +9,7 @@ target_link_libraries(updater PRIVATE common fmt::fmt)
 target_include_directories(updater PRIVATE .)
 
 if(WIN32)
+	target_sources(updater PRIVATE ../pcsx2-qt/VCRuntimeChecker.cpp)
 	target_link_libraries(updater PRIVATE
 		LZMA::LZMA
 		Comctl32.lib

--- a/updater/updater.vcxproj
+++ b/updater/updater.vcxproj
@@ -53,6 +53,7 @@
   <ItemGroup>
     <ClCompile Include="Updater.cpp" />
     <ClCompile Include="Windows\WindowsUpdater.cpp" />
+	<ClCompile Include="$(SolutionDir)pcsx2-qt\VCRuntimeChecker.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="SZErrors.h" />

--- a/updater/updater.vcxproj.filters
+++ b/updater/updater.vcxproj.filters
@@ -3,6 +3,7 @@
   <ItemGroup>
     <ClCompile Include="Updater.cpp" />
     <ClCompile Include="Windows\WindowsUpdater.cpp">
+	<ClCompile Include="$(SolutionDir)pcsx2-qt\VCRuntimeChecker.cpp" />
       <Filter>Windows</Filter>
     </ClCompile>
   </ItemGroup>


### PR DESCRIPTION
### Description of Changes
Add VC runtime checker to the updater

### Rationale behind Changes
So it warns user that try to run the new version.

### Suggested Testing Steps
Run the updater with an old VC Runtime installed.
