### PR TITLE
Qt: Fix crash in copy game settings

### DIFF
--- a/pcsx2-qt/Settings/SettingsWindow.cpp
+++ b/pcsx2-qt/Settings/SettingsWindow.cpp
@@ -299,6 +299,7 @@ void SettingsWindow::onCopyGlobalSettingsClicked()
 	{
 		auto lock = Host::GetSettingsLock();
 		Pcsx2Config::CopyConfiguration(m_sif.get(), *Host::Internal::GetBaseSettingsLayer());
+		Pcsx2Config::ClearInvalidPerGameConfiguration(m_sif.get());
 	}
 	saveAndReloadGameSettings();
 

--- a/pcsx2-qt/Settings/SettingsWindow.cpp
+++ b/pcsx2-qt/Settings/SettingsWindow.cpp
@@ -303,7 +303,7 @@ void SettingsWindow::onCopyGlobalSettingsClicked()
 	saveAndReloadGameSettings();
 
 
-	QMessageBox::information(reopen(), tr("PCSX2 Settings"), tr("Per-game configuration copied from global settings."));
+	reopen(tr("Per-game configuration copied from global settings."));
 }
 
 void SettingsWindow::onClearSettingsClicked()
@@ -324,17 +324,16 @@ void SettingsWindow::onClearSettingsClicked()
 	Pcsx2Config::ClearConfiguration(m_sif.get());
 	saveAndReloadGameSettings();
 
-	QMessageBox::information(reopen(), tr("PCSX2 Settings"), tr("Per-game configuration cleared."));
+	reopen(tr("Per-game configuration cleared."));
 }
 
-SettingsWindow* SettingsWindow::reopen()
+void SettingsWindow::reopen(const QString& message)
 {
 	// This doesn't work for global settings, because MainWindow maintains a pointer.
 	if (!m_sif)
-		return this;
+		return;
 
-	close();
-
+	// After closing, this pointer is freed. So we need to grab everything early.
 	std::unique_ptr<INISettingsInterface> new_sif = std::make_unique<INISettingsInterface>(m_sif->GetFileName());
 	if (FileSystem::FileExists(new_sif->GetFileName().c_str()))
 		new_sif->Load();
@@ -344,9 +343,14 @@ SettingsWindow* SettingsWindow::reopen()
 
 	SettingsWindow* dlg = new SettingsWindow(std::move(new_sif), game, m_serial, m_disc_crc, m_filename);
 	dlg->QWidget::setWindowTitle(windowTitle());
-	dlg->show();
 
-	return dlg;
+	// See note above.
+	QtHost::RunOnUIThread([this, dlg, message]() {
+		close();
+		dlg->show();
+		if (!message.isEmpty())
+			QMessageBox::information(dlg, tr("PCSX2 Settings"), message);
+	});
 }
 
 void SettingsWindow::addWidget(QWidget* widget, QString title, QString icon, QString help_text)

--- a/pcsx2-qt/Settings/SettingsWindow.h
+++ b/pcsx2-qt/Settings/SettingsWindow.h
@@ -119,7 +119,7 @@ private:
 	void addWidget(QWidget* widget, QString title, QString icon, QString help_text);
 	bool handleWheelEvent(QWheelEvent* event);
 
-	SettingsWindow* reopen();
+	void reopen(const QString& message);
 
 	std::unique_ptr<INISettingsInterface> m_sif;
 

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -1195,6 +1195,9 @@ struct Pcsx2Config
 
 	/// Clears all core keys from the specified interface.
 	static void ClearConfiguration(SettingsInterface* dest_si);
+
+	/// Removes keys that are not valid for per-game settings.
+	static void ClearInvalidPerGameConfiguration(SettingsInterface* si);
 };
 
 extern Pcsx2Config EmuConfig;

--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -2770,6 +2770,7 @@ void FullscreenUI::DoCopyGameSettings()
 		return;
 
 	Pcsx2Config::CopyConfiguration(s_game_settings_interface.get(), *GetEditingSettingsInterface(false));
+	Pcsx2Config::ClearInvalidPerGameConfiguration(s_game_settings_interface.get());
 
 	SetSettingsChanged(s_game_settings_interface.get());
 

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -1838,6 +1838,13 @@ void Pcsx2Config::ClearConfiguration(SettingsInterface* dest_si)
 	temp.LoadSaveCore(wrapper);
 }
 
+void Pcsx2Config::ClearInvalidPerGameConfiguration(SettingsInterface* si)
+{
+	// Deprecated in favor of patches.
+	si->DeleteValue("EmuCore", "EnableWideScreenPatches");
+	si->DeleteValue("EmuCore", "EnableNoInterlacingPatches");
+}
+
 void EmuFolders::SetAppRoot()
 {
 	const std::string program_path = FileSystem::GetProgramPath();


### PR DESCRIPTION
### Description of Changes

derp derp

### Rationale behind Changes

Fixes #11489.

### Suggested Testing Steps

Check steps listed in #11489.
