### PR TITLE
OSD: Allow independent left- and right-align for OSD

### DIFF
--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -113,7 +113,8 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* dialog, QWidget* 
 	// OSD Settings
 	//////////////////////////////////////////////////////////////////////////
 	SettingWidgetBinder::BindWidgetToFloatSetting(sif, m_ui.osdScale, "EmuCore/GS", "OsdScale", 100.0f);
-	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.osdShowMessages, "EmuCore/GS", "OsdShowMessages", true);
+	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.osdMessagesPos, "EmuCore/GS", "OsdMessagesPos", static_cast<int>(OsdOverlayPos::TopLeft));
+	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.osdPerformancePos, "EmuCore/GS", "OsdPerformancePos", static_cast<int>(OsdOverlayPos::TopRight));
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.osdShowSpeed, "EmuCore/GS", "OsdShowSpeed", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.osdShowFPS, "EmuCore/GS", "OsdShowFPS", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.osdShowCPU, "EmuCore/GS", "OsdShowCPU", false);
@@ -137,6 +138,10 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* dialog, QWidget* 
 
 	connect(m_ui.shadeBoost, &QCheckBox::checkStateChanged, this, &GraphicsSettingsWidget::onShadeBoostChanged);
 	onShadeBoostChanged();
+	connect(m_ui.osdMessagesPos, &QComboBox::currentIndexChanged, this, &GraphicsSettingsWidget::onMessagesPosChanged);
+	connect(m_ui.osdPerformancePos, &QComboBox::currentIndexChanged, this, &GraphicsSettingsWidget::onPerformancePosChanged);
+	onMessagesPosChanged();
+	onPerformancePosChanged();
 
 	//////////////////////////////////////////////////////////////////////////
 	// HW Settings
