### PR TITLE
GameDB: Various Fixes

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -9515,7 +9515,8 @@ SCPS-51012:
   name: "Gigantic Drive"
   region: "NTSC-J"
   gsHWFixes:
-    autoFlush: 2 # Fixes DOF effect.
+    autoFlush: 2 # Fixes Depth of Field effect.
+    halfPixelOffset: 4 # Aligns Depth of Field.
 SCPS-51013:
   name: "Torneko's Adventure 3"
   region: "NTSC-J"
@@ -9609,6 +9610,7 @@ SCPS-55014:
   gsHWFixes:
     halfPixelOffset: 4 # Corrects positioning of reflections on suit's surfaces.
     roundSprite: 2 # Reduces garbage on the UI whilst upscaling.
+    mergeSprite: 1 # Fixes incorrect blur when Round Sprite is enabled.
 SCPS-55015:
   name: "Zettai Zetsumei Toshi"
   region: "NTSC-J"
@@ -16651,6 +16653,7 @@ SLES-51399:
   gsHWFixes:
     halfPixelOffset: 4 # Corrects positioning of reflections on suit's surfaces.
     roundSprite: 2 # Reduces garbage on the UI whilst upscaling.
+    mergeSprite: 1 # Fixes incorrect blur when Round Sprite is enabled.
 SLES-51400:
   name: "Tenchu - Wrath of Heaven"
   region: "PAL-S"
@@ -17605,7 +17608,8 @@ SLES-51856:
   name: "Monster Attack"
   region: "PAL-E"
   gsHWFixes:
-    halfPixelOffset: 4 # Fixes depth of field positioning.
+    autoFlush: 2 # Fixes Depth of Field effect.
+    halfPixelOffset: 4 # Aligns Depth of Field.
 SLES-51859:
   name: "Billiards Xciting"
   region: "PAL-E"
@@ -25058,8 +25062,9 @@ SLES-54464:
   region: "PAL-E"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 4 # Fixes post processing positioning.
-    nativeScaling: 1 # Fixes post processing effects caused by upscaling.
+    autoFlush: 2 # Fixes Depth of Field effect.
+    halfPixelOffset: 4 # Aligns Depth of Field.
+    nativeScaling: 1 # Fixes Depth of Field effect.
 SLES-54465:
   name: "CSI - 3 Dimensions of Murder"
   region: "PAL-M5"
@@ -28942,8 +28947,9 @@ SLKA-15058:
   name-sort: "Terra Defence Force, The 2"
   region: "NTSC-K"
   gsHWFixes:
-    halfPixelOffset: 4 # Fixes post processing positioning.
-    nativeScaling: 1 # Fixes post processing effects caused by upscaling.
+    autoFlush: 2 # Fixes Depth of Field effect.
+    halfPixelOffset: 4 # Aligns Depth of Field.
+    nativeScaling: 1 # Fixes Depth of Field effect.
 SLKA-15060:
   name: "Raiden III"
   region: "NTSC-K"
@@ -34109,7 +34115,8 @@ SLPM-62209:
   name-en: "Gigantic Drive"
   region: "NTSC-J"
   gsHWFixes:
-    autoFlush: 2 # Fixes DOF effect.
+    autoFlush: 2 # Fixes Depth of Field effect.
+    halfPixelOffset: 4 # Aligns Depth of Field.
 SLPM-62211:
   name: "18WHEELER"
   name-sort: "18WHEELER"
@@ -34728,7 +34735,8 @@ SLPM-62344:
   name-en: "Simple 2000 Series Vol. 31 - The Chikyuu Boueigun"
   region: "NTSC-J"
   gsHWFixes:
-    halfPixelOffset: 4 # Fixes depth of field positioning.
+    autoFlush: 2 # Fixes Depth of Field effect.
+    halfPixelOffset: 4 # Aligns Depth of Field.
 SLPM-62345:
   name: "SIMPLE2000シリーズVol.32 THE戦車"
   name-sort: "しんぷる2000しりーずVol.32 THEせんしゃ"
@@ -36269,8 +36277,9 @@ SLPM-62652:
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 4 # Fixes depth of field positioning.
-    nativeScaling: 1 # Fixes post processing effects due to upscaling.
+    autoFlush: 2 # Fixes Depth of Field effect.
+    halfPixelOffset: 4 # Aligns Depth of Field.
+    nativeScaling: 1 # Fixes Depth of Field effect.
 SLPM-62653:
   name: "Psikyo Shooting Collection Vol.1 - Strikers 1945 1-2 [Taito The Best]"
   region: "NTSC-J"
