### PR TITLE
CI: Move appdata generation into flatpak manifest

### DIFF
--- a/.github/workflows/linux_build_flatpak.yml
+++ b/.github/workflows/linux_build_flatpak.yml
@@ -94,12 +94,6 @@ jobs:
           cd bin/resources
           wget "${{ inputs.patchesUrl }}/patches.zip"
 
-      - name: Generate AppStream XML
-        run: |
-          ./.github/workflows/scripts/linux/generate-metainfo.sh .github/workflows/scripts/linux/flatpak/net.pcsx2.PCSX2.metainfo.xml
-          cat .github/workflows/scripts/linux/flatpak/net.pcsx2.PCSX2.metainfo.xml
-      #    flatpak-builder-lint appstream .github/workflows/scripts/linux/flatpak/net.pcsx2.PCSX2.metainfo.xml
-
       - name: Validate manifest
         run: |
           flatpak-builder-lint manifest .github/workflows/scripts/linux/flatpak/net.pcsx2.PCSX2.json

--- a/.github/workflows/scripts/linux/flatpak/net.pcsx2.PCSX2.json
+++ b/.github/workflows/scripts/linux/flatpak/net.pcsx2.PCSX2.json
@@ -9,7 +9,7 @@
   "add-extensions": {
     "org.freedesktop.Platform.ffmpeg-full": {
       "directory": "lib/ffmpeg",
-      "version": "22.08",
+      "version": "23.08",
       "add-ld-path": ".",
       "autodownload": true
     }
@@ -51,7 +51,7 @@
           "-DCMAKE_SHARED_LINKER_FLAGS_INIT=-fuse-ld=lld",
           "-DUSE_LINKED_FFMPEG=ON",
           "-DDISABLE_ADVANCE_SIMD=TRUE"
-	]
+        ]
       },
       "sources": [
         {
@@ -63,8 +63,10 @@
         "cp -a bin \"${FLATPAK_DEST}\"",
         "install -Dm644 \"${FLATPAK_BUILDER_BUILDDIR}/bin/resources/icons/AppIconLarge.png\" \"${FLATPAK_DEST}/share/icons/hicolor/512x512/apps/net.pcsx2.PCSX2.png\"",
         "install -Dm644 \"${FLATPAK_BUILDER_BUILDDIR}/.github/workflows/scripts/linux/pcsx2-qt.desktop\" \"${FLATPAK_DEST}/share/applications/net.pcsx2.PCSX2.desktop\"",
-	"desktop-file-edit --set-key=Icon --set-value=net.pcsx2.PCSX2 \"${FLATPAK_DEST}/share/applications/net.pcsx2.PCSX2.desktop\"",
-	"install -Dm644 \"${FLATPAK_BUILDER_BUILDDIR}/.github/workflows/scripts/linux/flatpak/net.pcsx2.PCSX2.metainfo.xml\" \"${FLATPAK_DEST}/share/metainfo/net.pcsx2.PCSX2.metainfo.xml\"",
+        "desktop-file-edit --set-key=Icon --set-value=net.pcsx2.PCSX2 \"${FLATPAK_DEST}/share/applications/net.pcsx2.PCSX2.desktop\"",
+        "${FLATPAK_BUILDER_BUILDDIR}/.github/workflows/scripts/linux/generate-metainfo.sh \"${FLATPAK_BUILDER_BUILDDIR}/net.pcsx2.PCSX2.metainfo.xml\"",
+        "cat \"${FLATPAK_BUILDER_BUILDDIR}/net.pcsx2.PCSX2.metainfo.xml\"",
+        "install -Dm644 \"${FLATPAK_BUILDER_BUILDDIR}/net.pcsx2.PCSX2.metainfo.xml\" \"${FLATPAK_DEST}/share/metainfo/net.pcsx2.PCSX2.metainfo.xml\"",
         "mkdir -p \"${FLATPAK_DEST}/lib/ffmpeg\""
       ]
     }


### PR DESCRIPTION
### Description of Changes
Currently building the flatpak fails as the metainfo file is missing.  This change moves generation of the metainfo file from the github gi workflow into the flatpak manifest.

The MR also updates the ffmpeg extension to match the freedesktop platform the package uses `23.08`. You can check this with:
```bash
flatpak run --command=grep org.kde.Platform//6.7 runtime-version /usr/manifest.json
```

### Rationale behind Changes
It makes it easier to compile the flatpak locally.

### Suggested Testing Steps
```bash
flatpak run org.flatpak.Builder --user --jobs=20 --force-clean --install ./_build ./.github/workflows/scripts/linux/flatpak/net.pcsx2.PCSX2.json
```


Out of interest is there a list of wayland related issues? Now that this project no longer uses wxWidgets I'm interested in tackling the ones that aren't just NVIDIA driver bugs.