### PR TITLE
Qt: FMV tooltip expand + frame-time typo

### DIFF
--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -446,9 +446,9 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* dialog, QWidget* 
 			tr("Enables the option to show the overscan area on games which draw more than the safe area of the screen."));
 
 		dialog->registerWidgetHelp(
-			m_ui.fmvAspectRatio, tr("FMV Aspect Ratio"), tr("Off (Default)"),
+			m_ui.fmvAspectRatio, tr("FMV Aspect Ratio Override"), tr("Off (Default)"),
 			tr("Overrides the full-motion video (FMV) aspect ratio. "
-			   "If disabled, the FMV Aspect Ratio will match the same value the general Aspect Ratio setting instead."));
+			   "If disabled, the FMV Aspect Ratio will match the same value as the general Aspect Ratio setting."));
 
 		dialog->registerWidgetHelp(m_ui.PCRTCAntiBlur, tr("Anti-Blur"), tr("Checked"),
 			tr("Enables internal Anti-Blur hacks. Less accurate to PS2 rendering but will make a lot of games look less blurry."));

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -446,7 +446,9 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* dialog, QWidget* 
 			tr("Enables the option to show the overscan area on games which draw more than the safe area of the screen."));
 
 		dialog->registerWidgetHelp(
-			m_ui.fmvAspectRatio, tr("FMV Aspect Ratio"), tr("Off (Default)"), tr("Overrides the full-motion video (FMV) aspect ratio."));
+			m_ui.fmvAspectRatio, tr("FMV Aspect Ratio"), tr("Off (Default)"),
+			tr("Overrides the full-motion video (FMV) aspect ratio. "
+			   "If disabled, the FMV Aspect Ratio will match the same value the general Aspect Ratio setting instead."));
 
 		dialog->registerWidgetHelp(m_ui.PCRTCAntiBlur, tr("Anti-Blur"), tr("Checked"),
 			tr("Enables internal Anti-Blur hacks. Less accurate to PS2 rendering but will make a lot of games look less blurry."));

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
@@ -109,7 +109,7 @@
        <item row="2" column="0">
         <widget class="QLabel" name="fmvAspectRatioLabel">
          <property name="text">
-          <string>FMV Aspect Ratio:</string>
+          <string>FMV Aspect Ratio Override:</string>
          </property>
         </widget>
        </item>

--- a/pcsx2-qt/Translations/pcsx2-qt_af-ZA.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_af-ZA.ts
@@ -4392,8 +4392,8 @@ Enter function name</translation>
     </message>
     <message>
       <location filename="../Settings/EmulationSettingsWidget.cpp" line="136"/>
-      <source>Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame times, but add additional input lag.</source>
-      <translation type="unfinished">Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame times, but add additional input lag.</translation>
+      <source>Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame-times, but add additional input lag.</source>
+      <translation type="unfinished">Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame-times, but add additional input lag.</translation>
     </message>
     <message>
       <location filename="../Settings/EmulationSettingsWidget.cpp" line="139"/>
@@ -4892,8 +4892,8 @@ The URL was: %1</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6935"/>
-      <source>Shows a visual history of frame times in the upper-left corner of the display.</source>
-      <translation type="unfinished">Shows a visual history of frame times in the upper-left corner of the display.</translation>
+      <source>Shows a visual history of frame-times in the upper-left corner of the display.</source>
+      <translation type="unfinished">Shows a visual history of frame-times in the upper-left corner of the display.</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6936"/>
@@ -5031,8 +5031,8 @@ Do you wish to shutdown anyways and IRREVERSIBLY DESTROY YOUR MEMORY CARD?</tran
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6956"/>
-      <source>Pins emulation threads to CPU cores to potentially improve performance/frame time variance.</source>
-      <translation type="unfinished">Pins emulation threads to CPU cores to potentially improve performance/frame time variance.</translation>
+      <source>Pins emulation threads to CPU cores to potentially improve performance/frame-time variance.</source>
+      <translation type="unfinished">Pins emulation threads to CPU cores to potentially improve performance/frame-time variance.</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6953"/>
@@ -8404,8 +8404,8 @@ Do you want to load this save and continue?</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="7581"/>
-      <source>Show Frame Times</source>
-      <translation type="unfinished">Show Frame Times</translation>
+      <source>Show Frame-Times</source>
+      <translation type="unfinished">Show Frame-Times</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="7582"/>
@@ -11346,8 +11346,8 @@ Percentage sign that will appear next to a number. Add a space or whatever is ne
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="1672"/>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="723"/>
-      <source>Show Frame Times</source>
-      <translation type="unfinished">Show Frame Times</translation>
+      <source>Show Frame-Times</source>
+      <translation type="unfinished">Show Frame-Times</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="1726"/>
@@ -12018,8 +12018,8 @@ Swap chain: see Microsoft&apos;s Terminology Portal.</extracomment>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="790"/>
-      <source>Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out frame time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</source>
-      <translation type="unfinished">Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out frame time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</translation>
+      <source>Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out the frame-time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</source>
+      <translation type="unfinished">Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out the frame-time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="1152"/>

--- a/pcsx2-qt/Translations/pcsx2-qt_af-ZA.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_af-ZA.ts
@@ -5136,8 +5136,8 @@ Do you wish to shutdown anyways and IRREVERSIBLY DESTROY YOUR MEMORY CARD?</tran
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6981"/>
-      <source>FMV Aspect Ratio</source>
-      <translation type="unfinished">FMV Aspect Ratio</translation>
+      <source>FMV Aspect Ratio Override</source>
+      <translation type="unfinished">FMV Aspect Ratio Override</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6982"/>
@@ -10274,8 +10274,8 @@ Scanning recursively takes more time, but will identify files in subdirectories.
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="112"/>
-      <source>FMV Aspect Ratio:</source>
-      <translation type="unfinished">FMV Aspect Ratio:</translation>
+      <source>FMV Aspect Ratio Override:</source>
+      <translation type="unfinished">FMV Aspect Ratio Override:</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="120"/>
@@ -11710,8 +11710,8 @@ Swap chain: see Microsoft&apos;s Terminology Portal.</extracomment>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="444"/>
-      <source>FMV Aspect Ratio</source>
-      <translation type="unfinished">FMV Aspect Ratio</translation>
+      <source>FMV Aspect Ratio Override</source>
+      <translation type="unfinished">FMV Aspect Ratio Override</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="444"/>

--- a/pcsx2-qt/Translations/pcsx2-qt_ar-SA.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_ar-SA.ts
@@ -5157,7 +5157,7 @@ Do you wish to shutdown anyways and IRREVERSIBLY DESTROY YOUR MEMORY CARD?</sour
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6981"/>
-      <source>FMV Aspect Ratio</source>
+      <source>FMV Aspect Ratio Override</source>
       <translation>تناسب أبعاد الأفلام (FMV)</translation>
     </message>
     <message>
@@ -10303,7 +10303,7 @@ Scanning recursively takes more time, but will identify files in subdirectories.
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="112"/>
-      <source>FMV Aspect Ratio:</source>
+      <source>FMV Aspect Ratio Override:</source>
       <translation>تناسب أبعاد الأفلام (FMV):</translation>
     </message>
     <message>
@@ -11739,7 +11739,7 @@ Swap chain: see Microsoft&apos;s Terminology Portal.</extracomment>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="444"/>
-      <source>FMV Aspect Ratio</source>
+      <source>FMV Aspect Ratio Override</source>
       <translation>تناسب أبعاد الأفلام (FMV)</translation>
     </message>
     <message>

--- a/pcsx2-qt/Translations/pcsx2-qt_ar-SA.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_ar-SA.ts
@@ -4413,7 +4413,7 @@ Enter function name</source>
     </message>
     <message>
       <location filename="../Settings/EmulationSettingsWidget.cpp" line="136"/>
-      <source>Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame times, but add additional input lag.</source>
+      <source>Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame-times, but add additional input lag.</source>
       <translation>يُحدد الحد الأقصى لعدد الأُطر التي سيتم معالجتها من قِبل وحدة الGS، قبل أن تستمر وحدة المعالجة المركزية في عملها. ستساعد القيم الأعلى في تحسين الأداء وجعله أكثر استقراراً، لكن سوف يُزيد مدة استجابة الإدخال.</translation>
     </message>
     <message>
@@ -4913,7 +4913,7 @@ The URL was: %1</source>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6935"/>
-      <source>Shows a visual history of frame times in the upper-left corner of the display.</source>
+      <source>Shows a visual history of frame-times in the upper-left corner of the display.</source>
       <translation>يعرض سجلا مرئيا لأوقات الإطار في الزاوية العلوية اليسرى من العرض.</translation>
     </message>
     <message>
@@ -5052,7 +5052,7 @@ Do you wish to shutdown anyways and IRREVERSIBLY DESTROY YOUR MEMORY CARD?</sour
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6956"/>
-      <source>Pins emulation threads to CPU cores to potentially improve performance/frame time variance.</source>
+      <source>Pins emulation threads to CPU cores to potentially improve performance/frame-time variance.</source>
       <translation>تثبيت محاكاة المواضيع إلى نواة وحدة المعالجة المركزية لتحسين الأداء / الفرق الزمني.</translation>
     </message>
     <message>
@@ -8425,7 +8425,7 @@ Do you want to load this save and continue?</source>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="7581"/>
-      <source>Show Frame Times</source>
+      <source>Show Frame-Times</source>
       <translation>إظهار أوقات الإطار</translation>
     </message>
     <message>
@@ -11375,7 +11375,7 @@ Percentage sign that will appear next to a number. Add a space or whatever is ne
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="1672"/>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="723"/>
-      <source>Show Frame Times</source>
+      <source>Show Frame-Times</source>
       <translation>عرض أوقات الإطارات</translation>
     </message>
     <message>
@@ -12047,8 +12047,8 @@ Swap chain: see Microsoft&apos;s Terminology Portal.</extracomment>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="790"/>
-      <source>Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out frame time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</source>
-      <translation type="unfinished">Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out frame time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</translation>
+      <source>Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out the frame-time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</source>
+      <translation type="unfinished">Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out the frame-time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="1152"/>

--- a/pcsx2-qt/Translations/pcsx2-qt_bg-BG.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_bg-BG.ts
@@ -5133,8 +5133,8 @@ Do you wish to shutdown anyways and IRREVERSIBLY DESTROY YOUR MEMORY CARD?</tran
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6981"/>
-      <source>FMV Aspect Ratio</source>
-      <translation type="unfinished">FMV Aspect Ratio</translation>
+      <source>FMV Aspect Ratio Override</source>
+      <translation type="unfinished">FMV Aspect Ratio Override</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6982"/>
@@ -10271,8 +10271,8 @@ Scanning recursively takes more time, but will identify files in subdirectories.
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="112"/>
-      <source>FMV Aspect Ratio:</source>
-      <translation type="unfinished">FMV Aspect Ratio:</translation>
+      <source>FMV Aspect Ratio Override:</source>
+      <translation type="unfinished">FMV Aspect Ratio Override:</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="120"/>
@@ -11707,8 +11707,8 @@ Swap chain: see Microsoft&apos;s Terminology Portal.</extracomment>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="444"/>
-      <source>FMV Aspect Ratio</source>
-      <translation type="unfinished">FMV Aspect Ratio</translation>
+      <source>FMV Aspect Ratio Override</source>
+      <translation type="unfinished">FMV Aspect Ratio Override</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="444"/>

--- a/pcsx2-qt/Translations/pcsx2-qt_bg-BG.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_bg-BG.ts
@@ -4389,8 +4389,8 @@ Enter function name</translation>
     </message>
     <message>
       <location filename="../Settings/EmulationSettingsWidget.cpp" line="136"/>
-      <source>Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame times, but add additional input lag.</source>
-      <translation type="unfinished">Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame times, but add additional input lag.</translation>
+      <source>Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame-times, but add additional input lag.</source>
+      <translation type="unfinished">Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame-times, but add additional input lag.</translation>
     </message>
     <message>
       <location filename="../Settings/EmulationSettingsWidget.cpp" line="139"/>
@@ -4889,8 +4889,8 @@ The URL was: %1</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6935"/>
-      <source>Shows a visual history of frame times in the upper-left corner of the display.</source>
-      <translation type="unfinished">Shows a visual history of frame times in the upper-left corner of the display.</translation>
+      <source>Shows a visual history of frame-times in the upper-left corner of the display.</source>
+      <translation type="unfinished">Shows a visual history of frame-times in the upper-left corner of the display.</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6936"/>
@@ -5028,8 +5028,8 @@ Do you wish to shutdown anyways and IRREVERSIBLY DESTROY YOUR MEMORY CARD?</tran
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6956"/>
-      <source>Pins emulation threads to CPU cores to potentially improve performance/frame time variance.</source>
-      <translation type="unfinished">Pins emulation threads to CPU cores to potentially improve performance/frame time variance.</translation>
+      <source>Pins emulation threads to CPU cores to potentially improve performance/frame-time variance.</source>
+      <translation type="unfinished">Pins emulation threads to CPU cores to potentially improve performance/frame-time variance.</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6953"/>
@@ -8401,8 +8401,8 @@ Do you want to load this save and continue?</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="7581"/>
-      <source>Show Frame Times</source>
-      <translation type="unfinished">Show Frame Times</translation>
+      <source>Show Frame-Times</source>
+      <translation type="unfinished">Show Frame-Times</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="7582"/>
@@ -11343,8 +11343,8 @@ Percentage sign that will appear next to a number. Add a space or whatever is ne
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="1672"/>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="723"/>
-      <source>Show Frame Times</source>
-      <translation type="unfinished">Show Frame Times</translation>
+      <source>Show Frame-Times</source>
+      <translation type="unfinished">Show Frame-Times</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="1726"/>
@@ -12015,8 +12015,8 @@ Swap chain: see Microsoft&apos;s Terminology Portal.</extracomment>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="790"/>
-      <source>Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out frame time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</source>
-      <translation type="unfinished">Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out frame time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</translation>
+      <source>Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out the frame-time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</source>
+      <translation type="unfinished">Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out the frame-time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="1152"/>

--- a/pcsx2-qt/Translations/pcsx2-qt_ca-ES.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_ca-ES.ts
@@ -4392,7 +4392,7 @@ Introdueix el nom de la funció</translation>
     </message>
     <message>
       <location filename="../Settings/EmulationSettingsWidget.cpp" line="136"/>
-      <source>Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame times, but add additional input lag.</source>
+      <source>Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame-times, but add additional input lag.</source>
       <translation>Estableix la quantitat màxima de fotogrames que podran posar-se en la cua del GS abans que el subprocés de la CPU esperi que un fotograma sigui completat per a poder continuar. Un valor alt podria ajudar a suavitzar les durades de fotogrames irregulars, però afegirà més retard en l'entrada dels controls.</translation>
     </message>
     <message>
@@ -4892,8 +4892,8 @@ URL introduïda: %1</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6935"/>
-      <source>Shows a visual history of frame times in the upper-left corner of the display.</source>
-      <translation type="unfinished">Shows a visual history of frame times in the upper-left corner of the display.</translation>
+      <source>Shows a visual history of frame-times in the upper-left corner of the display.</source>
+      <translation type="unfinished">Shows a visual history of frame-times in the upper-left corner of the display.</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6936"/>
@@ -5031,8 +5031,8 @@ Do you wish to shutdown anyways and IRREVERSIBLY DESTROY YOUR MEMORY CARD?</tran
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6956"/>
-      <source>Pins emulation threads to CPU cores to potentially improve performance/frame time variance.</source>
-      <translation type="unfinished">Pins emulation threads to CPU cores to potentially improve performance/frame time variance.</translation>
+      <source>Pins emulation threads to CPU cores to potentially improve performance/frame-time variance.</source>
+      <translation type="unfinished">Pins emulation threads to CPU cores to potentially improve performance/frame-time variance.</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6953"/>
@@ -8404,8 +8404,8 @@ Do you want to load this save and continue?</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="7581"/>
-      <source>Show Frame Times</source>
-      <translation type="unfinished">Show Frame Times</translation>
+      <source>Show Frame-Times</source>
+      <translation type="unfinished">Show Frame-Times</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="7582"/>
@@ -11346,8 +11346,8 @@ Percentage sign that will appear next to a number. Add a space or whatever is ne
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="1672"/>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="723"/>
-      <source>Show Frame Times</source>
-      <translation type="unfinished">Show Frame Times</translation>
+      <source>Show Frame-Times</source>
+      <translation type="unfinished">Show Frame-Times</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="1726"/>
@@ -12018,8 +12018,8 @@ Swap chain: see Microsoft&apos;s Terminology Portal.</extracomment>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="790"/>
-      <source>Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out frame time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</source>
-      <translation type="unfinished">Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out frame time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</translation>
+      <source>Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out the frame-time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</source>
+      <translation type="unfinished">Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out the frame-time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="1152"/>

--- a/pcsx2-qt/Translations/pcsx2-qt_ca-ES.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_ca-ES.ts
@@ -5136,8 +5136,8 @@ Do you wish to shutdown anyways and IRREVERSIBLY DESTROY YOUR MEMORY CARD?</tran
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6981"/>
-      <source>FMV Aspect Ratio</source>
-      <translation type="unfinished">FMV Aspect Ratio</translation>
+      <source>FMV Aspect Ratio Override</source>
+      <translation type="unfinished">FMV Aspect Ratio Override</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6982"/>
@@ -10274,8 +10274,8 @@ Scanning recursively takes more time, but will identify files in subdirectories.
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="112"/>
-      <source>FMV Aspect Ratio:</source>
-      <translation type="unfinished">FMV Aspect Ratio:</translation>
+      <source>FMV Aspect Ratio Override:</source>
+      <translation type="unfinished">FMV Aspect Ratio Override:</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="120"/>
@@ -11710,8 +11710,8 @@ Swap chain: see Microsoft&apos;s Terminology Portal.</extracomment>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="444"/>
-      <source>FMV Aspect Ratio</source>
-      <translation type="unfinished">FMV Aspect Ratio</translation>
+      <source>FMV Aspect Ratio Override</source>
+      <translation type="unfinished">FMV Aspect Ratio Override</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="444"/>

--- a/pcsx2-qt/Translations/pcsx2-qt_cs-CZ.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_cs-CZ.ts
@@ -5146,7 +5146,7 @@ Přejete si přesto vypnout a NEVRATNĚ ZNIČIT VAŠI PAMĚŤOVOU KARTU?</transl
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6981"/>
-      <source>FMV Aspect Ratio</source>
+      <source>FMV Aspect Ratio Override</source>
       <translation>Poměr stran FMV</translation>
     </message>
     <message>
@@ -10288,8 +10288,8 @@ Scanning recursively takes more time, but will identify files in subdirectories.
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="112"/>
-      <source>FMV Aspect Ratio:</source>
-      <translation type="unfinished">FMV Aspect Ratio:</translation>
+      <source>FMV Aspect Ratio Override:</source>
+      <translation type="unfinished">FMV Aspect Ratio Override:</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="120"/>
@@ -11724,8 +11724,8 @@ Swap chain: see Microsoft&apos;s Terminology Portal.</extracomment>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="444"/>
-      <source>FMV Aspect Ratio</source>
-      <translation type="unfinished">FMV Aspect Ratio</translation>
+      <source>FMV Aspect Ratio Override</source>
+      <translation type="unfinished">FMV Aspect Ratio Override</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="444"/>

--- a/pcsx2-qt/Translations/pcsx2-qt_cs-CZ.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_cs-CZ.ts
@@ -4402,7 +4402,7 @@ Zadejte název funkce</translation>
     </message>
     <message>
       <location filename="../Settings/EmulationSettingsWidget.cpp" line="136"/>
-      <source>Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame times, but add additional input lag.</source>
+      <source>Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame-times, but add additional input lag.</source>
       <translation>Nastaví maximální počet snímků, které mohou být zařazeny do fronty do GS předtím, než vlákno procesoru počká na dokončení jednoho z nich, než bude pokračovat. Vyšší hodnoty mohou pomoci s vyhlazením nepravidelných časů snímků, ale přidají další vstupní zpoždění.</translation>
     </message>
     <message>
