### PR TITLE
GameDB: Revert wrongly changed game title

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -52138,7 +52138,7 @@ SLPS-25168:
   name: "NBA Live 2003"
   region: "NTSC-J"
 SLPS-25169:
-  name: ARMORED CORE3 Silent Line
+  name: アーマード・コア 3　サイレントライン
   name-sort: あーまーどこあ3 さいれんとらいん
   name-en: "Armored Core 3 - Silent Line"
   region: "NTSC-J"


### PR DESCRIPTION
### Description of Changes
Reverted an accidentally changed game title by #10928 

### Rationale behind Changes
wrong names bad

### Suggested Testing Steps
See game list