### PR TITLE
GS/Vulkan: Restore VK_EXT_attachment_feedback_loop_layout

### DIFF
--- a/bin/resources/shaders/vulkan/tfx.glsl
+++ b/bin/resources/shaders/vulkan/tfx.glsl
@@ -349,7 +349,7 @@ layout(set = 1, binding = 1) uniform texture2D Palette;
 #endif
 
 #if PS_FEEDBACK_LOOP_IS_NEEDED
-	#if defined(DISABLE_TEXTURE_BARRIER)
+	#if defined(DISABLE_TEXTURE_BARRIER) || defined(HAS_FEEDBACK_LOOP_LAYOUT)
 		layout(set = 1, binding = 2) uniform texture2D RtSampler;
 		vec4 sample_from_rt() { return texelFetch(RtSampler, ivec2(gl_FragCoord.xy), 0); }
 	#else

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h
@@ -44,6 +44,7 @@ public:
 		bool vk_ext_swapchain_maintenance1 : 1;
 		bool vk_khr_driver_properties : 1;
 		bool vk_khr_shader_non_semantic_info : 1;
+		bool vk_ext_attachment_feedback_loop_layout : 1;
 	};
 
 	// Global state accessors
@@ -55,6 +56,13 @@ public:
 	__fi u32 GetPresentQueueFamilyIndex() const { return m_present_queue_family_index; }
 	__fi const VkPhysicalDeviceProperties& GetDeviceProperties() const { return m_device_properties; }
 	__fi const OptionalExtensions& GetOptionalExtensions() const { return m_optional_extensions; }
+
+	// The interaction between raster order attachment access and fbfetch is unclear.
+	__fi bool UseFeedbackLoopLayout() const
+	{
+		return (m_optional_extensions.vk_ext_attachment_feedback_loop_layout &&
+				!m_optional_extensions.vk_ext_rasterization_order_attachment_access);
+	}
 
 	// Helpers for getting constants
 	__fi u32 GetBufferCopyOffsetAlignment() const
@@ -563,6 +571,7 @@ public:
 	void UpdateHWPipelineSelector(GSHWDrawConfig& config, PipelineSelector& pipe);
 	void UploadHWDrawVerticesAndIndices(const GSHWDrawConfig& config);
 	VkImageMemoryBarrier GetColorBufferBarrier(GSTextureVK* rt) const;
+	VkDependencyFlags GetColorBufferBarrierFlags() const;
 	void SendHWDraw(const GSHWDrawConfig& config, GSTextureVK* draw_rt,
 		bool one_barrier, bool full_barrier, bool skip_first_barrier);
 

--- a/pcsx2/ShaderCacheVersion.h
+++ b/pcsx2/ShaderCacheVersion.h
@@ -3,4 +3,4 @@
 
 /// Version number for GS and other shaders. Increment whenever any of the contents of the
 /// shaders change, to invalidate the cache.
-static constexpr u32 SHADER_CACHE_VERSION = 53;
+static constexpr u32 SHADER_CACHE_VERSION = 54;


### PR DESCRIPTION
### Description of Changes
Test restoring feedback loop layout.

Fixes #11238 

### Rationale behind Changes
Fixes rendering problems on RDNA 2 and 3 GPUs on Windows.

### Suggested Testing Steps
Test to see if rainbows or other strange phenomena appear on RDNA 2 or 3 GPUs on Windows.
