### PR TITLE
Add eeClampMode fix to SLPM-66644

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -45821,6 +45821,8 @@ SLPM-66644:
   name-sort: Jりーぐ ぷろさっかーくらぶをつくろう!5
   name-en: "J-League Pro Soccer Club o Tsukurou 5"
   region: "NTSC-J"
+  clampModes:
+    eeClampMode: 3 # Makes the game to correctly register left and right Dpad button input.
 SLPM-66645:
   name: バイオニクル ヒーローズ
   name-sort: ばいおにくる ひーろーず


### PR DESCRIPTION
### Description of Changes
Add eeClampMode fix to SLPM-66644 (J-League Pro Soccer Club o Tsukurou 5)

### Rationale behind Changes
Makes the game correctly register left and right Dpad button input in certain screens.

### Suggested Testing Steps
Go to the roster screen, and without patch you can't go further right than the leftmost players. You can do that with the patch. Patch adapted from SLES-54151 (same engine).