### PR TITLE
GS: Match data types in shaders to be the same when doing bitwise operations.

### DIFF
--- a/bin/resources/shaders/dx11/tfx.fx
+++ b/bin/resources/shaders/dx11/tfx.fx
@@ -772,17 +772,17 @@ float4 ps_color(PS_INPUT input)
 		uint4 denorm_c_before = uint4(T);
 		if (PS_PROCESS_BA & SHUFFLE_READ)
 		{
-			T.r = float((denorm_c_before.b << 3) & 0xF8);
-			T.g = float(((denorm_c_before.b >> 2) & 0x38) | ((denorm_c_before.a << 6) & 0xC0));
-			T.b = float((denorm_c_before.a << 1) & 0xF8);
-			T.a = float(denorm_c_before.a & 0x80);
+			T.r = float((denorm_c_before.b << 3) & 0xF8u);
+			T.g = float(((denorm_c_before.b >> 2) & 0x38u) | ((denorm_c_before.a << 6) & 0xC0u));
+			T.b = float((denorm_c_before.a << 1) & 0xF8u);
+			T.a = float(denorm_c_before.a & 0x80u);
 		}
 		else
 		{
-			T.r = float((denorm_c_before.r << 3) & 0xF8);
-			T.g = float(((denorm_c_before.r >> 2) & 0x38) | ((denorm_c_before.g << 6) & 0xC0));
-			T.b = float((denorm_c_before.g << 1) & 0xF8);
-			T.a = float(denorm_c_before.g & 0x80);
+			T.r = float((denorm_c_before.r << 3) & 0xF8u);
+			T.g = float(((denorm_c_before.r >> 2) & 0x38u) | ((denorm_c_before.g << 6) & 0xC0u));
+			T.b = float((denorm_c_before.g << 1) & 0xF8u);
+			T.a = float(denorm_c_before.g & 0x80u);
 		}
 		
 		T.a = (T.a >= 127.5f ? TA.y : !PS_AEM || any(int3(T.rgb) & 0xF8) ? TA.x : 0) * 255.0f;
@@ -874,17 +874,17 @@ void ps_blend(inout float4 Color, inout float4 As_rgba, float2 pos_xy)
 			uint4 denorm_rt = uint4(RT);
 			if (PS_PROCESS_BA & SHUFFLE_WRITE)
 			{
-				RT.r = float((denorm_rt.b << 3) & 0xF8);
-				RT.g = float(((denorm_rt.b >> 2) & 0x38) | ((denorm_rt.a << 6) & 0xC0));
-				RT.b = float((denorm_rt.a << 1) & 0xF8);
-				RT.a = float(denorm_rt.a & 0x80);
+				RT.r = float((denorm_rt.b << 3) & 0xF8u);
+				RT.g = float(((denorm_rt.b >> 2) & 0x38u) | ((denorm_rt.a << 6) & 0xC0u));
+				RT.b = float((denorm_rt.a << 1) & 0xF8u);
+				RT.a = float(denorm_rt.a & 0x80u);
 			}
 			else
 			{
-				RT.r = float((denorm_rt.r << 3) & 0xF8);
-				RT.g = float(((denorm_rt.r >> 2) & 0x38) | ((denorm_rt.g << 6) & 0xC0));
-				RT.b = float((denorm_rt.g << 1) & 0xF8);
-				RT.a = float(denorm_rt.g & 0x80);
+				RT.r = float((denorm_rt.r << 3) & 0xF8u);
+				RT.g = float(((denorm_rt.r >> 2) & 0x38u) | ((denorm_rt.g << 6) & 0xC0u));
+				RT.b = float((denorm_rt.g << 1) & 0xF8u);
+				RT.a = float(denorm_rt.g & 0x80u);
 			}
 		}
 		
