### PR TITLE
Debugger: Refactor nocash symbol importer

### DIFF
--- a/pcsx2/DebugTools/SymbolImporter.h
+++ b/pcsx2/DebugTools/SymbolImporter.h
@@ -43,8 +43,18 @@ public:
 		const ccc::ElfSymbolFile& elf,
 		const std::string& nocash_path,
 		const Pcsx2Config::DebugAnalysisOptions& options,
+		const std::map<std::string, ccc::DataTypeHandle>& builtin_types,
 		const std::atomic_bool* interrupt);
-	static bool ImportNocashSymbols(ccc::SymbolDatabase& database, const std::string& file_path);
+
+	static ccc::Result<bool> ImportNocashSymbols(
+		ccc::SymbolDatabase& database,
+		const std::string& file_path,
+		const std::map<std::string, ccc::DataTypeHandle>& builtin_types);
+
+	static std::unique_ptr<ccc::ast::Node> GetBuiltInType(
+		const std::string& name,
+		ccc::ast::BuiltInClass bclass,
+		const std::map<std::string, ccc::DataTypeHandle>& builtin_types);
 
 	static void ScanForFunctions(
 		ccc::SymbolDatabase& database, const ccc::ElfSymbolFile& elf, const Pcsx2Config::DebugAnalysisOptions& options);
@@ -57,6 +67,8 @@ protected:
 
 	std::thread m_import_thread;
 	std::atomic_bool m_interrupt_import_thread = false;
+
+	std::map<std::string, ccc::DataTypeHandle> m_builtin_types;
 };
 
 extern SymbolImporter R5900SymbolImporter;


### PR DESCRIPTION
### Description of Changes
- Improve error handling.
- Create type name AST nodes instead of built-in nodes. This means different types will be shown in the global variables tab for these symbols e.g.  `u8`  instead of `8-bit unsigned integer`.
- Use `FileSystem::OpenManagedCFile` instead of `FileSystem::OpenCFile`.
### Rationale behind Changes
- Silence a spammy error message.
- The previous behaviour with the built-in AST node made the type more annoying the edit in the debugger.

### Suggested Testing Steps
- Make sure any .sym files you have are still being imported correctly.