### PR TITLE
GSrunner: Add CMake Build Option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,14 @@ if(ENABLE_TESTS)
 	add_subdirectory(tests/ctest)
 endif()
 
+# gsrunner
+if(ENABLE_GSRUNNER)
+	if (NOT WIN32)
+		message(WARNING "GSRunner is only supported on Windows and may not build on your system")
+	endif()
+	add_subdirectory(pcsx2-gsrunner)
+endif()
+
 #-------------------------------------------------------------------------------
 if(NOT IS_SUPPORTED_COMPILER)
 	message(WARNING "

--- a/cmake/BuildParameters.cmake
+++ b/cmake/BuildParameters.cmake
@@ -5,6 +5,7 @@ set(PCSX2_DEFS "")
 # Misc option
 #-------------------------------------------------------------------------------
 option(ENABLE_TESTS "Enables building the unit tests" ON)
+option(ENABLE_GSRUNNER "Enables building the GSRunner" OFF)
 option(LTO_PCSX2_CORE "Enable LTO/IPO/LTCG on the subset of pcsx2 that benefits most from it but not anything else")
 option(USE_VTUNE "Plug VTUNE to profile GS JIT.")
 

--- a/pcsx2-gsrunner/CMakeLists.txt
+++ b/pcsx2-gsrunner/CMakeLists.txt
@@ -1,9 +1,9 @@
-add_executable(pcsx2-gsrunnner)
+add_executable(pcsx2-gsrunner)
 
 if (PACKAGE_MODE)
-	install(TARGETS pcsx2-gsrunnner DESTINATION ${CMAKE_INSTALL_BINDIR})
+	install(TARGETS pcsx2-gsrunner DESTINATION ${CMAKE_INSTALL_BINDIR})
 else()
-	install(TARGETS pcsx2-gsrunnner DESTINATION ${CMAKE_SOURCE_DIR}/bin)
+	install(TARGETS pcsx2-gsrunner DESTINATION ${CMAKE_SOURCE_DIR}/bin)
 endif()
 
 target_sources(pcsx2-gsrunner PRIVATE


### PR DESCRIPTION
### Description of Changes
Adds `ENABLE_GSRUNNER` option to build GSRunner using CMake
Remove the extra `n` in pcsx2-gsrunner CMakeList

### Rationale behind Changes
Parity with MSBuild

### Suggested Testing Steps
Make sure GSRunner is not built when CMake is configured without `-DENABLE_GSRUNNER=ON`
Build pcsx2 using CMake with an additional configure argument `-DENABLE_GSRUNNER=ON` on windows