@@ -48744,6 +48753,7 @@ SLPM-67524:
   gsHWFixes:
     halfPixelOffset: 4 # Corrects positioning of reflections on suit's surfaces.
     roundSprite: 2 # Reduces garbage on the UI whilst upscaling.
+    mergeSprite: 1 # Fixes incorrect blur when Round Sprite is enabled.
 SLPM-67525:
   name: "Medal of Honor - Frontline"
   region: "NTSC-K"
@@ -52547,6 +52557,7 @@ SLPS-25112:
   gsHWFixes:
     halfPixelOffset: 4 # Corrects positioning of reflections on suit's surfaces.
     roundSprite: 2 # Reduces garbage on the UI whilst upscaling.
+    mergeSprite: 1 # Fixes incorrect blur when Round Sprite is enabled.
 SLPS-25113:
   name: "絶体絶命都市"
   name-sort: "ぜったいぜつめいとし"
@@ -53919,6 +53930,9 @@ SLPS-25362:
   name-sort: "てつじん28ごう"
   name-en: "Tetsujin 28 Go"
   region: "NTSC-J"
+  gsHWFixes:
+    autoFlush: 2 # Fixes Depth of Field effect.
+    halfPixelOffset: 4 # Aligns Depth of Field.
 SLPS-25363:
   name: "桜坂消防隊"
   name-sort: "さくらざかしょうぼうたい"
@@ -56126,12 +56140,17 @@ SLPS-25731:
   clampModes:
     eeClampMode: 2 # Fixes Abnormal AI behavior.
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Improves sky rendering.
     textureInsideRT: 1 # Fixes texture corruption.
 SLPS-25732:
   name: "ARMORED CORE 3 (ARMORED CORE PREMIUM BOX同梱用)"
   name-sort: "あーまーどこあ3"
   name-en: "Armored Core 3"
   region: "NTSC-J"
+  gsHWFixes:
+    halfPixelOffset: 4 # Corrects positioning of reflections on suit's surfaces.
+    roundSprite: 2 # Reduces garbage on the UI whilst upscaling.
+    mergeSprite: 1 # Fixes incorrect blur when Round Sprite is enabled.
 SLPS-25733:
   name: "スーパーロボット大戦OG ORIGINAL GENERATIONS"
   name-sort: "すーぱーろぼっとたいせんOG ORIGINAL GENERATIONS"
@@ -60301,6 +60320,7 @@ SLUS-20435:
   gsHWFixes:
     halfPixelOffset: 4 # Corrects positioning of reflections on suit's surfaces.
     roundSprite: 2 # Reduces garbage on the UI whilst upscaling.
+    mergeSprite: 1 # Fixes incorrect blur when Round Sprite is enabled.
 SLUS-20436:
   name: "Guilty Gear X2"
   region: "NTSC-U"
@@ -60345,11 +60365,12 @@ SLUS-20444:
   name: "Tankers"
   region: "NTSC-U"
 SLUS-20445:
-  name: "Robot Alchemic Drive - RAD"
+  name: "Robot Alchemic Drive - R.A.D."
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    autoFlush: 2 # Fixes DOF effect.
+    autoFlush: 2 # Fixes Depth of Field effect.
+    halfPixelOffset: 4 # Aligns Depth of Field.
 SLUS-20446:
   name: "Agassi Tennis Generation"
   region: "NTSC-U"
@@ -69070,10 +69091,11 @@ SLUS-29022:
   name: "UFC - Throwdown [Regular Demo]"
   region: "NTSC-U"
 SLUS-29025:
-  name: "R.A.D. - Robot Alchemic Drive [Demo]"
+  name: "Robot Alchemic Drive - R.A.D. [Demo]"
   region: "NTSC-U"
   gsHWFixes:
-    autoFlush: 2 # Fixes DOF effect.
+    autoFlush: 2 # Fixes Depth of Field effect.
+    halfPixelOffset: 4 # Aligns Depth of Field.
 SLUS-29026:
   name: "MX SuperFly [Demo]"
   region: "NTSC-U"

--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -53928,7 +53928,7 @@ SLPS-25361:
 SLPS-25362:
   name: "鉄人28号"
   name-sort: "てつじん28ごう"
