### PR TITLE
qt/MainWindow: for disable hide window if render to main is enabled

### DIFF
--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -1053,7 +1053,7 @@ bool MainWindow::shouldHideMouseCursor() const
 bool MainWindow::shouldHideMainWindow() const
 {
 	// NOTE: We can't use isRenderingToMain() here, because this happens post-fullscreen-switch.
-	return Host::GetBoolSettingValue("UI", "HideMainWindowWhenRunning", false) ||
+	return (Host::GetBoolSettingValue("UI", "HideMainWindowWhenRunning", false) && !g_emu_thread->shouldRenderToMain()) ||
 		   (g_emu_thread->shouldRenderToMain() && (isRenderingFullscreen() || m_is_temporarily_windowed)) ||
 		   QtHost::InNoGUIMode();
 }


### PR DESCRIPTION

### Description of Changes
This fixes a crash on wayland (and possibly others)

### Suggested Testing Steps
On Wayland, check hide main window, make sure render to main is set, boot a game then try to boot another.


@kamfretoz to test