### PR TITLE
input-rec: Directly use recorded values for pressure sensitive buttons

### DIFF
--- a/pcsx2/Recording/PadData.cpp
+++ b/pcsx2/Recording/PadData.cpp
@@ -97,24 +97,24 @@ void PadData::OverrideActualController() const
 	PadBase* pad = Pad::GetPad(m_ext_port);
 	pad->SetRawAnalogs(m_leftAnalog, m_rightAnalog);
 
-	pad->Set(PadDualshock2::Inputs::PAD_RIGHT, std::get<1>(m_right));
-	pad->Set(PadDualshock2::Inputs::PAD_LEFT, std::get<1>(m_left));
-	pad->Set(PadDualshock2::Inputs::PAD_UP, std::get<1>(m_up));
-	pad->Set(PadDualshock2::Inputs::PAD_DOWN, std::get<1>(m_down));
+	pad->SetRawPressureButton(PadDualshock2::Inputs::PAD_RIGHT, m_right);
+	pad->SetRawPressureButton(PadDualshock2::Inputs::PAD_LEFT, m_left);
+	pad->SetRawPressureButton(PadDualshock2::Inputs::PAD_UP, m_up);
+	pad->SetRawPressureButton(PadDualshock2::Inputs::PAD_DOWN, m_down);
 	pad->Set(PadDualshock2::Inputs::PAD_START, m_start);
 	pad->Set(PadDualshock2::Inputs::PAD_SELECT, m_select);
 	pad->Set(PadDualshock2::Inputs::PAD_R3, m_r3);
 	pad->Set(PadDualshock2::Inputs::PAD_L3, m_l3);
 
-	pad->Set(PadDualshock2::Inputs::PAD_SQUARE, std::get<1>(m_square));
-	pad->Set(PadDualshock2::Inputs::PAD_CROSS, std::get<1>(m_cross));
-	pad->Set(PadDualshock2::Inputs::PAD_CIRCLE, std::get<1>(m_circle));
-	pad->Set(PadDualshock2::Inputs::PAD_TRIANGLE, std::get<1>(m_triangle));
+	pad->SetRawPressureButton(PadDualshock2::Inputs::PAD_SQUARE, m_square);
+	pad->SetRawPressureButton(PadDualshock2::Inputs::PAD_CROSS, m_cross);
+	pad->SetRawPressureButton(PadDualshock2::Inputs::PAD_CIRCLE, m_circle);
+	pad->SetRawPressureButton(PadDualshock2::Inputs::PAD_TRIANGLE, m_triangle);
 
-	pad->Set(PadDualshock2::Inputs::PAD_R1, std::get<1>(m_r1));
-	pad->Set(PadDualshock2::Inputs::PAD_L1, std::get<1>(m_l1));
-	pad->Set(PadDualshock2::Inputs::PAD_R2, std::get<1>(m_r2));
-	pad->Set(PadDualshock2::Inputs::PAD_L2, std::get<1>(m_l2));
+	pad->SetRawPressureButton(PadDualshock2::Inputs::PAD_R1, m_r1);
+	pad->SetRawPressureButton(PadDualshock2::Inputs::PAD_L1, m_l1);
+	pad->SetRawPressureButton(PadDualshock2::Inputs::PAD_R2, m_r2);
+	pad->SetRawPressureButton(PadDualshock2::Inputs::PAD_L2, m_l2);
 }
 
 void addButtonInfoToString(std::string label, std::string& str, std::tuple<bool, u8> buttonInfo)

--- a/pcsx2/SIO/Pad/PadBase.h
+++ b/pcsx2/SIO/Pad/PadBase.h
@@ -39,6 +39,7 @@ public: // Public members
 
 	virtual void Set(u32 index, float value) = 0;
 	virtual void SetRawAnalogs(const std::tuple<u8, u8> left, const std::tuple<u8, u8> right) = 0;
