### PR TITLE
OSD: Fix Pause indicator not showing up

### DIFF
--- a/pcsx2/ImGui/ImGuiOverlays.cpp
+++ b/pcsx2/ImGui/ImGuiOverlays.cpp
@@ -1133,9 +1133,6 @@ void SaveStateSelectorUI::ShowSlotOSDMessage()
 
 void ImGuiManager::RenderOverlays()
 {
-	if (VMManager::GetState() != VMState::Running)
-		return;
-
 	const float scale = ImGuiManager::GetGlobalScale();
 	const float margin = std::ceil(10.0f * scale);
 	const float spacing = std::ceil(5.0f * scale);


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Fixes #11981 

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Actually shows shows when we are paused.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Make sure i didn't break anything else (for real this time).