### PR TITLE
GameDB: Ensure NativeScaling doesn't nag users at native res

### DIFF
--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -779,7 +779,7 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* dialog, QWidget* 
 
 		dialog->registerWidgetHelp(m_ui.skipPresentingDuplicateFrames, tr("Skip Presenting Duplicate Frames"), tr("Unchecked"),
 			tr("Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still "
-			   "rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth our frame time "
+			   "rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out frame time "
 			   "fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase "
 			   "input lag."));
 

--- a/pcsx2/GameDatabase.cpp
+++ b/pcsx2/GameDatabase.cpp
@@ -640,7 +640,7 @@ bool GameDatabaseSchema::GameEntry::configMatchesHWFix(const Pcsx2Config::GSOpti
 			return (config.UpscaleMultiplier <= 1.0f || config.UserHacks_RoundSprite == value);
 
 		case GSHWFixId::NativeScaling:
-			return (static_cast<int>(config.UserHacks_NativeScaling) == value);
+			return (config.UpscaleMultiplier <= 1.0f || static_cast<int>(config.UserHacks_NativeScaling) == value);
 
 		case GSHWFixId::TexturePreloading:
 			return (static_cast<int>(config.TexturePreloading) <= value);


### PR DESCRIPTION
### Description of Changes
Made it so that the native scaling ImGui nag for manual HW fixes does not nag users at native or lower resolution.

### Rationale behind Changes
Currently no matter what if you are at native or lower resolution and have manual HW fixes enabled, native scaling will nag you in the ImGui messages (even if you have the corresponding native scaling enabled). Much like HPO and RS, it should not nag you whatsoever until you upscale.

### Suggested Testing Steps
Try messing around with a game that has native scaling recommended in the DB.

### Addendum
Additionally corrects unambiguous typo in a graphics settings description.