### PR TITLE
Config: Set `{ntsc,pal}FrameRate` bounds to 10-300 Hz

### DIFF
--- a/pcsx2-qt/Settings/AdvancedSettingsWidget.ui
+++ b/pcsx2-qt/Settings/AdvancedSettingsWidget.ui
@@ -430,6 +430,12 @@
             <property name="singleStep">
              <double>0.010000000000000</double>
             </property>
+            <property name="minimum">
+             <double>10.0</double>
+            </property>
+            <property name="maximum">
+             <double>300.0</double>
+            </property>
            </widget>
           </item>
           <item row="0" column="1">
@@ -439,6 +445,12 @@
             </property>
             <property name="singleStep">
              <double>0.010000000000000</double>
+            </property>
+            <property name="minimum">
+             <double>10.0</double>
+            </property>
+            <property name="maximum">
+             <double>300.0</double>
             </property>
            </widget>
           </item>


### PR DESCRIPTION
### Description of Changes
Allows the `NTSC Frame Rate` and `PAL Frame Rate` options in the Advanced settings to go up to 1000.0, instead of 99.99.

### Rationale behind Changes
This option is useful for either:
- Playing a game at higher speeds without speeding up the audio.
- If the game physics use delta time, then you get higher framerates at the same speed. Playing above 60 FPS is cool (and for PS2 games, there's no other way to do it while keeping a normal audio).
  - Some games don't use delta time, but have a static internal "Game speed": for instance, you can set it to half speed with a cheat code, set the framerate to 120 FPS, and get a 120 FPS experience at normal speed.

Regardless of how it might break things, this option was already there, in the Advanced settings, I'm just raising the limit.

(Also, the setting was not in the Fullscreen UI, and it still isn't. Shall I add it? If yes, as a `DrawFloatListSetting` or as a `DrawFloatSpinBoxSetting`? If the former, which numbers should be listed?)