### PR TITLE
Fix invertR and invertL settings being incorrectly set in Big Picture Mode

### DIFF
--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -2649,7 +2649,7 @@ void FullscreenUI::DrawSettingInfoSetting(SettingsInterface* bsi, const char* se
 
 		case SettingInfo::Type::IntegerList:
 			DrawIntListSetting(
-				bsi, title.c_str(), si.description, section, key, si.IntegerDefaultValue(), si.options, 0, si.IntegerMinValue(), true);
+				bsi, title.c_str(), si.description, section, key, si.IntegerDefaultValue(), si.options, 0, true, si.IntegerMinValue());
 			break;
 
 		case SettingInfo::Type::Float:


### PR DESCRIPTION
### Description of Changes
Fixes bug  #10935 where changing the value of invertL or invertR settings in Big Pitcture Mode would result in the wrong values actually being saved.

### Rationale behind Changes
The method behind updating these settings in Big Picture mode would add an offset of +1 to the value of the settings because of a wrong placement of a method parameter.

### Suggested Testing Steps

Test 1 :
1 - In Desktop Mode, open controllers settings and select a controller port
2 - In Settings, set the "Invert Left Stick" and "Invert Right Stick" values to "Not Inverted"
3 - Open Big Picture Mode
4 - Go to controller settings
5 - Expected values should be "Not Inverted" for both (before the fix, the values were "Unknown")

Test 2:
1 - In Big Picture Mode, open controllers settings
2 - Set the "Invert Left Stick" and "Invert Right Stick" values to "Invert Left/Right + Up/down"
3 - Restart PCSX2
4 - In Desktop mode, go to controller settings and select the correct controller port
5 - In Settings, expected values should be "Invert Left/Right + Up/down" for both (before the fix, the values were blank)

Test 3 :
1 - In Desktop Mode, open controllers settings and select a controller port
2 - In Settings, set the "Invert Left Stick" and "Invert Right Stick" values to "Invert Left/Right"
3 - Open Big Picture Mode
4 - Go to controller settings
5 - Expected values should be "Invert Left/Right" for both (before the fix, the values were "Not Inverted")