### PR TITLE
 FileSystem: Fix handling of symlinks

### DIFF
--- a/common/FileSystem.h
+++ b/common/FileSystem.h
@@ -84,6 +84,7 @@ namespace FileSystem
 
 	/// Directory exists?
 	bool DirectoryExists(const char* path);
+	bool IsRealDirectory(const char* path);
 
 	/// Directory does not contain any files?
 	bool DirectoryIsEmpty(const char* path);


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Revert of [`c8a3e5a` (#11739)](https://github.com/PCSX2/pcsx2/pull/11739/commits/c8a3e5a9ec4b41ae8c268de78414942b726c9e1f)

My previous PR broke the handling of symlinks on Linux, so let's revert that.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
No more broke

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
See if i didn't broke anything else for real this time
