### PR TITLE
fix heap-buffer-overflow in `recompileNextInstruction`

### DIFF
--- a/pcsx2/x86/ix86-32/iR5900.cpp
+++ b/pcsx2/x86/ix86-32/iR5900.cpp
@@ -1707,7 +1707,7 @@ void recompileNextInstruction(bool delayslot, bool swapped_delay_slot)
 	g_pCurInstInfo++;
 
 	// pc might be past s_nEndBlock if the last instruction in the block is a DI.
-	if (pc <= s_nEndBlock)
+	if (pc <= s_nEndBlock && (g_pCurInstInfo + (s_nEndBlock - pc) / 4 + 1) <= s_pInstCache + s_nInstCacheSize)
 	{
 		int count;
 		for (u32 i = 0; i < iREGCNT_GPR; ++i)


### PR DESCRIPTION
### Description of Changes
Fixed a heap-buffer-overflow in `recompileNextInstruction`.

### Rationale behind Changes
Fixes a heap-buffer-overflow found by ASAN.

```
00000001	23:44:41	[7340] =================================================================	
00000002	23:44:41	[7340] ==7340==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x119da91652c7 at pc 0x7ff6cd94ce59 bp 0x0023e8bfe870 sp 0x0023e8bfe8b8	
00000003	23:44:41	[7340] READ of size 1 at 0x119da91652c7 thread T1	
00000004	23:44:41	[7340]     #0 0x7ff6cd94ce58 in _recIsRegReadOrWritten(EEINST*, int, unsigned char, unsigned char) C:/src/pcsx2/pcsx2/x86/iCore.cpp:911:9	
00000005	23:44:41	[7340]     #1 0x7ff6cd1a951f in recompileNextInstruction(bool, bool) C:/src/pcsx2/pcsx2/x86/ix86-32/iR5900.cpp:1717:13	
00000006	23:44:41	[7340]     #2 0x7ff6cdc9ab9c in R5900::Dynarec::OpcodeImpl::recBNE_const() C:/src/pcsx2/pcsx2/x86/ix86-32/iR5900Branch.cpp:190:2	
00000007	23:44:41	[7340]     #3 0x7ff6cdc9ab9c in R5900::Dynarec::OpcodeImpl::recBNE() C:/src/pcsx2/pcsx2/x86/ix86-32/iR5900Branch.cpp:233:3	
00000008	23:44:41	[7340]     #4 0x7ff6cd1a929d in recompileNextInstruction(bool, bool) C:/src/pcsx2/pcsx2/x86/ix86-32/iR5900.cpp:1821:3	
00000009	23:44:41	[7340]     #5 0x7ff6cd1b03aa in recRecompile(unsigned int) C:/src/pcsx2/pcsx2/x86/ix86-32/iR5900.cpp:2629:4	
00000010	23:44:41	[7340]     #6 0x7ff709b0002a  (<unknown module>)	
00000011	23:44:41	[7340] 	
00000012	23:44:41	[7340] 0x119da91652c7 is located 119 bytes after 24656-byte region [0x119da915f200,0x119da9165250)	
00000013	23:44:41	[7340] allocated by thread T1 here:	
00000014	23:44:41	[7340]     #0 0x7ffcb0d84fb1 in malloc (C:\msys64\clang64\bin\libclang_rt.asan_dynamic-x86_64.dll+0x180044fb1)	
00000015	23:44:41	[7340]     #1 0x7ff6cd1af3d8 in recRecompile(unsigned int) C:/src/pcsx2/pcsx2/x86/ix86-32/iR5900.cpp:2542:28	
00000016	23:44:41	[7340]     #2 0x7ff709b0002a  (<unknown module>)	
00000017	23:44:41	[7340] 	
00000018	23:44:41	[7340] Thread T1 created by T0 here:	
00000019	23:44:41	[7340]     #0 0x7ffcb0d94536 in CreateThread (C:\msys64\clang64\bin\libclang_rt.asan_dynamic-x86_64.dll+0x180054536)	
00000020	23:44:41	[7340]     #1 0x7ffcb8327e6c in QThread::start(QThread::Priority) (C:\msys64\clang64\bin\Qt6Core.dll+0x180237e6c)	
00000021	23:44:41	[7340]     #2 0x7ff6cc77550e in EmuThread::start() C:/src/pcsx2/pcsx2-qt/QtHost.cpp:115:25	
00000022	23:44:41	[7340]     #3 0x7ff6cc7913d2 in qMain(int, char**) C:/src/pcsx2/pcsx2-qt/QtHost.cpp:2329:2	
00000023	23:44:41	[7340]     #4 0x7ff6cce8be07 in main C:/M/B/src/mingw-w64/mingw-w64-crt/crt/crtexewin.c:67:10	
00000024	23:44:41	[7340]     #5 0x7ff6cc6a1310 in __tmainCRTStartup C:/M/B/src/mingw-w64/mingw-w64-crt/crt/crtexe.c:267:15	
00000025	23:44:41	[7340]     #6 0x7ff6cc6a1155 in .l_startw C:/M/B/src/mingw-w64/mingw-w64-crt/crt/crtexe.c:157:9	
00000026	23:44:41	[7340]     #7 0x7ffd2e937373  (C:\WINDOWS\System32\KERNEL32.DLL+0x180017373)	
00000027	23:44:41	[7340]     #8 0x7ffd2f15cc90  (C:\WINDOWS\SYSTEM32\ntdll.dll+0x18004cc90)	
00000028	23:44:41	[7340] 	
00000029	23:44:41	[7340] SUMMARY: AddressSanitizer: heap-buffer-overflow C:/src/pcsx2/pcsx2/x86/iCore.cpp:911:9 in _recIsRegReadOrWritten(EEINST*, int, unsigned char, unsigned char)	
00000030	23:44:41	[7340] Shadow bytes around the buggy address:	
00000031	23:44:41	[7340]   0x119da9165000: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00	
00000032	23:44:41	[7340]   0x119da9165080: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00	
00000033	23:44:41	[7340]   0x119da9165100: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00	
00000034	23:44:41	[7340]   0x119da9165180: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00	
00000035	23:44:41	[7340]   0x119da9165200: 00 00 00 00 00 00 00 00 00 00 fa fa fa fa fa fa	
00000036	23:44:41	[7340] =>0x119da9165280: fa fa fa fa fa fa fa fa[fa]fa fa fa fa fa fa fa	
00000037	23:44:41	[7340]   0x119da9165300: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa	
00000038	23:44:41	[7340]   0x119da9165380: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa	
00000039	23:44:41	[7340]   0x119da9165400: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa	
00000040	23:44:41	[7340]   0x119da9165480: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa	
00000041	23:44:41	[7340]   0x119da9165500: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa	
00000042	23:44:41	[7340] Shadow byte legend (one shadow byte represents 8 application bytes):	
00000043	23:44:41	[7340]   Addressable:           00	
00000044	23:44:41	[7340]   Partially addressable: 01 02 03 04 05 06 07 	
00000045	23:44:41	[7340]   Heap left redzone:       fa	
00000046	23:44:41	[7340]   Freed heap region:       fd	
00000047	23:44:41	[7340]   Stack left redzone:      f1	
00000048	23:44:41	[7340]   Stack mid redzone:       f2	
00000049	23:44:41	[7340]   Stack right redzone:     f3	
00000050	23:44:41	[7340]   Stack after return:      f5	
00000051	23:44:41	[7340]   Stack use after scope:   f8	
00000052	23:44:41	[7340]   Global redzone:          f9	
00000053	23:44:41	[7340]   Global init order:       f6	
00000054	23:44:41	[7340]   Poisoned by user:        f7	
00000055	23:44:41	[7340]   Container overflow:      fc	
00000056	23:44:41	[7340]   Array cookie:            ac	
00000057	23:44:41	[7340]   Intra object redzone:    bb	
00000058	23:44:41	[7340]   ASan internal:           fe	
00000059	23:44:41	[7340]   Left alloca redzone:     ca	
00000060	23:44:41	[7340]   Right alloca redzone:    cb	
00000061	23:44:41	[7340] ==7340==ABORTING	
```