### PR TITLE
DEV9: Various improvements to ATA interrupts & Support 8bit IO to ATA regs

### DIFF
--- a/pcsx2/DEV9/ATA/ATA.h
+++ b/pcsx2/DEV9/ATA/ATA.h
@@ -96,6 +96,8 @@ private:
 
 	u8 regStatus; //ReadOnly. When read via AlternateStatus pending interrupts are not cleared
 
+	bool pendingInterrupt = false;
+
 	//Transfer
 	//Write Buffer(s)
 	bool awaitFlush = false;

--- a/pcsx2/DEV9/ATA/ATA.h
+++ b/pcsx2/DEV9/ATA/ATA.h
@@ -160,8 +160,8 @@ public:
 
 	void ATA_HardReset();
 
-	u16 Read16(u32 addr);
-	void Write16(u32 addr, u16 value);
+	u16 Read(u32 addr, int width);
+	void Write(u32 addr, u16 value, int width);
 
 	void Async(u32 cycles);
 

--- a/pcsx2/DEV9/ATA/ATA.h
+++ b/pcsx2/DEV9/ATA/ATA.h
@@ -234,8 +234,8 @@ private:
 	void HDD_WriteDMA(bool isLBA48);
 
 	void PreCmdExecuteDeviceDiag();
-	void PostCmdExecuteDeviceDiag();
-	void HDD_ExecuteDeviceDiag();
+	void PostCmdExecuteDeviceDiag(bool sendIRQ);
+	void HDD_ExecuteDeviceDiag(bool sendIRQ);
 
 	void PostCmdNoData();
 	void CmdNoDataAbort();

--- a/pcsx2/DEV9/ATA/ATA_State.cpp
+++ b/pcsx2/DEV9/ATA/ATA_State.cpp
@@ -318,7 +318,7 @@ void ATA::ResetEnd(bool hard)
 	}
 
 	HDD_ExecuteDeviceDiag(false);
-	regControlEnableIRQ = true;
+	regControlEnableIRQ = false;
 }
 
 void ATA::ATA_HardReset()

--- a/pcsx2/DEV9/ATA/ATA_State.cpp
+++ b/pcsx2/DEV9/ATA/ATA_State.cpp
@@ -400,7 +400,7 @@ u16 ATA::Read(u32 addr, int width)
 
 void ATA::Write(u32 addr, u16 value, int width)
 {
-	if (addr != ATA_R_CMD && (regStatus & (ATA_STAT_BUSY | ATA_STAT_DRQ)) != 0)
+	if ((addr != ATA_R_CMD && addr != ATA_R_CONTROL) && (regStatus & (ATA_STAT_BUSY | ATA_STAT_DRQ)) != 0)
 	{
 		Console.Error("DEV9: ATA: DEVICE BUSY, DROPPING WRITE");
 		return;

--- a/pcsx2/DEV9/ATA/ATA_State.cpp
+++ b/pcsx2/DEV9/ATA/ATA_State.cpp
@@ -317,8 +317,7 @@ void ATA::ResetEnd(bool hard)
 			mdmaMode = 2;
 	}
 
-	regControlEnableIRQ = false;
-	HDD_ExecuteDeviceDiag();
+	HDD_ExecuteDeviceDiag(false);
 	regControlEnableIRQ = true;
 }
 

--- a/pcsx2/DEV9/ATA/Commands/ATA_CmdDMA.cpp
+++ b/pcsx2/DEV9/ATA/Commands/ATA_CmdDMA.cpp
@@ -23,6 +23,7 @@ void ATA::PostCmdDMADataToHost()
 	dmaReady = false;
 
 	dev9.irqcause &= ~SPD_INTR_ATA_FIFO_DATA;
+	pendingInterrupt = true;
 	if (regControlEnableIRQ)
 		_DEV9irq(ATA_INTR_INTRQ, 1);
 	//PCSX2 Will Start DMA
@@ -66,8 +67,9 @@ void ATA::PostCmdDMADataFromHost()
 	if (fetWriteCacheEnabled)
 	{
 		regStatus &= ~ATA_STAT_BUSY;
+		pendingInterrupt = true;
 		if (regControlEnableIRQ)
-			_DEV9irq(ATA_INTR_INTRQ, 1); //0x6C
+			_DEV9irq(ATA_INTR_INTRQ, 1);
 	}
 	else
 		awaitFlush = true;

