### PR TITLE
Memory Card: Count auto eject ticks by command, not vsync

### DIFF
--- a/pcsx2/Counters.cpp
+++ b/pcsx2/Counters.cpp
@@ -499,8 +499,6 @@ static __fi void VSyncStart(u32 sCycle)
 	if (EmuConfig.Trace.Enabled && EmuConfig.Trace.EE.m_EnableAll)
 		SysTrace.EE.Counters.Write("    ================  EE COUNTER VSYNC START (frame: %d)  ================", g_FrameCount);
 
-	// Memcard auto ejection - Uses a tick system timed off of real time, decrementing one tick per frame.
-	AutoEject::CountDownTicks();
 	// Memcard IO detection - Uses a tick system to determine when memcards are no longer being written.
 	MemcardBusy::Decrement();
 

--- a/pcsx2/SIO/Sio.cpp
+++ b/pcsx2/SIO/Sio.cpp
@@ -79,7 +79,7 @@ void AutoEject::CountDownTicks()
 
 	if (reinserted)
 	{
-		Host::AddIconOSDMessage("AutoEjectAllSet", ICON_PF_MEMORY_CARD,
+		Host::AddIconOSDMessage("AutoEjectCountDownFinished", ICON_PF_MEMORY_CARD,
 			TRANSLATE_SV("MemoryCard", "Memory Cards reinserted."), Host::OSD_INFO_DURATION);
 	}
 }
@@ -88,7 +88,7 @@ void AutoEject::Set(size_t port, size_t slot)
 {
 	if (mcds[port][slot].autoEjectTicks == 0)
 	{
-		mcds[port][slot].autoEjectTicks = 60; // 60 frames is enough.
+		mcds[port][slot].autoEjectTicks = 80; // Number of memcard commands which will be answered as all 0xFF (no signal)
 		mcds[port][slot].term = Terminator::NOT_READY; // Reset terminator to NOT_READY (0x66), forces the PS2 to recheck the memcard.
 	}
 }
@@ -101,7 +101,7 @@ void AutoEject::Clear(size_t port, size_t slot)
 void AutoEject::SetAll()
 {
 	Host::AddIconOSDMessage("AutoEjectAllSet", ICON_PF_MEMORY_CARD,
-		TRANSLATE_SV("MemoryCard", "Force ejecting all Memory Cards. Reinserting in 1 second."), Host::OSD_INFO_DURATION);
+		TRANSLATE_SV("MemoryCard", "Force ejecting all Memory Cards. Reinserting after game has detected them as ejected."), Host::OSD_INFO_DURATION);
 
 	for (size_t port = 0; port < SIO::PORTS; port++)
 	{

--- a/pcsx2/SIO/Sio2.cpp
+++ b/pcsx2/SIO/Sio2.cpp
@@ -259,6 +259,8 @@ void Sio2::Memcard()
 			g_Sio2FifoOut.push_back(0xff);
 		}
 
+		// Remove one tick for this command.
+		AutoEject::CountDownTicks();
 		return;
 	}
 


### PR DESCRIPTION
### Description of Changes
Switches memory card auto eject behavior back to the old method, counting memory card commands rather than vsyncs.

### Rationale behind Changes
Not all games are reacting to terminator resets as expected. Some games such as Neo Contra seem to not bother reindexing after a terminator reset. While they may indeed go through re-authorization, it looks like the game might still try using its old index of the memory card, which in turn will blow it up.

The side effect is this will bring back the old behavior where a game will not detect a card for a bit and you will have to retry a few times. But this is better than losing all your save data forever.

### Suggested Testing Steps
Boot a game, capture a savestate, save the game to the memory card, load the savestate. The card should eject, and then the game should not detect it immediately next time you try to save to the memory card. After a few retries, it should work.

Some games such as Ratchet and Clank constantly probe the memory card even when not in active use, and these games will almost immediately redetect the card.
