### PR TITLE
CI: Fix Translation Workflow Scripts Order of Operation

### DIFF
--- a/.github/workflows/scripts/common/update_base_translation.sh
+++ b/.github/workflows/scripts/common/update_base_translation.sh
@@ -6,9 +6,9 @@ set -e
 
 # While we use custom Qt builds for our releases, the Qt6 package will be good enough
 # for just updating translations. Saves building it for this action alone.
-"$SCRIPTDIR/../../../../tools/retry.sh" sudo apt-get -y install qt6-l10n-tools python3  
+"$SCRIPTDIR/../../../../tools/retry.sh" sudo apt-get -y install qt6-l10n-tools python3
 
+"$SCRIPTDIR/../../../../tools/generate_fullscreen_ui_translation_strings.py"
+"$SCRIPTDIR/../../../../pcsx2-qt/Translations/update_glyph_ranges.py"
+"$SCRIPTDIR/../../../../tools/generate_update_fa_glyph_ranges.py"
 PATH=/usr/lib/qt6/bin:$PATH "$SCRIPTDIR/../../../../pcsx2-qt/Translations/update_base_translation.sh"
-PATH=/usr/bin/python3:$PATH "$SCRIPTDIR/../../../../pcsx2-qt/Translations/update_glyph_ranges.py"
-PATH=/usr/bin/python3:$PATH "$SCRIPTDIR/../../../../tools/generate_fullscreen_ui_translation_strings.py"
-PATH=/usr/bin/python3:$PATH "$SCRIPTDIR/../../../../tools/generate_update_fa_glyph_ranges.py"


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->

With how the previous scripts are executed out of order, any strings changes that happens inside BPM will not be picked up by the Qt translation script update on the first run. This PR changes the order of operations for the workflow scripts so that the other scripts for BPM and Glyph ranges are executed first ensuring that the string changes are properly getting picked up by the Qt script as it will be the very last one to be executed.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Fixing the workflow so that all the translations changes are correctly picked up

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Nothing for now.