### PR TITLE
DEV9: Set/Clear SEEK bit in all relevent commands

### DIFF
--- a/pcsx2/DEV9/ATA/ATA.h
+++ b/pcsx2/DEV9/ATA/ATA.h
@@ -94,7 +94,11 @@ private:
 	u8 regNsector;
 	u8 regNsectorHOB;
 
-	u8 regStatus; //ReadOnly. When read via AlternateStatus pending interrupts are not cleared
+	u8 regStatus; // ReadOnly. When read via AlternateStatus, pending interrupts are not cleared.
+	// When an error occurs, the SEEK bit shall not be changed until the Status Register is read,
+	// after which this bit again indicates Seek completed.
+	// A value of -1 is locked clear, a value of 1 is locked set, 0 is unlocked.
+	s8 regStatusSeekLock; 
 
 	bool pendingInterrupt = false;
 

--- a/pcsx2/DEV9/ATA/ATA_State.cpp
+++ b/pcsx2/DEV9/ATA/ATA_State.cpp
@@ -318,6 +318,7 @@ void ATA::ResetEnd(bool hard)
 	}
 
 	regStatus |= ATA_STAT_SEEK;
+	regStatusSeekLock = 0;
 
 	HDD_ExecuteDeviceDiag(false);
 	regControlEnableIRQ = false;
@@ -393,6 +394,19 @@ u16 ATA::Read(u32 addr, int width)
 
 			if (GetSelectedDevice() != 0)
 				return 0;
+
+			// When an error occurs, the seek bit shall not be changed until the Status Register is read, after which the bit then indicates the current Seek status.
+			// This handles reporting the locked value, and then unlocking if read form STATUS rather then ALT_STATUS.
+			// locking is performed where the errror occurs, by setting regStatusSeekLock to either 1 or -1 based on the locked SEEK value.
+			if (regStatusSeekLock != 0)
+			{
+				u8 hard = (regStatus & ~ATA_STAT_SEEK);
+				hard |= (regStatusSeekLock > 0) ? ATA_STAT_SEEK : static_cast<u8>(0);
+				if (addr == ATA_R_STATUS)
+					regStatusSeekLock = 0;
+				return hard;
+			}
+
 			return regStatus;
 		default:
 			Console.Error("DEV9: ATA: Unknown %dbit read at address %x", width, addr);

--- a/pcsx2/DEV9/ATA/ATA_State.cpp
+++ b/pcsx2/DEV9/ATA/ATA_State.cpp
@@ -317,6 +317,8 @@ void ATA::ResetEnd(bool hard)
 			mdmaMode = 2;
 	}
 
+	regStatus |= ATA_STAT_SEEK;
+
 	HDD_ExecuteDeviceDiag(false);
 	regControlEnableIRQ = false;
 }

--- a/pcsx2/DEV9/ATA/ATA_Transfer.cpp
+++ b/pcsx2/DEV9/ATA/ATA_Transfer.cpp
@@ -483,9 +483,11 @@ bool ATA::HDD_CanAssessOrSetError()
 		if (nsector == -1)
 		{
 			regStatus &= ~ATA_STAT_SEEK;
+			regStatusSeekLock = -1;
 			PostCmdNoData();
 			return false;
 		}
+		regStatusSeekLock = 1;
 	}
 	return true;
 }

--- a/pcsx2/DEV9/ATA/ATA_Transfer.cpp
+++ b/pcsx2/DEV9/ATA/ATA_Transfer.cpp
@@ -482,6 +482,7 @@ bool ATA::HDD_CanAssessOrSetError()
 		regError |= static_cast<u8>(ATA_ERR_ID);
 		if (nsector == -1)
 		{
+			regStatus &= ~ATA_STAT_SEEK;
 			PostCmdNoData();
 			return false;
 		}

--- a/pcsx2/DEV9/ATA/Commands/ATA_CmdDMA.cpp
+++ b/pcsx2/DEV9/ATA/Commands/ATA_CmdDMA.cpp
@@ -143,6 +143,7 @@ void ATA::HDD_ReadDMA(bool isLBA48)
 		Console.Error("DEV9: ATA: Transfer from invalid LBA %lu", HDD_GetLBA());
 		nsector = -1;
 		regStatus |= ATA_STAT_ERR;
