### PR TITLE
Config: Prevent pad settings lingering in game properties blocking profiles

### DIFF
--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -938,10 +938,7 @@ bool VMManager::UpdateGameSettingsLayer()
 
 	std::string input_profile_name;
 	if (new_interface)
-	{
-		if (!new_interface->GetBoolValue("Pad", "UseGameSettingsForController", false))
-			new_interface->GetStringValue("EmuCore", "InputProfileName", &input_profile_name);
-	}
+		new_interface->GetStringValue("EmuCore", "InputProfileName", &input_profile_name);
 
 	if (!s_game_settings_interface && !new_interface && s_input_profile_name == input_profile_name)
 		return false;


### PR DESCRIPTION


### Description of Changes
Removes a leftover check against the old "use per-game controls" setting which can be lingering in game properties files, allowing profiles to actually load without interference.

### Rationale behind Changes
Partially fixes #11764. Will allow profiles to load properly for anyone who hasn't cleared lingering pad settings out of their game properties.

### Suggested Testing Steps
Create a profile with bindings very different from shared, switch profiles and verify controls still switch as intended.
