### PR TITLE
Qt: Add Video Capture button to toolbar

### DIFF
--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -396,7 +396,7 @@ void MainWindow::connectSignals()
 	connect(m_ui.actionSaveBlockDump, &QAction::toggled, this, &MainWindow::onBlockDumpActionToggled);
 	connect(m_ui.actionShowAdvancedSettings, &QAction::toggled, this, &MainWindow::onShowAdvancedSettingsToggled);
 	connect(m_ui.actionSaveGSDump, &QAction::triggered, this, &MainWindow::onSaveGSDumpActionTriggered);
-	connect(m_ui.actionToolsVideoCapture, &QAction::toggled, this, &MainWindow::onToolsVideoCaptureToggled);
+	connect(m_ui.actionVideoCapture, &QAction::toggled, this, &MainWindow::onVideoCaptureToggled);
 	connect(m_ui.actionEditPatches, &QAction::triggered, this, [this]() { onToolsEditCheatsPatchesTriggered(false); });
 	connect(m_ui.actionEditCheats, &QAction::triggered, this, [this]() { onToolsEditCheatsPatchesTriggered(true); });
 
@@ -712,14 +712,14 @@ void MainWindow::updateAdvancedSettingsVisibility()
 	m_ui.actionEnableVerboseLogging->setVisible(enabled);
 }
 
-void MainWindow::onToolsVideoCaptureToggled(bool checked)
+void MainWindow::onVideoCaptureToggled(bool checked)
 {
 	if (!s_vm_valid)
 		return;
 
 	// Reset the checked state, we'll get updated by the GS thread.
-	QSignalBlocker sb(m_ui.actionToolsVideoCapture);
-	m_ui.actionToolsVideoCapture->setChecked(!checked);
+	QSignalBlocker sb(m_ui.actionVideoCapture);
+	m_ui.actionVideoCapture->setChecked(!checked);
 
 	if (!checked)
 	{
@@ -744,8 +744,8 @@ void MainWindow::onCaptureStarted(const QString& filename)
 	if (!s_vm_valid)
 		return;
 
-	QSignalBlocker sb(m_ui.actionToolsVideoCapture);
-	m_ui.actionToolsVideoCapture->setChecked(true);
+	QSignalBlocker sb(m_ui.actionVideoCapture);
+	m_ui.actionVideoCapture->setChecked(true);
 }
 
 void MainWindow::onCaptureStopped()
@@ -753,8 +753,8 @@ void MainWindow::onCaptureStopped()
 	if (!s_vm_valid)
 		return;
 
-	QSignalBlocker sb(m_ui.actionToolsVideoCapture);
-	m_ui.actionToolsVideoCapture->setChecked(false);
+	QSignalBlocker sb(m_ui.actionVideoCapture);
+	m_ui.actionVideoCapture->setChecked(false);
 }
 
 void MainWindow::onAchievementsLoginRequested(Achievements::LoginRequestReason reason)
