### PR TITLE
GS/HW: Keep real rect before draw to avoid bad valid rect update

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -1992,6 +1992,7 @@ SCAJ-20177:
     textureInsideRT: 1 # Required for swirl battle transition.
     nativePaletteDraw: 1
     nativeScaling: 2 # Fixes depth of field effects and bloom.
+    roundSprite: 1 # Fixes lines in transitions.
 SCAJ-20178:
   name: "Ape Escape - Million Monkeys"
   region: "NTSC-Unk"
@@ -2098,6 +2099,7 @@ SCAJ-20197:
     textureInsideRT: 1 # Required for swirl battle transition.
     nativePaletteDraw: 1
     nativeScaling: 2 # Fixes depth of field effects and bloom.
+    roundSprite: 1 # Fixes lines in transitions.
 SCAJ-20198:
   name: "Everybody's Tennis [PlayStation 2 the Best]"
   region: "NTSC-Unk"
@@ -6981,6 +6983,7 @@ SCKA-20079:
     textureInsideRT: 1 # Required for swirl battle transition.
     nativePaletteDraw: 1
     nativeScaling: 2 # Fixes depth of field effects and bloom.
+    roundSprite: 1 # Fixes lines in transitions.
 SCKA-20081:
   name: "Tekken 5 [PlayStation 2 Big Hit Series]"
   region: "NTSC-K"
@@ -24809,6 +24812,7 @@ SLES-54644:
     textureInsideRT: 1 # Required for swirl battle transition.
     nativePaletteDraw: 1
     nativeScaling: 2 # Fixes depth of field effects and bloom.
+    roundSprite: 1 # Fixes lines in transitions.
 SLES-54645:
   name: "Valkyrie Profile 2 - Silmeria"
   region: "PAL-F"
@@ -24819,6 +24823,7 @@ SLES-54645:
     textureInsideRT: 1 # Required for swirl battle transition.
     nativePaletteDraw: 1
     nativeScaling: 2 # Fixes depth of field effects and bloom.
+    roundSprite: 1 # Fixes lines in transitions.
 SLES-54646:
   name: "Valkyrie Profile 2 - Silmeria"
   region: "PAL-G"
@@ -24830,6 +24835,7 @@ SLES-54646:
     textureInsideRT: 1 # Required for swirl battle transition.
     nativePaletteDraw: 1
     nativeScaling: 2 # Fixes depth of field effects and bloom.
+    roundSprite: 1 # Fixes lines in transitions.
 SLES-54647:
   name: "Valkyrie Profile 2 - Silmeria"
   region: "PAL-I"
@@ -24841,6 +24847,7 @@ SLES-54647:
     textureInsideRT: 1 # Required for swirl battle transition.
     nativePaletteDraw: 1
     nativeScaling: 2 # Fixes depth of field effects and bloom.
+    roundSprite: 1 # Fixes lines in transitions.
 SLES-54648:
   name: "Valkyrie Profile 2 - Silmeria"
   region: "PAL-S"
@@ -24851,6 +24858,7 @@ SLES-54648:
     textureInsideRT: 1 # Required for swirl battle transition.
     nativePaletteDraw: 1
     nativeScaling: 2 # Fixes depth of field effects and bloom.
+    roundSprite: 1 # Fixes lines in transitions.
 SLES-54653:
   name: "Freak Out - Extreme Freeride"
   region: "PAL-M5"
@@ -43947,6 +43955,7 @@ SLPM-66419:
     textureInsideRT: 1 # Required for swirl battle transition.
     nativePaletteDraw: 1
     nativeScaling: 2 # Fixes depth of field effects and bloom.
+    roundSprite: 1 # Fixes lines in transitions.
 SLPM-66420:
   name: フロントミッション4 [アルティメットヒッツ]
   name-sort: ふろんとみっしょん4 [あるてぃめっとひっつ]
@@ -46167,6 +46176,7 @@ SLPM-66782:
     textureInsideRT: 1 # Required for swirl battle transition.
     nativePaletteDraw: 1
     nativeScaling: 2 # Fixes depth of field effects and bloom.
+    roundSprite: 1 # Fixes lines in transitions.
 SLPM-66783:
   name: アイドル雀士 スーチーパイIV 「完全限定版・コレクターズエディション」
   name-sort: あいどるじゃんし すーちーぱい4 [かんぜんげんていばん・これくたーずえでぃしょん]
@@ -64793,6 +64803,7 @@ SLUS-21452:
     textureInsideRT: 1 # Required for swirl battle transition.
     nativePaletteDraw: 1
     nativeScaling: 2 # Fixes depth of field effects and bloom.
+    roundSprite: 1 # Fixes lines in transitions.
 SLUS-21453:
   name: "Disney's Meet the Robinsons"
   region: "NTSC-U"

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -3339,6 +3339,7 @@ void GSRendererHW::Draw()
 	}
 
 	//
+	const GSVector4i real_rect = m_r;
 
 	if (!skip_draw)
 		DrawPrims(rt, ds, src, tmm);
@@ -3358,9 +3359,9 @@ void GSRendererHW::Draw()
 	{
 		//rt->m_valid = rt->m_valid.runion(r);
 		// Limit to 2x the vertical height of the resolution (for double buffering)
-		rt->UpdateValidity(m_r, can_update_size || (m_r.w <= (resolution.y * 2) && !m_texture_shuffle));
+		rt->UpdateValidity(real_rect, can_update_size || (real_rect.w <= (resolution.y * 2) && !m_texture_shuffle));
 
-		g_texture_cache->InvalidateVideoMem(context->offset.fb, m_r, false);
+		g_texture_cache->InvalidateVideoMem(context->offset.fb, real_rect, false);
 
 		// Remove overwritten Zs at the FBP.
 		g_texture_cache->InvalidateVideoMemType(GSTextureCache::DepthStencil, m_cached_ctx.FRAME.Block(),
@@ -3371,9 +3372,9 @@ void GSRendererHW::Draw()
 	{
 		//ds->m_valid = ds->m_valid.runion(r);
 		// Limit to 2x the vertical height of the resolution (for double buffering)
-		ds->UpdateValidity(m_r, can_update_size || (m_r.w <= (resolution.y * 2) && !m_texture_shuffle));
+		ds->UpdateValidity(real_rect, can_update_size || (real_rect.w <= (resolution.y * 2) && !m_texture_shuffle));
 
-		g_texture_cache->InvalidateVideoMem(context->offset.zb, m_r, false);
+		g_texture_cache->InvalidateVideoMem(context->offset.zb, real_rect, false);
 
 		// Remove overwritten RTs at the ZBP.
 		g_texture_cache->InvalidateVideoMemType(
@@ -3415,7 +3416,7 @@ void GSRendererHW::Draw()
 
 #ifdef DISABLE_HW_TEXTURE_CACHE
 	if (rt)
-		g_texture_cache->Read(rt, m_r);
+		g_texture_cache->Read(rt, real_rect);
 #endif
 
 	//


### PR DESCRIPTION
### Description of Changes
Keeps the correct draw rect for the final clean up of draws.

### Rationale behind Changes
the draw rect was getting changed to 1024x1024 when a channel shuffle happened, causing the validrect update check to mistakingly pass, this meant we had targets saying they were huge, taking up most of the memory and misfiring, most notably in Valkyrie Profile 2.

### Suggested Testing Steps
Test Valkyrie Profile 2 (already done), dump run also good, probably just gonna merge when it builds.
