### PR TITLE
Savestate: Always write HostFS savestate tag (Savestate bump)

### DIFF
--- a/pcsx2/IopBios.cpp
+++ b/pcsx2/IopBios.cpp
@@ -1423,18 +1423,18 @@ namespace R3000A
 
 bool SaveStateBase::handleFreeze()
 {
-	if (!EmuConfig.HostFs) //if hostfs isn't enabled, skip loading/saving file handles
-		return IsOkay();
-
-	if (IsLoading())
-		R3000A::ioman::reset();
-
 	if (!FreezeTag("hostHandles"))
 		return false;
 
+	if (EmuConfig.HostFs && IsLoading())
+		R3000A::ioman::reset();
+
 	const int firstfd = R3000A::ioman::firstfd;
-	size_t handleCount = R3000A::handles.size();
+	size_t handleCount = EmuConfig.HostFs ? R3000A::handles.size() : 0;
 	Freeze(handleCount);
+
+	if (!EmuConfig.HostFs) //if hostfs isn't enabled, skip loading/saving file handles
+		return IsOkay();
 
 	for (size_t i = 0; i < handleCount; i++)
 	{

--- a/pcsx2/SaveState.cpp
+++ b/pcsx2/SaveState.cpp
@@ -315,6 +315,9 @@ memLoadingState::memLoadingState(const VmStateBuffer& load_from)
 // Loading of state data from a memory buffer...
 void memLoadingState::FreezeMem( void* data, int size )
 {
+	if (m_idx + size > m_memory.size())
+		m_error = true;
+
 	if (m_error)
 	{
 		std::memset(data, 0, size);

--- a/pcsx2/SaveState.h
+++ b/pcsx2/SaveState.h
@@ -25,7 +25,7 @@ enum class FreezeAction
 // [SAVEVERSION+]
 // This informs the auto updater that the users savestates will be invalidated.
 
-static const u32 g_SaveVersion = (0x9A50 << 16) | 0x0000;
+static const u32 g_SaveVersion = (0x9A51 << 16) | 0x0000;
 
 
 // the freezing data between submodules and core


### PR DESCRIPTION
### Description of Changes
Add bounds checking for `FreezeMem` loads
Always save HostFS data

### Rationale behind Changes
When a savestate is saved without Host File System enabled, this tag is omitted.
If that savestate is then loaded after enabling Host File System, then FreezeTag will fail to find HostFS tag and reject the savestate
Additionally, `FreezeTag` will end up reading beyond the end of the savestate in such a situation.

### Suggested Testing Steps
Test savestates with and without Host filesystem enabled.
