### PR TITLE
Debugger: Bring back the expression parser

### DIFF
--- a/pcsx2-qt/Debugger/BreakpointDialog.cpp
+++ b/pcsx2-qt/Debugger/BreakpointDialog.cpp
@@ -93,10 +93,9 @@ void BreakpointDialog::accept()
 		PostfixExpression expr;
 
 		u64 address;
-		if (!m_cpu->initExpression(m_ui.txtAddress->text().toLocal8Bit().constData(), expr) ||
-			!m_cpu->parseExpression(expr, address))
+		if (!m_cpu->evaluateExpression(m_ui.txtAddress->text().toStdString().c_str(), address))
 		{
-			QMessageBox::warning(this, tr("Error"), tr("Invalid address \"%1\"").arg(m_ui.txtAddress->text()));
+			QMessageBox::warning(this, tr("Invalid Address"), getExpressionError());
 			return;
 		}
 
@@ -109,9 +108,9 @@ void BreakpointDialog::accept()
 			bp->hasCond = true;
 			bp->cond.debug = m_cpu;
 
-			if (!m_cpu->initExpression(m_ui.txtCondition->text().toLocal8Bit().constData(), expr))
+			if (!m_cpu->initExpression(m_ui.txtCondition->text().toStdString().c_str(), expr))
 			{
-				QMessageBox::warning(this, tr("Error"), tr("Invalid condition \"%1\"").arg(getExpressionError()));
+				QMessageBox::warning(this, tr("Invalid Condition"), getExpressionError());
 				return;
 			}
 
