### PR TITLE
GS/HW: Implement RT in RT support

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -174,9 +174,8 @@ PAPX-90020:
     recommendedBlendingLevel: 4 # Improves banding and effect emulation.
     autoFlush: 1 # Fixes light bloom intensity.
     estimateTextureRegion: 1 # Improves performance and reduces hash cache size.
-    halfPixelOffset: 4 # Aligns post effects.
+    halfPixelOffset: 2 # Aligns post effects.
     nativeScaling: 1 # Fixes post effects.
-    getSkipCount: "GSC_GiTS"
 PAPX-90201:
   name: "ファンタビジョン [体験版]"
   name-sort: "ふぁんたびじょん [たいけんばん]"
@@ -524,7 +523,7 @@ PAPX-90524:
   region: "NTSC-J"
   gsHWFixes:
     roundSprite: 1 # Fixes font sizes and lines in UI.
-    cpuFramebufferConversion: 1 # Fixes sepia-tone flashback sequences.
+    textureInsideRT: 1 # Fixes sepia-tone flashback sequences.
     forceEvenSpritePosition: 1 # Fixes font artifacts and out-of-bound 2D textures.
     gpuPaletteConversion: 2 # Fixes micro-stuttering and reduces HC size.
 PBGP-0061:
@@ -1250,26 +1249,31 @@ SCAJ-10011:
   region: "NTSC-Unk"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
+    textureInsideRT: 1 # Fixes post effects.
 SCAJ-10012:
   name: "Taiko Drum Master"
   region: "NTSC-Unk"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
+    textureInsideRT: 1 # Fixes post effects.
 SCAJ-10013:
   name: "Taiko no Tatsujin - Tobikkiri! Anime Special"
   region: "NTSC-Unk"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
+    textureInsideRT: 1 # Fixes post effects.
 SCAJ-10014:
   name: "Taiko no Tatsujin - Wai Wai Happy! Rokudaime"
   region: "NTSC-Unk"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
+    textureInsideRT: 1 # Fixes post effects.
 SCAJ-10015:
   name: "Taiko no Tatsujin - Doka! to Oomori Nanadaime"
   region: "NTSC-Unk"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
+    textureInsideRT: 1 # Fixes post effects.
     getSkipCount: "GSC_Tekken5" # Fixes upscaling grid, same engine.
 SCAJ-20001:
   name: "Ratchet & Clank"
@@ -1330,7 +1334,6 @@ SCAJ-20010:
   region: "NTSC-Unk"
   gsHWFixes:
     textureInsideRT: 1 # Fixes inside RT shuffling.
-    getSkipCount: "GSC_BigMuthaTruckers"
 SCAJ-20011:
   name: "Armored Core 3 - Silent Line"
   region: "NTSC-HK"
@@ -1395,6 +1398,8 @@ SCAJ-20020:
     texturePreloading: 1 # Performs better with partial preload because it is slow on locations outside gameplay foremost.
     mergeSprite: 1 # Fixes misaligned white lines.
     PCRTCOverscan: 1 # Fixes missing HUD.
+    textureInsideRT: 1 # Fixes post shuffle effect.
+    halfPixelOffset: 2 # Fixes boxes around shuffle effect pages.
 SCAJ-20021:
   name: "Metal Slug 3"
   region: "NTSC-Unk"
@@ -1511,6 +1516,8 @@ SCAJ-20047:
   region: "NTSC-Unk"
   gsHWFixes:
     texturePreloading: 0 # Performs much better with no preload.
+    textureInsideRT: 1 # Fixes post processing.
+    halfPixelOffset: 5 # Fixes alignment of shuffles and post processing.
 SCAJ-20048:
   name: "R:RACING EVOLUTION"
   name-sort: "Rれーしんぐえぼりゅーしょん"
@@ -1560,6 +1567,8 @@ SCAJ-20060:
   region: "NTSC-Unk"
   gsHWFixes:
     texturePreloading: 0 # Performs much better with no preload.
+    textureInsideRT: 1 # Fixes post processing.
+    halfPixelOffset: 5 # Fixes alignment of shuffles and post processing.
 SCAJ-20061:
   name: "Seven Samurai 20XX"
   region: "NTSC-Unk"
@@ -1631,9 +1640,9 @@ SCAJ-20072:
     recommendedBlendingLevel: 4 # Improves banding and effect emulation.
     autoFlush: 1 # Fixes light bloom intensity.
     estimateTextureRegion: 1 # Improves performance and reduces hash cache size.
-    halfPixelOffset: 4 # Aligns post effects.
+    halfPixelOffset: 2 # Aligns post effects.
     nativeScaling: 1 # Fixes post effects.
-    getSkipCount: "GSC_GiTS"
+    textureInsideRT: 1 # Fixes post shuffles.
 SCAJ-20073:
   name: "Jak and Daxter II"
   region: "NTSC-Unk"
@@ -1899,9 +1908,8 @@ SCAJ-20116:
   region: "NTSC-C-J"
   gsHWFixes:
     alignSprite: 1 # Fixes FMV lines.
-    cpuSpriteRenderBW: 2 # Prevents Death By VRAM explosion.
-    cpuSpriteRenderLevel: 2 # Needed for above.
-    getSkipCount: "GSC_DeathByDegreesTekkenNinaWilliams"
+    halfPixelOffset: 5 # Fixes alignment of shuffles and post processing.
+    textureInsideRT: 1 # Fixes post shuffles.
 SCAJ-20117:
   name: "Fu-un Bakumatsu-den"
   region: "NTSC-Unk"
@@ -2274,7 +2282,7 @@ SCAJ-20169:
   region: "NTSC-Unk"
   gsHWFixes:
     autoFlush: 1 # Fixes lighting.
-    halfPixelOffset: 4 # Fixes ghosting.
+    halfPixelOffset: 5 # Fixes ghosting.
     nativeScaling: 2 # Fixes post processing.
     recommendedBlendingLevel: 4 # Fixes missing light brightness.
 SCAJ-20170:
@@ -2373,7 +2381,7 @@ SCAJ-20183:
   region: "NTSC-J"
   gsHWFixes:
     roundSprite: 1 # Fixes font sizes and lines in UI.
-    cpuFramebufferConversion: 1 # Fixes sepia-tone flashback sequences.
+    textureInsideRT: 1 # Fixes sepia-tone flashback sequences.
     forceEvenSpritePosition: 1 # Fixes font artifacts and out-of-bound 2D textures.
     gpuPaletteConversion: 2 # Fixes micro-stuttering and reduces HC size.
 SCAJ-20184:
@@ -3571,6 +3579,7 @@ SCED-52137:
     autoFlush: 2 # Fixes sun luminosity.
     halfPixelOffset: 2 # Aligns Depth of Field.
     nativeScaling: 2 # Fixes Depth of Field effect.
+    textureInsideRT: 1 # Fixes half screen fog effect.
 SCED-52141:
   name: "WRC 3 [Demo]"
   region: "PAL-E"
@@ -3582,6 +3591,7 @@ SCED-52141:
     autoFlush: 2 # Fixes sun luminosity.
     halfPixelOffset: 2 # Aligns Depth of Field.
     nativeScaling: 2 # Fixes Depth of Field effect.
+    textureInsideRT: 1 # Fixes half screen fog effect.
 SCED-52147:
   name: "EyeToy - Christmas Wishi Washi"
   region: "PAL-E"
@@ -4565,8 +4575,7 @@ SCES-50000:
   clampModes:
     vuClampMode: 2 # Fixes texture rendering in the intro.
   gsHWFixes:
-    cpuFramebufferConversion: 1
-    textureInsideRT: 1
+    textureInsideRT: 1 # Fixes post effects
     halfPixelOffset: 2 # Fixes title screen and some intro post processing alignment.
     roundSprite: 1 # Fixes ui and hud alignment.
     gpuPaletteConversion: 2 # Lots of CLUTs in large textures.
@@ -5289,6 +5298,7 @@ SCES-51684:
     autoFlush: 2 # Fixes sun luminosity.
     halfPixelOffset: 2 # Aligns Depth of Field.
     nativeScaling: 2 # Fixes Depth of Field effect.
+    textureInsideRT: 1 # Fixes half screen fog effect.
   patches:
     80802EA9:
       content: |-
@@ -5331,6 +5341,8 @@ SCES-51844:
   region: "PAL-M5"
   gsHWFixes:
     texturePreloading: 0 # Performs much better with no preload.
+    textureInsideRT: 1 # Fixes post processing.
+    halfPixelOffset: 5 # Fixes alignment of shuffles and post processing.
 SCES-51895:
   name: "EyeToy - Groove"
   region: "PAL-M11"
@@ -5428,6 +5440,7 @@ SCES-52137:
     autoFlush: 2 # Fixes sun luminosity.
     halfPixelOffset: 2 # Aligns Depth of Field.
     nativeScaling: 2 # Fixes Depth of Field effect.
+    textureInsideRT: 1 # Fixes half screen fog effect.
 SCES-52154:
   name: "EyeToy - Chat"
   region: "PAL-M11"
@@ -5635,9 +5648,8 @@ SCES-52586:
   compat: 5
   gsHWFixes:
     alignSprite: 1 # Fixes FMV lines.
-    cpuSpriteRenderBW: 2 # Prevents Death By VRAM explosion.
-    cpuSpriteRenderLevel: 2 # Needed for above.
-    getSkipCount: "GSC_DeathByDegreesTekkenNinaWilliams"
+    halfPixelOffset: 5 # Fixes alignment of shuffles and post processing.
+    textureInsideRT: 1 # Fixes post shuffles.
 SCES-52596:
   name: "This is Football 2005"
   region: "PAL-Unk"
@@ -5657,6 +5669,7 @@ SCES-52684:
     autoFlush: 2 # Fixes sun luminosity.
     halfPixelOffset: 2 # Aligns Depth of Field.
     nativeScaling: 2 # Fixes Depth of Field effect.
+    textureInsideRT: 1 # Fixes half screen fog effect.
 SCES-52748:
   name: "EyeToy - Play 2"
   region: "PAL-M12"
@@ -5737,18 +5750,16 @@ SCES-53053:
   region: "PAL-F-I"
   gsHWFixes:
     alignSprite: 1 # Fixes FMV lines.
-    cpuSpriteRenderBW: 2 # Prevents Death By VRAM explosion.
-    cpuSpriteRenderLevel: 2 # Needed for above.
-    getSkipCount: "GSC_DeathByDegreesTekkenNinaWilliams"
+    halfPixelOffset: 5 # Fixes alignment of shuffles and post processing.
+    textureInsideRT: 1 # Fixes post shuffles.
 SCES-53054:
   name: "Death by Degrees"
   region: "PAL-E-G"
   compat: 5
   gsHWFixes:
     alignSprite: 1 # Fixes FMV lines.
-    cpuSpriteRenderBW: 2 # Prevents Death By VRAM explosion.
-    cpuSpriteRenderLevel: 2 # Needed for above.
-    getSkipCount: "GSC_DeathByDegreesTekkenNinaWilliams"
+    halfPixelOffset: 5 # Fixes alignment of shuffles and post processing.
+    textureInsideRT: 1 # Fixes post shuffles.
 SCES-53055:
   name: "Eyetoy - Antigrav"
   region: "PAL-M5"
@@ -6998,6 +7009,8 @@ SCKA-20015:
   compat: 5
   gsHWFixes:
     texturePreloading: 0 # Performs much better with no preload.
+    textureInsideRT: 1 # Fixes post processing.
+    halfPixelOffset: 5 # Fixes alignment of shuffles and post processing.
 SCKA-20016:
   name: "SoulCalibur II"
   region: "NTSC-K"
@@ -7071,9 +7084,9 @@ SCKA-20027:
     recommendedBlendingLevel: 4 # Improves banding and effect emulation.
     autoFlush: 1 # Fixes light bloom intensity.
     estimateTextureRegion: 1 # Improves performance and reduces hash cache size.
-    halfPixelOffset: 4 # Aligns post effects.
+    halfPixelOffset: 2 # Aligns post effects.
     nativeScaling: 1 # Fixes post effects.
-    getSkipCount: "GSC_GiTS"
+    textureInsideRT: 1 # Fixes post shuffles.
 SCKA-20028:
   name: "Ico [PlayStation2 Big Hit Series]"
   region: "NTSC-K"
@@ -7125,6 +7138,8 @@ SCKA-20034:
   region: "NTSC-K"
   gsHWFixes:
     texturePreloading: 0 # Performs much better with no preload.
+    textureInsideRT: 1 # Fixes post processing.
+    halfPixelOffset: 5 # Fixes alignment of shuffles and post processing.
 SCKA-20035:
   name: "Hot Shots Golf 3 [PlayStation 2 Big Hit Series]"
   region: "NTSC-K"
@@ -7155,9 +7170,8 @@ SCKA-20039:
   region: "NTSC-K"
   gsHWFixes:
     alignSprite: 1 # Fixes FMV lines.
-    cpuSpriteRenderBW: 2 # Prevents Death By VRAM explosion.
-    cpuSpriteRenderLevel: 2 # Needed for above.
-    getSkipCount: "GSC_DeathByDegreesTekkenNinaWilliams"
+    halfPixelOffset: 2 # Aligns post effects.
+    textureInsideRT: 1 # Fixes post shuffles.
 SCKA-20040:
   name: "Jak 3"
   region: "NTSC-K"
@@ -8651,9 +8665,8 @@ SCPS-15064:
     recommendedBlendingLevel: 4 # Improves banding and effect emulation.
     autoFlush: 1 # Fixes light bloom intensity.
     estimateTextureRegion: 1 # Improves performance and reduces hash cache size.
-    halfPixelOffset: 4 # Aligns post effects.
+    halfPixelOffset: 2 # Aligns post effects.
     nativeScaling: 1 # Fixes post effects.
-    getSkipCount: "GSC_GiTS"
   patches:
     A5768F53:
       content: |-
@@ -9145,7 +9158,7 @@ SCPS-15118:
   region: "NTSC-J"
   gsHWFixes:
     roundSprite: 1 # Fixes font sizes and lines in UI.
-    cpuFramebufferConversion: 1 # Fixes sepia-tone flashback sequences.
+    textureInsideRT: 1 # Fixes sepia-tone flashback sequences.
     forceEvenSpritePosition: 1 # Fixes font artifacts and out-of-bound 2D textures.
     gpuPaletteConversion: 2 # Fixes micro-stuttering and reduces HC size.
 SCPS-15119:
@@ -9846,7 +9859,7 @@ SCPS-19333:
   region: "NTSC-J"
   gsHWFixes:
     roundSprite: 1 # Fixes font sizes and lines in UI.
-    cpuFramebufferConversion: 1 # Fixes sepia-tone flashback sequences.
+    textureInsideRT: 1 # Fixes sepia-tone flashback sequences.
     forceEvenSpritePosition: 1 # Fixes font artifacts and out-of-bound 2D textures.
     gpuPaletteConversion: 2 # Fixes micro-stuttering and reduces HC size.
 SCPS-19335:
@@ -13336,6 +13349,12 @@ SLED-52736:
 SLED-52851:
   name: "TOCA Race Driver 2"
   region: "PAL-Unk"
+  gsHWFixes:
+    alignSprite: 1 # Fixes lighting and vertical lines, also works with normal vertex.
+    roundSprite: 1 # Fixes misaligned map.
+    halfPixelOffset: 2 # Fixes depth of field alignment.
+    nativeScaling: 1 # Fixes depth of field.
+    textureInsideRT: 1 # Fixes shadows.
 SLED-52852:
   name: "Forgotten Realms - Demon Stone [Demo]"
   region: "PAL-E"
@@ -13422,8 +13441,13 @@ SLED-53109:
     cpuCLUTRender: 1 # Fixes broken headlights.
     minimumBlendingLevel: 3
 SLED-53137:
-  name: "Stolen"
-  region: "PAL-Unk"
+  name: "Stolen [Demo]"
+  region: "PAL-M5"
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes misaligned bloom effects.
+    texturePreloading: 1 # Performs much better with partial preload.
+    textureInsideRT: 1 # Fixes post effects.
+    nativeScaling: 1 # Fixes lighting quality and positioning.
 SLED-53198:
   name: "Rugby 2005"
   region: "PAL-Unk"
@@ -13581,6 +13605,7 @@ SLED-53723:
     autoFlush: 1 # Corrects vignette to match software.
     estimateTextureRegion: 1 # Improves performance and reduces hash cache size.
     halfPixelOffset: 4 # Aligns blur more correctly to match software.
+    textureInsideRT: 1 # Fixes post processing effects.
 SLED-53731:
   name: "Battlefield 2 - Modern Combat [Demo]"
   region: "PAL-E"
@@ -13627,10 +13652,9 @@ SLED-53888:
   gsHWFixes:
     alignSprite: 1 # Fixes lighting and vertical lines, also works with normal vertex.
     roundSprite: 1 # Fixes misaligned map.
-    skipDrawStart: 1 # Removes large black box around player car till we properly emulate it.
-    skipDrawEnd: 1 # Removes large black box around player car till we properly emulate it.
     halfPixelOffset: 2 # Fixes depth of field alignment.
     nativeScaling: 1 # Fixes depth of field.
+    textureInsideRT: 1 # Fixes shadows.
 SLED-53937:
   name: "Black [Demo]"
   region: "PAL-M5"
@@ -15882,8 +15906,6 @@ SLES-50876:
   gsHWFixes:
     autoFlush: 1 # Aligns and corrects shadows.
     halfPixelOffset: 2 # Fixes sun and depth line.
-    cpuCLUTRender: 1 # Fixes janky coloured cars.
-    gpuTargetCLUT: 1 # Fixes janky coloured cars.
     textureInsideRT: 1 # Fixes car textures.
     cpuSpriteRenderBW: 4 # Alleviates text and sky rendering issues.
     cpuSpriteRenderLevel: 2 # Needed for above.
@@ -17062,7 +17084,6 @@ SLES-51355:
   compat: 5
   gsHWFixes:
     textureInsideRT: 1 # Fixes inside RT shuffling.
-    getSkipCount: "GSC_BigMuthaTruckers"
 SLES-51356:
   name: "Road Trip Adventure"
   region: "PAL-M3"
@@ -18547,6 +18568,9 @@ SLES-51997:
   compat: 5
   clampModes:
     eeClampMode: 3 # For grey screen ingame.
+  gsHWFixes:
+    textureInsideRT: 1 # Fixes post effects on player 2.
+    halfPixelOffset: 4 # Fixes chromatic effect.
 SLES-51998:
   name: "Kao the Kangaroo - Round 2"
   region: "PAL-M5"
@@ -18746,11 +18770,14 @@ SLES-52096:
     halfPixelOffset: 4 # Fixes post processing alignment.
     roundSprite: 1 # Fixes sprite misaligment.
 SLES-52097:
-  name: "SWAT - Global Strike Force"
+  name: "SWAT - Global Strike Team"
   region: "PAL-E-G"
   compat: 5
   clampModes:
     eeClampMode: 3 # For grey screen ingame.
+  gsHWFixes:
+    textureInsideRT: 1 # Fixes post effects on player 2.
+    halfPixelOffset: 4 # Fixes chromatic effect.
 SLES-52100:
   name: "NRL Rugby League"
   region: "PAL-E"
@@ -18758,7 +18785,7 @@ SLES-52101:
   name: "Wrath Unleashed"
   region: "PAL-M5"
   gsHWFixes:
-    textureInsideRT: 1 # Fixes flashing and some models still very broken in hardware mode.
+    textureInsideRT: 1 # Fixes colors.
 SLES-52102:
   name: "Hugo Bukkazoom!"
   region: "PAL-M12"
@@ -18821,6 +18848,8 @@ SLES-52132:
   gsHWFixes:
     texturePreloading: 1 # Performs much better with partial preload.
     autoFlush: 1 # Fixes bloom rendering.
+    textureInsideRT: 1 # Fixes post processing.
+    halfPixelOffset: 5 # Fixes alignment of shuffles and post processing.
   roundModes:
     vu1RoundMode: 0 # Fixes missing light cones curtains and certain effects.
   speedHacks:
@@ -18831,6 +18860,8 @@ SLES-52133:
   gsHWFixes:
     texturePreloading: 1 # Performs much better with partial preload.
     autoFlush: 1 # Fixes bloom rendering.
+    textureInsideRT: 1 # Fixes post processing.
+    halfPixelOffset: 5 # Fixes alignment of shuffles and post processing.
   roundModes:
     vu1RoundMode: 0 # Fixes missing light cones curtains and certain effects.
   speedHacks:
@@ -18842,6 +18873,8 @@ SLES-52134:
   gsHWFixes:
     texturePreloading: 1 # Performs much better with partial preload.
     autoFlush: 1 # Fixes bloom rendering.
+    textureInsideRT: 1 # Fixes post processing.
+    halfPixelOffset: 5 # Fixes alignment of shuffles and post processing.
   roundModes:
     vu1RoundMode: 0 # Fixes missing light cones curtains and certain effects.
   speedHacks:
@@ -18852,6 +18885,8 @@ SLES-52135:
   gsHWFixes:
     texturePreloading: 1 # Performs much better with partial preload.
     autoFlush: 1 # Fixes bloom rendering.
+    textureInsideRT: 1 # Fixes post processing.
+    halfPixelOffset: 5 # Fixes alignment of shuffles and post processing.
   roundModes:
     vu1RoundMode: 0 # Fixes missing light cones curtains and certain effects.
   speedHacks:
@@ -18862,6 +18897,8 @@ SLES-52136:
   gsHWFixes:
     texturePreloading: 1 # Performs much better with partial preload.
     autoFlush: 1 # Fixes bloom rendering.
+    textureInsideRT: 1 # Fixes post processing.
+    halfPixelOffset: 5 # Fixes alignment of shuffles and post processing.
   roundModes:
     vu1RoundMode: 0 # Fixes missing light cones curtains and certain effects.
   speedHacks:
@@ -18900,8 +18937,6 @@ SLES-52153:
   gsHWFixes:
     autoFlush: 1 # Aligns and corrects shadows.
     halfPixelOffset: 2 # Fixes sun and depth line.
-    cpuCLUTRender: 1 # Fixes janky coloured cars.
-    gpuTargetCLUT: 1 # Fixes janky coloured cars.
     textureInsideRT: 1 # Fixes car textures.
     cpuSpriteRenderBW: 4 # Alleviates text and sky rendering issues.
     cpuSpriteRenderLevel: 2 # Needed for above.
@@ -19244,6 +19279,8 @@ SLES-52322:
     texturePreloading: 1 # Performs better with partial preload because it is slow on locations outside gameplay foremost.
     mergeSprite: 1 # Fixes misaligned white lines.
     PCRTCOverscan: 1 # Fixes missing HUD.
+    textureInsideRT: 1 # Fixes post shuffle effect.
+    halfPixelOffset: 2 # Fixes boxes around shuffle effect pages.
 SLES-52323:
   name: "Richard Burns Rally"
   region: "PAL-M5"
@@ -20122,12 +20159,17 @@ SLES-52637:
   region: "PAL-M5"
   gsHWFixes:
     alignSprite: 1 # Fixes lighting and vertical lines, also works with normal vertex.
+    textureInsideRT: 1 # Fixes shadows.
 SLES-52638:
   name: "DTM Race Driver 2"
   region: "PAL-M5"
   compat: 5
   gsHWFixes:
     alignSprite: 1 # Fixes lighting and vertical lines, also works with normal vertex.
+    roundSprite: 1 # Fixes misaligned map.
+    halfPixelOffset: 2 # Fixes depth of field alignment.
+    nativeScaling: 1 # Fixes depth of field.
+    textureInsideRT: 1 # Fixes shadows.
 SLES-52639:
   name: "V8 Supercars 2"
   region: "PAL-M5"
@@ -20790,7 +20832,7 @@ SLES-52859:
   gsHWFixes:
     autoFlush: 1 # Fixes the post processing positioning.
     textureInsideRT: 1 # Fixes post processing.
-    halfPixelOffset: 4 # Aligns bloom effect.
+    halfPixelOffset: 5 # Aligns bloom effect.
     nativeScaling: 2 # Fixes post processing smoothness and position.
 SLES-52861:
   name: "King Arthur"
@@ -20838,9 +20880,10 @@ SLES-52882:
   region: "PAL-M5"
   compat: 4
   gsHWFixes:
-    disablePartialInvalidation: 1 # Improves performance.
     halfPixelOffset: 2 # Fixes misaligned bloom effects.
     texturePreloading: 1 # Performs much better with partial preload.
+    textureInsideRT: 1 # Fixes post effects.
+    nativeScaling: 1 # Fixes lighting quality and positioning.
 SLES-52884:
   name: "Duel Masters"
   region: "PAL-M5"
@@ -21018,6 +21061,8 @@ SLES-52942:
   gsHWFixes:
     halfPixelOffset: 2 # Aligns post bloom.
     nativeScaling: 2 # Fixes light blooms.
+    textureInsideRT: 1 # Improves performance.
+    preloadFrameData: 1 # Fixes light trails.
     getSkipCount: "GSC_MidnightClub3"
   patches:
     EBE1972D:
@@ -21282,9 +21327,9 @@ SLES-53020:
     recommendedBlendingLevel: 4 # Improves banding and effect emulation.
     autoFlush: 1 # Fixes light bloom intensity.
     estimateTextureRegion: 1 # Improves performance and reduces hash cache size.
-    halfPixelOffset: 4 # Aligns post effects.
+    halfPixelOffset: 2 # Aligns post effects.
     nativeScaling: 1 # Fixes post effects.
-    getSkipCount: "GSC_GiTS"
+    textureInsideRT: 1 # Fixes post shuffles.
   patches:
     BF6F101F:
       content: |-
@@ -21351,7 +21396,7 @@ SLES-53028:
   clampModes:
     vuClampMode: 0 # Fixes bump mapping issues.
   gsHWFixes:
-    halfPixelOffset: 4 # Fixes post processing position.
+    halfPixelOffset: 5 # Fixes alignment of shuffles and post processing.
     autoFlush: 1 # Fixes sun intensity.
     textureInsideRT: 1 # Fixes post processing.
     getSkipCount: "GSC_HitmanBloodMoney"
@@ -21361,7 +21406,7 @@ SLES-53029:
   clampModes:
     vuClampMode: 0 # Fixes bump mapping issues.
   gsHWFixes:
-    halfPixelOffset: 4 # Fixes post processing position.
+    halfPixelOffset: 5 # Fixes alignment of shuffles and post processing.
     autoFlush: 1 # Fixes sun intensity.
     textureInsideRT: 1 # Fixes post processing.
     getSkipCount: "GSC_HitmanBloodMoney"
@@ -21371,7 +21416,7 @@ SLES-53030:
   clampModes:
     vuClampMode: 0 # Fixes bump mapping issues.
   gsHWFixes:
-    halfPixelOffset: 4 # Fixes post processing position.
+    halfPixelOffset: 5 # Fixes alignment of shuffles and post processing.
     autoFlush: 1 # Fixes sun intensity.
     textureInsideRT: 1 # Fixes post processing.
     getSkipCount: "GSC_HitmanBloodMoney"
@@ -21381,7 +21426,7 @@ SLES-53031:
   clampModes:
     vuClampMode: 0 # Fixes bump mapping issues.
   gsHWFixes:
-    halfPixelOffset: 4 # Fixes post processing position.
+    halfPixelOffset: 5 # Fixes alignment of shuffles and post processing.
     autoFlush: 1 # Fixes sun intensity.
     textureInsideRT: 1 # Fixes post processing.
     getSkipCount: "GSC_HitmanBloodMoney"
@@ -21391,7 +21436,7 @@ SLES-53032:
   clampModes:
     vuClampMode: 0 # Fixes bump mapping issues.
   gsHWFixes:
-    halfPixelOffset: 4 # Fixes post processing position.
+    halfPixelOffset: 5 # Fixes alignment of shuffles and post processing.
     autoFlush: 1 # Fixes sun intensity.
     textureInsideRT: 1 # Fixes post processing.
     getSkipCount: "GSC_HitmanBloodMoney"
@@ -21557,10 +21602,9 @@ SLES-53087:
   gsHWFixes:
     alignSprite: 1 # Fixes lighting and vertical lines, also works with normal vertex.
     roundSprite: 1 # Fixes misaligned map.
-    skipDrawStart: 1 # Removes large black box around player car till we properly emulate it.
-    skipDrawEnd: 1 # Removes large black box around player car till we properly emulate it.
     halfPixelOffset: 2 # Fixes depth of field alignment.
     nativeScaling: 1 # Fixes depth of field.
+    textureInsideRT: 1 # Fixes shadows.
   memcardFilters:
     - "SLES-53087"
     - "SLES-52637" # Race Driver 2 save unlocks 'Class A 4WD Track Challenge' in career early.
@@ -21570,10 +21614,9 @@ SLES-53088:
   gsHWFixes:
     alignSprite: 1 # Fixes lighting and vertical lines, also works with normal vertex.
     roundSprite: 1 # Fixes misaligned map.
-    skipDrawStart: 1 # Removes large black box around player car till we properly emulate it.
-    skipDrawEnd: 1 # Removes large black box around player car till we properly emulate it.
     halfPixelOffset: 2 # Fixes depth of field alignment.
     nativeScaling: 1 # Fixes depth of field.
+    textureInsideRT: 1 # Fixes shadows.
   memcardFilters:
     - "SLES-53088"
     - "SLES-52638" # Race Driver 2 save unlocks 'Class A 4WD Track Challenge' in career early.
