### PR TITLE
GameDB: Street Fighter EX3 - Fix the post processing at high resolution

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -13106,6 +13106,7 @@ SLES-50072:
   compat: 5
   gsHWFixes:
     getSkipCount: "GSC_SFEX3"
+    halfPixelOffset: 4 # Aligns post effects.
 SLES-50073:
   name: "Driving Emotion Type-S"
   region: "PAL-M5"
@@ -31048,6 +31049,7 @@ SLPM-60105:
   region: "NTSC-J"
   gsHWFixes:
     getSkipCount: "GSC_SFEX3"
+    halfPixelOffset: 4 # Aligns post effects.
 SLPM-60106:
   name: "Koei PlayStation 2 Line-Up"
   region: "NTSC-J"
@@ -48481,6 +48483,7 @@ SLPS-20003:
   region: "NTSC-J"
   gsHWFixes:
     getSkipCount: "GSC_SFEX3"
+    halfPixelOffset: 4 # Aligns post effects.
 SLPS-20004:
   name: "Kakinoki Shougi IV"
   region: "NTSC-J"
@@ -57501,6 +57504,7 @@ SLUS-20130:
   compat: 5
   gsHWFixes:
     getSkipCount: "GSC_SFEX3"
+    halfPixelOffset: 4 # Aligns post effects.
 SLUS-20131:
   name: "Dark Angel - Vampire Apocalypse"
   region: "NTSC-U"


### PR DESCRIPTION
When upscaled, the post processing is misaligned (noticeable with higher resolution 6x or 8x) and there's a weird ghosting effect. The new "Natively downscale targets" hack solves it.

Before : 
![Street Fighter EX3_SLUS-20130_20240623145930](https://github.com/PCSX2/pcsx2/assets/47425204/0f73d509-7c2e-46b3-a40d-b29a30fb79b2)

After : 
![Street Fighter EX3_SLUS-20130_20240623145945](https://github.com/PCSX2/pcsx2/assets/47425204/8bd2f8b6-9a3b-41f1-9c21-8d03bdfaebc1)
