### PR TITLE
DEV9: Sockets: return server IP alongside payload

### DIFF
--- a/pcsx2/DEV9/Sessions/BaseSession.h
+++ b/pcsx2/DEV9/Sessions/BaseSession.h
@@ -5,6 +5,7 @@
 
 #include "DEV9/PacketReader/IP/IP_Packet.h"
 #include <functional>
+#include <optional>
 #include <vector>
 
 namespace Sessions
@@ -22,6 +23,12 @@ namespace Sessions
 
 		bool operator==(const ConnectionKey& other) const;
 		bool operator!=(const ConnectionKey& other) const;
+	};
+
+	struct ReceivedPayload
+	{
+		PacketReader::IP::IP_Address sourceIP;
+		std::unique_ptr<PacketReader::IP::IP_Payload> payload;
 	};
 
 	class BaseSession
@@ -42,7 +49,7 @@ namespace Sessions
 
 		void AddConnectionClosedHandler(ConnectionClosedEventHandler handler);
 
-		virtual PacketReader::IP::IP_Payload* Recv() = 0;
+		virtual std::optional<ReceivedPayload> Recv() = 0;
 		virtual bool Send(PacketReader::IP::IP_Payload* payload) = 0;
 		virtual void Reset() = 0;
 

--- a/pcsx2/DEV9/Sessions/ICMP_Session/ICMP_Session.h
+++ b/pcsx2/DEV9/Sessions/ICMP_Session/ICMP_Session.h
@@ -78,7 +78,7 @@ namespace Sessions
 	public:
 		ICMP_Session(ConnectionKey parKey, PacketReader::IP::IP_Address parAdapterIP, ThreadSafeMap<Sessions::ConnectionKey, Sessions::BaseSession*>* parConnections);
 
-		virtual PacketReader::IP::IP_Payload* Recv();
+		virtual std::optional<ReceivedPayload> Recv();
 		virtual bool Send(PacketReader::IP::IP_Payload* payload);
 		bool Send(PacketReader::IP::IP_Payload* payload, PacketReader::IP::IP_Packet* packet);
 		virtual void Reset();

--- a/pcsx2/DEV9/Sessions/TCP_Session/TCP_Session.cpp
+++ b/pcsx2/DEV9/Sessions/TCP_Session/TCP_Session.cpp
@@ -18,13 +18,13 @@ using namespace PacketReader::IP::TCP;
 
 namespace Sessions
 {
-	void TCP_Session::PushRecvBuff(TCP_Packet* tcp)
+	void TCP_Session::PushRecvBuff(std::unique_ptr<TCP_Packet> tcp)
 	{
-		_recvBuff.Enqueue(tcp);
+		_recvBuff.Enqueue(std::move(tcp));
 	}
-	TCP_Packet* TCP_Session::PopRecvBuff()
+	std::unique_ptr<TCP_Packet> TCP_Session::PopRecvBuff()
 	{
-		TCP_Packet* ret;
+		std::unique_ptr<TCP_Packet> ret;
 		if (_recvBuff.Dequeue(&ret))
 			return ret;
 		else
@@ -102,13 +102,13 @@ namespace Sessions
 		return delta;
 	}
 
-	TCP_Packet* TCP_Session::CreateBasePacket(PayloadData* data)
+	std::unique_ptr<TCP_Packet> TCP_Session::CreateBasePacket(PayloadData* data)
 	{
 		//DevCon.WriteLn("Creating base packet");
 		if (data == nullptr)
 			data = new PayloadData(0);
 
-		TCP_Packet* ret = new TCP_Packet(data);
+		std::unique_ptr<TCP_Packet> ret = std::make_unique<TCP_Packet>(data);
 
 		// Setup common packet infomation
 		ret->sourcePort = destPort;
@@ -159,15 +159,13 @@ namespace Sessions
 		// Clear out _recvBuff
 		while (!_recvBuff.IsQueueEmpty())
 		{
-			TCP_Packet* retPay;
+			std::unique_ptr<TCP_Packet> retPay;
 			if (!_recvBuff.Dequeue(&retPay))
 			{
 				using namespace std::chrono_literals;
 				std::this_thread::sleep_for(1ms);
 				continue;
 			}
-
-			delete retPay;
 		}
 	}
 } // namespace Sessions

--- a/pcsx2/DEV9/Sessions/TCP_Session/TCP_Session.h
+++ b/pcsx2/DEV9/Sessions/TCP_Session/TCP_Session.h
@@ -42,7 +42,7 @@ namespace Sessions
 			Bad
 		};
 
