### PR TITLE
GS:Capture: VAAPI support

### DIFF
--- a/pcsx2/GS/GSCapture.cpp
+++ b/pcsx2/GS/GSCapture.cpp
@@ -460,6 +460,8 @@ bool GSCapture::BeginCapture(float fps, GSVector2i recommendedResolution, float 
 				}
 			}
 		}
+		if (sw_pix_fmt == AV_PIX_FMT_VAAPI)
+			sw_pix_fmt = AV_PIX_FMT_NV12;
 		s_video_codec_context->pix_fmt = sw_pix_fmt;
 
 		// Can we use hardware encoding?


### PR DESCRIPTION
### Description of Changes
VAAPI seems to report as supporting `AV_PIX_FMT_VAAPI` but trying to create with a `sw_format` of `AV_PIX_FMT_VAAPI` doesn't work.  I'm assuming we're supposed to use `NV12` based on [ffmpeg documentation telling people to use nv12 on the CLI](https://trac.ffmpeg.org/wiki/Hardware/VAAPI) but tbh I don't know if this is the right solution.  It does work on my computer though.

### Rationale behind Changes
Linux hardware encoding

### Suggested Testing Steps
Try all the vaapi encoders your gpu supports
Note: You may need to adjust some packages to enable VAAPI, e.g. [Fedora directions](https://rpmfusion.org/Howto/Multimedia)