@@ -21583,10 +21626,9 @@ SLES-53089:
   gsHWFixes:
     alignSprite: 1 # Fixes lighting and vertical lines, also works with normal vertex.
     roundSprite: 1 # Fixes misaligned map.
-    skipDrawStart: 1 # Removes large black box around player car till we properly emulate it.
-    skipDrawEnd: 1 # Removes large black box around player car till we properly emulate it.
     halfPixelOffset: 2 # Fixes depth of field alignment.
     nativeScaling: 1 # Fixes depth of field.
+    textureInsideRT: 1 # Fixes shadows.
   memcardFilters:
     - "SLES-53089"
     - "SLES-52639" # Race Driver 2 save unlocks 'Class A 4WD Track Challenge' in career early.
@@ -21676,7 +21718,7 @@ SLES-53124:
   gsHWFixes:
     autoFlush: 1 # Fixes the post processing positioning.
     textureInsideRT: 1 # Fixes post processing.
-    halfPixelOffset: 4 # Aligns bloom effect.
+    halfPixelOffset: 5 # Aligns bloom effect.
     nativeScaling: 2 # Fixes post processing smoothness and position.
 SLES-53125:
   name: "Enthusia Professional Racing"
@@ -22373,6 +22415,7 @@ SLES-53415:
     halfPixelOffset: 2 # Fix text and post blur.
     nativeScaling: 2 # Fixes post effects.
     cpuSpriteRenderBW: 1 # Fixes textures.
+    cpuSpriteRenderLevel: 1 # Needed for above.
 SLES-53416:
   name: "Call of Duty 2 - Big Red One"
   region: "PAL-M3"
@@ -22382,6 +22425,7 @@ SLES-53416:
     halfPixelOffset: 2 # Fix text and post blur.
     nativeScaling: 2 # Fixes post effects.
     cpuSpriteRenderBW: 1 # Fixes textures.
+    cpuSpriteRenderLevel: 1 # Needed for above.
 SLES-53417:
   name: "Call of Duty 2 - Big Red One"
   region: "PAL-G"
@@ -22391,6 +22435,7 @@ SLES-53417:
     halfPixelOffset: 2 # Fix text and post blur.
     nativeScaling: 2 # Fixes post effects.
     cpuSpriteRenderBW: 1 # Fixes textures.
+    cpuSpriteRenderLevel: 1 # Needed for above.
 SLES-53418:
   name: "Tak - The Great JuJu Challenge"
   region: "PAL-A"
@@ -23136,6 +23181,7 @@ SLES-53616:
     eeRoundMode: 0 # Fixes scene switching in intro.
   gsHWFixes:
     cpuSpriteRenderBW: 1 # Fixes textures.
+    cpuSpriteRenderLevel: 1 # Needed for above.
     preloadFrameData: 1 # Fixes numberplates and ensures above targets are valid.
     roundSprite: 1 # Fixes lines in some post-effects.
     gpuTargetCLUT: 1 # Fixes light occlusion.
@@ -23150,6 +23196,7 @@ SLES-53617:
     eeRoundMode: 0 # Fixes scene switching in intro.
   gsHWFixes:
     cpuSpriteRenderBW: 1 # Fixes textures.
+    cpuSpriteRenderLevel: 1 # Needed for above.
     preloadFrameData: 1 # Fixes numberplates and ensures above targets are valid.
     roundSprite: 1 # Fixes lines in some post-effects.
     gpuTargetCLUT: 1 # Fixes light occlusion.
@@ -23164,6 +23211,7 @@ SLES-53618:
     eeRoundMode: 0 # Fixes scene switching in intro.
   gsHWFixes:
     cpuSpriteRenderBW: 1 # Fixes textures.
+    cpuSpriteRenderLevel: 1 # Needed for above.
     preloadFrameData: 1 # Fixes numberplates and ensures above targets are valid.
     roundSprite: 1 # Fixes lines in some post-effects.
     gpuTargetCLUT: 1 # Fixes light occlusion.
@@ -23436,6 +23484,7 @@ SLES-53703:
     autoFlush: 1 # Corrects vignette to match software.
     estimateTextureRegion: 1 # Improves performance and reduces hash cache size.
     halfPixelOffset: 4 # Aligns blur more correctly to match software.
+    textureInsideRT: 1 # Fixes post processing effects.
 SLES-53704:
   name: "Peter Jackson's King Kong - The Official Game of the Movie"
   name-sort: "King Kong, Peter Jackson's - The Official Game of the Movie"
@@ -23445,6 +23494,7 @@ SLES-53704:
     autoFlush: 1 # Corrects vignette to match software.
     estimateTextureRegion: 1 # Improves performance and reduces hash cache size.
     halfPixelOffset: 4 # Aligns blur more correctly to match software.
+    textureInsideRT: 1 # Fixes post processing effects.
 SLES-53705:
   name: "Peter Jackson's King Kong - The Official Game of the Movie"
   name-sort: "King Kong, Peter Jackson's - The Official Game of the Movie"
@@ -23454,6 +23504,7 @@ SLES-53705:
     autoFlush: 1 # Corrects vignette to match software.
     estimateTextureRegion: 1 # Improves performance and reduces hash cache size.
     halfPixelOffset: 4 # Aligns blur more correctly to match software.
+    textureInsideRT: 1 # Fixes post processing effects.
 SLES-53706:
   name: "The Chronicles of Narnia - The Lion, the Witch and the Wardrobe"
   name-sort: "Chronicles of Narnia, The - The Lion, the Witch and the Wardrobe"
@@ -23507,6 +23558,8 @@ SLES-53717:
   gsHWFixes:
     halfPixelOffset: 2 # Aligns post bloom.
     nativeScaling: 2 # Fixes light blooms.
+    textureInsideRT: 1 # Improves performance.
+    preloadFrameData: 1 # Fixes light trails.
     getSkipCount: "GSC_MidnightClub3"
   patches:
     208183AF:
@@ -23538,6 +23591,7 @@ SLES-53722:
     halfPixelOffset: 2 # Fix text and post blur.
     nativeScaling: 2 # Fixes post effects.
     cpuSpriteRenderBW: 1 # Fixes textures.
+    cpuSpriteRenderLevel: 1 # Needed for above.
 SLES-53724:
   name: "World Series of Poker"
   region: "PAL-E"
@@ -24865,7 +24919,7 @@ SLES-54185:
   compat: 5
   gsHWFixes:
     autoFlush: 1 # Fixes lighting.
-    halfPixelOffset: 4 # Fixes ghosting.
+    halfPixelOffset: 5 # Fixes ghosting.
     nativeScaling: 2 # Fixes post processing.
     recommendedBlendingLevel: 4 # Fixes missing light brightness.
 SLES-54186:
@@ -25902,12 +25956,21 @@ SLES-54510:
 SLES-54511:
   name: "UEFA Champions League 2006-2007"
   region: "PAL-E"
+  gsHWFixes:
+    cpuSpriteRenderBW: 2 # Fixes broken lights due to copying around P8 data.
+    cpuSpriteRenderLevel: 2 # Needed for above.
 SLES-54512:
   name: "UEFA Champions League 2006-2007"
   region: "PAL-F-G"
+  gsHWFixes:
+    cpuSpriteRenderBW: 2 # Fixes broken lights due to copying around P8 data.
+    cpuSpriteRenderLevel: 2 # Needed for above.
 SLES-54513:
   name: "UEFA Champions League 2006-2007"
   region: "PAL-I-S"
+  gsHWFixes:
+    cpuSpriteRenderBW: 2 # Fixes broken lights due to copying around P8 data.
+    cpuSpriteRenderLevel: 2 # Needed for above.
 SLES-54516:
   name: "Thrillville"
   region: "PAL-F-G"
@@ -26851,8 +26914,9 @@ SLES-54819:
   region: "PAL-M5"
   compat: 5
   gsHWFixes:
-    getSkipCount: "GSC_Manhunt2"
     autoFlush: 1 # Fixes missing lights and light intensity.
+    textureInsideRT: 1 # Fixes post lighting.
+    halfPixelOffset: 2 # Fixes post effects.
 SLES-54820:
   name: "Stuntman - Ignition"
   region: "PAL-M5"
@@ -27318,7 +27382,7 @@ SLES-54972:
   region: "PAL-M3"
   gsHWFixes:
     roundSprite: 1 # Fixes font sizes and lines in UI.
-    cpuFramebufferConversion: 1 # Fixes sepia-tone flashback sequences.
+    textureInsideRT: 1 # Fixes sepia-tone flashback sequences.
     forceEvenSpritePosition: 1 # Fixes font artifacts and out-of-bound 2D textures.
     gpuPaletteConversion: 2 # Fixes micro-stuttering and reduces HC size.
 SLES-54973:
@@ -27721,6 +27785,7 @@ SLES-55031:
   region: "PAL-F"
   gsHWFixes:
     cpuSpriteRenderBW: 1 # Fixes textures.
+    cpuSpriteRenderLevel: 1 # Needed for above.
     halfPixelOffset: 4 # Aligns post processing.
     autoFlush: 1 # Fixes post processing.
 SLES-55032:
@@ -27873,6 +27938,8 @@ SLES-55109:
   region: "PAL-E"
   roundModes:
     vu0RoundMode: 0 # Fixes invisible wall collision in bedroom.
+  gsHWFixes:
+    textureInsideRT: 1 # Fixes half screen.
 SLES-55110:
   name: "Odin Sphere"
   region: "PAL-M5"
@@ -28085,6 +28152,7 @@ SLES-55191:
     autoFlush: 1 # Fixes bloom intensity.
     halfPixelOffset: 4 # Mostly aligns post processing.
     nativeScaling: 1 # Fixes post processing smoothness and position.
+    getSkipCount: "GSC_GuitarHero"
 SLES-55192:
   name: "Steam Express"
   region: "PAL-M5"
@@ -28150,6 +28218,7 @@ SLES-55200:
     autoFlush: 1 # Fixes bloom intensity.
     halfPixelOffset: 4 # Mostly aligns post processing.
     nativeScaling: 1 # Fixes post processing smoothness and position.
+    getSkipCount: "GSC_GuitarHero"
 SLES-55201:
   name: "Riding Star"
   region: "PAL-M4"
@@ -28233,6 +28302,7 @@ SLES-55234:
   region: "PAL-SW"
   gsHWFixes:
     cpuSpriteRenderBW: 1 # Fixes textures.
+    cpuSpriteRenderLevel: 1 # Needed for above.
     halfPixelOffset: 4 # Aligns post processing.
     autoFlush: 1 # Fixes post processing.
 SLES-55235:
@@ -28240,6 +28310,7 @@ SLES-55235:
   region: "PAL-I"
   gsHWFixes:
     cpuSpriteRenderBW: 1 # Fixes textures.
+    cpuSpriteRenderLevel: 1 # Needed for above.
     halfPixelOffset: 4 # Aligns post processing.
     autoFlush: 1 # Fixes post processing.
 SLES-55236:
@@ -28247,6 +28318,7 @@ SLES-55236:
   region: "PAL-G-S"
   gsHWFixes:
     cpuSpriteRenderBW: 1 # Fixes textures.
+    cpuSpriteRenderLevel: 1 # Needed for above.
     halfPixelOffset: 4 # Aligns post processing.
     autoFlush: 1 # Fixes post processing.
 SLES-55237:
@@ -30595,8 +30667,6 @@ SLKA-25196:
   gsHWFixes:
     autoFlush: 1 # Aligns and corrects shadows.
     halfPixelOffset: 2 # Fixes sun and depth line.
-    cpuCLUTRender: 1 # Fixes janky coloured cars.
-    gpuTargetCLUT: 1 # Fixes janky coloured cars.
     textureInsideRT: 1 # Fixes car textures.
     cpuSpriteRenderBW: 4 # Alleviates text and sky rendering issues.
     cpuSpriteRenderLevel: 2 # Needed for above.
@@ -30721,6 +30791,8 @@ SLKA-25218:
   gsHWFixes:
     texturePreloading: 1 # Performs much better with partial preload.
     autoFlush: 1 # Fixes bloom rendering.
+    textureInsideRT: 1 # Fixes post processing.
+    halfPixelOffset: 5 # Fixes alignment of shuffles and post processing.
   roundModes:
     vu1RoundMode: 0 # Fixes missing light cones curtains and certain effects.
   speedHacks:
@@ -31270,6 +31342,7 @@ SLKA-25337:
     autoFlush: 1 # Corrects vignette to match software.
     estimateTextureRegion: 1 # Improves performance and reduces hash cache size.
     halfPixelOffset: 4 # Aligns blur more correctly to match software.
+    textureInsideRT: 1 # Fixes post processing effects.
 SLKA-25338:
   name: "The Godfather"
   name-sort: "Godfather, The"
@@ -31691,6 +31764,7 @@ SLKA-25434:
     autoFlush: 1 # Fixes bloom intensity.
     halfPixelOffset: 4 # Mostly aligns post processing.
     nativeScaling: 1 # Fixes post processing smoothness and position.
+    getSkipCount: "GSC_GuitarHero"
 SLKA-25435:
   name: "Sengoku Basara X"
   region: "NTSC-J-K"
@@ -31699,6 +31773,7 @@ SLKA-25436:
   region: "NTSC-K"
   gsHWFixes:
     cpuSpriteRenderBW: 1 # Fixes textures.
+    cpuSpriteRenderLevel: 1 # Needed for above.
 SLKA-25437:
   name: "Street Fighter Anniversary Collection"
   region: "NTSC-K"
@@ -32190,10 +32265,9 @@ SLPM-55046:
   gsHWFixes:
     alignSprite: 1 # Fixes lighting and vertical lines, also works with normal vertex.
     roundSprite: 1 # Fixes misaligned map.
-    skipDrawStart: 1 # Removes large black box around player car till we properly emulate it.
-    skipDrawEnd: 1 # Removes large black box around player car till we properly emulate it.
     halfPixelOffset: 2 # Fixes depth of field alignment.
     nativeScaling: 1 # Fixes depth of field.
+    textureInsideRT: 1 # Fixes shadows.
   memcardFilters:
     - "SLPM-55046"
     - "SLPM-66498" # Race Driver 2 save unlocks 'Class A 4WD Track Challenge' in career early.
@@ -32371,6 +32445,8 @@ SLPM-55080:
     texturePreloading: 1 # Performs better with partial preload because it is slow on locations outside gameplay foremost.
     mergeSprite: 1 # Fixes misaligned white lines.
     PCRTCOverscan: 1 # Fixes missing HUD.
+    textureInsideRT: 1 # Fixes post shuffle effect.
+    halfPixelOffset: 2 # Fixes boxes around shuffle effect pages.
 SLPM-55081:
   name: "ドラッグオンドラグーン2 ～封印の紅 背徳の黒～"
   name-sort: "どらっぐおんどらぐーん2 ～ふういんのあか はいとくのくろ～"
@@ -33461,8 +33537,7 @@ SLPM-60109:
   clampModes:
     vuClampMode: 2 # Fixes texture rendering in the intro.
   gsHWFixes:
-    cpuFramebufferConversion: 1
-    textureInsideRT: 1
+    textureInsideRT: 1 # Fixes post effects
     halfPixelOffset: 2 # Fixes title screen and some intro post processing alignment.
     roundSprite: 1 # Fixes ui and hud alignment.
     gpuPaletteConversion: 2 # Lots of CLUTs in large textures.
@@ -33966,6 +34041,8 @@ SLPM-60217:
   region: "NTSC-J"
   gsHWFixes:
     texturePreloading: 0 # Performs much better with no preload.
+    textureInsideRT: 1 # Fixes post processing.
+    halfPixelOffset: 5 # Fixes alignment of shuffles and post processing.
 SLPM-60218:
   name: "GUNGRAVE O.D. [体験版]"
   name-sort: "がんぐれいぶ おーでぃー [たいけんばん]"
@@ -34138,9 +34215,8 @@ SLPM-60257:
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes FMV lines.
-    cpuSpriteRenderBW: 2 # Prevents Death By VRAM explosion.
-    cpuSpriteRenderLevel: 2 # Needed for above.
-    getSkipCount: "GSC_DeathByDegreesTekkenNinaWilliams"
+    halfPixelOffset: 5 # Fixes alignment of shuffles and post processing.
+    textureInsideRT: 1 # Fixes post shuffles.
 SLPM-60258:
   name: "THE TYPING OF THE DEAD ZOMBIE PANIC [体験版]"
   name-sort: "ざ たいぴんぐおぶ ざ でっど ぞんび ぱにっく [たいけんばん]"
@@ -34694,8 +34770,6 @@ SLPM-61092:
   gsHWFixes:
     autoFlush: 1 # Aligns and corrects shadows.
     halfPixelOffset: 2 # Fixes sun and depth line.
-    cpuCLUTRender: 1 # Fixes janky coloured cars.
-    gpuTargetCLUT: 1 # Fixes janky coloured cars.
     textureInsideRT: 1 # Fixes car textures.
     cpuSpriteRenderBW: 4 # Alleviates text and sky rendering issues.
     cpuSpriteRenderLevel: 2 # Needed for above.
@@ -36981,7 +37055,6 @@ SLPM-62378:
   region: "NTSC-J"
   gsHWFixes:
     textureInsideRT: 1 # Fixes inside RT shuffling.
-    getSkipCount: "GSC_BigMuthaTruckers"
 SLPM-62379:
   name: "カラオケレボリューション J-POPベストVol.2"
   name-sort: "からおけれぼりゅーしょん J-POPべすとVol.2"
@@ -39606,6 +39679,9 @@ SLPM-65073:
   name-sort: "げんそうすいこでん3 [しょかいせいさんぶん:とくしゅしよう]"
   name-en: "Gensou Suikoden III [Limited Edition]"
   region: "NTSC-J"
+  gsHWFixes:
+    textureInsideRT: 1 # Fixes half screen.
+    halfPixelOffset: 4 # Fixes post effects.
   memcardFilters: # This looks like a mess because it includes all serials for Suikoden 3, Suikoden 2, Suikogaiden 1, and Suikogaiden 2. A lot of these probably aren't actually required but it's not really hurting anything to have them here.
     - "SLPM-65073"
     - "SLPM-65074"
@@ -39625,6 +39701,9 @@ SLPM-65074:
   name-sort: "げんそうすいこでん3"
   name-en: "Gensou Suikoden III"
   region: "NTSC-J"
+  gsHWFixes:
+    textureInsideRT: 1 # Fixes half screen.
+    halfPixelOffset: 4 # Fixes post effects.
   memcardFilters:
     - "SLPM-65073"
     - "SLPM-65074"
@@ -40544,7 +40623,6 @@ SLPM-65234:
   region: "NTSC-J"
   gsHWFixes:
     textureInsideRT: 1 # Fixes inside RT shuffling.
-    getSkipCount: "GSC_BigMuthaTruckers"
 SLPM-65235:
   name: "ニュールーマニア ポロリ青春"
   name-sort: "にゅーるーまにあ ぽろりせいしゅん"
@@ -40740,6 +40818,8 @@ SLPM-65266:
     texturePreloading: 1 # Performs better with partial preload because it is slow on locations outside gameplay foremost.
     mergeSprite: 1 # Fixes misaligned white lines.
     PCRTCOverscan: 1 # Fixes missing HUD.
+    textureInsideRT: 1 # Fixes post shuffle effect.
+    halfPixelOffset: 2 # Fixes boxes around shuffle effect pages.
 SLPM-65267:
   name: "鋼鉄の咆哮2 - ウォーシップガンナー"
   name-sort: "くろがねのほうこう2 うぉーしっぷがんなー"
@@ -40965,6 +41045,9 @@ SLPM-65305:
   name-sort: "げんそうすいこでん3 [KONAMI THE BEST]"
   name-en: "Gensou Suikoden 3"
   region: "NTSC-J"
+  gsHWFixes:
+    textureInsideRT: 1 # Fixes half screen.
+    halfPixelOffset: 4 # Fixes post effects.
   memcardFilters:
     - "SLPM-65073"
     - "SLPM-65074"
@@ -42509,6 +42592,7 @@ SLPM-65583:
     autoFlush: 2 # Fixes sun luminosity.
     halfPixelOffset: 2 # Aligns Depth of Field.
     nativeScaling: 2 # Fixes Depth of Field effect.
+    textureInsideRT: 1 # Fixes half screen fog effect.
 SLPM-65584:
   name: "真・三國無双3 猛将伝"
   name-sort: "しんさんごくむそう3 もうしょうでん"
@@ -43132,6 +43216,9 @@ SLPM-65694:
   name-sort: "げんそうすいこでん3 [こなみでんどうせれくしょん]"
   name-en: "Gensou Suikoden 3 [KONAMI Dendou Selection]"
   region: "NTSC-J"
+  gsHWFixes:
+    textureInsideRT: 1 # Fixes half screen.
+    halfPixelOffset: 4 # Fixes post effects.
   memcardFilters:
     - "SLPM-65073"
     - "SLPM-65074"
@@ -43404,8 +43491,6 @@ SLPM-65741:
   gsHWFixes:
     autoFlush: 1 # Aligns and corrects shadows.
     halfPixelOffset: 2 # Fixes sun and depth line.
-    cpuCLUTRender: 1 # Fixes janky coloured cars.
-    gpuTargetCLUT: 1 # Fixes janky coloured cars.
     textureInsideRT: 1 # Fixes car textures.
     cpuSpriteRenderBW: 4 # Alleviates text and sky rendering issues.
     cpuSpriteRenderLevel: 2 # Needed for above.
@@ -45542,6 +45627,7 @@ SLPM-66103:
     autoFlush: 2 # Fixes sun luminosity.
     halfPixelOffset: 2 # Aligns Depth of Field.
     nativeScaling: 2 # Fixes Depth of Field effect.
+    textureInsideRT: 1 # Fixes half screen fog effect.
 SLPM-66104:
   name: "ぷよぷよフィーバー2 [チュー！]"
   name-sort: "ぷよぷよふぃーばー2"
@@ -46252,6 +46338,7 @@ SLPM-66211:
     autoFlush: 1 # Corrects vignette to match software.
     estimateTextureRegion: 1 # Improves performance and reduces hash cache size.
     halfPixelOffset: 4 # Aligns blur more correctly to match software.
+    textureInsideRT: 1 # Fixes post processing effects.
 SLPM-66212:
   name: "SEGA RALLY 2006"
   name-sort: "せが らりー 2006"
@@ -46662,7 +46749,7 @@ SLPM-66271:
   compat: 5
   gsHWFixes:
     autoFlush: 1 # Fixes lighting.
-    halfPixelOffset: 4 # Fixes ghosting.
+    halfPixelOffset: 5 # Fixes ghosting.
     nativeScaling: 2 # Fixes post processing.
     recommendedBlendingLevel: 4 # Fixes missing light brightness.
 SLPM-66272:
@@ -47034,6 +47121,7 @@ SLPM-66328:
     halfPixelOffset: 2 # Fix text and post blur.
     nativeScaling: 2 # Fixes post effects.
     cpuSpriteRenderBW: 1 # Fixes textures.
+    cpuSpriteRenderLevel: 1 # Needed for above.
 SLPM-66329:
   name: "魔法先生ネギま！ 課外授業 乙女のドキドキ・ビーチサイド"
   name-sort: "まほうせんせいねぎま！ かがいじゅぎょう おとめのどきどき びーちさいど"
@@ -47916,6 +48004,7 @@ SLPM-66473:
     eeRoundMode: 0 # Fixes scene switching in intro.
   gsHWFixes:
     cpuSpriteRenderBW: 1 # Fixes textures.
+    cpuSpriteRenderLevel: 1 # Needed for above.
     preloadFrameData: 1 # Fixes numberplates and ensures above targets are valid.
     roundSprite: 1 # Fixes lines in some post-effects.
     gpuTargetCLUT: 1 # Fixes light occlusion.
@@ -48092,6 +48181,10 @@ SLPM-66498:
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes lighting and vertical lines, also works with normal vertex.
+    roundSprite: 1 # Fixes misaligned map.
+    halfPixelOffset: 2 # Fixes depth of field alignment.
+    nativeScaling: 1 # Fixes depth of field.
+    textureInsideRT: 1 # Fixes shadows.
 SLPM-66499:
   name: "神様家族 応援願望"
   name-sort: "かみさまかぞく おうえんがんぼう"
@@ -48878,7 +48971,7 @@ SLPM-66629:
   region: "NTSC-J"
   gsHWFixes:
     autoFlush: 1 # Fixes lighting.
-    halfPixelOffset: 4 # Fixes ghosting.
+    halfPixelOffset: 5 # Fixes ghosting.
     nativeScaling: 2 # Fixes post processing.
     recommendedBlendingLevel: 4 # Fixes missing light brightness.
 SLPM-66630:
@@ -50408,10 +50501,9 @@ SLPM-66881:
   gsHWFixes:
     alignSprite: 1 # Fixes lighting and vertical lines, also works with normal vertex.
     roundSprite: 1 # Fixes misaligned map.
-    skipDrawStart: 1 # Removes large black box around player car till we properly emulate it.
-    skipDrawEnd: 1 # Removes large black box around player car till we properly emulate it.
     halfPixelOffset: 2 # Fixes depth of field alignment.
     nativeScaling: 1 # Fixes depth of field.
+    textureInsideRT: 1 # Fixes shadows.
   memcardFilters:
     - "SLPM-66881"
     - "SLPM-66498" # Race Driver 2 save unlocks 'Class A 4WD Track Challenge' in career early.
@@ -51432,7 +51524,7 @@ SLPM-68016:
   region: "NTSC-J"
   gsHWFixes:
     autoFlush: 1 # Fixes lighting.
-    halfPixelOffset: 4 # Fixes ghosting.
+    halfPixelOffset: 5 # Fixes ghosting.
     nativeScaling: 2 # Fixes post processing.
     recommendedBlendingLevel: 4 # Fixes missing light brightness.
 SLPM-68017:
@@ -51500,6 +51592,9 @@ SLPM-68505:
   name-sort: "げんそうすいこでん3"
   name-en: "Gensou Suikoden III"
   region: "NTSC-J"
+  gsHWFixes:
+    textureInsideRT: 1 # Fixes half screen.
+    halfPixelOffset: 4 # Fixes post effects.
 SLPM-68509:
   name: "頭文字D Special Stage [講談社懸賞品]"
   name-sort: "いにしゃるD すぺしゃる すてーじ [こうだんしゃけんしょうひん]"
@@ -51928,6 +52023,7 @@ SLPM-74243:
     eeRoundMode: 0 # Fixes scene switching in intro.
   gsHWFixes:
     cpuSpriteRenderBW: 1 # Fixes textures.
+    cpuSpriteRenderLevel: 1 # Needed for above.
     preloadFrameData: 1 # Fixes numberplates and ensures above targets are valid.
     roundSprite: 1 # Fixes lines in some post-effects.
     gpuTargetCLUT: 1 # Fixes light occlusion.
@@ -52389,8 +52485,7 @@ SLPS-20001:
   clampModes:
     vuClampMode: 2 # Fixes texture rendering in the intro.
   gsHWFixes:
-    cpuFramebufferConversion: 1
-    textureInsideRT: 1
+    textureInsideRT: 1 # Fixes post effects
     halfPixelOffset: 2 # Fixes title screen and some intro post processing alignment.
     roundSprite: 1 # Fixes ui and hud alignment.
     gpuPaletteConversion: 2 # Lots of CLUTs in large textures.
@@ -54213,6 +54308,7 @@ SLPS-20382:
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
+    textureInsideRT: 1 # Fixes post effects.
 SLPS-20383:
   name: "太鼓の達人 あつまれ！祭りだ！！四代目"
   name-sort: "たいこのたつじん あつまれ！まつりだ！！よんだいめ"
@@ -54220,6 +54316,7 @@ SLPS-20383:
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
+    textureInsideRT: 1 # Fixes post effects.
 SLPS-20384:
   name: "流行り神 警視庁怪異事件ファイル [初回限定版]"
   name-sort: "はやりがみ けいしちょうかいいじけんふぁいる [しょかいげんていばん]"
@@ -54287,6 +54384,7 @@ SLPS-20399:
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
+    textureInsideRT: 1 # Fixes post effects.
 SLPS-20400:
   name: "太鼓の達人 ゴー！ゴー！五代目 [ソフト単体]"
   name-sort: "たいこのたつじん ごー！ごー！ごだいめ [そふとたんたい]"
@@ -54294,6 +54392,7 @@ SLPS-20400:
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
+    textureInsideRT: 1 # Fixes post effects.
 SLPS-20401:
   name: "テクモ ヒットパレード"
   name-sort: "てくも ひっとぱれーど"
@@ -54365,6 +54464,7 @@ SLPS-20413:
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
+    textureInsideRT: 1 # Fixes post effects.
 SLPS-20414:
   name: "太鼓の達人 TAIKO DRUM MASTER"
   name-sort: "たいこのたつじん TAIKO DRUM MASTER"
@@ -54373,6 +54473,7 @@ SLPS-20414:
   compat: 5
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
+    textureInsideRT: 1 # Fixes post effects.
 SLPS-20416:
   name: "陰陽大戦記 白虎演舞 [“EyeToy”カメラ同梱版]"
   name-sort: "おんみょうたいせんき びゃっこえんぶ [あいとーいかめらどうこんばん]"
