### PR TITLE
GS: Miscellaneous changes.

### DIFF
--- a/pcsx2/GS/GSLocalMemory.cpp
+++ b/pcsx2/GS/GSLocalMemory.cpp
@@ -372,7 +372,7 @@ std::vector<GSVector2i>* GSLocalMemory::GetPage2TileMap(const GIFRegTEX0& TEX0)
 	int th = std::max<int>(1 << TEX0.TH, bs.y);
 
 	// Limit the size to the maximum size of the GS memory, there's no point in mapping more than this.
-	if ((tw * th) > VM_SIZE)
+	if ((tw * th) > static_cast<int>(VM_SIZE))
 	{
 		tw = 2048;
 		th = 2048;

--- a/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
+++ b/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
@@ -1118,6 +1118,7 @@ bool GSDeviceMTL::Create(GSVSyncMode vsync_mode, bool allow_present_throttle)
 				pdesc.depthAttachmentPixelFormat = MTLPixelFormatInvalid;
 				break;
 			case ShaderConvert::DEPTH_COPY:
+			case ShaderConvert::FLOAT32_TO_FLOAT24:
 			case ShaderConvert::RGBA8_TO_FLOAT32:
 			case ShaderConvert::RGBA8_TO_FLOAT24:
 			case ShaderConvert::RGBA8_TO_FLOAT16:


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS: Fix Wsign-compare warning.
GS/Metal: Add FLOAT32_TO_FLOAT24 case to DepthStencil texture format for shader convert.
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Correction, cleanup.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test 32 to 24 depth conversion still works on metal from https://github.com/PCSX2/pcsx2/pull/11476.
