### PR TITLE
OSD: Add hardware info statistics

### DIFF
--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -126,6 +126,7 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* dialog, QWidget* 
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.osdShowInputs, "EmuCore/GS", "OsdShowInputs", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.osdShowFrameTimes, "EmuCore/GS", "OsdShowFrameTimes", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.osdShowVersion, "EmuCore/GS", "OsdShowVersion", false);
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.osdShowHardwareInfo, "EmuCore/GS", "OsdShowHardwareInfo", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.warnAboutUnsafeSettings, "EmuCore", "WarnAboutUnsafeSettings", true);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.fxaa, "EmuCore/GS", "fxaa", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.shadeBoost, "EmuCore/GS", "ShadeBoost", false);
@@ -733,6 +734,9 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* dialog, QWidget* 
 		
 		dialog->registerWidgetHelp(m_ui.osdShowVersion, tr("Show PCSX2 Version"), tr("Unchecked"),
 			tr("Shows the current PCSX2 version on the top-right corner of the display"));
+
+		dialog->registerWidgetHelp(m_ui.osdShowHardwareInfo, tr("Show Hardware Info"), tr("Unchecked"),
+			tr("Shows the current system hardware information on the OSD."));
 
 		dialog->registerWidgetHelp(m_ui.warnAboutUnsafeSettings, tr("Warn About Unsafe Settings"), tr("Checked"),
 			tr("Displays warnings when settings are enabled which may break games."));

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
@@ -1662,17 +1662,31 @@
           </item>
           <item row="3" column="0" colspan="2">
            <layout class="QGridLayout" name="gridLayout_6">
-            <item row="0" column="0">
-             <widget class="QCheckBox" name="osdShowResolution">
+            <item row="5" column="0">
+             <widget class="QCheckBox" name="osdShowFrameTimes">
               <property name="text">
-               <string>Show Resolution</string>
+               <string>Show Frame Times</string>
               </property>
              </widget>
             </item>
-            <item row="0" column="1">
-             <widget class="QCheckBox" name="osdShowFPS">
+            <item row="2" column="0">
+             <widget class="QCheckBox" name="osdShowVersion">
               <property name="text">
-               <string>Show FPS</string>
+               <string>Show PCSX2 Version</string>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="0">
+             <widget class="QCheckBox" name="osdShowIndicators">
+              <property name="text">
+               <string>Show Indicators</string>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="1">
+             <widget class="QCheckBox" name="osdShowSpeed">
+              <property name="text">
+               <string>Show Speed Percentages</string>
               </property>
              </widget>
             </item>
@@ -1690,24 +1704,17 @@
               </property>
              </widget>
             </item>
-            <item row="2" column="0">
-             <widget class="QCheckBox" name="osdShowVersion">
+            <item row="4" column="0">
+             <widget class="QCheckBox" name="osdShowGSStats">
               <property name="text">
-               <string>Show PCSX2 Version</string>
+               <string>Show Statistics</string>
               </property>
              </widget>
             </item>
-            <item row="2" column="1">
-             <widget class="QCheckBox" name="osdShowSpeed">
+            <item row="5" column="1">
+             <widget class="QCheckBox" name="warnAboutUnsafeSettings">
               <property name="text">
-               <string>Show Speed Percentages</string>
-              </property>
-             </widget>
-            </item>
-            <item row="3" column="0">
-             <widget class="QCheckBox" name="osdShowIndicators">
-              <property name="text">
-               <string>Show Indicators</string>
+               <string>Warn About Unsafe Settings</string>
               </property>
              </widget>
             </item>
@@ -1718,10 +1725,17 @@
               </property>
              </widget>
             </item>
-            <item row="4" column="0">
-             <widget class="QCheckBox" name="osdShowGSStats">
+            <item row="0" column="1">
+             <widget class="QCheckBox" name="osdShowFPS">
               <property name="text">
-               <string>Show Statistics</string>
+               <string>Show FPS</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="0">
+             <widget class="QCheckBox" name="osdShowResolution">
+              <property name="text">
+               <string>Show Resolution</string>
               </property>
              </widget>
             </item>
@@ -1732,17 +1746,10 @@
               </property>
              </widget>
             </item>
-            <item row="5" column="0">
-             <widget class="QCheckBox" name="osdShowFrameTimes">
+            <item row="6" column="0">
+             <widget class="QCheckBox" name="osdShowHardwareInfo">
               <property name="text">
-               <string>Show Frame Times</string>
-              </property>
-             </widget>
-            </item>
-            <item row="5" column="1">
-             <widget class="QCheckBox" name="warnAboutUnsafeSettings">
-              <property name="text">
-               <string>Warn About Unsafe Settings</string>
+               <string>Show Hardware Info</string>
               </property>
              </widget>
             </item>

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -628,6 +628,7 @@ struct Pcsx2Config
 					OsdShowInputs : 1,
 					OsdShowFrameTimes : 1,
 					OsdShowVersion : 1,
+					OsdShowHardwareInfo : 1,
 					HWSpinGPUForReadbacks : 1,
 					HWSpinCPUForReadbacks : 1,
 					GPUPaletteConversion : 1,

--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -3154,6 +3154,9 @@ void FullscreenUI::DrawInterfaceSettingsPage()
 	DrawToggleSetting(bsi, FSUI_ICONSTR(ICON_PF_HEARTBEAT_ALT, "Show Frame Times"),
 		FSUI_CSTR("Shows a visual history of frame times in the upper-left corner of the display."), "EmuCore/GS", "OsdShowFrameTimes",
 		false);
