### PR TITLE
CDVD: Added cdvdTrack, cdvdTrackIndex, assigned subQ from hardware reads

### DIFF
--- a/pcsx2/CDVD/CDVDcommon.cpp
+++ b/pcsx2/CDVD/CDVDcommon.cpp
@@ -52,6 +52,11 @@ u32 lastLSN; // needed for block dumping
 
 static OutputIsoFile blockDumpFile;
 
+// Information about tracks on disc
+u8 strack;
+u8 etrack;
+cdvdTrack tracks[100];
+
 // Assertion check for CDVD != NULL (in devel and debug builds), because its handier than
 // relying on DEP exceptions -- and a little more reliable too.
 static void CheckNullCDVD()

--- a/pcsx2/CDVD/CDVDcommon.h
+++ b/pcsx2/CDVD/CDVDcommon.h
@@ -10,19 +10,48 @@
 class Error;
 class ProgressCallback;
 
-typedef struct _cdvdSubQ
+typedef struct _cdvdTrackIndex
 {
-	u8 ctrl : 4; // control and mode bits
-	u8 mode : 4; // control and mode bits
+	bool isPregap;
+	u8 trackM; // current minute offset from first track (BCD encoded)
+	u8 trackS; // current sector offset from first track (BCD encoded)
+	u8 trackF; // current frame offset from first track (BCD encoded)
+	u8 discM; // current minute location on the disc (BCD encoded)
+	u8 discS; // current sector location on the disc (BCD encoded)
+	u8 discF; // current frame location on the disc (BCD encoded)
+
+} cdvdTrackIndex;
+
+typedef struct _cdvdTrack
+{
+	u32 start_lba; // Starting lba of track, note that some formats will be missing 2 seconds, cue, bin
+	u8 type; // Track Type
 	u8 trackNum; // current track number (1 to 99)
 	u8 trackIndex; // current index within track (0 to 99)
-	u8 trackM; // current minute location on the disc (BCD encoded)
-	u8 trackS; // current sector location on the disc (BCD encoded)
-	u8 trackF; // current frame location on the disc (BCD encoded)
+	u8 trackM; // current minute offset from first track (BCD encoded)
+	u8 trackS; // current sector offset from first track (BCD encoded)
+	u8 trackF; // current frame offset from first track (BCD encoded)
+	u8 discM; // current minute location on the disc (BCD encoded)
+	u8 discS; // current sector location on the disc (BCD encoded)
+	u8 discF; // current frame location on the disc (BCD encoded)
+
+	// 0 is pregap, 1 is data
+	_cdvdTrackIndex index[2];
+} cdvdTrack;
+
+typedef struct _cdvdSubQ
+{
+	u8 ctrl : 4; // control and adr bits
+	u8 adr : 4; // control and adr bits, note that adr determines what SubQ info we're recieving.
+	u8 trackNum; // current track number (1 to 99)
+	u8 trackIndex; // current index within track (0 to 99)
+	u8 trackM; // current minute offset from first track (BCD encoded)
+	u8 trackS; // current sector offset from first track (BCD encoded)
+	u8 trackF; // current frame offset from first track (BCD encoded)
 	u8 pad; // unused
-	u8 discM; // current minute offset from first track (BCD encoded)
-	u8 discS; // current sector offset from first track (BCD encoded)
-	u8 discF; // current frame offset from first track (BCD encoded)
+	u8 discM; // current minute location on the disc (BCD encoded)
+	u8 discS; // current sector location on the disc (BCD encoded)
+	u8 discF; // current frame location on the disc (BCD encoded)
 } cdvdSubQ;
 
 typedef struct _cdvdTD
@@ -64,6 +93,12 @@ typedef struct _cdvdTN
 #define CDVD_TYPE_DETCTCD 0x02 // Detecting Cd
 #define CDVD_TYPE_DETCT 0x01 // Detecting
 #define CDVD_TYPE_NODISC 0x00 // No Disc
+
+// SUBQ CONTROL:
+#define CDVD_CONTROL_AUDIO_PREEMPHASIS(control) ((control & (4 << 1)))
+#define CDVD_CONTROL_DIGITAL_COPY_ALLOWED(control) ((control & (5 << 1)))
+#define CDVD_CONTROL_IS_DATA(control) ((control & (6 << 1))) // Detects if track is Data or Audio
+#define CDVD_CONTROL_IS_QUADRAPHONIC_AUDIO(control) ((control & (7 << 1)))
 
 // CDVDgetTrayStatus returns:
 #define CDVD_TRAY_CLOSE 0x00
@@ -147,6 +182,10 @@ extern const CDVD_API* CDVD; // currently active CDVD access mode api (either Is
 extern const CDVD_API CDVDapi_Iso;
 extern const CDVD_API CDVDapi_Disc;
 extern const CDVD_API CDVDapi_NoDisc;
+
+extern u8 strack;
+extern u8 etrack;
+extern cdvdTrack tracks[100];
 
 extern void CDVDsys_ChangeSource(CDVD_SourceType type);
 extern void CDVDsys_SetFile(CDVD_SourceType srctype, std::string newfile);

--- a/pcsx2/CDVD/CDVDdiscReader.cpp
+++ b/pcsx2/CDVD/CDVDdiscReader.cpp
@@ -76,31 +76,35 @@ void cdvdParseTOC()
 	strack = 0xFF;
 	etrack = 0;
 
