### PR TITLE
[RFC] Common: Use cpuinfo to detect cache line size on FreeBSD

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -171,6 +171,9 @@ else()
 		X11::X11
 		X11::Xrandr
 	)
+	if(${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD")
+		target_link_libraries(common PRIVATE cpuinfo)
+	endif()
 endif()
 
 set_source_files_properties(PrecompiledHeader.cpp PROPERTIES HEADER_FILE_ONLY TRUE)


### PR DESCRIPTION
### Description of Changes
Use cpuinfo to detect cache line size on FreeBSD

I elected to keep the existing logic for other platforms as if, as I can't test Mac or Arm.
If desired, I could swap all platforms to use cpuinfo for this

### Rationale behind Changes
Fix FreeBSD builds (With the workarounds mentioned here https://github.com/PCSX2/pcsx2/pull/11287)
This is only a build fix, the code doesn't actually get used on x86, and I don't think cpuinfo supports FreeBSD on Arm (but neither do we)

### Suggested Testing Steps
Test CI works,
