### PR TITLE
GS Capture: Set Avutil Channel Layout and Implement Pixel Format Selection

### DIFF
--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -397,6 +397,7 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* dialog, QWidget* 
 			&GraphicsSettingsWidget::onEnableAudioCaptureArgumentsChanged);
 
 		onCaptureContainerChanged();
+		onCaptureCodecChanged();
 		onEnableVideoCaptureChanged();
 		onEnableVideoCaptureArgumentsChanged();
 		onVideoCaptureAutoResolutionChanged();
@@ -735,6 +736,10 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* dialog, QWidget* 
 		
 		"<b>If unsure, leave it on default.<b>"));
 
+		dialog->registerWidgetHelp(m_ui.videoCaptureFormat, tr("Video Format"), tr("Default"), tr("Selects which Video Format to be used for Video Capture. If by chance the codec does not support the format, the first format available will be used. "
+		
+		"<b>If unsure, leave it on default.<b>"));
+
 		dialog->registerWidgetHelp(m_ui.videoCaptureBitrate, tr("Video Bitrate"), tr("6000 kbps"), tr("Sets the video bitrate to be used. "
 		
 		"Larger bitrate generally yields better video quality at the cost of larger resulting file size."));
@@ -914,6 +919,7 @@ void GraphicsSettingsWidget::onCaptureContainerChanged()
 
 	SettingWidgetBinder::BindWidgetToStringSetting(
 		m_dialog->getSettingsInterface(), m_ui.videoCaptureCodec, "EmuCore/GS", "VideoCaptureCodec");
+	connect(m_ui.videoCaptureCodec, &QComboBox::currentIndexChanged, this, &GraphicsSettingsWidget::onCaptureCodecChanged);
 
 	m_ui.audioCaptureCodec->disconnect();
 	m_ui.audioCaptureCodec->clear();
@@ -927,6 +933,30 @@ void GraphicsSettingsWidget::onCaptureContainerChanged()
 
 	SettingWidgetBinder::BindWidgetToStringSetting(
 		m_dialog->getSettingsInterface(), m_ui.audioCaptureCodec, "EmuCore/GS", "AudioCaptureCodec");
+}
+
+void GraphicsSettingsWidget::GraphicsSettingsWidget::onCaptureCodecChanged()
+{
+	m_ui.videoCaptureFormat->disconnect();
+	m_ui.videoCaptureFormat->clear();
+	//: This string refers to a default pixel format
+	m_ui.videoCaptureFormat->addItem(tr("Default"), "");
+
+	const std::string codec(
+		m_dialog->getEffectiveStringValue("EmuCore/GS", "VideoCaptureCodec", ""));
+
+	if (!codec.empty())
+	{
+		for (const auto& [id, name] : GSCapture::GetVideoFormatList(codec.c_str()))
+		{
+			const QString qid(QString::number(id));
+			const QString qname(QString::fromStdString(name));
+			m_ui.videoCaptureFormat->addItem(qname, qid);
+		}
+	}
+
+	SettingWidgetBinder::BindWidgetToStringSetting(
+		m_dialog->getSettingsInterface(), m_ui.videoCaptureFormat, "EmuCore/GS", "VideoCaptureFormat");
 }
 
 void GraphicsSettingsWidget::onEnableVideoCaptureChanged()

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.h
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.h
@@ -38,6 +38,7 @@ private Q_SLOTS:
 	void onTextureReplacementChanged();
 	void onShadeBoostChanged();
 	void onCaptureContainerChanged();
+	void onCaptureCodecChanged();
 	void onEnableVideoCaptureChanged();
 	void onEnableVideoCaptureArgumentsChanged();
 	void onVideoCaptureAutoResolutionChanged();

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
@@ -1847,13 +1847,23 @@
                 <widget class="QComboBox" name="videoCaptureCodec"/>
                </item>
                <item row="1" column="0">
+                <widget class="QLabel" name="videoCaptureFomatLabel">
+                 <property name="text">
+                  <string>Format:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="1">
+                <widget class="QComboBox" name="videoCaptureFormat"/>
+               </item>
+               <item row="2" column="0">
                 <widget class="QLabel" name="videoCaptureBitrateLabel">
                  <property name="text">
                   <string>Bitrate:</string>
                  </property>
                 </widget>
                </item>
-               <item row="1" column="1">
+               <item row="2" column="1">
                 <widget class="QSpinBox" name="videoCaptureBitrate">
                  <property name="suffix">
                   <string extracomment="Unit that will appear next to a number. Alter the space or whatever is needed before the text depending on your language."> kbps</string>
@@ -1869,14 +1879,14 @@
                  </property>
                 </widget>
                </item>
-               <item row="2" column="0">
+               <item row="3" column="0">
                 <widget class="QLabel" name="videoCaptureResolutionLabel">
                  <property name="text">
                   <string>Resolution:</string>
                  </property>
                 </widget>
                </item>
-               <item row="2" column="1">
+               <item row="3" column="1">
                 <layout class="QHBoxLayout" name="horizontalLayout_10" stretch="1,0,1,0">
                  <item>
                   <widget class="QSpinBox" name="videoCaptureWidth">
@@ -1926,14 +1936,14 @@
                  </item>
                 </layout>
                </item>
-               <item row="3" column="0" colspan="2">
+               <item row="4" column="0" colspan="2">
                 <widget class="QCheckBox" name="enableVideoCaptureArguments">
                  <property name="text">
                   <string>Extra Arguments</string>
                  </property>
                 </widget>
                </item>
