### PR TITLE
PAD: Fix negcon and jogcon BPM crash

### DIFF
--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -4391,7 +4391,8 @@ void FullscreenUI::DrawControllerSettingsPage()
 			StartAutomaticBinding(global_slot);
 
 		for (const InputBindingInfo& bi : ci->bindings)
-			DrawInputBindingButton(bsi, bi.bind_type, section, bi.name, Host::TranslateToCString("Pad", bi.display_name), bi.icon_name, true);
+			if (bi.name) [[likely]]
+				DrawInputBindingButton(bsi, bi.bind_type, section, bi.name, Host::TranslateToCString("Pad", bi.display_name), bi.icon_name, true);
 
 		if (mtap_enabled[mtap_port])
 		{


### PR DESCRIPTION
### Description of Changes
Should fix #11960
I quickly tested it, seems to work fine. Would like more testing though, I'm not entirely sure why those empty bindings were there in the first place.

### Rationale behind Changes
Crashing is bad.

### Suggested Testing Steps
Test negcon and jogcon emulation. Test configuring them in the fullscreen UI as well.