-		SimpleQueue<PacketReader::IP::TCP::TCP_Packet*> _recvBuff;
+		SimpleQueue<std::unique_ptr<PacketReader::IP::TCP::TCP_Packet>> _recvBuff;
 
 #ifdef _WIN32
 		SOCKET client = INVALID_SOCKET;
@@ -77,7 +77,7 @@ namespace Sessions
 	public:
 		TCP_Session(ConnectionKey parKey, PacketReader::IP::IP_Address parAdapterIP);
 
-		virtual PacketReader::IP::IP_Payload* Recv();
+		virtual std::optional<ReceivedPayload> Recv();
 		virtual bool Send(PacketReader::IP::IP_Payload* payload);
 		virtual void Reset();
 
@@ -85,8 +85,8 @@ namespace Sessions
 
 	private:
 		// Async functions
-		void PushRecvBuff(PacketReader::IP::TCP::TCP_Packet* tcp);
-		PacketReader::IP::TCP::TCP_Packet* PopRecvBuff();
+		void PushRecvBuff(std::unique_ptr<PacketReader::IP::TCP::TCP_Packet> tcp);
+		std::unique_ptr<PacketReader::IP::TCP::TCP_Packet> PopRecvBuff();
 
 		void IncrementMyNumber(u32 amount);
 		void UpdateReceivedAckNumber(u32 ack);
@@ -104,7 +104,7 @@ namespace Sessions
 		bool ValidateEmptyPacket(PacketReader::IP::TCP::TCP_Packet* tcp, bool ignoreOld = true);
 
 		// PS2 sent SYN
-		PacketReader::IP::TCP::TCP_Packet* ConnectTCPComplete(bool success);
+		std::unique_ptr<PacketReader::IP::TCP::TCP_Packet> ConnectTCPComplete(bool success);
 		bool SendConnect(PacketReader::IP::TCP::TCP_Packet* tcp);
 		bool SendConnected(PacketReader::IP::TCP::TCP_Packet* tcp);
 
@@ -120,7 +120,7 @@ namespace Sessions
 		 * S4: PS2 then Sends ACK
 		 */
 		bool CloseByPS2Stage1_2(PacketReader::IP::TCP::TCP_Packet* tcp);
-		PacketReader::IP::TCP::TCP_Packet* CloseByPS2Stage3();
+		std::unique_ptr<PacketReader::IP::TCP::TCP_Packet> CloseByPS2Stage3();
 		bool CloseByPS2Stage4(PacketReader::IP::TCP::TCP_Packet* tcp);
 
 		/*
@@ -132,7 +132,7 @@ namespace Sessions
 		 * Closing_ClosedByRemoteThenPS2_WaitingForAck
 		 * we then check if S3 has been completed
 		 */
-		PacketReader::IP::TCP::TCP_Packet* CloseByRemoteStage1();
+		std::unique_ptr<PacketReader::IP::TCP::TCP_Packet> CloseByRemoteStage1();
 		bool CloseByRemoteStage2_ButAfter4(PacketReader::IP::TCP::TCP_Packet* tcp);
 		bool CloseByRemoteStage3_4(PacketReader::IP::TCP::TCP_Packet* tcp);
 
@@ -140,7 +140,7 @@ namespace Sessions
 		void CloseByRemoteRST();
 
 		// Returned TCP_Packet takes ownership of data
-		PacketReader::IP::TCP::TCP_Packet* CreateBasePacket(PacketReader::PayloadData* data = nullptr);
+		std::unique_ptr<PacketReader::IP::TCP::TCP_Packet> CreateBasePacket(PacketReader::PayloadData* data = nullptr);
 
 		void CloseSocket();
 	};

--- a/pcsx2/DEV9/Sessions/TCP_Session/TCP_Session_Out.cpp
+++ b/pcsx2/DEV9/Sessions/TCP_Session/TCP_Session_Out.cpp
@@ -363,10 +363,10 @@ namespace Sessions
 			}
 			// ACK data
 			//DevCon.WriteLn("[SRV] ACK data: %u", expectedSeqNumber);
-			TCP_Packet* ret = CreateBasePacket();
+			std::unique_ptr<TCP_Packet> ret = CreateBasePacket();
 			ret->SetACK(true);
 
-			PushRecvBuff(ret);
+			PushRecvBuff(std::move(ret));
 		}
 		return true;
 	}
@@ -521,10 +521,10 @@ namespace Sessions
 #endif
 
 		// Connection close part 2, send ACK to PS2
