### PR TITLE
GameDB: Correct two Phoenix Games title names

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -18588,10 +18588,10 @@ SLES-52291:
   name: "Countryside Bears"
   region: "PAL-M3"
 SLES-52292:
-  name: "Disney's Mighty Mulan"
+  name: "Mighty Mulan"
   region: "PAL-M3"
 SLES-52293:
-  name: "Disney's Son of the Lion King"
+  name: "Son of the Lion King"
   region: "PAL-M3"
 SLES-52294:
   name: "The Toys Room"


### PR DESCRIPTION
### Description of Changes
Removes "Disney's" from two Phoenix Games titles which are not at all associated with Disney.

### Rationale behind Changes
These two titles were mistakenly prefixed with "Disney's". While their box art and naming is somewhat convincing, these are not in fact real Disney titles.