### PR TITLE
Qt: Simplify compat line in GameSummaryWidget

### DIFF
--- a/pcsx2-qt/Settings/GameSummaryWidget.cpp
+++ b/pcsx2-qt/Settings/GameSummaryWidget.cpp
@@ -35,10 +35,6 @@ GameSummaryWidget::GameSummaryWidget(const GameList::Entry* entry, SettingsWindo
 		m_ui.region->setItemIcon(i,
 			QIcon(QStringLiteral("%1/icons/flags/%2.png").arg(base_path).arg(GameList::RegionToString(static_cast<GameList::Region>(i)))));
 	}
-	for (int i = 1; i < m_ui.compatibility->count(); i++)
-	{
-		m_ui.compatibility->setItemIcon(i, QIcon(QStringLiteral("%1/icons/star-%2.png").arg(base_path).arg(i)));
-	}
 
 	m_entry_path = entry->path;
 	populateInputProfiles();
@@ -74,7 +70,15 @@ void GameSummaryWidget::populateDetails(const GameList::Entry* entry)
 	m_ui.crc->setText(QString::fromStdString(fmt::format("{:08X}", entry->crc)));
 	m_ui.type->setCurrentIndex(static_cast<int>(entry->type));
 	m_ui.region->setCurrentIndex(static_cast<int>(entry->region));
-	m_ui.compatibility->setCurrentIndex(static_cast<int>(entry->compatibility_rating));
+	m_ui.compatibility->setText(QString("%0%1")
+		.arg(GameList::EntryCompatibilityRatingToString(entry->compatibility_rating))
+		.arg([entry]() {
+			if (entry->compatibility_rating == GameList::CompatibilityRating::Unknown)
+				return QString();
+
+			const qsizetype compatibility_value = static_cast<qsizetype>(entry->compatibility_rating);
+			return QString(" ") + QString("★").repeated(compatibility_value - 1) + QString("☆").repeated(6 - compatibility_value);
+		}()));
 
 	int row = 0;
 	m_ui.detailsFormLayout->getWidgetPosition(m_ui.titleSort, &row, nullptr);

--- a/pcsx2-qt/Settings/GameSummaryWidget.ui
+++ b/pcsx2-qt/Settings/GameSummaryWidget.ui
@@ -363,54 +363,10 @@
     </widget>
    </item>
    <item row="8" column="1">
-    <widget class="QComboBox" name="compatibility">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="editable">
+    <widget class="QLineEdit" name="compatibility">
+     <property name="readOnly">
       <bool>true</bool>
      </property>
-     <item>
-      <property name="text">
-       <string>Unknown</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Not Bootable</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Reaches Intro</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Reaches Menu</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>In-Game</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Playable</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Perfect</string>
-      </property>
-     </item>
     </widget>
    </item>
    <item row="9" column="0">


### PR DESCRIPTION
### Description of Changes
Get rid of extraneous icon for the compat line in GameSummaryWidget and turn the line into a read-only text field.

### Rationale behind Changes
The icon was so tiny as to be unreadable and therefore useless. The line was previously a dropdown menu that could not be changed, creating an extraneous arrow symbol on the right side of the line and reducing the contrast of the text against the background.

Before:
![Before](https://github.com/user-attachments/assets/8566f54e-dc25-4cd8-9671-f511e3867a66)

After:
![After](https://github.com/user-attachments/assets/1c26d508-a54e-46d1-9059-a734cf508872)


### Suggested Testing Steps
Check the game properties widget for your games.

### Addendum
Also adds a star rating system that was poorly implemented previously as icons. Credit to @F0bes for amending my star rating lambda to be more compact.