### PR TITLE
Config: Use directory containing bundle as AppRoot on macOS.

### DIFF
--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2002-2024 PCSX2 Dev Team
 // SPDX-License-Identifier: GPL-3.0+
 
+#include "common/CocoaTools.h"
 #include "common/FileSystem.h"
 #include "common/Path.h"
 #include "common/SettingsInterface.h"
@@ -1859,7 +1860,15 @@ void Pcsx2Config::ClearInvalidPerGameConfiguration(SettingsInterface* si)
 
 void EmuFolders::SetAppRoot()
 {
-	const std::string program_path = FileSystem::GetProgramPath();
+	std::string program_path = FileSystem::GetProgramPath();
+#ifdef __APPLE__
+	const auto bundle_path = CocoaTools::GetNonTranslocatedBundlePath();
+	if (bundle_path.has_value())
+	{
+		// On macOS, override with the bundle path if launched from a bundle.
+		program_path = bundle_path.value();
+	}
+#endif
 	Console.WriteLnFmt("Program Path: {}", program_path);
 
 	AppRoot = Path::Canonicalize(Path::GetDirectory(program_path));
@@ -1875,7 +1884,8 @@ bool EmuFolders::SetResourcesDirectory()
 	Resources = Path::Combine(AppRoot, "resources");
 #else
 	// On macOS, this is in the bundle resources directory.
-	Resources = Path::Canonicalize(Path::Combine(AppRoot, "../Resources"));
+	const std::string program_path = FileSystem::GetProgramPath();
+	Resources = Path::Canonicalize(Path::Combine(Path::GetDirectory(program_path), "../Resources"));
 #endif
 
 	Console.WriteLnFmt("Resources Directory: {}", Resources);


### PR DESCRIPTION
### Description of Changes
Updates the macOS version to use the directory containing the bundle as the AppRoot, instead of the directory of the executable file.

### Rationale behind Changes
Currently portable mode does not work properly on macOS; you must put the `portable.ini`/`portable.txt` and all of the user data inside of the app bundle instead of next to it. This is a problem as it breaks app bundle integrity, and if the user replaces the app bundle, e.g. for an update, all of their data could be lost.

### Suggested Testing Steps
I've tested the emulator both without portable mode and with a `portable.txt` next to the app bundle, in both cases the user data is placed in the expected location.
