### PR TITLE
DEV9: Support NdisMediumIP/DLT_RAW adapters with pcap

### DIFF
--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -286,6 +286,7 @@ set(pcsx2DEV9Sources
 	DEV9/ATA/ATA_State.cpp
 	DEV9/ATA/ATA_Transfer.cpp
 	DEV9/ATA/HddCreate.cpp
+	DEV9/InternalServers/ARP_Logger.cpp
 	DEV9/InternalServers/DHCP_Logger.cpp
 	DEV9/InternalServers/DHCP_Server.cpp
 	DEV9/InternalServers/DNS_Logger.cpp
@@ -325,6 +326,7 @@ set(pcsx2DEV9Headers
 	DEV9/ATA/ATA.h
 	DEV9/ATA/HddCreate.h
 	DEV9/DEV9.h
+	DEV9/InternalServers/ARP_Logger.h
 	DEV9/InternalServers/DHCP_Logger.h
 	DEV9/InternalServers/DHCP_Server.h
 	DEV9/InternalServers/DNS_Logger.h

--- a/pcsx2/DEV9/AdapterUtils.cpp
+++ b/pcsx2/DEV9/AdapterUtils.cpp
@@ -384,7 +384,8 @@ std::vector<IP_Address> AdapterUtils::GetGateways(const Adapter* adapter)
 		if (ReadAddressFamily(address->Address.lpSockaddr) == AF_INET)
 		{
 			const sockaddr_in* sockaddr = reinterpret_cast<sockaddr_in*>(address->Address.lpSockaddr);
-			collection.push_back(std::bit_cast<IP_Address>(sockaddr->sin_addr));
+			if (sockaddr->sin_addr.S_un.S_addr != 0)
+				collection.push_back(std::bit_cast<IP_Address>(sockaddr->sin_addr));
 		}
 		address = address->Next;
 	}

--- a/pcsx2/DEV9/InternalServers/ARP_Logger.cpp
+++ b/pcsx2/DEV9/InternalServers/ARP_Logger.cpp
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: 2002-2024 PCSX2 Dev Team
+// SPDX-License-Identifier: GPL-3.0+
+
+#include "ARP_Logger.h"
+#include "DEV9/PacketReader/EthernetFrame.h"
+
+#include "common/Console.h"
+
+using namespace PacketReader;
+using namespace PacketReader::ARP;
+
+namespace InternalServers
+{
+	void ARP_Logger::InspectRecv(Payload* payload)
+	{
+		ARP_Packet* arp = static_cast<ARP_Packet*>(payload);
+		LogPacket(arp);
+	}
+
+	void ARP_Logger::InspectSend(Payload* payload)
+	{
+		ARP_Packet* arp = static_cast<ARP_Packet*>(payload);
+		LogPacket(arp);
+	}
+
+	std::string ARP_Logger::ArrayToString(const std::unique_ptr<u8[]>& data, int length)
+	{
+		std::string str;
+		if (length != 0)
+		{
+			str.reserve(length * 4);
+			for (size_t i = 0; i < length; i++)
+				str += std::to_string(data[i]) + ":";
+
+			str.pop_back();
+		} //else leave string empty
+
+		return str;
+	}
+
+	const char* ARP_Logger::HardwareTypeToString(u8 op)
+	{
+		switch (op)
+		{
+			case 1:
+				return "Ethernet";
+			case 6:
+				return "IEEE 802";
+			default:
+				return "Unknown";
+		}
+	}
+
+	const char* ARP_Logger::ProtocolToString(u16 protocol)
+	{
+		switch (protocol)
+		{
+			case static_cast<u16>(EtherType::IPv4):
+				return "IPv4";
+			case static_cast<u16>(EtherType::ARP):
+				return "ARP";
+			default:
+				return "Unknown";
+		}
+	}
+
+	const char* ARP_Logger::OperationToString(u16 op)
+	{
+		switch (op)
+		{
+			case 1:
+				return "Request";
+			case 2:
+				return "Reply";
+			default:
+				return "Unknown";
+		}
+	}
+
+	void ARP_Logger::LogPacket(ARP_Packet* arp)
+	{
+		Console.WriteLn("DEV9: ARP: Hardware Type %s (%i)", HardwareTypeToString(arp->hardwareType), arp->hardwareType);
+		Console.WriteLn("DEV9: ARP: Protocol %s (%i)", ProtocolToString(arp->protocol), arp->protocol);
+		Console.WriteLn("DEV9: ARP: Operation %s (%i)", OperationToString(arp->op), arp->op);
+		Console.WriteLn("DEV9: ARP: Hardware Length %i", arp->hardwareAddressLength);
+		Console.WriteLn("DEV9: ARP: Protocol Length %i", arp->protocolAddressLength);
+		Console.WriteLn("DEV9: ARP: Sender Hardware Address %s", ArrayToString(arp->senderHardwareAddress, arp->hardwareAddressLength).c_str());
+		Console.WriteLn("DEV9: ARP: Sender Protocol Address %s", ArrayToString(arp->senderProtocolAddress, arp->protocolAddressLength).c_str());
+		Console.WriteLn("DEV9: ARP: Target Hardware Address %s", ArrayToString(arp->targetHardwareAddress, arp->hardwareAddressLength).c_str());
+		Console.WriteLn("DEV9: ARP: Target Protocol Address %s", ArrayToString(arp->targetProtocolAddress, arp->protocolAddressLength).c_str());
+	}
+} // namespace InternalServers

--- a/pcsx2/DEV9/InternalServers/ARP_Logger.h
+++ b/pcsx2/DEV9/InternalServers/ARP_Logger.h
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2002-2024 PCSX2 Dev Team
+// SPDX-License-Identifier: GPL-3.0+
+
+#pragma once
+#include "DEV9/PacketReader/Payload.h"
+#include "DEV9/PacketReader/ARP/ARP_Packet.h"
+
+namespace InternalServers
+{
+	class ARP_Logger
+	{
+	public:
+		ARP_Logger(){};
+
+		//Expects a ARP_payload
+		void InspectRecv(PacketReader::Payload* payload);
+		//Expects a ARP_payload
+		void InspectSend(PacketReader::Payload* payload);
+
+	private:
+		std::string ArrayToString(const std::unique_ptr<u8[]>& data, int length);
+		const char* HardwareTypeToString(u8 op); // Same as DHCP
+		const char* ProtocolToString(u16 protocol);
+		const char* OperationToString(u16 op);
+		void LogPacket(PacketReader::ARP::ARP_Packet* payload);
+	};
+} // namespace InternalServers

--- a/pcsx2/DEV9/InternalServers/DHCP_Server.h
+++ b/pcsx2/DEV9/InternalServers/DHCP_Server.h
@@ -24,8 +24,8 @@ namespace InternalServers
 	{
 	public:
 		PacketReader::IP::IP_Address ps2IP;
-		PacketReader::IP::IP_Address gateway;
-		PacketReader::IP::IP_Address broadcastIP;
+		PacketReader::IP::IP_Address gateway{};
+		PacketReader::IP::IP_Address broadcastIP{};
 
 	private:
 		std::function<void()> callback;

--- a/pcsx2/DEV9/PacketReader/IP/IP_Address.h
+++ b/pcsx2/DEV9/PacketReader/IP/IP_Address.h
@@ -17,5 +17,30 @@ namespace PacketReader::IP
 
 		bool operator==(const IP_Address& other) const { return this->integer == other.integer; }
 		bool operator!=(const IP_Address& other) const { return this->integer != other.integer; }
+
+		IP_Address operator~() const
+		{
+			IP_Address ret;
+			ret.integer = ~this->integer;
+			return ret;
+		}
+		IP_Address operator&(const IP_Address& other) const 
+		{
+			IP_Address ret;
+			ret.integer = this->integer & other.integer;
+			return ret; 
+		}
+		IP_Address operator|(const IP_Address& other) const
+		{
+			IP_Address ret;
+			ret.integer = this->integer | other.integer;
+			return ret;
+		}
+		IP_Address operator^(const IP_Address& other) const
+		{
+			IP_Address ret;
+			ret.integer = this->integer ^ other.integer;
+			return ret;
+		}
 	};
 } // namespace PacketReader::IP