+	int i = 0;
+
 	for (auto& entry : src->ReadTOC())
 	{
 		if (entry.track < 1 || entry.track > 99)
 			continue;
 		strack = std::min(strack, entry.track);
 		etrack = std::max(etrack, entry.track);
-		tracks[entry.track].start_lba = entry.lba;
+		tracks[i].start_lba = entry.lba;
 		if ((entry.control & 0x0C) == 0x04)
 		{
 			std::array<u8, 2352> buffer;
 			// Byte 15 of a raw CD data sector determines the track mode
 			if (src->ReadSectors2352(entry.lba, 1, buffer.data()) && (buffer[15] & 3) == 2)
 			{
-				tracks[entry.track].type = CDVD_MODE2_TRACK;
+				tracks[i].type = CDVD_MODE2_TRACK;
 			}
 			else
 			{
-				tracks[entry.track].type = CDVD_MODE1_TRACK;
+				tracks[i].type = CDVD_MODE1_TRACK;
 			}
 		}
 		else
 		{
-			tracks[entry.track].type = CDVD_AUDIO_TRACK;
+			tracks[i].type = CDVD_AUDIO_TRACK;
 		}
 		fprintf(stderr, "Track %u start sector: %u\n", entry.track, entry.lba);
+
+		i += 1;
 	}
 }
 

--- a/pcsx2/CDVD/CDVDdiscReader.h
+++ b/pcsx2/CDVD/CDVDdiscReader.h
@@ -7,6 +7,7 @@
 #include "common/RedtapeWindows.h"
 #endif
 
+#include "CDVDcommon.h"
 #include "common/Pcsx2Defs.h"
 
 #include <array>
@@ -16,16 +17,6 @@
 #include <vector>
 
 class Error;
-
-struct track
-{
-	u32 start_lba;
-	u8 type;
-};
-
-extern u8 strack;
-extern u8 etrack;
-extern track tracks[100];
 
 extern int curDiskType;
 extern int curTrayStatus;
@@ -70,6 +61,7 @@ public:
 	const std::vector<toc_entry>& ReadTOC() const;
 	bool ReadSectors2048(u32 sector, u32 count, u8* buffer) const;
 	bool ReadSectors2352(u32 sector, u32 count, u8* buffer) const;
+	bool ReadTrackSubQ(cdvdSubQ* subq) const;
 	u32 GetLayerBreakAddress() const;
 	s32 GetMediaType() const;
 	void SetSpindleSpeed(bool restore_defaults) const;

--- a/pcsx2/CDVD/CDVDisoReader.cpp
+++ b/pcsx2/CDVD/CDVDisoReader.cpp
@@ -65,7 +65,7 @@ static s32 ISOreadSubQ(u32 lsn, cdvdSubQ* subq)
 	// fake it
 	u8 min, sec, frm;
 	subq->ctrl = 4;
-	subq->mode = 1;
+	subq->adr = 1;
 	subq->trackNum = itob(1);
 	subq->trackIndex = itob(1);
 

--- a/pcsx2/CDVD/Darwin/IOCtlSrc.cpp
+++ b/pcsx2/CDVD/Darwin/IOCtlSrc.cpp
@@ -241,6 +241,11 @@ bool IOCtlSrc::ReadCDInfo()
 #endif
 }
 
+bool IOCtlSrc::ReadTrackSubQ(cdvdSubQ* subQ) const
+{
+	return false;
+}
+
 bool IOCtlSrc::DiscReady()
 {
 #ifdef __APPLE__

--- a/pcsx2/CDVD/Linux/IOCtlSrc.cpp
+++ b/pcsx2/CDVD/Linux/IOCtlSrc.cpp
@@ -5,6 +5,7 @@
 #include "CDVD/CDVD.h"
 
 #include "common/Error.h"
+#include "common/Console.h"
 
 #include <linux/cdrom.h>
 #include <fcntl.h>
@@ -193,6 +194,35 @@ bool IOCtlSrc::ReadCDInfo()
 
 	return true;
 }
+
+bool IOCtlSrc::ReadTrackSubQ(cdvdSubQ* subQ) const
+{
+	cdrom_subchnl osSubQ;
+
+	osSubQ.cdsc_format = CDROM_MSF;
+
+	if (ioctl(m_device, CDROMSUBCHNL, &osSubQ) == -1)
+	{
+		Console.Error("SUB CHANNEL READ ERROR: %s\n", strerror(errno));
+		return false;
+	}
+
+	subQ->adr = osSubQ.cdsc_adr;
+	subQ->ctrl = osSubQ.cdsc_ctrl;
+	subQ->trackNum = osSubQ.cdsc_trk;
+	subQ->trackIndex = osSubQ.cdsc_ind;
+
+	subQ->discM = osSubQ.cdsc_absaddr.msf.minute;
+	subQ->discS = osSubQ.cdsc_absaddr.msf.second;
+	subQ->discF = osSubQ.cdsc_absaddr.msf.frame;
+
+	subQ->trackM = osSubQ.cdsc_reladdr.msf.minute;
+	subQ->trackS = osSubQ.cdsc_reladdr.msf.second;
+	subQ->trackF = osSubQ.cdsc_reladdr.msf.frame;
+
+	return true;
+}
+
 
 bool IOCtlSrc::DiscReady()
 {


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Added cdvdTrack, cdvdTrackIndex, changed sub Q mode field to ADR

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
- Prep work for track-based formats like CHD, BIN / CUE. Using cdvdTrack as a common type for all track reading formats including CDVD Disc reader. 

- [Other than that, moar accuracy](https://psx-spx.consoledev.net/cdromdrive/#subchannel-q) 

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Already tested, PR makes no significant changes to CD-based games outside of more correct SubQ reads and fixes Track layout in array. This fixes Dance Factory by pushing tracks into, 0 indexed array instead of 1 indexed