@@ -691,9 +696,12 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* dialog, QWidget* 
 	{
 		dialog->registerWidgetHelp(m_ui.osdScale, tr("OSD Scale"), tr("100%"), tr("Scales the size of the onscreen OSD from 50% to 500%."));
 
-		dialog->registerWidgetHelp(m_ui.osdShowMessages, tr("Show OSD Messages"), tr("Checked"),
+		dialog->registerWidgetHelp(m_ui.osdMessagesPos, tr("OSD Messages Position"), tr("Left (Default)"),
 			tr("Shows on-screen-display messages when events occur such as save states being "
 			   "created/loaded, screenshots being taken, etc."));
+		
+		dialog->registerWidgetHelp(m_ui.osdPerformancePos, tr("OSD Statistics Position"), tr("Right (Default)"),
+			tr("Shows a variety of on-screen performance data points as selected by the user."));
 
 		dialog->registerWidgetHelp(m_ui.osdShowFPS, tr("Show FPS"), tr("Unchecked"),
 			tr("Shows the internal frame rate of the game in the top-right corner of the display."));
@@ -884,6 +892,28 @@ void GraphicsSettingsWidget::onShadeBoostChanged()
 	m_ui.shadeBoostBrightness->setEnabled(enabled);
 	m_ui.shadeBoostContrast->setEnabled(enabled);
 	m_ui.shadeBoostSaturation->setEnabled(enabled);
+}
+
+void GraphicsSettingsWidget::onMessagesPosChanged()
+{
+	const bool enabled = m_ui.osdMessagesPos->currentIndex() != (m_dialog->isPerGameSettings() ? 1 : 0);
+
+	m_ui.warnAboutUnsafeSettings->setEnabled(enabled);
+}
+
+void GraphicsSettingsWidget::onPerformancePosChanged()
+{
+	const bool enabled = m_ui.osdPerformancePos->currentIndex() != (m_dialog->isPerGameSettings() ? 1 : 0);
+	
+	m_ui.osdShowSpeed->setEnabled(enabled);
+	m_ui.osdShowFPS->setEnabled(enabled);
+	m_ui.osdShowCPU->setEnabled(enabled);
+	m_ui.osdShowGPU->setEnabled(enabled);
+	m_ui.osdShowResolution->setEnabled(enabled);
+	m_ui.osdShowGSStats->setEnabled(enabled);
+	m_ui.osdShowIndicators->setEnabled(enabled);
+	m_ui.osdShowFrameTimes->setEnabled(enabled);
+	m_ui.osdShowVersion->setEnabled(enabled);
 }
 
 void GraphicsSettingsWidget::onTextureDumpChanged()

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.h
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.h
@@ -37,6 +37,8 @@ private Q_SLOTS:
 	void onTextureDumpChanged();
 	void onTextureReplacementChanged();
 	void onShadeBoostChanged();
+	void onMessagesPosChanged();
+	void onPerformancePosChanged();
 	void onCaptureContainerChanged();
 	void onCaptureCodecChanged();
 	void onEnableVideoCaptureChanged();

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
@@ -1608,9 +1608,68 @@
             </property>
            </widget>
           </item>
-          <item row="1" column="0" colspan="2">
+          <item row="1" column="0">
+           <widget class="QLabel" name="osdMessagesPosLabel">
+            <property name="text">
+             <string>OSD Messages Position:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QComboBox" name="osdMessagesPos">
+            <item>
+             <property name="text">
+              <string>None</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Left (Default)</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Right</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="osdPerformancePosLabel">
+            <property name="text">
+             <string>OSD Performance Position:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QComboBox" name="osdPerformancePos">
+            <item>
+             <property name="text">
+              <string>None</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Left</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Right (Default)</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+          <item row="3" column="0" colspan="2">
            <layout class="QGridLayout" name="gridLayout_6">
-            <item row="1" column="1">
+            <item row="0" column="0">
+             <widget class="QCheckBox" name="osdShowResolution">
+              <property name="text">
+               <string>Show Resolution</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
              <widget class="QCheckBox" name="osdShowFPS">
               <property name="text">
                <string>Show FPS</string>
@@ -1618,86 +1677,72 @@
              </widget>
             </item>
             <item row="1" column="0">
-             <widget class="QCheckBox" name="osdShowVersion">
-              <property name="text">
-               <string>Show PCSX2 Version</string>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="0">
              <widget class="QCheckBox" name="osdShowCPU">
               <property name="text">
                <string>Show CPU Usage</string>
               </property>
              </widget>
             </item>
-            <item row="3" column="1">
-             <widget class="QCheckBox" name="osdShowIndicators">
-              <property name="text">
-               <string>Show Indicators</string>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="0">
-             <widget class="QCheckBox" name="osdShowMessages">
-              <property name="text">
-               <string>Show OSD Messages</string>
-              </property>
-             </widget>
-            </item>
-            <item row="7" column="0">
-             <widget class="QCheckBox" name="warnAboutUnsafeSettings">
-              <property name="text">
-               <string>Warn About Unsafe Settings</string>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="1">
+            <item row="1" column="1">
              <widget class="QCheckBox" name="osdShowGPU">
               <property name="text">
                <string>Show GPU Usage</string>
               </property>
              </widget>
             </item>
-            <item row="0" column="1">
-             <widget class="QCheckBox" name="osdShowResolution">
+            <item row="2" column="0">
+             <widget class="QCheckBox" name="osdShowVersion">
               <property name="text">
-               <string>Show Resolution</string>
+               <string>Show PCSX2 Version</string>
               </property>
              </widget>
             </item>
-            <item row="6" column="1">
-             <widget class="QCheckBox" name="osdShowFrameTimes">
-              <property name="text">
-               <string>Show Frame Times</string>
-              </property>
-             </widget>
-            </item>
-            <item row="4" column="1">
-             <widget class="QCheckBox" name="osdShowGSStats">
-              <property name="text">
-               <string>Show Statistics</string>
-              </property>
-             </widget>
-            </item>
-            <item row="3" column="0">
+            <item row="2" column="1">
              <widget class="QCheckBox" name="osdShowSpeed">
               <property name="text">
                <string>Show Speed Percentages</string>
               </property>
              </widget>
             </item>
-            <item row="6" column="0">
+            <item row="3" column="0">
+             <widget class="QCheckBox" name="osdShowIndicators">
+              <property name="text">
+               <string>Show Indicators</string>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="1">
+             <widget class="QCheckBox" name="osdShowSettings">
+              <property name="text">
+               <string>Show Settings</string>
+              </property>
+             </widget>
+            </item>
+            <item row="4" column="0">
+             <widget class="QCheckBox" name="osdShowGSStats">
+              <property name="text">
+               <string>Show Statistics</string>
+              </property>
+             </widget>
+            </item>
+            <item row="4" column="1">
              <widget class="QCheckBox" name="osdShowInputs">
               <property name="text">
                <string>Show Inputs</string>
               </property>
              </widget>
             </item>
-            <item row="4" column="0">
-             <widget class="QCheckBox" name="osdShowSettings">
+            <item row="5" column="0">
+             <widget class="QCheckBox" name="osdShowFrameTimes">
               <property name="text">
-               <string>Show Settings</string>
+               <string>Show Frame Times</string>
+              </property>
+             </widget>
+            </item>
+            <item row="5" column="1">
+             <widget class="QCheckBox" name="warnAboutUnsafeSettings">
+              <property name="text">
+               <string>Warn About Unsafe Settings</string>
               </property>
              </widget>
             </item>

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -304,6 +304,13 @@ enum class AccBlendLevel : u8
 	Maximum,
 };
 
