### PR TITLE
GameDB: Atelier Iris (SLUS-21113) fixes

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -64136,11 +64136,6 @@ SLUS-21113:
   name: "Atelier Iris - Eternal Mana"
   region: "NTSC-U"
   compat: 5
-  gameFixes:
-    - SoftwareRendererFMVHack # Fixes horizontal lines in FMV and prevents hash cache from disabling itself
-  gsHWFixes:
-    roundSprite: 2 # Fixes character portraits when upscaling and reduces lines in FMVs when using HW renderer 
-    texturePreloading: 2 # Fixes flickering black lines around sprites when upscaling.
 SLUS-21114:
   name: "NHRA Championship Drag Racing"
   region: "NTSC-U"

--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -64136,6 +64136,11 @@ SLUS-21113:
   name: "Atelier Iris - Eternal Mana"
   region: "NTSC-U"
   compat: 5
+  gameFixes:
+    - SoftwareRendererFMVHack # Fixes horizontal lines in FMV and prevents hash cache from disabling itself
+  gsHWFixes:
+    roundSprite: 2 # Fixes character portraits when upscaling and reduces lines in FMVs when using HW renderer 
+    texturePreloading: 2 # Fixes flickering black lines around sprites when upscaling.
 SLUS-21114:
   name: "NHRA Championship Drag Racing"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
Assorted graphics tweaks to fix sprite and FMV issues 

### Rationale behind Changes
Fixes assorted lines around/through sprites when upscaling. Includes confirmed fixes from https://wiki.pcsx2.net/Atelier_Iris:_Eternal_Mana, and matches fixes with games with similar engine from same developer (SLES-54385, SLPM-65985, SLUS-21327)
When upscaling:
- If `Texture Preloading` is set to `Full` or `Partial` and HW Renderer used for FMVs, an error is generated that the hash cache has used too much VRAM and has been disabled.
- - If `Texture Preloading` is set to `None`, small black lines intermittently appear around sprites in-game, particularly if they're moving
- Using HW Renderer causes FMVs to have black horizontal lines running through them
- - Using `Round Sprite` at `Half `mitigates this slightly, `Full `almost completely erases it
- Using `SoftwareRendererFMVHack `bypasses both the black lines in FMVs and hash cache errors, and allows for `Texture Preloading` to be enabled to prevent other black line/offset issues.

### Suggested Testing Steps

