### PR TITLE
Debugger: Fix loading symbols from ELF files other than the boot ELF 

### DIFF
--- a/pcsx2/DebugTools/SymbolImporter.cpp
+++ b/pcsx2/DebugTools/SymbolImporter.cpp
@@ -356,7 +356,7 @@ void SymbolImporter::ImportSymbols(
 			continue;
 		}
 
-		ccc::Result<std::vector<std::unique_ptr<ccc::SymbolTable>>> symbol_tables = elf.get_all_symbol_tables();
+		ccc::Result<std::vector<std::unique_ptr<ccc::SymbolTable>>> symbol_tables = (*symbol_file)->get_all_symbol_tables();
 		if (!symbol_tables.success())
 		{
 			ccc::report_error(symbol_tables.error());


### PR DESCRIPTION
### Description of Changes
This fixes an unfortunate typo in SymbolImporter.cpp. Previously, instead of loading symbol from the file specified it would just try to load symbols from the boot ELF again.

### Rationale behind Changes
- This fixes loading extra ELF files.

### Suggested Testing Steps
Test that loading extra ELF files in the debug analysis settings dialog works.
