### PR TITLE
GameDB: RE Outbreak disable FBMask patch

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -16557,6 +16557,12 @@ SLES-51588:
 SLES-51589:
   name: "Resident Evil - Outbreak"
   region: "PAL-M5"
+  patches:
+    47C231CC:
+      content: |-
+        //Patched by Refraction.
+        //Removes silly mask causing high barriers on draws (Requires game restart).
+        patch=0,EE,001972D0,word,24050000
 SLES-51590:
   name: "Cabela's Big Game Hunter"
   region: "PAL-E"
@@ -60710,6 +60716,12 @@ SLUS-20765:
   name: "Resident Evil - Outbreak"
   region: "NTSC-U"
   compat: 5
+  patches:
+    0245EF6D:
+      content: |-
+        //Patched by Refraction.
+        //Removes silly mask causing high barriers on draws (Requires game restart).
+        patch=0,EE,0019FF60,word,24050000
 SLUS-20766:
   name: "Fatal Frame II - Crimson Butterfly"
   region: "NTSC-U"
@@ -61895,6 +61907,12 @@ SLUS-20984:
   name: "Resident Evil Outbreak - File #2"
   region: "NTSC-U"
   compat: 5
+  patches:
+    1E65A50E:
+      content: |-
+        //Patched by Refraction.
+        //Removes silly mask causing high barriers on draws (Requires game restart).
+        patch=0,EE,001EE550,word,24050000
   memcardFilters:
     - "SLUS-20984"
     - "SLUS-20765"


### PR DESCRIPTION
### Description of Changes
Disables FBMask reducing the silly barrier count from 12,000 odd to 0.

### Rationale behind Changes
Capcom are dumb and are ruining our performance.

### Suggested Testing Steps
Make sure the patches work correctly as described on the tin.
