### PR TITLE
Qt: Work around theme swap bug with Classic Windows

### DIFF
--- a/pcsx2-qt/LogWindow.cpp
+++ b/pcsx2-qt/LogWindow.cpp
@@ -37,10 +37,7 @@ LogWindow::LogWindow(bool attach_to_main)
 	Log::SetHostOutputLevel(GetWindowLogLevel(), &LogWindow::logCallback);
 }
 
-LogWindow::~LogWindow()
-{
-	Log::SetHostOutputLevel(LOGLEVEL_NONE, nullptr);
-}
+LogWindow::~LogWindow() = default;
 
 void LogWindow::updateSettings()
 {

--- a/pcsx2-qt/MainWindow.h
+++ b/pcsx2-qt/MainWindow.h
@@ -165,6 +165,8 @@ private Q_SLOTS:
 	void updateTheme();
 	void reloadThemeSpecificImages();
 	void updateLanguage();
+	void onThemeChanged();
+	void onLanguageChanged();
 	void onScreenshotActionTriggered();
 	void onSaveGSDumpActionTriggered();
 	void onBlockDumpActionToggled(bool checked);


### PR DESCRIPTION
### Description of Changes

Works around the menu-backgrounds-being-transparent bug when switching between classic windows and any other style by recreating the window. Terrible, but I don't feel like debugging Qt today.

### Rationale behind Changes

Bug workarounds.

### Suggested Testing Steps

Test changing theme.
