### PR TITLE
Qt: Hackfix settings icon stretching on Windows themes

### DIFF
--- a/.github/workflows/scripts/windows/build-dependencies.bat
+++ b/.github/workflows/scripts/windows/build-dependencies.bat
@@ -195,6 +195,9 @@ cd "qtbase-everywhere-src-%QT%" || goto error
 rem Disable the PCRE2 JIT, it doesn't properly verify AVX2 support.
 %PATCH% -p1 < "%SCRIPTDIR%\qtbase-disable-pcre2-jit.patch" || goto error
 
+rem Hackfix settings icon stretching
+%PATCH% -p1 < "%SCRIPTDIR%\qtbase-fix-icon-stretch.patch" || goto error
+
 cmake -B build -DFEATURE_sql=OFF -DCMAKE_INSTALL_PREFIX="%INSTALLDIR%" %FORCEPDB% -DINPUT_gui=yes -DINPUT_widgets=yes -DINPUT_ssl=yes -DINPUT_openssl=no -DINPUT_schannel=yes -DFEATURE_system_png=ON -DFEATURE_system_jpeg=ON -DFEATURE_system_zlib=ON -DFEATURE_system_freetype=ON -DFEATURE_system_harfbuzz=ON %QTBUILDSPEC% || goto error
 cmake --build build --parallel || goto error
 ninja -C build install || goto error

--- a/.github/workflows/scripts/windows/qtbase-fix-icon-stretch.patch
+++ b/.github/workflows/scripts/windows/qtbase-fix-icon-stretch.patch
@@ -1,0 +1,13 @@
+diff --git a/src/plugins/styles/modernwindows/qwindowsvistastyle.cpp b/src/plugins/styles/modernwindows/qwindowsvistastyle.cpp
+index 208420d7e8..26ef6f31ef 100644
+--- a/src/plugins/styles/modernwindows/qwindowsvistastyle.cpp
++++ b/src/plugins/styles/modernwindows/qwindowsvistastyle.cpp
+@@ -4232,8 +4232,6 @@ QRect QWindowsVistaStyle::subElementRect(SubElement element, const QStyleOption
+
+     case SE_ItemViewItemDecoration:
+         rect = QWindowsStyle::subElementRect(element, option, widget);
+-        if (qstyleoption_cast<const QStyleOptionViewItem *>(option))
+-            rect.adjust(-2, 0, 2, 0);
+         break;
+
+     case SE_ItemViewItemFocusRect:


### PR DESCRIPTION
### Description of Changes
Qt alters the size of rectangles used for SE_ItemViewItemDecoration (Icons in Item Views), widening it by 4 pixels

### Rationale behind Changes
This altered rectangle causes our settings icons to be stretched by 4 pixels when using the native or classic theme on Windows
I don't know _why_ Qt does this.

### Suggested Testing Steps
Look at the icons in the settings window
Go though any other list views to see if something is missing 2 pixels each side (or otherwise squashed).
