### PR TITLE
Debugger: Improve the responsiveness of some symbol tree widgets

### DIFF
--- a/pcsx2-qt/Debugger/SymbolTree/SymbolTreeDelegates.cpp
+++ b/pcsx2-qt/Debugger/SymbolTree/SymbolTreeDelegates.cpp
@@ -77,6 +77,7 @@ QWidget* SymbolTreeValueDelegate::createEditor(QWidget* parent, const QStyleOpti
 					{
 						QCheckBox* editor = new QCheckBox(parent);
 						editor->setChecked(value.toBool());
+						connect(editor, &QCheckBox::checkStateChanged, this, &SymbolTreeValueDelegate::onCheckBoxStateChanged);
 						result = editor;
 
 						break;
@@ -274,6 +275,13 @@ void SymbolTreeValueDelegate::setModelData(QWidget* editor, QAbstractItemModel* 
 
 	if (value.isValid())
 		model->setData(index, value, SymbolTreeModel::EDIT_ROLE);
+}
+
+void SymbolTreeValueDelegate::onCheckBoxStateChanged(Qt::CheckState state)
+{
+	QCheckBox* check_box = qobject_cast<QCheckBox*>(sender());
+	if (check_box)
+		commitData(check_box);
 }
 
 void SymbolTreeValueDelegate::onComboBoxIndexChanged(int index)

--- a/pcsx2-qt/Debugger/SymbolTree/SymbolTreeDelegates.h
+++ b/pcsx2-qt/Debugger/SymbolTree/SymbolTreeDelegates.h
@@ -21,8 +21,10 @@ public:
 	void setModelData(QWidget* editor, QAbstractItemModel* model, const QModelIndex& index) const override;
 
 protected:
-	// Without this, setModelData would only be called when a combo box was
-	// deselected rather than when an option was picked.
+	// These make it so the values inputted are written back to memory
+	// immediately when the widgets are interacted with rather than when they
+	// are deselected.
+	void onCheckBoxStateChanged(Qt::CheckState state);
 	void onComboBoxIndexChanged(int index);
 
 	DebugInterface& m_cpu;

--- a/pcsx2-qt/Debugger/SymbolTree/SymbolTreeModel.cpp
+++ b/pcsx2-qt/Debugger/SymbolTree/SymbolTreeModel.cpp
@@ -484,6 +484,9 @@ std::vector<std::unique_ptr<SymbolTreeNode>> SymbolTreeModel::populateChildren(
 		}
 	}
 
+	for (std::unique_ptr<SymbolTreeNode>& child : children)
+		child->readFromVM(cpu, database);
+
 	return children;
 }
 


### PR DESCRIPTION
### Description of Changes
This fixes two minor issues with the symbol trees:
- When you click a checkbox in the symbol tree (displayed for bools) it will now write the new value back to memory immediately instead of waiting for you to deselect the checkbox.
- When you reset the children of a symbol tree node it will now populate their values from memory immediately instead of waiting for them to update. This prevents flicker.

### Rationale behind Changes
It makes the check box widgets delightful to use.

### Suggested Testing Steps
- Create a global variable of type bool for some variable where the result is immediately apparent on screen, and check and uncheck the box repeatedly until you're satisfied that the new behaviour is better.
- Now make an array and click the "Reset Children" context menu option on it, and observe that the children don't flicker.