### PR TITLE
IOP HLE: Only track handles to valid files.

### DIFF
--- a/pcsx2/IopBios.cpp
+++ b/pcsx2/IopBios.cpp
@@ -613,14 +613,16 @@ namespace R3000A
 					v0 = allocfd(file);
 					if ((s32)v0 < 0)
 						file->close();
+					else
+					{
+						fileHandle handle;
+						handle.fd_index = v0 - firstfd;
+						handle.flags = flags;
+						handle.full_path = path;
+						handle.mode = mode;
+						handles.push_back(handle);
+					}
 				}
-
-				fileHandle handle;
-				handle.fd_index = v0 - firstfd;
-				handle.flags = flags;
-				handle.full_path = path;
-				handle.mode = mode;
-				handles.push_back(handle);
 
 				pc = ra;
 				return 1;
@@ -1463,7 +1465,7 @@ bool SaveStateBase::handleFreeze()
 			//save the current file position
 			const u32 fd = R3000A::handles[i].fd_index;
 			IOManFile* file = R3000A::ioman::getfd<IOManFile>(fd + firstfd);
-			s32 pos = file->lseek(0, SEEK_CUR);
+			s32 pos = file ? file->lseek(0, SEEK_CUR) : 0;
 			Freeze(pos);
 
 			//save the parameters for opening the file


### PR DESCRIPTION
### Description of Changes
We were tracking file descriptors of files that were never properly opened.
Also included a check when saving states to ensure that the hostfs file actually existed on the host device. If not we fix `pos` to zero but don't try and exclude it from the state.

### Rationale behind Changes
Crashing when trying to save a state is bad.

### Suggested Testing Steps
Save and Load states with homebrew that use hostfs.
See if the reproduction steps on https://github.com/PCSX2/pcsx2/pull/11875 still work.