--- a/pcsx2/DEV9/Win32/pcap_io_win32.cpp
+++ b/pcsx2/DEV9/Win32/pcap_io_win32.cpp
@@ -100,7 +100,7 @@ bool load_pcap()
 	if (fp_##name == nullptr)                                \
 	{                                                        \
 		FreeLibrary(hpcap);                                  \
-		Console.Error("DEV9: %s not found", #name);          \
+		Console.Error("DEV9: PCAP: %s not found", #name);    \
 		hpcap = nullptr;                                     \
 		return false;                                        \
 	}

--- a/pcsx2/DEV9/net.cpp
+++ b/pcsx2/DEV9/net.cpp
@@ -17,6 +17,7 @@
 #include "sockets.h"
 
 #include "PacketReader/EthernetFrame.h"
+#include "PacketReader/ARP/ARP_Packet.h"
 #include "PacketReader/IP/IP_Packet.h"
 #include "PacketReader/IP/UDP/UDP_Packet.h"
 
@@ -160,6 +161,7 @@ void TermNet()
 }
 
 using namespace PacketReader;
+using namespace PacketReader::ARP;
 using namespace PacketReader::IP;
 using namespace PacketReader::IP::UDP;
 
@@ -233,6 +235,13 @@ void NetAdapter::InspectSend(NetPacket* pkt)
 				}
 			}
 		}
