### PR TITLE
EE Cache: Fix cache masking, support caching invalid phadr, and cache line locking

### DIFF
--- a/pcsx2/Cache.h
+++ b/pcsx2/Cache.h
@@ -8,13 +8,13 @@
 #include "common/SingleRegisterTypes.h"
 
 void resetCache();
-void writeCache8(u32 mem, u8 value);
-void writeCache16(u32 mem, u16 value);
-void writeCache32(u32 mem, u32 value);
-void writeCache64(u32 mem, const u64 value);
-void writeCache128(u32 mem, const mem128_t* value);
-u8 readCache8(u32 mem);
-u16 readCache16(u32 mem);
-u32 readCache32(u32 mem);
-u64 readCache64(u32 mem);
-RETURNS_R128 readCache128(u32 mem);
+void writeCache8(u32 mem, u8 value, bool validPFN = true);
+void writeCache16(u32 mem, u16 value, bool validPFN = true);
+void writeCache32(u32 mem, u32 value, bool validPFN = true);
+void writeCache64(u32 mem, const u64 value, bool validPFN = true);
+void writeCache128(u32 mem, const mem128_t* value, bool validPFN = true);
+u8 readCache8(u32 mem, bool validPFN = true);
+u16 readCache16(u32 mem, bool validPFN = true);
+u32 readCache32(u32 mem, bool validPFN = true);
+u64 readCache64(u32 mem, bool validPFN = true);
+RETURNS_R128 readCache128(u32 mem, bool validPFN = true);

--- a/pcsx2/vtlb.cpp
+++ b/pcsx2/vtlb.cpp
@@ -113,7 +113,7 @@ __inline int ConvertPageMask(u32 PageMask)
 {
 	const u32 mask = std::popcount(PageMask >> 13);
 
-	pxAssertMsg (!((mask & 1) || mask > 12), "Invalid page mask for this TLB entry. EE cache doesn't know what to do here.");
+	pxAssertMsg(!((mask & 1) || mask > 12), "Invalid page mask for this TLB entry. EE cache doesn't know what to do here.");
 
 	return (1 << (12 + mask)) - 1;
 }


### PR DESCRIPTION
### Description of Changes
You are able to make TLB entries that point to invalid physical addresses. Because the cache is accessed before the physical write , the cache will still store data for these physical addresses. Once the cache data is evicted, curiously there is no bus error for addresses such as 0x70004000, so the data is silently discarded.
Find my Own Way uses this method to create a "virtual scratchpad" of higher speed, temporary memory.

Previously our cache line locking wasn't fully implemented. This PR addresses that as well.
With the combined invalid physical address mapping and cache line locking support, **I believe I have fixed the find my own way demo!.**

### Rationale behind Changes
This is proper cache behaviour.

### Suggested Testing Steps
Test games that require EE Cache (I'm sorry, I know it's slow :( ), make sure they still work.
Also, **if any game causes bus errors** please try and test it with this PR and EE Cache enabled. This might be the fix required.

## If you're testing games with bus errors (including find my own way), I recommend disabling the system console. The bus error spam slows it down.