### PR TITLE
USB: Further troubleshooting of FFB "loss of detail" issues

### DIFF
--- a/pcsx2/USB/usb-pad/usb-pad-sdl-ff.h
+++ b/pcsx2/USB/usb-pad/usb-pad-sdl-ff.h
@@ -5,6 +5,51 @@
 
 #include "USB/usb-pad/usb-pad.h"
 #include "Input/SDLInputSource.h"
+#ifdef __WIN32__
+#include <sdl_haptic.h>
+#include <dinput.h>
+#endif
+
+#ifdef __WIN32__
+// Copied some internal structure definitions from SDL's source
+// in order to scoop out their inner bits that are excluded from
+// public-facing headers.
+
+// It's ugly, but it works for the purposes of this hack/PoC
+
+struct haptic_hweffect
+{
+	DIEFFECT effect;
+	LPDIRECTINPUTEFFECT ref;
+};
+
+struct haptic_effect
+{
+	SDL_HapticEffect effect; // The current event
+	struct haptic_hweffect* hweffect; // The hardware behind the event
+};
+
+struct _SDL_Haptic
+{
+	Uint8 index; /* Stores index it is attached to */
+
+	struct haptic_effect* effects; /* Allocated effects */
+	int neffects; /* Maximum amount of effects */
+	int nplaying; /* Maximum amount of effects to play at the same time */
+	unsigned int supported; /* Supported effects */
+	int naxes; /* Number of axes on the device. */
+
+	struct haptic_hwdata* hwdata; /* Driver dependent */
+	int ref_count; /* Count for multiple opens */
+
+	int rumble_id; /* ID of rumble effect for simple rumble API. */
+	SDL_HapticEffect rumble_effect; /* Rumble effect. */
+	struct _SDL_Haptic* next; /* pointer to next haptic we have allocated */
+};
+
+#endif
+
+
 
 namespace usb_pad
 {

--- a/pcsx2/USB/usb-pad/usb-pad.cpp
+++ b/pcsx2/USB/usb-pad/usb-pad.cpp
@@ -166,6 +166,9 @@ namespace usb_pad
 					"Off", nullptr, nullptr, nullptr, nullptr, SteeringCurveExponentOptions},
 				{SettingInfo::Type::Boolean, "FfbDropoutWorkaround", TRANSLATE_NOOP("USB", "Workaround for Intermittent FFB Loss"),
 					TRANSLATE_NOOP("USB", "Works around bugs in some wheels' firmware that result in brief interruptions in force. Leave this disabled unless you need it, as it has negative side effects on many wheels."),
+					"false"},
+				{SettingInfo::Type::Boolean, "FfbDirectInputHack", TRANSLATE_NOOP("USB", "HACK: Bypass SDL for FFB updates on Windows"),
+					TRANSLATE_NOOP("USB", "Forgive me, SDL. It's not you, it's me. (It's you). Has no effect on non-Windows platforms."),
 					"false"}
 			};
 
@@ -233,6 +236,11 @@ namespace usb_pad
 			{
 				const bool use_ffb_dropout_workaround = USB::GetConfigBool(si, port, devname, "FfbDropoutWorkaround", false);
 				mFFdev->use_ffb_dropout_workaround = use_ffb_dropout_workaround;
+			}
+			if (mFFdev != NULL)
+			{
+				const bool bypass_sdl_when_updating = USB::GetConfigBool(si, port, devname, "FfbDirectInputHack", false);
+				mFFdev->bypass_sdl_when_updating = bypass_sdl_when_updating;
 			}
 		}
 	}

--- a/pcsx2/USB/usb-pad/usb-pad.h
+++ b/pcsx2/USB/usb-pad/usb-pad.h
@@ -289,6 +289,7 @@ namespace usb_pad
 		virtual void DisableForce(EffectID force) = 0;
 
 		bool use_ffb_dropout_workaround = false;
+		bool bypass_sdl_when_updating = false;
 	};
 
 	struct PadState


### PR DESCRIPTION
## Due to changing life circumstances I won't be able to continue work on FFB for a while, so I'm putting this draft PR up to help other maintainers that might want to pick this up.

### Description of Changes
SDL adds some unnecessary flags to DirectInput SetParameters calls, which causes unnecessary HID reports to be sent over the wire to the FFB device. This may be the cause of complaints about a loss of definition/detail compared to the old WXWidgets USB plugin. This draft PR offers a hack that should make it easier for affected users to test whether this is the cause.

### Rationale behind Changes
- Prevents unnecessary HID reports from being sent over the wire. These unnecessary reports could be causing wheels to repeatedly re-initialize the force ID that they're using as a constant force, which could be what's causing the loss of definition.
- This is the only other thing that current PCSX2 does differently than the old WXWidgets USB plugin, which directly used DirectInput.
- I tested the WX build alongside USBPcap in order to confirm that this hack makes the behavior of the two identical over the wire

### Suggested Testing Steps
- Windows is required
- Any FFB game that predominantly relies on constant forces (GT4 is the only game I have to test with)
- Toggle it on and off and see if you can feel a difference (the setting will update immediately after checking/unchecking)
- Use wireshark with usbpcap to confirm that redundant HID reports are no longer being sent

Take a look at this screenshot, and I'll give some context:

- The USB PID ("physical interface device" or something) spec is really similar to the semantics of DirectInput in a lot of ways. Forces are created as individual objects with a type (constant, spring, etc), then following commands need to reference the ID of that force in order to update/set its data.
- Report ID 0x01 updates a force's generic data (anything that is common among all force types)
- Report ID 0x05 updates a constant force's magnitude (there is a different report id for each force type's type-specific data)
- See more of the spec here: https://www.usb.org/sites/default/files/documents/pid1_01.pdf
- The redundant sending of 0x01 with each force update might be causing some wheels to lose "detail" in the force. Possibly some reinitialization? Either way, **commercial PC titles don't redundantly send report ID 0x01** the way that PCSX2 is (I'm not aware of any commercial titles that use SDL for force feedback wheels, they either use DirectInput or they send the raw HID reports directly via their own implementation)

This is a screenshot from quickly toggling this hack off and on in Gran Turismo 4, a game which primarily relies on constant forces for its FFB effects. 
![usbpcap-ffb](https://github.com/user-attachments/assets/331008a3-0acc-497f-aca1-a07e56cb694d)

# IMPORTANT: The hack is off by default. You'll need to toggle it on when testing: 
![image](https://github.com/user-attachments/assets/18fdc8f9-eb1b-4e7b-a481-5d64d67e1646)