+		if (frame.protocol == static_cast<u16>(EtherType::ARP))
+		{
+			Console.WriteLn("DEV9: ARP: Packet Sent");
+			PayloadPtr* payload = static_cast<PayloadPtr*>(frame.GetPayload());
+			ARP_Packet arppkt(payload->data, payload->GetLength());
+			arpLogger.InspectSend(&arppkt);
+		}
 	}
 }
 void NetAdapter::InspectRecv(NetPacket* pkt)
@@ -264,6 +273,13 @@ void NetAdapter::InspectRecv(NetPacket* pkt)
 					dhcpLogger.InspectRecv(&udppkt);
 				}
 			}
+		}
+		if (frame.protocol == static_cast<u16>(EtherType::ARP))
+		{
+			Console.WriteLn("DEV9: ARP: Packet Received");
+			PayloadPtr* payload = static_cast<PayloadPtr*>(frame.GetPayload());
+			ARP_Packet arppkt(payload->data, payload->GetLength());
+			arpLogger.InspectRecv(&arppkt);
 		}
 	}
 }

--- a/pcsx2/DEV9/net.h
+++ b/pcsx2/DEV9/net.h
@@ -24,6 +24,7 @@
 
 #include "PacketReader/MAC_Address.h"
 #include "PacketReader/IP/IP_Address.h"
+#include "InternalServers/ARP_Logger.h"
 #include "InternalServers/DHCP_Logger.h"
 #include "InternalServers/DHCP_Server.h"
 #include "InternalServers/DNS_Logger.h"
@@ -100,6 +101,7 @@ private:
 	bool dhcpOn = false;
 
 protected:
+	InternalServers::ARP_Logger arpLogger;
 	InternalServers::DHCP_Logger dhcpLogger;
 	InternalServers::DHCP_Server dhcpServer = InternalServers::DHCP_Server([&] { InternalSignalReceived(); });
 	InternalServers::DNS_Logger dnsLogger;

--- a/pcsx2/DEV9/pcap_io.cpp
+++ b/pcsx2/DEV9/pcap_io.cpp
@@ -17,8 +17,8 @@
 #include "DEV9.h"
 #include "AdapterUtils.h"
 #include "net.h"
