### PR TITLE
Debugger Expressions: Add FPU registers to breakpoint conditionals.

### DIFF
--- a/pcsx2/DebugTools/DebugInterface.cpp
+++ b/pcsx2/DebugTools/DebugInterface.cpp
@@ -55,10 +55,16 @@ public:
 		{
 			char reg[8];
 			std::snprintf(reg, std::size(reg), "r%d", i);
-
 			if (StringUtil::Strcasecmp(str, reg) == 0 || StringUtil::Strcasecmp(str, cpu->getRegisterName(0, i)) == 0)
 			{
 				referenceIndex = i;
+				return true;
+			}
+
+			std::snprintf(reg, std::size(reg), "f%d", i);
+			if (StringUtil::Strcasecmp(str, reg) == 0)
+			{
+				referenceIndex = i | REF_INDEX_FPU;
 				return true;
 			}
 		}
@@ -144,6 +150,10 @@ public:
 				}
 			}
 			return 0;
+		}
+		if (referenceIndex & REF_INDEX_FPU)
+		{
+			return cpu->getRegister(EECAT_FPR, referenceIndex & 0x1F)._u64[0];
 		}
 		return -1;
 	}

--- a/pcsx2/DebugTools/ExpressionParser.cpp
+++ b/pcsx2/DebugTools/ExpressionParser.cpp
@@ -539,10 +539,16 @@ bool parsePostfixExpression(PostfixExpression& exp, IExpressionFunctions* funcs,
 					valueStack.push_back(arg[1]<arg[0]);
 				break;
 			case EXOP_EQUAL:		// a == b
-				valueStack.push_back(arg[1]==arg[0]);
+				if (useFloat)
+					valueStack.push_back(fArg[1] == fArg[0]);
+				else
+					valueStack.push_back(arg[1]==arg[0]);
 				break;
 			case EXOP_NOTEQUAL:			// a != b
-				valueStack.push_back(arg[1]!=arg[0]);
+				if (useFloat)
+					valueStack.push_back(fArg[1] != fArg[0]);
+				else
+					valueStack.push_back(arg[1]!=arg[0]);
 				break;
 			case EXOP_BITAND:			// a&b
 				valueStack.push_back(arg[1]&arg[0]);


### PR DESCRIPTION
### Description of Changes
Add f[0->31] register support in the expression parser.

### Rationale behind Changes
Breaking only when an FPU register is a certain value is a possible need for some.

### Suggested Testing Steps
See if breakpoints properly evaluate FPU registers.

Note: Using `==` with floating point constants casts the value into a **host (NOT PS2)** float and compares it that way. Not using any float constants causes the expression parser to use bit comparisons. Think `f0==f2` for example. Using float constants has more error tolerance than a bit compare, but do know that like any other programming, using == with floating point is a sin and can cause a bad day. I was thinking of adding a lenient floating compare such as `~=` (identical to the memory search system) but defining behaviour rules for it was difficult, so I scrapped the idea.
