### PR TITLE
Hotkeys: Implement "SelectNextSlotAndSaveState"

### DIFF
--- a/pcsx2/Hotkeys.cpp
+++ b/pcsx2/Hotkeys.cpp
@@ -239,6 +239,14 @@ DEFINE_HOTKEY("LoadStateFromSlot", TRANSLATE_NOOP("Hotkeys", "Save States"),
 		if (!pressed && VMManager::HasValidVM())
 			SaveStateSelectorUI::LoadCurrentSlot();
 	})
+DEFINE_HOTKEY("SaveStateAndSelectNextSlot", TRANSLATE_NOOP("Hotkeys", "Save States"),
+	TRANSLATE_NOOP("Hotkeys", "Save State and Select Next Slot"), [](s32 pressed) {
+		if (!pressed && VMManager::HasValidVM())
+		{
+			SaveStateSelectorUI::SaveCurrentSlot();
+			SaveStateSelectorUI::SelectNextSlot(false);
+		}
+	})
 DEFINE_HOTKEY("SelectNextSlotAndSaveState", TRANSLATE_NOOP("Hotkeys", "Save States"),
 	TRANSLATE_NOOP("Hotkeys", "Select Next Slot and Save State"), [](s32 pressed) {
 		if (!pressed && VMManager::HasValidVM())

--- a/pcsx2/Hotkeys.cpp
+++ b/pcsx2/Hotkeys.cpp
@@ -239,12 +239,12 @@ DEFINE_HOTKEY("LoadStateFromSlot", TRANSLATE_NOOP("Hotkeys", "Save States"),
 		if (!pressed && VMManager::HasValidVM())
 			SaveStateSelectorUI::LoadCurrentSlot();
 	})
-DEFINE_HOTKEY("SaveStateAndSelectNextSlot", TRANSLATE_NOOP("Hotkeys", "Save States"),
-	TRANSLATE_NOOP("Hotkeys", "Save State and Select Next Slot"), [](s32 pressed) {
+DEFINE_HOTKEY("SelectNextSlotAndSaveState", TRANSLATE_NOOP("Hotkeys", "Save States"),
+	TRANSLATE_NOOP("Hotkeys", "Select Next Slot and Save State"), [](s32 pressed) {
 		if (!pressed && VMManager::HasValidVM())
 		{
-			SaveStateSelectorUI::SaveCurrentSlot();
 			SaveStateSelectorUI::SelectNextSlot(false);
+			SaveStateSelectorUI::SaveCurrentSlot();
 		}
 	})
 


### PR DESCRIPTION
Flipped the order of Hotkey action "SaveStateAndSelectNextSlot" to "SelectNextSlotAndSaveState"

### Description of Changes
Flipped the order of hotkey actions from
Creating a Save State -> Selecting Next Save Slot
to
Selecting Next Save Slot -> Creating a Save State

### Rationale behind Changes
The intention behind this is to streamline the quicksave/quickload process, as with this change the LoadStateFromSlot action will load the most recent Save State instead of the oldest one.
