### PR TITLE
iop/hostfs: don't replace back slashes with forward slashes on Windows

### DIFF
--- a/pcsx2/IopBios.cpp
+++ b/pcsx2/IopBios.cpp
@@ -153,9 +153,13 @@ namespace R3000A
 	// the directory is considered non-existant
 	static __fi std::string clean_path(const std::string& path)
 	{
+#ifndef _WIN32
 		std::string ret = path;
 		std::replace(ret.begin(), ret.end(), '\\', '/');
 		return ret;
+#else // This function will cause problems with Windows WSL / device paths where forward slashes are required
+		return path;
+#endif
 	}
 
 	static int host_stat(const std::string& path, fio_stat_t* host_stats, fio_stat_flags& stat = ioman_stat)


### PR DESCRIPTION
### Description of Changes
Disables the 'clean_path' function on Windows that replaces back slashes with forward slashes.

### Rationale behind Changes
It's currently breaking WSL paths because you can't use all forward slashes when accessing the WSL filesystem.

### Suggested Testing Steps
Use ulaunchelf on Windows and try to load an elf from a WSL path.

fixes #11843 