+	DrawToggleSetting(bsi, FSUI_ICONSTR(ICON_PF_MONITOR_CODE, "Show Hardware Info"),
+		FSUI_CSTR("Shows the current system hardware information on the OSD."), "EmuCore/GS", "OsdShowHardwareInfo",
+		false);
 	DrawToggleSetting(bsi, FSUI_ICONSTR(ICON_FA_EXCLAMATION, "Warn About Unsafe Settings"),
 		FSUI_CSTR("Displays warnings when settings are enabled which may break games."), "EmuCore", "WarnAboutUnsafeSettings", true);
 

--- a/pcsx2/ImGui/ImGuiOverlays.cpp
+++ b/pcsx2/ImGui/ImGuiOverlays.cpp
@@ -25,6 +25,7 @@
 #include "USB/USB.h"
 #include "VMManager.h"
 #include "svnrev.h"
+#include "cpuinfo.h"
 
 #include "common/BitUtils.h"
 #include "common/FileSystem.h"
@@ -191,6 +192,13 @@ __ri void ImGuiManager::DrawPerformanceOverlay(float& position_y, float scale, f
 			GSgetMemoryStats(text);
 			if (!text.empty())
 				DRAW_LINE(fixed_font, text.c_str(), IM_COL32(255, 255, 255, 255));
+
+			text.clear();
+			text.append_format("{} QF | {:.2f}ms | {:.2f}ms | {:.2f}ms",
+				MTGS::GetCurrentVsyncQueueSize() - 1, // we subtract one for the current frame
+				PerformanceMetrics::GetMinimumFrameTime(), PerformanceMetrics::GetAverageFrameTime(),
+				PerformanceMetrics::GetMaximumFrameTime());
+			DRAW_LINE(fixed_font, text.c_str(), IM_COL32(255, 255, 255, 255));
 		}
 
 		if (GSConfig.OsdShowResolution)
@@ -203,15 +211,18 @@ __ri void ImGuiManager::DrawPerformanceOverlay(float& position_y, float scale, f
 			DRAW_LINE(fixed_font, text.c_str(), IM_COL32(255, 255, 255, 255));
 		}
 
-		if (GSConfig.OsdShowCPU)
+		if (GSConfig.OsdShowHardwareInfo)
 		{
 			text.clear();
-			text.append_format("{} QF | {:.2f}ms | {:.2f}ms | {:.2f}ms",
-				MTGS::GetCurrentVsyncQueueSize() - 1, // we subtract one for the current frame
-				PerformanceMetrics::GetMinimumFrameTime(), PerformanceMetrics::GetAverageFrameTime(),
-				PerformanceMetrics::GetMaximumFrameTime());
+			text.append_format("CPU: {} ({}C/{}T)",
+				cpuinfo_get_package(0)->name,
+				cpuinfo_get_cores_count(),
+				cpuinfo_get_processors_count());
 			DRAW_LINE(fixed_font, text.c_str(), IM_COL32(255, 255, 255, 255));
+		}
 
+		if (GSConfig.OsdShowCPU)
+		{
 			text.clear();
 			if (EmuConfig.Speedhacks.EECycleRate != 0 || EmuConfig.Speedhacks.EECycleSkip != 0)
 				text.append_format("EE[{}/{}]: ", EmuConfig.Speedhacks.EECycleRate, EmuConfig.Speedhacks.EECycleSkip);

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -631,6 +631,7 @@ Pcsx2Config::GSOptions::GSOptions()
 	OsdShowInputs = false;
 	OsdShowFrameTimes = false;
 	OsdShowVersion = false;
+	OsdShowHardwareInfo = false;
 
 	HWDownloadMode = GSHardwareDownloadMode::Enabled;
 	HWSpinGPUForReadbacks = false;
@@ -838,6 +839,7 @@ void Pcsx2Config::GSOptions::LoadSave(SettingsWrapper& wrap)
 	SettingsWrapBitBool(OsdShowInputs);
 	SettingsWrapBitBool(OsdShowFrameTimes);
 	SettingsWrapBitBool(OsdShowVersion);
+	SettingsWrapBitBool(OsdShowHardwareInfo);
 
 	SettingsWrapBitBool(HWSpinGPUForReadbacks);
 	SettingsWrapBitBool(HWSpinCPUForReadbacks);

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -2370,8 +2370,7 @@ inline void LogUserPowerPlan()
 }
 #endif
 
-#if 0
-#if defined(__linux__) || defined(_WIN32)
+#if defined(_WIN32)
 void LogGPUCapabilities()
 {
 	Console.WriteLn(Color_StrongBlack, "Graphics Adapters Detected:");
@@ -2484,7 +2483,6 @@ void LogGPUCapabilities()
 #endif
 }
 #endif
-#endif
 
 void VMManager::LogCPUCapabilities()
 {
@@ -2532,7 +2530,7 @@ void VMManager::LogCPUCapabilities()
 	}
 #endif
 
-#if 0
+#if defined(_WIN32)
 	LogGPUCapabilities();
 #endif
 }


### PR DESCRIPTION
### Description of Changes
Shows the current system CPU in the OSD when ticking the new show hardware info OSD option. Also reenables Fobes previously disabled GPU info and driver logging.

Example:
![image](https://github.com/user-attachments/assets/c22e4f7d-7397-4e2c-8a54-d428e4188f75)

### Rationale behind Changes
 This will be helpful for support queries as well as people who stream or make videos and want to display hardware information easily.

### Suggested Testing Steps
Make sure the CPU info works on Windows Linux and Mac and doesn't end up making anything else go boom.
