### PR TITLE
Deps: Update to libzip 1.11.1

### DIFF
--- a/3rdparty/libzip/AUTHORS
+++ b/3rdparty/libzip/AUTHORS
@@ -1,2 +1,2 @@
 Dieter Baron <dillo@nih.at>
-Thomas Klausner <tk@giga.or.at>
+Thomas Klausner <wiz@gatalith.at>

--- a/3rdparty/libzip/CMakeLists.txt
+++ b/3rdparty/libzip/CMakeLists.txt
@@ -250,6 +250,7 @@ add_library(zip STATIC
   lib/zip_unchange_archive.c
   lib/zip_unchange_data.c
   lib/zip_utf-8.c
+  lib/zip_source_get_dostime.c
   ${CMAKE_CURRENT_BINARY_DIR}/zip_err_str.c
   )
 

--- a/3rdparty/libzip/NEWS.md
+++ b/3rdparty/libzip/NEWS.md
@@ -1,0 +1,343 @@
+# 1.11.1 [2024-09-19]
+
+* Fix zipconf.h for version number with missing third component.
+
+# 1.11 [2024-09-19]
+
+* Stop searching after finding acceptable central directory, even if it contains inconsistencies.
+* Only write Zip64 EOCD if fields don't fit in normal EOCD. Previously libzip also wrote it when any directory entry required Zip64.
+* Allow bytes from 0x00-0x1F as UTF-8.
+* Add new error code `ZIP_ER_TRUNCATED_ZIP` for files that start with a valid local header signature.
+* `zipcmp`: add `-T` option for comparing timestamps.
+* `zip_file_replace` now removes the target's extra field information.
+
+# 1.10.1 [2023-08-23]
+
+* Add `ZIP_LENGTH_TO_END` and `ZIP_LENGTH_UNCHECKED`. Unless `ZIP_LENGTH_UNCHECKED` is used as `length`, it is an error for a file to shrink between the time when the source is created and when its data is read.
+* Fix test on Windows.
+
+# 1.10.0 [2023-06-23]
+
+* Make support for layered sources public.
+* Add `zip_source_zip_file` and `zip_source_zip_file_create`, deprecate `zip_source_zip` and `zip_source_zip_create`.
+* Allow reading changed file data.
+* Fix handling of files of size 4294967295.
+* `zipmerge`: copy extra fields.
+* `zipmerge`: add option to keep files uncompressed.
+* Switch test framework to use nihtest instead of Perl.
+* Fix reading/writing compressed data with buffers > 4GiB.
+* Restore support for torrentzip.
+* Add warnings when using deprecated functions.
+* Allow keeping files for empty archives.
+* Support mbedTLS>=3.3.0.
+* Support OpenSSL 3.
+* Use ISO C secure library functions, if available.
+
+
+# 1.9.2 [2022-06-28]
+
+* Fix version number in header file.
+
+
+# 1.9.1 [2022-06-28]
+
+* Fix `zip_file_is_seekable()`.
+
+
+# 1.9.0 [2022-06-13]
+
+* Add `zip_file_is_seekable()`.
+* Improve compatibility with WinAES.
+* Fix encoding handling in `zip_name_locate()`.
+* Add option to `zipcmp` to output summary of changes.
+* Various bug fixes and documentation improvements.
+
+
+# 1.8.0 [2021-06-18]
+
+* Add support for zstd (Zstandard) compression.
+* Add support for lzma (ID 14) compression.
+* Add `zip_source_window_create()`.
+* Add `zip_source_zip_create()` variant to `zip_source_zip()`.
+* Allow method specific `comp_flags` in `zip_set_file_compression()`.
+* Allow `zip_source_tell()` on sources that don't support seeking and `zip_ftell()` on compressed data.
+* Provide more details for consistency check errors.
+* Improve output of `zipcmp`.
+* In `zipcmp`, don’t ignore empty directories when comparing directory listing.
+* Treat empty string as no password given in `zip_file_set_encryption()`, `zip_fopen_encrypted()`, and `zip_set_default_password()`.
+
+
+# 1.7.3 [2020-07-15]
+
+* Support cmake < 3.17 again.
+* Fix pkgconfig file (regression in 1.7.2).
+
+
+# 1.7.2 [2020-07-11]
+
+* Fixes for the CMake `find_project()` files.
+* libzip moved to the CMake `libzip::` `NAMESPACE`.
+* CMake usage best practice cleanups.
+
+
+# 1.7.1 [2020-06-13]
+
+* Restore `LIBZIP_VERSION_{MAJOR,MINOR,MICRO}` symbols.
+* Fixes warnings reported by PVS-Studio.
+* Add `LIBZIP_DO_INSTALL` build setting to make it easier to use
+  libzip as subproject.
+
+
+# 1.7.0 [2020-06-05]
+
+* Add support for encrypting using traditional PKWare encryption.
+* Add `zip_compression_method_supported()`.
+* Add `zip_encryption_method_supported()`.
+* Add the `ZIP_SOURCE_GET_FILE_ATTRIBUTES` source command.
+* Refactor stdio file backend.
+* Add CMake find_project() support.
+
+
+# 1.6.1 [2020-02-03]
+
+* Bugfix for double-free in `zipcmp(1)` during cleanup.
+
+
+# 1.6.0 [2020-01-24]
+
+* Avoid using `umask()` since it's not thread-safe.
+* Set close-on-exec flag when opening files.
+* Do not accept empty files as valid zip archives any longer.
+* Add support for XZ compressed files (using liblzma).
+* Add support for cancelling while closing zip archives.
+* Add support for setting the time in the on-disk format.
+
+
+# 1.5.2 [2019-03-12]
+
+* Fix bug in AES encryption affecting certain file sizes
+* Keep file permissions when modifying zip archives
+* Support systems with small stack size.
+* Support mbed TLS as crypto backend.
+* Add nullability annotations.
+
+
+# 1.5.1 [2018-04-11]
+
+* Choose format of installed documentation based on available tools.
+* Fix visibility of symbols.
+* Fix zipcmp directory support.
+* Don't set RPATH on Linux.
+* Use Libs.private for link dependencies in pkg-config file.
+* Fix build with LibreSSL.
+* Various bugfixes.
+
+
+# 1.5.0 [2018-03-11]
+
+* Use standard cryptographic library instead of custom AES implementation.
+  This also simplifies the license.
+* Use `clang-format` to format the source code.
+* More Windows improvements.
+
+
+# 1.4.0 [2017-12-29]
+
+* Improve build with cmake
+* Retire autoconf/automake build system
+* Add `zip_source_buffer_fragment()`.
+* Add support to clone unchanged beginning of archive (instead of rewriting it).
+  Supported for buffer sources and on Apple File System.
+* Add support for Microsoft Universal Windows Platform.
+
+
+# 1.3.2 [2017-11-20]
+
+* Fix bug introduced in last: zip_t was erroneously freed if zip_close() failed.
+
+
+# 1.3.1 [2017-11-19]
+
+* Install zipconf.h into ${PREFIX}/include
+* Add zip_libzip_version()
+* Fix AES tests on Linux
+
+
+# 1.3.0 [2017-09-02]
+
+* Support bzip2 compressed zip archives
+* Improve file progress callback code
+* Fix zip_fdopen()
+* CVE-2017-12858: Fix double free()
+* CVE-2017-14107: Improve EOCD64 parsing
+
+
+# 1.2.0 [2017-02-19]
+
+* Support for AES encryption (Winzip version), both encryption
+  and decryption
+* Support legacy zip files with >64k entries
+* Fix seeking in zip_source_file if start > 0
+* Add zip_fseek() for seeking in uncompressed data
+* Add zip_ftell() for telling position in uncompressed data
+* Add zip_register_progress_callback() for UI updates during zip_close()
+
+
+# 1.1.3 [2016-05-28]
+
+* Fix build on Windows when using autoconf
+
+
+# 1.1.2 [2016-02-19]
+
+* Improve support for 3MF files
+
+
+# 1.1.1 [2016-02-07]
+
+* Build fixes for Linux
+* Fix some warnings reported by PVS-Studio
+
+
+# 1.1 [2016-01-26]
+
+* ziptool(1): command line tool to modify zip archives
+* Speedups for archives with many entries
+* Coverity fixes
+* Better APK support
+* Support for running tests on Windows
+* More build fixes for Windows
+* Portability fixes
+* Documentation improvements
+
+
+# 1.0.1 [2015-05-04]
+
+* Build fixes for Windows
+
+
+# 1.0 [2015-05-03]
+
+* Implemented an I/O abstraction layer
+* Added support for native Windows API for files
+* Added support for setting the last modification time for a file
+* Added a new type zip_error_t for errors
+* Added more typedefs for structs
+* Torrentzip support was removed
+* CVE-2015-2331 was fixed
+* Addressed all Coverity CIDs
+
+
+# 0.11.2 [2013-12-19]
+
+* Support querying/setting operating system and external attributes
+* For newly added files, set operating system to UNIX, permissions
+  to 0666 (0777 for directories)
+* Fix bug when writing zip archives containing files bigger than 4GB
+
+
+# 0.11.1 [2013-04-27]
+
+* Fix bugs in zip_set_file_compression()
+* Include Xcode build infrastructure
+
+
+# 0.11 [2013-03-23]
+
+* Added Zip64 support (large file support)
+* Added UTF-8 support for file names, file comments, and archive comments
+* Changed API for name and comment related functions for UTF-8 support
+* Added zip_discard()
+* Added ZIP_TRUNCATE for zip_open()
+* Added zip_set_file_compression()
+* Added API for accessing and modifying extra fields
+* Improved API type consistency
+* Use gcc4's visibility __attribute__
+* More changes for Windows support
+* Additional test cases
+
+
+# 0.10.1 [2012-03-20]
+
+* Fixed CVE-2012-1162
+* Fixed CVE-2012-1163
+
+
+# 0.10 [2010-03-18]
+
+* Added zip_get_num_entries(), deprecated zip_get_num_files()
+* Better windows support
+* Support for traditional PKWARE encryption added
+* Fix opening archives with more than 65535 entries
+* Fix some memory leaks
+* Fix cmake build and installation
+* Fix memory leak in error case in zip_open()
+* Fixed CVE-2011-0421 (no security implications though)
+* More documentation
+
+
+# 0.9.3 [2010-02-01]
+
+* Include m4/ directory in distribution; some packagers need it
+
+
+# 0.9.2 [2010-01-31]
+
+* Avoid passing uninitialized data to deflate()
+* Fix memory leak when closing zip archives
+
+
+# 0.9.1 [2010-01-24]
+
+* Fix infinite loop on reading some broken files
+* Optimization in time conversion (don't call localtime())
+* Clear data descriptor flag in central directory, fixing Open Office files
+* Allow more than 64k entries
+
+
+# 0.9 [2008-07-25]
+
+* on Windows, explicitly set dllimport/dllexport
+* remove erroneous references to GPL
+* add support for torrentzip
+* new functions: zip_get_archive_flag, zip_set_archive_flag
+* zip_source_zip: add flag to force recompression
+* zip_sorce_file: only keep file open while reading from it
+
+
+# 0.8 [2007-06-06]
+
+* fix for zip archives larger than 2GiB
+* fix zip_error_strerror to include libzip error string
+* add support for reading streamed zip files
+* new functions: zip_add_dir, zip_error_clear, zip_file_error_clear
+* add basic support for building with CMake (incomplete)
+
+
+# 0.7.1 [2006-05-18]
+
+* bugfix for zip_close
+
+
+# 0.7 [2006-05-06]
+
+* struct zip_stat increased for future encryption support
+* zip_add return value changed (now returns new index of added file)
+* shared library major bump because of previous two
+* added functions for reading and writing file and archive comments
+  New functions: zip_get_archive_comment, zip_get_file_comment,
+  zip_set_archive_comment, zip_set_file_comment, zip_unchange_archive
+
+
+# 0.6.1 [2005-07-14]
+
+* various bug fixes
+
+
+# 0.6 [2005-06-09]
+
+* first standalone release
+* changed license to three-clause BSD
+* overhauled API
+* added man pages
+* install zipcmp and zipmerge

--- a/3rdparty/libzip/lib/CMakeLists.txt
+++ b/3rdparty/libzip/lib/CMakeLists.txt
@@ -82,6 +82,7 @@ add_library(zip
   zip_source_file_stdio.c
   zip_source_free.c
   zip_source_function.c
+  zip_source_get_dostime.c
   zip_source_get_file_attributes.c
   zip_source_is_deleted.c
   zip_source_layered.c
@@ -117,6 +118,7 @@ add_library(zip
 add_library(libzip::zip ALIAS zip)
 
 if(WIN32)
+  target_compile_definitions(zip PRIVATE WIN32_LEAN_AND_MEAN)
   target_sources(zip PRIVATE
     zip_source_file_win32.c
     zip_source_file_win32_named.c
@@ -172,7 +174,8 @@ if(HAVE_CRYPTO)
 endif()
 
 if(SHARED_LIB_VERSIONNING)
-  set_target_properties(zip PROPERTIES VERSION 5.5 SOVERSION 5)
+  # MACHO_*_VERSION can be removed when SOVERSION gets increased. Cf #405
+  set_target_properties(zip PROPERTIES VERSION 5.5 SOVERSION 5 MACHO_CURRENT_VERSION 6.5 MACHO_COMPATIBILITY_VERSION 6)
 endif()
 
 target_link_libraries(zip PRIVATE ZLIB::ZLIB)

--- a/3rdparty/libzip/lib/compat.h
+++ b/3rdparty/libzip/lib/compat.h
@@ -3,7 +3,7 @@
 
 /*
   compat.h -- compatibility defines.
-  Copyright (C) 1999-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 1999-2022 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip.h
+++ b/3rdparty/libzip/lib/zip.h
@@ -3,7 +3,7 @@
 
 /*
   zip.h -- exported declarations.
-  Copyright (C) 1999-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 1999-2024 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>
@@ -154,6 +154,7 @@ extern "C" {
 #define ZIP_ER_CANCELLED 32       /* N Operation cancelled */
 #define ZIP_ER_DATA_LENGTH 33     /* N Unexpected length of data */
 #define ZIP_ER_NOT_ALLOWED 34     /* N Not allowed in torrentzip */
+#define ZIP_ER_TRUNCATED_ZIP 35   /* N Possibly truncated or corrupted zip archive */
 
 /* type of system error value */
 
@@ -256,7 +257,8 @@ enum zip_source_cmd {
     ZIP_SOURCE_BEGIN_WRITE_CLONING, /* like ZIP_SOURCE_BEGIN_WRITE, but keep part of original file */
     ZIP_SOURCE_ACCEPT_EMPTY,        /* whether empty files are valid archives */
     ZIP_SOURCE_GET_FILE_ATTRIBUTES, /* get additional file attributes */
-    ZIP_SOURCE_SUPPORTS_REOPEN      /* allow reading from changed entry */
+    ZIP_SOURCE_SUPPORTS_REOPEN,     /* allow reading from changed entry */
+    ZIP_SOURCE_GET_DOS_TIME         /* get last modification time in DOS format */
 };
 typedef enum zip_source_cmd zip_source_cmd_t;
 

--- a/3rdparty/libzip/lib/zip_add.c
+++ b/3rdparty/libzip/lib/zip_add.c
@@ -1,6 +1,6 @@
 /*
   zip_add.c -- add file via callback function
-  Copyright (C) 1999-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 1999-2022 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_add_dir.c
+++ b/3rdparty/libzip/lib/zip_add_dir.c
@@ -1,6 +1,6 @@
 /*
   zip_add_dir.c -- add directory
-  Copyright (C) 1999-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 1999-2022 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_add_entry.c
+++ b/3rdparty/libzip/lib/zip_add_entry.c
@@ -1,6 +1,6 @@
 /*
   zip_add_entry.c -- create and init struct zip_entry
-  Copyright (C) 1999-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 1999-2024 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>
@@ -64,7 +64,7 @@ _zip_add_entry(zip_t *za) {
             return -1;
         }
         rentries = (zip_entry_t *)realloc(za->entry, sizeof(struct zip_entry) * (size_t)nalloc);
-        if (!rentries) {
+        if (rentries == NULL) {
             zip_error_set(&za->error, ZIP_ER_MEMORY, 0);
             return -1;
         }

--- a/3rdparty/libzip/lib/zip_algorithm_bzip2.c
+++ b/3rdparty/libzip/lib/zip_algorithm_bzip2.c
@@ -1,6 +1,6 @@
 /*
   zip_algorithm_bzip2.c -- bzip2 (de)compression routines
-  Copyright (C) 2017-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 2017-2023 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_algorithm_deflate.c
+++ b/3rdparty/libzip/lib/zip_algorithm_deflate.c
@@ -1,6 +1,6 @@
 /*
   zip_algorithm_deflate.c -- deflate (de)compression routines
-  Copyright (C) 2017-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 2017-2023 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_algorithm_xz.c
+++ b/3rdparty/libzip/lib/zip_algorithm_xz.c
@@ -1,7 +1,7 @@
 /*
   zip_algorithm_xz.c -- LZMA/XZ (de)compression routines
   Bazed on zip_algorithm_deflate.c -- deflate (de)compression routines
-  Copyright (C) 2017-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 2017-2023 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_algorithm_zstd.c
+++ b/3rdparty/libzip/lib/zip_algorithm_zstd.c
@@ -1,6 +1,6 @@
 /*
   zip_algorithm_zstd.c -- zstd (de)compression routines
-  Copyright (C) 2020-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 2020-2023 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_buffer.c
+++ b/3rdparty/libzip/lib/zip_buffer.c
@@ -1,6 +1,6 @@
 /*
  zip_buffer.c -- bounds checked access to memory buffer
- Copyright (C) 2014-2021 Dieter Baron and Thomas Klausner
+ Copyright (C) 2014-2024 Dieter Baron and Thomas Klausner
 
  This file is part of libzip, a library to manipulate ZIP archives.
  The authors can be contacted at <info@libzip.org>
@@ -306,8 +306,7 @@ _zip_buffer_put_8(zip_buffer_t *buffer, zip_uint8_t i) {
 }
 
 
-int
-_zip_buffer_set_offset(zip_buffer_t *buffer, zip_uint64_t offset) {
+int _zip_buffer_set_offset(zip_buffer_t *buffer, zip_uint64_t offset) {
     if (offset > buffer->size) {
         buffer->ok = false;
         return -1;

--- a/3rdparty/libzip/lib/zip_crypto.h
+++ b/3rdparty/libzip/lib/zip_crypto.h
@@ -1,6 +1,6 @@
 /*
   zip_crypto.h -- crypto definitions
-  Copyright (C) 2017-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 2017-2022 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_crypto_commoncrypto.c
+++ b/3rdparty/libzip/lib/zip_crypto_commoncrypto.c
@@ -1,6 +1,6 @@
 /*
   zip_crypto_commoncrypto.c -- CommonCrypto wrapper.
-  Copyright (C) 2018-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 2018-2022 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_crypto_commoncrypto.h
+++ b/3rdparty/libzip/lib/zip_crypto_commoncrypto.h
@@ -1,6 +1,6 @@
 /*
   zip_crypto_commoncrypto.h -- definitions for CommonCrypto wrapper.
-  Copyright (C) 2018 Dieter Baron and Thomas Klausner
+  Copyright (C) 2018-2022 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_crypto_gnutls.c
+++ b/3rdparty/libzip/lib/zip_crypto_gnutls.c
@@ -1,6 +1,6 @@
 /*
   zip_crypto_gnutls.c -- GnuTLS wrapper.
-  Copyright (C) 2018-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 2018-2022 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_crypto_gnutls.h
+++ b/3rdparty/libzip/lib/zip_crypto_gnutls.h
@@ -1,6 +1,6 @@
 /*
   zip_crypto_gnutls.h -- definitions for GnuTLS wrapper.
-  Copyright (C) 2018-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 2018-2022 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_crypto_mbedtls.c
+++ b/3rdparty/libzip/lib/zip_crypto_mbedtls.c
@@ -1,6 +1,6 @@
 /*
   zip_crypto_mbedtls.c -- mbed TLS wrapper
-  Copyright (C) 2018-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 2018-2023 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_crypto_mbedtls.h
+++ b/3rdparty/libzip/lib/zip_crypto_mbedtls.h
@@ -1,6 +1,6 @@
 /*
   zip_crypto_mbedtls.h -- definitions for mbedtls wrapper
-  Copyright (C) 2018-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 2018-2022 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_crypto_openssl.c
+++ b/3rdparty/libzip/lib/zip_crypto_openssl.c
@@ -1,6 +1,6 @@
 /*
   zip_crypto_openssl.c -- OpenSSL wrapper.
-  Copyright (C) 2018-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 2018-2023 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>
@@ -126,8 +126,9 @@ _zip_crypto_aes_free(_zip_crypto_aes_t *aes) {
 
 bool
 _zip_crypto_aes_encrypt_block(_zip_crypto_aes_t *aes, const zip_uint8_t *in, zip_uint8_t *out) {
-    int len;
-    if (EVP_EncryptUpdate(aes, out, &len, in, ZIP_CRYPTO_AES_BLOCK_LENGTH) != 1) {
+    int len = 0;
+    if (EVP_EncryptUpdate(aes, out, &len, in, ZIP_CRYPTO_AES_BLOCK_LENGTH) != 1
+        || len != ZIP_CRYPTO_AES_BLOCK_LENGTH) {
         return false;
     }
     return true;
@@ -214,11 +215,11 @@ _zip_crypto_hmac_free(_zip_crypto_hmac_t *hmac) {
 bool
 _zip_crypto_hmac_output(_zip_crypto_hmac_t *hmac, zip_uint8_t *data) {
 #ifdef USE_OPENSSL_3_API
-    size_t length;
+    size_t length = 0;
     return EVP_MAC_final(hmac->ctx, data, &length, ZIP_CRYPTO_SHA1_LENGTH) == 1 && length == ZIP_CRYPTO_SHA1_LENGTH;
 #else
-    unsigned int length;
-    return HMAC_Final(hmac, data, &length) == 1;
+    unsigned int length = 0;
+    return HMAC_Final(hmac, data, &length) == 1 && length == ZIP_CRYPTO_SHA1_LENGTH;
 #endif
 }
 

--- a/3rdparty/libzip/lib/zip_crypto_openssl.h
+++ b/3rdparty/libzip/lib/zip_crypto_openssl.h
@@ -1,6 +1,6 @@
 /*
   zip_crypto_openssl.h -- definitions for OpenSSL wrapper.
-  Copyright (C) 2018-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 2018-2023 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_crypto_win.c
+++ b/3rdparty/libzip/lib/zip_crypto_win.c
@@ -1,6 +1,6 @@
 /*
   zip_crypto_win.c -- Windows Crypto API wrapper.
-  Copyright (C) 2018-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 2018-2023 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>
@@ -36,9 +36,6 @@
 #include "zipint.h"
 
 #include "zip_crypto.h"
-
-#define WIN32_LEAN_AND_MEAN
-#define NOCRYPT
 
 #include <windows.h>
 

--- a/3rdparty/libzip/lib/zip_crypto_win.h
+++ b/3rdparty/libzip/lib/zip_crypto_win.h
@@ -1,6 +1,6 @@
 /*
   zip_crypto_win.h -- Windows Crypto API wrapper.
-  Copyright (C) 2018-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 2018-2022 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_delete.c
+++ b/3rdparty/libzip/lib/zip_delete.c
@@ -1,6 +1,6 @@
 /*
   zip_delete.c -- delete file from zip archive
-  Copyright (C) 1999-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 1999-2022 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_dirent.c
+++ b/3rdparty/libzip/lib/zip_dirent.c
@@ -1,6 +1,6 @@
 /*
   zip_dirent.c -- read directory entry (local or central), clean dirent
-  Copyright (C) 1999-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 1999-2024 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>
@@ -39,9 +39,10 @@
 #include <time.h>
 #include <zlib.h>
 
+#include "zip.h"
 #include "zipint.h"
 
-static zip_string_t *_zip_dirent_process_ef_utf_8(const zip_dirent_t *de, zip_uint16_t id, zip_string_t *str);
+static zip_string_t *_zip_dirent_process_ef_utf_8(const zip_dirent_t *de, zip_uint16_t id, zip_string_t *str, bool check_consistency);
 static zip_extra_field_t *_zip_ef_utf8(zip_uint16_t, zip_string_t *, zip_error_t *);
 static bool _zip_dirent_process_winzip_aes(zip_dirent_t *de, zip_error_t *error);
 
@@ -50,8 +51,9 @@ void
 _zip_cdir_free(zip_cdir_t *cd) {
     zip_uint64_t i;
 
-    if (!cd)
+    if (cd == NULL) {
         return;
+    }
 
     for (i = 0; i < cd->nentry; i++)
         _zip_entry_finalize(cd->entry + i);
@@ -62,7 +64,7 @@ _zip_cdir_free(zip_cdir_t *cd) {
 
 
 zip_cdir_t *
-_zip_cdir_new(zip_uint64_t nentry, zip_error_t *error) {
+_zip_cdir_new(zip_error_t *error) {
     zip_cdir_t *cd;
 
     if ((cd = (zip_cdir_t *)malloc(sizeof(*cd))) == NULL) {
@@ -75,11 +77,6 @@ _zip_cdir_new(zip_uint64_t nentry, zip_error_t *error) {
     cd->size = cd->offset = 0;
     cd->comment = NULL;
     cd->is_zip64 = false;
-
-    if (!_zip_cdir_grow(cd, nentry, error)) {
-        _zip_cdir_free(cd);
-        return NULL;
-    }
 
     return cd;
 }
@@ -126,8 +123,6 @@ _zip_cdir_write(zip_t *za, const zip_filelist_t *filelist, zip_uint64_t survivor
     zip_buffer_t *buffer;
     zip_int64_t off;
     zip_uint64_t i;
-    bool is_zip64;
-    int ret;
     zip_uint32_t cdir_crc;
 
     if ((off = zip_source_tell_write(za->src)) < 0) {
@@ -135,8 +130,6 @@ _zip_cdir_write(zip_t *za, const zip_filelist_t *filelist, zip_uint64_t survivor
         return -1;
     }
     offset = (zip_uint64_t)off;
-
-    is_zip64 = false;
 
     if (ZIP_WANT_TORRENTZIP(za)) {
         cdir_crc = (zip_uint32_t)crc32(0, NULL, 0);
@@ -146,10 +139,10 @@ _zip_cdir_write(zip_t *za, const zip_filelist_t *filelist, zip_uint64_t survivor
     for (i = 0; i < survivors; i++) {
         zip_entry_t *entry = za->entry + filelist[i].idx;
 
-        if ((ret = _zip_dirent_write(za, entry->changes ? entry->changes : entry->orig, ZIP_FL_CENTRAL)) < 0)
+        if (_zip_dirent_write(za, entry->changes ? entry->changes : entry->orig, ZIP_FL_CENTRAL) < 0) {
+            za->write_crc = NULL;
             return -1;
-        if (ret)
-            is_zip64 = true;
+        }
     }
 
     za->write_crc = NULL;
@@ -160,16 +153,12 @@ _zip_cdir_write(zip_t *za, const zip_filelist_t *filelist, zip_uint64_t survivor
     }
     size = (zip_uint64_t)off - offset;
 
-    if (offset > ZIP_UINT32_MAX || survivors > ZIP_UINT16_MAX) {
-        is_zip64 = true;
-    }
-
     if ((buffer = _zip_buffer_new(buf, sizeof(buf))) == NULL) {
         zip_error_set(&za->error, ZIP_ER_MEMORY, 0);
         return -1;
     }
 
-    if (is_zip64) {
+    if (survivors > ZIP_UINT16_MAX || offset > ZIP_UINT32_MAX || size > ZIP_UINT32_MAX) {
         _zip_buffer_put(buffer, EOCD64_MAGIC, 4);
         _zip_buffer_put_64(buffer, EOCD64LEN - 12);
         _zip_buffer_put_16(buffer, 45);
@@ -298,7 +287,8 @@ _zip_dirent_init(zip_dirent_t *de) {
     de->version_needed = 10; /* 1.0 */
     de->bitflags = 0;
     de->comp_method = ZIP_CM_DEFAULT;
-    de->last_mod = 0;
+    de->last_mod.date = 0;
+    de->last_mod.time = 0;
     de->crc = 0;
     de->comp_size = 0;
     de->uncomp_size = 0;
@@ -336,7 +326,7 @@ _zip_dirent_new(void) {
 }
 
 
-/* _zip_dirent_read(zde, fp, bufp, left, localp, error):
+/*
    Fills the zip directory entry zde.
 
    If buffer is non-NULL, data is taken from there; otherwise data is read from fp as needed.
@@ -347,11 +337,12 @@ _zip_dirent_new(void) {
 */
 
 zip_int64_t
-_zip_dirent_read(zip_dirent_t *zde, zip_source_t *src, zip_buffer_t *buffer, bool local, zip_error_t *error) {
+_zip_dirent_read(zip_dirent_t *zde, zip_source_t *src, zip_buffer_t *buffer, bool local, zip_uint64_t central_compressed_size, bool check_consistency, zip_error_t *error) {
     zip_uint8_t buf[CDENTRYSIZE];
-    zip_uint16_t dostime, dosdate;
     zip_uint32_t size, variable_size;
     zip_uint16_t filename_len, comment_len, ef_len;
+    zip_string_t *utf8_string;
+    bool is_zip64 = false;
 
     bool from_buffer = (buffer != NULL);
 
@@ -389,9 +380,8 @@ _zip_dirent_read(zip_dirent_t *zde, zip_source_t *src, zip_buffer_t *buffer, boo
     zde->comp_method = _zip_buffer_get_16(buffer);
 
     /* convert to time_t */
-    dostime = _zip_buffer_get_16(buffer);
-    dosdate = _zip_buffer_get_16(buffer);
-    zde->last_mod = _zip_d2u_time(dostime, dosdate);
+    zde->last_mod.time = _zip_buffer_get_16(buffer);
+    zde->last_mod.date = _zip_buffer_get_16(buffer);
 
     zde->crc = _zip_buffer_get_32(buffer);
     zde->comp_size = _zip_buffer_get_32(buffer);
@@ -458,7 +448,7 @@ _zip_dirent_read(zip_dirent_t *zde, zip_source_t *src, zip_buffer_t *buffer, boo
 
     if (filename_len) {
         zde->filename = _zip_read_string(buffer, src, filename_len, 1, error);
-        if (!zde->filename) {
+        if (zde->filename == NULL) {
             if (zip_error_code_zip(error) == ZIP_ER_EOF) {
                 zip_error_set(error, ZIP_ER_INCONS, ZIP_ER_DETAIL_VARIABLE_SIZE_OVERFLOW);
             }
@@ -502,7 +492,7 @@ _zip_dirent_read(zip_dirent_t *zde, zip_source_t *src, zip_buffer_t *buffer, boo
 
     if (comment_len) {
         zde->comment = _zip_read_string(buffer, src, comment_len, 0, error);
-        if (!zde->comment) {
+        if (zde->comment == NULL) {
             if (!from_buffer) {
                 _zip_buffer_free(buffer);
             }
@@ -519,8 +509,24 @@ _zip_dirent_read(zip_dirent_t *zde, zip_source_t *src, zip_buffer_t *buffer, boo
         }
     }
 
-    zde->filename = _zip_dirent_process_ef_utf_8(zde, ZIP_EF_UTF_8_NAME, zde->filename);
-    zde->comment = _zip_dirent_process_ef_utf_8(zde, ZIP_EF_UTF_8_COMMENT, zde->comment);
+    if ((utf8_string = _zip_dirent_process_ef_utf_8(zde, ZIP_EF_UTF_8_NAME, zde->filename, check_consistency)) == NULL && zde->filename != NULL) {
+        zip_error_set(error, ZIP_ER_INCONS, ZIP_ER_DETAIL_UTF8_FILENAME_MISMATCH);
+        if (!from_buffer) {
+            _zip_buffer_free(buffer);
+        }
+        return -1;
+    }
+    zde->filename = utf8_string;
+    if (!local) {
+        if ((utf8_string = _zip_dirent_process_ef_utf_8(zde, ZIP_EF_UTF_8_COMMENT, zde->comment, check_consistency)) == NULL && zde->comment != NULL) {
+            zip_error_set(error, ZIP_ER_INCONS, ZIP_ER_DETAIL_UTF8_COMMENT_MISMATCH);
+            if (!from_buffer) {
+                _zip_buffer_free(buffer);
+            }
+            return -1;
+        }
+        zde->comment = utf8_string;
+    }
 
     /* Zip64 */
 
@@ -535,6 +541,7 @@ _zip_dirent_read(zip_dirent_t *zde, zip_source_t *src, zip_buffer_t *buffer, boo
                 return -1;
             }
         }
+        is_zip64 = true;
     }
 
 
@@ -545,8 +552,38 @@ _zip_dirent_read(zip_dirent_t *zde, zip_source_t *src, zip_buffer_t *buffer, boo
         }
         return -1;
     }
+
     if (!from_buffer) {
         _zip_buffer_free(buffer);
+    }
+
+    if (local && zde->bitflags & ZIP_GPBF_DATA_DESCRIPTOR) {
+        zip_uint32_t df_crc;
+        zip_uint64_t df_comp_size, df_uncomp_size;
+        if (zip_source_seek(src, central_compressed_size, SEEK_CUR) != 0 || (buffer = _zip_buffer_new_from_source(src, MAX_DATA_DESCRIPTOR_LENGTH, buf, error)) == NULL) {
+            return -1;
+        }
+        if (memcmp(_zip_buffer_peek(buffer, MAGIC_LEN), DATADES_MAGIC, MAGIC_LEN) == 0) {
+            _zip_buffer_skip(buffer, MAGIC_LEN);
+        }
+        df_crc = _zip_buffer_get_32(buffer);
+        df_comp_size = is_zip64 ? _zip_buffer_get_64(buffer) : _zip_buffer_get_32(buffer);
+        df_uncomp_size = is_zip64 ? _zip_buffer_get_64(buffer) : _zip_buffer_get_32(buffer);
+
+        if (!_zip_buffer_ok(buffer)) {
+            zip_error_set(error, ZIP_ER_INTERNAL, 0);
+            _zip_buffer_free(buffer);
+            return -1;
+        }
+        _zip_buffer_free(buffer);
+
+        if ((zde->crc != 0 && zde->crc != df_crc) || (zde->comp_size != 0 && zde->comp_size != df_comp_size) || (zde->uncomp_size != 0 && zde->uncomp_size != df_uncomp_size)) {
+            zip_error_set(error, ZIP_ER_INCONS, ZIP_ER_DETAIL_DATA_DESCRIPTOR_MISMATCH);
+            return -1;
+        }
+        zde->crc = df_crc;
+        zde->comp_size = df_comp_size;
+        zde->uncomp_size = df_uncomp_size;
     }
 
     /* zip_source_seek / zip_source_tell don't support values > ZIP_INT64_MAX */
@@ -564,7 +601,8 @@ _zip_dirent_read(zip_dirent_t *zde, zip_source_t *src, zip_buffer_t *buffer, boo
     return (zip_int64_t)size + (zip_int64_t)variable_size;
 }
 
-bool zip_dirent_process_ef_zip64(zip_dirent_t* zde, const zip_uint8_t* ef, zip_uint64_t got_len, bool local, zip_error_t* error) {
+bool
+zip_dirent_process_ef_zip64(zip_dirent_t *zde, const zip_uint8_t *ef, zip_uint64_t got_len, bool local, zip_error_t *error) {
     zip_buffer_t *ef_buffer;
 
     if ((ef_buffer = _zip_buffer_new((zip_uint8_t *)ef, got_len)) == NULL) {
@@ -625,7 +663,7 @@ bool zip_dirent_process_ef_zip64(zip_dirent_t* zde, const zip_uint8_t* ef, zip_u
 
 
 static zip_string_t *
-_zip_dirent_process_ef_utf_8(const zip_dirent_t *de, zip_uint16_t id, zip_string_t *str) {
+_zip_dirent_process_ef_utf_8(const zip_dirent_t *de, zip_uint16_t id, zip_string_t *str, bool check_consistency) {
     zip_uint16_t ef_len;
     zip_uint32_t ef_crc;
     zip_buffer_t *buffer;
@@ -648,6 +686,14 @@ _zip_dirent_process_ef_utf_8(const zip_dirent_t *de, zip_uint16_t id, zip_string
         zip_string_t *ef_str = _zip_string_new(_zip_buffer_get(buffer, len), len, ZIP_FL_ENC_UTF_8, NULL);
 
         if (ef_str != NULL) {
+            if (check_consistency) {
+                if (!_zip_string_equal(str, ef_str) && _zip_string_is_ascii(ef_str)) {
+                    _zip_string_free(ef_str);
+                    _zip_buffer_free(buffer);
+                    return NULL;
+                }
+            }
+
             _zip_string_free(str);
             str = ef_str;
         }
@@ -688,18 +734,18 @@ _zip_dirent_process_winzip_aes(zip_dirent_t *de, zip_error_t *error) {
 
     crc_valid = true;
     switch (_zip_buffer_get_16(buffer)) {
-        case 1:
-            break;
+    case 1:
+        break;
 
-        case 2:
-            crc_valid = false;
-            /* TODO: When checking consistency, check that crc is 0. */
-            break;
-            
-        default:
-            zip_error_set(error, ZIP_ER_ENCRNOTSUPP, 0);
-            _zip_buffer_free(buffer);
-            return false;
+    case 2:
+        crc_valid = false;
+        /* TODO: When checking consistency, check that crc is 0. */
+        break;
+
+    default:
+        zip_error_set(error, ZIP_ER_ENCRNOTSUPP, 0);
+        _zip_buffer_free(buffer);
+        return false;
     }
 
     /* vendor */
@@ -787,7 +833,7 @@ _zip_dirent_size(zip_source_t *src, zip_uint16_t flags, zip_error_t *error) {
 
 int
 _zip_dirent_write(zip_t *za, zip_dirent_t *de, zip_flags_t flags) {
-    zip_uint16_t dostime, dosdate;
+    zip_dostime_t dostime;
     zip_encoding_type_t com_enc, name_enc;
     zip_extra_field_t *ef;
     zip_extra_field_t *ef64;
@@ -926,14 +972,14 @@ _zip_dirent_write(zip_t *za, zip_dirent_t *de, zip_flags_t flags) {
     }
 
     if (ZIP_WANT_TORRENTZIP(za)) {
-        dostime = 0xbc00;
-        dosdate = 0x2198;
+        dostime.time = 0xbc00;
+        dostime.date = 0x2198;
     }
     else {
-        _zip_u2d_time(de->last_mod, &dostime, &dosdate);
+        dostime = de->last_mod;
     }
-    _zip_buffer_put_16(buffer, dostime);
-    _zip_buffer_put_16(buffer, dosdate);
+    _zip_buffer_put_16(buffer, dostime.time);
+    _zip_buffer_put_16(buffer, dostime.date);
 
     if (is_winzip_aes && de->uncomp_size < 20) {
         _zip_buffer_put_32(buffer, 0);
@@ -1034,7 +1080,7 @@ _zip_dirent_write(zip_t *za, zip_dirent_t *de, zip_flags_t flags) {
 
 
 time_t
-_zip_d2u_time(zip_uint16_t dtime, zip_uint16_t ddate) {
+_zip_d2u_time(const zip_dostime_t *dtime) {
     struct tm tm;
 
     memset(&tm, 0, sizeof(tm));
@@ -1042,13 +1088,13 @@ _zip_d2u_time(zip_uint16_t dtime, zip_uint16_t ddate) {
     /* let mktime decide if DST is in effect */
     tm.tm_isdst = -1;
 
-    tm.tm_year = ((ddate >> 9) & 127) + 1980 - 1900;
-    tm.tm_mon = ((ddate >> 5) & 15) - 1;
-    tm.tm_mday = ddate & 31;
+    tm.tm_year = ((dtime->date >> 9) & 127) + 1980 - 1900;
+    tm.tm_mon = ((dtime->date >> 5) & 15) - 1;
+    tm.tm_mday = dtime->date & 31;
 
-    tm.tm_hour = (dtime >> 11) & 31;
-    tm.tm_min = (dtime >> 5) & 63;
-    tm.tm_sec = (dtime << 1) & 62;
+    tm.tm_hour = (dtime->time >> 11) & 31;
+    tm.tm_min = (dtime->time >> 5) & 63;
+    tm.tm_sec = (dtime->time << 1) & 62;
 
     return mktime(&tm);
 }
@@ -1119,23 +1165,28 @@ _zip_get_dirent(zip_t *za, zip_uint64_t idx, zip_flags_t flags, zip_error_t *err
 }
 
 
-void
-_zip_u2d_time(time_t intime, zip_uint16_t *dtime, zip_uint16_t *ddate) {
+int
+_zip_u2d_time(time_t intime, zip_dostime_t *dtime, zip_error_t *ze) {
     struct tm *tpm;
     struct tm tm;
     tpm = zip_localtime(&intime, &tm);
     if (tpm == NULL) {
         /* if localtime fails, return an arbitrary date (1980-01-01 00:00:00) */
-        *ddate = (1 << 5) + 1;
-        *dtime = 0;
-        return;
+        dtime->date = (1 << 5) + 1;
+        dtime->time = 0;
+        if (ze) {
+            zip_error_set(ze, ZIP_ER_INVAL, errno);
+        }
+        return -1;
     }
     if (tpm->tm_year < 80) {
         tpm->tm_year = 80;
     }
 
-    *ddate = (zip_uint16_t)(((tpm->tm_year + 1900 - 1980) << 9) + ((tpm->tm_mon + 1) << 5) + tpm->tm_mday);
-    *dtime = (zip_uint16_t)(((tpm->tm_hour) << 11) + ((tpm->tm_min) << 5) + ((tpm->tm_sec) >> 1));
+    dtime->date = (zip_uint16_t)(((tpm->tm_year + 1900 - 1980) << 9) + ((tpm->tm_mon + 1) << 5) + tpm->tm_mday);
+    dtime->time = (zip_uint16_t)(((tpm->tm_hour) << 11) + ((tpm->tm_min) << 5) + ((tpm->tm_sec) >> 1));
+
+    return 0;
 }
 
 
@@ -1192,10 +1243,11 @@ _zip_dirent_apply_attributes(zip_dirent_t *de, zip_file_attributes_t *attributes
    Set values suitable for torrentzip.
 */
 
-void zip_dirent_torrentzip_normalize(zip_dirent_t *de) {
+void
+zip_dirent_torrentzip_normalize(zip_dirent_t *de) {
     de->version_madeby = 0;
     de->version_needed = 20; /* 2.0 */
-    de->bitflags = 2; /* maximum compression */
+    de->bitflags = 2;        /* maximum compression */
     de->comp_method = ZIP_CM_DEFLATE;
     de->compression_level = TORRENTZIP_COMPRESSION_FLAGS;
     de->disk_number = 0;
@@ -1203,5 +1255,12 @@ void zip_dirent_torrentzip_normalize(zip_dirent_t *de) {
     de->ext_attrib = 0;
 
     /* last_mod, extra_fields, and comment are normalized in zip_dirent_write() directly */
+}
 
+int
+zip_dirent_check_consistency(zip_dirent_t *dirent) {
+    if (dirent->comp_method == ZIP_CM_STORE && dirent->comp_size != dirent->uncomp_size) {
+        return ZIP_ER_DETAIL_STORED_SIZE_MISMATCH;
+    }
+    return 0;
 }

--- a/3rdparty/libzip/lib/zip_discard.c
+++ b/3rdparty/libzip/lib/zip_discard.c
@@ -1,6 +1,6 @@
 /*
   zip_discard.c -- discard and free struct zip
-  Copyright (C) 1999-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 1999-2022 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_entry.c
+++ b/3rdparty/libzip/lib/zip_entry.c
@@ -1,6 +1,6 @@
 /*
   zip_entry.c -- struct zip_entry helper functions
-  Copyright (C) 1999-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 1999-2022 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_error.c
+++ b/3rdparty/libzip/lib/zip_error.c
@@ -1,6 +1,6 @@
 /*
   zip_error.c -- zip_error_t helper functions
-  Copyright (C) 1999-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 1999-2022 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_error_clear.c
+++ b/3rdparty/libzip/lib/zip_error_clear.c
@@ -1,6 +1,6 @@
 /*
   zip_error_clear.c -- clear zip error
-  Copyright (C) 1999-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 1999-2022 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_error_get.c
+++ b/3rdparty/libzip/lib/zip_error_get.c
@@ -1,6 +1,6 @@
 /*
   zip_error_get.c -- get zip error
-  Copyright (C) 1999-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 1999-2022 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_error_get_sys_type.c
+++ b/3rdparty/libzip/lib/zip_error_get_sys_type.c
@@ -1,6 +1,6 @@
 /*
   zip_error_get_sys_type.c -- return type of system error code
-  Copyright (C) 1999-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 1999-2022 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_error_strerror.c
+++ b/3rdparty/libzip/lib/zip_error_strerror.c
@@ -1,6 +1,6 @@
 /*
   zip_error_sterror.c -- get string representation of struct zip_error
-  Copyright (C) 1999-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 1999-2023 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>
@@ -49,6 +49,9 @@ zip_error_strerror(zip_error_t *err) {
 
     if (err->zip_err < 0 || err->zip_err >= _zip_err_str_count) {
         system_error_buffer = (char *)malloc(128);
+        if (system_error_buffer == NULL) {
+            return _zip_err_str[ZIP_ER_MEMORY].description;
+        }
         snprintf_s(system_error_buffer, 128, "Unknown error %d", err->zip_err);
         system_error_buffer[128 - 1] = '\0'; /* make sure string is NUL-terminated */
         zip_error_string = NULL;
@@ -61,6 +64,9 @@ zip_error_strerror(zip_error_t *err) {
             case ZIP_ET_SYS: {
                 size_t len = strerrorlen_s(err->sys_err) + 1;
                 system_error_buffer = malloc(len);
+                if (system_error_buffer == NULL) {
+                    return _zip_err_str[ZIP_ER_MEMORY].description;
+                }
                 strerror_s(system_error_buffer, len, err->sys_err);
                 system_error_string = system_error_buffer;
                 break;
@@ -79,12 +85,18 @@ zip_error_strerror(zip_error_t *err) {
                 }
                 else if (error >= _zip_err_details_count) {
                     system_error_buffer = (char *)malloc(128);
+                    if (system_error_buffer == NULL) {
+                        return _zip_err_str[ZIP_ER_MEMORY].description;
+                    }
                     snprintf_s(system_error_buffer, 128, "invalid detail error %u", error);
                     system_error_buffer[128 - 1] = '\0'; /* make sure string is NUL-terminated */
                     system_error_string = system_error_buffer;
                 }
                 else if (_zip_err_details[error].type == ZIP_DETAIL_ET_ENTRY && index < MAX_DETAIL_INDEX) {
                     system_error_buffer = (char *)malloc(128);
+                    if (system_error_buffer == NULL) {
+                        return _zip_err_str[ZIP_ER_MEMORY].description;
+                    }
                     snprintf_s(system_error_buffer, 128, "entry %d: %s", index, _zip_err_details[error].description);
                     system_error_buffer[128 - 1] = '\0'; /* make sure string is NUL-terminated */
                     system_error_string = system_error_buffer;

--- a/3rdparty/libzip/lib/zip_error_to_str.c
+++ b/3rdparty/libzip/lib/zip_error_to_str.c
@@ -1,6 +1,6 @@
 /*
   zip_error_to_str.c -- get string representation of zip error code
-  Copyright (C) 1999-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 1999-2022 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_extra_field.c
+++ b/3rdparty/libzip/lib/zip_extra_field.c
@@ -1,6 +1,6 @@
 /*
   zip_extra_field.c -- manipulate extra fields
-  Copyright (C) 2012-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 2012-2022 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_extra_field_api.c
+++ b/3rdparty/libzip/lib/zip_extra_field_api.c
@@ -1,6 +1,6 @@
 /*
   zip_extra_field_api.c -- public extra fields API functions
-  Copyright (C) 2012-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 2012-2024 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>
@@ -54,10 +54,6 @@ zip_file_extra_field_delete(zip_t *za, zip_uint64_t idx, zip_uint16_t ef_idx, zi
 
     if (ZIP_IS_RDONLY(za)) {
         zip_error_set(&za->error, ZIP_ER_RDONLY, 0);
-        return -1;
-    }
-    if (ZIP_WANT_TORRENTZIP(za)) {
-        zip_error_set(&za->error, ZIP_ER_NOT_ALLOWED, 0);
         return -1;
     }
 

--- a/3rdparty/libzip/lib/zip_fclose.c
+++ b/3rdparty/libzip/lib/zip_fclose.c
@@ -1,6 +1,6 @@
 /*
   zip_fclose.c -- close file in zip archive
-  Copyright (C) 1999-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 1999-2022 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_fdopen.c
+++ b/3rdparty/libzip/lib/zip_fdopen.c
@@ -1,6 +1,6 @@
 /*
   zip_fdopen.c -- open read-only archive from file descriptor
-  Copyright (C) 2009-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 2009-2022 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_file_add.c
+++ b/3rdparty/libzip/lib/zip_file_add.c
@@ -1,6 +1,6 @@
 /*
   zip_file_add.c -- add file via callback function
-  Copyright (C) 1999-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 1999-2022 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_file_error_clear.c
+++ b/3rdparty/libzip/lib/zip_file_error_clear.c
@@ -1,6 +1,6 @@
 /*
   zip_file_error_clear.c -- clear zip file error
-  Copyright (C) 1999-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 1999-2022 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_file_error_get.c
+++ b/3rdparty/libzip/lib/zip_file_error_get.c
@@ -1,6 +1,6 @@
 /*
   zip_file_error_get.c -- get zip file error
-  Copyright (C) 1999-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 1999-2022 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_file_get_comment.c
+++ b/3rdparty/libzip/lib/zip_file_get_comment.c
@@ -1,6 +1,6 @@
 /*
   zip_file_get_comment.c -- get file comment
-  Copyright (C) 2006-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 2006-2022 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_file_get_external_attributes.c
+++ b/3rdparty/libzip/lib/zip_file_get_external_attributes.c
@@ -1,6 +1,6 @@
 /*
   zip_file_get_external_attributes.c -- get opsys/external attributes
-  Copyright (C) 2013-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 2013-2022 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_file_get_offset.c
+++ b/3rdparty/libzip/lib/zip_file_get_offset.c
@@ -1,6 +1,6 @@
 /*
   zip_file_get_offset.c -- get offset of file data in archive.
-  Copyright (C) 1999-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 1999-2022 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_file_rename.c
+++ b/3rdparty/libzip/lib/zip_file_rename.c
@@ -1,6 +1,6 @@
 /*
   zip_file_rename.c -- rename file in zip archive
-  Copyright (C) 1999-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 1999-2022 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_file_replace.c
+++ b/3rdparty/libzip/lib/zip_file_replace.c
@@ -1,6 +1,6 @@
 /*
   zip_file_replace.c -- replace file via callback function
-  Copyright (C) 1999-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 1999-2024 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>
@@ -80,6 +80,12 @@ _zip_file_replace(zip_t *za, zip_uint64_t idx, const char *name, zip_source_t *s
             _zip_entry_finalize(za->entry + idx);
             za->nentry = za_nentry_prev;
         }
+        return -1;
+    }
+
+    /* delete all extra fields - these are usually data that are
+     * strongly coupled with the original data */
+    if (zip_file_extra_field_delete(za, idx, ZIP_EXTRA_FIELD_ALL, ZIP_FL_CENTRAL | ZIP_FL_LOCAL) < 0) {
         return -1;
     }
 

--- a/3rdparty/libzip/lib/zip_file_set_comment.c
+++ b/3rdparty/libzip/lib/zip_file_set_comment.c
@@ -1,6 +1,6 @@
 /*
   zip_file_set_comment.c -- set comment for file in archive
-  Copyright (C) 2006-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 2006-2023 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_file_set_encryption.c
+++ b/3rdparty/libzip/lib/zip_file_set_encryption.c
@@ -1,6 +1,6 @@
 /*
   zip_file_set_encryption.c -- set encryption for file in archive
-  Copyright (C) 2016-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 2016-2023 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_file_set_external_attributes.c
+++ b/3rdparty/libzip/lib/zip_file_set_external_attributes.c
@@ -1,6 +1,6 @@
 /*
   zip_file_set_external_attributes.c -- set external attributes for entry
-  Copyright (C) 2013-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 2013-2023 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_file_strerror.c
+++ b/3rdparty/libzip/lib/zip_file_strerror.c
@@ -1,6 +1,6 @@
 /*
   zip_file_sterror.c -- get string representation of zip file error
-  Copyright (C) 1999-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 1999-2022 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_fopen.c
+++ b/3rdparty/libzip/lib/zip_fopen.c
@@ -1,6 +1,6 @@
 /*
   zip_fopen.c -- open file in zip archive for reading
-  Copyright (C) 1999-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 1999-2022 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_fopen_encrypted.c
+++ b/3rdparty/libzip/lib/zip_fopen_encrypted.c
@@ -1,6 +1,6 @@
 /*
   zip_fopen_encrypted.c -- open file for reading with password
-  Copyright (C) 1999-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 1999-2022 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_fopen_index.c
+++ b/3rdparty/libzip/lib/zip_fopen_index.c
@@ -1,6 +1,6 @@
 /*
   zip_fopen_index.c -- open file in zip archive for reading by index
-  Copyright (C) 1999-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 1999-2022 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_fopen_index_encrypted.c
+++ b/3rdparty/libzip/lib/zip_fopen_index_encrypted.c
@@ -1,6 +1,6 @@
 /*
   zip_fopen_index_encrypted.c -- open file for reading by index w/ password
-  Copyright (C) 1999-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 1999-2023 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_fread.c
+++ b/3rdparty/libzip/lib/zip_fread.c
@@ -1,6 +1,6 @@
 /*
   zip_fread.c -- read from file
-  Copyright (C) 1999-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 1999-2024 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>
@@ -39,11 +39,13 @@ ZIP_EXTERN zip_int64_t
 zip_fread(zip_file_t *zf, void *outbuf, zip_uint64_t toread) {
     zip_int64_t n;
 
-    if (!zf)
+    if (zf == NULL) {
         return -1;
+    }
 
-    if (zf->error.zip_err != 0)
+    if (zf->error.zip_err != 0) {
         return -1;
+    }
 
     if (toread > ZIP_INT64_MAX) {
         zip_error_set(&zf->error, ZIP_ER_INVAL, 0);

--- a/3rdparty/libzip/lib/zip_fseek.c
+++ b/3rdparty/libzip/lib/zip_fseek.c
@@ -1,6 +1,6 @@
 /*
   zip_fseek.c -- seek in file
-  Copyright (C) 2016-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 2016-2024 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>
@@ -36,11 +36,13 @@
 
 ZIP_EXTERN zip_int8_t
 zip_fseek(zip_file_t *zf, zip_int64_t offset, int whence) {
-    if (!zf)
+    if (zf == NULL) {
         return -1;
+    }
 
-    if (zf->error.zip_err != 0)
+    if (zf->error.zip_err != 0) {
         return -1;
+    }
 
     if (zip_source_seek(zf->src, offset, whence) < 0) {
         zip_error_set_from_source(&zf->error, zf->src);
@@ -53,7 +55,7 @@ zip_fseek(zip_file_t *zf, zip_int64_t offset, int whence) {
 
 ZIP_EXTERN int
 zip_file_is_seekable(zip_file_t *zfile) {
-    if (!zfile) {
+    if (zfile == NULL) {
         return -1;
     }
     

--- a/3rdparty/libzip/lib/zip_ftell.c
+++ b/3rdparty/libzip/lib/zip_ftell.c
@@ -1,6 +1,6 @@
 /*
   zip_ftell.c -- tell position in file
-  Copyright (C) 2016-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 2016-2024 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>
@@ -38,11 +38,13 @@ ZIP_EXTERN zip_int64_t
 zip_ftell(zip_file_t *zf) {
     zip_int64_t res;
 
-    if (!zf)
+    if (zf == NULL) {
         return -1;
+    }
 
-    if (zf->error.zip_err != 0)
+    if (zf->error.zip_err != 0) {
         return -1;
+    }
 
     res = zip_source_tell(zf->src);
     if (res < 0) {

--- a/3rdparty/libzip/lib/zip_get_archive_comment.c
+++ b/3rdparty/libzip/lib/zip_get_archive_comment.c
@@ -1,6 +1,6 @@
 /*
   zip_get_archive_comment.c -- get archive comment
-  Copyright (C) 2006-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 2006-2022 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_get_archive_flag.c
+++ b/3rdparty/libzip/lib/zip_get_archive_flag.c
@@ -1,6 +1,6 @@
 /*
   zip_get_archive_flag.c -- get archive global flag
-  Copyright (C) 2008-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 2008-2022 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_get_encryption_implementation.c
+++ b/3rdparty/libzip/lib/zip_get_encryption_implementation.c
@@ -1,6 +1,6 @@
 /*
   zip_get_encryption_implementation.c -- get encryption implementation
-  Copyright (C) 2009-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 2009-2022 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_get_file_comment.c
+++ b/3rdparty/libzip/lib/zip_get_file_comment.c
@@ -1,6 +1,6 @@
 /*
   zip_get_file_comment.c -- get file comment
-  Copyright (C) 2006-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 2006-2022 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_get_name.c
+++ b/3rdparty/libzip/lib/zip_get_name.c
@@ -1,6 +1,6 @@
 /*
   zip_get_name.c -- get filename for a file in zip file
-  Copyright (C) 1999-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 1999-2022 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_get_num_entries.c
+++ b/3rdparty/libzip/lib/zip_get_num_entries.c
@@ -1,6 +1,6 @@
 /*
   zip_get_num_entries.c -- get number of entries in archive
-  Copyright (C) 1999-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 1999-2022 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_get_num_files.c
+++ b/3rdparty/libzip/lib/zip_get_num_files.c
@@ -1,6 +1,6 @@
 /*
   zip_get_num_files.c -- get number of files in archive
-  Copyright (C) 1999-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 1999-2022 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_hash.c
+++ b/3rdparty/libzip/lib/zip_hash.c
@@ -1,6 +1,6 @@
 /*
   zip_hash.c -- hash table string -> uint64
-  Copyright (C) 2015-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 2015-2022 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_io_util.c
+++ b/3rdparty/libzip/lib/zip_io_util.c
@@ -1,6 +1,6 @@
 /*
  zip_io_util.c -- I/O helper functions
- Copyright (C) 1999-2021 Dieter Baron and Thomas Klausner
+ Copyright (C) 1999-2024 Dieter Baron and Thomas Klausner
 
  This file is part of libzip, a library to manipulate ZIP archives.
  The authors can be contacted at <info@libzip.org>
@@ -70,7 +70,7 @@ _zip_read_data(zip_buffer_t *buffer, zip_source_t *src, size_t length, bool nulp
     }
 
     r = (zip_uint8_t *)malloc(length + (nulp ? 1 : 0));
-    if (!r) {
+    if (r == NULL) {
         zip_error_set(error, ZIP_ER_MEMORY, 0);
         return NULL;
     }

--- a/3rdparty/libzip/lib/zip_libzip_version.c
+++ b/3rdparty/libzip/lib/zip_libzip_version.c
@@ -1,6 +1,6 @@
 /*
   zip_libzip_version.c -- return run-time version of library
-  Copyright (C) 2017-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 2017-2022 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_memdup.c
+++ b/3rdparty/libzip/lib/zip_memdup.c
@@ -1,6 +1,6 @@
 /*
   zip_memdup.c -- internal zip function, "strdup" with len
-  Copyright (C) 1999-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 1999-2024 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>
@@ -45,7 +45,7 @@ _zip_memdup(const void *mem, size_t len, zip_error_t *error) {
         return NULL;
 
     ret = malloc(len);
-    if (!ret) {
+    if (ret == NULL) {
         zip_error_set(error, ZIP_ER_MEMORY, 0);
         return NULL;
     }

--- a/3rdparty/libzip/lib/zip_new.c
+++ b/3rdparty/libzip/lib/zip_new.c
@@ -1,6 +1,6 @@
 /*
   zip_new.c -- create and init struct zip
-  Copyright (C) 1999-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 1999-2024 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>
@@ -46,7 +46,7 @@ _zip_new(zip_error_t *error) {
     zip_t *za;
 
     za = (zip_t *)malloc(sizeof(struct zip));
-    if (!za) {
+    if (za == NULL) {
         zip_error_set(error, ZIP_ER_MEMORY, 0);
         return NULL;
     }

--- a/3rdparty/libzip/lib/zip_pkware.c
+++ b/3rdparty/libzip/lib/zip_pkware.c
@@ -1,6 +1,6 @@
 /*
   zip_pkware.c -- Traditional PKWARE de/encryption backend routines
-  Copyright (C) 2009-2020 Dieter Baron and Thomas Klausner
+  Copyright (C) 2009-2022 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_progress.c
+++ b/3rdparty/libzip/lib/zip_progress.c
@@ -1,6 +1,6 @@
 /*
  zip_progress.c -- progress reporting
- Copyright (C) 2017-2020 Dieter Baron and Thomas Klausner
+ Copyright (C) 2017-2024 Dieter Baron and Thomas Klausner
 
  This file is part of libzip, a library to manipulate ZIP archives.
  The authors can be contacted at <info@libzip.org>
@@ -191,7 +191,7 @@ _zip_progress_update(zip_progress_t *progress, double sub_current) {
     if (progress->callback_progress != NULL) {
         current = ZIP_MIN(ZIP_MAX(sub_current, 0.0), 1.0) * (progress->end - progress->start) + progress->start;
 
-        if (current - progress->last_update > progress->precision) {
+        if (current - progress->last_update > progress->precision || (progress->last_update < 1 && current == 1)) {
             progress->callback_progress(progress->za, current, progress->ud_progress);
             progress->last_update = current;
         }

--- a/3rdparty/libzip/lib/zip_random_unix.c
+++ b/3rdparty/libzip/lib/zip_random_unix.c
@@ -1,6 +1,6 @@
 /*
   zip_random_unix.c -- fill the user's buffer with random stuff (Unix version)
-  Copyright (C) 2016-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 2016-2023 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_random_uwp.c
+++ b/3rdparty/libzip/lib/zip_random_uwp.c
@@ -1,6 +1,6 @@
 /*
   zip_random_uwp.c -- fill the user's buffer with random stuff (UWP version)
-  Copyright (C) 2017-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 2017-2023 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_random_win32.c
+++ b/3rdparty/libzip/lib/zip_random_win32.c
@@ -1,6 +1,6 @@
 /*
   zip_random_win32.c -- fill the user's buffer with random stuff (Windows version)
-  Copyright (C) 2016-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 2016-2023 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_rename.c
+++ b/3rdparty/libzip/lib/zip_rename.c
@@ -1,6 +1,6 @@
 /*
   zip_rename.c -- rename file in zip archive
-  Copyright (C) 1999-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 1999-2022 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_replace.c
+++ b/3rdparty/libzip/lib/zip_replace.c
@@ -1,6 +1,6 @@
 /*
   zip_replace.c -- replace file via callback function
-  Copyright (C) 1999-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 1999-2022 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_set_archive_comment.c
+++ b/3rdparty/libzip/lib/zip_set_archive_comment.c
@@ -1,6 +1,6 @@
 /*
   zip_set_archive_comment.c -- set archive comment
-  Copyright (C) 2006-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 2006-2023 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_set_archive_flag.c
+++ b/3rdparty/libzip/lib/zip_set_archive_flag.c
@@ -1,6 +1,6 @@
 /*
   zip_get_archive_flag.c -- set archive global flag
-  Copyright (C) 2008-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 2008-2023 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_set_default_password.c
+++ b/3rdparty/libzip/lib/zip_set_default_password.c
@@ -1,6 +1,6 @@
 /*
   zip_set_default_password.c -- set default password for decryption
-  Copyright (C) 2009-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 2009-2022 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_set_file_comment.c
+++ b/3rdparty/libzip/lib/zip_set_file_comment.c
@@ -1,6 +1,6 @@
 /*
   zip_set_file_comment.c -- set comment for file in archive
-  Copyright (C) 2006-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 2006-2022 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_set_file_compression.c
+++ b/3rdparty/libzip/lib/zip_set_file_compression.c
@@ -1,6 +1,6 @@
 /*
   zip_set_file_compression.c -- set compression for file in archive
-  Copyright (C) 2012-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 2012-2023 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_set_name.c
+++ b/3rdparty/libzip/lib/zip_set_name.c
@@ -1,6 +1,6 @@
 /*
   zip_set_name.c -- rename helper function
-  Copyright (C) 1999-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 1999-2022 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_source_accept_empty.c
+++ b/3rdparty/libzip/lib/zip_source_accept_empty.c
@@ -1,6 +1,6 @@
 /*
   zip_source_accept_empty.c -- if empty source is a valid archive
-  Copyright (C) 2019-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 2019-2022 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_source_begin_write.c
+++ b/3rdparty/libzip/lib/zip_source_begin_write.c
@@ -1,6 +1,6 @@
 /*
   zip_source_begin_write.c -- start a new file for writing
-  Copyright (C) 2014-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 2014-2022 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_source_begin_write_cloning.c
+++ b/3rdparty/libzip/lib/zip_source_begin_write_cloning.c
@@ -1,6 +1,6 @@
 /*
   zip_source_begin_write_cloning.c -- clone part of file for writing
-  Copyright (C) 2017-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 2017-2022 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_source_buffer.c
+++ b/3rdparty/libzip/lib/zip_source_buffer.c
@@ -1,6 +1,6 @@
 /*
   zip_source_buffer.c -- create zip data source from buffer
-  Copyright (C) 1999-2022 Dieter Baron and Thomas Klausner
+  Copyright (C) 1999-2023 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_source_call.c
+++ b/3rdparty/libzip/lib/zip_source_call.c
@@ -1,6 +1,6 @@
 /*
  zip_source_call.c -- invoke callback command on zip_source
- Copyright (C) 2009-2021 Dieter Baron and Thomas Klausner
+ Copyright (C) 2009-2022 Dieter Baron and Thomas Klausner
 
  This file is part of libzip, a library to manipulate ZIP archives.
  The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_source_close.c
+++ b/3rdparty/libzip/lib/zip_source_close.c
@@ -1,6 +1,6 @@
 /*
   zip_source_close.c -- close zip_source (stop reading)
-  Copyright (C) 2009-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 2009-2022 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_source_commit_write.c
+++ b/3rdparty/libzip/lib/zip_source_commit_write.c
@@ -1,6 +1,6 @@
 /*
   zip_source_commit_write.c -- commit changes to file
-  Copyright (C) 2014-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 2014-2022 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_source_compress.c
+++ b/3rdparty/libzip/lib/zip_source_compress.c
@@ -1,6 +1,6 @@
 /*
   zip_source_compress.c -- (de)compression routines
-  Copyright (C) 2017-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 2017-2023 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_source_crc.c
+++ b/3rdparty/libzip/lib/zip_source_crc.c
@@ -1,6 +1,6 @@
 /*
   zip_source_crc.c -- pass-through source that calculates CRC32 and size
-  Copyright (C) 2009-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 2009-2023 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_source_error.c
+++ b/3rdparty/libzip/lib/zip_source_error.c
@@ -1,6 +1,6 @@
 /*
   zip_source_error.c -- get last error from zip_source
-  Copyright (C) 2009-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 2009-2022 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_source_file.h
+++ b/3rdparty/libzip/lib/zip_source_file.h
@@ -1,6 +1,9 @@
+#ifndef _HAD_ZIP_SOURCE_FILE_H
+#define _HAD_ZIP_SOURCE_FILE_H
+
 /*
   zip_source_file.h -- header for common file operations
-  Copyright (C) 2020-2022 Dieter Baron and Thomas Klausner
+  Copyright (C) 2020-2024 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>
@@ -88,3 +91,5 @@ struct zip_source_file_operations {
 };
 
 zip_source_t *zip_source_file_common_new(const char *fname, void *file, zip_uint64_t start, zip_int64_t len, const zip_stat_t *st, zip_source_file_operations_t *ops, void *ops_userdata, zip_error_t *error);
+
+#endif /* _HAD_ZIP_SOURCE_FILE_H */

--- a/3rdparty/libzip/lib/zip_source_file_common.c
+++ b/3rdparty/libzip/lib/zip_source_file_common.c
@@ -1,6 +1,6 @@
 /*
   zip_source_file_common.c -- create data source from file
-  Copyright (C) 1999-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 1999-2023 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_source_file_stdio.c
+++ b/3rdparty/libzip/lib/zip_source_file_stdio.c
@@ -1,6 +1,6 @@
 /*
   zip_source_file_stdio.c -- read-only stdio file source implementation
-  Copyright (C) 2020 Dieter Baron and Thomas Klausner
+  Copyright (C) 2020-2023 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_source_file_stdio.h
+++ b/3rdparty/libzip/lib/zip_source_file_stdio.h
@@ -3,7 +3,7 @@
 
 /*
   zip_source_file_stdio.h -- common header for stdio file implementation
-  Copyright (C) 2020 Dieter Baron and Thomas Klausner
+  Copyright (C) 2020-2022 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_source_file_stdio_named.c
+++ b/3rdparty/libzip/lib/zip_source_file_stdio_named.c
@@ -1,6 +1,6 @@
 /*
   zip_source_file_stdio_named.c -- source for stdio file opened by name
-  Copyright (C) 1999-2022 Dieter Baron and Thomas Klausner
+  Copyright (C) 1999-2023 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_source_file_win32.c
+++ b/3rdparty/libzip/lib/zip_source_file_win32.c
@@ -1,6 +1,6 @@
 /*
   zip_source_file_win32.c -- read-only Windows file source implementation
-  Copyright (C) 1999-2022 Dieter Baron and Thomas Klausner
+  Copyright (C) 1999-2023 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_source_file_win32.h
+++ b/3rdparty/libzip/lib/zip_source_file_win32.h
@@ -3,7 +3,7 @@
 
 /*
   zip_source_file_win32.h -- common header for Windows file implementation
-  Copyright (C) 2020 Dieter Baron and Thomas Klausner
+  Copyright (C) 2020-2024 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>
@@ -59,6 +59,7 @@ struct zip_win32_file_operations {
     BOOL(__stdcall *move_file)(const void *from, const void *to, DWORD flags);
     BOOL(__stdcall *set_file_attributes)(const void *name, DWORD attributes);
     char *(*string_duplicate)(const char *string);
+    HANDLE(__stdcall *find_first_file)(const void *name, void *data);
 };
 
 typedef struct zip_win32_file_operations zip_win32_file_operations_t;
@@ -72,13 +73,5 @@ zip_int64_t _zip_win32_op_tell(zip_source_file_context_t *ctx, void *f);
 
 bool _zip_filetime_to_time_t(FILETIME ft, time_t *t);
 int _zip_win32_error_to_errno(DWORD win32err);
-
-#ifdef __clang__
-#define DONT_WARN_INCOMPATIBLE_FN_PTR_BEGIN _Pragma("GCC diagnostic push") _Pragma("GCC diagnostic ignored \"-Wincompatible-function-pointer-types\"")
-#define DONT_WARN_INCOMPATIBLE_FN_PTR_END _Pragma("GCC diagnostic pop")
-#else
-#define DONT_WARN_INCOMPATIBLE_FN_PTR_BEGIN
-#define DONT_WARN_INCOMPATIBLE_FN_PTR_END
-#endif
 
 #endif /* _HAD_ZIP_SOURCE_FILE_WIN32_H */

--- a/3rdparty/libzip/lib/zip_source_file_win32_utf8.c
+++ b/3rdparty/libzip/lib/zip_source_file_win32_utf8.c
@@ -1,6 +1,6 @@
 /*
   zip_source_file_win32_ansi.c -- source for Windows file opened by UTF-8 name
-  Copyright (C) 1999-2020 Dieter Baron and Thomas Klausner
+  Copyright (C) 1999-2023 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_source_free.c
+++ b/3rdparty/libzip/lib/zip_source_free.c
@@ -1,6 +1,6 @@
 /*
   zip_source_free.c -- free zip data source
-  Copyright (C) 1999-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 1999-2022 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_source_get_file_attributes.c
+++ b/3rdparty/libzip/lib/zip_source_get_file_attributes.c
@@ -1,6 +1,6 @@
 /*
   zip_source_get_file_attributes.c -- get attributes for file from source
-  Copyright (C) 2020 Dieter Baron and Thomas Klausner
+  Copyright (C) 2020-2022 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_source_is_deleted.c
+++ b/3rdparty/libzip/lib/zip_source_is_deleted.c
@@ -1,6 +1,6 @@
 /*
   zip_source_is_deleted.c -- was archive was removed?
-  Copyright (C) 2014-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 2014-2022 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_source_layered.c
+++ b/3rdparty/libzip/lib/zip_source_layered.c
@@ -1,6 +1,6 @@
 /*
   zip_source_layered.c -- create layered source
-  Copyright (C) 2009-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 2009-2023 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_source_open.c
+++ b/3rdparty/libzip/lib/zip_source_open.c
@@ -1,6 +1,6 @@
 /*
   zip_source_open.c -- open zip_source (prepare for reading)
-  Copyright (C) 2009-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 2009-2022 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_source_pass_to_lower_layer.c
+++ b/3rdparty/libzip/lib/zip_source_pass_to_lower_layer.c
@@ -1,6 +1,6 @@
 /*
   zip_source_pass_to_lower_layer.c -- pass command to lower layer
-  Copyright (C) 2022 Dieter Baron and Thomas Klausner
+  Copyright (C) 2022-2024 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>
@@ -47,11 +47,11 @@ zip_int64_t zip_source_pass_to_lower_layer(zip_source_t *src, void *data, zip_ui
 
     case ZIP_SOURCE_ACCEPT_EMPTY:
     case ZIP_SOURCE_ERROR:
+    case ZIP_SOURCE_GET_DOS_TIME:
     case ZIP_SOURCE_READ:
     case ZIP_SOURCE_SEEK:
     case ZIP_SOURCE_TELL:
         return _zip_source_call(src, data, length, command);
-
 
     case ZIP_SOURCE_BEGIN_WRITE:
     case ZIP_SOURCE_BEGIN_WRITE_CLONING:

--- a/3rdparty/libzip/lib/zip_source_pkware_decode.c
+++ b/3rdparty/libzip/lib/zip_source_pkware_decode.c
@@ -1,6 +1,6 @@
 /*
   zip_source_pkware_decode.c -- Traditional PKWARE decryption routines
-  Copyright (C) 2009-2020 Dieter Baron and Thomas Klausner
+  Copyright (C) 2009-2024 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>
@@ -80,9 +80,9 @@ zip_source_pkware_decode(zip_t *za, zip_source_t *src, zip_uint16_t em, int flag
 static int
 decrypt_header(zip_source_t *src, struct trad_pkware *ctx) {
     zip_uint8_t header[ZIP_CRYPTO_PKWARE_HEADERLEN];
-    struct zip_stat st;
+    zip_stat_t st;
+    zip_dostime_t dostime;
     zip_int64_t n;
-    bool ok = false;
 
     if ((n = zip_source_read(src, header, ZIP_CRYPTO_PKWARE_HEADERLEN)) < 0) {
         zip_error_set_from_source(&ctx->error, src);
@@ -96,36 +96,35 @@ decrypt_header(zip_source_t *src, struct trad_pkware *ctx) {
 
     _zip_pkware_decrypt(&ctx->keys, header, header, ZIP_CRYPTO_PKWARE_HEADERLEN);
 
-    if (zip_source_stat(src, &st)) {
-        /* stat failed, skip password validation */
+    if (zip_source_stat(src, &st) < 0 || (st.valid & ZIP_STAT_CRC) == 0) {
+        /* skip password validation */
         return 0;
     }
 
-    /* password verification - two ways:
-     *  mtime - InfoZIP way, to avoid computing complete CRC before encrypting data
-     *  CRC - old PKWare way
-     */
+    if (zip_source_get_dos_time(src, &dostime) <= 0) {
+        if ((st.valid & ZIP_STAT_MTIME) == 0) {
+            /* no date available, skip password validation */
+            return 0;
+        }
 
-    if (st.valid & ZIP_STAT_MTIME) {
-        unsigned short dostime, dosdate;
-        _zip_u2d_time(st.mtime, &dostime, &dosdate);
-        if (header[ZIP_CRYPTO_PKWARE_HEADERLEN - 1] == dostime >> 8) {
-            ok = true;
+        if (_zip_u2d_time(st.mtime, &dostime, &ctx->error) < 0) {
+            return -1;
         }
     }
 
-    if (st.valid & ZIP_STAT_CRC) {
-        if (header[ZIP_CRYPTO_PKWARE_HEADERLEN - 1] == st.crc >> 24) {
-            ok = true;
-        }
+    /*
+       password verification - two ways:
+       - mtime - InfoZIP way, to avoid computing complete CRC before encrypting data
+       - CRC - old PKWare way
+    */
+    if (header[ZIP_CRYPTO_PKWARE_HEADERLEN - 1] == dostime.time >> 8
+        || header[ZIP_CRYPTO_PKWARE_HEADERLEN - 1] == st.crc >> 24) {
+        return 0;
     }
-
-    if (!ok && ((st.valid & (ZIP_STAT_MTIME | ZIP_STAT_CRC)) != 0)) {
+    else {
         zip_error_set(&ctx->error, ZIP_ER_WRONGPASSWD, 0);
         return -1;
     }
-
-    return 0;
 }
 
 

--- a/3rdparty/libzip/lib/zip_source_read.c
+++ b/3rdparty/libzip/lib/zip_source_read.c
@@ -1,6 +1,6 @@
 /*
   zip_source_read.c -- read data from zip_source
-  Copyright (C) 2009-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 2009-2022 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_source_remove.c
+++ b/3rdparty/libzip/lib/zip_source_remove.c
@@ -1,6 +1,6 @@
 /*
  zip_source_remove.c -- remove empty archive
- Copyright (C) 2014-2021 Dieter Baron and Thomas Klausner
+ Copyright (C) 2014-2022 Dieter Baron and Thomas Klausner
 
  This file is part of libzip, a library to manipulate ZIP archives.
  The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_source_rollback_write.c
+++ b/3rdparty/libzip/lib/zip_source_rollback_write.c
@@ -1,6 +1,6 @@
 /*
   zip_source_rollback_write.c -- discard changes
-  Copyright (C) 2014-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 2014-2022 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_source_seek.c
+++ b/3rdparty/libzip/lib/zip_source_seek.c
@@ -1,6 +1,6 @@
 /*
   zip_source_seek.c -- seek to offset
-  Copyright (C) 2014-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 2014-2022 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_source_seek_write.c
+++ b/3rdparty/libzip/lib/zip_source_seek_write.c
@@ -1,6 +1,6 @@
 /*
   zip_source_seek_write.c -- seek to offset for writing
-  Copyright (C) 2014-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 2014-2022 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_source_stat.c
+++ b/3rdparty/libzip/lib/zip_source_stat.c
@@ -1,6 +1,6 @@
 /*
   zip_source_stat.c -- get meta information from zip_source
-  Copyright (C) 2009-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 2009-2023 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_source_supports.c
+++ b/3rdparty/libzip/lib/zip_source_supports.c
@@ -1,6 +1,6 @@
 /*
   zip_source_supports.c -- check for supported functions
-  Copyright (C) 2014-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 2014-2023 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_source_tell.c
+++ b/3rdparty/libzip/lib/zip_source_tell.c
@@ -1,6 +1,6 @@
 /*
   zip_source_tell.c -- report current offset
-  Copyright (C) 2014-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 2014-2022 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_source_tell_write.c
+++ b/3rdparty/libzip/lib/zip_source_tell_write.c
@@ -1,6 +1,6 @@
 /*
   zip_source_tell_write.c -- report current offset for writing
-  Copyright (C) 2014-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 2014-2022 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_source_winzip_aes_decode.c
+++ b/3rdparty/libzip/lib/zip_source_winzip_aes_decode.c
@@ -1,6 +1,6 @@
 /*
   zip_source_winzip_aes_decode.c -- Winzip AES decryption routines
-  Copyright (C) 2009-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 2009-2023 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_source_winzip_aes_encode.c
+++ b/3rdparty/libzip/lib/zip_source_winzip_aes_encode.c
@@ -1,6 +1,6 @@
 /*
   zip_source_winzip_aes_encode.c -- Winzip AES encryption routines
-  Copyright (C) 2009-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 2009-2023 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_source_write.c
+++ b/3rdparty/libzip/lib/zip_source_write.c
@@ -1,6 +1,6 @@
 /*
   zip_source_write.c -- start a new file for writing
-  Copyright (C) 2014-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 2014-2022 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_source_zip.c
+++ b/3rdparty/libzip/lib/zip_source_zip.c
@@ -1,6 +1,6 @@
 /*
   zip_source_zip.c -- create data source from zip file
-  Copyright (C) 1999-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 1999-2023 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_source_zip_new.c
+++ b/3rdparty/libzip/lib/zip_source_zip_new.c
@@ -1,6 +1,6 @@
 /*
   zip_source_zip_new.c -- prepare data structures for zip_fopen/zip_source_zip
-  Copyright (C) 2012-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 2012-2024 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>
@@ -200,7 +200,7 @@ ZIP_EXTERN zip_source_t *zip_source_zip_file_create(zip_t *srcza, zip_uint64_t s
             st2.valid |= ZIP_STAT_MTIME;
         }
 
-        if ((src = _zip_source_window_new(src, start, data_len, &st2, ZIP_STAT_NAME, &attributes, source_archive, source_index, take_ownership, error)) == NULL) {
+        if ((src = _zip_source_window_new(src, start, data_len, &st2, ZIP_STAT_NAME, &attributes, &de->last_mod, source_archive, source_index, take_ownership, error)) == NULL) {
             return NULL;
         }
     }
@@ -219,7 +219,7 @@ ZIP_EXTERN zip_source_t *zip_source_zip_file_create(zip_t *srcza, zip_uint64_t s
            attributes and to have a source that positions the read
            offset properly before each read for multiple zip_file_t
            referring to the same underlying source */
-        if ((src =  _zip_source_window_new(srcza->src, 0, (zip_int64_t)st.comp_size, &st, ZIP_STAT_NAME, &attributes, srcza, srcidx, take_ownership, error)) == NULL) {
+        if ((src =  _zip_source_window_new(srcza->src, 0, (zip_int64_t)st.comp_size, &st, ZIP_STAT_NAME, &attributes, &de->last_mod, srcza, srcidx, take_ownership, error)) == NULL) {
             return NULL;
         }
     }
@@ -235,7 +235,7 @@ ZIP_EXTERN zip_source_t *zip_source_zip_file_create(zip_t *srcza, zip_uint64_t s
            attributes and to have a source that positions the read
            offset properly before each read for multiple zip_file_t
            referring to the same underlying source */
-        if ((src = _zip_source_window_new(src, 0, data_len, &st, ZIP_STAT_NAME, &attributes, NULL, 0, take_ownership, error)) == NULL) {
+        if ((src = _zip_source_window_new(src, 0, data_len, &st, ZIP_STAT_NAME, &attributes, &de->last_mod, NULL, 0, take_ownership, error)) == NULL) {
             return NULL;
         }
     }
@@ -253,6 +253,7 @@ ZIP_EXTERN zip_source_t *zip_source_zip_file_create(zip_t *srcza, zip_uint64_t s
         zip_encryption_implementation enc_impl;
 
         if ((enc_impl = _zip_get_encryption_implementation(st.encryption_method, ZIP_CODEC_DECODE)) == NULL) {
+            zip_source_free(src);
             zip_error_set(error, ZIP_ER_ENCRNOTSUPP, 0);
             return NULL;
         }
@@ -289,7 +290,7 @@ ZIP_EXTERN zip_source_t *zip_source_zip_file_create(zip_t *srcza, zip_uint64_t s
             st2.valid = ZIP_STAT_SIZE;
             st2.size = (zip_uint64_t)data_len;
         }
-        s2 = _zip_source_window_new(src, start, data_len, &st2, ZIP_STAT_NAME, NULL, NULL, 0, true, error);
+        s2 = _zip_source_window_new(src, start, data_len, &st2, ZIP_STAT_NAME, NULL, NULL, NULL, 0, true, error);
         if (s2 == NULL) {
             zip_source_free(src);
             return NULL;

--- a/3rdparty/libzip/lib/zip_stat.c
+++ b/3rdparty/libzip/lib/zip_stat.c
@@ -1,6 +1,6 @@
 /*
   zip_stat.c -- get information about file by name
-  Copyright (C) 1999-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 1999-2022 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_stat_index.c
+++ b/3rdparty/libzip/lib/zip_stat_index.c
@@ -1,6 +1,6 @@
 /*
   zip_stat_index.c -- get information about file by index
-  Copyright (C) 1999-2020 Dieter Baron and Thomas Klausner
+  Copyright (C) 1999-2024 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>
@@ -77,7 +77,7 @@ zip_stat_index(zip_t *za, zip_uint64_t index, zip_flags_t flags, zip_stat_t *st)
         }
 
         if (entry->changes != NULL && entry->changes->changed & ZIP_DIRENT_LAST_MOD) {
-            st->mtime = de->last_mod;
+            st->mtime = _zip_d2u_time(&de->last_mod);
             st->valid |= ZIP_STAT_MTIME;
         }
     }
@@ -86,7 +86,7 @@ zip_stat_index(zip_t *za, zip_uint64_t index, zip_flags_t flags, zip_stat_t *st)
 
         st->crc = de->crc;
         st->size = de->uncomp_size;
-        st->mtime = de->last_mod;
+        st->mtime = _zip_d2u_time(&de->last_mod);
         st->comp_size = de->comp_size;
         st->comp_method = (zip_uint16_t)de->comp_method;
         st->encryption_method = de->encryption_method;
@@ -97,8 +97,9 @@ zip_stat_index(zip_t *za, zip_uint64_t index, zip_flags_t flags, zip_stat_t *st)
     }
 
     if ((za->ch_flags & ZIP_AFL_WANT_TORRENTZIP) && (flags & ZIP_FL_UNCHANGED) == 0) {
+        zip_dostime_t dostime = {0xbc00, 0x2198};
         st->comp_method = ZIP_CM_DEFLATE;
-        st->mtime = _zip_d2u_time(0xbc00, 0x2198);
+        st->mtime = _zip_d2u_time(&dostime);
         st->valid |= ZIP_STAT_MTIME | ZIP_STAT_COMP_METHOD;
         st->valid &= ~ZIP_STAT_COMP_SIZE;
     }

--- a/3rdparty/libzip/lib/zip_stat_init.c
+++ b/3rdparty/libzip/lib/zip_stat_init.c
@@ -1,6 +1,6 @@
 /*
   zip_stat_init.c -- initialize struct zip_stat.
-  Copyright (C) 2006-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 2006-2022 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_strerror.c
+++ b/3rdparty/libzip/lib/zip_strerror.c
@@ -1,6 +1,6 @@
 /*
   zip_sterror.c -- get string representation of zip error
-  Copyright (C) 1999-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 1999-2022 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_unchange_all.c
+++ b/3rdparty/libzip/lib/zip_unchange_all.c
@@ -1,6 +1,6 @@
 /*
   zip_unchange.c -- undo changes to all files in zip archive
-  Copyright (C) 1999-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 1999-2022 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_unchange_archive.c
+++ b/3rdparty/libzip/lib/zip_unchange_archive.c
@@ -1,6 +1,6 @@
 /*
   zip_unchange_archive.c -- undo global changes to ZIP archive
-  Copyright (C) 2006-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 2006-2022 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_unchange_data.c
+++ b/3rdparty/libzip/lib/zip_unchange_data.c
@@ -1,6 +1,6 @@
 /*
   zip_unchange_data.c -- undo helper function
-  Copyright (C) 1999-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 1999-2022 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zip_utf-8.c
+++ b/3rdparty/libzip/lib/zip_utf-8.c
@@ -1,6 +1,6 @@
 /*
   zip_utf-8.c -- UTF-8 support functions for libzip
-  Copyright (C) 2011-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 2011-2024 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>
@@ -101,70 +101,124 @@ _zip_guess_encoding(zip_string_t *str, zip_encoding_type_t expected_encoding) {
     zip_encoding_type_t enc;
     const zip_uint8_t *name;
     zip_uint32_t i, j, ulen;
+    bool can_be_ascii = true;
+    bool can_be_utf8 = true;
+    bool has_control_characters = false;
 
-    if (str == NULL)
+    if (str == NULL) {
         return ZIP_ENCODING_ASCII;
+    }
 
     name = str->raw;
 
-    if (str->encoding != ZIP_ENCODING_UNKNOWN)
-        enc = str->encoding;
-    else {
-        enc = ZIP_ENCODING_ASCII;
-        for (i = 0; i < str->length; i++) {
-            if ((name[i] > 31 && name[i] < 128) || name[i] == '\r' || name[i] == '\n' || name[i] == '\t')
-                continue;
+    if (str->encoding != ZIP_ENCODING_UNKNOWN) {
+        return str->encoding;
+    }
 
-            enc = ZIP_ENCODING_UTF8_GUESSED;
-            if ((name[i] & UTF_8_LEN_2_MASK) == UTF_8_LEN_2_MATCH)
-                ulen = 1;
-            else if ((name[i] & UTF_8_LEN_3_MASK) == UTF_8_LEN_3_MATCH)
-                ulen = 2;
-            else if ((name[i] & UTF_8_LEN_4_MASK) == UTF_8_LEN_4_MATCH)
-                ulen = 3;
-            else {
-                enc = ZIP_ENCODING_CP437;
-                break;
+    for (i = 0; i < str->length; i++) {
+        if (name[i] < 128) {
+            if (name[i] < 32 && name[i] != '\r' && name[i] != '\n' && name[i] != '\t') {
+                has_control_characters = true;
             }
-
-            if (i + ulen >= str->length) {
-                enc = ZIP_ENCODING_CP437;
-                break;
-            }
-
-            for (j = 1; j <= ulen; j++) {
-                if ((name[i + j] & UTF_8_CONTINUE_MASK) != UTF_8_CONTINUE_MATCH) {
-                    enc = ZIP_ENCODING_CP437;
-                    goto done;
-                }
-            }
-            i += ulen;
+            continue;
         }
+
+        can_be_ascii = false;
+        if ((name[i] & UTF_8_LEN_2_MASK) == UTF_8_LEN_2_MATCH) {
+            ulen = 1;
+        }
+        else if ((name[i] & UTF_8_LEN_3_MASK) == UTF_8_LEN_3_MATCH) {
+            ulen = 2;
+        }
+        else if ((name[i] & UTF_8_LEN_4_MASK) == UTF_8_LEN_4_MATCH) {
+            ulen = 3;
+        }
+        else {
+            can_be_utf8 = false;
+            break;
+        }
+
+        if (i + ulen >= str->length) {
+            can_be_utf8 = false;
+            break;
+        }
+
+        for (j = 1; j <= ulen; j++) {
+            if ((name[i + j] & UTF_8_CONTINUE_MASK) != UTF_8_CONTINUE_MATCH) {
+                can_be_utf8 = false;
+                goto done;
+            }
+        }
+        i += ulen;
     }
 
-done:
+ done:
+    enc = ZIP_ENCODING_CP437;
+
+    switch (expected_encoding) {
+    case ZIP_ENCODING_UTF8_KNOWN:
+    case ZIP_ENCODING_UTF8_GUESSED:
+        if (can_be_utf8) {
+            enc = ZIP_ENCODING_UTF8_KNOWN;
+        }
+        else {
+            enc = ZIP_ENCODING_ERROR;
+        }
+        break;
+
+    case ZIP_ENCODING_ASCII:
+        if (can_be_ascii && !has_control_characters) {
+            enc = ZIP_ENCODING_ASCII;
+        }
+        else {
+            enc = ZIP_ENCODING_ERROR;
+        }
+        break;
+
+    case ZIP_ENCODING_CP437:
+        enc = ZIP_ENCODING_CP437;
+        break;
+
+    case ZIP_ENCODING_UNKNOWN:
+        if (can_be_ascii && !has_control_characters) {
+            /* only bytes from 0x20-0x7F */
+            enc = ZIP_ENCODING_ASCII;
+        }
+        else if (can_be_ascii && has_control_characters) {
+            /* only bytes from 0x00-0x7F */
+            enc = ZIP_ENCODING_CP437;
+        }
+        else if (can_be_utf8) {
+            /* contains bytes from 0x80-0xFF and is valid UTF-8 */
+            enc =  ZIP_ENCODING_UTF8_GUESSED;
+        }
+        else {
+            /* fallback */
+            enc = ZIP_ENCODING_CP437;
+        }
+        break;
+    case ZIP_ENCODING_ERROR:
+        /* invalid, shouldn't happen */
+        enc = ZIP_ENCODING_ERROR;
+        break;
+    }
+
     str->encoding = enc;
-
-    if (expected_encoding != ZIP_ENCODING_UNKNOWN) {
-        if (expected_encoding == ZIP_ENCODING_UTF8_KNOWN && enc == ZIP_ENCODING_UTF8_GUESSED)
-            str->encoding = enc = ZIP_ENCODING_UTF8_KNOWN;
-
-        if (expected_encoding != enc && enc != ZIP_ENCODING_ASCII)
-            return ZIP_ENCODING_ERROR;
-    }
-
     return enc;
 }
 
 
 static zip_uint32_t
 _zip_unicode_to_utf8_len(zip_uint32_t codepoint) {
-    if (codepoint < 0x0080)
+    if (codepoint < 0x0080) {
         return 1;
-    if (codepoint < 0x0800)
+    }
+    if (codepoint < 0x0800) {
         return 2;
-    if (codepoint < 0x10000)
+    }
+    if (codepoint < 0x10000) {
         return 3;
+    }
     return 4;
 }
 
@@ -201,14 +255,16 @@ _zip_cp437_to_utf8(const zip_uint8_t *const _cp437buf, zip_uint32_t len, zip_uin
     zip_uint32_t buflen, i, offset;
 
     if (len == 0) {
-        if (utf8_lenp)
+        if (utf8_lenp) {
             *utf8_lenp = 0;
+        }
         return NULL;
     }
 
     buflen = 1;
-    for (i = 0; i < len; i++)
+    for (i = 0; i < len; i++) {
         buflen += _zip_unicode_to_utf8_len(_cp437_to_unicode[cp437buf[i]]);
+    }
 
     if ((utf8buf = (zip_uint8_t *)malloc(buflen)) == NULL) {
         zip_error_set(error, ZIP_ER_MEMORY, 0);
@@ -216,11 +272,13 @@ _zip_cp437_to_utf8(const zip_uint8_t *const _cp437buf, zip_uint32_t len, zip_uin
     }
 
     offset = 0;
-    for (i = 0; i < len; i++)
+    for (i = 0; i < len; i++) {
         offset += _zip_unicode_to_utf8(_cp437_to_unicode[cp437buf[i]], utf8buf + offset);
+    }
 
     utf8buf[buflen - 1] = 0;
-    if (utf8_lenp)
+    if (utf8_lenp) {
         *utf8_lenp = buflen - 1;
+    }
     return utf8buf;
 }

--- a/3rdparty/libzip/lib/zip_winzip_aes.c
+++ b/3rdparty/libzip/lib/zip_winzip_aes.c
@@ -1,6 +1,6 @@
 /*
   zip_winzip_aes.c -- Winzip AES de/encryption backend routines
-  Copyright (C) 2017-2021 Dieter Baron and Thomas Klausner
+  Copyright (C) 2017-2022 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>

--- a/3rdparty/libzip/lib/zipint.h
+++ b/3rdparty/libzip/lib/zipint.h
@@ -3,7 +3,7 @@
 
 /*
   zipint.h -- internal declarations.
-  Copyright (C) 1999-2022 Dieter Baron and Thomas Klausner
+  Copyright (C) 1999-2024 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>
@@ -56,6 +56,7 @@
 #define DATADES_MAGIC "PK\7\10"
 #define EOCD64LOC_MAGIC "PK\6\7"
 #define EOCD64_MAGIC "PK\6\6"
+#define MAGIC_LEN 4
 #define CDENTRYSIZE 46u
 #define LENTRYSIZE 30
 #define MAXCOMLEN 65536
@@ -229,12 +230,17 @@ extern const int _zip_err_details_count;
 #define ZIP_ER_DETAIL_CDIR_INVALID 11  /* G invalid value in central directory */
 #define ZIP_ER_DETAIL_VARIABLE_SIZE_OVERFLOW 12 /* E variable size fields overflow header */
 #define ZIP_ER_DETAIL_INVALID_UTF8_IN_FILENAME 13 /* E invalid UTF-8 in filename */
-#define ZIP_ER_DETAIL_INVALID_UTF8_IN_COMMENT 13 /* E invalid UTF-8 in comment */
-#define ZIP_ER_DETAIL_INVALID_ZIP64_EF 14 /* E invalid Zip64 extra field */
-#define ZIP_ER_DETAIL_INVALID_WINZIPAES_EF 14 /* E invalid WinZip AES extra field */
-#define ZIP_ER_DETAIL_EF_TRAILING_GARBAGE 15 /* E garbage at end of extra fields */
-#define ZIP_ER_DETAIL_INVALID_EF_LENGTH 16 /* E extra field length is invalid */
-#define ZIP_ER_DETAIL_INVALID_FILE_LENGTH 17 /* E file length in header doesn't match actual file length */
+#define ZIP_ER_DETAIL_INVALID_UTF8_IN_COMMENT 14 /* E invalid UTF-8 in comment */
+#define ZIP_ER_DETAIL_INVALID_ZIP64_EF 15 /* E invalid Zip64 extra field */
+#define ZIP_ER_DETAIL_INVALID_WINZIPAES_EF 16 /* E invalid WinZip AES extra field */
+#define ZIP_ER_DETAIL_EF_TRAILING_GARBAGE 17 /* E garbage at end of extra fields */
+#define ZIP_ER_DETAIL_INVALID_EF_LENGTH 18 /* E extra field length is invalid */
+#define ZIP_ER_DETAIL_INVALID_FILE_LENGTH 19 /* E file length in header doesn't match actual file length */
+#define ZIP_ER_DETAIL_STORED_SIZE_MISMATCH 20 /* E compressed and uncompressed sizes don't match for stored file */
+#define ZIP_ER_DETAIL_DATA_DESCRIPTOR_MISMATCH 21 /* E local header and data descriptor do not match */
+#define ZIP_ER_DETAIL_EOCD64_LOCATOR_MISMATCH 22 /* G EOCD64 and EOCD64 locator do not match */
+#define ZIP_ER_DETAIL_UTF8_FILENAME_MISMATCH 23 /* E UTF-8 filename is ASCII and doesn't match filename */
+#define ZIP_ER_DETAIL_UTF8_COMMENT_MISMATCH 24 /* E UTF-8 comment is ASCII and doesn't match comment */
 
 /* directory entry: general purpose bit flags */
 
@@ -270,6 +276,7 @@ struct zip_hash;
 struct zip_progress;
 
 typedef struct zip_cdir zip_cdir_t;
+typedef struct zip_dostime zip_dostime_t;
 typedef struct zip_dirent zip_dirent_t;
 typedef struct zip_entry zip_entry_t;
 typedef struct zip_extra_field zip_extra_field_t;
@@ -328,6 +335,11 @@ struct zip_file {
 #define ZIP_DIRENT_PASSWORD 0x0080u
 #define ZIP_DIRENT_ALL ZIP_UINT32_MAX
 
+struct zip_dostime {
+    zip_uint16_t time;
+    zip_uint16_t date;
+};
+
 struct zip_dirent {
     zip_uint32_t changed;
     bool local_extra_fields_read; /*      whether we already read in local header extra fields */
@@ -339,7 +351,7 @@ struct zip_dirent {
     zip_uint16_t version_needed;     /* (cl) version needed to extract */
     zip_uint16_t bitflags;           /* (cl) general purpose bit flag */
     zip_int32_t comp_method;         /* (cl) compression method used (uint16 and ZIP_CM_DEFAULT (-1)) */
-    time_t last_mod;                 /* (cl) time of last modification */
+    zip_dostime_t last_mod;          /* (cl) time of last modification */
     zip_uint32_t crc;                /* (cl) CRC-32 of uncompressed data */
     zip_uint64_t comp_size;          /* (cl) size of compressed data */
     zip_uint64_t uncomp_size;        /* (cl) size of uncompressed data */
@@ -363,8 +375,13 @@ struct zip_cdir {
     zip_uint64_t nentry;       /* number of entries */
     zip_uint64_t nentry_alloc; /* number of entries allocated */
 
+    zip_uint32_t this_disk;
+    zip_uint32_t eocd_disk;
+    zip_uint64_t disk_entries; /* number of entries on this disk */
+    zip_uint64_t num_entries;  /* number of entries on all disks */
     zip_uint64_t size;     /* size of central directory */
     zip_uint64_t offset;   /* offset of central directory in file */
+    zip_uint64_t eocd_offset; /* offset of EOCD in file */
     zip_string_t *comment; /* zip archive comment */
     bool is_zip64;         /* central directory in zip64 format */
 };
@@ -526,12 +543,13 @@ zip_uint64_t _zip_buffer_size(zip_buffer_t *buffer);
 
 void _zip_cdir_free(zip_cdir_t *);
 bool _zip_cdir_grow(zip_cdir_t *cd, zip_uint64_t additional_entries, zip_error_t *error);
-zip_cdir_t *_zip_cdir_new(zip_uint64_t, zip_error_t *);
+zip_cdir_t *_zip_cdir_new(zip_error_t *);
 zip_int64_t _zip_cdir_write(zip_t *za, const zip_filelist_t *filelist, zip_uint64_t survivors);
-time_t _zip_d2u_time(zip_uint16_t, zip_uint16_t);
+time_t _zip_d2u_time(const zip_dostime_t*);
 void _zip_deregister_source(zip_t *za, zip_source_t *src);
 
 void _zip_dirent_apply_attributes(zip_dirent_t *, zip_file_attributes_t *, bool, zip_uint32_t);
+int zip_dirent_check_consistency(zip_dirent_t *dirent);
 zip_dirent_t *_zip_dirent_clone(const zip_dirent_t *);
 void _zip_dirent_free(zip_dirent_t *);
 void _zip_dirent_finalize(zip_dirent_t *);
@@ -539,7 +557,7 @@ void _zip_dirent_init(zip_dirent_t *);
 bool _zip_dirent_needs_zip64(const zip_dirent_t *, zip_flags_t);
 zip_dirent_t *_zip_dirent_new(void);
 bool zip_dirent_process_ef_zip64(zip_dirent_t * zde, const zip_uint8_t * ef, zip_uint64_t got_len, bool local, zip_error_t * error);
-zip_int64_t _zip_dirent_read(zip_dirent_t *zde, zip_source_t *src, zip_buffer_t *buffer, bool local, zip_error_t *error);
+zip_int64_t _zip_dirent_read(zip_dirent_t *zde, zip_source_t *src, zip_buffer_t *buffer, bool local, zip_uint64_t central_compressed_size, bool check_consistency, zip_error_t *error);
 void _zip_dirent_set_version_needed(zip_dirent_t *de, bool force_zip64);
 void zip_dirent_torrentzip_normalize(zip_dirent_t *de);
 
@@ -611,18 +629,21 @@ void _zip_set_open_error(int *zep, const zip_error_t *err, int ze);
 bool zip_source_accept_empty(zip_source_t *src);
 zip_int64_t _zip_source_call(zip_source_t *src, void *data, zip_uint64_t length, zip_source_cmd_t command);
 bool _zip_source_eof(zip_source_t *);
+int zip_source_get_dos_time(zip_source_t *src, zip_dostime_t *dos_time);
+
 zip_source_t *_zip_source_file_or_p(const char *, FILE *, zip_uint64_t, zip_int64_t, const zip_stat_t *, zip_error_t *error);
 bool _zip_source_had_error(zip_source_t *);
 void _zip_source_invalidate(zip_source_t *src);
 zip_source_t *_zip_source_new(zip_error_t *error);
 int _zip_source_set_source_archive(zip_source_t *, zip_t *);
-zip_source_t *_zip_source_window_new(zip_source_t *src, zip_uint64_t start, zip_int64_t length, zip_stat_t *st, zip_uint64_t st_invalid, zip_file_attributes_t *attributes, zip_t *source_archive, zip_uint64_t source_index, bool take_ownership, zip_error_t *error);
+zip_source_t *_zip_source_window_new(zip_source_t *src, zip_uint64_t start, zip_int64_t length, zip_stat_t *st, zip_uint64_t st_invalid, zip_file_attributes_t *attributes, zip_dostime_t *dostime, zip_t *source_archive, zip_uint64_t source_index, bool take_ownership, zip_error_t *error);
 
 int _zip_stat_merge(zip_stat_t *dst, const zip_stat_t *src, zip_error_t *error);
 int _zip_string_equal(const zip_string_t *a, const zip_string_t *b);
 void _zip_string_free(zip_string_t *string);
 zip_uint32_t _zip_string_crc32(const zip_string_t *string);
 const zip_uint8_t *_zip_string_get(zip_string_t *string, zip_uint32_t *lenp, zip_flags_t flags, zip_error_t *error);
+bool _zip_string_is_ascii(const zip_string_t *string);
 zip_uint16_t _zip_string_length(const zip_string_t *string);
 zip_string_t *_zip_string_new(const zip_uint8_t *raw, zip_uint16_t length, zip_flags_t flags, zip_error_t *error);
 int _zip_string_write(zip_t *za, const zip_string_t *string);
@@ -647,9 +668,9 @@ zip_t *_zip_new(zip_error_t *);
 
 zip_int64_t _zip_file_replace(zip_t *, zip_uint64_t, const char *, zip_source_t *, zip_flags_t);
 int _zip_set_name(zip_t *, zip_uint64_t, const char *, zip_flags_t);
-void _zip_u2d_time(time_t, zip_uint16_t *, zip_uint16_t *);
+int _zip_u2d_time(time_t, zip_dostime_t *, zip_error_t *);
 int _zip_unchange(zip_t *, zip_uint64_t, int);
 void _zip_unchange_data(zip_entry_t *);
 int _zip_write(zip_t *za, const void *data, zip_uint64_t length);
 
-#endif /* zipint.h */
+#endif /* _HAD_ZIPINT_H */

--- a/3rdparty/libzip/libzip.vcxproj
+++ b/3rdparty/libzip/libzip.vcxproj
@@ -146,6 +146,7 @@
     <ClCompile Include="lib\zip_unchange_archive.c" />
     <ClCompile Include="lib\zip_unchange_data.c" />
     <ClCompile Include="lib\zip_utf-8.c" />
+    <ClCompile Include="lib\zip_source_get_dostime.c" />
     <ClCompile Include="msvc\zip_err_str.c" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
### Description of Changes
Bumps zibzip to version 1.11.1.

### Rationale behind Changes
New APIs and bugfixes especially helps with the new savestate compression setting being added.

### Suggested Testing Steps
Make sure GS Dumps and save states still load and save correctly.
