### PR TITLE
Fix BIOS dump link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Installers and binaries for both stable and nightly builds are available from [o
 
 PCSX2 supports Windows, Linux, and Mac platforms. Our [setup documentation page](https://pcsx2.net/docs/setup/requirements) contains additional details on software and hardware requirements.
 
-Please note that a BIOS dump from a legitimately-owned PS2 console is required to use the emulator. For more information, visit [this page](https://pcsx2.net/docs/setup/gather/#how-to-dump-your-ps2-bios).
+Please note that a BIOS dump from a legitimately-owned PS2 console is required to use the emulator. For more information, visit [this page](https://pcsx2.net/docs/setup/bios/).
 
 ## Contributing / Building
 


### PR DESCRIPTION
### Description of Changes
Replaced the broken link to BIOS dumping instructions to the one currently used in Setup Wizard.

### Rationale behind Changes
The link was broken, verly likely outdated.

### Suggested Testing Steps
Follow the link? Hope it works now!
