### PR TITLE
Big Picture: Remove ability to make per-game controls

### DIFF
--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -660,11 +660,6 @@ void VMManager::LoadInputBindings(SettingsInterface& si, std::unique_lock<std::m
 			Host::Internal::SetInputSettingsLayer(s_input_settings_interface.get(), lock);
 		}
 	}
-	else if (SettingsInterface* gsi = Host::Internal::GetGameSettingsLayer();
-			 gsi && gsi->GetBoolValue("Pad", "UseGameSettingsForController", false))
-	{
-		InputManager::ReloadBindings(si, *gsi, si);
-	}
 	else
 	{
 		InputManager::ReloadBindings(si, si, si);


### PR DESCRIPTION

### Description of Changes
Removes the option to make literal per-game mappings, and PCSX2's ability to read them. Instead introduces the same input profile selector found in the normal UI to Big Picture. 

### Rationale behind Changes
This allows the same functionality of having controls customizable on a per-game basis, but in the same clean sandbox of profiles as in the desktop UI. This in turn fixes the issues we've been having with controls being seemingly "stuck", because they are crammed into game properties files when the user never really wanted them to be.

### Suggested Testing Steps
Create a new profile, set mappings which purposely don't make sense or are partially incomplete so that it is extra obvious when you have one profile vs another enabled, then test swapping profiles via each UI mode and using said controls. Swap profiles in and out both in desktop and big picture mode, ensuring that both UIs react to when you change profiles both on itself and the other UI. 