### PR TITLE
VMManager: Add renderer selection warning

### DIFF
--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -3154,6 +3154,15 @@ void VMManager::WarnAboutUnsafeSettings()
 			append(ICON_FA_IMAGES,
 				TRANSLATE_SV("VMManager", "Mipmapping is disabled. This may break rendering in some games."));
 		}
+		static bool render_change_warn = false;
+		if (EmuConfig.GS.Renderer != GSRendererType::Auto && EmuConfig.GS.Renderer != GSRendererType::SW && !render_change_warn)
+		{
+			// show messagesbox
+			render_change_warn = true;
+
+			append(ICON_FA_EXCLAMATION_CIRCLE,
+				TRANSLATE_SV("VMManager", "Renderer is not set to Automatic. This may cause performance problems and graphical issues."));
+		}
 	}
 	if (EmuConfig.GS.TextureFiltering != BiFiltering::PS2)
 	{


### PR DESCRIPTION
### Description of Changes
Adds a once per launch warning if a user does not have the renderer set to Automatic or Software.

![image](https://github.com/user-attachments/assets/f9744490-df73-4b24-98cf-55e5c0e93bc2)

### Rationale behind Changes
Some users may change the renderer to a sub optimal option and experience problems with graphical issues performance and driver crashes on certain brands of GPUs. This warning will help point them in the right direction as to why this is happening.

### Suggested Testing Steps
Make sure the warning works correctly.