-		TCP_Packet* ret = CreateBasePacket();
+		std::unique_ptr<TCP_Packet> ret = CreateBasePacket();
 
 		ret->SetACK(true);
-		PushRecvBuff(ret);
+		PushRecvBuff(std::move(ret));
 
 		return true;
 	}
@@ -587,11 +587,11 @@ namespace Sessions
 				errno);
 #endif
 
-		TCP_Packet* ret = CreateBasePacket();
+		std::unique_ptr<TCP_Packet> ret = CreateBasePacket();
 
 		ret->SetACK(true);
 
-		PushRecvBuff(ret);
+		PushRecvBuff(std::move(ret));
 
 		if (myNumberACKed.load())
 		{
@@ -609,9 +609,9 @@ namespace Sessions
 	// Error on sending data
 	void TCP_Session::CloseByRemoteRST()
 	{
-		TCP_Packet* reterr = CreateBasePacket();
+		std::unique_ptr<TCP_Packet> reterr = CreateBasePacket();
 		reterr->SetRST(true);
-		PushRecvBuff(reterr);
+		PushRecvBuff(std::move(reterr));
 
 		CloseSocket();
 		state = TCP_State::CloseCompletedFlushBuffer;

--- a/pcsx2/DEV9/Sessions/UDP_Session/UDP_FixedPort.h
+++ b/pcsx2/DEV9/Sessions/UDP_Session/UDP_FixedPort.h
@@ -40,7 +40,7 @@ namespace Sessions
 
 		void Init();
 
-		virtual PacketReader::IP::IP_Payload* Recv();
+		virtual std::optional<ReceivedPayload> Recv();
 		virtual bool Send(PacketReader::IP::IP_Payload* payload);
 		virtual void Reset();
 

--- a/pcsx2/DEV9/Sessions/UDP_Session/UDP_Session.h
+++ b/pcsx2/DEV9/Sessions/UDP_Session/UDP_Session.h
@@ -46,7 +46,7 @@ namespace Sessions
 		UDP_Session(ConnectionKey parKey, PacketReader::IP::IP_Address parAdapterIP, bool parIsBroadcast, bool parIsMulticast, int parClient);
 #endif
 
-		virtual PacketReader::IP::IP_Payload* Recv();
+		virtual std::optional<ReceivedPayload> Recv();
 		virtual bool WillRecive(PacketReader::IP::IP_Address parDestIP);
 		virtual bool Send(PacketReader::IP::IP_Payload* payload);
 		virtual void Reset();

--- a/pcsx2/DEV9/SimpleQueue.h
+++ b/pcsx2/DEV9/SimpleQueue.h
@@ -52,7 +52,7 @@ void SimpleQueue<T>::Enqueue(T entry)
 	SimpleQueueEntry* newEntry = head.exchange(newHead);
 
 	//Fill in
-	newEntry->value = entry;
+	newEntry->value = std::move(entry);
 	newEntry->next = newHead;
 
 	//Set ready (can be dequeued)
@@ -68,7 +68,7 @@ bool SimpleQueue<T>::Dequeue(T* entry)
 	SimpleQueueEntry* retEntry = tail;
 	tail = retEntry->next;
 
-	*entry = retEntry->value;
+	*entry = std::move(retEntry->value);
 	delete retEntry;
 	return true;
 }

--- a/pcsx2/DEV9/sockets.cpp
+++ b/pcsx2/DEV9/sockets.cpp
@@ -220,13 +220,13 @@ bool SocketAdapter::recv(NetPacket* pkt)
 			if (!connections.TryGetValue(key, &session))
 				continue;
 
-			IP_Payload* pl = session->Recv();
+			std::optional<ReceivedPayload> pl = session->Recv();
 
-			if (pl != nullptr)
+			if (pl.has_value())
 			{
-				IP_Packet* ipPkt = new IP_Packet(pl);
+				IP_Packet* ipPkt = new IP_Packet(pl->payload.release());
 				ipPkt->destinationIP = session->sourceIP;
-				ipPkt->sourceIP = session->destIP;
+				ipPkt->sourceIP = pl->sourceIP;
 
 				EthernetFrame frame(ipPkt);
 				frame.sourceMAC = internalMAC;


### PR DESCRIPTION
### Description of Changes
Return the server IP that sent the packet alongside the payload
Use unique_ptr instead of raw pointers for managing the return packet within sessions

### Rationale behind Changes
The existing method of passing the server IP by adjusting the destIP field is not obvious.
ICMP was reusing the destIP field, and would end up targeting the incorrect address during traceroute.
Less managing raw pointers

### Suggested Testing Steps
Test networking games using sockets.
