### PR TITLE
CDVD: Actually fix NVRAM open mode

### DIFF
--- a/pcsx2/CDVD/CDVD.cpp
+++ b/pcsx2/CDVD/CDVD.cpp
@@ -197,11 +197,15 @@ void cdvdSaveNVRAM()
 {
 	Error error;
 	const std::string nvmfile = cdvdGetNVRAMPath();
-	auto fp = FileSystem::OpenManagedCFile(nvmfile.c_str(), "wb", &error);
+	auto fp = FileSystem::OpenManagedCFile(nvmfile.c_str(), "r+b", &error);
 	if (!fp)
 	{
-		ERROR_LOG("Failed to open NVRAM at {} for updating: {}", Path::GetFileName(nvmfile), error.GetDescription());
-		return;
+		fp = FileSystem::OpenManagedCFile(nvmfile.c_str(), "w+b", &error);
+		if (!fp) [[unlikely]]
+		{
+			ERROR_LOG("Failed to open NVRAM at {} for updating: {}", Path::GetFileName(nvmfile), error.GetDescription());
+			return;
+		}
 	}
 
 	u8 existing_nvram[NVRAM_SIZE];


### PR DESCRIPTION
a0d32d493c0781dc283106d418542f995a493a8c is incorrect, it always truncates the file, which makes the check-for-modification redundant.