### PR TITLE
Debugger: Use safe vtlb read/write methods

### DIFF
--- a/pcsx2/DebugTools/DebugInterface.cpp
+++ b/pcsx2/DebugTools/DebugInterface.cpp
@@ -171,7 +171,7 @@ public:
 			return m_cpu->getLO()._u64[0];
 		if (referenceIndex & REF_INDEX_IS_OPSL)
 		{
-			const u32 OP = memRead32(m_cpu->getPC());
+			const u32 OP = m_cpu->read32(m_cpu->getPC());
 			const R5900::OPCODE& opcode = R5900::GetInstruction(OP);
 			if (opcode.flags & IS_MEMORY)
 			{
@@ -393,7 +393,11 @@ u32 R5900DebugInterface::read8(u32 address)
 	if (!isValidAddress(address))
 		return -1;
 
-	return memRead8(address);
+	u8 value;
+	if (!vtlb_memSafeReadBytes(address, &value, sizeof(u8)))
+		return -1;
+
+	return value;
 }
 
 u32 R5900DebugInterface::read8(u32 address, bool& valid)
@@ -401,7 +405,11 @@ u32 R5900DebugInterface::read8(u32 address, bool& valid)
 	if (!(valid = isValidAddress(address)))
 		return -1;
 
-	return memRead8(address);
+	u8 value;
+	if (!(valid = vtlb_memSafeReadBytes(address, &value, sizeof(u8))))
+		return -1;
+
+	return value;
 }
 
 
@@ -410,7 +418,11 @@ u32 R5900DebugInterface::read16(u32 address)
 	if (!isValidAddress(address) || address % 2)
 		return -1;
 
-	return memRead16(address);
+	u16 value;
+	if (!vtlb_memSafeReadBytes(address, &value, sizeof(u16)))
+		return -1;
+
+	return static_cast<u32>(value);
 }
 
 u32 R5900DebugInterface::read16(u32 address, bool& valid)
@@ -418,7 +430,11 @@ u32 R5900DebugInterface::read16(u32 address, bool& valid)
 	if (!(valid = (isValidAddress(address) || address % 2)))
 		return -1;
 
-	return memRead16(address);
+	u16 value;
+	if (!(valid = vtlb_memSafeReadBytes(address, &value, sizeof(u16))))
+		return -1;
+
+	return static_cast<u32>(value);
 }
 
 u32 R5900DebugInterface::read32(u32 address)
@@ -426,7 +442,11 @@ u32 R5900DebugInterface::read32(u32 address)
 	if (!isValidAddress(address) || address % 4)
 		return -1;
 
-	return memRead32(address);
+	u32 value;
+	if (!vtlb_memSafeReadBytes(address, &value, sizeof(u32)))
+		return -1;
+
+	return value;
 }
 
 u32 R5900DebugInterface::read32(u32 address, bool& valid)
@@ -434,7 +454,11 @@ u32 R5900DebugInterface::read32(u32 address, bool& valid)
 	if (!(valid = (isValidAddress(address) || address % 4)))
 		return -1;
 
-	return memRead32(address);
+	u32 value;
+	if (!(valid = vtlb_memSafeReadBytes(address, &value, sizeof(u32))))
+		return -1;
+
+	return value;
 }
 
 u64 R5900DebugInterface::read64(u32 address)
@@ -442,7 +466,11 @@ u64 R5900DebugInterface::read64(u32 address)
 	if (!isValidAddress(address) || address % 8)
 		return -1;
 
-	return memRead64(address);
+	u64 value;
+	if (!vtlb_memSafeReadBytes(address, &value, sizeof(u64)))
+		return -1;
+
+	return value;
 }
 
 u64 R5900DebugInterface::read64(u32 address, bool& valid)
@@ -450,7 +478,11 @@ u64 R5900DebugInterface::read64(u32 address, bool& valid)
 	if (!(valid = (isValidAddress(address) || address % 8)))
 		return -1;
 
-	return memRead64(address);
+	u64 value;
+	if (!(valid = vtlb_memSafeReadBytes(address, &value, sizeof(u64))))
+		return -1;
+
+	return value;
 }
 
 u128 R5900DebugInterface::read128(u32 address)
@@ -462,7 +494,11 @@ u128 R5900DebugInterface::read128(u32 address)
 		return result;
 	}
 
