### PR TITLE
GS/HW: Allow offset channel shuffles on sources.

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -25872,9 +25872,9 @@ SLES-55169:
   name: "Monster Lab"
   region: "PAL-M5"
   gsHWFixes:
-    cpuFramebufferConversion: 1 # Fixes black with rainbow screen.
     gpuPaletteConversion: 2 # Fixes HC size and eliminates most texture uploads.
     halfPixelOffset: 2 # Fixes offset bloom.
+    textureInsideRT: 1 # Crowd textures.
 SLES-55170:
   name: "Margot's Word Brain"
   region: "PAL-M5"
@@ -65671,9 +65671,9 @@ SLUS-21838:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    cpuFramebufferConversion: 1 # Fixes black with rainbow screen.
     gpuPaletteConversion: 2 # Fixes HC size and eliminates most texture uploads.
     halfPixelOffset: 2 # Fixes offset bloom.
+    textureInsideRT: 1 # Crowd textures.
 SLUS-21839:
   name: "Ski and Shoot"
   region: "NTSC-U"

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -3921,10 +3921,19 @@ __ri bool GSRendererHW::EmulateChannelShuffle(GSTextureCache::Target* src, bool 
 		// We can use the minimum UV to work out which channel it's grabbing.
 		// Used by Ape Escape 2, Everybody's Tennis/Golf, Okage, and Valkyrie Profile 2.
 		// Page align test to limit false detections (there is a few).
-		const GSVector4i min_uv = GSVector4i(m_vt.m_min.t.upld(GSVector4::zero()));
+		GSVector4i min_uv = GSVector4i(m_vt.m_min.t.upld(GSVector4::zero()));
 		ChannelFetch channel = ChannelFetch_NONE;
+		const GSLocalMemory::psm_t& t_psm = GSLocalMemory::m_psm[m_cached_ctx.TEX0.PSM];;
+		const GSLocalMemory::psm_t& f_psm = GSLocalMemory::m_psm[m_cached_ctx.FRAME.PSM];
+		GSVector4i block_offset = GSVector4i(min_uv.x / t_psm.bs.x, min_uv.y / t_psm.bs.y).xyxy();
+		GSVector4i m_r_block_offset = GSVector4i((m_r.x & (f_psm.pgs.x - 1)) / f_psm.bs.x, (m_r.y & (f_psm.pgs.y - 1)) / f_psm.bs.y);
+
+		// Adjust it back to the page boundary
+		min_uv.x -= block_offset.x * t_psm.bs.x;
+		min_uv.y -= block_offset.y * t_psm.bs.y;
+
 		if (GSLocalMemory::IsPageAligned(src->m_TEX0.PSM, m_r) &&
-			m_r.upl64(GSVector4i::zero()).eq(GSVector4i::zero()))
+			block_offset.eq(m_r_block_offset))
 		{
 			if (min_uv.eq(GSVector4i::cxpr(0, 0, 0, 0)))
 				channel = ChannelFetch_RED;


### PR DESCRIPTION
### Description of Changes
Allows offsetting in to render targets on offset channel shuffles.

### Rationale behind Changes
A bunch of games do channel shuffles in such a way we can't override it and HLE it, so this allows that to work, but also accounts for both the draw and the read being offset by a number of blocks (block layout matches, so this is allowed).  This means as a result a lot of uploads etc are reduced.

As a result, we can now upscaled Monster Lab, just be careful as it gets heavy, plus this gets rid of a readback, so it should increase performance on some machines.

### Suggested Testing Steps
Check the following games.

Hitman - Blood Money (just make sure it's no worse, it should be fine, but won't be fixed)
Draw Calls: -4 [492=>488]
Render Passes: -5 [396=>391]
Copies: -1 [31=>30]
Uploads: -1 [47=>46]

Monster_Lab
Draw Calls: +1 [548=>549]
Render Passes: +1 [17=>18]
Copies: +1 [3=>4]
Uploads: -132 [151=>19]
Readbacks: -1 [2=>1]

Tomb_Raider_-_Legend
Draw Calls: -74 [273=>199]
Render Passes: -62 [102=>40]
Uploads: -14 [40=>26]


8x Upscaling Monster Lab: (Keep in mind it will be very slow in this resolution)
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/55d8a64c-a3ea-452c-831b-12c26461f5c2)

PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/b98a8df0-a4bb-4d74-827b-47247753d7f9)

