### PR TITLE
Qt: Use serials by default for cover filenames with downloader

### DIFF
--- a/pcsx2-qt/CoverDownloadDialog.cpp
+++ b/pcsx2-qt/CoverDownloadDialog.cpp
@@ -91,7 +91,7 @@ void CoverDownloadDialog::updateEnabled()
 
 void CoverDownloadDialog::startThread()
 {
-	m_thread = std::make_unique<CoverDownloadThread>(this, m_ui.urls->toPlainText(), m_ui.useSerialFileNames->isChecked());
+	m_thread = std::make_unique<CoverDownloadThread>(this, m_ui.urls->toPlainText(), !m_ui.useTitleFileNames->isChecked());
 	m_last_refresh_time.Reset();
 	connect(m_thread.get(), &CoverDownloadThread::statusUpdated, this, &CoverDownloadDialog::onDownloadStatus);
 	connect(m_thread.get(), &CoverDownloadThread::progressUpdated, this, &CoverDownloadDialog::onDownloadProgress);

--- a/pcsx2-qt/CoverDownloadDialog.ui
+++ b/pcsx2-qt/CoverDownloadDialog.ui
@@ -60,7 +60,7 @@
    <item>
     <widget class="QLabel" name="label_2">
      <property name="text">
-      <string>By default, the downloaded covers will be saved with the game's title. If this is not desired, you can check the &quot;Use Serial File Names&quot; box below. Using serials instead of game titles will prevent conflicts when multiple regions of the same game are used.</string>
+      <string>By default, the downloaded covers will be saved with the game's serial to ensure covers do not break with GameDB changes and that titles with multiple regions do not conflict. If this is not desired, you can check the &quot;Use Title File Names&quot; box below.</string>
      </property>
      <property name="wordWrap">
       <bool>true</bool>
@@ -68,9 +68,9 @@
     </widget>
    </item>
    <item>
-    <widget class="QCheckBox" name="useSerialFileNames">
+    <widget class="QCheckBox" name="useTitleFileNames">
      <property name="text">
-      <string>Use Serial File Names</string>
+      <string>Use Title File Names</string>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
### Description of Changes
Uses serials by default when using the cover downloader instead of titles of games. It has now flipped so that there is a 'Use Title File Names' option.

### Rationale behind Changes
Using the titles of games is an inherently unstable, messy way to name these files by default. When a user creates and downloads their covers, in all likelihood they do not want to ever have to re-configure the covers. However, using the title by default creates exactly that problem, and it has cropped up several times in the Discord: Jordan or I change the name in the GameDB, and now suddenly the cover images are broken for the end user who needs to go and replace them again.

Additionally, it means that titles with the same name but different covers for multiple regions will have a collision. It is clear that using the serial is the optimal way to go about this since it uniquely, permanently identifies the game, but it leaves the title option for users who want to tinker around in and more easily parse the covers directory. The user should not have to manually use a checkbox to select the clearly optimal, more reliable option for 99.99% of the userbase.

### Suggested Testing Steps
Try using the cover downloader without the box checked and see if the file names produced read like serials (e.g. 'SCES-53285' instead of 'Ratchet - Gladiator'). Also make sure the title name option works correctly.
