### PR TITLE
GS/HW: Allow conversion from 32bit to 24bit depth

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -17124,6 +17124,10 @@ SLES-51785:
 SLES-51787:
   name: "Harry Potter - Quidditch World Cup"
   region: "PAL-M10"
+  gsHWFixes:
+    halfPixelOffset: 4 # Fixes post alignment.
+    nativeScaling: 1 # Fixes post processing smoothness.
+    recommendedBlendingLevel: 4 # Fixes missing lighting.
 SLES-51792:
   name: "Aliens Versus Predator - Extinction"
   region: "PAL-E"
@@ -28306,6 +28310,10 @@ SLKA-15015:
 SLKA-15016:
   name: "Harry Potter - Quidditch World Cup"
   region: "NTSC-K"
+  gsHWFixes:
+    halfPixelOffset: 4 # Fixes post alignment.
+    nativeScaling: 1 # Fixes post processing smoothness.
+    recommendedBlendingLevel: 4 # Fixes missing lighting.
 SLKA-15018:
   name: "Kidou Senshi Gundam Seed"
   region: "NTSC-K"
@@ -34381,6 +34389,10 @@ SLPM-62408:
   name-sort: はりーぽったー くぃでぃっち わーるどかっぷ
   name-en: "Harry Potter - Quidditch World Cup"
   region: "NTSC-J"
+  gsHWFixes:
+    halfPixelOffset: 4 # Fixes post alignment.
+    nativeScaling: 1 # Fixes post processing smoothness.
+    recommendedBlendingLevel: 4 # Fixes missing lighting.
 SLPM-62409:
   name: ウィザードリィ エンパイアIII 〜覇王の系譜〜
   name-sort: うぃざーどりぃ えんぱいあ3 はおうのけいふ
@@ -61317,6 +61329,10 @@ SLUS-20769:
   name: "Harry Potter - Quidditch World Cup"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 4 # Fixes post alignment.
+    nativeScaling: 1 # Fixes post processing smoothness.
+    recommendedBlendingLevel: 4 # Fixes missing lighting.
 SLUS-20770:
   name: "The Lord of the Rings - The Return of the King"
   name-sort: "Lord of the Rings, The - The Return of the King"

--- a/bin/resources/shaders/dx11/convert.fx
+++ b/bin/resources/shaders/dx11/convert.fx
@@ -237,6 +237,13 @@ float rgb5a1_to_depth16(float4 val)
 	return float(((c.r & 0xF8u) >> 3) | ((c.g & 0xF8u) << 2) | ((c.b & 0xF8u) << 7) | ((c.a & 0x80u) << 8)) * exp2(-32.0f);
 }
 
+float ps_convert_float32_float24(PS_INPUT input) : SV_Depth
+{
+	// Truncates depth value to 24bits
+	uint d = uint(sample_c(input.t).r * exp2(32.0f)) & 0xFFFFFF;
+	return float(d) * exp2(-32.0f);
+}
+
 float ps_convert_rgba8_float32(PS_INPUT input) : SV_Depth
 {
 	// Convert an RGBA texture into a float depth texture

--- a/bin/resources/shaders/opengl/convert.glsl
+++ b/bin/resources/shaders/opengl/convert.glsl
@@ -144,6 +144,15 @@ float rgb5a1_to_depth16(vec4 unorm)
 	return float(((c.r & 0xF8u) >> 3) | ((c.g & 0xF8u) << 2) | ((c.b & 0xF8u) << 7) | ((c.a & 0x80u) << 8)) * exp2(-32.0f);
 }
 
+#ifdef ps_convert_float32_float24
+void ps_convert_float32_float24()
+{
+	// Truncates depth value to 24bits
+	uint d = uint(sample_c().r * exp2(32.0f)) & 0xFFFFFF;
+	gl_FragDepth = float(d) * exp2(-32.0f);
+}
+#endif
+
 #ifdef ps_convert_rgba8_float32
 void ps_convert_rgba8_float32()
 {

--- a/bin/resources/shaders/vulkan/convert.glsl
+++ b/bin/resources/shaders/vulkan/convert.glsl
@@ -214,6 +214,15 @@ float rgb5a1_to_depth16(vec4 unorm)
 	return float(((c.r & 0xF8u) >> 3) | ((c.g & 0xF8u) << 2) | ((c.b & 0xF8u) << 7) | ((c.a & 0x80u) << 8)) * exp2(-32.0f);
 }
 
