### PR TITLE
GS/HW: Allow use of trilinear with shader sampling

### DIFF
--- a/bin/resources/shaders/dx11/tfx.fx
+++ b/bin/resources/shaders/dx11/tfx.fx
@@ -162,6 +162,7 @@ cbuffer cb1
 	uint4 FbMask;
 	float4 HalfTexel;
 	float4 MinMax;
+	float4 LODParams;
 	float4 STRange;
 	int4 ChannelShuffle;
 	float2 TC_OffsetHack;
@@ -207,10 +208,10 @@ float4 sample_c(float2 uv, float uv_w)
 	return Texture.Sample(TextureSampler, uv);
 #elif PS_MANUAL_LOD == 1
 	// FIXME add LOD: K - ( LOG2(Q) * (1 << L))
-	float K = MinMax.x;
-	float L = MinMax.y;
-	float bias = MinMax.z;
-	float max_lod = MinMax.w;
+	float K = LODParams.x;
+	float L = LODParams.y;
+	float bias = LODParams.z;
+	float max_lod = LODParams.w;
 
 	float gs_lod = K - log2(abs(uv_w)) * L;
 	// FIXME max useful ?

--- a/bin/resources/shaders/opengl/tfx_fs.glsl
+++ b/bin/resources/shaders/opengl/tfx_fs.glsl
@@ -44,6 +44,7 @@ layout(std140, binding = 0) uniform cb21
 	vec4 HalfTexel;
 
 	vec4 MinMax;
+	vec4 LODParams;
 	vec4 STRange;
 
 	ivec4 ChannelShuffle;
@@ -159,10 +160,10 @@ vec4 sample_c(vec2 uv)
 	return texture(TextureSampler, uv);
 #elif PS_MANUAL_LOD == 1
 	// FIXME add LOD: K - ( LOG2(Q) * (1 << L))
-	float K = MinMax.x;
-	float L = MinMax.y;
-	float bias = MinMax.z;
-	float max_lod = MinMax.w;
+	float K = LODParams.x;
+	float L = LODParams.y;
+	float bias = LODParams.z;
+	float max_lod = LODParams.w;
 
 	float gs_lod = K - log2(abs(PSin.t_float.w)) * L;
 	// FIXME max useful ?

--- a/bin/resources/shaders/vulkan/tfx.glsl
+++ b/bin/resources/shaders/vulkan/tfx.glsl
@@ -316,6 +316,7 @@ layout(std140, set = 0, binding = 1) uniform cb1
 	uvec4 FbMask;
 	vec4 HalfTexel;
 	vec4 MinMax;
+	vec4 LODParams;
 	vec4 STRange;
 	ivec4 ChannelShuffle;
 	vec2 TC_OffsetHack;
@@ -399,10 +400,10 @@ vec4 sample_c(vec2 uv)
 	return texture(Texture, uv);
 #elif PS_MANUAL_LOD == 1
 	// FIXME add LOD: K - ( LOG2(Q) * (1 << L))
-	float K = MinMax.x;
-	float L = MinMax.y;
-	float bias = MinMax.z;
-	float max_lod = MinMax.w;
+	float K = LODParams.x;
+	float L = LODParams.y;
+	float bias = LODParams.z;
+	float max_lod = LODParams.w;
 
 	float gs_lod = K - log2(abs(vsIn.t.w)) * L;
 	// FIXME max useful ?

--- a/pcsx2/GS/Renderers/Common/GSDevice.h
+++ b/pcsx2/GS/Renderers/Common/GSDevice.h
@@ -585,6 +585,7 @@ struct alignas(16) GSHWDrawConfig
 
 		GSVector4 HalfTexel;
 		GSVector4 MinMax;
