### PR TITLE
Bios: Fix Rom2 size limit

### DIFF
--- a/pcsx2/IopMem.cpp
+++ b/pcsx2/IopMem.cpp
@@ -39,18 +39,18 @@ void iopMemRelease()
 // which is performed by MemInit and PsxMemInit()
 void iopMemReset()
 {
-	pxAssert( iopMem );
+	pxAssert(iopMem);
 
 	DbgCon.WriteLn("IOP resetting main memory...");
 
-	memset(psxMemWLUT, 0, 0x2000 * sizeof(uptr) * 2);	// clears both allocations, RLUT and WLUT
+	memset(psxMemWLUT, 0, 0x2000 * sizeof(uptr) * 2); // clears both allocations, RLUT and WLUT
 
 	// Trick!  We're accessing RLUT here through WLUT, since it's the non-const pointer.
 	// So the ones with a 0x2000 prefixed are RLUT tables.
 
 	// Map IOP main memory, which is Read/Write, and mirrored three times
 	// at 0x0, 0x8000, and 0xa000:
-	for (int i=0; i<0x0080; i++)
+	for (int i = 0; i < 0x0080; i++)
 	{
 		psxMemWLUT[i + 0x0000] = (uptr)&iopMem->Main[(i & 0x1f) << 16];
 
@@ -78,7 +78,7 @@ void iopMemReset()
 		psxMemWLUT[i + 0x2000 + 0x1e00] = (uptr)&eeMem->ROM1[i << 16];
 	}
 
-	for (int i = 0; i < 0x0008; i++)
+	for (int i = 0; i < 0x0040; i++)
 	{
 		psxMemWLUT[i + 0x2000 + 0x1e40] = (uptr)&eeMem->ROM2[i << 16];
 	}
@@ -318,7 +318,7 @@ void iopMemWrite16(u32 mem, u16 value)
 
 			default:
 				psxHu16(mem) = value;
-			break;
+				break;
 		}
 	} else
 	{
@@ -443,7 +443,7 @@ void iopMemWrite32(u32 mem, u32 value)
 
 					case 0x60:
 						psHu32(SBUS_F260) = 0;
-					return;
+						return;
 
 				}
 #if PSX_EXTRALOGS
@@ -529,11 +529,11 @@ bool iopMemSafeWriteBytes(u32 mem, const void* src, u32 size)
 
 std::string iopMemReadString(u32 mem, int maxlen)
 {
-    std::string ret;
-    char c;
+	std::string ret;
+	char c;
 
-    while ((c = iopMemRead8(mem++)) && maxlen--)
-        ret.push_back(c);
+	while ((c = iopMemRead8(mem++)) && maxlen--)
+		ret.push_back(c);
 
-    return ret;
+	return ret;
 }

--- a/pcsx2/MemoryTypes.h
+++ b/pcsx2/MemoryTypes.h
@@ -11,7 +11,7 @@ namespace Ps2MemSize
 	static constexpr u32 TotalRam = _1mb * 128;// 128 MB total memory.
 	static constexpr u32 Rom = _1mb * 4;       // 4 MB main rom
 	static constexpr u32 Rom1 = _1mb * 4;      // DVD player
-	static constexpr u32 Rom2 = 0x00080000;    // Chinese rom extension
+	static constexpr u32 Rom2 = _1mb * 4;      // Chinese rom extension
 	static constexpr u32 Hardware = _64kb;
 	static constexpr u32 Scratch = _16kb;
 

--- a/pcsx2/x86/ix86-32/iR5900.cpp
+++ b/pcsx2/x86/ix86-32/iR5900.cpp
@@ -548,7 +548,7 @@ static void recReserveRAM()
 		recLUT_SetPage(recLUT, hwLUT, recROM1, 0xa000, i, i - 0x1e00);
 	}
 
-	for (int i = 0x1e40; i < 0x1e48; i++)
+	for (int i = 0x1e40; i < 0x1e80; i++)
 	{
 		recLUT_SetPage(recLUT, hwLUT, recROM2, 0x0000, i, i - 0x1e40);
 		recLUT_SetPage(recLUT, hwLUT, recROM2, 0x8000, i, i - 0x1e40);
@@ -691,7 +691,7 @@ static void recExecute()
 	if (!fastjmp_set(&m_SetJmp_StateCheck))
 	{
 		eeCpuExecuting = true;
-		((void(*)())EnterRecompiledCode)();
+		((void (*)())EnterRecompiledCode)();
 
 		// Generally unreachable code here ...
 	}
@@ -1544,7 +1544,7 @@ void dynarecMemcheck(size_t i)
 
 	auto mc = CBreakPoints::GetMemChecks(BREAKPOINT_EE)[i];
 
-	if(mc.hasCond)
+	if (mc.hasCond)
 	{
 		if (!mc.cond.Evaluate())
 			return;
@@ -1557,7 +1557,7 @@ void dynarecMemcheck(size_t i)
 		else
 			DevCon.WriteLn("Hit load breakpoint @0x%x", cpuRegs.pc);
 	}
-	
+
 	CBreakPoints::SetBreakpointTriggered(true, BREAKPOINT_EE);
 	VMManager::SetPaused(true);
 	recExitExecution();


### PR DESCRIPTION
### Description of Changes
The SCPH-50009 model features a 64-Mbit DVD-ROM chip, with the first 4MB allocated to Rom1 and the last 4MB to Rom2. This entire chip is mapped to the EE/IOP memory at address 0x1E000000. This PR addresses the issue of hardcoded size limits for Rom2, previously set to 512KB.

### Rationale behind Changes
This PR resolves the improper loading of `rom2:GB18030` into memory, which was previously being loaded in a cropped state.

### Suggested Testing Steps
Please refer to the game list provided in [this comment](https://github.com/PCSX2/pcsx2/pull/3439#issuecomment-2231805578). Potentially affected games include:

- Ape Escape 2 - 捉猴啦 2 (SCCS 40001
- Viorate no Atelier: Gramnad no Renkinjutsushi 2 - 薇欧蕾特的工房 ～古拉姆那特的炼金术士2～ (SCCS 40015)
- EyeToy: Play - 爱淘儿 (SCCS 40017)
- EyeToy: Saru EyeToy: Oosawagi! Ukkiuki Game Tenkomori!! - 比波猴@爱淘儿 (SCCS 40018)