-  name-en: "Tetsujin 28 Go"
+  name-en: "Tetsujin 28-gō"
   region: "NTSC-J"
   gsHWFixes:
     autoFlush: 2 # Fixes Depth of Field effect.


### PR DESCRIPTION
### Description of Changes
Adds Merge Sprite to Armored Core 3 and adds HPO Native + Autoflush to all Sandlot titles.

[GSdumps.zip](https://github.com/user-attachments/files/17252105/GSdumps.zip)

#### Armored Core 3 : Add Merge Sprite
- Fixes blur effects in cutscenes when Round Sprite is enabled.
![Armored Core 3_SLUS-20435 Master](https://github.com/user-attachments/assets/c5a409ac-58f5-4f7a-a2ba-0d1b583510bc)
![Armored Core 3_SLUS-20435 PR](https://github.com/user-attachments/assets/d3ed7c1e-9ecc-471d-b8ee-a082d4efafb3)
![Armored Core 3_SLUS-20435 SW](https://github.com/user-attachments/assets/6f316364-b26f-4d6d-8e0e-c6c040ad7aee)

#### Tetsujin 28-gō : Add HPO Native + Autoflush
- Fixes and aligns Depth of Field effects. All Sandlot titles tested benefit from this change.
  - (Off-screen warning icons are broken on all renderers. This issue has been reported in the [Discord](https://discord.com/channels/309643527816609793/923492653788692480/1256446162563760129).)
![Tetsujin 28 Go_SLPS-25362 Master](https://github.com/user-attachments/assets/758ddea4-28ef-408c-b9b4-b2b74dcd1ba8)
![Tetsujin 28 Go_SLPS-25362 PR](https://github.com/user-attachments/assets/cc16d92c-25e9-4e28-b704-9adcec3a17f4)
![Tetsujin 28 Go_SLPS-25362 SW](https://github.com/user-attachments/assets/e327a6a9-1897-485d-b853-8a79595f1b90)

#### Gigantic Drive / Robot Alchemic Drive : Add HPO Native
- Aligns Depth of Field effects.
![Gigantic Drive_SLPM-62209 Master](https://github.com/user-attachments/assets/5c14032c-3665-4cb4-87e4-fcdce7cfcf2f)
![Gigantic Drive_SLPM-62209 PR](https://github.com/user-attachments/assets/4ab29075-1512-458f-a8ab-7c0ea3695389)
![Gigantic Drive_SLPM-62209 SW](https://github.com/user-attachments/assets/3df462a5-0a69-4e31-b04c-f7e17764979a)

### The Chikyuu Boueigun / Earth Defense Force : Add Autoflush
- Fixes Depth of Field effects.
![Simple 2000 Series Vol  31 - The Chikyuu Boueigun_SLPM-62344 Master](https://github.com/user-attachments/assets/a93978ef-10ad-4c2d-9b8a-7fe4b793d3f9)
![Simple 2000 Series Vol  31 - The Chikyuu Boueigun_SLPM-62344 PR](https://github.com/user-attachments/assets/62930b67-e835-4f16-993a-a076fa3cf312)
![Simple 2000 Series Vol  31 - The Chikyuu Boueigun_SLPM-62344 SW](https://github.com/user-attachments/assets/e7937ae2-ac6d-48e6-88ea-b1e7ebef27a8)

### The Chikyuu Boueigun 2 / Earth Defense Force 2 : Add Autoflush
- Fixes Depth of Field effects.
![Simple 2000 Series Vol  81 - The Chikyuu Boueigun 2_SLPM-62652 Master](https://github.com/user-attachments/assets/51584082-ef1e-4a16-b402-b85d150d2244)
![Simple 2000 Series Vol  81 - The Chikyuu Boueigun 2_SLPM-62652 PR](https://github.com/user-attachments/assets/f4248dcd-6b6d-448e-ad4e-b0328ffdc34b)
![Simple 2000 Series Vol  81 - The Chikyuu Boueigun 2_SLPM-62652 SW](https://github.com/user-attachments/assets/e03d756a-97f4-45fc-8b2e-4ca5c738804e)

### Rationale behind Changes
Match HW Renderer to SW Renderer and real hardware.

### Suggested Testing Steps
N/A.
Possibly check if Tekkōki Mikazuki Trial Edition benefits from HPO Native + Autoflush. Unable to test myself.
