### PR TITLE
GS/HW: Further expand blend multipass.

### DIFF
--- a/bin/resources/shaders/dx11/tfx.fx
+++ b/bin/resources/shaders/dx11/tfx.fx
@@ -959,6 +959,8 @@ void ps_blend(inout float4 Color, inout float4 As_rgba, float2 pos_xy)
 	}
 	else
 	{
+		float3 Alpha = PS_BLEND_C == 2 ? (float3)Af : (float3)As;
+
 		if (PS_BLEND_HW == 1)
 		{
 			// Needed for Cd * (As/Ad/F + 1) blending modes
@@ -967,8 +969,7 @@ void ps_blend(inout float4 Color, inout float4 As_rgba, float2 pos_xy)
 		else if (PS_BLEND_HW == 2)
 		{
 			// Cd*As,Cd*Ad or Cd*F
-			float Alpha = PS_BLEND_C == 2 ? Af : As;
-			Color.rgb = saturate((float3)Alpha - (float3)1.0f) * (float3)255.0f;
+			Color.rgb = saturate(Alpha - (float3)1.0f) * (float3)255.0f;
 		}
 		else if (PS_BLEND_HW == 3 && PS_RTA_CORRECTION == 0)
 		{
@@ -983,10 +984,23 @@ void ps_blend(inout float4 Color, inout float4 As_rgba, float2 pos_xy)
 		}
 		else if (PS_BLEND_HW == 4)
 		{
-			// Needed for Cd * (1 - Ad) and Cd*(1 + Alpha)
-			float Alpha = PS_BLEND_C == 2 ? Af : As;
-			As_rgba.rgb = (float3)Alpha * (float3)(128.0f / 255.0f);
+			// Needed for Cd * (1 - Ad) and Cd*(1 + Alpha).
+			As_rgba.rgb = Alpha * (float3)(128.0f / 255.0f);
 			Color.rgb = (float3)127.5f;
+		}
+		else if (PS_BLEND_HW == 5)
+		{
+			// Needed for Cs*Alpha + Cd*(1 - Alpha).
+			Alpha *= (float3)(128.0f / 255.0f);
+			As_rgba.rgb = (Alpha - (float3)0.5f);
+			Color.rgb = (Color.rgb * Alpha);
+		}
+		else if (PS_BLEND_HW == 6)
+		{
+			// Needed for Cd*Alpha + Cs*(1 - Alpha).
+			Alpha *= (float3)(128.0f / 255.0f);
+			As_rgba.rgb = Alpha;
+			Color.rgb *= (Alpha - (float3)0.5f);
 		}
 	}
 }

--- a/bin/resources/shaders/opengl/tfx_fs.glsl
+++ b/bin/resources/shaders/opengl/tfx_fs.glsl
@@ -910,17 +910,18 @@ float As = As_rgba.a;
 #endif
 
 #else
+
+#if PS_BLEND_C == 2
+	vec3 Alpha = vec3(Af);
+#else
+	vec3 Alpha = vec3(As);
+#endif
+
 	// Needed for Cd * (As/Ad/F + 1) blending modes
 #if PS_BLEND_HW == 1
 	Color.rgb = vec3(255.0f);
 #elif PS_BLEND_HW == 2
 	// Cd*As,Cd*Ad or Cd*F
-
-#if PS_BLEND_C == 2
-	float Alpha = Af;
-#else
-	float Alpha = As;
-#endif
 
 	Color.rgb = max(vec3(0.0f), (Alpha - vec3(1.0f)));
 	Color.rgb *= vec3(255.0f);
@@ -934,15 +935,20 @@ float As = As_rgba.a;
 	float color_compensate = 255.0f / max(128.0f, max_color);
 	Color.rgb *= vec3(color_compensate);
 #elif PS_BLEND_HW == 4
-	// Needed for Cd * (1 - Ad) and Cd*(1 + Alpha)
+	// Needed for Cd * (1 - Ad) and Cd*(1 + Alpha).
 
-#if PS_BLEND_C == 2
-	float Alpha = Af;
-#else
-	float Alpha = As;
-#endif
-	As_rgba.rgb = vec3(Alpha) * vec3(128.0f / 255.0f);
+	As_rgba.rgb = Alpha * vec3(128.0f / 255.0f);
 	Color.rgb = vec3(127.5f);
+#elif PS_BLEND_HW == 5
+	// Needed for Cs*Alpha + Cd*(1 - Alpha).
+	Alpha *= vec3(128.0f / 255.0f);
+	As_rgba.rgb = (Alpha - vec3(0.5f));
+	Color.rgb = (Color.rgb * Alpha);
+#elif PS_BLEND_HW == 6
+	// Needed for Cd*Alpha + Cs*(1 - Alpha).
+	Alpha *= vec3(128.0f / 255.0f);
+	As_rgba.rgb = Alpha;
+	Color.rgb *= (Alpha - vec3(0.5f));
 #endif
 
 #endif

