### PR TITLE
USB: Work around FFB dropouts with certain modern wheels

### DIFF
--- a/pcsx2/USB/usb-pad/usb-pad-sdl-ff.cpp
+++ b/pcsx2/USB/usb-pad/usb-pad-sdl-ff.cpp
@@ -187,13 +187,13 @@ namespace usb_pad
 				Console.Warning("SDL_HapticUpdateEffect() for constant failed: %s", SDL_GetError());
 		}
 
-		if (!m_constant_effect_running)
-		{
-			if (SDL_HapticRunEffect(m_haptic, m_constant_effect_id, SDL_HAPTIC_INFINITY) == 0)
-				m_constant_effect_running = true;
-			else
-				Console.Error("SDL_HapticRunEffect() for constant failed: %s", SDL_GetError());
-		}
+		// Always 'run' the constant force effect, even when already running. This
+		// mitigates FFB timeout issues experienced by some modern direct-drive
+		// wheels, such as Moza R5, R9, etc...
+		if (SDL_HapticRunEffect(m_haptic, m_constant_effect_id, SDL_HAPTIC_INFINITY) == 0)
+			m_constant_effect_running = true;
+		else
+			Console.Error("SDL_HapticRunEffect() for constant failed: %s", SDL_GetError());
 	}
 
 	template <typename T>


### PR DESCRIPTION
### Description of Changes
When updating a constant force FFB effect, unconditionally start the effect regardless of whether it is currently running.

### Rationale behind Changes
Certain modern direct-drive wheels such as the Moza R5, R9, etc. implement timeouts for FFB constant forces, and only restart their 'timeout clock' when the force is started, regardless of whether the effect is regularly being updated. I've read similar-sounding complaints from users of the Logitech G29, but I don't have that wheel on hand to test with.

In Gran Turismo 4 (and likely other titles with wheel support unless their implementation differs significantly), Moza wheels will experience sudden, sporadic dropouts of FFB during racing. The FFB won't return until the wheel returns to neutral and the car is settled, as this is when the game (conditionally) issues a CMD_STOP to the FFB hardware. After the CMD_STOP is received, PCSX2 will send another 'start' command when the next constant force is sent, resulting in a momentary return of FFB.

Most of GT4's ingame FFB comes from constant force commands. I regression tested against my other wheel, a Thrustmaster T150, which was unaffected by this issue, to confirm that FFB still feels the same after this change.

Note that this is a workaround, and doesn't fix certain cases. Long-living constant forces will still eventually timeout, but in most cases this only happens within menus, which isn't nearly as impactful. "Fully" fixing this issue would require repeatedly restarting the constant force, which was a larger code impact than I was comfortable prescribing given that this change alone is enough to satisfy most affected users.

### Suggested Testing Steps
Tested on Windows 11 playing Gran Turismo 4 with the following wheels for 30+ minutes:

- Moza R9 (primary testing)
- Thrustmaster T150 (for regression testing, did not experience this issue)
- Any other commercial wheels from other manufacturers would be appreciated.