### PR TITLE
GS/HW: Add all levels/unclamped mipmap modes,credit by stenzek

### DIFF
--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -155,7 +155,8 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* dialog, QWidget* 
 	SettingWidgetBinder::BindWidgetToEnumSetting(sif, m_ui.anisotropicFiltering, "EmuCore/GS", "MaxAnisotropy",
 		s_anisotropic_filtering_entries, s_anisotropic_filtering_values, "0");
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.dithering, "EmuCore/GS", "dithering_ps2", 2);
-	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.mipmapping, "EmuCore/GS", "hw_mipmap", true);
+	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.hwMipmapMode, "EmuCore/GS", "hw_mipmap_mode",
+		static_cast<int>(GSHWMipmapMode::Enabled));
 	SettingWidgetBinder::BindWidgetToIntSetting(
 		sif, m_ui.blending, "EmuCore/GS", "accurate_blending_unit", static_cast<int>(AccBlendLevel::Basic));
 	SettingWidgetBinder::BindWidgetToIntSetting(
@@ -506,8 +507,8 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* dialog, QWidget* 
 			   "FMV resolution will remain unchanged, as the video files are pre-rendered."));
 
 		dialog->registerWidgetHelp(
-			m_ui.mipmapping, tr("Mipmapping"), tr("Checked"), tr("Enables mipmapping, which some games require to render correctly."));
-
+			m_ui.hwMipmapMode, tr("Mipmapping"), tr("Enabled"), tr("Enables mipmapping, which many games require to render correctly. "
+																   "Unclamped allows higher texture detail levels to be used, but may break certain graphical effects."));
 		dialog->registerWidgetHelp(
 			m_ui.textureFiltering, tr("Texture Filtering"), tr("Bilinear (PS2)"),
 			tr("Changes what filtering algorithm is used to map textures to surfaces.<br> "

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
@@ -611,22 +611,46 @@
        </item>
        <item row="7" column="0" colspan="2">
         <layout class="QGridLayout" name="hardwareRenderingOptionsLayout">
-         <item row="0" column="1">
+         <item row="0" column="0">
           <widget class="QCheckBox" name="enableHWFixes">
            <property name="text">
             <string>Manual Hardware Renderer Fixes</string>
            </property>
           </widget>
          </item>
-         <item row="0" column="0">
-          <widget class="QCheckBox" name="mipmapping">
-           <property name="text">
-            <string>Mipmapping</string>
-           </property>
-          </widget>
-         </item>
         </layout>
        </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="hwMipmappingLabel">
+         <property name="text">
+          <string>Mipmapping:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="QComboBox" name="hwMipmapMode">
+         <item>
+          <property name="text">
+           <string>Disabled</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Enabled</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>All Levels</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Unclamped</string>
+          </property>
+         </item>
+        </widget>
+       </item>	   
       </layout>
      </widget>
      <widget class="QWidget" name="softwareRenderingTab">

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -286,6 +286,15 @@ enum class BiFiltering : u8
 	Forced_But_Sprite,
 };
 
+enum class GSHWMipmapMode : u8
+{
+	Disabled,
+	Enabled,
+	AllLevels,
+	Unclamped,
+	MaxCount
+};
+
 enum class TriFiltering : s8
 {
 	Automatic = -1,
@@ -637,7 +646,6 @@ struct Pcsx2Config
 					AutoFlushSW : 1,
 					PreloadFrameWithGSData : 1,
 					Mipmap : 1,
-					HWMipmap : 1,
 					ManualUserHacks : 1,
 					UserHacks_AlignSpriteX : 1,
 					UserHacks_CPUFBConversion : 1,
@@ -694,6 +702,7 @@ struct Pcsx2Config
 		float UpscaleMultiplier = 1.0f;
 
 		AccBlendLevel AccurateBlendingUnit = AccBlendLevel::Basic;
+		GSHWMipmapMode HWMipmapMode = GSHWMipmapMode::Disabled;
 		BiFiltering TextureFiltering = BiFiltering::PS2;
 		TexturePreloadingLevel TexturePreloading = TexturePreloadingLevel::Full;
 		GSDumpCompressionMethod GSDumpCompression = GSDumpCompressionMethod::Zstandard;

--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -762,7 +762,7 @@ void GSUpdateConfig(const Pcsx2Config::GSOptions& new_config)
 
 	// reload texture cache when trilinear filtering or TC options change
 	if (
-		(GSIsHardwareRenderer() && GSConfig.HWMipmap != old_config.HWMipmap) ||
+		(GSIsHardwareRenderer() && GSConfig.HWMipmapMode != old_config.HWMipmapMode) ||
 		GSConfig.TexturePreloading != old_config.TexturePreloading ||
 		GSConfig.TriFilter != old_config.TriFilter ||
 		GSConfig.GPUPaletteConversion != old_config.GPUPaletteConversion ||
@@ -1138,9 +1138,10 @@ BEGIN_HOTKEY_LIST(g_gs_hotkeys){"Screenshot", TRANSLATE_NOOP("Hotkeys", "Graphic
 		[](s32 pressed) {
 			if (!pressed)
 			{
-				EmuConfig.GS.HWMipmap = !EmuConfig.GS.HWMipmap;
+				EmuConfig.GS.HWMipmapMode =
+					(EmuConfig.GS.HWMipmapMode >= GSHWMipmapMode::Enabled) ? GSHWMipmapMode::Disabled : GSHWMipmapMode::Enabled;
 				Host::AddKeyedOSDMessage("ToggleMipmapMode",
-					EmuConfig.GS.HWMipmap ?
+					(EmuConfig.GS.HWMipmapMode >= GSHWMipmapMode::Enabled) ?
 						TRANSLATE_STR("Hotkeys", "Hardware mipmapping is now enabled.") :
 						TRANSLATE_STR("Hotkeys", "Hardware mipmapping is now disabled."),
 					Host::OSD_INFO_DURATION);

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -4447,7 +4447,9 @@ GSTextureCache::Source* GSTextureCache::CreateSource(const GIFRegTEX0& TEX0, con
 	{
 		// lod won't contain the full range when using basic mipmapping, only that
 		// which is hashed, so we just allocate the full thing.
-		tlevels = GSConfig.HWMipmap ? std::min(lod->y - lod->x + 1, GSDevice::GetMipmapLevelsForSize(tw, th)) : -1;
+		tlevels = (GSConfig.HWMipmapMode >= GSHWMipmapMode::Enabled) ?
+					  std::min(lod->y - lod->x + 1, GSDevice::GetMipmapLevelsForSize(tw, th)) :
+					  -1;
 		src->m_lod = *lod;
 	}
 
@@ -5390,7 +5392,10 @@ GSTextureCache::HashCacheEntry* GSTextureCache::LookupHashCache(const GIFRegTEX0
 	// expand/upload texture
 	const int tw = region.HasX() ? region.GetWidth() : (1 << TEX0.TW);
 	const int th = region.HasY() ? region.GetHeight() : (1 << TEX0.TH);
-	const int tlevels = lod ? (GSConfig.HWMipmap ? std::min(lod->y - lod->x + 1, GSDevice::GetMipmapLevelsForSize(tw, th)) : -1) : 1;
+	const int tlevels = lod ? ((GSConfig.HWMipmapMode >= GSHWMipmapMode::Enabled) ?
+									  std::min(lod->y - lod->x + 1, GSDevice::GetMipmapLevelsForSize(tw, th)) :
+									  -1) :
+							  1;
 	GSTexture* tex = g_gs_device->CreateTexture(tw, th, tlevels, paltex ? GSTexture::Format::UNorm8 : GSTexture::Format::Color);
 	if (!tex)
 	{

--- a/pcsx2/GS/Renderers/HW/GSTextureReplacements.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureReplacements.cpp
@@ -661,7 +661,7 @@ void GSTextureReplacements::PrecacheReplacementTextures()
 
 	// predict whether the requests will come with mipmaps
 	// TODO: This will be wrong for hw mipmap games like Jak.
-	const bool mipmap = GSConfig.HWMipmap || GSConfig.TriFilter == TriFiltering::Forced;
+	const bool mipmap = (GSConfig.HWMipmapMode >= GSHWMipmapMode::Enabled || GSConfig.TriFilter == TriFiltering::Forced);
 
 	// pretty simple, just go through the filenames and if any aren't cached, cache them
 	for (const auto& it : s_replacement_texture_filenames)

--- a/pcsx2/GameDatabase.cpp
+++ b/pcsx2/GameDatabase.cpp
@@ -622,7 +622,7 @@ bool GameDatabaseSchema::GameEntry::configMatchesHWFix(const Pcsx2Config::GSOpti
 			return (static_cast<int>(config.PCRTCOverscan) == value);
 
 		case GSHWFixId::Mipmap:
-			return (static_cast<int>(config.HWMipmap) == value);
+			return (static_cast<int>(config.HWMipmapMode) == value);
 
 		case GSHWFixId::TrilinearFiltering:
 			return (config.TriFilter == TriFiltering::Automatic || static_cast<int>(config.TriFilter) == value);
@@ -780,8 +780,10 @@ void GameDatabaseSchema::GameEntry::applyGSHardwareFixes(Pcsx2Config::GSOptions&
 				break;
 
 			case GSHWFixId::Mipmap:
-				config.HWMipmap = (value > 0);
-				break;
+				{
+				if (value >= 0 && value < static_cast<int>(GSHWMipmapMode::MaxCount))
+					config.HWMipmapMode = static_cast<GSHWMipmapMode>(value > 0);
+				}
 
 			case GSHWFixId::TrilinearFiltering:
 			{

--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -3569,6 +3569,12 @@ void FullscreenUI::DrawGraphicsSettingsPage(SettingsInterface* bsi, bool show_ad
 		"11",
 		"12",
 	};
+	static constexpr const char* s_mipmapping_options[] = {
+		FSUI_NSTR("Disabled"),
+		FSUI_NSTR("Enabled"),
+		FSUI_NSTR("All Levels"),
+		FSUI_NSTR("Unclamped"),
+	};
 	static constexpr const char* s_bilinear_options[] = {
 		FSUI_NSTR("Nearest"),
 		FSUI_NSTR("Bilinear (Forced)"),
@@ -3702,6 +3708,9 @@ void FullscreenUI::DrawGraphicsSettingsPage(SettingsInterface* bsi, bool show_ad
 		DrawStringListSetting(bsi, FSUI_CSTR("Internal Resolution"),
 			FSUI_CSTR("Multiplies the render resolution by the specified factor (upscaling)."), "EmuCore/GS", "upscale_multiplier",
 			"1.000000", s_resolution_options, s_resolution_values, std::size(s_resolution_options), true);
+		DrawIntListSetting(
+			bsi, FSUI_CSTR("Mipmapping"), FSUI_CSTR("Enables emulation of the GS's texture mipmapping."), "EmuCore/GS", "hw_mipmap_mode",
+			static_cast<int>(GSHWMipmapMode::Enabled), s_mipmapping_options, std::size(s_mipmapping_options), true);
 		DrawIntListSetting(bsi, FSUI_CSTR("Bilinear Filtering"),
 			FSUI_CSTR("Selects where bilinear filtering is utilized when rendering textures."), "EmuCore/GS", "filter",
 			static_cast<int>(BiFiltering::PS2), s_bilinear_options, std::size(s_bilinear_options), true);
@@ -3721,8 +3730,6 @@ void FullscreenUI::DrawGraphicsSettingsPage(SettingsInterface* bsi, bool show_ad
 				"Uploads full textures to the GPU on use, rather than only the utilized regions. Can improve performance in some games."),
 			"EmuCore/GS", "texture_preloading", static_cast<int>(TexturePreloadingLevel::Off), s_preloading_options,
 			std::size(s_preloading_options), true);
-		DrawToggleSetting(
-			bsi, FSUI_CSTR("Mipmapping"), FSUI_CSTR("Enables emulation of the GS's texture mipmapping."), "EmuCore/GS", "hw_mipmap", true);
 	}
 	else
 	{
@@ -7027,6 +7034,8 @@ TRANSLATE_NOOP("FullscreenUI", "Enables internal Anti-Blur hacks. Less accurate 
 TRANSLATE_NOOP("FullscreenUI", "Rendering");
 TRANSLATE_NOOP("FullscreenUI", "Internal Resolution");
 TRANSLATE_NOOP("FullscreenUI", "Multiplies the render resolution by the specified factor (upscaling).");
+TRANSLATE_NOOP("FullscreenUI", "Mipmapping");
+TRANSLATE_NOOP("FullscreenUI", "Enables emulation of the GS's texture mipmapping.");
 TRANSLATE_NOOP("FullscreenUI", "Bilinear Filtering");
 TRANSLATE_NOOP("FullscreenUI", "Selects where bilinear filtering is utilized when rendering textures.");
 TRANSLATE_NOOP("FullscreenUI", "Trilinear Filtering");
@@ -7039,8 +7048,6 @@ TRANSLATE_NOOP("FullscreenUI", "Blending Accuracy");
 TRANSLATE_NOOP("FullscreenUI", "Determines the level of accuracy when emulating blend modes not supported by the host graphics API.");
 TRANSLATE_NOOP("FullscreenUI", "Texture Preloading");
 TRANSLATE_NOOP("FullscreenUI", "Uploads full textures to the GPU on use, rather than only the utilized regions. Can improve performance in some games.");
-TRANSLATE_NOOP("FullscreenUI", "Mipmapping");
-TRANSLATE_NOOP("FullscreenUI", "Enables emulation of the GS's texture mipmapping.");
 TRANSLATE_NOOP("FullscreenUI", "Software Rendering Threads");
 TRANSLATE_NOOP("FullscreenUI", "Number of threads to use in addition to the main GS thread for rasterization.");
 TRANSLATE_NOOP("FullscreenUI", "Auto Flush (Software)");

--- a/pcsx2/ImGui/ImGuiOverlays.cpp
+++ b/pcsx2/ImGui/ImGuiOverlays.cpp
@@ -406,8 +406,8 @@ __ri void ImGuiManager::DrawSettingsOverlay(float scale, float margin, float spa
 		if (GSConfig.HWDownloadMode != GSHardwareDownloadMode::Enabled)
 			APPEND("DL={} ", static_cast<unsigned>(GSConfig.HWDownloadMode));
 
-		if (GSConfig.HWMipmap)
-			APPEND("MM ");
+		if (GSConfig.HWMipmapMode != GSHWMipmapMode::Disabled)
+			APPEND("MM={} ", static_cast<unsigned>(GSConfig.HWMipmapMode));
 
 		// deliberately test global and print local here for auto values
 		if (EmuConfig.GS.TextureFiltering != BiFiltering::PS2)

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -644,7 +644,6 @@ Pcsx2Config::GSOptions::GSOptions()
 	AutoFlushSW = true;
 	PreloadFrameWithGSData = false;
 	Mipmap = true;
-	HWMipmap = true;
 
 	ManualUserHacks = false;
 	UserHacks_AlignSpriteX = false;
@@ -712,6 +711,7 @@ bool Pcsx2Config::GSOptions::OptionsAreEqual(const GSOptions& right) const
 		OpEqu(UpscaleMultiplier) &&
 
 		OpEqu(AccurateBlendingUnit) &&
+		OpEqu(HWMipmapMode) &&
 		OpEqu(TextureFiltering) &&
 		OpEqu(TexturePreloading) &&
 		OpEqu(GSDumpCompression) &&
@@ -899,7 +899,7 @@ void Pcsx2Config::GSOptions::LoadSave(SettingsWrapper& wrap)
 	SettingsWrapIntEnumEx(Renderer, "Renderer");
 	SettingsWrapEntryEx(UpscaleMultiplier, "upscale_multiplier");
 
-	SettingsWrapBitBoolEx(HWMipmap, "hw_mipmap");
+	SettingsWrapIntEnumEx(HWMipmapMode, "hw_mipmap_mode");
 	SettingsWrapIntEnumEx(AccurateBlendingUnit, "accurate_blending_unit");
 	SettingsWrapIntEnumEx(TextureFiltering, "filter");
 	SettingsWrapIntEnumEx(TexturePreloading, "texture_preloading");

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -3158,10 +3158,10 @@ void VMManager::WarnAboutUnsafeSettings()
 			append(ICON_FA_EXCLAMATION_CIRCLE,
 				TRANSLATE_SV("VMManager", "Texture dumping is enabled, this will continually dump textures to disk."));
 		}
-		if (!EmuConfig.GS.HWMipmap)
+		if (EmuConfig.GS.HWMipmapMode != GSHWMipmapMode::Enabled && EmuConfig.GS.HWMipmapMode != GSHWMipmapMode::AllLevels)
 		{
 			append(ICON_FA_IMAGES,
-				TRANSLATE_SV("VMManager", "Mipmapping is disabled. This may break rendering in some games."));
+				TRANSLATE_SV("VMManager", "Mipmapping is not set to Enabled/All Levels. This may break rendering in some games."));
 		}
 	}
 	if (EmuConfig.GS.TextureFiltering != BiFiltering::PS2)


### PR DESCRIPTION
### Description of Changes
This PR brings back the mipmapping dropdown (oh noes), but it does not bring back basic (phew).

It adds two new modes:

All Levels
Instead of creating TC sources with LODs M..MXL, where M is the highest LOD from the vertex trace, it always uploads mip levels 0..MXL. This should have the result of producing fewer duplicate textures when dumping, and potentially increase TC efficiency, since there's less duplicates in the hash cache too.

Unclamped
This is a new, enhanced mode, that uses the full range of texture LODs that the game provides, but ignores the L/K values/game's bias. This results in higher-resolution textures being used when upscaling, and makes anisotropic filtering work again without requiring forced trilinear.

Rationale behind Changes
New enhancement for improved visuals in games, because forcing mipmapping everywhere was actually a visual regression in some cases.

credit by stenzek

### Suggested Testing Steps
 Burnout 3, Need for speed 6 ,and other racing games with super long viewing distance
