### PR TITLE
GS/HW: Prefer SW blend over HDR for colclip without overlap

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -4283,7 +4283,7 @@ void GSRendererHW::EmulateBlending(int rt_alpha_min, int rt_alpha_max, bool& DAT
 			// Blending with alpha > 1 will be wrong, except BLEND_HW2.
 			|| (!(blend_flag & BLEND_HW2) && (alpha_c2_high_one || alpha_c0_high_max_one) && no_prim_overlap)
 			// Ad blends are completely wrong without sw blend (Ad is 0.5 not 1 for 128). We can spare a barrier for it.
-			|| (blend_ad && no_prim_overlap);
+			|| (blend_ad && no_prim_overlap && !new_rt_alpha_scale);
 
 		switch (GSConfig.AccurateBlendingUnit)
 		{

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -4376,13 +4376,7 @@ void GSRendererHW::EmulateBlending(int rt_alpha_min, int rt_alpha_max, bool& DAT
 	// Color clip
 	if (COLCLAMP.CLAMP == 0)
 	{
-		bool free_colclip = false;
-		if (features.framebuffer_fetch)
-			free_colclip = true;
-		else if (features.texture_barrier)
-			free_colclip = no_prim_overlap || blend_non_recursive;
-		else
-			free_colclip = blend_non_recursive;
+		const bool free_colclip = features.framebuffer_fetch || no_prim_overlap || blend_non_recursive;
 
 		GL_DBG("COLCLIP Info (Blending: %u/%u/%u/%u, OVERLAP: %d)", m_conf.ps.blend_a, m_conf.ps.blend_b, m_conf.ps.blend_c, m_conf.ps.blend_d, m_prim_overlap);
 		if (color_dest_blend || color_dest_blend2)


### PR DESCRIPTION
### Description of Changes

Why were we doing this to begin with?? It's two copies versus one.

As much as I dislike doing things that benefit DX, this is a no-brainer.

### Rationale behind Changes

Fixes #11480.

Honourable mentions:
```
Big.Mutha.Truckers ['Draw Calls: -405 [1308=>903]', 'Render Passes: -535 [1152=>617]', 'Copies: -202 [764=>562]']
Detective Conan MENU Graphics Bug Multi Frame ['Draw Calls: -335 [1934=>1599]', 'Render Passes: -418 [1073=>655]', 'Copies: -167 [714=>547]']
sakura taisen shadows 1 (hw) ['Draw Calls: -46 [396=>350]', 'Render Passes: -53 [240=>187]', 'Copies: -23 [162=>139]']
Shadow_of_Rome_SLES-52950 ['Draw Calls: -88 [819=>731]', 'Render Passes: -61 [168=>107]', 'Copies: -44 [109=>65]']
Sly_2_-_Band_of_Thieves_SCUS-97316_20221019165824 ['Draw Calls: -1013 [3868=>2855]', 'Render Passes: -761 [2842=>2081]', 'Copies: -507 [1226=>719]']
Tekken_5_SLUS-21059_20240108195029 ['Draw Calls: -186 [827=>641]', 'Render Passes: -163 [473=>310]', 'Copies: -93 [361=>268]']
The_Matrix_-_Path_of_Neo_SLUS-21273_20231022001128 ['Draw Calls: -30 [379=>349]', 'Render Passes: -51 [229=>178]', 'Copies: -15 [133=>118]']
```

Before:
![image](https://github.com/PCSX2/pcsx2/assets/11288319/560edcf3-da6d-498a-8ef7-4f0c9d981eca)
After:
![image](https://github.com/PCSX2/pcsx2/assets/11288319/f540d4b7-2c15-4195-a029-e82590fa4f5e)
Before:
![image](https://github.com/PCSX2/pcsx2/assets/11288319/595bfa67-3934-4c48-b921-d51519b5fc13)
After:
![image](https://github.com/PCSX2/pcsx2/assets/11288319/18c7ff54-eb05-402d-bafa-51b2fbc04eeb)

### Suggested Testing Steps

Check linked castlevania dump.