--- a/pcsx2/DEV9/ATA/Commands/ATA_CmdExecuteDeviceDiag.cpp
+++ b/pcsx2/DEV9/ATA/Commands/ATA_CmdExecuteDeviceDiag.cpp
@@ -12,20 +12,22 @@ void ATA::PreCmdExecuteDeviceDiag()
 	//dev9.spd.regIntStat &= unchecked((UInt16)~DEV9Header.ATA_INTR_DMA_RDY); //Is this correct?
 }
 
-void ATA::PostCmdExecuteDeviceDiag()
+void ATA::PostCmdExecuteDeviceDiag(bool sendIRQ)
 {
 	regStatus &= ~ATA_STAT_BUSY;
 	regStatus |= ATA_STAT_READY;
 
 	SetSelectedDevice(0);
 
-	if (regControlEnableIRQ)
+	// If Device Diagnostics is performed as part of a reset
+	// then we don't raise an IRQ or set pending interrupt
+	if (regControlEnableIRQ && sendIRQ)
 		_DEV9irq(ATA_INTR_INTRQ, 1);
 }
 
 //GENRAL FEATURE SET
 
-void ATA::HDD_ExecuteDeviceDiag()
+void ATA::HDD_ExecuteDeviceDiag(bool sendIRQ)
 {
 	PreCmdExecuteDeviceDiag();
 	//Perform Self Diag
@@ -44,5 +46,5 @@ void ATA::HDD_ExecuteDeviceDiag()
 	regStatus &= ~ATA_STAT_ECC;
 	regStatus &= ~ATA_STAT_ERR;
 
-	PostCmdExecuteDeviceDiag();
+	PostCmdExecuteDeviceDiag(sendIRQ);
 }

--- a/pcsx2/DEV9/ATA/Commands/ATA_CmdExecuteDeviceDiag.cpp
+++ b/pcsx2/DEV9/ATA/Commands/ATA_CmdExecuteDeviceDiag.cpp
@@ -8,6 +8,7 @@ void ATA::PreCmdExecuteDeviceDiag()
 {
 	regStatus |= ATA_STAT_BUSY;
 	regStatus &= ~ATA_STAT_READY;
+	pendingInterrupt = false;
 	dev9.irqcause &= ~ATA_INTR_INTRQ;
 	//dev9.spd.regIntStat &= unchecked((UInt16)~DEV9Header.ATA_INTR_DMA_RDY); //Is this correct?
 }
@@ -21,8 +22,12 @@ void ATA::PostCmdExecuteDeviceDiag(bool sendIRQ)
 
 	// If Device Diagnostics is performed as part of a reset
 	// then we don't raise an IRQ or set pending interrupt
-	if (regControlEnableIRQ && sendIRQ)
-		_DEV9irq(ATA_INTR_INTRQ, 1);
+	if (sendIRQ)
+	{
+		pendingInterrupt = true;
+		if (regControlEnableIRQ)
+			_DEV9irq(ATA_INTR_INTRQ, 1);
+	}
 }
 
 //GENRAL FEATURE SET

--- a/pcsx2/DEV9/ATA/Commands/ATA_CmdNoData.cpp
+++ b/pcsx2/DEV9/ATA/Commands/ATA_CmdNoData.cpp
@@ -8,6 +8,7 @@ void ATA::PostCmdNoData()
 {
 	regStatus &= ~ATA_STAT_BUSY;
 
+	pendingInterrupt = true;
 	if (regControlEnableIRQ)
 		_DEV9irq(ATA_INTR_INTRQ, 1);
 }

