### PR TITLE
3rdparty/ccc: Backport some fixes

### DIFF
--- a/3rdparty/ccc/src/ccc/elf.cpp
+++ b/3rdparty/ccc/src/ccc/elf.cpp
@@ -10,34 +10,35 @@ Result<ElfFile> ElfFile::parse(std::vector<u8> image)
 	ElfFile elf;
 	elf.image = std::move(image);
 	
-	const ElfIdentHeader* ident = get_packed<ElfIdentHeader>(elf.image, 0);
+	const ElfIdentHeader* ident = get_unaligned<ElfIdentHeader>(elf.image, 0);
 	CCC_CHECK(ident, "ELF ident header out of range.");
 	CCC_CHECK(ident->magic == CCC_FOURCC("\x7f\x45\x4c\x46"), "Not an ELF file.");
 	CCC_CHECK(ident->e_class == ElfIdentClass::B32, "Wrong ELF class (not 32 bit).");
 	
-	const ElfFileHeader* header = get_packed<ElfFileHeader>(elf.image, sizeof(ElfIdentHeader));
+	const ElfFileHeader* header = get_unaligned<ElfFileHeader>(elf.image, sizeof(ElfIdentHeader));
 	CCC_CHECK(header, "ELF file header out of range.");
 	elf.file_header = *header;
 	
