### PR TITLE
BugFix: Error popup on insufficient permissions during memcard conversion

### DIFF
--- a/.github/workflows/scripts/linux/build-dependencies-qt.sh
+++ b/.github/workflows/scripts/linux/build-dependencies-qt.sh
@@ -51,7 +51,7 @@ aa27e4454ce631c5a17924ce0624eac736da19fc6f5a2ab15a6c58da7b36950f  shaderc-glslan
 03ee1a2c06f3b61008478f4abe9423454e53e580b9488b47c8071547c6a9db47  shaderc-spirv-tools-$SHADERC_SPIRVTOOLS.tar.gz
 EOF
 
-curl -C - -L \
+curl -L \
 	-O "https://github.com/ianlancetaylor/libbacktrace/archive/$LIBBACKTRACE.zip" \
 	-O "https://ijg.org/files/jpegsrc.v$LIBJPEG.tar.gz" \
 	-O "https://downloads.sourceforge.net/project/libpng/libpng16/$LIBPNG/libpng-$LIBPNG.tar.xz" \

--- a/pcsx2-qt/Settings/MemoryCardConvertDialog.h
+++ b/pcsx2-qt/Settings/MemoryCardConvertDialog.h
@@ -41,6 +41,7 @@ private:
 	void SetType_32();
 	void SetType_64();
 	void SetType_Folder();
+	void FileOpenError(const QString errmsg);
 	
 	Ui::MemoryCardConvertDialog m_ui;
 


### PR DESCRIPTION
### Description of Changes
Added a permissions check during the conversion of a memory card. It occurred to me that if somehow the permissions change during the setup of the conversion, then it will finish successfully, but wont be copied over to the new directory.

Furthermore, I also made a slight modification to the `build-dependencies.sh`, as I had an error when using curl.
More specifically: `curl: (33) HTTP server does not seem to support byte ranges. Cannot resume.`

### Rationale behind Changes
Its just a bug fix. Helps user understand what went wrong.

### Suggested Testing Steps
- Have permissions to the memcard directory
- Select a memcard for conversion
- When the popup is displayed, change permissions of the directory to nobody (`sudo chmod 000 ./memory_save`)
- Start conversion

This time you should get an error popup.