@@ -880,11 +880,11 @@ void MainWindow::updateEmulationActions(bool starting, bool running, bool stoppi
 
 	m_ui.actionViewGameProperties->setEnabled(running);
 
-	m_ui.actionToolsVideoCapture->setEnabled(running);
-	if (!running && m_ui.actionToolsVideoCapture->isChecked())
+	m_ui.actionVideoCapture->setEnabled(running);
+	if (!running && m_ui.actionVideoCapture->isChecked())
 	{
-		QSignalBlocker sb(m_ui.actionToolsVideoCapture);
-		m_ui.actionToolsVideoCapture->setChecked(false);
+		QSignalBlocker sb(m_ui.actionVideoCapture);
+		m_ui.actionVideoCapture->setChecked(false);
 	}
 
 	m_game_list_widget->setDisabled(starting && !running);

--- a/pcsx2-qt/MainWindow.h
+++ b/pcsx2-qt/MainWindow.h
@@ -171,7 +171,7 @@ private Q_SLOTS:
 	void onSaveGSDumpActionTriggered();
 	void onBlockDumpActionToggled(bool checked);
 	void onShowAdvancedSettingsToggled(bool checked);
-	void onToolsVideoCaptureToggled(bool checked);
+	void onVideoCaptureToggled(bool checked);
 	void onSettingsTriggeredFromToolbar();
 
 	// Input Recording

--- a/pcsx2-qt/MainWindow.ui
+++ b/pcsx2-qt/MainWindow.ui
@@ -210,7 +210,7 @@
     <addaction name="separator"/>
     <addaction name="actionToggleSoftwareRendering"/>
     <addaction name="menuInputRecording"/>
-    <addaction name="actionToolsVideoCapture"/>
+    <addaction name="actionVideoCapture"/>
     <addaction name="separator"/>
     <addaction name="actionEnableSystemConsole"/>
     <addaction name="actionEnableDebugConsole"/>
@@ -260,7 +260,9 @@
    <addaction name="actionToolbarReset"/>
    <addaction name="actionToolbarPause"/>
    <addaction name="actionToolbarChangeDisc"/>
+   <addaction name="separator"/>
    <addaction name="actionToolbarScreenshot"/>
+   <addaction name="actionVideoCapture"/>
    <addaction name="separator"/>
    <addaction name="actionToolbarLoadState"/>
    <addaction name="actionToolbarSaveState"/>
@@ -1080,12 +1082,16 @@
     <string>Recording Viewer</string>
    </property>
   </action>
-  <action name="actionToolsVideoCapture">
+  <action name="actionVideoCapture">
    <property name="checkable">
     <bool>true</bool>
    </property>
    <property name="text">
     <string>Video Capture</string>
+   </property>
+   <property name="icon">
+    <iconset theme="camera-video">
+     <normaloff>.</normaloff>.</iconset>
    </property>
   </action>
   <action name="actionEditCheats">

--- a/pcsx2-qt/resources/icons/black/svg/camera-video.svg
+++ b/pcsx2-qt/resources/icons/black/svg/camera-video.svg
@@ -1,0 +1,7 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Transformed by: SVG Repo Mixer Tools -->
+<svg width="256px" height="256px" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" fill="#000000" class="bi bi-camera-video">
+<g id="SVGRepo_bgCarrier" stroke-width="0"/>
+<g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"/>
+<g id="SVGRepo_iconCarrier"> <path fill-rule="evenodd" d="M0 5a2 2 0 0 1 2-2h7.5a2 2 0 0 1 1.983 1.738l3.11-1.382A1 1 0 0 1 16 4.269v7.462a1 1 0 0 1-1.406.913l-3.111-1.382A2 2 0 0 1 9.5 13H2a2 2 0 0 1-2-2V5zm11.5 5.175 3.5 1.556V4.269l-3.5 1.556v4.35zM2 4a1 1 0 0 0-1 1v6a1 1 0 0 0 1 1h7.5a1 1 0 0 0 1-1V5a1 1 0 0 0-1-1H2z"/> </g>
+</svg>

--- a/pcsx2-qt/resources/icons/white/svg/camera-video.svg
+++ b/pcsx2-qt/resources/icons/white/svg/camera-video.svg
@@ -1,0 +1,7 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Transformed by: SVG Repo Mixer Tools -->
+<svg width="256px" height="256px" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" fill="#ffffff" class="bi bi-camera-video">
+<g id="SVGRepo_bgCarrier" stroke-width="0"/>
+<g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"/>
+<g id="SVGRepo_iconCarrier"> <path fill-rule="evenodd" d="M0 5a2 2 0 0 1 2-2h7.5a2 2 0 0 1 1.983 1.738l3.11-1.382A1 1 0 0 1 16 4.269v7.462a1 1 0 0 1-1.406.913l-3.111-1.382A2 2 0 0 1 9.5 13H2a2 2 0 0 1-2-2V5zm11.5 5.175 3.5 1.556V4.269l-3.5 1.556v4.35zM2 4a1 1 0 0 0-1 1v6a1 1 0 0 0 1 1h7.5a1 1 0 0 0 1-1V5a1 1 0 0 0-1-1H2z"/> </g>
+</svg>

--- a/pcsx2-qt/resources/resources.qrc
+++ b/pcsx2-qt/resources/resources.qrc
@@ -9,16 +9,17 @@
 		<file>icons/black/svg/band-aid-line.svg</file>
 		<file>icons/black/svg/brush-line.svg</file>
 		<file>icons/black/svg/buzz-controller-line.svg</file>
+		<file>icons/black/svg/camera-video.svg</file>
 		<file>icons/black/svg/cheats-line.svg</file>
 		<file>icons/black/svg/checkbox-multiple-blank-line.svg</file>
 		<file>icons/black/svg/chip-line.svg</file>
 		<file>icons/black/svg/close-line.svg</file>
 		<file>icons/black/svg/controller-line.svg</file>
 		<file>icons/black/svg/controller-strike-line.svg</file>
+		<file>icons/black/svg/debugger-line.svg</file>
 		<file>icons/black/svg/debug-step-into-line.svg</file>
 		<file>icons/black/svg/debug-step-out-line.svg</file>
 		<file>icons/black/svg/debug-step-over-line.svg</file>
-		<file>icons/black/svg/debugger-line.svg</file>
 		<file>icons/black/svg/delete-back-2-line.svg</file>
 		<file>icons/black/svg/disc-2-line.svg</file>
 		<file>icons/black/svg/disc-eject-line.svg</file>
@@ -105,16 +106,17 @@
 		<file>icons/white/svg/band-aid-line.svg</file>
 		<file>icons/white/svg/brush-line.svg</file>
 		<file>icons/white/svg/buzz-controller-line.svg</file>
+		<file>icons/white/svg/camera-video.svg</file>
 		<file>icons/white/svg/cheats-line.svg</file>
 		<file>icons/white/svg/checkbox-multiple-blank-line.svg</file>
 		<file>icons/white/svg/chip-line.svg</file>
 		<file>icons/white/svg/close-line.svg</file>
 		<file>icons/white/svg/controller-line.svg</file>
 		<file>icons/white/svg/controller-strike-line.svg</file>
+		<file>icons/white/svg/debugger-line.svg</file>
 		<file>icons/white/svg/debug-step-into-line.svg</file>
 		<file>icons/white/svg/debug-step-out-line.svg</file>
 		<file>icons/white/svg/debug-step-over-line.svg</file>
-		<file>icons/white/svg/debugger-line.svg</file>
 		<file>icons/white/svg/delete-back-2-line.svg</file>
 		<file>icons/white/svg/disc-2-line.svg</file>
 		<file>icons/white/svg/disc-eject-line.svg</file>

--- a/pcsx2/GS/GSCapture.cpp
+++ b/pcsx2/GS/GSCapture.cpp
@@ -295,11 +295,13 @@ bool GSCapture::LoadFFmpeg(bool report_errors)
 	{
 		Host::ReportErrorAsync(TRANSLATE_SV("GSCapture","Failed to load FFmpeg"),
 			fmt::format(TRANSLATE_FS("GSCapture","You may be missing one or more files, or are using the incorrect version. This build of PCSX2 requires:\n"
-						"  libavcodec: {}\n"
-						"  libavformat: {}\n"
-						"  libavutil: {}\n"
-						"  libswscale: {}\n"
-				"  libswresample: {}\n"), LIBAVCODEC_VERSION_MAJOR, LIBAVFORMAT_VERSION_MAJOR, LIBAVUTIL_VERSION_MAJOR,
+				"  libavcodec: {}\n"
+				"  libavformat: {}\n"
+				"  libavutil: {}\n"
+				"  libswscale: {}\n"
+				"  libswresample: {}\n\n"
+				"Please see our official documentation for more information."), 
+				LIBAVCODEC_VERSION_MAJOR, LIBAVFORMAT_VERSION_MAJOR, LIBAVUTIL_VERSION_MAJOR,
 				LIBSWSCALE_VERSION_MAJOR, LIBSWRESAMPLE_VERSION_MAJOR));
 	}
 


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->

This PR adds the Video Capture button into the toolbar for quicker access.
![image](https://github.com/user-attachments/assets/1820bb3c-83b1-4801-b279-de99819efce8)


### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Easier to access the video capture rather than going through Tools -> Video Capture

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
QoL 100