### PR TITLE
Dis5900asm: Fix an out of bounds access on invalid pmfhl formats

### DIFF
--- a/pcsx2/DebugTools/DisR5900asm.cpp
+++ b/pcsx2/DebugTools/DisR5900asm.cpp
@@ -1071,7 +1071,7 @@ void MTSAH( std::string& output )   { _sap("mtsah\t%s, 0x%04X") GPR_REG[DECODE_R
 
 
 //***************************SPECIAL 2 CPU OPCODES*******************
-const char* pmfhl_sub[] = {"lw", "uw", "slw", "lh", "sh", "??", "??"};
+const char* pmfhl_sub[] = {"lw", "uw", "slw", "lh", "sh", "??", "??", "??"};
 
 void MADD( std::string& output )    { _sap("madd\t%s, %s %s")        GPR_REG[DECODE_RD],GPR_REG[DECODE_RS], GPR_REG[DECODE_RT]); }
 void MADDU( std::string& output )   { _sap("maddu\t%s, %s %s")       GPR_REG[DECODE_RD],GPR_REG[DECODE_RS], GPR_REG[DECODE_RT]);}


### PR DESCRIPTION
### Description of Changes
Off by one issue fix when I originally fixed this in #9761

### Rationale behind Changes
Fixes a crash when disassembling invalid PMFHL opcodes (or memory with the value 0x70003ff0)

### Suggested Testing Steps
See if #11959 is fixed.
You can reproduce this by going into the memory view, right clicking and showing at 4 bytes. Enter 0x70003ff0 somewhere and take the disassembler to that memory area.