+		regStatusSeekLock = -1;
 		regError |= ATA_ERR_ID;
 		PostCmdNoData();
 		return;
@@ -168,6 +169,7 @@ void ATA::HDD_WriteDMA(bool isLBA48)
 		Console.Error("DEV9: ATA: Transfer from invalid LBA %lu", HDD_GetLBA());
 		nsector = -1;
 		regStatus |= ATA_STAT_ERR;
+		regStatusSeekLock = -1;
 		regError |= ATA_ERR_ID;
 		PostCmdNoData();
 		return;

--- a/pcsx2/DEV9/ATA/Commands/ATA_CmdDMA.cpp
+++ b/pcsx2/DEV9/ATA/Commands/ATA_CmdDMA.cpp
@@ -137,6 +137,7 @@ void ATA::HDD_ReadDMA(bool isLBA48)
 
 	IDE_CmdLBA48Transform(isLBA48);
 
+	regStatus &= ~ATA_STAT_SEEK;
 	if (!HDD_CanSeek())
 	{
 		Console.Error("DEV9: ATA: Transfer from invalid LBA %lu", HDD_GetLBA());
@@ -146,6 +147,8 @@ void ATA::HDD_ReadDMA(bool isLBA48)
 		PostCmdNoData();
 		return;
 	}
+	else
+		regStatus |= ATA_STAT_SEEK;
 
 	//Do Sync Read
 	HDD_ReadSync(&ATA::DRQCmdDMADataToHost);
@@ -159,6 +162,7 @@ void ATA::HDD_WriteDMA(bool isLBA48)
 
 	IDE_CmdLBA48Transform(isLBA48);
 
+	regStatus &= ~ATA_STAT_SEEK;
 	if (!HDD_CanSeek())
 	{
 		Console.Error("DEV9: ATA: Transfer from invalid LBA %lu", HDD_GetLBA());
@@ -168,6 +172,8 @@ void ATA::HDD_WriteDMA(bool isLBA48)
 		PostCmdNoData();
 		return;
 	}
+	else
+		regStatus |= ATA_STAT_SEEK;
 
 	//Do Async write
 	DRQCmdDMADataFromHost();

--- a/pcsx2/DEV9/ATA/Commands/ATA_CmdNoData.cpp
+++ b/pcsx2/DEV9/ATA/Commands/ATA_CmdNoData.cpp
@@ -19,6 +19,7 @@ void ATA::CmdNoDataAbort()
 
 	regError |= ATA_ERR_ABORT;
 	regStatus |= ATA_STAT_ERR;
+	regStatusSeekLock = (regStatus & ATA_STAT_SEEK) ? 1 : -1;
 	PostCmdNoData();
 }
 
@@ -62,6 +63,7 @@ void ATA::HDD_ReadVerifySectors(bool isLBA48)
 	if (!HDD_CanSeek())
 	{
 		regStatus |= ATA_STAT_ERR;
+		regStatusSeekLock = -1;
 		regError |= ATA_ERR_TRACK0;
 	}
 	else
@@ -104,6 +106,7 @@ void ATA::HDD_SeekCmd()
 	if (HDD_CanSeek())
 	{
 		regStatus |= ATA_STAT_ERR;
+		regStatusSeekLock = -1;
 		regError |= ATA_ERR_ID;
 	}
 	else
@@ -198,6 +201,7 @@ void ATA::HDD_Nop()
 	//Always ends in error
 	regError |= ATA_ERR_ABORT;
 	regStatus |= ATA_STAT_ERR;
+	regStatusSeekLock = (regStatus & ATA_STAT_SEEK) ? 1 : -1;
 	PostCmdNoData();
 }
 

--- a/pcsx2/DEV9/ATA/Commands/ATA_CmdNoData.cpp
+++ b/pcsx2/DEV9/ATA/Commands/ATA_CmdNoData.cpp
@@ -52,6 +52,15 @@ void ATA::HDD_ReadVerifySectors(bool isLBA48)
 
 	IDE_CmdLBA48Transform(isLBA48);
 
