### PR TITLE
GS/HW: Improve scale detection and allow non-bilinear downscales

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -20072,6 +20072,7 @@ SLES-52917:
     eeRoundMode: 2 # Fixes missing text.
   gsHWFixes:
     autoFlush: 1 # Fixes player shadow.
+    nativeScaling: 2 # Fixes post processing position.
 SLES-52918:
   name: "Scaler"
   region: "PAL-M4"
@@ -20080,6 +20081,7 @@ SLES-52918:
     eeRoundMode: 2 # Fixes missing text.
   gsHWFixes:
     autoFlush: 1 # Fixes player shadow.
+    nativeScaling: 2 # Fixes post processing position.
 SLES-52919:
   name: "NRL Rugby League 2"
   region: "PAL-E"
@@ -62349,6 +62351,7 @@ SLUS-20957:
     eeRoundMode: 2 # Fixes missing text.
   gsHWFixes:
     autoFlush: 1 # Fixes player shadow.
+    nativeScaling: 2 # Fixes post processing position.
 SLUS-20958:
   name: "Tom Clancy's Splinter Cell - Pandora Tomorrow"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
Allow detection of non-bilinear downscales

### Rationale behind Changes
Scaler downscales non-bilinearly.

### Suggested Testing Steps
Test Scaler and some random games with native scaling.

Scaler:
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/f210ef24-12f7-4009-bb29-d12757e2358f)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/079fede0-e4a7-4928-9add-25b1cb97e9dc)


Drakengard 2 slightly improves:
Master:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/255a6d4c-133a-4b6f-9f83-9be17a0e180c)
PR:
![image](https://github.com/PCSX2/pcsx2/assets/6278726/f8dbf6e0-9b04-4537-8066-6b5d3ae4d64f)
