### PR TITLE
PINE: Fix stack buffer overflow for long XDG_RUNTIME_DIR paths

### DIFF
--- a/pcsx2/PINE.cpp
+++ b/pcsx2/PINE.cpp
@@ -306,7 +306,7 @@ bool PINEServer::Initialize(int slot)
 		return false;
 	}
 	server.sun_family = AF_UNIX;
-	strcpy(server.sun_path, m_socket_name.c_str());
+	StringUtil::Strlcpy(server.sun_path, m_socket_name, sizeof(server.sun_path));
 
 	// we unlink the socket so that when releasing this thread the socket gets
 	// freed even if we didn't close correctly the loop


### PR DESCRIPTION
### Description of Changes
A `strcpy` call has been swapped out with a ~~`strncpy`~~ `StringUtil::Strlcpy` call in `PINEServer::Initialize`.

### Rationale behind Changes
For example, on Linux you could previously make it crash with the following command if PINE was enabled:

```
XDG_RUNTIME_DIR=/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/really/long/path ./build/bin/pcsx2-qt 
```

### Suggested Testing Steps
Try the command above, make sure it doesn't crash.
