### PR TITLE
Console: Limit buffer size in ConsoleLogFromVM::Write

### DIFF
--- a/pcsx2/DebugTools/Debug.h
+++ b/pcsx2/DebugTools/Debug.h
@@ -87,8 +87,7 @@ struct ConsoleLog : public LogBase
 //  ConsoleLogFromVM
 // --------------------------------------------------------------------------------------
 // Special console logger for Virtual Machine log sources, such as the EE and IOP console
-// writes (actual game developer messages and such).  These logs do *not* automatically
-// append newlines, since the VM generates them manually; and they do *not* support printf
+// writes (actual game developer messages and such).  These logs do *not* support printf
 // formatting, since anything coming over the EE/IOP consoles should be considered raw
 // string data.  (otherwise %'s would get mis-interpreted).
 //
@@ -102,22 +101,18 @@ public:
 	{
 		for (const char ch : msg)
 		{
-			if (ch == '\n')
-			{
-				if (!m_buffer.empty())
-				{
-					Console.WriteLn(conColor, m_buffer);
-					m_buffer.clear();
-				}
-			}
-			else if (ch < 0x20)
-			{
-				// Ignore control characters.
-				// Otherwise you get fun bells going off.
-			}
-			else
-			{
+			// Ignore control characters.
+			// Otherwise you get fun bells going off.
+			if (ch < 0x20)
+				continue;
+
+			if (ch != '\n')
 				m_buffer.push_back(ch);
+
+			if (ch == '\n' || m_buffer.size() >= 4096)
+			{
+				Console.WriteLn(conColor, m_buffer);
+				m_buffer.clear();
 			}
 		}
 


### PR DESCRIPTION
### Description of Changes
The buffer size for lines written to the EE/IOP consoles has been limited to 4096 characters. In addition, consecutive newline characters are no longer eaten.

### Rationale behind Changes
Previously it was very easy to accidentally exhaust the host's memory. For example, if you made an infinite loop and forgot the newline character. Since there would be no output it wouldn't be immediately obvious what was wrong either.

Here's a small program that triggers this behaviour:

```
# ee-gcc exhaustmem.s -o exhaustmem.elf -nostdlib
	.set noat
	.set noreorder
	.set nomacro
	.global _start
_start:
print_loop:
	lui $a0, %hi(format_string)
	addiu $a0, $a0, %lo(format_string)
	addiu $v1, $zero, 117
	syscall
	b print_loop
	nop
	
	.section .rodata
format_string:
	.string "hello world"
```

### Suggested Testing Steps

Here's the above program in its compiled form:
[exhaustmem.zip](https://github.com/user-attachments/files/17902695/exhaustmem.zip)

Since it's been intentionally written to use up lots of memory think twice before running it.

Note that the Qt console window has a similar quirk where it will just keep using more and more memory. This PR doesn't address that issue.