@@ -54424,6 +54525,7 @@ SLPS-20424:
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
+    textureInsideRT: 1 # Fixes post effects.
 SLPS-20425:
   name: "太鼓の達人 とびっきり！アニメスペシャル [ソフト単体]"
   name-sort: "たいこのたつじん とびっきり！あにめすぺしゃる [そふとたんたい]"
@@ -54431,6 +54533,7 @@ SLPS-20425:
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
+    textureInsideRT: 1 # Fixes post effects.
 SLPS-20426:
   name: "マダガスカル"
   name-sort: "まだかすかる"
@@ -54540,6 +54643,7 @@ SLPS-20450:
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
+    textureInsideRT: 1 # Fixes post effects.
 SLPS-20451:
   name: "太鼓の達人 わいわいハッピー！六代目"
   name-sort: "たいこのたつじん わいわいはっぴー！ろくだいめ"
@@ -54547,6 +54651,7 @@ SLPS-20451:
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
+    textureInsideRT: 1 # Fixes post effects.
 SLPS-20452:
   name: "SIMPLE2000シリーズ Ultimate Vol.30 降臨！族車ゴッド～仏恥義理★愛羅武勇～"
   name-sort: "しんぷる2000しりーず あるてぃめっと Vol.30 こうりん！ぞくしゃごっど ぶっちぎりあいらぶゆう"
@@ -54747,6 +54852,7 @@ SLPS-20485:
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
+    textureInsideRT: 1 # Fixes post effects.
     getSkipCount: "GSC_Tekken5" # Fixes upscaling grid, same engine.
 SLPS-20486:
   name: "太鼓の達人 ドカッ！と大盛り七代目 [ソフト単体]"
@@ -54755,6 +54861,7 @@ SLPS-20486:
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
+    textureInsideRT: 1 # Fixes post effects.
     getSkipCount: "GSC_Tekken5" # Fixes upscaling grid, same engine.
 SLPS-20487:
   name: "パチスロキング！ 科学忍者隊ガッチャマン"
@@ -56546,6 +56653,8 @@ SLPS-25289:
   region: "NTSC-J"
   gsHWFixes:
     texturePreloading: 0 # Performs much better with no preload.
+    textureInsideRT: 1 # Fixes post processing.
+    halfPixelOffset: 5 # Fixes alignment of shuffles and post processing.
 SLPS-25290:
   name: "タイムクライシス3 [ソフト単体]"
   name-sort: "たいむくらいしす3 [そふとたんたい]"
@@ -56553,6 +56662,8 @@ SLPS-25290:
   region: "NTSC-J"
   gsHWFixes:
     texturePreloading: 0 # Performs much better with no preload.
+    textureInsideRT: 1 # Fixes post processing.
+    halfPixelOffset: 5 # Fixes alignment of shuffles and post processing.
 SLPS-25291:
   name: "Baldur's Gate - DARK ALLIANCE - [PCCW Japan The BEST]"
   name-sort: "ばるだーずげーと だーくあらいあんす [PCCW Japan The BEST]"
@@ -57275,6 +57386,8 @@ SLPS-25406:
   gsHWFixes:
     texturePreloading: 1 # Performs much better with partial preload.
     autoFlush: 1 # Fixes bloom rendering.
+    textureInsideRT: 1 # Fixes post processing.
+    halfPixelOffset: 5 # Fixes alignment of shuffles and post processing.
   roundModes:
     vu1RoundMode: 0 # Fixes missing light cones curtains and certain effects.
   speedHacks:
@@ -57404,9 +57517,8 @@ SLPS-25422:
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes FMV lines.
-    cpuSpriteRenderBW: 2 # Prevents Death By VRAM explosion.
-    cpuSpriteRenderLevel: 2 # Needed for above.
-    getSkipCount: "GSC_DeathByDegreesTekkenNinaWilliams"
+    halfPixelOffset: 5 # Fixes alignment of shuffles and post processing.
+    textureInsideRT: 1 # Fixes post shuffles.
 SLPS-25423:
   name: "怪盗アプリコット 完全版 [限定版]"
   name-sort: "かいとうあぷりこっと かんぜんばん [げんていばん]"
@@ -58177,6 +58289,8 @@ SLPS-25563:
   gsHWFixes:
     texturePreloading: 1 # Performs much better with partial preload.
     autoFlush: 1 # Fixes bloom rendering.
+    textureInsideRT: 1 # Fixes post processing.
+    halfPixelOffset: 5 # Fixes alignment of shuffles and post processing.
   roundModes:
     vu1RoundMode: 0 # Fixes missing light cones curtains and certain effects.
   speedHacks:
@@ -60130,6 +60244,7 @@ SLPS-25886:
     autoFlush: 1 # Fixes bloom intensity.
     halfPixelOffset: 4 # Mostly aligns post processing.
     nativeScaling: 1 # Fixes post processing smoothness and position.
+    getSkipCount: "GSC_GuitarHero"
 SLPS-25887:
   name: "スーパーロボット大戦Ｚ"
   name-sort: "すーぱーろぼっとたいせんZ"
@@ -60166,6 +60281,7 @@ SLPS-25889:
     autoFlush: 1 # Fixes bloom intensity.
     halfPixelOffset: 4 # Mostly aligns post processing.
     nativeScaling: 1 # Fixes post processing smoothness and position.
+    getSkipCount: "GSC_GuitarHero"
 SLPS-25890:
   name: "ギターヒーロー3 レジェンドオブロック [ソフト単体]"
   name-sort: "ぎたーひーろー3 れじぇんどおぶろっく [そふとたんたい]"
@@ -60751,8 +60867,7 @@ SLPS-71502:
   name-en: "Ridge Racer V [MEGA HITS!]"
   region: "NTSC-J"
   gsHWFixes:
-    cpuFramebufferConversion: 1
-    textureInsideRT: 1
+    textureInsideRT: 1 # Fixes post effects
     halfPixelOffset: 2 # Fixes title screen and some intro post processing alignment.
     roundSprite: 1 # Fixes ui and hud alignment.
     gpuPaletteConversion: 2 # Lots of CLUTs in large textures.
@@ -61671,8 +61786,7 @@ SLUS-20002:
   clampModes:
     vuClampMode: 2 # Fixes texture rendering in the intro.
   gsHWFixes:
-    cpuFramebufferConversion: 1
-    textureInsideRT: 1
+    textureInsideRT: 1 # Fixes post effects
     halfPixelOffset: 2 # Fixes title screen and some intro post processing alignment.
     roundSprite: 1 # Fixes ui and hud alignment.
     gpuPaletteConversion: 2 # Lots of CLUTs in large textures.
@@ -62854,7 +62968,6 @@ SLUS-20291:
   compat: 5
   gsHWFixes:
     textureInsideRT: 1 # Fixes inside RT shuffling.
-    getSkipCount: "GSC_BigMuthaTruckers"
 SLUS-20292:
   name: "Tsugunai - Atonement"
   region: "NTSC-U"
@@ -63329,6 +63442,9 @@ SLUS-20387:
   name: "Suikoden III"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    textureInsideRT: 1 # Fixes half screen.
+    halfPixelOffset: 4 # Fixes post effects.
   memcardFilters: # Allows import of Suikoden II clear data.
     - "SLUS-20387"
     - "SLUS-00958"
@@ -63575,6 +63691,9 @@ SLUS-20433:
   compat: 5
   clampModes:
     eeClampMode: 3 # For grey screen ingame.
+  gsHWFixes:
+    textureInsideRT: 1 # Fixes post effects on player 2.
+    halfPixelOffset: 4 # Fixes chromatic effect.
 SLUS-20434:
   name: "Myst III - Exile"
   region: "NTSC-U"
@@ -64397,8 +64516,6 @@ SLUS-20587:
   gsHWFixes:
     autoFlush: 1 # Aligns and corrects shadows.
     halfPixelOffset: 2 # Fixes sun and depth line.
-    cpuCLUTRender: 1 # Fixes janky coloured cars.
-    gpuTargetCLUT: 1 # Fixes janky coloured cars.
     textureInsideRT: 1 # Fixes car textures.
     cpuSpriteRenderBW: 4 # Alleviates text and sky rendering issues.
     cpuSpriteRenderLevel: 2 # Needed for above.
@@ -64495,7 +64612,6 @@ SLUS-20605:
   region: "NTSC-U"
   gsHWFixes:
     textureInsideRT: 1 # Fixes inside RT shuffling.
-    getSkipCount: "GSC_BigMuthaTruckers"
 SLUS-20606:
   name: "Bounty Hunter - Seek & Destroy"
   region: "NTSC-U"
@@ -64687,6 +64803,8 @@ SLUS-20645:
   compat: 5
   gsHWFixes:
     texturePreloading: 0 # Performs much better with no preload.
+    textureInsideRT: 1 # Fixes post processing.
+    halfPixelOffset: 5 # Fixes alignment of shuffles and post processing.
 SLUS-20646:
   name: "Mark Davis Pro Bass Challenge"
   region: "NTSC-U"
@@ -65155,6 +65273,8 @@ SLUS-20732:
     texturePreloading: 1 # Performs better with partial preload because it is slow on locations outside gameplay foremost.
     mergeSprite: 1 # Fixes misaligned white lines.
     PCRTCOverscan: 1 # Fixes missing HUD.
+    textureInsideRT: 1 # Fixes post shuffle effect.
+    halfPixelOffset: 2 # Fixes boxes around shuffle effect pages.
 SLUS-20733:
   name: "Castlevania - Lament of Innocence"
   region: "NTSC-U"
@@ -65701,7 +65821,7 @@ SLUS-20840:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    textureInsideRT: 1 # Fixes flashing and some models still very broken in hardware mode.
+    textureInsideRT: 1 # Fixes colors.
 SLUS-20841:
   name: "NFL Street"
   region: "NTSC-U"
@@ -65955,6 +66075,8 @@ SLUS-20882:
   gsHWFixes:
     texturePreloading: 1 # Performs much better with partial preload.
     autoFlush: 1 # Fixes bloom rendering.
+    textureInsideRT: 1 # Fixes post processing.
+    halfPixelOffset: 5 # Fixes alignment of shuffles and post processing.
   roundModes:
     vu1RoundMode: 0 # Fixes missing light cones curtains and certain effects.
   speedHacks:
@@ -66284,9 +66406,8 @@ SLUS-20934:
   compat: 5
   gsHWFixes:
     alignSprite: 1 # Fixes FMV lines.
-    cpuSpriteRenderBW: 2 # Prevents Death By VRAM explosion.
-    cpuSpriteRenderLevel: 2 # Needed for above.
-    getSkipCount: "GSC_DeathByDegreesTekkenNinaWilliams"
+    halfPixelOffset: 5 # Fixes alignment of shuffles and post processing.
+    textureInsideRT: 1 # Fixes post shuffles.
 SLUS-20935:
   name: "IHRA Professional Drag Racing 2005"
   region: "NTSC-U"
@@ -66720,9 +66841,9 @@ SLUS-21006:
     recommendedBlendingLevel: 4 # Improves banding and effect emulation.
     autoFlush: 1 # Fixes light bloom intensity.
     estimateTextureRegion: 1 # Improves performance and reduces hash cache size.
-    halfPixelOffset: 4 # Aligns post effects.
+    halfPixelOffset: 2 # Aligns post effects.
     nativeScaling: 1 # Fixes post effects.
-    getSkipCount: "GSC_GiTS"
+    textureInsideRT: 1 # Fixes post shuffles.
   patches:
     default:
       content: |-
@@ -66887,6 +67008,8 @@ SLUS-21029:
   gsHWFixes:
     halfPixelOffset: 2 # Aligns post bloom.
     nativeScaling: 2 # Fixes light blooms.
+    textureInsideRT: 1 # Improves performance.
+    preloadFrameData: 1 # Fixes light trails.
     getSkipCount: "GSC_MidnightClub3"
   patches:
     0DD3417A:
@@ -66950,7 +67073,7 @@ SLUS-21037:
     autoFlush: 1 # Fixes the post processing positioning.
     textureInsideRT: 1 # Fixes post processing.
     nativeScaling: 2 # Fixes post processing smoothness and position.
-    halfPixelOffset: 4 # Makes bloom alignment slightly less awful.
+    halfPixelOffset: 5 # Makes bloom alignment slightly less awful.
 SLUS-21038:
   name: "Pinball Hall of Fame - The Gottlieb Collection"
   region: "NTSC-U"
@@ -66961,6 +67084,10 @@ SLUS-21039:
   compat: 5
   gsHWFixes:
     alignSprite: 1 # Fixes lighting and vertical lines, also works with normal vertex.
+    roundSprite: 1 # Fixes misaligned map.
+    halfPixelOffset: 2 # Fixes depth of field alignment.
+    nativeScaling: 1 # Fixes depth of field.
+    textureInsideRT: 1 # Fixes shadows.
 SLUS-21040:
   name: "The Shield"
   name-sort: "Shield, The"
@@ -67274,9 +67401,10 @@ SLUS-21099:
   region: "NTSC-U"
   compat: 4
   gsHWFixes:
-    disablePartialInvalidation: 1 # Improves performance.
     halfPixelOffset: 2 # Fixes misaligned bloom effects.
     texturePreloading: 1 # Performs much better with partial preload.
+    textureInsideRT: 1 # Fixes post effects.
+    nativeScaling: 1 # Fixes lighting quality and positioning.
 SLUS-21100:
   name: "NCAA March Madness 2005"
   region: "NTSC-U"
@@ -67319,6 +67447,7 @@ SLUS-21106:
     eeRoundMode: 0 # Fixes scene switching in intro.
   gsHWFixes:
     cpuSpriteRenderBW: 1 # Fixes textures.
+    cpuSpriteRenderLevel: 1 # Needed for above.
     preloadFrameData: 1 # Fixes numberplates and ensures above targets are valid.
     roundSprite: 1 # Fixes lines in some post-effects.
     gpuTargetCLUT: 1 # Fixes light occlusion.
@@ -67335,7 +67464,7 @@ SLUS-21108:
   clampModes:
     vuClampMode: 0 # Fixes bump mapping issues
   gsHWFixes:
-    halfPixelOffset: 4 # Fixes post processing position.
+    halfPixelOffset: 5 # Fixes alignment of shuffles and post processing.
     autoFlush: 1 # Fixes sun intensity.
     textureInsideRT: 1 # Fixes post processing.
     getSkipCount: "GSC_HitmanBloodMoney"
@@ -67746,10 +67875,9 @@ SLUS-21182:
   gsHWFixes:
     alignSprite: 1 # Fixes lighting and vertical lines, also works with normal vertex.
     roundSprite: 1 # Fixes misaligned map.
-    skipDrawStart: 1 # Removes large black box around player car till we properly emulate it.
-    skipDrawEnd: 1 # Removes large black box around player car till we properly emulate it.
     halfPixelOffset: 2 # Fixes depth of field alignment.
     nativeScaling: 1 # Fixes depth of field.
+    textureInsideRT: 1 # Fixes shadows.
   memcardFilters:
     - "SLUS-21182"
     - "SLUS-21039" # Race Driver 2 save unlocks 'Class A 4WD Track Challenge' in career early.
@@ -68046,6 +68174,7 @@ SLUS-21228:
     halfPixelOffset: 2 # Fix text and post blur.
     nativeScaling: 2 # Fixes post effects.
     cpuSpriteRenderBW: 1 # Fixes textures.
+    cpuSpriteRenderLevel: 1 # Needed for above.
 SLUS-21229:
   name: "Motocross Mania 3"
   region: "NTSC-U"
@@ -68684,6 +68813,7 @@ SLUS-21311:
     autoFlush: 1 # Corrects vignette to match software.
     estimateTextureRegion: 1 # Improves performance and reduces hash cache size.
     halfPixelOffset: 4 # Aligns blur more correctly to match software.
+    textureInsideRT: 1 # Fixes post processing effects.
 SLUS-21312:
   name: "Wallace & Gromit - The Curse of the Were-Rabbit"
   region: "NTSC-U"
@@ -68734,6 +68864,7 @@ SLUS-21318:
   gsHWFixes:
     roundSprite: 1 # Fixes lines in sprites.
     cpuSpriteRenderBW: 1 # Fixes textures.
+    cpuSpriteRenderLevel: 1 # Needed for above.
 SLUS-21319:
   name: "Flow - Urban Dance Uprising"
   region: "NTSC-U"
@@ -68968,6 +69099,8 @@ SLUS-21355:
   gsHWFixes:
     halfPixelOffset: 2 # Aligns post bloom.
     nativeScaling: 2 # Fixes light blooms.
+    textureInsideRT: 1 # Improves performance.
+    preloadFrameData: 1 # Fixes light trails.
     getSkipCount: "GSC_MidnightClub3"
   patches:
     60A42FF5:
@@ -69432,7 +69565,7 @@ SLUS-21419:
   compat: 5
   gsHWFixes:
     autoFlush: 1 # Fixes lighting.
-    halfPixelOffset: 4 # Fixes ghosting.
+    halfPixelOffset: 5 # Fixes ghosting.
     nativeScaling: 2 # Fixes post processing.
     recommendedBlendingLevel: 4 # Fixes missing light brightness.
 SLUS-21420:
@@ -70191,6 +70324,9 @@ SLUS-21581:
   name: "UEFA Champions League 2006-2007"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    cpuSpriteRenderBW: 2 # Fixes broken lights due to copying around P8 data.
+    cpuSpriteRenderLevel: 2 # Needed for above.
 SLUS-21582:
   name: "MVP '07 - NCAA Baseball"
   region: "NTSC-U"
@@ -70386,8 +70522,9 @@ SLUS-21613:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    getSkipCount: "GSC_Manhunt2"
     autoFlush: 1 # Fixes missing lights and light intensity.
+    textureInsideRT: 1 # Fixes post lighting.
+    halfPixelOffset: 2 # Fixes Post effects.
 SLUS-21614:
   name: "Star Wars - The Force Unleashed"
   region: "NTSC-U"
@@ -70411,7 +70548,7 @@ SLUS-21615:
   compat: 5
   gsHWFixes:
     roundSprite: 1 # Fixes font sizes and lines in UI.
-    cpuFramebufferConversion: 1 # Fixes sepia-tone flashback sequences.
+    textureInsideRT: 1 # Fixes sepia-tone flashback sequences.
     forceEvenSpritePosition: 1 # Fixes font artifacts and out-of-bound 2D textures.
     gpuPaletteConversion: 2 # Fixes micro-stuttering and reduces HC size.
 SLUS-21616:
@@ -70971,6 +71108,8 @@ SLUS-21716:
   compat: 5
   roundModes:
     vu0RoundMode: 0 # Fixes invisible wall collision in bedroom.
+  gsHWFixes:
+    textureInsideRT: 1 # Fixes half screen.
 SLUS-21717:
   name: "Dora the Explorer - Dora Saves the Mermaids"
   region: "NTSC-U"
@@ -71119,6 +71258,7 @@ SLUS-21740:
     autoFlush: 1 # Fixes bloom intensity.
     halfPixelOffset: 4 # Mostly aligns post processing.
     nativeScaling: 1 # Fixes post processing smoothness and position.
+    getSkipCount: "GSC_GuitarHero"
 SLUS-21741:
   name: "Sea Monsters - A Prehistoric Adventure"
   region: "NTSC-U"
@@ -71208,6 +71348,7 @@ SLUS-21757:
   compat: 5
   gsHWFixes:
     cpuSpriteRenderBW: 1 # Fixes textures.
+    cpuSpriteRenderLevel: 1 # Needed for above.
     halfPixelOffset: 4 # Aligns post processing.
     autoFlush: 1 # Fixes post processing.
 SLUS-21758:
@@ -72699,6 +72840,8 @@ SLUS-29087:
     eeClampMode: 3 # Characters are visible in-game.
   gsHWFixes:
     texturePreloading: 1 # Performs better with partial preload because it is slow on locations outside gameplay foremost.
+    textureInsideRT: 1 # Fixes post shuffle effect.
+    halfPixelOffset: 2 # Fixes boxes around shuffle effect pages.
 SLUS-29088:
   name: "Champions of Norrath - Realms of EverQuest [Demo]"
   region: "NTSC-U"
@@ -72813,9 +72956,9 @@ SLUS-29123:
     recommendedBlendingLevel: 4 # Improves banding and effect emulation.
     autoFlush: 1 # Fixes light bloom intensity.
     estimateTextureRegion: 1 # Improves performance and reduces hash cache size.
-    halfPixelOffset: 4 # Aligns post effects.
+    halfPixelOffset: 2 # Aligns post effects.
     nativeScaling: 1 # Fixes post effects.
-    getSkipCount: "GSC_GiTS"
+    textureInsideRT: 1 # Fixes post shuffles.
 SLUS-29124:
   name: "Fight Club [Demo]"
   region: "NTSC-U"
@@ -72856,7 +72999,7 @@ SLUS-29131:
   gsHWFixes:
     autoFlush: 1 # Fixes the post processing positioning.
     textureInsideRT: 1 # Fixes post processing.
-    halfPixelOffset: 4 # Aligns bloom effect.
+    halfPixelOffset: 5 # Aligns bloom effect.
     nativeScaling: 2 # Fixes post processing smoothness and position.
 SLUS-29132:
   name: "S.L.A.I. - Steel Lancer Arena International - Phantom Crash [Public Beta Vol.1.0]"
@@ -73092,10 +73235,9 @@ SLUS-29178:
   gsHWFixes:
     alignSprite: 1 # Fixes lighting and vertical lines, also works with normal vertex.
     roundSprite: 1 # Fixes misaligned map.
-    skipDrawStart: 1 # Removes large black box around player car till we properly emulate it.
-    skipDrawEnd: 1 # Removes large black box around player car till we properly emulate it.
     halfPixelOffset: 2 # Fixes depth of field alignment.
     nativeScaling: 1 # Fixes depth of field.
+    textureInsideRT: 1 # Fixes shadows.
 SLUS-29179:
   name: "Sonic Riders [Demo]"
   region: "NTSC-U"
@@ -73143,6 +73285,7 @@ SLUS-29191:
     vuClampMode: 0 # Fixes bump mapping issues
   gsHWFixes:
     textureInsideRT: 1 # Fixes post processing.
+    halfPixelOffset: 5 # Fixes alignment of shuffles and post processing in Hitman.
     getSkipCount: "GSC_HitmanBloodMoney"
 SLUS-29192:
   name: "Test Drive Unlimited [Public Beta Vol.1.0]"

--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -13278,8 +13278,9 @@ SLED-52441:
   speedHacks:
     mtvu: 0
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes depth line.
+    halfPixelOffset: 5 # Fixes depth line.
     textureInsideRT: 1 # Fixes shadow and sky rendering.
+    nativeScaling: 2 # Fixes light rays.
     deinterlace: 9 # Any other method causes very bad lines on movement of the camera.
 SLED-52473:
   name: "Transformers - Optimus Prime [Demo]"
@@ -13289,8 +13290,9 @@ SLED-52473:
   speedHacks:
     mtvu: 0
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes depth line.
+    halfPixelOffset: 5 # Fixes depth line.
     textureInsideRT: 1 # Fixes shadow and sky rendering.
+    nativeScaling: 2 # Fixes light rays.
     deinterlace: 9 # Any other method causes very bad lines on movement of the camera.
 SLED-52474:
   name: "Transformers - Red Alert [Demo]"
@@ -13300,8 +13302,9 @@ SLED-52474:
   speedHacks:
     mtvu: 0
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes depth line.
+    halfPixelOffset: 5 # Fixes depth line.
     textureInsideRT: 1 # Fixes shadow and sky rendering.
+    nativeScaling: 2 # Fixes light rays.
     deinterlace: 9 # Any other method causes very bad lines on movement of the camera.
 SLED-52476:
   name: "UEFA Euro 2004 - Portugal [Demo]"
@@ -19460,8 +19463,9 @@ SLES-52388:
   speedHacks:
     mtvu: 0
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes depth line.
+    halfPixelOffset: 5 # Fixes depth line.
     textureInsideRT: 1 # Fixes shadow and sky rendering.
+    nativeScaling: 2 # Fixes light rays.
     deinterlace: 9 # Any other method causes very bad lines on movement of the camera.
 SLES-52392:
   name: "Combat Elite - WWII Paratroopers [Preview]"
@@ -22082,8 +22086,9 @@ SLES-53309:
   speedHacks:
     mtvu: 0
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes depth line.
+    halfPixelOffset: 5 # Fixes depth line.
     textureInsideRT: 1 # Fixes shadow and sky rendering.
+    nativeScaling: 2 # Fixes light rays.
     deinterlace: 9 # Any other method causes very bad lines on movement of the camera.
 SLES-53311:
   name: "Graffiti Kingdom"
@@ -30604,8 +30609,9 @@ SLKA-25175:
   speedHacks:
     mtvu: 0
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes depth line.
+    halfPixelOffset: 5 # Fixes depth line.
     textureInsideRT: 1 # Fixes shadow and sky rendering.
+    nativeScaling: 2 # Fixes light rays.
     deinterlace: 9 # Any other method causes very bad lines on movement of the camera.
 SLKA-25176:
   name: "Pump It Up - Exceed"
@@ -64911,8 +64917,9 @@ SLUS-20668:
   speedHacks:
     mtvu: 0
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes depth line.
+    halfPixelOffset: 5 # Fixes depth line.
     textureInsideRT: 1 # Fixes shadow and sky rendering.
+    nativeScaling: 2 # Fixes light rays.
     deinterlace: 9 # Any other method causes very bad lines on movement of the camera.
 SLUS-20669:
   name: "Resident Evil - Dead Aim"
@@ -72469,8 +72476,9 @@ SLUS-28040:
   speedHacks:
     mtvu: 0
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes depth line.
+    halfPixelOffset: 5 # Fixes depth line.
     textureInsideRT: 1 # Fixes shadow and sky rendering.
+    nativeScaling: 2 # Fixes light rays.
     deinterlace: 9 # Any other method causes very bad lines on movement of the camera.
 SLUS-28043:
   name: "Test Drive - Eve of Destruction [Trade Demo]"
@@ -72901,8 +72909,9 @@ SLUS-29107:
   speedHacks:
     mtvu: 0
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes depth line.
+    halfPixelOffset: 5 # Fixes depth line.
     textureInsideRT: 1 # Fixes shadow and sky rendering.
+    nativeScaling: 2 # Fixes light rays.
     deinterlace: 9 # Any other method causes very bad lines on movement of the camera.
 SLUS-29108:
   name: "Def Jam - Fight for NY [Demo]"

--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -3887,9 +3887,13 @@ SCED-52899:
 SCED-52932:
   name: "Bonus Demo 8"
   region: "PAL-M5"
+  gsHWFixes:
+    textureInsideRT: 1 # Fixes shadows in TOCA Race Driver 2.
 SCED-52933:
   name: "Bonus Demo 8"
   region: "PAL-M5"
+  gsHWFixes:
+    textureInsideRT: 1 # Fixes shadows in TOCA Race Driver 2.
 SCED-52935:
   name: "SingStar Party [Demo]"
   region: "PAL-E"
@@ -3963,6 +3967,8 @@ SCED-52997:
 SCED-53018:
   name: "Bonus Demo 8 (Geu)"
   region: "PAL-G"
+  gsHWFixes:
+    textureInsideRT: 1 # Fixes shadows in TOCA Race Driver 2.
 SCED-53043:
   name: "Magazine Ufficiale PlayStation 2 Speciale Platinum Italia"
   region: "PAL-I"
@@ -13614,8 +13620,7 @@ SLED-53731:
     autoFlush: 1 # Post-processing.
     halfPixelOffset: 2 # Offset post-processing.
     texturePreloading: 1 # Improves performance.
-    getSkipCount: "GSC_Battlefield2" # Depth clear.
-    beforeDraw: "OI_Battlefield2" # Framebuffer copy, fixes rendering for bottom part of screen.
+    textureInsideRT: 1 # Fixes per line drawing.
 SLED-53732:
   name: "Spartan - Total Warrior [Demo]"
   region: "PAL"
@@ -23615,8 +23620,7 @@ SLES-53729:
     autoFlush: 1 # Post-processing.
     halfPixelOffset: 2 # Offset post-processing.
     texturePreloading: 1 # Improves performance.
-    getSkipCount: "GSC_Battlefield2" # Depth clear.
-    beforeDraw: "OI_Battlefield2" # Framebuffer copy, fixes rendering for bottom part of screen.
+    textureInsideRT: 1 # Fixes per line drawing.
 SLES-53730:
   name: "Battlefield 2 - Modern Combat"
   region: "PAL-M3"
@@ -23625,8 +23629,7 @@ SLES-53730:
     autoFlush: 1 # Post-processing.
     halfPixelOffset: 2 # Offset post-processing.
     texturePreloading: 1 # Improves performance.
-    getSkipCount: "GSC_Battlefield2" # Depth clear.
-    beforeDraw: "OI_Battlefield2" # Framebuffer copy, fixes rendering for bottom part of screen.
+    textureInsideRT: 1 # Fixes per line drawing.
 SLES-53734:
   name: "50 Cent - Bulletproof"
   region: "PAL-E"
@@ -31298,13 +31301,11 @@ SLKA-25330:
   name: "Battlefield 2 - Modern Combat"
   region: "NTSC-K"
   gsHWFixes:
-    autoFlush: 2 # Post-processing.
+    minimumBlendingLevel: 4 # Fixes ground texture rendering.
+    autoFlush: 1 # Post-processing.
     halfPixelOffset: 2 # Offset post-processing.
