### PR TITLE
Deps: Update Flatpak dependencies

### DIFF
--- a/.github/workflows/scripts/linux/flatpak/modules/10-libpcap.json
+++ b/.github/workflows/scripts/linux/flatpak/modules/10-libpcap.json
@@ -8,8 +8,8 @@
     {
       "type": "git",
       "url": "https://github.com/the-tcpdump-group/libpcap.git",
-      "tag": "libpcap-1.10.4",
-      "commit": "104271ba4a14de6743e43bcf87536786d8fddea4"
+      "tag": "libpcap-1.10.5",
+      "commit": "bbcbc9174df3298a854daee2b3e666a4b6e5383a"
     }
   ],
   "cleanup": [

--- a/.github/workflows/scripts/linux/flatpak/net.pcsx2.PCSX2.json
+++ b/.github/workflows/scripts/linux/flatpak/net.pcsx2.PCSX2.json
@@ -1,15 +1,15 @@
 {
   "app-id": "net.pcsx2.PCSX2",
   "runtime": "org.kde.Platform",
-  "runtime-version": "6.7",
+  "runtime-version": "6.8",
   "sdk": "org.kde.Sdk",
   "sdk-extensions": [
-    "org.freedesktop.Sdk.Extension.llvm17"
+    "org.freedesktop.Sdk.Extension.llvm18"
   ],
   "add-extensions": {
     "org.freedesktop.Platform.ffmpeg-full": {
       "directory": "lib/ffmpeg",
-      "version": "23.08",
+      "version": "24.08",
       "add-ld-path": ".",
       "autodownload": true
     }
@@ -44,8 +44,8 @@
         "config-opts": [
           "-DCMAKE_BUILD_TYPE=Release",
           "-DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON",
-          "-DCMAKE_C_COMPILER=/usr/lib/sdk/llvm17/bin/clang",
-          "-DCMAKE_CXX_COMPILER=/usr/lib/sdk/llvm17/bin/clang++",
+          "-DCMAKE_C_COMPILER=/usr/lib/sdk/llvm18/bin/clang",
+          "-DCMAKE_CXX_COMPILER=/usr/lib/sdk/llvm18/bin/clang++",
           "-DCMAKE_EXE_LINKER_FLAGS_INIT=-fuse-ld=lld",
           "-DCMAKE_MODULE_LINKER_FLAGS_INIT=-fuse-ld=lld",
           "-DCMAKE_SHARED_LINKER_FLAGS_INIT=-fuse-ld=lld",


### PR DESCRIPTION
### Description of Changes
Update Flatpak dependencies: Qt to 6.8, FFMPEG extension and libpcap.

### Rationale behind Changes
Up-to-date dependencies.

### Suggested Testing Steps
Successful build, install the PCSX2 flatpak and run it; I suppose.