-               <item row="4" column="0" colspan="2">
+               <item row="5" column="0" colspan="2">
                 <widget class="QLineEdit" name="videoCaptureArguments"/>
                </item>
               </layout>

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -731,6 +731,7 @@ struct Pcsx2Config
 
 		std::string CaptureContainer = DEFAULT_CAPTURE_CONTAINER;
 		std::string VideoCaptureCodec;
+		std::string VideoCaptureFormat;
 		std::string VideoCaptureParameters;
 		std::string AudioCaptureCodec;
 		std::string AudioCaptureParameters;

--- a/pcsx2/GS/GSCapture.cpp
+++ b/pcsx2/GS/GSCapture.cpp
@@ -42,6 +42,7 @@ extern "C" {
 #include "libavutil/dict.h"
 #include "libavutil/opt.h"
 #include "libavutil/version.h"
+#include "libavutil/channel_layout.h"
 #include "libswscale/swscale.h"
 #include "libswscale/version.h"
 #include "libswresample/swresample.h"
@@ -88,7 +89,8 @@ extern "C" {
 #else
 #define AVUTIL_57_IMPORTS(X) \
 	X(av_channel_layout_default) \
-	X(av_channel_layout_copy)
+	X(av_channel_layout_copy) \
+	X(av_opt_set_chlayout)
 #endif
 
 #define VISIT_AVUTIL_IMPORTS(X) \
@@ -690,9 +692,16 @@ bool GSCapture::BeginCapture(float fps, GSVector2i recommendedResolution, float 
 				return false;
 			}
 
+			#if LIBAVUTIL_VERSION_MAJOR >= 57
+				const AVChannelLayout layout = AV_CHANNEL_LAYOUT_STEREO;
+				wrap_av_opt_set_chlayout(s_swr_context, "in_chlayout", &layout, 0);
+				wrap_av_opt_set_chlayout(s_swr_context, "out_chlayout", &layout, 0);
+			#endif
+			
 			wrap_av_opt_set_int(s_swr_context, "in_channel_count", AUDIO_CHANNELS, 0);
 			wrap_av_opt_set_int(s_swr_context, "in_sample_rate", sample_rate, 0);
 			wrap_av_opt_set_sample_fmt(s_swr_context, "in_sample_fmt", AV_SAMPLE_FMT_S16, 0);
+
 			wrap_av_opt_set_int(s_swr_context, "out_channel_count", AUDIO_CHANNELS, 0);
 			wrap_av_opt_set_int(s_swr_context, "out_sample_rate", sample_rate, 0);
 			wrap_av_opt_set_sample_fmt(s_swr_context, "out_sample_fmt", s_audio_codec_context->sample_fmt, 0);

--- a/pcsx2/GS/GSCapture.h
+++ b/pcsx2/GS/GSCapture.h
@@ -37,4 +37,8 @@ namespace GSCapture
 	using CodecList = std::vector<CodecName>;
 	CodecList GetVideoCodecList(const char* container);
 	CodecList GetAudioCodecList(const char* container);
+
+	using FormatName = std::pair<int , std::string>; // id,name
+	using FormatList = std::vector<FormatName>;
+	FormatList GetVideoFormatList(const char* codec);
 }; // namespace GSCapture

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -750,6 +750,7 @@ bool Pcsx2Config::GSOptions::OptionsAreEqual(const GSOptions& right) const
 
 		OpEqu(CaptureContainer) &&
 		OpEqu(VideoCaptureCodec) &&
+		OpEqu(VideoCaptureFormat) &&
 		OpEqu(VideoCaptureParameters) &&
 		OpEqu(AudioCaptureCodec) &&
 		OpEqu(AudioCaptureParameters) &&
@@ -925,6 +926,7 @@ void Pcsx2Config::GSOptions::LoadSave(SettingsWrapper& wrap)
 
 	SettingsWrapEntryEx(CaptureContainer, "CaptureContainer");
 	SettingsWrapEntryEx(VideoCaptureCodec, "VideoCaptureCodec");
+	SettingsWrapEntryEx(VideoCaptureFormat, "VideoCaptureFormat");
 	SettingsWrapEntryEx(VideoCaptureParameters, "VideoCaptureParameters");
 	SettingsWrapEntryEx(AudioCaptureCodec, "AudioCaptureCodec");
 	SettingsWrapEntryEx(AudioCaptureParameters, "AudioCaptureParameters");


### PR DESCRIPTION
### Description of Changes
On newer avutil versions we must set the channel layout. This wasn't an issue on the flatpack because the ffmpeg version is fixed. On appimages this was an issue because we depend on the system library, which can be a higher version.

I implemented the ability to select the pixel format based on the current codec selected. This fixes hw encoding with AMD GPUs on Windows as it did not like the YUV420P format. As for Linux, I'm not entirely sure. It appears that hw encoding support is quite a mess. AMF is only supported on nonfree AMDGPU-PRO drivers, and I don't really know the capabilities of mesa.

### Rationale behind Changes
Fixes captures on newer ffmpeg/libavutil versions.

More capture options for the videophiles. 

Obviously if you select weird options like `cuda` or `d3d11` things are going to not work. Don't bother reporting if your desired 1 bit pixel format isn't supported on your GPU :^)

Also, the default pixel format is now NV12 instead of YUV420P. This change was made due to the fact that AMD hardware encoding fails with the format as YUV420P.

### Suggested Testing Steps

I could create an entire truth table for this, but here is what I expect:
**Assuming you use hardware decoding with the default pixel format (NV12 now)**
Windows with AMD should work (**YUV420P, the old default, doesn't seem to work**)
Linux with AMD + Mesa -> VAAPI works with #11372
Linux with AMD + AMDGPU PRO -> Haven't tested, AMF options should work?
Intel and NVIDIA should not have changed behaviour


Resolves #11548

(With #11372)
Resolves #10646