### PR TITLE
GS/HW: Don't kill old targets unless completely dirty or targets overlap

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -4296,7 +4296,7 @@ void GSTextureCache::IncAge()
 
 	AgeHashCache();
 
-	// As of 04/15/2024 this is s et to 60 (just 1 second of targets), which should be fine now as it doesn't destroy targets which haven't been coevred.
+	// As of 04/15/2024 this is s et to 60 (just 1 second of targets), which should be fine now as it doesn't destroy targets which haven't been covered.
 	// 
 	// For reference, here are some games sensitive to killing old targets:
 	// Original maxage was 4 here, Xenosaga 2 needs at least 240, else it flickers on scene transitions.
@@ -4318,7 +4318,7 @@ void GSTextureCache::IncAge()
 			{
 				const Target* overlapping_tgt = FindOverlappingTarget(t);
 
-				if (!t->m_dirty.empty() || overlapping_tgt != nullptr)
+				if (overlapping_tgt != nullptr || t->m_dirty.GetTotalRect(t->m_TEX0, GSVector2i(t->m_valid.width(), t->m_valid.height())).rintersect(t->m_valid).eq(t->m_valid))
 				{
 					i = list.erase(i);
 					GL_CACHE("TC: Remove Target(%s): (0x%x) due to age", to_string(type),


### PR DESCRIPTION
### Description of Changes
Stops killing targets that are just a little bit dirty.

### Rationale behind Changes
No real need to destroy the whole target because it's slightly dirty, doesn't make a lot of sense if there isn't another target over it.

### Suggested Testing Steps
Try Shadow hearts pause menu (already checked with GS Dump)

Fixes Shadow Hearts pause screens.

Before:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/c3772a99-d33a-43ae-aba9-dca04e5c34d4)

PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/d6471831-5518-4c5b-9908-dda27db877fc)

(the bit at the bottom is a TODO, pretend that's not there)
Edit: Decided to fix this other bug, so now it looks fine.

![image](https://github.com/PCSX2/pcsx2/assets/6278726/33d4860e-e554-43a6-a122-8e2863b1f7d8)
