### PR TITLE
VMManager: Refactor Affinity Control to Thread Pinning

### DIFF
--- a/pcsx2-qt/Settings/AdvancedSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/AdvancedSettingsWidget.cpp
@@ -29,6 +29,7 @@ AdvancedSettingsWidget::AdvancedSettingsWidget(SettingsWindow* dialog, QWidget* 
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.vu0Recompiler, "EmuCore/CPU/Recompiler", "EnableVU0", true);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.vu1Recompiler, "EmuCore/CPU/Recompiler", "EnableVU1", true);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.vuFlagHack, "EmuCore/Speedhacks", "vuFlagHack", true);
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.instantVU1, "EmuCore/Speedhacks", "vu1Instant", true);
 
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.eeRoundingMode, "EmuCore/CPU", "FPU.Roundmode", static_cast<int>(FPRoundMode::ChopZero));
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.eeDivRoundingMode, "EmuCore/CPU", "FPUDiv.Roundmode", static_cast<int>(FPRoundMode::Nearest));
@@ -100,6 +101,9 @@ AdvancedSettingsWidget::AdvancedSettingsWidget(SettingsWindow* dialog, QWidget* 
 	"The default value handles the vast majority of games; <b>modifying this setting when a game is not having a visible problem can cause instability.</b>"));
 	dialog->registerWidgetHelp(m_ui.vu1ClampMode, tr("VU1 Clamping Mode"), tr("Normal (Default)"), tr("Changes how PCSX2 handles keeping floats in a standard x86 range in the Emotion Engine's Vector Unit 1 (EE VU1). "
 	"The default value handles the vast majority of games; <b>modifying this setting when a game is not having a visible problem can cause instability.</b>"));
+
+	dialog->registerWidgetHelp(m_ui.instantVU1, tr("Enable Instant VU1"), tr("Checked"), tr("Runs VU1 instantly. Provides a modest speed improvement in most games. "
+		   "Safe for most games, but a few games may exhibit graphical errors."));
 
 	//: VU0 = Vector Unit 0. One of the PS2's processors.
 	dialog->registerWidgetHelp(m_ui.vu0Recompiler, tr("Enable VU0 Recompiler (Micro Mode)"), tr("Checked"), tr("Enables VU0 Recompiler."));

--- a/pcsx2-qt/Settings/AdvancedSettingsWidget.ui
+++ b/pcsx2-qt/Settings/AdvancedSettingsWidget.ui
@@ -33,8 +33,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>807</width>
-        <height>723</height>
+        <width>790</width>
+        <height>765</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout">
@@ -202,7 +202,7 @@
             </item>
             <item row="3" column="0">
              <widget class="QCheckBox" name="extraMemory">
-              <property	name="text">
+              <property name="text">
                <string>Enable 128MB RAM (Dev Console)</string>
               </property>
              </widget>
@@ -269,6 +269,13 @@
              <widget class="QCheckBox" name="vu0Recompiler">
               <property name="text">
                <string>Enable VU0 Recompiler (Micro Mode)</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="1">
+             <widget class="QCheckBox" name="instantVU1">
+              <property name="text">
+               <string>Enable Instant VU1</string>
               </property>
              </widget>
             </item>
@@ -494,7 +501,7 @@
        <item>
         <spacer name="verticalSpacer_2">
          <property name="orientation">
-          <enum>Qt::Vertical</enum>
+          <enum>Qt::Orientation::Vertical</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>

--- a/pcsx2-qt/Settings/EmulationSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/EmulationSettingsWidget.cpp
@@ -40,10 +40,9 @@ EmulationSettingsWidget::EmulationSettingsWidget(SettingsWindow* dialog, QWidget
 	m_ui.optimalFramePacing->setTristate(dialog->isPerGameSettings());
 
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.eeCycleSkipping, "EmuCore/Speedhacks", "EECycleSkip", DEFAULT_EE_CYCLE_SKIP);
-	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.affinityControl, "EmuCore/CPU", "AffinityControlMode", 0);
 
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.MTVU, "EmuCore/Speedhacks", "vuThread", false);
-	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.instantVU1, "EmuCore/Speedhacks", "vu1Instant", true);
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.threadPinning, "EmuCore", "EnableThreadPinning", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.fastCDVD, "EmuCore/Speedhacks", "fastCDVD", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.precacheCDVD, "EmuCore", "CdvdPrecache", false);
 
