### PR TITLE
USB: Fix CaptureEye corruption on dark images

### DIFF
--- a/pcsx2/USB/usb-eyetoy/cam-windows.cpp
+++ b/pcsx2/USB/usb-eyetoy/cam-windows.cpp
@@ -435,7 +435,7 @@ namespace usb_eyetoy
 										float r = src[2];
 										float g = src[1];
 										float b = src[0];
-										comprBuf[in_pos++] = 0.299f * r + 0.587f * g + 0.114f * b;
+										comprBuf[in_pos++] = std::clamp<u8>(0.299f * r + 0.587f * g + 0.114f * b, 1, 255);
 									}
 								}
 					comprBuf.resize(80 * 64);
@@ -498,7 +498,7 @@ namespace usb_eyetoy
 				{
 					for (int x = 0; x < 80; x++)
 					{
-						comprBuf[80 * y + x] = 255 * y / 80;
+						comprBuf[80 * y + x] = std::clamp<u8>(255 * y / 80, 1, 255);
 					}
 				}
 			}


### PR DESCRIPTION
### Description of Changes
Fix CaptureEye corruption on dark images.
CaptureEye uses 16 consecutive zeros as padding to fill the iso packets when no data is available.
For 2000's cameras it wasn't a problem because they were unable to capture pure black images without noise, but now we have better cameras.
Theoretically it's enough to have a single non-zero pixel every 16 bytes, but it's easier to limit the grayscale range between 1 and 255.

### Rationale behind Changes
Fix CaptureEye corruption on dark images.

### Suggested Testing Steps
none