### PR TITLE
DebugTools: Fix some compiler warnings

### DIFF
--- a/pcsx2-qt/Debugger/Models/BreakpointModel.cpp
+++ b/pcsx2-qt/Debugger/Models/BreakpointModel.cpp
@@ -254,8 +254,6 @@ QVariant BreakpointModel::headerData(int section, Qt::Orientation orientation, i
 
 Qt::ItemFlags BreakpointModel::flags(const QModelIndex& index) const
 {
-	volatile const int row = index.row();
-
 	switch (index.column())
 	{
 		case BreakpointColumns::CONDITION:

--- a/pcsx2/DebugTools/DebugInterface.cpp
+++ b/pcsx2/DebugTools/DebugInterface.cpp
@@ -299,13 +299,13 @@ std::optional<u32> DebugInterface::getStackFrameSize(const ccc::Function& functi
 		u32 instruction = read32(function.address().value);
 
 		if ((instruction & 0xffff0000) == 0x27bd0000)
-			stack_frame_size = -(instruction & 0xffff);
+			stack_frame_size = -static_cast<s16>(instruction & 0xffff);
 
 		if (stack_frame_size < 0)
 			return std::nullopt;
 	}
 
-	return (u32)stack_frame_size;
+	return static_cast<u32>(stack_frame_size);
 }
 
 bool DebugInterface::initExpression(const char* exp, PostfixExpression& dest)

--- a/pcsx2/DebugTools/SymbolGuardian.cpp
+++ b/pcsx2/DebugTools/SymbolGuardian.cpp
@@ -3,7 +3,6 @@
 
 #include "SymbolGuardian.h"
 
-#include <demangle.h>
 #include <ccc/ast.h>
 #include <ccc/elf.h>
 #include <ccc/importer_flags.h>
@@ -18,6 +17,8 @@
 #include "MIPSAnalyst.h"
 #include "Host.h"
 #include "VMManager.h"
+
+#include <demangle.h>
 
 SymbolGuardian R5900SymbolGuardian;
 SymbolGuardian R3000SymbolGuardian;
@@ -122,20 +123,6 @@ void SymbolGuardian::Reset()
 			(*symbol)->set_type(std::move(type));
 		}
 	});
-}
-
-static void CreateBuiltInDataType(
-	ccc::SymbolDatabase& database, ccc::SymbolSourceHandle source, const char* name, ccc::ast::BuiltInClass bclass)
-{
-	ccc::Result<ccc::DataType*> symbol = database.data_types.create_symbol(name, source, nullptr);
-	if (!symbol.success())
-		return;
-
-	std::unique_ptr<ccc::ast::BuiltIn> type = std::make_unique<ccc::ast::BuiltIn>();
-	type->name = name;
-	type->size_bytes = ccc::ast::builtin_class_size(bclass);
-	type->bclass = bclass;
-	(*symbol)->set_type(std::move(type));
 }
 
 void SymbolGuardian::ImportElf(std::vector<u8> elf, std::string elf_file_name, const std::string& nocash_path)

--- a/pcsx2/DebugTools/SymbolGuardian.h
+++ b/pcsx2/DebugTools/SymbolGuardian.h
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include <queue>
 #include <atomic>
 #include <thread>
 #include <functional>
@@ -103,9 +102,6 @@ protected:
 
 	std::thread m_import_thread;
 	std::atomic_bool m_interrupt_import_thread = false;
-
-	std::queue<ccc::SymbolDatabase> m_load_queue;
-	std::mutex m_load_queue_lock;
 };
 
 extern SymbolGuardian R5900SymbolGuardian;


### PR DESCRIPTION
### Description of Changes
Some very minor changes have been made to fix some compiler warnings on Windows. All except for the breakpoint one were introduced by [my symbol table PR](https://github.com/PCSX2/pcsx2/pull/10224).

### Rationale behind Changes
Warnings are undesirable (except for Without Warning).

### Suggested Testing Steps
Build on Windows.
