### PR TITLE
Add native pixel ratio 640:448 (10:7)

### DIFF
--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
@@ -104,6 +104,11 @@
            <string>Widescreen (16:9)</string>
           </property>
          </item>
+         <item>
+          <property name="text">
+           <string>Native (10:7)</string>
+          </property>
+         </item>
         </widget>
        </item>
        <item row="2" column="0">
@@ -133,6 +138,11 @@
          <item>
           <property name="text">
            <string>Widescreen (16:9)</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Native (10:7)</string>
           </property>
          </item>
         </widget>

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -196,6 +196,7 @@ enum class AspectRatioType : u8
 	RAuto4_3_3_2,
 	R4_3,
 	R16_9,
+	R10_7,
 	MaxCount
 };
 
@@ -205,6 +206,7 @@ enum class FMVAspectRatioSwitchType : u8
 	RAuto4_3_3_2,
 	R4_3,
 	R16_9,
+	R10_7,
 	MaxCount
 };
 

--- a/pcsx2/Counters.cpp
+++ b/pcsx2/Counters.cpp
@@ -469,6 +469,9 @@ static __fi void DoFMVSwitch()
 		case FMVAspectRatioSwitchType::R16_9:
 			EmuConfig.CurrentAspectRatio = new_fmv_state ? AspectRatioType::R16_9 : EmuConfig.GS.AspectRatio;
 			break;
+		case FMVAspectRatioSwitchType::R10_7:
+			EmuConfig.CurrentAspectRatio = new_fmv_state ? AspectRatioType::R10_7 : EmuConfig.GS.AspectRatio;
+			break;
 		default:
 			break;
 	}

--- a/pcsx2/GS/Renderers/Common/GSRenderer.cpp
+++ b/pcsx2/GS/Renderers/Common/GSRenderer.cpp
@@ -277,7 +277,7 @@ float GSRenderer::GetModXYOffset()
 
 static float GetCurrentAspectRatioFloat(bool is_progressive)
 {
-	static constexpr std::array<float, static_cast<size_t>(AspectRatioType::MaxCount) + 1> ars = {{4.0f / 3.0f, 4.0f / 3.0f, 4.0f / 3.0f, 16.0f / 9.0f, 3.0f / 2.0f}};
+	static constexpr std::array<float, static_cast<size_t>(AspectRatioType::MaxCount) + 1> ars = {{4.0f / 3.0f, 4.0f / 3.0f, 4.0f / 3.0f, 16.0f / 9.0f, 10.0f / 7.0f, 3.0f / 2.0f}};
 	return ars[static_cast<u32>(GSConfig.AspectRatio) + (3u * (is_progressive && GSConfig.AspectRatio == AspectRatioType::RAuto4_3_3_2))];
 }
 
@@ -300,7 +300,13 @@ static GSVector4 CalculateDrawDstRect(s32 window_width, s32 window_height, const
 		targetAr = 4.0f / 3.0f;
 	}
 	else if (EmuConfig.CurrentAspectRatio == AspectRatioType::R16_9)
+	{
 		targetAr = 16.0f / 9.0f;
+	}
+	else if (EmuConfig.CurrentAspectRatio == AspectRatioType::R10_7)
+	{
+		targetAr = 10.0f / 7.0f;
+	}
 
 	const float crop_adjust = (static_cast<float>(src_rect.width()) / static_cast<float>(src_size.x)) /
 		(static_cast<float>(src_rect.height()) / static_cast<float>(src_size.y));

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -553,6 +553,7 @@ const char* Pcsx2Config::GSOptions::AspectRatioNames[] = {
 	"Auto 4:3/3:2",
 	"4:3",
 	"16:9",
+	"10:7",
 	nullptr};
 
 const char* Pcsx2Config::GSOptions::FMVAspectRatioSwitchNames[] = {
@@ -560,6 +561,7 @@ const char* Pcsx2Config::GSOptions::FMVAspectRatioSwitchNames[] = {
 	"Auto 4:3/3:2",
 	"4:3",
 	"16:9",
+	"10:7",
 	nullptr};
 
 const char* Pcsx2Config::GSOptions::BlendingLevelNames[] = {

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -877,6 +877,9 @@ void VMManager::RequestDisplaySize(float scale /*= 0.0f*/)
 		case AspectRatioType::R16_9:
 			x_scale = (16.0f / 9.0f) / (static_cast<float>(iwidth) / static_cast<float>(iheight));
 			break;
+		case AspectRatioType::R10_7:
+			x_scale = (10.0f / 7.0f) / (static_cast<float>(iwidth) / static_cast<float>(iheight));
+			break;
 		case AspectRatioType::Stretch:
 		default:
 			x_scale = 1.0f;


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Add native pixel ratio 640:448 (10:7) for some games.
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Most games have an internal native pixel ratio of 640:448 (10:7), which is then stretched to 4:3, and the developers at the time were also well aware of this. So 4:3 usually gets the correct ratio. However, there are always exceptions, and some game developers seem to insist on using the original pixel ratio instead of 4:3 to express the true effect of the game. If still stretch it to 4:3 in pcsx2, causing the y-axis to be stretched by 7.14% and the character to look a bit thin and long visually.

For example:

Tekken Tag Tournament

4:3 ratio
![Tekken Tag Tournament_SLPS-20015_20240920095538](https://github.com/user-attachments/assets/59833b71-c572-4609-8ad0-6fd2b312a091)
native ratio
![Tekken Tag Tournament_SLPS-20015_20240920095519](https://github.com/user-attachments/assets/77c1128b-6dfb-4119-ae20-a201e2abe88c)


Sengoku Basara X

4:3 ratio
![Sengoku Basara X_SLPM-55008_20240920100742](https://github.com/user-attachments/assets/2bad38b3-9cf6-4dff-91d3-d06cb1589abc)
native ratio
![Sengoku Basara X_SLPM-55008_20240920100748](https://github.com/user-attachments/assets/25a6ed94-0ad5-47b9-bdcb-a704127e247c)


Tenchu: Fatal Shadows
Although its internal resolution is 512:448, it seems to follow the 10:7 ratio.

4:3 ratio
![Tenchu Kurenai_SCAJ-20100_20240920103907](https://github.com/user-attachments/assets/e84a0dc9-3c7d-4deb-a39a-ac2bcad28d52)
10:7 ratio
![Tenchu Kurenai_SCAJ-20100_20240920103848](https://github.com/user-attachments/assets/fd59557a-20a0-4dc3-a20a-fcb2840b2b8a)


### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
test these games ,maybe there are another more