-    texturePreloading: 1 # Spikes all over the place otherwise.
-    textureInsideRT: 1 # Fixes light shinging through objects.
-    cpuCLUTRender: 1 # Fixes light shining through objects.
-    getSkipCount: "GSC_Battlefield2" # Depth clear.
-    beforeDraw: "OI_Battlefield2" # Framebuffer copy, fixes rendering for bottom part of screen.
+    texturePreloading: 1 # Improves performance.
+    textureInsideRT: 1 # Fixes per line drawing.
 SLKA-25331:
   name: "Marc Ecko's Getting Up - Contents Under Pressure"
   region: "NTSC-K"
@@ -32192,8 +32193,7 @@ SLPM-55034:
     autoFlush: 1 # Post-processing.
     halfPixelOffset: 2 # Offset post-processing.
     texturePreloading: 1 # Improves performance.
-    getSkipCount: "GSC_Battlefield2" # Depth clear.
-    beforeDraw: "OI_Battlefield2" # Framebuffer copy, fixes rendering for bottom part of screen.
+    textureInsideRT: 1 # Fixes per line drawing.
 SLPM-55035:
   name: "ファイトナイト ラウンド2 [EA:SY! 1980]"
   name-sort: "ふぁいとないと らうんど2 [EA:SY! 1980]"
@@ -46304,8 +46304,7 @@ SLPM-66206:
     autoFlush: 1 # Post-processing.
     halfPixelOffset: 2 # Offset post-processing.
     texturePreloading: 1 # Improves performance.
-    getSkipCount: "GSC_Battlefield2" # Depth clear.
-    beforeDraw: "OI_Battlefield2" # Framebuffer copy, fixes rendering for bottom part of screen.
+    textureInsideRT: 1 # Fixes per line drawing.
 SLPM-66207:
   name: "どろろ [SEGA THE BEST 2800]"
   name-sort: "どろろ [SEGA THE BEST 2800]"
@@ -49096,8 +49095,7 @@ SLPM-66651:
     autoFlush: 1 # Post-processing.
     halfPixelOffset: 2 # Offset post-processing.
     texturePreloading: 1 # Improves performance.
-    getSkipCount: "GSC_Battlefield2" # Depth clear.
-    beforeDraw: "OI_Battlefield2" # Framebuffer copy, fixes rendering for bottom part of screen.
+    textureInsideRT: 1 # Fixes per line drawing.
 SLPM-66652:
   name: "バーンアウト リベンジ [EA BEST HITS]"
   name-sort: "ばーんあうと りべんじ [EA BEST HITS]"
@@ -66987,8 +66985,7 @@ SLUS-21026:
     autoFlush: 1 # Post-processing.
     halfPixelOffset: 2 # Offset post-processing.
     texturePreloading: 1 # Improves performance.
-    getSkipCount: "GSC_Battlefield2" # Depth clear.
-    beforeDraw: "OI_Battlefield2" # Framebuffer copy, fixes rendering for bottom part of screen.
+    textureInsideRT: 1 # Fixes per line drawing.
 SLUS-21027:
   name: "The Lord of the Rings - The Third Age"
   name-sort: "Lord of the Rings, The - The Third Age"
@@ -72940,8 +72937,7 @@ SLUS-29117:
     autoFlush: 1 # Post-processing.
     halfPixelOffset: 2 # Offset post-processing.
     texturePreloading: 1 # Improves performance.
-    getSkipCount: "GSC_Battlefield2" # Depth clear.
-    beforeDraw: "OI_Battlefield2" # Framebuffer copy, fixes rendering for bottom part of screen.
+    textureInsideRT: 1 # Fixes per line drawing.
 SLUS-29118:
   name: "Need for Speed - Underground 2 [Demo]"
   region: "NTSC-U"
@@ -73093,8 +73089,7 @@ SLUS-29152:
     autoFlush: 1 # Post-processing.
     halfPixelOffset: 2 # Offset post-processing.
     texturePreloading: 1 # Improves performance.
-    getSkipCount: "GSC_Battlefield2" # Depth clear.
-    beforeDraw: "OI_Battlefield2" # Framebuffer copy, fixes rendering for bottom part of screen.
+    textureInsideRT: 1 # Fixes per line drawing.
 SLUS-29153:
   name: "Burnout Revenge [Demo]"
   region: "NTSC-U"
@@ -73209,8 +73204,7 @@ SLUS-29172:
     autoFlush: 1 # Post-processing.
     halfPixelOffset: 2 # Offset post-processing.
     texturePreloading: 1 # Improves performance.
-    getSkipCount: "GSC_Battlefield2" # Depth clear.
-    beforeDraw: "OI_Battlefield2" # Framebuffer copy, fixes rendering for bottom part of screen.
+    textureInsideRT: 1 # Fixes per line drawing.
 SLUS-29173:
   name: "The Sims 2 [Demo]"
   name-sort: "Sims 2, The [Demo]"

--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -1973,6 +1973,7 @@ SCAJ-20125:
   clampModes:
     eeClampMode: 2 # Fixes camera and stops constant coin noises on Pirates Cove.
   gsHWFixes:
+    textureInsideRT: 1 # Fixes heat haze half screen problem.
     alignSprite: 1
     halfPixelOffset: 4 # Align post.
     nativeScaling: 1 # Fixes depth of field effect.
@@ -1983,6 +1984,7 @@ SCAJ-20126:
   clampModes:
     eeClampMode: 2 # Fixes camera and stops constant coin noises on Pirates Cove.
   gsHWFixes:
+    textureInsideRT: 1 # Fixes heat haze half screen problem.
     alignSprite: 1
     halfPixelOffset: 4 # Align post.
     nativeScaling: 1 # Fixes depth of field effect.
@@ -2460,6 +2462,7 @@ SCAJ-20199:
   clampModes:
     eeClampMode: 2 # Fixes camera and stops constant coin noises on Pirates Cove.
   gsHWFixes:
+    textureInsideRT: 1 # Fixes heat haze half screen problem.
     alignSprite: 1
     halfPixelOffset: 4 # Align post.
     nativeScaling: 1 # Fixes depth of field effect.
@@ -4162,6 +4165,7 @@ SCED-53538:
   clampModes:
     eeClampMode: 2 # Fixes camera and stops constant coin noises on Pirates Cove.
   gsHWFixes:
+    textureInsideRT: 1 # Fixes heat haze half screen problem.
     alignSprite: 1
     halfPixelOffset: 4 # Align post.
     nativeScaling: 1 # Fixes depth of field effect.
@@ -5787,6 +5791,7 @@ SCES-53202:
   clampModes:
     eeClampMode: 2 # Fixes camera and stops constant coin noises on Pirates Cove.
   gsHWFixes:
+    textureInsideRT: 1 # Fixes heat haze half screen problem.
     alignSprite: 1
     halfPixelOffset: 4 # Align post.
     nativeScaling: 1 # Fixes depth of field effect.
@@ -7238,6 +7243,7 @@ SCKA-20049:
   clampModes:
     eeClampMode: 2 # Fixes camera and stops constant coin noises on Pirates Cove.
   gsHWFixes:
+    textureInsideRT: 1 # Fixes heat haze half screen problem.
     alignSprite: 1
     halfPixelOffset: 4 # Align post.
     nativeScaling: 1 # Fixes depth of field effect.
@@ -7463,6 +7469,7 @@ SCKA-20081:
   clampModes:
     eeClampMode: 2 # Fixes camera and stops constant coin noises on Pirates Cove.
   gsHWFixes:
+    textureInsideRT: 1 # Fixes heat haze half screen problem.
     alignSprite: 1
     halfPixelOffset: 4 # Align post.
     nativeScaling: 1 # Fixes depth of field effect.
@@ -57880,6 +57887,7 @@ SLPS-25510:
   clampModes:
     eeClampMode: 2 # Fixes camera and stops constant coin noises on Pirates Cove.
   gsHWFixes:
+    textureInsideRT: 1 # Fixes heat haze half screen problem.
     alignSprite: 1 # Fixes vertical lines.
     halfPixelOffset: 4 # Align post.
     nativeScaling: 1 # Fixes depth of field effect.
@@ -61052,6 +61060,7 @@ SLPS-73223:
   clampModes:
     eeClampMode: 2 # Fixes camera and stops constant coin noises on Pirates Cove.
   gsHWFixes:
+    textureInsideRT: 1 # Fixes heat haze half screen problem.
     alignSprite: 1 # Fixes vertical lines.
     halfPixelOffset: 4 # Align post.
     nativeScaling: 1 # Fixes depth of field effect.
@@ -67063,6 +67072,7 @@ SLUS-21059:
   clampModes:
     eeClampMode: 2 # Fixes camera and stops constant coin noises on Pirates Cove.
   gsHWFixes:
+    textureInsideRT: 1 # Fixes heat haze half screen problem.
     alignSprite: 1 # Fixes vertical lines.
     halfPixelOffset: 4 # Align post.
     nativeScaling: 1 # Fixes depth of field effect.
@@ -67612,6 +67622,7 @@ SLUS-21160:
   clampModes:
     eeClampMode: 2 # Fixes camera and stops constant coin noises on Pirates Cove.
   gsHWFixes:
+    textureInsideRT: 1 # Fixes heat haze half screen problem.
     alignSprite: 1 # Fixes vertical lines.
     halfPixelOffset: 4 # Align post.
     nativeScaling: 1 # Fixes depth of field effect.

--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -27286,6 +27286,7 @@ SLES-54962:
     autoFlush: 1 # Fixes bloom intensity.
     halfPixelOffset: 4 # Mostly aligns post processing.
     nativeScaling: 1 # Fixes post processing smoothness and position.
+    getSkipCount: "GSC_GuitarHero"
 SLES-54963:
   name: "Tony Hawk's Proving Ground"
   region: "PAL-E"
@@ -27333,6 +27334,7 @@ SLES-54974:
     autoFlush: 1 # Fixes bloom intensity.
     halfPixelOffset: 4 # Mostly aligns post processing.
     nativeScaling: 1 # Fixes post processing smoothness and position.
+    getSkipCount: "GSC_GuitarHero"
 SLES-54975:
   name: "George Of The Jungle"
   region: "PAL-E"
@@ -31633,6 +31635,7 @@ SLKA-25414:
     autoFlush: 1 # Fixes bloom intensity.
     halfPixelOffset: 4 # Mostly aligns post processing.
     nativeScaling: 1 # Fixes post processing smoothness and position.
+    getSkipCount: "GSC_GuitarHero"
 SLKA-25417:
   name: "Jin Samguk Mussang 4 - Empires"
   region: "NTSC-K"
@@ -59870,6 +59873,7 @@ SLPS-25840:
     autoFlush: 1 # Fixes bloom intensity.
     halfPixelOffset: 4 # Mostly aligns post processing.
     nativeScaling: 1 # Fixes post processing smoothness and position.
+    getSkipCount: "GSC_GuitarHero"
 SLPS-25841:
   name: "テイルズ オブ デスティニー ディレクターズカット [プレミアムBOX]"
   name-sort: "ているず おぶ ですてぃにー でぃれくたーずかっと [ぷれみあむBOX]"
@@ -60174,6 +60178,7 @@ SLPS-25890:
     autoFlush: 1 # Fixes bloom intensity.
     halfPixelOffset: 4 # Mostly aligns post processing.
     nativeScaling: 1 # Fixes post processing smoothness and position.
+    getSkipCount: "GSC_GuitarHero"
 SLPS-25891:
   name: "乃木坂春香の秘密 こすぷれ、はじめました♥ [限定版]"
   name-sort: "のぎざかはるかのひみつ こすぷれ はじめました [げんていばん]"
@@ -70742,6 +70747,7 @@ SLUS-21672:
     autoFlush: 1 # Fixes bloom intensity.
     halfPixelOffset: 4 # Mostly aligns post processing.
     nativeScaling: 1 # Fixes post processing smoothness and position.
+    getSkipCount: "GSC_GuitarHero"
 SLUS-21673:
   name: "College Hoops 2K8"
   region: "NTSC-U"

--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -13621,6 +13621,7 @@ SLED-53731:
     halfPixelOffset: 2 # Offset post-processing.
     texturePreloading: 1 # Improves performance.
     textureInsideRT: 1 # Fixes per line drawing.
+    getSkipCount: "GSC_Battlefield2" # Depth clear.
 SLED-53732:
   name: "Spartan - Total Warrior [Demo]"
   region: "PAL"
@@ -23621,6 +23622,7 @@ SLES-53729:
     halfPixelOffset: 2 # Offset post-processing.
     texturePreloading: 1 # Improves performance.
     textureInsideRT: 1 # Fixes per line drawing.
+    getSkipCount: "GSC_Battlefield2" # Depth clear.
 SLES-53730:
   name: "Battlefield 2 - Modern Combat"
   region: "PAL-M3"
@@ -23630,6 +23632,7 @@ SLES-53730:
     halfPixelOffset: 2 # Offset post-processing.
     texturePreloading: 1 # Improves performance.
     textureInsideRT: 1 # Fixes per line drawing.
+    getSkipCount: "GSC_Battlefield2" # Depth clear.
 SLES-53734:
   name: "50 Cent - Bulletproof"
   region: "PAL-E"
@@ -31306,6 +31309,7 @@ SLKA-25330:
     halfPixelOffset: 2 # Offset post-processing.
     texturePreloading: 1 # Improves performance.
     textureInsideRT: 1 # Fixes per line drawing.
+    getSkipCount: "GSC_Battlefield2" # Depth clear.
 SLKA-25331:
   name: "Marc Ecko's Getting Up - Contents Under Pressure"
   region: "NTSC-K"
@@ -32194,6 +32198,7 @@ SLPM-55034:
     halfPixelOffset: 2 # Offset post-processing.
     texturePreloading: 1 # Improves performance.
     textureInsideRT: 1 # Fixes per line drawing.
+    getSkipCount: "GSC_Battlefield2" # Depth clear.
 SLPM-55035:
   name: "ファイトナイト ラウンド2 [EA:SY! 1980]"
   name-sort: "ふぁいとないと らうんど2 [EA:SY! 1980]"
@@ -46305,6 +46310,7 @@ SLPM-66206:
     halfPixelOffset: 2 # Offset post-processing.
     texturePreloading: 1 # Improves performance.
     textureInsideRT: 1 # Fixes per line drawing.
+    getSkipCount: "GSC_Battlefield2" # Depth clear.
 SLPM-66207:
   name: "どろろ [SEGA THE BEST 2800]"
   name-sort: "どろろ [SEGA THE BEST 2800]"
@@ -49096,6 +49102,7 @@ SLPM-66651:
     halfPixelOffset: 2 # Offset post-processing.
     texturePreloading: 1 # Improves performance.
     textureInsideRT: 1 # Fixes per line drawing.
+    getSkipCount: "GSC_Battlefield2" # Depth clear.
 SLPM-66652:
   name: "バーンアウト リベンジ [EA BEST HITS]"
   name-sort: "ばーんあうと りべんじ [EA BEST HITS]"
@@ -66986,6 +66993,7 @@ SLUS-21026:
     halfPixelOffset: 2 # Offset post-processing.
     texturePreloading: 1 # Improves performance.
     textureInsideRT: 1 # Fixes per line drawing.
+    getSkipCount: "GSC_Battlefield2" # Depth clear.
 SLUS-21027:
   name: "The Lord of the Rings - The Third Age"
   name-sort: "Lord of the Rings, The - The Third Age"
@@ -72938,6 +72946,7 @@ SLUS-29117:
     halfPixelOffset: 2 # Offset post-processing.
     texturePreloading: 1 # Improves performance.
     textureInsideRT: 1 # Fixes per line drawing.
+    getSkipCount: "GSC_Battlefield2" # Depth clear.
 SLUS-29118:
   name: "Need for Speed - Underground 2 [Demo]"
   region: "NTSC-U"
@@ -73090,6 +73099,7 @@ SLUS-29152:
     halfPixelOffset: 2 # Offset post-processing.
     texturePreloading: 1 # Improves performance.
     textureInsideRT: 1 # Fixes per line drawing.
+    getSkipCount: "GSC_Battlefield2" # Depth clear.
 SLUS-29153:
   name: "Burnout Revenge [Demo]"
   region: "NTSC-U"
@@ -73205,6 +73215,7 @@ SLUS-29172:
     halfPixelOffset: 2 # Offset post-processing.
     texturePreloading: 1 # Improves performance.
     textureInsideRT: 1 # Fixes per line drawing.
+    getSkipCount: "GSC_Battlefield2" # Depth clear.
 SLUS-29173:
   name: "The Sims 2 [Demo]"
   name-sort: "Sims 2, The [Demo]"

