### PR TITLE
GS/HW: Optimize blends in some zero color scenarios

### DIFF
--- a/pcsx2/GS/GSLocalMemory.cpp
+++ b/pcsx2/GS/GSLocalMemory.cpp
@@ -371,6 +371,13 @@ std::vector<GSVector2i>* GSLocalMemory::GetPage2TileMap(const GIFRegTEX0& TEX0)
 	int tw = std::max<int>(1 << TEX0.TW, bs.x);
 	int th = std::max<int>(1 << TEX0.TH, bs.y);
 
+	// Limit the size to the maximum size of the GS memory, there's no point in mapping more than this.
+	if ((tw * th) > VM_SIZE)
+	{
+		tw = 2048;
+		th = 2048;
+	}
+
 	GSOffset off = GetOffset(TEX0.TBP0, TEX0.TBW, TEX0.PSM);
 	GSOffset::BNHelper bn = off.bnMulti(0, 0);
 

--- a/pcsx2/GS/Renderers/HW/GSHwHack.cpp
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.cpp
@@ -1429,6 +1429,8 @@ bool GSHwHack::MV_Ico(GSRendererHW& r)
 	dst->UpdateValidChannels(PSMCT32, 0);
 	dst->UpdateValidity(draw_rc);
 	dst->UnscaleRTAlpha();
+	dst->m_alpha_min = 0;
+	dst->m_alpha_max = 255;
 
 	GSHWDrawConfig& config = GSRendererHW::GetInstance()->BeginHLEHardwareDraw(
 		dst->GetTexture(), nullptr, dst->GetScale(), src->GetTexture(), src->GetScale(), draw_rc);


### PR DESCRIPTION
### Description of Changes
Optimises blends to use constants in some situations to avoid software blending.
Fixed a bug with GPU CLUT not setting the right alphas (Setting it to "don't know" currently, as it's better than blatantly wrong)
Fixed up GS memory page mapping to only map up to the maximum size of the GS memory, not much point in doing more.

### Rationale behind Changes
Optimisation are always nice, in some cases (listed below) it saves hundreds to thousands of barriers, making some games run faster on AMD and low powered GPU systems.

### Suggested Testing Steps
Test below listed games when GPU limited (you will need either a potato or hope 8x native resolution is enough), using default blending for said games.

Improves the GPU limited performance of the following games:

Ace Combat 5/Zero/Squadron Leader
Driver - Parallel Lines
Need for Speed Most Wanted/Carbon/Underground
Sims The - Bustin Out
Tom Clancys Splinter_Cell - Double Agent
Zone of Enders 2
