### PR TITLE
GameDB: Fix shadows alignment on Crash Twinsanity

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -1579,7 +1579,7 @@ SCAJ-20111:
   gameFixes:
     - XGKickHack # Fixes bad Geometry.
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes depth lines.
+    roundSprite: 1 # Fixes depth lines + shadows misalignment.
 SCAJ-20112:
   name: "Tales of Rebirth"
   region: "NTSC-Unk"
@@ -12454,7 +12454,7 @@ SLED-52574:
   gameFixes:
     - XGKickHack # Fixes bad geometry.
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes depth lines.
+    roundSprite: 1 # Fixes depth lines + shadows misalignment.
 SLED-52597:
   name: "Burnout 3 - Takedown [Demo]"
   region: "PAL-E"
@@ -18852,7 +18852,7 @@ SLES-52568:
   gameFixes:
     - XGKickHack # Fixes bad geometry.
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes depth lines.
+    roundSprite: 1 # Fixes depth lines + shadows misalignment.
     PCRTCOverscan: 1 # Fixes offscreen image.
 SLES-52569:
   name: "Spyro - A Hero's Tail"
@@ -40312,7 +40312,7 @@ SLPM-65801:
   gameFixes:
     - XGKickHack # Fixes bad geometry.
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes depth lines.
+    roundSprite: 1 # Fixes depth lines + shadows misalignment.
 SLPM-65802:
   name: EA BEST HITS DEF JAM VENDETTA
   name-sort: DEF JAM VENDETTA [EA BEST HITS]
@@ -61445,7 +61445,7 @@ SLUS-20909:
   gameFixes:
     - XGKickHack # Fixes bad geometry.
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes depth lines.
+    roundSprite: 1 # Fixes depth lines + shadows misalignment.
 SLUS-20910:
   name: "Test Drive - Eve of Destruction"
   region: "NTSC-U"
@@ -67741,7 +67741,7 @@ SLUS-29101:
   gameFixes:
     - XGKickHack # Fixes bad geometry.
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes depth lines.
+    roundSprite: 1 # Fixes depth lines + shadows misalignment.
 SLUS-29104:
   name: "Galactic Wrestling - Featuring Ultimate Muscle [Demo]"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
Changed Half Pixel Offset "Special (Texture)" with Round Sprite "Half"

### Rationale behind Changes
It achieves the same effect as Half Pixel Offset on "Special (Texture)" while also aligning shadows more like on software renderer/real HW.

### Suggested Testing Steps
Check if it makes anything look weird (At least I couldn't find anything).

GS Dump (For reference):
[Crash Twinsanity_SLES-52568_20240621132529.zip](https://github.com/user-attachments/files/15926912/Crash.Twinsanity_SLES-52568_20240621132529.zip)

Before:
![Crash Twinsanity_SLES-52568_20240621143251](https://github.com/PCSX2/pcsx2/assets/35299377/06da1422-ba16-47a3-8aa5-728b3c5289cd)

After:
![Crash Twinsanity_SLES-52568_20240621143239](https://github.com/PCSX2/pcsx2/assets/35299377/91393fba-19f7-4649-8368-fe77f0cc5bb7)