### PR TITLE
Debugger: Avoid resetting symbol trees while single stepping

### DIFF
--- a/pcsx2-qt/Debugger/CpuWidget.cpp
+++ b/pcsx2-qt/Debugger/CpuWidget.cpp
@@ -164,10 +164,6 @@ void CpuWidget::setupSymbolTrees()
 	m_ui.tabLocalVariables->layout()->addWidget(m_local_variable_tree);
 	m_ui.tabParameterVariables->layout()->addWidget(m_parameter_variable_tree);
 
-	connect(m_ui.tabWidgetRegFunc, &QTabWidget::currentChanged, m_function_tree, &SymbolTreeWidget::updateModel);
-	connect(m_ui.tabWidget, &QTabWidget::currentChanged, m_global_variable_tree, &SymbolTreeWidget::updateModel);
-	connect(m_ui.tabWidget, &QTabWidget::currentChanged, m_local_variable_tree, &SymbolTreeWidget::updateModel);
-
 	connect(m_function_tree, &SymbolTreeWidget::goToInDisassembly, m_ui.disassemblyWidget, &DisassemblyWidget::gotoAddressAndSetFocus);
 	connect(m_global_variable_tree, &SymbolTreeWidget::goToInDisassembly, m_ui.disassemblyWidget, &DisassemblyWidget::gotoAddressAndSetFocus);
 	connect(m_local_variable_tree, &SymbolTreeWidget::goToInDisassembly, m_ui.disassemblyWidget, &DisassemblyWidget::gotoAddressAndSetFocus);
@@ -207,8 +203,10 @@ void CpuWidget::reloadCPUWidgets()
 	m_ui.disassemblyWidget->update();
 	m_ui.memoryviewWidget->update();
 
-	m_local_variable_tree->reset();
-	m_parameter_variable_tree->reset();
+	m_function_tree->updateModel();
+	m_global_variable_tree->updateModel();
+	m_local_variable_tree->updateModel();
+	m_parameter_variable_tree->updateModel();
 }
 
 void CpuWidget::paintEvent(QPaintEvent* event)

--- a/pcsx2-qt/Debugger/SymbolTree/SymbolTreeWidgets.h
+++ b/pcsx2-qt/Debugger/SymbolTree/SymbolTreeWidgets.h
@@ -72,6 +72,8 @@ protected:
 	void setupMenu();
 	void openMenu(QPoint pos);
 
+	virtual bool needsReset() const;
+
 	virtual std::vector<SymbolWork> getSymbols(
 		const QString& filter, const ccc::SymbolDatabase& database) = 0;
 
@@ -172,6 +174,8 @@ public:
 	virtual ~LocalVariableTreeWidget();
 
 protected:
+	bool needsReset() const override;
+
 	std::vector<SymbolWork> getSymbols(
 		const QString& filter, const ccc::SymbolDatabase& database) override;
 
@@ -182,6 +186,7 @@ protected:
 
 	void onNewButtonPressed() override;
 
+	ccc::FunctionHandle m_function;
 	std::optional<u32> m_caller_stack_pointer;
 };
 
@@ -193,6 +198,8 @@ public:
 	virtual ~ParameterVariableTreeWidget();
 
 protected:
+	bool needsReset() const override;
+
 	std::vector<SymbolWork> getSymbols(
 		const QString& filter, const ccc::SymbolDatabase& database) override;
 
@@ -203,6 +210,7 @@ protected:
 
 	void onNewButtonPressed() override;
 
+	ccc::FunctionHandle m_function;
 	std::optional<u32> m_caller_stack_pointer;
 };
 


### PR DESCRIPTION
### Description of Changes
The local and parameter symbol trees will now check if the program counter is inside or outside the function they're displaying the variables for when deciding whether to reset. The `CpuWidget::reloadCPUWidgets` function now calls `SymbolTreeWidget::updateModel` instead of `SymbolTreeWidget::reset` directly.

### Rationale behind Changes
Previously the local and parameter symbol trees would reset when single stepping, which would collapse any nodes the user had expanded. This was annoying.

### Suggested Testing Steps
Find a function, create a local/parameter variable with an array type e.g. "int[10]" so you can expand it, then single step inside the function.