### PR TITLE
DEV9: ICMP Cleanup

### DIFF
--- a/pcsx2/DEV9/PacketReader/IP/IP_Payload.h
+++ b/pcsx2/DEV9/PacketReader/IP/IP_Payload.h
@@ -96,10 +96,10 @@ namespace PacketReader::IP
 		{
 			//If buffer & data point to the same location
 			//Then no copy is needed
-			if (data == buffer)
+			if (data == &buffer[*offset])
 				return;
 
-			memcpy(buffer, data, length);
+			memcpy(&buffer[*offset], data, length);
 			*offset += length;
 		}
 		virtual IP_Payload* Clone() const

--- a/pcsx2/DEV9/Sessions/ICMP_Session/ICMP_Session.cpp
+++ b/pcsx2/DEV9/Sessions/ICMP_Session/ICMP_Session.cpp
@@ -189,8 +189,16 @@ namespace Sessions
 		{
 			ResetEvent(icmpEvent);
 
-			[[maybe_unused]] int count = IcmpParseReplies(icmpResponseBuffer.get(), icmpResponseBufferLen);
-			pxAssert(count == 1);
+			int count = IcmpParseReplies(icmpResponseBuffer.get(), icmpResponseBufferLen);
+			pxAssert(count <= 1);
+
+			// Timeout
+			if (count == 0)
+			{
+				result.type = -2;
+				result.code = 0;
+				return &result;
+			}
 
 			// Rely on implicit object creation
 			ICMP_ECHO_REPLY* pingRet = reinterpret_cast<ICMP_ECHO_REPLY*>(icmpResponseBuffer.get());

--- a/pcsx2/DEV9/Sessions/ICMP_Session/ICMP_Session.cpp
+++ b/pcsx2/DEV9/Sessions/ICMP_Session/ICMP_Session.cpp
@@ -47,7 +47,7 @@ using namespace std::chrono_literals;
 		However we may be missing that cap on some builds
 	Linux has socket(PF_INET, SOCK_DGRAM, IPPROTO_ICMP), used similar to raw sockets but for ICMP only
 		Auto filters responses
-		Requires net.ipv4.ping_group_range sysctl, default off on alot of distros
+		Requires net.ipv4.ping_group_range sysctl, default off on a lot of distros
 	Timeouts reported via sock_extended_err control messages (with IP_RECVERR socket option set)
 
 	Mac
@@ -104,7 +104,7 @@ namespace Sessions
 	{
 		switch (icmpConnectionKind)
 		{
-			//Two different methods for raw/icmp sockets bettween the unix OSes
+			//Two different methods for raw/icmp sockets between the unix OSes
 			//Play it safe and only enable when we know which of the two methods we use
 #if defined(ICMP_SOCKETS_LINUX) || defined(ICMP_SOCKETS_BSD)
 			case (PingType::ICMP):
@@ -135,7 +135,7 @@ namespace Sessions
 					//We get packet + header
 					icmpResponseBufferLen = 20 + 8 + requestSize;
 #elif defined(ICMP_SOCKETS_BSD)
-					//As above, but we will also directly recive error ICMP messages
+					//As above, but we will also directly receive error ICMP messages
 					icmpResponseBufferLen = 20 + 8 + std::max(20 + 8, requestSize);
 #endif
 					break;
@@ -217,7 +217,7 @@ namespace Sessions
 					//Destination network unknown
 					//or
 					//Destination host unknown
-					//Use host unkown
+					//Use host unknown
 					result.type = 3;
 					result.code = 7;
 					break;
@@ -295,7 +295,7 @@ namespace Sessions
 
 					socklen_t len = sizeof(error);
 					if (getsockopt(icmpSocket, SOL_SOCKET, SO_ERROR, (char*)&error, &len) < 0)
-						Console.Error("DEV9: ICMP: Unkown ICMP Connection Error (getsockopt Error: %d)", errno);
+						Console.Error("DEV9: ICMP: Unknown ICMP Connection Error (getsockopt Error: %d)", errno);
 					else
 						Console.Error("DEV9: ICMP: Recv Error: %d", error);
 				}
@@ -324,7 +324,7 @@ namespace Sessions
 #if defined(ICMP_SOCKETS_LINUX)
 				//Needs to hold cmsghdr + sock_extended_err + sockaddr_in
 				//for ICMP error responses (total 44 bytes)
-				//Unkown for other types of error
+				//Unknown for other types of error
 				u8 cbuff[64];
 #endif
 
@@ -515,7 +515,7 @@ namespace Sessions
 				(DWORD)std::chrono::duration_cast<std::chrono::milliseconds>(ICMP_TIMEOUT).count());
 
 		//Documentation states that IcmpSendEcho2 returns ERROR_IO_PENDING
-		//However, it actully returns zero, with the error set to ERROR_IO_PENDING
+		//However, it actually returns zero, with the error set to ERROR_IO_PENDING
 		if (ret == 0)
 			ret = GetLastError();
 
@@ -563,7 +563,7 @@ namespace Sessions
 				}
 #endif
 
