### PR TITLE
gh: update the feature request template labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -2,7 +2,7 @@
 name: Feature request
 description: Suggest a new feature or improve an existing one
 title: "[Feature Request]: "
-labels: ["Enhancement / Feature Request"]
+labels: ["Enhancement / Feature Request", "FR: Awaiting Consideration"]
 # assignees:
 #   - octocat
 body:


### PR DESCRIPTION
We will be trying out a new feature request labelling system.

Feature requests (abbreviated as FR) are going to have a `FR: Awaiting Consideration` label once created.

Once a team member looks over it they will remove the  `FR: Awaiting Consideration` label and categorize the feature request based on their complexity and priority.

There are a new bunch of labels for this system:
Priority
![image](https://github.com/user-attachments/assets/bc0e4cfa-cace-4c35-b17e-71b354143f37)
![image](https://github.com/user-attachments/assets/ca506f23-99f9-403d-8945-388651012754)
![image](https://github.com/user-attachments/assets/24b3ad59-9f3b-4354-bd78-47dff915bf3f)
Complexity
![image](https://github.com/user-attachments/assets/167d03ab-3003-4658-91ac-108794f71211)
![image](https://github.com/user-attachments/assets/926e3e34-6474-4e80-8535-018649a26701)
![image](https://github.com/user-attachments/assets/640a1a2b-a450-47e1-ab67-8f4a52053d64)

I hope that this helps new and current contributors find tasks that need to be worked on. I also hope that this helps with this years Hacktoberfest which we plan on participating in.