### PR TITLE
USB: Set actual_length value for Get HID descriptor

### DIFF
--- a/pcsx2/USB/usb-pad/usb-buzz.cpp
+++ b/pcsx2/USB/usb-pad/usb-buzz.cpp
@@ -133,7 +133,8 @@ namespace usb_pad
 				{
 					case USB_DT_REPORT:
 						ret = sizeof(hid_report_descriptor);
-						memcpy(data, hid_report_descriptor, ret);
+						std::memcpy(data, hid_report_descriptor, ret);
+						p->actual_length = ret;
 						break;
 				}
 				break;

--- a/pcsx2/USB/usb-pad/usb-gametrak.cpp
+++ b/pcsx2/USB/usb-pad/usb-gametrak.cpp
@@ -166,7 +166,8 @@ namespace usb_pad
 				{
 					case USB_DT_REPORT:
 						ret = sizeof(hid_report_descriptor);
-						memcpy(data, hid_report_descriptor, ret);
+						std::memcpy(data, hid_report_descriptor, ret);
+						p->actual_length = ret;
 						break;
 				}
 				break;

--- a/pcsx2/USB/usb-pad/usb-realplay.cpp
+++ b/pcsx2/USB/usb-pad/usb-realplay.cpp
@@ -216,7 +216,8 @@ namespace usb_pad
 				{
 					case USB_DT_REPORT:
 						ret = sizeof(hid_report_descriptor);
-						memcpy(data, hid_report_descriptor, ret);
+						std::memcpy(data, hid_report_descriptor, ret);
+						p->actual_length = ret;
 						break;
 				}
 				break;

--- a/pcsx2/USB/usb-pad/usb-seamic.cpp
+++ b/pcsx2/USB/usb-pad/usb-seamic.cpp
@@ -296,7 +296,7 @@ namespace usb_pad
 				{
 					case USB_DT_REPORT:
 						ret = sizeof(hid_report_descriptor);
-						memcpy(data, hid_report_descriptor, ret);
+						std::memcpy(data, hid_report_descriptor, ret);
 						p->actual_length = ret;
 						break;
 					default:
@@ -308,7 +308,6 @@ namespace usb_pad
 				if (length > 0)
 				{
 					p->actual_length = 0;
-					//p->status = USB_RET_SUCCESS;
 				}
 				break;
 			case SET_IDLE:


### PR DESCRIPTION
### Description of Changes
Set actual_length value for Get HID descriptor

### Rationale behind Changes
Improve emulation's accuracy

### Suggested Testing Steps
None