### PR TITLE
DEV9: Move Adapter Detection Hack

### DIFF
--- a/pcsx2/DEV9/smap.cpp
+++ b/pcsx2/DEV9/smap.cpp
@@ -287,6 +287,10 @@ void emac3_write(u32 addr)
 					switch (reg)
 					{
 						case SMAP_DsPHYTER_BMCR:
+							if (val & SMAP_PHY_BMCR_RST)
+							{
+								ad_reset();
+							}
 							val &= ~SMAP_PHY_BMCR_RST;
 							val |= 0x1;
 							break;


### PR DESCRIPTION
### Description of Changes
Relocate the Adapter Detection Hack
Relocate call to resetting the network backend (tap/pcap/sockets)

### Rationale behind Changes
The Adapter Detection Hack sets `TXEND`/`RXEND`/`TXDNV` bits in the `SPD_R_INTR_STAT` in order to pass a check during initialisation.
PSBBN (see https://github.com/PCSX2/pcsx2/issues/11746), however, clears `TXEND`/`RXEND` after we set them, causing it to fail to init.
HW tests indicate that both `TXEND`(expected) & `RXEND`(??) get set when processing `SMAP_E3_TX_GNP_0`.
`TXDNV` also exists, but isn't set during `SMAP_E3_TX_GNP_0` (at least in the init phase), so I'm yet unsure where it comes from.

Additionally, none of the values written to `SMAP_R_EMAC3_TxMODE1` are related to resetting, so move resetting the network backend.
The `EMAC` and `PHY` are reset during SMAP initialisation, so lets reset the network backend when the `PHY` is reset.

### Suggested Testing Steps
Test networking games and homebrew.
Test with sockets, since that would be more sensitive to backend resets.