+		GSVector4 LODParams;
 		GSVector4 STRange;
 		GSVector4i ChannelShuffle;
 		GSVector2 TCOffsetHack;

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -4789,9 +4789,9 @@ __ri void GSRendererHW::EmulateTextureSampler(const GSTextureCache::Target* rt, 
 	// we keep the shader clamp. See #5851 on github, and the note in Draw().
 	[[maybe_unused]] static constexpr const char* clamp_modes[] = {"REPEAT", "CLAMP", "REGION_CLAMP", "REGION_REPEAT"};
 	const bool redundant_wms = IsRedundantClamp(m_cached_ctx.CLAMP.WMS, m_cached_ctx.CLAMP.MINU,
-													 m_cached_ctx.CLAMP.MAXU, tex->m_TEX0.TW);
+													 m_cached_ctx.CLAMP.MAXU, m_cached_ctx.TEX0.TW);
 	const bool redundant_wmt = IsRedundantClamp(m_cached_ctx.CLAMP.WMT, m_cached_ctx.CLAMP.MINV,
-													 m_cached_ctx.CLAMP.MAXV, tex->m_TEX0.TH);
+													 m_cached_ctx.CLAMP.MAXV, m_cached_ctx.TEX0.TH);
 	const u8 wms = EffectiveClamp(m_cached_ctx.CLAMP.WMS, !tex->m_target && (source_region.HasX() || redundant_wms));
 	const u8 wmt = EffectiveClamp(m_cached_ctx.CLAMP.WMT, !tex->m_target && (source_region.HasY() || redundant_wmt));
 	const bool complex_wms_wmt = !!((wms | wmt) & 2) || target_region;

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -5366,8 +5366,7 @@ GSTextureCache::HashCacheEntry* GSTextureCache::LookupHashCache(const GIFRegTEX0
 	if (lod)
 	{
 		const int basemip = lod->x;
-		const int nmips = lod->y - lod->x + 1;
-		for (int mip = 1; mip < nmips; mip++)
+		for (int mip = 1; mip < tlevels; mip++)
 		{
 			const GIFRegTEX0 MIP_TEX0{g_gs_renderer->GetTex0Layer(basemip + mip)};
 			std::pair<u8, u8> mip_alpha_minmax;
@@ -5379,6 +5378,8 @@ GSTextureCache::HashCacheEntry* GSTextureCache::LookupHashCache(const GIFRegTEX0
 				alpha_minmax.second = std::max(alpha_minmax.second, mip_alpha_minmax.second);
 			}
 		}
+
+		tex->ClearMipmapGenerationFlag();
 	}
 
 	// remove the palette hash when using paltex/indexed

--- a/pcsx2/GS/Renderers/Metal/GSMTLSharedHeader.h
+++ b/pcsx2/GS/Renderers/Metal/GSMTLSharedHeader.h
@@ -111,6 +111,7 @@ struct GSMTLMainPSUniform
 		vector_float4 uv_min_max;
 		vector_uint4 uv_msk_fix;
 	};
+	vector_float4 lod_params;
 	vector_float4 st_range;
 	struct
 	{

--- a/pcsx2/GS/Renderers/Metal/tfx.metal
+++ b/pcsx2/GS/Renderers/Metal/tfx.metal
@@ -356,10 +356,10 @@ struct PSMain
 		}
 		else if (PS_MANUAL_LOD)
 		{
-			float K = cb.uv_min_max.x;
-			float L = cb.uv_min_max.y;
-			float bias = cb.uv_min_max.z;
-			float max_lod = cb.uv_min_max.w;
+			float K = cb.lod_params.x;
+			float L = cb.lod_params.y;
+			float bias = cb.lod_params.z;
+			float max_lod = cb.lod_params.w;
 
 			float gs_lod = K - log2(abs(in.t.w)) * L;
 			// FIXME max useful ?

--- a/pcsx2/ShaderCacheVersion.h
+++ b/pcsx2/ShaderCacheVersion.h
@@ -3,4 +3,4 @@
 
 /// Version number for GS and other shaders. Increment whenever any of the contents of the
 /// shaders change, to invalidate the cache.
-static constexpr u32 SHADER_CACHE_VERSION = 50;
+static constexpr u32 SHADER_CACHE_VERSION = 51;


### PR DESCRIPTION
### Description of Changes

Apparently this was completely missing, whoops.

Also enables clamp elimination in mipmapped situations, which is important due to us having mipmapping on by default now. TW/TH won't match when mipmap minimization eliminates the base level, so use the TEX0 register from the context instead.

### Rationale behind Changes

Fixes #11441.

Couple of other noteworthy mentions:
![image](https://github.com/PCSX2/pcsx2/assets/11288319/98b31dcf-1f44-4dde-9fce-93486f33b036)
![image](https://github.com/PCSX2/pcsx2/assets/11288319/505bff4f-5fb2-46d7-ba6d-999df23506a5)
![image](https://github.com/PCSX2/pcsx2/assets/11288319/afe1b34c-8d76-43c8-a4a6-db285008013b)
![image](https://github.com/PCSX2/pcsx2/assets/11288319/5fcb5e07-66de-47e1-9699-fe437a892c79)
![image](https://github.com/PCSX2/pcsx2/assets/11288319/bf8a2d6f-90c1-49b8-9107-1be11c799705)
![image](https://github.com/PCSX2/pcsx2/assets/11288319/6d56079d-bd66-455c-b02f-62a157a869ee)

### Suggested Testing Steps

Check linked dump on all renderers.
Smoke test, runner says we good.