@@ -113,16 +112,13 @@ EmulationSettingsWidget::EmulationSettingsWidget(SettingsWindow* dialog, QWidget
 		tr("Makes the emulated Emotion Engine skip cycles. "
 		   //: SOTC = Shadow of the Colossus. A game's title, should not be translated unless an official translation exists.
 		   "Helps a small subset of games like SOTC. Most of the time it's harmful to performance."));
-	dialog->registerWidgetHelp(m_ui.affinityControl, tr("Affinity Control"), tr("Disabled"),
+	dialog->registerWidgetHelp(m_ui.threadPinning, tr("Enable Thread Pinning"), tr("Unchecked"),
 		tr("Sets the priority for specific threads in a specific order ignoring the system scheduler. "
 		   //: P-Core = Performance Core, E-Core = Efficiency Core. See if Intel has official translations for these terms.
 		   "May help CPUs with big (P) and little (E) cores (e.g. Intel 12th or newer generation CPUs from Intel or other vendors such as AMD)."));
 	dialog->registerWidgetHelp(m_ui.MTVU, tr("Enable Multithreaded VU1 (MTVU1)"), tr("Checked"),
 		tr("Generally a speedup on CPUs with 4 or more cores. "
 		   "Safe for most games, but a few are incompatible and may hang."));
-	dialog->registerWidgetHelp(m_ui.instantVU1, tr("Enable Instant VU1"), tr("Checked"),
-		tr("Runs VU1 instantly. Provides a modest speed improvement in most games. "
-		   "Safe for most games, but a few games may exhibit graphical errors."));
 	dialog->registerWidgetHelp(m_ui.fastCDVD, tr("Enable Fast CDVD"), tr("Unchecked"),
 		tr("Fast disc access, less loading times. Check HDLoader compatibility lists for known games that have issues with this."));
 	dialog->registerWidgetHelp(m_ui.precacheCDVD, tr("Enable CDVD Precaching"), tr("Unchecked"),

--- a/pcsx2-qt/Settings/EmulationSettingsWidget.ui
+++ b/pcsx2-qt/Settings/EmulationSettingsWidget.ui
@@ -68,90 +68,6 @@
       <string>System Settings</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_5">
-      <item row="3" column="0" colspan="2">
-       <layout class="QGridLayout" name="systemSettingsLayout">
-        <item row="0" column="1">
-         <widget class="QCheckBox" name="instantVU1">
-          <property name="text">
-           <string>Enable Instant VU1</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="QCheckBox" name="cheats">
-          <property name="text">
-           <string>Enable Cheats</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="0">
-         <widget class="QCheckBox" name="MTVU">
-          <property name="text">
-           <string>Enable Multithreaded VU1 (MTVU)</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1">
-         <widget class="QCheckBox" name="hostFilesystem">
-          <property name="text">
-           <string>Enable Host Filesystem</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="1">
-         <widget class="QCheckBox" name="fastCDVD">
-          <property name="text">
-           <string>Enable Fast CDVD</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QCheckBox" name="precacheCDVD">
-          <property name="text">
-           <string>Enable CDVD Precaching</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_10">
-        <property name="text">
-         <string>EE Cycle Skipping:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QComboBox" name="eeCycleSkipping">
-        <item>
-         <property name="text">
-          <string>Disabled</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Mild Underclock</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Moderate Underclock</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Maximum Underclock</string>
-         </property>
-        </item>
-       </widget>
-      </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="label_9">
-        <property name="text">
-         <string>EE Cycle Rate:</string>
-        </property>
-       </widget>
-      </item>
       <item row="0" column="1">
        <widget class="QComboBox" name="eeCycleRate">
         <item>
@@ -191,15 +107,8 @@
         </item>
        </widget>
       </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="label">
-        <property name="text">
-         <string>Affinity Control:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="QComboBox" name="affinityControl">
+      <item row="1" column="1">
+       <widget class="QComboBox" name="eeCycleSkipping">
         <item>
          <property name="text">
           <string>Disabled</string>
@@ -207,34 +116,79 @@
         </item>
         <item>
          <property name="text">
-          <string>EE &gt; VU &gt; GS</string>
+          <string>Mild Underclock</string>
          </property>
         </item>
         <item>
          <property name="text">
-          <string>EE &gt; GS &gt; VU</string>
+          <string>Moderate Underclock</string>
          </property>
         </item>
         <item>
          <property name="text">
-          <string>VU &gt; EE &gt; GS</string>
+          <string>Maximum Underclock</string>
          </property>
         </item>
-        <item>
-         <property name="text">
-          <string>VU &gt; GS &gt; EE</string>
-         </property>
+       </widget>
+      </item>
+      <item row="2" column="0" colspan="2">
+       <layout class="QGridLayout" name="systemSettingsLayout">
+        <item row="1" column="0">
+         <widget class="QCheckBox" name="cheats">
+          <property name="text">
+           <string>Enable Cheats</string>
+          </property>
+         </widget>
         </item>
-        <item>
-         <property name="text">
-          <string>GS &gt; EE &gt; VU</string>
-         </property>
+        <item row="0" column="0">
+         <widget class="QCheckBox" name="MTVU">
+          <property name="text">
+           <string>Enable Multithreaded VU1 (MTVU)</string>
+          </property>
+         </widget>
         </item>
-        <item>
-         <property name="text">
-          <string>GS &gt; VU &gt; EE</string>
-         </property>
+        <item row="1" column="1">
+         <widget class="QCheckBox" name="hostFilesystem">
+          <property name="text">
+           <string>Enable Host Filesystem</string>
+          </property>
+         </widget>
         </item>
+        <item row="2" column="1">
+         <widget class="QCheckBox" name="fastCDVD">
+          <property name="text">
+           <string>Enable Fast CDVD</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="0">
+         <widget class="QCheckBox" name="precacheCDVD">
+          <property name="text">
+           <string>Enable CDVD Precaching</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="QCheckBox" name="threadPinning">
+          <property name="text">
+           <string>Enable Thread Pinning</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_9">
+        <property name="text">
+         <string>EE Cycle Rate:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_10">
+        <property name="text">
+         <string>EE Cycle Skipping:</string>
+        </property>
        </widget>
       </item>
      </layout>

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -545,8 +545,6 @@ struct Pcsx2Config
 		FPControlRegister VU0FPCR;
 		FPControlRegister VU1FPCR;
 
-		u32 AffinityControlMode;
-
 		CpuOptions();
 		void LoadSave(SettingsWrapper& wrap);
 		void ApplySanityCheck();
@@ -1119,6 +1117,7 @@ struct Pcsx2Config
 		EnableNoInterlacingPatches : 1,
 		EnableFastBoot : 1,
 		EnableFastBootFastForward : 1,
+		EnableThreadPinning : 1,
 		// TODO - Vaser - where are these settings exposed in the Qt UI?
 		EnableRecordingTools : 1,
 		EnableGameFixes : 1, // enables automatic game fixes

--- a/pcsx2/GS/Renderers/SW/GSRasterizer.h
+++ b/pcsx2/GS/Renderers/SW/GSRasterizer.h
@@ -166,7 +166,7 @@ protected:
 
 	GSRasterizerList(int threads);
 
-	static void OnWorkerStartup(int i);
+	static void OnWorkerStartup(int i, u64 affinity);
 	static void OnWorkerShutdown(int i);
 
 public:

--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -3275,15 +3275,6 @@ void FullscreenUI::DrawEmulationSettingsPage()
 		FSUI_NSTR("Moderate Underclock"),
 		FSUI_NSTR("Maximum Underclock"),
 	};
-	static constexpr const char* affinity_control_settings[] = {
-		FSUI_NSTR("Disabled"),
-		FSUI_NSTR("EE > VU > GS"),
-		FSUI_NSTR("EE > GS > VU"),
-		FSUI_NSTR("VU > EE > GS"),
-		FSUI_NSTR("VU > GS > EE"),
-		FSUI_NSTR("GS > EE > VU"),
-		FSUI_NSTR("GS > VU > EE"),
-	};
 	static constexpr const char* queue_entries[] = {
 		FSUI_NSTR("0 Frames (Hard Sync)"),
 		FSUI_NSTR("1 Frame"),
@@ -3311,14 +3302,11 @@ void FullscreenUI::DrawEmulationSettingsPage()
 	DrawIntListSetting(bsi, FSUI_CSTR("EE Cycle Skipping"),
 		FSUI_CSTR("Makes the emulated Emotion Engine skip cycles. Helps a small subset of games like SOTC. Most of the time it's harmful to performance."), "EmuCore/Speedhacks", "EECycleSkip", 0,
 		ee_cycle_skip_settings, std::size(ee_cycle_skip_settings), true);
-	DrawIntListSetting(bsi, FSUI_CSTR("Affinity Control Mode"),
-		FSUI_CSTR("Pins emulation threads to CPU cores to potentially improve performance/frame time variance."), "EmuCore/CPU",
-		"AffinityControlMode", 0, affinity_control_settings, std::size(affinity_control_settings), true);
 	DrawToggleSetting(bsi, FSUI_CSTR("Enable MTVU (Multi-Threaded VU1)"),
 		FSUI_CSTR("Generally a speedup on CPUs with 4 or more cores. Safe for most games, but a few are incompatible and may hang."), "EmuCore/Speedhacks", "vuThread", false);
-	DrawToggleSetting(bsi, FSUI_CSTR("Enable Instant VU1"),
-		FSUI_CSTR("Runs VU1 instantly. Provides a modest speed improvement in most games. Safe for most games, but a few games may exhibit graphical errors."),
-		"EmuCore/Speedhacks", "vu1Instant", true);
+	DrawToggleSetting(bsi, FSUI_CSTR("Thread Pinning"),
+		FSUI_CSTR("Pins emulation threads to CPU cores to potentially improve performance/frame time variance."), "EmuCore",
+		"EnableThreadPinning", false);
 	DrawToggleSetting(
 		bsi, FSUI_CSTR("Enable Cheats"), FSUI_CSTR("Enables loading cheats from pnach files."), "EmuCore", "EnableCheats", false);
 	DrawToggleSetting(bsi, FSUI_CSTR("Enable Host Filesystem"),
@@ -4769,6 +4757,9 @@ void FullscreenUI::DrawAdvancedSettingsPage()
 			true);
 		DrawToggleSetting(bsi, FSUI_CSTR("Enable VU Flag Optimization"),
 			FSUI_CSTR("Good speedup and high compatibility, may cause graphical errors."), "EmuCore/Speedhacks", "vuFlagHack", true);
+		DrawToggleSetting(bsi, FSUI_CSTR("Enable Instant VU1"),
+			FSUI_CSTR("Runs VU1 instantly. Provides a modest speed improvement in most games. Safe for most games, but a few games may exhibit graphical errors."),
+			"EmuCore/Speedhacks", "vu1Instant", true);
 
 		MenuHeading(FSUI_CSTR("I/O Processor"));
 		DrawToggleSetting(bsi, FSUI_CSTR("Enable IOP Recompiler"),
@@ -6944,12 +6935,10 @@ TRANSLATE_NOOP("FullscreenUI", "EE Cycle Rate");
 TRANSLATE_NOOP("FullscreenUI", "Underclocks or overclocks the emulated Emotion Engine CPU.");
 TRANSLATE_NOOP("FullscreenUI", "EE Cycle Skipping");
 TRANSLATE_NOOP("FullscreenUI", "Makes the emulated Emotion Engine skip cycles. Helps a small subset of games like SOTC. Most of the time it's harmful to performance.");
-TRANSLATE_NOOP("FullscreenUI", "Affinity Control Mode");
-TRANSLATE_NOOP("FullscreenUI", "Pins emulation threads to CPU cores to potentially improve performance/frame time variance.");
 TRANSLATE_NOOP("FullscreenUI", "Enable MTVU (Multi-Threaded VU1)");
 TRANSLATE_NOOP("FullscreenUI", "Generally a speedup on CPUs with 4 or more cores. Safe for most games, but a few are incompatible and may hang.");
-TRANSLATE_NOOP("FullscreenUI", "Enable Instant VU1");
-TRANSLATE_NOOP("FullscreenUI", "Runs VU1 instantly. Provides a modest speed improvement in most games. Safe for most games, but a few games may exhibit graphical errors.");
+TRANSLATE_NOOP("FullscreenUI", "Thread Pinning");
+TRANSLATE_NOOP("FullscreenUI", "Pins emulation threads to CPU cores to potentially improve performance/frame time variance.");
 TRANSLATE_NOOP("FullscreenUI", "Enable Cheats");
 TRANSLATE_NOOP("FullscreenUI", "Enables loading cheats from pnach files.");
 TRANSLATE_NOOP("FullscreenUI", "Enable Host Filesystem");
@@ -7224,6 +7213,8 @@ TRANSLATE_NOOP("FullscreenUI", "New Vector Unit recompiler with much improved co
 TRANSLATE_NOOP("FullscreenUI", "Enable VU1 Recompiler");
 TRANSLATE_NOOP("FullscreenUI", "Enable VU Flag Optimization");
 TRANSLATE_NOOP("FullscreenUI", "Good speedup and high compatibility, may cause graphical errors.");
+TRANSLATE_NOOP("FullscreenUI", "Enable Instant VU1");
+TRANSLATE_NOOP("FullscreenUI", "Runs VU1 instantly. Provides a modest speed improvement in most games. Safe for most games, but a few games may exhibit graphical errors.");
 TRANSLATE_NOOP("FullscreenUI", "I/O Processor");
 TRANSLATE_NOOP("FullscreenUI", "Enable IOP Recompiler");
 TRANSLATE_NOOP("FullscreenUI", "Performs just-in-time binary translation of 32-bit MIPS-I machine code to native code.");
@@ -7391,13 +7382,6 @@ TRANSLATE_NOOP("FullscreenUI", "Normal (Default)");
 TRANSLATE_NOOP("FullscreenUI", "Mild Underclock");
 TRANSLATE_NOOP("FullscreenUI", "Moderate Underclock");
 TRANSLATE_NOOP("FullscreenUI", "Maximum Underclock");
-TRANSLATE_NOOP("FullscreenUI", "Disabled");
-TRANSLATE_NOOP("FullscreenUI", "EE > VU > GS");
-TRANSLATE_NOOP("FullscreenUI", "EE > GS > VU");
-TRANSLATE_NOOP("FullscreenUI", "VU > EE > GS");
-TRANSLATE_NOOP("FullscreenUI", "VU > GS > EE");
-TRANSLATE_NOOP("FullscreenUI", "GS > EE > VU");
-TRANSLATE_NOOP("FullscreenUI", "GS > VU > EE");
 TRANSLATE_NOOP("FullscreenUI", "0 Frames (Hard Sync)");
 TRANSLATE_NOOP("FullscreenUI", "1 Frame");
 TRANSLATE_NOOP("FullscreenUI", "2 Frames");
@@ -7491,6 +7475,7 @@ TRANSLATE_NOOP("FullscreenUI", "Sprites/Triangles");
 TRANSLATE_NOOP("FullscreenUI", "Blended Sprites/Triangles");
 TRANSLATE_NOOP("FullscreenUI", "1 (Normal)");
 TRANSLATE_NOOP("FullscreenUI", "2 (Aggressive)");
+TRANSLATE_NOOP("FullscreenUI", "Disabled");
 TRANSLATE_NOOP("FullscreenUI", "Inside Target");
 TRANSLATE_NOOP("FullscreenUI", "Merge Targets");
 TRANSLATE_NOOP("FullscreenUI", "Normal (Vertex)");

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -499,7 +499,7 @@ bool Pcsx2Config::CpuOptions::operator!=(const CpuOptions& right) const
 
 bool Pcsx2Config::CpuOptions::operator==(const CpuOptions& right) const
 {
-	return OpEqu(FPUFPCR) && OpEqu(FPUDivFPCR) && OpEqu(VU0FPCR) && OpEqu(VU1FPCR) && OpEqu(AffinityControlMode) && OpEqu(Recompiler);
+	return OpEqu(FPUFPCR) && OpEqu(FPUDivFPCR) && OpEqu(VU0FPCR) && OpEqu(VU1FPCR) && OpEqu(Recompiler);
 }
 
 Pcsx2Config::CpuOptions::CpuOptions()
@@ -512,14 +512,11 @@ Pcsx2Config::CpuOptions::CpuOptions()
 
 	VU0FPCR = DEFAULT_VU_FP_CONTROL_REGISTER;
 	VU1FPCR = DEFAULT_VU_FP_CONTROL_REGISTER;
-	AffinityControlMode = 0;
 	ExtraMemory = false;
 }
 
 void Pcsx2Config::CpuOptions::ApplySanityCheck()
 {
-	AffinityControlMode = std::min<u32>(AffinityControlMode, 6);
-
 	Recompiler.ApplySanityCheck();
 }
 
@@ -544,7 +541,6 @@ void Pcsx2Config::CpuOptions::LoadSave(SettingsWrapper& wrap)
 	read_fpcr(VU0FPCR, "VU0");
 	read_fpcr(VU1FPCR, "VU1");
 
-	SettingsWrapEntry(AffinityControlMode);
 	SettingsWrapBitBool(ExtraMemory);
 
 	Recompiler.LoadSave(wrap);
@@ -1714,6 +1710,7 @@ void Pcsx2Config::LoadSaveCore(SettingsWrapper& wrap)
 	SettingsWrapBitBool(EnableNoInterlacingPatches);
 	SettingsWrapBitBool(EnableFastBoot);
 	SettingsWrapBitBool(EnableFastBootFastForward);
+	SettingsWrapBitBool(EnableThreadPinning);
 	SettingsWrapBitBool(EnableRecordingTools);
 	SettingsWrapBitBool(EnableGameFixes);
 	SettingsWrapBitBool(SaveStateOnShutdown);

--- a/pcsx2/VMManager.h
+++ b/pcsx2/VMManager.h
@@ -224,10 +224,6 @@ namespace VMManager
 	/// Initializes default configuration in the specified file for the specified categories.
 	void SetDefaultSettings(SettingsInterface& si, bool folders, bool core, bool controllers, bool hotkeys, bool ui);
 
-	/// Returns a list of processors in the system, and their corresponding affinity mask.
-	/// This list is ordered by most performant to least performant for pinning threads to.
-	const std::vector<u32>& GetSortedProcessorList();
-
 	/// Returns the time elapsed in the current play session.
 	u64 GetSessionPlayedTime();
 
@@ -284,6 +280,9 @@ namespace VMManager
 
 		/// Resets/clears all execution/code caches.
 		void ClearCPUExecutionCaches();
+
+		/// Returns a list of processors in the system, suitable for pinning for the software renderer.
+		const std::vector<u32>& GetSoftwareRendererProcessorList();
 
 		const std::string& GetELFOverride();
 		bool IsExecutionInterrupted();


### PR DESCRIPTION
### Description of Changes

Instead of having control over specific threads, thread pinning puts the EE/VU/GS threads on the most performant cores, then the software threads on the remaining cores, but only if they're in the same cluster.

This way we don't end up pinning across clusters with different performance characteristics, which would harm instead of help software renderer performance.

Also unpins on shutdown, that way we don't keep CPU cores awake.

And ignores SMT cores, because you don't want to be pinning two heavy threads on the same hyperthread...

### Rationale behind Changes

The option in its current form is potentially detrimental to performance on heterogeneous CPUs.

### Suggested Testing Steps

Check option behaves as expected. You can see what threads are pinned in the log.