### PR TITLE
DEV9: Always bind UDP ports in sockets

### DIFF
--- a/pcsx2/DEV9/Sessions/UDP_Session/UDP_FixedPort.cpp
+++ b/pcsx2/DEV9/Sessions/UDP_Session/UDP_FixedPort.cpp
@@ -225,10 +225,18 @@ namespace Sessions
 
 	void UDP_FixedPort::Reset()
 	{
-		std::lock_guard numberlock(connectionSentry);
+		// Reseting a session may cause that session to close itself,
+		// when that happens, the connections vector gets modified via our close handler.
+		// Duplicate the vector to avoid iterating over a modified collection,
+		// this also avoids the issue of recursive locking when our close handler takes a lock.
+		std::vector<UDP_BaseSession*> connectionsCopy;
+		{
+			std::lock_guard numberlock(connectionSentry);
+			connectionsCopy = connections;
+		}
 
-		for (size_t i = 0; i < connections.size(); i++)
-			connections[i]->Reset();
+		for (size_t i = 0; i < connectionsCopy.size(); i++)
+			connectionsCopy[i]->Reset();
 	}
 
 	UDP_Session* UDP_FixedPort::NewClientSession(ConnectionKey parNewKey, bool parIsBrodcast, bool parIsMulticast)


### PR DESCRIPTION
### Description of Changes
Always bind the UDP source port when using sockets
Reworded some logs
Duplicate FixedPort's connections vector for resetting child connections

### Rationale behind Changes
Previously, we would only bind the UDP source port in specific situations (Broadcast, multicast and when src and dst port similar).
This proved inadequate for some games, which would either fail to connect of behave strangely if the source port wasn't maintained.
Expanding the heuristics used to catch every game seemed non-trivial, so I've opted to forgo this previously used heuristic and always bind the port.

This does mean we now sometimes bind the port unnecessarily (namely DNS requests), however, different games use ranges for dynamic ports, so avoiding this seemed not worth the effort.

Additionally, FixedPort's `Reset()` method could potentially iterate over a modified vector if the child connection closed itself (and thus got removed from the connections vector in FixedPort's connection closed handler).
Duplicating this vector avoids that situation.
This also allows us to reduce the scope of the lock in `Reset()`, avoiding a deadlock (or crash) as FixedPort's connection closed handler would also try to lock.

### Suggested Testing Steps
Test networking using Sockets
