### PR TITLE
USB: Implement trance vibrator and buzz savestate freezing

### DIFF
--- a/pcsx2/USB/usb-pad/usb-buzz.cpp
+++ b/pcsx2/USB/usb-pad/usb-buzz.cpp
@@ -198,6 +198,11 @@ namespace usb_pad
 		return "BuzzDevice";
 	}
 
+	bool BuzzDevice::Freeze(USBDevice* dev, StateWrapper& sw) const
+	{
+		return true;
+	}
+
 	USBDevice* BuzzDevice::CreateDevice(SettingsInterface& si, u32 port, u32 subtype) const
 	{
 		BuzzState* s = new BuzzState(port);

--- a/pcsx2/USB/usb-pad/usb-buzz.h
+++ b/pcsx2/USB/usb-pad/usb-buzz.h
@@ -84,6 +84,7 @@ namespace usb_pad
 	public:
 		const char* Name() const override;
 		const char* TypeName() const override;
+		bool Freeze(USBDevice* dev, StateWrapper& sw) const override;
 		float GetBindingValue(const USBDevice* dev, u32 bind_index) const override;
 		void SetBindingValue(USBDevice* dev, u32 bind_index, float value) const override;
 		std::span<const InputBindingInfo> Bindings(u32 subtype) const override;

--- a/pcsx2/USB/usb-pad/usb-trance-vibrator.cpp
+++ b/pcsx2/USB/usb-pad/usb-trance-vibrator.cpp
@@ -129,6 +129,11 @@ namespace usb_pad
 		return "TranceVibrator";
 	}
 
+	bool TranceVibratorDevice::Freeze(USBDevice* dev, StateWrapper& sw) const
+	{
+		return true;
+	}
+
 	USBDevice* TranceVibratorDevice::CreateDevice(SettingsInterface& si, u32 port, u32 subtype) const
 	{
 		TranceVibratorState* s = new TranceVibratorState(port);

--- a/pcsx2/USB/usb-pad/usb-trance-vibrator.h
+++ b/pcsx2/USB/usb-pad/usb-trance-vibrator.h
@@ -26,6 +26,7 @@ namespace usb_pad
 	public:
 		const char* Name() const override;
 		const char* TypeName() const override;
+		bool Freeze(USBDevice* dev, StateWrapper& sw) const override;
 		float GetBindingValue(const USBDevice* dev, u32 bind_index) const override;
 		void SetBindingValue(USBDevice* dev, u32 bind_index, float value) const override;
 		std::span<const InputBindingInfo> Bindings(u32 subtype) const override;


### PR DESCRIPTION
Oversight when merging some USB prs, oops.

### Description of Changes
When these devices were created / moved, their freeze function wasn't implemented.

### Rationale behind Changes
It made it so you could not save state when these devices are selected

### Suggested Testing Steps
Try to save and load a savestate.
