### PR TITLE
OSD: Rename and split G and V values

### DIFF
--- a/pcsx2-qt/QtHost.cpp
+++ b/pcsx2-qt/QtHost.cpp
@@ -1052,14 +1052,14 @@ void EmuThread::updatePerformanceMetrics(bool force)
 		if (gfps != m_last_game_fps || force)
 		{
 			QMetaObject::invokeMethod(g_main_window->getStatusFPSWidget(), "setText", Qt::QueuedConnection,
-				Q_ARG(const QString&, tr("Game: %1 FPS").arg(gfps, 0, 'f', 0)));
+				Q_ARG(const QString&, tr("FPS: %1").arg(gfps, 0, 'f', 0)));
 			m_last_game_fps = gfps;
 		}
 
 		if (speed != m_last_speed || vfps != m_last_video_fps || force)
 		{
 			QMetaObject::invokeMethod(g_main_window->getStatusVPSWidget(), "setText", Qt::QueuedConnection,
-				Q_ARG(const QString&, tr("Video: %1 FPS (%2%)").arg(vfps, 0, 'f', 0).arg(speed, 0, 'f', 0)));
+				Q_ARG(const QString&, tr("VPS: %1 (%2%) ").arg(vfps, 0, 'f', 0).arg(speed, 0, 'f', 0)));
 			m_last_speed = speed;
 			m_last_video_fps = vfps;
 		}

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -117,6 +117,7 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* dialog, QWidget* 
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.osdPerformancePos, "EmuCore/GS", "OsdPerformancePos", static_cast<int>(OsdOverlayPos::TopRight));
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.osdShowSpeed, "EmuCore/GS", "OsdShowSpeed", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.osdShowFPS, "EmuCore/GS", "OsdShowFPS", false);
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.osdShowVPS, "EmuCore/GS", "OsdShowVPS", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.osdShowCPU, "EmuCore/GS", "OsdShowCPU", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.osdShowGPU, "EmuCore/GS", "OsdShowGPU", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.osdShowResolution, "EmuCore/GS", "OsdShowResolution", false);
@@ -718,6 +719,9 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* dialog, QWidget* 
 
 		dialog->registerWidgetHelp(m_ui.osdShowFPS, tr("Show FPS"), tr("Unchecked"),
 			tr("Shows the internal frame rate of the game in the top-right corner of the display."));
+
+		dialog->registerWidgetHelp(m_ui.osdShowVPS, tr("Show VPS"), tr("Unchecked"),
+			tr("Shows the vsync rate of the emulator in the top-right corner of the display."));
 
 		dialog->registerWidgetHelp(m_ui.osdShowSpeed, tr("Show Speed Percentages"), tr("Unchecked"),
 			tr("Shows the current emulation speed of the system in the top-right corner of the display as a percentage."));

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
@@ -1622,24 +1622,10 @@
           </item>
           <item row="3" column="0" colspan="2">
            <layout class="QGridLayout" name="osdOptionLayout">
-            <item row="0" column="0">
-             <widget class="QCheckBox" name="osdShowResolution">
+            <item row="6" column="1">
+             <widget class="QCheckBox" name="osdShowVideoCapture">
               <property name="text">
-               <string>Show Resolution</string>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="1">
-             <widget class="QCheckBox" name="osdShowFPS">
-              <property name="text">
-               <string>Show FPS</string>
-              </property>
-             </widget>
-            </item>
-            <item row="5" column="0">
-             <widget class="QCheckBox" name="osdShowFrameTimes">
-              <property name="text">
-               <string>Show Frame Times</string>
+               <string>Show Video Capture Status</string>
               </property>
              </widget>
             </item>
@@ -1650,24 +1636,17 @@
               </property>
              </widget>
             </item>
