### PR TITLE
GameList: Make compat strings translatable

### DIFF
--- a/pcsx2-qt/Settings/GameSummaryWidget.cpp
+++ b/pcsx2-qt/Settings/GameSummaryWidget.cpp
@@ -72,14 +72,16 @@ void GameSummaryWidget::populateDetails(const GameList::Entry* entry)
 	m_ui.crc->setText(QString::fromStdString(fmt::format("{:08X}", entry->crc)));
 	m_ui.type->setCurrentIndex(static_cast<int>(entry->type));
 	m_ui.region->setCurrentIndex(static_cast<int>(entry->region));
-	m_ui.compatibility->setText(QString("%0%1")
+	//: First arg is a GameList compat; second is a string with space followed by star rating OR empty if Unknown compat
+	m_ui.compatibility->setText(tr("%0%1")
 		.arg(GameList::EntryCompatibilityRatingToString(entry->compatibility_rating))
 		.arg([entry]() {
 			if (entry->compatibility_rating == GameList::CompatibilityRating::Unknown)
-				return QString();
+				return QStringLiteral("");
 
 			const qsizetype compatibility_value = static_cast<qsizetype>(entry->compatibility_rating);
-			return QString(" ") + QString("★").repeated(compatibility_value - 1) + QString("☆").repeated(6 - compatibility_value);
+			//: First arg is filled-in stars for game compatibility; second is empty stars; should be swapped for RTL languages
+			return tr(" %0%1").arg(QStringLiteral("★").repeated(compatibility_value - 1)).arg(QStringLiteral("☆").repeated(6 - compatibility_value));
 		}()));
 
 	int row = 0;

--- a/pcsx2/GameList.cpp
+++ b/pcsx2/GameList.cpp
@@ -117,14 +117,14 @@ const char* GameList::EntryCompatibilityRatingToString(CompatibilityRating ratin
 	// clang-format off
 	switch (rating)
 	{
-	case CompatibilityRating::Unknown: return "Unknown";
-	case CompatibilityRating::Nothing: return "Nothing";
-	case CompatibilityRating::Intro: return "Intro";
-	case CompatibilityRating::Menu: return "Menu";
-	case CompatibilityRating::InGame: return "InGame";
-	case CompatibilityRating::Playable: return "Playable";
-	case CompatibilityRating::Perfect: return "Perfect";
-	default: return "";
+		case CompatibilityRating::Unknown:  return TRANSLATE("GameList", "Unknown");
+		case CompatibilityRating::Nothing:  return TRANSLATE("GameList", "Nothing");
+		case CompatibilityRating::Intro:    return TRANSLATE("GameList", "Intro");
+		case CompatibilityRating::Menu:     return TRANSLATE("GameList", "Menu");
+		case CompatibilityRating::InGame:   return TRANSLATE("GameList", "In-Game");
+		case CompatibilityRating::Playable: return TRANSLATE("GameList", "Playable");
+		case CompatibilityRating::Perfect:  return TRANSLATE("GameList", "Perfect");
+		default: return "";
 	}
 	// clang-format on
 }


### PR DESCRIPTION
### Description of Changes
Makes the GameList::EntryCompatibilityRatingToString return strings translatable.

### Rationale behind Changes
Unbreaks what I broke in my previous PR and makes this function more versatile.

### Suggested Testing Steps
Make sure the compat string still displays correctly in the summary widget and the fullscreen UI.