### PR TITLE
FSUI: Don't move IMGUI cursor unnecessarily in DrawGameGrid()

### DIFF
--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -6221,12 +6221,22 @@ void FullscreenUI::DrawGameGrid(const ImVec2& heading_size)
 	SmallString draw_title;
 
 	u32 grid_x = 0;
-	ImGui::SetCursorPos(ImVec2(start_x, 0.0f));
 	for (const GameList::Entry* entry : s_game_list_sorted_entries)
 	{
 		ImGuiWindow* window = ImGui::GetCurrentWindow();
 		if (window->SkipItems)
 			continue;
+
+		if (grid_x == grid_count_x)
+		{
+			grid_x = 0;
+			ImGui::SetCursorPosX(start_x);
+			ImGui::SetCursorPosY(ImGui::GetCursorPosY() + item_spacing);
+		}
+		else
+		{
+			ImGui::SameLine(start_x + static_cast<float>(grid_x) * (item_width + item_spacing));
+		}
 
 		const ImGuiID id = window->GetID(entry->path.c_str(), entry->path.c_str() + entry->path.length());
 		const ImVec2 pos(window->DC.CursorPos);
@@ -6280,16 +6290,6 @@ void FullscreenUI::DrawGameGrid(const ImVec2& heading_size)
 		}
 
 		grid_x++;
-		if (grid_x == grid_count_x)
-		{
-			grid_x = 0;
-			ImGui::SetCursorPosX(start_x);
-			ImGui::SetCursorPosY(ImGui::GetCursorPosY() + item_spacing);
-		}
-		else
-		{
-			ImGui::SameLine(start_x + static_cast<float>(grid_x) * (item_width + item_spacing));
-		}
 	}
 
 	EndMenuButtons();


### PR DESCRIPTION
### Description of Changes
Move setting the cursor to the beginning of the Game Grid drawing loop.
Previously we would also set the cursor for the next item, even when we where the last item.

### Rationale behind Changes
If the GameGrid was drawing an empty list, or a list where the number of grids was a multiple of the grid width, we would set the cursor onto a "grid line" with no entries.

In older versions of IMGUI, setting the cursor implicitly extended the parent's boundaries, this change was deprecated and only adding items would set the size. https://github.com/ocornut/imgui/issues/5548
During this, an assert was added to detect the programs relying on this deprecated behaviour.

We trigger this assert when we move the cursor onto a new line, but leave it empty.

As the problem this PR addresses is minor, it should not block v2.2's release.

### Suggested Testing Steps
Test Big Picture Mode's GameList, using the grid view