### PR TITLE
Debugger: Fix Open Debugger option to not toggle

### DIFF
--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -2572,7 +2572,7 @@ DebuggerWindow* MainWindow::getDebuggerWindow()
 void MainWindow::openDebugger()
 {
 	DebuggerWindow* dwnd = getDebuggerWindow();
-	dwnd->isVisible() ? dwnd->hide() : dwnd->show();
+	dwnd->isVisible() ? dwnd->activateWindow() : dwnd->show();
 }
 
 void MainWindow::doControllerSettings(ControllerSettingsWindow::Category category)


### PR DESCRIPTION
### Description of Changes
Previously, selecting 'Open Debugger' while the debugger window was open would close the debugger as though it were toggling it.

### Rationale behind Changes
If a user accidentally reclicks 'Open Debugger', they probably don't want the window closed.

### Suggested Testing Steps
Select Open Debugger both while the window is opened and closed.
