### PR TITLE
USB: Use infinite duration for FFB forces, make the recently added FFB workaround optional

### DIFF
--- a/pcsx2/USB/usb-pad/usb-pad.cpp
+++ b/pcsx2/USB/usb-pad/usb-pad.cpp
@@ -163,7 +163,10 @@ namespace usb_pad
 					"0", "0", "100", "1", TRANSLATE_NOOP("USB", "%d%%"), nullptr, nullptr, 1.0f},
 				{SettingInfo::Type::StringList, "SteeringCurveExponent", TRANSLATE_NOOP("USB", "Steering Damping"),
 					TRANSLATE_NOOP("USB", "Applies power curve filter to steering axis values. Dampens small inputs."),
-					"Off", nullptr, nullptr, nullptr, nullptr, SteeringCurveExponentOptions}
+					"Off", nullptr, nullptr, nullptr, nullptr, SteeringCurveExponentOptions},
+				{SettingInfo::Type::Boolean, "FfbDropoutWorkaround", TRANSLATE_NOOP("USB", "Workaround for Intermittent FFB Loss"),
+					TRANSLATE_NOOP("USB", "Works around bugs in some wheels' firmware that result in brief interruptions in force. Leave this disabled unless you need it, as it has negative side effects on many wheels."),
+					"false"}
 			};
 
 			return info;
@@ -225,6 +228,11 @@ namespace usb_pad
 				mFFdev.reset();
 				mFFdevName = std::move(ffdevname);
 				OpenFFDevice();
+			}
+			if (mFFdev != NULL)
+			{
+				const bool use_ffb_dropout_workaround = USB::GetConfigBool(si, port, devname, "FfbDropoutWorkaround", false);
+				mFFdev->use_ffb_dropout_workaround = use_ffb_dropout_workaround;
 			}
 		}
 	}

--- a/pcsx2/USB/usb-pad/usb-pad.h
+++ b/pcsx2/USB/usb-pad/usb-pad.h
@@ -287,6 +287,8 @@ namespace usb_pad
 		virtual void SetAutoCenter(int value) = 0;
 		//virtual void SetGain(int gain) = 0;
 		virtual void DisableForce(EffectID force) = 0;
+
+		bool use_ffb_dropout_workaround = false;
 	};
 
 	struct PadState


### PR DESCRIPTION
#### Note

This PR changed a lot over the course of its development as a lot of research was done to ensure this was the correct approach; I ultimately pivoted back to this after digging through everything I could find. As a result, the comment history may be confusing/misleading if read out of context.

### Description of Changes
- By default, remove the workaround that bypassed the "effect already running" check for constant forces
- Change the length of all FFB effects to SDL_HAPTIC_INFINITY.
- Add a config option to restore the old workaround for wheels that still need it

### Rationale behind Changes

Getting here has been a bit of a journey, and I'm not sure whether this counts as a victory or a surrender. Some wheels are just... outright bugged. Issues we've been seeing with the Simagic wheel appear to be encountered by some other games such as BeamNG, which have some workarounds in their config options that specifically specify that "buggy wheels" might need them.

For the wheels that are bugged-but-less-bugged, adding an infinite duration to the constant force will prevent FFB dropouts. The majority of wheels that don't respect the iteration count still respect infinite durations... except Simagic (at least the Alpha Mini). 

The old workaround's approach of restarting the force constantly results in a loss of subjective quality/definition in the wheel, as independently noticed by several testers. As a result, **we want that behavior configurable and off-by-default**, since most wheels will no longer need it.

This leaves room for followup PRs that improve the workaround by restarting the force every 10-ish seconds, rather than every time the force is updated.

### Suggested Testing Steps
- The workaround toggle can be validated via Wireshark with USBPcap. Try this filter: `usb.src=="host" && usb.data_len!=0 && usbhid.data[0]==0x0a`

Known problem wheels:
- Moza series: Does not honor DI effect iteration counts, DOES honor infinite durations, experiences detail loss with old workaround.
- Simagic Alpha Mini: Does not honor DI effect iteration counts, does NOT honor infinite durations. Experiences detail loss with old workaround, but still needs it to avoid dropouts (A followup PR can mitigate this)
- Accuforce V2: Does not honor DI effect iteration counts, DOES (appear to) honor infinite durations, and experiences notable micro-drops with the old workaround due to the wheel temporarily pausing when a force is restarted.

Known good wheels for regression testing:
- Thrustmaster T150: Implements DI effect iteration count, implements infinite force durations, gummy gear drive so you'll never notice a loss of detail if one manifests 😅. Ironically, despite being a low-end wheel, it's by far the most compliant with the HID force-feedback standard.