### PR TITLE
Config: Allow specifying portable directory relative path in portable.txt

### DIFF
--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -169,6 +169,7 @@ namespace EmuFolders
 	std::string Videos;
 
 	static bool ShouldUsePortableMode();
+	static std::string GetPortableModePath();
 } // namespace EmuFolders
 
 TraceFiltersEE::TraceFiltersEE()
@@ -1896,6 +1897,14 @@ bool EmuFolders::ShouldUsePortableMode()
 	return FileSystem::FileExists(Path::Combine(AppRoot, "portable.ini").c_str()) || FileSystem::FileExists(Path::Combine(AppRoot, "portable.txt").c_str());
 }
 
+std::string EmuFolders::GetPortableModePath()
+{
+	const auto portable_txt_path = Path::Combine(AppRoot, "portable.txt");
+	const auto portable_path = FileSystem::ReadFileToString(portable_txt_path.c_str()).value_or("");
+	const auto trimmed_path = StringUtil::StripWhitespace(portable_path);
+	return std::string(trimmed_path);
+}
+
 bool EmuFolders::SetDataDirectory(Error* error)
 {
 	if (!ShouldUsePortableMode())
@@ -1940,7 +1949,7 @@ bool EmuFolders::SetDataDirectory(Error* error)
 
 	// couldn't determine the data directory, or using portable mode? fallback to portable.
 	if (DataRoot.empty())
-		DataRoot = AppRoot;
+		DataRoot = Path::Combine(AppRoot, GetPortableModePath());
 
 	// inis is always below the data root
 	Settings = Path::Combine(DataRoot, "inis");


### PR DESCRIPTION
### Description of Changes
Adds the ability to put a relative path in the `portable.txt` file to place portable data in a specific relative location.

Note that this only applies to `portable.txt` and not `portable.ini` as adding an INI format definition for this would be a more complex. If it doesn't matter whether it's an actual INI formatted file, I could just add it in as an alternate path and read in the same way, but in the interest of respecting the file type I've just added it for the TXT file currently.

### Rationale behind Changes
This allows users to have a portable setup without all of the various data files and directories in the same directory as the executable. For example, the data could be put in a sub-folder, or in a different directory on the same drive used for various emulator data.

### Suggested Testing Steps
Put a `portable.txt` next to the emulator and put a relative path in its contents. I've tested this on my own system and it correctly used the directory I specified.
