### PR TITLE
DEV9: Add ATA commands used by PS2 Linux

### DIFF
--- a/pcsx2/DEV9/ATA/ATA.h
+++ b/pcsx2/DEV9/ATA/ATA.h
@@ -244,6 +244,7 @@ private:
 	void HDD_FlushCache();
 	void HDD_InitDevParameters();
 	void HDD_ReadVerifySectors(bool isLBA48);
+	void HDD_Recalibrate();
 	void HDD_SeekCmd();
 	void HDD_SetFeatures();
 	void HDD_SetMultipleMode();

--- a/pcsx2/DEV9/ATA/ATA.h
+++ b/pcsx2/DEV9/ATA/ATA.h
@@ -264,6 +264,7 @@ private:
 
 	void HDD_Smart();
 	void SMART_SetAutoSaveAttribute();
+	void SMART_SaveAttribute();
 	void SMART_ExecuteOfflineImmediate();
 	void SMART_EnableOps(bool enable);
 	void SMART_ReturnStatus();

--- a/pcsx2/DEV9/ATA/Commands/ATA_CmdNoData.cpp
+++ b/pcsx2/DEV9/ATA/Commands/ATA_CmdNoData.cpp
@@ -57,6 +57,27 @@ void ATA::HDD_ReadVerifySectors(bool isLBA48)
 	PostCmdNoData();
 }
 
+void ATA::HDD_Recalibrate()
+{
+	if (!PreCmd())
+		return;
+	DevCon.WriteLn("DEV9: HDD_Recalibrate");
+
+	lba48 = false;
+	// Report minimum address (LBA 0 or CHS 0/0/1).
+	// SetLBA currently only supports LBA, so set the regs directly.
+	regSelect = regSelect & 0xf0;
+	regHcyl = 0;
+	regLcyl = 0;
+	regSector = (regSelect & 0x40) ? 0 : 1;
+
+	// If recalibrate fails, we would set ATA_STAT_ERR in regStatus and ATA_ERR_TRACK0 in regError.
+	// we will never fail, so set ATA_STAT_SEEK in regStatus to indicate we finished seeking.
+	regStatus |= ATA_STAT_SEEK;
+
+	PostCmdNoData();
+}
+
 void ATA::HDD_SeekCmd()
 {
 	if (!PreCmd())

--- a/pcsx2/DEV9/ATA/Commands/ATA_CmdNoData.cpp
+++ b/pcsx2/DEV9/ATA/Commands/ATA_CmdNoData.cpp
@@ -65,6 +65,7 @@ void ATA::HDD_SeekCmd()
 
 	regStatus &= ~ATA_STAT_SEEK;
 
+	lba48 = false;
 	if (HDD_CanSeek())
 	{
 		regStatus |= ATA_STAT_ERR;

--- a/pcsx2/DEV9/ATA/Commands/ATA_CmdSMART.cpp
+++ b/pcsx2/DEV9/ATA/Commands/ATA_CmdSMART.cpp
@@ -35,6 +35,7 @@ void ATA::HDD_Smart()
 			SMART_SetAutoSaveAttribute();
 			return;
 		case 0xD3: //SMART_ATTR_SAVE
+			SMART_SaveAttribute();
 			return;
 		case 0xDA: //SMART_STATUS (is fault in disk?)
 			SMART_ReturnStatus();
@@ -77,6 +78,13 @@ void ATA::SMART_SetAutoSaveAttribute()
 			CmdNoDataAbort();
 			return;
 	}
+	PostCmdNoData();
+}
+
+void ATA::SMART_SaveAttribute()
+{
+	PreCmd();
+	// Stub
 	PostCmdNoData();
 }
 

--- a/pcsx2/DEV9/ATA/Commands/ATA_Command.cpp
+++ b/pcsx2/DEV9/ATA/Commands/ATA_Command.cpp
@@ -11,6 +11,9 @@ void ATA::IDE_ExecCmd(u16 value)
 		case 0x00:
 			HDD_Nop();
 			break;
+		case 0x10:
+			HDD_Recalibrate();
+			break;
 		case 0x20:
 			HDD_ReadSectors(false);
 			break;

--- a/pcsx2/DEV9/ATA/Commands/ATA_Command.cpp
+++ b/pcsx2/DEV9/ATA/Commands/ATA_Command.cpp
@@ -53,6 +53,9 @@ void ATA::IDE_ExecCmd(u16 value)
 		case 0xC4:
 			HDD_ReadMultiple(false);
 			break;
+		case 0xC6:
+			HDD_SetMultipleMode();
+			break;
 		case 0xC8:
 			HDD_ReadDMA(false);
 			break;


### PR DESCRIPTION
### Description of Changes
Stubs SMART Save Attributes sub-command.
Implements Recalibrate command.
Exposes Set Multiple Mode.

### Rationale behind Changes
These commands are used by PS2 Linux
SMART `SaveAttributes` is stubbed as we don't actually record any SMART data.
`Recalibrate` seeks to the 1st sector. Will always succeed as if we can't access the start of a file then we probably have bigger problems.
`SetMultipleMode` affects the `ReadMultiple` command. I had previously implemented these commands, but didn't expose them as nothing before had used these over `ReadSector` or `ReadDMA`.

Fixes https://github.com/PCSX2/pcsx2/issues/11892
This is hopefully the second to last DEV9 pr that PS2 Linux needs (at least until it hits TLB-miss town).

### Suggested Testing Steps
Test HDD software
