### PR TITLE
GS/HW: Fix line width factor when upscaling.

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -4771,8 +4771,11 @@ __ri void GSRendererHW::EmulateTextureSampler(const GSTextureCache::Target* rt, 
 	HandleTextureHazards(rt, ds, tex, tmm, source_region, target_region, unscaled_size, scale, src_copy);
 
 	// This is used for reading depth sources, so we should go off the source scale.
-	float scale_factor = scale;
-	m_conf.cb_ps.ScaleFactor = GSVector4(scale_factor * (1.0f / 16.0f), 1.0f / scale_factor, scale_factor, 0.0f);
+	// the Z vector contains line width which will be based on the target draw, where XY are used for source reading.
+	const float scale_factor = scale;
+	const float scale_rt = rt ? rt->GetScale() : ds->GetScale();
+
+	m_conf.cb_ps.ScaleFactor = GSVector4(scale_factor * (1.0f / 16.0f), 1.0f / scale_factor, scale_rt, 0.0f);
 
 	if ((m_conf.ps.tex_is_fb && rt->m_rt_alpha_scale) || (tex->m_target && tex->m_from_target && tex->m_target_direct && tex->m_from_target->m_rt_alpha_scale))
 		m_conf.ps.rta_source_correction = 1;


### PR DESCRIPTION
### Description of Changes
Correct the scale factor for lines when texturing.

### Rationale behind Changes
When I modified this, I didn't quite understand what was going on with the Z vector, presumed it was all the same thing, but it turns out that is target scale not source, so upscaling in Vulkan really showed this up when lines were being drawn. Regression from #11337

### Suggested Testing Steps
Test 007 - Everything or Nothing

Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/226941fb-b34a-47b5-b42b-5e5b385a2940)

PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/3c0c67da-3774-464c-9744-82fe9e4d9556)


