### PR TITLE
Covers: Use serial for cover image names when selected individually

### DIFF
--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -2664,7 +2664,7 @@ void MainWindow::setGameListEntryCoverImage(const GameList::Entry* entry)
 		return;
 
 	const QString old_filename = QString::fromStdString(GameList::GetCoverImagePathForEntry(entry));
-	const QString new_filename = QString::fromStdString(GameList::GetNewCoverImagePathForEntry(entry, filename.toUtf8().constData()));
+	const QString new_filename = QString::fromStdString(GameList::GetNewCoverImagePathForEntry(entry, filename.toUtf8().constData(), true));
 	if (new_filename.isEmpty())
 		return;
 


### PR DESCRIPTION
### Description of Changes
Previously, right-clicking games on the list and choosing a game cover individually created an image in pcsx2 > covers whose filename was that of the name we use in the DB. It now uses the game's serial instead.

### Rationale behind Changes
Resolves #10126. Game names are often highly volatile, as Jordan and I change them in the DB all the time. Using the game serial makes it so that it is near impossible for a GameDB update to break a user's config in this manner. Moreover, if two games had different covers but the same names (e.g. from different regions), you would simply have to select one and share them or change the name of one manually.

### Suggested Testing Steps
Try right-clicking a game in the game list, then selecting a cover image. Check pcsx2 > covers and see if the game has a serial instead of its full name.