@@ -4902,7 +4902,7 @@ Tato URL byla: %1</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6935"/>
-      <source>Shows a visual history of frame times in the upper-left corner of the display.</source>
+      <source>Shows a visual history of frame-times in the upper-left corner of the display.</source>
       <translation>Zobrazí vizuální historii naměřeného času mezi snímky v levém horním rohu displeje.</translation>
     </message>
     <message>
@@ -5041,7 +5041,7 @@ Přejete si přesto vypnout a NEVRATNĚ ZNIČIT VAŠI PAMĚŤOVOU KARTU?</transl
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6956"/>
-      <source>Pins emulation threads to CPU cores to potentially improve performance/frame time variance.</source>
+      <source>Pins emulation threads to CPU cores to potentially improve performance/frame-time variance.</source>
       <translation>Připne emulační vlákna do jader procesoru, aby se potenciálně zlepšila odchylka výkonu/doba snímku.</translation>
     </message>
     <message>
@@ -8414,8 +8414,8 @@ Do you want to load this save and continue?</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="7581"/>
-      <source>Show Frame Times</source>
-      <translation type="unfinished">Show Frame Times</translation>
+      <source>Show Frame-Times</source>
+      <translation type="unfinished">Show Frame-Times</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="7582"/>
@@ -11360,8 +11360,8 @@ Percentage sign that will appear next to a number. Add a space or whatever is ne
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="1672"/>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="723"/>
-      <source>Show Frame Times</source>
-      <translation type="unfinished">Show Frame Times</translation>
+      <source>Show Frame-Times</source>
+      <translation type="unfinished">Show Frame-Times</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="1726"/>
@@ -12032,8 +12032,8 @@ Swap chain: see Microsoft&apos;s Terminology Portal.</extracomment>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="790"/>
-      <source>Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out frame time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</source>
-      <translation type="unfinished">Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out frame time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</translation>
+      <source>Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out the frame-time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</source>
+      <translation type="unfinished">Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out the frame-time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="1152"/>

--- a/pcsx2-qt/Translations/pcsx2-qt_da-DK.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_da-DK.ts
@@ -4392,8 +4392,8 @@ Enter function name</translation>
     </message>
     <message>
       <location filename="../Settings/EmulationSettingsWidget.cpp" line="136"/>
-      <source>Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame times, but add additional input lag.</source>
-      <translation type="unfinished">Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame times, but add additional input lag.</translation>
+      <source>Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame-times, but add additional input lag.</source>
+      <translation type="unfinished">Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame-times, but add additional input lag.</translation>
     </message>
     <message>
       <location filename="../Settings/EmulationSettingsWidget.cpp" line="139"/>
@@ -4892,8 +4892,8 @@ The URL was: %1</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6935"/>
-      <source>Shows a visual history of frame times in the upper-left corner of the display.</source>
-      <translation type="unfinished">Shows a visual history of frame times in the upper-left corner of the display.</translation>
+      <source>Shows a visual history of frame-times in the upper-left corner of the display.</source>
+      <translation type="unfinished">Shows a visual history of frame-times in the upper-left corner of the display.</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6936"/>
@@ -5031,8 +5031,8 @@ Do you wish to shutdown anyways and IRREVERSIBLY DESTROY YOUR MEMORY CARD?</tran
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6956"/>
-      <source>Pins emulation threads to CPU cores to potentially improve performance/frame time variance.</source>
-      <translation type="unfinished">Pins emulation threads to CPU cores to potentially improve performance/frame time variance.</translation>
+      <source>Pins emulation threads to CPU cores to potentially improve performance/frame-time variance.</source>
+      <translation type="unfinished">Pins emulation threads to CPU cores to potentially improve performance/frame-time variance.</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6953"/>
@@ -8404,8 +8404,8 @@ Do you want to load this save and continue?</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="7581"/>
-      <source>Show Frame Times</source>
-      <translation type="unfinished">Show Frame Times</translation>
+      <source>Show Frame-Times</source>
+      <translation type="unfinished">Show Frame-Times</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="7582"/>
@@ -11346,8 +11346,8 @@ Percentage sign that will appear next to a number. Add a space or whatever is ne
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="1672"/>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="723"/>
-      <source>Show Frame Times</source>
-      <translation type="unfinished">Show Frame Times</translation>
+      <source>Show Frame-Times</source>
+      <translation type="unfinished">Show Frame-Times</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="1726"/>
@@ -12018,8 +12018,8 @@ Swap chain: see Microsoft&apos;s Terminology Portal.</extracomment>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="790"/>
-      <source>Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out frame time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</source>
-      <translation type="unfinished">Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out frame time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</translation>
+      <source>Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out the frame-time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</source>
+      <translation type="unfinished">Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out the frame-time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="1152"/>

--- a/pcsx2-qt/Translations/pcsx2-qt_da-DK.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_da-DK.ts
@@ -5136,8 +5136,8 @@ Do you wish to shutdown anyways and IRREVERSIBLY DESTROY YOUR MEMORY CARD?</tran
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6981"/>
-      <source>FMV Aspect Ratio</source>
-      <translation type="unfinished">FMV Aspect Ratio</translation>
+      <source>FMV Aspect Ratio Override</source>
+      <translation type="unfinished">FMV Aspect Ratio Override</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6982"/>
@@ -10274,8 +10274,8 @@ Scanning recursively takes more time, but will identify files in subdirectories.
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="112"/>
-      <source>FMV Aspect Ratio:</source>
-      <translation type="unfinished">FMV Aspect Ratio:</translation>
+      <source>FMV Aspect Ratio Override:</source>
+      <translation type="unfinished">FMV Aspect Ratio Override:</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="120"/>
@@ -11710,8 +11710,8 @@ Swap chain: see Microsoft&apos;s Terminology Portal.</extracomment>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="444"/>
-      <source>FMV Aspect Ratio</source>
-      <translation type="unfinished">FMV Aspect Ratio</translation>
+      <source>FMV Aspect Ratio Override</source>
+      <translation type="unfinished">FMV Aspect Ratio Override</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="444"/>

--- a/pcsx2-qt/Translations/pcsx2-qt_de-DE.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_de-DE.ts
@@ -5136,7 +5136,7 @@ Möchtest du trotzdem herunterfahren und DEINE MEMORY CARD IRREVERSIBEL ZERSTÖR
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6981"/>
-      <source>FMV Aspect Ratio</source>
+      <source>FMV Aspect Ratio Override</source>
       <translation>FMV Seitenverhältnis</translation>
     </message>
     <message>
@@ -10272,7 +10272,7 @@ Das Scannen braucht mehr Zeit, aber es wird Dateien in Unterverzeichnissen erken
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="112"/>
-      <source>FMV Aspect Ratio:</source>
+      <source>FMV Aspect Ratio Override:</source>
       <translation>FMV Seitenverhältnis:</translation>
     </message>
     <message>
@@ -11708,7 +11708,7 @@ Swap chain: see Microsoft&apos;s Terminology Portal.</extracomment>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="444"/>
-      <source>FMV Aspect Ratio</source>
+      <source>FMV Aspect Ratio Override</source>
       <translation>FMV Seitenverhältnis</translation>
     </message>
     <message>

--- a/pcsx2-qt/Translations/pcsx2-qt_de-DE.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_de-DE.ts
@@ -4392,7 +4392,7 @@ Gebe den Funktionsnamen ein</translation>
     </message>
     <message>
       <location filename="../Settings/EmulationSettingsWidget.cpp" line="136"/>
-      <source>Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame times, but add additional input lag.</source>
+      <source>Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame-times, but add additional input lag.</source>
       <translation>Setzt die maximale Anzahl von Frames fest, die in einer Warteschlange zum GS stehen können. Der CPU-Thread wartet jedes mal bis ein Frame fertiggestellt wurde bevor es mit dem nächsten weitermacht . Höhere Werte können bei der Glättung unregelmäßiger Bildzeiten (Frame Times) helfen, fügt aber zusätzliche Eingabeverzögerungen (Input Lag) hinzu.</translation>
     </message>
     <message>
@@ -4892,7 +4892,7 @@ Die URL war: %1</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6935"/>
-      <source>Shows a visual history of frame times in the upper-left corner of the display.</source>
+      <source>Shows a visual history of frame-times in the upper-left corner of the display.</source>
       <translation>Zeigt ein Histogramm der Frametimes in der oberen linken Ecke des Displays an.</translation>
     </message>
     <message>
@@ -5031,7 +5031,7 @@ Möchtest du trotzdem herunterfahren und DEINE MEMORY CARD IRREVERSIBEL ZERSTÖR
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6956"/>
-      <source>Pins emulation threads to CPU cores to potentially improve performance/frame time variance.</source>
+      <source>Pins emulation threads to CPU cores to potentially improve performance/frame-time variance.</source>
       <translation>Setzt Emulations-Threads fest auf echte CPU-Kerne (anstatt Hyperthreading/SMT Kerne), um eventuell die Performance/Frametimes zu verbessern bzw. Schwankungen zu verringern.</translation>
     </message>
     <message>
@@ -8404,7 +8404,7 @@ Möchten Sie diesen laden und fortfahren?</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="7581"/>
-      <source>Show Frame Times</source>
+      <source>Show Frame-Times</source>
       <translation>Frametime anzeigen</translation>
     </message>
     <message>
@@ -11344,7 +11344,7 @@ Percentage sign that will appear next to a number. Add a space or whatever is ne
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="1672"/>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="723"/>
-      <source>Show Frame Times</source>
+      <source>Show Frame-Times</source>
       <translation>Frametimes anzeigen</translation>
     </message>
     <message>
@@ -12016,7 +12016,7 @@ Swap chain: see Microsoft&apos;s Terminology Portal.</extracomment>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="790"/>
-      <source>Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out frame time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</source>
+      <source>Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out the frame-time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</source>
       <translation>Erkennt, wann inaktive Frames in 25/30fps Spielen dargestellt werden und überspringt die Darstellung dieser Frames. Das Frame wird immer noch gerendert, es bedeutet lediglich, dass die GPU mehr Zeit hat, es zu vervollständigen (dies ist KEIN frame skipping). Kann Frametime schwankungen glätten, wenn die CPU/GPU nahezu maximal Ausgelastet sind, aber macht Framepacing inkonsistenter und kann die Eingabeverzögerung erhöhen.</translation>
     </message>
     <message>

--- a/pcsx2-qt/Translations/pcsx2-qt_el-GR.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_el-GR.ts
@@ -4392,8 +4392,8 @@ Enter function name</translation>
     </message>
     <message>
       <location filename="../Settings/EmulationSettingsWidget.cpp" line="136"/>
-      <source>Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame times, but add additional input lag.</source>
-      <translation type="unfinished">Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame times, but add additional input lag.</translation>
+      <source>Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame-times, but add additional input lag.</source>
+      <translation type="unfinished">Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame-times, but add additional input lag.</translation>
     </message>
     <message>
       <location filename="../Settings/EmulationSettingsWidget.cpp" line="139"/>
@@ -4892,8 +4892,8 @@ The URL was: %1</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6935"/>
-      <source>Shows a visual history of frame times in the upper-left corner of the display.</source>
-      <translation type="unfinished">Shows a visual history of frame times in the upper-left corner of the display.</translation>
+      <source>Shows a visual history of frame-times in the upper-left corner of the display.</source>
+      <translation type="unfinished">Shows a visual history of frame-times in the upper-left corner of the display.</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6936"/>
@@ -5031,8 +5031,8 @@ Do you wish to shutdown anyways and IRREVERSIBLY DESTROY YOUR MEMORY CARD?</tran
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6956"/>
-      <source>Pins emulation threads to CPU cores to potentially improve performance/frame time variance.</source>
-      <translation type="unfinished">Pins emulation threads to CPU cores to potentially improve performance/frame time variance.</translation>
+      <source>Pins emulation threads to CPU cores to potentially improve performance/frame-time variance.</source>
+      <translation type="unfinished">Pins emulation threads to CPU cores to potentially improve performance/frame-time variance.</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6953"/>
@@ -8404,8 +8404,8 @@ Do you want to load this save and continue?</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="7581"/>
-      <source>Show Frame Times</source>
-      <translation type="unfinished">Show Frame Times</translation>
+      <source>Show Frame-Times</source>
+      <translation type="unfinished">Show Frame-Times</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="7582"/>
@@ -11346,8 +11346,8 @@ Percentage sign that will appear next to a number. Add a space or whatever is ne
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="1672"/>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="723"/>
-      <source>Show Frame Times</source>
-      <translation type="unfinished">Show Frame Times</translation>
+      <source>Show Frame-Times</source>
+      <translation type="unfinished">Show Frame-Times</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="1726"/>
@@ -12018,8 +12018,8 @@ Swap chain: see Microsoft&apos;s Terminology Portal.</extracomment>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="790"/>
-      <source>Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out frame time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</source>
-      <translation type="unfinished">Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out frame time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</translation>
+      <source>Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out the frame-time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</source>
+      <translation type="unfinished">Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out the frame-time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="1152"/>

--- a/pcsx2-qt/Translations/pcsx2-qt_el-GR.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_el-GR.ts
@@ -5136,8 +5136,8 @@ Do you wish to shutdown anyways and IRREVERSIBLY DESTROY YOUR MEMORY CARD?</tran
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6981"/>
-      <source>FMV Aspect Ratio</source>
-      <translation type="unfinished">FMV Aspect Ratio</translation>
+      <source>FMV Aspect Ratio Override</source>
+      <translation type="unfinished">FMV Aspect Ratio Override</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6982"/>
@@ -10274,8 +10274,8 @@ Scanning recursively takes more time, but will identify files in subdirectories.
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="112"/>
-      <source>FMV Aspect Ratio:</source>
-      <translation type="unfinished">FMV Aspect Ratio:</translation>
+      <source>FMV Aspect Ratio Override:</source>
+      <translation type="unfinished">FMV Aspect Ratio Override:</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="120"/>
@@ -11710,8 +11710,8 @@ Swap chain: see Microsoft&apos;s Terminology Portal.</extracomment>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="444"/>
-      <source>FMV Aspect Ratio</source>
-      <translation type="unfinished">FMV Aspect Ratio</translation>
+      <source>FMV Aspect Ratio Override</source>
+      <translation type="unfinished">FMV Aspect Ratio Override</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="444"/>

--- a/pcsx2-qt/Translations/pcsx2-qt_en.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_en.ts
@@ -5095,7 +5095,7 @@ Do you wish to shutdown anyways and IRREVERSIBLY DESTROY YOUR MEMORY CARD?</sour
     </message>
     <message>
         <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6981"/>
-        <source>FMV Aspect Ratio</source>
+        <source>FMV Aspect Ratio Override</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -10209,7 +10209,7 @@ Scanning recursively takes more time, but will identify files in subdirectories.
     </message>
     <message>
         <location filename="../Settings/GraphicsSettingsWidget.ui" line="112"/>
-        <source>FMV Aspect Ratio:</source>
+        <source>FMV Aspect Ratio Override:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -11645,7 +11645,7 @@ Swap chain: see Microsoft&apos;s Terminology Portal.</extracomment>
     </message>
     <message>
         <location filename="../Settings/GraphicsSettingsWidget.cpp" line="444"/>
-        <source>FMV Aspect Ratio</source>
+        <source>FMV Aspect Ratio Override</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/pcsx2-qt/Translations/pcsx2-qt_en.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_en.ts
@@ -4357,7 +4357,7 @@ Enter function name</source>
     </message>
     <message>
         <location filename="../Settings/EmulationSettingsWidget.cpp" line="136"/>
-        <source>Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame times, but add additional input lag.</source>
+        <source>Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame-times, but add additional input lag.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4853,7 +4853,7 @@ The URL was: %1</source>
     </message>
     <message>
         <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6935"/>
-        <source>Shows a visual history of frame times in the upper-left corner of the display.</source>
+        <source>Shows a visual history of frame-times in the upper-left corner of the display.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4990,7 +4990,7 @@ Do you wish to shutdown anyways and IRREVERSIBLY DESTROY YOUR MEMORY CARD?</sour
     </message>
     <message>
         <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6956"/>
-        <source>Pins emulation threads to CPU cores to potentially improve performance/frame time variance.</source>
+        <source>Pins emulation threads to CPU cores to potentially improve performance/frame-time variance.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8359,7 +8359,7 @@ Do you want to load this save and continue?</source>
     </message>
     <message>
         <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="7581"/>
-        <source>Show Frame Times</source>
+        <source>Show Frame-Times</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -11281,7 +11281,7 @@ Percentage sign that will appear next to a number. Add a space or whatever is ne
     <message>
         <location filename="../Settings/GraphicsSettingsWidget.ui" line="1672"/>
         <location filename="../Settings/GraphicsSettingsWidget.cpp" line="723"/>
-        <source>Show Frame Times</source>
+        <source>Show Frame-Times</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -11953,7 +11953,7 @@ Swap chain: see Microsoft&apos;s Terminology Portal.</extracomment>
     </message>
     <message>
         <location filename="../Settings/GraphicsSettingsWidget.cpp" line="790"/>
-        <source>Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out frame time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</source>
+        <source>Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out the frame-time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/pcsx2-qt/Translations/pcsx2-qt_es-419.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_es-419.ts
@@ -5136,8 +5136,8 @@ Do you wish to shutdown anyways and IRREVERSIBLY DESTROY YOUR MEMORY CARD?</tran
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6981"/>
-      <source>FMV Aspect Ratio</source>
-      <translation type="unfinished">FMV Aspect Ratio</translation>
+      <source>FMV Aspect Ratio Override</source>
+      <translation type="unfinished">FMV Aspect Ratio Override</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6982"/>
@@ -10274,8 +10274,8 @@ Escanear recursivamente toma más tiempo pero identificará archivos en subdirec
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="112"/>
-      <source>FMV Aspect Ratio:</source>
-      <translation type="unfinished">FMV Aspect Ratio:</translation>
+      <source>FMV Aspect Ratio Override:</source>
+      <translation type="unfinished">FMV Aspect Ratio Override:</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="120"/>
@@ -11710,8 +11710,8 @@ Swap chain: see Microsoft&apos;s Terminology Portal.</extracomment>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="444"/>
-      <source>FMV Aspect Ratio</source>
-      <translation type="unfinished">FMV Aspect Ratio</translation>
+      <source>FMV Aspect Ratio Override</source>
+      <translation type="unfinished">FMV Aspect Ratio Override</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="444"/>

--- a/pcsx2-qt/Translations/pcsx2-qt_es-419.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_es-419.ts
@@ -4392,8 +4392,8 @@ Inserta el nombre de función</translation>
     </message>
     <message>
       <location filename="../Settings/EmulationSettingsWidget.cpp" line="136"/>
-      <source>Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame times, but add additional input lag.</source>
-      <translation type="unfinished">Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame times, but add additional input lag.</translation>
+      <source>Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame-times, but add additional input lag.</source>
+      <translation type="unfinished">Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame-times, but add additional input lag.</translation>
     </message>
     <message>
       <location filename="../Settings/EmulationSettingsWidget.cpp" line="139"/>