@@ -121,21 +120,17 @@ void BreakpointDialog::accept()
 	}
 	if (auto* mc = std::get_if<MemCheck>(&m_bp_mc))
 	{
-		PostfixExpression expr;
-
 		u64 startAddress;
-		if (!m_cpu->initExpression(m_ui.txtAddress->text().toLocal8Bit().constData(), expr) ||
-			!m_cpu->parseExpression(expr, startAddress))
+		if (!m_cpu->evaluateExpression(m_ui.txtAddress->text().toStdString().c_str(), startAddress))
 		{
-			QMessageBox::warning(this, tr("Error"), tr("Invalid address \"%1\"").arg(m_ui.txtAddress->text()));
+			QMessageBox::warning(this, tr("Invalid Address"), getExpressionError());
 			return;
 		}
 
 		u64 size;
-		if (!m_cpu->initExpression(m_ui.txtSize->text().toLocal8Bit(), expr) ||
-			!m_cpu->parseExpression(expr, size) || !size)
+		if (!m_cpu->evaluateExpression(m_ui.txtSize->text().toStdString().c_str(), size) || !size)
 		{
-			QMessageBox::warning(this, tr("Error"), tr("Invalid size \"%1\"").arg(m_ui.txtSize->text()));
+			QMessageBox::warning(this, tr("Invalid Size"), getExpressionError());
 			return;
 		}
 
@@ -147,9 +142,10 @@ void BreakpointDialog::accept()
 			mc->hasCond = true;
 			mc->cond.debug = m_cpu;
 
-			if (!m_cpu->initExpression(m_ui.txtCondition->text().toLocal8Bit().constData(), expr))
+			PostfixExpression expr;
+			if (!m_cpu->initExpression(m_ui.txtCondition->text().toStdString().c_str(), expr))
 			{
-				QMessageBox::warning(this, tr("Error"), tr("Invalid condition \"%1\"").arg(getExpressionError()));
+				QMessageBox::warning(this, tr("Invalid Condition"), getExpressionError());
 				return;
 			}
 

--- a/pcsx2-qt/Debugger/DisassemblyWidget.cpp
+++ b/pcsx2-qt/Debugger/DisassemblyWidget.cpp
@@ -163,21 +163,20 @@ void DisassemblyWidget::contextFollowBranch()
 void DisassemblyWidget::contextGoToAddress()
 {
 	bool ok;
-	const QString targetString = QInputDialog::getText(this, tr("Go to address"), "",
+	const QString targetString = QInputDialog::getText(this, tr("Go To In Disassembly"), "",
 		QLineEdit::Normal, "", &ok);
 
 	if (!ok)
 		return;
 
-	const u32 targetAddress = targetString.toUInt(&ok, 16) & ~3;
-
-	if (!ok)
+	u64 address = 0;
+	if (!m_cpu->evaluateExpression(targetString.toStdString().c_str(), address))
 	{
-		QMessageBox::warning(this, tr("Go to address error"), tr("Invalid address"));
+		QMessageBox::warning(this, tr("Cannot Go To"), getExpressionError());
 		return;
 	}
 
-	gotoAddressAndSetFocus(targetAddress);
+	gotoAddressAndSetFocus(static_cast<u32>(address) & ~3);
 }
 
 void DisassemblyWidget::contextAddFunction()

--- a/pcsx2-qt/Debugger/MemoryViewWidget.cpp
+++ b/pcsx2-qt/Debugger/MemoryViewWidget.cpp
@@ -592,21 +592,20 @@ void MemoryViewWidget::contextPaste()
 void MemoryViewWidget::contextGoToAddress()
 {
 	bool ok;
-	QString targetString = QInputDialog::getText(this, tr("Go to address"), "",
+	QString targetString = QInputDialog::getText(this, tr("Go To In Memory View"), "",
 		QLineEdit::Normal, "", &ok);
 
 	if (!ok)
 		return;
 
-	const u32 targetAddress = targetString.toUInt(&ok, 16);
-
-	if (!ok)
+	u64 address = 0;
+	if (!m_cpu->evaluateExpression(targetString.toStdString().c_str(), address))
 	{
-		QMessageBox::warning(this, "Go to address error", "Invalid address");
+		QMessageBox::warning(this, tr("Cannot Go To"), getExpressionError());
 		return;
 	}
 
-	gotoAddress(targetAddress);
+	gotoAddress(static_cast<u32>(address));
 }
 
 void MemoryViewWidget::mouseDoubleClickEvent(QMouseEvent* event)

--- a/pcsx2-qt/Debugger/SymbolTree/SymbolTreeNode.h
+++ b/pcsx2-qt/Debugger/SymbolTree/SymbolTreeNode.h
@@ -25,6 +25,7 @@ public:
 	Tag tag = OBJECT;
 	ccc::MultiSymbolHandle symbol;
 	QString name;
+	QString mangled_name;
 	SymbolTreeLocation location;
 	bool is_location_editable = false;
 	std::optional<u32> size;

--- a/pcsx2-qt/Debugger/SymbolTree/SymbolTreeWidgets.h
+++ b/pcsx2-qt/Debugger/SymbolTree/SymbolTreeWidgets.h
@@ -84,6 +84,7 @@ protected:
 	void onDeleteButtonPressed();
 
 	void onCopyName();
+	void onCopyMangledName();
 	void onCopyLocation();
 	void onRenameSymbol();
 	void onGoToInDisassembly();
@@ -117,7 +118,8 @@ protected:
 		NO_SYMBOL_TREE_FLAGS = 0,
 		ALLOW_GROUPING = 1 << 0,
 		ALLOW_SORTING_BY_IF_TYPE_IS_KNOWN = 1 << 1,
-		ALLOW_TYPE_ACTIONS = 1 << 2
+		ALLOW_TYPE_ACTIONS = 1 << 2,
+		ALLOW_MANGLED_NAME_ACTIONS = 1 << 3
 	};
 
 	u32 m_flags;

--- a/pcsx2/DebugTools/DebugInterface.h
+++ b/pcsx2/DebugTools/DebugInterface.h
@@ -79,6 +79,7 @@ public:
 	[[nodiscard]] virtual SymbolGuardian& GetSymbolGuardian() const = 0;
 	[[nodiscard]] virtual std::vector<std::unique_ptr<BiosThread>> GetThreadList() const = 0;
 
+	bool evaluateExpression(const char* expression, u64& dest);
 	bool initExpression(const char* exp, PostfixExpression& dest);
 	bool parseExpression(PostfixExpression& exp, u64& dest);
 	bool isAlive();

--- a/pcsx2/DebugTools/ExpressionParser.h
+++ b/pcsx2/DebugTools/ExpressionParser.h
@@ -22,7 +22,7 @@ public:
 	virtual bool parseSymbol(char* str, u64& symbolValue) = 0;
 	virtual u64 getReferenceValue(u64 referenceIndex) = 0;
 	virtual ExpressionType getReferenceType(u64 referenceIndex) = 0;
-	virtual bool getMemoryValue(u32 address, int size, u64& dest, char* error) = 0;
+	virtual bool getMemoryValue(u32 address, int size, u64& dest, std::string& error) = 0;
 };
 
 bool initPostfixExpression(const char* infix, IExpressionFunctions* funcs, PostfixExpression& dest);


### PR DESCRIPTION
### Description of Changes
The old wxWidgets debugger used the expression parser for the go to in memory and go to in disassembly dialogs, however previously the Qt debugger did not. This brings back that missing functionality.

In addition, I've made it so it should now be possible to translate the error messages generated by the expression parser. I've made some changes to its logic to fix an annoyance where it wouldn't accept a hex value starting with a letter (e.g. "f0000") without base suffx, and to fix some stack buffer overflows.

Lastly, it fixes an issue introduced by my symbol table PR where it would try to lookup symbol by their demangled names, even though the expression parser only supports parsing unmangled names. The approach I've taken to build a map of the demangled names in `MipsExpressionFunctions::MipsExpressionFunctions` since while this restores the previous functionality, I don't it's ideal. Improving this behaviour would require a more substantial rewrite of the expression parser, however.

To make the behavior explained above more practical, I've added an option in the function and global variable symbol trees to copy the mangled name of a symbol to the clipboard.

### Rationale behind Changes
This was a very useful feature.

### Suggested Testing Steps
- Make sure the go to dialogs still work.
- Make sure the breakpoints dialog still works.
- Try entering expressions containing a really long tokens in the breakpoint creation dialog and observe that PCSX2 doesn't crash now.
