### PR TITLE
CI/AppImage: Explicitly remove libwayland-*

### DIFF
--- a/.github/workflows/scripts/linux/appimage-qt.sh
+++ b/.github/workflows/scripts/linux/appimage-qt.sh
@@ -55,6 +55,12 @@ declare -a MANUAL_QT_PLUGINS=(
 	"wayland-shell-integration"
 )
 
+declare -a REMOVE_LIBS=(
+	'libwayland-client.so*'
+	'libwayland-cursor.so*'
+	'libwayland-egl.so*'
+)
+
 set -e
 
 LINUXDEPLOY=./linuxdeploy-x86_64.AppImage
@@ -155,6 +161,16 @@ for GROUP in "${MANUAL_QT_PLUGINS[@]}"; do
 		echo "    $srcsopath -> $dstsopath"
 		cp "$srcsopath" "$dstsopath"
 		$PATCHELF --set-rpath '$ORIGIN/../../lib:$ORIGIN' "$dstsopath"
+	done
+done
+
+# Why do we have to manually remove these libs? Because the linuxdeploy Qt plugin
+# copies them, not the "main" linuxdeploy binary, and plugins don't inherit the
+# include list...
+for lib in "${REMOVE_LIBS[@]}"; do
+	for libpath in $(find "$OUTDIR/usr/lib" -name "$lib"); do
+		echo "    Removing problematic library ${libpath}."
+		rm -f "$libpath"
 	done
 done
 


### PR DESCRIPTION
### Description of Changes

Wayland still being a pain in the arse, **despite us using xcb**, and appimages being the rubbish, hacked dependency hell that they are...

Ironically, if we didn't ship the QPA so fools can override the environment variable and get a broken experience, this wouldn't have been a problem to begin with.

### Rationale behind Changes

Closes #11407.

### Suggested Testing Steps

Try PCSX2 on Meme Linux.