@@ -4892,8 +4892,8 @@ La URL era: %1</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6935"/>
-      <source>Shows a visual history of frame times in the upper-left corner of the display.</source>
-      <translation type="unfinished">Shows a visual history of frame times in the upper-left corner of the display.</translation>
+      <source>Shows a visual history of frame-times in the upper-left corner of the display.</source>
+      <translation type="unfinished">Shows a visual history of frame-times in the upper-left corner of the display.</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6936"/>
@@ -5031,8 +5031,8 @@ Do you wish to shutdown anyways and IRREVERSIBLY DESTROY YOUR MEMORY CARD?</tran
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6956"/>
-      <source>Pins emulation threads to CPU cores to potentially improve performance/frame time variance.</source>
-      <translation type="unfinished">Pins emulation threads to CPU cores to potentially improve performance/frame time variance.</translation>
+      <source>Pins emulation threads to CPU cores to potentially improve performance/frame-time variance.</source>
+      <translation type="unfinished">Pins emulation threads to CPU cores to potentially improve performance/frame-time variance.</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6953"/>
@@ -8404,8 +8404,8 @@ Do you want to load this save and continue?</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="7581"/>
-      <source>Show Frame Times</source>
-      <translation type="unfinished">Show Frame Times</translation>
+      <source>Show Frame-Times</source>
+      <translation type="unfinished">Show Frame-Times</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="7582"/>
@@ -11346,8 +11346,8 @@ Percentage sign that will appear next to a number. Add a space or whatever is ne
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="1672"/>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="723"/>
-      <source>Show Frame Times</source>
-      <translation type="unfinished">Show Frame Times</translation>
+      <source>Show Frame-Times</source>
+      <translation type="unfinished">Show Frame-Times</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="1726"/>
@@ -12018,7 +12018,7 @@ Swap chain: see Microsoft&apos;s Terminology Portal.</extracomment>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="790"/>
-      <source>Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out frame time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</source>
+      <source>Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out the frame-time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</source>
       <translation>Detecta cuando se presentan cuadros inactivos en juegos de 25/30fps, y omite presentar esos cuadros. El cuadro sigue siendo renderizado, esto sólo significa que la GPU tiene más tiempo para completarlo (esto NO es omision de fotograma). Puede suavizar las fluctuaciones de tiempo del cuadro cuando la CPU/GPU está cerca de la máxima utilización, pero hace que el ritmo del cuadro sea más inconsistente y puede aumentar el retraso de la entrada.</translation>
     </message>
     <message>

--- a/pcsx2-qt/Translations/pcsx2-qt_es-ES.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_es-ES.ts
@@ -5136,7 +5136,7 @@ Do you wish to shutdown anyways and IRREVERSIBLY DESTROY YOUR MEMORY CARD?</sour
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6981"/>
-      <source>FMV Aspect Ratio</source>
+      <source>FMV Aspect Ratio Override</source>
       <translation>Relación de aspecto de vídeos FMV</translation>
     </message>
     <message>
@@ -10273,7 +10273,7 @@ La búsqueda recursiva llevará más tiempo, pero identificará todo archivo que
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="112"/>
-      <source>FMV Aspect Ratio:</source>
+      <source>FMV Aspect Ratio Override:</source>
       <translation>Relación de aspecto de vídeos FMV:</translation>
     </message>
     <message>
@@ -11709,7 +11709,7 @@ Swap chain: see Microsoft&apos;s Terminology Portal.</extracomment>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="444"/>
-      <source>FMV Aspect Ratio</source>
+      <source>FMV Aspect Ratio Override</source>
       <translation>Relación de aspecto de vídeos FMV</translation>
     </message>
     <message>

--- a/pcsx2-qt/Translations/pcsx2-qt_es-ES.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_es-ES.ts
@@ -4392,7 +4392,7 @@ Introduce el nombre de la función</translation>
     </message>
     <message>
       <location filename="../Settings/EmulationSettingsWidget.cpp" line="136"/>
-      <source>Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame times, but add additional input lag.</source>
+      <source>Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame-times, but add additional input lag.</source>
       <translation>Establece la cantidad máxima de fotogramas que podrán ponerse en la cola del GS antes de que el subproceso de la CPU espere a que un fotograma sea completado para poder continuar. Un valor alto podría ayudar a suavizar las duraciones de fotogramas irregulares, pero añadirá más retraso en la entrada de los controles.</translation>
     </message>
     <message>
@@ -4892,7 +4892,7 @@ URL introducida: %1</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6935"/>
-      <source>Shows a visual history of frame times in the upper-left corner of the display.</source>
+      <source>Shows a visual history of frame-times in the upper-left corner of the display.</source>
       <translation>Muestra un historial visual de duraciones de fotogramas en la esquina superior izquierda de la imagen.</translation>
     </message>
     <message>
@@ -5031,7 +5031,7 @@ Do you wish to shutdown anyways and IRREVERSIBLY DESTROY YOUR MEMORY CARD?</sour
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6956"/>
-      <source>Pins emulation threads to CPU cores to potentially improve performance/frame time variance.</source>
+      <source>Pins emulation threads to CPU cores to potentially improve performance/frame-time variance.</source>
       <translation>Asigna hilos de la emulación a otros núcleos de la CPU, lo que podría mejorar el rendimiento o reducir la variación de la duración de fotogramas.</translation>
     </message>
     <message>
@@ -8404,7 +8404,7 @@ Do you want to load this save and continue?</source>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="7581"/>
-      <source>Show Frame Times</source>
+      <source>Show Frame-Times</source>
       <translation>Mostrar duraciones de fotogramas</translation>
     </message>
     <message>
@@ -11345,7 +11345,7 @@ Percentage sign that will appear next to a number. Add a space or whatever is ne
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="1672"/>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="723"/>
-      <source>Show Frame Times</source>
+      <source>Show Frame-Times</source>
       <translation>Mostrar duraciones de fotogramas</translation>
     </message>
     <message>
@@ -12017,7 +12017,7 @@ Swap chain: see Microsoft&apos;s Terminology Portal.</extracomment>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="790"/>
-      <source>Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out frame time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</source>
+      <source>Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out the frame-time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</source>
       <translation>Detecta cuándo se van a presentar fotogramas inactivos en juegos a 25/30 FPS y omite su presentación. El fotograma seguirá renderizándose, pero la GPU tendrá más tiempo para completarlo (esto NO ES omitir fotogramas). Puede suavizar las fluctuaciones en las duraciones de fotogramas cuando la CPU y la GPU estén siendo utilizadas al máximo, pero hará que el ritmo de fotogramas sea más inconsistente y puede aumentar el retraso de la señal de entrada.</translation>
     </message>
     <message>

--- a/pcsx2-qt/Translations/pcsx2-qt_fa-IR.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_fa-IR.ts
@@ -5136,7 +5136,7 @@ Do you wish to shutdown anyways and IRREVERSIBLY DESTROY YOUR MEMORY CARD?</sour
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6981"/>
-      <source>FMV Aspect Ratio</source>
+      <source>FMV Aspect Ratio Override</source>
       <translation>نسبت تصویر FMV</translation>
     </message>
     <message>
@@ -10274,7 +10274,7 @@ Scanning recursively takes more time, but will identify files in subdirectories.
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="112"/>
-      <source>FMV Aspect Ratio:</source>
+      <source>FMV Aspect Ratio Override:</source>
       <translation>نسبت تصویر FMV:</translation>
     </message>
     <message>
@@ -11710,7 +11710,7 @@ Swap chain: see Microsoft&apos;s Terminology Portal.</extracomment>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="444"/>
-      <source>FMV Aspect Ratio</source>
+      <source>FMV Aspect Ratio Override</source>
       <translation>نسبت تصویر FMV</translation>
     </message>
     <message>

--- a/pcsx2-qt/Translations/pcsx2-qt_fa-IR.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_fa-IR.ts
@@ -4392,7 +4392,7 @@ Enter function name</source>
     </message>
     <message>
       <location filename="../Settings/EmulationSettingsWidget.cpp" line="136"/>
-      <source>Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame times, but add additional input lag.</source>
+      <source>Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame-times, but add additional input lag.</source>
       <translation>حداکثر تعداد فریم‌هایی را که می‌توان در صف GS قرار داد را تنظیم می‌کند، قبل از اینکه رشته های پردازنده قبل از ادامه منتظر بماند تا یکی از آنها کارش تکمیل شود. مقادیر بالاتر می تواند به نرم کردن زمان های فریم نامنظم کمک کند، اما تاخیر ورودی اضافی پیش می آید.</translation>
     </message>
     <message>
@@ -4892,7 +4892,7 @@ The URL was: %1</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6935"/>
-      <source>Shows a visual history of frame times in the upper-left corner of the display.</source>
+      <source>Shows a visual history of frame-times in the upper-left corner of the display.</source>
       <translation>تاریخچه بصری زمان های فریم را در گوشه سمت چپ بالای صفحه نشان می دهد.</translation>
     </message>
     <message>
@@ -5031,7 +5031,7 @@ Do you wish to shutdown anyways and IRREVERSIBLY DESTROY YOUR MEMORY CARD?</sour
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6956"/>
-      <source>Pins emulation threads to CPU cores to potentially improve performance/frame time variance.</source>
+      <source>Pins emulation threads to CPU cores to potentially improve performance/frame-time variance.</source>
       <translation>رشته های شبیه سازی را به هسته های CPU پین میکند تا به طور بالقوه به واریانس زمان فریم/پرفورمنس اجرا کمک کند.</translation>
     </message>
     <message>
@@ -8404,7 +8404,7 @@ Do you want to load this save and continue?</source>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="7581"/>
-      <source>Show Frame Times</source>
+      <source>Show Frame-Times</source>
       <translation>نمایش زمان های فریم</translation>
     </message>
     <message>
@@ -11346,7 +11346,7 @@ Percentage sign that will appear next to a number. Add a space or whatever is ne
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="1672"/>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="723"/>
-      <source>Show Frame Times</source>
+      <source>Show Frame-Times</source>
       <translation>نمایش زمان های فریم</translation>
     </message>
     <message>
@@ -12018,8 +12018,8 @@ Swap chain: see Microsoft&apos;s Terminology Portal.</extracomment>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="790"/>
-      <source>Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out frame time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</source>
-      <translation type="unfinished">Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out frame time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</translation>
+      <source>Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out the frame-time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</source>
+      <translation type="unfinished">Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out the frame-time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="1152"/>

--- a/pcsx2-qt/Translations/pcsx2-qt_fi-FI.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_fi-FI.ts
@@ -5137,7 +5137,7 @@ Haluatko sammuttaa siitä huolimatta ja PERUUTTAMATTOMASTI TUHOTA MUISTIKORTTISI
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6981"/>
-      <source>FMV Aspect Ratio</source>
+      <source>FMV Aspect Ratio Override</source>
       <translation>FMV-kuvasuhde</translation>
     </message>
     <message>
@@ -10275,7 +10275,7 @@ Rekursiivinen skannaus vie enemmän aikaa, mutta tunnistaa tiedostot alikansiois
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="112"/>
-      <source>FMV Aspect Ratio:</source>
+      <source>FMV Aspect Ratio Override:</source>
       <translation>FMV-kuvasuhde:</translation>
     </message>
     <message>
@@ -11711,7 +11711,7 @@ Swap chain: see Microsoft&apos;s Terminology Portal.</extracomment>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="444"/>
-      <source>FMV Aspect Ratio</source>
+      <source>FMV Aspect Ratio Override</source>
       <translation>FMV-kuvasuhde</translation>
     </message>
     <message>

--- a/pcsx2-qt/Translations/pcsx2-qt_fi-FI.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_fi-FI.ts
@@ -4393,7 +4393,7 @@ Anna funktion nimi</translation>
     </message>
     <message>
       <location filename="../Settings/EmulationSettingsWidget.cpp" line="136"/>
-      <source>Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame times, but add additional input lag.</source>
+      <source>Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame-times, but add additional input lag.</source>
       <translation>Asettaa enimmäismäärän kuvia, jotka jonotetaan GS:ään, ennen kuin prosessorin säie odottaa yhden niistä valmistumista ennen jatkamista. Suuremmat arvot voivat auttaa tasoittamaan epäsäännöllisiä ruutuaikoja, mutta lisäävät ylimääräistä syöttöviivettä.</translation>
     </message>
     <message>
@@ -4893,7 +4893,7 @@ URL-osoite oli: %1</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6935"/>
-      <source>Shows a visual history of frame times in the upper-left corner of the display.</source>
+      <source>Shows a visual history of frame-times in the upper-left corner of the display.</source>
       <translation>Näyttää kehysaikojen visuaalisen historian näytön vasemmassa yläkulmassa.</translation>
     </message>
     <message>
@@ -5032,7 +5032,7 @@ Haluatko sammuttaa siitä huolimatta ja PERUUTTAMATTOMASTI TUHOTA MUISTIKORTTISI
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6956"/>
-      <source>Pins emulation threads to CPU cores to potentially improve performance/frame time variance.</source>
+      <source>Pins emulation threads to CPU cores to potentially improve performance/frame-time variance.</source>
       <translation>Yhdistää emulaatiosäikeet prosessorin ytimiin parantaakseen suorituskykyä/kehysaikojen vaihtelua.</translation>
     </message>
     <message>
@@ -8405,7 +8405,7 @@ Do you want to load this save and continue?</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="7581"/>
-      <source>Show Frame Times</source>
+      <source>Show Frame-Times</source>
       <translation>Näytä kehysajat</translation>
     </message>
     <message>
@@ -11347,7 +11347,7 @@ Percentage sign that will appear next to a number. Add a space or whatever is ne
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="1672"/>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="723"/>
-      <source>Show Frame Times</source>
+      <source>Show Frame-Times</source>
       <translation>Näytä kehysajat</translation>
     </message>
     <message>
@@ -12019,8 +12019,8 @@ Swap chain: see Microsoft&apos;s Terminology Portal.</extracomment>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="790"/>
-      <source>Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out frame time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</source>
-      <translation type="unfinished">Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out frame time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</translation>
+      <source>Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out the frame-time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</source>
+      <translation type="unfinished">Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out the frame-time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="1152"/>

--- a/pcsx2-qt/Translations/pcsx2-qt_fr-FR.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_fr-FR.ts
@@ -4392,7 +4392,7 @@ Saisissez le nom de la fonction :</translation>
     </message>
     <message>
       <location filename="../Settings/EmulationSettingsWidget.cpp" line="136"/>
-      <source>Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame times, but add additional input lag.</source>
+      <source>Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame-times, but add additional input lag.</source>
       <translation>Définissez le nombre maximum d'images pouvant être en attente du GS, avant que le thread CPU ne doive attendre qu'une des images soit terminée avant de reprendre. Plus la valeur est élevée, plus les variations de durées d'image sont lissées, et plus la latence d'entrée augmente.</translation>
     </message>
     <message>
@@ -4892,7 +4892,7 @@ URL : %1</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6935"/>
-      <source>Shows a visual history of frame times in the upper-left corner of the display.</source>
+      <source>Shows a visual history of frame-times in the upper-left corner of the display.</source>
       <translation>Afficher un historique visuel des durées d'image dans le coin supérieur gauche de l'écran.</translation>
     </message>
     <message>
@@ -5031,7 +5031,7 @@ Voulez-vous quand même éteindre la machine virtuelle et DÉTRUIRE DE FAÇON IR
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6956"/>
-      <source>Pins emulation threads to CPU cores to potentially improve performance/frame time variance.</source>
+      <source>Pins emulation threads to CPU cores to potentially improve performance/frame-time variance.</source>
       <translation>Associer certains threads de l'émulateur à certains cœurs CPU pour potentiellement améliorer les performances et lisser les variations de durée d'image.</translation>
     </message>
     <message>
@@ -8404,7 +8404,7 @@ Voulez-vous charger cette sauvegarde et continuer ?</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="7581"/>
-      <source>Show Frame Times</source>
+      <source>Show Frame-Times</source>
       <translation>Afficher les durées d'image</translation>
     </message>
     <message>
@@ -11346,7 +11346,7 @@ Percentage sign that will appear next to a number. Add a space or whatever is ne
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="1672"/>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="723"/>
-      <source>Show Frame Times</source>
+      <source>Show Frame-Times</source>
       <translation>Afficher les durées d'image</translation>
     </message>
     <message>
@@ -12018,7 +12018,7 @@ Swap chain: see Microsoft&apos;s Terminology Portal.</extracomment>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="790"/>
-      <source>Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out frame time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</source>
+      <source>Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out the frame-time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</source>
       <translation>Détecter quand des images en double sont présentées dans des jeux à 25 ou 30 IPS et sauter leur présentation. Le rendu de ces images est toujours effectué mais le GPU a plus de temps pour les terminer (ce n'est PAS du saut d'images). L'option peut permettre de lisser les durées d'image lorsque la charge CPU ou GPU est maximale, mais la cadence d'image sera plus variable et la latence d'entrée peut augmenter.</translation>
     </message>
     <message>

--- a/pcsx2-qt/Translations/pcsx2-qt_fr-FR.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_fr-FR.ts
@@ -5136,7 +5136,7 @@ Voulez-vous quand même éteindre la machine virtuelle et DÉTRUIRE DE FAÇON IR
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6981"/>
-      <source>FMV Aspect Ratio</source>
+      <source>FMV Aspect Ratio Override</source>
       <translation>Format d'image FMV</translation>
     </message>
     <message>
@@ -10274,7 +10274,7 @@ Scanner les sous-dossiers prend plus de temps mais les jeux se trouvant dans un 
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="112"/>
-      <source>FMV Aspect Ratio:</source>
+      <source>FMV Aspect Ratio Override:</source>
       <translation>Format d'image FMV :</translation>
     </message>
     <message>
@@ -11710,7 +11710,7 @@ Swap chain: see Microsoft&apos;s Terminology Portal.</extracomment>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="444"/>
-      <source>FMV Aspect Ratio</source>
+      <source>FMV Aspect Ratio Override</source>
       <translation>Format d'image FMV</translation>
     </message>
     <message>

--- a/pcsx2-qt/Translations/pcsx2-qt_he-IL.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_he-IL.ts
@@ -4399,8 +4399,8 @@ Enter function name</translation>
     </message>
     <message>
       <location filename="../Settings/EmulationSettingsWidget.cpp" line="136"/>
-      <source>Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame times, but add additional input lag.</source>
-      <translation type="unfinished">Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame times, but add additional input lag.</translation>
+      <source>Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame-times, but add additional input lag.</source>
+      <translation type="unfinished">Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame-times, but add additional input lag.</translation>
     </message>
     <message>
       <location filename="../Settings/EmulationSettingsWidget.cpp" line="139"/>
@@ -4899,8 +4899,8 @@ The URL was: %1</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6935"/>
-      <source>Shows a visual history of frame times in the upper-left corner of the display.</source>
-      <translation type="unfinished">Shows a visual history of frame times in the upper-left corner of the display.</translation>
+      <source>Shows a visual history of frame-times in the upper-left corner of the display.</source>
+      <translation type="unfinished">Shows a visual history of frame-times in the upper-left corner of the display.</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6936"/>
@@ -5038,8 +5038,8 @@ Do you wish to shutdown anyways and IRREVERSIBLY DESTROY YOUR MEMORY CARD?</tran
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6956"/>
-      <source>Pins emulation threads to CPU cores to potentially improve performance/frame time variance.</source>
-      <translation type="unfinished">Pins emulation threads to CPU cores to potentially improve performance/frame time variance.</translation>
+      <source>Pins emulation threads to CPU cores to potentially improve performance/frame-time variance.</source>
+      <translation type="unfinished">Pins emulation threads to CPU cores to potentially improve performance/frame-time variance.</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6953"/>
@@ -8411,8 +8411,8 @@ Do you want to load this save and continue?</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="7581"/>
-      <source>Show Frame Times</source>
-      <translation type="unfinished">Show Frame Times</translation>
+      <source>Show Frame-Times</source>
+      <translation type="unfinished">Show Frame-Times</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="7582"/>
@@ -11357,8 +11357,8 @@ Percentage sign that will appear next to a number. Add a space or whatever is ne
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="1672"/>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="723"/>
-      <source>Show Frame Times</source>
-      <translation type="unfinished">Show Frame Times</translation>
+      <source>Show Frame-Times</source>
+      <translation type="unfinished">Show Frame-Times</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="1726"/>
@@ -12029,8 +12029,8 @@ Swap chain: see Microsoft&apos;s Terminology Portal.</extracomment>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="790"/>
-      <source>Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out frame time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</source>
-      <translation type="unfinished">Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out frame time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</translation>
+      <source>Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out the frame-time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</source>
+      <translation type="unfinished">Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out the frame-time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="1152"/>

