### PR TITLE
GS/HW: Extend Bilinear Upscale Hack to dirty depth

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -10406,6 +10406,8 @@ SCUS-97211:
   name: "ATV Offroad Fury 2"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    bilinearUpscale: 2 # Fixes broken textures.
 SCUS-97212:
   name: "My Street"
   region: "NTSC-U"
@@ -10523,6 +10525,8 @@ SCUS-97236:
 SCUS-97238:
   name: "ATV Offroad Fury 2 [Demo]"
   region: "NTSC-U"
+  gsHWFixes:
+    bilinearUpscale: 2 # Fixes broken textures.
 SCUS-97239:
   name: "Jet X2O [Demo]"
   region: "NTSC-U"
@@ -10929,6 +10933,8 @@ SCUS-97369:
   name: "ATV Offroad Fury 2"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    bilinearUpscale: 2 # Fixes broken textures.
 SCUS-97370:
   name: "NCAA Final Four 2004"
   region: "NTSC-U"
@@ -11571,6 +11577,8 @@ SCUS-97509:
 SCUS-97510:
   name: "ATV Offroad Fury 2 [Greatest Hits]"
   region: "NTSC-U"
+  gsHWFixes:
+    bilinearUpscale: 2 # Fixes broken textures.
 SCUS-97511:
   name: "SOCOM II - U.S. Navy SEALs [Greatest Hits]"
   region: "NTSC-U"
@@ -17359,6 +17367,8 @@ SLES-51813:
 SLES-51814:
   name: "ATV Offroad Fury 2"
   region: "PAL-E"
+  gsHWFixes:
+    bilinearUpscale: 2 # Fixes broken textures.
 SLES-51815:
   name: "Final Fantasy X-2"
   region: "PAL-E"
@@ -67117,6 +67127,8 @@ SLUS-21638:
   compat: 5
   clampModes:
     vuClampMode: 3 # Missing geometry with microVU.
+  memcardFilters:
+    - "SLUS-21620"
 SLUS-21639:
   name: "NASCAR 08"
   region: "NTSC-U"

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -6305,16 +6305,17 @@ void GSTextureCache::Target::Update(bool cannot_scale)
 				m_rt_alpha_scale = true;
 		}
 
-		ShaderConvert depth_shader = upscaled ? ShaderConvert::RGBA8_TO_FLOAT32_BILN : ShaderConvert::RGBA8_TO_FLOAT32;
+		const bool linear = upscaled && GSConfig.UserHacks_BilinearHack != GSBilinearDirtyMode::ForceNearest;
+		ShaderConvert depth_shader = linear ? ShaderConvert::RGBA8_TO_FLOAT32_BILN : ShaderConvert::RGBA8_TO_FLOAT32;
 		if (m_type == DepthStencil && GSLocalMemory::m_psm[m_TEX0.PSM].trbpp != 32)
 		{
 			switch (GSLocalMemory::m_psm[m_TEX0.PSM].trbpp)
 			{
 				case 24:
-					depth_shader = upscaled ? ShaderConvert::RGBA8_TO_FLOAT24_BILN : ShaderConvert::RGBA8_TO_FLOAT24;
+					depth_shader = linear ? ShaderConvert::RGBA8_TO_FLOAT24_BILN : ShaderConvert::RGBA8_TO_FLOAT24;
 					break;
 				case 16:
-					depth_shader = upscaled ? ShaderConvert::RGB5A1_TO_FLOAT16_BILN : ShaderConvert::RGB5A1_TO_FLOAT16;
+					depth_shader = linear ? ShaderConvert::RGB5A1_TO_FLOAT16_BILN : ShaderConvert::RGB5A1_TO_FLOAT16;
 					break;
 				default:
 					break;


### PR DESCRIPTION
### Description of Changes
Extends the bilinear upscale fix to cover dirty depth this fixes the broken textures in ATV Offroad Fury 2 when upscaling.
Fixes #7611 

Before:
![image](https://github.com/user-attachments/assets/b902a66a-3b2e-491a-adfc-9a80523184cf)

After:
![image](https://github.com/user-attachments/assets/5c5a71df-64e2-42b9-813c-3179b3d74886)

### Rationale behind Changes
Broken textures bad.

### Suggested Testing Steps
Make sure games that already use Bilinear Upscale Nearest in the db still work correctly.
