### PR TITLE
Qt: Clarify Pressure Modifier String

### DIFF
--- a/pcsx2-qt/Translations/pcsx2-qt_en-US.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_en-US.ts
@@ -16,7 +16,7 @@
 <context>
     <name>Achievements</name>
     <message numerus="yes">
-        <location filename="../../pcsx2/Achievements.cpp" line="1021"/>
+        <location filename="../../pcsx2/Achievements.cpp" line="1023"/>
         <source>You have unlocked {} of %n achievements</source>
         <comment>Achievement popup</comment>
         <translation>
@@ -25,7 +25,7 @@
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../../pcsx2/Achievements.cpp" line="1024"/>
+        <location filename="../../pcsx2/Achievements.cpp" line="1026"/>
         <source>and earned {} of %n points</source>
         <comment>Achievement popup</comment>
         <translation>
@@ -34,7 +34,7 @@
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../../pcsx2/Achievements.cpp" line="1109"/>
+        <location filename="../../pcsx2/Achievements.cpp" line="1111"/>
         <source>%n achievements</source>
         <comment>Mastery popup</comment>
         <translation>
@@ -43,7 +43,7 @@
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../../pcsx2/Achievements.cpp" line="1111"/>
+        <location filename="../../pcsx2/Achievements.cpp" line="1113"/>
         <source>%n points</source>
         <comment>Mastery popup</comment>
         <translation>

--- a/pcsx2-qt/Translations/pcsx2-qt_en.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_en.ts
@@ -1914,7 +1914,6 @@ Leaderboard Position: {1} of {2}</source>
     </message>
     <message>
         <location filename="../Debugger/BreakpointDialog.ui" line="84"/>
-        <location filename="../Debugger/BreakpointDialog.ui" line="236"/>
         <source>Execute</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1960,41 +1959,43 @@ Leaderboard Position: {1} of {2}</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Debugger/BreakpointDialog.ui" line="242"/>
+        <location filename="../Debugger/BreakpointDialog.ui" line="239"/>
         <source>Condition</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Debugger/BreakpointDialog.ui" line="270"/>
+        <location filename="../Debugger/BreakpointDialog.ui" line="267"/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Debugger/BreakpointDialog.ui" line="280"/>
+        <location filename="../Debugger/BreakpointDialog.ui" line="277"/>
         <source>Enable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Debugger/BreakpointDialog.cpp" line="97"/>
-        <location filename="../Debugger/BreakpointDialog.cpp" line="112"/>
-        <location filename="../Debugger/BreakpointDialog.cpp" line="129"/>
-        <location filename="../Debugger/BreakpointDialog.cpp" line="137"/>
+        <location filename="../Debugger/BreakpointDialog.cpp" line="99"/>
+        <location filename="../Debugger/BreakpointDialog.cpp" line="114"/>
+        <location filename="../Debugger/BreakpointDialog.cpp" line="130"/>
+        <location filename="../Debugger/BreakpointDialog.cpp" line="138"/>
+        <location filename="../Debugger/BreakpointDialog.cpp" line="152"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Debugger/BreakpointDialog.cpp" line="97"/>
-        <location filename="../Debugger/BreakpointDialog.cpp" line="129"/>
+        <location filename="../Debugger/BreakpointDialog.cpp" line="99"/>
+        <location filename="../Debugger/BreakpointDialog.cpp" line="130"/>
         <source>Invalid address &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Debugger/BreakpointDialog.cpp" line="112"/>
+        <location filename="../Debugger/BreakpointDialog.cpp" line="114"/>
+        <location filename="../Debugger/BreakpointDialog.cpp" line="152"/>
         <source>Invalid condition &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Debugger/BreakpointDialog.cpp" line="137"/>
+        <location filename="../Debugger/BreakpointDialog.cpp" line="138"/>
         <source>Invalid size &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2009,7 +2010,6 @@ Leaderboard Position: {1} of {2}</source>
     <message>
         <location filename="../Debugger/Models/BreakpointModel.cpp" line="57"/>
         <location filename="../Debugger/Models/BreakpointModel.cpp" line="80"/>
-        <location filename="../Debugger/Models/BreakpointModel.cpp" line="82"/>
         <source>--</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15954,6 +15954,11 @@ This action cannot be reversed, and you will lose any saves on the card.</source
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../pcsx2/SIO/Pad/PadDualshock2.cpp" line="78"/>
+        <source>Pressure Modifier Amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../pcsx2/SIO/Pad/PadDualshock2.cpp" line="725"/>
         <source>Analog light is now on for port {0} / slot {1}</source>
         <translation type="unfinished"></translation>
@@ -15991,11 +15996,6 @@ This action cannot be reversed, and you will lose any saves on the card.</source
     <message>
         <location filename="../../pcsx2/SIO/Pad/PadDualshock2.cpp" line="72"/>
         <source>Increases or decreases the intensity of high frequency vibration sent by the game.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../pcsx2/SIO/Pad/PadDualshock2.cpp" line="78"/>
-        <source>Modifier Pressure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/pcsx2/SIO/Pad/PadDualshock2.cpp
+++ b/pcsx2/SIO/Pad/PadDualshock2.cpp
@@ -75,7 +75,7 @@ static const SettingInfo s_settings[] = {
 		TRANSLATE_NOOP("Pad", "Sets the deadzone for activating buttons/triggers, i.e. the fraction of the trigger "
 							  "which will be ignored."),
 		"0.00", "0.00", "1.00", "0.01", TRANSLATE_NOOP("Pad", "%.0f%%"), nullptr, nullptr, 100.0f},
-	{SettingInfo::Type::Float, "PressureModifier", TRANSLATE_NOOP("Pad", "Modifier Pressure"),
+	{SettingInfo::Type::Float, "PressureModifier", TRANSLATE_NOOP("Pad", "Pressure Modifier Amount"),
 		TRANSLATE_NOOP("Pad", "Sets the pressure when the modifier button is held."), "0.50", "0.01", "1.00", "0.01",
 		TRANSLATE_NOOP("Pad", "%.0f%%"), nullptr, nullptr, 100.0f},
 };


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->

![Screenshot_20240711_224519](https://github.com/PCSX2/pcsx2/assets/14798312/ea1cde28-503e-4452-b0c0-e76dd7122ecb)

This PR clarify the confusing pressure modifier string `Modifier Pressure` -> `Pressure Modifier Amount`

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Translation 100

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Already tested.