### PR TITLE
Qt: Call 'map_text_to_keycode()' only when Shift modifier is being used

### DIFF
--- a/pcsx2-qt/QtKeyCodes.cpp
+++ b/pcsx2-qt/QtKeyCodes.cpp
@@ -566,16 +566,17 @@ const char* InputManager::ConvertHostKeyboardCodeToIcon(u32 code)
 
 u32 QtUtils::KeyEventToCode(const QKeyEvent* ev)
 {
+	Qt::KeyboardModifiers modifiers = ev->modifiers();
 	const QString text = ev->text();
-	const u8 keycode = map_text_to_keycode(text); // Map special text symbols to keycodes
+	// Map special text symbols to keycodes if we're using Shift modifier.
+	// Also check that we're not using Keypad modifier otherwise "NumpadAsterisk" would return "8" keycode
+	// and "NumpadPlus" would return "Equal" keycode.
+	const bool set_keycode = (modifiers & Qt::ShiftModifier) && !(modifiers & Qt::KeypadModifier);
+	const u8 keycode = set_keycode ? map_text_to_keycode(text) : 0;
 	int key = ev->key();
 
 	if (keycode != 0)
-	{
 		key = keycode; // Override key if mapped
-	}
-
-	Qt::KeyboardModifiers modifiers = ev->modifiers();
 
 #ifdef __APPLE__
 	// On macOS, Qt applies the Keypad modifier regardless of whether the arrow keys, or numpad was pressed.


### PR DESCRIPTION
### Description of Changes
Call  `map_text_to_keycode()` only if we're using Shift modifier and also if we're not using Keypad modifier (or else "NumpadAsterisk" would return "8" keycode and "NumpadPlus" would return "Equal" keycode.).

### Rationale behind Changes
See #11838, currently Keypad "*" and "+" return incorrect keycodes due to the function not checking for Shift modifier.

It's also a big issue as an AZERTY FR keyboard user because without a Shift modifier check it messes up heavily with default bindings, especially R2 and R3, both keys being mapped to the same "Apostrophe" keycode. See my 2nd reply in #11838 for more details.

Although this is much better with these modifiers checks, this is still not a perfect solution, for example on AZERTY FR "5" and "%" are on 2 different keys and `map_text_to_keycode()` will map "%" to "5" keycode, so if I bind a hotkey to "Shift+5" and another one to "Shift+%" they will both end up being mapped to the same "Shift+5" combo.

So this is just an "improvement" PR and not a real fix unfortunately :/ If this is a problem I'll close it, but I'm not experienced enough to add keyboard layout detection or whatever would be needed to solve this issue properly...

### Suggested Testing Steps
Idk, I personally tried messing with remapping, hotkeys and a game that supports keyboard. Besides the remaining issue mentioned above it's working fine AFAICT.
