### PR TITLE
CI/Appimage: Use fuse3 compatible appimagetool

### DIFF
--- a/.github/workflows/linux_build_qt.yml
+++ b/.github/workflows/linux_build_qt.yml
@@ -58,14 +58,6 @@ jobs:
       CCACHE_MAXSIZE: 100M
 
     steps:
-      # Work around https://github.com/actions/runner-images/issues/8659
-      - name: Remove GCC 13 from runner image
-        shell: bash
-        run: |
-          sudo rm -f /etc/apt/sources.list.d/ubuntu-toolchain-r-ubuntu-test-jammy.list
-          sudo apt-get update
-          sudo apt-get install -y --allow-downgrades 'libc6=2.35-0ubuntu*' 'libc6-dev=2.35-0ubuntu*' libstdc++6=12.3.0-1ubuntu1~22.04 libgcc-s1=12.3.0-1ubuntu1~22.04
-
       - name: Checkout Repository
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/linux_build_qt.yml
+++ b/.github/workflows/linux_build_qt.yml
@@ -68,6 +68,8 @@ jobs:
 
       - name: Checkout Repository
         uses: actions/checkout@v4
+        with:
+           fetch-depth: 0
 
       # actions/checkout elides tags, fetch them primarily for releases
       - name: Fetch Tags

--- a/.github/workflows/scripts/linux/appimage-qt.sh
+++ b/.github/workflows/scripts/linux/appimage-qt.sh
@@ -63,9 +63,9 @@ declare -a REMOVE_LIBS=(
 
 set -e
 
-LINUXDEPLOY=./linuxdeploy-x86_64.AppImage
-LINUXDEPLOY_PLUGIN_QT=./linuxdeploy-plugin-qt-x86_64.AppImage
-APPIMAGETOOL=./appimagetool-x86_64.AppImage
+LINUXDEPLOY=./linuxdeploy-x86_64
+LINUXDEPLOY_PLUGIN_QT=./linuxdeploy-plugin-qt-x86_64
+APPIMAGETOOL=./appimagetool-x86_64
 PATCHELF=patchelf
 
 if [ ! -f "$LINUXDEPLOY" ]; then
@@ -78,8 +78,11 @@ if [ ! -f "$LINUXDEPLOY_PLUGIN_QT" ]; then
 	chmod +x "$LINUXDEPLOY_PLUGIN_QT"
 fi
 
+# Using go-appimage
+# Backported from https://github.com/stenzek/duckstation/pull/3251
 if [ ! -f "$APPIMAGETOOL" ]; then
-	"$PCSX2DIR/tools/retry.sh" wget -O "$APPIMAGETOOL" https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage
+	APPIMAGETOOLURL=$(wget -q https://api.github.com/repos/probonopd/go-appimage/releases -O - | sed 's/[()",{} ]/\n/g' | grep -o 'https.*continuous.*tool.*86_64.*mage$' | head -1)
+	"$PCSX2DIR/tools/retry.sh" wget -O "$APPIMAGETOOL" "$APPIMAGETOOLURL"
 	chmod +x "$APPIMAGETOOL"
 fi
 
@@ -199,6 +202,16 @@ for hookpath in "$SCRIPTDIR/apprun-hooks"/*; do
 done
 
 echo "Generating AppImage..."
+GIT_VERSION=$(git tag --points-at HEAD)
+
+if [[ "${GIT_VERSION}" == "" ]]; then
+	# In the odd event that we run this script before the release gets tagged.
+	GIT_VERSION=$(git describe --tags)
+	if [[ "${GIT_VERSION}" == "" ]]; then
+		GIT_VERSION=$(git rev-parse HEAD)
+	fi
+fi
+
 rm -f "$NAME.AppImage"
-$APPIMAGETOOL -v "$OUTDIR" "$NAME.AppImage"
+ARCH=x86_64 VERSION="${GIT_VERSION}" "$APPIMAGETOOL" -s "$OUTDIR" && mv ./*.AppImage "$NAME.AppImage"
 

--- a/.github/workflows/scripts/linux/pcsx2-qt.metainfo.xml.in
+++ b/.github/workflows/scripts/linux/pcsx2-qt.metainfo.xml.in
@@ -18,14 +18,23 @@
   <url type="faq">https://pcsx2.net/docs/</url>
   <url type="help">https://pcsx2.net/discord</url>
   <url type="translate">https://crowdin.com/project/pcsx2-emulator</url>
-  <url type="vcs-browser">https://github.com/PCSX2/pcsx2</url>
   <url type="contact">https://mastodon.social/@PCSX2</url>
   <screenshots>
     <screenshot type="default">
-      <image>https://raw.githubusercontent.com/PCSX2/pcsx2/master/.github/workflows/scripts/linux/flatpak/screenshots/screenshot1.png</image>
+      <image>
+        https://raw.githubusercontent.com/PCSX2/pcsx2/master/.github/workflows/scripts/linux/flatpak/screenshots/screenshot1.png
+      </image>
+      <caption>
+        The main PCSX2 Qt interface
+      </caption>
     </screenshot>
     <screenshot>
-      <image>https://raw.githubusercontent.com/PCSX2/pcsx2/master/.github/workflows/scripts/linux/flatpak/screenshots/screenshot2.png</image>
+      <image>
+        https://raw.githubusercontent.com/PCSX2/pcsx2/master/.github/workflows/scripts/linux/flatpak/screenshots/screenshot2.png
+      </image>
+      <caption>
+        PCSX2 running a game
+      </caption>
     </screenshot>
   </screenshots>
   <content_rating type="oars-1.1"/>


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Backported from: https://github.com/stenzek/duckstation/pull/3251
This solves the common problem of the appimage needing libfuse2 to function.  

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Better compatibility with newer distros.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test if the build succeeded and the appimage works.