### PR TITLE
FileSystem: Add a case-insensitive match for nvm and mec file loading.

### DIFF
--- a/common/FileSystem.cpp
+++ b/common/FileSystem.cpp
@@ -994,6 +994,37 @@ std::FILE* FileSystem::OpenCFile(const char* filename, const char* mode, Error* 
 #endif
 }
 
+std::FILE* FileSystem::OpenCFileTryIgnoreCase(const char* filename, const char* mode, Error* error)
+{
+#ifdef _WIN32
+	return OpenCFile(filename, mode, error);
+#else
+	std::FILE* fp = std::fopen(filename, mode);
+	const auto cur_errno = errno;
+
+	if (!fp)
+	{
+		const auto dir = std::string(Path::GetDirectory(filename));
+		FindResultsArray files;
+		if (FindFiles(dir.c_str(), "*", FILESYSTEM_FIND_FILES | FILESYSTEM_FIND_HIDDEN_FILES, &files))
+		{
+			for (auto& file : files)
+			{
+				if (StringUtil::compareNoCase(file.FileName, filename))
+				{
+					fp = std::fopen(file.FileName.c_str(), mode);
+					break;
+				}
+			}
+		}
+	}
+	if (!fp)
+		Error::SetErrno(error, cur_errno);
+	return fp;
+#endif
+}
+
+
 int FileSystem::OpenFDFile(const char* filename, int flags, int mode, Error* error)
 {
 #ifdef _WIN32
@@ -1013,6 +1044,11 @@ int FileSystem::OpenFDFile(const char* filename, int flags, int mode, Error* err
 FileSystem::ManagedCFilePtr FileSystem::OpenManagedCFile(const char* filename, const char* mode, Error* error)
 {
 	return ManagedCFilePtr(OpenCFile(filename, mode, error));
+}
+
+FileSystem::ManagedCFilePtr FileSystem::OpenManagedCFileTryIgnoreCase(const char* filename, const char* mode, Error* error)
+{
+	return ManagedCFilePtr(OpenCFileTryIgnoreCase(filename, mode, error));
 }
 
 std::FILE* FileSystem::OpenSharedCFile(const char* filename, const char* mode, FileShareMode share_mode, Error* error)

--- a/common/FileSystem.h
+++ b/common/FileSystem.h
@@ -107,7 +107,16 @@ namespace FileSystem
 	/// open files
 	using ManagedCFilePtr = std::unique_ptr<std::FILE, FileDeleter>;
 	ManagedCFilePtr OpenManagedCFile(const char* filename, const char* mode, Error* error = nullptr);
+	// Tries to open a file using the given filename, but if that fails searches
+	// the directory for a file with a case-insensitive match.
+	// This is the same as OpenManagedCFile on Windows
+	ManagedCFilePtr OpenManagedCFileTryIgnoreCase(const char* filename, const char* mode, Error* error = nullptr);
 	std::FILE* OpenCFile(const char* filename, const char* mode, Error* error = nullptr);
+	// Tries to open a file using the given filename, but if that fails searches
+	// the directory for a file with a case-insensitive match.
+	// This is the same as OpenCFile on Windows
+	std::FILE* OpenCFileTryIgnoreCase(const char* filename, const char* mode, Error* error = nullptr);
+
 	int FSeek64(std::FILE* fp, s64 offset, int whence);
 	s64 FTell64(std::FILE* fp);
 	s64 FSize64(std::FILE* fp);

--- a/pcsx2/CDVD/CDVD.cpp
+++ b/pcsx2/CDVD/CDVD.cpp
@@ -155,7 +155,7 @@ void cdvdLoadNVRAM()
 {
 	Error error;
 	const std::string nvmfile = cdvdGetNVRAMPath();
-	auto fp = FileSystem::OpenManagedCFile(nvmfile.c_str(), "rb", &error);
+	auto fp = FileSystem::OpenManagedCFileTryIgnoreCase(nvmfile.c_str(), "rb", &error);
 	if (!fp || std::fread(s_nvram, sizeof(s_nvram), 1, fp.get()) != 1)
 	{
 		ERROR_LOG("Failed to open or read NVRAM at {}: {}", Path::GetFileName(nvmfile), error.GetDescription());
@@ -178,7 +178,7 @@ void cdvdLoadNVRAM()
 
 	// Also load the mechacon version while we're here.
 	const std::string mecfile = Path::ReplaceExtension(BiosPath, "mec");
-	fp = FileSystem::OpenManagedCFile(mecfile.c_str(), "rb", &error);
+	fp = FileSystem::OpenManagedCFileTryIgnoreCase(mecfile.c_str(), "rb", &error);
 	if (!fp || std::fread(&s_mecha_version, sizeof(s_mecha_version), 1, fp.get()) != 1)
 	{
 		s_mecha_version = DEFAULT_MECHA_VERSION;
@@ -186,7 +186,7 @@ void cdvdLoadNVRAM()
 		ERROR_LOG("Failed to open or read MEC file at {}: {}, creating default.", Path::GetFileName(nvmfile),
 			error.GetDescription());
 		fp.reset();
-		fp = FileSystem::OpenManagedCFile(mecfile.c_str(), "wb");
+		fp = FileSystem::OpenManagedCFileTryIgnoreCase(mecfile.c_str(), "wb");
 		if (!fp || std::fwrite(&s_mecha_version, sizeof(s_mecha_version), 1, fp.get()) != 1)
 			Host::ReportErrorAsync("Error", "Failed to write MEC file. Check your BIOS setup/permission settings.");
 	}
@@ -197,10 +197,10 @@ void cdvdSaveNVRAM()
 {
 	Error error;
 	const std::string nvmfile = cdvdGetNVRAMPath();
-	auto fp = FileSystem::OpenManagedCFile(nvmfile.c_str(), "r+b", &error);
+	auto fp = FileSystem::OpenManagedCFileTryIgnoreCase(nvmfile.c_str(), "r+b", &error);
 	if (!fp)
 	{
-		fp = FileSystem::OpenManagedCFile(nvmfile.c_str(), "w+b", &error);
+		fp = FileSystem::OpenManagedCFileTryIgnoreCase(nvmfile.c_str(), "w+b", &error);
 		if (!fp) [[unlikely]]
 		{
 			ERROR_LOG("Failed to open NVRAM at {} for updating: {}", Path::GetFileName(nvmfile), error.GetDescription());

--- a/pcsx2/ps2/BiosTools.cpp
+++ b/pcsx2/ps2/BiosTools.cpp
@@ -226,7 +226,7 @@ static void LoadExtraRom(const char* ext, u32 offset, u32 size)
 
 	BiosRom.resize(offset + size);
 
-	auto fp = FileSystem::OpenManagedCFile(Bios1.c_str(), "rb");
+	auto fp = FileSystem::OpenManagedCFileTryIgnoreCase(Bios1.c_str(), "rb");
 	if (!fp || std::fread(&BiosRom[offset], static_cast<size_t>(std::min<s64>(size, filesize)), 1, fp.get()) != 1)
 	{
 		Console.Warning("BIOS Warning: %s could not be read (permission denied?)", ext);


### PR DESCRIPTION
### Description of Changes
Adds some open file methods to the filesystem abstraction that will fallback to case-insensitive matching.
I was unsure if it's safe to assume that MacOS always uses a case insensitive filesystem, so this fallback will happen on MacOS.

### Rationale behind Changes

By default PCSX2 assumes that the nvm and mec files will be [rom0 filename].nvm and [rom0 filename].mec
On case-insensitive filesystems this is fine, but there is a difference in behaviour when you are on case-sensitive filesystems when using extensions such as NVM and MEC.

There really shouldn't be any good reason why you have these extensions capitalized, but this PR addresses the difference in behaviour.

### Suggested Testing Steps
The code is the same for Windows platforms, so that should be fine.
On Linux and MacOS platforms, rename the nvm file to something with a different case. `bios.nvm = bios.NVM` and boot the BIOS and see if the first-time setup menu shows (or look in the console to see if there is an error message regarding opening the NVM file).