--- a/pcsx2-qt/Translations/pcsx2-qt_he-IL.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_he-IL.ts
@@ -5143,8 +5143,8 @@ Do you wish to shutdown anyways and IRREVERSIBLY DESTROY YOUR MEMORY CARD?</tran
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6981"/>
-      <source>FMV Aspect Ratio</source>
-      <translation type="unfinished">FMV Aspect Ratio</translation>
+      <source>FMV Aspect Ratio Override</source>
+      <translation type="unfinished">FMV Aspect Ratio Override</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6982"/>
@@ -10285,8 +10285,8 @@ Scanning recursively takes more time, but will identify files in subdirectories.
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="112"/>
-      <source>FMV Aspect Ratio:</source>
-      <translation type="unfinished">FMV Aspect Ratio:</translation>
+      <source>FMV Aspect Ratio Override:</source>
+      <translation type="unfinished">FMV Aspect Ratio Override:</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="120"/>
@@ -11721,8 +11721,8 @@ Swap chain: see Microsoft&apos;s Terminology Portal.</extracomment>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="444"/>
-      <source>FMV Aspect Ratio</source>
-      <translation type="unfinished">FMV Aspect Ratio</translation>
+      <source>FMV Aspect Ratio Override</source>
+      <translation type="unfinished">FMV Aspect Ratio Override</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="444"/>

--- a/pcsx2-qt/Translations/pcsx2-qt_hi-IN.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_hi-IN.ts
@@ -5138,8 +5138,8 @@ Do you wish to shutdown anyways and IRREVERSIBLY DESTROY YOUR MEMORY CARD?</tran
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6981"/>
-      <source>FMV Aspect Ratio</source>
-      <translation type="unfinished">FMV Aspect Ratio</translation>
+      <source>FMV Aspect Ratio Override</source>
+      <translation type="unfinished">FMV Aspect Ratio Override</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6982"/>
@@ -10276,8 +10276,8 @@ Scanning recursively takes more time, but will identify files in subdirectories.
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="112"/>
-      <source>FMV Aspect Ratio:</source>
-      <translation type="unfinished">FMV Aspect Ratio:</translation>
+      <source>FMV Aspect Ratio Override:</source>
+      <translation type="unfinished">FMV Aspect Ratio Override:</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="120"/>
@@ -11712,8 +11712,8 @@ Swap chain: see Microsoft&apos;s Terminology Portal.</extracomment>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="444"/>
-      <source>FMV Aspect Ratio</source>
-      <translation type="unfinished">FMV Aspect Ratio</translation>
+      <source>FMV Aspect Ratio Override</source>
+      <translation type="unfinished">FMV Aspect Ratio Override</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="444"/>

--- a/pcsx2-qt/Translations/pcsx2-qt_hi-IN.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_hi-IN.ts
@@ -4394,8 +4394,8 @@ Enter function name</translation>
     </message>
     <message>
       <location filename="../Settings/EmulationSettingsWidget.cpp" line="136"/>
-      <source>Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame times, but add additional input lag.</source>
-      <translation type="unfinished">Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame times, but add additional input lag.</translation>
+      <source>Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame-times, but add additional input lag.</source>
+      <translation type="unfinished">Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame-times, but add additional input lag.</translation>
     </message>
     <message>
       <location filename="../Settings/EmulationSettingsWidget.cpp" line="139"/>
@@ -4894,8 +4894,8 @@ The URL was: %1</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6935"/>
-      <source>Shows a visual history of frame times in the upper-left corner of the display.</source>
-      <translation type="unfinished">Shows a visual history of frame times in the upper-left corner of the display.</translation>
+      <source>Shows a visual history of frame-times in the upper-left corner of the display.</source>
+      <translation type="unfinished">Shows a visual history of frame-times in the upper-left corner of the display.</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6936"/>
@@ -5033,8 +5033,8 @@ Do you wish to shutdown anyways and IRREVERSIBLY DESTROY YOUR MEMORY CARD?</tran
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6956"/>
-      <source>Pins emulation threads to CPU cores to potentially improve performance/frame time variance.</source>
-      <translation type="unfinished">Pins emulation threads to CPU cores to potentially improve performance/frame time variance.</translation>
+      <source>Pins emulation threads to CPU cores to potentially improve performance/frame-time variance.</source>
+      <translation type="unfinished">Pins emulation threads to CPU cores to potentially improve performance/frame-time variance.</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6953"/>
@@ -8406,8 +8406,8 @@ Do you want to load this save and continue?</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="7581"/>
-      <source>Show Frame Times</source>
-      <translation type="unfinished">Show Frame Times</translation>
+      <source>Show Frame-Times</source>
+      <translation type="unfinished">Show Frame-Times</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="7582"/>
@@ -11348,8 +11348,8 @@ Percentage sign that will appear next to a number. Add a space or whatever is ne
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="1672"/>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="723"/>
-      <source>Show Frame Times</source>
-      <translation type="unfinished">Show Frame Times</translation>
+      <source>Show Frame-Times</source>
+      <translation type="unfinished">Show Frame-Times</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="1726"/>
@@ -12020,8 +12020,8 @@ Swap chain: see Microsoft&apos;s Terminology Portal.</extracomment>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="790"/>
-      <source>Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out frame time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</source>
-      <translation type="unfinished">Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out frame time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</translation>
+      <source>Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out the frame-time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</source>
+      <translation type="unfinished">Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out the frame-time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="1152"/>

--- a/pcsx2-qt/Translations/pcsx2-qt_hr-HR.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_hr-HR.ts
@@ -5143,8 +5143,8 @@ Do you wish to shutdown anyways and IRREVERSIBLY DESTROY YOUR MEMORY CARD?</tran
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6981"/>
-      <source>FMV Aspect Ratio</source>
-      <translation type="unfinished">FMV Aspect Ratio</translation>
+      <source>FMV Aspect Ratio Override</source>
+      <translation type="unfinished">FMV Aspect Ratio Override</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6982"/>
@@ -10283,8 +10283,8 @@ Scanning recursively takes more time, but will identify files in subdirectories.
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="112"/>
-      <source>FMV Aspect Ratio:</source>
-      <translation type="unfinished">FMV Aspect Ratio:</translation>
+      <source>FMV Aspect Ratio Override:</source>
+      <translation type="unfinished">FMV Aspect Ratio Override:</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="120"/>
@@ -11719,8 +11719,8 @@ Swap chain: see Microsoft&apos;s Terminology Portal.</extracomment>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="444"/>
-      <source>FMV Aspect Ratio</source>
-      <translation type="unfinished">FMV Aspect Ratio</translation>
+      <source>FMV Aspect Ratio Override</source>
+      <translation type="unfinished">FMV Aspect Ratio Override</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="444"/>

--- a/pcsx2-qt/Translations/pcsx2-qt_hr-HR.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_hr-HR.ts
@@ -4399,8 +4399,8 @@ Enter function name</translation>
     </message>
     <message>
       <location filename="../Settings/EmulationSettingsWidget.cpp" line="136"/>
-      <source>Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame times, but add additional input lag.</source>
-      <translation type="unfinished">Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame times, but add additional input lag.</translation>
+      <source>Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame-times, but add additional input lag.</source>
+      <translation type="unfinished">Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame-times, but add additional input lag.</translation>
     </message>
     <message>
       <location filename="../Settings/EmulationSettingsWidget.cpp" line="139"/>
@@ -4899,8 +4899,8 @@ The URL was: %1</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6935"/>
-      <source>Shows a visual history of frame times in the upper-left corner of the display.</source>
-      <translation type="unfinished">Shows a visual history of frame times in the upper-left corner of the display.</translation>
+      <source>Shows a visual history of frame-times in the upper-left corner of the display.</source>
+      <translation type="unfinished">Shows a visual history of frame-times in the upper-left corner of the display.</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6936"/>
@@ -5038,8 +5038,8 @@ Do you wish to shutdown anyways and IRREVERSIBLY DESTROY YOUR MEMORY CARD?</tran
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6956"/>
-      <source>Pins emulation threads to CPU cores to potentially improve performance/frame time variance.</source>
-      <translation type="unfinished">Pins emulation threads to CPU cores to potentially improve performance/frame time variance.</translation>
+      <source>Pins emulation threads to CPU cores to potentially improve performance/frame-time variance.</source>
+      <translation type="unfinished">Pins emulation threads to CPU cores to potentially improve performance/frame-time variance.</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6953"/>
@@ -8411,8 +8411,8 @@ Do you want to load this save and continue?</source>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="7581"/>
-      <source>Show Frame Times</source>
-      <translation type="unfinished">Show Frame Times</translation>
+      <source>Show Frame-Times</source>
+      <translation type="unfinished">Show Frame-Times</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="7582"/>
@@ -11355,8 +11355,8 @@ Percentage sign that will appear next to a number. Add a space or whatever is ne
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="1672"/>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="723"/>
-      <source>Show Frame Times</source>
-      <translation type="unfinished">Show Frame Times</translation>
+      <source>Show Frame-Times</source>
+      <translation type="unfinished">Show Frame-Times</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="1726"/>
@@ -12027,8 +12027,8 @@ Swap chain: see Microsoft&apos;s Terminology Portal.</extracomment>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="790"/>
-      <source>Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out frame time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</source>
-      <translation type="unfinished">Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out frame time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</translation>
+      <source>Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out the frame-time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</source>
+      <translation type="unfinished">Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out the frame-time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="1152"/>

--- a/pcsx2-qt/Translations/pcsx2-qt_hu-HU.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_hu-HU.ts
@@ -5132,7 +5132,7 @@ Szeretnéd még úgy is kikapcsolni és VISSZAFORDÍTHATATLANUL ELRONTOD A MEMÓ
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6981"/>
-      <source>FMV Aspect Ratio</source>
+      <source>FMV Aspect Ratio Override</source>
       <translation>FMV-k Képaránya</translation>
     </message>
     <message>
@@ -10270,8 +10270,8 @@ Scanning recursively takes more time, but will identify files in subdirectories.
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="112"/>
-      <source>FMV Aspect Ratio:</source>
-      <translation type="unfinished">FMV Aspect Ratio:</translation>
+      <source>FMV Aspect Ratio Override:</source>
+      <translation type="unfinished">FMV Aspect Ratio Override:</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="120"/>
@@ -11706,8 +11706,8 @@ Swap chain: see Microsoft&apos;s Terminology Portal.</extracomment>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="444"/>
-      <source>FMV Aspect Ratio</source>
-      <translation type="unfinished">FMV Aspect Ratio</translation>
+      <source>FMV Aspect Ratio Override</source>
+      <translation type="unfinished">FMV Aspect Ratio Override</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="444"/>

--- a/pcsx2-qt/Translations/pcsx2-qt_hu-HU.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_hu-HU.ts
@@ -4388,8 +4388,8 @@ Enter function name</translation>
     </message>
     <message>
       <location filename="../Settings/EmulationSettingsWidget.cpp" line="136"/>
-      <source>Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame times, but add additional input lag.</source>
-      <translation type="unfinished">Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame times, but add additional input lag.</translation>
+      <source>Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame-times, but add additional input lag.</source>
+      <translation type="unfinished">Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame-times, but add additional input lag.</translation>
     </message>
     <message>
       <location filename="../Settings/EmulationSettingsWidget.cpp" line="139"/>
@@ -4888,8 +4888,8 @@ The URL was: %1</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6935"/>
-      <source>Shows a visual history of frame times in the upper-left corner of the display.</source>
-      <translation type="unfinished">Shows a visual history of frame times in the upper-left corner of the display.</translation>
+      <source>Shows a visual history of frame-times in the upper-left corner of the display.</source>
+      <translation type="unfinished">Shows a visual history of frame-times in the upper-left corner of the display.</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6936"/>
@@ -5027,8 +5027,8 @@ Szeretnéd még úgy is kikapcsolni és VISSZAFORDÍTHATATLANUL ELRONTOD A MEMÓ
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6956"/>
-      <source>Pins emulation threads to CPU cores to potentially improve performance/frame time variance.</source>
-      <translation type="unfinished">Pins emulation threads to CPU cores to potentially improve performance/frame time variance.</translation>
+      <source>Pins emulation threads to CPU cores to potentially improve performance/frame-time variance.</source>
+      <translation type="unfinished">Pins emulation threads to CPU cores to potentially improve performance/frame-time variance.</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6953"/>
@@ -8400,8 +8400,8 @@ Do you want to load this save and continue?</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="7581"/>
-      <source>Show Frame Times</source>
-      <translation type="unfinished">Show Frame Times</translation>
+      <source>Show Frame-Times</source>
+      <translation type="unfinished">Show Frame-Times</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="7582"/>
@@ -11342,8 +11342,8 @@ Percentage sign that will appear next to a number. Add a space or whatever is ne
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="1672"/>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="723"/>
-      <source>Show Frame Times</source>
-      <translation type="unfinished">Show Frame Times</translation>
+      <source>Show Frame-Times</source>
+      <translation type="unfinished">Show Frame-Times</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="1726"/>
@@ -12014,8 +12014,8 @@ Swap chain: see Microsoft&apos;s Terminology Portal.</extracomment>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="790"/>
-      <source>Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out frame time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</source>
-      <translation type="unfinished">Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out frame time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</translation>
+      <source>Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out the frame-time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</source>
+      <translation type="unfinished">Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out the frame-time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="1152"/>

--- a/pcsx2-qt/Translations/pcsx2-qt_id-ID.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_id-ID.ts
@@ -5131,8 +5131,8 @@ Apakah Anda ingin menghentikan game dan MENGHANCURKAN MEMORY CARD Anda secara pe
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6981"/>
-      <source>FMV Aspect Ratio</source>
-      <translation>FMV Aspect Ratio</translation>
+      <source>FMV Aspect Ratio Override</source>
+      <translation>FMV Aspect Ratio Override</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6982"/>
@@ -10267,7 +10267,7 @@ Pemindaian rekursif akan membuat proses pencarian menjadi lebih lama, namun dapa
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="112"/>
-      <source>FMV Aspect Ratio:</source>
+      <source>FMV Aspect Ratio Override:</source>
       <translation>Aspek Rasio FMV:</translation>
     </message>
     <message>
@@ -11703,7 +11703,7 @@ Swap chain: see Microsoft&apos;s Terminology Portal.</extracomment>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="444"/>
-      <source>FMV Aspect Ratio</source>
+      <source>FMV Aspect Ratio Override</source>
       <translation>Aspek Rasio FMV</translation>
     </message>
     <message>

--- a/pcsx2-qt/Translations/pcsx2-qt_id-ID.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_id-ID.ts
@@ -4387,8 +4387,8 @@ Enter function name</translation>
     </message>
     <message>
       <location filename="../Settings/EmulationSettingsWidget.cpp" line="136"/>
-      <source>Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame times, but add additional input lag.</source>
-      <translation>Mengatur jumlah frame maksimum yang dapat diantrekan ke GS, sebelum thread CPU menunggu salah satunya selesai sebelum melanjutkan. Jumlah yang lebih tinggi dapat menghaluskan frame time yang tidak teratur, namun akan menambah input lag.</translation>
+      <source>Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame-times, but add additional input lag.</source>
+      <translation>Mengatur jumlah frame maksimum yang dapat diantrekan ke GS, sebelum thread CPU menunggu salah satunya selesai sebelum melanjutkan. Jumlah yang lebih tinggi dapat menghaluskan frame-time yang tidak teratur, namun akan menambah input lag.</translation>
     </message>
     <message>
       <location filename="../Settings/EmulationSettingsWidget.cpp" line="139"/>
@@ -4887,8 +4887,8 @@ Tautan nya adalah: %1</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6935"/>
-      <source>Shows a visual history of frame times in the upper-left corner of the display.</source>
-      <translation>Menampilkan riwayat visual dari frame times di sudut kiri atas di layar.</translation>
+      <source>Shows a visual history of frame-times in the upper-left corner of the display.</source>
+      <translation>Menampilkan riwayat visual dari frame-times di sudut kiri atas di layar.</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6936"/>
@@ -5026,8 +5026,8 @@ Apakah Anda ingin menghentikan game dan MENGHANCURKAN MEMORY CARD Anda secara pe
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6956"/>
-      <source>Pins emulation threads to CPU cores to potentially improve performance/frame time variance.</source>
-      <translation>Menyematkan thread untuk emulasi ke core CPU yang mungkin dapat meningkatkan performa / perbedaan frame time.</translation>
+      <source>Pins emulation threads to CPU cores to potentially improve performance/frame-time variance.</source>
+      <translation>Menyematkan thread untuk emulasi ke core CPU yang mungkin dapat meningkatkan performa / perbedaan frame-time.</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6953"/>
@@ -8400,7 +8400,7 @@ Apakah Anda ingin memuat savestate ini dan melanjutkan?</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="7581"/>
-      <source>Show Frame Times</source>
+      <source>Show Frame-Times</source>
       <translation>Tampilkan Frame Time</translation>
     </message>
     <message>
@@ -11339,7 +11339,7 @@ Percentage sign that will appear next to a number. Add a space or whatever is ne
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="1672"/>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="723"/>
-      <source>Show Frame Times</source>
+      <source>Show Frame-Times</source>
       <translation>Tampilkan Frame Time</translation>
     </message>
     <message>
@@ -12011,8 +12011,8 @@ Swap chain: see Microsoft&apos;s Terminology Portal.</extracomment>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="790"/>
-      <source>Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out frame time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</source>
-      <translation>Mendeteksi saat frame diam sedang ditampilkan di game 25/30 FPS dan melewati menampilkan frame-frame diam tersebut. Framenya tetap di-render, namun GPU kini memiliki lebih banyak waktu untuk menyelesaikannya (TIDAK sama dengan frame skipping). Dapat menghaluskan fluktuasi frame time saat CPU/GPU hampir sepenuhnya dipakai, namun membuat frame pacing lebih inkonsisten dan dapat menambah input lag.</translation>
+      <source>Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out the frame-time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</source>
+      <translation>Mendeteksi saat frame diam sedang ditampilkan di game 25/30 FPS dan melewati menampilkan frame-frame diam tersebut. Framenya tetap di-render, namun GPU kini memiliki lebih banyak waktu untuk menyelesaikannya (TIDAK sama dengan frame skipping). Dapat menghaluskan fluktuasi frame-time saat CPU/GPU hampir sepenuhnya dipakai, namun membuat frame pacing lebih inkonsisten dan dapat menambah input lag.</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="1152"/>

--- a/pcsx2-qt/Translations/pcsx2-qt_it-IT.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_it-IT.ts
@@ -4392,8 +4392,8 @@ Inserire nome funzione</translation>
     </message>
     <message>
       <location filename="../Settings/EmulationSettingsWidget.cpp" line="136"/>
-      <source>Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame times, but add additional input lag.</source>
-      <translation>Imposta il numero massimo di frame che può essere accodato al GS, prima che il thread CPU attenda che uno di loro sia completo prima di continuare. Valori più elevati possono aiutare a rendere il frame time più regolare ma aggiungono ulteriore input lag.</translation>
+      <source>Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame-times, but add additional input lag.</source>
+      <translation>Imposta il numero massimo di frame che può essere accodato al GS, prima che il thread CPU attenda che uno di loro sia completo prima di continuare. Valori più elevati possono aiutare a rendere il frame-time più regolare ma aggiungono ulteriore input lag.</translation>
     </message>
     <message>
       <location filename="../Settings/EmulationSettingsWidget.cpp" line="139"/>
@@ -4892,7 +4892,7 @@ L'URL era: %1</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6935"/>
-      <source>Shows a visual history of frame times in the upper-left corner of the display.</source>
+      <source>Shows a visual history of frame-times in the upper-left corner of the display.</source>
       <translation>Mostra una cronologia visiva dei tempi dei fotogrammi nell'angolo in alto a sinistra del display.</translation>
     </message>
     <message>
@@ -5031,7 +5031,7 @@ Vuoi spegnere comunque e RENDERE INUTILIZZABILE IRRIMEDIABILMENTE LA MEMORY CARD
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6956"/>
-      <source>Pins emulation threads to CPU cores to potentially improve performance/frame time variance.</source>
+      <source>Pins emulation threads to CPU cores to potentially improve performance/frame-time variance.</source>
       <translation>Fissa i thread di emulazione ai core della CPU per migliorare potenzialmente la variabilità delle prestazioni/fotogrammi. </translation>
     </message>
     <message>