-	const ElfSectionHeader* shstr_section_header = get_packed<ElfSectionHeader>(elf.image, header->shoff + header->shstrndx * sizeof(ElfSectionHeader));
+	const ElfSectionHeader* shstr_section_header =
+		get_unaligned<ElfSectionHeader>(elf.image, header->shoff + header->shstrndx * sizeof(ElfSectionHeader));
 	CCC_CHECK(shstr_section_header, "ELF section name header out of range.");
 	
 	for(u32 i = 0; i < header->shnum; i++) {
 		u64 header_offset = header->shoff + i * sizeof(ElfSectionHeader);
-		const ElfSectionHeader* section_header = get_packed<ElfSectionHeader>(elf.image, header_offset);
+		const ElfSectionHeader* section_header = get_unaligned<ElfSectionHeader>(elf.image, header_offset);
 		CCC_CHECK(section_header, "ELF section header out of range.");
 		
-		const char* name = get_string(elf.image, shstr_section_header->offset + section_header->name);
-		CCC_CHECK(section_header, "ELF section name out of range.");
+		std::optional<std::string_view> name = get_string(elf.image, shstr_section_header->offset + section_header->name);
+		CCC_CHECK(name.has_value(), "ELF section name out of range.");
 		
 		ElfSection& section = elf.sections.emplace_back();
-		section.name = name;
+		section.name = *name;
 		section.header = *section_header;
 	}
 	
 	for(u32 i = 0; i < header->phnum; i++) {
 		u64 header_offset = header->phoff + i * sizeof(ElfProgramHeader);
-		const ElfProgramHeader* program_header = get_packed<ElfProgramHeader>(elf.image, header_offset);
+		const ElfProgramHeader* program_header = get_unaligned<ElfProgramHeader>(elf.image, header_offset);
 		CCC_CHECK(program_header, "ELF program header out of range.");
 		
 		elf.segments.emplace_back(*program_header);

--- a/3rdparty/ccc/src/ccc/elf_symtab.cpp
+++ b/3rdparty/ccc/src/ccc/elf_symtab.cpp
@@ -60,7 +60,7 @@ Result<void> import_symbols(
 	DemanglerFunctions demangler)
 {
 	for(u32 i = 0; i < symtab.size() / sizeof(Symbol); i++) {
-		const Symbol* symbol = get_packed<Symbol>(symtab, i * sizeof(Symbol));
+		const Symbol* symbol = get_unaligned<Symbol>(symtab, i * sizeof(Symbol));
 		CCC_ASSERT(symbol);
 		
 		Address address;
@@ -86,13 +86,14 @@ Result<void> import_symbols(
 			}
 		}
 		
-		const char* string = get_string(strtab, symbol->name);
-		CCC_CHECK(string, "Symbol string out of range.");
+		std::optional<std::string_view> string_view = get_string(strtab, symbol->name);
+		CCC_CHECK(string_view.has_value(), "Symbol string out of range.");
+		std::string string(*string_view);
 		
 		switch(symbol->type()) {
 			case SymbolType::NOTYPE: {
 				Result<Label*> label = database.labels.create_symbol(
-					string, group.source, group.module_symbol, address, importer_flags, demangler);
+					std::move(string), group.source, group.module_symbol, address, importer_flags, demangler);
 				CCC_RETURN_IF_ERROR(label);
 				
 				// These symbols get emitted at the same addresses as functions
@@ -108,7 +109,7 @@ Result<void> import_symbols(
 			case SymbolType::OBJECT: {
 				if(symbol->size != 0) {
 					Result<GlobalVariable*> global_variable = database.global_variables.create_symbol(
-						string, group.source, group.module_symbol, address, importer_flags, demangler);
+						std::move(string), group.source, group.module_symbol, address, importer_flags, demangler);
 					CCC_RETURN_IF_ERROR(global_variable);
 					
 					if(*global_variable) {
@@ -116,7 +117,7 @@ Result<void> import_symbols(
 					}
 				} else {
 					Result<Label*> label = database.labels.create_symbol(
-						string, group.source, group.module_symbol, address, importer_flags, demangler);
+						std::move(string), group.source, group.module_symbol, address, importer_flags, demangler);
 					CCC_RETURN_IF_ERROR(label);
 				}
 				
@@ -124,7 +125,7 @@ Result<void> import_symbols(
 			}
 			case SymbolType::FUNC: {
 				Result<Function*> function = database.functions.create_symbol(
-					string, group.source, group.module_symbol, address, importer_flags, demangler);
+					std::move(string), group.source, group.module_symbol, address, importer_flags, demangler);
 				CCC_RETURN_IF_ERROR(function);
 				
 				if(*function) {
@@ -135,7 +136,7 @@ Result<void> import_symbols(
 			}
 			case SymbolType::FILE: {
 				Result<SourceFile*> source_file = database.source_files.create_symbol(
-					string, group.source, group.module_symbol);
+					std::move(string), group.source, group.module_symbol);
 				CCC_RETURN_IF_ERROR(source_file);
 				
 				break;
@@ -153,18 +154,18 @@ Result<void> print_symbol_table(FILE* out, std::span<const u8> symtab, std::span
 	fprintf(out, "   Num:    Value  Size Type    Bind   Vis      Ndx Name\n");
 	
 	for(u32 i = 0; i < symtab.size() / sizeof(Symbol); i++) {
-		const Symbol* symbol = get_packed<Symbol>(symtab, i * sizeof(Symbol));
+		const Symbol* symbol = get_unaligned<Symbol>(symtab, i * sizeof(Symbol));
 		CCC_ASSERT(symbol);
 		
 		const char* type = symbol_type_to_string(symbol->type());
 		const char* bind = symbol_bind_to_string(symbol->bind());
 		const char* visibility = symbol_visibility_to_string(symbol->visibility());
 		
-		const char* string = get_string(strtab, symbol->name);
-		CCC_CHECK(string, "Symbol string out of range.");
+		std::optional<std::string_view> string = get_string(strtab, symbol->name);
+		CCC_CHECK(string.has_value(), "Symbol string out of range.");
 		
 		fprintf(out, "%6u: %08x %5u %-7s %-7s %-7s %3u %s\n",
-			i, symbol->value, symbol->size, type, bind, visibility, symbol->shndx, string);
+			i, symbol->value, symbol->size, type, bind, visibility, symbol->shndx, string->data());
 		
 	}
 	

--- a/3rdparty/ccc/src/ccc/sndll.cpp
+++ b/3rdparty/ccc/src/ccc/sndll.cpp
@@ -54,18 +54,19 @@ static const char* sndll_symbol_type_to_string(SNDLLSymbolType type);
 
 Result<SNDLLFile> parse_sndll_file(std::span<const u8> image, Address address, SNDLLType type)
 {
-	const u32* magic = get_packed<u32>(image, 0);
+	std::optional<u32> magic = copy_unaligned<u32>(image, 0);
+	CCC_CHECK(magic.has_value(), "Failed to read SNDLL header.");
 	CCC_CHECK((*magic & 0xffffff) == CCC_FOURCC("SNR\00"), "Not a SNDLL %s.", address.valid() ? "section" : "file");
 	
 	char version = *magic >> 24;
 	switch(version) {
 		case '1': {
-			const SNDLLHeaderV1* header = get_packed<SNDLLHeaderV1>(image, 0);
+			const SNDLLHeaderV1* header = get_unaligned<SNDLLHeaderV1>(image, 0);
 			CCC_CHECK(header, "File too small to contain SNDLL V1 header.");
 			return parse_sndll_common(image, address, type, header->common, SNDLL_V1);
 		}
 		case '2': {
-			const SNDLLHeaderV2* header = get_packed<SNDLLHeaderV2>(image, 0);
+			const SNDLLHeaderV2* header = get_unaligned<SNDLLHeaderV2>(image, 0);
 			CCC_CHECK(header, "File too small to contain SNDLL V2 header.");
 			return parse_sndll_common(image, address, type, header->common, SNDLL_V2);
 		}
@@ -84,10 +85,9 @@ static Result<SNDLLFile> parse_sndll_common(
 	sndll.version = version;
 	
 	if(common.elf_path) {
-		const char* elf_path = get_string(image, common.elf_path);
-		if(elf_path) {
-			sndll.elf_path = elf_path;
-		}
+		std::optional<std::string_view> elf_path = get_string(image, common.elf_path);
+		CCC_CHECK(elf_path.has_value(), "SNDLL header has invalid ELF path field.");
+		sndll.elf_path = *elf_path;
 	}
 	
 	CCC_CHECK(common.symbol_count < (32 * 1024 * 1024) / sizeof(SNDLLSymbol), "SNDLL symbol count is too high.");
@@ -95,10 +95,10 @@ static Result<SNDLLFile> parse_sndll_common(
 	
 	for(u32 i = 0; i < common.symbol_count; i++) {
 		u32 symbol_offset = common.symbols - address.get_or_zero() + i * sizeof(SNDLLSymbolHeader);
-		const SNDLLSymbolHeader* symbol_header = get_packed<SNDLLSymbolHeader>(image, symbol_offset);
+		const SNDLLSymbolHeader* symbol_header = get_unaligned<SNDLLSymbolHeader>(image, symbol_offset);
 		CCC_CHECK(symbol_header, "SNDLL symbol out of range.");
 		
-		const char* string = nullptr;
+		std::optional<std::string_view> string;
 		if(symbol_header->string) {
 			string = get_string(image, symbol_header->string - address.get_or_zero());
 		}
@@ -106,7 +106,9 @@ static Result<SNDLLFile> parse_sndll_common(
 		SNDLLSymbol& symbol = sndll.symbols.emplace_back();
 		symbol.type = symbol_header->type;
 		symbol.value = symbol_header->value;
-		symbol.string = string;
+		if(string.has_value()) {
+			symbol.string = *string;
+		}
 	}
 	
 	return sndll;

--- a/3rdparty/ccc/src/ccc/symbol_file.cpp
+++ b/3rdparty/ccc/src/ccc/symbol_file.cpp
@@ -7,8 +7,8 @@ namespace ccc {
 
 Result<std::unique_ptr<SymbolFile>> parse_symbol_file(std::vector<u8> image, std::string file_name)
 {
-	const u32* magic = get_packed<u32>(image, 0);
-	CCC_CHECK(magic, "File too small.");
+	const std::optional<u32> magic = copy_unaligned<u32>(image, 0);
+	CCC_CHECK(magic.has_value(), "File too small.");
 	
 	std::unique_ptr<SymbolFile> symbol_file;
 	

--- a/3rdparty/ccc/src/ccc/util.cpp
+++ b/3rdparty/ccc/src/ccc/util.cpp
@@ -51,14 +51,17 @@ void set_custom_error_callback(CustomErrorCallback callback)
 	custom_error_callback = callback;
 }
 
-const char* get_string(std::span<const u8> bytes, u64 offset)
+std::optional<std::string_view> get_string(std::span<const u8> bytes, u64 offset)
 {
-	for(const unsigned char* c = bytes.data() + offset; c < bytes.data() + bytes.size(); c++) {
-		if(*c == '\0') {
-			return (const char*) &bytes[offset];
+	for(u64 i = offset; i < bytes.size(); i++) {
+		if(bytes[i] == '\0') {
+			return std::string_view(
+				reinterpret_cast<const char*>(&bytes[offset]),
+				reinterpret_cast<const char*>(&bytes[i]));
 		}
 	}
-	return nullptr;
+	
+	return std::nullopt;
 }
 
 std::string merge_paths(const std::string& base, const std::string& path)

--- a/3rdparty/ccc/src/ccc/util.h
+++ b/3rdparty/ccc/src/ccc/util.h
@@ -71,8 +71,15 @@ void set_custom_error_callback(CustomErrorCallback callback);
 		exit(1); \
 	}
 
+#define CCC_ABORT_IF_FALSE(condition, ...) \
+	if (!(condition)) { \
+		ccc::Error error = ccc::format_error(__FILE__, __LINE__, __VA_ARGS__); \
+		ccc::report_error(error); \
+		abort(); \
+	}
+
 #define CCC_ASSERT(condition) \
-	CCC_CHECK_FATAL(condition, #condition)
+	CCC_ABORT_IF_FALSE(condition, #condition)
 
 // The main error handling construct in CCC. This class is used to bundle
 // together a return value and a pointer to error information, so that errors


### PR DESCRIPTION
### Description of Changes
DWARF support is in the works but will still likely take a few months to be ready for prime time. In the meantime, I thought I would backport some crash fixes just for PCSX2.

The bounds checking bugs were found via fuzzing, so I think are unlikely to affect any games, but I still think it's nice to get them fixed. The assertion fix makes CCC crash more cleanly if an assertion were to fail, since previously it called exit which PCSX2 doesn't like very much.

### Rationale behind Changes
Fix some bugs.

### Suggested Testing Steps
You could test some of the games listed in my original symbol table PR #10224 and open the debugger.
