### PR TITLE
USB: Fix period key not working

### DIFF
--- a/pcsx2/USB/usb-hid/usb-hid.cpp
+++ b/pcsx2/USB/usb-hid/usb-hid.cpp
@@ -546,7 +546,7 @@ namespace usb_hid
 		{Q_KEY_CODE_CUT, "Cut"},
 		{Q_KEY_CODE_D, "D"},
 		{Q_KEY_CODE_DELETE, "Delete"},
-		{Q_KEY_CODE_DOT, "Dot"},
+		{Q_KEY_CODE_DOT, "Period"},
 		{Q_KEY_CODE_DOWN, "Down"},
 		{Q_KEY_CODE_E, "E"},
 		{Q_KEY_CODE_END, "End"},


### PR DESCRIPTION
### Description of Changes
Map `Q_KEY_CODE_DOT` to "Period" instead of "Dot"

### Rationale behind Changes
Fix the regression noted in https://github.com/PCSX2/pcsx2/issues/7605#issuecomment-2209905668

As far as I can tell, current code builds mappings between the Q_KEY_CODE (which is the scan code) to QT::Keys based on the name.
The equivalent QT key `Qt::Key_Period` has the name of "Period" and wouldn't match before.

### Suggested Testing Steps
Test keyboard input, in particular the "." button.