### PR TITLE
HostFS: Retain File Handles in Save States

### DIFF
--- a/pcsx2/SaveState.cpp
+++ b/pcsx2/SaveState.cpp
@@ -275,6 +275,8 @@ bool SaveStateBase::FreezeInternals(Error* error)
 
 	okay = okay && InputRecordingFreeze();
 
+	okay = okay && handleFreeze(); //file handles
+
 	return okay;
 }
 

--- a/pcsx2/SaveState.h
+++ b/pcsx2/SaveState.h
@@ -25,7 +25,7 @@ enum class FreezeAction
 // [SAVEVERSION+]
 // This informs the auto updater that the users savestates will be invalidated.
 
-static const u32 g_SaveVersion = (0x9A4F << 16) | 0x0000;
+static const u32 g_SaveVersion = (0x9A50 << 16) | 0x0000;
 
 
 // the freezing data between submodules and core
@@ -211,6 +211,7 @@ protected:
 	bool cdvdFreeze();
 	bool psxRcntFreeze();
 	bool deci2Freeze();
+	bool handleFreeze();
 
 	// Save or load PCSX2's global frame counter (g_FrameCount) along with each savestate
 	//


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
[SAVEVERSION+]
Save host file handle and position information in save states, and reopen handles at the correct position when states are loaded.

Note: This is my first contribution, and I am still learning PCSX2's codebase, as well as best C++ practices. Criticism is appreciated!

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Currently, if a homebrew/game uses Host Filesystem to stream files, using save states can cause issues. For example if the streamed file is audio, it can cause audio to be desynced, stop entirely or even play the incorrect song. This is caused by open file handles no longer existing or the file offset pointer being different when loading a savestate.
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
@penguino118 has graciously created a homebrew elf that demonstrates this issue. The program streams audio from `GTA.wav`and `HMU.wav`. (Assets are copyright free/public domain)
[hostfs_handle_test.zip](https://github.com/user-attachments/files/17266999/hostfs_handle_test.zip)

Expected behaviour on master:

1. Boot `tutorial_06.elf`. Press X to begin.
2. Save a state while a song is playing.
3. Wait a few seconds for the song to progress, then load the state you just made.
4. The song will continue playing from the point it was at before the state was loaded. (Bad)
5. Press X to Switch song. Load the state again. The song you switched to will continue to play instead of the one the state was saved on. (Bad!)
6. Reset the elf, do NOT press X to begin. Load the state. The song will endlessly stutter. (Bad!!)

Expected behaviour on this branch:

1. Open `tutorial_06.elf`. Press X to begin.
2. Save a state while a song is playing.
3. Wait a few seconds for the song to progress, then load the state you just made.
4. The song will play from the point it was at when the state was made. (Good)
5. Press X to Switch song. Load the state again. It will play the song that the state was saved on. (Good)
6. Reset the elf, do NOT press X to begin. Load the state. The song will play. (Good)
