### PR TITLE
FileSystem: Don't follow symbolic links when recursively deleting directories

### DIFF
--- a/common/FileSystem.h
+++ b/common/FileSystem.h
@@ -84,7 +84,6 @@ namespace FileSystem
 
 	/// Directory exists?
 	bool DirectoryExists(const char* path);
-	bool IsRealDirectory(const char* path);
 
 	/// Directory does not contain any files?
 	bool DirectoryIsEmpty(const char* path);
@@ -169,6 +168,12 @@ namespace FileSystem
 	/// Does not apply the compression flag recursively if called for a directory.
 	/// Does nothing and returns false on non-Windows platforms.
 	bool SetPathCompression(const char* path, bool enable);
+
+	/// Checks if a file or directory is a symbolic link.
+	bool IsSymbolicLink(const char* path);
+
+	/// Deletes a symbolic link (either a file or directory).
+	bool DeleteSymbolicLink(const char* path, Error* error = nullptr);
 
 #ifdef _WIN32
 	// Path limit remover, but also converts to a wide string at the same time.

--- a/tests/ctest/common/CMakeLists.txt
+++ b/tests/ctest/common/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_pcsx2_test(common_test
 	byteswap_tests.cpp
+	filesystem_tests.cpp
 	path_tests.cpp
 	string_util_tests.cpp
 )

--- a/tests/ctest/common/filesystem_tests.cpp
+++ b/tests/ctest/common/filesystem_tests.cpp
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: 2002-2024 PCSX2 Dev Team
+// SPDX-License-Identifier: GPL-3.0+
+
+#include "common/FileSystem.h"
+#include "common/Path.h"
+#include <gtest/gtest.h>
+
+#ifdef __linux__
+
+#include <unistd.h>
+
+static std::optional<std::string> create_test_directory()
+{
+	for (u16 i = 0; i < UINT16_MAX; i++)
+	{
+		std::string path = std::string("/tmp/pcsx2_filesystem_test_") + std::to_string(i);
+		if (!FileSystem::DirectoryExists(path.c_str()))
+		{
+			if (!FileSystem::CreateDirectoryPath(path.c_str(), false))
+				break;
+
+			return path;
+		}
+	}
+
+	return std::nullopt;
+}
+
+TEST(FileSystem, RecursiveDeleteDirectoryDontFollowSymbolicLinks)
+{
+	// Find a suitable location to write some test files.
+	std::optional<std::string> test_dir = create_test_directory();
+	ASSERT_TRUE(test_dir.has_value());
+
+	// Create a target directory containing a file that shouldn't be deleted.
+	std::string target_dir = Path::Combine(*test_dir, "target_dir");
+	ASSERT_TRUE(FileSystem::CreateDirectoryPath(target_dir.c_str(), false));
+	std::string file_path = Path::Combine(target_dir, "file.txt");
+	ASSERT_TRUE(FileSystem::WriteStringToFile(file_path.c_str(), "Lorem ipsum!"));
+
+	// Create a directory containing a symlink to the target directory.
+	std::string dir_to_delete = Path::Combine(*test_dir, "dir_to_delete");
+	ASSERT_TRUE(FileSystem::CreateDirectoryPath(dir_to_delete.c_str(), false));
+	std::string symlink_path = Path::Combine(dir_to_delete, "link");
+	ASSERT_EQ(symlink(target_dir.c_str(), symlink_path.c_str()), 0);
+
+	// Delete the directory containing the symlink.
+	ASSERT_TRUE(dir_to_delete.starts_with("/tmp/"));
+	ASSERT_TRUE(FileSystem::RecursiveDeleteDirectory(dir_to_delete.c_str()));
+
+	// Make sure the target file didn't get deleted.
+	ASSERT_TRUE(FileSystem::FileExists(file_path.c_str()));
+
+	// Clean up.
+	ASSERT_TRUE(FileSystem::DeleteFilePath(file_path.c_str()));
+	ASSERT_TRUE(FileSystem::DeleteDirectory(target_dir.c_str()));
+	ASSERT_TRUE(FileSystem::DeleteDirectory(test_dir->c_str()));
+}
+
+#endif


### PR DESCRIPTION
### Description of Changes
- The `FileSystem::RecursiveDeleteDirectory` function will no longer recurse through symbolic links.
- To support this change, the `FileSystem::IsSymbolicLink` and `FileSystem::DeleteSymbolicLink` functions have been added. The `FileSystem::IsRealDirectory` function has been removed since it was unused.

### Rationale behind Changes
Prevent accidental data loss e.g. when deleting folder memory cards.

### Suggested Testing Steps
This needs testing on macOS and especially Windows, since it touches Windows API code and I've only tested it on Linux. Since this is modifying some fairly important code I want multiple core contributors to review it before it's merged.

Here's an example of how you could reproduce the issue on Linux/macOS:
```
cd path/to/memcards/directory/
pcsx2-qt # create a folder card called "testcard" from the gui
mkdir important_dir
nano important_dir/important_file.txt # add only copy of private key for 1000000 bitcoin reserve
ln -s $(realpath important_dir) testcard.ps2/link # it's important to use an absolute path here
pcsx2-qt # try to delete "testcard" from the gui
ls important_dir/important_file.txt # oh no!
```
Be careful that you don't e.g. symlink your home directory by accident while testing this, as you could lose all your data.