@@ -6996,7 +6996,7 @@ Vuoi caricare questo salvataggio e continuare?</translation>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6975"/>
       <source>Disables PCSX2&apos;s internal frame timing, and uses host vsync instead.</source>
-      <translation>Disabilita il frame time interno di PCSX2 e usa invece il vsync dell'host.</translation>
+      <translation>Disabilita il frame-time interno di PCSX2 e usa invece il vsync dell'host.</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="7123"/>
@@ -8404,8 +8404,8 @@ Vuoi caricare questo salvataggio e continuare?</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="7581"/>
-      <source>Show Frame Times</source>
-      <translation>Mostra frame time</translation>
+      <source>Show Frame-Times</source>
+      <translation>Mostra frame-time</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="7582"/>
@@ -11345,8 +11345,8 @@ Percentage sign that will appear next to a number. Add a space or whatever is ne
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="1672"/>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="723"/>
-      <source>Show Frame Times</source>
-      <translation>Mostra frame time</translation>
+      <source>Show Frame-Times</source>
+      <translation>Mostra frame-time</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="1726"/>
@@ -12017,8 +12017,8 @@ Swap chain: see Microsoft&apos;s Terminology Portal.</extracomment>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="790"/>
-      <source>Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out frame time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</source>
-      <translation>Rileva quando i frame inattivi vengono presentati nei giochi a 25/30fps, e salta la presentazione di quei frame. Il frame viene comunque renderizzato, ma la GPU ha più tempo per completarlo (questo NON è un salto dei frame). Può rendere più morbide le fluttuazioni del frame time quando la CPU/GPU sono vicine al massimo dell'utilizzo, ma rende il ritmo dei frame più incostante e può aumentare l'input lag.</translation>
+      <source>Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out the frame-time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</source>
+      <translation>Rileva quando i frame inattivi vengono presentati nei giochi a 25/30fps, e salta la presentazione di quei frame. Il frame viene comunque renderizzato, ma la GPU ha più tempo per completarlo (questo NON è un salto dei frame). Può rendere più morbide le fluttuazioni del frame-time quando la CPU/GPU sono vicine al massimo dell'utilizzo, ma rende il ritmo dei frame più incostante e può aumentare l'input lag.</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="1152"/>

--- a/pcsx2-qt/Translations/pcsx2-qt_it-IT.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_it-IT.ts
@@ -5136,7 +5136,7 @@ Vuoi spegnere comunque e RENDERE INUTILIZZABILE IRRIMEDIABILMENTE LA MEMORY CARD
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6981"/>
-      <source>FMV Aspect Ratio</source>
+      <source>FMV Aspect Ratio Override</source>
       <translation>Rapporto d'aspetto FMV</translation>
     </message>
     <message>
@@ -10273,7 +10273,7 @@ La scansione ricorsiva richiede più tempo, ma identificherà i file nelle sotto
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="112"/>
-      <source>FMV Aspect Ratio:</source>
+      <source>FMV Aspect Ratio Override:</source>
       <translation>Rapporto d'aspetto FMV:</translation>
     </message>
     <message>
@@ -11709,7 +11709,7 @@ Swap chain: see Microsoft&apos;s Terminology Portal.</extracomment>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="444"/>
-      <source>FMV Aspect Ratio</source>
+      <source>FMV Aspect Ratio Override</source>
       <translation>Rapporto d'aspetto FMV</translation>
     </message>
     <message>

--- a/pcsx2-qt/Translations/pcsx2-qt_ja-JP.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_ja-JP.ts
@@ -5131,7 +5131,7 @@ Do you wish to shutdown anyways and IRREVERSIBLY DESTROY YOUR MEMORY CARD?</sour
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6981"/>
-      <source>FMV Aspect Ratio</source>
+      <source>FMV Aspect Ratio Override</source>
       <translation>FMV アスペクト比</translation>
     </message>
     <message>
@@ -10264,7 +10264,7 @@ Scanning recursively takes more time, but will identify files in subdirectories.
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="112"/>
-      <source>FMV Aspect Ratio:</source>
+      <source>FMV Aspect Ratio Override:</source>
       <translation>FMV アスペクト比:</translation>
     </message>
     <message>
@@ -11700,7 +11700,7 @@ Swap chain: see Microsoft&apos;s Terminology Portal.</extracomment>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="444"/>
-      <source>FMV Aspect Ratio</source>
+      <source>FMV Aspect Ratio Override</source>
       <translation>FMV アスペクト比</translation>
     </message>
     <message>

--- a/pcsx2-qt/Translations/pcsx2-qt_ja-JP.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_ja-JP.ts
@@ -4387,7 +4387,7 @@ Enter function name</source>
     </message>
     <message>
       <location filename="../Settings/EmulationSettingsWidget.cpp" line="136"/>
-      <source>Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame times, but add additional input lag.</source>
+      <source>Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame-times, but add additional input lag.</source>
       <translation>CPU スレッドが続行する前に、GS にキューイングできるフレームの最大数を設定します。値が大きいほど規則なフレームタイムを滑らかにできますが、その分入力遅延が発生します。</translation>
     </message>
     <message>
@@ -4887,7 +4887,7 @@ URL: %1</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6935"/>
-      <source>Shows a visual history of frame times in the upper-left corner of the display.</source>
+      <source>Shows a visual history of frame-times in the upper-left corner of the display.</source>
       <translation>ディスプレイの左上に、フレームタイムの視覚的な履歴を表示します。</translation>
     </message>
     <message>
@@ -5026,7 +5026,7 @@ Do you wish to shutdown anyways and IRREVERSIBLY DESTROY YOUR MEMORY CARD?</sour
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6956"/>
-      <source>Pins emulation threads to CPU cores to potentially improve performance/frame time variance.</source>
+      <source>Pins emulation threads to CPU cores to potentially improve performance/frame-time variance.</source>
       <translation>エミュレーションスレッドを CPU コアに固定して、パフォーマンス/フレーム時間の差異を改善できる可能性があります。</translation>
     </message>
     <message>
@@ -8398,7 +8398,7 @@ Do you want to load this save and continue?</source>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="7581"/>
-      <source>Show Frame Times</source>
+      <source>Show Frame-Times</source>
       <translation>フレームタイムを表示</translation>
     </message>
     <message>
@@ -11336,7 +11336,7 @@ Percentage sign that will appear next to a number. Add a space or whatever is ne
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="1672"/>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="723"/>
-      <source>Show Frame Times</source>
+      <source>Show Frame-Times</source>
       <translation>フレームタイムを表示</translation>
     </message>
     <message>
@@ -12008,8 +12008,8 @@ Swap chain: see Microsoft&apos;s Terminology Portal.</extracomment>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="790"/>
-      <source>Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out frame time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</source>
-      <translation type="unfinished">Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out frame time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</translation>
+      <source>Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out the frame-time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</source>
+      <translation type="unfinished">Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out the frame-time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="1152"/>

--- a/pcsx2-qt/Translations/pcsx2-qt_ka-GE.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_ka-GE.ts
@@ -4390,8 +4390,8 @@ Enter function name</translation>
     </message>
     <message>
       <location filename="../Settings/EmulationSettingsWidget.cpp" line="136"/>
-      <source>Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame times, but add additional input lag.</source>
-      <translation type="unfinished">Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame times, but add additional input lag.</translation>
+      <source>Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame-times, but add additional input lag.</source>
+      <translation type="unfinished">Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame-times, but add additional input lag.</translation>
     </message>
     <message>
       <location filename="../Settings/EmulationSettingsWidget.cpp" line="139"/>
@@ -4890,8 +4890,8 @@ The URL was: %1</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6935"/>
-      <source>Shows a visual history of frame times in the upper-left corner of the display.</source>
-      <translation type="unfinished">Shows a visual history of frame times in the upper-left corner of the display.</translation>
+      <source>Shows a visual history of frame-times in the upper-left corner of the display.</source>
+      <translation type="unfinished">Shows a visual history of frame-times in the upper-left corner of the display.</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6936"/>
@@ -5029,8 +5029,8 @@ Do you wish to shutdown anyways and IRREVERSIBLY DESTROY YOUR MEMORY CARD?</tran
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6956"/>
-      <source>Pins emulation threads to CPU cores to potentially improve performance/frame time variance.</source>
-      <translation type="unfinished">Pins emulation threads to CPU cores to potentially improve performance/frame time variance.</translation>
+      <source>Pins emulation threads to CPU cores to potentially improve performance/frame-time variance.</source>
+      <translation type="unfinished">Pins emulation threads to CPU cores to potentially improve performance/frame-time variance.</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6953"/>
@@ -8402,8 +8402,8 @@ Do you want to load this save and continue?</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="7581"/>
-      <source>Show Frame Times</source>
-      <translation type="unfinished">Show Frame Times</translation>
+      <source>Show Frame-Times</source>
+      <translation type="unfinished">Show Frame-Times</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="7582"/>
@@ -11344,8 +11344,8 @@ Percentage sign that will appear next to a number. Add a space or whatever is ne
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="1672"/>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="723"/>
-      <source>Show Frame Times</source>
-      <translation type="unfinished">Show Frame Times</translation>
+      <source>Show Frame-Times</source>
+      <translation type="unfinished">Show Frame-Times</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="1726"/>
@@ -12016,8 +12016,8 @@ Swap chain: see Microsoft&apos;s Terminology Portal.</extracomment>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="790"/>
-      <source>Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out frame time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</source>
-      <translation type="unfinished">Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out frame time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</translation>
+      <source>Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out the frame-time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</source>
+      <translation type="unfinished">Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out the frame-time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="1152"/>

--- a/pcsx2-qt/Translations/pcsx2-qt_ka-GE.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_ka-GE.ts
@@ -5134,8 +5134,8 @@ Do you wish to shutdown anyways and IRREVERSIBLY DESTROY YOUR MEMORY CARD?</tran
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6981"/>
-      <source>FMV Aspect Ratio</source>
-      <translation type="unfinished">FMV Aspect Ratio</translation>
+      <source>FMV Aspect Ratio Override</source>
+      <translation type="unfinished">FMV Aspect Ratio Override</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6982"/>
@@ -10272,8 +10272,8 @@ Scanning recursively takes more time, but will identify files in subdirectories.
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="112"/>
-      <source>FMV Aspect Ratio:</source>
-      <translation type="unfinished">FMV Aspect Ratio:</translation>
+      <source>FMV Aspect Ratio Override:</source>
+      <translation type="unfinished">FMV Aspect Ratio Override:</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="120"/>
@@ -11708,8 +11708,8 @@ Swap chain: see Microsoft&apos;s Terminology Portal.</extracomment>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="444"/>
-      <source>FMV Aspect Ratio</source>
-      <translation type="unfinished">FMV Aspect Ratio</translation>
+      <source>FMV Aspect Ratio Override</source>
+      <translation type="unfinished">FMV Aspect Ratio Override</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="444"/>

--- a/pcsx2-qt/Translations/pcsx2-qt_ko-KR.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_ko-KR.ts
@@ -5129,7 +5129,7 @@ Do you wish to shutdown anyways and IRREVERSIBLY DESTROY YOUR MEMORY CARD?</sour
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6981"/>
-      <source>FMV Aspect Ratio</source>
+      <source>FMV Aspect Ratio Override</source>
       <translation>FMV 종횡비</translation>
     </message>
     <message>
@@ -10264,7 +10264,7 @@ Scanning recursively takes more time, but will identify files in subdirectories.
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="112"/>
-      <source>FMV Aspect Ratio:</source>
+      <source>FMV Aspect Ratio Override:</source>
       <translation>FMV 종횡비 :</translation>
     </message>
     <message>
@@ -11700,7 +11700,7 @@ Swap chain: see Microsoft&apos;s Terminology Portal.</extracomment>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="444"/>
-      <source>FMV Aspect Ratio</source>
+      <source>FMV Aspect Ratio Override</source>
       <translation>FMV 종횡비</translation>
     </message>
     <message>

--- a/pcsx2-qt/Translations/pcsx2-qt_ko-KR.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_ko-KR.ts
@@ -4385,7 +4385,7 @@ Enter function name</source>
     </message>
     <message>
       <location filename="../Settings/EmulationSettingsWidget.cpp" line="136"/>
-      <source>Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame times, but add additional input lag.</source>
+      <source>Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame-times, but add additional input lag.</source>
       <translation>CPU 스레드가 한 프레임이 완료될 때까지 기다렸다가 계속 진행하기 전에 GS에 대기할 수 있는 최대 프레임 수를 설정합니다. 값이 클수록 불규칙한 프레임 시간을 부드럽게 하는 데 도움이 될 수 있지만 입력 대기가 추가됩니다.</translation>
     </message>
     <message>
@@ -4885,7 +4885,7 @@ The URL was: %1</source>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6935"/>
-      <source>Shows a visual history of frame times in the upper-left corner of the display.</source>
+      <source>Shows a visual history of frame-times in the upper-left corner of the display.</source>
       <translation>화면 좌측 상단 모서리에 프레임 시간의 시각적 기록을 표시합니다.</translation>
     </message>
     <message>
@@ -5024,7 +5024,7 @@ Do you wish to shutdown anyways and IRREVERSIBLY DESTROY YOUR MEMORY CARD?</sour
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6956"/>
-      <source>Pins emulation threads to CPU cores to potentially improve performance/frame time variance.</source>
+      <source>Pins emulation threads to CPU cores to potentially improve performance/frame-time variance.</source>
       <translation>에뮬레이션 스레드를 CPU 코어에 고정하여 잠재적으로 성능/프레임 시간 편차를 개선합니다.</translation>
     </message>
     <message>
@@ -8397,7 +8397,7 @@ Do you want to load this save and continue?</source>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="7581"/>
-      <source>Show Frame Times</source>
+      <source>Show Frame-Times</source>
       <translation>프레임 시간 표시</translation>
     </message>
     <message>
@@ -11336,7 +11336,7 @@ Percentage sign that will appear next to a number. Add a space or whatever is ne
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="1672"/>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="723"/>
-      <source>Show Frame Times</source>
+      <source>Show Frame-Times</source>
       <translation>프레임 시간 표시</translation>
     </message>
     <message>
@@ -12008,7 +12008,7 @@ Swap chain: see Microsoft&apos;s Terminology Portal.</extracomment>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="790"/>
-      <source>Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out frame time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</source>
+      <source>Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out the frame-time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</source>
       <translation>25/30fps 게임에서 유휴 프레임이 표시되는 시점을 감지하고 해당 프레임 표시를 건너뜁니다. 프레임은 여전히 렌더링되며, GPU가 프레임을 완료할 시간이 더 많다는 의미일 뿐입니다(프레임 건너뛰기가 아님). CPU/GPU가 최대 활용률에 가까울 때 프레임 시간 변동을 완화할 수 있지만 프레임 속도가 더 일관되지 않고 입력 지연이 증가할 수 있습니다.</translation>
     </message>
     <message>

--- a/pcsx2-qt/Translations/pcsx2-qt_lt-LT.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_lt-LT.ts
@@ -5145,7 +5145,7 @@ Ar norite vis tiek išjungti žaidimą ir NEGRĮŽTAMAI SUGADINTI JŪSŲ ATMINTI
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6981"/>
-      <source>FMV Aspect Ratio</source>
+      <source>FMV Aspect Ratio Override</source>
       <translation>FMV Vaizdo santykis</translation>
     </message>
     <message>
@@ -10287,7 +10287,7 @@ Skenavimas pakartotinai užima daugiau laiko, tačiau bus nustatyti papildomai s
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="112"/>
-      <source>FMV Aspect Ratio:</source>
+      <source>FMV Aspect Ratio Override:</source>
       <translation>FMV Vaizdo santykis:</translation>
     </message>
     <message>
@@ -11723,7 +11723,7 @@ Swap chain: see Microsoft&apos;s Terminology Portal.</extracomment>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="444"/>
-      <source>FMV Aspect Ratio</source>
+      <source>FMV Aspect Ratio Override</source>
       <translation>FMV Vaizdo santykis</translation>
     </message>
     <message>

--- a/pcsx2-qt/Translations/pcsx2-qt_lt-LT.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_lt-LT.ts
@@ -4401,7 +4401,7 @@ Enter function name</translation>
     </message>
     <message>
       <location filename="../Settings/EmulationSettingsWidget.cpp" line="136"/>
-      <source>Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame times, but add additional input lag.</source>
+      <source>Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame-times, but add additional input lag.</source>
       <translation>Nustato didžiausią kadrų, kurie gali būti įrašyti į GS eilę, skaičių, kol procesoriaus thread'as lauks, kol vienas iš jų bus baigtas, ir tik tada tęs darbą. Didesnės vertės gali padėti išlyginti netolygų kadrų laiką, tačiau prideda papildomą įvesties vėlavimą.</translation>
     </message>
     <message>
@@ -4901,8 +4901,8 @@ The URL was: %1</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6935"/>
-      <source>Shows a visual history of frame times in the upper-left corner of the display.</source>
-      <translation type="unfinished">Shows a visual history of frame times in the upper-left corner of the display.</translation>
+      <source>Shows a visual history of frame-times in the upper-left corner of the display.</source>
+      <translation type="unfinished">Shows a visual history of frame-times in the upper-left corner of the display.</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6936"/>
@@ -5040,8 +5040,8 @@ Ar norite vis tiek išjungti žaidimą ir NEGRĮŽTAMAI SUGADINTI JŪSŲ ATMINTI
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6956"/>
-      <source>Pins emulation threads to CPU cores to potentially improve performance/frame time variance.</source>
-      <translation type="unfinished">Pins emulation threads to CPU cores to potentially improve performance/frame time variance.</translation>
+      <source>Pins emulation threads to CPU cores to potentially improve performance/frame-time variance.</source>
+      <translation type="unfinished">Pins emulation threads to CPU cores to potentially improve performance/frame-time variance.</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6953"/>
@@ -8413,7 +8413,7 @@ Do you want to load this save and continue?</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="7581"/>
-      <source>Show Frame Times</source>
+      <source>Show Frame-Times</source>
       <translation>Rodyti kadrų laiką</translation>
     </message>
     <message>
@@ -11359,7 +11359,7 @@ Percentage sign that will appear next to a number. Add a space or whatever is ne
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="1672"/>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="723"/>
-      <source>Show Frame Times</source>
+      <source>Show Frame-Times</source>
       <translation>Rodyti kadrų laiką</translation>
     </message>
     <message>
@@ -12031,8 +12031,8 @@ Swap chain: see Microsoft&apos;s Terminology Portal.</extracomment>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="790"/>
-      <source>Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out frame time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</source>
-      <translation type="unfinished">Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out frame time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</translation>
+      <source>Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out the frame-time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</source>
+      <translation type="unfinished">Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out the frame-time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="1152"/>

--- a/pcsx2-qt/Translations/pcsx2-qt_lv-LV.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_lv-LV.ts
@@ -5144,8 +5144,8 @@ Do you wish to shutdown anyways and IRREVERSIBLY DESTROY YOUR MEMORY CARD?</tran
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6981"/>
-      <source>FMV Aspect Ratio</source>
-      <translation type="unfinished">FMV Aspect Ratio</translation>
+      <source>FMV Aspect Ratio Override</source>
+      <translation type="unfinished">FMV Aspect Ratio Override</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6982"/>
@@ -10284,8 +10284,8 @@ Scanning recursively takes more time, but will identify files in subdirectories.
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="112"/>
-      <source>FMV Aspect Ratio:</source>
-      <translation type="unfinished">FMV Aspect Ratio:</translation>
+      <source>FMV Aspect Ratio Override:</source>
+      <translation type="unfinished">FMV Aspect Ratio Override:</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="120"/>
@@ -11720,8 +11720,8 @@ Swap chain: see Microsoft&apos;s Terminology Portal.</extracomment>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="444"/>
-      <source>FMV Aspect Ratio</source>
-      <translation type="unfinished">FMV Aspect Ratio</translation>
+      <source>FMV Aspect Ratio Override</source>
+      <translation type="unfinished">FMV Aspect Ratio Override</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="444"/>

