### PR TITLE
GS/HW: Check for full cover in more situations when we disable blending.

### DIFF
--- a/bin/resources/shaders/dx11/convert.fx
+++ b/bin/resources/shaders/dx11/convert.fx
@@ -240,7 +240,7 @@ float rgb5a1_to_depth16(float4 val)
 float ps_convert_float32_float24(PS_INPUT input) : SV_Depth
 {
 	// Truncates depth value to 24bits
-	uint d = uint(sample_c(input.t).r * exp2(32.0f)) & 0xFFFFFF;
+	uint d = uint(sample_c(input.t).r * exp2(32.0f)) & 0xFFFFFFu;
 	return float(d) * exp2(-32.0f);
 }
 

--- a/bin/resources/shaders/opengl/convert.glsl
+++ b/bin/resources/shaders/opengl/convert.glsl
@@ -148,7 +148,7 @@ float rgb5a1_to_depth16(vec4 unorm)
 void ps_convert_float32_float24()
 {
 	// Truncates depth value to 24bits
-	uint d = uint(sample_c().r * exp2(32.0f)) & 0xFFFFFF;
+	uint d = uint(sample_c().r * exp2(32.0f)) & 0xFFFFFFu;
 	gl_FragDepth = float(d) * exp2(-32.0f);
 }
 #endif

--- a/bin/resources/shaders/vulkan/convert.glsl
+++ b/bin/resources/shaders/vulkan/convert.glsl
@@ -218,7 +218,7 @@ float rgb5a1_to_depth16(vec4 unorm)
 void ps_convert_float32_float24()
 {
 	// Truncates depth value to 24bits
-	uint d = uint(sample_c(v_tex).r * exp2(32.0f)) & 0xFFFFFF;
+	uint d = uint(sample_c(v_tex).r * exp2(32.0f)) & 0xFFFFFFu;
 	gl_FragDepth = float(d) * exp2(-32.0f);
 }
 #endif

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.h
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.h
@@ -95,7 +95,7 @@ private:
 	void SetupIA(float target_scale, float sx, float sy);
 	void EmulateTextureShuffleAndFbmask(GSTextureCache::Target* rt, GSTextureCache::Source* tex);
 	bool EmulateChannelShuffle(GSTextureCache::Target* src, bool test_only);
-	void EmulateBlending(int rt_alpha_min, int rt_alpha_max, bool& DATE_PRIMID, bool& DATE_BARRIER, GSTextureCache::Target* rt,
+	void EmulateBlending(int rt_alpha_min, int rt_alpha_max, const bool DATE, bool& DATE_PRIMID, bool& DATE_BARRIER, GSTextureCache::Target* rt,
 		bool can_scale_rt_alpha, bool& new_rt_alpha_scale);
 	void CleanupDraw(bool invalidate_temp_src);
 

--- a/pcsx2/ShaderCacheVersion.h
+++ b/pcsx2/ShaderCacheVersion.h
@@ -3,4 +3,4 @@
 
 /// Version number for GS and other shaders. Increment whenever any of the contents of the
 /// shaders change, to invalidate the cache.
-static constexpr u32 SHADER_CACHE_VERSION = 51;
+static constexpr u32 SHADER_CACHE_VERSION = 52;


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS/HW: Check for full cover in more situations when we disable blending.
More hits on RTA Scaling/Descaling.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Improves RTA Scale/Descale.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Some games gain/lose copies/passes/barriers.
dump run is clear on dx and vk, nothing broken.
Improves Star Wars Battlefront on DX with basic blending:
Before vs after:
![image](https://github.com/PCSX2/pcsx2/assets/18107717/d16fdfb3-0d32-4c37-9fc2-079b3b912697)
![image](https://github.com/PCSX2/pcsx2/assets/18107717/c585ed01-8cd4-4789-b224-55618bbae75a)


