### PR TITLE
Qt: Add per-game link to PCSX2 Wiki pages on right-click

### DIFF
--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -1356,6 +1356,11 @@ void MainWindow::onGameListEntryContextMenuRequested(const QPoint& point)
 
 		connect(menu.addAction(tr("Reset Play Time")), &QAction::triggered, [this, entry]() { clearGameListEntryPlayTime(entry); });
 
+		if (!entry->serial.empty())
+		{
+			connect(menu.addAction(tr("Check Wiki Page")), &QAction::triggered, [this, entry]() { goToWikiPage(entry); });
+		}
+		
 		menu.addSeparator();
 
 		if (!s_vm_valid)
@@ -2717,6 +2722,11 @@ void MainWindow::clearGameListEntryPlayTime(const GameList::Entry* entry)
 
 	GameList::ClearPlayedTimeForSerial(entry->serial);
 	m_game_list_widget->refresh(false);
+}
+
+void MainWindow::goToWikiPage(const GameList::Entry* entry)
+{
+	QtUtils::OpenURL(this, fmt::format("https://wiki.pcsx2.net/{}", entry->serial).c_str());
 }
 
 std::optional<bool> MainWindow::promptForResumeState(const QString& save_state_path)

--- a/pcsx2-qt/MainWindow.h
+++ b/pcsx2-qt/MainWindow.h
@@ -267,6 +267,7 @@ private:
 		const GameList::Entry* entry, std::optional<s32> save_slot = std::nullopt, std::optional<bool> fast_boot = std::nullopt);
 	void setGameListEntryCoverImage(const GameList::Entry* entry);
 	void clearGameListEntryPlayTime(const GameList::Entry* entry);
+	void goToWikiPage(const GameList::Entry* entry);
 
 	std::optional<bool> promptForResumeState(const QString& save_state_path);
 	void loadSaveStateSlot(s32 slot);

--- a/pcsx2-qt/Settings/GameSummaryWidget.cpp
+++ b/pcsx2-qt/Settings/GameSummaryWidget.cpp
@@ -49,11 +49,13 @@ GameSummaryWidget::GameSummaryWidget(const GameList::Entry* entry, SettingsWindo
 	connect(m_ui.inputProfile, &QComboBox::currentIndexChanged, this, &GameSummaryWidget::onInputProfileChanged);
 	connect(m_ui.verify, &QAbstractButton::clicked, this, &GameSummaryWidget::onVerifyClicked);
 	connect(m_ui.searchHash, &QAbstractButton::clicked, this, &GameSummaryWidget::onSearchHashClicked);
+	connect(m_ui.checkWiki, &QAbstractButton::clicked, this, [this, entry]() { onCheckWikiClicked(entry); });
 
 	bool has_custom_title = false, has_custom_region = false;
 	GameList::CheckCustomAttributesForPath(m_entry_path, has_custom_title, has_custom_region);
 	m_ui.restoreTitle->setEnabled(has_custom_title);
 	m_ui.restoreRegion->setEnabled(has_custom_region);
+	m_ui.checkWiki->setEnabled(!entry->serial.empty());
 }
 
 GameSummaryWidget::~GameSummaryWidget() = default;
@@ -346,6 +348,11 @@ void GameSummaryWidget::onSearchHashClicked()
 		return;
 
 	QtUtils::OpenURL(this, fmt::format("http://redump.org/discs/quicksearch/{}", m_redump_search_keyword).c_str());
+}
+
+void GameSummaryWidget::onCheckWikiClicked(const GameList::Entry* entry)
+{
+	QtUtils::OpenURL(this, fmt::format("https://wiki.pcsx2.net/{}", entry->serial).c_str());
 }
 
 void GameSummaryWidget::setVerifyResult(QString error)

--- a/pcsx2-qt/Settings/GameSummaryWidget.h
+++ b/pcsx2-qt/Settings/GameSummaryWidget.h
@@ -28,6 +28,7 @@ private Q_SLOTS:
 	void onDiscPathBrowseClicked();
 	void onVerifyClicked();
 	void onSearchHashClicked();
+	void onCheckWikiClicked(const GameList::Entry* entry);
 
 private:
 	void populateInputProfiles();

--- a/pcsx2-qt/Settings/GameSummaryWidget.ui
+++ b/pcsx2-qt/Settings/GameSummaryWidget.ui
@@ -104,11 +104,25 @@
     </widget>
    </item>
    <item row="4" column="1">
-    <widget class="QLineEdit" name="serial">
-     <property name="readOnly">
-      <bool>true</bool>
-     </property>
-    </widget>
+    <layout class="QHBoxLayout" name="horizontalLayout_8">
+     <item>
+      <widget class="QLineEdit" name="serial">
+       <property name="readOnly">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="checkWiki">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="text">
+        <string>Check Wiki</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
    <item row="5" column="0">
     <widget class="QLabel" name="label_36">


### PR DESCRIPTION
### Description of Changes
Gives the user an option in the game list's right-click menu to be taken to the relevant PCSX2 wiki page.

It accomplishes this because I recently ran a script on the wiki to create redirects to the relevant pages for every single serial in the GameDB. Most games should currently work, but the serials that redirect to a red link (a non-existent article) or which attempt to double-redirect (not possible on MediaWiki) will need to be corrected over time.

### Rationale behind Changes
Gives the user a quick and easy way to access the relevant PCSX2 wiki page for their game. Much better and more consistent than using the entry's name, as that frequently changes both in the DB and on the wiki. This gives us a permanent bridge between those two platforms.

### Suggested Testing Steps
Right-click on your games in the game list/grid and select 'Check Wiki Page'. See if that a) gets you to the PCSX2 wiki and b) if you hit a red link or a serial redirect. Ideally you should be redirected directly to the article for the game in question.

### Addendum
Also adds a button in the game properties widget to check out the wiki page, again only if the serial exists.