### PR TITLE
GameDB: Champions of Norrath & Champions: Return to Arms (PAL)

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -18688,6 +18688,9 @@ SLES-52325:
     - BlitInternalFPSHack # Fixes internal fps detection in some areas.
   gsHWFixes:
     estimateTextureRegion: 1 # Improves performance.
+    roundSprite: 1 # Fixes lines in menus HUD and in game.
+    halfPixelOffset: 2 # Fixes edge garbage.
+    PCRTCOverscan: 1 # Fixes offscreen image.
 SLES-52326:
   name: "Spawn - Armageddon"
   region: "PAL-M5"
@@ -18788,6 +18791,9 @@ SLES-52373:
     - BlitInternalFPSHack # Fixes internal fps detection in some areas.
   gsHWFixes:
     estimateTextureRegion: 1 # Improves performance.
+    roundSprite: 1 # Fixes lines in menus HUD and in game.
+    halfPixelOffset: 2 # Fixes edge garbage.
+    PCRTCOverscan: 1 # Fixes offscreen image.
 SLES-52374:
   name: "Fight Night 2004"
   region: "PAL-M3"
@@ -20855,6 +20861,7 @@ SLES-53039:
     estimateTextureRegion: 1 # Improves performance.
     roundSprite: 1 # Fixes lines in menus HUD and in game.
     halfPixelOffset: 2 # Fixes erroneous line in menus.
+    PCRTCOverscan: 1 # Fixes offscreen image.
   memcardFilters: # Allows import of characters from first game.
     - "SLES-53039"
     - "SLES-52325"


### PR DESCRIPTION
### Description of Changes
Add Half Pixel Offset Special (Texture) and Round Sprite Half to _Champions of Norrath_.
Add Show Overscan to _Champions of Norrath_ and _Champions: Return to Arms_.

### Rationale behind Changes
Fix edge garbage (visible on the left half of the bottom of the screen, most noticeable when braziers, torches, etc. are at the top of the screen) and UI seams (most visible around button prompts and skill tree) in _Champions of Norrath_. Same fixes are already applied to _Champions: Return to Arms_.

Fix offscreen image in _Champions of Norrath_ and _Champions: Return to Arms_. Reveals ~6 lines (at native resolution) that were pushed off the top of the screen, removing a black bar at the bottom. These games lack a screen position setting.

_Champions of Norrath_ Gameplay - Master
![CoN-gameplay-master](https://github.com/user-attachments/assets/206b8d8f-0600-42c5-afcd-4bdd1785ad5a)

_Champions of Norrath_ Gameplay - PR
![CoN-gameplay-PR](https://github.com/user-attachments/assets/648e3cb8-23d8-41de-9d44-3ed749a4d5c6)

_Champions of Norrath_ UI - Master
![CoN-UI-master](https://github.com/user-attachments/assets/53e9bc89-734c-498d-98dd-8aeac0666941)

_Champions of Norrath_ UI - PR
![CoN-UI-PR](https://github.com/user-attachments/assets/dcc5401b-a9d1-4875-9a1c-e13691e25371)

_Champions: Return to Arms_ - Master
![RTA-master](https://github.com/user-attachments/assets/320eff0a-ddcb-48d4-b541-c13423c516f4)

_Champions: Return to Arms_ - PR
![RTA-PR](https://github.com/user-attachments/assets/bf687149-4472-4601-b373-4ea0e3c82e76)


### Suggested Testing Steps
Check CI.