+	virtual void SetRawPressureButton(u32 index, const std::tuple<bool, u8> value) = 0;
 	virtual void SetAxisScale(float deadzone, float scale) = 0;
 	virtual float GetVibrationScale(u32 motor) const = 0;
 	virtual void SetVibrationScale(u32 motor, float scale) = 0;

--- a/pcsx2/SIO/Pad/PadDualshock2.cpp
+++ b/pcsx2/SIO/Pad/PadDualshock2.cpp
@@ -560,29 +560,6 @@ void PadDualshock2::Set(u32 index, float value)
 		return;
 	}
 
-	// Since we reordered the buttons for better UI, we need to remap them here.
-	static constexpr std::array<u8, Inputs::LENGTH> bitmaskMapping = {{
-		12, // PAD_UP
-		13, // PAD_RIGHT
-		14, // PAD_DOWN
-		15, // PAD_LEFT
-		4, // PAD_TRIANGLE
-		5, // PAD_CIRCLE
-		6, // PAD_CROSS
-		7, // PAD_SQUARE
-		8, // PAD_SELECT
-		11, // PAD_START
-		2, // PAD_L1
-		0, // PAD_L2
-		3, // PAD_R1
-		1, // PAD_R2
-		9, // PAD_L3
-		10, // PAD_R3
-		16, // PAD_ANALOG
-		17, // PAD_PRESSURE
-		// remainder are analogs and not used here
-	}};
-
 	if (IsAnalogKey(index))
 	{
 		this->rawInputs[index] = static_cast<u8>(std::clamp(value * this->axisScale * 255.0f, 0.0f, 255.0f));
@@ -740,6 +717,20 @@ void PadDualshock2::SetRawAnalogs(const std::tuple<u8, u8> left, const std::tupl
 	this->analogs.ly = std::get<1>(left);
 	this->analogs.rx = std::get<0>(right);
 	this->analogs.ry = std::get<1>(right);
+}
+
+void PadDualshock2::SetRawPressureButton(u32 index, const std::tuple<bool, u8> value)
+{
+	this->rawInputs[index] = std::get<1>(value);
+
+	if (std::get<0>(value))
+	{
+		this->buttons &= ~(1u << bitmaskMapping[index]);
+	}
+	else
+	{
+		this->buttons |= (1u << bitmaskMapping[index]);
+	}
 }
 
 void PadDualshock2::SetAxisScale(float deadzone, float scale)

--- a/pcsx2/SIO/Pad/PadDualshock2.h
+++ b/pcsx2/SIO/Pad/PadDualshock2.h
@@ -85,6 +85,29 @@ private:
 	// Used to store the last vibration mapping request the PS2 made for the large motor.
 	u8 largeMotorLastConfig = 0xff;
 
+	// Since we reordered the buttons for better UI, we need to remap them here.
+	static constexpr std::array<u8, Inputs::LENGTH> bitmaskMapping = {{
+		12, // PAD_UP
+		13, // PAD_RIGHT
+		14, // PAD_DOWN
+		15, // PAD_LEFT
+		4, // PAD_TRIANGLE
+		5, // PAD_CIRCLE
+		6, // PAD_CROSS
+		7, // PAD_SQUARE
+		8, // PAD_SELECT
+		11, // PAD_START
+		2, // PAD_L1
+		0, // PAD_L2
+		3, // PAD_R1
+		1, // PAD_R2
+		9, // PAD_L3
+		10, // PAD_R3
+		16, // PAD_ANALOG
+		17, // PAD_PRESSURE
+		// remainder are analogs and not used here
+	}};
+
 	void ConfigLog();
 
 	u8 Mystery(u8 commandByte);
@@ -117,6 +140,7 @@ public:
 	const Pad::ControllerInfo& GetInfo() const override;
 	void Set(u32 index, float value) override;
 	void SetRawAnalogs(const std::tuple<u8, u8> left, const std::tuple<u8, u8> right) override;
+	void SetRawPressureButton(u32 index, const std::tuple<bool, u8> value) override;
 	void SetAxisScale(float deadzone, float scale) override;
 	float GetVibrationScale(u32 motor) const override;
 	void SetVibrationScale(u32 motor, float scale) override;

--- a/pcsx2/SIO/Pad/PadGuitar.cpp
+++ b/pcsx2/SIO/Pad/PadGuitar.cpp
@@ -318,6 +318,20 @@ void PadGuitar::SetRawAnalogs(const std::tuple<u8, u8> left, const std::tuple<u8
 {
 }
 
+void PadGuitar::SetRawPressureButton(u32 index, const std::tuple<bool, u8> value)
+{
+	this->rawInputs[index] = std::get<1>(value);
+
+	if (std::get<0>(value))
+	{
+		this->buttons &= ~(1u << bitmaskMapping[index]);
+	}
+	else
+	{
+		this->buttons |= (1u << bitmaskMapping[index]);
+	}
+}
+
 void PadGuitar::SetAxisScale(float deadzone, float scale)
 {
 	this->whammyDeadzone = deadzone;

--- a/pcsx2/SIO/Pad/PadGuitar.h
+++ b/pcsx2/SIO/Pad/PadGuitar.h
@@ -37,6 +37,20 @@ private:
 	float whammyDeadzone = 0.0f;
 	float buttonDeadzone = 0.0f; // Button deadzone is still a good idea, in case a host analog stick is bound to a guitar button
 
+	// Since we reordered the buttons for better UI, we need to remap them here.
+	static constexpr std::array<u8, Inputs::LENGTH> bitmaskMapping = {{
+		12, // STRUM_UP
+		14, // STRUM_DOWN
+		8, // SELECT
+		11, // START
+		1, // GREEN
+		5, // RED
+		4, // YELLOW
+		6, // BLUE
+		7, // ORANGE
+		0 // TILT
+	}};
+
 	void ConfigLog();
 
 	u8 Mystery(u8 commandByte);
@@ -58,6 +72,7 @@ public:
 	const Pad::ControllerInfo& GetInfo() const override;
 	void Set(u32 index, float value) override;
 	void SetRawAnalogs(const std::tuple<u8, u8> left, const std::tuple<u8, u8> right) override;
+	void SetRawPressureButton(u32 index, const std::tuple<bool, u8> value) override;
 	void SetAxisScale(float deadzone, float scale) override;
 	float GetVibrationScale(u32 motor) const override;
 	void SetVibrationScale(u32 motor, float scale) override;

--- a/pcsx2/SIO/Pad/PadNotConnected.cpp
+++ b/pcsx2/SIO/Pad/PadNotConnected.cpp
@@ -36,6 +36,11 @@ void PadNotConnected::SetRawAnalogs(const std::tuple<u8, u8> left, const std::tu
 
 }
 
+void PadNotConnected::SetRawPressureButton(u32 index, const std::tuple<bool, u8> value)
+{
+
+}
+
 void PadNotConnected::SetAxisScale(float deadzone, float scale)
 {
 

--- a/pcsx2/SIO/Pad/PadNotConnected.h
+++ b/pcsx2/SIO/Pad/PadNotConnected.h
@@ -15,6 +15,7 @@ public:
 	const Pad::ControllerInfo& GetInfo() const override;
 	void Set(u32 index, float value) override;
 	void SetRawAnalogs(const std::tuple<u8, u8> left, const std::tuple<u8, u8> right) override;
+	void SetRawPressureButton(u32 index, const std::tuple<bool, u8> value) override;
 	void SetAxisScale(float deadzone, float scale) override;
 	float GetVibrationScale(u32 motor) const override;
 	void SetVibrationScale(u32 motor, float scale) override;

--- a/pcsx2/SIO/Pad/PadPopn.cpp
+++ b/pcsx2/SIO/Pad/PadPopn.cpp
@@ -376,21 +376,6 @@ void PadPopn::Set(u32 index, float value)
 		return;
 	}
 
-	// Since we reordered the buttons for better UI, we need to remap them here.
-	static constexpr std::array<u8, Inputs::LENGTH> bitmaskMapping = {{
-		5, // PAD_YELLOW_LEFT
-		12, // PAD_YELLOW_RIGHT
-		6, // PAD_BLUE_LEFT
-		7, // PAD_BLUE_RIGHT
-		4, // PAD_WHITE_LEFT
-		0, // PAD_WHITE_RIGHT
-		3, // PAD_GREEN_LEFT
-		1, // PAD_GREEN_RIGHT
-		2, // PAD_RED
-		11, // PAD_START
-		8, // PAD_SELECT
-	}};
-
 	this->rawInputs[index] = static_cast<u8>(std::clamp(value * 255.0f, 0.0f, 255.0f));
 
 	if (value)
@@ -405,6 +390,20 @@ void PadPopn::Set(u32 index, float value)
 
 void PadPopn::SetRawAnalogs(const std::tuple<u8, u8> left, const std::tuple<u8, u8> right)
 {
+}
+
+void PadPopn::SetRawPressureButton(u32 index, const std::tuple<bool, u8> value)
+{
+	this->rawInputs[index] = std::get<1>(value);
+
+	if (std::get<0>(value))
+	{
+		this->buttons &= ~(1u << bitmaskMapping[index]);
+	}
+	else
+	{
+		this->buttons |= (1u << bitmaskMapping[index]);
+	}
 }
 
 void PadPopn::SetAxisScale(float deadzone, float scale)

--- a/pcsx2/SIO/Pad/PadPopn.h
+++ b/pcsx2/SIO/Pad/PadPopn.h
@@ -59,6 +59,21 @@ private:
 	bool commandStage = false;
 	u32 responseBytes = 0;
 
+	// Since we reordered the buttons for better UI, we need to remap them here.
+	static constexpr std::array<u8, Inputs::LENGTH> bitmaskMapping = {{
+		5, // PAD_YELLOW_LEFT
+		12, // PAD_YELLOW_RIGHT
+		6, // PAD_BLUE_LEFT
+		7, // PAD_BLUE_RIGHT
+		4, // PAD_WHITE_LEFT
+		0, // PAD_WHITE_RIGHT
+		3, // PAD_GREEN_LEFT
+		1, // PAD_GREEN_RIGHT
+		2, // PAD_RED
+		11, // PAD_START
+		8, // PAD_SELECT
+	}};
+
 	void ConfigLog();
 
 	u8 Mystery(u8 commandByte);
@@ -81,6 +96,7 @@ public:
 	const Pad::ControllerInfo& GetInfo() const override;
 	void Set(u32 index, float value) override;
 	void SetRawAnalogs(const std::tuple<u8, u8> left, const std::tuple<u8, u8> right) override;
+	void SetRawPressureButton(u32 index, const std::tuple<bool, u8> value) override;
 	void SetAxisScale(float deadzone, float scale) override;
 	float GetVibrationScale(u32 motor) const override;
 	void SetVibrationScale(u32 motor, float scale) override;


### PR DESCRIPTION
### Description of Changes
Directly set the controller state to the values recorded, bypassing the extra processing in `Set()`

### Rationale behind Changes
Existing code did not correctly pass the pressure value, treating any pressure value above 0 as 255.
This was due to the input recorder passing a value of range 0-255, rather than a 0-1 float range that `Set()` expected.

Existing code recalculated the pressed state, which could differ from the recorded value
I managed to create a recording with a pressed state of true, but zero pressure
I suspect this happened because my triggers had higher resolution than the PS2 controllers, and a _very_ light touch got rounded down.

### Suggested Testing Steps
Record your input and then play it back, comparing the results
I had used padtest for comparing.

I would like if someone could test with pressure sensitive face buttons. the controller I used for testing just had analogue triggers.