-	memRead128(address, result);
+	if (!vtlb_memSafeReadBytes(address, &result, sizeof(u128)))
+	{
+		result.hi = result.lo = -1;
+	}
+
 	return result;
 }
 
@@ -471,7 +507,7 @@ void R5900DebugInterface::write8(u32 address, u8 value)
 	if (!isValidAddress(address))
 		return;
 
-	memWrite8(address, value);
+	vtlb_memSafeWriteBytes(address, &value, sizeof(u8));
 }
 
 void R5900DebugInterface::write16(u32 address, u16 value)
@@ -479,7 +515,7 @@ void R5900DebugInterface::write16(u32 address, u16 value)
 	if (!isValidAddress(address))
 		return;
 
-	memWrite16(address, value);
+	vtlb_memSafeWriteBytes(address, &value, sizeof(u16));
 }
 
 void R5900DebugInterface::write32(u32 address, u32 value)
@@ -487,7 +523,7 @@ void R5900DebugInterface::write32(u32 address, u32 value)
 	if (!isValidAddress(address))
 		return;
 
-	memWrite32(address, value);
+	vtlb_memSafeWriteBytes(address, &value, sizeof(u32));
 }
 
 void R5900DebugInterface::write64(u32 address, u64 value)
@@ -495,7 +531,7 @@ void R5900DebugInterface::write64(u32 address, u64 value)
 	if (!isValidAddress(address))
 		return;
 
-	memWrite64(address, value);
+	vtlb_memSafeWriteBytes(address, &value, sizeof(u64));
 }
 
 void R5900DebugInterface::write128(u32 address, u128 value)
@@ -503,7 +539,7 @@ void R5900DebugInterface::write128(u32 address, u128 value)
 	if (!isValidAddress(address))
 		return;
 
-	memWrite128(address, value);
+	vtlb_memSafeWriteBytes(address, &value, sizeof(u128));
 }
 
 int R5900DebugInterface::getRegisterCategoryCount()

--- a/pcsx2/DebugTools/DisassemblyManager.cpp
+++ b/pcsx2/DebugTools/DisassemblyManager.cpp
@@ -23,7 +23,7 @@ static u32 computeHash(u32 address, u32 size)
 	u32 hash = 0xBACD7814;
 	while (address < end)
 	{
-		hash += memRead32(address);
+		hash += r5900Debug.read32(address);
 		address += 4;
 	}
 	return hash;
@@ -918,7 +918,7 @@ void DisassemblyData::createLines()
 		bool inString = false;
 		while (pos < end)
 		{
-			u8 b = memRead8(pos++);
+			u8 b = r5900Debug.read8(pos++);
 			if (b >= 0x20 && b <= 0x7F)
 			{
 				if (currentLine.size()+1 >= maxChars)
@@ -995,18 +995,18 @@ void DisassemblyData::createLines()
 			switch (type)
 			{
 			case DATATYPE_BYTE:
-				value = memRead8(pos);
+				value = cpu->read8(pos);
 				std::snprintf(buffer,std::size(buffer),"0x%02X",value);
 				pos++;
 				break;
 			case DATATYPE_HALFWORD:
-				value = memRead16(pos);
+				value = cpu->read16(pos);
 				std::snprintf(buffer,std::size(buffer),"0x%04X",value);
 				pos += 2;
 				break;
 			case DATATYPE_WORD:
 				{
-					value = memRead32(pos);
+					value = cpu->read32(pos);
 					const std::string label = cpu->GetSymbolGuardian().SymbolStartingAtAddress(value).name;
 					if (!label.empty())
 						std::snprintf(buffer,std::size(buffer),"%s",label.c_str());


### PR DESCRIPTION
### Description of Changes
Instead of using the unsafe vtlb access functions that can cause tlb misses and trigger MMIO handlers I've migrated the debugger to use the safer ones.

### Rationale behind Changes
This seems to have fixed the recursion issue when pause-on-tlb-miss is enabled.
It also wasn't great that the debugger can read guest FIFOs and such.

### Suggested Testing Steps
Enable pause-on-tlb-miss, open the debugger, and reset a bunch of times and see if PCSX2 crashes.
Test and see if the debugger still works fine.

Fixes #11594 