### PR TITLE
Console: Fix newline logging regression

### DIFF
--- a/pcsx2/DebugTools/Debug.h
+++ b/pcsx2/DebugTools/Debug.h
@@ -103,10 +103,7 @@ public:
 		{
 			// Ignore control characters.
 			// Otherwise you get fun bells going off.
-			if (ch < 0x20)
-				continue;
-
-			if (ch != '\n')
+			if (ch >= 0x20)
 				m_buffer.push_back(ch);
 
 			if (ch == '\n' || m_buffer.size() >= 4096)


### PR DESCRIPTION
### Description of Changes
This fixes a silly regression introduced by [this PR](https://github.com/PCSX2/pcsx2/pull/12034) where, contrary to its marketing claims, it would eat all newlines.

### Rationale behind Changes
Tried to do some last minute refactoring, ended up breaking console logging. Turns out newlines are control characters, doh.

### Suggested Testing Steps
Observe that newlines are not eaten now.
