### PR TITLE
iR5900: Remove mid block jumping

### DIFF
--- a/pcsx2/x86/ix86-32/iR5900.cpp
+++ b/pcsx2/x86/ix86-32/iR5900.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2002-2024 PCSX2 Dev Team
+// SPDX-FileCopyrightText: 2002-2025 PCSX2 Dev Team
 // SPDX-License-Identifier: GPL-3.0+
 
 #include "Common.h"
@@ -350,7 +350,6 @@ static void dyna_page_reset(u32 start, u32 sz);
 static const void* DispatcherEvent = nullptr;
 static const void* DispatcherReg = nullptr;
 static const void* JITCompile = nullptr;
-static const void* JITCompileInBlock = nullptr;
 static const void* EnterRecompiledCode = nullptr;
 static const void* DispatchBlockDiscard = nullptr;
 static const void* DispatchPageReset = nullptr;
@@ -386,13 +385,6 @@ static const void* _DynGen_JITCompile()
 	xMOV(rcx, ptrNative[xComplexAddress(rcx, recLUT, rax * wordsize)]);
 	xJMP(ptrNative[rbx * (wordsize / 4) + rcx]);
 
-	return retval;
-}
-
-static const void* _DynGen_JITCompileInBlock()
-{
-	u8* retval = xGetAlignedCallTarget();
-	xJMP(JITCompile);
 	return retval;
 }
 
@@ -479,7 +471,6 @@ static void _DynGen_Dispatchers()
 	DispatcherReg = _DynGen_DispatcherReg();
 
 	JITCompile = _DynGen_JITCompile();
-	JITCompileInBlock = _DynGen_JITCompileInBlock();
 	EnterRecompiledCode = _DynGen_EnterRecompiledCode();
 	DispatchBlockDiscard = _DynGen_DispatchBlockDiscard();
 	DispatchPageReset = _DynGen_DispatchPageReset();
@@ -773,9 +764,7 @@ void recClear(u32 addr, u32 size)
 
 		lowerextent = std::min(lowerextent, blockstart);
 		upperextent = std::max(upperextent, blockend);
-		// This might end up inside a block that doesn't contain the clearing range,
-		// so set it to recompile now.  This will become JITCompile if we clear it.
-		pblock->SetFnptr((uptr)JITCompileInBlock);
+		pblock->SetFnptr((uptr)JITCompile);
 
 		blockidx--;
 	}
@@ -2305,8 +2294,6 @@ static void recRecompile(const u32 startpc)
 
 	while (1)
 	{
-		BASEBLOCK* pblock = PC_GETBLOCK(i);
-
 		// stop before breakpoints
 		if (isBreakpointNeeded(i) != 0 || isMemcheckNeeded(i) != 0)
 		{
@@ -2322,13 +2309,6 @@ static void recRecompile(const u32 startpc)
 				s_nEndBlock = i;
 
 				eeRecPerfLog.Write("Pagesplit @ %08X : size=%d insts", startpc, (i - startpc) / 4);
-				break;
-			}
-
-			if (pblock->GetFnptr() != (uptr)JITCompile && pblock->GetFnptr() != (uptr)JITCompileInBlock)
-			{
-				willbranch3 = 1;
-				s_nEndBlock = i;
 				break;
 			}
 		}
@@ -2634,41 +2614,7 @@ StartRecomp:
 	pxAssert((pc - startpc) >> 2 <= 0xffff);
 	s_pCurBlockEx->size = (pc - startpc) >> 2;
 
-	if (HWADDR(pc) <= Ps2MemSize::ExposedRam)
-	{
-		BASEBLOCKEX* oldBlock;
-		int i;
-
-		i = recBlocks.LastIndex(HWADDR(pc) - 4);
-		while ((oldBlock = recBlocks[i--]))
-		{
-			if (oldBlock == s_pCurBlockEx)
-				continue;
-			if (oldBlock->startpc >= HWADDR(pc))
-				continue;
-			if ((oldBlock->startpc + oldBlock->size * 4) <= HWADDR(startpc))
-				break;
-
-			if (memcmp(&recRAMCopy[oldBlock->startpc / 4], PSM(oldBlock->startpc),
-					oldBlock->size * 4))
-			{
-				recClear(startpc, (pc - startpc) / 4);
-				s_pCurBlockEx = recBlocks.Get(HWADDR(startpc));
-				pxAssert(s_pCurBlockEx->startpc == HWADDR(startpc));
-				break;
-			}
-		}
-
-		memcpy(&recRAMCopy[HWADDR(startpc) / 4], PSM(startpc), pc - startpc);
-	}
-
 	s_pCurBlock->SetFnptr((uptr)recPtr);
-
-	for (i = 1; i < static_cast<u32>(s_pCurBlockEx->size); i++)
-	{
-		if ((uptr)JITCompile == s_pCurBlock[i].GetFnptr())
-			s_pCurBlock[i].SetFnptr((uptr)JITCompileInBlock);
-	}
 
 	if (!(pc & 0x10000000))
 		maxrecmem = std::max((pc & ~0xa0000000), maxrecmem);


### PR DESCRIPTION
### Description of Changes
Removes JIT mid block jumping.

### Rationale behind Changes
Vroom.

### Suggested Testing Steps
Test any games you'd like and see if it breaks anything.