--- a/pcsx2-qt/Translations/pcsx2-qt_lv-LV.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_lv-LV.ts
@@ -4400,8 +4400,8 @@ Enter function name</translation>
     </message>
     <message>
       <location filename="../Settings/EmulationSettingsWidget.cpp" line="136"/>
-      <source>Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame times, but add additional input lag.</source>
-      <translation type="unfinished">Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame times, but add additional input lag.</translation>
+      <source>Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame-times, but add additional input lag.</source>
+      <translation type="unfinished">Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame-times, but add additional input lag.</translation>
     </message>
     <message>
       <location filename="../Settings/EmulationSettingsWidget.cpp" line="139"/>
@@ -4900,8 +4900,8 @@ The URL was: %1</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6935"/>
-      <source>Shows a visual history of frame times in the upper-left corner of the display.</source>
-      <translation type="unfinished">Shows a visual history of frame times in the upper-left corner of the display.</translation>
+      <source>Shows a visual history of frame-times in the upper-left corner of the display.</source>
+      <translation type="unfinished">Shows a visual history of frame-times in the upper-left corner of the display.</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6936"/>
@@ -5039,8 +5039,8 @@ Do you wish to shutdown anyways and IRREVERSIBLY DESTROY YOUR MEMORY CARD?</tran
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6956"/>
-      <source>Pins emulation threads to CPU cores to potentially improve performance/frame time variance.</source>
-      <translation type="unfinished">Pins emulation threads to CPU cores to potentially improve performance/frame time variance.</translation>
+      <source>Pins emulation threads to CPU cores to potentially improve performance/frame-time variance.</source>
+      <translation type="unfinished">Pins emulation threads to CPU cores to potentially improve performance/frame-time variance.</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6953"/>
@@ -8412,8 +8412,8 @@ Do you want to load this save and continue?</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="7581"/>
-      <source>Show Frame Times</source>
-      <translation type="unfinished">Show Frame Times</translation>
+      <source>Show Frame-Times</source>
+      <translation type="unfinished">Show Frame-Times</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="7582"/>
@@ -11356,8 +11356,8 @@ Percentage sign that will appear next to a number. Add a space or whatever is ne
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="1672"/>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="723"/>
-      <source>Show Frame Times</source>
-      <translation type="unfinished">Show Frame Times</translation>
+      <source>Show Frame-Times</source>
+      <translation type="unfinished">Show Frame-Times</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="1726"/>
@@ -12028,8 +12028,8 @@ Swap chain: see Microsoft&apos;s Terminology Portal.</extracomment>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="790"/>
-      <source>Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out frame time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</source>
-      <translation type="unfinished">Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out frame time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</translation>
+      <source>Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out the frame-time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</source>
+      <translation type="unfinished">Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out the frame-time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="1152"/>

--- a/pcsx2-qt/Translations/pcsx2-qt_nl-NL.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_nl-NL.ts
@@ -5137,7 +5137,7 @@ Wilt u toch afsluiten en TOCH DOODMEPPEN VAN UW MEMORY CARD?</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6981"/>
-      <source>FMV Aspect Ratio</source>
+      <source>FMV Aspect Ratio Override</source>
       <translation>FMV / Cutscene-Beeldsverhouding</translation>
     </message>
     <message>
@@ -10275,8 +10275,8 @@ Scanning recursively takes more time, but will identify files in subdirectories.
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="112"/>
-      <source>FMV Aspect Ratio:</source>
-      <translation type="unfinished">FMV Aspect Ratio:</translation>
+      <source>FMV Aspect Ratio Override:</source>
+      <translation type="unfinished">FMV Aspect Ratio Override:</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="120"/>
@@ -11711,8 +11711,8 @@ Swap chain: see Microsoft&apos;s Terminology Portal.</extracomment>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="444"/>
-      <source>FMV Aspect Ratio</source>
-      <translation type="unfinished">FMV Aspect Ratio</translation>
+      <source>FMV Aspect Ratio Override</source>
+      <translation type="unfinished">FMV Aspect Ratio Override</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="444"/>

--- a/pcsx2-qt/Translations/pcsx2-qt_nl-NL.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_nl-NL.ts
@@ -4393,7 +4393,7 @@ Enter functienaam</translation>
     </message>
     <message>
       <location filename="../Settings/EmulationSettingsWidget.cpp" line="136"/>
-      <source>Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame times, but add additional input lag.</source>
+      <source>Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame-times, but add additional input lag.</source>
       <translation>Stelt het maximum aantal frames in dat in de wachtrij kan worden gezet tot het GS, voordat de CPU thread zal wachten tot een van hen voltooid zal zijn voordat u verder gaat. Hogere waarden kunnen helpen bij het vereffenen van onregelmatige frame tijden, maar voegen extra invoervertraging toe.</translation>
     </message>
     <message>
@@ -4893,8 +4893,8 @@ De URL was: %1</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6935"/>
-      <source>Shows a visual history of frame times in the upper-left corner of the display.</source>
-      <translation type="unfinished">Shows a visual history of frame times in the upper-left corner of the display.</translation>
+      <source>Shows a visual history of frame-times in the upper-left corner of the display.</source>
+      <translation type="unfinished">Shows a visual history of frame-times in the upper-left corner of the display.</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6936"/>
@@ -5032,7 +5032,7 @@ Wilt u toch afsluiten en TOCH DOODMEPPEN VAN UW MEMORY CARD?</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6956"/>
-      <source>Pins emulation threads to CPU cores to potentially improve performance/frame time variance.</source>
+      <source>Pins emulation threads to CPU cores to potentially improve performance/frame-time variance.</source>
       <translation>Pint geëmuleerde threads aan CPU-kernen voor mogelijk de prestatie/beeldtijdsvariatie te verbeteren.</translation>
     </message>
     <message>
@@ -8405,8 +8405,8 @@ Do you want to load this save and continue?</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="7581"/>
-      <source>Show Frame Times</source>
-      <translation type="unfinished">Show Frame Times</translation>
+      <source>Show Frame-Times</source>
+      <translation type="unfinished">Show Frame-Times</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="7582"/>
@@ -11347,8 +11347,8 @@ Percentage sign that will appear next to a number. Add a space or whatever is ne
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="1672"/>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="723"/>
-      <source>Show Frame Times</source>
-      <translation type="unfinished">Show Frame Times</translation>
+      <source>Show Frame-Times</source>
+      <translation type="unfinished">Show Frame-Times</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="1726"/>
@@ -12019,8 +12019,8 @@ Swap chain: see Microsoft&apos;s Terminology Portal.</extracomment>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="790"/>
-      <source>Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out frame time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</source>
-      <translation type="unfinished">Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out frame time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</translation>
+      <source>Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out the frame-time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</source>
+      <translation type="unfinished">Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out the frame-time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="1152"/>

--- a/pcsx2-qt/Translations/pcsx2-qt_no-NO.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_no-NO.ts
@@ -4392,7 +4392,7 @@ Skriv inn funksjonsnavn</translation>
     </message>
     <message>
       <location filename="../Settings/EmulationSettingsWidget.cpp" line="136"/>
-      <source>Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame times, but add additional input lag.</source>
+      <source>Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame-times, but add additional input lag.</source>
       <translation>Angir det maksimale antallet bilder som kan settes i kø til GS før CPU-tråden venter på at ett av dem skal fullføres før den fortsetter. Høyere verdier kan bidra til å jevne ut uregelmessige rammetider, men gir ekstra inndata-forsinkelse.</translation>
     </message>
     <message>
@@ -4892,8 +4892,8 @@ URL-en var: %1</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6935"/>
-      <source>Shows a visual history of frame times in the upper-left corner of the display.</source>
-      <translation type="unfinished">Shows a visual history of frame times in the upper-left corner of the display.</translation>
+      <source>Shows a visual history of frame-times in the upper-left corner of the display.</source>
+      <translation type="unfinished">Shows a visual history of frame-times in the upper-left corner of the display.</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6936"/>
@@ -5031,8 +5031,8 @@ Do you wish to shutdown anyways and IRREVERSIBLY DESTROY YOUR MEMORY CARD?</tran
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6956"/>
-      <source>Pins emulation threads to CPU cores to potentially improve performance/frame time variance.</source>
-      <translation type="unfinished">Pins emulation threads to CPU cores to potentially improve performance/frame time variance.</translation>
+      <source>Pins emulation threads to CPU cores to potentially improve performance/frame-time variance.</source>
+      <translation type="unfinished">Pins emulation threads to CPU cores to potentially improve performance/frame-time variance.</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6953"/>
@@ -8404,8 +8404,8 @@ Do you want to load this save and continue?</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="7581"/>
-      <source>Show Frame Times</source>
-      <translation type="unfinished">Show Frame Times</translation>
+      <source>Show Frame-Times</source>
+      <translation type="unfinished">Show Frame-Times</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="7582"/>
@@ -11346,7 +11346,7 @@ Percentage sign that will appear next to a number. Add a space or whatever is ne
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="1672"/>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="723"/>
-      <source>Show Frame Times</source>
+      <source>Show Frame-Times</source>
       <translation>Vis bildetider</translation>
     </message>
     <message>
@@ -12018,8 +12018,8 @@ Swap chain: see Microsoft&apos;s Terminology Portal.</extracomment>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="790"/>
-      <source>Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out frame time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</source>
-      <translation type="unfinished">Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out frame time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</translation>
+      <source>Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out the frame-time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</source>
+      <translation type="unfinished">Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out the frame-time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="1152"/>

--- a/pcsx2-qt/Translations/pcsx2-qt_no-NO.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_no-NO.ts
@@ -5136,8 +5136,8 @@ Do you wish to shutdown anyways and IRREVERSIBLY DESTROY YOUR MEMORY CARD?</tran
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6981"/>
-      <source>FMV Aspect Ratio</source>
-      <translation type="unfinished">FMV Aspect Ratio</translation>
+      <source>FMV Aspect Ratio Override</source>
+      <translation type="unfinished">FMV Aspect Ratio Override</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6982"/>
@@ -10274,7 +10274,7 @@ Rekursiv skanning tar lengre tid, men identifiserer filer i underkataloger.</tra
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="112"/>
-      <source>FMV Aspect Ratio:</source>
+      <source>FMV Aspect Ratio Override:</source>
       <translation>FMV størrelsesforhold:</translation>
     </message>
     <message>
@@ -11710,7 +11710,7 @@ Swap chain: see Microsoft&apos;s Terminology Portal.</extracomment>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="444"/>
-      <source>FMV Aspect Ratio</source>
+      <source>FMV Aspect Ratio Override</source>
       <translation>FMV størrelsesforhold</translation>
     </message>
     <message>

--- a/pcsx2-qt/Translations/pcsx2-qt_pl-PL.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_pl-PL.ts
@@ -5146,7 +5146,7 @@ Czy mimo to chcesz zamknąć i NIEODWRACALNIE ZEPSUĆ SWOJĄ KARTĘ PAMIĘCI?</t
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6981"/>
-      <source>FMV Aspect Ratio</source>
+      <source>FMV Aspect Ratio Override</source>
       <translation>Format obrazu przy FMV</translation>
     </message>
     <message>
@@ -10286,7 +10286,7 @@ Skanowanie to zajmuje więcej czasu, ale identyfikuje pliki w podkatalogach.</tr
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="112"/>
-      <source>FMV Aspect Ratio:</source>
+      <source>FMV Aspect Ratio Override:</source>
       <translation>Format obrazu przy FMV:</translation>
     </message>
     <message>
@@ -11722,7 +11722,7 @@ Swap chain: see Microsoft&apos;s Terminology Portal.</extracomment>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="444"/>
-      <source>FMV Aspect Ratio</source>
+      <source>FMV Aspect Ratio Override</source>
       <translation>Format obrazu przy FMV</translation>
     </message>
     <message>

--- a/pcsx2-qt/Translations/pcsx2-qt_pl-PL.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_pl-PL.ts
@@ -4402,7 +4402,7 @@ Wprowadź nazwę funkcji</translation>
     </message>
     <message>
       <location filename="../Settings/EmulationSettingsWidget.cpp" line="136"/>
-      <source>Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame times, but add additional input lag.</source>
+      <source>Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame-times, but add additional input lag.</source>
       <translation>Ustawia maksymalną liczbę ramek, które mogą być umieszczone w kolejce do GS, zanim wątek CPU będzie czekał, aż jeden z nich zakończy się przed kontynuowaniem. Wyższe wartości mogą pomóc w wygładzaniu nieprawidłowych klatek czasowych, ale dodają dodatkowe opóźnienie wejściowe.</translation>
     </message>
     <message>
@@ -4902,7 +4902,7 @@ Adres URL to: %1</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6935"/>
-      <source>Shows a visual history of frame times in the upper-left corner of the display.</source>
+      <source>Shows a visual history of frame-times in the upper-left corner of the display.</source>
       <translation>Pokazuje wizualną historię czasów klatki w lewym górnym rogu ekranu.</translation>
     </message>
     <message>
@@ -5041,7 +5041,7 @@ Czy mimo to chcesz zamknąć i NIEODWRACALNIE ZEPSUĆ SWOJĄ KARTĘ PAMIĘCI?</t
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6956"/>
-      <source>Pins emulation threads to CPU cores to potentially improve performance/frame time variance.</source>
+      <source>Pins emulation threads to CPU cores to potentially improve performance/frame-time variance.</source>
       <translation>Przypina wątki emulacyjne do rdzeni procesora w celu potencjalnej poprawy wariancji czasowej wydajności/ramki.</translation>
     </message>
     <message>
@@ -8414,7 +8414,7 @@ Czy chcesz załadować ten zapis i kontynuować?</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="7581"/>
-      <source>Show Frame Times</source>
+      <source>Show Frame-Times</source>
       <translation>Pokaż czasy klatek</translation>
     </message>
     <message>
@@ -11358,7 +11358,7 @@ Percentage sign that will appear next to a number. Add a space or whatever is ne
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="1672"/>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="723"/>
-      <source>Show Frame Times</source>
+      <source>Show Frame-Times</source>
       <translation>Pokaż czasy klatek</translation>
     </message>
     <message>
@@ -12030,7 +12030,7 @@ Swap chain: see Microsoft&apos;s Terminology Portal.</extracomment>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="790"/>
-      <source>Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out frame time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</source>
+      <source>Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out the frame-time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</source>
       <translation>Wykrywa, kiedy bezczynne klatki są prezentowane w grach 25/30fps i pomija te klatki. Klatka jest nadal renderowana, oznacza to, jedynie, że karta graficzna ma więcej czasu na jej ukończenie (to NIE jest pomijanie klatek). Może łagodzić wahania czasu wyświetlania klatek, gdy zużycie procesora lub karty graficznej zbliża się do maksimum, ale sprawia, że tempo klatek jest bardziej niespójne i może zwiększyć opóźnienie wejściowe.</translation>
     </message>
     <message>

--- a/pcsx2-qt/Translations/pcsx2-qt_pt-BR.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_pt-BR.ts
@@ -5136,7 +5136,7 @@ Você deseja desligar de qualquer modo e DESTRUIR IRREVERSIVELMENTE SEU CARTÃO 
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6981"/>
-      <source>FMV Aspect Ratio</source>
+      <source>FMV Aspect Ratio Override</source>
       <translation>Proporção do Aspecto do FMV</translation>
     </message>
     <message>
@@ -10274,7 +10274,7 @@ O escaneamento recursivamente leva mais tempo mas identificará os arquivos nos 
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="112"/>
-      <source>FMV Aspect Ratio:</source>
+      <source>FMV Aspect Ratio Override:</source>
       <translation>Proporção do Aspecto do FMV:</translation>
     </message>
     <message>
@@ -11710,7 +11710,7 @@ Swap chain: see Microsoft&apos;s Terminology Portal.</extracomment>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="444"/>
-      <source>FMV Aspect Ratio</source>
+      <source>FMV Aspect Ratio Override</source>
       <translation>Proporção do Aspecto do FMV</translation>
     </message>
     <message>

--- a/pcsx2-qt/Translations/pcsx2-qt_pt-BR.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_pt-BR.ts
@@ -4392,7 +4392,7 @@ Insira o nome da função</translation>
     </message>
     <message>
       <location filename="../Settings/EmulationSettingsWidget.cpp" line="136"/>
-      <source>Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame times, but add additional input lag.</source>
+      <source>Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame-times, but add additional input lag.</source>
       <translation>Define o número máximo de frames que podem ser enfileirados até o GS antes que o thread da CPU espere que um deles complete antes de continuar. Valores maiores podem ajudar a suavizar os tempos dos frames irregulares mas adiciona atraso adicional da entrada.</translation>
     </message>
     <message>
@@ -4892,7 +4892,7 @@ A URL era: %1</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6935"/>
-      <source>Shows a visual history of frame times in the upper-left corner of the display.</source>
+      <source>Shows a visual history of frame-times in the upper-left corner of the display.</source>
       <translation>Mostra um histórico visual dos tempos dos frames no canto superior esquerdo da tela.</translation>
     </message>
     <message>
@@ -5031,7 +5031,7 @@ Você deseja desligar de qualquer modo e DESTRUIR IRREVERSIVELMENTE SEU CARTÃO 
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6956"/>
-      <source>Pins emulation threads to CPU cores to potentially improve performance/frame time variance.</source>
+      <source>Pins emulation threads to CPU cores to potentially improve performance/frame-time variance.</source>
       <translation>Fixa os threads da emulação nos núcleos da CPU pra melhorar potencialmente a variação da performance/tempo dos frames.</translation>
     </message>
     <message>
@@ -8404,7 +8404,7 @@ Você quer carregar este save e continuar?</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="7581"/>
-      <source>Show Frame Times</source>
+      <source>Show Frame-Times</source>
       <translation>Mostrar o Tempo dos Frames</translation>
     </message>
     <message>
@@ -11346,7 +11346,7 @@ Percentage sign that will appear next to a number. Add a space or whatever is ne
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="1672"/>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="723"/>
-      <source>Show Frame Times</source>
+      <source>Show Frame-Times</source>
       <translation>Mostrar o Tempo dos Frames</translation>
     </message>
     <message>
@@ -12018,7 +12018,7 @@ Swap chain: see Microsoft&apos;s Terminology Portal.</extracomment>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="790"/>
-      <source>Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out frame time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</source>
+      <source>Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out the frame-time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</source>
       <translation>Detecta quando frames ociosos estão sendo apresentados em jogos de 25/30fps, e pula a apresentação desses frames. O frame ainda é renderizado, apenas significa que a GPU tem mais tempo para completá-lo (isto NÃO é pular frames). Pode suavizar as flutuações do tempo de frame quando a CPU/GPU estão próximas da utilização máxima, mas torna a cadência dos frames mais inconsistente e pode aumentar o atraso de entrada.</translation>
     </message>
     <message>

--- a/pcsx2-qt/Translations/pcsx2-qt_pt-PT.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_pt-PT.ts
@@ -4390,7 +4390,7 @@ Enter function name</translation>
     </message>
     <message>
       <location filename="../Settings/EmulationSettingsWidget.cpp" line="136"/>
-      <source>Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame times, but add additional input lag.</source>
+      <source>Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame-times, but add additional input lag.</source>
       <translation>Define o número máximo de quadrados que podem ser agregados ao GS, antes do núcleo do processador esperar que um deles seja completado antes de continuar. Valores maiores podem ajudar a reduzir tempos irregulares dos quadrados, porém, noticiar-se-á um atraso de input(entrada) adicional.</translation>
     </message>
     <message>
