### PR TITLE
GameDB: Fix Enemies Stuck in Armored Core Nine Breaker

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -1588,6 +1588,14 @@ SCAJ-20105:
     recommendedBlendingLevel: 3 # Fixes level brightness.
     cpuSpriteRenderBW: 2 # Fixes broken water on "Upper Sea" level.
     cpuSpriteRenderLevel: 2 # Needed for above.
+  dynaPatches:
+    - pattern:
+        - { offset: 0x0, value: 0x3C023E4C }
+        - { offset: 0x4, value: 0x3442CCCD }
+        - { offset: 0x8, value: 0xE7A300D0 }
+        - { offset: 0xC, value: 0xE7A200D4 }
+      replacement:
+        - { offset: 0x4, value: 0x3442CCE0 }
 SCAJ-20107:
   name: "Bakufuu Slash! Kizna Arashi"
   region: "NTSC-Unk"
@@ -6914,6 +6922,14 @@ SCKA-20047:
     - "SCKA-20047"
     - "SLKA-25201"
     - "SLKA-25202"
+  dynaPatches:
+    - pattern:
+        - { offset: 0x0, value: 0x3C023E4C }
+        - { offset: 0x4, value: 0x3442CCCD }
+        - { offset: 0x8, value: 0xE7A300D0 }
+        - { offset: 0xC, value: 0xE7A200D4 }
+      replacement:
+        - { offset: 0x4, value: 0x3442CCE0 }
 SCKA-20048:
   name: "Killzone"
   region: "NTSC-K"
@@ -23245,6 +23261,14 @@ SLES-53819:
     - "SLES-53819"
     - "SLES-82036"
     - "SLES-82037"
+  dynaPatches:
+    - pattern:
+        - { offset: 0x0, value: 0x3C023E4C }
+        - { offset: 0x4, value: 0x3442CCCD }
+        - { offset: 0x8, value: 0xE7A300D0 }
+        - { offset: 0xC, value: 0xE7A200D4 }
+      replacement:
+        - { offset: 0x4, value: 0x3442CCE0 }
 SLES-53820:
   name: "Armored Core - Last Raven"
   region: "PAL-E"
@@ -54273,6 +54297,14 @@ SLPS-25408:
     - "SLPS-25339"
     - "SLPS-73202"
     - "SLPS-73203"
+  dynaPatches:
+    - pattern:
+        - { offset: 0x0, value: 0x3C023E4C }
+        - { offset: 0x4, value: 0x3442CCCD }
+        - { offset: 0x8, value: 0xE7A300D0 }
+        - { offset: 0xC, value: 0xE7A200D4 }
+      replacement:
+        - { offset: 0x4, value: 0x3442CCE0 }
 SLPS-25409:
   name: "双恋—フタコイ— 初回限定版"
   name-sort: "ふたこい しょかいげんていばん"
@@ -64590,6 +64622,14 @@ SLUS-21200:
     - "SLUS-21200"
     - "SLUS-20986"
     - "SLUS-21079"
+  dynaPatches:
+    - pattern:
+        - { offset: 0x0, value: 0x3C023E4C }
+        - { offset: 0x4, value: 0x3442CCCD }
+        - { offset: 0x8, value: 0xE7A300D0 }
+        - { offset: 0xC, value: 0xE7A200D4 }
+      replacement:
+        - { offset: 0x4, value: 0x3442CCE0 }
 SLUS-21201:
   name: "Tales of Legendia"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
- Reversed instructions that reads each enemies' stature and found a constant that is used for switching stuck and unstuck.
- This patch just makes the constant little bigger. (`3E4CCCCD` -> `3E4CCCE0`)

```
[Fix Enemy Stuck (dynamic)]
author=Berylskid
description=Fix Enemies' stuck. Region free.
dpatch=0,4,1,0,3C023E4C,4,3442CCCD,8,E7A300D0,C,E7A200D4,4,3442CCE0
```

### Rationale behind Changes
Related to #8587 

### Suggested Testing Steps
- Test all kind of MT enemies (except AC enemies like Arena, I mean).
- Test various region versions.

### Known Issues
- [Resolved] Enemies ignore walls