+	regStatus &= ~ATA_STAT_SEEK;
+	if (!HDD_CanSeek())
+	{
+		regStatus |= ATA_STAT_ERR;
+		regError |= ATA_ERR_TRACK0;
+	}
+	else
+		regStatus |= ATA_STAT_SEEK;
+
 	HDD_CanAssessOrSetError();
 
 	PostCmdNoData();
@@ -84,9 +93,8 @@ void ATA::HDD_SeekCmd()
 		return;
 	DevCon.WriteLn("DEV9: HDD_SeekCmd");
 
-	regStatus &= ~ATA_STAT_SEEK;
-
 	lba48 = false;
+	regStatus &= ~ATA_STAT_SEEK;
 	if (HDD_CanSeek())
 	{
 		regStatus |= ATA_STAT_ERR;

--- a/pcsx2/DEV9/ATA/Commands/ATA_CmdNoData.cpp
+++ b/pcsx2/DEV9/ATA/Commands/ATA_CmdNoData.cpp
@@ -30,8 +30,14 @@ void ATA::HDD_FlushCache() //Can't when DRQ set
 		return;
 	DevCon.WriteLn("DEV9: HDD_FlushCache");
 
-	awaitFlush = true;
-	Async(-1);
+	if (!writeQueue.IsQueueEmpty())
+	{
+		regStatus |= ATA_STAT_SEEK;
+		awaitFlush = true;
+		Async(-1);
+	}
+	else
+		PostCmdNoData();
 }
 
 void ATA::HDD_InitDevParameters()

--- a/pcsx2/DEV9/ATA/Commands/ATA_CmdPIOData.cpp
+++ b/pcsx2/DEV9/ATA/Commands/ATA_CmdPIOData.cpp
@@ -101,6 +101,7 @@ void ATA::HDD_ReadPIO(bool isLBA48)
 	if (!HDD_CanSeek())
 	{
 		regStatus |= ATA_STAT_ERR;
+		regStatusSeekLock = -1;
 		regError |= ATA_ERR_ID;
 		PostCmdNoData();
 		return;

--- a/pcsx2/DEV9/ATA/Commands/ATA_CmdPIOData.cpp
+++ b/pcsx2/DEV9/ATA/Commands/ATA_CmdPIOData.cpp
@@ -97,6 +97,7 @@ void ATA::HDD_ReadPIO(bool isLBA48)
 
 	IDE_CmdLBA48Transform(isLBA48);
 
+	regStatus &= ~ATA_STAT_SEEK;
 	if (!HDD_CanSeek())
 	{
 		regStatus |= ATA_STAT_ERR;
@@ -104,6 +105,8 @@ void ATA::HDD_ReadPIO(bool isLBA48)
 		PostCmdNoData();
 		return;
 	}
+	else
+		regStatus |= ATA_STAT_SEEK;
 
 	HDD_ReadSync(&ATA::HDD_ReadPIOS2);
 }

--- a/pcsx2/DEV9/ATA/Commands/ATA_Command.cpp
+++ b/pcsx2/DEV9/ATA/Commands/ATA_Command.cpp
@@ -142,8 +142,6 @@ bool ATA::PreCmd()
 	regStatus &= ~ATA_STAT_DRQ;
 	regStatus &= ~ATA_STAT_ERR;
 
-	regStatus &= ~ATA_STAT_SEEK;
-
 	regError = 0;
 
 	return true;


### PR DESCRIPTION
### Description of Changes
Set/Clear the seek bit any any command could need to seek to complete
Implement holding the value of the SEEK bit when en error occurs

### Rationale behind Changes
PS2Linux actually checks for the SEEK bit to determine if a DMA command completed.
The SEEK bit will be set/cleared based on what happens with the command
With the exception of the Flush command, I've opted not to factor in the actions of the write cache.

The holding/locking of the reported value of the SEEK bit as added here is specified in older version of the ATA spec.

The last of my PSBBN prs, Fixes https://github.com/PCSX2/pcsx2/issues/11924

### Suggested Testing Steps
Test HDD software/games
