### PR TITLE
GS/HW: Implement PABE(Per pixel alpha blending) on accumulation and add optimizations.

### DIFF
--- a/bin/resources/shaders/dx11/tfx.fx
+++ b/bin/resources/shaders/dx11/tfx.fx
@@ -862,9 +862,15 @@ void ps_blend(inout float4 Color, inout float4 As_rgba, float2 pos_xy)
 		// PABE
 		if (PS_PABE)
 		{
+			// As_rgba needed for accumulation blend to manipulate Cd.
 			// No blending so early exit
 			if (As < 1.0f)
+			{
+				As_rgba.rgb = (float3)0.0f;
 				return;
+			}
+
+			As_rgba.rgb = (float3)1.0f;
 		}
 
 		float4 RT = SW_BLEND_NEEDS_RT ? RtTexture.Load(int3(pos_xy, 0)) : (float4)0.0f;

--- a/bin/resources/shaders/opengl/tfx_fs.glsl
+++ b/bin/resources/shaders/opengl/tfx_fs.glsl
@@ -783,9 +783,15 @@ float As = As_rgba.a;
 
 	// PABE
 #if PS_PABE
+	// As_rgba needed for accumulation blend to manipulate Cd.
 	// No blending so early exit
 	if (As < 1.0f)
+	{
+		As_rgba.rgb = vec3(0.0f);
 		return;
+	}
+
+	As_rgba.rgb = vec3(1.0f);
 #endif
 
 #if SW_BLEND_NEEDS_RT

--- a/bin/resources/shaders/vulkan/tfx.glsl
+++ b/bin/resources/shaders/vulkan/tfx.glsl
@@ -1050,9 +1050,15 @@ void ps_blend(inout vec4 Color, inout vec4 As_rgba)
 
 		// PABE
 		#if PS_PABE
+			// As_rgba needed for accumulation blend to manipulate Cd
 			// No blending so early exit
 			if (As < 1.0f)
+			{
+				As_rgba.rgb = vec3(0.0f);
 				return;
+			}
+
+			As_rgba.rgb = vec3(1.0f);
 		#endif
 
 		#if PS_FEEDBACK_LOOP_IS_NEEDED

--- a/pcsx2/GS/Renderers/Metal/tfx.metal
+++ b/pcsx2/GS/Renderers/Metal/tfx.metal
@@ -925,9 +925,15 @@ struct PSMain
 			// PABE
 			if (PS_PABE)
 			{
+				// As_rgba needed for accumulation blend to manipulate Cd.
 				// No blending so early exit
 				if (As < 1.f)
+				{
+					As_rgba.rgb = float3(0.f);
 					return;
+				}
+
+				As_rgba.rgb = float3(1.f);
 			}
 
 			float Ad = PS_RTA_CORRECTION ? trunc(current_color.a * 128.1f) / 128.f : trunc(current_color.a * 255.1f) / 128.f;

--- a/pcsx2/ShaderCacheVersion.h
+++ b/pcsx2/ShaderCacheVersion.h
@@ -3,4 +3,4 @@
 
 /// Version number for GS and other shaders. Increment whenever any of the contents of the
 /// shaders change, to invalidate the cache.
-static constexpr u32 SHADER_CACHE_VERSION = 55;
+static constexpr u32 SHADER_CACHE_VERSION = 56;


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS/HW: Implement PABE(Per pixel alpha blending) on accumulation and add optimizations.

PABE accumulation blend:
Idea is to achieve final output Cs when As < 1, we do this with manipulating Cd using the src1 output.
This can't be done with reverse subtraction as we want Cd to be 0 when As < 1.
Blend mix is excluded as no games were found, otherwise it can be added.

PABE Disable blending:
We can disable blending here as an optimization since alpha max is 128
which if alpha is 1 in the formula Cs*Alpha + Cd*(1 - Alpha) will give us a result of Cs.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Better accuracy using hw or hw/sw blend mixed mode, less barriers/draw calls, more speed.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Dumps to benchmark/test:
[PABE.zip](https://github.com/user-attachments/files/16695561/PABE.zip)
Smoke test metal if it still works.
The following games will see a perf increase using vk/gl so they need to be benchmarked:
```
C12 Final Resistance. PSX ['Barriers: -3 [3=>0]']
Shadow of the Colossus HW Distant FogWater Issue ['Draw Calls: -120 [1769=>1649]', 'Barriers: -120 [168=>48]']
Simple 2000 Series Vol.81 - The Chikyuu Boueigun 2 _NTSC-J__SLPM-62652_20220404193151 ['Draw Calls: -325 [4366=>4041]', 'Render Passes: -1 [9=>8]', 'Barriers: -404 [404=>0]']
Super Robot Wars - Alpha 3 - flicker ['Draw Calls: -4 [450=>446]', 'Render Passes: -1 [6=>5]', 'Barriers: -176 [176=>0]']
```
Fixes Simple 2000 Series Vol.81 - The Chikyuu Boueigun 2  on DX11/12
![image](https://github.com/user-attachments/assets/ae50c6e9-47fa-4705-bab4-a38a67fb2617)