--- a/bin/resources/shaders/dx11/tfx.fx
+++ b/bin/resources/shaders/dx11/tfx.fx
@@ -1127,7 +1127,7 @@ PS_OUTPUT ps_main(PS_INPUT input)
 		{
 			if (PS_PROCESS_BA == SHUFFLE_READWRITE && PS_PROCESS_RG == SHUFFLE_READWRITE)
 			{
-				C.br = C.rb;				
+				C.br = C.rb;
 				C.ag = C.ga;
 			}
 			else if(PS_PROCESS_BA & SHUFFLE_READ)

--- a/bin/resources/shaders/dx11/tfx.fx
+++ b/bin/resources/shaders/dx11/tfx.fx
@@ -1127,11 +1127,8 @@ PS_OUTPUT ps_main(PS_INPUT input)
 		{
 			if (PS_PROCESS_BA == SHUFFLE_READWRITE && PS_PROCESS_RG == SHUFFLE_READWRITE)
 			{
-				C.rb = C.br;
-				float g_temp = C.g;
-				
-				C.g = C.a;
-				C.a = g_temp;
+				C.b = C.r;
+				C.a = C.g;
 			}
 			else if(PS_PROCESS_BA & SHUFFLE_READ)
 			{

--- a/bin/resources/shaders/dx11/tfx.fx
+++ b/bin/resources/shaders/dx11/tfx.fx
@@ -1127,8 +1127,8 @@ PS_OUTPUT ps_main(PS_INPUT input)
 		{
 			if (PS_PROCESS_BA == SHUFFLE_READWRITE && PS_PROCESS_RG == SHUFFLE_READWRITE)
 			{
-				C.b = C.r;
-				C.a = C.g;
+				C.br = C.rb;				
+				C.ag = C.ga;
 			}
 			else if(PS_PROCESS_BA & SHUFFLE_READ)
 			{

--- a/bin/resources/shaders/dx11/tfx.fx
+++ b/bin/resources/shaders/dx11/tfx.fx
@@ -767,7 +767,7 @@ float4 ps_color(PS_INPUT input)
 	float4 T = sample_color(st, input.t.w);
 #endif
 
-	if (PS_SHUFFLE && !PS_SHUFFLE_SAME && !PS_READ16_SRC)
+	if (PS_SHUFFLE && !PS_SHUFFLE_SAME && !PS_READ16_SRC && !(PS_PROCESS_BA == SHUFFLE_READWRITE && PS_PROCESS_RG == SHUFFLE_READWRITE))
 	{
 		uint4 denorm_c_before = uint4(T);
 		if (PS_PROCESS_BA & SHUFFLE_READ)
@@ -1086,7 +1086,7 @@ PS_OUTPUT ps_main(PS_INPUT input)
 
 	if (PS_SHUFFLE)
 	{
-		if (!PS_SHUFFLE_SAME && !PS_READ16_SRC)
+		if (!PS_SHUFFLE_SAME && !PS_READ16_SRC && !(PS_PROCESS_BA == SHUFFLE_READWRITE && PS_PROCESS_RG == SHUFFLE_READWRITE))
 		{
 			uint4 denorm_c_after = uint4(C);
 			if (PS_PROCESS_BA & SHUFFLE_READ)

--- a/bin/resources/shaders/opengl/tfx_fs.glsl
+++ b/bin/resources/shaders/opengl/tfx_fs.glsl
@@ -1095,11 +1095,8 @@ void ps_main()
 			C.ga = vec2(float((denorm_c.g >> 6) | ((denorm_c.b >> 3) << 2) | (denorm_TA.x & 0x80u)));
 	#elif PS_SHUFFLE_ACROSS
 		#if(PS_PROCESS_BA == SHUFFLE_READWRITE && PS_PROCESS_RG == SHUFFLE_READWRITE)
-			C.rb = C.br;
-			float g_temp = C.g;
-			
-			C.g = C.a;
-			C.a = g_temp;
+			C.b = C.r;
+			C.a = C.g;
 		#elif(PS_PROCESS_BA & SHUFFLE_READ)
 			C.rb = C.bb;
 			C.ga = C.aa;

--- a/bin/resources/shaders/opengl/tfx_fs.glsl
+++ b/bin/resources/shaders/opengl/tfx_fs.glsl
@@ -1095,7 +1095,7 @@ void ps_main()
 			C.ga = vec2(float((denorm_c.g >> 6) | ((denorm_c.b >> 3) << 2) | (denorm_TA.x & 0x80u)));
 	#elif PS_SHUFFLE_ACROSS
 		#if(PS_PROCESS_BA == SHUFFLE_READWRITE && PS_PROCESS_RG == SHUFFLE_READWRITE)
-			C.br = C.rb;				
+			C.br = C.rb;
 			C.ag = C.ga;
 		#elif(PS_PROCESS_BA & SHUFFLE_READ)
 			C.rb = C.bb;

--- a/bin/resources/shaders/opengl/tfx_fs.glsl
+++ b/bin/resources/shaders/opengl/tfx_fs.glsl
@@ -1095,8 +1095,8 @@ void ps_main()
 			C.ga = vec2(float((denorm_c.g >> 6) | ((denorm_c.b >> 3) << 2) | (denorm_TA.x & 0x80u)));
 	#elif PS_SHUFFLE_ACROSS
 		#if(PS_PROCESS_BA == SHUFFLE_READWRITE && PS_PROCESS_RG == SHUFFLE_READWRITE)
-			C.b = C.r;
-			C.a = C.g;
+			C.br = C.rb;				
+			C.ag = C.ga;
 		#elif(PS_PROCESS_BA & SHUFFLE_READ)
 			C.rb = C.bb;
 			C.ga = C.aa;

--- a/bin/resources/shaders/opengl/tfx_fs.glsl
+++ b/bin/resources/shaders/opengl/tfx_fs.glsl
@@ -679,7 +679,7 @@ vec4 ps_color()
 	vec4 T = sample_color(st);
 #endif
 
-	#if PS_SHUFFLE && !PS_READ16_SRC && !PS_SHUFFLE_SAME
+	#if PS_SHUFFLE && !PS_READ16_SRC && !PS_SHUFFLE_SAME && !(PS_PROCESS_BA == SHUFFLE_READWRITE && PS_PROCESS_RG == SHUFFLE_READWRITE)
 		uvec4 denorm_c_before = uvec4(T);
 		#if (PS_PROCESS_BA & SHUFFLE_READ)
 			T.r = float((denorm_c_before.b << 3) & 0xF8u);
@@ -1064,7 +1064,7 @@ void ps_main()
 
 
 #if PS_SHUFFLE
-	#if !PS_READ16_SRC && !PS_SHUFFLE_SAME
+	#if !PS_READ16_SRC && !PS_SHUFFLE_SAME && !(PS_PROCESS_BA == SHUFFLE_READWRITE && PS_PROCESS_RG == SHUFFLE_READWRITE)
 		uvec4 denorm_c_after = uvec4(C);
 		#if (PS_PROCESS_BA & SHUFFLE_READ)
 			C.b = float(((denorm_c_after.r >> 3) & 0x1Fu) | ((denorm_c_after.g << 2) & 0xE0u));

--- a/bin/resources/shaders/vulkan/tfx.glsl
+++ b/bin/resources/shaders/vulkan/tfx.glsl
@@ -1343,8 +1343,6 @@ void main()
 			#endif
 		#endif
 
-		
-		
 		// Special case for 32bit input and 16bit output, shuffle used by The Godfather
 		#if PS_SHUFFLE_SAME
 			#if (PS_PROCESS_BA & SHUFFLE_READ)
@@ -1362,7 +1360,7 @@ void main()
 		// Write RB part. Mask will take care of the correct destination
 		#elif PS_SHUFFLE_ACROSS
 			#if(PS_PROCESS_BA == SHUFFLE_READWRITE && PS_PROCESS_RG == SHUFFLE_READWRITE)
-				C.br = C.rb;				
+				C.br = C.rb;
 				C.ag = C.ga;
 			#elif(PS_PROCESS_BA & SHUFFLE_READ)
 				C.rb = C.bb;

--- a/bin/resources/shaders/vulkan/tfx.glsl
+++ b/bin/resources/shaders/vulkan/tfx.glsl
@@ -1362,8 +1362,8 @@ void main()
 		// Write RB part. Mask will take care of the correct destination
 		#elif PS_SHUFFLE_ACROSS
 			#if(PS_PROCESS_BA == SHUFFLE_READWRITE && PS_PROCESS_RG == SHUFFLE_READWRITE)
-				C.b = C.r;				
-				C.a = C.g;
+				C.br = C.rb;				
+				C.ag = C.ga;
 			#elif(PS_PROCESS_BA & SHUFFLE_READ)
 				C.rb = C.bb;
 				C.ga = C.aa;

--- a/bin/resources/shaders/vulkan/tfx.glsl
+++ b/bin/resources/shaders/vulkan/tfx.glsl
@@ -946,7 +946,7 @@ vec4 ps_color()
 	vec4 T = sample_color(st);
 #endif
 
-	#if PS_SHUFFLE && !PS_READ16_SRC && !PS_SHUFFLE_SAME
+	#if PS_SHUFFLE && !PS_READ16_SRC && !PS_SHUFFLE_SAME && !(PS_PROCESS_BA == SHUFFLE_READWRITE && PS_PROCESS_RG == SHUFFLE_READWRITE)
 		uvec4 denorm_c_before = uvec4(T);
 		#if (PS_PROCESS_BA & SHUFFLE_READ)
 			T.r = float((denorm_c_before.b << 3) & 0xF8u);
@@ -1332,7 +1332,7 @@ void main()
 	ps_blend(C, alpha_blend);
 
 #if PS_SHUFFLE
-		#if !PS_READ16_SRC && !PS_SHUFFLE_SAME
+		#if !PS_READ16_SRC && !PS_SHUFFLE_SAME && !(PS_PROCESS_BA == SHUFFLE_READWRITE && PS_PROCESS_RG == SHUFFLE_READWRITE)
 			uvec4 denorm_c_after = uvec4(C);
 			#if (PS_PROCESS_BA & SHUFFLE_READ)
 				C.b = float(((denorm_c_after.r >> 3) & 0x1Fu) | ((denorm_c_after.g << 2) & 0xE0u));

--- a/bin/resources/shaders/vulkan/tfx.glsl
+++ b/bin/resources/shaders/vulkan/tfx.glsl
@@ -1362,11 +1362,8 @@ void main()
 		// Write RB part. Mask will take care of the correct destination
 		#elif PS_SHUFFLE_ACROSS
 			#if(PS_PROCESS_BA == SHUFFLE_READWRITE && PS_PROCESS_RG == SHUFFLE_READWRITE)
-				C.rb = C.br;
-				float g_temp = C.g;
-				
-				C.g = C.a;
-				C.a = g_temp;
+				C.b = C.r;				
+				C.a = C.g;
 			#elif(PS_PROCESS_BA & SHUFFLE_READ)
 				C.rb = C.bb;
 				C.ga = C.aa;

--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -435,6 +435,15 @@ void GSgifTransfer3(u8* mem, u32 size)
 
 void GSvsync(u32 field, bool registers_written)
 {
+	// Update this here because we need to check if the pending draw affects the current frame, so our regs need to be updated.
+	g_gs_renderer->PCRTCDisplays.SetVideoMode(g_gs_renderer->GetVideoMode());
+	g_gs_renderer->PCRTCDisplays.EnableDisplays(g_gs_renderer->m_regs->PMODE, g_gs_renderer->m_regs->SMODE2, g_gs_renderer->isReallyInterlaced());
+	g_gs_renderer->PCRTCDisplays.CheckSameSource();
+	g_gs_renderer->PCRTCDisplays.SetRects(0, g_gs_renderer->m_regs->DISP[0].DISPLAY, g_gs_renderer->m_regs->DISP[0].DISPFB);
+	g_gs_renderer->PCRTCDisplays.SetRects(1, g_gs_renderer->m_regs->DISP[1].DISPLAY, g_gs_renderer->m_regs->DISP[1].DISPFB);
+	g_gs_renderer->PCRTCDisplays.CalculateDisplayOffset(g_gs_renderer->m_scanmask_used);
+	g_gs_renderer->PCRTCDisplays.CalculateFramebufferOffset(g_gs_renderer->m_scanmask_used);
+
 	// Do not move the flush into the VSync() method. It's here because EE transfers
 	// get cleared in HW VSync, and may be needed for a buffered draw (FFX FMVs).
 	g_gs_renderer->Flush(GSState::VSYNC);

--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -1674,7 +1674,8 @@ void GSState::FlushPrim()
 			Console.Warning("GS: Possible invalid draw, Frame PSM %x ZPSM %x", m_context->FRAME.PSM, m_context->ZBUF.PSM);
 		}
 #endif
-
+		// Update scissor, it may have been modified by a previous draw
+		m_env.CTXT[PRIM->CTXT].UpdateScissor();
 		m_vt.Update(m_vertex.buff, m_index.buff, m_vertex.tail, m_index.tail, GSUtil::GetPrimClass(PRIM->PRIM));
 
 		// Texel coordinate rounding

--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -467,7 +467,8 @@ void GSState::DumpVertices(const std::string& filename)
 		file << std::setfill('0') << std::setw(3) << unsigned(v.RGBAQ.R) << DEL;
 		file << std::setfill('0') << std::setw(3) << unsigned(v.RGBAQ.G) << DEL;
 		file << std::setfill('0') << std::setw(3) << unsigned(v.RGBAQ.B) << DEL;
-		file << std::setfill('0') << std::setw(3) << unsigned(v.RGBAQ.A);
+		file << std::setfill('0') << std::setw(3) << unsigned(v.RGBAQ.A) << DEL;
+		file << "FOG: " << std::setfill('0') << std::setw(3) << unsigned(v.FOG);
 		file << std::endl;
 	}
 
@@ -3100,7 +3101,7 @@ __forceinline bool GSState::IsAutoFlushDraw(u32 prim)
 	{
 		// Pretty confident here...
 		GSVertex* buffer = &m_vertex.buff[0];
-		const bool const_spacing = (buffer[m_index.buff[0]].U - buffer[m_index.buff[0]].XYZ.X) == (m_v.U - m_v.XYZ.X);
+		const bool const_spacing = std::abs(buffer[m_index.buff[0]].U - buffer[m_index.buff[0]].XYZ.X) == std::abs(m_v.U - m_v.XYZ.X) && std::abs(buffer[m_index.buff[1]].XYZ.X - buffer[m_index.buff[0]].XYZ.X) < 64;
 
 		if (const_spacing)
 			return false;

--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -1477,6 +1477,35 @@ void GSState::Flush(GSFlushReason reason)
 
 	if (m_index.tail > 0)
 	{
+		// Unless Vsync really needs the pending draw, don't do it when VSync happens as it can really screw up our heuristics when looking ahead.
+		if (reason == VSYNC)
+		{
+			GSDrawingContext* draw_ctx = &m_prev_env.CTXT[m_prev_env.PRIM.CTXT];
+			const u32 start_bp = GSLocalMemory::GetStartBlockAddress(draw_ctx->FRAME.Block(), draw_ctx->FRAME.FBW, draw_ctx->FRAME.PSM, temp_draw_rect);
+			const u32 end_bp = GSLocalMemory::GetEndBlockAddress(draw_ctx->FRAME.Block(), draw_ctx->FRAME.FBW, draw_ctx->FRAME.PSM, temp_draw_rect);
+			bool needs_flush[2] = {PCRTCDisplays.PCRTCDisplays[0].enabled, PCRTCDisplays.PCRTCDisplays[1].enabled};
+
+			if (PCRTCDisplays.PCRTCDisplays[1].enabled)
+			{
+				const u32 out_start_bp = GSLocalMemory::GetStartBlockAddress(PCRTCDisplays.PCRTCDisplays[1].Block(), PCRTCDisplays.PCRTCDisplays[1].FBW, PCRTCDisplays.PCRTCDisplays[1].PSM, PCRTCDisplays.PCRTCDisplays[1].framebufferRect);
+				const u32 out_end_bp = GSLocalMemory::GetEndBlockAddress(PCRTCDisplays.PCRTCDisplays[1].Block(), PCRTCDisplays.PCRTCDisplays[1].FBW, PCRTCDisplays.PCRTCDisplays[1].PSM, PCRTCDisplays.PCRTCDisplays[1].framebufferRect);
+
+				if (out_start_bp > end_bp || out_end_bp < start_bp)
+					needs_flush[1] = false;
+			}
+			
+			if (PCRTCDisplays.PCRTCDisplays[0].enabled)
+			{
+				const u32 out_start_bp = GSLocalMemory::GetStartBlockAddress(PCRTCDisplays.PCRTCDisplays[0].Block(), PCRTCDisplays.PCRTCDisplays[0].FBW, PCRTCDisplays.PCRTCDisplays[0].PSM, PCRTCDisplays.PCRTCDisplays[0].framebufferRect);
+				const u32 out_end_bp = GSLocalMemory::GetEndBlockAddress(PCRTCDisplays.PCRTCDisplays[0].Block(), PCRTCDisplays.PCRTCDisplays[0].FBW, PCRTCDisplays.PCRTCDisplays[0].PSM, PCRTCDisplays.PCRTCDisplays[0].framebufferRect);
+
+				if (out_start_bp > end_bp || out_end_bp < start_bp)
+					needs_flush[0] = false;
+			}
+
+			if (!needs_flush[0] && !needs_flush[1])
+				return;
+		}
 		m_state_flush_reason = reason;
 
 		// Used to prompt the current draw that it's modifying its own CLUT.
@@ -1942,10 +1971,10 @@ void GSState::Write(const u8* mem, int len)
 			m_draw_transfers.push_back(new_transfer);
 		}
 
-		GL_CACHE("Write! %u ...  => 0x%x W:%d F:%s (DIR %d%d), dPos(%d %d) size(%d %d)", s_transfer_n,
+		GL_CACHE("Write! %u ...  => 0x%x W:%d F:%s (DIR %d%d), dPos(%d %d) size(%d %d) draw %d", s_transfer_n,
 				blit.DBP, blit.DBW, psm_str(blit.DPSM),
 				m_env.TRXPOS.DIRX, m_env.TRXPOS.DIRY,
-				m_env.TRXPOS.DSAX, m_env.TRXPOS.DSAY, w, h);
+				m_env.TRXPOS.DSAX, m_env.TRXPOS.DSAY, w, h, s_n);
 
 		if (len >= m_tr.total)
 		{
@@ -3093,7 +3122,7 @@ void GSState::CalculatePrimitiveCoversWithoutGaps()
 	}
 	else if (m_vt.m_primclass == GS_TRIANGLE_CLASS)
 	{
-		m_primitive_covers_without_gaps = ((m_index.tail % 6) == 0 && TrianglesAreQuads()) ? m_primitive_covers_without_gaps : GapsFound;
+		m_primitive_covers_without_gaps = ((m_index.tail == 6 || ((m_index.tail % 6) == 0 && m_primitive_covers_without_gaps == FullCover)) && TrianglesAreQuads()) ? m_primitive_covers_without_gaps : GapsFound;
 		return;
 	}
 	else if (m_vt.m_primclass != GS_SPRITE_CLASS)
@@ -3123,7 +3152,7 @@ __forceinline bool GSState::IsAutoFlushDraw(u32 prim)
 	{
 		// Pretty confident here...
 		GSVertex* buffer = &m_vertex.buff[0];
-		const bool const_spacing = std::abs(buffer[m_index.buff[0]].U - buffer[m_index.buff[0]].XYZ.X) == std::abs(m_v.U - m_v.XYZ.X) && std::abs(buffer[m_index.buff[1]].XYZ.X - buffer[m_index.buff[0]].XYZ.X) < 64;
+		const bool const_spacing = std::abs(buffer[m_index.buff[0]].U - buffer[m_index.buff[0]].XYZ.X) == std::abs(m_v.U - m_v.XYZ.X) && std::abs(buffer[m_index.buff[1]].XYZ.X - buffer[m_index.buff[0]].XYZ.X) <= 256; // Lequal to 16 pixels apart.
 
 		if (const_spacing)
 			return false;
@@ -4727,10 +4756,16 @@ GSVector2i GSState::GSPCRTCRegs::GetFramebufferSize(int display)
 void GSState::GSPCRTCRegs::SetRects(int display, GSRegDISPLAY displayReg, GSRegDISPFB framebufferReg)
 {
 	// Save framebuffer information first, while we're here.
+	PCRTCDisplays[display].prevFramebufferReg.FBP = PCRTCDisplays[display].FBP;
+	PCRTCDisplays[display].prevFramebufferReg.FBW = PCRTCDisplays[display].FBW;
+	PCRTCDisplays[display].prevFramebufferReg.PSM = PCRTCDisplays[display].PSM;
+	PCRTCDisplays[display].prevFramebufferReg.DBX = PCRTCDisplays[display].DBX;
+	PCRTCDisplays[display].prevFramebufferReg.DBY = PCRTCDisplays[display].DBY;
 	PCRTCDisplays[display].FBP = framebufferReg.FBP;
 	PCRTCDisplays[display].FBW = framebufferReg.FBW;
 	PCRTCDisplays[display].PSM = framebufferReg.PSM;
-	PCRTCDisplays[display].prevFramebufferReg = framebufferReg;
+	PCRTCDisplays[display].DBX = framebufferReg.DBX;
+	PCRTCDisplays[display].DBY = framebufferReg.DBY;
 	// Probably not really enabled but will cause a mess.
 	// Q-Ball Billiards enables both circuits but doesn't set one of them up.
 	if (PCRTCDisplays[display].FBW == 0 && displayReg.DW == 0 && displayReg.DH == 0 && displayReg.MAGH == 0)

--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -4467,7 +4467,7 @@ bool GSState::GSTransferBuffer::Update(int tw, int th, int bpp, int& len)
 	{
 		if (len > packet_size)
 		{
-#if defined(PCSX2_DEVBUILD) || defined(_DEBUG)
+#if defined(_DEBUG)
 			Console.Warning("GS transfer buffer overflow len %d remaining %d, tex_size %d tw %d th %d bpp %d", len, remaining, tex_size, tw, th, bpp);
 #endif
 		}

--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -3093,7 +3093,7 @@ void GSState::CalculatePrimitiveCoversWithoutGaps()
 	}
 	else if (m_vt.m_primclass == GS_TRIANGLE_CLASS)
 	{
-		m_primitive_covers_without_gaps = (m_index.tail == 6 && TrianglesAreQuads()) ? m_primitive_covers_without_gaps : GapsFound;
+		m_primitive_covers_without_gaps = ((m_index.tail % 6) == 0 && TrianglesAreQuads()) ? m_primitive_covers_without_gaps : GapsFound;
 		return;
 	}
 	else if (m_vt.m_primclass != GS_SPRITE_CLASS)

--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -225,6 +225,7 @@ public:
 	bool m_isPackedUV_HackFlag = false;
 	bool m_channel_shuffle = false;
 	bool m_in_target_draw = false;
+	u32 m_target_offset = 0;
 	u8 m_scanmask_used = 0;
 	u32 m_dirty_gs_regs = 0;
 	int m_backed_up_ctx = 0;

--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -224,6 +224,7 @@ public:
 	bool m_texflush_flag = false;
 	bool m_isPackedUV_HackFlag = false;
 	bool m_channel_shuffle = false;
+	bool m_in_target_draw = false;
 	u8 m_scanmask_used = 0;
 	u32 m_dirty_gs_regs = 0;
 	int m_backed_up_ctx = 0;

--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -234,6 +234,8 @@ public:
 	GSVector4i temp_draw_rect = {};
 	std::unique_ptr<GSDumpBase> m_dump;
 	bool m_scissor_invalid = false;
+	bool m_quad_check_valid = false;
+	bool m_are_quads = false;
 	bool m_nativeres = false;
 	bool m_mipmap = false;
 	bool m_texflush_flag = false;
@@ -439,7 +441,7 @@ public:
 
 	void DumpVertices(const std::string& filename);
 
-	bool TrianglesAreQuads(bool shuffle_check = false) const;
+	bool TrianglesAreQuads(bool shuffle_check = false);
 	PRIM_OVERLAP PrimitiveOverlap();
 	bool SpriteDrawWithoutGaps();
 	void CalculatePrimitiveCoversWithoutGaps();

--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -145,6 +145,21 @@ protected:
 		u32 tail;
 	} m_index = {};
 
+	struct
+	{
+		GSVertex* buff;
+		u32 head, tail, next, maxcount; // head: first vertex, tail: last vertex + 1, next: last indexed + 1
+		u32 xy_tail;
+		GSVector4i xy[4];
+		GSVector4i xyhead;
+	} m_draw_vertex = {};
+
+	struct
+	{
+		u16* buff;
+		u32 tail;
+	} m_draw_index = {};
+
 	void UpdateContext();
 	void UpdateScissor();
 
@@ -225,6 +240,8 @@ public:
 	bool m_isPackedUV_HackFlag = false;
 	bool m_channel_shuffle = false;
 	bool m_in_target_draw = false;
+	bool m_channel_shuffle_abort = false;
+
 	u32 m_target_offset = 0;
 	u8 m_scanmask_used = 0;
 	u32 m_dirty_gs_regs = 0;

--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -323,6 +323,8 @@ public:
 			int FBP;
 			int FBW;
 			int PSM;
+			int DBY;
+			int DBX;
 			GSRegDISPFB prevFramebufferReg;
 			GSVector2i prevDisplayOffset;
 			GSVector2i displayOffset;

--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -239,6 +239,8 @@ public:
 	bool m_texflush_flag = false;
 	bool m_isPackedUV_HackFlag = false;
 	bool m_channel_shuffle = false;
+	bool m_using_temp_z = false;
+	bool m_temp_z_full_copy = false;
 	bool m_in_target_draw = false;
 	bool m_channel_shuffle_abort = false;
 

--- a/pcsx2/GS/GSVector4i.h
+++ b/pcsx2/GS/GSVector4i.h
@@ -1599,6 +1599,11 @@ public:
 		return loadh(&v);
 	}
 
+	__forceinline static GSVector4i loadl(const GSVector2i& v)
+	{
+		return loadl(&v);
+	}
+
 	__forceinline static GSVector4i load(const void* pl, const void* ph)
 	{
 		return loadh(ph, loadl(pl));

--- a/pcsx2/GS/Renderers/Common/GSRenderer.cpp
+++ b/pcsx2/GS/Renderers/Common/GSRenderer.cpp
@@ -87,10 +87,6 @@ bool GSRenderer::Merge(int field)
 	int y_offset[3] = { 0, 0, 0 };
 	const bool feedback_merge = m_regs->EXTWRITE.WRITE == 1;
 
-	PCRTCDisplays.SetVideoMode(GetVideoMode());
-	PCRTCDisplays.EnableDisplays(m_regs->PMODE, m_regs->SMODE2, isReallyInterlaced());
-	PCRTCDisplays.CheckSameSource();
-
 	if (!PCRTCDisplays.PCRTCDisplays[0].enabled && !PCRTCDisplays.PCRTCDisplays[1].enabled)
 	{
 		m_real_size = GSVector2i(0, 0);
@@ -100,11 +96,6 @@ bool GSRenderer::Merge(int field)
 	// Need to do this here, if the user has Anti-Blur enabled, these offsets can get wiped out/changed.
 	const bool game_deinterlacing = (m_regs->DISP[0].DISPFB.DBY != PCRTCDisplays.PCRTCDisplays[0].prevFramebufferReg.DBY) !=
 									(m_regs->DISP[1].DISPFB.DBY != PCRTCDisplays.PCRTCDisplays[1].prevFramebufferReg.DBY);
-
-	PCRTCDisplays.SetRects(0, m_regs->DISP[0].DISPLAY, m_regs->DISP[0].DISPFB);
-	PCRTCDisplays.SetRects(1, m_regs->DISP[1].DISPLAY, m_regs->DISP[1].DISPFB);
-	PCRTCDisplays.CalculateDisplayOffset(m_scanmask_used);
-	PCRTCDisplays.CalculateFramebufferOffset(m_scanmask_used);
 
 	// Only need to check the right/bottom on software renderer, hardware always gets the full texture then cuts a bit out later.
 	if (PCRTCDisplays.FrameRectMatch() && !PCRTCDisplays.FrameWrap() && !feedback_merge)

--- a/pcsx2/GS/Renderers/HW/GSHwHack.cpp
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.cpp
@@ -248,19 +248,25 @@ bool GSHwHack::GSC_Tekken5(GSRendererHW& r, int& skip)
 
 		if (!s_nativeres && r.PRIM->PRIM == GS_SPRITE && RTME && RTEX0.TFX == 1 && RFPSM == RTPSM && RTPSM == PSMCT32 && RFBMSK == 0xFF000000 && r.m_index.tail > 2)
 		{
+			GSVertex* v = &r.m_vertex.buff[0];
 			// Don't enable hack on native res.
 			// Fixes ghosting/blur effect and white lines appearing in stages: Moonfit Wilderness, Acid Rain - caused by upscaling.
 			// Game copies the framebuffer as individual page rects with slight offsets (like 1/16 of a pixel etc) which doesn't wokr well with upscaling.
 			// This should catch all the scenarios, maybe overdoes it, but it's for 1 game and it's non-detrimental, it's better than squares all over the screen.
-			const GSVector4i draw_size(r.m_vt.m_min.p.x, r.m_vt.m_min.p.y, r.m_vt.m_max.p.x + 1.0f, r.m_vt.m_max.p.y + 1.0f);
-			const GSVector4i read_size(r.m_vt.m_min.t.x, r.m_vt.m_min.t.y, r.m_vt.m_max.t.x + 0.5f, r.m_vt.m_max.t.y + 0.5f);
-			r.ReplaceVerticesWithSprite(draw_size, read_size, GSVector2i(read_size.width(), read_size.height()), draw_size);
-		}
-		else if (RZTST == 1 && RTME && (RFBP == 0x02bc0 || RFBP == 0x02be0 || RFBP == 0x02d00 || RFBP == 0x03480 || RFBP == 0x034a0) && RFPSM == RTPSM && RTBP0 == 0x00000 && RTPSM == PSMCT32)
-		{
-			// The moving display effect(flames) is not emulated properly in the entire screen so let's remove the effect in the stage: Burning Temple. Related to half screen bottom issue.
-			// Fixes black lines in the stage: Burning Temple - caused by upscaling. Note the black lines can also be fixed with Merge Sprite hack.
-			skip = 2;
+			if (v[0].XYZ.X & 0xF)
+			{
+				const GSVector4i draw_size(r.m_vt.m_min.p.x, r.m_vt.m_min.p.y, r.m_vt.m_max.p.x + 1.0f, r.m_vt.m_max.p.y + 1.0f);
+				const GSVector4i read_size(r.m_vt.m_min.t.x, r.m_vt.m_min.t.y, r.m_vt.m_max.t.x + 0.5f, r.m_vt.m_max.t.y + 0.5f);
+				r.ReplaceVerticesWithSprite(draw_size, read_size, GSVector2i(read_size.width(), read_size.height()), draw_size);
+			}
+			else
+			{
+				// Fixes the alignment of the two halves for the heat haze on the temple stage.
+				for (int i = 0; i < r.m_index.tail; i+=2)
+				{
+					v[i].XYZ.Y -= 0x8;
+				}
+			}
 		}
 	}
 

--- a/pcsx2/GS/Renderers/HW/GSHwHack.cpp
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.cpp
@@ -1145,7 +1145,7 @@ bool GSHwHack::OI_SonicUnleashed(GSRendererHW& r, GSTexture* rt, GSTexture* ds, 
 
 	const GSVector4 sRect(0.0f, 0.0f, static_cast<float>(copy_size.x) / static_cast<float>(src_size.x), static_cast<float>(copy_size.y) / static_cast<float>(src_size.y));
 	// This is kind of a bodge because the game confuses everything since the source is really 16bit and it assumes it's really drawing 16bit on the copy back, resizing the target.
-	const GSVector4 dRect(0, 0, copy_size.x, copy_size.y * (src->m_32_bits_fmt ? 1 : 2));
+	const GSVector4 dRect(0, 0, copy_size.x, copy_size.y);
 
 	g_gs_device->StretchRect(src->m_texture, sRect, rt, dRect, true, true, true, false);
 

--- a/pcsx2/GS/Renderers/HW/GSHwHack.cpp
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.cpp
@@ -1004,6 +1004,10 @@ bool GSHwHack::OI_PointListPalette(GSRendererHW& r, GSTexture* rt, GSTexture* ds
 		&& r.m_cached_ctx.FRAME.FBMSK == 0 // No frame buffer masking.
 	)
 	{
+		int mask = (r.m_vt.m_max.p.xyxy() == r.m_vt.m_min.p.xyxy()).mask();
+		if (mask == 0xf)
+			return true;
+
 		const u32 FBP = r.m_cached_ctx.FRAME.Block();
 		const u32 FBW = r.m_cached_ctx.FRAME.FBW;
 		GL_INS("PointListPalette - m_r = <%d, %d => %d, %d>, n_vertices = %u, FBP = 0x%x, FBW = %u", r.m_r.x, r.m_r.y, r.m_r.z, r.m_r.w, n_vertices, FBP, FBW);

--- a/pcsx2/GS/Renderers/HW/GSHwHack.cpp
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.cpp
@@ -1099,7 +1099,7 @@ bool GSHwHack::OI_SonicUnleashed(GSRendererHW& r, GSTexture* rt, GSTexture* ds, 
 	// compute shadow in RG,
 	// save result in alpha with a TS,
 	// Restore RG channel that we previously copied to render shadows.
-
+	// Important note: The game downsizes the target to half height, then later expands it back up to full size, that's why PCSX2 doesn't like it, we don't support that behaviour.
 	const GIFRegTEX0& Texture = RTEX0;
 
 	GIFRegTEX0 Frame = {};
@@ -1110,9 +1110,9 @@ bool GSHwHack::OI_SonicUnleashed(GSRendererHW& r, GSTexture* rt, GSTexture* ds, 
 	if ((!rt) || (!RPRIM->TME) || (GSLocalMemory::m_psm[Texture.PSM].bpp != 16) || (GSLocalMemory::m_psm[Frame.PSM].bpp != 16) || (Texture.TBP0 == Frame.TBP0) || (Frame.TBW != 16 && Texture.TBW != 16))
 		return true;
 
-	GL_INS("OI_SonicUnleashed replace draw by a copy");
+	GL_INS("OI_SonicUnleashed replace draw by a copy draw %d", r.s_n);
 
-	GSTextureCache::Target* src = g_texture_cache->LookupTarget(Texture, GSVector2i(1, 1), r.GetTextureScaleFactor(), GSTextureCache::RenderTarget);
+	GSTextureCache::Target* src = g_texture_cache->LookupTarget(Texture, GSVector2i(1, 1), r.GetTextureScaleFactor(), GSTextureCache::RenderTarget, true, 0, false, false, true, true, GSVector4i::zero(), true);
 
 	if (!src)
 		return true;

--- a/pcsx2/GS/Renderers/HW/GSHwHack.cpp
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.cpp
@@ -1142,43 +1142,6 @@ bool GSHwHack::OI_BurnoutGames(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GS
 	return false;
 }
 
-bool GSHwHack::GSC_Battlefield2(GSRendererHW& r, int& skip)
-{
-	if (skip == 0)
-	{
-		if (RZBP >= RFBP && RFBP >= 0x2000 && RZBP >= 0x2700 && ((RZBP - RFBP) == 0x700))
-		{
-			skip = 7;
-
-			GIFRegTEX0 TEX0 = {};
-			TEX0.TBP0 = RFBP;
-			TEX0.TBW = 8;
-			GSTextureCache::Target* dst = g_texture_cache->LookupTarget(TEX0, r.GetTargetSize(), r.GetTextureScaleFactor(), GSTextureCache::DepthStencil);
-			if (dst)
-			{
-				g_gs_device->ClearDepth(dst->m_texture, 0.0f);
-			}
-		}
-	}
-
-	return true;
-}
-
-bool GSHwHack::OI_Battlefield2(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t)
-{
-	if (!RPRIM->TME || RFRAME.Block() > 0xD00 || RTEX0.TBP0 > 0x1D00)
-		return true;
-
-	if (rt && t && RFRAME.Block() == 0 && RTEX0.TBP0 == 0x1000)
-	{
-		const GSVector4i rc(0, 0, std::min(rt->GetWidth(), t->m_texture->GetWidth()), std::min(rt->GetHeight(), t->m_texture->GetHeight()));
-		g_gs_device->CopyRect(t->m_texture, rt, rc, 0, 0);
-	}
-
-	g_texture_cache->InvalidateTemporarySource();
-	return false;
-}
-
 bool GSHwHack::OI_HauntingGround(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t)
 {
 	// Haunting Ground clears two targets by doing a direct colour write at 0x3000, covering a target at 0x3380.
@@ -1474,7 +1437,6 @@ const GSHwHack::Entry<GSRendererHW::GSC_Ptr> GSHwHack::s_get_skip_count_function
 	CRC_F(GSC_ZettaiZetsumeiToshi2),
 	CRC_F(GSC_BlackAndBurnoutSky),
 	CRC_F(GSC_BlueTongueGames),
-	CRC_F(GSC_Battlefield2),
 	CRC_F(GSC_NFSUndercover),
 	CRC_F(GSC_PolyphonyDigitalGames),
 	CRC_F(GSC_MetalGearSolid3),
@@ -1500,7 +1462,6 @@ const GSHwHack::Entry<GSRendererHW::OI_Ptr> GSHwHack::s_before_draw_functions[] 
 	CRC_F(OI_SonicUnleashed),
 	CRC_F(OI_ArTonelico2),
 	CRC_F(OI_BurnoutGames),
-	CRC_F(OI_Battlefield2),
 	CRC_F(OI_HauntingGround),
 };
 

--- a/pcsx2/GS/Renderers/HW/GSHwHack.cpp
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.cpp
@@ -1144,7 +1144,8 @@ bool GSHwHack::OI_SonicUnleashed(GSRendererHW& r, GSTexture* rt, GSTexture* ds, 
 	const GSVector2i copy_size(std::min(rt_size.x, src_size.x), std::min(rt_size.y, src_size.y));
 
 	const GSVector4 sRect(0.0f, 0.0f, static_cast<float>(copy_size.x) / static_cast<float>(src_size.x), static_cast<float>(copy_size.y) / static_cast<float>(src_size.y));
-	const GSVector4 dRect(0, 0, copy_size.x, copy_size.y);
+	// This is kind of a bodge because the game confuses everything since the source is really 16bit and it assumes it's really drawing 16bit on the copy back, resizing the target.
+	const GSVector4 dRect(0, 0, copy_size.x, copy_size.y * (src->m_32_bits_fmt ? 1 : 2));
 
 	g_gs_device->StretchRect(src->m_texture, sRect, rt, dRect, true, true, true, false);
 

--- a/pcsx2/GS/Renderers/HW/GSHwHack.cpp
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.cpp
@@ -936,7 +936,7 @@ bool GSHwHack::OI_PointListPalette(GSRendererHW& r, GSTexture* rt, GSTexture* ds
 		&& r.m_cached_ctx.FRAME.FBMSK == 0 // No frame buffer masking.
 	)
 	{
-		int mask = (r.m_vt.m_max.p.xyxy() == r.m_vt.m_min.p.xyxy()).mask();
+		const int mask = (r.m_vt.m_max.p.xyxy() == r.m_vt.m_min.p.xyxy()).mask();
 		if (mask == 0xf)
 			return true;
 

--- a/pcsx2/GS/Renderers/HW/GSHwHack.cpp
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.cpp
@@ -131,6 +131,22 @@ bool GSHwHack::GSC_SacredBlaze(GSRendererHW& r, int& skip)
 	return true;
 }
 
+bool GSHwHack::GSC_GuitarHero(GSRendererHW& r, int& skip)
+{
+	// Crowd sprite generation is a mess, better done in software.
+	if (skip == 0)
+	{
+		if (RTBW <= 4 && RTME && RFBW <= 4 && (r.m_context->TEX1.MMIN & 1) == 0)
+		{
+			r.ClearGSLocalMemory(r.m_context->offset.zb, r.m_r, 0);
+			r.SwPrimRender(r, RFBP != 0x2DC0, false);
+			skip = 1;
+		}
+	}
+
+	return true;
+}
+
 bool GSHwHack::GSC_SFEX3(GSRendererHW& r, int& skip)
 {
 	if (skip == 0)
@@ -1531,6 +1547,7 @@ const GSHwHack::Entry<GSRendererHW::GSC_Ptr> GSHwHack::s_get_skip_count_function
 	CRC_F(GSC_Manhunt2),
 	CRC_F(GSC_MidnightClub3),
 	CRC_F(GSC_SacredBlaze),
+	CRC_F(GSC_GuitarHero),
 	CRC_F(GSC_SakuraWarsSoLongMyLove),
 	CRC_F(GSC_Simple2000Vol114),
 	CRC_F(GSC_SFEX3),

--- a/pcsx2/GS/Renderers/HW/GSHwHack.h
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.h
@@ -25,7 +25,6 @@ public:
 	static bool GSC_UrbanReign(GSRendererHW& r, int& skip);
 	static bool GSC_SteambotChronicles(GSRendererHW& r, int& skip);
 	static bool GSC_BlueTongueGames(GSRendererHW& r, int& skip);
-	static bool GSC_Battlefield2(GSRendererHW& r, int& skip);
 	static bool GSC_NFSUndercover(GSRendererHW& r, int& skip);
 	static bool GSC_PolyphonyDigitalGames(GSRendererHW& r, int& skip);
 	static bool GSC_MetalGearSolid3(GSRendererHW& r, int& skip);
@@ -37,7 +36,6 @@ public:
 	static bool OI_SonicUnleashed(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
 	static bool OI_ArTonelico2(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
 	static bool OI_BurnoutGames(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
-	static bool OI_Battlefield2(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
 	static bool OI_HauntingGround(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
 
 	static bool MV_Growlanser(GSRendererHW& r);

--- a/pcsx2/GS/Renderers/HW/GSHwHack.h
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.h
@@ -10,6 +10,7 @@ public:
 	static bool GSC_GiTS(GSRendererHW& r, int& skip);
 	static bool GSC_Manhunt2(GSRendererHW& r, int& skip);
 	static bool GSC_SacredBlaze(GSRendererHW& r, int& skip);
+	static bool GSC_GuitarHero(GSRendererHW& r, int& skip);
 	static bool GSC_SFEX3(GSRendererHW& r, int& skip);
 	static bool GSC_DTGames(GSRendererHW& r, int& skip);
 	static bool GSC_Tekken5(GSRendererHW& r, int& skip);

--- a/pcsx2/GS/Renderers/HW/GSHwHack.h
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.h
@@ -26,6 +26,7 @@ public:
 	static bool GSC_SteambotChronicles(GSRendererHW& r, int& skip);
 	static bool GSC_BlueTongueGames(GSRendererHW& r, int& skip);
 	static bool GSC_NFSUndercover(GSRendererHW& r, int& skip);
+	static bool GSC_Battlefield2(GSRendererHW& r, int& skip);
 	static bool GSC_PolyphonyDigitalGames(GSRendererHW& r, int& skip);
 	static bool GSC_MetalGearSolid3(GSRendererHW& r, int& skip);
 	static bool GSC_HitmanBloodMoney(GSRendererHW& r, int& skip);

--- a/pcsx2/GS/Renderers/HW/GSHwHack.h
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.h
@@ -6,8 +6,6 @@
 class GSHwHack
 {
 public:
-	static bool GSC_DeathByDegreesTekkenNinaWilliams(GSRendererHW& r, int& skip);
-	static bool GSC_GiTS(GSRendererHW& r, int& skip);
 	static bool GSC_Manhunt2(GSRendererHW& r, int& skip);
 	static bool GSC_SacredBlaze(GSRendererHW& r, int& skip);
 	static bool GSC_GuitarHero(GSRendererHW& r, int& skip);
@@ -31,7 +29,6 @@ public:
 	static bool GSC_NFSUndercover(GSRendererHW& r, int& skip);
 	static bool GSC_PolyphonyDigitalGames(GSRendererHW& r, int& skip);
 	static bool GSC_MetalGearSolid3(GSRendererHW& r, int& skip);
-	static bool GSC_BigMuthaTruckers(GSRendererHW& r, int& skip);
 	static bool GSC_HitmanBloodMoney(GSRendererHW& r, int& skip);
 
 	static bool OI_PointListPalette(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -1252,10 +1252,14 @@ bool GSRendererHW::IsSplitTextureShuffle(GIFRegTEX0& rt_TEX0, GSVector4i& valid_
 
 	const GSLocalMemory::psm_t& frame_psm = GSLocalMemory::m_psm[m_cached_ctx.FRAME.PSM];
 	const GSDrawingContext& next_ctx = m_env.CTXT[m_backed_up_ctx];
+
+	// Also don't allow pag sized shuffles when we have RT inside RT, we handle this manually. See Peter Jackson's - King Kong.
+	const bool in_rt_per_page = GSConfig.UserHacks_TextureInsideRt >= GSTextureInRtMode::InsideTargets && (pos_rc.width() <= frame_psm.pgs.x && pos_rc.height() <= frame_psm.pgs.y);
+
 	// Y should be page aligned. X should be too, but if it's doing a copy with a shuffle (which is kinda silly), both the
 	// position and coordinates may be offset by +8. See Psi-Ops - The Mindgate Conspiracy.
 	if ((aligned_rc.x & 7) != 0 || aligned_rc.x > 8 || (aligned_rc.z & 7) != 0 ||
-		aligned_rc.y != 0 || (aligned_rc.w & (frame_psm.pgs.y - 1)) != 0)
+		aligned_rc.y != 0 || (aligned_rc.w & (frame_psm.pgs.y - 1)) != 0 || in_rt_per_page)
 	{
 		return false;
 	}

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -1029,6 +1029,12 @@ GSVector2i GSRendererHW::GetValidSize(const GSTextureCache::Source* tex)
 	// e.g. Burnout 3, God of War II, etc.
 	int height = std::min<int>(m_context->scissor.in.w, m_r.w);
 
+	// We can check if the next draw is doing the same from the next page, and assume it's a per line clear.
+	// Battlefield 2 does this.
+	int pages = ((GSLocalMemory::GetEndBlockAddress(m_cached_ctx.FRAME.Block(), m_cached_ctx.FRAME.FBW, m_cached_ctx.FRAME.PSM, m_r) + 1) - m_cached_ctx.FRAME.Block()) >> 5;
+	if (m_cached_ctx.FRAME.FBW > 1 && m_r.height() <= 64 && (pages % m_cached_ctx.FRAME.FBW) == 0 && m_env.CTXT[m_backed_up_ctx].FRAME.FBP == (m_cached_ctx.FRAME.FBP + pages) && NextDrawMatchesShuffle())
+		height = std::max<int>(m_context->scissor.in.w, height);
+
 	// If the draw is less than a page high, FBW=0 is the same as FBW=1.
 	const GSLocalMemory::psm_t& frame_psm = GSLocalMemory::m_psm[m_cached_ctx.FRAME.PSM];
 	int width = std::min(std::max<int>(m_cached_ctx.FRAME.FBW, 1) * 64, m_context->scissor.in.z);

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -2187,8 +2187,12 @@ void GSRendererHW::Draw()
 
 		if (m_channel_shuffle)
 		{
-			m_last_channel_shuffle_fbp = m_context->FRAME.Block();
-			m_last_channel_shuffle_tbp = m_context->TEX0.TBP0;
+			// These HLE's skip several channel shuffles in a row which change blends etc. Let's not break the flow, it gets upset.
+			if (!m_conf.ps.urban_chaos_hle && !m_conf.ps.tales_of_abyss_hle)
+			{
+				m_last_channel_shuffle_fbp = m_context->FRAME.Block();
+				m_last_channel_shuffle_tbp = m_context->TEX0.TBP0;
+			}
 
 			num_skipped_channel_shuffle_draws++;
 			return;

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -5860,7 +5860,8 @@ __ri void GSRendererHW::HandleTextureHazards(const GSTextureCache::Target* rt, c
 		GL_CACHE("Source is render target, taking copy.");
 		src_target = rt;
 	}
-	else if (ds && m_conf.tex == m_conf.ds)
+	// Be careful of single page channel shuffles where depth is the source but it's not going to the same place, we can't read this directly.
+	else if (ds && m_conf.tex == m_conf.ds && (!m_channel_shuffle || static_cast<int>(m_cached_ctx.FRAME.Block() - rt->m_TEX0.TBP0) ==  static_cast<int>(m_cached_ctx.ZBUF.Block() - ds->m_TEX0.TBP0)))
 	{
 		// GL, Vulkan (in General layout), not DirectX!
 		const bool can_read_current_depth_buffer = g_gs_device->Features().test_and_sample_depth;

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -3109,8 +3109,8 @@ void GSRendererHW::Draw()
 		// Normally we would use 1024 here to match the clear above, but The Godfather does a 1023x1023 draw instead
 		// (very close to 1024x1024, but apparently the GS rounds down..). So, catch that here, we don't want to
 		// create that target, because the clear isn't black, it'll hang around and never get invalidated.
-		const bool is_square = (t_size.y == t_size.x) && m_r.w >= 1023 && m_primitive_covers_without_gaps == NoGapsType::FullCover;
-		const bool is_clear = is_possible_mem_clear && is_square;
+		const bool is_large_rect = (t_size.y >= t_size.x) && m_r.w >= 1023 && m_primitive_covers_without_gaps == NoGapsType::FullCover;
+		const bool is_clear = is_possible_mem_clear && is_large_rect;
 
 		// Preserve downscaled target when copying directly from a downscaled target, or it's a normal draw using a downscaled target. Clears that are drawing to the target can also preserve size.
 		// Of course if this size is different (in width) or this is a shuffle happening, this will be bypassed.
@@ -3119,7 +3119,7 @@ void GSRendererHW::Draw()
 		rt = g_texture_cache->LookupTarget(FRAME_TEX0, t_size, ((src && src->m_scale != 1) && GSConfig.UserHacks_NativeScaling == GSNativeScaling::Normal && !possible_shuffle) ? GetTextureScaleFactor() : target_scale, GSTextureCache::RenderTarget, true,
 			fm, false, force_preload, preserve_rt_rgb, preserve_rt_alpha, lookup_rect, possible_shuffle, is_possible_mem_clear && FRAME_TEX0.TBP0 != m_cached_ctx.ZBUF.Block(),
 			GSConfig.UserHacks_NativeScaling != GSNativeScaling::Off && preserve_downscale_draw && is_possible_mem_clear != ClearType::NormalClear, src, ds, (no_ds || !ds) ? -1 : (m_cached_ctx.ZBUF.Block() - ds->m_TEX0.TBP0));
-		 
+
 		// Draw skipped because it was a clear and there was no target.
 		if (!rt)
 		{
@@ -3785,6 +3785,7 @@ void GSRendererHW::Draw()
 			// Limit to 2x the vertical height of the resolution (for double buffering)
 			rt->UpdateValidity(update_rect, !frame_masked && (rt_update || (m_r.w <= (resolution.y * 2) && !m_texture_shuffle)));
 			rt->UpdateDrawn(update_rect, !frame_masked && (rt_update || (m_r.w <= (resolution.y * 2) && !m_texture_shuffle)));
+
 			// Probably changing to double buffering, so invalidate any old target that was next to it.
 			// This resolves an issue where the PCRTC will find the old target in FMV's causing flashing.
 			// Grandia Xtreme, Onimusha Warlord.
@@ -3833,7 +3834,7 @@ void GSRendererHW::Draw()
 			const bool z_masked = m_cached_ctx.ZBUF.ZMSK;
 
 			ds->UpdateValidity(m_r, !z_masked && (can_update_size || m_r.w <= (resolution.y * 2)));
-			ds->UpdateDrawn(m_r,  !z_masked && (can_update_size || m_r.w <= (resolution.y * 2)));
+			ds->UpdateDrawn(m_r, !z_masked && (can_update_size || m_r.w <= (resolution.y * 2)));
 
 			if (!new_rect && new_height && old_end_block != ds->m_end_block)
 			{

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -339,7 +339,7 @@ void GSRendererHW::ConvertSpriteTextureShuffle(u32& process_rg, u32& process_ba,
 	tex_pos &= 0xFF;
 	shuffle_across = (((tex_pos + 8) >> 4) ^ ((pos + 8) >> 4)) & 0x8;
 
-	const bool full_width = !shuffle_across && ((second_vert.XYZ.X - first_vert.XYZ.X) >> 4) >= 16 && m_r.width() > 8;
+	const bool full_width = ((second_vert.XYZ.X - first_vert.XYZ.X) >> 4) >= 16 && m_r.width() > 8;
 	process_ba = ((pos > 112 && pos < 136) || full_width) ? SHUFFLE_WRITE : 0;
 	process_rg = (!process_ba || full_width) ? SHUFFLE_WRITE : 0;
 	// "same group" means it can read blue and write alpha using C32 tricks
@@ -482,7 +482,7 @@ void GSRendererHW::ConvertSpriteTextureShuffle(u32& process_rg, u32& process_ba,
 			// Dogs will reuse the Z in a different size format for a completely unrelated draw with an FBW of 2, then go back to using it in full width
 			const bool size_is_wrong = tex->m_target ? (static_cast<int>(tex->m_from_target_TEX0.TBW * 64) < tex->m_from_target->m_valid.z / 2) : false;
 			const u32 draw_page_width = std::max(static_cast<int>(m_vt.m_max.p.x + (!(process_ba & SHUFFLE_WRITE) ? 8.9f : 0.9f)) / 64, 1);
-			const bool single_direction_doubled = (m_vt.m_max.p.y > rt->m_valid.w) != (m_vt.m_max.p.x > rt->m_valid.z);
+			const bool single_direction_doubled = (m_vt.m_max.p.y > rt->m_valid.w) != (m_vt.m_max.p.x > rt->m_valid.z) || (IsSinglePageDraw() && m_r.height() > 32);
 
 			if (size_is_wrong || (rt && ((rt->m_TEX0.TBW % draw_page_width) == 0 || single_direction_doubled)))
 			{
@@ -579,6 +579,14 @@ void GSRendererHW::ConvertSpriteTextureShuffle(u32& process_rg, u32& process_ba,
 					v[i + reversed_U].U -= 128u;
 				else
 					v[i + 1 - reversed_U].U += 128u;
+			}
+			else
+			{
+				if (((pos + 8) >> 4) & 0x8)
+				{
+					v[i + reversed_pos].XYZ.X -= 128u;
+					v[i + 1 - reversed_pos].XYZ.X -= 128u;
+				}
 			}
 
 			if (half_bottom_vert)
@@ -695,6 +703,14 @@ void GSRendererHW::ConvertSpriteTextureShuffle(u32& process_rg, u32& process_ba,
 				m_vt.m_min.t.x -= 8.0f;
 			else
 				m_vt.m_max.t.x += 8.0f;
+		}
+	}
+	else
+	{
+		if (fmod(std::floor(m_vt.m_min.p.x), 64.0f) == 8.0f)
+		{
+			m_vt.m_min.p.x -= 8.0f;
+			m_vt.m_max.p.x -= 8.0f;
 		}
 	}
 
@@ -976,7 +992,7 @@ GSVector2i GSRendererHW::GetValidSize(const GSTextureCache::Source* tex)
 	}
 
 	// If it's a channel shuffle, it'll likely be just a single page, so assume full screen.
-	if (m_channel_shuffle)
+	if (m_channel_shuffle || (tex && IsPageCopy()))
 	{
 		const int page_x = frame_psm.pgs.x - 1;
 		const int page_y = frame_psm.pgs.y - 1;
@@ -1111,6 +1127,25 @@ bool GSRendererHW::IsPossibleChannelShuffle() const
 	}
 
 	return false;
+}
+
+bool GSRendererHW::IsPageCopy() const
+{
+	if (!PRIM->TME)
+		return false;
+
+	const GSDrawingContext& next_ctx = m_env.CTXT[m_backed_up_ctx];
+
+	if (next_ctx.TEX0.TBP0 != (m_cached_ctx.TEX0.TBP0 + 0x20))
+		return false;
+
+	if (next_ctx.FRAME.FBP != (m_cached_ctx.FRAME.FBP + 0x1))
+		return false;
+
+	if (!NextDrawMatchesShuffle())
+		return false;
+
+	return true;
 }
 
 bool GSRendererHW::NextDrawMatchesShuffle() const
@@ -1268,6 +1303,16 @@ GSVector4i GSRendererHW::GetDrawRectForPages(u32 bw, u32 psm, u32 num_pages)
 	const GSVector2i& pgs = GSLocalMemory::m_psm[psm].pgs;
 	const GSVector2i size = GSVector2i(static_cast<int>(bw) * pgs.x, static_cast<int>(num_pages / std::max(1U, bw)) * pgs.y);
 	return GSVector4i::loadh(size);
+}
+
+bool GSRendererHW::IsSinglePageDraw() const
+{
+	const GSVector2i& frame_pgs = GSLocalMemory::m_psm[m_cached_ctx.FRAME.PSM].pgs;
+
+	if (m_r.width() <= frame_pgs.x && m_r.height() <= frame_pgs.y)
+		return true;
+
+	return false;
 }
 
 bool GSRendererHW::TryToResolveSinglePageFramebuffer(GIFRegFRAME& FRAME, bool only_next_draw)
@@ -1680,7 +1725,11 @@ void GSRendererHW::Move()
 
 	const int w = m_env.TRXREG.RRW;
 	const int h = m_env.TRXREG.RRH;
-
+	GL_CACHE("Starting Move! 0x%x W:%d F:%s => 0x%x W:%d F:%s (DIR %d%d), sPos(%d %d) dPos(%d %d) size(%d %d) draw %d",
+		m_env.BITBLTBUF.SBP, m_env.BITBLTBUF.SBW, psm_str(m_env.BITBLTBUF.SPSM),
+		m_env.BITBLTBUF.DBP, m_env.BITBLTBUF.DBW, psm_str(m_env.BITBLTBUF.DPSM),
+		m_env.TRXPOS.DIRX, m_env.TRXPOS.DIRY,
+		sx, sy, dx, dy, w, h, s_n);
 	if (g_texture_cache->Move(m_env.BITBLTBUF.SBP, m_env.BITBLTBUF.SBW, m_env.BITBLTBUF.SPSM, sx, sy,
 			m_env.BITBLTBUF.DBP, m_env.BITBLTBUF.DBW, m_env.BITBLTBUF.DPSM, dx, dy, w, h))
 	{
@@ -2661,7 +2710,7 @@ void GSRendererHW::Draw()
 				FRAME_TEX0.PSM = m_cached_ctx.FRAME.PSM;
 
 				GSTextureCache::Target* tgt = g_texture_cache->LookupTarget(FRAME_TEX0, GSVector2i(m_vt.m_max.p.x, m_vt.m_max.p.y), GetTextureScaleFactor(), GSTextureCache::RenderTarget, false,
-					fm);
+					fm, false, false, false, false, GSVector4i::zero(), true);
 
 				if (tgt)
 					shuffle_target = tgt->m_32_bits_fmt;
@@ -2753,14 +2802,11 @@ void GSRendererHW::Draw()
 	const bool can_expand = !(m_cached_ctx.ZBUF.ZMSK && output_black);
 
 	// Estimate size based on the scissor rectangle and height cache.
-	const GSVector2i t_size = GetTargetSize(src, can_expand);
+	GSVector2i t_size = GetTargetSize(src, can_expand);
 	const GSVector4i t_size_rect = GSVector4i::loadh(t_size);
 
 	// Ensure draw rect is clamped to framebuffer size. Necessary for updating valid area.
 	const GSVector4i unclamped_draw_rect = m_r;
-	// Don't clamp on shuffle, the height cache may troll us with the REAL height.
-	if (!m_texture_shuffle && m_split_texture_shuffle_pages == 0)
-		m_r = m_r.rintersect(t_size_rect);
 
 	float target_scale = GetTextureScaleFactor();
 	int scale_draw = IsScalingDraw(src, m_primitive_covers_without_gaps != NoGapsType::GapsFound);
@@ -2817,6 +2863,10 @@ void GSRendererHW::Draw()
 
 	GSTextureCache::Target* rt = nullptr;
 	GIFRegTEX0 FRAME_TEX0;
+	const GSLocalMemory::psm_t& frame_psm = GSLocalMemory::m_psm[m_cached_ctx.FRAME.PSM];
+
+	m_in_target_draw = false;
+
 	if (!no_rt)
 	{
 		// FBW is going to be wrong for channel shuffling into a new target, so take it from the source.
@@ -2825,21 +2875,28 @@ void GSRendererHW::Draw()
 		FRAME_TEX0.TBW = (m_channel_shuffle && src->m_target) ? src->m_from_target_TEX0.TBW : m_cached_ctx.FRAME.FBW;
 		FRAME_TEX0.PSM = m_cached_ctx.FRAME.PSM;
 
+		const bool possible_shuffle = draw_sprite_tex && (((src && src->m_target && src->m_from_target && src->m_from_target->m_32_bits_fmt) &&
+															  GSLocalMemory::m_psm[m_cached_ctx.TEX0.PSM].bpp == 16 && GSLocalMemory::m_psm[m_cached_ctx.FRAME.PSM].bpp == 16) ||
+															 IsPossibleChannelShuffle());
+		// Don't clamp on shuffle, the height cache may troll us with the REAL height.
+		if (!possible_shuffle && m_split_texture_shuffle_pages == 0)
+			m_r = m_r.rintersect(t_size_rect);
+		
 		// Normally we would use 1024 here to match the clear above, but The Godfather does a 1023x1023 draw instead
 		// (very close to 1024x1024, but apparently the GS rounds down..). So, catch that here, we don't want to
 		// create that target, because the clear isn't black, it'll hang around and never get invalidated.
 		const bool is_square = (t_size.y == t_size.x) && m_r.w >= 1023 && m_primitive_covers_without_gaps == NoGapsType::FullCover;
 		const bool is_clear = is_possible_mem_clear && is_square;
-		const bool possible_shuffle = draw_sprite_tex && (((src && src->m_target && src->m_from_target && src->m_from_target->m_32_bits_fmt) &&
-															  GSLocalMemory::m_psm[m_cached_ctx.TEX0.PSM].bpp == 16 && GSLocalMemory::m_psm[m_cached_ctx.FRAME.PSM].bpp == 16) ||
-															 IsPossibleChannelShuffle());
 
 		// Preserve downscaled target when copying directly from a downscaled target, or it's a normal draw using a downscaled target. Clears that are drawing to the target can also preserve size.
 		// Of course if this size is different (in width) or this is a shuffle happening, this will be bypassed.
 		const bool preserve_downscale_draw = std::abs(scale_draw) == 1 || (scale_draw == 0 && ((src && src->m_from_target && src->m_from_target->m_downscaled) || is_possible_mem_clear == ClearType::ClearWithDraw));
 
+		m_in_target_draw = false;
+		
 		rt = g_texture_cache->LookupTarget(FRAME_TEX0, t_size, ((src && src->m_scale != 1) && GSConfig.UserHacks_NativeScaling == GSNativeScaling::Normal && !possible_shuffle) ? GetTextureScaleFactor() : target_scale, GSTextureCache::RenderTarget, true,
-			fm, false, force_preload, preserve_rt_rgb, preserve_rt_alpha, unclamped_draw_rect, possible_shuffle, is_possible_mem_clear && FRAME_TEX0.TBP0 != m_cached_ctx.ZBUF.Block(), GSConfig.UserHacks_NativeScaling != GSNativeScaling::Off && preserve_downscale_draw && is_possible_mem_clear != ClearType::NormalClear);
+			fm, false, force_preload, preserve_rt_rgb, preserve_rt_alpha, unclamped_draw_rect, possible_shuffle, is_possible_mem_clear && FRAME_TEX0.TBP0 != m_cached_ctx.ZBUF.Block(),
+			GSConfig.UserHacks_NativeScaling != GSNativeScaling::Off && preserve_downscale_draw && is_possible_mem_clear != ClearType::NormalClear, src);
 
 		// Draw skipped because it was a clear and there was no target.
 		if (!rt)
@@ -2860,6 +2917,10 @@ void GSRendererHW::Draw()
 				CleanupDraw(true);
 				return;
 			}
+			else if (IsPageCopy() && src->m_from_target && m_cached_ctx.TEX0.TBP0 >= src->m_from_target->m_TEX0.TBP0)
+			{
+				FRAME_TEX0.TBW = src->m_from_target->m_TEX0.TBW;
+			}
 
 			rt = g_texture_cache->CreateTarget(FRAME_TEX0, t_size, GetValidSize(src), (scale_draw < 0 && is_possible_mem_clear != ClearType::NormalClear) ? src->m_from_target->GetScale() : target_scale, GSTextureCache::RenderTarget, true,
 				fm, false, force_preload, preserve_rt_color || possible_shuffle, m_r, src);
@@ -2870,7 +2931,36 @@ void GSRendererHW::Draw()
 				return;
 			}
 		}
+		else if (rt->m_TEX0.TBP0 != FRAME_TEX0.TBP0) // Must have done rt in rt
+		{
+			GSVertex* v = &m_vertex.buff[0];
+			u32 vertical_offset = (((FRAME_TEX0.TBP0 - rt->m_TEX0.TBP0) >> 5) / std::max(rt->m_TEX0.TBW, 1U)) * frame_psm.pgs.y; // I know I could just not shift it..
 
+			const u32 horizontal_offset = (((FRAME_TEX0.TBP0 - rt->m_TEX0.TBP0) >> 5) % std::max(rt->m_TEX0.TBW, 1U)) * frame_psm.pgs.x;
+
+			for (u32 i = 0; i < m_vertex.tail; i++)
+			{
+				v[i].XYZ.Y += vertical_offset << 4;
+				v[i].XYZ.X += horizontal_offset << 4;
+			}
+
+			m_context->scissor.in.x += horizontal_offset;
+			m_context->scissor.in.z += horizontal_offset;
+			m_context->scissor.in.y += vertical_offset;
+			m_context->scissor.in.w += vertical_offset;
+			m_r.y += vertical_offset;
+			m_r.w += vertical_offset;
+			m_r.x += horizontal_offset;
+			m_r.z += horizontal_offset;
+			m_in_target_draw = true;
+			m_vt.m_min.p.x += horizontal_offset;
+			m_vt.m_max.p.x += horizontal_offset;
+			m_vt.m_min.p.y += vertical_offset;
+			m_vt.m_max.p.y += vertical_offset;
+			t_size.x = rt->m_unscaled_size.x - horizontal_offset;
+			t_size.y = rt->m_unscaled_size.y - vertical_offset;
+		}
+		
 		if (src && src->m_from_target && src->m_target_direct && src->m_from_target == rt)
 		{
 			src->m_texture = rt->m_texture;
@@ -2907,7 +2997,6 @@ void GSRendererHW::Draw()
 
 		if (!ds)
 		{
-			
 				ds = g_texture_cache->CreateTarget(ZBUF_TEX0, t_size, GetValidSize(src), target_scale, GSTextureCache::DepthStencil,
 					true, 0, false, force_preload, preserve_depth, m_r, src);
 				if (!ds) [[unlikely]]
@@ -3184,7 +3273,7 @@ void GSRendererHW::Draw()
 			}
 		}
 		const bool blending_cd = PRIM->ABE && !m_context->ALPHA.IsOpaque();
-		if (rt && ((!is_possible_mem_clear || blending_cd) || rt->m_TEX0.PSM != FRAME_TEX0.PSM))
+		if (rt && ((!is_possible_mem_clear || blending_cd) || rt->m_TEX0.PSM != FRAME_TEX0.PSM) && !m_in_target_draw)
 		{
 			if (rt->m_TEX0.TBW != FRAME_TEX0.TBW && !m_cached_ctx.ZBUF.ZMSK && (m_cached_ctx.FRAME.FBMSK & 0xFF000000))
 			{
@@ -3195,11 +3284,15 @@ void GSRendererHW::Draw()
 				if (m_cached_ctx.FRAME.FBMSK & 0xF0000000)
 					rt->m_valid_alpha_high = false;
 			}
-			rt->m_TEX0 = FRAME_TEX0;
+			if (FRAME_TEX0.TBW != 1 || (m_r.width() > frame_psm.pgs.x || m_r.height() > frame_psm.pgs.y))
+				rt->m_TEX0 = FRAME_TEX0;
 		}
 
-		if (ds && (!is_possible_mem_clear || ds->m_TEX0.PSM != ZBUF_TEX0.PSM || (rt && ds->m_TEX0.TBW != rt->m_TEX0.TBW)))
-			ds->m_TEX0 = ZBUF_TEX0;
+		if (ds && (!is_possible_mem_clear || ds->m_TEX0.PSM != ZBUF_TEX0.PSM || (rt && ds->m_TEX0.TBW != rt->m_TEX0.TBW)) && !m_in_target_draw)
+		{
+			if (ZBUF_TEX0.TBW != 1 || (m_r.width() > frame_psm.pgs.x || m_r.height() > frame_psm.pgs.y))
+				ds->m_TEX0 = ZBUF_TEX0;
+		}
 	}
 	else if (!m_texture_shuffle)
 	{
@@ -3207,7 +3300,7 @@ void GSRendererHW::Draw()
 		// The FBW should also be okay, since it's coming from the source.
 		if (rt)
 		{
-			const bool update_fbw = (m_channel_shuffle && src->m_target) && (!PRIM->ABE || IsOpaque() || m_context->ALPHA.IsBlack());
+			const bool update_fbw = rt->m_last_draw == s_n && (m_channel_shuffle && src->m_target) && (!PRIM->ABE || IsOpaque() || m_context->ALPHA.IsBlack());
 			rt->m_TEX0.TBW = update_fbw ? FRAME_TEX0.TBW : std::max(rt->m_TEX0.TBW, FRAME_TEX0.TBW);
 			rt->m_TEX0.PSM = FRAME_TEX0.PSM;
 		}
@@ -3229,7 +3322,7 @@ void GSRendererHW::Draw()
 	GSTextureCache::Target* old_ds = nullptr;
 
 	// If the draw is dated, we're going to expand in to black, so it's just a pointless rescale which will mess up our valid rects and end blocks.
-	if(!(m_cached_ctx.TEST.DATE && m_cached_ctx.TEST.DATM))
+	if (!(m_cached_ctx.TEST.DATE && m_cached_ctx.TEST.DATM))
 	{
 		GSVector2i new_size = t_size;
 
@@ -3277,7 +3370,7 @@ void GSRendererHW::Draw()
 				rt->ResizeDrawn(rt->GetUnscaledRect());
 			}
 
-			const GSVector4i update_rect = m_r.rintersect(GSVector4i::loadh(new_size));
+			const GSVector4i update_rect = m_r.rintersect(GSVector4i::loadh(GSVector2i(new_w, new_h)));
 			// Limit to 2x the vertical height of the resolution (for double buffering)
 			rt->UpdateValidity(update_rect, can_update_size || (m_r.w <= (resolution.y * 2) && !m_texture_shuffle));
 			rt->UpdateDrawn(update_rect, can_update_size || (m_r.w <= (resolution.y * 2) && !m_texture_shuffle));
@@ -3346,7 +3439,7 @@ void GSRendererHW::Draw()
 			}
 		}
 	}
-	else
+	else if (!m_in_target_draw)
 	{
 		// RT and DS sizes need to match, even if we're not doing any resizing.
 		const int new_w = std::max(rt ? rt->m_unscaled_size.x : 0, ds ? ds->m_unscaled_size.x : 0);
@@ -4132,8 +4225,8 @@ __ri bool GSRendererHW::EmulateChannelShuffle(GSTextureCache::Target* src, bool 
 		min_uv.x -= block_offset.x * t_psm.bs.x;
 		min_uv.y -= block_offset.y * t_psm.bs.y;
 
-		if (GSLocalMemory::IsPageAligned(src->m_TEX0.PSM, m_r) &&
-			block_offset.eq(m_r_block_offset))
+		//if (/*GSLocalMemory::IsPageAligned(src->m_TEX0.PSM, m_r) &&*/
+		//	block_offset.eq(m_r_block_offset))
 		{
 			if (min_uv.eq(GSVector4i::cxpr(0, 0, 0, 0)))
 				channel = ChannelFetch_RED;
@@ -4181,13 +4274,36 @@ __ri bool GSRendererHW::EmulateChannelShuffle(GSTextureCache::Target* src, bool 
 	// Performance GPU note: it could be wise to reduce the size to
 	// the rendered size of the framebuffer
 
-	GSVertex* s = &m_vertex.buff[0];
-	s[0].XYZ.X = static_cast<u16>(m_context->XYOFFSET.OFX + 0);
-	s[1].XYZ.X = static_cast<u16>(m_context->XYOFFSET.OFX + 16384);
-	s[0].XYZ.Y = static_cast<u16>(m_context->XYOFFSET.OFY + 0);
-	s[1].XYZ.Y = static_cast<u16>(m_context->XYOFFSET.OFY + 16384);
+	if (!m_in_target_draw && (GSConfig.UserHacks_TextureInsideRt == GSTextureInRtMode::Disabled || NextDrawMatchesShuffle()))
+	{
+		GSVertex* s = &m_vertex.buff[0];
+		s[0].XYZ.X = static_cast<u16>(m_context->XYOFFSET.OFX + 0);
+		s[1].XYZ.X = static_cast<u16>(m_context->XYOFFSET.OFX + 16384);
+		s[0].XYZ.Y = static_cast<u16>(m_context->XYOFFSET.OFY + 0);
+		s[1].XYZ.Y = static_cast<u16>(m_context->XYOFFSET.OFY + 16384);
 
-	m_r = GSVector4i(0, 0, 1024, 1024);
+		s[0].U = 0;
+		s[1].U = 16384;
+		s[0].V = 0;
+		s[1].V = 16384;
+		
+		m_r = GSVector4i(0, 0, 1024, 1024);
+	}
+	else
+	{
+		GSVertex* s = &m_vertex.buff[0];
+		s[0].XYZ.X = static_cast<u16>(m_context->XYOFFSET.OFX + (m_r.x << 4));
+		s[1].XYZ.X = static_cast<u16>(m_context->XYOFFSET.OFX + (m_r.z << 4));
+		s[0].XYZ.Y = static_cast<u16>(m_context->XYOFFSET.OFY + (m_r.y << 4));
+		s[1].XYZ.Y = static_cast<u16>(m_context->XYOFFSET.OFY + (m_r.w << 4));
+
+		s[0].U = (m_r.x << 4);
+		s[1].U = (m_r.z << 4);
+		s[0].V = (m_r.y << 4);
+		s[1].V = (m_r.w << 4);
+		m_last_channel_shuffle_fbmsk = 0xFFFFFFFF;
+	}
+	
 	m_vertex.head = m_vertex.tail = m_vertex.next = 2;
 	m_index.tail = 2;
 
@@ -5415,9 +5531,13 @@ __ri void GSRendererHW::HandleTextureHazards(const GSTextureCache::Target* rt, c
 	const GSTextureCache::Source* tex, const TextureMinMaxResult& tmm, GSTextureCache::SourceRegion& source_region,
 	bool& target_region, GSVector2i& unscaled_size, float& scale, GSDevice::RecycledTexture& src_copy)
 {
+
+	const int tex_diff = tex->m_from_target ? static_cast<int>(m_cached_ctx.TEX0.TBP0 - tex->m_from_target->m_TEX0.TBP0) : 0;
+	const int frame_diff = rt ? static_cast<int>(m_cached_ctx.FRAME.Block() - rt->m_TEX0.TBP0) : 0;
 	// Detect framebuffer read that will need special handling
 	const GSTextureCache::Target* src_target = nullptr;
-	if (rt && m_conf.tex == m_conf.rt)
+
+	if (rt && m_conf.tex == m_conf.rt && !(m_channel_shuffle && tex && tex_diff != frame_diff))
 	{
 		// Can we read the framebuffer directly? (i.e. sample location matches up).
 		if (CanUseTexIsFB(rt, tex, tmm))
@@ -5457,6 +5577,10 @@ __ri void GSRendererHW::HandleTextureHazards(const GSTextureCache::Target* rt, c
 		GL_CACHE("Source is depth buffer, unsafe to read, taking copy.");
 		src_target = ds;
 	}
+	else if (m_channel_shuffle && tex->m_from_target && tex_diff != frame_diff)
+	{
+		src_target = tex->m_from_target;
+	}
 	else if (!m_downscale_source)
 	{
 		// No match.
@@ -5479,7 +5603,34 @@ __ri void GSRendererHW::HandleTextureHazards(const GSTextureCache::Target* rt, c
 	{
 		copy_range = src_bounds;
 		copy_size = src_unscaled_size;
+
 		GSVector4i::storel(&copy_dst_offset, copy_range);
+		if (m_channel_shuffle && (tex_diff || frame_diff))
+		{
+
+			u32 page_offset = (m_cached_ctx.TEX0.TBP0 - src_target->m_TEX0.TBP0) >> 5;
+			u32 vertical_offset = (page_offset / src_target->m_TEX0.TBW) * GSLocalMemory::m_psm[src_target->m_TEX0.PSM].pgs.y;
+			u32 horizontal_offset = (page_offset % src_target->m_TEX0.TBW) * GSLocalMemory::m_psm[src_target->m_TEX0.PSM].pgs.x;
+			copy_range.y += vertical_offset;
+			copy_range.x += horizontal_offset;
+			copy_size.y -= vertical_offset;
+			copy_size.x -= horizontal_offset;
+
+			if (m_in_target_draw)
+			{
+				copy_size.x = m_r.width();
+				copy_size.y = m_r.height();
+				copy_range.w = copy_range.y + copy_size.y;
+				copy_range.z = copy_range.x + copy_size.x;
+
+				if (tex_diff != frame_diff)
+				{
+					GSVector4i::storel(&copy_dst_offset, m_r);
+					copy_size.x += copy_dst_offset.x;
+					copy_size.y += copy_dst_offset.y;
+				}
+			}
+		}
 	}
 	else
 	{
@@ -5489,7 +5640,7 @@ __ri void GSRendererHW::HandleTextureHazards(const GSTextureCache::Target* rt, c
 		copy_size.y = std::min(tex_size.y, src_unscaled_size.y);
 
 		// Use the texture min/max to get the copy range if not reinterpreted.
-		if (m_texture_shuffle)
+		if (m_texture_shuffle || m_channel_shuffle)
 			copy_range = GSVector4i::loadh(copy_size);
 		else
 			copy_range = tmm.coverage;

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -3073,33 +3073,24 @@ void GSRendererHW::Draw()
 			if (vertical_offset < 0)
 			{
 				rt->m_TEX0.TBP0 = m_cached_ctx.FRAME.Block();
-				GSVector2i new_scaled_size = rt->m_unscaled_size * rt->m_scale;
+				GSVector2i new_size = rt->m_unscaled_size;
 				// Make sure to use the original format for the offset.
 				int new_offset = std::abs((vertical_offset / frame_psm.pgs.y) * GSLocalMemory::m_psm[rt->m_TEX0.PSM].pgs.y);
 				texture_offset = new_offset;
 
-				new_scaled_size.y += new_offset * rt->m_scale;
-				GSTexture* tex = g_gs_device->CreateRenderTarget(new_scaled_size.x, new_scaled_size.y, GSTexture::Format::Color, true);
-				//if (!tex)
-				//	return nullptr;
-				//m_target_memory_usage += tex->GetMemUsage();
-				GSVector4i dRect = GSVector4i(0, new_offset * rt->m_scale, new_scaled_size.x, new_scaled_size.y);
-				g_gs_device->StretchRect(rt->m_texture, GSVector4(0,0,1,1), tex, GSVector4(dRect), ShaderConvert::COPY, false);
+				new_size.y += new_offset;
 
+				rt->ResizeTexture(new_size.x, new_size.y, true, true, GSVector4i::loadh(new_size * rt->m_scale).loadl(GSVector2i(0, new_offset * rt->m_scale)));
 
 				if (src && src->m_from_target && src->m_from_target == rt && src->m_target_direct)
 				{
-					src->m_texture = tex;
+					src->m_texture = rt->m_texture;
 				}
-
-				g_gs_device->Recycle(rt->m_texture);
 
 				rt->m_valid.y += new_offset;
 				rt->m_valid.w += new_offset;
 				rt->m_drawn_since_read.y += new_offset;
 				rt->m_drawn_since_read.w += new_offset;
-				rt->m_texture = tex;
-				rt->m_unscaled_size = new_scaled_size / rt->m_scale;
 
 				t_size.y += std::abs(vertical_offset);
 				vertical_offset = 0;

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -3614,6 +3614,7 @@ void GSRendererHW::Draw()
 			}
 			if (FRAME_TEX0.TBW != 1 || (m_r.width() > frame_psm.pgs.x || m_r.height() > frame_psm.pgs.y))
 			{
+				FRAME_TEX0.TBP0 = rt->m_TEX0.TBP0;
 				rt->m_TEX0 = FRAME_TEX0;
 
 			}
@@ -3622,7 +3623,10 @@ void GSRendererHW::Draw()
 		if (ds && (!is_possible_mem_clear || ds->m_TEX0.PSM != ZBUF_TEX0.PSM || (rt && ds->m_TEX0.TBW != rt->m_TEX0.TBW)) && !m_in_target_draw)
 		{
 			if (ZBUF_TEX0.TBW != 1 || (m_r.width() > frame_psm.pgs.x || m_r.height() > frame_psm.pgs.y))
+			{
+				ZBUF_TEX0.TBP0 = ds->m_TEX0.TBP0;
 				ds->m_TEX0 = ZBUF_TEX0;
+			}
 		}
 	}
 	else if (!m_texture_shuffle)

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -8569,7 +8569,10 @@ bool GSRendererHW::TextureCoversWithoutGapsNotEqual()
 int GSRendererHW::IsScalingDraw(GSTextureCache::Source* src, bool no_gaps)
 {
 	const GSVector2i draw_size = GSVector2i(m_vt.m_max.p.x - m_vt.m_min.p.x, m_vt.m_max.p.y - m_vt.m_min.p.y);
-	const GSVector2i tex_size = GSVector2i(m_vt.m_max.t.x - m_vt.m_min.t.x, m_vt.m_max.t.y - m_vt.m_min.t.y);
+	GSVector2i tex_size = GSVector2i(m_vt.m_max.t.x - m_vt.m_min.t.x, m_vt.m_max.t.y - m_vt.m_min.t.y);
+
+	tex_size.x = std::min(tex_size.x, 1 << m_cached_ctx.TEX0.TW);
+	tex_size.y = std::min(tex_size.y, 1 << m_cached_ctx.TEX0.TH);
 
 	const bool is_target_src = src && src->m_from_target;
 

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.h
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.h
@@ -174,6 +174,7 @@ private:
 
 	u32 m_last_channel_shuffle_fbmsk = 0;
 	u32 m_last_channel_shuffle_fbp = 0;
+	u32 m_last_channel_shuffle_tbp = 0;
 	u32 m_last_channel_shuffle_end_block = 0;
 
 	GIFRegFRAME m_split_clear_start = {};

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.h
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.h
@@ -92,7 +92,7 @@ private:
 	void DrawPrims(GSTextureCache::Target* rt, GSTextureCache::Target* ds, GSTextureCache::Source* tex, const TextureMinMaxResult& tmm);
 
 	void ResetStates();
-	void SetupIA(float target_scale, float sx, float sy);
+	void SetupIA(float target_scale, float sx, float sy, bool req_vert_backup);
 	void EmulateTextureShuffleAndFbmask(GSTextureCache::Target* rt, GSTextureCache::Source* tex);
 	bool EmulateChannelShuffle(GSTextureCache::Target* src, bool test_only);
 	void EmulateBlending(int rt_alpha_min, int rt_alpha_max, const bool DATE, bool& DATE_PRIMID, bool& DATE_BARRIER, GSTextureCache::Target* rt,
@@ -115,7 +115,7 @@ private:
 	bool IsPossibleChannelShuffle() const;
 	bool IsPageCopy() const;
 	bool NextDrawMatchesShuffle() const;
-	bool IsSplitTextureShuffle(GSTextureCache::Target* rt);
+	bool IsSplitTextureShuffle(GIFRegTEX0& rt_TEX0, GSVector4i& valid_area);
 	GSVector4i GetSplitTextureShuffleDrawRect() const;
 	u32 GetEffectiveTextureShuffleFbmsk() const;
 
@@ -176,6 +176,10 @@ private:
 	u32 m_last_channel_shuffle_fbp = 0;
 	u32 m_last_channel_shuffle_tbp = 0;
 	u32 m_last_channel_shuffle_end_block = 0;
+	u32 m_channel_shuffle_width = 0;
+	bool m_full_screen_shuffle = false;
+
+	GSTextureCache::Target* m_last_rt;
 
 	GIFRegFRAME m_split_clear_start = {};
 	GIFRegZBUF m_split_clear_start_Z = {};

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.h
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.h
@@ -177,6 +177,7 @@ private:
 	u32 m_last_channel_shuffle_tbp = 0;
 	u32 m_last_channel_shuffle_end_block = 0;
 	u32 m_channel_shuffle_width = 0;
+	GSVector4i m_channel_shuffle_src_valid = GSVector4i::zero();
 	bool m_full_screen_shuffle = false;
 
 	GSTextureCache::Target* m_last_rt;
@@ -206,6 +207,7 @@ public:
 
 	__fi static GSRendererHW* GetInstance() { return static_cast<GSRendererHW*>(g_gs_renderer.get()); }
 	__fi HWCachedCtx* GetCachedCtx() { return &m_cached_ctx; }
+	__fi u32 GetLastChannelShuffleFBP() { return m_last_channel_shuffle_fbp; }
 	void Destroy() override;
 
 	void UpdateRenderFixes() override;

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.h
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.h
@@ -113,12 +113,14 @@ private:
 	void SetTCOffset();
 	bool NextDrawHDR() const;
 	bool IsPossibleChannelShuffle() const;
+	bool IsPageCopy() const;
 	bool NextDrawMatchesShuffle() const;
 	bool IsSplitTextureShuffle(GSTextureCache::Target* rt);
 	GSVector4i GetSplitTextureShuffleDrawRect() const;
 	u32 GetEffectiveTextureShuffleFbmsk() const;
 
 	static GSVector4i GetDrawRectForPages(u32 bw, u32 psm, u32 num_pages);
+	bool IsSinglePageDraw() const;
 	bool TryToResolveSinglePageFramebuffer(GIFRegFRAME& FRAME, bool only_next_draw);
 
 	bool IsSplitClearActive() const;

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.h
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.h
@@ -94,7 +94,7 @@ private:
 	void ResetStates();
 	void SetupIA(float target_scale, float sx, float sy, bool req_vert_backup);
 	void EmulateTextureShuffleAndFbmask(GSTextureCache::Target* rt, GSTextureCache::Source* tex);
-	bool EmulateChannelShuffle(GSTextureCache::Target* src, bool test_only);
+	bool EmulateChannelShuffle(GSTextureCache::Target* src, bool test_only, GSTextureCache::Target* rt = nullptr);
 	void EmulateBlending(int rt_alpha_min, int rt_alpha_max, const bool DATE, bool& DATE_PRIMID, bool& DATE_BARRIER, GSTextureCache::Target* rt,
 		bool can_scale_rt_alpha, bool& new_rt_alpha_scale);
 	void CleanupDraw(bool invalidate_temp_src);

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -1386,6 +1386,7 @@ GSTextureCache::Source* GSTextureCache::LookupSource(const bool is_color, const 
 								DevCon.Warning("Failed to update dst matched texture");
 							}
 							t->m_valid_rgb = true;
+							t->m_TEX0 = dst_match->m_TEX0;
 							break;
 						}
 					}
@@ -4007,19 +4008,6 @@ bool GSTextureCache::Move(u32 SBP, u32 SBW, u32 SPSM, int sx, int sy, u32 DBP, u
 	if (alpha_only && (!dst || GSLocalMemory::m_psm[dst->m_TEX0.PSM].bpp != 32))
 		return false;
 
-	// This is probably copying to a new buffer but using the original one as an offset, so better to use a new texture, if we don't find one.
-	if (dst && DBP == SBP && dy > dst->m_unscaled_size.y)
-	{
-		u32 new_DBP = DBP + (((dy / GSLocalMemory::m_psm[dst->m_TEX0.PSM].pgs.y) * DBW) << 5);
-
-		dst = nullptr;
-
-		DBP = new_DBP;
-		dy = 0;
-
-		dst = GetExactTarget(DBP, DBW, dpsm_s.depth ? DepthStencil : RenderTarget, DBP);
-	}
-
 	// Beware of the case where a game might create a larger texture by moving a bunch of chunks around.
 	if (dst && DBP == SBP && dy > dst->m_unscaled_size.y)
 	{
@@ -4032,7 +4020,7 @@ bool GSTextureCache::Move(u32 SBP, u32 SBW, u32 SPSM, int sx, int sy, u32 DBP, u
 
 		dst = GetExactTarget(DBP, DBW, dpsm_s.depth ? DepthStencil : RenderTarget, DBP);
 	}
-
+	
 	// Beware of the case where a game might create a larger texture by moving a bunch of chunks around.
 	// We use dx/dy == 0 and the TBW check as a safeguard to make sure these go through to local memory.
 	// We can also recreate the target if it's previously been created in the height cache with a valid size.

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -379,7 +379,7 @@ GSVector4i GSTextureCache::TranslateAlignedRectByPage(u32 tbp, u32 tebp, u32 tbw
 				if (horizontal_offset)
 					page_count += dst_pgw - horizontal_offset;
 
-				int new_height = (page_count / dst_pgw) * dst_page_size.y;
+				const int new_height = (page_count / dst_pgw) * dst_page_size.y;
 				new_rect.x = 0;
 				new_rect.z = dst_pgw * dst_page_size.x;
 				new_rect.y = start_page.y * dst_page_size.y;
@@ -3653,7 +3653,7 @@ void GSTextureCache::InvalidateVideoMem(const GSOffset& off, const GSVector4i& r
 				}
 			}
 
-			u32 bbp = bp + bw * 0x10;
+			const u32 bbp = bp + bw * 0x10;
 			if (bw >= 16 && bbp < 16384)
 			{
 				// Detect half of the render target (fix snow engine game)
@@ -4223,7 +4223,7 @@ bool GSTextureCache::Move(u32 SBP, u32 SBW, u32 SPSM, int sx, int sy, u32 DBP, u
 
 		dst = GetExactTarget(DBP, DBW, dpsm_s.depth ? DepthStencil : RenderTarget, DBP);
 	}
-	
+
 	// Beware of the case where a game might create a larger texture by moving a bunch of chunks around.
 	// We use dx/dy == 0 and the TBW check as a safeguard to make sure these go through to local memory.
 	// We can also recreate the target if it's previously been created in the height cache with a valid size.
@@ -7578,7 +7578,7 @@ std::shared_ptr<GSTextureCache::Palette> GSTextureCache::PaletteMap::LookupPalet
 			{
 				// Palette is unused
 				it = map.erase(it); // Erase element from map
-					// The palette object should now be gone as the shared pointer to the object in the map is deleted
+				// The palette object should now be gone as the shared pointer to the object in the map is deleted
 			}
 			else
 			{

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -2019,14 +2019,16 @@ GSTextureCache::Source* GSTextureCache::LookupSource(const bool is_color, const 
 		{
 			if (src->m_from_target->m_TEX0.TBP0 == src->m_TEX0.TBP0)
 			{
-				src->m_region.SetX(std::min(region.GetMinX(), src->m_region.GetMinX()), std::max(region.GetMaxX(), src->m_region.GetMaxX()));
-				src->m_region.SetY(std::min(region.GetMinY(), src->m_region.GetMinY()), std::max(region.GetMaxY(), src->m_region.GetMaxY()));
+				src->m_region.bits = 0;
+				src->m_region.SetX(0, region.HasX() ? region.GetMaxX() : (1 << TEX0.TW));
+				src->m_region.SetY(0, region.HasY() ? region.GetMaxY() : (1 << TEX0.TH));
 			}
 			else if (src->m_TEX0.TBP0 > src->m_from_target->m_TEX0.TBP0)
 			{
 				GSVector4i dst_offset = TranslateAlignedRectByPage(src->m_from_target, src->m_TEX0.TBP0, src->m_TEX0.PSM, src->m_TEX0.TBW, GSVector4i(0, 0, 1, 1), false);
-				src->m_region.SetX(dst_offset.x + region.GetMinX(), dst_offset.x + region.GetMaxX());
-				src->m_region.SetY(dst_offset.y + region.GetMinY(), dst_offset.y + region.GetMaxY());
+				src->m_region.bits = 0;
+				src->m_region.SetX(dst_offset.x, dst_offset.x + (region.HasX() ? std::min(region.GetMaxX(), (1 << TEX0.TW)) : (1 << TEX0.TW)));
+				src->m_region.SetY(dst_offset.y, dst_offset.y + (region.HasY() ? std::min(region.GetMaxY(), (1 << TEX0.TH)) : (1 << TEX0.TH)));
 			}
 		}
 
@@ -2090,7 +2092,6 @@ GSTextureCache::Target* GSTextureCache::LookupTarget(GIFRegTEX0 TEX0, const GSVe
 		for (auto i = list.begin(); i != list.end();)
 		{
 			Target* t = *i;
-
 			if (bp == t->m_TEX0.TBP0)
 			{
 				bool can_use = true;

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -1714,6 +1714,9 @@ GSTextureCache::Source* GSTextureCache::LookupSource(const bool is_color, const 
 							if (!t->HasValidBitsForFormat(psm, req_color, req_alpha, t->m_TEX0.TBW == TEX0.TBW) && !(possible_shuffle && GSLocalMemory::m_psm[psm].bpp == 16 && GSLocalMemory::m_psm[t->m_TEX0.PSM].bpp == 32))
 								continue;
 
+							if (!t->Inside(bp, bw, psm, block_boundary_rect))
+								continue;
+
 							x_offset = rect.x;
 							y_offset = rect.y;
 							dst = t;

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -1160,8 +1160,8 @@ GSTextureCache::Source* GSTextureCache::LookupDepthSource(const bool is_depth, c
 		if (inside_target)
 		{
 			// Need to set it up as a region target.
-			src->m_region.SetX(block_boundary_rect.x, block_boundary_rect.z);
-			src->m_region.SetY(block_boundary_rect.y, block_boundary_rect.w);
+			src->m_region.SetX(block_boundary_rect.x, src->m_from_target->m_valid.z);
+			src->m_region.SetY(block_boundary_rect.y, src->m_from_target->m_valid.w);
 		}
 
 		if (GSRendererHW::GetInstance()->IsTBPFrameOrZ(dst->m_TEX0.TBP0))

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -5506,13 +5506,7 @@ GSTextureCache::Source* GSTextureCache::CreateSource(const GIFRegTEX0& TEX0, con
 			src->m_shared_texture = true;
 			src->m_32_bits_fmt = dst->m_32_bits_fmt;
 
-			// kill source immediately if it's the RT/DS, because that'll get invalidated immediately
-			if (GSRendererHW::GetInstance()->IsTBPFrameOrZ(dst->m_TEX0.TBP0) || channel_shuffle)
-			{
-				GL_CACHE("TC: Source is RT or ZBUF, invalidating after draw.");
-				m_temporary_source = src;
-			}
-			else if (new_size != dst_texture_size)
+			if (new_size != dst_texture_size)
 			{
 				// if the size doesn't match, we need to engage shader sampling.
 				GL_CACHE("TC: Sample reduced region directly from target: %dx%d -> %dx%d", dst_texture_size.x,
@@ -5522,6 +5516,13 @@ GSTextureCache::Source* GSTextureCache::CreateSource(const GIFRegTEX0& TEX0, con
 					src->m_region.SetX(region_rect.x, region_rect.z);
 				if (new_size.y != dst_texture_size.y)
 					src->m_region.SetY(region_rect.y, region_rect.w);
+			}
+
+			// kill source immediately if it's the RT/DS, because that'll get invalidated immediately
+			if (GSRendererHW::GetInstance()->IsTBPFrameOrZ(dst->m_TEX0.TBP0) || channel_shuffle)
+			{
+				GL_CACHE("TC: Source is RT or ZBUF, invalidating after draw.");
+				m_temporary_source = src;
 			}
 		}
 		else

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -4627,7 +4627,7 @@ GSTextureCache::Target* GSTextureCache::GetTargetWithSharedBits(u32 BP, u32 PSM)
 	{
 		Target* t = *it;
 		const u32 t_psm = (t->HasValidAlpha()) ? t->m_TEX0.PSM & ~0x1 : t->m_TEX0.PSM;
-		if (GSUtil::HasSharedBits(BP, PSM, t->m_TEX0.TBP0, t_psm))
+		if (GSUtil::HasSharedBits(PSM, t_psm) && (t->m_TEX0.TBP0 == BP || (GSConfig.UserHacks_TextureInsideRt >= GSTextureInRtMode::InsideTargets && t->m_TEX0.TBP0 < BP && t->UnwrappedEndBlock() > BP)))
 			return t;
 	}
 

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -2369,15 +2369,14 @@ GSTextureCache::Target* GSTextureCache::LookupTarget(GIFRegTEX0 TEX0, const GSVe
 			{
 				if (scale_down)
 				{
-					if ((new_size.y * 2) < 1024)
-					{
-						new_scaled_size.y *= 2;
-						new_size.y *= 2;
-						dst->m_valid.y *= 2;
-						dst->m_valid.w *= 2;
-					}
+					new_scaled_size.y *= 2;
+					dst->m_valid.y *= 2;
+					dst->m_valid.w *= 2;
 					dRect.y *= 2;
 					dRect.w *= 2;
+
+					new_size.y *= 2;
+					new_size.y = std::max(dst->m_valid.w, new_size.y);
 				}
 				else
 				{
@@ -2387,6 +2386,7 @@ GSTextureCache::Target* GSTextureCache::LookupTarget(GIFRegTEX0 TEX0, const GSVe
 					dRect.w /= 2;
 					dst->m_valid.y /= 2;
 					dst->m_valid.w /= 2;
+					new_size.y = std::max(dst->m_valid.w, new_size.y);
 				}
 			}
 			if (!is_shuffle)
@@ -2627,7 +2627,7 @@ GSTextureCache::Target* GSTextureCache::LookupTarget(GIFRegTEX0 TEX0, const GSVe
 			dst->m_valid = dst_match->m_valid;
 			dst->m_valid_alpha_low = dst_match->m_valid_alpha_low; //&& psm_s.trbpp != 24;
 			dst->m_valid_alpha_high = dst_match->m_valid_alpha_high; //&& psm_s.trbpp != 24;
-			dst->m_valid_rgb = dst_match->m_valid_rgb;
+			dst->m_valid_rgb = dst_match->m_valid_rgb && (dst->m_TEX0.TBW == TEX0.TBW || min_rect.w <= GSLocalMemory::m_psm[dst_match->m_TEX0.PSM].pgs.y);
 			dst->m_was_dst_matched = true;
 			dst_match->m_was_dst_matched = true;
 			dst_match->m_valid_rgb = preserve_rgb;

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -5506,9 +5506,15 @@ GSTextureCache::Source* GSTextureCache::CreateSource(const GIFRegTEX0& TEX0, con
 			src->m_shared_texture = true;
 			src->m_32_bits_fmt = dst->m_32_bits_fmt;
 
-			// if the size doesn't match, we need to engage shader sampling.
-			if (new_size != dst_texture_size)
+			// kill source immediately if it's the RT/DS, because that'll get invalidated immediately
+			if (GSRendererHW::GetInstance()->IsTBPFrameOrZ(dst->m_TEX0.TBP0) || channel_shuffle)
 			{
+				GL_CACHE("TC: Source is RT or ZBUF, invalidating after draw.");
+				m_temporary_source = src;
+			}
+			else if (new_size != dst_texture_size)
+			{
+				// if the size doesn't match, we need to engage shader sampling.
 				GL_CACHE("TC: Sample reduced region directly from target: %dx%d -> %dx%d", dst_texture_size.x,
 					dst_texture_size.y, new_size.x, new_size.y);
 
@@ -5516,13 +5522,6 @@ GSTextureCache::Source* GSTextureCache::CreateSource(const GIFRegTEX0& TEX0, con
 					src->m_region.SetX(region_rect.x, region_rect.z);
 				if (new_size.y != dst_texture_size.y)
 					src->m_region.SetY(region_rect.y, region_rect.w);
-			}
-
-			// kill source immediately if it's the RT/DS, because that'll get invalidated immediately
-			if (GSRendererHW::GetInstance()->IsTBPFrameOrZ(dst->m_TEX0.TBP0) || channel_shuffle)
-			{
-				GL_CACHE("TC: Source is RT or ZBUF, invalidating after draw.");
-				m_temporary_source = src;
 			}
 		}
 		else

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -1948,10 +1948,10 @@ GSTextureCache::Target* GSTextureCache::LookupTarget(GIFRegTEX0 TEX0, const GSVe
 						(static_cast<u32>(min_rect.width()) <= (widthpage_offset * 64))));*/
 				const bool is_aligned_ok = widthpage_offset == 0 || ((min_rect.width() <= static_cast<int>((t->m_TEX0.TBW - widthpage_offset) * 64) && (t->m_TEX0.TBW == TEX0.TBW || TEX0.TBW == 1)) && bp >= t->m_TEX0.TBP0);
 				const bool no_target_or_newer = (!dst || ((GSState::s_n - dst->m_last_draw) < (GSState::s_n - t->m_last_draw)));
-				const bool width_match = (t->m_TEX0.TBW == TEX0.TBW || TEX0.TBW == 1);
+				const bool width_match = (t->m_TEX0.TBW == TEX0.TBW || (TEX0.TBW == 1 && draw_rect.w <= GSLocalMemory::m_psm[t->m_TEX0.PSM].pgs.y));
 				// if it's a shuffle, some games tend to offset back by a page, such as Tomb Raider, for no disernable reason, but it then causes problems.
 				// This can also happen horizontally (Catwoman moves everything one page left with shuffles), but this is too messy to deal with right now.
-				const bool overlaps = t->Overlaps(bp, TEX0.TBW, TEX0.PSM, min_rect) || (is_shuffle && t->Overlaps(bp, TEX0.TBW, TEX0.PSM, min_rect + GSVector4i(0, 0, 0, 32)));
+				const bool overlaps = t->Overlaps(bp, TEX0.TBW, TEX0.PSM, min_rect) || (is_shuffle && src && GSLocalMemory::m_psm[src->m_TEX0.PSM].bpp == 8 && t->Overlaps(bp, TEX0.TBW, TEX0.PSM, min_rect + GSVector4i(0, 0, 0, 32)));
 				if (no_target_or_newer && is_aligned_ok && width_match && overlaps)
 				{
 					const GSLocalMemory::psm_t& s_psm = GSLocalMemory::m_psm[TEX0.PSM];

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -2073,7 +2073,7 @@ GSTextureCache::Target* GSTextureCache::LookupTarget(GIFRegTEX0 TEX0, const GSVe
 				// 2. Preserved data will be in the correct place (in most cases)
 				// 3. Less deleting sources/targets
 				// 4. We can basically do clears in hardware, if they aren't insane ones
-				if (can_use && !is_shuffle && ((preserve_alpha && preserve_rgb) || (draw_rect.w > GSLocalMemory::m_psm[t->m_TEX0.PSM].pgs.y && !possible_clear)) && TEX0.TBW != t->m_TEX0.TBW && t->m_dirty.size() >= 1)
+				if (can_use && ((!is_shuffle && t->m_dirty.size() >= 1) || (is_shuffle && src && GSLocalMemory::m_psm[src->m_TEX0.PSM].bpp == 8 && GSLocalMemory::m_psm[t->m_TEX0.PSM].bpp == 16)) && ((preserve_alpha && preserve_rgb) || (draw_rect.w > GSLocalMemory::m_psm[t->m_TEX0.PSM].pgs.y && !possible_clear)) && TEX0.TBW != t->m_TEX0.TBW)
 				{
 					can_use = false;
 				}
@@ -5320,6 +5320,8 @@ GSTextureCache::Source* GSTextureCache::CreateSource(const GIFRegTEX0& TEX0, con
 					g_gs_device->StretchRect(
 						sTex, sRectF, dTex, GSVector4(destX, destY, new_size.x, new_size.y), shader, false);
 				}
+
+				m_temporary_source = src;
 
 				g_perfmon.Put(GSPerfMon::TextureCopies, 1);
 

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.h
@@ -491,7 +491,7 @@ public:
 	Target* FindTargetOverlap(Target* target, int type, int psm);
 	Target* LookupTarget(GIFRegTEX0 TEX0, const GSVector2i& size, float scale, int type, bool used = true, u32 fbmask = 0,
 						 bool is_frame = false, bool preload = GSConfig.PreloadFrameWithGSData, bool preserve_rgb = true, bool preserve_alpha = true,
-						 const GSVector4i draw_rc = GSVector4i::zero(), bool is_shuffle = false, bool possible_clear = false, bool preserve_scale = false);
+		const GSVector4i draw_rc = GSVector4i::zero(), bool is_shuffle = false, bool possible_clear = false, bool preserve_scale = false, GSTextureCache::Source* src = nullptr);
 	Target* CreateTarget(GIFRegTEX0 TEX0, const GSVector2i& size, const GSVector2i& valid_size,float scale, int type, bool used = true, u32 fbmask = 0,
 		bool is_frame = false, bool preload = GSConfig.PreloadFrameWithGSData, bool preserve_target = true,
 		const GSVector4i draw_rc = GSVector4i::zero(), GSTextureCache::Source* src = nullptr);

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.h
@@ -257,7 +257,7 @@ public:
 		void UpdateValidChannels(u32 psm, u32 fbmsk);
 
 		/// Resizes target texture, DOES NOT RESCALE.
-		bool ResizeTexture(int new_unscaled_width, int new_unscaled_height, bool recycle_old = true);
+		bool ResizeTexture(int new_unscaled_width, int new_unscaled_height, bool recycle_old = true, bool require_offset = false, GSVector4i offset = GSVector4i::zero(), bool keep_old = false);
 
 	private:
 		void UpdateTextureDebugName();

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.h
@@ -427,6 +427,7 @@ protected:
 	std::unordered_map<SurfaceOffsetKey, SurfaceOffset, SurfaceOffsetKeyHash, SurfaceOffsetKeyEqual> m_surface_offset_cache;
 
 	Source* m_temporary_source = nullptr; // invalidated after the draw
+	GSTexture* m_temporary_z = nullptr; // invalidated after the draw
 
 	std::unique_ptr<GSDownloadTexture> m_color_download_texture;
 	std::unique_ptr<GSDownloadTexture> m_uint16_download_texture;
@@ -508,7 +509,7 @@ public:
 	bool HasTargetInHeightCache(u32 bp, u32 fbw, u32 psm, u32 max_age = std::numeric_limits<u32>::max(), bool move_front = true);
 	bool Has32BitTarget(u32 bp);
 
-	void InvalidateContainedTargets(u32 start_bp, u32 end_bp, u32 write_psm = PSMCT32);
+	void InvalidateContainedTargets(u32 start_bp, u32 end_bp, u32 write_psm = PSMCT32, u32 write_bw = 1);
 	void InvalidateVideoMemType(int type, u32 bp, u32 write_psm = PSMCT32, u32 write_fbmsk = 0, bool dirty_only = false);
 	void InvalidateVideoMemSubTarget(GSTextureCache::Target* rt);
 	void InvalidateVideoMem(const GSOffset& off, const GSVector4i& r, bool target = true);
@@ -551,6 +552,11 @@ public:
 
 	/// Invalidates a temporary source, a partial copy only created from the current RT/DS for the current draw.
 	void InvalidateTemporarySource();
+	void SetTemporaryZ(GSTexture* temp_z);
+	GSTexture* GetTemporaryZ();
+
+	/// Invalidates a temporary Z, a partial copy only created from the current DS for the current draw when Z is not offset but RT is
+	void InvalidateTemporaryZ();
 
 	/// Injects a texture into the hash cache, by using GSTexture::Swap(), transitively applying to all sources. Ownership of tex is transferred.
 	void InjectHashCacheTexture(const HashCacheKey& key, GSTexture* tex, const std::pair<u8, u8>& alpha_minmax);

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.h
@@ -491,7 +491,7 @@ public:
 	Target* FindTargetOverlap(Target* target, int type, int psm);
 	Target* LookupTarget(GIFRegTEX0 TEX0, const GSVector2i& size, float scale, int type, bool used = true, u32 fbmask = 0,
 						 bool is_frame = false, bool preload = GSConfig.PreloadFrameWithGSData, bool preserve_rgb = true, bool preserve_alpha = true,
-		const GSVector4i draw_rc = GSVector4i::zero(), bool is_shuffle = false, bool possible_clear = false, bool preserve_scale = false, GSTextureCache::Source* src = nullptr);
+		const GSVector4i draw_rc = GSVector4i::zero(), bool is_shuffle = false, bool possible_clear = false, bool preserve_scale = false, GSTextureCache::Source* src = nullptr, int offset = -1);
 	Target* CreateTarget(GIFRegTEX0 TEX0, const GSVector2i& size, const GSVector2i& valid_size,float scale, int type, bool used = true, u32 fbmask = 0,
 		bool is_frame = false, bool preload = GSConfig.PreloadFrameWithGSData, bool preserve_target = true,
 		const GSVector4i draw_rc = GSVector4i::zero(), GSTextureCache::Source* src = nullptr);

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.h
@@ -518,7 +518,7 @@ public:
 	/// Removes any sources which point to the specified target.
 	void InvalidateSourcesFromTarget(const Target* t);
 
-	/// Replaces a source's texture externally. Required for some CRC hacks.
+	/// Removes any sources which point to the same address as a new target.
 	void ReplaceSourceTexture(Source* s, GSTexture* new_texture, float new_scale, const GSVector2i& new_unscaled_size,
 		HashCacheEntry* hc_entry, bool new_texture_is_shared);
 

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.h
@@ -563,7 +563,7 @@ public:
 	GSTexture* GetTemporaryZ();
 	TempZAddress GetTemporaryZInfo();
 	void SetTemporaryZInfo(u32 address, u32 offset);
-	/// Invalidates a temporary Z, a partial copy only created from the current DS for the current draw when Z is not offset but RT is
+	/// Invalidates a temporary Z, a partial copy only created from the current DS for the current draw when Z is not offset but RT is.
 	void InvalidateTemporaryZ();
 
 	/// Injects a texture into the hash cache, by using GSTexture::Swap(), transitively applying to all sources. Ownership of tex is transferred.

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.h
@@ -238,7 +238,7 @@ public:
 		static Target* Create(GIFRegTEX0 TEX0, int w, int h, float scale, int type, bool clear);
 
 		__fi bool HasValidAlpha() const { return (m_valid_alpha_low | m_valid_alpha_high); }
-		bool HasValidBitsForFormat(u32 psm, bool req_color, bool req_alpha);
+		bool HasValidBitsForFormat(u32 psm, bool req_color, bool req_alpha, bool width_match);
 
 		void ResizeDrawn(const GSVector4i& rect);
 		void UpdateDrawn(const GSVector4i& rect, bool can_resize = true);

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.h
@@ -492,7 +492,7 @@ public:
 	Target* FindTargetOverlap(Target* target, int type, int psm);
 	Target* LookupTarget(GIFRegTEX0 TEX0, const GSVector2i& size, float scale, int type, bool used = true, u32 fbmask = 0,
 						 bool is_frame = false, bool preload = GSConfig.PreloadFrameWithGSData, bool preserve_rgb = true, bool preserve_alpha = true,
-		const GSVector4i draw_rc = GSVector4i::zero(), bool is_shuffle = false, bool possible_clear = false, bool preserve_scale = false, GSTextureCache::Source* src = nullptr, int offset = -1);
+		const GSVector4i draw_rc = GSVector4i::zero(), bool is_shuffle = false, bool possible_clear = false, bool preserve_scale = false, GSTextureCache::Source* src = nullptr, GSTextureCache::Target* ds = nullptr, int offset = -1);
 	Target* CreateTarget(GIFRegTEX0 TEX0, const GSVector2i& size, const GSVector2i& valid_size,float scale, int type, bool used = true, u32 fbmask = 0,
 		bool is_frame = false, bool preload = GSConfig.PreloadFrameWithGSData, bool preserve_target = true,
 		const GSVector4i draw_rc = GSVector4i::zero(), GSTextureCache::Source* src = nullptr);

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.h
@@ -206,6 +206,12 @@ public:
 		bool operator()(const PaletteKey& lhs, const PaletteKey& rhs) const;
 	};
 
+	struct TempZAddress
+	{
+		u32 ZBP;
+		u32 offset;
+	};
+
 	class Target : public Surface
 	{
 	public:
@@ -428,6 +434,7 @@ protected:
 
 	Source* m_temporary_source = nullptr; // invalidated after the draw
 	GSTexture* m_temporary_z = nullptr; // invalidated after the draw
+	TempZAddress m_temporary_z_info;
 
 	std::unique_ptr<GSDownloadTexture> m_color_download_texture;
 	std::unique_ptr<GSDownloadTexture> m_uint16_download_texture;
@@ -554,7 +561,8 @@ public:
 	void InvalidateTemporarySource();
 	void SetTemporaryZ(GSTexture* temp_z);
 	GSTexture* GetTemporaryZ();
-
+	TempZAddress GetTemporaryZInfo();
+	void SetTemporaryZInfo(u32 address, u32 offset);
 	/// Invalidates a temporary Z, a partial copy only created from the current DS for the current draw when Z is not offset but RT is
 	void InvalidateTemporaryZ();
 

--- a/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
+++ b/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
@@ -2114,7 +2114,7 @@ void GSDeviceMTL::MREInitHWDraw(GSHWDrawConfig& config, const Map& verts)
 
 void GSDeviceMTL::RenderHW(GSHWDrawConfig& config)
 { @autoreleasepool {
-	if (config.tex && config.ds == config.tex)
+	if (config.tex && (config.ds == config.tex || config.rt == config.tex))
 		EndRenderPass(); // Barrier
 
 	size_t vertsize = config.nverts * sizeof(*config.verts);

--- a/pcsx2/GS/Renderers/Metal/tfx.metal
+++ b/pcsx2/GS/Renderers/Metal/tfx.metal
@@ -1175,11 +1175,8 @@ struct PSMain
 			{
 				if (PS_PROCESS_BA == SHUFFLE_READWRITE && PS_PROCESS_RG == SHUFFLE_READWRITE)
 				{
-					C.rb = C.br;
-					float g_temp = C.g;
-					
-					C.g = C.a;
-					C.a = g_temp;
+					C.b = C.r;
+					C.a = C.g;
 				}
 				else if(PS_PROCESS_BA & SHUFFLE_READ)
 				{

--- a/pcsx2/GS/Renderers/Metal/tfx.metal
+++ b/pcsx2/GS/Renderers/Metal/tfx.metal
@@ -1175,7 +1175,7 @@ struct PSMain
 			{
 				if (PS_PROCESS_BA == SHUFFLE_READWRITE && PS_PROCESS_RG == SHUFFLE_READWRITE)
 				{
-					C.br = C.rb;				
+					C.br = C.rb;
 					C.ag = C.ga;
 				}
 				else if(PS_PROCESS_BA & SHUFFLE_READ)
@@ -1190,7 +1190,7 @@ struct PSMain
 				}
 			}
 		}
-		
+
 		ps_dither(C, alpha_blend.a);
 
 		// Color clamp/wrap needs to be done after sw blending and dithering

--- a/pcsx2/GS/Renderers/Metal/tfx.metal
+++ b/pcsx2/GS/Renderers/Metal/tfx.metal
@@ -1175,8 +1175,8 @@ struct PSMain
 			{
 				if (PS_PROCESS_BA == SHUFFLE_READWRITE && PS_PROCESS_RG == SHUFFLE_READWRITE)
 				{
-					C.b = C.r;
-					C.a = C.g;
+					C.br = C.rb;				
+					C.ag = C.ga;
 				}
 				else if(PS_PROCESS_BA & SHUFFLE_READ)
 				{

--- a/pcsx2/GS/Renderers/Metal/tfx.metal
+++ b/pcsx2/GS/Renderers/Metal/tfx.metal
@@ -826,7 +826,7 @@ struct PSMain
 		else
 			T = sample_color(st);
 
-		if (PS_SHUFFLE && !PS_SHUFFLE_SAME && !PS_READ16_SRC)
+		if (PS_SHUFFLE && !PS_SHUFFLE_SAME && !PS_READ16_SRC && !(PS_PROCESS_BA == SHUFFLE_READWRITE && PS_PROCESS_RG == SHUFFLE_READWRITE))
 		{
 			uint4 denorm_c_before = uint4(T);
 			if (PS_PROCESS_BA & SHUFFLE_READ)
@@ -1134,7 +1134,7 @@ struct PSMain
 
 		if (PS_SHUFFLE)
 		{
-			if (!PS_SHUFFLE_SAME && !PS_READ16_SRC)
+			if (!PS_SHUFFLE_SAME && !PS_READ16_SRC && !(PS_PROCESS_BA == SHUFFLE_READWRITE && PS_PROCESS_RG == SHUFFLE_READWRITE))
 			{
 				uint4 denorm_c_after = uint4(C);
 				if (PS_PROCESS_BA & SHUFFLE_READ)

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
@@ -5641,6 +5641,10 @@ void GSDeviceVK::RenderHW(GSHWDrawConfig& config)
 	PipelineSelector& pipe = m_pipeline_selector;
 	UpdateHWPipelineSelector(config, pipe);
 
+	// If we don't have a barrier but the texture was drawn to last draw, end the pass to insert a barrier.
+	if (InRenderPass() && !pipe.IsRTFeedbackLoop() && (config.tex == m_current_render_target || config.tex == m_current_depth_target))
+		EndRenderPass();
+
 	// now blit the hdr texture back to the original target
 	if (hdr_rt)
 	{

--- a/pcsx2/ShaderCacheVersion.h
+++ b/pcsx2/ShaderCacheVersion.h
@@ -3,4 +3,4 @@
 
 /// Version number for GS and other shaders. Increment whenever any of the contents of the
 /// shaders change, to invalidate the cache.
-static constexpr u32 SHADER_CACHE_VERSION = 61;
+static constexpr u32 SHADER_CACHE_VERSION = 62;


### PR DESCRIPTION
### Description of Changes
Adds support for render target inside render target draws and shuffles, where games point to an offset inside a previously drawn target, usually to update single pages, or offset half way through a picture.

### Rationale behind Changes
We didn't support this and relied on exact start address matches, and a bunch of games do it.

### Suggested Testing Steps
Test games which had "top left corner" bugs or weird half screen problems.

Known to fix:
Battlefield 2 - Fixes things the CRC hack was chopping out, also required fixing how sources get invalidated
Big Mutha Truckers - No longer requires a CRC hack for half screen shuffle
Call of Duty - World at War - Final Fronts - lighting closer matches software
Conflct Desert Storm - Flickering fixed
Death by Degrees - lighting and fog effects post processing (top left corner) are fixed (CRC can be removed)
Delta Force - Black Hawk Down - Fixes player 2 night vision
Drakengard - Post shuffle effect on death
Driv3r - Doesn't need such a cacophony of fixes, just CSBW 4/2 + Tex in RT, plus fixes the sun glares.
Haunting Ground - Quite possibly no longer needs CRC hack
Hitman Blood Money - Post processing and shadows fixed (still needs CRC for weird corner uploading thing, but may be more fixable these days)
Hitman Contracts - Graphics completely fixed
Ghost in the Shell - Stand Alone Complex - No longer requires CRC hack and fixes channel shuffle
Jak X - Combat Racing - Player 2 now visible
Peter Jackson's King Kong- The Official Game of the Movie - pretty much fixed with rt in rt
Manhunt 2 - Post Process (top left corner) lighting fixed
Onimusha - Warlords - fmvs seem to not flicker (game currently uses SW FMV)
Ridge Racer V - Less hacks required, intro can now be upscaled
Sniper Elite - Second player lighting overlay fixed
Stolen - All graphics processing is fixed, lighting, etc. Speed is also not terrible
Spiderwick Chronicles - Half screen problem in book fixed
Suikoden III - Half screen black and white effect fixed
SWAT - Global Strike Team - Player 2 colours corrected
Taiko no Tatsujin Bang Tap - Lighting overlay (top left corner) fixed
Tekken 5 - Fire effect can now be used upscaled and half screen fire effect problem is fixed
TOCA Race Driver 2 - shadows fixed
Time Crisis 3 - Post processing looks correct now
Tomb Raider - Legends - Fixes for post lighting effects not covering the screen in some levels and goggles
Urban Reign - Post bloom/blur effect
Wild Arms 5 - No longer requires Framebuffer Conversion hack ,meaning sepia scenes now upscale properly
Wrath Unleashed - Fixes colours
WRC 3 - Half screen fog effect fixed.

Improves but doesn't currently fix:
Pachipara
Raw Danger
Steambot Chronicles

All the above games will likely need a further CRC to fix the remaining issues due to a weird shuffle and manual deswizzling of depth.

Note: This is gated behind Tex in RT and will break some games if left on, be it on your own head!

Fixes #11417 - Battlefield 2
Fixes #11416 - Battlefield 2
Fixes #8869 - Battlefield 2
Fixes #11085 - Death by Degrees
Fixes #3855 - Drakengard
Fixes #10399 - Hitman - Contracts
Fixes #4251 - Hitman - Blood Money
Fixes #12215 - Jak green sage's eyes
Fixes #4964 - Jak X - Combat Racing
Fixes #11870 - King Kong
Fixes #10164 - Manhunt 2
Fixes #8574 - Ridge Racer V coloured light problem
Fixes #8328 - Stolen
Fixes #3849 - Suikoden 3
Fixes #10471 - SWAT Global Strike Team
Fixes #8995 - Tekken 5
Fixes #7942 - Time Crisis 3
Fixes #913 - TOCA Race Driver 2
Fixes #267 - Wrath Unleashed
Fixes #10982 - WRC 3
Fixes #9888 - Conflict Desert Storm
Fixes #11965 - Delta Force - Black Hawk Down
Fixes #10763 - Urban Reign

### Screenshots

Battlefield 2:
Master:
![image](https://github.com/user-attachments/assets/d540ba47-aa9c-4d50-b3d5-153121443531)
PR:
![image](https://github.com/user-attachments/assets/83f06423-cd22-4516-b98d-79f655214eae)

Call of Duty - World at War:
Master:
![image](https://github.com/user-attachments/assets/58e257f4-ae49-4fcb-aa85-139f366e0851)
PR:
![image](https://github.com/user-attachments/assets/34f2f969-b887-45d6-9c64-b4d481cc0f18)

Death by Degrees (in native as the fog doesn't upscale well, even with fixes):
Master:
![image](https://github.com/user-attachments/assets/cc7c6649-a6c5-4833-8bb9-4693a7007c20)
PR:
![image](https://github.com/user-attachments/assets/77aee32c-24e0-4622-97c1-0ca2d8e5d22e)
Upscaled on PR just to show:
Edit: This is no longer the case thanks to Align to Native wtih Texture Offsets.
![image](https://github.com/user-attachments/assets/d187a4a8-55a2-4106-82b2-f1e96f8c8f16)

Delta Force - Black Hawk Down:
Master:
![image](https://github.com/user-attachments/assets/62831306-72b1-4a2f-a807-b4bad2097af8)
PR:
![image](https://github.com/user-attachments/assets/8c38f919-8434-415d-98c2-658917094d7a)

Drakengard:
Master:
![image](https://github.com/user-attachments/assets/56fd843b-2b22-4cd1-a484-c2c317b5238d)
PR:
![image](https://github.com/user-attachments/assets/44960fc7-dc32-4627-ac43-a94e392ef3b6)

Hitman - Blood Money:
Master:
![image](https://github.com/user-attachments/assets/e1d2dd4a-299d-4201-b05b-adc2b4ba0bac)
PR:
![image](https://github.com/user-attachments/assets/08a652cd-c7a2-40d1-96a1-f067ec7766a7)

Hitman - Contracts:
Master:
![image](https://github.com/user-attachments/assets/0879235f-dfa3-4672-95ae-f2bc41b5dd8b)
PR:
![image](https://github.com/user-attachments/assets/28f39492-66b5-4ff3-8ec7-63440685b5f7)

Ghost in the Shell:
Master:
![image](https://github.com/user-attachments/assets/63ffca8d-a712-46d8-8ed0-648b99665668)
PR:
![image](https://github.com/user-attachments/assets/e573d820-85a2-4d81-931e-d1ef52e0c315)

Jak and Daxter - The Precursor Legacy:
Master:
![image](https://github.com/user-attachments/assets/832e7f25-bd63-46ca-bb28-225ee3a5357c)
PR:
![image](https://github.com/user-attachments/assets/f599c785-49f6-4a4e-b54b-19d76ed8fe51)

Jak X - Modern Combat Racing:
Master:
![image](https://github.com/user-attachments/assets/a52135d1-966c-4941-9841-08b4e39a83a1)
PR:
![image](https://github.com/user-attachments/assets/42f3b70a-8404-4470-b7f7-fd0adb7a3d83)

Peter Jackson's King Kong:
Master:
![image](https://github.com/user-attachments/assets/d5961b75-512b-42fb-8d38-d788569a3013)
PR:
![image](https://github.com/user-attachments/assets/905be65a-bf65-47f0-9a0a-17d61f4b1717)

Manhunt 2:
Master:
![image](https://github.com/user-attachments/assets/7b7e0f84-a1c4-4d22-a654-6d13b58ac1f5)
PR:
![image](https://github.com/user-attachments/assets/5d9e16ab-35ae-4afe-b141-309b438db347)

Ridge Racer V (Intro, to show upscaling now works):
Master:
![image](https://github.com/user-attachments/assets/b669422e-3961-4fdb-a07a-03b437db06fb)
PR:
![image](https://github.com/user-attachments/assets/c71a52ea-3673-4471-9d22-0d402d20c4a5)

Sniper Elite:
Master:
![image](https://github.com/user-attachments/assets/cd949a2d-eb0e-4150-b3b0-feb5f81d6300)
PR:
![image](https://github.com/user-attachments/assets/83214377-a428-4925-8f9d-71423876a78c)

Stolen:
Master (Had to take this twice because it flashes black ever other frame:
![image](https://github.com/user-attachments/assets/50a9b72e-4500-4622-96af-8bbda75289e8)
PR:
![image](https://github.com/user-attachments/assets/19a55051-e4b0-4506-b993-0c4510568178)

Spiderwick Chronicles:
Master:
![image](https://github.com/user-attachments/assets/b96330e1-e8e0-43b2-b3ba-cd85772b3230)
PR:
![image](https://github.com/user-attachments/assets/0e529c4e-9262-4e6c-8ba3-a6fc6c419890)

Suikoden III:
Master:
![image](https://github.com/user-attachments/assets/2049d2f0-8318-4dfe-8d13-ed2a3a7ae144)
PR:
![image](https://github.com/user-attachments/assets/8ea4f4fb-c99d-4516-b66b-9ab28f4264a4)

SWAT - Global Strike Team:
Master:
![image](https://github.com/user-attachments/assets/4ded2bf5-3d13-4061-b845-23394f6a0f90)
PR:
![image](https://github.com/user-attachments/assets/7e4e9b2a-aa89-4133-b9ca-e2eff672a185)

Taiko no Tatsujin Bang Tap (in Native res as it doesn't upscale well):
Master:
![image](https://github.com/user-attachments/assets/26860688-6c98-40fb-b43c-dfef0b5f8ffb)
PR:
![image](https://github.com/user-attachments/assets/b546a442-1892-4e20-9d41-af0a19c2ed7e)

TOCA Race Driver 2:
Master:
![image](https://github.com/user-attachments/assets/c3ae344d-0422-4bcb-a5f4-e040d5d0dcdb)
PR:
![image](https://github.com/user-attachments/assets/e4351e32-c922-45cb-a2a2-189c1ea056b6)

TOCA Race Driver 3:
Master:
![image](https://github.com/user-attachments/assets/f5455214-df39-45d4-8afa-e20199dd1370)
PR:
![image](https://github.com/user-attachments/assets/5ddfcb9c-a425-44e8-8e53-7f955e7ba43d)

Time Crisis 3 (Native as it doesn't upscale great):
Master:
![image](https://github.com/user-attachments/assets/e3f6a853-fa34-4c29-8ecd-5efceae86aa0)
PR:
![image](https://github.com/user-attachments/assets/1c8b8604-e682-4ca6-9c97-e396e61cc0f4)

Tomb Raider Legends:
Master:
![image](https://github.com/user-attachments/assets/78d8456b-9443-42f0-96f5-7eb48ab1e8be)
PR:
![image](https://github.com/user-attachments/assets/61200480-080c-4356-af24-11f8e6caf07a)

Wild Arms 5 (To show it now upscales):
Master:
![image](https://github.com/user-attachments/assets/92e00447-9789-49b0-8502-2df3fc775a06)
PR:
![image](https://github.com/user-attachments/assets/54ec70ee-31ea-4885-9f56-4c6bfbf58909)

Wrath Unleashed:
Master:
![image](https://github.com/user-attachments/assets/3b43a426-f954-4378-ab7a-349c37e8ac7c)
PR:
![image](https://github.com/user-attachments/assets/552f72d1-f35f-40b8-af9e-65262410bb7f)

WRC 3 (Fog on the left):
Master:
![image](https://github.com/user-attachments/assets/9c956c86-3787-4b87-991c-b73f35a9072c)
PR:
![image](https://github.com/user-attachments/assets/b94fe461-8398-478b-8f7d-b34eb6799e66)