-#include "PacketReader/EthernetFrame.h"
 #include "PacketReader/EthernetFrameEditor.h"
+#include "PacketReader/ARP/ARP_Packet.h"
 #include "PacketReader/ARP/ARP_PacketEditor.h"
 #ifndef PCAP_NETMASK_UNKNOWN
 #define PCAP_NETMASK_UNKNOWN 0xffffffff
@@ -65,31 +65,37 @@ PCAPAdapter::PCAPAdapter()
 	else
 		Console.Error("DEV9: PCAP: Failed to get adapter information");
 
-	if (adMAC.has_value())
+	// DLT_RAW adapters may not have a MAC address
+	// Just use the default MAC in such case
+	// SetMACSwitchedFilter will also fail on such adapters
+	if (!ipOnly)
 	{
-		hostMAC = adMAC.value();
-		MAC_Address newMAC = ps2MAC;
+		if (adMAC.has_value())
+		{
+			hostMAC = adMAC.value();
+			MAC_Address newMAC = ps2MAC;
 
-		//Lets take the hosts last 2 bytes to make it unique on Xlink
-		newMAC.bytes[5] = hostMAC.bytes[4];
-		newMAC.bytes[4] = hostMAC.bytes[5];
+			//Lets take the hosts last 2 bytes to make it unique on Xlink
+			newMAC.bytes[5] = hostMAC.bytes[4];
+			newMAC.bytes[4] = hostMAC.bytes[5];
 
-		SetMACAddress(&newMAC);
-	}
-	else
-	{
-		Console.Error("DEV9: PCAP: Failed to get MAC address for adapter");
-		pcap_close(hpcap);
-		hpcap = nullptr;
-		return;
-	}
+			SetMACAddress(&newMAC);
+		}
+		else
+		{
+			Console.Error("DEV9: PCAP: Failed to get MAC address for adapter");
+			pcap_close(hpcap);
+			hpcap = nullptr;
+			return;
+		}
 
-	if (switched && !SetMACSwitchedFilter(ps2MAC))
-	{
-		pcap_close(hpcap);
-		hpcap = nullptr;
-		Console.Error("DEV9: PCAP: Can't open Device '%s'", EmuConfig.DEV9.EthDevice.c_str());
-		return;
+		if (switched && !SetMACSwitchedFilter(ps2MAC))
+		{
+			pcap_close(hpcap);
+			hpcap = nullptr;
+			Console.Error("DEV9: PCAP: Can't open Device '%s'", EmuConfig.DEV9.EthDevice.c_str());
+			return;
+		}
 	}
 
 	if (foundAdapter)
@@ -118,6 +124,16 @@ bool PCAPAdapter::recv(NetPacket* pkt)
 	if (!blocking && NetAdapter::recv(pkt))
 		return true;
 
+	EthernetFrame* bFrame;
+	if (vRecBuffer.Dequeue(&bFrame))
+	{
+		bFrame->WritePacket(pkt);
+		InspectRecv(pkt);
+
+		delete bFrame;
+		return true;
+	}
+
 	pcap_pkthdr* header;
 	const u_char* pkt_data;
 
