### PR TITLE
QT: Use SetStatusText instead of passing a formatted string as a fmt

### DIFF
--- a/pcsx2/GameList.cpp
+++ b/pcsx2/GameList.cpp
@@ -623,7 +623,7 @@ void GameList::ScanDirectory(const char* path, bool recursive, bool only_cache, 
 		}
 
 		const std::string_view filename = Path::GetFileName(ffd.FileName);
-		progress->SetFormattedStatusText(fmt::format(TRANSLATE_FS("GameList","Scanning {}..."), filename.data()).c_str());
+		progress->SetStatusText(fmt::format(TRANSLATE_FS("GameList","Scanning {}..."), filename.data()).c_str());
 		ScanFile(std::move(ffd.FileName), ffd.ModificationTime, lock, played_time_map, custom_attributes_ini);
 		progress->SetProgressValue(files_scanned);
 	}


### PR DESCRIPTION
This caused crashes when file names had percent signs in them because we passed the file name as the format to SetFormattedStatusText. I opted to continue to use fmt for consistency.

### Description of Changes
Use SetStatusText instead of SetFormattedStatusText because we already format the string.

### Rationale behind Changes
This issue caused the crash in #12011. This PR fixes #12011.

### Suggested Testing Steps
Rename a file in your game directory `Ichigo 100% Strawberry Diary (Japan).chd`. Reload the game list and see if it crashes.