### PR TITLE
InputManager: Release settings lock before shutting down the input source

### DIFF
--- a/pcsx2/Input/InputManager.cpp
+++ b/pcsx2/Input/InputManager.cpp
@@ -1605,7 +1605,10 @@ void InputManager::UpdateInputSourceState(SettingsInterface& si, std::unique_loc
 	{
 		if (s_input_sources[static_cast<u32>(type)])
 		{
+			settings_lock.unlock();
 			s_input_sources[static_cast<u32>(type)]->Shutdown();
+			settings_lock.lock();
+
 			s_input_sources[static_cast<u32>(type)].reset();
 		}
 	}


### PR DESCRIPTION
### Description of Changes
Fixes a crash when disabling the input source while emulation was running. 

### Rationale behind Changes
Crash bad.

### Suggested Testing Steps
1. Run any game.
2. Enable any input source (SDL, DInput, XInput).
3. Disable that input source.
4. PCSX2 should not crash.

Fixes #11377