@@ -1067,13 +1067,13 @@ PS_OUTPUT ps_main(PS_INPUT input)
 			uint4 denorm_c_after = uint4(C);
 			if (PS_PROCESS_BA & SHUFFLE_READ)
 			{
-				C.b = float(((denorm_c_after.r >> 3) & 0x1F) | ((denorm_c_after.g << 2) & 0xE0));
-				C.a = float(((denorm_c_after.g >> 6) & 0x3) | ((denorm_c_after.b >> 1) & 0x7C) | (denorm_c_after.a & 0x80));
+				C.b = float(((denorm_c_after.r >> 3) & 0x1Fu) | ((denorm_c_after.g << 2) & 0xE0u));
+				C.a = float(((denorm_c_after.g >> 6) & 0x3u) | ((denorm_c_after.b >> 1) & 0x7Cu) | (denorm_c_after.a & 0x80u));
 			}
 			else
 			{
-				C.r = float(((denorm_c_after.r >> 3) & 0x1F) | ((denorm_c_after.g << 2) & 0xE0));
-				C.g = float(((denorm_c_after.g >> 6) & 0x3) | ((denorm_c_after.b >> 1) & 0x7C) | (denorm_c_after.a & 0x80));
+				C.r = float(((denorm_c_after.r >> 3) & 0x1Fu) | ((denorm_c_after.g << 2) & 0xE0u));
+				C.g = float(((denorm_c_after.g >> 6) & 0x3u) | ((denorm_c_after.b >> 1) & 0x7Cu) | (denorm_c_after.a & 0x80u));
 			}
 		}
 

--- a/bin/resources/shaders/opengl/tfx_fs.glsl
+++ b/bin/resources/shaders/opengl/tfx_fs.glsl
@@ -681,15 +681,15 @@ vec4 ps_color()
 	#if PS_SHUFFLE && !PS_READ16_SRC && !PS_SHUFFLE_SAME
 		uvec4 denorm_c_before = uvec4(T);
 		#if (PS_PROCESS_BA & SHUFFLE_READ)
-			T.r = float((denorm_c_before.b << 3) & 0xF8);
-			T.g = float(((denorm_c_before.b >> 2) & 0x38) | ((denorm_c_before.a << 6) & 0xC0));
-			T.b = float((denorm_c_before.a << 1) & 0xF8);
-			T.a = float(denorm_c_before.a & 0x80);
+			T.r = float((denorm_c_before.b << 3) & 0xF8u);
+			T.g = float(((denorm_c_before.b >> 2) & 0x38u) | ((denorm_c_before.a << 6) & 0xC0u));
+			T.b = float((denorm_c_before.a << 1) & 0xF8u);
+			T.a = float(denorm_c_before.a & 0x80u);
 		#else
-			T.r = float((denorm_c_before.r << 3) & 0xF8);
-			T.g = float(((denorm_c_before.r >> 2) & 0x38) | ((denorm_c_before.g << 6) & 0xC0));
-			T.b = float((denorm_c_before.g << 1) & 0xF8);
-			T.a = float(denorm_c_before.g & 0x80);
+			T.r = float((denorm_c_before.r << 3) & 0xF8u);
+			T.g = float(((denorm_c_before.r >> 2) & 0x38u) | ((denorm_c_before.g << 6) & 0xC0u));
+			T.b = float((denorm_c_before.g << 1) & 0xF8u);
+			T.a = float(denorm_c_before.g & 0x80u);
 		#endif
 		
 		T.a = ((T.a >= 127.5f) ? TA.y : ((PS_AEM == 0 || any(bvec3(ivec3(T.rgb) & ivec3(0xF8)))) ? TA.x : 0.0f)) * 255.0f;
@@ -804,15 +804,15 @@ float As = As_rgba.a;
 	#if PS_SHUFFLE && SW_BLEND_NEEDS_RT
 		uvec4 denorm_rt = uvec4(RT);
 		#if (PS_PROCESS_BA & SHUFFLE_WRITE)
-			RT.r = float((denorm_rt.b << 3) & 0xF8);
-			RT.g = float(((denorm_rt.b >> 2) & 0x38) | ((denorm_rt.a << 6) & 0xC0));
-			RT.b = float((denorm_rt.a << 1) & 0xF8);
-			RT.a = float(denorm_rt.a & 0x80);
+			RT.r = float((denorm_rt.b << 3) & 0xF8u);
+			RT.g = float(((denorm_rt.b >> 2) & 0x38u) | ((denorm_rt.a << 6) & 0xC0u));
+			RT.b = float((denorm_rt.a << 1) & 0xF8u);
+			RT.a = float(denorm_rt.a & 0x80u);
 		#else