+            <item row="5" column="1">
+             <widget class="QCheckBox" name="osdShowInputRec">
+              <property name="text">
+               <string>Show Input Recording Status</string>
+              </property>
+             </widget>
+            </item>
             <item row="4" column="1">
              <widget class="QCheckBox" name="osdShowInputs">
               <property name="text">
                <string>Show Inputs</string>
-              </property>
-             </widget>
-            </item>
-            <item row="3" column="1">
-             <widget class="QCheckBox" name="osdShowSettings">
-              <property name="text">
-               <string>Show Settings</string>
-              </property>
-             </widget>
-            </item>
-            <item row="3" column="0">
-             <widget class="QCheckBox" name="osdShowIndicators">
-              <property name="text">
-               <string>Show Indicators</string>
               </property>
              </widget>
             </item>
@@ -1685,24 +1664,31 @@
               </property>
              </widget>
             </item>
-            <item row="2" column="0">
-             <widget class="QCheckBox" name="osdShowVersion">
+            <item row="5" column="0">
+             <widget class="QCheckBox" name="osdShowFrameTimes">
               <property name="text">
-               <string>Show PCSX2 Version</string>
+               <string>Show Frame Times</string>
               </property>
              </widget>
             </item>
-            <item row="5" column="1">
-             <widget class="QCheckBox" name="osdShowInputRec">
+            <item row="3" column="1">
+             <widget class="QCheckBox" name="osdShowSettings">
               <property name="text">
-               <string>Show Input Recording Status</string>
+               <string>Show Settings</string>
               </property>
              </widget>
             </item>
-            <item row="6" column="1">
-             <widget class="QCheckBox" name="osdShowVideoCapture">
+            <item row="7" column="0">
+             <widget class="QCheckBox" name="warnAboutUnsafeSettings">
               <property name="text">
-               <string>Show Video Capture Status</string>
+               <string>Warn About Unsafe Settings</string>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="0">
+             <widget class="QCheckBox" name="osdShowIndicators">
+              <property name="text">
+               <string>Show Indicators</string>
               </property>
              </widget>
             </item>
@@ -1720,10 +1706,31 @@
               </property>
              </widget>
             </item>
-            <item row="7" column="0">
-             <widget class="QCheckBox" name="warnAboutUnsafeSettings">
+            <item row="0" column="1">
+             <widget class="QCheckBox" name="osdShowFPS">
               <property name="text">
-               <string>Warn About Unsafe Settings</string>
+               <string>Show FPS</string>
+              </property>
+             </widget>
+            </item>
+            <item row="7" column="1">
+             <widget class="QCheckBox" name="osdShowVersion">
+              <property name="text">
+               <string>Show PCSX2 Version</string>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="0">
+             <widget class="QCheckBox" name="osdShowResolution">
+              <property name="text">
+               <string>Show Resolution</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="0">
+             <widget class="QCheckBox" name="osdShowVPS">
+              <property name="text">
+               <string>Show VPS</string>
               </property>
              </widget>
             </item>

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -619,6 +619,7 @@ struct Pcsx2Config
 					SkipDuplicateFrames : 1,
 					OsdShowSpeed : 1,
 					OsdShowFPS : 1,
+					OsdShowVPS : 1,
 					OsdShowCPU : 1,
 					OsdShowGPU : 1,
 					OsdShowResolution : 1,

