### PR TITLE
GraphicsSettingsWidget.cpp: Add text to upscaling multipliers and remove two fractional multipliers

### DIFF
--- a/pcsx2-qt/Settings/AdvancedSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/AdvancedSettingsWidget.cpp
@@ -61,7 +61,7 @@ AdvancedSettingsWidget::AdvancedSettingsWidget(SettingsWindow* dialog, QWidget* 
 
 	dialog->registerWidgetHelp(m_ui.eeRoundingMode, tr("Rounding Mode"), tr("Chop/Zero (Default)"), tr("Changes how PCSX2 handles rounding while emulating the Emotion Engine's Floating Point Unit (EE FPU). "
 	"Because the various FPUs in the PS2 are non-compliant with international standards, some games may need different modes to do math correctly. The default value handles the vast majority of games; <b>modifying this setting when a game is not having a visible problem can cause instability.</b>"));
-	dialog->registerWidgetHelp(m_ui.eeDivRoundingMode, tr("Division Rounding Mode"), tr("Nearest (Default)"), tr("Determines how the results of floating-point division is rounded. Some games need specific settings; <b>modifying this setting when a game is not having a visible problem can cause instability.</b>"));
+	dialog->registerWidgetHelp(m_ui.eeDivRoundingMode, tr("Division Rounding Mode"), tr("Nearest (Default)"), tr("Determines how the results of floating-point division are rounded. Some games need specific settings; <b>modifying this setting when a game is not having a visible problem can cause instability.</b>"));
 
 	dialog->registerWidgetHelp(m_ui.eeClampMode, tr("Clamping Mode"), tr("Normal (Default)"), tr("Changes how PCSX2 handles keeping floats in a standard x86 range. "
 	"The default value handles the vast majority of games; <b>modifying this setting when a game is not having a visible problem can cause instability.</b>"));

--- a/pcsx2-qt/Settings/GameFixSettingsWidget.ui
+++ b/pcsx2-qt/Settings/GameFixSettingsWidget.ui
@@ -53,7 +53,7 @@
        <item>
         <widget class="QGroupBox" name="groupBox">
          <property name="title">
-          <string>Game Fixes (NOT recommended to change globally)</string>
+          <string>Game Fixes</string>
          </property>
          <layout class="QVBoxLayout" name="verticalLayout_2">
           <item>

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
@@ -2087,6 +2087,13 @@
               </property>
              </widget>
             </item>
+            <item row="1" column="1">
+             <widget class="QCheckBox" name="extendedUpscales">
+              <property name="text">
+               <string>Extended Upscaling Multipliers</string>
+              </property>
+             </widget>
+            </item>
            </layout>
           </item>
           <item row="2" column="0">

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -598,6 +598,7 @@ struct Pcsx2Config
 					SynchronousMTGS : 1,
 					VsyncEnable : 1,
 					DisableMailboxPresentation : 1,
+					ExtendedUpscalingMultipliers : 1,
 					PCRTCAntiBlur : 1,
 					DisableInterlaceOffset : 1,
 					PCRTCOffsets : 1,

--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -3485,20 +3485,22 @@ void FullscreenUI::DrawGraphicsSettingsPage(SettingsInterface* bsi, bool show_ad
 	};
 	static const char* s_resolution_options[] = {
 		FSUI_NSTR("Native (PS2)"),
-		FSUI_NSTR("1.25x Native"),
-		FSUI_NSTR("1.5x Native"),
-		FSUI_NSTR("1.75x Native"),
-		FSUI_NSTR("2x Native (~720p)"),
-		FSUI_NSTR("2.25x Native"),
-		FSUI_NSTR("2.5x Native"),
-		FSUI_NSTR("2.75x Native"),
-		FSUI_NSTR("3x Native (~1080p)"),
-		FSUI_NSTR("3.5x Native"),
-		FSUI_NSTR("4x Native (~1440p/2K)"),
-		FSUI_NSTR("5x Native (~1620p)"),
-		FSUI_NSTR("6x Native (~2160p/4K)"),
-		FSUI_NSTR("7x Native (~2520p)"),
-		FSUI_NSTR("8x Native (~2880p)"),
+		FSUI_NSTR("1.25x Native (~450px)"),
+		FSUI_NSTR("1.5x Native (~540px)"),
+		FSUI_NSTR("1.75x Native (~630px)"),
+		FSUI_NSTR("2x Native (~720px/HD)"),
+		FSUI_NSTR("2.5x Native (~900px/HD+)"),
+		FSUI_NSTR("3x Native (~1080px/FHD)"),
+		FSUI_NSTR("3.5x Native (~1260px)"),
+		FSUI_NSTR("4x Native (~1440px/QHD)"),
+		FSUI_NSTR("5x Native (~1800px/QHD+)"),
+		FSUI_NSTR("6x Native (~2160px/4K UHD)"),
+		FSUI_NSTR("7x Native (~2520px)"),
+		FSUI_NSTR("8x Native (~2880px/5K UHD)"),
+		FSUI_NSTR("9x Native (~3240px)"),
+		FSUI_NSTR("10x Native (~3600px/6K UHD)"),
+		FSUI_NSTR("11x Native (~3960px)"),
+		FSUI_NSTR("12x Native (~4320px/8K UHD)"),
 	};
 	static const char* s_resolution_values[] = {
 		"1",
@@ -3506,9 +3508,7 @@ void FullscreenUI::DrawGraphicsSettingsPage(SettingsInterface* bsi, bool show_ad
 		"1.5",
 		"1.75",
 		"2",
-		"2.25",
 		"2.5",
-		"2.75",
 		"3",
 		"3.5",
 		"4",
@@ -3516,6 +3516,10 @@ void FullscreenUI::DrawGraphicsSettingsPage(SettingsInterface* bsi, bool show_ad
 		"6",
 		"7",
 		"8",
+		"9",
+		"10",
+		"11",
+		"12",
 	};
 	static constexpr const char* s_bilinear_options[] = {
 		FSUI_NSTR("Nearest"),
@@ -3905,6 +3909,10 @@ void FullscreenUI::DrawGraphicsSettingsPage(SettingsInterface* bsi, bool show_ad
 			FSUI_CSTR("Forces the use of FIFO over Mailbox presentation, i.e. double buffering instead of triple buffering. "
 					  "Usually results in worse frame pacing."),
 			"EmuCore/GS", "DisableMailboxPresentation", false);
+		/* DrawToggleSetting(bsi, FSUI_CSTR("Extended Upscaling Multipliers"),
+			FSUI_CSTR("Displays additional, very high upscaling multipliers dependent on GPU capability."),
+			"EmuCore/GS", "ExtendedUpscalingMultipliers", false); */
+		// TODO: Immplement this button properly
 		if (IsEditingGameSettings(bsi))
 		{
 			DrawIntListSetting(bsi, FSUI_CSTR("Hardware Download Mode"), FSUI_CSTR("Changes synchronization behavior for GS downloads."),
@@ -7108,6 +7116,8 @@ TRANSLATE_NOOP("FullscreenUI", "Skip Presenting Duplicate Frames");
 TRANSLATE_NOOP("FullscreenUI", "Skips displaying frames that don't change in 25/30fps games. Can improve speed, but increase input lag/make frame pacing worse.");
 TRANSLATE_NOOP("FullscreenUI", "Disable Mailbox Presentation");
 TRANSLATE_NOOP("FullscreenUI", "Forces the use of FIFO over Mailbox presentation, i.e. double buffering instead of triple buffering. Usually results in worse frame pacing.");
+TRANSLATE_NOOP("FullscreenUI", "Extended Upscaling Multipliers");
+TRANSLATE_NOOP("FullscreenUI", "Displays additional, very high upscaling multipliers dependent on GPU capability.");
 TRANSLATE_NOOP("FullscreenUI", "Hardware Download Mode");
 TRANSLATE_NOOP("FullscreenUI", "Changes synchronization behavior for GS downloads.");
 TRANSLATE_NOOP("FullscreenUI", "Allow Exclusive Fullscreen");

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -791,6 +791,7 @@ void Pcsx2Config::GSOptions::LoadSave(SettingsWrapper& wrap)
 
 	SettingsWrapBitBool(VsyncEnable);
 	SettingsWrapBitBool(DisableMailboxPresentation);
+	SettingsWrapBitBool(ExtendedUpscalingMultipliers);
 
 	SettingsWrapEntry(VsyncQueueSize);
 


### PR DESCRIPTION
### Description of Changes
* Add text for up to 25x resolution in the Qt UI.
* Remove 2.25x and 2.75x upscaling multipliers.

### Rationale behind Changes
Stenzek recently changed upscaling options to up to 12x by default; this adds text for those new options like we do for the old ones. Furthermore, in Advanced Settings, you can now go up to a resolution limited by your hardware specifications; this goes up to 25x for seemingly most people.

Regarding the removal of 2.25x and 2.75x, whereas 2.5x or 900p seems very reasonable, the 2.25x and 2.75x multipliers seem to just take up space, and I have never heard of anybody using them.

### Suggested Testing Steps
Enable Advanced Settings and look up to 25x. Also try without Advanced Settings enabled to make sure I didn't break anything for the default user experience.

### Addendum
Also fixed the 5x option reading `~1620p`, despite the fact that we establish a clear pattern of multiplying by 360, which should yield `~1800p`.

Also also removed the '(NOT recommended to change globally)` text within the game fixes UI, as it no longer applies given you can no longer implement game fixes globally and they must be done per-game.

Also also also brings the fullscreen UI more in line with Stenzek's PR. It now goes up to 12x by default, although it will eventually need to be fixed to allow up to 25x with advanced settings.

Also also also also adds a checkbox in the advanced graphics settings for the extended upscaling multipliers instead of showing them automatically when advanced settings are shown.

### Screenshots
![12x (non-advanced)](https://github.com/PCSX2/pcsx2/assets/12673964/b21f4de4-86f5-4246-b69f-638d42321989)
![25x (advanced)](https://github.com/PCSX2/pcsx2/assets/12673964/f7f0a789-c251-4225-a064-5a54e5c43b40)