-			RT.r = float((denorm_rt.r << 3) & 0xF8);
-			RT.g = float(((denorm_rt.r >> 2) & 0x38) | ((denorm_rt.g << 6) & 0xC0));
-			RT.b = float((denorm_rt.g << 1) & 0xF8);
-			RT.a = float(denorm_rt.g & 0x80);
+			RT.r = float((denorm_rt.r << 3) & 0xF8u);
+			RT.g = float(((denorm_rt.r >> 2) & 0x38u) | ((denorm_rt.g << 6) & 0xC0u));
+			RT.b = float((denorm_rt.g << 1) & 0xF8u);
+			RT.a = float(denorm_rt.g & 0x80u);
 		#endif
 	#endif
 		
@@ -1046,11 +1046,11 @@ void ps_main()
 	#if !PS_READ16_SRC && !PS_SHUFFLE_SAME
 		uvec4 denorm_c_after = uvec4(C);
 		#if (PS_PROCESS_BA & SHUFFLE_READ)
-			C.b = float(((denorm_c_after.r >> 3) & 0x1F) | ((denorm_c_after.g << 2) & 0xE0));
-			C.a = float(((denorm_c_after.g >> 6) & 0x3) | ((denorm_c_after.b >> 1) & 0x7C) | (denorm_c_after.a & 0x80));
+			C.b = float(((denorm_c_after.r >> 3) & 0x1Fu) | ((denorm_c_after.g << 2) & 0xE0u));
+			C.a = float(((denorm_c_after.g >> 6) & 0x3u) | ((denorm_c_after.b >> 1) & 0x7Cu) | (denorm_c_after.a & 0x80u));
 		#else
-			C.r = float(((denorm_c_after.r >> 3) & 0x1F) | ((denorm_c_after.g << 2) & 0xE0));
-			C.g = float(((denorm_c_after.g >> 6) & 0x3) | ((denorm_c_after.b >> 1) & 0x7C) | (denorm_c_after.a & 0x80));
+			C.r = float(((denorm_c_after.r >> 3) & 0x1Fu) | ((denorm_c_after.g << 2) & 0xE0u));
+			C.g = float(((denorm_c_after.g >> 6) & 0x3u) | ((denorm_c_after.b >> 1) & 0x7Cu) | (denorm_c_after.a & 0x80u));
 		#endif
 	#endif
 

--- a/bin/resources/shaders/vulkan/tfx.glsl
+++ b/bin/resources/shaders/vulkan/tfx.glsl
@@ -948,15 +948,15 @@ vec4 ps_color()
 	#if PS_SHUFFLE && !PS_READ16_SRC && !PS_SHUFFLE_SAME
 		uvec4 denorm_c_before = uvec4(T);
 		#if (PS_PROCESS_BA & SHUFFLE_READ)
-			T.r = float((denorm_c_before.b << 3) & 0xF8);
-			T.g = float(((denorm_c_before.b >> 2) & 0x38) | ((denorm_c_before.a << 6) & 0xC0));
-			T.b = float((denorm_c_before.a << 1) & 0xF8);
-			T.a = float(denorm_c_before.a & 0x80);
+			T.r = float((denorm_c_before.b << 3) & 0xF8u);
+			T.g = float(((denorm_c_before.b >> 2) & 0x38u) | ((denorm_c_before.a << 6) & 0xC0u));
+			T.b = float((denorm_c_before.a << 1) & 0xF8u);
+			T.a = float(denorm_c_before.a & 0x80u);
 		#else
-			T.r = float((denorm_c_before.r << 3) & 0xF8);
-			T.g = float(((denorm_c_before.r >> 2) & 0x38) | ((denorm_c_before.g << 6) & 0xC0));
-			T.b = float((denorm_c_before.g << 1) & 0xF8);
-			T.a = float(denorm_c_before.g & 0x80);
+			T.r = float((denorm_c_before.r << 3) & 0xF8u);
+			T.g = float(((denorm_c_before.r >> 2) & 0x38) | ((denorm_c_before.g << 6) & 0xC0u));
+			T.b = float((denorm_c_before.g << 1) & 0xF8u);
+			T.a = float(denorm_c_before.g & 0x80u);
 		#endif
 		
 		T.a = ((T.a >= 127.5f) ? TA.y : ((PS_AEM == 0 || any(bvec3(ivec3(T.rgb) & ivec3(0xF8)))) ? TA.x : 0.0f)) * 255.0f;
