### PR TITLE
GS/DX11: Fix feedback write 1 null pointer crash.

### DIFF
--- a/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
@@ -1603,7 +1603,7 @@ void GSDevice11::DoMerge(GSTexture* sTex[3], GSVector4* sRect, GSTexture* dTex, 
 
 	if (feedback_write_1)
 	{
-		StretchRect(sTex[0], full_r, sTex[2], dRect[2], m_convert.ps[static_cast<int>(ShaderConvert::YUV)].get(),
+		StretchRect(dTex, full_r, sTex[2], dRect[2], m_convert.ps[static_cast<int>(ShaderConvert::YUV)].get(),
 			m_merge.cb.get(), nullptr, linear);
 	}
 }


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS/DX11: Fix feedback write 1 null pointer crash.
We were using the wrong texture as the source, should be dTex when copying.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Fixes crash on dx11 on DoMerge when merging 2 source textures.
DX11, OpenGL and possibly Metal differ than DX12 and Vulkan, something to look in to in the future.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Fixes Dynasty Warriors 2 crashing on dx11.
Check if the dump doesn't crash anymore on dx11.
Rename .zip to .xz [Dynasty Warriors 2  Shin Sangoku Musou - Garbage on post character selection screen with software rendering_2.gs.zip](https://github.com/user-attachments/files/16617551/Dynasty.Warriors.2.Shin.Sangoku.Musou.-.Garbage.on.post.character.selection.screen.with.software.rendering_2.gs.zip)

