### PR TITLE
GS: Misc adapter and vendor detection changes

### DIFF
--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -1137,13 +1137,13 @@ void GraphicsSettingsWidget::updateRendererDependentOptions()
 		std::string current_adapter = Host::GetBaseStringSettingValue("EmuCore/GS", "Adapter", "");
 		m_ui.adapterDropdown->clear();
 		m_ui.adapterDropdown->setEnabled(!adapters.empty());
-		m_ui.adapterDropdown->addItem(tr("(Default)"));
+		m_ui.adapterDropdown->addItem(GetDefaultAdapter().c_str());
 		m_ui.adapterDropdown->setCurrentIndex(0);
 
 		if (m_dialog->isPerGameSettings())
 		{
 			m_ui.adapterDropdown->insertItem(
-				0, tr("Use Global Setting [%1]").arg(current_adapter.empty() ? tr("(Default)") : QString::fromStdString(current_adapter)));
+				0, tr("Use Global Setting [%1]").arg(current_adapter.empty() ? GetDefaultAdapter().c_str() : QString::fromStdString(current_adapter)));
 			if (!m_dialog->getSettingsInterface()->GetStringValue("EmuCore/GS", "Adapter", &current_adapter))
 			{
 				// clear the adapter so we don't set it to the global value

--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -69,6 +69,12 @@ bool GSIsHardwareRenderer()
 	return (GSCurrentRenderer != GSRendererType::SW);
 }
 
+std::string GetDefaultAdapter()
+{
+	// Will be treated as empty.
+	return "(Default)";
+}
+
 static RenderAPI GetAPIForRenderer(GSRendererType renderer)
 {
 	switch (renderer)

--- a/pcsx2/GS/GS.h
+++ b/pcsx2/GS/GS.h
@@ -89,6 +89,7 @@ void GSSetVSyncMode(GSVSyncMode mode, bool allow_present_throttle);
 
 GSRendererType GSGetCurrentRenderer();
 bool GSIsHardwareRenderer();
+std::string GetDefaultAdapter();
 bool GSWantsExclusiveFullscreen();
 std::optional<float> GSGetHostRefreshRate();
 std::vector<GSAdapterInfo> GSGetAdapterInfo(GSRendererType renderer);

--- a/pcsx2/GS/Renderers/DX11/D3D.cpp
+++ b/pcsx2/GS/Renderers/DX11/D3D.cpp
@@ -197,7 +197,7 @@ bool D3D::GetRequestedExclusiveFullscreenModeDesc(IDXGIFactory5* factory, const 
 
 wil::com_ptr_nothrow<IDXGIAdapter1> D3D::GetAdapterByName(IDXGIFactory5* factory, const std::string_view name)
 {
-	if (name.empty())
+	if (name.empty() || name == GetDefaultAdapter())
 		return {};
 
 	// This might seem a bit odd to cache the names.. but there's a method to the madness.

--- a/pcsx2/GS/Renderers/DX11/D3D.cpp
+++ b/pcsx2/GS/Renderers/DX11/D3D.cpp
@@ -375,7 +375,7 @@ GSRendererType D3D::GetPreferredRenderer()
 	};
 	const auto get_d3d12_device = [&adapter]() {
 		wil::com_ptr_nothrow<ID3D12Device> device;
-		const HRESULT hr = D3D12CreateDevice(adapter.get(), D3D_FEATURE_LEVEL_11_0, IID_PPV_ARGS(device.put()));
+		const HRESULT hr = D3D12CreateDevice(adapter.get(), D3D_FEATURE_LEVEL_12_0, IID_PPV_ARGS(device.put()));
 		if (FAILED(hr))
 			Console.Error("D3D12CreateDevice() for automatic renderer failed: %08X", hr);
 		return device;

--- a/pcsx2/GS/Renderers/DX12/GSDevice12.h
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.h
@@ -144,7 +144,7 @@ private:
 		bool has_timestamp_query = false;
 	};
 
-	bool CreateDevice();
+	bool CreateDevice(u32& vendor_id);
 	bool CreateDescriptorHeaps();
 	bool CreateCommandLists();
 	bool CreateTimestampQuery();
@@ -373,7 +373,7 @@ private:
 	ComPtr<ID3DBlob> GetUtilityVertexShader(const std::string& source, const char* entry_point);
 	ComPtr<ID3DBlob> GetUtilityPixelShader(const std::string& source, const char* entry_point);
 
-	bool CheckFeatures();
+	bool CheckFeatures(const u32& vendor_id);
 	bool CreateNullTexture();
 	bool CreateBuffers();
 	bool CreateRootSignatures();

--- a/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
+++ b/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
@@ -851,7 +851,9 @@ bool GSDeviceMTL::Create(GSVSyncMode vsync_mode, bool allow_present_throttle)
 	}
 	if (!m_dev.dev)
 	{
-		if (!GSConfig.Adapter.empty())
+		if (GSConfig.Adapter == GetDefaultAdapter())
+			Console.WriteLn("Metal: Using default adapter");
+		else if (!GSConfig.Adapter.empty())
 			Console.Warning("Metal: Couldn't find adapter %s, using default", GSConfig.Adapter.c_str());
 		m_dev = GSMTLDevice(MRCTransfer(MTLCreateSystemDefaultDevice()));
 		if (!m_dev.dev)

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -660,7 +660,7 @@ bool GSDeviceOGL::CheckFeatures(bool& buggy_pbo)
 			extensions.append(ext);
 		}
 	}
-	Console.WriteLn(std::move(extensions));
+	DevCon.WriteLn(std::move(extensions));
 
 	if (!GLAD_GL_ARB_shading_language_420pack)
 	{

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
@@ -2511,7 +2511,8 @@ bool GSDeviceVK::CreateDeviceAndSwapChain()
 		return false;
 	}
 
-	if (!GSConfig.Adapter.empty())
+	const bool is_default_gpu = GSConfig.Adapter == GetDefaultAdapter();
+	if (!(GSConfig.Adapter.empty() || is_default_gpu))
 	{
 		u32 gpu_index = 0;
 		for (; gpu_index < static_cast<u32>(gpus.size()); gpu_index++)
@@ -2532,7 +2533,7 @@ bool GSDeviceVK::CreateDeviceAndSwapChain()
 	}
 	else
 	{
-		INFO_LOG("No GPU requested, using first ({})", gpus[0].second.name);
+		INFO_LOG("{} GPU requested, using first ({})", is_default_gpu ? "Default" : "No", gpus[0].second.name);
 		m_physical_device = gpus[0].first;
 	}
 


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS: Check feature level 12 as a requirement when selecting auto renderer on intel.
Just to be on the safe side when selecting OpenGL.

GS/D3D12: Disable DX12 if feature level is not detected.
Intel Haswell doesn't actually support DX12 even tho the device is created which results in a crash,
to get around this check if device can be created using feature level 12 (skylake+).

GS/Qt: Adjust how we handle Default adapter.
Try to resolve it again since it annoys me.
Treat is as empty.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Bugfix, better defaults.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Make sure DX12 still works on amd/nvidia, and Intel Skylake and above.
Make sure OpenGL is auto selected on Skylake and above on intel.
Check log for Vulkan when using Default adapter what GPU is selected.