@@ -4890,8 +4890,8 @@ O URL era: %1</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6935"/>
-      <source>Shows a visual history of frame times in the upper-left corner of the display.</source>
-      <translation type="unfinished">Shows a visual history of frame times in the upper-left corner of the display.</translation>
+      <source>Shows a visual history of frame-times in the upper-left corner of the display.</source>
+      <translation type="unfinished">Shows a visual history of frame-times in the upper-left corner of the display.</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6936"/>
@@ -5029,8 +5029,8 @@ Do you wish to shutdown anyways and IRREVERSIBLY DESTROY YOUR MEMORY CARD?</tran
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6956"/>
-      <source>Pins emulation threads to CPU cores to potentially improve performance/frame time variance.</source>
-      <translation type="unfinished">Pins emulation threads to CPU cores to potentially improve performance/frame time variance.</translation>
+      <source>Pins emulation threads to CPU cores to potentially improve performance/frame-time variance.</source>
+      <translation type="unfinished">Pins emulation threads to CPU cores to potentially improve performance/frame-time variance.</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6953"/>
@@ -8402,8 +8402,8 @@ Do you want to load this save and continue?</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="7581"/>
-      <source>Show Frame Times</source>
-      <translation type="unfinished">Show Frame Times</translation>
+      <source>Show Frame-Times</source>
+      <translation type="unfinished">Show Frame-Times</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="7582"/>
@@ -11344,8 +11344,8 @@ Percentage sign that will appear next to a number. Add a space or whatever is ne
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="1672"/>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="723"/>
-      <source>Show Frame Times</source>
-      <translation type="unfinished">Show Frame Times</translation>
+      <source>Show Frame-Times</source>
+      <translation type="unfinished">Show Frame-Times</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="1726"/>
@@ -12016,8 +12016,8 @@ Swap chain: see Microsoft&apos;s Terminology Portal.</extracomment>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="790"/>
-      <source>Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out frame time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</source>
-      <translation type="unfinished">Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out frame time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</translation>
+      <source>Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out the frame-time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</source>
+      <translation type="unfinished">Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out the frame-time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="1152"/>

--- a/pcsx2-qt/Translations/pcsx2-qt_pt-PT.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_pt-PT.ts
@@ -5134,7 +5134,7 @@ Do you wish to shutdown anyways and IRREVERSIBLY DESTROY YOUR MEMORY CARD?</tran
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6981"/>
-      <source>FMV Aspect Ratio</source>
+      <source>FMV Aspect Ratio Override</source>
       <translation>Proporção dos FMVs</translation>
     </message>
     <message>
@@ -10272,8 +10272,8 @@ Procurar recursivamente leva mais tempo, mas irá identificar arquivos em subpas
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="112"/>
-      <source>FMV Aspect Ratio:</source>
-      <translation type="unfinished">FMV Aspect Ratio:</translation>
+      <source>FMV Aspect Ratio Override:</source>
+      <translation type="unfinished">FMV Aspect Ratio Override:</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="120"/>
@@ -11708,8 +11708,8 @@ Swap chain: see Microsoft&apos;s Terminology Portal.</extracomment>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="444"/>
-      <source>FMV Aspect Ratio</source>
-      <translation type="unfinished">FMV Aspect Ratio</translation>
+      <source>FMV Aspect Ratio Override</source>
+      <translation type="unfinished">FMV Aspect Ratio Override</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="444"/>

--- a/pcsx2-qt/Translations/pcsx2-qt_ro-RO.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_ro-RO.ts
@@ -4395,8 +4395,8 @@ Enter function name</translation>
     </message>
     <message>
       <location filename="../Settings/EmulationSettingsWidget.cpp" line="136"/>
-      <source>Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame times, but add additional input lag.</source>
-      <translation type="unfinished">Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame times, but add additional input lag.</translation>
+      <source>Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame-times, but add additional input lag.</source>
+      <translation type="unfinished">Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame-times, but add additional input lag.</translation>
     </message>
     <message>
       <location filename="../Settings/EmulationSettingsWidget.cpp" line="139"/>
@@ -4895,8 +4895,8 @@ The URL was: %1</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6935"/>
-      <source>Shows a visual history of frame times in the upper-left corner of the display.</source>
-      <translation type="unfinished">Shows a visual history of frame times in the upper-left corner of the display.</translation>
+      <source>Shows a visual history of frame-times in the upper-left corner of the display.</source>
+      <translation type="unfinished">Shows a visual history of frame-times in the upper-left corner of the display.</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6936"/>
@@ -5034,8 +5034,8 @@ Do you wish to shutdown anyways and IRREVERSIBLY DESTROY YOUR MEMORY CARD?</tran
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6956"/>
-      <source>Pins emulation threads to CPU cores to potentially improve performance/frame time variance.</source>
-      <translation type="unfinished">Pins emulation threads to CPU cores to potentially improve performance/frame time variance.</translation>
+      <source>Pins emulation threads to CPU cores to potentially improve performance/frame-time variance.</source>
+      <translation type="unfinished">Pins emulation threads to CPU cores to potentially improve performance/frame-time variance.</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6953"/>
@@ -8407,8 +8407,8 @@ Do you want to load this save and continue?</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="7581"/>
-      <source>Show Frame Times</source>
-      <translation type="unfinished">Show Frame Times</translation>
+      <source>Show Frame-Times</source>
+      <translation type="unfinished">Show Frame-Times</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="7582"/>
@@ -11351,8 +11351,8 @@ Percentage sign that will appear next to a number. Add a space or whatever is ne
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="1672"/>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="723"/>
-      <source>Show Frame Times</source>
-      <translation type="unfinished">Show Frame Times</translation>
+      <source>Show Frame-Times</source>
+      <translation type="unfinished">Show Frame-Times</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="1726"/>
@@ -12023,8 +12023,8 @@ Swap chain: see Microsoft&apos;s Terminology Portal.</extracomment>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="790"/>
-      <source>Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out frame time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</source>
-      <translation type="unfinished">Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out frame time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</translation>
+      <source>Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out the frame-time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</source>
+      <translation type="unfinished">Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out the frame-time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="1152"/>

--- a/pcsx2-qt/Translations/pcsx2-qt_ro-RO.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_ro-RO.ts
@@ -5139,8 +5139,8 @@ Do you wish to shutdown anyways and IRREVERSIBLY DESTROY YOUR MEMORY CARD?</tran
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6981"/>
-      <source>FMV Aspect Ratio</source>
-      <translation type="unfinished">FMV Aspect Ratio</translation>
+      <source>FMV Aspect Ratio Override</source>
+      <translation type="unfinished">FMV Aspect Ratio Override</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6982"/>
@@ -10279,8 +10279,8 @@ Scanning recursively takes more time, but will identify files in subdirectories.
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="112"/>
-      <source>FMV Aspect Ratio:</source>
-      <translation type="unfinished">FMV Aspect Ratio:</translation>
+      <source>FMV Aspect Ratio Override:</source>
+      <translation type="unfinished">FMV Aspect Ratio Override:</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="120"/>
@@ -11715,8 +11715,8 @@ Swap chain: see Microsoft&apos;s Terminology Portal.</extracomment>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="444"/>
-      <source>FMV Aspect Ratio</source>
-      <translation type="unfinished">FMV Aspect Ratio</translation>
+      <source>FMV Aspect Ratio Override</source>
+      <translation type="unfinished">FMV Aspect Ratio Override</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="444"/>

--- a/pcsx2-qt/Translations/pcsx2-qt_ru-RU.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_ru-RU.ts
@@ -4402,7 +4402,7 @@ Enter function name</source>
     </message>
     <message>
       <location filename="../Settings/EmulationSettingsWidget.cpp" line="136"/>
-      <source>Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame times, but add additional input lag.</source>
+      <source>Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame-times, but add additional input lag.</source>
       <translation>Устанавливает максимальное количество кадров, которые могут быть поставлены в очередь GS, прежде чем поток ЦП дождется завершения кадра перед продолжением. Большое значение может помочь сгладить неравномерную длительность кадров, но увеличит задержку при вводе управления.</translation>
     </message>
     <message>
@@ -4902,7 +4902,7 @@ URL-адрес: %1</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6935"/>
-      <source>Shows a visual history of frame times in the upper-left corner of the display.</source>
+      <source>Shows a visual history of frame-times in the upper-left corner of the display.</source>
       <translation>Отображает визуальную историю времени кадров в левом верхнем углу экрана.</translation>
     </message>
     <message>
@@ -5041,7 +5041,7 @@ Do you wish to shutdown anyways and IRREVERSIBLY DESTROY YOUR MEMORY CARD?</sour
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6956"/>
-      <source>Pins emulation threads to CPU cores to potentially improve performance/frame time variance.</source>
+      <source>Pins emulation threads to CPU cores to potentially improve performance/frame-time variance.</source>
       <translation>Прикрепляет потоки эмуляции к ядрам ЦП, чтобы потенциально улучшить производительность и разброс времени кадра.</translation>
     </message>
     <message>
@@ -8414,7 +8414,7 @@ Do you want to load this save and continue?</source>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="7581"/>
-      <source>Show Frame Times</source>
+      <source>Show Frame-Times</source>
       <translation>Показывать время кадров</translation>
     </message>
     <message>
@@ -11356,7 +11356,7 @@ Percentage sign that will appear next to a number. Add a space or whatever is ne
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="1672"/>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="723"/>
-      <source>Show Frame Times</source>
+      <source>Show Frame-Times</source>
       <translation>Показывать время кадров</translation>
     </message>
     <message>
@@ -12028,8 +12028,8 @@ Swap chain: see Microsoft&apos;s Terminology Portal.</extracomment>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="790"/>
-      <source>Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out frame time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</source>
-      <translation type="unfinished">Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out frame time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</translation>
+      <source>Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out the frame-time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</source>
+      <translation type="unfinished">Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out the frame-time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="1152"/>

--- a/pcsx2-qt/Translations/pcsx2-qt_ru-RU.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_ru-RU.ts
@@ -5146,7 +5146,7 @@ Do you wish to shutdown anyways and IRREVERSIBLY DESTROY YOUR MEMORY CARD?</sour
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6981"/>
-      <source>FMV Aspect Ratio</source>
+      <source>FMV Aspect Ratio Override</source>
       <translation>Соотношение сторон FMV</translation>
     </message>
     <message>
@@ -10284,7 +10284,7 @@ Scanning recursively takes more time, but will identify files in subdirectories.
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="112"/>
-      <source>FMV Aspect Ratio:</source>
+      <source>FMV Aspect Ratio Override:</source>
       <translation>Соотношение сторон FMV:</translation>
     </message>
     <message>
@@ -11720,7 +11720,7 @@ Swap chain: see Microsoft&apos;s Terminology Portal.</extracomment>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="444"/>
-      <source>FMV Aspect Ratio</source>
+      <source>FMV Aspect Ratio Override</source>
       <translation>Соотношение сторон FMV</translation>
     </message>
     <message>

--- a/pcsx2-qt/Translations/pcsx2-qt_sr-SP.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_sr-SP.ts
@@ -5141,8 +5141,8 @@ Do you wish to shutdown anyways and IRREVERSIBLY DESTROY YOUR MEMORY CARD?</tran
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6981"/>
-      <source>FMV Aspect Ratio</source>
-      <translation type="unfinished">FMV Aspect Ratio</translation>
+      <source>FMV Aspect Ratio Override</source>
+      <translation type="unfinished">FMV Aspect Ratio Override</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6982"/>
@@ -10281,8 +10281,8 @@ Scanning recursively takes more time, but will identify files in subdirectories.
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="112"/>
-      <source>FMV Aspect Ratio:</source>
-      <translation type="unfinished">FMV Aspect Ratio:</translation>
+      <source>FMV Aspect Ratio Override:</source>
+      <translation type="unfinished">FMV Aspect Ratio Override:</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="120"/>
@@ -11717,8 +11717,8 @@ Swap chain: see Microsoft&apos;s Terminology Portal.</extracomment>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="444"/>
-      <source>FMV Aspect Ratio</source>
-      <translation type="unfinished">FMV Aspect Ratio</translation>
+      <source>FMV Aspect Ratio Override</source>
+      <translation type="unfinished">FMV Aspect Ratio Override</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="444"/>

--- a/pcsx2-qt/Translations/pcsx2-qt_sr-SP.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_sr-SP.ts
@@ -4397,8 +4397,8 @@ Enter function name</translation>
     </message>
     <message>
       <location filename="../Settings/EmulationSettingsWidget.cpp" line="136"/>
-      <source>Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame times, but add additional input lag.</source>
-      <translation type="unfinished">Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame times, but add additional input lag.</translation>
+      <source>Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame-times, but add additional input lag.</source>
+      <translation type="unfinished">Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame-times, but add additional input lag.</translation>
     </message>
     <message>
       <location filename="../Settings/EmulationSettingsWidget.cpp" line="139"/>
@@ -4897,8 +4897,8 @@ The URL was: %1</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6935"/>
-      <source>Shows a visual history of frame times in the upper-left corner of the display.</source>
-      <translation type="unfinished">Shows a visual history of frame times in the upper-left corner of the display.</translation>
+      <source>Shows a visual history of frame-times in the upper-left corner of the display.</source>
+      <translation type="unfinished">Shows a visual history of frame-times in the upper-left corner of the display.</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6936"/>
@@ -5036,8 +5036,8 @@ Do you wish to shutdown anyways and IRREVERSIBLY DESTROY YOUR MEMORY CARD?</tran
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6956"/>
-      <source>Pins emulation threads to CPU cores to potentially improve performance/frame time variance.</source>
-      <translation type="unfinished">Pins emulation threads to CPU cores to potentially improve performance/frame time variance.</translation>
+      <source>Pins emulation threads to CPU cores to potentially improve performance/frame-time variance.</source>
+      <translation type="unfinished">Pins emulation threads to CPU cores to potentially improve performance/frame-time variance.</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6953"/>
@@ -8409,8 +8409,8 @@ Do you want to load this save and continue?</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="7581"/>
-      <source>Show Frame Times</source>
-      <translation type="unfinished">Show Frame Times</translation>
+      <source>Show Frame-Times</source>
+      <translation type="unfinished">Show Frame-Times</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="7582"/>
@@ -11353,8 +11353,8 @@ Percentage sign that will appear next to a number. Add a space or whatever is ne
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="1672"/>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="723"/>
-      <source>Show Frame Times</source>
-      <translation type="unfinished">Show Frame Times</translation>
+      <source>Show Frame-Times</source>
+      <translation type="unfinished">Show Frame-Times</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="1726"/>
@@ -12025,8 +12025,8 @@ Swap chain: see Microsoft&apos;s Terminology Portal.</extracomment>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="790"/>
-      <source>Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out frame time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</source>
-      <translation type="unfinished">Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out frame time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</translation>
+      <source>Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out the frame-time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</source>
+      <translation type="unfinished">Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out the frame-time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="1152"/>

--- a/pcsx2-qt/Translations/pcsx2-qt_sv-SE.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_sv-SE.ts
@@ -4391,8 +4391,8 @@ Ange funktionsnamn</translation>
     </message>
     <message>
       <location filename="../Settings/EmulationSettingsWidget.cpp" line="136"/>
-      <source>Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame times, but add additional input lag.</source>
-      <translation type="unfinished">Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame times, but add additional input lag.</translation>
+      <source>Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame-times, but add additional input lag.</source>
+      <translation type="unfinished">Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame-times, but add additional input lag.</translation>
     </message>
     <message>
       <location filename="../Settings/EmulationSettingsWidget.cpp" line="139"/>
@@ -4891,8 +4891,8 @@ The URL was: %1</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6935"/>
-      <source>Shows a visual history of frame times in the upper-left corner of the display.</source>
-      <translation>Visar en visuell historik över frame times i det övre vänstra hörnet av displayen.</translation>
+      <source>Shows a visual history of frame-times in the upper-left corner of the display.</source>
+      <translation>Visar en visuell historik över frame-times i det övre vänstra hörnet av displayen.</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6936"/>
@@ -5030,8 +5030,8 @@ Vill du stänga av i alla fall och IRREVERSIBELT FÖRSTÖRA DITT MINNESKORT?</tr
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6956"/>
-      <source>Pins emulation threads to CPU cores to potentially improve performance/frame time variance.</source>
-      <translation type="unfinished">Pins emulation threads to CPU cores to potentially improve performance/frame time variance.</translation>
+      <source>Pins emulation threads to CPU cores to potentially improve performance/frame-time variance.</source>
+      <translation type="unfinished">Pins emulation threads to CPU cores to potentially improve performance/frame-time variance.</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6953"/>
@@ -8403,8 +8403,8 @@ Do you want to load this save and continue?</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="7581"/>
-      <source>Show Frame Times</source>
-      <translation type="unfinished">Show Frame Times</translation>
+      <source>Show Frame-Times</source>
+      <translation type="unfinished">Show Frame-Times</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="7582"/>
@@ -11345,8 +11345,8 @@ Percentage sign that will appear next to a number. Add a space or whatever is ne
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="1672"/>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="723"/>
-      <source>Show Frame Times</source>
-      <translation type="unfinished">Show Frame Times</translation>
+      <source>Show Frame-Times</source>
+      <translation type="unfinished">Show Frame-Times</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="1726"/>
@@ -12017,8 +12017,8 @@ Swap chain: see Microsoft&apos;s Terminology Portal.</extracomment>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="790"/>
-      <source>Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out frame time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</source>
-      <translation type="unfinished">Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out frame time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</translation>
+      <source>Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out the frame-time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</source>
+      <translation type="unfinished">Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out the frame-time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="1152"/>

--- a/pcsx2-qt/Translations/pcsx2-qt_sv-SE.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_sv-SE.ts
@@ -5135,7 +5135,7 @@ Vill du stänga av i alla fall och IRREVERSIBELT FÖRSTÖRA DITT MINNESKORT?</tr
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6981"/>
-      <source>FMV Aspect Ratio</source>
+      <source>FMV Aspect Ratio Override</source>
       <translation>FMV Bildförhållande</translation>
     </message>
     <message>
@@ -10273,8 +10273,8 @@ Scanning recursively takes more time, but will identify files in subdirectories.
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="112"/>
-      <source>FMV Aspect Ratio:</source>
-      <translation type="unfinished">FMV Aspect Ratio:</translation>
+      <source>FMV Aspect Ratio Override:</source>
+      <translation type="unfinished">FMV Aspect Ratio Override:</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="120"/>
@@ -11709,8 +11709,8 @@ Swap chain: see Microsoft&apos;s Terminology Portal.</extracomment>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="444"/>
-      <source>FMV Aspect Ratio</source>
-      <translation type="unfinished">FMV Aspect Ratio</translation>
+      <source>FMV Aspect Ratio Override</source>
+      <translation type="unfinished">FMV Aspect Ratio Override</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="444"/>

--- a/pcsx2-qt/Translations/pcsx2-qt_tr-TR.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_tr-TR.ts
@@ -5138,7 +5138,7 @@ Yinede kapatıp GERİ DÖNÜLEMEYECEK BİR ŞEKİLDE HAFIZA KARDINIZI YOK ETMEK 
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6981"/>
-      <source>FMV Aspect Ratio</source>
+      <source>FMV Aspect Ratio Override</source>
       <translation>Ara Sahne En/Boy Oranı</translation>
     </message>
     <message>
@@ -10276,7 +10276,7 @@ Yinelemeli tarama daha fazla zaman alır, ancak alt dizinlerdeki dosyaları bula
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="112"/>
-      <source>FMV Aspect Ratio:</source>
+      <source>FMV Aspect Ratio Override:</source>
       <translation>FMV En-Boy Oranı:</translation>
     </message>
     <message>
@@ -11712,7 +11712,7 @@ Swap chain: see Microsoft&apos;s Terminology Portal.</extracomment>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="444"/>
-      <source>FMV Aspect Ratio</source>
+      <source>FMV Aspect Ratio Override</source>
       <translation>FMV En-Boy Oranı</translation>
     </message>
     <message>

--- a/pcsx2-qt/Translations/pcsx2-qt_tr-TR.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_tr-TR.ts
@@ -4392,7 +4392,7 @@ Fonskiyon adını girin</translation>
     </message>
     <message>
       <location filename="../Settings/EmulationSettingsWidget.cpp" line="136"/>
-      <source>Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame times, but add additional input lag.</source>
+      <source>Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame-times, but add additional input lag.</source>
       <translation>CPU iş parçacığı devam etmeden evvel karelerden birinin tamamlanmasını beklemeden önce, GSye dizilebilecek maksimum kare sayısını ayarlar. Daha yüksek değerler, düzensiz kare sürelerini yumuşatmaya yardımcı olabilir, ancak ek giriş gecikmesine sebep olur.</translation>
     </message>
     <message>
