### PR TITLE
Qt: Fix symbol sources list in per-game settings dialog

### DIFF
--- a/pcsx2-qt/Settings/DebugAnalysisSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/DebugAnalysisSettingsWidget.cpp
@@ -261,11 +261,11 @@ void DebugAnalysisSettingsWidget::setupSymbolSourceGrid()
 
 void DebugAnalysisSettingsWidget::symbolSourceCheckStateChanged()
 {
-	QComboBox* combo_box = qobject_cast<QComboBox*>(sender());
-	if (!combo_box)
+	QCheckBox* check_box = qobject_cast<QCheckBox*>(sender());
+	if (!check_box)
 		return;
 
-	auto temp = m_symbol_sources.find(combo_box->currentText().toStdString());
+	auto temp = m_symbol_sources.find(check_box->text().toStdString());
 	if (temp == m_symbol_sources.end())
 		return;
 
@@ -311,6 +311,7 @@ void DebugAnalysisSettingsWidget::saveSymbolSources()
 			continue;
 
 		std::string section = "Debugger/Analysis/SymbolSources/" + std::to_string(i);
+		sif->SetStringValue(section.c_str(), "Name", name.c_str());
 		sif->SetBoolValue(section.c_str(), "ClearDuringAnalysis", temp.check_box->isChecked());
 
 		i++;


### PR DESCRIPTION
### Description of Changes
This fixes the symbol sources list in the "Clear Existing Symbols" section of the analysis tab in the per-game settings dialog. Due to a rather silly mistake in [this PR](https://github.com/PCSX2/pcsx2/pull/11901), `DebugAnalysisSettingsWidget::saveSymbolSources` was previously never actually run.

### Rationale behind Changes
To be fair check boxes and combo boxes are quite similar.

### Suggested Testing Steps
- Launch a game.
- Launch the debugger.
- Open the per-game settings dialog.
- Try checking/unchecking the symbol sources.
- Restart PCSX2.
- Make sure the changes stay.