--- a/pcsx2/DEV9/ATA/Commands/ATA_CmdPIOData.cpp
+++ b/pcsx2/DEV9/ATA/Commands/ATA_CmdPIOData.cpp
@@ -15,8 +15,12 @@ void ATA::DRQCmdPIODataToHost(u8* buff, int buffLen, int buffIndex, int size, bo
 	regStatus &= ~ATA_STAT_BUSY;
 	regStatus |= ATA_STAT_DRQ;
 
+	// Only set pendingInterrupt if nIEN is cleared
 	if (regControlEnableIRQ && sendIRQ)
-		_DEV9irq(ATA_INTR_INTRQ, 1); //0x6c cycles before
+	{
+		pendingInterrupt = true;
+		_DEV9irq(ATA_INTR_INTRQ, 1);
+	}
 }
 void ATA::PostCmdPIODataToHost()
 {

--- a/pcsx2/DEV9/ATA/Commands/ATA_Command.cpp
+++ b/pcsx2/DEV9/ATA/Commands/ATA_Command.cpp
@@ -39,7 +39,7 @@ void ATA::IDE_ExecCmd(u16 value)
 			HDD_SeekCmd();
 			break;
 		case 0x90:
-			HDD_ExecuteDeviceDiag();
+			HDD_ExecuteDeviceDiag(true);
 			break;
 		case 0x91:
 			HDD_InitDevParameters();

--- a/pcsx2/DEV9/DEV9.cpp
+++ b/pcsx2/DEV9/DEV9.cpp
@@ -704,8 +704,7 @@ u8 DEV9read8(u32 addr)
 
 	if (addr >= ATA_DEV9_HDD_BASE && addr < ATA_DEV9_HDD_END)
 	{
-		Console.Error("DEV9: ATA does not support 8bit reads %lx", addr);
-		return 0;
+		return dev9.ata->Read(addr, 8);
 	}
 	// Note, ATA regs within range of addresses used by Speed
 	if (addr >= SPD_REGBASE && addr < SMAP_REGBASE)
@@ -745,7 +744,7 @@ u16 DEV9read16(u32 addr)
 
 	if (addr >= ATA_DEV9_HDD_BASE && addr < ATA_DEV9_HDD_END)
 	{
-		return dev9.ata->Read16(addr);
+		return dev9.ata->Read(addr, 16);
 	}
 	// Note, ATA regs within range of addresses used by Speed
 	if (addr >= SPD_REGBASE && addr < SMAP_REGBASE)
@@ -811,10 +810,7 @@ void DEV9write8(u32 addr, u8 value)
 
 	if (addr >= ATA_DEV9_HDD_BASE && addr < ATA_DEV9_HDD_END)
 	{
-#ifdef ENABLE_ATA
-		ata_write<1>(addr, value);
-#endif
-		Console.Error("DEV9: ATA does not support 8bit writes %lx", addr);
+		dev9.ata->Write(addr, value, 8);
 		return;
 	}
 	// Note, ATA regs within range of addresses used by Speed
@@ -847,7 +843,7 @@ void DEV9write16(u32 addr, u16 value)
 
 	if (addr >= ATA_DEV9_HDD_BASE && addr < ATA_DEV9_HDD_END)
 	{
-		dev9.ata->Write16(addr, value);
+		dev9.ata->Write(addr, value, 16);
 		return;
 	}
 	// Note, ATA regs within range of addresses used by Speed


### PR DESCRIPTION
### Description of Changes
Support 8bit IO.
Implement pending interrupts, per ATA spec.
Disable interrupts in the initial/reset state.
Don't drop writes to `ATA_R_CONTROL` while mid command.

### Rationale behind Changes

- PSBBN and PS2 Linux use 8bit IO to talk to most ATA regs
- PSBBN and PS2 Linux rely on pending interrupts during read DMA
  - They will issue a ReadDMA command with IRQs disabled, enable IRQ interrupts and wait for the command completion interrupt
  - We currently complete the command before IRQs are enabled, so pending interrupts are required here.
- PS2 Linux seems to not expect interrupts to be enabled on bootup.
  - It issues a HDD identify command and then gets confused if it receives a PIO data ready interrupt, after a multi second delay it will continue.
  - PSBBN's boot enables interrupts before handing over to linux so runs into the issue regardless, I think we might be missing a reset somewhere.
- `ATA_R_CONTROL` needs to be writable to allow interrupts to be enabled mid command, as required by PSBBN and PS2 Linux.

Fixes https://github.com/PCSX2/pcsx2/issues/11909 and fixes https://github.com/PCSX2/pcsx2/issues/11894 what's left of it

### Suggested Testing Steps
Test HDD homebrew and games
