### PR TITLE
Achievements: Reset client state on system reset

### DIFF
--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -1706,6 +1706,8 @@ void VMManager::Reset()
 	if (elf_was_changed)
 		HandleELFChange(false);
 
+	Achievements::ResetClient();
+
 	mmap_ResetBlockTracking();
 	memSetExtraMemMode(EmuConfig.Cpu.ExtraMemory);
 	Internal::ClearCPUExecutionCaches();


### PR DESCRIPTION
### Description of Changes
When resetting the VM we didn't notify the rc client

### Rationale behind Changes
Game achievement state wouldn't be reset when you reset the VM

### Suggested Testing Steps
See if https://github.com/PCSX2/pcsx2/issues/11795 is fixed