### PR TITLE
DebugInterface: Try to show the kernel memory mappings, again

### DIFF
--- a/pcsx2/DebugTools/DebugInterface.cpp
+++ b/pcsx2/DebugTools/DebugInterface.cpp
@@ -828,12 +828,16 @@ bool R5900DebugInterface::isValidAddress(u32 addr)
 				return true;
 			break;
 		case 8:
-		case 9:
 		case 0xA:
+			if(lopart <= 0xFFFFF)
+				return true;
+			break;
+		case 9:
 		case 0xB:
 			// [ 8000_0000 - BFFF_FFFF ] kernel
 			if (lopart >= 0xFC00000)
 				return true;
+			break;
 		case 0xF:
 			// [ 8000_0000 - BFFF_FFFF ] IOP or kernel stack
 			if (lopart >= 0xfff8000)


### PR DESCRIPTION
### Description of Changes
Try to allow debugger kernel memory access.

### Rationale behind Changes
I changed it long ago to allow 0xBFCxxxx access but this caused crashes when accessing invalid 0x8xxxxxxx mappings.
I then partially reverted this change, and now I need kernel access again so this is my attempt at having both mappings work and not crash.

### Suggested Testing Steps
Access kernel memory and beyond and hope it doesn't crash.