--- a/pcsx2/ImGui/ImGuiOverlays.cpp
+++ b/pcsx2/ImGui/ImGuiOverlays.cpp
@@ -132,41 +132,45 @@ __ri void ImGuiManager::DrawPerformanceOverlay(float& position_y, float scale, f
 			switch (PerformanceMetrics::GetInternalFPSMethod())
 			{
 				case PerformanceMetrics::InternalFPSMethod::GSPrivilegedRegister:
-					text.append_format("G: {:.2f} [P] | V: {:.2f}", PerformanceMetrics::GetInternalFPS(),
+					text.append_format("FPS: {:.2f} [P]", PerformanceMetrics::GetInternalFPS(),
 						PerformanceMetrics::GetFPS());
 					break;
 
 				case PerformanceMetrics::InternalFPSMethod::DISPFBBlit:
-					text.append_format("G: {:.2f} [B] | V: {:.2f}", PerformanceMetrics::GetInternalFPS(),
+					text.append_format("FPS: {:.2f} [B]", PerformanceMetrics::GetInternalFPS(),
 						PerformanceMetrics::GetFPS());
 					break;
 
 				case PerformanceMetrics::InternalFPSMethod::None:
 				default:
-					text.append_format("V: {:.2f}", PerformanceMetrics::GetFPS());
+					text.append_format("FPS: {:.2f}", PerformanceMetrics::GetFPS());
 					break;
 			}
 			first = false;
 		}
 
+		if (GSConfig.OsdShowVPS)
+		{
+			text.append_format("{}VPS: {:.2f}", first ? "" : " | ", PerformanceMetrics::GetFPS(),
+				PerformanceMetrics::GetFPS());
+			first = false;
+		}
+
 		if (GSConfig.OsdShowSpeed)
 		{
-			text.append_format("{}{}%", first ? "" : " | ", static_cast<u32>(std::round(speed)));
+			text.append_format("{}Speed: {}%", first ? "" : " | ", static_cast<u32>(std::round(speed)));
 
 			const float target_speed = VMManager::GetTargetSpeed();
 			if (target_speed == 0.0f)
-				text.append(" (Max)");
+				text.append(" (T: Max)");
 			else
-				text.append_format(" ({:.0f}%)", target_speed * 100.0f);
+				text.append_format(" (T: {:.0f}%)", target_speed * 100.0f);
+			first = false;
 		}
 
 		if (GSConfig.OsdShowVersion)
 		{
-			if (GSConfig.OsdShowFPS || GSConfig.OsdShowSpeed)
-			{
-				text.append_format(" | ");
-			}
-			text.append_format("PCSX2 {}", GIT_REV);
+			text.append_format("{}PCSX2 {}", first ? "" : " | ", GIT_REV);
 		}
 
 		if (!text.empty())

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -624,6 +624,7 @@ Pcsx2Config::GSOptions::GSOptions()
 	OsdPerformancePos = OsdOverlayPos::TopRight;
 	OsdShowSpeed = false;
 	OsdShowFPS = false;
+	OsdShowVPS = false;
 	OsdShowCPU = false;
 	OsdShowGPU = false;
 	OsdShowResolution = false;
@@ -834,6 +835,7 @@ void Pcsx2Config::GSOptions::LoadSave(SettingsWrapper& wrap)
 	SettingsWrapBitBool(SkipDuplicateFrames);
 	SettingsWrapBitBool(OsdShowSpeed);
 	SettingsWrapBitBool(OsdShowFPS);
+	SettingsWrapBitBool(OsdShowVPS);
 	SettingsWrapBitBool(OsdShowCPU);
 	SettingsWrapBitBool(OsdShowGPU);
 	SettingsWrapBitBool(OsdShowResolution);


### PR DESCRIPTION
### Description of Changes
Renames and splits the G and V values on the OSD into FPS and VPS and adds Speed with a target percentage eg Max for uncapped. A big thanks to Kam for helping me get into a 3 day long fist fight with the OSD to get the layout correct.

Current display;
![image](https://github.com/user-attachments/assets/531e9b9d-1159-4ed6-b0ac-92c06e9c5b4d)

PR display:
![image](https://github.com/user-attachments/assets/e1fe3cd1-5a84-4bb5-9acf-142381a1c8a7)

### Rationale behind Changes
It will more accurately represent what they do and to make it easier for users to understand what a game is running at and what the emulator is running at as these names are inline with other emulators who use the same terminology for statistics.

### Suggested Testing Steps
Test different combinations of OSD settings between FPS VPS and Speed and make sure these all display and function correctly under different internal FPS type detections eg Privileged Register Blit ect.