+enum class OsdOverlayPos : u8
+{
+	None,
+	TopLeft,
+	TopRight,
+};
+
 enum class TexturePreloadingLevel : u8
 {
 	Off,
@@ -610,7 +617,6 @@ struct Pcsx2Config
 					DisableFramebufferFetch : 1,
 					DisableVertexShaderExpand : 1,
 					SkipDuplicateFrames : 1,
-					OsdShowMessages : 1,
 					OsdShowSpeed : 1,
 					OsdShowFPS : 1,
 					OsdShowCPU : 1,
@@ -677,7 +683,9 @@ struct Pcsx2Config
 		float StretchY = 100.0f;
 		int Crop[4] = {};
 
-		float OsdScale = 100.0;
+		float OsdScale = 100.0f;
+		OsdOverlayPos OsdMessagesPos = OsdOverlayPos::TopLeft;
+		OsdOverlayPos OsdPerformancePos = OsdOverlayPos::TopRight;
 
 		GSRendererType Renderer = GSRendererType::Auto;
 		float UpscaleMultiplier = 1.0f;

--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -1043,18 +1043,13 @@ static void HotkeyAdjustUpscaleMultiplier(s32 delta)
 
 static void HotkeyToggleOSD()
 {
-	GSConfig.OsdShowMessages ^= EmuConfig.GS.OsdShowMessages;
-	GSConfig.OsdShowSpeed ^= EmuConfig.GS.OsdShowSpeed;
-	GSConfig.OsdShowFPS ^= EmuConfig.GS.OsdShowFPS;
-	GSConfig.OsdShowCPU ^= EmuConfig.GS.OsdShowCPU;
-	GSConfig.OsdShowGPU ^= EmuConfig.GS.OsdShowGPU;
-	GSConfig.OsdShowResolution ^= EmuConfig.GS.OsdShowResolution;
-	GSConfig.OsdShowGSStats ^= EmuConfig.GS.OsdShowGSStats;
-	GSConfig.OsdShowIndicators ^= EmuConfig.GS.OsdShowIndicators;
 	GSConfig.OsdShowSettings ^= EmuConfig.GS.OsdShowSettings;
 	GSConfig.OsdShowInputs ^= EmuConfig.GS.OsdShowInputs;
-	GSConfig.OsdShowFrameTimes ^= EmuConfig.GS.OsdShowFrameTimes;
-	GSConfig.OsdShowVersion ^= EmuConfig.GS.OsdShowVersion;
+
+	GSConfig.OsdMessagesPos =
+		GSConfig.OsdMessagesPos == OsdOverlayPos::None ? EmuConfig.GS.OsdMessagesPos : OsdOverlayPos::None;
+	GSConfig.OsdPerformancePos =
+		GSConfig.OsdPerformancePos == OsdOverlayPos::None ? EmuConfig.GS.OsdPerformancePos : OsdOverlayPos::None;
 }
 
 BEGIN_HOTKEY_LIST(g_gs_hotkeys){"Screenshot", TRANSLATE_NOOP("Hotkeys", "Graphics"),

--- a/pcsx2/ImGui/ImGuiManager.cpp
+++ b/pcsx2/ImGui/ImGuiManager.cpp
@@ -685,7 +685,7 @@ void ImGuiManager::AcquirePendingOSDMessages(Common::Timer::Value current_time)
 		if (s_osd_posted_messages.empty())
 			break;
 
-		if (GSConfig.OsdShowMessages)
+		if (GSConfig.OsdMessagesPos != OsdOverlayPos::None)
 		{
 			OSDMessage& new_msg = s_osd_posted_messages.front();
 			std::deque<OSDMessage>::iterator iter;
@@ -727,7 +727,7 @@ void ImGuiManager::DrawOSDMessages(Common::Timer::Value current_time)
 	const float padding = std::ceil(8.0f * scale);
 	const float rounding = std::ceil(5.0f * scale);
 	const float max_width = s_window_width - (margin + padding) * 2.0f;
-	float position_x = margin;
+	float position_x = GSConfig.OsdMessagesPos == OsdOverlayPos::TopRight ? GetWindowWidth() - margin : margin;
 	float position_y = margin;
 
 	auto iter = s_osd_active_messages.begin();
@@ -780,10 +780,10 @@ void ImGuiManager::DrawOSDMessages(Common::Timer::Value current_time)
 		if (actual_y >= s_window_height)
 			break;
 
-		const ImVec2 pos(position_x, actual_y);
 		const ImVec2 text_size(
 			font->CalcTextSizeA(font->FontSize, max_width, max_width, msg.text.c_str(), msg.text.c_str() + msg.text.length()));
 		const ImVec2 size(text_size.x + padding * 2.0f, text_size.y + padding * 2.0f);
+		const ImVec2 pos(position_x - (GSConfig.OsdMessagesPos == OsdOverlayPos::TopRight ? size.x : 0), actual_y);
 		const ImVec4 text_rect(pos.x + padding, pos.y + padding, pos.x + size.x - padding, pos.y + size.y - padding);
 
 		ImDrawList* dl = ImGui::GetBackgroundDrawList();

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -618,7 +618,8 @@ Pcsx2Config::GSOptions::GSOptions()
 	DisableFramebufferFetch = false;
 	DisableVertexShaderExpand = false;
 	SkipDuplicateFrames = false;
-	OsdShowMessages = true;
+	OsdMessagesPos = OsdOverlayPos::TopLeft;
+	OsdPerformancePos = OsdOverlayPos::TopRight;
 	OsdShowSpeed = false;
 	OsdShowFPS = false;
 	OsdShowCPU = false;
@@ -699,6 +700,8 @@ bool Pcsx2Config::GSOptions::OptionsAreEqual(const GSOptions& right) const
 		OpEqu(Crop[3]) &&
 
 		OpEqu(OsdScale) &&
+		OpEqu(OsdMessagesPos) &&
+		OpEqu(OsdPerformancePos) &&
 
 		OpEqu(Renderer) &&
 		OpEqu(UpscaleMultiplier) &&
@@ -824,7 +827,6 @@ void Pcsx2Config::GSOptions::LoadSave(SettingsWrapper& wrap)
 	SettingsWrapBitBool(DisableFramebufferFetch);
 	SettingsWrapBitBool(DisableVertexShaderExpand);
 	SettingsWrapBitBool(SkipDuplicateFrames);
-	SettingsWrapBitBool(OsdShowMessages);
 	SettingsWrapBitBool(OsdShowSpeed);
 	SettingsWrapBitBool(OsdShowFPS);
 	SettingsWrapBitBool(OsdShowCPU);
@@ -883,6 +885,8 @@ void Pcsx2Config::GSOptions::LoadSave(SettingsWrapper& wrap)
 	SettingsWrapIntEnumEx(InterlaceMode, "deinterlace_mode");
 
 	SettingsWrapEntry(OsdScale);
+	SettingsWrapIntEnumEx(OsdMessagesPos, "OsdMessagesPos");
+	SettingsWrapIntEnumEx(OsdPerformancePos, "OsdPerformancePos");
 
 	SettingsWrapIntEnumEx(Renderer, "Renderer");
 	SettingsWrapEntryEx(UpscaleMultiplier, "upscale_multiplier");


### PR DESCRIPTION
### Description of Changes
* Allow performance OSD to be toggled off altogether
* Allow right-alignment of OSD messages
* Allow left-alignment of OSD performance statistics
* Create QComboBox for OSD messages (obsoletes `Show OSD Messages` checkbox)
* Create QComboBox for OSD performance statistics
* Make the way we do OSD more extensible.

Note that the performance statistics `None` setting does not disable controller input OSD or settings OSD, and furthermore note that the positions of the inputs and settings cannot be swapped.

### Rationale behind Changes
Allow the user to switch between alignment of the OSD messages and OSD performance. Allows the user to easily disable all OSD performance without using a hotkey.

Partially addresses #6642.

### Suggested Testing Steps
Change OSD position around.

### Screenshots
![OSD](https://github.com/user-attachments/assets/a7b7e2f3-68f0-495e-85d2-8527e3757a31)