### PR TITLE
GameDB: ACE3 fixes

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -55161,6 +55161,8 @@ SLPS-25784:
   name-sort: Another Century’s Episode 3 THE FINAL
   name-en: "Another Century's Episode 3 - The Final"
   region: "NTSC-J"
+  gameFixes:
+    - SoftwareRendererFMVHack # Fixed strong flickering on the title screen.
   clampModes:
     vuClampMode: 3 # Was used to fix game crash, but not sure it's required anymore.
 SLPS-25786:


### PR DESCRIPTION
Another Century’s Episode 3 THE FINAL

Fixed strong flickering on the title screen when use Hardware Rendering
 
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->

### Suggested Testing Steps
--use Hardware Rendering, When starting the game from the first second, observe the strong flashing of the memory card prompt and the manufacturer's logo, skip the op fmv, and continue to observe the strong flashing of the title screen.
