### PR TITLE
linux/cmake: Allow libbacktrace to be disabled

### DIFF
--- a/cmake/BuildParameters.cmake
+++ b/cmake/BuildParameters.cmake
@@ -23,6 +23,7 @@ if(UNIX AND NOT APPLE)
 	option(ENABLE_SETCAP "Enable networking capability for DEV9" OFF)
 	option(X11_API "Enable X11 support" ON)
 	option(WAYLAND_API "Enable Wayland support" ON)
+	option(USE_BACKTRACE "Enable libbacktrace support" ON)
 endif()
 
 if(UNIX)

--- a/cmake/SearchForStuff.cmake
+++ b/cmake/SearchForStuff.cmake
@@ -65,7 +65,10 @@ else()
 			find_package(Wayland REQUIRED Egl)
 		endif()
 
-		find_package(Libbacktrace REQUIRED)
+		if(USE_BACKTRACE)
+			find_package(Libbacktrace REQUIRED)
+		endif()
+
 		find_package(PkgConfig REQUIRED)
 		pkg_check_modules(DBUS REQUIRED dbus-1)
 	endif()

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -167,10 +167,13 @@ else()
 	)
 	target_link_libraries(common PRIVATE
 		${DBUS_LINK_LIBRARIES}
-		libbacktrace::libbacktrace
 		X11::X11
 		X11::Xrandr
 	)
+	if(USE_BACKTRACE)
+		target_compile_definitions(common PRIVATE "HAS_LIBBACKTRACE=1")
+		target_link_libraries(common PRIVATE libbacktrace::libbacktrace)
+	endif()
 	if(${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD")
 		target_link_libraries(common PRIVATE cpuinfo)
 	endif()

--- a/common/CrashHandler.cpp
+++ b/common/CrashHandler.cpp
@@ -176,7 +176,7 @@ void CrashHandler::WriteDumpForCaller()
 	WriteMinidumpAndCallstack(nullptr);
 }
 
-#elif !defined(__APPLE__)
+#elif !defined(__APPLE__) && defined(HAS_LIBBACKTRACE)
 
 #include "FileSystem.h"
 


### PR DESCRIPTION
RFC? Should this be implemented?

### Description of Changes
Adds the USE_BACKTRACE CMake build option to optionally disable libbacktrace

### Rationale behind Changes
fixes #11566 

### Suggested Testing Steps
Try to build with -DUSE_BACKTRACE=1 (default) and -DUSE_BACKTRACE=0

Please know that support will not be given for builds with libbacktrace disabled.

I'd also like to remind Linux users: **First class Linux support is provided for the AppImage and Flatpack only. If it is not reproducible on either builds, we will consider the issue invalid.** 