@@ -125,32 +141,72 @@ bool PCAPAdapter::recv(NetPacket* pkt)
 	// This delays getting packets we need, so instead loop untill a valid packet, or no packet, is returned from pcap_next_ex.
 	while (pcap_next_ex(hpcap, &header, &pkt_data) > 0)
 	{
-		// 1518 is the largest Ethernet frame we can get using an MTU of 1500 (assuming no VLAN tagging).
-		// This includes the FCS, which should be trimmed (PS2 SDK dosn't allow extra space for this).
-		if (header->len > 1518)
+		if (!ipOnly)
 		{
-			Console.Error("DEV9: PCAP: Dropped jumbo frame of size: %u", header->len);
-			continue;
-		}
-
-		pxAssert(header->len == header->caplen);
-
-		memcpy(pkt->buffer, pkt_data, header->len);
-		pkt->size = static_cast<int>(header->len);
-
-		if (!switched)
-			SetMACBridgedRecv(pkt);
-
-		if (VerifyPkt(pkt, header->len))
-		{
-			HandleFrameCheckSequence(pkt);
-
-			// FCS (if present) has been removed, apply correct limit
-			if (pkt->size > 1514)
+			// 1518 is the largest Ethernet frame we can get using an MTU of 1500 (assuming no VLAN tagging).
+			// This includes the FCS, which should be trimmed (PS2 SDK dosn't allow extra space for this).
+			if (header->len > 1518)
 			{
-				Console.Error("DEV9: PCAP: Dropped jumbo frame of size: %u", pkt->size);
+				Console.Error("DEV9: PCAP: Dropped jumbo frame of size: %u", header->len);
 				continue;
 			}
+
+			pxAssert(header->len == header->caplen);
+
+			memcpy(pkt->buffer, pkt_data, header->len);
+			pkt->size = static_cast<int>(header->len);
+
+			if (!switched)
+				SetMACBridgedRecv(pkt);
+
+			if (VerifyPkt(pkt, header->len))
+			{
+				HandleFrameCheckSequence(pkt);
+
+				// FCS (if present) has been removed, apply correct limit
+				if (pkt->size > 1514)
+				{
+					Console.Error("DEV9: PCAP: Dropped jumbo frame of size: %u", pkt->size);
+					continue;
+				}
+
+				InspectRecv(pkt);
+				return true;
+			}
+		}
+		else
+		{
+			// MTU of 1500
+			if (header->len > 1500)
+			{
+				Console.Error("DEV9: PCAP: Dropped jumbo IP packet of size: %u", header->len);
+				continue;
+			}
+
+			// Ensure IPv4
+			u8 ver = (pkt_data[0] & 0xF0) >> 4;
+			if (ver != 4)
+			{
+				Console.Error("DEV9: PCAP: Dropped non IPv4 packet");
+				continue;
+			}
+
+			// Avoid pcap looping packets by checking IP
+			IP_Packet ipPkt(const_cast<u_char*>(pkt_data), header->len);
+			if (ipPkt.sourceIP == ps2IP)
+			{
+				continue;
+			}
+
+			pxAssert(header->len == header->caplen);
+
+			// Build EtherFrame using captured packet
+			PayloadPtr* pl = new PayloadPtr(const_cast<u_char*>(pkt_data), header->len);
+			EthernetFrame frame(pl);
+			frame.sourceMAC = internalMAC;
+			frame.destinationMAC = ps2MAC;
+			frame.protocol = static_cast<u16>(EtherType::IPv4);
+			frame.WritePacket(pkt);
 
 			InspectRecv(pkt);
 			return true;
@@ -170,13 +226,71 @@ bool PCAPAdapter::send(NetPacket* pkt)
 		return true;
 
 	// TODO: loopback broadcast packets to host pc in switched mode.
-	if (!switched)
-		SetMACBridgedSend(pkt);
+	if (!ipOnly)
+	{
+		if (!switched)
+			SetMACBridgedSend(pkt);
 
-	if (pcap_sendpacket(hpcap, (u_char*)pkt->buffer, pkt->size))
-		return false;
+		if (pcap_sendpacket(hpcap, (u_char*)pkt->buffer, pkt->size))
+			return false;
+		else
+			return true;
+	}
 	else
-		return true;
+	{
+		EthernetFrameEditor frame(pkt);
+		if (frame.GetProtocol() == static_cast<u16>(EtherType::IPv4))
+		{
+			PayloadPtr* payload = frame.GetPayload();
+			IP_Packet pkt(payload->data, payload->GetLength());
+
+			if (pkt.sourceIP != IP_Address{{{0, 0, 0, 0}}})
+			{
+				ps2IP = pkt.sourceIP;
+			}
+
+			if (pcap_sendpacket(hpcap, payload->data, pkt.GetLength()))
+				return false;
+			else
+				return true;
+		}
+		if (frame.GetProtocol() == static_cast<u16>(EtherType::ARP))
+		{
+			// We will need to respond to ARP requests for all except the PS2 ip
+			// However, we won't know the PS2 ip yet unless our dhcpServer is used
+			PayloadPtr* payload = frame.GetPayload();
+			ARP_Packet arpPkt(payload->data, payload->GetLength());
+			if (arpPkt.protocol == static_cast<u16>(EtherType::IPv4))
+			{
+				/* This is untested */
+				if (arpPkt.op == 1) //ARP request
+				{
+					if (*(IP_Address*)arpPkt.targetProtocolAddress.get() != dhcpServer.ps2IP)
+					// it's trying to resolve the gateway's mac addr
+					{
+						Console.Error("DEV9: PCAP: ARP Request on DLT_RAW adapter, providing assumed response");
+						ARP_Packet* arpRet = new ARP_Packet(6, 4);
+						std::memcpy(arpRet->targetHardwareAddress.get(), arpPkt.senderHardwareAddress.get(), sizeof(MAC_Address));
+						std::memcpy(arpRet->senderHardwareAddress.get(), &internalMAC, sizeof(MAC_Address));
+						std::memcpy(arpRet->targetProtocolAddress.get(), arpPkt.senderProtocolAddress.get(), sizeof(IP_Address));
+						std::memcpy(arpRet->senderProtocolAddress.get(), arpPkt.targetProtocolAddress.get(), sizeof(IP_Address));
+						arpRet->op = 2,
+						arpRet->protocol = arpPkt.protocol;
+						arpRet->hardwareType = arpPkt.hardwareType;
+
+						EthernetFrame* retARP = new EthernetFrame(arpRet);
+						retARP->destinationMAC = ps2MAC;
+						retARP->sourceMAC = internalMAC;
+						retARP->protocol = static_cast<u16>(EtherType::ARP);
+
+						vRecBuffer.Enqueue(retARP);
+					}
+				}
+			}
+			return true;
+		}
+		return false;
+	}
 }
 
 void PCAPAdapter::reloadSettings()
@@ -195,6 +309,20 @@ PCAPAdapter::~PCAPAdapter()
 	{
 		pcap_close(hpcap);
 		hpcap = nullptr;
+	}
+
+	//Clear out vRecBuffer
+	while (!vRecBuffer.IsQueueEmpty())
+	{
+		EthernetFrame* retPay;
+		if (!vRecBuffer.Dequeue(&retPay))
+		{
+			using namespace std::chrono_literals;
+			std::this_thread::sleep_for(1ms);
+			continue;
+		}
+
+		delete retPay;
 	}
 }
 
