### PR TITLE
Vk: Don't try to transition present source during present

### DIFF
--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
@@ -2344,6 +2344,11 @@ GSDevice::PresentResult GSDeviceVK::BeginPresent(bool frame_skip)
 	swap_chain_texture->OverrideImageLayout(GSTextureVK::Layout::Undefined);
 	swap_chain_texture->TransitionToLayout(cmdbuffer, GSTextureVK::Layout::ColorAttachment);
 
+	// Present render pass gets started out here, so we can't transition source textures in DoStretchRect
+	// Make sure they're ready now
+	if (!frame_skip && m_current)
+		static_cast<GSTextureVK*>(m_current)->TransitionToLayout(GSTextureVK::Layout::ShaderReadOnly);
+
 	const VkFramebuffer fb = swap_chain_texture->GetFramebuffer(false);
 	if (fb == VK_NULL_HANDLE)
 		return GSDevice::PresentResult::FrameSkipped;


### PR DESCRIPTION
### Description of Changes
Fixes #11716
(Attempting to transition textures in the middle of the present render pass)

### Rationale behind Changes
Less crashy

### Suggested Testing Steps
Test things from #11716