--- a/bin/resources/shaders/vulkan/tfx.glsl
+++ b/bin/resources/shaders/vulkan/tfx.glsl
@@ -1177,17 +1177,18 @@ void ps_blend(inout vec4 Color, inout vec4 As_rgba)
 		#endif
 
 	#else
+
+		#if PS_BLEND_C == 2
+			vec3 Alpha = vec3(Af);
+		#else
+			vec3 Alpha = vec3(As);
+		#endif
+
 		#if PS_BLEND_HW == 1
 			// Needed for Cd * (As/Ad/F + 1) blending modes
 			Color.rgb = vec3(255.0f);
 		#elif PS_BLEND_HW == 2
 			// Cd*As,Cd*Ad or Cd*F
-
-			#if PS_BLEND_C == 2
-				float Alpha = Af;
-			#else
-				float Alpha = As;
-			#endif
 
 			Color.rgb = max(vec3(0.0f), (Alpha - vec3(1.0f)));
 			Color.rgb *= vec3(255.0f);
@@ -1201,16 +1202,20 @@ void ps_blend(inout vec4 Color, inout vec4 As_rgba)
 			float color_compensate = 255.0f / max(128.0f, max_color);
 			Color.rgb *= vec3(color_compensate);
 		#elif PS_BLEND_HW == 4
-			// Needed for Cd * (1 - Ad) and Cd*(1 + Alpha)
+			// Needed for Cd * (1 - Ad) and Cd*(1 + Alpha).
 
-			#if PS_BLEND_C == 2
-				float Alpha = Af;
-			#else
-				float Alpha = As;
-			#endif
-
-			As_rgba.rgb = vec3(Alpha) * vec3(128.0f / 255.0f);
+			As_rgba.rgb = Alpha * vec3(128.0f / 255.0f);
 			Color.rgb = vec3(127.5f);
+		#elif PS_BLEND_HW == 5
+			// Needed for Cs*Alpha + Cd*(1 - Alpha).
+			Alpha *= vec3(128.0f / 255.0f);
+			As_rgba.rgb = (Alpha - vec3(0.5f));
+			Color.rgb = (Color.rgb * Alpha);
+		#elif PS_BLEND_HW == 6
+			// Needed for Cd*Alpha + Cs*(1 - Alpha).
+			Alpha *= vec3(128.0f / 255.0f);
+			As_rgba.rgb = Alpha;
+			Color.rgb *= (Alpha - vec3(0.5f));
 		#endif
 	#endif
 }

--- a/pcsx2/GS/Renderers/Common/GSDevice.h
+++ b/pcsx2/GS/Renderers/Common/GSDevice.h
@@ -176,6 +176,8 @@ enum class HWBlendType
 	SRC_ALPHA_DST_FACTOR    = 2, // Use the dest color as blend factor, Cs is set to (Alpha - 1).
 	SRC_DOUBLE              = 3, // Double source color.
 	SRC_HALF_ONE_DST_FACTOR = 4, // Use the dest color as blend factor, Cs is set to 0.5, additionally divide As or Af by 2.
+	SRC_INV_DST_BLEND_HALF  = 5, // Halve the alpha then double the final result.
+	INV_SRC_DST_BLEND_HALF  = 6, // Halve the alpha then double the final result.
 
 	BMIX1_ALPHA_HIGH_ONE    = 1, // Blend formula is replaced when alpha is higher than 1.
 	BMIX1_SRC_HALF          = 2, // Impossible blend will always be wrong on hw, divide Cs by 2.

--- a/pcsx2/ShaderCacheVersion.h
+++ b/pcsx2/ShaderCacheVersion.h
@@ -3,4 +3,4 @@
 
 /// Version number for GS and other shaders. Increment whenever any of the contents of the
 /// shaders change, to invalidate the cache.
-static constexpr u32 SHADER_CACHE_VERSION = 56;
+static constexpr u32 SHADER_CACHE_VERSION = 57;


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS/HW: Further expand blend multipass.
For formulas:
```
Cs*Alpha + Cd*(1 - Alpha).
Cd*Alpha + Cs*(1 - Alpha).
```
Where Alpha is higher than 1 and is either As or Af.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Improves accuracy on basic blend on dx11/12.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Dump run is fine, smoke test all renderers (vk and gl with and without barriers disabled.
Some comparisons/fixes:
![image](https://github.com/user-attachments/assets/e1423c70-d34d-4b65-8bea-f7d243f56966)
![image](https://github.com/user-attachments/assets/19b0d31c-c832-4f64-8536-194ede6ea94c)
![image](https://github.com/user-attachments/assets/1fcb493e-2a2e-444a-9e25-6eb35dd7b6d5)
![image](https://github.com/user-attachments/assets/6335ca28-5ed6-407e-8430-16e63055e80f)
![image](https://github.com/user-attachments/assets/e022fe9c-fd95-42aa-b115-88eff2a53e60)
![image](https://github.com/user-attachments/assets/60283516-211b-427e-b244-782af20d6808)