@@ -302,6 +430,10 @@ bool PCAPAdapter::InitPCAP(const std::string& adapter, bool promiscuous)
 	{
 		case DLT_EN10MB:
 			//case DLT_IEEE802_11:
+			ipOnly = false;
+			break;
+		case DLT_RAW:
+			ipOnly = true;
 			break;
 		default:
 			Console.Error("DEV9: PCAP: Error, unsupported data link type (%d): %s", dlt, dlt_name);

--- a/pcsx2/DEV9/pcap_io.h
+++ b/pcsx2/DEV9/pcap_io.h
@@ -5,6 +5,7 @@
 #include "pcap.h"
 #include "net.h"
 #include "PacketReader/MAC_Address.h"
+#include "PacketReader/EthernetFrame.h"
 
 #ifdef _WIN32
 bool load_pcap();
@@ -18,6 +19,9 @@ private:
 
 	bool switched;
 	bool blocking;
+	bool ipOnly;
+
+	SimpleQueue<PacketReader::EthernetFrame*> vRecBuffer;
 
 	PacketReader::IP::IP_Address ps2IP{};
 	PacketReader::MAC_Address hostMAC;

--- a/pcsx2/DEV9/smap.cpp
+++ b/pcsx2/DEV9/smap.cpp
@@ -241,6 +241,7 @@ void tx_process()
 	// if we actualy send something set TXEND
 	if (cnt != 0)
 	{
+		Console.WriteLn("DEV9: SMAP: Sent %d packets", cnt);
 		_DEV9irq(SMAP_INTR_TXEND, 100); //now ? or when the fifo is empty ? i guess now atm
 	}
 	else

--- a/pcsx2/pcsx2.vcxproj
+++ b/pcsx2/pcsx2.vcxproj
@@ -170,6 +170,7 @@
     <ClCompile Include="DEV9\ATA\HddCreate.cpp" />
     <ClCompile Include="DEV9\DEV9.cpp" />
     <ClCompile Include="DEV9\flash.cpp" />
+    <ClCompile Include="DEV9\InternalServers\ARP_Logger.cpp" />
     <ClCompile Include="DEV9\InternalServers\DHCP_Logger.cpp" />
     <ClCompile Include="DEV9\InternalServers\DHCP_Server.cpp" />
     <ClCompile Include="DEV9\InternalServers\DNS_Logger.cpp" />
@@ -607,6 +608,7 @@
     <ClInclude Include="DEV9\ATA\ATA.h" />
     <ClInclude Include="DEV9\ATA\HddCreate.h" />
     <ClInclude Include="DEV9\DEV9.h" />
+    <ClInclude Include="DEV9\InternalServers\ARP_Logger.h" />
     <ClInclude Include="DEV9\InternalServers\DHCP_Logger.h" />
     <ClInclude Include="DEV9\InternalServers\DHCP_Server.h" />
     <ClInclude Include="DEV9\InternalServers\DNS_Logger.h" />

--- a/pcsx2/pcsx2.vcxproj.filters
+++ b/pcsx2/pcsx2.vcxproj.filters
@@ -872,6 +872,9 @@
     <ClCompile Include="DEV9\flash.cpp">
       <Filter>System\Ps2\DEV9</Filter>
     </ClCompile>
+    <ClCompile Include="DEV9\InternalServers\ARP_Logger.cpp">
+      <Filter>System\Ps2\DEV9\InternalServers</Filter>
+    </ClCompile>
     <ClCompile Include="DEV9\InternalServers\DHCP_Logger.cpp">
       <Filter>System\Ps2\DEV9\InternalServers</Filter>
     </ClCompile>
@@ -1756,6 +1759,9 @@
     </ClInclude>
     <ClInclude Include="DEV9\DEV9.h">
       <Filter>System\Ps2\DEV9</Filter>
+    </ClInclude>
+    <ClInclude Include="DEV9\InternalServers\ARP_Logger.h">
+      <Filter>System\Ps2\DEV9\InternalServers</Filter>
     </ClInclude>
     <ClInclude Include="DEV9\InternalServers\DHCP_Logger.h">
       <Filter>System\Ps2\DEV9\InternalServers</Filter>


### PR DESCRIPTION
### Description of Changes
Support adapters with a capture data type of `DLT_RAW`. 
Handle point-point links with the internal DHCP.

### Rationale behind Changes
Some VPN software, like Cloudflare's WARP, uses `NdisMediumIP` adapters (which npcap maps to `DLT_RAW`) which, as its name might suggest, handles IP packets directly, instead of Ethernet frames.

These VPN adapters may also present a point-point link (having a netmask of 255.255.255.255)
PS2's networking doesn't expect such networks, instead requiring a gateway IP present within the same network.
As a workaround, we set the gateway to the PS2's IP, fudging this requirement.

### Suggested Testing Steps
Test pcap on VPN adapters, such as Cloudflare's WARP or ProtonVPN.
ProtonVPN might not use the point-point netmask, so is worthwhile testing both