### PR TITLE
Qt: Fix for keyboard SHIFT with non-alpha characters

### DIFF
--- a/pcsx2-qt/QtKeyCodes.cpp
+++ b/pcsx2-qt/QtKeyCodes.cpp
@@ -13,6 +13,53 @@
 
 #include <QtGui/QKeyEvent>
 
+u8 map_text_to_keycode(const QString& text)
+{
+	if (text == "!")
+		return Qt::Key_1;
+	if (text == "@")
+		return Qt::Key_2;
+	if (text == "#")
+		return Qt::Key_3;
+	if (text == "$")
+		return Qt::Key_4;
+	if (text == "%")
+		return Qt::Key_5;
+	if (text == "^")
+		return Qt::Key_6;
+	if (text == "&")
+		return Qt::Key_7;
+	if (text == "*")
+		return Qt::Key_8;
+	if (text == "(")
+		return Qt::Key_9;
+	if (text == ")")
+		return Qt::Key_0;
+	if (text == "_")
+		return Qt::Key_Minus;
+	if (text == "+")
+		return Qt::Key_Equal;
+	if (text == "?")
+		return Qt::Key_Slash;
+	if (text == ":")
+		return Qt::Key_Semicolon;
+	if (text == "\"")
+		return Qt::Key_Apostrophe;
+	if (text == "~")
+		return Qt::Key_QuoteLeft;
+	if (text == "<")
+		return Qt::Key_Comma;
+	if (text == ">")
+		return Qt::Key_Period;
+	if (text == "|")
+		return Qt::Key_Backslash;
+	if (text == "{")
+		return Qt::Key_BracketLeft;
+	if (text == "}")
+		return Qt::Key_BracketRight;
+	return 0; // No remapping
+}
+
 struct KeyCodeName
 {
 	int code;
@@ -519,7 +566,15 @@ const char* InputManager::ConvertHostKeyboardCodeToIcon(u32 code)
 
 u32 QtUtils::KeyEventToCode(const QKeyEvent* ev)
 {
+	const QString text = ev->text();
+	const u8 keycode = map_text_to_keycode(text); // Map special text symbols to keycodes
 	int key = ev->key();
+
+	if (keycode != 0)
+	{
+		key = keycode; // Override key if mapped
+	}
+
 	Qt::KeyboardModifiers modifiers = ev->modifiers();
 
 #ifdef __APPLE__


### PR DESCRIPTION
This addresses an issue present in EQOA where SHIFT only worked on alpha characters. SHIFT now is detected and works to produce symbols as well. It also should address most issues reported in https://github.com/PCSX2/pcsx2/issues/7605.

### Description of Changes
This pull request introduces functionality that allows the SHIFT key to be properly detected for non-alpha characters. The change fixes an issue present in EQOA where symbols (e.g., "!" or "@") were not being produced when SHIFT was pressed in conjunction with number keys and other symbol-producing keys.

### Rationale behind Changes
The previous behavior only detected SHIFT for alphabetic characters, limiting the usability of symbol entry. This change ensures that symbols can be correctly produced when the SHIFT key is pressed alongside other keys, addressing a specific issue in EQOA and improving the general user experience for keyboard input.

### Suggested Testing Steps
Run EQOA (or any other game supporting text input) and enter the game's text input mode.
Test SHIFT in combination with number keys and special characters (e.g., SHIFT + 1 should produce "!").
Ensure that all alphanumeric and symbol-producing keys are functioning as expected when combined with SHIFT.
Confirm that no regressions have occurred for other keyboard inputs, especially when typing in normal lowercase or uppercase.

NOTE: Some games appears to not support certain characters by design. EQOA doesn't render # for example. 