+#ifdef ps_convert_float32_float24
+void ps_convert_float32_float24()
+{
+	// Truncates depth value to 24bits
+	uint d = uint(sample_c(v_tex).r * exp2(32.0f)) & 0xFFFFFF;
+	gl_FragDepth = float(d) * exp2(-32.0f);
+}
+#endif
+
 #ifdef ps_convert_rgba8_float32
 void ps_convert_rgba8_float32()
 {

--- a/pcsx2/GS/Renderers/Common/GSDevice.cpp
+++ b/pcsx2/GS/Renderers/Common/GSDevice.cpp
@@ -64,6 +64,7 @@ const char* shaderName(ShaderConvert value)
 		case ShaderConvert::RGBA8_TO_FLOAT24_BILN:  return "ps_convert_rgba8_float24_biln";
 		case ShaderConvert::RGBA8_TO_FLOAT16_BILN:  return "ps_convert_rgba8_float16_biln";
 		case ShaderConvert::RGB5A1_TO_FLOAT16_BILN: return "ps_convert_rgb5a1_float16_biln";
+		case ShaderConvert::FLOAT32_TO_FLOAT24:     return "ps_convert_float32_float24";
 		case ShaderConvert::DEPTH_COPY:             return "ps_depth_copy";
 		case ShaderConvert::DOWNSAMPLE_COPY:        return "ps_downsample_copy";
 		case ShaderConvert::RGBA_TO_8I:             return "ps_convert_rgba_8i";

--- a/pcsx2/GS/Renderers/Common/GSDevice.h
+++ b/pcsx2/GS/Renderers/Common/GSDevice.h
@@ -39,6 +39,7 @@ enum class ShaderConvert
 	RGBA8_TO_FLOAT24_BILN,
 	RGBA8_TO_FLOAT16_BILN,
 	RGB5A1_TO_FLOAT16_BILN,
+	FLOAT32_TO_FLOAT24,
 	DEPTH_COPY,
 	DOWNSAMPLE_COPY,
 	RGBA_TO_8I,
@@ -78,6 +79,7 @@ static inline bool HasDepthOutput(ShaderConvert shader)
 		case ShaderConvert::RGBA8_TO_FLOAT24_BILN:
 		case ShaderConvert::RGBA8_TO_FLOAT16_BILN:
 		case ShaderConvert::RGB5A1_TO_FLOAT16_BILN:
+		case ShaderConvert::FLOAT32_TO_FLOAT24:
 		case ShaderConvert::DEPTH_COPY:
 			return true;
 		default:

--- a/pcsx2/GS/Renderers/Metal/convert.metal
+++ b/pcsx2/GS/Renderers/Metal/convert.metal
@@ -249,6 +249,13 @@ struct ConvertToDepthRes
 	}
 };
 
+fragment DepthOut ps_convert_float32_float24(ConvertShaderData data [[stage_in]], ConvertPSDepthRes res)
+{
+	// Truncates depth value to 24bits
+	uint val = uint(res.sample(data.t) * 0x1p32) & 0xFFFFFF;
+	return float(val) * 0x1p-32f;
+}
+
 fragment DepthOut ps_convert_rgba8_float32(ConvertShaderData data [[stage_in]], ConvertToDepthRes res)
 {
 	return rgba8_to_depth32(res.sample(data.t));


### PR DESCRIPTION
### Description of Changes
Truncates depth buffers from 32bit to 24bit values when a game requests to read depth as 24bit.

### Rationale behind Changes
We store depth as a normalized 0-1 value, so when a game swaps to 24bit it still retains what would normally be the upper 8 bits of the depth buffer.  In the case of Harry Potter it expects this top 8 bits to be gone, and it messes up handling of the post processing.

Also added upscaling fixes to said game so it doesn't look sucky when upscaled.

### Suggested Testing Steps
Dump run said it was fine, test Harry Potter - Quidditch World Cup. Also try Superman Returns and X-Men - Wolverine's Revenge as they showed up in the dump run as probably hitting this code (have tried them, no noticable difference).

~~TODO: Need to do DX, OGL, Metal~~

You can test this dump:
[Harry Potter - Quidditch World Cup_SLUS-20769_20240626200416.gs.zip](https://github.com/user-attachments/files/16020356/Harry.Potter.-.Quidditch.World.Cup_SLUS-20769_20240626200416.gs.zip)


Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/62053983-2e06-4cc1-8700-441cb2b1e30e)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/52dfb9f5-8c6d-4d3d-a6a4-993d5f811ae8)