@@ -4894,7 +4894,7 @@ FullscreenUI
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6935"/>
-      <source>Shows a visual history of frame times in the upper-left corner of the display.</source>
+      <source>Shows a visual history of frame-times in the upper-left corner of the display.</source>
       <translation>Ekranın sol üst köşesinde kare sürelerinin görsel geçmişini gösterir.</translation>
     </message>
     <message>
@@ -5033,7 +5033,7 @@ Yinede kapatıp GERİ DÖNÜLEMEYECEK BİR ŞEKİLDE HAFIZA KARDINIZI YOK ETMEK 
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6956"/>
-      <source>Pins emulation threads to CPU cores to potentially improve performance/frame time variance.</source>
+      <source>Pins emulation threads to CPU cores to potentially improve performance/frame-time variance.</source>
       <translation>Performansı/çerçeve süresi farklılığını potansiyel olarak iyileştirmek için emülasyon thread'lerini CPU çekirdeklerine sabitler.</translation>
     </message>
     <message>
@@ -8406,8 +8406,8 @@ Do you want to load this save and continue?</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="7581"/>
-      <source>Show Frame Times</source>
-      <translation type="unfinished">Show Frame Times</translation>
+      <source>Show Frame-Times</source>
+      <translation type="unfinished">Show Frame-Times</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="7582"/>
@@ -11348,7 +11348,7 @@ Percentage sign that will appear next to a number. Add a space or whatever is ne
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="1672"/>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="723"/>
-      <source>Show Frame Times</source>
+      <source>Show Frame-Times</source>
       <translation>Kare Süresi</translation>
     </message>
     <message>
@@ -12020,8 +12020,8 @@ Swap chain: see Microsoft&apos;s Terminology Portal.</extracomment>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="790"/>
-      <source>Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out frame time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</source>
-      <translation type="unfinished">Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out frame time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</translation>
+      <source>Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out the frame-time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</source>
+      <translation type="unfinished">Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out the frame-time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="1152"/>

--- a/pcsx2-qt/Translations/pcsx2-qt_uk-UA.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_uk-UA.ts
@@ -5146,7 +5146,7 @@ Do you wish to shutdown anyways and IRREVERSIBLY DESTROY YOUR MEMORY CARD?</tran
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6981"/>
-      <source>FMV Aspect Ratio</source>
+      <source>FMV Aspect Ratio Override</source>
       <translation>Співвідношення сторін FMV</translation>
     </message>
     <message>
@@ -10288,7 +10288,7 @@ Scanning recursively takes more time, but will identify files in subdirectories.
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="112"/>
-      <source>FMV Aspect Ratio:</source>
+      <source>FMV Aspect Ratio Override:</source>
       <translation>Співвідношення сторін FMV:</translation>
     </message>
     <message>
@@ -11724,7 +11724,7 @@ Swap chain: see Microsoft&apos;s Terminology Portal.</extracomment>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="444"/>
-      <source>FMV Aspect Ratio</source>
+      <source>FMV Aspect Ratio Override</source>
       <translation>Співвідношення сторін FMV</translation>
     </message>
     <message>

--- a/pcsx2-qt/Translations/pcsx2-qt_uk-UA.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_uk-UA.ts
@@ -4402,7 +4402,7 @@ Enter function name</source>
     </message>
     <message>
       <location filename="../Settings/EmulationSettingsWidget.cpp" line="136"/>
-      <source>Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame times, but add additional input lag.</source>
+      <source>Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame-times, but add additional input lag.</source>
       <translation>Встановлює максимальну кількість кадрів які будуть ставати у чергу до GS, перед тим як потік процесора буде чекати, поки один із них не завершиться. Вищі значення можуть допомогти зі згладжуванням нерівномірних тривалостей кадрів, але додає додаткову затримку введення.</translation>
     </message>
     <message>
@@ -4902,7 +4902,7 @@ The URL was: %1</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6935"/>
-      <source>Shows a visual history of frame times in the upper-left corner of the display.</source>
+      <source>Shows a visual history of frame-times in the upper-left corner of the display.</source>
       <translation>Показує візуальну історію тривалості кадрів у верхньому лівому куті екрану.</translation>
     </message>
     <message>
@@ -5041,7 +5041,7 @@ Do you wish to shutdown anyways and IRREVERSIBLY DESTROY YOUR MEMORY CARD?</tran
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6956"/>
-      <source>Pins emulation threads to CPU cores to potentially improve performance/frame time variance.</source>
+      <source>Pins emulation threads to CPU cores to potentially improve performance/frame-time variance.</source>
       <translation>Призначає потоки емуляції до ядер ЦП, що може сприяти продуктивності/дисперсії тривалості кадрів.</translation>
     </message>
     <message>
@@ -8414,7 +8414,7 @@ Do you want to load this save and continue?</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="7581"/>
-      <source>Show Frame Times</source>
+      <source>Show Frame-Times</source>
       <translation>Показувати тривалість кадрів</translation>
     </message>
     <message>
@@ -11360,7 +11360,7 @@ Percentage sign that will appear next to a number. Add a space or whatever is ne
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="1672"/>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="723"/>
-      <source>Show Frame Times</source>
+      <source>Show Frame-Times</source>
       <translation>Показувати тривалість кадрів</translation>
     </message>
     <message>
@@ -12032,8 +12032,8 @@ Swap chain: see Microsoft&apos;s Terminology Portal.</extracomment>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="790"/>
-      <source>Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out frame time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</source>
-      <translation type="unfinished">Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out frame time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</translation>
+      <source>Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out the frame-time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</source>
+      <translation type="unfinished">Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out the frame-time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="1152"/>

--- a/pcsx2-qt/Translations/pcsx2-qt_vi-VN.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_vi-VN.ts
@@ -5134,8 +5134,8 @@ Do you wish to shutdown anyways and IRREVERSIBLY DESTROY YOUR MEMORY CARD?</tran
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6981"/>
-      <source>FMV Aspect Ratio</source>
-      <translation type="unfinished">FMV Aspect Ratio</translation>
+      <source>FMV Aspect Ratio Override</source>
+      <translation type="unfinished">FMV Aspect Ratio Override</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6982"/>
@@ -10270,8 +10270,8 @@ Scanning recursively takes more time, but will identify files in subdirectories.
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="112"/>
-      <source>FMV Aspect Ratio:</source>
-      <translation type="unfinished">FMV Aspect Ratio:</translation>
+      <source>FMV Aspect Ratio Override:</source>
+      <translation type="unfinished">FMV Aspect Ratio Override:</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="120"/>
@@ -11706,8 +11706,8 @@ Swap chain: see Microsoft&apos;s Terminology Portal.</extracomment>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="444"/>
-      <source>FMV Aspect Ratio</source>
-      <translation type="unfinished">FMV Aspect Ratio</translation>
+      <source>FMV Aspect Ratio Override</source>
+      <translation type="unfinished">FMV Aspect Ratio Override</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="444"/>

--- a/pcsx2-qt/Translations/pcsx2-qt_vi-VN.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_vi-VN.ts
@@ -4390,8 +4390,8 @@ Enter function name</translation>
     </message>
     <message>
       <location filename="../Settings/EmulationSettingsWidget.cpp" line="136"/>
-      <source>Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame times, but add additional input lag.</source>
-      <translation type="unfinished">Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame times, but add additional input lag.</translation>
+      <source>Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame-times, but add additional input lag.</source>
+      <translation type="unfinished">Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame-times, but add additional input lag.</translation>
     </message>
     <message>
       <location filename="../Settings/EmulationSettingsWidget.cpp" line="139"/>
@@ -4890,8 +4890,8 @@ The URL was: %1</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6935"/>
-      <source>Shows a visual history of frame times in the upper-left corner of the display.</source>
-      <translation type="unfinished">Shows a visual history of frame times in the upper-left corner of the display.</translation>
+      <source>Shows a visual history of frame-times in the upper-left corner of the display.</source>
+      <translation type="unfinished">Shows a visual history of frame-times in the upper-left corner of the display.</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6936"/>
@@ -5029,8 +5029,8 @@ Do you wish to shutdown anyways and IRREVERSIBLY DESTROY YOUR MEMORY CARD?</tran
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6956"/>
-      <source>Pins emulation threads to CPU cores to potentially improve performance/frame time variance.</source>
-      <translation type="unfinished">Pins emulation threads to CPU cores to potentially improve performance/frame time variance.</translation>
+      <source>Pins emulation threads to CPU cores to potentially improve performance/frame-time variance.</source>
+      <translation type="unfinished">Pins emulation threads to CPU cores to potentially improve performance/frame-time variance.</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6953"/>
@@ -8402,8 +8402,8 @@ Do you want to load this save and continue?</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="7581"/>
-      <source>Show Frame Times</source>
-      <translation type="unfinished">Show Frame Times</translation>
+      <source>Show Frame-Times</source>
+      <translation type="unfinished">Show Frame-Times</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="7582"/>
@@ -11342,8 +11342,8 @@ Percentage sign that will appear next to a number. Add a space or whatever is ne
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="1672"/>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="723"/>
-      <source>Show Frame Times</source>
-      <translation type="unfinished">Show Frame Times</translation>
+      <source>Show Frame-Times</source>
+      <translation type="unfinished">Show Frame-Times</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="1726"/>
@@ -12014,8 +12014,8 @@ Swap chain: see Microsoft&apos;s Terminology Portal.</extracomment>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="790"/>
-      <source>Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out frame time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</source>
-      <translation type="unfinished">Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out frame time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</translation>
+      <source>Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out the frame-time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</source>
+      <translation type="unfinished">Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out the frame-time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="1152"/>

--- a/pcsx2-qt/Translations/pcsx2-qt_zh-CN.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_zh-CN.ts
@@ -4386,7 +4386,7 @@ Enter function name</source>
     </message>
     <message>
       <location filename="../Settings/EmulationSettingsWidget.cpp" line="136"/>
-      <source>Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame times, but add additional input lag.</source>
+      <source>Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame-times, but add additional input lag.</source>
       <translation>设置可以排队到 GS 的最大帧数量,在此之前 CPU 线程将等待其中一个帧完成然后再继续。较高的值有助于平滑不规则的帧时间,但会增加额外的输入延迟。</translation>
     </message>
     <message>
@@ -4886,7 +4886,7 @@ URL: %1</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6935"/>
-      <source>Shows a visual history of frame times in the upper-left corner of the display.</source>
+      <source>Shows a visual history of frame-times in the upper-left corner of the display.</source>
       <translation>在显示器的左上角显示帧时间的可视历史记录。</translation>
     </message>
     <message>
@@ -5025,7 +5025,7 @@ Do you wish to shutdown anyways and IRREVERSIBLY DESTROY YOUR MEMORY CARD?</sour
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6956"/>
-      <source>Pins emulation threads to CPU cores to potentially improve performance/frame time variance.</source>
+      <source>Pins emulation threads to CPU cores to potentially improve performance/frame-time variance.</source>
       <translation>将模拟线程固定到 CPU 核心以潜在地改善性能/帧时间差异。</translation>
     </message>
     <message>
@@ -8398,7 +8398,7 @@ Do you want to load this save and continue?</source>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="7581"/>
-      <source>Show Frame Times</source>
+      <source>Show Frame-Times</source>
       <translation>显示帧时间</translation>
     </message>
     <message>
@@ -11338,7 +11338,7 @@ Percentage sign that will appear next to a number. Add a space or whatever is ne
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="1672"/>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="723"/>
-      <source>Show Frame Times</source>
+      <source>Show Frame-Times</source>
       <translation>显示帧时间</translation>
     </message>
     <message>
@@ -12010,7 +12010,7 @@ Swap chain: see Microsoft&apos;s Terminology Portal.</extracomment>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="790"/>
-      <source>Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out frame time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</source>
+      <source>Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out the frame-time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</source>
       <translation>检测 25/30fps 游戏中何时呈现空闲帧,并跳过呈现这些帧。帧仍然被渲染,这只是意味着图形处理器有更多时间来完成它(这不是跳帧)。当 CPU/GPU 接近最大利用率时可以平滑帧时间波动，但会使帧节奏更加不一致并且可能会增加输入延迟。</translation>
     </message>
     <message>

--- a/pcsx2-qt/Translations/pcsx2-qt_zh-CN.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_zh-CN.ts
@@ -5130,7 +5130,7 @@ Do you wish to shutdown anyways and IRREVERSIBLY DESTROY YOUR MEMORY CARD?</sour
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6981"/>
-      <source>FMV Aspect Ratio</source>
+      <source>FMV Aspect Ratio Override</source>
       <translation>FMV 高宽比</translation>
     </message>
     <message>
@@ -10266,7 +10266,7 @@ Scanning recursively takes more time, but will identify files in subdirectories.
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="112"/>
-      <source>FMV Aspect Ratio:</source>
+      <source>FMV Aspect Ratio Override:</source>
       <translation>FMV 高宽比:</translation>
     </message>
     <message>
@@ -11702,7 +11702,7 @@ Swap chain: see Microsoft&apos;s Terminology Portal.</extracomment>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="444"/>
-      <source>FMV Aspect Ratio</source>
+      <source>FMV Aspect Ratio Override</source>
       <translation>FMV 高宽比</translation>
     </message>
     <message>

--- a/pcsx2-qt/Translations/pcsx2-qt_zh-TW.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_zh-TW.ts
@@ -4387,7 +4387,7 @@ Enter function name</source>
     </message>
     <message>
       <location filename="../Settings/EmulationSettingsWidget.cpp" line="136"/>
-      <source>Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame times, but add additional input lag.</source>
+      <source>Sets the maximum number of frames that can be queued up to the GS, before the CPU thread will wait for one of them to complete before continuing. Higher values can assist with smoothing out irregular frame-times, but add additional input lag.</source>
       <translation>設定可以排隊到 GS 的最大幀數量,在此之前 CPU 執行緒將等待其中一個幀完成然後再繼續。較高的值有助於平滑不規則的幀時間,但會增加額外的輸入延遲。</translation>
     </message>
     <message>
@@ -4887,7 +4887,7 @@ The URL was: %1</translation>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6935"/>
-      <source>Shows a visual history of frame times in the upper-left corner of the display.</source>
+      <source>Shows a visual history of frame-times in the upper-left corner of the display.</source>
       <translation>在顯示器的左上角顯示幀時間的可視歷史記錄。</translation>
     </message>
     <message>
@@ -5026,7 +5026,7 @@ Do you wish to shutdown anyways and IRREVERSIBLY DESTROY YOUR MEMORY CARD?</tran
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6956"/>
-      <source>Pins emulation threads to CPU cores to potentially improve performance/frame time variance.</source>
+      <source>Pins emulation threads to CPU cores to potentially improve performance/frame-time variance.</source>
       <translation>將模擬執行緒固定到 CPU 核心以潛在地改善效能/幀時間差異。</translation>
     </message>
     <message>
@@ -8399,7 +8399,7 @@ Do you want to load this save and continue?</source>
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="7581"/>
-      <source>Show Frame Times</source>
+      <source>Show Frame-Times</source>
       <translation>顯示幀時間</translation>
     </message>
     <message>
@@ -11339,7 +11339,7 @@ Percentage sign that will appear next to a number. Add a space or whatever is ne
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="1672"/>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="723"/>
-      <source>Show Frame Times</source>
+      <source>Show Frame-Times</source>
       <translation>顯示幀時間</translation>
     </message>
     <message>
@@ -12011,8 +12011,8 @@ Swap chain: see Microsoft&apos;s Terminology Portal.</extracomment>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="790"/>
-      <source>Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out frame time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</source>
-      <translation type="unfinished">Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out frame time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</translation>
+      <source>Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out the frame-time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</source>
+      <translation type="unfinished">Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out the frame-time fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase input lag.</translation>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="1152"/>

--- a/pcsx2-qt/Translations/pcsx2-qt_zh-TW.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_zh-TW.ts
@@ -5131,7 +5131,7 @@ Do you wish to shutdown anyways and IRREVERSIBLY DESTROY YOUR MEMORY CARD?</tran
     </message>
     <message>
       <location filename="../../pcsx2/ImGui/FullscreenUI.cpp" line="6981"/>
-      <source>FMV Aspect Ratio</source>
+      <source>FMV Aspect Ratio Override</source>
       <translation>FMV 高寬比</translation>
     </message>
     <message>
@@ -10267,7 +10267,7 @@ Scanning recursively takes more time, but will identify files in subdirectories.
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.ui" line="112"/>
-      <source>FMV Aspect Ratio:</source>
+      <source>FMV Aspect Ratio Override:</source>
       <translation>FMV 高寬比:</translation>
     </message>
     <message>
@@ -11703,7 +11703,7 @@ Swap chain: see Microsoft&apos;s Terminology Portal.</extracomment>
     </message>
     <message>
       <location filename="../Settings/GraphicsSettingsWidget.cpp" line="444"/>
-      <source>FMV Aspect Ratio</source>
+      <source>FMV Aspect Ratio Override</source>
       <translation>FMV 高寬比</translation>
     </message>
     <message>

--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -3607,7 +3607,7 @@ void FullscreenUI::DrawGraphicsSettingsPage(SettingsInterface* bsi, bool show_ad
 	DrawStringListSetting(bsi, FSUI_CSTR("Aspect Ratio"), FSUI_CSTR("Selects the aspect ratio to display the game content at."),
 		"EmuCore/GS", "AspectRatio", "Auto 4:3/3:2", Pcsx2Config::GSOptions::AspectRatioNames, Pcsx2Config::GSOptions::AspectRatioNames, 0,
 		false);
-	DrawStringListSetting(bsi, FSUI_CSTR("FMV Aspect Ratio"),
+	DrawStringListSetting(bsi, FSUI_CSTR("FMV Aspect Ratio Override"),
 		FSUI_CSTR("Selects the aspect ratio for display when a FMV is detected as playing."), "EmuCore/GS", "FMVAspectRatioSwitch",
 		"Auto 4:3/3:2", Pcsx2Config::GSOptions::FMVAspectRatioSwitchNames, Pcsx2Config::GSOptions::FMVAspectRatioSwitchNames, 0, false);
 	DrawIntListSetting(bsi, FSUI_CSTR("Deinterlacing"),
@@ -6978,7 +6978,7 @@ TRANSLATE_NOOP("FullscreenUI", "Selects the API used to render the emulated GS."
 TRANSLATE_NOOP("FullscreenUI", "Display");
 TRANSLATE_NOOP("FullscreenUI", "Aspect Ratio");
 TRANSLATE_NOOP("FullscreenUI", "Selects the aspect ratio to display the game content at.");
-TRANSLATE_NOOP("FullscreenUI", "FMV Aspect Ratio");
+TRANSLATE_NOOP("FullscreenUI", "FMV Aspect Ratio Override");
 TRANSLATE_NOOP("FullscreenUI", "Selects the aspect ratio for display when a FMV is detected as playing.");
 TRANSLATE_NOOP("FullscreenUI", "Deinterlacing");
 TRANSLATE_NOOP("FullscreenUI", "Selects the algorithm used to convert the PS2's interlaced output to progressive for display.");


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
~~This will add the Virtual in front of the controller name, in future we should change the struct so if you change to other type like Guitar, Pop n Music, or in future new pad devices to not say controllers.~~

Also added that FMV Aspect Ratio will inherent the value of the regular Aspect Ratio if you put the same value for Aspect Ratio and FMV Aspect ratio it would have the same effect if you left FMV Aspect Ratio on the 'Off (Default)'. Extra word with Override along side FMV Aspect Ratio as it will copy/match the general value and less rely on tooltip

Examples:

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
~~Less confusing for players that the controller you see on PCSX2 controller port section is the one you emulate as, aka tricking the game you are using a DualShock 2 controller where it can actually be Keyboard to 8bitdo, Sony (DS3, DS4, DS5) , Xbox (360, One) and more ...~~

More correct and easier for people to know what FMV Aspect ratio does, also fix the typo for frametimes as it looks better.
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test tooltip