-				// TTL (Note multicast & regular ttl are seperate)
+				// TTL (Note multicast & regular ttl are separate)
 				if (setsockopt(icmpSocket, IPPROTO_IP, IP_TTL, (const char*)&parTimeToLive, sizeof(parTimeToLive)) == -1)
 				{
 					Console.Error("DEV9: ICMP: Failed to set TTL. Error: %d", errno);
@@ -756,7 +756,7 @@ namespace Sessions
 				{
 					case 3:
 					{
-						Console.Error("DEV9: ICMP: Recived Packet Rejected, Port Closed");
+						Console.Error("DEV9: ICMP: Received Packet Rejected, Port Closed");
 
 						//RE:Outbreak Hackfix
 						//TODO, check if still needed

--- a/pcsx2/DEV9/Sessions/ICMP_Session/ICMP_Session.cpp
+++ b/pcsx2/DEV9/Sessions/ICMP_Session/ICMP_Session.cpp
@@ -166,7 +166,7 @@ namespace Sessions
 #endif
 	}
 
-	bool ICMP_Session::Ping::IsInitialised()
+	bool ICMP_Session::Ping::IsInitialised() const
 	{
 #ifdef _WIN32
 		return icmpFile != INVALID_HANDLE_VALUE;
@@ -190,7 +190,7 @@ namespace Sessions
 		{
 			ResetEvent(icmpEvent);
 
-			int count = IcmpParseReplies(icmpResponseBuffer.get(), icmpResponseBufferLen);
+			const int count = IcmpParseReplies(icmpResponseBuffer.get(), icmpResponseBufferLen);
 			pxAssert(count <= 1);
 
 			// Timeout
@@ -202,7 +202,7 @@ namespace Sessions
 			}
 
 			// Rely on implicit object creation
-			ICMP_ECHO_REPLY* pingRet = reinterpret_cast<ICMP_ECHO_REPLY*>(icmpResponseBuffer.get());
+			const ICMP_ECHO_REPLY* pingRet = reinterpret_cast<ICMP_ECHO_REPLY*>(icmpResponseBuffer.get());
 
 			// Map status to ICMP type/code
 			switch (pingRet->Status)
@@ -419,8 +419,8 @@ namespace Sessions
 #endif
 					{
 						// Rely on implicit object creation
-						ip* ipHeader = reinterpret_cast<ip*>(icmpResponseBuffer.get());
-						int headerLength = ipHeader->ip_hl << 2;
+						const ip* ipHeader = reinterpret_cast<ip*>(icmpResponseBuffer.get());
+						const int headerLength = ipHeader->ip_hl << 2;
 						pxAssert(headerLength == 20);
 
 						offset = headerLength;
@@ -448,7 +448,7 @@ namespace Sessions
 						// Check if response is for us
 						if (icmpConnectionKind == PingType::RAW)
 						{
-							ICMP_HeaderDataIdentifier headerData(icmp.headerData);
+							const ICMP_HeaderDataIdentifier headerData(icmp.headerData);
 							if (headerData.identifier != icmpId)
 								return nullptr;
 						}
@@ -473,7 +473,7 @@ namespace Sessions
 						ICMP_Packet icmpInner(ipPayload->data, ipPayload->GetLength());
 
 						// Check if response is for us
-						ICMP_HeaderDataIdentifier headerData(icmpInner.headerData);
+						const ICMP_HeaderDataIdentifier headerData(icmpInner.headerData);
 						if (headerData.identifier != icmpId)
 							return nullptr;
 
@@ -553,7 +553,7 @@ namespace Sessions
 				}
 
 #if defined(ICMP_SOCKETS_LINUX)
-				int value = 1;
+				const int value = 1;
 				if (setsockopt(icmpSocket, SOL_IP, IP_RECVERR, reinterpret_cast<const char*>(&value), sizeof(value)))
 				{
 					Console.Error("DEV9: ICMP: Failed to setsockopt IP_RECVERR. Error: %d", errno);
@@ -685,8 +685,7 @@ namespace Sessions
 
 		for (size_t i = 0; i < pings.size(); i++)
 		{
-			ICMP_Session::PingResult* pingRet = nullptr;
-			pingRet = pings[i]->Recv();
+			const ICMP_Session::PingResult* pingRet = pings[i]->Recv();
 			if (pingRet != nullptr)
 			{
 				std::unique_ptr<Ping> ping = std::move(pings[i]);
@@ -710,7 +709,7 @@ namespace Sessions
 						// Allocate fullsize buffer
 						std::vector<u8> temp = std::vector<u8>(ping->originalPacket->GetLength());
 						// Allocate returned ICMP payload
-						int responseSize = ping->originalPacket->GetHeaderLength() + 8;
+						const int responseSize = ping->originalPacket->GetHeaderLength() + 8;
 						data = new PayloadData(responseSize);
 
 						// Write packet into buffer
@@ -793,8 +792,8 @@ namespace Sessions
 							retPkt = std::make_unique<IP_Packet>(&icmpPayload->data[off], icmpPayload->GetLength(), true);
 						}
 
-						IP_Address srvIP = retPkt->sourceIP;
-						u8 prot = retPkt->protocol;
+						const IP_Address srvIP = retPkt->sourceIP;
+						const u8 prot = retPkt->protocol;
 						u16 srvPort = 0;
 						u16 ps2Port = 0;
 						switch (prot)

--- a/pcsx2/DEV9/Sessions/ICMP_Session/ICMP_Session.cpp
+++ b/pcsx2/DEV9/Sessions/ICMP_Session/ICMP_Session.cpp
@@ -299,7 +299,7 @@ namespace Sessions
 				if (ret == -1)
 				{
 					hasData = false;
-					Console.WriteLn("DEV9: ICMP: select failed. Error Code: %d", errno);
+					Console.WriteLn("DEV9: ICMP: select failed. Error: %d", errno);
 				}
 				else if (FD_ISSET(icmpSocket, &sExcept))
 				{
@@ -309,9 +309,9 @@ namespace Sessions
 
 					socklen_t len = sizeof(error);
 					if (getsockopt(icmpSocket, SOL_SOCKET, SO_ERROR, reinterpret_cast<char*>(&error), &len) < 0)
-						Console.Error("DEV9: ICMP: Unknown ICMP Connection Error (getsockopt Error: %d)", errno);
+						Console.Error("DEV9: ICMP: Unknown ICMP connection error (getsockopt error: %d)", errno);
 					else
-						Console.Error("DEV9: ICMP: Recv Error: %d", error);
+						Console.Error("DEV9: ICMP: Recv error: %d", error);
 				}
 				else
 					hasData = FD_ISSET(icmpSocket, &sReady);
@@ -440,7 +440,7 @@ namespace Sessions
 					}
 					else
 					{
-						Console.Error("DEV9: ICMP: Recv Error %d", exError.ee_errno);
+						Console.Error("DEV9: ICMP: Recv error %d", exError.ee_errno);
 						result.type = -1;
 						result.code = exError.ee_errno;
 						return &result;
@@ -560,7 +560,7 @@ namespace Sessions
 
 		if (ret != ERROR_IO_PENDING)
 		{
-			Console.Error("DEV9: ICMP: Failed to Send Echo, %d", GetLastError());
+			Console.Error("DEV9: ICMP: Failed to send echo, %d", GetLastError());
 			return false;
 		}
 
@@ -655,7 +655,7 @@ namespace Sessions
 				const int ret = sendto(icmpSocket, buffer.get(), icmp.GetLength(), 0, reinterpret_cast<const sockaddr*>(&endpoint), sizeof(endpoint));
 				if (ret == -1)
 				{
-					Console.Error("DEV9: ICMP: Send Error %d", errno);
+					Console.Error("DEV9: ICMP: Send error %d", errno);
 					::close(icmpSocket);
 					icmpSocket = -1;
 					return false;
@@ -758,11 +758,11 @@ namespace Sessions
 				// Free ping
 				delete ping;
 
-				if (--open == 0)
-					RaiseEventConnectionClosed();
-
 				if (ret.has_value())
 					DevCon.WriteLn("DEV9: ICMP: Return Ping");
+
+				if (--open == 0)
+					RaiseEventConnectionClosed();
 
 				// Return packet
 				return ret;

--- a/pcsx2/DEV9/Sessions/ICMP_Session/ICMP_Session.cpp
+++ b/pcsx2/DEV9/Sessions/ICMP_Session/ICMP_Session.cpp
@@ -704,20 +704,17 @@ namespace Sessions
 					{
 						// Copy the original packet into the returned ICMP packet
 						// Allocate fullsize buffer
-						u8* temp = new u8[ping->originalPacket->GetLength()];
+						std::vector<u8> temp = std::vector<u8>(ping->originalPacket->GetLength());
 						// Allocate returned ICMP payload
 						int responseSize = ping->originalPacket->GetHeaderLength() + 8;
 						data = new PayloadData(responseSize);
 
 						// Write packet into buffer
 						int offset = 0;
-						ping->originalPacket->WriteBytes(temp, &offset);
+						ping->originalPacket->WriteBytes(temp.data(), &offset);
 
 						// Copy only needed bytes
-						memcpy(data->data.get(), temp, responseSize);
-
-						// Cleanup
-						delete[] temp;
+						memcpy(data->data.get(), temp.data(), responseSize);
 					}
 
 					std::unique_ptr<ICMP_Packet> pRet = std::make_unique<ICMP_Packet>(data);

--- a/pcsx2/DEV9/Sessions/ICMP_Session/ICMP_Session.h
+++ b/pcsx2/DEV9/Sessions/ICMP_Session/ICMP_Session.h
@@ -57,7 +57,7 @@ namespace Sessions
 			//Return buffers
 			PingResult result{};
 			int icmpResponseBufferLen{0};
-			std::unique_ptr<u8[]> icmpResponseBuffer;
+			std::unique_ptr<std::byte[]> icmpResponseBuffer;
 
 		public:
 			Ping(int requestSize);

--- a/pcsx2/DEV9/Sessions/ICMP_Session/ICMP_Session.h
+++ b/pcsx2/DEV9/Sessions/ICMP_Session/ICMP_Session.h
@@ -47,14 +47,14 @@ namespace Sessions
 
 			static PingType icmpConnectionKind;
 
-			//Sockets
+			// Sockets
 			int icmpSocket{-1};
 			std::chrono::steady_clock::time_point icmpDeathClockStart;
 			u16 icmpId;
 
 #endif
 
-			//Return buffers
+			// Return buffers
 			PingResult result{};
 			int icmpResponseBufferLen{0};
 			std::unique_ptr<std::byte[]> icmpResponseBuffer;

--- a/pcsx2/DEV9/Sessions/ICMP_Session/ICMP_Session.h
+++ b/pcsx2/DEV9/Sessions/ICMP_Session/ICMP_Session.h
@@ -68,9 +68,8 @@ namespace Sessions
 			~Ping();
 		};
 
-		SimpleQueue<PacketReader::IP::ICMP::ICMP_Packet*> _recvBuff;
 		std::mutex ping_mutex;
-		std::vector<Ping*> pings;
+		std::vector<std::unique_ptr<Ping>> pings;
 		ThreadSafeMap<Sessions::ConnectionKey, Sessions::BaseSession*>* connections;
 
 		std::atomic<int> open{0};

--- a/pcsx2/DEV9/Sessions/ICMP_Session/ICMP_Session.h
+++ b/pcsx2/DEV9/Sessions/ICMP_Session/ICMP_Session.h
@@ -61,7 +61,7 @@ namespace Sessions
 
 		public:
 			Ping(int requestSize);
-			bool IsInitialised();
+			bool IsInitialised() const;
 			PingResult* Recv();
 			bool Send(PacketReader::IP::IP_Address parAdapterIP, PacketReader::IP::IP_Address parDestIP, int parTimeToLive, PacketReader::PayloadPtr* parPayload);
 


### PR DESCRIPTION
### Description of Changes

Replace C-Style casts with C++ equivalents.
Make capitalisation of text in log messages consistent.
Format comments to (hopefully) be more inline with PCSX2's comment style
Use non-blocking sockets, unifying code between Linux and Mac/FreeBSD
Various bug fixes and cleanup
Add consts

It may be easier to review each commit one by one rather than the whole pr at once

### Rationale behind Changes
Improve code quality
Fix bugs

### Suggested Testing Steps
Test networked games/apps that performs pings using the sockets backend.
