### PR TITLE
DebugTools: Scan for functions from the ELF instead of from memory

### DIFF
--- a/pcsx2/DebugTools/DebugInterface.cpp
+++ b/pcsx2/DebugTools/DebugInterface.cpp
@@ -1181,3 +1181,84 @@ std::vector<std::unique_ptr<BiosThread>> R3000DebugInterface::GetThreadList() co
 {
 	return getIOPThreads();
 }
+
+ElfMemoryReader::ElfMemoryReader(const ccc::ElfFile& elf)
+	: m_elf(elf)
+{
+}
+
+u32 ElfMemoryReader::read8(u32 address)
+{
+	ccc::Result<u8> result = m_elf.get_object_virtual<u8>(address);
+	if (!result.success())
+		return 0;
+
+	return *result;
+}
+
+u32 ElfMemoryReader::read8(u32 address, bool& valid)
+{
+	ccc::Result<u8> result = m_elf.get_object_virtual<u8>(address);
+	valid = result.success();
+	if (!valid)
+		return 0;
+
+	return *result;
+}
+
+u32 ElfMemoryReader::read16(u32 address)
+{
+	ccc::Result<u16> result = m_elf.get_object_virtual<u16>(address);
+	if (!result.success())
+		return 0;
+
+	return *result;
+}
+
+u32 ElfMemoryReader::read16(u32 address, bool& valid)
+{
+	ccc::Result<u16> result = m_elf.get_object_virtual<u16>(address);
+	valid = result.success();
+	if (!valid)
+		return 0;
+
+	return *result;
+}
+
+u32 ElfMemoryReader::read32(u32 address)
+{
+	ccc::Result<u32> result = m_elf.get_object_virtual<u32>(address);
+	if (!result.success())
+		return 0;
+
+	return *result;
+}
+
+u32 ElfMemoryReader::read32(u32 address, bool& valid)
+{
+	ccc::Result<u32> result = m_elf.get_object_virtual<u32>(address);
+	valid = result.success();
+	if (!valid)
+		return 0;
+
+	return *result;
+}
+
+u64 ElfMemoryReader::read64(u32 address)
+{
+	ccc::Result<u64> result = m_elf.get_object_virtual<u64>(address);
+	if (!result.success())
+		return 0;
+
+	return *result;
+}
+
+u64 ElfMemoryReader::read64(u32 address, bool& valid)
+{
+	ccc::Result<u64> result = m_elf.get_object_virtual<u64>(address);
+	valid = result.success();
+	if (!valid)
+		return 0;
+
+	return *result;
+}

--- a/pcsx2/DebugTools/DebugInterface.h
+++ b/pcsx2/DebugTools/DebugInterface.h
@@ -32,15 +32,9 @@ enum BreakPointCpu
 	BREAKPOINT_IOP_AND_EE = 0x03
 };
 
-class DebugInterface
+class MemoryReader
 {
 public:
-	enum RegisterType
-	{
-		NORMAL,
-		SPECIAL
-	};
-
 	virtual u32 read8(u32 address) = 0;
 	virtual u32 read8(u32 address, bool& valid) = 0;
 	virtual u32 read16(u32 address) = 0;
@@ -49,6 +43,17 @@ public:
 	virtual u32 read32(u32 address, bool& valid) = 0;
 	virtual u64 read64(u32 address) = 0;
 	virtual u64 read64(u32 address, bool& valid) = 0;
+};
+
+class DebugInterface : public MemoryReader
+{
+public:
+	enum RegisterType
+	{
+		NORMAL,
+		SPECIAL
+	};
+
 	virtual u128 read128(u32 address) = 0;
 	virtual void write8(u32 address, u8 value) = 0;
 	virtual void write16(u32 address, u16 value) = 0;
@@ -140,7 +145,6 @@ public:
 	BreakPointCpu getCpuType() override;
 };
 
-
 class R3000DebugInterface : public DebugInterface
 {
 public:
@@ -181,6 +185,25 @@ public:
 	bool isValidAddress(u32 address) override;
 	u32 getCycles() override;
 	BreakPointCpu getCpuType() override;
+};
+
+// Provides access to the loadable segments from the ELF as they are on disk.
+class ElfMemoryReader : public MemoryReader
+{
+public:
+	ElfMemoryReader(const ccc::ElfFile& elf);
+
+	u32 read8(u32 address) override;
+	u32 read8(u32 address, bool& valid) override;
+	u32 read16(u32 address) override;
+	u32 read16(u32 address, bool& valid) override;
+	u32 read32(u32 address) override;
+	u32 read32(u32 address, bool& valid) override;
+	u64 read64(u32 address) override;
+	u64 read64(u32 address, bool& valid) override;
+
+protected:
+	const ccc::ElfFile& m_elf;
 };
 
 extern R5900DebugInterface r5900Debug;

--- a/pcsx2/DebugTools/MIPSAnalyst.h
+++ b/pcsx2/DebugTools/MIPSAnalyst.h
@@ -3,10 +3,8 @@
 
 #pragma once
 
+#include "DebugInterface.h"
 #include "SymbolGuardian.h"
-
-class DebugInterface;
-
 
 #define MIPS_GET_OP(op)   ((op>>26) & 0x3F)
 #define MIPS_GET_FUNC(op) (op & 0x3F)
@@ -29,7 +27,7 @@ namespace MIPSAnalyst
 		char name[64];
 	};
 
-	void ScanForFunctions(ccc::SymbolDatabase& database, u32 startAddr, u32 endAddr);
+	void ScanForFunctions(ccc::SymbolDatabase& database, MemoryReader& reader, u32 startAddr, u32 endAddr);
 
 	enum LoadStoreLRType { LOADSTORE_NORMAL, LOADSTORE_LEFT, LOADSTORE_RIGHT };
 


### PR DESCRIPTION
### Description of Changes
I've been planning to change the behaviour of the `MIPSAnalyst` so that it at first only reads from the ELF file on the disc, and then later the user can re-run it on demand if the code in memory was overwritten.

This PR implements the first half of that plan. I've added a `MemoryReader` interface for the `MIPSAnalyst` to use which is implemented by the debug interfaces and a new `ElfMemoryReader` class.  The `SymbolGuardian::ImportElf` function has been updated accordingly.

While I was at it, I also fixed some error handling logic in `MIPSAnalyst::ScanForFunctions`. In practice I believe this was harmless since `SymbolDatabase::get_symbol_source` should really never fail, however it's still nice to get this fixed.

### Rationale behind Changes
The previous behaviour resulted in a race condition where `MIPSAnalyst::ScanForFunctions` would be run at a different time, and hence on different memory contents, depending on how long it took to parse the symbol table(s).

More seriously, f0bes pointed out a deadlock bug in the previous implementation where if `SymbolGuardian::ShutdownWorkerThread` was called right at the same moment the worker thread entered `Host::RunOnCPUThread` both threads would block on each other.

This behaviour would only be appropriate if the user was playing Ratchet: Deadlocked, and is hence what prompted me to split this into two pull requests.

### Suggested Testing Steps
- Check that symbol table loading still works.
- Check that the functions tab still gets populated correctly, especially for games that don't have a symbol table.
- Try constantly restarting the VM.
