### PR TITLE
Fix Pro/TOCA/V8SC/DTM Race Driver Vertical Lines

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -14839,8 +14839,8 @@ SLES-50723:
   name: "TOCA Race Driver"
   region: "PAL-M3"
   gsHWFixes:
-    alignSprite: 1 # Fixes vertical lines, also works with normal vertex.
     mergeSprite: 1 # Fixes lighting.
+    halfPixelOffset: 1 # Fixes vertical lines
 SLES-50725:
   name: "V-Rally 3"
   region: "PAL-M5"
@@ -14937,8 +14937,8 @@ SLES-50767:
   name: "V8 Supercars Australia - Race Driver"
   region: "PAL-A"
   gsHWFixes:
-    alignSprite: 1 # Fixes vertical lines, also works with normal vertex.
     mergeSprite: 1 # Fixes lighting.
+    halfPixelOffset: 1 # Fixes vertical lines
 SLES-50768:
   name: "Rally Championship"
   region: "PAL-Unk"
@@ -15104,14 +15104,14 @@ SLES-50816:
   region: "PAL-M3"
   compat: 5
   gsHWFixes:
-    alignSprite: 1 # Fixes vertical lines, also works with normal vertex.
     mergeSprite: 1 # Fixes lighting.
+    halfPixelOffset: 1 # Fixes vertical lines
 SLES-50818:
   name: "Pro Race Driver"
   region: "PAL-I"
   gsHWFixes:
-    alignSprite: 1 # Fixes vertical lines, also works with normal vertex.
     mergeSprite: 1 # Fixes lighting.
+    halfPixelOffset: 1 # Fixes vertical lines
 SLES-50820:
   name: "Micro Machines"
   region: "PAL-M5"
@@ -59733,8 +59733,8 @@ SLUS-20329:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    alignSprite: 1 # Fixes vertical lines, also works with normal vertex.
     mergeSprite: 1 # Fixes lighting.
+    halfPixelOffset: 1 # Fixes vertical lines
 SLUS-20330:
   name: "NBA 2K2 - Sega Sports"
   region: "NTSC-U"


### PR DESCRIPTION
Align sprite no longer works, requires Half Pixel Offset (Normal Vertex).

### Description of Changes
Changed all instances of Align Sprite to Half Pixel Offset in all versions of Pro/TOCA/V8SC/DTM Race Driver.
### Rationale behind Changes
Vertical lines persist with default Align Sprite in recent nightlies, hence the change to normal vertex, as the comments helpfully point out.