### PR TITLE
GS: Clear draw queue when using the null renderer

### DIFF
--- a/pcsx2/GS/Renderers/Null/GSRendererNull.cpp
+++ b/pcsx2/GS/Renderers/Null/GSRendererNull.cpp
@@ -5,6 +5,13 @@
 
 GSRendererNull::GSRendererNull() = default;
 
+void GSRendererNull::VSync(u32 field, bool registers_written, bool idle_frame)
+{
+	GSRenderer::VSync(field, registers_written, idle_frame);
+
+	m_draw_transfers.clear();
+}
+
 void GSRendererNull::Draw()
 {
 }

--- a/pcsx2/GS/Renderers/Null/GSRendererNull.h
+++ b/pcsx2/GS/Renderers/Null/GSRendererNull.h
@@ -11,6 +11,7 @@ public:
 	GSRendererNull();
 
 protected:
+	void VSync(u32 field, bool registers_written, bool idle_frame) override;
 	void Draw() override;
 	GSTexture* GetOutput(int i, float& scale, int& y_offset) override;
 };


### PR DESCRIPTION
### Description of Changes
The null renderer was ignoring draws a little _too_ well. The draw queue was filling endlessly, causing a memory leak.

### Rationale behind Changes
Memory leaks are bad

### Suggested Testing Steps
Run a heavy game (GT4 night course worked well) with the null renderer with the framerate unlocked and see if memory usage increases a lot. GS dumps were affected too.
