### PR TITLE
Add memcardFilter for SLES-51953 and SLES-52022

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -17807,6 +17807,9 @@ SLES-51953:
   region: "PAL-M4"
   clampModes:
     vuClampMode: 2 # Missing geometry with microVU.
+  memcardFilters: # Football Fusion with Total Club Manager 2004
+    - "SLES-52022"
+    - "SLES-59153"
 SLES-51954:
   name: "Max Payne 2 - The Fall of Max Payne"
   region: "PAL-E"
@@ -17986,6 +17989,9 @@ SLES-52022:
   region: "PAL-M4"
   clampModes:
     vu1ClampMode: 3 # Fixes 3D rendering.
+  memcardFilters: # Football Fusion with FIFA 2004
+    - "SLES-52022"
+    - "SLES-51953"
 SLES-52023:
   name: "Manhunt"
   region: "PAL-M5"


### PR DESCRIPTION
### Description of Changes
Enables use of the Football Fusion cross-play feature in FIFA 2004 and Total Club Manager 2004 with FolderMCs.

### Rationale behind Changes
Allows FolderMC users to use this (admittedly niche) feature.

### Suggested Testing Steps
1. Start a new career of TCM 2004.
2. Get to the first friendly match.
3. Export to Football Fusion.
4. Switch game to FIFA 2004.
5. Use Football Fusion to play the match.
6. Export back to TCM 2004.
7. Load the Fusion back in.
8. Progress should have been saved.