### PR TITLE
GS/Vulkan: Release swap chain images on acquire fail

### DIFF
--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h
@@ -41,6 +41,7 @@ public:
 		bool vk_ext_rasterization_order_attachment_access : 1;
 		bool vk_ext_full_screen_exclusive : 1;
 		bool vk_ext_line_rasterization : 1;
+		bool vk_ext_swapchain_maintenance1 : 1;
 		bool vk_khr_driver_properties : 1;
 		bool vk_khr_shader_non_semantic_info : 1;
 	};
@@ -125,7 +126,8 @@ public:
 
 private:
 	// Helper method to create a Vulkan instance.
-	static VkInstance CreateVulkanInstance(const WindowInfo& wi, bool enable_debug_utils, bool enable_validation_layer);
+	static VkInstance CreateVulkanInstance(const WindowInfo& wi, OptionalExtensions* oe, bool enable_debug_utils,
+		bool enable_validation_layer);
 
 	// Returns a list of Vulkan-compatible GPUs.
 	using GPUList = std::vector<std::pair<VkPhysicalDevice, std::string>>;
@@ -173,7 +175,8 @@ private:
 	};
 
 	using ExtensionList = std::vector<const char*>;
-	static bool SelectInstanceExtensions(ExtensionList* extension_list, const WindowInfo& wi, bool enable_debug_utils);
+	static bool SelectInstanceExtensions(ExtensionList* extension_list, const WindowInfo& wi, OptionalExtensions* oe,
+		bool enable_debug_utils);
 	bool SelectDeviceExtensions(ExtensionList* extension_list, bool enable_surface);
 	bool SelectDeviceFeatures();
 	bool CreateDevice(VkSurfaceKHR surface, bool enable_validation_layer);

--- a/pcsx2/GS/Renderers/Vulkan/VKEntryPoints.inl
+++ b/pcsx2/GS/Renderers/Vulkan/VKEntryPoints.inl
@@ -238,4 +238,7 @@ VULKAN_DEVICE_ENTRY_POINT(vkGetCalibratedTimestampsEXT, false)
 // VK_KHR_push_descriptor
 VULKAN_DEVICE_ENTRY_POINT(vkCmdPushDescriptorSetKHR, false)
 
+// VK_EXT_swapchain_maintenance1
+VULKAN_DEVICE_ENTRY_POINT(vkReleaseSwapchainImagesEXT, false)
+
 #endif // VULKAN_DEVICE_ENTRY_POINT

--- a/pcsx2/GS/Renderers/Vulkan/VKSwapChain.h
+++ b/pcsx2/GS/Renderers/Vulkan/VKSwapChain.h
@@ -68,6 +68,7 @@ public:
 	VkFormat GetTextureFormat() const;
 	VkResult AcquireNextImage();
 	void ReleaseCurrentImage();
+	void ResetImageAcquireResult();
 
 	bool RecreateSurface(const WindowInfo& new_wi);
 	bool ResizeSwapChain(u32 new_width = 0, u32 new_height = 0, float new_scale = 1.0f);


### PR DESCRIPTION
### Description of Changes

When image acquire returns suboptimal, apparently we should release the swap chain image we just acquired, because apparently that doesn't happen implicitly on creation of a new swap chain? (if you're transferring, not destroying/creating).

### Rationale behind Changes

Related to #11280.

### Suggested Testing Steps

See if the leak/driver crash occurs.
