### PR TITLE
GS: Make sure min/max for texture is at least 1 pixel

### DIFF
--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -4003,7 +4003,17 @@ GSState::TextureMinMaxResult GSState::GetTextureMinMax(GIFRegTEX0 TEX0, GIFRegCL
 
 		const bool inc_x = vr.x < tr.z;
 		const bool inc_y = vr.y < tr.w;
-		vr = (vr + GSVector4i(inc_x ? 0 : -1, inc_y ? 0 : -1, inc_x ? 1 : 0, inc_y ? 1 : 0).xxyy()).rintersect(tr);
+		vr = (vr + GSVector4i(inc_x ? 0 : -1, inc_y ? 0 : -1, inc_x ? 1 : 0, inc_y ? 1 : 0)).rintersect(tr);
+	}
+	else if (vr.xzxz().rempty())
+	{
+		const bool inc_x = vr.x < tr.z;
+		vr = (vr + GSVector4i(inc_x ? 0 : -1, 0, inc_x ? 1 : 0, 0)).rintersect(tr);
+	}
+	else if (vr.ywyw().rempty())
+	{
+		const bool inc_y = vr.y < tr.w;
+		vr = (vr + GSVector4i(0, inc_y ? 0 : -1, 0, inc_y ? 1 : 0)).rintersect(tr);
 	}
 
 	return { vr, uses_border };


### PR DESCRIPTION
### Description of Changes
Enforces a minimum rect size should there be a zero height or width

### Rationale behind Changes
Because of some recent changes that stopped a rect *always* being too big, it meant any zero sized rects became zero, so now we need to check these at the end, since rects are exclusive end.

### Suggested Testing Steps
Smoke test mainly, dump run (and splashdown in software) says it's good
