### PR TITLE
QT: Clear m_status_verbose_widget text on VM stop

### DIFF
--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -2017,6 +2017,7 @@ void MainWindow::onVMStopped()
 	m_status_fps_widget->setText(empty_string);
 	m_status_vps_widget->setText(empty_string);
 	m_status_speed_widget->setText(empty_string);
+	m_status_verbose_widget->setText(empty_string);
 
 	updateEmulationActions(false, false, false);
 	updateGameDependentActions();


### PR DESCRIPTION
### Description of Changes
Clears the text of `m_status_verbose_widget`

### Rationale behind Changes
When starting emulation, either onVMResumed or onVMPaused is called depending on if Pause on start is set.
The emulator stop prompt will pause the emulator, if you accept, this will backup the previous value of `m_status_verbose_widget` to `m_last_fps_status` and set the text of `m_status_verbose_widget` to "Paused"

When you that start the emulator again, with Pause on start enabled, onVMPaused is called again, which will overwrite the backup text in `m_last_fps_status` with the value of `m_status_verbose_widget`, which was left as "Paused" from the previous run.

When you unpause, the text of m_status_verbose_widget is set to the value of m_last_fps_status, which contains "Paused" leading to no visual change.

This PR resets the value of `m_status_verbose_widget` to prevent this.

Note that the issue is not visible when "View -> Verbose Status" is enabled, as that replaces the text continuously

### Suggested Testing Steps
Enable Pause on start
Start and stop, then start again the emulator