@@ -1071,15 +1071,15 @@ void ps_blend(inout vec4 Color, inout vec4 As_rgba)
 		#if PS_SHUFFLE && PS_FEEDBACK_LOOP_IS_NEEDED
 			uvec4 denorm_rt = uvec4(RT);
 			#if (PS_PROCESS_BA & SHUFFLE_WRITE)
-				RT.r = float((denorm_rt.b << 3) & 0xF8);
-				RT.g = float(((denorm_rt.b >> 2) & 0x38) | ((denorm_rt.a << 6) & 0xC0));
-				RT.b = float((denorm_rt.a << 1) & 0xF8);
-				RT.a = float(denorm_rt.a & 0x80);
+				RT.r = float((denorm_rt.b << 3) & 0xF8u);
+				RT.g = float(((denorm_rt.b >> 2) & 0x38u) | ((denorm_rt.a << 6) & 0xC0u));
+				RT.b = float((denorm_rt.a << 1) & 0xF8u);
+				RT.a = float(denorm_rt.a & 0x80u);
 			#else
-				RT.r = float((denorm_rt.r << 3) & 0xF8);
-				RT.g = float(((denorm_rt.r >> 2) & 0x38) | ((denorm_rt.g << 6) & 0xC0));
-				RT.b = float((denorm_rt.g << 1) & 0xF8);
-				RT.a = float(denorm_rt.g & 0x80);
+				RT.r = float((denorm_rt.r << 3) & 0xF8u);
+				RT.g = float(((denorm_rt.r >> 2) & 0x38u) | ((denorm_rt.g << 6) & 0xC0u));
+				RT.b = float((denorm_rt.g << 1) & 0xF8u);
+				RT.a = float(denorm_rt.g & 0x80u);
 			#endif
 		#endif
 
@@ -1312,11 +1312,11 @@ void main()
 		#if !PS_READ16_SRC && !PS_SHUFFLE_SAME
 			uvec4 denorm_c_after = uvec4(C);
 			#if (PS_PROCESS_BA & SHUFFLE_READ)
-				C.b = float(((denorm_c_after.r >> 3) & 0x1F) | ((denorm_c_after.g << 2) & 0xE0));
-				C.a = float(((denorm_c_after.g >> 6) & 0x3) | ((denorm_c_after.b >> 1) & 0x7C) | (denorm_c_after.a & 0x80));
+				C.b = float(((denorm_c_after.r >> 3) & 0x1Fu) | ((denorm_c_after.g << 2) & 0xE0u));
+				C.a = float(((denorm_c_after.g >> 6) & 0x3u) | ((denorm_c_after.b >> 1) & 0x7Cu) | (denorm_c_after.a & 0x80u));
 			#else
-				C.r = float(((denorm_c_after.r >> 3) & 0x1F) | ((denorm_c_after.g << 2) & 0xE0));
-				C.g = float(((denorm_c_after.g >> 6) & 0x3) | ((denorm_c_after.b >> 1) & 0x7C) | (denorm_c_after.a & 0x80));
+				C.r = float(((denorm_c_after.r >> 3) & 0x1Fu) | ((denorm_c_after.g << 2) & 0xE0u));
+				C.g = float(((denorm_c_after.g >> 6) & 0x3u) | ((denorm_c_after.b >> 1) & 0x7Cu) | (denorm_c_after.a & 0x80u));
 			#endif
 		#endif
 

--- a/pcsx2/ShaderCacheVersion.h
+++ b/pcsx2/ShaderCacheVersion.h
@@ -3,4 +3,4 @@
 
 /// Version number for GS and other shaders. Increment whenever any of the contents of the
 /// shaders change, to invalidate the cache.
-static constexpr u32 SHADER_CACHE_VERSION = 54;
+static constexpr u32 SHADER_CACHE_VERSION = 55;


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS: Match data types to be the same in shaders.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Fixes shader warnings on gl on linux, mesa, or windows using mesa gl drivers.
Also changed dx and vk for consistency.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test GOW on OpenGL, see if the warnings are fixed using mesa drivers on linux/windows.
