### PR TITLE
IOP/EE: Add SBUS interrupts

### DIFF
--- a/pcsx2/HwWrite.cpp
+++ b/pcsx2/HwWrite.cpp
@@ -16,6 +16,8 @@
 #include "CDVD/Ps1CD.h"
 #include "CDVD/CDVD.h"
 
+#include "IopDma.h" // for iopIntcIrq
+
 using namespace R5900;
 
 // Shift the middle 8 bits (bits 4-12) into the lower 8 bits.
@@ -165,7 +167,11 @@ void _hwWrite32( u32 mem, u32 value )
 					psHu32(mem) &= ~value;
 				return;
 
-				mcase(SBUS_F240) :
+				mcase(SBUS_F240):
+					if (value & (1 << 18))
+					{
+						iopIntcIrq(1);
+					}
 					if (value & (1 << 19))
 					{
 						u32 cycle = psxRegs.cycle;

--- a/pcsx2/ps2/Iop/IopHwWrite.cpp
+++ b/pcsx2/ps2/Iop/IopHwWrite.cpp
@@ -286,6 +286,13 @@ static __fi void _HwWrite_16or32_Page1( u32 addr, T val )
 	{
 		switch( masked_addr )
 		{
+			case 0x450:
+				psxHu(addr) = val;
+				if (val & (1 << 1))
+				{
+					hwIntcIrq(INTC_SBUS);
+				}
+				break;
 			// ------------------------------------------------------------------------
 			case (HW_SIO_DATA & 0x0fff):
 				Console.Error("%s(%08X, %08X) Unexpected 16 or 32 bit write to SIO0 DATA!", __FUNCTION__, addr, val);


### PR DESCRIPTION
### Description of Changes
Each CPU can trigger an SBUS interrupt on the other, this implements that.

Only confirmed use case is Linux IRQ relay.

### Suggested Testing Steps
Just test some stuff, this should not impact anything normal.