### PR TITLE
Debugger: Fix crash in symbol tree menu code

### DIFF
--- a/pcsx2-qt/Debugger/CpuWidget.cpp
+++ b/pcsx2-qt/Debugger/CpuWidget.cpp
@@ -154,6 +154,11 @@ void CpuWidget::setupSymbolTrees()
 	m_local_variable_tree = new LocalVariableTreeWidget(m_cpu);
 	m_parameter_variable_tree = new ParameterVariableTreeWidget(m_cpu);
 
+	m_function_tree->updateModel();
+	m_global_variable_tree->updateModel();
+	m_local_variable_tree->updateModel();
+	m_parameter_variable_tree->updateModel();
+
 	m_ui.tabFunctions->layout()->addWidget(m_function_tree);
 	m_ui.tabGlobalVariables->layout()->addWidget(m_global_variable_tree);
 	m_ui.tabLocalVariables->layout()->addWidget(m_local_variable_tree);

--- a/pcsx2-qt/Debugger/SymbolTree/SymbolTreeWidgets.cpp
+++ b/pcsx2-qt/Debugger/SymbolTree/SymbolTreeWidgets.cpp
@@ -445,6 +445,8 @@ void SymbolTreeWidget::setupMenu()
 void SymbolTreeWidget::openMenu(QPoint pos)
 {
 	SymbolTreeNode* node = currentNode();
+	if (!node)
+		return;
 
 	bool node_is_object = node->tag == SymbolTreeNode::OBJECT;
 	bool node_is_symbol = node->symbol.valid();


### PR DESCRIPTION
### Description of Changes
I've added a previously missing null pointer check and made it so `SymbolTreeWidget::updateModel` gets called on all the symbol tree widgets right after they're created.

### Rationale behind Changes
Previously the parameters tab wouldn't get properly setup until a game was loaded, so if you started PCSX2 then immediately opened the debugger and right clicked said tab, PCSX2 would crash.

### Suggested Testing Steps
Make sure it doesn't crash.