### PR TITLE
DEV9: Further use `ReceivedPayload` in TCP_Session

### DIFF
--- a/pcsx2/DEV9/Sessions/TCP_Session/TCP_Session.cpp
+++ b/pcsx2/DEV9/Sessions/TCP_Session/TCP_Session.cpp
@@ -18,17 +18,17 @@ using namespace PacketReader::IP::TCP;
 
 namespace Sessions
 {
-	void TCP_Session::PushRecvBuff(std::unique_ptr<TCP_Packet> tcp)
+	void TCP_Session::PushRecvBuff(ReceivedPayload tcp)
 	{
 		_recvBuff.Enqueue(std::move(tcp));
 	}
-	std::unique_ptr<TCP_Packet> TCP_Session::PopRecvBuff()
+	std::optional<ReceivedPayload> TCP_Session::PopRecvBuff()
 	{
-		std::unique_ptr<TCP_Packet> ret;
+		ReceivedPayload ret;
 		if (_recvBuff.Dequeue(&ret))
 			return ret;
 		else
-			return nullptr;
+			return std::nullopt;
 	}
 
 	void TCP_Session::IncrementMyNumber(u32 amount)
@@ -159,7 +159,7 @@ namespace Sessions
 		// Clear out _recvBuff
 		while (!_recvBuff.IsQueueEmpty())
 		{
-			std::unique_ptr<TCP_Packet> retPay;
+			ReceivedPayload retPay;
 			if (!_recvBuff.Dequeue(&retPay))
 			{
 				using namespace std::chrono_literals;

--- a/pcsx2/DEV9/Sessions/TCP_Session/TCP_Session.h
+++ b/pcsx2/DEV9/Sessions/TCP_Session/TCP_Session.h
@@ -42,7 +42,7 @@ namespace Sessions
 			Bad
 		};
 
-		SimpleQueue<std::unique_ptr<PacketReader::IP::TCP::TCP_Packet>> _recvBuff;
+		SimpleQueue<ReceivedPayload> _recvBuff;
 
 #ifdef _WIN32
 		SOCKET client = INVALID_SOCKET;
@@ -85,8 +85,8 @@ namespace Sessions
 
 	private:
 		// Async functions
-		void PushRecvBuff(std::unique_ptr<PacketReader::IP::TCP::TCP_Packet> tcp);
-		std::unique_ptr<PacketReader::IP::TCP::TCP_Packet> PopRecvBuff();
+		void PushRecvBuff(ReceivedPayload tcp);
+		std::optional<ReceivedPayload> PopRecvBuff();
 
 		void IncrementMyNumber(u32 amount);
 		void UpdateReceivedAckNumber(u32 ack);
@@ -104,7 +104,7 @@ namespace Sessions
 		bool ValidateEmptyPacket(PacketReader::IP::TCP::TCP_Packet* tcp, bool ignoreOld = true);
 
 		// PS2 sent SYN
-		std::unique_ptr<PacketReader::IP::TCP::TCP_Packet> ConnectTCPComplete(bool success);
+		std::optional<ReceivedPayload> ConnectTCPComplete(bool success);
 		bool SendConnect(PacketReader::IP::TCP::TCP_Packet* tcp);
 		bool SendConnected(PacketReader::IP::TCP::TCP_Packet* tcp);
 
@@ -120,7 +120,7 @@ namespace Sessions
 		 * S4: PS2 then Sends ACK
 		 */
 		bool CloseByPS2Stage1_2(PacketReader::IP::TCP::TCP_Packet* tcp);
-		std::unique_ptr<PacketReader::IP::TCP::TCP_Packet> CloseByPS2Stage3();
+		ReceivedPayload CloseByPS2Stage3();
 		bool CloseByPS2Stage4(PacketReader::IP::TCP::TCP_Packet* tcp);
 
 		/*
@@ -132,7 +132,7 @@ namespace Sessions
 		 * Closing_ClosedByRemoteThenPS2_WaitingForAck
 		 * we then check if S3 has been completed
 		 */
-		std::unique_ptr<PacketReader::IP::TCP::TCP_Packet> CloseByRemoteStage1();
+		ReceivedPayload CloseByRemoteStage1();
 		bool CloseByRemoteStage2_ButAfter4(PacketReader::IP::TCP::TCP_Packet* tcp);
 		bool CloseByRemoteStage3_4(PacketReader::IP::TCP::TCP_Packet* tcp);
 

--- a/pcsx2/DEV9/Sessions/TCP_Session/TCP_Session_Out.cpp
+++ b/pcsx2/DEV9/Sessions/TCP_Session/TCP_Session_Out.cpp
@@ -366,7 +366,7 @@ namespace Sessions
 			std::unique_ptr<TCP_Packet> ret = CreateBasePacket();
 			ret->SetACK(true);
 
-			PushRecvBuff(std::move(ret));
+			PushRecvBuff(ReceivedPayload{destIP, std::move(ret)});
 		}
 		return true;
 	}
@@ -524,7 +524,7 @@ namespace Sessions
 		std::unique_ptr<TCP_Packet> ret = CreateBasePacket();
 
 		ret->SetACK(true);
-		PushRecvBuff(std::move(ret));
+		PushRecvBuff(ReceivedPayload{destIP, std::move(ret)});
 
 		return true;
 	}
@@ -591,7 +591,7 @@ namespace Sessions
 
 		ret->SetACK(true);
 
-		PushRecvBuff(std::move(ret));
+		PushRecvBuff(ReceivedPayload{destIP, std::move(ret)});
 
 		if (myNumberACKed.load())
 		{
@@ -611,7 +611,7 @@ namespace Sessions
 	{
 		std::unique_ptr<TCP_Packet> reterr = CreateBasePacket();
 		reterr->SetRST(true);
-		PushRecvBuff(std::move(reterr));
+		PushRecvBuff(ReceivedPayload{destIP, std::move(reterr)});
 
 		CloseSocket();
 		state = TCP_State::CloseCompletedFlushBuffer;


### PR DESCRIPTION
### Description of Changes
Instead of shuffling a `unique_ptr` around, use `ReceivedPayload` 
Fixes handling of connection failure in `ConnectTCPComplete()`

### Rationale behind Changes
Existing code would not correctly handle a connection failure, returning an invalid `ReceivedPayload` with a nullptr (instead of returning `std::nullopt`).

### Suggested Testing Steps
Test networking with sockets