### PR TITLE
Misc: Minimise the amount of work done when svnrev.h is updated

### DIFF
--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -19,7 +19,6 @@
 #include "Settings/MemoryCardCreateDialog.h"
 #include "Tools/InputRecording/InputRecordingViewer.h"
 #include "Tools/InputRecording/NewInputRecordingDlg.h"
-#include "svnrev.h"
 
 #include "pcsx2/Achievements.h"
 #include "pcsx2/CDVD/CDVDcommon.h"

--- a/pcsx2-qt/QtHost.cpp
+++ b/pcsx2-qt/QtHost.cpp
@@ -10,10 +10,10 @@
 #include "QtProgressCallback.h"
 #include "QtUtils.h"
 #include "SetupWizardDialog.h"
-#include "svnrev.h"
 
 #include "pcsx2/CDVD/CDVDcommon.h"
 #include "pcsx2/Achievements.h"
+#include "pcsx2/BuildVersion.h"
 #include "pcsx2/CDVD/CDVD.h"
 #include "pcsx2/Counters.h"
 #include "pcsx2/DebugTools/Debug.h"
@@ -1468,7 +1468,7 @@ bool Host::RequestResetSettings(bool folders, bool core, bool controllers, bool 
 
 QString QtHost::GetAppNameAndVersion()
 {
-	return QStringLiteral("PCSX2 " GIT_REV);
+	return QString("PCSX2 %1").arg(BuildVersion::GitRev);
 }
 
 QString QtHost::GetAppConfigSuffix()

--- a/pcsx2/Achievements.cpp
+++ b/pcsx2/Achievements.cpp
@@ -4,6 +4,7 @@
 #define IMGUI_DEFINE_MATH_OPERATORS
 
 #include "Achievements.h"
+#include "BuildVersion.h"
 #include "CDVD/CDVD.h"
 #include "Elfheader.h"
 #include "Host.h"
@@ -16,7 +17,6 @@
 #include "Memory.h"
 #include "SaveState.h"
 #include "VMManager.h"
-#include "svnrev.h"
 #include "vtlb.h"
 
 #include "common/Assertions.h"
@@ -3039,7 +3039,7 @@ void Achievements::SwitchToRAIntegration()
 
 void Achievements::RAIntegration::InitializeRAIntegration(void* main_window_handle)
 {
-	RA_InitClient((HWND)main_window_handle, "PCSX2", GIT_TAG);
+	RA_InitClient((HWND)main_window_handle, "PCSX2", BuildVersion::GitTag);
 	RA_SetUserAgentDetail(Host::GetHTTPUserAgent().c_str());
 
 	RA_InstallSharedFunctions(RACallbackIsActive, RACallbackCauseUnpause, RACallbackCausePause, RACallbackRebuildMenu,

--- a/pcsx2/BuildVersion.cpp
+++ b/pcsx2/BuildVersion.cpp
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: 2002-2024 PCSX2 Dev Team
+// SPDX-License-Identifier: GPL-3.0+
+
+#include "svnrev.h"
+
+namespace BuildVersion
+{
+	const char* GitTag = GIT_TAG;
+	bool GitTaggedCommit = GIT_TAGGED_COMMIT;
+	int GitTagHi = GIT_TAG_HI;
+	int GitTagMid = GIT_TAG_MID;
+	int GitTagLo = GIT_TAG_LO;
+	const char* GitRev = GIT_REV;
+	const char* GitHash = GIT_HASH;
+	const char* GitDate = GIT_DATE;
+} // namespace BuildVersion

--- a/pcsx2/BuildVersion.h
+++ b/pcsx2/BuildVersion.h
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2002-2024 PCSX2 Dev Team
+// SPDX-License-Identifier: GPL-3.0+
+
+#pragma once
+
+// This file provides the same information as svnrev.h except you don't need to
+// recompile each object file using it when said information is updated.
+namespace BuildVersion
+{
+	extern const char* GitTag;
+	extern bool GitTaggedCommit;
+	extern int GitTagHi;
+	extern int GitTagMid;
+	extern int GitTagLo;
+	extern const char* GitRev;
+	extern const char* GitHash;
+	extern const char* GitDate;
+} // namespace BuildVersion

--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -54,6 +54,7 @@ endif(WIN32)
 # Main pcsx2 source
 set(pcsx2Sources
 	Achievements.cpp
+	BuildVersion.cpp
 	Cache.cpp
 	COP0.cpp
 	COP2.cpp
@@ -140,6 +141,7 @@ set(pcsx2Sources
 # Main pcsx2 header
 set(pcsx2Headers
 	Achievements.h
+	BuildVersion.h
 	Cache.h
 	Common.h
 	Config.h

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
@@ -10,6 +10,7 @@
 #include "GS/Renderers/Vulkan/VKShaderCache.h"
 #include "GS/Renderers/Vulkan/VKSwapChain.h"
 
+#include "BuildVersion.h"
 #include "Host.h"
 
 #include "common/Console.h"
@@ -103,16 +104,15 @@ VkInstance GSDeviceVK::CreateVulkanInstance(const WindowInfo& wi, OptionalExtens
 	if (!SelectInstanceExtensions(&enabled_extensions, wi, oe, enable_debug_utils))
 		return VK_NULL_HANDLE;
 
-	// Remember to manually update this every release. We don't pull in svnrev.h here, because
-	// it's only the major/minor version, and rebuilding the file every time something else changes
-	// is unnecessary.
 	VkApplicationInfo app_info = {};
 	app_info.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO;
 	app_info.pNext = nullptr;
 	app_info.pApplicationName = "PCSX2";
-	app_info.applicationVersion = VK_MAKE_VERSION(1, 7, 0);
+	app_info.applicationVersion = VK_MAKE_VERSION(
+		BuildVersion::GitTagHi, BuildVersion::GitTagMid, BuildVersion::GitTagLo);
 	app_info.pEngineName = "PCSX2";
-	app_info.engineVersion = VK_MAKE_VERSION(1, 7, 0);
+	app_info.engineVersion = VK_MAKE_VERSION(
+		BuildVersion::GitTagHi, BuildVersion::GitTagMid, BuildVersion::GitTagLo);
 	app_info.apiVersion = VK_API_VERSION_1_1;
 
 	VkInstanceCreateInfo instance_create_info = {};

--- a/pcsx2/Host.cpp
+++ b/pcsx2/Host.cpp
@@ -1,12 +1,12 @@
 // SPDX-FileCopyrightText: 2002-2024 PCSX2 Dev Team
 // SPDX-License-Identifier: GPL-3.0+
 
+#include "BuildVersion.h"
 #include "GS.h"
 #include "GS/Renderers/HW/GSTextureReplacements.h"
 #include "Host.h"
 #include "LayeredSettingsInterface.h"
 #include "VMManager.h"
-#include "svnrev.h"
 
 #include "common/Assertions.h"
 #include "common/CrashHandler.h"
@@ -159,7 +159,7 @@ bool Host::ConfirmFormattedMessage(const std::string_view title, const char* for
 
 std::string Host::GetHTTPUserAgent()
 {
-	return fmt::format("PCSX2 " GIT_REV " ({})", GetOSVersionString());
+	return fmt::format("PCSX2 {} ({})", BuildVersion::GitRev, GetOSVersionString());
 }
 
 std::unique_lock<std::mutex> Host::GetSettingsLock()

--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -3,6 +3,7 @@
 
 #define IMGUI_DEFINE_MATH_OPERATORS
 
+#include "BuildVersion.h"
 #include "CDVD/CDVDcommon.h"
 #include "GS/Renderers/Common/GSDevice.h"
 #include "GS/Renderers/Common/GSTexture.h"
@@ -23,7 +24,6 @@
 #include "USB/USB.h"
 #include "VMManager.h"
 #include "ps2/BiosTools.h"
-#include "svnrev.h"
 
 #include "common/Console.h"
 #include "common/Error.h"
@@ -6633,7 +6633,7 @@ void FullscreenUI::DrawAboutWindow()
 									 "This allows you to play PS2 games on your PC, with many additional features and benefits."));
 		ImGui::NewLine();
 
-		ImGui::TextWrapped(FSUI_CSTR("Version: %s"), GIT_REV);
+		ImGui::TextWrapped(FSUI_CSTR("Version: %s"), BuildVersion::GitRev);
 		ImGui::NewLine();
 
 		ImGui::TextWrapped("%s",

--- a/pcsx2/ImGui/ImGuiOverlays.cpp
+++ b/pcsx2/ImGui/ImGuiOverlays.cpp
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2002-2024 PCSX2 Dev Team
 // SPDX-License-Identifier: GPL-3.0+
 
+#include "BuildVersion.h"
 #include "Config.h"
 #include "Counters.h"
 #include "GS.h"
@@ -24,7 +25,6 @@
 #include "SIO/Pad/PadBase.h"
 #include "USB/USB.h"
 #include "VMManager.h"
-#include "svnrev.h"
 #include "cpuinfo.h"
 
 #include "common/BitUtils.h"
@@ -170,7 +170,7 @@ __ri void ImGuiManager::DrawPerformanceOverlay(float& position_y, float scale, f
 
 		if (GSConfig.OsdShowVersion)
 		{
-			text.append_format("{}PCSX2 {}", first ? "" : " | ", GIT_REV);
+			text.append_format("{}PCSX2 {}", first ? "" : " | ", BuildVersion::GitRev);
 		}
 
 		if (!text.empty())

--- a/pcsx2/PINE.cpp
+++ b/pcsx2/PINE.cpp
@@ -1,13 +1,13 @@
 // SPDX-FileCopyrightText: 2002-2024 PCSX2 Dev Team
 // SPDX-License-Identifier: GPL-3.0+
 
+#include "BuildVersion.h"
 #include "Common.h"
 #include "Host.h"
 #include "Memory.h"
 #include "Elfheader.h"
 #include "PINE.h"
 #include "VMManager.h"
-#include "svnrev.h"
 
 #include <atomic>
 #include <cstdio>
@@ -607,14 +607,12 @@ PINEServer::IPCBuffer PINEServer::ParseCommand(std::span<u8> buf, std::vector<u8
 			{
 				if (!VMManager::HasValidVM())
 					goto error;
-
-				static constexpr const char* version = "PCSX2 " GIT_REV;
-				static constexpr u32 size = sizeof(version) + 1;
+				u32 size = strlen(BuildVersion::GitRev) + 7;
 				if (!SafetyChecks(buf_cnt, 0, ret_cnt, size + 4, buf_size)) [[unlikely]]
 					goto error;
 				ToResultVector(ret_buffer, size, ret_cnt);
 				ret_cnt += 4;
-				memcpy(&ret_buffer[ret_cnt], version, size);
+				snprintf(reinterpret_cast<char*>(&ret_buffer[ret_cnt]), size, "PCSX2 %s", BuildVersion::GitRev);
 				ret_cnt += size;
 				break;
 			}

--- a/pcsx2/Recording/InputRecordingFile.cpp
+++ b/pcsx2/Recording/InputRecordingFile.cpp
@@ -3,13 +3,10 @@
 
 #include "InputRecordingFile.h"
 
+#include "BuildVersion.h"
 #include "Utilities/InputRecordingLogger.h"
 
 #include "common/FileSystem.h"
-#include "common/StringUtil.h"
-#include "DebugTools/Debug.h"
-#include "MemoryTypes.h"
-#include "svnrev.h"
 
 #include <fmt/format.h>
 
@@ -23,7 +20,7 @@ void InputRecordingFile::InputRecordingFileHeader::init() noexcept
 
 void InputRecordingFile::setEmulatorVersion()
 {
-	StringUtil::Strlcpy(m_header.m_emulatorVersion, "PCSX2-" GIT_REV, sizeof(m_header.m_emulatorVersion));
+	snprintf(m_header.m_emulatorVersion, sizeof(m_header.m_emulatorVersion), "PCSX2-%s", BuildVersion::GitRev);
 }
 
 void InputRecordingFile::setAuthor(const std::string& _author)

--- a/pcsx2/SIO/Memcard/MemoryCardFile.cpp
+++ b/pcsx2/SIO/Memcard/MemoryCardFile.cpp
@@ -20,8 +20,6 @@
 #include "Host.h"
 #include "IconsPromptFont.h"
 
-#include "svnrev.h"
-
 #include "fmt/core.h"
 
 #include <map>

--- a/pcsx2/SIO/Memcard/MemoryCardFolder.cpp
+++ b/pcsx2/SIO/Memcard/MemoryCardFolder.cpp
@@ -21,8 +21,6 @@
 #include "ryml_std.hpp"
 #include "ryml.hpp"
 
-#include "svnrev.h"
-
 #include <sstream>
 #include <mutex>
 #include <optional>

--- a/pcsx2/SaveState.cpp
+++ b/pcsx2/SaveState.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0+
 
 #include "Achievements.h"
+#include "BuildVersion.h"
 #include "CDVD/CDVD.h"
 #include "COP0.h"
 #include "Cache.h"
@@ -27,7 +28,6 @@
 #include "VMManager.h"
 #include "VUmicro.h"
 #include "ps2/BiosTools.h"
-#include "svnrev.h"
 
 #include "common/Error.h"
 #include "common/FileSystem.h"
@@ -972,11 +972,14 @@ static bool SaveState_AddToZip(zip_t* zf, ArchiveEntryList* srclist, SaveStateSc
 
 		VersionIndicator* vi = static_cast<VersionIndicator*>(std::malloc(sizeof(VersionIndicator)));
 		vi->save_version = g_SaveVersion;
-#if GIT_TAGGED_COMMIT
-		StringUtil::Strlcpy(vi->version, GIT_TAG, std::size(vi->version));
-#else
-		StringUtil::Strlcpy(vi->version, "Unknown", std::size(vi->version));
-#endif
+		if (BuildVersion::GitTaggedCommit)
+		{
+			StringUtil::Strlcpy(vi->version, BuildVersion::GitTag, std::size(vi->version));
+		}
+		else
+		{
+			StringUtil::Strlcpy(vi->version, "Unknown", std::size(vi->version));
+		}
 
 		zip_source_t* const zs = zip_source_buffer(zf, vi, sizeof(*vi), 1);
 		if (!zs)

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0+
 
 #include "Achievements.h"
+#include "BuildVersion.h"
 #include "CDVD/CDVD.h"
 #include "CDVD/IsoReader.h"
 #include "Counters.h"
@@ -40,7 +41,6 @@
 #include "Vif_Dynarec.h"
 #include "VMManager.h"
 #include "ps2/BiosTools.h"
-#include "svnrev.h"
 
 #include "common/Console.h"
 #include "common/Error.h"
@@ -2490,7 +2490,7 @@ void LogGPUCapabilities()
 
 void VMManager::LogCPUCapabilities()
 {
-	Console.WriteLn(Color_StrongGreen, "PCSX2 " GIT_REV);
+	Console.WriteLn(Color_StrongGreen, "PCSX2 %s", BuildVersion::GitRev);
 	Console.WriteLnFmt("Savestate version: 0x{:x}\n", g_SaveVersion);
 	Console.WriteLn();
 

--- a/pcsx2/pcsx2.vcxproj
+++ b/pcsx2/pcsx2.vcxproj
@@ -419,6 +419,7 @@
       <ExcludedFromBuild Condition="'$(Platform)'!='x64'">true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="ps2\BiosTools.cpp" />
+    <ClCompile Include="BuildVersion.cpp" />
     <ClCompile Include="Counters.cpp" />
     <ClCompile Include="FiFo.cpp" />
     <ClCompile Include="Hw.cpp" />
@@ -865,6 +866,7 @@
     <ClInclude Include="Elfheader.h" />
     <ClInclude Include="CDVD\IsoFileFormats.h" />
     <ClInclude Include="resource.h" />
+    <ClInclude Include="BuildVersion.h" />
     <ClInclude Include="Common.h" />
     <ClInclude Include="Config.h" />
     <ClInclude Include="SaveState.h" />

--- a/pcsx2/pcsx2.vcxproj.filters
+++ b/pcsx2/pcsx2.vcxproj.filters
@@ -1292,6 +1292,9 @@
     <ClCompile Include="Pcsx2Config.cpp">
       <Filter>Misc</Filter>
     </ClCompile>
+    <ClCompile Include="BuildVersion.cpp">
+      <Filter>Misc</Filter>
+    </ClCompile>
     <ClCompile Include="Counters.cpp">
       <Filter>System\Ps2\EmotionEngine\Hardware</Filter>
     </ClCompile>
@@ -2243,6 +2246,9 @@
     </ClInclude>
     <ClInclude Include="ps2\pgif.h">
       <Filter>System\Ps2\Iop</Filter>
+    </ClInclude>
+    <ClInclude Include="BuildVersion.h">
+      <Filter>Misc</Filter>
     </ClInclude>
     <ClInclude Include="Counters.h">
       <Filter>System\Ps2\EmotionEngine\Hardware</Filter>


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->

I have created a new pair of files for retrieving version information: `BuildVersion.h` and `BuildVersion.cpp`. They provide exactly the same information as `svnrev.h` but they don't force a recompile for all translation units using them every time cmake configure is run.

Most systems that used `svnrev.h` directly have been ported to use this new wrapper instead. The most notable changes are in the auto updater since it previously relied on a lot of preprocessor logic.

The only place `svnrev.h` is used directly is now the Windows resource files.

![buildversion](https://github.com/user-attachments/assets/9acafe1d-b9ad-4c41-9220-6357a9d6398e)

### Rationale behind Changes
- Don't recompile a bunch of files unnecessarily whenever cmake configure is run.
- No more `// Remember to manually update this every release.` shenanigans (see GSDeviceVK.cpp).
- Minimal changes made to the existing build systems.
- Get our money's worth out of our linkers.

### Suggested Testing Steps
The systems that have been touched are:
- The Qt GUI (version displayed).
- The auto updater (preprocessor conditionals replaced with runtime logic).
- The achievement system (version reported to RetroAchievements library).
- The Vulkan renderer (version reported via the Vulkan API).
- Networking code (the HTTP user agent).
- Fullscreen UI (version displayed).
- PINE (version reported via MsgVersion).
- Input recording (version stored in the file header).
- The save state system (version stored in save states).
- Log output (PCSX2 version number).

Ideally there should be no differences in functionality or output for any of these systems.