### PR TITLE
OSD: Update OSD Text on SW mode so no overlap keyword appears

### DIFF
--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -646,6 +646,7 @@ void GSgetStats(SmallStringBase& info)
 		const double fillrate = pm.Get(GSPerfMon::Fillrate);
 		double pps = fps * fillrate;
 		char prefix = '\0';
+		
 		if (pps >= 170000000)
 		{
 			pps /= 1073741824; // Gpps
@@ -665,7 +666,6 @@ void GSgetStats(SmallStringBase& info)
 		{
 			prefix = '\0';
 		}
-
 
 		info.format("{} SW | {} SP | {} P | {} D | {:.2f} S | {:.2f} U | {:.2f} {}pps",
 			api_name,

--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -644,7 +644,7 @@ void GSgetStats(SmallStringBase& info)
 	{
 		const double fps = GetVerticalFrequency();
 		const double fillrate = pm.Get(GSPerfMon::Fillrate);
-		info.format("{} SW | {} S | {} P | {} D | {:.2f} U | {:.2f} D | {:.2f} mpps",
+		info.format("{} SW | {} SP | {} P | {} D | {:.2f} S | {:.2f} U | {:.2f} mpps",
 			api_name,
 			(int)pm.Get(GSPerfMon::SyncPoint),
 			(int)pm.Get(GSPerfMon::Prim),

--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -644,14 +644,37 @@ void GSgetStats(SmallStringBase& info)
 	{
 		const double fps = GetVerticalFrequency();
 		const double fillrate = pm.Get(GSPerfMon::Fillrate);
-		info.format("{} SW | {} SP | {} P | {} D | {:.2f} S | {:.2f} U | {:.2f} mpps",
+		double pps = fps * fillrate;
+		char prefix = '\0';
+		if (pps >= 170000000)
+		{
+			pps /= 1073741824; // Gpps
+			prefix = 'G';
+		}
+		else if (pps >= 35000000)
+		{
+			pps /= 1048576; // Mpps
+			prefix = 'M';
+		}
+		else if (pps >= 1024)
+		{
+			pps /= 1024;
+			prefix = 'K';
+		}
+		else
+		{
+			prefix = '\0';
+		}
+
+
+		info.format("{} SW | {} SP | {} P | {} D | {:.2f} S | {:.2f} U | {:.2f} {}pps",
 			api_name,
 			(int)pm.Get(GSPerfMon::SyncPoint),
 			(int)pm.Get(GSPerfMon::Prim),
 			(int)pm.Get(GSPerfMon::Draw),
 			pm.Get(GSPerfMon::Swizzle) / 1024,
 			pm.Get(GSPerfMon::Unswizzle) / 1024,
-			fps * fillrate / (1024 * 1024));
+			pps,prefix);
 	}
 	else if (GSCurrentRenderer == GSRendererType::Null)
 	{


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
OSD Performance Text in SW mode has overlapped keywords which confuses if D means Drawcall or Download.
This commit fixes it by renaming few stuff and naming it correctly.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
D vs D is off

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Make sure OSD is OK in SW.
