### PR TITLE
DiscordRPC: Add RCheevos game icon support.

### DIFF
--- a/pcsx2/Achievements.cpp
+++ b/pcsx2/Achievements.cpp
@@ -199,6 +199,7 @@ namespace Achievements
 	static std::string s_game_hash;
 	static std::string s_game_title;
 	static std::string s_game_icon;
+	static std::string s_game_icon_url;
 	static u32 s_game_crc;
 	static rc_client_user_game_summary_t s_game_summary;
 	static u32 s_game_id = 0;
@@ -401,6 +402,10 @@ const std::string& Achievements::GetRichPresenceString()
 	return s_rich_presence_string;
 }
 
+const std::string& Achievements::GetGameIconURL()
+{
+	return s_game_icon_url;
+}
 
 bool Achievements::Initialize()
 {
@@ -945,6 +950,7 @@ void Achievements::ClientLoadGameCallback(int result, const char* error_message,
 	s_has_leaderboards = has_leaderboards;
 	s_has_rich_presence = rc_client_has_rich_presence(client);
 	s_game_icon = {};
+	s_game_icon_url = {};
 
 	// ensure fullscreen UI is ready for notifications
 	MTGS::RunOnGSThread(&ImGuiManager::InitializeFullscreenUI);
@@ -964,6 +970,16 @@ void Achievements::ClientLoadGameCallback(int result, const char* error_message,
 				ReportRCError(err, "rc_client_game_get_image_url() failed: ");
 			}
 		}
+	}
+
+	char icon_url[64];
+	if (int err = rc_client_game_get_image_url(info, icon_url, std::size(icon_url)); err == RC_OK)
+	{
+		s_game_icon_url = icon_url;
+	}
+	else
+	{
+		ReportRCError(err, "rc_client_game_get_image_url() failed: ");
 	}
 
 	UpdateGameSummary();
@@ -990,6 +1006,7 @@ void Achievements::ClearGameInfo()
 	s_game_id = 0;
 	s_game_title = {};
 	s_game_icon = {};
+	s_game_icon_url = {};
 	s_has_achievements = false;
 	s_has_leaderboards = false;
 	s_has_rich_presence = false;

--- a/pcsx2/Achievements.h
+++ b/pcsx2/Achievements.h
@@ -108,6 +108,10 @@ namespace Achievements
 	/// Should be called with the lock held.
 	const std::string& GetRichPresenceString();
 
+	/// Returns the current game icon url.
+	/// Should be called with the lock held.
+	const std::string& GetGameIconURL();
+
 	/// Returns the RetroAchievements title for the current game.
 	/// Should be called with the lock held.
 	const std::string& GetGameTitle();

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -3608,15 +3608,21 @@ void VMManager::UpdateDiscordPresence(bool update_session_time)
 	// https://discord.com/developers/docs/rich-presence/how-to#updating-presence-update-presence-payload-fields
 	DiscordRichPresence rp = {};
 	rp.largeImageKey = "4k-pcsx2";
-	rp.largeImageText = "PCSX2 Emulator";
+	rp.largeImageText = "PCSX2 PS2 Emulator";
 	rp.startTimestamp = s_discord_presence_time_epoch;
 	rp.details = s_title.empty() ?  TRANSLATE("VMManager","No Game Running") : s_title.c_str();
 
 	std::string state_string;
+
 	if (Achievements::HasRichPresence())
 	{
+		auto lock = Achievements::GetLock();
+
 		state_string = StringUtil::Ellipsise(Achievements::GetRichPresenceString(), 128);
 		rp.state = state_string.c_str();
+
+		rp.largeImageKey = Achievements::GetGameIconURL().c_str();
+		rp.largeImageText = s_title.c_str();
 	}
 
 	Discord_UpdatePresence(&rp);


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
This PR adds RetroAchievement icon support to our Discord's Rich Presence implementation.
**NOTE: This require said game to have Rich Presence and achievement support available for that game on RCheevos, otherwise the icon will not show up!**

Preview:
![image](https://github.com/user-attachments/assets/14cc1f33-ec29-4ddf-ab64-9d463c68a98d)

![image](https://github.com/user-attachments/assets/7a938d7e-57b9-4d6f-ad45-1b0c947ba5fa)

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->

Coolness Factor 2x

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
See if the icon shows up properly and nothing else breaks.
