### PR TITLE
GameDB: Add eeClampMode fix to SLPM-66644

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -23685,7 +23685,7 @@ SLES-54151:
   region: "PAL-M5"
   compat: 5
   clampModes:
-    eeClampMode: 3 # Makes the game to correctly register left and right Dpad button input.
+    eeClampMode: 3 # Makes the game correctly register left and right Dpad button input.
   memcardFilters: # Enables import of players from completed career saves.
     - "SLES-54151"
     - "SLES-54153"
@@ -45821,6 +45821,8 @@ SLPM-66644:
   name-sort: Jりーぐ ぷろさっかーくらぶをつくろう!5
   name-en: "J-League Pro Soccer Club o Tsukurou 5"
   region: "NTSC-J"
+  clampModes:
+    eeClampMode: 3 # Makes the game correctly register left and right Dpad button input.
 SLPM-66645:
   name: バイオニクル ヒーローズ
   name-sort: ばいおにくる ひーろーず


### PR DESCRIPTION
Previously under #11502, resubmitted with cleaner commit (and Unix EOL)
Previously contributed under @CelestialRyuneko and @JamesKnight313 (both accounts lost to 2FA failure)

### Description of Changes
Add eeClampMode fix to SLPM-66644 (J-League Pro Soccer Club o Tsukurou 5)

### Rationale behind Changes
Makes the game correctly register left and right Dpad button input in certain screens.

### Suggested Testing Steps
Go to the roster screen, and without patch you can't go further right than the leftmost players. You can do that with the patch. Patch adapted from SLES-54151 (same engine).

